### PR TITLE
mcumgr: shell: Change command exit code from rc to ret

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -252,6 +252,12 @@ Libraries / Subsystems
   * MCUMGR race condition when using the task status function whereby if a
     thread state changed it could give a falsely short process list has been
     fixed.
+  * MCUMGR shell (group 9) CBOR structure has changed, the ``rc``
+    response is now only used for mcumgr errors, shell command
+    execution result codes are instead returned in the ``ret``
+    variable instead, see :ref:`mcumgr_smp_group_9` for updated
+    information. Legacy bahaviour can be restored by enabling
+    :kconfig:option:`CONFIG_MCUMGR_CMD_SHELL_MGMT_LEGACY_RC_RETURN_CODE`
 
 HALs
 ****

--- a/doc/services/device_mgmt/smp_groups/smp_group_9.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_9.rst
@@ -77,12 +77,20 @@ Command line execute response header fields:
     | ``3``  | ``9``        |  ``0``         |
     +--------+--------------+----------------+
 
-CBOR data of response:
+CBOR data of successful response:
 
 .. code-block:: none
 
     {
         (str)"o"            : (str)
+        (str)"ret"          : (int)
+    }
+
+In case of error the CBOR data takes form:
+
+.. code-block:: none
+
+    {
         (str)"rc"           : (int)
     }
 
@@ -92,8 +100,17 @@ where:
     :align: center
 
     +-----------------------+---------------------------------------------------+
+    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes` (only     |
+    |                       | present if an error occurred)                     |
+    +-----------------------+---------------------------------------------------+
     | "o"                   | command output                                    |
     +-----------------------+---------------------------------------------------+
-    | "rc"                  | either return code from shell command execution   |
-    |                       | or :ref:`mcumgr_smp_protocol_status_codes`        |
+    | "ret"                 | return code from shell command execution          |
     +-----------------------+---------------------------------------------------+
+
+In case when "rc" is not 0, success, the other fields will not appear.
+
+.. note::
+    In older versions of Zephyr, "rc" was used for both the mcumgr status code
+    and shell command execution return code, this legacy behaviour can be
+    restored by enabling :kconfig:option:`CONFIG_MCUMGR_CMD_SHELL_MGMT_LEGACY_RC_RETURN_CODE`

--- a/subsys/mgmt/mcumgr/lib/cmd/shell_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/lib/cmd/shell_mgmt/Kconfig
@@ -2,7 +2,7 @@
 # Copyright Nordic Semiconductor ASA 2020-2022. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-config MCUMGR_CMD_SHELL_MGMT
+menuconfig MCUMGR_CMD_SHELL_MGMT
 	bool "Mcumgr handlers for shell management"
 	depends on SHELL
 	select SHELL_BACKEND_DUMMY
@@ -22,3 +22,17 @@ config MCUMGR_CMD_SHELL_MGMT
 	  on a stack, by the mcumgr, so enabling MCUMGR_CMD_SHELL_MGMT and
 	  changes to the CONFIG_SHELL_CMD_BUFF_SIZE may increase stack size
 	  requirements.
+
+if MCUMGR_CMD_SHELL_MGMT
+
+config MCUMGR_CMD_SHELL_MGMT_LEGACY_RC_RETURN_CODE
+	bool "Legacy behaviour: Use rc field for shell function return code"
+	help
+	  Enabling this options brings back legacy behaviour where the shell
+	  return code is returned, incorrectly, in the rc field that was
+	  originally designated for returning SMP processing errors. When
+	  disabled, there will be an additional ret field which contains the
+	  shell command exit code, and rc will be used for SMP processing
+	  error codes.
+
+endif # MCUMGR_CMD_SHELL_MGMT

--- a/subsys/mgmt/mcumgr/lib/cmd/shell_mgmt/src/shell_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/shell_mgmt/src/shell_mgmt.c
@@ -107,10 +107,14 @@ shell_mgmt_exec(struct mgmt_ctxt *ctxt)
 	cmd_out.value = shell_get_output(&cmd_out.len);
 
 	/* Key="o"; value=<command-output> */
-	/* Key="rc"; value=<status> */
+	/* Key="ret"; value=<status>, or rc if legacy option enabled */
 	ok = zcbor_tstr_put_lit(zse, "o")		&&
 	     zcbor_tstr_encode(zse, &cmd_out)		&&
+#ifdef CONFIG_MCUMGR_CMD_SHELL_MGMT_LEGACY_RC_RETURN_CODE
 	     zcbor_tstr_put_lit(zse, "rc")		&&
+#else
+	     zcbor_tstr_put_lit(zse, "ret")		&&
+#endif
 	     zcbor_int32_put(zse, rc);
 
 	zcbor_map_end_decode(zsd);


### PR DESCRIPTION
    mcumgr: shell: Change command exit code from rc to ret
    
    This prevents the shell command response code conflicting with the
    mcumgr response code, which are 2 distinct variable types

Includes documentation and release note updates.

Fixes #40893