### PR TITLE
ITE: drivers/i2c: I2C related fixes

### DIFF
--- a/drivers/i2c/Kconfig.it8xxx2
+++ b/drivers/i2c/Kconfig.it8xxx2
@@ -19,8 +19,8 @@ config I2C_IT8XXX2_FIFO_MODE
 	  This is an option to enable FIFO mode which can reduce
 	  the time between each byte to improve the I2C bus clock
 	  stretching during I2C transaction.
-	  The I2C controller supports two 32-bytes FIFOs, channel
-	  A and channel C are supported now.
+	  The I2C controller supports two 32-bytes FIFOs, FIFO2
+	  only supports one channel of B or C.
 	  I2C FIFO mode of it8xxx2 can support I2C APIs including:
 	  i2c_write(), i2c_read(), i2c_burst_read.
 

--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -531,7 +531,9 @@ static int i2c_enhance_pio_transfer(const struct device *dev,
 	int res;
 
 	if (data->i2ccs == I2C_CH_NORMAL) {
-		msgs->flags |= I2C_MSG_START;
+		struct i2c_msg *start_msg = &msgs[0];
+
+		start_msg->flags |= I2C_MSG_START;
 	}
 
 	for (int i = 0; i < data->num_msgs; i++) {
@@ -540,10 +542,6 @@ static int i2c_enhance_pio_transfer(const struct device *dev,
 		data->ridx = 0;
 		data->err = 0;
 		data->msgs = &(msgs[i]);
-
-		if (msgs->flags & I2C_MSG_START) {
-			data->i2ccs = I2C_CH_NORMAL;
-		}
 
 		/*
 		 * Start transaction.
@@ -584,7 +582,7 @@ static int i2c_enhance_pio_transfer(const struct device *dev,
 	}
 
 	/* reset i2c channel status */
-	if (data->err || (msgs->flags & I2C_MSG_STOP)) {
+	if (data->err || (data->msgs->flags & I2C_MSG_STOP)) {
 		data->i2ccs = I2C_CH_NORMAL;
 	}
 

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -912,6 +912,8 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 	 * exclude checking bus busy.
 	 */
 	if (data->i2ccs == I2C_CH_NORMAL) {
+		struct i2c_msg *start_msg = &msgs[0];
+
 		/* Make sure we're in a good state to start */
 		if (i2c_bus_not_available(dev)) {
 			/* Recovery I2C bus */
@@ -927,7 +929,7 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 			}
 		}
 
-		msgs->flags |= I2C_MSG_START;
+		start_msg->flags |= I2C_MSG_START;
 	}
 #ifdef CONFIG_I2C_IT8XXX2_FIFO_MODE
 	/* Store num_msgs to data struct. */
@@ -949,9 +951,6 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 		data->msgs = &(msgs[i]);
 		data->addr_16bit = addr;
 
-		if (msgs->flags & I2C_MSG_START) {
-			data->i2ccs = I2C_CH_NORMAL;
-		}
 #ifdef CONFIG_I2C_IT8XXX2_FIFO_MODE
 		data->active_msg_index = 0;
 		/*
@@ -1025,7 +1024,7 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 	}
 #endif
 	/* reset i2c channel status */
-	if (data->err || (msgs->flags & I2C_MSG_STOP)) {
+	if (data->err || (data->msgs->flags & I2C_MSG_STOP)) {
 		data->i2ccs = I2C_CH_NORMAL;
 	}
 	/* Unlock mutex of i2c controller */

--- a/dts/bindings/i2c/ite,common-i2c.yaml
+++ b/dts/bindings/i2c/ite,common-i2c.yaml
@@ -15,7 +15,20 @@ properties:
     port-num:
       type: int
       required: true
+      enum:
+            - 0
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
       description: Ordinal identifying the port
+        0 = SMB_CHANNEL_A,
+        1 = SMB_CHANNEL_B,
+        2 = SMB_CHANNEL_C,
+        3 = I2C_CHANNEL_D,
+        4 = I2C_CHANNEL_E,
+        5 = I2C_CHANNEL_F,
 
     scl-gpios:
       type: phandle-array

--- a/dts/bindings/i2c/ite,it8xxx2-i2c.yaml
+++ b/dts/bindings/i2c/ite,it8xxx2-i2c.yaml
@@ -6,3 +6,11 @@ description: ITE it8xxx2 I2C
 compatible: "ite,it8xxx2-i2c"
 
 include: ite,common-i2c.yaml
+
+properties:
+    fifo-enable:
+      required: false
+      type: boolean
+      description: |
+        FIFO1 supports channel A.
+        FIFO2 only supports one channel of B or C.

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -934,10 +934,11 @@
 			interrupts = <IT8XXX2_IRQ_SMB_A IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-			port-num = <0>;
+			port-num = <SMB_CHANNEL_A>;
 			scl-gpios = <&gpiob 3 0>;
 			sda-gpios = <&gpiob 4 0>;
 			clock-gate-offset = <CGC_OFFSET_SMBA>;
+			fifo-enable;   /* FIFO1 */
 		};
 
 		i2c1: i2c@f01c80 {
@@ -945,14 +946,15 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00f01c80 0x0040   /* Base address */
-					0 0x0001>; /* Not supported */
+			       0x00f01c0f 0x0001>; /* MSTFCTRL2 */
 			interrupts = <IT8XXX2_IRQ_SMB_B IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-			port-num = <1>;
+			port-num = <SMB_CHANNEL_B>;
 			scl-gpios = <&gpioc 1 0>;
 			sda-gpios = <&gpioc 2 0>;
 			clock-gate-offset = <CGC_OFFSET_SMBB>;
+			/delete-property/ fifo-enable;   /* FIFO2 */
 		};
 
 		i2c2: i2c@f01cc0 {
@@ -964,10 +966,11 @@
 			interrupts = <IT8XXX2_IRQ_SMB_C IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-			port-num = <2>;
+			port-num = <SMB_CHANNEL_C>;
 			scl-gpios = <&gpiof 6 0>;
 			sda-gpios = <&gpiof 7 0>;
 			clock-gate-offset = <CGC_OFFSET_SMBC>;
+			fifo-enable;   /* FIFO2 */
 		};
 
 		i2c3: i2c@f03680 {
@@ -978,7 +981,7 @@
 			interrupts = <IT8XXX2_IRQ_SMB_D IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-			port-num = <3>;
+			port-num = <I2C_CHANNEL_D>;
 			scl-gpios = <&gpioh 1 0>;
 			sda-gpios = <&gpioh 2 0>;
 			clock-gate-offset = <CGC_OFFSET_SMBD>;
@@ -992,7 +995,7 @@
 			interrupts = <IT8XXX2_IRQ_SMB_E IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-			port-num = <4>;
+			port-num = <I2C_CHANNEL_E>;
 			scl-gpios = <&gpioe 0 0>;
 			sda-gpios = <&gpioe 7 0>;
 			clock-gate-offset = <CGC_OFFSET_SMBE>;
@@ -1006,7 +1009,7 @@
 			interrupts = <IT8XXX2_IRQ_SMB_F IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-			port-num = <5>;
+			port-num = <I2C_CHANNEL_F>;
 			scl-gpios = <&gpioa 4 0>;
 			sda-gpios = <&gpioa 5 0>;
 			clock-gate-offset = <CGC_OFFSET_SMBF>;

--- a/include/zephyr/dt-bindings/i2c/i2c.h
+++ b/include/zephyr/dt-bindings/i2c/i2c.h
@@ -12,4 +12,11 @@
 #define I2C_BITRATE_HIGH	3400000	/* 3.4 Mbit/s */
 #define I2C_BITRATE_ULTRA	5000000 /* 5 Mbit/s */
 
+#define SMB_CHANNEL_A	0
+#define SMB_CHANNEL_B	1
+#define SMB_CHANNEL_C	2
+#define I2C_CHANNEL_D	3
+#define I2C_CHANNEL_E	4
+#define I2C_CHANNEL_F	5
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_I2C_I2C_H_ */

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -1762,6 +1762,7 @@ enum chip_pll_mode {
 /* 0x0F: SMBus FIFO Control 2 */
 #define IT8XXX2_SMB_BLKDS             BIT(4)
 #define IT8XXX2_SMB_FFEN              BIT(3)
+#define IT8XXX2_SMB_FFCHSEL2_B        0
 #define IT8XXX2_SMB_FFCHSEL2_C        BIT(0)
 /* 0x10: SMBus FIFO Status 2 */
 #define IT8XXX2_SMB_FIFO2_EMPTY       BIT(7)
@@ -1770,6 +1771,7 @@ enum chip_pll_mode {
 #define IT8XXX2_SMB_MAIF              BIT(7)
 #define IT8XXX2_SMB_MBCIF             BIT(6)
 #define IT8XXX2_SMB_MCIFI             BIT(2)
+#define IT8XXX2_SMB_MBIFI             BIT(1)
 #define IT8XXX2_SMB_MAIFI             BIT(0)
 /* 0x13: I2C Wr To Rd FIFO Interrupt Status */
 #define IT8XXX2_SMB_MCIFID            BIT(2)


### PR DESCRIPTION
This PR includes three commits as follows:
1. Fix the bug of msgs in I2C transfer.
2. Rename the parameter in data struct.
3. FIFO2 of SMBus can be selected to support channel of B or C by dtsi.

test: I2C0~I2C5
tests\driver\i2c\i2c_api--> pass

Signed-off-by: Tim Lin [tim2.lin@ite.corp-partner.google.com](mailto:tim2.lin@ite.corp-partner.google.com)