### PR TITLE
net: lwm2m: Fixed LwM2M message wrong error response

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -618,7 +618,7 @@ static int select_writer(struct lwm2m_output_context *out, uint16_t accept)
 
 	default:
 		LOG_WRN("Unknown content type %u", accept);
-		return -ENOMSG;
+		return -ECANCELED;
 	}
 
 	return 0;
@@ -2100,6 +2100,8 @@ error:
 		msg->code = COAP_RESPONSE_CODE_UNSUPPORTED_CONTENT_FORMAT;
 	} else if (r == -EACCES) {
 		msg->code = COAP_RESPONSE_CODE_UNAUTHORIZED;
+	} else if (r == -ECANCELED) {
+		msg->code = COAP_RESPONSE_CODE_NOT_ACCEPTABLE;
 	} else {
 		/* Failed to handle the request */
 		msg->code = COAP_RESPONSE_CODE_INTERNAL_ERROR;


### PR DESCRIPTION
LwM2M was not reported properly case when message "Accept"
coap option was not not supported. In that case LwM2M transport
specification define 4.06 "Not Accepted"

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>