### PR TITLE
Bluetooth: Audio: Fix missing metadata_updated calls

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -107,6 +107,7 @@ static void ascs_ep_unbind_audio_iso(struct bt_audio_ep *ep)
 void ascs_ep_set_state(struct bt_audio_ep *ep, uint8_t state)
 {
 	struct bt_audio_stream *stream;
+	bool state_changed;
 	uint8_t old_state;
 
 	if (!ep) {
@@ -117,6 +118,7 @@ void ascs_ep_set_state(struct bt_audio_ep *ep, uint8_t state)
 
 	old_state = ep->status.state;
 	ep->status.state = state;
+	state_changed = old_state != state;
 
 	BT_DBG("ep %p id 0x%02x %s -> %s", ep, ep->status.id,
 	       bt_audio_ep_state_str(old_state),
@@ -125,7 +127,7 @@ void ascs_ep_set_state(struct bt_audio_ep *ep, uint8_t state)
 	/* Notify clients*/
 	ase_status_changed(ep, old_state, state);
 
-	if (ep->stream == NULL || old_state == state) {
+	if (ep->stream == NULL) {
 		return;
 	}
 
@@ -212,8 +214,10 @@ void ascs_ep_set_state(struct bt_audio_ep *ep, uint8_t state)
 				return;
 			}
 
-			if (ops->enabled != NULL) {
+			if (state_changed && ops->enabled != NULL) {
 				ops->enabled(stream);
+			} else if (!state_changed && ops->metadata_updated) {
+				ops->metadata_updated(stream);
 			}
 
 			break;
@@ -230,8 +234,10 @@ void ascs_ep_set_state(struct bt_audio_ep *ep, uint8_t state)
 				return;
 			}
 
-			if (ops->started != NULL) {
+			if (state_changed && ops->started != NULL) {
 				ops->started(stream);
+			} else if (!state_changed && ops->metadata_updated) {
+				ops->metadata_updated(stream);
 			}
 
 			break;
@@ -290,7 +296,8 @@ void ascs_ep_set_state(struct bt_audio_ep *ep, uint8_t state)
 		}
 	}
 
-	if (state == BT_AUDIO_EP_STATE_CODEC_CONFIGURED &&
+	if (state_changed &&
+	    state == BT_AUDIO_EP_STATE_CODEC_CONFIGURED &&
 	    old_state != BT_AUDIO_EP_STATE_IDLE) {
 		ascs_ep_unbind_audio_iso(ep);
 	}

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -643,7 +643,8 @@ static void unicast_client_ep_qos_state(struct bt_audio_ep *ep,
 }
 
 static void unicast_client_ep_enabling_state(struct bt_audio_ep *ep,
-					     struct net_buf_simple *buf)
+					     struct net_buf_simple *buf,
+					     bool state_changed)
 {
 	struct bt_ascs_ase_status_enable *enable;
 	struct bt_audio_stream *stream;
@@ -666,16 +667,29 @@ static void unicast_client_ep_enabling_state(struct bt_audio_ep *ep,
 
 	unicast_client_ep_set_metadata(ep, buf, enable->metadata_len, NULL);
 
-	/* Notify upper layer */
-	if (stream->ops != NULL && stream->ops->enabled != NULL) {
-		stream->ops->enabled(stream);
+	/* Notify upper layer
+	 *
+	 * If the state did not change then only the metadata was changed
+	 */
+	if (state_changed) {
+		if (stream->ops != NULL && stream->ops->enabled != NULL) {
+			stream->ops->enabled(stream);
+		} else {
+			BT_WARN("No callback for enabled set");
+		}
 	} else {
-		BT_WARN("No callback for enabled set");
+		if (stream->ops != NULL &&
+		    stream->ops->metadata_updated != NULL) {
+			stream->ops->metadata_updated(stream);
+		} else {
+			BT_WARN("No callback for metadata_updated set");
+		}
 	}
 }
 
 static void unicast_client_ep_streaming_state(struct bt_audio_ep *ep,
-					      struct net_buf_simple *buf)
+					      struct net_buf_simple *buf,
+					      bool state_changed)
 {
 	struct bt_ascs_ase_status_stream *stream_status;
 	struct bt_audio_stream *stream;
@@ -696,11 +710,23 @@ static void unicast_client_ep_streaming_state(struct bt_audio_ep *ep,
 	BT_DBG("dir 0x%02x cig 0x%02x cis 0x%02x",
 	       ep->dir, ep->cig_id, ep->cis_id);
 
-	/* Notify upper layer */
-	if (stream->ops != NULL && stream->ops->started != NULL) {
-		stream->ops->started(stream);
+	/* Notify upper layer
+	 *
+	 * If the state did not change then only the metadata was changed
+	 */
+	if (state_changed) {
+		if (stream->ops != NULL && stream->ops->started != NULL) {
+			stream->ops->started(stream);
+		} else {
+			BT_WARN("No callback for started set");
+		}
 	} else {
-		BT_WARN("No callback for started set");
+		if (stream->ops != NULL &&
+		    stream->ops->metadata_updated != NULL) {
+			stream->ops->metadata_updated(stream);
+		} else {
+			BT_WARN("No callback for metadata_updated set");
+		}
 	}
 }
 
@@ -759,6 +785,7 @@ static void unicast_client_ep_set_status(struct bt_audio_ep *ep,
 					 struct net_buf_simple *buf)
 {
 	struct bt_ascs_ase_status *status;
+	bool state_changed;
 	uint8_t old_state;
 
 	if (!ep) {
@@ -767,9 +794,9 @@ static void unicast_client_ep_set_status(struct bt_audio_ep *ep,
 
 	status = net_buf_simple_pull_mem(buf, sizeof(*status));
 
-
 	old_state = ep->status.state;
 	ep->status = *status;
+	state_changed = old_state != ep->status.state;
 
 	BT_DBG("ep %p handle 0x%04x id 0x%02x dir %u state %s -> %s", ep,
 	       ep->client.handle, status->id, ep->dir,
@@ -852,7 +879,7 @@ static void unicast_client_ep_set_status(struct bt_audio_ep *ep,
 			return;
 		}
 
-		unicast_client_ep_enabling_state(ep, buf);
+		unicast_client_ep_enabling_state(ep, buf, state_changed);
 		break;
 	case BT_AUDIO_EP_STATE_STREAMING:
 		switch (old_state) {
@@ -868,7 +895,7 @@ static void unicast_client_ep_set_status(struct bt_audio_ep *ep,
 			return;
 		}
 
-		unicast_client_ep_streaming_state(ep, buf);
+		unicast_client_ep_streaming_state(ep, buf, state_changed);
 		break;
 	case BT_AUDIO_EP_STATE_DISABLING:
 		if (ep->dir == BT_AUDIO_DIR_SOURCE) {


### PR DESCRIPTION
The metadataa_updated callback has existed for a long
time, but was never actually used. The metadata is set
or updated in the enabling and streaming state.

Added checks to see if the state actually changes when going
into these states, and if not, then it means that the
metadata was updated.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>