### PR TITLE
mgmt: mcumgr: Add optional image number to erase command

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -258,6 +258,9 @@ Libraries / Subsystems
     variable instead, see :ref:`mcumgr_smp_group_9` for updated
     information. Legacy bahaviour can be restored by enabling
     :kconfig:option:`CONFIG_MCUMGR_CMD_SHELL_MGMT_LEGACY_RC_RETURN_CODE`
+  * MCUMGR img_mgmt erase command now accepts an optional slot number
+    to select which image will be erased, using the ``slot`` input
+    (will default to slot 1 if not provided).
 
 HALs
 ****

--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -354,10 +354,6 @@ Image erase
 The command is used for erasing image slot on a target device.
 
 .. note::
-    Currently Zephyr version of mcumgr is hardcoded to always erase secondary slot
-    of the first image.
-
-.. note::
     This is synchronous command which means that a sender of request will not
     receive response until the command completes.
 
@@ -375,7 +371,25 @@ Image erase request header fields:
     | ``2``  | ``1``        |  ``5``         |
     +--------+--------------+----------------+
 
-The command sends sends empty CBOR map as data.
+CBOR data of request:
+
+.. code-block:: none
+
+    {
+        {
+            (str,opt)"slot"     : (uint)
+        }
+    }
+
+where:
+
+.. table::
+    :align: center
+
+    +---------+-----------------------------------------------------------------+
+    | "slot"  | optional slot number, it does not have to appear in the request |
+    |         | at all, in which case it is assumed to be 1.                    |
+    +---------+-----------------------------------------------------------------+
 
 Image erase response
 ====================

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
@@ -22,11 +22,13 @@ extern "C" {
 #endif
 
 /**
- * @brief Ensures the spare slot (slot 1) is fully erased.
+ * @brief Ensures the spare slot is fully erased.
+ *
+ * @param slot		The slot to erase.  In the typical use case, this is 1.
  *
  * @return 0 on success, MGMT_ERR_[...] code on failure.
  */
-int img_mgmt_impl_erase_slot(void);
+int img_mgmt_impl_erase_slot(int slot);
 
 /**
  * @brief Marks the image in the specified slot as pending. On the next reboot,


### PR DESCRIPTION
Allows selecting which image will be erased, will default back to
image 1 as it would do in previous versions if the optional parameter
is not provided

Fixes #40855