### PR TITLE
nrf52_bsim: Add Level interrupts support

### DIFF
--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -110,6 +110,8 @@ void posix_irq_handler(void)
 		vector_to_irq(irq_nbr, &may_swap);
 		currently_running_irq = last_running_irq;
 
+		hw_irq_ctrl_reeval_level_irq(irq_nbr);
+
 		hw_irq_ctrl_set_cur_prio(last_current_running_prio);
 	}
 

--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 93406267eca506003bcb86a86927777a32e729d9
+      revision: 65bc5305d432c08e24a3f343006d1e7deaff4908
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 8d53544871e1f300c478224faca6be8384ab0d04


### PR DESCRIPTION
    nrf52_bsim: Add support for level interrupt
    
    Change in the MCU/interrupt handler model
    which enables using the new nrf52 HW models irq controller
    level interrupts.
    
    Note that this change requires the updated HW models which
    provide the new level based interrupts API.
    
    Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

-------

    manifest: Use latest nrf HW models
    
    Use the latest nRF HW models which provide level
    interrupt support in the interrupt controller.
    Add an EGU peripheral stub, and have other minor changes.
    
    Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>
