### PR TITLE
boards: stm32f411e_disco: Fix devicetree node deletion

### DIFF
--- a/boards/arm/stm32f411e_disco/stm32f411e_disco_B.overlay
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco_B.overlay
@@ -6,12 +6,13 @@
 
 / {
 	aliases {
+		/delete-property/ magn0;
 		accel0 = &lsm303dlhc_accel;
 	};
 };
 
 &i2c1 {
-    /delete-node/ lsm303agr-magn;
+    /delete-node/ lsm303agr-magn@1e;
     /delete-node/ lsm303agr-accel@19;
 
 	lsm303dlhc_magn: lsm303dlhc-magn@1e {


### PR DESCRIPTION
The stm32f411e_disco_B.overlay wasn't propertly deleting the
lsm303agr-magn@1e node and associated alias.  Fix this which also
addresses a DTC warning we get.

Signed-off-by: Kumar Gala <galak@kernel.org>