### PR TITLE
dts: stm32: l0: Move usb PHY nodes out of SoC to fix warning

### DIFF
--- a/dts/arm/st/l0/stm32l053.dtsi
+++ b/dts/arm/st/l0/stm32l053.dtsi
@@ -28,10 +28,10 @@
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
+	};
 
-		otgfs_phy: otgfs_phy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-		};
+	otgfs_phy: otgfs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
 	};
 };


### PR DESCRIPTION
We currently get a number of warnings like:

        Warning (simple_bus_reg): /soc/otgfs_phy: missing or empty
        reg/ranges property

This is due to the usb phy nodes not have a reg property since they
don't have an mmio address associated with them.

Move the phy nodes out of the SoC node so their lack of a reg property
will not cause a warning.  This is similar to how Linux dts files
handle the phy nodes.

Signed-off-by: Kumar Gala <galak@kernel.org>