### PR TITLE
dts: arm: xilinx: Remove improper range property

### DIFF
--- a/dts/arm/xilinx/zynq7000.dtsi
+++ b/dts/arm/xilinx/zynq7000.dtsi
@@ -128,7 +128,6 @@
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0";
 
-			ranges;
 			#address-cells = <1>;
 			#size-cells = <0>;
 

--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -213,7 +213,6 @@
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0";
 
-			ranges;
 			#address-cells = <1>;
 			#size-cells = <0>;
 


### PR DESCRIPTION
Remove 'ranges' property from gpio node as it shouldn't be there
since we aren't converting 1:1 between address spaces.  This fixes
the following DTC warning:

   Warning (ranges_format): /soc/gpio@e000a000:ranges: empty "ranges"
   property but its #size-cells (0) differs from /soc (1)

Signed-off-by: Kumar Gala <galak@kernel.org>