### PR TITLE
dts: quicklogic: Add missing reg property to gpio node

### DIFF
--- a/dts/arm/quicklogic/quicklogic_eos_s3.dtsi
+++ b/dts/arm/quicklogic/quicklogic_eos_s3.dtsi
@@ -48,8 +48,9 @@
 			interrupt-names = "rx";
 		};
 
-		gpio: gpio {
+		gpio: gpio@40005000 {
 			compatible = "quicklogic,eos-s3-gpio";
+			reg = <0x40005000 DT_SIZE_K(4)>;
 			status = "disabled";
 			interrupts = <5 2>;
 			#gpio-cells = <2>;


### PR DESCRIPTION
Add reg property to GPIO node that was missing.  Fixes a DTC
warning about having no 'reg' property.

Signed-off-by: Kumar Gala <galak@kernel.org>