### PR TITLE
Zephyr Shared ISRs

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -34,6 +34,7 @@ config ARM
 	# is really only necessary for Cortex-M with ARM MPU!
 	select GEN_PRIV_STACKS
 	select ARCH_HAS_THREAD_LOCAL_STORAGE if CPU_AARCH32_CORTEX_R || CPU_CORTEX_M || CPU_AARCH32_CORTEX_A
+	select ARCH_HAS_SW_ISR_TABLE_SHARED_IRQ
 	help
 	  ARM architecture
 
@@ -47,6 +48,7 @@ config ARM64
 	select USE_SWITCH
 	select USE_SWITCH_SUPPORTED
 	select IRQ_OFFLOAD_NESTED if IRQ_OFFLOAD
+	select ARCH_HAS_SW_ISR_TABLE_SHARED_IRQ
 	help
 	  ARM64 (AArch64) architecture
 
@@ -69,6 +71,7 @@ config SPARC
 	select ATOMIC_OPERATIONS_C if !SPARC_CASA
 	select ARCH_HAS_THREAD_LOCAL_STORAGE
 	select ARCH_HAS_EXTRA_EXCEPTION_INFO
+	select ARCH_HAS_SW_ISR_TABLE_SHARED_IRQ
 	help
 	  SPARC architecture
 
@@ -405,6 +408,13 @@ config GEN_IRQ_VECTOR_TABLE
 	  indexed by IRQ line. In the latter case, the vector table must be
 	  supplied by the application or architecture code.
 
+config ISR_SHARE_IRQ
+	bool "Allow IRQs to share multiple ISRs"
+	depends on GEN_ISR_TABLES
+	help
+	  Some peripherals share an IRQ and this option enables the system
+	  to call all ISRs attached to a pending IRQ.
+
 config ARCH_IRQ_VECTOR_TABLE_ALIGN
 	int "Alignment size of the interrupt vector table"
 	default 4
@@ -574,6 +584,12 @@ config ARCH_HAS_SUSPEND_TO_RAM
 #
 # Other architecture related options
 #
+
+config ARCH_HAS_SW_ISR_TABLE_SHARED_IRQ
+	bool
+	help
+	  This option controls if mulitple ISRs can share
+	  the same IRQ.
 
 config ARCH_HAS_THREAD_ABORT
 	bool

--- a/cmake/linker_script/arm/linker.cmake
+++ b/cmake/linker_script/arm/linker.cmake
@@ -83,6 +83,8 @@ zephyr_linker_section_configure(SECTION .text INPUT ".glue_7t")
 zephyr_linker_section_configure(SECTION .text INPUT ".glue_7")
 zephyr_linker_section_configure(SECTION .text INPUT ".vfp11_veneer")
 zephyr_linker_section_configure(SECTION .text INPUT ".v4_bx")
+zephyr_linker_section_configure(SECTION .text INPUT ".shared_irq")
+zephyr_linker_section_configure(SECTION .text INPUT ".shared_irq_arg")
 
 if(CONFIG_CPLUSPLUS)
   zephyr_linker_section(NAME .ARM.extab GROUP ROM_REGION)

--- a/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -141,6 +141,8 @@ SECTIONS
 
         *(.text)
         *(".text.*")
+        *(.shared_irq)
+        *(.shared_irq_arg)
         *(.gnu.linkonce.t.*)
 
         /*

--- a/include/zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -135,6 +135,8 @@ SECTIONS
 	*(.text)
 	*(".text.*")
 	*(".TEXT.*")
+        *(.shared_irq)
+        *(.shared_irq_arg)
 	*(.gnu.linkonce.t.*)
 
 	/*

--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -111,6 +111,8 @@ SECTIONS
 
         *(.text)
         *(".text.*")
+        *(.shared_irq)
+        *(.shared_irq_arg)
         *(.gnu.linkonce.t.*)
 
         /*

--- a/include/zephyr/arch/sparc/linker.ld
+++ b/include/zephyr/arch/sparc/linker.ld
@@ -34,6 +34,8 @@ SECTIONS
 		*(.text.traptable)
 		*(.text)
 		*(.text.*)
+		*(.shared_irq)
+		*(.shared_irq_arg)
 		*(.stub)
 		*(.gnu.linkonce.t.*)
 	} GROUP_LINK_IN(REGION_TEXT)

--- a/tests/kernel/interrupt/CMakeLists.txt
+++ b/tests/kernel/interrupt/CMakeLists.txt
@@ -15,5 +15,6 @@ target_sources(app PRIVATE
     src/nested_irq.c
     )
 
+target_sources_ifdef(CONFIG_ISR_SHARE_IRQ app PRIVATE src/shared_irq.c)
 target_sources_ifdef(CONFIG_DYNAMIC_INTERRUPTS app PRIVATE src/dynamic_isr.c)
 target_sources_ifdef(CONFIG_X86 app PRIVATE src/regular_isr.c)

--- a/tests/kernel/interrupt/src/shared_irq.c
+++ b/tests/kernel/interrupt/src/shared_irq.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 The Chromium OS Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/interrupt_util.h>
+
+#define DURATION        5
+
+#if defined(CONFIG_GIC)
+#define ISR0_OFFSET	10
+#define ISR1_2_OFFSET	11
+#define ISR3_4_5_OFFSET	12
+#define ISR6_OFFSET	13
+#else
+/* Offset for the interrupt used in this test. */
+#define ISR0_OFFSET     (CONFIG_NUM_IRQS - 7)
+#define ISR1_2_OFFSET   (CONFIG_NUM_IRQS - 6)
+#define ISR3_4_5_OFFSET (CONFIG_NUM_IRQS - 5)
+#define ISR6_OFFSET     (CONFIG_NUM_IRQS - 4)
+#endif
+
+#define MAX_ISR_TESTS 7
+
+static volatile int test_flag[MAX_ISR_TESTS] = {0};
+
+static void isr0(void *arg)
+{
+	int value = POINTER_TO_INT(arg);
+
+	test_flag[0] = value;
+}
+
+static void share_isr1(void *arg)
+{
+	int value = POINTER_TO_INT(arg);
+
+	test_flag[1] = value;
+}
+
+static void share_isr2(void *arg)
+{
+	int value = POINTER_TO_INT(arg);
+
+	test_flag[2] = value;
+}
+
+static void share_isr3(void *arg)
+{
+	int value = POINTER_TO_INT(arg);
+
+	test_flag[3] = value;
+}
+
+static void share_isr4(void *arg)
+{
+	int value = POINTER_TO_INT(arg);
+
+	test_flag[4] = value;
+}
+
+static void share_isr5(void *arg)
+{
+	int value = POINTER_TO_INT(arg);
+
+	test_flag[5] = value;
+}
+
+static void isr6(void *arg)
+{
+	int value = POINTER_TO_INT(arg);
+
+	test_flag[6] = value;
+}
+
+/**
+ * @brief Test shared interrupt
+ *
+ * @details Validate that shared interrupts work as expected.
+ * - Register two regular interrupt at build time.
+ * - Two shared interrupts at build time.
+ * - Three shared interrupts at build time.
+ * - Trigger interrupts and check if isrs handler are executed or not.
+ *
+ * @ingroup kernel_interrupt_tests
+ */
+ZTEST(interrupt_feature, test_shared_irq)
+{
+	/* Ensure the IRQ is disabled before enabling it at run time */
+	irq_disable(ISR0_OFFSET);
+	irq_disable(ISR1_2_OFFSET);
+	irq_disable(ISR3_4_5_OFFSET);
+	irq_disable(ISR6_OFFSET);
+
+	/* Place the non-direct shared interrupts */
+	IRQ_CONNECT(ISR0_OFFSET,     0, isr0,       (void *)1, 0);
+	IRQ_CONNECT(ISR1_2_OFFSET,   0, share_isr1, (void *)2, 0);
+	IRQ_CONNECT(ISR1_2_OFFSET,   0, share_isr2, (void *)3, 0);
+	IRQ_CONNECT(ISR3_4_5_OFFSET, 0, share_isr3, (void *)4, 0);
+	IRQ_CONNECT(ISR3_4_5_OFFSET, 0, share_isr4, (void *)5, 0);
+	IRQ_CONNECT(ISR3_4_5_OFFSET, 0, share_isr5, (void *)6, 0);
+	IRQ_CONNECT(ISR6_OFFSET,     0, isr6,       (void *)7, 0);
+
+	/* Enable and pend the interrupts */
+	irq_enable(ISR0_OFFSET);
+	irq_enable(ISR1_2_OFFSET);
+	irq_enable(ISR3_4_5_OFFSET);
+	irq_enable(ISR6_OFFSET);
+
+	/* Trigger the interrupts */
+	trigger_irq(ISR0_OFFSET);
+	trigger_irq(ISR1_2_OFFSET);
+	trigger_irq(ISR3_4_5_OFFSET);
+	trigger_irq(ISR6_OFFSET);
+	k_busy_wait(MS_TO_US(DURATION));
+
+	for (int i = 0; i < MAX_ISR_TESTS; i++) {
+		zassert_true(test_flag[i] == i + 1, "Test flag not set by ISR%d\n", i);
+	}
+}

--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -11,3 +11,10 @@ tests:
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     extra_configs:
       - CONFIG_CMAKE_LINKER_GENERATOR=y
+
+  arch.interrupt.isr_share_irq:
+    platform_allow: qemu_cortex_m0 qemu_cortex_m3 qemu_cortex_a9 qemu_cortex_a53 qemu_cortex_a53_smp
+    tags: kernel interrupt isr_share_irq
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
+    extra_configs:
+      - CONFIG_ISR_SHARE_IRQ=y


### PR DESCRIPTION
This PR implements a feature that allows for the use of shared interrupts in Zephyr. I've only tested it on the arm aarch32. Please see #49379 for more context. Also, I'm not a python programmer, so I'm sure my changes to gen_isr_tables.py can be improved upon.