### PR TITLE
Bluetooth: Controller: Kconfig to permit periodic sync event skip

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -284,6 +284,27 @@ config BT_CTRL_ADV_ADI_IN_SCAN_RSP
 	help
 	  Enable ADI field in AUX_SCAN_RSP PDU
 
+config BT_CTLR_SYNC_PERIODIC_SKIP_ON_SCAN_AUX
+	bool "Skip Periodic Sync event on overlap with Extended Scan Event"
+	depends on BT_CTLR_SYNC_PERIODIC
+	help
+	  When AUX_ADV_IND or AUX_CHAIN_IND auxiliary channel PDU scan radio
+	  event overlaps Periodic Sync radio event in unreserved time space,
+	  let the Periodic Sync radio event be aborted so that the auxiliary
+	  channel PDU can be received to generate Extended Advertising Reports.
+
+	  By default we want Periodic Advertising Sync Events to take priority
+	  over any overlapping Extended Advertising Primary and Auxiliary
+	  channel PDU reception in order to not skip Periodic Advertising Report
+	  generation.
+
+	  But under simultaneous multiple Periodic Advertising Sync support with
+	  small Periodic Advertising Intervals where there will be a lot of
+	  overlapping Periodic Advertising Sync events, it is desirable to
+	  permit Extended Advertising auxiliary PDU reception be allowed in a
+	  round robin scheduling to skip the overlapping Periodic Advertising
+	  Sync event. This permits new Periodic Advertising peers be discovered.
+
 config BT_CTLR_SCAN_AUX_SET
 	int "LE Extended Scanning Auxiliary Sets"
 	depends on BT_OBSERVER && BT_CTLR_ADV_EXT

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -474,7 +474,8 @@ static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb)
 			struct lll_scan_aux *lll_aux;
 
 			lll_aux = ull_scan_aux_lll_is_valid_get(next);
-			if (!lll_aux) {
+			if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC_SKIP_ON_SCAN_AUX) ||
+			    !lll_aux) {
 				/* Abort current event as next event is not a
 				 * scan and not a scan aux event.
 				 */


### PR DESCRIPTION
When AUX_ADV_IND or AUX_CHAIN_IND auxiliary channel PDU
scan radio event overlaps Periodic Sync radio event, let
the Periodic Sync radio event be aborted so that the
auxiliary channel PDU can be received to generate Extended
Advertising Reports. Added a new Kconfig to enable this.

Fixes #49410.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>