### PR TITLE
dts: arm: st: Fix DTC warnings

### DIFF
--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -547,9 +547,9 @@
 			};
 		};
 
-		timers13: timers@40001C00 {
+		timers13: timers@40001c00 {
 			compatible = "st,stm32-timers";
-			reg = <0x40001C00 0x400>;
+			reg = <0x40001c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000080>;
 			interrupts = <44 0>;
 			interrupt-names = "global";

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -8,9 +8,9 @@
 
 / {
 	soc {
-		timers5: timers@40000C00 {
+		timers5: timers@40000c00 {
 			compatible = "st,stm32-timers";
-			reg = <0x40000C00 0x400>;
+			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000008>;
 			interrupts = <50 0>;
 			interrupt-names = "global";

--- a/dts/arm/st/l1/stm32l151Xc.dtsi
+++ b/dts/arm/st/l1/stm32l151Xc.dtsi
@@ -19,9 +19,9 @@
 			};
 		};
 
-		timers5: timers@40000C00 {
+		timers5: timers@40000c00 {
 			compatible = "st,stm32-timers";
-			reg = <0x40000C00 0x400>;
+			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000008>;
 			interrupts = <45 0>;
 			interrupt-names = "global";

--- a/dts/arm/st/l1/stm32l152Xc.dtsi
+++ b/dts/arm/st/l1/stm32l152Xc.dtsi
@@ -19,9 +19,9 @@
 			};
 		};
 
-		timers5: timers@40000C00 {
+		timers5: timers@40000c00 {
 			compatible = "st,stm32-timers";
-			reg = <0x40000C00 0x400>;
+			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000008>;
 			interrupts = <45 0>;
 			interrupt-names = "global";

--- a/dts/arm/st/l1/stm32l152Xe.dtsi
+++ b/dts/arm/st/l1/stm32l152Xe.dtsi
@@ -19,9 +19,9 @@
 			};
 		};
 
-		timers5: timers@40000C00 {
+		timers5: timers@40000c00 {
 			compatible = "st,stm32-timers";
-			reg = <0x40000C00 0x400>;
+			reg = <0x40000c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000008>;
 			interrupts = <45 0>;
 			interrupt-names = "global";

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -280,9 +280,9 @@
 			status = "disabled";
 		};
 
-		ltdc: display-controller@5A001000 {
+		ltdc: display-controller@5a001000 {
 			compatible = "st,stm32-ltdc";
-			reg = <0x5A001000 0x200>;
+			reg = <0x5a001000 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK_BUS_APB4 0x00000001>;


### PR DESCRIPTION
Fix various DTC warnings of the form:

   Warning (simple_bus_reg): simple-bus unit address format error

Signed-off-by: Kumar Gala <galak@kernel.org>