### PR TITLE
soc: nxp: Remove the no cache linker script

### DIFF
--- a/soc/arm/nxp_imx/rt/CMakeLists.txt
+++ b/soc/arm/nxp_imx/rt/CMakeLists.txt
@@ -48,10 +48,6 @@ if(CONFIG_ENTROPY_MCUX_CAAM)
   )
 endif()
 
-
-zephyr_linker_sources(
-  RWDATA nocache.ld)
-
 zephyr_linker_section_configure(
   SECTION .rom_start
   INPUT ".boot_hdr.ivt"

--- a/soc/arm/nxp_imx/rt/nocache.ld
+++ b/soc/arm/nxp_imx/rt/nocache.ld
@@ -1,8 +1,0 @@
-/*
- * Copyright (c) 2020 NXP
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-. = ALIGN(4);
-KEEP(*(NonCacheable))

--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 0c54992ad4fe53b1edfc35ea24b6f343e38df2ca
+      revision: 3516aa5f722eb70b969b3bc57bcf9389ad901057
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
The nocache linker script has been moved to the NXP HAL layer so that all SDK NonCacheable symbols get placed in the nocache region
Also pull in the HAL changes associated with this change. 
This is dependent on PR https://github.com/zephyrproject-rtos/zephyr/pull/49368
