### PR TITLE
cache: Fix build warning 'No SOURCES given to Zephyr library'

### DIFF
--- a/drivers/cache/CMakeLists.txt
+++ b/drivers/cache/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
+zephyr_library_property(ALLOW_EMPTY TRUE)
 
 zephyr_library_sources_ifdef(CONFIG_CACHE_ASPEED	cache_aspeed.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE		cache_handlers.c)


### PR DESCRIPTION
Following 4806e1087eb0eabc6864f4a5e29eafc3d4c5d58d , the following warning appears for some boards (e.g. `qemu_cortex_a53`):
```
CMake Warning at /zephyr/CMakeLists.txt:798 (message):
  No SOURCES given to Zephyr library: drivers__cache

  Excluding target from build.
```

Allow this driver to have no sources.

Ping @carlocaione on this. Feel free to drop this MR and do a better fix if appropriate.
