### PR TITLE
Cleanup and fix log_output dependencies

### DIFF
--- a/subsys/logging/CMakeLists.txt
+++ b/subsys/logging/CMakeLists.txt
@@ -6,7 +6,6 @@ if(NOT CONFIG_LOG_MODE_MINIMAL)
     log_core.c
     log_mgmt.c
     log_msg.c
-    log_output.c
   )
 
   zephyr_sources_ifdef(

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -228,6 +228,7 @@ config SHELL_LOG_BACKEND
 	bool "Shell log backend"
 	depends on LOG && !LOG_MODE_MINIMAL
 	select MPSC_PBUF
+	select LOG_OUTPUT
 	default y if LOG
 	help
 	  When enabled, backend will use the shell for logging.


### PR DESCRIPTION
Logging cmake files where adding `log_output.c` even when `CONFIG_LOG_OUTPUT` was not set.
Shell was not enabling LOG_OUTPUT when used as shell log backend.

Putting those two together resulted in a misbehavior of logging through shell (timestamp was not printed).