### PR TITLE
arch: arm64: Include GOT in RODATA

### DIFF
--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -164,6 +164,14 @@ SECTIONS
         *(".rodata.*")
         *(.gnu.linkonce.r.*)
 
+        /*
+         * The following is a workaround to allow compiling with GCC 12 and
+         * above, which may emit "GOT indirections" for the weak symbol
+         * references (see the GitHub issue zephyrproject-rtos/sdk-ng#547).
+         */
+        *(.got)
+        *(.got.plt)
+
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
@@ -186,9 +194,7 @@ SECTIONS
      */
     /DISCARD/ :
     {
-        *(.got.plt)
         *(.igot.plt)
-        *(.got)
         *(.igot)
     }
 


### PR DESCRIPTION
GCC 12 and above may emit "GOT indirections" for the weak symbol
references, and this requires the Global Offset Table (GOT) to be
included in the output.

This commit places the `.got` section in the RODATA section so that
the addresses of the weak symbols can be resolved at run-time. Note
that the GOT is populated with the symbol addresses at the default
linking address by the linker.

The `.got.plt` section, although unused, is also placed in the RODATA
section because the linker refuses to allow discarding this section
even when the `.plt` section is discarded.

In case of the GCC releases prior to 12, the weak symbol addresses are
placed in the literal pool and the `.got` section is not created at
all; therefore, this patch will be no-op.

For more details, refer to the following GitHub issue:
zephyrproject-rtos/sdk-ng#547.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>