### PR TITLE
dts/arm: stm32f105: enable master can gating clock for can2

### DIFF
--- a/dts/arm/st/f1/stm32f105.dtsi
+++ b/dts/arm/st/f1/stm32f105.dtsi
@@ -47,7 +47,8 @@
 			reg = <0x40006800 0x400>;
 			interrupts = <63 0>, <64 0>, <65 0>, <66 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x04000000>;
+			/* also enabling clock for can1 (master instance) */
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x06000000>;
 			status = "disabled";
 			sjw = <1>;
 			sample-point = <875>;


### PR DESCRIPTION
The can2 only works if gating clock of the master can (can1)
is enabled, therefore also set that bit for can2.

fixes  #49769