### PR TITLE
Add option to use BL1 from TF-M.

### DIFF
--- a/doc/services/tfm/overview.rst
+++ b/doc/services/tfm/overview.rst
@@ -147,6 +147,11 @@ The default secure bootloader in TF-M is based on
 (for the second-stage bootloader, potentially after a HW-based bootloader on
 the secure MCU, etc.).
 
+TF-M also provides an optional immutable first stage bootloader - BL1. This can
+either be the default TF-M BL1 bootloader which uses most of the same codebase
+as BL2/MCUBoot mentioned above or a platform specific bootloader provided by a
+vendor.
+
 All images in TF-M are hashed and signed, with the hash and signature verified
 by MCUBoot during the firmware update process.
 
@@ -174,7 +179,8 @@ When dealing with (optionally) encrypted images:
 
 Key config properties to control secure boot in Zephyr are:
 
-* :kconfig:option:`CONFIG_TFM_BL2` toggles the bootloader (default = ``y``).
+* :kconfig:option:`CONFIG_TFM_BL1` toggles the BL1 bootloader (default = ``n``).
+* :kconfig:option:`CONFIG_TFM_BL2` toggles the BL2 bootloader (default = ``y``).
 * :kconfig:option:`CONFIG_TFM_KEY_FILE_S` overrides the secure signing key.
 * :kconfig:option:`CONFIG_TFM_KEY_FILE_NS` overrides the non-secure signing key.
 

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -44,6 +44,11 @@ if (CONFIG_BUILD_WITH_TFM)
   if (CONFIG_TFM_REGRESSION_NS)
     list(APPEND TFM_CMAKE_ARGS -DTEST_NS=ON)
   endif()
+  if (CONFIG_TFM_BL1)
+    list(APPEND TFM_CMAKE_ARGS -DBL1=TRUE)
+  else()
+    list(APPEND TFM_CMAKE_ARGS -DBL1=FALSE)
+  endif()
   if (CONFIG_TFM_BL2)
     list(APPEND TFM_CMAKE_ARGS -DBL2=TRUE)
   else()
@@ -167,7 +172,11 @@ if (CONFIG_BUILD_WITH_TFM)
     set(COMBINE_DIR_INITIAL_ATTESTATION initial_attestation)
     set(PSA_TEST_COMBINE_FILE ${TFM_BINARY_DIR}/tf-m-tests/app/psa_api_tests/dev_apis/${COMBINE_DIR_${TFM_PSA_TEST_SUITE}}/test_combine.a)
   endif()
-
+  if(CONFIG_TFM_BL1)
+    set(BL1_ELF_FILE ${TFM_BINARY_DIR}/bin/bl1.elf)
+    set(BL1_BIN_FILE ${TFM_BINARY_DIR}/bin/bl1.bin)
+    set(BL1_HEX_FILE ${TFM_BINARY_DIR}/bin/bl1.hex)
+  endif()
   if(CONFIG_TFM_BL2)
     set(BL2_ELF_FILE ${TFM_BINARY_DIR}/bin/bl2.elf)
     set(BL2_BIN_FILE ${TFM_BINARY_DIR}/bin/bl2.bin)
@@ -190,6 +199,9 @@ if (CONFIG_BUILD_WITH_TFM)
     ${PSA_TEST_PAL_FILE}
     ${PSA_TEST_COMBINE_FILE}
     ${PLATFORM_NS_FILE}
+    ${BL1_ELF_FILE}
+    ${BL1_BIN_FILE}
+    ${BL1_HEX_FILE}
     ${BL2_ELF_FILE}
     ${BL2_BIN_FILE}
     ${BL2_HEX_FILE}
@@ -335,6 +347,13 @@ if (CONFIG_BUILD_WITH_TFM)
       )
   endif()
 
+  if(CONFIG_TFM_BL1)
+    set_target_properties(tfm PROPERTIES
+      BL1_ELF_FILE ${BL1_ELF_FILE}
+      BL1_BIN_FILE ${BL1_BIN_FILE}
+      BL1_HEX_FILE ${BL1_HEX_FILE}
+      )
+  endif()
   # Set TFM S/NS executable file paths as target properties on 'tfm'
   # These files are produced by the TFM build system.
   # Note that the Nonsecure FW is replaced by the Zephyr app in regular Zephyr
@@ -475,7 +494,7 @@ if (CONFIG_BUILD_WITH_TFM)
     set(NS_APP_FILE ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME})
   endif()
 
-  if (NOT CONFIG_TFM_BL2)
+  if (NOT (CONFIG_TFM_BL1 OR CONFIG_TFM_BL2))
     # Merge tfm_s and zephyr (NS) image to a single binary.
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
       COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
@@ -501,6 +520,7 @@ if (CONFIG_BUILD_WITH_TFM)
 
       COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
         -o ${MERGED_FILE}
+        $<TARGET_PROPERTY:tfm,BL1_HEX_FILE>
         $<TARGET_PROPERTY:tfm,BL2_HEX_FILE>
         ${S_NS_SIGNED_FILE}
     )
@@ -527,6 +547,7 @@ if (CONFIG_BUILD_WITH_TFM)
 
       COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
         -o ${MERGED_FILE}
+        $<TARGET_PROPERTY:tfm,BL1_HEX_FILE>
         $<TARGET_PROPERTY:tfm,BL2_HEX_FILE>
         ${S_SIGNED_FILE}
         ${NS_SIGNED_FILE}

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -198,13 +198,20 @@ config TFM_IMAGE_VERSION_NS
 	  versions of both the secure firmware and non-secure firmware. This sets
 	  the non-secure firmware's version for rollback prevention.
 
+config TFM_BL1
+	bool "Use BL1 immutable bootloader from TFM"
+	default n
+	help
+          TFM provides a reference immutable bootloader, BL1.
+          This config adds BL1 to the build - built via TFM's build system.
+
 config TFM_BL2
-	bool "Add MCUboot to TFM"
+	bool "Use BL2 bootloader from TFM"
 	depends on !TFM_BL2_NOT_SUPPORTED
 	default y
 	help
-	  TFM is designed to run with MCUboot in a certain configuration.
-	  This config adds MCUboot to the build - built via TFM's build system.
+          TFM provides a reference second-stage flash bootloader, BL2.
+          This config adds BL2 to the build - built via TFM's build system.
 
 config TFM_BUILD_NS
 	bool "Build the TF-M Non-Secure application and libraries"
@@ -349,14 +356,15 @@ config ROM_START_OFFSET
 
 endif # !TFM_BL2
 
-# Option to instruct flashing a merged binary consisting of BL2 (optionally),
-# TF-M (Secure), and application (Non-Secure).
+# Option to instruct flashing a merged binary consisting of BL1 (optionally),
+# BL2 (optionally), # TF-M (Secure), and application (Non-Secure).
 config TFM_FLASH_MERGED_BINARY
 	bool
 	help
 	  This option instructs west flash to program the combined (merged)
 	  binary consisting of the TF-M Secure firmware image, optionally, the
-	  BL2 image (if building with TFM_BL2 is enabled), and the Non-Secure
+	  BL1 image (if building with TFM_BL1 is enabled), optinally
+	  the BL2 image (if building with TFM_BL2 is enabled), and the Non-Secure
 	  application firmware.
 
 config TFM_LOG_LEVEL_SILENCE

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -204,6 +204,8 @@ config TFM_BL1
 	help
           TFM provides a reference immutable bootloader, BL1.
           This config adds BL1 to the build - built via TFM's build system.
+          One usecase for using a BL1 bootloader is being able to sign
+          and update (the next stage) BL2 bootloader.
 
 config TFM_BL2
 	bool "Use BL2 bootloader from TFM"
@@ -211,7 +213,10 @@ config TFM_BL2
 	default y
 	help
           TFM provides a reference second-stage flash bootloader, BL2.
-          This config adds BL2 to the build - built via TFM's build system.
+          This bootloader is usually based on MCUBoot, and contains
+          the public keys used to verify firmware updates for subsequent
+          images in the chain of trust. This config adds BL2 to the build
+          - built via TFM's build system.
 
 config TFM_BUILD_NS
 	bool "Build the TF-M Non-Secure application and libraries"
@@ -356,8 +361,6 @@ config ROM_START_OFFSET
 
 endif # !TFM_BL2
 
-# Option to instruct flashing a merged binary consisting of BL1 (optionally),
-# BL2 (optionally), # TF-M (Secure), and application (Non-Secure).
 config TFM_FLASH_MERGED_BINARY
 	bool
 	help


### PR DESCRIPTION
Certain TF-M configurations build a stage 1 bootloader.
Enable CONFIG_TFM_PROVIDES_BL1 to use the BL1 bootloader created by
TF-M build when creating a merged HEX file.

Signed-off-by: Michael Wojciechowski-Jensen <ext-mwo@trackunit.com>