### PR TITLE
build: set recursive option for globbing relocated files

### DIFF
--- a/doc/kernel/code-relocation.rst
+++ b/doc/kernel/code-relocation.rst
@@ -61,7 +61,8 @@ for  data copy operations from ROM to required memory type.
 
   .. note::
 
-     The file argument supports limited regular expressions.
+     The file argument supports limited regular expressions. Files are searched
+     using the Python's glob function (with ``recursive=True``).
      function zephyr_code_relocate() can be called  as many times as required.
      This step has to be performed before the inclusion of boilerplate.cmake.
 

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -435,7 +435,7 @@ def create_dict_wrt_mem():
 
         mem_region, copy_flag, file_name = line.split(':', 2)
 
-        file_name_list = glob.glob(file_name)
+        file_name_list = glob.glob(file_name, recursive=True)
         if not file_name_list:
             warnings.warn("File: "+file_name+" Not found")
             continue


### PR DESCRIPTION
It might be handy to select all files from a subdirectory when doing code relocation.