### PR TITLE
mgmt: mcumgr: Fix non-start outgoing packets sent with start headers

### DIFF
--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -199,7 +199,7 @@ static void uart_mcumgr_isr(const struct device *unused, void *user_data)
 /**
  * Sends raw data over the UART.
  */
-static int uart_mcumgr_send_raw(const void *data, int len, void *arg)
+static int uart_mcumgr_send_raw(const void *data, int len)
 {
 	const uint8_t *u8p;
 
@@ -213,7 +213,7 @@ static int uart_mcumgr_send_raw(const void *data, int len, void *arg)
 
 int uart_mcumgr_send(const uint8_t *data, int len)
 {
-	return mcumgr_serial_tx_pkt(data, len, uart_mcumgr_send_raw, NULL);
+	return mcumgr_serial_tx_pkt(data, len, uart_mcumgr_send_raw);
 }
 
 

--- a/include/zephyr/mgmt/mcumgr/serial.h
+++ b/include/zephyr/mgmt/mcumgr/serial.h
@@ -93,11 +93,10 @@ struct mcumgr_serial_rx_ctxt {
  *
  * @param data                  The data to transmit.
  * @param len                   The number of bytes to transmit.
- * @param arg                   An optional argument.
  *
  * @return                      0 on success; negative error code on failure.
  */
-typedef int (*mcumgr_serial_tx_cb)(const void *data, int len, void *arg);
+typedef int (*mcumgr_serial_tx_cb)(const void *data, int len);
 
 /**
  * @brief Processes an mcumgr request fragment received over a serial
@@ -128,12 +127,10 @@ struct net_buf *mcumgr_serial_process_frag(
  * @param data                  The mcumgr packet data to send.
  * @param len                   The length of the unencoded mcumgr packet.
  * @param cb                    A callback used to transmit raw bytes.
- * @param arg                   An optional argument to pass to the callback.
  *
  * @return                      0 on success; negative error code on failure.
  */
-int mcumgr_serial_tx_pkt(const uint8_t *data, int len, mcumgr_serial_tx_cb cb,
-			 void *arg);
+int mcumgr_serial_tx_pkt(const uint8_t *data, int len, mcumgr_serial_tx_cb cb);
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/transport/serial_util.c
+++ b/subsys/mgmt/mcumgr/transport/serial_util.c
@@ -143,11 +143,10 @@ struct net_buf *mcumgr_serial_process_frag(
 }
 
 /**
- * Base64-encodes a small chunk of data and transmits it.  The data must be no
- * larger than three bytes.
+ * Base64-encodes a small chunk of data and transmits it. The data must be no larger than three
+ * bytes.
  */
-static int mcumgr_serial_tx_small(const void *data, int len,
-				  mcumgr_serial_tx_cb cb, void *arg)
+static int mcumgr_serial_tx_small(const void *data, int len, mcumgr_serial_tx_cb cb)
 {
 	uint8_t b64[4 + 1]; /* +1 required for null terminator. */
 	size_t dst_len;
@@ -157,179 +156,159 @@ static int mcumgr_serial_tx_small(const void *data, int len,
 	__ASSERT_NO_MSG(rc == 0);
 	__ASSERT_NO_MSG(dst_len == 4);
 
-	return cb(b64, 4, arg);
+	return cb(b64, 4);
 }
 
 /**
- * @brief Transmits a single mcumgr frame over serial.
+ * @brief Transmits a single mcumgr packet over serial, splits into multiple frames as needed.
  *
- * @param data                  The frame payload to transmit.  This does not
- *                                  include a header or CRC.
- * @param first                 Whether this is the first frame in the packet.
- * @param len                   The number of untransmitted data bytes in the
- *                                  packet.
- * @param crc                   The 16-bit CRC of the entire packet.
+ * @param data                  The packet payload to transmit. This does not include a header or
+ *                                  CRC.
+ * @param len                   The size of the packet payload.
  * @param cb                    A callback used for transmitting raw data.
- * @param arg                   An optional argument that gets passed to the
- *                                  callback.
- * @param out_data_bytes_txed   On success, the number of data bytes
- *                                  transmitted gets written here.
  *
  * @return                      0 on success; negative error code on failure.
  */
-int mcumgr_serial_tx_frame(const uint8_t *data, bool first, int len,
-			   uint16_t crc, mcumgr_serial_tx_cb cb, void *arg,
-			   int *out_data_bytes_txed)
+int mcumgr_serial_tx_pkt(const uint8_t *data, int len, mcumgr_serial_tx_cb cb)
 {
+	bool first = true;
+	bool last = false;
 	uint8_t raw[3];
 	uint16_t u16;
+	uint16_t crc;
 	int src_off = 0;
 	int rc = 0;
 	int to_process;
-	bool last = false;
 	int reminder;
 
 	/*
 	 * This is max input bytes that can be taken to the frame before encoding with Base64;
 	 * Base64 has three-to-four ratio, which means that for each three input bytes there are
-	 * going to be four bytes of output used.  The frame starts with two byte marker and ends
+	 * going to be four bytes of output used. The frame starts with two byte marker and ends
 	 * with newline character, which are not encoded (this is the "-3" in calculation).
 	 */
 	int max_input = (((MCUMGR_SERIAL_MAX_FRAME - 3) >> 2) * 3);
 
-	if (first) {
-		/* First frame marker */
-		u16 = sys_cpu_to_be16(MCUMGR_SERIAL_HDR_PKT);
-	} else {
-		/* Continuation frame marker */
-		u16 = sys_cpu_to_be16(MCUMGR_SERIAL_HDR_FRAG);
-	}
+	/* Calculate the CRC16 checksum of the whole packet, prior to splitting it into frames */
+	crc = mcumgr_serial_calc_crc(data, len);
 
-	rc = cb(&u16, sizeof(u16), arg);
-	if (rc != 0) {
-		return rc;
-	}
+	/* First frame marker */
+	u16 = sys_cpu_to_be16(MCUMGR_SERIAL_HDR_PKT);
 
-	/*
-	 * Only the first fragment contains the packet length; the packet length, which is two
-	 * byte long is paired with first byte of input buffer to form triplet for Base64 encoding.
-	 */
-	if (first) {
-		/* The size of the CRC16 should be added to packet length */
-		u16 = sys_cpu_to_be16(len + 2);
-		memcpy(raw, &u16, sizeof(u16));
-		raw[2] = data[0];
-
-		rc = mcumgr_serial_tx_small(raw, 3, cb, arg);
+	while (src_off < len) {
+		/* Send first frame or continuation frame marker */
+		rc = cb(&u16, sizeof(u16));
 		if (rc != 0) {
 			return rc;
 		}
 
-		++src_off;
-		/* One triple of allowed input already used */
-		max_input -= 3;
-	}
-
-	/*
-	 * Only as much as fits into the frame can be processed, but we also need to fit in the
-	 * two byte CRC.  The frame can not be stretched and current logic does not allow to
-	 * send CRC separately so if CRC would not fit as a whole, shrink to_process by one byte
-	 * forcing one byte to the next frame, with the CRC.
-	 */
-	to_process = MIN(max_input, len - src_off);
-	reminder = max_input - (len - src_off);
-
-	if (reminder == 0 || reminder == 1) {
-		to_process -= 1;
-	} else if (reminder >= 2) {
-		last = true;
-	}
-
-	/*
-	 * Try to process input buffer by chunks of three bytes that will be output as four byte
-	 * chunks, due to Base64 encoding; the number of chunks that can be processed is calculated
-	 * from number of three byte, complete, chunks in input buffer,  but can not be greater
-	 * than the number of four byte, complete, chunks that the frame can accept.
-	 */
-	while (to_process >= 3) {
-		memcpy(raw, data + src_off, 3);
-		rc = mcumgr_serial_tx_small(raw, 3, cb, arg);
-		if (rc != 0) {
-			return rc;
-		}
-		src_off += 3;
-		to_process -= 3;
-	}
-
-	if (last) {
 		/*
-		 * Process the reminder bytes of the input buffer, after sending it in three byte
-		 * chunks, and CRC.
+		 * Only the first fragment contains the packet length; the packet length, which is
+		 * two byte long is paired with first byte of input buffer to form triplet for
+		 * Base64 encoding.
 		 */
-		switch (len - src_off) {
-		case 0:
-			raw[0] = (crc & 0xff00) >> 8;
-			raw[1] = crc & 0x00ff;
-			rc = mcumgr_serial_tx_small(raw, 2, cb, arg);
-			break;
+		if (first) {
+			/* The size of the CRC16 should be added to packet length */
+			u16 = sys_cpu_to_be16(len + 2);
+			memcpy(raw, &u16, sizeof(u16));
+			raw[2] = data[0];
 
-		case 1:
-			raw[0] = data[src_off++];
-
-			raw[1] = (crc & 0xff00) >> 8;
-			raw[2] = crc & 0x00ff;
-			rc = mcumgr_serial_tx_small(raw, 3, cb, arg);
-			break;
-
-		case 2:
-			raw[0] = data[src_off++];
-			raw[1] = data[src_off++];
-
-			raw[2] = (crc & 0xff00) >> 8;
-			rc = mcumgr_serial_tx_small(raw, 3, cb, arg);
+			rc = mcumgr_serial_tx_small(raw, 3, cb);
 			if (rc != 0) {
 				return rc;
 			}
 
-			raw[0] = crc & 0x00ff;
-			rc = mcumgr_serial_tx_small(raw, 1, cb, arg);
-			break;
+			++src_off;
+			/* One triple of allowed input already used */
+			max_input -= 3;
 		}
 
+		/*
+		 * Only as much as fits into the frame can be processed, but we also need to fit
+		 * in the two byte CRC. The frame can not be stretched and current logic does not
+		 * allow to send CRC separately so if CRC would not fit as a whole, shrink
+		 * to_process by one byte forcing one byte to the next frame, with the CRC.
+		 */
+		to_process = MIN(max_input, len - src_off);
+		reminder = max_input - (len - src_off);
+
+		if (reminder == 0 || reminder == 1) {
+			to_process -= 1;
+
+			/* This is the last frame but the checksum cannot be added, remove the
+			 * last packet flag until the function runs again with the final piece of
+			 * data and place the checksum there
+			 */
+			last = false;
+		} else if (reminder >= 2) {
+			last = true;
+		}
+
+		/*
+		 * Try to process input buffer by chunks of three bytes that will be output as
+		 * four byte chunks, due to Base64 encoding; the number of chunks that can be
+		 * processed is calculated from number of three byte, complete, chunks in input
+		 * buffer, but can not be greater than the number of four byte, complete, chunks
+		 * that the frame can accept.
+		 */
+		while (to_process >= 3) {
+			memcpy(raw, data + src_off, 3);
+			rc = mcumgr_serial_tx_small(raw, 3, cb);
+			if (rc != 0) {
+				return rc;
+			}
+			src_off += 3;
+			to_process -= 3;
+		}
+
+		if (last) {
+			/*
+			 * Process the reminder bytes of the input buffer, after sending it in
+			 * three byte chunks, and CRC.
+			 */
+			switch (len - src_off) {
+			case 0:
+				raw[0] = (crc & 0xff00) >> 8;
+				raw[1] = crc & 0x00ff;
+				rc = mcumgr_serial_tx_small(raw, 2, cb);
+				break;
+
+			case 1:
+				raw[0] = data[src_off++];
+
+				raw[1] = (crc & 0xff00) >> 8;
+				raw[2] = crc & 0x00ff;
+				rc = mcumgr_serial_tx_small(raw, 3, cb);
+				break;
+
+			case 2:
+				raw[0] = data[src_off++];
+				raw[1] = data[src_off++];
+
+				raw[2] = (crc & 0xff00) >> 8;
+				rc = mcumgr_serial_tx_small(raw, 3, cb);
+				if (rc != 0) {
+					return rc;
+				}
+
+				raw[0] = crc & 0x00ff;
+				rc = mcumgr_serial_tx_small(raw, 1, cb);
+				break;
+			}
+
+			if (rc != 0) {
+				return rc;
+			}
+		}
+
+		rc = cb("\n", 1);
 		if (rc != 0) {
 			return rc;
 		}
-	}
 
-	rc = cb("\n", 1, arg);
-	if (rc != 0) {
-		return rc;
-	}
-
-	*out_data_bytes_txed = src_off;
-	return 0;
-}
-
-int mcumgr_serial_tx_pkt(const uint8_t *data, int len, mcumgr_serial_tx_cb cb,
-			 void *arg)
-{
-	uint16_t crc;
-	int data_bytes_txed = 0;
-	int rc;
-
-	/* Calculate CRC of entire packet. */
-	crc = mcumgr_serial_calc_crc(data, len);
-
-	/* Transmit packet as a sequence of frames. */
-	while (len) {
-		rc = mcumgr_serial_tx_frame(data, data_bytes_txed == 0, len, crc, cb, arg,
-					    &data_bytes_txed);
-		if (rc != 0) {
-			return rc;
-		}
-
-		data += data_bytes_txed;
-		len -= data_bytes_txed;
+		/* Use a continuation frame marker for the next packet */
+		u16 = sys_cpu_to_be16(MCUMGR_SERIAL_HDR_FRAG);
+		first = false;
 	}
 
 	return 0;

--- a/subsys/mgmt/mcumgr/transport/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/smp_shell.c
@@ -26,6 +26,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(smp_shell);
 
+BUILD_ASSERT(CONFIG_MCUMGR_SMP_SHELL_MTU != 0, "CONFIG_MCUMGR_SMP_SHELL_MTU must be > 0");
+
 static struct zephyr_smp_transport smp_shell_transport;
 
 static struct mcumgr_serial_rx_ctxt smp_shell_rx_ctxt;
@@ -160,7 +162,7 @@ static uint16_t smp_shell_get_mtu(const struct net_buf *nb)
 	return CONFIG_MCUMGR_SMP_SHELL_MTU;
 }
 
-static int smp_shell_tx_raw(const void *data, int len, void *arg)
+static int smp_shell_tx_raw(const void *data, int len)
 {
 	const struct shell *const sh = shell_backend_uart_get_ptr();
 	const struct shell_uart *const su = sh->iface->ctx;
@@ -180,7 +182,7 @@ static int smp_shell_tx_pkt(struct net_buf *nb)
 {
 	int rc;
 
-	rc = mcumgr_serial_tx_pkt(nb->data, nb->len, smp_shell_tx_raw, NULL);
+	rc = mcumgr_serial_tx_pkt(nb->data, nb->len, smp_shell_tx_raw);
 	mcumgr_buf_free(nb);
 
 	return rc;

--- a/subsys/mgmt/mcumgr/transport/smp_uart.c
+++ b/subsys/mgmt/mcumgr/transport/smp_uart.c
@@ -19,6 +19,8 @@
 #include <zephyr/mgmt/mcumgr/smp.h>
 #include "../smp_internal.h"
 
+BUILD_ASSERT(CONFIG_MCUMGR_SMP_UART_MTU != 0, "CONFIG_MCUMGR_SMP_UART_MTU must be > 0");
+
 struct device;
 
 static void smp_uart_process_rx_queue(struct k_work *work);

--- a/subsys/mgmt/mcumgr/transport/smp_udp.c
+++ b/subsys/mgmt/mcumgr/transport/smp_udp.c
@@ -28,6 +28,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(smp_udp);
 
+BUILD_ASSERT(CONFIG_MCUMGR_SMP_UDP_MTU != 0, "CONFIG_MCUMGR_SMP_UDP_MTU must be > 0");
+
 struct config {
 	int sock;
 	const char *proto;
@@ -64,24 +66,40 @@ static struct configs configs = {
 #ifdef CONFIG_MCUMGR_SMP_UDP_IPV4
 static int smp_udp4_tx(struct net_buf *nb)
 {
+	int ret;
 	struct sockaddr *addr = net_buf_user_data(nb);
-	int ret = sendto(configs.ipv4.sock, nb->data, nb->len,
-			 0, addr, sizeof(*addr));
+
+	ret = sendto(configs.ipv4.sock, nb->data, nb->len, 0, addr, sizeof(*addr));
+
+	if (ret < 0) {
+		ret = MGMT_ERR_EINVAL;
+	} else {
+		ret = MGMT_ERR_EOK;
+	}
+
 	mcumgr_buf_free(nb);
 
-	return ret < 0 ? MGMT_ERR_EINVAL : MGMT_ERR_EOK;
+	return ret;
 }
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_UDP_IPV6
 static int smp_udp6_tx(struct net_buf *nb)
 {
+	int ret;
 	struct sockaddr *addr = net_buf_user_data(nb);
-	int ret = sendto(configs.ipv6.sock, nb->data, nb->len,
-			 0, addr, sizeof(*addr));
+
+	ret = sendto(configs.ipv6.sock, nb->data, nb->len, 0, addr, sizeof(*addr));
+
+	if (ret < 0) {
+		ret = MGMT_ERR_EINVAL;
+	} else {
+		ret = MGMT_ERR_EOK;
+	}
+
 	mcumgr_buf_free(nb);
 
-	return ret < 0 ? MGMT_ERR_EINVAL : MGMT_ERR_EOK;
+	return ret;
 }
 #endif
 


### PR DESCRIPTION
Fixes an issue with outgoing mcumgr frames that are larger than the
transport MTU size whereby they would wrongly be split up into multiple
frames with multiple start frame headers, which affected SMP over
console transports. Now, the whole mcumgr packet is chunked into frames
after calculating the full length and checksum.

Fixes #49444

Also happens to reduce smp_svr build size by 144 bytes with the overlay-bt.conf, which is a nice added benefit

Tested backends:
- [X] Shell
- [X] UART
- [X] Bluetooth
- [X] UDP