### PR TITLE
west.yml: Update Espressif HAL to pull GCC 12 fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -62,7 +62,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 22b47009dc27bdd395c6ef1a66c347037a2fb585
+      revision: a85cf740929b7537e0bb07572b6c4f3456b04420
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This commit updates the Espressif HAL (hal_espressif) to pull in the
fixes for the warnings and `-march` flag related build failures with
the GCC 12.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

**NOTE: This is to be merged after the Zephyr SDK 0.15.0 is mainlined and the minimum required Zephyr SDK version is updated to 0.15.0.**