### PR TITLE
net: lwm2m: Fixes FOTA update result code

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -99,16 +99,24 @@ void lwm2m_firmware_set_update_state_inst(uint16_t obj_inst_id, uint8_t state)
 	bool error = false;
 	char path[LWM2M_MAX_PATH_STR_LEN];
 
+	snprintk(path, sizeof(path), "%" PRIu16 "/%" PRIu16 "/%" PRIu16,
+		LWM2M_OBJECT_FIRMWARE_ID, obj_inst_id, FIRMWARE_UPDATE_RESULT_ID);
+
 	/* Check LWM2M SPEC appendix E.6.1 */
 	switch (state) {
 	case STATE_DOWNLOADING:
-		if (update_state[obj_inst_id] != STATE_IDLE) {
+		if (update_state[obj_inst_id] == STATE_IDLE) {
+			lwm2m_engine_set_u8(path, RESULT_DEFAULT);
+		} else {
 			error = true;
 		}
 		break;
 	case STATE_DOWNLOADED:
-		if (update_state[obj_inst_id] != STATE_DOWNLOADING &&
-		    update_state[obj_inst_id] != STATE_UPDATING) {
+		if (update_state[obj_inst_id] == STATE_DOWNLOADING) {
+			lwm2m_engine_set_u8(path, RESULT_DEFAULT);
+		} else if (update_state[obj_inst_id] == STATE_UPDATING) {
+			lwm2m_engine_set_u8(path, RESULT_UPDATE_FAILED);
+		} else {
 			error = true;
 		}
 		break;


### PR DESCRIPTION
The update result is supposed to indicate success only after a firmware
update has been applied. The bug here was that the success was reported
already when the update image download was done.

Signed-off-by: Veijo Pesonen <veijo.pesonen@nordicsemi.no>

![image](https://user-images.githubusercontent.com/33285290/186423681-b0dc4e0f-3cd5-48f4-8400-3ad02cd8d7f3.png)
