### PR TITLE
soc: arch: stm32g0: fix ucpd strobe init for g070 an g0b0

### DIFF
--- a/soc/arm/st_stm32/stm32g0/soc.c
+++ b/soc/arm/st_stm32/stm32g0/soc.c
@@ -52,16 +52,16 @@ static void stm32g0_disable_dead_battery(void)
 #endif /* SYSCFG_CFGR1_UCPD2_STROBE */
 
 	for (int n = 0; n < ARRAY_SIZE(addr_inst); n++) {
-#if defined(SYSCFG_CFGR1_UCPD1_STROBE)
+#if defined(SYSCFG_CFGR1_UCPD1_STROBE) && defined(UCPD1_BASE)
 		if (addr_inst[n] == UCPD1_BASE) {
 			strobe &= ~LL_SYSCFG_UCPD1_STROBE;
 		}
-#endif /* SYSCFG_CFGR1_UCPD1_STROBE */
-#if defined(SYSCFG_CFGR1_UCPD2_STROBE)
+#endif /* SYSCFG_CFGR1_UCPD1_STROBE && UCPD1_BASE */
+#if defined(SYSCFG_CFGR1_UCPD2_STROBE) && defined(UCPD2_BASE)
 		if (addr_inst[n] == UCPD2_BASE) {
 			strobe &= ~LL_SYSCFG_UCPD2_STROBE;
 		}
-#endif /* SYSCFG_CFGR1_UCPD2_STROBE */
+#endif /* SYSCFG_CFGR1_UCPD2_STROBE && UCPD2_BASE */
 	}
 
 	if (strobe != 0) {


### PR DESCRIPTION
The STM32G070 and STM32G0B0 Socs don't have USB power delivery support
but the PINs PD0, PD2, PB15, PA8 pins of these still have the same
pull down on boot configuration options as the SOCs with UCPD support.

This commit skips the check if the UCPD peripheral instance is enabled,
therefore the configuration to disable the pull-down will always be applied on these SOCs
and the compile error is resolved.

Note:
I don't have the hardware to verify this changes, but it resolves the compile error and should work according to the reference manual.

Fixes #49463