### PR TITLE
net: wifi: Allow to use offloaded wifi_mgmt API with native stack

### DIFF
--- a/drivers/wifi/Kconfig
+++ b/drivers/wifi/Kconfig
@@ -29,6 +29,12 @@ config WIFI_OFFLOAD
 	help
 	  Enable support for Full-MAC Wi-Fi devices.
 
+config WIFI_USE_NATIVE_NETWORKING
+	bool
+	help
+	  When selected, this hidden configuration enables Wi-Fi driver
+	  to use native ethernet stack interface.
+
 source "drivers/wifi/winc1500/Kconfig.winc1500"
 source "drivers/wifi/simplelink/Kconfig.simplelink"
 source "drivers/wifi/eswifi/Kconfig.eswifi"

--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -4,6 +4,7 @@ menuconfig WIFI_ESP32
 	bool "ESP32 SoC WiFi support"
 	depends on !SMP
 	select THREAD_CUSTOM_DATA
+	select WIFI_USE_NATIVE_NETWORKING
 	help
 	  Enable ESP32 SoC WiFi support. Only supported in single
 	  core mode because the network stack is not aware of SMP

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -12,6 +12,7 @@ LOG_MODULE_REGISTER(esp32_wifi, CONFIG_WIFI_LOG_LEVEL);
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/wifi_mgmt.h>
 #include <zephyr/device.h>
 #include <soc.h>
 #include <ethernet/eth_stats.h>
@@ -220,19 +221,18 @@ static int eth_esp32_dev_init(const struct device *dev)
 	return ret;
 }
 
-
 static struct esp32_wifi_runtime eth_data;
 
-static const struct ethernet_api eth_esp32_apis = {
-	.iface_api.init	= eth_esp32_init,
-	.send =  eth_esp32_send,
+static const struct net_wifi_mgmt_offload esp32_api = {
+	.wifi_iface.iface_api.init = eth_esp32_init,
+	.wifi_iface.send = eth_esp32_send,
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
-	.get_stats = eth_esp32_stats,
-#endif
+	.wifi_iface.get_stats = eth_esp32_stats,
+ #endif
 };
 
 NET_DEVICE_DT_INST_DEFINE(0,
 		eth_esp32_dev_init, NULL,
 		&eth_data, NULL, CONFIG_ETH_INIT_PRIORITY,
-		&eth_esp32_apis, ETHERNET_L2,
+		&esp32_api, ETHERNET_L2,
 		NET_L2_GET_CTX_TYPE(ETHERNET_L2), NET_ETH_MTU);

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -1088,7 +1088,7 @@ static void esp_iface_init(struct net_if *iface)
 }
 
 static const struct net_wifi_mgmt_offload esp_api = {
-	.iface_api.init = esp_iface_init,
+	.wifi_iface.init = esp_iface_init,
 	.scan		= esp_mgmt_scan,
 	.connect	= esp_mgmt_connect,
 	.disconnect	= esp_mgmt_disconnect,

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -679,7 +679,7 @@ static int eswifi_init(const struct device *dev)
 }
 
 static const struct net_wifi_mgmt_offload eswifi_offload_api = {
-	.iface_api.init = eswifi_iface_init,
+	.wifi_iface.init = eswifi_iface_init,
 	.scan		= eswifi_mgmt_scan,
 	.connect	= eswifi_mgmt_connect,
 	.disconnect	= eswifi_mgmt_disconnect,

--- a/drivers/wifi/simplelink/simplelink.c
+++ b/drivers/wifi/simplelink/simplelink.c
@@ -264,7 +264,7 @@ static void simplelink_iface_init(struct net_if *iface)
 }
 
 static const struct net_wifi_mgmt_offload simplelink_api = {
-	.iface_api.init = simplelink_iface_init,
+	.wifi_iface.init = simplelink_iface_init,
 	.scan		= simplelink_mgmt_scan,
 	.connect	= simplelink_mgmt_connect,
 	.disconnect	= simplelink_mgmt_disconnect,

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -1100,7 +1100,7 @@ static void winc1500_iface_init(struct net_if *iface)
 }
 
 static const struct net_wifi_mgmt_offload winc1500_api = {
-	.iface_api.init = winc1500_iface_init,
+	.wifi_iface.init = winc1500_iface_init,
 	.scan		= winc1500_mgmt_scan,
 	.connect	= winc1500_mgmt_connect,
 	.disconnect	= winc1500_mgmt_disconnect,

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -14,6 +14,7 @@
 
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/wifi.h>
+#include <zephyr/net/ethernet.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -130,7 +131,11 @@ struct net_wifi_mgmt_offload {
 	 * net_if_api structure. So we make current structure pointer
 	 * that can be casted to a net_if_api structure pointer.
 	 */
-	struct net_if_api iface_api;
+#ifdef CONFIG_WIFI_USE_NATIVE_NETWORKING
+	struct ethernet_api wifi_iface;
+#else
+	struct net_if_api wifi_iface;
+#endif
 
 	/* cb parameter is the cb that should be called for each
 	 * result by the driver. The wifi mgmt part will take care of
@@ -148,14 +153,10 @@ struct net_wifi_mgmt_offload {
 /* Make sure that the network interface API is properly setup inside
  * Wifi mgmt offload API struct (it is the first one).
  */
-BUILD_ASSERT(offsetof(struct net_wifi_mgmt_offload, iface_api) == 0);
-
-#ifdef CONFIG_WIFI_OFFLOAD
+BUILD_ASSERT(offsetof(struct net_wifi_mgmt_offload, wifi_iface) == 0);
 
 void wifi_mgmt_raise_connect_result_event(struct net_if *iface, int status);
 void wifi_mgmt_raise_disconnect_result_event(struct net_if *iface, int status);
-
-#endif /* CONFIG_WIFI_OFFLOAD */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
wifi drivers that depends on native ethernet stack cannot perform
wifi API calls missing availability. This changes adds the ethernet_api
interface in wifi_mgmt so that it becomes possible.

Naming "offload" in "struct net_wifi_mgmt_offload" is kept because
Zephyr still has no supplicant to handle a full non-offloaded driver.

This PR comes from #45565.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>