### PR TITLE
Bluetooth: Define global Bluetooth address constants

### DIFF
--- a/include/zephyr/bluetooth/addr.h
+++ b/include/zephyr/bluetooth/addr.h
@@ -54,16 +54,20 @@ typedef struct {
 	bt_addr_t a;
 } bt_addr_le_t;
 
+/* Global Bluetooth address constants defined in bluetooth/common/addr.c */
+extern const bt_addr_t bt_addr_any;
+extern const bt_addr_t bt_addr_none;
+extern const bt_addr_le_t bt_addr_le_any;
+extern const bt_addr_le_t bt_addr_le_none;
+
 /** Bluetooth device "any" address, not a valid address */
-#define BT_ADDR_ANY     ((bt_addr_t[]) { { { 0, 0, 0, 0, 0, 0 } } })
+#define BT_ADDR_ANY     (&bt_addr_any)
 /** Bluetooth device "none" address, not a valid address */
-#define BT_ADDR_NONE    ((bt_addr_t[]) { { \
-			 { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } } })
+#define BT_ADDR_NONE    (&bt_addr_none)
 /** Bluetooth LE device "any" address, not a valid address */
-#define BT_ADDR_LE_ANY  ((bt_addr_le_t[]) { { 0, { { 0, 0, 0, 0, 0, 0 } } } })
+#define BT_ADDR_LE_ANY  (&bt_addr_le_any)
 /** Bluetooth LE device "none" address, not a valid address */
-#define BT_ADDR_LE_NONE ((bt_addr_le_t[]) { { 0, \
-			 { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } } } })
+#define BT_ADDR_LE_NONE (&bt_addr_le_none)
 
 /** @brief Compare Bluetooth device addresses.
  *

--- a/subsys/bluetooth/common/CMakeLists.txt
+++ b/subsys/bluetooth/common/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 zephyr_library()
 
+zephyr_library_sources(addr.c)
 zephyr_library_sources(dummy.c)
 zephyr_library_sources(log.c)
 

--- a/subsys/bluetooth/common/addr.c
+++ b/subsys/bluetooth/common/addr.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Stephanos Ioannidis <root@stephanos.io>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/bluetooth/addr.h>
+
+const bt_addr_t bt_addr_any = { { 0, 0, 0, 0, 0, 0 } };
+const bt_addr_t bt_addr_none = { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } };
+const bt_addr_le_t bt_addr_le_any = { 0, { { 0, 0, 0, 0, 0, 0 } } };
+const bt_addr_le_t bt_addr_le_none = { 0, { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } } };

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -308,7 +308,7 @@ static struct db_hash {
 } db_hash;
 #endif
 
-static struct gatt_sc_cfg *find_sc_cfg(uint8_t id, bt_addr_le_t *addr)
+static struct gatt_sc_cfg *find_sc_cfg(uint8_t id, const bt_addr_le_t *addr)
 {
 	BT_DBG("id: %u, addr: %s", id, bt_addr_le_str(addr));
 

--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -220,7 +220,7 @@ void bt_monitor_send(uint16_t opcode, const void *data, size_t len)
 	atomic_clear_bit(&flags, BT_LOG_BUSY);
 }
 
-void bt_monitor_new_index(uint8_t type, uint8_t bus, bt_addr_t *addr,
+void bt_monitor_new_index(uint8_t type, uint8_t bus, const bt_addr_t *addr,
 			  const char *name)
 {
 	struct bt_monitor_new_index pkt;

--- a/subsys/bluetooth/host/monitor.h
+++ b/subsys/bluetooth/host/monitor.h
@@ -97,7 +97,7 @@ static inline uint8_t bt_monitor_opcode(struct net_buf *buf)
 
 void bt_monitor_send(uint16_t opcode, const void *data, size_t len);
 
-void bt_monitor_new_index(uint8_t type, uint8_t bus, bt_addr_t *addr,
+void bt_monitor_new_index(uint8_t type, uint8_t bus, const bt_addr_t *addr,
 			  const char *name);
 
 #else /* !CONFIG_BT_MONITOR */


### PR DESCRIPTION
The Bluetooth address constants (BT_ADDR[_LE]_ANY, BT_ADDR[_LE]_NONE)
are currently defined as the address of the local anonymous structs
that are initialised to the corresponding address values, and assigning
them to a variable whose scope is greater than that of a function may
end up creating dangling pointers (for instance, as done in the
`bt_conn_get_info` function).

This commit defines the Bluetooth address constants as global constant
variables that are placed in the read-only data section, and modifies
the Bluetooth address constant macros to use the address of these
variables instead.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

This fixes the warnings that are seen when compiling with GCC 12, such as:

```
/__w/zephyr-testing/zephyr-testing/subsys/bluetooth/host/conn.c: In function 'bt_conn_get_info':
/__w/zephyr-testing/zephyr-testing/subsys/bluetooth/host/conn.c:2334:38: error: storing the address of local variable '({anonymous})' in '*info.<U5558>.le.dst' [-Werror=dangling-pointer=]
 2334 |                         info->le.dst = BT_ADDR_LE_NONE;
In file included from ../../../../../../include/zephyr/bluetooth/hci.h:17,
                 from /__w/zephyr-testing/zephyr-testing/subsys/bluetooth/host/conn.c:21:
../../../../../../include/zephyr/bluetooth/addr.h:65:43: note: '({anonymous})' declared here
   65 | #define BT_ADDR_LE_NONE ((bt_addr_le_t[]) { { 0, \
      |                                           ^
/__w/zephyr-testing/zephyr-testing/subsys/bluetooth/host/conn.c:2334:40: note: in expansion of macro 'BT_ADDR_LE_NONE'
 2334 |                         info->le.dst = BT_ADDR_LE_NONE;
      |                                        ^~~~~~~~~~~~~~~
../../../../../../include/zephyr/bluetooth/addr.h:65:43: note: 'info' declared here
   65 | #define BT_ADDR_LE_NONE ((bt_addr_le_t[]) { { 0, \
      |                                           ^
/__w/zephyr-testing/zephyr-testing/subsys/bluetooth/host/conn.c:2334:40: note: in expansion of macro 'BT_ADDR_LE_NONE'
 2334 |                         info->le.dst = BT_ADDR_LE_NONE;
      |                                        ^~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

Related discussion on Discord: https://discord.com/channels/720317445772017664/733036837576376341/1011989711495114752