### PR TITLE
west: blobs: Finally fix the --format option handling

### DIFF
--- a/scripts/west_commands/blobs.py
+++ b/scripts/west_commands/blobs.py
@@ -114,7 +114,7 @@ class Blobs(WestCommand):
 
     def list(self, args):
         blobs = self.get_blobs(args)
-        fmt = getattr(args, 'Namespace.format', self.DEFAULT_LIST_FMT)
+        fmt = args.format or self.DEFAULT_LIST_FMT
         for blob in blobs:
             log.inf(fmt.format(**blob))
 


### PR DESCRIPTION
Turns out that `Namespace.format` was not a good fix to the issue
described in f033040812b0ce8c5c09105757eb0b3e2e9e8d17, it was returning
the default format even when the user specified -f/--format.

Replace "getattr" with a simple logical operation.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>