### PR TITLE
boards: thingy52_nrf52832: some Kconfig/init cleanups

### DIFF
--- a/boards/arm/thingy52_nrf52832/CMakeLists.txt
+++ b/boards/arm/thingy52_nrf52832/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_GPIO)
+if(CONFIG_CCS811)
 zephyr_library()
 zephyr_library_sources(board.c)
 endif()

--- a/boards/arm/thingy52_nrf52832/Kconfig
+++ b/boards/arm/thingy52_nrf52832/Kconfig
@@ -5,14 +5,6 @@
 
 if BOARD_THINGY52_NRF52832
 
-config BOARD_VDD_PWR_CTRL_INIT_PRIORITY
-	int "VDD power rail init priority"
-	default 50
-	depends on GPIO
-	help
-	  Initialization priority for the VDD power rail. Has to be greater
-	  than GPIO_INIT_PRIORITY.
-
 config BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY
 	int "CCS_VDD power rail init priority"
 	default 85

--- a/boards/arm/thingy52_nrf52832/Kconfig.defconfig
+++ b/boards/arm/thingy52_nrf52832/Kconfig.defconfig
@@ -8,12 +8,6 @@ if BOARD_THINGY52_NRF52832
 config BOARD
 	default "thingy52_nrf52832"
 
-config I2C
-	default y
-
-config GPIO
-	default y
-
 config BT_CTLR
 	default BT
 

--- a/boards/arm/thingy52_nrf52832/board.c
+++ b/boards/arm/thingy52_nrf52832/board.c
@@ -8,22 +8,21 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/printk.h>
 
-#define CCS_VDD_PWR_CTRL_GPIO_PIN 10
-
-struct pwr_ctrl_cfg {
-	const struct device *gpio_dev;
-	uint32_t pin;
-};
+static const struct gpio_dt_spec ccs_gpio =
+	GPIO_DT_SPEC_GET(DT_NODELABEL(ccs_pwr), enable_gpios);
 
 static int pwr_ctrl_init(const struct device *dev)
 {
-	const struct pwr_ctrl_cfg *cfg = dev->config;
+	int ret;
 
-	if (!device_is_ready(cfg->gpio_dev)) {
+	if (!device_is_ready(ccs_gpio.port)) {
 		return -ENODEV;
 	}
 
-	gpio_pin_configure(cfg->gpio_dev, cfg->pin, GPIO_OUTPUT_HIGH);
+	ret = gpio_pin_configure_dt(&ccs_gpio, GPIO_OUTPUT_HIGH);
+	if (ret < 0) {
+		return ret;
+	}
 
 	k_sleep(K_MSEC(1)); /* Wait for the rail to come up and stabilize */
 
@@ -35,11 +34,6 @@ static int pwr_ctrl_init(const struct device *dev)
 #error BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY must be lower than SENSOR_INIT_PRIORITY
 #endif
 
-static const struct pwr_ctrl_cfg ccs_vdd_pwr_ctrl_cfg = {
-	.gpio_dev = DEVICE_DT_GET(DT_INST(0, semtech_sx1509b)),
-	.pin = CCS_VDD_PWR_CTRL_GPIO_PIN,
-};
-
 DEVICE_DEFINE(ccs_vdd_pwr_ctrl_init, "", pwr_ctrl_init, NULL, NULL,
-	      &ccs_vdd_pwr_ctrl_cfg, POST_KERNEL,
+	      NULL, POST_KERNEL,
 	      CONFIG_BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY, NULL);

--- a/boards/arm/thingy52_nrf52832/board.c
+++ b/boards/arm/thingy52_nrf52832/board.c
@@ -33,6 +33,5 @@ static int pwr_ctrl_init(const struct device *dev)
 #error BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY must be lower than SENSOR_INIT_PRIORITY
 #endif
 
-DEVICE_DEFINE(ccs_vdd_pwr_ctrl_init, "", pwr_ctrl_init, NULL, NULL,
-	      NULL, POST_KERNEL,
-	      CONFIG_BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY, NULL);
+SYS_INIT(pwr_ctrl_init, POST_KERNEL,
+	 CONFIG_BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY);

--- a/boards/arm/thingy52_nrf52832/board.c
+++ b/boards/arm/thingy52_nrf52832/board.c
@@ -6,7 +6,6 @@
 
 #include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/sys/printk.h>
 
 static const struct gpio_dt_spec ccs_gpio =
 	GPIO_DT_SPEC_GET(DT_NODELABEL(ccs_pwr), enable_gpios);

--- a/boards/arm/thingy52_nrf52832/board.c
+++ b/boards/arm/thingy52_nrf52832/board.c
@@ -8,7 +8,6 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/printk.h>
 
-#define VDD_PWR_CTRL_GPIO_PIN 30
 #define CCS_VDD_PWR_CTRL_GPIO_PIN 10
 
 struct pwr_ctrl_cfg {
@@ -31,34 +30,6 @@ static int pwr_ctrl_init(const struct device *dev)
 	return 0;
 }
 
-/*
- * The CCS811 sensor is connected to the CCS_VDD power rail, which is downstream
- * from the VDD power rail. Both of these power rails need to be enabled before
- * the sensor driver init can be performed. The VDD rail also has to be powered up
- * before the CCS_VDD rail. These checks are to enforce the power up sequence
- * constraints.
- */
-
-#if CONFIG_BOARD_VDD_PWR_CTRL_INIT_PRIORITY <= CONFIG_GPIO_INIT_PRIORITY
-#error GPIO_INIT_PRIORITY must be lower than \
-	BOARD_VDD_PWR_CTRL_INIT_PRIORITY
-#endif
-
-static const struct pwr_ctrl_cfg vdd_pwr_ctrl_cfg = {
-	.gpio_dev = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
-	.pin = VDD_PWR_CTRL_GPIO_PIN,
-};
-
-DEVICE_DEFINE(vdd_pwr_ctrl_init, "", pwr_ctrl_init, NULL, NULL,
-	      &vdd_pwr_ctrl_cfg,
-	      POST_KERNEL, CONFIG_BOARD_VDD_PWR_CTRL_INIT_PRIORITY,
-	      NULL);
-
-#ifdef CONFIG_SENSOR
-
-#if CONFIG_BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY <= CONFIG_BOARD_VDD_PWR_CTRL_INIT_PRIORITY
-#error BOARD_VDD_PWR_CTRL_INIT_PRIORITY must be lower than BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY
-#endif
 
 #if CONFIG_SENSOR_INIT_PRIORITY <= CONFIG_BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY
 #error BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY must be lower than SENSOR_INIT_PRIORITY
@@ -72,5 +43,3 @@ static const struct pwr_ctrl_cfg ccs_vdd_pwr_ctrl_cfg = {
 DEVICE_DEFINE(ccs_vdd_pwr_ctrl_init, "", pwr_ctrl_init, NULL, NULL,
 	      &ccs_vdd_pwr_ctrl_cfg, POST_KERNEL,
 	      CONFIG_BOARD_CCS_VDD_PWR_CTRL_INIT_PRIORITY, NULL);
-
-#endif

--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
@@ -76,6 +76,7 @@
 		regulator-name = "vdd-pwr-ctrl";
 		enable-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;
+		startup-delay-us = <1000>;
 	};
 
 	spk_pwr: spk-pwr-ctrl {

--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
@@ -89,18 +89,21 @@
 		compatible = "regulator-fixed";
 		regulator-name = "mpu-pwr-ctrl";
 		enable-gpios = <&sx1509b 8 GPIO_ACTIVE_HIGH>;
+		status = "disabled";
 	};
 
 	mic_pwr: mic-pwr-ctrl {
 		compatible = "regulator-fixed";
 		regulator-name = "mic-pwr-ctrl";
 		enable-gpios = <&sx1509b 9 GPIO_ACTIVE_HIGH>;
+		status = "disabled";
 	};
 
 	ccs_pwr: ccs-pwr-ctrl {
 		compatible = "regulator-fixed";
 		regulator-name = "ccs-pwr-ctrl";
 		enable-gpios = <&sx1509b 10 GPIO_ACTIVE_HIGH>;
+		status = "disabled";
 	};
 };
 

--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832_defconfig
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832_defconfig
@@ -16,6 +16,11 @@ CONFIG_HW_STACK_PROTECTION=y
 # Enable RTT
 CONFIG_USE_SEGGER_RTT=y
 
+# enable regulators (init priority adjusted so that they
+# are turned before I2C GPIO expander)
+CONFIG_REGULATOR=y
+CONFIG_REGULATOR_FIXED_INIT_PRIORITY=45
+
 # enable GPIO
 CONFIG_GPIO=y
 

--- a/drivers/gpio/Kconfig.sx1509b
+++ b/drivers/gpio/Kconfig.sx1509b
@@ -7,7 +7,7 @@ menuconfig GPIO_SX1509B
 	bool "SX1509B I2C GPIO chip"
 	default y
 	depends on DT_HAS_SEMTECH_SX1509B_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for SX1509B I2C GPIO chip.
 


### PR DESCRIPTION
- Update SX1509B GPIO expander to use select instead of depends on
- Remove redundant entries in Kconfig.deconfig
- Rely on regulator drivers to turn on VDD power rail

Note: this board is a good example that shows the limitations of Zephyr manual init priorities, to the point there's a use case they can't solve. Ref. c409ac0c83ab7ea86882acca3838033abdc2caa5