### PR TITLE
modules: Mark the build as tainted if blobs present

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -630,6 +630,12 @@ config WARN_EXPERIMENTAL
 	  Print a warning when the Kconfig tree is parsed if any experimental
 	  features are enabled.
 
+config TAINT
+	bool
+	help
+	  Symbol that must be selected by a feature or module if the Zephyr
+	  build is considered tainted.
+
 config ENFORCE_ZEPHYR_STDINT
 	bool
 	prompt "Enforce Zephyr convention for stdint"

--- a/modules/Kconfig
+++ b/modules/Kconfig
@@ -1,6 +1,13 @@
 # Copyright (c) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+config TAINT_BLOBS
+	bool
+	select TAINT
+	help
+	  This option is selected when binary blobs are present locally at
+	  build time to reflect that the build might have been tainted by them.
+
 comment "Available modules."
 
 osource "$(KCONFIG_BINARY_DIR)/Kconfig.modules"

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -18,6 +18,7 @@ maintained in modules in addition to what is available in the main Zephyr tree.
 '''
 
 import argparse
+import hashlib
 import os
 import re
 import subprocess
@@ -131,6 +132,9 @@ mapping:
 MODULE_YML_PATH = PurePath('zephyr/module.yml')
 # Path to the blobs folder
 MODULE_BLOBS_PATH = PurePath('zephyr/blobs')
+BLOB_PRESENT = 'A'
+BLOB_NOT_PRESENT = 'D'
+BLOB_OUTDATED = 'M'
 
 schema = yaml.safe_load(METADATA_SCHEMA)
 
@@ -223,6 +227,34 @@ def process_settings(module, meta):
                 out_text += f'"{root_path.as_posix()}"\n'
 
     return out_text
+
+
+def get_blob_status(path, sha256):
+    if not path.is_file():
+        return BLOB_NOT_PRESENT
+    with path.open('rb') as f:
+        m = hashlib.sha256()
+        m.update(f.read())
+        if sha256.lower() == m.hexdigest():
+            return BLOB_PRESENT
+        else:
+            return BLOB_OUTDATED
+
+
+def process_blobs(module, meta):
+    blobs = []
+    mblobs = meta.get('blobs', None)
+    if not mblobs:
+        return blobs
+
+    blobs_path = Path(module) / MODULE_BLOBS_PATH
+    for blob in mblobs:
+        blob['module'] = meta.get('name', None)
+        blob['abspath'] = blobs_path / Path(blob['path'])
+        blob['status'] = get_blob_status(blob['abspath'], blob['sha256'])
+        blobs.append(blob)
+
+    return blobs
 
 
 def kconfig_snippet(meta, path, kconfig_file=None):


### PR DESCRIPTION
Whenever binary blobs are present in the filesystem (i.e. fetched,
regardless of whether they are up-to-date or not) we consider the Zephyr
build as tainted. In order to ensure that it is marked as so, add a
Kconfig `select` statement whenever this is the case.
