### PR TITLE
tests: devicetree: device: Rename gpio@0 to avoid name conflict

### DIFF
--- a/tests/lib/devicetree/devices/app.overlay
+++ b/tests/lib/devicetree/devices/app.overlay
@@ -15,12 +15,12 @@
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 
-		test_gpio_0: gpio@0 {
+		test_gpio_0: gpio@ffff {
 			gpio-controller;
 			#gpio-cells = <0x2>;
 			compatible = "vnd,gpio-device";
 			status = "okay";
-			reg = <0x0 0x1000>;
+			reg = <0xffff 0x1000>;
 		};
 
 		test_i2c: i2c@11112222 {


### PR DESCRIPTION
There are some platforms like the lpcxpresso54114 that utilize gpio@0
so rename gpio@0 to gpio@ffff as this is a highly unlikely to conflict
with any real device.

Fixes #49439

Signed-off-by: Kumar Gala <galak@kernel.org>