### PR TITLE
twister: Set stdin explicitly on stty calls

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -286,7 +286,7 @@ class BinaryHandler(Handler):
         # FIXME: This is needed when killing the simulator, the console is
         # garbled and needs to be reset. Did not find a better way to do that.
         if sys.stdout.isatty():
-            subprocess.call(["stty", "sane"])
+            subprocess.call(["stty", "sane"], stdin=sys.stdout)
 
         if harness.is_pytest:
             harness.pytest_run(self.log)
@@ -839,7 +839,7 @@ class QEMUHandler(Handler):
         logger.debug("Spawning QEMUHandler Thread for %s" % self.name)
         self.thread.start()
         if sys.stdout.isatty():
-            subprocess.call(["stty", "sane"])
+            subprocess.call(["stty", "sane"], stdin=sys.stdout)
 
         logger.debug("Running %s (%s)" % (self.name, self.type_str))
         command = [self.generator_cmd]

--- a/scripts/twister
+++ b/scripts/twister
@@ -406,6 +406,6 @@ if __name__ == "__main__":
     finally:
         if (os.name != "nt") and os.isatty(1):
             # (OS is not Windows) and (stdout is interactive)
-            os.system("stty sane")
+            os.system("stty sane <&1")
 
     sys.exit(ret)


### PR DESCRIPTION
stty operates on the file descriptor from stdin, but we want to operate
on stdout. If stdin and stdout are not the same tty then stty prints an
error.

Redirect stdout to stdin for stty calls.

Tested by running twister -T tests/subsys/shell </dev/null

Signed-off-by: Jeremy Bettis <jbettis@google.com>