### PR TITLE
intel_adsp: gpdma: Fix driver initialiaziation

### DIFF
--- a/drivers/dma/Kconfig.intel_adsp_gpdma
+++ b/drivers/dma/Kconfig.intel_adsp_gpdma
@@ -10,6 +10,13 @@ config DMA_INTEL_ADSP_GPDMA
 
 if DMA_INTEL_ADSP_GPDMA
 
+config DMA_INTEL_ADSP_GPDMA_NEED_CONTROLLER_OWNERSHIP
+	bool
+	default y if !SOC_INTEL_CAVS_V15
+	help
+	  Hidden option to indicate that the driver needs to request
+	  dma controller ownership from the host.
+
 config DMA_INTEL_ADSP_GPDMA_HAS_LLP
 	bool "Intel ADSP GPDMA Linear Link Position Feature"
 	default y if SOC_SERIES_INTEL_ACE1X

--- a/drivers/dma/dma_intel_adsp_gpdma.c
+++ b/drivers/dma/dma_intel_adsp_gpdma.c
@@ -238,8 +238,10 @@ int intel_adsp_gpdma_init(const struct device *dev)
 	}
 #endif
 
+#ifdef CONFIG_DMA_INTEL_ADSP_GPDMA_NEED_CONTROLLER_OWNERSHIP
 	sys_write32(LPGPDMA_CHOSEL_FLAG | LPGPDMA_CTLOSEL_FLAG, DSP_INIT_LPGPDMA(0));
 	sys_write32(LPGPDMA_CHOSEL_FLAG | LPGPDMA_CTLOSEL_FLAG, DSP_INIT_LPGPDMA(1));
+#endif
 
 	/* Disable dynamic clock gating appropriately before initializing */
 	intel_adsp_gpdma_clock_enable(dev);


### PR DESCRIPTION
cavs15 does not need to request ownership of the dma controller.

Fixes #49203

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>