### PR TITLE
tests: timer: timer_behavior: Fix compile issues

### DIFF
--- a/tests/kernel/timer/timer_behavior/src/main.c
+++ b/tests/kernel/timer/timer_behavior/src/main.c
@@ -10,8 +10,8 @@
 
 #include <zephyr/zephyr.h>
 
-#include <tc_util.h>
-#include <ztest.h>
+#include <zephyr/tc_util.h>
+#include <zephyr/ztest.h>
 
 static uint32_t periodic_idx;
 static uint32_t periodic_rollovers;


### PR DESCRIPTION
Includes need to be <zephyr/tc_util.h> and <zephyr/ztest.h> otherwise
we get build errors.

Signed-off-by: Kumar Gala <galak@kernel.org>