### PR TITLE
twister: Remove import exception handler for psutil

### DIFF
--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -42,7 +42,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}
     - name: install-packages
       run: |
-        pip3 install pytest colorama pyyaml ply mock pykwalify
+        pip3 install -r scripts/requirements-base.txt -r scripts/requirements-build-test.txt
     - name: Run pytest
       env:
         ZEPHYR_BASE: ./

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -16,17 +16,13 @@ import subprocess
 import threading
 import select
 import re
+import psutil
 from twisterlib.environment import ZEPHYR_BASE
 
 try:
     import serial
 except ImportError:
     print("Install pyserial python module with pip to use --device-testing option.")
-
-try:
-    import psutil
-except ImportError:
-    print("Install psutil python module with pip to run in Qemu.")
 
 try:
     import pty


### PR DESCRIPTION
`handlers.py` treats the `psutil` package as optional and quietly prints
a message to stdout if it is not present, but it is actually a hard
requirement for the base `Handler` class. This try/except block is bad
as it hides the requirement until a timeout occurs and the handler
attempts to use `psutil` in the terminate method, which will crash if
the module happens to be missing.

This PR removes the try/except guard so missing `psutil` will cause
twister to immediately fail. `psutil` is already specified in the
`requirements.txt` file, so this should only affect users who
unwittingly have an outdated/incorrect environment.

Signed-off-by: Tristan Honscheid <honscheid@google.com>