### PR TITLE
dtsi: esp32c3: add missing wifi node

### DIFF
--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -35,6 +35,11 @@
 		status = "okay";
 	};
 
+	wifi: wifi {
+		compatible = "espressif,esp32-wifi";
+		status = "disabled";
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;


### PR DESCRIPTION
Add ESP32C3 wifi entry in dtsi file.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>