### PR TITLE
mgmt: mcumgr: Reduce unnecessary pointers and objects

### DIFF
--- a/include/zephyr/mgmt/mcumgr/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp.h
@@ -121,6 +121,27 @@ void zephyr_smp_transport_init(struct zephyr_smp_transport *zst,
  */
 void zephyr_smp_rx_req(struct zephyr_smp_transport *zst, struct net_buf *nb);
 
+/**
+ * @brief Allocates a response buffer.
+ *
+ * If a source buf is provided, its user data is copied into the new buffer.
+ *
+ * @param req		An optional source buffer to copy user data from.
+ * @param arg		The streamer providing the callback.
+ *
+ * @return	Newly-allocated buffer on success
+ *		NULL on failure.
+ */
+void *zephyr_smp_alloc_rsp(const void *req, void *arg);
+
+/**
+ * @brief Frees an allocated buffer.
+ *
+ * @param buf		The buffer to free.
+ * @param arg		The streamer providing the callback.
+ */
+void zephyr_smp_free_buf(void *buf, void *arg);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -130,41 +130,10 @@ typedef void *(*mgmt_alloc_rsp_fn)(const void *src_buf, void *arg);
  */
 typedef void (*mgmt_reset_buf_fn)(void *buf, void *arg);
 
-/** @typedef mgmt_write_at_fn
- * @brief Writes header at the beginning of buffer
- *
- * Overwrites beginning of buffer with header; moves buffer data pointer so that next
- * non-header writes would happen after header.
- *
- * @param writer	The encoder to write to.
- * @param hdr		Header to write (struct mgmt_hdr);
- *
- * @return 0 on success, MGMT_ERR_[...] code on failure.
- */
-typedef int (*mgmt_write_hdr_fn)(struct cbor_nb_writer *writer, const struct mgmt_hdr *hdr);
-
-/** @typedef mgmt_init_writer_fn
- * @brief Frees the specified buffer.
- *
- * @param buf	The buffer to free.
- * @param arg	Optional streamer argument.
- */
-typedef void (*mgmt_free_buf_fn)(void *buf, void *arg);
-
-/**
- * @brief Configuration for constructing a mgmt_streamer object.
- */
-struct mgmt_streamer_cfg {
-	mgmt_alloc_rsp_fn alloc_rsp;
-	mgmt_write_hdr_fn write_hdr;
-	mgmt_free_buf_fn free_buf;
-};
-
 /**
  * @brief Decodes requests and encodes responses for any mcumgr protocol.
  */
 struct mgmt_streamer {
-	const struct mgmt_streamer_cfg *cfg;
 	void *cb_arg;
 	struct cbor_nb_reader *reader;
 	struct cbor_nb_writer *writer;
@@ -225,19 +194,6 @@ struct mgmt_group {
 };
 
 /**
- * @brief Uses the specified streamer to allocates a response buffer.
- *
- * If a source buf is provided, its user data is copied into the new buffer.
- *
- * @param streamer	The streamer providing the callback.
- * @param src_buf	An optional source buffer to copy user data from.
- *
- * @return	Newly-allocated buffer on success
- *		NULL on failure.
- */
-void *mgmt_streamer_alloc_rsp(struct mgmt_streamer *streamer, const void *src_buf);
-
-/**
  * @brief Uses the specified streamer to trim data from the front of a buffer.
  *
  * If the amount to trim exceeds the size of the buffer, the buffer is
@@ -250,20 +206,6 @@ void *mgmt_streamer_alloc_rsp(struct mgmt_streamer *streamer, const void *src_bu
 void mgmt_streamer_trim_front(struct mgmt_streamer *streamer, void *buf, size_t len);
 
 /**
- * @brief Uses the specified streamer to write header to buffer.
- *
- * Any existing data at the beginning buffer will be overwritten with header.
- * Any new data that extends past the buffer's current length is appended.
- *
- * @param streamer	The streamer providing the callback.
- * @param writer	The encoder to write to.
- * @param hdr		The mgmt_hdr struct to write.
- *
- * @return 0 on success, MGMT_ERR_[...] code on failure.
- */
-int mgmt_streamer_write_hdr(struct mgmt_streamer *streamer, const struct mgmt_hdr *hdr);
-
-/**
  * @brief Uses the specified streamer to initialize a CBOR reader.
  *
  * @param streamer	The streamer providing the callback.
@@ -274,13 +216,6 @@ int mgmt_streamer_write_hdr(struct mgmt_streamer *streamer, const struct mgmt_hd
  */
 int mgmt_streamer_init_reader(struct mgmt_streamer *streamer, void *buf);
 
-/**
- * @brief Uses the specified streamer to free a buffer.
- *
- * @param streamer	The streamer providing the callback.
- * @param buf		The buffer to free.
- */
-void mgmt_streamer_free_buf(struct mgmt_streamer *streamer, void *buf);
 
 /**
  * @brief Registers a full command group.

--- a/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
@@ -16,24 +16,6 @@ static mgmt_on_evt_cb evt_cb;
 static struct mgmt_group *mgmt_group_list;
 static struct mgmt_group *mgmt_group_list_end;
 
-void *
-mgmt_streamer_alloc_rsp(struct mgmt_streamer *streamer, const void *req)
-{
-	return streamer->cfg->alloc_rsp(req, streamer->cb_arg);
-}
-
-int
-mgmt_streamer_write_hdr(struct mgmt_streamer *streamer, const struct mgmt_hdr *hdr)
-{
-	return streamer->cfg->write_hdr(streamer->writer, hdr);
-}
-
-void
-mgmt_streamer_free_buf(struct mgmt_streamer *streamer, void *buf)
-{
-	streamer->cfg->free_buf(buf, streamer->cb_arg);
-}
-
 void
 mgmt_unregister_group(struct mgmt_group *group)
 {

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -25,10 +25,7 @@ LOG_MODULE_REGISTER(mcumgr_smp, CONFIG_MCUMGR_SMP_LOG_LEVEL);
 #define WEAK
 #endif
 
-static const struct mgmt_streamer_cfg zephyr_smp_cbor_cfg;
-
-static void *
-zephyr_smp_alloc_rsp(const void *req, void *arg)
+void *zephyr_smp_alloc_rsp(const void *req, void *arg)
 {
 	const struct net_buf_pool *pool;
 	const struct net_buf *req_nb;
@@ -115,16 +112,7 @@ zephyr_smp_split_frag(struct net_buf **nb, void *arg, uint16_t mtu)
 	return frag;
 }
 
-static int
-zephyr_smp_write_hdr(struct cbor_nb_writer *cnw, const struct mgmt_hdr *hdr)
-{
-	memcpy(cnw->nb->data, hdr, sizeof(*hdr));
-
-	return 0;
-}
-
-static void
-zephyr_smp_free_buf(void *buf, void *arg)
+void zephyr_smp_free_buf(void *buf, void *arg)
 {
 	struct zephyr_smp_transport *zst = arg;
 
@@ -189,7 +177,6 @@ zephyr_smp_process_packet(struct zephyr_smp_transport *zst,
 
 	streamer = (struct smp_streamer) {
 		.mgmt_stmr = {
-			.cfg = &zephyr_smp_cbor_cfg,
 			.reader = &reader,
 			.writer = &writer,
 			.cb_arg = zst,
@@ -216,12 +203,6 @@ zephyr_smp_handle_reqs(struct k_work *work)
 		zephyr_smp_process_packet(zst, nb);
 	}
 }
-
-static const struct mgmt_streamer_cfg zephyr_smp_cbor_cfg = {
-	.alloc_rsp = zephyr_smp_alloc_rsp,
-	.write_hdr = zephyr_smp_write_hdr,
-	.free_buf = zephyr_smp_free_buf,
-};
 
 void
 zephyr_smp_transport_init(struct zephyr_smp_transport *zst,


### PR DESCRIPTION
Reduces the level of indirection for functions by calling the zephyr
functions directly as support for multiple operating systems is no
longer required with mcumgr being forked and placed into the zephyr
tree. Saves 60 bytes flash when compiling smp_svr on an ARM Cortex
M4 board.

Fixes #42324

Might be incomplete, will need to study the mcumgr code further to see if there are additional levels of indirection that can be reduced.