### PR TITLE
dietemp node generates following warning at compilation:

### DIFF
--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -348,17 +348,6 @@
 			has-vref-channel;
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp-cal";
-			ts-cal1-addr = <0x1FFFF7B8>;
-			ts-cal2-addr = <0x1FFFF7C2>;
-			ts-cal1-temp = <30>;
-			ts-cal2-temp = <110>;
-			ts-cal-vrefanalog = <3300>;
-			io-channels = <&adc1 16>;
-			status = "disabled";
-		};
-
 		dma1: dma@40020000 {
 			compatible = "st,stm32-dma-v2bis";
 			#dma-cells = <2>;
@@ -367,6 +356,17 @@
 			interrupts = <9 0 10 0 10 0 11 0 11 0>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x1FFFF7B8>;
+		ts-cal2-addr = <0x1FFFF7C2>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <110>;
+		ts-cal-vrefanalog = <3300>;
+		io-channels = <&adc1 16>;
+		status = "disabled";
 	};
 };
 

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -296,15 +296,6 @@
 			has-vref-channel;
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp";
-			io-channels = <&adc1 16>;
-			status = "disabled";
-			avgslope = <43>;
-			v25 = <1430>;
-			ntc;
-		};
-
 		dma1: dma@40020000 {
 			compatible = "st,stm32-dma-v2bis";
 			#dma-cells = <2>;
@@ -313,6 +304,15 @@
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp";
+		io-channels = <&adc1 16>;
+		status = "disabled";
+		avgslope = <43>;
+		v25 = <1430>;
+		ntc;
 	};
 };
 

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -341,15 +341,6 @@
 			has-vref-channel;
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp";
-			io-channels = <&adc1 16>;
-			status = "disabled";
-			v25 = <760>;
-			ntc;
-			avgslope = <25>;
-		};
-
 		dma1: dma@40026000 {
 			compatible = "st,stm32-dma-v1";
 			#dma-cells = <4>;
@@ -604,6 +595,15 @@
 			zephyr,memory-region = "BACKUP_SRAM";
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp";
+		io-channels = <&adc1 16>;
+		status = "disabled";
+		v25 = <760>;
+		ntc;
+		avgslope = <25>;
 	};
 
 	otgfs_phy: otgfs_phy {

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -238,17 +238,6 @@
 			status = "disabled";
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp-cal";
-			ts-cal1-addr = <0x1FFFF7B8>;
-			ts-cal2-addr = <0x1FFFF7C2>;
-			ts-cal1-temp = <30>;
-			ts-cal2-temp = <110>;
-			ts-cal-vrefanalog = <3300>;
-			io-channels = <&adc1 16>;
-			status = "disabled";
-		};
-
 		timers2: timers@40000000 {
 			compatible = "st,stm32-timers";
 			reg = <0x40000000 0x400>;
@@ -377,6 +366,17 @@
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x1FFFF7B8>;
+		ts-cal2-addr = <0x1FFFF7C2>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <110>;
+		ts-cal-vrefanalog = <3300>;
+		io-channels = <&adc1 16>;
+		status = "disabled";
 	};
 
 	usb_fs_phy: usbphy {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -244,17 +244,6 @@
 			status = "disabled";
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp-cal";
-			ts-cal1-addr = <0x1FFF7A2C>;
-			ts-cal2-addr = <0x1FFF7A2E>;
-			ts-cal1-temp = <30>;
-			ts-cal2-temp = <110>;
-			ts-cal-vrefanalog = <3300>;
-			io-channels = <&adc1 16>;
-			status = "disabled";
-		};
-
 		spi1: spi@40013000 {
 			compatible = "st,stm32-spi";
 			#address-cells = <1>;
@@ -488,6 +477,17 @@
 			interrupts = <49 0>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x1FFF7A2C>;
+		ts-cal2-addr = <0x1FFF7A2E>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <110>;
+		ts-cal-vrefanalog = <3300>;
+		io-channels = <&adc1 16>;
+		status = "disabled";
 	};
 
 	otgfs_phy: otgfs_phy {

--- a/dts/arm/st/f4/stm32f410.dtsi
+++ b/dts/arm/st/f4/stm32f410.dtsi
@@ -67,10 +67,6 @@
 			status = "disabled";
 		};
 
-		die_temp: dietemp {
-			io-channels = <&adc1 18>;
-		};
-
 		timers6: timers@40001000 {
 			compatible = "st,stm32-timers";
 			reg = <0x40001000 0x400>;
@@ -96,4 +92,7 @@
 
 	};
 
+	die_temp: dietemp {
+		io-channels = <&adc1 18>;
+	};
 };

--- a/dts/arm/st/f4/stm32f411.dtsi
+++ b/dts/arm/st/f4/stm32f411.dtsi
@@ -44,10 +44,6 @@
 			status = "disabled";
 		};
 
-		die_temp: dietemp {
-			io-channels = <&adc1 18>;
-		};
-
 		i2s5: i2s@40015000 {
 			compatible = "st,stm32-i2s";
 			#address-cells = <1>;
@@ -60,5 +56,9 @@
 			dma-names = "tx", "rx";
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		io-channels = <&adc1 18>;
 	};
 };

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -81,10 +81,6 @@
 			status = "disabled";
 		};
 
-		die_temp: dietemp {
-			io-channels = <&adc1 18>;
-		};
-
 		fmc: memory-controller@a0000000 {
 			compatible = "st,stm32-fmc";
 			reg = <0xa0000000 0x400>;
@@ -98,5 +94,9 @@
 				status = "disabled";
 			};
 		};
+	};
+
+	die_temp: dietemp {
+		io-channels = <&adc1 18>;
 	};
 };

--- a/dts/arm/st/f4/stm32f437.dtsi
+++ b/dts/arm/st/f4/stm32f437.dtsi
@@ -37,10 +37,6 @@
 			status = "disabled";
 		};
 
-		die_temp: dietemp {
-			io-channels = <&adc1 18>;
-		};
-
 		uart8: serial@40007c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
@@ -103,5 +99,9 @@
 			interrupts = <79 0>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		io-channels = <&adc1 18>;
 	};
 };

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -46,10 +46,6 @@
 			status = "disabled";
 		};
 
-		die_temp: dietemp {
-			io-channels = <&adc1 18>;
-		};
-
 		can1: can@40006400 {
 			compatible = "st,stm32-can";
 			reg = <0x40006400 0x400>;
@@ -120,6 +116,10 @@
 				status = "disabled";
 			};
 		};
+	};
+
+	die_temp: dietemp {
+		io-channels = <&adc1 18>;
 	};
 
 	otghs_fs_phy: otghs_fs_phy {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -633,17 +633,6 @@
 			has-vref-channel;
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp-cal";
-			ts-cal1-addr = <0x1FF07A2C>;
-			ts-cal2-addr = <0x1FF07A2E>;
-			ts-cal1-temp = <30>;
-			ts-cal2-temp = <110>;
-			ts-cal-vrefanalog = <3300>;
-			io-channels = <&adc1 18>;
-			status = "disabled";
-		};
-
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
@@ -704,6 +693,17 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x2>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x1FF07A2C>;
+		ts-cal2-addr = <0x1FF07A2E>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <110>;
+		ts-cal-vrefanalog = <3300>;
+		io-channels = <&adc1 18>;
+		status = "disabled";
 	};
 
 	otghs_fs_phy: otghs_fs_phy {

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -41,11 +41,6 @@
 			};
 		};
 
-		die_temp: dietemp {
-			ts-cal1-addr = <0x1FF0F44C>;
-			ts-cal2-addr = <0x1FF0F44E>;
-		};
-
 		i2c4: i2c@40006000 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
@@ -91,5 +86,10 @@
 				 <&rcc STM32_CLOCK_BUS_AHB1 0x10000000>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		ts-cal1-addr = <0x1FF0F44C>;
+		ts-cal2-addr = <0x1FF0F44E>;
 	};
 };

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -340,17 +340,6 @@
 			has-vbat-channel;
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp-cal";
-			ts-cal1-addr = <0x1FFF75A8>;
-			ts-cal2-addr = <0x1FFF75CA>;
-			ts-cal1-temp = <30>;
-			ts-cal2-temp = <130>;
-			ts-cal-vrefanalog = <3000>;
-			io-channels = <&adc1 12>;
-			status = "disabled";
-		};
-
 		dma1: dma@40020000 {
 			compatible = "st,stm32-dma-v2";
 			#dma-cells = <3>;
@@ -373,6 +362,17 @@
 			dma-requests= <49>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x1FFF75A8>;
+		ts-cal2-addr = <0x1FFF75CA>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <130>;
+		ts-cal-vrefanalog = <3000>;
+		io-channels = <&adc1 12>;
+		status = "disabled";
 	};
 };
 

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -86,17 +86,6 @@
 			has-temp-channel;
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp-cal";
-			ts-cal1-addr = <0x1FFF75A8>;
-			ts-cal2-addr = <0x1FFF75CA>;
-			ts-cal1-temp = <30>;
-			ts-cal2-temp = <130>;
-			ts-cal-vrefanalog = <3000>;
-			io-channels = <&adc1 16>;
-			status = "disabled";
-		};
-
 		adc2: adc@50000100 {
 			compatible = "st,stm32-adc";
 			reg = <0x50000100 0x100>;
@@ -576,6 +565,17 @@
 			interrupts = <63 0>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x1FFF75A8>;
+		ts-cal2-addr = <0x1FFF75CA>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <130>;
+		ts-cal-vrefanalog = <3000>;
+		io-channels = <&adc1 16>;
+		status = "disabled";
 	};
 
 	usb_fs_phy: usbphy {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -680,18 +680,6 @@
 			has-vref-channel;
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp-cal";
-			ts-cal1-addr = <0x1FF1E820>;
-			ts-cal2-addr = <0x1FF1E840>;
-			ts-cal1-temp = <30>;
-			ts-cal2-temp = <110>;
-			ts-cal-vrefanalog = <3300>;
-			ts-cal-resolution = <16>;
-			io-channels = <&adc3 18>;
-			status = "disabled";
-		};
-
 		adc2: adc@40022100 {
 			compatible = "st,stm32-adc";
 			reg = <0x40022100 0x400>;
@@ -839,6 +827,18 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00004000>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x1FF1E820>;
+		ts-cal2-addr = <0x1FF1E840>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <110>;
+		ts-cal-vrefanalog = <3300>;
+		ts-cal-resolution = <16>;
+		io-channels = <&adc3 18>;
+		status = "disabled";
 	};
 };
 

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -30,11 +30,6 @@
 			status = "disabled";
 		};
 
-		die_temp: dietemp {
-			io-channels = <&adc3 17>;
-			ts-cal2-temp = <130>;
-		};
-
 		usart10: serial@40011c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011c00 0x400>;
@@ -123,5 +118,10 @@
 		compatible = "zephyr,memory-region", "arm,itcm";
 		reg = <0x00000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "ITCM";
+	};
+
+	die_temp: dietemp {
+		io-channels = <&adc3 17>;
+		ts-cal2-temp = <130>;
 	};
 };

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -57,13 +57,6 @@
 			status = "disabled";
 		};
 
-		die_temp: dietemp {
-			ts-cal1-addr = <0x08FFF814>;
-			ts-cal2-addr = <0x08FFF818>;
-			io-channels = <&adc2 18>;
-			ts-cal2-temp = <130>;
-		};
-
 		octospi2: octospi@5200a000 {
 			compatible = "st,stm32-ospi";
 			reg = <0x5200a000 0x1000>;
@@ -138,5 +131,12 @@
 	otghs_fs_phy: otghs_fs_phy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;
+	};
+
+	die_temp: dietemp {
+		ts-cal1-addr = <0x08FFF814>;
+		ts-cal2-addr = <0x08FFF818>;
+		io-channels = <&adc2 18>;
+		ts-cal2-temp = <130>;
 	};
 };

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -270,17 +270,6 @@
 			has-vref-channel;
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp-cal";
-			ts-cal1-addr = <0x1FF8007A>;
-			ts-cal2-addr = <0x1FF8007E>;
-			ts-cal1-temp = <30>;
-			ts-cal2-temp = <130>;
-			ts-cal-vrefanalog = <3000>;
-			io-channels = <&adc1 18>;
-			status = "disabled";
-		};
-
 		dma1: dma@40020000 {
 			compatible = "st,stm32-dma-v2";
 			#dma-cells = <3>;
@@ -294,6 +283,17 @@
 			compatible = "st,stm32-eeprom";
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x1FF8007A>;
+		ts-cal2-addr = <0x1FF8007E>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <130>;
+		ts-cal-vrefanalog = <3000>;
+		io-channels = <&adc1 18>;
+		status = "disabled";
 	};
 };
 

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -207,17 +207,6 @@
 			has-vref-channel;
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp-cal";
-			ts-cal1-addr = <0x1FF800FA>;
-			ts-cal2-addr = <0x1FF800FE>;
-			ts-cal1-temp = <30>;
-			ts-cal2-temp = <110>;
-			ts-cal-vrefanalog = <3000>;
-			io-channels = <&adc1 16>;
-			status = "disabled";
-		};
-
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
@@ -411,6 +400,17 @@
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x1FF800FA>;
+		ts-cal2-addr = <0x1FF800FE>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <110>;
+		ts-cal-vrefanalog = <3000>;
+		io-channels = <&adc1 16>;
+		status = "disabled";
 	};
 };
 

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -346,17 +346,6 @@
 			#io-channel-cells = <1>;
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp-cal";
-			ts-cal1-addr = <0x1FFF75A8>;
-			ts-cal2-addr = <0x1FFF75CA>;
-			ts-cal1-temp = <30>;
-			ts-cal2-temp = <110>;
-			ts-cal-vrefanalog = <3000>;
-			io-channels = <&adc1 17>;
-			status = "disabled";
-		};
-
 		adc2: adc@50040100 {
 			compatible = "st,stm32-adc";
 			reg = <0x50040100 0x100>;
@@ -404,6 +393,17 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00040000>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x1FFF75A8>;
+		ts-cal2-addr = <0x1FFF75CA>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <110>;
+		ts-cal-vrefanalog = <3000>;
+		io-channels = <&adc1 17>;
+		status = "disabled";
 	};
 };
 

--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -31,14 +31,14 @@
 			status = "disabled";
 		};
 
-		die_temp: dietemp {
-			ts-cal2-temp = <130>;
-		};
-
 		adc1: adc@50040000 {
 			has-temp-channel;
 			has-vref-channel;
 		};
+	};
+
+	die_temp: dietemp {
+		ts-cal2-temp = <130>;
 	};
 
 	usb_fs_phy: usbphy {

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -44,10 +44,6 @@
 			sample-point = <875>;
 		};
 
-		die_temp: dietemp {
-			ts-cal2-temp = <130>;
-		};
-
 		usb: usb@40006800 {
 			compatible = "st,stm32-usb";
 			reg = <0x40006800 0x40000>;
@@ -73,6 +69,10 @@
 			has-temp-channel;
 			has-vref-channel;
 		};
+	};
+
+	die_temp: dietemp {
+		ts-cal2-temp = <130>;
 	};
 
 	usb_fs_phy: usbphy {

--- a/dts/arm/st/l4/stm32l452.dtsi
+++ b/dts/arm/st/l4/stm32l452.dtsi
@@ -39,10 +39,6 @@
 			status = "disabled";
 		};
 
-		die_temp: dietemp {
-			ts-cal2-temp = <130>;
-		};
-
 		i2c2: i2c@40005800 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
@@ -147,6 +143,10 @@
 			has-temp-channel;
 			has-vref-channel;
 		};
+	};
+
+	die_temp: dietemp {
+		ts-cal2-temp = <130>;
 	};
 
 	usb_fs_phy: usbphy {

--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -32,10 +32,6 @@
 			};
 		};
 
-		die_temp: dietemp {
-			ts-cal2-temp = <130>;
-		};
-
 		adc3: adc@50040200 {
 			compatible = "st,stm32-adc";
 			reg = <0x50040200 0x100>;
@@ -44,5 +40,9 @@
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
+	};
+
+	die_temp: dietemp {
+		ts-cal2-temp = <130>;
 	};
 };

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -543,17 +543,6 @@
 			has-vref-channel;
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp-cal";
-			ts-cal1-addr = <0x0BFA05A8>;
-			ts-cal2-addr = <0x0BFA05CA>;
-			ts-cal1-temp = <30>;
-			ts-cal2-temp = <130>;
-			ts-cal-vrefanalog = <3000>;
-			io-channels = <&adc1 17>;
-			status = "disabled";
-		};
-
 		adc2: adc@42028100 {
 			compatible = "st,stm32-adc";
 			reg = <0x42028100 0x100>;
@@ -582,6 +571,17 @@
 			interrupts = <106 0>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x0BFA05A8>;
+		ts-cal2-addr = <0x0BFA05CA>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <130>;
+		ts-cal-vrefanalog = <3000>;
+		io-channels = <&adc1 17>;
+		status = "disabled";
 	};
 
 	usb_fs_phy: usbphy {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -540,18 +540,6 @@
 			has-vref-channel;
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp-cal";
-			ts-cal1-addr = <0x0BFA0710>;
-			ts-cal2-addr = <0x0BFA0742>;
-			ts-cal1-temp = <30>;
-			ts-cal2-temp = <130>;
-			ts-cal-vrefanalog = <3000>;
-			ts-cal-resolution = <14>;
-			io-channels = <&adc1 19>;
-			status = "disabled";
-		};
-
 		adc4: adc@46021000 {
 			compatible = "st,stm32-adc";
 			reg = <0x46021000 0x400>;
@@ -609,6 +597,18 @@
 			dma-offset = <0>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x0BFA0710>;
+		ts-cal2-addr = <0x0BFA0742>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <130>;
+		ts-cal-vrefanalog = <3000>;
+		ts-cal-resolution = <14>;
+		io-channels = <&adc1 19>;
+		status = "disabled";
 	};
 };
 

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -339,17 +339,6 @@
 			has-vref-channel;
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp-cal";
-			ts-cal1-addr = <0x1FFF75A8>;
-			ts-cal2-addr = <0x1FFF75CA>;
-			ts-cal1-temp = <30>;
-			ts-cal2-temp = <130>;
-			ts-cal-vrefanalog = <3000>;
-			io-channels = <&adc1 17>;
-			status = "disabled";
-		};
-
 		iwdg: watchdog@40003000 {
 			compatible = "st,stm32-watchdog";
 			reg = <0x40003000 0x400>;
@@ -429,6 +418,17 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00040000>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x1FFF75A8>;
+		ts-cal2-addr = <0x1FFF75CA>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <130>;
+		ts-cal-vrefanalog = <3000>;
+		io-channels = <&adc1 17>;
+		status = "disabled";
 	};
 
 	usb_fs_phy: usbphy {

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -295,17 +295,6 @@
 			has-vref-channel;
 		};
 
-		die_temp: dietemp {
-			compatible = "st,stm32-temp-cal";
-			ts-cal1-addr = <0x1FFF75A8>;
-			ts-cal2-addr = <0x1FFF75C8>;
-			ts-cal1-temp = <30>;
-			ts-cal2-temp = <130>;
-			ts-cal-vrefanalog = <3300>;
-			io-channels = <&adc1 12>;
-			status = "disabled";
-		};
-
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
@@ -429,6 +418,17 @@
 			dma-requests= <38>;
 			status = "disabled";
 		};
+	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x1FFF75A8>;
+		ts-cal2-addr = <0x1FFF75C8>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <130>;
+		ts-cal-vrefanalog = <3300>;
+		io-channels = <&adc1 12>;
+		status = "disabled";
 	};
 };
 


### PR DESCRIPTION
zephyr.dts:482.21-491.5: Warning (simple_bus_reg): /soc/dietemp: missing
or empty reg/ranges property.
To fix this bug, just move dietemp node outside of soc{}.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/49471