### PR TITLE
include: types: remove ulong_t

### DIFF
--- a/arch/mips/core/fatal.c
+++ b/arch/mips/core/fatal.c
@@ -38,7 +38,7 @@ FUNC_NORETURN void z_mips_fatal_error(unsigned int reason,
 	CODE_UNREACHABLE;
 }
 
-static char *cause_str(ulong_t cause)
+static char *cause_str(unsigned long cause)
 {
 	switch (cause) {
 	case 0:
@@ -86,7 +86,7 @@ static char *cause_str(ulong_t cause)
 
 void _Fault(z_arch_esf_t *esf)
 {
-	ulong_t cause;
+	unsigned long cause;
 
 	cause = (read_c0_cause() & CAUSE_EXP_MASK) >> CAUSE_EXP_SHIFT;
 

--- a/arch/mips/core/irq_manage.c
+++ b/arch/mips/core/irq_manage.c
@@ -17,7 +17,7 @@ uint32_t mips_cp0_status_int_mask;
 
 FUNC_NORETURN void z_irq_spurious(const void *unused)
 {
-	ulong_t cause;
+	unsigned long cause;
 
 	ARG_UNUSED(unused);
 	cause = (read_c0_cause() & CAUSE_EXP_MASK) >> CAUSE_EXP_SHIFT;

--- a/arch/mips/core/thread.c
+++ b/arch/mips/core/thread.c
@@ -27,15 +27,15 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 				);
 
 	/* Setup the initial stack frame */
-	stack_init->a0 = (ulong_t)entry;
-	stack_init->a1 = (ulong_t)p1;
-	stack_init->a2 = (ulong_t)p2;
-	stack_init->a3 = (ulong_t)p3;
+	stack_init->a0 = (unsigned long)entry;
+	stack_init->a1 = (unsigned long)p1;
+	stack_init->a2 = (unsigned long)p2;
+	stack_init->a3 = (unsigned long)p3;
 
 	stack_init->status = CP0_STATUS_DEF_RESTORE
 			| mips_cp0_status_int_mask;
 
-	stack_init->epc = (ulong_t)z_thread_entry;
+	stack_init->epc = (unsigned long)z_thread_entry;
 
-	thread->callee_saved.sp = (ulong_t)stack_init;
+	thread->callee_saved.sp = (unsigned long)stack_init;
 }

--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -59,7 +59,7 @@ FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
 	CODE_UNREACHABLE;
 }
 
-static char *cause_str(ulong_t cause)
+static char *cause_str(unsigned long cause)
 {
 	switch (cause) {
 	case 0:
@@ -148,22 +148,22 @@ void _Fault(z_arch_esf_t *esf)
 	 * treated as recoverable.
 	 */
 	for (int i = 0; i < ARRAY_SIZE(exceptions); i++) {
-		ulong_t start = (ulong_t)exceptions[i].start;
-		ulong_t end = (ulong_t)exceptions[i].end;
+		unsigned long start = (unsigned long)exceptions[i].start;
+		unsigned long end = (unsigned long)exceptions[i].end;
 
 		if (esf->mepc >= start && esf->mepc < end) {
-			esf->mepc = (ulong_t)exceptions[i].fixup;
+			esf->mepc = (unsigned long)exceptions[i].fixup;
 			return;
 		}
 	}
 #endif /* CONFIG_USERSPACE */
 
-	ulong_t mcause;
+	unsigned long mcause;
 
 	__asm__ volatile("csrr %0, mcause" : "=r" (mcause));
 
 #ifndef CONFIG_SOC_OPENISA_RV32M1_RISCV32
-	ulong_t mtval;
+	unsigned long mtval;
 	__asm__ volatile("csrr %0, mtval" : "=r" (mtval));
 #endif
 

--- a/arch/riscv/core/irq_manage.c
+++ b/arch/riscv/core/irq_manage.c
@@ -11,7 +11,7 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 FUNC_NORETURN void z_irq_spurious(const void *unused)
 {
-	ulong_t mcause;
+	unsigned long mcause;
 
 	ARG_UNUSED(unused);
 

--- a/arch/riscv/core/pmp.S
+++ b/arch/riscv/core/pmp.S
@@ -18,8 +18,8 @@
  * void z_riscv_write_pmp_entries(unsigned int start,		// a0
  *                                unsigned int end,		// a1
  *                                bool clear_trailing_entries,	// a2
- *                                ulong_t *pmp_addr,		// a3
- *                                ulong_t *pmp_cfg)		// a4
+ *                                unsigned long *pmp_addr,		// a3
+ *                                unsigned long *pmp_cfg)		// a4
  *
  * Called from pmp.c to write a range of PMP entries.
  *

--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -44,7 +44,7 @@ LOG_MODULE_REGISTER(mpu);
 # define PR_ADDR "0x%08lx"
 #endif
 
-#define PMPCFG_STRIDE sizeof(ulong_t)
+#define PMPCFG_STRIDE sizeof(unsigned long)
 
 #define PMP_ADDR(addr)			((addr) >> 2)
 #define NAPOT_RANGE(size)		(((size) - 1) >> 1)
@@ -53,7 +53,7 @@ LOG_MODULE_REGISTER(mpu);
 #define PMP_NONE 0
 
 static void print_pmp_entries(unsigned int start, unsigned int end,
-			      ulong_t *pmp_addr, ulong_t *pmp_cfg,
+			      unsigned long *pmp_addr, unsigned long *pmp_cfg,
 			      const char *banner)
 {
 	uint8_t *pmp_n_cfg = (uint8_t *)pmp_cfg;
@@ -61,7 +61,7 @@ static void print_pmp_entries(unsigned int start, unsigned int end,
 
 	LOG_DBG("PMP %s:", banner);
 	for (index = start; index < end; index++) {
-		ulong_t start, end, tmp;
+		unsigned long start, end, tmp;
 
 		switch (pmp_n_cfg[index] & PMP_A) {
 		case PMP_TOR:
@@ -102,8 +102,8 @@ static void print_pmp_entries(unsigned int start, unsigned int end,
 
 static void dump_pmp_regs(const char *banner)
 {
-	ulong_t pmp_addr[CONFIG_PMP_SLOTS];
-	ulong_t pmp_cfg[CONFIG_PMP_SLOTS / PMPCFG_STRIDE];
+	unsigned long pmp_addr[CONFIG_PMP_SLOTS];
+	unsigned long pmp_cfg[CONFIG_PMP_SLOTS / PMPCFG_STRIDE];
 
 #define PMPADDR_READ(x) pmp_addr[x] = csr_read(pmpaddr##x)
 
@@ -150,7 +150,7 @@ static void dump_pmp_regs(const char *banner)
  */
 static bool set_pmp_entry(unsigned int *index_p, uint8_t perm,
 			  uintptr_t start, size_t size,
-			  ulong_t *pmp_addr, ulong_t *pmp_cfg,
+			  unsigned long *pmp_addr, unsigned long *pmp_cfg,
 			  unsigned int index_limit)
 {
 	uint8_t *pmp_n_cfg = (uint8_t *)pmp_cfg;
@@ -207,8 +207,8 @@ static bool set_pmp_entry(unsigned int *index_p, uint8_t perm,
  */
 extern void z_riscv_write_pmp_entries(unsigned int start, unsigned int end,
 				      bool clear_trailing_entries,
-				      const ulong_t *pmp_addr,
-				      const ulong_t *pmp_cfg);
+				      const unsigned long *pmp_addr,
+				      const unsigned long *pmp_cfg);
 
 /**
  * @brief Write a range of PMP entries to corresponding PMP registers
@@ -224,7 +224,7 @@ extern void z_riscv_write_pmp_entries(unsigned int start, unsigned int end,
  */
 static void write_pmp_entries(unsigned int start, unsigned int end,
 			      bool clear_trailing_entries,
-			      ulong_t *pmp_addr, ulong_t *pmp_cfg,
+			      unsigned long *pmp_addr, unsigned long *pmp_cfg,
 			      unsigned int index_limit)
 {
 	__ASSERT(start < end && end <= index_limit &&
@@ -262,7 +262,7 @@ static void write_pmp_entries(unsigned int start, unsigned int end,
 	 * The QEMU fix is here with more details about this bug:
 	 * https://lists.gnu.org/archive/html/qemu-devel/2022-06/msg02800.html
 	 */
-	static const ulong_t pmp_zero[CONFIG_PMP_SLOTS] = { 0, };
+	static const unsigned long pmp_zero[CONFIG_PMP_SLOTS] = { 0, };
 
 	z_riscv_write_pmp_entries(start, CONFIG_PMP_SLOTS, false,
 				  pmp_zero, pmp_zero);
@@ -295,8 +295,8 @@ static void write_pmp_entries(unsigned int start, unsigned int end,
  * sharing the same cfg register. Locked entries aren't modifiable but
  * we could have non-locked entries here too.
  */
-static ulong_t global_pmp_cfg[1];
-static ulong_t global_pmp_last_addr;
+static unsigned long global_pmp_cfg[1];
+static unsigned long global_pmp_last_addr;
 
 /* End of global PMP entry range */
 static unsigned int global_pmp_end_index;
@@ -306,8 +306,8 @@ static unsigned int global_pmp_end_index;
  */
 void z_riscv_pmp_init(void)
 {
-	ulong_t pmp_addr[4];
-	ulong_t pmp_cfg[1];
+	unsigned long pmp_addr[4];
+	unsigned long pmp_cfg[1];
 	unsigned int index = 0;
 
 	/* The read-only area is always there for every mode */
@@ -350,8 +350,8 @@ void z_riscv_pmp_init(void)
 /**
  * @Brief Initialize the per-thread PMP register copy with global values.
  */
-static inline unsigned int z_riscv_pmp_thread_init(ulong_t *pmp_addr,
-						   ulong_t *pmp_cfg,
+static inline unsigned int z_riscv_pmp_thread_init(unsigned long *pmp_addr,
+						   unsigned long *pmp_cfg,
 						   unsigned int index_limit)
 {
 	ARG_UNUSED(index_limit);

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -35,10 +35,10 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 				);
 
 	/* Setup the initial stack frame */
-	stack_init->a0 = (ulong_t)entry;
-	stack_init->a1 = (ulong_t)p1;
-	stack_init->a2 = (ulong_t)p2;
-	stack_init->a3 = (ulong_t)p3;
+	stack_init->a0 = (unsigned long)entry;
+	stack_init->a1 = (unsigned long)p1;
+	stack_init->a2 = (unsigned long)p2;
+	stack_init->a3 = (unsigned long)p3;
 
 	/*
 	 * Following the RISC-V architecture,
@@ -82,18 +82,18 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	thread->arch.priv_stack_start = 0;
 
 	/* the unwound stack pointer upon exiting exception */
-	stack_init->sp = (ulong_t)(stack_init + 1);
+	stack_init->sp = (unsigned long)(stack_init + 1);
 #endif /* CONFIG_USERSPACE */
 
 	/* Assign thread entry point and mstatus.MPRV mode. */
 	if (IS_ENABLED(CONFIG_USERSPACE)
 	    && (thread->base.user_options & K_USER)) {
 		/* User thread */
-		stack_init->mepc = (ulong_t)k_thread_user_mode_enter;
+		stack_init->mepc = (unsigned long)k_thread_user_mode_enter;
 
 	} else {
 		/* Supervisor thread */
-		stack_init->mepc = (ulong_t)z_thread_entry;
+		stack_init->mepc = (unsigned long)z_thread_entry;
 
 #if defined(CONFIG_PMP_STACK_GUARD)
 		/* Enable PMP in mstatus.MPRV mode for RISC-V machine mode
@@ -112,10 +112,10 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	stack_init->soc_context = soc_esf_init;
 #endif
 
-	thread->callee_saved.sp = (ulong_t)stack_init;
+	thread->callee_saved.sp = (unsigned long)stack_init;
 
 	/* where to go when returning from z_riscv_switch() */
-	thread->callee_saved.ra = (ulong_t)z_riscv_thread_start;
+	thread->callee_saved.ra = (unsigned long)z_riscv_thread_start;
 
 	/* our switch handle is the thread pointer itself */
 	thread->switch_handle = thread;
@@ -199,18 +199,18 @@ int arch_float_enable(struct k_thread *thread, unsigned int options)
 FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 					void *p1, void *p2, void *p3)
 {
-	ulong_t top_of_user_stack, top_of_priv_stack;
-	ulong_t status;
+	unsigned long top_of_user_stack, top_of_priv_stack;
+	unsigned long status;
 
 	/* Set up privileged stack */
 #ifdef CONFIG_GEN_PRIV_STACKS
 	_current->arch.priv_stack_start =
-			(ulong_t)z_priv_stack_find(_current->stack_obj);
+			(unsigned long)z_priv_stack_find(_current->stack_obj);
 	/* remove the stack guard from the main stack */
 	_current->stack_info.start -= K_THREAD_STACK_RESERVED;
 	_current->stack_info.size += K_THREAD_STACK_RESERVED;
 #else
-	_current->arch.priv_stack_start = (ulong_t)_current->stack_obj;
+	_current->arch.priv_stack_start = (unsigned long)_current->stack_obj;
 #endif /* CONFIG_GEN_PRIV_STACKS */
 	top_of_priv_stack = Z_STACK_PTR_ALIGN(_current->arch.priv_stack_start +
 					      K_KERNEL_STACK_RESERVED +

--- a/include/zephyr/arch/mips/exp.h
+++ b/include/zephyr/arch/mips/exp.h
@@ -18,36 +18,36 @@ extern "C" {
 #endif
 
 struct __esf {
-	ulong_t ra;		/* return address */
-	ulong_t gp;		/* global pointer */
+	unsigned long ra;		/* return address */
+	unsigned long gp;		/* global pointer */
 
-	ulong_t t0;		/* Caller-saved temporary register */
-	ulong_t t1;		/* Caller-saved temporary register */
-	ulong_t t2;		/* Caller-saved temporary register */
-	ulong_t t3;		/* Caller-saved temporary register */
-	ulong_t t4;		/* Caller-saved temporary register */
-	ulong_t t5;		/* Caller-saved temporary register */
-	ulong_t t6;		/* Caller-saved temporary register */
-	ulong_t t7;		/* Caller-saved temporary register */
-	ulong_t t8;		/* Caller-saved temporary register */
-	ulong_t t9;		/* Caller-saved temporary register */
+	unsigned long t0;		/* Caller-saved temporary register */
+	unsigned long t1;		/* Caller-saved temporary register */
+	unsigned long t2;		/* Caller-saved temporary register */
+	unsigned long t3;		/* Caller-saved temporary register */
+	unsigned long t4;		/* Caller-saved temporary register */
+	unsigned long t5;		/* Caller-saved temporary register */
+	unsigned long t6;		/* Caller-saved temporary register */
+	unsigned long t7;		/* Caller-saved temporary register */
+	unsigned long t8;		/* Caller-saved temporary register */
+	unsigned long t9;		/* Caller-saved temporary register */
 
-	ulong_t a0;		/* function argument */
-	ulong_t a1;		/* function argument */
-	ulong_t a2;		/* function argument */
-	ulong_t a3;		/* function argument */
+	unsigned long a0;		/* function argument */
+	unsigned long a1;		/* function argument */
+	unsigned long a2;		/* function argument */
+	unsigned long a3;		/* function argument */
 
-	ulong_t v0;		/* return value */
-	ulong_t v1;		/* return value */
+	unsigned long v0;		/* return value */
+	unsigned long v1;		/* return value */
 
-	ulong_t at;		/* assembly temporary */
+	unsigned long at;		/* assembly temporary */
 
-	ulong_t epc;
-	ulong_t badvaddr;
-	ulong_t hi;
-	ulong_t lo;
-	ulong_t status;
-	ulong_t cause;
+	unsigned long epc;
+	unsigned long badvaddr;
+	unsigned long hi;
+	unsigned long lo;
+	unsigned long status;
+	unsigned long cause;
 };
 
 typedef struct __esf z_arch_esf_t;

--- a/include/zephyr/arch/mips/thread.h
+++ b/include/zephyr/arch/mips/thread.h
@@ -29,17 +29,17 @@
  * saved/restored when a cooperative context switch occurs.
  */
 struct _callee_saved {
-	ulong_t sp;	/* Stack pointer */
+	unsigned long sp;	/* Stack pointer */
 
-	ulong_t s0;	/* saved register */
-	ulong_t s1;	/* saved register */
-	ulong_t s2;	/* saved register */
-	ulong_t s3;	/* saved register */
-	ulong_t s4;	/* saved register */
-	ulong_t s5;	/* saved register */
-	ulong_t s6;	/* saved register */
-	ulong_t s7;	/* saved register */
-	ulong_t s8;	/* saved register AKA fp */
+	unsigned long s0;	/* saved register */
+	unsigned long s1;	/* saved register */
+	unsigned long s2;	/* saved register */
+	unsigned long s3;	/* saved register */
+	unsigned long s4;	/* saved register */
+	unsigned long s5;	/* saved register */
+	unsigned long s6;	/* saved register */
+	unsigned long s7;	/* saved register */
+	unsigned long s8;	/* saved register AKA fp */
 };
 typedef struct _callee_saved _callee_saved_t;
 

--- a/include/zephyr/arch/riscv/exp.h
+++ b/include/zephyr/arch/riscv/exp.h
@@ -50,36 +50,36 @@ struct soc_esf {
 #endif
 
 struct __esf {
-	ulong_t ra;		/* return address */
+	unsigned long ra;		/* return address */
 
-	ulong_t t0;		/* Caller-saved temporary register */
-	ulong_t t1;		/* Caller-saved temporary register */
-	ulong_t t2;		/* Caller-saved temporary register */
+	unsigned long t0;		/* Caller-saved temporary register */
+	unsigned long t1;		/* Caller-saved temporary register */
+	unsigned long t2;		/* Caller-saved temporary register */
 #if !defined(CONFIG_RISCV_ISA_RV32E)
-	ulong_t t3;		/* Caller-saved temporary register */
-	ulong_t t4;		/* Caller-saved temporary register */
-	ulong_t t5;		/* Caller-saved temporary register */
-	ulong_t t6;		/* Caller-saved temporary register */
+	unsigned long t3;		/* Caller-saved temporary register */
+	unsigned long t4;		/* Caller-saved temporary register */
+	unsigned long t5;		/* Caller-saved temporary register */
+	unsigned long t6;		/* Caller-saved temporary register */
 #endif /* !CONFIG_RISCV_ISA_RV32E */
 
-	ulong_t a0;		/* function argument/return value */
-	ulong_t a1;		/* function argument */
-	ulong_t a2;		/* function argument */
-	ulong_t a3;		/* function argument */
-	ulong_t a4;		/* function argument */
-	ulong_t a5;		/* function argument */
+	unsigned long a0;		/* function argument/return value */
+	unsigned long a1;		/* function argument */
+	unsigned long a2;		/* function argument */
+	unsigned long a3;		/* function argument */
+	unsigned long a4;		/* function argument */
+	unsigned long a5;		/* function argument */
 #if !defined(CONFIG_RISCV_ISA_RV32E)
-	ulong_t a6;		/* function argument */
-	ulong_t a7;		/* function argument */
+	unsigned long a6;		/* function argument */
+	unsigned long a7;		/* function argument */
 #endif /* !CONFIG_RISCV_ISA_RV32E */
 
-	ulong_t mepc;		/* machine exception program counter */
-	ulong_t mstatus;	/* machine status register */
+	unsigned long mepc;		/* machine exception program counter */
+	unsigned long mstatus;	/* machine status register */
 
-	ulong_t s0;		/* callee-saved s0 */
+	unsigned long s0;		/* callee-saved s0 */
 
 #ifdef CONFIG_USERSPACE
-	ulong_t sp;		/* preserved (user or kernel) stack pointer */
+	unsigned long sp;		/* preserved (user or kernel) stack pointer */
 #endif
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)

--- a/include/zephyr/arch/riscv/irq.h
+++ b/include/zephyr/arch/riscv/irq.h
@@ -65,11 +65,11 @@ static inline void arch_isr_direct_header(void)
 	++(arch_curr_cpu()->nested);
 }
 
-extern void __soc_handle_irq(ulong_t mcause);
+extern void __soc_handle_irq(unsigned long mcause);
 
 static inline void arch_isr_direct_footer(int swap)
 {
-	ulong_t mcause;
+	unsigned long mcause;
 
 	/* Get the IRQ number */
 	__asm__ volatile("csrr %0, mcause" : "=r" (mcause));

--- a/include/zephyr/arch/riscv/syscall.h
+++ b/include/zephyr/arch/riscv/syscall.h
@@ -41,13 +41,13 @@ static inline uintptr_t arch_syscall_invoke6(uintptr_t arg1, uintptr_t arg2,
 					     uintptr_t arg5, uintptr_t arg6,
 					     uintptr_t call_id)
 {
-	register ulong_t a0 __asm__ ("a0") = arg1;
-	register ulong_t a1 __asm__ ("a1") = arg2;
-	register ulong_t a2 __asm__ ("a2") = arg3;
-	register ulong_t a3 __asm__ ("a3") = arg4;
-	register ulong_t a4 __asm__ ("a4") = arg5;
-	register ulong_t a5 __asm__ ("a5") = arg6;
-	register ulong_t t0 __asm__ ("t0") = call_id;
+	register unsigned long a0 __asm__ ("a0") = arg1;
+	register unsigned long a1 __asm__ ("a1") = arg2;
+	register unsigned long a2 __asm__ ("a2") = arg3;
+	register unsigned long a3 __asm__ ("a3") = arg4;
+	register unsigned long a4 __asm__ ("a4") = arg5;
+	register unsigned long a5 __asm__ ("a5") = arg6;
+	register unsigned long t0 __asm__ ("t0") = call_id;
 
 	__asm__ volatile ("ecall"
 			  : "+r" (a0)
@@ -62,12 +62,12 @@ static inline uintptr_t arch_syscall_invoke5(uintptr_t arg1, uintptr_t arg2,
 					     uintptr_t arg5,
 					     uintptr_t call_id)
 {
-	register ulong_t a0 __asm__ ("a0") = arg1;
-	register ulong_t a1 __asm__ ("a1") = arg2;
-	register ulong_t a2 __asm__ ("a2") = arg3;
-	register ulong_t a3 __asm__ ("a3") = arg4;
-	register ulong_t a4 __asm__ ("a4") = arg5;
-	register ulong_t t0 __asm__ ("t0") = call_id;
+	register unsigned long a0 __asm__ ("a0") = arg1;
+	register unsigned long a1 __asm__ ("a1") = arg2;
+	register unsigned long a2 __asm__ ("a2") = arg3;
+	register unsigned long a3 __asm__ ("a3") = arg4;
+	register unsigned long a4 __asm__ ("a4") = arg5;
+	register unsigned long t0 __asm__ ("t0") = call_id;
 
 	__asm__ volatile ("ecall"
 			  : "+r" (a0)
@@ -80,11 +80,11 @@ static inline uintptr_t arch_syscall_invoke4(uintptr_t arg1, uintptr_t arg2,
 					     uintptr_t arg3, uintptr_t arg4,
 					     uintptr_t call_id)
 {
-	register ulong_t a0 __asm__ ("a0") = arg1;
-	register ulong_t a1 __asm__ ("a1") = arg2;
-	register ulong_t a2 __asm__ ("a2") = arg3;
-	register ulong_t a3 __asm__ ("a3") = arg4;
-	register ulong_t t0 __asm__ ("t0") = call_id;
+	register unsigned long a0 __asm__ ("a0") = arg1;
+	register unsigned long a1 __asm__ ("a1") = arg2;
+	register unsigned long a2 __asm__ ("a2") = arg3;
+	register unsigned long a3 __asm__ ("a3") = arg4;
+	register unsigned long t0 __asm__ ("t0") = call_id;
 
 	__asm__ volatile ("ecall"
 			  : "+r" (a0)
@@ -97,10 +97,10 @@ static inline uintptr_t arch_syscall_invoke3(uintptr_t arg1, uintptr_t arg2,
 					     uintptr_t arg3,
 					     uintptr_t call_id)
 {
-	register ulong_t a0 __asm__ ("a0") = arg1;
-	register ulong_t a1 __asm__ ("a1") = arg2;
-	register ulong_t a2 __asm__ ("a2") = arg3;
-	register ulong_t t0 __asm__ ("t0") = call_id;
+	register unsigned long a0 __asm__ ("a0") = arg1;
+	register unsigned long a1 __asm__ ("a1") = arg2;
+	register unsigned long a2 __asm__ ("a2") = arg3;
+	register unsigned long t0 __asm__ ("t0") = call_id;
 
 	__asm__ volatile ("ecall"
 			  : "+r" (a0)
@@ -112,9 +112,9 @@ static inline uintptr_t arch_syscall_invoke3(uintptr_t arg1, uintptr_t arg2,
 static inline uintptr_t arch_syscall_invoke2(uintptr_t arg1, uintptr_t arg2,
 					     uintptr_t call_id)
 {
-	register ulong_t a0 __asm__ ("a0") = arg1;
-	register ulong_t a1 __asm__ ("a1") = arg2;
-	register ulong_t t0 __asm__ ("t0") = call_id;
+	register unsigned long a0 __asm__ ("a0") = arg1;
+	register unsigned long a1 __asm__ ("a1") = arg2;
+	register unsigned long t0 __asm__ ("t0") = call_id;
 
 	__asm__ volatile ("ecall"
 			  : "+r" (a0)
@@ -125,8 +125,8 @@ static inline uintptr_t arch_syscall_invoke2(uintptr_t arg1, uintptr_t arg2,
 
 static inline uintptr_t arch_syscall_invoke1(uintptr_t arg1, uintptr_t call_id)
 {
-	register ulong_t a0 __asm__ ("a0") = arg1;
-	register ulong_t t0 __asm__ ("t0") = call_id;
+	register unsigned long a0 __asm__ ("a0") = arg1;
+	register unsigned long t0 __asm__ ("t0") = call_id;
 
 	__asm__ volatile ("ecall"
 			  : "+r" (a0)
@@ -137,8 +137,8 @@ static inline uintptr_t arch_syscall_invoke1(uintptr_t arg1, uintptr_t call_id)
 
 static inline uintptr_t arch_syscall_invoke0(uintptr_t call_id)
 {
-	register ulong_t a0 __asm__ ("a0");
-	register ulong_t t0 __asm__ ("t0") = call_id;
+	register unsigned long a0 __asm__ ("a0");
+	register unsigned long t0 __asm__ ("t0") = call_id;
 
 	__asm__ volatile ("ecall"
 			  : "=r" (a0)
@@ -148,7 +148,7 @@ static inline uintptr_t arch_syscall_invoke0(uintptr_t call_id)
 }
 
 #ifdef CONFIG_USERSPACE
-register ulong_t riscv_tp_reg __asm__ ("tp");
+register unsigned long riscv_tp_reg __asm__ ("tp");
 
 static inline bool arch_is_user_context(void)
 {

--- a/include/zephyr/arch/riscv/thread.h
+++ b/include/zephyr/arch/riscv/thread.h
@@ -55,22 +55,22 @@
  * saved/restored when a context switch occurs.
  */
 struct _callee_saved {
-	ulong_t sp;	/* Stack pointer, (x2 register) */
-	ulong_t ra;	/* return address */
+	unsigned long sp;	/* Stack pointer, (x2 register) */
+	unsigned long ra;	/* return address */
 
-	ulong_t s0;	/* saved register/frame pointer */
-	ulong_t s1;	/* saved register */
+	unsigned long s0;	/* saved register/frame pointer */
+	unsigned long s1;	/* saved register */
 #if !defined(CONFIG_RISCV_ISA_RV32E)
-	ulong_t s2;	/* saved register */
-	ulong_t s3;	/* saved register */
-	ulong_t s4;	/* saved register */
-	ulong_t s5;	/* saved register */
-	ulong_t s6;	/* saved register */
-	ulong_t s7;	/* saved register */
-	ulong_t s8;	/* saved register */
-	ulong_t s9;	/* saved register */
-	ulong_t s10;	/* saved register */
-	ulong_t s11;	/* saved register */
+	unsigned long s2;	/* saved register */
+	unsigned long s3;	/* saved register */
+	unsigned long s4;	/* saved register */
+	unsigned long s5;	/* saved register */
+	unsigned long s6;	/* saved register */
+	unsigned long s7;	/* saved register */
+	unsigned long s8;	/* saved register */
+	unsigned long s9;	/* saved register */
+	unsigned long s10;	/* saved register */
+	unsigned long s11;	/* saved register */
 #endif
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
@@ -95,17 +95,17 @@ typedef struct _callee_saved _callee_saved_t;
 
 struct _thread_arch {
 #ifdef CONFIG_USERSPACE
-	ulong_t priv_stack_start;
-	ulong_t u_mode_pmpaddr_regs[CONFIG_PMP_SLOTS];
-	ulong_t u_mode_pmpcfg_regs[CONFIG_PMP_SLOTS / sizeof(ulong_t)];
+	unsigned long priv_stack_start;
+	unsigned long u_mode_pmpaddr_regs[CONFIG_PMP_SLOTS];
+	unsigned long u_mode_pmpcfg_regs[CONFIG_PMP_SLOTS / sizeof(unsigned long)];
 	unsigned int u_mode_pmp_domain_offset;
 	unsigned int u_mode_pmp_end_index;
 	unsigned int u_mode_pmp_update_nr;
 #endif
 #ifdef CONFIG_PMP_STACK_GUARD
 	unsigned int m_mode_pmp_end_index;
-	ulong_t m_mode_pmpaddr_regs[PMP_M_MODE_SLOTS];
-	ulong_t m_mode_pmpcfg_regs[PMP_M_MODE_SLOTS / sizeof(ulong_t)];
+	unsigned long m_mode_pmpaddr_regs[PMP_M_MODE_SLOTS];
+	unsigned long m_mode_pmpcfg_regs[PMP_M_MODE_SLOTS / sizeof(unsigned long)];
 #endif
 };
 

--- a/include/zephyr/types.h
+++ b/include/zephyr/types.h
@@ -14,9 +14,6 @@
 extern "C" {
 #endif
 
-/* 32 bits on ILP32 builds, 64 bits on LP64 builds */
-typedef unsigned long       ulong_t;
-
 /*
  * A type with strong alignment requirements, similar to C11 max_align_t. It can
  * be used to force alignment of data structures allocated on the stack or as

--- a/soc/riscv/riscv-privilege/andes_v5/l2_cache.c
+++ b/soc/riscv/riscv-privilege/andes_v5/l2_cache.c
@@ -62,7 +62,7 @@
 
 static void andes_v5_l2c_enable(void)
 {
-	ulong_t mcache_ctl;
+	unsigned long mcache_ctl;
 	volatile uint64_t *l2c_ctrl =
 		INT_TO_POINTER(ANDES_V5_L2C_BASE + L2C_CTRL);
 

--- a/soc/riscv/riscv-privilege/andes_v5/pma.c
+++ b/soc/riscv/riscv-privilege/andes_v5/pma.c
@@ -70,15 +70,15 @@ struct pma_region_attr {
 };
 
 struct pma_region {
-	ulong_t start;
-	ulong_t size;
+	unsigned long start;
+	unsigned long size;
 	struct pma_region_attr attr;
 };
 
 /*
  * Write value to CSRs pmaaddr{i}
  */
-static void write_pmaaddr_csr(const uint32_t index, ulong_t value)
+static void write_pmaaddr_csr(const uint32_t index, unsigned long value)
 {
 	switch (index) {
 	case 0:
@@ -125,7 +125,7 @@ static void write_pmacfg_entry(const uint32_t entry_index,
 	/* 1-byte pma{i}cfg entries are packed into XLEN-byte CSRs pmacfg{j} */
 	uint32_t index = PMACFG_NUM(entry_index);
 	uint8_t shift = PMACFG_SHIFT(entry_index);
-	ulong_t pmacfg = 0;
+	unsigned long pmacfg = 0;
 
 	switch (index) {
 	case 0:
@@ -164,7 +164,7 @@ static void write_pmacfg_entry(const uint32_t entry_index,
 static void region_init(const uint32_t index,
 	const struct pma_region *region_conf)
 {
-	ulong_t pmaaddr;
+	unsigned long pmaaddr;
 	uint8_t pmacfg;
 
 	if (region_conf->size == 4) {
@@ -208,8 +208,8 @@ static int pma_region_is_valid(const struct pma_region *region)
 static void configure_nocache_region(void)
 {
 	const struct pma_region nocache_region = {
-		.start = (ulong_t)&_nocache_ram_start,
-		.size = (ulong_t)&_nocache_ram_size,
+		.start = (unsigned long)&_nocache_ram_start,
+		.size = (unsigned long)&_nocache_ram_size,
 		.attr = {PMACFG_MTYPE_MEMORY_NOCACHE_BUFFERABLE},
 	};
 
@@ -240,7 +240,7 @@ void pma_init_per_core(void)
 
 static int pma_init(const struct device *arg)
 {
-	ulong_t mmsc_cfg;
+	unsigned long mmsc_cfg;
 
 	__asm__ volatile ("csrr %0, %1" : "=r" (mmsc_cfg) : "i" (NDS_MMSC_CFG));
 


### PR DESCRIPTION
ulong_t was mainly used in MIPS/RISC-V. Just use "unsigned long".

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>