### PR TITLE
mgmt: mcumgr: Add runtime taskstat tick usage

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -275,6 +275,9 @@ Libraries / Subsystems
     enabled by default, this makes thread priorities in the taskstat command
     signed, which matches the signed priority of tasks in Zephyr, to revert
     to previous behaviour of using unsigned values, disable this Kconfig.
+  * MCUMGR taskstat runtime field support has been added, if
+    :kconfig:option:`CONFIG_OS_MGMT_TASKSTAT` is enabled, which will report the
+    number of CPU cycles have been spent executing the thread.
 
 HALs
 ****


### PR DESCRIPTION
Adds the runtime tick count of threads to mcumgr's taskstat response,
if CONFIG_SCHED_THREAD_USAGE is enabled, which reports the number of
execution cycles that each thread has been running for.

Fixes #40854

Is using https://github.com/zephyrproject-rtos/zephyr/pull/49513 as a base so has a commit from that PR too

`Will need documentation update PR to be added`