### PR TITLE
mgmt: mcumgr: Make signed thread priorities enabled by default

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -261,6 +261,10 @@ Libraries / Subsystems
   * MCUMGR img_mgmt erase command now accepts an optional slot number
     to select which image will be erased, using the ``slot`` input
     (will default to slot 1 if not provided).
+  * MCUMGR :kconfig:option:`CONFIG_OS_MGMT_TASKSTAT_SIGNED_PRIORITY` is now
+    enabled by default, this makes thread priorities in the taskstat command
+    signed, which matches the signed priority of tasks in Zephyr, to revert
+    to previous behaviour of using unsigned values, disable this Kconfig.
 
 HALs
 ****

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/Kconfig
@@ -89,12 +89,13 @@ config OS_MGMT_TASKSTAT_THREAD_NAME_LEN
 
 config OS_MGMT_TASKSTAT_SIGNED_PRIORITY
 	bool "Signed priorities"
+	default y
 	help
 	  Zephyr uses int8_t as thread priorities, but in taskstat response it encodes
 	  them as unsigned.  Enabling this option will use signed int for priorities in
 	  responses, which is more natural for Zephyr.
-	  Enable this option only if your client software is able to properly decode
-	  and accept signed integers as priorities.
+	  Disable this option if your client software is unable to properly decode and
+	  accept signed integers as priorities.
 
 config OS_MGMT_TASKSTAT_STACK_INFO
 	bool "Include stack info in taskstat responses"


### PR DESCRIPTION
By default, thread priorities in mcumgr task stat responses are
unsigned, whilst in zephyr, thread priorities are signed. This means
that clients get obscenely large numbers for priorities that make no
sense. The fork of mcumgr has been in zephyr long enough now that
this should be changed to use signed thread priorities by default
instead of sticking with the old mcumgr default.

~~`Will require another commit with release note changes`~~ Added