### PR TITLE
net: openthread: add option for optimizing large packet transmission

### DIFF
--- a/modules/openthread/Kconfig.thread
+++ b/modules/openthread/Kconfig.thread
@@ -162,3 +162,8 @@ config OPENTHREAD_CLI_TCP_ENABLE
 
 config OPENTHREAD_HISTORY_TRACKER
 	bool "History tracker support"
+
+config OPENTHREAD_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS
+	bool "Stay awake between packet fragments"
+	help
+	  This optimization is done at the expense of power consumption on SED/SSED devices.

--- a/modules/openthread/platform/openthread-core-zephyr-config.h
+++ b/modules/openthread/platform/openthread-core-zephyr-config.h
@@ -424,4 +424,16 @@
 #define OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE CONFIG_OPENTHREAD_MESSAGE_BUFFER_SIZE
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS
+ *
+ * Enable to stay awake between fragments while transmitting a large packet,
+ * and to stay awake after receiving a packet with frame pending set to true.
+ *
+ */
+#ifdef CONFIG_OPENTHREAD_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS
+#define OPENTHREAD_CONFIG_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS                                         \
+	CONFIG_OPENTHREAD_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS
+#endif
+
 #endif  /* OPENTHREAD_CORE_ZEPHYR_CONFIG_H_ */


### PR DESCRIPTION
If enabled the optimization is done at the expense of power consumption on SED/SSED devices.