### PR TITLE
soc: riscv: ite: remove pinmux/pinctrl dead code

### DIFF
--- a/soc/riscv/riscv-ite/common/soc_dt.h
+++ b/soc/riscv/riscv-ite/common/soc_dt.h
@@ -7,40 +7,6 @@
 #ifndef _ITE_IT8XXX2_SOC_DT_H_
 #define _ITE_IT8XXX2_SOC_DT_H_
 
-#define IT8XXX2_DEV_PINMUX(idx, inst)    DEVICE_DT_GET(DT_PHANDLE( \
-	DT_INST_PINCTRL_0(inst, idx), pinctrls))
-#define IT8XXX2_DEV_PIN(idx, inst)       DT_PHA( \
-	DT_INST_PINCTRL_0(inst, idx), pinctrls, pin)
-#define IT8XXX2_DEV_ALT_FUNC(idx, inst)  DT_PHA( \
-	DT_INST_PINCTRL_0(inst, idx), pinctrls, alt_func)
-
-/**
- * @brief Macro function to construct it8xxx2 alt item in UTIL_LISTIFY extension.
- *
- * @param idx index in UTIL_LISTIFY extension.
- * @param inst instance number for compatible defined in DT_DRV_COMPAT.
- * @return macro function to construct a it8xxx2 alt structure.
- */
-#define IT8XXX2_DT_ALT_ITEMS_FUNC(idx, inst)                 \
-	{                                                    \
-		.pinctrls = IT8XXX2_DEV_PINMUX(idx, inst),   \
-		.pin = IT8XXX2_DEV_PIN(idx, inst),           \
-		.alt_fun = IT8XXX2_DEV_ALT_FUNC(idx, inst),  \
-	}
-
-/**
- * @brief Macro function to construct a list of it8xxx2 alt items with
- * compatible defined in DT_DRV_COMPAT by UTIL_LISTIFY func
- *
- * @param inst instance number for compatible defined in DT_DRV_COMPAT.
- * @return an array of it8xxx2 alt items.
- */
-#define IT8XXX2_DT_ALT_ITEMS_LIST(inst) {		\
-	LISTIFY(DT_INST_NUM_PINCTRLS_BY_IDX(inst, 0),	\
-		IT8XXX2_DT_ALT_ITEMS_FUNC, (,),		\
-		inst)					\
-	}
-
 /*
  * For it8xxx2 wake-up controller (WUC)
  */


### PR DESCRIPTION
Remove unused definitions coming from the pre-pinctrl era.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>