### PR TITLE
intel_adsp: fix leakage of Kconfigs in soc family defconfig

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -70,15 +70,22 @@ config XTENSA_SMALL_VECTOR_TABLE_ENTRY
 	  handlers to the end of vector table, renaming them to
 	  _Level\LVL\()VectorHelper.
 
+config XTENSA_RPO_CACHE
+	bool "Cached/uncached RPO mapping"
+	help
+	  Support Cached/uncached RPO mapping.
+
+	  A design trick on multi-core hardware is to map memory twice
+	  so that it can be seen in both (incoherent) cached mappings
+	  and a coherent "shared" area.
+
+if XTENSA_RPO_CACHE
 config XTENSA_CACHED_REGION
 	int "Cached RPO mapping"
 	range 0 7
 	help
-	  A design trick on multi-core hardware is to map memory twice
-	  so that it can be seen in both (incoherent) cached mappings
-	  and a coherent "shared" area.  This specifies which 512M
-	  region (0-7, as defined by the Xtensa Region Protection
-	  Option) contains the "cached" mapping.
+	  This specifies which 512M region (0-7, as defined by the Xtensa
+	  Region Protection Option) contains the "cached" mapping.
 
 config XTENSA_UNCACHED_REGION
 	int "Uncached RPO mapping"
@@ -86,6 +93,8 @@ config XTENSA_UNCACHED_REGION
 	help
 	  As for XTENSA_CACHED_REGION, this specifies which 512M
 	  region (0-7) contains the "uncached" mapping.
+
+endif
 
 config XTENSA_CCOUNT_HZ
 	int "CCOUNT cycle rate"

--- a/include/zephyr/arch/xtensa/cache.h
+++ b/include/zephyr/arch/xtensa/cache.h
@@ -78,7 +78,9 @@ static ALWAYS_INLINE void z_xtensa_cache_flush_inv_all(void)
 	z_xtensa_cache_flush_inv(NULL, Z_DCACHE_MAX);
 }
 
-#ifdef CONFIG_ARCH_HAS_COHERENCE
+
+#if defined(CONFIG_XTENSA_RPO_CACHE)
+#if defined(CONFIG_ARCH_HAS_COHERENCE)
 static inline bool arch_mem_coherent(void *ptr)
 {
 	size_t addr = (size_t) ptr;
@@ -107,7 +109,6 @@ static ALWAYS_INLINE uint32_t z_xtrpoflip(uint32_t addr, uint32_t rto, uint32_t 
 		return (addr & ~(7U << 29)) | rto;
 	}
 }
-
 /**
  * @brief Return cached pointer to a RAM address
  *
@@ -210,6 +211,8 @@ static inline void *arch_xtensa_uncached_ptr(void __sparse_cache *ptr)
 	register uint32_t addr = 0, addrincr = 0x20000000;	\
 	FOR_EACH(_SET_ONE_TLB, (;), 0, 1, 2, 3, 4, 5, 6, 7);	\
 } while (0)
+
+#endif
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/soc/xtensa/intel_adsp/Kconfig.defconfig
+++ b/soc/xtensa/intel_adsp/Kconfig.defconfig
@@ -3,24 +3,20 @@
 # Copyright (c) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+if SOC_FAMILY_INTEL_ADSP
 source "soc/xtensa/intel_adsp/*/Kconfig.defconfig.series"
 
-# Lower priority defaults come AFTER the series-specific ones set above
 
+config XTENSA_RPO_CACHE
+	def_bool y
+
+if XTENSA_RPO_CACHE
 config XTENSA_CACHED_REGION
 	default 5
 
 config XTENSA_UNCACHED_REGION
 	default 4
 
-if INTEL_ADSP_CAVS
+endif # XTENSA_RPO_CACHE
 
-config DMA_INTEL_ADSP_GPDMA
-	default y
-	depends on DMA
-
-config XTENSA_CCOUNT_HZ
-	default 400000000 if SOC_INTEL_CAVS_V25
-	default 200000000
-
-endif # INTEL_ADSP_CAVS
+endif # SOC_FAMILY_INTEL_ADSP

--- a/soc/xtensa/intel_adsp/cavs/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs/Kconfig.defconfig.series
@@ -12,4 +12,12 @@ config INTEL_ADSP_CAVS
 
 source "soc/xtensa/intel_adsp/cavs/Kconfig.defconfig.cavs*"
 
+config DMA_INTEL_ADSP_GPDMA
+	default y
+	depends on DMA
+
+config XTENSA_CCOUNT_HZ
+	default 400000000 if SOC_INTEL_CAVS_V25
+	default 200000000
+
 endif # SOC_SERIES_INTEL_ADSP_CAVS


### PR DESCRIPTION
Add missing conditionals and move CAVS related configs into own series
defconfig.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
