### PR TITLE
Shell: Increase ARGC_MAX default val

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -84,7 +84,7 @@ config SHELL_DEFAULT_TERMINAL_HEIGHT
 config SHELL_ARGC_MAX
 	int "Maximum arguments in shell command"
 	range 3 255
-	default 12
+	default 20
 	help
 	  Maximum number of arguments that can build a command.
 

--- a/tests/subsys/shell/shell/src/main.c
+++ b/tests/subsys/shell/shell/src/main.c
@@ -421,13 +421,14 @@ SHELL_CMD_REGISTER(dummy, NULL, NULL, cmd_dummy);
 
 ZTEST(shell, test_max_argc)
 {
-	BUILD_ASSERT(CONFIG_SHELL_ARGC_MAX == 12,
+	BUILD_ASSERT(CONFIG_SHELL_ARGC_MAX == 20,
 		     "Unexpected test configuration.");
 
-	test_shell_execute_cmd("dummy 1 2 3 4 5 6 7 8 9 10 11", 0);
-	test_shell_execute_cmd("dummy 1 2 3 4 5 6 7 8 9 10 11 12", -ENOEXEC);
+	test_shell_execute_cmd("dummy 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19", 0);
+	test_shell_execute_cmd("dummy 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15"
+			       " 16 17 18 19 20",
+			       -ENOEXEC);
 }
-
 
 static int cmd_handler_dict_1(const struct shell *sh, size_t argc, char **argv, void *data)
 {


### PR DESCRIPTION
Increase deafult value of SHELL_ARGC_MAX configuration.
This allows users to utilize deeper nested shell menus without
risking maxing out the number of allowed arguments.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>