### PR TITLE
drivers: sensors: sgp40 self-test needs more time

### DIFF
--- a/drivers/sensor/sgp40/sgp40.h
+++ b/drivers/sensor/sgp40/sgp40.h
@@ -18,7 +18,7 @@
 
 #define SGP40_RESET_WAIT_MS	10
 #define SGP40_MEASURE_WAIT_MS	30
-#define SGP40_TEST_WAIT_MS	250
+#define SGP40_TEST_WAIT_MS	320
 
 /*
  * CRC parameters were taken from the


### PR DESCRIPTION
During debugging, I found out that according to the datasheet of the SGP40, the sensor needs more time for the self-test. Augmenting this number to 320ms solved my issue - and is exactly within the specs in the datasheet (https://sensirion.com/media/documents/296373BB/6203C5DF/Sensirion_Gas_Sensors_Datasheet_SGP40.pdf, page 12):
| **Command**               | **Command hex. code** | **Duration, typical [ms]** | **Duration, maximum [ms]** |
|---------------------------|:---------------------:|:--------------------------:|:--------------------------:|
| _sgp40_execute_self_test_ |             0x28 0x0E |                        300 |                        320 |

Refer also to section "3.3 Built-in Self-Test" on page 10:
_With the sgp40_execute_self_test command, users can perform an on-chip self-test for, e.g., in-line or end-of-line production
testing. If this command is called when the sensor is in idle mode, the sensor returns to idle mode after the test (Figure 9). In
case this command is called during VOC measurement mode (i.e., after calling the sgp40_measure_raw_signal command), the
hotplate remains switched on thereafter. After 320 ms, the master can read a fixed data pattern (1 word + CRC byte) to check if
the test was successful or not._