### PR TITLE
Bluetooth: Increase RX thread stack size

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -129,7 +129,7 @@ config BT_RX_STACK_SIZE
 	default 2200 if BT_MESH
 	default 2048 if BT_AUDIO
 	default 2200 if BT_SETTINGS
-	default 1024
+	default 1200
 	help
 	  Size of the receiving thread stack. This is the context from
 	  which all event callbacks to the application occur. The


### PR DESCRIPTION
Normal usage for Bluetooth applications are getting close to or
already overflowing the default BT RX stack size of 1024.

For example:
 - Discovery using the fixed ATT channel used 984 bytes.
 - Discovery using an enhanced ATT channel used 1048 bytes,
   which would lead to stack overflow using the default BT RX thread
   stack size.

Signed-off-by: Herman Berget <herman.berget@nordicsemi.no>