### PR TITLE
mgmt/mcumgr: Drop zst from zephyr_smp_transport_out_fn

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -278,6 +278,10 @@ Libraries / Subsystems
   * MCUMGR taskstat runtime field support has been added, if
     :kconfig:option:`CONFIG_OS_MGMT_TASKSTAT` is enabled, which will report the
     number of CPU cycles have been spent executing the thread.
+  * MCUMgr transport API drops ``zst`` parameter, of :c:struct:`zephyr_smp_transport`
+    type, from :c:func:`zephyr_smp_transport_out_fn` type callback as it has
+    not been used, and the ``nb`` parameter, of :c:struct:`net_buf` type,
+    can carry additional transport information when needed.
 
 HALs
 ****

--- a/include/zephyr/mgmt/mcumgr/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp.h
@@ -21,13 +21,11 @@ struct net_buf;
  *
  * The supplied net_buf is always consumed, regardless of return code.
  *
- * @param zst                   The transport to send via.
  * @param nb                    The net_buf to transmit.
  *
  * @return                      0 on success, MGMT_ERR_[...] code on failure.
  */
-typedef int zephyr_smp_transport_out_fn(struct zephyr_smp_transport *zst,
-					struct net_buf *nb);
+typedef int zephyr_smp_transport_out_fn(struct net_buf *nb);
 
 /** @typedef zephyr_smp_transport_get_mtu_fn
  * @brief SMP MTU query function for Zephyr.

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -180,7 +180,7 @@ zephyr_smp_tx_rsp(struct smp_streamer *ns, void *rsp, void *arg)
 			return MGMT_ERR_ENOMEM;
 		}
 
-		rc = zst->zst_output(zst, frag);
+		rc = zst->zst_output(frag);
 		if (rc != 0) {
 			return MGMT_ERR_EUNKNOWN;
 		}

--- a/subsys/mgmt/mcumgr/transport/smp_bt.c
+++ b/subsys/mgmt/mcumgr/transport/smp_bt.c
@@ -375,7 +375,7 @@ static int smp_bt_ud_copy(struct net_buf *dst, const struct net_buf *src)
 /**
  * Transmits the specified SMP response.
  */
-static int smp_bt_tx_pkt(struct zephyr_smp_transport *zst, struct net_buf *nb)
+static int smp_bt_tx_pkt(struct net_buf *nb)
 {
 	struct bt_conn *conn;
 	int rc = MGMT_ERR_EOK;

--- a/subsys/mgmt/mcumgr/transport/smp_dummy.c
+++ b/subsys/mgmt/mcumgr/transport/smp_dummy.c
@@ -170,8 +170,7 @@ int dummy_mcumgr_send_raw(const void *data, int len, void *arg)
 	return 0;
 }
 
-static int smp_dummy_tx_pkt_int(struct zephyr_smp_transport *zst,
-				struct net_buf *nb)
+static int smp_dummy_tx_pkt_int(struct net_buf *nb)
 {
 	int rc;
 

--- a/subsys/mgmt/mcumgr/transport/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/smp_shell.c
@@ -176,8 +176,7 @@ static int smp_shell_tx_raw(const void *data, int len, void *arg)
 	return 0;
 }
 
-static int smp_shell_tx_pkt(struct zephyr_smp_transport *zst,
-			    struct net_buf *nb)
+static int smp_shell_tx_pkt(struct net_buf *nb)
 {
 	int rc;
 

--- a/subsys/mgmt/mcumgr/transport/smp_uart.c
+++ b/subsys/mgmt/mcumgr/transport/smp_uart.c
@@ -77,8 +77,7 @@ static uint16_t smp_uart_get_mtu(const struct net_buf *nb)
 	return CONFIG_MCUMGR_SMP_UART_MTU;
 }
 
-static int smp_uart_tx_pkt(struct zephyr_smp_transport *zst,
-			   struct net_buf *nb)
+static int smp_uart_tx_pkt(struct net_buf *nb)
 {
 	int rc;
 

--- a/subsys/mgmt/mcumgr/transport/smp_udp.c
+++ b/subsys/mgmt/mcumgr/transport/smp_udp.c
@@ -62,10 +62,8 @@ static struct configs configs = {
 };
 
 #ifdef CONFIG_MCUMGR_SMP_UDP_IPV4
-static int smp_udp4_tx(struct zephyr_smp_transport *zst, struct net_buf *nb)
+static int smp_udp4_tx(struct net_buf *nb)
 {
-	ARG_UNUSED(zst);
-
 	struct sockaddr *addr = net_buf_user_data(nb);
 	int ret = sendto(configs.ipv4.sock, nb->data, nb->len,
 			 0, addr, sizeof(*addr));
@@ -76,10 +74,8 @@ static int smp_udp4_tx(struct zephyr_smp_transport *zst, struct net_buf *nb)
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_UDP_IPV6
-static int smp_udp6_tx(struct zephyr_smp_transport *zst, struct net_buf *nb)
+static int smp_udp6_tx(struct net_buf *nb)
 {
-	ARG_UNUSED(zst);
-
 	struct sockaddr *addr = net_buf_user_data(nb);
 	int ret = sendto(configs.ipv6.sock, nb->data, nb->len,
 			 0, addr, sizeof(*addr));


### PR DESCRIPTION
Never used and not needed.

RFC: https://github.com/zephyrproject-rtos/zephyr/issues/49962

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>