### PR TITLE
mgmt/mcumgr: Drop zephyr_ prefix from functions

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -26,6 +26,49 @@ Removed APIs in this release
 Deprecated in this release
 ==========================
 
+* MCUmgr subsystem, specifically the SMP transport API, is dropping `zephyr_`
+  prefix, deprecating prefixed functions and callback type definitions with the
+  prefix and replacing them with with prefix-less variants.
+  The :c:struct:`zephyr_smp_transport` type, representing transport object,
+  is now replaced with :c:struct:`smp_transport`, and the later one is used,
+  instead of the former one, by all prefix-less functions.
+
+  Deprecated functions and their replacements:
+
+  .. table::
+     :align: center
+
+     +-------------------------------------+---------------------------------------+
+     | Deprecated                          | Drop in replacement                   |
+     +=====================================+=======================================+
+     | :c:func:`zephyr_smp_transport_init` | :c:func:`smp_transport_init`          |
+     +-------------------------------------+---------------------------------------+
+     | :c:func:`zephyr_smp_rx_req`         | :c:func:`smp_rx_req`                  |
+     +-------------------------------------+---------------------------------------+
+     | :c:func:`zephyr_smp_alloc_rsp`      | :c:func:`smp_alloc_rsp`               |
+     +-------------------------------------+---------------------------------------+
+     | :c:func:`zephyr_smp_free_buf`       | :c:func:`smp_free_buf`                |
+     +-------------------------------------+---------------------------------------+
+
+  Deprecated callback types and their replacements:
+
+  .. table::
+     :align: center
+
+     +---------------------------------------------+---------------------------------------+
+     | Deprecated                                  | Drop in replacement                   |
+     +=============================================+=======================================+
+     | :c:func:`zephyr_smp_transport_out_fn`       | :c:func:`smp_transport_out_fn`        |
+     +---------------------------------------------+---------------------------------------+
+     | :c:func:`zephyr_smp_transport_get_mtu_fn`   | :c:func:`smp_transport_get_mtu_fn`    |
+     +---------------------------------------------+---------------------------------------+
+     | :c:func:`zephyr_smp_transport_ud_copy_fn`   | :c:func:`smp_transport_ud_copy_fn`    |
+     +---------------------------------------------+---------------------------------------+
+     | :c:func:`zephyr_smp_transport_ud_free_fn`   | :c:func:`smp_transport_ud_free_fn`    |
+     +---------------------------------------------+---------------------------------------+
+
+  NOTE: Only functions are marked as ``__deprecated``, type definitions are not.
+
 Stable API changes in this release
 ==================================
 

--- a/include/zephyr/mgmt/mcumgr/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp.h
@@ -84,15 +84,15 @@ typedef void zephyr_smp_transport_ud_free_fn(void *ud);
  */
 struct smp_transport {
 	/* Must be the first member. */
-	struct k_work zst_work;
+	struct k_work work;
 
 	/* FIFO containing incoming requests to be processed. */
-	struct k_fifo zst_fifo;
+	struct k_fifo fifo;
 
-	smp_transport_out_fn zst_output;
-	smp_transport_get_mtu_fn zst_get_mtu;
-	smp_transport_ud_copy_fn zst_ud_copy;
-	smp_transport_ud_free_fn zst_ud_free;
+	smp_transport_out_fn output;
+	smp_transport_get_mtu_fn get_mtu;
+	smp_transport_ud_copy_fn ud_copy;
+	smp_transport_ud_free_fn ud_free;
 
 #ifdef CONFIG_MCUMGR_SMP_REASSEMBLY
 	/* Packet reassembly internal data, API access only */

--- a/include/zephyr/mgmt/mcumgr/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp.h
@@ -140,7 +140,7 @@ void smp_transport_init(struct smp_transport *smpt,
 			smp_transport_ud_copy_fn ud_copy_func,
 			smp_transport_ud_free_fn ud_free_func);
 
-static inline
+__deprecated static inline
 void zephyr_smp_transport_init(struct zephyr_smp_transport *smpt,
 			       zephyr_smp_transport_out_fn *output_func,
 			       zephyr_smp_transport_get_mtu_fn *get_mtu_func,

--- a/include/zephyr/mgmt/mcumgr/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp.h
@@ -128,13 +128,13 @@ struct zephyr_smp_transport {
 /**
  * @brief Initializes a Zephyr SMP transport object.
  *
- * @param zst                   The transport to construct.
+ * @param smpt                  The transport to construct.
  * @param output_func           The transport's send function.
  * @param get_mtu_func          The transport's get-MTU function.
  * @param ud_copy_func          The transport buffer user_data copy function.
  * @param ud_free_func          The transport buffer user_data free function.
  */
-void smp_transport_init(struct smp_transport *zst,
+void smp_transport_init(struct smp_transport *smpt,
 			smp_transport_out_fn output_func,
 			smp_transport_get_mtu_fn get_mtu_func,
 			smp_transport_ud_copy_fn ud_copy_func,

--- a/include/zephyr/mgmt/mcumgr/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp.h
@@ -13,11 +13,12 @@
 extern "C" {
 #endif
 
+struct smp_transport;
 struct zephyr_smp_transport;
 struct net_buf;
 
-/** @typedef zephyr_smp_transport_out_fn
- * @brief SMP transmit function for Zephyr.
+/** @typedef smp_transport_out_fn
+ * @brief SMP transmit callback for transport
  *
  * The supplied net_buf is always consumed, regardless of return code.
  *
@@ -25,10 +26,12 @@ struct net_buf;
  *
  * @return                      0 on success, MGMT_ERR_[...] code on failure.
  */
+typedef int (*smp_transport_out_fn)(struct net_buf *nb);
+/* use smp_transport_out_fn instead */
 typedef int zephyr_smp_transport_out_fn(struct net_buf *nb);
 
-/** @typedef zephyr_smp_transport_get_mtu_fn
- * @brief SMP MTU query function for Zephyr.
+/** @typedef smp_transport_get_mtu_fn
+ * @brief SMP MTU query callback for transport
  *
  * The supplied net_buf should contain a request received from the peer whose
  * MTU is being queried.  This function takes a net_buf parameter because some
@@ -40,10 +43,12 @@ typedef int zephyr_smp_transport_out_fn(struct net_buf *nb);
  * @return                      The transport's MTU;
  *                              0 if transmission is currently not possible.
  */
+typedef uint16_t (*smp_transport_get_mtu_fn)(const struct net_buf *nb);
+/* use smp_transport_get_mtu_fn instead */
 typedef uint16_t zephyr_smp_transport_get_mtu_fn(const struct net_buf *nb);
 
-/** @typedef zephyr_smp_transport_ud_copy_fn
- * @brief SMP copy buffer user_data function for Zephyr.
+/** @typedef smp_transport_ud_copy_fn
+ * @brief SMP copy user_data callback
  *
  * The supplied src net_buf should contain a user_data that cannot be copied
  * using regular memcpy function (e.g., the BLE transport net_buf user_data
@@ -55,11 +60,14 @@ typedef uint16_t zephyr_smp_transport_get_mtu_fn(const struct net_buf *nb);
  *
  * @return                      0 on success, MGMT_ERR_[...] code on failure.
  */
+typedef int (*smp_transport_ud_copy_fn)(struct net_buf *dst,
+					const struct net_buf *src);
+/* use smp_transport_ud_copy_fn instead */
 typedef int zephyr_smp_transport_ud_copy_fn(struct net_buf *dst,
 					    const struct net_buf *src);
 
-/** @typedef zephyr_smp_transport_ud_free_fn
- * @brief SMP free buffer user_data function for Zephyr.
+/** @typedef smp_transport_ud_free_fn
+ * @brief SMP free user_data callback
  *
  * This function frees net_buf user data, because some transports store
  * connection-specific information in the net_buf user data (e.g., the BLE
@@ -67,11 +75,35 @@ typedef int zephyr_smp_transport_ud_copy_fn(struct net_buf *dst,
  *
  * @param ud                    Contains a user_data pointer to be freed.
  */
+typedef void (*smp_transport_ud_free_fn)(void *ud);
+/* use smp_transport_ud_free_fn instead */
 typedef void zephyr_smp_transport_ud_free_fn(void *ud);
 
 /**
- * @brief Provides Zephyr-specific functionality for sending SMP responses.
+ * @brief SMP transport object for sending SMP responses.
  */
+struct smp_transport {
+	/* Must be the first member. */
+	struct k_work zst_work;
+
+	/* FIFO containing incoming requests to be processed. */
+	struct k_fifo zst_fifo;
+
+	smp_transport_out_fn zst_output;
+	smp_transport_get_mtu_fn zst_get_mtu;
+	smp_transport_ud_copy_fn zst_ud_copy;
+	smp_transport_ud_free_fn zst_ud_free;
+
+#ifdef CONFIG_MCUMGR_SMP_REASSEMBLY
+	/* Packet reassembly internal data, API access only */
+	struct {
+		struct net_buf *current;	/* net_buf used for reassembly */
+		uint16_t expected;		/* expected bytes to come */
+	} __reassembly;
+#endif
+};
+
+/* Deprecated, use smp_transport instead */
 struct zephyr_smp_transport {
 	/* Must be the first member. */
 	struct k_work zst_work;
@@ -79,10 +111,10 @@ struct zephyr_smp_transport {
 	/* FIFO containing incoming requests to be processed. */
 	struct k_fifo zst_fifo;
 
-	zephyr_smp_transport_out_fn *zst_output;
-	zephyr_smp_transport_get_mtu_fn *zst_get_mtu;
-	zephyr_smp_transport_ud_copy_fn *zst_ud_copy;
-	zephyr_smp_transport_ud_free_fn *zst_ud_free;
+	smp_transport_out_fn zst_output;
+	smp_transport_get_mtu_fn zst_get_mtu;
+	smp_transport_ud_copy_fn zst_ud_copy;
+	smp_transport_ud_free_fn zst_ud_free;
 
 #ifdef CONFIG_MCUMGR_SMP_REASSEMBLY
 	/* Packet reassembly internal data, API access only */
@@ -102,11 +134,25 @@ struct zephyr_smp_transport {
  * @param ud_copy_func          The transport buffer user_data copy function.
  * @param ud_free_func          The transport buffer user_data free function.
  */
-void zephyr_smp_transport_init(struct zephyr_smp_transport *zst,
+void smp_transport_init(struct smp_transport *zst,
+			smp_transport_out_fn output_func,
+			smp_transport_get_mtu_fn get_mtu_func,
+			smp_transport_ud_copy_fn ud_copy_func,
+			smp_transport_ud_free_fn ud_free_func);
+
+static inline
+void zephyr_smp_transport_init(struct zephyr_smp_transport *smpt,
 			       zephyr_smp_transport_out_fn *output_func,
 			       zephyr_smp_transport_get_mtu_fn *get_mtu_func,
 			       zephyr_smp_transport_ud_copy_fn *ud_copy_func,
-			       zephyr_smp_transport_ud_free_fn *ud_free_func);
+			       zephyr_smp_transport_ud_free_fn *ud_free_func)
+{
+	smp_transport_init((struct smp_transport *)smpt,
+			   (smp_transport_out_fn)output_func,
+			   (smp_transport_get_mtu_fn)get_mtu_func,
+			   (smp_transport_ud_copy_fn)ud_copy_func,
+			   (smp_transport_ud_free_fn)ud_free_func);
+}
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/lib/smp/include/smp/smp.h
+++ b/subsys/mgmt/mcumgr/lib/smp/include/smp/smp.h
@@ -38,7 +38,7 @@ struct mgmt_hdr;
  * @brief Decodes, encodes, and transmits SMP packets.
  */
 struct smp_streamer {
-	struct zephyr_smp_transport *smpt;
+	struct smp_transport *smpt;
 	struct cbor_nb_reader *reader;
 	struct cbor_nb_writer *writer;
 };

--- a/subsys/mgmt/mcumgr/lib/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/lib/smp/src/smp.c
@@ -233,8 +233,8 @@ smp_on_err(struct smp_streamer *streamer, const struct mgmt_hdr *req_hdr,
 	}
 
 	/* Free any extra buffers. */
-	zephyr_smp_free_buf(req, streamer->smpt);
-	zephyr_smp_free_buf(rsp, streamer->smpt);
+	smp_free_buf(req, streamer->smpt);
+	smp_free_buf(rsp, streamer->smpt);
 }
 
 /**
@@ -290,7 +290,7 @@ smp_process_request_packet(struct smp_streamer *streamer, void *vreq)
 			break;
 		}
 
-		rsp = zephyr_smp_alloc_rsp(req, streamer->smpt);
+		rsp = smp_alloc_rsp(req, streamer->smpt);
 		if (rsp == NULL) {
 			rc = MGMT_ERR_ENOMEM;
 			break;
@@ -332,8 +332,8 @@ smp_process_request_packet(struct smp_streamer *streamer, void *vreq)
 		return rc;
 	}
 
-	zephyr_smp_free_buf(req, streamer->smpt);
-	zephyr_smp_free_buf(rsp, streamer->smpt);
+	smp_free_buf(req, streamer->smpt);
+	smp_free_buf(rsp, streamer->smpt);
 
 	return rc;
 }

--- a/subsys/mgmt/mcumgr/lib/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/lib/smp/src/smp.c
@@ -228,7 +228,7 @@ smp_on_err(struct smp_streamer *streamer, const struct mgmt_hdr *req_hdr,
 	/* Build and transmit the error response. */
 	rc = smp_build_err_rsp(streamer, req_hdr, status, rsn);
 	if (rc == 0) {
-		streamer->smpt->zst_output(rsp);
+		streamer->smpt->output(rsp);
 		rsp = NULL;
 	}
 
@@ -306,7 +306,7 @@ smp_process_request_packet(struct smp_streamer *streamer, void *vreq)
 		}
 
 		/* Send the response. */
-		rc = streamer->smpt->zst_output(rsp);
+		rc = streamer->smpt->output(rsp);
 		rsp = NULL;
 		if (rc != 0) {
 			break;

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -59,8 +59,8 @@ void *smp_alloc_rsp(const void *req, void *arg)
 		return NULL;
 	}
 
-	if (smpt->zst_ud_copy) {
-		smpt->zst_ud_copy(rsp_nb, req_nb);
+	if (smpt->ud_copy) {
+		smpt->ud_copy(rsp_nb, req_nb);
 	} else {
 		pool = net_buf_pool_get(req_nb->pool_id);
 		memcpy(net_buf_user_data(rsp_nb),
@@ -79,8 +79,8 @@ void smp_free_buf(void *buf, void *arg)
 		return;
 	}
 
-	if (smpt->zst_ud_free) {
-		smpt->zst_ud_free(net_buf_user_data((struct net_buf *)buf));
+	if (smpt->ud_free) {
+		smpt->ud_free(net_buf_user_data((struct net_buf *)buf));
 	}
 
 	mcumgr_buf_free(buf);
@@ -118,7 +118,7 @@ smp_handle_reqs(struct k_work *work)
 
 	smpt = (void *)work;
 
-	while ((nb = net_buf_get(&smpt->zst_fifo, K_NO_WAIT)) != NULL) {
+	while ((nb = net_buf_get(&smpt->fifo, K_NO_WAIT)) != NULL) {
 		smp_process_packet(smpt, nb);
 	}
 }
@@ -131,18 +131,18 @@ smp_transport_init(struct smp_transport *smpt,
 		   smp_transport_ud_free_fn ud_free_func)
 {
 	*smpt = (struct smp_transport) {
-		.zst_output = output_func,
-		.zst_get_mtu = get_mtu_func,
-		.zst_ud_copy = ud_copy_func,
-		.zst_ud_free = ud_free_func,
+		.output = output_func,
+		.get_mtu = get_mtu_func,
+		.ud_copy = ud_copy_func,
+		.ud_free = ud_free_func,
 	};
 
 #ifdef CONFIG_MCUMGR_SMP_REASSEMBLY
 	smp_reassembly_init(smpt);
 #endif
 
-	k_work_init(&smpt->zst_work, smp_handle_reqs);
-	k_fifo_init(&smpt->zst_fifo);
+	k_work_init(&smpt->work, smp_handle_reqs);
+	k_fifo_init(&smpt->fifo);
 }
 
 /**
@@ -157,8 +157,8 @@ smp_transport_init(struct smp_transport *smpt,
 WEAK void
 smp_rx_req(struct smp_transport *smpt, struct net_buf *nb)
 {
-	net_buf_put(&smpt->zst_fifo, nb);
-	k_work_submit_to_queue(&smp_work_queue, &smpt->zst_work);
+	net_buf_put(&smpt->fifo, nb);
+	k_work_submit_to_queue(&smp_work_queue, &smpt->work);
 }
 
 static int smp_init(const struct device *dev)

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -45,12 +45,12 @@ static const struct k_work_queue_config smp_work_queue_config = {
  * @return	Newly-allocated buffer on success
  *		NULL on failure.
  */
-void *zephyr_smp_alloc_rsp(const void *req, void *arg)
+void *smp_alloc_rsp(const void *req, void *arg)
 {
 	const struct net_buf_pool *pool;
 	const struct net_buf *req_nb;
 	struct net_buf *rsp_nb;
-	struct zephyr_smp_transport *zst = arg;
+	struct smp_transport *zst = arg;
 
 	req_nb = req;
 
@@ -71,9 +71,9 @@ void *zephyr_smp_alloc_rsp(const void *req, void *arg)
 	return rsp_nb;
 }
 
-void zephyr_smp_free_buf(void *buf, void *arg)
+void smp_free_buf(void *buf, void *arg)
 {
-	struct zephyr_smp_transport *zst = arg;
+	struct smp_transport *zst = arg;
 
 	if (!buf) {
 		return;
@@ -90,7 +90,7 @@ void zephyr_smp_free_buf(void *buf, void *arg)
  * Processes a single SMP packet and sends the corresponding response(s).
  */
 static int
-zephyr_smp_process_packet(struct zephyr_smp_transport *zst,
+smp_process_packet(struct smp_transport *zst,
 			  struct net_buf *nb)
 {
 	struct cbor_nb_reader reader;
@@ -112,26 +112,26 @@ zephyr_smp_process_packet(struct zephyr_smp_transport *zst,
  * Processes all received SNP request packets.
  */
 static void
-zephyr_smp_handle_reqs(struct k_work *work)
+smp_handle_reqs(struct k_work *work)
 {
-	struct zephyr_smp_transport *zst;
+	struct smp_transport *zst;
 	struct net_buf *nb;
 
 	zst = (void *)work;
 
 	while ((nb = net_buf_get(&zst->zst_fifo, K_NO_WAIT)) != NULL) {
-		zephyr_smp_process_packet(zst, nb);
+		smp_process_packet(zst, nb);
 	}
 }
 
 void
-zephyr_smp_transport_init(struct zephyr_smp_transport *zst,
-			  zephyr_smp_transport_out_fn *output_func,
-			  zephyr_smp_transport_get_mtu_fn *get_mtu_func,
-			  zephyr_smp_transport_ud_copy_fn *ud_copy_func,
-			  zephyr_smp_transport_ud_free_fn *ud_free_func)
+smp_transport_init(struct smp_transport *zst,
+		   smp_transport_out_fn output_func,
+		   smp_transport_get_mtu_fn get_mtu_func,
+		   smp_transport_ud_copy_fn ud_copy_func,
+		   smp_transport_ud_free_fn ud_free_func)
 {
-	*zst = (struct zephyr_smp_transport) {
+	*zst = (struct smp_transport) {
 		.zst_output = output_func,
 		.zst_get_mtu = get_mtu_func,
 		.zst_ud_copy = ud_copy_func,
@@ -139,10 +139,10 @@ zephyr_smp_transport_init(struct zephyr_smp_transport *zst,
 	};
 
 #ifdef CONFIG_MCUMGR_SMP_REASSEMBLY
-	zephyr_smp_reassembly_init(zst);
+	smp_reassembly_init(zst);
 #endif
 
-	k_work_init(&zst->zst_work, zephyr_smp_handle_reqs);
+	k_work_init(&zst->zst_work, smp_handle_reqs);
 	k_fifo_init(&zst->zst_fifo);
 }
 
@@ -156,13 +156,13 @@ zephyr_smp_transport_init(struct zephyr_smp_transport *zst,
  * @param nb                    The request packet to process.
  */
 WEAK void
-zephyr_smp_rx_req(struct zephyr_smp_transport *zst, struct net_buf *nb)
+smp_rx_req(struct smp_transport *zst, struct net_buf *nb)
 {
 	net_buf_put(&zst->zst_fifo, nb);
 	k_work_submit_to_queue(&smp_work_queue, &zst->zst_work);
 }
 
-static int zephyr_smp_init(const struct device *dev)
+static int smp_init(const struct device *dev)
 {
 	k_work_queue_init(&smp_work_queue);
 
@@ -173,4 +173,4 @@ static int zephyr_smp_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(zephyr_smp_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
+SYS_INIT(smp_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/subsys/mgmt/mcumgr/smp_internal.h
+++ b/subsys/mgmt/mcumgr/smp_internal.h
@@ -21,11 +21,11 @@ struct net_buf;
  *
  * This function always consumes the supplied net_buf.
  *
- * @param zst                   The transport to use to send the corresponding
+ * @param smtp                  The transport to use to send the corresponding
  *                                  response(s).
  * @param nb                    The request packet to process.
  */
-void smp_rx_req(struct smp_transport *zst, struct net_buf *nb);
+void smp_rx_req(struct smp_transport *smtp, struct net_buf *nb);
 
 static inline
 void zephyr_smp_rx_req(struct zephyr_smp_transport *smpt, struct net_buf *nb)

--- a/subsys/mgmt/mcumgr/smp_internal.h
+++ b/subsys/mgmt/mcumgr/smp_internal.h
@@ -12,6 +12,7 @@
 extern "C" {
 #endif
 
+struct smp_transport;
 struct zephyr_smp_transport;
 struct net_buf;
 
@@ -24,7 +25,13 @@ struct net_buf;
  *                                  response(s).
  * @param nb                    The request packet to process.
  */
-void zephyr_smp_rx_req(struct zephyr_smp_transport *zst, struct net_buf *nb);
+void smp_rx_req(struct smp_transport *zst, struct net_buf *nb);
+
+static inline
+void zephyr_smp_rx_req(struct zephyr_smp_transport *smpt, struct net_buf *nb)
+{
+	smp_rx_req((struct smp_transport *)smpt, nb);
+}
 
 /**
  * @brief Allocates a response buffer.
@@ -37,7 +44,14 @@ void zephyr_smp_rx_req(struct zephyr_smp_transport *zst, struct net_buf *nb);
  * @return	Newly-allocated buffer on success
  *		NULL on failure.
  */
-void *zephyr_smp_alloc_rsp(const void *req, void *arg);
+void *smp_alloc_rsp(const void *req, void *arg);
+
+static inline
+void *zephyr_smp_alloc_rsp(const void *req, void *arg)
+{
+	return smp_alloc_rsp(req, arg);
+}
+
 
 /**
  * @brief Frees an allocated buffer.
@@ -45,7 +59,13 @@ void *zephyr_smp_alloc_rsp(const void *req, void *arg);
  * @param buf		The buffer to free.
  * @param arg		The streamer providing the callback.
  */
-void zephyr_smp_free_buf(void *buf, void *arg);
+void smp_free_buf(void *buf, void *arg);
+
+static inline
+void zephyr_smp_free_buf(void *buf, void *arg)
+{
+	smp_free_buf(buf, arg);
+}
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/smp_internal.h
+++ b/subsys/mgmt/mcumgr/smp_internal.h
@@ -27,7 +27,7 @@ struct net_buf;
  */
 void smp_rx_req(struct smp_transport *smtp, struct net_buf *nb);
 
-static inline
+__deprecated static inline
 void zephyr_smp_rx_req(struct zephyr_smp_transport *smpt, struct net_buf *nb)
 {
 	smp_rx_req((struct smp_transport *)smpt, nb);
@@ -46,7 +46,7 @@ void zephyr_smp_rx_req(struct zephyr_smp_transport *smpt, struct net_buf *nb)
  */
 void *smp_alloc_rsp(const void *req, void *arg);
 
-static inline
+__deprecated static inline
 void *zephyr_smp_alloc_rsp(const void *req, void *arg)
 {
 	return smp_alloc_rsp(req, arg);
@@ -61,7 +61,7 @@ void *zephyr_smp_alloc_rsp(const void *req, void *arg)
  */
 void smp_free_buf(void *buf, void *arg);
 
-static inline
+__deprecated static inline
 void zephyr_smp_free_buf(void *buf, void *arg)
 {
 	smp_free_buf(buf, arg);

--- a/subsys/mgmt/mcumgr/smp_reassembly.c
+++ b/subsys/mgmt/mcumgr/smp_reassembly.c
@@ -13,13 +13,13 @@
 #include <smp/smp.h>
 #include "smp_internal.h"
 
-void zephyr_smp_reassembly_init(struct zephyr_smp_transport *zst)
+void smp_reassembly_init(struct smp_transport *zst)
 {
 	zst->__reassembly.current = NULL;
 	zst->__reassembly.expected = 0;
 }
 
-int zephyr_smp_reassembly_expected(const struct zephyr_smp_transport *zst)
+int smp_reassembly_expected(const struct smp_transport *zst)
 {
 	if (zst->__reassembly.current == NULL) {
 		return -EINVAL;
@@ -28,7 +28,7 @@ int zephyr_smp_reassembly_expected(const struct zephyr_smp_transport *zst)
 	return zst->__reassembly.expected;
 }
 
-int zephyr_smp_reassembly_collect(struct zephyr_smp_transport *zst, const void *buf, uint16_t len)
+int smp_reassembly_collect(struct smp_transport *zst, const void *buf, uint16_t len)
 {
 	if (zst->__reassembly.current == NULL) {
 		/*
@@ -80,7 +80,7 @@ int zephyr_smp_reassembly_collect(struct zephyr_smp_transport *zst, const void *
 	return zst->__reassembly.expected;
 }
 
-int zephyr_smp_reassembly_complete(struct zephyr_smp_transport *zst, bool force)
+int smp_reassembly_complete(struct smp_transport *zst, bool force)
 {
 	if (zst->__reassembly.current == NULL) {
 		return -EINVAL;
@@ -89,7 +89,7 @@ int zephyr_smp_reassembly_complete(struct zephyr_smp_transport *zst, bool force)
 	if (zst->__reassembly.expected == 0 || force) {
 		int expected = zst->__reassembly.expected;
 
-		zephyr_smp_rx_req(zst, zst->__reassembly.current);
+		smp_rx_req(zst, zst->__reassembly.current);
 		zst->__reassembly.expected = 0;
 		zst->__reassembly.current = NULL;
 		return expected;
@@ -97,7 +97,7 @@ int zephyr_smp_reassembly_complete(struct zephyr_smp_transport *zst, bool force)
 	return -ENODATA;
 }
 
-int zephyr_smp_reassembly_drop(struct zephyr_smp_transport *zst)
+int smp_reassembly_drop(struct smp_transport *zst)
 {
 	if (zst->__reassembly.current == NULL) {
 		return -EINVAL;
@@ -110,7 +110,7 @@ int zephyr_smp_reassembly_drop(struct zephyr_smp_transport *zst)
 	return 0;
 }
 
-void *zephyr_smp_reassembly_get_ud(const struct zephyr_smp_transport *zst)
+void *smp_reassembly_get_ud(const struct smp_transport *zst)
 {
 	if (zst->__reassembly.current != NULL) {
 		return net_buf_user_data(zst->__reassembly.current);

--- a/subsys/mgmt/mcumgr/smp_reassembly.h
+++ b/subsys/mgmt/mcumgr/smp_reassembly.h
@@ -16,12 +16,12 @@ struct smp_transport;
 /**
  * Initialize re-assembly context within smp_transport
  *
- * @param zst	the SMP transport.
+ * @param smpt	the SMP transport.
  *
- * Note: for efficiency there is no NULL check on @p zst pointer and it is caller's responsibility
+ * Note: for efficiency there is no NULL check on @p smpt pointer and it is caller's responsibility
  * to validate the pointer before passing it to this function.
  */
-void smp_reassembly_init(struct smp_transport *zst);
+void smp_reassembly_init(struct smp_transport *smpt);
 
 /**
  * Collect data to re-assembly buffer
@@ -32,11 +32,11 @@ void smp_reassembly_init(struct smp_transport *zst);
  * Note: Currently the function is not able to concatenate buffers so re-assembled packet needs
  * to fit into one buffer.
  *
- * @param zst	the SMP transport;
+ * @param smpt	the SMP transport;
  * @param buf	buffer with data to add;
  * @param len	length of data to add;
  *
- * Note: For efficiency there are ot NULL checks on @p zst and @p buf pointers and it is caller's
+ * Note: For efficiency there are ot NULL checks on @p smpt and @p buf pointers and it is caller's
  * responsibility to make sure these are not NULL.  Also @p len should not be 0 as there is no
  * point in passing an empty fragment for re-assembly.
  *
@@ -50,35 +50,35 @@ void smp_reassembly_init(struct smp_transport *zst);
  *		-ENODATA if the first received fragment was not big enough to figure out a size
  *		of the packet; MTU is set too low;
  */
-int smp_reassembly_collect(struct smp_transport *zst, const void *buf, uint16_t len);
+int smp_reassembly_collect(struct smp_transport *smpt, const void *buf, uint16_t len);
 
 /**
  * Return number of expected bytes to complete the packet
  *
- * @param zst	the SMP transport;
+ * @param smpt	the SMP transport;
  *
- * Note: for efficiency there is no NULL check on @p zst pointer and it is caller's responsibility
+ * Note: for efficiency there is no NULL check on @p smpt pointer and it is caller's responsibility
  * to validate the pointer before passing it to this function.
  *
  * @return	number of bytes needed to complete the packet;
  *		-EINVAL if there is no packet in re-assembly;
  */
-int smp_reassembly_expected(const struct smp_transport *zst);
+int smp_reassembly_expected(const struct smp_transport *smpt);
 
 /**
  * Pass packet for further processing
  *
  * Checks if the packet has enough data to be re-assembled and passes it for further processing.
- * If successful then the re-assembly context in @p zst will indicate that there is no
+ * If successful then the re-assembly context in @p smpt will indicate that there is no
  * re-assembly in progress.
  * The function can be forced to pass a data for processing even if the packet is not complete,
  * in which case it is users responsibility to use the user data, passed with the packet, to notify
  * receiving end of such case.
  *
- * @param zst	the SMP transport;
+ * @param smpt	the SMP transport;
  * @param force	process anyway;
  *
- * Note: for efficiency there is no NULL check on @p zst pointer and it is caller's responsibility
+ * Note: for efficiency there is no NULL check on @p smpt pointer and it is caller's responsibility
  * to validate the pointer before passing it to this function.
  *
  * @return	0 on success and not forced;
@@ -87,33 +87,33 @@ int smp_reassembly_expected(const struct smp_transport *zst);
  *		-ENODATA if there is not enough data to consider packet re-assembled, it has not
  *		been passed further.
  */
-int smp_reassembly_complete(struct smp_transport *zst, bool force);
+int smp_reassembly_complete(struct smp_transport *smpt, bool force);
 
 /**
  * Drop packet and release buffer
  *
- * @param zst	the SMP transport;
+ * @param smpt	the SMP transport;
  *
- * Note: for efficiency there is no NULL check on @p zst pointer and it is caller's responsibility
+ * Note: for efficiency there is no NULL check on @p smpt pointer and it is caller's responsibility
  * to validate the pointer before passing it to this function.
  *
  * @return	0 on success;
  *		-EINVAL if there is no re-assembly in progress.
  */
-int smp_reassembly_drop(struct smp_transport *zst);
+int smp_reassembly_drop(struct smp_transport *smpt);
 
 /**
  * Get "user data" pointer for current packet re-assembly
  *
- * @param zst	the SMP transport;
+ * @param smpt	the SMP transport;
  *
- * Note: for efficiency there is no NULL check on @p zst pointer and it is caller's responsibility
+ * Note: for efficiency there is no NULL check on @p smpt pointer and it is caller's responsibility
  * to validate the pointer before passing it to this function.
  *
  * @return	pointer to "user data" of CONFIG_MCUMGR_BUF_USER_DATA_SIZE size;
  *		NULL if no re-assembly in progress.
  */
-void *smp_reassembly_get_ud(const struct smp_transport *zst);
+void *smp_reassembly_get_ud(const struct smp_transport *smpt);
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/smp_reassembly.h
+++ b/subsys/mgmt/mcumgr/smp_reassembly.h
@@ -11,17 +11,17 @@
 extern "C" {
 #endif
 
-struct zephyr_smp_transport;
+struct smp_transport;
 
 /**
- * Initialize re-assembly context within zephyr_smp_transport
+ * Initialize re-assembly context within smp_transport
  *
  * @param zst	the SMP transport.
  *
  * Note: for efficiency there is no NULL check on @p zst pointer and it is caller's responsibility
  * to validate the pointer before passing it to this function.
  */
-void zephyr_smp_reassembly_init(struct zephyr_smp_transport *zst);
+void smp_reassembly_init(struct smp_transport *zst);
 
 /**
  * Collect data to re-assembly buffer
@@ -50,7 +50,7 @@ void zephyr_smp_reassembly_init(struct zephyr_smp_transport *zst);
  *		-ENODATA if the first received fragment was not big enough to figure out a size
  *		of the packet; MTU is set too low;
  */
-int zephyr_smp_reassembly_collect(struct zephyr_smp_transport *zst, const void *buf, uint16_t len);
+int smp_reassembly_collect(struct smp_transport *zst, const void *buf, uint16_t len);
 
 /**
  * Return number of expected bytes to complete the packet
@@ -63,7 +63,7 @@ int zephyr_smp_reassembly_collect(struct zephyr_smp_transport *zst, const void *
  * @return	number of bytes needed to complete the packet;
  *		-EINVAL if there is no packet in re-assembly;
  */
-int zephyr_smp_reassembly_expected(const struct zephyr_smp_transport *zst);
+int smp_reassembly_expected(const struct smp_transport *zst);
 
 /**
  * Pass packet for further processing
@@ -87,7 +87,7 @@ int zephyr_smp_reassembly_expected(const struct zephyr_smp_transport *zst);
  *		-ENODATA if there is not enough data to consider packet re-assembled, it has not
  *		been passed further.
  */
-int zephyr_smp_reassembly_complete(struct zephyr_smp_transport *zst, bool force);
+int smp_reassembly_complete(struct smp_transport *zst, bool force);
 
 /**
  * Drop packet and release buffer
@@ -100,7 +100,7 @@ int zephyr_smp_reassembly_complete(struct zephyr_smp_transport *zst, bool force)
  * @return	0 on success;
  *		-EINVAL if there is no re-assembly in progress.
  */
-int zephyr_smp_reassembly_drop(struct zephyr_smp_transport *zst);
+int smp_reassembly_drop(struct smp_transport *zst);
 
 /**
  * Get "user data" pointer for current packet re-assembly
@@ -113,7 +113,7 @@ int zephyr_smp_reassembly_drop(struct zephyr_smp_transport *zst);
  * @return	pointer to "user data" of CONFIG_MCUMGR_BUF_USER_DATA_SIZE size;
  *		NULL if no re-assembly in progress.
  */
-void *zephyr_smp_reassembly_get_ud(const struct zephyr_smp_transport *zst);
+void *smp_reassembly_get_ud(const struct smp_transport *zst);
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/transport/smp_dummy.c
+++ b/subsys/mgmt/mcumgr/transport/smp_dummy.c
@@ -33,7 +33,7 @@ BUILD_ASSERT(CONFIG_MCUMGR_SMP_DUMMY_RX_BUF_SIZE != 0,
 struct device;
 static struct mcumgr_serial_rx_ctxt smp_dummy_rx_ctxt;
 static struct mcumgr_serial_rx_ctxt smp_dummy_tx_ctxt;
-static struct zephyr_smp_transport smp_dummy_transport;
+static struct smp_transport smp_dummy_transport;
 static bool enable_dummy_smp;
 static struct k_sem smp_data_ready_sem;
 static uint8_t smp_send_buffer[CONFIG_MCUMGR_SMP_DUMMY_RX_BUF_SIZE];
@@ -102,7 +102,7 @@ static void smp_dummy_process_frag(struct uart_mcumgr_rx_buf *rx_buf)
 	 * processing.
 	 */
 	if (nb != NULL) {
-		zephyr_smp_rx_req(&smp_dummy_transport, nb);
+		smp_rx_req(&smp_dummy_transport, nb);
 	}
 }
 
@@ -189,8 +189,8 @@ static int smp_dummy_init(const struct device *dev)
 
 	k_sem_init(&smp_data_ready_sem, 0, 1);
 
-	zephyr_smp_transport_init(&smp_dummy_transport, smp_dummy_tx_pkt_int,
-				  smp_dummy_get_mtu, NULL, NULL);
+	smp_transport_init(&smp_dummy_transport, smp_dummy_tx_pkt_int,
+			   smp_dummy_get_mtu, NULL, NULL);
 	dummy_mgumgr_recv_cb = smp_dummy_rx_frag;
 
 	return 0;

--- a/subsys/mgmt/mcumgr/transport/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/smp_shell.c
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(smp_shell);
 
 BUILD_ASSERT(CONFIG_MCUMGR_SMP_SHELL_MTU != 0, "CONFIG_MCUMGR_SMP_SHELL_MTU must be > 0");
 
-static struct zephyr_smp_transport smp_shell_transport;
+static struct smp_transport smp_shell_transport;
 
 static struct mcumgr_serial_rx_ctxt smp_shell_rx_ctxt;
 
@@ -150,7 +150,7 @@ void smp_shell_process(struct smp_shell_data *data)
 						buf->data,
 						buf->len);
 		if (nb != NULL) {
-			zephyr_smp_rx_req(&smp_shell_transport, nb);
+			smp_rx_req(&smp_shell_transport, nb);
 		}
 
 		net_buf_unref(buf);
@@ -190,8 +190,8 @@ static int smp_shell_tx_pkt(struct net_buf *nb)
 
 int smp_shell_init(void)
 {
-	zephyr_smp_transport_init(&smp_shell_transport, smp_shell_tx_pkt,
-				  smp_shell_get_mtu, NULL, NULL);
+	smp_transport_init(&smp_shell_transport, smp_shell_tx_pkt,
+			   smp_shell_get_mtu, NULL, NULL);
 
 	return 0;
 }

--- a/subsys/mgmt/mcumgr/transport/smp_uart.c
+++ b/subsys/mgmt/mcumgr/transport/smp_uart.c
@@ -29,7 +29,7 @@ K_FIFO_DEFINE(smp_uart_rx_fifo);
 K_WORK_DEFINE(smp_uart_work, smp_uart_process_rx_queue);
 
 static struct mcumgr_serial_rx_ctxt smp_uart_rx_ctxt;
-static struct zephyr_smp_transport smp_uart_transport;
+static struct smp_transport smp_uart_transport;
 
 /**
  * Processes a single line (fragment) coming from the mcumgr UART driver.
@@ -51,7 +51,7 @@ static void smp_uart_process_frag(struct uart_mcumgr_rx_buf *rx_buf)
 	 * processing.
 	 */
 	if (nb != NULL) {
-		zephyr_smp_rx_req(&smp_uart_transport, nb);
+		smp_rx_req(&smp_uart_transport, nb);
 	}
 }
 
@@ -93,8 +93,8 @@ static int smp_uart_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	zephyr_smp_transport_init(&smp_uart_transport, smp_uart_tx_pkt,
-				  smp_uart_get_mtu, NULL, NULL);
+	smp_transport_init(&smp_uart_transport, smp_uart_tx_pkt,
+			   smp_uart_get_mtu, NULL, NULL);
 	uart_mcumgr_register(smp_uart_rx_frag);
 
 	return 0;

--- a/subsys/mgmt/mcumgr/transport/smp_udp.c
+++ b/subsys/mgmt/mcumgr/transport/smp_udp.c
@@ -33,7 +33,7 @@ BUILD_ASSERT(CONFIG_MCUMGR_SMP_UDP_MTU != 0, "CONFIG_MCUMGR_SMP_UDP_MTU must be 
 struct config {
 	int sock;
 	const char *proto;
-	struct zephyr_smp_transport smp_transport;
+	struct smp_transport smp_transport;
 	char recv_buffer[CONFIG_MCUMGR_SMP_UDP_MTU];
 	struct k_thread thread;
 	K_KERNEL_STACK_MEMBER(stack, CONFIG_MCUMGR_SMP_UDP_STACK_SIZE);
@@ -152,7 +152,7 @@ static void smp_udp_receive_thread(void *p1, void *p2, void *p3)
 			ud = net_buf_user_data(nb);
 			net_ipaddr_copy(ud, &addr);
 
-			zephyr_smp_rx_req(&conf->smp_transport, nb);
+			smp_rx_req(&conf->smp_transport, nb);
 		} else if (len < 0) {
 			LOG_ERR("recvfrom error (%s): %i", conf->proto, errno);
 		}
@@ -164,15 +164,15 @@ static int smp_udp_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 #ifdef CONFIG_MCUMGR_SMP_UDP_IPV4
-	zephyr_smp_transport_init(&configs.ipv4.smp_transport,
-				  smp_udp4_tx, smp_udp_get_mtu,
-				  smp_udp_ud_copy, NULL);
+	smp_transport_init(&configs.ipv4.smp_transport,
+			   smp_udp4_tx, smp_udp_get_mtu,
+			   smp_udp_ud_copy, NULL);
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_UDP_IPV6
-	zephyr_smp_transport_init(&configs.ipv6.smp_transport,
-				  smp_udp6_tx, smp_udp_get_mtu,
-				  smp_udp_ud_copy, NULL);
+	smp_transport_init(&configs.ipv6.smp_transport,
+			   smp_udp6_tx, smp_udp_get_mtu,
+			   smp_udp_ud_copy, NULL);
 #endif
 
 	return MGMT_ERR_EOK;

--- a/tests/subsys/mgmt/mcumgr/smp_reassembly/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/smp_reassembly/src/main.c
@@ -12,25 +12,25 @@
 #include <mgmt/mgmt.h>
 #include "../../../../../../subsys/mgmt/mcumgr/smp_reassembly.h"
 
-static struct zephyr_smp_transport zst;
+static struct smp_transport smpt;
 static uint8_t buff[CONFIG_MCUMGR_BUF_SIZE];
 #define TEST_FRAME_SIZE 256
 
 static struct net_buf *backup;
 
-/* The function is called by zephyr_smp_reassembly_complete to pass a completed packet
+/* The function is called by smp_reassembly_complete to pass a completed packet
  * for further processing; since there is nothing to process, this stub will only backup
  * buffer the pointer to allow a test case to free it with use of the mcumgr net_buf
  * management.
  */
-void zephyr_smp_rx_req(struct zephyr_smp_transport *zst, struct net_buf *nb)
+void smp_rx_req(struct smp_transport *smpt, struct net_buf *nb)
 {
 	backup = nb;
 }
 
 ZTEST(smp_reassembly, test_first)
 {
-	zephyr_smp_reassembly_init(&zst);
+	smp_reassembly_init(&smpt);
 	struct mgmt_hdr *mh = (struct mgmt_hdr *)buff;
 	int frag_used;
 	int ret;
@@ -38,35 +38,35 @@ ZTEST(smp_reassembly, test_first)
 
 	/** First fragment errors **/
 	/* Len longer than netbuf error */
-	zassert_equal(-ENOSR, zephyr_smp_reassembly_collect(&zst, buff, CONFIG_MCUMGR_BUF_SIZE + 1),
+	zassert_equal(-ENOSR, smp_reassembly_collect(&smpt, buff, CONFIG_MCUMGR_BUF_SIZE + 1),
 		      "Expected -ENOSR error");
 	/* Len not enough to read expected size from header */
 	zassert_equal(-ENODATA,
-		      zephyr_smp_reassembly_collect(&zst, buff, sizeof(struct mgmt_hdr) - 1),
+		      smp_reassembly_collect(&smpt, buff, sizeof(struct mgmt_hdr) - 1),
 		      "Expected -ENODATA error");
 	/* Length extracted from header, plus size of header, is bigger than buffer */
 	mh->nh_len = sys_cpu_to_be16(CONFIG_MCUMGR_BUF_SIZE - sizeof(struct mgmt_hdr) + 1);
 	zassert_equal(-ENOSR,
-		      zephyr_smp_reassembly_collect(&zst, buff, sizeof(struct mgmt_hdr) + 1),
+		      smp_reassembly_collect(&smpt, buff, sizeof(struct mgmt_hdr) + 1),
 		      "Expected -ENOSR error");
 
 	/* Successfully alloc buffer */
 	mh->nh_len = sys_cpu_to_be16(TEST_FRAME_SIZE - sizeof(struct mgmt_hdr));
 	frag_used = 40;
 	expected = TEST_FRAME_SIZE - frag_used;
-	ret = zephyr_smp_reassembly_collect(&zst, buff, frag_used);
+	ret = smp_reassembly_collect(&smpt, buff, frag_used);
 	zassert_equal(expected, ret,
 		      "Expected is %d should be %d\n", ret, expected);
 
 	/* Force complete it, expected returned number of bytes missing */
-	ret = zephyr_smp_reassembly_complete(&zst, true);
+	ret = smp_reassembly_complete(&smpt, true);
 	zassert_equal(expected, ret,
 		      "Forced completion ret %d, but expected was %d\n", ret, expected);
 
 	/* Check fail due to lack of buffers: there is only one buffer and it already got passed
 	 * for processing by complete
 	 */
-	ret = zephyr_smp_reassembly_collect(&zst, buff, frag_used);
+	ret = smp_reassembly_collect(&smpt, buff, frag_used);
 	zassert_equal(-ENOMEM, ret,
 		      "Expected is %d should be %d\n", ret, expected);
 
@@ -88,11 +88,11 @@ ZTEST(smp_reassembly, test_drops)
 	mh->nh_len = sys_cpu_to_be16(TEST_FRAME_SIZE - sizeof(struct mgmt_hdr));
 	frag_used = 40;
 	expected = TEST_FRAME_SIZE - frag_used;
-	ret = zephyr_smp_reassembly_collect(&zst, buff, frag_used);
+	ret = smp_reassembly_collect(&smpt, buff, frag_used);
 	zassert_equal(expected, ret,
 		      "Expected is %d should be %d\n", ret, expected);
 
-	ret = zephyr_smp_reassembly_drop(&zst);
+	ret = smp_reassembly_drop(&smpt);
 	zassert_equal(0, ret,
 		      "Expected %d from drop, got %d", ret, expected);
 }
@@ -114,7 +114,7 @@ ZTEST(smp_reassembly, test_collection)
 	/* First fragment with header */
 	mh->nh_len = sys_cpu_to_be16(TEST_FRAME_SIZE - sizeof(struct mgmt_hdr));
 	frag = 40;
-	ret = zephyr_smp_reassembly_collect(&zst, buff, frag);
+	ret = smp_reassembly_collect(&smpt, buff, frag);
 	expected = TEST_FRAME_SIZE - frag;
 	zassert_equal(expected, ret,
 		      "Expected is %d should be %d\n", ret, expected);
@@ -122,29 +122,29 @@ ZTEST(smp_reassembly, test_collection)
 
 	/* Next fragment */
 	frag = 40;
-	ret = zephyr_smp_reassembly_collect(&zst, &buff[pkt_used], frag);
+	ret = smp_reassembly_collect(&smpt, &buff[pkt_used], frag);
 	pkt_used += frag;
 	expected = TEST_FRAME_SIZE - pkt_used;
 	zassert_equal(expected, ret,
 		      "Expected is %d should be %d\n", ret, expected);
 
 	/* Try to complete incomplete, no force */
-	ret = zephyr_smp_reassembly_complete(&zst, false);
+	ret = smp_reassembly_complete(&smpt, false);
 	zassert_equal(-ENODATA, ret,
 		      "Expected -ENODATA when completing incomplete buffer");
 
 	/* Last fragment */
-	ret = zephyr_smp_reassembly_collect(&zst, &buff[pkt_used], expected);
+	ret = smp_reassembly_collect(&smpt, &buff[pkt_used], expected);
 	zassert_equal(0, ret,
 		      "Expected is %d should be %d\n", ret, 0);
 
 	/* And overflow */
-	ret = zephyr_smp_reassembly_collect(&zst, buff, 1);
+	ret = smp_reassembly_collect(&smpt, buff, 1);
 	zassert_equal(-EOVERFLOW, ret,
 		      "Expected -EOVERFLOW, got %d\n", ret);
 
 	/* Complete successfully complete buffer */
-	ret = zephyr_smp_reassembly_complete(&zst, false);
+	ret = smp_reassembly_complete(&smpt, false);
 	zassert_equal(0, ret,
 		      "Expected 0 from complete, got %d\n", ret);
 
@@ -164,15 +164,15 @@ ZTEST(smp_reassembly, test_no_packet_started)
 	int ret;
 
 	/** Complete on non-started packet **/
-	ret = zephyr_smp_reassembly_complete(&zst, false);
+	ret = smp_reassembly_complete(&smpt, false);
 	zassert_equal(-EINVAL, ret,
 		      "Expected -EINVAL from complete, got %d", ret);
-	ret = zephyr_smp_reassembly_complete(&zst, true);
+	ret = smp_reassembly_complete(&smpt, true);
 	zassert_equal(-EINVAL, ret,
 		      "Expected -EINVAL from complete, got %d", ret);
 
 	/* Try to drop packet when there is none yet */
-	ret = zephyr_smp_reassembly_drop(&zst);
+	ret = smp_reassembly_drop(&smpt);
 	zassert_equal(-EINVAL, ret,
 		      "Expected -EINVAL, there is no packet started yet");
 }
@@ -186,20 +186,20 @@ ZTEST(smp_reassembly, test_ud)
 	void *p;
 
 	/* No packet started yet */
-	p = zephyr_smp_reassembly_get_ud(&zst);
+	p = smp_reassembly_get_ud(&smpt);
 	zassert_equal(p, NULL, "Expect NULL ud poiner");
 
 	/* After collecting first fragment */
 	mh->nh_len = sys_cpu_to_be16(TEST_FRAME_SIZE);
 	frag_used = 40;
 	expected = TEST_FRAME_SIZE - frag_used + sizeof(struct mgmt_hdr);
-	ret = zephyr_smp_reassembly_collect(&zst, buff, frag_used);
+	ret = smp_reassembly_collect(&smpt, buff, frag_used);
 	zassert_equal(expected, ret,
 		      "Expected is %d should be %d\n", ret, expected);
 
-	p = zephyr_smp_reassembly_get_ud(&zst);
+	p = smp_reassembly_get_ud(&smpt);
 	zassert_not_equal(p, NULL, "Expect non-NULL ud poiner");
-	zephyr_smp_reassembly_drop(&zst);
+	smp_reassembly_drop(&smpt);
 }
 
 ZTEST_SUITE(smp_reassembly, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
The MCUMgr library is now part of Zephyr, so there is no point
to prefix SMP functions with Zephyr.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Closes: https://github.com/zephyrproject-rtos/zephyr/issues/49962

~~DNM until dependency https://github.com/zephyrproject-rtos/zephyr/pull/50904 is merged.~~

