### PR TITLE
lib: os: cbprintf: Renamed flags used for conversion function

### DIFF
--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -177,7 +177,7 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
 
 /**@} */
 
-/**@defgroup CBPRINTF_PACKAGE_COPY_FLAGS Package flags.
+/**@defgroup CBPRINTF_PACKAGE_CONVERT_FLAGS Package flags.
  * @{
  */
 
@@ -189,7 +189,8 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
  * are copied into destination package. Address of strings indicated as read-write
  * are also checked and if determined to be read-only they are also copied.
  */
-#define CBPRINTF_PACKAGE_COPY_RO_STR BIT(0)
+#define CBPRINTF_PACKAGE_CONVERT_RO_STR BIT(0)
+#define CBPRINTF_PACKAGE_COPY_RO_STR CBPRINTF_PACKAGE_CONVERT_RO_STR __DEPRECATED_MACRO
 
 /** @brief Append read-write strings from source package to destination package.
  *
@@ -197,18 +198,20 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
  * arrays of indexes where string address can be found in the package. When flag
  * is set, list of read-write strings is examined and if they are not determined
  * to be read-only, they are copied into the destination package.
- * If @ref CBPRINTF_PACKAGE_COPY_RO_STR is not set, remaining string locations
+ * If @ref CBPRINTF_PACKAGE_CONVERT_RO_STR is not set, remaining string locations
  * are considered as pointing to read-only location and they are copy to the
- * package if @ref CBPRINTF_PACKAGE_COPY_KEEP_RO_STR is set.
+ * package if @ref CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR is set.
  */
-#define CBPRINTF_PACKAGE_COPY_RW_STR BIT(1)
+#define CBPRINTF_PACKAGE_CONVERT_RW_STR BIT(1)
+#define CBPRINTF_PACKAGE_COPY_RW_STR CBPRINTF_PACKAGE_CONVERT_RW_STR __DEPRECATED_MACRO
 
 /** @brief Keep read-only location indexes in the package.
  *
  * If it is set read-only string pointers are kept in the package after copy. If
  * not set they are discarded.
  */
-#define CBPRINTF_PACKAGE_COPY_KEEP_RO_STR BIT(2)
+#define CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR BIT(2)
+#define CBPRINTF_PACKAGE_COPY_KEEP_RO_STR CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR __DEPRECATED_MACRO
 
 /**@} */
 
@@ -443,7 +446,7 @@ int cbvprintf_package(void *packaged,
  *
  * @param ctx Context provided to the @p cb.
  *
- * @param flags Flags. See @ref CBPRINTF_PACKAGE_COPY_FLAGS.
+ * @param flags Flags. See @ref CBPRINTF_PACKAGE_CONVERT_FLAGS.
  *
  * @param[in, out] strl if @p packaged is null, it is a pointer to the array where
  * @p strl_len first string lengths will is stored. If @p packaged is not null,
@@ -503,7 +506,7 @@ static inline int z_cbprintf_cpy(const void *buf, size_t len, void *ctx)
  * @param len Available space in the location pointed by @p packaged. Not used when
  * @p packaged is null.
  *
- * @param flags Flags. See @ref CBPRINTF_PACKAGE_COPY_FLAGS.
+ * @param flags Flags. See @ref CBPRINTF_PACKAGE_CONVERT_FLAGS.
  *
  * @param[in, out] strl if @p packaged is null, it is a pointer to the array where
  * @p strl_len first string lengths will is stored. If @p packaged is not null,
@@ -571,8 +574,8 @@ static inline int cbprintf_fsc_package(void *in_packaged,
 				       size_t len)
 {
 	return cbprintf_package_copy(in_packaged, in_len, packaged, len,
-				     CBPRINTF_PACKAGE_COPY_RO_STR |
-				     CBPRINTF_PACKAGE_COPY_RW_STR, NULL, 0);
+				     CBPRINTF_PACKAGE_CONVERT_RO_STR |
+				     CBPRINTF_PACKAGE_CONVERT_RW_STR, NULL, 0);
 }
 
 /** @brief Generate the output for a previously captured format

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -876,14 +876,14 @@ int cbprintf_package_convert(void *in_packaged,
 	 */
 	ros_nbr = in_desc->ro_str_cnt;
 	ro_cpy = ros_nbr &&
-		(flags & CBPRINTF_PACKAGE_COPY_RO_STR) == CBPRINTF_PACKAGE_COPY_RO_STR;
+		(flags & CBPRINTF_PACKAGE_CONVERT_RO_STR) == CBPRINTF_PACKAGE_CONVERT_RO_STR;
 
 	/* Get number of RW string indexes in the package and check if copying
 	 * includes appending those strings.
 	 */
 	rws_nbr = in_desc->rw_str_cnt;
 	rw_cpy = rws_nbr > 0 &&
-		 (flags & CBPRINTF_PACKAGE_COPY_RW_STR) == CBPRINTF_PACKAGE_COPY_RW_STR;
+		 (flags & CBPRINTF_PACKAGE_CONVERT_RW_STR) == CBPRINTF_PACKAGE_CONVERT_RW_STR;
 
 	/* If flags are not set or appending request without rw string indexes
 	 * present is chosen, just do a simple copy (or length calculation).
@@ -927,22 +927,22 @@ int cbprintf_package_convert(void *in_packaged,
 				str_pos++;
 			}
 		} else {
-			if (ros_nbr && flags & CBPRINTF_PACKAGE_COPY_KEEP_RO_STR) {
+			if (ros_nbr && flags & CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR) {
 				str_pos += ros_nbr;
 			}
 		}
 
 		bool drop_ro_str_pos = !(flags &
-					(CBPRINTF_PACKAGE_COPY_KEEP_RO_STR |
-					 CBPRINTF_PACKAGE_COPY_RO_STR));
+					(CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR |
+					 CBPRINTF_PACKAGE_CONVERT_RO_STR));
 
 		/* Handle RW strings. */
 		for (int i = 0; i < rws_nbr; i++) {
 			const char *str = *(const char **)&buf32[*str_pos];
 			bool is_ro = ptr_in_rodata(str);
 
-			if ((is_ro && flags & CBPRINTF_PACKAGE_COPY_RO_STR) ||
-			    (!is_ro && flags & CBPRINTF_PACKAGE_COPY_RW_STR)) {
+			if ((is_ro && flags & CBPRINTF_PACKAGE_CONVERT_RO_STR) ||
+			    (!is_ro && flags & CBPRINTF_PACKAGE_CONVERT_RW_STR)) {
 				int len = append_string(cb, NULL, str, 0);
 
 				/* If possible store calculated string length. */
@@ -983,7 +983,7 @@ int cbprintf_package_convert(void *in_packaged,
 		scpy_cnt = ros_nbr;
 		keep_cnt = 0;
 		dst = cpy_str_pos;
-	} else if (ros_nbr && flags & CBPRINTF_PACKAGE_COPY_KEEP_RO_STR) {
+	} else if (ros_nbr && flags & CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR) {
 		scpy_cnt = 0;
 		keep_cnt = ros_nbr;
 		dst = keep_str_pos;
@@ -1006,17 +1006,17 @@ int cbprintf_package_convert(void *in_packaged,
 		bool is_ro = ptr_in_rodata(str);
 
 		if (is_ro) {
-			if (flags & CBPRINTF_PACKAGE_COPY_RO_STR) {
+			if (flags & CBPRINTF_PACKAGE_CONVERT_RO_STR) {
 				__ASSERT_NO_MSG(scpy_cnt < sizeof(cpy_str_pos));
 				cpy_str_pos[scpy_cnt++] = *str_pos;
-			} else if (flags & CBPRINTF_PACKAGE_COPY_KEEP_RO_STR) {
+			} else if (flags & CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR) {
 				__ASSERT_NO_MSG(keep_cnt < sizeof(keep_str_pos));
 				keep_str_pos[keep_cnt++] = *str_pos;
 			} else {
 				/* Drop information about ro_str location. */
 			}
 		} else {
-			if (flags & CBPRINTF_PACKAGE_COPY_RW_STR) {
+			if (flags & CBPRINTF_PACKAGE_CONVERT_RW_STR) {
 				__ASSERT_NO_MSG(scpy_cnt < sizeof(cpy_str_pos));
 				cpy_str_pos[scpy_cnt++] = *str_pos;
 			} else {
@@ -1030,9 +1030,9 @@ int cbprintf_package_convert(void *in_packaged,
 	/* Set amount of strings appended to the package. */
 	out_desc.len = in_desc->len;
 	out_desc.str_cnt = in_desc->str_cnt + scpy_cnt;
-	out_desc.rw_str_cnt = (flags & CBPRINTF_PACKAGE_COPY_RW_STR) ? 0 : keep_cnt;
-	out_desc.ro_str_cnt = (flags & CBPRINTF_PACKAGE_COPY_RO_STR) ? 0 :
-			((flags & CBPRINTF_PACKAGE_COPY_KEEP_RO_STR) ? keep_cnt : 0);
+	out_desc.rw_str_cnt = (flags & CBPRINTF_PACKAGE_CONVERT_RW_STR) ? 0 : keep_cnt;
+	out_desc.ro_str_cnt = (flags & CBPRINTF_PACKAGE_CONVERT_RO_STR) ? 0 :
+			((flags & CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR) ? keep_cnt : 0);
 
 	/* Temporary overwrite input descriptor to allow bulk transfer */
 	struct cbprintf_package_desc in_desc_backup = *in_desc;

--- a/subsys/logging/log_frontend_dict_uart.c
+++ b/subsys/logging/log_frontend_dict_uart.c
@@ -263,7 +263,7 @@ void log_frontend_msg(const void *source,
 	uint16_t strl[4];
 	struct log_msg_desc outdesc = desc;
 	int plen = cbprintf_package_copy(package, desc.package_len, NULL, 0,
-					 CBPRINTF_PACKAGE_COPY_RW_STR,
+					 CBPRINTF_PACKAGE_CONVERT_RW_STR,
 					 strl, ARRAY_SIZE(strl));
 	size_t dlen = desc.data_len;
 	bool dev_ready = device_is_ready(dev);
@@ -293,7 +293,7 @@ void log_frontend_msg(const void *source,
 
 	plen = cbprintf_package_copy(package, desc.package_len,
 				     pkt->data, plen,
-				     CBPRINTF_PACKAGE_COPY_RW_STR,
+				     CBPRINTF_PACKAGE_CONVERT_RW_STR,
 				     strl, ARRAY_SIZE(strl));
 	if (plen < 0) {
 		/* error */

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -52,7 +52,7 @@ void z_impl_z_log_msg_static_create(const void *source,
 	struct log_msg *msg;
 
 	if (inlen > 0) {
-		uint32_t flags = CBPRINTF_PACKAGE_COPY_RW_STR;
+		uint32_t flags = CBPRINTF_PACKAGE_CONVERT_RW_STR;
 		uint16_t strl[4];
 		int len;
 

--- a/tests/lib/cbprintf_package/src/main.c
+++ b/tests/lib/cbprintf_package/src/main.c
@@ -361,7 +361,7 @@ ZTEST(cbprintf_package, test_cbprintf_ro_loc)
 
 	/* Calculate size needed for package with appended read-only strings. */
 	clen = cbprintf_package_copy(package, sizeof(package), NULL, 0,
-				     CBPRINTF_PACKAGE_COPY_RO_STR, NULL, 0);
+				     CBPRINTF_PACKAGE_CONVERT_RO_STR, NULL, 0);
 
 	/* Length will be increased by string length + null terminator. */
 	zassert_equal(clen, len + (int)strlen(test_str) + 1, NULL);
@@ -369,7 +369,7 @@ ZTEST(cbprintf_package, test_cbprintf_ro_loc)
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) cpackage[clen];
 
 	int clen2 = cbprintf_package_copy(package, sizeof(package), cpackage, sizeof(cpackage),
-				     CBPRINTF_PACKAGE_COPY_RO_STR, NULL, 0);
+				     CBPRINTF_PACKAGE_CONVERT_RO_STR, NULL, 0);
 
 	zassert_equal(clen, clen2, NULL);
 
@@ -425,7 +425,7 @@ ZTEST(cbprintf_package, test_cbprintf_ro_loc_rw_present)
 
 	/* Calculate size needed for package with appended read-only strings. */
 	clen = cbprintf_package_copy(package, sizeof(package), NULL, 0,
-				     CBPRINTF_PACKAGE_COPY_RO_STR, NULL, 0);
+				     CBPRINTF_PACKAGE_CONVERT_RO_STR, NULL, 0);
 
 	/* Length will be increased by string length + null terminator. */
 	zassert_equal(clen, len + (int)strlen(test_str) + 1, NULL);
@@ -433,7 +433,7 @@ ZTEST(cbprintf_package, test_cbprintf_ro_loc_rw_present)
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) cpackage[clen];
 
 	int clen2 = cbprintf_package_copy(package, sizeof(package), cpackage, sizeof(cpackage),
-				     CBPRINTF_PACKAGE_COPY_RO_STR, NULL, 0);
+				     CBPRINTF_PACKAGE_CONVERT_RO_STR, NULL, 0);
 
 	zassert_equal(clen, clen2, NULL);
 
@@ -510,7 +510,7 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc)
 
 	/* Calculate size needed for package with appended read-only strings. */
 	clen = cbprintf_package_copy(package, sizeof(package), NULL, 0,
-				     CBPRINTF_PACKAGE_COPY_RO_STR, strl, ARRAY_SIZE(strl));
+				     CBPRINTF_PACKAGE_CONVERT_RO_STR, strl, ARRAY_SIZE(strl));
 
 	/* Length will be increased by 2 string lengths + null terminators. */
 	zassert_equal(clen, len + (int)strlen(test_str) + (int)strlen(cstr) + 2, NULL);
@@ -520,7 +520,7 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc)
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) cpackage[clen];
 
 	int clen2 = cbprintf_package_copy(package, sizeof(package), cpackage, sizeof(cpackage),
-				     CBPRINTF_PACKAGE_COPY_RO_STR, strl, ARRAY_SIZE(strl));
+				     CBPRINTF_PACKAGE_CONVERT_RO_STR, strl, ARRAY_SIZE(strl));
 
 	zassert_equal(clen, clen2, NULL);
 
@@ -534,8 +534,8 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc)
 	check_package(package, len, exp_str);
 	check_package(cpackage, clen, exp_str);
 
-	uint32_t cpy_flags = CBPRINTF_PACKAGE_COPY_RW_STR |
-			     CBPRINTF_PACKAGE_COPY_KEEP_RO_STR;
+	uint32_t cpy_flags = CBPRINTF_PACKAGE_CONVERT_RW_STR |
+			     CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR;
 
 	/* Calculate size needed for package with appended read-write strings. */
 	clen = cbprintf_package_copy(package, sizeof(package), NULL, 0,
@@ -628,7 +628,7 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc_const_char_ptr)
 
 	/* Calculate size needed for package with appended read-only strings. */
 	clen = cbprintf_package_copy(package, sizeof(package), NULL, 0,
-				     CBPRINTF_PACKAGE_COPY_RO_STR, NULL, 0);
+				     CBPRINTF_PACKAGE_CONVERT_RO_STR, NULL, 0);
 
 	/* Length will be increased by 2 string lengths + null terminators. */
 	size_t str_append_len = (int)strlen(test_str) +
@@ -639,7 +639,7 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc_const_char_ptr)
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) cpackage[clen];
 
 	int clen2 = cbprintf_package_copy(package, sizeof(package), cpackage, sizeof(cpackage),
-				     CBPRINTF_PACKAGE_COPY_RO_STR, NULL, 0);
+				     CBPRINTF_PACKAGE_CONVERT_RO_STR, NULL, 0);
 
 	zassert_equal(clen, clen2, NULL);
 
@@ -655,7 +655,7 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc_const_char_ptr)
 
 	/* Calculate size needed for package with appended read-write strings. */
 	clen = cbprintf_package_copy(package, sizeof(package), NULL, 0,
-				     CBPRINTF_PACKAGE_COPY_RW_STR, NULL, 0);
+				     CBPRINTF_PACKAGE_CONVERT_RW_STR, NULL, 0);
 
 	/* Length will be increased by 1 string length + null terminator. */
 	zassert_equal(clen, len + (int)strlen(test_str1) + 1, NULL);
@@ -663,7 +663,7 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc_const_char_ptr)
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) cpackage2[clen];
 
 	clen2 = cbprintf_package_copy(package, sizeof(package), cpackage2, sizeof(cpackage2),
-				     CBPRINTF_PACKAGE_COPY_RW_STR, NULL, 0);
+				     CBPRINTF_PACKAGE_CONVERT_RW_STR, NULL, 0);
 
 	zassert_equal(clen, clen2, NULL);
 
@@ -729,8 +729,8 @@ static void cbprintf_rw_loc_const_char_ptr(bool keep_ro_str)
 	zassert_equal(hdr[2], 0, NULL);
 	zassert_equal(hdr[3], 2, NULL);
 
-	uint32_t copy_flags = CBPRINTF_PACKAGE_COPY_RW_STR |
-			 (keep_ro_str ? CBPRINTF_PACKAGE_COPY_KEEP_RO_STR : 0);
+	uint32_t copy_flags = CBPRINTF_PACKAGE_CONVERT_RW_STR |
+			 (keep_ro_str ? CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR : 0);
 
 	/* Calculate size needed for package with appended read-only strings. */
 	clen = cbprintf_package_copy(spackage, sizeof(spackage), NULL, 0,
@@ -870,8 +870,8 @@ ZTEST(cbprintf_package, test_cbprintf_package_convert)
 	slen = cbprintf_package(spackage, slen, flags, TEST_FMT);
 	zassert_true(slen > 0, NULL);
 
-	uint32_t copy_flags = CBPRINTF_PACKAGE_COPY_RW_STR |
-			      CBPRINTF_PACKAGE_COPY_KEEP_RO_STR;
+	uint32_t copy_flags = CBPRINTF_PACKAGE_CONVERT_RW_STR |
+			      CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR;
 
 	clen = cbprintf_package_convert(spackage, slen, NULL, 0, copy_flags, NULL, 0);
 	zassert_true(clen > 0, NULL);


### PR DESCRIPTION
At some point, package copy function was extended and renamed
to cbprintf_package_convert. However, flags used by this
function were not renamed and used contained COPY idiom.
Deprecating flags with COPY and replacing them with flags
with CONVERT idiom to match function which is utilizing them.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>