### PR TITLE
Bluetooth: Host: Fix invalid sync term callback params

### DIFF
--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -907,8 +907,8 @@ void bt_hci_le_per_adv_sync_established(struct net_buf *buf)
 			struct bt_le_per_adv_sync_term_info term_info;
 
 			/* Terminate the pending PA sync and notify app */
-			term_info.addr = &pending_per_adv_sync->addr;
-			term_info.sid = pending_per_adv_sync->sid;
+			term_info.addr = &evt->adv_addr;
+			term_info.sid = evt->sid;
 			term_info.reason = unexpected_evt ? BT_HCI_ERR_UNSPECIFIED : evt->status;
 
 			/* Deleting before callback, so the caller will be able


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/49540

When using periodic advertising list and receiving
hci_le_per_adv_sync_established event from controller with
an error code the bt_le_per_adv_sync_term_info would be
incorrectly populated with le_addr and sid. This is because
the current pending advertising sync object is not populated
with any le_addr and sid from bt_le_per_adv_sync_create as
those are not used when option
BT_LE_PER_ADV_SYNC_OPT_USE_PER_ADV_LIST is set.

Instead the bt_le_per_adv_sync_term_info shall be populated
with the le_addr and sid coming in the event from controller.

Signed-off-by: Jakob Krantz <jakob.krantz@u-blox.com>

From discussions in https://github.com/zephyrproject-rtos/zephyr/issues/49465

@Thalley https://github.com/zephyrproject-rtos/zephyr/issues/49465#issuecomment-1227198440
> Ah, yes, that makes sense. Indeed it should use the event address (the event address should be compared to the `pending_per_adv_sync->addr` when the list is not being used.

This is already checked here https://github.com/zephyrproject-rtos/zephyr/blob/80b4df8839c157db12c28786c0af38048282c22f/subsys/bluetooth/host/scan.c#L895 

In the case of NOT using periodic adv. list and a missmatch between controller `bt_hci_evt_le_per_adv_sync_established`  address and the host `get_pending_per_adv_sync()` address this commit will change which le address is sent to the application, previously it was the host's address, now it will be the controllers. Does that matter? If so I can add a check for `unexpected_evt` and populate accordingly.
