### PR TITLE
STM32U5: Fix imgtool configuration when using MCUboot

### DIFF
--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -19,7 +19,7 @@ lpc_checksum
 Pillow
 
 # can be used to sign a Zephyr application binary for consumption by a bootloader
-imgtool>=1.7.1
+imgtool>=1.9
 
 # used by nanopb module to generate sources from .proto files
 grpcio-tools

--- a/soc/arm/st_stm32/stm32u5/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32u5/Kconfig.defconfig.series
@@ -13,4 +13,7 @@ config SOC_SERIES
 config STM32_LPTIM_TIMER
 	default y if PM
 
+config MCUBOOT_EXTRA_IMGTOOL_ARGS
+	default "--header-size 1024" if BOOTLOADER_MCUBOOT
+
 endif # SOC_SERIES_STM32U5X


### PR DESCRIPTION
Fixes #47781