### PR TITLE
Maintainers: remove myself as docs collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -463,7 +463,6 @@ Documentation:
   collaborators:
     - nashif
     - utzig
-    - mbolivar-nordic
     - gmarull
   files:
     - doc/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -418,7 +418,6 @@ Devicetree:
     - dts/bindings/
     - dts/common/
     - tests/lib/devicetree/
-    - dts/bindings/test/
     - doc/build/dts/
     - include/zephyr/devicetree/
   labels:


### PR DESCRIPTION
I am still interested in contributing to the documentation, but I am
tired of the spam I'm getting from zephyrbot whenever any pull request
touches anything in doc/.
