### PR TITLE
gpio_mcp23sxx_fix: spi_msg and multiple inst

### DIFF
--- a/drivers/gpio/gpio_mcp23sxx.c
+++ b/drivers/gpio/gpio_mcp23sxx.c
@@ -43,8 +43,7 @@ static int mcp23sxx_read_port_regs(const struct device *dev, uint8_t reg, uint16
 		.buffers = &tx_buf,
 		.count = 1,
 	};
-	const struct spi_buf rx_buf[2] = { { .buf = NULL, .len = 2 },
-					   { .buf = (uint8_t *)&port_data, .len = nread } };
+	const struct spi_buf rx_buf[1] = { { .buf = NULL, .len = nread + 2 } };
 	const struct spi_buf_set rx = {
 		.buffers = rx_buf,
 		.count = ARRAY_SIZE(rx_buf),
@@ -68,20 +67,18 @@ static int mcp23sxx_write_port_regs(const struct device *dev, uint8_t reg, uint1
 
 	uint8_t nwrite = (config->ngpios == 8) ? 1 : 2;
 	uint16_t port_data = sys_cpu_to_le16(value);
+	uint8_t port_a_data = port_data & 0xFF;
+	uint8_t port_b_data = (port_data >> 8) & 0xFF;
 
 	port_data = sys_cpu_to_le16(value);
 
 	uint8_t addr = MCP23SXX_ADDR;
-	uint8_t buffer_tx[2] = { addr, reg };
+	uint8_t buffer_tx[4] = { addr, reg, port_a_data, port_b_data };
 
-	const struct spi_buf tx_buf[2] = {
+	const struct spi_buf tx_buf[1] = {
 		{
 			.buf = buffer_tx,
-			.len = 2,
-		},
-		{
-			.buf = (uint8_t *)&port_data,
-			.len = nwrite,
+			.len = nwrite + 2,
 		}
 	};
 	const struct spi_buf_set tx = {
@@ -112,7 +109,7 @@ static int mcp23sxx_bus_is_ready(const struct device *dev)
 
 #define DT_DRV_COMPAT microchip_mcp23sxx
 
-#define GPIO_MCP23SXX_DEVICE(n)                                                               \
+#define GPIO_MCP23SXX_DEVICE(inst)                                                               \
 	static struct mcp23xxx_drv_data mcp23sxx_##inst##_drvdata = {                         \
 		/* Default for registers according to datasheet */                            \
 		.reg_cache.iodir = 0xFFFF, .reg_cache.ipol = 0x0,   .reg_cache.gpinten = 0x0, \
@@ -122,19 +119,19 @@ static int mcp23sxx_bus_is_ready(const struct device *dev)
 	};                                                                                    \
 	static struct mcp23xxx_config mcp23sxx_##inst##_config = {                            \
 		.config = {					                              \
-			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),                  \
+			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(inst),                  \
 		},						                              \
 		.bus = {                                                                      \
-			.spi = SPI_DT_SPEC_INST_GET(n,                                        \
+			.spi = SPI_DT_SPEC_INST_GET(inst,                                        \
 				SPI_OP_MODE_MASTER | SPI_MODE_CPOL |                          \
 				SPI_MODE_CPHA | SPI_WORD_SET(8), 0)                           \
 		},                                                                            \
-		.ngpios =  DT_INST_PROP(n, ngpios),		                              \
+		.ngpios =  DT_INST_PROP(inst, ngpios),		                              \
 		.read_fn = mcp23sxx_read_port_regs,                                           \
 		.write_fn = mcp23sxx_write_port_regs,                                         \
 		.bus_fn = mcp23sxx_bus_is_ready                                               \
 	};                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, gpio_mcp23xxx_init, NULL, &mcp23sxx_##inst##_drvdata,        \
+	DEVICE_DT_INST_DEFINE(inst, gpio_mcp23xxx_init, NULL, &mcp23sxx_##inst##_drvdata,        \
 			      &mcp23sxx_##inst##_config, POST_KERNEL,                         \
 			      CONFIG_GPIO_MCP23SXX_INIT_PRIORITY, &gpio_mcp23xxx_api_table);
 


### PR DESCRIPTION
**Changed SPI message from 2 seperate to 1**
The SPI communication did not work since the data frame was split into (addr, reg) and (data,data) but now the data frame is sent as a whole (addr, reg, data, data)

**Fixed problem using multiple instances**
It is now possible to add more than one instance of a gpio_mcp23sxx device

Signed-off-by: Daniel Skatt <daniel.skatt@gmail.com>