### PR TITLE
[v2.7 branch] Fix newer versions of pylink not working

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -7,6 +7,7 @@
 import argparse
 import logging
 import os
+from packaging.version import Version
 from pathlib import Path
 import shlex
 import subprocess
@@ -16,6 +17,7 @@ import tempfile
 from runners.core import ZephyrBinaryRunner, RunnerCaps
 
 try:
+    import pylink
     from pylink.library import Library
     MISSING_REQUIREMENTS = False
 except ImportError:
@@ -141,16 +143,23 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         # to load the shared library distributed with the tools, which
         # provides an API call for getting the version.
         if not hasattr(self, '_jlink_version'):
+            # pylink >= 0.14.0 exposes JLink SDK DLL (libjlinkarm) in
+            # JLINK_SDK_STARTS_WITH, while previous versions use JLINK_SDK_NAME
+            if Version(pylink.__version__) >= Version('0.14.0'):
+                sdk = Library.JLINK_SDK_STARTS_WITH
+            else:
+                sdk = Library.JLINK_SDK_NAME
+
             plat = sys.platform
             if plat.startswith('win32'):
                 libname = Library.get_appropriate_windows_sdk_name() + '.dll'
             elif plat.startswith('linux'):
-                libname = Library.JLINK_SDK_NAME + '.so'
+                libname = sdk + '.so'
             elif plat.startswith('darwin'):
-                libname = Library.JLINK_SDK_NAME + '.dylib'
+                libname = sdk + '.dylib'
             else:
                 self.logger.warning(f'unknown platform {plat}; assuming UNIX')
-                libname = Library.JLINK_SDK_NAME + '.so'
+                libname = sdk + '.so'
 
             lib = Library(dllpath=os.fspath(Path(self.commander).parent /
                                             libname))

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -7,7 +7,6 @@
 import argparse
 import logging
 import os
-from packaging.version import Version
 from pathlib import Path
 import shlex
 import subprocess
@@ -143,9 +142,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         # to load the shared library distributed with the tools, which
         # provides an API call for getting the version.
         if not hasattr(self, '_jlink_version'):
-            # pylink >= 0.14.0 exposes JLink SDK DLL (libjlinkarm) in
-            # JLINK_SDK_STARTS_WITH, while previous versions use JLINK_SDK_NAME
-            if Version(pylink.__version__) >= Version('0.14.0'):
+            # pylink 0.14.0/0.14.1 exposes JLink SDK DLL (libjlinkarm) in
+            # JLINK_SDK_STARTS_WITH, while other versions use JLINK_SDK_NAME
+            if pylink.__version__ in ('0.14.0', '0.14.1'):
                 sdk = Library.JLINK_SDK_STARTS_WITH
             else:
                 sdk = Library.JLINK_SDK_NAME


### PR DESCRIPTION
Brings in https://github.com/zephyrproject-rtos/zephyr/pull/48680 and https://github.com/zephyrproject-rtos/zephyr/pull/49272 to support using newer versions of pylink
```
commit 06f9af3ec26052f0bf5ef4520a9c6d326ecf6520 (HEAD -> pylinkfix, mine/pylinkfix)
Author: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
Date:   Fri Aug 19 11:12:55 2022 +0200

    scripts: west_commands: runners: jlink: support pylink >= 0.14.2
    
    It looks like the latest release, 0.14.2, changed the contents of
    JLINK_SDK_NAME as it was before 0.14.0 release. That means that the
    previous fix is only applicable to a couple of releases: 0.14.0/0.14.1.
    
    Fixes #49564
    
    Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
    (cherry picked from commit 2d712c6c55dc336438ad82d97ccd251dc17f478b)

commit 4ce14f700e93c551683254245070fd5b93007647
Author: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
Date:   Thu Aug 4 12:25:55 2022 +0200

    scripts: west_commands: runners: jlink: support pylink >= 0.14
    
    pylink 0.14.0 changed the class variable where JLink DLL library name
    (libjlinkarm) is stored. This patch adds support for new pylink
    libraries while keeping backwards compatibility.
    
    Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
    (cherry picked from commit a57001347f6e9c21654abacb630324f96d74e898)
```

Fixes #https://github.com/zephyrproject-rtos/zephyr/issues/49564