### PR TITLE
Bluetooth: Controller: Add Kconfig for minimal time reservation 

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -284,6 +284,17 @@ config BT_CTRL_ADV_ADI_IN_SCAN_RSP
 	help
 	  Enable ADI field in AUX_SCAN_RSP PDU
 
+config BT_CTLR_SCAN_AUX_SYNC_RESERVE_MIN
+	bool "Use minimal Scan Auxiliary and Periodic Sync PDU time reservation"
+	depends on (BT_OBSERVER && BT_CTLR_ADV_EXT) || BT_CTLR_SYNC_PERIODIC
+	default y
+	help
+	  Use minimal time reservation for Auxiliary and Periodic Sync PDU
+	  reception. A peer device could scheduling multiple advertising sets
+	  in a short duration with small PDUs hence using the minimal time
+	  reservation would avoid skipping closely scheduled reception of
+	  multiple Auxiliary or Periodic Sync PDUs.
+
 config BT_CTLR_SYNC_PERIODIC_SKIP_ON_SCAN_AUX
 	bool "Skip Periodic Sync event on overlap with Extended Scan Event"
 	depends on BT_CTLR_SYNC_PERIODIC

--- a/subsys/bluetooth/controller/ll_sw/lll_sync.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync.h
@@ -32,6 +32,14 @@ struct lll_sync {
 	uint8_t sca:3;
 #endif /* CONFIG_BT_CTLR_SYNC_ISO */
 
+#if defined(CONFIG_BT_CTLR_SCAN_AUX_SYNC_RESERVE_MIN)
+	/* Counter used by LLL abort of event when in unreserved time space to
+	 * provide near fair scheduling of overlapping multiple Periodic
+	 * Sync sets.
+	 */
+	uint8_t abort_count;
+#endif /* CONFIG_BT_CTLR_SCAN_AUX_SYNC_RESERVE_MIN */
+
 	uint16_t skip_prepare;
 	uint16_t skip_event;
 	uint16_t event_counter;
@@ -66,3 +74,4 @@ void lll_sync_prepare(void *param);
 enum sync_status lll_sync_cte_is_allowed(uint8_t cte_type_mask, uint8_t filter_policy,
 					 uint8_t rx_cte_time, uint8_t rx_cte_type);
 extern uint16_t ull_sync_lll_handle_get(struct lll_sync *lll);
+extern struct lll_sync *ull_sync_lll_is_valid_get(struct lll_sync *lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -738,10 +738,13 @@ int lll_prepare_resolve(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 #if !defined(CONFIG_BT_CTLR_LOW_LAT)
 	uint32_t ret;
 
-	/* Stop any scheduled preempt ticker */
-	ret = preempt_ticker_stop();
-	LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
-		  (ret == TICKER_STATUS_BUSY));
+	/* NOTE: preempt timeout started prior for the current event that has
+	 *       its prepare that is now invoked is not explicitly stopped here.
+	 *       If there is a next prepare event in pipeline, then the prior
+	 *       preempt timeout if started will be stopped before starting
+	 *       the new preempt timeout. Refer to implementation in
+	 *       preempt_ticker_start().
+	 */
 
 	/* Find next prepare needing preempt timeout to be setup */
 	do {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -467,21 +467,60 @@ static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb)
 
 	/* Different radio event overlap */
 	if (next != curr) {
+		struct lll_scan_aux *lll_aux;
 		struct lll_scan *lll;
 
 		lll = ull_scan_lll_is_valid_get(next);
-		if (!lll) {
-			struct lll_scan_aux *lll_aux;
-
-			lll_aux = ull_scan_aux_lll_is_valid_get(next);
-			if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC_SKIP_ON_SCAN_AUX) ||
-			    !lll_aux) {
-				/* Abort current event as next event is not a
-				 * scan and not a scan aux event.
-				 */
-				return -ECANCELED;
-			}
+		if (lll) {
+			/* Do not abort current periodic sync event as next
+			 * event is a scan event.
+			 */
+			return 0;
 		}
+
+		lll_aux = ull_scan_aux_lll_is_valid_get(next);
+		if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC_SKIP_ON_SCAN_AUX) &&
+		    lll_aux) {
+			/* Do not abort current periodic sync event as next
+			 * event is a scan aux event.
+			 */
+			return 0;
+		}
+
+#if defined(CONFIG_BT_CTLR_SCAN_AUX_SYNC_RESERVE_MIN)
+		struct lll_sync *lll_sync_next;
+		struct lll_sync *lll_sync_curr;
+
+		lll_sync_next = ull_sync_lll_is_valid_get(next);
+		if (!lll_sync_next) {
+			/* Abort current event as next event is not a
+			 * scan and not a scan aux event.
+			 */
+			return -ECANCELED;
+		}
+
+		lll_sync_curr = curr;
+		if (lll_sync_curr->abort_count < lll_sync_next->abort_count) {
+			if (lll_sync_curr->abort_count < UINT8_MAX) {
+				lll_sync_curr->abort_count++;
+			}
+
+			/* Abort current event as next event has higher abort
+			 * count.
+			 */
+			return -ECANCELED;
+		}
+
+		if (lll_sync_next->abort_count < UINT8_MAX) {
+			lll_sync_next->abort_count++;
+		}
+
+#else /* !CONFIG_BT_CTLR_SCAN_AUX_SYNC_RESERVE_MIN */
+		/* Abort current event as next event is not a
+		 * scan and not a scan aux event.
+		 */
+		return -ECANCELED;
+#endif /* !CONFIG_BT_CTLR_SCAN_AUX_SYNC_RESERVE_MIN */
 	}
 
 	/* Do not abort if current periodic sync event overlaps next interval
@@ -1012,6 +1051,14 @@ static void isr_rx_done_cleanup(struct lll_sync *lll, uint8_t crc_ok, bool sync_
 		/* Reset window widening, as anchor point sync-ed */
 		lll->window_widening_event_us = 0U;
 		lll->window_size_event_us = 0U;
+
+#if defined(CONFIG_BT_CTLR_SCAN_AUX_SYNC_RESERVE_MIN)
+		/* Reset LLL abort count as LLL event is gracefully done and
+		 * was not aborted by any other event when current event could
+		 * have been using unreserved time space.
+		 */
+		lll->abort_count = 0U;
+#endif /* CONFIG_BT_CTLR_SCAN_AUX_SYNC_RESERVE_MIN */
 	}
 
 	lll_isr_cleanup(lll);

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -41,6 +41,14 @@
 
 /* Advertisement channel maximum payload size */
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
+
+/* Extended Scan and Periodic Sync Rx PDU time reservation */
+#if defined(CONFIG_BT_CTLR_SCAN_AUX_SYNC_RESERVE_MIN)
+#define PDU_AC_EXT_PAYLOAD_RX_SIZE 0U
+#else /* !CONFIG_BT_CTLR_SCAN_AUX_SYNC_RESERVE_MIN */
+#define PDU_AC_EXT_PAYLOAD_RX_SIZE PDU_AC_EXT_PAYLOAD_SIZE_MAX
+#endif /* !CONFIG_BT_CTLR_SCAN_AUX_SYNC_RESERVE_MIN */
+
 #define PDU_AC_EXT_HEADER_SIZE_MIN  offsetof(struct pdu_adv_com_ext_adv, \
 					     ext_hdr_adv_data)
 #define PDU_AC_EXT_HEADER_SIZE_MAX  63

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -654,7 +654,8 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	aux->ull.ticks_slot =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US +
 				       ready_delay_us +
-				       PDU_AC_MAX_US(0U, lll_aux->phy) +
+				       PDU_AC_MAX_US(PDU_AC_EXT_PAYLOAD_RX_SIZE,
+						     lll_aux->phy) +
 				       EVENT_OVERHEAD_END_US);
 
 	ticks_slot_offset = MAX(aux->ull.ticks_active_to_start,

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -761,7 +761,8 @@ void ull_sync_setup(struct ll_scan_set *scan, struct ll_scan_aux_set *aux,
 	sync->ull.ticks_slot =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US +
 				       ready_delay_us +
-				       PDU_AC_MAX_US(0U, lll->phy) +
+				       PDU_AC_MAX_US(PDU_AC_EXT_PAYLOAD_RX_SIZE,
+						     lll->phy) +
 				       EVENT_OVERHEAD_END_US);
 
 	ticks_slot_offset = MAX(sync->ull.ticks_active_to_start,

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -253,6 +253,11 @@ uint8_t ll_sync_create(uint8_t options, uint8_t sid, uint8_t adv_addr_type,
 	ull_hdr_init(&sync->ull);
 	lll_hdr_init(lll_sync, sync);
 
+#if defined(CONFIG_BT_CTLR_SCAN_AUX_SYNC_RESERVE_MIN)
+	/* Initialise LLL abort count */
+	lll_sync->abort_count = 0U;
+#endif /* CONFIG_BT_CTLR_SCAN_AUX_SYNC_RESERVE_MIN */
+
 	/* Enable scanner to create sync */
 	scan->periodic.sync = sync;
 
@@ -527,6 +532,19 @@ struct ll_sync_set *ull_sync_is_valid_get(struct ll_sync_set *sync)
 	}
 
 	return sync;
+}
+
+struct lll_sync *ull_sync_lll_is_valid_get(struct lll_sync *lll)
+{
+	struct ll_sync_set *sync;
+
+	sync = HDR_LLL2ULL(lll);
+	sync = ull_sync_is_valid_get(sync);
+	if (sync) {
+		return &sync->lll;
+	}
+
+	return NULL;
 }
 
 uint16_t ull_sync_handle_get(struct ll_sync_set *sync)


### PR DESCRIPTION
Add Kconfig to use minimal time reservation for auxiliary
and sync PDU reception. A peer device could be scheduling
multiple advertising sets in a short duration with small
PDUs hence using the minimal time reservation would avoid
skipping closely scheduled reception of multiple auxiliary
PDUs.

Add implementation in Periodic Sync LLL abort to use near
fair scheduling to ensure overlapping multiple Periodic
Sync set each get to use the radio and not lead to Sync
Loss.

The implementation is used when overlap in radio event
happens in unreserved time space of the event. An abort
count is maintain in each Periodic Sync instance and is
used to decide whether the current event or the next
event is to be aborted when they overlap.

Fixes #49465.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>