### PR TITLE
Bluetooth: Mesh: Align Config Client API with Health Client API

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -90,6 +90,9 @@ Deprecated in this release
    valid for specific bindings to specify like :dtcompatible:`gpio-leds` and
    :dtcompatible:`fixed-partitions`.
 
+* Bluetooth mesh Configuration Client API prefixed with ``bt_mesh_cfg_``
+  is deprecated in favor of a new API with prefix ``bt_mesh_cfg_cli_``.
+
 Stable API changes in this release
 ==================================
 

--- a/include/zephyr/bluetooth/mesh/cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/cfg_cli.h
@@ -213,7 +213,7 @@ struct bt_mesh_cfg_cli {
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_node_reset(uint16_t net_idx, uint16_t addr, bool *status);
+__deprecated int bt_mesh_cfg_node_reset(uint16_t net_idx, uint16_t addr, bool *status);
 
 /** @brief Get the target node's composition data.
  *
@@ -234,8 +234,8 @@ int bt_mesh_cfg_node_reset(uint16_t net_idx, uint16_t addr, bool *status);
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_comp_data_get(uint16_t net_idx, uint16_t addr, uint8_t page,
-			      uint8_t *rsp, struct net_buf_simple *comp);
+__deprecated int bt_mesh_cfg_comp_data_get(uint16_t net_idx, uint16_t addr, uint8_t page,
+					   uint8_t *rsp, struct net_buf_simple *comp);
 
 /** @brief Get the target node's network beacon state.
  *
@@ -251,7 +251,7 @@ int bt_mesh_cfg_comp_data_get(uint16_t net_idx, uint16_t addr, uint8_t page,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_beacon_get(uint16_t net_idx, uint16_t addr, uint8_t *status);
+__deprecated int bt_mesh_cfg_beacon_get(uint16_t net_idx, uint16_t addr, uint8_t *status);
 
 /** @brief             Get the target node's network key refresh phase state.
  *
@@ -267,8 +267,8 @@ int bt_mesh_cfg_beacon_get(uint16_t net_idx, uint16_t addr, uint8_t *status);
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_krp_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
-			uint8_t *status, uint8_t *phase);
+__deprecated int bt_mesh_cfg_krp_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				     uint8_t *status, uint8_t *phase);
 
 /** @brief             Set the target node's network key refresh phase parameters.
  *
@@ -286,8 +286,8 @@ int bt_mesh_cfg_krp_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_krp_set(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
-			uint8_t transition, uint8_t *status, uint8_t *phase);
+__deprecated int bt_mesh_cfg_krp_set(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				     uint8_t transition, uint8_t *status, uint8_t *phase);
 
 /** @brief Set the target node's network beacon state.
  *
@@ -305,7 +305,8 @@ int bt_mesh_cfg_krp_set(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_beacon_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *status);
+__deprecated int bt_mesh_cfg_beacon_set(uint16_t net_idx, uint16_t addr, uint8_t val,
+					uint8_t *status);
 
 /** @brief Get the target node's Time To Live value.
  *
@@ -319,7 +320,7 @@ int bt_mesh_cfg_beacon_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_ttl_get(uint16_t net_idx, uint16_t addr, uint8_t *ttl);
+__deprecated int bt_mesh_cfg_ttl_get(uint16_t net_idx, uint16_t addr, uint8_t *ttl);
 
 /** @brief Set the target node's Time To Live value.
  *
@@ -334,7 +335,7 @@ int bt_mesh_cfg_ttl_get(uint16_t net_idx, uint16_t addr, uint8_t *ttl);
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_ttl_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *ttl);
+__deprecated int bt_mesh_cfg_ttl_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *ttl);
 
 /** @brief Get the target node's Friend feature status.
  *
@@ -350,7 +351,7 @@ int bt_mesh_cfg_ttl_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *t
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_friend_get(uint16_t net_idx, uint16_t addr, uint8_t *status);
+__deprecated int bt_mesh_cfg_friend_get(uint16_t net_idx, uint16_t addr, uint8_t *status);
 
 /** @brief Set the target node's Friend feature state.
  *
@@ -369,7 +370,8 @@ int bt_mesh_cfg_friend_get(uint16_t net_idx, uint16_t addr, uint8_t *status);
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_friend_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *status);
+__deprecated int bt_mesh_cfg_friend_set(uint16_t net_idx, uint16_t addr, uint8_t val,
+					uint8_t *status);
 
 /** @brief Get the target node's Proxy feature state.
  *
@@ -386,7 +388,7 @@ int bt_mesh_cfg_friend_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_gatt_proxy_get(uint16_t net_idx, uint16_t addr, uint8_t *status);
+__deprecated int bt_mesh_cfg_gatt_proxy_get(uint16_t net_idx, uint16_t addr, uint8_t *status);
 
 /** @brief Set the target node's Proxy feature state.
  *
@@ -406,8 +408,8 @@ int bt_mesh_cfg_gatt_proxy_get(uint16_t net_idx, uint16_t addr, uint8_t *status)
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_gatt_proxy_set(uint16_t net_idx, uint16_t addr, uint8_t val,
-			       uint8_t *status);
+__deprecated int bt_mesh_cfg_gatt_proxy_set(uint16_t net_idx, uint16_t addr, uint8_t val,
+					    uint8_t *status);
 
 /** @brief Get the target node's network_transmit state.
  *
@@ -423,8 +425,7 @@ int bt_mesh_cfg_gatt_proxy_set(uint16_t net_idx, uint16_t addr, uint8_t val,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_net_transmit_get(uint16_t net_idx, uint16_t addr,
-			  uint8_t *transmit);
+__deprecated int bt_mesh_cfg_net_transmit_get(uint16_t net_idx, uint16_t addr, uint8_t *transmit);
 
 /** @brief Set the target node's network transmit parameters.
  *
@@ -441,8 +442,8 @@ int bt_mesh_cfg_net_transmit_get(uint16_t net_idx, uint16_t addr,
  *                    @ref BT_MESH_TRANSMIT_COUNT and @ref BT_MESH_TRANSMIT_INT.
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_net_transmit_set(uint16_t net_idx, uint16_t addr,
-		uint8_t val, uint8_t *transmit);
+__deprecated int bt_mesh_cfg_net_transmit_set(uint16_t net_idx, uint16_t addr, uint8_t val,
+					      uint8_t *transmit);
 
 /** @brief Get the target node's Relay feature state.
  *
@@ -461,8 +462,8 @@ int bt_mesh_cfg_net_transmit_set(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_relay_get(uint16_t net_idx, uint16_t addr, uint8_t *status,
-			  uint8_t *transmit);
+__deprecated int bt_mesh_cfg_relay_get(uint16_t net_idx, uint16_t addr, uint8_t *status,
+				       uint8_t *transmit);
 
 /** @brief Set the target node's Relay parameters.
  *
@@ -487,8 +488,8 @@ int bt_mesh_cfg_relay_get(uint16_t net_idx, uint16_t addr, uint8_t *status,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_relay_set(uint16_t net_idx, uint16_t addr, uint8_t new_relay,
-			  uint8_t new_transmit, uint8_t *status, uint8_t *transmit);
+__deprecated int bt_mesh_cfg_relay_set(uint16_t net_idx, uint16_t addr, uint8_t new_relay,
+				       uint8_t new_transmit, uint8_t *status, uint8_t *transmit);
 
 /** @brief Add a network key to the target node.
  *
@@ -504,8 +505,8 @@ int bt_mesh_cfg_relay_set(uint16_t net_idx, uint16_t addr, uint8_t new_relay,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_net_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
-			    const uint8_t net_key[16], uint8_t *status);
+__deprecated int bt_mesh_cfg_net_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+					 const uint8_t net_key[16], uint8_t *status);
 
 /** @brief Get a list of the target node's network key indexes.
  *
@@ -523,8 +524,8 @@ int bt_mesh_cfg_net_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_id
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_net_key_get(uint16_t net_idx, uint16_t addr, uint16_t *keys,
-			    size_t *key_cnt);
+__deprecated int bt_mesh_cfg_net_key_get(uint16_t net_idx, uint16_t addr, uint16_t *keys,
+					 size_t *key_cnt);
 
 /** @brief Delete a network key from the target node.
  *
@@ -539,8 +540,8 @@ int bt_mesh_cfg_net_key_get(uint16_t net_idx, uint16_t addr, uint16_t *keys,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_net_key_del(uint16_t net_idx, uint16_t addr,
-			    uint16_t key_net_idx, uint8_t *status);
+__deprecated int bt_mesh_cfg_net_key_del(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+					 uint8_t *status);
 
 /** @brief Add an application key to the target node.
  *
@@ -557,9 +558,9 @@ int bt_mesh_cfg_net_key_del(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_app_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
-			    uint16_t key_app_idx, const uint8_t app_key[16],
-			    uint8_t *status);
+__deprecated int bt_mesh_cfg_app_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+					 uint16_t key_app_idx, const uint8_t app_key[16],
+					 uint8_t *status);
 
 /** @brief Get a list of the target node's application key indexes for a
  *         specific network key.
@@ -582,9 +583,8 @@ int bt_mesh_cfg_app_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_id
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_app_key_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
-			    uint8_t *status, uint16_t *keys, size_t *key_cnt);
-
+__deprecated int bt_mesh_cfg_app_key_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+					 uint8_t *status, uint16_t *keys, size_t *key_cnt);
 
 /** @brief Delete an application key from the target node.
  *
@@ -600,8 +600,8 @@ int bt_mesh_cfg_app_key_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_id
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_app_key_del(uint16_t net_idx, uint16_t addr,
-		uint16_t key_net_idx, uint16_t key_app_idx, uint8_t *status);
+__deprecated int bt_mesh_cfg_app_key_del(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+					 uint16_t key_app_idx, uint8_t *status);
 
 /** @brief Bind an application to a SIG model on the target node.
  *
@@ -618,8 +618,8 @@ int bt_mesh_cfg_app_key_del(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_app_bind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			     uint16_t mod_app_idx, uint16_t mod_id, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_app_bind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					  uint16_t mod_app_idx, uint16_t mod_id, uint8_t *status);
 
 /** @brief Unbind an application from a SIG model on the target node.
  *
@@ -636,9 +636,8 @@ int bt_mesh_cfg_mod_app_bind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_app_unbind(uint16_t net_idx, uint16_t addr,
-	uint16_t elem_addr, uint16_t mod_app_idx,
-	uint16_t mod_id, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_app_unbind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					    uint16_t mod_app_idx, uint16_t mod_id, uint8_t *status);
 
 /** @brief Bind an application to a vendor model on the target node.
  *
@@ -656,9 +655,9 @@ int bt_mesh_cfg_mod_app_unbind(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_app_bind_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				 uint16_t mod_app_idx, uint16_t mod_id, uint16_t cid,
-				 uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_app_bind_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					      uint16_t mod_app_idx, uint16_t mod_id, uint16_t cid,
+					      uint8_t *status);
 
 /** @brief Unbind an application from a vendor model on the target node.
  *
@@ -676,9 +675,9 @@ int bt_mesh_cfg_mod_app_bind_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_app_unbind_vnd(uint16_t net_idx, uint16_t addr,
-	uint16_t elem_addr, uint16_t mod_app_idx, uint16_t mod_id,
-	uint16_t cid, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_app_unbind_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+						uint16_t mod_app_idx, uint16_t mod_id, uint16_t cid,
+						uint8_t *status);
 
 /** @brief Get a list of all applications bound to a SIG model on the target
  *         node.
@@ -700,10 +699,9 @@ int bt_mesh_cfg_mod_app_unbind_vnd(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_app_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			    uint16_t mod_id, uint8_t *status, uint16_t *apps,
-			    size_t *app_cnt);
-
+__deprecated int bt_mesh_cfg_mod_app_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					 uint16_t mod_id, uint8_t *status, uint16_t *apps,
+					 size_t *app_cnt);
 
 /** @brief Get a list of all applications bound to a vendor model on the target
  *         node.
@@ -726,9 +724,9 @@ int bt_mesh_cfg_mod_app_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				uint16_t mod_id, uint16_t cid, uint8_t *status,
-				uint16_t *apps, size_t *app_cnt);
+__deprecated int bt_mesh_cfg_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					     uint16_t mod_id, uint16_t cid, uint8_t *status,
+					     uint16_t *apps, size_t *app_cnt);
 
 /**
  *
@@ -736,7 +734,7 @@ int bt_mesh_cfg_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
  *
  *  @param steps Number of 100ms steps.
  *
- *  @return Encoded value that can be assigned to bt_mesh_cfg_mod_pub.period
+ *  @return Encoded value that can be assigned to bt_mesh_cfg_cli_mod_pub.period
  */
 #define BT_MESH_PUB_PERIOD_100MS(steps)  ((steps) & BIT_MASK(6))
 
@@ -745,7 +743,7 @@ int bt_mesh_cfg_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
  *
  *  @param steps Number of 1 second steps.
  *
- *  @return Encoded value that can be assigned to bt_mesh_cfg_mod_pub.period
+ *  @return Encoded value that can be assigned to bt_mesh_cfg_cli_mod_pub.period
  */
 #define BT_MESH_PUB_PERIOD_SEC(steps)   (((steps) & BIT_MASK(6)) | (1 << 6))
 
@@ -756,7 +754,7 @@ int bt_mesh_cfg_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
  *
  *  @param steps Number of 10 second steps.
  *
- *  @return Encoded value that can be assigned to bt_mesh_cfg_mod_pub.period
+ *  @return Encoded value that can be assigned to bt_mesh_cfg_cli_mod_pub.period
  */
 #define BT_MESH_PUB_PERIOD_10SEC(steps) (((steps) & BIT_MASK(6)) | (2 << 6))
 
@@ -767,12 +765,38 @@ int bt_mesh_cfg_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
  *
  *  @param steps Number of 10 minute steps.
  *
- *  @return Encoded value that can be assigned to bt_mesh_cfg_mod_pub.period
+ *  @return Encoded value that can be assigned to bt_mesh_cfg_cli_mod_pub.period
  */
 #define BT_MESH_PUB_PERIOD_10MIN(steps) (((steps) & BIT_MASK(6)) | (3 << 6))
 
 /** Model publication configuration parameters. */
-struct bt_mesh_cfg_mod_pub {
+__deprecated struct bt_mesh_cfg_mod_pub {
+	/** Publication destination address. */
+	uint16_t addr;
+	/** Virtual address UUID, or NULL if this is not a virtual address. */
+	const uint8_t *uuid;
+	/** Application index to publish with. */
+	uint16_t app_idx;
+	/** Friendship credential flag. */
+	bool cred_flag;
+	/** Time To Live to publish with. */
+	uint8_t ttl;
+	/**
+	 * Encoded publish period.
+	 * @see BT_MESH_PUB_PERIOD_100MS, BT_MESH_PUB_PERIOD_SEC,
+	 * BT_MESH_PUB_PERIOD_10SEC,
+	 * BT_MESH_PUB_PERIOD_10MIN
+	 */
+	uint8_t period;
+	/**
+	 * Encoded transmit parameters.
+	 * @see BT_MESH_TRANSMIT
+	 */
+	uint8_t transmit;
+};
+
+/** Model publication configuration parameters. */
+struct bt_mesh_cfg_cli_mod_pub {
 	/** Publication destination address. */
 	uint16_t addr;
 	/** Virtual address UUID, or NULL if this is not a virtual address. */
@@ -812,9 +836,9 @@ struct bt_mesh_cfg_mod_pub {
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_pub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			    uint16_t mod_id, struct bt_mesh_cfg_mod_pub *pub,
-			    uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_pub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					 uint16_t mod_id, struct bt_mesh_cfg_mod_pub *pub,
+					 uint8_t *status);
 
 /** @brief Get publish parameters for a vendor model on the target node.
  *
@@ -832,9 +856,9 @@ int bt_mesh_cfg_mod_pub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_pub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				uint16_t mod_id, uint16_t cid,
-				struct bt_mesh_cfg_mod_pub *pub, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_pub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					     uint16_t mod_id, uint16_t cid,
+					     struct bt_mesh_cfg_mod_pub *pub, uint8_t *status);
 
 /** @brief Set publish parameters for a SIG model on the target node.
  *
@@ -853,9 +877,9 @@ int bt_mesh_cfg_mod_pub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_pub_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			    uint16_t mod_id, struct bt_mesh_cfg_mod_pub *pub,
-			    uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_pub_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					 uint16_t mod_id, struct bt_mesh_cfg_mod_pub *pub,
+					 uint8_t *status);
 
 /** @brief Set publish parameters for a vendor model on the target node.
  *
@@ -875,9 +899,9 @@ int bt_mesh_cfg_mod_pub_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_pub_set_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				uint16_t mod_id, uint16_t cid,
-				struct bt_mesh_cfg_mod_pub *pub, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_pub_set_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					     uint16_t mod_id, uint16_t cid,
+					     struct bt_mesh_cfg_mod_pub *pub, uint8_t *status);
 
 /** @brief Add a group address to a SIG model's subscription list.
  *
@@ -894,8 +918,8 @@ int bt_mesh_cfg_mod_pub_set_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_add(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			    uint16_t sub_addr, uint16_t mod_id, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_sub_add(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					 uint16_t sub_addr, uint16_t mod_id, uint8_t *status);
 
 /** @brief Add a group address to a vendor model's subscription list.
  *
@@ -913,9 +937,9 @@ int bt_mesh_cfg_mod_sub_add(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				 uint16_t sub_addr, uint16_t mod_id, uint16_t cid,
-				 uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_sub_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					     uint16_t sub_addr, uint16_t mod_id, uint16_t cid,
+					     uint8_t *status);
 
 /** @brief Delete a group address in a SIG model's subscription list.
  *
@@ -932,8 +956,8 @@ int bt_mesh_cfg_mod_sub_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_del(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			    uint16_t sub_addr, uint16_t mod_id, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_sub_del(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					 uint16_t sub_addr, uint16_t mod_id, uint8_t *status);
 
 /** @brief Delete a group address in a vendor model's subscription list.
  *
@@ -951,9 +975,9 @@ int bt_mesh_cfg_mod_sub_del(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				 uint16_t sub_addr, uint16_t mod_id, uint16_t cid,
-				 uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_sub_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					     uint16_t sub_addr, uint16_t mod_id, uint16_t cid,
+					     uint8_t *status);
 
 /** @brief Overwrite all addresses in a SIG model's subscription list with a
  * group address.
@@ -974,8 +998,8 @@ int bt_mesh_cfg_mod_sub_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_overwrite(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				  uint16_t sub_addr, uint16_t mod_id, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_sub_overwrite(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					       uint16_t sub_addr, uint16_t mod_id, uint8_t *status);
 
 /** @brief Overwrite all addresses in a vendor model's subscription list with a
  * group address.
@@ -997,9 +1021,9 @@ int bt_mesh_cfg_mod_sub_overwrite(uint16_t net_idx, uint16_t addr, uint16_t elem
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_overwrite_vnd(uint16_t net_idx, uint16_t addr,
-				      uint16_t elem_addr, uint16_t sub_addr,
-				      uint16_t mod_id, uint16_t cid, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_sub_overwrite_vnd(uint16_t net_idx, uint16_t addr,
+						   uint16_t elem_addr, uint16_t sub_addr,
+						   uint16_t mod_id, uint16_t cid, uint8_t *status);
 
 /** @brief Add a virtual address to a SIG model's subscription list.
  *
@@ -1017,9 +1041,9 @@ int bt_mesh_cfg_mod_sub_overwrite_vnd(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_va_add(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			       const uint8_t label[16], uint16_t mod_id,
-			       uint16_t *virt_addr, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_sub_va_add(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					    const uint8_t label[16], uint16_t mod_id,
+					    uint16_t *virt_addr, uint8_t *status);
 
 /** @brief Add a virtual address to a vendor model's subscription list.
  *
@@ -1038,9 +1062,9 @@ int bt_mesh_cfg_mod_sub_va_add(uint16_t net_idx, uint16_t addr, uint16_t elem_ad
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_va_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				   const uint8_t label[16], uint16_t mod_id,
-				   uint16_t cid, uint16_t *virt_addr, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_sub_va_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+						const uint8_t label[16], uint16_t mod_id,
+						uint16_t cid, uint16_t *virt_addr, uint8_t *status);
 
 /** @brief Delete a virtual address in a SIG model's subscription list.
  *
@@ -1058,9 +1082,9 @@ int bt_mesh_cfg_mod_sub_va_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t ele
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_va_del(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			       const uint8_t label[16], uint16_t mod_id,
-			       uint16_t *virt_addr, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_sub_va_del(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					    const uint8_t label[16], uint16_t mod_id,
+					    uint16_t *virt_addr, uint8_t *status);
 
 /** @brief Delete a virtual address in a vendor model's subscription list.
  *
@@ -1079,9 +1103,9 @@ int bt_mesh_cfg_mod_sub_va_del(uint16_t net_idx, uint16_t addr, uint16_t elem_ad
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_va_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				   const uint8_t label[16], uint16_t mod_id,
-				   uint16_t cid, uint16_t *virt_addr, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_sub_va_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+						const uint8_t label[16], uint16_t mod_id,
+						uint16_t cid, uint16_t *virt_addr, uint8_t *status);
 
 /** @brief Overwrite all addresses in a SIG model's subscription list with a
  *  virtual address.
@@ -1103,10 +1127,10 @@ int bt_mesh_cfg_mod_sub_va_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t ele
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_va_overwrite(uint16_t net_idx, uint16_t addr,
-				     uint16_t elem_addr, const uint8_t label[16],
-				     uint16_t mod_id, uint16_t *virt_addr,
-				     uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_sub_va_overwrite(uint16_t net_idx, uint16_t addr,
+						  uint16_t elem_addr, const uint8_t label[16],
+						  uint16_t mod_id, uint16_t *virt_addr,
+						  uint8_t *status);
 
 /** @brief Overwrite all addresses in a vendor model's subscription list with a
  *  virtual address.
@@ -1129,10 +1153,10 @@ int bt_mesh_cfg_mod_sub_va_overwrite(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_va_overwrite_vnd(uint16_t net_idx, uint16_t addr,
-					 uint16_t elem_addr, const uint8_t label[16],
-					 uint16_t mod_id, uint16_t cid,
-					 uint16_t *virt_addr, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_sub_va_overwrite_vnd(uint16_t net_idx, uint16_t addr,
+						      uint16_t elem_addr, const uint8_t label[16],
+						      uint16_t mod_id, uint16_t cid,
+						      uint16_t *virt_addr, uint8_t *status);
 
 /** @brief Get the subscription list of a SIG model on the target node.
  *
@@ -1153,9 +1177,9 @@ int bt_mesh_cfg_mod_sub_va_overwrite_vnd(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			    uint16_t mod_id, uint8_t *status, uint16_t *subs,
-			    size_t *sub_cnt);
+__deprecated int bt_mesh_cfg_mod_sub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					 uint16_t mod_id, uint8_t *status, uint16_t *subs,
+					 size_t *sub_cnt);
 
 /** @brief Get the subscription list of a vendor model on the target node.
  *
@@ -1177,12 +1201,50 @@ int bt_mesh_cfg_mod_sub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				uint16_t mod_id, uint16_t cid, uint8_t *status,
-				uint16_t *subs, size_t *sub_cnt);
+__deprecated int bt_mesh_cfg_mod_sub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					     uint16_t mod_id, uint16_t cid, uint8_t *status,
+					     uint16_t *subs, size_t *sub_cnt);
 
 /** Heartbeat subscription configuration parameters. */
-struct bt_mesh_cfg_hb_sub {
+__deprecated struct bt_mesh_cfg_hb_sub {
+	/** Source address to receive Heartbeat messages from. */
+	uint16_t src;
+	/** Destination address to receive Heartbeat messages on. */
+	uint16_t dst;
+	/**
+	 * Logarithmic subscription period to keep listening for.
+	 * The decoded subscription period is (1 << (period - 1)) seconds, or 0
+	 * seconds if period is 0.
+	 */
+	uint8_t  period;
+	/**
+	 * Logarithmic Heartbeat subscription receive count.
+	 * The decoded Heartbeat count is (1 << (count - 1)) if count is
+	 * between 1 and 0xfe, 0 if count is 0 and 0xffff if count is 0xff.
+	 *
+	 * Ignored in Heartbeat subscription set.
+	 */
+	uint8_t  count;
+	/**
+	 * Minimum hops in received messages, ie the shortest registered path
+	 * from the publishing node to the subscribing node. A Heartbeat
+	 * received from an immediate neighbor has hop count = 1.
+	 *
+	 * Ignored in Heartbeat subscription set.
+	 */
+	uint8_t  min;
+	/**
+	 * Maximum hops in received messages, ie the longest registered path
+	 * from the publishing node to the subscribing node. A Heartbeat
+	 * received from an immediate neighbor has hop count = 1.
+	 *
+	 * Ignored in Heartbeat subscription set.
+	 */
+	uint8_t  max;
+};
+
+/** Heartbeat subscription configuration parameters. */
+struct bt_mesh_cfg_cli_hb_sub {
 	/** Source address to receive Heartbeat messages from. */
 	uint16_t src;
 	/** Destination address to receive Heartbeat messages on. */
@@ -1234,8 +1296,8 @@ struct bt_mesh_cfg_hb_sub {
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_hb_sub_set(uint16_t net_idx, uint16_t addr,
-			   struct bt_mesh_cfg_hb_sub *sub, uint8_t *status);
+__deprecated int bt_mesh_cfg_hb_sub_set(uint16_t net_idx, uint16_t addr,
+					struct bt_mesh_cfg_hb_sub *sub, uint8_t *status);
 
 /** @brief Get the target node's Heartbeat subscription parameters.
  *
@@ -1250,11 +1312,46 @@ int bt_mesh_cfg_hb_sub_set(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_hb_sub_get(uint16_t net_idx, uint16_t addr,
-			   struct bt_mesh_cfg_hb_sub *sub, uint8_t *status);
+__deprecated int bt_mesh_cfg_hb_sub_get(uint16_t net_idx, uint16_t addr,
+					struct bt_mesh_cfg_hb_sub *sub, uint8_t *status);
+/** Heartbeat publication configuration parameters. */
+__deprecated struct bt_mesh_cfg_hb_pub {
+	/** Heartbeat destination address. */
+	uint16_t dst;
+	/**
+	 * Logarithmic Heartbeat count. Decoded as (1 << (count - 1)) if count
+	 * is between 1 and 0x11, 0 if count is 0, or "indefinitely" if count is
+	 * 0xff.
+	 *
+	 * When used in Heartbeat publication set, this parameter denotes the
+	 * number of Heartbeat messages to send.
+	 *
+	 * When returned from Heartbeat publication get, this parameter denotes
+	 * the number of Heartbeat messages remaining to be sent.
+	 */
+	uint8_t  count;
+	/**
+	 * Logarithmic Heartbeat publication transmit interval in seconds.
+	 * Decoded as (1 << (period - 1)) if period is between 1 and 0x11.
+	 * If period is 0, Heartbeat publication is disabled.
+	 */
+	uint8_t  period;
+	/** Publication message Time To Live value. */
+	uint8_t  ttl;
+	/**
+	 * Bitmap of features that trigger Heartbeat publications.
+	 * Legal values are @ref BT_MESH_FEAT_RELAY,
+	 * @ref BT_MESH_FEAT_PROXY, @ref BT_MESH_FEAT_FRIEND and
+	 * @ref BT_MESH_FEAT_LOW_POWER
+	 */
+	uint16_t feat;
+	/** Network index to publish with. */
+	uint16_t net_idx;
+};
+
 
 /** Heartbeat publication configuration parameters. */
-struct bt_mesh_cfg_hb_pub {
+struct bt_mesh_cfg_cli_hb_pub {
 	/** Heartbeat destination address. */
 	uint16_t dst;
 	/**
@@ -1305,8 +1402,8 @@ struct bt_mesh_cfg_hb_pub {
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_hb_pub_set(uint16_t net_idx, uint16_t addr,
-			   const struct bt_mesh_cfg_hb_pub *pub, uint8_t *status);
+__deprecated int bt_mesh_cfg_hb_pub_set(uint16_t net_idx, uint16_t addr,
+					const struct bt_mesh_cfg_hb_pub *pub, uint8_t *status);
 
 /** @brief Get the target node's Heartbeat publication parameters.
  *
@@ -1321,8 +1418,8 @@ int bt_mesh_cfg_hb_pub_set(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_hb_pub_get(uint16_t net_idx, uint16_t addr,
-			   struct bt_mesh_cfg_hb_pub *pub, uint8_t *status);
+__deprecated int bt_mesh_cfg_hb_pub_get(uint16_t net_idx, uint16_t addr,
+					struct bt_mesh_cfg_hb_pub *pub, uint8_t *status);
 
 /** @brief Delete all group addresses in a SIG model's subscription list.
  *
@@ -1338,9 +1435,8 @@ int bt_mesh_cfg_hb_pub_get(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_del_all(uint16_t net_idx, uint16_t addr,
-				uint16_t elem_addr, uint16_t mod_id,
-				uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_sub_del_all(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					     uint16_t mod_id, uint8_t *status);
 
 /** @brief Delete all group addresses in a vendor model's subscription list.
  *
@@ -1357,9 +1453,9 @@ int bt_mesh_cfg_mod_sub_del_all(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_mod_sub_del_all_vnd(uint16_t net_idx, uint16_t addr,
-				    uint16_t elem_addr, uint16_t mod_id,
-				    uint16_t cid, uint8_t *status);
+__deprecated int bt_mesh_cfg_mod_sub_del_all_vnd(uint16_t net_idx, uint16_t addr,
+						 uint16_t elem_addr, uint16_t mod_id, uint16_t cid,
+						 uint8_t *status);
 
 /** @brief Update a network key to the target node.
  *
@@ -1375,9 +1471,8 @@ int bt_mesh_cfg_mod_sub_del_all_vnd(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_net_key_update(uint16_t net_idx, uint16_t addr,
-			       uint16_t key_net_idx, const uint8_t net_key[16],
-			       uint8_t *status);
+__deprecated int bt_mesh_cfg_net_key_update(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+					    const uint8_t net_key[16], uint8_t *status);
 
 /** @brief Update an application key to the target node.
  *
@@ -1394,9 +1489,9 @@ int bt_mesh_cfg_net_key_update(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_app_key_update(uint16_t net_idx, uint16_t addr,
-			       uint16_t key_net_idx, uint16_t key_app_idx,
-			       const uint8_t app_key[16], uint8_t *status);
+__deprecated int bt_mesh_cfg_app_key_update(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+					    uint16_t key_app_idx, const uint8_t app_key[16],
+					    uint8_t *status);
 
 /** @brief Set the Node Identity parameters.
  *
@@ -1415,9 +1510,9 @@ int bt_mesh_cfg_app_key_update(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_node_identity_set(uint16_t net_idx, uint16_t addr,
-				  uint16_t key_net_idx, uint8_t new_identity,
-				  uint8_t *status, uint8_t *identity);
+__deprecated int bt_mesh_cfg_node_identity_set(uint16_t net_idx, uint16_t addr,
+					       uint16_t key_net_idx, uint8_t new_identity,
+					       uint8_t *status, uint8_t *identity);
 
 /** @brief Get the Node Identity parameters.
  *
@@ -1435,9 +1530,9 @@ int bt_mesh_cfg_node_identity_set(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_node_identity_get(uint16_t net_idx, uint16_t addr,
-				  uint16_t key_net_idx, uint8_t *status,
-				  uint8_t *identity);
+__deprecated int bt_mesh_cfg_node_identity_get(uint16_t net_idx, uint16_t addr,
+					       uint16_t key_net_idx, uint8_t *status,
+					       uint8_t *identity);
 
 /** @brief Get the Low Power Node Polltimeout parameters.
  *
@@ -1452,8 +1547,1101 @@ int bt_mesh_cfg_node_identity_get(uint16_t net_idx, uint16_t addr,
  *
  *  @return 0 on success, or (negative) error code on failure.
  */
-int bt_mesh_cfg_lpn_timeout_get(uint16_t net_idx, uint16_t addr,
-				uint16_t unicast_addr, int32_t *polltimeout);
+__deprecated int bt_mesh_cfg_lpn_timeout_get(uint16_t net_idx, uint16_t addr, uint16_t unicast_addr,
+					     int32_t *polltimeout);
+
+/** @brief Reset the target node and remove it from the network.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param status  Status response parameter
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_node_reset(uint16_t net_idx, uint16_t addr, bool *status);
+
+/** @brief Get the target node's composition data.
+ *
+ *  If the other device does not have the given composition data page, it will
+ *  return the largest page number it supports that is less than the requested
+ *  page index. The actual page the device responds with is returned in @c rsp.
+ *
+ *  This method can be used asynchronously by setting @p rsp and @p comp
+ *  as NULL. This way the method will not wait for response and will return
+ *  immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param page    Composition data page, or 0xff to request the first available
+ *                 page.
+ *  @param rsp     Return parameter for the returned page number, or NULL.
+ *  @param comp    Composition data buffer to fill.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_comp_data_get(uint16_t net_idx, uint16_t addr, uint8_t page, uint8_t *rsp,
+				  struct net_buf_simple *comp);
+
+/** @brief Get the target node's network beacon state.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param status  Status response parameter, returns one of
+ *                 @ref BT_MESH_BEACON_DISABLED or @ref BT_MESH_BEACON_ENABLED
+ *                 on success.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_beacon_get(uint16_t net_idx, uint16_t addr, uint8_t *status);
+
+/** @brief             Get the target node's network key refresh phase state.
+ *
+ *  This method can be used asynchronously by setting @p status and @p phase
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx     Network index to encrypt with.
+ *  @param addr        Target node address.
+ *  @param key_net_idx Network key index.
+ *  @param status      Status response parameter.
+ *  @param phase       Pointer to the Key Refresh variable to fill.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_krp_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx, uint8_t *status,
+			    uint8_t *phase);
+
+/** @brief             Set the target node's network key refresh phase parameters.
+ *
+ *  This method can be used asynchronously by setting @p status and @p phase
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx     Network index to encrypt with.
+ *  @param addr        Target node address.
+ *  @param key_net_idx Network key index.
+ *  @param transition  Transition parameter.
+ *  @param status      Status response parameter.
+ *  @param phase       Pointer to the new Key Refresh phase. Will return the actual
+ *                     Key Refresh phase after updating.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_krp_set(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+			    uint8_t transition, uint8_t *status, uint8_t *phase);
+
+/** @brief Set the target node's network beacon state.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param val     New network beacon state, should be one of
+ *                 @ref BT_MESH_BEACON_DISABLED or @ref BT_MESH_BEACON_ENABLED.
+ *  @param status  Status response parameter. Returns one of
+ *                 @ref BT_MESH_BEACON_DISABLED or @ref BT_MESH_BEACON_ENABLED
+ *                 on success.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_beacon_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *status);
+
+/** @brief Get the target node's Time To Live value.
+ *
+ *  This method can be used asynchronously by setting @p ttl
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param ttl     TTL response buffer.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_ttl_get(uint16_t net_idx, uint16_t addr, uint8_t *ttl);
+
+/** @brief Set the target node's Time To Live value.
+ *
+ *  This method can be used asynchronously by setting @p ttl
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param val     New Time To Live value.
+ *  @param ttl     TTL response buffer.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_ttl_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *ttl);
+
+/** @brief Get the target node's Friend feature status.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param status  Status response parameter. Returns one of
+ *                 @ref BT_MESH_FRIEND_DISABLED, @ref BT_MESH_FRIEND_ENABLED or
+ *                 @ref BT_MESH_FRIEND_NOT_SUPPORTED on success.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_friend_get(uint16_t net_idx, uint16_t addr, uint8_t *status);
+
+/** @brief Set the target node's Friend feature state.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param val     New Friend feature state. Should be one of
+ *                 @ref BT_MESH_FRIEND_DISABLED or
+ *                 @ref BT_MESH_FRIEND_ENABLED.
+ *  @param status  Status response parameter. Returns one of
+ *                 @ref BT_MESH_FRIEND_DISABLED, @ref BT_MESH_FRIEND_ENABLED or
+ *                 @ref BT_MESH_FRIEND_NOT_SUPPORTED on success.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_friend_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *status);
+
+/** @brief Get the target node's Proxy feature state.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param status  Status response parameter. Returns one of
+ *                 @ref BT_MESH_GATT_PROXY_DISABLED,
+ *                 @ref BT_MESH_GATT_PROXY_ENABLED or
+ *                 @ref BT_MESH_GATT_PROXY_NOT_SUPPORTED on success.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_gatt_proxy_get(uint16_t net_idx, uint16_t addr, uint8_t *status);
+
+/** @brief Set the target node's Proxy feature state.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param val     New Proxy feature state. Must be one of
+ *                 @ref BT_MESH_GATT_PROXY_DISABLED or
+ *                 @ref BT_MESH_GATT_PROXY_ENABLED.
+ *  @param status  Status response parameter. Returns one of
+ *                 @ref BT_MESH_GATT_PROXY_DISABLED,
+ *                 @ref BT_MESH_GATT_PROXY_ENABLED or
+ *                 @ref BT_MESH_GATT_PROXY_NOT_SUPPORTED on success.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_gatt_proxy_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *status);
+
+/** @brief Get the target node's network_transmit state.
+ *
+ *  This method can be used asynchronously by setting @p transmit
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx  Network index to encrypt with.
+ *  @param addr     Target node address.
+ *  @param transmit Network transmit response parameter. Returns the encoded
+ *                  network transmission parameters on success. Decoded with
+ *                  @ref BT_MESH_TRANSMIT_COUNT and @ref BT_MESH_TRANSMIT_INT.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_net_transmit_get(uint16_t net_idx, uint16_t addr, uint8_t *transmit);
+
+/** @brief Set the target node's network transmit parameters.
+ *
+ *  This method can be used asynchronously by setting @p transmit
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx    Network index to encrypt with.
+ *  @param addr       Target node address.
+ *  @param val        New encoded network transmit parameters.
+ *                    @see BT_MESH_TRANSMIT.
+ *  @param transmit   Network transmit response parameter. Returns the encoded
+ *                    network transmission parameters on success. Decoded with
+ *                    @ref BT_MESH_TRANSMIT_COUNT and @ref BT_MESH_TRANSMIT_INT.
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_net_transmit_set(uint16_t net_idx, uint16_t addr, uint8_t val,
+				     uint8_t *transmit);
+
+/** @brief Get the target node's Relay feature state.
+ *
+ *  This method can be used asynchronously by setting @p status and @p transmit
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx  Network index to encrypt with.
+ *  @param addr     Target node address.
+ *  @param status   Status response parameter. Returns one of
+ *                  @ref BT_MESH_RELAY_DISABLED, @ref BT_MESH_RELAY_ENABLED or
+ *                  @ref BT_MESH_RELAY_NOT_SUPPORTED on success.
+ *  @param transmit Transmit response parameter. Returns the encoded relay
+ *                  transmission parameters on success. Decoded with
+ *                  @ref BT_MESH_TRANSMIT_COUNT and @ref BT_MESH_TRANSMIT_INT.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_relay_get(uint16_t net_idx, uint16_t addr, uint8_t *status, uint8_t *transmit);
+
+/** @brief Set the target node's Relay parameters.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p transmit as NULL. This way the method will not wait for
+ *  response and will return immediately after sending the command.
+ *
+ *  @param net_idx      Network index to encrypt with.
+ *  @param addr         Target node address.
+ *  @param new_relay    New relay state. Must be one of
+ *                      @ref BT_MESH_RELAY_DISABLED or
+ *                      @ref BT_MESH_RELAY_ENABLED.
+ *  @param new_transmit New encoded relay transmit parameters.
+ *                      @see BT_MESH_TRANSMIT.
+ *  @param status       Status response parameter. Returns one of
+ *                      @ref BT_MESH_RELAY_DISABLED, @ref BT_MESH_RELAY_ENABLED
+ *                      or @ref BT_MESH_RELAY_NOT_SUPPORTED on success.
+ *  @param transmit     Transmit response parameter. Returns the encoded relay
+ *                      transmission parameters on success. Decoded with
+ *                      @ref BT_MESH_TRANSMIT_COUNT and
+ *                      @ref BT_MESH_TRANSMIT_INT.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_relay_set(uint16_t net_idx, uint16_t addr, uint8_t new_relay,
+			      uint8_t new_transmit, uint8_t *status, uint8_t *transmit);
+
+/** @brief Add a network key to the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx     Network index to encrypt with.
+ *  @param addr        Target node address.
+ *  @param key_net_idx Network key index.
+ *  @param net_key     Network key.
+ *  @param status      Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_net_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				const uint8_t net_key[16], uint8_t *status);
+
+/** @brief Get a list of the target node's network key indexes.
+ *
+ *  This method can be used asynchronously by setting @p keys
+ *  or @p key_cnt as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param keys    Net key index list response parameter. Will be filled with
+ *                 all the returned network key indexes it can fill.
+ *  @param key_cnt Net key index list length. Should be set to the
+ *                 capacity of the @c keys list when calling. Will return the
+ *                 number of returned network key indexes upon success.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_net_key_get(uint16_t net_idx, uint16_t addr, uint16_t *keys, size_t *key_cnt);
+
+/** @brief Delete a network key from the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx     Network index to encrypt with.
+ *  @param addr        Target node address.
+ *  @param key_net_idx Network key index.
+ *  @param status      Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_net_key_del(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				uint8_t *status);
+
+/** @brief Add an application key to the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx     Network index to encrypt with.
+ *  @param addr        Target node address.
+ *  @param key_net_idx Network key index the application key belongs to.
+ *  @param key_app_idx Application key index.
+ *  @param app_key     Application key.
+ *  @param status      Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_app_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				uint16_t key_app_idx, const uint8_t app_key[16], uint8_t *status);
+
+/** @brief Get a list of the target node's application key indexes for a
+ *         specific network key.
+ *
+ *  This method can be used asynchronously by setting @p status and
+ *  ( @p keys or @p key_cnt ) as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
+ *
+ *  @param net_idx     Network index to encrypt with.
+ *  @param addr        Target node address.
+ *  @param key_net_idx Network key index to request the app key indexes of.
+ *  @param status      Status response parameter.
+ *  @param keys        App key index list response parameter. Will be filled
+ *                     with all the returned application key indexes it can
+ *                     fill.
+ *  @param key_cnt     App key index list length. Should be set to the
+ *                     capacity of the @c keys list when calling. Will return
+ *                     the number of returned application key indexes upon
+ *                     success.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_app_key_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				uint8_t *status, uint16_t *keys, size_t *key_cnt);
+
+/** @brief Delete an application key from the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx     Network index to encrypt with.
+ *  @param addr        Target node address.
+ *  @param key_net_idx Network key index the application key belongs to.
+ *  @param key_app_idx Application key index.
+ *  @param status      Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_app_key_del(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				uint16_t key_app_idx, uint8_t *status);
+
+/** @brief Bind an application to a SIG model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx     Network index to encrypt with.
+ *  @param addr        Target node address.
+ *  @param elem_addr   Element address the model is in.
+ *  @param mod_app_idx Application index to bind.
+ *  @param mod_id      Model ID.
+ *  @param status      Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_app_bind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				 uint16_t mod_app_idx, uint16_t mod_id, uint8_t *status);
+
+/** @brief Unbind an application from a SIG model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx     Network index to encrypt with.
+ *  @param addr        Target node address.
+ *  @param elem_addr   Element address the model is in.
+ *  @param mod_app_idx Application index to unbind.
+ *  @param mod_id      Model ID.
+ *  @param status      Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_app_unbind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				   uint16_t mod_app_idx, uint16_t mod_id, uint8_t *status);
+
+/** @brief Bind an application to a vendor model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx     Network index to encrypt with.
+ *  @param addr        Target node address.
+ *  @param elem_addr   Element address the model is in.
+ *  @param mod_app_idx Application index to bind.
+ *  @param mod_id      Model ID.
+ *  @param cid         Company ID of the model.
+ *  @param status      Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_app_bind_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				     uint16_t mod_app_idx, uint16_t mod_id, uint16_t cid,
+				     uint8_t *status);
+
+/** @brief Unbind an application from a vendor model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response and will
+ *  return immediately after sending the command.
+ *
+ *  @param net_idx     Network index to encrypt with.
+ *  @param addr        Target node address.
+ *  @param elem_addr   Element address the model is in.
+ *  @param mod_app_idx Application index to unbind.
+ *  @param mod_id      Model ID.
+ *  @param cid         Company ID of the model.
+ *  @param status      Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_app_unbind_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				       uint16_t mod_app_idx, uint16_t mod_id, uint16_t cid,
+				       uint8_t *status);
+
+/** @brief Get a list of all applications bound to a SIG model on the target
+ *         node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and ( @p apps or @p app_cnt ) as NULL. This way the method will
+ *  not wait for response and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param mod_id    Model ID.
+ *  @param status    Status response parameter.
+ *  @param apps      App index list response parameter. Will be filled with all
+ *                   the returned application key indexes it can fill.
+ *  @param app_cnt   App index list length. Should be set to the capacity of the
+ *                   @c apps list when calling. Will return the number of
+ *                   returned application key indexes upon success.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_app_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t mod_id, uint8_t *status, uint16_t *apps, size_t *app_cnt);
+
+/** @brief Get a list of all applications bound to a vendor model on the target
+ *         node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and ( @p apps or @p app_cnt ) as NULL. This way the method will
+ *  not wait for response and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param mod_id    Model ID.
+ *  @param cid       Company ID of the model.
+ *  @param status    Status response parameter.
+ *  @param apps      App index list response parameter. Will be filled with all
+ *                   the returned application key indexes it can fill.
+ *  @param app_cnt   App index list length. Should be set to the capacity of the
+ *                   @c apps list when calling. Will return the number of
+ *                   returned application key indexes upon success.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t mod_id, uint16_t cid, uint8_t *status, uint16_t *apps,
+				    size_t *app_cnt);
+
+/** @brief Get publish parameters for a SIG model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status and
+ *  @p pub as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param mod_id    Model ID.
+ *  @param pub       Publication parameter return buffer.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_pub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t mod_id, struct bt_mesh_cfg_cli_mod_pub *pub,
+				uint8_t *status);
+
+/** @brief Get publish parameters for a vendor model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p pub as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param mod_id    Model ID.
+ *  @param cid       Company ID of the model.
+ *  @param pub       Publication parameter return buffer.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_pub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t mod_id, uint16_t cid,
+				    struct bt_mesh_cfg_cli_mod_pub *pub, uint8_t *status);
+
+/** @brief Set publish parameters for a SIG model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @p pub shall not be NULL.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param mod_id    Model ID.
+ *  @param pub       Publication parameters.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_pub_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t mod_id, struct bt_mesh_cfg_cli_mod_pub *pub,
+				uint8_t *status);
+
+/** @brief Set publish parameters for a vendor model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @p pub shall not be NULL.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param mod_id    Model ID.
+ *  @param cid       Company ID of the model.
+ *  @param pub       Publication parameters.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_pub_set_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t mod_id, uint16_t cid,
+				    struct bt_mesh_cfg_cli_mod_pub *pub, uint8_t *status);
+
+/** @brief Add a group address to a SIG model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param sub_addr  Group address to add to the subscription list.
+ *  @param mod_id    Model ID.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_add(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t sub_addr, uint16_t mod_id, uint8_t *status);
+
+/** @brief Add a group address to a vendor model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param sub_addr  Group address to add to the subscription list.
+ *  @param mod_id    Model ID.
+ *  @param cid       Company ID of the model.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t sub_addr, uint16_t mod_id, uint16_t cid,
+				    uint8_t *status);
+
+/** @brief Delete a group address in a SIG model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param sub_addr  Group address to add to the subscription list.
+ *  @param mod_id    Model ID.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_del(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t sub_addr, uint16_t mod_id, uint8_t *status);
+
+/** @brief Delete a group address in a vendor model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param sub_addr  Group address to add to the subscription list.
+ *  @param mod_id    Model ID.
+ *  @param cid       Company ID of the model.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t sub_addr, uint16_t mod_id, uint16_t cid,
+				    uint8_t *status);
+
+/** @brief Overwrite all addresses in a SIG model's subscription list with a
+ * group address.
+ *
+ * Deletes all subscriptions in the model's subscription list, and adds a
+ * single group address instead.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param sub_addr  Group address to add to the subscription list.
+ *  @param mod_id    Model ID.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_overwrite(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				      uint16_t sub_addr, uint16_t mod_id, uint8_t *status);
+
+/** @brief Overwrite all addresses in a vendor model's subscription list with a
+ * group address.
+ *
+ * Deletes all subscriptions in the model's subscription list, and adds a
+ * single group address instead.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param sub_addr  Group address to add to the subscription list.
+ *  @param mod_id    Model ID.
+ *  @param cid       Company ID of the model.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_overwrite_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					  uint16_t sub_addr, uint16_t mod_id, uint16_t cid,
+					  uint8_t *status);
+
+/** @brief Add a virtual address to a SIG model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p virt_addr as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param label     Virtual address label to add to the subscription list.
+ *  @param mod_id    Model ID.
+ *  @param virt_addr Virtual address response parameter.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_va_add(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				   const uint8_t label[16], uint16_t mod_id, uint16_t *virt_addr,
+				   uint8_t *status);
+
+/** @brief Add a virtual address to a vendor model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p virt_addr as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param label     Virtual address label to add to the subscription list.
+ *  @param mod_id    Model ID.
+ *  @param cid       Company ID of the model.
+ *  @param virt_addr Virtual address response parameter.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_va_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				       const uint8_t label[16], uint16_t mod_id, uint16_t cid,
+				       uint16_t *virt_addr, uint8_t *status);
+
+/** @brief Delete a virtual address in a SIG model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p virt_addr as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param label     Virtual address parameter to add to the subscription list.
+ *  @param mod_id    Model ID.
+ *  @param virt_addr Virtual address response parameter.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_va_del(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				   const uint8_t label[16], uint16_t mod_id, uint16_t *virt_addr,
+				   uint8_t *status);
+
+/** @brief Delete a virtual address in a vendor model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p virt_addr as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param label     Virtual address label to add to the subscription list.
+ *  @param mod_id    Model ID.
+ *  @param cid       Company ID of the model.
+ *  @param virt_addr Virtual address response parameter.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_va_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				       const uint8_t label[16], uint16_t mod_id, uint16_t cid,
+				       uint16_t *virt_addr, uint8_t *status);
+
+/** @brief Overwrite all addresses in a SIG model's subscription list with a
+ *  virtual address.
+ *
+ *  Deletes all subscriptions in the model's subscription list, and adds a
+ *  single group address instead.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p virt_addr as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param label     Virtual address label to add to the subscription list.
+ *  @param mod_id    Model ID.
+ *  @param virt_addr Virtual address response parameter.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_va_overwrite(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					 const uint8_t label[16], uint16_t mod_id,
+					 uint16_t *virt_addr, uint8_t *status);
+
+/** @brief Overwrite all addresses in a vendor model's subscription list with a
+ *  virtual address.
+ *
+ *  Deletes all subscriptions in the model's subscription list, and adds a
+ *  single group address instead.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p virt_addr as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param label     Virtual address label to add to the subscription list.
+ *  @param mod_id    Model ID.
+ *  @param cid       Company ID of the model.
+ *  @param virt_addr Virtual address response parameter.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_va_overwrite_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					     const uint8_t label[16], uint16_t mod_id, uint16_t cid,
+					     uint16_t *virt_addr, uint8_t *status);
+
+/** @brief Get the subscription list of a SIG model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status and
+ *  ( @p subs or @p sub_cnt ) as NULL. This way the method will
+ *  not wait for response and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param mod_id    Model ID.
+ *  @param status    Status response parameter.
+ *  @param subs      Subscription list response parameter. Will be filled with
+ *                   all the returned subscriptions it can fill.
+ *  @param sub_cnt   Subscription list element count. Should be set to the
+ *                   capacity of the @c subs list when calling. Will return the
+ *                   number of returned subscriptions upon success.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t mod_id, uint8_t *status, uint16_t *subs, size_t *sub_cnt);
+
+/** @brief Get the subscription list of a vendor model on the target node.
+ *
+ *  This method can be used asynchronously by setting @p status and
+ *  ( @p subs or @p sub_cnt ) as NULL. This way the method will
+ *  not wait for response and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param mod_id    Model ID.
+ *  @param cid       Company ID of the model.
+ *  @param status    Status response parameter.
+ *  @param subs      Subscription list response parameter. Will be filled with
+ *                   all the returned subscriptions it can fill.
+ *  @param sub_cnt   Subscription list element count. Should be set to the
+ *                   capacity of the @c subs list when calling. Will return the
+ *                   number of returned subscriptions upon success.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t mod_id, uint16_t cid, uint8_t *status, uint16_t *subs,
+				    size_t *sub_cnt);
+
+/** @brief Set the target node's Heartbeat subscription parameters.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @p sub shall not be null.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param sub     New Heartbeat subscription parameters.
+ *  @param status  Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_hb_sub_set(uint16_t net_idx, uint16_t addr, struct bt_mesh_cfg_cli_hb_sub *sub,
+			       uint8_t *status);
+
+/** @brief Get the target node's Heartbeat subscription parameters.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p sub as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param sub     Heartbeat subscription parameter return buffer.
+ *  @param status  Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_hb_sub_get(uint16_t net_idx, uint16_t addr, struct bt_mesh_cfg_cli_hb_sub *sub,
+			       uint8_t *status);
+
+/** @brief Set the target node's Heartbeat publication parameters.
+ *
+ *  @note The target node must already have received the specified network key.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @p pub shall not be NULL;
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param pub     New Heartbeat publication parameters.
+ *  @param status  Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_hb_pub_set(uint16_t net_idx, uint16_t addr,
+			       const struct bt_mesh_cfg_cli_hb_pub *pub, uint8_t *status);
+
+/** @brief Get the target node's Heartbeat publication parameters.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p pub as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param pub     Heartbeat publication parameter return buffer.
+ *  @param status  Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_hb_pub_get(uint16_t net_idx, uint16_t addr, struct bt_mesh_cfg_cli_hb_pub *pub,
+			       uint8_t *status);
+
+/** @brief Delete all group addresses in a SIG model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param mod_id    Model ID.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_del_all(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t mod_id, uint8_t *status);
+
+/** @brief Delete all group addresses in a vendor model's subscription list.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx   Network index to encrypt with.
+ *  @param addr      Target node address.
+ *  @param elem_addr Element address the model is in.
+ *  @param mod_id    Model ID.
+ *  @param cid       Company ID of the model.
+ *  @param status    Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_mod_sub_del_all_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					uint16_t mod_id, uint16_t cid, uint8_t *status);
+
+/** @brief Update a network key to the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx     Network index to encrypt with.
+ *  @param addr        Target node address.
+ *  @param key_net_idx Network key index.
+ *  @param net_key     Network key.
+ *  @param status      Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_net_key_update(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				   const uint8_t net_key[16], uint8_t *status);
+
+/** @brief Update an application key to the target node.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx     Network index to encrypt with.
+ *  @param addr        Target node address.
+ *  @param key_net_idx Network key index the application key belongs to.
+ *  @param key_app_idx Application key index.
+ *  @param app_key     Application key.
+ *  @param status      Status response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_app_key_update(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				   uint16_t key_app_idx, const uint8_t app_key[16],
+				   uint8_t *status);
+
+/** @brief Set the Node Identity parameters.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p identity as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param new_identity  New identity state. Must be one of
+ *                      @ref BT_MESH_NODE_IDENTITY_STOPPED or
+ *                      @ref BT_MESH_NODE_IDENTITY_RUNNING
+ *  @param key_net_idx Network key index the application key belongs to.
+ *  @param status  Status response parameter.
+ *  @param identity Identity response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_node_identity_set(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				      uint8_t new_identity, uint8_t *status, uint8_t *identity);
+
+/** @brief Get the Node Identity parameters.
+ *
+ *  This method can be used asynchronously by setting @p status
+ *  and @p identity as NULL. This way the method will not wait
+ *  for response and will return immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param key_net_idx Network key index the application key belongs to.
+ *  @param status  Status response parameter.
+ *  @param identity Identity response parameter. Must be one of
+ *                      @ref BT_MESH_NODE_IDENTITY_STOPPED or
+ *                      @ref BT_MESH_NODE_IDENTITY_RUNNING
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_node_identity_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				      uint8_t *status, uint8_t *identity);
+
+/** @brief Get the Low Power Node Polltimeout parameters.
+ *
+ *  This method can be used asynchronously by setting @p polltimeout
+ *  as NULL. This way the method will not wait for response
+ *  and will return immediately after sending the command.
+ *
+ *  @param net_idx Network index to encrypt with.
+ *  @param addr    Target node address.
+ *  @param unicast_addr LPN unicast address.
+ *  @param polltimeout Poll timeout response parameter.
+ *
+ *  @return 0 on success, or (negative) error code on failure.
+ */
+int bt_mesh_cfg_cli_lpn_timeout_get(uint16_t net_idx, uint16_t addr, uint16_t unicast_addr,
+				    int32_t *polltimeout);
 
 /** @brief Get the current transmission timeout value.
  *
@@ -1470,7 +2658,7 @@ void bt_mesh_cfg_cli_timeout_set(int32_t timeout);
 /** Parsed Composition data page 0 representation.
  *
  *  Should be pulled from the return buffer passed to
- *  @ref bt_mesh_cfg_comp_data_get using
+ *  @ref bt_mesh_cfg_cli_comp_data_get using
  *  @ref bt_mesh_comp_p0_get.
  */
 struct bt_mesh_comp_p0 {
@@ -1505,14 +2693,14 @@ struct bt_mesh_comp_p0_elem {
  *  The composition data page object will take ownership over the buffer, which
  *  should not be manipulated directly after this call.
  *
- *  This function can be used in combination with @ref bt_mesh_cfg_comp_data_get
+ *  This function can be used in combination with @ref bt_mesh_cfg_cli_comp_data_get
  *  to read out composition data page 0 from other devices:
  *
  *  @code
  *  NET_BUF_SIMPLE_DEFINE(buf, BT_MESH_RX_SDU_MAX);
  *  struct bt_mesh_comp_p0 comp;
  *
- *  err = bt_mesh_cfg_comp_data_get(net_idx, addr, 0, &page, &buf);
+ *  err = bt_mesh_cfg_cli_comp_data_get(net_idx, addr, 0, &page, &buf);
  *  if (!err) {
  *          bt_mesh_comp_p0_get(&comp, &buf);
  *  }

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -120,23 +120,22 @@ static void configure(void)
 	printk("Configuring...\n");
 
 	/* Add Application Key */
-	bt_mesh_cfg_app_key_add(net_idx, addr, net_idx, app_idx, app_key, NULL);
+	bt_mesh_cfg_cli_app_key_add(net_idx, addr, net_idx, app_idx, app_key, NULL);
 
 	/* Bind to vendor model */
-	bt_mesh_cfg_mod_app_bind_vnd(net_idx, addr, addr, app_idx,
-				     MOD_LF, BT_COMP_ID_LF, NULL);
+	bt_mesh_cfg_cli_mod_app_bind_vnd(net_idx, addr, addr, app_idx, MOD_LF, BT_COMP_ID_LF, NULL);
 
 	/* Bind to Health model */
-	bt_mesh_cfg_mod_app_bind(net_idx, addr, addr, app_idx,
-				 BT_MESH_MODEL_ID_HEALTH_SRV, NULL);
+	bt_mesh_cfg_cli_mod_app_bind(net_idx, addr, addr, app_idx, BT_MESH_MODEL_ID_HEALTH_SRV,
+				     NULL);
 
 	/* Add model subscription */
-	bt_mesh_cfg_mod_sub_add_vnd(net_idx, addr, addr, GROUP_ADDR,
-				    MOD_LF, BT_COMP_ID_LF, NULL);
+	bt_mesh_cfg_cli_mod_sub_add_vnd(net_idx, addr, addr, GROUP_ADDR, MOD_LF, BT_COMP_ID_LF,
+					NULL);
 
 #if NODE_ADDR == PUBLISHER_ADDR
 	{
-		struct bt_mesh_cfg_hb_pub pub = {
+		struct bt_mesh_cfg_cli_hb_pub pub = {
 			.dst = GROUP_ADDR,
 			.count = 0xff,
 			.period = 0x05,
@@ -145,7 +144,7 @@ static void configure(void)
 			.net_idx = net_idx,
 		};
 
-		bt_mesh_cfg_hb_pub_set(net_idx, addr, &pub, NULL);
+		bt_mesh_cfg_cli_hb_pub_set(net_idx, addr, &pub, NULL);
 		printk("Publishing heartbeat messages\n");
 	}
 #endif
@@ -205,13 +204,13 @@ static void bt_ready(int err)
 	 * it explicitly.
 	 */
 	{
-		struct bt_mesh_cfg_hb_sub sub = {
+		struct bt_mesh_cfg_cli_hb_sub sub = {
 			.src = PUBLISHER_ADDR,
 			.dst = GROUP_ADDR,
 			.period = 0x10,
 		};
 
-		bt_mesh_cfg_hb_sub_set(net_idx, addr, &sub, NULL);
+		bt_mesh_cfg_cli_hb_sub_set(net_idx, addr, &sub, NULL);
 		printk("Subscribing to heartbeat messages\n");
 	}
 #endif

--- a/samples/bluetooth/mesh_provisioner/src/main.c
+++ b/samples/bluetooth/mesh_provisioner/src/main.c
@@ -101,17 +101,16 @@ static void configure_self(struct bt_mesh_cdb_node *self)
 	}
 
 	/* Add Application Key */
-	err = bt_mesh_cfg_app_key_add(self->net_idx, self->addr, self->net_idx,
-				      app_idx, key->keys[0].app_key, &status);
+	err = bt_mesh_cfg_cli_app_key_add(self->net_idx, self->addr, self->net_idx, app_idx,
+					  key->keys[0].app_key, &status);
 	if (err || status) {
 		printk("Failed to add app-key (err %d, status %d)\n", err,
 		       status);
 		return;
 	}
 
-	err = bt_mesh_cfg_mod_app_bind(self->net_idx, self->addr, self->addr,
-				       app_idx, BT_MESH_MODEL_ID_HEALTH_CLI,
-				       &status);
+	err = bt_mesh_cfg_cli_mod_app_bind(self->net_idx, self->addr, self->addr, app_idx,
+					   BT_MESH_MODEL_ID_HEALTH_CLI, &status);
 	if (err || status) {
 		printk("Failed to bind app-key (err %d, status %d)\n", err,
 		       status);
@@ -145,15 +144,15 @@ static void configure_node(struct bt_mesh_cdb_node *node)
 	}
 
 	/* Add Application Key */
-	err = bt_mesh_cfg_app_key_add(net_idx, node->addr, net_idx, app_idx,
-				      key->keys[0].app_key, &status);
+	err = bt_mesh_cfg_cli_app_key_add(net_idx, node->addr, net_idx, app_idx,
+					  key->keys[0].app_key, &status);
 	if (err || status) {
 		printk("Failed to add app-key (err %d status %d)\n", err, status);
 		return;
 	}
 
 	/* Get the node's composition data and bind all models to the appkey */
-	err = bt_mesh_cfg_comp_data_get(net_idx, node->addr, 0, &status, &buf);
+	err = bt_mesh_cfg_cli_comp_data_get(net_idx, node->addr, 0, &status, &buf);
 	if (err || status) {
 		printk("Failed to get Composition data (err %d, status: %d)\n",
 		       err, status);
@@ -180,9 +179,8 @@ static void configure_node(struct bt_mesh_cdb_node *node)
 			printk("Binding AppKey to model 0x%03x:%04x\n",
 			       elem_addr, id);
 
-			err = bt_mesh_cfg_mod_app_bind(net_idx, node->addr,
-						       elem_addr, app_idx, id,
-						       &status);
+			err = bt_mesh_cfg_cli_mod_app_bind(net_idx, node->addr, elem_addr, app_idx,
+							   id, &status);
 			if (err || status) {
 				printk("Failed (err: %d, status: %d)\n", err,
 				       status);
@@ -196,10 +194,8 @@ static void configure_node(struct bt_mesh_cdb_node *node)
 			printk("Binding AppKey to model 0x%03x:%04x:%04x\n",
 			       elem_addr, id.company, id.id);
 
-			err = bt_mesh_cfg_mod_app_bind_vnd(net_idx, node->addr,
-							   elem_addr, app_idx,
-							   id.id, id.company,
-							   &status);
+			err = bt_mesh_cfg_cli_mod_app_bind_vnd(net_idx, node->addr, elem_addr,
+							       app_idx, id.id, id.company, &status);
 			if (err || status) {
 				printk("Failed (err: %d, status: %d)\n", err,
 				       status);

--- a/samples/boards/reel_board/mesh_badge/src/mesh.c
+++ b/samples/boards/reel_board/mesh_badge/src/mesh.c
@@ -504,7 +504,7 @@ static int provision_and_configure(void)
 		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
 		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
 	};
-	struct bt_mesh_cfg_mod_pub pub = {
+	struct bt_mesh_cfg_cli_mod_pub pub = {
 		.addr = GROUP_ADDR,
 		.app_idx = APP_IDX,
 		.ttl = DEFAULT_TTL,
@@ -538,28 +538,26 @@ static int provision_and_configure(void)
 	printk("Configuring...\n");
 
 	/* Add Application Key */
-	bt_mesh_cfg_app_key_add(NET_IDX, addr, NET_IDX, APP_IDX, app_key, NULL);
+	bt_mesh_cfg_cli_app_key_add(NET_IDX, addr, NET_IDX, APP_IDX, app_key, NULL);
 
 	/* Bind to vendor model */
-	bt_mesh_cfg_mod_app_bind_vnd(NET_IDX, addr, addr, APP_IDX,
-				     MOD_LF, BT_COMP_ID_LF, NULL);
+	bt_mesh_cfg_cli_mod_app_bind_vnd(NET_IDX, addr, addr, APP_IDX, MOD_LF, BT_COMP_ID_LF, NULL);
 
-	bt_mesh_cfg_mod_app_bind(NET_IDX, addr, addr, APP_IDX,
-				 BT_MESH_MODEL_ID_GEN_ONOFF_SRV, NULL);
+	bt_mesh_cfg_cli_mod_app_bind(NET_IDX, addr, addr, APP_IDX, BT_MESH_MODEL_ID_GEN_ONOFF_SRV,
+				     NULL);
 
-	bt_mesh_cfg_mod_app_bind(NET_IDX, addr, addr, APP_IDX,
-				 BT_MESH_MODEL_ID_SENSOR_SRV, NULL);
+	bt_mesh_cfg_cli_mod_app_bind(NET_IDX, addr, addr, APP_IDX, BT_MESH_MODEL_ID_SENSOR_SRV,
+				     NULL);
 
 	/* Bind to Health model */
-	bt_mesh_cfg_mod_app_bind(NET_IDX, addr, addr, APP_IDX,
-				 BT_MESH_MODEL_ID_HEALTH_SRV, NULL);
+	bt_mesh_cfg_cli_mod_app_bind(NET_IDX, addr, addr, APP_IDX, BT_MESH_MODEL_ID_HEALTH_SRV,
+				     NULL);
 
 	/* Add model subscription */
-	bt_mesh_cfg_mod_sub_add_vnd(NET_IDX, addr, addr, GROUP_ADDR,
-				    MOD_LF, BT_COMP_ID_LF, NULL);
+	bt_mesh_cfg_cli_mod_sub_add_vnd(NET_IDX, addr, addr, GROUP_ADDR, MOD_LF, BT_COMP_ID_LF,
+					NULL);
 
-	bt_mesh_cfg_mod_pub_set_vnd(NET_IDX, addr, addr, MOD_LF, BT_COMP_ID_LF,
-				    &pub, NULL);
+	bt_mesh_cfg_cli_mod_pub_set_vnd(NET_IDX, addr, addr, MOD_LF, BT_COMP_ID_LF, &pub, NULL);
 
 	printk("Configuration complete\n");
 

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -633,7 +633,7 @@ struct mod_pub_param {
 	uint16_t cid;
 	uint16_t elem_addr;
 	uint8_t *status;
-	struct bt_mesh_cfg_mod_pub *pub;
+	struct bt_mesh_cfg_cli_mod_pub *pub;
 };
 
 static int mod_pub_status(struct bt_mesh_model *model,
@@ -642,7 +642,7 @@ static int mod_pub_status(struct bt_mesh_model *model,
 {
 	struct mod_pub_param *param;
 	uint16_t mod_id, cid, elem_addr;
-	struct bt_mesh_cfg_mod_pub pub;
+	struct bt_mesh_cfg_cli_mod_pub pub;
 	uint8_t status;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
@@ -791,7 +791,7 @@ static int mod_sub_list_vnd(struct bt_mesh_model *model,
 
 struct hb_sub_param {
 	uint8_t *status;
-	struct bt_mesh_cfg_hb_sub *sub;
+	struct bt_mesh_cfg_cli_hb_sub *sub;
 };
 
 static int hb_sub_status(struct bt_mesh_model *model,
@@ -799,7 +799,7 @@ static int hb_sub_status(struct bt_mesh_model *model,
 			 struct net_buf_simple *buf)
 {
 	struct hb_sub_param *param;
-	struct bt_mesh_cfg_hb_sub sub;
+	struct bt_mesh_cfg_cli_hb_sub sub;
 	uint8_t status;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
@@ -831,7 +831,7 @@ static int hb_sub_status(struct bt_mesh_model *model,
 
 struct hb_pub_param {
 	uint8_t *status;
-	struct bt_mesh_cfg_hb_pub *pub;
+	struct bt_mesh_cfg_cli_hb_pub *pub;
 };
 
 static int hb_pub_status(struct bt_mesh_model *model,
@@ -840,7 +840,7 @@ static int hb_pub_status(struct bt_mesh_model *model,
 {
 	struct hb_pub_param *param;
 	uint8_t status;
-	struct bt_mesh_cfg_hb_pub pub;
+	struct bt_mesh_cfg_cli_hb_pub pub;
 
 	BT_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s",
 	       ctx->net_idx, ctx->app_idx, ctx->addr, buf->len,
@@ -1026,8 +1026,375 @@ static int cli_prepare(void *param, uint32_t op, uint16_t addr)
 	return bt_mesh_msg_ack_ctx_prepare(&cli->ack_ctx, op, addr, param);
 }
 
-int bt_mesh_cfg_comp_data_get(uint16_t net_idx, uint16_t addr, uint8_t page,
-			      uint8_t *rsp, struct net_buf_simple *comp)
+int bt_mesh_cfg_comp_data_get(uint16_t net_idx, uint16_t addr, uint8_t page, uint8_t *rsp,
+			      struct net_buf_simple *comp)
+{
+	return bt_mesh_cfg_cli_comp_data_get(net_idx, addr, page, rsp, comp);
+}
+
+int bt_mesh_cfg_beacon_get(uint16_t net_idx, uint16_t addr, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_beacon_get(net_idx, addr, status);
+}
+
+int bt_mesh_cfg_krp_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx, uint8_t *status,
+			uint8_t *phase)
+{
+	return bt_mesh_cfg_cli_krp_get(net_idx, addr, key_net_idx, status, phase);
+}
+
+int bt_mesh_cfg_krp_set(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx, uint8_t transition,
+			uint8_t *status, uint8_t *phase)
+{
+	return bt_mesh_cfg_cli_krp_set(net_idx, addr, key_net_idx, transition, status, phase);
+}
+
+int bt_mesh_cfg_beacon_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_beacon_set(net_idx, addr, val, status);
+}
+
+int bt_mesh_cfg_ttl_get(uint16_t net_idx, uint16_t addr, uint8_t *ttl)
+{
+	return bt_mesh_cfg_cli_ttl_get(net_idx, addr, ttl);
+}
+
+int bt_mesh_cfg_ttl_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *ttl)
+{
+	return bt_mesh_cfg_cli_ttl_set(net_idx, addr, val, ttl);
+}
+
+int bt_mesh_cfg_friend_get(uint16_t net_idx, uint16_t addr, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_friend_get(net_idx, addr, status);
+}
+
+int bt_mesh_cfg_friend_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_friend_set(net_idx, addr, val, status);
+}
+
+int bt_mesh_cfg_gatt_proxy_get(uint16_t net_idx, uint16_t addr, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_gatt_proxy_get(net_idx, addr, status);
+}
+
+int bt_mesh_cfg_gatt_proxy_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_gatt_proxy_set(net_idx, addr, val, status);
+}
+
+int bt_mesh_cfg_net_transmit_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *transmit)
+{
+	return bt_mesh_cfg_cli_net_transmit_set(net_idx, addr, val, transmit);
+}
+
+int bt_mesh_cfg_net_transmit_get(uint16_t net_idx, uint16_t addr, uint8_t *transmit)
+{
+	return bt_mesh_cfg_cli_net_transmit_get(net_idx, addr, transmit);
+}
+
+int bt_mesh_cfg_relay_get(uint16_t net_idx, uint16_t addr, uint8_t *status, uint8_t *transmit)
+{
+	return bt_mesh_cfg_cli_relay_get(net_idx, addr, status, transmit);
+}
+
+int bt_mesh_cfg_relay_set(uint16_t net_idx, uint16_t addr, uint8_t new_relay, uint8_t new_transmit,
+			  uint8_t *status, uint8_t *transmit)
+{
+	return bt_mesh_cfg_cli_relay_set(net_idx, addr, new_relay, new_transmit, status, transmit);
+}
+
+int bt_mesh_cfg_net_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+			    const uint8_t net_key[16], uint8_t *status)
+{
+	return bt_mesh_cfg_cli_net_key_add(net_idx, addr, key_net_idx, net_key, status);
+}
+
+int bt_mesh_cfg_net_key_update(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+			       const uint8_t net_key[16], uint8_t *status)
+{
+	return bt_mesh_cfg_cli_net_key_update(net_idx, addr, key_net_idx, net_key, status);
+}
+
+int bt_mesh_cfg_net_key_get(uint16_t net_idx, uint16_t addr, uint16_t *keys, size_t *key_cnt)
+{
+	return bt_mesh_cfg_cli_net_key_get(net_idx, addr, keys, key_cnt);
+}
+
+int bt_mesh_cfg_net_key_del(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_net_key_del(net_idx, addr, key_net_idx, status);
+}
+
+int bt_mesh_cfg_app_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+			    uint16_t key_app_idx, const uint8_t app_key[16], uint8_t *status)
+{
+	return bt_mesh_cfg_cli_app_key_add(net_idx, addr, key_net_idx, key_app_idx, app_key,
+					   status);
+}
+
+int bt_mesh_cfg_app_key_update(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+			       uint16_t key_app_idx, const uint8_t app_key[16], uint8_t *status)
+{
+	return bt_mesh_cfg_cli_app_key_update(net_idx, addr, key_net_idx, key_app_idx, app_key,
+					      status);
+}
+
+int bt_mesh_cfg_node_reset(uint16_t net_idx, uint16_t addr, bool *status)
+{
+	return bt_mesh_cfg_cli_node_reset(net_idx, addr, status);
+}
+
+int bt_mesh_cfg_app_key_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx, uint8_t *status,
+			    uint16_t *keys, size_t *key_cnt)
+{
+	return bt_mesh_cfg_cli_app_key_get(net_idx, addr, key_net_idx, status, keys, key_cnt);
+}
+
+int bt_mesh_cfg_app_key_del(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+			    uint16_t key_app_idx, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_app_key_del(net_idx, addr, key_net_idx, key_app_idx, status);
+}
+
+int bt_mesh_cfg_mod_app_bind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+			     uint16_t mod_app_idx, uint16_t mod_id, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_app_bind(net_idx, addr, elem_addr, mod_app_idx, mod_id, status);
+}
+
+int bt_mesh_cfg_mod_app_bind_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				 uint16_t mod_app_idx, uint16_t mod_id, uint16_t cid,
+				 uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_app_bind_vnd(net_idx, addr, elem_addr, mod_app_idx, mod_id, cid,
+						status);
+}
+
+int bt_mesh_cfg_mod_app_unbind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+			       uint16_t mod_app_idx, uint16_t mod_id, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_app_unbind(net_idx, addr, elem_addr, mod_app_idx, mod_id,
+					      status);
+}
+
+int bt_mesh_cfg_mod_app_unbind_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				   uint16_t mod_app_idx, uint16_t mod_id, uint16_t cid,
+				   uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_app_unbind_vnd(net_idx, addr, elem_addr, mod_app_idx, mod_id,
+						  cid, status);
+}
+
+int bt_mesh_cfg_mod_app_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, uint16_t mod_id,
+			    uint8_t *status, uint16_t *apps, size_t *app_cnt)
+{
+	return bt_mesh_cfg_cli_mod_app_get(net_idx, addr, elem_addr, mod_id, status, apps, app_cnt);
+}
+
+int bt_mesh_cfg_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t mod_id, uint16_t cid, uint8_t *status, uint16_t *apps,
+				size_t *app_cnt)
+{
+	return bt_mesh_cfg_cli_mod_app_get_vnd(net_idx, addr, elem_addr, mod_id, cid, status, apps,
+					       app_cnt);
+}
+
+int bt_mesh_cfg_mod_sub_add(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, uint16_t sub_addr,
+			    uint16_t mod_id, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_sub_add(net_idx, addr, elem_addr, sub_addr, mod_id, status);
+}
+
+int bt_mesh_cfg_mod_sub_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t sub_addr, uint16_t mod_id, uint16_t cid, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_sub_add_vnd(net_idx, addr, elem_addr, sub_addr, mod_id, cid,
+					       status);
+}
+
+int bt_mesh_cfg_mod_sub_del(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, uint16_t sub_addr,
+			    uint16_t mod_id, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_sub_del(net_idx, addr, elem_addr, sub_addr, mod_id, status);
+}
+
+int bt_mesh_cfg_mod_sub_del_all(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t mod_id, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_sub_del_all(net_idx, addr, elem_addr, mod_id, status);
+}
+
+int bt_mesh_cfg_mod_sub_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t sub_addr, uint16_t mod_id, uint16_t cid, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_sub_del_vnd(net_idx, addr, elem_addr, sub_addr, mod_id, cid,
+					       status);
+}
+
+int bt_mesh_cfg_mod_sub_del_all_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t mod_id, uint16_t cid, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_sub_del_all_vnd(net_idx, addr, elem_addr, mod_id, cid, status);
+}
+
+int bt_mesh_cfg_mod_sub_overwrite(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				  uint16_t sub_addr, uint16_t mod_id, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_sub_overwrite(net_idx, addr, elem_addr, sub_addr, mod_id,
+						 status);
+}
+
+int bt_mesh_cfg_mod_sub_overwrite_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				      uint16_t sub_addr, uint16_t mod_id, uint16_t cid,
+				      uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_sub_overwrite_vnd(net_idx, addr, elem_addr, sub_addr, mod_id,
+						     cid, status);
+}
+
+int bt_mesh_cfg_mod_sub_va_add(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+			       const uint8_t label[16], uint16_t mod_id, uint16_t *virt_addr,
+			       uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_sub_va_add(net_idx, addr, elem_addr, label, mod_id, virt_addr,
+					      status);
+}
+
+int bt_mesh_cfg_mod_sub_va_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				   const uint8_t label[16], uint16_t mod_id, uint16_t cid,
+				   uint16_t *virt_addr, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_sub_va_add_vnd(net_idx, addr, elem_addr, label, mod_id, cid,
+						  virt_addr, status);
+}
+
+int bt_mesh_cfg_mod_sub_va_del(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+			       const uint8_t label[16], uint16_t mod_id, uint16_t *virt_addr,
+			       uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_sub_va_del(net_idx, addr, elem_addr, label, mod_id, virt_addr,
+					      status);
+}
+
+int bt_mesh_cfg_mod_sub_va_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				   const uint8_t label[16], uint16_t mod_id, uint16_t cid,
+				   uint16_t *virt_addr, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_sub_va_del_vnd(net_idx, addr, elem_addr, label, mod_id, cid,
+						  virt_addr, status);
+}
+
+int bt_mesh_cfg_mod_sub_va_overwrite(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				     const uint8_t label[16], uint16_t mod_id, uint16_t *virt_addr,
+				     uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_sub_va_overwrite(net_idx, addr, elem_addr, label, mod_id,
+						    virt_addr, status);
+}
+
+int bt_mesh_cfg_mod_sub_va_overwrite_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					 const uint8_t label[16], uint16_t mod_id, uint16_t cid,
+					 uint16_t *virt_addr, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_sub_va_overwrite_vnd(net_idx, addr, elem_addr, label, mod_id,
+							cid, virt_addr, status);
+}
+
+int bt_mesh_cfg_mod_sub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, uint16_t mod_id,
+			    uint8_t *status, uint16_t *subs, size_t *sub_cnt)
+{
+	return bt_mesh_cfg_cli_mod_sub_get(net_idx, addr, elem_addr, mod_id, status, subs, sub_cnt);
+}
+
+int bt_mesh_cfg_mod_sub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t mod_id, uint16_t cid, uint8_t *status, uint16_t *subs,
+				size_t *sub_cnt)
+{
+	return bt_mesh_cfg_cli_mod_sub_get_vnd(net_idx, addr, elem_addr, mod_id, cid, status, subs,
+					       sub_cnt);
+}
+
+int bt_mesh_cfg_mod_pub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, uint16_t mod_id,
+			    struct bt_mesh_cfg_mod_pub *pub, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_pub_get(net_idx, addr, elem_addr, mod_id,
+					   (struct bt_mesh_cfg_cli_mod_pub *)pub, status);
+}
+
+int bt_mesh_cfg_mod_pub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t mod_id, uint16_t cid, struct bt_mesh_cfg_mod_pub *pub,
+				uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_pub_get_vnd(net_idx, addr, elem_addr, mod_id, cid,
+					       (struct bt_mesh_cfg_cli_mod_pub *)pub, status);
+}
+
+int bt_mesh_cfg_mod_pub_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, uint16_t mod_id,
+			    struct bt_mesh_cfg_mod_pub *pub, uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_pub_set(net_idx, addr, elem_addr, mod_id,
+					   (struct bt_mesh_cfg_cli_mod_pub *)pub, status);
+}
+
+int bt_mesh_cfg_mod_pub_set_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t mod_id, uint16_t cid, struct bt_mesh_cfg_mod_pub *pub,
+				uint8_t *status)
+{
+	return bt_mesh_cfg_cli_mod_pub_set_vnd(net_idx, addr, elem_addr, mod_id, cid,
+					       (struct bt_mesh_cfg_cli_mod_pub *)pub, status);
+}
+
+int bt_mesh_cfg_hb_sub_set(uint16_t net_idx, uint16_t addr, struct bt_mesh_cfg_hb_sub *sub,
+			   uint8_t *status)
+{
+	return bt_mesh_cfg_cli_hb_sub_set(net_idx, addr, (struct bt_mesh_cfg_cli_hb_sub *)sub,
+					  status);
+}
+
+int bt_mesh_cfg_hb_sub_get(uint16_t net_idx, uint16_t addr, struct bt_mesh_cfg_hb_sub *sub,
+			   uint8_t *status)
+{
+	return bt_mesh_cfg_cli_hb_sub_get(net_idx, addr, (struct bt_mesh_cfg_cli_hb_sub *)sub,
+					  status);
+}
+
+int bt_mesh_cfg_hb_pub_set(uint16_t net_idx, uint16_t addr, const struct bt_mesh_cfg_hb_pub *pub,
+			   uint8_t *status)
+{
+	return bt_mesh_cfg_cli_hb_pub_set(net_idx, addr, (struct bt_mesh_cfg_cli_hb_pub *)pub,
+					  status);
+}
+
+int bt_mesh_cfg_hb_pub_get(uint16_t net_idx, uint16_t addr, struct bt_mesh_cfg_hb_pub *pub,
+			   uint8_t *status)
+{
+	return bt_mesh_cfg_cli_hb_pub_get(net_idx, addr, (struct bt_mesh_cfg_cli_hb_pub *)pub,
+					  status);
+}
+
+int bt_mesh_cfg_node_identity_set(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				  uint8_t new_identity, uint8_t *status, uint8_t *identity)
+{
+	return bt_mesh_cfg_cli_node_identity_set(net_idx, addr, key_net_idx, new_identity, status,
+						 identity);
+}
+
+int bt_mesh_cfg_node_identity_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				  uint8_t *status, uint8_t *identity)
+{
+	return bt_mesh_cfg_cli_node_identity_get(net_idx, addr, key_net_idx, status, identity);
+}
+
+int bt_mesh_cfg_lpn_timeout_get(uint16_t net_idx, uint16_t addr, uint16_t unicast_addr,
+				int32_t *polltimeout)
+{
+	return bt_mesh_cfg_cli_lpn_timeout_get(net_idx, addr, unicast_addr, polltimeout);
+}
+
+int bt_mesh_cfg_cli_comp_data_get(uint16_t net_idx, uint16_t addr, uint8_t page, uint8_t *rsp,
+				  struct net_buf_simple *comp)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_DEV_COMP_DATA_GET, 1);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1065,8 +1432,7 @@ int bt_mesh_cfg_comp_data_get(uint16_t net_idx, uint16_t addr, uint8_t page,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-static int get_state_u8(uint16_t net_idx, uint16_t addr, uint32_t op, uint32_t rsp,
-			uint8_t *val)
+static int get_state_u8(uint16_t net_idx, uint16_t addr, uint32_t op, uint32_t rsp, uint8_t *val)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, DUMMY_2_BYTE_OP, 0);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1099,8 +1465,8 @@ static int get_state_u8(uint16_t net_idx, uint16_t addr, uint32_t op, uint32_t r
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-static int set_state_u8(uint16_t net_idx, uint16_t addr, uint32_t op, uint32_t rsp,
-			uint8_t new_val, uint8_t *val)
+static int set_state_u8(uint16_t net_idx, uint16_t addr, uint32_t op, uint32_t rsp, uint8_t new_val,
+			uint8_t *val)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, DUMMY_2_BYTE_OP, 1);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1134,14 +1500,13 @@ static int set_state_u8(uint16_t net_idx, uint16_t addr, uint32_t op, uint32_t r
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_beacon_get(uint16_t net_idx, uint16_t addr, uint8_t *status)
+int bt_mesh_cfg_cli_beacon_get(uint16_t net_idx, uint16_t addr, uint8_t *status)
 {
-	return get_state_u8(net_idx, addr, OP_BEACON_GET, OP_BEACON_STATUS,
-			    status);
+	return get_state_u8(net_idx, addr, OP_BEACON_GET, OP_BEACON_STATUS, status);
 }
 
-int bt_mesh_cfg_krp_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
-			uint8_t *status, uint8_t *phase)
+int bt_mesh_cfg_cli_krp_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx, uint8_t *status,
+			    uint8_t *phase)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_KRP_GET, 2);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1179,8 +1544,8 @@ int bt_mesh_cfg_krp_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_krp_set(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
-			uint8_t transition, uint8_t *status, uint8_t *phase)
+int bt_mesh_cfg_cli_krp_set(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+			    uint8_t transition, uint8_t *status, uint8_t *phase)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_KRP_SET, 3);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1219,66 +1584,54 @@ int bt_mesh_cfg_krp_set(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_beacon_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *status)
+int bt_mesh_cfg_cli_beacon_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *status)
 {
-	return set_state_u8(net_idx, addr, OP_BEACON_SET, OP_BEACON_STATUS,
-			    val, status);
+	return set_state_u8(net_idx, addr, OP_BEACON_SET, OP_BEACON_STATUS, val, status);
 }
 
-int bt_mesh_cfg_ttl_get(uint16_t net_idx, uint16_t addr, uint8_t *ttl)
+int bt_mesh_cfg_cli_ttl_get(uint16_t net_idx, uint16_t addr, uint8_t *ttl)
 {
-	return get_state_u8(net_idx, addr, OP_DEFAULT_TTL_GET,
-			    OP_DEFAULT_TTL_STATUS, ttl);
+	return get_state_u8(net_idx, addr, OP_DEFAULT_TTL_GET, OP_DEFAULT_TTL_STATUS, ttl);
 }
 
-int bt_mesh_cfg_ttl_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *ttl)
+int bt_mesh_cfg_cli_ttl_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *ttl)
 {
-	return set_state_u8(net_idx, addr, OP_DEFAULT_TTL_SET,
-			    OP_DEFAULT_TTL_STATUS, val, ttl);
+	return set_state_u8(net_idx, addr, OP_DEFAULT_TTL_SET, OP_DEFAULT_TTL_STATUS, val, ttl);
 }
 
-int bt_mesh_cfg_friend_get(uint16_t net_idx, uint16_t addr, uint8_t *status)
+int bt_mesh_cfg_cli_friend_get(uint16_t net_idx, uint16_t addr, uint8_t *status)
 {
-	return get_state_u8(net_idx, addr, OP_FRIEND_GET,
-			    OP_FRIEND_STATUS, status);
+	return get_state_u8(net_idx, addr, OP_FRIEND_GET, OP_FRIEND_STATUS, status);
 }
 
-int bt_mesh_cfg_friend_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *status)
+int bt_mesh_cfg_cli_friend_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *status)
 {
-	return set_state_u8(net_idx, addr, OP_FRIEND_SET, OP_FRIEND_STATUS,
-			    val, status);
+	return set_state_u8(net_idx, addr, OP_FRIEND_SET, OP_FRIEND_STATUS, val, status);
 }
 
-int bt_mesh_cfg_gatt_proxy_get(uint16_t net_idx, uint16_t addr, uint8_t *status)
+int bt_mesh_cfg_cli_gatt_proxy_get(uint16_t net_idx, uint16_t addr, uint8_t *status)
 {
-	return get_state_u8(net_idx, addr, OP_GATT_PROXY_GET,
-			    OP_GATT_PROXY_STATUS, status);
+	return get_state_u8(net_idx, addr, OP_GATT_PROXY_GET, OP_GATT_PROXY_STATUS, status);
 }
 
-int bt_mesh_cfg_gatt_proxy_set(uint16_t net_idx, uint16_t addr, uint8_t val,
-			       uint8_t *status)
+int bt_mesh_cfg_cli_gatt_proxy_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *status)
 {
-	return set_state_u8(net_idx, addr, OP_GATT_PROXY_SET,
-			    OP_GATT_PROXY_STATUS, val, status);
+	return set_state_u8(net_idx, addr, OP_GATT_PROXY_SET, OP_GATT_PROXY_STATUS, val, status);
 }
 
-int bt_mesh_cfg_net_transmit_set(uint16_t net_idx, uint16_t addr,
-		uint8_t val, uint8_t *transmit)
+int bt_mesh_cfg_cli_net_transmit_set(uint16_t net_idx, uint16_t addr, uint8_t val,
+				     uint8_t *transmit)
 {
-	return set_state_u8(net_idx, addr, OP_NET_TRANSMIT_SET,
-				OP_NET_TRANSMIT_STATUS, val, transmit);
+	return set_state_u8(net_idx, addr, OP_NET_TRANSMIT_SET, OP_NET_TRANSMIT_STATUS, val,
+			    transmit);
 }
 
-int bt_mesh_cfg_net_transmit_get(uint16_t net_idx, uint16_t addr,
-		uint8_t *transmit)
+int bt_mesh_cfg_cli_net_transmit_get(uint16_t net_idx, uint16_t addr, uint8_t *transmit)
 {
-	return get_state_u8(net_idx, addr, OP_NET_TRANSMIT_GET,
-			OP_NET_TRANSMIT_STATUS, transmit);
+	return get_state_u8(net_idx, addr, OP_NET_TRANSMIT_GET, OP_NET_TRANSMIT_STATUS, transmit);
 }
 
-
-int bt_mesh_cfg_relay_get(uint16_t net_idx, uint16_t addr, uint8_t *status,
-			  uint8_t *transmit)
+int bt_mesh_cfg_cli_relay_get(uint16_t net_idx, uint16_t addr, uint8_t *status, uint8_t *transmit)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_RELAY_GET, 0);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1315,8 +1668,8 @@ int bt_mesh_cfg_relay_get(uint16_t net_idx, uint16_t addr, uint8_t *status,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_relay_set(uint16_t net_idx, uint16_t addr, uint8_t new_relay,
-			  uint8_t new_transmit, uint8_t *status, uint8_t *transmit)
+int bt_mesh_cfg_cli_relay_set(uint16_t net_idx, uint16_t addr, uint8_t new_relay,
+			      uint8_t new_transmit, uint8_t *status, uint8_t *transmit)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_RELAY_SET, 2);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1355,8 +1708,8 @@ int bt_mesh_cfg_relay_set(uint16_t net_idx, uint16_t addr, uint8_t new_relay,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_net_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
-			    const uint8_t net_key[16], uint8_t *status)
+int bt_mesh_cfg_cli_net_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				const uint8_t net_key[16], uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_ADD, 18);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1395,9 +1748,8 @@ int bt_mesh_cfg_net_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_id
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_net_key_update(uint16_t net_idx, uint16_t addr,
-			       uint16_t key_net_idx, const uint8_t net_key[16],
-			       uint8_t *status)
+int bt_mesh_cfg_cli_net_key_update(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				   const uint8_t net_key[16], uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_UPDATE, 18);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1436,8 +1788,7 @@ int bt_mesh_cfg_net_key_update(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_net_key_get(uint16_t net_idx, uint16_t addr, uint16_t *keys,
-			     size_t *key_cnt)
+int bt_mesh_cfg_cli_net_key_get(uint16_t net_idx, uint16_t addr, uint16_t *keys, size_t *key_cnt)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_GET, 0);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1474,8 +1825,8 @@ int bt_mesh_cfg_net_key_get(uint16_t net_idx, uint16_t addr, uint16_t *keys,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_net_key_del(uint16_t net_idx, uint16_t addr,
-			    uint16_t key_net_idx, uint8_t *status)
+int bt_mesh_cfg_cli_net_key_del(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_DEL, 2);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1513,9 +1864,8 @@ int bt_mesh_cfg_net_key_del(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_app_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
-			    uint16_t key_app_idx, const uint8_t app_key[16],
-			    uint8_t *status)
+int bt_mesh_cfg_cli_app_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				uint16_t key_app_idx, const uint8_t app_key[16], uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_ADD, 19);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1555,9 +1905,8 @@ int bt_mesh_cfg_app_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_net_id
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_app_key_update(uint16_t net_idx, uint16_t addr,
-			       uint16_t key_net_idx, uint16_t key_app_idx,
-			       const uint8_t app_key[16], uint8_t *status)
+int bt_mesh_cfg_cli_app_key_update(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				   uint16_t key_app_idx, const uint8_t app_key[16], uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_UPDATE, 19);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1597,7 +1946,7 @@ int bt_mesh_cfg_app_key_update(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_node_reset(uint16_t net_idx, uint16_t addr, bool *status)
+int bt_mesh_cfg_cli_node_reset(uint16_t net_idx, uint16_t addr, bool *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NODE_RESET, 0);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1635,8 +1984,8 @@ int bt_mesh_cfg_node_reset(uint16_t net_idx, uint16_t addr, bool *status)
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_app_key_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
-			     uint8_t *status, uint16_t *keys, size_t *key_cnt)
+int bt_mesh_cfg_cli_app_key_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				uint8_t *status, uint16_t *keys, size_t *key_cnt)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_GET, 2);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1676,8 +2025,8 @@ int bt_mesh_cfg_app_key_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_id
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_app_key_del(uint16_t net_idx, uint16_t addr,
-	uint16_t key_net_idx, uint16_t key_app_idx, uint8_t *status)
+int bt_mesh_cfg_cli_app_key_del(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				uint16_t key_app_idx, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_DEL, 3);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1716,9 +2065,8 @@ int bt_mesh_cfg_app_key_del(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-static int mod_app_bind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			uint16_t mod_app_idx, uint16_t mod_id, uint16_t cid,
-			uint8_t *status)
+static int mod_app_bind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, uint16_t mod_app_idx,
+			uint16_t mod_id, uint16_t cid, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_BIND, 8);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1766,28 +2114,25 @@ static int mod_app_bind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_mod_app_bind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			     uint16_t mod_app_idx, uint16_t mod_id, uint8_t *status)
+int bt_mesh_cfg_cli_mod_app_bind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				 uint16_t mod_app_idx, uint16_t mod_id, uint8_t *status)
 {
-	return mod_app_bind(net_idx, addr, elem_addr, mod_app_idx, mod_id,
-			    CID_NVAL, status);
+	return mod_app_bind(net_idx, addr, elem_addr, mod_app_idx, mod_id, CID_NVAL, status);
 }
 
-int bt_mesh_cfg_mod_app_bind_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				 uint16_t mod_app_idx, uint16_t mod_id, uint16_t cid,
-				 uint8_t *status)
+int bt_mesh_cfg_cli_mod_app_bind_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				     uint16_t mod_app_idx, uint16_t mod_id, uint16_t cid,
+				     uint8_t *status)
 {
 	if (cid == CID_NVAL) {
 		return -EINVAL;
 	}
 
-	return mod_app_bind(net_idx, addr, elem_addr, mod_app_idx, mod_id, cid,
-			    status);
+	return mod_app_bind(net_idx, addr, elem_addr, mod_app_idx, mod_id, cid, status);
 }
 
-static int mod_app_unbind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			uint16_t mod_app_idx, uint16_t mod_id, uint16_t cid,
-			uint8_t *status)
+static int mod_app_unbind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, uint16_t mod_app_idx,
+			  uint16_t mod_id, uint16_t cid, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_UNBIND, 8);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1835,30 +2180,26 @@ static int mod_app_unbind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_mod_app_unbind(uint16_t net_idx, uint16_t addr,
-	uint16_t elem_addr, uint16_t mod_app_idx,
-	uint16_t mod_id, uint8_t *status)
+int bt_mesh_cfg_cli_mod_app_unbind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				   uint16_t mod_app_idx, uint16_t mod_id, uint8_t *status)
 {
-	return mod_app_unbind(net_idx, addr, elem_addr, mod_app_idx, mod_id,
-			CID_NVAL, status);
+	return mod_app_unbind(net_idx, addr, elem_addr, mod_app_idx, mod_id, CID_NVAL, status);
 }
 
-int bt_mesh_cfg_mod_app_unbind_vnd(uint16_t net_idx, uint16_t addr,
-		uint16_t elem_addr, uint16_t mod_app_idx,
-		uint16_t mod_id, uint16_t cid, uint8_t *status)
+int bt_mesh_cfg_cli_mod_app_unbind_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				       uint16_t mod_app_idx, uint16_t mod_id, uint16_t cid,
+				       uint8_t *status)
 {
 	if (cid == CID_NVAL) {
 		return -EINVAL;
 	}
 
-	return mod_app_unbind(net_idx, addr, elem_addr, mod_app_idx,
-			mod_id, cid, status);
+	return mod_app_unbind(net_idx, addr, elem_addr, mod_app_idx, mod_id, cid, status);
 }
 
-static int mod_member_list_get(uint32_t op, uint32_t expect_op, uint16_t net_idx,
-			       uint16_t addr, uint16_t elem_addr, uint16_t mod_id,
-			       uint16_t cid, uint8_t *status, uint16_t *apps,
-			       size_t *app_cnt)
+static int mod_member_list_get(uint32_t op, uint32_t expect_op, uint16_t net_idx, uint16_t addr,
+			       uint16_t elem_addr, uint16_t mod_id, uint16_t cid, uint8_t *status,
+			       uint16_t *apps, size_t *app_cnt)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, DUMMY_2_BYTE_OP, 6);
 	struct bt_mesh_msg_ctx ctx = {
@@ -1882,8 +2223,7 @@ static int mod_member_list_get(uint32_t op, uint32_t expect_op, uint16_t net_idx
 		return err;
 	}
 
-	BT_DBG("net_idx 0x%04x addr 0x%04x elem_addr 0x%04x",
-	       net_idx, addr, elem_addr);
+	BT_DBG("net_idx 0x%04x addr 0x%04x elem_addr 0x%04x", net_idx, addr, elem_addr);
 	BT_DBG("mod_id 0x%04x cid 0x%04x op: %x", mod_id, cid, op);
 
 	bt_mesh_model_msg_init(&msg, op);
@@ -1910,26 +2250,23 @@ static int mod_member_list_get(uint32_t op, uint32_t expect_op, uint16_t net_idx
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_mod_app_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			    uint16_t mod_id, uint8_t *status, uint16_t *apps,
-			    size_t *app_cnt)
+int bt_mesh_cfg_cli_mod_app_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t mod_id, uint8_t *status, uint16_t *apps, size_t *app_cnt)
 {
-	return mod_member_list_get(OP_SIG_MOD_APP_GET, OP_SIG_MOD_APP_LIST,
-				   net_idx, addr, elem_addr, mod_id, CID_NVAL,
-				   status, apps, app_cnt);
+	return mod_member_list_get(OP_SIG_MOD_APP_GET, OP_SIG_MOD_APP_LIST, net_idx, addr,
+				   elem_addr, mod_id, CID_NVAL, status, apps, app_cnt);
 }
 
-int bt_mesh_cfg_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				uint16_t mod_id, uint16_t cid, uint8_t *status,
-				uint16_t *apps, size_t *app_cnt)
+int bt_mesh_cfg_cli_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t mod_id, uint16_t cid, uint8_t *status, uint16_t *apps,
+				    size_t *app_cnt)
 {
 	if (cid == CID_NVAL) {
 		return -EINVAL;
 	}
 
-	return mod_member_list_get(OP_VND_MOD_APP_GET, OP_VND_MOD_APP_LIST,
-				   net_idx, addr, elem_addr, mod_id, cid,
-				   status, apps, app_cnt);
+	return mod_member_list_get(OP_VND_MOD_APP_GET, OP_VND_MOD_APP_LIST, net_idx, addr,
+				   elem_addr, mod_id, cid, status, apps, app_cnt);
 }
 
 static int mod_sub(uint32_t op, uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
@@ -1984,101 +2321,97 @@ static int mod_sub(uint32_t op, uint16_t net_idx, uint16_t addr, uint16_t elem_a
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_mod_sub_add(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			    uint16_t sub_addr, uint16_t mod_id, uint8_t *status)
+int bt_mesh_cfg_cli_mod_sub_add(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t sub_addr, uint16_t mod_id, uint8_t *status)
 {
 	if (!BT_MESH_ADDR_IS_GROUP(sub_addr) && !BT_MESH_ADDR_IS_FIXED_GROUP(sub_addr)) {
 		return -EINVAL;
 	}
 
-	return mod_sub(OP_MOD_SUB_ADD, net_idx, addr, elem_addr, sub_addr,
-		       mod_id, CID_NVAL, status);
+	return mod_sub(OP_MOD_SUB_ADD, net_idx, addr, elem_addr, sub_addr, mod_id, CID_NVAL,
+		       status);
 }
 
-int bt_mesh_cfg_mod_sub_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				 uint16_t sub_addr, uint16_t mod_id, uint16_t cid,
-				 uint8_t *status)
+int bt_mesh_cfg_cli_mod_sub_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t sub_addr, uint16_t mod_id, uint16_t cid,
+				    uint8_t *status)
 {
 	if ((!BT_MESH_ADDR_IS_GROUP(sub_addr) && !BT_MESH_ADDR_IS_FIXED_GROUP(sub_addr)) ||
-		cid == CID_NVAL) {
+	    cid == CID_NVAL) {
 		return -EINVAL;
 	}
 
-	return mod_sub(OP_MOD_SUB_ADD, net_idx, addr, elem_addr, sub_addr,
-		       mod_id, cid, status);
+	return mod_sub(OP_MOD_SUB_ADD, net_idx, addr, elem_addr, sub_addr, mod_id, cid, status);
 }
 
-int bt_mesh_cfg_mod_sub_del(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			    uint16_t sub_addr, uint16_t mod_id, uint8_t *status)
+int bt_mesh_cfg_cli_mod_sub_del(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t sub_addr, uint16_t mod_id, uint8_t *status)
 {
 	if (!BT_MESH_ADDR_IS_GROUP(sub_addr) && !BT_MESH_ADDR_IS_FIXED_GROUP(sub_addr)) {
 		return -EINVAL;
 	}
 
-	return mod_sub(OP_MOD_SUB_DEL, net_idx, addr, elem_addr, sub_addr,
+	return mod_sub(OP_MOD_SUB_DEL, net_idx, addr, elem_addr, sub_addr, mod_id, CID_NVAL,
+		       status);
+}
+
+int bt_mesh_cfg_cli_mod_sub_del_all(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t mod_id, uint8_t *status)
+{
+	return mod_sub(OP_MOD_SUB_DEL_ALL, net_idx, addr, elem_addr, BT_MESH_ADDR_UNASSIGNED,
 		       mod_id, CID_NVAL, status);
 }
 
-int bt_mesh_cfg_mod_sub_del_all(uint16_t net_idx, uint16_t addr,
-				uint16_t elem_addr, uint16_t mod_id,
-				uint8_t *status)
-{
-	return mod_sub(OP_MOD_SUB_DEL_ALL, net_idx, addr, elem_addr,
-		       BT_MESH_ADDR_UNASSIGNED, mod_id, CID_NVAL, status);
-}
-
-int bt_mesh_cfg_mod_sub_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				uint16_t sub_addr, uint16_t mod_id, uint16_t cid,
-				uint8_t *status)
+int bt_mesh_cfg_cli_mod_sub_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t sub_addr, uint16_t mod_id, uint16_t cid,
+				    uint8_t *status)
 {
 	if ((!BT_MESH_ADDR_IS_GROUP(sub_addr) && !BT_MESH_ADDR_IS_FIXED_GROUP(sub_addr)) ||
-		cid == CID_NVAL) {
+	    cid == CID_NVAL) {
 		return -EINVAL;
 	}
 
-	return mod_sub(OP_MOD_SUB_DEL, net_idx, addr, elem_addr, sub_addr,
-		       mod_id, cid, status);
+	return mod_sub(OP_MOD_SUB_DEL, net_idx, addr, elem_addr, sub_addr, mod_id, cid, status);
 }
 
-int bt_mesh_cfg_mod_sub_del_all_vnd(uint16_t net_idx, uint16_t addr,
-				    uint16_t elem_addr, uint16_t mod_id,
-				    uint16_t cid, uint8_t *status)
+int bt_mesh_cfg_cli_mod_sub_del_all_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					uint16_t mod_id, uint16_t cid, uint8_t *status)
 {
 	if (cid == CID_NVAL) {
 		return -EINVAL;
 	}
 
-	return mod_sub(OP_MOD_SUB_DEL_ALL, net_idx, addr, elem_addr,
-		       BT_MESH_ADDR_UNASSIGNED, mod_id, cid, status);
+	return mod_sub(OP_MOD_SUB_DEL_ALL, net_idx, addr, elem_addr, BT_MESH_ADDR_UNASSIGNED,
+		       mod_id, cid, status);
 }
 
-int bt_mesh_cfg_mod_sub_overwrite(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				  uint16_t sub_addr, uint16_t mod_id, uint8_t *status)
+int bt_mesh_cfg_cli_mod_sub_overwrite(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				      uint16_t sub_addr, uint16_t mod_id, uint8_t *status)
 {
 	if (!BT_MESH_ADDR_IS_GROUP(sub_addr) && !BT_MESH_ADDR_IS_FIXED_GROUP(sub_addr)) {
 		return -EINVAL;
 	}
 
-	return mod_sub(OP_MOD_SUB_OVERWRITE, net_idx, addr, elem_addr,
-		       sub_addr, mod_id, CID_NVAL, status);
+	return mod_sub(OP_MOD_SUB_OVERWRITE, net_idx, addr, elem_addr, sub_addr, mod_id, CID_NVAL,
+		       status);
 }
 
-int bt_mesh_cfg_mod_sub_overwrite_vnd(uint16_t net_idx, uint16_t addr,
-				      uint16_t elem_addr, uint16_t sub_addr,
-				      uint16_t mod_id, uint16_t cid, uint8_t *status)
+int bt_mesh_cfg_cli_mod_sub_overwrite_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					  uint16_t sub_addr, uint16_t mod_id, uint16_t cid,
+					  uint8_t *status)
 {
 	if ((!BT_MESH_ADDR_IS_GROUP(sub_addr) && !BT_MESH_ADDR_IS_FIXED_GROUP(sub_addr)) ||
-		cid == CID_NVAL) {
+	    cid == CID_NVAL) {
 		return -EINVAL;
 	}
 
-	return mod_sub(OP_MOD_SUB_OVERWRITE, net_idx, addr, elem_addr,
-		       sub_addr, mod_id, cid, status);
+	return mod_sub(OP_MOD_SUB_OVERWRITE, net_idx, addr, elem_addr, sub_addr, mod_id, cid,
+		       status);
 }
 
 static int mod_sub_va(uint32_t op, uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-		      const uint8_t label[16], uint16_t mod_id, uint16_t cid,
-		      uint16_t *virt_addr, uint8_t *status)
+		      const uint8_t label[16], uint16_t mod_id, uint16_t cid, uint16_t *virt_addr,
+		      uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, DUMMY_2_BYTE_OP, 22);
 	struct bt_mesh_msg_ctx ctx = {
@@ -2101,8 +2434,8 @@ static int mod_sub_va(uint32_t op, uint16_t net_idx, uint16_t addr, uint16_t ele
 		return err;
 	}
 
-	BT_DBG("net_idx 0x%04x addr 0x%04x elem_addr 0x%04x label %s",
-	       net_idx, addr, elem_addr, bt_hex(label, 16));
+	BT_DBG("net_idx 0x%04x addr 0x%04x elem_addr 0x%04x label %s", net_idx, addr, elem_addr,
+	       bt_hex(label, 16));
 	BT_DBG("mod_id 0x%04x cid 0x%04x", mod_id, cid);
 
 	bt_mesh_model_msg_init(&msg, op);
@@ -2130,93 +2463,87 @@ static int mod_sub_va(uint32_t op, uint16_t net_idx, uint16_t addr, uint16_t ele
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_mod_sub_va_add(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			       const uint8_t label[16], uint16_t mod_id,
-			       uint16_t *virt_addr, uint8_t *status)
+int bt_mesh_cfg_cli_mod_sub_va_add(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				   const uint8_t label[16], uint16_t mod_id, uint16_t *virt_addr,
+				   uint8_t *status)
 {
-	return mod_sub_va(OP_MOD_SUB_VA_ADD, net_idx, addr, elem_addr, label,
-			  mod_id, CID_NVAL, virt_addr, status);
+	return mod_sub_va(OP_MOD_SUB_VA_ADD, net_idx, addr, elem_addr, label, mod_id, CID_NVAL,
+			  virt_addr, status);
 }
 
-int bt_mesh_cfg_mod_sub_va_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				   const uint8_t label[16], uint16_t mod_id,
-				   uint16_t cid, uint16_t *virt_addr, uint8_t *status)
-{
-	if (cid == CID_NVAL) {
-		return -EINVAL;
-	}
-
-	return mod_sub_va(OP_MOD_SUB_VA_ADD, net_idx, addr, elem_addr, label,
-			  mod_id, cid, virt_addr, status);
-}
-
-int bt_mesh_cfg_mod_sub_va_del(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			       const uint8_t label[16], uint16_t mod_id,
-			       uint16_t *virt_addr, uint8_t *status)
-{
-	return mod_sub_va(OP_MOD_SUB_VA_DEL, net_idx, addr, elem_addr, label,
-			  mod_id, CID_NVAL, virt_addr, status);
-}
-
-int bt_mesh_cfg_mod_sub_va_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				   const uint8_t label[16], uint16_t mod_id,
-				   uint16_t cid, uint16_t *virt_addr, uint8_t *status)
+int bt_mesh_cfg_cli_mod_sub_va_add_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				       const uint8_t label[16], uint16_t mod_id, uint16_t cid,
+				       uint16_t *virt_addr, uint8_t *status)
 {
 	if (cid == CID_NVAL) {
 		return -EINVAL;
 	}
 
-	return mod_sub_va(OP_MOD_SUB_VA_DEL, net_idx, addr, elem_addr, label,
-			  mod_id, cid, virt_addr, status);
+	return mod_sub_va(OP_MOD_SUB_VA_ADD, net_idx, addr, elem_addr, label, mod_id, cid,
+			  virt_addr, status);
 }
 
-int bt_mesh_cfg_mod_sub_va_overwrite(uint16_t net_idx, uint16_t addr,
-				     uint16_t elem_addr, const uint8_t label[16],
-				     uint16_t mod_id, uint16_t *virt_addr,
-				     uint8_t *status)
+int bt_mesh_cfg_cli_mod_sub_va_del(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				   const uint8_t label[16], uint16_t mod_id, uint16_t *virt_addr,
+				   uint8_t *status)
 {
-	return mod_sub_va(OP_MOD_SUB_VA_OVERWRITE, net_idx, addr, elem_addr,
-			  label, mod_id, CID_NVAL, virt_addr, status);
+	return mod_sub_va(OP_MOD_SUB_VA_DEL, net_idx, addr, elem_addr, label, mod_id, CID_NVAL,
+			  virt_addr, status);
 }
 
-int bt_mesh_cfg_mod_sub_va_overwrite_vnd(uint16_t net_idx, uint16_t addr,
-					 uint16_t elem_addr, const uint8_t label[16],
-					 uint16_t mod_id, uint16_t cid,
+int bt_mesh_cfg_cli_mod_sub_va_del_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				       const uint8_t label[16], uint16_t mod_id, uint16_t cid,
+				       uint16_t *virt_addr, uint8_t *status)
+{
+	if (cid == CID_NVAL) {
+		return -EINVAL;
+	}
+
+	return mod_sub_va(OP_MOD_SUB_VA_DEL, net_idx, addr, elem_addr, label, mod_id, cid,
+			  virt_addr, status);
+}
+
+int bt_mesh_cfg_cli_mod_sub_va_overwrite(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					 const uint8_t label[16], uint16_t mod_id,
 					 uint16_t *virt_addr, uint8_t *status)
 {
-	if (cid == CID_NVAL) {
-		return -EINVAL;
-	}
-
-	return mod_sub_va(OP_MOD_SUB_VA_OVERWRITE, net_idx, addr, elem_addr,
-			  label, mod_id, cid, virt_addr, status);
+	return mod_sub_va(OP_MOD_SUB_VA_OVERWRITE, net_idx, addr, elem_addr, label, mod_id,
+			  CID_NVAL, virt_addr, status);
 }
 
-int bt_mesh_cfg_mod_sub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			    uint16_t mod_id, uint8_t *status, uint16_t *subs,
-			    size_t *sub_cnt)
-{
-	return mod_member_list_get(OP_MOD_SUB_GET, OP_MOD_SUB_LIST, net_idx,
-				   addr, elem_addr, mod_id, CID_NVAL, status,
-				   subs, sub_cnt);
-}
-
-int bt_mesh_cfg_mod_sub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				uint16_t mod_id, uint16_t cid, uint8_t *status,
-				uint16_t *subs, size_t *sub_cnt)
+int bt_mesh_cfg_cli_mod_sub_va_overwrite_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+					     const uint8_t label[16], uint16_t mod_id, uint16_t cid,
+					     uint16_t *virt_addr, uint8_t *status)
 {
 	if (cid == CID_NVAL) {
 		return -EINVAL;
 	}
 
-	return mod_member_list_get(OP_MOD_SUB_GET_VND, OP_MOD_SUB_LIST_VND,
-				   net_idx, addr, elem_addr, mod_id, cid,
-				   status, subs, sub_cnt);
+	return mod_sub_va(OP_MOD_SUB_VA_OVERWRITE, net_idx, addr, elem_addr, label, mod_id, cid,
+			  virt_addr, status);
 }
 
-static int mod_pub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-		       uint16_t mod_id, uint16_t cid,
-		       struct bt_mesh_cfg_mod_pub *pub, uint8_t *status)
+int bt_mesh_cfg_cli_mod_sub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t mod_id, uint8_t *status, uint16_t *subs, size_t *sub_cnt)
+{
+	return mod_member_list_get(OP_MOD_SUB_GET, OP_MOD_SUB_LIST, net_idx, addr, elem_addr,
+				   mod_id, CID_NVAL, status, subs, sub_cnt);
+}
+
+int bt_mesh_cfg_cli_mod_sub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t mod_id, uint16_t cid, uint8_t *status, uint16_t *subs,
+				    size_t *sub_cnt)
+{
+	if (cid == CID_NVAL) {
+		return -EINVAL;
+	}
+
+	return mod_member_list_get(OP_MOD_SUB_GET_VND, OP_MOD_SUB_LIST_VND, net_idx, addr,
+				   elem_addr, mod_id, cid, status, subs, sub_cnt);
+}
+
+static int mod_pub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, uint16_t mod_id,
+		       uint16_t cid, struct bt_mesh_cfg_cli_mod_pub *pub, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_PUB_GET, 6);
 	struct bt_mesh_msg_ctx ctx = {
@@ -2264,17 +2591,16 @@ static int mod_pub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_mod_pub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			    uint16_t mod_id, struct bt_mesh_cfg_mod_pub *pub,
-			    uint8_t *status)
+int bt_mesh_cfg_cli_mod_pub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t mod_id, struct bt_mesh_cfg_cli_mod_pub *pub,
+				uint8_t *status)
 {
-	return mod_pub_get(net_idx, addr, elem_addr, mod_id, CID_NVAL,
-			   pub, status);
+	return mod_pub_get(net_idx, addr, elem_addr, mod_id, CID_NVAL, pub, status);
 }
 
-int bt_mesh_cfg_mod_pub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				uint16_t mod_id, uint16_t cid,
-				struct bt_mesh_cfg_mod_pub *pub, uint8_t *status)
+int bt_mesh_cfg_cli_mod_pub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t mod_id, uint16_t cid,
+				    struct bt_mesh_cfg_cli_mod_pub *pub, uint8_t *status)
 {
 	if (cid == CID_NVAL) {
 		return -EINVAL;
@@ -2283,9 +2609,8 @@ int bt_mesh_cfg_mod_pub_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
 	return mod_pub_get(net_idx, addr, elem_addr, mod_id, cid, pub, status);
 }
 
-static int mod_pub_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-		       uint16_t mod_id, uint16_t cid,
-		       struct bt_mesh_cfg_mod_pub *pub, uint8_t *status)
+static int mod_pub_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, uint16_t mod_id,
+		       uint16_t cid, struct bt_mesh_cfg_cli_mod_pub *pub, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_PUB_SET, 13);
 	struct bt_mesh_msg_ctx ctx = {
@@ -2338,9 +2663,8 @@ static int mod_pub_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-static int mod_pub_va_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			  uint16_t mod_id, uint16_t cid,
-			  struct bt_mesh_cfg_mod_pub *pub, uint8_t *status)
+static int mod_pub_va_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, uint16_t mod_id,
+			  uint16_t cid, struct bt_mesh_cfg_cli_mod_pub *pub, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_PUB_VA_SET, 27);
 	struct bt_mesh_msg_ctx ctx = {
@@ -2393,9 +2717,9 @@ static int mod_pub_va_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_mod_pub_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-			    uint16_t mod_id, struct bt_mesh_cfg_mod_pub *pub,
-			    uint8_t *status)
+int bt_mesh_cfg_cli_mod_pub_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				uint16_t mod_id, struct bt_mesh_cfg_cli_mod_pub *pub,
+				uint8_t *status)
 {
 	if (!pub) {
 		return -EINVAL;
@@ -2408,9 +2732,9 @@ int bt_mesh_cfg_mod_pub_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
 	}
 }
 
-int bt_mesh_cfg_mod_pub_set_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
-				uint16_t mod_id, uint16_t cid, struct bt_mesh_cfg_mod_pub *pub,
-				uint8_t *status)
+int bt_mesh_cfg_cli_mod_pub_set_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_addr,
+				    uint16_t mod_id, uint16_t cid,
+				    struct bt_mesh_cfg_cli_mod_pub *pub, uint8_t *status)
 {
 	if (!pub) {
 		return -EINVAL;
@@ -2427,8 +2751,8 @@ int bt_mesh_cfg_mod_pub_set_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
 	}
 }
 
-int bt_mesh_cfg_hb_sub_set(uint16_t net_idx, uint16_t addr,
-			   struct bt_mesh_cfg_hb_sub *sub, uint8_t *status)
+int bt_mesh_cfg_cli_hb_sub_set(uint16_t net_idx, uint16_t addr, struct bt_mesh_cfg_cli_hb_sub *sub,
+			       uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_SUB_SET, 5);
 	struct bt_mesh_msg_ctx ctx = {
@@ -2472,8 +2796,8 @@ int bt_mesh_cfg_hb_sub_set(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_hb_sub_get(uint16_t net_idx, uint16_t addr,
-			   struct bt_mesh_cfg_hb_sub *sub, uint8_t *status)
+int bt_mesh_cfg_cli_hb_sub_get(uint16_t net_idx, uint16_t addr, struct bt_mesh_cfg_cli_hb_sub *sub,
+			       uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_SUB_GET, 0);
 	struct bt_mesh_msg_ctx ctx = {
@@ -2510,8 +2834,8 @@ int bt_mesh_cfg_hb_sub_get(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_hb_pub_set(uint16_t net_idx, uint16_t addr,
-			   const struct bt_mesh_cfg_hb_pub *pub, uint8_t *status)
+int bt_mesh_cfg_cli_hb_pub_set(uint16_t net_idx, uint16_t addr,
+			       const struct bt_mesh_cfg_cli_hb_pub *pub, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_PUB_SET, 9);
 	struct bt_mesh_msg_ctx ctx = {
@@ -2557,8 +2881,8 @@ int bt_mesh_cfg_hb_pub_set(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_hb_pub_get(uint16_t net_idx, uint16_t addr,
-			   struct bt_mesh_cfg_hb_pub *pub, uint8_t *status)
+int bt_mesh_cfg_cli_hb_pub_get(uint16_t net_idx, uint16_t addr, struct bt_mesh_cfg_cli_hb_pub *pub,
+			       uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_PUB_GET, 0);
 	struct bt_mesh_msg_ctx ctx = {
@@ -2595,9 +2919,8 @@ int bt_mesh_cfg_hb_pub_get(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_node_identity_set(uint16_t net_idx, uint16_t addr,
-				  uint16_t key_net_idx, uint8_t new_identity,
-				  uint8_t *status, uint8_t *identity)
+int bt_mesh_cfg_cli_node_identity_set(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				      uint8_t new_identity, uint8_t *status, uint8_t *identity)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NODE_IDENTITY_SET, 4);
 	struct bt_mesh_msg_ctx ctx = {
@@ -2637,9 +2960,8 @@ int bt_mesh_cfg_node_identity_set(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_node_identity_get(uint16_t net_idx, uint16_t addr,
-				  uint16_t key_net_idx, uint8_t *status,
-				  uint8_t *identity)
+int bt_mesh_cfg_cli_node_identity_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_idx,
+				      uint8_t *status, uint8_t *identity)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NODE_IDENTITY_GET, 2);
 	struct bt_mesh_msg_ctx ctx = {
@@ -2678,8 +3000,8 @@ int bt_mesh_cfg_node_identity_get(uint16_t net_idx, uint16_t addr,
 	return bt_mesh_msg_ack_ctx_wait(&cli->ack_ctx, K_MSEC(msg_timeout));
 }
 
-int bt_mesh_cfg_lpn_timeout_get(uint16_t net_idx, uint16_t addr,
-				uint16_t unicast_addr, int32_t *polltimeout)
+int bt_mesh_cfg_cli_lpn_timeout_get(uint16_t net_idx, uint16_t addr, uint16_t unicast_addr,
+				    int32_t *polltimeout)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_LPN_TIMEOUT_GET, 2);
 	struct bt_mesh_msg_ctx ctx = {

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -434,7 +434,7 @@ static int cmd_reset(const struct shell *shell, size_t argc, char *argv[])
 		int err;
 		bool reset = false;
 
-		err = bt_mesh_cfg_node_reset(net.net_idx, net.dst, &reset);
+		err = bt_mesh_cfg_cli_node_reset(net.net_idx, net.dst, &reset);
 		if (err) {
 			shell_error(shell, "Unable to send "
 					"Remote Node Reset (err %d)", err);
@@ -559,7 +559,7 @@ static int cmd_get_comp(const struct shell *shell, size_t argc, char *argv[])
 		}
 	}
 
-	err = bt_mesh_cfg_comp_data_get(net.net_idx, net.dst, page, &page,
+	err = bt_mesh_cfg_cli_comp_data_get(net.net_idx, net.dst, page, &page,
 					&buf);
 	if (err) {
 		shell_error(shell, "Getting composition failed (err %d)", err);
@@ -770,7 +770,7 @@ static int cmd_beacon(const struct shell *shell, size_t argc, char *argv[])
 	int err = 0;
 
 	if (argc < 2) {
-		err = bt_mesh_cfg_beacon_get(net.net_idx, net.dst, &status);
+		err = bt_mesh_cfg_cli_beacon_get(net.net_idx, net.dst, &status);
 	} else {
 		uint8_t val = shell_strtobool(argv[1], 0, &err);
 
@@ -779,7 +779,7 @@ static int cmd_beacon(const struct shell *shell, size_t argc, char *argv[])
 			return err;
 		}
 
-		err = bt_mesh_cfg_beacon_set(net.net_idx, net.dst, val, &status);
+		err = bt_mesh_cfg_cli_beacon_set(net.net_idx, net.dst, val, &status);
 	}
 
 	if (err) {
@@ -921,7 +921,7 @@ static int cmd_ttl(const struct shell *shell, size_t argc, char *argv[])
 	int err = 0;
 
 	if (argc < 2) {
-		err = bt_mesh_cfg_ttl_get(net.net_idx, net.dst, &ttl);
+		err = bt_mesh_cfg_cli_ttl_get(net.net_idx, net.dst, &ttl);
 	} else {
 		uint8_t val = shell_strtoul(argv[1], 0, &err);
 
@@ -930,7 +930,7 @@ static int cmd_ttl(const struct shell *shell, size_t argc, char *argv[])
 			return err;
 		}
 
-		err = bt_mesh_cfg_ttl_set(net.net_idx, net.dst, val, &ttl);
+		err = bt_mesh_cfg_cli_ttl_set(net.net_idx, net.dst, val, &ttl);
 	}
 
 	if (err) {
@@ -950,7 +950,7 @@ static int cmd_friend(const struct shell *shell, size_t argc, char *argv[])
 	int err = 0;
 
 	if (argc < 2) {
-		err = bt_mesh_cfg_friend_get(net.net_idx, net.dst, &frnd);
+		err = bt_mesh_cfg_cli_friend_get(net.net_idx, net.dst, &frnd);
 	} else {
 		uint8_t val = shell_strtobool(argv[1], 0, &err);
 
@@ -959,7 +959,7 @@ static int cmd_friend(const struct shell *shell, size_t argc, char *argv[])
 			return err;
 		}
 
-		err = bt_mesh_cfg_friend_set(net.net_idx, net.dst, val, &frnd);
+		err = bt_mesh_cfg_cli_friend_set(net.net_idx, net.dst, val, &frnd);
 	}
 
 	if (err) {
@@ -979,7 +979,7 @@ static int cmd_gatt_proxy(const struct shell *shell, size_t argc, char *argv[])
 	int err = 0;
 
 	if (argc < 2) {
-		err = bt_mesh_cfg_gatt_proxy_get(net.net_idx, net.dst, &proxy);
+		err = bt_mesh_cfg_cli_gatt_proxy_get(net.net_idx, net.dst, &proxy);
 	} else {
 		uint8_t val = shell_strtobool(argv[1], 0, &err);
 
@@ -988,7 +988,7 @@ static int cmd_gatt_proxy(const struct shell *shell, size_t argc, char *argv[])
 			return err;
 		}
 
-		err = bt_mesh_cfg_gatt_proxy_set(net.net_idx, net.dst, val,
+		err = bt_mesh_cfg_cli_gatt_proxy_set(net.net_idx, net.dst, val,
 						 &proxy);
 	}
 
@@ -1016,7 +1016,7 @@ static int cmd_polltimeout_get(const struct shell *sh,
 		return err;
 	}
 
-	err = bt_mesh_cfg_lpn_timeout_get(net.net_idx,
+	err = bt_mesh_cfg_cli_lpn_timeout_get(net.net_idx,
 					  net.dst, lpn_address,
 					  &poll_timeout);
 	if (err) {
@@ -1037,7 +1037,7 @@ static int cmd_net_transmit(const struct shell *shell,
 	int err = 0;
 
 	if (argc < 2) {
-		err = bt_mesh_cfg_net_transmit_get(net.net_idx,
+		err = bt_mesh_cfg_cli_net_transmit_get(net.net_idx,
 				net.dst, &transmit);
 	} else {
 		if (argc != 3) {
@@ -1057,7 +1057,7 @@ static int cmd_net_transmit(const struct shell *shell,
 
 		new_transmit = BT_MESH_TRANSMIT(count, interval);
 
-		err = bt_mesh_cfg_net_transmit_set(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_net_transmit_set(net.net_idx, net.dst,
 				new_transmit, &transmit);
 	}
 
@@ -1080,7 +1080,7 @@ static int cmd_relay(const struct shell *shell, size_t argc, char *argv[])
 	int err = 0;
 
 	if (argc < 2) {
-		err = bt_mesh_cfg_relay_get(net.net_idx, net.dst, &relay,
+		err = bt_mesh_cfg_cli_relay_get(net.net_idx, net.dst, &relay,
 					    &transmit);
 	} else {
 		uint8_t count, interval, new_transmit;
@@ -1109,7 +1109,7 @@ static int cmd_relay(const struct shell *shell, size_t argc, char *argv[])
 			return err;
 		}
 
-		err = bt_mesh_cfg_relay_set(net.net_idx, net.dst, val,
+		err = bt_mesh_cfg_cli_relay_set(net.net_idx, net.dst, val,
 					    new_transmit, &relay, &transmit);
 	}
 
@@ -1176,7 +1176,7 @@ static int cmd_net_key_add(const struct shell *shell, size_t argc, char *argv[])
 		}
 	}
 
-	err = bt_mesh_cfg_net_key_add(net.net_idx, net.dst, key_net_idx,
+	err = bt_mesh_cfg_cli_net_key_add(net.net_idx, net.dst, key_net_idx,
 				      key_val, &status);
 	if (err) {
 		shell_print(shell, "Unable to send NetKey Add (err %d)", err);
@@ -1219,7 +1219,7 @@ static int cmd_net_key_update(const struct shell *sh, size_t argc, char *argv[])
 		memcpy(key_val, default_key, sizeof(key_val));
 	}
 
-	err = bt_mesh_cfg_net_key_update(net.net_idx, net.dst, key_net_idx,
+	err = bt_mesh_cfg_cli_net_key_update(net.net_idx, net.dst, key_net_idx,
 					 key_val, &status);
 	if (err) {
 		shell_print(sh, "Unable to send NetKey Update (err %d)", err);
@@ -1245,7 +1245,7 @@ static int cmd_net_key_get(const struct shell *shell, size_t argc, char *argv[])
 
 	cnt = ARRAY_SIZE(keys);
 
-	err = bt_mesh_cfg_net_key_get(net.net_idx, net.dst, keys, &cnt);
+	err = bt_mesh_cfg_cli_net_key_get(net.net_idx, net.dst, keys, &cnt);
 	if (err) {
 		shell_print(shell, "Unable to send NetKeyGet (err %d)", err);
 		return 0;
@@ -1271,7 +1271,7 @@ static int cmd_net_key_del(const struct shell *shell, size_t argc, char *argv[])
 		return err;
 	}
 
-	err = bt_mesh_cfg_net_key_del(net.net_idx, net.dst, key_net_idx,
+	err = bt_mesh_cfg_cli_net_key_del(net.net_idx, net.dst, key_net_idx,
 				      &status);
 	if (err) {
 		shell_print(shell, "Unable to send NetKeyDel (err %d)", err);
@@ -1341,7 +1341,7 @@ static int cmd_app_key_add(const struct shell *shell, size_t argc, char *argv[])
 		}
 	}
 
-	err = bt_mesh_cfg_app_key_add(net.net_idx, net.dst, key_net_idx,
+	err = bt_mesh_cfg_cli_app_key_add(net.net_idx, net.dst, key_net_idx,
 				      key_app_idx, key_val, &status);
 	if (err) {
 		shell_error(shell, "Unable to send App Key Add (err %d)", err);
@@ -1384,7 +1384,7 @@ static int cmd_app_key_upd(const struct shell *sh, size_t argc, char *argv[])
 		memcpy(key_val, default_key, sizeof(key_val));
 	}
 
-	err = bt_mesh_cfg_app_key_update(net.net_idx, net.dst, key_net_idx,
+	err = bt_mesh_cfg_cli_app_key_update(net.net_idx, net.dst, key_net_idx,
 					 key_app_idx, key_val, &status);
 	if (err) {
 		shell_error(sh, "Unable to send App Key Update (err %d)", err);
@@ -1419,7 +1419,7 @@ static int cmd_app_key_get(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 
-	err = bt_mesh_cfg_app_key_get(net.net_idx, net.dst, net_idx, &status,
+	err = bt_mesh_cfg_cli_app_key_get(net.net_idx, net.dst, net_idx, &status,
 				      keys, &cnt);
 	if (err) {
 		shell_print(shell, "Unable to send AppKeyGet (err %d)", err);
@@ -1455,7 +1455,7 @@ static int cmd_node_id(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (argc < 2) {
-		err = bt_mesh_cfg_node_identity_get(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_node_identity_get(net.net_idx, net.dst,
 						    net_idx, &status,
 						    &identify);
 		if (err) {
@@ -1470,7 +1470,7 @@ static int cmd_node_id(const struct shell *sh, size_t argc, char *argv[])
 			return err;
 		}
 
-		err = bt_mesh_cfg_node_identity_set(net.net_idx, net.dst, net_idx, new_identify,
+		err = bt_mesh_cfg_cli_node_identity_set(net.net_idx, net.dst, net_idx, new_identify,
 						    &status, &identify);
 		if (err) {
 			shell_print(sh, "Unable to send Node Identify Set (err %d)", err);
@@ -1503,7 +1503,7 @@ static int cmd_app_key_del(const struct shell *shell, size_t argc, char *argv[])
 		return err;
 	}
 
-	err = bt_mesh_cfg_app_key_del(net.net_idx, net.dst, key_net_idx,
+	err = bt_mesh_cfg_cli_app_key_del(net.net_idx, net.dst, key_net_idx,
 				      key_app_idx, &status);
 	if (err) {
 		shell_error(shell, "Unable to send App Key del(err %d)", err);
@@ -1543,11 +1543,11 @@ static int cmd_mod_app_bind(const struct shell *shell, size_t argc,
 			return err;
 		}
 
-		err = bt_mesh_cfg_mod_app_bind_vnd(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_app_bind_vnd(net.net_idx, net.dst,
 						   elem_addr, mod_app_idx,
 						   mod_id, cid, &status);
 	} else {
-		err = bt_mesh_cfg_mod_app_bind(net.net_idx, net.dst, elem_addr,
+		err = bt_mesh_cfg_cli_mod_app_bind(net.net_idx, net.dst, elem_addr,
 					       mod_app_idx, mod_id, &status);
 	}
 
@@ -1590,11 +1590,11 @@ static int cmd_mod_app_unbind(const struct shell *shell, size_t argc,
 			return err;
 		}
 
-		err = bt_mesh_cfg_mod_app_unbind_vnd(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_app_unbind_vnd(net.net_idx, net.dst,
 						   elem_addr, mod_app_idx,
 						   mod_id, cid, &status);
 	} else {
-		err = bt_mesh_cfg_mod_app_unbind(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_app_unbind(net.net_idx, net.dst,
 				elem_addr, mod_app_idx, mod_id, &status);
 	}
 
@@ -1639,11 +1639,11 @@ static int cmd_mod_app_get(const struct shell *shell, size_t argc,
 			return err;
 		}
 
-		err = bt_mesh_cfg_mod_app_get_vnd(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_app_get_vnd(net.net_idx, net.dst,
 						  elem_addr, mod_id, cid,
 						  &status, apps, &cnt);
 	} else {
-		err = bt_mesh_cfg_mod_app_get(net.net_idx, net.dst, elem_addr,
+		err = bt_mesh_cfg_cli_mod_app_get(net.net_idx, net.dst, elem_addr,
 					      mod_id, &status, apps, &cnt);
 	}
 
@@ -1695,11 +1695,11 @@ static int cmd_mod_sub_add(const struct shell *shell, size_t argc, char *argv[])
 			return err;
 		}
 
-		err = bt_mesh_cfg_mod_sub_add_vnd(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_sub_add_vnd(net.net_idx, net.dst,
 						  elem_addr, sub_addr, mod_id,
 						  cid, &status);
 	} else {
-		err = bt_mesh_cfg_mod_sub_add(net.net_idx, net.dst, elem_addr,
+		err = bt_mesh_cfg_cli_mod_sub_add(net.net_idx, net.dst, elem_addr,
 					      sub_addr, mod_id, &status);
 	}
 
@@ -1740,11 +1740,11 @@ static int cmd_mod_sub_del(const struct shell *shell, size_t argc, char *argv[])
 			return err;
 		}
 
-		err = bt_mesh_cfg_mod_sub_del_vnd(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_sub_del_vnd(net.net_idx, net.dst,
 						  elem_addr, sub_addr, mod_id,
 						  cid, &status);
 	} else {
-		err = bt_mesh_cfg_mod_sub_del(net.net_idx, net.dst, elem_addr,
+		err = bt_mesh_cfg_cli_mod_sub_del(net.net_idx, net.dst, elem_addr,
 					      sub_addr, mod_id, &status);
 	}
 
@@ -1791,11 +1791,11 @@ static int cmd_mod_sub_add_va(const struct shell *shell, size_t argc,
 			return err;
 		}
 
-		err = bt_mesh_cfg_mod_sub_va_add_vnd(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_sub_va_add_vnd(net.net_idx, net.dst,
 						     elem_addr, label, mod_id,
 						     cid, &sub_addr, &status);
 	} else {
-		err = bt_mesh_cfg_mod_sub_va_add(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_sub_va_add(net.net_idx, net.dst,
 						 elem_addr, label, mod_id,
 						 &sub_addr, &status);
 	}
@@ -1844,11 +1844,11 @@ static int cmd_mod_sub_del_va(const struct shell *shell, size_t argc,
 			return err;
 		}
 
-		err = bt_mesh_cfg_mod_sub_va_del_vnd(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_sub_va_del_vnd(net.net_idx, net.dst,
 						     elem_addr, label, mod_id,
 						     cid, &sub_addr, &status);
 	} else {
-		err = bt_mesh_cfg_mod_sub_va_del(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_sub_va_del(net.net_idx, net.dst,
 						 elem_addr, label, mod_id,
 						 &sub_addr, &status);
 	}
@@ -1891,11 +1891,11 @@ static int cmd_mod_sub_ow(const struct shell *sh, size_t argc, char *argv[])
 			return err;
 		}
 
-		err = bt_mesh_cfg_mod_sub_overwrite_vnd(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_sub_overwrite_vnd(net.net_idx, net.dst,
 							elem_addr, sub_addr, mod_id,
 							cid, &status);
 	} else {
-		err = bt_mesh_cfg_mod_sub_overwrite(net.net_idx, net.dst, elem_addr,
+		err = bt_mesh_cfg_cli_mod_sub_overwrite(net.net_idx, net.dst, elem_addr,
 						    sub_addr, mod_id, &status);
 	}
 
@@ -1942,11 +1942,11 @@ static int cmd_mod_sub_ow_va(const struct shell *sh, size_t argc,
 			return err;
 		}
 
-		err = bt_mesh_cfg_mod_sub_va_overwrite_vnd(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_sub_va_overwrite_vnd(net.net_idx, net.dst,
 							   elem_addr, label, mod_id,
 							   cid, &sub_addr, &status);
 	} else {
-		err = bt_mesh_cfg_mod_sub_va_overwrite(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_sub_va_overwrite(net.net_idx, net.dst,
 						       elem_addr, label, mod_id,
 						       &sub_addr, &status);
 	}
@@ -1988,11 +1988,11 @@ static int cmd_mod_sub_del_all(const struct shell *sh, size_t argc, char *argv[]
 			return err;
 		}
 
-		err = bt_mesh_cfg_mod_sub_del_all_vnd(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_sub_del_all_vnd(net.net_idx, net.dst,
 						      elem_addr, mod_id,
 						      cid, &status);
 	} else {
-		err = bt_mesh_cfg_mod_sub_del_all(net.net_idx, net.dst, elem_addr,
+		err = bt_mesh_cfg_cli_mod_sub_del_all(net.net_idx, net.dst, elem_addr,
 						  mod_id, &status);
 	}
 
@@ -2037,11 +2037,11 @@ static int cmd_mod_sub_get(const struct shell *shell, size_t argc,
 			return err;
 		}
 
-		err = bt_mesh_cfg_mod_sub_get_vnd(net.net_idx, net.dst,
+		err = bt_mesh_cfg_cli_mod_sub_get_vnd(net.net_idx, net.dst,
 						  elem_addr, mod_id, cid,
 						  &status, subs, &cnt);
 	} else {
-		err = bt_mesh_cfg_mod_sub_get(net.net_idx, net.dst, elem_addr,
+		err = bt_mesh_cfg_cli_mod_sub_get(net.net_idx, net.dst, elem_addr,
 					      mod_id, &status, subs, &cnt);
 	}
 
@@ -2086,7 +2086,7 @@ static int cmd_krp(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (argc < 3) {
-		err = bt_mesh_cfg_krp_get(net.net_idx, net.dst, key_net_idx,
+		err = bt_mesh_cfg_cli_krp_get(net.net_idx, net.dst, key_net_idx,
 					  &status, &phase);
 	} else {
 		uint16_t trans = shell_strtoul(argv[2], 0, &err);
@@ -2096,7 +2096,7 @@ static int cmd_krp(const struct shell *sh, size_t argc, char *argv[])
 			return err;
 		}
 
-		err = bt_mesh_cfg_krp_set(net.net_idx, net.dst, key_net_idx,
+		err = bt_mesh_cfg_cli_krp_set(net.net_idx, net.dst, key_net_idx,
 					  trans, &status, &phase);
 	}
 
@@ -2115,15 +2115,15 @@ static int cmd_krp(const struct shell *sh, size_t argc, char *argv[])
 static int mod_pub_get(const struct shell *shell, uint16_t addr, uint16_t mod_id,
 		       uint16_t cid)
 {
-	struct bt_mesh_cfg_mod_pub pub;
+	struct bt_mesh_cfg_cli_mod_pub pub;
 	uint8_t status;
 	int err;
 
 	if (cid == CID_NVAL) {
-		err = bt_mesh_cfg_mod_pub_get(net.net_idx, net.dst, addr,
+		err = bt_mesh_cfg_cli_mod_pub_get(net.net_idx, net.dst, addr,
 					      mod_id, &pub, &status);
 	} else {
-		err = bt_mesh_cfg_mod_pub_get_vnd(net.net_idx, net.dst, addr,
+		err = bt_mesh_cfg_cli_mod_pub_get_vnd(net.net_idx, net.dst, addr,
 						  mod_id, cid, &pub, &status);
 	}
 
@@ -2157,7 +2157,7 @@ static int mod_pub_get(const struct shell *shell, uint16_t addr, uint16_t mod_id
 static int mod_pub_set(const struct shell *sh, uint16_t addr, bool is_va,
 		       uint16_t mod_id, uint16_t cid, char *argv[])
 {
-	struct bt_mesh_cfg_mod_pub pub;
+	struct bt_mesh_cfg_cli_mod_pub pub;
 	uint8_t status, count;
 	uint16_t interval;
 	uint8_t uuid[16];
@@ -2198,10 +2198,10 @@ static int mod_pub_set(const struct shell *sh, uint16_t addr, bool is_va,
 	pub.transmit = BT_MESH_PUB_TRANSMIT(count, interval);
 
 	if (cid == CID_NVAL) {
-		err = bt_mesh_cfg_mod_pub_set(net.net_idx, net.dst, addr,
+		err = bt_mesh_cfg_cli_mod_pub_set(net.net_idx, net.dst, addr,
 					      mod_id, &pub, &status);
 	} else {
-		err = bt_mesh_cfg_mod_pub_set_vnd(net.net_idx, net.dst, addr,
+		err = bt_mesh_cfg_cli_mod_pub_set_vnd(net.net_idx, net.dst, addr,
 						  mod_id, cid, &pub, &status);
 	}
 
@@ -2279,7 +2279,7 @@ static int cmd_mod_pub_va(const struct shell *sh, size_t argc, char *argv[])
 }
 
 static void hb_sub_print(const struct shell *shell,
-			 struct bt_mesh_cfg_hb_sub *sub)
+			 struct bt_mesh_cfg_cli_hb_sub *sub)
 {
 	shell_print(shell, "Heartbeat Subscription:\n"
 		    "\tSource:      0x%04x\n"
@@ -2294,11 +2294,11 @@ static void hb_sub_print(const struct shell *shell,
 
 static int hb_sub_get(const struct shell *shell, size_t argc, char *argv[])
 {
-	struct bt_mesh_cfg_hb_sub sub;
+	struct bt_mesh_cfg_cli_hb_sub sub;
 	uint8_t status;
 	int err;
 
-	err = bt_mesh_cfg_hb_sub_get(net.net_idx, net.dst, &sub, &status);
+	err = bt_mesh_cfg_cli_hb_sub_get(net.net_idx, net.dst, &sub, &status);
 	if (err) {
 		shell_error(shell, "Heartbeat Subscription Get failed (err %d)",
 			    err);
@@ -2317,7 +2317,7 @@ static int hb_sub_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int hb_sub_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	struct bt_mesh_cfg_hb_sub sub;
+	struct bt_mesh_cfg_cli_hb_sub sub;
 	uint8_t status;
 	int err = 0;
 
@@ -2329,7 +2329,7 @@ static int hb_sub_set(const struct shell *shell, size_t argc, char *argv[])
 		return err;
 	}
 
-	err = bt_mesh_cfg_hb_sub_set(net.net_idx, net.dst, &sub, &status);
+	err = bt_mesh_cfg_cli_hb_sub_set(net.net_idx, net.dst, &sub, &status);
 	if (err) {
 		shell_error(shell, "Heartbeat Subscription Set failed (err %d)",
 			    err);
@@ -2361,11 +2361,11 @@ static int cmd_hb_sub(const struct shell *shell, size_t argc, char *argv[])
 
 static int hb_pub_get(const struct shell *shell, size_t argc, char *argv[])
 {
-	struct bt_mesh_cfg_hb_pub pub;
+	struct bt_mesh_cfg_cli_hb_pub pub;
 	uint8_t status;
 	int err;
 
-	err = bt_mesh_cfg_hb_pub_get(net.net_idx, net.dst, &pub, &status);
+	err = bt_mesh_cfg_cli_hb_pub_get(net.net_idx, net.dst, &pub, &status);
 	if (err) {
 		shell_error(shell, "Heartbeat Publication Get failed (err %d)",
 			    err);
@@ -2389,7 +2389,7 @@ static int hb_pub_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int hb_pub_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	struct bt_mesh_cfg_hb_pub pub;
+	struct bt_mesh_cfg_cli_hb_pub pub;
 	uint8_t status;
 	int err = 0;
 
@@ -2404,7 +2404,7 @@ static int hb_pub_set(const struct shell *shell, size_t argc, char *argv[])
 		return err;
 	}
 
-	err = bt_mesh_cfg_hb_pub_set(net.net_idx, net.dst, &pub, &status);
+	err = bt_mesh_cfg_cli_hb_pub_set(net.net_idx, net.dst, &pub, &status);
 	if (err) {
 		shell_error(shell, "Heartbeat Publication Set failed (err %d)",
 			    err);

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.c
@@ -202,22 +202,19 @@ static void bt_mesh_device_provision_and_configure(void)
 
 	/* Self configure */
 
-	err = bt_mesh_cfg_app_key_add(0, cfg->addr, 0, 0, test_app_key,
-				      &status);
+	err = bt_mesh_cfg_cli_app_key_add(0, cfg->addr, 0, 0, test_app_key, &status);
 	if (err || status) {
 		FAIL("AppKey add failed (err %d, status %u)", err, status);
 		return;
 	}
 
-	err = bt_mesh_cfg_mod_app_bind(0, cfg->addr, cfg->addr, 0, TEST_MOD_ID,
-				       &status);
+	err = bt_mesh_cfg_cli_mod_app_bind(0, cfg->addr, cfg->addr, 0, TEST_MOD_ID, &status);
 	if (err || status) {
 		FAIL("Mod app bind failed (err %d, status %u)", err, status);
 		return;
 	}
 
-	err = bt_mesh_cfg_net_transmit_set(0, cfg->addr,
-					   BT_MESH_TRANSMIT(2, 20), &status);
+	err = bt_mesh_cfg_cli_net_transmit_set(0, cfg->addr, BT_MESH_TRANSMIT(2, 20), &status);
 	if (err || status != BT_MESH_TRANSMIT(2, 20)) {
 		FAIL("Net transmit set failed (err %d, status %u)", err,
 		     status);

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_access.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_access.c
@@ -319,24 +319,21 @@ static void common_configure(uint16_t addr)
 	uint16_t model_ids[] = {TEST_MODEL_ID_1, TEST_MODEL_ID_2,
 			TEST_MODEL_ID_3, TEST_MODEL_ID_4, TEST_MODEL_ID_5};
 
-	err = bt_mesh_cfg_app_key_add(0, addr, 0, 0, app_key,
-				      &status);
+	err = bt_mesh_cfg_cli_app_key_add(0, addr, 0, 0, app_key, &status);
 	if (err || status) {
 		FAIL("AppKey add failed (err %d, status %u)", err, status);
 		return;
 	}
 
 	for (int i = 0; i < ARRAY_SIZE(model_ids); i++) {
-		err = bt_mesh_cfg_mod_app_bind(0, addr, addr, 0, model_ids[i],
-					       &status);
+		err = bt_mesh_cfg_cli_mod_app_bind(0, addr, addr, 0, model_ids[i], &status);
 		if (err || status) {
 			FAIL("Model %#4x bind failed (err %d, status %u)",
 					model_ids[i], err, status);
 			return;
 		}
 
-		err = bt_mesh_cfg_mod_app_bind(0, addr, addr + 1, 0, model_ids[i],
-					       &status);
+		err = bt_mesh_cfg_cli_mod_app_bind(0, addr, addr + 1, 0, model_ids[i], &status);
 		if (err || status) {
 			FAIL("Model %#4x bind failed (err %d, status %u)",
 					model_ids[i], err, status);
@@ -344,8 +341,7 @@ static void common_configure(uint16_t addr)
 		}
 	}
 
-	err = bt_mesh_cfg_net_transmit_set(0, addr,
-					   BT_MESH_TRANSMIT(2, 20), &status);
+	err = bt_mesh_cfg_cli_net_transmit_set(0, addr, BT_MESH_TRANSMIT(2, 20), &status);
 	if (err || status != BT_MESH_TRANSMIT(2, 20)) {
 		FAIL("Net transmit set failed (err %d, status %u)", err,
 		     status);
@@ -358,7 +354,7 @@ static void subscription_configure(uint16_t addr)
 	uint8_t status;
 	int err;
 
-	err = bt_mesh_cfg_mod_sub_add(0, addr, addr, GROUP_ADDR, TEST_MODEL_ID_2, &status);
+	err = bt_mesh_cfg_cli_mod_sub_add(0, addr, addr, GROUP_ADDR, TEST_MODEL_ID_2, &status);
 
 	if (err || status) {
 		FAIL("Model %#4x subscription configuration failed (err %d, status %u)",
@@ -475,7 +471,7 @@ static void test_sub_capacity_ext_model(void)
 	 * in the extension linked list.
 	 */
 	for (i = 0; i < 5 * CONFIG_BT_MESH_MODEL_GROUP_COUNT; i++) {
-		ASSERT_OK(bt_mesh_cfg_mod_sub_add(0, UNICAST_ADDR2, UNICAST_ADDR2,
+		ASSERT_OK(bt_mesh_cfg_cli_mod_sub_add(0, UNICAST_ADDR2, UNICAST_ADDR2,
 			GROUP_ADDR + i, TEST_MODEL_ID_2, &status),
 			"Can't deliver subscription on address %#4x", GROUP_ADDR + i);
 
@@ -486,7 +482,7 @@ static void test_sub_capacity_ext_model(void)
 			TEST_MODEL_ID_3, TEST_MODEL_ID_4, TEST_MODEL_ID_5};
 
 	for (int j = 0; j < ARRAY_SIZE(model_ids); j++) {
-		ASSERT_OK(bt_mesh_cfg_mod_sub_add(0, UNICAST_ADDR2, UNICAST_ADDR2,
+		ASSERT_OK(bt_mesh_cfg_cli_mod_sub_add(0, UNICAST_ADDR2, UNICAST_ADDR2,
 			GROUP_ADDR + i, model_ids[j], &status),
 			"Can't deliver subscription on address %#4x", GROUP_ADDR + i);
 
@@ -498,7 +494,7 @@ static void test_sub_capacity_ext_model(void)
 
 static void pub_param_set(uint8_t period, uint8_t transmit)
 {
-	struct bt_mesh_cfg_mod_pub pub_params = {
+	struct bt_mesh_cfg_cli_mod_pub pub_params = {
 		.addr = UNICAST_ADDR2,
 		.uuid = NULL,
 		.cred_flag = false,
@@ -510,8 +506,8 @@ static void pub_param_set(uint8_t period, uint8_t transmit)
 	uint8_t status;
 	int err;
 
-	err = bt_mesh_cfg_mod_pub_set(0, UNICAST_ADDR1, UNICAST_ADDR1, TEST_MODEL_ID_1,
-				      &pub_params, &status);
+	err = bt_mesh_cfg_cli_mod_pub_set(0, UNICAST_ADDR1, UNICAST_ADDR1, TEST_MODEL_ID_1,
+					  &pub_params, &status);
 	if (err || status) {
 		FAIL("Mod pub set failed (err %d, status %u)", err, status);
 	}
@@ -666,7 +662,7 @@ static void test_tx_transmit(void)
 	 * least possible time, which is 50ms. This will let the access layer publish a message
 	 * with 50ms retransmission interval.
 	 */
-	err = bt_mesh_cfg_net_transmit_set(0, UNICAST_ADDR1,
+	err = bt_mesh_cfg_cli_net_transmit_set(0, UNICAST_ADDR1,
 				BT_MESH_TRANSMIT(0, CONFIG_BT_MESH_NETWORK_TRANSMIT_INTERVAL),
 				&status);
 	if (err || status != BT_MESH_TRANSMIT(0, CONFIG_BT_MESH_NETWORK_TRANSMIT_INTERVAL)) {

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_beacon.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_beacon.c
@@ -595,7 +595,7 @@ static void test_rx_kr_old_key(void)
 	bt_mesh_test_setup();
 	bt_mesh_iv_update_test(true);
 
-	err = bt_mesh_cfg_net_key_update(0, cfg->addr, 0, test_net_key_secondary, &status);
+	err = bt_mesh_cfg_cli_net_key_update(0, cfg->addr, 0, test_net_key_secondary, &status);
 	if (err || status) {
 		FAIL("Net Key update failed (err %d, status %u)", err, status);
 	}
@@ -777,14 +777,14 @@ static void test_rx_multiple_netkeys(void)
 	 * Refresh procedure.
 	 */
 	for (size_t i = 0; i < ARRAY_SIZE(net_key_pairs); i++) {
-		err = bt_mesh_cfg_net_key_add(0, cfg->addr, i + 1, net_key_pairs[i].primary,
+		err = bt_mesh_cfg_cli_net_key_add(0, cfg->addr, i + 1, net_key_pairs[i].primary,
 					      &status);
 		if (err || status) {
 			FAIL("Net Key add failed (err %d, status %u)", err, status);
 		}
 
-		err = bt_mesh_cfg_net_key_update(0, cfg->addr, i + 1, net_key_pairs[i].secondary,
-						 &status);
+		err = bt_mesh_cfg_cli_net_key_update(0, cfg->addr, i + 1,
+						     net_key_pairs[i].secondary, &status);
 		if (err || status) {
 			FAIL("Net Key update failed (err %d, status %u)", err, status);
 		}

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_friendship.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_friendship.c
@@ -632,14 +632,14 @@ static void test_lpn_group(void)
 
 	bt_mesh_test_setup();
 
-	err = bt_mesh_cfg_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR,
+	err = bt_mesh_cfg_cli_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR,
 				      TEST_MOD_ID, &status);
 	if (err || status) {
 		FAIL("Group addr add failed with err %d status 0x%x", err,
 		     status);
 	}
 
-	err = bt_mesh_cfg_mod_sub_va_add(0, cfg->addr, cfg->addr, test_va_uuid,
+	err = bt_mesh_cfg_cli_mod_sub_va_add(0, cfg->addr, cfg->addr, test_va_uuid,
 					 TEST_MOD_ID, &vaddr, &status);
 	if (err || status) {
 		FAIL("VA addr add failed with err %d status 0x%x", err, status);
@@ -696,7 +696,7 @@ static void test_lpn_group(void)
 	/* Add a new group addr, then receive on it to ensure that the friend
 	 * has added it to the subscription list.
 	 */
-	err = bt_mesh_cfg_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR + 1,
+	err = bt_mesh_cfg_cli_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR + 1,
 				      TEST_MOD_ID, &status);
 	if (err || status) {
 		FAIL("Group addr add failed with err %d status 0x%x", err,
@@ -731,14 +731,14 @@ static void test_lpn_loopback(void)
 
 	bt_mesh_test_setup();
 
-	err = bt_mesh_cfg_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR,
+	err = bt_mesh_cfg_cli_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR,
 				      TEST_MOD_ID, &status);
 	if (err || status) {
 		FAIL("Group addr add failed with err %d status 0x%x", err,
 		     status);
 	}
 
-	err = bt_mesh_cfg_mod_sub_va_add(0, cfg->addr, cfg->addr, test_va_uuid,
+	err = bt_mesh_cfg_cli_mod_sub_va_add(0, cfg->addr, cfg->addr, test_va_uuid,
 					 TEST_MOD_ID, &vaddr, &status);
 	if (err || status) {
 		FAIL("VA addr add failed with err %d status 0x%x", err, status);

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_persistence.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_persistence.c
@@ -98,7 +98,7 @@ static uint8_t test_mod_data[] = { 0xfa, 0xff, 0xf4, 0x43 };
 static uint8_t vnd_test_mod_data[] = { 0xad, 0xdf, 0x14, 0x53, 0x54, 0x1f };
 
 struct access_cfg {
-	struct bt_mesh_cfg_mod_pub pub_params;
+	struct bt_mesh_cfg_cli_mod_pub pub_params;
 
 	size_t appkeys_count;
 	uint16_t appkeys[CONFIG_BT_MESH_MODEL_KEY_COUNT];
@@ -288,8 +288,8 @@ static void prov_node_added(uint16_t net_idx, uint8_t uuid[16], uint16_t addr, u
 	k_sem_give(&prov_sem);
 }
 
-static void check_mod_pub_params(const struct bt_mesh_cfg_mod_pub *expected,
-				 const struct bt_mesh_cfg_mod_pub *got)
+static void check_mod_pub_params(const struct bt_mesh_cfg_cli_mod_pub *expected,
+				 const struct bt_mesh_cfg_cli_mod_pub *got)
 {
 	ASSERT_EQUAL(expected->addr, got->addr);
 	ASSERT_EQUAL(expected->app_idx, got->app_idx);
@@ -408,7 +408,7 @@ static void provisioner_setup(void)
 	memcpy(subnet->keys[0].net_key, test_netkey, 16);
 	bt_mesh_cdb_subnet_store(subnet);
 
-	err = bt_mesh_cfg_net_key_add(0, TEST_PROV_ADDR, test_netkey_idx, test_netkey, &status);
+	err = bt_mesh_cfg_cli_net_key_add(0, TEST_PROV_ADDR, test_netkey_idx, test_netkey, &status);
 	if (err || status) {
 		FAIL("Failed to add test_netkey (err: %d, status: %d)", err, status);
 	}
@@ -471,7 +471,7 @@ static void test_provisioning_data_load(void)
 	/* send TTL Get to verify Tx/Rx path works with loaded config */
 	uint8_t ttl;
 
-	err = bt_mesh_cfg_ttl_get(test_netkey_idx, TEST_ADDR, &ttl);
+	err = bt_mesh_cfg_cli_ttl_get(test_netkey_idx, TEST_ADDR, &ttl);
 	if (err) {
 		FAIL("Failed to read ttl value");
 	}
@@ -493,7 +493,7 @@ static void node_configure(void)
 	int err;
 	uint8_t status;
 	uint16_t va;
-	struct bt_mesh_cfg_mod_pub pub_params;
+	struct bt_mesh_cfg_cli_mod_pub pub_params;
 
 	struct test_appkey_t test_appkeys[] = {
 		{ .idx = TEST_APPKEY_0_IDX, .key = TEST_APPKEY_0_KEY },
@@ -501,7 +501,7 @@ static void node_configure(void)
 	};
 
 	for (size_t i = 0; i < ARRAY_SIZE(test_appkeys); i++) {
-		err = bt_mesh_cfg_app_key_add(test_netkey_idx, TEST_ADDR, test_netkey_idx,
+		err = bt_mesh_cfg_cli_app_key_add(test_netkey_idx, TEST_ADDR, test_netkey_idx,
 					      test_appkeys[i].idx, test_appkeys[i].key, &status);
 		if (err || status) {
 			FAIL("AppKey add failed (err %d, status %u, i %d)", err, status, i);
@@ -510,29 +510,29 @@ static void node_configure(void)
 
 	/* SIG model. */
 	for (size_t i = 0; i < ARRAY_SIZE(test_appkeys); i++) {
-		err = bt_mesh_cfg_mod_app_bind(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+		err = bt_mesh_cfg_cli_mod_app_bind(test_netkey_idx, TEST_ADDR, TEST_ADDR,
 					       test_appkeys[i].idx, TEST_MOD_ID, &status);
 		if (err || status) {
 			FAIL("Mod app bind failed (err %d, status %u, i %d)", err, status, i);
 		}
 	}
 
-	err = bt_mesh_cfg_mod_sub_add(test_netkey_idx, TEST_ADDR, TEST_ADDR, TEST_GROUP_0,
+	err = bt_mesh_cfg_cli_mod_sub_add(test_netkey_idx, TEST_ADDR, TEST_ADDR, TEST_GROUP_0,
 				      TEST_MOD_ID, &status);
 	if (err || status) {
 		FAIL("Mod sub add failed (err %d, status %u)", err, status);
 	}
 
-	err = bt_mesh_cfg_mod_sub_va_add(test_netkey_idx, TEST_ADDR, TEST_ADDR, TEST_VA_0_UUID,
+	err = bt_mesh_cfg_cli_mod_sub_va_add(test_netkey_idx, TEST_ADDR, TEST_ADDR, TEST_VA_0_UUID,
 					 TEST_MOD_ID, &va, &status);
 	if (err || status) {
 		FAIL("Mod sub add failed (err %d, status %u)", err, status);
 	}
 	ASSERT_EQUAL(TEST_VA_0_ADDR, va);
 
-	memcpy(&pub_params, &(struct bt_mesh_cfg_mod_pub)TEST_MOD_PUB_PARAMS,
-	       sizeof(struct bt_mesh_cfg_mod_pub));
-	err = bt_mesh_cfg_mod_pub_set(test_netkey_idx, TEST_ADDR, TEST_ADDR, TEST_MOD_ID,
+	memcpy(&pub_params, &(struct bt_mesh_cfg_cli_mod_pub)TEST_MOD_PUB_PARAMS,
+	       sizeof(struct bt_mesh_cfg_cli_mod_pub));
+	err = bt_mesh_cfg_cli_mod_pub_set(test_netkey_idx, TEST_ADDR, TEST_ADDR, TEST_MOD_ID,
 				      &pub_params, &status);
 	if (err || status) {
 		FAIL("Mod pub set failed (err %d, status %u)", err, status);
@@ -546,7 +546,7 @@ static void node_configure(void)
 
 	/* Vendor model. */
 	for (size_t i = 0; i < ARRAY_SIZE(test_appkeys); i++) {
-		err = bt_mesh_cfg_mod_app_bind_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+		err = bt_mesh_cfg_cli_mod_app_bind_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
 						   test_appkeys[i].idx, TEST_VND_MOD_ID,
 						   TEST_VND_COMPANY_ID, &status);
 		if (err || status) {
@@ -554,26 +554,27 @@ static void node_configure(void)
 		}
 	}
 
-	err = bt_mesh_cfg_mod_sub_add_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+	err = bt_mesh_cfg_cli_mod_sub_add_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
 					  TEST_GROUP_0, TEST_VND_MOD_ID,
 					  TEST_VND_COMPANY_ID, &status);
 	if (err || status) {
 		FAIL("Mod sub add failed (err %d, status %u)", err, status);
 	}
 
-	err = bt_mesh_cfg_mod_sub_va_add_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR, TEST_VA_0_UUID,
-					     TEST_VND_MOD_ID,
-					     TEST_VND_COMPANY_ID, &va, &status);
+	err = bt_mesh_cfg_cli_mod_sub_va_add_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+						 TEST_VA_0_UUID, TEST_VND_MOD_ID,
+						 TEST_VND_COMPANY_ID, &va, &status);
 	if (err || status) {
 		FAIL("Mod sub add failed (err %d, status %u)", err, status);
 	}
 
 	ASSERT_EQUAL(TEST_VA_0_ADDR, va);
 
-	memcpy(&pub_params, &(struct bt_mesh_cfg_mod_pub)TEST_VND_MOD_PUB_PARAMS,
-	       sizeof(struct bt_mesh_cfg_mod_pub));
-	err = bt_mesh_cfg_mod_pub_set_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR, TEST_VND_MOD_ID,
-					  TEST_VND_COMPANY_ID, &pub_params, &status);
+	memcpy(&pub_params, &(struct bt_mesh_cfg_cli_mod_pub)TEST_VND_MOD_PUB_PARAMS,
+	       sizeof(struct bt_mesh_cfg_cli_mod_pub));
+	err = bt_mesh_cfg_cli_mod_pub_set_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+					      TEST_VND_MOD_ID, TEST_VND_COMPANY_ID, &pub_params,
+					      &status);
 	if (err || status) {
 		FAIL("Mod pub set failed (err %d, status %u)", err, status);
 	}
@@ -615,11 +616,11 @@ static void node_configuration_check(const struct access_cfg (*cfg)[2])
 		bool vnd = m == 1;
 
 		if (!vnd) {
-			err = bt_mesh_cfg_mod_app_get(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+			err = bt_mesh_cfg_cli_mod_app_get(test_netkey_idx, TEST_ADDR, TEST_ADDR,
 						      TEST_MOD_ID, &status, appkeys,
 						      &appkeys_count);
 		} else {
-			err = bt_mesh_cfg_mod_app_get_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+			err = bt_mesh_cfg_cli_mod_app_get_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
 							  TEST_VND_MOD_ID, TEST_VND_COMPANY_ID,
 							  &status, appkeys, &appkeys_count);
 		}
@@ -633,10 +634,10 @@ static void node_configuration_check(const struct access_cfg (*cfg)[2])
 		}
 
 		if (!vnd) {
-			err = bt_mesh_cfg_mod_sub_get(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+			err = bt_mesh_cfg_cli_mod_sub_get(test_netkey_idx, TEST_ADDR, TEST_ADDR,
 						      TEST_MOD_ID, &status, subs, &subs_count);
 		} else {
-			err = bt_mesh_cfg_mod_sub_get_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+			err = bt_mesh_cfg_cli_mod_sub_get_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
 							  TEST_VND_MOD_ID, TEST_VND_COMPANY_ID,
 							  &status, subs, &subs_count);
 		}
@@ -649,13 +650,13 @@ static void node_configuration_check(const struct access_cfg (*cfg)[2])
 			ASSERT_EQUAL((*cfg)[m].subs[i], subs[i]);
 		}
 
-		struct bt_mesh_cfg_mod_pub pub_params = {};
+		struct bt_mesh_cfg_cli_mod_pub pub_params = {};
 
 		if (!vnd) {
-			err = bt_mesh_cfg_mod_pub_get(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+			err = bt_mesh_cfg_cli_mod_pub_get(test_netkey_idx, TEST_ADDR, TEST_ADDR,
 						      TEST_MOD_ID, &pub_params, &status);
 		} else {
-			err = bt_mesh_cfg_mod_pub_get_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+			err = bt_mesh_cfg_cli_mod_pub_get_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
 							  TEST_VND_MOD_ID, TEST_VND_COMPANY_ID,
 							  &pub_params, &status);
 		}
@@ -696,13 +697,13 @@ static void test_access_sub_overwrite(void)
 		FAIL("Device should boot up as already provisioned");
 	}
 
-	err = bt_mesh_cfg_mod_sub_overwrite(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+	err = bt_mesh_cfg_cli_mod_sub_overwrite(test_netkey_idx, TEST_ADDR, TEST_ADDR,
 					    TEST_GROUP_0, TEST_MOD_ID, &status);
 	if (err || status) {
 		FAIL("Mod sub overwrite failed (err %d, status %u)", err, status);
 	}
 
-	err = bt_mesh_cfg_mod_sub_va_overwrite_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+	err = bt_mesh_cfg_cli_mod_sub_va_overwrite_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
 						   TEST_VA_0_UUID, TEST_VND_MOD_ID,
 						   TEST_VND_COMPANY_ID, &va, &status);
 	if (err || status) {
@@ -719,7 +720,7 @@ static void test_access_data_remove(void)
 {
 	int err;
 	uint8_t status;
-	struct bt_mesh_cfg_mod_pub pub_params;
+	struct bt_mesh_cfg_cli_mod_pub pub_params;
 
 	/* In this test stack should boot as provisioned */
 	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
@@ -735,23 +736,23 @@ static void test_access_data_remove(void)
 
 	/* SIG Model. */
 	for (size_t i = 0; i < ARRAY_SIZE(test_appkeys); i++) {
-		err = bt_mesh_cfg_mod_app_unbind(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+		err = bt_mesh_cfg_cli_mod_app_unbind(test_netkey_idx, TEST_ADDR, TEST_ADDR,
 						 test_appkeys[i].idx, TEST_MOD_ID, &status);
 		if (err || status) {
 			FAIL("Mod app bind failed (err %d, status %u, i %d)", err, status, i);
 		}
 	}
 
-	err = bt_mesh_cfg_mod_sub_del_all(test_netkey_idx, TEST_ADDR, TEST_ADDR, TEST_MOD_ID,
+	err = bt_mesh_cfg_cli_mod_sub_del_all(test_netkey_idx, TEST_ADDR, TEST_ADDR, TEST_MOD_ID,
 					  &status);
 	if (err || status) {
 		FAIL("Mod sub del all failed (err %d, status %u)", err, status);
 	}
 
-	memcpy(&pub_params, &(struct bt_mesh_cfg_mod_pub)TEST_MOD_PUB_PARAMS,
-	       sizeof(struct bt_mesh_cfg_mod_pub));
+	memcpy(&pub_params, &(struct bt_mesh_cfg_cli_mod_pub)TEST_MOD_PUB_PARAMS,
+	       sizeof(struct bt_mesh_cfg_cli_mod_pub));
 	pub_params.addr = BT_MESH_ADDR_UNASSIGNED;
-	err = bt_mesh_cfg_mod_pub_set(test_netkey_idx, TEST_ADDR, TEST_ADDR, TEST_MOD_ID,
+	err = bt_mesh_cfg_cli_mod_pub_set(test_netkey_idx, TEST_ADDR, TEST_ADDR, TEST_MOD_ID,
 				      &pub_params, &status);
 	if (err || status) {
 		FAIL("Mod pub set failed (err %d, status %u)", err, status);
@@ -764,7 +765,7 @@ static void test_access_data_remove(void)
 
 	/* Vendor model. */
 	for (size_t i = 0; i < ARRAY_SIZE(test_appkeys); i++) {
-		err = bt_mesh_cfg_mod_app_unbind_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+		err = bt_mesh_cfg_cli_mod_app_unbind_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
 						     test_appkeys[i].idx, TEST_VND_MOD_ID,
 						     TEST_VND_COMPANY_ID, &status);
 		if (err || status) {
@@ -772,19 +773,20 @@ static void test_access_data_remove(void)
 		}
 	}
 
-	err = bt_mesh_cfg_mod_sub_del_all_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+	err = bt_mesh_cfg_cli_mod_sub_del_all_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
 					      TEST_VND_MOD_ID, TEST_VND_COMPANY_ID,
 					      &status);
 	if (err || status) {
 		FAIL("Mod sub del all failed (err %d, status %u)", err, status);
 	}
 
-	memcpy(&pub_params, &(struct bt_mesh_cfg_mod_pub)TEST_VND_MOD_PUB_PARAMS,
-	       sizeof(struct bt_mesh_cfg_mod_pub));
+	memcpy(&pub_params, &(struct bt_mesh_cfg_cli_mod_pub)TEST_VND_MOD_PUB_PARAMS,
+	       sizeof(struct bt_mesh_cfg_cli_mod_pub));
 	pub_params.addr = BT_MESH_ADDR_UNASSIGNED;
 	pub_params.uuid = NULL;
-	err = bt_mesh_cfg_mod_pub_set_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR, TEST_VND_MOD_ID,
-					  TEST_VND_COMPANY_ID, &pub_params, &status);
+	err = bt_mesh_cfg_cli_mod_pub_set_vnd(test_netkey_idx, TEST_ADDR, TEST_ADDR,
+					      TEST_VND_MOD_ID, TEST_VND_COMPANY_ID, &pub_params,
+					      &status);
 	if (err || status) {
 		FAIL("Mod pub set failed (err %d, status %u)", err, status);
 	}
@@ -815,38 +817,38 @@ static void test_cfg_save(void)
 		FAIL("Mesh setup failed. Settings should not be loaded.");
 	}
 
-	err = bt_mesh_cfg_beacon_set(test_netkey_idx, TEST_ADDR,
+	err = bt_mesh_cfg_cli_beacon_set(test_netkey_idx, TEST_ADDR,
 				     current_stack_cfg->beacon, &status);
 	if (err || status != current_stack_cfg->beacon) {
 		FAIL("Beacon set failed (err %d, status %u)", err, status);
 	}
 
-	err = bt_mesh_cfg_ttl_set(test_netkey_idx, TEST_ADDR,
+	err = bt_mesh_cfg_cli_ttl_set(test_netkey_idx, TEST_ADDR,
 				  current_stack_cfg->ttl, &status);
 	if (err || status != current_stack_cfg->ttl) {
 		FAIL("TTL set failed (err %d, status %u)", err, status);
 	}
 
-	err = bt_mesh_cfg_gatt_proxy_set(test_netkey_idx, TEST_ADDR,
+	err = bt_mesh_cfg_cli_gatt_proxy_set(test_netkey_idx, TEST_ADDR,
 					 current_stack_cfg->gatt_proxy, &status);
 	if (err || status != current_stack_cfg->gatt_proxy) {
 		FAIL("GATT Proxy set failed (err %d, status %u)", err, status);
 	}
 
-	err = bt_mesh_cfg_friend_set(test_netkey_idx, TEST_ADDR,
+	err = bt_mesh_cfg_cli_friend_set(test_netkey_idx, TEST_ADDR,
 				     current_stack_cfg->friend, &status);
 	if (err || status != current_stack_cfg->friend) {
 		FAIL("Friend set failed (err %d, status %u)", err, status);
 	}
 
-	err = bt_mesh_cfg_net_transmit_set(test_netkey_idx, TEST_ADDR,
+	err = bt_mesh_cfg_cli_net_transmit_set(test_netkey_idx, TEST_ADDR,
 					   current_stack_cfg->net_transmit,
 					   &transmit);
 	if (err || transmit != current_stack_cfg->net_transmit) {
 		FAIL("Net transmit set failed (err %d, transmit %x)", err, transmit);
 	}
 
-	err = bt_mesh_cfg_relay_set(test_netkey_idx, TEST_ADDR,
+	err = bt_mesh_cfg_cli_relay_set(test_netkey_idx, TEST_ADDR,
 				    current_stack_cfg->relay.state,
 				    current_stack_cfg->relay.transmit,
 				    &status, &transmit);
@@ -876,32 +878,32 @@ static void test_cfg_load(void)
 		FAIL("Device should boot up as already provisioned");
 	}
 
-	err = bt_mesh_cfg_beacon_get(test_netkey_idx, TEST_ADDR, &status);
+	err = bt_mesh_cfg_cli_beacon_get(test_netkey_idx, TEST_ADDR, &status);
 	if (err || status != current_stack_cfg->beacon) {
 		FAIL("Beacon get failed (err %d, status %u)", err, status);
 	}
 
-	err = bt_mesh_cfg_ttl_get(test_netkey_idx, TEST_ADDR, &status);
+	err = bt_mesh_cfg_cli_ttl_get(test_netkey_idx, TEST_ADDR, &status);
 	if (err || status != current_stack_cfg->ttl) {
 		FAIL("TTL get failed (err %d, status %u)", err, status);
 	}
 
-	err = bt_mesh_cfg_gatt_proxy_get(test_netkey_idx, TEST_ADDR, &status);
+	err = bt_mesh_cfg_cli_gatt_proxy_get(test_netkey_idx, TEST_ADDR, &status);
 	if (err || status != current_stack_cfg->gatt_proxy) {
 		FAIL("GATT Proxy get failed (err %d, status %u)", err, status);
 	}
 
-	err = bt_mesh_cfg_friend_get(test_netkey_idx, TEST_ADDR, &status);
+	err = bt_mesh_cfg_cli_friend_get(test_netkey_idx, TEST_ADDR, &status);
 	if (err || status != current_stack_cfg->friend) {
 		FAIL("Friend get failed (err %d, status %u)", err, status);
 	}
 
-	err = bt_mesh_cfg_net_transmit_get(test_netkey_idx, TEST_ADDR, &status);
+	err = bt_mesh_cfg_cli_net_transmit_get(test_netkey_idx, TEST_ADDR, &status);
 	if (err || status != current_stack_cfg->net_transmit) {
 		FAIL("Net transmit get failed (err %d, status %u)", err, status);
 	}
 
-	err = bt_mesh_cfg_relay_get(test_netkey_idx, TEST_ADDR, &status, &transmit);
+	err = bt_mesh_cfg_cli_relay_get(test_netkey_idx, TEST_ADDR, &status, &transmit);
 	if (err || status != current_stack_cfg->relay.state ||
 	    transmit != current_stack_cfg->relay.transmit) {
 		FAIL("Relay get failed (err %d, state %u, transmit %x)", err, status, transmit);
@@ -976,7 +978,7 @@ static void test_reprovisioning_provisioner(void)
 	/* Let the remote device store configuration. */
 	k_sleep(K_SECONDS(CONFIG_BT_MESH_STORE_TIMEOUT * 2));
 
-	err = bt_mesh_cfg_node_reset(test_netkey_idx, TEST_ADDR, &status);
+	err = bt_mesh_cfg_cli_node_reset(test_netkey_idx, TEST_ADDR, &status);
 	if (err || !status) {
 		FAIL("Reset failed (err %d, status: %d)", err, status);
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_provision.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_provision.c
@@ -533,17 +533,17 @@ static void test_provisioner_pb_adv_reprovision(void)
 		uint8_t status;
 		size_t subs_count = 1;
 		uint16_t sub;
-		struct bt_mesh_cfg_mod_pub healthpub = { 0 };
+		struct bt_mesh_cfg_cli_mod_pub healthpub = { 0 };
 		struct bt_mesh_cdb_node *node;
 
 		/* Check that publication and subscription are reset after last iteration */
-		ASSERT_OK(bt_mesh_cfg_mod_sub_get(0, current_dev_addr, current_dev_addr,
+		ASSERT_OK(bt_mesh_cfg_cli_mod_sub_get(0, current_dev_addr, current_dev_addr,
 						  BT_MESH_MODEL_ID_HEALTH_SRV, &status, &sub,
 						  &subs_count));
 		ASSERT_EQUAL(0, status);
 		ASSERT_TRUE(subs_count == 0);
 
-		ASSERT_OK(bt_mesh_cfg_mod_pub_get(0, current_dev_addr, current_dev_addr,
+		ASSERT_OK(bt_mesh_cfg_cli_mod_pub_get(0, current_dev_addr, current_dev_addr,
 						  BT_MESH_MODEL_ID_HEALTH_SRV, &healthpub,
 						  &status));
 		ASSERT_EQUAL(0, status);
@@ -558,32 +558,32 @@ static void test_provisioner_pb_adv_reprovision(void)
 		healthpub.period = BT_MESH_PUB_PERIOD_10SEC(1);
 		healthpub.transmit = BT_MESH_TRANSMIT(3, 100);
 
-		ASSERT_OK(bt_mesh_cfg_app_key_add(0, current_dev_addr, 0, 0, test_app_key,
+		ASSERT_OK(bt_mesh_cfg_cli_app_key_add(0, current_dev_addr, 0, 0, test_app_key,
 						  &status));
 		ASSERT_EQUAL(0, status);
 
 		k_sleep(K_SECONDS(1));
 
-		ASSERT_OK(bt_mesh_cfg_mod_app_bind(0, current_dev_addr, current_dev_addr, 0x0,
+		ASSERT_OK(bt_mesh_cfg_cli_mod_app_bind(0, current_dev_addr, current_dev_addr, 0x0,
 						   BT_MESH_MODEL_ID_HEALTH_SRV, &status));
 		ASSERT_EQUAL(0, status);
 
 		k_sleep(K_SECONDS(1));
 
-		ASSERT_OK(bt_mesh_cfg_mod_sub_add(0, current_dev_addr, current_dev_addr, 0xc000,
+		ASSERT_OK(bt_mesh_cfg_cli_mod_sub_add(0, current_dev_addr, current_dev_addr, 0xc000,
 						  BT_MESH_MODEL_ID_HEALTH_SRV, &status));
 		ASSERT_EQUAL(0, status);
 
 		k_sleep(K_SECONDS(1));
 
-		ASSERT_OK(bt_mesh_cfg_mod_pub_set(0, current_dev_addr, current_dev_addr,
+		ASSERT_OK(bt_mesh_cfg_cli_mod_pub_set(0, current_dev_addr, current_dev_addr,
 						  BT_MESH_MODEL_ID_HEALTH_SRV, &healthpub,
 						  &status));
 		ASSERT_EQUAL(0, status);
 
 		k_sleep(K_SECONDS(1));
 
-		ASSERT_OK(bt_mesh_cfg_node_reset(0, current_dev_addr, (bool *)&status));
+		ASSERT_OK(bt_mesh_cfg_cli_node_reset(0, current_dev_addr, (bool *)&status));
 
 		node = bt_mesh_cdb_node_get(current_dev_addr);
 		bt_mesh_cdb_node_del(node, true);

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_transport.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_transport.c
@@ -177,13 +177,13 @@ static void test_tx_unknown_app(void)
 
 	bt_mesh_test_setup();
 
-	ASSERT_OK(bt_mesh_cfg_app_key_add(0, cfg->addr, 0, 1, app_key, &status),
+	ASSERT_OK(bt_mesh_cfg_cli_app_key_add(0, cfg->addr, 0, 1, app_key, &status),
 		  "Failed adding additional appkey");
 	if (status) {
 		FAIL("App key add status: 0x%02x", status);
 	}
 
-	ASSERT_OK(bt_mesh_cfg_mod_app_bind(0, cfg->addr, cfg->addr, 1,
+	ASSERT_OK(bt_mesh_cfg_cli_mod_app_bind(0, cfg->addr, cfg->addr, 1,
 					   TEST_MOD_ID, &status),
 		  "Failed binding additional appkey");
 	if (status) {
@@ -214,7 +214,7 @@ static void test_tx_loopback_group(void)
 
 	bt_mesh_test_setup();
 
-	err = bt_mesh_cfg_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR,
+	err = bt_mesh_cfg_cli_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR,
 				      TEST_MOD_ID, &status);
 	ASSERT_OK(err || status, "Mod sub add failed (err %d, status %u)",
 		  err, status);
@@ -384,7 +384,7 @@ static void test_rx_group(void)
 
 	bt_mesh_test_setup();
 
-	err = bt_mesh_cfg_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR,
+	err = bt_mesh_cfg_cli_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR,
 				      TEST_MOD_ID, &status);
 	ASSERT_OK(err || status, "Mod sub add failed (err %d, status %u)",
 		  err, status);
@@ -408,7 +408,7 @@ static void test_rx_va(void)
 
 	bt_mesh_test_setup();
 
-	err = bt_mesh_cfg_mod_sub_va_add(0, cfg->addr, cfg->addr, test_va_uuid,
+	err = bt_mesh_cfg_cli_mod_sub_va_add(0, cfg->addr, cfg->addr, test_va_uuid,
 					 TEST_MOD_ID, &virtual_addr, &status);
 	ASSERT_OK(err || status, "Sub add failed (err %d, status %u)", err,
 		  status);
@@ -462,7 +462,7 @@ static void test_rx_seg_concurrent(void)
 	bt_mesh_test_setup();
 
 	/* Subscribe to group addr */
-	err = bt_mesh_cfg_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR,
+	err = bt_mesh_cfg_cli_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR,
 				      TEST_MOD_ID, &status);
 	ASSERT_OK(err || status, "Mod sub add failed (err %d, status %u)",
 		  err, status);

--- a/tests/bluetooth/tester/src/mesh.c
+++ b/tests/bluetooth/tester/src/mesh.c
@@ -889,7 +889,7 @@ static void composition_data_get(uint8_t *data, uint16_t len)
 
 	net_buf_simple_init(comp, 0);
 
-	err = bt_mesh_cfg_comp_data_get(cmd->net_idx, cmd->address, cmd->page,
+	err = bt_mesh_cfg_cli_comp_data_get(cmd->net_idx, cmd->address, cmd->page,
 					&page, comp);
 	if (err) {
 		LOG_ERR("err %d", err);
@@ -914,7 +914,8 @@ static void config_krp_get(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_krp_get(cmd->net_idx, cmd->address, cmd->key_net_idx, &status, &phase);
+	err = bt_mesh_cfg_cli_krp_get(cmd->net_idx, cmd->address, cmd->key_net_idx, &status,
+				      &phase);
 
 	if (err) {
 		LOG_ERR("err %d", err);
@@ -942,7 +943,7 @@ static void config_krp_set(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_krp_set(cmd->net_idx, cmd->address, cmd->key_net_idx, cmd->transition,
+	err = bt_mesh_cfg_cli_krp_set(cmd->net_idx, cmd->address, cmd->key_net_idx, cmd->transition,
 				  &status, &phase);
 	if (err) {
 		LOG_ERR("err %d", err);
@@ -968,7 +969,7 @@ static void config_beacon_get(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_beacon_get(cmd->net_idx, cmd->address, &status);
+	err = bt_mesh_cfg_cli_beacon_get(cmd->net_idx, cmd->address, &status);
 	if (err) {
 		LOG_ERR("err %d", err);
 		goto fail;
@@ -990,7 +991,7 @@ static void config_beacon_set(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_beacon_set(cmd->net_idx, cmd->address, cmd->val,
+	err = bt_mesh_cfg_cli_beacon_set(cmd->net_idx, cmd->address, cmd->val,
 				     &status);
 	if (err) {
 		LOG_ERR("err %d", err);
@@ -1012,7 +1013,7 @@ static void config_default_ttl_get(uint8_t *data, uint16_t len)
 	int err;
 
 	LOG_DBG("");
-	err = bt_mesh_cfg_ttl_get(cmd->net_idx, cmd->address, &status);
+	err = bt_mesh_cfg_cli_ttl_get(cmd->net_idx, cmd->address, &status);
 
 	if (err) {
 		LOG_ERR("err %d", err);
@@ -1035,7 +1036,7 @@ static void config_default_ttl_set(uint8_t *data, uint16_t len)
 	int err;
 
 	LOG_DBG("");
-	err = bt_mesh_cfg_ttl_set(cmd->net_idx, cmd->address, cmd->val,
+	err = bt_mesh_cfg_cli_ttl_set(cmd->net_idx, cmd->address, cmd->val,
 				  &status);
 
 	if (err) {
@@ -1059,7 +1060,7 @@ static void config_gatt_proxy_get(uint8_t *data, uint16_t len)
 	int err;
 
 	LOG_DBG("");
-	err = bt_mesh_cfg_gatt_proxy_get(cmd->net_idx, cmd->address, &status);
+	err = bt_mesh_cfg_cli_gatt_proxy_get(cmd->net_idx, cmd->address, &status);
 
 	if (err) {
 		LOG_ERR("err %d", err);
@@ -1082,7 +1083,7 @@ static void config_gatt_proxy_set(uint8_t *data, uint16_t len)
 	int err;
 
 	LOG_DBG("");
-	err = bt_mesh_cfg_gatt_proxy_set(cmd->net_idx, cmd->address, cmd->val,
+	err = bt_mesh_cfg_cli_gatt_proxy_set(cmd->net_idx, cmd->address, cmd->val,
 					 &status);
 
 	if (err) {
@@ -1106,7 +1107,7 @@ static void config_friend_get(uint8_t *data, uint16_t len)
 	int err;
 
 	LOG_DBG("");
-	err = bt_mesh_cfg_friend_get(cmd->net_idx, cmd->address, &status);
+	err = bt_mesh_cfg_cli_friend_get(cmd->net_idx, cmd->address, &status);
 
 	if (err) {
 		LOG_ERR("err %d", err);
@@ -1128,7 +1129,7 @@ static void config_friend_set(uint8_t *data, uint16_t len)
 	int err;
 
 	LOG_DBG("");
-	err = bt_mesh_cfg_friend_set(cmd->net_idx, cmd->address, cmd->val,
+	err = bt_mesh_cfg_cli_friend_set(cmd->net_idx, cmd->address, cmd->val,
 				     &status);
 
 	if (err) {
@@ -1152,7 +1153,7 @@ static void config_relay_get(uint8_t *data, uint16_t len)
 	int err;
 
 	LOG_DBG("");
-	err = bt_mesh_cfg_relay_get(cmd->net_idx, cmd->address, &status,
+	err = bt_mesh_cfg_cli_relay_get(cmd->net_idx, cmd->address, &status,
 				    &transmit);
 
 	if (err) {
@@ -1176,7 +1177,7 @@ static void config_relay_set(uint8_t *data, uint16_t len)
 	int err;
 
 	LOG_DBG("");
-	err = bt_mesh_cfg_relay_set(cmd->net_idx, cmd->address, cmd->new_relay,
+	err = bt_mesh_cfg_cli_relay_set(cmd->net_idx, cmd->address, cmd->new_relay,
 				    cmd->new_transmit, &status, &transmit);
 
 	if (err) {
@@ -1195,12 +1196,12 @@ fail:
 static void config_mod_pub_get(uint8_t *data, uint16_t len)
 {
 	struct mesh_cfg_model_pub_get_cmd *cmd = (void *)data;
-	struct bt_mesh_cfg_mod_pub pub;
+	struct bt_mesh_cfg_cli_mod_pub pub;
 	uint8_t status;
 	int err;
 
 	LOG_DBG("");
-	err = bt_mesh_cfg_mod_pub_get(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_pub_get(cmd->net_idx, cmd->address,
 				      cmd->elem_address, cmd->model_id, &pub,
 				      &status);
 
@@ -1222,7 +1223,7 @@ static void config_mod_pub_set(uint8_t *data, uint16_t len)
 {
 	struct mesh_cfg_model_pub_set_cmd *cmd = (void *)data;
 	uint8_t status;
-	struct bt_mesh_cfg_mod_pub pub;
+	struct bt_mesh_cfg_cli_mod_pub pub;
 	int err;
 
 	LOG_DBG("");
@@ -1235,7 +1236,7 @@ static void config_mod_pub_set(uint8_t *data, uint16_t len)
 	pub.period = cmd->period;
 	pub.transmit = cmd->transmit;
 
-	err = bt_mesh_cfg_mod_pub_set(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_pub_set(cmd->net_idx, cmd->address,
 				      cmd->elem_address, cmd->model_id, &pub,
 				      &status);
 
@@ -1257,7 +1258,7 @@ static void config_mod_pub_va_set(uint8_t *data, uint16_t len)
 {
 	struct mesh_cfg_model_pub_va_set_cmd *cmd = (void *)data;
 	uint8_t status;
-	struct bt_mesh_cfg_mod_pub pub;
+	struct bt_mesh_cfg_cli_mod_pub pub;
 	int err;
 
 	LOG_DBG("");
@@ -1269,7 +1270,7 @@ static void config_mod_pub_va_set(uint8_t *data, uint16_t len)
 	pub.period = cmd->period;
 	pub.transmit = cmd->transmit;
 
-	err = bt_mesh_cfg_mod_pub_set(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_pub_set(cmd->net_idx, cmd->address,
 				      cmd->elem_address, cmd->model_id,
 				      &pub, &status);
 
@@ -1295,7 +1296,7 @@ static void config_mod_sub_add(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_mod_sub_add(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_sub_add(cmd->net_idx, cmd->address,
 				      cmd->elem_address, cmd->sub_addr,
 				      cmd->model_id, &status);
 
@@ -1321,7 +1322,7 @@ static void config_mod_sub_ovw(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_mod_sub_overwrite(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_sub_overwrite(cmd->net_idx, cmd->address,
 					    cmd->elem_address, cmd->sub_addr,
 					    cmd->model_id, &status);
 
@@ -1347,7 +1348,7 @@ static void config_mod_sub_del(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_mod_sub_del(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_sub_del(cmd->net_idx, cmd->address,
 				      cmd->elem_address, cmd->sub_addr,
 				      cmd->model_id, &status);
 
@@ -1373,7 +1374,7 @@ static void config_mod_sub_del_all(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_mod_sub_del_all(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_sub_del_all(cmd->net_idx, cmd->address,
 					  cmd->elem_address, cmd->model_id,
 					  &status);
 
@@ -1401,7 +1402,7 @@ static void config_mod_sub_get(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_mod_sub_get(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_sub_get(cmd->net_idx, cmd->address,
 				      cmd->elem_address, cmd->model_id, &status,
 				      &subs, &sub_cn);
 
@@ -1429,7 +1430,7 @@ static void config_mod_sub_get_vnd(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_mod_sub_get_vnd(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_sub_get_vnd(cmd->net_idx, cmd->address,
 					  cmd->elem_address, cmd->model_id,
 					  cmd->cid, &status, &subs, &sub_cn);
 
@@ -1456,7 +1457,7 @@ static void config_mod_sub_va_add(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_mod_sub_va_add(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_sub_va_add(cmd->net_idx, cmd->address,
 					 cmd->elem_address, cmd->uuid,
 					 cmd->model_id, &virt_addr_rcv,
 					 &status);
@@ -1484,7 +1485,7 @@ static void config_mod_sub_va_del(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_mod_sub_va_del(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_sub_va_del(cmd->net_idx, cmd->address,
 					 cmd->elem_address, cmd->uuid,
 					 cmd->model_id, &virt_addr_rcv,
 					 &status);
@@ -1512,7 +1513,7 @@ static void config_mod_sub_va_ovw(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_mod_sub_va_overwrite(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_sub_va_overwrite(cmd->net_idx, cmd->address,
 					       cmd->elem_address,
 					       cmd->uuid, cmd->model_id,
 					       &virt_addr_rcv, &status);
@@ -1539,7 +1540,7 @@ static void config_netkey_add(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_net_key_add(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_net_key_add(cmd->net_idx, cmd->address,
 				      cmd->net_key_idx, cmd->net_key, &status);
 
 	if (err) {
@@ -1563,7 +1564,7 @@ static void config_netkey_update(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_net_key_update(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_net_key_update(cmd->net_idx, cmd->address,
 					 cmd->net_key_idx, cmd->net_key,
 					 &status);
 
@@ -1590,7 +1591,7 @@ static void config_netkey_get(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_net_key_get(cmd->net_idx, cmd->address, &keys,
+	err = bt_mesh_cfg_cli_net_key_get(cmd->net_idx, cmd->address, &keys,
 				      &key_cnt);
 
 	if (err) {
@@ -1614,7 +1615,7 @@ static void config_netkey_del(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_net_key_del(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_net_key_del(cmd->net_idx, cmd->address,
 				      cmd->net_key_idx, &status);
 
 	if (err) {
@@ -1638,7 +1639,7 @@ static void config_appkey_add(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_app_key_add(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_app_key_add(cmd->net_idx, cmd->address,
 				      cmd->net_key_idx, cmd->app_key_idx,
 				      cmd->app_key, &status);
 
@@ -1663,7 +1664,7 @@ static void config_appkey_update(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_app_key_update(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_app_key_update(cmd->net_idx, cmd->address,
 					 cmd->net_key_idx, cmd->app_key_idx,
 					 cmd->app_key, &status);
 
@@ -1689,7 +1690,7 @@ static void config_appkey_del(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_app_key_del(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_app_key_del(cmd->net_idx, cmd->address,
 				      cmd->net_key_idx, cmd->app_key_idx,
 				      &status);
 
@@ -1716,7 +1717,7 @@ static void config_appkey_get(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_app_key_get(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_app_key_get(cmd->net_idx, cmd->address,
 				      cmd->net_key_idx, &status, &keys,
 				      &key_cnt);
 
@@ -1741,7 +1742,7 @@ static void config_model_app_bind(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_mod_app_bind(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_app_bind(cmd->net_idx, cmd->address,
 				       cmd->elem_address, cmd->app_key_idx,
 				       cmd->mod_id, &status);
 
@@ -1767,7 +1768,7 @@ static void config_model_app_bind_vnd(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_mod_app_bind_vnd(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_app_bind_vnd(cmd->net_idx, cmd->address,
 					   cmd->elem_address, cmd->app_key_idx,
 					   cmd->mod_id, cmd->cid, &status);
 
@@ -1793,7 +1794,7 @@ static void config_model_app_unbind(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_mod_app_unbind(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_app_unbind(cmd->net_idx, cmd->address,
 					 cmd->elem_address, cmd->app_key_idx,
 					 cmd->mod_id, &status);
 
@@ -1821,7 +1822,7 @@ static void config_model_app_get(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_mod_app_get(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_app_get(cmd->net_idx, cmd->address,
 				      cmd->elem_address, cmd->mod_id, &status,
 				      &apps, &app_cnt);
 
@@ -1849,7 +1850,7 @@ static void config_model_app_vnd_get(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_mod_app_get_vnd(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_mod_app_get_vnd(cmd->net_idx, cmd->address,
 					  cmd->elem_address, cmd->mod_id,
 					  cmd->cid, &status, &apps, &app_cnt);
 
@@ -1871,7 +1872,7 @@ static void config_hb_pub_set(uint8_t *data, uint16_t len)
 {
 	struct mesh_cfg_heartbeat_pub_set_cmd *cmd = (void *)data;
 	uint8_t status;
-	struct bt_mesh_cfg_hb_pub pub;
+	struct bt_mesh_cfg_cli_hb_pub pub;
 	int err;
 
 	LOG_DBG("");
@@ -1883,7 +1884,7 @@ static void config_hb_pub_set(uint8_t *data, uint16_t len)
 	pub.ttl = cmd->ttl;
 	pub.feat = cmd->features;
 
-	err = bt_mesh_cfg_hb_pub_set(cmd->net_idx, cmd->address, &pub, &status);
+	err = bt_mesh_cfg_cli_hb_pub_set(cmd->net_idx, cmd->address, &pub, &status);
 
 	if (err) {
 		LOG_ERR("err %d", err);
@@ -1903,12 +1904,12 @@ static void config_hb_pub_get(uint8_t *data, uint16_t len)
 {
 	struct mesh_cfg_val_get_cmd *cmd = (void *)data;
 	uint8_t status;
-	struct bt_mesh_cfg_hb_pub pub;
+	struct bt_mesh_cfg_cli_hb_pub pub;
 	int err;
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_hb_pub_get(cmd->net_idx, cmd->address, &pub, &status);
+	err = bt_mesh_cfg_cli_hb_pub_get(cmd->net_idx, cmd->address, &pub, &status);
 
 	if (err) {
 		LOG_ERR("err %d", err);
@@ -1928,7 +1929,7 @@ static void config_hb_sub_set(uint8_t *data, uint16_t len)
 {
 	struct mesh_cfg_heartbeat_sub_set_cmd *cmd = (void *)data;
 	uint8_t status;
-	struct bt_mesh_cfg_hb_sub sub;
+	struct bt_mesh_cfg_cli_hb_sub sub;
 	int err;
 
 	LOG_DBG("");
@@ -1937,7 +1938,7 @@ static void config_hb_sub_set(uint8_t *data, uint16_t len)
 	sub.dst = cmd->destination;
 	sub.period = cmd->period_log;
 
-	err = bt_mesh_cfg_hb_sub_set(cmd->net_idx, cmd->address, &sub, &status);
+	err = bt_mesh_cfg_cli_hb_sub_set(cmd->net_idx, cmd->address, &sub, &status);
 
 	if (err) {
 		LOG_ERR("err %d", err);
@@ -1957,12 +1958,12 @@ static void config_hb_sub_get(uint8_t *data, uint16_t len)
 {
 	struct mesh_cfg_val_get_cmd *cmd = (void *)data;
 	uint8_t status;
-	struct bt_mesh_cfg_hb_sub sub;
+	struct bt_mesh_cfg_cli_hb_sub sub;
 	int err;
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_hb_sub_get(cmd->net_idx, cmd->address, &sub, &status);
+	err = bt_mesh_cfg_cli_hb_sub_get(cmd->net_idx, cmd->address, &sub, &status);
 
 	if (err) {
 		LOG_ERR("err %d", err);
@@ -1986,7 +1987,7 @@ static void config_net_trans_get(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_net_transmit_get(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_net_transmit_get(cmd->net_idx, cmd->address,
 					   &transmit);
 
 	if (err) {
@@ -2011,7 +2012,7 @@ static void config_net_trans_set(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_net_transmit_set(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_net_transmit_set(cmd->net_idx, cmd->address,
 					   cmd->transmit, &transmit);
 
 	if (err) {
@@ -2038,7 +2039,7 @@ static void config_node_identity_set(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_node_identity_set(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_node_identity_set(cmd->net_idx, cmd->address,
 					    cmd->net_key_idx, cmd->new_identity,
 					    &status, &identity);
 
@@ -2069,7 +2070,7 @@ static void config_node_identity_get(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_node_identity_get(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_node_identity_get(cmd->net_idx, cmd->address,
 					    cmd->net_key_idx, &status,
 					    &identity);
 
@@ -2098,7 +2099,7 @@ static void config_node_reset(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_node_reset(cmd->net_idx, cmd->address, &status);
+	err = bt_mesh_cfg_cli_node_reset(cmd->net_idx, cmd->address, &status);
 
 	if (err) {
 		LOG_ERR("err %d", err);
@@ -2121,7 +2122,7 @@ static void config_lpn_timeout_get(uint8_t *data, uint16_t len)
 
 	LOG_DBG("");
 
-	err = bt_mesh_cfg_lpn_timeout_get(cmd->net_idx, cmd->address,
+	err = bt_mesh_cfg_cli_lpn_timeout_get(cmd->net_idx, cmd->address,
 					  cmd->unicast_addr, &polltimeout);
 
 	if (err) {


### PR DESCRIPTION
This PR adds a `*_cli_*` infix to the Config Client API to match
the changes in Health Client. The old API is marked as deprecated.

Signed-off-by: Michal Narajowski <michal.narajowski@codecoup.pl>