### PR TITLE
boards: nucleo_wb55rg: Take default OB value for partition definition

### DIFF
--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -205,10 +205,9 @@ zephyr_udc0: &usb {
 		#size-cells = <1>;
 
 		/*
-		 * Configure partitions while leaving space for M0 BLE f/w
-		 * Since STM32WBCube release V1.13.2, only _HCIOnly_ f/w are supported.
-		 * These FW are expected to be located not before 0x080DB000
-		 * Current partition is using the first 876K of the flash for M4
+		 * Configure partitions while leaving space for M0 BLE f/w.
+		 * Partition for M0 BLE f/w is defined by SFSA option bytes
+		 * which board production value is 0x080cf000.
 		 */
 
 		boot_partition: partition@0 {
@@ -217,19 +216,19 @@ zephyr_udc0: &usb {
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000c000 DT_SIZE_K(400)>;
+			reg = <0x0000c000 DT_SIZE_K(378)>;
 		};
-		slot1_partition: partition@70000 {
+		slot1_partition: partition@6a800 {
 			label = "image-1";
-			reg = <0x00070000 DT_SIZE_K(400)>;
+			reg = <0x0006a800 DT_SIZE_K(378)>;
 		};
-		scratch_partition: partition@d4000 {
+		scratch_partition: partition@c9000 {
 			label = "image-scratch";
-			reg = <0x000d4000 DT_SIZE_K(16)>;
+			reg = <0x000c9000 DT_SIZE_K(16)>;
 		};
-		storage_partition: partition@d8000 {
+		storage_partition: partition@cd000 {
 			label = "storage";
-			reg = <0x000d8000 DT_SIZE_K(8)>;
+			reg = <0x000cd000 DT_SIZE_K(8)>;
 		};
 
 	};


### PR DESCRIPTION
Default flash partitioning uses Option Bytes SFSA value to define
partition allocated to application vs protected area for BLE f/w.

Even if the address defined in production for SFSA does allow to optimize
fully the fact that Zephyr uses a HCI only BLE f/w, we should take it into
account in order to ensure out of the box compatibility.

Validated with the following command:
```
west -v build -p always -b nucleo_wb55rg --sysbuild samples/hello_world -- -DSB_CONFIG_BOOTLOADER_MCUBOOT=y -DCONFIG_MCUBOOT_SIGNATURE_KEY_FILE=\"bootloader/mcuboot/root-rsa-2048.pem\"
```

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>