### PR TITLE
samples: sof: Uses CONFIG_SCHED_CPU_MASK_PIN_ONLY

### DIFF
--- a/samples/modules/sof/prj.conf
+++ b/samples/modules/sof/prj.conf
@@ -23,3 +23,7 @@ CONFIG_SMP_BOOT_DELAY=y
 CONFIG_SYS_CLOCK_TICKS_PER_SEC=15000
 CONFIG_DAI=y
 CONFIG_HEAP_MEM_POOL_SIZE=2048
+
+# SoF pins threads to specific cores. This option allows
+# Zephyr to do further cache optimizations
+CONFIG_SCHED_CPU_MASK_PIN_ONLY=y


### PR DESCRIPTION
SoF pins threads to specific cores and don't need them to be executed in
multiple cores. This options allows Zephyr to do cache optimizations
during context switches.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>