### PR TITLE
boards: gd32e507v_start: add pyOCD support

### DIFF
--- a/boards/arm/gd32e507v_start/board.cmake
+++ b/boards/arm/gd32e507v_start/board.cmake
@@ -1,6 +1,8 @@
 # Copyright (c) 2022, Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(pyocd "--target=gd32e507ve")
 board_runner_args(jlink "--device=GD32E507VE" "--speed=4000")
 
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/gd32e507v_start/doc/index.rst
+++ b/boards/arm/gd32e507v_start/doc/index.rst
@@ -81,12 +81,18 @@ follows:
 
 - JP3/4: Select 2-3 for both (boot from user memory)
 
-Using J-Link
-=============
+Using GD-Link or J-Link
+=======================
 
-While the board comes with an embedded GD-Link programmer, it is not yet
-supported by OpenOCD. However, J-Link can be used to program the board using
-the SWD interface exposed in the JP1 header.
+The board comes with an embedded GD-Link programmer. It can be used with pyOCD
+provided you install the necessary CMSIS-Pack:
+
+.. code-block:: console
+
+   pyocd pack install gd32e507ve
+
+J-Link can also be used to program the board using the SWD interface exposed in
+the JP1 header.
 
 #. Build the Zephyr kernel and the :ref:`hello_world` sample application:
 


### PR DESCRIPTION
The board can be programmed via the built-in GD-Link using pyOCD
(provided GigaDevice.GD32E50x_DFP CMSIS-Pack is installed. Update
instructions and set default runner to pyOCD since it does not require
any external tool like with J-Link.

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>