### PR TITLE
boards: nucleo_g474re revert pyocd workaround

### DIFF
--- a/boards/arm/nucleo_g474re/board.cmake
+++ b/boards/arm/nucleo_g474re/board.cmake
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# use target=stm32g474rbtx instead of stm32g474retx
-# to allow board re-flashing (see PR #23230)
-board_runner_args(pyocd "--target=stm32g474rbtx")
+board_runner_args(pyocd "--target=stm32g474retx")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
The workaround is no longer necessary.

In the past pyocd couldn't flash the nucleo_g474re board with the target
`stm32g474retx` (issue #23351).
Therefore PR #23230 introduced a workaround changing the target
to `stm32g474rbtx`.
In the meantime this issue has been resolved, therefore the
workaround can be reverted.
