### PR TITLE
ztress: fix the progress stats

### DIFF
--- a/subsys/testsuite/ztest/src/ztress.c
+++ b/subsys/testsuite/ztest/src/ztress.c
@@ -83,15 +83,16 @@ static void progress_timeout(struct k_timer *timer)
 	struct ztress_context_data *thread_data = k_timer_user_data_get(timer);
 	uint32_t progress = 100;
 	uint32_t cnt = context_cnt;
+	uint32_t thread_data_start_index = 0;
 
 	if (tmr_data != NULL) {
-		cnt--;
-		if (tmr_data->exec_cnt != 0 && exec_cnt[cnt] != 0) {
-			progress = (100 * exec_cnt[cnt]) / tmr_data->exec_cnt;
+		thread_data_start_index = 1;
+		if (tmr_data->exec_cnt != 0 && exec_cnt[0] != 0) {
+			progress = (100 * exec_cnt[0]) / tmr_data->exec_cnt;
 		}
 	}
 
-	for (uint32_t i = 0; i < cnt; i++) {
+	for (uint32_t i = thread_data_start_index; i < cnt; i++) {
 		if (thread_data[i].exec_cnt == 0 && thread_data[i].preempt_cnt == 0) {
 			continue;
 		}


### PR DESCRIPTION
Current ztress design supports both timer context and thread
context. The timer context always uses the first element of
several global array variables like exec_cnt[] and backoff[].
But progress_timeout() is using the last element of exec_cnt[]
to calculate the progress of timer context. It is not right.

Signed-off-by: Ming Shao <ming.shao@intel.com>