### PR TITLE
cmake: fix use of unsupported -fno-pie with xcc

### DIFF
--- a/cmake/compiler/xcc/compiler_flags.cmake
+++ b/cmake/compiler/xcc/compiler_flags.cmake
@@ -9,3 +9,6 @@ include(${ZEPHYR_BASE}/cmake/compiler/gcc/compiler_flags.cmake)
 check_set_compiler_property(APPEND PROPERTY warning_base "-fgnu89-inline")
 
 set_compiler_property(PROPERTY warning_error_misra_sane)
+
+# XCC does not support -fno-pic and -fno-pie
+set_compiler_property(PROPERTY no_position_independent "")


### PR DESCRIPTION
The commit 8259931fce1b ('xcc-clang: Do not used unavailable options')
has a side-effect that builds with xcc default to use -fno-pie. This
is not a supported compiler option for xcc, resulting in failing builds.

Use same configuration for xcc as is in place for xcc-clang, and
do not use -fno-pie.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>