### PR TITLE
samples: Rename 'samples' to 'sample'

### DIFF
--- a/samples/drivers/w1/scanner/sample.yaml
+++ b/samples/drivers/w1/scanner/sample.yaml
@@ -5,7 +5,7 @@ common:
     harness: console
 
 tests:
-  samples.drivers.w1.scanner.ds2484:
+  sample.drivers.w1.scanner.ds2484:
     depends_on: arduino_i2c
     extra_args: DTC_OVERLAY_FILE=ds2484.overlay
     platform_allow: nrf52840dk_nrf52840
@@ -14,7 +14,7 @@ tests:
       regex:
         - "Number of devices found on bus: .*"
       fixture: w1_scanner_ds2484
-  samples.drivers.w1.scanner.w1_serial:
+  sample.drivers.w1.scanner.w1_serial:
     depends_on: arduino_serial
     extra_args: DTC_OVERLAY_FILE=w1_serial.overlay
     platform_allow: nrf52840dk_nrf52840


### PR DESCRIPTION
Samples testcases should start with 'sample'. Some testcases
start with 'samples'.
This commit rename these testcases.

Signed-off-by: Katarzyna Giadla <katarzyna.giadla@nordicsemi.no>