### PR TITLE
tests: exception: riscv: run illegal instruction from text section

### DIFF
--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -79,9 +79,12 @@ void entry_cpu_exception(void *p1, void *p2, void *p3)
 	__asm__ volatile ("trap");
 #elif defined(CONFIG_ARC)
 	__asm__ volatile ("swi");
+#elif defined(CONFIG_RISCV)
+	/* Illegal instruction on RISCV. */
+	__asm__ volatile (".word 0x77777777");
 #else
-	/* Triggers usage fault on ARM, illegal instruction on RISCV
-	 * and xtensa, TLB exception (instruction fetch) on MIPS.
+	/* Triggers usage fault on ARM, illegal instruction on
+	 * xtensa, TLB exception (instruction fetch) on MIPS.
 	 */
 	{
 		volatile long illegal = 0;


### PR DESCRIPTION
On the original implementation in entry_cpu_exception function,
an illegal instruction will be executed from RAM section to trigger
an exception.
Test result will fail on the SOC (eg. it81302) which executes code
in flash (text section).
This patch changes the test code to run illegal instruction from text
section.

fixes: #49462

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>