### PR TITLE
samples: Add name "sample" in the some samples modules

### DIFF
--- a/samples/subsys/debug/fuzz/sample.yaml
+++ b/samples/subsys/debug/fuzz/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: native_posix-based libfuzzer example
   name: fuzz
 tests:
-  debug.fuzz:
+  sample.debug.fuzz:
     toolchain_allow: llvm
     platform_allow: native_posix_64
     harness: console

--- a/samples/subsys/testsuite/integration/testcase.yaml
+++ b/samples/subsys/testsuite/integration/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   # section.subsection
-  testing.ztest:
+  sample.testing.ztest:
     build_only: true
     platform_allow: native_posix
     tags: testing

--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -7,33 +7,33 @@ common:
         - "thread_a: Hello World from (.*)!"
         - "thread_b: Hello World from (.*)!"
 tests:
-  tracing.user:
+  sample.tracing.user:
     extra_args: CONF_FILE="prj_user.conf"
-  tracing.format.sysview:
+  sample.tracing.format.sysview:
     platform_allow: nrf52840dk_nrf52840 mimxrt1050_evk mimxrt1064_evk
     extra_args: CONF_FILE="prj_sysview.conf"
-  tracing.osawareness.openocd:
+  sample.tracing.osawareness.openocd:
     arch_exclude: posix xtensa
     platform_exclude: qemu_x86_64
-  tracing.transport.uart:
+  sample.tracing.transport.uart:
     platform_allow: qemu_x86 qemu_x86_64
     extra_args: CONF_FILE="prj_uart.conf"
     filter: dt_chosen_enabled("zephyr,tracing-uart")
-  tracing.transport.usb:
+  sample.tracing.transport.usb:
     platform_allow: sam_e70_xplained
     depends_on: usb_device
     extra_args: CONF_FILE="prj_usb.conf"
-  tracing.transport.ctf:
+  sample.tracing.transport.uart.ctf:
     platform_allow: qemu_x86 qemu_x86_64
     extra_args: CONF_FILE="prj_uart_ctf.conf"
     filter: dt_chosen_enabled("zephyr,tracing-uart")
-  tracing.transport.ctf:
+  sample.tracing.transport.usb.ctf:
     platform_allow: sam_e70_xplained
     depends_on: usb_device
     extra_args: CONF_FILE="prj_usb_ctf.conf"
-  tracing.transport.native_posix:
+  sample.tracing.transport.native_posix:
     platform_allow: native_posix
     extra_args: CONF_FILE="prj_native_posix.conf"
-  tracing.transport.posix.ctf:
+  sample.tracing.transport.native_posix.ctf:
     platform_allow: native_posix
     extra_args: CONF_FILE="prj_native_posix_ctf.conf"


### PR DESCRIPTION
Some test cases in the module `samples` have not a name of this module.
This change adds the name `sample` to these test cases.

Signed-off-by: Katarzyna Giadla <katarzyna.giadla@nordicsemi.no>