### PR TITLE
Ospi with DMA transfer for stm32U5 devices

### DIFF
--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -230,8 +230,12 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 	__ASSERT_NO_MSG(id < config->max_streams);
 
 	stream = &config->streams[id];
-	/* Exit if stream is no more busy */
-	if (stream->busy == false) {
+	/* The busy channel is pertinent if not overridden by the HAL */
+	if ((stream->hal_override != true) && (stream->busy == false)) {
+		/*
+		 * When DMA channel is not overridden by HAL,
+		 * ignore irq if the channel is not busy anymore
+		 */
 		dma_stm32_clear_stream_irq(dev, id);
 		return;
 	}
@@ -246,9 +250,6 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 		}
 		stream->dma_callback(dev, stream->user_data, callback_arg, 0);
 	} else if (stm32_dma_is_tc_irq_active(dma, id)) {
-#ifdef CONFIG_DMAMUX_STM32
-		stream->busy = false;
-#endif
 		/* Let HAL DMA handle flags on its own */
 		if (!stream->hal_override) {
 			dma_stm32_clear_tc(dma, id);
@@ -540,6 +541,9 @@ static int dma_stm32_reload(const struct device *dev, uint32_t id,
 				     size / stream->dst_size);
 	}
 
+	/* When reloading the dma, the stream is busy again before enabling */
+	stream->busy = true;
+
 	stm32_dma_enable_stream(dma, id);
 
 	return 0;
@@ -549,6 +553,7 @@ static int dma_stm32_start(const struct device *dev, uint32_t id)
 {
 	const struct dma_stm32_config *config = dev->config;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
+	struct dma_stm32_stream *stream;
 
 	/* Give channel from index 0 */
 	id = id - STM32_DMA_STREAM_OFFSET;
@@ -557,6 +562,10 @@ static int dma_stm32_start(const struct device *dev, uint32_t id)
 	if (id >= config->max_streams) {
 		return -EINVAL;
 	}
+
+	/* When starting the dma, the stream is busy before enabling */
+	stream = &config->streams[id];
+	stream->busy = true;
 
 	dma_stm32_clear_stream_irq(dev, id);
 
@@ -578,10 +587,10 @@ static int dma_stm32_stop(const struct device *dev, uint32_t id)
 		return -EINVAL;
 	}
 
+	LL_DMA_DisableIT_TC(dma, dma_stm32_id_to_stream(id));
+
 	dma_stm32_clear_stream_irq(dev, id);
 	dma_stm32_disable_stream(dma, id);
-
-	LL_DMA_DisableIT_TC(dma, dma_stm32_id_to_stream(id));
 
 	/* Finally, flag stream as free */
 	stream->busy = false;
@@ -715,16 +724,9 @@ static void dma_stm32_config_irq_0(const struct device *dev)
 	DMA_STM32_IRQ_CONNECT(0, 2);
 	DMA_STM32_IRQ_CONNECT(0, 3);
 	DMA_STM32_IRQ_CONNECT(0, 4);
-#if DT_INST_IRQ_HAS_IDX(0, 5)
 	DMA_STM32_IRQ_CONNECT(0, 5);
-#if DT_INST_IRQ_HAS_IDX(0, 6)
 	DMA_STM32_IRQ_CONNECT(0, 6);
-#if DT_INST_IRQ_HAS_IDX(0, 7)
 	DMA_STM32_IRQ_CONNECT(0, 7);
-#endif /* DT_INST_IRQ_HAS_IDX(0, 5) */
-#endif /* DT_INST_IRQ_HAS_IDX(0, 6) */
-#endif /* DT_INST_IRQ_HAS_IDX(0, 7) */
-/* Either 5 or 6 or 7 or 8 channels for DMA across all stm32 series. */
 	DMA_STM32_IRQ_CONNECT(0, 8);
 	DMA_STM32_IRQ_CONNECT(0, 9);
 	DMA_STM32_IRQ_CONNECT(0, 10);

--- a/drivers/flash/Kconfig.stm32_ospi
+++ b/drivers/flash/Kconfig.stm32_ospi
@@ -20,5 +20,8 @@ config FLASH_STM32_OSPI
 	select DMA if $(DT_STM32_OCTOSPI_1_HAS_DMA) || $(DT_STM32_OCTOSPI_2_HAS_DMA)
 	select USE_STM32_HAL_DMA if $(DT_STM32_OCTOSPI_1_HAS_DMA) || \
 					$(DT_STM32_OCTOSPI_2_HAS_DMA)
+	select USE_STM32_HAL_DMA_EX if SOC_SERIES_STM32U5X && \
+					($(DT_STM32_OCTOSPI_1_HAS_DMA) || \
+					 $(DT_STM32_OCTOSPI_2_HAS_DMA))
 	help
 	  Enable OSPI-NOR support on the STM32 family of processors.

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -30,6 +30,7 @@ LOG_MODULE_REGISTER(flash_stm32_ospi, CONFIG_FLASH_LOG_LEVEL);
 #define STM32_OSPI_RESET_GPIO DT_INST_NODE_HAS_PROP(0, reset_gpios)
 
 #define STM32_OSPI_USE_DMA DT_NODE_HAS_PROP(DT_PARENT(DT_DRV_INST(0)), dmas)
+
 #if STM32_OSPI_USE_DMA
 #include <zephyr/drivers/dma/dma_stm32.h>
 #include <zephyr/drivers/dma.h>
@@ -50,6 +51,27 @@ LOG_MODULE_REGISTER(flash_stm32_ospi, CONFIG_FLASH_LOG_LEVEL);
 #define SPI_NOR_WRITEOC_NONE 0xFF
 
 #if STM32_OSPI_USE_DMA
+#if CONFIG_DMA_STM32U5
+static const uint32_t table_src_size[] = {
+	LL_DMA_SRC_DATAWIDTH_BYTE,
+	LL_DMA_SRC_DATAWIDTH_HALFWORD,
+	LL_DMA_SRC_DATAWIDTH_WORD,
+};
+
+static const uint32_t table_dest_size[] = {
+	LL_DMA_DEST_DATAWIDTH_BYTE,
+	LL_DMA_DEST_DATAWIDTH_HALFWORD,
+	LL_DMA_DEST_DATAWIDTH_WORD,
+};
+
+/* Lookup table to set dma priority from the DTS */
+static const uint32_t table_priority[] = {
+	LL_DMA_LOW_PRIORITY_LOW_WEIGHT,
+	LL_DMA_LOW_PRIORITY_MID_WEIGHT,
+	LL_DMA_LOW_PRIORITY_HIGH_WEIGHT,
+	LL_DMA_HIGH_PRIORITY,
+};
+#else
 static const uint32_t table_m_size[] = {
 	LL_DMA_MDATAALIGN_BYTE,
 	LL_DMA_MDATAALIGN_HALFWORD,
@@ -69,6 +91,7 @@ static const uint32_t table_priority[] = {
 	DMA_PRIORITY_HIGH,
 	DMA_PRIORITY_VERY_HIGH,
 };
+#endif /* CONFIG_DMA_STM32U5 */
 
 struct stream {
 	DMA_TypeDef *reg;
@@ -119,7 +142,7 @@ struct flash_stm32_ospi_data {
 	int cmd_status;
 #if STM32_OSPI_USE_DMA
 	struct stream dma;
-#endif
+#endif /* STM32_OSPI_USE_DMA */
 };
 
 static inline void ospi_lock_thread(const struct device *dev)
@@ -220,7 +243,7 @@ static int ospi_write_access(const struct device *dev, OSPI_RegularCmdTypeDef *c
 #endif
 
 	if (hal_ret != HAL_OK) {
-		LOG_ERR("%d: Failed to read data", hal_ret);
+		LOG_ERR("%d: Failed to write data", hal_ret);
 		return -EIO;
 	}
 
@@ -1046,18 +1069,19 @@ static int flash_stm32_ospi_write(const struct device *dev, off_t addr,
 	LOG_DBG("OSPI: write %zu data", size);
 	ospi_lock_thread(dev);
 
+	ret = stm32_ospi_mem_ready(&dev_data->hospi,
+				   dev_cfg->data_mode, dev_cfg->data_rate);
+	if (ret != 0) {
+		LOG_ERR("OSPI: write not ready");
+		return -EIO;
+	}
+
 	while ((size > 0) && (ret == 0)) {
 		to_write = size;
-
-		ret = stm32_ospi_mem_ready(&dev_data->hospi,
-						 dev_cfg->data_mode, dev_cfg->data_rate);
-		if (ret != 0) {
-			break;
-		}
-
 		ret = stm32_ospi_write_enable(&dev_data->hospi,
 						    dev_cfg->data_mode, dev_cfg->data_rate);
 		if (ret != 0) {
+			LOG_ERR("OSPI: write not enabled");
 			break;
 		}
 		/* Don't write more than a page. */
@@ -1075,6 +1099,7 @@ static int flash_stm32_ospi_write(const struct device *dev, off_t addr,
 
 		ret = ospi_write_access(dev, &cmd_pp, data, to_write);
 		if (ret != 0) {
+			LOG_ERR("OSPI: write not access");
 			break;
 		}
 
@@ -1086,6 +1111,7 @@ static int flash_stm32_ospi_write(const struct device *dev, off_t addr,
 		ret = stm32_ospi_mem_ready(&dev_data->hospi,
 						 dev_cfg->data_mode, dev_cfg->data_rate);
 		if (ret != 0) {
+			LOG_ERR("OSPI: write PP not ready");
 			break;
 		}
 	}
@@ -1678,8 +1704,11 @@ static int flash_stm32_ospi_init(const struct device *dev)
 	/* HACK: This field is used to inform driver that it is overridden */
 	dma_cfg.linked_channel = STM32_DMA_HAL_OVERRIDE;
 	/* Because of the STREAM OFFSET, the DMA channel given here is from 1 - 8 */
-	ret = dma_config(dev_data->dma.dev, dev_data->dma.channel + 1, &dma_cfg);
+	ret = dma_config(dev_data->dma.dev,
+			 (dev_data->dma.channel + STM32_DMA_STREAM_OFFSET), &dma_cfg);
 	if (ret != 0) {
+		LOG_ERR("Failed to configure DMA channel %d",
+			dev_data->dma.channel + STM32_DMA_STREAM_OFFSET);
 		return ret;
 	}
 
@@ -1691,29 +1720,55 @@ static int flash_stm32_ospi_init(const struct device *dev)
 
 	int index = find_lsb_set(dma_cfg.source_data_size) - 1;
 
+#if CONFIG_DMA_STM32U5
+	/* Fill the structure for dma init */
+	hdma.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+	hdma.Init.SrcInc = DMA_SINC_FIXED;
+	hdma.Init.DestInc = DMA_DINC_INCREMENTED;
+	hdma.Init.SrcDataWidth = table_src_size[index];
+	hdma.Init.DestDataWidth = table_dest_size[index];
+	hdma.Init.SrcBurstLength = 4;
+	hdma.Init.DestBurstLength = 4;
+	hdma.Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT1;
+	hdma.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+#else
 	hdma.Init.PeriphDataAlignment = table_p_size[index];
 	hdma.Init.MemDataAlignment = table_m_size[index];
 	hdma.Init.PeriphInc = DMA_PINC_DISABLE;
 	hdma.Init.MemInc = DMA_MINC_ENABLE;
+#endif /* CONFIG_DMA_STM32U5 */
 	hdma.Init.Mode = DMA_NORMAL;
 	hdma.Init.Priority = table_priority[dma_cfg.channel_priority];
 	hdma.Init.Direction = DMA_PERIPH_TO_MEMORY;
+#ifdef CONFIG_DMA_STM32_V1
+	/* TODO: Not tested in this configuration */
+	hdma.Init.Channel = dma_cfg.dma_slot;
+	hdma.Instance = __LL_DMA_GET_STREAM_INSTANCE(dev_data->dma.reg,
+						     dev_data->dma.channel);
+#else
 	hdma.Init.Request = dma_cfg.dma_slot;
-#ifdef CONFIG_DMAMUX_STM32
+#if CONFIG_DMA_STM32U5
+	hdma.Instance = LL_DMA_GET_CHANNEL_INSTANCE(dev_data->dma.reg,
+						      dev_data->dma.channel);
+#elif defined(CONFIG_DMAMUX_STM32)
 	/*
 	 * HAL expects a valid DMA channel (not DMAMUX).
-	 * The channel is from 0 to 7 because of the STREAM_OFFSET in the dma_stm32 driver
+	 * The channel is from 0 to 7 because of the STM32_DMA_STREAM_OFFSET in the dma_stm32 driver
 	 */
 	hdma.Instance = __LL_DMA_GET_CHANNEL_INSTANCE(dev_data->dma.reg,
 						      dev_data->dma.channel);
 #else
 	hdma.Instance = __LL_DMA_GET_CHANNEL_INSTANCE(dev_data->dma.reg,
 						      dev_data->dma.channel-1);
-#endif /* CONFIG_DMAMUX_STM32 */
+#endif /* CONFIG_DMA_STM32U5 */
+#endif /* CONFIG_DMA_STM32_V1 */
 
 	/* Initialize DMA HAL */
 	__HAL_LINKDMA(&dev_data->hospi, hdma, hdma);
-	HAL_DMA_Init(&hdma);
+	if (HAL_DMA_Init(&hdma) != HAL_OK) {
+		LOG_ERR("OSPI DMA Init failed");
+		return -EIO;
+	}
 	LOG_INF("OSPI with DMA transfer");
 
 #endif /* STM32_OSPI_USE_DMA */

--- a/samples/drivers/spi_flash/boards/b_u585i_iot02a.overlay
+++ b/samples/drivers/spi_flash/boards/b_u585i_iot02a.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&octospi2 {
+            /* channel 12-15 are for transfers to/from external memories */
+            dmas = <&gpdma1 12 41 0x10480>; /* request 41 for OCTOSPI2 */
+            dma-names = "tx_rx";
+};


### PR DESCRIPTION
This PR enables the octoSPI NOR flash that is present on the  stm32u585 disco kit

The octospi peripheral are defined by the DTS of the devices.
The boards enable the mx25lm51245 NOR octo-flash controller.
The file overlay is enabling the GPDMA (channel12) for OSPI transfer (This corresponds to the request 41)

It requires https://github.com/zephyrproject-rtos/zephyr/pull/45151

Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)