### PR TITLE
scripts: west_commands: runners: linux: stm32cubeprogrammer: enable exec from PATH

### DIFF
--- a/scripts/west_commands/runners/stm32cubeprogrammer.py
+++ b/scripts/west_commands/runners/stm32cubeprogrammer.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import platform
 import os
 import shlex
+import shutil
 from typing import List, Optional, ClassVar, Dict
 
 from runners.core import ZephyrBinaryRunner, RunnerCaps, RunnerConfig
@@ -63,6 +64,10 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
         """Obtain path of the STM32CubeProgrammer CLI tool."""
 
         if platform.system() == "Linux":
+            cmd = shutil.which("STM32_Programmer_CLI")
+            if cmd is not None:
+                return Path(cmd)
+
             return (
                 Path.home()
                 / "STMicroelectronics"


### PR DESCRIPTION
Allows to use the stm32cubeprogrammer runner on Linux to be executed
from any installation directory as long as the executable is found
in PATH.

Until now on Linux the programmer could only be used if it either has
been installed in the default location or if the executable path was
passed via the cli parameter.