### PR TITLE
dts: arm: st: g4: STM32G491xC and STM32G491xE fix flash size

### DIFF
--- a/dts/arm/st/g4/stm32g431X6.dtsi
+++ b/dts/arm/st/g4/stm32g431X6.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g431.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(32)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(32)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(32)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(32)>;
 };

--- a/dts/arm/st/g4/stm32g431X8.dtsi
+++ b/dts/arm/st/g4/stm32g431X8.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g431.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(32)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(32)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(64)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/st/g4/stm32g431Xb.dtsi
+++ b/dts/arm/st/g4/stm32g431Xb.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g431.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(32)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(32)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(128)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/st/g4/stm32g441Xb.dtsi
+++ b/dts/arm/st/g4/stm32g441Xb.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g441.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(32)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(32)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(128)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/st/g4/stm32g473Xb.dtsi
+++ b/dts/arm/st/g4/stm32g473Xb.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g473.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(128)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(128)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(128)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/st/g4/stm32g473Xc.dtsi
+++ b/dts/arm/st/g4/stm32g473Xc.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g473.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(128)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(128)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(256)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/st/g4/stm32g473Xe.dtsi
+++ b/dts/arm/st/g4/stm32g473Xe.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g473.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(128)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(128)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(512)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/st/g4/stm32g474Xb.dtsi
+++ b/dts/arm/st/g4/stm32g474Xb.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g474.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(128)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(128)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(128)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(128)>;
 };

--- a/dts/arm/st/g4/stm32g474Xc.dtsi
+++ b/dts/arm/st/g4/stm32g474Xc.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g474.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(128)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(128)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(256)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/st/g4/stm32g474Xe.dtsi
+++ b/dts/arm/st/g4/stm32g474Xe.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g474.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(128)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(128)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(512)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/st/g4/stm32g483Xe.dtsi
+++ b/dts/arm/st/g4/stm32g483Xe.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g483.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(128)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(128)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(512)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/st/g4/stm32g484Xe.dtsi
+++ b/dts/arm/st/g4/stm32g484Xe.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g484.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(128)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(128)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(512)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/st/g4/stm32g491Xc.dtsi
+++ b/dts/arm/st/g4/stm32g491Xc.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g491.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(112)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(112)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(256)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/st/g4/stm32g491Xc.dtsi
+++ b/dts/arm/st/g4/stm32g491Xc.dtsi
@@ -15,7 +15,7 @@
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(512)>;
+				reg = <0x08000000 DT_SIZE_K(256)>;
 			};
 		};
 	};

--- a/dts/arm/st/g4/stm32g491Xe.dtsi
+++ b/dts/arm/st/g4/stm32g491Xe.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g491.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(112)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(112)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(512)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(512)>;
 };

--- a/dts/arm/st/g4/stm32g491Xe.dtsi
+++ b/dts/arm/st/g4/stm32g491Xe.dtsi
@@ -15,7 +15,7 @@
 	soc {
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(256)>;
+				reg = <0x08000000 DT_SIZE_K(512)>;
 			};
 		};
 	};

--- a/dts/arm/st/g4/stm32g4a1Xe.dtsi
+++ b/dts/arm/st/g4/stm32g4a1Xe.dtsi
@@ -7,16 +7,10 @@
 #include <mem.h>
 #include <st/g4/stm32g4a1.dtsi>
 
-/ {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(112)>;
-	};
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(112)>;
+};
 
-	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				reg = <0x08000000 DT_SIZE_K(512)>;
-			};
-		};
-	};
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(512)>;
 };


### PR DESCRIPTION
Fix the flash size of the two stm32g491 target.
Additionally simplify the assignment of the FLASH/RAM size for this series.