### PR TITLE
samples: net: gsm_modem: check for node existence

### DIFF
--- a/samples/net/gsm_modem/src/main.c
+++ b/samples/net/gsm_modem/src/main.c
@@ -18,6 +18,9 @@
 LOG_MODULE_REGISTER(sample_gsm_ppp, LOG_LEVEL_DBG);
 
 #define GSM_MODEM_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_gsm_ppp)
+#if GSM_MODEM_NODE == DT_INVALID_NODE
+#error "No Zephyr gsm ppp node defined"
+#endif
 #define UART_NODE DT_BUS(GSM_MODEM_NODE)
 
 static const struct device *const gsm_dev = DEVICE_DT_GET(GSM_MODEM_NODE);


### PR DESCRIPTION
Compiling the gsm_modem sample fails when building for various boards using instructions from the README:
eg.
```
west build -p always -b reel_board samples/net/gsm_modem -- -DCONFIG_MODEM_GSM_APN=\"internet\"
```
This addition does not solve it, but at least provides a more descriptive preprocessor error.

Signed-off-by: Toon Stegen <toon@toostsolutions.be>