### PR TITLE
Bluetooth: ISO: Remove TS size from SDU len check

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -2047,11 +2047,6 @@ int bt_audio_stream_release(struct bt_audio_stream *stream, bool cache);
  *
  *  @param stream   Stream object.
  *  @param buf      Buffer containing data to be sent.
- *                  The maximum size is the SDU that was
- *                  configured, minus the header size. The header size is either
- *                  @ref BT_HCI_ISO_DATA_HDR_SIZE or
- *                  @ref BT_HCI_ISO_TS_DATA_HDR_SIZE depending on @p ts
- *                  (the latter is used if @p ts is not BT_ISO_TIMESTAMP_NONE).
  *  @param seq_num  Packet Sequence number. This value shall be incremented for
  *                  each call to this function and at least once per SDU
  *                  interval for a specific channel.

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -665,11 +665,6 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan);
  *
  *  @param chan     Channel object.
  *  @param buf      Buffer containing data to be sent.
- *                  The maximum size is the @ref bt_iso_chan_io_qos.sdu that was
- *                  configured, minus the header size. The header size is either
- *                  @ref BT_HCI_ISO_DATA_HDR_SIZE or
- *                  @ref BT_HCI_ISO_TS_DATA_HDR_SIZE depending on @p ts
- *                  (the latter is used if @p ts is not BT_ISO_TIMESTAMP_NONE).
  *  @param seq_num  Packet Sequence number. This value shall be incremented for
  *                  each call to this function and at least once per SDU
  *                  interval for a specific channel.

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -735,24 +735,6 @@ static uint16_t iso_chan_max_data_len(const struct bt_iso_chan *chan,
 	/* Update the max_data_len to take the max_controller_data_len into account */
 	max_data_len = MIN(max_data_len, max_controller_data_len);
 
-	/* Since this returns the maximum ISO data length size, we have to take
-	 * the header size into account, as that also needs to be inserted into
-	 * the SDU
-	 */
-	if (ts == BT_ISO_TIMESTAMP_NONE) {
-		if (max_data_len > BT_HCI_ISO_DATA_HDR_SIZE) {
-			max_data_len -= BT_HCI_ISO_DATA_HDR_SIZE;
-		} else {
-			max_data_len = 0U;
-		}
-	} else {
-		if (max_data_len > BT_HCI_ISO_TS_DATA_HDR_SIZE) {
-			max_data_len -= BT_HCI_ISO_TS_DATA_HDR_SIZE;
-		} else {
-			max_data_len = 0U;
-		}
-	}
-
 	return max_data_len;
 }
 


### PR DESCRIPTION
The timestamp is not part of the SDU, and should
thus not be used to get the maximum SDU size.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/49629