### PR TITLE
Allow failed zassume calls to fail the test binary at the end

### DIFF
--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -149,6 +149,15 @@ config ZTEST_VERBOSE_SUMMARY
 	  This option controls whether suite summary is shown verbosely or
 	  just in one line.
 
+config ZTEST_FAIL_ON_ASSUME
+	bool "Fail the test run when an assumption fails"
+	default y
+	help
+	  When enabled, the test binary will fail at the end if an assumption failed. This means
+	  that while tests will still be marked as skipped on failed zassume calls, the final test
+	  result will be shown as a failure in order to increase visibility. This precludes tests
+	  that skipped with the ZTEST_EXPECT_SKIP annotation.
+
 endif # ZTEST_NEW_API
 
 config TEST_LOGGING_FLUSH_AFTER_TEST

--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -27,6 +27,7 @@ extern "C" {
 const char *ztest_relative_filename(const char *file);
 void ztest_test_fail(void);
 void ztest_test_skip(void);
+void ztest_skip_failed_assumption(void);
 #if CONFIG_ZTEST_ASSERT_VERBOSE == 0
 
 static inline bool z_zassert_(bool cond, const char *file, int line)
@@ -46,7 +47,7 @@ static inline bool z_zassume_(bool cond, const char *file, int line)
 {
 	if (cond == false) {
 		PRINT("\n    Assumption failed at %s:%d\n", ztest_relative_filename(file), line);
-		ztest_test_skip();
+		ztest_skip_failed_assumption();
 		return false;
 	}
 
@@ -93,7 +94,7 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
 		vprintk(msg, vargs);
 		printk("\n");
 		va_end(vargs);
-		ztest_test_skip();
+		ztest_skip_failed_assumption();
 		return false;
 	}
 #if CONFIG_ZTEST_ASSERT_VERBOSE == 2

--- a/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
@@ -331,6 +331,9 @@ void ztest_test_pass(void);
  */
 void ztest_test_skip(void);
 
+
+void ztest_skip_failed_assumption(void);
+
 #define Z_TEST(suite, fn, t_options, use_fixture)                                                  \
 	struct ztest_unit_test_stats z_ztest_unit_test_stats_##suite##_##fn;                       \
 	static void _##suite##_##fn##_wrapper(void *data);                                         \

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -334,7 +334,7 @@ void ztest_test_fail(void)
 	case TEST_PHASE_AFTER:
 	case TEST_PHASE_TEARDOWN:
 	case TEST_PHASE_FRAMEWORK:
-		PRINT(" ERROR: cannot fail in test '%s()', bailing\n",
+		PRINT(" ERROR: cannot fail in test phase '%s()', bailing\n",
 		      get_friendly_phase_name(phase));
 		longjmp(stack_fail, 1);
 	}
@@ -345,7 +345,8 @@ void ztest_test_pass(void)
 	if (phase == TEST_PHASE_TEST) {
 		longjmp(test_pass, 1);
 	}
-	PRINT(" ERROR: cannot pass in test '%s()', bailing\n", get_friendly_phase_name(phase));
+	PRINT(" ERROR: cannot pass in test phase '%s()', bailing\n",
+	      get_friendly_phase_name(phase));
 	longjmp(stack_fail, 1);
 }
 
@@ -357,7 +358,7 @@ void ztest_test_skip(void)
 	case TEST_PHASE_TEST:
 		longjmp(test_skip, 1);
 	default:
-		PRINT(" ERROR: cannot skip in test '%s()', bailing\n",
+		PRINT(" ERROR: cannot skip in test phase '%s()', bailing\n",
 		      get_friendly_phase_name(phase));
 		longjmp(stack_fail, 1);
 	}
@@ -448,7 +449,7 @@ void ztest_test_fail(void)
 		test_finalize();
 		break;
 	default:
-		PRINT(" ERROR: cannot fail in test '%s()', bailing\n",
+		PRINT(" ERROR: cannot fail in test phase '%s()', bailing\n",
 		      get_friendly_phase_name(phase));
 		test_status = ZTEST_STATUS_CRITICAL_ERROR;
 		break;
@@ -463,7 +464,7 @@ void ztest_test_pass(void)
 		test_finalize();
 		break;
 	default:
-		PRINT(" ERROR: cannot pass in test '%s()', bailing\n",
+		PRINT(" ERROR: cannot pass in test phase '%s()', bailing\n",
 		      get_friendly_phase_name(phase));
 		test_status = ZTEST_STATUS_CRITICAL_ERROR;
 		if (phase == TEST_PHASE_BEFORE) {
@@ -484,7 +485,7 @@ void ztest_test_skip(void)
 		test_finalize();
 		break;
 	default:
-		PRINT(" ERROR: cannot skip in test '%s()', bailing\n",
+		PRINT(" ERROR: cannot skip in test phase '%s()', bailing\n",
 		      get_friendly_phase_name(phase));
 		test_status = ZTEST_STATUS_CRITICAL_ERROR;
 		break;

--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -372,12 +372,14 @@ static void *fail_assume_in_setup_setup(void)
 
 ZTEST_SUITE(fail_assume_in_setup, NULL, fail_assume_in_setup_setup, NULL, NULL, NULL);
 
+ZTEST_EXPECT_SKIP(fail_assume_in_setup, test_to_skip0);
 ZTEST(fail_assume_in_setup, test_to_skip0)
 {
 	/* This test should never be run */
 	ztest_test_fail();
 }
 
+ZTEST_EXPECT_SKIP(fail_assume_in_setup, test_to_skip1);
 ZTEST(fail_assume_in_setup, test_to_skip1)
 {
 	/* This test should never be run */
@@ -392,12 +394,14 @@ static void fail_assume_in_before_before(void *unused)
 
 ZTEST_SUITE(fail_assume_in_before, NULL, NULL, fail_assume_in_before_before, NULL, NULL);
 
+ZTEST_EXPECT_SKIP(fail_assume_in_before, test_to_skip0);
 ZTEST(fail_assume_in_before, test_to_skip0)
 {
 	/* This test should never be run */
 	ztest_test_fail();
 }
 
+ZTEST_EXPECT_SKIP(fail_assume_in_before, test_to_skip1);
 ZTEST(fail_assume_in_before, test_to_skip1)
 {
 	/* This test should never be run */
@@ -406,6 +410,7 @@ ZTEST(fail_assume_in_before, test_to_skip1)
 
 ZTEST_SUITE(fail_assume_in_test, NULL, NULL, NULL, NULL, NULL);
 
+ZTEST_EXPECT_SKIP(fail_assume_in_test, test_to_skip);
 ZTEST(fail_assume_in_test, test_to_skip)
 {
 	zassume_true(false);

--- a/tests/ztest/fail/Kconfig
+++ b/tests/ztest/fail/Kconfig
@@ -29,12 +29,12 @@ endchoice
 
 config TEST_ERROR_STRING
 	string
-	default "ERROR: cannot fail in test 'after()', bailing" if ZTEST_FAIL_TEST_ASSERT_AFTER
-	default "ERROR: cannot fail in test 'teardown()', bailing" if ZTEST_FAIL_TEST_ASSERT_TEARDOWN
-	default "ERROR: cannot skip in test 'after()', bailing" if ZTEST_FAIL_TEST_ASSUME_AFTER
-	default "ERROR: cannot skip in test 'teardown()', bailing" if ZTEST_FAIL_TEST_ASSUME_TEARDOWN
-	default "ERROR: cannot pass in test 'after()', bailing" if ZTEST_FAIL_TEST_PASS_AFTER
-	default "ERROR: cannot pass in test 'teardown()', bailing" if ZTEST_FAIL_TEST_PASS_TEARDOWN
+	default "ERROR: cannot fail in test phase 'after()', bailing" if ZTEST_FAIL_TEST_ASSERT_AFTER
+	default "ERROR: cannot fail in test phase 'teardown()', bailing" if ZTEST_FAIL_TEST_ASSERT_TEARDOWN
+	default "ERROR: cannot skip in test phase 'after()', bailing" if ZTEST_FAIL_TEST_ASSUME_AFTER
+	default "ERROR: cannot skip in test phase 'teardown()', bailing" if ZTEST_FAIL_TEST_ASSUME_TEARDOWN
+	default "ERROR: cannot pass in test phase 'after()', bailing" if ZTEST_FAIL_TEST_PASS_AFTER
+	default "ERROR: cannot pass in test phase 'teardown()', bailing" if ZTEST_FAIL_TEST_PASS_TEARDOWN
 	default "Assumption failed at " if ZTEST_FAIL_TEST_UNEXPECTED_ASSUME
 
 source "Kconfig.zephyr"

--- a/tests/ztest/fail/Kconfig
+++ b/tests/ztest/fail/Kconfig
@@ -22,6 +22,9 @@ config ZTEST_FAIL_TEST_PASS_AFTER
 config ZTEST_FAIL_TEST_PASS_TEARDOWN
 	bool "Add a call to ztest_test_pass() in the teardown phase"
 
+config ZTEST_FAIL_TEST_UNEXPECTED_ASSUME
+	bool "Add a test which fails a zassume() call"
+
 endchoice
 
 config TEST_ERROR_STRING
@@ -32,5 +35,6 @@ config TEST_ERROR_STRING
 	default "ERROR: cannot skip in test 'teardown()', bailing" if ZTEST_FAIL_TEST_ASSUME_TEARDOWN
 	default "ERROR: cannot pass in test 'after()', bailing" if ZTEST_FAIL_TEST_PASS_AFTER
 	default "ERROR: cannot pass in test 'teardown()', bailing" if ZTEST_FAIL_TEST_PASS_TEARDOWN
+	default "Assumption failed at " if ZTEST_FAIL_TEST_UNEXPECTED_ASSUME
 
 source "Kconfig.zephyr"

--- a/tests/ztest/fail/core/CMakeLists.txt
+++ b/tests/ztest/fail/core/CMakeLists.txt
@@ -19,6 +19,8 @@ elseif(CONFIG_ZTEST_FAIL_TEST_PASS_AFTER)
   list(APPEND SOURCES src/pass_after.cpp)
 elseif(CONFIG_ZTEST_FAIL_TEST_PASS_TEARDOWN)
   list(APPEND SOURCES src/pass_teardown.cpp)
+elseif(CONFIG_ZTEST_FAIL_TEST_UNEXPECTED_ASSUME)
+  list(APPEND SOURCES src/unexpected_assume.cpp)
 endif()
 
 if(BOARD STREQUAL unit_testing)

--- a/tests/ztest/fail/core/src/unexpected_assume.cpp
+++ b/tests/ztest/fail/core/src/unexpected_assume.cpp
@@ -1,0 +1,16 @@
+/* Copyright (c) 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+#include "fail_test.hpp"
+
+void fail_test_after_impl(void) {}
+
+void fail_test_teardown_impl(void) {}
+
+ZTEST(fail, test_unexpected_assume)
+{
+	zassume_true(false, NULL);
+}

--- a/tests/ztest/fail/testcase.yaml
+++ b/tests/ztest/fail/testcase.yaml
@@ -50,3 +50,11 @@ tests:
     platform_allow: native_posix
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_PASS_TEARDOWN=y
+  testing.fail.unit.fail_on_bad_assumption:
+    type: unit
+    extra_configs:
+      - CONFIG_ZTEST_FAIL_TEST_UNEXPECTED_ASSUME=y
+  testing.fail.zephyr.fail_on_bad_assumption:
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_ZTEST_FAIL_TEST_UNEXPECTED_ASSUME=y


### PR DESCRIPTION
Make failing assumptions mark the test run as failed.