### PR TITLE
boards: heltec_wifi_lora32_v2: improve integration

### DIFF
--- a/boards/xtensa/heltec_wifi_lora32_v2/doc/index.rst
+++ b/boards/xtensa/heltec_wifi_lora32_v2/doc/index.rst
@@ -18,7 +18,7 @@ The features include the following:
   RF shielding, and other protection measures
 - Onboard SH1.25-2 battery interface, integrated lithium battery management system
 - Integrated WiFi, LoRa, Bluetooth three network connections, onboard Wi-Fi, Bluetooth dedicated 2.4GHz
-   metal 3D antenna, reserved IPEX (U.FL) interface for LoRa use
+  metal 3D antenna, reserved IPEX (U.FL) interface for LoRa use
 - Onboard 0.96-inch 128*64 dot matrix OLED display
 - Integrated CP2102 USB to serial port chip
 
@@ -108,11 +108,28 @@ You can debug an application in the usual way. Here is an example for the :ref:`
    :board: heltec_wifi_lora32_v2
    :goals: debug
 
+Utilizing Hardware Features
+***************************
+
+Onboard OLED display
+--------------------
+
+The onboard OLED display is of type ``ssd1306``, has 128*64 pixels and is
+connected via I2C. It can therefore be used by enabling the
+:ref:`ssd1306_128_shield` as shown in the following for the :ref:`lvgl-sample`:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/display/lvgl
+   :board: heltec_wifi_lora32_v2
+   :shield: ssd1306_128x64
+   :goals: flash
+
 References
 **********
 
+- `Heltec WiFi LoRa (v2) Pinout Diagram <https://resource.heltec.cn/download/WiFi_LoRa_32/WIFI_LoRa_32_V2.pdf>`_
+- `Heltec WiFi LoRa (v2) Schematic Diagrams <https://resource.heltec.cn/download/WiFi_LoRa_32/V2>`_
+- `ESP32 Toolchain <https://docs.espressif.com/projects/esp-idf/en/v4.2/esp32/api-guides/tools/idf-tools.html#xtensa-esp32-elf>`_
+- `esptool documentation <https://github.com/espressif/esptool/blob/master/README.md>`_
+
 .. [1] https://heltec.org/project/wifi-lora-32/
-.. _`Heltec WiFi LoRa (v2) Pinout Diagram`: https://resource.heltec.cn/download/WiFi_LoRa_32/WIFI_LoRa_32_V2.pdf
-.. _`Heltec WiFi LoRa (v2) Schematic Diagrams`: https://resource.heltec.cn/download/WiFi_LoRa_32/V2
-.. _`ESP32 Toolchain`: https://docs.espressif.com/projects/esp-idf/en/v4.2/esp32/api-guides/tools/idf-tools.html#xtensa-esp32-elf
-.. _`esptool documentation`: https://github.com/espressif/esptool/blob/master/README.md

--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
@@ -128,5 +128,5 @@
 	};
 };
 
-/* Required by OLED samples */
+/* Required by the ssd1306_128x64 shield which enables the OLED display */
 arduino_i2c: &i2c0 {};

--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
@@ -76,6 +76,10 @@
 	status = "okay";
 };
 
+&trng0 {
+	status = "okay";
+};
+
 &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;


### PR DESCRIPTION
Using Zephyr on a Heltec WiFi LoRa 32 v2 board, I stumbled across a couple of issues when trying to get the provided samples working:

* The esp32_wifi_station sample fails due to a missing entropy source. This can be worked around by setting CONFIG_TEST_RANDOM_GENERATOR but the ESP32 in fact provides a prng which is already used on other ESP32 boards. Hence, I propose to enable it on this board as well.
* Samples that use the onboard OLED display do not work out of the box as no display is defined for the board. The easiest way to use the display is to handle it like an ssd1306_128x64 shield. Hence, I added a corresponding paragraph to the board documentation.
* While working on the documentation, I fixed a formatting issue and made some invisible references visible.