### PR TITLE
modules: liblc3: add NEWLIB_LIBC as dependency

### DIFF
--- a/modules/liblc3/Kconfig
+++ b/modules/liblc3/Kconfig
@@ -4,5 +4,6 @@
 config LIBLC3
 	bool "liblc3 Support"
 	depends on FPU
+	select REQUIRES_FULL_LIBC
 	help
 	  This option enables the Android liblc3 library for Bluetooth LE Audio


### PR DESCRIPTION
Since LC3 lib requires to support floating point, we should
add c-lib NEWLIB_LIBC as dependency.

Fixes: #49602

Signed-off-by: Hang Fan <fanhang@xiaomi.com>