### PR TITLE
boards: Update pan1782_evb evaluation board slow clock config

### DIFF
--- a/boards/arm/pan1782_evb/pan1782_evb_defconfig
+++ b/boards/arm/pan1782_evb/pan1782_evb_defconfig
@@ -31,3 +31,6 @@ CONFIG_GPIO_AS_PINRESET=y
 
 # using pinctrl
 CONFIG_PINCTRL=y
+
+# using rc for slow clock
+CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y


### PR DESCRIPTION
The pan1782 module on the evaluation board will not longer be available
with external oscillator, so the internal RC must be used by default
for the slow clock.

Signed-off-by: Steffen Jahnke <steffen.jahnke@eu.panasonic.com>