### PR TITLE
drivers: clock_control: nrf: fix temperature sensor usage

### DIFF
--- a/drivers/clock_control/nrf_clock_calibration.c
+++ b/drivers/clock_control/nrf_clock_calibration.c
@@ -48,11 +48,21 @@ static void cal_lf_callback(struct onoff_manager *mgr,
 static struct onoff_client cli;
 static struct onoff_manager *mgrs;
 
+/* Temperature sensor is only needed if
+ * CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP > 0, since a value of 0
+ * indicates performing calibration periodically regardless of temperature
+ * change.
+ */
+#define USE_TEMP_SENSOR							\
+	(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP > 0)
+
+#if USE_TEMP_SENSOR
 static const struct device *const temp_sensor =
 	DEVICE_DT_GET_OR_NULL(DT_INST(0, nordic_nrf_temp));
 
 static void measure_temperature(struct k_work *work);
 static K_WORK_DEFINE(temp_measure_work, measure_temperature);
+#endif /* USE_TEMP_SENSOR */
 
 static void timeout_handler(struct k_timer *timer);
 static K_TIMER_DEFINE(backoff_timer, timeout_handler, NULL);
@@ -155,13 +165,18 @@ static void cal_hf_callback(struct onoff_manager *mgr,
 			    struct onoff_client *cli,
 			    uint32_t state, int res)
 {
-	if ((temp_sensor == NULL) || !IS_ENABLED(CONFIG_MULTITHREADING)) {
+#if USE_TEMP_SENSOR
+	if (!device_is_ready(temp_sensor)) {
 		start_hw_cal();
 	} else {
 		k_work_submit(&temp_measure_work);
 	}
+#else
+	start_hw_cal();
+#endif /* USE_TEMP_SENSOR */
 }
 
+#if USE_TEMP_SENSOR
 /* Convert sensor value to 0.25'C units. */
 static inline int16_t sensor_value_to_temp_unit(struct sensor_value *val)
 {
@@ -218,6 +233,7 @@ static void measure_temperature(struct k_work *work)
 	LOG_DBG("Calibration %s. Temperature diff: %d (in 0.25'C units).",
 			started ? "started" : "skipped", diff);
 }
+#endif /* USE_TEMP_SENSOR */
 
 void z_nrf_clock_calibration_init(struct onoff_manager *onoff_mgrs)
 {
@@ -225,20 +241,6 @@ void z_nrf_clock_calibration_init(struct onoff_manager *onoff_mgrs)
 	total_cnt = 0;
 	total_skips_cnt = 0;
 }
-
-#if CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP
-static int temp_sensor_init(const struct device *arg)
-{
-	if ((temp_sensor != NULL) && !device_is_ready(temp_sensor)) {
-		LOG_ERR("Temperature sensor not ready");
-		return -ENODEV;
-	}
-
-	return 0;
-}
-
-SYS_INIT(temp_sensor_init, APPLICATION, 0);
-#endif /* CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP */
 
 static void start_unconditional_cal_process(void)
 {


### PR DESCRIPTION
The temperature sensor was only needed when
CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP > 0. Implementation did
not reflect this dependency correctly, and sensor sampling code was
always compiled. Also removed CONFIG_MULTITHREADING checks, since this
driver is only compiled if CONFIG_MULTITHREADING=y.

Fixes #49663