### PR TITLE
Bluetooth: Mesh: Fixes issue in 'reset' command

### DIFF
--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -434,7 +434,7 @@ static int cmd_reset(const struct shell *shell, size_t argc, char *argv[])
 		int err;
 		bool reset = false;
 
-		err = bt_mesh_cfg_node_reset(net.net_idx, net.dst, &reset);
+		err = bt_mesh_cfg_node_reset(net.net_idx, addr, &reset);
 		if (err) {
 			shell_error(shell, "Unable to send "
 					"Remote Node Reset (err %d)", err);


### PR DESCRIPTION
The 'reset' shell command ignores address parameter, if it is not equal
to local address. It should accept the address parameter as per the
command documentation.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@nordicsemi.no>