### PR TITLE
logging: Add LOG_RAW macro

### DIFF
--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -79,7 +79,17 @@ extern "C" {
  * @param ... A string optionally containing printk valid conversion specifier,
  * followed by as many values as specifiers.
  */
-#define LOG_PRINTK(...) Z_LOG_PRINTK(__VA_ARGS__)
+#define LOG_PRINTK(...) Z_LOG_PRINTK(0, __VA_ARGS__)
+
+/**
+ * @brief Unconditionally print raw log message.
+ *
+ * Provided string is printed as is without appending any characters (e.g., color or newline).
+ *
+ * @param ... A string optionally containing printk valid conversion specifier,
+ * followed by as many values as specifiers.
+ */
+#define LOG_RAW(...) Z_LOG_PRINTK(1, __VA_ARGS__)
 
 /**
  * @brief Writes an ERROR level message associated with the instance to the log.

--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -391,7 +391,17 @@ static inline char z_log_minimal_level_to_char(int level)
 extern struct log_source_const_data __log_const_start[];
 extern struct log_source_const_data __log_const_end[];
 
-#define Z_LOG_PRINTK(...) do { \
+/** @brief Create message for logging printk-like string or a raw string.
+ *
+ * Part of printk string processing is appending of carriage return after any
+ * new line character found in the string. If it is not desirable then @p _is_raw
+ * can be set to 1 to indicate raw string. This information is stored in the source
+ * field which is not used for its typical purpose in this case.
+ *
+ * @param _is_raw	Set to 1 to indicate raw string, set to 0 to indicate printk.
+ * @param ...		Format string with arguments.
+ */
+#define Z_LOG_PRINTK(_is_raw, ...) do { \
 	if (IS_ENABLED(CONFIG_LOG_MODE_MINIMAL)) { \
 		z_log_minimal_printk(__VA_ARGS__); \
 		break; \
@@ -401,7 +411,7 @@ extern struct log_source_const_data __log_const_end[];
 		z_log_printf_arg_checker(__VA_ARGS__); \
 	} \
 	Z_LOG_MSG2_CREATE(!IS_ENABLED(CONFIG_USERSPACE), _mode, \
-			  CONFIG_LOG_DOMAIN_ID, NULL, \
+			  CONFIG_LOG_DOMAIN_ID, (uintptr_t)_is_raw, \
 			  LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0, __VA_ARGS__);\
 } while (0)
 

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -412,6 +412,11 @@ static bool msg_filter_check(struct log_backend const *backend,
 	domain_id = log_msg_get_domain(&msg->log);
 	source_id = source ? log_dynamic_source_id(source) : -1;
 
+	/* Accept all non-logging messages. */
+	if (level == LOG_LEVEL_NONE) {
+		return true;
+	}
+
 	backend_level = log_filter_get(backend, domain_id,
 				       source_id, true);
 

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -693,6 +693,29 @@ ZTEST(test_log_api, test_log_printk)
 	process_and_validate(false, true);
 }
 
+ZTEST(test_log_api, test_log_printk_vs_raw)
+{
+	log_timestamp_t exp_timestamp = TIMESTAMP_INIT_VAL;
+
+	log_setup(false);
+
+	mock_log_frontend_record(0, LOG_LEVEL_INTERNAL_RAW_STRING, "test 100\n");
+	mock_log_backend_record(&backend1, 0,
+				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INTERNAL_RAW_STRING,
+				exp_timestamp++, "test 100\n");
+	LOG_PRINTK("test %d\n", 100);
+
+
+	mock_log_frontend_record(1, LOG_LEVEL_INTERNAL_RAW_STRING, "test 100\n");
+	mock_log_backend_record(&backend1, 1,
+				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INTERNAL_RAW_STRING,
+				exp_timestamp++, "test 100\n");
+	LOG_RAW("test %d\n", 100);
+
+
+	process_and_validate(false, false);
+}
+
 ZTEST(test_log_api, test_log_arg_evaluation)
 {
 	char str[128];

--- a/tests/subsys/logging/log_api/src/mock_backend.c
+++ b/tests/subsys/logging/log_api/src/mock_backend.c
@@ -152,7 +152,9 @@ static void process(const struct log_backend *const backend,
 	uint32_t source_id;
 	const void *source = msg->log.hdr.source;
 
-	if (source == NULL) {
+	if (exp->level == LOG_LEVEL_INTERNAL_RAW_STRING) {
+		source_id = (uintptr_t)source;
+	} else if (source == NULL) {
 		source_id = 0;
 	} else {
 		source_id = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?

--- a/tests/subsys/logging/log_api/src/mock_frontend.c
+++ b/tests/subsys/logging/log_api/src/mock_frontend.c
@@ -102,9 +102,15 @@ void log_frontend_msg(const void *source,
 	zassert_equal(desc.level, exp_msg->level, NULL);
 	zassert_equal(desc.domain, exp_msg->domain_id, NULL);
 
-	uint32_t source_id = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
-		log_dynamic_source_id((struct log_source_dynamic_data *)source) :
-		log_const_source_id((const struct log_source_const_data *)source);
+	uint32_t source_id;
+
+	if (desc.level == LOG_LEVEL_NONE) {
+		source_id = (uintptr_t)source;
+	} else {
+		source_id = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
+			log_dynamic_source_id((struct log_source_dynamic_data *)source) :
+			log_const_source_id((const struct log_source_const_data *)source);
+	}
 
 	zassert_equal(source_id, exp_msg->source_id, "got: %d, exp: %d",
 			source_id, exp_msg->source_id);


### PR DESCRIPTION
Add macro for logging raw formatted string. It is similar to
LOG_PRINTK macro but contrary to LOG_PRINTK it should not append
carriage return character to any new line character found in the
string. LOG_PRINTK processed by log_output module has that to
mimic printk behavior.

Fixes #49659.

