### PR TITLE
Bluetooth: Audio: Fix error check for bt_gatt_subscribe error log

### DIFF
--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -2065,7 +2065,7 @@ static uint8_t unicast_client_pacs_avail_ctx_discover_cb(struct bt_conn *conn,
 			sub_params->value = BT_GATT_CCC_NOTIFY;
 
 			err = bt_gatt_subscribe(conn, sub_params);
-			if (err != 0) {
+			if (err != 0 && err != -EALREADY) {
 				BT_ERR("Failed to subscribe to avail_ctx: %d", err);
 			}
 		} /* else already subscribed */
@@ -2260,7 +2260,7 @@ static uint8_t unicast_client_pacs_location_discover_cb(struct bt_conn *conn,
 		sub_params->value = BT_GATT_CCC_NOTIFY;
 
 		err = bt_gatt_subscribe(conn, sub_params);
-		if (err != 0) {
+		if (err != 0 && err != -EALREADY) {
 			BT_ERR("Failed to subscribe to location: %d", err);
 		}
 	}


### PR DESCRIPTION
We shouldn't log an error if we are already subscribed to the device.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>