### PR TITLE
soc: esp32: updates to sync with v4.4.1 hal_espressif

### DIFF
--- a/boards/common/esp32.board.cmake
+++ b/boards/common/esp32.board.cmake
@@ -10,7 +10,7 @@ board_runner_args(openocd  --gdb-init "flushregs")
 board_runner_args(openocd  --gdb-init "mon reset halt")
 board_runner_args(openocd  --gdb-init "thb main")
 
-set(ESP_IDF_PATH ${ZEPHYR_ESPRESSIF_MODULE_DIR})
+set(ESP_IDF_PATH ${ZEPHYR_HAL_ESPRESSIF_MODULE_DIR})
 assert(ESP_IDF_PATH "ESP_IDF_PATH is not set")
 
 board_finalize_runner_args(esp32 "--esp-idf-path=${ESP_IDF_PATH}")

--- a/boards/xtensa/esp32/doc/index.rst
+++ b/boards/xtensa/esp32/doc/index.rst
@@ -47,12 +47,12 @@ System requirements
 Prerequisites
 -------------
 
-Espressif HAL requires binary blobs in order work. The west extension below performs the required
-syncronization to clone, checkout and pull the submodules:
+Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
+below to retrieve those files.
 
 .. code-block:: console
 
-   west espressif update
+   west blobs fetch hal_espressif
 
 .. note::
 

--- a/boards/xtensa/esp32_net/doc/index.rst
+++ b/boards/xtensa/esp32_net/doc/index.rst
@@ -16,12 +16,12 @@ System requirements
 Prerequisites
 -------------
 
-Espressif HAL requires binary blobs in order work. The west extension below performs the required
-syncronization to clone, checkout and pull the submodules:
+Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
+below to retrieve those files.
 
 .. code-block:: console
 
-   west espressif update
+   west blobs fetch hal_espressif
 
 .. note::
 

--- a/boards/xtensa/esp32s2_saola/doc/index.rst
+++ b/boards/xtensa/esp32s2_saola/doc/index.rst
@@ -36,12 +36,12 @@ System requirements
 Prerequisites
 -------------
 
-Espressif HAL requires binary blobs in order work. The west extension below performs the required
-syncronization to clone, checkout and pull the submodules:
+Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
+below to retrieve those files.
 
 .. code-block:: console
 
-   west espressif update
+   west blobs fetch hal_espressif
 
 .. note::
 

--- a/boards/xtensa/esp_wrover_kit/doc/index.rst
+++ b/boards/xtensa/esp_wrover_kit/doc/index.rst
@@ -445,12 +445,12 @@ System requirements
 Prerequisites
 -------------
 
-Espressif HAL requires binary blobs in order work. The west extension below performs the required
-syncronization to clone, checkout and pull the submodules:
+Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
+below to retrieve those files.
 
 .. code-block:: console
 
-   west espressif update
+   west blobs fetch hal_espressif
 
 .. note::
 

--- a/boards/xtensa/heltec_wifi_lora32_v2/doc/index.rst
+++ b/boards/xtensa/heltec_wifi_lora32_v2/doc/index.rst
@@ -28,12 +28,12 @@ System requirements
 Prerequisites
 -------------
 
-Espressif HAL requires binary blobs in order work. The west extension below performs the required
-syncronization to clone, checkout and pull the submodules:
+Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
+below to retrieve those files.
 
 .. code-block:: console
 
-   west espressif update
+   west blobs fetch hal_espressif
 
 .. note::
 

--- a/boards/xtensa/odroid_go/doc/index.rst
+++ b/boards/xtensa/odroid_go/doc/index.rst
@@ -84,12 +84,12 @@ System requirements
 Prerequisites
 -------------
 
-Espressif HAL requires binary blobs in order work. The west extension below performs the required
-syncronization to clone, checkout and pull the submodules:
+Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
+below to retrieve those files.
 
 .. code-block:: console
 
-   west espressif update
+   west blobs fetch hal_espressif
 
 .. note::
 

--- a/boards/xtensa/olimex_esp32_evb/doc/index.rst
+++ b/boards/xtensa/olimex_esp32_evb/doc/index.rst
@@ -94,12 +94,12 @@ System requirements
 Prerequisites
 -------------
 
-Espressif HAL requires binary blobs in order work. The west extension below performs the required
-syncronization to clone, checkout and pull the submodules:
+Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
+below to retrieve those files.
 
 .. code-block:: console
 
-   west espressif update
+   west blobs fetch hal_espressif
 
 .. note::
 

--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -20,6 +20,7 @@
 #define DT_CPU_COMPAT cdns_tensilica_xtensa_lx7
 #include <zephyr/dt-bindings/clock/esp32s2_clock.h>
 #include "esp32s2/rom/rtc.h"
+#include "soc/dport_reg.h"
 #elif CONFIG_IDF_TARGET_ESP32C3
 #define DT_CPU_COMPAT espressif_riscv
 #include <zephyr/dt-bindings/clock/esp32c3_clock.h>
@@ -29,7 +30,9 @@
 #include <soc/rtc.h>
 #endif
 
+#include "esp_rom_sys.h"
 #include <soc/rtc.h>
+#include <soc/i2s_reg.h>
 #include <soc/apb_ctrl_reg.h>
 #include <soc/timer_group_reg.h>
 #include <hal/clk_gate_ll.h>
@@ -115,6 +118,294 @@ static int clock_control_esp32_get_rate(const struct device *dev,
 	return 0;
 }
 
+#if defined(CONFIG_SOC_ESP32) || defined(CONFIG_SOC_ESP32_NET)
+static void esp32_clock_perip_init(void)
+{
+	uint32_t common_perip_clk;
+	uint32_t hwcrypto_perip_clk;
+	uint32_t wifi_bt_sdio_clk;
+
+#if !CONFIG_SMP
+	soc_reset_reason_t rst_reas[1];
+#else
+	soc_reset_reason_t rst_reas[2];
+#endif
+
+	rst_reas[0] = esp_rom_get_reset_reason(0);
+#if CONFIG_SMP
+	rst_reas[1] = esp_rom_get_reset_reason(1);
+#endif
+
+	/* For reason that only reset CPU, do not disable the clocks
+	 * that have been enabled before reset.
+	 */
+	if ((rst_reas[0] == RESET_REASON_CPU0_MWDT0 || rst_reas[0] == RESET_REASON_CPU0_SW ||
+		rst_reas[0] == RESET_REASON_CPU0_RTC_WDT)
+#if CONFIG_SMP
+		|| (rst_reas[1] == RESET_REASON_CPU1_MWDT1 || rst_reas[1] == RESET_REASON_CPU1_SW ||
+			rst_reas[1] == RESET_REASON_CPU1_RTC_WDT)
+#endif
+	) {
+		common_perip_clk = ~DPORT_READ_PERI_REG(DPORT_PERIP_CLK_EN_REG);
+		hwcrypto_perip_clk = ~DPORT_READ_PERI_REG(DPORT_PERI_CLK_EN_REG);
+		wifi_bt_sdio_clk = ~DPORT_READ_PERI_REG(DPORT_WIFI_CLK_EN_REG);
+	} else {
+		common_perip_clk = DPORT_WDG_CLK_EN |
+			DPORT_PCNT_CLK_EN |
+			DPORT_LEDC_CLK_EN |
+			DPORT_TIMERGROUP1_CLK_EN |
+			DPORT_PWM0_CLK_EN |
+			DPORT_TWAI_CLK_EN |
+			DPORT_PWM1_CLK_EN |
+			DPORT_PWM2_CLK_EN |
+			DPORT_PWM3_CLK_EN;
+
+		hwcrypto_perip_clk = DPORT_PERI_EN_AES |
+			DPORT_PERI_EN_SHA |
+			DPORT_PERI_EN_RSA |
+			DPORT_PERI_EN_SECUREBOOT;
+
+		wifi_bt_sdio_clk = DPORT_WIFI_CLK_WIFI_EN |
+			DPORT_WIFI_CLK_BT_EN_M |
+			DPORT_WIFI_CLK_UNUSED_BIT5 |
+			DPORT_WIFI_CLK_UNUSED_BIT12 |
+			DPORT_WIFI_CLK_SDIOSLAVE_EN |
+			DPORT_WIFI_CLK_SDIO_HOST_EN |
+			DPORT_WIFI_CLK_EMAC_EN;
+	}
+
+	/* Reset peripherals like I2C, SPI, UART, I2S and bring them to known state */
+	common_perip_clk |= DPORT_I2S0_CLK_EN |
+			DPORT_UART_CLK_EN |
+			DPORT_SPI2_CLK_EN |
+			DPORT_I2C_EXT0_CLK_EN |
+			DPORT_UHCI0_CLK_EN |
+			DPORT_RMT_CLK_EN |
+			DPORT_UHCI1_CLK_EN |
+			DPORT_SPI3_CLK_EN |
+			DPORT_I2C_EXT1_CLK_EN |
+			DPORT_I2S1_CLK_EN |
+			DPORT_SPI_DMA_CLK_EN;
+
+	common_perip_clk &= ~DPORT_SPI01_CLK_EN;
+	common_perip_clk &= ~DPORT_SPI2_CLK_EN;
+	common_perip_clk &= ~DPORT_SPI3_CLK_EN;
+
+	/* Change I2S clock to audio PLL first. Because if I2S uses 160MHz clock,
+	 * the current is not reduced when disable I2S clock.
+	 */
+	DPORT_SET_PERI_REG_MASK(I2S_CLKM_CONF_REG(0), I2S_CLKA_ENA);
+	DPORT_SET_PERI_REG_MASK(I2S_CLKM_CONF_REG(1), I2S_CLKA_ENA);
+
+	/* Disable some peripheral clocks. */
+	DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, common_perip_clk);
+	DPORT_SET_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, common_perip_clk);
+
+	/* Disable hardware crypto clocks. */
+	DPORT_CLEAR_PERI_REG_MASK(DPORT_PERI_CLK_EN_REG, hwcrypto_perip_clk);
+	DPORT_SET_PERI_REG_MASK(DPORT_PERI_RST_EN_REG, hwcrypto_perip_clk);
+
+	/* Disable WiFi/BT/SDIO clocks. */
+	DPORT_CLEAR_PERI_REG_MASK(DPORT_WIFI_CLK_EN_REG, wifi_bt_sdio_clk);
+
+	/* Enable RNG clock. */
+	periph_module_enable(PERIPH_RNG_MODULE);
+}
+#endif
+
+#if defined(CONFIG_SOC_ESP32S2)
+static void esp32_clock_perip_init(void)
+{
+	uint32_t common_perip_clk;
+	uint32_t hwcrypto_perip_clk;
+	uint32_t wifi_bt_sdio_clk;
+	uint32_t common_perip_clk1;
+
+	soc_reset_reason_t rst_reason = esp_rom_get_reset_reason(0);
+
+	/* For reason that only reset CPU, do not disable the clocks
+	 * that have been enabled before reset.
+	 */
+	if (rst_reason == RESET_REASON_CPU0_MWDT0 || rst_reason == RESET_REASON_CPU0_SW ||
+		rst_reason == RESET_REASON_CPU0_RTC_WDT || rst_reason == RESET_REASON_CPU0_MWDT1) {
+		common_perip_clk = ~DPORT_READ_PERI_REG(DPORT_PERIP_CLK_EN_REG);
+		hwcrypto_perip_clk = ~DPORT_READ_PERI_REG(DPORT_PERIP_CLK_EN1_REG);
+		wifi_bt_sdio_clk = ~DPORT_READ_PERI_REG(DPORT_WIFI_CLK_EN_REG);
+	} else {
+		common_perip_clk = DPORT_WDG_CLK_EN |
+			DPORT_I2S0_CLK_EN |
+			DPORT_UART1_CLK_EN |
+			DPORT_SPI2_CLK_EN |
+			DPORT_I2C_EXT0_CLK_EN |
+			DPORT_UHCI0_CLK_EN |
+			DPORT_RMT_CLK_EN |
+			DPORT_PCNT_CLK_EN |
+			DPORT_LEDC_CLK_EN |
+			DPORT_TIMERGROUP1_CLK_EN |
+			DPORT_SPI3_CLK_EN |
+			DPORT_PWM0_CLK_EN |
+			DPORT_TWAI_CLK_EN |
+			DPORT_PWM1_CLK_EN |
+			DPORT_I2S1_CLK_EN |
+			DPORT_SPI2_DMA_CLK_EN |
+			DPORT_SPI3_DMA_CLK_EN |
+			DPORT_PWM2_CLK_EN |
+			DPORT_PWM3_CLK_EN;
+
+		common_perip_clk1 = 0;
+
+		hwcrypto_perip_clk = DPORT_CRYPTO_AES_CLK_EN |
+				DPORT_CRYPTO_SHA_CLK_EN |
+				DPORT_CRYPTO_RSA_CLK_EN;
+
+		wifi_bt_sdio_clk = DPORT_WIFI_CLK_WIFI_EN |
+			DPORT_WIFI_CLK_BT_EN_M |
+			DPORT_WIFI_CLK_UNUSED_BIT5 |
+			DPORT_WIFI_CLK_UNUSED_BIT12 |
+			DPORT_WIFI_CLK_SDIOSLAVE_EN |
+			DPORT_WIFI_CLK_SDIO_HOST_EN |
+			DPORT_WIFI_CLK_EMAC_EN;
+	}
+
+	/* Reset peripherals like I2C, SPI, UART, I2S and bring them to known state */
+	common_perip_clk |= DPORT_I2S0_CLK_EN |
+			DPORT_UART1_CLK_EN |
+			DPORT_USB_CLK_EN |
+			DPORT_SPI2_CLK_EN |
+			DPORT_I2C_EXT0_CLK_EN |
+			DPORT_UHCI0_CLK_EN |
+			DPORT_RMT_CLK_EN |
+			DPORT_UHCI1_CLK_EN |
+			DPORT_SPI3_CLK_EN |
+			DPORT_I2C_EXT1_CLK_EN |
+			DPORT_I2S1_CLK_EN |
+			DPORT_SPI2_DMA_CLK_EN |
+			DPORT_SPI3_DMA_CLK_EN;
+
+	common_perip_clk1 = 0;
+
+	/* Change I2S clock to audio PLL first. Because if I2S uses 160MHz clock,
+	 * the current is not reduced when disable I2S clock.
+	 */
+	REG_SET_FIELD(I2S_CLKM_CONF_REG(0), I2S_CLK_SEL, I2S_CLK_AUDIO_PLL);
+	REG_SET_FIELD(I2S_CLKM_CONF_REG(1), I2S_CLK_SEL, I2S_CLK_AUDIO_PLL);
+
+	/* Disable some peripheral clocks. */
+	DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, common_perip_clk);
+	DPORT_SET_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, common_perip_clk);
+
+	DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_CLK_EN1_REG, common_perip_clk1);
+	DPORT_SET_PERI_REG_MASK(DPORT_PERIP_RST_EN1_REG, common_perip_clk1);
+
+	/* Disable hardware crypto clocks. */
+	DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_CLK_EN1_REG, hwcrypto_perip_clk);
+	DPORT_SET_PERI_REG_MASK(DPORT_PERIP_RST_EN1_REG, hwcrypto_perip_clk);
+
+	/* Disable WiFi/BT/SDIO clocks. */
+	DPORT_CLEAR_PERI_REG_MASK(DPORT_WIFI_CLK_EN_REG, wifi_bt_sdio_clk);
+
+	/* Enable WiFi MAC and POWER clocks */
+	DPORT_SET_PERI_REG_MASK(DPORT_WIFI_CLK_EN_REG, DPORT_WIFI_CLK_WIFI_EN);
+
+	/* Set WiFi light sleep clock source to RTC slow clock */
+	DPORT_REG_SET_FIELD(DPORT_BT_LPCK_DIV_INT_REG, DPORT_BT_LPCK_DIV_NUM, 0);
+	DPORT_CLEAR_PERI_REG_MASK(DPORT_BT_LPCK_DIV_FRAC_REG, DPORT_LPCLK_SEL_8M);
+	DPORT_SET_PERI_REG_MASK(DPORT_BT_LPCK_DIV_FRAC_REG, DPORT_LPCLK_SEL_RTC_SLOW);
+
+	/* Enable RNG clock. */
+	periph_module_enable(PERIPH_RNG_MODULE);
+}
+#endif
+
+#if defined(CONFIG_SOC_ESP32C3)
+static void esp32_clock_perip_init(void)
+{
+	uint32_t common_perip_clk;
+	uint32_t hwcrypto_perip_clk;
+	uint32_t wifi_bt_sdio_clk;
+	uint32_t common_perip_clk1;
+
+	soc_reset_reason_t rst_reason = esp_rom_get_reset_reason(0);
+
+	/* For reason that only reset CPU, do not disable the clocks
+	 * that have been enabled before reset.
+	 */
+	if (rst_reason == RESET_REASON_CPU0_MWDT0 || rst_reason == RESET_REASON_CPU0_SW ||
+		rst_reason == RESET_REASON_CPU0_RTC_WDT || rst_reason == RESET_REASON_CPU0_MWDT1) {
+		common_perip_clk = ~READ_PERI_REG(SYSTEM_PERIP_CLK_EN0_REG);
+		hwcrypto_perip_clk = ~READ_PERI_REG(SYSTEM_PERIP_CLK_EN1_REG);
+		wifi_bt_sdio_clk = ~READ_PERI_REG(SYSTEM_WIFI_CLK_EN_REG);
+	} else {
+		common_perip_clk = SYSTEM_WDG_CLK_EN |
+				SYSTEM_I2S0_CLK_EN |
+				SYSTEM_UART1_CLK_EN |
+				SYSTEM_SPI2_CLK_EN |
+				SYSTEM_I2C_EXT0_CLK_EN |
+				SYSTEM_UHCI0_CLK_EN |
+				SYSTEM_RMT_CLK_EN |
+				SYSTEM_LEDC_CLK_EN |
+				SYSTEM_TIMERGROUP1_CLK_EN |
+				SYSTEM_SPI3_CLK_EN |
+				SYSTEM_SPI4_CLK_EN |
+				SYSTEM_TWAI_CLK_EN |
+				SYSTEM_I2S1_CLK_EN |
+				SYSTEM_SPI2_DMA_CLK_EN |
+				SYSTEM_SPI3_DMA_CLK_EN;
+
+		common_perip_clk1 = 0;
+
+		hwcrypto_perip_clk = SYSTEM_CRYPTO_AES_CLK_EN |
+				SYSTEM_CRYPTO_SHA_CLK_EN |
+				SYSTEM_CRYPTO_RSA_CLK_EN;
+
+		wifi_bt_sdio_clk = SYSTEM_WIFI_CLK_WIFI_EN |
+				SYSTEM_WIFI_CLK_BT_EN_M |
+				SYSTEM_WIFI_CLK_UNUSED_BIT5 |
+				SYSTEM_WIFI_CLK_UNUSED_BIT12;
+	}
+
+	/* Reset peripherals like I2C, SPI, UART, I2S and bring them to known state */
+	common_perip_clk |= SYSTEM_I2S0_CLK_EN |
+			SYSTEM_UART1_CLK_EN |
+			SYSTEM_SPI2_CLK_EN |
+			SYSTEM_I2C_EXT0_CLK_EN |
+			SYSTEM_UHCI0_CLK_EN |
+			SYSTEM_RMT_CLK_EN |
+			SYSTEM_UHCI1_CLK_EN |
+			SYSTEM_SPI3_CLK_EN |
+			SYSTEM_SPI4_CLK_EN |
+			SYSTEM_I2C_EXT1_CLK_EN |
+			SYSTEM_I2S1_CLK_EN |
+			SYSTEM_SPI2_DMA_CLK_EN |
+			SYSTEM_SPI3_DMA_CLK_EN;
+
+	common_perip_clk1 = 0;
+
+	/* Disable some peripheral clocks. */
+	CLEAR_PERI_REG_MASK(SYSTEM_PERIP_CLK_EN0_REG, common_perip_clk);
+	SET_PERI_REG_MASK(SYSTEM_PERIP_RST_EN0_REG, common_perip_clk);
+
+	CLEAR_PERI_REG_MASK(SYSTEM_PERIP_CLK_EN1_REG, common_perip_clk1);
+	SET_PERI_REG_MASK(SYSTEM_PERIP_RST_EN1_REG, common_perip_clk1);
+
+	/* Disable hardware crypto clocks. */
+	CLEAR_PERI_REG_MASK(SYSTEM_PERIP_CLK_EN1_REG, hwcrypto_perip_clk);
+	SET_PERI_REG_MASK(SYSTEM_PERIP_RST_EN1_REG, hwcrypto_perip_clk);
+
+	/* Disable WiFi/BT/SDIO clocks. */
+	CLEAR_PERI_REG_MASK(SYSTEM_WIFI_CLK_EN_REG, wifi_bt_sdio_clk);
+	SET_PERI_REG_MASK(SYSTEM_WIFI_CLK_EN_REG, SYSTEM_WIFI_CLK_EN);
+
+	/* Set WiFi light sleep clock source to RTC slow clock */
+	REG_SET_FIELD(SYSTEM_BT_LPCK_DIV_INT_REG, SYSTEM_BT_LPCK_DIV_NUM, 0);
+	CLEAR_PERI_REG_MASK(SYSTEM_BT_LPCK_DIV_FRAC_REG, SYSTEM_LPCLK_SEL_8M);
+	SET_PERI_REG_MASK(SYSTEM_BT_LPCK_DIV_FRAC_REG, SYSTEM_LPCLK_SEL_RTC_SLOW);
+
+	/* Enable RNG clock. */
+	periph_module_enable(PERIPH_RNG_MODULE);
+}
+#endif
+
 static int clock_control_esp32_init(const struct device *dev)
 {
 	const struct esp32_clock_config *cfg = dev->config;
@@ -162,8 +453,7 @@ static int clock_control_esp32_init(const struct device *dev)
 	/* Re-calculate the ccount to make time calculation correct */
 	cpu_hal_set_cycle_count((uint64_t)cpu_hal_get_cycle_count() * new_freq_mhz / old_freq_mhz);
 
-	/* Enable RNG clock. */
-	periph_module_enable(PERIPH_RNG_MODULE);
+	esp32_clock_perip_init();
 
 	return 0;
 }

--- a/drivers/interrupt_controller/intc_esp32.c
+++ b/drivers/interrupt_controller/intc_esp32.c
@@ -873,25 +873,26 @@ void IRAM_ATTR esp_intr_noniram_disable(void)
 {
 	int oldint;
 	int cpu = esp_core_id();
-	int intmask = ~non_iram_int_mask[cpu];
+	int non_iram_ints = ~non_iram_int_mask[cpu];
 
 	if (non_iram_int_disabled_flag[cpu]) {
 		abort();
 	}
 	non_iram_int_disabled_flag[cpu] = true;
-	oldint = interrupt_controller_hal_disable_int_mask(intmask);
+	oldint = interrupt_controller_hal_read_interrupt_mask();
+	interrupt_controller_hal_disable_interrupts(non_iram_ints);
 	/* Save which ints we did disable */
-	non_iram_int_disabled[cpu] = oldint & non_iram_int_mask[cpu];
+	non_iram_int_disabled[cpu] = oldint & non_iram_ints;
 }
 
 void IRAM_ATTR esp_intr_noniram_enable(void)
 {
 	int cpu = esp_core_id();
-	int intmask = non_iram_int_disabled[cpu];
+	int non_iram_ints = non_iram_int_disabled[cpu];
 
 	if (!non_iram_int_disabled_flag[cpu]) {
 		abort();
 	}
 	non_iram_int_disabled_flag[cpu] = false;
-	interrupt_controller_hal_enable_int_mask(intmask);
+	interrupt_controller_hal_enable_interrupts(non_iram_ints);
 }

--- a/drivers/pwm/pwm_mc_esp32.c
+++ b/drivers/pwm/pwm_mc_esp32.c
@@ -8,6 +8,7 @@
 
 #include <hal/mcpwm_hal.h>
 #include <hal/mcpwm_ll.h>
+#include "driver/mcpwm.h"
 
 #include <soc.h>
 #include <errno.h>

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -197,8 +197,6 @@ static int eth_esp32_dev_init(const struct device *dev)
 
 	wifi_init_config_t config = WIFI_INIT_CONFIG_DEFAULT();
 	esp_err_t ret = esp_wifi_init(&config);
-
-	ret |= esp_supplicant_init();
 	ret |= esp_wifi_start();
 
 	if (IS_ENABLED(CONFIG_ESP32_WIFI_STA_AUTO)) {

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -94,7 +94,7 @@
 				compatible = "soc-nv-flash";
 				reg = <0 0x400000>;
 				erase-block-size = <4096>;
-				write-block-size = <32>;
+				write-block-size = <4>;
 			};
 		};
 

--- a/include/zephyr/drivers/interrupt_controller/intc_esp32c3.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_esp32c3.h
@@ -17,7 +17,28 @@
 
 /* Keep the LEVELx values as they are here; they match up with (1<<level) */
 #define ESP_INTR_FLAG_LEVEL1		(1<<1)	/* Accept a Level 1 int vector, lowest priority */
-#define ESP_INTR_FLAG_EDGE		    (1<<9)	/* Edge-triggered interrupt */
+#define ESP_INTR_FLAG_LEVEL2		(1<<2)	/* Accept a Level 2 int vector */
+#define ESP_INTR_FLAG_LEVEL3		(1<<3)	/* Accept a Level 3 int vector */
+#define ESP_INTR_FLAG_LEVEL4		(1<<4)	/* Accept a Level 4 int vector */
+#define ESP_INTR_FLAG_LEVEL5		(1<<5)	/* Accept a Level 5 int vector */
+#define ESP_INTR_FLAG_LEVEL6		(1<<6)	/* Accept a Level 6 int vector */
+#define ESP_INTR_FLAG_NMI		(1<<7)	/* Accept a Level 7 int vector, highest priority */
+#define ESP_INTR_FLAG_SHARED		(1<<8)	/* Interrupt can be shared between ISRs */
+#define ESP_INTR_FLAG_EDGE		(1<<9)	/* Edge-triggered interrupt */
+#define ESP_INTR_FLAG_IRAM		(1<<10)	/* ISR can be called if cache is disabled */
+#define ESP_INTR_FLAG_INTRDISABLED	(1<<11)	/* Return with this interrupt disabled */
+
+/* Low and medium prio interrupts. These can be handled in C. */
+#define ESP_INTR_FLAG_LOWMED	(ESP_INTR_FLAG_LEVEL1|ESP_INTR_FLAG_LEVEL2|ESP_INTR_FLAG_LEVEL3)
+
+/* High level interrupts. Need to be handled in assembly. */
+#define ESP_INTR_FLAG_HIGH	(ESP_INTR_FLAG_LEVEL4|ESP_INTR_FLAG_LEVEL5|ESP_INTR_FLAG_LEVEL6| \
+				 ESP_INTR_FLAG_NMI)
+
+/* Mask for all level flags */
+#define ESP_INTR_FLAG_LEVELMASK	(ESP_INTR_FLAG_LEVEL1|ESP_INTR_FLAG_LEVEL2|ESP_INTR_FLAG_LEVEL3| \
+				 ESP_INTR_FLAG_LEVEL4|ESP_INTR_FLAG_LEVEL5|ESP_INTR_FLAG_LEVEL6| \
+				 ESP_INTR_FLAG_NMI)
 
 /* Function prototype for interrupt handler function */
 typedef void (*isr_handler_t)(const void *arg);

--- a/soc/riscv/esp32c3/soc.h
+++ b/soc/riscv/esp32c3/soc.h
@@ -12,7 +12,7 @@
 #include <rom/spi_flash.h>
 #include <zephyr/types.h>
 #include <stdbool.h>
-#include <esp_clk.h>
+#include "esp32c3/clk.h"
 #endif
 
 /* IRQ numbers */

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -202,6 +202,8 @@ SECTIONS
     *(.tdata.*)
     *(.tbss)
     *(.tbss.*)
+    *(.rodata_wlog)
+    *(.rodata_wlog*)
     _thread_local_end = ABSOLUTE(.);
     . = ALIGN(4);
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
@@ -372,7 +374,7 @@ SECTIONS
 
 #if defined(CONFIG_ESP32_WIFI_IRAM_OPT)
     *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
-    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
+    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiorslpiram .wifiorslpiram.*)
 #endif
 
 #if defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
@@ -491,7 +493,7 @@ SECTIONS
 
 #if !defined(CONFIG_ESP32_WIFI_IRAM_OPT)
     *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
-    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
+    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiorslpiram .wifiorslpiram.*)
 #endif
 
 #if !defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)

--- a/soc/xtensa/esp32/soc.c
+++ b/soc/xtensa/esp32/soc.c
@@ -26,6 +26,7 @@
 #include "soc/gpio_periph.h"
 #include "esp_spi_flash.h"
 #include "esp_err.h"
+#include "esp_timer.h"
 #include "esp32/spiram.h"
 #include "esp_app_format.h"
 #include <zephyr/sys/printk.h>
@@ -117,6 +118,8 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 	*wdt_rtc_protect = RTC_CNTL_WDT_WKEY_VALUE;
 	*wdt_rtc_reg &= ~RTC_CNTL_WDT_EN;
 	*wdt_rtc_protect = 0;
+
+	esp_timer_early_init();
 
 #if CONFIG_ESP32_NETWORK_CORE
 	/* start the esp32 network core before

--- a/soc/xtensa/esp32/soc.h
+++ b/soc/xtensa/esp32/soc.h
@@ -11,6 +11,7 @@
 #include <soc/soc_caps.h>
 #include <esp32/rom/ets_sys.h>
 #include <esp32/rom/spi_flash.h>
+#include <esp_rom_sys.h>
 
 #include <zephyr/types.h>
 #include <stdbool.h>

--- a/soc/xtensa/esp32s2/linker.ld
+++ b/soc/xtensa/esp32s2/linker.ld
@@ -175,6 +175,8 @@ SECTIONS
     *(.tdata.*)
     *(.tbss)
     *(.tbss.*)
+    *(.rodata_wlog)
+    *(.rodata_wlog*)
     _thread_local_end = ABSOLUTE(.);
     _rodata_reserved_end = ABSOLUTE(.);
     . = ALIGN(4);
@@ -274,7 +276,7 @@ SECTIONS
 
 #if defined(CONFIG_ESP32_WIFI_IRAM_OPT)
     *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
-    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
+    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiorslpiram .wifiorslpiram.*)
 #endif
 
 #if defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)
@@ -425,7 +427,7 @@ SECTIONS
 
 #if !defined(CONFIG_ESP32_WIFI_IRAM_OPT)
     *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
-    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
+    *libpp.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.* .wifiorslpiram .wifiorslpiram.*)
 #endif
 
 #if !defined(CONFIG_ESP32_WIFI_RX_IRAM_OPT)

--- a/soc/xtensa/esp32s2/soc.c
+++ b/soc/xtensa/esp32s2/soc.c
@@ -22,7 +22,10 @@
 #include "esp32s2/rom/cache.h"
 #include "soc/gpio_periph.h"
 #include "esp_spi_flash.h"
+#include "esp_cpu.h"
 #include "hal/cpu_ll.h"
+#include "hal/soc_ll.h"
+#include "esp_timer.h"
 #include "esp_err.h"
 #include "esp32s2/spiram.h"
 #include <zephyr/sys/printk.h>
@@ -91,6 +94,8 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 	*wdt_rtc_protect = RTC_CNTL_WDT_WKEY_VALUE;
 	*wdt_rtc_reg &= ~RTC_CNTL_WDT_EN;
 	*wdt_rtc_protect = 0;
+
+	esp_timer_early_init();
 
 #if CONFIG_ESP_SPIRAM
 
@@ -175,9 +180,10 @@ void IRAM_ATTR esp_restart_noos(void)
 
 	/* Reset wifi/ethernet/sdio (bb/mac) */
 	DPORT_SET_PERI_REG_MASK(DPORT_CORE_RST_EN_REG,
-				DPORT_BB_RST | DPORT_FE_RST | DPORT_MAC_RST |
-				DPORT_SDIO_RST | DPORT_SDIO_HOST_RST |
-				DPORT_EMAC_RST | DPORT_MACPWR_RST);
+				DPORT_BB_RST | DPORT_FE_RST | DPORT_MAC_RST | DPORT_BT_RST |
+				DPORT_BTMAC_RST | DPORT_SDIO_RST | DPORT_SDIO_RST |
+				DPORT_SDIO_HOST_RST | DPORT_EMAC_RST | DPORT_MACPWR_RST |
+				DPORT_RW_BTMAC_RST | DPORT_RW_BTLP_RST);
 	DPORT_REG_WRITE(DPORT_CORE_RST_EN_REG, 0);
 
 	/* Reset timer/spi/uart */
@@ -188,12 +194,9 @@ void IRAM_ATTR esp_restart_noos(void)
 		DPORT_UART_RST);
 	DPORT_REG_WRITE(DPORT_PERIP_RST_EN_REG, 0);
 
-	/* Set CPU back to XTAL source, no PLL, same as hard reset */
-	rtc_clk_cpu_freq_set_xtal();
-
 	/* Reset CPUs */
 	if (core_id == 0) {
-		SET_PERI_REG_MASK(RTC_CNTL_OPTIONS0_REG, RTC_CNTL_SW_PROCPU_RST_M);
+		soc_ll_reset_core(0);
 	}
 
 	while (true) {

--- a/soc/xtensa/esp32s2/soc.h
+++ b/soc/xtensa/esp32s2/soc.h
@@ -14,7 +14,8 @@
 #include <esp32s2/rom/ets_sys.h>
 #include <esp32s2/rom/spi_flash.h>
 #include <esp32s2/rom/cache.h>
-#include <esp_clk.h>
+#include <esp32s2/clk.h>
+#include <esp_rom_sys.h>
 
 #include <zephyr/types.h>
 #include <stdbool.h>

--- a/west.yml
+++ b/west.yml
@@ -62,7 +62,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: a85cf740929b7537e0bb07572b6c4f3456b04420
+      revision: 1e29548e4492807eb18cbaa77d3e78801cc7d07e
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This PR brings a few updates to meet `hal_espressif` v4.4.1 baseline.

This also integrates the binary blob documentation, which is now available in `hal_espressif`.

Issues below were also fixed during hal_v4.4.1 bring up:  
Closes #43655
Closes #49762