### PR TITLE
Bluetooth: Add Byteorder encode XX-bit macros

### DIFF
--- a/include/zephyr/bluetooth/audio/lc3.h
+++ b/include/zephyr/bluetooth/audio/lc3.h
@@ -19,6 +19,7 @@
  */
 
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/bluetooth/byteorder.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -254,18 +255,14 @@ enum bt_codec_config_type {
  * If the flags argument is != 1 it will evaluate to the third argument which inserts a LTV
  * entry for the max_frames_per_sdu value.
  */
- #define BT_CODEC_LC3_DATA(_freq, _duration, _chan_count, _len_min, _len_max, _max_frames_per_sdu) \
+#define BT_CODEC_LC3_DATA(_freq, _duration, _chan_count, _len_min, _len_max, _max_frames_per_sdu) \
 { \
-	BT_CODEC_DATA(BT_CODEC_LC3_FREQ, \
-		      ((_freq) & 0xFFU), \
-		      (((_freq) >> 8) & 0xFFU)), \
+	BT_CODEC_DATA(BT_CODEC_LC3_FREQ, BT_BYTES_LIST_LE16(_freq)), \
 	BT_CODEC_DATA(BT_CODEC_LC3_DURATION, _duration), \
 	BT_CODEC_DATA(BT_CODEC_LC3_CHAN_COUNT, _chan_count), \
 	BT_CODEC_DATA(BT_CODEC_LC3_FRAME_LEN, \
-		      ((_len_min) & 0xFFU), \
-		      (((_len_min) >> 8) & 0xFFU), \
-		      ((_len_max) & 0xFFU), \
-		      (((_len_max) >> 8) & 0xFFU)) \
+		      BT_BYTES_LIST_LE16(_len_min), \
+		      BT_BYTES_LIST_LE16(_len_max)) \
 	COND_CODE_1(_max_frames_per_sdu, (), \
 		    (, BT_CODEC_DATA(BT_CODEC_LC3_FRAME_COUNT, \
 				     _max_frames_per_sdu))) \
@@ -276,9 +273,7 @@ enum bt_codec_config_type {
  */
 #define BT_CODEC_LC3_META(_prefer_context) \
 { \
-	BT_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PREF_CONTEXT, \
-		      ((_prefer_context) & 0xFFU), \
-		      (((_prefer_context) >> 8) & 0xFFU)) \
+	BT_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PREF_CONTEXT, BT_BYTES_LIST_LE16(_prefer_context)) \
 }
 
 /**
@@ -306,14 +301,8 @@ enum bt_codec_config_type {
 { \
 	BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FREQ, _freq), \
 	BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_DURATION, _duration), \
-	BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_CHAN_ALLOC, \
-		      ((_loc) & 0xFFU), \
-		      (((_loc) >> 8) & 0xFFU), \
-		      (((_loc) >> 16) & 0xFFU), \
-		      (((_loc) >> 24) & 0xFFU)), \
-	BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FRAME_LEN, \
-		      ((_len) & 0xFFU), \
-		      (((_len) >> 8) & 0xFFU)) \
+	BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_CHAN_ALLOC, BT_BYTES_LIST_LE32(_loc)), \
+	BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FRAME_LEN, BT_BYTES_LIST_LE16(_len)), \
 	COND_CODE_1(_frame_blocks_per_sdu, (), \
 		    (, BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FRAME_BLKS_PER_SDU, \
 				     _frame_blocks_per_sdu))) \
@@ -324,9 +313,7 @@ enum bt_codec_config_type {
  */
 #define BT_CODEC_LC3_CONFIG_META(_stream_context) \
 { \
-	BT_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT, \
-		      ((_stream_context) & 0xFFU), \
-		      (((_stream_context) >> 8) & 0xFFU)) \
+	BT_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT, BT_BYTES_LIST_LE16(_stream_context)) \
 }
 
 /**

--- a/include/zephyr/bluetooth/byteorder.h
+++ b/include/zephyr/bluetooth/byteorder.h
@@ -1,0 +1,118 @@
+/** @file
+ *  @brief Bluetooth byteorder API
+ */
+
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_BYTEORDER_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_BYTEORDER_H_
+
+/**
+ * @brief Byteorder
+ * @defgroup bt_buf Byteorder
+ * @ingroup bluetooth
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/** @brief Encode 16-bit value into array values in little-endian format.
+ *
+ *  Helper macro to encode 16-bit values into comma separated values.
+ *
+ *  @note @p _v is evaluated 2 times.
+ *
+ *  @param _v 16-bit integer in host endianness.
+ *
+ *  @return The comma separated values for the 16-bit value.
+ */
+#define BT_BYTES_LIST_LE16(_v)         \
+	(((_v) >>  0) & 0xFFU),     \
+	(((_v) >>  8) & 0xFFU)      \
+
+/** @brief Encode 24-bit value into array values in little-endian format.
+ *
+ *  Helper macro to encode 24-bit values into comma separated values.
+ *
+ *  @note @p _v is evaluated 3 times.
+ *
+ *  @param _v 24-bit integer in host endianness.
+ *
+ *  @return The comma separated values for the 24-bit value.
+ */
+#define BT_BYTES_LIST_LE24(_v)         \
+	BT_BYTES_LIST_LE16(_v),        \
+	(((_v) >> 16) & 0xFFU)      \
+
+/** @brief Encode 32-bit value into array values in little-endian format.
+ *
+ *  Helper macro to encode 32-bit values into comma separated values.
+ *
+ *  @note @p _v is evaluated 4 times.
+ *
+ *  @param _v 32-bit integer in host endianness.
+ *
+ *  @return The comma separated values for the 32-bit value.
+ */
+#define BT_BYTES_LIST_LE32(_v)         \
+	BT_BYTES_LIST_LE24(_v),        \
+	(((_v) >> 24) & 0xFFU)      \
+
+/** @brief Encode 40-bit value into array values in little-endian format.
+ *
+ *  Helper macro to encode 40-bit values into comma separated values.
+ *
+ *  @note @p _v is evaluated 5 times.
+ *
+ *  @param _v 40-bit integer in host endianness.
+ *
+ *  @return The comma separated values for the 40-bit value.
+ */
+#define BT_BYTES_LIST_LE40(_v)         \
+	BT_BYTES_LIST_LE24(_v),        \
+	BT_BYTES_LIST_LE16((_v) >> 24) \
+
+/** @brief Encode 48-bit value into array values in little-endian format.
+ *
+ *  Helper macro to encode 48-bit values into comma separated values.
+ *
+ *  @note @p _v is evaluated 6 times.
+ *
+ *  @param _v 48-bit integer in host endianness.
+ *
+ *  @return The comma separated values for the 48-bit value.
+ */
+#define BT_BYTES_LIST_LE48(_v)         \
+	BT_BYTES_LIST_LE32(_v),        \
+	BT_BYTES_LIST_LE16((_v) >> 32) \
+
+/** @brief Encode 64-bit value into array values in little-endian format.
+ *
+ *  Helper macro to encode 64-bit values into comma separated values.
+ *
+ *  @note @p _v is evaluated 8 times.
+ *
+ *  @param _v 64-bit integer in host endianness.
+ *
+ *  @return The comma separated values for the 64-bit value.
+ */
+#define BT_BYTES_LIST_LE64(_v)         \
+	BT_BYTES_LIST_LE32(_v),        \
+	BT_BYTES_LIST_LE32((_v) >> 32) \
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_BYTEORDER_H_ */

--- a/include/zephyr/bluetooth/byteorder.h
+++ b/include/zephyr/bluetooth/byteorder.h
@@ -13,7 +13,7 @@
 
 /**
  * @brief Byteorder
- * @defgroup bt_buf Byteorder
+ * @defgroup bt_byteorder Byteorder
  * @ingroup bluetooth
  * @{
  */

--- a/include/zephyr/bluetooth/gap.h
+++ b/include/zephyr/bluetooth/gap.h
@@ -12,6 +12,7 @@
 #define ZEPHYR_INCLUDE_BLUETOOTH_GAP_H_
 
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/bluetooth/byteorder.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -531,12 +532,7 @@ enum {
  * @return The comma separated values for LE Supported Features value that
  *         may be used directly as an argument for @ref BT_DATA_BYTES.
  */
-#define BT_LE_SUPP_FEAT_40_ENCODE(w64) \
-	(((w64) >> 0) & 0xFF),  \
-	(((w64) >> 8) & 0xFF),  \
-	(((w64) >> 16) & 0xFF), \
-	(((w64) >> 24) & 0xFF), \
-	(((w64) >> 32) & 0xFF)
+#define BT_LE_SUPP_FEAT_40_ENCODE(w64) BT_BYTES_LIST_LE40(w64)
 
 /** @brief Encode 4 least significant bytes of 64-bit LE Supported Features into
  *         4 bytes long array of values in little-endian format.
@@ -556,11 +552,7 @@ enum {
  * @return The comma separated values for LE Supported Features value that
  *         may be used directly as an argument for @ref BT_DATA_BYTES.
  */
-#define BT_LE_SUPP_FEAT_32_ENCODE(w64) \
-	(((w64) >> 0) & 0xFF),  \
-	(((w64) >> 8) & 0xFF),  \
-	(((w64) >> 16) & 0xFF), \
-	(((w64) >> 24) & 0xFF)
+#define BT_LE_SUPP_FEAT_32_ENCODE(w64) BT_BYTES_LIST_LE32(w64)
 
 /**
  * @brief Encode 3 least significant bytes of 64-bit LE Supported Features into
@@ -581,10 +573,7 @@ enum {
  * @return The comma separated values for LE Supported Features value that
  *         may be used directly as an argument for @ref BT_DATA_BYTES.
  */
-#define BT_LE_SUPP_FEAT_24_ENCODE(w64) \
-	(((w64) >> 0) & 0xFF),  \
-	(((w64) >> 8) & 0xFF),  \
-	(((w64) >> 16) & 0xFF),
+#define BT_LE_SUPP_FEAT_24_ENCODE(w64) BT_BYTES_LIST_LE24(w64)
 
 /**
  * @brief Encode 2 least significant bytes of 64-bit LE Supported Features into
@@ -605,9 +594,7 @@ enum {
  * @return The comma separated values for LE Supported Features value that
  *         may be used directly as an argument for @ref BT_DATA_BYTES.
  */
-#define BT_LE_SUPP_FEAT_16_ENCODE(w64) \
-	(((w64) >> 0) & 0xFF),  \
-	(((w64) >> 8) & 0xFF),
+#define BT_LE_SUPP_FEAT_16_ENCODE(w64) BT_BYTES_LIST_LE16(w64)
 
 /**
  * @brief Encode the least significant byte of 64-bit LE Supported Features into

--- a/include/zephyr/bluetooth/mesh/health_srv.h
+++ b/include/zephyr/bluetooth/mesh/health_srv.h
@@ -18,6 +18,7 @@
  */
 
 #include <zephyr/bluetooth/mesh.h>
+#include <zephyr/bluetooth/byteorder.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -206,7 +207,7 @@ struct bt_mesh_health_srv {
  *  @return A comma separated list of values that make Health Test Info Metadata
  */
 #define BT_MESH_HEALTH_TEST_INFO(cid, tests...)                                \
-	(cid & 0xff), (cid >> 8), sizeof((uint8_t[]){ tests }), tests
+	BT_BYTES_LIST_LE16(cid), sizeof((uint8_t[]){ tests }), tests
 
 /** @brief Notify the stack that the fault array state of the given element has
  *  changed.

--- a/include/zephyr/bluetooth/uuid.h
+++ b/include/zephyr/bluetooth/uuid.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 
 #include <zephyr/sys/util.h>
+#include <zephyr/bluetooth/byteorder.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -174,22 +175,11 @@ struct bt_uuid_128 {
  *          @ref BT_UUID_INIT_128 or @ref BT_UUID_DECLARE_128
  */
 #define BT_UUID_128_ENCODE(w32, w1, w2, w3, w48) \
-	(((w48) >>  0) & 0xFF), \
-	(((w48) >>  8) & 0xFF), \
-	(((w48) >> 16) & 0xFF), \
-	(((w48) >> 24) & 0xFF), \
-	(((w48) >> 32) & 0xFF), \
-	(((w48) >> 40) & 0xFF), \
-	(((w3)  >>  0) & 0xFF), \
-	(((w3)  >>  8) & 0xFF), \
-	(((w2)  >>  0) & 0xFF), \
-	(((w2)  >>  8) & 0xFF), \
-	(((w1)  >>  0) & 0xFF), \
-	(((w1)  >>  8) & 0xFF), \
-	(((w32) >>  0) & 0xFF), \
-	(((w32) >>  8) & 0xFF), \
-	(((w32) >> 16) & 0xFF), \
-	(((w32) >> 24) & 0xFF)
+	BT_BYTES_LIST_LE48(w48),\
+	BT_BYTES_LIST_LE16(w3), \
+	BT_BYTES_LIST_LE16(w2), \
+	BT_BYTES_LIST_LE16(w1), \
+	BT_BYTES_LIST_LE32(w32)
 
 /** @brief Encode 16-bit UUID into array values in little-endian format.
  *
@@ -206,9 +196,7 @@ struct bt_uuid_128 {
  * @return The comma separated values for UUID 16 value that
  *         may be used directly as an argument for @ref BT_DATA_BYTES.
  */
-#define BT_UUID_16_ENCODE(w16)  \
-	(((w16) >>  0) & 0xFF), \
-	(((w16) >>  8) & 0xFF)
+#define BT_UUID_16_ENCODE(w16) BT_BYTES_LIST_LE16(w16)
 
 /** @brief Encode 32-bit UUID into array values in little-endian format.
  *
@@ -225,11 +213,7 @@ struct bt_uuid_128 {
  * @return The comma separated values for UUID 32 value that
  *         may be used directly as an argument for @ref BT_DATA_BYTES.
  */
-#define BT_UUID_32_ENCODE(w32)  \
-	(((w32) >>  0) & 0xFF), \
-	(((w32) >>  8) & 0xFF), \
-	(((w32) >> 16) & 0xFF), \
-	(((w32) >> 24) & 0xFF)
+#define BT_UUID_32_ENCODE(w32) BT_BYTES_LIST_LE32(w32)
 
 /**
  *  @brief Recommended length of user string buffer for Bluetooth UUID.

--- a/samples/bluetooth/hap_ha/src/main.c
+++ b/samples/bluetooth/hap_ha/src/main.c
@@ -9,6 +9,7 @@
 #include <zephyr/sys/printk.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/byteorder.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
@@ -32,10 +33,8 @@ BUILD_ASSERT((CONFIG_BT_PACS_SNK_CONTEXT & MANDATORY_SINK_CONTEXT) == MANDATORY_
 static uint8_t unicast_server_addata[] = {
 	BT_UUID_16_ENCODE(BT_UUID_ASCS_VAL), /* ASCS UUID */
 	BT_AUDIO_UNICAST_ANNOUNCEMENT_TARGETED, /* Target Announcement */
-	(((AVAILABLE_SINK_CONTEXT) >>  0) & 0xFF),
-	(((AVAILABLE_SINK_CONTEXT) >>  8) & 0xFF),
-	(((AVAILABLE_SOURCE_CONTEXT) >>  0) & 0xFF),
-	(((AVAILABLE_SOURCE_CONTEXT) >>  8) & 0xFF),
+	BT_BYTES_LIST_LE16(AVAILABLE_SINK_CONTEXT),
+	BT_BYTES_LIST_LE16(AVAILABLE_SOURCE_CONTEXT),
 	0x00, /* Metadata length */
 };
 

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -11,6 +11,7 @@
 #include <zephyr/sys/printk.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/byteorder.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
@@ -56,10 +57,8 @@ static K_SEM_DEFINE(sem_disconnected, 0, 1);
 static uint8_t unicast_server_addata[] = {
 	BT_UUID_16_ENCODE(BT_UUID_ASCS_VAL), /* ASCS UUID */
 	BT_AUDIO_UNICAST_ANNOUNCEMENT_TARGETED, /* Target Announcement */
-	(((AVAILABLE_SINK_CONTEXT) >>  0) & 0xFF),
-	(((AVAILABLE_SINK_CONTEXT) >>  8) & 0xFF),
-	(((AVAILABLE_SOURCE_CONTEXT) >>  0) & 0xFF),
-	(((AVAILABLE_SOURCE_CONTEXT) >>  8) & 0xFF),
+	BT_BYTES_LIST_LE16(AVAILABLE_SINK_CONTEXT),
+	BT_BYTES_LIST_LE16(AVAILABLE_SOURCE_CONTEXT),
 	0x00, /* Metadata length */
 };
 

--- a/tests/bsim/bluetooth/audio/src/bap_bass_broadcaster_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_bass_broadcaster_test.c
@@ -11,11 +11,6 @@ extern enum bst_result_t bst_result;
 
 /* TODO: Deprecate in favor of broadcast_source_test */
 
-#define BROADCAST_ID_ENCODE(broadcast_id)  \
-	(((broadcast_id) >>  0) & 0xFF), \
-	(((broadcast_id) >>  8) & 0xFF), \
-	(((broadcast_id) >> 16) & 0xFF)
-
 static void test_main(void)
 {
 	int err;
@@ -25,7 +20,7 @@ static void test_main(void)
 		BT_DATA_BYTES(BT_DATA_FLAGS, BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR),
 		BT_DATA_BYTES(BT_DATA_SVC_DATA16,
 			      BT_UUID_16_ENCODE(BT_UUID_BROADCAST_AUDIO_VAL),
-			      BROADCAST_ID_ENCODE(broadcast_id))
+			      BT_BYTES_LIST_LE24(broadcast_id)),
 	};
 
 	err = bt_enable(NULL);

--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -6,6 +6,7 @@
 
 #ifdef CONFIG_BT_BAP_SCAN_DELEGATOR
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/byteorder.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/sys/byteorder.h>
@@ -529,8 +530,7 @@ static int mod_source(struct sync_state *state)
 	uint8_t pref_context_metadata[4] = {
 		0x03, /* length of the type and value */
 		BT_AUDIO_METADATA_TYPE_PREF_CONTEXT,
-		((pref_context >> 0) & 0xFF),
-		((pref_context >> 8) & 0xFF),
+		BT_BYTES_LIST_LE16(pref_context),
 	};
 	int err;
 

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_test.c
@@ -7,6 +7,7 @@
 #if defined(CONFIG_BT_CAP_INITIATOR)
 
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/byteorder.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/audio/bap.h>
@@ -635,11 +636,9 @@ static void test_cap_initiator_broadcast(void)
 	const uint16_t mock_ccid = 0x1234;
 	const struct bt_codec_data new_metadata[] = {
 		BT_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT,
-			      (BT_AUDIO_CONTEXT_TYPE_MEDIA & 0xFFU),
-			      ((BT_AUDIO_CONTEXT_TYPE_MEDIA >> 8) & 0xFFU)),
+			      BT_BYTES_LIST_LE16(BT_AUDIO_CONTEXT_TYPE_MEDIA)),
 		BT_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST,
-			      (mock_ccid & 0xFFU),
-			      ((mock_ccid >> 8) & 0xFFU)),
+			      BT_BYTES_LIST_LE16(mock_ccid)),
 	};
 	struct bt_cap_initiator_broadcast_stream_param
 		stream_params[ARRAY_SIZE(broadcast_source_streams)];


### PR DESCRIPTION
Add a series of macros to help encode little-endian values into an array. 
Modifies a couple of Bluetooth macros to use these new macros. 

The macros can easily be expanded to also handle big-endian and more bit variants (e.g. 54-bits)