### PR TITLE
Bluetooth: Mesh: Replace segack tx delay with Kconfig options

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -533,6 +533,30 @@ config BT_MESH_TX_SEG_MAX
 	  which leaves 56 bytes for application layer data using a
 	  4-byte MIC and 52 bytes using an 8-byte MIC.
 
+config BT_MESH_SEG_ACK_BASE_TIMEOUT
+	int "SegAck transmission base timeout"
+	default 150
+	range 150 400
+	help
+	  Defines a base timeout for the acknowledgment timer used to delay
+	  transmission of the Segmented Acknowledgment message.
+
+config BT_MESH_SEG_ACK_PER_HOP_TIMEOUT
+	int "SegAck transmission timeout per hop"
+	default 50
+	range 50 250
+	help
+	  Defines an additional per-hop timeout for the acknowledgment timer
+	  used to delay transmission of the Segmented Acknowledgment message.
+
+config BT_MESH_SEG_ACK_PER_SEGMENT_TIMEOUT
+	int "SegAck transmission timeout per segment not yet received"
+	default 0
+	range 0 100
+	help
+	  Defines an additional timeout for the acknowledgment timer for every
+	  segment not yet received.
+
 config BT_MESH_DEFAULT_TTL
 	int "Default TTL value"
 	default 7

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1001,13 +1001,15 @@ static inline int32_t ack_timeout(struct seg_rx *rx)
 	/* The acknowledgment timer shall be set to a minimum of
 	 * 150 + 50 * TTL milliseconds.
 	 */
-	to = 150 + (ttl * 50U);
+	to = CONFIG_BT_MESH_SEG_ACK_BASE_TIMEOUT +
+	     (ttl * (int32_t)CONFIG_BT_MESH_SEG_ACK_PER_HOP_TIMEOUT);
 
-	/* 100 ms for every not yet received segment */
-	to += ((rx->seg_n + 1) - popcount(rx->block)) * 100U;
+	/* Add timeout for evenry not yet received segment. */
+	to += ((rx->seg_n + 1) - popcount(rx->block)) *
+		(int32_t)CONFIG_BT_MESH_SEG_ACK_PER_SEGMENT_TIMEOUT;
 
 	/* Make sure we don't send more frequently than the duration for
-	 * each packet (default is 300ms).
+	 * each packet (default is 400ms).
 	 */
 	return MAX(to, 400);
 }


### PR DESCRIPTION
Additional uncontrolled delay for transmitting segack affects throughput
of the segmented messages. Though the best throughput can be achieved
with the smallest allowed values, move them to Kconfig option so that
the segack delay can be controlled by a user.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>