### PR TITLE
Bluetooth: Audio: Fix bad BASE config check for broadcast sink

### DIFF
--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -346,8 +346,7 @@ static bool net_buf_decode_codec_ltv(struct net_buf_simple *buf,
 }
 
 static bool net_buf_decode_bis_data(struct net_buf_simple *buf,
-				    struct bt_audio_base_bis_data *bis,
-				    bool codec_data_already_found)
+				    struct bt_audio_base_bis_data *bis)
 {
 	uint8_t len;
 
@@ -373,19 +372,6 @@ static bool net_buf_decode_bis_data(struct net_buf_simple *buf,
 	if (len > 0) {
 		struct net_buf_simple ltv_buf;
 		void *ltv_data;
-
-		if (codec_data_already_found) {
-			/* Codec config can either be specific to each
-			 *  BIS or for all, but not both
-			 */
-			BT_DBG("BASE contains both codec config data and BIS "
-			       "codec config data. Aborting.");
-			return false;
-		}
-
-		/* TODO: Support codec configuration data per bis */
-		BT_WARN("BIS specific codec config data of length %u "
-			"was found but is not supported yet", len);
 
 		/* Use an extra net_buf_simple to be able to decode until it
 		 * is empty (len = 0)
@@ -496,8 +482,7 @@ static bool net_buf_decode_subgroup(struct net_buf_simple *buf,
 	}
 
 	for (int i = 0; i < subgroup->bis_count; i++) {
-		if (!net_buf_decode_bis_data(buf, &subgroup->bis_data[i],
-					     codec->data_count > 0)) {
+		if (!net_buf_decode_bis_data(buf, &subgroup->bis_data[i])) {
 			BT_DBG("Failed to decode BIS data for bis %d", i);
 			return false;
 		}


### PR DESCRIPTION
The broadcast sink did not allow codec config data to exist
in both the subgroup and in the individual BISes, which
not only doesn't make sense to not allow, but would
also cause interoperability issues.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/49531