### PR TITLE
twister: make skip reason clearer

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -707,7 +707,7 @@ class TestPlan:
                 if ts.depends_on:
                     dep_intersection = ts.depends_on.intersection(set(plat.supported))
                     if dep_intersection != set(ts.depends_on):
-                        instance.add_filter("No hardware support", Filters.PLATFORM)
+                        instance.add_filter(f"No hardware support, lacking {set(ts.depends_on) - dep_intersection}.", Filters.PLATFORM)
 
                 if plat.flash < ts.min_flash:
                     instance.add_filter("Not enough FLASH", Filters.PLATFORM)

--- a/scripts/tests/twister/conftest.py
+++ b/scripts/tests/twister/conftest.py
@@ -15,6 +15,7 @@ sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts"))
 from twisterlib.testplan import TestPlan
 from twisterlib.testinstance import TestInstance
 from twisterlib.environment import TwisterEnv, parse_arguments
+from twisterlib.hardwaremap import HardwareMap
 
 def new_get_toolchain(*args, **kwargs):
     return 'zephyr'
@@ -40,6 +41,7 @@ def tesenv_obj(test_data, testsuites_dir, tmpdir_factory):
     env.board_roots = [test_data +"board_config/1_level/2_level/"]
     env.test_roots = [testsuites_dir + '/tests', testsuites_dir + '/samples']
     env.outdir = tmpdir_factory.mktemp("sanity_out_demo")
+    env.hwm = HardwareMap(env)
     return env
 
 

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -45,12 +45,12 @@ def test_check_build_or_run(class_testplan, monkeypatch, all_testsuites_dict, pl
     testsuite.slow = slow
 
     testinstance = TestInstance(testsuite, platform, class_testplan.env.outdir)
-    run = testinstance.check_runnable(slow, device_testing, fixture)
+    run, _ = testinstance.check_runnable(slow, device_testing, fixture)
     _, r = expected
     assert run == r
 
     monkeypatch.setattr("os.name", "nt")
-    run = testinstance.check_runnable()
+    run, _ = testinstance.check_runnable()
     assert not run
 
 TESTDATA_2 = [


### PR DESCRIPTION
The aim of this PR is to make the skip reasons less obscure. Without it, there is a wide class of configurations getting "Not runnable on device" status, which is quite obscure. There are several different reasons for this status: harness not supported, fixture not available, missing installation of a simulator, etc. Statuses are clearer with this PR

Before:
`scripts/twister  -T samples/boards/nrf/clock_skew -T samples/basic/blinky -T tests/drivers/gpio/gpio_basic_api -v -v --inline-logs -p nrf52840dk_nrf52840 --device-testing --device-serial /dev/ttyACM0 `:

DEBUG   - nrf52840dk_nrf52840       samples/boards/nrf/clock_skew/sample.boards.nrf.clock_skew SKIPPED: Not runnable on device
DEBUG   - nrf52840dk_nrf52840       samples/basic/blinky/sample.basic.blinky           SKIPPED: Not runnable on device
DEBUG   - nrf52840dk_nrf52840       tests/drivers/gpio/gpio_basic_api/drivers.gpio.2pin SKIPPED: Not runnable on device
DEBUG   - nrf52840dk_nrf52840       tests/drivers/gpio/gpio_basic_api/drivers.gpio.nrf_sense_edge SKIPPED: Not runnable on 

and 
`scripts/twister -T samples/hello_world -p nsim_hs -p hifive1 -v -v --filter runnable`:

DEBUG   - nsim_hs                   samples/hello_world/sample.basic.helloworld        SKIPPED: Not runnable on device
DEBUG   - hifive1                     samples/hello_world/sample.basic.helloworld        SKIPPED: Not runnable on device

With the PR the above commands produce:

DEBUG   - nrf52840dk_nrf52840       samples/boards/nrf/clock_skew/sample.boards.nrf.clock_skew SKIPPED: Not runnable on device: test is marked as build-only.
DEBUG   - nrf52840dk_nrf52840       samples/basic/blinky/sample.basic.blinky           SKIPPED: Not runnable on device: Harness led is not supported.
DEBUG   - nrf52840dk_nrf52840       tests/drivers/gpio/gpio_basic_api/drivers.gpio.2pin SKIPPED: Not runnable on device: Fixture gpio_loopback is not available.
DEBUG   - nrf52840dk_nrf52840       tests/drivers/gpio/gpio_basic_api/drivers.gpio.nrf_sense_edge SKIPPED: Not runnable on device: Fixture gpio_loopback is not available.

and

DEBUG   - nsim_hs                   samples/hello_world/sample.basic.helloworld        SKIPPED: Not runnable on device: nsimdrv not found.

DEBUG   - hifive1                     samples/hello_world/sample.basic.helloworld        SKIPPED: Not runnable on device: renode not found.

Each commit from this PR is explaining the changes introduced.