### PR TITLE
drivers: sdhc: add clock init for USDHC2-block of NXP i.MX-processors

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -55,8 +55,9 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 		break;
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc1), okay) && CONFIG_IMX_USDHC
+#if CONFIG_IMX_USDHC
 	case IMX_CCM_USDHC1_CLK:
+	case IMX_CCM_USDHC2_CLK:
 		clock_root = kCLOCK_Root_Usdhc1 + instance;
 		break;
 #endif

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -443,12 +443,22 @@ static ALWAYS_INLINE void clock_init(void)
 	USB_EhciPhyInit(kUSB_ControllerEhci1, CPU_XTAL_CLK_HZ, &usbPhyConfig);
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc1), okay) && CONFIG_IMX_USDHC
+#if CONFIG_IMX_USDHC
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc1), okay)
 	/* Configure USDHC1 using  SysPll2Pfd2*/
 	rootCfg.mux = kCLOCK_USDHC1_ClockRoot_MuxSysPll2Pfd2;
 	rootCfg.div = 2;
 	CLOCK_SetRootClock(kCLOCK_Root_Usdhc1, &rootCfg);
 	CLOCK_EnableClock(kCLOCK_Usdhc1);
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc2), okay)
+	/* Configure USDHC2 using  SysPll2Pfd2*/
+	rootCfg.mux = kCLOCK_USDHC2_ClockRoot_MuxSysPll2Pfd2;
+	rootCfg.div = 2;
+	CLOCK_SetRootClock(kCLOCK_Root_Usdhc2, &rootCfg);
+	CLOCK_EnableClock(kCLOCK_Usdhc2);
+#endif
 #endif
 
 #if !(defined(CONFIG_CODE_FLEXSPI) || defined(CONFIG_CODE_FLEXSPI2)) && \


### PR DESCRIPTION
The missing init is added analog to existing init of USDHC1 block.

Signed-off-by: Nils Larsen <nils.larsen@posteo.de>