### PR TITLE
boards: arm: mimxrt1024: correct flash chip size and devicetree partition layout

### DIFF
--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -74,7 +74,7 @@
 			reg = <0x00010000 DT_SIZE_K(1920)>;
 		};
 
-		slot1_partition: partition@200000 {
+		slot1_partition: partition@1f0000 {
 			label = "image-1";
 			reg = <0x001F0000 DT_SIZE_K(1920)>;
 		};

--- a/dts/arm/nxp/nxp_rt1024.dtsi
+++ b/dts/arm/nxp/nxp_rt1024.dtsi
@@ -31,10 +31,10 @@
 &flexspi {
 	status = "okay";
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(4)>;
-	/* 4 MB internal flash present on chip */
+	/* 32 megabit internal flash present on chip */
 	w25q32jvwj0: w25q32jvwj0@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		size = <DT_SIZE_M(4)>;
+		size = <DT_SIZE_M(32)>;
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";


### PR DESCRIPTION
Correct flash chip size for RT1024 SOC onboard flash. This chip uses a 32 megabit onboard flash chip. Additionally, fix an incorrect address in the board devicetree partitions to prevent warnings from the devicetree compiler.