### PR TITLE
tests: log_core_additional: Fix log_user test filter

### DIFF
--- a/tests/subsys/logging/log_core_additional/testcase.yaml
+++ b/tests/subsys/logging/log_core_additional/testcase.yaml
@@ -33,11 +33,15 @@ tests:
     tags: logging
     filter: CONFIG_USERSPACE
     extra_args: CONF_FILE=log_user.conf USERSPACE_TEST=1
-    integration_platforms:
-      - qemu_x86
     # FIXME: log_user test fails when compiled with the GCC 12 from Zephyr SDK.
     #        (see the GitHub issue zephyrproject-rtos/zephyr#49213)
+    #        Make sure to un-comment `integration_platforms` when the above
+    #        issue is fixed. It has been temporarily disabled because
+    #        `integration_platforms` and `toolchain_exclude` cannot be used
+    #        together.
     toolchain_exclude: zephyr
+    # integration_platforms:
+    #   - qemu_x86
     testcases:
       - log_from_user
       - log_hexdump_from_user


### PR DESCRIPTION
This commit temporarily disables the `integration_platforms` for the
`log_user` test because it cannot be specified alongside the
`toolchain_exclude` filter.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

**Hotfix for `log_user` test, which has been disabled, "mysteriously" running in the CI.**