### PR TITLE
cbprintf: Remove unnecessary downcast

### DIFF
--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -484,7 +484,7 @@ static inline int z_cbprintf_cpy(const void *buf, size_t len, void *ctx)
 		return -ENOSPC;
 	}
 
-	memcpy(&((uint8_t *)desc->buf)[desc->off], (void *)buf, len);
+	memcpy(&((uint8_t *)desc->buf)[desc->off], buf, len);
 	desc->off += len;
 
 	return len;


### PR DESCRIPTION
Downcast from const void* to void* is unnecessary since the signature of
memcpy expects a const in second param. This downcast will raise a
compile error when -Werror=cast-qual is on.

Signed-off-by: Rob Barnes <robbarnes@google.com>