### PR TITLE
west.yml: Update CMSIS to pull GCC 12 warning fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -32,7 +32,7 @@ manifest:
       revision: ef76d3456db07e4959df555047d6962279528c8d
       path: modules/lib/chre
     - name: cmsis
-      revision: 5f86244bad4ad5a590e084f0e72ba7a1416c2edf
+      revision: 093de61c2a7d12dc9253daf8692f61f793a9254a
       path: modules/hal/cmsis
       groups:
         - hal


### PR DESCRIPTION
This commit updates the CMSIS module to pull in the fixes for the
uninitialised variable warnings reported by GCC 12 and above.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #49637

**Hotfix for CMSIS-DSP related test failures seen in the CI for some PRs**