### PR TITLE
arch: arm: Ignore Wattributes warning in direct ISR

### DIFF
--- a/include/zephyr/arch/arm/aarch32/irq.h
+++ b/include/zephyr/arch/arm/aarch32/irq.h
@@ -177,6 +177,8 @@ static inline void arch_isr_direct_footer(int maybe_swap)
 
 #define ARCH_ISR_DIRECT_DECLARE(name) \
 	static inline int name##_body(void); \
+	_Pragma("GCC diagnostic push") \
+	_Pragma("GCC diagnostic ignored \"-Wattributes\"") \
 	__attribute__ ((interrupt ("IRQ"))) void name(void) \
 	{ \
 		int check_reschedule; \
@@ -184,6 +186,7 @@ static inline void arch_isr_direct_footer(int maybe_swap)
 		check_reschedule = name##_body(); \
 		ISR_DIRECT_FOOTER(check_reschedule); \
 	} \
+	_Pragma("GCC diagnostic pop") \
 	static inline int name##_body(void)
 
 #if defined(CONFIG_DYNAMIC_DIRECT_INTERRUPTS)


### PR DESCRIPTION
GCC 11 and above may report the following warning for the functions
declared with the `interrupt` attribute when compiling FPU-enabled
ARM targets:

  warning: FP registers might be clobbered despite 'interrupt'
  attribute: compile with '-mgeneral-regs-only' [-Wattributes]

This commit disables the above warning because:

* For M-profile architectures (Cortex-M), this warning does not apply
  because the caller saved registers, including the FPU registers, are
  automatically saved upon exception entry and the callee saved
  registers are saved by the called functions as per the AAPCS (for
  more details, see the GitHub issue #49631).

* For A- and R-profile architectures (Cortex-A/Cortex-R), this warning
  is not very helpful either because the Zephyr ARM arch implementation
  strictly adheres to the AAPCS and, when applicable, only the caller
  saved registers need be saved upon exception entry.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #49631

**Hotfix for ARM direct ISR related test failures seen in the CI for some PRs**