### PR TITLE
tests: kernel/smp: fix get_cpu test random failure on cache incoherent systems

### DIFF
--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -541,16 +541,17 @@ static void thread_get_cpu_entry(void *p1, void *p2, void *p3)
  *
  * @see arch_curr_cpu()
  */
+static int _cpu_id;
 ZTEST(smp, test_get_cpu)
 {
 	k_tid_t thread_id;
 
 	/* get current cpu number */
-	int cpu_id = arch_curr_cpu()->id;
+	_cpu_id = arch_curr_cpu()->id;
 
 	thread_id = k_thread_create(&t2, t2_stack, T2_STACK_SIZE,
 				      (k_thread_entry_t)thread_get_cpu_entry,
-				      &cpu_id, NULL, NULL,
+				      &_cpu_id, NULL, NULL,
 				      K_PRIO_COOP(2),
 				      K_INHERIT_PERMS, K_NO_WAIT);
 

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -144,6 +144,7 @@ ZTEST(smp, test_smp_coop_threads)
 	}
 
 	k_thread_abort(tid);
+	k_thread_join(tid, K_FOREVER);
 	zassert_true(ok, "SMP test failed");
 }
 
@@ -184,6 +185,7 @@ ZTEST(smp, test_cpu_id_threads)
 	k_sem_take(&cpuid_sema, K_FOREVER);
 
 	k_thread_abort(tid);
+	k_thread_join(tid, K_FOREVER);
 }
 
 static void thread_entry(void *p1, void *p2, void *p3)
@@ -244,6 +246,10 @@ static void abort_threads(int num)
 {
 	for (int i = 0; i < num; i++) {
 		k_thread_abort(tinfo[i].tid);
+	}
+
+	for (int i = 0; i < num; i++) {
+		k_thread_join(tinfo[i].tid, K_FOREVER);
 	}
 }
 
@@ -551,6 +557,7 @@ ZTEST(smp, test_get_cpu)
 	k_busy_wait(DELAY_US);
 
 	k_thread_abort(thread_id);
+	k_thread_join(thread_id, K_FOREVER);
 }
 
 #ifdef CONFIG_TRACE_SCHED_IPI
@@ -1005,8 +1012,10 @@ ZTEST(smp, test_smp_switch_torture)
 	k_sleep(K_MSEC(SLEEP_MS_LONG));
 
 	k_thread_abort(&t2);
+	k_thread_join(&t2, K_FOREVER);
 	for (uintptr_t i = 0; i < THREADS_NUM; i++) {
 		k_thread_abort(&tthread[i]);
+		k_thread_join(&tthread[i], K_FOREVER);
 	}
 }
 


### PR DESCRIPTION
Inside test_get_cpu, the current CPU ID is stored in the test
thread's stack. Another thread is spawned with a pointer to
the variable holding this CPU ID, where this thread is supposed
to run on another CPU. On a cache incoherent platform, this
value of this variable may not have been updated on other CPU's
internal cache. Therefore when checking CPU IDs inside the newly
spawned thread, it is not checking the passed in CPU ID, but
actually whatever is on the another CPU's cache. This results in
random failure on the test_get_cpu test. Since for cache
incoherence architectures, CONFIG_KERNEL_COHERENCE is enabled by
default on SMP where shared data is placed in multiprocessor
coherent (generally "uncached") memory. The fix to this is to
simply make this variable as a global variable, as global
variable are consided shared data and will be placed in
multiprocessor coherent memory, and thus the correct value will
be referenced inside the newly spawned thread.

Fixes #49442

Bonus: do `k_thread_join()` to make sure threads are not running after each test.