### PR TITLE
ztress: Coherence fix for tests/lib/spsc_pbuf

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztress.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztress.h
@@ -159,10 +159,14 @@ struct ztress_context_data {
 #define ZTRESS_EXECUTE(...) do {							\
 	Z_ZTRESS_TIMER_CONTEXT_VALIDATE(__VA_ARGS__);					\
 	int has_timer = Z_ZTRESS_HAS_TIMER(__VA_ARGS__);				\
-	struct ztress_context_data data[] = {						\
+	struct ztress_context_data data1[] = {						\
 		FOR_EACH(Z_ZTRESS_GET_HANDLER_DATA, (,), __VA_ARGS__)			\
 	};										\
-	size_t cnt = ARRAY_SIZE(data) - has_timer;					\
+	size_t cnt = ARRAY_SIZE(data1) - has_timer;					\
+	static struct ztress_context_data data[ARRAY_SIZE(data1)];                      \
+	for (int i = 0; i < ARRAY_SIZE(data1); i++) {                                    \
+		data[i] = data1[i];                                                     \
+	}	                                                                        \
 	int err = ztress_execute(has_timer ? &data[0] : NULL, &data[has_timer], cnt);	\
 											\
 	zassert_equal(err, 0, "ztress_execute failed (err: %d)", err);			\


### PR DESCRIPTION
When CONFIG_KERNEL_COHERENCE=y, it's illegal to place shared
data(like ztress_context_data in this test case) on the stack,
because that memory is incoherent with respect to other CPUs
in the system.

In this specific case, it will cause PC register to load invalid
handler function pointer and crash the Xtensa processor.

Make it static.

Signed-off-by: Ming Shao <ming.shao@intel.com>

Fix: https://github.com/zephyrproject-rtos/zephyr/issues/47300