### PR TITLE
ztress: Use XOSHIRO rng generator when entropy device is present

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -27,6 +27,8 @@ osource "$(KCONFIG_BINARY_DIR)/Kconfig.soc.defconfig"
 osource "soc/$(ARCH)/*/Kconfig.defconfig"
 # This loads the toolchain defconfigs
 osource "$(TOOLCHAIN_KCONFIG_DIR)/Kconfig.defconfig"
+# This loads the testsuite defconfig
+source "subsys/testsuite/Kconfig.defconfig"
 
 # This should be early since the autogen Kconfig.dts symbols may get
 # used by modules

--- a/subsys/testsuite/Kconfig.defconfig
+++ b/subsys/testsuite/Kconfig.defconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if TEST
+
+choice RNG_GENERATOR_CHOICE
+	default XOSHIRO_RANDOM_GENERATOR if ZTRESS && ENTROPY_HAS_DRIVER
+endchoice
+
+endif # TEST

--- a/subsys/testsuite/ztest/src/ztress.c
+++ b/subsys/testsuite/ztest/src/ztress.c
@@ -467,6 +467,12 @@ static int ztress_cpu_clock_to_sys_clock_check(const struct device *unused)
 	 */
 	cpu_sys_clock_ok = t <= 12;
 
+	/* Read first random number. There are some generators which do not support
+	 * reading first random number from an interrupt context (initialization
+	 * is performed at the first read).
+	 */
+	(void)sys_rand32_get();
+
 	return 0;
 }
 


### PR DESCRIPTION
Test environment does not require true RNG and true RNG may have limitations (e.g., sys_rand32_get() cannot be called from an interrupt context).
Updating ztress to force XOSHIRO when possible. It required update in random subsystem configuration to allow forcing default generator.