### PR TITLE
Bluetooth: Controller: legacy: terminate condition to check role first

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1520,22 +1520,24 @@ void ull_conn_done(struct node_rx_event_done *done)
 	reason_final = conn->llcp_terminate.reason_final;
 	if (reason_final && (
 #if defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
-#if defined(CONFIG_BT_CENTRAL)
-		(((conn->llcp_terminate.req -
-		       conn->llcp_terminate.ack) & 0xFF) ==
-		     TERM_ACKED) ||
-		    conn->central.terminate_ack ||
-		    (reason_final == BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL) ||
-#endif /* CONFIG_BT_CENTRAL */
 #if defined(CONFIG_BT_PERIPHERAL)
-		lll->role
+			    lll->role ||
 #else /* CONFIG_BT_PERIPHERAL */
-		false
+			    false ||
 #endif /* CONFIG_BT_PERIPHERAL */
-#else /* defined(CONFIG_BT_LL_SW_LLCP_LEGACY) */
-	    true
-#endif /* !defined(CONFIG_BT_LL_SW_LLCP_LEGACY) */
-		)) {
+#if defined(CONFIG_BT_CENTRAL)
+			    (((conn->llcp_terminate.req -
+			       conn->llcp_terminate.ack) & 0xFF) ==
+			     TERM_ACKED) ||
+			    conn->central.terminate_ack ||
+			    (reason_final == BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL)
+#else /* CONFIG_BT_CENTRAL */
+			    true
+#endif /* CONFIG_BT_CENTRAL */
+#else /* !CONFIG_BT_LL_SW_LLCP_LEGACY */
+			    true
+#endif /* !CONFIG_BT_LL_SW_LLCP_LEGACY */
+			    )) {
 		conn_cleanup(conn, reason_final);
 
 		return;


### PR DESCRIPTION
Refactor to revert back the terminate check condition to
check the connection role first.

Reverts legacy code changed in
commit 8b1d50b9819d ("Bluetooth: controller: llcp: fix issue
 re. missing ack of terminate ind").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>