### PR TITLE
Bluetooth: Controller: Fix incorrect cond compile scheduling BIG

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -804,14 +804,9 @@ static uint32_t adv_iso_start(struct ll_adv_iso_set *adv_iso,
 	}
 	ticks_slot = adv_iso->ull.ticks_slot + ticks_slot_overhead;
 
-#if defined(BT_CTLR_SCHED_ADVANCED)
 	/* Find the slot after Periodic Advertisings events */
 	err = ull_sched_adv_aux_sync_free_slot_get(TICKER_USER_ID_THREAD,
 						   ticks_slot, &ticks_anchor);
-#else
-	/* advanced scheduling not enabled */
-	err = -1;
-#endif
 	if (err) {
 		ticks_anchor = ticker_ticks_now_get();
 	}


### PR DESCRIPTION
Fix incorrect conditional compile to disable Controller
advanced scheduling feature which is required for Broadcast
ISO implementation.

Regression in commit 6fe1299c3399 ("Bluetooth: controller:
llcp: fix CI tests for new LLCP").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>