### PR TITLE
Bluetooth: Controller: Add missing margin to BIG ticks_anchor

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -850,7 +850,10 @@ static uint32_t adv_iso_start(struct ll_adv_iso_set *adv_iso,
 	/* Find the slot after Periodic Advertisings events */
 	err = ull_sched_adv_aux_sync_free_slot_get(TICKER_USER_ID_THREAD,
 						   ticks_slot, &ticks_anchor);
-	if (err) {
+	if (!err) {
+		ticks_anchor += HAL_TICKER_US_TO_TICKS(
+			EVENT_TICKER_RES_MARGIN_US);
+	} else {
 		ticks_anchor = ticker_ticks_now_get();
 	}
 


### PR DESCRIPTION
Add the missing ticker resolution margin when calculating
the ticks_anchor to be used to get non-overlapping BIG
events.

Relates to commit https://github.com/zephyrproject-rtos/zephyr/commit/fab4511164724eaf846763a38693fcc9ad9e0608 ("Bluetooth: Controller: Fix
overlapping advertising events").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>