### PR TITLE
Bluetooth: Controller: Dont prioritize ticker slot window that yield

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -813,12 +813,14 @@ static uint8_t ticker_resolve_collision(struct ticker_node *nodes,
 			uint8_t next_is_critical = ticker_next->priority ==
 				TICKER_PRIORITY_CRITICAL;
 
+#if defined(CONFIG_BT_TICKER_EXT_SLOT_WINDOW_YIELD)
 			/* Does next node have higher priority? */
 			uint8_t next_has_priority =
-				(lazy_next - ticker_next->priority) >
-				(lazy_current - ticker->priority);
+				(!ticker_next->ext_data ||
+				 !ticker_next->ext_data->ticks_slot_window) &&
+				((lazy_next - ticker_next->priority) >
+				 (lazy_current - ticker->priority));
 
-#if defined(CONFIG_BT_TICKER_EXT_SLOT_WINDOW_YIELD)
 			/* Can the current ticker with ticks_slot_window be
 			 * scheduled after the colliding ticker?
 			 */
@@ -842,6 +844,11 @@ static uint8_t ticker_resolve_collision(struct ticker_node *nodes,
 					   ticker_next->ticks_slot) <
 					  ticker->ticks_slot));
 #else /* !CONFIG_BT_TICKER_EXT_SLOT_WINDOW_YIELD */
+			/* Does next node have higher priority? */
+			uint8_t next_has_priority =
+				(lazy_next - ticker_next->priority) >
+				(lazy_current - ticker->priority);
+
 			uint8_t curr_has_ticks_slot_window = 0U;
 			uint8_t next_not_ticks_slot_window = 1U;
 #endif /* !CONFIG_BT_TICKER_EXT_SLOT_WINDOW_YIELD */


### PR DESCRIPTION
Do not use lazy value to prioritize ticker with ticks slot
window that yield to other tickers. Primary channel PDUs
use ticks slow window to nudge themself after an
overlapping ticker within the ticks slot window, but such
ticker may be skipped to next interval. At the next
interval if they again overlap with other tickers then
lazy value shall not be used to prioritize but rather
continue to yield again. This is required to avoid BIG
events from being skipped.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>