### PR TITLE
samples: pm: demonstrate usage of the policy latency APIs

### DIFF
--- a/samples/subsys/pm/latency/CMakeLists.txt
+++ b/samples/subsys/pm/latency/CMakeLists.txt
@@ -1,0 +1,10 @@
+
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(latency)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/pm/latency/Kconfig
+++ b/samples/subsys/pm/latency/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+menu "Zephyr"
+source "Kconfig.zephyr"
+endmenu
+
+module = APP
+module-str = Application
+source "subsys/logging/Kconfig.template.log_config"

--- a/samples/subsys/pm/latency/boards/native_posix.overlay
+++ b/samples/subsys/pm/latency/boards/native_posix.overlay
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	power-states {
+		runtime_idle: runtime-idle {
+			compatible = "zephyr,power-state";
+			power-state-name = "runtime-idle";
+			min-residency-us = <1000000>;
+			exit-latency-us = <10000>;
+		};
+		suspend_to_idle: suspend-to-idle {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			min-residency-us = <1100000>;
+			exit-latency-us = <20000>;
+		};
+		standby: standby {
+			compatible = "zephyr,power-state";
+			power-state-name = "standby";
+			min-residency-us = <1200000>;
+			exit-latency-us = <30000>;
+		};
+	};
+};
+
+&cpu0 {
+	cpu-power-states = <&runtime_idle &suspend_to_idle &standby>;
+};

--- a/samples/subsys/pm/latency/prj.conf
+++ b/samples/subsys/pm/latency/prj.conf
@@ -1,0 +1,2 @@
+CONFIG_PM=y
+CONFIG_LOG=y

--- a/samples/subsys/pm/latency/sample.yaml
+++ b/samples/subsys/pm/latency/sample.yaml
@@ -1,0 +1,55 @@
+sample:
+  name: Demonstrate usage of the PM policy latency APIs
+tests:
+  sample.pm.latency:
+    platform_allow: native_posix
+    tags: pm
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "<inf> app: Sleeping for 1.1 seconds, we should enter RUNTIME_IDLE"
+        - "<inf> soc_pm: Entering RUNTIME_IDLE{0}"
+        - "<inf> app: Sleeping for 1.2 seconds, we should enter SUSPEND_TO_IDLE"
+        - "<inf> soc_pm: Entering SUSPEND_TO_IDLE{0}"
+        - "<inf> app: Sleeping for 1.3 seconds, we should enter STANDBY"
+        - "<inf> soc_pm: Entering STANDBY{0}"
+        - "<inf> app: Setting latency constraint: 30ms"
+        - "<inf> app: Sleeping for 1.1 seconds, we should enter RUNTIME_IDLE"
+        - "<inf> soc_pm: Entering RUNTIME_IDLE{0}"
+        - "<inf> app: Sleeping for 1.2 seconds, we should enter SUSPEND_TO_IDLE"
+        - "<inf> soc_pm: Entering SUSPEND_TO_IDLE{0}"
+        - "<inf> app: Sleeping for 1.3 seconds, we should enter SUSPEND_TO_IDLE"
+        - "<inf> soc_pm: Entering SUSPEND_TO_IDLE{0}"
+        - "<inf> app: Opening test device"
+        - "<inf> dev_test: Adding latency constraint: 20ms"
+        - "<inf> app: Latency constraint changed: 20ms"
+        - "<inf> app: Sleeping for 1.1 seconds, we should enter RUNTIME_IDLE"
+        - "<inf> soc_pm: Entering RUNTIME_IDLE{0}"
+        - "<inf> app: Sleeping for 1.2 seconds, we should enter RUNTIME_IDLE"
+        - "<inf> soc_pm: Entering RUNTIME_IDLE{0}"
+        - "<inf> app: Sleeping for 1.3 seconds, we should enter RUNTIME_IDLE"
+        - "<inf> soc_pm: Entering RUNTIME_IDLE{0}"
+        - "<inf> app: Updating latency constraint: 10ms"
+        - "<inf> app: Latency constraint changed: 10ms"
+        - "<inf> dev_test: Latency constraint changed: 10ms"
+        - "<inf> app: Sleeping for 1.1 seconds, we should stay ACTIVE"
+        - "<inf> app: Sleeping for 1.2 seconds, we should stay ACTIVE"
+        - "<inf> app: Sleeping for 1.3 seconds, we should stay ACTIVE"
+        - "<inf> app: Updating latency constraint: 30ms"
+        - "<inf> app: Latency constraint changed: 20ms"
+        - "<inf> dev_test: Latency constraint changed: 20ms"
+        - "<inf> app: Closing test device"
+        - "<inf> dev_test: Removing latency constraint"
+        - "<inf> app: Latency constraint changed: 30ms"
+        - "<inf> dev_test: Latency constraint changed: 30ms"
+        - "<inf> app: Sleeping for 1.1 seconds, we should enter RUNTIME_IDLE"
+        - "<inf> soc_pm: Entering RUNTIME_IDLE{0}"
+        - "<inf> app: Sleeping for 1.2 seconds, we should enter SUSPEND_TO_IDLE"
+        - "<inf> soc_pm: Entering SUSPEND_TO_IDLE{0}"
+        - "<inf> app: Sleeping for 1.3 seconds, we should enter SUSPEND_TO_IDLE"
+        - "<inf> soc_pm: Entering SUSPEND_TO_IDLE{0}"
+        - "<inf> app: Removing latency constraint"
+        - "<inf> app: Latency constraint changed: none"
+        - "<inf> app: Finished, we should now enter STANDBY"
+        - "<inf> soc_pm: Entering STANDBY{0}"

--- a/samples/subsys/pm/latency/src/main.c
+++ b/samples/subsys/pm/latency/src/main.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "test.h"
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/sys_clock.h>
+
+LOG_MODULE_REGISTER(app, CONFIG_APP_LOG_LEVEL);
+
+static void on_latency_changed(int32_t latency)
+{
+	if (latency == SYS_FOREVER_US) {
+		LOG_INF("Latency constraint changed: none");
+	} else {
+		LOG_INF("Latency constraint changed: %" PRId32 "ms",
+			latency / USEC_PER_MSEC);
+	}
+}
+
+void main(void)
+{
+	struct pm_policy_latency_subscription subs;
+	struct pm_policy_latency_request req;
+	const struct device *dev;
+
+	dev = device_get_binding("dev_test");
+	if (!device_is_ready(dev)) {
+		LOG_ERR("Device not ready");
+		return;
+	}
+
+	pm_policy_latency_changed_subscribe(&subs, on_latency_changed);
+
+	/* test without any latency constraint */
+	LOG_INF("Sleeping for 1.1 seconds, we should enter RUNTIME_IDLE");
+	k_msleep(1100);
+	LOG_INF("Sleeping for 1.2 seconds, we should enter SUSPEND_TO_IDLE");
+	k_msleep(1200);
+	LOG_INF("Sleeping for 1.3 seconds, we should enter STANDBY");
+	k_msleep(1300);
+
+	/* add an application level latency constraint */
+	LOG_INF("Setting latency constraint: 30ms");
+	pm_policy_latency_request_add(&req, 30000);
+
+	/* test with an application level constraint */
+	LOG_INF("Sleeping for 1.1 seconds, we should enter RUNTIME_IDLE");
+	k_msleep(1100);
+	LOG_INF("Sleeping for 1.2 seconds, we should enter SUSPEND_TO_IDLE");
+	k_msleep(1200);
+	LOG_INF("Sleeping for 1.3 seconds, we should enter SUSPEND_TO_IDLE");
+	k_msleep(1300);
+
+	/* open test device (adds its own latency constraint) */
+	LOG_INF("Opening test device");
+	test_open(dev);
+
+	/* test with application + driver latency constraints */
+	LOG_INF("Sleeping for 1.1 seconds, we should enter RUNTIME_IDLE");
+	k_msleep(1100);
+	LOG_INF("Sleeping for 1.2 seconds, we should enter RUNTIME_IDLE");
+	k_msleep(1200);
+	LOG_INF("Sleeping for 1.3 seconds, we should enter RUNTIME_IDLE");
+	k_msleep(1300);
+
+	/* update application level latency constraint */
+	LOG_INF("Updating latency constraint: 10ms");
+	pm_policy_latency_request_update(&req, 10000);
+
+	/* test with updated application + driver latency constraints */
+	LOG_INF("Sleeping for 1.1 seconds, we should stay ACTIVE");
+	k_msleep(1100);
+	LOG_INF("Sleeping for 1.2 seconds, we should stay ACTIVE");
+	k_msleep(1200);
+	LOG_INF("Sleeping for 1.3 seconds, we should stay ACTIVE");
+	k_msleep(1300);
+
+	/* restore application level latency constraint */
+	LOG_INF("Updating latency constraint: 30ms");
+	pm_policy_latency_request_update(&req, 30000);
+
+	/* close test device (removes its own latency constraint) */
+	LOG_INF("Closing test device");
+	test_close(dev);
+
+	/* test again with an application level constraint */
+	LOG_INF("Sleeping for 1.1 seconds, we should enter RUNTIME_IDLE");
+	k_msleep(1100);
+	LOG_INF("Sleeping for 1.2 seconds, we should enter SUSPEND_TO_IDLE");
+	k_msleep(1200);
+	LOG_INF("Sleeping for 1.3 seconds, we should enter SUSPEND_TO_IDLE");
+	k_msleep(1300);
+
+	/* remove application level constraint and terminate */
+	LOG_INF("Removing latency constraints");
+	pm_policy_latency_request_remove(&req);
+
+	pm_policy_latency_changed_unsubscribe(&subs);
+
+	LOG_INF("Finished, we should now enter STANDBY");
+}

--- a/samples/subsys/pm/latency/src/pm.c
+++ b/samples/subsys/pm/latency/src/pm.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/pm/pm.h>
+
+LOG_MODULE_REGISTER(soc_pm, CONFIG_APP_LOG_LEVEL);
+
+static const char *state2str(enum pm_state state)
+{
+	switch (state) {
+	case PM_STATE_ACTIVE:
+		return "ACTIVE";
+	case PM_STATE_RUNTIME_IDLE:
+		return "RUNTIME_IDLE";
+	case PM_STATE_SUSPEND_TO_IDLE:
+		return "SUSPEND_TO_IDLE";
+	case PM_STATE_STANDBY:
+		return "STANDBY";
+	case PM_STATE_SUSPEND_TO_RAM:
+		return "SUSPEND_TO_RAM";
+	case PM_STATE_SUSPEND_TO_DISK:
+		return "SUSPEND_TO_DISK";
+	case PM_STATE_SOFT_OFF:
+		return "SOFT_OFF";
+	default:
+		return "UNKNOWN";
+	}
+}
+
+/*
+ * PM callbacks are typically implemented at SoC level and run the actual
+ * code to enter the given PM state.
+ */
+
+void pm_state_set(enum pm_state state, uint8_t substate_id)
+{
+	LOG_INF("Entering %s{%u}", state2str(state), substate_id);
+	k_cpu_idle();
+}
+
+void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+}

--- a/samples/subsys/pm/latency/src/test.c
+++ b/samples/subsys/pm/latency/src/test.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "test.h"
+
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/sys_clock.h>
+
+LOG_MODULE_REGISTER(dev_test, CONFIG_APP_LOG_LEVEL);
+
+struct dev_test_data {
+	struct pm_policy_latency_subscription subs;
+	struct pm_policy_latency_request req;
+};
+
+static void on_latency_changed(int32_t latency)
+{
+	if (latency == SYS_FOREVER_US) {
+		LOG_INF("Latency constraint changed: none");
+	} else {
+		LOG_INF("Latency constraint changed: %" PRId32 "ms",
+			latency / USEC_PER_MSEC);
+	}
+}
+
+static void dev_test_open(const struct device *dev)
+{
+	struct dev_test_data *data = dev->data;
+
+	LOG_INF("Adding latency constraint: 20ms");
+	pm_policy_latency_request_add(&data->req, 20000);
+
+	pm_policy_latency_changed_subscribe(&data->subs, on_latency_changed);
+}
+
+static void dev_test_close(const struct device *dev)
+{
+	struct dev_test_data *data = dev->data;
+
+	LOG_INF("Removing latency constraint");
+	pm_policy_latency_request_remove(&data->req);
+
+	pm_policy_latency_changed_unsubscribe(&data->subs);
+}
+
+static const struct test_api dev_test_api = {
+	.open = dev_test_open,
+	.close = dev_test_close,
+};
+
+int dev_test_init(const struct device *dev)
+{
+	return 0;
+}
+
+static struct dev_test_data data;
+
+DEVICE_DEFINE(dev_test, "dev_test", &dev_test_init, NULL, &data, NULL,
+	      APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &dev_test_api);

--- a/samples/subsys/pm/latency/src/test.h
+++ b/samples/subsys/pm/latency/src/test.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+
+struct test_api {
+	void (*open)(const struct device *dev);
+	void (*close)(const struct device *dev);
+};
+
+static inline void test_open(const struct device *dev)
+{
+	const struct test_api *api =
+		(const struct test_api *)dev->api;
+
+	api->open(dev);
+}
+
+static inline void test_close(const struct device *dev)
+{
+	const struct test_api *api =
+		(const struct test_api *)dev->api;
+
+	api->close(dev);
+}


### PR DESCRIPTION
Even though we have unit tests that cover the PM policy latency APIs, it
may not be obvious on how to use it in practice. This patch adds a new
sample where both the application and a device driver impose latency
requirements. The sample illustrates how latency requirements are
aggregated and are considered when choosing the CPU power state.
The test has been designed to run on native_posix, since it only serves
for demonstration purposes.