### PR TITLE
include: fix files using legacy include paths

### DIFF
--- a/drivers/power_domain/power_domain_intel_adsp.c
+++ b/drivers/power_domain/power_domain_intel_adsp.c
@@ -8,7 +8,7 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(power_domain_intel_adsp, LOG_LEVEL_INF);
 
 #define PWRCTL_OFFSET 0xD0

--- a/soc/riscv/riscv-privilege/andes_v5/pma.c
+++ b/soc/riscv/riscv-privilege/andes_v5/pma.c
@@ -11,7 +11,7 @@
 
 #ifndef CONFIG_ASSERT
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pma_init, LOG_LEVEL);
 #endif
 

--- a/subsys/net/lib/tls_credentials/tls_credentials_trusted.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials_trusted.c
@@ -5,9 +5,9 @@
  */
 #include <string.h>
 
-#include <init.h>
-#include <kernel.h>
-#include <logging/log.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 
 #include <psa/protected_storage.h>
 


### PR DESCRIPTION
Some files were still using the already deprecated include path, fix
this.