### PR TITLE
remove soc.h from drivers for ARM64

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm.c
+++ b/drivers/clock_control/clock_control_mcux_ccm.c
@@ -6,7 +6,6 @@
 
 #define DT_DRV_COMPAT nxp_imx_ccm
 #include <errno.h>
-#include <soc.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/imx_ccm.h>

--- a/drivers/pinctrl/pinctrl_imx.c
+++ b/drivers/pinctrl/pinctrl_imx.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/drivers/pinctrl.h>
-#include <soc.h>
 
 
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -11,7 +11,6 @@
 #include <zephyr/drivers/clock_control.h>
 #include <errno.h>
 #include <fsl_uart.h>
-#include <soc.h>
 #include <zephyr/drivers/pinctrl.h>
 
 struct mcux_iuart_config {


### PR DESCRIPTION
As soc.h is cleaned up from ARM64 soc platforms, so remove it accordingly from drivers.