### PR TITLE
scripts: meta file build cope with no manifest-rev branches

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -389,7 +389,12 @@ def process_meta(zephyr_base, west_projs, modules, extra_modules=None,
             project_path = PurePath(project.posixpath).as_posix()
             revision, dirty = git_revision(project_path)
             workspace_dirty |= dirty
-            if project.sha(MANIFEST_REV_BRANCH) != revision:
+            try:
+                manifest_rev_sha = project.sha(MANIFEST_REV_BRANCH)
+            except:
+                # no manifest-rev branch found, so we are definetly off
+                manifest_rev_sha = None
+            if manifest_rev_sha != revision:
                 revision += '-off'
                 workspace_off = True
             meta_project = {'path': project_path,


### PR DESCRIPTION
Ran into a problem during development where I used Zephyr with two custom modules. Both of the modules hadn't a `manifest-rev`-branch. During the build, I got a not interpretable error which I traced down to be a problem that one of the custom modules didn't had the `manifest-rev` branch. Since this information is solely used for the `zephyr.meta` file, it makes sense to treat this error as "definitely dirty".

Log of the build-state is not broken since the commit-id is still present.