### PR TITLE
samples: modem: small improvements

### DIFF
--- a/samples/net/gsm_modem/src/main.c
+++ b/samples/net/gsm_modem/src/main.c
@@ -119,6 +119,11 @@ int main(void)
 		return -ENODEV;
 	}
 
+	if (!device_is_ready(uart_dev)) {
+		LOG_ERR("UART node is not ready!")
+		return -ENODEV;
+	}
+
 	/* Optional register modem power callbacks */
 	gsm_ppp_register_modem_power_callback(gsm_dev, modem_on_cb, modem_off_cb, NULL);
 

--- a/samples/net/gsm_modem/src/main.c
+++ b/samples/net/gsm_modem/src/main.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(sample_gsm_ppp, LOG_LEVEL_DBG);
 #define GSM_MODEM_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_gsm_ppp)
 #define UART_NODE DT_BUS(GSM_MODEM_NODE)
 
-static const struct device *const gsm_dev = DEVICE_DT_GET(GSM_MODEM_NODE);
+static const struct device *const gsm_dev = DEVICE_DT_GET_OR_NULL(GSM_MODEM_NODE);
 static struct net_mgmt_event_callback mgmt_cb;
 static bool starting = IS_ENABLED(CONFIG_GSM_PPP_AUTOSTART);
 
@@ -113,6 +113,11 @@ static void modem_off_cb(const struct device *dev, void *user_data)
 int main(void)
 {
 	const struct device *const uart_dev = DEVICE_DT_GET(UART_NODE);
+
+	if (!device_is_ready(gsm_dev)) {
+		LOG_ERR("GSM DEV is not ready! Verify your gsm modem node.")
+		return -ENODEV;
+	}
 
 	/* Optional register modem power callbacks */
 	gsm_ppp_register_modem_power_callback(gsm_dev, modem_on_cb, modem_off_cb, NULL);


### PR DESCRIPTION
Return the device pointer if the node identifier refers to a gsm modem node with status “okay”, otherwise return NULL and before the use check the pointers via `device_is_ready` function.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>