### PR TITLE
drivers: spi: Migrate spi_context_{complete,lock} usage 

### DIFF
--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -181,7 +181,7 @@ static void spi_gecko_xfer(const struct device *dev,
 	} while (!ret && spi_gecko_transfer_ongoing(data));
 
 	spi_context_cs_control(ctx, false);
-	spi_context_complete(ctx, 0);
+	spi_context_complete(ctx, dev, 0);
 }
 
 static void spi_gecko_init_pins(const struct device *dev)

--- a/drivers/spi/spi_litespi.c
+++ b/drivers/spi/spi_litespi.c
@@ -121,7 +121,7 @@ static void spi_litespi_xfer(const struct device *dev,
 			ctx->rx_buf[i] = read_data;
 		}
 	}
-	spi_context_complete(ctx, 0);
+	spi_context_complete(ctx, dev, 0);
 }
 
 /* API Functions */

--- a/drivers/spi/spi_psoc6.c
+++ b/drivers/spi/spi_psoc6.c
@@ -345,7 +345,7 @@ static int spi_psoc6_transceive_sync(const struct device *dev,
 				     const struct spi_buf_set *rx_bufs)
 {
 	return spi_psoc6_transceive(dev, spi_cfg, tx_bufs,
-				    rx_bufs, false, NULL);
+				    rx_bufs, false, NULL, NULL);
 }
 
 #ifdef CONFIG_SPI_ASYNC
@@ -353,10 +353,11 @@ static int spi_psoc6_transceive_async(const struct device *dev,
 				      const struct spi_config *spi_cfg,
 				      const struct spi_buf_set *tx_bufs,
 				      const struct spi_buf_set *rx_bufs,
-				      struct k_poll_signal *async)
+				      spi_callback_t cb,
+				      void *userdata)
 {
 	return spi_psoc6_transceive(dev, spi_cfg, tx_bufs,
-				    rx_bufs, true, async);
+				    rx_bufs, true, cb, userdata);
 }
 #endif /* CONFIG_SPI_ASYNC */
 

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -167,7 +167,7 @@ static void spi_sifive_xfer(const struct device *dev, const bool hw_cs_control)
 		sys_write32(SF_CSMODE_OFF, SPI_REG(dev, REG_CSMODE));
 	}
 
-	spi_context_complete(ctx, 0);
+	spi_context_complete(ctx, dev, 0);
 }
 
 /* API Functions */
@@ -207,7 +207,7 @@ static int spi_sifive_transceive(const struct device *dev,
 	bool hw_cs_control = false;
 
 	/* Lock the SPI Context */
-	spi_context_lock(&SPI_DATA(dev)->ctx, false, NULL, config);
+	spi_context_lock(&SPI_DATA(dev)->ctx, false, NULL, NULL, config);
 
 	/* Configure the SPI bus */
 	SPI_DATA(dev)->ctx.config = config;


### PR DESCRIPTION
This series updates the SPI driver to reflect the `spi_context_complete` and `spi_context_lock` function signature changes introduced in the commit https://github.com/zephyrproject-rtos/zephyr/commit/4c20403629df1ae6a58d37a7a5bd73d4698cc11a (https://github.com/zephyrproject-rtos/zephyr/pull/49180 forgot to migrate these).

Fixes various `error: too few arguments to function 'spi_context_complete'` errors seen in the CI.