### PR TITLE
drivers: flash: stm32 ospi: Limit bytes read from DT SFDP table

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -257,7 +257,7 @@ static int ospi_read_sfdp(const struct device *dev, off_t addr, uint8_t *data,
 	/* simulate the SDFP */
 	ARG_UNUSED(addr); /* addr is 0 */
 
-	for (uint8_t i_ind = 0; i_ind < ARRAY_SIZE(dev_cfg->sfdp_bfp); i_ind++) {
+	for (uint8_t i_ind = 0; i_ind < MIN(size, ARRAY_SIZE(dev_cfg->sfdp_bfp)); i_ind++) {
 		*(data + i_ind) = dev_cfg->sfdp_bfp[i_ind];
 	}
 #else /* sfdp_bfp */


### PR DESCRIPTION
In case SFDP table is provided via device tree, take care not reading
more than expected by the function caller as the result is written
in a structure which size is predefined by one specific byte in the
table, and could be smaller than the table size.

Fixes #49715

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>