### PR TITLE
tests: gpio: add initial state of GPIO set bits

### DIFF
--- a/tests/drivers/gpio/gpio_api_1pin/src/test_port.c
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_port.c
@@ -352,6 +352,8 @@ ZTEST(gpio_api_1pin_port, test_gpio_port_set_bits_clear_bits_raw)
 	}
 	zassert_equal(ret, 0, "Failed to configure the pin");
 
+	port_clear_bits_raw_and_verify(port, 0xFFFFFFFF, 0);
+
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		port_set_bits_raw_and_verify(port, test_vector[i][0], i);
 		val_expected |= test_vector[i][0] & (BIT(TEST_PIN));


### PR DESCRIPTION
When a GPIO is 1 and port_set_bits_raw_and_verify function does
not set that bit, it will still be 1. So calculate the expected
value only by the parameter of port_set_bits_raw_and_verify is
not enough. A proper way is to clear all the GPIO bit fist and
then do the test.
Fixes: #49714

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>