### PR TITLE
doc: release-notes: Add note on mcumgr task status bug fix

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -245,6 +245,12 @@ Devicetree
 Libraries / Subsystems
 **********************
 
+* Management
+
+  * MCUMGR race condition when using the task status function whereby if a
+    thread state changed it could give a falsely short process list has been
+    fixed.
+
 HALs
 ****
 


### PR DESCRIPTION
Adds a note to the release notes on a bug fixed in mcumgr whereby a
race condition existed that could have gave a false short process
list if a process state changed whilst the list function was running.

Release notes for https://github.com/zephyrproject-rtos/zephyr/pull/49513