### PR TITLE
drivers: ec_host_cmd_periph: Update Kconfig

### DIFF
--- a/drivers/ec_host_cmd_periph/Kconfig
+++ b/drivers/ec_host_cmd_periph/Kconfig
@@ -14,6 +14,8 @@ if EC_HOST_CMD_PERIPH
 
 config EC_HOST_CMD_SIMULATOR
 	bool "Embedded Controller Host Command Peripheral Simulator"
+	default y
+	depends on DT_HAS_ZEPHYR_SIM_EC_HOST_CMD_PERIPH_ENABLED
 	help
 	  Enable the EC host command simulator.
 


### PR DESCRIPTION
Utilize DT_HAS_<COMPAT>_ENABLED for devicetree based drivers

Signed-off-by: Kumar Gala <galak@kernel.org>