### PR TITLE
drivers: disk: sdmmc: Update Kconfig

### DIFF
--- a/drivers/disk/Kconfig.sdmmc
+++ b/drivers/disk/Kconfig.sdmmc
@@ -2,8 +2,6 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ST_STM32_SDMMC := st,stm32-sdmmc
-DT_COMPAT_ZEPHYR_MMC := zephyr,sdmmc-disk
 DT_STM32_SDMMC_HAS_DMA := $(dt_nodelabel_has_prop,sdmmc,dmas)
 
 config DISK_DRIVER_SDMMC
@@ -30,19 +28,20 @@ config SDMMC_SUBSYS
 	bool "SDMMC access via SD subsystem"
 	select SD_STACK
 	select SDHC
-	default $(dt_compat_enabled,$(DT_COMPAT_ZEPHYR_MMC))
+	default y
+	depends on DT_HAS_ZEPHYR_SDMMC_DISK_ENABLED
 	help
 	  Enable SDMMC access via SD subsystem
 
 config SDMMC_STM32
 	bool "STM32 SDMMC driver"
-	depends on HAS_STM32CUBE
+	default y
+	depends on DT_HAS_ST_STM32_SDMMC_ENABLED
 	select USE_STM32_HAL_SD
 	select USE_STM32_HAL_SD_EX if SOC_SERIES_STM32L4X
 	select USE_STM32_LL_SDMMC
 	select USE_STM32_HAL_DMA if (SOC_SERIES_STM32L4X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32F4X)
 	select DMA if ($(DT_STM32_SDMMC_HAS_DMA) && SOC_SERIES_STM32F4X)
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_SDMMC))
 	help
 	  File system on sdmmc accessed through stm32 sdmmc.
 


### PR DESCRIPTION
Utilize DT_HAS_<COMPAT>_ENABLED for devicetree based drivers

Signed-off-by: Kumar Gala <galak@kernel.org>