### PR TITLE
modbus: Update Kconfig

### DIFF
--- a/subsys/modbus/Kconfig
+++ b/subsys/modbus/Kconfig
@@ -1,8 +1,6 @@
 # Copyright (c) 2020 PHYTEC Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_MODBUS_RTU := zephyr,modbus-serial
-
 menuconfig MODBUS
 	bool "Modbus support"
 
@@ -42,8 +40,9 @@ config MODBUS_CLIENT
 
 config MODBUS_SERIAL
 	bool "Modbus over serial line support"
+	default y
 	depends on SERIAL && SERIAL_HAS_DRIVER
-	default $(dt_compat_enabled,$(DT_COMPAT_MODBUS_RTU))
+	depends on DT_HAS_ZEPHYR_MODBUS_SERIAL_ENABLED
 	help
 	  Enable Modbus over serial line support.
 


### PR DESCRIPTION
Utilize DT_HAS_<COMPAT>_ENABLED for devicetree based driver

Signed-off-by: Kumar Gala <galak@kernel.org>