### PR TITLE
drivers: dai: Update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/dai/intel/alh/Kconfig.alh
+++ b/drivers/dai/intel/alh/Kconfig.alh
@@ -3,11 +3,10 @@
 # Copyright (c) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_INTEL_ALH_DAI := intel,alh-dai
-
 config DAI_INTEL_ALH
 	bool "Intel ALH driver for Dai interface"
-	default $(dt_compat_enabled,$(DT_COMPAT_INTEL_ALH_DAI))
+	default y
+	depends on DT_HAS_INTEL_ALH_DAI_ENABLED
 	select DMA
 	help
 	  Select this to enable Intel ALH driver.

--- a/drivers/dai/intel/dmic/Kconfig.dmic
+++ b/drivers/dai/intel/dmic/Kconfig.dmic
@@ -5,6 +5,8 @@
 
 config DAI_INTEL_DMIC
 	bool "Intel digital PDM microphone driver support for DAI interface"
+	default y
+	depends on DT_HAS_INTEL_DAI_DMIC_ENABLED
 	help
 	  Enable Intel digital PDM microphone driver for DAI interface
 

--- a/drivers/dai/intel/ssp/Kconfig.ssp
+++ b/drivers/dai/intel/ssp/Kconfig.ssp
@@ -3,11 +3,10 @@
 # Copyright (c) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_DAI_INTEL_SSP := intel,ssp-dai
-
 config DAI_INTEL_SSP
 	bool "Intel I2S (SSP) Bus Driver for Dai interface"
-	default $(dt_compat_enabled,$(DT_COMPAT_DAI_INTEL_SSP))
+	default y
+	depends on DT_HAS_INTEL_SSP_DAI_ENABLED
 	select DMA
 	depends on PM_DEVICE_RUNTIME
 	help


### PR DESCRIPTION
Update dai drivers to use DT_HAS_<compat>_ENABLED Kconfig symbol
to expose the driver and enable it by default based on devicetree.

Signed-off-by: Kumar Gala <galak@kernel.org>