### PR TITLE
drivers: gpio: Cleanup Kconfig.test

### DIFF
--- a/drivers/gpio/Kconfig.test
+++ b/drivers/gpio/Kconfig.test
@@ -2,11 +2,8 @@
 # Organisation (CSIRO) ABN 41 687 119 230.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_VND_GPIO := vnd,gpio
-
 # Hidden option for turning on the dummy driver for vnd,gpio devices
 # used in testing.
 config GPIO_TEST
-	def_bool $(dt_compat_enabled,$(DT_COMPAT_VND_GPIO))
-	default y
+	def_bool DT_HAS_VND_GPIO_ENABLED
 	depends on DT_HAS_VND_GPIO_ENABLED


### PR DESCRIPTION
Use DT_HAS_VND_GPIO_ENABLED for GPIO_TEST similar to what we
do for SPI_TEST, I2C_TEST, etc.

Signed-off-by: Kumar Gala <galak@kernel.org>