### PR TITLE
boards: arm: Remove DT_COMPAT_<compat> defines

### DIFF
--- a/boards/arm/bl5340_dvk/Kconfig.defconfig
+++ b/boards/arm/bl5340_dvk/Kconfig.defconfig
@@ -87,11 +87,8 @@ config FLASH_LOAD_SIZE
 
 endif # BOARD_BL5340_DVK_CPUAPP_NS
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_TI_TCA9538 := ti,tca9538
-
 config I2C
-default $(dt_compat_on_bus,$(DT_COMPAT_TI_TCA9538),i2c)
+	default $(dt_compat_on_bus,$(DT_COMPAT_TI_TCA9538),i2c)
 
 endif # BOARD_BL5340_DVK_CPUAPP || BOARD_BL5340_DVK_CPUAPP_NS
 

--- a/boards/arm/bt610/Kconfig.defconfig
+++ b/boards/arm/bt610/Kconfig.defconfig
@@ -11,9 +11,6 @@ config BOARD
 config BT_CTLR
 	default BT
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_TI_TCA9538 := ti,tca9538
-
 config I2C
 	default $(dt_compat_on_bus,$(DT_COMPAT_TI_TCA9538),i2c)
 

--- a/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
@@ -56,9 +56,6 @@ config BT_HCI_VS
 config BT_WAIT_NOP
 	default BT && $(dt_nodelabel_enabled,nrf52840_reset)
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_NXP_PCAL6408A := nxp,pcal6408a
-
 config I2C
 	default $(dt_compat_on_bus,$(DT_COMPAT_NXP_PCAL6408A),i2c)
 


### PR DESCRIPTION
We auto-generate DT_COMPAT_<compat> defines so we dont need to
explicitly define them anymore.

Signed-off-by: Kumar Gala <galak@kernel.org>