### PR TITLE
samples: i2s: echo: Remove DT_COMPAT_<compat> defines

### DIFF
--- a/samples/drivers/i2s/echo/Kconfig
+++ b/samples/drivers/i2s/echo/Kconfig
@@ -1,10 +1,7 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_WOLFSON_WM8731 := wolfson,wm8731
+source "Kconfig.zephyr"
 
 config I2C
 	default $(dt_compat_on_bus,$(DT_COMPAT_WOLFSON_WM8731),i2c)
-
-source "Kconfig.zephyr"


### PR DESCRIPTION
We auto-generate DT_COMPAT_<compat> defines so we dont need to
explicitly define them anymore.

Signed-off-by: Kumar Gala <galak@kernel.org>