### PR TITLE
drivers: serial: rtt: Remove DT_COMPAT_<compat> defines

### DIFF
--- a/drivers/serial/Kconfig.rtt
+++ b/drivers/serial/Kconfig.rtt
@@ -14,9 +14,6 @@ menuconfig UART_RTT
 
 if UART_RTT
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_SEGGER_RTT_UART  := segger,rtt-uart
-
 config UART_RTT_0
 	def_bool $(dt_nodelabel_enabled_with_compat,rtt0,$(DT_COMPAT_SEGGER_RTT_UART))
 	depends on SEGGER_RTT_MAX_NUM_UP_BUFFERS >= 1 && SEGGER_RTT_MAX_NUM_DOWN_BUFFERS >= 1


### PR DESCRIPTION
We auto-generate DT_COMPAT_<compat> defines so we dont need to
explicitly define them anymore.

Signed-off-by: Kumar Gala <galak@kernel.org>