### PR TITLE
soc/xtensa/intel_adsp/cavs: Fix XTENSA_CCOUNT_HZ value

### DIFF
--- a/soc/xtensa/intel_adsp/cavs/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs/Kconfig.defconfig.series
@@ -17,8 +17,7 @@ config DMA_INTEL_ADSP_GPDMA
 	depends on DMA
 
 config XTENSA_CCOUNT_HZ
-	default 400000000 if SOC_INTEL_CAVS_V25
-	default 200000000
+	default 400000000
 
 config SYS_CLOCK_TICKS_PER_SEC
 	default 50000


### PR DESCRIPTION
The default value is actually 400MHz on cavs15 and cavs18.

Fixes: #49711

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>

--

Note: In a ideal world, this info should come from clock control if available.