### PR TITLE
drivers: usb: create thread and connect IRQ during init

### DIFF
--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -1045,6 +1045,7 @@ static int usb_kinetis_init(const struct device *dev)
 			USBD_THREAD_STACK_SIZE,
 			usb_kinetis_thread_main, NULL, NULL, NULL,
 			K_PRIO_COOP(2), 0, K_NO_WAIT);
+	k_thread_name_set(&dev_data.thread, "usb_kinetis");
 
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    usb_kinetis_isr_handler, 0, 0);

--- a/drivers/usb/device/usb_dc_mcux.c
+++ b/drivers/usb/device/usb_dc_mcux.c
@@ -845,6 +845,7 @@ static int usb_mcux_init(const struct device *dev)
 			USBD_MCUX_THREAD_STACK_SIZE,
 			usb_mcux_thread_main, NULL, NULL, NULL,
 			K_PRIO_COOP(2), 0, K_NO_WAIT);
+	k_thread_name_set(&dev_data.thread, "usb_mcux");
 
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    usb_isr_handler, 0, 0);

--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -747,6 +747,7 @@ static int usb_rpi_init(const struct device *dev)
 			USBD_THREAD_STACK_SIZE,
 			udc_rpi_thread_main, NULL, NULL, NULL,
 			K_PRIO_COOP(2), 0, K_NO_WAIT);
+	k_thread_name_set(&thread, "usb_rpi");
 
 	IRQ_CONNECT(USB_IRQ, USB_IRQ_PRI, udc_rpi_isr, 0, 0);
 	irq_enable(USB_IRQ);


### PR DESCRIPTION
So far thread was created as part of `usb_dc_attach()` by `k_thread_create()`.
This means that if following function were executed:

 * `usb_enable()`
 * `usb_disable()`
 * `usb_enable()`

then `k_thread_create()` was called second time. This results in undefined
behavior.

Fix above issue by moving `k_thread_create()` invocation to function called
during system initialization.

While at it, move `IRQ_CONNECT()` and `irq_enable()` invocations to init as
well.

Set thread names, which are useful when debugging or using shell with
`CONFIG_THREAD_NAME=y`.