### PR TITLE
ARM: nxp_imx: rt10xx: remove USB clock dependency on sysclk

### DIFF
--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -719,7 +719,6 @@
 			reg = <0x402E0000 0x200>;
 			interrupts = <113 1>;
 			interrupt-names = "usb_otg";
-			clocks = <&sysclk>;
 			num-bidir-endpoints = <8>;
 			maximum-speed = "full-speed";
 			status = "disabled";
@@ -730,7 +729,6 @@
 			reg = <0x402E0200 0x200>;
 			interrupts = <112 1>;
 			interrupt-names = "usb_otg";
-			clocks = <&sysclk>;
 			num-bidir-endpoints = <8>;
 			maximum-speed = "full-speed";
 			status = "disabled";

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -172,18 +172,14 @@ static ALWAYS_INLINE void clock_init(void)
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usb1), okay) && CONFIG_USB_DC_NXP_EHCI
-	CLOCK_EnableUsbhs0PhyPllClock(kCLOCK_Usb480M,
-		DT_PROP_BY_PHANDLE(DT_NODELABEL(usb1), clocks, clock_frequency));
-	CLOCK_EnableUsbhs0Clock(kCLOCK_Usb480M,
-		DT_PROP_BY_PHANDLE(DT_NODELABEL(usb1), clocks, clock_frequency));
+	CLOCK_EnableUsbhs0PhyPllClock(kCLOCK_Usb480M, 480000000);
+	CLOCK_EnableUsbhs0Clock(kCLOCK_Usb480M, 480000000);
 	USB_EhciPhyInit(kUSB_ControllerEhci0, CPU_XTAL_CLK_HZ, &usbPhyConfig);
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usb2), okay) && CONFIG_USB_DC_NXP_EHCI
-	CLOCK_EnableUsbhs1PhyPllClock(kCLOCK_Usb480M,
-		DT_PROP_BY_PHANDLE(DT_NODELABEL(usb2), clocks, clock_frequency));
-	CLOCK_EnableUsbhs1Clock(kCLOCK_Usb480M,
-		DT_PROP_BY_PHANDLE(DT_NODELABEL(usb2), clocks, clock_frequency));
+	CLOCK_EnableUsbhs1PhyPllClock(kCLOCK_Usb480M, 480000000);
+	CLOCK_EnableUsbhs1Clock(kCLOCK_Usb480M, 480000000);
 	USB_EhciPhyInit(kUSB_ControllerEhci1, CPU_XTAL_CLK_HZ, &usbPhyConfig);
 #endif
 


### PR DESCRIPTION
Both CLOCK_EnableUsbhs0PhyPllClock() and CLOCK_EnableUsbhs0Clock() do not
use any of the arguments passed to those functions, for any of the rt10xx
family devices. If they would, then they would probably expect 24MHz XTAL
frequency or 480MHz PLL3 frequency. Hard to guess HAL API designer
intentions, as even documentation of CLOCK_EnableUsbhs0Clock() says about
'freq' that "parameter is ignored", while in case of
CLOCK_EnableUsbhs0PhyPllClock() it is not clear what 'freq' value is
expected.

Remove 'sysclk' from DT's 'clocks' property, as it makes no sense to
provide ARM clock (which is what 'sysclk' value is set to) to USB/USBPHY
clock initialization functions.