### PR TITLE
ARM: nxp_imx: rt10xx: add XTAL and RTC_XTAL DT clocks

### DIFF
--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -48,6 +48,18 @@
 		#clock-cells = <0>;
 	};
 
+	xtal: clock-xtal {
+		compatible = "fixed-clock";
+		clock-frequency = <24000000>;
+		#clock-cells = <0>;
+	};
+
+	rtc_xtal: clock-rtc-xtal {
+		compatible = "fixed-clock";
+		clock-frequency = <32768>;
+		#clock-cells = <0>;
+	};
+
 	soc {
 		flexram: flexram@400b0000 {
 			compatible = "nxp,imx-flexram";
@@ -232,6 +244,8 @@
 		ccm: ccm@400fc000 {
 			compatible = "nxp,imx-ccm";
 			reg = <0x400fc000 0x4000>;
+			clocks = <&xtal>, <&rtc_xtal>;
+			clock-names = "xtal", "rtc-xtal";
 
 			#clock-cells = <3>;
 		};

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -21,6 +21,8 @@
 #include "usb_dc_mcux.h"
 #endif
 
+#define CCM_NODE	DT_INST(0, nxp_imx_ccm)
+
 #ifdef CONFIG_INIT_ARM_PLL
 /* ARM PLL configuration for RUN mode */
 const clock_arm_pll_config_t armPllConfig = {
@@ -103,8 +105,10 @@ static ALWAYS_INLINE void clock_init(void)
 	/* Boot ROM did initialize the XTAL, here we only sets external XTAL
 	 * OSC freq
 	 */
-	CLOCK_SetXtalFreq(24000000U);
-	CLOCK_SetRtcXtalFreq(32768U);
+	CLOCK_SetXtalFreq(DT_PROP(DT_CLOCKS_CTLR_BY_NAME(CCM_NODE, xtal),
+				  clock_frequency));
+	CLOCK_SetRtcXtalFreq(DT_PROP(DT_CLOCKS_CTLR_BY_NAME(CCM_NODE, rtc_xtal),
+				     clock_frequency));
 
 	/* Set PERIPH_CLK2 MUX to OSC */
 	CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 0x1);


### PR DESCRIPTION
There are two external clocks driving i.MX RT 10xx SoCs: XTAL and
RTC_XTAL. Add "fixed-clock" DT nodes for each. Update also "nxp,imx-ccm"
binding, so that CCM (Clock Control Module) peripheral consumes those
clocks by "xtal" and "rtc-xtal" names.