### PR TITLE
ARM: nxp_imx: rt10xx: remove unused LPUART peripheral header include

### DIFF
--- a/soc/arm/nxp_imx/rt/power_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/power_rt10xx.c
@@ -12,7 +12,6 @@
 #include <fsl_dcdc.h>
 #include <fsl_pmu.h>
 #include <fsl_gpc.h>
-#include <fsl_lpuart.h>
 #include <fsl_clock.h>
 #include <zephyr/logging/log.h>
 


### PR DESCRIPTION
This allows to disable UART peripheral driver and still be able to build
correctly (header is not visible when LPUART driver is not enabled).