### PR TITLE
drivers: mcux_lpuart: clear Received Overrun Flag

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -841,10 +841,8 @@ static void mcux_lpuart_async_tx_timeout(struct k_work *work)
 static void mcux_lpuart_isr(const struct device *dev)
 {
 	struct mcux_lpuart_data *data = dev->data;
-#if CONFIG_PM || CONFIG_UART_ASYNC_API
 	const struct mcux_lpuart_config *config = dev->config;
 	const uint32_t status = LPUART_GetStatusFlags(config->base);
-#endif
 
 #if CONFIG_PM
 	if (status & kLPUART_TransmissionCompleteFlag) {
@@ -864,6 +862,10 @@ static void mcux_lpuart_isr(const struct device *dev)
 #if CONFIG_UART_INTERRUPT_DRIVEN
 	if (data->callback) {
 		data->callback(dev, data->cb_data);
+	}
+
+	if (status & kLPUART_RxOverrunFlag) {
+		LPUART_ClearStatusFlags(config->base, kLPUART_RxOverrunFlag);
 	}
 #endif
 


### PR DESCRIPTION
According to i.MX RT1060 Reference Manual:

>  While the OR flag is set, no additional data is stored in the data
  buffer even if sufficient room exists. To clear OR, write logic 1 to
  the OR flag.

Clear OR (Overrun) flag unconditionally after processing interrupt, so
that data continues to be received after potential data overrun.