### PR TITLE
ARM: nxp_imx: rt10xx: migrate ARM, AHB and IPG dividers to DT

### DIFF
--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -22,6 +22,14 @@
 	reg = <0x20200000 DT_SIZE_K(64)>;
 };
 
+&ccm {
+	/delete-node/ arm-podf;
+
+	ipg-podf {
+		clock-div = <4>;
+	};
+};
+
 &gpio1 {
 	interrupts = <70 0>, <71 0>;
 };

--- a/dts/arm/nxp/nxp_rt1015.dtsi
+++ b/dts/arm/nxp/nxp_rt1015.dtsi
@@ -23,6 +23,12 @@
 	reg = <0x20200000 DT_SIZE_K(64)>;
 };
 
+&ccm {
+	ipg-podf {
+		clock-div = <4>;
+	};
+};
+
 &gpt2 {
 	gptfreq = <12500000>;
 };

--- a/dts/arm/nxp/nxp_rt1020.dtsi
+++ b/dts/arm/nxp/nxp_rt1020.dtsi
@@ -23,6 +23,12 @@
 	reg = <0x20200000 DT_SIZE_K(128)>;
 };
 
+&ccm {
+	ipg-podf {
+		clock-div = <4>;
+	};
+};
+
 &gpt2 {
 	gptfreq = <12500000>;
 };

--- a/dts/arm/nxp/nxp_rt1024.dtsi
+++ b/dts/arm/nxp/nxp_rt1024.dtsi
@@ -28,6 +28,12 @@
 	reg = <0x20200000 DT_SIZE_K(128)>;
 };
 
+&ccm {
+	ipg-podf {
+		clock-div = <4>;
+	};
+};
+
 &flexspi {
 	status = "okay";
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(4)>;

--- a/dts/arm/nxp/nxp_rt1050.dtsi
+++ b/dts/arm/nxp/nxp_rt1050.dtsi
@@ -5,6 +5,16 @@
  */
 #include <nxp/nxp_rt10xx.dtsi>
 
+&ccm {
+	arm-podf {
+		clock-div = <2>;
+	};
+
+	ipg-podf {
+		clock-div = <4>;
+	};
+};
+
 / {
 	soc {
 		/* GPIOS 6-9 are not preset on RT1050 */

--- a/dts/arm/nxp/nxp_rt1060.dtsi
+++ b/dts/arm/nxp/nxp_rt1060.dtsi
@@ -17,6 +17,16 @@
 	reg = <0x20200000 DT_SIZE_K(768)>;
 };
 
+&ccm {
+	arm-podf {
+		clock-div = <2>;
+	};
+
+	ipg-podf {
+		clock-div = <4>;
+	};
+};
+
 /* i.MX rt1060 has a second Ethernet controller. */
 / {
 	soc {

--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -7,6 +7,16 @@
 
 #include <nxp/nxp_rt1060.dtsi>
 
+&ccm {
+	arm-podf {
+		clock-div = <2>;
+	};
+
+	ipg-podf {
+		clock-div = <4>;
+	};
+};
+
 &flexspi2 {
 	status = "okay";
 	reg = <0x402a4000 0x4000>, <0x70000000 DT_SIZE_M(4)>;

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -254,6 +254,24 @@
 			clocks = <&xtal>, <&rtc_xtal>;
 			clock-names = "xtal", "rtc-xtal";
 
+			arm-podf {
+				compatible = "fixed-factor-clock";
+				clock-div = <1>;
+				#clock-cells = <0>;
+			};
+
+			ahb-podf {
+				compatible = "fixed-factor-clock";
+				clock-div = <1>;
+				#clock-cells = <0>;
+			};
+
+			ipg-podf {
+				compatible = "fixed-factor-clock";
+				clock-div = <1>;
+				#clock-cells = <0>;
+			};
+
 			#clock-cells = <3>;
 		};
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1010
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1010
@@ -9,20 +9,8 @@ config SOC
 	string
 	default "mimxrt1011"
 
-config HAS_ARM_DIV
-	default n
-
 config NUM_IRQS
 	default 80
-
-config ARM_DIV
-	default 0
-
-config AHB_DIV
-	default 0
-
-config IPG_DIV
-	default 3
 
 config DCDC_VALUE
 	default 0x12

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1015
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1015
@@ -11,15 +11,6 @@ config SOC
 config NUM_IRQS
 	default 142
 
-config ARM_DIV
-	default 0
-
-config AHB_DIV
-	default 0
-
-config IPG_DIV
-	default 3
-
 config DCDC_VALUE
 	default 0x12
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1021
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1021
@@ -11,15 +11,6 @@ config SOC
 config NUM_IRQS
 	default 142
 
-config ARM_DIV
-	default 0
-
-config AHB_DIV
-	default 0
-
-config IPG_DIV
-	default 3
-
 config DCDC_VALUE
 	default 0x12
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1024
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1024
@@ -11,15 +11,6 @@ config SOC
 config NUM_IRQS
 	default 142
 
-config ARM_DIV
-	default 0
-
-config AHB_DIV
-	default 0
-
-config IPG_DIV
-	default 3
-
 config DCDC_VALUE
 	default 0x12
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1052
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1052
@@ -11,15 +11,6 @@ config SOC
 config NUM_IRQS
 	default 160
 
-config ARM_DIV
-	default 1
-
-config AHB_DIV
-	default 0
-
-config IPG_DIV
-	default 3
-
 config GPIO
 	default y
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1062
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1062
@@ -11,15 +11,6 @@ config SOC
 config NUM_IRQS
 	default 160
 
-config ARM_DIV
-	default 1
-
-config AHB_DIV
-	default 0
-
-config IPG_DIV
-	default 3
-
 config GPIO
 	default y
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1064
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1064
@@ -11,15 +11,6 @@ config SOC
 config NUM_IRQS
 	default 160
 
-config ARM_DIV
-	default 1
-
-config AHB_DIV
-	default 0
-
-config IPG_DIV
-	default 3
-
 config GPIO
 	default y
 

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -626,25 +626,6 @@ config INIT_ENET_PLL
 	  MIMXRT1021 - see commit 17f4d6bec7 ("soc: nxp_imx: fix ENET_PLL selection
 	  for MIMXRT1021").
 
-config HAS_ARM_DIV
-	bool "Has the divider for ARM"
-	default y
-
-config ARM_DIV
-	int "ARM clock divider"
-	range 0 7
-	default 0
-
-config AHB_DIV
-	int "AHB clock divider"
-	range 0 7
-	default 0
-
-config IPG_DIV
-	int "IPG clock divider"
-	range 0 3
-	default 0
-
 config DCDC_VALUE
 	hex "DCDC value for VDD_SOC"
 	default 0x13

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -23,6 +23,11 @@
 
 #define CCM_NODE	DT_INST(0, nxp_imx_ccm)
 
+#define BUILD_ASSERT_PODF_IN_RANGE(podf, a, b)				\
+	BUILD_ASSERT(DT_PROP(DT_CHILD(CCM_NODE, podf), clock_div) >= (a) && \
+		     DT_PROP(DT_CHILD(CCM_NODE, podf), clock_div) <= (b), \
+		     #podf " is out of supported range (" #a ", " #b ")")
+
 #ifdef CONFIG_INIT_ARM_PLL
 /* ARM PLL configuration for RUN mode */
 const clock_arm_pll_config_t armPllConfig = {
@@ -135,11 +140,17 @@ static ALWAYS_INLINE void clock_init(void)
 	CLOCK_InitVideoPll(&videoPllConfig);
 #endif
 
-#ifdef CONFIG_HAS_ARM_DIV
-	CLOCK_SetDiv(kCLOCK_ArmDiv, CONFIG_ARM_DIV); /* Set ARM PODF */
+#if DT_NODE_EXISTS(DT_CHILD(CCM_NODE, arm_podf))
+	/* Set ARM PODF */
+	BUILD_ASSERT_PODF_IN_RANGE(arm_podf, 1, 8);
+	CLOCK_SetDiv(kCLOCK_ArmDiv, DT_PROP(DT_CHILD(CCM_NODE, arm_podf), clock_div) - 1);
 #endif
-	CLOCK_SetDiv(kCLOCK_AhbDiv, CONFIG_AHB_DIV); /* Set AHB PODF */
-	CLOCK_SetDiv(kCLOCK_IpgDiv, CONFIG_IPG_DIV); /* Set IPG PODF */
+	/* Set AHB PODF */
+	BUILD_ASSERT_PODF_IN_RANGE(ahb_podf, 1, 8);
+	CLOCK_SetDiv(kCLOCK_AhbDiv, DT_PROP(DT_CHILD(CCM_NODE, ahb_podf), clock_div) - 1);
+	/* Set IPG PODF */
+	BUILD_ASSERT_PODF_IN_RANGE(ipg_podf, 1, 4);
+	CLOCK_SetDiv(kCLOCK_IpgDiv, DT_PROP(DT_CHILD(CCM_NODE, ipg_podf), clock_div) - 1);
 
 	/* Set PRE_PERIPH_CLK to PLL1, 1200M */
 	CLOCK_SetMux(kCLOCK_PrePeriphMux, 0x3);


### PR DESCRIPTION
Those dividers were configured in Kconfig so far. Add 'arm-podf',
'ahb-podf' and 'ipg-podf' "fixed-factor-clock" compatible DT child nodes
under 'ccm' (Clock Control Module) and use configured 'clock-div' values
instead of Kconfig equivalents.