### PR TITLE
drivers: regulator: enable support for regulator modes

### DIFF
--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -156,9 +156,9 @@ arduino_serial: &flexcomm12 {
 
 	pca9420: pca9420@61 {
 		reg = <0x61>;
+		compatible = "regulator-pmic";
 
 		pca9420_sw1: sw1_buck {
-			compatible = "regulator-pmic";
 			voltage-range = <PCA9420_SW1_VOLTAGE_RANGE>;
 			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
 			num-voltages = <42>;
@@ -175,7 +175,6 @@ arduino_serial: &flexcomm12 {
 		};
 
 		pca9420_sw2: sw2_buck {
-			compatible = "regulator-pmic";
 			voltage-range = <PCA9420_SW2_VOLTAGE_RANGE>;
 			num-voltages = <50>;
 			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
@@ -192,7 +191,6 @@ arduino_serial: &flexcomm12 {
 		};
 
 		pca9420_ldo1: ldo1_reg {
-			compatible = "regulator-pmic";
 			voltage-range = <PCA9420_LDO1_VOLTAGE_RANGE>;
 			num-voltages = <9>;
 			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
@@ -209,7 +207,6 @@ arduino_serial: &flexcomm12 {
 		};
 
 		pca9420_ldo2: ldo2_reg {
-			compatible = "regulator-pmic";
 			voltage-range = <PCA9420_LDO2_VOLTAGE_RANGE>;
 			num-voltages = <50>;
 			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;

--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -157,7 +157,26 @@ arduino_serial: &flexcomm12 {
 	pca9420: pca9420@61 {
 		reg = <0x61>;
 		compatible = "regulator-pmic";
-
+		/*
+		 * This mode-reg setting will permit mode control by
+		 * pins, a feature of the PCA9240. If mode control via
+		 * I2C is desired, the following settings
+		 * should be used:
+		 * regulator-initial-mode = <PCA9420_MODECFG0_I2C>;
+		 * regulator-allowed-modes = <PCA9420_MODECFG0_I2C>,
+		 *			<PCA9420_MODECFG1_I2C>,
+		 *			<PCA9420_MODECFG2_I2C>,
+		 *			<PCA9420_MODECFG3_I2C>;
+		 * modesel-reg = <PCA9420_TOP_CNTL3>;
+		 * modesel-mask = <PCA9420_TOP_CNTL3_MODE_I2C_MASK>;
+		 */
+		regulator-allowed-modes = <PCA9420_MODECFG0_PIN>,
+					<PCA9420_MODECFG1_PIN>,
+					<PCA9420_MODECFG2_PIN>,
+					<PCA9420_MODECFG3_PIN>;
+		regulator-initial-mode = <PCA9420_MODECFG0_PIN>;
+		modesel-reg = <PCA9420_MODECFG_0_0>;
+		modesel-mask = <PCA9420_MODECFG_0_MODE_CTRL_SEL_MASK>;
 		pca9420_sw1: sw1_buck {
 			voltage-range = <PCA9420_SW1_VOLTAGE_RANGE>;
 			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
@@ -208,7 +227,7 @@ arduino_serial: &flexcomm12 {
 
 		pca9420_ldo2: ldo2_reg {
 			voltage-range = <PCA9420_LDO2_VOLTAGE_RANGE>;
-			num-voltages = <50>;
+			num-voltages = <51>;
 			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
 			ilim-reg = <PCA9420_TOP_CNTL0>;
 			ilim-mask = <PCA9420_TOP_CNTL0_VIN_ILIM_SEL_MASK>;

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -230,9 +230,9 @@ i2s1: &flexcomm3 {
 
 	pca9420: pca9420@61 {
 		reg = <0x61>;
+		compatible = "regulator-pmic";
 
 		pca9420_sw1: sw1_buck {
-			compatible = "regulator-pmic";
 			voltage-range = <PCA9420_SW1_VOLTAGE_RANGE>;
 			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
 			num-voltages = <42>;
@@ -249,7 +249,6 @@ i2s1: &flexcomm3 {
 		};
 
 		pca9420_sw2: sw2_buck {
-			compatible = "regulator-pmic";
 			voltage-range = <PCA9420_SW2_VOLTAGE_RANGE>;
 			num-voltages = <50>;
 			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
@@ -266,7 +265,6 @@ i2s1: &flexcomm3 {
 		};
 
 		pca9420_ldo1: ldo1_reg {
-			compatible = "regulator-pmic";
 			voltage-range = <PCA9420_LDO1_VOLTAGE_RANGE>;
 			num-voltages = <9>;
 			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
@@ -283,7 +281,6 @@ i2s1: &flexcomm3 {
 		};
 
 		pca9420_ldo2: ldo2_reg {
-			compatible = "regulator-pmic";
 			voltage-range = <PCA9420_LDO2_VOLTAGE_RANGE>;
 			num-voltages = <50>;
 			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -231,7 +231,26 @@ i2s1: &flexcomm3 {
 	pca9420: pca9420@61 {
 		reg = <0x61>;
 		compatible = "regulator-pmic";
-
+		/*
+		 * This mode-reg setting will permit mode control by
+		 * pins, a feature of the PCA9240. If mode control via
+		 * I2C is desired, the following settings
+		 * should be used:
+		 * regulator-initial-mode = <PCA9420_MODECFG0_I2C>;
+		 * regulator-allowed-modes = <PCA9420_MODECFG0_I2C>,
+		 *			<PCA9420_MODECFG1_I2C>,
+		 *			<PCA9420_MODECFG2_I2C>,
+		 *			<PCA9420_MODECFG3_I2C>;
+		 * modesel-reg = <PCA9420_TOP_CNTL3>;
+		 * modesel-mask = <PCA9420_TOP_CNTL3_MODE_I2C_MASK>;
+		 */
+		regulator-allowed-modes = <PCA9420_MODECFG0_PIN>,
+					<PCA9420_MODECFG1_PIN>,
+					<PCA9420_MODECFG2_PIN>,
+					<PCA9420_MODECFG3_PIN>;
+		regulator-initial-mode = <PCA9420_MODECFG0_PIN>;
+		modesel-reg = <PCA9420_MODECFG_0_0>;
+		modesel-mask = <PCA9420_MODECFG_0_MODE_CTRL_SEL_MASK>;
 		pca9420_sw1: sw1_buck {
 			voltage-range = <PCA9420_SW1_VOLTAGE_RANGE>;
 			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
@@ -282,7 +301,7 @@ i2s1: &flexcomm3 {
 
 		pca9420_ldo2: ldo2_reg {
 			voltage-range = <PCA9420_LDO2_VOLTAGE_RANGE>;
-			num-voltages = <50>;
+			num-voltages = <51>;
 			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
 			ilim-reg = <PCA9420_TOP_CNTL0>;
 			ilim-mask = <PCA9420_TOP_CNTL0_VIN_ILIM_SEL_MASK>;

--- a/drivers/regulator/regulator_pmic.c
+++ b/drivers/regulator/regulator_pmic.c
@@ -59,6 +59,16 @@ struct regulator_config {
 };
 
 /**
+ * Reads a register from the PMIC
+ * Returns 0 on success, or errno on error
+ */
+static int regulator_read_register(const struct regulator_config *conf,
+	uint8_t reg, uint8_t *out)
+{
+	return i2c_reg_read_byte_dt(&conf->i2c, reg, out);
+}
+
+/**
  * Modifies a register within the PMIC
  * Returns 0 on success, or errno on error
  */
@@ -68,7 +78,7 @@ static int regulator_modify_register(const struct regulator_config *conf,
 	uint8_t reg_current;
 	int rc;
 
-	rc = i2c_reg_read_byte_dt(&conf->i2c, reg, &reg_current);
+	rc = regulator_read_register(conf, reg, &reg_current);
 	if (rc) {
 		return rc;
 	}
@@ -162,7 +172,7 @@ int regulator_get_voltage(const struct device *dev)
 	int rc, i = 0;
 	uint8_t raw_reg;
 
-	rc = i2c_reg_read_byte_dt(&config->i2c, config->vsel_reg, &raw_reg);
+	rc = regulator_read_register(config, config->vsel_reg, &raw_reg);
 	if (rc) {
 		return rc;
 	}
@@ -221,7 +231,7 @@ int regulator_get_current_limit(const struct device *dev)
 	if (config->num_current_levels == 0) {
 		return -ENOTSUP;
 	}
-	rc = i2c_reg_read_byte_dt(&config->i2c, config->ilim_reg, &raw_reg);
+	rc = regulator_read_register(config, config->ilim_reg, &raw_reg);
 	if (rc) {
 		return rc;
 	}

--- a/dts/bindings/regulator/regulator-pmic.yaml
+++ b/dts/bindings/regulator/regulator-pmic.yaml
@@ -7,6 +7,36 @@ include: regulator.yaml
 
 compatible: "regulator-pmic"
 
+properties:
+  regulator-initial-mode:
+      type: int
+      required: false
+      description: |
+        Initial operating mode of the regulator. Regulators modes can be
+        used for better power saving, or different voltage configurations,
+        and are hardware specific.
+  regulator-allowed-modes:
+      type: array
+      required: false
+      description: |
+        Array of operating modes that software may configure for the
+        regulator at runtime. The set of possible operating modes depends on
+        what the hardware supports.
+
+  modesel-reg:
+    type: int
+    required: false
+    description: |
+      Mode selection register. This register is used by the regulator driver
+      to select the target mode of the regulator
+
+  modesel-mask:
+    type: int
+    required: false
+    description: |
+      Mode selection mask. Applied to a mode selection when it is written
+      to the modesel-reg.
+
 child-binding:
   description: Voltage output of PMIC controller regulator
   properties:

--- a/dts/bindings/regulator/regulator-pmic.yaml
+++ b/dts/bindings/regulator/regulator-pmic.yaml
@@ -7,84 +7,86 @@ include: regulator.yaml
 
 compatible: "regulator-pmic"
 
-properties:
-    voltage-range:
-        type: array
-        required: true
-        description: |
-           array of voltage values in uV, followed by the register value that
-           must be written to enable the voltage. For example, [3300000, 0x3]
-           denotes a value of 0x3 must be written to the register to set 3.3V
-    num-voltages:
-        type: int
-        required: true
-        description: number of voltages present in the voltage-range array.
-    vsel-reg:
-        type: int
-        required: true
-        description: I2C register to write voltage selection value to
-    vsel-mask:
-        type: int
-        required: true
-        description: |
-          Mask to apply to the voltage range value when written to vsel
-          register
-    enable-reg:
-        type: int
-        required: true
-        description: I2C register to write enable value to
-    enable-mask:
-        type: int
-        required: true
-        description: |
-          Mask to apply to the enable bit (either 1 for enabled,
-          or 0 for disabled) when writing it to the I2C enable register.
-    enable-val:
-        type: int
-        required: true
-        description: |
-          value to apply enable-mask to, and write to enable-reg in order
-          to enable the regulator output.
-    min-uV:
-        type: int
-        required: true
-        description: |
-           Minimum voltage in microvolts that this regulator supports
-    max-uV:
-        type: int
-        required: true
-        description: |
-           Maximum voltage in microvolts that this regulator supports
-    enable-inverted:
-        type: boolean
-        required: false
-        description: |
-          If the enable bit should be zero to turn the regulator on, add this
-          property.
-    current-levels:
-        type: array
-        required: false
-        description: |
-          Array of current limit values in uA, followed by the register value
-          that must be written to enable the current limit. For example,
-          [800000, 0x3] denotes a value of 0x3 must be written to the register
-          to set a current limit of 800mA
-    num-current-levels:
-        type: int
-        required: false
-        default: 0
-        description: |
-          Number of current limit levels this regulator supports. If left as
-          default, regulator current support will be disabled.
-    ilim-reg:
-        type: int
-        required: false
-        description: |
-          Register to write the register value given in current-levels into
-          to set the current limit
-    ilim-mask:
-        type: int
-        required: false
-        description: |
-          Mask to apply to the current-levels value before writing it to the
-          ilim-reg value to set the current limit
+child-binding:
+  description: Voltage output of PMIC controller regulator
+  properties:
+      voltage-range:
+          type: array
+          required: true
+          description: |
+             array of voltage values in uV, followed by the register value that
+             must be written to enable the voltage. For example, [3300000, 0x3]
+             denotes a value of 0x3 must be written to the register to set 3.3V
+      num-voltages:
+          type: int
+          required: true
+          description: number of voltages present in the voltage-range array.
+      vsel-reg:
+          type: int
+          required: true
+          description: I2C register to write voltage selection value to
+      vsel-mask:
+          type: int
+          required: true
+          description: |
+            Mask to apply to the voltage range value when written to vsel
+            register
+      enable-reg:
+          type: int
+          required: true
+          description: I2C register to write enable value to
+      enable-mask:
+          type: int
+          required: true
+          description: |
+            Mask to apply to the enable bit (either 1 for enabled,
+            or 0 for disabled) when writing it to the I2C enable register.
+      enable-val:
+          type: int
+          required: true
+          description: |
+            value to apply enable-mask to, and write to enable-reg in order
+            to enable the regulator output.
+      min-uV:
+          type: int
+          required: true
+          description: |
+             Minimum voltage in microvolts that this regulator supports
+      max-uV:
+          type: int
+          required: true
+          description: |
+             Maximum voltage in microvolts that this regulator supports
+      enable-inverted:
+          type: boolean
+          required: false
+          description: |
+            If the enable bit should be zero to turn the regulator on, add this
+            property.
+      current-levels:
+          type: array
+          required: false
+          description: |
+            Array of current limit values in uA, followed by the register value
+            that must be written to enable the current limit. For example,
+            [800000, 0x3] denotes a value of 0x3 must be written to the register
+            to set a current limit of 800mA
+      num-current-levels:
+          type: int
+          required: false
+          default: 0
+          description: |
+            Number of current limit levels this regulator supports. If left as
+            default, regulator current support will be disabled.
+      ilim-reg:
+          type: int
+          required: false
+          description: |
+            Register to write the register value given in current-levels into
+            to set the current limit
+      ilim-mask:
+          type: int
+          required: false
+          description: |
+            Mask to apply to the current-levels value before writing it to the
+            ilim-reg value to set the current limit

--- a/include/zephyr/drivers/regulator/consumer.h
+++ b/include/zephyr/drivers/regulator/consumer.h
@@ -35,6 +35,17 @@ extern "C" {
 int regulator_count_voltages(const struct device *dev);
 
 /**
+ * @brief Return the number of supported regulator modes
+ * Returns the number of supported regulator modes. Many regulators will only
+ * support one mode. Regulator modes can be set and selected with
+ * regulator_set_mode
+ *
+ * @param dev: Regulator device to count supported regulator modes for
+ * @return number of supported modes
+ */
+int regulator_count_modes(const struct device *dev);
+
+/**
  * @brief Return supported voltage
  * Returns a voltage that can be passed to @ref regulator_set_voltage(), zero
  * if the selector code can't be used, or a negative errno.
@@ -90,6 +101,21 @@ int regulator_set_current_limit(const struct device *dev, int min_uA, int max_uA
  * @return current limit in uA, or errno
  */
 int regulator_get_current_limit(const struct device *dev);
+
+/**
+ * @brief Select mode of regulator
+ * Regulators can support multiple modes in order to permit different voltage
+ * configuration or better power savings. This API will apply a mode for
+ * the regulator, and also configure the remainder of the regulator APIs,
+ * such as those disabling, changing voltage/current targets, or querying
+ * voltage/current targets to target that mode.
+ * @param dev: regulator to switch mode for
+ * @param mode: Mode to select for this regulator. Only modes present
+ * in the regulator-allowed-modes property are permitted.
+ * @return 0 on success, or errno on error
+ */
+int regulator_set_mode(const struct device *dev, uint32_t mode);
+
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/dt-bindings/regulator/pca9420_i2c.h
+++ b/include/zephyr/dt-bindings/regulator/pca9420_i2c.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_PCA9420_I2C_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_REGULATOR_PCA9420_I2C_H_
 
+#include "pmic_i2c.h"
+
 /*
  * Voltage Ranges should be defined without commas, spaces, or brackets. These
  * ranges will be inserted directly into the devicetree as arrays, so that the
@@ -33,7 +35,7 @@
 	925000 0x11		/* SW1 output voltage 0.925V. */\
 	950000 0x12		/* SW1 output voltage 0.950V. */\
 	975000 0x13		/* SW1 output voltage 0.975V. */\
-	1000000 0x14		/* SW1 output voltage 1.000V. */\
+	1000000 0x14		/* SW1 output voltage 1.000V. (Default) */\
 	1025000 0x15		/* SW1 output voltage 1.025V. */\
 	1050000 0x16		/* SW1 output voltage 1.050V. */\
 	1075000 0x17		/* SW1 output voltage 1.075V. */\
@@ -69,7 +71,7 @@
 	1725000 0x09		/* SW2 output voltage 1.725V. */\
 	1750000 0x0A		/* SW2 output voltage 1.750V. */\
 	1775000 0x0B		/* SW2 output voltage 1.775V. */\
-	1800000 0x0C		/* SW2 output voltage 1.800V. */\
+	1800000 0x0C		/* SW2 output voltage 1.800V. (Default) */\
 	1825000 0x0D		/* SW2 output voltage 1.825V. */\
 	1850000 0x0E		/* SW2 output voltage 1.850V. */\
 	1875000 0x0F		/* SW2 output voltage 1.875V. */\
@@ -113,7 +115,7 @@
 	1725000 0x10		/* LDO1 output voltage 1.725V. */\
 	1750000 0x20		/* LDO1 output voltage 1.750V. */\
 	1775000 0x30		/* LDO1 output voltage 1.775V. */\
-	1800000 0x40		/* LDO1 output voltage 1.800V. */\
+	1800000 0x40		/* LDO1 output voltage 1.800V. (Default) */\
 	1825000 0x50		/* LDO1 output voltage 1.825V. */\
 	1850000 0x60		/* LDO1 output voltage 1.850V. */\
 	1875000 0x70		/* LDO1 output voltage 1.875V. */\
@@ -170,6 +172,7 @@
 	3250000 0x36		/* LDO2 output voltage 3.250V. */\
 	3275000 0x37		/* LDO2 output voltage 3.275V. */\
 	3300000 0x38		/* LDO2 output voltage 3.300V. */\
+	3300000 0x39		/* LDO2 output voltage 3.300V. (Default) */\
 
 #define PCA9420_CURRENT_LIMIT_LEVELS \
 	85000 0x00		/* min: 74mA, typ: 85mA, max: 98mA */\
@@ -180,7 +183,29 @@
 	935000 0xA0		/* min: 813mA, typ: 935mA, max: 1075mA */\
 	1105000 0xC0		/* min: 961mA, typ: 1105mA, max: 1271mA */\
 
+#define PCA9420_MODECFG0 \
+	(PMIC_MODE(0x0, 0x0, 0x0)) /* ModeCfg 0, selected via I2C */
+#define PCA9420_MODECFG1 \
+	(PMIC_MODE(0x4, 0x0, 0x8)) /* ModeCfg 1, selected via I2C */
+#define PCA9420_MODECFG2 \
+	(PMIC_MODE(0x8, 0x0, 0x10)) /* ModeCfg 2, selected via I2C */
+#define PCA9420_MODECFG3 \
+	(PMIC_MODE(0xC, 0x0, 0x18)) /* ModeCfg 3, selected via I2C */
 
+/* ModeCfg 0, selected via PIN */
+#define PCA9420_MODECFG0_PIN \
+	(PMIC_MODE(0x0, PMIC_MODE_FLAG_MODESEL_MULTI_REG, 0x40))
+/* ModeCfg 1, selected via PIN */
+#define PCA9420_MODECFG1_PIN \
+	(PMIC_MODE(0x4, PMIC_MODE_FLAG_MODESEL_MULTI_REG, 0x40))
+/* ModeCfg 2, selected via PIN */
+#define PCA9420_MODECFG2_PIN \
+	(PMIC_MODE(0x8, PMIC_MODE_FLAG_MODESEL_MULTI_REG, 0x40))
+/* ModeCfg 3, selected via PIN */
+#define PCA9420_MODECFG3_PIN \
+	(PMIC_MODE(0xC, PMIC_MODE_FLAG_MODESEL_MULTI_REG, 0x40))
+
+#define PCA9420_MODE_OFFSET 0x4
 
 /** Register memory map. See datasheet for more details. */
 /** General purpose registers */

--- a/include/zephyr/dt-bindings/regulator/pmic_i2c.h
+++ b/include/zephyr/dt-bindings/regulator/pmic_i2c.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PMIC_I2C_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_PMIC_I2C_H_
+
+#define PMIC_MODE_OFFSET_MASK 0x1E00
+#define PMIC_MODE_OFFSET_SHIFT 0x9
+
+/*
+ * PMIC mode offset macro. This macro will encode a PMIC mode offset into
+ * a given PMIC mode. When selecting a mode for the regulator, all registers
+ * will have an offset applied (vsel, ilim, enable), so that the new mode
+ * can be configured. This macro encodes that offset for a given mode.
+ * @param off: Offset to apply to PMIC config regs when selecting mode
+ */
+#define PMIC_MODE_OFFSET(off) \
+	((off << PMIC_MODE_OFFSET_SHIFT) & PMIC_MODE_OFFSET_MASK)
+
+
+/*
+ * PMIC mode selection multi-register flag. This flag indicates that the
+ * mode selection register for this mode requires an offset applied to it.
+ * When this flag is set for a given mode, the value passed as the PMIC
+ * mode selector will be written into the register:
+ * <modesel-reg> + <pmic mode offset value>. If the flag is not passed,
+ * the value of the PMIC mode selector will be written directly to
+ * <modesel-reg> with no offset applied.
+ */
+#define PMIC_MODE_FLAG_MODESEL_MULTI_REG 0x100
+
+/*
+ * PMIC flags mask. These bits are used to indicate features or requirements
+ * of PMIC modes.
+ */
+#define PMIC_MODE_FLAGS_MASK 0xF00
+
+#define PMIC_MODE_SELECTOR_MASK 0xFF
+
+/*
+ * PMIC mode selector macro. This macro should be passed a value to be written
+ * to the PMIC modesel-reg, in order to select a given mode. When the regulator
+ * driver mode is switched, this value will be written to <modesel-reg>, or
+ * <modesel-reg> + <pmic mode offset value> if MODESEL_MULTI_REG flag is set.
+ * this will switch the PMIC to the new mode, which can then be configured with
+ * the voltage and current limit setting APIs.
+ * @param mode: mode selection value, to be written to modesel-reg
+ */
+#define PMIC_MODE_SELECTOR(mode) (mode & PMIC_MODE_SELECTOR_MASK)
+
+
+/*
+ * PMIC mode macro. This macro should be used to create a PMIC mode definition
+ * for each PMIC mode. Each mode encodes the offset that must be applied to
+ * the regulator's configuration registers to manage the specific mode, as well
+ * as the value to write to the regulators' <modesel-reg>. Finally, the flags
+ * field controls specific behaviors of the PMIC mode, which are defined
+ * with the pattern PMIC_MODE_FLAG_xxx.
+ *
+ * @param offset: offset to apply to regulator configuration registers to
+ *	configure the target PMIC mode's voltage and current
+ * @param flags: pmic mode flags, used to indicate specific behaviors of
+ *	a given mode.
+ * @param selection_val: selection value, this is the actual value to be
+ *	written to the pmic's <modesel-reg> to select the given mode.
+ */
+
+#define PMIC_MODE(offset, flags, selection_val) \
+	PMIC_MODE_OFFSET(offset) | \
+	(flags & PMIC_MODE_FLAGS_MASK) | \
+	PMIC_MODE_SELECTOR(selection_val)
+
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PMIC_I2C_H_ */


### PR DESCRIPTION
Enable support for regulator modes. Some regulators, such as the PCA9420, offer support for several modes, with each mode containing a discrete set of voltage levels. This PR adds support for managing regulator modes to the `regulator_pmic` driver, and enables it for the PCA9420.