### PR TITLE
tests: drivers: adc-dma: fix the dma dest address check failure

### DIFF
--- a/tests/drivers/adc/adc_dma/boards/frdm_k64f.overlay
+++ b/tests/drivers/adc/adc_dma/boards/frdm_k64f.overlay
@@ -10,3 +10,9 @@
 	high-speed;
 	periodic-trigger;
 };
+
+&edma0 {
+	dma-buf-alignment = <4>;
+};
+
+test_dma: &edma0 { };

--- a/tests/drivers/adc/adc_dma/boards/frdm_k82f.overlay
+++ b/tests/drivers/adc/adc_dma/boards/frdm_k82f.overlay
@@ -10,3 +10,9 @@
 	high-speed;
 	periodic-trigger;
 };
+
+&edma0 {
+        dma-buf-alignment = <4>;
+};
+
+test_dma: &edma0 { };

--- a/tests/drivers/adc/adc_dma/src/test_adc.c
+++ b/tests/drivers/adc/adc_dma/src/test_adc.c
@@ -7,6 +7,7 @@
  */
 
 
+#include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/kernel.h>
@@ -37,8 +38,9 @@
 #define SAMPLE_INTERVAL_US (10000U)
 
 #define BUFFER_SIZE 24
-static ZTEST_BMEM int16_t m_sample_buffer[BUFFER_SIZE];
-static ZTEST_BMEM int16_t m_sample_buffer2[2][BUFFER_SIZE];
+#define ALIGNMENT DMA_BUF_ALIGNMENT(DT_NODELABEL(test_dma))
+static ZTEST_BMEM __aligned(ALIGNMENT) int16_t m_sample_buffer[BUFFER_SIZE];
+static ZTEST_BMEM __aligned(ALIGNMENT) int16_t m_sample_buffer2[2][BUFFER_SIZE];
 static int current_buf_inx;
 
 static const struct adc_channel_cfg m_1st_channel_cfg = {


### PR DESCRIPTION
force the dma destination address 32 bit aligned

Fixes #49792

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>