### PR TITLE
dts: arm: npcx: fix clock source of spi_fiu node

### DIFF
--- a/dts/arm/nuvoton/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx.dtsi
@@ -503,7 +503,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40020000 0x2000>;
-			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL1 2>;
+			clocks = <&pcc NPCX_CLOCK_BUS_FIU NPCX_PWDWN_CTL1 2>;
 		};
 
 		peci0: peci@400d4000 {


### PR DESCRIPTION
The clock bus of the specific SPI module (FIU) is under FIUCLK. The
previous commit misconfigured it to APB3_CLK. Although it won't
cause any issue as the driver doesn't use it. It should be fixed to
prevent confusion when reading the datasheet.

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>