### PR TITLE
shields: adafruit_2_8_tft: fix build failure

### DIFF
--- a/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
@@ -9,6 +9,7 @@
 / {
 	chosen {
 		zephyr,display = &ili9340;
+		zephyr,keyboard-scan = &touch_controller;
 	};
 };
 


### PR DESCRIPTION
We're now taking the kscan device from the zephyr,keyboard-scan node. Add it to the overlay.