### PR TITLE
samples: stm32 serial wakeup: Don't run on stm32l562e_dk in CI

### DIFF
--- a/samples/boards/stm32/power_mgmt/serial_wakeup/sample.yaml
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/sample.yaml
@@ -14,4 +14,4 @@ tests:
       - nucleo_wb55rg
     filter: dt_compat_enabled("zephyr,power-state")
     extra_args: "CONFIG_DEBUG=y"
-    platform_allow: nucleo_wb55rg stm32l562e_dk
+    platform_allow: nucleo_wb55rg


### PR DESCRIPTION
On STM32 PM serial wakeup sample, a power efficient configuration using
lpuart is provided for stm32l562e_dk target.
Though, since default configuration of the board is using ST-Link virtual
port com on uart1, which can't be changed in CI and hence can't be tested,
then remove this target from sample yaml configuration

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>