### PR TITLE
tests: subsys: usb: device: add zassert to judge whether USB enable

### DIFF
--- a/tests/subsys/usb/device/src/main.c
+++ b/tests/subsys/usb/device/src/main.c
@@ -195,7 +195,10 @@ static void *device_usb_setup(void)
 	int ret;
 
 	ret = usb_enable(NULL);
-	zassume_true(ret == 0, "Failed to enable USB");
+	zassert_true(ret == 0, "Failed to enable USB");
+	/*
+	 *Judge failure whether is due to failing to enable USB.
+	 */
 
 	return NULL;
 }


### PR DESCRIPTION
Change zassume to zassert to judge the failure whether is due to failing to enable USB.
Because zassume is only used to check behavior that is already tested elsewhere and zassume skips the test/testsuite. So if we want to have a single assertion or limited root cause assertion failures to find why a test isn't passing, we should use zassert.

Signed-off-by: Zhao Shuai <shuai1x.zhao@intel.com>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/48665