### PR TITLE
samples: sensors: lsm6dso: Fix regex filter following unit fix

### DIFF
--- a/samples/sensor/lsm6dso/sample.yaml
+++ b/samples/sensor/lsm6dso/sample.yaml
@@ -11,5 +11,5 @@ tests:
       ordered: true
       regex:
         - "accel x:[-.0-9]* ms/2 y:[-.0-9]* ms/2 z:[-.0-9]* ms/2"
-        - "gyro x:[-.0-9]* dps y:[-.0-9]* dps z:[-.0-9]* dps"
+        - "gyro x:[-.0-9]* rad/s y:[-.0-9]* rad/s z:[-.0-9]* rad/s"
         - "trig_cnt:[0-9]*"


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/49068 fixed units
displayed by  the sample from dps to rad/s but did not update the
sample twister regex filter.
Fix the filter as well to allow testing in CI.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>