### PR TITLE
drivers: counter: Update counter_set_channel_alarm documentation

### DIFF
--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -410,6 +410,7 @@ static inline int z_impl_counter_get_value_64(const struct device *dev,
  *		    interrupts or requested channel).
  * @retval -EINVAL if alarm settings are invalid.
  * @retval -ETIME  if absolute alarm was set too late.
+ * @retval -EBUSY  if alarm is already active.
  */
 __syscall int counter_set_channel_alarm(const struct device *dev,
 					uint8_t chan_id,


### PR DESCRIPTION
Adds the -EBUSY return code to the documentation of the
counter_set_channel_alarm function which is returned when an alarm
is already active.