### PR TITLE
Bluetooth: Shell: Remove nRF board overlays

### DIFF
--- a/tests/bluetooth/shell/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/bluetooth/shell/boards/nrf52840dk_nrf52840.overlay
@@ -1,6 +1,0 @@
-&uart0 {
-	compatible = "nordic,nrf-uarte";
-	current-speed = <1000000>;
-	status = "okay";
-	hw-flow-control;
-};

--- a/tests/bluetooth/shell/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/bluetooth/shell/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,6 +1,0 @@
-&uart0 {
-	compatible = "nordic,nrf-uarte";
-	current-speed = <1000000>;
-	status = "okay";
-	hw-flow-control;
-};


### PR DESCRIPTION
The board overlays were added to increase the baud rate,
which was useful when scanning when there were many devices.

For that scenario it is probably better to use the
scan filters.

The changed baudrate in the overlays made it harder
to easily switch between e.g. the BT shell and other
applications, as the default baudrate is different, and
you'd need to restablish a connection to the boards UART
to handle the changes.

The other values in the overlays also do not really
provide any advantage to have for just the shell
application.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>