### PR TITLE
test: nested_irq: Remove all printk in the nested irq handler

### DIFF
--- a/subsys/testsuite/include/zephyr/interrupt_util.h
+++ b/subsys/testsuite/include/zephyr/interrupt_util.h
@@ -76,8 +76,6 @@ static inline void trigger_irq(int irq)
 
 static inline void trigger_irq(int irq)
 {
-	printk("Triggering irq : %d\n", irq);
-
 	/* Ensure that the specified IRQ number is a valid SGI interrupt ID */
 	zassert_true(irq <= 15, "%u is not a valid SGI interrupt ID", irq);
 

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -79,19 +79,13 @@ void isr1(const void *param)
 {
 	ARG_UNUSED(param);
 
-	printk("isr1: Enter\n");
-
 	/* Set verification token */
 	isr1_result = ISR1_TOKEN;
-
-	printk("isr1: Leave\n");
 }
 
 void isr0(const void *param)
 {
 	ARG_UNUSED(param);
-
-	printk("isr0: Enter\n");
 
 	/* Set verification token */
 	isr0_result = ISR0_TOKEN;
@@ -104,8 +98,6 @@ void isr0(const void *param)
 
 	/* Validate nested ISR result token */
 	zassert_equal(isr1_result, ISR1_TOKEN, "isr1 did not execute");
-
-	printk("isr0: Leave\n");
 }
 
 /**


### PR DESCRIPTION
Fix https://github.com/zephyrproject-rtos/zephyr/issues/49491#issuecomment-1233436589

Accessing Advanced SIMD registers in the nested irq has a side effect with FPU sharing enabled #35410. We fix it by simply simulating the sequence of STR instructions. 
But for GCC12, things are more complicated which is GCC 12 will use `ldp q0, q1, [sp|xn #xx]` and `stp q0, q1, [sp #xx]` pairs to copy content when handling the `va_start()` things (printk). It is not worth emulating more of those instructions considering the combination of gcc v12 + va_arg usage within IRQ handlers + recursive IRQs shouldn't happen much in practice
with real applications.

Fix this issue #49491 by removing all printk that will cause the nested irq test failures.