### PR TITLE
tests/kernel/timer/timer_api: modify logic for longer real time

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -804,7 +804,7 @@ ZTEST_USER(timer_api, test_sleep_abs)
 	 */
 	k_ticks_t late = end - (start + sleep_ticks);
 
-	zassert_true(late >= 0 && late < k_us_to_ticks_ceil32(250),
+	zassert_true(late >= 0 && late <= MAX(2, k_us_to_ticks_ceil32(250)),
 		     "expected wakeup at %lld, got %lld (late %lld)",
 		     start + sleep_ticks, end, late);
 }


### PR DESCRIPTION
SYS_CLOCK_TICKS_PER_SEC of it8xxx2 is 4096 (244us).
Running test_sleep_abs item on it8xxx2 and we get
k_us_to_ticks_ceil32(250) = 2 and late = 2, so it failed.
After we enable the CONFIG_PM, it needs more time to resume
from low power mode, so I modify the logic to <= for passing
the test.

fixes #49605

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>