### PR TITLE
MAINTAINERS: update maintainers for hal_nuvoton

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2244,8 +2244,7 @@ West:
 "West project: hal_nuvoton":
   status: maintained
   maintainers:
-    - MulinChao
-    - ChiHuaL
+    - ssekar15
   files:
     - modules/Kconfig.nuvoton
   labels:


### PR DESCRIPTION
The nuvoton HAL module is for the Numicro platform, not NPCX. Update the
list of maintainers accordingly.

Link: https://github.com/zephyrproject-rtos/zephyr/issues/49678#issuecomment-1233666614