### PR TITLE
soc: telink_b91: Fix ROM region section overlap

### DIFF
--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.yaml
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.yaml
@@ -4,10 +4,7 @@ type: mcu
 arch: riscv32
 toolchain:
   - cross-compile
-  # FIXME: This platform is broken due to the incorrect linker script and
-  #        cannot be compiled using the current version of the Zephyr SDK. For
-  #        more details, refer to the GitHub issue #49036.
-  # - zephyr
+  - zephyr
 ram: 128
 flash: 1024
 supported:

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1142,7 +1142,6 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 #    ROM_START     Inside the first output section of the image. This option is
 #                  currently only available on ARM Cortex-M, ARM Cortex-R,
 #                  x86, ARC, openisa_rv32m1, and RISC-V.
-#                  Note: On RISC-V the rom_start section will be after vector section.
 #    RAM_SECTIONS  Inside the RAMABLE_REGION GROUP, not initialized.
 #    DATA_SECTIONS Inside the RAMABLE_REGION GROUP, initialized.
 #    RAMFUNC_SECTION Inside the RAMFUNC RAMABLE_REGION GROUP, not initialized.

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -110,12 +110,6 @@ SECTIONS
     GROUP_START(ROMABLE_REGION)
     __rom_region_start = ROM_BASE;
 
-    SECTION_PROLOGUE(_VECTOR_SECTION_NAME,,)
-    {
-		. = ALIGN(4);
-		KEEP(*(.vectors.*))
-    } GROUP_LINK_IN(ROMABLE_REGION)
-
     SECTION_PROLOGUE(rom_start,,)
     {
 		. = ALIGN(16);
@@ -124,6 +118,13 @@ SECTIONS
  */
 #include <snippets-rom-start.ld>
     } GROUP_LINK_IN(ROMABLE_REGION)
+
+    SECTION_PROLOGUE(_VECTOR_SECTION_NAME,,)
+    {
+		. = ALIGN(4);
+		KEEP(*(.vectors.*))
+    } GROUP_LINK_IN(ROMABLE_REGION)
+
 
 #ifdef CONFIG_CODE_DATA_RELOCATION
 #include <linker_relocate.ld>

--- a/soc/riscv/riscv-privilege/telink_b91/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_b91/CMakeLists.txt
@@ -13,3 +13,4 @@ zephyr_ld_options(-fuse-ld=bfd)
 # Set compile options
 zephyr_compile_options_ifdef(CONFIG_TELINK_B91_HWDSP -mext-dsp)
 zephyr_compile_options_ifndef(CONFIG_RISCV_GP -mno-relax)
+zephyr_linker_sources(ROM_START init.ld)

--- a/soc/riscv/riscv-privilege/telink_b91/init.ld
+++ b/soc/riscv/riscv-privilege/telink_b91/init.ld
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2022 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+KEEP(*(.init.*))

--- a/soc/riscv/riscv-privilege/telink_b91/linker.ld
+++ b/soc/riscv/riscv-privilege/telink_b91/linker.ld
@@ -13,18 +13,7 @@
 
 MEMORY
 {
-	ROM_INIT (rx)  : ORIGIN = DT_REG_ADDR(DT_CHOSEN(zephyr_flash)), LENGTH = DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
 	RAM_ILM  (rwx) : ORIGIN = DT_REG_ADDR(DT_NODELABEL(ram_ilm)), LENGTH = DT_REG_SIZE(DT_NODELABEL(ram_ilm))
-}
-
-SECTIONS
-{
-	SECTION_PROLOGUE(vector,,)
-	{
-		. = CONFIG_ROM_START_OFFSET;
-		. = ALIGN(4);
-		KEEP(*(.init.*))
-	} GROUP_LINK_IN(ROM_INIT)
 }
 
 #include <zephyr/arch/riscv/common/linker.ld>


### PR DESCRIPTION
This PR places the `vectors` sections after the `ROM_START` sections in [arch/riscv/common/linker.ld](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/arch/riscv/common/linker.ld)
It also adds an `init.ld` script that will prevent overlapping `.init` sections in the `telink_b91` SoC.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/49036.