### PR TITLE
sys_clock: define NSEC_PER_MSEC

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -15,6 +15,7 @@
 #include <zephyr/init.h>
 #include <string.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys_clock.h>
 
 #include "spi_nor.h"
 #include "jesd216.h"
@@ -43,10 +44,6 @@ LOG_MODULE_REGISTER(spi_nor, CONFIG_FLASH_LOG_LEVEL);
  */
 
 #define SPI_NOR_MAX_ADDR_WIDTH 4
-
-#ifndef NSEC_PER_MSEC
-#define NSEC_PER_MSEC (NSEC_PER_USEC * USEC_PER_MSEC)
-#endif
 
 #if DT_INST_NODE_HAS_PROP(0, t_enter_dpd)
 #define T_DP_MS ceiling_fraction(DT_INST_PROP(0, t_enter_dpd), NSEC_PER_MSEC)

--- a/include/zephyr/posix/time.h
+++ b/include/zephyr/posix/time.h
@@ -73,8 +73,6 @@ extern "C" {
 #define CLOCK_MONOTONIC 4
 #endif
 
-#define NSEC_PER_MSEC (NSEC_PER_USEC * USEC_PER_MSEC)
-
 #ifndef TIMER_ABSTIME
 #define TIMER_ABSTIME 4
 #endif

--- a/include/zephyr/sys_clock.h
+++ b/include/zephyr/sys_clock.h
@@ -123,6 +123,9 @@ extern void z_enable_sys_clock(void);
 /* number of nsec per usec */
 #define NSEC_PER_USEC 1000U
 
+/* number of nsec per msec */
+#define NSEC_PER_MSEC 1000000U
+
 /* number of microseconds per millisecond */
 #define USEC_PER_MSEC 1000U
 

--- a/subsys/portability/cmsis_rtos_v1/cmsis_signal.c
+++ b/subsys/portability/cmsis_rtos_v1/cmsis_signal.c
@@ -7,7 +7,6 @@
 #include <zephyr/kernel.h>
 #include <cmsis_os.h>
 
-#define NSEC_PER_MSEC		(NSEC_PER_USEC * USEC_PER_MSEC)
 #define MAX_VALID_SIGNAL_VAL	((1 << osFeature_Signals) - 1)
 
 void *k_thread_other_custom_data_get(struct k_thread *thread_id)

--- a/subsys/portability/cmsis_rtos_v2/thread_flags.c
+++ b/subsys/portability/cmsis_rtos_v2/thread_flags.c
@@ -8,7 +8,6 @@
 #include "wrapper.h"
 
 #define DONT_CARE               (0)
-#define NSEC_PER_MSEC           (NSEC_PER_USEC * USEC_PER_MSEC)
 
 /**
  * @brief Set the specified Thread Flags of a thread.

--- a/tests/kernel/common/src/boot_delay.c
+++ b/tests/kernel/common/src/boot_delay.c
@@ -6,7 +6,6 @@
 
 #include <zephyr/ztest.h>
 
-#define NSEC_PER_MSEC (uint64_t)(NSEC_PER_USEC * USEC_PER_MSEC)
 /**
  * @brief Test delay during boot
  * @defgroup kernel_init_tests Init


### PR DESCRIPTION
`NSEC_PER_MSEC` should be defined along with the rest of the per-sec macros in `sys_clock.h`. Currently, it's defined multiply in a few separate locations.
