### PR TITLE
drivers: ethernet: stm32_hal: Rename flag.

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -846,7 +846,7 @@ static int eth_initialize(const struct device *dev)
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	heth->Instance->MACTSCR |= ETH_MACTSCR_TSENALL;
 #else
-	heth->Instance->PTPTSCR |= ETH_PTPTSSR_TSSARFE;
+	heth->Instance->PTPTSCR |= ETH_PTPTSCR_TSSARFE;
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
@@ -1395,7 +1395,7 @@ static int ptp_stm32_init(const struct device *port)
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	heth->Instance->MACTSCR |= ETH_MACTSCR_TSCTRLSSR;
 #else
-	heth->Instance->PTPTSCR |= ETH_PTPTSSR_TSSSR;
+	heth->Instance->PTPTSCR |= ETH_PTPTSCR_TSSSR;
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
 
 	/* Initialize timestamp */


### PR DESCRIPTION
Last HAL udpdates came with a fix on two ethernet flags:
- ETH_PTPTS*S*R_TSSARFE > ETH_PTPTS*C*R_TSSARFE
- ETH_PTPTS*S*R_TSSSR > ETH_PTPTS*C*R_TSSSR

Update driver to be aligned with these changes.

Fixes #49763

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>