### PR TITLE
modules: openthread: Build FTD/MTD libraries based on device type

### DIFF
--- a/modules/openthread/CMakeLists.txt
+++ b/modules/openthread/CMakeLists.txt
@@ -20,6 +20,14 @@ set(
     FORCE
 )
 
+if(CONFIG_OPENTHREAD_FTD)
+  set(OT_FTD ON CACHE BOOL "Enable FTD" FORCE)
+  set(OT_MTD OFF CACHE BOOL "Enable MTD" FORCE)
+elseif(CONFIG_OPENTHREAD_MTD)
+  set(OT_FTD OFF CACHE BOOL "Enable FTD" FORCE)
+  set(OT_MTD ON CACHE BOOL "Enable MTD" FORCE)
+endif()
+
 if(CONFIG_ASSERT)
   set(OT_ASSERT ON CACHE BOOL "Enable assert function OT_ASSERT()" FORCE)
 else()


### PR DESCRIPTION
Set OpenThread specific `cmake` options depending on the selected device type.
This reduces the number of libraries to build.