### PR TITLE
test: timer: Disable nsim_em

### DIFF
--- a/tests/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/kernel/timer/timer_behavior/testcase.yaml
@@ -5,4 +5,4 @@ tests:
       - mcu
     # Really want to exclude renode not the physical boards, but no good
     # way of doing so at the moment.
-    platform_exclude: hifive1 tflite-micro it8xxx2_evb m2gl025_miv mpfs_icicle hifive_unleashed mps2_an385 mps2_an521_ns
+    platform_exclude: hifive1 tflite-micro it8xxx2_evb m2gl025_miv mpfs_icicle hifive_unleashed mps2_an385 mps2_an521_ns nsim_em


### PR DESCRIPTION
The test will always fail on emulated/simulated environments. Exclude
this one which was failing.

Fixes #49786 

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>