### PR TITLE
sys: util: Prevent ARRAY_SIZE being defined if already defined

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -82,7 +82,9 @@ extern "C" {
 /* The built-in function used below for type checking in C is not
  * supported by GNU C++.
  */
+#ifndef ARRAY_SIZE
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
+#endif
 
 #else /* __cplusplus */
 
@@ -105,8 +107,10 @@ extern "C" {
  *
  * In C, passing a pointer as @p array causes a compile error.
  */
+#ifndef ARRAY_SIZE
 #define ARRAY_SIZE(array) \
 	((size_t) (IS_ARRAY(array) + (sizeof(array) / sizeof((array)[0]))))
+#endif
 
 #endif /* __cplusplus */
 


### PR DESCRIPTION
Prevents ARRAY_SIZE being defined by util.h if it is already defined,
prevents possible future include file ordering issues that have
plagued CI tests in the past.