### PR TITLE
mgmt/mcumgr: Remove APP_LINK_WITH_MCUMGR Kconfig option

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -259,6 +259,9 @@ Libraries / Subsystems
     information. Legacy bahaviour can be restored by enabling
     :kconfig:option:`CONFIG_MCUMGR_CMD_SHELL_MGMT_LEGACY_RC_RETURN_CODE`
 
+  * MCUMgr :kconfig:option:`CONFIG_APP_LINK_WITH_MCUMGR` has been removed as
+    it has not been doing anything.
+
 HALs
 ****
 

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -15,15 +15,6 @@ module = MCUMGR
 module-str = mcumgr
 source "subsys/logging/Kconfig.template.log_config"
 
-
-config APP_LINK_WITH_MCUMGR
-	bool "Link 'app' with MCUMGR"
-	default y
-	help
-	  Add MCUMGR header files to the 'app' include path. It may be
-	  disabled if the include paths for MCUMGR are causing aliasing
-	  issues for 'app'.
-
 rsource "lib/Kconfig"
 
 config MGMT_MAX_MAIN_MAP_ENTRIES


### PR DESCRIPTION
This option is not actually doing anything.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>