### PR TITLE
drivers: entropy: Disable CAAM driver

### DIFF
--- a/drivers/entropy/Kconfig.mcux
+++ b/drivers/entropy/Kconfig.mcux
@@ -32,7 +32,9 @@ config ENTROPY_MCUX_RNG
 
 config ENTROPY_MCUX_CAAM
 	bool "MCUX CAAM driver"
-	default y
+	# FIXME: temporarily disabled because this driver hangs
+	# 	 during initialization on rt11xx platforms
+	#default y
 	depends on DT_HAS_NXP_IMX_CAAM_ENABLED
 	select ENTROPY_HAS_DRIVER
 	help


### PR DESCRIPTION
Updating the NXP HAL at the same time as adding the CAAM driver caused an unexpected bug during initialization on MIMXRT11XX platforms. Disable the CAAM driver until this can be fixed. 

Fixes #49440
Fixes #49846