### PR TITLE
soc: arm: nxp_kinetis: Fix flash MPU configuration for k6x

### DIFF
--- a/soc/arm/nxp_kinetis/k6x/nxp_mpu_regions.c
+++ b/soc/arm/nxp_kinetis/k6x/nxp_mpu_regions.c
@@ -41,7 +41,8 @@ static const struct nxp_mpu_region mpu_regions[] = {
 	/* Region 3 */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
-			 0x07FFFFFF,
+			 (CONFIG_FLASH_BASE_ADDRESS +
+				(CONFIG_FLASH_SIZE * 1024) - 1),
 			 REGION_FLASH_ATTR),
 	/* Region 4 */
 	MPU_REGION_ENTRY("RAM_U_0",


### PR DESCRIPTION
Fix NXP MPU configuration for k6x flash region. The previous flash MPU
setting was based around the assumption that the user was executing from
the flash region at 0x0000_0000–0x07FF_FFFF, which may not be case if the
user selects to execute from SRAM, such as running from sram_l

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>