### PR TITLE
cmake: locate Zephyr SDK before locating other host tools.

### DIFF
--- a/cmake/modules/FindHostTools.cmake
+++ b/cmake/modules/FindHostTools.cmake
@@ -48,6 +48,10 @@ if(HostTools_FOUND)
   return()
 endif()
 
+find_package(Deprecated COMPONENTS XCC_USE_CLANG CROSS_COMPILE)
+
+find_package(Zephyr-sdk 0.15)
+
 # gperf is an optional dependency
 find_program(GPERF gperf)
 
@@ -60,10 +64,6 @@ find_program(BOSSAC bossac)
 # imgtool is an optional dependency (the build may also fall back to scripts/imgtool.py
 # in the mcuboot repository if that's present in some cases)
 find_program(IMGTOOL imgtool)
-
-find_package(Deprecated COMPONENTS XCC_USE_CLANG CROSS_COMPILE)
-
-find_package(Zephyr-sdk 0.15)
 
 # Pick host system's toolchain if we are targeting posix
 if("${ARCH}" STREQUAL "posix")


### PR DESCRIPTION
Follow-up: #49672

Zephyr SDK and host tools detection was reworked in #49672.

That rework accidentally changed the lookup order from:
- Zephyr SDK
- Other host tools
- Generic (host) C compiler

into
- Other host tools
- Zephyr SDK
- Generic (host) C compiler

this causes host tools shipped with Zephyr SDK, such as openocd to not
be discovered unless in path.

Restore the original order so that Zephyr SDK is located first so that
host tools from the SDK can be found without having them in path.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

----
reported on discord: https://discord.com/channels/720317445772017664/883404732423606303/1015154124611932170