### PR TITLE
soc: riscv: andes_v5: Fix system initialization for L2C

### DIFF
--- a/soc/riscv/riscv-privilege/andes_v5/l2_cache.c
+++ b/soc/riscv/riscv-privilege/andes_v5/l2_cache.c
@@ -14,6 +14,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/drivers/syscon.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(andes_v5_l2_cache, CONFIG_SOC_LOG_LEVEL);
 
 #if DT_NODE_EXISTS(DT_INST(0, andestech_l2c))
 
@@ -88,6 +90,7 @@ static void andes_v5_l2c_enable(void)
 
 static int andes_v5_l2c_init(const struct device *dev)
 {
+#if DT_NODE_HAS_STATUS(DT_INST(0, syscon), okay)
 	uint32_t system_cfg;
 	const struct device *const syscon_dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 
@@ -100,12 +103,16 @@ static int andes_v5_l2c_init(const struct device *dev)
 			/* This SoC doesn't have L2 cache */
 			return -ENODEV;
 		}
+	} else {
+		LOG_DBG("Init might fail for some hardware combinations "
+					"if syscon driver isn't ready\n");
 	}
+#endif
 
 	andes_v5_l2c_enable();
 	return 0;
 }
 
-SYS_INIT(andes_v5_l2c_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(andes_v5_l2c_init, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 #endif /* DT_NODE_EXISTS(DT_INST(0, andestech_l2c)) */


### PR DESCRIPTION
This PR fixes the following problems for L2 cache initialization in Andes SOC:
1.  L2 cache should not have higher initialization priority than syscon driver
2.  Because SMU is configurable in Andes SOC, compile time error shouldn't happen when syscon node is removed or disabled.

Signed-off-by: Wei-Tai Lee <wtlee@andestech.com>