### PR TITLE
LE Audio: Stream release fix

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -2032,11 +2032,10 @@ int bt_audio_stream_stop(struct bt_audio_stream *stream);
  *  bt_audio_broadcast_source_delete().
  *
  *  @param stream Stream object
- *  @param cache True to cache the codec configuration or false to forget it
  *
  *  @return 0 in case of success or negative value in case of error.
  */
-int bt_audio_stream_release(struct bt_audio_stream *stream, bool cache);
+int bt_audio_stream_release(struct bt_audio_stream *stream);
 
 /** @brief Send data to Audio stream
  *

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -496,12 +496,21 @@ static void stream_recv(struct bt_audio_stream *stream,
 
 #endif
 
+static void stream_stopped(struct bt_audio_stream *stream)
+{
+	printk("Audio Stream %p stopped\n", stream);
+
+	/* Stop send timer */
+	k_work_cancel_delayable(&audio_send_work);
+}
+
 static struct bt_audio_stream_ops stream_ops = {
 #if defined(CONFIG_LIBLC3)
-	.recv = stream_recv_lc3_codec
+	.recv = stream_recv_lc3_codec,
 #else
-	.recv = stream_recv
+	.recv = stream_recv,
 #endif
+	.stopped = stream_stopped,
 };
 
 static void connected(struct bt_conn *conn, uint8_t err)

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -1185,13 +1185,13 @@ int bt_audio_stream_disable(struct bt_audio_stream *stream)
 	return 0;
 }
 
-int bt_audio_stream_release(struct bt_audio_stream *stream, bool cache)
+int bt_audio_stream_release(struct bt_audio_stream *stream)
 {
 	uint8_t state;
 	uint8_t role;
 	int err;
 
-	BT_DBG("stream %p cache %s", stream, cache ? "true" : "false");
+	BT_DBG("stream %p", stream);
 
 	CHECKIF(stream == NULL || stream->ep == NULL || stream->conn == NULL) {
 		BT_DBG("Invalid stream");
@@ -1222,7 +1222,7 @@ int bt_audio_stream_release(struct bt_audio_stream *stream, bool cache)
 		err = bt_unicast_client_release(stream);
 	} else if (IS_ENABLED(CONFIG_BT_AUDIO_UNICAST_SERVER) &&
 		   role == BT_HCI_ROLE_PERIPHERAL) {
-		err = bt_unicast_server_release(stream, cache);
+		err = bt_unicast_server_release(stream);
 	} else {
 		err = -EOPNOTSUPP;
 	}

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -206,8 +206,6 @@ static void unicast_client_ep_iso_disconnected(struct bt_iso_chan *chan,
 	} else {
 		BT_WARN("No callback for stopped set");
 	}
-
-	bt_unicast_client_ep_set_state(ep, BT_AUDIO_EP_STATE_QOS_CONFIGURED);
 }
 
 static struct bt_iso_chan_ops unicast_client_iso_ops = {
@@ -1064,33 +1062,6 @@ fail:
 	codec->meta_count = 0;
 	(void)memset(codec->meta, 0, sizeof(codec->meta));
 	return err;
-}
-
-void bt_unicast_client_ep_set_state(struct bt_audio_ep *ep, uint8_t state)
-{
-	uint8_t old_state;
-
-	if (!ep) {
-		return;
-	}
-
-	BT_DBG("ep %p id 0x%02x %s -> %s", ep, ep->status.id,
-	       bt_audio_ep_state_str(ep->status.state),
-	       bt_audio_ep_state_str(state));
-
-	old_state = ep->status.state;
-	ep->status.state = state;
-
-	if (!ep->stream || old_state == state) {
-		return;
-	}
-
-	if (state == BT_AUDIO_EP_STATE_CODEC_CONFIGURED) {
-		bt_unicast_client_ep_unbind_audio_iso(ep);
-	} else if (state == BT_AUDIO_EP_STATE_IDLE) {
-		bt_unicast_client_ep_unbind_audio_iso(ep);
-		bt_audio_stream_detach(ep->stream);
-	}
 }
 
 static uint8_t unicast_client_cp_notify(struct bt_conn *conn,

--- a/subsys/bluetooth/audio/unicast_client_internal.h
+++ b/subsys/bluetooth/audio/unicast_client_internal.h
@@ -25,9 +25,6 @@ int bt_unicast_client_stop(struct bt_audio_stream *stream);
 
 int bt_unicast_client_release(struct bt_audio_stream *stream);
 
-
-void bt_unicast_client_ep_set_state(struct bt_audio_ep *ep, uint8_t state);
-
 struct net_buf_simple *bt_unicast_client_ep_create_pdu(uint8_t op);
 
 int bt_unicast_client_ep_qos(struct bt_audio_ep *ep, struct net_buf_simple *buf,

--- a/subsys/bluetooth/audio/unicast_server.c
+++ b/subsys/bluetooth/audio/unicast_server.c
@@ -158,7 +158,7 @@ int bt_unicast_server_disable(struct bt_audio_stream *stream)
 	return 0;
 }
 
-int bt_unicast_server_release(struct bt_audio_stream *stream, bool cache)
+int bt_unicast_server_release(struct bt_audio_stream *stream)
 {
 	int err;
 
@@ -172,15 +172,10 @@ int bt_unicast_server_release(struct bt_audio_stream *stream, bool cache)
 		return err;
 	}
 
-	if (cache) {
-		ascs_ep_set_state(stream->ep,
-				  BT_AUDIO_EP_STATE_CODEC_CONFIGURED);
-	} else {
-		/* ase_process will set the state to IDLE after sending the
-		 * notification, finalizing the release
-		 */
-		ascs_ep_set_state(stream->ep, BT_AUDIO_EP_STATE_RELEASING);
-	}
+	/* ase_process will set the state to IDLE after sending the
+	 * notification, finalizing the release
+	 */
+	ascs_ep_set_state(stream->ep, BT_AUDIO_EP_STATE_RELEASING);
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/unicast_server.h
+++ b/subsys/bluetooth/audio/unicast_server.h
@@ -17,4 +17,4 @@ int bt_unicast_server_metadata(struct bt_audio_stream *stream,
 			       struct bt_codec_data meta[],
 			       size_t meta_count);
 int bt_unicast_server_disable(struct bt_audio_stream *stream);
-int bt_unicast_server_release(struct bt_audio_stream *stream, bool cache);
+int bt_unicast_server_release(struct bt_audio_stream *stream);

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -767,7 +767,7 @@ static int cmd_release(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	err = bt_audio_stream_release(default_stream, false);
+	err = bt_audio_stream_release(default_stream);
 	if (err) {
 		shell_error(sh, "Unable to release Channel");
 		return -ENOEXEC;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
@@ -323,7 +323,7 @@ static size_t release_streams(size_t stream_cnt)
 
 		UNSET_FLAG(flag_stream_released);
 
-		err = bt_audio_stream_release(&g_streams[i], false);
+		err = bt_audio_stream_release(&g_streams[i]);
 		if (err != 0) {
 			FAIL("Unable to release stream[%zu]: %d", i, err);
 			return 0;


### PR DESCRIPTION
This PR removes caching of endpoint states, as we do not properly support it. By removing the caching, handling the releasing state also becomes easier to handle and fix. 

The unicast server will now ensure that the CIS is disconnected before going into the idle state (and calling the `released` callback). 

Also removes a ASE state change done locally on the client, as that would put the ASE state into a mismatch between the server and client. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/49733