### PR TITLE
Bluetooth: Audio: Set transparent coding format for default ISO path

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -250,7 +250,9 @@ static void bt_iso_chan_add(struct bt_conn *iso, struct bt_iso_chan *chan)
 static int bt_iso_setup_data_path(struct bt_iso_chan *chan)
 {
 	int err;
-	struct bt_iso_chan_path default_hci_path = { .pid = BT_ISO_DATA_PATH_HCI };
+	struct bt_iso_chan_path default_hci_path = { .pid = BT_ISO_DATA_PATH_HCI,
+						     .format = BT_HCI_CODING_FORMAT_TRANSPARENT,
+						     .cc_len = 0x00 };
 	struct bt_iso_chan_path *out_path = NULL;
 	struct bt_iso_chan_path *in_path = NULL;
 	struct bt_iso_chan_io_qos *tx_qos;


### PR DESCRIPTION
As per BAP_v1.0, Section 5.6.3.1:

If HCI is used when setting up their respective audio data paths,
and if the codec in use resides in the Bluetooth Host of the device
using the LE Setup ISO Data Path command, the Unicast Client and/or
Unicast Server shall:
* Write the LE Setup ISO Data Path command Codec_Configuration_Length
parameter with the value 0x00.
* Write octet 0 (Coding_Format) of the LE Setup ISO Data Path command
Codec_ID parameter with the value 0x03 (Transparent).

We can assume the codec in use resides in the Bluetooth Host default.

Signed-off-by: Hang Fan <fanhang@xiaomi.com>