### PR TITLE
footprint: Add bt_hci_rpmsg with ISO for the nRF5340 netcore

### DIFF
--- a/scripts/footprint/plan.txt
+++ b/scripts/footprint/plan.txt
@@ -21,5 +21,7 @@ bt_mesh_demo,default,bbc_microbit,samples/bluetooth/mesh_demo,
 bt_hap_ha,default,nrf52840dk_nrf52840,samples/bluetooth/hap_ha,
 bt_hap_ha,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/hap_ha,
 bt_hci_rpmsg,default,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,
+bt_hci_rpmsg,iso-broadcast,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,-DCONF_FILE=nrf5340_cpunet_iso_broadcast.conf
+bt_hci_rpmsg,iso-receive,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,-DCONF_FILE=nrf5340_cpunet_iso_receive.conf
 sof,default,intel_adsp_cavs25,samples/subsys/audio/sof,
 sof,default,nxp_adsp_imx8,samples/subsys/audio/sof,


### PR DESCRIPTION
Add footprint tracking of the samples/bluetooth/hci_rpmsg
sample for the nRF5340 with ISO broadcast and ISO receive respectively.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>