### PR TITLE
posix: clock: make tz non-const in gettimeofday

### DIFF
--- a/include/zephyr/posix/sys/time.h
+++ b/include/zephyr/posix/sys/time.h
@@ -29,7 +29,7 @@ struct timeval {
 extern "C" {
 #endif
 
-int gettimeofday(struct timeval *tv, const void *tz);
+int gettimeofday(struct timeval *tv, void *tz);
 
 #ifdef __cplusplus
 }

--- a/lib/posix/clock.c
+++ b/lib/posix/clock.c
@@ -111,7 +111,7 @@ int clock_settime(clockid_t clock_id, const struct timespec *tp)
  *
  * See IEEE 1003.1
  */
-int gettimeofday(struct timeval *tv, const void *tz)
+int gettimeofday(struct timeval *tv, void *tz)
 {
 	struct timespec ts;
 	int res;


### PR DESCRIPTION
This `tz` field is not const in the spec.
