### PR TITLE
mgmt: mcumgr: fix includes to avoid redefinition

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/zephyr_fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/zephyr_fs_mgmt.c
@@ -6,8 +6,8 @@
 
 #include <zephyr/fs/fs.h>
 #include <errno.h>
-#include <zephyr/mgmt/mcumgr/buf.h>
 #include <mgmt/mgmt.h>
+#include <zephyr/mgmt/mcumgr/buf.h>
 #include <fs_mgmt/fs_mgmt_impl.h>
 
 int


### PR DESCRIPTION
Fix include order to avoid redefinition of `ARRAY_SIZE`, because `sys/util.h` and `zcbor_common.h` both define it, but `sys/util.h` does not protect against redefinition.