### PR TITLE
mgmt: mcumgr: fs_mgmt: Fix build warning

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/zephyr_fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/zephyr_fs_mgmt.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <mgmt/mgmt.h>
+#include <zephyr/mgmt/mcumgr/buf.h>
 #include <zephyr/fs/fs.h>
 #include <errno.h>
-#include <zephyr/mgmt/mcumgr/buf.h>
-#include <mgmt/mgmt.h>
 #include <fs_mgmt/fs_mgmt_impl.h>
 
 int


### PR DESCRIPTION
Fixes a build warning due to file include order