### PR TITLE
sample: smp_svr: fix test name mcumg -> mcumgr

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -5,18 +5,18 @@ common:
     harness: bluetooth
     tags: bluetooth
 tests:
-  sample.mcumg.smp_svr.bt:
+  sample.mcumgr.smp_svr.bt:
     extra_args: OVERLAY_CONFIG="overlay-bt.conf"
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 pinnacle_100_dvk
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
-  sample.mcumg.smp_svr.udp:
+  sample.mcumgr.smp_svr.udp:
     extra_args: OVERLAY_CONFIG="overlay-udp.conf"
     platform_allow: frdm_k64f
     integration_platforms:
         - frdm_k64f
-  sample.mcumg.smp_svr.cdc:
+  sample.mcumgr.smp_svr.cdc:
     extra_args: OVERLAY_CONFIG="overlay-cdc.conf"
                 DTC_OVERLAY_FILE="usb.overlay"
     platform_allow: nrf52833dk_nrf52820 nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp pinnacle_100_dvk
@@ -25,29 +25,29 @@ tests:
       - nrf52833dk_nrf52833
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-  sample.mcumg.smp_svr.serial:
+  sample.mcumgr.smp_svr.serial:
     extra_args: OVERLAY_CONFIG="overlay-serial.conf"
     platform_allow: nrf52840dk_nrf52840 pinnacle_100_dvk
     integration_platforms:
       - nrf52840dk_nrf52840
-  sample.mcumg.smp_svr.serial:
+  sample.mcumgr.smp_svr.serial:
     extra_args: OVERLAY_CONFIG="overlay-serial-console.conf"
     platform_allow: nrf52840dk_nrf52840 pinnacle_100_dvk
     integration_platforms:
       - nrf52840dk_nrf52840
-  sample.mcumg.smp_svr.shell:
+  sample.mcumgr.smp_svr.shell:
     extra_args: OVERLAY_CONFIG="overlay-shell.conf"
     platform_allow: nrf52840dk_nrf52840 mimxrt1060_evk mimxrt1064_evk pinnacle_100_dvk
     integration_platforms:
       - nrf52840dk_nrf52840
       - mimxrt1060_evk
       - mimxrt1064_evk
-  sample.mcumg.smp_svr.shell_mgmt:
+  sample.mcumgr.smp_svr.shell_mgmt:
     extra_args: OVERLAY_CONFIG="overlay-shell-mgmt.conf"
     platform_allow: nrf52840dk_nrf52840 pinnacle_100_dvk
     integration_platforms:
       - nrf52840dk_nrf52840
-  sample.mcumg.smp_svr.fs:
+  sample.mcumgr.smp_svr.fs:
     extra_args: OVERLAY_CONFIG="overlay-fs.conf"
     platform_allow: nrf52840dk_nrf52840 pinnacle_100_dvk
     integration_platforms:


### PR DESCRIPTION
The test names are missing an "r" from "mcumgr" for some reason. Add it
back.