### PR TITLE
Bluetooth: Audio: Add Broadcast source application AD

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -2192,10 +2192,13 @@ int bt_audio_broadcast_source_reconfig(struct bt_audio_broadcast_source *source,
  *  be streamed.
  *
  *  @param source      Pointer to the broadcast source
+ *  @param adv         Pointer to an extended advertising set with periodic
+ *                     advertising configured.
  *
  *  @return Zero on success or (negative) error code otherwise.
  */
-int bt_audio_broadcast_source_start(struct bt_audio_broadcast_source *source);
+int bt_audio_broadcast_source_start(struct bt_audio_broadcast_source *source,
+				    struct bt_le_ext_adv *adv);
 
 /** @brief Stop audio broadcast source.
  *
@@ -2220,6 +2223,41 @@ int bt_audio_broadcast_source_stop(struct bt_audio_broadcast_source *source);
  *  @return Zero on success or (negative) error code otherwise.
  */
 int bt_audio_broadcast_source_delete(struct bt_audio_broadcast_source *source);
+
+/**
+ * @brief Get the broadcast ID of a broadcast source
+ *
+ * This will return the 3-octet broadcast ID that should be advertised in the
+ * extended advertising data with @ref BT_UUID_BROADCAST_AUDIO_VAL as
+ * @ref BT_DATA_SVC_DATA16.
+ *
+ * See table 3.14 in the Basic Audio Profile v1.0.1 for the structure.
+ *
+ * @param[in]  source        Pointer to the broadcast source.
+ * @param[out] broadcast_id  Pointer to the 3-octet broadcast ID.
+ *
+ * @return int		0 if on success, errno on error.
+ */
+int bt_audio_broadcast_source_get_id(const struct bt_audio_broadcast_source *source,
+				     uint32_t *const broadcast_id);
+
+/**
+ * @brief Get the Broadcast Audio Stream Endpoint of a broadcast source
+ *
+ * This will encode the BASE of a broadcast source into a buffer, that can be
+ * used for advertisement. The encoded BASE will thus be encoded as
+ * little-endian. The BASE shall be put into the periodic advertising data
+ * (see bt_le_per_adv_set_data()).
+ *
+ * See table 3.15 in the Basic Audio Profile v1.0.1 for the structure.
+ *
+ * @param source        Pointer to the broadcast source.
+ * @param base_buf      Pointer to a buffer where the BASE will be inserted.
+ *
+ * @return int		0 if on success, errno on error.
+ */
+int bt_audio_broadcast_source_get_base(const struct bt_audio_broadcast_source *source,
+				       struct net_buf_simple *base_buf);
 
 /** @brief Register Broadcast sink callbacks
  * *

--- a/samples/bluetooth/broadcast_audio_source/src/main.c
+++ b/samples/bluetooth/broadcast_audio_source/src/main.c
@@ -88,6 +88,7 @@ static struct bt_audio_stream_ops stream_ops = {
 void main(void)
 {
 	struct bt_audio_stream *streams_p[ARRAY_SIZE(streams)];
+	struct bt_le_ext_adv *adv;
 	int err;
 
 	err = bt_enable(NULL);
@@ -108,6 +109,30 @@ void main(void)
 	}
 
 	while (true) {
+		/* Broadcast Audio Streaming Endpoint advertising data */
+		NET_BUF_SIMPLE_DEFINE(ad_buf,
+				      BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
+		NET_BUF_SIMPLE_DEFINE(base_buf, 64);
+		struct bt_data ext_ad;
+		struct bt_data per_ad;
+		uint32_t broadcast_id;
+
+		/* Create a non-connectable non-scannable advertising set */
+		err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, &adv);
+		if (err != 0) {
+			printk("Unable to create extended advertising set: %d\n",
+			       err);
+			return;
+		}
+
+		/* Set periodic advertising parameters */
+		err = bt_le_per_adv_set_param(adv, BT_LE_PER_ADV_DEFAULT);
+		if (err) {
+			printk("Failed to set periodic advertising parameters"
+			" (err %d)\n", err);
+			return;
+		}
+
 		printk("Creating broadcast source\n");
 		err = bt_audio_broadcast_source_create(streams_p,
 						       ARRAY_SIZE(streams_p),
@@ -119,9 +144,63 @@ void main(void)
 			return;
 		}
 
+		err = bt_audio_broadcast_source_get_id(broadcast_source,
+						       &broadcast_id);
+		if (err != 0) {
+			printk("Unable to get broadcast ID: %d\n", err);
+			return;
+		}
+
+		/* Setup extended advertising data */
+		net_buf_simple_add_le16(&ad_buf, BT_UUID_BROADCAST_AUDIO_VAL);
+		net_buf_simple_add_le24(&ad_buf, broadcast_id);
+		ext_ad.type = BT_DATA_SVC_DATA16;
+		ext_ad.data_len = ad_buf.len;
+		ext_ad.data = ad_buf.data;
+		err = bt_le_ext_adv_set_data(adv, &ext_ad, 1, NULL, 0);
+		if (err != 0) {
+			printk("Failed to set extended advertising data: %d\n",
+			       err);
+			return;
+		}
+
+		/* Setup periodic advertising data */
+		err = bt_audio_broadcast_source_get_base(broadcast_source,
+							 &base_buf);
+		if (err != 0) {
+			printk("Failed to get encoded BASE: %d\n", err);
+			return;
+		}
+
+		per_ad.type = BT_DATA_SVC_DATA16;
+		per_ad.data_len = base_buf.len;
+		per_ad.data = base_buf.data;
+		err = bt_le_per_adv_set_data(adv, &per_ad, 1);
+		if (err != 0) {
+			printk("Failed to set periodic advertising data: %d\n",
+			       err);
+			return;
+		}
+
+		/* Start extended advertising */
+		err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
+		if (err) {
+			printk("Failed to start extended advertising: %d\n",
+			       err);
+			return;
+		}
+
+		/* Enable Periodic Advertising */
+		err = bt_le_per_adv_start(adv);
+		if (err) {
+			printk("Failed to enable periodic advertising: %d\n",
+			       err);
+			return;
+		}
+
 		printk("Starting broadcast source\n");
 		stopping = false;
-		err = bt_audio_broadcast_source_start(broadcast_source);
+		err = bt_audio_broadcast_source_start(broadcast_source, adv);
 		if (err != 0) {
 			printk("Unable to start broadcast source: %d\n", err);
 			return;
@@ -167,5 +246,26 @@ void main(void)
 		printk("Broadcast source deleted\n");
 		broadcast_source = NULL;
 		seq_num = 0;
+
+		err = bt_le_per_adv_stop(adv);
+		if (err) {
+			printk("Failed to stop periodic advertising (err %d)\n",
+			       err);
+			return;
+		}
+
+		err = bt_le_ext_adv_stop(adv);
+		if (err) {
+			printk("Failed to stop extended advertising (err %d)\n",
+			       err);
+			return;
+		}
+
+		err = bt_le_ext_adv_delete(adv);
+		if (err) {
+			printk("Failed to delete extended advertising (err %d)\n",
+			       err);
+			return;
+		}
 	}
 }

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -96,10 +96,10 @@ struct bt_audio_broadcast_source {
 	uint32_t pd; /** QoS Presentation Delay */
 	uint32_t broadcast_id; /* 24 bit */
 
-	struct bt_le_ext_adv *adv;
 	struct bt_iso_big *big;
 	struct bt_iso_chan *bis[BROADCAST_STREAM_CNT];
 	struct bt_codec_qos *qos;
+	struct bt_codec *codec;
 	/* The streams used to create the broadcast source */
 	sys_slist_t streams;
 };

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -1239,14 +1239,21 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 static int cmd_start_broadcast(const struct shell *sh, size_t argc,
 			       char *argv[])
 {
+	struct bt_le_ext_adv *adv = adv_sets[selected_adv];
 	int err;
+
+	if (adv == NULL) {
+		shell_info(sh, "Extended advertising set is NULL");
+		return -ENOEXEC;
+	}
 
 	if (default_source == NULL) {
 		shell_info(sh, "Broadcast source not created");
 		return -ENOEXEC;
 	}
 
-	err = bt_audio_broadcast_source_start(default_source);
+	err = bt_audio_broadcast_source_start(default_source,
+					      adv_sets[selected_adv]);
 	if (err != 0) {
 		shell_error(sh, "Unable to start broadcast source: %d", err);
 		return err;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
@@ -96,10 +96,114 @@ static struct bt_audio_stream_ops stream_ops = {
 	.sent = sent_cb
 };
 
-static void test_main(void)
+static int setup_extended_adv(const struct bt_audio_broadcast_source *source,
+			      struct bt_le_ext_adv **adv)
+{
+	/* Broadcast Audio Streaming Endpoint advertising data */
+	NET_BUF_SIMPLE_DEFINE(ad_buf,
+			      BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
+	NET_BUF_SIMPLE_DEFINE(base_buf, 64);
+	struct bt_data ext_ad;
+	struct bt_data per_ad;
+	uint32_t broadcast_id;
+	int err;
+
+	/* Create a non-connectable non-scannable advertising set */
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, adv);
+	if (err != 0) {
+		printk("Unable to create extended advertising set: %d\n", err);
+		return err;
+	}
+
+	/* Set periodic advertising parameters */
+	err = bt_le_per_adv_set_param(*adv, BT_LE_PER_ADV_DEFAULT);
+	if (err) {
+		printk("Failed to set periodic advertising parameters: %d\n",
+		       err);
+		return err;
+	}
+
+	err = bt_audio_broadcast_source_get_id(source, &broadcast_id);
+	if (err != 0) {
+		printk("Unable to get broadcast ID: %d\n", err);
+		return err;
+	}
+
+	/* Setup extended advertising data */
+	net_buf_simple_add_le16(&ad_buf, BT_UUID_BROADCAST_AUDIO_VAL);
+	net_buf_simple_add_le24(&ad_buf, broadcast_id);
+	ext_ad.type = BT_DATA_SVC_DATA16;
+	ext_ad.data_len = ad_buf.len;
+	ext_ad.data = ad_buf.data;
+	err = bt_le_ext_adv_set_data(*adv, &ext_ad, 1, NULL, 0);
+	if (err != 0) {
+		printk("Failed to set extended advertising data: %d\n", err);
+		return err;
+	}
+
+	/* Setup periodic advertising data */
+	err = bt_audio_broadcast_source_get_base(source, &base_buf);
+	if (err != 0) {
+		printk("Failed to get encoded BASE: %d\n", err);
+		return err;
+	}
+
+	per_ad.type = BT_DATA_SVC_DATA16;
+	per_ad.data_len = base_buf.len;
+	per_ad.data = base_buf.data;
+	err = bt_le_per_adv_set_data(*adv, &per_ad, 1);
+	if (err != 0) {
+		printk("Failed to set periodic advertising data: %d\n", err);
+		return err;
+	}
+
+	/* Start extended advertising */
+	err = bt_le_ext_adv_start(*adv, BT_LE_EXT_ADV_START_DEFAULT);
+	if (err) {
+		printk("Failed to start extended advertising: %d\n", err);
+		return err;
+	}
+
+	/* Enable Periodic Advertising */
+	err = bt_le_per_adv_start(*adv);
+	if (err) {
+		printk("Failed to enable periodic advertising: %d\n", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int stop_extended_adv(struct bt_le_ext_adv *adv)
 {
 	int err;
+
+	err = bt_le_per_adv_stop(adv);
+	if (err) {
+		printk("Failed to stop periodic advertising: %d\n", err);
+		return err;
+	}
+
+	err = bt_le_ext_adv_stop(adv);
+	if (err) {
+		printk("Failed to stop extended advertising: %d\n", err);
+		return err;
+	}
+
+	err = bt_le_ext_adv_delete(adv);
+	if (err) {
+		printk("Failed to delete extended advertising: %d\n", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static void test_main(void)
+{
 	struct bt_audio_broadcast_source *source;
+	struct bt_le_ext_adv *adv;
+	int err;
 
 	err = bt_enable(NULL);
 	if (err) {
@@ -127,6 +231,12 @@ static void test_main(void)
 		return;
 	}
 
+	err = setup_extended_adv(source, &adv);
+	if (err != 0) {
+		FAIL("Failed to setup extended advertising: %d\n", err);
+		return;
+	}
+
 	printk("Reconfiguring broadcast source\n");
 	err = bt_audio_broadcast_source_reconfig(source, &preset_16_2_1.codec,
 						 &preset_16_2_1.qos);
@@ -136,7 +246,7 @@ static void test_main(void)
 	}
 
 	printk("Starting broadcast source\n");
-	err = bt_audio_broadcast_source_start(source);
+	err = bt_audio_broadcast_source_start(source, adv);
 	if (err != 0) {
 		FAIL("Unable to start broadcast source: %d\n", err);
 		return;
@@ -156,7 +266,7 @@ static void test_main(void)
 	}
 
 	/* Keeping running for a little while */
-	k_sleep(K_SECONDS(10));
+	k_sleep(K_SECONDS(15));
 
 	printk("Stopping broadcast source\n");
 	SET_FLAG(flag_stopping);
@@ -179,6 +289,14 @@ static void test_main(void)
 		return;
 	}
 	source = NULL;
+
+
+	err = stop_extended_adv(adv);
+	if (err != 0) {
+		FAIL("Unable to stop extended advertising: %d\n", err);
+		return;
+	}
+	adv = NULL;
 
 	/* Recreate broadcast source to verify that it's possible */
 	printk("Recreating broadcast source\n");


### PR DESCRIPTION
This refactors how the BAP broadcast source handles the
extended and periodic advertising.

First it removes the start and stop of the extended
advertising, and instead expects the application
(or upper layers) to do this.

Second it exposes API functions to get the
necessary advertising data from BAP (service data and
the BASE), which the upper layers will then also
be responsible for setting and updating.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/49740
fixes https://github.com/zephyrproject-rtos/zephyr/issues/47299