### PR TITLE
drivers/clock_control: stm32: Configure and enable PLL2

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -463,6 +463,27 @@ static void set_up_plls(void)
 	}
 	LL_RCC_PLL_Disable();
 
+#endif
+
+#if defined(STM32_PLL2_ENABLED)
+	/*
+	 * Disable PLL2 after switching to HSI for SysClk
+	 * and disabling PLL, but before enabling PLL again,
+	 * since PLL source can be PLL2.
+	 */
+	LL_RCC_PLL2_Disable();
+
+	config_pll2();
+
+	/* Enable PLL2 */
+	LL_RCC_PLL2_Enable();
+	while (LL_RCC_PLL2_IsReady() != 1U) {
+	/* Wait for PLL2 ready */
+	}
+#endif /* STM32_PLL2_ENABLED */
+
+#if defined(STM32_PLL_ENABLED)
+
 #ifdef CONFIG_SOC_SERIES_STM32F7X
 	/* Assuming we stay on Power Scale default value: Power Scale 1 */
 	if (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC > 180000000) {

--- a/drivers/clock_control/clock_stm32_ll_common.h
+++ b/drivers/clock_control/clock_stm32_ll_common.h
@@ -62,6 +62,9 @@ void config_pll_sysclock(void);
 uint32_t get_pllout_frequency(void);
 uint32_t get_pllsrc_frequency(void);
 #endif
+#if defined(STM32_PLL2_ENABLED)
+void config_pll2(void);
+#endif
 void config_enable_default_clocks(void);
 
 /* function exported to the soc power.c */

--- a/drivers/clock_control/clock_stm32f1.c
+++ b/drivers/clock_control/clock_stm32f1.c
@@ -97,6 +97,50 @@ void config_pll_sysclock(void)
 
 #endif /* defined(STM32_PLL_ENABLED) */
 
+#if defined(STM32_PLL2_ENABLED)
+
+/**
+ * @brief Set up pll2 configuration
+ */
+__unused
+void config_pll2(void)
+{
+	uint32_t pll_mul, pll_div;
+
+	/*
+	 * PLL2MUL on SOC_STM32F10X_CONNECTIVITY_LINE_DEVICE
+	 * 8  -> LL_RCC_PLL2_MUL_8  -> 0x00000600
+	 * 9  -> LL_RCC_PLL2_MUL_9  -> 0x00000700
+	 * ...
+	 * 14 -> LL_RCC_PLL2_MUL_14 -> 0x00000C00
+	 * 16 -> LL_RCC_PLL2_MUL_16 -> 0x00000E00
+	 * 20 -> LL_RCC_PLL2_MUL_20 -> 0x00000F00
+	 */
+	if (STM32_PLL2_MULTIPLIER == 20) {
+		pll_mul = RCC_CFGR2_PLL2MUL20;
+	} else {
+		pll_mul = ((STM32_PLL2_MULTIPLIER - 2) << RCC_CFGR2_PLL2MUL_Pos);
+	}
+
+	/*
+	 * SOC_STM32F10X_CONNECTIVITY_LINE_DEVICE
+	 * 1  -> LL_RCC_HSE_PREDIV2_DIV_1  -> 0x00000000
+	 * 2  -> LL_RCC_HSE_PREDIV2_DIV_2  -> 0x00000010
+	 * ...
+	 * 16 -> LL_RCC_HSE_PREDIV2_DIV_16 -> 0x000000F0
+	 */
+	pll_div = ((STM32_PLL2_PREDIV - 1) << RCC_CFGR2_PREDIV2_Pos);
+
+	/* Check PLL2 source */
+	if (!IS_ENABLED(STM32_PLL2_SRC_HSE)) {
+		__ASSERT(0, "Invalid source");
+	}
+
+	LL_RCC_PLL_ConfigDomain_PLL2(pll_div, pll_mul);
+}
+
+#endif /* defined(STM32_PLL2_ENABLED) */
+
 /**
  * @brief Activate default clocks
  */

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -167,6 +167,12 @@
 #define STM32_PLL_MULTIPLIER	DT_PROP(DT_NODELABEL(pll), mul)
 #endif
 
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll2), st_stm32f105_pll2_clock, okay)
+#define STM32_PLL2_ENABLED	1
+#define STM32_PLL2_MULTIPLIER	DT_PROP(DT_NODELABEL(pll2), mul)
+#define STM32_PLL2_PREDIV	DT_PROP(DT_NODELABEL(pll2), prediv)
+#endif
+
 /** PLL/PLL1 clock source */
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pll), okay) && \
 	DT_NODE_HAS_PROP(DT_NODELABEL(pll), clocks)


### PR DESCRIPTION
Currently, PLL2 is not configured/enabled for stm32f105/stm32f107 even when defined in DT.
#49747 reports PLL2 indeed not working.

New to Zephyr so not sure if that's how it is supposed to be fixed.