### PR TITLE
docs: esp32c3: add west blobs reference

### DIFF
--- a/boards/riscv/esp32c3_devkitm/doc/index.rst
+++ b/boards/riscv/esp32c3_devkitm/doc/index.rst
@@ -38,12 +38,12 @@ System requirements
 Prerequisites
 -------------
 
-Espressif HAL requires binary blobs in order work. The west extension below performs the required
-syncronization to clone, checkout and pull the submodules:
+Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
+below to retrieve those files.
 
 .. code-block:: console
 
-   west espressif update
+   west blobs fetch hal_espressif
 
 .. note::
 


### PR DESCRIPTION
As part of #49682, this updates esp32c3
documentation to add proper west blobs command.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>