### PR TITLE
drivers/can: stm32_fd: move clock configuration from kconfig to devicetree

### DIFF
--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -181,6 +181,8 @@
 };
 
 &can1 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>,
+		 <&rcc STM32_SRC_HSE FDCAN_SEL(0)>;
 	pinctrl-0 = <&fdcan1_rx_pa11 &fdcan1_tx_pa12>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;

--- a/drivers/can/Kconfig.stm32fd
+++ b/drivers/can/Kconfig.stm32fd
@@ -28,46 +28,8 @@ config CAN_MAX_EXT_ID_FILTER
 	  Defines the maximum number of filters with extended ID (29-bit)
 	  that can be attached.
 
-choice CAN_STM32FD_CLOCK_SOURCE
-	prompt "CAN clock source"
-	default CAN_STM32FD_CLOCK_SOURCE_HSE
-	help
-	  CAN clock source selection.
-
-config CAN_STM32FD_CLOCK_SOURCE_HSE
-	bool "HSE"
-	help
-	  HSE clock used as FDCAN clock source.
-
-config CAN_STM32FD_CLOCK_SOURCE_PLL
-	bool "PLL"
-	depends on !SOC_SERIES_STM32U5X
-	help
-	  PLL "Q" clock used ad FDCAN clock source.
-
-config CAN_STM32FD_CLOCK_SOURCE_PCLK1
-	bool "PCLK1"
-	depends on !SOC_SERIES_STM32U5X
-	help
-	  PCLK1 clock used ad FDCAN clock source.
-
-config CAN_STM32FD_CLOCK_SOURCE_PLL1Q
-	bool "PLL1Q"
-	depends on SOC_SERIES_STM32U5X
-	help
-	  PLL1 "Q" clock used as FDCAN clock source.
-
-config CAN_STM32FD_CLOCK_SOURCE_PLL2P
-	bool "PLL2P"
-	depends on SOC_SERIES_STM32U5X
-	help
-	  PLL2 "P" clock used as FDCAN clock source.
-
-endchoice
-
 config CAN_STM32FD_CLOCK_DIVISOR
 	int "CAN clock divisor"
-	depends on CAN_STM32FD_CLOCK_SOURCE_PCLK1
 	range 1 30
 	default 1
 	help

--- a/drivers/can/Kconfig.stm32fd
+++ b/drivers/can/Kconfig.stm32fd
@@ -28,14 +28,4 @@ config CAN_MAX_EXT_ID_FILTER
 	  Defines the maximum number of filters with extended ID (29-bit)
 	  that can be attached.
 
-config CAN_STM32FD_CLOCK_DIVISOR
-	int "CAN clock divisor"
-	range 1 30
-	default 1
-	help
-	  The APB clock is divided by this value (stored in CKDIV register)
-	  before it is fed to the CAN core.
-	  Note that the the divisor affects all CAN controllers.
-	  Allowed values: 1 or 2 * n, where n <= 15.
-
 endif # CAN_STM32FD

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1086,3 +1086,15 @@ int can_mcan_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
 
 	return 0;
 }
+
+/* helper function allowing mcan drivers without access to private mcan
+ * definitions to set CCCR_CCE, which might be needed to disable write
+ * protection for some registers.
+ */
+void can_mcan_enable_configuration_change(const struct device *dev)
+{
+	const struct can_mcan_config *cfg = dev->config;
+	struct can_mcan_reg *can = cfg->can;
+
+	can->cccr |= CAN_MCAN_CCCR_CCE;
+}

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -296,4 +296,6 @@ void can_mcan_set_state_change_callback(const struct device *dev,
 
 int can_mcan_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate);
 
+void can_mcan_enable_configuration_change(const struct device *dev);
+
 #endif /* ZEPHYR_DRIVERS_CAN_MCAN_H_ */

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -18,16 +18,6 @@
 
 LOG_MODULE_REGISTER(can_stm32fd, CONFIG_CAN_LOG_LEVEL);
 
-#ifdef CONFIG_CAN_STM32FD_CLOCK_DIVISOR
-#if CONFIG_CAN_STM32FD_CLOCK_DIVISOR != 1 && CONFIG_CAN_STM32FD_CLOCK_DIVISOR & 0x01
-#error CAN_STM32FD_CLOCK_DIVISOR invalid. Allowed values are 1 or 2 * n, where n <= 15.
-#else
-#define CAN_STM32FD_CLOCK_DIVISOR CONFIG_CAN_STM32FD_CLOCK_DIVISOR
-#endif /* CONFIG_CAN_STM32FD_CLOCK_DIVISOR */
-#else
-#define CAN_STM32FD_CLOCK_DIVISOR 1U
-#endif /* CONFIG_CAN_STM32FD_CLOCK_DIVISOR*/
-
 #define DT_DRV_COMPAT st_stm32_fdcan
 
 /* This symbol takes the value 1 if one of the device instances */
@@ -43,6 +33,7 @@ struct can_stm32fd_config {
 	const struct stm32_pclken *pclken;
 	void (*config_irq)(void);
 	const struct pinctrl_dev_config *pcfg;
+	uint8_t clock_divider;
 };
 
 static int can_stm32fd_get_core_clock(const struct device *dev, uint32_t *rate)
@@ -56,7 +47,11 @@ static int can_stm32fd_get_core_clock(const struct device *dev, uint32_t *rate)
 		return -EIO;
 	}
 
-	*rate = rate_tmp / CAN_STM32FD_CLOCK_DIVISOR;
+	if (FDCAN_CONFIG->CKDIV == 0) {
+		*rate = rate_tmp;
+	} else {
+		*rate = rate_tmp / (FDCAN_CONFIG->CKDIV << 1);
+	}
 
 	return 0;
 }
@@ -87,8 +82,10 @@ static int can_stm32fd_clock_enable(const struct device *dev)
 		return ret;
 	}
 
-	can_mcan_enable_configuration_change(dev);
-	FDCAN_CONFIG->CKDIV = CAN_STM32FD_CLOCK_DIVISOR >> 1;
+	if (stm32fd_cfg->clock_divider != 0) {
+		can_mcan_enable_configuration_change(dev);
+		FDCAN_CONFIG->CKDIV = stm32fd_cfg->clock_divider >> 1;
+	}
 
 	return 0;
 }
@@ -194,6 +191,7 @@ static void config_can_##inst##_irq(void)                                      \
 		.pclk_len = DT_INST_NUM_CLOCKS(inst),			\
 		.config_irq = config_can_##inst##_irq,			\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),		\
+		.clock_divider = DT_INST_PROP_OR(inst, clk_divider, 0)  \
 	};								\
 									\
 	static const struct can_mcan_config can_mcan_cfg_##inst =	\

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -87,6 +87,7 @@ static int can_stm32fd_clock_enable(const struct device *dev)
 		return ret;
 	}
 
+	can_mcan_enable_configuration_change(dev);
 	FDCAN_CONFIG->CKDIV = CAN_STM32FD_CLOCK_DIVISOR >> 1;
 
 	return 0;

--- a/dts/bindings/can/st,stm32-fdcan.yaml
+++ b/dts/bindings/can/st,stm32-fdcan.yaml
@@ -13,3 +13,31 @@ properties:
 
     clocks:
       required: true
+
+    clk-divider:
+      type: int
+      required: false
+      enum:
+        - 1
+        - 2
+        - 4
+        - 6
+        - 8
+        - 10
+        - 12
+        - 14
+        - 16
+        - 18
+        - 20
+        - 22
+        - 24
+        - 26
+        - 28
+        - 30
+
+      description: |
+        Divides the kernel clock giving the time quanta clock that is fed to the
+        CAN core(FDCAN_CKDIV).
+        Note that the divisor is common to all 'st,stm32-fdcan' instances.
+        Divide by 1 is the peripherals reset value and remains set unless
+        this property is configured.


### PR DESCRIPTION
- Use domain clocks if they are defined in devicetree.

    Until now domain clock sources could be selected via kconfig.
    STM32 platform now can configure domain clock sources via
    clock control driver, therefore this commit makes use of it.
   
    The configuration is shared between canfd instances, so a domain clock
    has to be defined for only one instance. Otherwise, only the
    configuration from the latest initialized instance will remain.

- move clock divider configuration to devicetree

    Remove the CAN_STM32FD_CLOCK_DIVISOR configuration option,
    and add configuration via dts property clk-divider instead.

-   Fix clock divider configuration

    The configurable CAN clock divider CAN_STM32FD_CLOCK_DIVISOR
    was not applied during initialization, because write protection
    was not disabled.
    
    While the clock divider was not applied, it was still used in clock rate
    calculation, therefore resulting in incorrect bus speed setup.

Fixes #49890