### PR TITLE
drivers: usb: usb_dc_sam_usbhs: Initialize Endpoint FIFO During Configuration

### DIFF
--- a/drivers/usb/device/usb_dc_sam_usbhs.c
+++ b/drivers/usb/device/usb_dc_sam_usbhs.c
@@ -465,6 +465,8 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data *const cfg)
 
 	/* Reset the endpoint */
 	usb_dc_ep_reset(ep_idx);
+	/* Initialize the endpoint FIFO */
+	usb_dc_ep_fifo_reset(ep_idx);
 
 	/* Map the endpoint type */
 	switch (cfg->ep_type) {


### PR DESCRIPTION
Ensure that the FIFO of each endpoint is initialized during endpoint configuration, to prevent a NULL FIFO from being encountered during the first call to usb_dc_ep_write() for a given endpoint.

Python script [from this comment of the issue](https://github.com/zephyrproject-rtos/zephyr/issues/48671#issuecomment-1236254450) will fail before change and pass after change (run with zephyr webusb sample on samv71b xplained board) because the FIFOs for each endpoint weren't being initialized before first use, causing the first write for each endpoint to not send any data to the host.

Fixes #48671

Signed-off-by: Nick Kraus <nick@nckraus.com>