### PR TITLE
dts/arm/st/f1: stm32f107: add Ethernet MAC

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -798,10 +798,10 @@ static int eth_initialize(const struct device *dev)
 		(clock_control_subsys_t *)&cfg->pclken_tx);
 	ret |= clock_control_on(dev_data->clock,
 		(clock_control_subsys_t *)&cfg->pclken_rx);
-#if !defined(CONFIG_SOC_SERIES_STM32H7X)
+#if DT_INST_CLOCKS_HAS_NAME(0, mac_clk_ptp)
 	ret |= clock_control_on(dev_data->clock,
 		(clock_control_subsys_t *)&cfg->pclken_ptp);
-#endif /* !defined(CONFIG_SOC_SERIES_STM32H7X) */
+#endif
 
 	if (ret) {
 		LOG_ERR("Failed to enable ethernet clock");
@@ -1069,10 +1069,10 @@ static const struct eth_stm32_hal_dev_cfg eth0_config = {
 		      .enr = DT_INST_CLOCKS_CELL_BY_NAME(0, mac_clk_tx, bits)},
 	.pclken_rx = {.bus = DT_INST_CLOCKS_CELL_BY_NAME(0, mac_clk_rx, bus),
 		      .enr = DT_INST_CLOCKS_CELL_BY_NAME(0, mac_clk_rx, bits)},
-#if !defined(CONFIG_SOC_SERIES_STM32H7X)
+#if DT_INST_CLOCKS_HAS_NAME(0, mac_clk_ptp)
 	.pclken_ptp = {.bus = DT_INST_CLOCKS_CELL_BY_NAME(0, mac_clk_ptp, bus),
 		       .enr = DT_INST_CLOCKS_CELL_BY_NAME(0, mac_clk_ptp, bits)},
-#endif /* !CONFIG_SOC_SERIES_STM32H7X */
+#endif
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };
 

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -26,9 +26,9 @@ struct eth_stm32_hal_dev_cfg {
 	struct stm32_pclken pclken;
 	struct stm32_pclken pclken_rx;
 	struct stm32_pclken pclken_tx;
-#if !defined(CONFIG_SOC_SERIES_STM32H7X)
+#if DT_INST_CLOCKS_HAS_NAME(0, mac_clk_ptp)
 	struct stm32_pclken pclken_ptp;
-#endif /* !defined(CONFIG_SOC_SERIES_STM32H7X) */
+#endif
 	const struct pinctrl_dev_config *pcfg;
 };
 

--- a/dts/arm/st/f1/stm32f107.dtsi
+++ b/dts/arm/st/f1/stm32f107.dtsi
@@ -16,5 +16,17 @@
 			interrupts = <56 0 57 0 58 0 59 0 60 0>;
 			status = "disabled";
 		};
+
+		mac: ethernet@40028000 {
+			compatible = "st,stm32-ethernet";
+			reg = <0x40028000 0x2000>;
+			interrupts = <61 0>;
+			clock-names = "stmmaceth", "mac-clk-tx",
+				      "mac-clk-rx";
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00004000>,
+				 <&rcc STM32_CLOCK_BUS_AHB1 0x00008000>,
+				 <&rcc STM32_CLOCK_BUS_AHB1 0x00010000>;
+			status = "disabled";
+		};
 	};
 };


### PR DESCRIPTION
Add Ethernet MAC to STM32F107 dts, similar to SMT32F207 but different clocks and especially no PTP clock.

Note that PHY configuration from Zephyr through DT or Kconfig is not possible, HAL has to be modified manually, in particular `stm32f1xx_hal_conf.h` when using a LAN8720A/LAN8742 for example, and also note that the default configuration generated by STM32CubeMX for LAN8742 is wrong (see: https://community.st.com/s/question/0D53W000015bQsFSAU/cant-get-f746zg-nucleo-ethernet-to-work-with-the-lwip-example-on-cubeide ).