### PR TITLE
boards: riscv: adp_xc7k_ae350: update dts for atmel eeprom driver

### DIFF
--- a/boards/riscv/adp_xc7k_ae350/adp_xc7k_ae350.dts
+++ b/boards/riscv/adp_xc7k_ae350/adp_xc7k_ae350.dts
@@ -19,6 +19,7 @@
 		led0 = &seg7_led1_g;
 		led1 = &seg7_led2_g;
 		sw0 = &user_button1;
+		eeprom-0 = &eeprom;
 	};
 
 	chosen {
@@ -164,6 +165,15 @@
 
 &i2c0 {
 	status = "okay";
+	eeprom: eeprom@50 {
+		compatible = "atmel,at24";
+		reg = <0x50>;
+		status = "okay";
+		size = <16384>;
+		pagesize = <64>;
+		address-width = <16>;
+		timeout = <5>;
+	};
 };
 
 &spi1 {

--- a/boards/riscv/adp_xc7k_ae350/adp_xc7k_ae350.yaml
+++ b/boards/riscv/adp_xc7k_ae350/adp_xc7k_ae350.yaml
@@ -11,6 +11,7 @@ supported:
   - counter
   - i2c
   - spi
+  - eeprom
 testing:
   ignore_tags:
     - bluetooth


### PR DESCRIPTION
Update dts for usage of atmel eeprom driver.

Signed-off-by: Wei-Tai Lee <wtlee@andestech.com>