### PR TITLE
logging: Use STRUCT_SECTION macros for log backend

### DIFF
--- a/include/zephyr/linker/common-rom/common-rom-logging.ld
+++ b/include/zephyr/linker/common-rom/common-rom-logging.ld
@@ -14,9 +14,4 @@
 		__log_const_end = .;
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-	SECTION_DATA_PROLOGUE(log_backends_sections,,)
-	{
-		__log_backends_start = .;
-		KEEP(*("._log_backend.*"));
-		__log_backends_end = .;
-	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	ITERABLE_SECTION_ROM(log_backend, 4)

--- a/include/zephyr/logging/log_backend.h
+++ b/include/zephyr/logging/log_backend.h
@@ -94,9 +94,6 @@ struct log_backend {
 	bool autostart;
 };
 
-extern const struct log_backend __log_backends_start[];
-extern const struct log_backend __log_backends_end[];
-
 /**
  * @brief Macro for creating a logger backend instance.
  *
@@ -246,7 +243,11 @@ static inline uint8_t log_backend_id_get(const struct log_backend *const backend
  */
 static inline const struct log_backend *log_backend_get(uint32_t idx)
 {
-	return &__log_backends_start[idx];
+	const struct log_backend *backend;
+
+	STRUCT_SECTION_GET(log_backend, idx, &backend);
+
+	return backend;
 }
 
 /**
@@ -256,7 +257,11 @@ static inline const struct log_backend *log_backend_get(uint32_t idx)
  */
 static inline int log_backend_count_get(void)
 {
-	return __log_backends_end - __log_backends_start;
+	int cnt;
+
+	STRUCT_SECTION_COUNT(log_backend, &cnt);
+
+	return cnt;
 }
 
 /**

--- a/subsys/logging/log_cmds.c
+++ b/subsys/logging/log_cmds.c
@@ -41,11 +41,9 @@ static const char * const severity_lvls_sorted[] = {
  */
 static const struct log_backend *backend_find(char const *name)
 {
-	const struct log_backend *backend;
 	size_t slen = strlen(name);
 
-	for (int i = 0; i < log_backend_count_get(); i++) {
-		backend = log_backend_get(i);
+	STRUCT_SECTION_FOREACH(log_backend, backend) {
 		if (strncmp(name, backend->name, slen) == 0) {
 			return backend;
 		}
@@ -343,13 +341,7 @@ static int cmd_log_backend_go(const struct shell *shell,
 static int cmd_log_backends_list(const struct shell *shell,
 				 size_t argc, char **argv)
 {
-	int backend_count;
-
-	backend_count = log_backend_count_get();
-
-	for (int i = 0; i < backend_count; i++) {
-		const struct log_backend *backend = log_backend_get(i);
-
+	STRUCT_SECTION_FOREACH(log_backend, backend) {
 		shell_fprintf(shell, SHELL_NORMAL,
 			      "%s\r\n"
 			      "\t- Status: %s\r\n"
@@ -410,9 +402,7 @@ static void backend_name_get(size_t idx, struct shell_static_entry *entry)
 	entry->subcmd = &sub_log_backend;
 	entry->syntax  = NULL;
 
-	if (idx < log_backend_count_get()) {
-		const struct log_backend *backend = log_backend_get(idx);
-
+	STRUCT_SECTION_FOREACH(log_backend, backend) {
 		entry->syntax = backend->name;
 	}
 }

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -159,11 +159,9 @@ static void z_log_msg_post_finalize(void)
 
 const struct log_backend *log_format_set_all_active_backends(size_t log_type)
 {
-	const struct log_backend *backend;
 	const struct log_backend *failed_backend = NULL;
 
-	for (int i = 0; i < log_backend_count_get(); i++) {
-		backend = log_backend_get(i);
+	STRUCT_SECTION_FOREACH(log_backend, backend) {
 		if (log_backend_is_active(backend)) {
 			int retCode = log_backend_format_set(backend, log_type);
 
@@ -262,16 +260,15 @@ static uint32_t z_log_init(bool blocking, bool can_sleep)
 	}
 
 	__ASSERT_NO_MSG(log_backend_count_get() < LOG_FILTERS_NUM_OF_SLOTS);
-	int i;
 
 	if (atomic_inc(&initialized) != 0) {
 		return 0;
 	}
 
-	/* Assign ids to backends. */
-	for (i = 0; i < log_backend_count_get(); i++) {
-		const struct log_backend *backend = log_backend_get(i);
+	int i = 0;
 
+	/* Assign ids to backends. */
+	STRUCT_SECTION_FOREACH(log_backend, backend) {
 		if (backend->autostart) {
 			log_backend_init(backend);
 
@@ -285,6 +282,8 @@ static uint32_t z_log_init(bool blocking, bool can_sleep)
 			} else {
 				mask |= BIT(i);
 			}
+
+			i++;
 		}
 	}
 
@@ -346,8 +345,6 @@ int log_set_timestamp_func(log_timestamp_get_t timestamp_getter, uint32_t freq)
 
 void z_impl_log_panic(void)
 {
-	struct log_backend const *backend;
-
 	if (panic_mode) {
 		return;
 	}
@@ -364,9 +361,7 @@ void z_impl_log_panic(void)
 		}
 	}
 
-	for (int i = 0; i < log_backend_count_get(); i++) {
-		backend = log_backend_get(i);
-
+	STRUCT_SECTION_FOREACH(log_backend, backend) {
 		if (log_backend_is_active(backend)) {
 			log_backend_panic(backend);
 		}
@@ -425,10 +420,7 @@ static bool msg_filter_check(struct log_backend const *backend,
 
 static void msg_process(union log_msg_generic *msg)
 {
-	struct log_backend const *backend;
-
-	for (int i = 0; i < log_backend_count_get(); i++) {
-		backend = log_backend_get(i);
+	STRUCT_SECTION_FOREACH(log_backend, backend) {
 		if (log_backend_is_active(backend) &&
 		    msg_filter_check(backend, msg)) {
 			log_backend_msg_process(backend, msg);
@@ -440,9 +432,7 @@ void dropped_notify(void)
 {
 	uint32_t dropped = z_log_dropped_read_and_clear();
 
-	for (int i = 0; i < log_backend_count_get(); i++) {
-		struct log_backend const *backend = log_backend_get(i);
-
+	STRUCT_SECTION_FOREACH(log_backend, backend) {
 		if (log_backend_is_active(backend)) {
 			log_backend_dropped(backend, dropped);
 		}
@@ -638,9 +628,7 @@ int log_mem_get_max_usage(uint32_t *max)
 static void log_backend_notify_all(enum log_backend_evt event,
 				   union log_backend_evt_arg *arg)
 {
-	for (int i = 0; i < log_backend_count_get(); i++) {
-		const struct log_backend *backend = log_backend_get(i);
-
+	STRUCT_SECTION_FOREACH(log_backend, backend) {
 		log_backend_notify(backend, event, arg);
 	}
 }

--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -104,12 +104,10 @@ uint32_t z_impl_log_filter_set(struct log_backend const *const backend,
 		uint32_t *filters = z_log_dynamic_filters_get(source_id);
 
 		if (backend == NULL) {
-			struct log_backend const *iter_backend;
 			uint32_t max = 0U;
 			uint32_t current;
 
-			for (int i = 0; i < log_backend_count_get(); i++) {
-				iter_backend = log_backend_get(i);
+			STRUCT_SECTION_FOREACH(log_backend, iter_backend) {
 				current = log_filter_set(iter_backend,
 							 domain_id,
 							 source_id, level);
@@ -174,14 +172,12 @@ static void backend_filter_set(struct log_backend const *const backend,
 
 const struct log_backend *log_backend_get_by_name(const char *backend_name)
 {
-	const struct log_backend *ptr = __log_backends_start;
-
-	while (ptr < __log_backends_end) {
-		if (strcmp(backend_name, ptr->name) == 0) {
-			return ptr;
+	STRUCT_SECTION_FOREACH(log_backend, backend) {
+		if (strcmp(backend_name, backend->name) == 0) {
+			return backend;
 		}
-		ptr++;
 	}
+
 	return NULL;
 }
 

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -127,7 +127,10 @@ static void process_and_validate(bool backend2_enable, bool panic)
 	mock_log_frontend_validate(panic);
 
 	if (NO_BACKENDS) {
-		zassert_equal(log_backend_count_get(), 0);
+		int cnt;
+
+		STRUCT_SECTION_COUNT(log_backend, &cnt);
+		zassert_equal(cnt, 0);
 		return;
 	}
 

--- a/tests/subsys/logging/log_backend_init/src/main.c
+++ b/tests/subsys/logging/log_backend_init/src/main.c
@@ -8,6 +8,7 @@
 #include <zephyr/tc_util.h>
 #include <stdbool.h>
 #include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/ztest.h>
 #include <zephyr/logging/log_backend.h>
 #include <zephyr/logging/log_ctrl.h>
@@ -111,7 +112,10 @@ LOG_BACKEND_DEFINE(backend2, backend_api, true, &context2);
  */
 ZTEST(log_backend_init, test_log_backends_initialization)
 {
-	if (log_backend_count_get() != 2) {
+	int cnt;
+
+	STRUCT_SECTION_COUNT(log_backend, &cnt);
+	if (cnt != 2) {
 		/* Other backends should not be enabled. */
 		ztest_test_skip();
 	}

--- a/tests/subsys/logging/log_core_additional/src/log_test.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test.c
@@ -238,10 +238,7 @@ ZTEST(test_log_core_additional, test_log_early_logging)
 		log_init();
 
 		/* deactivate other backends */
-		const struct log_backend *backend;
-
-		for (int i = 0; i < log_backend_count_get(); i++) {
-			backend = log_backend_get(i);
+		STRUCT_SECTION_FOREACH(log_backend, backend) {
 			if (strcmp(backend->name, "test")) {
 				log_backend_deactivate(backend);
 			}
@@ -309,10 +306,7 @@ ZTEST(test_log_core_additional, test_log_timestamping)
 
 	log_init();
 	/* deactivate all other backend */
-	const struct log_backend *backend;
-
-	for (int i = 0; i < log_backend_count_get(); i++) {
-		backend = log_backend_get(i);
+	STRUCT_SECTION_FOREACH(log_backend, backend) {
 		log_backend_deactivate(backend);
 	}
 
@@ -356,18 +350,19 @@ ZTEST(test_log_core_additional, test_log_timestamping)
 #define UART_BACKEND "log_backend_uart"
 ZTEST(test_log_core_additional, test_multiple_backends)
 {
+	int cnt;
+
 	TC_PRINT("Test multiple backends");
 	/* enable both backend1 and backend2 */
 	log_setup(true);
-	zassert_true((log_backend_count_get() >= 2),
+	STRUCT_SECTION_COUNT(log_backend, &cnt);
+	zassert_true((cnt >= 2),
 		     "There is no multi backends");
 
 	if (IS_ENABLED(CONFIG_LOG_BACKEND_UART)) {
 		bool have_uart = false;
-		struct log_backend const *backend;
 
-		for (int i = 0; i < log_backend_count_get(); i++) {
-			backend = log_backend_get(i);
+		STRUCT_SECTION_FOREACH(log_backend, backend) {
 			if (strcmp(backend->name, UART_BACKEND) == 0) {
 				have_uart = true;
 			}


### PR DESCRIPTION
Clean up logging code to utilize macros for handling sections.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>