### PR TITLE
logging: log_output: Use \r\n instead of \n\r for printk

### DIFF
--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -125,10 +125,10 @@ static int out_func(int c, void *ctx)
 
 static int cr_out_func(int c, void *ctx)
 {
-	out_func(c, ctx);
 	if (c == '\n') {
 		out_func((int)'\r', ctx);
 	}
+	out_func(c, ctx);
 
 	return 0;
 }


### PR DESCRIPTION
Replace order to be compatible with printk and other logging outputs.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>