### PR TITLE
shell: Add option to format logging timestamp

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -238,6 +238,14 @@ config SHELL_LOG_BACKEND
 	  using the shell backend's LOG_LEVEL option
 	  (e.g. CONFIG_SHELL_TELNET_INIT_LOG_LEVEL_NONE=y).
 
+config SHELL_LOG_FORMAT_TIMESTAMP
+	bool "Format timestamp"
+	default y
+	depends on SHELL_LOG_BACKEND
+	help
+	  Enable timestamp formatting.
+
+
 source "subsys/shell/modules/Kconfig"
 
 endif # SHELL

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -158,7 +158,8 @@ static void process_log_msg(const struct shell *sh,
 	unsigned int key = 0;
 	uint32_t flags = LOG_OUTPUT_FLAG_LEVEL |
 		      LOG_OUTPUT_FLAG_TIMESTAMP |
-		      LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
+		      (IS_ENABLED(CONFIG_SHELL_LOG_FORMAT_TIMESTAMP) ?
+			LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP : 0);
 
 	if (colors) {
 		flags |= LOG_OUTPUT_FLAG_COLORS;


### PR DESCRIPTION
Add option to control formatting of the logging timestamp. By default
formatting is enabled which maintains backward compatibility.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>