### PR TITLE
cmake: remove obsolete CONFIG_ZTEST_NEW_API from CMakeLists.txt

### DIFF
--- a/tests/bluetooth/controller/ctrl_cte_req/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_cte_req/CMakeLists.txt
@@ -9,7 +9,6 @@ FILE(GLOB SOURCES
   src/*.c
 )
 
-set(CONFIG_ZTEST_NEW_API y)
 project(bluetooth_ull_llcp_le_cte_req)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)


### PR DESCRIPTION
Follow-up: #49243, #48732

With the introduction of Kconfig for unit_testing board and setting
ZTEST_NEW_API in testcase.yaml, the need and support of setting this
directly in CMakeLists.txt is obsolete.

Remove the code line.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>