### PR TITLE
tests: kernel: gen_isr_table: Disable RISC-V direct ISR test

### DIFF
--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -38,6 +38,9 @@ tests:
       - CONFIG_TEST_HW_STACK_PROTECTION=n
     tags: kernel interrupt isr_table
   arch.interrupt.gen_isr_table.riscv_direct:
+    # FIXME: Direct ISR (IRQ vector table) test is disabled due to broken
+    #        vectors table placement (see GitHub issue #49903).
+    arch_exclude: riscv32 riscv64
     platform_exclude: m2gl025_miv
     filter: CONFIG_RISCV and CONFIG_SOC_FAMILY_RISCV_PRIVILEGE
     tags: kernel interrupt isr_table


### PR DESCRIPTION
This commit disables the RISC-V direct ISR test due to the broken
`vectors` section placement with the IRQ vector table enabled,
introduced by the commit d2f8ec70235208f4a70e371ccb1ed8dfe0f573c5.

For more details, refer to the GitHub issue #49903 tracking this bug.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

**This is a temporary fix to make the CI pass until a more fundamental solution described in #49903 is implemented.**