### PR TITLE
samples: net: sockets: can: unconditionally include can.h

### DIFF
--- a/samples/net/sockets/can/src/main.c
+++ b/samples/net/sockets/can/src/main.c
@@ -9,13 +9,10 @@ LOG_MODULE_REGISTER(net_socket_can_sample, LOG_LEVEL_DBG);
 
 #include <zephyr/zephyr.h>
 
+#include <zephyr/drivers/can.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/socketcan.h>
 #include <zephyr/net/socketcan_utils.h>
-
-#ifdef CONFIG_SAMPLE_SOCKETCAN_LOOPBACK_MODE
-#include <zephyr/drivers/can.h>
-#endif
 
 #define PRIORITY  k_thread_priority_get(k_current_get())
 #define STACKSIZE 1024


### PR DESCRIPTION
This header is also needed for `struct can_filter`, so it should not only be included if one wants to set the device into loopback mode.