### PR TITLE
net: socketcan: make socketcan_frame CAN FD capable

### DIFF
--- a/include/zephyr/net/socketcan.h
+++ b/include/zephyr/net/socketcan.h
@@ -39,11 +39,20 @@ enum {
 	CAN_RAW_FILTER = 1,
 };
 
-/* SocketCAN max data payload length */
+/* SocketCAN MTU size compatible with Linux */
+#ifdef CONFIG_CAN_FD_MODE
+#define SOCKETCAN_MAX_DLEN 64U
+#define CANFD_MTU (sizeof(struct socketcan_frame))
+#define CAN_MTU (CANFD_MTU - 56U)
+#else /* CONFIG_CAN_FD_MODE */
 #define SOCKETCAN_MAX_DLEN 8U
+#define CAN_MTU (sizeof(struct socketcan_frame))
+#endif /* !CONFIG_CAN_FD_MODE */
 
-/* SocketCAN MTU size */
-#define CAN_MTU sizeof(struct socketcan_frame)
+/* CAN-FD specific flags from Linux Kernel (include/uapi/linux/can.h) */
+#define CANFD_BRS 0x01 /* bit rate switch (second bitrate for payload data) */
+#define CANFD_ESI 0x02 /* error state indicator of the transmitting node */
+#define CANFD_FDF 0x04 /* mark CAN FD for dual use of struct canfd_frame */
 
 /**
  * struct sockaddr_can - The sockaddr structure for CAN sockets
@@ -92,12 +101,11 @@ typedef uint32_t socketcan_id_t;
 struct socketcan_frame {
 	/** 32-bit CAN ID + EFF/RTR/ERR flags. */
 	socketcan_id_t can_id;
-
-	/** The data length code (DLC). */
-	uint8_t can_dlc;
-
+	/** Frame payload length in bytes. */
+	uint8_t len;
+	/** Additional flags for CAN FD. */
+	uint8_t flags;
 	/** @cond INTERNAL_HIDDEN */
-	uint8_t pad;   /* padding. */
 	uint8_t res0;  /* reserved/padding. */
 	uint8_t res1;  /* reserved/padding. */
 	/** @endcond */

--- a/include/zephyr/net/socketcan_utils.h
+++ b/include/zephyr/net/socketcan_utils.h
@@ -39,7 +39,8 @@ static inline void socketcan_to_can_frame(const struct socketcan_frame *sframe,
 	zframe->id_type = (sframe->can_id & BIT(31)) >> 31;
 	zframe->rtr = (sframe->can_id & BIT(30)) >> 30;
 	zframe->id = sframe->can_id & BIT_MASK(29);
-	zframe->dlc = sframe->can_dlc;
+	zframe->dlc = can_bytes_to_dlc(sframe->len);
+	zframe->fd = !!(sframe->flags & CANFD_FDF);
 	memcpy(zframe->data, sframe->data, MIN(sizeof(sframe->data), sizeof(zframe->data)));
 }
 
@@ -53,7 +54,10 @@ static inline void socketcan_from_can_frame(const struct can_frame *zframe,
 					    struct socketcan_frame *sframe)
 {
 	sframe->can_id = (zframe->id_type << 31) | (zframe->rtr << 30) | zframe->id;
-	sframe->can_dlc = zframe->dlc;
+	sframe->len = can_dlc_to_bytes(zframe->dlc);
+	if (zframe->fd) {
+		sframe->flags = CANFD_FDF;
+	}
 	memcpy(sframe->data, zframe->data, MIN(sizeof(zframe->data), sizeof(sframe->data)));
 }
 

--- a/tests/net/socket/can/src/main.c
+++ b/tests/net/socket/can/src/main.c
@@ -24,7 +24,7 @@ ZTEST(socket_can, test_socketcan_frame_to_can_frame)
 						   0x05, 0x06, 0x07, 0x08 };
 
 	sframe.can_id = BIT(31) | BIT(30) | 1234;
-	sframe.can_dlc = sizeof(data);
+	sframe.len = sizeof(data);
 	memcpy(sframe.data, data, sizeof(sframe.data));
 
 	expected.rtr = CAN_REMOTEREQUEST;
@@ -56,7 +56,7 @@ ZTEST(socket_can, test_can_frame_to_socketcan_frame)
 						   0x05, 0x06, 0x07, 0x08 };
 
 	expected.can_id = BIT(31) | BIT(30) | 1234;
-	expected.can_dlc = sizeof(data);
+	expected.len = sizeof(data);
 	memcpy(expected.data, data, sizeof(expected.data));
 
 	zframe.rtr = CAN_REMOTEREQUEST;
@@ -74,7 +74,7 @@ ZTEST(socket_can, test_can_frame_to_socketcan_frame)
 	zassert_equal(sframe.can_id, expected.can_id, "CAN ID not same");
 	zassert_mem_equal(&sframe.data, &expected.data, sizeof(sframe.data),
 			  "CAN data not same");
-	zassert_equal(sframe.can_dlc, expected.can_dlc,
+	zassert_equal(sframe.len, expected.len,
 		      "CAN msg length not same");
 }
 


### PR DESCRIPTION
Align the `struct socketcan_frame` to most recent [Linux kernel](https://elixir.bootlin.com/linux/v5.19.6/source/include/uapi/linux/can.h).

Compatibility with legacy can frames is maintained because the DLC is equal to payload length for up to 8 bytes. Only the data buffer is extended, resulting in larger size when CAN FD is enabled.
