### PR TITLE
use dts for mmu mapping

### DIFF
--- a/boards/arm64/mimx8mm_evk/mimx8mm_evk_a53.dts
+++ b/boards/arm64/mimx8mm_evk/mimx8mm_evk_a53.dts
@@ -37,6 +37,8 @@
 };
 
 &uart4 {
+	zephyr,memory-region = "UART4";
+	zephyr,memory-region-mmu = "MT_DEVICE_nGnRnE", "MT_P_RW_U_NA", "MT_NS";
 	current-speed = <115200>;
 	pinctrl-0 = <&uart4_default>;
 	pinctrl-names = "default";

--- a/boards/arm64/mimx8mm_evk/mimx8mm_evk_a53_smp.dts
+++ b/boards/arm64/mimx8mm_evk/mimx8mm_evk_a53_smp.dts
@@ -39,6 +39,8 @@
 };
 
 &uart4 {
+	zephyr,memory-region = "UART4";
+	zephyr,memory-region-mmu = "MT_DEVICE_nGnRnE", "MT_P_RW_U_NA", "MT_NS";
 	current-speed = <115200>;
 	pinctrl-0 = <&uart4_default>;
 	pinctrl-names = "default";

--- a/boards/arm64/mimx8mn_evk/mimx8mn_evk_a53.dts
+++ b/boards/arm64/mimx8mn_evk/mimx8mn_evk_a53.dts
@@ -37,6 +37,8 @@
 };
 
 &uart4 {
+	zephyr,memory-region = "UART4";
+	zephyr,memory-region-mmu = "MT_DEVICE_nGnRnE", "MT_P_RW_U_NA", "MT_NS";
 	current-speed = <115200>;
 	pinctrl-0 = <&uart4_default>;
 	pinctrl-names = "default";

--- a/boards/arm64/mimx8mn_evk/mimx8mn_evk_a53_smp.dts
+++ b/boards/arm64/mimx8mn_evk/mimx8mn_evk_a53_smp.dts
@@ -39,6 +39,8 @@
 };
 
 &uart4 {
+	zephyr,memory-region = "UART4";
+	zephyr,memory-region-mmu = "MT_DEVICE_nGnRnE", "MT_P_RW_U_NA", "MT_NS";
 	current-speed = <115200>;
 	pinctrl-0 = <&uart4_default>;
 	pinctrl-names = "default";

--- a/boards/arm64/mimx8mp_evk/mimx8mp_evk_a53.dts
+++ b/boards/arm64/mimx8mp_evk/mimx8mp_evk_a53.dts
@@ -37,6 +37,8 @@
 };
 
 &uart4 {
+	zephyr,memory-region = "UART4";
+	zephyr,memory-region-mmu = "MT_DEVICE_nGnRnE", "MT_P_RW_U_NA", "MT_NS";
 	status = "okay";
 	current-speed = <115200>;
 	clocks = <&ccm IMX_CCM_UART4_CLK 0x6c 24>;

--- a/boards/arm64/mimx8mp_evk/mimx8mp_evk_a53_smp.dts
+++ b/boards/arm64/mimx8mp_evk/mimx8mp_evk_a53_smp.dts
@@ -40,6 +40,8 @@
 };
 
 &uart4 {
+	zephyr,memory-region = "UART4";
+	zephyr,memory-region-mmu = "MT_DEVICE_nGnRnE", "MT_P_RW_U_NA", "MT_NS";
 	current-speed = <115200>;
 	pinctrl-0 = <&uart4_default>;
 	pinctrl-names = "default";

--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -233,6 +233,7 @@ other-macro =/ %s"DT_N_INST_" dt-name %s"_NUM_OKAY"
 ; DT_FOREACH_STATUS_OKAY_NODE respectively.
 other-macro =/ %s"DT_FOREACH_HELPER"
 other-macro =/ %s"DT_FOREACH_OKAY_HELPER"
+other-macro =/ %s"DT_FOREACH_OKAY_VARGS_HELPER"
 ; These are used internally by DT_FOREACH_STATUS_OKAY,
 ; which iterates over each enabled node of a compatible.
 other-macro =/ %s"DT_FOREACH_OKAY_" dt-name

--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -109,3 +109,22 @@ properties:
       required: false
       type: string-array
       description: Provided names of mailbox / IPM channel specifiers
+
+    zephyr,memory-region:
+      type: string
+      required: false
+      description: |
+        Signify that this node should result in a dedicated build script memory
+        region in the final executable when supported by the build script. The
+        region address and size is taken from the <reg> property, while the name
+        is the value of this property.
+
+    zephyr,memory-region-mmu:
+      type: string-array
+      required: false
+      description: |
+        Signify that this node should result in a dedicated MMU region. The
+        region address and size are taken from the <reg> property, the name
+        is taken from <zephyr,memory-region>, while the MMU attribute is the
+        value of this string array property, each attribute string will be a
+        valid C token.

--- a/dts/bindings/base/zephyr,memory-region.yaml
+++ b/dts/bindings/base/zephyr,memory-region.yaml
@@ -9,13 +9,7 @@ include: base.yaml
 
 properties:
   zephyr,memory-region:
-    type: string
     required: true
-    description: |
-      Signify that this node should result in a dedicated linker script
-      memory region in the final executable. The region address and size
-      is taken from the <reg> property, while the name is the value of
-      this property.
 
   zephyr,memory-region-mpu:
     type: string

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2093,6 +2093,20 @@
 #define DT_FOREACH_STATUS_OKAY_NODE(fn) DT_FOREACH_OKAY_HELPER(fn)
 
 /**
+ * @brief Invokes "fn" with arguments for every status "okay" node in the tree.
+ *
+ * The macro "fn" can take extra parameters except node identifier.
+ * The macro is expanded once for each node in the tree with status
+ * "okay" (as usual, a missing status property is treated as status
+ * "okay"). The order that nodes are visited in is not
+ * specified.
+ *
+ * @param fn macro to invoke
+ * @param ... variable number of arguments to pass to fn
+ */
+#define DT_FOREACH_STATUS_OKAY_NODE_VARGS(fn, ...) DT_FOREACH_OKAY_VARGS_HELPER(fn, __VA_ARGS__)
+
+/**
  * @brief Invokes "fn" for each child of "node_id"
  *
  * The macro "fn" must take one parameter, which will be the node

--- a/include/zephyr/linker/devicetree_regions.h
+++ b/include/zephyr/linker/devicetree_regions.h
@@ -326,13 +326,13 @@
  *
  *   static const struct arm_mpu_region mpu_regions[] = {
  *       ...
- *       LINKER_DT_REGION_MPU(MPU_FN)
+ *       BUILD_DT_REGION_MPU(MPU_FN)
  *       ...
  *   };
  * @endcode
  *
  */
-#define LINKER_DT_REGION_MPU(mpu_fn) _CHECK_APPLY_MPU_FN(_DT_COMPATIBLE, _EXPAND_MPU_FN, mpu_fn)
+#define BUILD_DT_REGION_MPU(mpu_fn) _CHECK_APPLY_MPU_FN(_DT_COMPATIBLE, _EXPAND_MPU_FN, mpu_fn)
 
 /**
  * @brief Generate MMU regions from the device tree nodes with both

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -862,6 +862,9 @@ def write_global_macros(edt):
     out_dt_define("FOREACH_OKAY_HELPER(fn)",
                   " ".join(f"fn(DT_{node.z_path_id})" for node in edt.nodes
                            if node.status == "okay"))
+    out_dt_define("FOREACH_OKAY_VARGS_HELPER(fn, ...)",
+                  " ".join(f"fn(DT_{node.z_path_id}, __VA_ARGS__)" for node in edt.nodes
+                           if node.status == "okay"))
 
     n_okay_macros = {}
     for_each_macros = {}

--- a/soc/arm/common/cortex_m/arm_mpu_regions.c
+++ b/soc/arm/common/cortex_m/arm_mpu_regions.c
@@ -31,7 +31,7 @@ static const struct arm_mpu_region mpu_regions[] = {
 #endif
 
 	/* DT-defined regions */
-	LINKER_DT_REGION_MPU(ARM_MPU_REGION_INIT)
+	BUILD_DT_REGION_MPU(ARM_MPU_REGION_INIT)
 };
 
 const struct arm_mpu_config mpu_config = {

--- a/soc/arm/st_stm32/stm32h7/mpu_regions.c
+++ b/soc/arm/st_stm32/stm32h7/mpu_regions.c
@@ -24,7 +24,7 @@ static const struct arm_mpu_region mpu_regions[] = {
 #endif
 
 	/* DT-defined regions */
-	LINKER_DT_REGION_MPU(ARM_MPU_REGION_INIT)
+	BUILD_DT_REGION_MPU(ARM_MPU_REGION_INIT)
 };
 
 const struct arm_mpu_config mpu_config = {

--- a/soc/arm64/arm/fvp_aemv8a/mmu_regions.c
+++ b/soc/arm64/arm/fvp_aemv8a/mmu_regions.c
@@ -5,6 +5,7 @@
  */
 #include <zephyr/arch/arm64/arm_mmu.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/sys/util.h>
 
 static const struct arm_mmu_region mmu_regions[] = {
@@ -18,6 +19,8 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
 			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+
+	BUILD_DT_REGION_MMU(MMU_REGION_FLAT_ENTRY)
 };
 
 const struct arm_mmu_config mmu_config = {

--- a/soc/arm64/bcm_vk/viper/mmu_regions.c
+++ b/soc/arm64/bcm_vk/viper/mmu_regions.c
@@ -6,6 +6,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/arch/arm64/arm_mmu.h>
+#include <zephyr/linker/devicetree_regions.h>
 
 
 #define PCIE_OB_HIGHMEM_ADDR	DT_REG_ADDR_BY_NAME(DT_NODELABEL(pcie0_ep), \
@@ -26,6 +27,8 @@ static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_FLAT_ENTRY("DRAM0_S0",
 			      0x60000000, MB(512),
 			      MT_NORMAL | MT_P_RW_U_NA | MT_SECURE),
+
+	BUILD_DT_REGION_MMU(MMU_REGION_FLAT_ENTRY)
 };
 
 const struct arm_mmu_config mmu_config = {

--- a/soc/arm64/intel_socfpga/agilex/mmu_regions.c
+++ b/soc/arm64/intel_socfpga/agilex/mmu_regions.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/arch/arm64/arm_mmu.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/sys/util.h>
 
 static const struct arm_mmu_region mmu_regions[] = {
@@ -35,6 +36,8 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_ADDR_BY_IDX(DT_NODELABEL(gic), 1),
 			      DT_REG_SIZE_BY_IDX(DT_NODELABEL(gic), 1),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+
+	BUILD_DT_REGION_MMU(MMU_REGION_FLAT_ENTRY)
 };
 
 const struct arm_mmu_config mmu_config = {

--- a/soc/arm64/nxp_imx/mimx8m/mmu_regions.c
+++ b/soc/arm64/nxp_imx/mimx8m/mmu_regions.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/arch/arm64/arm_mmu.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/sys/util.h>
 
 static const struct arm_mmu_region mmu_regions[] = {
@@ -25,25 +26,17 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_SIZE(DT_NODELABEL(ccm)),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
 
-	MMU_REGION_FLAT_ENTRY("UART2",
-			      DT_REG_ADDR(DT_NODELABEL(uart2)),
-			      DT_REG_SIZE(DT_NODELABEL(uart2)),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
-
 	MMU_REGION_FLAT_ENTRY("ANA_PLL",
 			      DT_REG_ADDR(DT_NODELABEL(ana_pll)),
 			      DT_REG_SIZE(DT_NODELABEL(ana_pll)),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
-
-	MMU_REGION_FLAT_ENTRY("UART4",
-			      DT_REG_ADDR(DT_NODELABEL(uart4)),
-			      DT_REG_SIZE(DT_NODELABEL(uart4)),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
 
 	MMU_REGION_FLAT_ENTRY("IOMUXC",
 			      DT_REG_ADDR(DT_NODELABEL(iomuxc)),
 			      DT_REG_SIZE(DT_NODELABEL(iomuxc)),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+
+	BUILD_DT_REGION_MMU(MMU_REGION_FLAT_ENTRY)
 };
 
 const struct arm_mmu_config mmu_config = {

--- a/soc/arm64/nxp_layerscape/ls1046a/mmu_regions.c
+++ b/soc/arm64/nxp_layerscape/ls1046a/mmu_regions.c
@@ -5,6 +5,7 @@
  */
 #include <zephyr/arch/arm64/arm_mmu.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/sys/util.h>
 
 static const struct arm_mmu_region mmu_regions[] = {
@@ -18,6 +19,8 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
 			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+
+	BUILD_DT_REGION_MMU(MMU_REGION_FLAT_ENTRY)
 };
 
 const struct arm_mmu_config mmu_config = {

--- a/soc/arm64/qemu_cortex_a53/mmu_regions.c
+++ b/soc/arm64/qemu_cortex_a53/mmu_regions.c
@@ -6,6 +6,7 @@
  */
 #include <zephyr/arch/arm64/arm_mmu.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/sys/util.h>
 
 static const struct arm_mmu_region mmu_regions[] = {
@@ -19,6 +20,8 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
 			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_DEFAULT_SECURE_STATE),
+
+	BUILD_DT_REGION_MMU(MMU_REGION_FLAT_ENTRY)
 };
 
 const struct arm_mmu_config mmu_config = {

--- a/soc/arm64/xenvm/mmu_regions.c
+++ b/soc/arm64/xenvm/mmu_regions.c
@@ -6,6 +6,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/arch/arm64/arm_mmu.h>
+#include <zephyr/linker/devicetree_regions.h>
 
 static const struct arm_mmu_region mmu_regions[] = {
 
@@ -23,6 +24,8 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_ADDR_BY_IDX(DT_INST(0, xen_xen), 0),
 			      DT_REG_SIZE_BY_IDX(DT_INST(0, xen_xen), 0),
 			      MT_NORMAL | MT_P_RW_U_NA | MT_NS),
+
+	BUILD_DT_REGION_MMU(MMU_REGION_FLAT_ENTRY)
 };
 
 const struct arm_mmu_config mmu_config = {

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1258,10 +1258,12 @@ ZTEST(devicetree_api, test_foreach)
 #define IS_ALIASES(node_id) + DT_SAME_NODE(DT_PATH(aliases), node_id)
 #define IS_DISABLED_GPIO(node_id) + DT_SAME_NODE(DT_NODELABEL(disabled_gpio), \
 						node_id)
+#define IS_ALIASES_VARGS(node_id, ...)  + DT_SAME_NODE(DT_PATH(aliases), node_id)
 	zassert_equal(1, DT_FOREACH_NODE(IS_ALIASES), "");
 	zassert_equal(1, DT_FOREACH_NODE(IS_DISABLED_GPIO), "");
 	zassert_equal(1, DT_FOREACH_STATUS_OKAY_NODE(IS_ALIASES), "");
 	zassert_equal(0, DT_FOREACH_STATUS_OKAY_NODE(IS_DISABLED_GPIO), "");
+	zassert_equal(1, DT_FOREACH_STATUS_OKAY_NODE_VARGS(IS_ALIASES_VARGS, 1), "");
 
 #undef IS_ALIASES
 #undef IS_DISABLED_GPIO


### PR DESCRIPTION
   devicetree: add mmu mapping support

   Currently for ARM64, mmu mapping entries are hardcoded in soc's
   mmu_regions.c, and such mapping will be used for all board and
   applications although some mapping are not useful for some
   applications.

   So this patch provides another method to add mmu mapping entry
   by devicetree, so such each application can specify mmu mapping
   by devicetree overlay.

   Devicetree need to do the following update:
    1. Add property "zephyr,memory-region" to specify mmu entry name.
    2. Add property "zephyr,memory-region-mmu" to specify mmu entry
       attribute with string array which is valid c token from  architecture
        speficied MMU header file.
    3. The address and size will from "reg" node.

    For example:

            ccm: ccm@30380000 {
                    compatible = "nxp,imx-ccm";
                    reg = <0x30380000 DT_SIZE_K(64)>;
                    zephyr,memory-region = "CCM";
                    zephyr,memory-region-mmu = "MT_DEVICE_nGnRnE", "MT_P_RW_U_NA", "MT_NS";
                    #clock-cells = <3>;
           };

    And then in C code to include mmu entries specified in devicetree:
    For example in "mmu_regions.c" for ARM64 platform
    ...
    ...

    static const struct arm_mmu_region mmu_regions[] = {
            ...
            LINKER_DT_REGION_MMU(MMU_REGION_FLAT_ENTRY)
            ...
    };

With this dts example, the code generated will be:
```
   static const struct arm_mpu_region mpu_regions[] = {
       ...
       { .name = "CCM",
         .base = 0x30380000,
         .size = DT_SIZE_K(64),
         .attr = MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS, },
       ...
   };
```