### PR TITLE
soc/imx: imx6sx and imx7 fix pinmux mask (second fix)

### DIFF
--- a/soc/arm/nxp_imx/mcimx6x_m4/pinctrl_soc.h
+++ b/soc/arm/nxp_imx/mcimx6x_m4/pinctrl_soc.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #define IOMUXC_SW_MUX_CTL_PAD_MUX_MODE(x) ((x) & 0xF)
 #define IOMUXC_SW_MUX_CTL_PAD_SION(x) (((x) & 0x1) << 4)
-#define IOMUXC_SELECT_INPUT_DAISY(x) ((x) & 0x3)
+#define IOMUXC_SELECT_INPUT_DAISY(x) ((x) & 0x7)
 
 #define MCUX_IMX_INPUT_SCHMITT_ENABLE_SHIFT 16
 #define MCUX_IMX_BIAS_PULL_DOWN_SHIFT 14

--- a/soc/arm/nxp_imx/mcimx7_m4/pinctrl_soc.h
+++ b/soc/arm/nxp_imx/mcimx7_m4/pinctrl_soc.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #define IOMUXC_SW_MUX_CTL_PAD_MUX_MODE(x) ((x) & 0xF)
 #define IOMUXC_SW_MUX_CTL_PAD_SION(x) (((x) & 0x1) << 4)
-#define IOMUXC_SELECT_INPUT_DAISY(x) ((x) & 0x3)
+#define IOMUXC_SELECT_INPUT_DAISY(x) ((x) & 0x7)
 
 #define MCUX_IMX_BIAS_PULL_UP_SHIFT 5
 #define MCUX_IMX_PULL_ENABLE_SHIFT 4


### PR DESCRIPTION
According to RM, there are 2 pins that need a 3 bit mask for daisy chain,
changed it accordingly.
(E.g. IOMUXC_UART4_IPP_UART_RXD_MUX_SELECT_INPUT for imx6sx)

Signed-off-by: Antonio Tessarolo <anthonytexdev@gmail.com>