### PR TITLE
Replace long object name zephyr_library() usage with zephyr_library_named()

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/CMakeLists.txt
+++ b/arch/arm/core/aarch32/cortex_m/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
+zephyr_library_named(aarch32_cortex_m)
 
 zephyr_library_sources(
   exc_exit.S

--- a/arch/arm/core/aarch32/cortex_m/cmse/CMakeLists.txt
+++ b/arch/arm/core/aarch32/cortex_m/cmse/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
+zephyr_library_named(cmse)
 
 zephyr_library_sources(arm_core_cmse.c)

--- a/modules/TraceRecorder/CMakeLists.txt
+++ b/modules/TraceRecorder/CMakeLists.txt
@@ -6,7 +6,7 @@ if(CONFIG_PERCEPIO_TRACERECORDER)
 
   set(TRACERECORDER_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
 
-  zephyr_library()
+  zephyr_library_named(trace_recorder)
   zephyr_library_sources_ifdef(
     CONFIG_PERCEPIO_TRACERECORDER
     ${TRACERECORDER_DIR}/kernelports/Zephyr/trcKernelPort.c

--- a/modules/canopennode/CMakeLists.txt
+++ b/modules/canopennode/CMakeLists.txt
@@ -4,7 +4,7 @@ if(CONFIG_CANOPENNODE)
 
   set(CANOPENNODE_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
 
-  zephyr_library()
+  zephyr_library_named(canopennode)
 
   zephyr_include_directories(
     ${CANOPENNODE_DIR}

--- a/modules/fff/CMakeLists.txt
+++ b/modules/fff/CMakeLists.txt
@@ -7,7 +7,7 @@ if(CONFIG_FFF_TEST)
   # Add the FFF C test suites as ztest suites
   message("CONFIG_FFF_TEST_TYPE_C=${CONFIG_FFF_TEST_TYPE_C}")
   message("CONFIG_FFF_TEST_TYPE_GLOBAL_C=${CONFIG_FFF_TEST_TYPE_GLOBAL_C}")
-  zephyr_library()
+  zephyr_library_named(fff)
   zephyr_include_directories(
       include
       "${ZEPHYR_CURRENT_MODULE_DIR}"

--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
+zephyr_library_named(nrfx)
 
 set(NRFX_DIR ${ZEPHYR_CURRENT_MODULE_DIR}/nrfx)
 set(INC_DIR ${NRFX_DIR}/drivers/include)

--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -3,7 +3,7 @@
 include(ExternalProject)
 
 if(CONFIG_HAS_RPI_PICO)
-  zephyr_library()
+  zephyr_library_named(hal_rpi_pico)
 
   set(rp2_common_dir ${ZEPHYR_HAL_RPI_PICO_MODULE_DIR}/src/rp2_common)
   set(rp2040_dir ${ZEPHYR_HAL_RPI_PICO_MODULE_DIR}/src/rp2040)

--- a/modules/littlefs/CMakeLists.txt
+++ b/modules/littlefs/CMakeLists.txt
@@ -8,7 +8,7 @@ if(CONFIG_FILE_SYSTEM_LITTLEFS)
   target_link_libraries(LITTLEFS INTERFACE zephyr_interface)
   target_compile_definitions(LITTLEFS INTERFACE LFS_CONFIG=zephyr_lfs_config.h)
 
-  zephyr_library()
+  zephyr_library_named(littlefs)
   zephyr_library_sources(
     ${ZEPHYR_LITTLEFS_MODULE_DIR}/lfs.c
     ${ZEPHYR_LITTLEFS_MODULE_DIR}/lfs_util.c

--- a/modules/lz4/CMakeLists.txt
+++ b/modules/lz4/CMakeLists.txt
@@ -5,7 +5,7 @@ if(CONFIG_LZ4)
 
   set(LZ4_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
 
-  zephyr_library()
+  zephyr_library_named(lz4)
 
   zephyr_include_directories(${LZ4_DIR}/lib)
 

--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -17,7 +17,7 @@ if(CONFIG_MBEDTLS_BUILTIN)
     include
   )
 
-  zephyr_library()
+  zephyr_library_named(mbedtls)
 
   file(GLOB
     mbedtls_sources # This is an output parameter

--- a/modules/nanopb/CMakeLists.txt
+++ b/modules/nanopb/CMakeLists.txt
@@ -15,7 +15,7 @@ if(CONFIG_NANOPB)
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${NANOPB_DIR}/extra)
   find_package(Nanopb REQUIRED)
 
-  zephyr_library()
+  zephyr_library_named(nanopb)
 
   zephyr_include_directories(${NANOPB_DIR})
 

--- a/modules/segger/CMakeLists.txt
+++ b/modules/segger/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(CONFIG_USE_SEGGER_RTT)
 
-  zephyr_library()
+  zephyr_library_named(segger)
   set(SEGGER_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
   zephyr_include_directories_ifdef(CONFIG_USE_SEGGER_RTT
     ${SEGGER_DIR}/SEGGER

--- a/modules/tflite-micro/CMakeLists.txt
+++ b/modules/tflite-micro/CMakeLists.txt
@@ -6,7 +6,7 @@ if(CONFIG_TENSORFLOW_LITE_MICRO)
 
   set(TENSORFLOW_LITE_MICRO_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
 
-  zephyr_library()
+  zephyr_library_named(tflite-micro)
 
   zephyr_include_directories(
     ${TENSORFLOW_LITE_MICRO_DIR}/.

--- a/modules/zcbor/CMakeLists.txt
+++ b/modules/zcbor/CMakeLists.txt
@@ -3,7 +3,7 @@ if(CONFIG_ZCBOR)
     ${ZEPHYR_ZCBOR_MODULE_DIR}/include
   )
 
-  zephyr_library()
+  zephyr_library_named(zcbor)
   zephyr_library_sources(
     ${ZEPHYR_ZCBOR_MODULE_DIR}/src/zcbor_common.c
     ${ZEPHYR_ZCBOR_MODULE_DIR}/src/zcbor_decode.c

--- a/soc/arm/common/cortex_m/CMakeLists.txt
+++ b/soc/arm/common/cortex_m/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 if(CONFIG_ARM_MPU AND NOT CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS)
 
-  zephyr_library()
+  zephyr_library_named(soc_cortex_m)
 
   zephyr_library_sources_ifdef(CONFIG_CPU_HAS_ARM_MPU
     arm_mpu_regions.c


### PR DESCRIPTION
This reduces some of the file path lengths for cmake object files to reduce the issues caused when building on windows. With this patch, the longest object file name is reduces by 21 characters when building for the `nrf5340dk_nrf5340_cpuapp` board.