### PR TITLE
mgmt/mcumgr: Remove internal functions form Zephyr header

### DIFF
--- a/include/zephyr/mgmt/mcumgr/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp.h
@@ -110,38 +110,6 @@ void zephyr_smp_transport_init(struct zephyr_smp_transport *zst,
 			       zephyr_smp_transport_ud_copy_fn *ud_copy_func,
 			       zephyr_smp_transport_ud_free_fn *ud_free_func);
 
-/**
- * @brief Enqueues an incoming SMP request packet for processing.
- *
- * This function always consumes the supplied net_buf.
- *
- * @param zst                   The transport to use to send the corresponding
- *                                  response(s).
- * @param nb                    The request packet to process.
- */
-void zephyr_smp_rx_req(struct zephyr_smp_transport *zst, struct net_buf *nb);
-
-/**
- * @brief Allocates a response buffer.
- *
- * If a source buf is provided, its user data is copied into the new buffer.
- *
- * @param req		An optional source buffer to copy user data from.
- * @param arg		The streamer providing the callback.
- *
- * @return	Newly-allocated buffer on success
- *		NULL on failure.
- */
-void *zephyr_smp_alloc_rsp(const void *req, void *arg);
-
-/**
- * @brief Frees an allocated buffer.
- *
- * @param buf		The buffer to free.
- * @param arg		The streamer providing the callback.
- */
-void zephyr_smp_free_buf(void *buf, void *arg);
-
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/mgmt/mcumgr/lib/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/lib/smp/src/smp.c
@@ -16,6 +16,7 @@
 #include <zcbor_common.h>
 #include <zcbor_encode.h>
 #include "smp/smp.h"
+#include "../../../smp_internal.h"
 
 /**
  * Converts a request opcode to its corresponding response opcode.

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -25,6 +25,17 @@ LOG_MODULE_REGISTER(mcumgr_smp, CONFIG_MCUMGR_SMP_LOG_LEVEL);
 #define WEAK
 #endif
 
+/**
+ * @brief Allocates a response buffer.
+ *
+ * If a source buf is provided, its user data is copied into the new buffer.
+ *
+ * @param req		An optional source buffer to copy user data from.
+ * @param arg		The streamer providing the callback.
+ *
+ * @return	Newly-allocated buffer on success
+ *		NULL on failure.
+ */
 void *zephyr_smp_alloc_rsp(const void *req, void *arg)
 {
 	const struct net_buf_pool *pool;
@@ -112,6 +123,12 @@ zephyr_smp_split_frag(struct net_buf **nb, void *arg, uint16_t mtu)
 	return frag;
 }
 
+/**
+ * @brief Frees an allocated buffer.
+ *
+ * @param buf		The buffer to free.
+ * @param arg		The streamer providing the callback.
+ */
 void zephyr_smp_free_buf(void *buf, void *arg)
 {
 	struct zephyr_smp_transport *zst = arg;
@@ -226,6 +243,15 @@ zephyr_smp_transport_init(struct zephyr_smp_transport *zst,
 	k_fifo_init(&zst->zst_fifo);
 }
 
+/**
+ * @brief Enqueues an incoming SMP request packet for processing.
+ *
+ * This function always consumes the supplied net_buf.
+ *
+ * @param zst                   The transport to use to send the corresponding
+ *                                  response(s).
+ * @param nb                    The request packet to process.
+ */
 WEAK void
 zephyr_smp_rx_req(struct zephyr_smp_transport *zst, struct net_buf *nb)
 {

--- a/subsys/mgmt/mcumgr/smp_bt.c
+++ b/subsys/mgmt/mcumgr/smp_bt.c
@@ -20,6 +20,7 @@
 #include <zephyr/mgmt/mcumgr/buf.h>
 
 #include <zephyr/mgmt/mcumgr/smp.h>
+#include "smp_internal.h"
 #include "smp_reassembly.h"
 
 #include <zephyr/logging/log.h>

--- a/subsys/mgmt/mcumgr/smp_internal.h
+++ b/subsys/mgmt/mcumgr/smp_internal.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright Runtime.io 2018. All rights reserved.
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef MGMT_MCUMGR_SMP_INTERNAL_H_
+#define MGMT_MCUMGR_SMP_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct zephyr_smp_transport;
+struct net_buf;
+
+/**
+ * @brief Enqueues an incoming SMP request packet for processing.
+ *
+ * This function always consumes the supplied net_buf.
+ *
+ * @param zst                   The transport to use to send the corresponding
+ *                                  response(s).
+ * @param nb                    The request packet to process.
+ */
+void zephyr_smp_rx_req(struct zephyr_smp_transport *zst, struct net_buf *nb);
+
+/**
+ * @brief Allocates a response buffer.
+ *
+ * If a source buf is provided, its user data is copied into the new buffer.
+ *
+ * @param req		An optional source buffer to copy user data from.
+ * @param arg		The streamer providing the callback.
+ *
+ * @return	Newly-allocated buffer on success
+ *		NULL on failure.
+ */
+void *zephyr_smp_alloc_rsp(const void *req, void *arg);
+
+/**
+ * @brief Frees an allocated buffer.
+ *
+ * @param buf		The buffer to free.
+ * @param arg		The streamer providing the callback.
+ */
+void zephyr_smp_free_buf(void *buf, void *arg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MGMT_MCUMGR_SMP_INTERNAL_H_ */

--- a/subsys/mgmt/mcumgr/smp_reassembly.c
+++ b/subsys/mgmt/mcumgr/smp_reassembly.c
@@ -11,6 +11,7 @@
 #include <zephyr/mgmt/mcumgr/smp.h>
 #include <mgmt/mgmt.h>
 #include <smp/smp.h>
+#include "smp_internal.h"
 
 void zephyr_smp_reassembly_init(struct zephyr_smp_transport *zst)
 {

--- a/subsys/mgmt/mcumgr/smp_shell.c
+++ b/subsys/mgmt/mcumgr/smp_shell.c
@@ -21,6 +21,7 @@
 #include "syscalls/uart.h"
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_uart.h>
+#include "smp_internal.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(smp_shell);

--- a/subsys/mgmt/mcumgr/smp_uart.c
+++ b/subsys/mgmt/mcumgr/smp_uart.c
@@ -17,6 +17,7 @@
 #include "mgmt/mgmt.h"
 #include <zephyr/mgmt/mcumgr/serial.h>
 #include <zephyr/mgmt/mcumgr/smp.h>
+#include "smp_internal.h"
 
 struct device;
 

--- a/subsys/mgmt/mcumgr/smp_udp.c
+++ b/subsys/mgmt/mcumgr/smp_udp.c
@@ -22,6 +22,7 @@
 #include <zephyr/mgmt/mcumgr/smp_udp.h>
 #include <zephyr/mgmt/mcumgr/buf.h>
 #include <zephyr/mgmt/mcumgr/smp.h>
+#include "smp_internal.h"
 
 #define LOG_LEVEL CONFIG_MCUMGR_LOG_LEVEL
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
The commit removes declarations of:
 zephyr_smp_rx_req, zephyr_smp_alloc_rsp, zephyr_smp_free_buf
from include/zephyr/mgmt/mcumgr/smp.h, as these are MCUMgr internal
functions used in SMP processing and should be not exposed
from header file that provides interface for SMP transports.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>