### PR TITLE
west.yml: update hal_espressif to fix redefinition issue

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -62,7 +62,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 1e29548e4492807eb18cbaa77d3e78801cc7d07e
+      revision: 63981bf847c1b3f34a4ae5082b6bc8c55c7a70e2
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
`unlikely`and `likely` definitions are causing build failure
due to redefinition in Zephyr. This fixes that by removing from
hal_espressif.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>