### PR TITLE
arch: xtensa: fix build warnings on XCC toolchain

### DIFF
--- a/include/zephyr/arch/xtensa/arch_inlines.h
+++ b/include/zephyr/arch/xtensa/arch_inlines.h
@@ -13,25 +13,33 @@
 #include <zephyr/kernel_structs.h>
 #include <zsr.h>
 
+#ifndef RSR
 #define RSR(sr) \
 	({uint32_t v; \
 	 __asm__ volatile ("rsr." sr " %0" : "=a"(v)); \
 	 v; })
+#endif
 
+#ifndef WSR
 #define WSR(sr, v) \
 	do { \
 		__asm__ volatile ("wsr." sr " %0" : : "r"(v)); \
 	} while (false)
+#endif
 
+#ifndef RUR
 #define RUR(ur) \
 	({uint32_t v; \
 	 __asm__ volatile ("rur." ur " %0" : "=a"(v)); \
 	 v; })
+#endif
 
+#ifndef WUR
 #define WUR(ur, v) \
 	do { \
 		__asm__ volatile ("wur." ur " %0" : : "r"(v)); \
 	} while (false)
+#endif
 
 static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {


### PR DESCRIPTION
The RSR/RUR/WUR/WSR macros added in commit ef2ee7ecf258 ("arch: xtensa:
add macros for user registers") cause a lof of compiler warnings with
toolchains that already define these same macros (example XCC
RG-2017.8).

Cc: Tomasz Leman <tomasz.m.leman@intel.com>
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>