### PR TITLE
drivers: pwm: pwm_mcux: Inverted polarity support and run options

### DIFF
--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -26,6 +26,8 @@ struct pwm_mcux_config {
 	clock_control_subsys_t clock_subsys;
 	pwm_clock_prescale_t prescale;
 	pwm_mode_t mode;
+	bool run_wait;
+	bool run_debug;
 	const struct pinctrl_dev_config *pincfg;
 };
 
@@ -155,6 +157,8 @@ static int pwm_mcux_init(const struct device *dev)
 	pwm_config.prescale = config->prescale;
 	pwm_config.reloadLogic = kPWM_ReloadPwmFullCycle;
 	pwm_config.clockSource = kPWM_BusClock;
+	pwm_config.enableDebugMode = config->run_debug;
+	pwm_config.enableWait = config->run_wait;
 
 	status = PWM_Init(config->base, config->index, &pwm_config);
 	if (status != kStatus_Success) {
@@ -191,6 +195,8 @@ static const struct pwm_driver_api pwm_mcux_driver_api = {
 		.prescale = kPWM_Prescale_Divide_128,			  \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
 		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
+		.run_wait = DT_INST_PROP(n, run_in_wait),		  \
+		.run_debug = DT_INST_PROP(n, run_in_debug),		  \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		  \
 	};								  \
 									  \

--- a/dts/bindings/pwm/nxp,imx-pwm.yaml
+++ b/dts/bindings/pwm/nxp,imx-pwm.yaml
@@ -16,6 +16,16 @@ properties:
     interrupts:
       required: true
 
+    run-in-wait:
+      type: boolean
+      description: |
+        Enable for PWM to keep running in WAIT mode.
+
+    run-in-debug:
+      type: boolean
+      description: |
+        Enable for PWM to keep running in debug mode.
+
     "#pwm-cells":
       const: 2
 


### PR DESCRIPTION
This PR adds 2 features to the MCUX PWM driver:

- Add support for inverted polarity
- Add options to run the PWM in WAIT or debug mode