### PR TITLE
soc: intel_adsp_ace1x: Added IPC/IDC implementation

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -97,6 +97,21 @@
 			#interrupt-cells = <3>;
 		};
 
+		adsp_host_ipc: ace_host_ipc@73000 {
+			compatible = "intel,adsp-host-ipc";
+			status = "okay";
+			reg = <0x73000 0x30>;
+			interrupts = <0 0 0>;
+			interrupt-parent = <&ace_intc>;
+		};
+
+		adsp_idc: ace_idc@70400 {
+			compatible = "intel,adsp-idc";
+			reg = <0x70400 0x0400>;
+			interrupts = <24 0 0>;
+			interrupt-parent = <&ace_intc>;
+		};
+
 		/* This is actually an array of per-core designware
 		 * controllers, but the special setup and extra
 		 * masking layer makes it easier for MTL to handle

--- a/soc/xtensa/intel_adsp/ace_v1x/include/adsp_ipc_regs.h
+++ b/soc/xtensa/intel_adsp/ace_v1x/include/adsp_ipc_regs.h
@@ -5,6 +5,7 @@
 #define ZEPHYR_SOC_INTEL_ADSP_ACE_IPC_REGS_H
 
 #include <intel_adsp_ipc.h>
+#include <intel_adsp_ipc_devtree.h>
 
 /**
  * @file
@@ -35,6 +36,18 @@ struct intel_adsp_ipc {
 	uint32_t idd;
 };
 
+/**
+ * @brief Set TDA busy bit.
+ *
+ * On ACE SoC family boards TDA bit 31 (BUSY) during IPC doorbell acknowledgment
+ * must be cleared (!), not set (in contrary to CAVS SoC family boards).
+ * This clears BUSY on the other side of the connection in IDR register.
+ */
+#define INTEL_ADSP_IPC_BUSY BIT(31)
+#define INTEL_ADSP_IPC_DONE 0
+
+#define INTEL_ADSP_IPC_CTL_TBIE BIT(0)
+#define INTEL_ADSP_IPC_CTL_IDIE BIT(1)
 /**
  * @brief ACE SoC family Intra DSP Communication.
  *


### PR DESCRIPTION
Added IPC and IDC implementation for Intel ADSP ACE1X SoCs.

Co-authored-by: Serhiy Katsyuba <serhiy.katsyuba@intel.com>
Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>