### PR TITLE
tests: drivers: can: add a delay for the shell backend to initialize

### DIFF
--- a/tests/drivers/can/shell/src/main.c
+++ b/tests/drivers/can/shell/src/main.c
@@ -578,4 +578,11 @@ static void can_shell_before(void *fixture)
 	memset(&frame_capture, 0, sizeof(frame_capture));
 }
 
-ZTEST_SUITE(can_shell, NULL, NULL, can_shell_before, NULL, NULL);
+static void *can_shell_setup(void)
+{
+	/* Let the shell backend initialize. */
+	k_msleep(20);
+	return NULL;
+}
+
+ZTEST_SUITE(can_shell, NULL, can_shell_setup, can_shell_before, NULL, NULL);


### PR DESCRIPTION
The CAN shell test is flaky on some qemu platform (qemu_riscv64_smp in
particular), where the first test command occasionally fails as it tries
to run with the backend not initialized.

The tests for net/shell/src/main.c have a setup delay, copying it to the
CAN shell test seems to make it work reliably.

Tested with:
  ./scripts/twister -v -n -M -p qemu_riscv64_smp -T tests/drivers/can/shell