### PR TITLE
boards: arm: rpi_pico: add blackmagicprobe runner configuration

### DIFF
--- a/boards/arm/rpi_pico/board.cmake
+++ b/boards/arm/rpi_pico/board.cmake
@@ -27,5 +27,8 @@ board_runner_args(openocd --cmd-pre-init "set_adapter_speed_if_not_set 2000")
 
 board_runner_args(jlink "--device=RP2040_M0_0")
 
+board_runner_args(blackmagicprobe "--gdb-serial=/dev/ttyBmpGdb")
+
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)


### PR DESCRIPTION
Black Magic Probe supports RP2040. Add the necessary configuration to
use it with west.