### PR TITLE
Fix ieee802154 associations

### DIFF
--- a/subsys/net/l2/ieee802154/ieee802154_frame.c
+++ b/subsys/net/l2/ieee802154/ieee802154_frame.c
@@ -234,15 +234,16 @@ static inline bool validate_beacon(struct ieee802154_mpdu *mpdu, uint8_t *buf, u
 }
 
 static inline bool validate_mac_command_cfi_to_mhr(struct ieee802154_mhr *mhr, uint8_t ar,
-						   uint8_t comp, uint8_t src,
-						   bool src_pan_brdcst_chk, uint8_t dst,
+						   uint8_t comp, uint8_t src_bf,
+						   bool src_pan_brdcst_chk, uint8_t dst_bf,
 						   bool dst_brdcst_chk)
 {
 	if (mhr->fs->fc.ar != ar || mhr->fs->fc.pan_id_comp != comp) {
 		return false;
 	}
 
-	if ((mhr->fs->fc.src_addr_mode != src) || (mhr->fs->fc.dst_addr_mode != dst)) {
+	if (!(BIT(mhr->fs->fc.src_addr_mode) & src_bf) ||
+	    !(BIT(mhr->fs->fc.dst_addr_mode) & dst_bf)) {
 		return false;
 	}
 
@@ -272,7 +273,7 @@ static inline bool validate_mac_command(struct ieee802154_mpdu *mpdu, uint8_t *b
 	bool dst_brdcst_chk = false;
 	uint8_t comp = 0U;
 	uint8_t ar = 0U;
-	uint8_t src, dst;
+	uint8_t src_bf, dst_bf;
 
 	if (*length < len) {
 		return false;
@@ -283,9 +284,9 @@ static inline bool validate_mac_command(struct ieee802154_mpdu *mpdu, uint8_t *b
 		return false;
 	case IEEE802154_CFI_ASSOCIATION_REQUEST:
 		len += IEEE802154_CMD_ASSOC_REQ_LENGTH;
-		src = IEEE802154_ADDR_MODE_EXTENDED;
+		src_bf = BIT(IEEE802154_ADDR_MODE_EXTENDED);
 		src_pan_brdcst_chk = true;
-		dst = IEEE802154_ADDR_MODE_SHORT | IEEE802154_ADDR_MODE_EXTENDED;
+		dst_bf = BIT(IEEE802154_ADDR_MODE_SHORT) | BIT(IEEE802154_ADDR_MODE_EXTENDED);
 
 		break;
 	case IEEE802154_CFI_ASSOCIATION_RESPONSE:
@@ -299,51 +300,52 @@ static inline bool validate_mac_command(struct ieee802154_mpdu *mpdu, uint8_t *b
 	case IEEE802154_CFI_PAN_ID_CONLICT_NOTIFICATION:
 		ar = 1U;
 		comp = 1U;
-		src = IEEE802154_ADDR_MODE_EXTENDED;
-		dst = IEEE802154_ADDR_MODE_EXTENDED;
+		src_bf = BIT(IEEE802154_ADDR_MODE_EXTENDED);
+		dst_bf = BIT(IEEE802154_ADDR_MODE_EXTENDED);
 
 		break;
 	case IEEE802154_CFI_DATA_REQUEST:
 		ar = 1U;
-		src = IEEE802154_ADDR_MODE_SHORT | IEEE802154_ADDR_MODE_EXTENDED;
+		src_bf = BIT(IEEE802154_ADDR_MODE_SHORT) | BIT(IEEE802154_ADDR_MODE_EXTENDED);
 
 		if (mpdu->mhr.fs->fc.dst_addr_mode == IEEE802154_ADDR_MODE_NONE) {
-			dst = IEEE802154_ADDR_MODE_NONE;
+			dst_bf = BIT(IEEE802154_ADDR_MODE_NONE);
 		} else {
 			comp = 1U;
-			dst = IEEE802154_ADDR_MODE_SHORT | IEEE802154_ADDR_MODE_EXTENDED;
+			dst_bf = BIT(IEEE802154_ADDR_MODE_SHORT) |
+				 BIT(IEEE802154_ADDR_MODE_EXTENDED);
 		}
 
 		break;
 	case IEEE802154_CFI_ORPHAN_NOTIFICATION:
 		comp = 1U;
-		src = IEEE802154_ADDR_MODE_EXTENDED;
-		dst = IEEE802154_ADDR_MODE_SHORT;
+		src_bf = BIT(IEEE802154_ADDR_MODE_EXTENDED);
+		dst_bf = BIT(IEEE802154_ADDR_MODE_SHORT);
 
 		break;
 	case IEEE802154_CFI_BEACON_REQUEST:
-		src = IEEE802154_ADDR_MODE_NONE;
-		dst = IEEE802154_ADDR_MODE_SHORT;
+		src_bf = BIT(IEEE802154_ADDR_MODE_NONE);
+		dst_bf = BIT(IEEE802154_ADDR_MODE_SHORT);
 		dst_brdcst_chk = true;
 
 		break;
 	case IEEE802154_CFI_COORDINATOR_REALIGNEMENT:
 		len += IEEE802154_CMD_COORD_REALIGN_LENGTH;
-		src = IEEE802154_ADDR_MODE_EXTENDED;
+		src_bf = BIT(IEEE802154_ADDR_MODE_EXTENDED);
 
 		if (mpdu->mhr.fs->fc.dst_addr_mode == IEEE802154_ADDR_MODE_SHORT) {
-			dst = IEEE802154_ADDR_MODE_SHORT;
+			dst_bf = BIT(IEEE802154_ADDR_MODE_SHORT);
 			dst_brdcst_chk = true;
 		} else {
-			dst = IEEE802154_ADDR_MODE_EXTENDED;
+			dst_bf = BIT(IEEE802154_ADDR_MODE_EXTENDED);
 		}
 
 		break;
 	case IEEE802154_CFI_GTS_REQUEST:
 		len += IEEE802154_GTS_REQUEST_LENGTH;
 		ar = 1U;
-		src = IEEE802154_ADDR_MODE_SHORT;
-		dst = IEEE802154_ADDR_MODE_NONE;
+		src_bf = BIT(IEEE802154_ADDR_MODE_SHORT);
+		dst_bf = BIT(IEEE802154_ADDR_MODE_NONE);
 
 		break;
 	default:
@@ -354,7 +356,8 @@ static inline bool validate_mac_command(struct ieee802154_mpdu *mpdu, uint8_t *b
 		return false;
 	}
 
-	if (!validate_mac_command_cfi_to_mhr(&mpdu->mhr, ar, comp, src, src_pan_brdcst_chk, dst,
+	if (!validate_mac_command_cfi_to_mhr(&mpdu->mhr, ar, comp, src_bf,
+					     src_pan_brdcst_chk, dst_bf,
 					     dst_brdcst_chk)) {
 		return false;
 	}

--- a/subsys/net/l2/ieee802154/ieee802154_frame.c
+++ b/subsys/net/l2/ieee802154/ieee802154_frame.c
@@ -283,7 +283,7 @@ static inline bool validate_mac_command(struct ieee802154_mpdu *mpdu, uint8_t *b
 		return false;
 	case IEEE802154_CFI_ASSOCIATION_REQUEST:
 		len += IEEE802154_CMD_ASSOC_REQ_LENGTH;
-		src = IEEE802154_EXT_ADDR_LENGTH;
+		src = IEEE802154_ADDR_MODE_EXTENDED;
 		src_pan_brdcst_chk = true;
 		dst = IEEE802154_ADDR_MODE_SHORT | IEEE802154_ADDR_MODE_EXTENDED;
 
@@ -299,8 +299,8 @@ static inline bool validate_mac_command(struct ieee802154_mpdu *mpdu, uint8_t *b
 	case IEEE802154_CFI_PAN_ID_CONLICT_NOTIFICATION:
 		ar = 1U;
 		comp = 1U;
-		src = IEEE802154_EXT_ADDR_LENGTH;
-		dst = IEEE802154_EXT_ADDR_LENGTH;
+		src = IEEE802154_ADDR_MODE_EXTENDED;
+		dst = IEEE802154_ADDR_MODE_EXTENDED;
 
 		break;
 	case IEEE802154_CFI_DATA_REQUEST:
@@ -317,7 +317,7 @@ static inline bool validate_mac_command(struct ieee802154_mpdu *mpdu, uint8_t *b
 		break;
 	case IEEE802154_CFI_ORPHAN_NOTIFICATION:
 		comp = 1U;
-		src = IEEE802154_EXT_ADDR_LENGTH;
+		src = IEEE802154_ADDR_MODE_EXTENDED;
 		dst = IEEE802154_ADDR_MODE_SHORT;
 
 		break;
@@ -329,7 +329,7 @@ static inline bool validate_mac_command(struct ieee802154_mpdu *mpdu, uint8_t *b
 		break;
 	case IEEE802154_CFI_COORDINATOR_REALIGNEMENT:
 		len += IEEE802154_CMD_COORD_REALIGN_LENGTH;
-		src = IEEE802154_EXT_ADDR_LENGTH;
+		src = IEEE802154_ADDR_MODE_EXTENDED;
 
 		if (mpdu->mhr.fs->fc.dst_addr_mode == IEEE802154_ADDR_MODE_SHORT) {
 			dst = IEEE802154_ADDR_MODE_SHORT;

--- a/subsys/net/l2/ieee802154/ieee802154_frame.c
+++ b/subsys/net/l2/ieee802154/ieee802154_frame.c
@@ -283,6 +283,7 @@ static inline bool validate_mac_command(struct ieee802154_mpdu *mpdu, uint8_t *b
 	case IEEE802154_CFI_UNKNOWN:
 		return false;
 	case IEEE802154_CFI_ASSOCIATION_REQUEST:
+		ar = 1U;
 		len += IEEE802154_CMD_ASSOC_REQ_LENGTH;
 		src_bf = BIT(IEEE802154_ADDR_MODE_EXTENDED);
 		src_pan_brdcst_chk = true;

--- a/subsys/net/l2/ieee802154/ieee802154_mgmt.c
+++ b/subsys/net/l2/ieee802154/ieee802154_mgmt.c
@@ -381,6 +381,8 @@ static int ieee802154_associate(uint32_t mgmt_request, struct net_if *iface,
 
 	ieee802154_mac_cmd_finalize(pkt, IEEE802154_CFI_ASSOCIATION_REQUEST);
 
+	ieee802154_filter_pan_id(iface, req->pan_id);
+
 	if (net_if_send_data(iface, pkt)) {
 		net_pkt_unref(pkt);
 		ret = -EIO;
@@ -432,6 +434,10 @@ static int ieee802154_associate(uint32_t mgmt_request, struct net_if *iface,
 	}
 
 out:
+	if (ret < 0) {
+		ieee802154_filter_pan_id(iface, 0);
+	}
+
 	k_sem_give(&ctx->ctx_lock);
 	return ret;
 }

--- a/subsys/net/l2/ieee802154/ieee802154_mgmt.c
+++ b/subsys/net/l2/ieee802154/ieee802154_mgmt.c
@@ -353,12 +353,6 @@ static int ieee802154_associate(uint32_t mgmt_request, struct net_if *iface,
 	params.dst.pan_id = req->pan_id;
 	params.pan_id = req->pan_id;
 
-	/* Set channel first */
-	if (ieee802154_set_channel(iface, req->channel)) {
-		ret = -EIO;
-		goto out;
-	}
-
 	pkt = ieee802154_create_mac_cmd_frame(
 		iface, IEEE802154_CFI_ASSOCIATION_REQUEST, &params);
 	if (!pkt) {

--- a/subsys/net/l2/ieee802154/ieee802154_mgmt.c
+++ b/subsys/net/l2/ieee802154/ieee802154_mgmt.c
@@ -367,9 +367,11 @@ static int ieee802154_associate(uint32_t mgmt_request, struct net_if *iface,
 	}
 
 	cmd = ieee802154_get_mac_command(pkt);
+	cmd->assoc_req.ci.reserved_1 = 0U; /* Reserved */
 	cmd->assoc_req.ci.dev_type = 0U; /* RFD */
 	cmd->assoc_req.ci.power_src = 0U; /* TODO: set right power source */
 	cmd->assoc_req.ci.rx_on = 1U; /* TODO: that will depends on PM */
+	cmd->assoc_req.ci.reserved_2 = 0U; /* Reserved */
 	cmd->assoc_req.ci.sec_capability = 0U; /* TODO: security support */
 	cmd->assoc_req.ci.alloc_addr = 0U; /* TODO: handle short addr */
 

--- a/subsys/net/l2/ieee802154/ieee802154_shell.c
+++ b/subsys/net/l2/ieee802154/ieee802154_shell.c
@@ -228,6 +228,7 @@ static int cmd_ieee802154_scan(const struct shell *shell,
 
 	net_mgmt_init_event_callback(&scan_cb, scan_result_cb,
 				     NET_EVENT_IEEE802154_SCAN_RESULT);
+	net_mgmt_add_event_callback(&scan_cb);
 
 	if (!strcmp(argv[1], "active")) {
 		scan_type = NET_REQUEST_IEEE802154_ACTIVE_SCAN;


### PR DESCRIPTION
Hello all,

I'm currently working on improving the Linux kernel ieee802154 stack and right now I'm working on getting various MLME operations working. I started with simulators (mac802154_hwsim), I then tested the changes with atusb hardware and I decided to do the extra mile by validating my work against Zephyr stack with an Arduino Nano BLE. My workflow involved doing:
```
ieee802154 set_chan 13
net iface up 1
ieee802154 ack 1
ieee802154 scan active 13 1000
ieee802154 associate 2 1
```

The least I can say, is that both sides needed fixes, so here are all the changes I gathered in my branch. In these fixes the first six are meant to be upstreamed, but the last two are quick and dirty fixes against Zephyr internal notifiers which I completely failed to get up and working. I really did not understand these two issues, maybe I missed a configuration option or something like that, so any advice about how to make it work would be appreciated because on my side, it does not.

Cheers,
Miquèl