### PR TITLE
tests: limit drivers/can tests to capable platforms

### DIFF
--- a/tests/drivers/can/shell/testcase.yaml
+++ b/tests/drivers/can/shell/testcase.yaml
@@ -4,3 +4,4 @@ tests:
       - native_posix
       - native_posix_64
     tags: drivers can shell
+    depends_on: can

--- a/tests/drivers/can/utilities/testcase.yaml
+++ b/tests/drivers/can/utilities/testcase.yaml
@@ -4,3 +4,4 @@ tests:
       - native_posix
       - native_posix_64
     tags: drivers can
+    depends_on: can


### PR DESCRIPTION
The drivers/can tests should only run on platforms with can bus
support. This can avoid false failures on other platforms.

Signed-off-by: Ming Shao <ming.shao@intel.com>