### PR TITLE
Shell: add shell ready function

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -1153,6 +1153,15 @@ int shell_set_root_cmd(const char *cmd);
  */
 void shell_set_bypass(const struct shell *shell, shell_bypass_cb_t bypass);
 
+/** @brief Get shell readiness to execute commands.
+ *
+ * @param[in] sh	Pointer to the shell instance.
+ *
+ * @retval true		Shell backend is ready to execute commands.
+ * @retval false	Shell backend is not initialized or not started.
+ */
+bool shell_ready(const struct shell *sh);
+
 /**
  * @brief Allow application to control text insert mode.
  * Value is modified atomically and the previous value is returned.

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1690,6 +1690,13 @@ void shell_set_bypass(const struct shell *sh, shell_bypass_cb_t bypass)
 	sh->ctx->bypass = bypass;
 }
 
+bool shell_ready(const struct shell *sh)
+{
+	__ASSERT_NO_MSG(sh);
+
+	return state_get(sh) ==	SHELL_STATE_ACTIVE;
+}
+
 static int cmd_help(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1525,6 +1525,8 @@ void shell_fprintf(const struct shell *shell, enum shell_vt100_color color,
 void shell_hexdump_line(const struct shell *shell, unsigned int offset,
 			const uint8_t *data, size_t len)
 {
+	__ASSERT_NO_MSG(shell);
+
 	int i;
 
 	shell_fprintf(shell, SHELL_NORMAL, "%08X: ", offset);
@@ -1564,6 +1566,8 @@ void shell_hexdump_line(const struct shell *shell, unsigned int offset,
 
 void shell_hexdump(const struct shell *shell, const uint8_t *data, size_t len)
 {
+	__ASSERT_NO_MSG(shell);
+
 	const uint8_t *p = data;
 	size_t line_len;
 
@@ -1681,6 +1685,8 @@ int shell_mode_delete_set(const struct shell *shell, bool val)
 
 void shell_set_bypass(const struct shell *sh, shell_bypass_cb_t bypass)
 {
+	__ASSERT_NO_MSG(sh);
+
 	sh->ctx->bypass = bypass;
 }
 

--- a/tests/subsys/shell/shell/src/main.c
+++ b/tests/subsys/shell/shell/src/main.c
@@ -23,9 +23,10 @@ static char dynamic_cmd_buffer[][MAX_CMD_SYNTAX_LEN] = {
 
 static void test_shell_execute_cmd(const char *cmd, int result)
 {
+	const struct shell *sh = shell_backend_dummy_get_ptr();
 	int ret;
 
-	ret = shell_execute_cmd(NULL, cmd);
+	ret = shell_execute_cmd(sh, cmd);
 
 	TC_PRINT("shell_execute_cmd(%s): %d\n", cmd, ret);
 
@@ -490,8 +491,11 @@ ZTEST(shell, test_section_cmd)
 
 static void *shell_setup(void)
 {
-	/* Let the shell backend initialize. */
-	k_msleep(20);
+	const struct shell *sh = shell_backend_dummy_get_ptr();
+
+	/* Wait for the initialization of the shell dummy backend. */
+	WAIT_FOR(shell_ready(sh), 20000, k_msleep(1));
+
 	return NULL;
 }
 


### PR DESCRIPTION
Tests with shell commands will fail if they are started before the shell backend is initialized or started.
Adding API function: shell_ready indicating shell readiness.