### PR TITLE
compiler: gcc: add support for tuning mcpu option for ARC targets

### DIFF
--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -58,9 +58,7 @@ if("${ARCH}" STREQUAL "arm")
 elseif("${ARCH}" STREQUAL "arm64")
   include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_arm64.cmake)
 elseif("${ARCH}" STREQUAL "arc")
-  list(APPEND TOOLCHAIN_C_FLAGS
-    -mcpu=${GCC_M_CPU}
-    )
+  include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_arc.cmake)
 elseif("${ARCH}" STREQUAL "riscv")
   include(${CMAKE_CURRENT_LIST_DIR}/target_riscv.cmake)
 elseif("${ARCH}" STREQUAL "x86")

--- a/cmake/compiler/gcc/target_arc.cmake
+++ b/cmake/compiler/gcc/target_arc.cmake
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(EXISTS ${SOC_DIR}/${ARCH}/${SOC_PATH}/tune_build_ops.cmake)
+  include(${SOC_DIR}/${ARCH}/${SOC_PATH}/tune_build_ops.cmake)
+endif()
+
+if(NOT DEFINED GCC_ARC_TUNED_CPU)
+  set(GCC_ARC_TUNED_CPU ${GCC_M_CPU})
+endif()
+
+list(APPEND TOOLCHAIN_C_FLAGS -mcpu=${GCC_ARC_TUNED_CPU})
+

--- a/soc/arc/snps_qemu/CMakeLists.txt
+++ b/soc/arc/snps_qemu/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-zephyr_compile_options(-mcpu=${GCC_M_CPU})
 
 if(CONFIG_ISA_ARCV2)
   zephyr_compile_options(-mno-sdata)


### PR DESCRIPTION
ARC processors are highly configurable, so ARC toolchain supports
big amount of mcpu options for all that HW configurations.
As difference in many configurations among the same processor
family usually doesn't affect Zephyr code we don't want
to create Kconfig option for each possible CPU configuration
(just to map Kconfig option to correspondent mcpu value
in 'cmake/gcc-m-cpu.cmake').
Instead we prefer being able to set proper mcpu value
individually for any ARC SoC and using 'cmake/gcc-m-cpu.cmake'
just for reasonable defaults.

Signed-off-by: Nikolay Agishev <agishev@synopsys.com>