### PR TITLE
tests: driver: gpio: fix the incorrect testsuite names

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/src/main.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/main.c
@@ -102,7 +102,7 @@ static void *gpio_basic_setup(void)
 ZTEST_SUITE(gpio_port, NULL, gpio_basic_setup, NULL, NULL, NULL);
 
 /* Test GPIO callback management */
-ZTEST_SUITE(gpio_cb_mgnt, NULL, gpio_basic_setup, NULL, NULL, NULL);
+ZTEST_SUITE(gpio_port_cb_mgmt, NULL, gpio_basic_setup, NULL, NULL, NULL);
 
 /* Test GPIO callbacks */
-ZTEST_SUITE(gpio_cb_vari, NULL, gpio_basic_setup, NULL, NULL, NULL);
+ZTEST_SUITE(gpio_port_cb_vari, NULL, gpio_basic_setup, NULL, NULL, NULL);

--- a/tests/drivers/gpio/gpio_basic_api/src/test_callback_manage.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_callback_manage.c
@@ -229,19 +229,19 @@ err_exit:
 	return TC_FAIL;
 }
 
-ZTEST(gpio_mgmt, test_gpio_callback_add_remove)
+ZTEST(gpio_port_cb_mgmt, test_gpio_callback_add_remove)
 {
 	zassert_equal(test_callback_add_remove(), TC_PASS,
 		     NULL);
 }
 
-ZTEST(gpio_mgmt, test_gpio_callback_self_remove)
+ZTEST(gpio_port_cb_mgmt, test_gpio_callback_self_remove)
 {
 	zassert_equal(test_callback_self_remove(), TC_PASS,
 		     NULL);
 }
 
-ZTEST(gpio_mgmt, test_gpio_callback_enable_disable)
+ZTEST(gpio_port_cb_mgmt, test_gpio_callback_enable_disable)
 {
 	zassert_equal(test_callback_enable_disable(), TC_PASS,
 		     NULL);

--- a/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
@@ -118,7 +118,7 @@ err_exit:
 }
 
 /* export test cases */
-ZTEST(gpio_vari, test_gpio_callback_variants)
+ZTEST(gpio_port_cb_vari, test_gpio_callback_variants)
 {
 	zassert_equal(test_callback(GPIO_INT_EDGE_FALLING), TC_PASS,
 		      "falling edge failed");


### PR DESCRIPTION
There are some erros in previous ztest API migration of
the gpio_basic_api tests. Fix the incorrect testsuite
name of the callback mgmt and vari tests.

Fixes #49953

Signed-off-by: Enjia Mai <enjia.mai@intel.com>