### PR TITLE
tests: drivers: flash driver for the non-secure stm32u5 board

### DIFF
--- a/tests/drivers/flash/boards/b_u585i_iot02a_ns.overlay
+++ b/tests/drivers/flash/boards/b_u585i_iot02a_ns.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022, STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ /{
+	chosen {
+		zephyr,code-partition = &slot1_ns_partition;
+	};
+};
+
+&flash0 {
+	partitions {
+	/delete-node/ slot1_partition;
+		/* Non-secure image primary slot */
+		slot1_ns_partition: partition@74000 {
+			label = "image-1-nonsecure";
+			reg = <0x00074000 DT_SIZE_K(512)>;
+		};
+	};
+};


### PR DESCRIPTION
This commit adds an overlay to run the tests/drivers/flash
on the b_u585i_iot02a_ns target platform.
It renames the non-secure partition to slot1_ns_partition to match the testcases.

This is fixing the compilation failure on 
tests/drivers/flash/drivers.flash.stm32 (b_u585i_iot02a_ns:tests/drivers/flash/drivers.flash.stm32) with error
as reported by the CI 
introduced by the commit 25b8c199a3d332cd85870348457651ff7e5bece2

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/50150

Signed-off-by: Francois Ramu <francois.ramu@st.com>