### PR TITLE
tests: drivers: flash: size to erase equals to size to write

### DIFF
--- a/tests/drivers/flash/src/main.c
+++ b/tests/drivers/flash/src/main.c
@@ -91,9 +91,12 @@ static void *flash_driver_setup(void)
 	}
 
 	if (!is_buf_clear) {
-		/* erase page */
+		/* Erase a nb of pages aligned to the EXPECTED_SIZE */
 		rc = flash_erase(flash_dev, page_info.start_offset,
-				 page_info.size);
+				(page_info.size *
+				((EXPECTED_SIZE + page_info.size - 1)
+				/ page_info.size)));
+
 		zassert_equal(rc, 0, "Flash memory not properly erased");
 	}
 


### PR DESCRIPTION
Need to erase as many bytes as the size to write.
In case the page_info.size is lower than the size to write,
the next write operation will fail.

This is the case when testing the tests/drivers/flash on the nucleo_l152re target platform
where the FLASH_PAGE_SIZE = 256 . When writing EXPECTED_SIZE = 512, the upper 256 bytes are not erased.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/50149

Signed-off-by: Francois Ramu <francois.ramu@st.com>