### PR TITLE
edtlib: remove python 3.5 workaround

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2950,18 +2950,6 @@ class _BindingLoader(Loader):
 # Add legacy '!include foo.yaml' handling
 _BindingLoader.add_constructor("!include", _binding_include)
 
-# Use OrderedDict instead of plain dict for YAML mappings, to preserve
-# insertion order on Python 3.5 and earlier (plain dicts only preserve
-# insertion order on Python 3.6+). This makes testing easier and avoids
-# surprises.
-#
-# Adapted from
-# https://stackoverflow.com/questions/5121931/in-python-how-can-you-load-yaml-mappings-as-ordereddicts.
-# Hopefully this API stays stable.
-_BindingLoader.add_constructor(
-    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-    lambda loader, node: OrderedDict(loader.construct_pairs(node)))
-
 #
 # "Default" binding for properties which are defined by the spec.
 #


### PR DESCRIPTION
Remove a yaml monkeypatch. It is no longer needed since we support 3.6
or later on Zephyr v2.7 LTS and 3.8 or later on what will become v3.2.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>