### PR TITLE
usb: cdc_acm: lower verbosity of cdc_acm_poll_out

### DIFF
--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -1009,7 +1009,7 @@ static void cdc_acm_poll_out(const struct device *dev, unsigned char c)
 	dev_data->tx_ready = false;
 
 	if (!ring_buf_put(dev_data->tx_ringbuf, &c, 1)) {
-		LOG_INF("Ring buffer full, drain buffer");
+		LOG_DBG("Ring buffer full, drain buffer");
 		if (!ring_buf_get(dev_data->tx_ringbuf, NULL, 1) ||
 		    !ring_buf_put(dev_data->tx_ringbuf, &c, 1)) {
 			LOG_ERR("Failed to drain buffer");


### PR DESCRIPTION
When no host console is attached to device and the buffer is full
printing message during draining of a single character actiually make
the things worse, causes message storm on other consoles
(RTT for example) and device became unresponsive, and often crashes
into LOG core subsystem.

```
00> --- 109 messages dropped ---
00> [00:06:41.664,825] <inf> usb_cdc_acm: Ring buffer full, drain buffer
00> --- 109 messages dropped ---
00> [00:06:41.763,549] <inf> usb_cdc_acm: Ring buffer full, drain buffer
00> --- 108 messages dropped ---
00> [00:06:41.857,238] <inf> usb_cdc_acm: Ring buffer full, drain buffer
```

Signed-off-by: Kiril Petrov <retfie@gmail.com>