### PR TITLE
doc: fix some doxygen grouping

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -20,9 +20,18 @@
  * @{
  * @}
  */
+
+/**
+ * @brief Device Model
+ * @defgroup device_model Device Model
+ * @{
+ * @}
+ */
+
 /**
  * @brief Device Model APIs
- * @defgroup device_model Device Model APIs
+ * @defgroup device_model_api Device Model APIs
+ * @ingroup device_model
  * @{
  */
 

--- a/include/zephyr/drivers/disk.h
+++ b/include/zephyr/drivers/disk.h
@@ -21,6 +21,7 @@
 /**
  * @brief Disk Driver Interface
  * @defgroup disk_driver_interface Disk Driver Interface
+ * @ingroup io_interfaces
  * @{
  */
 

--- a/include/zephyr/drivers/mm/system_mm.h
+++ b/include/zephyr/drivers/mm/system_mm.h
@@ -26,6 +26,7 @@ extern "C" {
 /**
  * @brief Memory Management Driver APIs
  * @defgroup mm_drv_apis Memory Management Driver APIs
+ * @ingroup memory_management
  * @{
  */
 

--- a/include/zephyr/ipc/ipc_rpmsg.h
+++ b/include/zephyr/ipc/ipc_rpmsg.h
@@ -18,6 +18,7 @@ extern "C" {
 /**
  * @brief IPC service RPMsg API
  * @defgroup ipc_service_rpmsg_api IPC service RPMsg API
+ * @ingroup ipc
  * @{
  */
 

--- a/include/zephyr/ipc/ipc_service.h
+++ b/include/zephyr/ipc/ipc_service.h
@@ -15,8 +15,15 @@ extern "C" {
 #endif
 
 /**
+ * @brief IPC
+ * @defgroup ipc IPC
+ * @{
+ * @}
+ */
+/**
  * @brief IPC Service API
  * @defgroup ipc_service_api IPC service APIs
+ * @ingroup ipc
  * @{
  *
  * Some terminology:

--- a/include/zephyr/ipc/ipc_static_vrings.h
+++ b/include/zephyr/ipc/ipc_static_vrings.h
@@ -18,6 +18,7 @@ extern "C" {
 /**
  * @brief IPC service static VRINGs API
  * @defgroup ipc_service_static_vrings_api IPC service static VRINGs API
+ * @ingroup ipc
  * @{
  */
 

--- a/include/zephyr/ipc/rpmsg_service.h
+++ b/include/zephyr/ipc/rpmsg_service.h
@@ -16,6 +16,7 @@ extern "C" {
 /**
  * @brief RPMsg service API
  * @defgroup rpmsg_service_api RPMsg service APIs
+ * @ingroup ipc
  * @{
  */
 

--- a/include/zephyr/storage/disk_access.h
+++ b/include/zephyr/storage/disk_access.h
@@ -15,8 +15,16 @@
 #define ZEPHYR_INCLUDE_STORAGE_DISK_ACCESS_H_
 
 /**
+ * @brief Storage APIs
+ * @defgroup storage_apis Storage APIs
+ * @{
+ * @}
+ */
+
+/**
  * @brief Disk Access APIs
  * @defgroup disk_access_interface Disk Access Interface
+ * @ingroup storage_apis
  * @{
  */
 

--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -17,6 +17,7 @@
  * @brief Abstraction over flash partitions/areas and their drivers
  *
  * @defgroup flash_area_api flash area Interface
+ * @ingroup storage_apis
  * @{
  */
 

--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -17,6 +17,7 @@
  * @brief Abstraction over stream writes to flash
  *
  * @defgroup stream_flash Stream to flash interface
+ * @ingroup storage_apis
  * @{
  */
 

--- a/include/zephyr/sys/device_mmio.h
+++ b/include/zephyr/sys/device_mmio.h
@@ -20,7 +20,7 @@
 
 /**
  * @defgroup device-mmio Device memory-mapped IO management
- * @ingroup device-model
+ * @ingroup device_model
  * @{
  */
 

--- a/include/zephyr/sys/mem_blocks.h
+++ b/include/zephyr/sys/mem_blocks.h
@@ -29,6 +29,7 @@ extern "C" {
 
 /**
  * @defgroup mem_blocks_apis Memory Blocks APIs
+ * @ingroup memory_management
  * @{
  */
 

--- a/include/zephyr/sys/mem_manage.h
+++ b/include/zephyr/sys/mem_manage.h
@@ -356,7 +356,11 @@ size_t k_mem_region_align(uintptr_t *aligned_addr, size_t *aligned_size,
 			  uintptr_t addr, size_t size, size_t align);
 
 /**
+ * @defgroup demand_paging Demand Paging
+ */
+/**
  * @defgroup mem-demand-paging Demand Paging APIs
+ * @ingroup demand_paging
  * @{
  */
 
@@ -492,6 +496,7 @@ __syscall void k_mem_paging_histogram_backing_store_page_out_get(
  * Eviction algorithm APIs
  *
  * @defgroup mem-demand-paging-eviction Eviction Algorithm APIs
+ * @ingroup demand_paging
  * @{
  */
 
@@ -526,6 +531,7 @@ void k_mem_paging_eviction_init(void);
  * Backing store APIs
  *
  * @defgroup mem-demand-paging-backing-store Backing Store APIs
+ * @ingroup demand_paging
  * @{
  */
 

--- a/include/zephyr/sys/mem_manage.h
+++ b/include/zephyr/sys/mem_manage.h
@@ -13,6 +13,13 @@
 #include <zephyr/arch/arm64/arm_mem.h>
 #endif
 
+/**
+ * @brief Memory Management
+ * @defgroup memory_management Memory Management
+ * @{
+ * @}
+ */
+
 /*
  * Caching mode definitions. These are mutually exclusive.
  */
@@ -357,6 +364,7 @@ size_t k_mem_region_align(uintptr_t *aligned_addr, size_t *aligned_size,
 
 /**
  * @defgroup demand_paging Demand Paging
+ * @ingroup memory_management
  */
 /**
  * @defgroup mem-demand-paging Demand Paging APIs

--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -54,6 +54,10 @@ static inline void ring_buf_internal_reset(struct ring_buf *buf, int32_t value)
 }
 
 /**
+ * @brief Data Structure APIs
+ * @defgroup datastructure_apis Data Structure APIs
+ */
+/**
  * @defgroup ring_buffer_apis Ring Buffer APIs
  * @ingroup datastructure_apis
  * @{

--- a/tests/kernel/lifo/lifo_usage/src/main.c
+++ b/tests/kernel/lifo/lifo_usage/src/main.c
@@ -153,6 +153,13 @@ static void thread_entry_wait(void *p1, void *p2, void *p3)
 	k_sem_give(&wait_sema);
 }
 
+/**
+ * @brief LIFOs
+ * @defgroup kernel_lifo_tests LIFOs
+ * @ingroup all_tests
+ * @{
+ * @}
+ */
 
 /**
  * @addtogroup kernel_lifo_tests

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -65,7 +65,7 @@ static int curr_cpu(void)
 }
 
 /**
- * @brief Tests for SMP
+ * @brief SMP
  * @defgroup kernel_smp_tests SMP Tests
  * @ingroup all_tests
  * @{
@@ -73,15 +73,15 @@ static int curr_cpu(void)
  */
 
 /**
- * @defgroup kernel_smp_integration_tests SMP Tests
- * @ingroup all_tests
+ * @defgroup kernel_smp_integration_tests SMP Integration Tests
+ * @ingroup kernel_smp_tests
  * @{
  * @}
  */
 
 /**
- * @defgroup kernel_smp_module_tests SMP Tests
- * @ingroup all_tests
+ * @defgroup kernel_smp_module_tests SMP Module Tests
+ * @ingroup kernel_smp_tests
  * @{
  * @}
  */


### PR DESCRIPTION
- doc: group demand paging APIs in doxygne
- doc: doxygen: restructure device model APIs
- doc: doxygen: add memory management group
- doc: doxygen: move lifo tests to test group
- doc: doxygen: group smp tests
- doc: doxygen: move all IPC APIs under one group
- doc: doxygen: add disk to io_interfaces
