### PR TITLE
arch/xtensa: Properly namespace special register API

### DIFF
--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -38,7 +38,7 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 	/* Our cache top stash location might have junk in it from a
 	 * pre-boot environment.  Must be zero or valid!
 	 */
-	WSR(ZSR_FLUSH_STR, 0);
+	XTENSA_WSR(ZSR_FLUSH_STR, 0);
 #endif
 
 	cpu0->nested = 0;
@@ -50,7 +50,7 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 	 * per-CPU thing and having it stored in a SR already is a big
 	 * win.
 	 */
-	WSR(ZSR_CPU_STR, cpu0);
+	XTENSA_WSR(ZSR_CPU_STR, cpu0);
 
 #ifdef CONFIG_INIT_STACKS
 	memset(Z_KERNEL_STACK_BUFFER(z_interrupt_stacks[0]), 0xAA,

--- a/include/zephyr/arch/xtensa/arch_inlines.h
+++ b/include/zephyr/arch/xtensa/arch_inlines.h
@@ -13,22 +13,22 @@
 #include <zephyr/kernel_structs.h>
 #include <zsr.h>
 
-#define RSR(sr) \
+#define XTENSA_RSR(sr) \
 	({uint32_t v; \
 	 __asm__ volatile ("rsr." sr " %0" : "=a"(v)); \
 	 v; })
 
-#define WSR(sr, v) \
+#define XTENSA_WSR(sr, v) \
 	do { \
 		__asm__ volatile ("wsr." sr " %0" : : "r"(v)); \
 	} while (false)
 
-#define RUR(ur) \
+#define XTENSA_RUR(ur) \
 	({uint32_t v; \
 	 __asm__ volatile ("rur." ur " %0" : "=a"(v)); \
 	 v; })
 
-#define WUR(ur, v) \
+#define XTENSA_WUR(ur, v) \
 	do { \
 		__asm__ volatile ("wur." ur " %0" : : "r"(v)); \
 	} while (false)
@@ -37,7 +37,7 @@ static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {
 	_cpu_t *cpu;
 
-	cpu = (_cpu_t *)RSR(ZSR_CPU_STR);
+	cpu = (_cpu_t *)XTENSA_RSR(ZSR_CPU_STR);
 
 	return cpu;
 }

--- a/soc/xtensa/intel_adsp/ace_v1x/power.c
+++ b/soc/xtensa/intel_adsp/ace_v1x/power.c
@@ -78,19 +78,19 @@ struct lpsram_header {
 
 static ALWAYS_INLINE void _core_basic_init(void)
 {
-	WSR("MEMCTL", MEMCTL_DEFAULT_VALUE);
-	WSR("PREFCTL", ADSP_L1_CACHE_PREFCTL_VALUE);
+	XTENSA_WSR("MEMCTL", MEMCTL_DEFAULT_VALUE);
+	XTENSA_WSR("PREFCTL", ADSP_L1_CACHE_PREFCTL_VALUE);
 	ARCH_XTENSA_SET_RPO_TLB();
-	WSR("ATOMCTL", 0x15);
+	XTENSA_WSR("ATOMCTL", 0x15);
 	__asm__ volatile("rsync");
 }
 
 static ALWAYS_INLINE void _save_core_context(uint32_t core_id)
 {
-	core_desc[core_id].vecbase = RSR("VECBASE");
-	core_desc[core_id].excsave2 = RSR("EXCSAVE2");
-	core_desc[core_id].excsave3 = RSR("EXCSAVE3");
-	core_desc[core_id].thread_ptr = RUR("THREADPTR");
+	core_desc[core_id].vecbase = XTENSA_RSR("VECBASE");
+	core_desc[core_id].excsave2 = XTENSA_RSR("EXCSAVE2");
+	core_desc[core_id].excsave3 = XTENSA_RSR("EXCSAVE3");
+	core_desc[core_id].thread_ptr = XTENSA_RUR("THREADPTR");
 	__asm__ volatile("mov %0, a0" : "=r"(core_desc[core_id].a0));
 	__asm__ volatile("mov %0, a1" : "=r"(core_desc[core_id].a1));
 }
@@ -99,10 +99,10 @@ static ALWAYS_INLINE void _restore_core_context(void)
 {
 	uint32_t core_id = arch_proc_id();
 
-	WSR("VECBASE", core_desc[core_id].vecbase);
-	WSR("EXCSAVE2", core_desc[core_id].excsave2);
-	WSR("EXCSAVE3", core_desc[core_id].excsave3);
-	WUR("THREADPTR", core_desc[core_id].thread_ptr);
+	XTENSA_WSR("VECBASE", core_desc[core_id].vecbase);
+	XTENSA_WSR("EXCSAVE2", core_desc[core_id].excsave2);
+	XTENSA_WSR("EXCSAVE3", core_desc[core_id].excsave3);
+	XTENSA_WUR("THREADPTR", core_desc[core_id].thread_ptr);
 	__asm__ volatile("mov a0, %0" :: "r"(core_desc[core_id].a0));
 	__asm__ volatile("mov a1, %0" :: "r"(core_desc[core_id].a1));
 	__asm__ volatile("rsync");
@@ -166,7 +166,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 			k_cpu_idle();
 		}
 	} else if (state == PM_STATE_RUNTIME_IDLE) {
-		core_desc[cpu].intenable = RSR("INTENABLE");
+		core_desc[cpu].intenable = XTENSA_RSR("INTENABLE");
 		z_xt_ints_off(0xffffffff);
 		DFDSPBRCP.bootctl[cpu].bctl &= ~DFDSPBRCP_BCTL_WAITIPPG;
 		DFDSPBRCP.bootctl[cpu].bctl &= ~DFDSPBRCP_BCTL_WAITIPCG;


### PR DESCRIPTION
The Xtensa arch has historically had state/user register accessor
macros with bare three-byte symbol names.  I think this might have
been in the original Cadence-contributed arch integration, but I'm not
sure.  In any case they also exist in the same names in vendor
HAL/toolchain code and are causing collisions.  We never should have
had these symbols exposed in our header.

Put them under an ARCH_ prefix to decollide.

Signed-off-by: Andy Ross <andyross@google.com>