### PR TITLE
ARC: boards: hs5x: enable zephyr toolchain

### DIFF
--- a/boards/arc/nsim/nsim_hs5x.yaml
+++ b/boards/arc/nsim/nsim_hs5x.yaml
@@ -4,6 +4,7 @@ type: mcu
 simulation: nsim
 arch: arc
 toolchain:
+  - zephyr
   - arcmwdt
   - cross-compile
 testing:

--- a/boards/arc/nsim/nsim_hs5x_smp.yaml
+++ b/boards/arc/nsim/nsim_hs5x_smp.yaml
@@ -4,6 +4,7 @@ type: mcu
 simulation: mdb-nsim
 arch: arc
 toolchain:
+  - zephyr
   - arcmwdt
   - cross-compile
 testing:

--- a/boards/arc/qemu_arc/qemu_arc_hs5x.yaml
+++ b/boards/arc/qemu_arc/qemu_arc_hs5x.yaml
@@ -4,6 +4,7 @@ type: qemu
 simulation: qemu
 arch: arc
 toolchain:
+  - zephyr
   - cross-compile
 testing:
   default: true


### PR DESCRIPTION
As we've finally switched to 0.15.0 Zephyr SDK in upstream verification we can enable zephyr toolchain for all ARC HS5x targets.