### PR TITLE
boards: pinnacle_100_dvk: enable uart1 flow control

### DIFF
--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -108,6 +108,7 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
+	hw-flow-control;
 	pinctrl-0 = <&uart1_default>;
 	pinctrl-1 = <&uart1_sleep>;
 	pinctrl-names = "default", "sleep";


### PR DESCRIPTION
UART1 flow control needs to be enabled for proper
HL7800 modem communication.

fixes #49988
