### PR TITLE
dts: rt11xx: add enet1g peripheral and set up clock

### DIFF
--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -703,6 +703,25 @@
 			};
 		};
 
+		/*
+		 * enet1g peripheral to use with kinetis-ethernet (eth_mcux) driver
+		 * just like the enet peripheral (i.e. only 10/100Mbit for now)
+		 */
+		enet1g: ethernet@40420000 {
+			compatible = "nxp,kinetis-ethernet";
+			reg = <0x40420000 0x628>;
+			interrupts = <141 0>;
+			interrupt-names = "COMMON";
+			status = "disabled";
+			phy-addr = <1>;
+			ptp1g: ptp {
+				compatible = "nxp,kinetis-ptp";
+				status = "disabled";
+				interrupts = <142 0>;
+				interrupt-names = "IEEE1588_TMR";
+			};
+		};
+
 		caam: caam@40440000 {
 			compatible = "nxp,imx-caam";
 			reg = <0x40440000 0x81000>;

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -368,6 +368,7 @@ static ALWAYS_INLINE void clock_init(void)
 
 
 #ifdef CONFIG_ETH_MCUX
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(enet), okay)
 	/* 50 MHz ENET clock */
 	rootCfg.mux = kCLOCK_ENET1_ClockRoot_MuxSysPll1Div2;
 	rootCfg.div = 10;
@@ -375,6 +376,19 @@ static ALWAYS_INLINE void clock_init(void)
 	/* Set ENET_REF_CLK as an output driven by ENET1_CLK_ROOT */
 	IOMUXC_GPR->GPR4 |= (IOMUXC_GPR_GPR4_ENET_REF_CLK_DIR(0x01U) |
 		IOMUXC_GPR_GPR4_ENET_TX_CLK_SEL(0x1U));
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(enet1g), okay)
+	/*
+	 * 50 MHz clock for 10/100Mbit RMII PHY -
+	 * operate ENET1G just like ENET peripheral
+	 */
+	rootCfg.mux = kCLOCK_ENET2_ClockRoot_MuxSysPll1Div2;
+	rootCfg.div = 10;
+	CLOCK_SetRootClock(kCLOCK_Root_Enet2, &rootCfg);
+	/* Set ENET1G_REF_CLK as an output driven by ENET2_CLK_ROOT */
+	IOMUXC_GPR->GPR5 |= (IOMUXC_GPR_GPR5_ENET1G_REF_CLK_DIR(0x01U) |
+		IOMUXC_GPR_GPR5_ENET1G_TX_CLK_SEL(0x1U));
+#endif
 #endif
 
 #ifdef CONFIG_PTP_CLOCK_MCUX


### PR DESCRIPTION
The enet1g peripheral was missing in device tree for nxp rt11xx. With this commit, the peripheral can be operated like the enet peripheral with the eth_mcux (kinetis-ethernet) driver at 10/100 Mbit (no gigabit).

Signed-off-by: Nils Larsen <nils.larsen@posteo.de>