### PR TITLE
cmake: improve warning deprecation message

### DIFF
--- a/cmake/modules/FindDeprecated.cmake
+++ b/cmake/modules/FindDeprecated.cmake
@@ -62,7 +62,9 @@ if("CROSS_COMPILE" IN_LIST Deprecated_FIND_COMPONENTS)
   if(NOT ZEPHYR_TOOLCHAIN_VARIANT AND
      (CROSS_COMPILE OR (DEFINED ENV{CROSS_COMPILE})))
       set(ZEPHYR_TOOLCHAIN_VARIANT cross-compile CACHE STRING "Zephyr toolchain variant" FORCE)
-      message(DEPRECATION  "CROSS_COMPILE is deprecated. Please set ZEPHYR_TOOLCHAIN_VARIANT to 'cross-compile'")
+      message(DEPRECATION  "Setting CROSS_COMPILE without setting ZEPHYR_TOOLCHAIN_VARIANT is deprecated."
+                           "Please set ZEPHYR_TOOLCHAIN_VARIANT to 'cross-compile'"
+      )
   endif()
 endif()
 


### PR DESCRIPTION
The current deprecation warning could give the impression that CROSS_COMPILE is deprecated, which is not the case.

Instead it is the behavior of defaulting to `cross-compile` when setting CROSS_COMPILE in environment without setting ZEPHYR_TOOLCHAIN_VARIANT that is deprecated.
Not the use of `CROSS_COMPILE` setting itself.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>