### PR TITLE
SD: Implement sdhc_card_busy in SDHC SPI-driver

### DIFF
--- a/drivers/sdhc/sdhc_spi.c
+++ b/drivers/sdhc/sdhc_spi.c
@@ -151,6 +151,27 @@ static int sdhc_spi_init_card(const struct device *dev)
 	return ret;
 }
 
+/* Checks if SPI SD card is sending busy signal */
+static int sdhc_spi_card_busy(const struct device *dev)
+{
+	const struct sdhc_spi_config *config = dev->config;
+	struct sdhc_spi_data *data = dev->data;
+	int ret;
+	uint8_t response;
+
+
+	ret = sdhc_spi_rx(config->spi_dev, data->spi_cfg, &response, 1);
+	if (ret) {
+		return -EIO;
+	}
+
+	if (response == 0xFF) {
+		return 0;
+	} else
+		return 1;
+
+}
+
 /* Waits for SPI SD card to stop sending busy signal */
 static int sdhc_spi_wait_unbusy(const struct device *dev,
 	int timeout_ms,
@@ -732,6 +753,7 @@ static struct sdhc_driver_api sdhc_spi_api = {
 	.get_host_props = sdhc_spi_get_host_props,
 	.get_card_present = sdhc_spi_get_card_present,
 	.reset = sdhc_spi_reset,
+	.card_busy = sdhc_spi_card_busy,
 };
 
 


### PR DESCRIPTION
Currently, the sdhc_card_busy function is unimplemented in the SDHC SPI-driver. This causes some functions which rely on f_sync(), such as fs_close(), to fail as it will timeout the busy-check. This PR implements sdhc_card_busy by checking if the MISO-line is kept high to check if the SD-card is idle (not busy).

Solves https://github.com/zephyrproject-rtos/zephyr/issues/49982

Signed-off-by: Ivan Herrera Olivares <ivan.herreraolivares@uantwerpen.be>