### PR TITLE
drivers/timer: stm32 lptim: Fix frequency check

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -306,9 +306,9 @@ static int sys_clock_driver_init(const struct device *dev)
 	/* For tick accuracy, a specific tick to freq ratio is expected */
 	/* This check assumes LSI@32KHz or LSE@32768Hz */
 	if (((lptim_clk[1].bus == STM32_SRC_LSI) &&
-	      (CONFIG_SYS_CLOCK_TICKS_PER_SEC == 4000)) ||
+	      (CONFIG_SYS_CLOCK_TICKS_PER_SEC != 4000)) ||
 	    ((lptim_clk[1].bus == STM32_SRC_LSE) &&
-	      (CONFIG_SYS_CLOCK_TICKS_PER_SEC == 4096))) {
+	      (CONFIG_SYS_CLOCK_TICKS_PER_SEC != 4096))) {
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
Aim is to error out on misconfifurations, not the other way round.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>