### PR TITLE
doc: doxygen: group heap APIs

### DIFF
--- a/include/zephyr/multi_heap/shared_multi_heap.h
+++ b/include/zephyr/multi_heap/shared_multi_heap.h
@@ -17,9 +17,16 @@ extern "C" {
 #endif
 
 /**
+ * @brief Heap Management
+ * @defgroup heaps Heap Management
+ * @{
+ * @}
+ */
+
+/**
  * @brief Shared Multi-Heap (SMH) interface
  * @defgroup shared_multi_heap Shared multi-heap interface
- * @ingroup multi_heap
+ * @ingroup heaps
  * @{
  *
  * The shared multi-heap manager uses the multi-heap allocator to manage a set

--- a/include/zephyr/sys/heap_listener.h
+++ b/include/zephyr/sys/heap_listener.h
@@ -19,6 +19,7 @@ extern "C" {
 
 /**
  * @defgroup heap_listener_apis Heap Listener APIs
+ * @ingroup heaps
  * @{
  */
 


### PR DESCRIPTION
Group heap APIs under heap management.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
