### PR TITLE
boards: arm: nucleo_u575zi_q: enable CAN

### DIFF
--- a/boards/arm/nucleo_u575zi_q/doc/nucleou575zi_q.rst
+++ b/boards/arm/nucleo_u575zi_q/doc/nucleou575zi_q.rst
@@ -146,6 +146,8 @@ The Zephyr nucleo_u575zi_q board configuration supports the following hardware f
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |
 +===========+============+=====================================+
+| CAN/CANFD | on-chip    | canbus                              |
++-----------+------------+-------------------------------------+
 | CLOCK     | on-chip    | reset and clock control             |
 +-----------+------------+-------------------------------------+
 | DAC       | on-chip    | DAC Controller                      |
@@ -186,6 +188,9 @@ For mode details please refer to `STM32 Nucleo-144 board User Manual`_.
 Default Zephyr Peripheral Mapping:
 ----------------------------------
 
+
+- CAN/CANFD_TX: PD1
+- CAN/CANFD_RX: PD0
 - DAC1_OUT1 : PA4
 - I2C_1_SCL : PB8
 - I2C_1_SDA : PB9

--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -117,3 +117,13 @@
 &rng {
 	status = "okay";
 };
+
+&can1 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>,
+		 <&rcc STM32_SRC_PLL1_Q FDCAN1_SEL(1)>;
+	pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
+	pinctrl-names = "default";
+	bus-speed = <125000>;
+	bus-speed-data = <1000000>;
+	status = "okay";
+};

--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q.dts
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q.dts
@@ -19,6 +19,7 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,canbus = &can1;
 	};
 
 	aliases {

--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q.yaml
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q.yaml
@@ -10,6 +10,8 @@ supported:
   - arduino_i2c
   - arduino_serial
   - arduino_spi
+  - can
+  - canfd
   - dac
   - gpio
   - i2c


### PR DESCRIPTION
Enable CAN on this board and set it's domain clock source to PLL1_Q, as no HSE is available on the board.