### PR TITLE
stm32: Fixes and configurations around lptim testing

### DIFF
--- a/boards/arm/nucleo_l073rz/Kconfig.defconfig
+++ b/boards/arm/nucleo_l073rz/Kconfig.defconfig
@@ -12,4 +12,8 @@ config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI
 
+# LPTIM clocked by LSI, force tick freq to 4000 for tick accuracy
+config SYS_CLOCK_TICKS_PER_SEC
+	default 4000 if STM32_LPTIM_TIMER
+
 endif # BOARD_NUCLEO_L073RZ

--- a/boards/arm/nucleo_l073rz/board.cmake
+++ b/boards/arm/nucleo_l073rz/board.cmake
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=STM32L073RZ" "--speed=4000")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -41,7 +41,8 @@
 		stop: state {
 			compatible = "zephyr,power-state";
 			power-state-name = "suspend-to-idle";
-			min-residency-us = <100>;
+			min-residency-us = <2000>;
+			exit-latency-us = <750>;
 		};
 	};
 
@@ -95,6 +96,7 @@
 &lptim1 {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>,
 		<&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
+	status = "okay";
 };
 
 &usart1 {

--- a/boards/arm/nucleo_wl55jc/Kconfig.defconfig
+++ b/boards/arm/nucleo_wl55jc/Kconfig.defconfig
@@ -9,6 +9,6 @@ config BOARD
 	default "nucleo_wl55jc"
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 4096 if STM32_LPTIM_TIMER
+	default 4000 if STM32_LPTIM_TIMER
 
 endif # BOARD_NUCLEO_WL55JC

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -56,7 +56,7 @@ static const struct device *const clk_ctrl = DEVICE_DT_GET(STM32_CLOCK_CONTROL_N
  * - with prescaler of 1, the max timeout (lptim_time_base) is 2seconds
  */
 
-static uint32_t lptim_clock_freq;
+static uint32_t lptim_clock_freq = 32000;
 static int32_t lptim_time_base;
 
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -75,7 +75,7 @@
 			#clock-cells = <0>;
 			compatible = "st,stm32-lse-clock";
 			clock-frequency = <32768>;
-			driving-capability = <0>;
+			driving-capability = <2>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Few fixes and configurations helping to pass `kernel/timer` tests using LPTIM (PM case)