### PR TITLE
util: provide IS_ARRAY_ELEMENT, ARRAY_INDEX, ARRAY_INDEX_FLOOR macros

### DIFF
--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -106,6 +106,26 @@ ZTEST(util_cxx, test_mixing_GET_ARG_and_FOR_EACH) {
 	run_mixing_GET_ARG_and_FOR_EACH();
 }
 
+ZTEST(util_cxx, test_IS_ARRAY_ELEMENT)
+{
+	run_IS_ARRAY_ELEMENT();
+}
+
+ZTEST(util_cxx, test_ARRAY_INDEX)
+{
+	run_ARRAY_INDEX();
+}
+
+ZTEST(util_cxx, test_PART_OF_ARRAY)
+{
+	run_PART_OF_ARRAY();
+}
+
+ZTEST(util_cxx, test_ARRAY_INDEX_FLOOR)
+{
+	run_ARRAY_INDEX_FLOOR();
+}
+
 ZTEST_SUITE(util_cxx, NULL, NULL, NULL, NULL, NULL);
 
 #if __cplusplus
@@ -202,6 +222,26 @@ ZTEST(util_cc, test_GET_ARGS_LESS_N) {
 
 ZTEST(util_cc, test_mixing_GET_ARG_and_FOR_EACH) {
 	run_mixing_GET_ARG_and_FOR_EACH();
+}
+
+ZTEST(util_cc, test_IS_ARRAY_ELEMENT)
+{
+	run_IS_ARRAY_ELEMENT();
+}
+
+ZTEST(util_cc, test_ARRAY_INDEX)
+{
+	run_ARRAY_INDEX();
+}
+
+ZTEST(util_cc, test_PART_OF_ARRAY)
+{
+	run_PART_OF_ARRAY();
+}
+
+ZTEST(util_cc, test_ARRAY_INDEX_FLOOR)
+{
+	run_ARRAY_INDEX_FLOOR();
 }
 
 ZTEST_SUITE(util_cc, NULL, NULL, NULL, NULL, NULL);

--- a/tests/unit/util/test.inc
+++ b/tests/unit/util/test.inc
@@ -467,3 +467,62 @@ void run_mixing_GET_ARG_and_FOR_EACH(void)
 	zassert_equal(a[3], 4);
 	zassert_equal(a[4], 5);
 }
+
+void run_IS_ARRAY_ELEMENT(void)
+{
+	size_t i;
+	size_t array[3];
+	uint8_t *const alias = (uint8_t *)array;
+
+	zassert_false(IS_ARRAY_ELEMENT(array, &array[-1]));
+	zassert_false(IS_ARRAY_ELEMENT(array, &array[ARRAY_SIZE(array)]));
+	zassert_false(IS_ARRAY_ELEMENT(array, &alias[1]));
+
+	for (i = 0; i < ARRAY_SIZE(array); ++i) {
+		zassert_true(IS_ARRAY_ELEMENT(array, &array[i]));
+	}
+}
+
+void run_ARRAY_INDEX(void)
+{
+	size_t i;
+	size_t array[] = {0, 1, 2, 3};
+
+	for (i = 0; i < ARRAY_SIZE(array); ++i) {
+		zassert_equal(array[ARRAY_INDEX(array, &array[i])], i);
+	}
+
+	/* ARRAY_INDEX(array, &alias[1]) asserts with CONFIG_ASSERT=y */
+}
+
+void run_PART_OF_ARRAY(void)
+{
+	size_t i;
+	size_t array[3];
+	uint8_t *const alias = (uint8_t *)array;
+
+	ARG_UNUSED(i);
+	ARG_UNUSED(alias);
+
+	zassert_false(PART_OF_ARRAY(array, &array[-1]));
+	zassert_false(PART_OF_ARRAY(array, &array[ARRAY_SIZE(array)]));
+
+	for (i = 0; i < ARRAY_SIZE(array); ++i) {
+		zassert_true(PART_OF_ARRAY(array, &array[i]));
+	}
+
+	zassert_true(PART_OF_ARRAY(array, &alias[1]));
+}
+
+void run_ARRAY_INDEX_FLOOR(void)
+{
+	size_t i;
+	size_t array[] = {0, 1, 2, 3};
+	uint8_t *const alias = (uint8_t *)array;
+
+	for (i = 0; i < ARRAY_SIZE(array); ++i) {
+		zassert_equal(array[ARRAY_INDEX_FLOOR(array, &array[i])], i);
+	}
+
+	zassert_equal(array[ARRAY_INDEX_FLOOR(array, &alias[1])], 0);
+}


### PR DESCRIPTION
`IS_ARRAY_ELEMENT(array, ptr)` behaves like `PART_OF_ARRAY()` except that it checks that `ptr` is aligned to an array-element boundary.

`ARRAY_INDEX(array, ptr)` returns the index of `ptr`, where `ptr` is aligned to an array-element boundary.

`ARRAY_INDEX_FLOOR(array, ptr)` returns the index of `ptr`, where `ptr` does not need to be aligned to an array-element boundary.

If `CONFIG_ASSERT=y`, then `ARRAY_INDEX()` and `ARRAY_INDEX_FLOOR()` will trigger an assertion for invalid `ptr`.
