### PR TITLE
boards: intel adsp mtpm: add missing DAI SSP defconfig

### DIFF
--- a/boards/xtensa/intel_adsp_ace15_mtpm/Kconfig.defconfig
+++ b/boards/xtensa/intel_adsp_ace15_mtpm/Kconfig.defconfig
@@ -7,4 +7,11 @@ if BOARD_INTEL_ADSP_ACE15_MTPM
 config BOARD
 	default "intel_adsp_ace15_mtpm"
 
+if DAI_INTEL_SSP
+
+config DAI_SSP_HAS_POWER_CONTROL
+	def_bool y
+
+endif
+
 endif # BOARD_INTEL_ADSP_ACE15_MTPM


### PR DESCRIPTION
Enables DAI_SSP_HAS_POWER_CONTROL in intel_adsp_ace15_mtpm defconfig.

