### PR TITLE
boards: arm: frdm_k64f: remove label from spi SDHC

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -156,11 +156,9 @@ arduino_spi: &spi0 {
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <0>;
 		status = "okay";
-		label = "SDHC_0";
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
-			label = "SDMMC_0";
 		};
 		spi-max-frequency = <24000000>;
 	};


### PR DESCRIPTION
remove deprecated label property from spi sd host controller, to fix twister failures.

Fixes #50023 

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>