### PR TITLE
devicetree: edtlib: gen_defines: Add model name macros based on compatibles

### DIFF
--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -57,6 +57,8 @@ node-macro =/ %s"DT_N" path-id %s"_PARTITION_ID" DIGIT
 node-macro =/ %s"DT_N" path-id %s"_COMPAT_MATCHES_" dt-name
 node-macro =/ %s"DT_N" path-id %s"_COMPAT_VENDOR_IDX_" DIGIT "_EXISTS"
 node-macro =/ %s"DT_N" path-id %s"_COMPAT_VENDOR_IDX_" DIGIT
+node-macro =/ %s"DT_N" path-id %s"_COMPAT_MODEL_IDX_" DIGIT "_EXISTS"
+node-macro =/ %s"DT_N" path-id %s"_COMPAT_MODEL_IDX_" DIGIT
 ; Every non-root node gets one of these macros, which expands to the node
 ; identifier for that node's parent in the devicetree.
 node-macro =/ %s"DT_N" path-id %s"_PARENT"

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -1713,7 +1713,7 @@
  */
 
 /**
- * @defgroup devicetree-generic-vendor Vendor name helpers
+ * @defgroup devicetree-generic-vendor Vendor and model name helpers
  * @ingroup devicetree
  * @{
  */
@@ -1795,6 +1795,82 @@
  */
 #define DT_NODE_VENDOR_OR(node_id, default_value) \
 	DT_NODE_VENDOR_BY_IDX_OR(node_id, 0, default_value)
+
+/**
+ * @brief Get the model at index "idx" as a string literal
+ *
+ * The model is a string extracted from the compatible after the vendor prefix.
+ *
+ * Example vendor-prefixes.txt:
+ *
+ *	vnd	A stand-in for a real vendor
+ *	zephyr	Zephyr-specific binding
+ *
+ * Example devicetree fragment:
+ *
+ *	n1: node-1 {
+ *		compatible = "vnd,model1", "gpio", "zephyr,model2";
+ *	};
+ *
+ * Example usage:
+ *
+ *	DT_NODE_MODEL_BY_IDX(DT_NODELABEL(n1), 0) // "model1"
+ *	DT_NODE_MODEL_BY_IDX(DT_NODELABEL(n1), 2) // "model2"
+ *
+ * Notice that the compatible at index 1 doesn't match any entries in the
+ * vendor prefix file and therefore index 1 is not a valid model index. Use
+ * DT_NODE_MODEL_HAS_IDX(node_id, idx) to determine if an index is valid.
+ *
+ * @param node_id node identifier
+ * @param idx index of the model to return
+ * @return string literal of the idx-th model
+ */
+#define DT_NODE_MODEL_BY_IDX(node_id, idx) \
+	DT_CAT3(node_id, _COMPAT_MODEL_IDX_, idx)
+
+/**
+ * @brief Does a node's compatible property have a model at an index?
+ *
+ * If this returns 1, then DT_NODE_MODEL_BY_IDX(node_id, idx) is valid. If it
+ * returns 0, it is an error to use DT_NODE_MODEL_BY_IDX(node_id, idx) with
+ * index "idx".
+ *
+ * @param node_id node identifier
+ * @param idx index of the model to check
+ * @return 1 if "idx" is a valid model index,
+ *         0 otherwise.
+ */
+#define DT_NODE_MODEL_HAS_IDX(node_id, idx) \
+	IS_ENABLED(DT_CAT4(node_id, _COMPAT_MODEL_IDX_, idx, _EXISTS))
+
+/**
+ * @brief Like DT_NODE_MODEL_BY_IDX(), but with a fallback to default_value.
+ *
+ * If the value exists, this expands to DT_NODE_MODEL_BY_IDX(node_id, idx).
+ * The default_value parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to default_value.
+ *
+ * @param node_id node identifier
+ * @param idx index of the model to return
+ * @return string literal of the idx-th model
+ * @param default_value a fallback value to expand to
+ * @return string literal of the idx-th model or "default_value"
+ */
+#define DT_NODE_MODEL_BY_IDX_OR(node_id, idx, default_value) \
+	COND_CODE_1(DT_NODE_MODEL_HAS_IDX(node_id, idx), \
+		    (DT_NODE_MODEL_BY_IDX(node_id, idx)), (default_value))
+
+/**
+ * @brief Get the node's (only) model as a string literal
+ *
+ * Equivalent to DT_NODE_MODEL_BY_IDX_OR(node_id, 0, default_value).
+ *
+ * @param node_id node identifier
+ * @param default_value a fallback value to expand to
+ */
+#define DT_NODE_MODEL_OR(node_id, default_value) \
+	DT_NODE_MODEL_BY_IDX_OR(node_id, 0, default_value)
 
 /**
  * @}

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -516,6 +516,11 @@ def write_compatibles(node):
             out_dt_define(f"{node.z_path_id}_COMPAT_VENDOR_IDX_{i}",
                           quote_str(node.edt.compat2vendor[compat]))
 
+        if node.edt.compat2model[compat]:
+            out_dt_define(f"{node.z_path_id}_COMPAT_MODEL_IDX_{i}_EXISTS", 1)
+            out_dt_define(f"{node.z_path_id}_COMPAT_MODEL_IDX_{i}",
+                          quote_str(node.edt.compat2model[compat]))
+
 def write_children(node):
     # Writes helper macros for dealing with node's children.
 

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -110,6 +110,10 @@ class EDT:
       A collections.defaultdict that maps each 'compatible' string that appears
       on some Node to a vendor name parsed from vendor_prefixes.
 
+    compat2model:
+      A collections.defaultdict that maps each 'compatible' string that appears
+      on some Node to a model name parsed from that compatible.
+
     label2node:
       A collections.OrderedDict that maps a node label to the node with
       that label.
@@ -455,6 +459,7 @@ class EDT:
         self.compat2nodes = defaultdict(list)
         self.compat2okay = defaultdict(list)
         self.compat2vendor = defaultdict(str)
+        self.compat2model = defaultdict(str)
 
         for node in self.nodes:
             for label in node.labels:
@@ -477,9 +482,10 @@ class EDT:
                          f"'{compat_re}'")
 
                 if ',' in compat and self._vendor_prefixes:
-                    vendor = compat.split(',', 1)[0]
+                    vendor, model = compat.split(',', 1)
                     if vendor in self._vendor_prefixes:
                         self.compat2vendor[compat] = self._vendor_prefixes[vendor]
+                        self.compat2model[compat] = model
 
                     # As an exception, the root node can have whatever
                     # compatibles it wants. Other nodes get checked.

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -37,6 +37,7 @@
 #define TEST_TEMP	DT_NODELABEL(test_temp_sensor)
 #define TEST_REG	DT_NODELABEL(test_reg)
 #define TEST_VENDOR	DT_NODELABEL(test_vendor)
+#define TEST_MODEL	DT_NODELABEL(test_vendor)
 #define TEST_ENUM_0	DT_NODELABEL(test_enum_0)
 
 #define TEST_I2C DT_NODELABEL(test_i2c)
@@ -426,6 +427,34 @@ ZTEST(devicetree_api, test_vendor)
 	/* DT_NODE_VENDOR_OR */
 	zassert_true(!strcmp(DT_NODE_VENDOR_OR(TEST_VENDOR, NULL), VND_VENDOR), "");
 }
+
+#define VND_MODEL "model1"
+#define ZEP_MODEL "model2"
+
+ZTEST(devicetree_api, test_model)
+{
+	/* DT_NODE_MODEL_HAS_IDX */
+	zassert_true(DT_NODE_MODEL_HAS_IDX(TEST_MODEL, 0), "");
+	zassert_false(DT_NODE_MODEL_HAS_IDX(TEST_MODEL, 1), "");
+	zassert_true(DT_NODE_MODEL_HAS_IDX(TEST_MODEL, 2), "");
+	zassert_false(DT_NODE_MODEL_HAS_IDX(TEST_MODEL, 3), "");
+
+	/* DT_NODE_MODEL_BY_IDX */
+	zassert_true(!strcmp(DT_NODE_MODEL_BY_IDX(TEST_MODEL, 0), VND_MODEL), "");
+	zassert_true(!strcmp(DT_NODE_MODEL_BY_IDX(TEST_MODEL, 2), ZEP_MODEL), "");
+
+	/* DT_NODE_MODEL_BY_IDX_OR */
+	zassert_true(!strcmp(DT_NODE_MODEL_BY_IDX_OR(TEST_MODEL, 0, NULL), VND_MODEL), "");
+	zassert_is_null(DT_NODE_MODEL_BY_IDX_OR(TEST_MODEL, 1, NULL), "");
+	zassert_true(!strcmp(DT_NODE_MODEL_BY_IDX_OR(TEST_MODEL, 2, NULL), ZEP_MODEL), "");
+	zassert_is_null(DT_NODE_MODEL_BY_IDX_OR(TEST_MODEL, 3, NULL), "");
+
+	/* DT_NODE_MODEL_OR */
+	zassert_true(!strcmp(DT_NODE_MODEL_OR(TEST_MODEL, NULL), VND_MODEL), "");
+}
+
+#undef ZEP_MODEL
+#undef VND_MODEL
 
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_reg_holder


### PR DESCRIPTION
Follow up to #49489 adding support in edtlib, gen_defines, and devicetree.h to get model name strings from a node's compatibles.

cc: @huhebo