### PR TITLE
Bluetooth: Controller: Fix missing supervision/sync lost

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -149,6 +149,7 @@ void lll_conn_prepare_reset(void)
 
 void lll_conn_abort_cb(struct lll_prepare_param *prepare_param, void *param)
 {
+	struct event_done_extra *e;
 	struct lll_conn *lll;
 	int err;
 
@@ -172,6 +173,17 @@ void lll_conn_abort_cb(struct lll_prepare_param *prepare_param, void *param)
 	/* Accumulate the latency as event is aborted while being in pipeline */
 	lll = prepare_param->param;
 	lll->latency_prepare += (prepare_param->lazy + 1);
+
+	/* Extra done event, to check supervision timeout */
+	e = ull_event_done_extra_get();
+	LL_ASSERT(e);
+
+	e->type = EVENT_DONE_EXTRA_TYPE_CONN;
+	e->trx_cnt = 0U;
+	e->crc_valid = 0U;
+#if defined(CONFIG_BT_CTLR_LE_ENC)
+	e->mic_state = LLL_CONN_MIC_NONE;
+#endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	lll_done(param);
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -131,7 +131,7 @@ static void prepare(void *param)
 
 	/* Accumulate window widening */
 	lll->window_widening_prepare_us += lll->window_widening_periodic_us *
-					   (p->lazy + 1);
+					   (p->lazy + 1U);
 	if (lll->window_widening_prepare_us > lll->window_widening_max_us) {
 		lll->window_widening_prepare_us = lll->window_widening_max_us;
 	}
@@ -256,12 +256,12 @@ static int create_prepare_cb(struct lll_prepare_param *p)
 	event_counter = lll->event_counter + lll->skip_event;
 
 	/* Reset accumulated latencies */
-	lll->skip_prepare = 0;
+	lll->skip_prepare = 0U;
 
 	chan_idx = data_channel_calc(lll);
 
 	/* Update event counter to next value */
-	lll->event_counter = (event_counter + 1);
+	lll->event_counter = (event_counter + 1U);
 
 	err = prepare_cb_common(p, chan_idx);
 	if (err) {
@@ -320,16 +320,17 @@ static int prepare_cb(struct lll_prepare_param *p)
 	event_counter = lll->event_counter + lll->skip_event;
 
 	/* Reset accumulated latencies */
-	lll->skip_prepare = 0;
+	lll->skip_prepare = 0U;
 
 	chan_idx = data_channel_calc(lll);
 
 	/* Update event counter to next value */
-	lll->event_counter = (event_counter + 1);
+	lll->event_counter = (event_counter + 1U);
 
 	err = prepare_cb_common(p, chan_idx);
 	if (err) {
 		DEBUG_RADIO_START_O(1);
+
 		return 0;
 	}
 
@@ -554,7 +555,7 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 
 	/* Accumulate the latency as event is aborted while being in pipeline */
 	lll = prepare_param->param;
-	lll->skip_prepare += (prepare_param->lazy + 1);
+	lll->skip_prepare += (prepare_param->lazy + 1U);
 
 	lll_done(param);
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -532,6 +532,7 @@ static int is_abort_cb(void *next, void *curr, lll_prepare_cb_t *resume_cb)
 
 static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 {
+	struct event_done_extra *e;
 	struct lll_sync *lll;
 	int err;
 
@@ -556,6 +557,20 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 	/* Accumulate the latency as event is aborted while being in pipeline */
 	lll = prepare_param->param;
 	lll->skip_prepare += (prepare_param->lazy + 1U);
+
+	/* Extra done event, to check sync lost */
+	e = ull_event_done_extra_get();
+	LL_ASSERT(e);
+
+	e->type = EVENT_DONE_EXTRA_TYPE_SYNC;
+	e->trx_cnt = 0U;
+	e->crc_valid = 0U;
+#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING) && \
+	defined(CONFIG_BT_CTLR_CTEINLINE_SUPPORT)
+	e->sync_term = 0U;
+#endif /* CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING &&
+	* CONFIG_BT_CTLR_CTEINLINE_SUPPORT
+	*/
 
 	lll_done(param);
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1550,7 +1550,11 @@ void ull_conn_done(struct node_rx_event_done *done)
 #else
 	latency_event = lll->latency_event;
 #endif
-	elapsed_event = latency_event + 1;
+	if (lll->latency_prepare) {
+		elapsed_event = latency_event + lll->latency_prepare;
+	} else {
+		elapsed_event = latency_event + 1U;
+	}
 
 	/* Peripheral drift compensation calc and new latency or
 	 * central terminate acked

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1572,7 +1572,7 @@ void ull_conn_done(struct node_rx_event_done *done)
 			if (conn->tx_head || memq_peek(lll->memq_tx.head,
 						       lll->memq_tx.tail,
 						       NULL)) {
-				lll->latency_event = 0;
+				lll->latency_event = 0U;
 			} else if (lll->periph.latency_enabled) {
 				lll->latency_event = lll->latency;
 			}
@@ -1584,7 +1584,7 @@ void ull_conn_done(struct node_rx_event_done *done)
 			if (ull_tx_q_peek(&conn->tx_q) ||
 			    memq_peek(lll->memq_tx.head,
 				      lll->memq_tx.tail, NULL)) {
-				lll->latency_event = 0;
+				lll->latency_event = 0U;
 			} else if (lll->periph.latency_enabled) {
 				lll->latency_event = lll->latency;
 			}
@@ -2768,7 +2768,7 @@ static struct node_tx *ctrl_tx_rsp_mem_acquire(struct ll_conn *conn,
 		rx->hdr.type = NODE_RX_TYPE_RELEASE;
 
 		/* Drop request */
-		*err = 0U;
+		*err = 0;
 
 		return NULL;
 	}
@@ -3223,7 +3223,7 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 		ctrl_tx_enqueue(conn, tx);
 #endif /* !CONFIG_BT_CTLR_SCHED_ADVANCED */
 	} else if (instant_latency <= 0x7FFF) {
-		uint32_t ticks_win_offset = 0;
+		uint32_t ticks_win_offset = 0U;
 		uint32_t ticks_slot_overhead;
 		uint16_t conn_interval_old;
 		uint16_t conn_interval_new;
@@ -3672,17 +3672,17 @@ static inline void event_enc_prep(struct ll_conn *conn)
 		       sizeof(lll->ccm_tx.iv));
 
 		/* initialise counter */
-		lll->ccm_rx.counter = 0;
-		lll->ccm_tx.counter = 0;
+		lll->ccm_rx.counter = 0U;
+		lll->ccm_tx.counter = 0U;
 
 		/* set direction: peripheral to central = 0,
 		 * central to peripheral = 1
 		 */
-		lll->ccm_rx.direction = 0;
-		lll->ccm_tx.direction = 1;
+		lll->ccm_rx.direction = 0U;
+		lll->ccm_tx.direction = 1U;
 
 		/* enable receive encryption */
-		lll->enc_rx = 1;
+		lll->enc_rx = 1U;
 
 		/* send enc start resp */
 		start_enc_rsp_send(conn, pdu_ctrl_tx);
@@ -4281,28 +4281,28 @@ static inline void dle_max_time_get(const struct ll_conn *conn,
 				    uint16_t *max_rx_time,
 				    uint16_t *max_tx_time)
 {
-	uint64_t feature_coded_phy = 0;
-	uint64_t feature_phy_2m = 0;
-	uint16_t rx_time = 0;
-	uint16_t tx_time = 0;
+	uint64_t feature_coded_phy = 0U;
+	uint64_t feature_phy_2m = 0U;
+	uint16_t rx_time = 0U;
+	uint16_t tx_time = 0U;
 
 #if defined(CONFIG_BT_CTLR_PHY)
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
 	feature_coded_phy = (conn->llcp_feature.features_conn &
 			     BIT64(BT_LE_FEAT_BIT_PHY_CODED));
 #else
-	feature_coded_phy = 0;
+	feature_coded_phy = 0U;
 #endif
 
 #if defined(CONFIG_BT_CTLR_PHY_2M)
 	feature_phy_2m = (conn->llcp_feature.features_conn &
 			  BIT64(BT_LE_FEAT_BIT_PHY_2M));
 #else
-	feature_phy_2m = 0;
+	feature_phy_2m = 0U;
 #endif
 #else
-	feature_coded_phy = 0;
-	feature_phy_2m = 0;
+	feature_coded_phy = 0U;
+	feature_phy_2m = 0U;
 #endif
 
 	if (!conn->common.fex_valid ||
@@ -4364,8 +4364,8 @@ static inline void event_len_prep(struct ll_conn *conn)
 		/*
 		 * initialize to 0 to eliminate compiler warnings
 		 */
-		uint16_t rx_time = 0;
-		uint16_t tx_time = 0;
+		uint16_t rx_time = 0U;
+		uint16_t tx_time = 0U;
 
 		tx = mem_acquire(&mem_conn_tx_ctrl.free);
 		if (!tx) {
@@ -4448,7 +4448,7 @@ static inline void event_len_prep(struct ll_conn *conn)
 				/* Initiate cached procedure */
 				conn->llcp_length.tx_octets =
 					conn->llcp_length.cache.tx_octets;
-				conn->llcp_length.cache.tx_octets = 0;
+				conn->llcp_length.cache.tx_octets = 0U;
 #if defined(CONFIG_BT_CTLR_PHY)
 				conn->llcp_length.tx_time =
 					conn->llcp_length.cache.tx_time;
@@ -4614,7 +4614,9 @@ static inline void event_phy_req_prep(struct ll_conn *conn)
 		} else {
 			conn->llcp.phy_upd_ind.rx = 0U;
 		}
-		/* conn->llcp.phy_upd_ind.instant = 0; */
+		/* conn->llcp.phy_upd_ind.instant = 0U; for now, will be filled
+		 * in initiate state.
+		 */
 		conn->llcp.phy_upd_ind.initiate = 1U;
 		conn->llcp.phy_upd_ind.cmd = conn->llcp_phy.cmd;
 
@@ -5360,10 +5362,10 @@ static int pause_enc_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 		}
 
 		/* disable transmit encryption */
-		conn->lll.enc_tx = 0;
+		conn->lll.enc_tx = 0U;
 	} else {
 		/* disable transmit encryption */
-		conn->lll.enc_tx = 0;
+		conn->lll.enc_tx = 0U;
 
 		goto pause_enc_rsp_send_exit;
 	}
@@ -5372,7 +5374,7 @@ static int pause_enc_rsp_send(struct ll_conn *conn, struct node_rx_pdu *rx,
 	conn->llcp_enc.pause_rx = 1U;
 
 	/* disable receive encryption */
-	conn->lll.enc_rx = 0;
+	conn->lll.enc_rx = 0U;
 
 	/* Enqueue pause enc rsp */
 	pdu_ctrl_tx = (void *)tx->pdu;
@@ -6664,7 +6666,7 @@ static inline void ctrl_tx_ack(struct ll_conn *conn, struct node_tx **tx,
 				/* Initiate cached procedure */
 				conn->llcp_length.tx_octets =
 					conn->llcp_length.cache.tx_octets;
-				conn->llcp_length.cache.tx_octets = 0;
+				conn->llcp_length.cache.tx_octets = 0U;
 #if defined(CONFIG_BT_CTLR_PHY)
 				conn->llcp_length.tx_time =
 					conn->llcp_length.cache.tx_time;
@@ -7616,8 +7618,8 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 				conn->llcp_phy.rx &= p->tx_phys;
 
 				if (!conn->llcp_phy.tx || !conn->llcp_phy.rx) {
-					conn->llcp_phy.tx = 0;
-					conn->llcp_phy.rx = 0;
+					conn->llcp_phy.tx = 0U;
+					conn->llcp_phy.rx = 0U;
 				}
 
 				/* pause data packet tx */
@@ -7650,8 +7652,8 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 			conn->llcp_phy.rx &= p->tx_phys;
 
 			if (!conn->llcp_phy.tx || !conn->llcp_phy.rx) {
-				conn->llcp_phy.tx = 0;
-				conn->llcp_phy.rx = 0;
+				conn->llcp_phy.tx = 0U;
+				conn->llcp_phy.rx = 0U;
 			}
 
 			/* pause data packet tx */
@@ -7713,7 +7715,9 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 			}
 
 			ull_chan_map_get(conn->llcp.chan_map.chm);
-			/* conn->llcp.chan_map.instant     = 0; */
+			/* conn->llcp.chan_map.instant = 0U; filled in initiate
+			 * state.
+			 */
 			conn->llcp.chan_map.initiate = 1U;
 
 			conn->llcp_type = LLCP_CHAN_MAP;
@@ -8057,9 +8061,9 @@ void ull_conn_chan_map_set(struct ll_conn *conn, const uint8_t chm[5])
 static inline void dle_max_time_get(struct ll_conn *conn, uint16_t *max_rx_time,
 				    uint16_t *max_tx_time)
 {
-	uint16_t rx_time = 0;
-	uint16_t tx_time = 0;
 	uint8_t phy_select = PHY_1M;
+	uint16_t rx_time = 0U;
+	uint16_t tx_time = 0U;
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	if (conn->llcp.fex.valid && feature_phy_coded(conn)) {
@@ -8099,7 +8103,7 @@ void ull_dle_max_time_get(struct ll_conn *conn, uint16_t *max_rx_time,
 
 uint8_t ull_dle_update_eff(struct ll_conn *conn)
 {
-	uint8_t dle_changed = 0;
+	uint8_t dle_changed = 0U;
 
 	const uint16_t eff_tx_octets =
 		MAX(MIN(conn->lll.dle.local.max_tx_octets, conn->lll.dle.remote.max_rx_octets),

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -331,7 +331,7 @@ uint8_t ll_sync_create_cancel(void **rx)
 	sync->is_stop = 1U;
 	cpu_dmb();
 
-	if (sync->timeout_reload != 0) {
+	if (sync->timeout_reload != 0U) {
 		uint16_t sync_handle = ull_sync_handle_get(sync);
 
 		LL_ASSERT(sync_handle <= UINT8_MAX);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -983,7 +983,11 @@ void ull_sync_done(struct node_rx_event_done *done)
 
 		/* Events elapsed used in timeout checks below */
 		skip_event = lll->skip_event;
-		elapsed_event = skip_event + 1;
+		if (lll->skip_prepare) {
+			elapsed_event = skip_event + lll->skip_prepare;
+		} else {
+			elapsed_event = skip_event + 1U;
+		}
 
 		/* Sync drift compensation and new skip calculation */
 		ticks_drift_plus = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -516,7 +516,11 @@ void ull_sync_iso_done(struct node_rx_event_done *done)
 
 	/* Events elapsed used in timeout checks below */
 	latency_event = lll->latency_event;
-	elapsed_event = latency_event + 1U;
+	if (lll->latency_prepare) {
+		elapsed_event = latency_event + lll->latency_prepare;
+	} else {
+		elapsed_event = latency_event + 1U;
+	}
 
 	/* Sync drift compensation and new skip calculation
 	 */


### PR DESCRIPTION
When radio event prepare is cancelled due to preemption by
overlapping radio events, the extra done event processing
was missing and hence the use of accumulated prepares'
skip/latency count.
This caused the check for supervision timeout and sync
lost not be aware of the elapsed events.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>