### PR TITLE
boards: arm: frdm_k64f: remove deprecated use of label

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -156,11 +156,9 @@ arduino_spi: &spi0 {
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <0>;
 		status = "okay";
-		label = "SDHC_0";
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
-			label = "SDMMC_0";
 		};
 		spi-max-frequency = <24000000>;
 	};


### PR DESCRIPTION
Remove the deprecated use of the devicetree label properties for SDHC_0.

Fixes: 33b851f71e4268685e850f053d7577026f052b53

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>