### PR TITLE
bluetooth: controller: Ext. adv. duration handling fix

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1314,7 +1314,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 	}
 
 #if !defined(CONFIG_BT_HCI_MESH_EXT)
-	ticks_anchor = ticker_ticks_now_get();
+	ticks_anchor = ticker_ticks_now_get() + HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 #else /* CONFIG_BT_HCI_MESH_EXT */
 	if (!at_anchor) {
 		ticks_anchor = ticker_ticks_now_get();
@@ -1995,11 +1995,10 @@ void ull_adv_done(struct node_rx_event_done *done)
 
 		rx_hdr = (void *)lll->node_rx_adv_term;
 		rx_hdr->rx_ftr.param_adv_term.status = BT_HCI_ERR_LIMIT_REACHED;
-	} else if (adv->ticks_remain_duration &&
-		   (adv->ticks_remain_duration <=
-		    HAL_TICKER_US_TO_TICKS((uint64_t)adv->interval *
-			ADV_INT_UNIT_US))) {
-		adv->ticks_remain_duration = 0;
+	} else if (adv->remain_duration_us &&
+		   (adv->remain_duration_us <=
+		    ((uint64_t)adv->interval * ADV_INT_UNIT_US))) {
+		adv->remain_duration_us = 0;
 
 		rx_hdr = (void *)lll->node_rx_adv_term;
 		rx_hdr->rx_ftr.param_adv_term.status = BT_HCI_ERR_ADV_TIMEOUT;
@@ -2290,21 +2289,20 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 						  0, 0, ticker_update_op_cb);
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-		adv->event_counter += (lazy + 1);
+		if (adv->remain_duration_us && adv->event_counter > 0) {
+			uint32_t interval_us = (uint64_t)adv->interval * ADV_INT_UNIT_US;
+			uint32_t elapsed_us = interval_us * (lazy + 1) +
+						 HAL_TICKER_TICKS_TO_US(ticks_drift);
 
-		if (adv->ticks_remain_duration) {
-			uint32_t ticks_interval =
-				HAL_TICKER_US_TO_TICKS((uint64_t)adv->interval *
-						       ADV_INT_UNIT_US);
-			uint32_t ticks_elapsed = ticks_interval * (lazy + 1) +
-						 ticks_drift;
-
-			if (adv->ticks_remain_duration > ticks_elapsed) {
-				adv->ticks_remain_duration -= ticks_elapsed;
+			/* End advertising if the added random delay pushes us beyond the limit */
+			if (adv->remain_duration_us > elapsed_us + interval_us + random_delay) {
+				adv->remain_duration_us -= elapsed_us;
 			} else {
-				adv->ticks_remain_duration = ticks_interval;
+				adv->remain_duration_us = interval_us;
 			}
 		}
+
+		adv->event_counter += (lazy + 1);
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 	}
 
@@ -2494,8 +2492,7 @@ static void adv_max_events_duration_set(struct ll_adv_set *adv,
 {
 	adv->event_counter = 0;
 	adv->max_events = max_ext_adv_evts;
-	adv->ticks_remain_duration =
-		HAL_TICKER_US_TO_TICKS((uint64_t)duration * 10 * USEC_PER_MSEC);
+	adv->remain_duration_us = (uint32_t)duration * 10 * USEC_PER_MSEC;
 }
 
 static void ticker_stop_aux_op_cb(uint32_t status, void *param)

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1932,13 +1932,11 @@ void ull_adv_done(struct node_rx_event_done *done)
 	lll = &adv->lll;
 
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
-	if (done->extra.result == DONE_COMPLETED) {
-		/* Event completed successfully */
-		adv->delay_remain = ULL_ADV_RANDOM_DELAY;
-	} else {
+	if (done->extra.result != DONE_COMPLETED) {
 		/* Event aborted or too late - try to re-schedule */
 		uint32_t ticks_elapsed;
 		uint32_t ticks_now;
+		uint32_t delay_remain;
 
 		const uint32_t prepare_overhead =
 			HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
@@ -1952,39 +1950,52 @@ void ull_adv_done(struct node_rx_event_done *done)
 			ticks_elapsed = ticks_now - ticks_adv_airtime;
 		}
 
-		if (adv->delay_remain >= adv->delay + ticks_elapsed) {
+		if (adv->delay_at_expire + ticks_elapsed <= ULL_ADV_RANDOM_DELAY) {
 			/* The perturbation window is still open */
-			adv->delay_remain -= (adv->delay + ticks_elapsed);
+			delay_remain = ULL_ADV_RANDOM_DELAY - (adv->delay_at_expire +
+							       ticks_elapsed);
 		} else {
-			adv->delay_remain = 0;
+			delay_remain = 0;
 		}
 
 		/* Check if we have enough time to re-schedule */
-		if (adv->delay_remain > prepare_overhead) {
+		if (delay_remain > prepare_overhead) {
 			uint32_t ticks_adjust_minus;
+			uint32_t interval_us = adv->interval * ADV_INT_UNIT_US;
 
 			/* Get negative ticker adjustment needed to pull back ADV one
 			 * interval plus the randomized delay. This means that the ticker
 			 * will be updated to expire in time frame of now + start
 			 * overhead, until 10 ms window is exhausted.
 			 */
-			ticks_adjust_minus = HAL_TICKER_US_TO_TICKS(
-				(uint64_t)adv->interval * ADV_INT_UNIT_US) + adv->delay;
+			ticks_adjust_minus = HAL_TICKER_US_TO_TICKS(interval_us) + adv->delay;
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+			if (adv->remain_duration_us > interval_us) {
+				/* Reset remain_duration_us to value before last ticker expire
+				 * to correct for the re-scheduling
+				 */
+				adv->remain_duration_us += interval_us +
+							   HAL_TICKER_TICKS_TO_US(
+								adv->delay_at_expire);
+			}
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
 
 			/* Apply random delay in range [prepare_overhead..delay_remain].
 			 * NOTE: This ticker_update may fail if update races with
 			 * ticker_stop, e.g. from ull_periph_setup. This is not a problem
 			 * and we can safely ignore the operation result.
 			 */
-			ticker_update_rand(adv, adv->delay_remain - prepare_overhead,
+			ticker_update_rand(adv, delay_remain - prepare_overhead,
 					   prepare_overhead, ticks_adjust_minus, NULL);
+
+			/* Delay from ticker_update_rand is in addition to the last random delay */
+			adv->delay += adv->delay_at_expire;
 
 			/* Score of the event was increased due to the result, but since
 			 * we're getting a another chance we'll set it back.
 			 */
 			adv->lll.hdr.score -= 1;
-		} else {
-			adv->delay_remain = ULL_ADV_RANDOM_DELAY;
 		}
 	}
 #endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
@@ -2276,6 +2287,7 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
 		adv->ticks_at_expire = ticks_at_expire;
+		adv->delay_at_expire = adv->delay;
 #endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 	}
 
@@ -2290,12 +2302,17 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 		if (adv->remain_duration_us && adv->event_counter > 0) {
+#if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+			/* ticks_drift is always 0 with JIT scheduling, populate manually */
+			ticks_drift = adv->delay_at_expire;
+#endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 			uint32_t interval_us = (uint64_t)adv->interval * ADV_INT_UNIT_US;
 			uint32_t elapsed_us = interval_us * (lazy + 1) +
 						 HAL_TICKER_TICKS_TO_US(ticks_drift);
 
 			/* End advertising if the added random delay pushes us beyond the limit */
-			if (adv->remain_duration_us > elapsed_us + interval_us + random_delay) {
+			if (adv->remain_duration_us > elapsed_us + interval_us +
+						      HAL_TICKER_TICKS_TO_US(random_delay)) {
 				adv->remain_duration_us -= elapsed_us;
 			} else {
 				adv->remain_duration_us = interval_us;
@@ -2933,7 +2950,7 @@ static void init_set(struct ll_adv_set *adv)
 	adv->lll.chan_map = BT_LE_ADV_CHAN_MAP_ALL;
 	adv->lll.filter_policy = BT_LE_ADV_FP_NO_FILTER;
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
-	adv->delay_remain = ULL_ADV_RANDOM_DELAY;
+	adv->delay = 0;
 #endif /* ONFIG_BT_CTLR_JIT_SCHEDULING */
 
 	init_pdu(lll_adv_data_peek(&ll_adv[0].lll), PDU_ADV_TYPE_ADV_IND);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -38,7 +38,7 @@ struct ll_adv_set {
 #endif
 	uint16_t event_counter;
 	uint16_t max_events;
-	uint32_t ticks_remain_duration;
+	uint32_t remain_duration_us;
 #else /* !CONFIG_BT_CTLR_ADV_EXT */
 	uint16_t interval;
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -60,7 +60,7 @@ struct ll_adv_set {
 #endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
 	uint32_t delay;
-	uint32_t delay_remain;
+	uint32_t delay_at_expire;
 	uint32_t ticks_at_expire;
 #endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 };

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
@@ -423,7 +423,7 @@ static void test_advx_main(void)
 	printk("Start advertising using extended commands (duration)...");
 	is_sent = false;
 	num_sent_actual = 0;
-	num_sent_expected = 4;
+	num_sent_expected = 5;
 	ext_adv_param.timeout = 50;
 	ext_adv_param.num_events = 0;
 	err = bt_le_ext_adv_start(adv, &ext_adv_param);
@@ -493,11 +493,11 @@ static void test_advx_main(void)
 	printk("Re-enable advertising using extended commands (duration)...");
 	is_sent = false;
 	num_sent_actual = 0;
-	num_sent_expected = 4;      /* 4 advertising events of (100 ms +
+	num_sent_expected = 5;      /* 5 advertising events with a spacing of (100 ms +
 				     * random_delay of upto 10 ms) transmit in
 				     * the range of 400 to 440 ms
 				     */
-	ext_adv_param.timeout = 50; /* Check there is atmost 4 advertising
+	ext_adv_param.timeout = 50; /* Check there is atmost 5 advertising
 				     * events in a timeout of 500 ms
 				     */
 	ext_adv_param.num_events = 0;

--- a/tests/bluetooth/bsim_bt/bsim_test_eatt/src/common.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_eatt/src/common.c
@@ -140,6 +140,8 @@ void peripheral_setup_and_connect(void)
 		FAIL("Can't enable Bluetooth (err %d)\n", err);
 	}
 
+	k_sleep(K_MSEC(100));
+
 	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_beacon.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_beacon.c
@@ -324,6 +324,8 @@ static bool wait_for_beacon(bool (*process_cb)(const uint8_t *net_id, void *ctx)
 		k_sleep(K_SECONDS(1));
 	}
 
+	k_sleep(K_MSEC(100));
+
 	return received;
 }
 

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_friendship.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_friendship.c
@@ -395,7 +395,7 @@ static void test_lpn_est(void)
 	 * when Friend Request from several devices collide in emulated radio channel.
 	 * This shift of start moment helps to avoid Friend Request collisions.
 	 */
-	k_sleep(K_MSEC(10 * get_device_nbr()));
+	 k_sleep(K_MSEC(9 * get_device_nbr()));
 
 	bt_mesh_lpn_set(true);
 


### PR DESCRIPTION
- Remaining duration is now in us instead of ticks to avoid overflow when ticks have higher resolution
- Account for the added random delay when updating remaining duration
- Re-worked JIT re-scheduling update a bit to keep the random delay information and remaining duration correct
- Add EVENT_OVERHEAD_START_US to ticks_anchor when enabling advertising, so the first advertising event is not late due to calculations for aux packets etc.

Signed-off-by: Troels Nilsson <trnn@demant.com>