### PR TITLE
boards: shields: use shield-specific sdhc nodelabels

### DIFF
--- a/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
@@ -36,7 +36,7 @@
 		ngamctrl = [00 0e 14 03 11 07 31 c1 48 08 0f 0c 31 36 0f];
 	};
 
-	sdhc0: sdhc@1 {
+	adafruit_2_8_tft_touch_v2_sdhc: sdhc@1 {
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <1>;
 		status = "okay";

--- a/boards/shields/waveshare_epaper/dts/waveshare_epaper_common.dtsi
+++ b/boards/shields/waveshare_epaper/dts/waveshare_epaper_common.dtsi
@@ -9,7 +9,7 @@
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>,	/* D10 */
 		   <&arduino_header 12 GPIO_ACTIVE_LOW>;	/* D04 */
 
-	sdhc0: sdhc@1 {
+	waveshare_epaper_sdhc: sdhc@1 {
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <1>;
 		status = "okay";


### PR DESCRIPTION
Use shield-specific sdhc devicetree nodelabels in order not to clash with sdhc nodelabels from the board devicetree.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>