### PR TITLE
drivers: can: transceiver: Update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/can/transceiver/Kconfig
+++ b/drivers/can/transceiver/Kconfig
@@ -13,8 +13,9 @@ config CAN_TRANSCEIVER_INIT_PRIORITY
 
 config CAN_TRANSCEIVER_GPIO
 	bool "GPIO controlled CAN transceiver"
+	default y
+	depends on DT_HAS_CAN_TRANSCEIVER_GPIO_ENABLED
 	depends on GPIO
-	default $(dt_compat_enabled,can-transceiver-gpio)
 	help
 	  Enable support for GPIO controlled CAN transceivers.
 


### PR DESCRIPTION
Update the GPIO-controlled CAN transceiver driver to use the DT_HAS_CAN_TRANSCEIVER_GPIO_ENABLED Kconfig symbol to expose the driver and enable it by default based on devicetree.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>