### PR TITLE
Bluetooth: Mesh: Use separate pool for relayed messages

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -344,16 +344,13 @@ config BT_MESH_MSG_CACHE_SIZE
 	  for each received network PDU and increases RAM footprint proportionately.
 
 config BT_MESH_ADV_BUF_COUNT
-	int "Number of advertising buffers"
+	int "Number of advertising buffers for local messages"
 	default 6
 	range 1 256
 	help
-	  Number of advertising buffers available. This should be chosen
-	  based on what kind of features the local node should have. E.g.
-	  a relay will perform better the more buffers it has. Another
-	  thing to consider is outgoing segmented messages. There must
-	  be at least three more advertising buffers than the maximum
-	  supported outgoing segment count (BT_MESH_TX_SEG_MAX).
+	  Number of advertising buffers available for sending local messages.
+	  This should be chosen based on the number of local messages that the node
+	  can send at concurrently.
 
 choice BT_MESH_ADV
 	prompt "Advertiser mode"
@@ -643,6 +640,21 @@ config BT_MESH_RELAY_RETRANSMIT_INTERVAL
 	  Controls the initial interval between retransmissions of relayed
 	  messages, in milliseconds. Can be changed through runtime
 	  configuration.
+
+config BT_MESH_RELAY_BUF_COUNT
+	int "Number of advertising buffers for relayed messages"
+	default 32
+	range 1 256
+	help
+	  Number of advertising buffers available for messages to be relayed.
+	  High number of advertising buffers increases the reliability of the
+	  mesh network. Low number of advertising buffers reduces the message
+	  latency on the Relay Node, but at the same time increases the amount
+	  of packet drops. When considering the message latency, also consider
+	  the values of BT_MESH_RELAY_RETRANSMIT_COUNT and
+	  BT_MESH_RELAY_RETRANSMIT_INTERVAL. A higher number of
+	  BT_MESH_RELAY_ADV_SETS allows the increase in the number of buffers
+	  while maintaining the latency.
 
 endif
 

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -687,7 +687,7 @@ static void bt_mesh_net_relay(struct net_buf_simple *sbuf,
 	buf = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_RELAY_ADV,
 				 transmit, K_NO_WAIT);
 	if (!buf) {
-		BT_WARN("Out of relay buffers");
+		BT_DBG("Out of relay buffers");
 		return;
 	}
 


### PR DESCRIPTION
Sharing the same pool for both, local and relayed messages has some disadwantages. In a high-traffic environment the relayed messages may occupy the whole pool without letting the node to send own messages, neither to process segmented messages. The vice versa situation is possible when local messages takes the whole pool so that the node is not able to relay other messages. Another thing is that it doesn't let to controll amount of local and relayed messages that the node can send at once. Controlling the number of messages that the node can relay may help to reduce the message latency.

This change adds separate net_buf_pool for the relayed messages that helps to avoid problems described above.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>