### PR TITLE
manifest: mcuboot update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -182,7 +182,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 21e56a1bd033af263e808940779a1adaf4d5465e
+      revision: fec7042dcde6090ac6df197e12be8b90247a3276
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Synch up to the mcu-tools/mcuboot SHA:
4030aac5944e5105f45bfcb02b7e0065810a8aeb)

- Switched zephyr port from using FLASH_AREA_ macros to FIXED_PARTITION_ macros
- Made flash_map_backend.h compatible with a C++ compiler
- Enabled watchdog feed by default
- Allowed to get the flash write alignment basing on the zephyr,flash DT chosen node property

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>