### PR TITLE
cmake: clang: Disable deprecated non-prototype warning

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -29,6 +29,7 @@ check_set_compiler_property(PROPERTY warning_base
                             -Wno-main
                             -Wno-unused-but-set-variable
                             -Wno-typedef-redefinition
+                            -Wno-deprecated-non-prototype
 )
 
 check_set_compiler_property(APPEND PROPERTY warning_base -Wno-pointer-sign)


### PR DESCRIPTION
Clang 15 added a new warning type `-Wdeprecated-non-prototype` that warns about the functions without prototypes, which have been deprecated since the C89 and will not work in the upcoming C2x.

This commit disables the warning because Zephyr deliberately makes use of the functions without prototypes to allow the use of a "generic" function pointer (notoriously in the cbprintf implementation) and Zephyr will not move to the C2x in the foreseeable future.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>