### PR TITLE
drivers: clock_control: stm32 fixed LSE system clock enable

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -595,18 +595,18 @@ static void set_up_fixed_clock_sources(void)
 		LL_RCC_LSE_SetDriveCapability(STM32_LSE_DRIVING << RCC_BDCR_LSEDRV_Pos);
 #endif
 
+		/* Enable LSE Oscillator (32.768 kHz) */
+		LL_RCC_LSE_Enable();
+		while (!LL_RCC_LSE_IsReady()) {
+			/* Wait for LSE ready */
+		}
+
 #ifdef RCC_BDCR_LSESYSEN
 		LL_RCC_LSE_EnablePropagation();
 		/* Wait till LSESYS is ready */
 		while (!LL_RCC_LSE_IsPropagationReady()) {
 		}
 #endif /* RCC_BDCR_LSESYSEN */
-
-		/* Enable LSE Oscillator (32.768 kHz) */
-		LL_RCC_LSE_Enable();
-		while (!LL_RCC_LSE_IsReady()) {
-			/* Wait for LSE ready */
-		}
 
 		LL_PWR_DisableBkUpAccess();
 


### PR DESCRIPTION
On some stm32 mcus, the LSE is enabled as system clock (LSESYS) 
only when the LSEON and LSERDY are both set.
The bit LSESYSEN is set in the RCC BDCR register
and the driver is waiting for the LSESYSRDY to be set. 

Signed-off-by: Francois Ramu <francois.ramu@st.com>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/49985