### PR TITLE
canbus: isotp: fix typo, `CF` stands for Consecutive Frame

### DIFF
--- a/include/zephyr/canbus/isotp.h
+++ b/include/zephyr/canbus/isotp.h
@@ -54,8 +54,8 @@
 /** Reception of next FC has timed out */
 #define ISOTP_N_TIMEOUT_BS     -2
 
-/** Cr has timed out */
-#define ISOTP_N_TIMEOUT_CR     -3
+/** Consecutive Frame has timed out */
+#define ISOTP_N_TIMEOUT_CF     -3
 
 /** Unexpected sequence number */
 #define ISOTP_N_WRONG_SN       -4

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -197,7 +197,7 @@ static void receive_timeout_handler(struct _timeout *to)
 	switch (ctx->state) {
 	case ISOTP_RX_STATE_WAIT_CF:
 		LOG_ERR("Timeout while waiting for CF");
-		receive_report_error(ctx, ISOTP_N_TIMEOUT_CR);
+		receive_report_error(ctx, ISOTP_N_TIMEOUT_CF);
 		break;
 
 	case ISOTP_RX_STATE_TRY_ALLOC:

--- a/tests/subsys/canbus/isotp/conformance/src/main.c
+++ b/tests/subsys/canbus/isotp/conformance/src/main.c
@@ -774,7 +774,7 @@ static void test_receive_timeouts(void)
 	zassert_equal(ret, DATA_SIZE_FF,
 		      "Expected FF data length but got %d", ret);
 	ret = isotp_recv(&recv_ctx, data_buf, sizeof(data_buf), K_FOREVER);
-	zassert_equal(ret, ISOTP_N_TIMEOUT_CR,
+	zassert_equal(ret, ISOTP_N_TIMEOUT_CF,
 		      "Expected timeout but got %d", ret);
 
 	time_diff = k_uptime_get_32() - start_time;


### PR DESCRIPTION
Fix the macro name used to describe a timeout when waiting for a Consecutive Frame, as per ISO-TP standard.
