### PR TITLE
drivers: serial: stm32 uart check baudrate register value

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -159,6 +159,13 @@ static inline void uart_stm32_set_baudrate(const struct device *dev, uint32_t ba
 				      presc_val,
 #endif
 				      baud_rate);
+		/* Check BRR is greater than or equal to 0x300 */
+		__ASSERT(LL_LPUART_ReadReg(config->usart, BRR) >= 0x300U,
+			 "BaudRateReg >= 0x300");
+
+		/* Check BRR is lower than or equal to 0xFFFFF */
+		__ASSERT(LL_LPUART_ReadReg(config->usart, BRR) < 0x000FFFFFU,
+			 "BaudRateReg < 0xFFFF");
 	} else {
 #endif /* HAS_LPUART_1 */
 #ifdef USART_CR1_OVER8
@@ -174,6 +181,9 @@ static inline void uart_stm32_set_baudrate(const struct device *dev, uint32_t ba
 				     LL_USART_OVERSAMPLING_16,
 #endif
 				     baud_rate);
+		/* Check BRR is greater than or equal to 16d */
+		__ASSERT(LL_USART_ReadReg(config->usart, BRR) > 16,
+			 "BaudRateReg >= 16");
 
 #if HAS_LPUART_1
 	}


### PR DESCRIPTION
The baudrate register (BRR) of a stm32 USART cannot be lower than 16
The baudrate register (BRR) of a stm32 LPUART cannot be lower than 0x300 and greater than 0xFFFFF.
Add assertion to check the range.
This could be the case when configuring a baudrate of 9600 on usart clocked by LSE (32768Hz).

This is done for example in the LL_LPUART_Init() or LL_USART_Init() of the stm32Cube.

Signed-off-by: Francois Ramu <francois.ramu@st.com>