### PR TITLE
dai: fix config and kconfig

### DIFF
--- a/drivers/dai/intel/alh/Kconfig.alh
+++ b/drivers/dai/intel/alh/Kconfig.alh
@@ -17,6 +17,7 @@ if DAI_INTEL_ALH
 
 config DAI_ALH_HAS_OWNERSHIP
 	bool "Intel ALH driver has ownership"
+	default y if SOC_SERIES_INTEL_ACE
 	help
 	  Select this to enable programming HW ownership
 

--- a/drivers/dai/intel/alh/alh.c
+++ b/drivers/dai/intel/alh/alh.c
@@ -126,6 +126,7 @@ static const struct dai_properties *dai_alh_get_properties(const struct device *
 		ALH_TXDA_OFFSET : ALH_RXDA_OFFSET;
 
 	prop->fifo_address = dai_base(dp) + offset + ALH_STREAM_OFFSET * stream_id;
+	prop->fifo_depth = ALH_GPDMA_BURST_LENGTH;
 	prop->dma_hs_id = alh_handshake_map[stream_id];
 	prop->stream_id = alh->params.stream_id;
 

--- a/drivers/dai/intel/alh/alh.c
+++ b/drivers/dai/intel/alh/alh.c
@@ -35,16 +35,25 @@ static int dai_alh_set_config_tplg(struct dai_intel_alh *dp, const void *spec_co
 	return 0;
 }
 
-static int dai_alh_set_config_blob(struct dai_intel_alh *dp, const void *spec_config)
+static int dai_alh_set_config_blob(struct dai_intel_alh *dp, const struct dai_config *cfg,
+				   const void *spec_config)
 {
 	struct dai_intel_alh_pdata *alh = dai_get_drvdata(dp);
 	const struct dai_intel_ipc4_alh_configuration_blob *blob = spec_config;
 	const struct ipc4_alh_multi_gtw_cfg *alh_cfg = &blob->alh_cfg;
 
-	alh->params.channels = ALH_CHANNELS_DEFAULT;
-	alh->params.rate = ALH_RATE_DEFAULT;
-	/* the LSB 8bits are for stream id */
-	alh->params.stream_id = alh_cfg->mapping[0].alh_id & 0xff;
+	alh->params.rate = cfg->rate;
+
+	for (int i = 0; i < alh_cfg->count; i++) {
+		/* the LSB 8bits are for stream id */
+		int alh_id = alh_cfg->mapping[i].alh_id & 0xff;
+
+		if (IPC4_ALH_DAI_INDEX(alh_id) == dp->index) {
+			alh->params.stream_id = alh_id;
+			alh->params.channels = popcount(alh_cfg->mapping[i].channel_mask);
+			break;
+		}
+	}
 
 	return 0;
 }
@@ -103,7 +112,7 @@ static int dai_alh_config_set(const struct device *dev, const struct dai_config 
 	if (cfg->type == DAI_INTEL_ALH) {
 		return dai_alh_set_config_tplg(dp, bespoke_cfg);
 	} else {
-		return dai_alh_set_config_blob(dp, bespoke_cfg);
+		return dai_alh_set_config_blob(dp, cfg, bespoke_cfg);
 	}
 }
 

--- a/drivers/dai/intel/alh/alh.h
+++ b/drivers/dai/intel/alh/alh.h
@@ -19,6 +19,12 @@
 #define IPC4_ALH_MAX_NUMBER_OF_GTW 16
 #define IPC4_ALH_DAI_INDEX_OFFSET 7
 
+/* copier id = (group id << 4) + codec id + IPC4_ALH_DAI_INDEX_OFFSET
+ * dai_index = (group id << 8) + codec id;
+ */
+#define IPC4_ALH_DAI_INDEX(x) ((((x) & 0xF0) << DAI_NUM_ALH_BI_DIR_LINKS_GROUP) + \
+				(((x) & 0xF) - IPC4_ALH_DAI_INDEX_OFFSET))
+
 #define ALH_GPDMA_BURST_LENGTH 4
 
 #define ALH_SET_BITS(b_hi, b_lo, x)	\

--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -580,6 +580,7 @@ const struct dai_properties *dai_dmic_get_properties(const struct device *dev,
 	struct dai_properties *prop = (struct dai_properties *)dev->config;
 
 	prop->fifo_address = dmic->fifo.offset;
+	prop->fifo_depth = dmic->fifo.depth;
 	prop->dma_hs_id = dmic->fifo.handshake;
 	prop->reg_init_delay = 0;
 

--- a/drivers/dai/intel/ssp/Kconfig.ssp
+++ b/drivers/dai/intel/ssp/Kconfig.ssp
@@ -15,6 +15,7 @@ config DAI_INTEL_SSP
 
 config DAI_SSP_HAS_POWER_CONTROL
 	bool "DAI ssp pm_runtime en/dis ssp power"
+	default y if SOC_SERIES_INTEL_ACE
 	depends on DAI_INTEL_SSP
 
 if DAI_INTEL_SSP


### PR DESCRIPTION
This will set ssp and alh power/ownership kconfigs for ACE by default, fix dai config properties and use alh params from blob