### PR TITLE
net: lib: coap: update method_from_code() to return error.

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -514,7 +514,10 @@ int coap_packet_append_payload(struct coap_packet *cpkt, const uint8_t *payload,
  * @param addr Peer address
  * @param addr_len Peer address length
  *
- * @return 0 in case of success or negative in case of error.
+ * @retval 0 in case of success.
+ * @retval -ENOTSUP in case of invalid request code.
+ * @retval -EPERM in case resource handler is not implemented.
+ * @retval -ENOENT in case the resource is not found.
  */
 int coap_handle_request(struct coap_packet *cpkt,
 			struct coap_resource *resources,

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -819,26 +819,33 @@ static bool uri_path_eq(const struct coap_packet *cpkt,
 	return true;
 }
 
-static coap_method_t method_from_code(const struct coap_resource *resource,
-				      uint8_t code)
+static int method_from_code(const struct coap_resource *resource,
+			    uint8_t code, coap_method_t *method)
 {
 	switch (code) {
 	case COAP_METHOD_GET:
-		return resource->get;
+		*method = resource->get;
+		return 0;
 	case COAP_METHOD_POST:
-		return resource->post;
+		*method = resource->post;
+		return 0;
 	case COAP_METHOD_PUT:
-		return resource->put;
+		*method = resource->put;
+		return 0;
 	case COAP_METHOD_DELETE:
-		return resource->del;
+		*method = resource->del;
+		return 0;
 	case COAP_METHOD_FETCH:
-		return resource->fetch;
+		*method = resource->fetch;
+		return 0;
 	case COAP_METHOD_PATCH:
-		return resource->patch;
+		*method = resource->patch;
+		return 0;
 	case COAP_METHOD_IPATCH:
-		return resource->ipatch;
+		*method = resource->ipatch;
+		return 0;
 	default:
-		return NULL;
+		return -EINVAL;
 	}
 }
 
@@ -871,7 +878,10 @@ int coap_handle_request(struct coap_packet *cpkt,
 		}
 
 		code = coap_header_get_code(cpkt);
-		method = method_from_code(resource, code);
+		if (method_from_code(resource, code, &method) < 0) {
+			return -ENOTSUP;
+		}
+
 		if (!method) {
 			return -EPERM;
 		}


### PR DESCRIPTION
method_from_code() function signature changed to return status and method.
In case of invalid request code, it returns -EINVAL which causes coap_handle_request()
to return -ENOTSUP. Adding tests as well.

Fixes: #49498

Signed-off-by: Sagar Shah <sagar.shah@legrand.com>