### PR TITLE
[RFC] Improved devicetree error reporting macrobatics

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -280,7 +280,10 @@ typedef int16_t device_handle_t;
  * @param node_id A devicetree node identifier
  * @return A pointer to the device object created for that node
  */
-#define DEVICE_DT_GET(node_id) (&DEVICE_DT_NAME_GET(node_id))
+#define DEVICE_DT_GET(node_id)						\
+({ struct device *ret = COND_CODE_1(DT_NODE_EXISTS(node_id), (&DEVICE_DT_NAME_GET(node_id)), (NULL)); \
+   BUILD_ASSERT(DT_NODE_EXISTS(node_id), "Invalid devicetree node identifier: " STRINGIFY(node_id)); \
+   ret; })
 
 /**
  * @brief Get a <tt>const struct device*</tt> for an instance of a

--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -5,8 +5,9 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/device.h>
 
 void main(void)
 {
-	printk("Hello World! %s\n", CONFIG_BOARD);
+	printk("Hello World! %p\n", DEVICE_DT_GET(DT_INVALID_NODE));
 }


### PR DESCRIPTION
This PR demonstrates how adding statement expressions to our repertoire of macrobatic tricks can turn inscrutable errors like this:

```
/home/mbolivar/zp/zephyr/samples/hello_world/src/main.c:12:39: error: ‘__device_dts_ord___ORD’ undeclared (first use in this function); did you mean ‘__device_dts_ord_11’?
   12 |         printk("Hello World! %p\n", DEVICE_DT_GET(DT_INVALID_NODE));
      |                                       ^~~~~~~~~~~~~~~~~~~~~~
      |                                       __device_dts_ord_11
```

Into much more helpful errors like this:

```
/home/mbolivar/zp/zephyr/samples/hello_world/src/main.c:12:38: error: static assertion failed: "Invalid devicetree node identifier: _"
   12 |         printk("Hello World! %p\n", DEVICE_DT_GET(DT_INVALID_NODE));
      |                                      ^~~~~~~~~~~~~~
```

Posting as an RFC to see what people think of the approach, with hopes of spurring various DT-derived APIs to adopt it.
