### PR TITLE
drivers: i2c: do not pass const pointer to i2c_bitbang_init

### DIFF
--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -141,7 +141,8 @@ static int i2c_gpio_init(const struct device *dev)
 		return err;
 	}
 
-	i2c_bitbang_init(&context->bitbang, &io_fns, config);
+	i2c_bitbang_init(&context->bitbang, &io_fns,
+		(struct i2c_gpio_config *)config);
 
 	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
 	err = i2c_bitbang_configure(&context->bitbang,


### PR DESCRIPTION
This causes compilation warnings which extends to failing Twister builds on projects using I2C bitbang.

Signed-off-by: Natanael Log <natte.log@gmail.com>