### PR TITLE
sys: util: fix WAIT_FOR() timeout calculation

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -475,7 +475,7 @@ char *utf8_lcpy(char *dst, const char *src, size_t n);
  */
 #define WAIT_FOR(expr, timeout, delay_stmt)                                                        \
 	({                                                                                         \
-		uint32_t cycle_count = (sys_clock_hw_cycles_per_sec() / USEC_PER_SEC) * (timeout); \
+		uint32_t cycle_count = k_us_to_cyc_ceil32(timeout); \
 		uint32_t start = k_cycle_get_32();                                                 \
 		while (!(expr) && (cycle_count > (k_cycle_get_32() - start))) {                    \
 			delay_stmt;                                                                \


### PR DESCRIPTION
Use k_us_to_cyc_ceil32() for calculating the number of hardware cycles for the given timeout value instead of using a custom calculation.
    
Fixes: #50032