### PR TITLE
dts/bindings/mm: Fix ADSP Meteor Lake DTS bindings

### DIFF
--- a/dts/bindings/mm/intel,adsp-mtl-tlb.yaml
+++ b/dts/bindings/mm/intel,adsp-mtl-tlb.yaml
@@ -11,3 +11,16 @@ include: mm_drv.yaml
 properties:
     reg:
         required: true
+
+    paddr-size:
+        type: int
+        description: Number of significant bits in the page index.
+        required: true
+
+    exec-bit-idx:
+        type: int
+        description: Index of the execute permission bit.
+
+    write-bit-idx:
+        type: int
+        description: Index of the write permission bit.


### PR DESCRIPTION
New properties were added but not in the bindings. Add them.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>