### PR TITLE
soc: arm: infineon_xmc: 4xxx: Disable unalign trap on reset

### DIFF
--- a/soc/arm/infineon_xmc/4xxx/soc.c
+++ b/soc/arm/infineon_xmc/4xxx/soc.c
@@ -16,6 +16,10 @@ void z_arm_platform_init(void)
 {
 	uint32_t temp;
 
+	/* unaligned trap bit is enabled on reset. disable it here and set later via */
+	/* CONFIG_TRAP_UNALIGNED_ACCESS if needed. */
+	SCB->CCR &= ~SCB_CCR_UNALIGN_TRP_Msk;
+
 	/* setup flash wait state */
 	temp = FLASH0->FCON;
 	temp &= ~FLASH_FCON_WSPFLASH_Msk;


### PR DESCRIPTION
The unaligned trap bit is set by default, contrary to the xmc reference manual. This PR unsets the bit in the initialization. It can still be set later via the CONFIG_TRAP_UNALIGNED option.

Note that the same approach is used in xmc4500 reference software init code (see SystemCoreSetup() in infineon hal module).

Signed-off-by: Andriy Gelman <andriy.gelman@gmail.com>