### PR TITLE
logging: Allow use of log_output without subsystem

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -1,7 +1,9 @@
 # Copyright (c) 2016 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig LOG
+menu "Logging"
+
+config LOG
 	bool "Logging"
 	select PRINTK if USERSPACE
 	help
@@ -37,3 +39,11 @@ endif #LOG_FRONTEND
 rsource "Kconfig.misc"
 
 endif # LOG
+
+config LOG_OUTPUT
+	bool "Formatter helper"
+	help
+	  Module which provides formatting of log messages to a human-readable
+	  strings.
+
+endmenu

--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -21,12 +21,6 @@ config LOG_FUNC_NAME_PREFIX_DBG
 
 endmenu
 
-config LOG_OUTPUT
-	bool "Formatter helper"
-	help
-	  Module which provides formatting of log messages to a human-readable
-	  strings.
-
 menuconfig LOG_MIPI_SYST_ENABLE
 	bool "MIPI SyS-T format output"
 	select MIPI_SYST_LIB

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -429,7 +429,7 @@ static uint32_t prefix_print(const struct log_output *output,
 	bool stamp = flags & LOG_OUTPUT_FLAG_TIMESTAMP;
 	bool colors_on = flags & LOG_OUTPUT_FLAG_COLORS;
 	bool level_on = flags & LOG_OUTPUT_FLAG_LEVEL;
-	const char *tag = z_log_get_tag();
+	const char *tag = IS_ENABLED(CONFIG_LOG) ? z_log_get_tag() : NULL;
 
 	if (IS_ENABLED(CONFIG_LOG_BACKEND_NET) &&
 	    flags & LOG_OUTPUT_FLAG_FORMAT_SYSLOG) {


### PR DESCRIPTION
Allow using log_output without the logging subsystem. It can be used in the situation where external messages are processed.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>