### PR TITLE
cavstool: add support for logs coming from HDA logging

### DIFF
--- a/soc/xtensa/intel_adsp/tools/cavstool_client.py
+++ b/soc/xtensa/intel_adsp/tools/cavstool_client.py
@@ -98,9 +98,10 @@ class cavstool_client():
         log.info(f"Start to monitor log output...")
         while True:
             # Receive data from the server and print out
-            receive_log = str(self.sock.recv(BUF_SIZE).strip(), "utf-8")
+            receive_log = str(self.sock.recv(BUF_SIZE), "utf-8").replace('\x00', '')
             if receive_log:
-                print(f"{receive_log}")
+                # DO NOT use print() because it implicitly adds a newline at the end
+                sys.stdout.write(f"{receive_log}")
                 time.sleep(0.1)
 
     def __del__(self):


### PR DESCRIPTION
(This PR further fix https://github.com/zephyrproject-rtos/zephyr/issues/46864.
It is meant to complete the https://github.com/zephyrproject-rtos/zephyr/pull/50006 for the sake of testing. 
And enhance the robustness of CAVS logging as well.)

**1)** Logs on CAVS platforms can go through either winstream or
HDA logging. Add output for HDA logging in cavstool.

**2)** And replace the print() with sys.stdout.write() in the
cavstool_client.py because print() can introduce excessive
newlines if the received bytes are not at the line boundary,
which can corrupt the output format randomly.

Use sys.stdout.write() to print what's received as-is.

Corrupted format like below:

DEBUG   - DEVICE: START - test_can_mode_listen_on
DEBUG   - DEVICE: ly

DEBUG   - DEVICE: - PASS - [can_shell.test_can_filter_add_missing_id
DEBUG   - DEVICE: ] duration = 0.001 seconds

**3)** HDA logging seems to be using some padding like '\x00'. Such
string can print well on a terminal but corrupt the string match.
And this can cause false failure if RunID matching is affected.
Remove all '\x00' char in the received content.

An affected RunID example:
'7aa9ba3c6db12\x00\...\x00\x00\x00\x00d0c7fcf382a4af40ec6'

Expected:
'7aa9ba3c6db12d0c7fcf382a4af40ec6'

**4)** Use non-displayable chars for live connection check. Otherwise
the log output will have subtle garbage like extra spaces which
locate randomly.


Signed-off-by: Ming Shao <ming.shao@intel.com>
