### PR TITLE
tests/fs: Fix littlefs overlay for nrf52840dk

### DIFF
--- a/tests/subsys/fs/littlefs/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/fs/littlefs/boards/nrf52840dk_nrf52840.overlay
@@ -10,7 +10,7 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
- 		small_partition: partition@0 {
+		small_partition: partition@0 {
 			label = "small";
 			reg = <0x00000000 0x00010000>;
 		};
@@ -18,7 +18,7 @@
 			label = "medium";
 			reg = <0x00010000 0x000F0000>;
 		};
-		larege_partition: partition@100000 {
+		large_partition: partition@100000 {
 			label = "large";
 			reg = <0x00100000 0x00300000>;
 		};


### PR DESCRIPTION
Type and space.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>