### PR TITLE
mcumgr: Fix issues with bluetooth backend

### DIFF
--- a/subsys/mgmt/mcumgr/lib/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/lib/smp/src/smp.c
@@ -224,8 +224,8 @@ smp_on_err(struct smp_streamer *streamer, const struct mgmt_hdr *req_hdr,
 	}
 
 	/* Free any extra buffers. */
-	zephyr_smp_free_buf(req, &streamer->mgmt_stmr.cb_arg);
-	zephyr_smp_free_buf(rsp, &streamer->mgmt_stmr.cb_arg);
+	zephyr_smp_free_buf(req, streamer->mgmt_stmr.cb_arg);
+	zephyr_smp_free_buf(rsp, streamer->mgmt_stmr.cb_arg);
 }
 
 /**
@@ -323,8 +323,8 @@ smp_process_request_packet(struct smp_streamer *streamer, void *vreq)
 		return rc;
 	}
 
-	zephyr_smp_free_buf(req, &streamer->mgmt_stmr.cb_arg);
-	zephyr_smp_free_buf(rsp, &streamer->mgmt_stmr.cb_arg);
+	zephyr_smp_free_buf(req, streamer->mgmt_stmr.cb_arg);
+	zephyr_smp_free_buf(rsp, streamer->mgmt_stmr.cb_arg);
 
 	return rc;
 }

--- a/subsys/mgmt/mcumgr/smp_bt.c
+++ b/subsys/mgmt/mcumgr/smp_bt.c
@@ -442,6 +442,10 @@ static int smp_bt_tx_pkt(struct zephyr_smp_transport *zst, struct net_buf *nb)
 		}
 	}
 
+	if (rc != MGMT_ERR_ENOENT) {
+		bt_conn_unref(conn);
+	}
+
 	smp_bt_ud_free(net_buf_user_data(nb));
 	mcumgr_buf_free(nb);
 


### PR DESCRIPTION
    mgmt: mcumgr: Fix wrongly using pointer of pointer in free function
    
    Fixes an issue introduced when the mcumgr code was simplified whereby
    the newer compressed free function call wrongly passes a pointer to a
    pointer instead of the pointer itself.

    mgmt: mcumgr: smp_bt: Fix missing notification connection unref
    
    Fixes an issue with the connection reference not being decremented
    at the end of the outgoing notification function resulting in an
    ever-increasing connection count.

Fixes #50073