### PR TITLE
peci: driver: Reset tx/rx fifo after every successful peci transaction

### DIFF
--- a/drivers/peci/peci_mchp_xec.c
+++ b/drivers/peci/peci_mchp_xec.c
@@ -401,6 +401,9 @@ static int peci_xec_transfer(const struct device *dev, struct peci_msg *msg)
 		return -EIO;
 	}
 
+	/* Reset Tx/Rx FIFO for successsful peci transactions */
+	peci_xec_bus_recovery(dev, false);
+
 	return 0;
 }
 


### PR DESCRIPTION
In the current implementation, FW reads FCS only for the commands having read_len > 1. But PECI host controller (EC HW) expects, for all commands (including Ping) either FW should read FCS or reset Tx/Rx FIFOs for every successful transaction.
In case of Ping command, PECI controller reads FCS from SOC and expected FW to read but FW didn't read since Ping have read_len=0. Due to this issue, FW getting corrupted response from PECI controller for all the subsequent PECI commands.

To address this issue, FW resets Tx/Rx FIFOs after every successful transaction.

Signed-off-by: Diwakar C <diwakar.c@intel.com>