### PR TITLE
kernel/sched: fix condition for CPU mask set

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1601,8 +1601,8 @@ static int cpu_mask_mod(k_tid_t thread, uint32_t enable_mask, uint32_t disable_m
 	int ret = 0;
 
 #ifdef CONFIG_SCHED_CPU_MASK_PIN_ONLY
-	__ASSERT((thread->base.thread_state != _THREAD_PRESTART),
-		 "Only PRESTARTED threads can change CPU pin");
+	__ASSERT(z_is_thread_prevented_from_running(thread),
+		 "Running threads cannot change CPU pin");
 #endif
 
 	LOCKED(&sched_spinlock) {


### PR DESCRIPTION
When building with CONFIG_SCHED_CPU_MASK_PIN_ONLY=y, CPU mask is fixed and cannot be changed while thread is running.

The current code asserts if thread state is anything but PREPARED.

We do however have interface like k_work_queue_start() where a thread is started as part of the queue start. To allow user to set the pinned CPU for the work queue thread, it needs to be possible to suspend the thread, set the mask, and then call k_thread_resume(). This seems to be a valid sequence, so relax the assert check to reflect this.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>