### PR TITLE
lib: p4wq: fix k_p4wq_enable_static_thread CPU mask setting

### DIFF
--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -192,6 +192,9 @@ void k_p4wq_enable_static_thread(struct k_p4wq *queue, struct k_thread *thread,
 	if (queue->flags & K_P4WQ_USER_CPU_MASK) {
 		unsigned int i;
 
+		i = k_thread_cpu_mask_clear(thread);
+		__ASSERT_NO_MSG(i == 0);
+
 		while ((i = find_lsb_set(cpu_mask))) {
 			int ret = k_thread_cpu_mask_enable(thread, i - 1);
 


### PR DESCRIPTION
The CPU mask must be first clear in k_p4wq_enable_static_thread(), before doing the additive loop where CPUs are enabled one by one.

Without this change, assert is hit in builds with
CONFIG_SCHED_CPU_MASK_PIN_ONLY=y.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>