### PR TITLE
xtensa: use lower-case hex in backtrace output

### DIFF
--- a/arch/xtensa/core/xtensa_backtrace.c
+++ b/arch/xtensa/core/xtensa_backtrace.c
@@ -97,7 +97,7 @@ int z_xtensa_backtrace_print(int depth, int *interrupted_stack)
 		mask = stk_frame.pc & 0xc0000000;
 	}
 	printk("\r\n\r\nBacktrace:");
-	printk("0x%08X:0x%08X ",
+	printk("0x%08x:0x%08x ",
 			z_xtensa_cpu_process_stack_pc(stk_frame.pc),
 			stk_frame.sp);
 
@@ -115,7 +115,7 @@ int z_xtensa_backtrace_print(int depth, int *interrupted_stack)
 		if (!z_xtensa_backtrace_get_next_frame(&stk_frame)) {
 			corrupted = true;
 		}
-		printk("0x%08X:0x%08X ", z_xtensa_cpu_process_stack_pc(stk_frame.pc), stk_frame.sp);
+		printk("0x%08x:0x%08x ", z_xtensa_cpu_process_stack_pc(stk_frame.pc), stk_frame.sp);
 	}
 
 	/* Print backtrace termination marker */


### PR DESCRIPTION
Align backtrace output with the style used in rest of the codespace. This makes it more convenient to compare the backtrace to e.g. objdump output.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>