### PR TITLE
logging: Fix signed integer cast for isprint

### DIFF
--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -390,7 +390,7 @@ static void hexdump_line_print(const struct log_output *output,
 		}
 
 		if (i < length) {
-			char c = (char)data[i];
+			unsigned char c = (unsigned char)data[i];
 
 			print_formatted(output, "%c",
 			      isprint((int)c) ? c : '.');

--- a/subsys/logging/log_output_syst.c
+++ b/subsys/logging/log_output_syst.c
@@ -582,7 +582,7 @@ static void hexdump_line_print(const uint8_t *data, uint32_t length,
 		}
 
 		if (i < length) {
-			char c = (char)data[i];
+			unsigned char c = (unsigned char)data[i];
 
 			*buf = isprint((int)c) ? c : '.';
 		} else {


### PR DESCRIPTION
Casting the value byte to char may result in it being a negative number. On some platforms this could lead to either UB, or a crash.

For example, `isprint` is defined as follows in the zephyr-sdk's ctype header file for x86_64:
```
#define __ctype_lookup(__c) ((__CTYPE_PTR+sizeof(""[__c]))[(int)(__c)])
#define isprint(__c)	(__ctype_lookup(__c)&(_P|_U|_L|_N|_B))
```

Signed-off-by: Dennis Sitelew <dennis.sitelew@grandcentrix.net>