### PR TITLE
mgmt: mcumgr: Remove zcbor_size_ definitions

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -29,16 +29,6 @@ const struct img_mgmt_dfu_callbacks_t *img_mgmt_dfu_callbacks_fn;
 
 struct img_mgmt_state g_img_mgmt_state;
 
-#if SIZE_MAX == UINT32_MAX
-#define zcbor_size_decode	zcbor_uint32_decode
-#define zcbor_size_put		zcbor_uint32_put
-#elif SIZE_MAX == UINT64_MAX
-#define zcbor_size_decode	zcbor_uint64_decode
-#define zcbor_size_put		zcbor_uint64_put
-#else
-#error "Unsupported size_t encoding"
-#endif
-
 #ifdef CONFIG_IMG_MGMT_VERBOSE_ERR
 const char *img_mgmt_err_str_app_reject = "app reject";
 const char *img_mgmt_err_str_hdr_malformed = "header malformed";


### PR DESCRIPTION
zcbor supports native zcbor_size_ functions for some time now, so there is no need to have local zcbor_size_ definitions.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>