### PR TITLE
net: context: Remove redunant check of automatically selected port

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -118,10 +118,6 @@ static uint16_t find_available_port(struct net_context *context,
 
 	do {
 		local_port = sys_rand32_get() | 0x8000;
-		if (local_port <= 1023U) {
-			/* 0 - 1023 ports are reserved */
-			continue;
-		}
 	} while (check_used_port(net_context_get_proto(context),
 				 htons(local_port), addr) == -EEXIST);
 


### PR DESCRIPTION
In the function find_available_port() a port is randomly selected. Because the random value is always >= 0x8000, it is redundant to check if it is <= 1023 afterwards.

This commit removes the redundant check.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>