### PR TITLE
Bluetooth: Mesh: Remove experimental tag from CDB

### DIFF
--- a/samples/bluetooth/mesh_provisioner/README.rst
+++ b/samples/bluetooth/mesh_provisioner/README.rst
@@ -27,9 +27,6 @@ If no errors are encountered, the node is marked as configured.
 The configuration of a node involves adding an application key, getting
 the composition data, and binding all its models to the application key.
 
-Please note that this sample uses the CDB API which is currently marked
-as EXPERIMENTAL and is likely to change.
-
 Requirements
 ************
 

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -68,8 +68,7 @@ config BT_MESH_PROVISIONER
 	  Enable this option to have support for provisioning remote devices.
 
 config BT_MESH_CDB
-	bool "Mesh Configuration Database [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "Mesh Configuration Database"
 
 if BT_MESH_CDB
 


### PR DESCRIPTION
The CDB module is a mandatory part of provisioning features in BTM, and can not be regarded as experimental anymore.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>