### PR TITLE
samples: direction_finding_connectionless_tx: Use identity address

### DIFF
--- a/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
@@ -31,6 +31,7 @@ static struct bt_le_ext_adv *adv_set;
 
 static struct bt_le_adv_param param =
 		BT_LE_ADV_PARAM_INIT(BT_LE_ADV_OPT_EXT_ADV |
+				     BT_LE_ADV_OPT_USE_IDENTITY |
 				     BT_LE_ADV_OPT_USE_NAME,
 				     BT_GAP_ADV_FAST_INT_MIN_2,
 				     BT_GAP_ADV_FAST_INT_MAX_2,
@@ -136,7 +137,14 @@ void main(void)
 	}
 	printk("success\n");
 
-	bt_le_ext_adv_oob_get_local(adv_set, &oob_local);
+	printk("Get extended advertising address...");
+	err = bt_le_ext_adv_oob_get_local(adv_set, &oob_local);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("success\n");
+
 	bt_addr_le_to_str(&oob_local.addr, addr_s, sizeof(addr_s));
 
 	printk("Started extended advertising as %s\n", addr_s);


### PR DESCRIPTION
Use Identiy address in direction_finding_connectionless_tx sample. Without this option the advertiser is advertising using an NRPA since it is a non-connectable advertiser.
The function bt_le_ext_adv_oob_get_local cannot be used to get the NRPA address of the non-connectable advertiser when privacy is disabled.

Check the return address of bt_le_ext_adv_oob_get_local.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>