### PR TITLE
Bluetooth: Shell: Fix L2CAP ecred commands

### DIFF
--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -278,7 +278,7 @@ static int cmd_register(const struct shell *sh, size_t argc, char *argv[])
 #if defined(CONFIG_BT_L2CAP_ECRED)
 static int cmd_ecred_reconfigure(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct bt_l2cap_chan *l2cap_ecred_chans[1] = {&l2ch_chan.ch.chan};
+	struct bt_l2cap_chan *l2cap_ecred_chans[] = { &l2ch_chan.ch.chan, NULL };
 	uint16_t mtu;
 	int err = 0;
 
@@ -311,7 +311,7 @@ static int cmd_ecred_reconfigure(const struct shell *sh, size_t argc, char *argv
 
 static int cmd_ecred_connect(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct bt_l2cap_chan *l2cap_ecred_chans[1] = {&l2ch_chan.ch.chan};
+	struct bt_l2cap_chan *l2cap_ecred_chans[] = { &l2ch_chan.ch.chan, NULL };
 	uint16_t psm;
 	int err = 0;
 


### PR DESCRIPTION
The channel array must be null-terminated if it is less than 5 elements long.

Signed-off-by: Herman Berget <herman.berget@nordicsemi.no>