### PR TITLE
cmake: support grouping of compile options for compiler testing

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -28,9 +28,8 @@ set_compiler_property(PROPERTY optimization_size  -Os)
 # GCC Option standard warning base in Zephyr
 check_set_compiler_property(PROPERTY warning_base
     -Wall
-    -Wformat
-    -Wformat-security
-    -Wno-format-zero-length
+    "SHELL:-Wformat -Wformat-security"
+    "SHELL:-Wformat -Wno-format-zero-length"
     -Wno-main
 )
 

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1048,7 +1048,7 @@ function(zephyr_check_compiler_flag lang option check)
   set(key_string "${key_string}${option}_")
   set(key_string "${key_string}${CMAKE_REQUIRED_FLAGS}_")
 
-  string(MD5 key ${key_string})
+  string(MD5 key "${key_string}")
 
   # Check the cache
   set(key_path ${ZEPHYR_TOOLCHAIN_CAPABILITY_CACHE_DIR}/${key})
@@ -1068,7 +1068,7 @@ function(zephyr_check_compiler_flag lang option check)
   # tested, so to test -Wno-<warning> flags we test -W<warning>
   # instead.
   if("${option}" MATCHES "-Wno-(.*)")
-    set(possibly_translated_option -W${CMAKE_MATCH_1})
+    string(REPLACE "-Wno-" "-W" possibly_translated_option "${option}")
   else()
     set(possibly_translated_option ${option})
   endif()
@@ -1814,7 +1814,7 @@ function(check_compiler_flag lang option ok)
   endif()
 
   string(MAKE_C_IDENTIFIER
-    check${option}_${lang}_${CMAKE_REQUIRED_FLAGS}
+    "check${option}_${lang}_${CMAKE_REQUIRED_FLAGS}"
     ${ok}
     )
 
@@ -2004,6 +2004,12 @@ endfunction()
 # with the extension that it will check that the compiler supports the flag
 # before setting the property on compiler or compiler-cpp targets.
 #
+# To test flags together, such as '-Wformat -Wformat-security', an option group
+# can be specified by using shell-like quoting along with a 'SHELL:' prefix.
+# The 'SHELL:' prefix will be dropped before testing, so that
+# '"SHELL:-Wformat -Wformat-security"' becomes '-Wformat -Wformat-security' for
+# testing.
+#
 # APPEND: Flag indicated that the property should be appended to the existing
 #         value list for the property.
 # PROPERTY: Name of property with the value(s) following immediately after
@@ -2021,8 +2027,13 @@ function(check_set_compiler_property)
   list(REMOVE_AT COMPILER_PROPERTY_PROPERTY 0)
 
   foreach(option ${COMPILER_PROPERTY_PROPERTY})
+    if(${option} MATCHES "^SHELL:")
+      string(REGEX REPLACE "^SHELL:" "" option ${option})
+      separate_arguments(option UNIX_COMMAND ${option})
+    endif()
+
     if(CONFIG_CPLUSPLUS)
-      zephyr_check_compiler_flag(CXX ${option} check)
+      zephyr_check_compiler_flag(CXX "${option}" check)
 
       if(${check})
         set_property(TARGET compiler-cpp ${APPEND-CPP} PROPERTY ${property} ${option})
@@ -2030,7 +2041,7 @@ function(check_set_compiler_property)
       endif()
     endif()
 
-    zephyr_check_compiler_flag(C ${option} check)
+    zephyr_check_compiler_flag(C "${option}" check)
 
     if(${check})
       set_property(TARGET compiler ${APPEND} PROPERTY ${property} ${option})


### PR DESCRIPTION
Fixes: #47588

Kitware decided to fail compiler tests of single options if the
compiler reported only a warning and not an error:
https://github.com/Kitware/CMake/commit/f745e0497ee71d35fd1b3524b1636a72da76c266
which affects CMake 3.23.0 and 3.23.1

This change was later reverted in CMake >=3.23.2 and >=3.24.0
https://github.com/Kitware/CMake/commit/4941887d7defecb3016d2bd94d3a45754251ca56

Although the immediate issue is related to CMake, and has been fixed
reverted in later releases, then it still makes sense to be able to
group compiler options together that generally are depending on each
other to function correctly.

This commit introduces the possibility to group compiler options which
must be tested together.
It uses same approach as
```
add_compile_options("SHELL:<option1> <option2> ...")
```

Usage:
```
check_set_compiler_property(PROPERTY <property>
                            "SHELL:<option1> <option2> ..."
)
```

Will test the option together.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>
