### PR TITLE
drivers: serial: stm32 uart driver set EXTI line for wakeup from lowPower

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1694,6 +1694,10 @@ static int uart_stm32_init(const struct device *dev)
 		 * CONFIG_PM_DEVICE=y : Controlled by pm_device_wakeup_enable()
 		 */
 		LL_USART_EnableInStopMode(config->usart);
+		if (config->wakeup_line != STM32_EXTI_LINE_NONE) {
+			/* Prepare the WAKEUP with the expected EXTI line */
+			LL_EXTI_EnableIT_0_31(BIT(config->wakeup_line));
+		}
 	}
 #endif /* CONFIG_PM */
 
@@ -1843,8 +1847,11 @@ static void uart_stm32_irq_config_func_##index(const struct device *dev)	\
 #endif
 
 #ifdef CONFIG_PM
-#define STM32_UART_PM_WAKEUP(index)					\
-	.wakeup_source = DT_INST_PROP(index, wakeup_source),
+#define STM32_UART_PM_WAKEUP(index)						\
+	.wakeup_source = DT_INST_PROP(index, wakeup_source),			\
+	.wakeup_line = COND_CODE_1(DT_INST_NODE_HAS_PROP(index, wakeup_line),	\
+			(DT_INST_PROP(index, wakeup_line)),			\
+			(STM32_EXTI_LINE_NONE)),
 #else
 #define STM32_UART_PM_WAKEUP(index) /* Not used */
 #endif

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -16,6 +16,8 @@
 
 #include <stm32_ll_usart.h>
 
+#define STM32_EXTI_LINE_NONE	0xFFFFFFFFU
+
 /* device config */
 struct uart_stm32_config {
 	/* USART instance */
@@ -44,6 +46,7 @@ struct uart_stm32_config {
 #if defined(CONFIG_PM)
 	/* Device defined as wake-up source */
 	bool wakeup_source;
+	uint32_t wakeup_line;
 #endif /* CONFIG_PM */
 };
 

--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -46,3 +46,13 @@ properties:
 
     pinctrl-names:
       required: true
+
+    wakeup-line:
+      type: int
+      required: false
+      description: |
+        EXTI line number matching the device wakeup interrupt mask register.
+        This property is required on stm32 devices where the wakeup interrupt signal could be
+        configured masked at boot (sm32wl55 for instance), preventing the device to wakeup
+        the core from stop mode(s).
+        Valid range: 0 - 31

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wl55jc.overlay
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wl55jc.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&clk_lse {
+	status = "okay";
+};
+
+/* LPUART1 clock source on LSE : set console at 9600 */
+&lpuart1 {
+	/delete-property/ clocks;
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000001>,
+		<&rcc STM32_SRC_LSE LPUART1_SEL(3)>;
+
+	current-speed = <9600>;
+	wakeup-source;
+	wakeup-line = <28>;
+};


### PR DESCRIPTION
The LPUART, especially on stm32wl, must set the EXTI line corresponding to the wakeUp source.
This makes the system exiting lowpower stop mode on EXTI interrupt.

When configuring the LPUART of the nucleo_wl55jc to wakeup from stop mode, the serial_wakeup sample is running on the target platform 
`west build -p auto -b nucleo_wl55jc samples/boards/stm32/power_mgmt/serial_wakeup`

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/49985

Signed-off-by: Francois Ramu <francois.ramu@st.com>