### PR TITLE
drivers: can: add start and stop CAN controller API functions

### DIFF
--- a/doc/hardware/peripherals/canbus/controller.rst
+++ b/doc/hardware/peripherals/canbus/controller.rst
@@ -305,9 +305,19 @@ The following example sets the bitrate to 250k baud with the sampling point at
     return;
   }
 
+  ret = can_stop(can_dev);
+  if (ret != 0) {
+    LOG_ERR("Failed to stop CAN controller");
+  }
+
   ret = can_set_timing(can_dev, &timing);
   if (ret != 0) {
     LOG_ERR("Failed to set timing");
+  }
+
+  ret = can_start(can_dev);
+  if (ret != 0) {
+    LOG_ERR("Failed to start CAN controller");
   }
 
 A similar API exists for calculating and setting the timing for the data phase for CAN-FD capable

--- a/drivers/can/can_esp32_twai.c
+++ b/drivers/can/can_esp32_twai.c
@@ -97,6 +97,8 @@ static int can_esp32_twai_init(const struct device *dev)
 
 const struct can_driver_api can_esp32_twai_driver_api = {
 	.get_capabilities = can_sja1000_get_capabilities,
+	.start = can_sja1000_start,
+	.stop = can_sja1000_stop,
 	.set_mode = can_sja1000_set_mode,
 	.set_timing = can_sja1000_set_timing,
 	.send = can_sja1000_send,

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -147,6 +147,22 @@ static inline int z_vrfy_can_get_capabilities(const struct device *dev, can_mode
 }
 #include <syscalls/can_get_capabilities_mrsh.c>
 
+static inline int z_vrfy_can_start(const struct device *dev)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, start));
+
+	return z_impl_can_start(dev);
+}
+#include <syscalls/can_start_mrsh.c>
+
+static inline int z_vrfy_can_stop(const struct device *dev)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, stop));
+
+	return z_impl_can_stop(dev);
+}
+#include <syscalls/can_stop_mrsh.c>
+
 static inline int z_vrfy_can_set_mode(const struct device *dev, can_mode_t mode)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, set_mode));

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -184,6 +184,7 @@ struct can_mcan_data {
 	uint8_t ext_filt_rtr;
 	uint8_t ext_filt_rtr_mask;
 	struct can_mcan_mm mm;
+	bool started;
 	void *custom;
 } __aligned(4);
 
@@ -258,6 +259,10 @@ struct can_mcan_reg;
 	}
 
 int can_mcan_get_capabilities(const struct device *dev, can_mode_t *cap);
+
+int can_mcan_start(const struct device *dev);
+
+int can_mcan_stop(const struct device *dev);
 
 int can_mcan_set_mode(const struct device *dev, can_mode_t mode);
 

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -287,24 +287,6 @@ const int mcp2515_set_mode_int(const struct device *dev, uint8_t mcp2515_mode)
 	return 0;
 }
 
-static int mcp2515_get_mode(const struct device *dev, uint8_t *mode)
-{
-	uint8_t canstat;
-
-	if (mode == NULL) {
-		return -EINVAL;
-	}
-
-	if (mcp2515_cmd_read_reg(dev, MCP2515_ADDR_CANSTAT, &canstat, 1)) {
-		return -EIO;
-	}
-
-	*mode = (canstat & MCP2515_CANSTAT_MODE_MASK)
-		>> MCP2515_CANSTAT_MODE_POS;
-
-	return 0;
-}
-
 static int mcp2515_get_core_clock(const struct device *dev, uint32_t *rate)
 {
 	const struct mcp2515_config *dev_cfg = dev->config;
@@ -339,9 +321,12 @@ static int mcp2515_set_timing(const struct device *dev,
 		return -EINVAL;
 	}
 
+	if (dev_data->started) {
+		return -EBUSY;
+	}
+
 	/* CNF3, CNF2, CNF1, CANINTE */
 	uint8_t config_buf[4];
-	uint8_t mode;
 
 	/* CNF1; SJW<7:6> | BRP<5:0> */
 	__ASSERT(timing->prescaler > 0, "Prescaler should be bigger than zero");
@@ -395,18 +380,6 @@ static int mcp2515_set_timing(const struct device *dev,
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 
-	ret = mcp2515_get_mode(dev, &mode);
-	if (ret < 0) {
-		LOG_ERR("Failed to read device mode [%d]", ret);
-		goto done;
-	}
-
-	ret = mcp2515_set_mode_int(dev, MCP2515_MODE_CONFIGURATION);
-	if (ret < 0) {
-		LOG_ERR("Failed to enter configuration mode [%d]", ret);
-		goto done;
-	}
-
 	ret = mcp2515_cmd_write_reg(dev, MCP2515_ADDR_CNF3, config_buf,
 				    sizeof(config_buf));
 	if (ret < 0) {
@@ -428,13 +401,6 @@ static int mcp2515_set_timing(const struct device *dev,
 		goto done;
 	}
 
-	/* Restore previous mode */
-	ret = mcp2515_set_mode_int(dev, mode);
-	if (ret < 0) {
-		LOG_ERR("Failed to restore mode [%d]", ret);
-		goto done;
-	}
-
 done:
 	k_mutex_unlock(&dev_data->mutex);
 	return ret;
@@ -449,41 +415,27 @@ static int mcp2515_get_capabilities(const struct device *dev, can_mode_t *cap)
 	return 0;
 }
 
-static int mcp2515_set_mode(const struct device *dev, can_mode_t mode)
+static int mcp2515_start(const struct device *dev)
 {
 	const struct mcp2515_config *dev_cfg = dev->config;
 	struct mcp2515_data *dev_data = dev->data;
-	uint8_t mcp2515_mode;
 	int ret;
 
-	switch (mode) {
-	case CAN_MODE_NORMAL:
-		mcp2515_mode = MCP2515_MODE_NORMAL;
-		break;
-	case CAN_MODE_LISTENONLY:
-		mcp2515_mode = MCP2515_MODE_SILENT;
-		break;
-	case CAN_MODE_LOOPBACK:
-		mcp2515_mode = MCP2515_MODE_LOOPBACK;
-		break;
-	default:
-		LOG_ERR("Unsupported CAN Mode %u", mode);
-		return -ENOTSUP;
+	if (dev_data->started) {
+		return -EALREADY;
 	}
-
-	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 
 	if (dev_cfg->phy != NULL) {
 		ret = can_transceiver_enable(dev_cfg->phy);
 		if (ret != 0) {
-			LOG_ERR("failed to enable CAN transceiver (err %d)", ret);
-			goto done;
+			LOG_ERR("Failed to enable CAN transceiver [%d]", ret);
+			return ret;
 		}
 	}
 
-	k_usleep(MCP2515_OSC_STARTUP_US);
+	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 
-	ret = mcp2515_set_mode_int(dev, mcp2515_mode);
+	ret = mcp2515_set_mode_int(dev, dev_data->mcp2515_mode);
 	if (ret < 0) {
 		LOG_ERR("Failed to set the mode [%d]", ret);
 
@@ -491,11 +443,73 @@ static int mcp2515_set_mode(const struct device *dev, can_mode_t mode)
 			/* Attempt to disable the CAN transceiver in case of error */
 			(void)can_transceiver_disable(dev_cfg->phy);
 		}
+	} else {
+		dev_data->started = true;
 	}
 
-done:
 	k_mutex_unlock(&dev_data->mutex);
+
 	return ret;
+}
+
+static int mcp2515_stop(const struct device *dev)
+{
+	const struct mcp2515_config *dev_cfg = dev->config;
+	struct mcp2515_data *dev_data = dev->data;
+	int ret;
+
+	if (!dev_data->started) {
+		return -EALREADY;
+	}
+
+	k_mutex_lock(&dev_data->mutex, K_FOREVER);
+
+	ret = mcp2515_set_mode_int(dev, MCP2515_MODE_CONFIGURATION);
+	if (ret < 0) {
+		LOG_ERR("Failed to enter configuration mode [%d]", ret);
+		k_mutex_unlock(&dev_data->mutex);
+		return ret;
+	}
+
+	dev_data->started = false;
+
+	k_mutex_unlock(&dev_data->mutex);
+
+	if (dev_cfg->phy != NULL) {
+		ret = can_transceiver_disable(dev_cfg->phy);
+		if (ret != 0) {
+			LOG_ERR("Failed to disable CAN transceiver [%d]", ret);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static int mcp2515_set_mode(const struct device *dev, can_mode_t mode)
+{
+	struct mcp2515_data *dev_data = dev->data;
+
+	if (dev_data->started) {
+		return -EBUSY;
+	}
+
+	switch (mode) {
+	case CAN_MODE_NORMAL:
+		dev_data->mcp2515_mode = MCP2515_MODE_NORMAL;
+		break;
+	case CAN_MODE_LISTENONLY:
+		dev_data->mcp2515_mode = MCP2515_MODE_SILENT;
+		break;
+	case CAN_MODE_LOOPBACK:
+		dev_data->mcp2515_mode = MCP2515_MODE_LOOPBACK;
+		break;
+	default:
+		LOG_ERR("Unsupported CAN Mode %u", mode);
+		return -ENOTSUP;
+	}
+
+	return 0;
 }
 
 static int mcp2515_send(const struct device *dev,
@@ -514,6 +528,10 @@ static int mcp2515_send(const struct device *dev,
 		LOG_ERR("DLC of %d exceeds maximum (%d)",
 			frame->dlc, CAN_MAX_DLC);
 		return -EINVAL;
+	}
+
+	if (!dev_data->started) {
+		return -ENETDOWN;
 	}
 
 	if (k_sem_take(&dev_data->tx_sem, timeout) != 0) {
@@ -681,6 +699,7 @@ static void mcp2515_tx_done(const struct device *dev, uint8_t tx_idx)
 static int mcp2515_get_state(const struct device *dev, enum can_state *state,
 			     struct can_bus_err_cnt *err_cnt)
 {
+	struct mcp2515_data *dev_data = dev->data;
 	uint8_t eflg;
 	uint8_t err_cnt_buf[2];
 	int ret;
@@ -692,7 +711,9 @@ static int mcp2515_get_state(const struct device *dev, enum can_state *state,
 	}
 
 	if (state != NULL) {
-		if (eflg & MCP2515_EFLG_TXBO) {
+		if (!dev_data->started) {
+			*state = CAN_STATE_STOPPED;
+		} else if (eflg & MCP2515_EFLG_TXBO) {
 			*state = CAN_STATE_BUS_OFF;
 		} else if ((eflg & MCP2515_EFLG_RXEP) || (eflg & MCP2515_EFLG_TXEP)) {
 			*state = CAN_STATE_ERROR_PASSIVE;
@@ -742,8 +763,13 @@ static void mcp2515_handle_errors(const struct device *dev)
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 static int mcp2515_recover(const struct device *dev, k_timeout_t timeout)
 {
-	ARG_UNUSED(dev);
+	struct mcp2515_data *dev_data = dev->data;
+
 	ARG_UNUSED(timeout);
+
+	if (!dev_data->started) {
+		return -ENETDOWN;
+	}
 
 	return -ENOTSUP;
 }
@@ -838,6 +864,8 @@ static void mcp2515_int_gpio_callback(const struct device *dev,
 static const struct can_driver_api can_api_funcs = {
 	.get_capabilities = mcp2515_get_capabilities,
 	.set_timing = mcp2515_set_timing,
+	.start = mcp2515_start,
+	.stop = mcp2515_stop,
 	.set_mode = mcp2515_set_mode,
 	.send = mcp2515_send,
 	.add_rx_filter = mcp2515_add_rx_filter,
@@ -956,6 +984,8 @@ static int mcp2515_init(const struct device *dev)
 			LOG_WRN("Bitrate error: %d", ret);
 		}
 	}
+
+	k_usleep(MCP2515_OSC_STARTUP_US);
 
 	ret = can_set_timing(dev, &timing);
 	if (ret) {

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -45,6 +45,8 @@ struct mcp2515_data {
 	/* general data */
 	struct k_mutex mutex;
 	enum can_state old_state;
+	uint8_t mcp2515_mode;
+	bool started;
 	uint8_t sjw;
 };
 

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -77,6 +77,8 @@ static int mcux_mcan_init(const struct device *dev)
 
 static const struct can_driver_api mcux_mcan_driver_api = {
 	.get_capabilities = can_mcan_get_capabilities,
+	.start = can_mcan_start,
+	.stop = can_mcan_stop,
 	.set_mode = can_mcan_set_mode,
 	.set_timing = can_mcan_set_timing,
 	.send = can_mcan_send,

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -71,6 +71,8 @@ static int can_sam_init(const struct device *dev)
 
 static const struct can_driver_api can_sam_driver_api = {
 	.get_capabilities = can_mcan_get_capabilities,
+	.start = can_mcan_start,
+	.stop = can_mcan_stop,
 	.set_mode = can_mcan_set_mode,
 	.set_timing = can_mcan_set_timing,
 	.send = can_mcan_send,

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -193,6 +193,8 @@ static const char *can_shell_state_to_string(enum can_state state)
 		return "error-passive";
 	case CAN_STATE_BUS_OFF:
 		return "bus-off";
+	case CAN_STATE_STOPPED:
+		return "stopped";
 	default:
 		return "unknown";
 	}

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -226,6 +226,48 @@ static void can_shell_print_capabilities(const struct shell *sh, can_mode_t cap)
 	}
 }
 
+static int cmd_can_start(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev = device_get_binding(argv[1]);
+	int err;
+
+	if (!device_is_ready(dev)) {
+		shell_error(sh, "device %s not ready", argv[1]);
+		return -ENODEV;
+	}
+
+	shell_print(sh, "starting %s", argv[1]);
+
+	err = can_start(dev);
+	if (err != 0) {
+		shell_error(sh, "failed to start CAN controller (err %d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int cmd_can_stop(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev = device_get_binding(argv[1]);
+	int err;
+
+	if (!device_is_ready(dev)) {
+		shell_error(sh, "device %s not ready", argv[1]);
+		return -ENODEV;
+	}
+
+	shell_print(sh, "stopping %s", argv[1]);
+
+	err = can_stop(dev);
+	if (err != 0) {
+		shell_error(sh, "failed to stop CAN controller (err %d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
 static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev = device_get_binding(argv[1]);
@@ -810,6 +852,14 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_can_filter_cmds,
 );
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_can_cmds,
+	SHELL_CMD_ARG(start, &dsub_can_device_name,
+		"Start CAN controller\n"
+		"Usage: can start <device>",
+		cmd_can_start, 2, 0),
+	SHELL_CMD_ARG(stop, &dsub_can_device_name,
+		"Stop CAN controller\n"
+		"Usage: can stop <device>",
+		cmd_can_stop, 2, 0),
 	SHELL_CMD_ARG(show, &dsub_can_device_name,
 		"Show CAN controller information\n"
 		"Usage: can show <device>",

--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -79,13 +79,22 @@ static inline int can_sja1000_leave_reset_mode(const struct device *dev)
 	return 0;
 }
 
+static inline void can_sja1000_clear_errors(const struct device *dev)
+{
+	/* Clear error counters */
+	can_sja1000_write_reg(dev, CAN_SJA1000_RXERR, 0);
+	can_sja1000_write_reg(dev, CAN_SJA1000_TXERR, 0);
+
+	/* Clear error capture */
+	(void)can_sja1000_read_reg(dev, CAN_SJA1000_ECC);
+}
+
 int can_sja1000_set_timing(const struct device *dev, const struct can_timing *timing)
 {
 	struct can_sja1000_data *data = dev->data;
 	uint8_t btr0;
 	uint8_t btr1;
 	uint8_t sjw;
-	int err;
 
 	__ASSERT_NO_MSG(timing->sjw == CAN_SJW_NO_CHANGE || (timing->sjw >= 1 && timing->sjw <= 4));
 	__ASSERT_NO_MSG(timing->prop_seg == 0);
@@ -93,12 +102,11 @@ int can_sja1000_set_timing(const struct device *dev, const struct can_timing *ti
 	__ASSERT_NO_MSG(timing->phase_seg2 >= 1 && timing->phase_seg2 <= 8);
 	__ASSERT_NO_MSG(timing->prescaler >= 1 && timing->prescaler <= 64);
 
-	k_mutex_lock(&data->mod_lock, K_FOREVER);
-
-	err = can_sja1000_enter_reset_mode(dev);
-	if (err != 0) {
-		goto unlock;
+	if (data->started) {
+		return -EBUSY;
 	}
+
+	k_mutex_lock(&data->mod_lock, K_FOREVER);
 
 	if (timing->sjw == CAN_SJW_NO_CHANGE) {
 		sjw = data->sjw;
@@ -119,15 +127,9 @@ int can_sja1000_set_timing(const struct device *dev, const struct can_timing *ti
 	can_sja1000_write_reg(dev, CAN_SJA1000_BTR0, btr0);
 	can_sja1000_write_reg(dev, CAN_SJA1000_BTR1, btr1);
 
-	err = can_sja1000_leave_reset_mode(dev);
-	if (err != 0) {
-		goto unlock;
-	}
-
-unlock:
 	k_mutex_unlock(&data->mod_lock);
 
-	return err;
+	return 0;
 }
 
 int can_sja1000_get_capabilities(const struct device *dev, can_mode_t *cap)
@@ -140,18 +142,14 @@ int can_sja1000_get_capabilities(const struct device *dev, can_mode_t *cap)
 	return 0;
 }
 
-int can_sja1000_set_mode(const struct device *dev, can_mode_t mode)
+int can_sja1000_start(const struct device *dev)
 {
 	const struct can_sja1000_config *config = dev->config;
 	struct can_sja1000_data *data = dev->data;
-	uint8_t btr1;
-	uint8_t mod;
 	int err;
 
-	if ((mode & ~(CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY | CAN_MODE_ONE_SHOT |
-		      CAN_MODE_3_SAMPLES)) != 0) {
-		LOG_ERR("unsupported mode: 0x%08x", mode);
-		return -ENOTSUP;
+	if (data->started) {
+		return -EALREADY;
 	}
 
 	if (config->phy != NULL) {
@@ -162,12 +160,69 @@ int can_sja1000_set_mode(const struct device *dev, can_mode_t mode)
 		}
 	}
 
-	k_mutex_lock(&data->mod_lock, K_FOREVER);
+	can_sja1000_clear_errors(dev);
+
+	err = can_sja1000_leave_reset_mode(dev);
+	if (err != 0) {
+		if (config->phy != NULL) {
+			/* Attempt to disable the CAN transceiver in case of error */
+			(void)can_transceiver_disable(config->phy);
+		}
+
+		return err;
+	}
+
+	data->started = true;
+
+	return 0;
+}
+
+int can_sja1000_stop(const struct device *dev)
+{
+	const struct can_sja1000_config *config = dev->config;
+	struct can_sja1000_data *data = dev->data;
+	int err;
+
+	if (!data->started) {
+		return -EALREADY;
+	}
 
 	err = can_sja1000_enter_reset_mode(dev);
 	if (err != 0) {
-		goto unlock;
+		return err;
 	}
+
+	if (config->phy != NULL) {
+		err = can_transceiver_disable(config->phy);
+		if (err != 0) {
+			LOG_ERR("failed to disable CAN transceiver (err %d)", err);
+			return err;
+		}
+	}
+
+	data->started = false;
+
+	return 0;
+}
+
+int can_sja1000_set_mode(const struct device *dev, can_mode_t mode)
+{
+	const struct can_sja1000_config *config = dev->config;
+	struct can_sja1000_data *data = dev->data;
+	uint8_t btr1;
+	uint8_t mod;
+
+	if ((mode & ~(CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY | CAN_MODE_ONE_SHOT |
+		      CAN_MODE_3_SAMPLES)) != 0) {
+		LOG_ERR("unsupported mode: 0x%08x", mode);
+		return -ENOTSUP;
+	}
+
+	if (data->started) {
+		return -EBUSY;
+	}
+
+	k_mutex_lock(&data->mod_lock, K_FOREVER);
 
 	mod = can_sja1000_read_reg(dev, CAN_SJA1000_MOD);
 	mod |= CAN_SJA1000_MOD_AFM;
@@ -195,16 +250,11 @@ int can_sja1000_set_mode(const struct device *dev, can_mode_t mode)
 	can_sja1000_write_reg(dev, CAN_SJA1000_MOD, mod);
 	can_sja1000_write_reg(dev, CAN_SJA1000_BTR1, btr1);
 
-	err = can_sja1000_leave_reset_mode(dev);
-	if (err != 0) {
-		goto unlock;
-	}
-
 	data->mode = mode;
-unlock:
+
 	k_mutex_unlock(&data->mod_lock);
 
-	return err;
+	return 0;
 }
 
 static void can_sja1000_read_frame(const struct device *dev, struct can_frame *frame)
@@ -311,6 +361,10 @@ int can_sja1000_send(const struct device *dev, const struct can_frame *frame, k_
 		return -EINVAL;
 	}
 
+	if (!data->started) {
+		return -ENETDOWN;
+	}
+
 	if (data->state == CAN_STATE_BUS_OFF) {
 		LOG_DBG("transmit failed, bus-off");
 		return -ENETUNREACH;
@@ -398,6 +452,10 @@ int can_sja1000_recover(const struct device *dev, k_timeout_t timeout)
 	uint8_t sr;
 	int err;
 
+	if (!data->started) {
+		return -ENETDOWN;
+	}
+
 	sr = can_sja1000_read_reg(dev, CAN_SJA1000_SR);
 	if ((sr & CAN_SJA1000_SR_BS) == 0) {
 		return 0;
@@ -439,7 +497,11 @@ int can_sja1000_get_state(const struct device *dev, enum can_state *state,
 	struct can_sja1000_data *data = dev->data;
 
 	if (state != NULL) {
-		*state = data->state;
+		if (!data->started) {
+			*state = CAN_STATE_STOPPED;
+		} else {
+			*state = data->state;
+		}
 	}
 
 	if (err_cnt != NULL) {
@@ -546,11 +608,8 @@ static void can_sja1000_handle_error_warning_irq(const struct device *dev)
 		data->state = CAN_STATE_BUS_OFF;
 		can_sja1000_tx_done(dev, -ENETUNREACH);
 #ifdef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
-		/* Recover bus now unless interrupted in the middle of a MOD register change. */
-		err = k_mutex_lock(&data->mod_lock, K_NO_WAIT);
-		if (err == 0) {
+		if (data->started) {
 			(void)can_sja1000_leave_reset_mode(dev);
-			k_mutex_unlock(&data->mod_lock);
 		}
 #endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 	} else if ((sr & CAN_SJA1000_SR_ES) != 0) {
@@ -683,17 +742,13 @@ int can_sja1000_init(const struct device *dev)
 	/* Set output control */
 	can_sja1000_write_reg(dev, CAN_SJA1000_OCR, config->ocr);
 
-	/* Clear error counters */
-	can_sja1000_write_reg(dev, CAN_SJA1000_RXERR, 0);
-	can_sja1000_write_reg(dev, CAN_SJA1000_TXERR, 0);
-
-	/* Clear error capture */
-	(void)can_sja1000_read_reg(dev, CAN_SJA1000_ECC);
+	/* Clear error counters and error capture */
+	can_sja1000_clear_errors(dev);
 
 	/* Set error warning limit */
 	can_sja1000_write_reg(dev, CAN_SJA1000_EWLR, 96);
 
-	/* Enter normal mode */
+	/* Set normal mode */
 	data->mode = CAN_MODE_NORMAL;
 	err = can_sja1000_set_mode(dev, CAN_MODE_NORMAL);
 	if (err != 0) {

--- a/drivers/can/can_sja1000.h
+++ b/drivers/can/can_sja1000.h
@@ -100,6 +100,7 @@ struct can_sja1000_data {
 	ATOMIC_DEFINE(rx_allocs, CONFIG_CAN_MAX_FILTER);
 	struct can_sja1000_rx_filter filters[CONFIG_CAN_MAX_FILTER];
 	struct k_mutex mod_lock;
+	bool started;
 	can_mode_t mode;
 	enum can_state state;
 	can_state_change_callback_t state_change_cb;
@@ -121,6 +122,10 @@ struct can_sja1000_data {
 int can_sja1000_set_timing(const struct device *dev, const struct can_timing *timing);
 
 int can_sja1000_get_capabilities(const struct device *dev, can_mode_t *cap);
+
+int can_sja1000_start(const struct device *dev);
+
+int can_sja1000_stop(const struct device *dev);
 
 int can_sja1000_set_mode(const struct device *dev, can_mode_t mode);
 

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -42,6 +42,7 @@ struct can_stm32_data {
 	can_state_change_callback_t state_change_cb;
 	void *state_change_cb_data;
 	enum can_state state;
+	bool started;
 };
 
 struct can_stm32_config {

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -121,6 +121,8 @@ static int can_stm32fd_init(const struct device *dev)
 
 static const struct can_driver_api can_stm32fd_driver_api = {
 	.get_capabilities = can_mcan_get_capabilities,
+	.start = can_mcan_start,
+	.stop = can_mcan_stop,
 	.set_mode = can_mcan_set_mode,
 	.set_timing = can_mcan_set_timing,
 	.send = can_mcan_send,

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -101,6 +101,8 @@ static int can_stm32h7_init(const struct device *dev)
 
 static const struct can_driver_api can_stm32h7_driver_api = {
 	.get_capabilities = can_mcan_get_capabilities,
+	.start = can_mcan_start,
+	.stop = can_mcan_stop,
 	.set_mode = can_mcan_set_mode,
 	.set_timing = can_mcan_set_timing,
 	.send = can_mcan_send,

--- a/include/zephyr/drivers/can/transceiver.h
+++ b/include/zephyr/drivers/can/transceiver.h
@@ -53,8 +53,9 @@ __subsystem struct can_transceiver_driver_api {
  * @note The CAN transceiver is controlled by the CAN controller driver and
  *       should not normally be controlled by the application.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @see can_start()
  *
+ * @param dev Pointer to the device structure for the driver instance.
  * @retval 0 If successful.
  * @retval -EIO General input/output error, failed to enable device.
  */
@@ -74,8 +75,9 @@ static inline int can_transceiver_enable(const struct device *dev)
  * @note The CAN transceiver is controlled by the CAN controller driver and
  *       should not normally be controlled by the application.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @see can_stop()
  *
+ * @param dev Pointer to the device structure for the driver instance.
  * @retval 0 If successful.
  * @retval -EIO General input/output error, failed to disable device.
  */

--- a/samples/drivers/can/counter/src/main.c
+++ b/samples/drivers/can/counter/src/main.c
@@ -117,6 +117,8 @@ char *state_to_str(enum can_state state)
 		return "error-passive";
 	case CAN_STATE_BUS_OFF:
 		return "bus-off";
+	case CAN_STATE_STOPPED:
+		return "stopped";
 	default:
 		return "unknown";
 	}
@@ -225,6 +227,11 @@ void main(void)
 		return;
 	}
 #endif
+	ret = can_start(can_dev);
+	if (ret != 0) {
+		printk("Error starting CAN controller [%d]", ret);
+		return;
+	}
 
 	if (led.port != NULL) {
 		if (!device_is_ready(led.port)) {

--- a/samples/net/sockets/can/src/main.c
+++ b/samples/net/sockets/can/src/main.c
@@ -178,10 +178,6 @@ static int setup_socket(void)
 		return -ENOENT;
 	}
 
-#ifdef CONFIG_SAMPLE_SOCKETCAN_LOOPBACK_MODE
-	can_set_mode(DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus)), CAN_MODE_LOOPBACK);
-#endif
-
 	fd = socket(AF_CAN, SOCK_RAW, CAN_RAW);
 	if (fd < 0) {
 		ret = -errno;
@@ -261,7 +257,23 @@ cleanup:
 
 void main(void)
 {
+	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+	int ret;
 	int fd;
+
+#ifdef CONFIG_SAMPLE_SOCKETCAN_LOOPBACK_MODE
+	ret = can_set_mode(dev, CAN_MODE_LOOPBACK);
+	if (ret != 0) {
+		LOG_ERR("Cannot set CAN loopback mode (%d)", ret);
+		return;
+	}
+#endif
+
+	ret = can_start(dev);
+	if (ret != 0) {
+		LOG_ERR("Cannot start CAN controller (%d)", ret);
+		return;
+	}
 
 	/* Let the device start before doing anything */
 	k_sleep(K_SECONDS(2));

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -1020,6 +1020,9 @@ ZTEST_USER(can_api, test_send_invalid_dlc)
 	zassert_equal(err, -EINVAL, "sent a frame with an invalid DLC");
 }
 
+/**
+ * @brief Test CAN controller bus recovery.
+ */
 ZTEST_USER(can_api, test_recover)
 {
 	int err;
@@ -1033,6 +1036,9 @@ ZTEST_USER(can_api, test_recover)
 	zassert_equal(err, 0, "failed to recover (err %d)", err);
 }
 
+/**
+ * @brief Test retrieving the state of the CAN controller.
+ */
 ZTEST_USER(can_api, test_get_state)
 {
 	struct can_bus_err_cnt err_cnt;
@@ -1052,6 +1058,9 @@ ZTEST_USER(can_api, test_get_state)
 	zassert_equal(err, 0, "failed to get CAN state + error counters (err %d)", err);
 }
 
+/**
+ * @brief Test that CAN RX filters are preserved through CAN controller mode changes.
+ */
 ZTEST_USER(can_api, test_filters_preserved_through_mode_change)
 {
 	struct can_frame frame;
@@ -1080,6 +1089,9 @@ ZTEST_USER(can_api, test_filters_preserved_through_mode_change)
 	can_remove_rx_filter(can_dev, filter_id);
 }
 
+/**
+ * @brief Test that CAN RX filters are preserved through CAN controller bitrate changes.
+ */
 ZTEST_USER(can_api, test_filters_preserved_through_bitrate_change)
 {
 	struct can_frame frame;

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -744,8 +744,14 @@ ZTEST_USER(can_api, test_set_bitrate_too_high)
 	zassert_equal(err, 0, "failed to get max bitrate (err %d)", err);
 	zassert_not_equal(max, 0, "max bitrate is 0");
 
+	err = can_stop(can_dev);
+	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+
 	err = can_set_bitrate(can_dev, max + 1);
 	zassert_equal(err, -ENOTSUP, "too high bitrate accepted");
+
+	err = can_start(can_dev);
+	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
 }
 
 /**
@@ -755,8 +761,14 @@ ZTEST_USER(can_api, test_set_bitrate)
 {
 	int err;
 
+	err = can_stop(can_dev);
+	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+
 	err = can_set_bitrate(can_dev, TEST_BITRATE_1);
 	zassert_equal(err, 0, "failed to set bitrate");
+
+	err = can_start(can_dev);
+	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
 }
 
 /**
@@ -1064,6 +1076,7 @@ ZTEST_USER(can_api, test_get_state)
 ZTEST_USER(can_api, test_filters_preserved_through_mode_change)
 {
 	struct can_frame frame;
+	enum can_state state;
 	int filter_id;
 	int err;
 
@@ -1074,11 +1087,21 @@ ZTEST_USER(can_api, test_filters_preserved_through_mode_change)
 	zassert_equal(err, 0, "receive timeout");
 	assert_frame_equal(&frame, &test_std_frame_1, 0);
 
+	err = can_stop(can_dev);
+	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+
+	err = can_get_state(can_dev, &state, NULL);
+	zassert_equal(err, 0, "failed to get CAN state (err %d)", err);
+	zassert_equal(state, CAN_STATE_STOPPED, "CAN controller not stopped");
+
 	err = can_set_mode(can_dev, CAN_MODE_NORMAL);
 	zassert_equal(err, 0, "failed to set normal mode (err %d)", err);
 
 	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
 	zassert_equal(err, 0, "failed to set loopback-mode (err %d)", err);
+
+	err = can_start(can_dev);
+	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
 
 	send_test_frame(can_dev, &test_std_frame_1);
 
@@ -1095,6 +1118,7 @@ ZTEST_USER(can_api, test_filters_preserved_through_mode_change)
 ZTEST_USER(can_api, test_filters_preserved_through_bitrate_change)
 {
 	struct can_frame frame;
+	enum can_state state;
 	int filter_id;
 	int err;
 
@@ -1105,11 +1129,21 @@ ZTEST_USER(can_api, test_filters_preserved_through_bitrate_change)
 	zassert_equal(err, 0, "receive timeout");
 	assert_frame_equal(&frame, &test_std_frame_1, 0);
 
+	err = can_stop(can_dev);
+	zassert_equal(err, 0, "failed to stop CAN controller (err %d)", err);
+
+	err = can_get_state(can_dev, &state, NULL);
+	zassert_equal(err, 0, "failed to get CAN state (err %d)", err);
+	zassert_equal(state, CAN_STATE_STOPPED, "CAN controller not stopped");
+
 	err = can_set_bitrate(can_dev, TEST_BITRATE_2);
 	zassert_equal(err, 0, "failed to set bitrate");
 
 	err = can_set_bitrate(can_dev, TEST_BITRATE_1);
 	zassert_equal(err, 0, "failed to set bitrate");
+
+	err = can_start(can_dev);
+	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
 
 	send_test_frame(can_dev, &test_std_frame_1);
 
@@ -1134,6 +1168,9 @@ void *can_api_setup(void)
 
 	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
 	zassert_equal(err, 0, "failed to set loopback mode (err %d)", err);
+
+	err = can_start(can_dev);
+	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
 
 	return NULL;
 }

--- a/tests/drivers/can/canfd/src/main.c
+++ b/tests/drivers/can/canfd/src/main.c
@@ -392,6 +392,9 @@ void *canfd_setup(void)
 	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK | CAN_MODE_FD);
 	zassert_equal(err, 0, "failed to set CAN-FD loopback mode (err %d)", err);
 
+	err = can_start(can_dev);
+	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
+
 	return NULL;
 }
 

--- a/tests/drivers/can/canfd/src/main.c
+++ b/tests/drivers/can/canfd/src/main.c
@@ -15,6 +15,16 @@
  * @}
  */
 
+/**
+ * Test bitrates in bits/second.
+ */
+#define TEST_BITRATE 1000000
+
+/**
+ * Test sample points in per mille.
+ */
+#define TEST_SAMPLE_POINT 750
+
 
 /**
  * @brief Test timeouts.
@@ -378,6 +388,36 @@ ZTEST(canfd, test_send_receive_mixed)
 {
 	send_receive(&test_std_filter_1, &test_std_filter_2,
 		     &test_std_frame_fd_1, &test_std_frame_2);
+}
+
+/**
+ * @brief Test setting bitrate is not allowed while started.
+ */
+ZTEST_USER(canfd, test_set_bitrate_data_while_started)
+{
+	int err;
+
+	err = can_set_bitrate_data(can_dev, TEST_BITRATE);
+	zassert_not_equal(err, 0, "changed data bitrate while started");
+	zassert_equal(err, -EBUSY, "wrong error return code (err %d)", err);
+}
+
+/**
+ * @brief Test setting timing is not allowed while started.
+ */
+ZTEST_USER(canfd, test_set_timing_data_while_started)
+{
+	struct can_timing timing;
+	int err;
+
+	timing.sjw = CAN_SJW_NO_CHANGE;
+
+	err = can_calc_timing_data(can_dev, &timing, TEST_BITRATE, TEST_SAMPLE_POINT);
+	zassert_ok(err, "failed to calculate data timing (err %d)", err);
+
+	err = can_set_timing(can_dev, &timing);
+	zassert_not_equal(err, 0, "changed data timing while started");
+	zassert_equal(err, -EBUSY, "wrong error return code (err %d)", err);
 }
 
 void *canfd_setup(void)

--- a/tests/drivers/can/shell/src/fake_can.c
+++ b/tests/drivers/can/shell/src/fake_can.c
@@ -16,6 +16,10 @@
 
 #define DT_DRV_COMPAT test_fake_can
 
+DEFINE_FAKE_VALUE_FUNC(int, fake_can_start, const struct device *);
+
+DEFINE_FAKE_VALUE_FUNC(int, fake_can_stop, const struct device *);
+
 DEFINE_FAKE_VALUE_FUNC(int, fake_can_set_timing, const struct device *, const struct can_timing *);
 
 DEFINE_FAKE_VALUE_FUNC(int, fake_can_set_timing_data, const struct device *,
@@ -49,6 +53,8 @@ static void fake_can_reset_rule_before(const struct ztest_unit_test *test, void 
 	ARG_UNUSED(test);
 	ARG_UNUSED(fixture);
 
+	RESET_FAKE(fake_can_start);
+	RESET_FAKE(fake_can_stop);
 	RESET_FAKE(fake_can_get_capabilities);
 	RESET_FAKE(fake_can_set_mode);
 	RESET_FAKE(fake_can_set_timing);
@@ -84,6 +90,8 @@ static int fake_can_get_max_bitrate(const struct device *dev, uint32_t *max_bitr
 }
 
 static const struct can_driver_api fake_can_driver_api = {
+	.start = fake_can_start,
+	.stop = fake_can_stop,
 	.get_capabilities = fake_can_get_capabilities,
 	.set_mode = fake_can_set_mode,
 	.set_timing = fake_can_set_timing,

--- a/tests/drivers/can/shell/src/fake_can.h
+++ b/tests/drivers/can/shell/src/fake_can.h
@@ -14,6 +14,10 @@
 extern "C" {
 #endif
 
+DECLARE_FAKE_VALUE_FUNC(int, fake_can_start, const struct device *);
+
+DECLARE_FAKE_VALUE_FUNC(int, fake_can_stop, const struct device *);
+
 DECLARE_FAKE_VALUE_FUNC(int, fake_can_set_timing, const struct device *, const struct can_timing *);
 
 DECLARE_FAKE_VALUE_FUNC(int, fake_can_set_timing_data, const struct device *,

--- a/tests/drivers/can/shell/src/main.c
+++ b/tests/drivers/can/shell/src/main.c
@@ -94,6 +94,26 @@ static int can_shell_test_capture_frame(const struct device *dev, const struct c
 	return 0;
 }
 
+ZTEST(can_shell, test_can_start)
+{
+	const struct shell *sh = shell_backend_dummy_get_ptr();
+	int err;
+
+	err = shell_execute_cmd(sh, "can start " FAKE_CAN_NAME);
+	zassert_ok(err, "failed to execute shell command (err %d)", err);
+	zassert_equal(fake_can_start_fake.call_count, 1, "start function not called");
+}
+
+ZTEST(can_shell, test_can_stop)
+{
+	const struct shell *sh = shell_backend_dummy_get_ptr();
+	int err;
+
+	err = shell_execute_cmd(sh, "can stop " FAKE_CAN_NAME);
+	zassert_ok(err, "failed to execute shell command (err %d)", err);
+	zassert_equal(fake_can_stop_fake.call_count, 1, "stop function not called");
+}
+
 ZTEST(can_shell, test_can_show)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();

--- a/tests/subsys/canbus/isotp/conformance/src/main.c
+++ b/tests/subsys/canbus/isotp/conformance/src/main.c
@@ -972,6 +972,9 @@ void *isotp_conformance_setup(void)
 	ret = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
 	zassert_equal(ret, 0, "Failed to set loopback mode [%d]", ret);
 
+	ret = can_start(can_dev);
+	zassert_equal(ret, 0, "Failed to start CAN controller [%d]", ret);
+
 	k_sem_init(&send_compl_sem, 0, 1);
 
 	return NULL;

--- a/tests/subsys/canbus/isotp/implementation/src/main.c
+++ b/tests/subsys/canbus/isotp/implementation/src/main.c
@@ -423,6 +423,9 @@ void *isotp_implementation_setup(void)
 	ret = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
 	zassert_equal(ret, 0, "Configuring loopback mode failed (%d)", ret);
 
+	ret = can_start(can_dev);
+	zassert_equal(ret, 0, "Failed to start CAN controller [%d]", ret);
+
 	return NULL;
 }
 


### PR DESCRIPTION
Up until now, the Zephyr CAN controller drivers set a default bitrate (or timing) specified via devicetree and start the CAN controller in their respective driver initialization functions.
    
This is fine for CAN nodes using only one fixed bitrate, but if the bitrate is set by the user (e.g. via a DIP-switch or other HMI which is very common), the CAN driver will still initialise with the default bitrate/timing at boot and use this until the application has determined the requested bitrate/timing and set it using can_set_bitrate()/can_set_timing().
    
During this period, the CAN node will potentially destroy valid CAN frames on the CAN bus (which is using the soon-to-be-set-by-the-application bitrate) by sending error frames. This causes interruptions to the ongoing CAN bus traffic when a Zephyr-based CAN node connected to the bus is (re-)booted.
    
Instead, require all configuration (setting bitrate, timing, or mode) to take place when the CAN controller is stopped. This maps nicely to entering "reset mode" (called "configuration mode" or "freeze mode" for some CAN controller implementations) when stopping and exiting this mode when starting the CAN controller.
    
Fixes: #45304
