### PR TITLE
logging: allow to select FORMAT_TIMESTAMP for ADSP_MTRACE backend

### DIFF
--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -153,7 +153,7 @@ config LOG_BACKEND_FORMAT_TIMESTAMP
 	bool "Timestamp formatting in the backend"
 	depends on LOG_BACKEND_UART || LOG_BACKEND_NATIVE_POSIX || LOG_BACKEND_RTT \
 	           || LOG_BACKEND_SWO || LOG_BACKEND_XTENSA_SIM || LOG_BACKEND_FS \
-	           || LOG_BACKEND_ADSP || LOG_BACKEND_ADSP_HDA
+	           || LOG_BACKEND_ADSP || LOG_BACKEND_ADSP_HDA || LOG_BACKEND_ADSP_MTRACE
 	default y
 	help
 	  When enabled timestamp is formatted to hh:mm:ss:ms,us.


### PR DESCRIPTION
The CONFIG_LOG_BACKEND_FORMAT_TIMESTAMP cannot be selected unless one of the enumerated backends is selected. Add the ADSP_MTRACE backend to the list, so timestamp formatting can be selected when only this backend is enabled in the build.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>