### PR TITLE
drivers/counter: stm32: Convert configuration from Kconfig to device tree

### DIFF
--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -47,6 +47,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(16)>;
 	status = "okay";
@@ -161,5 +165,7 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };

--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -53,6 +53,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(16)>;
 	status = "okay";
@@ -175,5 +179,7 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };

--- a/boards/arm/96b_neonkey/96b_neonkey.dts
+++ b/boards/arm/96b_neonkey/96b_neonkey.dts
@@ -56,6 +56,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -117,5 +121,7 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };

--- a/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
+++ b/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
@@ -51,6 +51,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(16)>;
 	status = "okay";
@@ -205,5 +209,7 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };

--- a/boards/arm/96b_wistrio/96b_wistrio.dts
+++ b/boards/arm/96b_wistrio/96b_wistrio.dts
@@ -55,6 +55,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -120,6 +124,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
+++ b/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
@@ -35,6 +35,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(12)>;
 	status = "okay";
@@ -98,6 +102,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -71,6 +71,10 @@
 	cpu-power-states = <&stop>;
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -149,6 +153,8 @@ arduino_i2c: &i2c1 {};
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -48,6 +48,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -206,6 +210,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/black_f407ve/black_f407ve.dts
+++ b/boards/arm/black_f407ve/black_f407ve.dts
@@ -57,6 +57,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(8)>;
 	status = "okay";
@@ -104,6 +108,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/black_f407zg_pro/black_f407zg_pro.dts
+++ b/boards/arm/black_f407zg_pro/black_f407zg_pro.dts
@@ -56,6 +56,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(8)>;
 	status = "okay";
@@ -103,6 +107,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/blackpill_f401cc/blackpill_f401cc.dts
+++ b/boards/arm/blackpill_f401cc/blackpill_f401cc.dts
@@ -107,6 +107,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 
@@ -119,6 +121,10 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa1>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&clk_lsi {
 	status = "okay";
 };
 

--- a/boards/arm/blackpill_f401ce/blackpill_f401ce.dts
+++ b/boards/arm/blackpill_f401ce/blackpill_f401ce.dts
@@ -107,6 +107,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 
@@ -119,6 +121,10 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa1>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&clk_lsi {
 	status = "okay";
 };
 

--- a/boards/arm/blackpill_f411ce/blackpill_f411ce.dts
+++ b/boards/arm/blackpill_f411ce/blackpill_f411ce.dts
@@ -108,6 +108,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 
@@ -120,6 +122,10 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa1>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&clk_lsi {
 	status = "okay";
 };
 

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -78,6 +78,10 @@
 	cpu-power-states = <&stop0 &stop1 &stop2>;
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_lse {
 	status = "okay";
 };
@@ -250,6 +254,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
+++ b/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
@@ -167,6 +167,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/mikroe_clicker_2/mikroe_clicker_2.dts
+++ b/boards/arm/mikroe_clicker_2/mikroe_clicker_2.dts
@@ -52,6 +52,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(25)>;
 	status = "okay";
@@ -96,6 +100,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f031k6/nucleo_f031k6.dts
+++ b/boards/arm/nucleo_f031k6/nucleo_f031k6.dts
@@ -40,6 +40,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -101,5 +105,7 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -60,6 +60,10 @@
 	status = "okay";
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &pll {
 	prediv = <1>;
 	mul = <6>;
@@ -118,6 +122,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -76,6 +76,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -138,6 +142,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
+++ b/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
@@ -42,6 +42,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -107,6 +111,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f303k8/nucleo_f303k8.dts
+++ b/boards/arm/nucleo_f303k8/nucleo_f303k8.dts
@@ -40,6 +40,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -97,5 +101,7 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };

--- a/boards/arm/nucleo_f303re/nucleo_f303re.dts
+++ b/boards/arm/nucleo_f303re/nucleo_f303re.dts
@@ -43,6 +43,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -79,6 +83,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -43,6 +43,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -110,6 +114,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -53,6 +53,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -155,6 +159,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f410rb/nucleo_f410rb.dts
+++ b/boards/arm/nucleo_f410rb/nucleo_f410rb.dts
@@ -42,6 +42,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -101,6 +105,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.dts
@@ -42,6 +42,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -111,5 +115,7 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -52,6 +52,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -120,5 +124,7 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -52,6 +52,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -120,5 +124,7 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -55,6 +55,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -139,6 +143,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -43,6 +43,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -109,6 +113,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/arm/nucleo_f446ze/nucleo_f446ze.dts
@@ -53,6 +53,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -158,6 +162,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -62,6 +62,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -142,6 +146,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
@@ -63,6 +63,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -149,6 +153,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -99,6 +99,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -106,6 +106,8 @@ zephyr_udc0: &usb {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
@@ -52,6 +52,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(24)>;
 	status = "okay";
@@ -128,6 +132,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -53,6 +53,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(24)>;
 	status = "okay";
@@ -139,6 +143,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
@@ -62,6 +62,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -108,6 +112,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB4 0x00010000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -60,6 +60,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -101,6 +105,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB4 0x00010000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
@@ -45,6 +45,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -74,6 +78,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB4 0x00010000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
@@ -59,6 +59,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -100,6 +104,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB4 0x00010000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -44,6 +44,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -85,6 +89,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l412rb_p/nucleo_l412rb_p.dts
+++ b/boards/arm/nucleo_l412rb_p/nucleo_l412rb_p.dts
@@ -42,6 +42,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -101,6 +105,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -33,6 +33,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -100,6 +104,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l433rc_p/nucleo_l433rc_p.dts
+++ b/boards/arm/nucleo_l433rc_p/nucleo_l433rc_p.dts
@@ -43,6 +43,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -117,6 +121,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l452re/nucleo_l452re_common.dtsi
+++ b/boards/arm/nucleo_l452re/nucleo_l452re_common.dtsi
@@ -34,6 +34,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -101,6 +105,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -67,6 +67,10 @@
 	status = "okay";
 };
 
+&clk_lse {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -175,6 +179,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
+++ b/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
@@ -62,6 +62,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -154,6 +158,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -66,6 +66,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -172,6 +176,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -89,6 +89,10 @@
 	status = "okay";
 };
 
+&clk_lsi1 {
+	status = "okay";
+};
+
 &clk_hse {
 	status = "okay";
 };
@@ -133,6 +137,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
+++ b/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
@@ -137,6 +137,8 @@ uext_spi: &spi1 {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
+++ b/boards/arm/olimex_stm32_e407/olimex_stm32_e407.dts
@@ -42,6 +42,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(12)>;
 	status = "okay";
@@ -86,6 +90,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/olimex_stm32_h405/olimex_stm32_h405.dts
+++ b/boards/arm/olimex_stm32_h405/olimex_stm32_h405.dts
@@ -43,6 +43,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(8)>;
 	status = "okay";
@@ -73,6 +77,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
@@ -42,6 +42,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(12)>;
 	status = "okay";
@@ -86,6 +90,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
+++ b/boards/arm/olimex_stm32_p405/olimex_stm32_p405.dts
@@ -43,6 +43,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(8)>;
 	status = "okay";
@@ -73,6 +77,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/ronoth_lodev/ronoth_lodev.dts
+++ b/boards/arm/ronoth_lodev/ronoth_lodev.dts
@@ -107,6 +107,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -163,6 +167,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/segger_trb_stm32f407/segger_trb_stm32f407.dts
+++ b/boards/arm/segger_trb_stm32f407/segger_trb_stm32f407.dts
@@ -41,6 +41,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(12)>;
 	status = "okay";
@@ -64,6 +68,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/sensortile_box/sensortile_box.dts
+++ b/boards/arm/sensortile_box/sensortile_box.dts
@@ -51,6 +51,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(16)>;
 	status = "okay";
@@ -174,6 +178,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/steval_fcu001v1/steval_fcu001v1.dts
+++ b/boards/arm/steval_fcu001v1/steval_fcu001v1.dts
@@ -39,6 +39,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(16)>;
 	status = "okay";
@@ -86,6 +90,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32373c_eval/stm32373c_eval.dts
+++ b/boards/arm/stm32373c_eval/stm32373c_eval.dts
@@ -42,6 +42,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(8)>;
 	status = "okay";
@@ -70,6 +74,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -74,6 +74,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -163,6 +167,8 @@ zephyr_udc0: &usb {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32f401_mini/stm32f401_mini.dts
+++ b/boards/arm/stm32f401_mini/stm32f401_mini.dts
@@ -99,6 +99,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 
@@ -111,6 +113,10 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa1>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&clk_lsi {
 	status = "okay";
 };
 

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -78,6 +78,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(8)>;
 	status = "okay";
@@ -144,6 +148,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -73,6 +73,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
@@ -125,6 +129,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -56,6 +56,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(8)>;
 	status = "okay";
@@ -86,6 +90,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
@@ -58,6 +58,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(8)>;
 	status = "okay";
@@ -114,5 +118,7 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };

--- a/boards/arm/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/arm/stm32f4_disco/stm32f4_disco.dts
@@ -65,6 +65,10 @@
 	status = "okay";
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(8)>;
 	status = "okay";
@@ -105,6 +109,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -55,6 +55,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(25)>;
 	status = "okay";
@@ -136,6 +140,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/arm/stm32f7508_dk/stm32f7508_dk.dts
@@ -56,6 +56,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(25)>;
 	status = "okay";
@@ -137,6 +141,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/arm/stm32l476g_disco/stm32l476g_disco.dts
@@ -65,6 +65,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -95,5 +99,7 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -63,6 +63,10 @@
 
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -131,6 +135,8 @@
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/arm/swan_r5/swan_r5.dts
+++ b/boards/arm/swan_r5/swan_r5.dts
@@ -54,6 +54,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };
@@ -161,6 +165,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
 

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -39,6 +39,16 @@ Changes in this release
 Removed APIs in this release
 ============================
 
+* Removed :kconfig:option:`CONFIG_COUNTER_RTC_STM32_LSE_DRIVE*`
+  This should now be configured using the ``driving_capability`` property of
+  LSE clock
+
+* Removed :kconfig:option:`CONFIG_COUNTER_RTC_STM32_LSE_BYPASS`
+  This should now be configured using the new ``lse_bypass`` property of
+  LSE clock
+
+* Removed :kconfig:option:`CONFIG_COUNTER_RTC_STM32_BACKUP_DOMAIN_RESET`
+
 Deprecated in this release
 ==========================
 
@@ -84,6 +94,11 @@ Deprecated in this release
      +---------------------------------------------+---------------------------------------+
 
   NOTE: Only functions are marked as ``__deprecated``, type definitions are not.
+
+* STM32 RTC source clock should now be configured using devicetree.
+  Related Kconfig :kconfig:option:`CONFIG_COUNTER_RTC_STM32_CLOCK_LSI` and
+  :kconfig:option:`CONFIG_COUNTER_RTC_STM32_CLOCK_LSE` options are now
+  deprecated.
 
 Stable API changes in this release
 ==================================
@@ -169,6 +184,8 @@ Drivers and Sensors
 * Clock control
 
 * Counter
+
+  * STM32 RTC based counter should now be configured using device tree.
 
 * Crypto
 
@@ -265,6 +282,10 @@ Devicetree
   * New:
 
     * :dtcompatible:`zephyr,flash-disk`
+
+    * STM32 SoCs:
+
+      * :dtcompatible: `st,stm32-lse-clock`: new ``lse-bypass`` property
 
 Libraries / Subsystems
 **********************

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -616,6 +616,11 @@ static void set_up_fixed_clock_sources(void)
 		LL_RCC_LSE_SetDriveCapability(STM32_LSE_DRIVING << RCC_BDCR_LSEDRV_Pos);
 #endif
 
+		if (IS_ENABLED(STM32_LSE_BYPASS)) {
+			/* Configure LSE bypass */
+			LL_RCC_LSE_EnableBypass();
+		}
+
 		/* Enable LSE Oscillator (32.768 kHz) */
 		LL_RCC_LSE_Enable();
 		while (!LL_RCC_LSE_IsReady()) {

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -602,6 +602,11 @@ static void set_up_fixed_clock_sources(void)
 		/* Configure driving capability */
 		LL_RCC_LSE_SetDriveCapability(STM32_LSE_DRIVING << RCC_BDCR_LSEDRV_Pos);
 
+		if (IS_ENABLED(STM32_LSE_BYPASS)) {
+			/* Configure LSE bypass */
+			LL_RCC_LSE_EnableBypass();
+		}
+
 		/* Enable LSE oscillator */
 		LL_RCC_LSE_Enable();
 		while (LL_RCC_LSE_IsReady() != 1) {

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -628,6 +628,11 @@ static void set_up_fixed_clock_sources(void)
 		/* Configure driving capability */
 		LL_RCC_LSE_SetDriveCapability(STM32_LSE_DRIVING << RCC_BDCR_LSEDRV_Pos);
 
+		if (IS_ENABLED(STM32_LSE_BYPASS)) {
+			/* Configure LSE bypass */
+			LL_RCC_LSE_EnableBypass();
+		}
+
 		/* Enable LSE Oscillator */
 		LL_RCC_LSE_Enable();
 		/* Wait for LSE ready */

--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -33,59 +33,9 @@ config COUNTER_RTC_STM32_CLOCK_LSE
 
 endchoice #COUNTER_RTC_STM32_CLOCK_SRC
 
-if !SOC_SERIES_STM32F4X
-
-choice COUNTER_RTC_STM32_LSE_DRIVE
-	prompt "LSE oscillator drive capability"
-	depends on COUNTER_RTC_STM32_CLOCK_LSE
-
-config COUNTER_RTC_STM32_LSE_DRIVE_LOW
-	bool "Low"
-	help
-	  Xtal mode lower driving capability
-
-config COUNTER_RTC_STM32_LSE_DRIVE_MEDIUMLOW
-	bool "Medium Low"
-	help
-	  Xtal mode medium low driving capability
-
-config COUNTER_RTC_STM32_LSE_DRIVE_MEDIUMHIGH
-	bool "Medium High"
-	help
-	  Xtal mode medium high driving capability
-
-config COUNTER_RTC_STM32_LSE_DRIVE_HIGH
-	bool "High"
-	help
-	  Xtal mode higher driving capability
-
-endchoice
-
-config COUNTER_RTC_STM32_LSE_DRIVE_STRENGTH
-	hex
-	default 0x00000000 if COUNTER_RTC_STM32_LSE_DRIVE_LOW
-	default 0x00000008 if COUNTER_RTC_STM32_LSE_DRIVE_MEDIUMLOW
-	default 0x00000010 if COUNTER_RTC_STM32_LSE_DRIVE_MEDIUMHIGH
-	default 0x00000018 if COUNTER_RTC_STM32_LSE_DRIVE_HIGH
-
-endif # !SOC_SERIES_STM32F4X
-
-config COUNTER_RTC_STM32_LSE_BYPASS
-	bool "LSE oscillator bypass"
-	depends on COUNTER_RTC_STM32_CLOCK_LSE
-	help
-	  Enable LSE bypass
-
-config COUNTER_RTC_STM32_BACKUP_DOMAIN_RESET
-	bool "Do backup domain reset"
-	default y
-	help
-	  Force a backup domain reset on startup
-
 config COUNTER_RTC_STM32_SAVE_VALUE_BETWEEN_RESETS
 	bool "Save rtc time value between resets"
 	default y
-	depends on !COUNTER_RTC_STM32_BACKUP_DOMAIN_RESET
 	help
 	  Do not reset the rtc time and date after each reset.
 

--- a/dts/bindings/clock/st,stm32-lse-clock.yaml
+++ b/dts/bindings/clock/st,stm32-lse-clock.yaml
@@ -20,3 +20,10 @@ properties:
         - 1
         - 2
         - 3
+
+    lse-bypass:
+      type: boolean
+      required: false
+      description: |
+        LSE crystal oscillator bypass
+        Set the property to by-pass the oscillator with an external clock.

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -237,14 +237,17 @@
 #define STM32_LSE_ENABLED	1
 #define STM32_LSE_FREQ		DT_PROP(DT_NODELABEL(clk_lse), clock_frequency)
 #define STM32_LSE_DRIVING	0
+#define STM32_LSE_BYPASS	DT_PROP(DT_NODELABEL(clk_lse), lse_bypass)
 #elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_lse), st_stm32_lse_clock, okay)
 #define STM32_LSE_ENABLED	1
 #define STM32_LSE_FREQ		DT_PROP(DT_NODELABEL(clk_lse), clock_frequency)
 #define STM32_LSE_DRIVING	DT_PROP(DT_NODELABEL(clk_lse), driving_capability)
+#define STM32_LSE_BYPASS	DT_PROP(DT_NODELABEL(clk_lse), lse_bypass)
 #else
 #define STM32_LSE_ENABLED	0
 #define STM32_LSE_FREQ		0
 #define STM32_LSE_DRIVING	0
+#define STM32_LSE_BYPASS	0
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_msi), st_stm32_msi_clock, okay) || \

--- a/include/zephyr/dt-bindings/clock/stm32f0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f0_clock.h
@@ -19,6 +19,7 @@
 /** Fixed clocks  */
 #define STM32_SRC_HSI		0x001
 #define STM32_SRC_LSE		0x002
+#define STM32_SRC_LSI		0x007
 /* #define STM32_SRC_HSI48	0x003 */
 /** System clock */
 #define STM32_SRC_SYSCLK	0x004
@@ -58,6 +59,9 @@
 /** @brief RCC_CFGRx register offset */
 #define CFGR3_REG		0x30
 
+/** @brief RCC_BDCR register offset */
+#define BDCR_REG		0x20
+
 /** @brief Device domain clocks selection helpers */
 /** CFGR3 devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CFGR3_REG)
@@ -67,5 +71,7 @@
 #define ADC_SEL(val)		STM32_CLOCK(val, 1, 8, CFGR3_REG)
 #define USART2_SEL(val)		STM32_CLOCK(val, 3, 16, CFGR3_REG)
 #define USART3_SEL(val)		STM32_CLOCK(val, 3, 18, CFGR3_REG)
+/** BDCR devices */
+#define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f1_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f1_clock.h
@@ -16,4 +16,46 @@
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB1
 
+/** Fixed clocks  */
+#define STM32_SRC_HSI		0x001
+#define STM32_SRC_HSE		0x002
+#define STM32_SRC_LSE		0x003
+#define STM32_SRC_LSI		0x004
+
+/**
+ * @brief STM32 clock configuration bit field.
+ *
+ * - reg   (1/2/3)         [ 0 : 7 ]
+ * - shift (0..31)         [ 8 : 12 ]
+ * - mask  (0x1, 0x3, 0x7) [ 13 : 15 ]
+ * - val   (0..7)          [ 16 : 18 ]
+ *
+ * @param reg RCC_CFGRx register offset
+ * @param shift Position within RCC_CFGRx.
+ * @param mask Mask for the RCC_CFGRx field.
+ * @param val Clock value (0, 1, ... 7).
+ */
+
+#define STM32_CLOCK_REG_MASK    0xFFU
+#define STM32_CLOCK_REG_SHIFT   0U
+#define STM32_CLOCK_SHIFT_MASK  0x1FU
+#define STM32_CLOCK_SHIFT_SHIFT 8U
+#define STM32_CLOCK_MASK_MASK   0x7U
+#define STM32_CLOCK_MASK_SHIFT  13U
+#define STM32_CLOCK_VAL_MASK    0x7U
+#define STM32_CLOCK_VAL_SHIFT   16U
+
+#define STM32_CLOCK(val, mask, shift, reg)					\
+	((((reg) & STM32_CLOCK_REG_MASK) << STM32_CLOCK_REG_SHIFT) |		\
+	 (((shift) & STM32_CLOCK_SHIFT_MASK) << STM32_CLOCK_SHIFT_SHIFT) |	\
+	 (((mask) & STM32_CLOCK_MASK_MASK) << STM32_CLOCK_MASK_SHIFT) |		\
+	 (((val) & STM32_CLOCK_VAL_MASK) << STM32_CLOCK_VAL_SHIFT))
+
+/** @brief RCC_BDCR register offset */
+#define BDCR_REG		0x20
+
+/** @brief Device domain clocks selection helpers */
+/** BDCR devices */
+#define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F1_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f3_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f3_clock.h
@@ -20,6 +20,7 @@
 /** Fixed clocks  */
 #define STM32_SRC_HSI		0x001
 #define STM32_SRC_LSE		0x002
+#define STM32_SRC_LSI		0x007
 /* #define STM32_SRC_HSI48	0x003 */
 /** System clock */
 #define STM32_SRC_SYSCLK	0x004
@@ -59,6 +60,9 @@
 /** @brief RCC_CFGRx register offset */
 #define CFGR3_REG		0x30
 
+/** @brief RCC_BDCR register offset */
+#define BDCR_REG		0x20
+
 /** @brief Device domain clocks selection helpers) */
 /** CFGR3 devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CFGR3_REG)
@@ -77,5 +81,7 @@
 #define USART5_SEL(val)		STM32_CLOCK(val, 3, 22, CFGR3_REG)
 #define TIM2_SEL(val)		STM32_CLOCK(val, 1, 24, CFGR3_REG)
 #define TIM3_4_SEL(val)		STM32_CLOCK(val, 1, 25, CFGR3_REG)
+/** BDCR devices */
+#define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F3_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f4_clock.h
@@ -26,5 +26,44 @@
 #define STM32_SRC_PLL_P	0x001
 #define STM32_SRC_PLL_Q	0x002
 #define STM32_SRC_PLL_R	0x003
+/** Fixed clocks */
+#define STM32_SRC_LSE	0x004
+#define STM32_SRC_LSI	0x005
+
+/**
+ * @brief STM32 clock configuration bit field.
+ *
+ * - reg   (1/2/3)         [ 0 : 7 ]
+ * - shift (0..31)         [ 8 : 12 ]
+ * - mask  (0x1, 0x3, 0x7) [ 13 : 15 ]
+ * - val   (0..7)          [ 16 : 18 ]
+ *
+ * @param reg RCC_CFGRx register offset
+ * @param shift Position within RCC_CFGRx.
+ * @param mask Mask for the RCC_CFGRx field.
+ * @param val Clock value (0, 1, ... 7).
+ */
+
+#define STM32_CLOCK_REG_MASK    0xFFU
+#define STM32_CLOCK_REG_SHIFT   0U
+#define STM32_CLOCK_SHIFT_MASK  0x1FU
+#define STM32_CLOCK_SHIFT_SHIFT 8U
+#define STM32_CLOCK_MASK_MASK   0x7U
+#define STM32_CLOCK_MASK_SHIFT  13U
+#define STM32_CLOCK_VAL_MASK    0x7U
+#define STM32_CLOCK_VAL_SHIFT   16U
+
+#define STM32_CLOCK(val, mask, shift, reg)					\
+	((((reg) & STM32_CLOCK_REG_MASK) << STM32_CLOCK_REG_SHIFT) |		\
+	 (((shift) & STM32_CLOCK_SHIFT_MASK) << STM32_CLOCK_SHIFT_SHIFT) |	\
+	 (((mask) & STM32_CLOCK_MASK_MASK) << STM32_CLOCK_MASK_SHIFT) |		\
+	 (((val) & STM32_CLOCK_VAL_MASK) << STM32_CLOCK_VAL_SHIFT))
+
+/** @brief RCC_BDCR register offset */
+#define BDCR_REG		0x70
+
+/** @brief Device domain clocks selection helpers */
+/** BDCR devices */
+#define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32g0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_clock.h
@@ -65,6 +65,9 @@
 #define CCIPR_REG		0x54
 #define CCIPR2_REG		0x58
 
+/** @brief RCC_BDCR register offset */
+#define BDCR_REG		0x5C
+
 /** @brief Device domain clocks selection helpers */
 /** CCIPR devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CCIPR_REG)
@@ -86,7 +89,8 @@
 #define I2S2_SEL(val)		STM32_CLOCK(val, 3, 2, CCIPR2_REG)
 #define FDCAN_SEL(val)		STM32_CLOCK(val, 3, 8, CCIPR2_REG)
 #define USB_SEL(val)		STM32_CLOCK(val, 3, 12, CCIPR2_REG)
-
+/** BDCR devices */
+#define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
 
 
 

--- a/include/zephyr/dt-bindings/clock/stm32g4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g4_clock.h
@@ -69,6 +69,9 @@
 #define CCIPR_REG		0x88
 #define CCIPR2_REG		0x9C
 
+/** @brief RCC_BDCR register offset */
+#define BDCR_REG		0x90
+
 /** @brief Device domain clocks selection helpers */
 /** CCIPR devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CCIPR_REG)
@@ -90,5 +93,7 @@
 /** CCIPR2 devices */
 #define I2C4_SEL(val)		STM32_CLOCK(val, 3, 0, CCIPR2_REG)
 #define QSPI_SEL(val)		STM32_CLOCK(val, 3, 20, CCIPR2_REG)
+/** BDCR devices */
+#define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32h7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h7_clock.h
@@ -91,6 +91,9 @@
 #define D2CCIP2R_REG		0x54
 #define D3CCIPR_REG		0x58
 
+/** @brief RCC_BDCR register offset */
+#define BDCR_REG		0x70
+
 /** @brief Device domain clocks selection helpers (RM0399.pdf) */
 /** D1CCIPR devices */
 #define FMC_SEL(val)		STM32_CLOCK(val, 3, 0, D1CCIPR_REG)
@@ -126,5 +129,7 @@
 #define SAI4A_SEL(val)		STM32_CLOCK(val, 7, 21, D3CCIPR_REG)
 #define SAI4B_SEL(val)		STM32_CLOCK(val, 7, 24, D3CCIPR_REG)
 #define SPI6_SEL(val)		STM32_CLOCK(val, 7, 28, D3CCIPR_REG)
+/** BDCR devices */
+#define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H7_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l0_clock.h
@@ -59,6 +59,9 @@
 /** @brief RCC_CCIPR register offset */
 #define CCIPR_REG		0x4C
 
+/** @brief RCC_CSR register offset */
+#define CSR_REG		0x50
+
 /** @brief Device domain clocks selection helpers */
 /** CCIPR devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CCIPR_REG)
@@ -68,5 +71,7 @@
 #define I2C3_SEL(val)		STM32_CLOCK(val, 3, 16, CCIPR_REG)
 #define LPTIM1_SEL(val)		STM32_CLOCK(val, 3, 18, CCIPR_REG)
 #define HSI48_SEL(val)		STM32_CLOCK(val, 1, 26, CCIPR_REG)
+/** CSR devices */
+#define RTC_SEL(val)		STM32_CLOCK(val, 3, 16, CSR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l4_clock.h
@@ -68,6 +68,9 @@
 #define CCIPR_REG		0x88
 #define CCIPR2_REG		0x9C
 
+/** @brief RCC_BDCR register offset */
+#define BDCR_REG		0x90
+
 /** @brief Device domain clocks selection helpers */
 /** CCIPR devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CCIPR_REG)
@@ -96,5 +99,7 @@
 #define DSI_SEL(val)		STM32_CLOCK(val, 1, 12, CCIPR2_REG)
 #define SDMMC_SEL(val)		STM32_CLOCK(val, 1, 14, CCIPR2_REG)
 #define OSPI_SEL(val)		STM32_CLOCK(val, 3, 20, CCIPR2_REG)
+/** BDCR devices */
+#define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32u5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u5_clock.h
@@ -79,6 +79,9 @@
 #define CCIPR2_REG		0xE4
 #define CCIPR3_REG		0xE8
 
+/** @brief RCC_BDCR register offset */
+#define BDCR_REG		0xF0
+
 /** @brief Device domain clocks selection helpers */
 /** CCIPR1 devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CCIPR1_REG)
@@ -113,5 +116,7 @@
 #define ADCDAC_SEL(val)		STM32_CLOCK(val, 7, 12, CCIPR3_REG)
 #define DAC1_SEL(val)		STM32_CLOCK(val, 1, 15, CCIPR3_REG)
 #define ADF1_SEL(val)		STM32_CLOCK(val, 7, 16, CCIPR3_REG)
+/** BDCR devices */
+#define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wb_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wb_clock.h
@@ -67,6 +67,9 @@
 /** @brief RCC_CCIPR register offset */
 #define CCIPR_REG		0x88
 
+/** @brief RCC_BDCR register offset */
+#define BDCR_REG		0x90
+
 /** @brief Device domain clocks selection helpers */
 /** CCIPR devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CCIPR_REG)
@@ -79,5 +82,7 @@
 #define CLK48_SEL(val)		STM32_CLOCK(val, 3, 26, CCIPR_REG)
 #define ADC_SEL(val)		STM32_CLOCK(val, 3, 28, CCIPR_REG)
 #define RNG_SEL(val)		STM32_CLOCK(val, 3, 30, CCIPR_REG)
+/** BDCR devices */
+#define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WB_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wl_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wl_clock.h
@@ -66,6 +66,9 @@
 /** @brief RCC_CCIPR register offset */
 #define CCIPR_REG		0x88
 
+/** @brief RCC_BDCR register offset */
+#define BDCR_REG		0x90
+
 /** @brief Device domain clocks selection helpers */
 /** CCIPR devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CCIPR_REG)
@@ -80,5 +83,7 @@
 #define LPTIM3_SEL(val)		STM32_CLOCK(val, 3, 22, CCIPR_REG)
 #define ADC_SEL(val)		STM32_CLOCK(val, 3, 28, CCIPR_REG)
 #define RNG_SEL(val)		STM32_CLOCK(val, 3, 30, CCIPR_REG)
+/** BDCR devices */
+#define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WL_CLOCK_H_ */


### PR DESCRIPTION
Use device tree to configure rtc counter driver instead of Kconfig for:
- RTC source clock selection (thanks to use of dts domain clock)
- LSE drive capability (use lse dts property)
