### PR TITLE
MAINTAINERS: Add mcumgr tests under mcumgr area.

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1318,6 +1318,7 @@ MCU Manager:
     - subsys/mgmt/mcumgr/
     - include/zephyr/mgmt/mcumgr/
     - samples/subsys/mgmt/mcumgr/
+    - tests/subsys/mgmt/mcumgr/
   labels:
     - "area: mcumgr"
 


### PR DESCRIPTION
The tests/subsys/mgmt/mcumgr/ added to mcumgr.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>