### PR TITLE
CODEOWNERS: Add/change onership of mcumgr components

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -617,6 +617,7 @@
 /include/zephyr/logging/                         @nordic-krch
 /include/zephyr/lorawan/lorawan.h                @Mani-Sadhasivam
 /include/zephyr/mgmt/osdp.h                      @sidcha
+/include/zephyr/mgmt/mcumgr/                     @de-nordic
 /include/zephyr/net/                             @rlubos @tbursztyka @pfalcon
 /include/zephyr/net/buf.h                        @jhedberg @tbursztyka @pfalcon @rlubos
 /include/zephyr/net/coap*.h                      @rlubos
@@ -759,8 +760,7 @@ scripts/build/gen_image_info.py           @tejlmand
 /subsys/logging/log_backend_net.c         @nordic-krch @rlubos
 /subsys/lorawan/                          @Mani-Sadhasivam
 /subsys/mgmt/ec_host_cmd/                 @jettr
-/subsys/mgmt/mcumgr/                      @carlescufi @nvlsianpu
-/subsys/mgmt/mcumgr/lib/                  @de-nordic
+/subsys/mgmt/mcumgr/                      @carlescufi @nvlsianpu @de-nordic
 /subsys/mgmt/hawkbit/                     @Navin-Sankar
 /subsys/mgmt/mcumgr/smp_udp.c             @aunsbjerg
 /subsys/mgmt/updatehub/                   @nandojve @otavio
@@ -830,6 +830,7 @@ scripts/build/gen_image_info.py           @tejlmand
 /tests/net/socket/                        @rlubos @tbursztyka @pfalcon
 /tests/subsys/debug/coredump/             @dcpleung
 /tests/subsys/fs/                         @nashif @nvlsianpu @de-nordic
+/tests/subsys/mgmt/mcumgr/                @de-nordic
 /tests/subsys/sd/                         @danieldegrasse
 /tests/subsys/rtio/                       @teburd
 /tests/subsys/settings/                   @nvlsianpu


### PR DESCRIPTION
Add de-nordic as codeowner for:
 include/zephyr/mgmt/mcumgr/
 subsys/mgmt/mcumgr/
 tests/subsus/mgmt/mcumgr/

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>