### PR TITLE
boards: doc: Update NXP boards docs with references to superset boards

### DIFF
--- a/boards/arm/frdm_k22f/doc/index.rst
+++ b/boards/arm/frdm_k22f/doc/index.rst
@@ -57,7 +57,12 @@ For more information about the K22F SoC and FRDM-K22F board:
 Supported Features
 ==================
 
-The frdm_k22f board configuration supports the following hardware features:
+The frdm_k22f board configuration supports the hardware features listed
+below.  For additional features not yet supported, please also refer to the
+:ref:`frdm_k64f`, which is the superset board in NXP's Kinetis K series.
+NXP prioritizes enabling the superset board with NXP's Full Platform Support for
+Zephyr.  Therefore, the frdm_k64f board may have additional features
+already supported, which can also be re-used on this frdm_k22f board:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/frdm_k64f/doc/index.rst
+++ b/boards/arm/frdm_k64f/doc/index.rst
@@ -58,7 +58,11 @@ For more information about the K64F SoC and FRDM-K64F board:
 Supported Features
 ==================
 
-The frdm_k64f board configuration supports the following hardware features:
+NXP considers the FRDM-K64F as the superset board for the Kinetis K
+series of MCUs.  This board is a focus for NXP's Full Platform Support for
+Zephyr, to better enable the entire Kinetis K series.  NXP prioritizes enabling
+this board with new support for Zephyr features.  The frdm_k64f board
+configuration supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/frdm_k82f/doc/index.rst
+++ b/boards/arm/frdm_k82f/doc/index.rst
@@ -58,7 +58,12 @@ For more information about the K82F SoC and FRDM-K82F board:
 Supported Features
 ==================
 
-The frdm_k82f board configuration supports the following hardware features:
+The frdm_k82f board configuration supports the hardware features listed
+below.  For additional features not yet supported, please also refer to the
+:ref:`frdm_k64f`, which is the superset board in NXP's Kinetis K series.
+NXP prioritizes enabling the superset board with NXP's Full Platform Support for
+Zephyr.  Therefore, the frdm_k64f board may have additional features
+already supported, which can also be re-used on this frdm_k82f board:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/lpcxpresso55s06/doc/index.rst
+++ b/boards/arm/lpcxpresso55s06/doc/index.rst
@@ -43,8 +43,12 @@ For more information about the LPC55S06 SoC and LPCXPresso55S06 board, see:
 Supported Features
 ==================
 
-The lpcxpresso55s06 board configuration supports the following
-hardware features:
+The lpcxpresso55s06 board configuration supports the hardware features listed
+below.  For additional features not yet supported, please also refer to the
+:ref:`lpcxpresso55s69` , which is the superset board in NXP's LPC55xx series.
+NXP prioritizes enabling the superset board with NXP's Full Platform Support for
+Zephyr.  Therefore, the lpcxpresso55s69 board may have additional features
+already supported, which can also be re-used on this lpcxpresso55s06 board:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/lpcxpresso55s16/doc/index.rst
+++ b/boards/arm/lpcxpresso55s16/doc/index.rst
@@ -48,8 +48,12 @@ For more information about the LPC55S16 SoC and LPCXPresso55S16 board, see:
 Supported Features
 ==================
 
-The lpcxpresso55s16 board configuration supports the following
-hardware features:
+The lpcxpresso55s16 board configuration supports the hardware features listed
+below.  For additional features not yet supported, please also refer to the
+:ref:`lpcxpresso55s69` , which is the superset board in NXP's LPC55xx series.
+NXP prioritizes enabling the superset board with NXP's Full Platform Support for
+Zephyr.  Therefore, the lpcxpresso55s69 board may have additional features
+already supported, which can also be re-used on this lpcxpresso55s16 board:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/lpcxpresso55s28/doc/index.rst
+++ b/boards/arm/lpcxpresso55s28/doc/index.rst
@@ -48,8 +48,12 @@ For more information about the LPC55S28 SoC and LPCXPresso55S28 board, see:
 Supported Features
 ==================
 
-The lpcxpresso55s28 board configuration supports the following
-hardware features:
+The lpcxpresso55s28 board configuration supports the hardware features listed
+below.  For additional features not yet supported, please also refer to the
+:ref:`lpcxpresso55s69` , which is the superset board in NXP's LPC55xx series.
+NXP prioritizes enabling the superset board with NXP's Full Platform Support for
+Zephyr.  Therefore, the lpcxpresso55s69 board may have additional features
+already supported, which can also be re-used on this lpcxpresso55s28 board:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/lpcxpresso55s36/doc/index.rst
+++ b/boards/arm/lpcxpresso55s36/doc/index.rst
@@ -47,7 +47,13 @@ For more information about the LPC55S36 SoC and LPCXPresso55S36 board, see:
 Supported Features
 ==================
 
-The Zephyr configuration for the LPC55S36 board (lpcxpresso55s36) is as follows:
+NXP considers the LPCXpresso55S36 as a superset board for the LPC55(S)3x
+family of MCUs.  This board is a focus for NXP's Full Platform Support for
+Zephyr, to better enable the entire LPC55(S)3x family.  NXP prioritizes enabling
+this board with new support for Zephyr features.  The lpcxpresso55s36 board
+configuration supports the hardware features below.  Another similar superset
+board is the :ref:`lpcxpresso55s69`, and that board may have additional features
+already supported, which can also be re-used on this lpcxpresso55s36 board:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/lpcxpresso55s69/doc/index.rst
+++ b/boards/arm/lpcxpresso55s69/doc/index.rst
@@ -47,8 +47,11 @@ For more information about the LPC55S69 SoC and LPCXPRESSO55S69 board, see:
 Supported Features
 ==================
 
-The lpcxpresso55s69 board configuration supports the following hardware
-features:
+NXP considers the LPCXpresso55S69 as the superset board for the LPC55xx
+series of MCUs.  This board is a focus for NXP's Full Platform Support for
+Zephyr, to better enable the entire LPC55xx series.  NXP prioritizes enabling
+this board with new support for Zephyr features.  The lpcxpresso55s69 board
+configuration supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/mimxrt1010_evk/doc/index.rst
+++ b/boards/arm/mimxrt1010_evk/doc/index.rst
@@ -54,8 +54,12 @@ these references:
 Supported Features
 ==================
 
-The mimxrt1010_evk board configuration supports the following hardware
-features:
+The mimxrt1010_evk board configuration supports the hardware features listed
+below.  For additional features not yet supported, please also refer to the
+:ref:`mimxrt1064_evk` , which is the superset board in NXP's i.MX RT10xx family.
+NXP prioritizes enabling the superset board with NXP's Full Platform Support for
+Zephyr.  Therefore, the mimxrt1064_evk board may have additional features
+already supported, which can also be re-used on this mimxrt1010_evk board:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/mimxrt1015_evk/doc/index.rst
+++ b/boards/arm/mimxrt1015_evk/doc/index.rst
@@ -54,8 +54,12 @@ these references:
 Supported Features
 ==================
 
-The mimxrt1015_evk board configuration supports the following hardware
-features:
+The mimxrt1015_evk board configuration supports the hardware features listed
+below.  For additional features not yet supported, please also refer to the
+:ref:`mimxrt1064_evk` , which is the superset board in NXP's i.MX RT10xx family.
+NXP prioritizes enabling the superset board with NXP's Full Platform Support for
+Zephyr.  Therefore, the mimxrt1064_evk board may have additional features
+already supported, which can also be re-used on this mimxrt1015_evk board:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/mimxrt1020_evk/doc/index.rst
+++ b/boards/arm/mimxrt1020_evk/doc/index.rst
@@ -62,8 +62,12 @@ these references:
 Supported Features
 ==================
 
-The mimxrt1020_evk board configuration supports the following hardware
-features:
+The mimxrt1020_evk board configuration supports the hardware features listed
+below.  For additional features not yet supported, please also refer to the
+:ref:`mimxrt1064_evk` , which is the superset board in NXP's i.MX RT10xx family.
+NXP prioritizes enabling the superset board with NXP's Full Platform Support for
+Zephyr.  Therefore, the mimxrt1064_evk board may have additional features
+already supported, which can also be re-used on this mimxrt1020_evk board:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/mimxrt1024_evk/doc/index.rst
+++ b/boards/arm/mimxrt1024_evk/doc/index.rst
@@ -67,8 +67,12 @@ these references:
 Supported Features
 ==================
 
-The mimxrt1024_evk board configuration supports the following hardware
-features:
+The mimxrt1024_evk board configuration supports the hardware features listed
+below.  For additional features not yet supported, please also refer to the
+:ref:`mimxrt1064_evk` , which is the superset board in NXP's i.MX RT10xx family.
+NXP prioritizes enabling the superset board with NXP's Full Platform Support for
+Zephyr.  Therefore, the mimxrt1064_evk board may have additional features
+already supported, which can also be re-used on this mimxrt1024_evk board:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/mimxrt1060_evk/doc/index.rst
+++ b/boards/arm/mimxrt1060_evk/doc/index.rst
@@ -83,8 +83,12 @@ these references:
 Supported Features
 ==================
 
-The mimxrt1060_evk board configuration supports the following hardware
-features:
+The mimxrt1060_evk board configuration supports the hardware features listed
+below.  For additional features not yet supported, please also refer to the
+:ref:`mimxrt1064_evk` , which is the superset board in NXP's i.MX RT10xx family.
+NXP prioritizes enabling the superset board with NXP's Full Platform Support for
+Zephyr.  Therefore, the mimxrt1064_evk board may have additional features
+already supported, which can also be re-used on this mimxrt1060_evk board:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/mimxrt1160_evk/doc/index.rst
+++ b/boards/arm/mimxrt1160_evk/doc/index.rst
@@ -81,8 +81,12 @@ these references:
 Supported Features
 ==================
 
-The mimxrt1160_evk board configuration supports the following hardware
-features:
+The mimxrt1160_evk board configuration supports the hardware features listed
+below.  For additional features not yet supported, please also refer to the
+:ref:`mimxrt1170_evk` , which is the superset board in NXP's i.MX RT11xx family.
+NXP prioritizes enabling the superset board with NXP's Full Platform Support for
+Zephyr.  Therefore, the mimxrt1170_evk board may have additional features
+already supported, which can also be re-used on this mimxrt1160_evk board:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/mimxrt1170_evk/doc/index.rst
+++ b/boards/arm/mimxrt1170_evk/doc/index.rst
@@ -83,8 +83,11 @@ these references:
 Supported Features
 ==================
 
-The mimxrt1170_evk board configuration supports the following hardware
-features:
+NXP considers the MIMXRT1170-EVK as the superset board for the i.MX RT11xx
+family of MCUs.  This board is a focus for NXP's Full Platform Support for
+Zephyr, to better enable the entire RT11xx family.  NXP prioritizes enabling
+this board with new support for Zephyr features.  The mimxrt1170_evk board
+configuration supports the following hardware features:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/mimxrt595_evk/doc/index.rst
+++ b/boards/arm/mimxrt595_evk/doc/index.rst
@@ -56,8 +56,13 @@ these references:
 Supported Features
 ==================
 
-The mimxrt595_evk board configuration supports the following hardware
-features:
+NXP considers the MIMXRT595-EVK as a superset board for the i.MX RT5xx
+family of MCUs.  This board is a focus for NXP's Full Platform Support for
+Zephyr, to better enable the entire RT5xx family.  NXP prioritizes enabling
+this board with new support for Zephyr features.  The mimxrt595_evk board
+configuration supports the hardware features below.  Another very similar
+board is the :ref:`mimxrt685_evk`, and that board may have additional features
+already supported, which can also be re-used on this mimxrt595_evk board:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |

--- a/boards/arm/mimxrt685_evk/doc/index.rst
+++ b/boards/arm/mimxrt685_evk/doc/index.rst
@@ -54,8 +54,13 @@ these references:
 Supported Features
 ==================
 
-The mimxrt685_evk board configuration supports the following hardware
-features:
+NXP considers the MIMXRT685-EVK as a superset board for the i.MX RT6xx
+family of MCUs.  This board is a focus for NXP's Full Platform Support for
+Zephyr, to better enable the entire RT6xx family.  NXP prioritizes enabling
+this board with new support for Zephyr features.  The mimxrt685_evk board
+configuration supports the hardware features below.  Another very similar
+board is the :ref:`mimxrt595_evk`, and that board may have additional features
+already supported, which can also be re-used on this mimxrt685_evk board:
 
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |


### PR DESCRIPTION
Detail which NXP boards are superset boards.  Other boards will link to their closest superset boards.

Signed-off-by: Derek Snell <derek.snell@nxp.com>