### PR TITLE
cmake: Add -gdwarf-4 at link time for gcc

### DIFF
--- a/cmake/linker/ld/gcc/linker_flags.cmake
+++ b/cmake/linker/ld/gcc/linker_flags.cmake
@@ -8,3 +8,7 @@ if (NOT CONFIG_COVERAGE_GCOV)
 endif()
 
 check_set_linker_property(TARGET linker APPEND PROPERTY gprof -pg)
+
+# GCC 11 by default emits DWARF version 5 which cannot be parsed by
+# pyelftools. Can be removed once pyelftools supports v5.
+add_link_options(-gdwarf-4)


### PR DESCRIPTION
Add a linker option for gcc to force dwarf symbols to be version 4.

Fixes #50106
Related to #35707

Signed-off-by: Jeremy Bettis <jbettis@google.com>