### PR TITLE
Revert "manifest: mcuboot update"

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -182,7 +182,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: fec7042dcde6090ac6df197e12be8b90247a3276
+      revision: 21e56a1bd033af263e808940779a1adaf4d5465e
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
This reverts commit 95292e85aafae0cc1b46865df727ad53465cf13e:

It's introducing a CI failure for sample.bootloader.mcuboot on frdm_k64f.

Original PR: https://github.com/zephyrproject-rtos/zephyr/pull/50041