### PR TITLE
Mark RTT as supported by RP2XXX Chip

### DIFF
--- a/soc/arm/rpi_pico/rp2/Kconfig.series
+++ b/soc/arm/rpi_pico/rp2/Kconfig.series
@@ -14,5 +14,6 @@ config SOC_SERIES_RP2XXX
 	select SOC_FAMILY_RPI_PICO
 	select HAS_RPI_PICO
 	select XIP
+	select HAS_SEGGER_RTT
 	help
 	  Enable support for Raspberry Pi RP2 MCU series


### PR DESCRIPTION
RTT is supported by the RP2XXX series of chips, so it should be marked as such.

Based on the other chips, this seemed to be the correct place for this.