### PR TITLE
reel_board: remove the hw_reset which blocks flashing

### DIFF
--- a/boards/arm/reel_board/support/pyocd.yaml
+++ b/boards/arm/reel_board/support/pyocd.yaml
@@ -1,6 +1,4 @@
 # reel_board global options
 
-# Use HW reset option on reel_board
-reset_type: 'hw'
 # Delay for 0.5s after the reset is issued
 reset.post_delay: 0.5


### PR DESCRIPTION
The hw reset type is blocking the flash of reel_board.
It seems removing it can fix the issue.

Signed-off-by: Ming Shao <ming.shao@intel.com>


(Disclaimer: I am not sure if this fix is appropriate. But it does work when I try to flash reel board)

The error I saw is:

> Traceback (most recent call last):
>   File "/home/ming/.local/lib/python3.10/site-packages/pyocd/__main__.py", line 161, in run
>     status = cmd.invoke()
>   File "/home/ming/.local/lib/python3.10/site-packages/pyocd/subcommands/load_cmd.py", line 125, in invoke
>     programmer.program(filename,
>   File "/home/ming/.local/lib/python3.10/site-packages/pyocd/flash/file_programmer.py", line 170, in program
>     self._loader.commit()
>   File "/home/ming/.local/lib/python3.10/site-packages/pyocd/flash/loader.py", line 289, in commit
>     perf = builder.program(chip_erase=chipErase,
>   File "/home/ming/.local/lib/python3.10/site-packages/pyocd/flash/builder.py", line 490, in program
>     sector_erase_count, page_program_time = self._compute_sector_erase_pages_and_weight(fast_verify)
>   File "/home/ming/.local/lib/python3.10/site-packages/pyocd/flash/builder.py", line 666, in _compute_sector_erase_pages_and_weight
>     self._analyze_pages_with_crc32(fast_verify)
>   File "/home/ming/.local/lib/python3.10/site-packages/pyocd/flash/builder.py", line 645, in _analyze_pages_with_crc32
>     self._enable_read_access()
>   File "/home/ming/.local/lib/python3.10/site-packages/pyocd/flash/builder.py", line 259, in _enable_read_access
>     self.flash.init(self.flash.Operation.VERIFY)
>   File "/home/ming/.local/lib/python3.10/site-packages/pyocd/flash/flash.py", line 252, in init
>     result = self._call_function_and_wait(self.flash_algo['pc_init'],
>   File "/home/ming/.local/lib/python3.10/site-packages/pyocd/flash/flash.py", line 653, in _call_function_and_wait
>     self._call_function(pc, r0, r1, r2, r3, init)
>   File "/home/ming/.local/lib/python3.10/site-packages/pyocd/flash/flash.py", line 555, in _call_function
>     self.target.write_core_registers_raw(reg_list, data_list)
>   File "/home/ming/.local/lib/python3.10/site-packages/pyocd/core/soc_target.py", line 235, in write_core_registers_raw
>     self.selected_core_or_raise.write_core_registers_raw(reg_list, data_list)
>   File "/home/ming/.local/lib/python3.10/site-packages/pyocd/coresight/cortex_m.py", line 1175, in write_core_registers_raw
>     self._base_write_core_registers_raw(reg_list, data_list)
>   File "/home/ming/.local/lib/python3.10/site-packages/pyocd/coresight/cortex_m.py", line 1189, in _base_write_core_registers_raw
>     raise exceptions.CoreRegisterAccessError(
> pyocd.core.exceptions.CoreRegisterAccessError: cannot write registers pc, r0, r1, r2, r9, sp, lr because core #0 is not halted
> **FATAL ERROR: command exited with status 1: pyocd flash --config** /home/ming/sources/zephyrproject/zephyr/boards/arm/reel_board/support/pyocd.yaml -e sector -t nrf52840 -f 4000000 /home/ming/sources/zephyrproject/zephyr/bld_reel/zephyr/zephyr.hex
> FAILED: zephyr/cmake/flash/CMakeFiles/flash /home/ming/sources/zephyrproject/zephyr/bld_reel/zephyr/cmake/flash/CMakeFiles/flash


