### PR TITLE
Add serial-wakeup sample for nucleo_wl55jc

### DIFF
--- a/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wl55jc.overlay
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wl55jc.overlay
@@ -1,9 +1,3 @@
-&clk_lsi {
-    /* prefer LSE over LSI */
-    status = "disabled";
-};
-
-
 &clk_lse {
 	status = "okay";
 };

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wl55jc.overlay
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wl55jc.overlay
@@ -1,0 +1,24 @@
+&clk_lsi {
+    /* prefer LSE over LSI */
+    status = "disabled";
+};
+
+
+&clk_lse {
+	status = "okay";
+};
+
+&lpuart1 {
+	pinctrl-1 = <&analog_pa2 &analog_pa3>;
+	pinctrl-names = "default","sleep";
+	
+    /delete-property/ clocks;
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000001>,
+		 <&rcc STM32_SRC_LSE LPUART1_SEL(3)>;
+	
+    wakeup-source;
+	
+    current-speed = <9600>;
+
+    status = "okay";
+};


### PR DESCRIPTION
This simple PR adds a minimum sample for low-power serial wakeup in support of the nucleo_wl55jc.

Example output:

```
*** Booting Zephyr OS build zephyr-v3.1.0-4974-g13935e57e374  ***       

Device is wakeup capable                                                        
Wakeup source enable ok                                                         
Wakeup source enabled                                                           
                                                                                
uart:~$                                                                         
uart:~$ 
```