### PR TITLE
i3c: doc: Make documentation readable

### DIFF
--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -1542,6 +1542,7 @@ static inline int i3c_reg_update_byte(struct i3c_device_desc *target,
  *
  * It looks something like this (with name "testing"):
  *
+ * @code
  * D: I3C msg: testing, addr=56
  * D:    W len=01:
  * D: contents:
@@ -1550,6 +1551,7 @@ static inline int i3c_reg_update_byte(struct i3c_device_desc *target,
  * D: contents:
  * D: 00 01 02 03 04 05 06 07 |........
  * D: 08 09 0a 0b 0c 0d       |......
+ * @endcode
  *
  * @param name Name of this dump, displayed at the top.
  * @param msgs Array of messages to dump.


### PR DESCRIPTION
Use @code .. @endcode blocks to make docs readable.

I commented it on PR also as a small nitpick.