### PR TITLE
rp2040: Added RTT support

### DIFF
--- a/soc/arm/rpi_pico/rp2/Kconfig.soc
+++ b/soc/arm/rpi_pico/rp2/Kconfig.soc
@@ -10,6 +10,7 @@ choice
 
 config SOC_RP2040
 	bool "Raspberry Pi RP2040"
+	select HAS_SEGGER_RTT
 
 endchoice
 


### PR DESCRIPTION
I added flag RTT for RP2040. I tested it - it works for for pico. 
Signed-off-by: Kamil Serwus <kserwus@gmail.com>