### PR TITLE
LoRa: Disconnect inactive pins to save power

### DIFF
--- a/drivers/lora/sx12xx_common.c
+++ b/drivers/lora/sx12xx_common.c
@@ -55,6 +55,11 @@ int __sx12xx_configure_pin(const struct gpio_dt_spec *gpio, gpio_flags_t flags)
 		return err;
 	}
 
+	/* Disconnect inactive pins to save power */
+	if (flags == GPIO_OUTPUT_INACTIVE) {
+		gpio_pin_configure_dt(gpio, GPIO_DISCONNECTED);
+	}
+
 	return 0;
 }
 

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wl55jc.overlay
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wl55jc.overlay
@@ -1,9 +1,3 @@
-&clk_lsi {
-    /* prefer LSE over LSI */
-    status = "disabled";
-};
-
-
 &clk_lse {
 	status = "okay";
 };

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wl55jc.overlay
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wl55jc.overlay
@@ -1,0 +1,24 @@
+&clk_lsi {
+    /* prefer LSE over LSI */
+    status = "disabled";
+};
+
+
+&clk_lse {
+	status = "okay";
+};
+
+&lpuart1 {
+	pinctrl-1 = <&analog_pa2 &analog_pa3>;
+	pinctrl-names = "default","sleep";
+	
+    /delete-property/ clocks;
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000001>,
+		 <&rcc STM32_SRC_LSE LPUART1_SEL(3)>;
+	
+    wakeup-source;
+	
+    current-speed = <9600>;
+
+    status = "okay";
+};


### PR DESCRIPTION
This humble PR saves just shy of 90uA on the nucleo_wl55jc as measured by the x-nucleo-lmp01a. It seeks to disconnect inactive GPIO pins so that the microcontroller can make use of low power management on the bus.

- It has been tested on the nucleo_wl55jc in both LoRa and LoRaWAN environments including Class A and C operations.
- It has been tested on the nrf52840dk (I don't have a PPK) in both LoRa and LoRaWAN environments including Class A and C operations.
- It has been tested on the nucleo_l152re with mb2cas shield in both LoRa and LoRaWAN environments including Class A and C operations.