### PR TITLE
stm32: nucleo_wl55jc: serial wakeup overlay sample

### DIFF
--- a/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wl55jc.overlay
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wl55jc.overlay
@@ -1,0 +1,13 @@
+&clk_lse {
+	status = "okay";
+};
+
+&lpuart1 {
+	pinctrl-1 = <&analog_pa2 &analog_pa3>;
+	pinctrl-names = "default","sleep";
+	/delete-property/ clocks;
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000001>,
+	         <&rcc STM32_SRC_LSE LPUART1_SEL(3)>;
+	wakeup-source;
+	current-speed = <9600>;
+};


### PR DESCRIPTION
This PR adds an overlay sample for the nucleo_wl55jc demonstrating low-power serial wakeup capabilities by setting LSE as the clock domain and reducing speed to 9600bps.

- tested on nucleo_wl55jc
