### PR TITLE
Fix apds9960_config structure to hold a const pointer to the user

### DIFF
--- a/drivers/sensor/apds9960/apds9960.h
+++ b/drivers/sensor/apds9960/apds9960.h
@@ -230,7 +230,7 @@ struct apds9960_data {
 
 #ifdef CONFIG_APDS9960_TRIGGER
 	sensor_trigger_handler_t p_th_handler;
-	struct sensor_trigger p_th_trigger;
+	const struct sensor_trigger *p_th_trigger;
 #else
 	struct k_sem data_sem;
 #endif

--- a/drivers/sensor/apds9960/apds9960_trigger.c
+++ b/drivers/sensor/apds9960/apds9960_trigger.c
@@ -25,7 +25,7 @@ void apds9960_work_cb(struct k_work *work)
 	const struct device *dev = data->dev;
 
 	if (data->p_th_handler != NULL) {
-		data->p_th_handler(dev, &data->p_th_trigger);
+		data->p_th_handler(dev, data->p_th_trigger);
 	}
 
 	apds9960_setup_int(dev->config, true);
@@ -75,6 +75,7 @@ int apds9960_trigger_set(const struct device *dev,
 	case SENSOR_TRIG_THRESHOLD:
 		if (trig->chan == SENSOR_CHAN_PROX) {
 			data->p_th_handler = handler;
+			data->p_th_trigger = trig;
 			if (i2c_reg_update_byte_dt(&config->i2c,
 						   APDS9960_ENABLE_REG,
 						   APDS9960_ENABLE_PIEN,


### PR DESCRIPTION
Fix apds9960_config structure to hold a const pointer to the user
allocated sensor_trigger structure.
This way the right context can be established in the callback function.

Signed-off-by: Michael Kaplan <m.kaplan@evva.com>