### PR TITLE
net: http_client: Check if host-header is already present.

### DIFF
--- a/include/zephyr/net/http_client.h
+++ b/include/zephyr/net/http_client.h
@@ -263,7 +263,8 @@ struct http_request {
 	 * The Content-Type may be specified here or in the next field.
 	 * Depending on your application, the Content-Type may vary, however
 	 * some header fields may remain constant through the application's
-	 * life cycle. This is a NULL terminated list of header fields.
+	 * life cycle. A custom Host header may also be specified here.
+	 * This is a NULL terminated list of header fields.
 	 */
 	const char **header_fields;
 

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -536,7 +536,16 @@ int http_client_req(int sock, struct http_request *req,
 
 	total_sent += ret;
 
-	if (req->port) {
+	bool host_header_present = false;
+
+	for (i = 0; req->header_fields && req->header_fields[i]; i++) {
+		if (strcasecmp(req->header_fields[i], "Host:") == 0) {
+			host_header_present = true;
+			break;
+		}
+	}
+
+	if (!host_header_present && req->port) {
 		ret = http_send_data(sock, send_buf, send_buf_max_len,
 				     &send_buf_pos, "Host", ": ", req->host,
 				     ":", req->port, HTTP_CRLF, NULL);
@@ -546,7 +555,7 @@ int http_client_req(int sock, struct http_request *req,
 		}
 
 		total_sent += ret;
-	} else {
+	} else if (!host_header_present) {
 		ret = http_send_data(sock, send_buf, send_buf_max_len,
 				     &send_buf_pos, "Host", ": ", req->host,
 				     HTTP_CRLF, NULL);


### PR DESCRIPTION
Currently, the HTTP host-header is always being sent at the beginning of a HTTP-request, even if the header is already present. This causes the HTTP-server to error as there is a duplicate header present.  This commit allows you to specify a custom host-header in req->header_fields which overrides the default header.

Signed-off-by: Ivan Herrera Olivares ivan.herreraolivares@uantwerpen.be