### PR TITLE
manifest: mcuboot update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -182,7 +182,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 21e56a1bd033af263e808940779a1adaf4d5465e
+      revision: dbe536a4adf4d55740b758387a7a57f4a1c218d4
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
This update contains the version update which was reverted plus relevant bugfix.
The revert took places here: #50120

Synch up to the mcu-tools/mcuboot SHA:
73d69e9b566daac1a91724aa1237bfc1b9d51fa3

- Switched zephyr port from using FLASH_AREA_ macros to FIXED_PARTITION_ macros
- Made flash_map_backend.h compatible with a C++ compiler
- Enabled watchdog feed by default
- Allowed to get the flash write alignment basing on the zephyr,flash DT chosen node property

- fixed watchdog device typos
- serial recovery: fixed build failure if CONFIG_BOOT_SERIAL_DETECT_PIN
has undefined value 

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>