### PR TITLE
pcie: devicetree: Add helper macros

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -3754,6 +3754,7 @@
 #include <zephyr/devicetree/fixed-partitions.h>
 #include <zephyr/devicetree/zephyr.h>
 #include <zephyr/devicetree/ordinals.h>
+#include <zephyr/devicetree/pcie.h>
 #include <zephyr/devicetree/pinctrl.h>
 #include <zephyr/devicetree/can.h>
 #include <zephyr/devicetree/reset.h>

--- a/include/zephyr/devicetree/pcie.h
+++ b/include/zephyr/devicetree/pcie.h
@@ -1,0 +1,49 @@
+/**
+ * @file
+ * @brief PCIE devicetree macro public API header file.
+ */
+
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DEVICETREE_PCIE_H_
+#define ZEPHYR_INCLUDE_DEVICETREE_PCIE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup devicetree-pcie Devicetree PCIE API
+ * @ingroup devicetree
+ * @{
+ */
+
+/**
+ * @brief Get PCIE BDF for a DT_DRV_COMPAT device
+ *
+ * @param inst DT_DRV_COMPAT instance number
+ * @return instance's PCIE BDF
+ */
+#define DT_INST_PCIE_BDF(inst) DT_INST_REG_ADDR(inst)
+
+/**
+ * @brief Get PCIE ID for a DT_DRV_COMPAT device
+ *
+ * @param inst DT_DRV_COMPAT instance number
+ * @return instance's PCIE ID
+ */
+#define DT_INST_PCIE_ID(inst) DT_INST_REG_SIZE(inst)
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DEVICETREE_PCIE_H_ */


### PR DESCRIPTION
At the moment PCIE BDF is hacked into REG_ADDR and PCIE ID is hacked into REG_SIZE. Add those macros so that the code looks readable.

Fixes: #26109