### PR TITLE
wifi: eswifi: fix random crash due to work->handler set to NULL

### DIFF
--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -397,7 +397,7 @@ static int eswifi_off_put(struct net_context *context)
 	}
 
 	if (--socket->usage <= 0) {
-		memset(socket, 0, sizeof(*socket));
+		socket->context = NULL;
 	}
 done:
 	eswifi_unlock(eswifi);

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -427,7 +427,7 @@ static int eswifi_socket_close(void *obj)
 	}
 
 	if (--socket->usage <= 0) {
-		memset(socket, 0, sizeof(*socket));
+		socket->context = NULL;
 	}
 
 done:


### PR DESCRIPTION
This fixes the random crash on L475 disco iot1 board described here: https://github.com/zephyrproject-rtos/zephyr/issues/49963 
