### PR TITLE
Bluetooth: Mesh: Check pending_buf in bt_mesh_send_cb in friend.c

### DIFF
--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -1147,6 +1147,11 @@ static void buf_send_start(uint16_t duration, int err, void *user_data)
 
 	BT_DBG("err %d", err);
 
+	if (!frnd->pending_buf) {
+		BT_WARN("Attempt of sending to removed friend");
+		return;
+	}
+
 	frnd->pending_buf = 0U;
 
 	/* Friend Offer doesn't follow the re-sending semantics */
@@ -1162,7 +1167,7 @@ static void buf_send_end(int err, void *user_data)
 
 	BT_DBG("err %d", err);
 
-	if (frnd->pending_req) {
+	if (frnd->pending_req || frnd->pending_buf) {
 		BT_WARN("Another request before previous completed sending");
 		return;
 	}


### PR DESCRIPTION
When friend entry is cleared by `friend_clear` after an adv buffer has been sent to that friend in `friend_timeout`, another friend request coming after this may reuse the same entry. It is possible that `friend_timeout` will be scheduled twice: once by the friend request and once by `buf_send_end` of the previously sent buffer. In that case, the code will assert on line friend.c:1234. It is not possible to cancel an adv buffer for the friendship that is to be cleared, therefore, we need to ensure in correctness of the pending_buf value in start and end callbacks.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>