### PR TITLE
tests: hda_log: Increase timeout for testing

### DIFF
--- a/tests/boards/intel_adsp/hda_log/testcase.yaml
+++ b/tests/boards/intel_adsp/hda_log/testcase.yaml
@@ -8,11 +8,14 @@ common:
 tests:
   boards.intel_adsp.hda_log:
     platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20 intel_adsp_cavs25
+    timeout: 120
   boards.intel_adsp.hda_log.printk:
     platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20 intel_adsp_cavs25
+    timeout: 120
     extra_configs:
       - CONFIG_LOG_PRINTK=y
   boards.intel_adsp.hda_log.1cpu:
     platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20 intel_adsp_cavs25
+    timeout: 120
     extra_configs:
       - CONFIG_MP_NUM_CPUS=1


### PR DESCRIPTION
The tests can take a bit of time as they try and work with real world buffer settings and excercise wrapping the ring buffer many times. It's important to do this as the padding and wrapping code may have sharp edges that are better caught in a test.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>