### PR TITLE
net: websockets: Fix websocket_send_msg return code

### DIFF
--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -707,6 +707,11 @@ quit:
 		k_free(data_to_send);
 	}
 
+	/* Do no math with 0 and error codes */
+	if (ret <= 0) {
+		return ret;
+	}
+
 	return ret - hdr_len;
 }
 


### PR DESCRIPTION
When the websocket_prepare_and_send is called from websocket_send_msg, the header length is subtracted to retrieve the transmitted payload length. Make an exclutsion to prevent the return code of
websocket_prepare_and_send being modified in case of 0 or a negative return code.
This avoid confusion with modificated error codes

Signed-off-by: Sjors Hettinga <s.a.hettinga@gmail.com>