### PR TITLE
boards/arm/thingy53_nrf5340: Add mcuboot's gpio aliases

### DIFF
--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -114,6 +114,8 @@
 		magn0 = &bmm150;
 		watchdog0 = &wdt0;
 		accel0 = &adxl362;
+		mcuboot-button0 = &button1;
+		mcuboot-led0 = &blue_led;
 	};
 };
 


### PR DESCRIPTION
Added aliases for the button and LED gpio pin which might be used by the MCUboot.

Aliases are required for MCUboot as we don't have labels anymore for GPIOs.
GPIO is used for instance for entering to the serial recovery mode.

Patch was missed here https://github.com/zephyrproject-rtos/zephyr/pull/44741

fixes #50317