### PR TITLE
cmake: deprecate CLANG_ROOT_DIR

### DIFF
--- a/cmake/modules/FindDeprecated.cmake
+++ b/cmake/modules/FindDeprecated.cmake
@@ -68,6 +68,18 @@ if("CROSS_COMPILE" IN_LIST Deprecated_FIND_COMPONENTS)
   endif()
 endif()
 
+if("CLANG_ROOT_DIR" IN_LIST Deprecated_FIND_COMPONENTS)
+  list(REMOVE_ITEM Deprecated_FIND_COMPONENTS CLANG_ROOT_DIR)
+  # This code was deprecated after Zephyr v3.1.0
+  if(NOT LLVM_TOOLCHAIN_PATH AND
+     (DEFINED ENV{CLANG_ROOT_DIR}))
+      set(LLVM_TOOLCHAIN_PATH "$ENV{CLANG_ROOT_DIR}")
+      message(DEPRECATION  "Setting CLANG_ROOT_DIR in environment is deprecated. "
+                           "Please set LLVM_TOOLCHAIN_PATH to '$ENV{CLANG_ROOT_DIR}' instead'"
+      )
+  endif()
+endif()
+
 if(NOT "${Deprecated_FIND_COMPONENTS}" STREQUAL "")
   message(STATUS "The following deprecated component(s) could not be found: "
                  "${Deprecated_FIND_COMPONENTS}")

--- a/cmake/toolchain/llvm/generic.cmake
+++ b/cmake/toolchain/llvm/generic.cmake
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Todo: deprecate CLANG_ROOT_DIR
-set_ifndef(LLVM_TOOLCHAIN_PATH "$ENV{CLANG_ROOT_DIR}")
+find_package(Deprecated COMPONENTS CLANG_ROOT_DIR)
 zephyr_get(LLVM_TOOLCHAIN_PATH)
 
 if(LLVM_TOOLCHAIN_PATH)


### PR DESCRIPTION
LLVM toolchain was updated to use LLVM_TOOLCHAIN_PATH in #24917. Deprecate the use of `CLANG_ROOT_DIR` and move code to deprecated module to make removal easier later.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>