### PR TITLE
soc: xtensa: tools: do not interfere with IPC in logs-only mode

### DIFF
--- a/soc/xtensa/intel_adsp/tools/cavstool.py
+++ b/soc/xtensa/intel_adsp/tools/cavstool.py
@@ -699,10 +699,11 @@ async def _main(server):
         (last_seq, output) = winstream_read(last_seq)
         if output:
             adsp_log(output, server)
-        if dsp.HIPCIDA & 0x80000000:
-            dsp.HIPCIDA = 1<<31 # must ACK any DONE interrupts that arrive!
-        if dsp.HIPCTDR & 0x80000000:
-            ipc_command(dsp.HIPCTDR & ~0x80000000, dsp.HIPCTDD)
+        if not args.log_only:
+            if dsp.HIPCIDA & 0x80000000:
+                dsp.HIPCIDA = 1<<31 # must ACK any DONE interrupts that arrive!
+            if dsp.HIPCTDR & 0x80000000:
+                ipc_command(dsp.HIPCTDR & ~0x80000000, dsp.HIPCTDD)
 
         if server:
             # Check if the client connection is alive.


### PR DESCRIPTION
The tool has caused some hard to detect failures when used concurrently with the SOF Linux driver to observe logs. This has been rootcaused to the code to handle and send IPC messages that has been active even in logs-only mode. In vast majority of cases, the SOF kernel driver is faster to act and handles the IPC interrupts. But occasionally the cavstool.py timing was just right and it managed to ack a message before Linux driver.

Fix the problem by not handling IPC messages when the tool is run in logs-only mode.

Reported-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>