### PR TITLE
CODEOWNERS: Remove alwa-noric from bluetooth mesh

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -803,6 +803,8 @@ scripts/build/gen_image_info.py           @tejlmand
 /tests/bluetooth/controller/              @cvinayak @thoh-ot @kruithofa @erbr-ot @sjanc @ppryga
 /tests/bluetooth/bsim_bt/                 @alwa-nordic @jhedberg @Vudentz @wopu-ot
 /tests/bluetooth/bsim_bt/bsim_test_audio/ @jhedberg @Vudentz @wopu-ot @Thalley
+/tests/bluetooth/bsim_bt/bsim_test_mesh/  @jhedberg @Vudentz @wopu-ot @PavelVPV
+/tests/bluetooth/mesh_shell/              @jhedberg @Vudentz @sjanc @PavelVPV
 /tests/bluetooth/tester/                  @alwa-nordic @jhedberg @Vudentz @sjanc
 /tests/posix/                             @pfalcon
 /tests/crypto/                            @ceolin


### PR DESCRIPTION
Removes alwa-nordic from the following paths:
/tests/bluetooth/bsim_bt/bsim_test_mesh/
/tests/bluetooth/mesh_shell

This is done by adding new definitions for those paths, inheriting the owners of the previously matching rule, but without alwa-nordic.

Signed-off-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemi.no>