### PR TITLE
manifest: zscilib update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -262,7 +262,7 @@ manifest:
       path: modules/lib/zcbor
     - name: zscilib
       path: modules/lib/zscilib
-      revision: a54986aa98db4082ac56b582843bb5b5435208a6
+      revision: ca070ddabdaf67175a2da901d0bd62e8899371c5
 
   group-filter:
     - -ci


### PR DESCRIPTION
This update introduces some fixes required to build with Zephyr 3.1 and the associated Zephyr SDK update.

It also enables running the zscilib test suite as part of the normal CI build process, referencing the `tests` folder in `module.yml`.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>