### PR TITLE
Bluetooth: controller: fixing missing reset of proc context greedy flag

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -293,6 +293,7 @@ static struct proc_ctx *create_procedure(enum llcp_proc proc, struct llcp_mem_po
 	ctx->proc = proc;
 	ctx->collision = 0U;
 	ctx->done = 0U;
+	ctx->rx_greedy = 0U;
 
 	/* Clear procedure data */
 	memset((void *)&ctx->data, 0, sizeof(ctx->data));


### PR DESCRIPTION
For the encryption procedure exists a flag used to indicate that the procedure expects all PDUs to be delivered to the procedure STM. This flag was not cleared during creation of new procedure. This could lead to unexpected PDUs being passed to local procedure STM

Signed-off-by: Erik Brockhoff <erbr@oticon.com>