### PR TITLE
Fix up SCHED_IPI_SUPPORTED=n bitrot

### DIFF
--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -119,6 +119,14 @@ ZTEST(smp, test_smp_coop_threads)
 {
 	int i, ok = 1;
 
+	if (!IS_ENABLED(CONFIG_SCHED_IPI_SUPPORTED)) {
+		/* The spawned thread enters an infinite loop, so it can't be
+		 * successfully aborted via an IPI.  Just skip in that
+		 * configuration.
+		 */
+		ztest_test_skip();
+	}
+
 	k_tid_t tid = k_thread_create(&t2, t2_stack, T2_STACK_SIZE, t2_fn,
 				      NULL, NULL, NULL,
 				      K_PRIO_COOP(2), 0, K_NO_WAIT);
@@ -546,6 +554,14 @@ ZTEST(smp, test_get_cpu)
 {
 	k_tid_t thread_id;
 
+	if (!IS_ENABLED(CONFIG_SCHED_IPI_SUPPORTED)) {
+		/* The spawned thread enters an infinite loop, so it can't be
+		 * successfully aborted via an IPI.  Just skip in that
+		 * configuration.
+		 */
+		ztest_test_skip();
+	}
+
 	/* get current cpu number */
 	_cpu_id = arch_curr_cpu()->id;
 
@@ -615,6 +631,7 @@ void z_trace_sched_ipi(void)
  *
  * @see arch_sched_ipi()
  */
+#ifdef CONFIG_SCHED_IPI_SUPPORTED
 ZTEST(smp, test_smp_ipi)
 {
 #ifndef CONFIG_TRACE_SCHED_IPI
@@ -640,6 +657,7 @@ ZTEST(smp, test_smp_ipi)
 				sched_ipi_has_called);
 	}
 }
+#endif
 
 void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 {

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -659,7 +659,7 @@ ZTEST(smp, test_smp_ipi)
 }
 #endif
 
-void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
 {
 	static int trigger;
 


### PR DESCRIPTION
The idle loop can't call yield anymore, and the test wasn't prepared for the implications of running without IPIs.  @justinyhuang  please try this.  It works for me on qemu_x86_64 and qemu_riscv64_smp if I apply this patch to force the kconfig off:

```patch
diff --git a/arch/Kconfig b/arch/Kconfig
index a6079eb90e..7d735aff3c 100644
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -112,7 +112,6 @@ config RISCV
        select IRQ_OFFLOAD_NESTED if IRQ_OFFLOAD
        select USE_SWITCH_SUPPORTED
        select USE_SWITCH
-       select SCHED_IPI_SUPPORTED if SMP
        imply XIP
        help
          RISCV architecture
diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
index 7249e04e4b..7cab2d7d41 100644
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -69,7 +69,7 @@ config X86_64
        select 64BIT
        select USE_SWITCH
        select USE_SWITCH_SUPPORTED
-       select SCHED_IPI_SUPPORTED
+       #select SCHED_IPI_SUPPORTED
        select X86_MMU
        select X86_CPU_HAS_MMX
        select X86_CPU_HAS_SSE
```

Longer term it would be nice to add a variant of this test with that kconfig set =n, but unfortunately the current design prevents it.  The scheduler will always use IPIs if it's told their available, and the flag is selected by the arch kconfig, which prevents it from being overriden.