### PR TITLE
sd: enable 4 bit bus width for high speed cards

### DIFF
--- a/subsys/sd/sdmmc.c
+++ b/subsys/sd/sdmmc.c
@@ -950,6 +950,14 @@ static int sdmmc_init_hs(struct sd_card *card)
 		LOG_ERR("Failed to switch card to HS mode");
 		return ret;
 	}
+	if (card->flags & SD_4BITS_WIDTH) {
+		/* Raise bus width to 4 bits */
+		ret = sdmmc_set_bus_width(card, SDHC_BUS_WIDTH4BIT);
+		if (ret) {
+			LOG_ERR("Failed to change card bus width to 4 bits");
+			return ret;
+		}
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Enable 4 bit bus width for high speed cards, so that host and card combinations that cannot use UHS mode will still benefit from the speed increase of using 4 data lines.


Some performance results using a Kingston 2GB SD card that only supports high speed mode (collected on an LPCXpresso55s69):

Without 4 bit bus mode:
| Read | Write |
| ---- | ---- |
| 3504 KiB/s | 2592 KiB/s |

With 4 bit bus mode:
| Read | Write |
| ---- | ---- |
| 9840 KiB/s | 5280 KiB/s |