### PR TITLE
clock: mcux: Use FSL_FEATURE_MCG_FFCLK_DIV to conditionalize

### DIFF
--- a/drivers/clock_control/clock_control_mcux_mcg.c
+++ b/drivers/clock_control/clock_control_mcux_mcg.c
@@ -37,7 +37,7 @@ static int mcux_mcg_get_rate(const struct device *dev,
 	clock_name_t clock_name;
 
 	switch ((uint32_t) sub_system) {
-#ifdef kCLOCK_McgFixedFreqClk
+#if defined(FSL_FEATURE_MCG_FFCLK_DIV) && (FSL_FEATURE_MCG_FFCLK_DIV)
 	case KINETIS_MCG_FIXED_FREQ_CLK:
 		clock_name = kCLOCK_McgFixedFreqClk;
 		break;

--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 5fb81c9d0a2da9cf889587f35990edbe9c6f137d
+      revision: 708c95825b0d5279620935a1356299fff5dfbc6e
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Use the FSL_FEATURE_MCG_FFCLK_DIV define to decide if we should call the api to get Fixed Frequency Clock.

This fixes Issue #49924