### PR TITLE
Fix support for Pi Pico and C11

### DIFF
--- a/modules/hal_rpi_pico/pico/config_autogen.h
+++ b/modules/hal_rpi_pico/pico/config_autogen.h
@@ -22,7 +22,9 @@
  * BUILD_ASSERT is included through toolchain.h.
  */
 #include <zephyr/toolchain.h>
+#if !defined(__cplusplus) && !defined(static_assert)
 #define static_assert(expr, msg...) BUILD_ASSERT((expr), "" msg)
+#endif /* static_assert && __cplusplus__ */
 
 /* Convert uses of asm, which is not supported in c99, to __asm */
 #define asm __asm


### PR DESCRIPTION
Currently if C11 or higher is enabled, many files fail to compile because they include assert.h and config_autogen.h, which define conflicting copies of static_assert. Disable the one in the hal if the other is found.

Closes https://github.com/zephyrproject-rtos/zephyr/issues/54190

Signed-off-by: Thad House <thadhouse1@gmail.com>