### PR TITLE
LoRa Fixes

### DIFF
--- a/drivers/lora/sx12xx_common.c
+++ b/drivers/lora/sx12xx_common.c
@@ -206,7 +206,7 @@ int sx12xx_lora_send(const struct device *dev, uint8_t *data,
 			k_poll(&evt, 1, K_FOREVER);
 		}
 	}
-	return 0;
+	return ret;
 }
 
 int sx12xx_lora_send_async(const struct device *dev, uint8_t *data,


### PR DESCRIPTION
This PR addresses two fairly major issues with the LoRa driver:

1. `lora_send()` wouldn't return an error if the transmit timed out, or another error occurred during the call to [`k_poll()`](https://github.com/zephyrproject-rtos/zephyr/blob/95c218a15020f378a9bdbb8054b5c3cf15affdd2/drivers/lora/sx12xx_common.c#L201)

---

The following patch was removed, see #48765 as mentioned below.

2. Using `lora_recv_async()` was fundamentally flawed, as the payload buffer was zero'd before being passed to the callback function - I don't know how this would have ever worked (unless `loramack-node` introduced the `memset()` at some point).
    - [`Radio.Rx()`](https://github.com/zephyrproject-rtos/zephyr/blob/878edeb6ff190a713910a0e5cb9022704c5934a3/drivers/lora/sx12xx_common.c#L107)
    - [`.Rx = SX127xSetRx`](https://github.com/zephyrproject-rtos/zephyr/blob/878edeb6ff190a713910a0e5cb9022704c5934a3/drivers/lora/sx127x.c#L539)
    - [`#define SX127xSetRx SX1276SetRx`](https://github.com/zephyrproject-rtos/zephyr/blob/878edeb6ff190a713910a0e5cb9022704c5934a3/drivers/lora/sx127x.c#L84)
    - [`void SX1276SetRx(...)`](https://github.com/zephyrproject-rtos/loramac-node/blob/zephyr/src/radio/sx1276/sx1276.c#L898)
    - [`memset(RxTxBuffer, 0, ...)`](https://github.com/zephyrproject-rtos/loramac-node/blob/zephyr/src/radio/sx1276/sx1276.c#L1033)