### PR TITLE
Bluetooth: Controller: Fix compile error BT_CTLR_JIT_SCHEDULING enabled

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1375,8 +1375,12 @@ static void isr_done(void *param)
 #endif /* CONFIG_BT_CTLR_ADV_INDICATION */
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT) || defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
 	/* If no auxiliary PDUs scheduled, generate primary radio event done */
-	if (!lll->aux) {
+	if (!lll->aux)
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
+
+	{
 		struct event_done_extra *extra;
 
 		extra = ull_done_extra_type_set(EVENT_DONE_EXTRA_TYPE_ADV);


### PR DESCRIPTION
Fix compile error when BT_CTLR_JIT_SCHEDULING is enabled but BT_CTLR_ADV_EXT is disabled.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>