### PR TITLE
SPI supports real usage

### DIFF
--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33-pinctrl.dtsi
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33-pinctrl.dtsi
@@ -49,6 +49,18 @@
 		};
 	};
 
+	pinmux_flexcomm5_spi: pinmux_flexcomm5_spi {
+		group0 {
+			pinmux = <FC5_SCK_PIO1_3>,
+					<FC5_TXD_SCL_MISO_WS_PIO1_4>,
+					<FC5_RXD_SDA_MOSI_DATA_PIO1_5>,
+					<FC5_CTS_SDA_SSEL0_PIO1_6>;
+			input-enable;
+			slew-rate = "normal";
+			drive-strength = "normal";
+		};
+	};
+
 	pinmux_flexcomm16_spi: pinmux_flexcomm16_spi {
 		group0 {
 			pinmux = <HS_SPI1_SCK_PIO1_3>,

--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -128,6 +128,17 @@ arduino_i2c: &flexcomm4 {
 	};
 };
 
+spi5: &flexcomm5 {
+	compatible = "nxp,lpc-spi";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-0 = <&pinmux_flexcomm5_spi>;
+	pinctrl-names = "default";
+	dmas = <&dma0 10>, <&dma0 11>;
+	dma-names = "rx", "tx";
+	status = "disabled";
+};
+
 hs_spi1: &hs_lspi1 {
 	compatible = "nxp,lpc-spi";
 	pinctrl-0 = <&pinmux_flexcomm16_spi>;

--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -9,7 +9,7 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_IMX_EPIT            counter_imx_epit
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_CTIMER         counter_mcux_ctimer.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_RTC            counter_mcux_rtc.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_LPC_RTC        counter_mcux_lpc_rtc.c)
-zephyr_library_sources_ifdef(CONFIG_RTC_MCUX_OSC32K             counter_mcux_lpc_rtc_1KHz.c)
+zephyr_library_sources_ifdef(CONFIG_RTC_MCUX_OSC32K             counter_mcux_lpc_wakeup_timer.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NRF_TIMER           counter_nrfx_timer.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NRF_RTC             counter_nrfx_rtc.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_RTC_STM32           counter_ll_stm32_rtc.c)

--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -9,6 +9,7 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_IMX_EPIT            counter_imx_epit
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_CTIMER         counter_mcux_ctimer.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_RTC            counter_mcux_rtc.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_LPC_RTC        counter_mcux_lpc_rtc.c)
+zephyr_library_sources_ifdef(CONFIG_RTC_MCUX_OSC32K             counter_mcux_lpc_rtc_1KHz.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NRF_TIMER           counter_nrfx_timer.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NRF_RTC             counter_nrfx_rtc.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_RTC_STM32           counter_ll_stm32_rtc.c)

--- a/drivers/counter/Kconfig.mcux_ctimer
+++ b/drivers/counter/Kconfig.mcux_ctimer
@@ -17,3 +17,19 @@ config COUNTER_MCUX_CTIMER_RESERVE_CHANNEL_FOR_SETTOP
 	help
 	  This reserves a CTimer channel to set the top value. Without
 	  this the set top value can be set only to the max counter value.
+
+if COUNTER_MCUX_CTIMER
+
+config COUNTER_MCUX_CTIMER_CAPTURE
+	bool "MCUX CTIMER Capture function"
+	default n
+	select PINCTRL
+	help
+	  Enable support for MCUX CTIMER Capture
+
+config COUNTER_MCUX_CTIMER_DMA
+	bool "MCUX CTIMER DMA function"
+	default n
+	help
+	  Enable support for MCUX CTIMER DMA
+endif

--- a/drivers/counter/Kconfig.mcux_lpc_rtc
+++ b/drivers/counter/Kconfig.mcux_lpc_rtc
@@ -7,3 +7,25 @@ config COUNTER_MCUX_LPC_RTC
 	depends on DT_HAS_NXP_LPC_RTC_ENABLED
 	help
 	  Enable support for LPC rtc driver.
+
+if COUNTER_MCUX_LPC_RTC
+
+config RTC_MCUX_OSC32K
+	bool "Enable RTC high-resolution/wake-up timer"
+	help
+	  Enables the 32 kHz output of the RTC oscillator (32k_clk). This output is only available if the RTC oscillator is
+	  running.
+
+config RTC_FLEXIO_OUTPUT_ENABLE
+	bool "Enable FLEXIO output low frequency"
+	select RTC_MCUX_OSC32K
+
+if RTC_FLEXIO_OUTPUT_ENABLE
+
+config RTC_FLEXIO_OUTPUT_FREQ
+	int "FLEXIO output frequency"
+	range 4 1000
+	default 60
+endif
+
+endif

--- a/drivers/counter/counter_mcux_ctimer.c
+++ b/drivers/counter/counter_mcux_ctimer.c
@@ -378,8 +378,10 @@ static int mcux_lpc_ctimer_set_dma_cfg(const struct device *dev, uint8_t chan_id
 			dma_blk_cfg->dest_address = counter_dma_cfg->dest_addr + (i * DMA_MAX_TRANS_NUM) * counter_dma_cfg->dest_data_size;
 		}
 
-		dma_blk_cfg->next_block = dma_blk_cfg + 1;
-		dma_blk_cfg = dma_blk_cfg->next_block;
+		if (i != dma_cfg->block_count - 1) {
+			dma_blk_cfg->next_block = dma_blk_cfg + 1;
+			dma_blk_cfg = dma_blk_cfg->next_block;
+		}
 	}
 
 	data->stream[chan_id].counter_dma_callback = counter_dma_cfg->callback;

--- a/drivers/counter/counter_mcux_ctimer.c
+++ b/drivers/counter/counter_mcux_ctimer.c
@@ -5,11 +5,17 @@
  */
 #define DT_DRV_COMPAT nxp_lpc_ctimer
 
-#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/counter/counter_mcux_ctimer.h>
 #include <fsl_ctimer.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <fsl_inputmux.h>
+#if defined(CONFIG_COUNTER_MCUX_CTIMER_CAPTURE)
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/devicetree/pinctrl.h>
+#endif
+
 LOG_MODULE_REGISTER(mcux_ctimer, CONFIG_COUNTER_LOG_LEVEL);
 
 #ifdef CONFIG_COUNTER_MCUX_CTIMER_RESERVE_CHANNEL_FOR_SETTOP
@@ -24,10 +30,27 @@ struct mcux_lpc_ctimer_channel_data {
 	void *alarm_user_data;
 };
 
+#if defined(CONFIG_COUNTER_MCUX_CTIMER_DMA)
+#define NUM_DMA_CHANNELS 2
+struct mcux_lpc_ctimer_dma_stream {
+	const struct device *dma_dev;
+	uint32_t dma_channel; /* stores the channel for dma */
+	struct dma_config dma_cfg;
+	struct dma_block_config dma_blk_cfg[CONFIG_DMA_LINK_QUEUE_SIZE];
+	struct mcux_counter_dma_cfg priv_cfg;
+	counter_dma_callback_t counter_dma_callback;
+	void *counter_dma_user_data;
+	const struct device *timer_dev;
+};
+#endif
+
 struct mcux_lpc_ctimer_data {
 	struct mcux_lpc_ctimer_channel_data channels[NUM_CHANNELS];
 	counter_top_callback_t top_callback;
 	void *top_user_data;
+#if defined(CONFIG_COUNTER_MCUX_CTIMER_DMA)
+	struct mcux_lpc_ctimer_dma_stream stream[NUM_DMA_CHANNELS];
+#endif
 };
 
 struct mcux_lpc_ctimer_config {
@@ -38,7 +61,14 @@ struct mcux_lpc_ctimer_config {
 	ctimer_timer_mode_t mode;
 	ctimer_capture_channel_t input;
 	uint32_t prescale;
+	uint8_t timer_no;
 	void (*irq_config_func)(const struct device *dev);
+
+#if defined(CONFIG_COUNTER_MCUX_CTIMER_CAPTURE)
+	uint8_t cap_pin;;
+	uint8_t cap_edge;
+	const struct pinctrl_dev_config *pincfg;
+#endif
 };
 
 static int mcux_lpc_ctimer_start(const struct device *dev)
@@ -97,13 +127,16 @@ static int mcux_lpc_ctimer_set_alarm(const struct device *dev, uint8_t chan_id,
 	uint32_t ticks = alarm_cfg->ticks;
 	uint32_t current = mcux_lpc_ctimer_read(config->base);
 	uint32_t top = mcux_lpc_ctimer_get_top_value(dev);
+	bool enable_stop = false;
+	bool enable_reset = false;
+	bool enable_interrupt = true;
 
 	if (alarm_cfg->ticks > top) {
 		return -EINVAL;
 	}
 
 	if (data->channels[chan_id].alarm_callback != NULL) {
-		LOG_ERR("channel already in use");
+		LOG_ERR("match channel already in use");
 		return -EBUSY;
 	}
 
@@ -114,15 +147,27 @@ static int mcux_lpc_ctimer_set_alarm(const struct device *dev, uint8_t chan_id,
 		}
 	}
 
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_AUTO_STOP)) {
+		enable_stop = true;
+	}
+
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_AUTO_RESET)) {
+		enable_reset = true;
+	}
+
+	if (alarm_cfg->callback == NULL) {
+		enable_interrupt = false;
+	}
+
 	data->channels[chan_id].alarm_callback = alarm_cfg->callback;
 	data->channels[chan_id].alarm_user_data = alarm_cfg->user_data;
 
 	ctimer_match_config_t match_config = { .matchValue = ticks,
-					       .enableCounterReset = false,
-					       .enableCounterStop = false,
+					       .enableCounterReset = enable_reset,
+					       .enableCounterStop = enable_stop,
 					       .outControl = kCTIMER_Output_NoAction,
 					       .outPinInitState = false,
-					       .enableInterrupt = true };
+					       .enableInterrupt = enable_interrupt };
 
 	CTIMER_SetupMatch(config->base, chan_id, &match_config);
 
@@ -213,6 +258,148 @@ static uint32_t mcux_lpc_ctimer_get_freq(const struct device *dev)
 	return (clk_freq / (config->prescale + 1));
 }
 
+#if defined(CONFIG_COUNTER_MCUX_CTIMER_CAPTURE)
+/* This function is executed in the interrupt context */
+static void mcux_lpc_ctimer_dma_callback(const struct device *dev, void *arg,
+			 uint32_t dma_channel, int status)
+{
+	/* arg directly holds the ctimer device */
+	struct mcux_lpc_ctimer_data *data = arg;
+
+	if (status != 0) {
+		LOG_ERR("DMA callback error with channel %d.", dma_channel);
+	} else {
+		for (uint8_t i = 0; i < NUM_DMA_CHANNELS; i++) {
+			if (dma_channel == data->stream[i].dma_channel) {
+				if (data->stream[i].counter_dma_callback) {
+					data->stream[i].counter_dma_callback(data->stream[i].timer_dev, data->stream[i].counter_dma_user_data,
+							i, status);
+				}
+				break;
+			}
+		}
+	}
+}
+
+static int mcux_lpc_ctimer_set_dma_cfg(const struct device *dev, uint8_t chan_id,
+				     struct counter_dma_cfg *counter_dma_cfg)
+{
+	const struct mcux_lpc_ctimer_config *config = dev->config;
+	struct mcux_lpc_ctimer_data *data = dev->data;
+	bool src_addr_wrap = false;
+	bool dest_addr_wrap = false;
+
+	if (chan_id > NUM_DMA_CHANNELS) {
+		return -EINVAL;
+	}
+	const struct device *dma = data->stream[chan_id].dma_dev;
+	if (dma == NULL) {
+		LOG_ERR("Only match channel 0 ~ 1 support DMA");
+		return -EINVAL;
+	}
+	/* DMA0 input trigger configure
+	 * Note: only support DMA0
+	 */
+	inputmux_connection_t conn = kINPUTMUX_Ctimer0M0ToDma0 +
+						config->timer_no * NUM_DMA_CHANNELS + chan_id;
+	INPUTMUX_AttachSignal(INPUTMUX, data->stream[chan_id].dma_channel, conn);
+
+	inputmux_signal_t signal = kINPUTMUX_Dmac0InputTriggerCtimer0M0Ena + 
+						config->timer_no * NUM_DMA_CHANNELS + chan_id;
+	INPUTMUX_EnableSignal(INPUTMUX, signal, true);
+	// INPUTMUX->DMAC0_ITRIG_ENA0_SET = (1 << 
+	// 			(4 + config->mux_config.timer_no * NUM_DMA_CHANNELS + chan_id));
+
+	/* preprare DMA configuration structure */
+	struct dma_config *dma_cfg = &data->stream[chan_id].dma_cfg;
+	memset(dma_cfg, 0, sizeof(struct dma_config ));
+
+	dma_cfg->channel_direction = counter_dma_cfg->channel_direction;
+	dma_cfg->channel_priority = counter_dma_cfg->channel_priority;
+	dma_cfg->source_data_size = counter_dma_cfg->source_data_size;
+	dma_cfg->dest_data_size = counter_dma_cfg->dest_data_size;
+	dma_cfg->source_burst_length = counter_dma_cfg->source_burst_length;
+	dma_cfg->dest_burst_length = counter_dma_cfg->dest_burst_length;
+	if (counter_dma_cfg->callback) {
+		dma_cfg->dma_callback = mcux_lpc_ctimer_dma_callback;
+		dma_cfg->user_data = (void *)dev->data;
+	}
+	dma_cfg->priv_dma_config = NULL;
+
+	if (counter_dma_cfg->priv_config) {
+		struct mcux_counter_dma_cfg *priv_dma_cfg = &data->stream[chan_id].priv_cfg;
+		struct mcux_counter_dma_cfg *mcux_counter_dma_cfg = (struct mcux_counter_dma_cfg *)counter_dma_cfg->priv_config;
+
+		memcpy(priv_dma_cfg, mcux_counter_dma_cfg, sizeof(struct mcux_counter_dma_cfg));
+
+		dma_cfg->priv_dma_config = priv_dma_cfg;
+
+		src_addr_wrap = (priv_dma_cfg->mcux_dma_cfg.channel_trigger.wrap & DMA_CHANNEL_CFG_SRCBURSTWRAP_MASK) ? true : false;
+		dest_addr_wrap = (priv_dma_cfg->mcux_dma_cfg.channel_trigger.wrap & DMA_CHANNEL_CFG_DSTBURSTWRAP_MASK) ? true : false;
+	}
+
+	// total bytes / dest_data_size
+	uint32_t dest_data_num = counter_dma_cfg->length / counter_dma_cfg->dest_data_size;
+
+	dma_cfg->block_count = (dest_data_num & 0x3FF) ? 
+			((dest_data_num >> 10) + 1) : 
+			(dest_data_num >> 10);
+
+	if (dma_cfg->block_count > CONFIG_DMA_LINK_QUEUE_SIZE) {
+		LOG_ERR("please config DMA_LINK_QUEUE_SIZE as %d",
+				dma_cfg->block_count);
+		return -EINVAL;
+	}
+
+	memset(&data->stream[chan_id].dma_blk_cfg[0], 0, sizeof(struct dma_block_config) * CONFIG_DMA_LINK_QUEUE_SIZE);
+	struct dma_block_config *dma_blk_cfg = &data->stream[chan_id].dma_blk_cfg[0];
+
+	dma_cfg->head_block = dma_blk_cfg;
+	if (dma_cfg->block_count > 1) {
+		dma_blk_cfg->source_gather_en = 1;
+	}
+
+	for (uint8_t i = 0; i < dma_cfg->block_count; i++) {
+		dma_blk_cfg->block_size = ((dest_data_num - i * DMA_MAX_TRANS_NUM) > DMA_MAX_TRANS_NUM) ?
+						counter_dma_cfg->dest_data_size * DMA_MAX_TRANS_NUM :
+						counter_dma_cfg->dest_data_size * (dest_data_num - i * DMA_MAX_TRANS_NUM);
+		dma_blk_cfg->source_addr_adj = counter_dma_cfg->source_addr_adj;
+		dma_blk_cfg->dest_addr_adj = counter_dma_cfg->dest_addr_adj;
+
+		if (counter_dma_cfg->source_addr_adj == DMA_ADDR_ADJ_NO_CHANGE || src_addr_wrap) {
+			dma_blk_cfg->source_address = counter_dma_cfg->src_addr;
+		} else {
+			dma_blk_cfg->source_address = counter_dma_cfg->src_addr + (i * DMA_MAX_TRANS_NUM) * counter_dma_cfg->source_data_size;
+		}
+
+		if (counter_dma_cfg->dest_addr_adj == DMA_ADDR_ADJ_NO_CHANGE || dest_addr_wrap) {
+			dma_blk_cfg->dest_address = counter_dma_cfg->dest_addr;
+		} else {
+			dma_blk_cfg->dest_address = counter_dma_cfg->dest_addr + (i * DMA_MAX_TRANS_NUM) * counter_dma_cfg->dest_data_size;
+		}
+
+		dma_blk_cfg->next_block = dma_blk_cfg + 1;
+		dma_blk_cfg = dma_blk_cfg->next_block;
+	}
+
+	data->stream[chan_id].counter_dma_callback = counter_dma_cfg->callback;
+	data->stream[chan_id].counter_dma_user_data = counter_dma_cfg->user_data;
+	data->stream[chan_id].timer_dev = dev;
+
+	mcux_lpc_ctimer_start(dev);
+	return dma_config(dma, data->stream[chan_id].dma_channel, dma_cfg);
+}
+#endif
+
+static int mcux_lpc_ctimer_reset(const struct device *dev)
+{
+	const struct mcux_lpc_ctimer_config *config = dev->config;
+
+	CTIMER_Reset(config->base);
+
+	return 0;
+}
+
 static void mcux_lpc_ctimer_isr(const struct device *dev)
 {
 	const struct mcux_lpc_ctimer_config *config = dev->config;
@@ -268,7 +455,24 @@ static int mcux_lpc_ctimer_init(const struct device *dev)
 	ctimer_config.input = config->input;
 	ctimer_config.prescale = config->prescale;
 
+	/* clear all interrupt flags */
+	CTIMER_ClearStatusFlags(config->base, 0xFF);
+
 	CTIMER_Init(config->base, &ctimer_config);
+
+#if defined(CONFIG_COUNTER_MCUX_CTIMER_CAPTURE)
+	if (config->pincfg) {
+		int err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+		if (err) {
+			return err;
+		}
+		/* INPUTMUX init in DMA */
+		INPUTMUX->CT32BIT_CAP_SEL[config->timer_no][config->input] = 
+					config->cap_pin;
+		CTIMER_SetupCapture(config->base, config->input, config->cap_edge, false);
+		LOG_DBG("\ntimer %d capture config input %d cap_edge %d\n", config->timer_no, config->input, config->cap_edge);
+	}
+#endif
 
 	config->irq_config_func(dev);
 
@@ -285,9 +489,62 @@ static const struct counter_driver_api mcux_ctimer_driver_api = {
 	.get_pending_int = mcux_lpc_ctimer_get_pending_int,
 	.get_top_value = mcux_lpc_ctimer_get_top_value,
 	.get_freq = mcux_lpc_ctimer_get_freq,
+#if defined(CONFIG_COUNTER_MCUX_CTIMER_DMA)
+	.set_dma_cfg = mcux_lpc_ctimer_set_dma_cfg,
+#endif
+	.reset = mcux_lpc_ctimer_reset,
 };
 
-#define COUNTER_LPC_CTIMER_DEVICE(id)                                                              \
+#define PINCTRL_DEFINE(id)				\
+		COND_CODE_1(DT_INST_NUM_PINCTRL_STATES(id), 		\
+			(PINCTRL_DT_INST_DEFINE(id)),	\
+			())
+
+#define PINCTRL_CONFIG(id)				\
+		COND_CODE_1(DT_INST_NUM_PINCTRL_STATES(id), 		\
+			(PINCTRL_DT_INST_DEV_CONFIG_GET(id)),	\
+			(NULL))
+
+#if defined(CONFIG_COUNTER_MCUX_CTIMER_CAPTURE)
+#define CTIMER_CAPTURE_PINCTRL_DEFINE(id) PINCTRL_DEFINE(id);
+#define CTIMER_CAPTURE_PINCTRL_INIT(id) .pincfg = PINCTRL_CONFIG(id),
+#define CTIMER_CAPTURE_CONFIG_INIT(id) 		\
+		.cap_pin = DT_INST_PROP_OR(id, capture_pin, 0),	\
+		.cap_edge = DT_INST_PROP_OR(id, capture_edge, 1),	\
+		CTIMER_CAPTURE_PINCTRL_INIT(id)			
+#else
+#define CTIMER_CAPTURE_PINCTRL_DEFINE(id)
+#define CTIMER_CAPTURE_PINCTRL_INIT(id)
+#define CTIMER_CAPTURE_CONFIG_INIT(id)
+#endif
+
+#if defined(CONFIG_COUNTER_MCUX_CTIMER_DMA)
+#define DMA_CHANNEL_DATA(id, name)					\
+	{						\
+		.dma_dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(id, name)), \
+		.dma_channel =						\
+			DT_INST_DMAS_CELL_BY_NAME(id, name, channel),		\
+		.dma_cfg = {					\
+				.dma_callback = mcux_lpc_ctimer_dma_callback,	\
+			}								\
+	},
+
+#define DMA_CHANNEL(id, name) 				\
+	COND_CODE_1(DT_INST_DMAS_HAS_NAME(id, name), 	\
+			(DMA_CHANNEL_DATA(id, name)),	\
+			({NULL},))
+
+#define TIMER_DMA_CHANNELS(id)				\
+	.stream = {										\
+		DMA_CHANNEL(id, m0)					\
+		DMA_CHANNEL(id, m1)					\
+	},
+#else
+#define TIMER_DMA_CHANNELS(id)
+#endif
+
+#define COUNTER_LPC_CTIMER_DEVICE(id)                                                          \
+	CTIMER_CAPTURE_PINCTRL_DEFINE(id)														   \
 	static void mcux_lpc_ctimer_irq_config_##id(const struct device *dev);                     \
 	static struct mcux_lpc_ctimer_config mcux_lpc_ctimer_config_##id = { \
 		.info = {						\
@@ -302,9 +559,13 @@ static const struct counter_driver_api mcux_ctimer_driver_api = {
 		.mode = DT_INST_PROP(id, mode),						\
 		.input = DT_INST_PROP(id, input),					\
 		.prescale = DT_INST_PROP(id, prescale),				\
+		.timer_no = DT_INST_PROP(id, timer_no),				\
 		.irq_config_func = mcux_lpc_ctimer_irq_config_##id,	\
+		CTIMER_CAPTURE_CONFIG_INIT(id)						\
 	};                     \
-	static struct mcux_lpc_ctimer_data mcux_lpc_ctimer_data_##id;                              \
+	static struct mcux_lpc_ctimer_data mcux_lpc_ctimer_data_##id = {					\
+		TIMER_DMA_CHANNELS(id)		\
+	};                              \
 	DEVICE_DT_INST_DEFINE(id, &mcux_lpc_ctimer_init, NULL, &mcux_lpc_ctimer_data_##id,         \
 			      &mcux_lpc_ctimer_config_##id, POST_KERNEL,                           \
 			      CONFIG_COUNTER_INIT_PRIORITY, &mcux_ctimer_driver_api);              \

--- a/drivers/counter/counter_mcux_lpc_rtc_1KHz.c
+++ b/drivers/counter/counter_mcux_lpc_rtc_1KHz.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2021, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_lpc_rtc_1khz
+
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/gpio.h>
+
+#ifdef CONFIG_PINCTRL
+#include <zephyr/drivers/pinctrl.h>
+#endif
+
+#include <fsl_rtc.h>
+
+#include <zephyr/logging/log.h>
+
+
+LOG_MODULE_REGISTER(mcux_rtc_1khz, CONFIG_COUNTER_LOG_LEVEL);
+
+#define RTC_1KHZ_INIT_PRIORITY 51
+#if CONFIG_COUNTER_INIT_PRIORITY >= RTC_1KHZ_INIT_PRIORITY
+	#error "rtc init priority config error"
+#endif
+
+#define RTC_WAKEUP_FREQ	(1000)
+
+/**
+ * @brief NXP 1KHz high-resolution/wake-up RTC timer
+ * 
+ * Currently only outputs low frequency clocks for flexio.
+ * Count and interrupts funciton may be added in the future.
+ */
+
+struct mcux_lpc_rtc_data {
+	counter_alarm_callback_t alarm_callback;
+	counter_top_callback_t top_callback;
+	void *alarm_user_data;
+	void *top_user_data;
+};
+
+struct mcux_lpc_rtc_config {
+	struct counter_config_info info;
+	RTC_Type *base;
+
+#if defined(CONFIG_RTC_MCUX_OSC32K)
+	const struct device *clock_dev;				/* used for enable 32K RTC clock */
+	clock_control_subsys_t clock_subsys;		/* fixed value: MCUX_OSC32K_CLK */
+#endif
+
+#if defined(CONFIG_RTC_FLEXIO_OUTPUT_ENABLE)
+	uint16_t output_freq;						/* the output low frequency of flexio */
+#endif
+
+#ifdef CONFIG_PINCTRL
+	const struct pinctrl_dev_config *pincfg;
+#endif
+};
+
+static int mcux_lpc_rtc_start(const struct device *dev)
+{
+	const struct counter_config_info *info = dev->config;
+	const struct mcux_lpc_rtc_config *config =
+		CONTAINER_OF(info, struct mcux_lpc_rtc_config, info);
+
+	RTC_EnableWakeupTimer(config->base, true);
+
+	/* main rtc timer should be running, otherwise wakeup timer is inactive */
+	if (!(config->base->CTRL & RTC_CTRL_RTC_EN_MASK)) {
+		RTC_StartTimer(config->base);
+	}
+
+#if defined(CONFIG_RTC_MCUX_OSC32K)
+	/* Enables the 32 kHz output of the RTC oscillator. 
+	 * Otherwise there is no clock to the wakeup timer
+	 */
+	clock_control_on(config->clock_dev, config->clock_subsys);
+#endif
+
+	return 0;
+}
+
+static int mcux_lpc_rtc_stop(const struct device *dev)
+{
+	const struct counter_config_info *info = dev->config;
+	const struct mcux_lpc_rtc_config *config =
+		CONTAINER_OF(info, struct mcux_lpc_rtc_config, info);
+
+	RTC_EnableWakeupTimer(config->base, false);
+
+	/* disable the 32 kHz output of the RTC oscillator. There is no clock to the wakeup timer */
+	clock_control_off(config->clock_dev, config->clock_subsys);
+
+	return 0;
+}
+
+static int mcux_lpc_rtc_init(const struct device *dev)
+{
+	const struct counter_config_info *info = dev->config;
+	const struct mcux_lpc_rtc_config *config =
+		CONTAINER_OF(info, struct mcux_lpc_rtc_config, info);
+
+	/* RTC has been initialized in 1Hz main RTC timer */
+
+	/* Support output 32KHZ_CLKOUT / CLKOUT / LOW_FREQ_CLKOUT / LOW_FREQ_CLKOUT_N */
+#ifdef CONFIG_PINCTRL
+	int err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+	if (err) {
+		return err;
+	}
+#endif
+
+#if defined(CONFIG_RTC_MCUX_OSC32K)
+	/* Enables the 32 kHz output of the RTC oscillator.
+	 * Otherwise there is no clock to the wakeup timer
+	 */
+	clock_control_on(config->clock_dev, config->clock_subsys);
+#endif
+
+#if defined(CONFIG_RTC_FLEXIO_OUTPUT_ENABLE)
+	/* If it is flexio low frequency output, config low frequency clock divide */
+	uint8_t divide = (config->info.freq % config->output_freq) ? ((config->info.freq / config->output_freq) + 1) :
+					(config->info.freq / config->output_freq);
+
+	clock_control_configure(config->clock_dev, config->clock_subsys, &divide);
+#endif
+
+	/* When warm reset, enable bit is not cleared. So disable 1kHz timer first! */
+	mcux_lpc_rtc_stop(dev);
+
+	return 0;
+}
+
+static const struct counter_driver_api mcux_rtc_driver_api = {
+	.start = mcux_lpc_rtc_start,
+	.stop = mcux_lpc_rtc_stop,
+	.get_value = NULL,
+	.set_alarm = NULL,
+	.cancel_alarm = NULL,
+	.set_top_value = NULL,
+	.get_pending_int = NULL,
+	.get_top_value = NULL,
+};
+
+
+/* low freq output pin config */
+#ifdef CONFIG_PINCTRL
+#define RTC_PINCTRL_DEFINE(id) PINCTRL_DT_INST_DEFINE(id);
+#define RTC_PINCTRL_INIT(id) .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),
+#else
+#define RTC_PINCTRL_DEFINE(id)
+#define RTC_PINCTRL_INIT(id)
+#endif
+
+
+#if defined(CONFIG_RTC_MCUX_OSC32K)
+	#define RTC_CLOCK_CONFIG(id) 											\
+			.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(id)),			\
+			.clock_subsys =													\
+					(clock_control_subsys_t)DT_INST_CLOCKS_CELL(id, name),
+#else
+	#define RTC_CLOCK_CONFIG(id) 
+#endif
+
+
+#if defined(CONFIG_RTC_FLEXIO_OUTPUT_ENABLE)
+	#define RTC_FLEXIO_LOW_FREQ_CONFIG		\
+			.output_freq = CONFIG_RTC_FLEXIO_OUTPUT_FREQ,
+#else
+	#define RTC_FLEXIO_LOW_FREQ_CONFIG
+#endif
+
+static struct mcux_lpc_rtc_data mcux_lpc_rtc_data;
+
+#define COUNTER_LPC_RTC_DEVICE(id)										\
+	RTC_PINCTRL_DEFINE(id)												\
+	static const struct mcux_lpc_rtc_config mcux_lpc_rtc_config##id = { \
+		.base = (RTC_Type *)DT_REG_ADDR(DT_PARENT(DT_DRV_INST(id))),						\
+		.info = {														\
+			.max_top_value = UINT16_MAX,								\
+			.freq = RTC_WAKEUP_FREQ,									\
+			.flags = COUNTER_CONFIG_INFO_COUNT_UP,						\
+			.channels = 1,												\
+		},																\
+		RTC_CLOCK_CONFIG(id)											\
+		RTC_FLEXIO_LOW_FREQ_CONFIG										\
+		RTC_PINCTRL_INIT(id)											\
+	};																	\
+	DEVICE_DT_INST_DEFINE(id, mcux_lpc_rtc_init,						\
+			NULL, &mcux_lpc_rtc_data, &mcux_lpc_rtc_config##id,			\
+			POST_KERNEL, RTC_1KHZ_INIT_PRIORITY,						\
+			&mcux_rtc_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(COUNTER_LPC_RTC_DEVICE)

--- a/drivers/counter/counter_mcux_lpc_wakeup_timer.c
+++ b/drivers/counter/counter_mcux_lpc_wakeup_timer.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT nxp_lpc_rtc_1khz
+#define DT_DRV_COMPAT nxp_lpc_wakeup_timer
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/clock_control.h>
@@ -19,7 +19,7 @@
 #include <zephyr/logging/log.h>
 
 
-LOG_MODULE_REGISTER(mcux_rtc_1khz, CONFIG_COUNTER_LOG_LEVEL);
+LOG_MODULE_REGISTER(mcux_wakeup_timer, CONFIG_COUNTER_LOG_LEVEL);
 
 #define RTC_1KHZ_INIT_PRIORITY 51
 #if CONFIG_COUNTER_INIT_PRIORITY >= RTC_1KHZ_INIT_PRIORITY
@@ -35,14 +35,14 @@ LOG_MODULE_REGISTER(mcux_rtc_1khz, CONFIG_COUNTER_LOG_LEVEL);
  * Count and interrupts funciton may be added in the future.
  */
 
-struct mcux_lpc_rtc_data {
+struct mcux_lpc_wakeup_timer_data {
 	counter_alarm_callback_t alarm_callback;
 	counter_top_callback_t top_callback;
 	void *alarm_user_data;
 	void *top_user_data;
 };
 
-struct mcux_lpc_rtc_config {
+struct mcux_lpc_wakeup_timer_config {
 	struct counter_config_info info;
 	RTC_Type *base;
 
@@ -60,11 +60,11 @@ struct mcux_lpc_rtc_config {
 #endif
 };
 
-static int mcux_lpc_rtc_start(const struct device *dev)
+static int mcux_lpc_wakeup_timer_start(const struct device *dev)
 {
 	const struct counter_config_info *info = dev->config;
-	const struct mcux_lpc_rtc_config *config =
-		CONTAINER_OF(info, struct mcux_lpc_rtc_config, info);
+	const struct mcux_lpc_wakeup_timer_config *config =
+		CONTAINER_OF(info, struct mcux_lpc_wakeup_timer_config, info);
 
 	RTC_EnableWakeupTimer(config->base, true);
 
@@ -83,11 +83,11 @@ static int mcux_lpc_rtc_start(const struct device *dev)
 	return 0;
 }
 
-static int mcux_lpc_rtc_stop(const struct device *dev)
+static int mcux_lpc_wakeup_timer_stop(const struct device *dev)
 {
 	const struct counter_config_info *info = dev->config;
-	const struct mcux_lpc_rtc_config *config =
-		CONTAINER_OF(info, struct mcux_lpc_rtc_config, info);
+	const struct mcux_lpc_wakeup_timer_config *config =
+		CONTAINER_OF(info, struct mcux_lpc_wakeup_timer_config, info);
 
 	RTC_EnableWakeupTimer(config->base, false);
 
@@ -97,11 +97,11 @@ static int mcux_lpc_rtc_stop(const struct device *dev)
 	return 0;
 }
 
-static int mcux_lpc_rtc_init(const struct device *dev)
+static int mcux_lpc_wakeup_timer_init(const struct device *dev)
 {
 	const struct counter_config_info *info = dev->config;
-	const struct mcux_lpc_rtc_config *config =
-		CONTAINER_OF(info, struct mcux_lpc_rtc_config, info);
+	const struct mcux_lpc_wakeup_timer_config *config =
+		CONTAINER_OF(info, struct mcux_lpc_wakeup_timer_config, info);
 
 	/* RTC has been initialized in 1Hz main RTC timer */
 
@@ -129,14 +129,14 @@ static int mcux_lpc_rtc_init(const struct device *dev)
 #endif
 
 	/* When warm reset, enable bit is not cleared. So disable 1kHz timer first! */
-	mcux_lpc_rtc_stop(dev);
+	mcux_lpc_wakeup_timer_stop(dev);
 
 	return 0;
 }
 
-static const struct counter_driver_api mcux_rtc_driver_api = {
-	.start = mcux_lpc_rtc_start,
-	.stop = mcux_lpc_rtc_stop,
+static const struct counter_driver_api mcux_wakeup_timer_driver_api = {
+	.start = mcux_lpc_wakeup_timer_start,
+	.stop = mcux_lpc_wakeup_timer_stop,
 	.get_value = NULL,
 	.set_alarm = NULL,
 	.cancel_alarm = NULL,
@@ -173,11 +173,11 @@ static const struct counter_driver_api mcux_rtc_driver_api = {
 	#define RTC_FLEXIO_LOW_FREQ_CONFIG
 #endif
 
-static struct mcux_lpc_rtc_data mcux_lpc_rtc_data;
+static struct mcux_lpc_wakeup_timer_data mcux_lpc_wakeup_timer_data;
 
 #define COUNTER_LPC_RTC_DEVICE(id)										\
 	RTC_PINCTRL_DEFINE(id)												\
-	static const struct mcux_lpc_rtc_config mcux_lpc_rtc_config##id = { \
+	static const struct mcux_lpc_wakeup_timer_config mcux_lpc_wakeup_timer_config##id = { \
 		.base = (RTC_Type *)DT_REG_ADDR(DT_PARENT(DT_DRV_INST(id))),						\
 		.info = {														\
 			.max_top_value = UINT16_MAX,								\
@@ -189,9 +189,9 @@ static struct mcux_lpc_rtc_data mcux_lpc_rtc_data;
 		RTC_FLEXIO_LOW_FREQ_CONFIG										\
 		RTC_PINCTRL_INIT(id)											\
 	};																	\
-	DEVICE_DT_INST_DEFINE(id, mcux_lpc_rtc_init,						\
-			NULL, &mcux_lpc_rtc_data, &mcux_lpc_rtc_config##id,			\
+	DEVICE_DT_INST_DEFINE(id, mcux_lpc_wakeup_timer_init,						\
+			NULL, &mcux_lpc_wakeup_timer_data, &mcux_lpc_wakeup_timer_config##id,			\
 			POST_KERNEL, RTC_1KHZ_INIT_PRIORITY,						\
-			&mcux_rtc_driver_api);
+			&mcux_wakeup_timer_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(COUNTER_LPC_RTC_DEVICE)

--- a/drivers/display/CMakeLists.txt
+++ b/drivers/display/CMakeLists.txt
@@ -19,6 +19,7 @@ zephyr_library_sources_ifdef(CONFIG_ST7789V		display_st7789v.c)
 zephyr_library_sources_ifdef(CONFIG_ST7735R		display_st7735r.c)
 zephyr_library_sources_ifdef(CONFIG_STM32_LTDC		display_stm32_ltdc.c)
 zephyr_library_sources_ifdef(CONFIG_RM68200		display_rm68200.c)
+zephyr_library_sources_ifdef(CONFIG_DISPLAY_JDI		display_jdi.c)
 
 zephyr_library_sources_ifdef(CONFIG_MICROBIT_DISPLAY
 	mb_display.c

--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -36,5 +36,6 @@ source "drivers/display/Kconfig.ls0xx"
 source "drivers/display/Kconfig.rm68200"
 source "drivers/display/Kconfig.max7219"
 source "drivers/display/Kconfig.intel_multibootfb"
+source "drivers/display/Kconfig.jdi"
 
 endif # DISPLAY

--- a/drivers/display/Kconfig.jdi
+++ b/drivers/display/Kconfig.jdi
@@ -1,0 +1,13 @@
+# Copyright (c) 2019, NXP
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig DISPLAY_JDI
+	bool "JDI driver"
+	help
+	  Enable support for mcux eLCDIF driver.
+
+if DISPLAY_JDI
+
+
+
+endif # DISPLAY_JDI

--- a/drivers/display/Kconfig.jdi
+++ b/drivers/display/Kconfig.jdi
@@ -8,6 +8,28 @@ menuconfig DISPLAY_JDI
 
 if DISPLAY_JDI
 
+choice JDI_CLOCK_GEN_MODE
+	prompt "Clock generation method"
+	default JDI_CLOCK_GEN_SPI_DMA_REQUEST
+	help
+	  Specify the type of the clock generation method.
 
+config JDI_CLOCK_GEN_SPI_DMA_REQUEST
+	bool "Use DMA Request of SPI to generate clock"
+	select SPI_MCUX_FLEXCOMM_DMA
+	help
+	  It may happen that the SHIFTBUF data is overwritten by the
+	  new data before the current SHIFTBUF data has been sent.
+
+config JDI_CLOCK_GEN_CTIMER_TRIGGER
+	bool "Use CTimer trigger to generate clock"
+	help
+	  Using the CTIMER trigger method can control the timing more finely,
+	  and avoid the SHIFTBUF being overwritten by new data before it has
+	  finished shifting the data. 
+	  Notice: the first clock pattern can't send via DMA and the CS pin
+	  of the SPI cannot be configured in the device tree.
+
+endchoice
 
 endif # DISPLAY_JDI

--- a/drivers/display/display_jdi.c
+++ b/drivers/display/display_jdi.c
@@ -1,0 +1,2033 @@
+/*
+ * Copyright 2019-22, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_flexio_jdi
+
+#include <zephyr/drivers/display.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/counter/counter_mcux_ctimer.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/dma/dma_mcux_lpc.h>
+
+#ifdef CONFIG_HAS_MCUX_CACHE
+#include <fsl_cache.h>
+#endif
+#include <fsl_flexio.h>
+#include <fsl_gpio.h>
+#include <fsl_ctimer.h>
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(display_jdi, CONFIG_DISPLAY_LOG_LEVEL);
+
+#if !defined(CONFIG_KERNEL_MEM_POOL) || !CONFIG_HEAP_MEM_POOL_SIZE
+    #error "jdi driver need config KERNEL_MEM_POOL and CONFIG_HEAP_MEM_POOL_SIZE"
+#endif
+
+/* 1 VCK slot contains 1 HST/VCK word and 30 words of RGB data.
+ * The first word is used to implement HST/VCK, and the next
+ * 30 words transmit RGB data.
+ */
+#define PIXEL_CLK_25_VCK_LEN_WORD		31
+#define PIXEL_CLK_25_VCK_NON_DATA_WORD	1
+#define PIXEL_CLK_2_5_MHZ				25
+
+/* The time (tdHST + tsHST + thHST) of 1 HST signal is maintained using 1 word */
+#define PIXEL_CLK_25_HST_LEN_WORD		1
+
+/* The number of words be sent by one input trigger */
+#define ONCE_TRANS_WORD_NUM             (2)
+
+/* DMA data: 484 VCK slots, 2 * PIXEL_CLK_25_VCK_LEN_WORD 32-bit word (@ 2.5 MHz shift clock) */
+/* TODO: 485 ~ 488 slot */
+#define IMAGE_DMA_DATA_SIZE_BYTES	    (PIXEL_CLK_25_VCK_LEN_WORD * 2 * 484 * sizeof(uint32_t))
+#define IMAGE_DMA_DATA_SIZE_WORDS	    (IMAGE_DMA_DATA_SIZE_BYTES / sizeof(uint32_t))
+
+
+/* Use SHIFTBUF[0] and SHIFTBUF[1] to cache RGB/VCK/HST data, which will be sent to jdi by shifter */
+#define FLEXIO_SHIFTER_PIXEL			0
+#define FLEXIO_SHIFTER_PIXEL_ADD		(FLEXIO_SHIFTER_PIXEL + 1)
+/* Used to extract even and odd bits in RGB data */
+#define FLEXIO_SHIFTER_AUX0				2
+#define FLEXIO_SHIFTER_AUX1				3
+
+/* VCK signal is transmitted through FLEXIO_D7.
+ * So VCK signal is in the 4th bit in the data
+ * that will be transmitted by SHIFTER0.
+ * 
+ * VCK is low when send Large Pixel Bit(LPB);
+ * VCK is high when send Small Pixel Bit(SPB).
+ */
+#define VCK_PATTERN		    (1<<3)
+#define VCK_BYTE0		    (VCK_PATTERN<< 0)
+#define VCK_BYTE1		    (VCK_PATTERN<< 8)
+#define VCK_BYTE2		    (VCK_PATTERN<<16)
+#define VCK_BYTE3		    (VCK_PATTERN<<24)
+#define VCK_BYTE0123	    (VCK_BYTE3 | VCK_BYTE2 | VCK_BYTE1 | VCK_BYTE0)
+#define VCK_BYTE3210	    VCK_BYTE0123
+#define VCK_BYTE123		    (VCK_BYTE3 | VCK_BYTE2 | VCK_BYTE1            )
+
+/* HST signal is transmitted through FLEXIO_D11.
+ * So HST signal is in the 8th bit in the data
+ * that will be transmitted by SHIFTER0.
+ */
+#define HST_PATTERN			(1<<7)
+#define HST_BYTE0			(HST_PATTERN<<0 )
+#define HST_BYTE1			(HST_PATTERN<<8 )
+#define HST_BYTE2			(HST_PATTERN<<16)
+#define HST_BYTE3			(HST_PATTERN<<24)
+#define HST_BYTE23			(            HST_BYTE2 | HST_BYTE3)
+#define HST_BYTE123			(HST_BYTE1 | HST_BYTE2 | HST_BYTE3)
+
+/* ctimer enum */
+enum {
+    PIXEL_DATA_TIMER,
+    XRST_VST_DATA_TIMER,
+    ENB_DATA_TIMER,
+    JDI_MAX_TIMER_NUM,
+};
+
+/* flexio timer enum */
+enum {
+    FLEXIO_TIMER_PIXEL,
+
+    /* HCK related flexio timers */
+    FLEXIO_TIMER_HCK_TRIGGER,
+    FLEXIO_TIMER_HCK,
+
+    /* ENB related flexio timers */
+    FLEXIO_TIMER_GEN,
+    FLEXIO_TIMER_ENB_0 = FLEXIO_TIMER_GEN,
+    FLEXIO_TIMER_ENB_1,
+    FLEXIO_TIMER_ENB_2,
+};
+
+/* FLEXIO_D3 used as ENB line. It used as FLEXIO_TIMER_ENB_2 pin output */
+#define FLEXIO_TIMER_ENB_PIN 		    3
+
+/* FLEXIO_D4 ~ FLEXIO_D11 used as SHIFTER0 parallel output */
+#define FLEXIO_SHIFTER_PIN_B0	    	4
+#define FLEXIO_SHIFTER_PIN_G0	    	5
+#define FLEXIO_SHIFTER_PIN_R0	    	6
+#define FLEXIO_SHIFTER_PIN_VCK			7
+#define FLEXIO_SHIFTER_PIN_B1	    	8
+#define FLEXIO_SHIFTER_PIN_G1	    	9
+#define FLEXIO_SHIFTER_PIN_R1	    	10
+#define FLEXIO_SHIFTER_PIN_HST			11	/**/
+
+/* FLEXIO_D12 used as FLEXIO_TIMER_HCK pin output. It also is HCK line of JDI */
+#define FLEXIO_TIMER_HCK_PIN			12
+
+/* FLEXIO_D13 used as FLEXIO_TIMER_PIXEL trigger source. It also is SPI5 CLK output */
+#define FLEXIO_TIMER_TRIG_PIN			13
+
+/* FLEXIO_D14 is FLEXIO_TIMER_ENB_0 timer output */
+#define FLEXIO_TIMER_ENB_0_OUT_PIN		14
+
+/* FLEXIO_D15 used as FLEXIO_TIMER_HCK_TRIGGER pin output. It also is FLEXIO_TIMER_HCK trigger source */
+#define FLEXIO_HCK_TRIG_PIN				15
+
+/**
+ * @brief Timer match configuration
+ * 
+ * @param chan_id match channel, rang 0~3
+ * @param match_config match config
+ */
+struct timer_match_config {
+    uint8_t chan_id;
+    struct counter_alarm_cfg match_config;
+};
+
+
+/**
+ * @brief PIXEL_DATA_TIMER config
+ * 
+ * Use a timer to trigger DMA transfer of DMA data. DMA data contain XRST / VST /
+ * VCK / HST / pixel data.
+ * 
+ * This timer needs to be configured to trigger counting
+ * on both rising and falling edges.
+ * 
+ * Trigger DMA when counter is 1, reset Timer Counter Register when counter is 2.
+ * Trigger source come from capture pin, that is @ref input_clock output.
+ * 
+ * When MR[0] match, send DMA data to SHIFTBUF.
+ * When MR[1] match, send 0x80 to SPI5 FIFOWR.
+ * When MR[2] match, the timer counter reset.
+ * 
+ * The detailed execution process is as follows
+ *      a. Every time CTIMER0 receives a 0x80, it bursts to send 2 data to SHIFTBUF[0]
+ *         and SHIFTBUF[1]
+ *      b. When SHIFTER Clock come, SHIFTER0 send data to FLEXIO_D4 ~ FLEXIOD11
+ */
+
+void pixel_data_m0_alarm_callback(const struct device *dev,
+                     uint8_t chan_id, uint32_t ticks,
+                     void *user_data)
+{
+    printk("\nchan_id %d ticks %d alarm callback\n", chan_id, ticks);	
+}
+const struct timer_match_config pixel_data_m0_dma_match_config = {
+    .chan_id = 0,		/* use match channel 0 to trigger dma */
+    .match_config = {
+        .callback = NULL/* pixel_data_m0_alarm_callback */,
+        .user_data = NULL,
+        .ticks = 1,		/* when match value, trigger dma to send DMA data to FLEXIO SHIFTBUF */
+        .flags = COUNTER_ALARM_CFG_ABSOLUTE,
+    },
+};
+
+/* MR1 is not used */
+const struct timer_match_config pixel_clock_m1_dma_match_config = {
+	.chan_id = 1,		/* use match channel 1 to trigger SPI DMA */
+	.match_config = {
+		.callback = NULL,
+		.user_data = NULL,
+		.ticks = 2,		/* when match value, trigger SPI dma to send @ref clkgen_pattern to FIFOWR */
+		.flags = COUNTER_ALARM_CFG_ABSOLUTE,
+	},
+};
+
+const struct timer_match_config pixel_data_reset_match_config = {
+    .chan_id = 2,		/* use match channel 2 to reset timer */
+    .match_config = {
+        .callback = NULL,
+        .user_data = NULL,
+        .ticks = 2,		/* when match value, reset timer */
+        .flags = COUNTER_ALARM_CFG_ABSOLUTE | COUNTER_ALARM_CFG_AUTO_RESET,
+    },
+};
+/**********************************************************************************************
+ *                  PIXEL_DATA_TIMER CONFIG END
+ *********************************************************************************************/
+
+
+/**
+ * @brief XRST_VST_DATA_TIMER config
+ * 
+ * XRST / VST of JDI use GPIO Pin to connect. and use a timer to 
+ * drive these pins to generate XRST / VST signals.
+ * 
+ * Trigger DMA to update MR1 when counter value is equal to MR0.
+ * Trigger DMA to toggle pin output and reset counter when counter 
+ * value is equal to MR1.
+ * Reset Timer Counter Register when counter value is equal to MR2
+ * 
+ * match and pin patterns for XRST/VST DMA driven GPIO control
+ * match[] role of MR1:
+ * dma_gpio_match[0]: XRST rising edge, coupled with dma_gpio_pin[0]
+ * dma_gpio_match[1]: VST rising edge, coupled with dma_gpio_pin[1]
+ * dma_gpio_match[2]: VST falling edge, coupled with dma_gpio_pin[2]
+ * dma_gpio_match[3]: XRST falling edge, coupled with dma_gpio_pin[3]
+ * dma_gpio_match[4]: must be set to satisfy the following: 
+ *           match[4]>MR[2]; MR[2]>match[i], i=0,1,2,3
+ * 
+ * 
+ * The detailed process of XRST / VST signal generation is as follows:
+ * 
+ *       a. The counter counts up until it matches MR0, then trigger
+ *          DMA of MR0 to update MR1 value to DMA_GPIO_TOGGLE_XRST_RE.
+ *          The counter continues to count up until it matches MR1,
+ *          then trigger DMA of MR1 to toggle XRST pin output for
+ *          generating XRST rising edge, then counter value reset to zero.
+ * 
+ *       b. The counter counts up until it matches MR0, then trigger
+ *          DMA of MR0 to update MR1 value to DMA_GPIO_TOGGLE_VST_RE.
+ *          The counter continues to count up until it matches MR1,
+ *          then trigger DMA of MR1 to toggle VST pin output for
+ *          generating VST rising edge, then counter value reset to zero.
+ * 
+ *       c. The counter counts up until it matches MR0, then trigger
+ *          DMA of MR0 to update MR1 value to DMA_GPIO_TOGGLE_VST_FE.
+ *          The counter continues to count up until it matches MR1,
+ *          then trigger DMA of MR1 to toggle VST pin output for
+ *          generating VST falling edge, then counter value reset to zero.
+ * 
+ *       d. The counter counts up until it matches MR0, then trigger
+ *          DMA of MR0 to update MR1 value. The match value of the falling
+ *          edge of XRST is related to the amount of DMA data pushed.
+ *          So @ref dma_gpio_match[3] value need to be dynamically assigned.
+ *          The counter continues to count up until it matches MR1,
+ *          then trigger DMA of MR1 to toggle XRST pin output for
+ *          generating XRST falling edge, then counter value reset to zero.
+ * 
+ *       e. After XRST falling edge is generated, counter counts up until it
+ *          matches MR0, then trigger DMA of MR0 to update MR1 value to @ref 
+ *          dma_gpio_match[4]. This dma_gpio_match[4] value TC count is unreachable.
+ *          This is to ensure that no XRST signal will be generated during a screen
+ *          refresh process. 
+ * 
+ *       f. After the DMA data is transferred, the timer is still active,
+ *          and the TC count is not cleared. Therefore, the TC count needs
+ *          to be cleared before the next screen refresh.
+ * 
+ * Note: 1. After all pixel data is sent, XRST fall to low level. 
+ *          So the match[3] value changes dynamically.
+ *       2. XRST / VST pins must be on the same port.
+ * 
+ * 
+ */
+
+/* During the data transmission of each line of JDI, XRST is the earliest signal.
+ * After the external input clock appears, delay 5 MOSI data (40 2.4MHz SPI clocks,
+ * about 14us), then generating XRST rising edge.
+ * 
+ * Note: The delay time could be any value.
+ */
+#define	DMA_GPIO_TOGGLE_XRST_RE		(5)
+
+/* There is XRST set-up time (tsXRST) between the rising edge of XRST and the rising edge of VST.
+ * The minimum value of tsXRST is 12.8us. The typical value of tsXRST is 17.6us.
+ * So use 6 MOSI data (48 2.4MHz SPI clocks, about 19us) to maintain the tsXRST time.
+ */
+#define	DMA_GPIO_TOGGLE_VST_RE		(6)
+
+/* There is VST set-up time (tsVST, 24us+) and VST hold time (thVST, 24.8us+) after VST rising edge.
+ * So use 17 MOSI data (136 2.4MHz SPI clocks, about 57us) to maintain this time.
+ */
+#define VST_SETUP_TIME              (8)
+#define VST_HOLD_TIME               (9)
+#define	DMA_GPIO_TOGGLE_VST_FE		(17)
+
+enum {
+    XRST_RE_MATCH_ID,
+    VST_RE_MATCH_ID,
+    VST_FE_MATCH_ID,
+    XRST_FE_MATCH_ID,
+    MATCH_ID_MAX,
+};
+
+/* List of matching values for M1 */
+#define DMA_GPIO_MATCH_NUM 	        (5)
+static uint32_t dma_gpio_match[DMA_GPIO_MATCH_NUM] = {
+    [0] = DMA_GPIO_TOGGLE_XRST_RE,
+    [1] = DMA_GPIO_TOGGLE_VST_RE,
+    [2] = DMA_GPIO_TOGGLE_VST_FE,
+    [3] = 0x80000000,
+    [4] = 0x8000000A,
+};
+
+#define DISPLAY_VST_PIN	  DT_INST_PHA_BY_NAME(0, gpios, vst, pin)
+#define DISPLAY_XRST_PIN  DT_INST_PHA_BY_NAME(0, gpios, xrst, pin)
+
+/* List of values written to the port of XRST / VST pins to toggle pin output. */
+#define DMA_GPIO_PIN_NUM 	        (4)
+static uint32_t dma_gpio_pin[DMA_GPIO_PIN_NUM] = {
+    [0] = 1 << DISPLAY_XRST_PIN,
+    [1] = 1 << DISPLAY_VST_PIN,
+    [2] = 1 << DISPLAY_VST_PIN,
+    [3] = 1 << DISPLAY_XRST_PIN,
+};
+
+const struct timer_match_config xrst_vst_m0_dma_match_config = {
+    .chan_id = 0,		        /* use match channel 0 to trigger dma */
+    .match_config = {
+        .callback = NULL,
+        .user_data = NULL,
+        .ticks = 1,		        /* when match value, trigger dma to update MR1 of XRST_VST_DATA_TIMER */
+        .flags = COUNTER_ALARM_CFG_ABSOLUTE,
+    },
+};
+
+const struct timer_match_config xrst_vst_m1_dma_match_config = {
+    .chan_id = 1,		        /* use match channel 1 to trigger dma */
+    .match_config = {
+        .callback = NULL,
+        .user_data = NULL,
+        .ticks = 0x80000000,	/* initial value must be >0, when match value, trigger dma to write the port pin NOT register changing the pins of interest */
+        .flags = COUNTER_ALARM_CFG_ABSOLUTE | COUNTER_ALARM_CFG_AUTO_RESET,
+    },
+};
+
+const struct timer_match_config xrst_vst_reset_match_config = {
+    .chan_id = 2,		        /* use match channel 2 to reset timer */
+    .match_config = {
+        .callback = NULL,
+        .user_data = NULL,
+        .ticks = 0x80000001,	/* initial value must be set as MR[2]>MR[1], when match value, timer stops and resets */
+        .flags = COUNTER_ALARM_CFG_ABSOLUTE | COUNTER_ALARM_CFG_AUTO_RESET | COUNTER_ALARM_CFG_AUTO_STOP,
+    },
+};
+/**********************************************************************************************
+ *                  XRST_VST_DATA_TIMER CONFIG END
+ *********************************************************************************************/
+
+/**
+ * @brief ENB_DATA_TIMER config
+ * 
+ */
+#define IOCON_IN_NOPUPD(x)	\
+    (IOPCTL_PIO_FSEL(x) 	|	\
+     IOPCTL_PIO_PUPDENA(0)	| IOPCTL_PIO_IBENA(1)	| IOPCTL_PIO_FULLDRIVE(0)	| \
+     IOPCTL_PIO_AMENA(0)	| IOPCTL_PIO_ODENA(0)	| IOPCTL_PIO_IIENA(0))
+
+/* PIO4_23: display GEN/ENB (timer output), configured as FLEXIO_D3 */
+#define DISPLAY_GEN_ENB_PORT			4
+#define DISPLAY_GEN_ENB_PIN				23
+#define DISPLAY_GEN_ENB_FUNC			8
+
+enum {
+    ENB_DISABLE_IN_NONE,                /* initialized status */
+    ENB_DISABLE_IN_PARTIAL_UPDATE,      /* ENB disable in partial update mode */
+    ENB_DISABLE_IN_ALL_UPDATE,          /* ENB disable in update mode  */
+};
+
+static uint32_t dma_jdi_enb_iocon_flexio = IOCON_IN_NOPUPD(DISPLAY_GEN_ENB_FUNC);
+static uint32_t dma_jdi_enb_iocon_gpio_0 = IOCON_IN_NOPUPD(0);
+
+static struct timer_match_config enb_m0_dma_match_config = {
+    .chan_id = 0,		/* use match channel 0 to trigger dma */
+    .match_config = {
+        .callback = NULL,
+        .user_data = NULL,
+        .ticks = 1,		/* when match value, trigger dma to update FLEXIO ENB pin to GPIO */
+        .flags = COUNTER_ALARM_CFG_ABSOLUTE,
+    },
+};
+
+static struct timer_match_config enb_reset_match_config = {
+    .chan_id = 1,		/* use match channel 1 to reset timer */
+    .match_config = {
+        .callback = NULL,
+        .user_data = NULL,
+        .ticks = 0x80000000,		/* initial value must be > 0, when match value, timer stops and resets */
+        .flags = COUNTER_ALARM_CFG_ABSOLUTE | COUNTER_ALARM_CFG_AUTO_RESET | COUNTER_ALARM_CFG_AUTO_STOP,
+    },
+};
+static int jdi_enb_timer_init(const struct device *dev);
+/**********************************************************************************************
+ *                  ENB_DATA_TIMER CONFIG END
+ *********************************************************************************************/
+
+struct display_info {
+    uint16_t panel_width;
+    uint16_t panel_height;	
+};
+
+enum {
+    VST_GPIO,
+    XRST_GPIO,
+    JDI_MAX_GPIO_NUM,
+};
+
+struct jdi_gpio_config {
+    const struct gpio_dt_spec gpio;
+    const GPIO_Type *gpio_base;
+    const uint8_t port_no;
+};
+
+/**
+ * @brief JDI configure structure
+ * 
+ * @param flexio_base FLEXIO register flexio_base address
+ * 
+ * @param display_info display information
+ * 
+ * @param pincfg FLEXIO pin configture
+ * 
+ * @param vcom_clock Use FLEXIO low frequency output function to generate VCOM/FRP/XFRP (60Hz).
+ * 		  So @ref vcom_clock device is 1kHz RTC timer
+ * 
+ * @param input_clock input clock to flexio for transmit jdi data
+ * 
+ * @param backlight_gpio backlight gpio pin
+ * 
+ * @param timer_dev ctimer device pointer
+ * 
+ * @param ctimer_base ctimer register base address
+ * 
+ * @param jdi_gpios gpio pin device info of XRST / VST
+ */
+struct jdi_config {
+    FLEXIO_Type *flexio_base;
+    struct display_info display_info;
+    void (*irq_config_func)(const struct device *dev);
+    const struct pinctrl_dev_config *pincfg;
+    const struct device *vcom_clock;
+    const struct device *input_clock;
+    const struct gpio_dt_spec backlight_gpio;
+    const struct device *timer_dev[JDI_MAX_TIMER_NUM];
+    const CTIMER_Type* ctimer_base[JDI_MAX_TIMER_NUM];
+    const struct jdi_gpio_config jdi_gpios[JDI_MAX_GPIO_NUM];
+};
+
+/**
+ * @brief DMA information during single frame transfer
+ * 
+ * @param dma_data Contains not only pixel data but also padding data to correspond other XRST/VST-like data
+ * 
+ * @param dma_data_clock_count The number of SPI output clocks required to transmit dma data
+ * 
+ * @param dma_data_word_count Transfer dma data number in word
+ * 
+ * @param rgb_baseline_dma_data_word_count the location of pixel data in @ref dma_data
+ * 
+ * @param jdi_enb_disable ENB end location
+ * 
+ * @param jdi_enb_disable_status ENB disable in update or partial-update mode
+ */
+struct frame_dma_data {
+    uint32_t dma_data[IMAGE_DMA_DATA_SIZE_WORDS];
+    uint32_t dma_data_clock_count;
+    uint32_t dma_data_word_count;
+    uint32_t rgb_baseline_dma_data_clock_count;
+    uint32_t rgb_baseline_dma_data_word_count;
+    uint32_t jdi_enb_disable;
+    uint32_t jdi_enb_disable_status;
+};
+
+struct jdi_data {
+    struct k_sem sem;
+    struct display_capabilities cap;
+    struct frame_dma_data frame;
+};
+
+static void counter_dma_callback(const struct device *dev, void *user_data,
+                   uint32_t chan_id, int status)
+{
+    printk("\nJDI callback, chan_id %d\n", chan_id);
+}
+
+/**
+ * @brief the configure struct for spi use to generate jdi clock
+ * 
+ * @param frequency 2.4MHz. Because HCK of jdi minimum cost 400ns (half period),
+ * 		  So frequency at most 2.5MHz, and double edge trigger for ctimer.
+ * 
+ */
+static const struct spi_config spi_cfg = {
+    .frequency = 2400000,       /* The whole clock cycle is about 420ns. That is the time cost of 1 bit of MOSI data */
+    .operation = SPI_WORD_SET(8) | SPI_OP_MODE_MASTER | SPI_MODE_CPHA,
+    .slave = 0,
+};
+
+/* Fixed output value of MOSI for capture by ctimer */
+static const uint8_t clkgen_pattern = 0x80;
+
+/**
+ * @brief SPI output CLK to FLEXIO to shift data to JDI,
+ *        and output MOSI data to CTIMER capture to trigger
+ *        prepare JDI signal data.
+ * 
+ * @param dev is JDI display device
+ * @return int 0 on success else negative errno code.
+ */
+static int jdi_flexio_clock_send(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+    struct jdi_data *data = (struct jdi_data *)dev->data;
+    struct frame_dma_data *frame = &data->frame;
+
+    LOG_DBG("\npixel clock count %d\n", frame->dma_data_clock_count);
+
+    uint32_t transfer_bytes = frame->dma_data_clock_count / CHAR_BIT;
+
+    struct spi_buf tx_buf = {
+        .buf = (uint8_t *)&clkgen_pattern,
+        .len = transfer_bytes,
+        .addr_nochange = true,
+    };
+
+    struct spi_buf_set tx = {
+        .buffers = (const struct spi_buf *)&tx_buf,
+        .count = 1,
+    };
+
+    int ret = spi_write(config->input_clock, &spi_cfg, &tx);
+    if (ret) {
+        LOG_ERR("%s fail %d\n", __FUNCTION__, ret);
+    }
+
+    return ret;
+}
+
+/**
+ * @brief When PIXEL_DATA_TIMER capture input signal, transfer RGB/HST/VCK data
+ *        to SHIFTBUF via DMA.
+ * 
+ * Note: 1. PIXEL_DATA_TIMER use MOSI data as trigger source, and transfer data
+ *          to SHIFTBUF. SHIFTER parallel shift 8 bits data to JDI from SHIFTBUF,
+ *          and SHIFTER trigger source is SPI CLK. 1 MOSI data corresponds 
+ *          to 8 clocks, therefore, SHIFTER output 2 words, when PIXEL_DATA_TIMER
+ *          MR0 matched.
+ * 
+ *       2. MR0 matches once, triggering the transmission of 2 words of data.
+ * 
+ * @param dev is JDI display device
+ * @return int 0 on success else negative errno code.
+ */
+int jdi_pixel_data_m0_dma_config(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+    struct jdi_data *dev_data = dev->data;
+
+    // dev_data->frame.dma_data_word_count = 1024;
+
+    const struct mcux_counter_dma_cfg pixel_data_m0_priv_dma_cfg = {
+        .mcux_dma_cfg = {
+            .channel_trigger = {
+                .type = kDMA_RisingEdgeTrigger,			// hw trigger, rising edge.
+                .burst = kDMA_EdgeBurstTransfer2,		// burst transfer, burst size. Burst transfor 2 * dest_data_size bytes at a time. Trigger to transmit all data at once
+                                                        // Assign value from end address to start address
+                .wrap = kDMA_DstWrap,					// destination burst wrap.  the destination address range for each burst will be the same
+            },
+            .disable_int = false,
+        },
+    };
+
+    const struct counter_dma_cfg pixel_data_m0_dma_config = {
+        .channel_direction = MEMORY_TO_MEMORY,
+        .channel_priority = 1, 					// priority = 1
+        .source_data_size = sizeof(uint32_t), 	// 32-bit transfers
+        .dest_data_size = sizeof(uint32_t),		// 32-bit transfers
+        .source_burst_length = 0,				// burst size = 0
+        .dest_burst_length = 2,					// burst size = 2
+        .src_addr = (uint32_t)dev_data->frame.dma_data,
+        .dest_addr = (uint32_t)&config->flexio_base->SHIFTBUF[FLEXIO_SHIFTER_PIXEL], /* Use SHIFTBUF[0] and SHIFTBUF[1] to cache RGB/ENB/VCK data */
+        .length = dev_data->frame.dma_data_word_count * sizeof(uint32_t),  // bytes num. So need to multiply by source_data_size
+        .source_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+        .dest_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+        .callback = counter_dma_callback,
+        .user_data = dev->data,
+        .priv_config = (void *)&(pixel_data_m0_priv_dma_cfg),
+    };
+    printk("dma data size %d\n", dev_data->frame.dma_data_word_count);
+    // printk("rgb data %08x %08x %08x %08x %08x %08x %08x %08x\n", dev_data->frame.dma_data[dev_data->frame.rgb_baseline_dma_data_word_count], 
+    //                         dev_data->frame.dma_data[dev_data->frame.rgb_baseline_dma_data_word_count + 1],
+    //                         dev_data->frame.dma_data[dev_data->frame.rgb_baseline_dma_data_word_count + 2],
+    //                         dev_data->frame.dma_data[dev_data->frame.rgb_baseline_dma_data_word_count + 3],
+    //                         dev_data->frame.dma_data[dev_data->frame.rgb_baseline_dma_data_word_count + 4],
+    //                         dev_data->frame.dma_data[dev_data->frame.rgb_baseline_dma_data_word_count + 5],
+    //                         dev_data->frame.dma_data[dev_data->frame.rgb_baseline_dma_data_word_count + 6],
+    //                         dev_data->frame.dma_data[dev_data->frame.rgb_baseline_dma_data_word_count + 7]);
+    return counter_set_dma_cfg(config->timer_dev[PIXEL_DATA_TIMER], pixel_data_m0_dma_match_config.chan_id, (struct counter_dma_cfg *)&pixel_data_m0_dma_config);
+
+}
+
+/**
+ * @brief DMA configure of XRST_VST_DATA_TIMER MR0
+ * 
+ * When MR0 matched, update MR1
+ * 
+ * @param dev is JDI display device
+ * @return int 0 on success else negative errno code.
+ */
+int jdi_xrst_vst_m0_dma_config(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+
+    const struct mcux_counter_dma_cfg xrst_vst_m0_priv_dma_cfg = {
+        .mcux_dma_cfg = {
+            .channel_trigger = {
+                .type = kDMA_RisingEdgeTrigger,			// hw trigger, rising edge.
+                .burst = kDMA_EdgeBurstTransfer1,		// burst transfer, burst size. Burst transfor 1 * dest_data_size bytes at a time. Trigger to transmit all data at once
+                                                        // Assign value from end address to start address
+                .wrap = kDMA_NoWrap,					// no burst wrap.
+            },
+            .desc_loop = true,
+            .disable_int = true,
+        },
+    };
+
+    struct counter_dma_cfg xrst_vst_m0_dma_config = {
+        .channel_direction = MEMORY_TO_MEMORY,
+        .channel_priority = 0, 					// priority = 0
+        .source_data_size = sizeof(uint32_t), 	// 32-bit transfers
+        .dest_data_size = sizeof(uint32_t),		// 32-bit transfers
+        .source_burst_length = 0,				//
+        .dest_burst_length = 1,					//
+        .src_addr = (uint32_t)&dma_gpio_match[0],
+        .dest_addr = (uint32_t)&config->ctimer_base[XRST_VST_DATA_TIMER]->MR[1],
+        .length = DMA_GPIO_MATCH_NUM * sizeof(uint32_t),			// bytes num
+        .source_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+        .dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE,
+        .callback = NULL,
+        .user_data = dev->data,
+        .priv_config = (void *)&(xrst_vst_m0_priv_dma_cfg),
+    };
+
+    return counter_set_dma_cfg(config->timer_dev[XRST_VST_DATA_TIMER], xrst_vst_m0_dma_match_config.chan_id, &xrst_vst_m0_dma_config);
+
+}
+
+/**
+ * @brief DMA configure of XRST_VST_DATA_TIMER MR1
+ * 
+ * When MR1 matched, generate XRST / VST signal.
+ * 
+ * @param dev is JDI display device
+ * @return int 0 on success else negative errno code.
+ */
+int jdi_xrst_vst_m1_dma_config(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+
+    uint32_t port_no = config->jdi_gpios[VST_GPIO].port_no;
+    uint32_t dest_addr = (uint32_t)&(config->jdi_gpios[VST_GPIO].gpio_base->NOT[port_no]);
+
+    const struct mcux_counter_dma_cfg xrst_vst_m1_priv_dma_cfg = {
+        .mcux_dma_cfg = {
+            .channel_trigger = {
+                .type = kDMA_RisingEdgeTrigger,			// hw trigger, rising edge.
+                .burst = kDMA_EdgeBurstTransfer1,		// burst transfer, burst size. Burst transfor 1 * dest_data_size bytes at a time. Trigger to transmit all data at once
+                                                        // Assign value from end address to start address
+                .wrap = kDMA_NoWrap,					// no burst wrap.
+            },
+            .desc_loop = true,
+            .disable_int = true,
+        },
+    };
+
+    struct counter_dma_cfg xrst_vst_m1_dma_config = {
+        .channel_direction = MEMORY_TO_MEMORY,
+        .channel_priority = 0, 					// priority = 0
+        .source_data_size = sizeof(uint32_t), 	// 32-bit transfers
+        .dest_data_size = sizeof(uint32_t),		// 32-bit transfers
+        .source_burst_length = 0,				//
+        .dest_burst_length = 1,					//
+        .src_addr = (uint32_t)&dma_gpio_pin[0],
+        .dest_addr = dest_addr,
+        .length = DMA_GPIO_PIN_NUM * sizeof(uint32_t),			// bytes num
+        .source_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+        .dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE,
+        .callback = NULL,
+        .user_data = dev->data,
+        .priv_config = (void *)&(xrst_vst_m1_priv_dma_cfg),
+    };
+
+    return counter_set_dma_cfg(config->timer_dev[XRST_VST_DATA_TIMER], xrst_vst_m1_dma_match_config.chan_id, &xrst_vst_m1_dma_config);
+
+}
+
+/**
+ * @brief DMA configure of ENB_DATA_TIMER MR0
+ * 
+ * @param dev is JDI display device
+ * @return int 0 on success else negative errno code.
+ */
+int jdi_enb_m0_dma_config(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+
+    // TODO
+    dma_jdi_enb_iocon_flexio = IOCON_IN_NOPUPD(DISPLAY_GEN_ENB_FUNC);
+    GPIO->DIRSET[DISPLAY_GEN_ENB_PORT] = 1<<DISPLAY_GEN_ENB_PIN;
+    GPIO->CLR[DISPLAY_GEN_ENB_PORT] = 1<<DISPLAY_GEN_ENB_PIN;
+    dma_jdi_enb_iocon_gpio_0  = IOCON_IN_NOPUPD(0);
+
+    const struct mcux_counter_dma_cfg enb_m0_priv_dma_cfg = {
+        .mcux_dma_cfg = {
+            .channel_trigger = {
+                .type = kDMA_RisingEdgeTrigger,			// hw trigger, rising edge.
+                .burst = kDMA_EdgeBurstTransfer1,		// burst transfer, burst size. Burst transfor 1 * dest_data_size bytes at a time. Trigger to transmit all data at once
+                                                        // Assign value from end address to start address
+                .wrap = kDMA_NoWrap,					// no burst wrap.
+            },
+            .desc_loop = true,
+            .disable_int = false,
+        },
+    };
+
+    struct counter_dma_cfg enb_m0_dma_config = {
+        .channel_direction = MEMORY_TO_MEMORY,
+        .channel_priority = 0, 					// priority = 0
+        .source_data_size = sizeof(uint32_t), 	// 32-bit transfers
+        .dest_data_size = sizeof(uint32_t),		// 32-bit transfers
+        .source_burst_length = 0,				//
+        .dest_burst_length = 0,					//
+        .src_addr = (uint32_t)&dma_jdi_enb_iocon_gpio_0,
+        .dest_addr = (uint32_t)&IOPCTL->PIO[DISPLAY_GEN_ENB_PORT][DISPLAY_GEN_ENB_PIN],
+        .length = 1024 * sizeof(uint32_t),			// bytes num
+        .source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE,
+        .dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE,
+        .callback = NULL,
+        .user_data = dev->data,
+        .priv_config = (void *)&(enb_m0_priv_dma_cfg),
+    };
+
+    return counter_set_dma_cfg(config->timer_dev[ENB_DATA_TIMER], enb_m0_dma_match_config.chan_id, &enb_m0_dma_config);
+
+}
+
+/**
+ * @brief generate VCOM / FRP / XFRP to control JDI on/off
+ * 
+ * Generate VCOM/FRP/XFRP using flexio's low frequency output function
+ * 
+ * @param dev is JDI display device
+ * @return int 0 on success else negative errno code.
+ */
+static void jdi_vcom_control(const struct device *dev, bool on_off)
+{
+    const struct jdi_config *config = dev->config;
+    if (config->vcom_clock == NULL) {
+        return;
+    }
+
+    if (on_off) {
+        counter_start(config->vcom_clock);
+    }
+    else {
+        counter_stop(config->vcom_clock);
+    }
+}
+
+/**
+ * @brief reset clock count, word count, enb status
+ * 
+ * @param frame jdi frame info
+ */
+static void jdi_dma_data_reset(struct frame_dma_data *frame)
+{
+	// reset all counters
+	frame->dma_data_clock_count = 0;
+	frame->dma_data_word_count = 0;
+	frame->rgb_baseline_dma_data_clock_count = 0;
+	frame->rgb_baseline_dma_data_word_count  = 0;
+
+	frame->jdi_enb_disable_status = 0;
+
+	return;    
+}
+
+/**
+ * @brief Fill 2 VCK slots without RGB data but with HST, and update ENB status
+ * 
+ * @param frame Frame for DMA data
+ * 
+ * @param jdi_enb_disable_status enb status will be set
+ */
+void jdi_dma_data_add_jdi_last_enb(struct frame_dma_data *frame, uint32_t jdi_enb_disable_status)
+{
+    uint32_t i_word_loc;
+
+    uint32_t *pnt_data_dma_lpb;
+    uint32_t *pnt_data_dma_spb;
+    // uint32_t *pnt_image_pixel0123;
+    // uint32_t *pnt_image_pixel4567;
+
+    uint32_t dma_word_count_loc = frame->dma_data_word_count;
+
+    /* initialize dma data pointers */
+    pnt_data_dma_lpb = (uint32_t *)&(frame->dma_data[dma_word_count_loc + PIXEL_CLK_25_HST_LEN_WORD]);
+    pnt_data_dma_spb = pnt_data_dma_lpb + PIXEL_CLK_25_VCK_LEN_WORD;
+
+    /* add VCK with zero data + VCK without horizontal control */
+    /* ======================================================== */
+    for (i_word_loc = 0; i_word_loc != (PIXEL_CLK_25_VCK_LEN_WORD - PIXEL_CLK_25_HST_LEN_WORD); i_word_loc++)
+    {
+        *pnt_data_dma_lpb = 0;
+        *pnt_data_dma_spb = VCK_BYTE0123;
+
+        pnt_data_dma_lpb++;
+        pnt_data_dma_spb++;
+    }
+
+    /* JDI: prepare HST & VCK
+     * LPB 0: HST
+     * SPB 0: HST + VCK
+     */
+    frame->dma_data[dma_word_count_loc + 0                            ]  = HST_BYTE23;
+    frame->dma_data[dma_word_count_loc + 0 + PIXEL_CLK_25_VCK_LEN_WORD]  = VCK_BYTE0123;
+
+    /* TODO: */
+    frame->jdi_enb_disable = (dma_word_count_loc + 0 + PIXEL_CLK_25_VCK_LEN_WORD + 2) >> 1;
+
+    pnt_data_dma_lpb += PIXEL_CLK_25_VCK_LEN_WORD + PIXEL_CLK_25_VCK_NON_DATA_WORD;
+    pnt_data_dma_spb += PIXEL_CLK_25_VCK_LEN_WORD + PIXEL_CLK_25_VCK_NON_DATA_WORD;
+
+    dma_word_count_loc += 2 * PIXEL_CLK_25_VCK_LEN_WORD;
+
+    /* update parameters */
+    frame->dma_data_word_count = dma_word_count_loc;
+
+    /* update JDI ENB disable status */
+    frame->jdi_enb_disable_status = jdi_enb_disable_status;
+
+    return;
+}
+
+/**
+ * @brief Prepare dummy data which inserted before pixel data and will be sent to SHIFTBUF
+ * 
+ * Before sending the real pixel data, VST/XRST/VCK-like data needs to be generated.
+ * These data and pixel data are triggered by the same input (SPI MOSI / CLK),
+ * so when these data are generated, DMA data transfer is also triggered. Therefore
+ * some dummy data needs to be filled before the pixel data.
+ * 
+ * Note: 1 MOSI data will trigger 2 words to be sent, so the number of padding bytes
+ * needs to be multiplied by 2
+ * 
+ * Note：generate the first VCK slot without any RGB data in this function.
+ * 
+ * @param frame Frame for DMA data
+ */
+void jdi_dma_data_add_head(struct frame_dma_data *frame)
+{
+    uint32_t i_loc;
+    uint32_t dma_word_count_loc;
+
+    dma_word_count_loc = frame->dma_data_word_count;
+
+    /* VST is handled by the CTIMER1 & DMA */
+    //====================================
+
+    /* + 10 us, prepare to generate XRST rising edge */
+    for (i_loc = 0; i_loc != (DMA_GPIO_TOGGLE_XRST_RE - 1) * 2; i_loc++)
+    {
+        frame->dma_data[dma_word_count_loc + i_loc] = 0;
+    }
+    dma_word_count_loc += (DMA_GPIO_TOGGLE_XRST_RE - 1) * 2;
+
+    /* add slot for XRST rising edge */
+    for (i_loc = 0; i_loc != 1 * 2; i_loc++)
+    {
+        frame->dma_data[dma_word_count_loc + i_loc] = 0x00000000;
+    }
+    dma_word_count_loc += 1 * 2;
+
+    /* tsXRST (XRST set-up time, min value is 12.8us) 12.8+ us before VST rising edge */
+    for (i_loc = 0; i_loc != DMA_GPIO_TOGGLE_VST_RE * 2; i_loc++)
+    {
+        frame->dma_data[dma_word_count_loc + i_loc] = 0x00000000;
+    }
+    dma_word_count_loc += DMA_GPIO_TOGGLE_VST_RE * 2;
+
+    /* 24+ us after VST rising edge <=> 7.75 x 3.2 us windows => implement 9 (8 + 1 for VST update) */
+    for (i_loc = 0; i_loc != VST_SETUP_TIME * 2; i_loc++)
+    {
+        frame->dma_data[dma_word_count_loc + i_loc] = 0x00000000;
+    }
+    dma_word_count_loc += VST_SETUP_TIME * 2;
+
+    /* VCK 1(twVCKH = tsVST + thVST): 24.8 + 24 us = 48.8 us <=> 15.25 x 3.2 us => implement 17 (16 + 1 for VST update) */
+    for (i_loc = 0; i_loc != DMA_GPIO_TOGGLE_VST_FE * 2; i_loc++)
+    {
+        frame->dma_data[dma_word_count_loc + i_loc] = VCK_BYTE0123;
+    }
+    dma_word_count_loc += DMA_GPIO_TOGGLE_VST_FE * 2;
+
+    /* update parameters */
+    frame->dma_data_word_count = dma_word_count_loc;
+
+    /* add_head prepares foundation for RGB data, save rgb_baseline */
+    frame->rgb_baseline_dma_data_word_count = dma_word_count_loc;
+
+    return;
+}
+
+/**
+ * @brief Prepare dma data for pixel data attached with VCK / HST 
+ * 
+ * In upodate mode, after the jdi_dma_data_add_head function is processed, prepare to generate
+ * the second and subsequent VCK.
+ * 
+ * At the beginning of the VCK slot, there are tdHST (HST delay time, 400ns), tsHST (HST set-up
+ * time, 200ns) and thHST (HST hold time, 200ns). Here, use 1 word to accomplish, the value of
+ * this word is HST_BYTE23, meaning tdHST is about 800ns and tsHST + thHST is about 800ns.
+ * 
+ * Start sending RGB data after HST. The current screen line is 240 pixels.
+ * 1 line of RGB data is transmitted in 2 times: LPB(Large Pixel Bit) and SPB(Small Pixel Bit).
+ * So 2 VCK slots are required to complete a line of RGB data transmission. 1 VCK slot contains
+ * 120 HCK slots with data and 2 dummy HCK slots. 
+ * 
+ * According to the timing requirements of JDI data transmission, adjust the RGB data format,
+ * store and transmit high-order bit data and low-order bit data separately.
+ * Use SHIFTBUFOES / SHIFTBUFEOS of SHIFTBUF to accomplish this function.
+ * 
+ * After the high-order bit and the low-order bit of the same color are isolated, one byte of
+ * DMA data contains 2 bits of Reg, 2 bits of Blue and 2 bits of Green. These bit data will be
+ * sent to the R1 / R2 / B1 / B2 / G1 / G2 lines of JDI.
+ * 
+ * 1 LPB or SPB RGB data needs 30 words of space to save, corresponding to 120 HCK slots.
+ * 
+ * 
+ * While transmitting RGB data, it also comes with VCK and HST. the first word store HST and VCK data
+ * When transmitting LPB data, VCK value is 0; When transmitting SPB data, VCK value is 1;
+ * 
+ * 
+ * @param frame Frame for DMA data
+ * 
+ * @param pixel_data pixel data
+ * 
+ * @param number_of_lines lines number of pixel data
+ */ 
+void jdi_prepare_image_dma_data(struct frame_dma_data *frame, uint8_t *pixel_data, uint32_t number_of_lines)
+{
+    uint32_t i_line_loc, i_word_loc;
+
+    uint32_t *pnt_data_dma_lpb;
+    uint32_t *pnt_data_dma_spb;
+    uint32_t *pnt_image_pixel0123;
+    uint32_t *pnt_image_pixel4567;
+
+    uint32_t dma_word_count_loc = frame->dma_data_word_count;
+
+    /* initialize pixel offsets 0, 1, 2, 3 */
+    pnt_image_pixel0123 = (uint32_t *)pixel_data;
+    pnt_image_pixel4567 = pnt_image_pixel0123 + 1;
+
+    /* initialize dma data pointers */
+    /* LPB data, the first word store HST and VCK data, so need to skip 1 */
+    pnt_data_dma_lpb = (uint32_t *)&(frame->dma_data[dma_word_count_loc + PIXEL_CLK_25_HST_LEN_WORD]);
+
+    /* SPB data, skip 30 words lpb data,
+     * then the next word store HST and VCK data, so need to skip 1.
+     */
+    pnt_data_dma_spb = pnt_data_dma_lpb + PIXEL_CLK_25_VCK_LEN_WORD;
+
+    for (i_line_loc = 0; i_line_loc != number_of_lines; i_line_loc++)
+    {
+        /* add line data, Separate high-order bits and low-order bits */
+        /* ============== */
+        for (i_word_loc = 0; i_word_loc != (PIXEL_CLK_25_VCK_LEN_WORD - PIXEL_CLK_25_HST_LEN_WORD); i_word_loc++)
+        {
+            FLEXIO0->SHIFTBUF[FLEXIO_SHIFTER_AUX0] = *pnt_image_pixel0123;
+            FLEXIO0->SHIFTBUF[FLEXIO_SHIFTER_AUX1] = *pnt_image_pixel4567;
+
+            *pnt_data_dma_lpb =
+                (FLEXIO0->SHIFTBUFOES[FLEXIO_SHIFTER_AUX1] & 0xFFFF0000) |
+                (FLEXIO0->SHIFTBUFEOS[FLEXIO_SHIFTER_AUX0] & 0x0000FFFF);
+
+            *pnt_data_dma_spb =
+                (FLEXIO0->SHIFTBUFEOS[FLEXIO_SHIFTER_AUX1] & 0xFFFF0000) |
+                (FLEXIO0->SHIFTBUFOES[FLEXIO_SHIFTER_AUX0] & 0x0000FFFF) |
+                VCK_BYTE0123;
+
+            pnt_image_pixel0123 += 2;
+            pnt_image_pixel4567 += 2;
+            pnt_data_dma_lpb++;
+            pnt_data_dma_spb++;
+        }
+
+        /* JDI: prepare HST & VCK
+         * LPB first word 0: HST
+         * SPB first word 0: HST + VCK
+         */
+        frame->dma_data[dma_word_count_loc + 0                            ]  = HST_BYTE23;
+        frame->dma_data[dma_word_count_loc + 0 + PIXEL_CLK_25_VCK_LEN_WORD]  = HST_BYTE23 | VCK_BYTE0123;
+
+        /* Skip to next LPB / SPB position */
+        pnt_data_dma_lpb += PIXEL_CLK_25_VCK_LEN_WORD + PIXEL_CLK_25_VCK_NON_DATA_WORD;
+        pnt_data_dma_spb += PIXEL_CLK_25_VCK_LEN_WORD + PIXEL_CLK_25_VCK_NON_DATA_WORD;
+
+        dma_word_count_loc += 2 * PIXEL_CLK_25_VCK_LEN_WORD;
+    }
+
+    /* update parameters */
+    frame->dma_data_word_count = dma_word_count_loc;
+
+    return;
+}
+
+/**
+ * @brief After filling the RGB data, add dma data corresponding to the remaining VCK/XRST data
+ * 
+ * In update mode, RGB data ends on VCK 481 slot, and ENB signal ends on VCK 482 slot.
+ * 
+ * In partial-update mode, The end position of RGB data is determined by how many lines
+ * of RGB data are transferred, and ENB signal ends on the next VCK slot following RGB
+ * data.
+ * 
+ * Fill VCK 484 ~ 486 slots, tfXRST (XRST falling time) and VCK 487.
+ * VCK 488 slot is low level, use delay for a while instead.
+ * 
+ * @param frame Frame for DMA data
+ */
+void jdi_dma_data_add_tail(struct frame_dma_data * frame)
+{
+    uint32_t i_loc;
+    uint32_t dma_word_count_loc;
+
+    if (frame->jdi_enb_disable_status == 0)
+    {	
+        /* Here in update mode, last ENB not added, do it now - add VCK 482/483 */
+        jdi_dma_data_add_jdi_last_enb(frame, 2);
+
+        dma_word_count_loc = frame->dma_data_word_count;
+    }
+    else
+    {
+        dma_word_count_loc = frame->dma_data_word_count;
+
+        if (frame->jdi_enb_disable_status == 1)
+        {
+            /* last ENB added before the tail, implement empty VCK 482/483 */
+
+            /* VCK_482 low */
+            for (i_loc = 0; i_loc != PIXEL_CLK_25_VCK_LEN_WORD; i_loc++)
+            {
+                frame->dma_data[dma_word_count_loc + i_loc] = 0;
+            }
+            dma_word_count_loc += PIXEL_CLK_25_VCK_LEN_WORD;
+
+            /* VCK_483 high */
+            for (i_loc = 0; i_loc != PIXEL_CLK_25_VCK_LEN_WORD; i_loc++)
+            {
+                frame->dma_data[dma_word_count_loc + i_loc] = VCK_BYTE0123;
+            }
+            dma_word_count_loc += PIXEL_CLK_25_VCK_LEN_WORD;
+        }
+    }
+
+    /* VCK_484 low */
+    for (i_loc = 0; i_loc != PIXEL_CLK_25_VCK_LEN_WORD; i_loc++)
+    {
+        frame->dma_data[dma_word_count_loc + i_loc] = 0;
+    }
+    dma_word_count_loc += PIXEL_CLK_25_VCK_LEN_WORD;
+
+    /* VCK_485 high */
+    for (i_loc = 0; i_loc != PIXEL_CLK_25_VCK_LEN_WORD; i_loc++)
+    {
+        frame->dma_data[dma_word_count_loc + i_loc] = VCK_BYTE0123;
+    }
+    dma_word_count_loc += PIXEL_CLK_25_VCK_LEN_WORD;
+
+    /* add slot for XRST falling edge */
+    for (i_loc = 0; i_loc != 1 * 2; i_loc++)
+    {
+        frame->dma_data[dma_word_count_loc + i_loc] = 0x00000000;
+    }
+    dma_word_count_loc += 1 * 2;
+
+    /* VCK_486 low */
+    for (i_loc = 0; i_loc != PIXEL_CLK_25_VCK_LEN_WORD; i_loc++)
+    {
+        frame->dma_data[dma_word_count_loc + i_loc] = 0;
+    }
+    dma_word_count_loc += PIXEL_CLK_25_VCK_LEN_WORD;
+
+    /* VCK_487 high */
+    for (i_loc = 0; i_loc != PIXEL_CLK_25_VCK_LEN_WORD; i_loc++)
+    {
+        frame->dma_data[dma_word_count_loc + i_loc] = VCK_BYTE0123;
+    }
+    dma_word_count_loc += PIXEL_CLK_25_VCK_LEN_WORD;
+
+    /* + 10 us */
+    for (i_loc = 0; i_loc != (DMA_GPIO_TOGGLE_XRST_RE - 1) * 2; i_loc++)
+    {
+        frame->dma_data[dma_word_count_loc + i_loc] = 0;
+    }
+    dma_word_count_loc += (DMA_GPIO_TOGGLE_XRST_RE - 1) * 2;
+
+    /* update parameters */
+    frame->dma_data_word_count  = dma_word_count_loc;
+    /* 1 MOSI data corresponds to 8 clocks, triggering the output of 2 words at the same time */
+    frame->dma_data_clock_count = 4 * dma_word_count_loc;
+
+    return;
+}
+
+/**
+ * @brief Generate SPI MOSI and CLK to trigger send JDI frame.
+ * 
+ * a. Reset XRST_VST_DATA_TIMER TC and restart it
+ * b. Update match value (dma_gpio_match[3]) of XRST falling edge
+ * c. Change ENB pin to FLEXIO function
+ * d. Set MR0 and MR1 of ENB_DATA_TIMER, and restart it
+ * e. Generate SPI MOSI and CLK
+ * 
+ * @param dev is JDI display device
+ */
+void jdi_send_frame(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+    struct jdi_data *dev_data = dev->data;
+    struct frame_dma_data *frame = &dev_data->frame;
+
+    counter_reset(config->timer_dev[XRST_VST_DATA_TIMER]);
+
+	/* rules for setting up MR[2] and dma_gpio_match[3], dma_gpio_match[4]
+	 *
+	 * dma_gpio_match[3] is set to control the XRST falling edge
+	 * MR[2] > dma_gpio_match[3]
+	 * dma_gpio_match[4] > MR[2]
+     *
+     * dma_gpio_match[3] value = The total number of DMAs to be sent - DMA header data number - DMA tail data number
+     * NOTE: MR value counter up with MOSI data, and 1 MOSI data corresponds to 2 words of DMA data, So need to divide by 2
+     * DMA header data number: refer to the jdi_dma_data_add_head function
+     * DMA tail data number: VCK 486 ~ 488 slot
+     */
+	dma_gpio_match[XRST_FE_MATCH_ID] = (frame->dma_data_word_count / 2) -
+                        (DMA_GPIO_TOGGLE_XRST_RE + DMA_GPIO_TOGGLE_VST_RE + DMA_GPIO_TOGGLE_VST_FE) -
+                        PIXEL_CLK_25_VCK_LEN_WORD - (DMA_GPIO_TOGGLE_XRST_RE - 1);
+
+	/* let XRST_VST_DATA_TIMER run */
+	counter_start(config->timer_dev[XRST_VST_DATA_TIMER]);
+
+	// enable FLEXIO @ ENB
+	IOPCTL->PIO[DISPLAY_GEN_ENB_PORT][DISPLAY_GEN_ENB_PIN] = dma_jdi_enb_iocon_flexio;
+
+	/* let CTIMER2 run */
+    enb_m0_dma_match_config.match_config.ticks = frame->jdi_enb_disable;
+    enb_reset_match_config.match_config.ticks = frame->jdi_enb_disable+1;
+    jdi_enb_timer_init(dev);
+
+	counter_start(config->timer_dev[ENB_DATA_TIMER]);
+
+    jdi_flexio_clock_send(dev);
+	return;
+}
+
+/**
+ * @brief Fill line data before or after valid data in partial update mode
+ * 
+ * The 1st line is the 2st VCK slot or the next slot to vaild data, which
+ * contain 1 HST data + 30 empty pixel data.
+ * 
+ * In invalid data area, the VCK slot maintain minimum 1us.
+ * According to SPI CLK, 1 bit 400ns, and shifter 8 lines are transmitted in
+ * parallel, that is, the VCK represented by 1 word is maintained at 1.6us,
+ * 
+ * @param frame Frame for DMA data
+ * @param number_of_lines number of lines to be filled
+ */
+void jdi_dma_data_add_ffwd_line(struct frame_dma_data * frame, uint32_t number_of_lines)
+{
+	uint32_t i_loc;
+	uint32_t dma_word_count_loc;
+
+	dma_word_count_loc = frame->dma_data_word_count;
+
+	if (number_of_lines != 0)
+	{
+		/* The 1st line is the 2st VCK slot, which contain 1 HST data + 30 pixel data */
+		uint32_t *pnt_data_dma_lpb = (uint32_t *)&(frame->dma_data[dma_word_count_loc + 1]);
+
+		for (i_loc = 0; i_loc != (PIXEL_CLK_25_VCK_LEN_WORD - 1); i_loc++)
+		{
+			*pnt_data_dma_lpb = 0;
+
+			pnt_data_dma_lpb++;
+		}
+
+		/* JDI: prepare HST & VCK
+		 * LPB 0: no HST
+		 * SPB 0: no HST + VCK
+         */
+		frame->dma_data[dma_word_count_loc + 0                            ]  = 0;
+        /* twVCKH (VCK High width) */
+		frame->dma_data[dma_word_count_loc + 0 + PIXEL_CLK_25_VCK_LEN_WORD]  = VCK_BYTE0123;
+
+		dma_word_count_loc += 1 * PIXEL_CLK_25_VCK_LEN_WORD + 1;
+
+		/* the rest of ffwed lines (if any) are mins (VCK 1us) */
+		if (number_of_lines > 1)
+		{
+            /* Use 1 word (1.6us) to represent the VCK corresponding to invalid pixel data */
+			for (i_loc = 1; i_loc != number_of_lines; i_loc++)
+			{
+                /* twVCKL (VCK Low width) + no pixel */
+				frame->dma_data[dma_word_count_loc + 0] = 0;
+
+                /* twVCKH (VCK High width) + no pixel */
+				frame->dma_data[dma_word_count_loc + 1] = VCK_BYTE0123;
+
+				dma_word_count_loc += 1 * 2;
+			}
+		}
+	}
+
+	/* update parameters */
+	frame->dma_data_word_count = dma_word_count_loc;
+
+	return;
+}
+
+
+static int jdi_write(const struct device *dev, const uint16_t x,
+                 const uint16_t y,
+                 const struct display_buffer_descriptor *desc,
+                 const void *buf)
+{
+    const struct jdi_config *config = dev->config;
+    struct jdi_data *dev_data = dev->data;
+    uint16_t panel_width = config->display_info.panel_width;
+    uint16_t panel_height = config->display_info.panel_height;
+
+    /* Only supports transferring the entire line of the screen at a time */
+    if (panel_width != desc->width || panel_width != desc->pitch) {
+        return -EINVAL;
+    }
+
+    k_sem_take(&dev_data->sem, K_FOREVER);
+
+    jdi_dma_data_reset(&dev_data->frame);
+
+    /* Generate timing diagrams corresponding to all DMA data */
+    jdi_dma_data_add_head(&dev_data->frame);
+
+    if (desc->height == panel_height) {
+        /* Update mode */
+        jdi_prepare_image_dma_data(&dev_data->frame, (uint8_t *)buf, desc->height);
+    } else {
+        /* Partial update mode */
+        /* Fill line data before pixel data */
+        jdi_dma_data_add_ffwd_line(&dev_data->frame, y);
+
+        /* Convert pixel data to DMA data */
+        jdi_prepare_image_dma_data(&dev_data->frame, (uint8_t *)buf, desc->height);
+
+        /* Fill 1 line data and disable ENB output in partial update mode */
+        jdi_dma_data_add_jdi_last_enb(&dev_data->frame, 1);
+
+        if (panel_height > y + desc->height + 1) {
+            /* Fill line data after pixel data */
+            jdi_dma_data_add_ffwd_line(&dev_data->frame, panel_height - (y + desc->height + 1));
+        }
+
+    }
+    jdi_dma_data_add_tail(&dev_data->frame);
+
+    /* prepare frame's dma descriptors */
+    jdi_pixel_data_m0_dma_config(dev);
+
+    jdi_send_frame(dev);
+
+    k_sem_give(&dev_data->sem);
+    uint8_t channel = 34;
+    LOG_DBG("DMA channel %d CFG %08x\n", channel, DMA0->CHANNEL[channel].CFG);
+    LOG_DBG("DMA channel %d XFERCFG %08x\n", channel, DMA0->CHANNEL[channel].XFERCFG);
+    
+    // printk("\n\n\n\n\n");
+    return 0;
+}
+
+static int jdi_read(const struct device *dev, const uint16_t x,
+                const uint16_t y,
+                const struct display_buffer_descriptor *desc,
+                void *buf)
+{
+    LOG_ERR("Read not implemented");
+    return -ENOTSUP;
+}
+
+static void *jdi_get_framebuffer(const struct device *dev)
+{
+    LOG_ERR("Direct framebuffer access not implemented");
+    return NULL;
+}
+
+static int jdi_display_blanking_off(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+
+    jdi_vcom_control(dev, false);
+
+    if (config->backlight_gpio.port != NULL) {
+        return gpio_pin_set_dt(&config->backlight_gpio, 1);
+    }
+    return -ENOTSUP;
+}
+
+static int jdi_display_blanking_on(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+
+    jdi_vcom_control(dev, true);
+
+    if (config->backlight_gpio.port != NULL) {
+        return gpio_pin_set_dt(&config->backlight_gpio, 0);
+    }
+    return -ENOTSUP;
+}
+
+static int jdi_set_brightness(const struct device *dev,
+                      const uint8_t brightness)
+{
+    LOG_WRN("Set brightness not implemented");
+    return -ENOTSUP;
+}
+
+static int jdi_set_contrast(const struct device *dev,
+                    const uint8_t contrast)
+{
+    LOG_ERR("Set contrast not implemented");
+    return -ENOTSUP;
+}
+
+static int jdi_set_pixel_format(const struct device *dev,
+                    const enum display_pixel_format
+                    pixel_format)
+{
+    struct jdi_data *dev_data = dev->data;
+    ARG_UNUSED(dev_data);
+
+    LOG_ERR("Pixel format change not implemented");
+    return -ENOTSUP;
+}
+
+static int jdi_set_orientation(const struct device *dev,
+        const enum display_orientation orientation)
+{
+    if (orientation == DISPLAY_ORIENTATION_NORMAL) {
+        return 0;
+    }
+    LOG_ERR("Changing display orientation not implemented");
+    return -ENOTSUP;
+}
+
+static void jdi_get_capabilities(const struct device *dev,
+        struct display_capabilities *capabilities)
+{
+    const struct jdi_config *config = dev->config;
+    struct jdi_data *dev_data = dev->data;
+    ARG_UNUSED(dev_data);
+    
+    if (capabilities == NULL) {
+        return;
+    }
+
+    capabilities->x_resolution = config->display_info.panel_width;
+    capabilities->y_resolution = config->display_info.panel_height;
+    capabilities->supported_pixel_formats = PIXEL_FORMAT_RGB_222;
+    return ;
+}
+
+/**
+ * @brief init a ctimer used for send DMA data to SHIFTBUF
+ * 
+ * @param dev JDI display device
+ * @return int 0 on success else negative errno code.
+ */
+static int jdi_pixel_data_timer_init(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+    int ret;
+
+    if (config->timer_dev[PIXEL_DATA_TIMER] == NULL) {
+        return -EINVAL;
+    }
+
+    /* Use a timer to trigger DMA transfer of pixel data.
+     * This timer needs to be configured to trigger counting
+     * on rising and falling edges.
+     * Trigger DMA when counter is 1, reset counter when counter is 2.
+     * Trigger source come from capture pin, that is @ref input_clock output
+     */
+
+    ret = counter_set_channel_alarm(config->timer_dev[PIXEL_DATA_TIMER], 
+                pixel_data_m0_dma_match_config.chan_id, &pixel_data_m0_dma_match_config.match_config);
+    if (ret) {
+        LOG_ERR("set timer %d chanenl %d fail %d", PIXEL_DATA_TIMER, pixel_data_m0_dma_match_config.chan_id, ret);
+        return ret;
+    }
+
+    ret = counter_set_channel_alarm(config->timer_dev[PIXEL_DATA_TIMER],
+    			pixel_clock_m1_dma_match_config.chan_id, &pixel_clock_m1_dma_match_config.match_config);
+    if (ret) {
+    	LOG_ERR("set timer %d chanenl %d fail %d", PIXEL_DATA_TIMER, pixel_clock_m1_dma_match_config.chan_id, ret);
+    	return ret;
+    }
+
+
+    ret = counter_set_channel_alarm(config->timer_dev[PIXEL_DATA_TIMER], 
+                pixel_data_reset_match_config.chan_id, &pixel_data_reset_match_config.match_config);
+    if (ret) {
+        LOG_ERR("set timer %d chanenl %d fail %d", PIXEL_DATA_TIMER, pixel_data_reset_match_config.chan_id, ret);
+        return ret;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief use CTIMER to generate XRST/VST line
+ * 
+ * T1_DMAREQ_M0 drives MATCH update, T1_DMAREQ_M1 drives PIN update.
+ * 
+ * MR[0] is set to 1 so that when CTIMER1 starts counting and reaches
+ * count of 1 this triggers a DMA request that updates MR[1] (MR[1] > MR[0])
+ * 
+ * MR[1] is set to match the point in time when a display line (XRST or VST)
+ * needs update. when CTIMER1 reaches count of MR[1] a DMA trigger is generated
+ * and a pattern is written into the port pin NOT register changing the pins
+ * of interest; at the same time when CTIMER1 count reaches MR[1] this resets
+ * CTIMER1 count, too, letting the CTIMER1 go back to 0 and counting up again,
+ * if CTIMER1 reaches MR[2] the timer stops and resets.
+ * 
+ * in reality when the XRST falling edge is generated (using match/pin arrays'
+ * index 3 entries) CTIMER1 resets and goes back to counting from 1 and the
+ * MR[1] will get updated with match[4]; soon after this the frame will end,
+ * the FLEXCOMM5 isr will execute and CTIMER1 will be stopped and reset in sw;
+ * if for whatever reason FLEXCOMM5 isr does not run soon after the frame ends,
+ * CTIMER1 will reach MR[2] and its hw will do the same thing on its own
+ * 
+ * the last MR[1] update must be made so that MR[1]>MR[2] guaranteeing that
+ * CTIMER1 driven DMA based pin updates will not make any port changes after
+ * the XRST falling edge is generated
+ * 
+ * @param dev JDI display device
+ * @return int 0 on success else negative errno code.
+ */
+int jdi_xrst_vst_timer_init(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+    int ret;
+
+    if (config->timer_dev[XRST_VST_DATA_TIMER] == NULL) {
+        return -EINVAL;
+    }
+
+    ret = counter_set_channel_alarm(config->timer_dev[XRST_VST_DATA_TIMER], 
+                xrst_vst_m0_dma_match_config.chan_id, &xrst_vst_m0_dma_match_config.match_config);
+    if (ret) {
+        LOG_ERR("set timer %d chanenl %d fail %d", XRST_VST_DATA_TIMER, xrst_vst_m0_dma_match_config.chan_id, ret);
+        return ret;
+    }
+
+    counter_set_channel_alarm(config->timer_dev[XRST_VST_DATA_TIMER], 
+                xrst_vst_m1_dma_match_config.chan_id, &xrst_vst_m1_dma_match_config.match_config);
+    if (ret) {
+        LOG_ERR("set timer %d chanenl %d fail %d", XRST_VST_DATA_TIMER, xrst_vst_m1_dma_match_config.chan_id, ret);
+        return ret;
+    }
+
+    counter_set_channel_alarm(config->timer_dev[XRST_VST_DATA_TIMER], 
+                xrst_vst_reset_match_config.chan_id, &xrst_vst_reset_match_config.match_config);
+    if (ret) {
+        LOG_ERR("set timer %d chanenl %d fail %d", XRST_VST_DATA_TIMER, xrst_vst_reset_match_config.chan_id, ret);
+        return ret;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief use CTIMER to generate ENB disable signal
+ * 
+ * use CTIMER2 to disable the ENB output following the last HST generated
+ * The FLEXIO is set to generate HST's matching ENB in the next half-line
+ * 
+ * @param dev JDI display device
+ * @return int 0 on success else negative errno code.
+ */
+static int jdi_enb_timer_init(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+    int ret;
+
+    if (config->timer_dev[ENB_DATA_TIMER] == NULL) {
+        return -EINVAL;
+    }
+
+    ret = counter_set_channel_alarm(config->timer_dev[ENB_DATA_TIMER], 
+                enb_m0_dma_match_config.chan_id, &enb_m0_dma_match_config.match_config);
+    if (ret) {
+        LOG_ERR("set timer %d chanenl %d fail %d", ENB_DATA_TIMER, enb_m0_dma_match_config.chan_id, ret);
+        return ret;
+    }
+
+    ret = counter_set_channel_alarm(config->timer_dev[ENB_DATA_TIMER], 
+                enb_reset_match_config.chan_id, &enb_reset_match_config.match_config);
+    if (ret) {
+        LOG_ERR("set timer %d chanenl %d fail %d", ENB_DATA_TIMER, enb_reset_match_config.chan_id, ret);
+        return ret;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief FLEXIO SHIFTER configure
+ * 
+ * Use SHIFTER0 to load RGB/VCK/HST data from SHIFTBUF0, and send to [FLEXIOD4, FLEXIOD11].
+ * The FLEXIO timer which SHIFTER used is external trigger source from SPI CLK
+ * SPI CLK also is shifter clock, and the cycle time of the clock is exactly equal to the
+ * time of RGB 1bit. Therefore in 1 MOSI data (8 SPI CLK), 8 bytes of pixel data are sent. 
+ * That is 1 MOSI data trigger the DMA of CTIMER0 MR0 to send 2 words of pixel data to SHIFTBUF.
+ * So FLEXIO need use 2 SHIFTBUF to receive data. It need to initialize 2 shifters
+ * 
+ * @param dev is JDI display device
+ */
+static void jdi_pixel_data_flexio_shifter_config(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+
+    /* SHIFTER0 support parallel transmit, so we use SHIFTER0 to send pixel data */
+    const flexio_shifter_config_t pixel_data_shifter0_cfg = {
+        .timerSelect = FLEXIO_TIMER_PIXEL,		/* FLEXIO_TIMER_PIXEL is used for controlling the logic/shift register 
+                                                   and generating the Shift clock */
+        .timerPolarity = kFLEXIO_ShifterTimerPolarityOnPositive, /*  Shift on posedge of Shift clock */
+        .pinConfig = kFLEXIO_PinConfigOutput,	/* Shifter pin output */
+        .pinSelect = 4,							/* FXIO_D4:FXIO_D[4 + PWIDTH] pin is used for SHIFTER0 output */
+        .parallelWidth = 7,						/* Parallel transmission 8 bit, there are RGB/VCK/HST data */
+        .pinPolarity = kFLEXIO_PinActiveHigh,	/* Pin is active high */
+        .shifterMode = kFLEXIO_ShifterModeTransmit, /* Transmit mode */
+        .inputSource = kFLEXIO_ShifterInputFromNextShifterOutput, /* Input Source: Shifter N+1 Output */
+        .shifterStop = kFLEXIO_ShifterStopBitDisable, 	/* Disable shifter stop bit */
+        .shifterStart = kFLEXIO_ShifterStartBitDisabledLoadDataOnEnable,	/* Disable shifter start bit */
+    };
+
+    FLEXIO_SetShifterConfig(config->flexio_base, FLEXIO_SHIFTER_PIXEL, &pixel_data_shifter0_cfg);
+    LOG_DBG("\nshifter0 SHIFTCFG %08x, SHIFTCTL %08x\n", config->flexio_base->SHIFTCFG[FLEXIO_SHIFTER_PIXEL], 
+                            config->flexio_base->SHIFTCTL[FLEXIO_SHIFTER_PIXEL]);
+
+    const flexio_shifter_config_t pixel_data_shifter1_cfg = {
+        .timerSelect = FLEXIO_TIMER_PIXEL,		/* FLEXIO_TIMER_PIXEL is used for controlling the logic/shift register 
+                                                   and generating the Shift clock */
+        .timerPolarity = kFLEXIO_ShifterTimerPolarityOnPositive, /*  Shift on posedge of Shift clock */
+        .pinConfig = kFLEXIO_PinConfigOutputDisabled,	/* Shifter pin output disabled */
+        .pinSelect = 0,							/* pin selected: NA */
+        .parallelWidth = 7,						/* Parallel transmission 8 bit, there are RGB/VCK/HST data */
+        .pinPolarity = kFLEXIO_PinActiveHigh,	/* Pin is active high */
+        .shifterMode = kFLEXIO_ShifterModeTransmit, /* Transmit mode */
+        .inputSource = kFLEXIO_ShifterInputFromNextShifterOutput, /* Input Source: Shifter N+1 Output */
+        .shifterStop = kFLEXIO_ShifterStopBitDisable, 	/* Disable shifter stop bit */
+        .shifterStart = kFLEXIO_ShifterStartBitDisabledLoadDataOnEnable,	/* Disable shifter start bit */
+    };
+
+    FLEXIO_SetShifterConfig(config->flexio_base, FLEXIO_SHIFTER_PIXEL_ADD, &pixel_data_shifter1_cfg);
+    LOG_DBG("\nshifter1 SHIFTCFG %08x, SHIFTCTL %08x\n", config->flexio_base->SHIFTCFG[FLEXIO_SHIFTER_PIXEL_ADD], 
+                            config->flexio_base->SHIFTCTL[FLEXIO_SHIFTER_PIXEL_ADD]);
+
+    /* make sure auxiliary shifters are not configured. Use this to separate odd and even bits in preparation for LPB and SPB */
+    FLEXIO0->SHIFTCTL[FLEXIO_SHIFTER_AUX0] = 0;
+    FLEXIO0->SHIFTCTL[FLEXIO_SHIFTER_AUX1] = 0;
+}
+
+/**
+ * @brief Shifter timer configure
+ * 
+ * The timer used by SHIFTER use external trigger source from SPI CLK.
+ * Therefore make sure that the SPI CLK is connected to FLEXIO_D13 on the hardware wiring.
+ * According to JDI timing requirements, the period of SPI CLK must be above 400ns.
+ * 
+ * @param dev is JDI display device
+ */
+static void jdi_pixel_data_flexio_timer_config(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+
+    /* flexio timer init, which is clock as pixel data shifter */
+    const flexio_timer_config_t pixel_data_timer_cfg = {
+        /* Trigger. */
+        .triggerSelect = FLEXIO_TIMER_TRIGGER_SEL_PININPUT(FLEXIO_TIMER_TRIG_PIN), /* FLEXIO_D13 used as FLEXIO_TIMER_PIXEL trigger */
+        .triggerPolarity = kFLEXIO_TimerTriggerPolarityActiveHigh,				   /* Trigger active high */
+        .triggerSource = kFLEXIO_TimerTriggerSourceInternal,					   /* Internal trigger selected */
+        /* Pin. */
+        .pinConfig = kFLEXIO_PinConfigOutputDisabled,							   /* Timer pin output disabled */
+        .pinSelect = 0,															   /* Timer Pin Select - NA */
+        .pinPolarity = kFLEXIO_PinActiveHigh,									   /* Pin is active - NA */
+        /* Timer. */
+        .timerMode = kFLEXIO_TimerModeSingle16Bit,								   /* Single 16-bit counter mode */
+        .timerOutput = kFLEXIO_TimerOutputZeroNotAffectedByReset,				   /* Timer output is logic zero when enabled and is not affected by timer reset */
+        .timerDecrement = 7,													   /* Decrement counter on Trigger input (rising edge), Shift clock equals Trigger input */
+        .timerReset = kFLEXIO_TimerResetNever,									   /* Timer never reset */
+        .timerDisable = kFLEXIO_TimerDisableNever,						           /* Timer never disabled */
+        .timerEnable = kFLEXIO_TimerEnabledAlways,								   /* Timer always enabled */
+        .timerStop = kFLEXIO_TimerStopBitDisabled,								   /* Stop bit disabled */
+        .timerStart = kFLEXIO_TimerStartBitDisabled,							   /* Start bit disabled */
+        .timerCompare = (8 - 1),												   /* reload shifter control: 4-line parallel interface <=> 32/4 = 8. 
+                                                                                    * When the shift clock source is a pin or trigger input, 
+                                                                                    * the compare register is used to set the number of bits in each
+                                                                                    * word equal to (CMP[15:0] + 1) / 2.
+                                                                                    */
+    };
+
+    FLEXIO_SetTimerConfig(config->flexio_base, FLEXIO_TIMER_PIXEL, &pixel_data_timer_cfg);
+    LOG_DBG("\nflexio pixel data timer TIMCFG %08x, TIMCTL %08x, TIMCMP %08x\n", config->flexio_base->TIMCFG[FLEXIO_TIMER_PIXEL], 
+                            config->flexio_base->TIMCTL[FLEXIO_TIMER_PIXEL], config->flexio_base->TIMCMP[FLEXIO_TIMER_PIXEL]);
+
+}
+
+/**
+ * @brief FELXIO initialization related to pixel data
+ * 
+ * @param dev is JDI display device
+ */
+static void jdi_pixel_data_flexio_config(const struct device *dev)
+{
+    jdi_pixel_data_flexio_shifter_config(dev);
+    jdi_pixel_data_flexio_timer_config(dev);
+}
+
+/**
+ * @brief HCK FLEXIO timer configure
+ * 
+ * When the HST signal occurs and continues tsHST (HST set-up time), the HCK signal needs
+ * to be generated.
+ * 
+ * HCK trigger timer is triggered by HST rising edge. According to the current code, the
+ * HST signal remains high for 800ns+, so config lower 8-bits of TIMCMP as 56 (based on FLEXIO
+ * CLOCK about 600ns). When the lower 8-bits equal zero, toggle FLEXIO_D15 output and disable
+ * decrement until next HST rising edge trigger.
+ * 
+ * HCK timer is triggered by FLEXIO_D15, the output of HCK trigger timer and output HCK signal,
+ * There are 122 HCK slots, so upper 8-bits of TIMCMP is 122.
+ *
+ * 
+ * @param dev is JDI display device
+ */
+static void jdi_hck_flexio_timer_config(const struct device *dev)
+{
+    uint32_t main_clk_freq = CLOCK_GetMainClkFreq();
+    uint32_t flexio_clk_freq = CLOCK_GetFlexioClkFreq();
+    LOG_DBG("\nMain Clock Freq %d, FLEXIO Clock Freq %d\n", main_clk_freq, flexio_clk_freq);
+
+    /* TIMCMP value of HCK trigger timer is based on 96M FLEXIO clock frequency */
+    assert(flexio_clk_freq == 96000000);
+
+    const struct jdi_config *config = dev->config;
+
+    /* HCK trigger timer init */
+    const flexio_timer_config_t hck_trigger_timer_cfg = {
+        /* Trigger. */
+        .triggerSelect = FLEXIO_TIMER_TRIGGER_SEL_PININPUT(FLEXIO_SHIFTER_PIN_HST), /* FLEXIO_D11(HST) used as FLEXIO_TIMER_HCK_TRIGGER trigger */
+        .triggerPolarity = kFLEXIO_TimerTriggerPolarityActiveHigh,				   /* Trigger active high */
+        .triggerSource = kFLEXIO_TimerTriggerSourceInternal,					   /* Internal trigger selected */
+        /* Pin. */
+        .pinConfig = kFLEXIO_PinConfigOutput,							   		   /* Timer pin output */
+        .pinSelect = FLEXIO_HCK_TRIG_PIN,										   /* Timer Pin Select - FLEXIO_HCK_TRIG_PIN (FLEXIO_D15) */
+        .pinPolarity = kFLEXIO_PinActiveHigh,									   /* Pin is active high */
+        /* Timer. */
+        .timerMode = kFLEXIO_TimerModeDual8BitBaudBit,							   /* 8-bit baud counter mode */
+        .timerOutput = kFLEXIO_TimerOutputZeroAffectedByReset,					   /* Timer output is logic zero when enabled and on timer reset */
+        .timerDecrement = kFLEXIO_TimerDecSrcOnFlexIOClockShiftTimerOutput,		   /* Decrement counter on FlexIO clock, Shift clock equals Timer output */
+        .timerReset = kFLEXIO_TimerResetNever,									   /* Timer never reset */
+        .timerDisable = kFLEXIO_TimerDisableOnTimerCompare,						   /* Timer disabled on Timer compare (upper 8-bits match and decrement) */
+        .timerEnable = kFLEXIO_TimerEnableOnTriggerRisingEdge,					   /* Timer enabled on Trigger rising edge */
+        .timerStop = kFLEXIO_TimerStopBitDisabled,								   /* Stop bit disabled */
+        .timerStart = kFLEXIO_TimerStartBitDisabled,							   /* Start bit disabled */
+        .timerCompare = ((2-1)<<8 | (56-1)<<0),									   /* 8-bit baud counter mode <=> number of bits + clock divider/delay.
+                                                                                    * When the lower 8-bits decrement to zero, the timer output is toggled
+                                                                                    * and the lower 8-bits reload from the compare register. The upper 8-bits
+                                                                                    * decrement when the lower 8-bits equal zero and decrement.
+                                                                                    */
+    };
+
+    FLEXIO_SetTimerConfig(config->flexio_base, FLEXIO_TIMER_HCK_TRIGGER, &hck_trigger_timer_cfg);
+    LOG_DBG("\nflexio HCK trigger timer TIMCFG %08x, TIMCTL %08x, TIMCMP %08x\n", config->flexio_base->TIMCFG[FLEXIO_TIMER_HCK_TRIGGER], 
+                            config->flexio_base->TIMCTL[FLEXIO_TIMER_HCK_TRIGGER], config->flexio_base->TIMCMP[FLEXIO_TIMER_HCK_TRIGGER]);
+
+    /* HCK timer init */
+    const flexio_timer_config_t hck_timer_cfg = {
+        /* Trigger. */
+        .triggerSelect = FLEXIO_TIMER_TRIGGER_SEL_PININPUT(FLEXIO_HCK_TRIG_PIN), /* FLEXIO_D15(HCK trigger timer output) used as FLEXIO_TIMER_HCK trigger */
+        .triggerPolarity = kFLEXIO_TimerTriggerPolarityActiveHigh,				   /* Trigger active high */
+        .triggerSource = kFLEXIO_TimerTriggerSourceInternal,					   /* Internal trigger selected */
+        /* Pin. */
+        .pinConfig = kFLEXIO_PinConfigOutput,							   		   /* Timer pin output */
+        .pinSelect = FLEXIO_TIMER_HCK_PIN,										   /* Timer Pin Select - FLEXIO_TIMER_HCK_PIN (FLEXIO_D12) */
+        .pinPolarity = kFLEXIO_PinActiveHigh,									   /* Pin is active high */
+        /* Timer. */
+        .timerMode = kFLEXIO_TimerModeDual8BitBaudBit,							   /* 8-bit baud counter mode */
+        .timerOutput = kFLEXIO_TimerOutputOneAffectedByReset,					   /* Timer output is logic one when enabled and on timer reset */
+        .timerDecrement = kFLEXIO_TimerDecSrcOnPinInputShiftPinInput,		 	   /* Decrement counter on Pin input (both edges), Shift clock equals Pin input */
+        .timerReset = kFLEXIO_TimerResetNever,									   /* Timer never reset */
+        .timerDisable = kFLEXIO_TimerDisableOnTimerCompare,						   /* Timer disabled on Timer compare (upper 8-bits match and decrement) */
+        .timerEnable = kFLEXIO_TimerEnableOnTriggerRisingEdge,					   /* Timer enabled on Trigger rising edge */
+        .timerStop = kFLEXIO_TimerStopBitDisabled,								   /* Stop bit disabled */
+        .timerStart = kFLEXIO_TimerStartBitDisabled,							   /* Start bit disabled */
+        .timerCompare = ((122-1)<<8 | (2-1)<<0),								   /* 8-bit baud counter mode <=> number of bits + clock divider */
+    };
+
+    FLEXIO_SetTimerConfig(config->flexio_base, FLEXIO_TIMER_HCK, &hck_timer_cfg);
+    /* the timer input pin is a different pin from the timer output pin. PINSEL must select an even
+     * numbered pin when this bit is set, so the output pin is even numbered and input pin is odd numbered.
+     * Timer pin input is selected by PINSEL+1 (FLEXIO_D13, also is SPI5 CLK)
+     */
+    FLEXIO0->TIMCTL[FLEXIO_TIMER_HCK] |= FLEXIO_TIMCTL_PININS(1);
+    LOG_DBG("\nflexio HCK timer TIMCFG %08x, TIMCTL %08x, TIMCMP %08x\n", config->flexio_base->TIMCFG[FLEXIO_TIMER_HCK], 
+                            config->flexio_base->TIMCTL[FLEXIO_TIMER_HCK], config->flexio_base->TIMCMP[FLEXIO_TIMER_HCK]);
+
+}
+
+/**
+ * @brief FELXIO initialization related to HCK
+ * 
+ * @param dev is JDI display device
+ */
+static void jdi_hck_flexio_config(const struct device *dev)
+{
+    jdi_hck_flexio_timer_config(dev);
+}
+
+static void jdi_enb_flexio_timer_config(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+
+    /* ENB timer init */
+    /* FLEXIO_TIMER_ENB_0: generate a pulse (@HCK 115, 116,117) */
+    const flexio_timer_config_t enb0_timer_cfg = {
+        /* Trigger. */
+        .triggerSelect = FLEXIO_TIMER_TRIGGER_SEL_PININPUT(FLEXIO_TIMER_TRIG_PIN), /* FLEXIO_D13(SPI CLK) used as FLEXIO_TIMER_ENB_0 trigger */
+        .triggerPolarity = kFLEXIO_TimerTriggerPolarityActiveHigh,				   /* Trigger active high */
+        .triggerSource = kFLEXIO_TimerTriggerSourceInternal,					   /* Internal trigger selected */
+        /* Pin. */
+        .pinConfig = kFLEXIO_PinConfigOutput,							   		   /* Timer pin output */
+        .pinSelect = FLEXIO_TIMER_ENB_0_OUT_PIN,								   /* Timer Pin Select - FLEXIO_TIMER_ENB_0_OUT_PIN (FLEXIO_D14) */
+        .pinPolarity = kFLEXIO_PinActiveHigh,									   /* Pin is active high */
+        /* Timer. */
+        .timerMode = 6,							   								   /* Dual 8-bit counters PWM low mode */
+        .timerOutput = kFLEXIO_TimerOutputZeroNotAffectedByReset,				   /* Timer output is logic zero when enabled and is not affected by timer reset */
+        .timerDecrement = kFLEXIO_TimerDecSrcOnTriggerInputShiftTriggerInput,	   /* Decrement counter on Trigger input (both edges), Shift clock equals Trigger input */
+        .timerReset = kFLEXIO_TimerResetNever,									   /* Timer never reset */
+        .timerDisable = kFLEXIO_TimerDisableOnTimerCompare,						   /* Timer disabled on Timer compare (upper 8-bits match and decrement) */
+        .timerEnable = kFLEXIO_TimerEnableOnPrevTimerEnable,					   /* Timer enabled on Timer N-1 enable */
+        .timerStop = kFLEXIO_TimerStopBitDisabled,								   /* Stop bit disabled */
+        .timerStart = kFLEXIO_TimerStartBitDisabled,							   /* Start bit disabled */
+        .timerCompare = ((6-1)<<8 | (228-1)<<0),								   /* Dual 8-bit counters PWM high mode: HIGH + LOW */
+    };
+
+    FLEXIO_SetTimerConfig(config->flexio_base, FLEXIO_TIMER_ENB_0, &enb0_timer_cfg);
+    LOG_DBG("\nflexio ENB 0 timer TIMCFG %08x, TIMCTL %08x, TIMCMP %08x\n", config->flexio_base->TIMCFG[FLEXIO_TIMER_ENB_0], 
+                            config->flexio_base->TIMCTL[FLEXIO_TIMER_ENB_0], config->flexio_base->TIMCMP[FLEXIO_TIMER_ENB_0]);
+
+    /* FLEXIO_TIMER_ENB_1: enabled by pin FLEXIO_TIMER_ENB_0_OUT_PIN */
+    const flexio_timer_config_t enb1_timer_cfg = {
+        /* Trigger. */
+        .triggerSelect = FLEXIO_TIMER_TRIGGER_SEL_PININPUT(FLEXIO_TIMER_TRIG_PIN), /* FLEXIO_D13(SPI CLK) used as FLEXIO_TIMER_ENB_0 trigger */
+        .triggerPolarity = kFLEXIO_TimerTriggerPolarityActiveHigh,				   /* Trigger active high */
+        .triggerSource = kFLEXIO_TimerTriggerSourceInternal,					   /* Internal trigger selected */
+        /* Pin. */
+        .pinConfig = kFLEXIO_PinConfigOutputDisabled,					 		   /* Timer pin output disabled */
+        .pinSelect = FLEXIO_TIMER_ENB_0_OUT_PIN,								   /* Timer Pin Select - FLEXIO_TIMER_ENB_0_OUT_PIN (FLEXIO_D14) */
+        .pinPolarity = kFLEXIO_PinActiveHigh,									   /* Pin is active high */
+        /* Timer. */
+        .timerMode = 6,							   								   /* Dual 8-bit counters PWM low mode */
+        .timerOutput = kFLEXIO_TimerOutputZeroNotAffectedByReset,				   /* Timer output is logic zero when enabled and is not affected by timer reset */
+        .timerDecrement = kFLEXIO_TimerDecSrcOnTriggerInputShiftTriggerInput,	   /* Decrement counter on Trigger input (both edges), Shift clock equals Trigger input */
+        .timerReset = kFLEXIO_TimerResetNever,									   /* Timer never reset */
+        .timerDisable = kFLEXIO_TimerDisableOnTimerCompare,						   /* Timer disabled on Timer compare (upper 8-bits match and decrement) */
+        .timerEnable = kFLEXIO_TimerEnableOnPinRisingEdge,						   /* Timer enabled on Pin rising edge */
+        .timerStop = kFLEXIO_TimerStopBitDisabled,								   /* Stop bit disabled */
+        .timerStart = kFLEXIO_TimerStartBitDisabled,							   /* Start bit disabled */
+        .timerCompare = ((2-1)<<8 | (2-1)<<0),								   	   /* Dual 8-bit counters PWM high mode: HIGH + LOW */
+    };
+
+    FLEXIO_SetTimerConfig(config->flexio_base, FLEXIO_TIMER_ENB_1, &enb1_timer_cfg);
+    LOG_DBG("\nflexio ENB 1 timer TIMCFG %08x, TIMCTL %08x, TIMCMP %08x\n", config->flexio_base->TIMCFG[FLEXIO_TIMER_ENB_1], 
+                            config->flexio_base->TIMCTL[FLEXIO_TIMER_ENB_1], config->flexio_base->TIMCMP[FLEXIO_TIMER_ENB_1]);
+
+    /* FLEXIO_TIMER_ENB_2: generate a pulse half-a-line later... */
+    const flexio_timer_config_t enb2_timer_cfg = {
+        /* Trigger. */
+        .triggerSelect = FLEXIO_TIMER_TRIGGER_SEL_PININPUT(FLEXIO_TIMER_TRIG_PIN), /* FLEXIO_D13(SPI CLK) used as FLEXIO_TIMER_ENB_0 trigger */
+        .triggerPolarity = kFLEXIO_TimerTriggerPolarityActiveHigh,				   /* Trigger active high */
+        .triggerSource = kFLEXIO_TimerTriggerSourceInternal,					   /* Internal trigger selected */
+        /* Pin. */
+        .pinConfig = kFLEXIO_PinConfigOutput,					 		   		   /* Timer pin output */
+        .pinSelect = FLEXIO_TIMER_ENB_PIN,								   	   	   /* Timer Pin Select - FLEXIO_TIMER_ENB_PIN (FLEXIO_D3) */
+        .pinPolarity = kFLEXIO_PinActiveHigh,									   /* Pin is active high */
+        /* Timer. */
+        .timerMode = 6,							   								   /* Dual 8-bit counters PWM low mode */
+        .timerOutput = kFLEXIO_TimerOutputZeroNotAffectedByReset,				   /* Timer output is logic zero when enabled and is not affected by timer reset */
+        .timerDecrement = kFLEXIO_TimerDecSrcOnTriggerInputShiftTriggerInput,	   /* Decrement counter on Trigger input (both edges), Shift clock equals Trigger input */
+        .timerReset = kFLEXIO_TimerResetNever,									   /* Timer never reset */
+        .timerDisable = kFLEXIO_TimerDisableOnTimerCompare,						   /* Timer disabled on Timer compare (upper 8-bits match and decrement) */
+        .timerEnable = kFLEXIO_TimerEnableOnPrevTimerEnable,					   /* Timer enabled on Timer N-1 enable */
+        .timerStop = kFLEXIO_TimerStopBitDisabled,								   /* Stop bit disabled */
+        .timerStart = kFLEXIO_TimerStartBitDisabled,							   /* Start bit disabled */
+        .timerCompare = ((124-1)<<8 | (83-1)<<0),							   	   /* Dual 8-bit counters PWM high mode: HIGH + LOW */
+    };
+
+    FLEXIO_SetTimerConfig(config->flexio_base, FLEXIO_TIMER_ENB_2, &enb2_timer_cfg);
+    LOG_DBG("\nflexio ENB 2 timer TIMCFG %08x, TIMCTL %08x, TIMCMP %08x\n", config->flexio_base->TIMCFG[FLEXIO_TIMER_ENB_2], 
+                            config->flexio_base->TIMCTL[FLEXIO_TIMER_ENB_2], config->flexio_base->TIMCMP[FLEXIO_TIMER_ENB_2]);
+}
+
+/**
+ * @brief FELXIO initialization related to ENB
+ * 
+ * @param dev is JDI display device
+ */
+static void jdi_enb_flexio_config(const struct device *dev)
+{
+    jdi_enb_flexio_timer_config(dev);
+}
+
+static int jdi_flexio_setup(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+
+    uint32_t main_clk_freq = CLOCK_GetMainClkFreq();
+    uint32_t flexio_clk_freq = CLOCK_GetFlexioClkFreq();
+    LOG_DBG("\nMain Clock Freq %d, FLEXIO Clock Freq %d\n", main_clk_freq, flexio_clk_freq);
+
+    /* init flexio */
+    flexio_config_t flexio_config;
+    FLEXIO_GetDefaultConfig(&flexio_config);
+
+    FLEXIO_Init(config->flexio_base, &flexio_config);
+
+    jdi_pixel_data_flexio_config(dev);
+
+    jdi_hck_flexio_config(dev);
+    
+    jdi_enb_flexio_config(dev);
+
+    return 0;
+}
+
+static int jdi_init(const struct device *dev)
+{
+    const struct jdi_config *config = dev->config;
+    struct jdi_data *dev_data = dev->data;
+    int err;
+
+    err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+    if (err) {
+        return err;
+    }
+
+    /* init VST / XRST GPIO pin */
+    for (uint8_t i = 0; i < JDI_MAX_GPIO_NUM; i++) {
+        err = gpio_pin_configure_dt(&config->jdi_gpios[i].gpio, GPIO_OUTPUT_INACTIVE);
+        if (err) {
+            return err;
+        }
+    }
+
+    if (config->backlight_gpio.port != NULL) {
+        err = gpio_pin_configure_dt(&config->backlight_gpio, GPIO_OUTPUT_ACTIVE);
+        if (err) {
+            return err;
+        }
+    }
+
+    jdi_flexio_setup(dev);
+
+    err = jdi_pixel_data_timer_init(dev);
+    if (err) {
+        LOG_ERR("pixel data timer init fail %d", err);
+        return err;
+    }
+
+    err = jdi_xrst_vst_timer_init(dev);
+    if (err) {
+        LOG_ERR("xrst/vst timer init fail %d", err);
+        return err;
+    }
+
+    err = jdi_enb_timer_init(dev);
+    if (err) {
+        LOG_ERR("enb timer init fail %d", err);
+        return err;
+    }
+
+    /* Set fixed DMA configuration */
+    err = jdi_xrst_vst_m0_dma_config(dev);
+    if (err) {
+        LOG_ERR("xrst/vst timer match0 dma config fail %d", err);
+        return err;
+    }
+    err = jdi_xrst_vst_m1_dma_config(dev);
+    if (err) {
+        LOG_ERR("xrst/vst timer match1 dma config fail %d", err);
+        return err;
+    }
+
+    err = jdi_enb_m0_dma_config(dev);
+    if (err) {
+        LOG_ERR("enb timer match0 dma config fail %d", err);
+        return err;
+    }
+
+    k_sem_init(&dev_data->sem, 0, 1);
+    k_sem_give(&dev_data->sem);
+
+    return 0;
+}
+
+static const struct display_driver_api flexio_jdi_api = {
+    .blanking_on = jdi_display_blanking_on,
+    .blanking_off = jdi_display_blanking_off,
+    .write = jdi_write,
+    .read = jdi_read,
+    .get_framebuffer = jdi_get_framebuffer,
+    .set_brightness = jdi_set_brightness,
+    .set_contrast = jdi_set_contrast,
+    .get_capabilities = jdi_get_capabilities,
+    .set_pixel_format = jdi_set_pixel_format,
+    .set_orientation = jdi_set_orientation,
+};
+
+#define BACKLIGHT_GPIO_INIT(id)				\
+        COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(id), backlight_gpios),	\
+        (GPIO_DT_SPEC_INST_GET(id, backlight_gpios)), \
+        ({							\
+            .port = NULL,			\
+            .pin = 0,				\
+            .dt_flags = 0,			\
+        }))
+
+#define JDI_CLOCK_CONFIG(id, name)				\
+        COND_CODE_1(DT_INST_CLOCKS_HAS_NAME(id, name), 		\
+            (DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_NAME(id, name))),	\
+            (NULL))
+
+#define JDI_TIMER_DEV_CONFIG(id, name)				\
+        COND_CODE_1(DT_INST_PROP_HAS_NAME(id, timers, name), 		\
+            (DEVICE_DT_GET(DT_INST_PHANDLE_BY_NAME(id, timers, name))),	\
+            (NULL))
+
+#define JDI_TIMER_REG_ADDR_CONFIG(id, name)				\
+        COND_CODE_1(DT_INST_PROP_HAS_NAME(id, timers, name), 		\
+            (DT_REG_ADDR_BY_IDX(DT_INST_PHANDLE_BY_NAME(id, timers, name), 0)),	\
+            (0))
+
+#define JDI_TIMERS_CONFIG(id)						\
+    .timer_dev	= {									\
+        JDI_TIMER_DEV_CONFIG(id, pixel),			\
+        JDI_TIMER_DEV_CONFIG(id, xrst),				\
+        JDI_TIMER_DEV_CONFIG(id, enb),				\
+    },												\
+    .ctimer_base = {									\
+        (const CTIMER_Type*)JDI_TIMER_REG_ADDR_CONFIG(id, pixel),			\
+        (const CTIMER_Type*)JDI_TIMER_REG_ADDR_CONFIG(id, xrst),			\
+        (const CTIMER_Type*)JDI_TIMER_REG_ADDR_CONFIG(id, enb),				\
+    },
+
+#define JDI_GPIO_CONFIG(id, name)                   \
+        {                                           \
+            .gpio = {                               \
+                .port = DEVICE_DT_GET(DT_INST_PHANDLE_BY_NAME(id, gpios, name)),     \
+                .pin = DT_INST_PHA_BY_NAME(id, gpios, name, pin),            \
+                .dt_flags = DT_INST_PHA_BY_NAME(id, gpios, name, flags),     \
+            },                                      \
+            .gpio_base = (const GPIO_Type *)DT_REG_ADDR_BY_IDX(DT_INST_PHANDLE_BY_NAME(id, gpios, name), 0), \
+            .port_no = DT_PROP(DT_INST_PHANDLE_BY_NAME(id, gpios, name), port),           \
+        }
+
+
+#define JDI_GPIOS_CONFIG(id)                        \
+    .jdi_gpios = {                                  \
+        [VST_GPIO] = JDI_GPIO_CONFIG(id, vst),      \
+        [XRST_GPIO] = JDI_GPIO_CONFIG(id, xrst),    \
+    },
+
+#define FLEXIO_JDI_DEVICE(id)							\
+    PINCTRL_DT_INST_DEFINE(id);							\
+    /* static void flexio_jdi_config_func_##id(const struct device *dev); */	\
+    static const struct jdi_config jdi_config_##id = {	\
+        .flexio_base = (FLEXIO_Type *) DT_INST_REG_ADDR(id),			\
+        .display_info = {							\
+            .panel_width = DT_INST_PROP(id, width),			\
+            .panel_height = DT_INST_PROP(id, height),		\
+        },								\
+        .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),			\
+        .vcom_clock = JDI_CLOCK_CONFIG(id, vcom),	\
+        .input_clock = JDI_CLOCK_CONFIG(id, input_clock),	\
+        .backlight_gpio = BACKLIGHT_GPIO_INIT(id),	\
+        JDI_TIMERS_CONFIG(id)				        \
+        JDI_GPIOS_CONFIG(id)                        \
+    };									\
+    static struct jdi_data flexio_jdi_data_##id;			\
+    DEVICE_DT_INST_DEFINE(id,						\
+                &jdi_init,					\
+                NULL,						\
+                &flexio_jdi_data_##id,				\
+                &jdi_config_##id,				\
+                POST_KERNEL,					\
+                CONFIG_DISPLAY_INIT_PRIORITY,			\
+                &flexio_jdi_api);
+
+
+DT_INST_FOREACH_STATUS_OKAY(FLEXIO_JDI_DEVICE)

--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -247,7 +247,7 @@ static int dma_mcux_lpc_configure(const struct device *dev, uint32_t channel,
 		block_config = block_config->next_block;
 
 		while (block_config != NULL) {
-			next_transfer = data->curr_transfer + sizeof(dma_descriptor_t);
+			next_transfer = data->curr_transfer + 1;
 
 			/* Ensure descriptor is aligned */
 			next_transfer = (dma_descriptor_t *)ROUND_UP(
@@ -445,7 +445,7 @@ static int dma_mcux_lpc_reload(const struct device *dev, uint32_t channel,
 			next_transfer = data->dma_descriptor_table;
 			data->descriptor_index = 1;
 		} else {
-			next_transfer = data->curr_transfer + sizeof(dma_descriptor_t);
+			next_transfer = data->curr_transfer + 1;
 			data->descriptor_index++;
 		}
 		/* Ensure descriptor is aligned */

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -80,6 +80,11 @@ static inline bool spi_context_configured(struct spi_context *ctx,
 	return !!(ctx->config == config);
 }
 
+static inline bool spi_buf_addr_nochange(const struct spi_buf *current)
+{
+	return current->addr_nochange;
+}
+
 static inline bool spi_context_is_slave(struct spi_context *ctx)
 {
 	return (ctx->config->operation & SPI_OP_MODE_SLAVE);

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -518,6 +518,9 @@ static int spi_mcux_dma_rx_load(const struct device *dev, uint8_t *buf,
 	if (buf == NULL) {
 		/* if rx buff is null, then write data to dummy address. */
 		blk_cfg->dest_address = (uint32_t)&dummy_rx_buffer;
+		/* The address cannot be incremented automatically, otherwise the buffer will overflow  */
+		blk_cfg->source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+		blk_cfg->dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 	} else {
 		blk_cfg->dest_address = (uint32_t)buf;
 	}

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -13,7 +13,7 @@
 #include <fsl_spi.h>
 #include <zephyr/logging/log.h>
 #ifdef CONFIG_SPI_MCUX_FLEXCOMM_DMA
-#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/dma/dma_mcux_lpc.h>
 #endif
 #ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
@@ -48,8 +48,6 @@ struct spi_mcux_config {
 #define SPI_MCUX_FLEXCOMM_DMA_TX_DONE_FLAG	0x04
 #define SPI_MCUX_FLEXCOMM_DMA_DONE_FLAG		\
 	(SPI_MCUX_FLEXCOMM_DMA_RX_DONE_FLAG | SPI_MCUX_FLEXCOMM_DMA_TX_DONE_FLAG)
-
-#define DMA_MAX_TRANS_NUM	(1024)
 
 struct stream {
 	const struct device *dma_dev;

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -411,6 +411,7 @@
 		mode = <0>;
 		input = <0>;
 		prescale = <0>;
+		timer-no = <0>;
 	};
 
 	ctimer1: ctimer@29000 {
@@ -423,6 +424,7 @@
 		mode = <0>;
 		input = <0>;
 		prescale = <0>;
+		timer-no = <1>;
 	};
 
 	ctimer2: ctimer@2a000 {
@@ -435,6 +437,7 @@
 		mode = <0>;
 		input = <0>;
 		prescale = <0>;
+		timer-no = <2>;
 	};
 
 	ctimer3: ctimer@2b000 {
@@ -447,6 +450,7 @@
 		mode = <0>;
 		input = <0>;
 		prescale = <0>;
+		timer-no = <3>;
 	};
 
 	ctimer4: ctimer@2c000 {
@@ -459,6 +463,7 @@
 		mode = <0>;
 		input = <0>;
 		prescale = <0>;
+		timer-no = <4>;
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -329,7 +329,7 @@
 		interrupts = <32 0>;
 		status = "disabled";
 		rtc_1khz: rtc_1khz {
-			compatible = "nxp,lpc-rtc-1khz";
+			compatible = "nxp,lpc-wakeup-timer";
 			clocks = <&clkctl0 MCUX_OSC32K_CLK>;
 			status = "disabled";
 			#clock-cells = <0>;

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -328,6 +328,12 @@
 		reg = <0x30000 0x1000>;
 		interrupts = <32 0>;
 		status = "disabled";
+		rtc_1khz: rtc_1khz {
+			compatible = "nxp,lpc-rtc-1khz";
+			clocks = <&clkctl0 MCUX_OSC32K_CLK>;
+			status = "disabled";
+			#clock-cells = <0>;
+		};
 	};
 
 	trng: random@138000 {

--- a/dts/bindings/counter/nxp,lpc-rtc-1khz.yaml
+++ b/dts/bindings/counter/nxp,lpc-rtc-1khz.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2022, NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Special fields for 1KHz rtc
+
+description: NXP The High-resolution/Wake-up Timer (WAKE) 
+    which is clocked at a 1 kHz rate 
+
+compatible: "nxp,lpc-rtc-1khz"
+
+include: [base.yaml, pinctrl-device.yaml]
+
+
+

--- a/dts/bindings/counter/nxp,lpc-wakeup_timer.yaml
+++ b/dts/bindings/counter/nxp,lpc-wakeup_timer.yaml
@@ -6,7 +6,7 @@
 description: NXP The High-resolution/Wake-up Timer (WAKE) 
     which is clocked at a 1 kHz rate 
 
-compatible: "nxp,lpc-rtc-1khz"
+compatible: "nxp,lpc-wakeup-timer"
 
 include: [base.yaml, pinctrl-device.yaml]
 

--- a/dts/bindings/display/nxp,flexio-jdi.yaml
+++ b/dts/bindings/display/nxp,flexio-jdi.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2022, NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP  (FLEXIO Interface) JDI display controller
+
+compatible: "nxp,flexio-jdi"
+
+include: [display-controller.yaml, pinctrl-device.yaml]
+
+properties:
+    reg:
+      required: true
+
+    clocks:
+      required: true
+
+    clock-names:
+      required: true
+      # There are the following names to choose
+      # "input_clock" use to transmit jdi data
+      # "vcom" use to generate VCOM/FRP/XFRP signal
+
+    timers:
+      required: false
+      type: phandle-array
+      description: timers specifiers
+
+    timer-names:
+      required: false
+      type: string-array
+      description: Provided names of timers specifiers. There are "pixel", "xrst", "enb".
+
+    gpios:
+      type: phandle-array
+      required: true
+      description:
+        GPIO pins used by JDI.
+
+    gpio-names:
+      required: true
+      type: string-array
+      description: Provided names of gpio specifiers. There are "vst", "xrst".

--- a/dts/bindings/timer/nxp,lpc-ctimer.yaml
+++ b/dts/bindings/timer/nxp,lpc-ctimer.yaml
@@ -5,7 +5,7 @@ description: NXP MCUX Standard Timer/Counter
 
 compatible: "nxp,lpc-ctimer"
 
-include: base.yaml
+include: [base.yaml, pinctrl-device.yaml]
 
 properties:
     reg:
@@ -27,9 +27,85 @@ properties:
     input:
       type: int
       required: true
+      enum:
+        - 0
+        - 1
+        - 2
+        - 3
       description: input channel
+        00 - Channel 0. CAPn.0 for CTIMERn
+        01 - Channel 1. CAPn.1 for CTIMERn
+        10 - Channel 2. CAPn.2 for CTIMERn
+        11 - Channel 3. CAPn.3 for CTIMERn
 
     prescale:
       type: int
       required: true
       description: prescale value
+
+    timer-no:
+      type: int
+      required: true
+      description: timer number
+
+    capture-pin:
+      type: int
+      required: false
+      default: 0
+      enum:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - 12
+        - 13
+        - 14
+        - 15
+        - 16
+        - 17
+        - 18
+      description: |
+        INPUTMUX CT32BIT0_CAP0_SEL - CT32BIT4_CAP3_SEL
+        Counter Timer n, Capture Input m 
+        for example: Timer2 Cap0 select INP1 pin as capture channel input.
+        00000 - CT_INP0 (function must be selected in IOPCTL)
+        00001 - CT_INP1 (function must be selected in IOPCTL)
+        00010 - CT_INP2 (function must be selected in IOPCTL)
+        00011 - CT_INP3 (function must be selected in IOPCTL)
+        00100 - CT_INP4 (function must be selected in IOPCTL)
+        00101 - CT_INP5 (function must be selected in IOPCTL)
+        00110 - CT_INP6 (function must be selected in IOPCTL)
+        00111 - CT_INP7 (function must be selected in IOPCTL)
+        01000 - CT_INP8 (function must be selected in IOPCTL)
+        01001 - CT_INP9 (function must be selected in IOPCTL)
+        01010 - CT_INP10 (function must be selected in IOPCTL)
+        01011 - CT_INP11 (function must be selected in IOPCTL)
+        01100 - CT_INP12 (function must be selected in IOPCTL)
+        01101 - CT_INP13 (function must be selected in IOPCTL)
+        01110 - CT_INP14 (function must be selected in IOPCTL)
+        01111 - CT_INP15 (function must be selected in IOPCTL)
+        10000 - SHARED I2S0_WS
+        10001 - SHARED I2S1_WS
+        10010 - USB1_FRAME_TOGGLE (see USB Controller Chapter)
+       
+    capture-edge:
+      type: int
+      required: false
+      default: 1
+      enum:
+        - 1
+        - 2
+        - 3
+      description: |
+        select capture edge 
+        1 - rising edge
+        2 - falling edge
+        3 - rising and falling edge

--- a/include/zephyr/drivers/counter/counter_mcux_ctimer.h
+++ b/include/zephyr/drivers/counter/counter_mcux_ctimer.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Broadcom
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef COUNTER_MCUX_CTIMER_H
+#define COUNTER_MCUX_CTIMER_H
+
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/dma/dma_mcux_lpc.h>
+
+#if defined(CONFIG_DMA)
+/**
+ * @brief DMA configuration structure with MCUX DMA private data.
+ * 
+ */
+
+struct mcux_counter_dma_cfg {
+    struct mcux_dma_config mcux_dma_cfg;  /* should be placed at first */
+};
+#endif
+#endif // COUNTER_MCUX_CTIMER_H

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -42,6 +42,7 @@ enum display_pixel_format {
 	PIXEL_FORMAT_ARGB_8888		= BIT(3),
 	PIXEL_FORMAT_RGB_565		= BIT(4),
 	PIXEL_FORMAT_BGR_565		= BIT(5),
+	PIXEL_FORMAT_RGB_222		= BIT(6),
 };
 
 enum display_screen_info {

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -183,6 +183,7 @@ typedef void (*dma_callback_t)(const struct device *dev, void *user_data,
  *     depends on availability of the DMA controller.
  * @param user_data  private data from DMA client.
  * @param dma_callback see dma_callback_t for details
+ * @param priv_dma_config which is private dma config (HW specific)
  */
 struct dma_config {
 	uint32_t  dma_slot :             8;
@@ -205,6 +206,7 @@ struct dma_config {
 	struct dma_block_config *head_block;
 	void *user_data;
 	dma_callback_t dma_callback;
+	void *priv_dma_config;
 };
 
 /**

--- a/include/zephyr/drivers/dma/dma_mcux_lpc.h
+++ b/include/zephyr/drivers/dma/dma_mcux_lpc.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Broadcom
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DMA_MCUX_LPC_H
+#define DMA_MCUX_LPC_H
+
+#include <zephyr/drivers/dma.h>
+#if defined(CONFIG_DMA)
+#include <fsl_dma.h>
+
+#define DMA_MAX_TRANS_NUM (1024)
+
+/**
+ * @brief DMA configuration structure with MCUX DMA private data.
+ * 
+ */
+
+struct mcux_dma_config {
+    dma_channel_trigger_t channel_trigger;
+    bool desc_loop;
+    bool disable_int;
+};
+#endif
+
+#endif // DMA_MCUX_LPC_H

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -430,10 +430,14 @@ struct spi_dt_spec {
  * @param len is the length of the buffer or, if buf is NULL, will be the
  *    length which as to be sent as dummy bytes (as TX buffer) or
  *    the length of bytes that should be skipped (as RX buffer).
+ * @param addr_nochange is a flag that whether adjust buf address when use
+ * 	  DMA. In default address is increased. If true, DMA will transfer the
+ *    first data @ref len times
  */
 struct spi_buf {
 	void *buf;
 	size_t len;
+	uint8_t  addr_nochange :  1;
 };
 
 /**

--- a/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
+++ b/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
@@ -44,4 +44,5 @@
 
 #define MCUX_I3C_CLK			30
 
+#define MCUX_OSC32K_CLK			31  /* The 32 kHz output of the RTC oscillator */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MCUX_LPC_SYSCON_H_ */

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -314,6 +314,12 @@ void clock_init(void)
 
 	/* Set main clock to FRO as deep sleep clock by default. */
 	POWER_SetDeepSleepClock(kDeepSleepClk_Fro);
+#ifdef CONFIG_DISPLAY_JDI
+	CLOCK_AttachClk(kFRO_DIV2_to_FLEXIO);
+	CLOCK_SetClkDiv(kCLOCK_DivFlexioClk, 1);
+	RESET_SetPeripheralReset(kFLEXIO_RST_SHIFT_RSTn);
+	RESET_ClearPeripheralReset(kFLEXIO_RST_SHIFT_RSTn);
+#endif
 }
 
 /**

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -270,6 +270,10 @@ void clock_init(void)
 	/* Switch FLEXCOMM4 to FRO_DIV4 */
 	CLOCK_AttachClk(kFRO_DIV4_to_FLEXCOMM4);
 #endif
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexcomm5), nxp_lpc_spi, okay)
+	/* Switch FLEXCOMM5 to FRO_DIV4 */
+	CLOCK_AttachClk(kFRO_DIV4_to_FLEXCOMM5);
+#endif
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(hs_spi1), nxp_lpc_spi, okay)
 	CLOCK_AttachClk(kFRO_DIV4_to_FLEXCOMM16);
 #endif


### PR DESCRIPTION
a. Many SPI peripherals will have the use case of writing commands and then receiving multiple bytes of data in a transfer. Current drivers are unable to support such case.

b. Some SPI peripherals, like display, need to push a lot of data at once viaDMA. But the current SPI driver supports up to 1024 byte transfers.

c. In some special scenarios, a pattern is used to send a lot of data, and the buffer address does not need to be increased, so add addr_nochange param to save memory overhead