### PR TITLE
net: context: Fix memory leak

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1669,7 +1669,8 @@ static int context_sendto(struct net_context *context,
 		if (net_context_get_type(context) == SOCK_DGRAM) {
 			NET_ERR("Available payload buffer (%zu) is not enough for requested DGRAM (%zu)",
 				tmp_len, len);
-			return -ENOMEM;
+			ret = -ENOMEM;
+			goto fail;
 		}
 		len = tmp_len;
 	}


### PR DESCRIPTION
Allocated, but too small packet must be not just be logged, but also unreferenced before returning an error.

Signed-off-by: Reto Schneider <reto.schneider@husqvarnagroup.com>