### PR TITLE
stm32: lptim: Allow to override configuration check

### DIFF
--- a/drivers/timer/Kconfig.stm32_lptim
+++ b/drivers/timer/Kconfig.stm32_lptim
@@ -44,4 +44,16 @@ config STM32_LPTIM_TIMEBASE
 	default 0xFFFF if STM32_LPTIM_CLOCK_LSE
 	default 0xF9FF if STM32_LPTIM_CLOCK_LSI
 
+config STM32_LPTIM_TICK_FREQ_RATIO_OVERRIDE
+	bool "Override tick to freq ratio check"
+	default y if ZTEST
+	help
+	  For LPTIM configuration, a specific tick freq is advised
+	  depending on LPTIM input clock:
+	  - LSI(32KHz): 4000 ticks/sec
+	  - LSE(32678): 4096 ticks/sec
+	  To prevent misconfigurations, a dedicated check is implemented
+	  in the driver.
+	  This options allows to override this check
+
 endif # STM32_LPTIM_TIMER

--- a/tests/kernel/tickless/tickless_concept/testcase.yaml
+++ b/tests/kernel/tickless/tickless_concept/testcase.yaml
@@ -4,5 +4,5 @@ tests:
     # FIXME: This test fails sporadically on all QEMU platforms, but fails
     # consistently when coverage is enabled. Disable until 14173 is fixed.
     platform_exclude: litex_vexriscv rv32m1_vega_zero_riscy rv32m1_vega_ri5cy
-      nrf5340dk_nrf5340_cpunet
+      nrf5340dk_nrf5340_cpunet nucleo_l073rz
     tags: kernel


### PR DESCRIPTION
Fixes: #50224

