### PR TITLE
drivers: gpio: stm32: Use of GPIOG on U5 requires enabling VDDIO

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -706,7 +706,8 @@ static int gpio_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-#if defined(PWR_CR2_IOSV) && DT_NODE_HAS_STATUS(DT_NODELABEL(gpiog), okay)
+#if (defined(PWR_CR2_IOSV) || defined(PWR_SVMCR_IO2SV)) && \
+	DT_NODE_HAS_STATUS(DT_NODELABEL(gpiog), okay)
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 	/* Port G[15:2] requires external power supply */
 	/* Cf: L4/L5 RM, Chapter "Independent I/O supply rail" */

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 5b1610c3cf46589d50e2634ba240b7b38bc59c53
+      revision: 4f26e65070600d946cf1055d791862b12a929166
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Fixes #50158