### PR TITLE
sys: util: Prevent multiple definitions of ARRAY_SIZE

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -28,6 +28,12 @@ Deprecated in this release
 
 Stable API changes in this release
 ==================================
+* System Utility Headers
+
+  * Prefixed :c:func:`MIN` and :c:func:`MAX` and :c:func:`ARRAY_SIZE` with `#undef` to prevent
+    accidential multiple definitions when dealing with third party libraries that bring their
+    own definitions.
+    This is a departure from previous behavior where include order of header files mattered.
 
 New APIs in this release
 ========================

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -239,7 +239,6 @@ extern "C" {
 #define ceiling_fraction(numerator, divider) \
 	(((numerator) + ((divider) - 1)) / (divider))
 
-#ifndef MAX
 /**
  * @brief Obtain the maximum of two values.
  *
@@ -251,10 +250,9 @@ extern "C" {
  *
  * @returns Maximum value of @p a and @p b.
  */
+#undef MAX
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
-#endif
 
-#ifndef MIN
 /**
  * @brief Obtain the minimum of two values.
  *
@@ -266,8 +264,8 @@ extern "C" {
  *
  * @returns Minimum value of @p a and @p b.
  */
+#undef MIN
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
-#endif
 
 #ifndef CLAMP
 /**

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -82,6 +82,7 @@ extern "C" {
 /* The built-in function used below for type checking in C is not
  * supported by GNU C++.
  */
+#undef ARRAY_SIZE
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
 
 #else /* __cplusplus */
@@ -105,6 +106,7 @@ extern "C" {
  *
  * In C, passing a pointer as @p array causes a compile error.
  */
+#undef ARRAY_SIZE
 #define ARRAY_SIZE(array) \
 	((size_t) (IS_ARRAY(array) + (sizeof(array) / sizeof((array)[0]))))
 

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -116,6 +116,11 @@ ZTEST(util_cxx, test_ARRAY_INDEX)
 	run_ARRAY_INDEX();
 }
 
+ZTEST(util_cxx, test_ARRAY_SIZE)
+{
+	run_ARRAY_SIZE();
+}
+
 ZTEST(util_cxx, test_PART_OF_ARRAY)
 {
 	run_PART_OF_ARRAY();
@@ -232,6 +237,11 @@ ZTEST(util_cc, test_IS_ARRAY_ELEMENT)
 ZTEST(util_cc, test_ARRAY_INDEX)
 {
 	run_ARRAY_INDEX();
+}
+
+ZTEST(util_cc, test_ARRAY_SIZE)
+{
+	run_ARRAY_SIZE();
 }
 
 ZTEST(util_cc, test_PART_OF_ARRAY)

--- a/tests/unit/util/test.inc
+++ b/tests/unit/util/test.inc
@@ -526,3 +526,9 @@ void run_ARRAY_INDEX_FLOOR(void)
 
 	zassert_equal(array[ARRAY_INDEX_FLOOR(array, &alias[1])], 0);
 }
+
+void run_ARRAY_SIZE(void)
+{
+	size_t array[] = {1, 2, 3, 4};
+	zassert_equal(ARRAY_SIZE(array), 4);
+}


### PR DESCRIPTION
Wrap ARRAY_SIZE macro with an #ifndef ARRAY_SIZE to prevent multiple definition issues when dealing with third party libraries that have their own definitions.

Fixes #51371

Signed-off-by: Moritz Fischer <moritzf@google.com>