### PR TITLE
net: ip: net_pkt: Simplify net_pkt_compact() API

### DIFF
--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -1555,10 +1555,8 @@ void net_pkt_frag_insert(struct net_pkt *pkt, struct net_buf *frag);
  *
  * @details After this there is no more any free space in individual fragments.
  * @param pkt Network packet.
- *
- * @return True if compact success, False otherwise.
  */
-bool net_pkt_compact(struct net_pkt *pkt);
+void net_pkt_compact(struct net_pkt *pkt);
 
 /**
  * @brief Get information about predefined RX, TX and DATA pools.

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -756,7 +756,7 @@ void net_pkt_frag_insert(struct net_pkt *pkt, struct net_buf *frag)
 	pkt->frags = frag;
 }
 
-bool net_pkt_compact(struct net_pkt *pkt)
+void net_pkt_compact(struct net_pkt *pkt)
 {
 	struct net_buf *frag, *prev;
 
@@ -812,8 +812,6 @@ bool net_pkt_compact(struct net_pkt *pkt)
 		prev = frag;
 		frag = frag->frags;
 	}
-
-	return true;
 }
 
 void net_pkt_get_info(struct k_mem_slab **rx,


### PR DESCRIPTION
Since db11fcd1747c5c34a26e984f1483eaee1ee16fc1 [net/net_pkt: Fully separate struct net_pkt from struct net_buf], net_pkt_compact() can not fail anymore.

This commit acknowledges this and simplifies the API accordingly.

Please note: For my use case, having this API simplified makes my life easier as I have one error less to check. However, I am unsure if and how much Zephyr minds API changes.