### PR TITLE
net: lib: lwm2m: Fix lwm2m exec

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_shell.c
+++ b/subsys/net/lib/lwm2m/lwm2m_shell.c
@@ -117,8 +117,8 @@ static int cmd_exec(const struct shell *sh, size_t argc, char **argv)
 
 	struct lwm2m_engine_res *res = lwm2m_engine_get_res(&path);
 
-	if (ret < 0) {
-		shell_error(sh, "Resource not found (err %d)\n", ret);
+	if (res == NULL) {
+		shell_error(sh, "Resource not found\n");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
The lwm2m exec erroneously checked the previous return value instead of checking if the resource existed.
This caused exec to try to get and execute the execute callback from NULL and caused a reboot.

Signed-off-by: Jarno Lämsä <jarno.lamsa@nordicsemi.no>