### PR TITLE
Bluetooth: audio: Handle lack of channel allocation structure

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -221,6 +221,11 @@ struct bt_codec_data {
  * These values are defined by the Generic Audio Assigned Numbers, bluetooth.com
  */
 enum bt_audio_location {
+	/*
+	 * As Audio Location is not mandatory, for handling lack of this field
+	 * in codec configuration we introduce special opcode with unspecified location.
+	 */
+	BT_AUDIO_LOCATION_UNSPECIFIED = 0,
 	BT_AUDIO_LOCATION_FRONT_LEFT = BIT(0),
 	BT_AUDIO_LOCATION_FRONT_RIGHT = BIT(1),
 	BT_AUDIO_LOCATION_FRONT_CENTER = BIT(2),

--- a/subsys/bluetooth/audio/codec.c
+++ b/subsys/bluetooth/audio/codec.c
@@ -123,13 +123,16 @@ int bt_codec_cfg_get_chan_allocation_val(const struct bt_codec *codec,
 
 	*chan_allocation = 0;
 	if (bt_codec_get_val(codec, BT_CODEC_CONFIG_LC3_CHAN_ALLOC, &element)) {
-
 		*chan_allocation = sys_le32_to_cpu(*((uint32_t *)&element->data.data[0]));
 
 		return BT_AUDIO_CODEC_PARSE_ERR_SUCCESS;
 	}
 
-	return BT_AUDIO_CODEC_PARSE_ERR_TYPE_NOT_FOUND;
+	/* BAP v1.0.1 4.3.2 Codec_Specific_Configuration LTV requirements
+	 * The absence of the Audio_Channel_Allocation LTV structure
+	 * shall be interpreted as a single channel with no specified Audio Location.
+	 */
+	return BT_AUDIO_LOCATION_UNSPECIFIED;
 }
 
 int bt_codec_cfg_get_octets_per_frame(const struct bt_codec *codec)


### PR DESCRIPTION
This commits fixes the handling of codec configuration in case there is no channel allocation field present.