### PR TITLE
Bluetooth: Controller: Fix TICKER_LOW_LAT Ext. Scan assert check

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -697,7 +697,9 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 				      ticks_slot_overhead),
 				     ticker_cb, aux, ticker_op_cb, aux);
 	LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
-		  (ticker_status == TICKER_STATUS_BUSY));
+		  (ticker_status == TICKER_STATUS_BUSY) ||
+		  ((ticker_status == TICKER_STATUS_FAILURE) &&
+		   IS_ENABLED(CONFIG_BT_TICKER_LOW_LAT)));
 
 	return;
 


### PR DESCRIPTION
Fix Extended Scanning assertion check when using Ticker Low Latency Implementation where the failure to schedule a ticker timeout is returned inline compared to deferred failure in the operation callback.

Auxiliary PDU is received using a single-shot ticker timeout with ticks_slot reservation. This single-shot ticker is allowed to fail if it is overlapping another event.

Fixes #49915 when `CONFIG_BT_TICKER_LOW_LAT=y` used.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>