### PR TITLE
soc: intel_adsp_ace1x: fix for IPC implementation

### DIFF
--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_ipc_regs.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_ipc_regs.h
@@ -36,15 +36,17 @@ struct intel_adsp_ipc {
 	uint32_t idd;
 };
 
+#define INTEL_ADSP_IPC_BUSY BIT(31)
+#define INTEL_ADSP_IPC_DONE BIT(31)
+
 /**
- * @brief Set TDA busy bit.
+ * @brief Clear TDA busy bit.
  *
  * On ACE SoC family boards TDA bit 31 (BUSY) during IPC doorbell acknowledgment
  * must be cleared (!), not set (in contrary to CAVS SoC family boards).
  * This clears BUSY on the other side of the connection in IDR register.
  */
-#define INTEL_ADSP_IPC_BUSY BIT(31)
-#define INTEL_ADSP_IPC_DONE 0
+#define INTEL_ADSP_IPC_ACE1X_TDA_DONE 0
 
 #define INTEL_ADSP_IPC_CTL_TBIE BIT(0)
 #define INTEL_ADSP_IPC_CTL_IDIE BIT(1)

--- a/soc/xtensa/intel_adsp/common/ipc.c
+++ b/soc/xtensa/intel_adsp/common/ipc.c
@@ -50,7 +50,11 @@ void z_intel_adsp_ipc_isr(const void *devarg)
 
 		regs->tdr = INTEL_ADSP_IPC_BUSY;
 		if (done && !IS_ENABLED(CONFIG_SOC_INTEL_CAVS_V15)) {
+#ifdef CONFIG_SOC_SERIES_INTEL_ACE
+			regs->tda = INTEL_ADSP_IPC_ACE1X_TDA_DONE;
+#else
 			regs->tda = INTEL_ADSP_IPC_DONE;
+#endif
 		}
 	}
 
@@ -88,7 +92,11 @@ int intel_adsp_ipc_init(const struct device *dev)
 		config->regs->idd = INTEL_ADSP_IPC_DONE;
 	} else {
 		config->regs->ida = INTEL_ADSP_IPC_DONE;
+#ifdef CONFIG_SOC_SERIES_INTEL_ACE
+		config->regs->tda = INTEL_ADSP_IPC_ACE1X_TDA_DONE;
+#else
 		config->regs->tda = INTEL_ADSP_IPC_DONE;
+#endif
 	}
 	config->regs->ctl |= (INTEL_ADSP_IPC_CTL_IDIE | INTEL_ADSP_IPC_CTL_TBIE);
 	return 0;
@@ -98,7 +106,11 @@ void intel_adsp_ipc_complete(const struct device *dev)
 {
 	const struct intel_adsp_ipc_config *config = dev->config;
 
+#ifdef CONFIG_SOC_SERIES_INTEL_ACE
+	config->regs->tda = INTEL_ADSP_IPC_ACE1X_TDA_DONE;
+#else
 	config->regs->tda = INTEL_ADSP_IPC_DONE;
+#endif
 }
 
 bool intel_adsp_ipc_is_complete(const struct device *dev)


### PR DESCRIPTION
For meteorlake during signaling IPC completion only TDA bit should be cleared not IDA.

In commit c75e6cfcb939 ("soc: intel_adsp_ace1x: Added IPC/IDC implementation") definition for INTEL_ADSP_IPC_DONE was modified for ace1x platforms. This change was not correct as the new definition was also used to program the IDA register.

Co-authored-by: Serhiy Katsyuba <serhiy.katsyuba@intel.com>
Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>