### PR TITLE
Bluetooth: Shell: Remove a debug-print

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -144,7 +144,6 @@ static bool is_substring(const char *substr, const char *str)
 	for (size_t pos = 0; pos < str_len; pos++) {
 		if (tolower(substr[0]) == tolower(str[pos])) {
 			if (pos + sub_str_len > str_len) {
-				shell_print(ctx_shell, "length fail");
 				return false;
 			}
 


### PR DESCRIPTION
I don't think it was intentional to leave this line. It spews "length fail" in the shell when using scan result filtering, filtering by name.