### PR TITLE
drivers: can: mcan: don't enabled trasceiver in init

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -357,12 +357,6 @@ int can_mcan_init(const struct device *dev)
 			LOG_ERR("CAN transceiver not ready");
 			return -ENODEV;
 		}
-
-		ret = can_transceiver_enable(cfg->phy);
-		if (ret != 0) {
-			LOG_ERR("failed to enable CAN transceiver (err %d)", ret);
-			return -EIO;
-		}
 	}
 
 	ret = can_exit_sleep_mode(can);


### PR DESCRIPTION
With the move to start/stop functions the transceiver is not expected to be enabled after driver initialization.
This is now done in `can_mcan_start()`

Fixes: #50263