### PR TITLE
drivers: wifi: esp32: sp32_wifi_ap_enable: fix ret value overwritten

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -390,7 +390,7 @@ static int esp32_wifi_ap_enable(const struct device *dev,
 	/* Start Wi-Fi in AP mode with configuration built above */
 	ret = esp_wifi_set_mode(ESP32_WIFI_MODE_AP);
 	ret |= esp_wifi_set_config(WIFI_IF_AP, &wifi_config);
-	ret = esp_wifi_start();
+	ret |= esp_wifi_start();
 	if (ret != ESP_OK) {
 		LOG_ERR("Failed to enable Wi-Fi AP mode");
 		return -EAGAIN;


### PR DESCRIPTION
The return values of esp_wifi_set_mode(), and esp_wifi_set_config() were overwritten once esp_wifi_start() was executed.

This commit fixes that by ORing the return value to the others.