### PR TITLE
drivers: can: mcan: do not enable the CAN transceiver at boot

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -357,12 +357,6 @@ int can_mcan_init(const struct device *dev)
 			LOG_ERR("CAN transceiver not ready");
 			return -ENODEV;
 		}
-
-		ret = can_transceiver_enable(cfg->phy);
-		if (ret != 0) {
-			LOG_ERR("failed to enable CAN transceiver (err %d)", ret);
-			return -EIO;
-		}
 	}
 
 	ret = can_exit_sleep_mode(can);


### PR DESCRIPTION
Do not enable the CAN transceiver at boot. The CAN transceiver will be enabled once the CAN controller is started.

Fixes: #50263

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>