### PR TITLE
drivers: can: native_posix_linux: drop rx frames while stopped

### DIFF
--- a/drivers/can/can_native_posix_linux.c
+++ b/drivers/can/can_native_posix_linux.c
@@ -103,11 +103,11 @@ static void rx_thread(void *arg1, void *arg2, void *arg3)
 
 				k_sem_give(&data->tx_idle);
 
-				if (!data->loopback || !data->started) {
+				if (!data->loopback) {
 					continue;
 				}
 			}
-			if (count <= 0) {
+			if ((count <= 0) || !data->started) {
 				break;
 			}
 


### PR DESCRIPTION
The driver should drop rx frames while in stopped state.

With this change the ack of a last message that may have been sent before the node was stopped will still be returned,
but all incoming messages are dropped. 

Fixes: #50266