### PR TITLE
stm32f3_disco internal (die) temperature sensor

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1151,8 +1151,7 @@ static int adc_stm32_init(const struct device *dev)
 	defined(CONFIG_SOC_SERIES_STM32L0X) || \
 	defined(CONFIG_SOC_SERIES_STM32WLX)
 	LL_ADC_SetClock(adc, LL_ADC_CLOCK_SYNC_PCLK_DIV4);
-#elif defined(STM32F3X_ADC_V1_1) || \
-	defined(CONFIG_SOC_SERIES_STM32L4X) || \
+#elif defined(CONFIG_SOC_SERIES_STM32L4X) || \
 	defined(CONFIG_SOC_SERIES_STM32L5X) || \
 	defined(CONFIG_SOC_SERIES_STM32WBX) || \
 	defined(CONFIG_SOC_SERIES_STM32G0X) || \
@@ -1160,6 +1159,15 @@ static int adc_stm32_init(const struct device *dev)
 	defined(CONFIG_SOC_SERIES_STM32H7X)
 	LL_ADC_SetCommonClock(__LL_ADC_COMMON_INSTANCE(adc),
 			      LL_ADC_CLOCK_SYNC_PCLK_DIV4);
+#elif defined(STM32F3X_ADC_V1_1)
+	/*
+	 * Set the synchronous clock mode to HCLK/1 (DIV1) or HCLK/2 (DIV2)
+	 * Both are valid common clock setting values.
+	 * The HCLK/1(DIV1) is possible only if
+	 * the ahb-prescaler = <1> in the RCC_CFGR.
+	 */
+	LL_ADC_SetCommonClock(__LL_ADC_COMMON_INSTANCE(adc),
+			      LL_ADC_CLOCK_SYNC_PCLK_DIV2);
 #elif defined(CONFIG_SOC_SERIES_STM32L1X) || \
 	defined(CONFIG_SOC_SERIES_STM32U5X)
 	LL_ADC_SetCommonClock(__LL_ADC_COMMON_INSTANCE(adc),

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -126,7 +126,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x10000000>;
 			interrupts = <18 0>;
 			status = "disabled";
-			vref-mv = <3300>;
+			vref-mv = <3000>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;


### PR DESCRIPTION
Configures the ADC channel and common registers to give a correct die-temperature sensor value

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/50152

On the stm32F3 disco board, the VDD = VDDA = VREF+ = 3V   (cf MB1035)

Thanks to this PR the die temperature on the stm32f3_disco platform with samples/sensor/stm32_temp_sensor/ is measured at
Current temperature: 32.7 °C

Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)