### PR TITLE
drivers: Fix BMI270 initialization

### DIFF
--- a/drivers/sensor/bmi270/bmi270.c
+++ b/drivers/sensor/bmi270/bmi270.c
@@ -631,7 +631,8 @@ static int bmi270_init(const struct device *dev)
 	adv_pwr_save = BMI270_SET_BITS_POS_0(adv_pwr_save,
 					     BMI270_PWR_CONF_ADV_PWR_SAVE,
 					     BMI270_PWR_CONF_ADV_PWR_SAVE_DIS);
-	ret = reg_write(dev, BMI270_REG_PWR_CONF, &adv_pwr_save, 1);
+	ret = reg_write_with_delay(dev, BMI270_REG_PWR_CONF, &adv_pwr_save, 1,
+		BMI270_INTER_WRITE_DELAY_US);
 	if (ret != 0) {
 		return ret;
 	}


### PR DESCRIPTION
On power on reset, after disable advanced power safe mode, you need to wait a delay before write again in the device. The missing wait produce random initialization failure. See §4.4 of the datasheet "bst-bmi270-ds000.pdf"

Signed-off-by: William MARTIN <william.martin@power-lan.com>