### PR TITLE
cpp: Add changes to operator new from C++17 and C++20

### DIFF
--- a/lib/libc/minimal/include/stdlib.h
+++ b/lib/libc/minimal/include/stdlib.h
@@ -23,6 +23,8 @@ long long strtoll(const char *nptr, char **endptr, int base);
 int atoi(const char *s);
 
 void *malloc(size_t size);
+void *aligned_alloc(size_t alignment, size_t size); /* From C11 */
+
 void free(void *ptr);
 void *calloc(size_t nmemb, size_t size);
 void *realloc(void *ptr, size_t size);

--- a/lib/libc/minimal/source/stdlib/malloc.c
+++ b/lib/libc/minimal/source/stdlib/malloc.c
@@ -54,6 +54,28 @@ void *malloc(size_t size)
 	return ret;
 }
 
+/* Compile in when C11 */
+#if __STDC_VERSION__ >= 201112L
+void *aligned_alloc(size_t alignment, size_t size)
+{
+	int lock_ret;
+
+	lock_ret = sys_mutex_lock(&z_malloc_heap_mutex, K_FOREVER);
+	__ASSERT_NO_MSG(lock_ret == 0);
+
+	void *ret = sys_heap_aligned_alloc(&z_malloc_heap,
+					   alignment,
+					   size);
+	if (ret == NULL && size != 0) {
+		errno = ENOMEM;
+	}
+
+	(void) sys_mutex_unlock(&z_malloc_heap_mutex);
+
+	return ret;
+}
+#endif /* __STDC_VERSION__ >= 201112L */
+
 static int malloc_prepare(const struct device *unused)
 {
 	ARG_UNUSED(unused);

--- a/subsys/cpp/cpp_new.cpp
+++ b/subsys/cpp/cpp_new.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <stdlib.h>
+#include <new>
 
 #if __cplusplus < 201103L
 #define NOEXCEPT
@@ -31,6 +32,30 @@ void* operator new[](std::size_t size, const std::nothrow_t& tag) NOEXCEPT
 {
 	return malloc(size);
 }
+
+#if __cplusplus >= 201703L
+void* operator new(size_t size, std::align_val_t al)
+{
+	return aligned_alloc(static_cast<size_t>(al), size);
+}
+
+void* operator new[](std::size_t size, std::align_val_t al)
+{
+	return aligned_alloc(static_cast<size_t>(al), size);
+}
+
+void* operator new(std::size_t size, std::align_val_t al,
+		   const std::nothrow_t&) NOEXCEPT
+{
+	return aligned_alloc(static_cast<size_t>(al), size);
+}
+
+void* operator new[](std::size_t size, std::align_val_t al,
+		     const std::nothrow_t&) NOEXCEPT
+{
+	return aligned_alloc(static_cast<size_t>(al), size);
+}
+#endif /* __cplusplus >= 201703L */
 
 void operator delete(void* ptr) NOEXCEPT
 {

--- a/subsys/cpp/cpp_new.cpp
+++ b/subsys/cpp/cpp_new.cpp
@@ -22,6 +22,16 @@ void* operator new[](size_t size)
 	return malloc(size);
 }
 
+void* operator new(std::size_t size, const std::nothrow_t& tag) NOEXCEPT
+{
+	return malloc(size);
+}
+
+void* operator new[](std::size_t size, const std::nothrow_t& tag) NOEXCEPT
+{
+	return malloc(size);
+}
+
 void operator delete(void* ptr) NOEXCEPT
 {
 	free(ptr);

--- a/subsys/cpp/cpp_new.cpp
+++ b/subsys/cpp/cpp_new.cpp
@@ -13,45 +13,51 @@
 #define NOEXCEPT noexcept
 #endif /* __cplusplus */
 
-void* operator new(size_t size)
+#if __cplusplus < 202002L
+#define NODISCARD
+#else
+#define NODISCARD [[nodiscard]]
+#endif /* __cplusplus */
+
+NODISCARD void* operator new(size_t size)
 {
 	return malloc(size);
 }
 
-void* operator new[](size_t size)
+NODISCARD void* operator new[](size_t size)
 {
 	return malloc(size);
 }
 
-void* operator new(std::size_t size, const std::nothrow_t& tag) NOEXCEPT
+NODISCARD void* operator new(std::size_t size, const std::nothrow_t& tag) NOEXCEPT
 {
 	return malloc(size);
 }
 
-void* operator new[](std::size_t size, const std::nothrow_t& tag) NOEXCEPT
+NODISCARD void* operator new[](std::size_t size, const std::nothrow_t& tag) NOEXCEPT
 {
 	return malloc(size);
 }
 
 #if __cplusplus >= 201703L
-void* operator new(size_t size, std::align_val_t al)
+NODISCARD void* operator new(size_t size, std::align_val_t al)
 {
 	return aligned_alloc(static_cast<size_t>(al), size);
 }
 
-void* operator new[](std::size_t size, std::align_val_t al)
+NODISCARD void* operator new[](std::size_t size, std::align_val_t al)
 {
 	return aligned_alloc(static_cast<size_t>(al), size);
 }
 
-void* operator new(std::size_t size, std::align_val_t al,
-		   const std::nothrow_t&) NOEXCEPT
+NODISCARD void* operator new(std::size_t size, std::align_val_t al,
+			     const std::nothrow_t&) NOEXCEPT
 {
 	return aligned_alloc(static_cast<size_t>(al), size);
 }
 
-void* operator new[](std::size_t size, std::align_val_t al,
-		     const std::nothrow_t&) NOEXCEPT
+NODISCARD void* operator new[](std::size_t size, std::align_val_t al,
+			       const std::nothrow_t&) NOEXCEPT
 {
 	return aligned_alloc(static_cast<size_t>(al), size);
 }

--- a/subsys/cpp/include/new
+++ b/subsys/cpp/include/new
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Stub header allowing compilation of `#include <new>`
+ */
+
+#ifndef ZEPHYR_SUBSYS_CPP_INCLUDE_NEW_
+#define ZEPHYR_SUBSYS_CPP_INCLUDE_NEW_
+
+#include <cstddef>
+
+namespace std {
+#if __cplusplus < 201103L
+	struct nothrow_t {};
+#else
+	struct nothrow_t {
+		explicit nothrow_t() = default;
+	};
+#endif /* __cplusplus */
+	extern const std::nothrow_t nothrow;
+}
+
+#endif /* ZEPHYR_SUBSYS_CPP_INCLUDE_NEW_ */

--- a/subsys/cpp/include/new
+++ b/subsys/cpp/include/new
@@ -24,6 +24,10 @@ namespace std {
 	};
 #endif /* __cplusplus */
 	extern const std::nothrow_t nothrow;
-}
 
+#if __cplusplus >= 201703L
+	enum class align_val_t : std::size_t {};
+#endif /* CONFIG_STD_CPP17 */
+
+}
 #endif /* ZEPHYR_SUBSYS_CPP_INCLUDE_NEW_ */


### PR DESCRIPTION
C++ subsystem defines exception throwing operator new.
Though the implementation never throws an exception.

If used by an application it should verify if requested
memory was allocated. This is against C++ standard.
If an application does not support exceptions or does not
want to call throwing new operator, it should use a
specialization of a new operator that makes sure it
never throws bad_alloc exception. The cpp subsystem
does not provide this specialization.

C++17 delivered another specialization of a new operator,
that allows to allocate a memory with requested alignment.
Implementation of this change requires an extension to 
minimal libc. There is no allocator that allows for request 
particular alignment.

C++20 standard added [[nodiscard]] attribute to operator new
definitions. In case value returned by operator new is ignored,
compiler emits a warning.