### PR TITLE
samples: drivers: can: babbling: start can node

### DIFF
--- a/samples/drivers/can/babbling/src/main.c
+++ b/samples/drivers/can/babbling/src/main.c
@@ -79,6 +79,12 @@ void main(void)
 		return;
 	}
 
+	err = can_start(dev);
+	if (err != 0) {
+		printk("Error starting CAN controller [%d]", err);
+		return;
+	}
+
 #if DT_NODE_EXISTS(BUTTON_NODE)
 	k_sem_init(&btn_cb_ctx.sem, 0, 1);
 


### PR DESCRIPTION
The device must be started before sending any frames.

Fixes: #50282