### PR TITLE
drivers: can: rcar: remote transmission request filters are not supported

### DIFF
--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -955,6 +955,10 @@ static int can_rcar_add_rx_filter(const struct device *dev, can_rx_callback_t cb
 	struct can_rcar_data *data = dev->data;
 	int filter_id;
 
+	if (filter->rtr == CAN_REMOTEREQUEST) {
+		return -ENOTSUP;
+	}
+
 	k_mutex_lock(&data->rx_mutex, K_FOREVER);
 	filter_id = can_rcar_add_rx_filter_unlocked(dev, cb, cb_arg, filter);
 	k_mutex_unlock(&data->rx_mutex);

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1132,6 +1132,7 @@ static inline int z_impl_can_send(const struct device *dev, const struct can_fra
  *
  * @retval filter_id on success.
  * @retval -ENOSPC if there are no free filters.
+ * @retval -ENOTSUP if the requested filter type is not supported.
  */
 static inline int can_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
 				    void *user_data, const struct can_filter *filter)
@@ -1174,6 +1175,7 @@ static inline int can_add_rx_filter(const struct device *dev, can_rx_callback_t 
  *
  * @retval filter_id on success.
  * @retval -ENOSPC if there are no free filters.
+ * @retval -ENOTSUP if the requested filter type is not supported.
  */
 __syscall int can_add_rx_filter_msgq(const struct device *dev, struct k_msgq *msgq,
 				     const struct can_filter *filter);

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -654,7 +654,14 @@ void send_receive_rtr(const struct can_filter *data_filter,
 	int filter_id;
 	int err;
 
-	filter_id = add_rx_msgq(can_dev, rtr_filter);
+	filter_id = can_add_rx_filter_msgq(can_dev, &can_msgq, rtr_filter);
+	if (filter_id == -ENOTSUP) {
+		/* Not all CAN controller drivers support remote transmission requests */
+		ztest_test_skip();
+	}
+
+	zassert_not_equal(filter_id, -ENOSPC, "no filters available");
+	zassert_true(filter_id >= 0, "negative filter number");
 
 	/* Verify that RTR filter does not match data frame */
 	send_test_frame(can_dev, data_frame);


### PR DESCRIPTION
- Some CAN controllers do not support all filter combinations (standard 11-bit ID filters, extended 29-bit filter, data frame filters, remote transmission request). Document the expected return value (-ENOTSUP) for unsupported filter types/combinations.
- The receive path for the Renesas R-Car CAN controller supports two RX FIFOs, which are currently configured for standard 11-bit CAN ID data frames in FIFO0, and extended 29-bit CAN ID data frames in FIFO1. As this leaves no room for matching remote transmission request (RTR)frames, have the driver return -ENOTSUP instead of silently accepting RTR filters.
- Skip the Remote Transmission Request (RTR) frame tests if the CAN controller driver does not support RTR filters.

Fixes: #50218