### PR TITLE
dtlib: error out on duplicate node names

### DIFF
--- a/boards/arm/arduino_nicla_sense_me/arduino_nicla_sense_me-pinctrl.dtsi
+++ b/boards/arm/arduino_nicla_sense_me/arduino_nicla_sense_me-pinctrl.dtsi
@@ -50,7 +50,7 @@
 		};
 	};
 
-	spi1_default: spi2_default {
+	spi1_default: spi1_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 11)>,
 				<NRF_PSEL(SPIM_MOSI, 0, 27)>,
@@ -58,7 +58,7 @@
 		};
 	};
 
-	spi1_sleep: spi2_sleep {
+	spi1_sleep: spi1_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 11)>,
 				<NRF_PSEL(SPIM_MOSI, 0, 27)>,

--- a/boards/arm/sam4e_xpro/sam4e_xpro-pinctrl.dtsi
+++ b/boards/arm/sam4e_xpro/sam4e_xpro-pinctrl.dtsi
@@ -69,7 +69,7 @@
 				 <PA24A_USART1_RTS>;
 			bias-pull-up;
 		};
-		group1 {
+		group2 {
 			pinmux = <PA22A_USART1_TXD>,
 				 <PA25A_USART1_CTS>;
 		};

--- a/boards/arm/sam4l_ek/sam4l_ek-pinctrl.dtsi
+++ b/boards/arm/sam4l_ek/sam4l_ek-pinctrl.dtsi
@@ -35,7 +35,7 @@
 				 <PC7B_USART2_RTS>;
 			bias-pull-up;
 		};
-		group1 {
+		group2 {
 			pinmux = <PA7B_USART0_TXD>,
 				 <PC8E_USART2_CTS>;
 		};

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-pinctrl.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-pinctrl.dtsi
@@ -120,7 +120,7 @@
 				 <PB3C_USART0_RTS>;
 			bias-pull-up;
 		};
-		group1 {
+		group2 {
 			pinmux = <PB1C_USART0_TXD>,
 				 <PB2C_USART0_CTS>,
 				 <PB13C_USART0_SCK>;
@@ -138,7 +138,7 @@
 				 <PA24A_USART1_RTS>;
 			bias-pull-up;
 		};
-		group1 {
+		group2 {
 			pinmux = <PB4D_USART1_TXD>,
 				 <PA25A_USART1_CTS>;
 		};
@@ -155,7 +155,7 @@
 				 <PD18B_USART2_RTS>;
 			bias-pull-up;
 		};
-		group1 {
+		group2 {
 			pinmux = <PD16B_USART2_TXD>,
 				 <PD19B_USART2_CTS>,
 				 <PD17B_USART2_SCK>;

--- a/boards/arm/sam_v71_xult/sam_v71_xult-pinctrl.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-pinctrl.dtsi
@@ -114,7 +114,7 @@
 				 <PB3C_USART0_RTS>;
 			bias-pull-up;
 		};
-		group1 {
+		group2 {
 			pinmux = <PB1C_USART0_TXD>,
 				 <PB2C_USART0_CTS>;
 		};
@@ -131,7 +131,7 @@
 				 <PA24A_USART1_RTS>;
 			bias-pull-up;
 		};
-		group1 {
+		group2 {
 			pinmux = <PB4D_USART1_TXD>,
 				 <PA25A_USART1_CTS>;
 		};
@@ -148,7 +148,7 @@
 				 <PD18B_USART2_RTS>;
 			bias-pull-up;
 		};
-		group1 {
+		group2 {
 			pinmux = <PD16B_USART2_TXD>,
 				 <PD19B_USART2_CTS>;
 		};

--- a/boards/arm/tdk_robokit1/tdk_robokit1-pinctrl.dtsi
+++ b/boards/arm/tdk_robokit1/tdk_robokit1-pinctrl.dtsi
@@ -158,7 +158,7 @@
 				 <PB3C_USART0_RTS>;
 			bias-pull-up;
 		};
-		group1 {
+		group2 {
 			pinmux = <PB1C_USART0_TXD>,
 				 <PB2C_USART0_CTS>,
 				 <PB13C_USART0_SCK>;
@@ -178,7 +178,7 @@
 				 <PA24A_USART1_RTS>;
 			bias-pull-up;
 		};
-		group1 {
+		group2 {
 			pinmux = <PB4D_USART1_TXD>,
 				 <PA25A_USART1_CTS>;
 		};
@@ -197,7 +197,7 @@
 				 <PD18B_USART2_RTS>;
 			bias-pull-up;
 		};
-		group1 {
+		group2 {
 			pinmux = <PD16B_USART2_TXD>,
 				 <PD19B_USART2_CTS>,
 				 <PD17B_USART2_SCK>;

--- a/boards/riscv/hifive1/hifive1-pinctrl.dtsi
+++ b/boards/riscv/hifive1/hifive1-pinctrl.dtsi
@@ -67,7 +67,7 @@
 	pwm2_0_default: pwm2_0_default {
 		pinmux = <10 SIFIVE_PINMUX_IOF1>;
 	};
-	pwm2_1_default: pwm1_1_default {
+	pwm2_1_default: pwm2_1_default {
 		pinmux = <11 SIFIVE_PINMUX_IOF1>;
 	};
 	pwm2_2_default: pwm2_2_default {

--- a/boards/riscv/hifive1_revb/hifive1_revb-pinctrl.dtsi
+++ b/boards/riscv/hifive1_revb/hifive1_revb-pinctrl.dtsi
@@ -67,7 +67,7 @@
 	pwm2_0_default: pwm2_0_default {
 		pinmux = <10 SIFIVE_PINMUX_IOF1>;
 	};
-	pwm2_1_default: pwm1_1_default {
+	pwm2_1_default: pwm2_1_default {
 		pinmux = <11 SIFIVE_PINMUX_IOF1>;
 	};
 	pwm2_2_default: pwm2_2_default {

--- a/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
+++ b/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
@@ -16,6 +16,10 @@
 	aliases {
 		i2c-0 = &i2c0;
 		peci-0 = &peci0;
+		led0 = &led0;
+		kscan0 = &kscan0;
+		watchdog0 = &twd0;
+		pwm-0 = &pwm0;
 	};
 
 	chosen {
@@ -27,13 +31,6 @@
 		zephyr,flash-controller = &flashctrl;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,keyboard-scan = &kscan0;
-	};
-
-	aliases {
-		led0 = &led0;
-		kscan0 = &kscan0;
-		watchdog0 = &twd0;
-		pwm-0 = &pwm0;
 	};
 
 	leds {

--- a/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi
+++ b/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi
@@ -189,10 +189,6 @@
 		pinmux = < MCHP_XEC_PINMUX(025, MCHP_AF1) >;
 	};
 
-	/omit-if-no-ref/ nsmi_gpio107: nsmi_gpio107 {
-		pinmux = < MCHP_XEC_PINMUX(0107, MCHP_AF1) >;
-	};
-
 	/* I2C ports */
 	/omit-if-no-ref/ i2c00_scl_gpio004: i2c00_scl_gpio004 {
 		pinmux = < MCHP_XEC_PINMUX(04, MCHP_AF1) >;
@@ -646,7 +642,7 @@
 		pinmux = < MCHP_XEC_PINMUX(0116, MCHP_AF2) >;
 	};
 
-	/omit-if-no-ref/ eeprom_clk_gpio117: gpspi_clk_gpio117 {
+	/omit-if-no-ref/ eeprom_clk_gpio117: eeprom_clk_gpio117 {
 		pinmux = < MCHP_XEC_PINMUX(0117, MCHP_AF2) >;
 	};
 

--- a/dts/arm/nxp/nxp_rt1160_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm4.dtsi
@@ -136,7 +136,7 @@
 			dma-names = "tx", "rx";
 		};
 
-		lpuart12: uart@40098000 {
+		lpuart12: uart@40c28000 {
 			dmas = <&edma_lpsr0 23 30>, <&edma_lpsr0 24 31>;
 			dma-names = "tx", "rx";
 		};

--- a/dts/arm/nxp/nxp_rt1160_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm7.dtsi
@@ -144,7 +144,7 @@
 			dma-names = "tx", "rx";
 		};
 
-		lpuart12: uart@40098000 {
+		lpuart12: uart@40c28000 {
 			dmas = <&edma0 23 30>, <&edma0 24 31>;
 			dma-names = "tx", "rx";
 		};

--- a/dts/arm/nxp/nxp_rt1170_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm4.dtsi
@@ -136,7 +136,7 @@
 			dma-names = "tx", "rx";
 		};
 
-		lpuart12: uart@40098000 {
+		lpuart12: uart@40c28000 {
 			dmas = <&edma_lpsr0 23 30>, <&edma_lpsr0 24 31>;
 			dma-names = "tx", "rx";
 		};

--- a/dts/arm/nxp/nxp_rt1170_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm7.dtsi
@@ -144,7 +144,7 @@
 			dma-names = "tx", "rx";
 		};
 
-		lpuart12: uart@40098000 {
+		lpuart12: uart@40c28000 {
 			dmas = <&edma0 23 30>, <&edma0 24 31>;
 			dma-names = "tx", "rx";
 		};

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -512,9 +512,9 @@
 			status = "disabled";
 		};
 
-		lpuart12: uart@40098000 {
+		lpuart12: uart@40c28000 {
 			compatible = "nxp,kinetis-lpuart";
-			reg = <0x40098000 0x4000>;
+			reg = <0x40c28000 0x4000>;
 			interrupts = <31 0>;
 			clocks = <&ccm IMX_CCM_LPUART12_CLK 0x80 14>;
 			status = "disabled";

--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -253,14 +253,14 @@
 			status = "okay";
 		};
 
-		alh0:alh@24400 {
-			compatible = "intel,alh-dai";
-			reg = <0x00024400 0x00024600>;
-
-			status = "okay";
-		};
-
-		alh1:alh@24400 {
+		/*
+		 * FIXME this is modeling individual alh channels/instances
+		 * with node labels, which has problems. A better representation
+		 * is discussed here:
+		 *
+		 * https://github.com/zephyrproject-rtos/zephyr/pull/50287#discussion_r974591009
+		 */
+		alh0: alh1: alh@24400 {
 			compatible = "intel,alh-dai";
 			reg = <0x00024400 0x00024600>;
 

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -2270,3 +2270,37 @@ def test_dangling_alias():
 };
 ''', force=True)
     assert dt.get_node('/aliases').props['foo'].to_string() == '/missing'
+
+def test_duplicate_nodes():
+    # Duplicate node names in the same {} block are an error in dtc,
+    # so we want to reproduce the same behavior. But we also need to
+    # make sure that doesn't break overlays modifying the same node.
+
+    verify_error_endswith("""
+/dts-v1/;
+
+/ {
+	foo {};
+	foo {};
+};
+""", "/foo: duplicate node name")
+
+    verify_parse("""
+/dts-v1/;
+
+/ {
+	foo { prop = <3>; };
+};
+/ {
+	foo { prop = <4>; };
+};
+""",
+"""
+/dts-v1/;
+
+/ {
+	foo {
+		prop = < 0x4 >;
+	};
+};
+""")

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 4f26e65070600d946cf1055d791862b12a929166
+      revision: 4c9e3576792810a1125c8842d2841b2e261e3487
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
This fix for a medium priority DT bug requires tree-wide cleanup.

Attempts to define two nodes with the same name within a single set of curly brackets should fail.

For example, this is invalid DTS according to dtc:

```dts
    / { foo {}; foo {}; };
```

By contrast, this is valid since the node named 'foo' appears twice in two different sets of curly brackets:

```dts
    / { foo {}; };
    / { foo {}; };
```

Zephyr's dtlib currently does not error out on the invalid condition. Before fixing that, we have to apply patches with updated devicetrees throughout zephyr and the STM32 HAL that remove duplicate nodes. Then we can make dtlib match dtc and add a regression test.

Fixes: #49590