### PR TITLE
gpio_emul: Fail at build time if ngpios is too big

### DIFF
--- a/drivers/gpio/gpio_emul.c
+++ b/drivers/gpio/gpio_emul.c
@@ -792,6 +792,9 @@ static int gpio_emul_pm_device_pm_action(const struct device *dev,
 		.num_pins = DT_INST_PROP(_num, ngpios),			\
 		.interrupt_caps = GPIO_EMUL_INT_CAPS(_num)		\
 	};								\
+	BUILD_ASSERT(							\
+		DT_INST_PROP(_num, ngpios) <= GPIO_MAX_PINS_PER_PORT,	\
+		"Too many ngpios");					\
 									\
 	static struct gpio_emul_data gpio_emul_data_##_num = {		\
 		.flags = gpio_emul_flags_##_num,			\


### PR DESCRIPTION
Add BUILD_ASSERT to check max val of ngpios. If someone sets ngpios to more than 32, and acts on pin 32 or higher, memory corruption will result. This is only a problem with the emulator, real hardware will have limits that are probably much smaller.

Signed-off-by: Jeremy Bettis <jbettis@google.com>