### PR TITLE
tests: Bluetooth: Mesh: adv test buffer management

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_advertiser.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_advertiser.c
@@ -51,6 +51,8 @@ static const char cb_msg[] = "cb test";
 static int64_t tx_timestamp;
 static int seq_checker;
 static struct bt_mesh_test_gatt gatt_param;
+static int num_adv_sent;
+static uint8_t previous_checker = 0xff;
 
 static K_SEM_DEFINE(observer_sem, 0, 1);
 
@@ -74,6 +76,56 @@ static void adv_init(void)
 {
 	bt_mesh_adv_init();
 	ASSERT_OK(bt_mesh_adv_enable(), "Mesh adv init failed");
+}
+
+static void allocate_all_array(struct net_buf **buf, size_t num_buf, uint8_t xmit)
+{
+	for (int i = 0; i < num_buf; i++) {
+		*buf = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
+					  xmit, K_NO_WAIT);
+
+		ASSERT_FALSE(!*buf, "Out of buffers");
+		buf++;
+	}
+}
+
+static void verify_adv_queue_overflow(void)
+{
+	struct net_buf *dummy_buf;
+
+	/* Verity Queue overflow */
+	dummy_buf = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
+				       BT_MESH_TRANSMIT(2, 20), K_NO_WAIT);
+	ASSERT_TRUE(!dummy_buf, "Unexpected extra buffer");
+}
+
+static bool check_delta_time(uint8_t transmit, uint64_t interval)
+{
+	static int cnt;
+	static int64_t timestamp;
+
+	if (cnt) {
+		int64_t delta = k_uptime_delta(&timestamp);
+
+		LOG_INF("rx: cnt(%d) delta(%dms)", cnt, delta);
+
+		ASSERT_TRUE(delta >= interval &&
+			    delta < (interval + 15));
+	} else {
+		timestamp = k_uptime_get();
+
+		LOG_INF("rx: cnt(%d) delta(0ms)", cnt);
+	}
+
+	cnt++;
+
+	if (cnt >= transmit) {
+		cnt = 0;
+		timestamp = 0;
+		return true;
+	}
+
+	return false;
 }
 
 static void single_start_cb(uint16_t duration, int err, void *cb_data)
@@ -164,9 +216,6 @@ static void parse_mesh_proxy_service(struct net_buf_simple *buf)
 static void gatt_scan_cb(const bt_addr_le_t *addr, int8_t rssi,
 			  uint8_t adv_type, struct net_buf_simple *buf)
 {
-	static int cnt;
-	static int64_t timestamp;
-
 	if (adv_type != BT_GAP_ADV_TYPE_ADV_IND) {
 		return;
 	}
@@ -179,24 +228,9 @@ static void gatt_scan_cb(const bt_addr_le_t *addr, int8_t rssi,
 		parse_mesh_proxy_service(buf);
 	}
 
-	if (cnt) {
-		int64_t delta = k_uptime_delta(&timestamp);
+	LOG_INF("rx: %s", txt_msg);
 
-		LOG_INF("rx: %s +%d ms", txt_msg, delta);
-
-		ASSERT_TRUE(delta >= gatt_param.interval &&
-			delta < (gatt_param.interval + 15));
-	} else {
-		timestamp = k_uptime_get();
-
-		LOG_INF("rx: %s +0 ms", txt_msg);
-	}
-
-	cnt++;
-
-	if (cnt == gatt_param.transmits) {
-		cnt = 0;
-		timestamp = 0;
+	if (check_delta_time(gatt_param.transmits, gatt_param.interval)) {
 		LOG_INF("rx completed. stop observer.");
 		k_sem_give(&observer_sem);
 	}
@@ -226,8 +260,6 @@ static void xmit_scan_cb(const bt_addr_le_t *addr, int8_t rssi, uint8_t adv_type
 			struct net_buf_simple *buf)
 {
 	uint8_t length;
-	static int cnt;
-	static int64_t timestamp;
 
 	if (adv_type != BT_GAP_ADV_TYPE_ADV_NONCONN_IND) {
 		return;
@@ -240,26 +272,11 @@ static void xmit_scan_cb(const bt_addr_le_t *addr, int8_t rssi, uint8_t adv_type
 
 	char *data = net_buf_simple_pull_mem(buf, sizeof(txt_msg));
 
+	LOG_INF("rx: %s", txt_msg);
 	ASSERT_EQUAL(0, memcmp(txt_msg, data, sizeof(txt_msg)));
 
-	if (cnt) {
-		int64_t delta = k_uptime_delta(&timestamp);
-
-		LOG_INF("rx: %s +%d ms", txt_msg, delta);
-
-		ASSERT_TRUE(delta >= xmit_param.interval &&
-			delta < (xmit_param.interval + 15));
-	} else {
-		timestamp = k_uptime_get();
-
-		LOG_INF("rx: %s +0 ms", txt_msg);
-	}
-
-	cnt++;
-
-	if (cnt > xmit_param.retr) {
-		cnt = 0;
-		timestamp = 0;
+	/* Add 1 initial transmit to the retransmit. */
+	if (check_delta_time(xmit_param.retr + 1, xmit_param.interval)) {
 		LOG_INF("rx completed. stop observer.");
 		k_sem_give(&observer_sem);
 	}
@@ -283,6 +300,120 @@ static void rx_xmit_adv(void)
 
 	err = bt_le_scan_stop();
 	ASSERT_FALSE(err && err != -EALREADY, "stopping scan failed (err %d)", err);
+}
+
+static void send_order_start_cb(uint16_t duration, int err, void *user_data)
+{
+	struct net_buf *buf = (struct net_buf *)user_data;
+
+	ASSERT_OK(err, "Failed adv start cb err (%d)", err);
+	ASSERT_EQUAL(2, buf->len);
+
+	uint8_t current = buf->data[0];
+	uint8_t previous = buf->data[1];
+
+	LOG_INF("tx start: current(%d) previous(%d)", current, previous);
+
+	ASSERT_EQUAL(previous_checker, previous);
+	previous_checker = current;
+}
+
+static void send_order_end_cb(int err, void *user_data)
+{
+	struct net_buf *buf = (struct net_buf *)user_data;
+
+	ASSERT_OK(err, "Failed adv start cb err (%d)", err);
+	ASSERT_TRUE(!buf->data, "Data not cleared!");
+	seq_checker++;
+	LOG_INF("tx end: seq(%d)", seq_checker);
+
+	if (seq_checker == num_adv_sent) {
+		seq_checker = 0;
+		previous_checker = 0xff;
+		k_sem_give(&observer_sem);
+	}
+}
+
+static void receive_order_scan_cb(const bt_addr_le_t *addr, int8_t rssi, uint8_t adv_type,
+			struct net_buf_simple *buf)
+{
+	uint8_t length;
+	uint8_t current;
+	uint8_t previous;
+
+	length = net_buf_simple_pull_u8(buf);
+	ASSERT_EQUAL(buf->len, length);
+	ASSERT_EQUAL(BT_DATA_MESH_MESSAGE, net_buf_simple_pull_u8(buf));
+	current = net_buf_simple_pull_u8(buf);
+	previous = net_buf_simple_pull_u8(buf);
+	LOG_INF("rx: current(%d) previous(%d)", current, previous);
+	ASSERT_EQUAL(previous_checker, previous);
+
+	/* Add 1 initial transmit to the retransmit. */
+	if (check_delta_time(xmit_param.retr + 1, xmit_param.interval)) {
+		previous_checker = current;
+		k_sem_give(&observer_sem);
+	}
+}
+
+static void receive_order(int expect_adv)
+{
+	struct bt_le_scan_param scan_param = {
+		.type       = BT_HCI_LE_SCAN_PASSIVE,
+		.options    = BT_LE_SCAN_OPT_NONE,
+		.interval   = BT_MESH_ADV_SCAN_UNIT(1000),
+		.window     = BT_MESH_ADV_SCAN_UNIT(1000)
+	};
+	int err;
+
+	err = bt_le_scan_start(&scan_param, receive_order_scan_cb);
+	ASSERT_FALSE(err && err != -EALREADY, "starting scan failed (err %d)", err);
+
+	previous_checker = 0xff;
+	for (int i = 0; i < expect_adv; i++) {
+		err = k_sem_take(&observer_sem, K_SECONDS(10));
+		ASSERT_OK(err, "Didn't receive adv in time");
+	}
+
+	err = bt_le_scan_stop();
+	ASSERT_FALSE(err && err != -EALREADY, "stopping scan failed (err %d)", err);
+}
+
+static void send_adv_buf(struct net_buf *buf, uint8_t curr, uint8_t prev)
+{
+	send_cb.start = send_order_start_cb;
+	send_cb.end = send_order_end_cb;
+
+	(void)net_buf_add_u8(buf, curr);
+	(void)net_buf_add_u8(buf, prev);
+
+	bt_mesh_adv_send(buf, &send_cb, buf);
+	net_buf_unref(buf);
+}
+
+static void send_adv_array(struct net_buf **buf, size_t num_buf, bool reverse)
+{
+	uint8_t previous;
+	int i;
+
+	num_adv_sent = num_buf;
+	previous = 0xff;
+	if (!reverse) {
+		i = 0;
+	} else {
+		i = num_buf - 1;
+	}
+	while ((!reverse && i < num_buf) || (reverse && i >= 0)) {
+		send_adv_buf(*buf, (uint8_t)i, previous);
+		previous = (uint8_t)i;
+		if (!reverse) {
+			buf++;
+			i++;
+		} else {
+			buf--;
+			i--;
+		}
+	}
 }
 
 static void test_tx_cb_single(void)
@@ -326,22 +457,13 @@ static void test_rx_xmit(void)
 static void test_tx_cb_multi(void)
 {
 	struct net_buf *buf[CONFIG_BT_MESH_ADV_BUF_COUNT];
-	struct net_buf *dummy_buf;
 	int err;
 
 	bt_init();
 	adv_init();
 
 	/* Allocate all network buffers. */
-	for (int i = 0; i < CONFIG_BT_MESH_ADV_BUF_COUNT; i++) {
-		buf[i] = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
-				BT_MESH_TRANSMIT(2, 20), K_NO_WAIT);
-		ASSERT_FALSE(!buf[i], "Out of buffers");
-	}
-
-	dummy_buf = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
-			BT_MESH_TRANSMIT(2, 20), K_NO_WAIT);
-	ASSERT_TRUE(!dummy_buf, "Unexpected extra buffer");
+	allocate_all_array(buf, ARRAY_SIZE(buf), BT_MESH_TRANSMIT(2, 20));
 
 	/* Start single adv to reallocate one network buffer in callback.
 	 * Check that the buffer is freed before cb is triggered.
@@ -452,6 +574,115 @@ static void test_rx_proxy_mixin(void)
 	PASS();
 }
 
+static void test_tx_send_order(void)
+{
+	struct net_buf *buf[CONFIG_BT_MESH_ADV_BUF_COUNT];
+	uint8_t xmit = BT_MESH_TRANSMIT(2, 20);
+
+	bt_init();
+	adv_init();
+
+	/* Verify sending order */
+	allocate_all_array(buf, ARRAY_SIZE(buf), xmit);
+	verify_adv_queue_overflow();
+	send_adv_array(&buf[0], ARRAY_SIZE(buf), false);
+
+	/* Wait for no message receive window to end. */
+	ASSERT_OK(k_sem_take(&observer_sem, K_SECONDS(10)),
+		  "Didn't call the last end tx cb.");
+
+	/* Verify buffer allocation/deallocation after sending */
+	allocate_all_array(buf, ARRAY_SIZE(buf), xmit);
+	verify_adv_queue_overflow();
+	for (int i = 0; i < CONFIG_BT_MESH_ADV_BUF_COUNT; i++) {
+		net_buf_unref(buf[i]);
+		buf[i] = NULL;
+	}
+	/* Check that it possible to add just one net buf. */
+	allocate_all_array(buf, 1, xmit);
+
+	PASS();
+}
+
+static void test_tx_reverse_order(void)
+{
+	struct net_buf *buf[CONFIG_BT_MESH_ADV_BUF_COUNT];
+	uint8_t xmit = BT_MESH_TRANSMIT(2, 20);
+
+	bt_init();
+	adv_init();
+
+	/* Verify reversed sending order */
+	allocate_all_array(buf, ARRAY_SIZE(buf), xmit);
+
+	send_adv_array(&buf[CONFIG_BT_MESH_ADV_BUF_COUNT - 1], ARRAY_SIZE(buf), true);
+
+	/* Wait for no message receive window to end. */
+	ASSERT_OK(k_sem_take(&observer_sem, K_SECONDS(10)),
+		  "Didn't call the last end tx cb.");
+
+	PASS();
+}
+
+static void test_tx_random_order(void)
+{
+	struct net_buf *buf[3];
+	uint8_t xmit = BT_MESH_TRANSMIT(0, 20);
+
+	bt_init();
+	adv_init();
+
+	/* Verify random order calls */
+	num_adv_sent = ARRAY_SIZE(buf);
+	previous_checker = 0xff;
+	buf[0] = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
+				    xmit, K_NO_WAIT);
+	ASSERT_FALSE(!buf[0], "Out of buffers");
+	buf[1] = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
+				    xmit, K_NO_WAIT);
+	ASSERT_FALSE(!buf[1], "Out of buffers");
+
+	send_adv_buf(buf[0], 0, 0xff);
+
+	buf[2] = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
+				    xmit, K_NO_WAIT);
+	ASSERT_FALSE(!buf[2], "Out of buffers");
+
+	send_adv_buf(buf[2], 2, 0);
+
+	send_adv_buf(buf[1], 1, 2);
+
+	/* Wait for no message receive window to end. */
+	ASSERT_OK(k_sem_take(&observer_sem, K_SECONDS(10)),
+		  "Didn't call the last end tx cb.");
+
+	PASS();
+}
+
+static void test_rx_receive_order(void)
+{
+	bt_init();
+
+	xmit_param.retr = 2;
+	xmit_param.interval = 20;
+
+	receive_order(CONFIG_BT_MESH_ADV_BUF_COUNT);
+
+	PASS();
+}
+
+static void test_rx_random_order(void)
+{
+	bt_init();
+
+	xmit_param.retr = 0;
+	xmit_param.interval = 20;
+
+	receive_order(3);
+
+	PASS();
+}
+
 #define TEST_CASE(role, name, description)                     \
 	{                                                      \
 		.test_id = "adv_" #role "_" #name,             \
@@ -462,12 +693,17 @@ static void test_rx_proxy_mixin(void)
 	}
 
 static const struct bst_test_instance test_adv[] = {
-	TEST_CASE(tx, cb_single,   "ADV: tx cb parameter checker"),
-	TEST_CASE(tx, cb_multi,    "ADV: tx cb sequence checker"),
-	TEST_CASE(tx, proxy_mixin, "ADV: proxy mix-in gatt adv"),
+	TEST_CASE(tx, cb_single,     "ADV: tx cb parameter checker"),
+	TEST_CASE(tx, cb_multi,      "ADV: tx cb sequence checker"),
+	TEST_CASE(tx, proxy_mixin,   "ADV: proxy mix-in gatt adv"),
+	TEST_CASE(tx, send_order,    "ADV: tx send order"),
+	TEST_CASE(tx, reverse_order, "ADV: tx reversed order"),
+	TEST_CASE(tx, random_order,  "ADV: tx random order"),
 
-	TEST_CASE(rx, xmit,        "ADV: xmit checker"),
-	TEST_CASE(rx, proxy_mixin, "ADV: proxy mix-in scanner"),
+	TEST_CASE(rx, xmit,          "ADV: xmit checker"),
+	TEST_CASE(rx, proxy_mixin,   "ADV: proxy mix-in scanner"),
+	TEST_CASE(rx, receive_order, "ADV: rx receive order"),
+	TEST_CASE(rx, random_order,  "ADV: rx random order"),
 
 	BSTEST_END_MARKER
 };

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/advertiser/random_order.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/advertiser/random_order.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# test buffer management by filling buffers and sending them in random order.
+RunTest mesh_adv_random_order adv_tx_random_order adv_rx_random_order

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/advertiser/reverse_order.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/advertiser/reverse_order.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# test buffer management by filling all the buffer and sending them in reversed order.
+RunTest mesh_adv_reverse_order adv_tx_reverse_order adv_rx_receive_order

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/advertiser/send_order.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/advertiser/send_order.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# test buffer management by filling all the buffer and sending them all in order.
+RunTest mesh_adv_send_order adv_tx_send_order adv_rx_receive_order


### PR DESCRIPTION
The advertiser runs in a loop, pulling advertising buffers from a queue. Features covered:
Queue overflow
Sending order
Buffer freeing
Dedicated buffer pools

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>