### PR TITLE
mgmt: mcumgr: fs_mgmt: hash/checksum: Fix size errors

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/hash_checksum_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/hash_checksum_mgmt.h
@@ -26,7 +26,7 @@ extern "C" {
  * @return 0 on success, negative error code on failure.
  */
 typedef int (*hash_checksum_mgmt_handler_fn)(struct fs_file_t *file,
-					     uint8_t *output, uint32_t *out_len,
+					     uint8_t *output, size_t *out_len,
 					     size_t len);
 
 /**

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/fs_mgmt.c
@@ -420,12 +420,18 @@ fs_mgmt_file_hash_checksum(struct mgmt_ctxt *ctxt)
 
 			if (group->output_size == sizeof(uint8_t)) {
 				tmp_val = (uint64_t)(*(uint8_t *)output);
+#if FS_MGMT_CHECKSUM_HASH_LARGEST_OUTPUT_SIZE > 1
 			} else if (group->output_size == sizeof(uint16_t)) {
 				tmp_val = (uint64_t)(*(uint16_t *)output);
+#if FS_MGMT_CHECKSUM_HASH_LARGEST_OUTPUT_SIZE > 2
 			} else if (group->output_size == sizeof(uint32_t)) {
 				tmp_val = (uint64_t)(*(uint32_t *)output);
+#if FS_MGMT_CHECKSUM_HASH_LARGEST_OUTPUT_SIZE > 4
 			} else if (group->output_size == sizeof(uint64_t)) {
 				tmp_val = (*(uint64_t *)output);
+#endif
+#endif
+#endif
 			} else {
 				LOG_ERR("Unable to handle numerical checksum size %u",
 					group->output_size);


### PR DESCRIPTION
There are warnings when building fs_mgmt with hash/checksum functionality enabled due to array access and a wrong variable type being used.

Fixes #50297