### PR TITLE
drivers: uart: stm32 uart driver must include ll_exti with CONFIG_PM

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -35,6 +35,9 @@
 
 #include <stm32_ll_usart.h>
 #include <stm32_ll_lpuart.h>
+#if defined(CONFIG_PM) && defined(IS_UART_WAKEUP_FROMSTOP_INSTANCE)
+#include <stm32_ll_exti.h>
+#endif /* CONFIG_PM */
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(uart_stm32, CONFIG_UART_LOG_LEVEL);


### PR DESCRIPTION
Missing include to compile correctly when the
CONFIG_PM && IS_UART_WAKEUP_FROMSTOP_INSTANCE are defined

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/50299

Signed-off-by: Francois Ramu <francois.ramu@st.com>