### PR TITLE
ci: twister: Check out west modules for test plan

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -76,7 +76,9 @@ jobs:
           git log  --pretty=oneline | head -n 10
           west init -l . || true
           west config manifest.group-filter -- +ci
-          # no need for west update here
+          west config --global update.narrow true
+          west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/zephyrproject)
+          west forall -c 'git reset --hard HEAD'
 
       - name: Generate Test Plan with Twister
         if: github.event_name == 'pull_request_target'


### PR DESCRIPTION
This commit updates the twister workflow to check out the west modules before running the test plan script for the pull request runs because the twister test plan logic resolves the the module dependencies and filters tests based on the local availability of the required modules.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Tested in https://github.com/zephyrproject-rtos/zephyr-testing/actions/runs/3066646467

This also fixes the issues arising from the module repositories cached in the MI being out of sync with the checked out Zephyr branch, such as https://github.com/zephyrproject-rtos/zephyr/actions/runs/3058788136/jobs/4935394267#step:7:26.