### PR TITLE
Bluetooth: controller: llcp: fix access to context after release

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -387,8 +387,13 @@ static void lr_st_idle(struct ll_conn *conn, uint8_t evt, void *param)
 	case LR_EVT_RUN:
 		ctx = llcp_lr_peek(conn);
 		if (ctx) {
+			/*
+			 * since the call to lr_act_run may release the context we need to remember
+			 * which procedure we are running
+			 */
+			const enum llcp_proc curr_proc = ctx->proc;
 			lr_act_run(conn);
-			if (ctx->proc != PROC_TERMINATE) {
+			if (curr_proc != PROC_TERMINATE) {
 				lr_set_state(conn, LR_STATE_ACTIVE);
 			} else {
 				lr_set_state(conn, LR_STATE_TERMINATE);


### PR DESCRIPTION
There is access to the procedure context after a potential release of the context, which (in theory) can lead to incorrect behaviour

There is no good way of testing this with a unittest without adding specal debug code to the ull_llcp_local module
After code-inspection no other location has been found with potential access after context release

fixes #48850

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>