### PR TITLE
Lwm2m Data Cache API

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -215,6 +215,25 @@ struct lwm2m_ctx {
 	uint8_t validate_buf[CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE];
 };
 
+/**
+* LwM2M Time series data structure
+*/
+struct lwm2m_time_series_elem {
+	/* Cached data Unix timestamp */
+	int64_t t;
+	union {
+		uint8_t u8;
+		uint16_t u16;
+		uint32_t u32;
+		uint32_t u64;
+		int8_t i8;
+		int8_t i16;
+		int8_t i32;
+		int8_t i64;
+		double f;
+		bool b;
+	};
+};
 
 /**
  * @brief Asynchronous callback to get a resource buffer and length.
@@ -1377,6 +1396,19 @@ int lwm2m_engine_send(struct lwm2m_ctx *ctx, char const *path_list[], uint8_t pa
  *
  */
 struct lwm2m_ctx *lwm2m_rd_client_ctx(void);
+
+/** 
+ * @brief LwM2M Resource data cache enable
+ *
+ * @param resource_path LwM2M resourcepath string "obj/obj-inst/res(/res-inst)"
+ * @param data_cache Pointer to Data cache array
+ * @param cache_element_size Length of Data cache entries
+ * 
+ * @return 0 for success or negative in case of error.
+ *
+ */
+int lwm2m_engine_enable_cache(char const *resource_path, struct lwm2m_time_series_elem *data_cache,
+			      size_t cache_element_size);
 
 #endif	/* ZEPHYR_INCLUDE_NET_LWM2M_H_ */
 /**@}  */

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -480,6 +480,19 @@ config LWM2M_RW_SENML_CBOR_RECORDS
 	  The CBOR library requires you to set an upper limit for the records when encoder
 	  and decoder do get generated.
 
+config LWM2M_RESOURCE_DATA_CACHE_SUPPORT
+	bool "Resource Time series data cache support"
+	depends on (LWM2M_RW_SENML_JSON_SUPPORT || LWM2M_RW_SENML_CBOR_SUPPORT)
+	help
+	  Enable Time series data storage for selected resources.
+
+config LWM2M_RESOURCE_DATA_CACHE_ELEMENT_SIZE
+	int "Maxium # of resource count for data cache"
+	default 4
+	range 1 10
+	help
+		This settings define how many different resource client can be enable for data cache.
+
 config LWM2M_DEVICE_PWRSRC_MAX
 	int "Maximum # of device power source records"
 	default 5

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -989,6 +989,8 @@ static int lwm2m_engine_init(const struct device *dev)
 	}
 
 	(void)memset(block1_contexts, 0, sizeof(block1_contexts));
+	/* Init data cache */
+	lwm2m_engine_data_cache_init();
 
 	/* start sock receive thread */
 	engine_thread_id = k_thread_create(&engine_thread_data, &engine_thread_stack[0],

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -965,18 +965,167 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst, struct lwm2m_eng
 	return ret;
 }
 
+static int lwm2m_read_resource_data(struct lwm2m_message *msg, void *data_ptr, size_t data_len,
+			       uint8_t data_type)
+{
+	int ret;
+
+	switch (data_type) {
+
+	case LWM2M_RES_TYPE_OPAQUE:
+		ret = engine_put_opaque(&msg->out, &msg->path, (uint8_t *)data_ptr, data_len);
+		break;
+
+	case LWM2M_RES_TYPE_STRING:
+		ret = engine_put_string(&msg->out, &msg->path, (uint8_t *)data_ptr,
+					strlen((uint8_t *)data_ptr));
+		break;
+
+	case LWM2M_RES_TYPE_U32:
+		ret = engine_put_s64(&msg->out, &msg->path, (int64_t) * (uint32_t *)data_ptr);
+		break;
+
+	case LWM2M_RES_TYPE_U16:
+		ret = engine_put_s32(&msg->out, &msg->path, (int32_t) * (uint16_t *)data_ptr);
+		break;
+
+	case LWM2M_RES_TYPE_U8:
+		ret = engine_put_s16(&msg->out, &msg->path, (int16_t) * (uint8_t *)data_ptr);
+		break;
+
+	case LWM2M_RES_TYPE_S64:
+		ret = engine_put_s64(&msg->out, &msg->path, *(int64_t *)data_ptr);
+		break;
+
+	case LWM2M_RES_TYPE_S32:
+		ret = engine_put_s32(&msg->out, &msg->path, *(int32_t *)data_ptr);
+		break;
+
+	case LWM2M_RES_TYPE_S16:
+		ret = engine_put_s16(&msg->out, &msg->path, *(int16_t *)data_ptr);
+		break;
+
+	case LWM2M_RES_TYPE_S8:
+		ret = engine_put_s8(&msg->out, &msg->path, *(int8_t *)data_ptr);
+		break;
+
+	case LWM2M_RES_TYPE_TIME:
+		ret = engine_put_time(&msg->out, &msg->path, (int64_t) * (uint32_t *)data_ptr);
+		break;
+
+	case LWM2M_RES_TYPE_BOOL:
+		ret = engine_put_bool(&msg->out, &msg->path, *(bool *)data_ptr);
+		break;
+
+	case LWM2M_RES_TYPE_FLOAT:
+		ret = engine_put_float(&msg->out, &msg->path, (double *)data_ptr);
+		break;
+
+	case LWM2M_RES_TYPE_OBJLNK:
+		ret = engine_put_objlnk(&msg->out, &msg->path, (struct lwm2m_objlnk *)data_ptr);
+		break;
+
+	default:
+		LOG_ERR("unknown obj data_type %d", data_type);
+		ret = -EINVAL;
+	}
+
+	return ret;
+}
+
+static int lwm2m_read_cached_data(struct lwm2m_message *msg,
+				  struct lwm2m_time_series_resource *cached_data, uint8_t data_type)
+{
+#if defined(CONFIG_LWM2M_RESOURCE_DATA_CACHE_SUPPORT)
+	int ret, i;
+	struct lwm2m_time_series_elem *elements_ptr = cached_data->elements;
+	int cache_lenght = cached_data->size;
+
+	cached_data->size = 0;
+	LOG_DBG("Read cached data size %u", cache_lenght);
+
+	for (i = 0; i < cache_lenght; i++) {
+
+		ret = engine_put_timestamp(&msg->out, elements_ptr->t);
+		if (ret) {
+			return ret;
+		}
+
+		switch (data_type) {
+
+		case LWM2M_RES_TYPE_U32:
+			ret = engine_put_s64(&msg->out, &msg->path, (int64_t)elements_ptr->u32);
+			break;
+
+		case LWM2M_RES_TYPE_U16:
+			ret = engine_put_s32(&msg->out, &msg->path, (int32_t)elements_ptr->u16);
+			break;
+
+		case LWM2M_RES_TYPE_U8:
+			ret = engine_put_s16(&msg->out, &msg->path, (int16_t)elements_ptr->u8);
+			break;
+
+		case LWM2M_RES_TYPE_S64:
+			ret = engine_put_s64(&msg->out, &msg->path, elements_ptr->i64);
+			break;
+
+		case LWM2M_RES_TYPE_S32:
+			ret = engine_put_s32(&msg->out, &msg->path, elements_ptr->i32);
+			break;
+
+		case LWM2M_RES_TYPE_S16:
+			ret = engine_put_s16(&msg->out, &msg->path, elements_ptr->i16);
+			break;
+
+		case LWM2M_RES_TYPE_S8:
+			ret = engine_put_s8(&msg->out, &msg->path, elements_ptr->i8);
+			break;
+
+		case LWM2M_RES_TYPE_BOOL:
+			ret = engine_put_bool(&msg->out, &msg->path, elements_ptr->b);
+			break;
+
+		case LWM2M_RES_TYPE_FLOAT:
+			ret = engine_put_float(&msg->out, &msg->path, &elements_ptr->f);
+			break;
+
+		default:
+			LOG_ERR("unknown obj data_type %d", data_type);
+			return -EINVAL;
+		}
+
+		/* Validate that we really read some data */
+		if (ret < 0) {
+			LOG_ERR("Read operation fail");
+			return -ENOMEM;
+		}
+		elements_ptr++;
+	}
+	return 0;
+#else
+	return -ENOTSUP;
+#endif
+}
+
 static int lwm2m_read_handler(struct lwm2m_engine_obj_inst *obj_inst, struct lwm2m_engine_res *res,
 			      struct lwm2m_engine_obj_field *obj_field, struct lwm2m_message *msg)
 {
 	int i, loop_max = 1, found_values = 0;
 	uint16_t res_inst_id_tmp = 0U;
 	void *data_ptr = NULL;
+	struct lwm2m_time_series_resource *cached_data = NULL;
 	size_t data_len = 0;
+	struct lwm2m_obj_path temp_path;
 	int ret = 0;
 
 	if (!obj_inst || !res || !obj_field || !msg) {
 		return -EINVAL;
 	}
+	temp_path.obj_id = obj_inst->obj->obj_id;
+
+	temp_path.obj_inst_id = obj_inst->obj_inst_id;
+	temp_path.res_id = obj_field->res_id;
+	temp_path.level = LWM2M_PATH_LEVEL_RESOURCE;
 
 	loop_max = res->res_inst_count;
 	if (res->multi_res_inst) {
@@ -1014,97 +1163,47 @@ static int lwm2m_read_handler(struct lwm2m_engine_obj_inst *obj_inst, struct lwm
 		if (res->res_inst_count > 1) {
 			msg->path.res_inst_id = res->res_instances[i].res_inst_id;
 		}
-
-		/* setup initial data elements */
-		data_ptr = res->res_instances[i].data_ptr;
-		data_len = res->res_instances[i].data_len;
-
-		/* allow user to override data elements via callback */
-		if (res->read_cb) {
-			data_ptr = res->read_cb(obj_inst->obj_inst_id, res->res_id,
-						res->res_instances[i].res_inst_id, &data_len);
+		if (res->multi_res_inst) {
+			temp_path.res_inst_id = res->res_instances[i].res_inst_id;
+			temp_path.level = LWM2M_PATH_LEVEL_RESOURCE_INST;
 		}
 
-		if (!data_ptr && data_len) {
-			return -ENOENT;
-		}
+		
 
-		if (!data_len) {
-			if (obj_field->data_type != LWM2M_RES_TYPE_OPAQUE &&
-			    obj_field->data_type != LWM2M_RES_TYPE_STRING) {
+		cached_data = lwm2m_cache_entry_get_by_object(&temp_path);
+
+		if (cached_data && cached_data->size && msg->out.writer->put_data_timestamp) {
+			/* Content Format Writer have to support timestamp write */
+			ret = lwm2m_read_cached_data(msg, cached_data, obj_field->data_type);
+		} else {
+			/* setup initial data elements */
+			data_ptr = res->res_instances[i].data_ptr;
+			data_len = res->res_instances[i].data_len;
+
+			/* allow user to override data elements via callback */
+			if (res->read_cb) {
+				data_ptr =
+					res->read_cb(obj_inst->obj_inst_id, res->res_id,
+						     res->res_instances[i].res_inst_id, &data_len);
+			}
+
+			if (!data_ptr && data_len) {
 				return -ENOENT;
 			}
-			/* Only opaque and string types can be empty, and when
-			 * empty, we should not give pointer to potentially uninitialized
-			 * data to a content formatter. Give pointer to empty string instead.
-			 */
-			data_ptr = "";
-		}
 
-		switch (obj_field->data_type) {
-
-		case LWM2M_RES_TYPE_OPAQUE:
-			ret = engine_put_opaque(&msg->out, &msg->path, (uint8_t *)data_ptr,
-						data_len);
-			break;
-
-		case LWM2M_RES_TYPE_STRING:
-			ret = engine_put_string(&msg->out, &msg->path, (uint8_t *)data_ptr,
-						strlen((uint8_t *)data_ptr));
-			break;
-
-		case LWM2M_RES_TYPE_U32:
-			ret = engine_put_s64(&msg->out, &msg->path,
-					     (int64_t) *(uint32_t *)data_ptr);
-			break;
-
-		case LWM2M_RES_TYPE_U16:
-			ret = engine_put_s32(&msg->out, &msg->path,
-					     (int32_t) *(uint16_t *)data_ptr);
-			break;
-
-		case LWM2M_RES_TYPE_U8:
-			ret = engine_put_s16(&msg->out, &msg->path,
-					     (int16_t) *(uint8_t *)data_ptr);
-			break;
-
-		case LWM2M_RES_TYPE_S64:
-			ret = engine_put_s64(&msg->out, &msg->path, *(int64_t *)data_ptr);
-			break;
-
-		case LWM2M_RES_TYPE_S32:
-			ret = engine_put_s32(&msg->out, &msg->path, *(int32_t *)data_ptr);
-			break;
-
-		case LWM2M_RES_TYPE_S16:
-			ret = engine_put_s16(&msg->out, &msg->path, *(int16_t *)data_ptr);
-			break;
-
-		case LWM2M_RES_TYPE_S8:
-			ret = engine_put_s8(&msg->out, &msg->path, *(int8_t *)data_ptr);
-			break;
-
-		case LWM2M_RES_TYPE_TIME:
-			ret = engine_put_time(&msg->out, &msg->path,
-					      (int64_t) *(uint32_t *)data_ptr);
-			break;
-
-		case LWM2M_RES_TYPE_BOOL:
-			ret = engine_put_bool(&msg->out, &msg->path, *(bool *)data_ptr);
-			break;
-
-		case LWM2M_RES_TYPE_FLOAT:
-			ret = engine_put_float(&msg->out, &msg->path, (double *)data_ptr);
-			break;
-
-		case LWM2M_RES_TYPE_OBJLNK:
-			ret = engine_put_objlnk(&msg->out, &msg->path,
-						(struct lwm2m_objlnk *)data_ptr);
-			break;
-
-		default:
-			LOG_ERR("unknown obj data_type %d", obj_field->data_type);
-			return -EINVAL;
+			if (!data_len) {
+				if (obj_field->data_type != LWM2M_RES_TYPE_OPAQUE &&
+				    obj_field->data_type != LWM2M_RES_TYPE_STRING) {
+					return -ENOENT;
+				}
+				/* Only opaque and string types can be empty, and when
+				 * empty, we should not give pointer to potentially uninitialized
+				 * data to a content formatter. Give pointer to empty string
+				 * instead.
+				 */
+				data_ptr = "";
+			}
+			ret = lwm2m_read_resource_data(msg, data_ptr, data_len, obj_field->data_type);
 		}
 
 		/* Validate that we really read some data */

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -430,16 +430,6 @@ struct lwm2m_opaque_context {
 	size_t remaining;
 };
 
-struct lwm2m_senml_json_context {
-	bool base_name_stored : 1;
-	bool full_name_true : 1;
-	uint8_t base64_buf_len : 2;
-	uint8_t base64_mod_buf[3];
-	uint8_t json_flags;
-	struct lwm2m_obj_path base_name_path;
-	uint8_t resource_path_level;
-};
-
 struct lwm2m_block_context {
 	struct coap_block_context ctx;
 	struct lwm2m_opaque_context opaque;

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -536,6 +536,8 @@ struct lwm2m_writer {
 			    struct lwm2m_obj_path *path);
 	int (*put_end_ri)(struct lwm2m_output_context *out,
 			  struct lwm2m_obj_path *path);
+	int (*put_data_timestamp)(struct lwm2m_output_context *out,
+				int64_t value);
 	int (*put_s8)(struct lwm2m_output_context *out,
 		      struct lwm2m_obj_path *path, int8_t value);
 	int (*put_s16)(struct lwm2m_output_context *out,
@@ -771,6 +773,16 @@ static inline int engine_put_corelink(struct lwm2m_output_context *out,
 	}
 
 	return -ENOTSUP;
+}
+
+static inline int engine_put_timestamp(struct lwm2m_output_context *out, int64_t timestamp)
+{
+	if (out->writer->put_data_timestamp) {
+		return out->writer->put_data_timestamp(out, timestamp);
+	}
+
+	return 0;
+	
 }
 
 static inline int engine_get_s32(struct lwm2m_input_context *in, int32_t *value)

--- a/subsys/net/lib/lwm2m/lwm2m_registry.h
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.h
@@ -196,4 +196,27 @@ size_t lwm2m_engine_get_opaque_more(struct lwm2m_input_context *in, uint8_t *buf
 /* Resources */
 sys_slist_t *lwm2m_engine_obj_list(void);
 sys_slist_t *lwm2m_engine_obj_inst_list(void);
+
+/* Data cache Internal API */
+
+/**
+* LwM2M Time series resoursce data storage
+*/
+struct lwm2m_time_series_resource {
+	/* object list */
+	sys_snode_t node;
+	/* Resource Path url */
+	const char *path;
+	/* Size of cached data */
+	size_t size;
+	/* Data cache capacity */
+	size_t capacity;
+	/* Cache buffer */
+	struct lwm2m_time_series_elem *elements;
+};
+
+int lwm2m_engine_data_cache_init(void);
+struct lwm2m_time_series_resource *lwm2m_cache_entry_get_by_object(struct lwm2m_obj_path *obj_path);
+struct lwm2m_time_series_resource *lwm2m_cache_entry_get_by_string(char const *resource_path);
+
 #endif /* LWM2M_REGISTRY_H */

--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.c
@@ -55,15 +55,34 @@ struct senml_boolean_payload {
 	bool val_bool;
 };
 
+struct senml_boolean_t_payload {
+	const char *name;
+	bool val_bool;
+	struct json_obj_token time;
+};
+
 struct senml_boolean_bn_payload {
 	const char *base_name;
 	const char *name;
 	bool val_bool;
 };
 
+struct senml_boolean_bn_t_payload {
+	const char *base_name;
+	const char *name;
+	bool val_bool;
+	struct json_obj_token base_time;
+};
+
 struct senml_float_payload {
 	const char *name;
 	struct json_obj_token val_float;
+};
+
+struct senml_float_t_payload {
+	const char *name;
+	struct json_obj_token val_float;
+	struct json_obj_token time;
 };
 
 struct senml_float_bn_payload {
@@ -72,12 +91,23 @@ struct senml_float_bn_payload {
 	struct json_obj_token val_float;
 };
 
+struct senml_float_bn_t_payload {
+	const char *base_name;
+	const char *name;
+	struct json_obj_token val_float;
+	struct json_obj_token base_time;
+};
+
 struct senml_json_object {
 	union {
 		struct senml_float_payload  float_obj;
+		struct senml_float_t_payload float_t_obj;
 		struct senml_float_bn_payload float_bn_obj;
+		struct senml_float_bn_t_payload float_bn_t_obj;
 		struct senml_boolean_payload boolean_obj;
+		struct senml_boolean_t_payload boolean_t_obj;
 		struct senml_boolean_bn_payload boolean_bn_obj;
+		struct senml_boolean_bn_t_payload boolean_bn_t_obj;
 		struct senml_opaque_payload  opaque_obj;
 		struct senml_opaque_bn_payload  opaque_bn_obj;
 		struct senml_string_payload string_obj;
@@ -89,8 +119,12 @@ struct json_out_formatter_data {
 	uint8_t writer_flags;
 	struct lwm2m_obj_path base_name;
 	bool add_base_name_to_start;
+	bool historical_data;
 	char bn_string[sizeof("/65535/65535/") + 1];
 	char name_string[sizeof("/65535/65535/") + 1];
+	char timestamp_buffer[42];
+	int timestamp_length;
+	int64_t base_time;
 	struct senml_json_object json;
 	struct lwm2m_output_context *out;
 };
@@ -146,11 +180,32 @@ static const struct json_obj_descr senml_float_bn_descr[] = {
 				  val_float, JSON_TOK_FLOAT),
 };
 
+static const struct json_obj_descr senml_float_bn_t_descr[] = {
+	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_float_bn_t_payload, "bn",
+				  base_name, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_float_bn_t_payload, "bt",
+				  base_time, JSON_TOK_FLOAT),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_float_bn_t_payload, "n",
+				  name, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_float_bn_t_payload, "v",
+				  val_float, JSON_TOK_FLOAT),
+	
+};
+
 static const struct json_obj_descr senml_float_descr[] = {
 	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_float_payload, "n",
 				  name, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_float_payload, "v",
 				  val_float, JSON_TOK_FLOAT),
+};
+
+static const struct json_obj_descr senml_float_t_descr[] = {
+	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_float_t_payload, "n",
+				  name, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_float_t_payload, "v",
+				  val_float, JSON_TOK_FLOAT),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_float_t_payload, "t",
+				  time, JSON_TOK_FLOAT),
 };
 
 static const struct json_obj_descr senml_boolean_bn_descr[] = {
@@ -162,11 +217,31 @@ static const struct json_obj_descr senml_boolean_bn_descr[] = {
 				  val_bool, JSON_TOK_TRUE),
 };
 
+static const struct json_obj_descr senml_boolean_bn_t_descr[] = {
+	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_boolean_bn_t_payload, "bn",
+				  base_name, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_boolean_bn_t_payload, "bt",
+				  base_time, JSON_TOK_FLOAT),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_boolean_bn_t_payload, "n",
+				  name, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_boolean_bn_t_payload, "vb",
+				  val_bool, JSON_TOK_TRUE),
+};
+
 static const struct json_obj_descr senml_boolean_descr[] = {
 	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_boolean_payload, "n",
 				  name, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_boolean_payload, "vb",
 				  val_bool, JSON_TOK_TRUE),
+};
+
+static const struct json_obj_descr senml_boolean_t_descr[] = {
+	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_boolean_t_payload, "n",
+				  name, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_boolean_t_payload, "vb",
+				  val_bool, JSON_TOK_TRUE),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct senml_boolean_t_payload, "t",
+				  time, JSON_TOK_FLOAT),
 };
 
 static const struct json_obj_descr senml_obj_lnk_bn_descr[] = {
@@ -347,20 +422,36 @@ static int put_end_ri(struct lwm2m_output_context *out, struct lwm2m_obj_path *p
 	return 0;
 }
 
-static int number_to_string(const char *format, ...)
+static int put_end_r(struct lwm2m_output_context *out, struct lwm2m_obj_path *path)
+{
+	struct json_out_formatter_data *fd;
+
+	fd = engine_get_out_user_data(out);
+	if (!fd) {
+		return -EINVAL;
+	}
+
+	/* Clear Historical Data */
+	fd->historical_data = false;
+	fd->base_time = 0;
+	return 0;
+}
+
+static int number_to_string(char *buf, size_t buf_len, const char *format, ...)
 {
 	va_list vargs;
 	int n;
 
 	va_start(vargs, format);
-	n = vsnprintk(pt_buffer, sizeof(pt_buffer), format, vargs);
+	n = vsnprintk(buf, buf_len, format, vargs);
 	va_end(vargs);
-	if (n < 0 || n >= sizeof(pt_buffer)) {
+	if (n < 0 || n >= buf_len) {
 		return -EINVAL;
 	}
 
 	return n;
 }
+
 
 static int float_to_string(double *value)
 {
@@ -418,21 +509,44 @@ static int json_float_object_write(struct lwm2m_output_context *out,
 	}
 
 	if (fd->add_base_name_to_start) {
-		descr = senml_float_bn_descr;
-		descr_len = ARRAY_SIZE(senml_float_bn_descr);
-		obj_payload = &fd->json.obj.float_bn_obj;
-		fd->json.obj.float_bn_obj.base_name = fd->bn_string;
-		fd->json.obj.float_bn_obj.name = fd->name_string;
-		fd->json.obj.float_bn_obj.val_float.start = pt_buffer;
-		fd->json.obj.float_bn_obj.val_float.length = float_string_length;
+		if (fd->historical_data) {
+			descr = senml_float_bn_t_descr;
+			descr_len = ARRAY_SIZE(senml_float_bn_t_descr);
+			obj_payload = &fd->json.obj.float_bn_t_obj;
+			fd->json.obj.float_bn_t_obj.base_name = fd->bn_string;
+			fd->json.obj.float_bn_t_obj.name = fd->name_string;
+			fd->json.obj.float_bn_t_obj.val_float.start = pt_buffer;
+			fd->json.obj.float_bn_t_obj.val_float.length = float_string_length;
+			fd->json.obj.float_bn_t_obj.base_time.start = fd->timestamp_buffer;
+			fd->json.obj.float_bn_t_obj.base_time.length = fd->timestamp_length;
+		} else {
+			descr = senml_float_bn_descr;
+			descr_len = ARRAY_SIZE(senml_float_bn_descr);
+			obj_payload = &fd->json.obj.float_bn_obj;
+			fd->json.obj.float_bn_obj.base_name = fd->bn_string;
+			fd->json.obj.float_bn_obj.name = fd->name_string;
+			fd->json.obj.float_bn_obj.val_float.start = pt_buffer;
+			fd->json.obj.float_bn_obj.val_float.length = float_string_length;
+		}
 
 	} else {
-		descr = senml_float_descr;
-		descr_len = ARRAY_SIZE(senml_float_descr);
-		obj_payload = &fd->json.obj.float_obj;
-		fd->json.obj.float_obj.name = fd->name_string;
-		fd->json.obj.float_obj.val_float.start = pt_buffer;
-		fd->json.obj.float_obj.val_float.length = float_string_length;
+		if (fd->historical_data) {
+			descr = senml_float_t_descr;
+			descr_len = ARRAY_SIZE(senml_float_t_descr);
+			obj_payload = &fd->json.obj.float_t_obj;
+			fd->json.obj.float_t_obj.name = fd->name_string;
+			fd->json.obj.float_t_obj.val_float.start = pt_buffer;
+			fd->json.obj.float_t_obj.val_float.length = float_string_length;
+			fd->json.obj.float_t_obj.time.start = fd->timestamp_buffer;
+			fd->json.obj.float_t_obj.time.length = fd->timestamp_length;
+		} else {
+			descr = senml_float_descr;
+			descr_len = ARRAY_SIZE(senml_float_descr);
+			obj_payload = &fd->json.obj.float_obj;
+			fd->json.obj.float_obj.name = fd->name_string;
+			fd->json.obj.float_obj.val_float.start = pt_buffer;
+			fd->json.obj.float_obj.val_float.length = float_string_length;
+		}
 	}
 
 	/* Calculate length */
@@ -518,19 +632,40 @@ static int json_boolean_object_write(struct lwm2m_output_context *out,
 	}
 
 	if (fd->add_base_name_to_start) {
-		descr = senml_boolean_bn_descr;
-		descr_len = ARRAY_SIZE(senml_boolean_bn_descr);
-		obj_payload = &fd->json.obj.boolean_bn_obj;
-		fd->json.obj.boolean_bn_obj.base_name = fd->bn_string;
-		fd->json.obj.boolean_bn_obj.name = fd->name_string;
-		fd->json.obj.boolean_bn_obj.val_bool = value;
+		if (fd->historical_data) {
+			descr = senml_boolean_bn_t_descr;
+			descr_len = ARRAY_SIZE(senml_boolean_bn_t_descr);
+			obj_payload = &fd->json.obj.boolean_bn_t_obj;
+			fd->json.obj.boolean_bn_t_obj.base_name = fd->bn_string;
+			fd->json.obj.boolean_bn_t_obj.name = fd->name_string;
+			fd->json.obj.boolean_bn_t_obj.base_time.start = fd->timestamp_buffer;
+			fd->json.obj.boolean_bn_t_obj.base_time.length = fd->timestamp_length;
+			fd->json.obj.boolean_bn_t_obj.val_bool = value;
+		} else {
+			descr = senml_boolean_bn_descr;
+			descr_len = ARRAY_SIZE(senml_boolean_bn_descr);
+			obj_payload = &fd->json.obj.boolean_bn_obj;
+			fd->json.obj.boolean_bn_obj.base_name = fd->bn_string;
+			fd->json.obj.boolean_bn_obj.name = fd->name_string;
+			fd->json.obj.boolean_bn_obj.val_bool = value;
+		}
 
 	} else {
-		descr = senml_boolean_descr;
-		descr_len = ARRAY_SIZE(senml_boolean_descr);
-		obj_payload = &fd->json.obj.boolean_obj;
-		fd->json.obj.boolean_obj.name = fd->name_string;
-		fd->json.obj.boolean_obj.val_bool = value;
+		if (fd->historical_data) {
+			descr = senml_boolean_t_descr;
+			descr_len = ARRAY_SIZE(senml_boolean_t_descr);
+			obj_payload = &fd->json.obj.boolean_t_obj;
+			fd->json.obj.boolean_t_obj.name = fd->name_string;
+			fd->json.obj.boolean_t_obj.time.start = fd->timestamp_buffer;
+			fd->json.obj.boolean_t_obj.time.length = fd->timestamp_length;
+			fd->json.obj.boolean_t_obj.val_bool = value;
+		} else {
+			descr = senml_boolean_descr;
+			descr_len = ARRAY_SIZE(senml_boolean_descr);
+			obj_payload = &fd->json.obj.boolean_obj;
+			fd->json.obj.boolean_obj.name = fd->name_string;
+			fd->json.obj.boolean_obj.val_bool = value;
+		}
 	}
 
 	/* Calculate length */
@@ -616,7 +751,7 @@ static int put_s32(struct lwm2m_output_context *out, struct lwm2m_obj_path *path
 		return -EINVAL;
 	}
 
-	len = number_to_string("%d", value);
+	len = number_to_string(pt_buffer, sizeof(pt_buffer), "%d", value);
 	if (len < 0) {
 		return len;
 	}
@@ -649,7 +784,7 @@ static int put_s64(struct lwm2m_output_context *out, struct lwm2m_obj_path *path
 		return -EINVAL;
 	}
 
-	len = number_to_string("%lld", value);
+	len = number_to_string(pt_buffer, sizeof(pt_buffer),"%lld", value);
 	if (len < 0) {
 		return len;
 	}
@@ -1181,12 +1316,43 @@ static int get_objlnk(struct lwm2m_input_context *in, struct lwm2m_objlnk *value
 	return total_len;
 }
 
+static int put_data_timestamp(struct lwm2m_output_context *out, int64_t value)
+{
+	struct json_out_formatter_data *fd;
+	int len;
+
+	fd = engine_get_out_user_data(out);
+
+	if (!out->out_cpkt || !fd) {
+		LOG_ERR("Timestamp fail");
+		return -EINVAL;
+	}
+
+	len = number_to_string(fd->timestamp_buffer, sizeof(fd->timestamp_buffer), "%lld",
+			       value - fd->base_time);
+
+	if (len < 0) {
+		return len;
+	}
+
+	if (fd->base_time == 0) {
+		/* Store  base time */
+		fd->base_time = value;
+	}
+
+	fd->timestamp_length = len;
+	fd->historical_data = true;
+
+	return 0;
+}
+
 const struct lwm2m_writer senml_json_writer = {
 	.put_begin = put_begin,
 	.put_end = put_end,
 	.put_begin_oi = put_begin_oi,
 	.put_begin_ri = put_begin_ri,
 	.put_end_ri = put_end_ri,
+	.put_end_r = put_end_r,
 	.put_s8 = put_s8,
 	.put_s16 = put_s16,
 	.put_s32 = put_s32,
@@ -1197,6 +1363,7 @@ const struct lwm2m_writer senml_json_writer = {
 	.put_bool = put_bool,
 	.put_opaque = put_opaque,
 	.put_objlnk = put_objlnk,
+	.put_data_timestamp = put_data_timestamp,
 };
 
 const struct lwm2m_reader senml_json_reader = {

--- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor.cddl
+++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor.cddl
@@ -2,13 +2,15 @@ lwm2m_senml = [1* record]
 
 record = {
 	? bn => tstr,            ; Base Name
+	? bt => int .size 8,     ; Base Time
 	? n => tstr,             ; Name
+	? t => int .size 8,      ; Time
 	? ( vi => int .size 8 // ; Integer Value
 	    vf => float       // ; Float Value
 	    vs => tstr        // ; String Value
 	    vb => bool        // ; Boolean Value
 	    vd => bstr ),        ; Data Value
-	0*3 key-value-pair       ; To handle unordered maps; length-first ordered map keys
+	0*5 key-value-pair       ; To handle unordered maps; length-first ordered map keys
 }
 
 ; now define the generic versions
@@ -17,7 +19,9 @@ key-value-pair = ( int => value )
 value = tstr / bstr / int .size 8 / float / bool
 
 n  = 0
+t = 6
 bn = -2
+bt = -3
 vi = 2
 vf = 2
 vs = 3

--- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_encode.c
+++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_encode.c
@@ -13,12 +13,15 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include <limits.h>
 #include "zcbor_encode.h"
 #include "lwm2m_senml_cbor_encode.h"
 #include "lwm2m_senml_cbor_types.h"
 
 static bool encode_repeated_record_bn(zcbor_state_t *state, const struct record_bn *input);
+static bool encode_repeated_record_bt(zcbor_state_t *state, const struct record_bt *input);
 static bool encode_repeated_record_n(zcbor_state_t *state, const struct record_n *input);
+static bool encode_repeated_record_t(zcbor_state_t *state, const struct record_t *input);
 static bool encode_repeated_record_union(zcbor_state_t *state, const struct record_union_ *input);
 static bool encode_value(zcbor_state_t *state, const struct value_ *input);
 static bool encode_key_value_pair(zcbor_state_t *state, const struct key_value_pair *input);
@@ -41,12 +44,46 @@ static bool encode_repeated_record_bn(zcbor_state_t *state, const struct record_
 	return tmp_result;
 }
 
+static bool encode_repeated_record_bt(zcbor_state_t *state, const struct record_bt *input)
+{
+	zcbor_print("%s\r\n", __func__);
+
+	bool tmp_result = ((((zcbor_int32_put(state, (-3)))) &&
+			    ((((*input)._record_bt >= INT64_MIN) &&
+			      ((*input)._record_bt <= INT64_MAX)) ||
+			     (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false)) &&
+			    (zcbor_int64_encode(state, (&(*input)._record_bt)))));
+
+	if (!tmp_result) {
+		zcbor_trace();
+	}
+
+	return tmp_result;
+}
+
 static bool encode_repeated_record_n(zcbor_state_t *state, const struct record_n *input)
 {
 	zcbor_print("%s\r\n", __func__);
 
 	bool tmp_result = ((((zcbor_uint32_put(state, (0)))) &&
 			    (zcbor_tstr_encode(state, (&(*input)._record_n)))));
+
+	if (!tmp_result) {
+		zcbor_trace();
+	}
+
+	return tmp_result;
+}
+
+static bool encode_repeated_record_t(zcbor_state_t *state, const struct record_t *input)
+{
+	zcbor_print("%s\r\n", __func__);
+
+	bool tmp_result =
+		((((zcbor_uint32_put(state, (6)))) &&
+		  ((((*input)._record_t >= INT64_MIN) && ((*input)._record_t <= INT64_MAX)) ||
+		   (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE), false)) &&
+		  (zcbor_int64_encode(state, (&(*input)._record_t)))));
 
 	if (!tmp_result) {
 		zcbor_trace();
@@ -81,8 +118,8 @@ static bool encode_repeated_record_union(zcbor_state_t *state, const struct reco
 								    ? (((zcbor_uint32_put(state,
 											  (8)))) &&
 								       (zcbor_bstr_encode(
-									state,
-									(&(*input)._union_vd))))
+									       state,
+									       (&(*input)._union_vd))))
 								    : false)))))));
 
 	if (!tmp_result) {
@@ -102,10 +139,8 @@ static bool encode_value(zcbor_state_t *state, const struct value_ *input)
 			: (((*input)._value_choice == _value_bstr)
 				   ? ((zcbor_bstr_encode(state, (&(*input)._value_bstr))))
 				   : (((*input)._value_choice == _value_int)
-					      ? (((((*input)._value_int >=
-						    INT64_MIN) &&
-						   ((*input)._value_int <=
-						    INT64_MAX)) ||
+					      ? (((((*input)._value_int >= INT64_MIN) &&
+						   ((*input)._value_int <= INT64_MAX)) ||
 						  (zcbor_error(state, ZCBOR_ERR_WRONG_RANGE),
 						   false)) &&
 						 (zcbor_int64_encode(state,
@@ -116,8 +151,8 @@ static bool encode_value(zcbor_state_t *state, const struct value_ *input)
 								   (&(*input)._value_float))))
 							 : (((*input)._value_choice == _value_bool)
 								    ? ((zcbor_bool_encode(
-									state,
-									(&(*input)._value_bool))))
+									      state,
+									      (&(*input)._value_bool))))
 								    : false)))))));
 
 	if (!tmp_result) {
@@ -155,19 +190,26 @@ static bool encode_repeated_record__key_value_pair(zcbor_state_t *state,
 	return tmp_result;
 }
 
-static bool encode_record(zcbor_state_t *state, const struct record *input)
+static bool encode_record(
+		zcbor_state_t *state, const struct record *input)
 {
 	zcbor_print("%s\r\n", __func__);
 
 	int max_keys = ARRAY_SIZE(input->_record__key_value_pair);
 
-	bool tmp_result = (((zcbor_map_start_encode(state, max_keys + 3) &&
+	bool tmp_result = (((zcbor_map_start_encode(state, max_keys + 5) &&
 			     ((zcbor_present_encode(&((*input)._record_bn_present),
 						    (zcbor_encoder_t *)encode_repeated_record_bn,
 						    state, (&(*input)._record_bn)) &&
+			       zcbor_present_encode(&((*input)._record_bt_present),
+						    (zcbor_encoder_t *)encode_repeated_record_bt,
+						    state, (&(*input)._record_bt)) &&
 			       zcbor_present_encode(&((*input)._record_n_present),
 						    (zcbor_encoder_t *)encode_repeated_record_n,
 						    state, (&(*input)._record_n)) &&
+			       zcbor_present_encode(&((*input)._record_t_present),
+						    (zcbor_encoder_t *)encode_repeated_record_t,
+						    state, (&(*input)._record_t)) &&
 			       zcbor_present_encode(&((*input)._record_union_present),
 						    (zcbor_encoder_t *)encode_repeated_record_union,
 						    state, (&(*input)._record_union)) &&
@@ -177,7 +219,7 @@ static bool encode_record(zcbor_state_t *state, const struct record *input)
 				       state, (&(*input)._record__key_value_pair),
 				       sizeof(struct record__key_value_pair))) ||
 			      (zcbor_list_map_end_force_encode(state), false)) &&
-			     zcbor_map_end_encode(state, max_keys + 3))));
+			     zcbor_map_end_encode(state, max_keys + 5))));
 
 	if (!tmp_result) {
 		zcbor_trace();
@@ -207,7 +249,7 @@ static bool encode_lwm2m_senml(zcbor_state_t *state, const struct lwm2m_senml *i
 }
 
 int cbor_encode_lwm2m_senml(uint8_t *payload, size_t payload_len, const struct lwm2m_senml *input,
-			    size_t *payload_len_out)
+		size_t *payload_len_out)
 {
 	zcbor_state_t states[5];
 

--- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_encode.h
+++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_encode.h
@@ -20,6 +20,6 @@
 #include "lwm2m_senml_cbor_types.h"
 
 int cbor_encode_lwm2m_senml(uint8_t *payload, size_t payload_len, const struct lwm2m_senml *input,
-			    size_t *payload_len_out);
+		size_t *payload_len_out);
 
 #endif /* LWM2M_SENML_CBOR_ENCODE_H__ */

--- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_types.h
+++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_types.h
@@ -21,7 +21,9 @@
 
 enum lwm2m_senml_cbor_key {
 	lwm2m_senml_cbor_key_bn = -2,
+	lwm2m_senml_cbor_key_bt = -3,
 	lwm2m_senml_cbor_key_n  = 0,
+	lwm2m_senml_cbor_key_t  = 6,
 	lwm2m_senml_cbor_key_vi = 2,
 	lwm2m_senml_cbor_key_vf = 2,
 	lwm2m_senml_cbor_key_vs = 3,
@@ -42,8 +44,16 @@ struct record_bn {
 	struct zcbor_string _record_bn;
 };
 
+struct record_bt {
+	int64_t _record_bt;
+};
+
 struct record_n {
 	struct zcbor_string _record_n;
+};
+
+struct record_t {
+	int64_t _record_t;
 };
 
 struct record_union_ {
@@ -102,11 +112,15 @@ struct record__key_value_pair {
 struct record {
 	struct record_bn _record_bn;
 	uint_fast32_t _record_bn_present;
+	struct record_bt _record_bt;
+	uint_fast32_t _record_bt_present;
 	struct record_n _record_n;
 	uint_fast32_t _record_n_present;
+	struct record_t _record_t;
+	uint_fast32_t _record_t_present;
 	struct record_union_ _record_union;
 	uint_fast32_t _record_union_present;
-	struct record__key_value_pair _record__key_value_pair[3];
+	struct record__key_value_pair _record__key_value_pair[5];
 	uint_fast32_t _record__key_value_pair_count;
 };
 


### PR DESCRIPTION
New API for enable Historical data storage for selected LwM2M resource.
Data cache is only supported at resource which resource size is static and well known:
* Signed and unsigned 8-64-bit resources
* Float
* Boolean

Object Writer Update

Extend output writer API for write cached data timestamp.

SenML-CBOR Encoder and CDDTL update

Added support for historical data encode by adding base time (bt) and time (t) label.
New labels are needed for Encoder so Decoder is not regenerated.
Added support for SenML-CBOR to write time series data.
Use "bt" base time and "t" timestamp labels for data cache.

SenML-JSON support for Historical data

Extend SenML-JSON content format for handle cached data timestamp API for base time and timestamp label's.
Added support for write historical data for static resource size's: Float (v) and Boolean (vb).


