### PR TITLE
mgmt/mcumgr: Fix CONFIG_MGMT_VERBOSE_ERR_RESPONSE 

### DIFF
--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -244,16 +244,6 @@ void mgmt_unregister_group(struct mgmt_group *group);
 const struct mgmt_handler *mgmt_find_handler(uint16_t group_id, uint16_t command_id);
 
 /**
- * @brief Encodes a response status into the specified management context.
- *
- * @param ctxt		The management context to encode into.
- * @param status	The response status to write.
- *
- * @return 0 on success, MGMT_ERR_[...] code on failure.
- */
-int mgmt_write_rsp_status(struct mgmt_ctxt *ctxt, int status);
-
-/**
  * @brief Byte-swaps an mcumgr header from network to host byte order.
  *
  * @param hdr The mcumgr header to byte-swap.

--- a/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
@@ -65,25 +65,6 @@ mgmt_register_group(struct mgmt_group *group)
 	sys_slist_append(&mgmt_group_list, &group->node);
 }
 
-int
-mgmt_write_rsp_status(struct mgmt_ctxt *ctxt, int errcode)
-{
-	bool ok;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
-
-	zcbor_tstr_put_lit(zse, "rc");
-	ok = zcbor_int32_put(zse, errcode);
-
-#ifdef CONFIG_MGMT_VERBOSE_ERR_RESPONSE
-	if (ok && MGMT_CTXT_RC_RSN(ctxt) != NULL) {
-		ok = zcbor_tstr_put_lit(zse, "rsn")			&&
-		     zcbor_tstr_put_term(zse, MGMT_CTXT_RC_RSN(ctxt));
-	}
-#endif
-
-	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
-}
-
 void
 mgmt_ntoh_hdr(struct mgmt_hdr *hdr)
 {

--- a/subsys/mgmt/mcumgr/lib/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/lib/smp/src/smp.c
@@ -72,10 +72,19 @@ smp_build_err_rsp(struct smp_streamer *streamer, const struct mgmt_hdr *req_hdr,
 	zcbor_state_t *zsp = nbw->zs;
 	bool ok;
 
-	ok = zcbor_map_start_encode(zsp, 1)		&&
+	ok = zcbor_map_start_encode(zsp, 2)		&&
 	     zcbor_tstr_put_lit(zsp, "rc")		&&
-	     zcbor_int32_put(zsp, status)		&&
-	     zcbor_map_end_encode(zsp, 1);
+	     zcbor_int32_put(zsp, status);
+
+#ifdef CONFIG_MGMT_VERBOSE_ERR_RESPONSE
+	if (ok && rc_rsn != NULL) {
+		ok = zcbor_tstr_put_lit(zsp, "rsn")			&&
+		     zcbor_tstr_put_term(zsp, rc_rsn);
+	}
+#else
+	ARG_UNUSED(rc_rsn);
+#endif
+	ok &= zcbor_map_end_encode(zsp, 2);
 
 	if (!ok) {
 		return MGMT_ERR_EMSGSIZE;


### PR DESCRIPTION
The PR consists of two commits:
 1) Fixing no longer working  `CONFIG_MGMT_VERBOSE_ERR_RESPONSE`, which have been broken during zcbor transition;
 2) Removing `mgmt_write_rsp_status` function, which is no longer needed as `smp_build_err_rsp` replaced it.