### PR TITLE
mgmt/mcumgr: Make img_mgmt_erase construct only good response

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -284,8 +284,10 @@ img_mgmt_erase(struct mgmt_ctxt *ctxt)
 		img_mgmt_dfu_stopped();
 	}
 
-	ok = zcbor_tstr_put_lit(zse, "rc")	&&
-	     zcbor_int32_put(zse, rc);
+	if (rc == 0) {
+		ok = zcbor_tstr_put_lit(zse, "rc")      &&
+		     zcbor_int32_put(zse, 0);
+	}
 
 	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }


### PR DESCRIPTION
Constructing error response makes no sense as smp_build_err_rsp will rewrite it.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>