### PR TITLE
manifest: mcuboot update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -182,7 +182,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: dbe536a4adf4d55740b758387a7a57f4a1c218d4
+      revision: 2fcae1c1a05fe3a0892ba3c649f93cf3e1077949
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Limit allowed build platforms.
Building sample.bootloader.mcuboot for many platforms is not possible (for instance a qemu).
The limit is need as otherwise zephyr-rtos/zephyr CI is failing on any push to main branch or nightly CI run.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>