### PR TITLE
Fix internal temperature value incorrect

### DIFF
--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -264,7 +264,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000200>;
 			interrupts = <12 0>;
 			status = "disabled";
-			vref-mv = <3000>;
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -201,7 +201,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000200>;
 			interrupts = <18 0>;
 			status = "disabled";
-			vref-mv = <3000>;
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -342,7 +342,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00002000>;
 			interrupts = <18 0>;
 			status = "disabled";
-			vref-mv = <3000>;
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -547,6 +547,7 @@
 			interrupts = <113 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			vref-mv = <3000>;
 			has-temp-channel;
 			has-vref-channel;
 		};
@@ -605,9 +606,8 @@
 		ts-cal2-addr = <0x0BFA0742>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
-		ts-cal-vrefanalog = <3000>;
-		ts-cal-resolution = <14>;
-		io-channels = <&adc1 19>;
+		ts-cal-vrefanalog = <3300>;
+		io-channels = <&adc4 13>;
 		status = "disabled";
 	};
 };


### PR DESCRIPTION
This ticket is to fix the incorrect temperature sensor (Die temp) value in the ADC device-tree node for the stm32 series below:
stm32U5
stm32L1
stm32L4
stm32L0
Acquired internal temperature values seems inconsistent and not compatible.