### PR TITLE
Adc support of the vbat monitoring on stm32 mcus

### DIFF
--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -221,6 +221,10 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &dac1 {
 	pinctrl-0 = <&dac1_out1_pa4>;
 	pinctrl-names = "default";

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -280,6 +280,10 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &dac1 {
 	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -146,6 +146,10 @@
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &dac1 {
 	status = "okay";
 	pinctrl-0 = <&dac_out1_pa4>;

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -155,6 +155,10 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &dma2 {
 	status = "okay";
 };

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -168,6 +168,10 @@
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &wwdg {
 	status = "okay";
 };

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -88,6 +88,10 @@
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &dac1 {
 	status = "okay";
 	pinctrl-0 = <&dac_out1_pa4>;

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -176,6 +176,10 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &mac {
 	status = "okay";
 	pinctrl-0 = <&eth_mdc_pc1

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -161,6 +161,10 @@
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -171,6 +171,10 @@ zephyr_udc0: &usb {
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &dac1 {
 	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -174,6 +174,10 @@
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &dac1 {
 	pinctrl-0 = <&dac1_out1_pa4>;
 	pinctrl-names = "default";

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -128,6 +128,10 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &die_temp {
 	status = "okay";
 };

--- a/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
+++ b/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
@@ -77,6 +77,10 @@
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &lpuart1 {
 	pinctrl-0 = <&lpuart1_tx_pg7 &lpuart1_rx_pg8>;
 	pinctrl-names = "default";

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -89,6 +89,10 @@
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &clk_hse {
 	status = "okay";
 };

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -169,6 +169,10 @@
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &aes {
 	status = "okay";
 };

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -212,6 +212,10 @@ zephyr_udc0: &usb {
 	status = "okay";
 };
 
+&stm_vbat {
+	status = "okay";
+};
+
 &dac1 {
 	status = "okay";
 	/* dac output pins(pa4,pa5,pa6) might conflict with spi1 pins */

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -367,6 +367,13 @@
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3300>;
 		io-channels = <&adc1 16>;
+	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <2>;
+		io-channels = <&adc1 18>;
+
 		status = "disabled";
 	};
 };

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -346,6 +346,7 @@
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+			has-vbat-channel;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -303,6 +303,7 @@
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+			has-vbat-channel;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -339,6 +339,7 @@
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+			has-vbat-channel;
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -607,6 +607,13 @@
 		avgslope = <25>;
 	};
 
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <2>;
+		io-channels = <&adc1 18>;
+		status = "disabled";
+	};
+
 	otgfs_phy: otgfs_phy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -376,6 +376,12 @@
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3300>;
 		io-channels = <&adc1 16>;
+	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <2>;
+		io-channels = <&adc1 18>;
 		status = "disabled";
 	};
 

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -84,4 +84,11 @@
 			has-vref-channel;
 		};
 	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <2>;
+		io-channels = <&adc1 17>;
+		status = "disabled";
+	};
 };

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -132,4 +132,11 @@
 			has-vref-channel;
 		};
 	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <2>;
+		io-channels = <&adc1 17>;
+		status = "disabled";
+	};
 };

--- a/dts/arm/st/f3/stm32f334.dtsi
+++ b/dts/arm/st/f3/stm32f334.dtsi
@@ -33,6 +33,13 @@
 			#io-channel-cells = <1>;
 		};
 	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <2>;
+		io-channels = <&adc1 17>;
+		status = "okay";
+	};
 };
 
 /delete-node/ &usb;

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -495,6 +495,13 @@
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;
 	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <2>;
+		io-channels = <&adc1 18>;
+		status = "disabled";
+	};
 };
 
 &nvic {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -449,6 +449,7 @@
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+			has-vbat-channel;
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f4/stm32f401.dtsi
+++ b/dts/arm/st/f4/stm32f401.dtsi
@@ -65,4 +65,11 @@
 		};
 
 	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <4>;
+		io-channels = <&adc1 18>;
+		status = "disabled";
+	};
 };

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -254,6 +254,13 @@
 		};
 	};
 
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <2>;
+		io-channels = <&adc1 18>;
+		status = "disabled";
+	};
+
 	otghs_fs_phy: otghs_fs_phy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -99,4 +99,11 @@
 	die_temp: dietemp {
 		io-channels = <&adc1 18>;
 	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <4>;
+		io-channels = <&adc1 18>;
+		status = "disabled";
+	};
 };

--- a/dts/arm/st/f4/stm32f437.dtsi
+++ b/dts/arm/st/f4/stm32f437.dtsi
@@ -104,4 +104,11 @@
 	die_temp: dietemp {
 		io-channels = <&adc1 18>;
 	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <4>;
+		io-channels = <&adc1 18>;
+		status = "disabled";
+	};
 };

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -631,6 +631,7 @@
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+			has-vbat-channel;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -707,6 +707,13 @@
 		status = "disabled";
 	};
 
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <4>;
+		io-channels = <&adc1 18>;
+		status = "okay";
+	};
+
 	otghs_fs_phy: otghs_fs_phy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;
@@ -716,6 +723,7 @@
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;
 	};
+
 };
 
 &nvic {

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -92,4 +92,11 @@
 		ts-cal1-addr = <0x1FF0F44C>;
 		ts-cal2-addr = <0x1FF0F44E>;
 	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <4>;
+		io-channels = <&adc1 18>;
+		status = "disabled";
+	};
 };

--- a/dts/arm/st/f7/stm32f767.dtsi
+++ b/dts/arm/st/f7/stm32f767.dtsi
@@ -96,4 +96,11 @@
 			status = "disabled";
 		};
 	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <4>;
+		io-channels = <&adc1 18>;
+		status = "disabled";
+	};
 };

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -372,6 +372,13 @@
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;
 		io-channels = <&adc1 12>;
+	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <3>;
+		io-channels = <&adc1 14>;
+
 		status = "disabled";
 	};
 };

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -84,6 +84,7 @@
 			#io-channel-cells = <1>;
 			has-vref-channel;
 			has-temp-channel;
+			has-vbat-channel;
 		};
 
 		adc2: adc@50000100 {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -576,6 +576,12 @@
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;
 		io-channels = <&adc1 16>;
+	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <3>;
+		io-channels = <&adc1 17>;
 		status = "disabled";
 	};
 

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -839,6 +839,13 @@
 		ts-cal-vrefanalog = <3300>;
 		ts-cal-resolution = <16>;
 		io-channels = <&adc3 18>;
+	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <4>;
+		io-channels = <&adc3 17>;
+
 		status = "disabled";
 	};
 };

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -678,6 +678,7 @@
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+			has-vbat-channel;
 		};
 
 		adc2: adc@40022100 {

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -404,6 +404,12 @@
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3000>;
 		io-channels = <&adc1 17>;
+	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <3>;
+		io-channels = <&adc3 18>;
 		status = "disabled";
 	};
 };

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -344,6 +344,7 @@
 			status = "disabled";
 			vref-mv = <3000>;
 			#io-channel-cells = <1>;
+			has-vbat-channel;
 		};
 
 		adc2: adc@50040100 {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -549,6 +549,7 @@
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+			has-vbat-channel;
 		};
 
 		adc2: adc@42028100 {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -582,6 +582,7 @@
 		};
 	};
 
+
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
 		ts-cal1-addr = <0x0BFA05A8>;
@@ -590,6 +591,12 @@
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;
 		io-channels = <&adc1 17>;
+	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <3>;
+		io-channels = <&adc1 18>;
 		status = "disabled";
 	};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -609,6 +609,12 @@
 		ts-cal-vrefanalog = <3000>;
 		ts-cal-resolution = <14>;
 		io-channels = <&adc1 19>;
+	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <4>;
+		io-channels = <&adc1 18>;
 		status = "disabled";
 	};
 };

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -538,6 +538,7 @@
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+			has-vbat-channel;
 		};
 
 		adc4: adc@46021000 {

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -337,6 +337,7 @@
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+			has-vbat-channel;
 		};
 
 		iwdg: watchdog@40003000 {

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -429,6 +429,12 @@
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;
 		io-channels = <&adc1 17>;
+	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <3>;
+		io-channels = <&adc1 18>;
 		status = "disabled";
 	};
 

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -429,6 +429,12 @@
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3300>;
 		io-channels = <&adc1 12>;
+	};
+
+	stm_vbat: stm32vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <3>;
+		io-channels = <&adc1 14>;
 		status = "disabled";
 	};
 };

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -293,6 +293,7 @@
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+			has-vbat-channel;
 		};
 
 		dac1: dac@40007400 {

--- a/samples/sensor/stm32_vbat_sensor/sample.yaml
+++ b/samples/sensor/stm32_vbat_sensor/sample.yaml
@@ -5,7 +5,7 @@ tests:
   sample.sensor.stm32_vbat_sensor:
     depends_on: adc
     tags: sensors
-    platform_allow: nucleo_g071rb nucleo_wb55rg
+    filter: dt_compat_enabled("st,stm32-vbat")
     timeout: 10
     harness: console
     harness_config:


### PR DESCRIPTION
Add the vbat monitoring property in the ADC device-tree node of each stm32 where it is available.

Check all the ADC of the stm32 mcus where the vbat monitoring is available (based on the Ref Man)
Add the has-vbat-channel; in the corresponding ADC node of the DTS of each stm32 mcu.
Note the the corresponding ratio to be defined as a property of the st,stm32-vbat;
(for example has-vbat-channel; /* ratio 1/4 */ ).
Add the corresponding test case for the mcu on the available target : this is adding and enabling the st,stm32-vbat; node to the target board.

To Reproduce
Steps to reproduce the behavior:

west build -p auto -b nucleo_g071rb samples/sensor/stm32_vbat_sensor/