### PR TITLE
mgmt/mcumgr: Reducing structures and path to zst_output callback

### DIFF
--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -132,15 +132,6 @@ typedef void *(*mgmt_alloc_rsp_fn)(const void *src_buf, void *arg);
 typedef void (*mgmt_reset_buf_fn)(void *buf, void *arg);
 
 /**
- * @brief Decodes requests and encodes responses for any mcumgr protocol.
- */
-struct mgmt_streamer {
-	void *cb_arg;
-	struct cbor_nb_reader *reader;
-	struct cbor_nb_writer *writer;
-};
-
-/**
  * @brief Context required by command handlers for parsing requests and writing
  *		responses.
  */

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -195,30 +195,6 @@ struct mgmt_group {
 };
 
 /**
- * @brief Uses the specified streamer to trim data from the front of a buffer.
- *
- * If the amount to trim exceeds the size of the buffer, the buffer is
- * truncated to a length of 0.
- *
- * @param streamer	The streamer providing the callback.
- * @param buf		The buffer to trim.
- * @param len		The number of bytes to remove.
- */
-void mgmt_streamer_trim_front(struct mgmt_streamer *streamer, void *buf, size_t len);
-
-/**
- * @brief Uses the specified streamer to initialize a CBOR reader.
- *
- * @param streamer	The streamer providing the callback.
- * @param reader	The reader to initialize.
- * @param buf		The buffer to configure the reader with.
- *
- * @return 0 on success, MGMT_ERR_[...] code on failure.
- */
-int mgmt_streamer_init_reader(struct mgmt_streamer *streamer, void *buf);
-
-
-/**
  * @brief Registers a full command group.
  *
  * @param group The group to register.

--- a/subsys/mgmt/mcumgr/lib/smp/include/smp/smp.h
+++ b/subsys/mgmt/mcumgr/lib/smp/include/smp/smp.h
@@ -34,17 +34,6 @@ extern "C" {
 struct smp_streamer;
 struct mgmt_hdr;
 
-/** @typedef smp_tx_rsp_fn
- * @brief Transmits an SMP response packet.
- *
- * @param ss	The streamer to transmit via.
- * @param buf	Buffer containing the response packet.
- * @param arg	Optional streamer argument.
- *
- * @return 0 on success, MGMT_ERR_[...] code on failure.
- */
-typedef int smp_tx_rsp_fn(struct smp_streamer *ss, void *buf, void *arg);
-
 /**
  * @brief Decodes, encodes, and transmits SMP packets.
  */
@@ -52,7 +41,6 @@ struct smp_streamer {
 	struct zephyr_smp_transport *smpt;
 	struct cbor_nb_reader *reader;
 	struct cbor_nb_writer *writer;
-	smp_tx_rsp_fn *tx_rsp_cb;
 };
 
 /**

--- a/subsys/mgmt/mcumgr/lib/smp/include/smp/smp.h
+++ b/subsys/mgmt/mcumgr/lib/smp/include/smp/smp.h
@@ -49,7 +49,9 @@ typedef int smp_tx_rsp_fn(struct smp_streamer *ss, void *buf, void *arg);
  * @brief Decodes, encodes, and transmits SMP packets.
  */
 struct smp_streamer {
-	struct mgmt_streamer mgmt_stmr;
+	struct zephyr_smp_transport *smpt;
+	struct cbor_nb_reader *reader;
+	struct cbor_nb_writer *writer;
 	smp_tx_rsp_fn *tx_rsp_cb;
 };
 

--- a/subsys/mgmt/mcumgr/lib/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/lib/smp/src/smp.c
@@ -219,7 +219,7 @@ smp_on_err(struct smp_streamer *streamer, const struct mgmt_hdr *req_hdr,
 	/* Build and transmit the error response. */
 	rc = smp_build_err_rsp(streamer, req_hdr, status, rsn);
 	if (rc == 0) {
-		streamer->tx_rsp_cb(streamer, rsp, streamer->smpt);
+		streamer->smpt->zst_output(rsp);
 		rsp = NULL;
 	}
 
@@ -297,7 +297,7 @@ smp_process_request_packet(struct smp_streamer *streamer, void *vreq)
 		}
 
 		/* Send the response. */
-		rc = streamer->tx_rsp_cb(streamer, rsp, streamer->smpt);
+		rc = streamer->smpt->zst_output(rsp);
 		rsp = NULL;
 		if (rc != 0) {
 			break;

--- a/subsys/mgmt/mcumgr/lib/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/lib/smp/src/smp.c
@@ -59,7 +59,7 @@ smp_read_hdr(const struct net_buf *nb, struct mgmt_hdr *dst_hdr)
 static inline int
 smp_write_hdr(struct smp_streamer *streamer, const struct mgmt_hdr *src_hdr)
 {
-	memcpy(streamer->mgmt_stmr.writer->nb->data, src_hdr, sizeof(*src_hdr));
+	memcpy(streamer->writer->nb->data, src_hdr, sizeof(*src_hdr));
 	return 0;
 }
 
@@ -68,7 +68,7 @@ smp_build_err_rsp(struct smp_streamer *streamer, const struct mgmt_hdr *req_hdr,
 		  const char *rc_rsn)
 {
 	struct mgmt_hdr rsp_hdr;
-	struct cbor_nb_writer *nbw = (struct cbor_nb_writer *)streamer->mgmt_stmr.writer;
+	struct cbor_nb_writer *nbw = streamer->writer;
 	zcbor_state_t *zsp = nbw->zs;
 	bool ok;
 
@@ -164,8 +164,8 @@ smp_handle_single_req(struct smp_streamer *streamer, const struct mgmt_hdr *req_
 {
 	struct mgmt_ctxt cbuf;
 	struct mgmt_hdr rsp_hdr;
-	struct cbor_nb_writer *nbw = (struct cbor_nb_writer *)streamer->mgmt_stmr.writer;
-	struct cbor_nb_reader *nbr = (struct cbor_nb_reader *)streamer->mgmt_stmr.reader;
+	struct cbor_nb_writer *nbw = streamer->writer;
+	struct cbor_nb_reader *nbr = streamer->reader;
 	zcbor_state_t *zsp = nbw->zs;
 	int rc;
 
@@ -214,18 +214,18 @@ smp_on_err(struct smp_streamer *streamer, const struct mgmt_hdr *req_hdr,
 	}
 
 	/* Clear the partial response from the buffer, if any. */
-	cbor_nb_writer_init(streamer->mgmt_stmr.writer, rsp);
+	cbor_nb_writer_init(streamer->writer, rsp);
 
 	/* Build and transmit the error response. */
 	rc = smp_build_err_rsp(streamer, req_hdr, status, rsn);
 	if (rc == 0) {
-		streamer->tx_rsp_cb(streamer, rsp, streamer->mgmt_stmr.cb_arg);
+		streamer->tx_rsp_cb(streamer, rsp, streamer->smpt);
 		rsp = NULL;
 	}
 
 	/* Free any extra buffers. */
-	zephyr_smp_free_buf(req, streamer->mgmt_stmr.cb_arg);
-	zephyr_smp_free_buf(rsp, streamer->mgmt_stmr.cb_arg);
+	zephyr_smp_free_buf(req, streamer->smpt);
+	zephyr_smp_free_buf(rsp, streamer->smpt);
 }
 
 /**
@@ -281,14 +281,14 @@ smp_process_request_packet(struct smp_streamer *streamer, void *vreq)
 			break;
 		}
 
-		rsp = zephyr_smp_alloc_rsp(req, streamer->mgmt_stmr.cb_arg);
+		rsp = zephyr_smp_alloc_rsp(req, streamer->smpt);
 		if (rsp == NULL) {
 			rc = MGMT_ERR_ENOMEM;
 			break;
 		}
 
-		cbor_nb_reader_init(streamer->mgmt_stmr.reader, req);
-		cbor_nb_writer_init(streamer->mgmt_stmr.writer, rsp);
+		cbor_nb_reader_init(streamer->reader, req);
+		cbor_nb_writer_init(streamer->writer, rsp);
 
 		/* Process the request payload and build the response. */
 		rc = smp_handle_single_req(streamer, &req_hdr, &handler_found, &rsn);
@@ -297,7 +297,7 @@ smp_process_request_packet(struct smp_streamer *streamer, void *vreq)
 		}
 
 		/* Send the response. */
-		rc = streamer->tx_rsp_cb(streamer, rsp, streamer->mgmt_stmr.cb_arg);
+		rc = streamer->tx_rsp_cb(streamer, rsp, streamer->smpt);
 		rsp = NULL;
 		if (rc != 0) {
 			break;
@@ -323,8 +323,8 @@ smp_process_request_packet(struct smp_streamer *streamer, void *vreq)
 		return rc;
 	}
 
-	zephyr_smp_free_buf(req, streamer->mgmt_stmr.cb_arg);
-	zephyr_smp_free_buf(rsp, streamer->mgmt_stmr.cb_arg);
+	zephyr_smp_free_buf(req, streamer->smpt);
+	zephyr_smp_free_buf(rsp, streamer->smpt);
 
 	return rc;
 }

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -86,21 +86,6 @@ void zephyr_smp_free_buf(void *buf, void *arg)
 	mcumgr_buf_free(buf);
 }
 
-static int
-zephyr_smp_tx_rsp(struct smp_streamer *ns, void *rsp, void *arg)
-{
-	struct zephyr_smp_transport *zst;
-	struct net_buf *nb;
-
-	zst = arg;
-	nb = rsp;
-
-	/* Pass full packet to output function so it can be transmitted or split into frames as
-	 * needed by the transport
-	 */
-	return zst->zst_output(nb);
-}
-
 /**
  * Processes a single SMP packet and sends the corresponding response(s).
  */
@@ -117,7 +102,6 @@ zephyr_smp_process_packet(struct zephyr_smp_transport *zst,
 		.reader = &reader,
 		.writer = &writer,
 		.smpt = zst,
-		.tx_rsp_cb = zephyr_smp_tx_rsp,
 	};
 
 	rc = smp_process_request_packet(&streamer, nb);

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -114,11 +114,9 @@ zephyr_smp_process_packet(struct zephyr_smp_transport *zst,
 	int rc;
 
 	streamer = (struct smp_streamer) {
-		.mgmt_stmr = {
-			.reader = &reader,
-			.writer = &writer,
-			.cb_arg = zst,
-		},
+		.reader = &reader,
+		.writer = &writer,
+		.smpt = zst,
 		.tx_rsp_cb = zephyr_smp_tx_rsp,
 	};
 


### PR DESCRIPTION
The PR consists of three commits:
 1) removing declarations of `mgmt_streamer_trim_front` and `mgmt_streamer_init_reader` which no longer exist;
 2) moving contents of `mgmt_streamer` structure to `smp_streamer` structure and removing the former; also `cb_arg` type has been changed to `zephyr_smp_transport` and renamed `smpt`.
 3) removing `tx_rsp_cb` from `smp_treamer` and replacing `tx_rsp_cb` calls with direct calls to `zephyr_smp_transport->zst_output`.
 
Would be nice if https://github.com/zephyrproject-rtos/zephyr/pull/49528 would go in first.