### PR TITLE
Fix the Base addresses for NXP RT1010

### DIFF
--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -51,7 +51,7 @@ arduino_serial: &lpuart1 {};
 };
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(16)>;
+	reg = <0x400a0000 0x4000>, <0x60000000 DT_SIZE_M(16)>;
 	at25sf128a: at25sf128a@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <134217728>;

--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -39,40 +39,20 @@
 	gptfreq = <12500000>;
 };
 
-&usb1 {
-	interrupts = <25 0>;
-};
-
-&flexspi {
-	interrupts = <26 0>;
-};
-
-&flexpwm1_pwm0 {
-	interrupts = <34 0>;
-};
-
-&flexpwm1_pwm1 {
-	interrupts = <35 0>;
-};
-
-&flexpwm1_pwm2 {
-	interrupts = <36 0>;
-};
-
-&flexpwm1_pwm3 {
-	interrupts = <37 0>;
-};
-
-&flexpwm1 {
-	interrupts = <38 0>;
-};
-
 &edma0 {
 	dma-channels = <16>;
 };
 
 / {
 	soc {
+		/* Remove GPIO3-GPIO9, they don't exist on RT1010 */
+		/delete-node/ gpio@401c0000;
+		/delete-node/ gpio@401c4000;
+		/delete-node/ gpio@42000000;
+		/delete-node/ gpio@42004000;
+		/delete-node/ gpio@42008000;
+		/delete-node/ gpio@4200c000;
+
 		/* Fixup GPIO2 its a different location on RT1010 */
 		/delete-node/ gpio@401bc000;
 
@@ -98,12 +78,60 @@
 				<&iomuxc_gpio_sd_13_gpio2_io13>;
 		};
 
-		/* Remove GPIO3-GPIO9, they dont exist on RT1010 */
-		/delete-node/ gpio@401c0000;
-		/delete-node/ gpio@401c4000;
-		/delete-node/ gpio@42004000;
-		/delete-node/ gpio@42008000;
-		/delete-node/ gpio@4200c000;
+		/* Remove Quad TImers, they don't exist on RT1010 */
+		/delete-node/ qtmr@401dc000;
+		/delete-node/ qtmr@401e0000;
+		/delete-node/ qtmr@401e4000;
+		/delete-node/ qtmr@401e8000;
+
+		/* Fixup FlexSPI its a different location on RT1010 */
+		/delete-node/ spi@402a8000;
+		flexspi: spi@400a0000 {
+			compatible = "nxp,imx-flexspi";
+			reg = <0x400a0000 0x4000>;
+			interrupts = <26 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			ahb-bufferable;
+			ahb-cacheable;
+			status = "disabled";
+		};
+
+		/* Remove SEMC, it does'nt exist on RT1010 */
+		/delete-node/ semc0@402f0000;
+
+		/* Fixup LPI2C1 and LPI2C2, they have different base addr on RT1010 */
+		/delete-node/ i2c@403f0000;
+		/delete-node/ i2c@403f4000;
+
+		lpi2c1: i2c@401a4000 {
+			compatible = "nxp,imx-lpi2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x401a4000 0x4000>;
+			interrupts = <28 0>;
+			clocks = <&ccm IMX_CCM_LPI2C_CLK 0x70 6>;
+			status = "disabled";
+		};
+
+		lpi2c2: i2c@401a8000 {
+			compatible = "nxp,imx-lpi2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x401a8000 0x4000>;
+			interrupts = <29 0>;
+			clocks = <&ccm IMX_CCM_LPI2C_CLK 0x70 8>;
+			status = "disabled";
+		};
+
+		/* Remove LPI2C3 & LPI2C4, they don't exist on RT1010 */
+		/delete-node/ i2c@403f8000;
+		/delete-node/ i2c@403fc000;
+
+		/* Remove LCDIF, it doesn't exist on RT1010 */
+		/delete-node/ display-controller@402b8000;
 
 		/* Fixup LPSPI1 and LPSPI2, they have different base addr on RT1010 */
 		/delete-node/ spi@40394000;
@@ -128,11 +156,168 @@
 			#size-cells = <0>;
 		};
 
+		/* Remove LPUART5-8, they don't exist on RT1010 */
+		/delete-node/ uart@40194000;
+		/delete-node/ uart@40198000;
+		/delete-node/ uart@4019c000;
+		/delete-node/ uart@401a0000;
+
 		/* Remove ADC2, it doesn't exist on RT1010 */
 		/delete-node/ adc@400C8000;
 
 		/* RT1010 has only one flexSPI controller */
 		/delete-node/ spi@402a4000;
+
+		/* Fixup FlexPWM1 it has different base addr and interrupt numbers on RT1010 */
+		/delete-node/ flexpwm@403dc000;
+		flexpwm1: flexpwm@401cc000 {
+			compatible = "nxp,flexpwm";
+			reg = <0x401cc000 0x4000>;
+			interrupts = <38 0>;
+
+			flexpwm1_pwm0: pwm0 {
+				compatible = "nxp,imx-pwm";
+				index = <0>;
+				interrupts = <34 0>;
+				#pwm-cells = <2>;
+				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+				status = "disabled";
+			};
+
+			flexpwm1_pwm1: pwm1 {
+				compatible = "nxp,imx-pwm";
+				index = <1>;
+				interrupts = <35 0>;
+				#pwm-cells = <2>;
+				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+				status = "disabled";
+			};
+
+			flexpwm1_pwm2: pwm2 {
+				compatible = "nxp,imx-pwm";
+				index = <2>;
+				interrupts = <36 0>;
+				#pwm-cells = <2>;
+				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+				status = "disabled";
+			};
+
+			flexpwm1_pwm3: pwm3 {
+				compatible = "nxp,imx-pwm";
+				index = <3>;
+				interrupts = <37 0>;
+				#pwm-cells = <2>;
+				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+				status = "disabled";
+			};
+		};
+		/* Remove FlexPWM2-4, they don't exist on RT1010 */
+		/delete-node/ flexpwm@403e0000;
+		/delete-node/ flexpwm@403e4000;
+		/delete-node/ flexpwm@403e8000;
+
+		/* Remove Ethernet, it does'nt exist on RT1010 */
+		/delete-node/ ethernet@402d8000;
+
+		/* Fixup USB it has different base addr and interrupt numbers on RT1010 */
+		/delete-node/ usbd@402e0000;
+		usb1: usbd@400e4000 {
+			compatible = "nxp,mcux-usbd";
+			reg = <0x400e4000 0x200>;
+			interrupts = <25 1>;
+			interrupt-names = "usb_otg";
+			clocks = <&usbclk>;
+			num-bidir-endpoints = <8>;
+			usb-controller-index = "Ehci0";
+			status = "disabled";
+		};
+
+		/* Remove USB2, it does'nt exist on RT1010 */
+		/delete-node/ usbd@402e0200;
+
+		/* Remove USDHC, they don't exist on RT1010 */
+		/delete-node/ usdhc@402c0000;
+		/delete-node/ usdhc@402c4000;
+
+		/* Remove CSI, it does'nt exist on RT1010 */
+		/delete-node/ csi@402bc000;
+
+		/* Remove FLEXCAN, they don't exist on RT1010 */
+		/delete-node/ can@401d0000;
+		/delete-node/ can@401d4000;
+		/delete-node/ can@401d8000;
+
+		/* Remove WDOG2, it does'nt exist on RT1010 */
+		/delete-node/ wdog@400d0000;
+
+		/* Fix SAI1, 3, it has different base addr on RT1010 */
+		/delete-node/ sai@40384000;
+		/delete-node/ sai@4038c000;
+		sai1: sai@401e0000 {
+			compatible = "nxp,mcux-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#pinmux-cells = <2>;
+			reg = <0x401e0000 0x4000>;
+			clocks = <&ccm IMX_CCM_SAI1_CLK 0x7C 18>;
+			/* Audio PLL Output Frequency is determined by:
+			 * (Fref * (DIV_SELECT + NUM/DENOM)) / POST_DIV
+			 * = (24MHz * (32 + 77 / 100)) / 1 = 786.48 MHz
+			 */
+		       pll-clocks = <&anatop 0x70 0xC000 0>,
+				      <&anatop 0x70 0x7F 32>,
+				      <&anatop 0x70 0x180000 1>,
+				      <&anatop 0x80 0x3FFFFFFF 77>,
+				      <&anatop 0x90 0x3FFFFFFF 100>;
+			pll-clock-names = "src", "lp", "pd", "num", "den";
+			/* The maximum input frequency into the SAI mclk input is 300MHz
+			 * Based on this requirement, pre-div must be at least 3
+			 * The pre-div and post-div are one less than the actual divide-by amount.
+			 * A pre-div value of 0x1 results in a pre-divider of
+			 * (1+1) = 2
+			 */
+			pre-div = <0x3>;
+			podf = <0x0F>;
+			pinmuxes = <&iomuxcgpr 0x4 0x80000>;
+			interrupts = <56 0>;
+			dmas = <&edma0 0 19>, <&edma0 0 20>;
+			dma-names = "rx", "tx";
+			/* This translates to SAIChannelMask (fsl_sai.c) and
+			 * cannot be 0
+			 */
+			nxp,tx-channel = <1>;
+			nxp,tx-dma-channel = <0>;
+			nxp,rx-dma-channel = <1>;
+			status = "disabled";
+		};
+
+		sai3: sai@401e8000 {
+			compatible = "nxp,mcux-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#pinmux-cells = <2>;
+			reg = <0x401e8000 0x4000>;
+			clocks = <&ccm IMX_CCM_SAI3_CLK 0x7C 22>;
+			pre-div = <0>;
+			podf = <63>;
+			pll-clocks = <&anatop 0x70 0xC000 0>,
+				   <&anatop 0x70 0x7F 32>,
+				   <&anatop 0x70 0x180000 1>,
+				   <&anatop 0x80 0x3FFFFFFF 77>,
+				   <&anatop 0x90 0x3FFFFFFF 100>;
+			pll-clock-names = "src", "lp", "pd", "num", "den";
+			pinmuxes = <&iomuxcgpr 0x4 0x200000>;
+			interrupts = <58 0>, <59 0>;
+			dmas = <&edma0 0 83>, <&edma0 0 84>;
+			dma-names = "rx", "tx";
+			nxp,tx-channel = <0>;
+			nxp,tx-dma-channel = <5>;
+			nxp,rx-dma-channel = <6>;
+			status = "disabled";
+		};
+
+		/* Remove SAI2, it does'nt exist on RT1010 */
+		/delete-node/ sai@40388000;
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -875,7 +875,7 @@
 			#size-cells = <0>;
 			#pinmux-cells = <2>;
 			reg = <0x40384000 0x4000>;
-			clocks = <&ccm IMX_CCM_SAI1_CLK 0x7C 2>;
+			clocks = <&ccm IMX_CCM_SAI1_CLK 0x7C 18>;
 			/* Audio PLL Output Frequency is determined by:
 			 * (Fref * (DIV_SELECT + NUM/DENOM)) / POST_DIV
 			 * = (24MHz * (32 + 77 / 100)) / 1 = 786.48 MHz
@@ -913,7 +913,7 @@
 			#size-cells = <0>;
 			#pinmux-cells = <2>;
 			reg = <0x40388000 0x4000>;
-			clocks = <&ccm IMX_CCM_SAI2_CLK 0x7C 2>;
+			clocks = <&ccm IMX_CCM_SAI2_CLK 0x7C 20>;
 			pre-div = <0>;
 			podf = <63>;
 			pll-clocks = <&anatop 0x70 0xC000 0x0>,
@@ -938,7 +938,7 @@
 			#size-cells = <0>;
 			#pinmux-cells = <2>;
 			reg = <0x4038C000 0x4000>;
-			clocks = <&ccm IMX_CCM_SAI3_CLK 0x7C 2>;
+			clocks = <&ccm IMX_CCM_SAI3_CLK 0x7C 22>;
 			pre-div = <0>;
 			podf = <63>;
 			pll-clocks = <&anatop 0x70 0xC000 0>,

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -108,10 +108,12 @@ if CODE_FLEXSPI
 
 config FLASH_SIZE
 	default $(dt_node_reg_size_int,/soc/spi@400cc000,1,K) if SOC_SERIES_IMX_RT11XX
+	default $(dt_node_reg_size_int,/soc/spi@400a0000,1,K) if SOC_MIMXRT1011
 	default $(dt_node_reg_size_int,/soc/spi@402a8000,1,K) if SOC_SERIES_IMX_RT10XX
 
 config FLASH_BASE_ADDRESS
 	default $(dt_node_reg_addr_hex,/soc/spi@400cc000,1) if SOC_SERIES_IMX_RT11XX
+	default $(dt_node_reg_addr_hex,/soc/spi@400a0000,1) if SOC_MIMXRT1011
 	default $(dt_node_reg_addr_hex,/soc/spi@402a8000,1) if SOC_SERIES_IMX_RT10XX
 
 endif # CODE_FLEXSPI


### PR DESCRIPTION
Update the RT1010 dts file to fix the Base addresses for the IP blocks that are located at a different address on RT1010.

This fixes Issue #46255
