### PR TITLE
dts: bindings: fixed pinctrl binding description for nxp mcux rt-iocon

### DIFF
--- a/dts/bindings/pinctrl/nxp,rt-iocon-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,rt-iocon-pinctrl.yaml
@@ -81,8 +81,9 @@ child-binding:
         description: |
           Pin output drive strength. Sets the FULLDRIVE field in the
           IOCON register.
-          0 FULLDRIVE_0- normal mode, output slew rate is standard
-          1 FULLDRIVE_1- slow mode, output slew rate is slower
+          0 FULLDRIVE_0- Normal output drive mode
+          1 FULLDRIVE_1- Full output drive mode, output strength is twice
+          the drive strength of normal drive mode.
       nxp,invert:
         type: boolean
         description: |


### PR DESCRIPTION
The FULLDRIVE description on the rt-iocon yaml file was describing the slew rate and not the FULLDRIVE property.

Signed-off-by: Emilio Benavente <emilio.benavente@nxp.com>