### PR TITLE
drivers: espi: Kconfig cleanup for UART mapping

### DIFF
--- a/drivers/espi/Kconfig.xec
+++ b/drivers/espi/Kconfig.xec
@@ -29,15 +29,6 @@ config ESPI_PERIPHERAL_DEBUG_PORT_80
 config ESPI_PERIPHERAL_UART
 	default y
 
-config ESPI_PERIPHERAL_UART_SOC_MAPPING
-	int "SoC port exposed as logical eSPI UART"
-	default 2 if SOC_SERIES_MEC1501X
-	default 1 if SOC_SERIES_MEC172X
-	depends on ESPI_PERIPHERAL_UART
-	help
-	  This tells the driver to which SoC UART to direct the UART traffic
-	  send over eSPI from host.
-
 config ESPI_OOB_BUFFER_SIZE
 	int "eSPI OOB channel buffer size in bytes"
 	default 128

--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -880,21 +880,17 @@ static void config_sub_devices(const struct device *dev)
 	 * Not all boards use same UART port for debug, hence needs to set
 	 * eSPI host logical UART0 bar address based on configuration.
 	 */
-	switch (CONFIG_ESPI_PERIPHERAL_UART_SOC_MAPPING) {
-	case 0:
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay)
 		ESPI_EIO_BAR_REGS->EC_BAR_UART_0 = ESPI_XEC_UART0_BAR_ADDRESS |
 		MCHP_ESPI_IO_BAR_HOST_VALID;
-		break;
-	case 1:
+#elif DT_NODE_HAS_STATUS(DT_NODELABEL(uart1), okay)
 		ESPI_EIO_BAR_REGS->EC_BAR_UART_1 = ESPI_XEC_UART0_BAR_ADDRESS |
 		MCHP_ESPI_IO_BAR_HOST_VALID;
-		break;
-	case 2:
+#elif DT_NODE_HAS_STATUS(DT_NODELABEL(uart2), okay)
 		ESPI_EIO_BAR_REGS->EC_BAR_UART_2 = ESPI_XEC_UART0_BAR_ADDRESS |
 		MCHP_ESPI_IO_BAR_HOST_VALID;
-		break;
-	}
 #endif
+#endif /* CONFIG_ESPI_PERIPHERAL_UART */
 #ifdef CONFIG_ESPI_PERIPHERAL_8042_KBC
 	KBC_REGS->KBC_CTRL |= MCHP_KBC_CTRL_AUXH;
 	KBC_REGS->KBC_CTRL |= MCHP_KBC_CTRL_OBFEN;
@@ -929,18 +925,14 @@ static void config_sub_devices(const struct device *dev)
 static void configure_sirq(void)
 {
 #ifdef CONFIG_ESPI_PERIPHERAL_UART
-	switch (CONFIG_ESPI_PERIPHERAL_UART_SOC_MAPPING) {
-	case ESPI_PERIPHERAL_UART_PORT0:
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay)
 		ESPI_SIRQ_REGS->UART_0_SIRQ = UART_DEFAULT_IRQ;
-		break;
-	case ESPI_PERIPHERAL_UART_PORT1:
+#elif DT_NODE_HAS_STATUS(DT_NODELABEL(uart1), okay)
 		ESPI_SIRQ_REGS->UART_1_SIRQ = UART_DEFAULT_IRQ;
-		break;
-	case ESPI_PERIPHERAL_UART_PORT2:
+#elif DT_NODE_HAS_STATUS(DT_NODELABEL(uart2), okay)
 		ESPI_SIRQ_REGS->UART_2_SIRQ = UART_DEFAULT_IRQ;
-		break;
-	}
 #endif
+#endif /* CONFIG_ESPI_PERIPHERAL_UART */
 #ifdef CONFIG_ESPI_PERIPHERAL_8042_KBC
 	ESPI_SIRQ_REGS->KBC_SIRQ_0 = 0x01;
 	ESPI_SIRQ_REGS->KBC_SIRQ_1 = 0x0C;

--- a/drivers/espi/espi_mchp_xec_host_v2.c
+++ b/drivers/espi/espi_mchp_xec_host_v2.c
@@ -898,7 +898,7 @@ static int init_p80bd0(const struct device *dev)
 
 #ifdef CONFIG_ESPI_PERIPHERAL_UART
 
-#if CONFIG_ESPI_PERIPHERAL_UART_SOC_MAPPING == 0
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay)
 int init_uart0(const struct device *dev)
 {
 	struct espi_xec_config *const cfg = ESPI_XEC_CONFIG(dev);
@@ -913,7 +913,8 @@ int init_uart0(const struct device *dev)
 #undef	INIT_UART0
 #define	INIT_UART0		init_uart0
 
-#elif CONFIG_ESPI_PERIPHERAL_UART_SOC_MAPPING == 1
+#elif DT_NODE_HAS_STATUS(DT_NODELABEL(uart1), okay)
+
 int init_uart1(const struct device *dev)
 {
 	struct espi_xec_config *const cfg = ESPI_XEC_CONFIG(dev);
@@ -927,7 +928,7 @@ int init_uart1(const struct device *dev)
 
 #undef	INIT_UART1
 #define	INIT_UART1		init_uart1
-#endif /* CONFIG_ESPI_PERIPHERAL_UART_SOC_MAPPING */
+#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay) */
 #endif /* CONFIG_ESPI_PERIPHERAL_UART */
 
 typedef int (*host_dev_irq_connect)(const struct device *dev);

--- a/drivers/espi/espi_mchp_xec_v2.c
+++ b/drivers/espi/espi_mchp_xec_v2.c
@@ -794,15 +794,12 @@ static void configure_sirq(const struct device *dev)
 	struct espi_iom_regs *regs = ESPI_XEC_REG_BASE(dev);
 
 #ifdef CONFIG_ESPI_PERIPHERAL_UART
-	switch (CONFIG_ESPI_PERIPHERAL_UART_SOC_MAPPING) {
-	case ESPI_PERIPHERAL_UART_PORT0:
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay)
 		regs->SIRQ[SIRQ_UART0] = UART_DEFAULT_IRQ;
-		break;
-	case ESPI_PERIPHERAL_UART_PORT1:
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart1), okay)
 		regs->SIRQ[SIRQ_UART1] = UART_DEFAULT_IRQ;
-		break;
-	}
 #endif
+#endif /* CONFIG_ESPI_PERIPHERAL_UART */
 #ifdef CONFIG_ESPI_PERIPHERAL_8042_KBC
 	regs->SIRQ[SIRQ_KBC_KIRQ] = 1;
 	regs->SIRQ[SIRQ_KBC_MIRQ] = 12;


### PR DESCRIPTION
Remove KConfig to map SoC physical UART to eSPI virtual UART.

Closes https://github.com/zephyrproject-rtos/zephyr/issues/45001

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>