### PR TITLE
Bluetooth: Controller: Fix stream handle use in Broadcast ISO Tx

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5719,7 +5719,7 @@ int hci_iso_handle(struct net_buf *buf, struct net_buf **evt)
 		if (handle < BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE) {
 			return -EINVAL;
 		}
-		stream_handle = handle - BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE;
+		stream_handle = LL_BIS_ADV_IDX_FROM_HANDLE(handle);
 
 		struct lll_adv_iso_stream *stream;
 
@@ -5778,7 +5778,7 @@ int hci_iso_handle(struct net_buf *buf, struct net_buf **evt)
 
 		stream->pkt_seq_num++;
 
-		if (ll_iso_tx_mem_enqueue(stream_handle, tx, NULL)) {
+		if (ll_iso_tx_mem_enqueue(handle, tx, NULL)) {
 			BT_ERR("Invalid ISO Tx Enqueue");
 			ll_iso_tx_mem_release(tx);
 			return -EINVAL;
@@ -7604,8 +7604,7 @@ static void le_big_sync_established(struct pdu_data *pdu,
 	for (uint8_t i = 0U; i < lll->stream_count; i++) {
 		uint16_t handle;
 
-		handle = BT_CTLR_SYNC_ISO_STREAM_HANDLE_BASE +
-			 lll->stream_handle[i];
+		handle = LL_BIS_SYNC_HANDLE_FROM_IDX(lll->stream_handle[i]);
 		sep->handle[i] = sys_cpu_to_le16(handle);
 	}
 }
@@ -7692,8 +7691,7 @@ static void le_big_complete(struct pdu_data *pdu_data,
 	for (uint8_t i = 0U; i < lll->num_bis; i++) {
 		uint16_t handle;
 
-		handle = BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE +
-			 lll->stream_handle[i];
+		handle = LL_BIS_ADV_HANDLE_FROM_IDX(lll->stream_handle[i]);
 		sep->handle[i] = sys_cpu_to_le16(handle);
 	}
 }

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -149,6 +149,8 @@ enum {
 #else /* !CONFIG_BT_MAX_CONN */
 #define BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE 0
 #endif /* !CONFIG_BT_MAX_CONN */
+#define LL_BIS_ADV_HANDLE_FROM_IDX(stream_handle) \
+	((stream_handle) + (BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE))
 #else /* !CONFIG_BT_CTLR_ADV_ISO */
 #define BT_CTLR_ADV_ISO_STREAM_MAX 0
 #endif /* CONFIG_BT_CTLR_ADV_ISO */
@@ -165,6 +167,8 @@ enum {
 #else /* !CONFIG_BT_MAX_CONN */
 #define BT_CTLR_SYNC_ISO_STREAM_HANDLE_BASE 0
 #endif /* !CONFIG_BT_MAX_CONN */
+#define LL_BIS_SYNC_HANDLE_FROM_IDX(stream_handle) \
+	((stream_handle) + (BT_CTLR_SYNC_ISO_STREAM_HANDLE_BASE))
 #else /* !CONFIG_BT_CTLR_SYNC_ISO */
 #define BT_CTLR_SYNC_ISO_STREAM_MAX 0
 #endif /* !CONFIG_BT_CTLR_SYNC_ISO */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -256,7 +256,7 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	bis_idx = lll->num_bis;
 	while (bis_idx--) {
 		stream_handle = lll->stream_handle[bis_idx];
-		handle = stream_handle + BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE;
+		handle = LL_BIS_ADV_HANDLE_FROM_IDX(stream_handle);
 		stream = ull_adv_iso_lll_stream_get(stream_handle);
 		LL_ASSERT(stream);
 
@@ -513,8 +513,7 @@ static void isr_tx_common(void *param,
 
 		for (uint8_t bis_idx = 0U; bis_idx < lll->num_bis; bis_idx++) {
 			stream_handle = lll->stream_handle[bis_idx];
-			handle = stream_handle +
-				 BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE;
+			handle = LL_BIS_ADV_HANDLE_FROM_IDX(stream_handle);
 			stream = ull_adv_iso_lll_stream_get(stream_handle);
 			LL_ASSERT(stream);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -1243,7 +1243,7 @@ static void tx_lll_flush(void *param)
 		uint16_t handle;
 
 		stream_handle = lll->stream_handle[num_bis];
-		handle = stream_handle + BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE;
+		handle = LL_BIS_ADV_HANDLE_FROM_IDX(stream_handle);
 		stream = ull_adv_iso_stream_get(stream_handle);
 
 		link = memq_dequeue(stream->memq_tx.tail, &stream->memq_tx.head,

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -316,7 +316,7 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 	if (handle < BT_CTLR_SYNC_ISO_STREAM_HANDLE_BASE) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
-	stream_handle = handle - BT_CTLR_SYNC_ISO_STREAM_HANDLE_BASE;
+	stream_handle = LL_BIS_SYNC_IDX_FROM_HANDLE(handle);
 
 	stream = ull_sync_iso_stream_get(stream_handle);
 	if (!stream || stream->dp) {
@@ -563,7 +563,7 @@ uint8_t ll_remove_iso_path(uint16_t handle, uint8_t path_dir)
 	if (handle < BT_CTLR_SYNC_ISO_STREAM_HANDLE_BASE) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
-	stream_handle = handle - BT_CTLR_SYNC_ISO_STREAM_HANDLE_BASE;
+	stream_handle = LL_BIS_SYNC_IDX_FROM_HANDLE(handle);
 
 	stream = ull_sync_iso_stream_get(stream_handle);
 	if (!stream) {
@@ -1090,8 +1090,10 @@ uint8_t ll_iso_transmit_test(uint16_t handle, uint8_t payload_type)
 
 	} else if (IS_ADV_ISO_HANDLE(handle)) {
 		struct lll_adv_iso_stream *stream;
+		uint16_t stream_handle;
 
-		stream = ull_adv_iso_stream_get(handle);
+		stream_handle = LL_BIS_ADV_IDX_FROM_HANDLE(handle);
+		stream = ull_adv_iso_stream_get(stream_handle);
 		if (!stream) {
 			return BT_HCI_ERR_UNKNOWN_CONN_ID;
 		}
@@ -1192,6 +1194,7 @@ int ll_iso_tx_mem_enqueue(uint16_t handle, void *node_tx, void *link)
 	} else if (IS_ENABLED(CONFIG_BT_CTLR_ADV_ISO) &&
 		   IS_ADV_ISO_HANDLE(handle)) {
 		struct lll_adv_iso_stream *stream;
+		uint16_t stream_handle;
 
 		/* FIXME: When hci_iso_handle uses ISOAL, link is provided and
 		 * this code should be removed.
@@ -1199,7 +1202,8 @@ int ll_iso_tx_mem_enqueue(uint16_t handle, void *node_tx, void *link)
 		link = mem_acquire(&mem_link_iso_tx.free);
 		LL_ASSERT(link);
 
-		stream = ull_adv_iso_stream_get(handle);
+		stream_handle = LL_BIS_ADV_IDX_FROM_HANDLE(handle);
+		stream = ull_adv_iso_stream_get(stream_handle);
 		memq_enqueue(link, node_tx, &stream->memq_tx.tail);
 
 	} else {

--- a/subsys/bluetooth/controller/ll_sw/ull_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso_types.h
@@ -4,8 +4,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* BIS Broadcaster */
+#if defined(CONFIG_BT_CTLR_ADV_ISO)
+#define LL_BIS_ADV_HANDLE_BASE BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE
+#define LL_BIS_ADV_IDX_FROM_HANDLE(conn_handle) \
+	((conn_handle) - (LL_BIS_ADV_HANDLE_BASE))
+#define IS_ADV_ISO_HANDLE(conn_handle) \
+	(((conn_handle) >= (LL_BIS_ADV_HANDLE_BASE)) && \
+	 ((conn_handle) <= ((LL_BIS_ADV_HANDLE_BASE) + \
+			    (BT_CTLR_ADV_ISO_STREAM_MAX) - 1U)))
+#else
+#define LL_BIS_ADV_IDX_FROM_HANDLE(conn_handle) 0U
+#define IS_ADV_ISO_HANDLE(conn_handle) 0U
+#endif /* CONFIG_BT_CTLR_ADV_ISO */
+
+/* BIS Synchronized Receiver */
+#if defined(CONFIG_BT_CTLR_SYNC_ISO)
+#define LL_BIS_SYNC_HANDLE_BASE BT_CTLR_SYNC_ISO_STREAM_HANDLE_BASE
+#define LL_BIS_SYNC_IDX_FROM_HANDLE(conn_handle) \
+	((conn_handle) - (LL_BIS_SYNC_HANDLE_BASE))
+#define IS_SYNC_ISO_HANDLE(conn_handle) \
+	(((conn_handle) >= (LL_BIS_SYNC_HANDLE_BASE)) && \
+	 ((conn_handle) <= ((LL_BIS_SYNC_HANDLE_BASE) + \
+			    (BT_CTLR_SYNC_ISO_STREAM_MAX) - 1U)))
+#else
+#define IS_SYNC_ISO_HANDLE(conn_handle) 0U
+#endif /* CONFIG_BT_CTLR_SYNC_ISO */
+
 /* CIS */
-#define LL_CIS_HANDLE_BASE CONFIG_BT_MAX_CONN
+#define LL_CIS_HANDLE_BASE (BT_CTLR_CONN_ISO_STREAM_HANDLE_BASE)
 
 #if defined(CONFIG_BT_CTLR_CONN_ISO_STREAMS)
 #define LAST_VALID_CIS_HANDLE \
@@ -24,23 +51,6 @@
 #else
 #define IS_CIS_HANDLE(_handle) 0
 #endif /* CONFIG_BT_CTLR_CONN_ISO */
-
-
-#if defined(CONFIG_BT_CTLR_ADV_ISO)
-#define IS_ADV_ISO_HANDLE(_handle) \
-	(((_handle) >= BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE) && \
-	((_handle) <= (BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE + BT_CTLR_ADV_ISO_STREAM_MAX - 1)))
-#else
-#define IS_ADV_ISO_HANDLE(_handle) 0
-#endif /* CONFIG_BT_CTLR_ADV_ISO */
-
-#if defined(CONFIG_BT_CTLR_SYNC_ISO)
-#define IS_SYNC_ISO_HANDLE(_handle) \
-	(((_handle) >= BT_CTLR_SYNC_ISO_STREAM_HANDLE_BASE) && \
-	((_handle) <= (BT_CTLR_SYNC_ISO_STREAM_HANDLE_BASE + BT_CTLR_SYNC_ISO_STREAM_MAX - 1U)))
-#else
-#define IS_SYNC_ISO_HANDLE(_handle) 0U
-#endif /* CONFIG_BT_CTLR_SYNC_ISO */
 
 struct ll_iso_test_mode_data {
 	uint32_t received_cnt;


### PR DESCRIPTION
Fix incorrect use of stream handle instead of connection handle to enqueue Tx ISO Data, and use stream handle to get stream instance.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>