### PR TITLE
arch: arm: userspace: fix the incorrect ssf under bad syscall

### DIFF
--- a/arch/arm/core/aarch32/userspace.S
+++ b/arch/arm/core/aarch32/userspace.S
@@ -410,9 +410,9 @@ SECTION_FUNC(TEXT, z_arm_do_syscall)
     /* BAD SYSCALL path */
     /* fixup stack frame on the privileged stack, adding ssf */
     mov r1, sp
-    push {r4,r5}
     /* ssf is present in r1 (sp) */
     push {r1,lr}
+    push {r4,r5}
     /* restore r0, r1 */
     mov r0, ip
     mov r1, lr


### PR DESCRIPTION
The parameter ssf of the handler_bad_syscall got null pointer due to that
the R1 does not push into the stack in a right order on cortex-M0. Adjust
the pushing order of stack to make the ssf being passed correctly.

Fixes #50146.

Signed-off-by: Enjia Mai <enjia.mai@intel.com>