### PR TITLE
twisterlib: re-add the logic to drain the serial leftover

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -335,6 +335,19 @@ class DeviceHandler(Handler):
 
         ser.flush()
 
+        # turns out the ser.flush() is not enough to clear serial leftover from last case
+        # explicitly readline() can do it reliably
+        old_timeout = ser.timeout
+        # wait for 1s if no serial output
+        ser.timeout = 1
+        # or read 1000 lines at most
+        # if the leftovers are more than 1000 lines, user should realize that once
+        # saw the caught ones and fix it.
+        leftover_lines = ser.readlines(1000)
+        for line in leftover_lines:
+            logger.debug(f"leftover log of previous test: {line}")
+        ser.timeout = old_timeout
+
         while ser.isOpen():
             readable, _, _ = select.select(readlist, [], [], self.timeout)
 


### PR DESCRIPTION
This logic was added before (see: https://github.com/zephyrproject-rtos/zephyr/pull/46132#issuecomment-1247698981) but seems
to be missed during the twister refactoring.

Some tests can cause serial leftover logs buffered somewhere.
Such leftover can interfere with the next test case because the 
serial log monitoring thread is started before a board is flashed.
And the monitoring thread can be fooled by such leftover logs
and make incorrect judgement of the test result.

A simple ser.flush() is not enough to eliminate such leftovers.
So add explicit readline() to drain such logs which ensures a clean
serial context for the case that follows.

An example from reel board captured with this patch:

leftover log of previous test: b'.287 seconds\r\n' 
leftover log of previous test: b' - SKIP - [...test_coredump_backend]...
leftover log of previous test: b'\r\n'
leftover log of previous test: b'------ TESTSUITE SUMMARY END ------\r\n'
leftover log of previous test: b'\r\n'
leftover log of previous test: b'========================================...
leftover log of previous test: b'RunID: 4e93757ad419988f03c53dcab9f0f5c6\r\n'
leftover log of previous test: b'PROJECT EXECUTION SUCCESSFUL\r\n

Signed-off-by: Ming Shao <ming.shao@intel.com>

The command to generate above serial leftover is:

`twister --hardware-map ~/sources/sm_zephyr_tools/twister_hw_map/reelboard.map --device-testing -vv -T tests/subsys/`