### PR TITLE
logging: Add log_output dependency to mipi syst

### DIFF
--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -24,6 +24,7 @@ endmenu
 menuconfig LOG_MIPI_SYST_ENABLE
 	bool "MIPI SyS-T format output"
 	select MIPI_SYST_LIB
+	select LOG_OUTPUT
 	help
 	  Enable MIPI SyS-T format output for the logger system.
 


### PR DESCRIPTION
Add missing dependency since log_output_syst.c is calling functions from log_output module.

Fixes #50341

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>