### PR TITLE
test: timer: behavior: Enhancement for running this test

### DIFF
--- a/arch/x86/core/Kconfig.ia32
+++ b/arch/x86/core/Kconfig.ia32
@@ -137,8 +137,7 @@ endif # CPU_HAS_FPU
 
 config X86_FP_USE_SOFT_FLOAT
 	bool
-	prompt "Use Software Floating Point Operations" if !(NEWLIB_LIBC && !FPU)
-	default y if NEWLIB_LIBC && !FPU
+	default y if !FPU
 	help
 	  Enable using software floating point operations.
 

--- a/tests/kernel/timer/timer_behavior/Kconfig
+++ b/tests/kernel/timer/timer_behavior/Kconfig
@@ -20,3 +20,9 @@ config TIMER_TEST_MAX_STDDEV
 config TIMER_TEST_MAX_DRIFT
 	int "Maximum drift in microseconds allowed (should be about 1 period allowance)"
 	default 1000
+
+config TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT
+	int "Maximum drift percentage for the timer period"
+	default 10
+	help
+	  A value of 10 means 10%.


### PR DESCRIPTION
Zephyr timer is based on system ticks, there usually exists some time drift due to round up/down errors between cycles, ticks and time delay, we need to add those expected time drift into the bound calculation for running this test.

Signed-off-by: Chen Peng1 <peng1.chen@intel.com>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/49576