### PR TITLE
doc: doxygen: fix Kconfig alias when using HTML output

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -254,7 +254,7 @@ TAB_SIZE               = 8
 ALIASES                = "rst=\verbatim embed:rst:leading-asterisk" \
                          endrst=\endverbatim \
                          "option{1}=\verbatim embed:rst:inline :kconfig:option:`\1` \endverbatim" \
-                         "kconfig{1}=\verbatim embed:rst:inline :kconfig:option:`\1` \endverbatim" \
+                         "kconfig{1}=\htmlonly <code>\1</code> \endhtmlonly \xmlonly \verbatim embed:rst:inline :kconfig:option:`\1` \endverbatim \endxmlonly" \
                          "req{1}=\ref ZEPH_\1 \"ZEPH-\1\"" \
                          "satisfy{1}=\xrefitem satisfy \"Satisfies requirement\" \"Requirement Implementation\" \1" \
                          "verify{1}=\xrefitem verify \"Verifies requirement\" \"Requirement Verification\" \1" \


### PR DESCRIPTION
The kconfig Doxygen alias needs to work for both, HTML and XML output (used later by Sphinx). This patch modifies the alias so that it outputs plain HTML for the HTML output and Sphinx roles for the XML output.

Before:
![image](https://user-images.githubusercontent.com/25011557/190971113-dd8066f4-5320-4ba8-8e8e-45b81134d2d5.png)

After:
![image](https://user-images.githubusercontent.com/25011557/190971163-e8e53015-97f6-447f-bd96-9535ee541ea0.png)

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>