### PR TITLE
doc: release-notes: add EEPROM release notes for v3.2.0

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -191,6 +191,9 @@ Drivers and Sensors
 
 * EEPROM
 
+  * Added Microchip XEC (MEC172x) on-chip EEPROM driver. See the
+    :dtcompatible:`microchip,xec-eeprom` devicetree binding for more information.
+
 * Entropy
 
 * Ethernet


### PR DESCRIPTION
Add EEPROM related release notes for Zephyr v3.2.0.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>