### PR TITLE
drivers: i2c_nrfx_twim: Fix compilation with disabled PINCTRL

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -289,8 +289,10 @@ static int i2c_nrfx_twim_recover_bus(const struct device *dev)
 
 	/* restore peripheral if it was active before */
 	if (state == PM_DEVICE_STATE_ACTIVE) {
+#ifdef CONFIG_PINCTRL
 		(void)pinctrl_apply_state(dev_config->pcfg,
 					  PINCTRL_STATE_DEFAULT);
+#endif
 		nrfx_twim_enable(&dev_config->twim);
 	}
 
@@ -307,9 +309,7 @@ static const struct i2c_driver_api i2c_nrfx_twim_driver_api = {
 static int twim_nrfx_pm_action(const struct device *dev,
 			       enum pm_device_action action)
 {
-#ifdef CONFIG_PINCTRL
 	const struct i2c_nrfx_twim_config *dev_config = dev->config;
-#endif
 	int ret = 0;
 
 	switch (action) {


### PR DESCRIPTION
This is a follow-up to commits 9974bb043f7f6cbdffd89d56d1201f1cb8039ef4 and 00ecc666773ea9c8c4b6c01cac38fee80d2bbc7e.

Add one missing `#ifdef CONFIG_PINCTRL` and remove a no longer needed one to restore the possibility to use this driver without PINCTRL.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>