### PR TITLE
libc: newlib: Call gettimeofday() also when CONFIG_POSIX_CLOCK

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -557,7 +557,7 @@ void *_sbrk_r(struct _reent *r, int count)
 
 int _gettimeofday(struct timeval *__tp, void *__tzp)
 {
-#ifdef CONFIG_POSIX_API
+#ifdef CONFIG_POSIX_CLOCK
 	return gettimeofday(__tp, __tzp);
 #else
 	/* Non-posix systems should not call gettimeofday() here as it will


### PR DESCRIPTION
When CONFIG_POSIX_CLOCK is enabled, we should have implementation of gettimeofday() and therefore time(NULL) should return correct time, instead of -1.

Signed-off-by: Seppo Takalo <seppo.takalo@nordicsemi.no>