### PR TITLE
Bluetooth: controller: Fix error codes for accept/reject CIS request

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -49,6 +49,12 @@ static struct ll_conn *ll_cis_get_acl_awaiting_reply(uint16_t handle, uint8_t *e
 {
 	struct ll_conn *acl_conn = NULL;
 
+	if (!IS_CIS_HANDLE(handle) || ll_conn_iso_stream_get(handle)->group == NULL) {
+		BT_ERR("Unknown CIS handle %u", handle);
+		*error = BT_HCI_ERR_UNKNOWN_CONN_ID;
+		return NULL;
+	}
+
 	for (int h = 0; h < CONFIG_BT_MAX_CONN; h++) {
 		struct ll_conn *conn = ll_conn_get(h);
 #if defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
@@ -66,7 +72,7 @@ static struct ll_conn *ll_cis_get_acl_awaiting_reply(uint16_t handle, uint8_t *e
 
 	if (!acl_conn) {
 		BT_ERR("No connection found for handle %u", handle);
-		*error = BT_HCI_ERR_UNKNOWN_CONN_ID;
+		*error = BT_HCI_ERR_CMD_DISALLOWED;
 		return NULL;
 	}
 


### PR DESCRIPTION
The LE Accept/Reject CIS Request commands shall return Unknown Connection Identifier if the handle is not a CIS handle or does not exist. If the CIS already has been established, the commands shall return Command Disallowed.

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>