### PR TITLE
drivers: pinctrl_nrf: Configure QSPI CSN pin as output set high

### DIFF
--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -289,7 +289,8 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			break;
 		case NRF_FUN_QSPI_CSN:
 			NRF_PSEL_QSPI(reg, CSN) = pin;
-			dir = NRF_GPIO_PIN_DIR_INPUT;
+			write = 1U;
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
 			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_QSPI_IO0:


### PR DESCRIPTION
... so that the pin keeps the inactive state of the CSN line when it is not controlled by the QSPI peripheral and the driver is not suspended.

Currently, the nrf_qspi_nor shim deinitializes the nrfx_qspi driver after each operation, what leaves the pin uncontrolled until a new operation is requested (and the nrfx_qspi driver is initialized again) or the driver is suspended (and the pin is put into low-power state). This can cause the flash chip to needlessly consume current when there is no pull-up resistor on its CSN line and the line appears active. Prevent this by keeping the pin in a defined (inactive) state.

Fixes #50191.