### PR TITLE
dfu/mcuboot: removes BOOT_MAX_ALIGN and BOOT_MAGIC_SZ definition copies

### DIFF
--- a/include/zephyr/dfu/mcuboot.h
+++ b/include/zephyr/dfu/mcuboot.h
@@ -64,15 +64,6 @@ extern "C" {
 
 #define BOOT_IMG_VER_STRLEN_MAX 25  /* 255.255.65535.4294967295\0 */
 
-/* Trailer: */
-#ifndef BOOT_MAX_ALIGN
-#define BOOT_MAX_ALIGN		8
-#endif
-
-#ifndef BOOT_MAGIC_SZ
-#define BOOT_MAGIC_SZ		16
-#endif
-
 #define BOOT_TRAILER_IMG_STATUS_OFFS(bank_area) ((bank_area)->fa_size -\
 						  BOOT_MAGIC_SZ -\
 						  BOOT_MAX_ALIGN * 2)

--- a/include/zephyr/dfu/mcuboot.h
+++ b/include/zephyr/dfu/mcuboot.h
@@ -65,7 +65,10 @@ extern "C" {
 #define BOOT_IMG_VER_STRLEN_MAX 25  /* 255.255.65535.4294967295\0 */
 
 /* Trailer: */
+#ifndef BOOT_MAX_ALIGN
 #define BOOT_MAX_ALIGN		8
+#endif
+
 #ifndef BOOT_MAGIC_SZ
 #define BOOT_MAGIC_SZ		16
 #endif

--- a/subsys/dfu/img_util/CMakeLists.txt
+++ b/subsys/dfu/img_util/CMakeLists.txt
@@ -1,3 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_sources_ifdef(CONFIG_MCUBOOT_IMG_MANAGER flash_img.c)
+
+zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -14,6 +14,7 @@
 #include <zephyr/storage/stream_flash.h>
 
 #ifdef CONFIG_IMG_ERASE_PROGRESSIVELY
+#include <bootutil/bootutil_public.h>
 #include <zephyr/dfu/mcuboot.h>
 #endif
 

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/CMakeLists.txt
@@ -15,3 +15,7 @@ zephyr_library_sources(
     src/img_mgmt_state.c
     src/img_mgmt_util.c
 )
+
+if(CONFIG_MCUBOOT_IMG_MANAGER)
+    zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
+endif()

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
@@ -13,6 +13,7 @@ LOG_MODULE_REGISTER(mcumgr_img_mgmt, CONFIG_MCUMGR_IMG_MGMT_LOG_LEVEL);
 #include <zephyr/kernel.h>
 #include <soc.h>
 #include <zephyr/init.h>
+#include <bootutil/bootutil_public.h>
 #include <zephyr/dfu/mcuboot.h>
 #include <zephyr/dfu/flash_img.h>
 #include <zephyr/mgmt/mcumgr/buf.h>
@@ -456,6 +457,12 @@ img_mgmt_impl_erase_image_data(unsigned int off, unsigned int num_bytes)
 
 	LOG_INF("Erased 0x%zx bytes of image slot", erase_size);
 
+#ifdef CONFIG_MCUBOOT_IMG_MANAGER
+	/* Right now MCUmgr supports only mcuboot images.
+	 * Above compilation swich might help to recognize mcuboot related
+	 * code when supports for anothe bootloader will be introduced.
+	 */
+
 	/* erase the image trailer area if it was not erased */
 	off = BOOT_TRAILER_IMG_STATUS_OFFS(fa);
 	if (off >= erase_size) {
@@ -474,7 +481,7 @@ img_mgmt_impl_erase_image_data(unsigned int off, unsigned int num_bytes)
 
 		LOG_INF("Erased 0x%zx bytes of image slot trailer", erase_size);
 	}
-
+#endif
 	rc = 0;
 
 end_fa:

--- a/tests/subsys/dfu/mcuboot/CMakeLists.txt
+++ b/tests/subsys/dfu/mcuboot/CMakeLists.txt
@@ -6,3 +6,5 @@ project(mcuboot)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+
+zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)

--- a/tests/subsys/dfu/mcuboot/src/main.c
+++ b/tests/subsys/dfu/mcuboot/src/main.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/storage/flash_map.h>
+#include <bootutil/bootutil_public.h>
 #include <zephyr/dfu/mcuboot.h>
 
 #define SLOT0_PARTITION		slot0_partition

--- a/tests/subsys/dfu/mcuboot_multi/CMakeLists.txt
+++ b/tests/subsys/dfu/mcuboot_multi/CMakeLists.txt
@@ -6,3 +6,5 @@ project(mcuboot)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+
+zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)

--- a/tests/subsys/dfu/mcuboot_multi/src/main.c
+++ b/tests/subsys/dfu/mcuboot_multi/src/main.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/storage/flash_map.h>
+#include <bootutil/bootutil_public.h>
 #include <zephyr/dfu/mcuboot.h>
 #include <zephyr/drivers/flash.h>
 


### PR DESCRIPTION
Mcuboot bootutil_public.h provides theses original definitions.
This patch includes bootutil_public.h in places where origina definitions are needed.
Thanks to that there is no need to copy then any more.

fixes #50342
