### PR TITLE
valid temperature sensor on stm32U5 and stm32L0, L1, L4

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -482,6 +482,7 @@ static int adc_stm32_enable(ADC_TypeDef *adc)
 	defined(CONFIG_SOC_SERIES_STM32G0X) || \
 	defined(CONFIG_SOC_SERIES_STM32G4X) || \
 	defined(CONFIG_SOC_SERIES_STM32H7X) || \
+	defined(CONFIG_SOC_SERIES_STM32U5X) || \
 	defined(CONFIG_SOC_SERIES_STM32WLX)
 
 	LL_ADC_ClearFlag_ADRDY(adc);

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -264,7 +264,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000200>;
 			interrupts = <12 0>;
 			status = "disabled";
-			vref-mv = <3000>;
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -201,7 +201,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000200>;
 			interrupts = <18 0>;
 			status = "disabled";
-			vref-mv = <3000>;
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -342,7 +342,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00002000>;
 			interrupts = <18 0>;
 			status = "disabled";
-			vref-mv = <3000>;
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 		};
 


### PR DESCRIPTION
This PR is measuring the internal die temperature 
- on the disco board  b_u585i_iot02a with the internal sensor present on the ADC1 of the stm32u585  (channel19). 
- with the correct Vref  for stm32L0, stm32L1, stm32L5 

1) for the stm32u5 use the channel19 of the ADC1 for measuring the die-temperature
Note that The ADC1 is 14 bit and calibration values are acquired on 14bit. However the drivers/sensor/stm32_temp/stm32_temp.c is left unchanged on same values `#define CAL_RES 12`
and `.resolution = 12U,`

2) Set the vref correctly for stm32L0, stm32L1, stm32L5 

run west build -p auto -b b_u585i_iot02a samples/sensor/stm32_temp_sensor/
`Current temperature: 32.2  °C  `

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/50152

Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)
