### PR TITLE
Fix: esp32c3_devkitm i2c build fail

### DIFF
--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
@@ -54,8 +54,6 @@
 &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	sda-gpios = <&gpio0 1 GPIO_OPEN_DRAIN>;
-	scl-gpios = <&gpio0 3 GPIO_OPEN_DRAIN>;
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };

--- a/boards/riscv/icev_wireless/icev_wireless.dts
+++ b/boards/riscv/icev_wireless/icev_wireless.dts
@@ -60,8 +60,6 @@
 
 &i2c0 {
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	sda-gpios = <&gpio0 2 GPIO_OPEN_DRAIN>;
-	scl-gpios = <&gpio0 8 GPIO_OPEN_DRAIN>;
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };

--- a/boards/riscv/icev_wireless/icev_wireless.dts
+++ b/boards/riscv/icev_wireless/icev_wireless.dts
@@ -62,6 +62,7 @@
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &trng0 {


### PR DESCRIPTION
Drop the sda-gpios and scl-gpios properties from the esp32c3 boards, the driver does not want these to be defined. Second patch enables the i2c node on the other c3 board we have so that can be used as well.

Tested with `./scripts/twister -v -n -M -p esp32c3_devkitm -p icev_wireless -T tests/drivers/build_all/led`