### PR TITLE
net: lora: RAK4631: fix sx1262 polarity of DIO1 pin

### DIFF
--- a/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
+++ b/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
@@ -110,7 +110,7 @@
 		busy-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
 		tx-enable-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 		rx-enable-gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
-		dio1-gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+		dio1-gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
 		dio2-tx-enable;
 		dio3-tcxo-voltage = <SX126X_DIO3_TCXO_3V3>;
 		tcxo-power-startup-delay-ms = <5>;


### PR DESCRIPTION
Device unable to join to LoraWAN network and returns the following error:
```<err> lorawan: MlmeConfirm failed : Tx timeout```

With proposed fix, device successful joins and send messages.

Signed-off-by: Kiril Petrov <retfie@gmail.com>