### PR TITLE
tests: work_queue: initialize msg

### DIFF
--- a/tests/kernel/workq/work_queue/src/main.c
+++ b/tests/kernel/workq/work_queue/src/main.c
@@ -730,7 +730,7 @@ static void msg_provider_thread(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
 
-	char msg[MSG_SIZE];
+	char msg[MSG_SIZE] = { 0 };
 
 	k_msgq_put(&triggered_from_msgq_test.msgq, &msg, K_NO_WAIT);
 }


### PR DESCRIPTION
Make sure msg is initialized before being used, fixes compiler warning:

  main.c:735:9: error: 'msg' may be used uninitialized

Fixes #50343