### PR TITLE
boards: remove remaining "pinmux supported" from board yaml files

### DIFF
--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.yaml
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.yaml
@@ -16,7 +16,6 @@ supported:
   - spi
   - i2c
   - gpio
-  - pinmux
   - counter
   - eeprom
   - nvs

--- a/boards/arm/faze/faze.yaml
+++ b/boards/arm/faze/faze.yaml
@@ -17,5 +17,4 @@ supported:
   - eeprom
   - gpio
   - i2c
-  - pinmux
   - serial

--- a/boards/arm/lpcxpresso11u68/lpcxpresso11u68.yaml
+++ b/boards/arm/lpcxpresso11u68/lpcxpresso11u68.yaml
@@ -7,7 +7,6 @@ toolchain:
 supported:
   - arduino_serial
   - clock_controller
-  - pinmux
   - gpio
   - i2c
   - serial

--- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.yaml
+++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.yaml
@@ -19,7 +19,6 @@ supported:
   - espi
   - gpio
   - i2c
-  - pinmux
   - pwm
   - watchdog
   - kscan

--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.yaml
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.yaml
@@ -19,7 +19,6 @@ supported:
   - espi
   - gpio
   - i2c
-  - pinmux
   - pwm
   - watchdog
   - kscan

--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.yaml
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.yaml
@@ -15,7 +15,6 @@ ram: 64
 flash: 352
 supported:
   - gpio
-  - pinmux
   - i2c
   - adc
   - pwm

--- a/boards/arm/npcx9m6f_evb/npcx9m6f_evb.yaml
+++ b/boards/arm/npcx9m6f_evb/npcx9m6f_evb.yaml
@@ -18,7 +18,6 @@ supported:
   - clock
   - gpio
   - i2c
-  - pinmux
   - pm
   - pwm
   - psl

--- a/boards/xtensa/esp32/esp32.yaml
+++ b/boards/xtensa/esp32/esp32.yaml
@@ -9,7 +9,6 @@ supported:
   - i2c
   - watchdog
   - uart
-  - pinmux
   - nvs
   - pwm
 testing:

--- a/boards/xtensa/esp32_net/esp32_net.yaml
+++ b/boards/xtensa/esp32_net/esp32_net.yaml
@@ -8,7 +8,6 @@ supported:
   - gpio
   - i2c
   - uart
-  - pinmux
 testing:
   ignore_tags:
     - net

--- a/boards/xtensa/esp_wrover_kit/esp_wrover_kit.yaml
+++ b/boards/xtensa/esp_wrover_kit/esp_wrover_kit.yaml
@@ -10,7 +10,6 @@ supported:
   - spi
   - watchdog
   - uart
-  - pinmux
   - nvs
   - pwm
 testing:

--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.yaml
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.yaml
@@ -9,7 +9,6 @@ supported:
   - i2c
   - watchdog
   - uart
-  - pinmux
   - nvs
 testing:
   ignore_tags:

--- a/boards/xtensa/odroid_go/odroid_go.yaml
+++ b/boards/xtensa/odroid_go/odroid_go.yaml
@@ -10,7 +10,6 @@ supported:
   - spi
   - watchdog
   - uart
-  - pinmux
   - nvs
 testing:
   ignore_tags:


### PR DESCRIPTION
The tag that marks pinmux as supported, to the best of my knowledge, is not used by any test or sample, therefore this doesn't seem to be needed anymore.

- remove from 3 mec1x boards, some still use pinmux, but as the tag is neither used in tests and pinmux deprected anyway no need for it (open PR #48893).
- remove from 5 esp32 boards, as they now use pinctrl.
- remove from 2 lpc boards, as they now use pinctrl.
- remove from 1 stm32 board, as it now uses pinctrl.
- remove from 1 npcx board, as it now uses pinctrl.