### PR TITLE
dts: arm: stm32f303: add uart5 node

### DIFF
--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -45,6 +45,14 @@
 			status = "disabled";
 		};
 
+		uart5: serial@40005000 {
+			compatible = "st,stm32-uart";
+			reg = <0x40005000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00100000>;
+			interrupts = <53 0>;
+			status = "disabled";
+		};
+
 		pinctrl: pin-controller@48000000 {
 
 			gpioe: gpio@48001000 {


### PR DESCRIPTION
Add missing UART5 node to STM32F303 chip family DTSI.

Signed-off-by: Ettore Chimenti <ettore.chimenti@seco.com>