### PR TITLE
drivers: adc: sam0: Add support for C2x

### DIFF
--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -152,9 +152,11 @@ static int adc_sam0_channel_setup(const struct device *dev,
 	case ADC_REF_EXTERNAL0:
 		refctrl = ADC_REFCTRL_REFSEL_AREFA;
 		break;
+#ifdef ADC_REFCTRL_REFSEL_AREFB
 	case ADC_REF_EXTERNAL1:
 		refctrl = ADC_REFCTRL_REFSEL_AREFB;
 		break;
+#endif
 	default:
 		LOG_ERR("Selected reference is not valid");
 		return -EINVAL;
@@ -449,7 +451,7 @@ static int adc_sam0_init(const struct device *dev)
 #ifdef MCLK
 	GCLK->PCHCTRL[cfg->gclk_id].reg = cfg->gclk_mask | GCLK_PCHCTRL_CHEN;
 
-	MCLK->APBDMASK.reg |= cfg->mclk_mask;
+	MCLK_ADC |= cfg->mclk_mask;
 #else
 	PM->APBCMASK.bit.ADC_ = 1;
 

--- a/soc/arm/atmel_sam0/common/adc_fixup_sam0.h
+++ b/soc/arm/atmel_sam0/common/adc_fixup_sam0.h
@@ -104,6 +104,19 @@
 #else
 #  define ADC_SAM0_BIASREFBUF(n) 0
 #endif
+
+/*
+ * The following MCLK clock configuration fix-up symbols map to the applicable
+ * APB-specific symbols, in order to accommodate different SoC series with the
+ * ADC core connected to different APBs.
+ */
+#if defined(MCLK_APBDMASK_ADC) || defined(MCLK_APBDMASK_ADC0)
+#  define MCLK_ADC (MCLK->APBDMASK.reg)
+#elif defined(MCLK_APBCMASK_ADC0)
+#  define MCLK_ADC (MCLK->APBCMASK.reg)
+#else
+#  error ADC not supported...
+#endif
 #endif /* MCLK */
 
 /*


### PR DESCRIPTION
According to #50384 this is fix for compilations for SAMs
C21 doesn't have ADC_REFCTRL_REFSEL_AREFB and have different APBs

Signed-off-by: Kamil Serwus <kserwus@gmail.com>