### PR TITLE
dts: mec172x: fix eeprom pinctrl clk definition

### DIFF
--- a/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi
+++ b/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi
@@ -646,7 +646,7 @@
 		pinmux = < MCHP_XEC_PINMUX(0116, MCHP_AF2) >;
 	};
 
-	/omit-if-no-ref/ eeprom_clk_gpio117: gpspi_clk_gpio117 {
+	/omit-if-no-ref/ eeprom_clk_gpio117: eeprom_clk_gpio117 {
 		pinmux = < MCHP_XEC_PINMUX(0117, MCHP_AF2) >;
 	};
 


### PR DESCRIPTION
fix eeprom clk gpio117 definition in mec172x pinctrl

Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>