### PR TITLE
drivers: gpio: add gpio-gaps property to resolve gpio pinmuxing issue

### DIFF
--- a/dts/arm/nxp/nxp_rt1015.dtsi
+++ b/dts/arm/nxp/nxp_rt1015.dtsi
@@ -75,6 +75,7 @@
 		<&iomuxc_gpio_ad_b1_13_gpio1_io29>,
 		<&iomuxc_gpio_ad_b1_14_gpio1_io30>,
 		<&iomuxc_gpio_ad_b1_15_gpio1_io31>;
+	gpio-reserved-ranges = <16 10>;
 };
 
 &gpio2{
@@ -96,6 +97,7 @@
 		<&iomuxc_gpio_emc_25_gpio2_io25>,
 		<&iomuxc_gpio_emc_26_gpio2_io26>,
 		<&iomuxc_gpio_emc_27_gpio2_io27>;
+	gpio-reserved-ranges = <0 4>, <10 6>;
 };
 
 &gpio3{
@@ -115,8 +117,10 @@
 		<&iomuxc_gpio_sd_b1_09_gpio3_io29>,
 		<&iomuxc_gpio_sd_b1_10_gpio3_io30>,
 		<&iomuxc_gpio_sd_b1_11_gpio3_io31>;
+	gpio-reserved-ranges = <4 16>;
 };
 
 &gpio5{
 	pinmux = <&iomuxc_snvs_pmic_on_req_gpio5_io01>;
+	gpio-reserved-ranges = <0 1>;
 };

--- a/dts/arm/nxp/nxp_rt1020.dtsi
+++ b/dts/arm/nxp/nxp_rt1020.dtsi
@@ -146,6 +146,7 @@
 		<&iomuxc_gpio_sd_b1_09_gpio3_io29>,
 		<&iomuxc_gpio_sd_b1_10_gpio3_io30>,
 		<&iomuxc_gpio_sd_b1_11_gpio3_io31>;
+	gpio-reserved-ranges = <10 3>;
 };
 
 &gpio5{

--- a/dts/arm/nxp/nxp_rt1024.dtsi
+++ b/dts/arm/nxp/nxp_rt1024.dtsi
@@ -90,6 +90,7 @@
 		<&iomuxc_gpio_ad_b1_13_gpio1_io29>,
 		<&iomuxc_gpio_ad_b1_14_gpio1_io30>,
 		<&iomuxc_gpio_ad_b1_15_gpio1_io31>;
+	gpio-reserved-ranges = <16 6>;
 };
 
 &gpio2{
@@ -157,6 +158,7 @@
 		<&iomuxc_gpio_sd_b1_09_gpio3_io29>,
 		<&iomuxc_gpio_sd_b1_10_gpio3_io30>,
 		<&iomuxc_gpio_sd_b1_11_gpio3_io31>;
+	gpio-reserved-ranges = <10 3>;
 };
 
 &gpio5{


### PR DESCRIPTION
Some GPIO controllers on NXP's iMX RT SOCs do not expose connections for all GPIO pins within an given GPIO port. For the RT1015, RT1020, and RT1024, there are "gaps" in GPIO numbering. For example, GPIO port 1 may have pins 0-10 and 16-20 present. When making pin control selections from the `pinmux` array, this requires knowledge of these "gaps".

This PR removes ad-hoc handling of these gaps, and encodes them into the gpio controller as a DTS property.

Fixes #50142