### PR TITLE
West runner jlink add optional loader details to address the CLI requirements of JLink v7.70d and later

### DIFF
--- a/boards/arm/mimxrt1050_evk/board.cmake
+++ b/boards/arm/mimxrt1050_evk/board.cmake
@@ -7,5 +7,9 @@
 board_runner_args(pyocd "--target=mimxrt1050_hyperflash")
 board_runner_args(jlink "--device=MCIMXRT1052")
 
+if(${CONFIG_BOARD_MIMXRT1050_EVK_QSPI})
+    board_runner_args(jlink "--loader=BankAddr=0x60000000&Loader=QSPI")
+endif()
+
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/mimxrt1060_evk/board.cmake
+++ b/boards/arm/mimxrt1060_evk/board.cmake
@@ -7,5 +7,9 @@
 board_runner_args(pyocd "--target=mimxrt1060")
 board_runner_args(jlink "--device=MIMXRT1062xxx6A")
 
+if ((${CONFIG_BOARD_MIMXRT1060_EVK}) OR (${CONFIG_BOARD_MIMXRT1060_EVKB}))
+    board_runner_args(jlink "--loader=BankAddr=0x60000000&Loader=QSPI")
+endif()
+
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
For some boards, the jlink '-device' switch requires more information to flash a binary, e.g. the type of device (qspi, etc), the base address, etc. For example, the change is needed for NXP's boards mimxrt1060_evk(b)* and mimxrt1050_evk_qspi. 

The approach taken is to add an optional argument the the jlink runner, i.e. '--loader' to specify the required information. 
The code is backward compatible with versions of jlink older than v7.70d.

This PR:
 - adds code to West's jlink runner 
 - updates the relevant board cmake files for the NXP boards mentioned above.

For more details from Segger on the new flashloader parameters, see
https://wiki.segger.com/J-Link_Multiple_Flashloader#Command_line_parameter
https://wiki.segger.com/i.MXRT1060#Available_flash_loaders

fixes #50327