### PR TITLE
Track common node types in the devicetree

### DIFF
--- a/dts/bindings/i2c/i2c-controller.yaml
+++ b/dts/bindings/i2c/i2c-controller.yaml
@@ -3,7 +3,10 @@
 
 # Common fields for I2C controllers
 
-include: base.yaml
+include:
+  - name: base.yaml
+    property-blocklist:
+      - label
 
 bus: i2c
 
@@ -18,3 +21,9 @@ properties:
       type: int
       required: false
       description: Initial clock frequency in Hz
+    label:
+      type: string
+      required: false
+      description: |
+        Friendly name for the I2C controller. Available for the "i2c" shell
+        commands only.

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2585,6 +2585,11 @@
 		    (UTIL_CAT(DT_FOREACH_OKAY_, compat)(fn)),	\
 		    ())
 
+#define DT_BUS_FOREACH(bus, fn) \
+	COND_CODE_1(1,			\
+		    (DT_CAT3(DT_BUS_, bus, _FOREACH_HELPER)(fn)),	\
+		    ())
+
 /**
  * @brief Invokes @p fn for each status `okay` node of a compatible
  *        with multiple arguments.


### PR DESCRIPTION
This is a proof of concept only.  My thought is that we could re-use the "bus:" type from devicetree.  This can then be used by shell commands to find device handles of a certain type.

We could also consider adding a new property in the devicetree to track common node types.