### PR TITLE
Fix mx25um51345g flash size on RT685 and RT595

### DIFF
--- a/boards/arm/mimxrt595_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt595_evk/Kconfig.defconfig
@@ -11,7 +11,7 @@ config BOARD
 config FLASH_MCUX_FLEXSPI_MX25UM51345G
 	default y if FLASH
 config FLASH_SIZE
-	default $(dt_node_int_prop_int,/soc/spi@134000/mx25um51345g@0,size,K)
+	default $(dt_node_int_prop_int,/soc/spi@134000/mx25um51345g@0,size,Kb)
 
 config FLASH_MCUX_FLEXSPI_XIP
 	default y if FLASH

--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -323,12 +323,19 @@ zephyr_udc0: &usbhs {
 	status = "okay";
 	mx25um51345g: mx25um51345g@0 {
 		compatible = "nxp,imx-flexspi-mx25um51345g";
-		size = <DT_SIZE_M(64)>;
+		/* MX25UM51245G is 64MB, 512MBit flash part */
+		size = <DT_SIZE_M(64 * 8)>;
 		reg = <0>;
 		spi-max-frequency = <200000000>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
 		erase-block-size = <4096>;
+		/*
+		 * Note- ECC will be disabled with a
+		 * write block size of 1 byte. To enable ECC, ensure
+		 * writes are in multiples of 16 bytes. This reduced
+		 * block size is required for MCUBoot support.
+		 */
 		write-block-size = <1>;
 
 		partitions {

--- a/boards/arm/mimxrt685_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt685_evk/Kconfig.defconfig
@@ -19,7 +19,7 @@ choice FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_MODE
 endchoice
 
 config FLASH_SIZE
-	default $(dt_node_int_prop_int,/soc/spi@134000/mx25um51345g@2,size,K)
+	default $(dt_node_int_prop_int,/soc/spi@134000/mx25um51345g@2,size,Kb)
 
 config FLASH_MCUX_FLEXSPI_XIP
 	default y if FLASH

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -309,12 +309,19 @@ i2s1: &flexcomm3 {
 	status = "okay";
 	mx25um51345g: mx25um51345g@2 {
 		compatible = "nxp,imx-flexspi-mx25um51345g";
-		size = <DT_SIZE_M(64)>;
+		/* MX25UM51245G is 64MB, 512MBit flash part */
+		size = <DT_SIZE_M(64 * 8)>;
 		reg = <2>;
 		spi-max-frequency = <200000000>;
 		status = "okay";
 		jedec-id = [c2 81 3a];
 		erase-block-size = <4096>;
+		/*
+		 * Note- ECC will be disabled with a
+		 * write block size of 1 byte. To enable ECC, ensure
+		 * writes are in multiples of 16 bytes. This reduced
+		 * block size is required for MCUBoot support.
+		 */
 		write-block-size = <1>;
 
 		partitions {

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -43,6 +43,12 @@ def _dt_units_to_scale(unit):
         return 20
     if unit in {'g', 'G'}:
         return 30
+    if unit in {'kb', 'Kb'}:
+        return 13
+    if unit in {'mb', 'Mb'}:
+        return 23
+    if unit in {'gb', 'Gb'}:
+        return 33
 
 
 def dt_chosen_label(kconf, _, chosen):
@@ -198,6 +204,9 @@ def _node_int_prop(node, prop, unit=None):
         'k' or 'K'  divide by 1024 (1 << 10)
         'm' or 'M'  divide by 1,048,576 (1 << 20)
         'g' or 'G'  divide by 1,073,741,824 (1 << 30)
+        'kb' or 'Kb'  divide by 8192 (1 << 13)
+        'mb' or 'Mb'  divide by 8,388,608 (1 << 23)
+        'gb' or 'Gb'  divide by 8,589,934,592 (1 << 33)
     """
     if not node:
         return 0
@@ -249,6 +258,9 @@ def _dt_chosen_reg_addr(kconf, chosen, index=0, unit=None):
         'k' or 'K'  divide by 1024 (1 << 10)
         'm' or 'M'  divide by 1,048,576 (1 << 20)
         'g' or 'G'  divide by 1,073,741,824 (1 << 30)
+        'kb' or 'Kb'  divide by 8192 (1 << 13)
+        'mb' or 'Mb'  divide by 8,388,608 (1 << 23)
+        'gb' or 'Gb'  divide by 8,589,934,592 (1 << 33)
     """
     if doc_mode or edt is None:
         return 0
@@ -270,6 +282,9 @@ def _dt_chosen_reg_size(kconf, chosen, index=0, unit=None):
         'k' or 'K'  divide by 1024 (1 << 10)
         'm' or 'M'  divide by 1,048,576 (1 << 20)
         'g' or 'G'  divide by 1,073,741,824 (1 << 30)
+        'kb' or 'Kb'  divide by 8192 (1 << 13)
+        'mb' or 'Mb'  divide by 8,388,608 (1 << 23)
+        'gb' or 'Gb'  divide by 8,589,934,592 (1 << 33)
     """
     if doc_mode or edt is None:
         return 0
@@ -305,6 +320,9 @@ def _dt_node_reg_addr(kconf, path, index=0, unit=None):
         'k' or 'K'  divide by 1024 (1 << 10)
         'm' or 'M'  divide by 1,048,576 (1 << 20)
         'g' or 'G'  divide by 1,073,741,824 (1 << 30)
+        'kb' or 'Kb'  divide by 8192 (1 << 13)
+        'mb' or 'Mb'  divide by 8,388,608 (1 << 23)
+        'gb' or 'Gb'  divide by 8,589,934,592 (1 << 33)
     """
     if doc_mode or edt is None:
         return 0
@@ -328,6 +346,9 @@ def _dt_node_reg_size(kconf, path, index=0, unit=None):
         'k' or 'K'  divide by 1024 (1 << 10)
         'm' or 'M'  divide by 1,048,576 (1 << 20)
         'g' or 'G'  divide by 1,073,741,824 (1 << 30)
+        'kb' or 'Kb'  divide by 8192 (1 << 13)
+        'mb' or 'Mb'  divide by 8,388,608 (1 << 23)
+        'gb' or 'Gb'  divide by 8,589,934,592 (1 << 33)
     """
     if doc_mode or edt is None:
         return 0
@@ -460,6 +481,9 @@ def dt_node_int_prop(kconf, name, path, prop, unit=None):
         'k' or 'K'  divide by 1024 (1 << 10)
         'm' or 'M'  divide by 1,048,576 (1 << 20)
         'g' or 'G'  divide by 1,073,741,824 (1 << 30)
+        'kb' or 'Kb'  divide by 8192 (1 << 13)
+        'mb' or 'Mb'  divide by 8,388,608 (1 << 23)
+        'gb' or 'Gb'  divide by 8,589,934,592 (1 << 33)
     """
     if doc_mode or edt is None:
         return "0"


### PR DESCRIPTION
Fix the flash size to be in megabits on the RT685 and RT595 EVK, as required by the `jedec,jesd216` binding. Introduce an extension to the size functions in `kconfigfunctions.py` to convert a node size between bits and bytes, so the `CONFIG_FLASH_SIZE` symbol can be calculated correctly.

Fixes #50394