### PR TITLE
Bluetooth: Controller: Fix maintaining MAFS between broadcasting roles

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1409,8 +1409,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 				ticks_anchor + ticks_slot +
 				HAL_TICKER_US_TO_TICKS(
 					MAX(EVENT_MAFS_US,
-					    EVENT_OVERHEAD_START_US) -
-					EVENT_OVERHEAD_START_US +
+					    EVENT_OVERHEAD_START_US) +
 					(EVENT_TICKER_RES_MARGIN_US << 1));
 
 			ticks_slot_overhead_aux =
@@ -1450,8 +1449,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 					ticks_anchor_aux + ticks_slot_aux +
 					HAL_TICKER_US_TO_TICKS(
 						MAX(EVENT_MAFS_US,
-						    EVENT_OVERHEAD_START_US) -
-						EVENT_OVERHEAD_START_US +
+						    EVENT_OVERHEAD_START_US) +
 						(EVENT_TICKER_RES_MARGIN_US << 1));
 
 				ret = ull_adv_sync_start(adv, sync,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -2419,7 +2419,9 @@ uint32_t ull_adv_aux_evt_init(struct ll_adv_aux_set *aux,
 	if (!err) {
 		*ticks_anchor = ticks_anchor_aux;
 		*ticks_anchor += HAL_TICKER_US_TO_TICKS(
-			EVENT_TICKER_RES_MARGIN_US);
+					MAX(EVENT_MAFS_US,
+					    EVENT_OVERHEAD_START_US) +
+					(EVENT_TICKER_RES_MARGIN_US << 1));
 	}
 #endif /* CONFIG_BT_CTLR_SCHED_ADVANCED */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -860,7 +860,9 @@ static uint32_t adv_iso_start(struct ll_adv_iso_set *adv_iso,
 						   ticks_slot, &ticks_anchor);
 	if (!err) {
 		ticks_anchor += HAL_TICKER_US_TO_TICKS(
-			EVENT_TICKER_RES_MARGIN_US);
+					MAX(EVENT_MAFS_US,
+					    EVENT_OVERHEAD_START_US) +
+					(EVENT_TICKER_RES_MARGIN_US << 1));
 	} else {
 		ticks_anchor = ticker_ticks_now_get();
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -888,7 +888,6 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 				HAL_TICKER_US_TO_TICKS(
 					MAX(EVENT_MAFS_US,
 					    EVENT_OVERHEAD_START_US) -
-					EVENT_OVERHEAD_START_US +
 					(EVENT_TICKER_RES_MARGIN_US << 1));
 		}
 


### PR DESCRIPTION
Fix maintaining MAFS between broadcasting roles. When
calculating the periodic offsets use as anchor points for
auxiliary, periodic and BIG events maintain the minimum
auxiliary frame spacing.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>