### PR TITLE
cmake: fix utterly cryptic error handling in the -DSPARSE=y build

### DIFF
--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -6,10 +6,36 @@ set_ifndef(C++ g++)
 # GCC-based toolchains
 
 if("${SPARSE}" STREQUAL "y")
-  find_program(CMAKE_C_COMPILER cgcc)
-  find_program(REAL_CC ${CROSS_COMPILE}${CC} PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-  set(ENV{REAL_CC} ${REAL_CC})
-else()
+  # No search PATHS because we need more than cgcc in the default PATH
+  find_program(CMAKE_C_COMPILER cgcc REQUIRED)
+  message(STATUS "Found sparse: ${CMAKE_C_COMPILER}")
+
+  find_program(SPARSE_REAL_COMPILER ${CROSS_COMPILE}${CC} PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH REQUIRED)
+
+  # We know what REAL_CC _must_ be, so why do we ask the user to define it?  Because CMake
+  # cannot set (evil) build time env variables at configure time:
+  # https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#how-can-i-get-or-set-environment-variables
+  # As of Sep. 2022, sparse/cgcc has unfortunately no --real-cc option as it should.
+  #
+  # In theory we could define REAL_CC ourselves here and fix the configure-time
+  # --print-file-name below (and maybe others). Then ask the user to define REAL_CC later
+  # at _build_ time. But in practice who would define environment variables at build time
+  # _only_?  So best to fail early and clearly here.
+  if ("$ENV{REAL_CC}" STREQUAL "")
+    message(FATAL_ERROR
+      "The only way to override its 'cc' default when cross-compiling with sparse is "
+      "unfortunately an environment variable. So you _must_ set REAL_CC at both configuration "
+      "time and build time to: ${SPARSE_REAL_COMPILER}")
+  else() # check ENV{REAL_CC}
+    file(REAL_PATH "${SPARSE_REAL_COMPILER}" real_compiler_rp)
+    file(REAL_PATH "$ENV{REAL_CC}" env_real_cc_rp)
+    cmake_path(COMPARE "${real_compiler_rp}" EQUAL "${env_real_cc_rp}" expected_env_REAL_CC)
+    if(NOT expected_env_REAL_CC)
+      message(FATAL_ERROR
+        "Unexpected environment variable REAL_CC: $ENV{REAL_CC}, must be: ${SPARSE_REAL_COMPILER}")
+    endif()
+  endif()
+else() # SPARSE
   find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC} PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 endif()
 

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -67,7 +67,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 
     if("${SPARSE}" STREQUAL "y")
-      set(ld_command ${REAL_CC})
+      set(ld_command ${SPARSE_REAL_COMPILER})
     else()
       set(ld_command ${CMAKE_C_COMPILER})
     endif()


### PR DESCRIPTION
Fixes commit 7a85ff768385 ("add sparse support")

The sparse build needs (at least) two things:
1. sparse to be in the PATH
2. the environment variable REAL_CC to be defined and to match the value expected by CMake

Fix error messages when either condition is wrong.

- New error message when 1. is not satisfied:
```
CMake Error at zephyr/cmake/compiler/gcc/target.cmake:12 (find_program):
  Could not find CMAKE_C_COMPILER using the following names: cgcc
```

- Previous error "message" when 1. is not satisfied:
```
CMake Error at zephyr/cmake/compiler/gcc/target.cmake:17 (message):
  C compiler
  ZSDK/xtensa-intel_s1000_zephyr-elf/bin/xtensa-intel_s1000_zephyr-elf-gcc
  not found - Please check your toolchain installation
```
(the reported location DOES exist!)

- New error message when 2. is not satisfied:
```
CMake Error at zephyr/cmake/compiler/gcc/target.cmake:25 (message):
  sparse's REAL_CC is undefined, it must be set to:
  zsdk/xtensa-intel_s1000_zephyr-elf/bin/xtensa-intel_s1000_zephyr-elf-gcc
```

- Previous error "message" when 2. is not satisfied:
```
modules/hal/xtensa/include/xtensa/config/core.h:54:10:
    error:unable to open 'core-isa.h'`
```

Also: stop using the same name REAL_CC for both the internal CMake variable and the external sparse parameter; they're two different things so name them differently. Environment variable messes are complicated enough.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>