### PR TITLE
lib: libc: newlib: fix compile warning for retargetable lock

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -305,6 +305,10 @@ void *_sbrk(intptr_t count)
 __weak FUNC_ALIAS(_sbrk, sbrk, void *);
 
 #ifdef CONFIG_MULTITHREADING
+
+/* Make sure _RETARGETABLE_LOCKING is enabled in toolchain */
+BUILD_ASSERT(IS_ENABLED(_RETARGETABLE_LOCKING), "Retargetable locking must be enabled");
+
 /*
  * Newlib Retargetable Locking Interface Implementation
  *


### PR DESCRIPTION
These APIs are only valid when enable _RETARGETABLE_LOCKING in toolchain, When _RETARGETABLE_LOCKING is enabled, "_LOCK_T" is "__lock" pointer type, otherwise "_LOCK_T" is "int" type, so without this modification, there will be the following compile warnings when toolchain doesn't enable _RETARGETABLE_LOCKING:

zephyr/lib/libc/newlib/libc-hooks.c:416:13: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
  416 |  k_sem_take((struct k_sem *)lock, K_FOREVER);
      |             ^
zephyr/lib/libc/newlib/libc-hooks.c: In function '__retarget_lock_acquire_recursive':
zephyr/lib/libc/newlib/libc-hooks.c:423:15: warning: cast to pointer from
integer of different size [-Wint-to-pointer-cast]
  423 |  k_mutex_lock((struct k_mutex *)lock, K_FOREVER);
      |               ^
...

Signed-off-by: Jiafei Pan <Jiafei.Pan@nxp.com>