### PR TITLE
arch: posix: Add defaults for recommended stack sizes

### DIFF
--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -11,7 +11,9 @@ config ARCH
 
 config ARCH_POSIX_RECOMMENDED_STACK_SIZE
 	int
+	default 44 if 64BIT && STACK_SENTINEL
 	default 40 if 64BIT
+	default 28 if STACK_SENTINEL
 	default 24
 	help
 	  In bytes, stack size for Zephyr threads meant only for the POSIX


### PR DESCRIPTION
The `CONFIG_STACK_SENTINEL` adds 4 bytes to the stack. Take these into account for `CONFIG_ARCH_POSIX_RECOMMENDED_STACK_SIZE`.