### PR TITLE
west: fix warning on user args in run_common

### DIFF
--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -169,7 +169,7 @@ def do_run_common(command, user_args, user_runner_args, domains=None):
             # Get the user specified domains.
             domains = load_domains(build_dir).get_domains(user_args.domain)
 
-    if len(domains) > 1 and len(user_runner_args) > 1:
+    if len(domains) > 1 and len(user_runner_args) > 0:
         log.wrn("Specifying runner options for multiple domains is experimental.\n"
                 "If problems are experienced, please specify a single domain "
                 "using '--domain <domain>'")


### PR DESCRIPTION
When using west runners with multi domains we want to warn users when they user runner args on multi domain builds.

Therefore fix the `>1` to the correct `>0` which ensures the warning is printed in all expected cases.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>