### PR TITLE
gpio: add support for get_config and get_direction in the nct38xx driver

### DIFF
--- a/drivers/gpio/gpio_nct38xx_port.c
+++ b/drivers/gpio/gpio_nct38xx_port.c
@@ -6,11 +6,10 @@
 
 #define DT_DRV_COMPAT nuvoton_nct38xx_gpio_port
 
-#include <zephyr/drivers/gpio.h>
-
 #include "gpio_nct38xx.h"
 #include <zephyr/drivers/gpio/gpio_utils.h>
 
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(gpio_ntc38xx, CONFIG_GPIO_LOG_LEVEL);
 
@@ -581,16 +580,16 @@ BUILD_ASSERT(CONFIG_GPIO_NCT38XX_PORT_INIT_PRIORITY > CONFIG_GPIO_NCT38XX_INIT_P
 
 #define GPIO_NCT38XX_PORT_DEVICE_INSTANCE(inst)                                                    \
 	static const struct gpio_nct38xx_port_config gpio_nct38xx_port_cfg_##inst = {              \
-		.common = { .port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(inst) &               \
-					     DT_INST_PROP(inst, pin_mask) },                       \
+		.common = {.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(inst) &                \
+					    DT_INST_PROP(inst, pin_mask)},                         \
 		.nct38xx_dev = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                \
 		.gpio_port = DT_INST_REG_ADDR(inst),                                               \
 		.pinmux_mask = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, pinmux_mask),               \
 					   (DT_INST_PROP(inst, pinmux_mask)), (0)),                \
 	};                                                                                         \
-	BUILD_ASSERT(!(DT_INST_REG_ADDR(inst) == 0 &&                                              \
-		       !(DT_INST_NODE_HAS_PROP(inst, pinmux_mask))),                               \
-		     "Port 0 should assign pinmux_mask property.");                                \
+	BUILD_ASSERT(                                                                              \
+		!(DT_INST_REG_ADDR(inst) == 0 && !(DT_INST_NODE_HAS_PROP(inst, pinmux_mask))),     \
+		"Port 0 should assign pinmux_mask property.");                                     \
 	static struct gpio_nct38xx_port_data gpio_nct38xx_port_data_##inst;                        \
 	DEVICE_DT_INST_DEFINE(inst, gpio_nct38xx_port_init, NULL, &gpio_nct38xx_port_data_##inst,  \
 			      &gpio_nct38xx_port_cfg_##inst, POST_KERNEL,                          \

--- a/drivers/gpio/gpio_nct38xx_port.c
+++ b/drivers/gpio/gpio_nct38xx_port.c
@@ -70,7 +70,7 @@ static int gpio_nct38xx_pin_config(const struct device *dev, gpio_pin_t pin, gpi
 		}
 
 		new_reg = reg | mask;
-		/* NCT3807 bit3 should be set to 0 */
+		/* NCT3807 bit3 must be set to 0 */
 		new_reg &= config->pinmux_mask;
 
 		ret = nct38xx_reg_update(config->nct38xx_dev, NCT38XX_REG_MUX_CONTROL, reg,
@@ -131,8 +131,8 @@ static int gpio_nct38xx_pin_config(const struct device *dev, gpio_pin_t pin, gpi
 
 	/* Configure pin as output, if requested 0:input 1:output */
 	if (flags & GPIO_OUTPUT) {
-		nct38xx_reg_read_byte(config->nct38xx_dev, NCT38XX_REG_GPIO_DIR(config->gpio_port),
-				      &reg);
+		ret = nct38xx_reg_read_byte(config->nct38xx_dev,
+					    NCT38XX_REG_GPIO_DIR(config->gpio_port), &reg);
 		if (ret < 0) {
 			goto done;
 		}


### PR DESCRIPTION
This PR adds the implementations for the API used to get current configurations of the pins in the NCT38xx IO expanders family.