### PR TITLE
Add missing west module entries (Renesas and Wurth)

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2365,6 +2365,15 @@ West:
   labels:
     - manifest-hal_ti
 
+"West project: hal_wurthelektronik":
+  status: maintained
+  maintainers:
+    - mah-eiSmart
+  files:
+    - modules/Kconfig.wurthelektronik
+  labels:
+    - manifest-hal_wurthelektronik
+
 "West project: hal_xtensa":
   status: maintained
   maintainers:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2296,6 +2296,14 @@ West:
   labels:
     - manifest-hal_quicklogic
 
+"West project: hal_renesas":
+  status: maintained
+  maintainers:
+    - andrzej-kaczmarek
+  files: []
+  labels:
+    - manifest-hal_renesas
+
 "West project: hal_rpi_pico":
   status: maintained
   maintainers:


### PR DESCRIPTION
Add two missing module maintainer entries, links for the respective HAL issues in the two commits.