### PR TITLE
drivers: can: provide default callback to can_send() if NULL

### DIFF
--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -170,7 +170,6 @@ struct can_mcan_data {
 	struct k_mutex inst_mutex;
 	struct k_sem tx_sem;
 	struct k_mutex tx_mtx;
-	struct k_sem tx_fin_sem[NUM_TX_BUF_ELEMENTS];
 	can_tx_callback_t tx_fin_cb[NUM_TX_BUF_ELEMENTS];
 	void *tx_fin_cb_arg[NUM_TX_BUF_ELEMENTS];
 	can_rx_callback_t rx_cb_std[NUM_STD_FILTER_DATA];

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -17,7 +17,6 @@
 #define MCP2515_FRAME_LEN               13
 
 struct mcp2515_tx_cb {
-	struct k_sem sem;
 	can_tx_callback_t cb;
 	void *cb_arg;
 };

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -185,7 +185,6 @@ struct can_rcar_cfg {
 };
 
 struct can_rcar_tx_cb {
-	struct k_sem sem;
 	can_tx_callback_t cb;
 	void *cb_arg;
 };
@@ -231,11 +230,7 @@ static void can_rcar_tx_done(const struct device *dev)
 	}
 
 	data->tx_unsent--;
-	if (tx_cb->cb != NULL) {
-		tx_cb->cb(dev, 0, tx_cb->cb_arg);
-	} else {
-		k_sem_give(&tx_cb->sem);
-	}
+	tx_cb->cb(dev, 0, tx_cb->cb_arg);
 	k_sem_give(&data->tx_sem);
 }
 
@@ -864,6 +859,7 @@ static int can_rcar_send(const struct device *dev, const struct can_frame *frame
 		"standard" : "extended"
 		, frame->rtr == CAN_DATAFRAME ? "no" : "yes");
 
+	__ASSERT_NO_MSG(callback != NULL);
 	__ASSERT(frame->dlc == 0U || frame->data != NULL, "Dataptr is null");
 
 	if (frame->dlc > CAN_MAX_DLC) {
@@ -885,8 +881,6 @@ static int can_rcar_send(const struct device *dev, const struct can_frame *frame
 	tx_cb = &data->tx_cb[data->tx_head];
 	tx_cb->cb = callback;
 	tx_cb->cb_arg = user_data;
-
-	k_sem_reset(&tx_cb->sem);
 
 	data->tx_head++;
 	if (data->tx_head >= RCAR_CAN_FIFO_DEPTH) {
@@ -921,9 +915,6 @@ static int can_rcar_send(const struct device *dev, const struct can_frame *frame
 	sys_write8(0xff, config->reg_addr + RCAR_CAN_TFPCR);
 
 	k_mutex_unlock(&data->inst_mutex);
-	if (callback == NULL) {
-		k_sem_take(&tx_cb->sem, K_FOREVER);
-	}
 
 	return 0;
 }
@@ -982,14 +973,10 @@ static int can_rcar_init(const struct device *dev)
 	struct can_timing timing;
 	int ret;
 	uint16_t ctlr;
-	uint8_t idx;
 
 	k_mutex_init(&data->inst_mutex);
 	k_mutex_init(&data->rx_mutex);
 	k_sem_init(&data->tx_sem, RCAR_CAN_FIFO_DEPTH, RCAR_CAN_FIFO_DEPTH);
-	for (idx = 0; idx < RCAR_CAN_FIFO_DEPTH; idx++) {
-		k_sem_init(&data->tx_cb[idx].sem, 0, 1);
-	}
 
 	data->tx_head = 0;
 	data->tx_tail = 0;

--- a/drivers/can/can_sja1000.h
+++ b/drivers/can/can_sja1000.h
@@ -106,10 +106,8 @@ struct can_sja1000_data {
 	can_state_change_callback_t state_change_cb;
 	void *state_change_cb_data;
 	struct k_sem tx_idle;
-	struct k_sem tx_done;
 	can_tx_callback_t tx_callback;
 	void *tx_user_data;
-	int tx_status;
 	uint32_t sjw;
 	void *custom;
 };

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -25,7 +25,6 @@
 struct can_stm32_mailbox {
 	can_tx_callback_t tx_callback;
 	void *callback_arg;
-	struct k_sem tx_int_sem;
 	int error;
 };
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -348,6 +348,9 @@ typedef int (*can_set_mode_t)(const struct device *dev, can_mode_t mode);
 /**
  * @brief Callback API upon sending a CAN frame
  * See @a can_send() for argument description
+ *
+ * @note From a driver perspective `callback` will never be `NULL` as a default callback will be
+ * provided if none is provided by the caller. This allows for simplifying the driver handling.
  */
 typedef int (*can_send_t)(const struct device *dev,
 			  const struct can_frame *frame,
@@ -1094,15 +1097,6 @@ __syscall int can_set_bitrate(const struct device *dev, uint32_t bitrate);
 __syscall int can_send(const struct device *dev, const struct can_frame *frame,
 		       k_timeout_t timeout, can_tx_callback_t callback,
 		       void *user_data);
-
-static inline int z_impl_can_send(const struct device *dev, const struct can_frame *frame,
-				  k_timeout_t timeout, can_tx_callback_t callback,
-				  void *user_data)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->send(dev, frame, timeout, callback, user_data);
-}
 
 /** @} */
 


### PR DESCRIPTION
Provide a default, internal callback to CAN controller drivers implementation of can_send() if no callback was provided by the caller.

This allows for simplifying the CAN driver implementations of can_send() as these no longer need special handling for callback/no callback operation.
