### PR TITLE
doc: release-notes: 3.2: bits for Xtensa, I3C, serial, PCIe, PECI, MM and IPM

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -188,6 +188,13 @@ Architectures
 
 * Xtensa
 
+  * Macros ``RSR`` and ``WSR`` have been renamed to :c:macro:`XTENSA_RSR`
+    and :c:macro:`XTENSA_WSR` to give them proper namespace.
+  * Fixed a rounding error in timing function when coverting from cycles
+    to nanoseconds.
+  * Fixed the calculation of average "cycles to nanoseconds" to actually
+    return nanoseconds instead of cycles.
+
 Bluetooth
 *********
 

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -72,6 +72,12 @@ Changes in this release
     allow distinguishing between an out of range bitrate/sample point, an unsupported bitrate, and a
     resulting sample point outside the guard limit.
 
+* Memory Management Drivers
+
+  * Added :c:func:`sys_mm_drv_update_page_flags` and
+    :c:func:`sys_mm_drv_update_region_flags` to update flags associated
+    with memory pages and regions.
+
 Removed APIs in this release
 ============================
 

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -443,6 +443,15 @@ Drivers and Sensors
 
   * Added serial driver for Renesas Smartbond platform
   * The STM32 driver now allows to use serial device as stop mode wake up source.
+  * Added check for clock control device readiness during configuration
+    for various drivers.
+  * Various fixes on ``lpuart``.
+  * Added a workaround on bytes dropping on ``nrfx_uarte``.
+  * Fixed compilation error on ``uart_pl011`` when interrupt is diabled.
+  * Added power management support on ``stm32``.
+  * ``xlnx_ps`` has moved to using ``DEVICE_MMIO`` API.
+  * ``gd32`` now supports using reset API to reset hardware and clock
+    control API to enable UART clock.
 
 * SPI
 

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -145,6 +145,10 @@ New APIs in this release
   * Added :c:enumerator:`CAN_MODE_3_SAMPLES` for enabling CAN controller triple-sampling receive
     mode.
 
+* I3C
+
+  * Added a set of new API for I3C controllers.
+
 * W1
 
   * Introduced the :ref:`W1 api<w1_api>`, used to interact with 1-Wire masters.
@@ -340,6 +344,9 @@ Drivers and Sensors
 * I2S
 
 * I3C
+
+  * Added a driver to support the NXP MCUX I3C hardware acting as the primary controller
+    on the bus (tested using RT685).
 
 * IEEE 802.15.4
 

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -389,6 +389,11 @@ Drivers and Sensors
 
 * PCIE
 
+  * Added a ``dump`` subcommand to the ``pcie`` shell command to print out
+    the first 16 configuration space registers.
+  * Added a ``ls`` subcommand to the ``pcie`` shell command to list
+    devices.
+
 * PECI
 
 * Pinmux

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -396,6 +396,11 @@ Drivers and Sensors
 
 * PECI
 
+  * Added PECI driver for Nuvoton NPCX family.
+  * Devicetree binding for ITE it8xxx2 PECI driver has changed from
+    ``ite,peci-it8xxx2`` to :dtcompatible:`ite,it8xxx2-peci` so that this aligns
+    with other ITE devices.
+
 * Pinmux
 
 * Pin control

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -365,6 +365,10 @@ Drivers and Sensors
 
 * IPM
 
+  * Kconfig is split into smaller, vendor oriented files.
+  * Support for Intel S1000 in cAVS IDC driver has been removed as the board
+    ``intel_s1000_crb`` has been removed.
+
 * LED
 
 * LoRa


### PR DESCRIPTION
This adds a fews bits in the 3.2 release notes on Xtensa, I3C, serial, PCIe, PECI, MM and IPM.