### PR TITLE
docs: releases: I2C, DMA, and RTIO Release Notes

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -303,6 +303,8 @@ Drivers and Sensors
 * DMA
 
   * STM32: Now supports stm32u5 series.
+  * cAVS drivers renamed with the broader Intel ADSP naming
+  * Kconfig depends on improvements with device tree statuses
 
 * EEPROM
 

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -508,6 +508,11 @@ Libraries / Subsystems
 
 * RTIO
 
+  * Initial version of an asynchronous task and executor API for I/O similar inspired
+    by Linux's very successful io_uring.
+  * Provides a simple linear and limited concurrency executor, simple task queuing,
+    and the ability to poll for task completions.
+
 * SD Subsystem
 
   * SDMMC STM32: Added DMA support and now compatible with STM32L5 series.

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -333,7 +333,15 @@ Drivers and Sensors
 
 * I2C
 
+  * Terminology updated to latest i2c specification removing master/slave
+    terminology and replacing with controller/target terminology.
+  * Asynchronous APIs added for requesting i2c transactions without
+    waiting for the completion of them.
+  * Added NXP LPI2C driver asynchronous i2c implementation with sample
+    showing usage with a FRDM-K64F board.
   * STM32: support for second target address was added.
+  * Kconfig depends on improvements with device tree statuses
+  * Improved ITE I2C support with FIFO and command queue mode
 
 * I2S
 


### PR DESCRIPTION
Release notes for DMA, I2C, and RTIO for the 3.2 release