### PR TITLE
twister: treat imgtool image exceeded as flash overflow

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -220,10 +220,14 @@ class CMake:
 
             if log_msg:
                 overflow_found = re.findall("region `(FLASH|ROM|RAM|ICCM|DCCM|SRAM|dram0_1_seg)' overflowed by", log_msg)
+                imgtool_overflow_found = re.findall(r"Error: Image size \(.*\) \+ trailer \(.*\) exceeds requested size", log_msg)
                 if overflow_found and not self.options.overflow_as_errors:
                     logger.debug("Test skipped due to {} Overflow".format(overflow_found[0]))
                     self.instance.status = "skipped"
                     self.instance.reason = "{} overflow".format(overflow_found[0])
+                elif imgtool_overflow_found and not self.options.overflow_as_errors:
+                    self.instance.status = "skipped"
+                    self.instance.reason = "imgtool overflow"
                 else:
                     self.instance.status = "error"
                     self.instance.reason = "Build failure"


### PR DESCRIPTION
Twister detects FLASH overflow and skips tests that trigger that condition by default, but sometimes images are just on the flash size limit and then overflows at a later stage when imgtool adds a trailer, which gets detected as a build fail and fails the run.

This detects the imgtool flash overflow together with the normal build ones, causing the build to be skipped on imgtool flash overflow as well.

Fixes #50386

(tested with `./scripts/twister -v -p lpcxpresso55s69_ns -T samples/net/sockets/http_get`)