### PR TITLE
Bluetooth: Controller: Fix auxiliary scan stop assertion check

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -639,12 +639,21 @@ uint8_t ull_scan_disable(uint8_t handle, struct ll_scan_set *scan)
 
 		aux_scan = HDR_LLL2ULL(aux_scan_lll);
 		if (aux_scan == scan) {
+			void *parent;
+
 			err = ull_scan_aux_stop(aux);
 			if (err && (err != -EALREADY)) {
 				return BT_HCI_ERR_CMD_DISALLOWED;
 			}
 
-			LL_ASSERT(!aux->parent);
+			/* Use a local variable to assert on auxiliary context's
+			 * release.
+			 * Under race condition a released aux context can be
+			 * allocated for reception of chain PDU of a periodic
+			 * sync role.
+			 */
+			parent = aux->parent;
+			LL_ASSERT(!parent || (parent != aux_scan_lll));
 		}
 	}
 #endif /* CONFIG_BT_CTLR_ADV_EXT */

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
@@ -43,7 +43,7 @@ struct ll_scan_aux_set {
 	struct lll_scan_aux lll;
 
 	/* lll_scan or lll_sync */
-	void *parent;
+	void *volatile parent;
 
 	struct node_rx_hdr *rx_head;
 	struct node_rx_hdr *rx_last;


### PR DESCRIPTION
Use a local variable to assert check on auxiliary context's release.
Add missing volatile qualifier to the parent field of the auxiliary scan context.
Under race condition a released aux context can be allocated for reception of chain PDU of a periodic sync role, hence fix the assertion check to consider that the released context can be allocated to other roles.

Fixes #50432.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>