### PR TITLE
Bluetooth: Host: Fix resolvable address update with Ext Adv enabled

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -403,7 +403,12 @@ static void adv_disable_rpa(struct bt_le_ext_adv *adv, void *data)
 	/* Disable advertising sets to prepare them for RPA update. */
 	if (atomic_test_bit(adv->flags, BT_ADV_ENABLED) &&
 	    !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) {
-		bt_le_adv_set_enable_ext(adv, false, NULL);
+		int err;
+
+		err = bt_le_adv_set_enable_ext(adv, false, NULL);
+		if (err) {
+			BT_ERR("Failed to disable advertising (err %d)", err);
+		}
 
 		adv_disabled[adv_index] = true;
 	}
@@ -432,7 +437,10 @@ static void adv_enable_rpa(struct bt_le_ext_adv *adv, void *data)
 				err);
 		}
 
-		bt_le_adv_set_enable_ext(adv, true, NULL);
+		err = bt_le_adv_set_enable_ext(adv, true, NULL);
+		if (err) {
+			BT_ERR("Failed to enable advertising (err %d)", err);
+		}
 	}
 }
 #endif /* defined(CONFIG_BT_EXT_ADV) && defined(CONFIG_BT_PRIVACY) */

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -295,7 +295,9 @@ int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv)
 		return 0;
 	}
 
-	if (adv == bt_le_adv_lookup_legacy() && adv->id == BT_ID_DEFAULT) {
+	if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
+	      BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) &&
+	    (adv == bt_le_adv_lookup_legacy()) && (adv->id == BT_ID_DEFAULT)) {
 		/* Make sure that a Legacy advertiser using default ID has same
 		 * RPA address as scanner roles.
 		 */


### PR DESCRIPTION
Fix resolvable address update after RPA timeout with Extended Advertising support enabled. As Extended
Advertising HCI Commands are being used to start legacy advertising, incorrectly the local random address was being used instead of using the random address populated in the Extended Advertising set. BT_DEV_RPA_VALID is not cleared when Extended Advertising HCI commands are used, hence the local random address is not updated and the incorrect use of it did not make any change to the advertising when disabled and enabled at RPA timeout.

Fixes #49014.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>