### PR TITLE
drivers: i2c: Fix Controller Initialization for Synopsis DW driver

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -868,7 +868,7 @@ static int i2c_dw_initialize(const struct device *dev)
 
 	k_sem_init(&dw->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 	uint32_t reg_base = get_regs(dev);
-
+	clear_bit_enable_en(reg_base);
 	/* verify that we have a valid DesignWare register first */
 	if (read_comp_type(reg_base) != I2C_DW_MAGIC_KEY) {
 		LOG_DBG("I2C: DesignWare magic key not found, check base "


### PR DESCRIPTION
Signed-off-by: Dennis Wang <dennisjw@fb.com>
According to Synopsys DW I2C spec, we can flush TX/RX FIFO by clearing the enable bit 
