### PR TITLE
doc: languages: c: Add formatted output section

### DIFF
--- a/doc/develop/languages/c/index.rst
+++ b/doc/develop/languages/c/index.rst
@@ -63,6 +63,19 @@ application.
 
 .. _`C Standard Library`: https://en.wikipedia.org/wiki/C_standard_library
 
+.. _c_library_formatted_output:
+
+Formatted Output
+****************
+
+C defines standard formatted output functions such as ``printf`` and
+``sprintf`` and these functions are implemented by the C standard
+libraries.
+
+Each C standard library has its own set of requirements and configurations for
+selecting the formatted output modes and capabilities. Refer to each C standard
+library documentation for more details.
+
 .. _c_library_dynamic_mem:
 
 Dynamic Memory Management

--- a/doc/develop/languages/c/minimal_libc.rst
+++ b/doc/develop/languages/c/minimal_libc.rst
@@ -15,6 +15,17 @@ with a number of different toolchains.
 The minimal libc implementation can be found in :file:`lib/libc/minimal` in the
 main Zephyr tree.
 
+Formatted Output
+****************
+
+The minimal libc does not implement its own formatted output processor;
+instead, it maps the C standard formatted output functions such as ``printf``
+and ``sprintf`` to the :c:func:`cbprintf` function, which is Zephyr's own
+C99-compatible formatted output implementation.
+
+For more details, refer to the :ref:`Formatted Output <formatted_output>` OS
+service documentation.
+
 Dynamic Memory Management
 *************************
 

--- a/doc/develop/languages/c/newlib.rst
+++ b/doc/develop/languages/c/newlib.rst
@@ -43,8 +43,9 @@ Nano Newlib
 
 The Newlib nano variant (:file:`libc_nano.a` and :file:`libm_nano.a`) is the
 size-optimized version of the Newlib, and supports all features that the full
-variant supports except the ``long long`` and ``double`` type format
-specifiers.
+variant supports except the new format specifiers introduced in C99, such as
+the ``char``, ``long long`` type format specifiers (i.e. ``%hhX`` and
+``%llX``).
 
 This variant can be enabled by selecting the
 :kconfig:option:`CONFIG_NEWLIB_LIBC` and
@@ -60,6 +61,22 @@ the Newlib nano variant is enabled by default unless
 :kconfig:option:`CONFIG_NEWLIB_LIBC_NANO` is explicitly de-selected.
 
 .. _`Newlib`: https://sourceware.org/newlib/
+
+Formatted Output
+****************
+
+Newlib supports all standard C formatted input and output functions, including
+``printf``, ``fprintf``, ``sprintf`` and ``sscanf``.
+
+The Newlib formatted input and output function implementation supports all
+format specifiers defined by the C standard with the following exceptions:
+
+* Floating point format specifiers (e.g. ``%f``) require
+  :kconfig:option:`CONFIG_NEWLIB_LIBC_FLOAT_PRINTF` and
+  :kconfig:option:`CONFIG_NEWLIB_LIBC_FLOAT_SCANF` to be enabled.
+* C99 format specifiers are not supported in the Newlib nano variant (i.e.
+  ``%hhX`` for ``char``, ``%llX`` for ``long long``, ``%jX`` for ``intmax_t``,
+  ``%zX`` for ``size_t``, ``%tX`` for ``ptrdiff_t``).
 
 Dynamic Memory Management
 *************************


### PR DESCRIPTION
This commit adds "Formatted Output" section to the "C Language Support" documentation that describes the C library-specific formatted output support details.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>