### PR TITLE
Fix the failure of finding GICv3 Redistributor base address for Cortex-R52

### DIFF
--- a/drivers/interrupt_controller/Kconfig.gic
+++ b/drivers/interrupt_controller/Kconfig.gic
@@ -43,6 +43,14 @@ config GIC_SINGLE_SECURITY_STATE
 	  Some ARM Cortex-family processors only supports single security
 	  state.
 
+config GIC_V3_RDIST_MATCHING_AFF0_ONLY
+	bool
+	depends on GIC_V3
+	default y if CPU_CORTEX_R52
+	help
+	  Some platforms only use aff0 to match mpdir and GICR.aff. With this
+	  enabled, we find the target redistributor by comparing the aff0 only.
+
 config GIC_V3_ITS
 	bool "GIC v3 Interrupt Translation Service"
 	depends on GIC_V3


### PR DESCRIPTION
Fix #50330
Some platforms like R52 platform[1] only use aff0 to match MPIDR.aff and GICR.aff. Introduce `GIC_V3_RDIST_MATCHING_AFF0_ONLY` to set the matching method only using aff0. With this config enabled, the matching function will find the target redistributor by comparing the aff0 only. This config is set to y if CPU_CORTEX_R52 is enabled. 

[1] https://developer.arm.com/documentation/100026/0101/Chunk723471919
