### PR TITLE
Bluetooth: host: l2cap deadlock fix

### DIFF
--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -279,6 +279,19 @@ struct bt_l2cap_chan_ops {
 	 */
 	void (*encrypt_change)(struct bt_l2cap_chan *chan, uint8_t hci_status);
 
+	/** @brief Channel alloc_seg callback
+	 *
+	 *  If this callback is provided the channel will use it to allocate
+	 *  buffers to store segments. This avoids wasting big SDU buffers with
+	 *  potentially much smaller PDUs. If this callback is supplied, it must
+	 *  return a valid buffer.
+	 *
+	 *  @param chan The channel requesting a buffer.
+	 *
+	 *  @return Allocated buffer.
+	 */
+	struct net_buf *(*alloc_seg)(struct bt_l2cap_chan *chan);
+
 	/** @brief Channel alloc_buf callback
 	 *
 	 *  If this callback is provided the channel will use it to allocate

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1971,12 +1971,12 @@ static int l2cap_chan_le_send(struct bt_l2cap_le_chan *ch,
 		BT_WARN("Unable to send seg %d", err);
 		atomic_inc(&ch->tx.credits);
 
-		/* If the segment is not the original buffer release it since it
-		 * won't be needed anymore.
+		/* The host takes ownership of the reference in seg when
+		 * bt_l2cap_send_cb is successful. The call returned an error,
+		 * so we must get rid of the reference that was taken in
+		 * l2cap_chan_create_seg.
 		 */
-		if (seg != buf) {
-			net_buf_unref(seg);
-		}
+		net_buf_unref(seg);
 
 		if (err == -ENOBUFS) {
 			/* Restore state since segment could not be sent */

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -76,7 +76,7 @@ struct l2cap_tx_meta {
 	struct l2cap_tx_meta_data *data;
 };
 
-static struct l2cap_tx_meta_data l2cap_tx_meta_data[CONFIG_BT_CONN_TX_MAX];
+static struct l2cap_tx_meta_data l2cap_tx_meta_data_storage[CONFIG_BT_CONN_TX_MAX];
 K_FIFO_DEFINE(free_l2cap_tx_meta_data);
 
 static struct l2cap_tx_meta_data *alloc_tx_meta_data(void)
@@ -2706,8 +2706,8 @@ void bt_l2cap_init(void)
 	}
 
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
-	for (size_t i = 0; i < ARRAY_SIZE(l2cap_tx_meta_data); i++) {
-		k_fifo_put(&free_l2cap_tx_meta_data, &l2cap_tx_meta_data[i]);
+	for (size_t i = 0; i < ARRAY_SIZE(l2cap_tx_meta_data_storage); i++) {
+		k_fifo_put(&free_l2cap_tx_meta_data, &l2cap_tx_meta_data_storage[i]);
 	}
 #endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
 }

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -917,6 +917,12 @@ static void l2cap_chan_tx_process(struct k_work *work)
 		if (sent < 0) {
 			if (sent == -EAGAIN) {
 				ch->tx_buf = buf;
+				/* If we don't reschedule, and the app doesn't nudge l2cap (e.g. by
+				 * sending another SDU), the channel will be stuck in limbo. To
+				 * prevent this, we attempt to re-schedule the work item for every
+				 * channel on every connection when an SDU has successfully been
+				 * sent.
+				 */
 			} else {
 				net_buf_unref(buf);
 			}
@@ -1847,6 +1853,17 @@ static void l2cap_chan_tx_resume(struct bt_l2cap_le_chan *ch)
 	k_work_submit(&ch->tx_work);
 }
 
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
+static void resume_all_channels(struct bt_conn *conn, void *data)
+{
+	struct bt_l2cap_chan *chan;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn->channels, chan, node) {
+		l2cap_chan_tx_resume(BT_L2CAP_LE_CHAN(chan));
+	}
+}
+#endif
+
 static void l2cap_chan_sdu_sent(struct bt_conn *conn, void *user_data, int err)
 {
 	struct l2cap_tx_meta_data *data = user_data;
@@ -1881,7 +1898,15 @@ static void l2cap_chan_sdu_sent(struct bt_conn *conn, void *user_data, int err)
 		cb(conn, cb_user_data, 0);
 	}
 
+	/* Resume the current channel */
 	l2cap_chan_tx_resume(BT_L2CAP_LE_CHAN(chan));
+
+	if (IS_ENABLED(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)) {
+		/* Resume all other channels in case one might be stuck.
+		 * The current channel has already been given priority.
+		 */
+		bt_conn_foreach(BT_CONN_TYPE_LE, resume_all_channels, NULL);
+	}
 }
 
 static void l2cap_chan_seg_sent(struct bt_conn *conn, void *user_data, int err)

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2258,12 +2258,19 @@ static void l2cap_chan_send_credits(struct bt_l2cap_le_chan *chan,
 				    struct net_buf *buf, uint16_t credits)
 {
 	struct bt_l2cap_le_credits *ev;
+	uint16_t old_credits;
 
 	__ASSERT_NO_MSG(bt_l2cap_chan_get_state(&chan->chan) == BT_L2CAP_CONNECTED);
 
 	/* Cap the number of credits given */
 	if (credits > chan->rx.init_credits) {
 		credits = chan->rx.init_credits;
+	}
+
+	/* Don't send back more than the initial amount. */
+	old_credits = atomic_get(&chan->rx.credits);
+	if (credits + old_credits > chan->rx.init_credits) {
+		credits = chan->rx.init_credits - old_credits;
 	}
 
 	buf = l2cap_create_le_sig_pdu(buf, BT_L2CAP_LE_CREDITS, get_ident(),
@@ -2297,6 +2304,8 @@ static void l2cap_chan_update_credits(struct bt_l2cap_le_chan *chan,
 	/* Restore enough credits to complete the sdu */
 	credits = ((chan->_sdu_len - net_buf_frags_len(buf)) +
 		   (chan->rx.mps - 1)) / chan->rx.mps;
+
+	BT_DBG("cred %d old %d", credits, (int)old_credits);
 
 	if (credits < old_credits) {
 		return;

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1779,13 +1779,20 @@ static void le_disconn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 	bt_l2cap_chan_del(&chan->chan);
 }
 
-static inline struct net_buf *l2cap_alloc_seg(struct net_buf *buf)
+static inline struct net_buf *l2cap_alloc_seg(struct net_buf *buf, struct bt_l2cap_le_chan *ch)
 {
 	struct net_buf_pool *pool = net_buf_pool_get(buf->pool_id);
 	struct net_buf *seg;
 
-	/* Try to use original pool if possible */
-	seg = net_buf_alloc(pool, K_NO_WAIT);
+	/* Use the dedicated segment callback if registered */
+	if (ch->chan.ops->alloc_seg) {
+		seg = ch->chan.ops->alloc_seg(&ch->chan);
+		__ASSERT_NO_MSG(seg);
+	} else {
+		/* Try to use original pool if possible */
+		seg = net_buf_alloc(pool, K_NO_WAIT);
+	}
+
 	if (seg) {
 		net_buf_reserve(seg, BT_L2CAP_CHAN_SEND_RESERVE);
 		return seg;
@@ -1822,7 +1829,8 @@ static struct net_buf *l2cap_chan_create_seg(struct bt_l2cap_le_chan *ch,
 	}
 
 segment:
-	seg = l2cap_alloc_seg(buf);
+	seg = l2cap_alloc_seg(buf, ch);
+
 	if (!seg) {
 		return NULL;
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_l2cap_stress/CMakeLists.txt
+++ b/tests/bluetooth/bsim_bt/bsim_test_l2cap_stress/CMakeLists.txt
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
+	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
+ the  environment variable BSIM_COMPONENTS_PATH to point to its components \
+ folder. More information can be found in\
+ https://babblesim.github.io/folder_structure_and_env.html")
+endif()
+
+find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+project(bsim_test_l2cap_stress)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources} )
+
+zephyr_include_directories(
+  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  )

--- a/tests/bluetooth/bsim_bt/bsim_test_l2cap_stress/prj.conf
+++ b/tests/bluetooth/bsim_bt/bsim_test_l2cap_stress/prj.conf
@@ -25,12 +25,11 @@ CONFIG_BT_BUF_ACL_TX_COUNT=4
 # L2AP MPS + L2CAP header (4)
 CONFIG_BT_BUF_ACL_RX_SIZE=81
 
-# TODO: find out why we can't use 16 buffers. It should fit.
-
-CONFIG_BT_L2CAP_TX_BUF_COUNT=30
-# CONFIG_BT_L2CAP_TX_BUF_COUNT=100
-
-CONFIG_BT_BUF_ACL_TX_COUNT=4
+# Governs BT_CONN_TX_MAX, and so must be >= than the max number of
+# peers, since we attempt to send one SDU per peer. The test execution
+# is a bit slowed down by having this at the very minimum, but we want
+# to keep it that way as to stress the stack as much as possible.
+CONFIG_BT_L2CAP_TX_BUF_COUNT=6
 
 CONFIG_BT_CTLR_RX_BUFFERS=10
 # The ring buffer now has space for three times as much data

--- a/tests/bluetooth/bsim_bt/bsim_test_l2cap_stress/prj.conf
+++ b/tests/bluetooth/bsim_bt/bsim_test_l2cap_stress/prj.conf
@@ -1,0 +1,45 @@
+CONFIG_BT=y
+CONFIG_BT_CENTRAL=y
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_DEVICE_NAME="L2CAP stress test"
+
+CONFIG_BT_EATT=n
+CONFIG_BT_L2CAP_ECRED=n
+
+CONFIG_BT_SMP=y # Next config depends on it
+CONFIG_BT_L2CAP_DYNAMIC_CHANNEL=y
+
+# Disable auto-initiated procedures so they don't
+# mess with the test's execution.
+CONFIG_BT_AUTO_PHY_UPDATE=n
+CONFIG_BT_AUTO_DATA_LEN_UPDATE=n
+CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS=n
+
+# L2CAP MPS
+# 23+27+27=77 makes exactly three full packets
+CONFIG_BT_L2CAP_TX_MTU=77
+CONFIG_BT_BUF_ACL_TX_SIZE=77
+CONFIG_BT_BUF_ACL_TX_COUNT=4
+
+# The minimum value for this is
+# L2AP MPS + L2CAP header (4)
+CONFIG_BT_BUF_ACL_RX_SIZE=81
+
+# TODO: find out why we can't use 16 buffers. It should fit.
+
+CONFIG_BT_L2CAP_TX_BUF_COUNT=30
+# CONFIG_BT_L2CAP_TX_BUF_COUNT=100
+
+CONFIG_BT_BUF_ACL_TX_COUNT=4
+
+CONFIG_BT_CTLR_RX_BUFFERS=10
+# The ring buffer now has space for three times as much data
+# (default 27, 3*27=81), so that it does not run out of data
+# while waiting for new SDUs to be queued.
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=81
+
+CONFIG_BT_MAX_CONN=10
+
+CONFIG_LOG=y
+CONFIG_ASSERT=y
+CONFIG_BT_DEBUG_LOG=y

--- a/tests/bluetooth/bsim_bt/bsim_test_l2cap_stress/src/common.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_l2cap_stress/src/common.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "common.h"
+
+extern enum bst_result_t bst_result;
+
+void test_init(void)
+{
+	bst_ticker_set_next_tick_absolute(WAIT_TIME);
+	bst_result = In_progress;
+}
+
+void test_tick(bs_time_t HW_device_time)
+{
+	if (bst_result != Passed) {
+		FAIL("test failed (not passed after %i seconds)\n", WAIT_SECONDS);
+	}
+}

--- a/tests/bluetooth/bsim_bt/bsim_test_l2cap_stress/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_l2cap_stress/src/common.h
@@ -1,0 +1,57 @@
+/*
+ * Common functions and helpers for L2CAP tests
+ *
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+
+#include <zephyr/types.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/byteorder.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include "bs_types.h"
+#include "bs_tracing.h"
+#include "bstests.h"
+#include "bs_pc_backchannel.h"
+
+extern enum bst_result_t bst_result;
+
+#define CREATE_FLAG(flag) static atomic_t flag = (atomic_t)false
+#define SET_FLAG(flag) (void)atomic_set(&flag, (atomic_t)true)
+#define UNSET_FLAG(flag) (void)atomic_set(&flag, (atomic_t)false)
+#define TEST_FLAG(flag) (atomic_get(&flag) == (atomic_t)true)
+#define WAIT_FOR_FLAG_SET(flag)		   \
+	while (!(bool)atomic_get(&flag)) { \
+		(void)k_sleep(K_MSEC(1));  \
+	}
+#define WAIT_FOR_FLAG_UNSET(flag)	  \
+	while ((bool)atomic_get(&flag)) { \
+		(void)k_sleep(K_MSEC(1)); \
+	}
+
+
+#define WAIT_SECONDS 120                         /* seconds */
+#define WAIT_TIME (WAIT_SECONDS * USEC_PER_SEC) /* microseconds*/
+
+#define FAIL(...)				       \
+	do {					       \
+		bst_result = Failed;		       \
+		bs_trace_error_time_line(__VA_ARGS__); \
+	} while (0)
+
+#define PASS(...)				    \
+	do {					    \
+		bst_result = Passed;		    \
+		bs_trace_info_time(1, __VA_ARGS__); \
+	} while (0)
+
+#define ASSERT(expr, ...) if (!(expr)) {FAIL(__VA_ARGS__); }
+
+void test_init(void);
+void test_tick(bs_time_t HW_device_time);

--- a/tests/bluetooth/bsim_bt/bsim_test_l2cap_stress/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_l2cap_stress/src/main.c
@@ -1,0 +1,434 @@
+/* main_l2cap_stress.c - Application main entry point */
+
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bstests.h"
+#include "common.h"
+
+#define LOG_MODULE_NAME main
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL_DBG);
+
+CREATE_FLAG(is_connected);
+CREATE_FLAG(flag_l2cap_connected);
+
+#define NUM_PERIPHERALS 6
+#define L2CAP_CHANS	NUM_PERIPHERALS
+#define INIT_CREDITS	10
+#define SDU_NUM		20
+#define SDU_LEN		1230
+
+/* Only one SDU per link will be transmitted at a time */
+/* FIXME: decrease size */
+NET_BUF_POOL_DEFINE(sdu_tx_pool,
+		    100, BT_L2CAP_BUF_SIZE(SDU_LEN),
+		    8, NULL);
+
+/* Only one SDU per link will be received at a time */
+NET_BUF_POOL_DEFINE(sdu_rx_pool,
+		    CONFIG_BT_MAX_CONN, BT_L2CAP_BUF_SIZE(SDU_LEN),
+		    8, NULL);
+
+static struct bt_l2cap_le_chan l2cap_channels[L2CAP_CHANS];
+static struct bt_l2cap_chan *l2cap_chans[L2CAP_CHANS];
+
+static uint8_t tx_data[SDU_LEN];
+static uint8_t tx_left[L2CAP_CHANS];
+static uint16_t rx_cnt;
+static uint8_t disconnect_counter;
+
+int l2cap_chan_send(struct bt_l2cap_chan *chan, uint8_t *data, size_t len)
+{
+	LOG_DBG("chan %p conn %p data %p len %d", chan, chan->conn, data, len);
+
+	struct net_buf *buf = net_buf_alloc(&sdu_tx_pool, K_NO_WAIT);
+
+	if (buf == NULL) {
+		FAIL("No more memory\n");
+		return -ENOMEM;
+	}
+
+	net_buf_reserve(buf, BT_L2CAP_CHAN_SEND_RESERVE);
+	net_buf_add_mem(buf, data, len);
+
+	int ret = bt_l2cap_chan_send(chan, buf);
+
+	if (ret < 0) {
+		FAIL("L2CAP error %d\n", ret);
+		net_buf_unref(buf);
+	}
+
+	LOG_DBG("sent %d len %d", ret, len);
+	return ret;
+}
+
+struct net_buf *alloc_buf_cb(struct bt_l2cap_chan *chan)
+{
+	return net_buf_alloc(&sdu_rx_pool, K_NO_WAIT);
+}
+
+static int get_l2cap_chan(struct bt_l2cap_chan *chan)
+{
+	for (int i = 0; i < L2CAP_CHANS; i++) {
+		if (l2cap_chans[i] == chan) {
+			return i;
+		}
+	}
+
+	FAIL("Channel %p not found\n", chan);
+	return -1;
+}
+
+static void register_channel(struct bt_l2cap_chan *chan)
+{
+	int i = get_l2cap_chan(NULL);
+
+	l2cap_chans[i] = chan;
+}
+
+void sent_cb(struct bt_l2cap_chan *chan)
+{
+	LOG_DBG("%p", chan);
+	int idx = get_l2cap_chan(chan);
+
+	if (tx_left[idx]) {
+		tx_left[idx]--;
+		l2cap_chan_send(chan, tx_data, sizeof(tx_data));
+	} else {
+		LOG_DBG("Done sending %p", chan->conn);
+	}
+}
+
+int recv_cb(struct bt_l2cap_chan *chan, struct net_buf *buf)
+{
+	LOG_DBG("len %d", buf->len);
+	rx_cnt++;
+
+	return 0;
+}
+
+void l2cap_chan_connected_cb(struct bt_l2cap_chan *l2cap_chan)
+{
+	struct bt_l2cap_le_chan *chan =
+		CONTAINER_OF(l2cap_chan, struct bt_l2cap_le_chan, chan);
+
+	SET_FLAG(flag_l2cap_connected);
+	LOG_DBG("%x (tx mtu %d mps %d) (tx mtu %d mps %d)",
+		l2cap_chan,
+		chan->tx.mtu,
+		chan->tx.mps,
+		chan->rx.mtu,
+		chan->rx.mps);
+
+	register_channel(l2cap_chan);
+}
+
+void l2cap_chan_disconnected_cb(struct bt_l2cap_chan *chan)
+{
+	UNSET_FLAG(flag_l2cap_connected);
+	LOG_DBG("%x", chan);
+}
+
+static struct bt_l2cap_chan_ops ops = {
+	.connected = l2cap_chan_connected_cb,
+	.disconnected = l2cap_chan_disconnected_cb,
+	.alloc_buf = alloc_buf_cb,
+	.recv = recv_cb,
+	.sent = sent_cb,
+};
+
+struct bt_l2cap_le_chan *get_free_l2cap_le_chan(void)
+{
+	for (int i = 0; i < L2CAP_CHANS; i++) {
+		struct bt_l2cap_le_chan *le_chan = &l2cap_channels[i];
+
+		if (le_chan->state != BT_L2CAP_DISCONNECTED) {
+			continue;
+		}
+
+		memset(le_chan, 0, sizeof(*le_chan));
+		return le_chan;
+	}
+
+	return NULL;
+}
+
+int server_accept_cb(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+{
+	struct bt_l2cap_le_chan *le_chan = NULL;
+
+	le_chan = get_free_l2cap_le_chan();
+	if (le_chan == NULL) {
+		return -ENOMEM;
+	}
+
+	memset(le_chan, 0, sizeof(*le_chan));
+	le_chan->chan.ops = &ops;
+	le_chan->rx.mtu = SDU_LEN;
+	le_chan->rx.init_credits = INIT_CREDITS;
+	le_chan->tx.init_credits = INIT_CREDITS;
+	*chan = &le_chan->chan;
+
+	return 0;
+}
+
+static struct bt_l2cap_server test_l2cap_server = {
+	.accept = server_accept_cb
+};
+
+static int l2cap_server_register(bt_security_t sec_level)
+{
+	test_l2cap_server.psm = 0;
+	test_l2cap_server.sec_level = sec_level;
+
+	int err = bt_l2cap_server_register(&test_l2cap_server);
+
+	ASSERT(err == 0, "Failed to register l2cap server.");
+
+	return test_l2cap_server.psm;
+}
+
+static void connected(struct bt_conn *conn, uint8_t conn_err)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	if (conn_err) {
+		FAIL("Failed to connect to %s (%u)", addr, conn_err);
+		return;
+	}
+
+	LOG_DBG("%s", addr);
+
+	SET_FLAG(is_connected);
+}
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	LOG_DBG("%p %s (reason 0x%02x)", conn, addr, reason);
+
+	UNSET_FLAG(is_connected);
+	disconnect_counter++;
+}
+
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.connected = connected,
+	.disconnected = disconnected,
+};
+
+static void disconnect_device(struct bt_conn *conn, void *data)
+{
+	int err;
+
+	SET_FLAG(is_connected);
+
+	err = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	ASSERT(!err, "Failed to initate disconnect (err %d)", err);
+
+	LOG_DBG("Waiting for disconnection...");
+	WAIT_FOR_FLAG_UNSET(is_connected);
+}
+
+#define BT_LE_ADV_CONN_NAME_OT BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
+					    BT_LE_ADV_OPT_USE_NAME |	\
+					    BT_LE_ADV_OPT_ONE_TIME,	\
+					    BT_GAP_ADV_FAST_INT_MIN_2, \
+					    BT_GAP_ADV_FAST_INT_MAX_2, NULL)
+
+static const struct bt_data ad[] = {
+	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+};
+
+static void test_peripheral_main(void)
+{
+	LOG_DBG("*L2CAP STRESS Peripheral started*");
+	int err;
+
+	err = bt_enable(NULL);
+	if (err) {
+		FAIL("Can't enable Bluetooth (err %d)", err);
+		return;
+	}
+
+	LOG_DBG("Peripheral Bluetooth initialized.");
+	LOG_DBG("Connectable advertising...");
+	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME_OT, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		FAIL("Advertising failed to start (err %d)", err);
+		return;
+	}
+
+	LOG_DBG("Advertising started.");
+	LOG_DBG("Peripheral waiting for connection...");
+	WAIT_FOR_FLAG_SET(is_connected);
+	LOG_DBG("Peripheral Connected.");
+
+	int psm = l2cap_server_register(BT_SECURITY_L1);
+
+	LOG_DBG("Registered server PSM %x", psm);
+
+	LOG_DBG("Peripheral waiting for transfer completion");
+	while (rx_cnt < SDU_NUM) {
+		k_msleep(100);
+	}
+
+	bt_conn_foreach(BT_CONN_TYPE_LE, disconnect_device, NULL);
+	WAIT_FOR_FLAG_UNSET(is_connected);
+	LOG_INF("Total received: %d", rx_cnt);
+	PASS("L2CAP STRESS Peripheral passed\n");
+}
+
+static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
+			 struct net_buf_simple *ad)
+{
+	struct bt_le_conn_param *param;
+	struct bt_conn *conn;
+	int err;
+
+	err = bt_le_scan_stop();
+	if (err) {
+		FAIL("Stop LE scan failed (err %d)", err);
+		return;
+	}
+
+	char str[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(addr, str, sizeof(str));
+
+	LOG_DBG("Connecting to %s", str);
+
+	param = BT_LE_CONN_PARAM_DEFAULT;
+	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN, param, &conn);
+	if (err) {
+		FAIL("Create conn failed (err %d)", err);
+		return;
+	}
+}
+
+static void connect_peripheral(void)
+{
+	struct bt_le_scan_param scan_param = {
+		.type = BT_LE_SCAN_TYPE_ACTIVE,
+		.options = BT_LE_SCAN_OPT_NONE,
+		.interval = BT_GAP_SCAN_FAST_INTERVAL,
+		.window = BT_GAP_SCAN_FAST_WINDOW,
+	};
+
+	UNSET_FLAG(is_connected);
+
+	int err = bt_le_scan_start(&scan_param, device_found);
+
+	ASSERT(!err, "Scanning failed to start (err %d)\n", err);
+
+	LOG_DBG("Central initiating connection...");
+	WAIT_FOR_FLAG_SET(is_connected);
+}
+
+static void connect_l2cap_channel(struct bt_conn *conn, void *data)
+{
+	int err;
+	struct bt_l2cap_le_chan *le_chan = get_free_l2cap_le_chan();
+
+	ASSERT(le_chan, "No more available channels\n");
+
+	le_chan->chan.ops = &ops;
+	le_chan->rx.mtu = SDU_LEN;
+	le_chan->rx.init_credits = INIT_CREDITS;
+	le_chan->tx.init_credits = INIT_CREDITS;
+
+	UNSET_FLAG(flag_l2cap_connected);
+
+	err = bt_l2cap_chan_connect(conn, &le_chan->chan, 0x0080);
+	ASSERT(!err, "Error connecting l2cap channel (err %d)\n", err);
+
+	WAIT_FOR_FLAG_SET(flag_l2cap_connected);
+}
+
+static void test_central_main(void)
+{
+	LOG_DBG("*L2CAP STRESS Central started*");
+	int err;
+
+	err = bt_enable(NULL);
+	ASSERT(err == 0, "Can't enable Bluetooth (err %d)\n", err);
+	LOG_DBG("Central Bluetooth initialized.");
+
+	/* Connect all peripherals */
+	for (int i = 0; i < NUM_PERIPHERALS; i++) {
+		connect_peripheral();
+	}
+
+	/* Connect L2CAP channels */
+	LOG_DBG("Connect L2CAP channels");
+	bt_conn_foreach(BT_CONN_TYPE_LE, connect_l2cap_channel, NULL);
+
+	/* Send SDU_NUM SDUs to each peripheral */
+	for (int i = 0; i < NUM_PERIPHERALS; i++) {
+		tx_left[i] = SDU_NUM;
+		l2cap_chan_send(l2cap_chans[i], tx_data, sizeof(tx_data));
+	}
+
+	LOG_DBG("Wait until all transfers are completed.");
+	int remaining_tx_total;
+
+	do {
+		k_msleep(100);
+
+		remaining_tx_total = 0;
+		for (int i = 0; i < L2CAP_CHANS; i++) {
+			remaining_tx_total += tx_left[i];
+		}
+	} while (remaining_tx_total);
+
+	LOG_DBG("Waiting until all peripherals are disconnected..");
+	while (disconnect_counter < NUM_PERIPHERALS) {
+		k_msleep(100);
+	}
+	LOG_DBG("All peripherals disconnected.");
+
+	PASS("L2CAP STRESS Central passed\n");
+}
+
+static const struct bst_test_instance test_def[] = {
+	{
+		.test_id = "peripheral",
+		.test_descr = "Peripheral L2CAP STRESS",
+		.test_post_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_peripheral_main
+	},
+	{
+		.test_id = "central",
+		.test_descr = "Central L2CAP STRESS",
+		.test_post_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_central_main
+	},
+	BSTEST_END_MARKER
+};
+
+struct bst_test_list *test_main_l2cap_stress_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_def);
+}
+
+extern struct bst_test_list *test_main_l2cap_stress_install(struct bst_test_list *tests);
+
+bst_test_install_t test_installers[] = {
+	test_main_l2cap_stress_install,
+	NULL
+};
+
+void main(void)
+{
+	bst_main();
+}

--- a/tests/bluetooth/bsim_bt/bsim_test_l2cap_stress/tests_scripts/l2cap.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_l2cap_stress/tests_scripts/l2cap.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# EATT test
+simulation_id="l2cap_stress"
+verbosity_level=2
+process_ids=""; exit_code=0
+
+function Execute(){
+  if [ ! -f $1 ]; then
+    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
+ compile it?)\e[39m"
+    exit 1
+  fi
+  # timeout 30 $@ & process_ids="$process_ids $!"
+  $@ & process_ids="$process_ids $!"
+}
+
+: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+
+#Give a default value to BOARD if it does not have one yet:
+BOARD="${BOARD:-nrf52_bsim}"
+
+cd ${BSIM_OUT_PATH}/bin
+
+bsim_exe=./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_l2cap_stress_prj_conf
+
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -rs=43
+
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -rs=42
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=2 -testid=peripheral -rs=10
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=3 -testid=peripheral -rs=23
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=4 -testid=peripheral -rs=7884
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=5 -testid=peripheral -rs=230
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=6 -testid=peripheral -rs=9
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=7 -sim_length=240e6 $@
+
+for process_id in $process_ids; do
+  wait $process_id || let "exit_code=$?"
+done
+exit $exit_code #the last exit code != 0

--- a/tests/bluetooth/bsim_bt/compile.sh
+++ b/tests/bluetooth/bsim_bt/compile.sh
@@ -40,6 +40,7 @@ app=tests/bluetooth/bsim_bt/bsim_test_gatt compile
 app=tests/bluetooth/bsim_bt/bsim_test_gatt_write compile
 app=tests/bluetooth/bsim_bt/bsim_test_l2cap compile
 app=tests/bluetooth/bsim_bt/bsim_test_l2cap_userdata compile
+app=tests/bluetooth/bsim_bt/bsim_test_l2cap_stress compile
 app=tests/bluetooth/bsim_bt/bsim_test_iso compile
 app=tests/bluetooth/bsim_bt/bsim_test_iso conf_file=prj_vs_dp.conf \
   compile


### PR DESCRIPTION
This combination of commits fixes the symptoms seen in #34600.
It also adds an multilink l2cap test to stress the host in case other bugs like this crop up.

Fixes #34600.

A note on the test:
As it is a special usage of the l2cap CoC API, the stack will throw a lot of errors, this is expected. 
We might want to downgrade those errors (in the near future) to be less scary, as no actual data loss is happening.

Expected errors/warnings:
```
d_00: @00:01:54.482920  [00:01:54.482,910] <wrn> bt_l2cap: No credits to transmit packet
d_00: @00:01:54.518763  [00:01:54.518,737] <err> bt_conn: Unable to allocate TX context
d_00: @00:01:54.518763  [00:01:54.518,737] <wrn> bt_l2cap: Unable to send seg -105
```