### PR TITLE
mgmt: mcumgr: img_mgmt: Prevent re-upload of duplicate image data

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -23,6 +23,10 @@
 #include "img_mgmt_priv.h"
 #include "img_mgmt/img_mgmt_config.h"
 
+#ifdef CONFIG_IMG_ENABLE_IMAGE_CHECK
+#include <zephyr/dfu/flash_img.h>
+#endif
+
 static img_mgmt_upload_fn img_mgmt_upload_cb;
 
 const struct img_mgmt_dfu_callbacks_t *img_mgmt_dfu_callbacks_fn;
@@ -417,6 +421,11 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
 		/*
 		 * New upload.
 		 */
+#ifdef CONFIG_IMG_ENABLE_IMAGE_CHECK
+		struct flash_img_context ctx;
+		struct flash_img_check fic;
+#endif
+
 		g_img_mgmt_state.off = 0;
 
 		img_mgmt_dfu_started();
@@ -431,6 +440,23 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
 		memcpy(g_img_mgmt_state.data_sha, req.data_sha.value, req.data_sha.len);
 		memset(&g_img_mgmt_state.data_sha[req.data_sha.len], 0,
 			   IMG_MGMT_DATA_SHA_LEN - req.data_sha.len);
+
+#ifdef CONFIG_IMG_ENABLE_IMAGE_CHECK
+		/* Check if the existing image hash matches the hash of the underlying data */
+		fic.match = g_img_mgmt_state.data_sha;
+		fic.clen = g_img_mgmt_state.size;
+
+		if (flash_img_check(&ctx, &fic, g_img_mgmt_state.area_id) == 0) {
+			/* Underlying data already matches, no need to upload any more, set offset
+			 * to image size so client knows upload has finished.
+			 */
+			g_img_mgmt_state.off = g_img_mgmt_state.size;
+			img_mgmt_dfu_pending();
+			cmd_status_arg.status = IMG_MGMT_ID_UPLOAD_STATUS_COMPLETE;
+			g_img_mgmt_state.area_id = -1;
+			goto end;
+		}
+#endif
 
 #ifndef CONFIG_IMG_ERASE_PROGRESSIVELY
 		/* erase the entire req.size all at once */


### PR DESCRIPTION
This adds a hash check when the CONFIG_IMG_ENABLE_IMAGE_CHECK Kconfig option is enabled that will check the underlying image hash to see if it is the same as the one provided by the mcumgr client, and if so, will prevent erasure/uploading the same image data.

Fixes #40924