### PR TITLE
maintainers: split documentation area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -464,18 +464,32 @@ Documentation:
     - carlescufi
   collaborators:
     - nashif
-    - utzig
-    - gmarull
   files:
-    - doc/
-    - doc/_static/
-    - doc/_templates/
-    - doc/_doxygen/
-    - doc/_scripts/
+    - doc/contribute/
+    - doc/develop/
+    - doc/introduction/
+    - doc/project/
+    - doc/releases/
+    - doc/security/
     - README.rst
-    - doc/Makefile
   labels:
     - "area: Documentation"
+
+Documentation Infrastructure:
+  status: maintained
+  maintainers:
+    - gmarull
+  collaborators:
+    - carlescufi
+    - nashif
+  files:
+    - doc/_*/
+    - doc/CMakeLists.txt
+    - doc/conf.py
+    - doc/Makefile
+    - doc/zephyr.doxyfile.in
+  labels:
+    - "area: Documentation Infrastructure"
 
 "Drivers: ADC":
   status: maintained


### PR DESCRIPTION
By including `doc/` under the "Documentation" area we put documentation
content and infrastucture in the same basket, however, people
maintaining infrastructure is often not interested in reviewing
documentation content. This patch creates a new "Documentation
Infrastructure" area and limits its scope to infrastructure-only files
(CMake, Sphinx, extensions, etc.). I've assigned myself as a maintainer
as I've been working on such areas for a long time now. @utzig removed
from the list of collaborators as it is no longer active in this area.
Core documentation, e.g. getting started, contribute, etc. is kept under
the "Documentation" area.

Subsystem specific documentation folders/files should be added in the
respective areas (many already do).

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>