### PR TITLE
Bluetooth: controller: conditionally compile legacy ctrl tx buffers

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -47,6 +47,9 @@
 #endif /* CONFIG_BT_CTLR_USER_EXT */
 
 #include "ull_internal.h"
+#if !defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
+#include "ull_llcp_internal.h"
+#endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 #include "ull_sched_internal.h"
 #include "ull_chan_internal.h"
 #include "ull_conn_internal.h"
@@ -200,7 +203,7 @@ static uint8_t force_md_cnt_calc(struct lll_conn *lll_conn, uint32_t tx_rate);
 #if defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
 #define CONN_TX_CTRL_BUFFERS (4 * CONFIG_BT_CTLR_LLCP_CONN)
 #else /* !CONFIG_BT_LL_SW_LLCP_LEGACY */
-#define CONN_TX_CTRL_BUFFERS 0
+#define CONN_TX_CTRL_BUFFERS LLCP_TX_CTRL_BUF_COUNT
 #endif /* !CONFIG_BT_LL_SW_LLCP_LEGACY */
 #define CONN_TX_CTRL_BUF_SIZE MROUND(offsetof(struct node_tx, pdu) + \
 				     offsetof(struct pdu_data, llctrl) + \
@@ -213,6 +216,10 @@ static uint8_t force_md_cnt_calc(struct lll_conn *lll_conn, uint32_t tx_rate);
 /* CIS Establishment procedure state values */
 #define CIS_REQUEST_AWAIT_HOST 2
 
+/*
+ * TODO: when the legacy LLCP is removed we can replace 'CONN_TX_CTRL_BUFFERS'
+ * with 'LLCP_TX_CTRL_BUF_COUNT'
+ */
 static MFIFO_DEFINE(conn_tx, sizeof(struct lll_tx), CONN_DATA_BUFFERS);
 static MFIFO_DEFINE(conn_ack, sizeof(struct lll_tx),
 		    (CONN_DATA_BUFFERS +

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -185,7 +185,7 @@ static uint8_t force_md_cnt_calc(struct lll_conn *lll_conn, uint32_t tx_rate);
  * Allocate additional Tx buffers to accommodate simultaneous encryption setup
  * across active connections.
  */
-#if defined(CONFIG_BT_CTLR_LE_ENC)
+#if defined(CONFIG_BT_CTLR_LE_ENC) && defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
 #define CONN_ENC_REQ_BUFFERS CONFIG_BT_CTLR_LLCP_CONN
 #else
 #define CONN_ENC_REQ_BUFFERS 0
@@ -197,7 +197,11 @@ static uint8_t force_md_cnt_calc(struct lll_conn *lll_conn, uint32_t tx_rate);
  * simultaneously, for example 2 for encryption, 1 for termination,
  * and 1 one that is in flight and has not been returned to the pool
  */
+#if defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
 #define CONN_TX_CTRL_BUFFERS (4 * CONFIG_BT_CTLR_LLCP_CONN)
+#else /* !CONFIG_BT_LL_SW_LLCP_LEGACY */
+#define CONN_TX_CTRL_BUFFERS 0
+#endif /* !CONFIG_BT_LL_SW_LLCP_LEGACY */
 #define CONN_TX_CTRL_BUF_SIZE MROUND(offsetof(struct node_tx, pdu) + \
 				     offsetof(struct pdu_data, llctrl) + \
 				     sizeof(struct pdu_data_llctrl))
@@ -219,10 +223,12 @@ static struct {
 	uint8_t pool[CONN_TX_BUF_SIZE * CONN_DATA_BUFFERS];
 } mem_conn_tx;
 
+#if defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
 static struct {
 	void *free;
 	uint8_t pool[CONN_TX_CTRL_BUF_SIZE * CONN_TX_CTRL_BUFFERS];
 } mem_conn_tx_ctrl;
+#endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 
 static struct {
 	void *free;
@@ -2212,9 +2218,11 @@ static int init_reset(void)
 	mem_init(mem_conn_tx.pool, CONN_TX_BUF_SIZE, CONN_DATA_BUFFERS,
 		 &mem_conn_tx.free);
 
+#if defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
 	/* Initialize tx ctrl pool. */
 	mem_init(mem_conn_tx_ctrl.pool, CONN_TX_CTRL_BUF_SIZE,
 		 CONN_TX_CTRL_BUFFERS, &mem_conn_tx_ctrl.free);
+#endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 
 	/* Initialize tx link pool. */
 	mem_init(mem_link_tx.pool, sizeof(memq_link_t),


### PR DESCRIPTION
Conditionally compile the legacy control procedure defined
control Tx buffers that is not required in the new control
procedure implementation

fixes #50461
fixes #49624

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>
Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>