### PR TITLE
mgmt: mcumgr: img_mgmt: Fix slot3 if check

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
@@ -142,7 +142,7 @@ zephyr_img_mgmt_flash_area_id(int slot)
 		break;
 #endif
 
-#if FIXED_PARTITION_EXISTS(slot3_partition)
+#if FIXED_PARTITION_EXISTS(SLOT3_PARTITION)
 	case 3:
 		fa_id = FIXED_PARTITION_ID(SLOT3_PARTITION);
 		break;


### PR DESCRIPTION
Fixes an issue with img_mgmt whereby the if check for a slot3 partition is using the wrong case for the partition name.

Fixes #50482