### PR TITLE
[backport v3.1-branch] drivers: gpio: stm32: Apply GPIOG specific code to U5 series

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -629,11 +629,16 @@ static int gpio_stm32_init(const struct device *dev)
 
 	data->dev = dev;
 
-#if defined(PWR_CR2_IOSV) && DT_NODE_HAS_STATUS(DT_NODELABEL(gpiog), okay)
+#if (defined(PWR_CR2_IOSV) || defined(PWR_SVMCR_IO2SV)) && \
+	DT_NODE_HAS_STATUS(DT_NODELABEL(gpiog), okay)
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 	/* Port G[15:2] requires external power supply */
-	/* Cf: L4/L5 RM, Chapter "Independent I/O supply rail" */
+	/* Cf: L4/L5/U5 RM, Chapter "Independent I/O supply rail" */
+#ifdef CONFIG_SOC_SERIES_STM32U5X
+	LL_PWR_EnableVDDIO2();
+#else
 	LL_PWR_EnableVddIO2();
+#endif
 	z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
 #endif
 	/* enable port clock (if runtime PM is not enabled) */


### PR DESCRIPTION
In STM32U5 as well it is required to enable VDD before use. Difference is that U5 enables this under PWR_SVMCR_IO2SV flag.

Note: Solution slightly differs from the fix done in main branch as a #ifdef CONFIG_SOC_SERIES_STM32U5X was preferred over a fix in hal in order to avoid maintaining a specific v3.1 branch on hal_stm32 module.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/50158