### PR TITLE
Bluetooth: Mesh: Fix Network ID/Node Identity interleaves for multiple subnets

### DIFF
--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -417,7 +417,7 @@ int bt_mesh_adv_gatt_start(const struct bt_le_adv_param *param,
 	struct bt_mesh_ext_adv *adv = gatt_adv_get();
 	struct bt_le_ext_adv_start_param start = {
 		/* Timeout is set in 10 ms steps, with 0 indicating "forever" */
-		.timeout = (duration == SYS_FOREVER_MS) ? 0 : (duration / 10),
+		.timeout = (duration == SYS_FOREVER_MS) ? 0 : MAX(1, duration / 10),
 	};
 
 	BT_DBG("Start advertising %d ms", duration);

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -590,7 +590,7 @@ static int gatt_proxy_advertise(struct bt_mesh_subnet *sub)
 			uint32_t active = k_uptime_get_32() - sub->node_id_start;
 
 			if (active < NODE_ID_TIMEOUT) {
-				remaining = NODE_ID_TIMEOUT - active;
+				remaining = MIN(remaining, NODE_ID_TIMEOUT - active);
 				BT_DBG("Node ID active for %u ms, %d ms remaining",
 				       active, remaining);
 				err = node_id_adv(sub, remaining);

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -632,6 +632,7 @@ static void subnet_evt(struct bt_mesh_subnet *sub, enum bt_mesh_key_evt evt)
 		}
 	} else {
 		bt_mesh_proxy_beacon_send(sub);
+		bt_mesh_adv_gatt_update();
 	}
 }
 


### PR DESCRIPTION
This PR fixes the following issues:
- Prevents from setting `struct bt_le_ext_adv_start_param.timeout` to zero when duration is between 1 and 9 and division equals to zero;
- Limits duration for one subnet when advertising with Node Identity with multiple subnets;
- Wakes up advertiser when a new subnet is added so that a node can start interleaving Network ID advertisements for multiple subnets;