### PR TITLE
ARC: fix possible memory corruption with userspace

### DIFF
--- a/arch/arc/core/arc_smp.c
+++ b/arch/arc/core/arc_smp.c
@@ -50,7 +50,7 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	 * arc_cpu_wake_flag will protect arc_cpu_sp that
 	 * only one slave cpu can read it per time
 	 */
-	arc_cpu_sp = Z_THREAD_STACK_BUFFER(stack) + sz;
+	arc_cpu_sp = Z_KERNEL_STACK_BUFFER(stack) + sz;
 
 	arc_cpu_wake_flag = cpu_num;
 


### PR DESCRIPTION
Use  Z_KERNEL_STACK_BUFFER instead of Z_THREAD_STACK_BUFFER for initial stack.

Fixes #50467

Signed-off-by: Ruud Derwig <Ruud.Derwig@synopsys.com>