### PR TITLE
soc: intel_adsp: use Z_KERNEL_STACK_BUFFER instead of Z_THREAD_STACK_BUFFER.

### DIFF
--- a/soc/xtensa/esp32/esp32-mp.c
+++ b/soc/xtensa/esp32/esp32-mp.c
@@ -235,12 +235,12 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 
 	sr.cpu = cpu_num;
 	sr.fn = fn;
-	sr.stack_top = Z_THREAD_STACK_BUFFER(stack) + sz;
+	sr.stack_top = Z_KERNEL_STACK_BUFFER(stack) + sz;
 	sr.arg = arg;
 	sr.vecbase = vb;
 	sr.alive = &alive_flag;
 
-	appcpu_top = Z_THREAD_STACK_BUFFER(stack) + sz;
+	appcpu_top = Z_KERNEL_STACK_BUFFER(stack) + sz;
 
 	start_rec = &sr;
 

--- a/soc/xtensa/intel_adsp/common/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/common/multiprocessing.c
@@ -137,7 +137,7 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	start_rec.fn = fn;
 	start_rec.arg = arg;
 
-	z_mp_stack_top = Z_THREAD_STACK_BUFFER(stack) + sz;
+	z_mp_stack_top = Z_KERNEL_STACK_BUFFER(stack) + sz;
 
 	soc_start_core(cpu_num);
 }


### PR DESCRIPTION
This is currently a symbolic change as Z_THREAD_STACK_BUFFER is simply an alias to Z_KERNEL_STACK_BUFFER without userspace, and Xtensa does not support userspace at the moment.