### PR TITLE
[Backport v2.7-branch] soc: intel_adsp: use Z_KERNEL_STACK_BUFFER instead of Z_THREAD_STACK_BUFFER.

### DIFF
--- a/soc/xtensa/esp32/esp32-mp.c
+++ b/soc/xtensa/esp32/esp32-mp.c
@@ -205,12 +205,12 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 
 	sr.cpu = cpu_num;
 	sr.fn = fn;
-	sr.stack_top = Z_THREAD_STACK_BUFFER(stack) + sz;
+	sr.stack_top = Z_KERNEL_STACK_BUFFER(stack) + sz;
 	sr.arg = arg;
 	sr.vecbase = vb;
 	sr.alive = &alive_flag;
 
-	appcpu_top = Z_THREAD_STACK_BUFFER(stack) + sz;
+	appcpu_top = Z_KERNEL_STACK_BUFFER(stack) + sz;
 
 	start_rec = &sr;
 

--- a/soc/xtensa/intel_adsp/common/soc_mp.c
+++ b/soc/xtensa/intel_adsp/common/soc_mp.c
@@ -331,7 +331,7 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	start_rec.vecbase = vecbase;
 	start_rec.alive = 0;
 
-	z_mp_stack_top = Z_THREAD_STACK_BUFFER(stack) + sz;
+	z_mp_stack_top = Z_KERNEL_STACK_BUFFER(stack) + sz;
 
 	/* Pre-2.x cAVS delivers the IDC to ROM code, so unmask it */
 	CAVS_INTCTRL[cpu_num].l2.clear = CAVS_L2_IDC;


### PR DESCRIPTION
Backport b820cde7a92c9389090d83d09ac04cd6b7cacbcb~2..b820cde7a92c9389090d83d09ac04cd6b7cacbcb from #50493

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/50468