### PR TITLE
kernel: move _static_thread_data to ROM

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -635,7 +635,7 @@ struct _static_thread_data {
 
 #define Z_THREAD_INITIALIZER(thread, stack, stack_size,           \
 			    entry, p1, p2, p3,                   \
-			    prio, options, delay, abort, tname)  \
+			    prio, options, delay, tname)         \
 	{                                                        \
 	.init_thread = (thread),				 \
 	.init_stack = (stack),					 \
@@ -647,7 +647,6 @@ struct _static_thread_data {
 	.init_prio = (prio),                                     \
 	.init_options = (options),                               \
 	.init_delay = (delay),                                   \
-	.init_abort = (abort),                                   \
 	.init_name = STRINGIFY(tname),                           \
 	}
 
@@ -693,7 +692,7 @@ struct _static_thread_data {
 		Z_THREAD_INITIALIZER(&_k_thread_obj_##name,		 \
 				    _k_thread_stack_##name, stack_size,  \
 				entry, p1, p2, p3, prio, options, delay, \
-				NULL, name);				 	 \
+				name);					 \
 	const k_tid_t name = (k_tid_t)&_k_thread_obj_##name
 
 /**

--- a/include/zephyr/linker/common-ram.ld
+++ b/include/zephyr/linker/common-ram.ld
@@ -73,8 +73,6 @@
 		__log_dynamic_end = .;
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-	ITERABLE_SECTION_RAM(_static_thread_data, 4)
-
 #ifdef CONFIG_USERSPACE
 	/* All kernel objects within are assumed to be either completely
 	 * initialized at build time, or initialized automatically at runtime

--- a/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
+++ b/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
@@ -68,6 +68,8 @@
 
 	ITERABLE_SECTION_ROM(k_p4wq_initparam, 4)
 
+	ITERABLE_SECTION_ROM(_static_thread_data, 4)
+
 #if defined(CONFIG_PCIE)
 	SECTION_DATA_PROLOGUE(irq_alloc,,)
 	{


### PR DESCRIPTION
Move the _static_thread_data created by K_THREAD_DEFINE to ROM. This change also deletes the unused .init_abort field from the static thread data.

Signed-off-by: Keith Short <keithshort@google.com>