### PR TITLE
doc: release-notes: 3.2: bits for eSPI

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -336,6 +336,11 @@ Drivers and Sensors
 
 * ESPI
 
+  * eSPI emulator initialization improvements.
+  * Nuvoton: Enabled platform specific Virtual Wire GPIO.
+  * Microchip: Added XEC (MEC152x) overcurrent platform-specific virtual wires.
+  * Nuvoton: Added driver flash channel operations support.
+
 * Ethernet
 
   * Atmel gmac: Add EEPROM devicetree bindings for MAC address.


### PR DESCRIPTION
This adds a few bits about the eSPI driver updates flash over eSPI support and platform-specific virtual wires support.

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>