### PR TITLE
drivers: led: led_pwm: add perceived brightness control

### DIFF
--- a/drivers/led/Kconfig.pwm
+++ b/drivers/led/Kconfig.pwm
@@ -1,9 +1,16 @@
 # Copyright (c) 2020 Seagate Technology LLC
 # SPDX-License-Identifier: Apache-2.0
 
-config LED_PWM
+menuconfig LED_PWM
 	bool "PWM LED driver"
 	default y
 	depends on PWM && DT_HAS_PWM_LEDS_ENABLED
 	help
 	  Enable driver for PWM LEDs.
+
+config LED_PWM_PERCEIVED_BRIGHTNESS_CTRL
+	bool "Perceived brightness control"
+	default y
+	depends on LED_PWM
+	help
+	  Control LED PWM brightness for perceived brightness.


### PR DESCRIPTION
This new option adjusts the perceived brightness (%) to be proportional to the cube root of the LED PWM duty cycle.

This follows the CIELAB color space lightness calculation using the cube root of the relative luminance, see:
 	https://en.wikipedia.org/wiki/CIELAB_color_space.