### PR TITLE
Bluetooth: pairing: OOB: Separate LE SC OOB from legacy OOB logic

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -113,6 +113,10 @@ Deprecated in this release
 Stable API changes in this release
 ==================================
 
+* Removed `bt_set_oob_data_flag` and replaced it with two new API calls:
+  * :c:func:`bt_le_oob_set_sc_flag` for setting/clearing OOB flag in SC pairing
+  * :c:func:`bt_le_oob_set_legacy_flag` for setting/clearing OOB flag in legacy paring
+
 New APIs in this release
 ========================
 

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1020,15 +1020,21 @@ void bt_conn_cb_register(struct bt_conn_cb *cb);
  */
 void bt_set_bondable(bool enable);
 
-/** @brief Allow/disallow remote OOB data to be used for pairing.
+/** @brief Allow/disallow remote LE SC OOB data to be used for pairing.
  *
- *  Set/clear the OOB data flag for SMP Pairing Request/Response data.
- *  The initial value of this flag depends on BT_OOB_DATA_PRESENT Kconfig
- *  setting.
+ *  Set/clear the OOB data flag for LE SC SMP Pairing Request/Response data.
  *
- *  @param enable Value allowing/disallowing remote OOB data.
+ *  @param enable Value allowing/disallowing remote LE SC OOB data.
  */
-void bt_set_oob_data_flag(bool enable);
+void bt_le_oob_set_sc_flag(bool enable);
+
+/** @brief Allow/disallow remote legacy OOB data to be used for pairing.
+ *
+ *  Set/clear the OOB data flag for legacy SMP Pairing Request/Response data.
+ *
+ *  @param enable Value allowing/disallowing remote legacy OOB data.
+ */
+void bt_le_oob_set_legacy_flag(bool enable);
 
 /** @brief Set OOB Temporary Key to be used for pairing
  *

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -276,7 +276,8 @@ static struct bt_smp_br bt_smp_br_pool[CONFIG_BT_MAX_CONN];
 
 static struct bt_smp bt_smp_pool[CONFIG_BT_MAX_CONN];
 static bool bondable = IS_ENABLED(CONFIG_BT_BONDABLE);
-static bool oobd_present;
+static bool sc_oobd_present;
+static bool legacy_oobd_present;
 static bool sc_supported;
 static const uint8_t *sc_public_key;
 static K_SEM_DEFINE(sc_local_pkey_ready, 0, 1);
@@ -2542,9 +2543,14 @@ void bt_set_bondable(bool enable)
 	bondable = enable;
 }
 
-void bt_set_oob_data_flag(bool enable)
+void bt_le_oob_set_sc_flag(bool enable)
 {
-	oobd_present = enable;
+	sc_oobd_present = enable;
+}
+
+void bt_le_oob_set_legacy_flag(bool enable)
+{
+	legacy_oobd_present = enable;
 }
 
 static uint8_t get_auth(struct bt_smp *smp, uint8_t auth)
@@ -2841,8 +2847,6 @@ static uint8_t smp_pairing_req(struct bt_smp *smp, struct net_buf *buf)
 
 	rsp->auth_req = get_auth(smp, req->auth_req);
 	rsp->io_capability = get_io_capa(smp);
-	rsp->oob_flag = oobd_present ? BT_SMP_OOB_PRESENT :
-				       BT_SMP_OOB_NOT_PRESENT;
 	rsp->max_key_size = BT_SMP_MAX_ENC_KEY_SIZE;
 	rsp->init_key_dist = (req->init_key_dist & RECV_KEYS);
 	rsp->resp_key_dist = (req->resp_key_dist & SEND_KEYS);
@@ -2853,6 +2857,14 @@ static uint8_t smp_pairing_req(struct bt_smp *smp, struct net_buf *buf)
 
 		rsp->init_key_dist &= RECV_KEYS_SC;
 		rsp->resp_key_dist &= SEND_KEYS_SC;
+	}
+
+	if (atomic_test_bit(smp->flags, SMP_FLAG_SC)) {
+		rsp->oob_flag = sc_oobd_present ? BT_SMP_OOB_PRESENT :
+				BT_SMP_OOB_NOT_PRESENT;
+	} else {
+		rsp->oob_flag = legacy_oobd_present ? BT_SMP_OOB_PRESENT :
+				BT_SMP_OOB_NOT_PRESENT;
 	}
 
 	if ((rsp->auth_req & BT_SMP_AUTH_CT2) &&
@@ -3020,8 +3032,15 @@ static int smp_send_pairing_req(struct bt_conn *conn)
 
 	req->auth_req = get_auth(smp, BT_SMP_AUTH_DEFAULT);
 	req->io_capability = get_io_capa(smp);
-	req->oob_flag = oobd_present ? BT_SMP_OOB_PRESENT :
-				       BT_SMP_OOB_NOT_PRESENT;
+
+	if (req->auth_req & BT_SMP_AUTH_SC) {
+		req->oob_flag = sc_oobd_present ? BT_SMP_OOB_PRESENT :
+				BT_SMP_OOB_NOT_PRESENT;
+	} else {
+		req->oob_flag = legacy_oobd_present ? BT_SMP_OOB_PRESENT :
+				BT_SMP_OOB_NOT_PRESENT;
+	}
+
 	req->max_key_size = BT_SMP_MAX_ENC_KEY_SIZE;
 
 	if (req->auth_req & BT_SMP_AUTH_BONDING) {

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -719,7 +719,7 @@ static void bt_ready(int err)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
-		bt_set_oob_data_flag(true);
+		bt_le_oob_set_legacy_flag(true);
 	}
 
 #if defined(CONFIG_BT_OBSERVER)
@@ -2834,7 +2834,7 @@ static int cmd_oob_remote(const struct shell *sh, size_t argc,
 			sizeof(oob_remote.le_sc_data.r));
 		hex2bin(argv[4], strlen(argv[4]), oob_remote.le_sc_data.c,
 			sizeof(oob_remote.le_sc_data.c));
-		bt_set_oob_data_flag(true);
+		bt_le_oob_set_sc_flag(true);
 	} else {
 		shell_help(sh);
 		return -ENOEXEC;
@@ -2846,7 +2846,7 @@ static int cmd_oob_remote(const struct shell *sh, size_t argc,
 static int cmd_oob_clear(const struct shell *sh, size_t argc, char *argv[])
 {
 	memset(&oob_remote, 0, sizeof(oob_remote));
-	bt_set_oob_data_flag(false);
+	bt_le_oob_set_sc_flag(false);
 
 	return 0;
 }

--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -429,7 +429,7 @@ static uint8_t set_oob_sc_remote_data(const void *cmd, uint16_t cmd_len,
 	const struct btp_gap_oob_sc_set_remote_data_cmd *cp = cmd;
 
 	cb.oob_data_request = oob_data_request;
-	bt_set_oob_data_flag(true);
+	bt_le_oob_set_sc_flag(true);
 
 	/* Note that the .addr field
 	 * will be set by the oob_data_request callback
@@ -1183,7 +1183,7 @@ static uint8_t set_oob_legacy_data(const void *cmd, uint16_t cmd_len,
 
 	memcpy(oob_legacy_tk, cp->oob_data, 16);
 
-	bt_set_oob_data_flag(true);
+	bt_le_oob_set_legacy_flag(true);
 	cb.oob_data_request = oob_data_request;
 
 	return BTP_STATUS_SUCCESS;


### PR DESCRIPTION
Some systems can support only legacy OOB pairing while others only LE SC OOB pairing.
A new API function was added to signal the OS that legacy OOB is used, "bt_set_legacy_oob_data_flag". The existent API function "bt_set_oob_data_flag" will be used to signal that SC OOB is used.
The code will now advertise the presence of LE SC or legacy OOB flag depending on the state of SC flag

Signed-off-by: Sebastian Panceac <sebastian.panceac@ext.grandcentrix.net>