### PR TITLE
mgmt: mcumgr: img_mgmt: Fix lack of rc if erase fails

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -284,10 +284,8 @@ img_mgmt_erase(struct mgmt_ctxt *ctxt)
 		img_mgmt_dfu_stopped();
 	}
 
-	if (rc == 0) {
-		ok = zcbor_tstr_put_lit(zse, "rc")      &&
-		     zcbor_int32_put(zse, 0);
-	}
+	ok = zcbor_tstr_put_lit(zse, "rc")      &&
+	     zcbor_int32_put(zse, rc);
 
 	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }


### PR DESCRIPTION
Fixes an issue with mcumgr whereby if running an erase command and it fails, it would return an empty map with no data.

Fixes #50522