### PR TITLE
boards: shields: Use new naming scheme for shield node labels

### DIFF
--- a/boards/shields/adafruit_winc1500/adafruit_winc1500.overlay
+++ b/boards/shields/adafruit_winc1500/adafruit_winc1500.overlay
@@ -8,7 +8,7 @@
 	status = "okay";
 	cs-gpios = <&arduino_header 16 0>;			/* D10 */
 
-	winc1500@0 {
+	winc1500_adafruit_winc1500: winc1500@0 {
 		status = "ok";
 		compatible = "atmel,winc1500";
 		reg = <0x0>;

--- a/boards/shields/amg88xx/amg88xx_eval_kit.overlay
+++ b/boards/shields/amg88xx/amg88xx_eval_kit.overlay
@@ -7,7 +7,7 @@
 &arduino_i2c {
 	status = "okay";
 
-	amg88xx@68 {
+	amg88xx_amg88xx_eval_kit: amg88xx@68 {
 		compatible = "panasonic,amg88xx";
 		reg = <0x68>;
 		/* Pin D6 from Arduino Connector */

--- a/boards/shields/arceli_eth_w5500/arceli_eth_w5500.overlay
+++ b/boards/shields/arceli_eth_w5500/arceli_eth_w5500.overlay
@@ -5,7 +5,7 @@
 &arduino_spi {
 	status = "okay";
 
-	eth_w5500: eth_w5500@0 {
+	eth_w5500_arceli_eth_w5500: eth_w5500@0 {
 		compatible = "wiznet,w5500";
 		reg = <0x0>;
 		spi-max-frequency = <80000000>;

--- a/boards/shields/atmel_rf2xx/atmel_rf2xx_arduino.overlay
+++ b/boards/shields/atmel_rf2xx/atmel_rf2xx_arduino.overlay
@@ -6,7 +6,7 @@
 
 / {
 	chosen {
-		zephyr,ieee802154 = &ieee802154;
+		zephyr,ieee802154 = &ieee802154_atmel_rf2xx_arduino;
 	};
 };
 
@@ -17,7 +17,7 @@
 	cs-gpios = <&arduino_header 16
 		    (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 
-	ieee802154: rf2xx@0 {
+	ieee802154_atmel_rf2xx_arduino: rf2xx@0 {
 		compatible = "atmel,rf2xx";
 		reg = <0x0>;
 		spi-max-frequency = <6000000>;

--- a/boards/shields/atmel_rf2xx/atmel_rf2xx_legacy.overlay
+++ b/boards/shields/atmel_rf2xx/atmel_rf2xx_legacy.overlay
@@ -6,14 +6,14 @@
 
 / {
 	chosen {
-		zephyr,ieee802154 = &ieee802154;
+		zephyr,ieee802154 = &ieee802154_atmel_rf2xx_legacy;
 	};
 };
 
 &ext1_spi {
 	status = "okay";
 
-	ieee802154: rf2xx@0 {
+	ieee802154_atmel_rf2xx_legacy: rf2xx@0 {
 		compatible = "atmel,rf2xx";
 		reg = <0x0>;
 		spi-max-frequency = <6000000>;

--- a/boards/shields/atmel_rf2xx/atmel_rf2xx_mikrobus.overlay
+++ b/boards/shields/atmel_rf2xx/atmel_rf2xx_mikrobus.overlay
@@ -6,7 +6,7 @@
 
 / {
 	chosen {
-		zephyr,ieee802154 = &ieee802154;
+		zephyr,ieee802154 = &ieee802154_atmel_rf2xx_mikrobus;
 	};
 };
 
@@ -16,7 +16,7 @@
 	/* CS */
 	cs-gpios = <&mikrobus_header 2 GPIO_ACTIVE_LOW>;
 
-	ieee802154: rf2xx@0 {
+	ieee802154_atmel_rf2xx_mikrobus: rf2xx@0 {
 		compatible = "atmel,rf2xx";
 		reg = <0x0>;
 		spi-max-frequency = <6000000>;

--- a/boards/shields/atmel_rf2xx/atmel_rf2xx_xplained.overlay
+++ b/boards/shields/atmel_rf2xx/atmel_rf2xx_xplained.overlay
@@ -6,14 +6,14 @@
 
 / {
 	chosen {
-		zephyr,ieee802154 = &ieee802154;
+		zephyr,ieee802154 = &ieee802154_atmel_rf2xx_xplained;
 	};
 };
 
 &xplained1_spi {
 	status = "okay";
 
-	ieee802154: rf2xx@0 {
+	ieee802154_atmel_rf2xx_xplained: rf2xx@0 {
 		compatible = "atmel,rf2xx";
 		reg = <0x0>;
 		spi-max-frequency = <6000000>;

--- a/boards/shields/atmel_rf2xx/atmel_rf2xx_xpro.overlay
+++ b/boards/shields/atmel_rf2xx/atmel_rf2xx_xpro.overlay
@@ -6,14 +6,14 @@
 
 / {
 	chosen {
-		zephyr,ieee802154 = &ieee802154;
+		zephyr,ieee802154 = &ieee802154_atmel_rf2xx_xpro;
 	};
 };
 
 &ext1_spi {
 	status = "okay";
 
-	ieee802154: rf2xx@0 {
+	ieee802154_atmel_rf2xx_xpro: rf2xx@0 {
 		compatible = "atmel,rf2xx";
 		reg = <0x0>;
 		spi-max-frequency = <6000000>;

--- a/boards/shields/boostxl_ulpsense/boostxl_ulpsense.overlay
+++ b/boards/shields/boostxl_ulpsense/boostxl_ulpsense.overlay
@@ -6,13 +6,13 @@
 
 / {
 	aliases {
-		accel0 = &adxl362_0;
+		accel0 = &adxl362_0_boostxl_ulpsense;
 	};
 };
 
 &boosterpack_spi {
 
-	adxl362_0: adxl362@0 {
+	adxl362_0_boostxl_ulpsense: adxl362@0 {
 		compatible = "adi,adxl362";
 		reg = <0>;
 		spi-max-frequency = <8000000>;

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
@@ -8,7 +8,7 @@
 
 / {
 	chosen {
-		zephyr,display = &ili9340;
+		zephyr,display = &ili9340_buydisplay_2_8_tft_touch_arduino;
 	};
 };
 
@@ -16,7 +16,7 @@
 	status = "okay";
 	cs-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>; /* D9 */
 
-	ili9340: ili9340@0 {
+	ili9340_buydisplay_2_8_tft_touch_arduino: ili9340@0 {
 		compatible = "ilitek,ili9340";
 		spi-max-frequency = <25000000>;
 		reg = <0>;
@@ -36,7 +36,7 @@
 };
 
 &arduino_i2c {
-	ft5336@38 {
+	ft5336_buydisplay_2_8_tft_touch_arduino: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		/* Uncomment if IRQ line is available (requires to solder jumper) */

--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
@@ -8,7 +8,7 @@
 
 / {
 	chosen {
-		zephyr,display = &ili9488;
+		zephyr,display = &ili9488_buydisplay_3_5_tft_touch_arduino;
 	};
 };
 
@@ -16,7 +16,7 @@
 	status = "okay";
 	cs-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>; /* D9 */
 
-	ili9488: ili9488@0 {
+	ili9488_buydisplay_3_5_tft_touch_arduino: ili9488@0 {
 		compatible = "ilitek,ili9488";
 		spi-max-frequency = <25000000>;
 		reg = <0>;
@@ -35,7 +35,7 @@
 };
 
 &arduino_i2c {
-	ft5336@38 {
+	ft5336_buydisplay_3_5_tft_touch_arduino: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		/* Uncomment if IRQ line is available (requires to solder jumper) */

--- a/boards/shields/dac80508_evm/dac80508_evm.overlay
+++ b/boards/shields/dac80508_evm/dac80508_evm.overlay
@@ -8,7 +8,7 @@
 	status = "okay";
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
-	dac80508: dac80508@0 {
+	dac80508_dac80508_evm: dac80508@0 {
 		compatible = "ti,dac80508";
 		reg = <0x0>;
 		spi-max-frequency = <1000000>;

--- a/boards/shields/frdm_cr20a/frdm_cr20a.overlay
+++ b/boards/shields/frdm_cr20a/frdm_cr20a.overlay
@@ -6,14 +6,14 @@
 
 / {
 	chosen {
-		zephyr,ieee802154 = &ieee802154;
+		zephyr,ieee802154 = &ieee802154_frdm_cr20a;
 	};
 };
 
 &arduino_spi {
 	status = "okay";
 
-	ieee802154: mcr20a@0 {
+	ieee802154_frdm_cr20a: mcr20a@0 {
 		compatible = "nxp,mcr20a";
 		reg = <0x0>;
 		spi-max-frequency = <4000000>;

--- a/boards/shields/frdm_kw41z/frdm_kw41z.overlay
+++ b/boards/shields/frdm_kw41z/frdm_kw41z.overlay
@@ -6,7 +6,7 @@
 
 / {
 	chosen {
-		zephyr,bt-uart = &arduino_serial;
+		zephyr,bt-uart = &arduino_serial_frdm_kw41z;
 	};
 };
 

--- a/boards/shields/frdm_stbc_agm01/frdm_stbc_agm01.overlay
+++ b/boards/shields/frdm_stbc_agm01/frdm_stbc_agm01.overlay
@@ -11,17 +11,17 @@
 };
 
 &arduino_i2c {
-    fxos8700_1e_frdm_stbc_agm01: fxos8700@1e {
+	fxos8700_1e_frdm_stbc_agm01: fxos8700@1e {
 		compatible = "nxp,fxos8700";
 		reg = <0x1e>;
 		int1-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&arduino_header 10 GPIO_ACTIVE_LOW>;
-    };
+	};
 
-	    fxas21002_frdm_stbc_agm01:     fxas21002@20 {
-        compatible = "nxp,fxas21002";
+	fxas21002_frdm_stbc_agm01: fxas21002@20 {
+		compatible = "nxp,fxas21002";
 		reg = <0x20>;
 		int1-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;
-    };
+	};
 };

--- a/boards/shields/frdm_stbc_agm01/frdm_stbc_agm01.overlay
+++ b/boards/shields/frdm_stbc_agm01/frdm_stbc_agm01.overlay
@@ -5,20 +5,20 @@
 
 / {
 	aliases {
-		magn0 = &fxos8700_1e;
-		accel0 = &fxos8700_1e;
+		magn0 = &fxos8700_1e_frdm_stbc_agm01;
+		accel0 = &fxos8700_1e_frdm_stbc_agm01;
 	};
 };
 
 &arduino_i2c {
-    fxos8700_1e: fxos8700@1e {
+    fxos8700_1e_frdm_stbc_agm01: fxos8700@1e {
 		compatible = "nxp,fxos8700";
 		reg = <0x1e>;
 		int1-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&arduino_header 10 GPIO_ACTIVE_LOW>;
     };
 
-    fxas21002@20 {
+	    fxas21002_frdm_stbc_agm01:     fxas21002@20 {
         compatible = "nxp,fxas21002";
 		reg = <0x20>;
 		int1-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>;

--- a/boards/shields/ftdi_vm800c/ftdi_vm800c.overlay
+++ b/boards/shields/ftdi_vm800c/ftdi_vm800c.overlay
@@ -11,7 +11,7 @@
 	cs-gpios = <&arduino_header 16
 		    (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 
-	ft800@0 {
+	ft800_ftdi_vm800c: ft800@0 {
 		compatible = "ftdi,ft800";
 		reg = <0x0>;
 		spi-max-frequency = <8000000>;

--- a/boards/shields/inventek_eswifi/inventek_eswifi_arduino_spi.overlay
+++ b/boards/shields/inventek_eswifi/inventek_eswifi_arduino_spi.overlay
@@ -10,7 +10,7 @@
 	/* D10 */
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;
 
-	wifi0: iwin@0 {
+	wifi0_inventek_eswifi_arduino_spi: iwin@0 {
 		status = "okay";
 		compatible = "inventek,eswifi";
 		spi-max-frequency = <2000000>;

--- a/boards/shields/link_board_eth/link_board_eth.overlay
+++ b/boards/shields/link_board_eth/link_board_eth.overlay
@@ -8,7 +8,7 @@
 	status = "okay";
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
-	enc424j600@0 {
+	enc424j600_link_board_eth: enc424j600@0 {
 		compatible = "microchip,enc424j600";
 		spi-max-frequency = <14000000>;
 		int-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */

--- a/boards/shields/lmp90100_evb/lmp90100_evb.overlay
+++ b/boards/shields/lmp90100_evb/lmp90100_evb.overlay
@@ -7,7 +7,7 @@
 &arduino_spi {
 	status = "okay";
 
-	lmp90100: lmp90100@0 {
+	lmp90100_lmp90100_evb: lmp90100@0 {
 		compatible = "ti,lmp90100";
 		reg = <0x0>;
 		spi-max-frequency = <1000000>;
@@ -28,7 +28,7 @@
 &arduino_i2c {
 	status = "okay";
 
-	eeprom0: eeprom@57 {
+	eeprom0_lmp90100_evb: eeprom@57 {
 		compatible = "atmel,at24";
 		reg = <0x57>;
 		size = <256>;

--- a/boards/shields/ls0xx_generic/ls013b7dh03.overlay
+++ b/boards/shields/ls0xx_generic/ls013b7dh03.overlay
@@ -6,7 +6,7 @@
 
 / {
 	chosen {
-		zephyr,display = &ls0xx;
+		zephyr,display = &ls0xx_ls013b7dh03;
 	};
 };
 
@@ -14,7 +14,7 @@
 	status = "okay";
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_HIGH>; /* D10 */
 
-	ls0xx: ls0xx@0 {
+	ls0xx_ls013b7dh03: ls0xx@0 {
 		compatible = "sharp,ls0xx";
 		spi-max-frequency = <2000000>;
 		reg = <0>;

--- a/boards/shields/max7219/max7219_8x8.overlay
+++ b/boards/shields/max7219/max7219_8x8.overlay
@@ -5,14 +5,14 @@
 
 / {
 	chosen {
-		zephyr,display = &max7219;
+		zephyr,display = &max7219_max7219_8x8;
 	};
 };
 
 &arduino_spi {
 	status = "okay";
 
-	max7219: max7219@0 {
+	max7219_max7219_8x8: max7219@0 {
 		compatible = "maxim,max7219";
 		reg = <0>;
 		spi-max-frequency = <1000000>;

--- a/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
+++ b/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
@@ -8,7 +8,7 @@
 	status = "okay";
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 
-	mcp2515: can@0 {
+	mcp2515_dfrobot_can_bus_v2_0: can@0 {
 		compatible = "microchip,mcp2515";
 		spi-max-frequency = <1000000>;
 		int-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>; /* D2 */
@@ -27,6 +27,6 @@
 
 / {
 	chosen {
-		zephyr,canbus = &mcp2515;
+		zephyr,canbus = &mcp2515_dfrobot_can_bus_v2_0;
 	};
 };

--- a/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
+++ b/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
@@ -8,7 +8,7 @@
 	status = "okay";
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 
-	mcp2515: can@0 {
+	mcp2515_keyestudio_can_bus_ks0411: can@0 {
 		compatible = "microchip,mcp2515";
 		spi-max-frequency = <1000000>;
 		int-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>; /* D8 */
@@ -27,6 +27,6 @@
 
 / {
 	chosen {
-		zephyr,canbus = &mcp2515;
+		zephyr,canbus = &mcp2515_keyestudio_can_bus_ks0411;
 	};
 };

--- a/boards/shields/mikroe_adc_click/boards/lpcxpresso55s16.overlay
+++ b/boards/shields/mikroe_adc_click/boards/lpcxpresso55s16.overlay
@@ -10,7 +10,7 @@
 	status = "okay";
 
 	/* LPCXpresso55S16 uses SSEL1 for mikroBUS SPI */
-	mcp3204: mcp3204@1 {
+	mcp3204_mikroe_adc_click: mcp3204@1 {
 		compatible = "microchip,mcp3204";
 		reg = <0x1>;
 		spi-max-frequency = <100000>;

--- a/boards/shields/mikroe_adc_click/mikroe_adc_click.overlay
+++ b/boards/shields/mikroe_adc_click/mikroe_adc_click.overlay
@@ -7,7 +7,7 @@
 &mikrobus_spi {
 	status = "okay";
 
-	mcp3204: mcp3204@0 {
+	mcp3204_mikroe_adc_click: mcp3204@0 {
 		compatible = "microchip,mcp3204";
 		reg = <0x0>;
 		spi-max-frequency = <100000>;

--- a/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_cpu0.overlay
+++ b/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_cpu0.overlay
@@ -14,7 +14,7 @@
 		   <&gpio1 12 GPIO_ACTIVE_LOW>,
 		   <&gpio1 26 GPIO_ACTIVE_LOW>;
 
-    /* LPCXpresso55xxx boards all use SSEL1. */
+	/* LPCXpresso55xxx boards all use SSEL1. */
 	eth_click_mikroe_eth_click: eth_click@1 {
 		compatible = "microchip,enc28j60";
 		reg = <0x1>;

--- a/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_cpu0.overlay
+++ b/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_cpu0.overlay
@@ -15,7 +15,7 @@
 		   <&gpio1 26 GPIO_ACTIVE_LOW>;
 
     /* LPCXpresso55xxx boards all use SSEL1. */
-	eth_click: eth_click@1 {
+	eth_click_mikroe_eth_click: eth_click@1 {
 		compatible = "microchip,enc28j60";
 		reg = <0x1>;
 		local-mac-address = [00 00 00 01 02 03];

--- a/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_ns.overlay
+++ b/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_ns.overlay
@@ -14,7 +14,7 @@
 		   <&gpio1 12 GPIO_ACTIVE_LOW>,
 		   <&gpio1 26 GPIO_ACTIVE_LOW>;
 
-    /* LPCXpresso55xxx boards all use SSEL1. */
+	/* LPCXpresso55xxx boards all use SSEL1. */
 	eth_click_mikroe_eth_click: eth_click@1 {
 		compatible = "microchip,enc28j60";
 		reg = <0x1>;

--- a/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_ns.overlay
+++ b/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_ns.overlay
@@ -15,7 +15,7 @@
 		   <&gpio1 26 GPIO_ACTIVE_LOW>;
 
     /* LPCXpresso55xxx boards all use SSEL1. */
-	eth_click: eth_click@1 {
+	eth_click_mikroe_eth_click: eth_click@1 {
 		compatible = "microchip,enc28j60";
 		reg = <0x1>;
 		local-mac-address = [00 00 00 01 02 03];

--- a/boards/shields/mikroe_eth_click/mikroe_eth_click.overlay
+++ b/boards/shields/mikroe_eth_click/mikroe_eth_click.overlay
@@ -5,7 +5,7 @@
 &mikrobus_spi {
 	status = "okay";
 
-	eth_click: eth_click@0 {
+	eth_click_mikroe_eth_click: eth_click@0 {
 		compatible = "microchip,enc28j60";
 		reg = <0x0>;
 		local-mac-address = [00 00 00 01 02 03];

--- a/boards/shields/semtech_sx1272mb2das/semtech_sx1272mb2das.overlay
+++ b/boards/shields/semtech_sx1272mb2das/semtech_sx1272mb2das.overlay
@@ -6,7 +6,7 @@
 
 / {
 	aliases {
-		lora0 = &lora;
+		lora0 = &lora_semtech_sx1272mb2das;
 	};
 };
 
@@ -15,7 +15,7 @@
 
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
-	lora: lora@0 {
+	lora_semtech_sx1272mb2das: lora@0 {
 		compatible = "semtech,sx1272";
 		reg = <0x0>;
 		spi-max-frequency = <3000000>;

--- a/boards/shields/ssd1306/sh1106_128x64.overlay
+++ b/boards/shields/ssd1306/sh1106_128x64.overlay
@@ -6,14 +6,14 @@
 
 / {
 	chosen {
-		zephyr,display = &sh1106;
+		zephyr,display = &sh1106_sh1106_128x64;
 	};
 };
 
 &arduino_i2c {
 	status = "okay";
 
-	sh1106: ssd1306@3c {
+	sh1106_sh1106_128x64: ssd1306@3c {
 		compatible = "solomon,ssd1306fb";
 		reg = <0x3c>;
 		width = <128>;

--- a/boards/shields/ssd1306/ssd1306_128x32.overlay
+++ b/boards/shields/ssd1306/ssd1306_128x32.overlay
@@ -6,14 +6,14 @@
 
 / {
 	chosen {
-		zephyr,display = &ssd1306;
+		zephyr,display = &ssd1306_ssd1306_128x32;
 	};
 };
 
 &arduino_i2c {
 	status = "okay";
 
-	ssd1306: ssd1306@3c {
+	ssd1306_ssd1306_128x32: ssd1306@3c {
 		compatible = "solomon,ssd1306fb";
 		reg = <0x3c>;
 		width = <128>;

--- a/boards/shields/ssd1306/ssd1306_128x64.overlay
+++ b/boards/shields/ssd1306/ssd1306_128x64.overlay
@@ -6,14 +6,14 @@
 
 / {
 	chosen {
-		zephyr,display = &ssd1306;
+		zephyr,display = &ssd1306_ssd1306_128x64;
 	};
 };
 
 &arduino_i2c {
 	status = "okay";
 
-	ssd1306: ssd1306@3c {
+	ssd1306_ssd1306_128x64: ssd1306@3c {
 		compatible = "solomon,ssd1306fb";
 		reg = <0x3c>;
 		width = <128>;

--- a/boards/shields/ssd1306/ssd1306_128x64_spi.overlay
+++ b/boards/shields/ssd1306/ssd1306_128x64_spi.overlay
@@ -6,14 +6,14 @@
 
 / {
 	chosen {
-		zephyr,display = &ssd1306;
+		zephyr,display = &ssd1306_ssd1306_128x64_spi;
 	};
 };
 
 &arduino_spi {
 	status = "okay";
 
-	ssd1306: ssd1306@0 {
+	ssd1306_ssd1306_128x64_spi: ssd1306@0 {
 		compatible = "solomon,ssd1306fb";
 		reg = <0x0>;
 		spi-max-frequency = <10000000>;

--- a/boards/shields/st7735r/st7735r_ada_160x128.overlay
+++ b/boards/shields/st7735r/st7735r_ada_160x128.overlay
@@ -6,7 +6,7 @@
 
 / {
 	chosen {
-		zephyr,display = &st7735r;
+		zephyr,display = &st7735r_st7735r_ada_160x128;
 	};
 };
 
@@ -14,7 +14,7 @@
 	status = "okay";
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
-	st7735r: st7735r@0 {
+	st7735r_st7735r_ada_160x128: st7735r@0 {
 		compatible = "sitronix,st7735r";
 		spi-max-frequency = <20000000>;
 		reg = <0>;

--- a/boards/shields/st7789v_generic/st7789v_tl019fqv01.overlay
+++ b/boards/shields/st7789v_generic/st7789v_tl019fqv01.overlay
@@ -6,7 +6,7 @@
 
 / {
 	chosen {
-		zephyr,display = &st7789v;
+		zephyr,display = &st7789v_st7789v_tl019fqv01;
 	};
 };
 
@@ -14,7 +14,7 @@
 	status = "okay";
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
-	st7789v: st7789v@0 {
+	st7789v_st7789v_tl019fqv01: st7789v@0 {
 		compatible = "sitronix,st7789v";
 		spi-max-frequency = <20000000>;
 		reg = <0>;

--- a/boards/shields/st7789v_generic/st7789v_waveshare_240x240.overlay
+++ b/boards/shields/st7789v_generic/st7789v_waveshare_240x240.overlay
@@ -7,7 +7,7 @@
 
 / {
 	chosen {
-		zephyr,display = &st7789v;
+		zephyr,display = &st7789v_st7789v_waveshare_240x240;
 	};
 };
 
@@ -15,7 +15,7 @@
 	status = "okay";
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
 
-	st7789v: st7789v@0 {
+	st7789v_st7789v_waveshare_240x240: st7789v@0 {
 		compatible = "sitronix,st7789v";
 		spi-max-frequency = <20000000>;
 		reg = <0>;

--- a/boards/shields/v2c_daplink/v2c_daplink.overlay
+++ b/boards/shields/v2c_daplink/v2c_daplink.overlay
@@ -23,7 +23,7 @@
 &daplink_quad_spi0 {
 	status = "okay";
 
-	daplink_flash0: flash@0 {
+	daplink_flash0_v2c_daplink: flash@0 {
 		compatible = "spansion,s25fl128s", "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <80000000>;
@@ -35,7 +35,7 @@
 &daplink_single_spi0 {
 	status = "okay";
 
-	sdhc0: sdhc@0 {
+	sdhc0_v2c_daplink: sdhc@0 {
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <0>;
 		spi-max-frequency = <25000000>;

--- a/boards/shields/v2c_daplink/v2c_daplink_cfg.overlay
+++ b/boards/shields/v2c_daplink/v2c_daplink_cfg.overlay
@@ -8,16 +8,16 @@
 
 / {
 	chosen {
-		zephyr,flash = &daplink_flash0;
+		zephyr,flash = &daplink_flash0_v2c_daplink_cfg;
 	};
 
 	soc {
-		daplink_flash0: flash@0 {
+		daplink_flash0_v2c_daplink_cfg: flash@0 {
 			compatible = "soc-nv-flash";
 			reg = <0x00000000 DT_SIZE_M(1)>;
 		};
 
-		itcm: memory@10000000 {
+		itcm_v2c_daplink_cfg: memory@10000000 {
 			compatible = "arm,itcm";
 			reg = <0x10000000 DT_SIZE_K(64)>;
 		};
@@ -27,7 +27,7 @@
 &daplink_single_spi0 {
 	status = "okay";
 
-	sdhc0: sdhc@0 {
+	sdhc0_v2c_daplink_cfg: sdhc@0 {
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <0>;
 		spi-max-frequency = <25000000>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0154a07.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0154a07.overlay
@@ -8,12 +8,12 @@
 
 / {
 	chosen {
-		zephyr,display = &ssd16xx;
+		zephyr,display = &ssd16xx_waveshare_epaper_gdeh0154a07;
 	};
 };
 
 &arduino_spi {
-	ssd16xx: ssd16xxfb@0 {
+	ssd16xx_waveshare_epaper_gdeh0154a07: ssd16xxfb@0 {
 		compatible = "gooddisplay,gdeh0154a07", "solomon,ssd1681", "solomon,ssd16xxfb";
 		spi-max-frequency = <4000000>;
 		reg = <0>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
@@ -8,12 +8,12 @@
 
 / {
 	chosen {
-		zephyr,display = &ssd16xx;
+		zephyr,display = &ssd16xx_waveshare_epaper_gdeh0213b1;
 	};
 };
 
 &arduino_spi {
-	ssd16xx: ssd16xxfb@0 {
+	ssd16xx_waveshare_epaper_gdeh0213b1: ssd16xxfb@0 {
 		compatible = "gooddisplay,gdeh0213b1", "solomon,ssd1673", "solomon,ssd16xxfb";
 		spi-max-frequency = <4000000>;
 		reg = <0>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
@@ -8,12 +8,12 @@
 
 / {
 	chosen {
-		zephyr,display = &ssd16xx;
+		zephyr,display = &ssd16xx_waveshare_epaper_gdeh0213b72;
 	};
 };
 
 &arduino_spi {
-	ssd16xx: ssd16xxfb@0 {
+	ssd16xx_waveshare_epaper_gdeh0213b72: ssd16xxfb@0 {
 		compatible = "gooddisplay,gdeh0213b72", "solomon,ssd1675a", "solomon,ssd16xxfb";
 		spi-max-frequency = <4000000>;
 		reg = <0>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
@@ -8,12 +8,12 @@
 
 / {
 	chosen {
-		zephyr,display = &ssd16xx;
+		zephyr,display = &ssd16xx_waveshare_epaper_gdeh029a1;
 	};
 };
 
 &arduino_spi {
-	ssd16xx: ssd16xxfb@0 {
+	ssd16xx_waveshare_epaper_gdeh029a1: ssd16xxfb@0 {
 		compatible = "gooddisplay,gdeh029a1", "solomon,ssd1608", "solomon,ssd16xxfb";
 		spi-max-frequency = <4000000>;
 		reg = <0>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2-p.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2-p.overlay
@@ -8,7 +8,7 @@
 
 / {
 	chosen {
-		zephyr,display = &uc8176;
+		zephyr,display = &uc8176_waveshare_epaper_gdew042t2-p;
 	};
 };
 
@@ -17,7 +17,7 @@
 	 * GoodDisplay GDEW042T2 with fast partial refresh. Based on
 	 * configuration from GoodDisplay's Arduino example.
 	 */
-	uc8176: uc8176@0 {
+	uc8176_waveshare_epaper_gdew042t2-p: uc8176@0 {
 		compatible = "gooddisplay,gdew042t2", "ultrachip,uc8176";
 		spi-max-frequency = <4000000>;
 		reg = <0>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2.overlay
@@ -7,12 +7,12 @@
 
 / {
 	chosen {
-		zephyr,display = &uc8176;
+		zephyr,display = &uc8176_waveshare_epaper_gdew042t2;
 	};
 };
 
 &arduino_spi {
-	uc8176: uc8176@0 {
+	uc8176_waveshare_epaper_gdew042t2: uc8176@0 {
 		compatible = "gooddisplay,gdew042t2", "ultrachip,uc8176";
 		spi-max-frequency = <4000000>;
 		reg = <0>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
@@ -8,12 +8,12 @@
 
 / {
 	chosen {
-		zephyr,display = &uc8179;
+		zephyr,display = &uc8179_waveshare_epaper_gdew075t7;
 	};
 };
 
 &arduino_spi {
-	uc8179: uc8179@0 {
+	uc8179_waveshare_epaper_gdew075t7: uc8179@0 {
 		compatible = "gooddisplay,gdew075t7", "ultrachip,uc8179";
 		spi-max-frequency = <4000000>;
 		reg = <0>;

--- a/boards/shields/x_nucleo_53l0a1/x_nucleo_53l0a1.overlay
+++ b/boards/shields/x_nucleo_53l0a1/x_nucleo_53l0a1.overlay
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 &arduino_i2c {
-	expander1: stmpe1600@42 {
+	expander1_x_nucleo_53l0a1: stmpe1600@42 {
 		compatible = "st,stmpe1600";
 		reg = <0x42>;
 		ngpios = <16>;
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
-	expander2: stmpe1600@43 {
+	expander2_x_nucleo_53l0a1: stmpe1600@43 {
 		compatible = "st,stmpe1600";
 		reg = <0x43>;
 		ngpios = <16>;
@@ -20,19 +20,19 @@
 	};
 
 	/* Center sensor soldered on the shield */
-	vl53l0x_c: vl53l0x@30 {
+	vl53l0x_c_x_nucleo_53l0a1: vl53l0x@30 {
 		compatible = "st,vl53l0x";
 		reg = <0x30>;
 		xshut-gpios = <&expander1 15 0>;
 	};
 
 	/* Satellites optional sensors */
-	vl53l0x_l: vl53l0x@31 {
+	vl53l0x_l_x_nucleo_53l0a1: vl53l0x@31 {
 		compatible = "st,vl53l0x";
 		reg = <0x31>;
 		xshut-gpios = <&expander2 14 0>;
 	};
-	vl53l0x_r: vl53l0x@32 {
+	vl53l0x_r_x_nucleo_53l0a1: vl53l0x@32 {
 		compatible = "st,vl53l0x";
 		reg = <0x32>;
 		xshut-gpios = <&expander2 15 0>;

--- a/boards/shields/x_nucleo_eeprma2/x_nucleo_eeprma2.overlay
+++ b/boards/shields/x_nucleo_eeprma2/x_nucleo_eeprma2.overlay
@@ -9,8 +9,8 @@
 
 / {
 	aliases {
-		eeprom-0 = &eeprom0;
-		eeprom-1 = &eeprom4;
+		eeprom-0 = &eeprom0_x_nucleo_eeprma2;
+		eeprom-1 = &eeprom4_x_nucleo_eeprma2;
 	};
 };
 
@@ -18,7 +18,7 @@
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
-	eeprom0: eeprom@54 {
+	eeprom0_x_nucleo_eeprma2: eeprom@54 {
 		/* M24C02-FMC6TG aka U1 (2 kbit eeprom in DFN8 package) */
 		compatible = "st,m24xxx", "atmel,at24";
 		reg = <0x54>;
@@ -31,7 +31,7 @@
 		/* wp-gpios = <&arduino_header 1 GPIO_ACTIVE_LOW>; */
 	};
 
-	eeprom1: eeprom@55 {
+	eeprom1_x_nucleo_eeprma2: eeprom@55 {
 		/* M24256-DFDW6TP aka U2 (256 kbit eeprom in TSSOP package) */
 		compatible = "st,m24xxx", "atmel,at24";
 		reg = <0x55>;
@@ -44,7 +44,7 @@
 		/* wp-gpios = <&arduino_header 1 GPIO_ACTIVE_LOW>; */
 	};
 
-	eeprom2: eeprom@56 {
+	eeprom2_x_nucleo_eeprma2: eeprom@56 {
 		/* M24M01-DFMN6TP aka U3 (1 Mbit eeprom in SO8N package) */
 		compatible = "st,m24xxx", "atmel,at24";
 		reg = <0x56>;
@@ -80,7 +80,7 @@
 	 * via an open solder bridge.
 	 */
 
-	eeprom4: eeprom_m95040@0 {
+	eeprom4_x_nucleo_eeprma2: eeprom_m95040@0 {
 		/* M95040-RMC6TG aka U5 (4 kbit eeprom in DFN8 package) */
 		compatible = "st,m95xxx", "atmel,at25";
 		reg = <0x00>;
@@ -94,7 +94,7 @@
 		/* wp-gpios = <&arduino_header 0 GPIO_ACTIVE_LOW>; */
 	};
 
-	eeprom5: eeprom_m95256@1 {
+	eeprom5_x_nucleo_eeprma2: eeprom_m95256@1 {
 		/* M95256-DFDW6TP aka U6 (256 kbit eeprom in TSSOP package) */
 		compatible = "st,m95xxx", "atmel,at25";
 		reg = <0x01>;
@@ -108,7 +108,7 @@
 		/* wp-gpios = <&arduino_header 0 GPIO_ACTIVE_LOW>; */
 	};
 
-	eeprom6: eeprom_m95m04@2 {
+	eeprom6_x_nucleo_eeprma2: eeprom_m95m04@2 {
 		/* M95M04-DRMN6TP aka U7 (4 Mbit eeprom in SON8 package) */
 		compatible = "st,m95xxx", "atmel,at25";
 		reg = <0x02>;

--- a/boards/shields/x_nucleo_idb05a1/boards/stm32mp157c_dk2.overlay
+++ b/boards/shields/x_nucleo_idb05a1/boards/stm32mp157c_dk2.overlay
@@ -5,7 +5,7 @@
  */
 
 &arduino_spi {
-	spbtle-rf@0 {
+	spbtle-rf_x_nucleo_idb05a1: spbtle-rf@0 {
 		cs-gpios = <&arduino_header 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;	      /* D10 */
 		irq-gpios = <&arduino_header 15 0>;	 /* D9 */
 	};

--- a/boards/shields/x_nucleo_idb05a1/x_nucleo_idb05a1.overlay
+++ b/boards/shields/x_nucleo_idb05a1/x_nucleo_idb05a1.overlay
@@ -7,7 +7,7 @@
 &arduino_spi {
 	cs-gpios = <&arduino_header 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;	      /* A1 */
 
-	spbtle-rf@0 {
+	spbtle-rf_x_nucleo_idb05a1: spbtle-rf@0 {
 		compatible = "zephyr,bt-hci-spi";
 		reg = <0>;
 		reset-gpios = <&arduino_header 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>; /* D7 */

--- a/boards/shields/x_nucleo_iks01a1/x_nucleo_iks01a1.overlay
+++ b/boards/shields/x_nucleo_iks01a1/x_nucleo_iks01a1.overlay
@@ -7,23 +7,23 @@
 
 &arduino_i2c {
 
-	hts221@5f {
+	hts221_x_nucleo_iks01a1: hts221@5f {
 		compatible = "st,hts221";
 		reg = <0x5f>;
 	};
 
-	lps25hb-press@5d {
+	lps25hb-press_x_nucleo_iks01a1: lps25hb-press@5d {
 		compatible = "st,lps25hb-press";
 		reg = <0x5d>;
 	};
 
-	lis3mdl-magn@1e {
+	lis3mdl-magn_x_nucleo_iks01a1: lis3mdl-magn@1e {
 		compatible = "st,lis3mdl-magn";
 		reg = <0x1e>;
 		irq-gpios = <&arduino_header 5 GPIO_ACTIVE_HIGH>; /* DRDY on A5 */
 	};
 
-	lsm6ds0@6b {
+	lsm6ds0_x_nucleo_iks01a1: lsm6ds0@6b {
 		compatible = "st,lsm6ds0";
 		reg = <0x6b>;
 	};

--- a/boards/shields/x_nucleo_iks01a2/boards/stm32mp157c_dk2.overlay
+++ b/boards/shields/x_nucleo_iks01a2/boards/stm32mp157c_dk2.overlay
@@ -10,11 +10,11 @@
  */
 
 &arduino_i2c {
-	lsm303agr-magn@1e {
+	lsm303agr-magn_x_nucleo_iks01a2: lsm303agr-magn@1e {
 		/delete-property/ irq-gpios;	/* A3 */
 	};
 
-	lsm303agr-accel@19 {
+	lsm303agr-accel_x_nucleo_iks01a2: lsm303agr-accel@19 {
 		/delete-property/ irq-gpios;	/* A3 */
 	};
 };

--- a/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
+++ b/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
@@ -7,37 +7,37 @@
 
 / {
 	aliases {
-		magn0 = &lsm303agr_magn_1e;
-		accel0 = &lsm303agr_accel_19;
-		accel1 = &lsm6dsl_6b;
+		magn0 = &lsm303agr_magn_1e_x_nucleo_iks01a2;
+		accel0 = &lsm303agr_accel_19_x_nucleo_iks01a2;
+		accel1 = &lsm6dsl_6b_x_nucleo_iks01a2;
 	};
 };
 
 &arduino_i2c {
 
-	hts221@5f {
+	hts221_x_nucleo_iks01a2: hts221@5f {
 		compatible = "st,hts221";
 		reg = <0x5f>;
 	};
 
-	lps22hb-press@5d {
+	lps22hb-press_x_nucleo_iks01a2: lps22hb-press@5d {
 		compatible = "st,lps22hb-press";
 		reg = <0x5d>;
 	};
 
-	lsm6dsl_6b: lsm6dsl@6b {
+	lsm6dsl_6b_x_nucleo_iks01a2: lsm6dsl@6b {
 		compatible = "st,lsm6dsl";
 		reg = <0x6b>;
 		irq-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;	/* D4 */
 	};
 
-	lsm303agr_magn_1e: lsm303agr-magn@1e {
+	lsm303agr_magn_1e_x_nucleo_iks01a2: lsm303agr-magn@1e {
 		compatible = "st,lis2mdl","st,lsm303agr-magn";
 		reg = <0x1e>;
 		irq-gpios = <&arduino_header 3 GPIO_ACTIVE_HIGH>;	/* A3 */
 	};
 
-	lsm303agr_accel_19: lsm303agr-accel@19 {
+	lsm303agr_accel_19_x_nucleo_iks01a2: lsm303agr-accel@19 {
 		compatible = "st,lis2dh", "st,lsm303agr-accel";
 		reg = <0x19>;
 		irq-gpios = <&arduino_header 3 GPIO_ACTIVE_HIGH>;	/* A3 */

--- a/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2_shub.overlay
+++ b/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2_shub.overlay
@@ -6,7 +6,7 @@
  */
 
 &arduino_i2c {
-	lsm6dsl@6b {
+	lsm6dsl_x_nucleo_iks01a2_shub: lsm6dsl@6b {
 		compatible = "st,lsm6dsl";
 		reg = <0x6b>;
 		irq-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;	/* D4 */

--- a/boards/shields/x_nucleo_iks01a3/boards/x_nucleo_iks01a3/stm32mp157c_dk2.overlay
+++ b/boards/shields/x_nucleo_iks01a3/boards/x_nucleo_iks01a3/stm32mp157c_dk2.overlay
@@ -10,15 +10,15 @@
  */
 
 &arduino_i2c {
-	lis2dw12@19 {
+	lis2dw12_x_nucleo_iks01a3: lis2dw12@19 {
 		/delete-property/ irq-gpios;	/* A3 */
 	};
 
-	lis2mdl@1e {
+	lis2mdl_x_nucleo_iks01a3: lis2mdl@1e {
 		/delete-property/ irq-gpios;    /* A3 */
 	};
 
-	lsm6dso@6b {
+	lsm6dso_x_nucleo_iks01a3: lsm6dso@6b {
 		/delete-property/ irq-gpios;    /* A3 */
 	};
 };

--- a/boards/shields/x_nucleo_iks01a3/boards/x_nucleo_iks01a3_shub/stm32mp157c_dk2.overlay
+++ b/boards/shields/x_nucleo_iks01a3/boards/x_nucleo_iks01a3_shub/stm32mp157c_dk2.overlay
@@ -10,11 +10,11 @@
  */
 
 &arduino_i2c {
-	lis2dw12@19 {
+	lis2dw12_x_nucleo_iks01a3: lis2dw12@19 {
 		/delete-property/ irq-gpios;	/* A3 */
 	};
 
-	lsm6dso@6b {
+	lsm6dso_x_nucleo_iks01a3: lsm6dso@6b {
 		/delete-property/ irq-gpios;    /* A3 */
 	};
 };

--- a/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3.overlay
+++ b/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3.overlay
@@ -6,44 +6,44 @@
 
 / {
 	aliases {
-		magn0 = &lis2mdl_1e;
-		accel0 = &lis2dw12_19;
-		accel1 = &lsm6dso_6b;
+		magn0 = &lis2mdl_1e_x_nucleo_iks01a3;
+		accel0 = &lis2dw12_19_x_nucleo_iks01a3;
+		accel1 = &lsm6dso_6b_x_nucleo_iks01a3;
 	};
 };
 
 &arduino_i2c {
 
-	hts221@5f {
+	hts221_x_nucleo_iks01a3: hts221@5f {
 		compatible = "st,hts221";
 		reg = <0x5f>;
 	};
 
-	lps22hh@5d {
+	lps22hh_x_nucleo_iks01a3: lps22hh@5d {
 		compatible = "st,lps22hh";
 		reg = <0x5d>;
 		drdy-gpios =  <&arduino_header 12 GPIO_ACTIVE_HIGH>; /* D6 */
 	};
 
-	stts751@4a {
+	stts751_x_nucleo_iks01a3: stts751@4a {
 		compatible = "st,stts751";
 		reg = <0x4a>;
 		drdy-gpios =  <&arduino_header 4 GPIO_ACTIVE_LOW>; /* A4 */
 	};
 
-	lis2mdl_1e: lis2mdl@1e {
+	lis2mdl_1e_x_nucleo_iks01a3: lis2mdl@1e {
 		compatible = "st,lis2mdl";
 		reg = <0x1e>;
 		irq-gpios =  <&arduino_header 2 GPIO_ACTIVE_HIGH>; /* A2 */
 	};
 
-	lis2dw12_19: lis2dw12@19 {
+	lis2dw12_19_x_nucleo_iks01a3: lis2dw12@19 {
 		compatible = "st,lis2dw12";
 		reg = <0x19>;
 		irq-gpios =  <&arduino_header 3 GPIO_ACTIVE_HIGH>; /* A3 */
 	};
 
-	lsm6dso_6b: lsm6dso@6b {
+	lsm6dso_6b_x_nucleo_iks01a3: lsm6dso@6b {
 		compatible = "st,lsm6dso";
 		reg = <0x6b>;
 		irq-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 */

--- a/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3_shub.overlay
+++ b/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3_shub.overlay
@@ -6,20 +6,20 @@
 
 / {
 	aliases {
-		accel0 = &lis2dw12_19;
-		accel1 = &lsm6dso_6b;
+		accel0 = &lis2dw12_19_x_nucleo_iks01a3_shub;
+		accel1 = &lsm6dso_6b_x_nucleo_iks01a3_shub;
 	};
 };
 
 &arduino_i2c {
 
-	lis2dw12_19: lis2dw12@19 {
+	lis2dw12_19_x_nucleo_iks01a3_shub: lis2dw12@19 {
 		compatible = "st,lis2dw12";
 		reg = <0x19>;
 		irq-gpios =  <&arduino_header 3 GPIO_ACTIVE_HIGH>; /* A3 */
 	};
 
-	lsm6dso_6b: lsm6dso@6b {
+	lsm6dso_6b_x_nucleo_iks01a3_shub: lsm6dso@6b {
 		compatible = "st,lsm6dso";
 		reg = <0x6b>;
 		irq-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 */

--- a/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1.overlay
+++ b/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1.overlay
@@ -15,27 +15,27 @@
 
 / {
 	aliases {
-		accel0 = &iis2dlpc_19;
-		accel1 = &ism330dhcx_6b;
+		accel0 = &iis2dlpc_19_x_nucleo_iks02a1;
+		accel1 = &ism330dhcx_6b_x_nucleo_iks02a1;
 	};
 };
 
 &arduino_i2c {
 
-	iis2dlpc_19: iis2dlpc@19 {
+	iis2dlpc_19_x_nucleo_iks02a1: iis2dlpc@19 {
 		compatible = "st,iis2dlpc";
 		reg = <0x19>;
 		drdy-gpios =  <&arduino_header 4 GPIO_ACTIVE_HIGH>; /* A4 - INT2 */
 		drdy-int =  <2>;
 	};
 
-	iis2mdc@1e {
+	iis2mdc_x_nucleo_iks02a1: iis2mdc@1e {
 		compatible = "st,iis2mdc";
 		reg = <0x1e>;
 		drdy-gpios =  <&arduino_header 2 GPIO_ACTIVE_HIGH>; /* A2 */
 	};
 
-	ism330dhcx_6b: ism330dhcx@6b {
+	ism330dhcx_6b_x_nucleo_iks02a1: ism330dhcx@6b {
 		compatible = "st,ism330dhcx";
 		reg = <0x6b>;
 		drdy-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 - INT2 */

--- a/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1_mic.overlay
+++ b/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1_mic.overlay
@@ -7,7 +7,7 @@
 &arduino_i2s {
 	status = "okay";
 
-	mp34dt05@0 {
+	mp34dt05_x_nucleo_iks02a1_mic: mp34dt05@0 {
 		compatible = "st,mpxxdtyy";
 		reg = <0>;
 	};

--- a/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1_shub.overlay
+++ b/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1_shub.overlay
@@ -17,21 +17,21 @@
 
 / {
 	aliases {
-		accel0 = &iis2dlpc_19;
-		accel1 = &ism330dhcx_6b;
+		accel0 = &iis2dlpc_19_x_nucleo_iks02a1_shub;
+		accel1 = &ism330dhcx_6b_x_nucleo_iks02a1_shub;
 	};
 };
 
 &arduino_i2c {
 
-	iis2dlpc_19: iis2dlpc@19 {
+	iis2dlpc_19_x_nucleo_iks02a1_shub: iis2dlpc@19 {
 		compatible = "st,iis2dlpc";
 		reg = <0x19>;
 		drdy-gpios =  <&arduino_header 4 GPIO_ACTIVE_HIGH>; /* A4 - INT2 */
 		drdy-int =  <2>;
 	};
 
-	ism330dhcx_6b: ism330dhcx@6b {
+	ism330dhcx_6b_x_nucleo_iks02a1_shub: ism330dhcx@6b {
 		compatible = "st,ism330dhcx";
 		reg = <0x6b>;
 		drdy-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 - INT2 */

--- a/doc/hardware/porting/shields.rst
+++ b/doc/hardware/porting/shields.rst
@@ -50,23 +50,12 @@ This should be done at two different level:
 * Pinmux: Connector pins should be correctly configured to match shield pins
 
 * Devicetree: A board :ref:`devicetree <dt-guide>` file,
-  :file:`BOARD.dts` should define a node alias for each connector interface.
+  :file:`BOARD.dts` should define an alternate nodelabel for each connector interface.
   For example, for Arduino I2C:
 
 .. code-block:: devicetree
 
-        #define arduino_i2c i2c1
-
-        aliases {
-                arduino,i2c = &i2c1;
-        };
-
-Note: With support of dtc v1.4.2, above will be replaced with the recently
-introduced overriding node element:
-
-.. code-block:: devicetree
-
-        arduino_i2c:i2c1{};
+        arduino_i2c: &i2c1 {};
 
 Board specific shield configuration
 -----------------------------------

--- a/doc/hardware/porting/shields.rst
+++ b/doc/hardware/porting/shields.rst
@@ -37,6 +37,18 @@ These files provides shield configuration as follows:
   shield configuration should be done by keeping in mind that features
   activation is application responsibility.
 
+Besides, in order to avoid name conflicts with devices that may be defined at
+board level, it is advised, specifically for shields devicetree descriptions,
+to provide a device nodelabel is the form <device>_<shield>, for instance:
+
+.. code-block:: devicetree
+
+        sdhc_myshield: sdhc@1 {
+                reg = <1>;
+                ...
+        };
+
+
 Board compatibility
 *******************
 


### PR DESCRIPTION
See https://github.com/zephyrproject-rtos/zephyr/issues/50040

Note: We end up with quite non nice labels like:
- `dac80508_dac80508_evm`
- `uc8176_waveshare_epaper_gdew042t2`
- `lsm303agr-magn_x_nucleo_iks01a2`

I wonder if `<shield_name>_<device>` instead of `<device>_<shield_name>` wouldn't be a better option. Toughs ?