### PR TITLE
doc: release-notes: Add C library release notes for 3.2

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -529,6 +529,18 @@ Libraries / Subsystems
 
 * C Library
 
+  * Added Picolibc as a Zephyr module. Picolibc module is a footprint-optimized
+    full C standard library implementation that is configurable at the build
+    time.
+  * C library heap initialization call has been moved from the ``APPLICATION``
+    phase to the ``POST_KERNEL`` phase to allow calling the libc dynamic memory
+    management functions (e.g. ``malloc()``) during the application
+    initialization phase.
+  * Added ``strerror()`` and ``strerror_r()`` functions to the minimal libc.
+  * Removed architecture-specific ``off_t`` type definition in the minimal
+    libc. ``off_t`` is now defined as ``intptr_t`` regardless of the selected
+    architecture.
+
 * C++ Subsystem
 
 * Emul


### PR DESCRIPTION
This commit adds the C library release notes for the Zephyr 3.2 release.

Signed-off-by: Stephanos Ioannidis <stephanos.ioannidis@nordicsemi.no>