### PR TITLE
samples: net: lwm2m_client: Split sensor modules out from main

### DIFF
--- a/samples/net/lwm2m_client/src/firmware_update.c
+++ b/samples/net/lwm2m_client/src/firmware_update.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define LOG_MODULE_NAME app_fw_update
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+#include <zephyr/net/lwm2m.h>
+#include "modules.h"
+
+static uint8_t firmware_buf[64];
+
+/* Array with supported PULL firmware update protocols */
+static uint8_t supported_protocol[1];
+
+static int firmware_update_cb(uint16_t obj_inst_id,
+			      uint8_t *args, uint16_t args_len)
+{
+	LOG_DBG("UPDATE");
+
+	/* TODO: kick off update process */
+
+	/* If success, set the update result as RESULT_SUCCESS.
+	 * In reality, it should be set at function lwm2m_setup()
+	 */
+	lwm2m_engine_set_u8("5/0/3", STATE_IDLE);
+	lwm2m_engine_set_u8("5/0/5", RESULT_SUCCESS);
+	return 0;
+}
+
+static void *firmware_get_buf(uint16_t obj_inst_id, uint16_t res_id,
+			      uint16_t res_inst_id, size_t *data_len)
+{
+	*data_len = sizeof(firmware_buf);
+	return firmware_buf;
+}
+
+static int firmware_block_received_cb(uint16_t obj_inst_id,
+				      uint16_t res_id, uint16_t res_inst_id,
+				      uint8_t *data, uint16_t data_len,
+				      bool last_block, size_t total_size)
+{
+	LOG_INF("FIRMWARE: BLOCK RECEIVED: len:%u last_block:%d",
+		data_len, last_block);
+	return 0;
+}
+
+void init_firmware_update(void)
+{
+	/* setup data buffer for block-wise transfer */
+	lwm2m_engine_register_pre_write_callback("5/0/0", firmware_get_buf);
+	lwm2m_firmware_set_write_cb(firmware_block_received_cb);
+
+	if (IS_ENABLED(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT)) {
+		lwm2m_engine_create_res_inst("5/0/8/0");
+		lwm2m_engine_set_res_buf("5/0/8/0", &supported_protocol[0],
+					 sizeof(supported_protocol[0]),
+					 sizeof(supported_protocol[0]), 0);
+
+		lwm2m_firmware_set_update_cb(firmware_update_cb);
+	}
+}

--- a/samples/net/lwm2m_client/src/led.c
+++ b/samples/net/lwm2m_client/src/led.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define LOG_MODULE_NAME app_led
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+#include "modules.h"
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/net/lwm2m.h>
+
+#define LIGHT_NAME "Test light"
+
+/* If led0 gpios doesn't exist the relevant IPSO object will simply not be created. */
+static const struct gpio_dt_spec led_gpio = GPIO_DT_SPEC_GET_OR(DT_ALIAS(led0), gpios, {});
+static uint32_t led_state;
+
+/* TODO: Move to a pre write hook that can handle ret codes once available */
+static int led_on_off_cb(uint16_t obj_inst_id, uint16_t res_id, uint16_t res_inst_id, uint8_t *data,
+			 uint16_t data_len, bool last_block, size_t total_size)
+{
+	int ret = 0;
+	uint32_t led_val;
+
+	led_val = *(uint8_t *)data;
+	if (led_val != led_state) {
+		ret = gpio_pin_set_dt(&led_gpio, (int)led_val);
+		if (ret) {
+			/*
+			 * We need an extra hook in LWM2M to better handle
+			 * failures before writing the data value and not in
+			 * post_write_cb, as there is not much that can be
+			 * done here.
+			 */
+			LOG_ERR("Fail to write to GPIO %d", led_gpio.pin);
+			return ret;
+		}
+
+		led_state = led_val;
+		/* TODO: Move to be set by an internal post write function */
+		lwm2m_engine_set_s32("3311/0/5852", 0);
+	}
+
+	return ret;
+}
+
+int init_led_device(void)
+{
+	int ret;
+
+	if (!device_is_ready(led_gpio.port)) {
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(&led_gpio, GPIO_OUTPUT_INACTIVE);
+	if (ret) {
+		return ret;
+	}
+
+	lwm2m_engine_create_obj_inst("3311/0");
+	lwm2m_engine_register_post_write_callback("3311/0/5850", led_on_off_cb);
+	lwm2m_engine_set_res_buf("3311/0/5750", LIGHT_NAME, sizeof(LIGHT_NAME), sizeof(LIGHT_NAME),
+				 LWM2M_RES_DATA_FLAG_RO);
+
+	return 0;
+}

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/net/lwm2m.h>
+#include "modules.h"
 
 #define APP_BANNER "Run LWM2M client"
 
@@ -46,13 +47,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define CLIENT_DEVICE_TYPE	"OMA-LWM2M Client"
 #define CLIENT_HW_VER		"1.0.1"
 
-#define LIGHT_NAME		"Test light"
-#define TIMER_NAME		"Test timer"
-
 #define ENDPOINT_LEN		32
-
-/* If led0 gpios doesn't exist the relevant IPSO object will simply not be created. */
-static const struct gpio_dt_spec led_gpio = GPIO_DT_SPEC_GET_OR(DT_ALIAS(led0), gpios, {});
 
 static uint8_t bat_idx = LWM2M_DEVICE_PWR_SRC_TYPE_BAT_INT;
 static int bat_mv = 3800;
@@ -65,14 +60,7 @@ static uint8_t bat_status = LWM2M_DEVICE_BATTERY_STATUS_CHARGING;
 static int mem_free = 15;
 static int mem_total = 25;
 
-static uint32_t led_state;
-
 static struct lwm2m_ctx client;
-
-#if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT)
-/* Array with supported PULL firmware update protocols */
-static uint8_t supported_protocol[1];
-#endif
 
 #if defined(CONFIG_LWM2M_DTLS_SUPPORT)
 #define TLS_TAG			1
@@ -87,56 +75,6 @@ static const char client_psk_id[] = "Client_identity";
 #endif /* CONFIG_LWM2M_DTLS_SUPPORT */
 
 static struct k_sem quit_lock;
-
-#if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT)
-static uint8_t firmware_buf[64];
-#endif
-
-/* TODO: Move to a pre write hook that can handle ret codes once available */
-static int led_on_off_cb(uint16_t obj_inst_id, uint16_t res_id, uint16_t res_inst_id,
-			 uint8_t *data, uint16_t data_len,
-			 bool last_block, size_t total_size)
-{
-	int ret = 0;
-	uint32_t led_val;
-
-	led_val = *(uint8_t *) data;
-	if (led_val != led_state) {
-		ret = gpio_pin_set_dt(&led_gpio, (int) led_val);
-		if (ret) {
-			/*
-			 * We need an extra hook in LWM2M to better handle
-			 * failures before writing the data value and not in
-			 * post_write_cb, as there is not much that can be
-			 * done here.
-			 */
-			LOG_ERR("Fail to write to GPIO %d", led_gpio.pin);
-			return ret;
-		}
-
-		led_state = led_val;
-		/* TODO: Move to be set by an internal post write function */
-		lwm2m_engine_set_s32("3311/0/5852", 0);
-	}
-
-	return ret;
-}
-
-static int init_led_device(void)
-{
-	int ret;
-
-	if (!device_is_ready(led_gpio.port)) {
-		return -ENODEV;
-	}
-
-	ret = gpio_pin_configure_dt(&led_gpio, GPIO_OUTPUT_INACTIVE);
-	if (ret) {
-		return ret;
-	}
-
-	return 0;
-}
 
 static int device_reboot_cb(uint16_t obj_inst_id,
 			    uint8_t *args, uint16_t args_len)
@@ -162,114 +100,6 @@ static int device_factory_default_cb(uint16_t obj_inst_id,
 	return 0;
 }
 
-#if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT)
-static int firmware_update_cb(uint16_t obj_inst_id,
-			      uint8_t *args, uint16_t args_len)
-{
-	LOG_DBG("UPDATE");
-
-	/* TODO: kick off update process */
-
-	/* If success, set the update result as RESULT_SUCCESS.
-	 * In reality, it should be set at function lwm2m_setup()
-	 */
-	lwm2m_engine_set_u8("5/0/3", STATE_IDLE);
-	lwm2m_engine_set_u8("5/0/5", RESULT_SUCCESS);
-	return 0;
-}
-#endif
-
-
-static void *temperature_get_buf(uint16_t obj_inst_id, uint16_t res_id,
-				 uint16_t res_inst_id, size_t *data_len)
-{
-	/* Last read temperature value, will use 25.5C if no sensor available */
-	static double v = 25.5;
-	const struct device *dev = NULL;
-
-#if defined(CONFIG_FXOS8700_TEMP)
-	dev = DEVICE_DT_GET_ONE(nxp_fxos8700);
-
-	if (!device_is_ready(dev)) {
-		LOG_ERR("%s: device not ready.", dev->name);
-		return;
-	}
-#endif
-
-	if (dev != NULL) {
-		struct sensor_value val;
-
-		if (sensor_sample_fetch(dev)) {
-			LOG_ERR("temperature data update failed");
-		}
-
-		sensor_channel_get(dev, SENSOR_CHAN_DIE_TEMP, &val);
-
-		v = sensor_value_to_double(&val);
-
-		LOG_DBG("LWM2M temperature set to %f", v);
-	}
-
-	/* echo the value back through the engine to update min/max values */
-	lwm2m_engine_set_float("3303/0/5700", &v);
-	*data_len = sizeof(v);
-	return &v;
-}
-
-
-#if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT)
-static void *firmware_get_buf(uint16_t obj_inst_id, uint16_t res_id,
-			      uint16_t res_inst_id, size_t *data_len)
-{
-	*data_len = sizeof(firmware_buf);
-	return firmware_buf;
-}
-
-static int firmware_block_received_cb(uint16_t obj_inst_id,
-				      uint16_t res_id, uint16_t res_inst_id,
-				      uint8_t *data, uint16_t data_len,
-				      bool last_block, size_t total_size)
-{
-	LOG_INF("FIRMWARE: BLOCK RECEIVED: len:%u last_block:%d",
-		data_len, last_block);
-	return 0;
-}
-#endif
-
-/* An example data validation callback. */
-static int timer_on_off_validate_cb(uint16_t obj_inst_id, uint16_t res_id,
-				    uint16_t res_inst_id, uint8_t *data,
-				    uint16_t data_len, bool last_block,
-				    size_t total_size)
-{
-	LOG_INF("Validating On/Off data");
-
-	if (data_len != 1) {
-		return -EINVAL;
-	}
-
-	if (*data > 1) {
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
-static int timer_digital_state_cb(uint16_t obj_inst_id,
-				  uint16_t res_id, uint16_t res_inst_id,
-				  uint8_t *data, uint16_t data_len,
-				  bool last_block, size_t total_size)
-{
-	bool *digital_state = (bool *)data;
-
-	if (*digital_state) {
-		LOG_INF("TIMER: ON");
-	} else {
-		LOG_INF("TIMER: OFF");
-	}
-
-	return 0;
-}
 
 static int lwm2m_setup(void)
 {
@@ -374,45 +204,18 @@ static int lwm2m_setup(void)
 				 sizeof(usb_ma), 0);
 
 	/* setup FIRMWARE object */
-
-#if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT)
-	/* setup data buffer for block-wise transfer */
-	lwm2m_engine_register_pre_write_callback("5/0/0", firmware_get_buf);
-	lwm2m_firmware_set_write_cb(firmware_block_received_cb);
-#endif
-#if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT)
-	lwm2m_engine_create_res_inst("5/0/8/0");
-	lwm2m_engine_set_res_buf("5/0/8/0", &supported_protocol[0],
-				 sizeof(supported_protocol[0]),
-				 sizeof(supported_protocol[0]), 0);
-
-	lwm2m_firmware_set_update_cb(firmware_update_cb);
-#endif
-
-	/* setup TEMP SENSOR object */
-	lwm2m_engine_create_obj_inst("3303/0");
-	lwm2m_engine_register_read_callback("3303/0/5700", temperature_get_buf);
-
-	/* IPSO: Light Control object */
-	if (init_led_device() == 0) {
-		lwm2m_engine_create_obj_inst("3311/0");
-		lwm2m_engine_register_post_write_callback("3311/0/5850",
-				led_on_off_cb);
-		lwm2m_engine_set_res_buf("3311/0/5750", LIGHT_NAME,
-					 sizeof(LIGHT_NAME),
-					 sizeof(LIGHT_NAME),
-					 LWM2M_RES_DATA_FLAG_RO);
+	if (IS_ENABLED(CONFIG_LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT)) {
+		init_firmware_update();
 	}
 
+	/* setup TEMP SENSOR object */
+	init_temp_sensor();
+
+	/* IPSO: Light Control object */
+	init_led_device();
+
 	/* IPSO: Timer object */
-	lwm2m_engine_create_obj_inst("3340/0");
-	lwm2m_engine_register_validate_callback("3340/0/5850",
-			timer_on_off_validate_cb);
-	lwm2m_engine_register_post_write_callback("3340/0/5543",
-			timer_digital_state_cb);
-	lwm2m_engine_set_res_buf("3340/0/5750", TIMER_NAME,
-				 sizeof(TIMER_NAME), sizeof(TIMER_NAME),
-				 LWM2M_RES_DATA_FLAG_RO);
+	init_timer_object();
 
 	return 0;
 }

--- a/samples/net/lwm2m_client/src/modules.h
+++ b/samples/net/lwm2m_client/src/modules.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _MODULES_H
+#define _MODULES_H
+
+int init_led_device(void);
+void init_timer_object(void);
+void init_temp_sensor(void);
+void init_firmware_update(void);
+
+#endif

--- a/samples/net/lwm2m_client/src/temperature.c
+++ b/samples/net/lwm2m_client/src/temperature.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define LOG_MODULE_NAME app_temp
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+#include "modules.h"
+
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/net/lwm2m.h>
+
+static void *temperature_get_buf(uint16_t obj_inst_id, uint16_t res_id, uint16_t res_inst_id,
+				 size_t *data_len)
+{
+	/* Last read temperature value, will use 25.5C if no sensor available */
+	static double v = 25.5;
+	const struct device *dev = NULL;
+
+#if defined(CONFIG_FXOS8700_TEMP)
+	dev = DEVICE_DT_GET_ONE(nxp_fxos8700);
+
+	if (!device_is_ready(dev)) {
+		LOG_ERR("%s: device not ready.", dev->name);
+		return;
+	}
+#endif
+
+	if (dev != NULL) {
+		struct sensor_value val;
+
+		if (sensor_sample_fetch(dev)) {
+			LOG_ERR("temperature data update failed");
+		}
+
+		sensor_channel_get(dev, SENSOR_CHAN_DIE_TEMP, &val);
+
+		v = sensor_value_to_double(&val);
+
+		LOG_DBG("LWM2M temperature set to %f", v);
+	}
+
+	/* echo the value back through the engine to update min/max values */
+	lwm2m_engine_set_float("3303/0/5700", &v);
+	*data_len = sizeof(v);
+	return &v;
+}
+
+void init_temp_sensor(void)
+{
+	lwm2m_engine_create_obj_inst("3303/0");
+	lwm2m_engine_register_read_callback("3303/0/5700", temperature_get_buf);
+}

--- a/samples/net/lwm2m_client/src/timer.c
+++ b/samples/net/lwm2m_client/src/timer.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define LOG_MODULE_NAME app_timer
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+#include "modules.h"
+
+#include <zephyr/net/lwm2m.h>
+
+#define TIMER_NAME "Test timer"
+
+/* An example data validation callback. */
+static int timer_on_off_validate_cb(uint16_t obj_inst_id, uint16_t res_id, uint16_t res_inst_id,
+				    uint8_t *data, uint16_t data_len, bool last_block,
+				    size_t total_size)
+{
+	LOG_INF("Validating On/Off data");
+
+	if (data_len != 1) {
+		return -EINVAL;
+	}
+
+	if (*data > 1) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int timer_digital_state_cb(uint16_t obj_inst_id, uint16_t res_id, uint16_t res_inst_id,
+				  uint8_t *data, uint16_t data_len, bool last_block,
+				  size_t total_size)
+{
+	bool *digital_state = (bool *)data;
+
+	if (*digital_state) {
+		LOG_INF("TIMER: ON");
+	} else {
+		LOG_INF("TIMER: OFF");
+	}
+
+	return 0;
+}
+
+void init_timer_object(void)
+{
+	lwm2m_engine_create_obj_inst("3340/0");
+	lwm2m_engine_register_validate_callback("3340/0/5850", timer_on_off_validate_cb);
+	lwm2m_engine_register_post_write_callback("3340/0/5543", timer_digital_state_cb);
+	lwm2m_engine_set_res_buf("3340/0/5750", TIMER_NAME, sizeof(TIMER_NAME), sizeof(TIMER_NAME),
+				 LWM2M_RES_DATA_FLAG_RO);
+}


### PR DESCRIPTION
Each module deserves their own file so we don't clutter the main application.

Fixes #19356
