### PR TITLE
boards: posix: native_posix: enable can_loopback0 by default

### DIFF
--- a/boards/posix/native_posix/native_posix.dts
+++ b/boards/posix/native_posix/native_posix.dts
@@ -188,7 +188,7 @@
 	};
 
 	can_loopback0: can_loopback0 {
-		status = "disabled";
+		status = "okay";
 		compatible = "zephyr,can-loopback";
 		sjw = <1>;
 		sample-point = <875>;

--- a/samples/drivers/can/counter/sample.yaml
+++ b/samples/drivers/can/counter/sample.yaml
@@ -5,6 +5,7 @@ tests:
     tags: can
     depends_on: can
     filter: dt_chosen_enabled("zephyr,canbus")
+    platform_exclude: native_posix native_posix_64
     harness: console
     harness_config:
       type: one_line

--- a/samples/net/sockets/can/boards/native_posix.overlay
+++ b/samples/net/sockets/can/boards/native_posix.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2022 Vestas Wind Systems A/S
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&can_loopback0 {
-	status = "okay";
-};

--- a/samples/net/sockets/can/boards/native_posix_64.overlay
+++ b/samples/net/sockets/can/boards/native_posix_64.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2022 Vestas Wind Systems A/S
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&can_loopback0 {
-	status = "okay";
-};

--- a/tests/drivers/can/api/boards/native_posix.overlay
+++ b/tests/drivers/can/api/boards/native_posix.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2021 Vestas Wind Systems A/S
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&can_loopback0 {
-	status = "okay";
-};

--- a/tests/drivers/can/api/boards/native_posix_64.overlay
+++ b/tests/drivers/can/api/boards/native_posix_64.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2021 Vestas Wind Systems A/S
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&can_loopback0 {
-	status = "okay";
-};

--- a/tests/drivers/can/canfd/boards/native_posix.overlay
+++ b/tests/drivers/can/canfd/boards/native_posix.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2022 Vestas Wind Systems A/S
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&can_loopback0 {
-	status = "okay";
-};

--- a/tests/drivers/can/canfd/boards/native_posix_64.overlay
+++ b/tests/drivers/can/canfd/boards/native_posix_64.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2022 Vestas Wind Systems A/S
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&can_loopback0 {
-	status = "okay";
-};

--- a/tests/drivers/can/timing/boards/native_posix.overlay
+++ b/tests/drivers/can/timing/boards/native_posix.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2021 Vestas Wind Systems A/S
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&can_loopback0 {
-	status = "okay";
-};

--- a/tests/drivers/can/timing/boards/native_posix_64.overlay
+++ b/tests/drivers/can/timing/boards/native_posix_64.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2021 Vestas Wind Systems A/S
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-&can_loopback0 {
-	status = "okay";
-};

--- a/tests/subsys/canbus/isotp/conformance/testcase.yaml
+++ b/tests/subsys/canbus/isotp/conformance/testcase.yaml
@@ -3,3 +3,4 @@ tests:
     tags: can isotp
     depends_on: can
     filter: dt_chosen_enabled("zephyr,canbus")
+    platform_exclude: native_posix native_posix_64

--- a/tests/subsys/canbus/isotp/implementation/testcase.yaml
+++ b/tests/subsys/canbus/isotp/implementation/testcase.yaml
@@ -3,3 +3,4 @@ tests:
     tags: can isotp
     depends_on: can
     filter: dt_chosen_enabled("zephyr,canbus")
+    platform_exclude: native_posix native_posix_64


### PR DESCRIPTION
The .yaml file states that CAN is supported and `zephyr,canbus` is chosen in the dts, but building the basic sample application samples/drivers/can/counter fails without additional configuration.

The loopback driver does not require any additional steps like the linux SocketCAN driver, so it is safe to enable it by default and get rid of the many overlay files in the tests.