### PR TITLE
drivers: flash: soc_flash_nrf: Account for ticker in timeout

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -128,6 +128,8 @@ Drivers and Sensors
 
 * Flash
 
+  * NRF: Added CONFIG_SOC_FLASH_NRF_TIMEOUT_MULTIPLIER to allow tweaking the timeout of flash operations.
+
 * GPIO
 
 * I2C

--- a/drivers/flash/Kconfig.nrf
+++ b/drivers/flash/Kconfig.nrf
@@ -67,6 +67,17 @@ config SOC_FLASH_NRF_PARTIAL_ERASE_MS
 	  Minimal timeout is 2ms maximum should not exceed half of
 	  FLASH_PAGE_ERASE_MAX_TIME_US im ms.
 
+config SOC_FLASH_NRF_TIMEOUT_MULTIPLIER
+	int "Multiplier for flash operation timeouts [x0.1]"
+	depends on !SOC_FLASH_NRF_RADIO_SYNC_NONE
+	default 15 if SOC_FLASH_NRF_PARTIAL_ERASE && SOC_FLASH_NRF_RADIO_SYNC_TICKER
+	default 10
+	help
+	  This is a multiplier that will be divided by 10 that is applied
+	  to the flash erase and write operations timeout. The base for
+	  the multiplication would allow erasing all nRF flash pages in
+	  blocking mode.
+
 config SOC_FLASH_NRF_UICR
 	bool "Access to UICR"
 	depends on !TRUSTED_EXECUTION_NONSECURE

--- a/drivers/flash/soc_flash_nrf.h
+++ b/drivers/flash/soc_flash_nrf.h
@@ -29,17 +29,12 @@ struct flash_context {
 
 #ifndef CONFIG_SOC_FLASH_NRF_RADIO_SYNC_NONE
 
-#if defined(CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE)
-/* The timeout is multiplied by 1.5 because switching tasks may take
- * significant portion of time.
+/* The timeout is multiplied by CONFIG_SOC_FLASH_NRF_TIMEOUT_MULTIPLIER/10
+ * because switching tasks may take a significant portion of time.
  */
 #define FLASH_TIMEOUT_MS ((FLASH_PAGE_ERASE_MAX_TIME_US) * \
-			  (FLASH_PAGE_MAX_CNT) / 1000 * 15 / 10)
-#else
-
-#define FLASH_TIMEOUT_MS ((FLASH_PAGE_ERASE_MAX_TIME_US) * \
-			  (FLASH_PAGE_MAX_CNT) / 1000)
-#endif /* CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE */
+			  (FLASH_PAGE_MAX_CNT) / 1000 * \
+			  CONFIG_SOC_FLASH_NRF_TIMEOUT_MULTIPLIER / 10)
 
 /**
  * @defgroup nrf_flash_sync sync backend API


### PR DESCRIPTION
We have been encountering timeout issues when erasing large flash sections (before receiving an image via mcuboot) from this semaphore take:
https://github.com/zephyrproject-rtos/zephyr/blob/5af0fbc2e30250968289ff4d3ffb69ea45f41d37/drivers/flash/soc_flash_nrf_ticker.c#L225-L233

I think this is because this constant is based on the time taken to erase the chip but doesn't take account of the fact it is being done by a ticker. If I understand correctly the ticker is a timeshare mechanism so the actual max erase time is some factor based on how much time is given to the task by the ticker.

This multiplies the max timeout by 1.5.