### PR TITLE
boards: stm32: Update doc for STM32U5/L5 boards

### DIFF
--- a/boards/arm/b_u585i_iot02a/doc/index.rst
+++ b/boards/arm/b_u585i_iot02a/doc/index.rst
@@ -276,14 +276,18 @@ Default settings are 115200 8N1.
 Programming and Debugging
 *************************
 
+B_U585I_IOT02A Discovery kit includes an ST-LINK/V3 embedded debug tool interface.
+This probe allows to flash the board using various tools.
+
 Flashing
 ========
 
-B_U585I_IOT02A Discovery kit includes an ST-LINK/V2-1 embedded debug tool interface.
-This interface is supported by the openocd version included in Zephyr SDK.
+Board is configured to be flashed using west STM32CubeProgrammer runner.
+Installation of `STM32CubeProgrammer`_ is then required to flash the board.
 
-Flashing an application to B_U585I_IOT02A Discovery kit
--------------------------------------------------------
+Alternatively, openocd (provided in Zephyr SDK), JLink and pyocd can also be
+used to flash and debug the board if west is told to use it as runner,
+using ``-r openocd``.
 
 Connect the B_U585I_IOT02A Discovery kit to your host computer using the USB
 port, then run a serial host program to connect with your Discovery
@@ -310,32 +314,40 @@ You should see the following message on the console:
 Debugging
 =========
 
-Debugging
-=========
-
-STM32U5 support is not currently supported in openocd. As a temporary workaround,
-user can use `STMicroelectronics customized version of OpenOCD`_ to debug the
-the B_U585I_IOT02A Discovery kit.
-For this you need to fetch this repo, checkout branch "openocd-cubeide-r3" and
-build openocd following the instructions provided in the README of the project.
-Then, build zephyr project indicating the openocd location in west build command.
-
+Default flasher for this board is openocd. It could be used in the usual way.
 Here is an example for the :ref:`blinky-sample` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
    :board: b_u585i_iot02a
-   :gen-args: -DOPENOCD="<path_to_openocd>/openocd/src/openocd" -DOPENOCD_DEFAULT_PATH="<path_to_openocd>/openocd/tcl/"
-   :goals: build
+   :goals: debug
 
-Then, indicate openocd as the chosen runner in flash and debug commands:
+Building a secure/non-secure with Arm |reg| TrustZone |reg|
+===========================================================
 
+The TF-M applications can be run on this board, thanks to its Arm |reg| TrustZone |reg|
+support.
+In TF-M configuration, Zephyr is run on the non-secure domain. A non-secure image
+can be generated using ``b_u585i_iot02a_ns`` as build target.
 
-   .. code-block:: console
+.. code-block:: bash
 
-      $ west flash -r openocd
-      $ west debug -r openocd
+   $ west build -b b_u585i_iot02a_ns path/to/source/directory
 
+Note: When building the ``*_ns`` image with TF-M, ``build/tfm/postbuild.sh`` bash script
+is run automatically in a post-build step to make some required flash layout changes.
+
+Once the build is completed, run the following script to initialize the option bytes.
+
+.. code-block:: bash
+
+   $ build/tfm/regression.sh
+
+Finally, to flash the board, run:
+
+.. code-block:: bash
+
+   $ west flash
 
 .. _B U585I IOT02A Discovery kit website:
    https://www.st.com/en/evaluation-tools/b-u585i-iot02a.html

--- a/boards/arm/nucleo_l552ze_q/doc/nucleol552ze_q.rst
+++ b/boards/arm/nucleo_l552ze_q/doc/nucleol552ze_q.rst
@@ -351,7 +351,7 @@ Finally, to flash the board, run:
 
 .. code-block:: bash
 
-   $ west flash --hex-file build/tfm_merged.hex
+   $ west flash
 
 Note: Check the ``build/tfm`` directory to ensure that the commands required by these scripts
 (``readlink``, etc.) are available on your system. Please also check ``STM32_Programmer_CLI``

--- a/boards/arm/nucleo_u575zi_q/board.cmake
+++ b/boards/arm/nucleo_u575zi_q/board.cmake
@@ -10,8 +10,6 @@ board_runner_args(pyocd "--target=stm32u575zitx")
 board_runner_args(jlink "--device=STM32U575ZI" "--reset-after-load")
 
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-# FIXME: openocd runner requires use of STMicro openocd fork.
-# Check board documentation for more details.
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_u575zi_q/doc/nucleou575zi_q.rst
+++ b/boards/arm/nucleo_u575zi_q/doc/nucleou575zi_q.rst
@@ -225,12 +225,11 @@ Nucleo U575ZI Q board has 6 U(S)ARTs. The Zephyr console output is assigned to
 USART1. Default settings are 115200 8N1.
 
 
-Programming
-***********
+Programming and Debugging
+*************************
 
-Applications for the ``nucleo_u575zi_q`` board configuration can be built and
-flashed in the usual way (see :ref:`build_an_application` and
-:ref:`application_run` for more details).
+Nucleo U575ZI-Q board includes an ST-LINK/V3 embedded debug tool interface.
+This probe allows to flash the board using various tools.
 
 Flashing
 ========
@@ -238,10 +237,11 @@ Flashing
 Board is configured to be flashed using west STM32CubeProgrammer runner.
 Installation of `STM32CubeProgrammer`_ is then required to flash the board.
 
-Alternatively pyocd and JLink can be used to flash and debug the board.
-JLink works out of the box if west is told to use it as runner,
-which can be done by passing ``-r jlink``.
-For pyocd (``-r pyocd``) additional target information needs to be installed.
+Alternatively, openocd (provided in Zephyr SDK), JLink and pyocd can also be
+used to flash and debug the board if west is told to use it as runner,
+which can be done by passing either ``-r openocd``, ``-r jlink`` or ``-r pyocd``.
+
+For pyocd additional target information needs to be installed.
 This can be done by executing the following commands.
 
 .. code-block:: console
@@ -279,29 +279,44 @@ You should see the following message on the console:
 Debugging
 =========
 
-STM32U5 support is not currently supported in openocd. As a temporary workaround,
-user can use `STMicroelectronics customized version of OpenOCD`_ to debug the
-the Nucleo U575ZI Q.
-For this you need to fetch this repo, checkout branch "openocd-cubeide-r3" and
-build openocd following the instructions provided in the README of the project.
-Then, build zephyr project indicating the openocd location in west build command.
-
+Default flasher for this board is openocd. It could be used in the usual way.
 Here is an example for the :ref:`blinky-sample` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
    :board: nucleo_u575zi_q
-   :gen-args: -DOPENOCD="<path_to_openocd>/openocd/src/openocd" -DOPENOCD_DEFAULT_PATH="<path_to_openocd>/openocd/tcl/"
-   :goals: build
+   :goals: debug
 
-Then, indicate openocd as the chosen runner in flash and debug commands:
+Building a secure/non-secure with Arm |reg| TrustZone |reg|
+===========================================================
 
+The TF-M applications can be run on this board, thanks to its Arm |reg| TrustZone |reg|
+support.
+In TF-M configuration, Zephyr is run on the non-secure domain. A non-secure image
+can be generated using ``nucleo_u575zi_q_ns`` as build target.
 
-   .. code-block:: console
+.. code-block:: bash
 
-      $ west flash -r openocd
-      $ west debug -r openocd
+   $ west build -b nucleo_u575zi_q_ns path/to/source/directory
 
+Note: When building the ``*_ns`` image with TF-M, ``build/tfm/postbuild.sh`` bash script
+is run automatically in a post-build step to make some required flash layout changes.
+
+Once the build is completed, run the following script to initialize the option bytes.
+
+.. code-block:: bash
+
+   $ build/tfm/regression.sh
+
+Finally, to flash the board, run:
+
+.. code-block:: bash
+
+   $ west flash
+
+Note: Check the ``build/tfm`` directory to ensure that the commands required by these scripts
+(``readlink``, etc.) are available on your system. Please also check ``STM32_Programmer_CLI``
+(which is used for initialization) is available in the PATH.
 
 .. _STM32 Nucleo-144 board User Manual:
    http://www.st.com/resource/en/user_manual/dm00615305.pdf


### PR DESCRIPTION
Update documentation for STM32U5 and STM32L5 based boards:
- Zepĥyr SDK openocd can be used instead of openocd ST fork.
- All these boards use a STLinkV3 instead of V2.
- Update (or provide when missing) instructions for building and flashing TFM applications.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>