### PR TITLE
doc: release-notes: Add C++ subsystem release notes for 3.2

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -531,6 +531,12 @@ Libraries / Subsystems
 
 * C++ Subsystem
 
+  * Added ``std::ptrdiff_t``, ``std::size_t``, ``std::max_align_t`` and
+    ``std::nullptr_t`` type definitions to the C++ subsystem ``cstddef``
+    header.
+  * Renamed global constructor list symbols to prevent the native POSIX host
+    runtime from executing the constructors before Zephyr loads.
+
 * Emul
 
 * Filesystem


### PR DESCRIPTION
This commit adds the C++ subsystem release notes for the Zephyr 3.2 release.

Signed-off-by: Stephanos Ioannidis <stephanos.ioannidis@nordicsemi.no>