### PR TITLE
Bluetooth: Controller: Fix infinite loop receiving ISO Data

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1673,14 +1673,14 @@ void ll_rx_release(void *node_rx)
 
 void ll_rx_put(memq_link_t *link, void *rx)
 {
-#if defined(CONFIG_BT_CONN)
+#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_CTLR_ADV_ISO)
 	struct node_rx_hdr *rx_hdr = rx;
 
 	/* Serialize Tx ack with Rx enqueue by storing reference to
 	 * last element index in Tx ack FIFO.
 	 */
 	rx_hdr->ack_last = mfifo_tx_ack.l;
-#endif /* CONFIG_BT_CONN */
+#endif /* CONFIG_BT_CONN || CONFIG_BT_CTLR_ADV_ISO */
 
 	/* Enqueue the Rx object */
 	memq_enqueue(link, rx, &memq_ll_rx.tail);


### PR DESCRIPTION
Fix inifinite loop in ll_rx_get() when both ISO Broadcast and ISO Receive features are enabled in a build. Missing conditional compile prevented the ack_last index that maintains a relation between number of packets complete and the received data packets was unassigned.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>