### PR TITLE
Bluetooth: audio: ascs: Fix Kconfig dependency

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.ascs
+++ b/subsys/bluetooth/audio/Kconfig.ascs
@@ -7,9 +7,7 @@
 #
 
 config BT_ASCS
-	bool "Audio Stream Control Service Support"
-	help
-	  This option enables support for Audio Stream Control Service.
+	def_bool BT_AUDIO_UNICAST_SERVER
 
 if BT_ASCS
 config BT_ASCS_ASE_SNK_COUNT

--- a/subsys/bluetooth/audio/Kconfig.baps
+++ b/subsys/bluetooth/audio/Kconfig.baps
@@ -20,7 +20,6 @@ config BT_AUDIO_UNICAST_SERVER
 	select BT_ISO_PERIPHERAL
 	select BT_GATT_DYNAMIC_DB
 	select BT_GATT_CACHING
-	select BT_ASCS
 	help
 	  This option enables support for Bluetooth Unicast Audio Server
 	  using Isochronous channels.

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -33,8 +33,6 @@
 #include "pacs_internal.h"
 #include "cap_internal.h"
 
-#if defined(CONFIG_BT_AUDIO_UNICAST_SERVER)
-
 #define ASE_ID(_ase) ase->ep.status.id
 #define ASE_DIR(_id) \
 	(_id > CONFIG_BT_ASCS_ASE_SNK_COUNT ? BT_AUDIO_DIR_SOURCE : BT_AUDIO_DIR_SINK)
@@ -2350,5 +2348,3 @@ BT_GATT_SERVICE_DEFINE(ascs_svc,
 		      NULL, ascs_cp_write, NULL),
 	BT_AUDIO_CCC(ascs_cp_cfg_changed),
 );
-
-#endif /* BT_AUDIO_UNICAST_SERVER */


### PR DESCRIPTION
This avoids user to enable BT_ASCS without BT_AUDIO_UNICAST_SERVER. The code was compiled out anyway, so the option even if enabled had no result. The BT_ASCS depends on BT_AUDIO_UNICAST_SERVER, thus enable it by default if BT_AUDIO_UNICAST_SERVER is enabled.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>