### PR TITLE
cmake: support relocating of a board folder

### DIFF
--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -104,6 +104,12 @@ Hints:
       message("Board alias ${BOARD_ALIAS} is hiding the real board of same name")
     endif()
   endif()
+  if(BOARD_DIR AND NOT EXISTS ${BOARD_DIR}/${BOARD}_defconfig)
+    message(WARNING "BOARD_DIR: ${BOARD_DIR} has been moved or deleted. "
+                    "Trying to find new location."
+    )
+    set(BOARD_DIR BOARD_DIR-NOTFOUND CACHE PATH "Path to a file." FORCE)
+  endif()
   find_path(BOARD_DIR
     NAMES ${BOARD}_defconfig
     PATHS ${root}/boards/*/*


### PR DESCRIPTION
Fixes: #49116

During development of out-of-tree boards and applications it is not uncommon to refactor / restructure code.

To allow developers more freedom, let's check that board's defconfig still exists during a CMake re-run.
If the defconfig no longer exists, either because it's been moved or deleted, then warn the user and set BOARD_DIR to NOTFOUND.

The NOTFOUND will request CMake to search for the new location in all board roots. If the board has not been found, as example it's deleted, then the existing error is printed later.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>