### PR TITLE
Bluetooth: audio: Factor out PACS related API to internal header

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1492,95 +1492,6 @@ struct bt_audio_unicast_server_cb {
 	int (*release)(struct bt_audio_stream *stream);
 };
 
-/**  @brief Callback structure for the Public Audio Capabilities Service (PACS)
- *
- * This is used for the Unicast Server
- * (@kconfig{CONFIG_BT_AUDIO_UNICAST_SERVER}) and Broadcast Sink
- * (@kconfig{CONFIG_BT_AUDIO_BROADCAST_SINK}) roles.
- */
-struct bt_audio_pacs_cb {
-	/** @brief Get available audio contexts callback
-	 *
-	 *  Get available audio contexts callback is called whenever a remote client
-	 *  requests to read the value of Published Audio Capabilities (PAC) Available
-	 *  Audio Contexts, or if the value needs to be notified.
-	 *
-	 *  @param[in]  conn     The connection that requests the available audio
-	 *                       contexts. Will be NULL if requested for sending
-	 *                       a notification, as a result of calling
-	 *                       bt_pacs_available_contexts_changed().
-	 *  @param[in]  dir      Direction of the endpoint.
-	 *  @param[out] context  Pointer to the contexts that needs to be set.
-	 *
-	 *  @return 0 in case of success or negative value in case of error.
-	 */
-	int (*get_available_contexts)(struct bt_conn *conn, enum bt_audio_dir dir,
-				      enum bt_audio_context *context);
-
-	/** @brief Publish Capability callback
-	 *
-	 *  Publish Capability callback is called whenever a remote client
-	 *  requests to read the Published Audio Capabilities (PAC) records.
-	 *  The callback will be called iteratively until it returns an error,
-	 *  increasing the @p index each time. Once an error value (non-zero)
-	 *  is returned, the previously returned @p codec values (if any) will
-	 *  be sent to the client that requested the value.
-	 *
-	 *  @param conn   The connection that requests the capabilities.
-	 *                Will be NULL if the capabilities is requested for
-	 *                sending a notification, as a result of calling
-	 *                bt_audio_capability_register() or
-	 *                bt_audio_capability_unregister().
-	 *  @param type   Type of the endpoint.
-	 *  @param index  Index of the codec object requested. Multiple objects
-	 *                may be returned, and this value keep tracks of how
-	 *                many have previously been returned.
-	 *  @param codec  Codec object that shall be populated if returning
-	 *                success (0). Ignored if returning non-zero.
-	 *
-	 *  @return 0 in case of success or negative value in case of error.
-	 */
-	int (*publish_capability)(struct bt_conn *conn, uint8_t type,
-				  uint8_t index, struct bt_codec *const codec);
-
-#if defined(CONFIG_BT_PAC_SNK_LOC) || defined(CONFIG_BT_PAC_SRC_LOC)
-	/** @brief Publish location callback
-	 *
-	 *  Publish location callback is called whenever a remote client
-	 *  requests to read the Published Audio Capabilities (PAC) location,
-	 *  or if the location needs to be notified.
-	 *
-	 *  @param[in]  conn      The connection that requests the location.
-	 *                        Will be NULL if the location is requested
-	 *                        for sending a notification, as a result of
-	 *                        calling bt_audio_pacs_location_changed().
-	 *  @param[in]  dir       Direction of the endpoint.
-	 *  @param[out] location  Pointer to the location that needs to be set.
-	 *
-	 *  @return 0 in case of success or negative value in case of error.
-	 */
-	int (*publish_location)(struct bt_conn *conn,
-				enum bt_audio_dir dir,
-				enum bt_audio_location *location);
-
-#if defined(CONFIG_BT_PAC_SNK_LOC_WRITEABLE) || defined(CONFIG_BT_PAC_SRC_LOC_WRITEABLE)
-	/** @brief Write location callback
-	 *
-	 *  Write location callback is called whenever a remote client
-	 *  requests to write the Published Audio Capabilities (PAC) location.
-	 *
-	 *  @param conn      The connection that requests the write.
-	 *  @param dir       Direction of the endpoint.
-	 *  @param location  The location being written.
-	 *
-	 *  @return 0 in case of success or negative value in case of error.
-	 */
-	int (*write_location)(struct bt_conn *conn, enum bt_audio_dir dir,
-			      enum bt_audio_location location);
-#endif /* CONFIG_BT_PAC_SNK_LOC_WRITEABLE || CONFIG_BT_PAC_SRC_LOC_WRITEABLE */
-#endif /* CONFIG_BT_PAC_SNK_LOC || CONFIG_BT_PAC_SRC_LOC */
-};
-
 /** Broadcast Audio Sink callback structure */
 struct bt_audio_broadcast_sink_cb {
 	/** @brief Scan receive callback
@@ -1793,40 +1704,6 @@ void bt_audio_stream_cb_register(struct bt_audio_stream *stream,
  * @ingroup bt_audio
  * @{
  */
-
-/** @brief Register Published Audio Capabilities Service callbacks.
- *
- *  Only one callback structure can be registered, and attempting to
- *  registering more than one will result in an error.
- *
- *  This can only be done for the Unicast Server
- *  (@kconfig{CONFIG_BT_AUDIO_UNICAST_SERVER}) and Broadcast Sink
- *  (@kconfig{CONFIG_BT_AUDIO_BROADCAST_SINK}) roles.
- *
- *  Calling bt_audio_capability_register() will implicitly register the
- *  callbacks.
- *
- *  @param cb  Unicast server callback structure.
- *
- *  @return 0 in case of success or negative value in case of error.
- */
-int bt_audio_pacs_register_cb(const struct bt_audio_pacs_cb *cb);
-
-/** @brief Notify that the location has changed
- *
- * @param dir Direction of the location changed.
- *
- * @return 0 in case of success or negative value in case of error.
- */
-int bt_audio_pacs_location_changed(enum bt_audio_dir dir);
-
-/** @brief Notify available audio contexts changed
- *
- * Notify connected clients that the available audio contexts has changed
- *
- * @return 0 in case of success or negative value in case of error.
- */
-int bt_pacs_available_contexts_changed(void);
 
 /** @brief Register unicast server callbacks.
  *

--- a/subsys/bluetooth/audio/pacs_internal.h
+++ b/subsys/bluetooth/audio/pacs_internal.h
@@ -50,6 +50,97 @@ struct bt_pacs_context {
 	uint16_t  src;
 } __packed;
 
+/**  @brief Callback structure for the Public Audio Capabilities Service (PACS)
+ *
+ * This is used for the Unicast Server
+ * (@kconfig{CONFIG_BT_AUDIO_UNICAST_SERVER}) and Broadcast Sink
+ * (@kconfig{CONFIG_BT_AUDIO_BROADCAST_SINK}) roles.
+ */
+struct bt_audio_pacs_cb {
+	/** @brief Get available audio contexts callback
+	 *
+	 *  Get available audio contexts callback is called whenever a remote client
+	 *  requests to read the value of Published Audio Capabilities (PAC) Available
+	 *  Audio Contexts, or if the value needs to be notified.
+	 *
+	 *  @param[in]  conn     The connection that requests the available audio
+	 *                       contexts. Will be NULL if requested for sending
+	 *                       a notification, as a result of calling
+	 *                       bt_pacs_available_contexts_changed().
+	 *  @param[in]  dir      Direction of the endpoint.
+	 *  @param[out] context  Pointer to the contexts that needs to be set.
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	int (*get_available_contexts)(struct bt_conn *conn, enum bt_audio_dir dir,
+				      enum bt_audio_context *context);
+
+	/** @brief Publish Capability callback
+	 *
+	 *  Publish Capability callback is called whenever a remote client
+	 *  requests to read the Published Audio Capabilities (PAC) records.
+	 *  The callback will be called iteratively until it returns an error,
+	 *  increasing the @p index each time. Once an error value (non-zero)
+	 *  is returned, the previously returned @p codec values (if any) will
+	 *  be sent to the client that requested the value.
+	 *
+	 *  @param conn   The connection that requests the capabilities.
+	 *                Will be NULL if the capabilities is requested for
+	 *                sending a notification, as a result of calling
+	 *                bt_audio_capability_register() or
+	 *                bt_audio_capability_unregister().
+	 *  @param type   Type of the endpoint.
+	 *  @param index  Index of the codec object requested. Multiple objects
+	 *                may be returned, and this value keep tracks of how
+	 *                many have previously been returned.
+	 *  @param codec  Codec object that shall be populated if returning
+	 *                success (0). Ignored if returning non-zero.
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	int (*publish_capability)(struct bt_conn *conn, uint8_t type,
+				  uint8_t index, struct bt_codec *const codec);
+
+#if defined(CONFIG_BT_PAC_SNK_LOC) || defined(CONFIG_BT_PAC_SRC_LOC)
+	/** @brief Publish location callback
+	 *
+	 *  Publish location callback is called whenever a remote client
+	 *  requests to read the Published Audio Capabilities (PAC) location,
+	 *  or if the location needs to be notified.
+	 *
+	 *  @param[in]  conn      The connection that requests the location.
+	 *                        Will be NULL if the location is requested
+	 *                        for sending a notification, as a result of
+	 *                        calling bt_audio_pacs_location_changed().
+	 *  @param[in]  dir       Direction of the endpoint.
+	 *  @param[out] location  Pointer to the location that needs to be set.
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	int (*publish_location)(struct bt_conn *conn,
+				enum bt_audio_dir dir,
+				enum bt_audio_location *location);
+
+#if defined(CONFIG_BT_PAC_SNK_LOC_WRITEABLE) || defined(CONFIG_BT_PAC_SRC_LOC_WRITEABLE)
+	/** @brief Write location callback
+	 *
+	 *  Write location callback is called whenever a remote client
+	 *  requests to write the Published Audio Capabilities (PAC) location.
+	 *
+	 *  @param conn      The connection that requests the write.
+	 *  @param dir       Direction of the endpoint.
+	 *  @param location  The location being written.
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	int (*write_location)(struct bt_conn *conn, enum bt_audio_dir dir,
+			      enum bt_audio_location location);
+#endif /* CONFIG_BT_PAC_SNK_LOC_WRITEABLE || CONFIG_BT_PAC_SRC_LOC_WRITEABLE */
+#endif /* CONFIG_BT_PAC_SNK_LOC || CONFIG_BT_PAC_SRC_LOC */
+};
+
+int bt_audio_pacs_register_cb(const struct bt_audio_pacs_cb *cb);
+int bt_audio_pacs_location_changed(enum bt_audio_dir dir);
 void bt_pacs_capabilities_changed(enum bt_audio_dir dir);
 int bt_pacs_available_contexts_changed(void);
 bool bt_pacs_context_available(enum bt_audio_dir dir, uint16_t context);


### PR DESCRIPTION
This moves the PACS API to internal header, as it duplicates the
bt_capabilities API.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>