### PR TITLE
tests: mem_protect: sys_sem: move a test case to new ztest API

### DIFF
--- a/tests/kernel/mem_protect/sys_sem/src/main.c
+++ b/tests/kernel/mem_protect/sys_sem/src/main.c
@@ -242,7 +242,7 @@ ZTEST_USER(sys_sem, test_sem_take_no_wait_fails)
 /**
  * @brief Test sys_sem_take() with timeout expiry
  */
-void test_sem_take_timeout_fails(void)
+ZTEST_USER(sys_sem_1cpu, test_sem_take_timeout_fails)
 {
 	int32_t ret_value;
 


### PR DESCRIPTION
move test case test_sem_take_timeout_fails() to new ztest API

Signed-off-by: Meng xianglin <xianglinx.meng@intel.com>