### PR TITLE
Bluetooth: Mesh: Shell: Update CDB clear/del behaviour

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/shell.rst
+++ b/doc/connectivity/bluetooth/api/mesh/shell.rst
@@ -132,7 +132,7 @@ General configuration
 ``mesh reset-local``
 --------------------
 
-	Reset the local mesh node to its initial unprovisioned state.
+	Reset the local mesh node to its initial unprovisioned state. This command will also clear the Configuration Database (CDB) if present.
 
 Target
 ======

--- a/subsys/bluetooth/mesh/shell/cfg_cli.c
+++ b/subsys/bluetooth/mesh/shell/cfg_cli.c
@@ -33,6 +33,14 @@ static int cmd_reset(const struct shell *sh, size_t argc, char *argv[])
 		return 0;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_MESH_CDB)) {
+		struct bt_mesh_cdb_node *node = bt_mesh_cdb_node_get(bt_mesh_shell_target_ctx.dst);
+
+		if (node) {
+			bt_mesh_cdb_node_del(node, true);
+		}
+	}
+
 	shell_print(sh, "Remote node reset complete");
 
 	return 0;

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -424,6 +424,9 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_reset(const struct shell *sh, size_t argc, char *argv[])
 {
+#if defined(CONFIG_BT_MESH_CDB)
+	bt_mesh_cdb_clear();
+# endif
 	bt_mesh_reset();
 	shell_print(sh, "Local node reset complete");
 


### PR DESCRIPTION
Applies the following alterations to CDB behaviour in mesh shell

- Adds feature that deletes the shell CDB node after perfoming a config client reset of another node.
- Adds feature that clears the CDB entry on local reset.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>