### PR TITLE
includes: prevent warnings (Z_CBPRINTF_ARG_SIZE shadows variables)

### DIFF
--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -178,15 +178,15 @@ extern "C" {
 #define Z_CBPRINTF_ARG_SIZE(v) z_cbprintf_cxx_arg_size(v)
 #else
 #define Z_CBPRINTF_ARG_SIZE(v) ({\
-	__auto_type _v = (v) + 0; \
+	__auto_type __v = (v) + 0; \
 	/* Static code analysis may complain about unused variable. */ \
-	(void)_v; \
-	size_t _arg_size = _Generic((v), \
+	(void)__v; \
+	size_t __arg_size = _Generic((v), \
 		float : sizeof(double), \
 		default : \
-			sizeof((_v)) \
+			sizeof((__v)) \
 		); \
-	_arg_size; \
+	__arg_size; \
 })
 #endif
 


### PR DESCRIPTION
We compile with the gcc compiler flags -Werror and -Wshadow. So the mentioned macro rasies a warning (and with the flags the warning becoms to an error). It uses the same variable names as on of its caller. Add an addidional underscore to the affected variables to prevent this warning.

Signed-off-by: Peter Tönz <peter@rideyourstyle.ch>