### PR TITLE
Fix nucleo f429 uart async

### DIFF
--- a/soc/arm/st_stm32/stm32f4/soc.c
+++ b/soc/arm/st_stm32/stm32f4/soc.c
@@ -32,7 +32,9 @@ static int st_stm32f4_init(const struct device *arg)
 
 	/* Enable ART Flash cache accelerator for both instruction and data */
 	LL_FLASH_EnableInstCache();
-	LL_FLASH_EnableDataCache();
+	if (IS_ENABLED(CONFIG_DCACHE)) {
+		LL_FLASH_EnableDataCache();
+	}
 
 	key = irq_lock();
 

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_f429zi.conf
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_f429zi.conf
@@ -1,0 +1,1 @@
+CONFIG_DCACHE=n


### PR DESCRIPTION
This PR fixes a failed test on Nucleo F429ZI board: tests/drivers/uart/uart_async_api/drivers.uart.async_api
This fix disables the data cache for this test as it is incompatible with the use of DMA.

Fixes #50554