### PR TITLE
doc: release-notes 3.2: STM32: Fix note on SDMMC driver update

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -598,7 +598,8 @@ Libraries / Subsystems
 
 * SD Subsystem
 
-  * SDMMC STM32: Added DMA support and now compatible with STM32L5 series.
+  * SDMMC STM32: Now compatible with STM32L5 series. Added DMA support for DMA-V1
+    compatible devices.
 
 * Settings
 


### PR DESCRIPTION
STM32 SDMMC: DMA is actually available only for DMA-V1 compatible devices.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>