### PR TITLE
kernel: Obtain current cpu inside of locks for thread usage

### DIFF
--- a/kernel/usage.c
+++ b/kernel/usage.c
@@ -98,8 +98,10 @@ void z_sched_usage_start(struct k_thread *thread)
 
 void z_sched_usage_stop(void)
 {
-	struct _cpu     *cpu = _current_cpu;
 	k_spinlock_key_t k   = k_spin_lock(&usage_lock);
+
+	struct _cpu     *cpu = _current_cpu;
+
 	uint32_t u0 = cpu->usage0;
 
 	if (u0 != 0) {
@@ -122,8 +124,9 @@ void z_sched_cpu_usage(uint8_t cpu_id, struct k_thread_runtime_stats *stats)
 	k_spinlock_key_t  key;
 	struct _cpu *cpu;
 
-	cpu = _current_cpu;
 	key = k_spin_lock(&usage_lock);
+	cpu = _current_cpu;
+
 
 	if (&_kernel.cpus[cpu_id] == cpu) {
 		uint32_t  now = usage_now();
@@ -173,8 +176,9 @@ void z_sched_thread_usage(struct k_thread *thread,
 	struct _cpu *cpu;
 	k_spinlock_key_t  key;
 
-	cpu = _current_cpu;
 	key = k_spin_lock(&usage_lock);
+	cpu = _current_cpu;
+
 
 	if (thread == cpu->current) {
 		uint32_t now = usage_now();
@@ -245,7 +249,6 @@ int k_thread_runtime_stats_enable(k_tid_t  thread)
 
 int k_thread_runtime_stats_disable(k_tid_t  thread)
 {
-	struct _cpu *cpu = _current_cpu;
 	k_spinlock_key_t key;
 
 	CHECKIF(thread == NULL) {
@@ -253,6 +256,8 @@ int k_thread_runtime_stats_disable(k_tid_t  thread)
 	}
 
 	key = k_spin_lock(&usage_lock);
+	struct _cpu *cpu = _current_cpu;
+
 	if (thread->base.usage.track_usage) {
 		thread->base.usage.track_usage = false;
 


### PR DESCRIPTION
Obtaining the CPU outside of the spin locks on SMP would result in an assert failing on __ASSERT(!z_smp_mobile()) which makes sense as the current cpu may change.

Found while using thread analyzer on smp machine.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>