### PR TITLE
soc: intel_adsp: Default log configuration for tests

### DIFF
--- a/soc/xtensa/intel_adsp/Kconfig.defconfig
+++ b/soc/xtensa/intel_adsp/Kconfig.defconfig
@@ -19,4 +19,38 @@ config XTENSA_UNCACHED_REGION
 
 endif # XTENSA_RPO_CACHE
 
+
+# Default options for testing
+if ZTEST
+
+config DMA
+	default y
+
+config LOG
+	default y
+
+config LOG_PRINTK
+	default y
+
+choice LOG_MODE
+	default LOG_MODE_IMMEDIATE
+endchoice
+
+config LOG_BACKEND_ADSP
+	default n
+
+config LOG_BACKEND_ADSP_HDA
+	default y
+
+config LOG_BACKEND_ADSP_HDA_SIZE
+	default 8192
+
+config LOG_BACKEND_ADSP_HDA_CAVSTOOL
+	default y
+
+config LOG_BACKEND_ADSP_HDA_PADDING
+	default y
+
+endif # ZTEST
+
 endif # SOC_FAMILY_INTEL_ADSP

--- a/soc/xtensa/intel_adsp/ace/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/ace/Kconfig.defconfig.series
@@ -58,7 +58,7 @@ config SYS_CLOCK_TICKS_PER_SEC
 config DYNAMIC_INTERRUPTS
 	default y
 
-if LOG
+if LOG && !ZTEST
 
 config LOG_BACKEND_ADSP
 	default y

--- a/soc/xtensa/intel_adsp/cavs/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs/Kconfig.defconfig.series
@@ -43,11 +43,11 @@ config 2ND_LEVEL_INTERRUPTS
 config DYNAMIC_INTERRUPTS
 	default y
 
-if LOG
+if LOG && !ZTEST
 
 config LOG_BACKEND_ADSP
 	default y
 
-endif # LOG
+endif # LOG && !ZTEST
 
 endif # SOC_SERIES_INTEL_ADSP_CAVS


### PR DESCRIPTION
Adds a default logger configuration when ZTEST is selected. This enables all tests to use the HDA DMA logger which does is lossless and fast.

Some tests cases may need to exclude this default configuration such as those testing the kernel and hardware drivers required for building up the log backend.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>