### PR TITLE
drivers: gpio: gpio_sam.c: Add Open-Drain Configure Support

### DIFF
--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -40,9 +40,17 @@ static int gpio_sam_port_configure(const struct device *dev, uint32_t mask,
 	const struct gpio_sam_config * const cfg = dev->config;
 	Pio * const pio = cfg->regs;
 
-	if (flags & GPIO_SINGLE_ENDED) {
-		/* TODO: Add support for Open Source, Open Drain mode */
-		return -ENOTSUP;
+	if ((flags & GPIO_SINGLE_ENDED) != 0) {
+		if ((flags & GPIO_LINE_OPEN_DRAIN) != 0) {
+			/* Enable open-drain drive mode */
+			pio->PIO_MDER = mask;
+		} else {
+			/* Open-drain is the only supported single-ended mode */
+			return -ENOTSUP;
+		}
+	} else {
+		/* Disable open-drain drive mode */
+		pio->PIO_MDDR = mask;
 	}
 
 	if (!(flags & (GPIO_OUTPUT | GPIO_INPUT))) {


### PR DESCRIPTION
Adds open-drain support to atmel,sam-gpio drivers, by writing to the PIO_MDER or PIO_MDDR registers during gpio configure.

A simple test sample [is available here](https://github.com/nick-kraus/zephyr/tree/add_sam_open_drain_io-test/samples/open_drain_io_test), which checks that the open-drain output works by reading its value when tied to an input pin with varying pull-up or pull-down resistors enabled.

Signed-off-by: Nick Kraus <nick@nckraus.com>