### PR TITLE
Bluetooth: Controller: Fix ticks_slot_id_previous reset on ticker yield

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -1409,7 +1409,9 @@ static inline void ticker_job_node_manage(struct ticker_instance *instance,
 			uint32_t ticks_at_yield;
 			uint32_t ticks_used;
 
-			instance->ticker_id_slot_previous = TICKER_NULL;
+			if (user_op->op != TICKER_USER_OP_TYPE_YIELD_ABS) {
+				instance->ticker_id_slot_previous = TICKER_NULL;
+			}
 
 			if ((user_op->op == TICKER_USER_OP_TYPE_YIELD_ABS) ||
 			    (user_op->op == TICKER_USER_OP_TYPE_STOP_ABS)) {

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -956,8 +956,7 @@ void ticker_worker(void *param)
 	 */
 	uint8_t slot_reserved = 0;
 
-	if ((instance->ticker_id_slot_previous != TICKER_NULL) &&
-	    (instance->ticks_slot_previous > ticks_elapsed)) {
+	if (instance->ticks_slot_previous > ticks_elapsed) {
 		/* This node intersects reserved slot */
 		slot_reserved = 1;
 	}
@@ -1933,8 +1932,7 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 		}
 
 		/* Check for intersection with already active node */
-		if (instance->ticker_id_slot_previous != TICKER_NULL &&
-			instance->ticks_slot_previous > ticks_elapsed) {
+		if (instance->ticks_slot_previous > ticks_elapsed) {
 			/* Active node intersects - window starts after end of
 			 * active slot
 			 */


### PR DESCRIPTION
Fix implementation to not reset the ticks_slot_id_previous
when ticker yields its reserved slot, only reset if ticker
was stopped.

Fix ticker worker from checking the ticks_slot_id_previous,
only ticks_slot_previous be checked as previous slot id
would be assigned to TICKER_NULL if the ticker was stopped.
The ticks_slot_previous value should be used to check that
a slot is reserved even if the ticker has been stopped.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>