### PR TITLE
driver: usb_dc_sam_usbhs: Restore EP0 after detach

### DIFF
--- a/drivers/usb/device/usb_dc_sam_usbhs.c
+++ b/drivers/usb/device/usb_dc_sam_usbhs.c
@@ -348,7 +348,7 @@ int usb_dc_attach(void)
 int usb_dc_detach(void)
 {
 	/* Detach the device */
-	USBHS->USBHS_DEVCTRL &= ~USBHS_DEVCTRL_DETACH;
+	USBHS->USBHS_DEVCTRL |= USBHS_DEVCTRL_DETACH;
 
 	/* Disable the USB clock */
 	usb_dc_disable_clock();

--- a/drivers/usb/device/usb_dc_sam_usbhs.c
+++ b/drivers/usb/device/usb_dc_sam_usbhs.c
@@ -244,6 +244,16 @@ static void usb_dc_isr(void)
 		/* Acknowledge the interrupt */
 		USBHS->USBHS_DEVICR = USBHS_DEVICR_EORSTC;
 
+		if (!usb_dc_ep_is_configured(0) && dev_data.ep_data[0].mps) {
+			/* Restore EP0 configuration to previously set mps */
+			struct usb_dc_ep_cfg_data cfg = {
+				.ep_addr = 0,
+				.ep_mps = dev_data.ep_data[0].mps,
+				.ep_type = USB_DC_EP_CONTROL,
+			};
+			usb_dc_ep_configure(&cfg);
+			usb_dc_ep_enable(0);
+		}
 		if (usb_dc_ep_is_enabled(0)) {
 			/* The device clears some of the configuration of EP0
 			 * when it receives the EORST.  Re-enable interrupts.


### PR DESCRIPTION
SAM V71 Xplained Ultra failed to re-enumerate on the bus after device detach-attach sequence. The device was recognized by the host, but it was not responding to control transfers, i.e. it was not acknowledging SETUP data. Make device acknowledge SETUP data by reconfiguring EP0 when necessary and actually set DETACH bit during detach instead of clearing it.

Fixes  #50549