### PR TITLE
arch: arm64: Disable ldp/stp Qn for consecutive 32-byte loads/stores

### DIFF
--- a/arch/arm64/core/CMakeLists.txt
+++ b/arch/arm64/core/CMakeLists.txt
@@ -44,4 +44,13 @@ endif ()
 
 zephyr_cc_option_ifdef(CONFIG_USERSPACE -mno-outline-atomics)
 
+# GCC may generate ldp/stp instructions with the Advanced SIMD Qn registers for
+# consecutive 32-byte loads and stores. Saving and restoring the Advanced SIMD
+# context is very expensive, and it is preferable to keep it turned off by not
+# emitting these instructions for better context switching performance.
+
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+  zephyr_cc_option(-moverride=tune=no_ldp_stp_qregs)
+endif()
+
 add_subdirectory_ifdef(CONFIG_SOC_XENVM xen)

--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -2,8 +2,6 @@ tests:
   arch.interrupt:
     # nios2 excluded, see #22956
     arch_exclude: nios2
-    # FIXME: qemu_cortex_a53 is excluded, see #49491
-    platform_exclude: qemu_cortex_a53 qemu_cortex_a53_smp
     tags: kernel interrupt
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
 


### PR DESCRIPTION
GCC may generate ldp/stp instructions with the Advanced SIMD Qn
registers for consecutive 32-byte loads and stores.

This commit disables this GCC behaviour because saving and restoring
the Advanced SIMD context is very expensive, and it is preferable to
keep it turned off by not emitting these instructions for better
context switching performance.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #49491