### PR TITLE
Bluetooth: Tests: Fix uninitialized value in eatt_notif test

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_eatt_notif/src/server_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_eatt_notif/src/server_test.c
@@ -115,6 +115,7 @@ static void gatt_discover(void)
 	discover_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
 	discover_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 	discover_params.type = BT_GATT_DISCOVER_PRIMARY;
+	discover_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 
 	err = bt_gatt_discover(g_conn, &discover_params);
 	if (err != 0) {
@@ -162,7 +163,8 @@ static void gatt_subscribe(void)
 	subscribe_params.ccc_handle = 0;
 	subscribe_params.disc_params = &disc_params,
 	subscribe_params.value = BT_GATT_CCC_NOTIFY;
-	subscribe_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE,
+	subscribe_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
+	subscribe_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 
 	printk("Subscribing: val %x\n", chrc_handle);
 	err = bt_gatt_subscribe(g_conn, &subscribe_params);


### PR DESCRIPTION
The chan_opt field was not set, and on some platforms it ended up with an invalid value. Explicitly set the field on all GATT parameter structs and make the discovery params static.

Fixes #50520

Signed-off-by: Herman Berget <herman.berget@nordicsemi.no>