### PR TITLE
mgmt: mcumgr: Rework event callback system

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -88,6 +88,11 @@ Deprecated in this release
 Stable API changes in this release
 ==================================
 
+* MCUmgr events have been reworked to use a single, unified callback system.
+  This allows better customisation of the callbacks with a lower flash size.
+  Applications using the existing callback system will need to be upgraded to
+  use the new API by following the :ref:`migration guide <mcumgr_cb_migration>`
+
 New APIs in this release
 ========================
 
@@ -299,6 +304,8 @@ Libraries / Subsystems
     has been replaced with the ``smp_streamer`` struct, the zcbor objects need
     to replace ``cnbe`` object access with ``writer`` and ``cnbd`` object
     access with ``reader`` to successfully build.
+  * MCUmgr callback system has been reworked with a unified singular interface
+    which supports status passing to the handler (:ref:`mcumgr_callbacks`).
 
 * LwM2M
 

--- a/doc/services/device_mgmt/index.rst
+++ b/doc/services/device_mgmt/index.rst
@@ -7,6 +7,7 @@ Device Management
     :maxdepth: 1
 
     mcumgr.rst
+    mcumgr_callbacks.rst
     mcumgr_backporting.rst
     smp_protocol.rst
     dfu.rst

--- a/doc/services/device_mgmt/mcumgr_callbacks.rst
+++ b/doc/services/device_mgmt/mcumgr_callbacks.rst
@@ -1,0 +1,284 @@
+.. _mcumgr_callbacks:
+
+MCUmgr Callbacks
+################
+
+Overview
+********
+
+MCUmgr has a customisable callback/notification system that allows application
+(and module) code to receive callbacks for MCUmgr events that they are
+interested in and react to them or return a status code to the calling function
+that provides control over if the action should be allowed or not. An example
+of this is with the fs_mgmt group, whereby file access can be gated, the
+callback allows the application to inspect the request path and allow or deny
+access to said file, or it can rewrite the provided path to a different path
+for transparent file redirection support.
+
+Implementation
+**************
+
+Enabling
+========
+
+The base callback/notification system can be enabled using
+:kconfig:option:`CONFIG_MCUMGR_MGMT_NOTIFICATION_HOOKS` which will compile the
+registration and notification system into the code. This will not provide any
+callbacks by default as the callbacks that are supported by a build must also
+be selected by enabling the Kconfig's for the required callbacks (see
+:ref:`mcumgr_cb_events` for further details). A callback function with the
+:c:type:`mgmt_cb` type definition can then be declared and registered by
+calling :c:func:`mgmt_callback_register` for the desired event inside of a
+:c:struct`mgmt_callback` structure. Handlers are called in the order that they
+were registered.
+
+With the system enabled, a basic handler can be set up and defined in
+application code as per:
+
+.. code-block:: c
+
+    #include <zephyr/kernel.h>
+    #include <mgmt/mgmt.h>
+    #include <zephyr/mgmt/mcumgr/mgmt/callbacks.h>
+
+    struct mgmt_callback my_callback;
+
+    int32_t my_function(uint32_t event, int32_t rc, bool *abort_more, void *data,
+                        size_t data_size)
+    {
+        if (event == MGMT_EVT_OP_CMD_DONE) {
+            /* This is the event we registered for */
+        }
+
+        /* Return OK status code to continue with acceptance to underlying handler */
+        return MGMT_ERR_EOK;
+    }
+
+    void main()
+    {
+        my_callback.callback = my_function;
+        my_callback.event_id = MGMT_EVT_OP_CMD_DONE;
+        mgmt_callback_register(&my_callback);
+    }
+
+This code registers a handler for the :c:enum:`MGMT_EVT_OP_CMD_DONE` event,
+which will be called after a MCUmgr command has been processed and output
+generated, note that this requires that
+:kconfig:option:`CONFIG_MCUMGR_SMP_COMMAND_STATUS_HOOKS` be enabled to
+receive this callback.
+
+Multiple callbacks can be setup to use a single function as a common callback,
+and many different functions can be used for each event by registering each
+group once, or all notifications for a whole group can be enabled by using one
+of the ``MGMT_EVT_OP_*_ALL`` events, alternatively a handler can setup for
+every notification by using :c:enum:`MGMT_EVT_OP_ALL`. When setting up
+handlers, events can be combined that are in the same group only, for example
+5 img_mgmt callbacks can be setup with a single registration call, but to also
+setup a callback for an os_mgmt callback, this must be done as a separate
+registration. Group IDs are numerical increments, event IDs are bitmask values,
+hence the restriction.
+
+.. _mcumgr_cb_events:
+
+Events
+======
+
+Events can be selected by enabling their corresponding Kconfig option:
+
+ - :kconfig:option:`CONFIG_MCUMGR_SMP_COMMAND_STATUS_HOOKS`
+    MCUmgr command status (:c:enum:`MGMT_EVT_OP_CMD_RECV`,
+    :c:enum:`MGMT_EVT_OP_CMD_STATUS`, :c:enum:`MGMT_EVT_OP_CMD_DONE`)
+ - :kconfig:option:`CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK`
+    fs_mgmt file access (:c:enum:`MGMT_EVT_OP_FS_MGMT_FILE_ACCESS`)
+ - :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK`
+    img_mgmt upload check (:c:enum:`MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK`)
+ - :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS`
+    img_mgmt upload status (:c:enum:`MGMT_EVT_OP_IMG_MGMT_DFU_STOPPED`,
+    :c:enum:`MGMT_EVT_OP_IMG_MGMT_DFU_STARTED`,
+    :c:enum:`MGMT_EVT_OP_IMG_MGMT_DFU_PENDING`,
+    :c:enum:`MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED`)
+ - :kconfig:option:`CONFIG_MCUMGR_GRP_OS_OS_RESET_HOOK`
+    os_mgmt reset check (:c:enum:`MGMT_EVT_OP_OS_MGMT_RESET`)
+
+Actions
+=======
+
+Some callbacks expect a return status to either allow or disallow an operation,
+an example is the fs_mgmt access hook which allows for access to files to be
+allowed or denied. With these handlers, the first non-OK error code returned
+by a handler will be returned to the MCUmgr client.
+
+An example of selectively denying file access:
+
+.. code-block:: c
+
+    #include <zephyr/kernel.h>
+    #include <mgmt/mgmt.h>
+    #include <zephyr/mgmt/mcumgr/mgmt/callbacks.h>
+    #include <string.h>
+
+    struct mgmt_callback my_callback;
+
+    int32_t my_function(uint32_t event, int32_t rc, bool *abort_more, void *data,
+                        size_t data_size)
+    {
+        /* Only run this handler if a previous handler has not failed */
+        if (event == MGMT_EVT_OP_FS_MGMT_FILE_ACCESS && rc == MGMT_ERR_EOK) {
+            struct fs_mgmt_file_access *fs_data = (struct fs_mgmt_file_access *)data;
+
+            /* Check if this is an upload and deny access if it is, otherwise check the
+             * the path and deny if is matches a name
+             */
+            if (fs_data->upload == true) {
+                /* Return an access denied error code to the client and abort calling
+                 * further handlers
+                 */
+                *abort_more = true;
+                return MGMT_ERR_EACCESSDENIED;
+            } else if (strcmp(fs_data->filename, "/lfs1/false_deny.txt") == 0) {
+                /* Return a no entry error code to the client, call additional handlers
+                 * (which will have failed set to true)
+                 */
+                return MGMT_ERR_ENOENT;
+            }
+        }
+
+        /* Return OK status code to continue with acceptance to underlying handler */
+        return MGMT_ERR_EOK;
+    }
+
+    void main()
+    {
+        my_callback.callback = my_function;
+        my_callback.event_id = MGMT_EVT_OP_FS_MGMT_FILE_ACCESS;
+        mgmt_callback_register(&my_callback);
+    }
+
+This code registers a handler for the :c:enum:`MGMT_EVT_OP_FS_MGMT_FILE_ACCESS`
+event, which will be called after a fs_mgmt file read/write command has been
+received to check if access to the file should be allowed or not, note that
+this requires that :kconfig:option:`CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK`
+be enabled to receive this callback.
+
+MCUmgr Command Callback Usage/Adding New Event Types
+====================================================
+
+To add a callback to a MCUmgr command, :c:func:`mgmt_callback_notify` can be
+called with the event ID and, optionally, a data struct to pass to the callback
+(which can be modified by handlers). If no data needs to be passed back,
+``NULL`` can be used instead, and size of the data set to 0.
+
+An example MCUmgr command handler:
+
+.. code-block:: c
+
+    #include <zephyr/kernel.h>
+    #include <zcbor_common.h>
+    #include <zcbor_encode.h>
+    #include <mgmt/mgmt.h>
+    #include <zephyr/mgmt/mcumgr/mgmt/callbacks.h>
+
+    #define MGMT_EVT_GRP_USER_ONE MGMT_EVT_GRP_USER_CUSTOM_START
+
+    enum user_one_group_events {
+        /** Callback on first post, data is test_struct. */
+        MGMT_EVT_OP_USER_ONE_FIRST  = MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_USER_ONE, 0),
+
+        /** Callback on second post, data is test_struct. */
+        MGMT_EVT_OP_USER_ONE_SECOND = MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_USER_ONE, 1),
+
+        /** Used to enable all user_one events. */
+        MGMT_EVT_OP_USER_ONE_ALL    = MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_USER_ONE),
+    };
+
+    struct test_struct {
+        uint8_t some_value;
+    };
+
+    static int test_command(struct mgmt_ctxt *ctxt)
+    {
+        int rc;
+        zcbor_state_t *zse = ctxt->cnbe->zs;
+        bool ok;
+        struct test_struct test_data = {
+            .some_value = 8,
+        };
+
+        rc = mgmt_callback_notify(MGMT_EVT_OP_USER_ONE_FIRST, &test_data,
+                                  sizeof(test_data));
+
+        if (rc != MGMT_ERR_EOK) {
+            /* A handler returned a failure code */
+            return rc;
+        }
+
+        /* All handlers returned success codes */
+
+        ok = zcbor_tstr_put_lit(zse, "output_value") &&
+             zcbor_int32_put(zse, 1234);
+
+        if (!ok) {
+                return MGMT_ERR_EMSGSIZE;
+        }
+
+        return MGMT_ERR_EOK;
+    }
+
+If no response is required for the callback, the function call be called and
+casted to void.
+
+.. _mcumgr_cb_migration:
+
+Migration
+*********
+
+If there is existing code using the previous callback system(s) in Zephyr 3.2
+or earlier, then it will need to be migrated to the new system. To migrate
+code, the following callback registration functions will need to be migrated
+to register for callbacks using :c:func:`mgmt_callback_register` (note that
+:kconfig:option:`CONFIG_MCUMGR_MGMT_NOTIFICATION_HOOKS` will need to be set to
+enable the new notification system in addition to any migrations):
+
+ * mgmt_evt
+    Using :c:enum:`MGMT_EVT_OP_CMD_RECV` if ``MGMT_EVT_OP_CMD_RECV`` was used,
+    :c:enum:`MGMT_EVT_OP_CMD_STATUS` if ``MGMT_EVT_OP_CMD_STATUS`` was used or
+    :c:enum:`MGMT_EVT_OP_CMD_DONE` if ``MGMT_EVT_OP_CMD_DONE`` was used, where
+    the provided data is :c:struct:`mgmt_evt_op_cmd_arg`.
+    :kconfig:option:`CONFIG_MCUMGR_SMP_COMMAND_STATUS_HOOKS` needs to be set.
+ * fs_mgmt_register_evt_cb
+    Using :c:enum:`MGMT_EVT_OP_FS_MGMT_FILE_ACCESS` where the provided data is
+    :c:struct:`fs_mgmt_file_access`. Instead of returning true to allow the
+    action or false to deny, a MCUmgr result code needs to be returned,
+    :c:enum:`MGMT_ERR_EOK` will allow the action, any other return code will
+    disallow it and return that code to the client
+    (:c:enum:`MGMT_ERR_EACCESSDENIED` can be used for an access denied error).
+    :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS` needs to be set.
+ * img_mgmt_register_callbacks
+    Using :c:enum:`MGMT_EVT_OP_IMG_MGMT_DFU_STARTED` if ``dfu_started_cb``
+    was used, :c:enum:`MGMT_EVT_OP_IMG_MGMT_DFU_STOPPED` if ``dfu_stopped_cb``
+    was used, :c:enum:`MGMT_EVT_OP_IMG_MGMT_DFU_PENDING` if ``dfu_pending_cb``
+    was used or :c:enum:`MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED` if
+    ``dfu_confirmed_cb`` was used. These callbacks do not have any return
+    status. :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS` needs to be
+    set.
+ * img_mgmt_set_upload_cb
+    Using :c:enum:`MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK` where the provided data is
+    :c:struct:`img_mgmt_upload_check`. Instead of returning true to allow the
+    action or false to deny, a MCUmgr result code needs to be returned,
+    :c:enum:`MGMT_ERR_EOK` will allow the action, any other return code will
+    disallow it and return that code to the client
+    (:c:enum:`MGMT_ERR_EACCESSDENIED` can be used for an access denied error).
+    :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK` needs to be set.
+ * os_mgmt_register_reset_evt_cb
+    Using :c:enum:`MGMT_EVT_OP_OS_MGMT_RESET`.  Instead of returning true to
+    allow the action or false to deny, a MCUmgr result code needs to be
+    returned, :c:enum:`MGMT_ERR_EOK` will allow the action, any other return
+    code will disallow it and return that code to the client
+    (:c:enum:`MGMT_ERR_EACCESSDENIED` can be used for an access denied error).
+    :kconfig:option:`CONFIG_MCUMGR_SMP_COMMAND_STATUS_HOOKS` needs to be set
+
+API Reference
+*************
+
+.. doxygengroup:: mcumgr_callback_api
+    :inner:

--- a/doc/services/device_mgmt/smp_groups/smp_group_0.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_0.rst
@@ -410,12 +410,12 @@ System reset
 
 Performs reset of system. The device should issue response before resetting so
 that the SMP client could receive information that the command has been
-accepted. By default, this command is accepted in all conditions, however if the
-:kconfig:option:`CONFIG_OS_MGMT_RESET_HOOK` is enabled and an application
-registers a callback, the callback will be called when this command is issued
-and can be used to perform any necessary tidy operations prior to the module
-rebooting, or to reject the reset request outright altogether with an error
-response.
+accepted. By default, this command is accepted in all conditions, however if
+the :kconfig:option:`CONFIG_MCUMGR_GRP_OS_OS_RESET_HOOK` is enabled and an
+application registers a callback, the callback will be called when this command
+is issued and can be used to perform any necessary tidy operations prior to the
+module rebooting, or to reject the reset request outright altogether with an
+error response. For details on this functionality, see `ref:`mcumgr_callbacks`.
 
 System reset request
 ====================

--- a/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 Laird Connectivity
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef H_MCUMGR_FS_MGMT_CALLBACKS_
+#define H_MCUMGR_FS_MGMT_CALLBACKS_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief MCUmgr fs_mgmt callback API
+ * @defgroup mcumgr_callback_api_fs_mgmt MCUmgr fs_mgmt callback API
+ * @ingroup mcumgr_callback_api
+ * @{
+ */
+
+/**
+ * Structure provided in the MGMT_EVT_OP_FS_MGMT_FILE_ACCESS notification callback: This callback
+ * function is used to notify the application about a pending file read/write request and to
+ * authorise or deny it. Access will be allowed so long as all notification handlers return
+ * MGMT_ERR_EOK, if one returns an error then access will be denied.
+ */
+struct fs_mgmt_file_access {
+	/** True if the request is for uploading data to the file, otherwise false */
+	bool upload;
+
+	/**
+	 * Path and filename of file be accesses, note that this can be changed by handlers to
+	 * redirect file access if needed (as long as it does not exceed the maximum path string
+	 * size).
+	 */
+	char *filename;
+};
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_callbacks.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Laird Connectivity
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef H_MCUMGR_IMG_MGMT_CALLBACKS_
+#define H_MCUMGR_IMG_MGMT_CALLBACKS_
+
+#include <img_mgmt/img_mgmt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief MCUmgr img_mgmt callback API
+ * @defgroup mcumgr_callback_api_img_mgmt MCUmgr img_mgmt callback API
+ * @ingroup mcumgr_callback_api
+ * @{
+ */
+
+/**
+ * Structure provided in the MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK notification callback: This callback
+ * function is used to notify the application about a pending firmware upload packet from a client
+ * and authorise or deny it. Upload will be allowed so long as all notification handlers return
+ * MGMT_ERR_EOK, if one returns an error then the upload will be denied.
+ */
+struct img_mgmt_upload_check {
+	/** Action to take */
+	struct img_mgmt_upload_action *action;
+
+	/** Upload request information */
+	struct img_mgmt_upload_req *req;
+};
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef H_MCUMGR_CALLBACKS_
+#define H_MCUMGR_CALLBACKS_
+
+#include <inttypes.h>
+#include <zephyr/sys/slist.h>
+#include <mgmt/mgmt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief MCUmgr callback API
+ * @defgroup mcumgr_callback_api MCUmgr callback API
+ * @ingroup mcumgr
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+/** Event which signfies that all event IDs for a particular group should be enabled. */
+#define MGMT_EVT_OP_ID_ALL 0xffff
+
+/** Get event for a particular group and event ID. */
+#define MGMT_DEF_EVT_OP_ID(group, event_id) ((group << 16) | BIT(event_id))
+
+/** Get event used for enabling all event IDs of a particular group. */
+#define MGMT_DEF_EVT_OP_ALL(group) ((group << 16) | MGMT_EVT_OP_ID_ALL)
+/** @endcond  */
+
+/** Get group from event. */
+#define MGMT_EVT_GET_GROUP(event) ((event >> 16) & MGMT_EVT_OP_ID_ALL)
+
+/** Get event ID from event. */
+#define MGMT_EVT_GET_ID(event) (event & MGMT_EVT_OP_ID_ALL)
+
+/**
+ * @typedef mgmt_cb
+ * @brief Function to be called on MGMT notification/event.
+ *
+ * This callback function is used to notify an application or system about a mcumgr mgmt event.
+ *
+ * @param event		MGMT_EVT_OP_[...].
+ * @param rc		MGMT_ERR_[...] of the previous handler calls, if it is an error then it
+ *			will be the first error that was returned by a handler (i.e. this handler
+ *			is being called for a notification only, the return code will be ignored).
+ * @param abort_more	Set to true to abort further processing by additional handlers.
+ * @param data		Optional event argument.
+ * @param data_size	Size of optional event argument (0 if no data is provided).
+ *
+ * @return		MGMT_ERR_[...] of the status to return to the calling code (only checked
+ *			when failed is false).
+ */
+typedef int32_t (*mgmt_cb)(uint32_t event, int32_t rc, bool *abort_more, void *data,
+			   size_t data_size);
+
+/**
+ * MGMT event callback group IDs. Note that this is not a 1:1 mapping with MGMT_GROUP_ID_[...]
+ * values.
+ */
+enum mgmt_cb_groups {
+	MGMT_EVT_GRP_ALL			= 0,
+	MGMT_EVT_GRP_SMP,
+
+	MGMT_EVT_GRP_USER_CUSTOM_START		= MGMT_GROUP_ID_PERUSER,
+};
+
+/**
+ * MGMT event opcodes for all command processing.
+ */
+enum smp_all_events {
+	/** Used to enable all events. */
+	MGMT_EVT_OP_ALL				= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_ALL),
+};
+
+/**
+ * MGMT event opcodes for base SMP command processing.
+ */
+enum smp_group_events {
+	/** Callback when a command is received, data is mgmt_evt_op_cmd_arg. */
+	MGMT_EVT_OP_CMD_RECV			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_SMP, 0),
+
+	/** Callback when a a status is updated, data is mgmt_evt_op_cmd_arg. */
+	MGMT_EVT_OP_CMD_STATUS			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_SMP, 1),
+
+	/** Callback when a command has been processed, data is mgmt_evt_op_cmd_arg. */
+	MGMT_EVT_OP_CMD_DONE			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_SMP, 2),
+
+	/** Used to enable all smp_group events. */
+	MGMT_EVT_OP_CMD_ALL			= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_SMP),
+};
+
+/**
+ * MGMT callback struct
+ */
+struct mgmt_callback {
+	/** Entry list node. */
+	sys_snode_t node;
+
+	/** Callback that will be called. */
+	mgmt_cb callback;
+
+	/** MGMT_EVT_[...] Event ID for handler to be called on. */
+	uint32_t event_id;
+};
+
+/**
+ * MGMT_EVT_OP_CMD_RECV, MGMT_EVT_OP_CMD_STATUS, MGMT_EVT_OP_CMD_DONE arguments
+ */
+struct mgmt_evt_op_cmd_arg {
+	/** MGMT_GROUP_ID_[...] */
+	uint16_t group;
+
+	/** Message ID within group */
+	uint8_t id;
+
+	union {
+		/** MGMT_ERR_[...], used in MGMT_EVT_OP_CMD_DONE */
+		int err;
+
+		/** IMG_MGMT_ID_UPLOAD_STATUS_[...], used in MGMT_EVT_OP_CMD_STATUS */
+		int status;
+	};
+};
+
+/**
+ * @brief This function is called to notify registered callbacks about mcumgr notifications/events.
+ *
+ * @param event		MGMT_EVT_OP_[...].
+ * @param data		Optional event argument.
+ * @param data_size	Size of optional event argument (0 if none).
+ *
+ * @return		MGMT_ERR_[...] either MGMT_ERR_EOK if all handlers returned it, or the
+ *			error code of the first handler that returned an error.
+ */
+int32_t mgmt_callback_notify(uint32_t event, void *data, size_t data_size);
+
+/**
+ * @brief Register event callback function.
+ *
+ * @param callback Callback struct.
+ */
+void mgmt_callback_register(struct mgmt_callback *callback);
+
+/**
+ * @brief Unregister event callback function.
+ *
+ * @param callback Callback struct.
+ */
+void mgmt_callback_unregister(struct mgmt_callback *callback);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_MCUMGR_CALLBACKS_ */

--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -74,6 +74,7 @@ typedef int32_t (*mgmt_cb)(uint32_t event, int32_t rc, bool *abort_more, void *d
 enum mgmt_cb_groups {
 	MGMT_EVT_GRP_ALL			= 0,
 	MGMT_EVT_GRP_SMP,
+	MGMT_EVT_GRP_OS,
 	MGMT_EVT_GRP_IMG,
 	MGMT_EVT_GRP_FS,
 
@@ -137,6 +138,17 @@ enum img_mgmt_group_events {
 
 	/** Used to enable all img_mgmt_group events. */
 	MGMT_EVT_OP_IMG_MGMT_ALL		= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_IMG),
+};
+
+/**
+ * MGMT event opcodes for operating system management group.
+ */
+enum os_mgmt_group_events {
+	/** Callback when a reset command has been received. */
+	MGMT_EVT_OP_OS_MGMT_RESET		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 0),
+
+	/** Used to enable all os_mgmt_group events. */
+	MGMT_EVT_OP_OS_MGMT_ALL			= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_OS),
 };
 
 /**

--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -11,6 +11,10 @@
 #include <zephyr/sys/slist.h>
 #include <mgmt/mgmt.h>
 
+#ifdef CONFIG_MCUMGR_CMD_FS_MGMT
+#include <zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -66,6 +70,8 @@ typedef int32_t (*mgmt_cb)(uint32_t event, int32_t rc, bool *abort_more, void *d
 enum mgmt_cb_groups {
 	MGMT_EVT_GRP_ALL			= 0,
 	MGMT_EVT_GRP_SMP,
+	MGMT_EVT_GRP_IMG,
+	MGMT_EVT_GRP_FS,
 
 	MGMT_EVT_GRP_USER_CUSTOM_START		= MGMT_GROUP_ID_PERUSER,
 };
@@ -93,6 +99,40 @@ enum smp_group_events {
 
 	/** Used to enable all smp_group events. */
 	MGMT_EVT_OP_CMD_ALL			= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_SMP),
+};
+
+/**
+ * MGMT event opcodes for filesystem management group.
+ */
+enum fs_mgmt_group_events {
+	/** Callback when a file has been accessed, data is fs_mgmt_file_access. */
+	MGMT_EVT_OP_FS_MGMT_FILE_ACCESS		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_FS, 0),
+
+	/** Used to enable all fs_mgmt_group events. */
+	MGMT_EVT_OP_FS_MGMT_ALL			= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_FS),
+};
+
+/**
+ * MGMT event opcodes for image management group.
+ */
+enum img_mgmt_group_events {
+	/** Callback when a client sends a file upload chunk, data is img_mgmt_upload_check. */
+	MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 0),
+
+	/** Callback when a DFU operation is stopped. */
+	MGMT_EVT_OP_IMG_MGMT_DFU_STOPPED	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 1),
+
+	/** Callback when a DFU operation is started. */
+	MGMT_EVT_OP_IMG_MGMT_DFU_STARTED	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 2),
+
+	/** Callback when a DFU operation has finished being transferred. */
+	MGMT_EVT_OP_IMG_MGMT_DFU_PENDING	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 3),
+
+	/** Callback when an image has been confirmed. */
+	MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 4),
+
+	/** Used to enable all img_mgmt_group events. */
+	MGMT_EVT_OP_IMG_MGMT_ALL		= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_IMG),
 };
 
 /**

--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -15,6 +15,10 @@
 #include <zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h>
 #endif
 
+#ifdef CONFIG_MCUMGR_CMD_IMG_MGMT
+#include <zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_callbacks.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -101,6 +101,30 @@ config MGMT_MAX_DECODING_LEVELS
 	  size of cbor_nb_reader structure by zcbor_state_t size per
 	  one unit selected here.
 
+config MCUMGR_MGMT_NOTIFICATION_HOOKS
+	bool "MCUmgr notification hook support"
+	help
+	  With this enabled, applications and parts of code can register for MCUmgr event
+	  notifications which will result in callbacks when a registered event occurs. Note that
+	  this enables the base notification functionality but itself does not enable any
+	  notifications, which must be enabled by selecting other Kconfig options.
+
+	  To enable notifications in code, mgmt_callback_register() must be called with the
+	  callback function and events that want to be received. Multiple handlers can be
+	  registered and will all be called when registered events occur.
+
+	  Some callbacks support notifying the calling function of a status, in which to accept
+	  or decline the current operation, by returning false this will signal to the calling
+	  function that the request should be denied, for informal-only notifications or
+	  acceptable, true must be returned by all the registered notification handlers.
+
+config MCUMGR_SMP_COMMAND_STATUS_HOOKS
+	bool "SMP command status hooks"
+	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS
+	help
+	  This will enable SMP command status notification hooks for when an SMP message is
+	  received or processed.
+
 menu "Command Handlers"
 
 rsource "lib/cmd/Kconfig"

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/Kconfig
@@ -140,8 +140,9 @@ config FS_MGMT_PATH_SIZE
 	  of this size gets allocated on the stack during handling of file upload
 	  and download commands.
 
-config FS_MGMT_FILE_ACCESS_HOOK
+config MCUMGR_GRP_FS_FILE_ACCESS_HOOK
 	bool "File read/write access hook"
+	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS
 	help
 	  Allows applications to control file read and write access by
 	  registering for a callback which is then triggered whenever a file

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/fs_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/fs_mgmt.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2022 mcumgr authors
  * Copyright (c) 2022 Laird Connectivity
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,37 +21,10 @@ extern "C" {
 #define FS_MGMT_ID_HASH_CHECKSUM		2
 #define FS_MGMT_ID_SUPPORTED_HASH_CHECKSUM	3
 
-#ifdef CONFIG_FS_MGMT_FILE_ACCESS_HOOK
-/** @typedef fs_mgmt_on_evt_cb
- * @brief Function to be called on fs mgmt event.
- *
- * This callback function is used to notify the application about a pending file
- * read/write request and to authorise or deny it.
- *
- * @param write		True if write access is requested, false for read access
- * @param path		The path of the file to query.
- *
- * @note That the path can potentially be changed by the application code so
- *	 long as it does not exceed the maximum path string size.
- *
- * @return 0 to allow read/write, MGMT_ERR_[...] code to disallow read/write.
- */
-typedef int (*fs_mgmt_on_evt_cb)(bool write, char *path);
-#endif
-
 /**
  * @brief Registers the file system management command handler group.
  */
 void fs_mgmt_register_group(void);
-
-#ifdef CONFIG_FS_MGMT_FILE_ACCESS_HOOK
-/**
- * @brief Register file read/write access event callback function.
- *
- * @param cb Callback function or NULL to disable.
- */
-void fs_mgmt_register_evt_cb(fs_mgmt_on_evt_cb cb);
-#endif
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/fs_mgmt.c
@@ -613,20 +613,20 @@ static void supported_hash_checksum_callback(const struct hash_checksum_mgmt_gro
  * Command handler: fs supported hash/checksum (read)
  */
 static int
-fs_mgmt_supported_hash_checksum(struct mgmt_ctxt *ctxt)
+fs_mgmt_supported_hash_checksum(struct smp_streamer *ctxt)
 {
-	zcbor_state_t *zse = ctxt->cnbe->zs;
-	struct hash_checksum_iterator_info ctx = {
+	zcbor_state_t *zse = ctxt->writer->zs;
+	struct hash_checksum_iterator_info itr_ctx = {
 		.zse = zse,
 	};
 
-	ctx.ok = zcbor_tstr_put_lit(zse, "types");
+	itr_ctx.ok = zcbor_tstr_put_lit(zse, "types");
 
 	zcbor_map_start_encode(zse, CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH_SUPPORTED_MAX_TYPES);
 
-	hash_checksum_mgmt_find_handlers(supported_hash_checksum_callback, &ctx);
+	hash_checksum_mgmt_find_handlers(supported_hash_checksum_callback, &itr_ctx);
 
-	if (!ctx.ok ||
+	if (!itr_ctx.ok ||
 	    !zcbor_map_end_encode(zse, CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH_SUPPORTED_MAX_TYPES)) {
 		return MGMT_ERR_EMSGSIZE;
 	}

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/fs_mgmt.c
@@ -32,6 +32,10 @@
 #include "fs_mgmt/hash_checksum_sha256.h"
 #endif
 
+#if defined(CONFIG_MCUMGR_MGMT_NOTIFICATION_HOOKS)
+#include <zephyr/mgmt/mcumgr/mgmt/callbacks.h>
+#endif
+
 #ifdef CONFIG_FS_MGMT_CHECKSUM_HASH
 /* Define default hash/checksum */
 #if defined(CONFIG_FS_MGMT_CHECKSUM_IEEE_CRC32)
@@ -77,10 +81,6 @@ struct hash_checksum_iterator_info {
 	zcbor_state_t *zse;
 	bool ok;
 };
-#endif
-
-#ifdef CONFIG_FS_MGMT_FILE_ACCESS_HOOK
-static fs_mgmt_on_evt_cb fs_evt_cb;
 #endif
 
 static int fs_mgmt_filelen(const char *path, size_t *out_len)
@@ -179,6 +179,13 @@ static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 		ZCBOR_MAP_DECODE_KEY_VAL(name, zcbor_tstr_decode, &name),
 	};
 
+#if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
+	struct fs_mgmt_file_access file_access_data = {
+		.upload = false,
+		.filename = path,
+	};
+#endif
+
 	ok = zcbor_map_decode_bulk(zsd, fs_download_decode,
 		ARRAY_SIZE(fs_download_decode), &decoded) == 0;
 
@@ -189,14 +196,13 @@ static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 	memcpy(path, name.value, name.len);
 	path[name.len] = '\0';
 
-#ifdef CONFIG_FS_MGMT_FILE_ACCESS_HOOK
-	if (fs_evt_cb != NULL) {
-		/* Send request to application to check if access should be allowed or not */
-		rc = fs_evt_cb(false, path);
+#if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
+	/* Send request to application to check if access should be allowed or not */
+	rc = mgmt_callback_notify(MGMT_EVT_OP_FS_MGMT_FILE_ACCESS, &file_access_data,
+				  sizeof(file_access_data));
 
-		if (rc != 0) {
-			return rc;
-		}
+	if (rc != MGMT_ERR_EOK) {
+		return rc;
 	}
 #endif
 
@@ -313,6 +319,13 @@ static int fs_mgmt_file_upload(struct smp_streamer *ctxt)
 		ZCBOR_MAP_DECODE_KEY_VAL(len, zcbor_uint64_decode, &len),
 	};
 
+#if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
+	struct fs_mgmt_file_access file_access_data = {
+		.upload = false,
+		.filename = file_name,
+	};
+#endif
+
 	ok = zcbor_map_decode_bulk(zsd, fs_upload_decode,
 		ARRAY_SIZE(fs_upload_decode), &decoded) == 0;
 
@@ -324,14 +337,13 @@ static int fs_mgmt_file_upload(struct smp_streamer *ctxt)
 	memcpy(file_name, name.value, name.len);
 	file_name[name.len] = '\0';
 
-#ifdef CONFIG_FS_MGMT_FILE_ACCESS_HOOK
-	if (fs_evt_cb != NULL) {
-		/* Send request to application to check if access should be allowed or not */
-		rc = fs_evt_cb(true, file_name);
+#if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
+	/* Send request to application to check if access should be allowed or not */
+	rc = mgmt_callback_notify(MGMT_EVT_OP_FS_MGMT_FILE_ACCESS, &file_access_data,
+				  sizeof(file_access_data));
 
-		if (rc != 0) {
-			return rc;
-		}
+	if (rc != MGMT_ERR_EOK) {
+		return rc;
 	}
 #endif
 
@@ -672,10 +684,3 @@ void fs_mgmt_register_group(void)
 #endif
 #endif
 }
-
-#ifdef CONFIG_FS_MGMT_FILE_ACCESS_HOOK
-void fs_mgmt_register_evt_cb(fs_mgmt_on_evt_cb cb)
-{
-	fs_evt_cb = cb;
-}
-#endif

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/Kconfig
@@ -84,6 +84,22 @@ config IMG_MGMT_FRUGAL_LIST
 	  a device but requires support in client software, which has to default omitted values.
 	  Works correctly with mcumgr-cli.
 
+config MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK
+	bool "Upload check hook"
+	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS
+	help
+	  This will enable the upload check hook which will send image upload requests to
+	  registered callbacks to check with the user application if an upload should be accepted
+	  or rejected.
+
+config MCUMGR_GRP_IMG_STATUS_HOOKS
+	bool "Status hooks"
+	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS
+	help
+	  This will enable DFU status hooks which can be checked by the application to monitor DFU
+	  uploads. Note that these are status checking only, to allow inspecting of a file upload
+	  or prevent it, CONFIG_MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK must be used.
+
 module = MCUMGR_IMG_MGMT
 module-str = mcumgr_img_mgmt
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -191,53 +192,6 @@ int img_mgmt_state_set_pending(int slot, int permanent);
  * @return 0 on success, non -zero on failure
  */
 int img_mgmt_state_confirm(void);
-
-/** @brief Generic callback function for events */
-typedef void (*img_mgmt_dfu_cb)(void);
-
-/** Callback function pointers */
-struct img_mgmt_dfu_callbacks_t {
-	img_mgmt_dfu_cb dfu_started_cb;
-	img_mgmt_dfu_cb dfu_stopped_cb;
-	img_mgmt_dfu_cb dfu_pending_cb;
-	img_mgmt_dfu_cb dfu_confirmed_cb;
-};
-
-/** @typedef img_mgmt_upload_fn
- * @brief Application callback that is executed when an image upload request is
- * received.
- *
- * The callback's return code determines whether the upload request is accepted
- * or rejected.  If the callback returns 0, processing of the upload request
- * proceeds.  If the callback returns nonzero, the request is rejected with a
- * response containing an `rc` value equal to the return code.
- *
- * @param req		Image upload request structure
- * @param action	Image upload action structure
- *
- * @return	0 if the upload request should be accepted; nonzero to reject
- *		the request with the specified status.
- */
-typedef int (*img_mgmt_upload_fn)(const struct img_mgmt_upload_req req,
-				  const struct img_mgmt_upload_action action);
-
-/**
- * @brief Configures a callback that gets called whenever a valid image upload
- * request is received.
- *
- * The callback's return code determines whether the upload request is accepted
- * or rejected.  If the callback returns 0, processing of the upload request
- * proceeds.  If the callback returns nonzero, the request is rejected with a
- * response containing an `rc` value equal to the return code.
- *
- * @param cb	The callback to execute on rx of an upload request.
- */
-void img_mgmt_set_upload_cb(img_mgmt_upload_fn cb);
-void img_mgmt_register_callbacks(const struct img_mgmt_dfu_callbacks_t *cb_struct);
-void img_mgmt_dfu_stopped(void);
-void img_mgmt_dfu_started(void);
-void img_mgmt_dfu_pending(void);
-void img_mgmt_dfu_confirmed(void);
 
 /**
  * Compares two image version numbers in a semver-compatible way.

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -506,8 +507,11 @@ img_mgmt_upload(struct smp_streamer *ctxt)
 end:
 
 	img_mgmt_upload_log(req.off == 0, g_img_mgmt_state.off == g_img_mgmt_state.size, rc);
-	mgmt_evt(MGMT_EVT_OP_CMD_STATUS, MGMT_GROUP_ID_IMAGE, IMG_MGMT_ID_UPLOAD,
-			 &cmd_status_arg);
+
+#if defined(CONFIG_MCUMGR_SMP_COMMAND_STATUS_HOOKS)
+	(void)mgmt_callback_notify(MGMT_EVT_OP_CMD_STATUS, MGMT_GROUP_ID_IMAGE,
+				   IMG_MGMT_ID_UPLOAD, &cmd_status_arg, false);
+#endif
 
 	if (rc != 0) {
 		img_mgmt_dfu_stopped();

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,6 +20,10 @@
 #include <mgmt/mgmt.h>
 #include "smp/smp.h"
 #include "zcbor_bulk/zcbor_bulk_priv.h"
+
+#ifdef CONFIG_MCUMGR_MGMT_NOTIFICATION_HOOKS
+#include <zephyr/mgmt/mcumgr/mgmt/callbacks.h>
+#endif
 
 /* The value here sets how many "characteristics" that describe image is
  * encoded into a map per each image (like bootable flags, and so on).
@@ -183,7 +188,10 @@ img_mgmt_state_confirm(void)
 		rc = MGMT_ERR_EUNKNOWN;
 	}
 
-	img_mgmt_dfu_confirmed();
+#if defined(CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS)
+	(void)mgmt_callback_notify(MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED, NULL, 0);
+#endif
+
 err:
 	return 0;
 }

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/Kconfig
@@ -19,9 +19,10 @@ config OS_MGMT_RESET_MS
 	  before performing the reset.  This delay allows time for the mcumgr
 	  response to be delivered.
 
-config OS_MGMT_RESET_HOOK
+config MCUMGR_GRP_OS_OS_RESET_HOOK
 	bool "Reset hook"
 	depends on REBOOT
+	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS
 	help
 	  Allows applications to control and get notifications of when a reset
 	  command has been issued via an mcumgr command. With this option

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/include/os_mgmt/os_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/include/os_mgmt/os_mgmt.h
@@ -23,31 +23,10 @@ extern "C" {
 #define OS_MGMT_ID_RESET		5
 #define OS_MGMT_ID_MCUMGR_PARAMS	6
 
-#ifdef CONFIG_OS_MGMT_RESET_HOOK
-/** @typedef os_mgmt_on_reset_evt_cb
- * @brief Function to be called on os mgmt reset event.
- *
- * This callback function is used to notify the application about a pending
- * reset request and to authorise or deny it.
- *
- * @return 0 to allow reset, MGMT_ERR_[...] code to disallow reset.
- */
-typedef int (*os_mgmt_on_reset_evt_cb)(void);
-#endif
-
 /**
  * @brief Registers the OS management command handler group.
  */
 void os_mgmt_register_group(void);
-
-#ifdef CONFIG_OS_MGMT_RESET_HOOK
-/**
- * @brief Register os reset event callback function.
- *
- * @param cb Callback function or NULL to disable.
- */
-void os_mgmt_register_reset_evt_cb(os_mgmt_on_reset_evt_cb cb);
-#endif
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -52,6 +52,7 @@ extern "C" {
 #define MGMT_ERR_ENOTSUP	8	/* Command not supported. */
 #define MGMT_ERR_ECORRUPT	9	/* Corrupt */
 #define MGMT_ERR_EBUSY		10	/* Command blocked by processing of other command */
+#define MGMT_ERR_EACCESSDENIED	11	/* Access to specific function or resource denied */
 #define MGMT_ERR_EPERUSER	256
 
 #define MGMT_HDR_SIZE		8

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -54,39 +55,6 @@ extern "C" {
 #define MGMT_ERR_EPERUSER	256
 
 #define MGMT_HDR_SIZE		8
-
-/*
- * MGMT event opcodes.
- */
-#define MGMT_EVT_OP_CMD_RECV	0x01
-#define MGMT_EVT_OP_CMD_STATUS	0x02
-#define MGMT_EVT_OP_CMD_DONE	0x03
-
-/*
- * MGMT_EVT_OP_CMD_STATUS argument
- */
-struct mgmt_evt_op_cmd_status_arg {
-	int status;
-};
-
-/*
- * MGMT_EVT_OP_CMD_DONE argument
- */
-struct mgmt_evt_op_cmd_done_arg {
-	int err;			/* MGMT_ERR_[...] */
-};
-
-/** @typedef mgmt_on_evt_cb
- * @brief Function to be called on MGMT event.
- *
- * This callback function is used to notify application about mgmt event.
- *
- * @param opcode	MGMT_EVT_OP_[...].
- * @param group		MGMT_GROUP_ID_[...].
- * @param id		Message ID within group.
- * @param arg		Optional event argument.
- */
-typedef void (*mgmt_on_evt_cb)(uint8_t opcode, uint16_t group, uint8_t id, void *arg);
 
 /** @typedef mgmt_alloc_rsp_fn
  * @brief Allocates a buffer suitable for holding a response.
@@ -176,23 +144,6 @@ void mgmt_unregister_group(struct mgmt_group *group);
  *		NULL on failure.
  */
 const struct mgmt_handler *mgmt_find_handler(uint16_t group_id, uint16_t command_id);
-
-/**
- * @brief Register event callback function.
- *
- * @param cb Callback function.
- */
-void mgmt_register_evt_cb(mgmt_on_evt_cb cb);
-
-/**
- * @brief This function is called to notify about mgmt event.
- *
- * @param opcode	MGMT_EVT_OP_[...].
- * @param group		MGMT_GROUP_ID_[...].
- * @param id		Message ID within group.
- * @param arg		Optional event argument.
- */
-void mgmt_evt(uint8_t opcode, uint16_t group, uint8_t id, void *arg);
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
@@ -9,9 +9,17 @@
 #include "mgmt/mgmt.h"
 #include "smp/smp.h"
 
-static mgmt_on_evt_cb evt_cb;
+#ifdef CONFIG_MCUMGR_MGMT_NOTIFICATION_HOOKS
+#include <zephyr/mgmt/mcumgr/mgmt/callbacks.h>
+#endif
+
 static sys_slist_t mgmt_group_list =
 	SYS_SLIST_STATIC_INIT(&mgmt_group_list);
+
+#if defined(CONFIG_MCUMGR_MGMT_NOTIFICATION_HOOKS)
+static sys_slist_t mgmt_callback_list =
+	SYS_SLIST_STATIC_INIT(&mgmt_callback_list);
+#endif
 
 void
 mgmt_unregister_group(struct mgmt_group *group)
@@ -62,16 +70,55 @@ mgmt_register_group(struct mgmt_group *group)
 	sys_slist_append(&mgmt_group_list, &group->node);
 }
 
-void
-mgmt_register_evt_cb(mgmt_on_evt_cb cb)
+#if defined(CONFIG_MCUMGR_MGMT_NOTIFICATION_HOOKS)
+void mgmt_callback_register(struct mgmt_callback *callback)
 {
-	evt_cb = cb;
+	sys_slist_append(&mgmt_callback_list, &callback->node);
 }
 
-void
-mgmt_evt(uint8_t opcode, uint16_t group, uint8_t id, void *arg)
+void mgmt_callback_unregister(struct mgmt_callback *callback)
 {
-	if (evt_cb) {
-		evt_cb(opcode, group, id, arg);
-	}
+	(void)sys_slist_find_and_remove(&mgmt_callback_list, &callback->node);
 }
+
+int32_t mgmt_callback_notify(uint32_t event, void *data, size_t data_size)
+{
+	sys_snode_t *snp, *sns;
+	bool failed = false;
+	bool abort_more = false;
+	int32_t rc;
+	int32_t return_rc = MGMT_ERR_EOK;
+	uint16_t group = MGMT_EVT_GET_GROUP(event);
+
+	/*
+	 * Search through the linked list for entries that have registered for this event and
+	 * notify them, the first handler to return an error code will have this error returned
+	 * to the calling function, errors returned by additional handlers will be ignored. If
+	 * all notification handlers return MGMT_ERR_EOK then access will be allowed and no error
+	 * will be returned to the calling function. The status of if a previous handler has
+	 * returned an error is provided to the functions through the failed variable, and a
+	 * handler function can set abort_more to true to prevent calling any further handlers.
+	 */
+	SYS_SLIST_FOR_EACH_NODE_SAFE(&mgmt_callback_list, snp, sns) {
+		struct mgmt_callback *loop_group =
+			CONTAINER_OF(snp, struct mgmt_callback, node);
+
+		if (loop_group->event_id == event || loop_group->event_id == MGMT_EVT_OP_ALL ||
+		    (MGMT_EVT_GET_GROUP(loop_group->event_id) == group &&
+		     MGMT_EVT_GET_ID(loop_group->event_id) == MGMT_EVT_OP_ID_ALL)) {
+			rc = loop_group->callback(event, return_rc, &abort_more, data, data_size);
+
+			if (rc != MGMT_ERR_EOK && failed == false) {
+				failed = true;
+				return_rc = rc;
+			}
+
+			if (abort_more == true) {
+				break;
+			}
+		}
+	}
+
+	return return_rc;
+}
+#endif


### PR DESCRIPTION
Reworks the event callback system to use a linked list to allow for chained handlers and support passing a status back to the handler to indicate if the request should be rejected or allowed.

- [X] Add slist callback system
- [X] Properly document callback struct
- [X] Convert existing mgmt_evt() calls to new system
- [X] Convert other event notifications to use new system in fs_mgmt
- [X] Convert other event notifications to use new system in img_mgmt
- [X] Convert other event notifications to use new system in os_mgmt
- [X] ~~Convert other event notifications to use new system in shell_mgmt (if any)~~
- [X] ~~Convert other event notifications to use new system in stat_mgmt (if any)~~
- [X] ~~Convert other event notifications to use new system in zephyr_basic (if any)~~
- [X] Add Kconfigs to enable/disable feature
- [X] Size comparison between old/new system
- [X] Add documentation
- [X] Add release notes
- [X] Add migration guide
- [X] Remove old callback code

Fixes #47274
Fixes #45891
Fixes #50923

Size comparison (smp_svr, registers handler, has callback functions that just outputs the provided variables to the LOG):
Old:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      159140 B       256 KB     60.71%
            SRAM:       56980 B       448 KB     12.42%
```
New (all hooks enabled):
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      158804 B       256 KB     60.58%
            SRAM:       56964 B       448 KB     12.42%
```
New (all hooks and notification system disabled):
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      158176 B       256 KB     60.34%
            SRAM:       56956 B       448 KB     12.42%
```