### PR TITLE
samples: usb: dfu: exclude lpcxpresso55s69_cpu0

### DIFF
--- a/samples/subsys/usb/dfu/sample.yaml
+++ b/samples/subsys/usb/dfu/sample.yaml
@@ -6,7 +6,7 @@ common:
   platform_exclude: native_posix native_posix_64 mimxrt1010_evk
     mimxrt1050_evk_qspi mimxrt1020_evk mimxrt1015_evk mimxrt1060_evk sam4l_ek
     mimxrt1050_evk mimxrt1060_evk_hyperflash nucleo_f207zg teensy40 teensy41
-    b_u585i_iot02a frdm_kl25z
+    b_u585i_iot02a frdm_kl25z lpcxpresso55s69_cpu0
   depends_on: usb_device
   filter: dt_label_with_parent_compat_enabled("slot0_partition", "fixed-partitions") and
           dt_label_with_parent_compat_enabled("slot1_partition", "fixed-partitions") and


### PR DESCRIPTION
Exclude lpcxpresso55s69_cpu0 from the USB DFU tests, this triggers a build assert due to unsupported flash write block size (512 bytes, mcuboot supports 8 to 32).

Tested with: `./scripts/twister --all -v -n -M -T samples/subsys/usb/dfu`

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/50538