### PR TITLE
Bluetooth: Controller: Warn LLCP Legacy implementation as DEPRECATED

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -299,7 +299,9 @@ Bluetooth
 
   * Made the new LLCP implementation the default one. Enable
     :kconfig:option:`CONFIG_BT_LL_SW_LLCP_LEGACY` to revert back to the legacy
-    implementation
+    implementation. :kconfig:option:`CONFIG_BT_LL_SW_LLCP_LEGACY` is marked
+    deprecated in favor of the new :kconfig:option:`CONFIG_BT_LL_SW_LLCP`, which
+    is the default now
   * Marked Extended Advertising as stable, no longer experimental
   * Added deinit() infrastructure in order to properly support disabling
     Bluetooth support, including the controller

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -81,8 +81,9 @@ choice BT_LL_SW_LLCP_IMPL
 	  Select the Bluetooth Low Energy Software Link Layer Control Procedure implementation.
 
 config BT_LL_SW_LLCP_LEGACY
-	bool "Legacy implementation"
+	bool "Legacy implementation (DEPRECATED)"
 	depends on !BT_CTLR_DF_CONN_CTE_RX && !BT_CTLR_DF_CONN_CTE_TX
+	select DEPRECATED
 	help
 	  Use the Bluetooth Low Energy Software Link Layer Legacy Control Procedure implementation.
 


### PR DESCRIPTION
Add in Kconfig, select DEPRECATED, to warn at build time that the LLCP legacy implementation is deprecated and the refactored LLCP enabled by BT_LL_SW_LLCP Kconfig option be used instead (which is the default now).

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>