### PR TITLE
soc: x86: Clean up GPIO related defines

### DIFF
--- a/drivers/gpio/gpio_intel.c
+++ b/drivers/gpio/gpio_intel.c
@@ -34,7 +34,6 @@ BUILD_ASSERT(DT_INST_IRQN(0) == 14);
 #define REG_MISCCFG			0x0010
 #define MISCCFG_IRQ_ROUTE_POS		3
 
-#define REG_PAD_OWNER_BASE		0x0020
 #define PAD_OWN_MASK			0x03
 #define PAD_OWN_HOST			0
 #define PAD_OWN_CSME			1
@@ -44,12 +43,10 @@ BUILD_ASSERT(DT_INST_IRQN(0) == 14);
 #define PAD_HOST_SW_OWN_GPIO		1
 #define PAD_HOST_SW_OWN_ACPI		0
 
-#define REG_GPI_INT_STS_BASE		0x0100
 
 #define PAD_CFG0_RXPADSTSEL		BIT(29)
 #define PAD_CFG0_RXRAW1			BIT(28)
 
-#define PAD_CFG0_PMODE_MASK		(0x0F << 10)
 
 #define PAD_CFG0_RXEVCFG_POS		25
 #define PAD_CFG0_RXEVCFG_MASK		(0x03 << PAD_CFG0_RXEVCFG_POS)
@@ -569,11 +566,11 @@ int gpio_intel_init(const struct device *dev)
 
 	isr_devs[nr_isr_devs++] = dev;
 
-	/* route to IRQ 14 */
-
-	sys_bitfield_clear_bit(regs(dev) + REG_MISCCFG,
-			       MISCCFG_IRQ_ROUTE_POS);
-
+	if (IS_ENABLED(CONFIG_SOC_APOLLO_LAKE)) {
+		/* route to IRQ 14 */
+		sys_bitfield_clear_bit(regs(dev) + REG_MISCCFG,
+				       MISCCFG_IRQ_ROUTE_POS);
+	}
 	return 0;
 }
 

--- a/soc/x86/apollo_lake/soc_gpio.h
+++ b/soc/x86/apollo_lake/soc_gpio.h
@@ -15,6 +15,10 @@
 #ifndef __SOC_GPIO_H_
 #define __SOC_GPIO_H_
 
+#define REG_PAD_OWNER_BASE              0x0020
+#define REG_GPI_INT_STS_BASE            0x0100
+#define PAD_CFG0_PMODE_MASK             (0x0F << 10)
+
 #define APL_GPIO_DEV_N_0		DT_NODELABEL(gpio_n_000_031)
 #define APL_GPIO_0			0
 #define APL_GPIO_1			1

--- a/soc/x86/elkhart_lake/soc_gpio.h
+++ b/soc/x86/elkhart_lake/soc_gpio.h
@@ -17,6 +17,10 @@
 
 #define GPIO_INTEL_NR_SUBDEVS		15
 
+#define REG_PAD_OWNER_BASE              0x0020
+#define REG_GPI_INT_STS_BASE            0x0100
+#define PAD_CFG0_PMODE_MASK             (0x0F << 10)
+
 #define REG_PAD_BASE_ADDR		0x000C
 #define REG_GPI_INT_EN_BASE		0x0120
 #define REG_PAD_HOST_SW_OWNER		0x0B0


### PR DESCRIPTION
Clean up and refactor x86 SoC headers in preparation of adding new platforms in the future.

Signed-off-by: Krishna, Anisetti Avinash <anisetti.avinash.krishna@intel.com>