### PR TITLE
doc: remove redundant copyright page

### DIFF
--- a/doc/copyright.rst
+++ b/doc/copyright.rst
@@ -1,9 +1,0 @@
-:orphan:
-
-.. _doc-copyrights:
-
-Documentation Copyrights
-########################
-
-* 2015-2017 Intel Corporation
-* 2015-2017 Wind River Systems, Inc


### PR DESCRIPTION
Copyright page does not contain any useful or updated information. Every Sphinx page is already copyrighted with the message:

> (c) Copyright 2015-2022 Zephyr Project members and individual contributors.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>