### PR TITLE
Bluetooth: host: reword scary warnings

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -300,6 +300,9 @@ config BT_DEBUG_LOG
 	bool "Normal printf-style to console"
 	select BT_DEBUG
 	select LOG
+	imply LOG_FUNC_NAME_PREFIX_INF
+	imply LOG_FUNC_NAME_PREFIX_WRN
+	imply LOG_FUNC_NAME_PREFIX_ERR
 	help
 	  This option enables Bluetooth debug going to standard
 	  serial console.

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3206,7 +3206,7 @@ static struct bt_att_chan *att_chan_new(struct bt_att *att, atomic_val_t flags)
 		}
 
 		if (quota == ATT_CHAN_MAX) {
-			BT_WARN("Maximum number of channels reached: %d", quota);
+			BT_DBG("Maximum number of channels reached: %d", quota);
 			return NULL;
 		}
 	}
@@ -3257,7 +3257,11 @@ static void att_enhanced_connection_work_handler(struct k_work *work)
 	const struct bt_att *att = CONTAINER_OF(dwork, struct bt_att, eatt.connection_work);
 	const int err = bt_eatt_connect(att->conn, att->eatt.chans_to_connect);
 
-	if (err < 0) {
+	if (err == -ENOMEM) {
+		BT_DBG("Failed to connect %d EATT channels, central has probably "
+		       "already established some.",
+		       att->eatt.chans_to_connect);
+	} else if (err < 0) {
 		BT_WARN("Failed to connect %d EATT channels (err: %d)",
 			att->eatt.chans_to_connect, err);
 	}

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4020,7 +4020,7 @@ void bt_data_parse(struct net_buf_simple *ad,
 		}
 
 		if (len > ad->len) {
-			BT_WARN("Malformed data");
+			BT_WARN("malformed advertising data");
 			return;
 		}
 

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2190,7 +2190,7 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		}
 		__fallthrough;
 	default:
-		BT_WARN("Unknown L2CAP PDU code 0x%02x", hdr->code);
+		BT_WARN("Rejecting unknown L2CAP PDU code 0x%02x", hdr->code);
 		l2cap_send_reject(chan->conn, hdr->ident,
 				  BT_L2CAP_REJ_NOT_UNDERSTOOD, NULL, 0);
 		break;

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1464,7 +1464,7 @@ static uint8_t smp_br_pairing_failed(struct bt_smp_br *smp, struct net_buf *buf)
 {
 	struct bt_smp_pairing_fail *req = (void *)buf->data;
 
-	BT_ERR("reason 0x%x", req->reason);
+	BT_ERR("pairing failed (peer reason 0x%x)", req->reason);
 
 	smp_pairing_br_complete(smp, req->reason);
 	smp_br_reset(smp);
@@ -3891,7 +3891,7 @@ static uint8_t smp_pairing_failed(struct bt_smp *smp, struct net_buf *buf)
 	const struct bt_conn_auth_cb *smp_auth_cb = latch_auth_cb(smp);
 	struct bt_smp_pairing_fail *req = (void *)buf->data;
 
-	BT_ERR("reason 0x%x", req->reason);
+	BT_ERR("pairing failed (peer reason 0x%x)", req->reason);
 
 	if (atomic_test_and_clear_bit(smp->flags, SMP_FLAG_USER) ||
 	    atomic_test_and_clear_bit(smp->flags, SMP_FLAG_DISPLAY)) {


### PR DESCRIPTION
This PR downgrades a few stack warnings (to debug level) that should only really be seen by the stack developers and not the end-users.