### PR TITLE
doc: add support for linkcheck 

### DIFF
--- a/boards/arc/em_starterkit/doc/index.rst
+++ b/boards/arc/em_starterkit/doc/index.rst
@@ -310,8 +310,8 @@ Release Notes
 
 The following is a list of TODO items:
 
-* :jira:`GH-2647`: Zephyr needs i-cache API (all targets)
-* :jira:`GH-2230`: Zephyr ARC port doesn't yet support nested regular interrupts.
+* ``GH-2647``: Zephyr needs i-cache API (all targets)
+* ``GH-2230``: Zephyr ARC port doesn't yet support nested regular interrupts.
 * pinmux driver: Possibly it can be written to configure PMods too.
 
 References

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -49,6 +49,7 @@ set(DOCS_DOCTREE_DIR ${CMAKE_CURRENT_BINARY_DIR}/doctrees)
 set(DOCS_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(DOCS_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/src)
 set(DOCS_HTML_DIR ${CMAKE_CURRENT_BINARY_DIR}/html)
+set(DOCS_LINKCHECK_DIR ${CMAKE_CURRENT_BINARY_DIR}/linkcheck)
 set(DOCS_LATEX_DIR ${CMAKE_CURRENT_BINARY_DIR}/latex)
 
 if(WIN32)
@@ -207,6 +208,33 @@ if(LATEX_PDFLATEX_FOUND AND LATEXMK)
 
   add_dependencies(pdf latex)
 endif()
+
+#-------------------------------------------------------------------------------
+# linkcheck
+
+add_doc_target(
+  linkcheck
+  COMMAND ${CMAKE_COMMAND} -E env ${SPHINX_ENV}
+  ${SPHINXBUILD}
+    -b linkcheck
+    -c ${DOCS_CFG_DIR}
+    -d ${DOCS_DOCTREE_DIR}
+    -w ${DOCS_BUILD_DIR}/linkcheck.log
+    -t ${DOC_TAG}
+    ${SPHINXOPTS}
+    ${DOCS_SRC_DIR}
+    ${DOCS_LINKCHECK_DIR}
+  USES_TERMINAL
+  COMMENT "Running Sphinx link check..."
+)
+
+set_target_properties(
+  linkcheck linkcheck-nodeps
+  PROPERTIES
+    ADDITIONAL_CLEAN_FILES "${DOCS_SRC_DIR};${DOCS_LINKCHECK_DIR};${DOCS_DOCTREE_DIR}"
+)
+
+add_dependencies(linkcheck devicetree)
 
 #-------------------------------------------------------------------------------
 # others

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -16,7 +16,7 @@ DT_TURBO_MODE ?= 0
 html-fast:
 	${MAKE} html DT_TURBO_MODE=1
 
-html latex pdf doxygen: configure
+html latex pdf linkcheck doxygen: configure
 	cmake --build ${BUILDDIR} --target $@
 
 configure:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -300,7 +300,6 @@ graphviz_dot_args = [
 # -- Linkcheck options ----------------------------------------------------
 
 extlinks = {
-    "jira": ("https://jira.zephyrproject.org/browse/%s", "JIRA #%s"),
     "github": ("https://github.com/zephyrproject-rtos/zephyr/issues/%s", "GitHub #%s"),
 }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -201,6 +201,12 @@ latex_documents = [
     ("index-tex", "zephyr.tex", "Zephyr Project Documentation", author, "manual"),
 ]
 
+# -- Options for linkcheck ------------------------------------------------
+
+linkcheck_ignore = [
+    r"https://github.com/zephyrproject-rtos/zephyr/issues/.*"
+]
+
 # -- Options for zephyr.doxyrunner plugin ---------------------------------
 
 doxyrunner_doxygen = os.environ.get("DOXYGEN_EXECUTABLE", "doxygen")

--- a/doc/releases/release-notes-1.5.rst
+++ b/doc/releases/release-notes-1.5.rst
@@ -122,166 +122,166 @@ JIRA Related Items
 Stories
 ========
 
-* :jira:`ZEP-49` - x86: unify separate SysV and IAMCU code
-* :jira:`ZEP-55` - enable nanokernel test_context on ARC
-* :jira:`ZEP-58` - investigate use of -fomit-frame-pointer
-* :jira:`ZEP-60` - irq priorities should be rebased to safe values
-* :jira:`ZEP-69` - Extend PWM API to use arbitrary unit of time
-* :jira:`ZEP-203` - clean up APIs for static exceptions
-* :jira:`ZEP-225` - Add kernel API to put SoC to Deep Sleep (DS) State
-* :jira:`ZEP-226` - Update sample PMA to support device suspend/resume
-* :jira:`ZEP-227` - Add kernel API to put SoC to Low Power State (LPS)
-* :jira:`ZEP-228` - File system interface designed after POSIX
-* :jira:`ZEP-232` - Support for USB communications device class ACM
-* :jira:`ZEP-234` - provide a direct memory access (DMA) interface
-* :jira:`ZEP-243` - Create Wiki Structure for Boards
-* :jira:`ZEP-249` - nios2: Enable altera_max10 board in sanitycheck runs for nanokernel
-* :jira:`ZEP-254` - nios2: define NANO_ESF struct and populate _default_esf
-* :jira:`ZEP-270` - nios2: determine optimal value for PERFOPT_ALIGN
-* :jira:`ZEP-271` - nios2: enable microkernel & test cases
-* :jira:`ZEP-272` - nios2: add global pointer support
-* :jira:`ZEP-273` - nios2: implement flashing scripts
-* :jira:`ZEP-274` - nios2: document GDB debugging procedure
-* :jira:`ZEP-275` - nios2: scope support for instruction/data caches
-* :jira:`ZEP-279` - nios2: demonstrate nanokernel hello world
-* :jira:`ZEP-285` - FAT filesystem support on top of SPI Flash
-* :jira:`ZEP-289` - nios2: implement kernel_event_logger
-* :jira:`ZEP-291` - Driver for the ENC28J60 ethernet device
-* :jira:`ZEP-304` - Investigate QEMU support for Nios II
-* :jira:`ZEP-327` - Encryption Libraries needed for Thread support
-* :jira:`ZEP-340` - TLS/SSL
-* :jira:`ZEP-354` - Provide a DMA driver for Quark SE core
-* :jira:`ZEP-356` - DMA device support
-* :jira:`ZEP-357` - Support for the MAX44009 sensor
-* :jira:`ZEP-358` - Add support for TMP112 sensor
-* :jira:`ZEP-412` - Add driver API reentrancy support to RTC driver for LMT
-* :jira:`ZEP-414` - Add driver API reentrancy support to flash driver
-* :jira:`ZEP-415` - aaU, I want to use the NATS messaging protocol to send sensor data to the cloud
-* :jira:`ZEP-416` - MQTT client capability: QoS1, QoS2
-* :jira:`ZEP-424` - AON counter driver needs to add driver API reentrancy support
-* :jira:`ZEP-430` - Add driver API reentrancy support to PWM shim driver
-* :jira:`ZEP-434` - Driver for HMC5883L magnetometer
-* :jira:`ZEP-440` - Add driver API reentrancy support to WDT shim driver
-* :jira:`ZEP-441` - Add driver API reentrancy support to GPIO shim drivers
-* :jira:`ZEP-489` - nios2: handle unimplemented multiply/divide instructions
-* :jira:`ZEP-500` - Domain Name System client library
-* :jira:`ZEP-506` - nios2: support bare metal boot and XIP on Altera MAX10
-* :jira:`ZEP-511` - Add Deep Sleep support in PMA
-* :jira:`ZEP-512` - Add suspend/resume support for some core devices to enable Deep Sleep support in PMA
-* :jira:`ZEP-541` - Integrate QMSI releases to Zephyr
-* :jira:`ZEP-567` - netz sample code
-* :jira:`ZEP-568` - MQTT QoS sample app
-* :jira:`ZEP-573` - IoT applications must use netz API
-* :jira:`ZEP-590` - Update Zephyr's TinyCrypt to version 2.0
-* :jira:`ZEP-643` - Add file system API documentation
-* :jira:`ZEP-650` - Quark SE: Implement PM reference application
-* :jira:`ZEP-652` - QMSI shim driver: RTC: Implement suspend and resume callbacks
-* :jira:`ZEP-655` - QMSI shim driver: PWM: Implement suspend and resume callbacks
-* :jira:`ZEP-658` - QMSI shim driver: GPIO: Implement suspend and resume callbacks
-* :jira:`ZEP-659` - QMSI shim driver: UART: Implement suspend and resume callbacks
-* :jira:`ZEP-662` - QMSI shim driver: Pinmux: Implement suspend and resume callbacks
+* ``ZEP-49`` - x86: unify separate SysV and IAMCU code
+* ``ZEP-55`` - enable nanokernel test_context on ARC
+* ``ZEP-58`` - investigate use of -fomit-frame-pointer
+* ``ZEP-60`` - irq priorities should be rebased to safe values
+* ``ZEP-69`` - Extend PWM API to use arbitrary unit of time
+* ``ZEP-203`` - clean up APIs for static exceptions
+* ``ZEP-225`` - Add kernel API to put SoC to Deep Sleep (DS) State
+* ``ZEP-226`` - Update sample PMA to support device suspend/resume
+* ``ZEP-227`` - Add kernel API to put SoC to Low Power State (LPS)
+* ``ZEP-228`` - File system interface designed after POSIX
+* ``ZEP-232`` - Support for USB communications device class ACM
+* ``ZEP-234`` - provide a direct memory access (DMA) interface
+* ``ZEP-243`` - Create Wiki Structure for Boards
+* ``ZEP-249`` - nios2: Enable altera_max10 board in sanitycheck runs for nanokernel
+* ``ZEP-254`` - nios2: define NANO_ESF struct and populate _default_esf
+* ``ZEP-270`` - nios2: determine optimal value for PERFOPT_ALIGN
+* ``ZEP-271`` - nios2: enable microkernel & test cases
+* ``ZEP-272`` - nios2: add global pointer support
+* ``ZEP-273`` - nios2: implement flashing scripts
+* ``ZEP-274`` - nios2: document GDB debugging procedure
+* ``ZEP-275`` - nios2: scope support for instruction/data caches
+* ``ZEP-279`` - nios2: demonstrate nanokernel hello world
+* ``ZEP-285`` - FAT filesystem support on top of SPI Flash
+* ``ZEP-289`` - nios2: implement kernel_event_logger
+* ``ZEP-291`` - Driver for the ENC28J60 ethernet device
+* ``ZEP-304`` - Investigate QEMU support for Nios II
+* ``ZEP-327`` - Encryption Libraries needed for Thread support
+* ``ZEP-340`` - TLS/SSL
+* ``ZEP-354`` - Provide a DMA driver for Quark SE core
+* ``ZEP-356`` - DMA device support
+* ``ZEP-357`` - Support for the MAX44009 sensor
+* ``ZEP-358`` - Add support for TMP112 sensor
+* ``ZEP-412`` - Add driver API reentrancy support to RTC driver for LMT
+* ``ZEP-414`` - Add driver API reentrancy support to flash driver
+* ``ZEP-415`` - aaU, I want to use the NATS messaging protocol to send sensor data to the cloud
+* ``ZEP-416`` - MQTT client capability: QoS1, QoS2
+* ``ZEP-424`` - AON counter driver needs to add driver API reentrancy support
+* ``ZEP-430`` - Add driver API reentrancy support to PWM shim driver
+* ``ZEP-434`` - Driver for HMC5883L magnetometer
+* ``ZEP-440`` - Add driver API reentrancy support to WDT shim driver
+* ``ZEP-441`` - Add driver API reentrancy support to GPIO shim drivers
+* ``ZEP-489`` - nios2: handle unimplemented multiply/divide instructions
+* ``ZEP-500`` - Domain Name System client library
+* ``ZEP-506`` - nios2: support bare metal boot and XIP on Altera MAX10
+* ``ZEP-511`` - Add Deep Sleep support in PMA
+* ``ZEP-512`` - Add suspend/resume support for some core devices to enable Deep Sleep support in PMA
+* ``ZEP-541`` - Integrate QMSI releases to Zephyr
+* ``ZEP-567`` - netz sample code
+* ``ZEP-568`` - MQTT QoS sample app
+* ``ZEP-573`` - IoT applications must use netz API
+* ``ZEP-590`` - Update Zephyr's TinyCrypt to version 2.0
+* ``ZEP-643`` - Add file system API documentation
+* ``ZEP-650`` - Quark SE: Implement PM reference application
+* ``ZEP-652`` - QMSI shim driver: RTC: Implement suspend and resume callbacks
+* ``ZEP-655`` - QMSI shim driver: PWM: Implement suspend and resume callbacks
+* ``ZEP-658`` - QMSI shim driver: GPIO: Implement suspend and resume callbacks
+* ``ZEP-659`` - QMSI shim driver: UART: Implement suspend and resume callbacks
+* ``ZEP-662`` - QMSI shim driver: Pinmux: Implement suspend and resume callbacks
 
 Epic
 ====
 
-* :jira:`ZEP-278` - Enable Nios II CPU on Altera Max10
-* :jira:`ZEP-284` - Flash Filesystem Support
-* :jira:`ZEP-305` - Device Suspend / Resume infrastructure
-* :jira:`ZEP-306` - PWM Enabling
-* :jira:`ZEP-406` - Drivers shall be re-entrant
+* ``ZEP-278`` - Enable Nios II CPU on Altera Max10
+* ``ZEP-284`` - Flash Filesystem Support
+* ``ZEP-305`` - Device Suspend / Resume infrastructure
+* ``ZEP-306`` - PWM Enabling
+* ``ZEP-406`` - Drivers shall be re-entrant
 
 Bug
 ===
 
-* :jira:`ZEP-68` - Final image contains duplicates of some routines
-* :jira:`ZEP-156` - PWM Set Value API behaves incorrectly
-* :jira:`ZEP-158` - PWM Set Duty Cycle API does not work
-* :jira:`ZEP-180` - make menuconfig user provided options are ignored at building time
-* :jira:`ZEP-187` - BLE APIs are not documented
-* :jira:`ZEP-218` - [drivers/nble][PTS_TEST] Fix responding with the wrong error codes to the Prepare Write Request
-* :jira:`ZEP-221` - [drivers/nble][PTS_TEST] Implement Execute Write Request handler
-* :jira:`ZEP-369` - When building out of the tree, application object files are not placed into outdir
-* :jira:`ZEP-379` - _k_command_stack may be improperly initialized when debugging
-* :jira:`ZEP-384` - D2000 hangs after I2C communication with BMC150 sensor
-* :jira:`ZEP-401` - PWM driver turns off pin if off time is 0 in set_values
-* :jira:`ZEP-423` - Quark D2000 CRB documentation should include instructions to flash bootloader
-* :jira:`ZEP-435` - Ethernet/IPv4/TCP: ip_buf_appdatalen returns wrong values
-* :jira:`ZEP-456` - doc: ``IDT security`` section disappeared
-* :jira:`ZEP-457` - doc: contribute/doxygen/typedefs.rst: examples files are broken
-* :jira:`ZEP-459` - doc: kconfig reference entries in HTML are lacking a title
-* :jira:`ZEP-460` - doc: document parameters of DEVICE* macros
-* :jira:`ZEP-461` - Release 1.4.0 has broken the BMI160 sample as well as an application based on it
-* :jira:`ZEP-463` - Getting started guide "next" link doesn't take you to "Checking Out the Source Code Anonymously" section
-* :jira:`ZEP-469` - Ethernet/IPv4/TCP: net_receive & net_reply in server mode
-* :jira:`ZEP-474` - ND: Neighbor cache is not getting cleared
-* :jira:`ZEP-475` - Issue with timer callback routine: Condition checked is incorrect
-* :jira:`ZEP-478` - Linux setup docs missing step to install curses development package for Fedora
-* :jira:`ZEP-497` - Ethernet/IPv4/TCP: failed to get free buffer
-* :jira:`ZEP-499` - TMP007 driver returns invalid values for negative temperature
-* :jira:`ZEP-514` - memory corruption in microkernel memory pool defrag()
-* :jira:`ZEP-516` - Ubuntu setup instructions missing 'upgrade' step
-* :jira:`ZEP-518` - SPI not working on Arduino101
-* :jira:`ZEP-522` - TCP/client-mode: disconnect
-* :jira:`ZEP-523` - FIFOs defined by DEFINE_FIFO macro use the same memory buffer
-* :jira:`ZEP-525` - srctree changes are breaking applications
-* :jira:`ZEP-526` - build "kernel event logger" sample app failed for BOARD=quark_d2000_crb
-* :jira:`ZEP-534` - Scan for consistent use of "platform/board/SoC" in documentation
-* :jira:`ZEP-537` - doc: create external wiki page "Maintainers"
-* :jira:`ZEP-545` - Wrong default value of CONFIG_ADC_QMSI_SAMPLE_WIDTH for x86 QMSI ADC
-* :jira:`ZEP-547` - [nble] Failed to start encryption after reconnection
-* :jira:`ZEP-554` - samples/drivers/aon_counter check README file
-* :jira:`ZEP-555` - correct libgcc not getting linked for CONFIG_FLOAT=y on ARM
-* :jira:`ZEP-556` - System hangs during I2C transfer
-* :jira:`ZEP-565` - Ethernet/IPv4/TCP: last commits are breaking network support
-* :jira:`ZEP-571` - ARC kernel BAT failed due to race in nested interrupts
-* :jira:`ZEP-572` - X86 kernel BAT failed: Kernel Allocation Failure!
-* :jira:`ZEP-575` - Ethernet/IPv4/UDP: ip_buf_appdatalen returns wrong values
-* :jira:`ZEP-595` - UART: usb simulated uart doesn't work in poll mode
-* :jira:`ZEP-598` - CoAP Link format filtering is not supported
-* :jira:`ZEP-611` - Links on downloads page are not named consistently
-* :jira:`ZEP-616` - OS X setup instructions not working on El Capitan
-* :jira:`ZEP-617` - MQTT samples build fail because netz.h file missing.
-* :jira:`ZEP-621` - samples/static_lib: fatal error: stdio.h: No such file or directory
-* :jira:`ZEP-623` - MQTT sample mqtt.h missing "mqtt_unsubscribe" function
-* :jira:`ZEP-632` - MQTT fail to re-connect to the broker.
-* :jira:`ZEP-633` - samples/usb/cdc_acm: undefined reference to 'uart_qmsi_pm_save_config'
-* :jira:`ZEP-642` - Inconsistent interpretation of pwm_pin_set_values arguments among drivers
-* :jira:`ZEP-645` - ARC QMSI ADC shim driver fails to read sample data
-* :jira:`ZEP-646` - I2C fail to read GY2561 sensor when GY2561 & GY271 sensor are attached to I2C bus.
-* :jira:`ZEP-647` - Power management state storage should use GPS1 instead of GPS0
-* :jira:`ZEP-669` - MQTT fail to pingreq if broker deliver topic to client but client doesn't read it.
-* :jira:`ZEP-673` - Sanity crashes and doesn't kill qemu upon timeout
-* :jira:`ZEP-679` - HMC5883L I2C Register Read Order
-* :jira:`ZEP-681` - MQTT client sample throws too many warnings when build.
-* :jira:`ZEP-687` - docs: Subsystems/Networking section is almost empty
-* :jira:`ZEP-689` - Builds on em_starterkit fail
-* :jira:`ZEP-695` - FatFs doesn't compile using Newlib
-* :jira:`ZEP-697` - samples/net/test_15_4 cannot be built by sanitycheck
-* :jira:`ZEP-703` - USB sample apps are broken after QMSI update
-* :jira:`ZEP-704` - test_atomic does not complete on ARC
-* :jira:`ZEP-708` - tests/kernel/test_ipm fails on Arduino 101
-* :jira:`ZEP-739` - warnings when building samples for quark_se devboard
+* ``ZEP-68`` - Final image contains duplicates of some routines
+* ``ZEP-156`` - PWM Set Value API behaves incorrectly
+* ``ZEP-158`` - PWM Set Duty Cycle API does not work
+* ``ZEP-180`` - make menuconfig user provided options are ignored at building time
+* ``ZEP-187`` - BLE APIs are not documented
+* ``ZEP-218`` - [drivers/nble][PTS_TEST] Fix responding with the wrong error codes to the Prepare Write Request
+* ``ZEP-221`` - [drivers/nble][PTS_TEST] Implement Execute Write Request handler
+* ``ZEP-369`` - When building out of the tree, application object files are not placed into outdir
+* ``ZEP-379`` - _k_command_stack may be improperly initialized when debugging
+* ``ZEP-384`` - D2000 hangs after I2C communication with BMC150 sensor
+* ``ZEP-401`` - PWM driver turns off pin if off time is 0 in set_values
+* ``ZEP-423`` - Quark D2000 CRB documentation should include instructions to flash bootloader
+* ``ZEP-435`` - Ethernet/IPv4/TCP: ip_buf_appdatalen returns wrong values
+* ``ZEP-456` - doc: ``IDT security``` section disappeared
+* ``ZEP-457`` - doc: contribute/doxygen/typedefs.rst: examples files are broken
+* ``ZEP-459`` - doc: kconfig reference entries in HTML are lacking a title
+* ``ZEP-460`` - doc: document parameters of DEVICE* macros
+* ``ZEP-461`` - Release 1.4.0 has broken the BMI160 sample as well as an application based on it
+* ``ZEP-463`` - Getting started guide "next" link doesn't take you to "Checking Out the Source Code Anonymously" section
+* ``ZEP-469`` - Ethernet/IPv4/TCP: net_receive & net_reply in server mode
+* ``ZEP-474`` - ND: Neighbor cache is not getting cleared
+* ``ZEP-475`` - Issue with timer callback routine: Condition checked is incorrect
+* ``ZEP-478`` - Linux setup docs missing step to install curses development package for Fedora
+* ``ZEP-497`` - Ethernet/IPv4/TCP: failed to get free buffer
+* ``ZEP-499`` - TMP007 driver returns invalid values for negative temperature
+* ``ZEP-514`` - memory corruption in microkernel memory pool defrag()
+* ``ZEP-516`` - Ubuntu setup instructions missing 'upgrade' step
+* ``ZEP-518`` - SPI not working on Arduino101
+* ``ZEP-522`` - TCP/client-mode: disconnect
+* ``ZEP-523`` - FIFOs defined by DEFINE_FIFO macro use the same memory buffer
+* ``ZEP-525`` - srctree changes are breaking applications
+* ``ZEP-526`` - build "kernel event logger" sample app failed for BOARD=quark_d2000_crb
+* ``ZEP-534`` - Scan for consistent use of "platform/board/SoC" in documentation
+* ``ZEP-537`` - doc: create external wiki page "Maintainers"
+* ``ZEP-545`` - Wrong default value of CONFIG_ADC_QMSI_SAMPLE_WIDTH for x86 QMSI ADC
+* ``ZEP-547`` - [nble] Failed to start encryption after reconnection
+* ``ZEP-554`` - samples/drivers/aon_counter check README file
+* ``ZEP-555`` - correct libgcc not getting linked for CONFIG_FLOAT=y on ARM
+* ``ZEP-556`` - System hangs during I2C transfer
+* ``ZEP-565`` - Ethernet/IPv4/TCP: last commits are breaking network support
+* ``ZEP-571`` - ARC kernel BAT failed due to race in nested interrupts
+* ``ZEP-572`` - X86 kernel BAT failed: Kernel Allocation Failure!
+* ``ZEP-575`` - Ethernet/IPv4/UDP: ip_buf_appdatalen returns wrong values
+* ``ZEP-595`` - UART: usb simulated uart doesn't work in poll mode
+* ``ZEP-598`` - CoAP Link format filtering is not supported
+* ``ZEP-611`` - Links on downloads page are not named consistently
+* ``ZEP-616`` - OS X setup instructions not working on El Capitan
+* ``ZEP-617`` - MQTT samples build fail because netz.h file missing.
+* ``ZEP-621`` - samples/static_lib: fatal error: stdio.h: No such file or directory
+* ``ZEP-623`` - MQTT sample mqtt.h missing "mqtt_unsubscribe" function
+* ``ZEP-632`` - MQTT fail to re-connect to the broker.
+* ``ZEP-633`` - samples/usb/cdc_acm: undefined reference to 'uart_qmsi_pm_save_config'
+* ``ZEP-642`` - Inconsistent interpretation of pwm_pin_set_values arguments among drivers
+* ``ZEP-645`` - ARC QMSI ADC shim driver fails to read sample data
+* ``ZEP-646`` - I2C fail to read GY2561 sensor when GY2561 & GY271 sensor are attached to I2C bus.
+* ``ZEP-647`` - Power management state storage should use GPS1 instead of GPS0
+* ``ZEP-669`` - MQTT fail to pingreq if broker deliver topic to client but client doesn't read it.
+* ``ZEP-673`` - Sanity crashes and doesn't kill qemu upon timeout
+* ``ZEP-679`` - HMC5883L I2C Register Read Order
+* ``ZEP-681`` - MQTT client sample throws too many warnings when build.
+* ``ZEP-687`` - docs: Subsystems/Networking section is almost empty
+* ``ZEP-689`` - Builds on em_starterkit fail
+* ``ZEP-695`` - FatFs doesn't compile using Newlib
+* ``ZEP-697`` - samples/net/test_15_4 cannot be built by sanitycheck
+* ``ZEP-703`` - USB sample apps are broken after QMSI update
+* ``ZEP-704`` - test_atomic does not complete on ARC
+* ``ZEP-708`` - tests/kernel/test_ipm fails on Arduino 101
+* ``ZEP-739`` - warnings when building samples for quark_se devboard
 
 Known issues
 ============
 
-* :jira:`ZEP-517` - build on windows failed "zephyr/Makefile:869: \*\*\* multiple target patterns"
+* ``ZEP-517`` - build on windows failed "zephyr/Makefile:869: \*\*\* multiple target patterns"
    - No workaround, will fix in future release.
 
-* :jira:`ZEP-711` - I2c: fails to write with mode fast plus
+* ``ZEP-711`` - I2c: fails to write with mode fast plus
    - No workaround need it, there is no support for high speed mode.
 
-* :jira:`ZEP-724` - build on windows failed: 'make: execvp: uname: File or path name too long'
+* ``ZEP-724`` - build on windows failed: 'make: execvp: uname: File or path name too long'
    - No workaround, will fix in future release.
 
-* :jira:`ZEP-467` - Hang using UART and console.
+* ``ZEP-467`` - Hang using UART and console.
    - No workaround, will fix in future release.
 
-* :jira:`ZEP-599` - Periodic call-back function for periodic REST resources is not getting invoked
+* ``ZEP-599`` - Periodic call-back function for periodic REST resources is not getting invoked
    - No workaround, will fix in future release.
 
-* :jira:`ZEP-471` - Ethernet packet with multicast address is not working
+* ``ZEP-471`` - Ethernet packet with multicast address is not working
    - No workaround, will fix in future release.
 
-* :jira:`ZEP-473` - Destination multicast address is not correct
+* ``ZEP-473`` - Destination multicast address is not correct
    - No workaround, will fix in future release.

--- a/doc/releases/release-notes-1.6.rst
+++ b/doc/releases/release-notes-1.6.rst
@@ -172,201 +172,201 @@ Deprecations
 JIRA Related Items
 ******************
 
-* :jira:`ZEP-308` - Build System cleanup and Kernel / Application build separation
-* :jira:`ZEP-334` - Unified Kernel
-* :jira:`ZEP-766` - USB Mass Storage access to internal filesystem
-* :jira:`ZEP-1090` - CPU x86 save/restore using new QMSI bootloader flow
-* :jira:`ZEP-1173` - Add support for bonding remove
-* :jira:`ZEP-48` - define API for interrupt controllers
-* :jira:`ZEP-181` - Persistent storage APIs
-* :jira:`ZEP-233` - Support USB mass storage device class
-* :jira:`ZEP-237` - Support pre-built host tools
-* :jira:`ZEP-240` - printk/printf usage in samples
-* :jira:`ZEP-248` - Add a BOARD/SOC porting guide
-* :jira:`ZEP-342` - USB DFU
-* :jira:`ZEP-451` - Quark SE output by default redirected to IPM
-* :jira:`ZEP-521` - ARM - add choice to floating point ABI selection
-* :jira:`ZEP-546` - UART interrupts not triggered on ARC
-* :jira:`ZEP-584` - warn user if SDK is out of date
-* :jira:`ZEP-592` - Sanitycheck support for multiple toolchains
-* :jira:`ZEP-605` - SMP over BR/EDR
-* :jira:`ZEP-614` - Port TinyCrypt 2.0 test cases to Zephyr
-* :jira:`ZEP-622` - Add FS API to truncate/shrink a file
-* :jira:`ZEP-627` - Port Trickle support from Contiki into current stack
-* :jira:`ZEP-635` - Add FS API to grow a file
-* :jira:`ZEP-636` - Add FS API to get volume total and free space
-* :jira:`ZEP-640` - Remove dynamic IRQs/exceptions from Zephyr
-* :jira:`ZEP-653` - QMSI shim driver: Watchdog: Implement suspend and resume callbacks
-* :jira:`ZEP-654` - QMSI shim driver: I2C: Implement suspend and resume callbacks
-* :jira:`ZEP-657` - QMSI shim driver: AONPT: Implement suspend and resume callbacks
-* :jira:`ZEP-661` - QMSI shim driver: SPI: Implement suspend and resume callbacks
-* :jira:`ZEP-688` - unify duplicated sections of arch linker scripts
-* :jira:`ZEP-715` - Add K64F clock configurations
-* :jira:`ZEP-716` - Add Hexiwear board support
-* :jira:`ZEP-717` - Add ksdk I2C shim driver
-* :jira:`ZEP-718` - Add ksdk ethernet shim driver
-* :jira:`ZEP-721` - Add FXOS8700 accelerometer/magnetometer sensor driver
-* :jira:`ZEP-737` - Update host tools from upstream: fixdep.c
-* :jira:`ZEP-740` - PWM API: Check if 'flags' argument is really required
-* :jira:`ZEP-745` - Revisit design of PWM Driver API
-* :jira:`ZEP-750` - Arduino 101 board should support one configuration using original bootloader
-* :jira:`ZEP-758` - Rename Quark SE Devboard to its official name: Quark SE C1000
-* :jira:`ZEP-767` - Add FS API to flush cache of an open file
-* :jira:`ZEP-775` - Enable USB CDC by default on Arduino 101 and redirect serial to USB
-* :jira:`ZEP-783` - ARM Cortex-M0/M0+ support
-* :jira:`ZEP-784` - Add support for Nordic Semiconductor nRF51822 SoC
-* :jira:`ZEP-850` - remove obsolete boards basic_minuteia and basic_cortex_m3
-* :jira:`ZEP-906` - [unified] Add scheduler time slicing support
-* :jira:`ZEP-907` - Test memory pool support (with mailboxes)
-* :jira:`ZEP-908` - Add task offload to fiber support
-* :jira:`ZEP-909` - Adapt tickless idle + power management for ARM
-* :jira:`ZEP-910` - Adapt tickless idle for x86
-* :jira:`ZEP-912` - Finish renaming kernel object types
-* :jira:`ZEP-916` - Eliminate kernel object API anomalies
-* :jira:`ZEP-920` - Investigate malloc/free support
-* :jira:`ZEP-921` - Miscellaneous documentation work
-* :jira:`ZEP-922` - Revise documentation for Kernel Event Logger
-* :jira:`ZEP-923` - Revise documentation for Timing
-* :jira:`ZEP-924` - Revise documentation for Interrupts
-* :jira:`ZEP-925` - API changes to message queues
-* :jira:`ZEP-926` - API changes to memory pools
-* :jira:`ZEP-927` - API changes to memory maps
-* :jira:`ZEP-928` - API changes to event handling
-* :jira:`ZEP-930` - Cut over to unified kernel
-* :jira:`ZEP-933` - Unified kernel ARC port
-* :jira:`ZEP-934` - NIOS_II port
-* :jira:`ZEP-935` - Kernel logger support (validation)
-* :jira:`ZEP-954` - Update device PM API to allow setting additional power states
-* :jira:`ZEP-957` - Create example sample for new unified kernel API usage
-* :jira:`ZEP-959` - sync checkpatch.pl with upstream Linux
-* :jira:`ZEP-966` - need support for EM7D SOC on em_starterkit
-* :jira:`ZEP-975` - DNS client port to new IP stack
-* :jira:`ZEP-981` - Add doxygen documentation to both include/kernel.h and include/legacy.h
-* :jira:`ZEP-989` - Cache next ready thread instead of finding out the long way
-* :jira:`ZEP-993` - Quark SE (x86): Refactor save/restore execution context feature
-* :jira:`ZEP-994` - Quark SE (ARC): Add PMA sample
-* :jira:`ZEP-996` - Refactor save/restore feature from i2c_qmsi driver
-* :jira:`ZEP-997` - Refactor save/restore feature from spi_qmsi driver
-* :jira:`ZEP-998` - Refactor save/restore feature from uart_qmsi driver
-* :jira:`ZEP-999` - Refactor save/restore feature from gpio_qmsi driver
-* :jira:`ZEP-1000` - Refactor save/restore feature from rtc_qmsi driver
-* :jira:`ZEP-1001` - Refactor save/restore feature from wdt_qmsi driver
-* :jira:`ZEP-1002` - Refactor save/restore feature from counter_qmsi_aonpt driver
-* :jira:`ZEP-1004` - Extend counter_qmsi_aon driver to support save/restore peripheral context
-* :jira:`ZEP-1005` - Extend dma_qmsi driver to support save/restore peripheral context
-* :jira:`ZEP-1006` - Extend soc_flash_qmsi driver to support save/restore peripheral context
-* :jira:`ZEP-1008` - Extend pwm_qmsi driver to support save/restore peripheral context
-* :jira:`ZEP-1023` - workq in Kernel primer for unified kernel
-* :jira:`ZEP-1030` - Enable QMSI shim drivers of SoC peripherals on the sensor subsystem
-* :jira:`ZEP-1043` - Update QMSI to 1.2
-* :jira:`ZEP-1045` - Add/Enhance shim layer to wrap SOC specific PM implementations
-* :jira:`ZEP-1046` - Implement RAM sharing between bootloader and Zephyr
-* :jira:`ZEP-1047` - Adapt to new PM related boot flow changes in QMSI boot loader
-* :jira:`ZEP-1106` - Fix all test failures from TCF
-* :jira:`ZEP-1107` - Update QMSI to 1.3
-* :jira:`ZEP-1109` - Texas Instruments CC3200 LaunchXL Support
-* :jira:`ZEP-1119` - move top level usb/ to sys/usb
-* :jira:`ZEP-1120` - move top level fs/ to sys/fs
-* :jira:`ZEP-1121` - Add config support for enabling SoCWatch in Zephyr
-* :jira:`ZEP-1140` - Add a unified kernel version of power_mgr sample app for testing PM code with the new kernel
-* :jira:`ZEP-1188` - Add an API to retrieve pending interrupts for wake events
-* :jira:`ZEP-1191` - Create wiki page for Hexiwear board
-* :jira:`ZEP-1235` - Basic shell support for file system browsing
-* :jira:`ZEP-1245` - ARM LTD V2M Beetle Support
-* :jira:`ZEP-1313` - porting and user guides must include a security section
-* :jira:`ZEP-1386` - Revise power management document to reflect latest changes
-* :jira:`ZEP-199` - Zephyr driver model is undocumented
-* :jira:`ZEP-436` - Test case tests/kernel/test_mem_safe fails on ARM hardware
-* :jira:`ZEP-471` - Ethernet packet with multicast address is not working
-* :jira:`ZEP-472` - Ethernet packets are getting missed if sent in quick succession.
-* :jira:`ZEP-517` - build on windows failed "zephyr/Makefile:869: \*\*\* multiple target patterns"
-* :jira:`ZEP-528` - ARC has 2 almost identical copies of the linker script
-* :jira:`ZEP-577` - Sample application source does not compile on Windows
-* :jira:`ZEP-601` - enable CONFIG_DEBUG_INFO
-* :jira:`ZEP-602` - unhandled CPU exceptions/interrupts report wrong faulting vector if triggered by CPU
-* :jira:`ZEP-615` - Un-supported flash erase size listed in SPI flash w25qxxdv driver header file
-* :jira:`ZEP-639` - device_pm_ops structure should be defined as static
-* :jira:`ZEP-686` - docs: Info in "Application Development Primer" and "Developing an Application and the Build System" is largely duplicated
-* :jira:`ZEP-698` - samples/task_profiler issues
-* :jira:`ZEP-707` - mem_safe test stomps on top of .data and bottom of .noinit
-* :jira:`ZEP-724` - build on windows failed: 'make: execvp: uname: File or path name too long'
-* :jira:`ZEP-733` - Minimal libc shouldn't be providing stddef.h
-* :jira:`ZEP-762` - unexpected "abspath" and "notdir" from mingw make system
-* :jira:`ZEP-777` - samples/driver/i2c_stts751: kconfig build warning from "select DMA_QMSI"
-* :jira:`ZEP-778` - Samples/drivers/i2c_lsm9ds0: kconfig build warning from "select DMA_QMSI"
-* :jira:`ZEP-779` - Using current MinGW gcc version 5.3.0 breaks Zephyr build on Windows
-* :jira:`ZEP-845` - UART for ARC on Arduino 101 behaves unexpectedly
-* :jira:`ZEP-905` - hello_world compilation for arduino_due target fails when using CROSS_COMPILE
-* :jira:`ZEP-940` - Fail to get ATT response
-* :jira:`ZEP-950` - USB: Device is not listed by USB20CV test suite
-* :jira:`ZEP-961` - samples: other cases cannot execute after run aon_counter case
-* :jira:`ZEP-967` - Sanity doesn't build 'samples/usb/dfu' with assertions (-R)
-* :jira:`ZEP-970` - Sanity doesn't build 'tests/kernel/test_build' with assertions (-R)
-* :jira:`ZEP-982` - Minimal libc has EWOULDBLOCK != EAGAIN
-* :jira:`ZEP-1014` - [TCF] tests/bluetooth/init build fail
-* :jira:`ZEP-1025` - Unified kernel build sometimes breaks on a missing .d dependency file.
-* :jira:`ZEP-1027` - Documentation for GCC ARM is not accurate
-* :jira:`ZEP-1031` - qmsi: dma: driver test fails with LLVM
-* :jira:`ZEP-1048` - grove_lcd sample: sample does not work if you disable serial
-* :jira:`ZEP-1051` - mpool allocation failed after defrag twice...
-* :jira:`ZEP-1062` - Unified kernel isn't compatible with CONFIG_NEWLIB_LIBC
-* :jira:`ZEP-1074` - ATT retrying misbehaves when ATT insufficient Authentication is received
-* :jira:`ZEP-1076` - "samples/philosophers/unified" build failed with dynamic stack
-* :jira:`ZEP-1077` - "samples/philosophers/unified" build warnings with NUM_PHIL<6
-* :jira:`ZEP-1079` - Licensing not clear for imported components
-* :jira:`ZEP-1097` - ENC28J60 driver fails on concurrent tx and rx
-* :jira:`ZEP-1098` - ENC28J60 fails to receive big data frames
-* :jira:`ZEP-1100` - Current master still identifies itself as 1.5.0
-* :jira:`ZEP-1101` - SYS_KERNEL_VER_PATCHLEVEL() and friends artificially limit version numbers to 4 bits
-* :jira:`ZEP-1124` - tests/kernel/test_sprintf/microkernel/testcase.ini#test failure on frdm_k64f
-* :jira:`ZEP-1130` - region 'RAM' overflowed occurs while building test_hmac_prng
-* :jira:`ZEP-1138` - Received packets not being passed to upper layer from IP stack when using ENC28J60 driver
-* :jira:`ZEP-1139` - Fix build error when power management is built with unified kernel
-* :jira:`ZEP-1141` - TinyCrypt SHA256 test fails with system crash using unified kernel type
-* :jira:`ZEP-1144` - TinyCrypt AES128 fixed-key with variable-text test fails using unified kernel type
-* :jira:`ZEP-1145` - system hang after TinyCrypt HMAC test
-* :jira:`ZEP-1146` - zephyrproject.org home page needs technical scrub for 1.6 release
-* :jira:`ZEP-1149` - port ztest framework to unified kernel
-* :jira:`ZEP-1154` - tests/samples failing with unified kernel
-* :jira:`ZEP-1155` - Fix filesystem API namespace
-* :jira:`ZEP-1163` - LIB_INCLUDE_DIR is clobbered in Makefile second pass
-* :jira:`ZEP-1164` - ztest skip waiting the test case to finish its execution
-* :jira:`ZEP-1179` - Build issues when compiling with LLVM from ISSM (icx)
-* :jira:`ZEP-1182` - kernel.h doxygen show unexpected "asm" blocks
-* :jira:`ZEP-1183` - btshell return "panic: errcode -1" when init bt
-* :jira:`ZEP-1195` - Wrong ATT error code passed to the application
-* :jira:`ZEP-1199` - [L2CAP] No credits to receive packet
-* :jira:`ZEP-1219` - [L2CAP] Data sent exceeds maximum PDU size
-* :jira:`ZEP-1221` - Connection Timeout during pairing
-* :jira:`ZEP-1226` - cortex M7 port assembler error
-* :jira:`ZEP-1227` - ztest native testing not working in unified kernel
-* :jira:`ZEP-1232` - Daily build is failing asserts
-* :jira:`ZEP-1234` - Removal of fiber* APIs due to unified migration breaks USB mass storage patchset
-* :jira:`ZEP-1247` - Test tests/legacy/benchmark/latency_measure is broken for daily sanitycheck
-* :jira:`ZEP-1252` - Test test_chan_blen_transfer does not build for quark_d2000_crb
-* :jira:`ZEP-1277` - Flash driver (w25qxxdv) erase function is not checking for offset alignment
-* :jira:`ZEP-1278` - Incorrect boundary check in flash driver (w25qxxdv) for erase offset
-* :jira:`ZEP-1287` - ARC SPI 1 Port is not working
-* :jira:`ZEP-1289` - Race condition with k_sem_take
-* :jira:`ZEP-1291` - libzephyr.a dependency on phony "gcc" target
-* :jira:`ZEP-1293` - ENC28J60 driver doesn't work on Arduino 101
-* :jira:`ZEP-1295` - incorrect doxygen comment in kernel.h:k_work_pending()
-* :jira:`ZEP-1297` - test/legacy/kernel/test_mail: failure on ARC platforms
-* :jira:`ZEP-1299` - System can't resume completely with DMA suspend and resume operation
-* :jira:`ZEP-1302` - ENC28J60 fails with rx/tx of long frames
-* :jira:`ZEP-1303` - Configuration talks about >32 thread prios, but the kernel does not support it
-* :jira:`ZEP-1309` - ARM uses the end of memory for its init stack
-* :jira:`ZEP-1310` - ARC uses the end of memory for its init stack
-* :jira:`ZEP-1312` - ARC: software crashed at k_mbox_get() with async sending a message
-* :jira:`ZEP-1319` - Zephyr is unable to compile when CONFIG_RUNTIME_NMI is enabled on ARM platforms
-* :jira:`ZEP-1341` - power_states test app passes wrong value as power state to post_ops functions
-* :jira:`ZEP-1343` - tests/drivers/pci_enum: failing on QEMU ARM and X86 due to missing commit
-* :jira:`ZEP-1345` - cpu context save and restore could corrupt stack
-* :jira:`ZEP-1349` - ARC sleep needs to pass interrupt priority threshold when interrupts are enabled
-* :jira:`ZEP-1353` - FDRM k64f Console output broken on normal flash mode
+* ``ZEP-308`` - Build System cleanup and Kernel / Application build separation
+* ``ZEP-334`` - Unified Kernel
+* ``ZEP-766`` - USB Mass Storage access to internal filesystem
+* ``ZEP-1090`` - CPU x86 save/restore using new QMSI bootloader flow
+* ``ZEP-1173`` - Add support for bonding remove
+* ``ZEP-48`` - define API for interrupt controllers
+* ``ZEP-181`` - Persistent storage APIs
+* ``ZEP-233`` - Support USB mass storage device class
+* ``ZEP-237`` - Support pre-built host tools
+* ``ZEP-240`` - printk/printf usage in samples
+* ``ZEP-248`` - Add a BOARD/SOC porting guide
+* ``ZEP-342`` - USB DFU
+* ``ZEP-451`` - Quark SE output by default redirected to IPM
+* ``ZEP-521`` - ARM - add choice to floating point ABI selection
+* ``ZEP-546`` - UART interrupts not triggered on ARC
+* ``ZEP-584`` - warn user if SDK is out of date
+* ``ZEP-592`` - Sanitycheck support for multiple toolchains
+* ``ZEP-605`` - SMP over BR/EDR
+* ``ZEP-614`` - Port TinyCrypt 2.0 test cases to Zephyr
+* ``ZEP-622`` - Add FS API to truncate/shrink a file
+* ``ZEP-627`` - Port Trickle support from Contiki into current stack
+* ``ZEP-635`` - Add FS API to grow a file
+* ``ZEP-636`` - Add FS API to get volume total and free space
+* ``ZEP-640`` - Remove dynamic IRQs/exceptions from Zephyr
+* ``ZEP-653`` - QMSI shim driver: Watchdog: Implement suspend and resume callbacks
+* ``ZEP-654`` - QMSI shim driver: I2C: Implement suspend and resume callbacks
+* ``ZEP-657`` - QMSI shim driver: AONPT: Implement suspend and resume callbacks
+* ``ZEP-661`` - QMSI shim driver: SPI: Implement suspend and resume callbacks
+* ``ZEP-688`` - unify duplicated sections of arch linker scripts
+* ``ZEP-715`` - Add K64F clock configurations
+* ``ZEP-716`` - Add Hexiwear board support
+* ``ZEP-717`` - Add ksdk I2C shim driver
+* ``ZEP-718`` - Add ksdk ethernet shim driver
+* ``ZEP-721`` - Add FXOS8700 accelerometer/magnetometer sensor driver
+* ``ZEP-737`` - Update host tools from upstream: fixdep.c
+* ``ZEP-740`` - PWM API: Check if 'flags' argument is really required
+* ``ZEP-745`` - Revisit design of PWM Driver API
+* ``ZEP-750`` - Arduino 101 board should support one configuration using original bootloader
+* ``ZEP-758`` - Rename Quark SE Devboard to its official name: Quark SE C1000
+* ``ZEP-767`` - Add FS API to flush cache of an open file
+* ``ZEP-775`` - Enable USB CDC by default on Arduino 101 and redirect serial to USB
+* ``ZEP-783`` - ARM Cortex-M0/M0+ support
+* ``ZEP-784`` - Add support for Nordic Semiconductor nRF51822 SoC
+* ``ZEP-850`` - remove obsolete boards basic_minuteia and basic_cortex_m3
+* ``ZEP-906`` - [unified] Add scheduler time slicing support
+* ``ZEP-907`` - Test memory pool support (with mailboxes)
+* ``ZEP-908`` - Add task offload to fiber support
+* ``ZEP-909`` - Adapt tickless idle + power management for ARM
+* ``ZEP-910`` - Adapt tickless idle for x86
+* ``ZEP-912`` - Finish renaming kernel object types
+* ``ZEP-916`` - Eliminate kernel object API anomalies
+* ``ZEP-920`` - Investigate malloc/free support
+* ``ZEP-921`` - Miscellaneous documentation work
+* ``ZEP-922`` - Revise documentation for Kernel Event Logger
+* ``ZEP-923`` - Revise documentation for Timing
+* ``ZEP-924`` - Revise documentation for Interrupts
+* ``ZEP-925`` - API changes to message queues
+* ``ZEP-926`` - API changes to memory pools
+* ``ZEP-927`` - API changes to memory maps
+* ``ZEP-928`` - API changes to event handling
+* ``ZEP-930`` - Cut over to unified kernel
+* ``ZEP-933`` - Unified kernel ARC port
+* ``ZEP-934`` - NIOS_II port
+* ``ZEP-935`` - Kernel logger support (validation)
+* ``ZEP-954`` - Update device PM API to allow setting additional power states
+* ``ZEP-957`` - Create example sample for new unified kernel API usage
+* ``ZEP-959`` - sync checkpatch.pl with upstream Linux
+* ``ZEP-966`` - need support for EM7D SOC on em_starterkit
+* ``ZEP-975`` - DNS client port to new IP stack
+* ``ZEP-981`` - Add doxygen documentation to both include/kernel.h and include/legacy.h
+* ``ZEP-989`` - Cache next ready thread instead of finding out the long way
+* ``ZEP-993`` - Quark SE (x86): Refactor save/restore execution context feature
+* ``ZEP-994`` - Quark SE (ARC): Add PMA sample
+* ``ZEP-996`` - Refactor save/restore feature from i2c_qmsi driver
+* ``ZEP-997`` - Refactor save/restore feature from spi_qmsi driver
+* ``ZEP-998`` - Refactor save/restore feature from uart_qmsi driver
+* ``ZEP-999`` - Refactor save/restore feature from gpio_qmsi driver
+* ``ZEP-1000`` - Refactor save/restore feature from rtc_qmsi driver
+* ``ZEP-1001`` - Refactor save/restore feature from wdt_qmsi driver
+* ``ZEP-1002`` - Refactor save/restore feature from counter_qmsi_aonpt driver
+* ``ZEP-1004`` - Extend counter_qmsi_aon driver to support save/restore peripheral context
+* ``ZEP-1005`` - Extend dma_qmsi driver to support save/restore peripheral context
+* ``ZEP-1006`` - Extend soc_flash_qmsi driver to support save/restore peripheral context
+* ``ZEP-1008`` - Extend pwm_qmsi driver to support save/restore peripheral context
+* ``ZEP-1023`` - workq in Kernel primer for unified kernel
+* ``ZEP-1030`` - Enable QMSI shim drivers of SoC peripherals on the sensor subsystem
+* ``ZEP-1043`` - Update QMSI to 1.2
+* ``ZEP-1045`` - Add/Enhance shim layer to wrap SOC specific PM implementations
+* ``ZEP-1046`` - Implement RAM sharing between bootloader and Zephyr
+* ``ZEP-1047`` - Adapt to new PM related boot flow changes in QMSI boot loader
+* ``ZEP-1106`` - Fix all test failures from TCF
+* ``ZEP-1107`` - Update QMSI to 1.3
+* ``ZEP-1109`` - Texas Instruments CC3200 LaunchXL Support
+* ``ZEP-1119`` - move top level usb/ to sys/usb
+* ``ZEP-1120`` - move top level fs/ to sys/fs
+* ``ZEP-1121`` - Add config support for enabling SoCWatch in Zephyr
+* ``ZEP-1140`` - Add a unified kernel version of power_mgr sample app for testing PM code with the new kernel
+* ``ZEP-1188`` - Add an API to retrieve pending interrupts for wake events
+* ``ZEP-1191`` - Create wiki page for Hexiwear board
+* ``ZEP-1235`` - Basic shell support for file system browsing
+* ``ZEP-1245`` - ARM LTD V2M Beetle Support
+* ``ZEP-1313`` - porting and user guides must include a security section
+* ``ZEP-1386`` - Revise power management document to reflect latest changes
+* ``ZEP-199`` - Zephyr driver model is undocumented
+* ``ZEP-436`` - Test case tests/kernel/test_mem_safe fails on ARM hardware
+* ``ZEP-471`` - Ethernet packet with multicast address is not working
+* ``ZEP-472`` - Ethernet packets are getting missed if sent in quick succession.
+* ``ZEP-517`` - build on windows failed "zephyr/Makefile:869: \*\*\* multiple target patterns"
+* ``ZEP-528`` - ARC has 2 almost identical copies of the linker script
+* ``ZEP-577`` - Sample application source does not compile on Windows
+* ``ZEP-601`` - enable CONFIG_DEBUG_INFO
+* ``ZEP-602`` - unhandled CPU exceptions/interrupts report wrong faulting vector if triggered by CPU
+* ``ZEP-615`` - Un-supported flash erase size listed in SPI flash w25qxxdv driver header file
+* ``ZEP-639`` - device_pm_ops structure should be defined as static
+* ``ZEP-686`` - docs: Info in "Application Development Primer" and "Developing an Application and the Build System" is largely duplicated
+* ``ZEP-698`` - samples/task_profiler issues
+* ``ZEP-707`` - mem_safe test stomps on top of .data and bottom of .noinit
+* ``ZEP-724`` - build on windows failed: 'make: execvp: uname: File or path name too long'
+* ``ZEP-733`` - Minimal libc shouldn't be providing stddef.h
+* ``ZEP-762`` - unexpected "abspath" and "notdir" from mingw make system
+* ``ZEP-777`` - samples/driver/i2c_stts751: kconfig build warning from "select DMA_QMSI"
+* ``ZEP-778`` - Samples/drivers/i2c_lsm9ds0: kconfig build warning from "select DMA_QMSI"
+* ``ZEP-779`` - Using current MinGW gcc version 5.3.0 breaks Zephyr build on Windows
+* ``ZEP-845`` - UART for ARC on Arduino 101 behaves unexpectedly
+* ``ZEP-905`` - hello_world compilation for arduino_due target fails when using CROSS_COMPILE
+* ``ZEP-940`` - Fail to get ATT response
+* ``ZEP-950`` - USB: Device is not listed by USB20CV test suite
+* ``ZEP-961`` - samples: other cases cannot execute after run aon_counter case
+* ``ZEP-967`` - Sanity doesn't build 'samples/usb/dfu' with assertions (-R)
+* ``ZEP-970`` - Sanity doesn't build 'tests/kernel/test_build' with assertions (-R)
+* ``ZEP-982`` - Minimal libc has EWOULDBLOCK != EAGAIN
+* ``ZEP-1014`` - [TCF] tests/bluetooth/init build fail
+* ``ZEP-1025`` - Unified kernel build sometimes breaks on a missing .d dependency file.
+* ``ZEP-1027`` - Documentation for GCC ARM is not accurate
+* ``ZEP-1031`` - qmsi: dma: driver test fails with LLVM
+* ``ZEP-1048`` - grove_lcd sample: sample does not work if you disable serial
+* ``ZEP-1051`` - mpool allocation failed after defrag twice...
+* ``ZEP-1062`` - Unified kernel isn't compatible with CONFIG_NEWLIB_LIBC
+* ``ZEP-1074`` - ATT retrying misbehaves when ATT insufficient Authentication is received
+* ``ZEP-1076`` - "samples/philosophers/unified" build failed with dynamic stack
+* ``ZEP-1077`` - "samples/philosophers/unified" build warnings with NUM_PHIL<6
+* ``ZEP-1079`` - Licensing not clear for imported components
+* ``ZEP-1097`` - ENC28J60 driver fails on concurrent tx and rx
+* ``ZEP-1098`` - ENC28J60 fails to receive big data frames
+* ``ZEP-1100`` - Current master still identifies itself as 1.5.0
+* ``ZEP-1101`` - SYS_KERNEL_VER_PATCHLEVEL() and friends artificially limit version numbers to 4 bits
+* ``ZEP-1124`` - tests/kernel/test_sprintf/microkernel/testcase.ini#test failure on frdm_k64f
+* ``ZEP-1130`` - region 'RAM' overflowed occurs while building test_hmac_prng
+* ``ZEP-1138`` - Received packets not being passed to upper layer from IP stack when using ENC28J60 driver
+* ``ZEP-1139`` - Fix build error when power management is built with unified kernel
+* ``ZEP-1141`` - TinyCrypt SHA256 test fails with system crash using unified kernel type
+* ``ZEP-1144`` - TinyCrypt AES128 fixed-key with variable-text test fails using unified kernel type
+* ``ZEP-1145`` - system hang after TinyCrypt HMAC test
+* ``ZEP-1146`` - zephyrproject.org home page needs technical scrub for 1.6 release
+* ``ZEP-1149`` - port ztest framework to unified kernel
+* ``ZEP-1154`` - tests/samples failing with unified kernel
+* ``ZEP-1155`` - Fix filesystem API namespace
+* ``ZEP-1163`` - LIB_INCLUDE_DIR is clobbered in Makefile second pass
+* ``ZEP-1164`` - ztest skip waiting the test case to finish its execution
+* ``ZEP-1179`` - Build issues when compiling with LLVM from ISSM (icx)
+* ``ZEP-1182`` - kernel.h doxygen show unexpected "asm" blocks
+* ``ZEP-1183`` - btshell return "panic: errcode -1" when init bt
+* ``ZEP-1195`` - Wrong ATT error code passed to the application
+* ``ZEP-1199`` - [L2CAP] No credits to receive packet
+* ``ZEP-1219`` - [L2CAP] Data sent exceeds maximum PDU size
+* ``ZEP-1221`` - Connection Timeout during pairing
+* ``ZEP-1226`` - cortex M7 port assembler error
+* ``ZEP-1227`` - ztest native testing not working in unified kernel
+* ``ZEP-1232`` - Daily build is failing asserts
+* ``ZEP-1234`` - Removal of fiber* APIs due to unified migration breaks USB mass storage patchset
+* ``ZEP-1247`` - Test tests/legacy/benchmark/latency_measure is broken for daily sanitycheck
+* ``ZEP-1252`` - Test test_chan_blen_transfer does not build for quark_d2000_crb
+* ``ZEP-1277`` - Flash driver (w25qxxdv) erase function is not checking for offset alignment
+* ``ZEP-1278`` - Incorrect boundary check in flash driver (w25qxxdv) for erase offset
+* ``ZEP-1287`` - ARC SPI 1 Port is not working
+* ``ZEP-1289`` - Race condition with k_sem_take
+* ``ZEP-1291`` - libzephyr.a dependency on phony "gcc" target
+* ``ZEP-1293`` - ENC28J60 driver doesn't work on Arduino 101
+* ``ZEP-1295`` - incorrect doxygen comment in kernel.h:k_work_pending()
+* ``ZEP-1297`` - test/legacy/kernel/test_mail: failure on ARC platforms
+* ``ZEP-1299`` - System can't resume completely with DMA suspend and resume operation
+* ``ZEP-1302`` - ENC28J60 fails with rx/tx of long frames
+* ``ZEP-1303`` - Configuration talks about >32 thread prios, but the kernel does not support it
+* ``ZEP-1309`` - ARM uses the end of memory for its init stack
+* ``ZEP-1310`` - ARC uses the end of memory for its init stack
+* ``ZEP-1312`` - ARC: software crashed at k_mbox_get() with async sending a message
+* ``ZEP-1319`` - Zephyr is unable to compile when CONFIG_RUNTIME_NMI is enabled on ARM platforms
+* ``ZEP-1341`` - power_states test app passes wrong value as power state to post_ops functions
+* ``ZEP-1343`` - tests/drivers/pci_enum: failing on QEMU ARM and X86 due to missing commit
+* ``ZEP-1345`` - cpu context save and restore could corrupt stack
+* ``ZEP-1349`` - ARC sleep needs to pass interrupt priority threshold when interrupts are enabled
+* ``ZEP-1353`` - FDRM k64f Console output broken on normal flash mode
 
 Known Issues
 ************
 
-* :jira:`ZEP-1405` - function l2cap_br_conn_req in /subsys/bluetooth/host/l2cap_br.c
+* ``ZEP-1405`` - function l2cap_br_conn_req in /subsys/bluetooth/host/l2cap_br.c
   references uninitialized pointer

--- a/doc/releases/release-notes-1.7.rst
+++ b/doc/releases/release-notes-1.7.rst
@@ -156,301 +156,301 @@ JIRA Related Items
 
 .. comment  List derived from https://jira.zephyrproject.org/issues/?filter=10345
 
-* :jira:`ZEP-19` - IPSP node support
-* :jira:`ZEP-145` - no 'make flash' for Arduino Due
-* :jira:`ZEP-328` - HW Encryption Abstraction
-* :jira:`ZEP-359` - Move QEMU handling to a central location
-* :jira:`ZEP-365` - Zephyr's MQTT library
-* :jira:`ZEP-437` - TCP/IP API
-* :jira:`ZEP-513` - extern declarations of  small microkernel objects in designated sections require __attribute__((section)) in gp-enabled systems
-* :jira:`ZEP-591` - MQTT Port to New IP Stack
-* :jira:`ZEP-604` - In coap_server sample app, CoAP resource separate is not able to send separate response
-* :jira:`ZEP-613` - TCP/UDP client and server mode functionality
-* :jira:`ZEP-641` - Bluetooth Eddystone sample does not correctly implement Eddystone beacon
-* :jira:`ZEP-648` - New CoAP Implementation
-* :jira:`ZEP-664` - Extend spi_qmsi_ss driver to support save/restore peripheral context
-* :jira:`ZEP-665` - Extend gpio_qmsi_ss driver to support save/restore peripheral context
-* :jira:`ZEP-666` - Extend i2c_qmsi_ss driver to support save/restore peripheral context
-* :jira:`ZEP-667` - Extend adc_qmsi_ss driver to support save/restore peripheral context
-* :jira:`ZEP-686` - docs: Info in Application Development Primer and Developing an Application and the Build System is largely duplicated
-* :jira:`ZEP-706` - cannot set debug breakpoints on ARC side of Arduino 101
-* :jira:`ZEP-719` - Add ksdk uart shim driver
-* :jira:`ZEP-734` - Port AES-CMAC-PRF-128 [RFC 4615] encryption library for Thread support
-* :jira:`ZEP-742` - nRF5x Series: System Clock driver using NRF_RTC
-* :jira:`ZEP-744` - USB WebUSB
-* :jira:`ZEP-748` - Enable mbedtls_sslclient sample to run on quark se board
-* :jira:`ZEP-759` - Add preliminary support for Atmel SAM E70 (Cortex-M7) chipset family and SAM E70 Xplained board
-* :jira:`ZEP-788` - UDP
-* :jira:`ZEP-789` - IPv4
-* :jira:`ZEP-790` - ICMPv4
-* :jira:`ZEP-791` - TCP
-* :jira:`ZEP-792` - ARP
-* :jira:`ZEP-793` - DNS Resolver
-* :jira:`ZEP-794` - Requirements for Internet Hosts - Communication Layers
-* :jira:`ZEP-796` - DHCPv4
-* :jira:`ZEP-798` - IPv6
-* :jira:`ZEP-799` - HTTP over TLS
-* :jira:`ZEP-801` - DNS Extensions to support IPv6
-* :jira:`ZEP-804` - IPv6 Addressing Architecture
-* :jira:`ZEP-805` - Internet Control Message Protocol (ICMP) v6
-* :jira:`ZEP-807` - Neighbor Discovery for IPv6
-* :jira:`ZEP-808` - IPv6 Stateless Autoconfiguration (SLAAC)
-* :jira:`ZEP-809` - IPv6 over 802.15.4
-* :jira:`ZEP-811` - The Trickle Algorithm
-* :jira:`ZEP-812` - Compression Format for IPv6 over 802.15.4
-* :jira:`ZEP-813` - RPL:  IPv6 Routing Protocol
-* :jira:`ZEP-814` - Routing Metrics used in Path Selection
-* :jira:`ZEP-815` - Objective Function Zero for RPL
-* :jira:`ZEP-816` - Minimum Rank with Hysteresis (RPL)
-* :jira:`ZEP-818` - CoAP working over the new IP stack
-* :jira:`ZEP-820` - HTTP v1.1 Server Sample
-* :jira:`ZEP-823` - New IP Stack - Documentation
-* :jira:`ZEP-824` - Network Device Driver Porting Guide
-* :jira:`ZEP-825` - Porting guide for old-to-new IP Stack APIs
-* :jira:`ZEP-827` - HTTP Client sample application
-* :jira:`ZEP-830` - ICMPv6 Parameter Problem Support
-* :jira:`ZEP-832` - Hop-by-Hop option handling
-* :jira:`ZEP-847` - Network protocols must be moved to subsys/net/lib
-* :jira:`ZEP-854` - CoAP with DTLS sample
-* :jira:`ZEP-859` - Migrate ENC28J60 driver to YAIP IP stack
-* :jira:`ZEP-865` - convert filesystem sample to a runnable test
-* :jira:`ZEP-872` - Unable to flash Zephyr on Arduino 101 using Ubuntu and following wiki instructions
-* :jira:`ZEP-873` - DMA API Update
-* :jira:`ZEP-875` - 6LoWPAN - Context based compression support
-* :jira:`ZEP-876` - 6LoWPAN - Offset based Reassembly of 802.15.4 packets
-* :jira:`ZEP-879` - 6LoWPAN - Stateless Address Autoconfiguration
-* :jira:`ZEP-882` - 6LoWPAN - IPv6 Next Header Compression
-* :jira:`ZEP-883` - IP Stack L2 Interface Management API
-* :jira:`ZEP-884` - 802.15.4 - CSMA-CA Radio protocol support
-* :jira:`ZEP-885` - 802.15.4 - Beacon frame support
-* :jira:`ZEP-886` - 802.15.4 - MAC command frame support
-* :jira:`ZEP-887` - 802.15.4 - Management service: RFD level support
-* :jira:`ZEP-911` - Refine thread priorities & locking
-* :jira:`ZEP-919` - Purge obsolete microkernel & nanokernel code
-* :jira:`ZEP-929` - Verify the preempt-thread-only and coop-thread-only configurations
-* :jira:`ZEP-931` - Finalize kernel file naming & locations
-* :jira:`ZEP-936` - Adapt drivers to unified kernel
-* :jira:`ZEP-937` - Adapt networking to unified kernel
-* :jira:`ZEP-946` - Galileo Gen1 board support dropped?
-* :jira:`ZEP-951` - CONFIG_GDB_INFO build not working on ARM
-* :jira:`ZEP-953` - CONFIG_HPET_TIMER_DEBUG build warning
-* :jira:`ZEP-958` - simplify pinmux interface and merge the pinmux_dev into one single API
-* :jira:`ZEP-964` - Add a (hidden?) Kconfig option for disabling legacy API
-* :jira:`ZEP-975` - DNS client port to new IP stack
-* :jira:`ZEP-1012` - NATS client port to new IP stack
-* :jira:`ZEP-1038` - Hard real-time interrupt support
-* :jira:`ZEP-1060` - Contributor guide for documentation missing
-* :jira:`ZEP-1103` - Propose and implement synchronization flow for multicore power management
-* :jira:`ZEP-1165` - support enums as IRQ line argument in IRQ_CONNECT()
-* :jira:`ZEP-1172` - Update logger Api to allow using a hook for SYS_LOG_BACKEND_FN function
-* :jira:`ZEP-1177` - Reduce Zephyr's Dependency on Host Tools
-* :jira:`ZEP-1179` - Build issues when compiling with LLVM from ISSM (icx)
-* :jira:`ZEP-1189` - SoC I2C peripheral of the Quark SE cannot be used from the ARC core
-* :jira:`ZEP-1190` - SoC SPI peripheral of the Quark SE cannot be used from the ARC core
-* :jira:`ZEP-1222` - Add save/restore support to ARC core
-* :jira:`ZEP-1223` - Add save/restore support to arcv2_irq_unit
-* :jira:`ZEP-1224` - Add save/restore support to arcv2_timer_0/sys_clock
-* :jira:`ZEP-1230` - Optimize interrupt return code on ARC.
-* :jira:`ZEP-1233` - mbedDTLS DTLS client stability does not work on top of the tree for the net branch
-* :jira:`ZEP-1251` - Abstract driver re-entrancy code
-* :jira:`ZEP-1267` - Echo server crashes upon reception of router advertisement
-* :jira:`ZEP-1276` - Move disk_access_* out of file system subsystem
-* :jira:`ZEP-1283` - compile option to skip gpio toggle in samples/power/power_mgr
-* :jira:`ZEP-1284` - Remove arch/arm/core/gdb_stub.S and all the abstractions it introduced
-* :jira:`ZEP-1288` - Define _arc_v2_irq_unit device
-* :jira:`ZEP-1292` - Update external mbed TLS library to latest version (2.4.0)
-* :jira:`ZEP-1300` - ARM LTD V2M Beetle Support [Phase 2]
-* :jira:`ZEP-1304` - Define device tree bindings for NXP Kinetis K64F
-* :jira:`ZEP-1305` - Add DTS/DTB targets to build infrastructure
-* :jira:`ZEP-1306` - Create DTS/DTB parser
-* :jira:`ZEP-1307` - Plumbing the DTS configuration
-* :jira:`ZEP-1308` - zephyr thread function k_sleep doesn't work with nrf51822
-* :jira:`ZEP-1320` - Update Architecture Porting Guide
-* :jira:`ZEP-1321` - Glossary of Terms needs updating
-* :jira:`ZEP-1323` - Eliminate references to fiber, task, and nanokernel under ./include
-* :jira:`ZEP-1324` - Get rid of references to CONFIG_NANOKERNEL
-* :jira:`ZEP-1325` - Eliminate TICKLESS_IDLE_SUPPORTED option
-* :jira:`ZEP-1327` - Eliminate obsolete kernel directories
-* :jira:`ZEP-1329` - Rename kernel APIs that have nano\_ prefixes
-* :jira:`ZEP-1334` - Add make debug support for QEMU-based boards
-* :jira:`ZEP-1337` - Relocate event logger files
-* :jira:`ZEP-1338` - Update external fs with new FATFS revision 0.12b
-* :jira:`ZEP-1342` - legacy/kernel/test_early_sleep/ fails on EMSK
-* :jira:`ZEP-1347` - sys_bitfield_*() take unsigned long* vs memaddr_t
-* :jira:`ZEP-1351` - FDRM k64f SPI does not work
-* :jira:`ZEP-1355` - Connection Failed to be Established
-* :jira:`ZEP-1357` - iot/dns: Client is broken
-* :jira:`ZEP-1358` - BMI160 accelerometer gives 0 on all axes
-* :jira:`ZEP-1361` - IP stack is broken
-* :jira:`ZEP-1363` - Missing wiki board support page for arm/arduino_101_ble
-* :jira:`ZEP-1365` - Missing wiki board support page for arm/c3200_launchxl
-* :jira:`ZEP-1370` - There's a wiki page for arduino_due but no zephyr/boards support folder
-* :jira:`ZEP-1374` - Add ksdk spi shim driver
-* :jira:`ZEP-1387` - Add a driver for Atmel ataes132a  HW Crypto module
-* :jira:`ZEP-1389` - Add support for KW41 SoC
-* :jira:`ZEP-1390` - Add support for FRDM-KW41Z
-* :jira:`ZEP-1393` - Add ksdk pinmux driver
-* :jira:`ZEP-1394` - Add ksdk gpio driver
-* :jira:`ZEP-1395` - Add data ready trigger to FXOS8700 driver
-* :jira:`ZEP-1401` - Enhance ready queue cache and interrupt exit code to reduce interrupt latency.
-* :jira:`ZEP-1403` - remove CONFIG_OMIT_FRAME_POINTER from ARC boards
-* :jira:`ZEP-1405` - function l2cap_br_conn_req in /subsys/bluetooth/host/l2cap_br.c references uninitialized pointer
-* :jira:`ZEP-1406` - Update sensor driver paths in wiki
-* :jira:`ZEP-1408` - quark_se_c1000_ss enter_arc_state() might need cc and memory clobber
-* :jira:`ZEP-1411` - Deprecate device_sync_call API and use semaphore directly
-* :jira:`ZEP-1413` - [ARC] test/legacy/kernel/test_tickless/microkernel fails to build
-* :jira:`ZEP-1415` - drivers/timer/* code comments still refer to micro/nano kernel
-* :jira:`ZEP-1418` - Add support for Nordic nRF52840 and its DK
-* :jira:`ZEP-1419` - SYS_LOG macros cause potentially bad behavior due to printk/printf selection
-* :jira:`ZEP-1420` - Make the time spent with interrupts disabled deterministic
-* :jira:`ZEP-1421` - BMI160 gyroscope driver stops reporting after 1-5 minutes
-* :jira:`ZEP-1422` - Arduino_101 doesn't response ipv6 ping request after enable echo_client ipv6
-* :jira:`ZEP-1427` - wpanusb dongle / 15.4 communication instability
-* :jira:`ZEP-1429` - NXP MCR20A Driver
-* :jira:`ZEP-1432` - ksdk pinmux driver should expose the public pinmux API
-* :jira:`ZEP-1434` - menuconfig screen shots show nanokernel options
-* :jira:`ZEP-1437` - AIO: Fail to retrieve pending interrupt in ISR
-* :jira:`ZEP-1440` - Kconfig choice for MINIMAL_LIBC vs NEWLIB_LIBC is not selectable
-* :jira:`ZEP-1442` - Samples/net/dhcpv4_client: Build fail as No rule to make target prj\_.conf
-* :jira:`ZEP-1443` - Samples/net/zperf: Build fail as net_private.h can not be found
-* :jira:`ZEP-1448` - Samples/net/mbedtls_sslclient:Build fail as net/ip_buf.h can not be found
-* :jira:`ZEP-1449` - samples: logger_hook
-* :jira:`ZEP-1456` - Asserts on nrf51 running Bluetooth hci_uart sample
-* :jira:`ZEP-1457` - Add SPDX Tags to Zephyr license boilerplate
-* :jira:`ZEP-1460` - Sanity check reports some qemu step failures as 'build_error'
-* :jira:`ZEP-1461` - Add zephyr support to openocd upstream
-* :jira:`ZEP-1467` - Cleanup misc/ and move features to subsystems in subsys/
-* :jira:`ZEP-1473` - ARP cache confused by use of gateway.
-* :jira:`ZEP-1474` - BLE Connection Parameter Request/Response Processing
-* :jira:`ZEP-1475` - k_free documentation should specify that NULL is valid
-* :jira:`ZEP-1476` - echo_client display port unreachable
-* :jira:`ZEP-1480` - Update supported distros in getting started guide
-* :jira:`ZEP-1481` - Bluetooth fails to init
-* :jira:`ZEP-1483` - H:4 HCI driver (h4.c) should rely on UART flow control to avoid dropping packets
-* :jira:`ZEP-1487` - I2C_SS: I2C doesn't set device busy before starting data transfer
-* :jira:`ZEP-1488` - SPI_SS: SPI doesn't set device busy before starting data transfer
-* :jira:`ZEP-1489` - [GATT] Nested Long Characteristic Value Reliable Writes
-* :jira:`ZEP-1490` - [PTS] TC_CONN_CPUP_BV_04_C test case is failing
-* :jira:`ZEP-1492` - Add Atmel SAM family GMAC Ethernet driver
-* :jira:`ZEP-1493` - Zephyr project documentation copyright
-* :jira:`ZEP-1495` - Networking API details documentation is missing
-* :jira:`ZEP-1496` - gpio_pin_enable_callback error
-* :jira:`ZEP-1497` - Cortex-M0 port exception and interrupt priority setting and getting is broken
-* :jira:`ZEP-1507` - fxos8700 broken gpio_callback implementation
-* :jira:`ZEP-1512` - doc-theme has its own conf.py
-* :jira:`ZEP-1514` - samples/bluetooth/ipsp build fail: net/ip_buf.h No such file or directory
-* :jira:`ZEP-1525` - driver: gpio: GPIO driver still uses  nano_timer
-* :jira:`ZEP-1532` - Wrong accelerometer readings
-* :jira:`ZEP-1536` - Convert documentation of PWM samples to RST
-* :jira:`ZEP-1537` - Convert documentation of power management samples to RST
-* :jira:`ZEP-1538` - Convert documentation of zoap samples to RST
-* :jira:`ZEP-1539` - Create documentation in RST for all networking samples
-* :jira:`ZEP-1540` - Convert Bluetooth samples to RST
-* :jira:`ZEP-1542` - Multi Sessions HTTP Server sample
-* :jira:`ZEP-1543` - HTTP Server sample with basic authentication
-* :jira:`ZEP-1544` - Arduino_101 doesn't respond to ipv6 ping request after enable echo_server ipv6
-* :jira:`ZEP-1545` - AON Counter : ISR triggered twice on ARC
-* :jira:`ZEP-1546` - Bug in Zephyr OS high-precision timings sub-system (function sys_cycle_get_32())
-* :jira:`ZEP-1547` - Add support for H7 crypto function and CT2 SMP auth flag
-* :jira:`ZEP-1548` - Python script invocation is inconsistent
-* :jira:`ZEP-1549` - k_cpu_sleep_mode unaligned byte address
-* :jira:`ZEP-1554` - Xtensa integration
-* :jira:`ZEP-1557` - RISC V Port
-* :jira:`ZEP-1558` - Support of user private data pointer in Timer expiry function
-* :jira:`ZEP-1559` - Implement _tsc_read  for ARC architecture
-* :jira:`ZEP-1562` - echo_server/echo_client examples hang randomly after some time of operation
-* :jira:`ZEP-1563` - move board documentation for NRF51/NRF52 back to git tree
-* :jira:`ZEP-1564` - 6lo uncompress_IPHC_header overwrites IPHC fields
-* :jira:`ZEP-1566` - WDT: Interrupt is triggered multiple times
-* :jira:`ZEP-1569` - net/tcp: TCP in server mode doesn't support multiple concurrent connections
-* :jira:`ZEP-1570` - net/tcp: TCP in server mode is unable to close client connections
-* :jira:`ZEP-1571` - Update "Changes from Version 1 Kernel" to include a "How-To Port Apps" section
-* :jira:`ZEP-1572` - Update QMSI to 1.4
-* :jira:`ZEP-1573` - net/tcp: User provided data in net_context_recv is not passed to callback
-* :jira:`ZEP-1574` - Samples/net/dhcpv4_client: Build fail as undefined reference to net_mgmt_add_event_callback
-* :jira:`ZEP-1579` - external links to zephyr technical docs are broken
-* :jira:`ZEP-1581` - [nRF52832] Blinky hangs after some minutes
-* :jira:`ZEP-1583` - ARC: warning: unmet direct dependencies (SOC_RISCV32_PULPINO || SOC_RISCV32_QEMU)
-* :jira:`ZEP-1585` - legacy.h should be disabled in kernel.h with CONFIG_LEGACY_KERNEL=n
-* :jira:`ZEP-1587` - sensor.h still uses legacy APIs and structs
-* :jira:`ZEP-1588` - I2C doesn't work on Arduino 101
-* :jira:`ZEP-1589` - Define yaml descriptions for UART devices
-* :jira:`ZEP-1590` - echo_server run on FRDM-K64F displays BUS FAULT
-* :jira:`ZEP-1591` - wiki: add Networking section and point https://wiki.zephyrproject.org/view/Network_Interfaces
-* :jira:`ZEP-1592` - echo-server does not build with newlib
-* :jira:`ZEP-1593` - /scripts/sysgen should create output using SPDX licensing tag
-* :jira:`ZEP-1598` - samples/philosophers build failed unexpectedly @quark_d2000  section noinit will not fit in region RAM
-* :jira:`ZEP-1601` - Console over Telnet
-* :jira:`ZEP-1602` - IPv6 ping fails using sample application echo_server on FRDM-K64F
-* :jira:`ZEP-1611` - Hardfault after a few echo requests (IPv6 over BLE)
-* :jira:`ZEP-1614` - Use correct i2c device driver name
-* :jira:`ZEP-1616` - Mix up between "network address" and "socket address" concepts in declaration of net_addr_pton()
-* :jira:`ZEP-1617` - mbedTLS server/client failing to run on qemu
-* :jira:`ZEP-1619` - Default value of NET_NBUF_RX_COUNT is too low, causes lock up on startup
-* :jira:`ZEP-1623` - (Parts) of Networking docs still refer to 1.5 world model (with fibers and tasks) and otherwise not up to date
-* :jira:`ZEP-1626` - SPI: spi cannot work in CPHA mode @ ARC
-* :jira:`ZEP-1632` - TCP ACK packet should not be forwarded to application recv cb.
-* :jira:`ZEP-1635` - MCR20A driver unstable
-* :jira:`ZEP-1638` - No (public) analog of inet_ntop()
-* :jira:`ZEP-1644` - Incoming connection handling for UDP is not exactly correct
-* :jira:`ZEP-1645` - API to wait on multiple kernel objects
-* :jira:`ZEP-1648` - Update links to wiki pages for board info back into the web docs
-* :jira:`ZEP-1650` - make clean (or pristine) is not removing all artifacts of document generation
-* :jira:`ZEP-1651` - i2c_dw malfunctioning due to various changes.
-* :jira:`ZEP-1653` - build issue when compiling with LLVM in ISSM (altmacro)
-* :jira:`ZEP-1654` - Build issues when compiling with LLVM(unknown attribute '_alloc_align_)
-* :jira:`ZEP-1655` - Build issues when compiling with LLVM(memory pool)
-* :jira:`ZEP-1656` - IPv6 over BLE no longer works after commit 2e9fd88
-* :jira:`ZEP-1657` - Zoap doxygen documentation needs to be perfected
-* :jira:`ZEP-1658` - IPv6 TCP low on buffers, stops responding after about 5 requests
-* :jira:`ZEP-1662` - zoap_packet_get_payload() should return the payload length
-* :jira:`ZEP-1663` - sanitycheck overrides user's environment for CCACHE
-* :jira:`ZEP-1665` - pinmux: missing default pinmux driver config for quark_se_ss
-* :jira:`ZEP-1669` - API documentation does not follow in-code documentation style
-* :jira:`ZEP-1672` - flash: Flash device binding failed on Arduino_101_sss
-* :jira:`ZEP-1674` - frdm_k64f: With Ethernet driver enabled, application can't start up without connected network cable
-* :jira:`ZEP-1677` - SDK: BLE cannot be initialized/advertised with CONFIG_ARC_INIT=y on Arduino 101
-* :jira:`ZEP-1681` - Save/restore debug registers during soc_sleep/soc_deep_sleep in c1000
-* :jira:`ZEP-1692` - [PTS] GATT/SR/GPA/BV-11-C fails
-* :jira:`ZEP-1701` - Provide an HTTP API
-* :jira:`ZEP-1704` - BMI160 samples fails to run
-* :jira:`ZEP-1706` - Barebone Panther board support
-* :jira:`ZEP-1707` - [PTS] 7 SM/MAS cases fail
-* :jira:`ZEP-1708` - [PTS] SM/MAS/PKE/BI-01-C fails
-* :jira:`ZEP-1709` - [PTS] SM/MAS/PKE/BI-02-C fails
-* :jira:`ZEP-1710` - Add TinyTILE board support
-* :jira:`ZEP-1713` - xtensa: correct all checkpatch issues
-* :jira:`ZEP-1716` - HTTP server sample that does not support up to 10 concurrent sessions.
-* :jira:`ZEP-1717` - GPIO: GPIO LEVEL interrupt cannot work well in deep sleep mode
-* :jira:`ZEP-1723` - Warnings in Network code/ MACROS, when built with ISSM's  llvm/icx compiler
-* :jira:`ZEP-1732` - sample of zoap_server runs error.
-* :jira:`ZEP-1733` - Work on ZEP-686 led to regressions in docs on integration with 3rd-party code
-* :jira:`ZEP-1745` - Bluetooth samples build failure
-* :jira:`ZEP-1753` - sample of dhcpv4_client runs error on Arduino 101
-* :jira:`ZEP-1754` - sample of coaps_server was tested failed on qemu
-* :jira:`ZEP-1756` - net apps: [-Wpointer-sign] build warning raised when built with ISSM's  llvm/icx compiler
-* :jira:`ZEP-1758` - PLL2 is not correctly enabled in STM32F10x connectivity line SoC
-* :jira:`ZEP-1763` - Nordic RTC timer driver not correct with tickless idle
-* :jira:`ZEP-1764` - samples: sample cases use hard code device name, such as "GPIOB" "I2C_0"
-* :jira:`ZEP-1768` - samples: cases miss testcase.ini
-* :jira:`ZEP-1774` - Malformed packet included with IPv6 over 802.15.4
-* :jira:`ZEP-1778` - tests/power: multicore case won't work as expected
-* :jira:`ZEP-1786` - TCP does not work on Arduino 101 board.
-* :jira:`ZEP-1787` - kernel event logger build failed with "CONFIG_LEGACY_KERNEL=n"
-* :jira:`ZEP-1789` - ARC: "samples/logger-hook" crashed __memory_error from sys_ring_buf_get
-* :jira:`ZEP-1799` - timeout_order_test _ASSERT_VALID_PRIO failed
-* :jira:`ZEP-1803` - Error occurs when exercising dma_transfer_stop
-* :jira:`ZEP-1806` - Build warnings with LLVM/icx (gdb_server)
-* :jira:`ZEP-1809` - Build error in net/ip with LLVM/icx
-* :jira:`ZEP-1810` - Build failure in net/lib/zoap with LLVM/icx
-* :jira:`ZEP-1811` - Build error in net/ip/net_mgmt.c with LLVM/icx
-* :jira:`ZEP-1839` - LL_ASSERT in event_common_prepareA
-* :jira:`ZEP-1851` - Build warnings with obj_tracing
-* :jira:`ZEP-1852` - LL_ASSERT in isr_radio_state_close()
-* :jira:`ZEP-1855` - IP stack buffer allocation fails over time
-* :jira:`ZEP-1858` - Zephyr NATS client fails to respond to  server MSG
-* :jira:`ZEP-1864` - llvm icx build warning in tests/drivers/uart/*
-* :jira:`ZEP-1872` - samples/net: the HTTP client sample app must run on QEMU x86
-* :jira:`ZEP-1877` - samples/net: the coaps_server sample app runs failed on Arduino 101
-* :jira:`ZEP-1883` - Enabling Console on ARC Genuino 101
-* :jira:`ZEP-1890` - Bluetooth IPSP sample: Too small user data size
+* ``ZEP-19`` - IPSP node support
+* ``ZEP-145`` - no 'make flash' for Arduino Due
+* ``ZEP-328`` - HW Encryption Abstraction
+* ``ZEP-359`` - Move QEMU handling to a central location
+* ``ZEP-365`` - Zephyr's MQTT library
+* ``ZEP-437`` - TCP/IP API
+* ``ZEP-513`` - extern declarations of  small microkernel objects in designated sections require __attribute__((section)) in gp-enabled systems
+* ``ZEP-591`` - MQTT Port to New IP Stack
+* ``ZEP-604`` - In coap_server sample app, CoAP resource separate is not able to send separate response
+* ``ZEP-613`` - TCP/UDP client and server mode functionality
+* ``ZEP-641`` - Bluetooth Eddystone sample does not correctly implement Eddystone beacon
+* ``ZEP-648`` - New CoAP Implementation
+* ``ZEP-664`` - Extend spi_qmsi_ss driver to support save/restore peripheral context
+* ``ZEP-665`` - Extend gpio_qmsi_ss driver to support save/restore peripheral context
+* ``ZEP-666`` - Extend i2c_qmsi_ss driver to support save/restore peripheral context
+* ``ZEP-667`` - Extend adc_qmsi_ss driver to support save/restore peripheral context
+* ``ZEP-686`` - docs: Info in Application Development Primer and Developing an Application and the Build System is largely duplicated
+* ``ZEP-706`` - cannot set debug breakpoints on ARC side of Arduino 101
+* ``ZEP-719`` - Add ksdk uart shim driver
+* ``ZEP-734`` - Port AES-CMAC-PRF-128 [RFC 4615] encryption library for Thread support
+* ``ZEP-742`` - nRF5x Series: System Clock driver using NRF_RTC
+* ``ZEP-744`` - USB WebUSB
+* ``ZEP-748`` - Enable mbedtls_sslclient sample to run on quark se board
+* ``ZEP-759`` - Add preliminary support for Atmel SAM E70 (Cortex-M7) chipset family and SAM E70 Xplained board
+* ``ZEP-788`` - UDP
+* ``ZEP-789`` - IPv4
+* ``ZEP-790`` - ICMPv4
+* ``ZEP-791`` - TCP
+* ``ZEP-792`` - ARP
+* ``ZEP-793`` - DNS Resolver
+* ``ZEP-794`` - Requirements for Internet Hosts - Communication Layers
+* ``ZEP-796`` - DHCPv4
+* ``ZEP-798`` - IPv6
+* ``ZEP-799`` - HTTP over TLS
+* ``ZEP-801`` - DNS Extensions to support IPv6
+* ``ZEP-804`` - IPv6 Addressing Architecture
+* ``ZEP-805`` - Internet Control Message Protocol (ICMP) v6
+* ``ZEP-807`` - Neighbor Discovery for IPv6
+* ``ZEP-808`` - IPv6 Stateless Autoconfiguration (SLAAC)
+* ``ZEP-809`` - IPv6 over 802.15.4
+* ``ZEP-811`` - The Trickle Algorithm
+* ``ZEP-812`` - Compression Format for IPv6 over 802.15.4
+* ``ZEP-813`` - RPL:  IPv6 Routing Protocol
+* ``ZEP-814`` - Routing Metrics used in Path Selection
+* ``ZEP-815`` - Objective Function Zero for RPL
+* ``ZEP-816`` - Minimum Rank with Hysteresis (RPL)
+* ``ZEP-818`` - CoAP working over the new IP stack
+* ``ZEP-820`` - HTTP v1.1 Server Sample
+* ``ZEP-823`` - New IP Stack - Documentation
+* ``ZEP-824`` - Network Device Driver Porting Guide
+* ``ZEP-825`` - Porting guide for old-to-new IP Stack APIs
+* ``ZEP-827`` - HTTP Client sample application
+* ``ZEP-830`` - ICMPv6 Parameter Problem Support
+* ``ZEP-832`` - Hop-by-Hop option handling
+* ``ZEP-847`` - Network protocols must be moved to subsys/net/lib
+* ``ZEP-854`` - CoAP with DTLS sample
+* ``ZEP-859`` - Migrate ENC28J60 driver to YAIP IP stack
+* ``ZEP-865`` - convert filesystem sample to a runnable test
+* ``ZEP-872`` - Unable to flash Zephyr on Arduino 101 using Ubuntu and following wiki instructions
+* ``ZEP-873`` - DMA API Update
+* ``ZEP-875`` - 6LoWPAN - Context based compression support
+* ``ZEP-876`` - 6LoWPAN - Offset based Reassembly of 802.15.4 packets
+* ``ZEP-879`` - 6LoWPAN - Stateless Address Autoconfiguration
+* ``ZEP-882`` - 6LoWPAN - IPv6 Next Header Compression
+* ``ZEP-883`` - IP Stack L2 Interface Management API
+* ``ZEP-884`` - 802.15.4 - CSMA-CA Radio protocol support
+* ``ZEP-885`` - 802.15.4 - Beacon frame support
+* ``ZEP-886`` - 802.15.4 - MAC command frame support
+* ``ZEP-887`` - 802.15.4 - Management service: RFD level support
+* ``ZEP-911`` - Refine thread priorities & locking
+* ``ZEP-919`` - Purge obsolete microkernel & nanokernel code
+* ``ZEP-929`` - Verify the preempt-thread-only and coop-thread-only configurations
+* ``ZEP-931`` - Finalize kernel file naming & locations
+* ``ZEP-936`` - Adapt drivers to unified kernel
+* ``ZEP-937`` - Adapt networking to unified kernel
+* ``ZEP-946`` - Galileo Gen1 board support dropped?
+* ``ZEP-951`` - CONFIG_GDB_INFO build not working on ARM
+* ``ZEP-953`` - CONFIG_HPET_TIMER_DEBUG build warning
+* ``ZEP-958`` - simplify pinmux interface and merge the pinmux_dev into one single API
+* ``ZEP-964`` - Add a (hidden?) Kconfig option for disabling legacy API
+* ``ZEP-975`` - DNS client port to new IP stack
+* ``ZEP-1012`` - NATS client port to new IP stack
+* ``ZEP-1038`` - Hard real-time interrupt support
+* ``ZEP-1060`` - Contributor guide for documentation missing
+* ``ZEP-1103`` - Propose and implement synchronization flow for multicore power management
+* ``ZEP-1165`` - support enums as IRQ line argument in IRQ_CONNECT()
+* ``ZEP-1172`` - Update logger Api to allow using a hook for SYS_LOG_BACKEND_FN function
+* ``ZEP-1177`` - Reduce Zephyr's Dependency on Host Tools
+* ``ZEP-1179`` - Build issues when compiling with LLVM from ISSM (icx)
+* ``ZEP-1189`` - SoC I2C peripheral of the Quark SE cannot be used from the ARC core
+* ``ZEP-1190`` - SoC SPI peripheral of the Quark SE cannot be used from the ARC core
+* ``ZEP-1222`` - Add save/restore support to ARC core
+* ``ZEP-1223`` - Add save/restore support to arcv2_irq_unit
+* ``ZEP-1224`` - Add save/restore support to arcv2_timer_0/sys_clock
+* ``ZEP-1230`` - Optimize interrupt return code on ARC.
+* ``ZEP-1233`` - mbedDTLS DTLS client stability does not work on top of the tree for the net branch
+* ``ZEP-1251`` - Abstract driver re-entrancy code
+* ``ZEP-1267`` - Echo server crashes upon reception of router advertisement
+* ``ZEP-1276`` - Move disk_access_* out of file system subsystem
+* ``ZEP-1283`` - compile option to skip gpio toggle in samples/power/power_mgr
+* ``ZEP-1284`` - Remove arch/arm/core/gdb_stub.S and all the abstractions it introduced
+* ``ZEP-1288`` - Define _arc_v2_irq_unit device
+* ``ZEP-1292`` - Update external mbed TLS library to latest version (2.4.0)
+* ``ZEP-1300`` - ARM LTD V2M Beetle Support [Phase 2]
+* ``ZEP-1304`` - Define device tree bindings for NXP Kinetis K64F
+* ``ZEP-1305`` - Add DTS/DTB targets to build infrastructure
+* ``ZEP-1306`` - Create DTS/DTB parser
+* ``ZEP-1307`` - Plumbing the DTS configuration
+* ``ZEP-1308`` - zephyr thread function k_sleep doesn't work with nrf51822
+* ``ZEP-1320`` - Update Architecture Porting Guide
+* ``ZEP-1321`` - Glossary of Terms needs updating
+* ``ZEP-1323`` - Eliminate references to fiber, task, and nanokernel under ./include
+* ``ZEP-1324`` - Get rid of references to CONFIG_NANOKERNEL
+* ``ZEP-1325`` - Eliminate TICKLESS_IDLE_SUPPORTED option
+* ``ZEP-1327`` - Eliminate obsolete kernel directories
+* ``ZEP-1329`` - Rename kernel APIs that have nano\_ prefixes
+* ``ZEP-1334`` - Add make debug support for QEMU-based boards
+* ``ZEP-1337`` - Relocate event logger files
+* ``ZEP-1338`` - Update external fs with new FATFS revision 0.12b
+* ``ZEP-1342`` - legacy/kernel/test_early_sleep/ fails on EMSK
+* ``ZEP-1347`` - sys_bitfield_*() take unsigned long* vs memaddr_t
+* ``ZEP-1351`` - FDRM k64f SPI does not work
+* ``ZEP-1355`` - Connection Failed to be Established
+* ``ZEP-1357`` - iot/dns: Client is broken
+* ``ZEP-1358`` - BMI160 accelerometer gives 0 on all axes
+* ``ZEP-1361`` - IP stack is broken
+* ``ZEP-1363`` - Missing wiki board support page for arm/arduino_101_ble
+* ``ZEP-1365`` - Missing wiki board support page for arm/c3200_launchxl
+* ``ZEP-1370`` - There's a wiki page for arduino_due but no zephyr/boards support folder
+* ``ZEP-1374`` - Add ksdk spi shim driver
+* ``ZEP-1387`` - Add a driver for Atmel ataes132a  HW Crypto module
+* ``ZEP-1389`` - Add support for KW41 SoC
+* ``ZEP-1390`` - Add support for FRDM-KW41Z
+* ``ZEP-1393`` - Add ksdk pinmux driver
+* ``ZEP-1394`` - Add ksdk gpio driver
+* ``ZEP-1395`` - Add data ready trigger to FXOS8700 driver
+* ``ZEP-1401`` - Enhance ready queue cache and interrupt exit code to reduce interrupt latency.
+* ``ZEP-1403`` - remove CONFIG_OMIT_FRAME_POINTER from ARC boards
+* ``ZEP-1405`` - function l2cap_br_conn_req in /subsys/bluetooth/host/l2cap_br.c references uninitialized pointer
+* ``ZEP-1406`` - Update sensor driver paths in wiki
+* ``ZEP-1408`` - quark_se_c1000_ss enter_arc_state() might need cc and memory clobber
+* ``ZEP-1411`` - Deprecate device_sync_call API and use semaphore directly
+* ``ZEP-1413`` - [ARC] test/legacy/kernel/test_tickless/microkernel fails to build
+* ``ZEP-1415`` - drivers/timer/* code comments still refer to micro/nano kernel
+* ``ZEP-1418`` - Add support for Nordic nRF52840 and its DK
+* ``ZEP-1419`` - SYS_LOG macros cause potentially bad behavior due to printk/printf selection
+* ``ZEP-1420`` - Make the time spent with interrupts disabled deterministic
+* ``ZEP-1421`` - BMI160 gyroscope driver stops reporting after 1-5 minutes
+* ``ZEP-1422`` - Arduino_101 doesn't response ipv6 ping request after enable echo_client ipv6
+* ``ZEP-1427`` - wpanusb dongle / 15.4 communication instability
+* ``ZEP-1429`` - NXP MCR20A Driver
+* ``ZEP-1432`` - ksdk pinmux driver should expose the public pinmux API
+* ``ZEP-1434`` - menuconfig screen shots show nanokernel options
+* ``ZEP-1437`` - AIO: Fail to retrieve pending interrupt in ISR
+* ``ZEP-1440`` - Kconfig choice for MINIMAL_LIBC vs NEWLIB_LIBC is not selectable
+* ``ZEP-1442`` - Samples/net/dhcpv4_client: Build fail as No rule to make target prj\_.conf
+* ``ZEP-1443`` - Samples/net/zperf: Build fail as net_private.h can not be found
+* ``ZEP-1448`` - Samples/net/mbedtls_sslclient:Build fail as net/ip_buf.h can not be found
+* ``ZEP-1449`` - samples: logger_hook
+* ``ZEP-1456`` - Asserts on nrf51 running Bluetooth hci_uart sample
+* ``ZEP-1457`` - Add SPDX Tags to Zephyr license boilerplate
+* ``ZEP-1460`` - Sanity check reports some qemu step failures as 'build_error'
+* ``ZEP-1461`` - Add zephyr support to openocd upstream
+* ``ZEP-1467`` - Cleanup misc/ and move features to subsystems in subsys/
+* ``ZEP-1473`` - ARP cache confused by use of gateway.
+* ``ZEP-1474`` - BLE Connection Parameter Request/Response Processing
+* ``ZEP-1475`` - k_free documentation should specify that NULL is valid
+* ``ZEP-1476`` - echo_client display port unreachable
+* ``ZEP-1480`` - Update supported distros in getting started guide
+* ``ZEP-1481`` - Bluetooth fails to init
+* ``ZEP-1483`` - H:4 HCI driver (h4.c) should rely on UART flow control to avoid dropping packets
+* ``ZEP-1487`` - I2C_SS: I2C doesn't set device busy before starting data transfer
+* ``ZEP-1488`` - SPI_SS: SPI doesn't set device busy before starting data transfer
+* ``ZEP-1489`` - [GATT] Nested Long Characteristic Value Reliable Writes
+* ``ZEP-1490`` - [PTS] TC_CONN_CPUP_BV_04_C test case is failing
+* ``ZEP-1492`` - Add Atmel SAM family GMAC Ethernet driver
+* ``ZEP-1493`` - Zephyr project documentation copyright
+* ``ZEP-1495`` - Networking API details documentation is missing
+* ``ZEP-1496`` - gpio_pin_enable_callback error
+* ``ZEP-1497`` - Cortex-M0 port exception and interrupt priority setting and getting is broken
+* ``ZEP-1507`` - fxos8700 broken gpio_callback implementation
+* ``ZEP-1512`` - doc-theme has its own conf.py
+* ``ZEP-1514`` - samples/bluetooth/ipsp build fail: net/ip_buf.h No such file or directory
+* ``ZEP-1525`` - driver: gpio: GPIO driver still uses  nano_timer
+* ``ZEP-1532`` - Wrong accelerometer readings
+* ``ZEP-1536`` - Convert documentation of PWM samples to RST
+* ``ZEP-1537`` - Convert documentation of power management samples to RST
+* ``ZEP-1538`` - Convert documentation of zoap samples to RST
+* ``ZEP-1539`` - Create documentation in RST for all networking samples
+* ``ZEP-1540`` - Convert Bluetooth samples to RST
+* ``ZEP-1542`` - Multi Sessions HTTP Server sample
+* ``ZEP-1543`` - HTTP Server sample with basic authentication
+* ``ZEP-1544`` - Arduino_101 doesn't respond to ipv6 ping request after enable echo_server ipv6
+* ``ZEP-1545`` - AON Counter : ISR triggered twice on ARC
+* ``ZEP-1546`` - Bug in Zephyr OS high-precision timings sub-system (function sys_cycle_get_32())
+* ``ZEP-1547`` - Add support for H7 crypto function and CT2 SMP auth flag
+* ``ZEP-1548`` - Python script invocation is inconsistent
+* ``ZEP-1549`` - k_cpu_sleep_mode unaligned byte address
+* ``ZEP-1554`` - Xtensa integration
+* ``ZEP-1557`` - RISC V Port
+* ``ZEP-1558`` - Support of user private data pointer in Timer expiry function
+* ``ZEP-1559`` - Implement _tsc_read  for ARC architecture
+* ``ZEP-1562`` - echo_server/echo_client examples hang randomly after some time of operation
+* ``ZEP-1563`` - move board documentation for NRF51/NRF52 back to git tree
+* ``ZEP-1564`` - 6lo uncompress_IPHC_header overwrites IPHC fields
+* ``ZEP-1566`` - WDT: Interrupt is triggered multiple times
+* ``ZEP-1569`` - net/tcp: TCP in server mode doesn't support multiple concurrent connections
+* ``ZEP-1570`` - net/tcp: TCP in server mode is unable to close client connections
+* ``ZEP-1571`` - Update "Changes from Version 1 Kernel" to include a "How-To Port Apps" section
+* ``ZEP-1572`` - Update QMSI to 1.4
+* ``ZEP-1573`` - net/tcp: User provided data in net_context_recv is not passed to callback
+* ``ZEP-1574`` - Samples/net/dhcpv4_client: Build fail as undefined reference to net_mgmt_add_event_callback
+* ``ZEP-1579`` - external links to zephyr technical docs are broken
+* ``ZEP-1581`` - [nRF52832] Blinky hangs after some minutes
+* ``ZEP-1583`` - ARC: warning: unmet direct dependencies (SOC_RISCV32_PULPINO || SOC_RISCV32_QEMU)
+* ``ZEP-1585`` - legacy.h should be disabled in kernel.h with CONFIG_LEGACY_KERNEL=n
+* ``ZEP-1587`` - sensor.h still uses legacy APIs and structs
+* ``ZEP-1588`` - I2C doesn't work on Arduino 101
+* ``ZEP-1589`` - Define yaml descriptions for UART devices
+* ``ZEP-1590`` - echo_server run on FRDM-K64F displays BUS FAULT
+* ``ZEP-1591`` - wiki: add Networking section and point https://wiki.zephyrproject.org/view/Network_Interfaces
+* ``ZEP-1592`` - echo-server does not build with newlib
+* ``ZEP-1593`` - /scripts/sysgen should create output using SPDX licensing tag
+* ``ZEP-1598`` - samples/philosophers build failed unexpectedly @quark_d2000  section noinit will not fit in region RAM
+* ``ZEP-1601`` - Console over Telnet
+* ``ZEP-1602`` - IPv6 ping fails using sample application echo_server on FRDM-K64F
+* ``ZEP-1611`` - Hardfault after a few echo requests (IPv6 over BLE)
+* ``ZEP-1614`` - Use correct i2c device driver name
+* ``ZEP-1616`` - Mix up between "network address" and "socket address" concepts in declaration of net_addr_pton()
+* ``ZEP-1617`` - mbedTLS server/client failing to run on qemu
+* ``ZEP-1619`` - Default value of NET_NBUF_RX_COUNT is too low, causes lock up on startup
+* ``ZEP-1623`` - (Parts) of Networking docs still refer to 1.5 world model (with fibers and tasks) and otherwise not up to date
+* ``ZEP-1626`` - SPI: spi cannot work in CPHA mode @ ARC
+* ``ZEP-1632`` - TCP ACK packet should not be forwarded to application recv cb.
+* ``ZEP-1635`` - MCR20A driver unstable
+* ``ZEP-1638`` - No (public) analog of inet_ntop()
+* ``ZEP-1644`` - Incoming connection handling for UDP is not exactly correct
+* ``ZEP-1645`` - API to wait on multiple kernel objects
+* ``ZEP-1648`` - Update links to wiki pages for board info back into the web docs
+* ``ZEP-1650`` - make clean (or pristine) is not removing all artifacts of document generation
+* ``ZEP-1651`` - i2c_dw malfunctioning due to various changes.
+* ``ZEP-1653`` - build issue when compiling with LLVM in ISSM (altmacro)
+* ``ZEP-1654`` - Build issues when compiling with LLVM(unknown attribute '_alloc_align_)
+* ``ZEP-1655`` - Build issues when compiling with LLVM(memory pool)
+* ``ZEP-1656`` - IPv6 over BLE no longer works after commit 2e9fd88
+* ``ZEP-1657`` - Zoap doxygen documentation needs to be perfected
+* ``ZEP-1658`` - IPv6 TCP low on buffers, stops responding after about 5 requests
+* ``ZEP-1662`` - zoap_packet_get_payload() should return the payload length
+* ``ZEP-1663`` - sanitycheck overrides user's environment for CCACHE
+* ``ZEP-1665`` - pinmux: missing default pinmux driver config for quark_se_ss
+* ``ZEP-1669`` - API documentation does not follow in-code documentation style
+* ``ZEP-1672`` - flash: Flash device binding failed on Arduino_101_sss
+* ``ZEP-1674`` - frdm_k64f: With Ethernet driver enabled, application can't start up without connected network cable
+* ``ZEP-1677`` - SDK: BLE cannot be initialized/advertised with CONFIG_ARC_INIT=y on Arduino 101
+* ``ZEP-1681`` - Save/restore debug registers during soc_sleep/soc_deep_sleep in c1000
+* ``ZEP-1692`` - [PTS] GATT/SR/GPA/BV-11-C fails
+* ``ZEP-1701`` - Provide an HTTP API
+* ``ZEP-1704`` - BMI160 samples fails to run
+* ``ZEP-1706`` - Barebone Panther board support
+* ``ZEP-1707`` - [PTS] 7 SM/MAS cases fail
+* ``ZEP-1708`` - [PTS] SM/MAS/PKE/BI-01-C fails
+* ``ZEP-1709`` - [PTS] SM/MAS/PKE/BI-02-C fails
+* ``ZEP-1710`` - Add TinyTILE board support
+* ``ZEP-1713`` - xtensa: correct all checkpatch issues
+* ``ZEP-1716`` - HTTP server sample that does not support up to 10 concurrent sessions.
+* ``ZEP-1717`` - GPIO: GPIO LEVEL interrupt cannot work well in deep sleep mode
+* ``ZEP-1723`` - Warnings in Network code/ MACROS, when built with ISSM's  llvm/icx compiler
+* ``ZEP-1732`` - sample of zoap_server runs error.
+* ``ZEP-1733`` - Work on ZEP-686 led to regressions in docs on integration with 3rd-party code
+* ``ZEP-1745`` - Bluetooth samples build failure
+* ``ZEP-1753`` - sample of dhcpv4_client runs error on Arduino 101
+* ``ZEP-1754`` - sample of coaps_server was tested failed on qemu
+* ``ZEP-1756`` - net apps: [-Wpointer-sign] build warning raised when built with ISSM's  llvm/icx compiler
+* ``ZEP-1758`` - PLL2 is not correctly enabled in STM32F10x connectivity line SoC
+* ``ZEP-1763`` - Nordic RTC timer driver not correct with tickless idle
+* ``ZEP-1764`` - samples: sample cases use hard code device name, such as "GPIOB" "I2C_0"
+* ``ZEP-1768`` - samples: cases miss testcase.ini
+* ``ZEP-1774`` - Malformed packet included with IPv6 over 802.15.4
+* ``ZEP-1778`` - tests/power: multicore case won't work as expected
+* ``ZEP-1786`` - TCP does not work on Arduino 101 board.
+* ``ZEP-1787`` - kernel event logger build failed with "CONFIG_LEGACY_KERNEL=n"
+* ``ZEP-1789`` - ARC: "samples/logger-hook" crashed __memory_error from sys_ring_buf_get
+* ``ZEP-1799`` - timeout_order_test _ASSERT_VALID_PRIO failed
+* ``ZEP-1803`` - Error occurs when exercising dma_transfer_stop
+* ``ZEP-1806`` - Build warnings with LLVM/icx (gdb_server)
+* ``ZEP-1809`` - Build error in net/ip with LLVM/icx
+* ``ZEP-1810`` - Build failure in net/lib/zoap with LLVM/icx
+* ``ZEP-1811`` - Build error in net/ip/net_mgmt.c with LLVM/icx
+* ``ZEP-1839`` - LL_ASSERT in event_common_prepareA
+* ``ZEP-1851`` - Build warnings with obj_tracing
+* ``ZEP-1852`` - LL_ASSERT in isr_radio_state_close()
+* ``ZEP-1855`` - IP stack buffer allocation fails over time
+* ``ZEP-1858`` - Zephyr NATS client fails to respond to  server MSG
+* ``ZEP-1864`` - llvm icx build warning in tests/drivers/uart/*
+* ``ZEP-1872`` - samples/net: the HTTP client sample app must run on QEMU x86
+* ``ZEP-1877`` - samples/net: the coaps_server sample app runs failed on Arduino 101
+* ``ZEP-1883`` - Enabling Console on ARC Genuino 101
+* ``ZEP-1890`` - Bluetooth IPSP sample: Too small user data size

--- a/doc/releases/release-notes-1.8.rst
+++ b/doc/releases/release-notes-1.8.rst
@@ -202,123 +202,123 @@ JIRA Related Items
 
 .. comment  List derived from Jira query: ...
 
-* :jira:`ZEP-248` - Add a BOARD/SOC porting guide
-* :jira:`ZEP-339` - Tickless Kernel
-* :jira:`ZEP-540` - add APIs for asynchronous transfer callbacks
-* :jira:`ZEP-628` - Validate RPL Routing node support
-* :jira:`ZEP-638` - feature to consider: flag missing functionality at build time when possible
-* :jira:`ZEP-720` - Add MAX30101 heart rate sensor driver
-* :jira:`ZEP-828` - IPv6 - Multicast Join/Leave Support
-* :jira:`ZEP-843` - Unified assert/unrecoverable error infrastructure
-* :jira:`ZEP-888` - 802.15.4 - Security support
-* :jira:`ZEP-932` - Adapt kernel sample & test projects
-* :jira:`ZEP-948` - Revisit the timeslicing algorithm
-* :jira:`ZEP-973` - Remove deprecated API related to device PM functions and DEVICE\_ and SYS\_* macros
-* :jira:`ZEP-1028` - shrink k_block struct size
-* :jira:`ZEP-1032` - IPSP router role support
-* :jira:`ZEP-1169` - Sample mbedDTLS DTLS client stability on ethernet driver
-* :jira:`ZEP-1171` - Event group kernel APIs
-* :jira:`ZEP-1280` - Provide Event Queues Object
-* :jira:`ZEP-1313` - porting and user guides must include a security section
-* :jira:`ZEP-1326` - Clean up _THREAD_xxx APIs
-* :jira:`ZEP-1388` - Add support for KW40 SoC
-* :jira:`ZEP-1391` - Add support for Hexiwear KW40
-* :jira:`ZEP-1392` - Add FXAS21002 gyroscope sensor driver
-* :jira:`ZEP-1435` - Improve Quark SE C1000 ARC Floating Point Performance
-* :jira:`ZEP-1438` - AIO: AIO Comparator is not stable on D2000 and Arduino101
-* :jira:`ZEP-1463` - Add Zephyr Support in segger SystemView
-* :jira:`ZEP-1500` - net/mqtt: Test case for the MQTT high-level API
-* :jira:`ZEP-1528` - Provide template for multi-core applications
-* :jira:`ZEP-1529` - Unable to exit menuconfig
-* :jira:`ZEP-1530` - Hotkeys for the menu at the bottom of menuconfig sometimes doesn't work
-* :jira:`ZEP-1568` - Replace arm cortex_m scs and scb functionality with direct CMSIS-core calls
-* :jira:`ZEP-1586` - menuconfig: Backspace is broken
-* :jira:`ZEP-1599` - printk() support for the '-' indicator  in format string (left justifier)
-* :jira:`ZEP-1607` - JSON encoding/decoding library
-* :jira:`ZEP-1621` - Stack Monitoring
-* :jira:`ZEP-1631` - Ability to use k_mem_pool_alloc (or similar API) from ISR
-* :jira:`ZEP-1684` - Add Atmel SAM family watchdog (WDT) driver
-* :jira:`ZEP-1695` - Support ADXL362 sensor
-* :jira:`ZEP-1698` - BME280 support for SPI communication
-* :jira:`ZEP-1711` - xtensa build defines Kconfigs with lowercase names
-* :jira:`ZEP-1718` - support for IPv6 fragmentation
-* :jira:`ZEP-1719` - TCP does not work with 6lo
-* :jira:`ZEP-1721` - many TinyCrypt test cases only run on ARM and x86
-* :jira:`ZEP-1722` - xtensa: TinyCrypt does not build
-* :jira:`ZEP-1735` - Controller to Host flow control
-* :jira:`ZEP-1759` - All python scripts needed for build should be moved to python 3 to minimize dependencies
-* :jira:`ZEP-1761` - K_MEM_POOL_DEFINE build error "invalid register name" when built with llvm/icx from ISSM toolchain
-* :jira:`ZEP-1769` - Implement  Set Event Mask and LE Set Event Mask commands
-* :jira:`ZEP-1772` - re-introduce controller to host flow control
-* :jira:`ZEP-1776` - sending LE COC data from RX thread can lead to deadlock
-* :jira:`ZEP-1785` - Tinytile: Flashing not supported with this board
-* :jira:`ZEP-1788` - [REG] bt_enable: No HCI driver registered
-* :jira:`ZEP-1800` - Update external mbed TLS library to latest version (2.4.2)
-* :jira:`ZEP-1812` - Add tickless kernel support in HPET timer
-* :jira:`ZEP-1816` - Add tickless kernel support in LOAPIC timer
-* :jira:`ZEP-1817` - Add tickless kernel support in ARCV2 timer
-* :jira:`ZEP-1818` - Add tickless kernel support in cortex_m_systick timer
-* :jira:`ZEP-1821` - Update PM apps to use mili/micro seconds instead of ticks
-* :jira:`ZEP-1823` - Improved Benchmarks
-* :jira:`ZEP-1825` - Context Switching KPI
-* :jira:`ZEP-1836` - Expose current ecb_encrypt() as bt_encrypt() so host can directly access it
-* :jira:`ZEP-1856` - remove legacy micro/nano kernel APIs
-* :jira:`ZEP-1857` - Build warnings [-Wpointer-sign] with LLVM/icx (bluetooth_handsfree)
-* :jira:`ZEP-1866` - Add Atmel SAM family I2C (TWIHS) driver
-* :jira:`ZEP-1880` - "samples/grove/temperature": warning raised when generating configure file
-* :jira:`ZEP-1886` - Build warnings [-Wpointer-sign] with LLVM/icx (tests/net/nbuf)
-* :jira:`ZEP-1887` - Build warnings [-Wpointer-sign] with LLVM/icx (tests/drivers/spi/spi_basic_api)
-* :jira:`ZEP-1893` - openocd: 'make flash' works with Zephyr SDK only and fails for all other toolchains
-* :jira:`ZEP-1896` - [PTS] L2CAP/LE/CFC/BV-06-C
-* :jira:`ZEP-1899` - Missing board documentation for xtensa/xt-sim
-* :jira:`ZEP-1908` - Missing board documentation for arm/nucleo_96b_nitrogen
-* :jira:`ZEP-1910` - Missing board documentation for arm/96b_carbon
-* :jira:`ZEP-1927` - AIO: AIO_CMP_POL_FALL is triggered immediately after aio_cmp_configure
-* :jira:`ZEP-1935` - Packet loss make RPL mesh more vulnerable
-* :jira:`ZEP-1936` - tests/drivers/spi/spi_basic_api/testcase.ini#test_spi - Assertion Fail
-* :jira:`ZEP-1946` - Time to Next Event
-* :jira:`ZEP-1955` - Nested interrupts crash on Xtensa architecture
-* :jira:`ZEP-1959` - Add Atmel SAM family serial (UART) driver
-* :jira:`ZEP-1965` - net-tools HEAD is broken for QEMU/TAP
-* :jira:`ZEP-1966` - Doesn't seem to be able to both send and receive locally via local address
-* :jira:`ZEP-1968` - "make mrproper" removes top-level dts/ dir, makes ARM builds fail afterwards
-* :jira:`ZEP-1980` - Move app_kernel benchmark to unified kernel
-* :jira:`ZEP-1984` - net_nbuf_append(), net_nbuf_append_bytes() have data integrity problems
-* :jira:`ZEP-1990` - Basic support for the BBC micro:bit LED display
-* :jira:`ZEP-1993` - Flowcontrol Required for CDC_ACM
-* :jira:`ZEP-1995` - samples/subsys/console breaks xtensa build
-* :jira:`ZEP-1997` - Crash during startup if co-processors are present
-* :jira:`ZEP-2008` - Port tickless idle test to unified kernel and cleanup
-* :jira:`ZEP-2009` - Port test_sleep test to unified kernel and cleanup
-* :jira:`ZEP-2011` - Retrieve RPL node information through CoAP requests
-* :jira:`ZEP-2012` - Fault in networking stack for cores that can't access unaligned memory
-* :jira:`ZEP-2013` - dead object monitor code
-* :jira:`ZEP-2014` - Default samples/subsys/shell/shell fails to build on QEMU RISCv32 / NIOS2
-* :jira:`ZEP-2019` - Xtensa port does not compile if CONFIG_TICKLESS_IDLE is enabled
-* :jira:`ZEP-2027` - Bluetooth Peripheral Sample won't pair with certain Android devices
-* :jira:`ZEP-2029` - xtensa: irq_offload() doesn't work on XRC_D2PM
-* :jira:`ZEP-2033` - Channel Selection Algorithm #2
-* :jira:`ZEP-2034` - High Duty Cycle Non-Connectable Advertising
-* :jira:`ZEP-2037` - Malformed echo response
-* :jira:`ZEP-2048` - Change UART "baud-rate" property to "current-speed"
-* :jira:`ZEP-2051` - Move away from C99 types to zephyr defined types
-* :jira:`ZEP-2052` - arm: unhandled exceptions in thread take down entire system
-* :jira:`ZEP-2055` - Add README.rst in the root of the project for github
-* :jira:`ZEP-2057` - crash in tests/net/rpl on qemu_x86 causing intermittent sanitycheck failure
-* :jira:`ZEP-2061` - samples/net/dns_resolve networking setup/README is confusing
-* :jira:`ZEP-2064` - RFC: Making net_shell command handlers reusable
-* :jira:`ZEP-2065` - struct dns_addrinfo has unused fields
-* :jira:`ZEP-2066` - nitpick: SOCK_STREAM/SOCK_DGRAM values swapped compared to most OSes
-* :jira:`ZEP-2069` - samples: net: dhcpv4_client: runs failed on frdm k64f board
-* :jira:`ZEP-2070` - net pkt doesn't full unref after send a data form bluetooth's ipsp
-* :jira:`ZEP-2076` - samples: net: coaps_server: build failed
-* :jira:`ZEP-2077` - Fix IID when using CONFIG_NET_L2_BLUETOOTH_ZEP1656
-* :jira:`ZEP-2080` - No reply from RPL node after 20-30 minutes.
-* :jira:`ZEP-2092` - [NRF][BT] Makefile:946: recipe for target 'include/generated/generated_dts_board.h' failed
-* :jira:`ZEP-2114` - tests/kernel/fatal : Fail for QC1000/arc
-* :jira:`ZEP-2125` - Compilation error when UART1 port is enabled via menuconfig
-* :jira:`ZEP-2132` - Build samples/bluetooth/hci_uart fail
-* :jira:`ZEP-2138` - Static code scan (coverity) issues seen
-* :jira:`ZEP-2143` - Compilation Error on Windows 10 with MSYS2
-* :jira:`ZEP-2152` - Xtensa crashes on startup for cores with coprocessors
-* :jira:`ZEP-2178` - Static code scan (coverity) issues seen
+* ``ZEP-248`` - Add a BOARD/SOC porting guide
+* ``ZEP-339`` - Tickless Kernel
+* ``ZEP-540`` - add APIs for asynchronous transfer callbacks
+* ``ZEP-628`` - Validate RPL Routing node support
+* ``ZEP-638`` - feature to consider: flag missing functionality at build time when possible
+* ``ZEP-720`` - Add MAX30101 heart rate sensor driver
+* ``ZEP-828`` - IPv6 - Multicast Join/Leave Support
+* ``ZEP-843`` - Unified assert/unrecoverable error infrastructure
+* ``ZEP-888`` - 802.15.4 - Security support
+* ``ZEP-932`` - Adapt kernel sample & test projects
+* ``ZEP-948`` - Revisit the timeslicing algorithm
+* ``ZEP-973`` - Remove deprecated API related to device PM functions and DEVICE\_ and SYS\_* macros
+* ``ZEP-1028`` - shrink k_block struct size
+* ``ZEP-1032`` - IPSP router role support
+* ``ZEP-1169`` - Sample mbedDTLS DTLS client stability on ethernet driver
+* ``ZEP-1171`` - Event group kernel APIs
+* ``ZEP-1280`` - Provide Event Queues Object
+* ``ZEP-1313`` - porting and user guides must include a security section
+* ``ZEP-1326`` - Clean up _THREAD_xxx APIs
+* ``ZEP-1388`` - Add support for KW40 SoC
+* ``ZEP-1391`` - Add support for Hexiwear KW40
+* ``ZEP-1392`` - Add FXAS21002 gyroscope sensor driver
+* ``ZEP-1435`` - Improve Quark SE C1000 ARC Floating Point Performance
+* ``ZEP-1438`` - AIO: AIO Comparator is not stable on D2000 and Arduino101
+* ``ZEP-1463`` - Add Zephyr Support in segger SystemView
+* ``ZEP-1500`` - net/mqtt: Test case for the MQTT high-level API
+* ``ZEP-1528`` - Provide template for multi-core applications
+* ``ZEP-1529`` - Unable to exit menuconfig
+* ``ZEP-1530`` - Hotkeys for the menu at the bottom of menuconfig sometimes doesn't work
+* ``ZEP-1568`` - Replace arm cortex_m scs and scb functionality with direct CMSIS-core calls
+* ``ZEP-1586`` - menuconfig: Backspace is broken
+* ``ZEP-1599`` - printk() support for the '-' indicator  in format string (left justifier)
+* ``ZEP-1607`` - JSON encoding/decoding library
+* ``ZEP-1621`` - Stack Monitoring
+* ``ZEP-1631`` - Ability to use k_mem_pool_alloc (or similar API) from ISR
+* ``ZEP-1684`` - Add Atmel SAM family watchdog (WDT) driver
+* ``ZEP-1695`` - Support ADXL362 sensor
+* ``ZEP-1698`` - BME280 support for SPI communication
+* ``ZEP-1711`` - xtensa build defines Kconfigs with lowercase names
+* ``ZEP-1718`` - support for IPv6 fragmentation
+* ``ZEP-1719`` - TCP does not work with 6lo
+* ``ZEP-1721`` - many TinyCrypt test cases only run on ARM and x86
+* ``ZEP-1722`` - xtensa: TinyCrypt does not build
+* ``ZEP-1735`` - Controller to Host flow control
+* ``ZEP-1759`` - All python scripts needed for build should be moved to python 3 to minimize dependencies
+* ``ZEP-1761`` - K_MEM_POOL_DEFINE build error "invalid register name" when built with llvm/icx from ISSM toolchain
+* ``ZEP-1769`` - Implement  Set Event Mask and LE Set Event Mask commands
+* ``ZEP-1772`` - re-introduce controller to host flow control
+* ``ZEP-1776`` - sending LE COC data from RX thread can lead to deadlock
+* ``ZEP-1785`` - Tinytile: Flashing not supported with this board
+* ``ZEP-1788`` - [REG] bt_enable: No HCI driver registered
+* ``ZEP-1800`` - Update external mbed TLS library to latest version (2.4.2)
+* ``ZEP-1812`` - Add tickless kernel support in HPET timer
+* ``ZEP-1816`` - Add tickless kernel support in LOAPIC timer
+* ``ZEP-1817`` - Add tickless kernel support in ARCV2 timer
+* ``ZEP-1818`` - Add tickless kernel support in cortex_m_systick timer
+* ``ZEP-1821`` - Update PM apps to use mili/micro seconds instead of ticks
+* ``ZEP-1823`` - Improved Benchmarks
+* ``ZEP-1825`` - Context Switching KPI
+* ``ZEP-1836`` - Expose current ecb_encrypt() as bt_encrypt() so host can directly access it
+* ``ZEP-1856`` - remove legacy micro/nano kernel APIs
+* ``ZEP-1857`` - Build warnings [-Wpointer-sign] with LLVM/icx (bluetooth_handsfree)
+* ``ZEP-1866`` - Add Atmel SAM family I2C (TWIHS) driver
+* ``ZEP-1880`` - "samples/grove/temperature": warning raised when generating configure file
+* ``ZEP-1886`` - Build warnings [-Wpointer-sign] with LLVM/icx (tests/net/nbuf)
+* ``ZEP-1887`` - Build warnings [-Wpointer-sign] with LLVM/icx (tests/drivers/spi/spi_basic_api)
+* ``ZEP-1893`` - openocd: 'make flash' works with Zephyr SDK only and fails for all other toolchains
+* ``ZEP-1896`` - [PTS] L2CAP/LE/CFC/BV-06-C
+* ``ZEP-1899`` - Missing board documentation for xtensa/xt-sim
+* ``ZEP-1908`` - Missing board documentation for arm/nucleo_96b_nitrogen
+* ``ZEP-1910`` - Missing board documentation for arm/96b_carbon
+* ``ZEP-1927`` - AIO: AIO_CMP_POL_FALL is triggered immediately after aio_cmp_configure
+* ``ZEP-1935`` - Packet loss make RPL mesh more vulnerable
+* ``ZEP-1936`` - tests/drivers/spi/spi_basic_api/testcase.ini#test_spi - Assertion Fail
+* ``ZEP-1946`` - Time to Next Event
+* ``ZEP-1955`` - Nested interrupts crash on Xtensa architecture
+* ``ZEP-1959`` - Add Atmel SAM family serial (UART) driver
+* ``ZEP-1965`` - net-tools HEAD is broken for QEMU/TAP
+* ``ZEP-1966`` - Doesn't seem to be able to both send and receive locally via local address
+* ``ZEP-1968`` - "make mrproper" removes top-level dts/ dir, makes ARM builds fail afterwards
+* ``ZEP-1980`` - Move app_kernel benchmark to unified kernel
+* ``ZEP-1984`` - net_nbuf_append(), net_nbuf_append_bytes() have data integrity problems
+* ``ZEP-1990`` - Basic support for the BBC micro:bit LED display
+* ``ZEP-1993`` - Flowcontrol Required for CDC_ACM
+* ``ZEP-1995`` - samples/subsys/console breaks xtensa build
+* ``ZEP-1997`` - Crash during startup if co-processors are present
+* ``ZEP-2008`` - Port tickless idle test to unified kernel and cleanup
+* ``ZEP-2009`` - Port test_sleep test to unified kernel and cleanup
+* ``ZEP-2011`` - Retrieve RPL node information through CoAP requests
+* ``ZEP-2012`` - Fault in networking stack for cores that can't access unaligned memory
+* ``ZEP-2013`` - dead object monitor code
+* ``ZEP-2014`` - Default samples/subsys/shell/shell fails to build on QEMU RISCv32 / NIOS2
+* ``ZEP-2019`` - Xtensa port does not compile if CONFIG_TICKLESS_IDLE is enabled
+* ``ZEP-2027`` - Bluetooth Peripheral Sample won't pair with certain Android devices
+* ``ZEP-2029`` - xtensa: irq_offload() doesn't work on XRC_D2PM
+* ``ZEP-2033`` - Channel Selection Algorithm #2
+* ``ZEP-2034`` - High Duty Cycle Non-Connectable Advertising
+* ``ZEP-2037`` - Malformed echo response
+* ``ZEP-2048`` - Change UART "baud-rate" property to "current-speed"
+* ``ZEP-2051`` - Move away from C99 types to zephyr defined types
+* ``ZEP-2052`` - arm: unhandled exceptions in thread take down entire system
+* ``ZEP-2055`` - Add README.rst in the root of the project for github
+* ``ZEP-2057`` - crash in tests/net/rpl on qemu_x86 causing intermittent sanitycheck failure
+* ``ZEP-2061`` - samples/net/dns_resolve networking setup/README is confusing
+* ``ZEP-2064`` - RFC: Making net_shell command handlers reusable
+* ``ZEP-2065`` - struct dns_addrinfo has unused fields
+* ``ZEP-2066`` - nitpick: SOCK_STREAM/SOCK_DGRAM values swapped compared to most OSes
+* ``ZEP-2069`` - samples: net: dhcpv4_client: runs failed on frdm k64f board
+* ``ZEP-2070`` - net pkt doesn't full unref after send a data form bluetooth's ipsp
+* ``ZEP-2076`` - samples: net: coaps_server: build failed
+* ``ZEP-2077`` - Fix IID when using CONFIG_NET_L2_BLUETOOTH_ZEP1656
+* ``ZEP-2080`` - No reply from RPL node after 20-30 minutes.
+* ``ZEP-2092`` - [NRF][BT] Makefile:946: recipe for target 'include/generated/generated_dts_board.h' failed
+* ``ZEP-2114`` - tests/kernel/fatal : Fail for QC1000/arc
+* ``ZEP-2125`` - Compilation error when UART1 port is enabled via menuconfig
+* ``ZEP-2132`` - Build samples/bluetooth/hci_uart fail
+* ``ZEP-2138`` - Static code scan (coverity) issues seen
+* ``ZEP-2143`` - Compilation Error on Windows 10 with MSYS2
+* ``ZEP-2152`` - Xtensa crashes on startup for cores with coprocessors
+* ``ZEP-2178`` - Static code scan (coverity) issues seen

--- a/doc/releases/release-notes-1.9.rst
+++ b/doc/releases/release-notes-1.9.rst
@@ -207,176 +207,176 @@ Tests and Samples
 
 JIRA Related Items
 ******************
-* :jira:`ZEP-230` - Define I2S driver APIs
-* :jira:`ZEP-601` - enable CONFIG_DEBUG_INFO
-* :jira:`ZEP-702` - Integrate Nordic's Phoenix Link Layer into Zephyr
-* :jira:`ZEP-749` - TinyCrypt uses an old, unoptimized version of micro-ecc
-* :jira:`ZEP-896` - nRF5x Series: Add support for power and clock peripheral
-* :jira:`ZEP-1067` - Driver for BMM150
-* :jira:`ZEP-1396` - Add ksdk adc shim driver
-* :jira:`ZEP-1426` - CONFIG_BOOT_TIME_MEASUREMENT on all targets?
-* :jira:`ZEP-1552` - Provide apds9960 sensor driver
-* :jira:`ZEP-1647` - Figure out new combo for breathe/doxygen/sphinx versions that are supported
-* :jira:`ZEP-1744` - UPF 56 BLE Controller Issues
-* :jira:`ZEP-1751` - Add template YAML file
-* :jira:`ZEP-1819` - Add tickless kernel support in nrf_rtc_timer timer
-* :jira:`ZEP-1843` - provide mechanism to filter test cases based on available hardware
-* :jira:`ZEP-1892` - Fix issues with Fix Release
-* :jira:`ZEP-1902` - Missing board documentation for arm/nucleo_f334r8
-* :jira:`ZEP-1911` - Missing board documentation for arm/stm3210c_eval
-* :jira:`ZEP-1917` - Missing board documentation for arm/stm32373c_eval
-* :jira:`ZEP-1918` - Fix connection parameter request procedure
-* :jira:`ZEP-2018` - Remove deprecated PWM APIs
-* :jira:`ZEP-2020` - tests/crypto/test_ecc_dsa intermittently fails on riscv32
-* :jira:`ZEP-2025` - Add mcux pwm shim driver for k64
-* :jira:`ZEP-2031` - ESP32 Architecture Configuration
-* :jira:`ZEP-2032` - Espressif Open-source Toolchain Support
-* :jira:`ZEP-2039` - Implement stm32cube LL based clock control driver
-* :jira:`ZEP-2054` - Convert all helper script to use python3
-* :jira:`ZEP-2062` - Convert gen_offset_header to a python script
-* :jira:`ZEP-2063` - Convert gen_idt to python
-* :jira:`ZEP-2068` - Need Tasks to Be Tracked in QRC too
-* :jira:`ZEP-2071` - samples: warning: (SPI_CS_GPIO && SPI_SS_CS_GPIO && I2C_NRF5) selects GPIO which has unmet direct dependencies
-* :jira:`ZEP-2085` - Add CONTRIBUTING.rst to root folder w/contributing guidelines
-* :jira:`ZEP-2089` - UART support for ESP32
-* :jira:`ZEP-2115` - Common API for networked applications for setting up network
-* :jira:`ZEP-2116` - Common API for networked apps to create client/server applications
-* :jira:`ZEP-2141` - Coverity CID 169303 in tests/net/ipv6/src/main.c
-* :jira:`ZEP-2150` - Move Arduino 101 to Device Tree
-* :jira:`ZEP-2151` - Move Quark D2000 to device tree
-* :jira:`ZEP-2156` - Build warnings [-Wformat] with LLVM/icx (tests/kernel/sprintf)
-* :jira:`ZEP-2168` - Timers seem to be broken with TICKLESS_KERNEL on nRF51 (Cortex M0)
-* :jira:`ZEP-2171` - Move all board pinmux code from drivers/pinmux/stm32 to the corresponding board/soc locations
-* :jira:`ZEP-2184` - Split data, bss, noinit sections into application and kernel areas
-* :jira:`ZEP-2188` - x86: Implement simple stack memory protection
-* :jira:`ZEP-2217` - schedule_api test fails on ARM with tickless kernel enabled
-* :jira:`ZEP-2218` - unexpected short timeslice when running schedule_api with tickless kernel enabled
-* :jira:`ZEP-2220` - Extend MPU to stm32 family
-* :jira:`ZEP-2225` - Ability to unregister GATT services
-* :jira:`ZEP-2226` - BSD Sockets API: Basic blocking API
-* :jira:`ZEP-2227` - BSD Sockets API: Non-blocking API
-* :jira:`ZEP-2229` - test_time_slicing_preemptible fails on bbc_microbit and other NRF boards
-* :jira:`ZEP-2250` - sanitycheck not filtering defconfigs properly
-* :jira:`ZEP-2258` - Coverity static scan issues seen
-* :jira:`ZEP-2265` - stack declaration macros for ARM MPU
-* :jira:`ZEP-2267` - Create Release Notes
-* :jira:`ZEP-2270` - Convert mpu_stack_guard_test from using k_thread_spawn to k_thread_create
-* :jira:`ZEP-2274` - Build warnings [-Wpointer-sign] with LLVM/icx (tests/net/ipv6_fragment)
-* :jira:`ZEP-2278` - KW41-Z 802.15.4 driver hangs if full debug is disabled
-* :jira:`ZEP-2279` - echo_server TCP handler corrupt by SYN flood
-* :jira:`ZEP-2280` - add test case for KBUILD_ZEPHYR_APP
-* :jira:`ZEP-2285` - non-boards shows up in board list for docs
-* :jira:`ZEP-2286` - Write a GPIO driver for ESP32
-* :jira:`ZEP-2289` - [DoS] Memory leak from large TCP packets
-* :jira:`ZEP-2296` - ESP32: watchdog driver
-* :jira:`ZEP-2297` - ESP32: Pin mux driver
-* :jira:`ZEP-2303` - Concurrent incoming TCP connections
-* :jira:`ZEP-2305` - linker: implement MMU alignment constraints
-* :jira:`ZEP-2306` - echo server hangs from IPv6 hop-by-hop option anomaly
-* :jira:`ZEP-2308` - (New) Networking API details documentation is missing
-* :jira:`ZEP-2310` - Improve configuration documentation index organization
-* :jira:`ZEP-2314` - Testcase failure :tests/benchmarks/timing_info/testcase.ini#test
-* :jira:`ZEP-2316` - Testcase failure :tests/bluetooth/shell/testcase.ini#test_br
-* :jira:`ZEP-2318` - some kernel objects sections are misaligned
-* :jira:`ZEP-2319` - tests/net/ieee802154/l2 uses semaphore before initialization
-* :jira:`ZEP-2321` - [PTS] All TC's of SM/GATT/GAP failed due to BTP_TIMEOUT error.
-* :jira:`ZEP-2326` - x86: API to validate user buffer
-* :jira:`ZEP-2328` - gen_mmu.py appears to generate incorrect tables in some situations
-* :jira:`ZEP-2329` - bad memory access tests/net/route
-* :jira:`ZEP-2330` - bad memory access tests/net/rpl
-* :jira:`ZEP-2331` - bad memory access tests/net/ieee802154/l2
-* :jira:`ZEP-2332` - bad memory access tests/net/ip-addr
-* :jira:`ZEP-2334` - bluetooth shell build warning when CONFIG_DEBUG=y
-* :jira:`ZEP-2335` - Ensure the Licensing page is up-to-date for the release
-* :jira:`ZEP-2340` - Disabling advertising gets stuck
-* :jira:`ZEP-2341` - Build warnings:override: reassigning to symbol MAIN_STACK_SIZE with LLVM/icx (/tests/net/6lo)
-* :jira:`ZEP-2343` - Coverity static scan issues seen
-* :jira:`ZEP-2344` - Coverity static scan issues seen
-* :jira:`ZEP-2345` - Coverity static scan issues seen
-* :jira:`ZEP-2352` - network API docs don't mention when callbacks are called from a different thread
-* :jira:`ZEP-2354` - ESP32: Random number generator
-* :jira:`ZEP-2355` - Coverity static scan issues seen
-* :jira:`ZEP-2358` - samples:net:echo_server: Failed to send UDP packets
-* :jira:`ZEP-2359` - samples:net:coaps_server: unable to bind with IPv6
-* :jira:`ZEP-2360` - Initial implementation of Bluetooth Mesh
-* :jira:`ZEP-2361` - Provide a POSIX compatibility Layer on top of native APIs
-* :jira:`ZEP-2365` - samples/net/wpanusb/test_15_4 fail on nrf52840_pca10056 and frdm_kw41z
-* :jira:`ZEP-2366` - implement \__kernel attribute
-* :jira:`ZEP-2367` - NULL pointer read in udp, tcp, context net tests
-* :jira:`ZEP-2368` - x86: QEMU: enable MMU at boot by default
-* :jira:`ZEP-2370` - [test] Create a stress test to test preemptive scheduling on zephyr
-* :jira:`ZEP-2371` - [test] Create a stress test to test round robin scheduling with equal priority tasks on zephyr
-* :jira:`ZEP-2374` - Build warnings:override: reassigning to symbol NET_IPV4 with LLVM/icx (/tests/net/dhcpv4)
-* :jira:`ZEP-2375` - Build warnings [-Wpointer-sign] with LLVM/icx (tests/net/udp)
-* :jira:`ZEP-2378` - sample/bluetooth/ipsp: When build the app 'ROM' overflowed
-* :jira:`ZEP-2379` - samples/bluetooth: Bluetooth init failed (err -19)
-* :jira:`ZEP-2380` - TCP is broken by Zephyr commit 3604c391e
-* :jira:`ZEP-2382` - Convert test to use ztest framework
-* :jira:`ZEP-2383` - Net-app API needs to support DTLS
-* :jira:`ZEP-2384` - "Common" bluetooth sample code does not build out of tree
-* :jira:`ZEP-2385` - Update TinyCrypt to 0.2.7
-* :jira:`ZEP-2395` - Assert in http_server example when run over bluetooth on nrf52840
-* :jira:`ZEP-2397` - net_if_ipv6_addr_rm calls k_delayed_work_cancel() on uninitialized k_delayed_work object
-* :jira:`ZEP-2398` - network stack test cases are only tested on x86
-* :jira:`ZEP-2403` - Enabling MMU for qemu_x86 broke active connect support
-* :jira:`ZEP-2407` - [Cortex m series ] Getting a crash on Cortex m3 series when more than 8 preemptive threads with equal priority are scheduled
-* :jira:`ZEP-2408` - design mechanism for kernel object sharing policy
-* :jira:`ZEP-2412` - Bluetooth tester app not working from commit c1e5cb
-* :jira:`ZEP-2423` - samples/bluetooth/ipsp's builtin TCP echo crashes on TCP closure
-* :jira:`ZEP-2432` - ieee802154_shell.c, net_mgmt call leads to a BUS FAULT
-* :jira:`ZEP-2433` - x86: do forensic analysis to determine stack overflow context in supervisor mode
-* :jira:`ZEP-2436` - Unable to see console output in Quark_D200_CRB
-* :jira:`ZEP-2437` - warnings when building applications for quark d2000
-* :jira:`ZEP-2444` - [nrf] Scheduling test API is getting failed in case of nrf51/nrf52 platforms
-* :jira:`ZEP-2445` - nrf52: CPU lock-up when using Bluetooth + Flash driver + CONFIG_ASSERT
-* :jira:`ZEP-2447` - 'make debugserver' fails for qemu_x86_iamcu
-* :jira:`ZEP-2451` - Move Bluetooth IPSP support functions from samples/bluetooth to a separate library
-* :jira:`ZEP-2452` - https server does not build for olimex_stm32_e407
-* :jira:`ZEP-2457` - generated/offsets.h is being regenerated unnecessarily
-* :jira:`ZEP-2459` - Sample application not working with Quark SE C1000
-* :jira:`ZEP-2460` - tests/crypto/ecc_dh fails on qemu_nios2
-* :jira:`ZEP-2464` - "allow IPv6 interface init to work with late IP assignment" patch broke non-late IPv6 assignment
-* :jira:`ZEP-2465` - Static code scan (coverity) issues seen
-* :jira:`ZEP-2467` - Static code scan (coverity) issues seen
-* :jira:`ZEP-2468` - Static code scan (coverity) issues seen
-* :jira:`ZEP-2469` - Static code scan (coverity) issues seen
-* :jira:`ZEP-2474` - Static code scan (coverity) issues seen
-* :jira:`ZEP-2480` - Build warnings [-Wpointer-sign] with LLVM/icx (samples/net/coaps_server)
-* :jira:`ZEP-2482` - Build warnings [-Wpointer-sign] with LLVM/icx (samples/net/telnet)
-* :jira:`ZEP-2483` - samples:net:http_client: Failed to get http requests in IPv6
-* :jira:`ZEP-2484` - samples:net:http_server: Failed to work in IPv6
-* :jira:`ZEP-2485` - Build warnings [-Wpointer-sign] with LLVM/icx (samples/net/coaps_client)
-* :jira:`ZEP-2486` - Build warnings [-Wpointer-sign] with LLVM/icx (samples/net/mbedtls_dtlsserver)
-* :jira:`ZEP-2488` - Build warnings [-Wpointer-sign] and [-Warray-bounds] with LLVM/icx (samples/net/irc_bot)
-* :jira:`ZEP-2489` - bug in _x86_mmu_buffer_validate API
-* :jira:`ZEP-2496` - Build failure on tests/benchmarks/object_footprint
-* :jira:`ZEP-2497` - [TIMER] k_timer_start should take 0 value for duration parameter
-* :jira:`ZEP-2498` - [Display] Minimum Duration argument to k_timer_start should be non Zero positive value
-* :jira:`ZEP-2508` - esp32 linkage doesn't unify ELF sections correctly
-* :jira:`ZEP-2510` - BT: CONFIG_BT_HCI_TX_STACK_SIZE appears to be too low for BT_SPI
-* :jira:`ZEP-2514` - XCC sanitycheck build compile wrong targets
-* :jira:`ZEP-2523` - Static code scan (Coverity) issue seen in file: /samples/net/zoap_server/src/zoap-server.c
-* :jira:`ZEP-2525` - Static code scan (Coverity) issue seen in file: /samples/net/zoap_server/src/zoap-server.c
-* :jira:`ZEP-2531` - Static code scan (Coverity) issue seen in file: /tests/net/lib/dns_resolve/src/main.c
-* :jira:`ZEP-2528` - Static code scan (Coverity) issue seen in file: /samples/net/nats/src/nats.c
-* :jira:`ZEP-2534` - Static code scan (Coverity) issue seen in file: /tests/kernel/irq_offload/src/irq_offload.c
-* :jira:`ZEP-2535` - Static code scan (Coverity) issue seen in file: /tests/net/lib/zoap/src/main.c
-* :jira:`ZEP-2537` - Static code scan (Coverity) issue seen in file: /tests/crypto/ecc_dh/src/ecc_dh.c
-* :jira:`ZEP-2538` - Static code scan (Coverity) issue seen in file: /arch/arm/soc/st_stm32/stm32f1/soc_gpio.c
-* :jira:`ZEP-2539` - Static code scan (Coverity) issue seen in file: /tests/net/ieee802154/l2/src/ieee802154_test.c
-* :jira:`ZEP-2540` - Static code scan (Coverity) issue seen in file: /ext/lib/crypto/tinycrypt/source/ecc_dh.c
-* :jira:`ZEP-2541` - Static code scan (Coverity) issue seen in file: /subsys/bluetooth/host/mesh/cfg.c
-* :jira:`ZEP-2549` - Static code scan (Coverity) issue seen in file: /samples/net/leds_demo/src/leds-demo.c
-* :jira:`ZEP-2552` - ESP32 uart poll_out always return 0
-* :jira:`ZEP-2553` - k_queue_poll not handling -EADDRINUSE (another thread already polling) properly
-* :jira:`ZEP-2556` - ESP32 watchdog WDT_MODE_INTERRUPT_RESET mode fails
-* :jira:`ZEP-2557` - ESP32 : Some GPIO tests are getting failed (tests/drivers/gpio/gpio_basic_api)
-* :jira:`ZEP-2558` - CONFIG_BLUETOOTH_* Kconfig options silently ignored
-* :jira:`ZEP-2560` - samples/net: the sample of zoap_server fails to add multicast address
-* :jira:`ZEP-2561` - samples/net: The HTTP client failed to send the POST request
-* :jira:`ZEP-2568` - [PTS] All TC's of L2CAP/SM/GATT/GAP failed due to BTP_ERROR.
-* :jira:`ZEP-2575` - error:[ '-O: command not found'] with LLVM/icx (samples/hello_world)
-* :jira:`ZEP-2576` - samples/net/sockets/echo, echo_async : fails to send the TCP packets
-* :jira:`ZEP-2581` - CC3220 executable binary format support
-* :jira:`ZEP-2584` - Update mbedTLS to 2.6.0
-* :jira:`ZEP-713`  - Implement preemptible regular IRQs on ARC
+* ``ZEP-230`` - Define I2S driver APIs
+* ``ZEP-601`` - enable CONFIG_DEBUG_INFO
+* ``ZEP-702`` - Integrate Nordic's Phoenix Link Layer into Zephyr
+* ``ZEP-749`` - TinyCrypt uses an old, unoptimized version of micro-ecc
+* ``ZEP-896`` - nRF5x Series: Add support for power and clock peripheral
+* ``ZEP-1067`` - Driver for BMM150
+* ``ZEP-1396`` - Add ksdk adc shim driver
+* ``ZEP-1426`` - CONFIG_BOOT_TIME_MEASUREMENT on all targets?
+* ``ZEP-1552`` - Provide apds9960 sensor driver
+* ``ZEP-1647`` - Figure out new combo for breathe/doxygen/sphinx versions that are supported
+* ``ZEP-1744`` - UPF 56 BLE Controller Issues
+* ``ZEP-1751`` - Add template YAML file
+* ``ZEP-1819`` - Add tickless kernel support in nrf_rtc_timer timer
+* ``ZEP-1843`` - provide mechanism to filter test cases based on available hardware
+* ``ZEP-1892`` - Fix issues with Fix Release
+* ``ZEP-1902`` - Missing board documentation for arm/nucleo_f334r8
+* ``ZEP-1911`` - Missing board documentation for arm/stm3210c_eval
+* ``ZEP-1917`` - Missing board documentation for arm/stm32373c_eval
+* ``ZEP-1918`` - Fix connection parameter request procedure
+* ``ZEP-2018`` - Remove deprecated PWM APIs
+* ``ZEP-2020`` - tests/crypto/test_ecc_dsa intermittently fails on riscv32
+* ``ZEP-2025`` - Add mcux pwm shim driver for k64
+* ``ZEP-2031`` - ESP32 Architecture Configuration
+* ``ZEP-2032`` - Espressif Open-source Toolchain Support
+* ``ZEP-2039`` - Implement stm32cube LL based clock control driver
+* ``ZEP-2054`` - Convert all helper script to use python3
+* ``ZEP-2062`` - Convert gen_offset_header to a python script
+* ``ZEP-2063`` - Convert gen_idt to python
+* ``ZEP-2068`` - Need Tasks to Be Tracked in QRC too
+* ``ZEP-2071`` - samples: warning: (SPI_CS_GPIO && SPI_SS_CS_GPIO && I2C_NRF5) selects GPIO which has unmet direct dependencies
+* ``ZEP-2085`` - Add CONTRIBUTING.rst to root folder w/contributing guidelines
+* ``ZEP-2089`` - UART support for ESP32
+* ``ZEP-2115`` - Common API for networked applications for setting up network
+* ``ZEP-2116`` - Common API for networked apps to create client/server applications
+* ``ZEP-2141`` - Coverity CID 169303 in tests/net/ipv6/src/main.c
+* ``ZEP-2150`` - Move Arduino 101 to Device Tree
+* ``ZEP-2151`` - Move Quark D2000 to device tree
+* ``ZEP-2156`` - Build warnings [-Wformat] with LLVM/icx (tests/kernel/sprintf)
+* ``ZEP-2168`` - Timers seem to be broken with TICKLESS_KERNEL on nRF51 (Cortex M0)
+* ``ZEP-2171`` - Move all board pinmux code from drivers/pinmux/stm32 to the corresponding board/soc locations
+* ``ZEP-2184`` - Split data, bss, noinit sections into application and kernel areas
+* ``ZEP-2188`` - x86: Implement simple stack memory protection
+* ``ZEP-2217`` - schedule_api test fails on ARM with tickless kernel enabled
+* ``ZEP-2218`` - unexpected short timeslice when running schedule_api with tickless kernel enabled
+* ``ZEP-2220`` - Extend MPU to stm32 family
+* ``ZEP-2225`` - Ability to unregister GATT services
+* ``ZEP-2226`` - BSD Sockets API: Basic blocking API
+* ``ZEP-2227`` - BSD Sockets API: Non-blocking API
+* ``ZEP-2229`` - test_time_slicing_preemptible fails on bbc_microbit and other NRF boards
+* ``ZEP-2250`` - sanitycheck not filtering defconfigs properly
+* ``ZEP-2258`` - Coverity static scan issues seen
+* ``ZEP-2265`` - stack declaration macros for ARM MPU
+* ``ZEP-2267`` - Create Release Notes
+* ``ZEP-2270`` - Convert mpu_stack_guard_test from using k_thread_spawn to k_thread_create
+* ``ZEP-2274`` - Build warnings [-Wpointer-sign] with LLVM/icx (tests/net/ipv6_fragment)
+* ``ZEP-2278`` - KW41-Z 802.15.4 driver hangs if full debug is disabled
+* ``ZEP-2279`` - echo_server TCP handler corrupt by SYN flood
+* ``ZEP-2280`` - add test case for KBUILD_ZEPHYR_APP
+* ``ZEP-2285`` - non-boards shows up in board list for docs
+* ``ZEP-2286`` - Write a GPIO driver for ESP32
+* ``ZEP-2289`` - [DoS] Memory leak from large TCP packets
+* ``ZEP-2296`` - ESP32: watchdog driver
+* ``ZEP-2297`` - ESP32: Pin mux driver
+* ``ZEP-2303`` - Concurrent incoming TCP connections
+* ``ZEP-2305`` - linker: implement MMU alignment constraints
+* ``ZEP-2306`` - echo server hangs from IPv6 hop-by-hop option anomaly
+* ``ZEP-2308`` - (New) Networking API details documentation is missing
+* ``ZEP-2310`` - Improve configuration documentation index organization
+* ``ZEP-2314`` - Testcase failure :tests/benchmarks/timing_info/testcase.ini#test
+* ``ZEP-2316`` - Testcase failure :tests/bluetooth/shell/testcase.ini#test_br
+* ``ZEP-2318`` - some kernel objects sections are misaligned
+* ``ZEP-2319`` - tests/net/ieee802154/l2 uses semaphore before initialization
+* ``ZEP-2321`` - [PTS] All TC's of SM/GATT/GAP failed due to BTP_TIMEOUT error.
+* ``ZEP-2326`` - x86: API to validate user buffer
+* ``ZEP-2328`` - gen_mmu.py appears to generate incorrect tables in some situations
+* ``ZEP-2329`` - bad memory access tests/net/route
+* ``ZEP-2330`` - bad memory access tests/net/rpl
+* ``ZEP-2331`` - bad memory access tests/net/ieee802154/l2
+* ``ZEP-2332`` - bad memory access tests/net/ip-addr
+* ``ZEP-2334`` - bluetooth shell build warning when CONFIG_DEBUG=y
+* ``ZEP-2335`` - Ensure the Licensing page is up-to-date for the release
+* ``ZEP-2340`` - Disabling advertising gets stuck
+* ``ZEP-2341`` - Build warnings:override: reassigning to symbol MAIN_STACK_SIZE with LLVM/icx (/tests/net/6lo)
+* ``ZEP-2343`` - Coverity static scan issues seen
+* ``ZEP-2344`` - Coverity static scan issues seen
+* ``ZEP-2345`` - Coverity static scan issues seen
+* ``ZEP-2352`` - network API docs don't mention when callbacks are called from a different thread
+* ``ZEP-2354`` - ESP32: Random number generator
+* ``ZEP-2355`` - Coverity static scan issues seen
+* ``ZEP-2358`` - samples:net:echo_server: Failed to send UDP packets
+* ``ZEP-2359`` - samples:net:coaps_server: unable to bind with IPv6
+* ``ZEP-2360`` - Initial implementation of Bluetooth Mesh
+* ``ZEP-2361`` - Provide a POSIX compatibility Layer on top of native APIs
+* ``ZEP-2365`` - samples/net/wpanusb/test_15_4 fail on nrf52840_pca10056 and frdm_kw41z
+* ``ZEP-2366`` - implement \__kernel attribute
+* ``ZEP-2367`` - NULL pointer read in udp, tcp, context net tests
+* ``ZEP-2368`` - x86: QEMU: enable MMU at boot by default
+* ``ZEP-2370`` - [test] Create a stress test to test preemptive scheduling on zephyr
+* ``ZEP-2371`` - [test] Create a stress test to test round robin scheduling with equal priority tasks on zephyr
+* ``ZEP-2374`` - Build warnings:override: reassigning to symbol NET_IPV4 with LLVM/icx (/tests/net/dhcpv4)
+* ``ZEP-2375`` - Build warnings [-Wpointer-sign] with LLVM/icx (tests/net/udp)
+* ``ZEP-2378`` - sample/bluetooth/ipsp: When build the app 'ROM' overflowed
+* ``ZEP-2379`` - samples/bluetooth: Bluetooth init failed (err -19)
+* ``ZEP-2380`` - TCP is broken by Zephyr commit 3604c391e
+* ``ZEP-2382`` - Convert test to use ztest framework
+* ``ZEP-2383`` - Net-app API needs to support DTLS
+* ``ZEP-2384`` - "Common" bluetooth sample code does not build out of tree
+* ``ZEP-2385`` - Update TinyCrypt to 0.2.7
+* ``ZEP-2395`` - Assert in http_server example when run over bluetooth on nrf52840
+* ``ZEP-2397`` - net_if_ipv6_addr_rm calls k_delayed_work_cancel() on uninitialized k_delayed_work object
+* ``ZEP-2398`` - network stack test cases are only tested on x86
+* ``ZEP-2403`` - Enabling MMU for qemu_x86 broke active connect support
+* ``ZEP-2407`` - [Cortex m series ] Getting a crash on Cortex m3 series when more than 8 preemptive threads with equal priority are scheduled
+* ``ZEP-2408`` - design mechanism for kernel object sharing policy
+* ``ZEP-2412`` - Bluetooth tester app not working from commit c1e5cb
+* ``ZEP-2423`` - samples/bluetooth/ipsp's builtin TCP echo crashes on TCP closure
+* ``ZEP-2432`` - ieee802154_shell.c, net_mgmt call leads to a BUS FAULT
+* ``ZEP-2433`` - x86: do forensic analysis to determine stack overflow context in supervisor mode
+* ``ZEP-2436`` - Unable to see console output in Quark_D200_CRB
+* ``ZEP-2437`` - warnings when building applications for quark d2000
+* ``ZEP-2444`` - [nrf] Scheduling test API is getting failed in case of nrf51/nrf52 platforms
+* ``ZEP-2445`` - nrf52: CPU lock-up when using Bluetooth + Flash driver + CONFIG_ASSERT
+* ``ZEP-2447`` - 'make debugserver' fails for qemu_x86_iamcu
+* ``ZEP-2451`` - Move Bluetooth IPSP support functions from samples/bluetooth to a separate library
+* ``ZEP-2452`` - https server does not build for olimex_stm32_e407
+* ``ZEP-2457`` - generated/offsets.h is being regenerated unnecessarily
+* ``ZEP-2459`` - Sample application not working with Quark SE C1000
+* ``ZEP-2460`` - tests/crypto/ecc_dh fails on qemu_nios2
+* ``ZEP-2464`` - "allow IPv6 interface init to work with late IP assignment" patch broke non-late IPv6 assignment
+* ``ZEP-2465`` - Static code scan (coverity) issues seen
+* ``ZEP-2467`` - Static code scan (coverity) issues seen
+* ``ZEP-2468`` - Static code scan (coverity) issues seen
+* ``ZEP-2469`` - Static code scan (coverity) issues seen
+* ``ZEP-2474`` - Static code scan (coverity) issues seen
+* ``ZEP-2480`` - Build warnings [-Wpointer-sign] with LLVM/icx (samples/net/coaps_server)
+* ``ZEP-2482`` - Build warnings [-Wpointer-sign] with LLVM/icx (samples/net/telnet)
+* ``ZEP-2483`` - samples:net:http_client: Failed to get http requests in IPv6
+* ``ZEP-2484`` - samples:net:http_server: Failed to work in IPv6
+* ``ZEP-2485`` - Build warnings [-Wpointer-sign] with LLVM/icx (samples/net/coaps_client)
+* ``ZEP-2486`` - Build warnings [-Wpointer-sign] with LLVM/icx (samples/net/mbedtls_dtlsserver)
+* ``ZEP-2488`` - Build warnings [-Wpointer-sign] and [-Warray-bounds] with LLVM/icx (samples/net/irc_bot)
+* ``ZEP-2489`` - bug in _x86_mmu_buffer_validate API
+* ``ZEP-2496`` - Build failure on tests/benchmarks/object_footprint
+* ``ZEP-2497`` - [TIMER] k_timer_start should take 0 value for duration parameter
+* ``ZEP-2498`` - [Display] Minimum Duration argument to k_timer_start should be non Zero positive value
+* ``ZEP-2508`` - esp32 linkage doesn't unify ELF sections correctly
+* ``ZEP-2510`` - BT: CONFIG_BT_HCI_TX_STACK_SIZE appears to be too low for BT_SPI
+* ``ZEP-2514`` - XCC sanitycheck build compile wrong targets
+* ``ZEP-2523`` - Static code scan (Coverity) issue seen in file: /samples/net/zoap_server/src/zoap-server.c
+* ``ZEP-2525`` - Static code scan (Coverity) issue seen in file: /samples/net/zoap_server/src/zoap-server.c
+* ``ZEP-2531`` - Static code scan (Coverity) issue seen in file: /tests/net/lib/dns_resolve/src/main.c
+* ``ZEP-2528`` - Static code scan (Coverity) issue seen in file: /samples/net/nats/src/nats.c
+* ``ZEP-2534`` - Static code scan (Coverity) issue seen in file: /tests/kernel/irq_offload/src/irq_offload.c
+* ``ZEP-2535`` - Static code scan (Coverity) issue seen in file: /tests/net/lib/zoap/src/main.c
+* ``ZEP-2537`` - Static code scan (Coverity) issue seen in file: /tests/crypto/ecc_dh/src/ecc_dh.c
+* ``ZEP-2538`` - Static code scan (Coverity) issue seen in file: /arch/arm/soc/st_stm32/stm32f1/soc_gpio.c
+* ``ZEP-2539`` - Static code scan (Coverity) issue seen in file: /tests/net/ieee802154/l2/src/ieee802154_test.c
+* ``ZEP-2540`` - Static code scan (Coverity) issue seen in file: /ext/lib/crypto/tinycrypt/source/ecc_dh.c
+* ``ZEP-2541`` - Static code scan (Coverity) issue seen in file: /subsys/bluetooth/host/mesh/cfg.c
+* ``ZEP-2549`` - Static code scan (Coverity) issue seen in file: /samples/net/leds_demo/src/leds-demo.c
+* ``ZEP-2552`` - ESP32 uart poll_out always return 0
+* ``ZEP-2553`` - k_queue_poll not handling -EADDRINUSE (another thread already polling) properly
+* ``ZEP-2556`` - ESP32 watchdog WDT_MODE_INTERRUPT_RESET mode fails
+* ``ZEP-2557`` - ESP32 : Some GPIO tests are getting failed (tests/drivers/gpio/gpio_basic_api)
+* ``ZEP-2558`` - CONFIG_BLUETOOTH_* Kconfig options silently ignored
+* ``ZEP-2560`` - samples/net: the sample of zoap_server fails to add multicast address
+* ``ZEP-2561`` - samples/net: The HTTP client failed to send the POST request
+* ``ZEP-2568`` - [PTS] All TC's of L2CAP/SM/GATT/GAP failed due to BTP_ERROR.
+* ``ZEP-2575`` - error:[ '-O: command not found'] with LLVM/icx (samples/hello_world)
+* ``ZEP-2576`` - samples/net/sockets/echo, echo_async : fails to send the TCP packets
+* ``ZEP-2581`` - CC3220 executable binary format support
+* ``ZEP-2584`` - Update mbedTLS to 2.6.0
+* ``ZEP-713``  - Implement preemptible regular IRQs on ARC


### PR DESCRIPTION
This patch adds support for the `linkcheck` Sphinx builder, so that we
can easily check for broken links in the documentation.

It can be run like this (after configuring):

```
ninja linkcheck
```

Or, using the Makefile shim:

```
make linkcheck
```

All Zephyr Github issues links are ignored, since we have lots of these
URLs and they quickly hit GH rate limit. They have small chance to be
incorrect, so we should be ok.

First commit deletes a bunch of dead JIRA links.