### PR TITLE
wifi: esp32: make ethernet carrier on after ESP32_WIFI_EVENT_STA_START

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -236,11 +236,11 @@ static void esp_wifi_event_task(void)
 		switch (evt.event_id) {
 		case ESP32_WIFI_EVENT_STA_START:
 			esp32_data.state = ESP32_STA_STARTED;
-			net_if_up(esp32_wifi_iface);
+			net_eth_carrier_on(esp32_wifi_iface);
 			break;
 		case ESP32_WIFI_EVENT_STA_STOP:
 			esp32_data.state = ESP32_STA_STOPPED;
-			net_if_down(esp32_wifi_iface);
+			net_eth_carrier_off(esp32_wifi_iface);
 			break;
 		case ESP32_WIFI_EVENT_STA_CONNECTED:
 			esp_wifi_handle_connect_event();
@@ -429,8 +429,7 @@ static void esp32_wifi_init(struct net_if *iface)
 	net_if_set_link_addr(iface, dev_data->mac_addr, 6, NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
-
-	net_eth_carrier_on(esp32_wifi_iface);
+	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
 
 	esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, eth_esp32_rx);
 }


### PR DESCRIPTION
Driver is not ready to handle `NET_REQUEST_WIFI_CONNECT` wifi_mgmt events before `ESP32_WIFI_EVENT_STA_START` event is received. Revert back to setting `NET_IF_NO_AUTO_START` flag for interface and call `net_eth_carrier_on()` after `ESP32_WIFI_EVENT_STA_START` event is received. This makes it possible for an application to wait for network interface to be ready, e.g. with:

```
  while (!net_if_is_up(iface)) {
     k_sleep(K_MSEC(100));
  }
```
before making a connect request with:
```
  net_mgmt(NET_REQUEST_WIFI_CONNECT, iface ...).
```
Fixes: 7d9edc8bf0fe ("wifi: esp32: add support to wifi api mgmt")