### PR TITLE
doc: api: update overview page

### DIFF
--- a/doc/develop/api/overview.rst
+++ b/doc/develop/api/overview.rst
@@ -20,7 +20,7 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`adc_api`
      - Stable
      - 1.0
-     - 3.1
+     - 3.2
 
    * - :ref:`audio_codec_api`
      - Experimental
@@ -35,7 +35,7 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`bluetooth_api`
      - Stable
      - 1.0
-     - 3.1
+     - 3.2
 
    * - :ref:`clock_control_api`
      - Stable
@@ -45,17 +45,17 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`coap_sock_interface`
      - Unstable
      - 1.10
-     - 2.4
+     - 3.2
 
    * - :ref:`can_api`
      - Unstable
      - 1.14
-     - 3.1
+     - 3.2
 
    * - :ref:`counter_api`
      - Unstable
      - 1.14
-     - 2.6
+     - 3.2
 
    * - :ref:`crypto_api`
      - Stable
@@ -70,22 +70,22 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`dai_api`
      - Experimental
      - 3.1
-     - 3.1
+     - 3.2
 
    * - :ref:`dma_api`
      - Stable
      - 1.5
-     - 3.1
+     - 3.2
 
    * - :ref:`device_model_api`
      - Stable
      - 1.0
-     - 3.1
+     - 3.2
 
    * - :ref:`devicetree_api`
      - Stable
      - 2.2
-     - 3.1
+     - 3.2
 
    * - :ref:`disk_access_api`
      - Stable
@@ -120,7 +120,7 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`file_system_api`
      - Stable
      - 1.5
-     - 2.4
+     - 3.2
 
    * - :ref:`flash_api`
      - Stable
@@ -135,7 +135,7 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`flash_map_api`
      - Stable
      - 1.11
-     - 2.6
+     - 3.2
 
    * - :ref:`gna_api`
      - Experimental
@@ -145,7 +145,7 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`gpio_api`
      - Stable
      - 1.0
-     - 3.1
+     - 3.2
 
    * - :ref:`hwinfo_api`
      - Stable
@@ -155,7 +155,7 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`i2c_eeprom_target_api`
      - Stable
      - 1.13
-     - 1.13
+     - 3.2
 
    * - :ref:`i2c_api`
      - Stable
@@ -190,7 +190,7 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`kernel_api`
      - Stable
      - 1.0
-     - 3.1
+     - 3.2
 
    * - :ref:`led_api`
      - Stable
@@ -200,17 +200,17 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`lwm2m_interface`
      - Unstable
      - 1.9
-     - 3.1
+     - 3.2
 
    * - :ref:`logging_api`
      - Stable
      - 1.13
-     - 3.1
+     - 3.2
 
    * - :ref:`lora_api`
      - Experimental
      - 2.2
-     - 2.2
+     - 3.2
 
    * - :ref:`lorawan_api`
      - Experimental
@@ -240,12 +240,12 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`networking_api`
      - Stable
      - 1.0
-     - 3.1
+     - 3.2
 
    * - :ref:`nvs_api`
      - Stable
      - 1.12
-     - 3.1
+     - 3.2
 
    * - :ref:`peci_api`
      - Stable
@@ -270,12 +270,12 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`pinmux_api`
      - Stable
      - 1.0
-     - 1.11
+     - 3.2
 
    * - :ref:`pm_api`
      - Experimental
      - 1.2
-     - 3.1
+     - 3.2
 
    * - :ref:`random_api`
      - Stable
@@ -300,22 +300,22 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`spi_api`
      - Stable
      - 1.0
-     - 3.1
+     - 3.2
 
    * - :ref:`sensor_api`
      - Stable
      - 1.2
-     - 2.6
+     - 3.2
 
    * - :ref:`settings_api`
      - Stable
      - 1.12
-     - 2.1
+     - 3.2
 
    * - :ref:`shell_api`
      - Stable
      - 1.14
-     - 3.1
+     - 3.2
 
    * - :ref:`stream_flash`
      - Experimental
@@ -350,7 +350,7 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`usb_api`
      - Stable
      - 1.5
-     - 3.1
+     - 3.2
 
    * - :ref:`usermode_api`
      - Stable
@@ -360,7 +360,7 @@ current :ref:`stability level <api_lifecycle>`.
    * - :ref:`util_api`
      - Experimental
      - 2.4
-     - 3.1
+     - 3.2
 
    * - :ref:`video_api`
      - Stable


### PR DESCRIPTION
Update the API overview page, guessing based on gitk v3.1.0..main on the various API headers.

-- 8< --

Personally I don't find this page very useful and updating it is somewhat tedious and subjective, but that's what we have now so let's at least keep it updated.