### PR TITLE
wifi: esp32: remove unused ESP32_WIFI_{SSID,PSK}

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -19,16 +19,6 @@ menuconfig WIFI_ESP32
 
 if WIFI_ESP32
 
-config ESP32_WIFI_SSID
-	string "SSID of WiFi network"
-	help
-	  SSID (network name) for the application to connect to.
-
-config ESP32_WIFI_PASSWORD
-	string "Password (WPA or WPA2) of WiFi network"
-	help
-	  WiFi password (WPA or WPA2) for the example to use.
-
 config ESP32_WIFI_STA_AUTO_DHCPV4
 	bool "Automatically starts DHCP4 negotiation"
 	depends on NET_DHCPV4


### PR DESCRIPTION
Those Kconfig options are no longer used after ESP32 WiFi driver was converted to Zephyr WiFi mgmt and the removal of platform specific `samples/boards/esp32/wifi`.

Fixes: d524015f825a ("samples: boards: remove esp32 wifi sample code")