### PR TITLE
Lis2dh high pass filter

### DIFF
--- a/drivers/sensor/lis2dh/Kconfig
+++ b/drivers/sensor/lis2dh/Kconfig
@@ -141,6 +141,9 @@ config LIS2DH_ODR_9_LOW
 
 endchoice
 
+config LIS2DH_ACCEL_HP_FILTERS
+	bool "Set High Pass filters for AOI functions on interrupt lines"
+
 config LIS2DH_BLOCK_DATA_UPDATE
 	bool "Output registers not updated until MSB and LSB read"
 

--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -290,6 +290,10 @@ static int lis2dh_acc_config(const struct device *dev,
 	case SENSOR_ATTR_SLOPE_DUR:
 		return lis2dh_acc_slope_config(dev, attr, val);
 #endif
+#ifdef CONFIG_LIS2DH_ACCEL_HP_FILTERS
+	case SENSOR_ATTR_CONFIGURATION:
+		return lis2dh_acc_hp_filter_set(dev, val->val1);
+#endif
 	default:
 		LOG_DBG("Accel attribute not supported.");
 		return -ENOTSUP;

--- a/drivers/sensor/lis2dh/lis2dh.h
+++ b/drivers/sensor/lis2dh/lis2dh.h
@@ -87,8 +87,12 @@
 #define LIS2DH_ODR_MASK			(BIT_MASK(4) << LIS2DH_ODR_SHIFT)
 
 #define LIS2DH_REG_CTRL2		0x21
+#define LIS2DH_HPIS1_EN_BIT		BIT(0)
 #define LIS2DH_HPIS2_EN_BIT		BIT(1)
 #define LIS2DH_FDS_EN_BIT		BIT(3)
+
+#define LIS2DH_HPIS_EN_SHIFT		0
+#define LIS2DH_HPIS_EN_MASK		BIT_MASK(2) << LIS2DH_HPIS_EN_SHIFT
 
 #define LIS2DH_REG_CTRL3		0x22
 #define LIS2DH_EN_DRDY1_INT1_SHIFT	4
@@ -283,6 +287,11 @@ int lis2dh_init_interrupt(const struct device *dev);
 int lis2dh_acc_slope_config(const struct device *dev,
 			    enum sensor_attribute attr,
 			    const struct sensor_value *val);
+#endif
+
+#ifdef CONFIG_LIS2DH_ACCEL_HP_FILTERS
+int lis2dh_acc_hp_filter_set(const struct device *dev,
+			     int32_t val);
 #endif
 
 int lis2dh_spi_init(const struct device *dev);

--- a/drivers/sensor/lis2dh/lis2dh_trigger.c
+++ b/drivers/sensor/lis2dh/lis2dh_trigger.c
@@ -265,6 +265,22 @@ int lis2dh_acc_slope_config(const struct device *dev,
 	return status;
 }
 
+#ifdef CONFIG_LIS2DH_ACCEL_HP_FILTERS
+int lis2dh_acc_hp_filter_set(const struct device *dev, int32_t val)
+{
+	struct lis2dh_data *lis2dh = dev->data;
+	int status;
+
+	status = lis2dh->hw_tf->update_reg(dev, LIS2DH_REG_CTRL2,
+					   LIS2DH_HPIS_EN_MASK, val);
+	if (status < 0) {
+		LOG_ERR("Failed to set high pass filters");
+	}
+
+	return status;
+}
+#endif
+
 static void lis2dh_gpio_int1_callback(const struct device *dev,
 				      struct gpio_callback *cb, uint32_t pins)
 {


### PR DESCRIPTION
In trigger mode, without setting high pass filter a storm of triggers are seen from device sitting idle on flat surface. Applying high pass filter improve its behavior tremendously.