### PR TITLE
Bluetooth: Controller: Fix extended continuous scanning stop forever until re-enable

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -127,7 +127,7 @@ void radio_tmr_status_reset(void);
 void radio_tmr_tifs_set(uint32_t tifs);
 uint32_t radio_tmr_start(uint8_t trx, uint32_t ticks_start, uint32_t remainder);
 uint32_t radio_tmr_start_tick(uint8_t trx, uint32_t tick);
-void radio_tmr_start_us(uint8_t trx, uint32_t us);
+uint32_t radio_tmr_start_us(uint8_t trx, uint32_t us);
 uint32_t radio_tmr_start_now(uint8_t trx);
 uint32_t radio_tmr_start_get(void);
 void radio_tmr_stop(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -1277,7 +1277,7 @@ static inline int isr_rx_pdu(struct lll_scan *lll, struct pdu_adv *pdu_adv_rx,
 	} else if (((pdu_adv_rx->type == PDU_ADV_TYPE_ADV_IND) ||
 		    (pdu_adv_rx->type == PDU_ADV_TYPE_SCAN_IND)) &&
 		   (pdu_adv_rx->len <= sizeof(struct pdu_adv_adv_ind)) &&
-		   lll->type &&
+		   lll->type && !lll->state &&
 #if defined(CONFIG_BT_CENTRAL)
 		   !lll->conn) {
 #else /* !CONFIG_BT_CENTRAL */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -845,6 +845,7 @@ static void isr_common_done(void *param)
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	lll->is_adv_ind = 0U;
+	lll->is_aux_sched = 0U;
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
 	/* setup tIFS switching */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -252,6 +252,7 @@ void lll_scan_aux_isr_aux_setup(void *param)
 	uint32_t aux_offset_us;
 	uint32_t aux_start_us;
 	struct lll_scan *lll;
+	uint32_t start_us;
 	uint8_t phy_aux;
 	uint32_t hcto;
 
@@ -336,13 +337,15 @@ void lll_scan_aux_isr_aux_setup(void *param)
 	aux_start_us -= lll_radio_rx_ready_delay_get(phy_aux, PHY_FLAGS_S8);
 	aux_start_us -= window_widening_us;
 	aux_start_us -= EVENT_JITTER_US;
-	radio_tmr_start_us(0, aux_start_us);
+
+	start_us = radio_tmr_start_us(0, aux_start_us);
 
 	/* Setup header complete timeout */
-	hcto = ftr->radio_end_us + aux_offset_us;
-	hcto += window_size_us;
-	hcto += window_widening_us;
+	hcto = start_us;
 	hcto += EVENT_JITTER_US;
+	hcto += window_widening_us;
+	hcto += lll_radio_rx_ready_delay_get(phy_aux, PHY_FLAGS_S8);
+	hcto += window_size_us;
 	hcto += radio_rx_chain_delay_get(phy_aux, PHY_FLAGS_S8);
 	hcto += addr_us_get(phy_aux);
 	radio_tmr_hcto_configure(hcto);
@@ -358,7 +361,7 @@ void lll_scan_aux_isr_aux_setup(void *param)
 #if defined(HAL_RADIO_GPIO_HAVE_LNA_PIN)
 	radio_gpio_lna_setup();
 
-	radio_gpio_pa_lna_enable(aux_start_us +
+	radio_gpio_pa_lna_enable(start_us +
 				 radio_rx_ready_delay_get(phy_aux,
 							  PHY_FLAGS_S8) -
 				 HAL_RADIO_GPIO_LNA_OFFSET);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -840,7 +840,7 @@ isr_rx_next_subevent:
 		hcto -= (EVENT_CLOCK_JITTER_US << 1);
 
 		start_us = hcto;
-		radio_tmr_start_us(0U, start_us);
+		hcto = radio_tmr_start_us(0U, start_us);
 
 		/* Add 4 us + 4 us + (4 us * subevents so far), as radio
 		 * was setup to listen 4 us early and subevents could have
@@ -858,7 +858,7 @@ isr_rx_next_subevent:
 		hcto += radio_tmr_ready_restore();
 
 		start_us = hcto;
-		radio_tmr_start_us(0U, start_us);
+		hcto = radio_tmr_start_us(0U, start_us);
 
 		hcto += ((EVENT_JITTER_US + EVENT_TICKER_RES_MARGIN_US +
 			  lll->window_widening_event_us) << 1) +

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -737,7 +737,7 @@ ull_scan_aux_rx_flush:
 			ll_rx_sched();
 
 			sync = HDR_LLL2ULL(sync_lll);
-			if (unlikely(sync->is_stop)) {
+			if (unlikely(sync->is_stop && sync_lll->lll_aux)) {
 				return;
 			}
 		}


### PR DESCRIPTION
Fix scan aux context leak on Periodic Sync Terminate. On
Periodic Sync Terminate the `is_stop` flag is set to prevent
the ULL from assigning an aux context to the sync context,
but the acquired aux context was neither assigned to sync
context nor was being released back to the aux context pool.
Fixed by releasing the aux context if not assigned to the
sync context when `is_stop` flag is set.

If scan is being disabled, rx could already be enqueued
before coming to ull_scan_aux_rx_flush. Check if node rx is
not the last in the list of received PDUs then add it to the
list, else do not add it to the list to avoid duplicate
report generation, release and probable infinite loop
processing of the list. It is possible that node rx has not
be already added in case of last PDU in the chain, under
this case when scan is being stopped add it to the list
before auxiliary context is flushed.

Add the node rx to aux context list of node rx if not
already added when coming to ull_scan_aux_rx_flush. This is
handling a race condition wherein the last PDU in chain is
received and at the same time scan is being disabled.

Fix receiving spurious overlapping ADV_IND and SCAN_IND PDU
when LLL state expects to receive SCAN_RSP PDU. Explicitly
check that these PDUs are not processed when in active
scanning and waiting for SCAN_RSP PDUs.

Fix missing is_aux_sched flag being reset before resuming to
scan for new advertising PDU in the same scan window after
having received an earlier primary channel PDU and auxiliary
channel PDU using LLL scheduling.

Fix radio_tmr_start_us to be soft realtime, if the requested
start in microseconds is in the past, setup the next
earliest expiry. This is to prevent radio not being started
and not let the LLL hanging. When setup to receive auxiliary
PDU in LLL scheduling, is_aux_sched is set and if radio does
not start and the window is requested to be pre-empted, then
it is blocked from being preempted due to the is_aux_sched
flag remaining to be set. This stalls the scanning
infinitely until explicit scan disable.

Fixes #50432.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>