### PR TITLE
doc: Do not use Sphinx 5.2.0.post0

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,7 +1,7 @@
 # DOC: used to generate docs
 
 breathe>=4.34
-sphinx~=5.0
+sphinx~=5.0,!=5.2.0.post0
 sphinx_rtd_theme~=1.0
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
Sphinx 5.2.0.post0 release has a known compatibility issue with the `sphinx_rtd_theme` (see the issue readthedocs/sphinx_rtd_theme#1343).

Revert this commit once this compatibility issue is resolved.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>