### PR TITLE
modules: loramac-node: fix CN470 linking

### DIFF
--- a/modules/loramac-node/CMakeLists.txt
+++ b/modules/loramac-node/CMakeLists.txt
@@ -78,7 +78,12 @@ zephyr_library_sources_ifdef(CONFIG_LORAMAC_REGION_AS923
   ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region/RegionAS923.c
 )
 zephyr_library_sources_ifdef(CONFIG_LORAMAC_REGION_CN470
+  ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region/RegionBaseUS.c
   ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region/RegionCN470.c
+  ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region/RegionCN470A20.c
+  ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region/RegionCN470A26.c
+  ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region/RegionCN470B20.c
+  ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region/RegionCN470B26.c
 )
 zephyr_library_sources_ifdef(CONFIG_LORAMAC_REGION_KR920
   ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region/RegionKR920.c


### PR DESCRIPTION
Update the source files compiled when `CONFIG_LORAMAC_REGION_CN470` is enabled to link. Despite the naming, a `RegionBaseUS.c` function (`RegionBaseUSVerifyFrequencyGroup`) is used by all four of the CN470 band implementations.

Validated by compiling `samples/subsys/lorawan/class_a` with `CONFIG_LORAMAC_REGION_CN470` instead of `CONFIG_LORAMAC_REGION_IN865`.

Fixes #49960.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>