### PR TITLE
drivers: can: mark CAN-FD data phase timing API as optional

### DIFF
--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -400,13 +400,13 @@ typedef void(*can_set_state_change_callback_t)(const struct device *dev,
 typedef int (*can_get_core_clock_t)(const struct device *dev, uint32_t *rate);
 
 /**
- * @brief Callback API upon getting the maximum number of concurrent CAN RX filters
+ * @brief Optional callback API upon getting the maximum number of concurrent CAN RX filters
  * See @a can_get_max_filters() for argument description
  */
 typedef int (*can_get_max_filters_t)(const struct device *dev, enum can_ide id_type);
 
 /**
- * @brief Callback API upon getting the maximum supported bitrate
+ * @brief Optional callback API upon getting the maximum supported bitrate
  * See @a can_get_max_bitrate() for argument description
  */
 typedef int (*can_get_max_bitrate_t)(const struct device *dev, uint32_t *max_bitrate);

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -315,7 +315,7 @@ typedef int (*can_set_timing_t)(const struct device *dev,
 				const struct can_timing *timing);
 
 /**
- * @brief Callback API upon setting CAN bus timing for the data phase.
+ * @brief Optional callback API upon setting CAN-FD bus timing for the data phase.
  * See @a can_set_timing_data() for argument description
  */
 typedef int (*can_set_timing_data_t)(const struct device *dev,
@@ -760,7 +760,7 @@ __syscall int can_calc_timing(const struct device *dev, struct can_timing *res,
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @return Pointer to the minimum supported timing parameter values, or NULL if
- *         CAN-FD is not supported.
+ *         CAN-FD support is not implemented by the driver.
  */
 __syscall const struct can_timing *can_get_timing_data_min(const struct device *dev);
 
@@ -784,7 +784,7 @@ static inline const struct can_timing *z_impl_can_get_timing_data_min(const stru
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @return Pointer to the maximum supported timing parameter values, or NULL if
- *         CAN-FD is not supported.
+ *         CAN-FD support is not implemented by the driver.
  */
 __syscall const struct can_timing *can_get_timing_data_max(const struct device *dev);
 
@@ -835,6 +835,7 @@ __syscall int can_calc_timing_data(const struct device *dev, struct can_timing *
  * @retval 0 If successful.
  * @retval -EBUSY if the CAN controller is not in stopped state.
  * @retval -EIO General input/output error, failed to configure device.
+ * @retval -ENOSYS if CAN-FD support is not implemented by the driver.
  */
 __syscall int can_set_timing_data(const struct device *dev,
 				  const struct can_timing *timing_data);
@@ -844,6 +845,10 @@ static inline int z_impl_can_set_timing_data(const struct device *dev,
 					     const struct can_timing *timing_data)
 {
 	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+
+	if (api->set_timing_data == NULL) {
+		return -ENOSYS;
+	}
 
 	return api->set_timing_data(dev, timing_data);
 }


### PR DESCRIPTION
The can_set_timing_data() API function is optional and is not supported by all CAN controller drivers.
    
On a board with only either classic CAN or CAN-FD capable controllers the current behavior is fine, but on boards with a mix of classic CAN and CAN-FD capable controllers/drivers, calling can_set_timing_data() on a classic CAN controller will lead to a NULL pointer dereference.
    
To ensure a proper behavior when calling can_set_timing_data() on classic CAN controller drivers, change the API wrapper function to return -ENOSYS if the CAN driver does not implement CAN-FD support.
    
Note that the data phase timing calculation functions are fine as-is, as the timing calculations will fail due to minimum/maximum data phase timing parameters being all zeros for drivers only supporting classic CAN.
    
Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>
