### PR TITLE
it8xxx2: intc: make sure IER disabling to take effect.

### DIFF
--- a/drivers/interrupt_controller/intc_ite_it8xxx2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.c
@@ -62,6 +62,7 @@ static uint8_t ier_setting[IT8XXX2_IER_COUNT];
 
 void ite_intc_save_and_disable_interrupts(void)
 {
+	volatile uint8_t _ier __unused;
 	/* Disable global interrupt for critical section */
 	unsigned int key = irq_lock();
 
@@ -70,6 +71,13 @@ void ite_intc_save_and_disable_interrupts(void)
 		ier_setting[i] = *reg_enable[i];
 		*reg_enable[i] = 0;
 	}
+	/*
+	 * This load operation will guarantee the above modification of
+	 * SOC's register can be seen by any following instructions.
+	 * Note: Barrier instruction can not synchronize chip register,
+	 * so we introduce workaround here.
+	 */
+	_ier = *reg_enable[IT8XXX2_IER_COUNT - 1];
 	irq_unlock(key);
 }
 


### PR DESCRIPTION
Add fake read to synchronize interrupt enable register (IER)
of SOC before enabling global interrupt.

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>