### PR TITLE
Fix FOTA state changes on URI write

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -301,9 +301,8 @@ static int package_uri_write_cb(uint16_t obj_inst_id, uint16_t res_id,
 	uint8_t state = lwm2m_firmware_get_update_state_inst(obj_inst_id);
 
 	if (state == STATE_IDLE) {
-		lwm2m_firmware_set_update_result_inst(obj_inst_id, RESULT_DEFAULT);
-
 		if (data_len > 0) {
+			lwm2m_firmware_set_update_state_inst(obj_inst_id, STATE_DOWNLOADING);
 			lwm2m_firmware_start_transfer(obj_inst_id, package_uri[obj_inst_id]);
 		}
 	} else if (state == STATE_DOWNLOADED && data_len == 0U) {

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware_pull.c
@@ -78,7 +78,5 @@ int lwm2m_firmware_start_transfer(uint16_t obj_inst_id, char *package_uri)
 		return error_code;
 	}
 
-	lwm2m_firmware_set_update_state_inst(obj_inst_id, STATE_DOWNLOADING);
-
 	return 0;
 }

--- a/subsys/net/lib/lwm2m/lwm2m_pull_context.c
+++ b/subsys/net/lib/lwm2m/lwm2m_pull_context.c
@@ -323,7 +323,7 @@ static void firmware_transfer(void)
 	int ret;
 	char *server_addr;
 
-	ret = k_sem_take(&lwm2m_pull_sem, K_NO_WAIT);
+	ret = k_sem_take(&lwm2m_pull_sem, K_FOREVER);
 
 #if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT)
 	server_addr = CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_ADDR;


### PR DESCRIPTION
This PR contains couple of fixes:
* Fix the state changes when URI is written. Any failure in the startup phase was previously overwritten by a second call to set the state, so any error code was lost.
* Pull context was closing the socket, while in a socket loop. This caused a crash while testing the previous fix.
