### PR TITLE
stm32 enables  HSI48 fixed clock with device tree

### DIFF
--- a/boards/arm/b_g474e_dpow1/b_g474e_dpow1.dts
+++ b/boards/arm/b_g474e_dpow1/b_g474e_dpow1.dts
@@ -77,6 +77,10 @@
 	};
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };

--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -75,6 +75,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };

--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -52,6 +52,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };

--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -56,6 +56,10 @@
 	};
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_lse {
 	status = "okay";
 };

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -57,6 +57,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(24)>;
 	status = "okay";

--- a/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
@@ -66,6 +66,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -64,6 +64,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
@@ -49,6 +49,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */

--- a/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
@@ -63,6 +63,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */

--- a/boards/arm/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
+++ b/boards/arm/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
@@ -58,6 +58,10 @@
 	};
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -79,6 +79,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &pll {
 	div = <2>;
 	mul = <8>;

--- a/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
+++ b/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
@@ -34,6 +34,10 @@
 	};
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_msi {
 	status = "okay";
 	msi-range = <6>;

--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -34,6 +34,10 @@
 	};
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_lse {
 	status = "okay";
 };

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -101,6 +101,16 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
+&clk48 {
+	/* Node is disabled by default as default source is HSI48 */
+	/* To select another clock, enable the node */
+	clocks = <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
+};
+
 &rcc {
 	clocks = <&clk_hse>;
 	clock-frequency = <DT_FREQ_M(32)>;

--- a/boards/arm/sensortile_box/sensortile_box.dts
+++ b/boards/arm/sensortile_box/sensortile_box.dts
@@ -55,6 +55,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(16)>;
 	status = "okay";

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -55,6 +55,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &pll {
 	div-m = <5>;
 	mul-n = <160>;

--- a/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -66,6 +66,10 @@
 	};
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(24)>;
 	status = "okay";

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -67,6 +67,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -59,6 +59,10 @@
 	cpu-power-states = <&stop0 &stop1 &stop2>;
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_msi {
 	status = "okay";
 	msi-range = <6>;

--- a/boards/arm/swan_r5/swan_r5.dts
+++ b/boards/arm/swan_r5/swan_r5.dts
@@ -58,6 +58,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -422,12 +422,16 @@ static void start_ble_rf(void)
 	LL_RCC_SetRTCClockSource(LL_RCC_RTC_CLKSOURCE_LSI);
 #endif
 
-	/* Set RNG on HSI48 */
+	/* HSI48 clock and CLK48 clock source are enabled using the device tree */
+#if !STM32_HSI48_ENABLED
+	/* Deprecated: enable HSI48 using device tree */
+#warning Bluetooth IPM requires HSI48 clock to be enabled using device tree
+	/* Keeping this sequence for legacy: */
 	LL_RCC_HSI48_Enable();
 	while (!LL_RCC_HSI48_IsReady()) {
 	}
 
-	LL_RCC_SetCLK48ClockSource(LL_RCC_CLK48_CLKSOURCE_HSI48);
+#endif /* !STM32_HSI48_ENABLED */
 }
 
 #ifdef CONFIG_BT_HCI_HOST

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -624,6 +624,24 @@ static void set_up_fixed_clock_sources(void)
 
 		z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
 	}
+
+#if defined(STM32_HSI48_ENABLED)
+	/* For all series with HSI 48 clock support */
+	if (IS_ENABLED(STM32_HSI48_ENABLED)) {
+#if defined(CONFIG_SOC_SERIES_STM32L0X)
+		/*
+		 * HSI48 requires VREFINT (see RM0376 section 7.2.4).
+		 * The SYSCFG is needed to control VREFINT, so clock it.
+		 */
+		LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SYSCFG);
+		LL_SYSCFG_VREFINT_EnableHSI48();
+#endif /* CONFIG_SOC_SERIES_STM32L0X */
+
+		LL_RCC_HSI48_Enable();
+		while (LL_RCC_HSI48_IsReady() != 1) {
+		}
+	}
+#endif /* STM32_HSI48_ENABLED */
 }
 
 /**

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -612,6 +612,12 @@ static void set_up_fixed_clock_sources(void)
 		while (LL_RCC_LSE_IsReady() != 1) {
 		}
 	}
+
+	if (IS_ENABLED(STM32_HSI48_ENABLED)) {
+		LL_RCC_HSI48_Enable();
+		while (LL_RCC_HSI48_IsReady() != 1) {
+		}
+	}
 }
 
 __unused

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -767,6 +767,11 @@ static void set_up_fixed_clock_sources(void)
 		}
 	}
 
+	if (IS_ENABLED(STM32_HSI48_ENABLED)) {
+		LL_RCC_HSI48_Enable();
+		while (LL_RCC_HSI48_IsReady() != 1) {
+		}
+	}
 }
 
 int stm32_clock_control_init(const struct device *dev)

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -154,13 +154,22 @@ static int stm32_sdmmc_clock_enable(struct stm32_sdmmc_priv *priv)
 
 #if defined(CONFIG_SOC_SERIES_STM32L5X) || \
 	defined(CONFIG_SOC_SERIES_STM32U5X)
-	/* By default the SDMMC clock source is set to 0 --> 48MHz, must be enabled */
+#if !STM32_HSI48_ENABLED
+	/* Deprecated: enable HSI48 using device tree */
+#warning USB device requires HSI48 clock to be enabled using device tree
+	/*
+	 * Keeping this sequence for legacy :
+	 * By default the SDMMC clock source is set to 0 --> 48MHz, must be enabled
+	 */
 	LL_RCC_HSI48_Enable();
 	while (!LL_RCC_HSI48_IsReady()) {
 	}
+#endif /* !STM32_HSI48_ENABLED */
 #endif /* CONFIG_SOC_SERIES_STM32L5X ||
 	* CONFIG_SOC_SERIES_STM32U5X
 	*/
+
+	/* HSI48 Clock is enabled through using the device tree */
 	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	/* Enable the APB clock for stm32_sdmmc */

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -207,7 +207,10 @@ static int usb_dc_stm32_clock_enable(void)
 	defined(CONFIG_SOC_SERIES_STM32H7X) || \
 	defined(CONFIG_SOC_SERIES_STM32L5X) || \
 	defined(CONFIG_SOC_SERIES_STM32U5X)
-
+#if !STM32_HSI48_ENABLED
+	/* Deprecated: enable HSI48 using device tree */
+#warning USB device requires HSI48 clock to be enabled using device tree
+#endif /* ! STM32_HSI48_ENABLED*/
 	/*
 	 * In STM32L0 series, HSI48 requires VREFINT and its buffer
 	 * with 48 MHz RC to be enabled.
@@ -226,6 +229,7 @@ static int usb_dc_stm32_clock_enable(void)
 
 	z_stm32_hsem_lock(CFG_HW_CLK48_CONFIG_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 
+	/* Keeping this sequence for legacy: */
 	LL_RCC_HSI48_Enable();
 	while (!LL_RCC_HSI48_IsReady()) {
 		/* Wait for HSI48 to become ready */

--- a/dts/arm/st/f0/stm32f072.dtsi
+++ b/dts/arm/st/f0/stm32f072.dtsi
@@ -8,6 +8,15 @@
 
 / {
 	soc {
+		clocks {
+			clk_hsi48: clk-hsi48 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(48)>;
+				status = "disabled";
+			};
+		};
+
 		pinctrl: pin-controller@48000000 {
 
 			gpioe: gpio@48001000 {

--- a/dts/arm/st/f0/stm32f091.dtsi
+++ b/dts/arm/st/f0/stm32f091.dtsi
@@ -8,6 +8,15 @@
 
 / {
 	soc {
+		clocks {
+			clk_hsi48: clk-hsi48 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(48)>;
+				status = "disabled";
+			};
+		};
+
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
 				erase-block-size = <2048>;

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -9,6 +9,15 @@
 
 / {
 	soc {
+		clocks {
+			clk_hsi48: clk-hsi48 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(48)>;
+				status = "disabled";
+			};
+		};
+
 		pinctrl: pin-controller@50000000 {
 			gpioe: gpio@50001000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -50,6 +50,13 @@
 			status = "disabled";
 		};
 
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+
 		clk_lse: clk-lse {
 			#clock-cells = <0>;
 			compatible = "fixed-clock";

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -58,6 +58,13 @@
 			status = "disabled";
 		};
 
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+
 		clk_csi: clk-csi {
 			#clock-cells = <0>;
 			compatible = "fixed-clock";

--- a/dts/arm/st/l0/stm32l053.dtsi
+++ b/dts/arm/st/l0/stm32l053.dtsi
@@ -8,6 +8,15 @@
 
 / {
 	soc {
+		clocks {
+			clk_hsi48: clk-hsi48 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(48)>;
+				status = "disabled";
+			};
+		};
+
 		usb: usb@40005c00 {
 			compatible = "st,stm32-usb";
 			reg = <0x40005c00 0x400>;

--- a/dts/arm/st/l0/stm32l072.dtsi
+++ b/dts/arm/st/l0/stm32l072.dtsi
@@ -12,6 +12,15 @@
 	};
 
 	soc {
+		clocks {
+			clk_hsi48: clk-hsi48 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(48)>;
+				status = "disabled";
+			};
+		};
+
 		usb: usb@40005c00 {
 			compatible = "st,stm32-usb";
 			reg = <0x40005c00 0x400>;

--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -8,6 +8,15 @@
 
 / {
 	soc {
+		clocks {
+			clk_hsi48: clk-hsi48 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(48)>;
+				status = "disabled";
+			};
+		};
+
 		usb: usb@40006800 {
 			compatible = "st,stm32-usb";
 			reg = <0x40006800 0x40000>;

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -8,6 +8,15 @@
 
 / {
 	soc {
+		clocks {
+			clk_hsi48: clk-hsi48 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(48)>;
+				status = "disabled";
+			};
+		};
+
 		spi3: spi@40003c00 {
 			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;

--- a/dts/arm/st/l4/stm32l452.dtsi
+++ b/dts/arm/st/l4/stm32l452.dtsi
@@ -8,6 +8,15 @@
 
 / {
 	soc {
+		clocks {
+			clk_hsi48: clk-hsi48 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(48)>;
+				status = "disabled";
+			};
+		};
+
 		pinctrl: pin-controller@48000000 {
 			gpiod: gpio@48000c00 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -8,6 +8,15 @@
 
 / {
 	soc {
+		clocks {
+			clk_hsi48: clk-hsi48 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(48)>;
+				status = "disabled";
+			};
+		};
+
 		i2c4: i2c@40008400 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -13,6 +13,15 @@
 	};
 
 	soc {
+		clocks {
+			clk_hsi48: clk-hsi48 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(48)>;
+				status = "disabled";
+			};
+		};
+
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
 				erase-block-size = <4096>;

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -59,6 +59,13 @@
 			status = "disabled";
 		};
 
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+
 		clk_msi: clk-msi {
 			#clock-cells = <0>;
 			compatible = "st,stm32-msi-clock";

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -57,6 +57,13 @@
 			status = "disabled";
 		};
 
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+
 		clk_msis: clk-msis {
 			#clock-cells = <0>;
 			compatible = "st,stm32u5-msi-clock";

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -63,6 +63,13 @@
 			status = "disabled";
 		};
 
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+
 		clk_msi: clk-msi {
 			#clock-cells = <0>;
 			compatible = "st,stm32-msi-clock";
@@ -95,6 +102,12 @@
 		pll: pll {
 			#clock-cells = <0>;
 			compatible = "st,stm32wb-pll-clock";
+			status = "disabled";
+		};
+
+		clk48: clk48 {
+			#clock-cells = <0>;
+			compatible = "st,stm32-clock-mux";
 			status = "disabled";
 		};
 	};

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -333,6 +333,10 @@
 #define STM32_HSE_FREQ		0
 #endif
 
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hsi48), fixed_clock, okay)
+#define STM32_HSI48_ENABLED	1
+#endif
+
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(perck), st_stm32_clock_mux, okay)
 #define STM32_CKPER_ENABLED	1
 #endif

--- a/include/zephyr/dt-bindings/clock/stm32f0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f0_clock.h
@@ -19,14 +19,14 @@
 /** Fixed clocks  */
 #define STM32_SRC_HSI		0x001
 #define STM32_SRC_LSE		0x002
-#define STM32_SRC_LSI		0x007
-/* #define STM32_SRC_HSI48	0x003 */
+#define STM32_SRC_LSI		0x003
+#define STM32_SRC_HSI48		0x004
 /** System clock */
-#define STM32_SRC_SYSCLK	0x004
+#define STM32_SRC_SYSCLK	0x005
 /** Bus clock */
-#define STM32_SRC_PCLK		0x005
+#define STM32_SRC_PCLK		0x006
 /** PLL clock */
-#define STM32_SRC_PLLCLK	0x006
+#define STM32_SRC_PLLCLK	0x007
 
 #define STM32_CLOCK_REG_MASK    0xFFU
 #define STM32_CLOCK_REG_SHIFT   0U

--- a/include/zephyr/dt-bindings/clock/stm32g0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_clock.h
@@ -20,18 +20,19 @@
 
 /** Fixed clocks  */
 #define STM32_SRC_HSI		0x001
-#define STM32_SRC_MSI		0x002
-#define STM32_SRC_HSE		0x003
-#define STM32_SRC_LSE		0x004
-#define STM32_SRC_LSI		0x005
+#define STM32_SRC_HSI48		0x002
+#define STM32_SRC_MSI		0x003
+#define STM32_SRC_HSE		0x004
+#define STM32_SRC_LSE		0x005
+#define STM32_SRC_LSI		0x006
 /** System clock */
-#define STM32_SRC_SYSCLK	0x006
+#define STM32_SRC_SYSCLK	0x007
 /** Peripheral bus clock */
-#define STM32_SRC_PCLK		0x007
+#define STM32_SRC_PCLK		0x008
 /** PLL clock outputs */
-#define STM32_SRC_PLL_P		0x008
-#define STM32_SRC_PLL_Q		0x009
-#define STM32_SRC_PLL_R		0x00a
+#define STM32_SRC_PLL_P		0x009
+#define STM32_SRC_PLL_Q		0x00a
+#define STM32_SRC_PLL_R		0x00b
 
 #define STM32_CLOCK_REG_MASK    0xFFU
 #define STM32_CLOCK_REG_SHIFT   0U

--- a/include/zephyr/dt-bindings/clock/stm32g4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g4_clock.h
@@ -22,7 +22,7 @@
 
 /** Fixed clocks  */
 #define STM32_SRC_HSI		0x001
-/* #define STM32_SRC_HSI48	0x002 */
+#define STM32_SRC_HSI48		0x002
 #define STM32_SRC_HSE		0x003
 #define STM32_SRC_LSE		0x004
 #define STM32_SRC_LSI		0x005

--- a/include/zephyr/dt-bindings/clock/stm32h7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h7_clock.h
@@ -25,8 +25,7 @@
 #define STM32_SRC_HSE		0x00A
 #define STM32_SRC_LSE		0x00B
 #define STM32_SRC_LSI		0x00C
-/** Oscillators not yet supported */
-/* #define STM32_SRC_HSI48	0x00D */
+#define STM32_SRC_HSI48		0x00D
 #define STM32_SRC_HSI_KER	0x00E /* HSI + HSIKERON */
 #define STM32_SRC_CSI_KER	0x00F /* CSI + CSIKERON */
 /** Core clock */

--- a/include/zephyr/dt-bindings/clock/stm32l0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l0_clock.h
@@ -23,10 +23,11 @@
 #define STM32_SRC_LSE		0x002
 #define STM32_SRC_LSI		0x003
 #define STM32_SRC_HSI		0x004
+#define STM32_SRC_HSI48		0x005
 /** System clock */
-#define STM32_SRC_SYSCLK	0x005
+#define STM32_SRC_SYSCLK	0x006
 /** Bus clock */
-#define STM32_SRC_PCLK		0x006
+#define STM32_SRC_PCLK		0x007
 
 #define STM32_CLOCK_REG_MASK    0xFFU
 #define STM32_CLOCK_REG_SHIFT   0U

--- a/include/zephyr/dt-bindings/clock/stm32l4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l4_clock.h
@@ -22,7 +22,7 @@
 
 /** Fixed clocks  */
 #define STM32_SRC_HSI		0x001
-/* #define STM32_SRC_HSI48	0x002 */
+#define STM32_SRC_HSI48		0x002
 #define STM32_SRC_LSE		0x003
 #define STM32_SRC_LSI		0x004
 #define STM32_SRC_MSI		0x005

--- a/include/zephyr/dt-bindings/clock/stm32u5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u5_clock.h
@@ -25,7 +25,7 @@
 #define STM32_SRC_LSE		0x00B
 #define STM32_SRC_LSI		0x00C
 #define STM32_SRC_HSI16		0x00D
-/* #define STM32_SRC_HSI48	0x00E */
+#define STM32_SRC_HSI48		0x00E
 #define STM32_SRC_MSIS		0x00F
 #define STM32_SRC_MSIK		0x010
 /** Core clock */

--- a/include/zephyr/dt-bindings/clock/stm32wb_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wb_clock.h
@@ -22,7 +22,7 @@
 
 /** Fixed clocks  */
 #define STM32_SRC_HSI		0x001
-/* #define STM32_SRC_HSI48	0x002 */
+#define STM32_SRC_HSI48		0x002
 #define STM32_SRC_LSE		0x003
 #define STM32_SRC_LSI		0x004
 #define STM32_SRC_MSI		0x005


### PR DESCRIPTION
Until now the HSI 48 clock of the stm32 mcu is enabled by the peripheral that needs it with LL_RCC_HSI48_Enable
With this PR, it is defined by the DeviceTree for each stm32 that needs it.
As the frequency is fixed at 48MHz, it is not required by the DTS to specify the value.

New sequence added in the stm32_clock_configuration/stm32_common_core/  testcase to check that HSI48 is ready when required.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/49870

Signed-off-by: Francois Ramu <francois.ramu@st.com>
