### PR TITLE
boards: arm: stm32: HW flow control stm32l496g_disco

### DIFF
--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -86,7 +86,7 @@
 };
 
 &usart1 {
-	pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pg10>;
+	pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pg10 &usart1_rts_pg12 &usart1_cts_pg11>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
 	status = "okay";


### PR DESCRIPTION
Add hardware flow control pinctrl mapping for stm32l496g_disco board. These are not used by default, the user needs to add the following devicetree overlay to enable them:
```
&usart1 {
    hw-flow-control;
}
```