### PR TITLE
Bluetooth: l2cap: prevent deadlock on chan timeout

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -966,8 +966,15 @@ static void l2cap_chan_destroy(struct bt_l2cap_chan *chan)
 	/* Cancel ongoing work. Since the channel can be re-used after this
 	 * we need to sync to make sure that the kernel does not have it
 	 * in its queue anymore.
+	 *
+	 * In the case where we are in the context of executing the rtx_work
+	 * item, we don't sync as it will deadlock the workqueue.
 	 */
-	k_work_cancel_delayable_sync(&le_chan->rtx_work, &le_chan->rtx_sync);
+	if (k_current_get() != &le_chan->rtx_work.queue->thread) {
+		k_work_cancel_delayable_sync(&le_chan->rtx_work, &le_chan->rtx_sync);
+	} else {
+		k_work_cancel_delayable(&le_chan->rtx_work);
+	}
 
 	if (le_chan->tx_buf) {
 		net_buf_unref(le_chan->tx_buf);

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -160,8 +160,15 @@ static void l2cap_br_chan_destroy(struct bt_l2cap_chan *chan)
 	/* Cancel ongoing work. Since the channel can be re-used after this
 	 * we need to sync to make sure that the kernel does not have it
 	 * in its queue anymore.
+	 *
+	 * In the case where we are in the context of executing the rtx_work
+	 * item, we don't sync as it will deadlock the workqueue.
 	 */
-	k_work_cancel_delayable_sync(&br_chan->rtx_work, &br_chan->rtx_sync);
+	if (k_current_get() != &br_chan->rtx_work.queue->thread) {
+		k_work_cancel_delayable_sync(&br_chan->rtx_work, &br_chan->rtx_sync);
+	} else {
+		k_work_cancel_delayable(&br_chan->rtx_work);
+	}
 
 	atomic_clear(BR_CHAN(chan)->flags);
 }


### PR DESCRIPTION
When getting a channel timeout, l2cap_chan_destroy is called from the rtx_work work item.

In that function we attempted to cancel the current work item, and sync on it being cancelled. The kernel API says that this will block until the work item completes execution, hence a deadlock.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>

Note: I tried to make a bsim test for it, trying to stall in the `accept` chan cb, but the supervision timeout kicks in. So there isn't any way to test this without resorting to ugly hacks or patching the host.
I tested it with the bt shell, by having a peripheral (w/ the l2cap server) with the l2cap reject response patched out.