### PR TITLE
net: l2: wifi: Fix channel length check

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -165,7 +165,7 @@ static int __wifi_args_to_params(size_t argc, char *argv[],
 	params->ssid_length = strlen(params->ssid);
 
 	/* Channel (optional) */
-	if ((idx < argc) && (strlen(argv[idx]) <= 2)) {
+	if ((idx < argc) && (strlen(argv[idx]) <= 3)) {
 		params->channel = strtol(argv[idx], &endptr, 10);
 		if (*endptr != '\0') {
 			return -EINVAL;


### PR DESCRIPTION
To allow 5GHz (and 6GHz) channels, use 3 digits check.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>