### PR TITLE
net: Add support for DSCP/ECN IPv4/IPv6 header fields

### DIFF
--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -319,6 +319,9 @@ __net_socket struct net_context {
 #if defined(CONFIG_NET_CONTEXT_SNDBUF)
 		uint16_t sndbuf;
 #endif
+#if defined(CONFIG_NET_CONTEXT_DSCP_ECN)
+		uint8_t dscp_ecn;
+#endif
 	} options;
 
 	/** Protocol (UDP, TCP or IEEE 802.3 protocol value) */
@@ -1068,6 +1071,7 @@ enum net_context_option {
 	NET_OPT_SNDTIMEO        = 5,
 	NET_OPT_RCVBUF		= 6,
 	NET_OPT_SNDBUF		= 7,
+	NET_OPT_DSCP_ECN	= 8,
 };
 
 /**

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -231,6 +231,14 @@ struct net_pkt {
 	uint8_t ipv6_ext_opt_len; /* IPv6 ND option length */
 	uint8_t ipv6_next_hdr;	/* What is the very first next header */
 #endif /* CONFIG_NET_IPV6 */
+
+#if defined(CONFIG_NET_IP_DSCP_ECN)
+	/** IPv4/IPv6 Differentiated Services Code Point value. */
+	uint8_t ip_dscp : 6;
+
+	/** IPv4/IPv6 Explicit Congestion Notification value. */
+	uint8_t ip_ecn : 2;
+#endif /* CONFIG_NET_IP_DSCP_ECN */
 #endif /* CONFIG_NET_IP */
 
 #if defined(CONFIG_NET_VLAN)
@@ -384,6 +392,38 @@ static inline void net_pkt_set_ip_hdr_len(struct net_pkt *pkt, uint8_t len)
 {
 #if defined(CONFIG_NET_IP)
 	pkt->ip_hdr_len = len;
+#endif
+}
+
+static inline uint8_t net_pkt_ip_dscp(struct net_pkt *pkt)
+{
+#if defined(CONFIG_NET_IP_DSCP_ECN)
+	return pkt->ip_dscp;
+#else
+	return 0;
+#endif
+}
+
+static inline void net_pkt_set_ip_dscp(struct net_pkt *pkt, uint8_t dscp)
+{
+#if defined(CONFIG_NET_IP_DSCP_ECN)
+	pkt->ip_dscp = dscp;
+#endif
+}
+
+static inline uint8_t net_pkt_ip_ecn(struct net_pkt *pkt)
+{
+#if defined(CONFIG_NET_IP_DSCP_ECN)
+	return pkt->ip_ecn;
+#else
+	return 0;
+#endif
+}
+
+static inline void net_pkt_set_ip_ecn(struct net_pkt *pkt, uint8_t ecn)
+{
+#if defined(CONFIG_NET_IP_DSCP_ECN)
+	pkt->ip_ecn = ecn;
 #endif
 }
 

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -983,9 +983,16 @@ struct ifreq {
 /** sockopt: Disable TCP buffering (ignored, for compatibility) */
 #define TCP_NODELAY 1
 
+/* Socket options for IPPROTO_IP level */
+/** sockopt: Set or receive the Type-Of-Service value for an outgoing packet. */
+#define IP_TOS 1
+
 /* Socket options for IPPROTO_IPV6 level */
 /** sockopt: Don't support IPv4 access (ignored, for compatibility) */
 #define IPV6_V6ONLY 26
+
+/** sockopt: Set or receive the traffic class value for an outgoing packet. */
+#define IPV6_TCLASS 67
 
 /** sockopt: Socket priority */
 #define SO_PRIORITY 12

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -122,6 +122,14 @@ config NET_INIT_PRIO
 	  Network initialization priority level. This number tells how
 	  early in the boot the network stack is initialized.
 
+config NET_IP_DSCP_ECN
+	bool "DSCP/ECN processing at IP layer"
+	depends on NET_IP
+	default y
+	help
+	  Specify whether DSCP/ECN values are processed at IP layer. The values
+	  are encoded within ToS field in IPv4 and TC field in IPv6.
+
 source "subsys/net/ip/Kconfig.ipv6"
 
 source "subsys/net/ip/Kconfig.ipv4"

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -636,6 +636,15 @@ config NET_CONTEXT_SNDBUF
 	  For TCP sockets, the sndbuf will determine the total size of queued
 	  data in the TCP layer.
 
+config NET_CONTEXT_DSCP_ECN
+	bool "Add support for setting DSCP/ECN IP properties on net_context"
+	depends on NET_IP_DSCP_ECN
+	default y
+	help
+	  Allow to set Differentiated Services and Explicit Congestion
+	  Notification values on net_context. Those values are then used in
+	  IPv4/IPv6 header when sending packets over net_context.
+
 config NET_TEST
 	bool "Network Testing"
 	help

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -457,6 +457,9 @@ static enum net_verdict icmpv4_handle_echo_request(struct net_pkt *pkt,
 		src = (struct in_addr *)ip_hdr->dst;
 	}
 
+	net_pkt_set_ip_dscp(reply, net_pkt_ip_dscp(pkt));
+	net_pkt_set_ip_ecn(reply, net_pkt_ip_ecn(pkt));
+
 	if (net_ipv4_create(reply, src, (struct in_addr *)ip_hdr->src)) {
 		goto drop;
 	}
@@ -503,6 +506,7 @@ int net_icmpv4_send_echo_request(struct net_if *iface,
 				 struct in_addr *dst,
 				 uint16_t identifier,
 				 uint16_t sequence,
+				 uint8_t tos,
 				 const void *data,
 				 size_t data_size)
 {
@@ -532,6 +536,9 @@ int net_icmpv4_send_echo_request(struct net_if *iface,
 	if (!pkt) {
 		return -ENOMEM;
 	}
+
+	net_pkt_set_ip_dscp(pkt, net_ipv4_get_dscp(tos));
+	net_pkt_set_ip_ecn(pkt, net_ipv4_get_ecn(tos));
 
 	if (net_ipv4_create(pkt, src, dst) ||
 	    icmpv4_create(pkt, NET_ICMPV4_ECHO_REQUEST, 0)) {

--- a/subsys/net/ip/icmpv4.h
+++ b/subsys/net/ip/icmpv4.h
@@ -62,6 +62,8 @@ int net_icmpv4_send_error(struct net_pkt *pkt, uint8_t type, uint8_t code);
  * to this Echo Request. May be zero.
  * @param sequence A sequence number to aid in matching Echo Replies
  * to this Echo Request. May be zero.
+ * @param tos IPv4 Type-of-service field value. Represents combined DSCP and ECN
+ * values.
  * @param data Arbitrary payload data that will be included in the
  * Echo Reply verbatim. May be zero.
  * @param data_size Size of the Payload Data in bytes. May be zero.
@@ -73,6 +75,7 @@ int net_icmpv4_send_echo_request(struct net_if *iface,
 				 struct in_addr *dst,
 				 uint16_t identifier,
 				 uint16_t sequence,
+				 uint8_t tos,
 				 const void *data,
 				 size_t data_size);
 #else
@@ -80,6 +83,7 @@ static inline int net_icmpv4_send_echo_request(struct net_if *iface,
 					       struct in_addr *dst,
 					       uint16_t identifier,
 					       uint16_t sequence,
+					       uint8_t tos,
 					       const void *data,
 					       size_t data_size)
 {
@@ -87,6 +91,7 @@ static inline int net_icmpv4_send_echo_request(struct net_if *iface,
 	ARG_UNUSED(dst);
 	ARG_UNUSED(identifier);
 	ARG_UNUSED(sequence);
+	ARG_UNUSED(tos);
 	ARG_UNUSED(data);
 	ARG_UNUSED(data_size);
 

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -149,6 +149,9 @@ enum net_verdict icmpv6_handle_echo_request(struct net_pkt *pkt,
 	net_pkt_lladdr_dst(reply)->addr = NULL;
 	net_pkt_lladdr_src(reply)->addr = NULL;
 
+	net_pkt_set_ip_dscp(reply, net_pkt_ip_dscp(pkt));
+	net_pkt_set_ip_ecn(reply, net_pkt_ip_ecn(pkt));
+
 	if (net_ipv6_create(reply, src, (struct in6_addr *)ip_hdr->src)) {
 		NET_DBG("DROP: wrong buffer");
 		goto drop;
@@ -337,6 +340,7 @@ int net_icmpv6_send_echo_request(struct net_if *iface,
 				 struct in6_addr *dst,
 				 uint16_t identifier,
 				 uint16_t sequence,
+				 uint8_t tc,
 				 const void *data,
 				 size_t data_size)
 {
@@ -357,6 +361,9 @@ int net_icmpv6_send_echo_request(struct net_if *iface,
 	if (!pkt) {
 		return -ENOMEM;
 	}
+
+	net_pkt_set_ip_dscp(pkt, net_ipv6_get_dscp(tc));
+	net_pkt_set_ip_ecn(pkt, net_ipv6_get_ecn(tc));
 
 	if (net_ipv6_create(pkt, src, dst) ||
 	    net_icmpv6_create(pkt, NET_ICMPV6_ECHO_REQUEST, 0)) {

--- a/subsys/net/ip/icmpv6.h
+++ b/subsys/net/ip/icmpv6.h
@@ -198,6 +198,8 @@ int net_icmpv6_send_error(struct net_pkt *pkt, uint8_t type, uint8_t code,
  * to this Echo Request. May be zero.
  * @param sequence A sequence number to aid in matching Echo Replies
  * to this Echo Request. May be zero.
+ * @param tc IPv6 Traffic Class field value. Represents combined DSCP and
+ * ECN values.
  * @param data Arbitrary payload data that will be included in the
  * Echo Reply verbatim. May be zero.
  * @param data_size Size of the Payload Data in bytes. May be zero.
@@ -209,6 +211,7 @@ int net_icmpv6_send_echo_request(struct net_if *iface,
 				 struct in6_addr *dst,
 				 uint16_t identifier,
 				 uint16_t sequence,
+				 uint8_t tc,
 				 const void *data,
 				 size_t data_size);
 #else
@@ -216,6 +219,7 @@ static inline int net_icmpv6_send_echo_request(struct net_if *iface,
 					       struct in6_addr *dst,
 					       uint16_t identifier,
 					       uint16_t sequence,
+					       uint8_t tc,
 					       const void *data,
 					       size_t data_size)
 {
@@ -223,6 +227,7 @@ static inline int net_icmpv6_send_echo_request(struct net_if *iface,
 	ARG_UNUSED(dst);
 	ARG_UNUSED(identifier);
 	ARG_UNUSED(sequence);
+	ARG_UNUSED(tc);
 	ARG_UNUSED(data);
 	ARG_UNUSED(data_size);
 

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -75,7 +75,14 @@ int net_ipv4_create(struct net_pkt *pkt,
 		    const struct in_addr *src,
 		    const struct in_addr *dst)
 {
-	return net_ipv4_create_full(pkt, src, dst, 0U, 0U, 0U, 0U,
+	uint8_t tos = 0;
+
+	if (IS_ENABLED(CONFIG_NET_IP_DSCP_ECN)) {
+		net_ipv4_set_dscp(&tos, net_pkt_ip_dscp(pkt));
+		net_ipv4_set_ecn(&tos, net_pkt_ip_ecn(pkt));
+	}
+
+	return net_ipv4_create_full(pkt, src, dst, tos, 0U, 0U, 0U,
 				    net_pkt_ipv4_ttl(pkt));
 }
 
@@ -247,6 +254,11 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 	}
 
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv4_hdr));
+
+	if (IS_ENABLED(CONFIG_NET_IP_DSCP_ECN)) {
+		net_pkt_set_ip_dscp(pkt, net_ipv4_get_dscp(hdr->tos));
+		net_pkt_set_ip_ecn(pkt, net_ipv4_get_ecn(hdr->tos));
+	}
 
 	opts_len = hdr_len - sizeof(struct net_ipv4_hdr);
 	if (opts_len > NET_IPV4_HDR_OPTNS_MAX_LEN) {

--- a/subsys/net/ip/ipv4.h
+++ b/subsys/net/ip/ipv4.h
@@ -21,6 +21,9 @@
 #include <zephyr/net/net_context.h>
 
 #define NET_IPV4_IHL_MASK 0x0F
+#define NET_IPV4_DSCP_MASK 0xFC
+#define NET_IPV4_DSCP_OFFSET 2
+#define NET_IPV4_ECN_MASK 0x03
 
 /* IPv4 Options */
 #define NET_IPV4_OPTS_EO   0   /* End of Options */
@@ -203,5 +206,53 @@ static inline int net_ipv4_parse_hdr_options(struct net_pkt *pkt,
 	return -ENOTSUP;
 }
 #endif
+
+/**
+ * @brief Decode DSCP value from ToS field.
+ *
+ * @param tos ToS field value from the IPv4 header.
+ *
+ * @return Decoded DSCP value.
+ */
+static inline uint8_t net_ipv4_get_dscp(uint8_t tos)
+{
+	return (tos & NET_IPV4_DSCP_MASK) >> NET_IPV4_DSCP_OFFSET;
+}
+
+/**
+ * @brief Encode DSCP value into ToS field.
+ *
+ * @param tos A pointer to the ToS field.
+ * @param dscp DSCP value to set.
+ */
+static inline void net_ipv4_set_dscp(uint8_t *tos, uint8_t dscp)
+{
+	*tos &= ~NET_IPV4_DSCP_MASK;
+	*tos |= (dscp << NET_IPV4_DSCP_OFFSET) & NET_IPV4_DSCP_MASK;
+}
+
+/**
+ * @brief Decode ECN value from ToS field.
+ *
+ * @param tos ToS field value from the IPv4 header.
+ *
+ * @return Decoded ECN value.
+ */
+static inline uint8_t net_ipv4_get_ecn(uint8_t tos)
+{
+	return tos & NET_IPV4_ECN_MASK;
+}
+
+/**
+ * @brief Encode ECN value into ToS field.
+ *
+ * @param tos A pointer to the ToS field.
+ * @param ecn ECN value to set.
+ */
+static inline void net_ipv4_set_ecn(uint8_t *tos, uint8_t ecn)
+{
+	*tos &= ~NET_IPV4_ECN_MASK;
+	*tos |= ecn & NET_IPV4_ECN_MASK;
+}
 
 #endif /* __IPV4_H */

--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -30,6 +30,10 @@
 
 #define NET_MAX_RS_COUNT 3
 
+#define NET_IPV6_DSCP_MASK 0xFC
+#define NET_IPV6_DSCP_OFFSET 2
+#define NET_IPV6_ECN_MASK 0x03
+
 /**
  * @brief Bitmaps for IPv6 extension header processing
  *
@@ -494,5 +498,54 @@ void net_ipv6_mld_init(void);
 #define net_ipv6_init(...)
 #define net_ipv6_nbr_init(...)
 #endif
+
+/**
+ * @brief Decode DSCP value from TC field.
+ *
+ * @param tc TC field value from the IPv6 header.
+ *
+ * @return Decoded DSCP value.
+ */
+static inline uint8_t net_ipv6_get_dscp(uint8_t tc)
+{
+	return (tc & NET_IPV6_DSCP_MASK) >> NET_IPV6_DSCP_OFFSET;
+}
+
+/**
+ * @brief Encode DSCP value into TC field.
+ *
+ * @param tc A pointer to the TC field.
+ * @param dscp DSCP value to set.
+ */
+static inline void net_ipv6_set_dscp(uint8_t *tc, uint8_t dscp)
+{
+	*tc &= ~NET_IPV6_DSCP_MASK;
+	*tc |= (dscp << NET_IPV6_DSCP_OFFSET) & NET_IPV6_DSCP_MASK;
+}
+
+/**
+ * @brief Decode ECN value from TC field.
+ *
+ * @param tc TC field value from the IPv6 header.
+ *
+ * @return Decoded ECN value.
+ */
+static inline uint8_t net_ipv6_get_ecn(uint8_t tc)
+{
+	return tc & NET_IPV6_ECN_MASK;
+}
+
+/**
+ * @brief Encode ECN value into TC field.
+ *
+ * @param tc A pointer to the TC field.
+ * @param ecn ECN value to set.
+ */
+static inline void net_ipv6_set_ecn(uint8_t *tc, uint8_t ecn)
+{
+	*tc &= ~NET_IPV6_ECN_MASK;
+	*tc |= ecn & NET_IPV6_ECN_MASK;
+}
+
 
 #endif /* __IPV6_H */

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1821,6 +1821,8 @@ static void clone_pkt_attributes(struct net_pkt *pkt, struct net_pkt *clone_pkt)
 	net_pkt_set_family(clone_pkt, net_pkt_family(pkt));
 	net_pkt_set_context(clone_pkt, net_pkt_context(pkt));
 	net_pkt_set_ip_hdr_len(clone_pkt, net_pkt_ip_hdr_len(pkt));
+	net_pkt_set_ip_dscp(clone_pkt, net_pkt_ip_dscp(pkt));
+	net_pkt_set_ip_ecn(clone_pkt, net_pkt_ip_ecn(pkt));
 	net_pkt_set_vlan_tag(clone_pkt, net_pkt_vlan_tag(pkt));
 	net_pkt_set_timestamp(clone_pkt, net_pkt_timestamp(pkt));
 	net_pkt_set_priority(clone_pkt, net_pkt_priority(pkt));

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -4066,6 +4066,7 @@ static int ping_ipv4(const struct shell *shell,
 						   &ipv4_target,
 						   sys_rand32_get(),
 						   i,
+						   0,
 						   &time_stamp,
 						   sizeof(time_stamp));
 		if (ret) {

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -4104,7 +4104,11 @@ static int parse_arg(size_t *i, size_t argc, char *argv[])
 	}
 
 	errno = 0;
-	res = strtol(str, &endptr, 10);
+	if (strncmp(str, "0x", 2) == 0) {
+		res = strtol(str, &endptr, 16);
+	} else {
+		res = strtol(str, &endptr, 10);
+	}
 
 	if (errno || (endptr == str)) {
 		return -1;

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3912,6 +3912,7 @@ static int ping_ipv6(const struct shell *shell,
 		     char *host,
 		     unsigned int count,
 		     unsigned int interval,
+		     uint8_t tos,
 		     int iface_idx)
 {
 	struct net_if *iface = net_if_get_by_index(iface_idx);
@@ -3957,7 +3958,7 @@ static int ping_ipv6(const struct shell *shell,
 						   &ipv6_target,
 						   sys_rand32_get(),
 						   i,
-						   0,
+						   tos,
 						   &time_stamp,
 						   sizeof(time_stamp));
 		if (ret) {
@@ -4042,6 +4043,7 @@ static int ping_ipv4(const struct shell *shell,
 		     char *host,
 		     unsigned int count,
 		     unsigned int interval,
+		     uint8_t tos,
 		     int iface_idx)
 {
 	struct in_addr ipv4_target;
@@ -4067,7 +4069,7 @@ static int ping_ipv4(const struct shell *shell,
 						   &ipv4_target,
 						   sys_rand32_get(),
 						   i,
-						   0,
+						   tos,
 						   &time_stamp,
 						   sizeof(time_stamp));
 		if (ret) {
@@ -4127,6 +4129,7 @@ static int cmd_net_ping(const struct shell *shell, size_t argc, char *argv[])
 	int count = 3;
 	int interval = 1000;
 	int iface_idx = -1;
+	int tos = 0;
 
 	for (size_t i = 1; i < argc; ++i) {
 
@@ -4161,6 +4164,15 @@ static int cmd_net_ping(const struct shell *shell, size_t argc, char *argv[])
 				return -ENOEXEC;
 			}
 			break;
+
+		case 'Q':
+			tos = parse_arg(&i, argc, argv);
+			if (tos < 0 || tos > UINT8_MAX) {
+				PR_WARNING("Parse error: %s\n", argv[i]);
+				return -ENOEXEC;
+			}
+
+			break;
 		default:
 			PR_WARNING("Unrecognized argument: %s\n", argv[i]);
 			return -ENOEXEC;
@@ -4175,7 +4187,7 @@ static int cmd_net_ping(const struct shell *shell, size_t argc, char *argv[])
 	shell_for_ping = shell;
 
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
-		ret = ping_ipv6(shell, host, count, interval, iface_idx);
+		ret = ping_ipv6(shell, host, count, interval, tos, iface_idx);
 		if (!ret) {
 			goto wait_reply;
 		} else if (ret == -EIO) {
@@ -4185,7 +4197,7 @@ static int cmd_net_ping(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
-		ret = ping_ipv4(shell, host, count, interval, iface_idx);
+		ret = ping_ipv4(shell, host, count, interval, tos, iface_idx);
 		if (ret) {
 			if (ret == -EIO || ret == -ENETUNREACH) {
 				PR_WARNING("Cannot send IPv4 ping\n");
@@ -5975,7 +5987,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_vlan,
 
 SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_ping,
 	SHELL_CMD(--help, NULL,
-		  "'net ping [-c count] [-i interval ms] [-I <iface index>] <host>' "
+		  "'net ping [-c count] [-i interval ms] [-I <iface index>] "
+		  "[-Q tos] <host>' "
 		  "Send ICMPv4 or ICMPv6 Echo-Request to a network host.",
 		  cmd_net_ping),
 	SHELL_SUBCMD_SET_END

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3957,6 +3957,7 @@ static int ping_ipv6(const struct shell *shell,
 						   &ipv6_target,
 						   sys_rand32_get(),
 						   i,
+						   0,
 						   &time_stamp,
 						   sizeof(time_stamp));
 		if (ret) {

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1885,6 +1885,48 @@ int zsock_getsockopt_ctx(struct net_context *ctx, int level, int optname,
 		}
 
 		break;
+
+	case IPPROTO_IP:
+		switch (optname) {
+		case IP_TOS:
+			if (IS_ENABLED(CONFIG_NET_CONTEXT_DSCP_ECN)) {
+				ret = net_context_get_option(ctx,
+							     NET_OPT_DSCP_ECN,
+							     optval,
+							     optlen);
+				if (ret < 0) {
+					errno  = -ret;
+					return -1;
+				}
+
+				return 0;
+			}
+
+			break;
+		}
+
+		break;
+
+	case IPPROTO_IPV6:
+		switch (optname) {
+		case IPV6_TCLASS:
+			if (IS_ENABLED(CONFIG_NET_CONTEXT_DSCP_ECN)) {
+				ret = net_context_get_option(ctx,
+							     NET_OPT_DSCP_ECN,
+							     optval,
+							     optlen);
+				if (ret < 0) {
+					errno  = -ret;
+					return -1;
+				}
+
+				return 0;
+			}
+
+			break;
+		}
+
+		break;
 	}
 
 	errno = ENOPROTOOPT;
@@ -2138,6 +2180,27 @@ int zsock_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 		}
 		break;
 
+	case IPPROTO_IP:
+		switch (optname) {
+		case IP_TOS:
+			if (IS_ENABLED(CONFIG_NET_CONTEXT_DSCP_ECN)) {
+				ret = net_context_set_option(ctx,
+							     NET_OPT_DSCP_ECN,
+							     optval,
+							     optlen);
+				if (ret < 0) {
+					errno  = -ret;
+					return -1;
+				}
+
+				return 0;
+			}
+
+			break;
+		}
+
+		break;
+
 	case IPPROTO_IPV6:
 		switch (optname) {
 		case IPV6_V6ONLY:
@@ -2145,7 +2208,24 @@ int zsock_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 			 * existing apps.
 			 */
 			return 0;
+
+		case IPV6_TCLASS:
+			if (IS_ENABLED(CONFIG_NET_CONTEXT_DSCP_ECN)) {
+				ret = net_context_set_option(ctx,
+							     NET_OPT_DSCP_ECN,
+							     optval,
+							     optlen);
+				if (ret < 0) {
+					errno  = -ret;
+					return -1;
+				}
+
+				return 0;
+			}
+
+			break;
 		}
+
 		break;
 	}
 

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1874,12 +1874,17 @@ int zsock_getsockopt_ctx(struct net_context *ctx, int level, int optname,
 			}
 			break;
 		}
+
+		break;
+
 	case IPPROTO_TCP:
 		switch (optname) {
 		case TCP_NODELAY:
 			ret = net_tcp_get_option(ctx, TCP_OPT_NODELAY, optval, optlen);
 			return ret;
 		}
+
+		break;
 	}
 
 	errno = ENOPROTOOPT;

--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -531,7 +531,7 @@ static int execute_upload(const struct shell *sh,
 		 * some time and start the test after that.
 		 */
 		net_icmpv6_send_echo_request(net_if_get_default(),
-					     &ipv6->sin6_addr, 0, 0, NULL, 0);
+					     &ipv6->sin6_addr, 0, 0, 0, NULL, 0);
 
 		k_sleep(K_SECONDS(1));
 	}


### PR DESCRIPTION
Currently there's no way to specify the value of DSCP/ECN IPv4/IPv6 header fields for outgoing packets, as well as those fields are not parsed from incoming packets. This PR attempts to fix this, by introducing the following changes:

* Specify the DSCP/ECN values at net_pkt level,
* Add processing of those fields in IPv4/IPv6 modules,
* Add new options for net_context and socket, which allow to specify the fields value on a net_context/socket,
* Add support for setting the fields value at ICMP level,
* Finally, introduce new options for `net shell` and `zperf` commands, which allow to configure DSCP/ECN value for outgoing packets.

Resolves #50139