### PR TITLE
drivers: serial: uart_mcux_lpuart: fix Irq-driven API when ASYNC API is enabled

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -303,6 +303,7 @@ static void mcux_lpuart_irq_rx_enable(const struct device *dev)
 	uint32_t mask = kLPUART_RxDataRegFullInterruptEnable;
 
 	LPUART_EnableInterrupts(config->base, mask);
+	LPUART_EnableRx(config->base, true);
 }
 
 static void mcux_lpuart_irq_rx_disable(const struct device *dev)
@@ -310,6 +311,7 @@ static void mcux_lpuart_irq_rx_disable(const struct device *dev)
 	const struct mcux_lpuart_config *config = dev->config;
 	uint32_t mask = kLPUART_RxDataRegFullInterruptEnable;
 
+	LPUART_EnableRx(config->base, false);
 	LPUART_DisableInterrupts(config->base, mask);
 }
 


### PR DESCRIPTION
If CONFIG_UART_ASYNC_API is enabled, the initialization of uart_mcux_lpuart disables reception until uart_rx_enable() is called. This also prevented reception when using the Interrupt-driven API, as uart_irq_rx_enable() did not enable reception.

With these changes, UART devices accessed through the Interrupt-driven API (e.g. for the shell) are again fully functional when CONFIG_UART_ASYNC_API is enabled.

Signed-off-by: Jan Peters <peters@kt-elektronik.de>