### PR TITLE
posix: conditionally compile perror pthread_common and nanosleep

### DIFF
--- a/lib/posix/CMakeLists.txt
+++ b/lib/posix/CMakeLists.txt
@@ -8,14 +8,15 @@ if(CONFIG_POSIX_API)
 endif()
 
 zephyr_library()
-zephyr_library_sources(perror.c)
-zephyr_library_sources(pthread_common.c)
+zephyr_library_sources_ifdef(CONFIG_POSIX_API perror.c)
+zephyr_library_sources_ifdef(CONFIG_PTHREAD_IPC pthread_common.c)
 zephyr_library_sources_ifdef(CONFIG_PTHREAD_IPC pthread_cond.c)
 zephyr_library_sources_ifdef(CONFIG_PTHREAD_IPC pthread_mutex.c)
 zephyr_library_sources_ifdef(CONFIG_PTHREAD_IPC pthread_barrier.c)
 zephyr_library_sources_ifdef(CONFIG_PTHREAD_IPC pthread.c)
 zephyr_library_sources_ifdef(CONFIG_PTHREAD_IPC pthread_sched.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_CLOCK clock.c)
+zephyr_library_sources_ifdef(CONFIG_POSIX_CLOCK nanosleep.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_CLOCK sleep.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_CLOCK timer.c)
 zephyr_library_sources_ifdef(CONFIG_PTHREAD_IPC pthread_rwlock.c)
@@ -26,13 +27,10 @@ zephyr_library_sources_ifdef(CONFIG_POSIX_FS fs.c)
 zephyr_library_sources_ifdef(CONFIG_EVENTFD eventfd.c)
 add_subdirectory_ifdef(CONFIG_GETOPT getopt)
 
-if(NOT (CONFIG_BOARD_NATIVE_POSIX OR CONFIG_BOARD_NATIVE_POSIX_64BIT))
-zephyr_library_sources(nanosleep.c)
-endif()
-
 zephyr_library_include_directories(
   ${ZEPHYR_BASE}/kernel/include
   ${ARCH_DIR}/${ARCH}/include
 )
 
 zephyr_library_link_libraries(posix_subsys)
+zephyr_library_property(ALLOW_EMPTY TRUE)


### PR DESCRIPTION
Previously, these files were compiled unconditionally.

Partially fixes #50654
