### PR TITLE
Bluetooth: Audio: Fix bad error check for bt_unicast_client_start

### DIFF
--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -714,7 +714,6 @@ int bt_audio_stream_connect(struct bt_audio_stream *stream)
 	case BT_ISO_STATE_DISCONNECTED:
 		return bt_iso_chan_connect(&param, 1);
 	case BT_ISO_STATE_CONNECTING:
-		return 0;
 	case BT_ISO_STATE_CONNECTED:
 		return -EALREADY;
 	default:

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -1686,10 +1686,6 @@ int bt_unicast_client_start(struct bt_audio_stream *stream)
 	 * Central Establishment procedure.
 	 */
 	err = bt_audio_stream_connect(stream);
-	if (!err) {
-		return 0;
-	}
-
 	if (err && err != -EALREADY) {
 		BT_DBG("bt_audio_stream_connect failed: %d", err);
 		return err;


### PR DESCRIPTION
If bt_audio_stream_connect didn't fail, we would just return without sending the receive start ready command.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>