### PR TITLE
Bluetooth: Audio: Increase unicast client Kconfig ranges

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.baps
+++ b/subsys/bluetooth/audio/Kconfig.baps
@@ -93,7 +93,7 @@ config BT_AUDIO_UNICAST_CLIENT_GROUP_STREAM_COUNT
 config BT_AUDIO_UNICAST_CLIENT_PAC_COUNT
 	int "Basic Audio Profile PAC count"
 	default 2
-	range 0 4
+	range 0 146
 	help
 	  This option enables caching a number of Published Audio Capabilities
 	  (PAC) for Basic Audio Profile on a per connection basis.
@@ -101,7 +101,7 @@ config BT_AUDIO_UNICAST_CLIENT_PAC_COUNT
 config BT_AUDIO_UNICAST_CLIENT_ASE_SNK_COUNT
 	int "Basic Audio Profile ASE Sink count"
 	default 2
-	range 0 2
+	range 0 255
 	help
 	  This option enables caching a number of Audio Stream Endpoint Sink
 	  instances for Basic Audio Profile on a per connection basis.
@@ -109,7 +109,7 @@ config BT_AUDIO_UNICAST_CLIENT_ASE_SNK_COUNT
 config BT_AUDIO_UNICAST_CLIENT_ASE_SRC_COUNT
 	int "Basic Audio Profile ASE Source count"
 	default 1
-	range 0 2
+	range 0 255
 	help
 	  This option enables caching a number of Audio Stream Endpoint Source
 	  instances for Basic Audio Profile on a per connection basis.


### PR DESCRIPTION
There is no reason for the previous limitation.

The limit of 255 for the ASEs is based on the ASE IDs which is a uint8_t, so there is a maximum of 255 of each ASE type.

The limit of 73 * 2 = 146 is based on the maximum size of an GATT attribute (512), and the minimum size of a PAC record (7) makes it a total of 73 PAC records for each direction.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>