### PR TITLE
Bluetooth: Audio: Add misisng stream_count reset for broadcast sink

### DIFF
--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -1063,6 +1063,7 @@ int bt_audio_broadcast_sink_sync(struct bt_audio_broadcast_sink *sink,
 		}
 	}
 
+	sink->stream_count = 0U;
 	for (size_t i = 0; i < stream_count; i++) {
 		struct bt_audio_stream *stream;
 		struct bt_codec *codec;


### PR DESCRIPTION
This caused the sink to attempt to sync to more stream for each call to bt_audio_broadcast_sink_sync as the stream count was stored in the struct bt_audio_broadcast_sink but never reset.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>