### PR TITLE
Bluetooth: Audio: Add additional check and log for stream->conn

### DIFF
--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -75,7 +75,7 @@ void bt_audio_stream_attach(struct bt_conn *conn,
 
 	if (conn != NULL) {
 		__ASSERT(stream->conn == NULL || stream->conn == conn,
-			 "stream->conn already attached");
+			 "stream->conn %p already attached", stream->conn);
 		stream->conn = bt_conn_ref(conn);
 	}
 	stream->codec = codec;
@@ -334,6 +334,11 @@ int bt_audio_stream_config(struct bt_conn *conn,
 	CHECKIF(conn == NULL || stream == NULL || codec == NULL) {
 		BT_DBG("NULL value(s) supplied)");
 		return -EINVAL;
+	}
+
+	if (stream->conn != NULL) {
+		BT_DBG("Stream already configured for conn %p", stream->conn);
+		return -EALREADY;
 	}
 
 	role = conn->role;


### PR DESCRIPTION
bt_audio_stream_config should not be called with a stream that is already configured to another connection.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>