### PR TITLE
tests: bluetooth: host: Remove unused definitions and inclusions

### DIFF
--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/main.c
@@ -10,7 +10,6 @@
 #include "mocks/conn.h"
 #include "mocks/hci_core.h"
 #include "mocks/keys_help_utils.h"
-#include "host_mocks/assert.h"
 #include "host_mocks/print_utils.h"
 #include "testing_common_defs.h"
 
@@ -167,7 +166,6 @@ static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixt
 		zassume_true(all_startup_checks_executed == true, NULL);
 	}
 
-	ASSERT_FFF_FAKES_LIST(RESET_FAKE);
 	CONN_FFF_FAKES_LIST(RESET_FAKE);
 	HCI_CORE_FFF_FAKES_LIST(RESET_FAKE);
 }

--- a/tests/bluetooth/host/keys/mocks/keys_help_utils.h
+++ b/tests/bluetooth/host/keys/mocks/keys_help_utils.h
@@ -22,10 +22,3 @@ uint32_t bt_keys_get_aging_counter_val(void);
 void clear_key_pool(void);
 int fill_key_pool_by_id_addr(const struct id_addr_pair src[], int size, struct bt_keys *refs[]);
 bool check_key_pool_is_empty(void);
-
-/* Repeat test entries */
-#define REGISTER_SETUP_TEARDOWN(i, ...) \
-	ztest_unit_test_setup_teardown(__VA_ARGS__, unit_test_setup, unit_test_noop)
-
-#define ztest_unit_test_setup(fn, setup) \
-	ztest_unit_test_setup_teardown(fn, setup, unit_test_noop)


### PR DESCRIPTION
Clean up sources by removing unused definitions and inclusions.

Signed-off-by: Ahmed Moheb <ahmed.moheb@nordicsemi.no>