### PR TITLE
dts: arm: nxp: use dt nodelabels for dma assignments on RT11xx

### DIFF
--- a/dts/arm/nxp/nxp_rt1160_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm4.dtsi
@@ -52,96 +52,97 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
-
-		sai1: sai@40404000 {
-			dmas = <&edma_lpsr0 0 54>, <&edma_lpsr0 0 55>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <0>;
-			nxp,rx-dma-channel = <1>;
-		};
-
-		sai2: sai@40408000 {
-			dmas = <&edma_lpsr0 0 56>, <&edma_lpsr0 0 57>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <3>;
-			nxp,rx-dma-channel = <4>;
-		};
-
-		sai3: sai@4040c000 {
-			dmas = <&edma_lpsr0 0 58>, <&edma_lpsr0 0 59>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <5>;
-			nxp,rx-dma-channel = <6>;
-		};
-
-		sai4: sai@40c40000 {
-			dmas = <&edma_lpsr0 0 60>, <&edma_lpsr0 0 61>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <7>;
-			nxp,rx-dma-channel = <8>;
-		};
-
-		lpuart1: uart@4007c000 {
-			dmas = <&edma_lpsr0 1 8>, <&edma_lpsr0 2 9>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart2: uart@40080000 {
-			dmas = <&edma_lpsr0 3 10>, <&edma_lpsr0 4 11>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart3: uart@40084000 {
-			dmas = <&edma_lpsr0 5 12>, <&edma_lpsr0 6 13>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart4: uart@40088000 {
-			dmas = <&edma_lpsr0 7 14>, <&edma_lpsr0 8 15>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart5: uart@4008c000 {
-			dmas = <&edma_lpsr0 9 16>, <&edma_lpsr0 10 17>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart6: uart@40090000 {
-			dmas = <&edma_lpsr0 11 18>, <&edma_lpsr0 12 19>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart7: uart@40094000 {
-			dmas = <&edma_lpsr0 13 20>, <&edma_lpsr0 14 21>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart8: uart@40098000 {
-			dmas = <&edma_lpsr0 15 22>, <&edma_lpsr0 16 23>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart9: uart@4009c000 {
-			dmas = <&edma_lpsr0 17 24>, <&edma_lpsr0 18 25>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart10: uart@400a0000 {
-			dmas = <&edma_lpsr0 19 26>, <&edma_lpsr0 20 27>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart11: uart@40c24000 {
-			dmas = <&edma_lpsr0 21 28>, <&edma_lpsr0 22 29>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart12: uart@40c28000 {
-			dmas = <&edma_lpsr0 23 30>, <&edma_lpsr0 24 31>;
-			dma-names = "tx", "rx";
-		};
 	};
 };
+
+&sai1 {
+	dmas = <&edma_lpsr0 0 54>, <&edma_lpsr0 0 55>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <0>;
+	nxp,rx-dma-channel = <1>;
+};
+
+&sai2 {
+	dmas = <&edma_lpsr0 0 56>, <&edma_lpsr0 0 57>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <3>;
+	nxp,rx-dma-channel = <4>;
+};
+
+&sai3 {
+	dmas = <&edma_lpsr0 0 58>, <&edma_lpsr0 0 59>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <5>;
+	nxp,rx-dma-channel = <6>;
+};
+
+&sai4 {
+	dmas = <&edma_lpsr0 0 60>, <&edma_lpsr0 0 61>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <7>;
+	nxp,rx-dma-channel = <8>;
+};
+
+&lpuart1 {
+	dmas = <&edma_lpsr0 1 8>, <&edma_lpsr0 2 9>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart2 {
+	dmas = <&edma_lpsr0 3 10>, <&edma_lpsr0 4 11>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart3 {
+	dmas = <&edma_lpsr0 5 12>, <&edma_lpsr0 6 13>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart4 {
+	dmas = <&edma_lpsr0 7 14>, <&edma_lpsr0 8 15>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart5 {
+	dmas = <&edma_lpsr0 9 16>, <&edma_lpsr0 10 17>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart6 {
+	dmas = <&edma_lpsr0 11 18>, <&edma_lpsr0 12 19>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart7 {
+	dmas = <&edma_lpsr0 13 20>, <&edma_lpsr0 14 21>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart8 {
+	dmas = <&edma_lpsr0 15 22>, <&edma_lpsr0 16 23>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart9 {
+	dmas = <&edma_lpsr0 17 24>, <&edma_lpsr0 18 25>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart10 {
+	dmas = <&edma_lpsr0 19 26>, <&edma_lpsr0 20 27>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart11 {
+	dmas = <&edma_lpsr0 21 28>, <&edma_lpsr0 22 29>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart12 {
+	dmas = <&edma_lpsr0 23 30>, <&edma_lpsr0 24 31>;
+	dma-names = "tx", "rx";
+};
+
 
 &gpio1 {
 	interrupts = <100 0>, <101 0>;

--- a/dts/arm/nxp/nxp_rt1160_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm7.dtsi
@@ -60,95 +60,95 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
-
-		sai1: sai@40404000 {
-			dmas = <&edma0 0 54>, <&edma0 0 55>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <0>;
-			nxp,rx-dma-channel = <1>;
-		};
-
-		sai2: sai@40408000 {
-			dmas = <&edma0 0 56>, <&edma0 0 57>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <3>;
-			nxp,rx-dma-channel = <4>;
-		};
-
-		sai3: sai@4040c000 {
-			dmas = <&edma0 0 58>, <&edma0 0 59>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <5>;
-			nxp,rx-dma-channel = <6>;
-		};
-
-		sai4: sai@40c40000 {
-			dmas = <&edma0 0 60>, <&edma0 0 61>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <7>;
-			nxp,rx-dma-channel = <8>;
-		};
-
-		lpuart1: uart@4007c000 {
-			dmas = <&edma0 1 8>, <&edma0 2 9>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart2: uart@40080000 {
-			dmas = <&edma0 3 10>, <&edma0 4 11>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart3: uart@40084000 {
-			dmas = <&edma0 5 12>, <&edma0 6 13>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart4: uart@40088000 {
-			dmas = <&edma0 7 14>, <&edma0 8 15>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart5: uart@4008c000 {
-			dmas = <&edma0 9 16>, <&edma0 10 17>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart6: uart@40090000 {
-			dmas = <&edma0 11 18>, <&edma0 12 19>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart7: uart@40094000 {
-			dmas = <&edma0 13 20>, <&edma0 14 21>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart8: uart@40098000 {
-			dmas = <&edma0 15 22>, <&edma0 16 23>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart9: uart@4009c000 {
-			dmas = <&edma0 17 24>, <&edma0 18 25>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart10: uart@400a0000 {
-			dmas = <&edma0 19 26>, <&edma0 20 27>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart11: uart@40c24000 {
-			dmas = <&edma0 21 28>, <&edma0 22 29>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart12: uart@40c28000 {
-			dmas = <&edma0 23 30>, <&edma0 24 31>;
-			dma-names = "tx", "rx";
-		};
 	};
+};
+
+&sai1 {
+	dmas = <&edma0 0 54>, <&edma0 0 55>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <0>;
+	nxp,rx-dma-channel = <1>;
+};
+
+&sai2 {
+	dmas = <&edma0 0 56>, <&edma0 0 57>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <3>;
+	nxp,rx-dma-channel = <4>;
+};
+
+&sai3 {
+	dmas = <&edma0 0 58>, <&edma0 0 59>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <5>;
+	nxp,rx-dma-channel = <6>;
+};
+
+&sai4 {
+	dmas = <&edma0 0 60>, <&edma0 0 61>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <7>;
+	nxp,rx-dma-channel = <8>;
+};
+
+&lpuart1 {
+	dmas = <&edma0 1 8>, <&edma0 2 9>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart2 {
+	dmas = <&edma0 3 10>, <&edma0 4 11>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart3 {
+	dmas = <&edma0 5 12>, <&edma0 6 13>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart4 {
+	dmas = <&edma0 7 14>, <&edma0 8 15>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart5 {
+	dmas = <&edma0 9 16>, <&edma0 10 17>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart6 {
+	dmas = <&edma0 11 18>, <&edma0 12 19>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart7 {
+	dmas = <&edma0 13 20>, <&edma0 14 21>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart8 {
+	dmas = <&edma0 15 22>, <&edma0 16 23>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart9 {
+	dmas = <&edma0 17 24>, <&edma0 18 25>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart10 {
+	dmas = <&edma0 19 26>, <&edma0 20 27>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart11 {
+	dmas = <&edma0 21 28>, <&edma0 22 29>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart12 {
+	dmas = <&edma0 23 30>, <&edma0 24 31>;
+	dma-names = "tx", "rx";
 };
 
 &gpio1 {

--- a/dts/arm/nxp/nxp_rt1170_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm4.dtsi
@@ -52,95 +52,95 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
-
-		sai1: sai@40404000 {
-			dmas = <&edma_lpsr0 0 54>, <&edma_lpsr0 0 55>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <0>;
-			nxp,rx-dma-channel = <1>;
-		};
-
-		sai2: sai@40408000 {
-			dmas = <&edma_lpsr0 0 56>, <&edma_lpsr0 0 57>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <3>;
-			nxp,rx-dma-channel = <4>;
-		};
-
-		sai3: sai@4040c000 {
-			dmas = <&edma_lpsr0 0 58>, <&edma_lpsr0 0 59>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <5>;
-			nxp,rx-dma-channel = <6>;
-		};
-
-		sai4: sai@40c40000 {
-			dmas = <&edma_lpsr0 0 60>, <&edma_lpsr0 0 61>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <7>;
-			nxp,rx-dma-channel = <8>;
-		};
-
-		lpuart1: uart@4007c000 {
-			dmas = <&edma_lpsr0 1 8>, <&edma_lpsr0 2 9>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart2: uart@40080000 {
-			dmas = <&edma_lpsr0 3 10>, <&edma_lpsr0 4 11>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart3: uart@40084000 {
-			dmas = <&edma_lpsr0 5 12>, <&edma_lpsr0 6 13>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart4: uart@40088000 {
-			dmas = <&edma_lpsr0 7 14>, <&edma_lpsr0 8 15>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart5: uart@4008c000 {
-			dmas = <&edma_lpsr0 9 16>, <&edma_lpsr0 10 17>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart6: uart@40090000 {
-			dmas = <&edma_lpsr0 11 18>, <&edma_lpsr0 12 19>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart7: uart@40094000 {
-			dmas = <&edma_lpsr0 13 20>, <&edma_lpsr0 14 21>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart8: uart@40098000 {
-			dmas = <&edma_lpsr0 15 22>, <&edma_lpsr0 16 23>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart9: uart@4009c000 {
-			dmas = <&edma_lpsr0 17 24>, <&edma_lpsr0 18 25>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart10: uart@400a0000 {
-			dmas = <&edma_lpsr0 19 26>, <&edma_lpsr0 20 27>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart11: uart@40c24000 {
-			dmas = <&edma_lpsr0 21 28>, <&edma_lpsr0 22 29>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart12: uart@40c28000 {
-			dmas = <&edma_lpsr0 23 30>, <&edma_lpsr0 24 31>;
-			dma-names = "tx", "rx";
-		};
 	};
+};
+
+&sai1 {
+	dmas = <&edma_lpsr0 0 54>, <&edma_lpsr0 0 55>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <0>;
+	nxp,rx-dma-channel = <1>;
+};
+
+&sai2 {
+	dmas = <&edma_lpsr0 0 56>, <&edma_lpsr0 0 57>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <3>;
+	nxp,rx-dma-channel = <4>;
+};
+
+&sai3 {
+	dmas = <&edma_lpsr0 0 58>, <&edma_lpsr0 0 59>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <5>;
+	nxp,rx-dma-channel = <6>;
+};
+
+&sai4 {
+	dmas = <&edma_lpsr0 0 60>, <&edma_lpsr0 0 61>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <7>;
+	nxp,rx-dma-channel = <8>;
+};
+
+&lpuart1 {
+	dmas = <&edma_lpsr0 1 8>, <&edma_lpsr0 2 9>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart2 {
+	dmas = <&edma_lpsr0 3 10>, <&edma_lpsr0 4 11>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart3 {
+	dmas = <&edma_lpsr0 5 12>, <&edma_lpsr0 6 13>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart4 {
+	dmas = <&edma_lpsr0 7 14>, <&edma_lpsr0 8 15>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart5 {
+	dmas = <&edma_lpsr0 9 16>, <&edma_lpsr0 10 17>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart6 {
+	dmas = <&edma_lpsr0 11 18>, <&edma_lpsr0 12 19>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart7 {
+	dmas = <&edma_lpsr0 13 20>, <&edma_lpsr0 14 21>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart8 {
+	dmas = <&edma_lpsr0 15 22>, <&edma_lpsr0 16 23>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart9 {
+	dmas = <&edma_lpsr0 17 24>, <&edma_lpsr0 18 25>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart10 {
+	dmas = <&edma_lpsr0 19 26>, <&edma_lpsr0 20 27>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart11 {
+	dmas = <&edma_lpsr0 21 28>, <&edma_lpsr0 22 29>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart12 {
+	dmas = <&edma_lpsr0 23 30>, <&edma_lpsr0 24 31>;
+	dma-names = "tx", "rx";
 };
 
 &gpio1 {

--- a/dts/arm/nxp/nxp_rt1170_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm7.dtsi
@@ -60,96 +60,98 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
-
-		sai1: sai@40404000 {
-			dmas = <&edma0 0 54>, <&edma0 0 55>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <0>;
-			nxp,rx-dma-channel = <1>;
-		};
-
-		sai2: sai@40408000 {
-			dmas = <&edma0 0 56>, <&edma0 0 57>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <3>;
-			nxp,rx-dma-channel = <4>;
-		};
-
-		sai3: sai@4040c000 {
-			dmas = <&edma0 0 58>, <&edma0 0 59>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <5>;
-			nxp,rx-dma-channel = <6>;
-		};
-
-		sai4: sai@40c40000 {
-			dmas = <&edma0 0 60>, <&edma0 0 61>;
-			dma-names = "rx", "tx";
-			nxp,tx-dma-channel = <7>;
-			nxp,rx-dma-channel = <8>;
-		};
-
-		lpuart1: uart@4007c000 {
-			dmas = <&edma0 1 8>, <&edma0 2 9>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart2: uart@40080000 {
-			dmas = <&edma0 3 10>, <&edma0 4 11>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart3: uart@40084000 {
-			dmas = <&edma0 5 12>, <&edma0 6 13>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart4: uart@40088000 {
-			dmas = <&edma0 7 14>, <&edma0 8 15>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart5: uart@4008c000 {
-			dmas = <&edma0 9 16>, <&edma0 10 17>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart6: uart@40090000 {
-			dmas = <&edma0 11 18>, <&edma0 12 19>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart7: uart@40094000 {
-			dmas = <&edma0 13 20>, <&edma0 14 21>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart8: uart@40098000 {
-			dmas = <&edma0 15 22>, <&edma0 16 23>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart9: uart@4009c000 {
-			dmas = <&edma0 17 24>, <&edma0 18 25>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart10: uart@400a0000 {
-			dmas = <&edma0 19 26>, <&edma0 20 27>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart11: uart@40c24000 {
-			dmas = <&edma0 21 28>, <&edma0 22 29>;
-			dma-names = "tx", "rx";
-		};
-
-		lpuart12: uart@40c28000 {
-			dmas = <&edma0 23 30>, <&edma0 24 31>;
-			dma-names = "tx", "rx";
-		};
 	};
 };
+
+
+&sai1 {
+	dmas = <&edma0 0 54>, <&edma0 0 55>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <0>;
+	nxp,rx-dma-channel = <1>;
+};
+
+&sai2 {
+	dmas = <&edma0 0 56>, <&edma0 0 57>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <3>;
+	nxp,rx-dma-channel = <4>;
+};
+
+&sai3 {
+	dmas = <&edma0 0 58>, <&edma0 0 59>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <5>;
+	nxp,rx-dma-channel = <6>;
+};
+
+&sai4 {
+	dmas = <&edma0 0 60>, <&edma0 0 61>;
+	dma-names = "rx", "tx";
+	nxp,tx-dma-channel = <7>;
+	nxp,rx-dma-channel = <8>;
+};
+
+&lpuart1 {
+	dmas = <&edma0 1 8>, <&edma0 2 9>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart2 {
+	dmas = <&edma0 3 10>, <&edma0 4 11>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart3 {
+	dmas = <&edma0 5 12>, <&edma0 6 13>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart4 {
+	dmas = <&edma0 7 14>, <&edma0 8 15>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart5 {
+	dmas = <&edma0 9 16>, <&edma0 10 17>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart6 {
+	dmas = <&edma0 11 18>, <&edma0 12 19>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart7 {
+	dmas = <&edma0 13 20>, <&edma0 14 21>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart8 {
+	dmas = <&edma0 15 22>, <&edma0 16 23>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart9 {
+	dmas = <&edma0 17 24>, <&edma0 18 25>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart10 {
+	dmas = <&edma0 19 26>, <&edma0 20 27>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart11 {
+	dmas = <&edma0 21 28>, <&edma0 22 29>;
+	dma-names = "tx", "rx";
+};
+
+&lpuart12 {
+	dmas = <&edma0 23 30>, <&edma0 24 31>;
+	dma-names = "tx", "rx";
+};
+
 
 &gpio1 {
 	interrupts = <100 0>, <101 0>;


### PR DESCRIPTION
Update RT11xx SOC DTSI files to use DT nodelabels on RT11xx SOCs, instead of reencoding the base address of each peripheral in the M7 and M4 DTSI files.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>