### PR TITLE
twister: fix testcases parsing for testsuites with console harness

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -152,11 +152,11 @@ class Console(Harness):
 
         self.process_test(line)
 
-        tc = self.instance.get_case_or_create(self.id)
-        if self.state == "passed":
-            tc.status = "passed"
-        else:
-            tc.status = "failed"
+        for tc in self.instance.testcases:
+            if self.state == "passed":
+                tc.status = "passed"
+            else:
+                tc.status = "failed"
 
 class Pytest(Harness):
     def configure(self, instance):


### PR DESCRIPTION
The current console harness won't parse and update each specific
testcase's status like test harness, it only has one common result
regex for the whole testsuite and only sets the status for the
testcase named with suite name, for other parsed testcases, their
status is always None, this will cause wrong test results in the
generated json and xml files.
So for those testsuites, if result regex matched, we should set
all testcases in this testsuite as passed.

Fixes #50567

Signed-off-by: Chen Peng1 <peng1.chen@intel.com>