### PR TITLE
Bluetooth: ISO: Guard addition ISO debug with CONFIG_BT_DEBUG_ISO_DATA

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -94,7 +94,9 @@ void hci_iso(struct net_buf *buf)
 	struct bt_conn *iso;
 	uint8_t flags;
 
-	BT_DBG("buf %p", buf);
+	if (IS_ENABLED(CONFIG_BT_DEBUG_ISO_DATA)) {
+		BT_DBG("buf %p", buf);
+	}
 
 	BT_ASSERT(buf->len >= sizeof(*hdr));
 
@@ -106,7 +108,10 @@ void hci_iso(struct net_buf *buf)
 	iso(buf)->handle = bt_iso_handle(handle);
 	iso(buf)->index = BT_CONN_INDEX_INVALID;
 
-	BT_DBG("handle %u len %u flags %u", iso(buf)->handle, len, flags);
+	if (IS_ENABLED(CONFIG_BT_DEBUG_ISO_DATA)) {
+		BT_DBG("handle %u len %u flags %u",
+		       iso(buf)->handle, len, flags);
+	}
 
 	if (buf->len != len) {
 		BT_ERR("ISO data length mismatch (%u != %u)", buf->len, len);
@@ -629,9 +634,11 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 			iso_info(buf)->flags = 0;
 		}
 
-		BT_DBG("%s, len %u total %u flags 0x%02x timestamp %u",
-		       pb == BT_ISO_START ? "Start" : "Single", buf->len, len,
-		       flags, iso_info(buf)->ts);
+		if (IS_ENABLED(CONFIG_BT_DEBUG_ISO_DATA)) {
+			BT_DBG("%s, len %u total %u flags 0x%02x timestamp %u",
+			       pb == BT_ISO_START ? "Start" : "Single",
+			       buf->len, len, flags, iso_info(buf)->ts);
+		}
 
 		if (iso->rx) {
 			BT_ERR("Unexpected ISO %s fragment",
@@ -663,7 +670,9 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 			return;
 		}
 
-		BT_DBG("Cont, len %u rx_len %u", buf->len, iso->rx_len);
+		if (IS_ENABLED(CONFIG_BT_DEBUG_ISO_DATA)) {
+			BT_DBG("Cont, len %u rx_len %u", buf->len, iso->rx_len);
+		}
 
 		if (buf->len > net_buf_tailroom(iso->rx)) {
 			BT_ERR("Not enough buffer space for ISO data");
@@ -681,7 +690,9 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 		/* The ISO_Data_Load field contains the last fragment of an
 		 * SDU.
 		 */
-		BT_DBG("End, len %u rx_len %u", buf->len, iso->rx_len);
+		if (IS_ENABLED(CONFIG_BT_DEBUG_ISO_DATA)) {
+			BT_DBG("End, len %u rx_len %u", buf->len, iso->rx_len);
+		}
 
 		if (iso->rx == NULL) {
 			BT_ERR("Unexpected ISO end fragment");

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -25,6 +25,12 @@
 #include "common/log.h"
 #include "common/assert.h"
 
+#if defined(CONFIG_BT_DEBUG_ISO_DATA)
+#define BT_ISO_DATA_DBG(fmt, ...) BT_DBG(fmt, ##__VA_ARGS__)
+#else
+#define BT_ISO_DATA_DBG(fmt, ...)
+#endif /* CONFIG_BT_DEBUG_ISO_DATA */
+
 #define iso_chan(_iso) ((_iso)->iso.chan);
 
 #if defined(CONFIG_BT_ISO_UNICAST) || defined(CONFIG_BT_ISO_SYNC_RECEIVER)
@@ -94,9 +100,7 @@ void hci_iso(struct net_buf *buf)
 	struct bt_conn *iso;
 	uint8_t flags;
 
-	if (IS_ENABLED(CONFIG_BT_DEBUG_ISO_DATA)) {
-		BT_DBG("buf %p", buf);
-	}
+	BT_ISO_DATA_DBG("buf %p", buf);
 
 	BT_ASSERT(buf->len >= sizeof(*hdr));
 
@@ -108,10 +112,8 @@ void hci_iso(struct net_buf *buf)
 	iso(buf)->handle = bt_iso_handle(handle);
 	iso(buf)->index = BT_CONN_INDEX_INVALID;
 
-	if (IS_ENABLED(CONFIG_BT_DEBUG_ISO_DATA)) {
-		BT_DBG("handle %u len %u flags %u",
-		       iso(buf)->handle, len, flags);
-	}
+	BT_ISO_DATA_DBG("handle %u len %u flags %u",
+			iso(buf)->handle, len, flags);
 
 	if (buf->len != len) {
 		BT_ERR("ISO data length mismatch (%u != %u)", buf->len, len);
@@ -587,10 +589,8 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 	pb = bt_iso_flags_pb(flags);
 	ts = bt_iso_flags_ts(flags);
 
-	if (IS_ENABLED(CONFIG_BT_DEBUG_ISO_DATA)) {
-		BT_DBG("handle %u len %u flags 0x%02x pb 0x%02x ts 0x%02x",
-		       iso->handle, buf->len, flags, pb, ts);
-	}
+	BT_ISO_DATA_DBG("handle %u len %u flags 0x%02x pb 0x%02x ts 0x%02x",
+			iso->handle, buf->len, flags, pb, ts);
 
 	/* When the PB_Flag does not equal 0b00, the fields Time_Stamp,
 	 * Packet_Sequence_Number, Packet_Status_Flag and ISO_SDU_Length
@@ -634,11 +634,9 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 			iso_info(buf)->flags = 0;
 		}
 
-		if (IS_ENABLED(CONFIG_BT_DEBUG_ISO_DATA)) {
-			BT_DBG("%s, len %u total %u flags 0x%02x timestamp %u",
-			       pb == BT_ISO_START ? "Start" : "Single",
-			       buf->len, len, flags, iso_info(buf)->ts);
-		}
+		BT_ISO_DATA_DBG("%s, len %u total %u flags 0x%02x timestamp %u",
+				pb == BT_ISO_START ? "Start" : "Single",
+				buf->len, len, flags, iso_info(buf)->ts);
 
 		if (iso->rx) {
 			BT_ERR("Unexpected ISO %s fragment",
@@ -670,9 +668,8 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 			return;
 		}
 
-		if (IS_ENABLED(CONFIG_BT_DEBUG_ISO_DATA)) {
-			BT_DBG("Cont, len %u rx_len %u", buf->len, iso->rx_len);
-		}
+		BT_ISO_DATA_DBG("Cont, len %u rx_len %u",
+				buf->len, iso->rx_len);
 
 		if (buf->len > net_buf_tailroom(iso->rx)) {
 			BT_ERR("Not enough buffer space for ISO data");
@@ -690,9 +687,7 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 		/* The ISO_Data_Load field contains the last fragment of an
 		 * SDU.
 		 */
-		if (IS_ENABLED(CONFIG_BT_DEBUG_ISO_DATA)) {
-			BT_DBG("End, len %u rx_len %u", buf->len, iso->rx_len);
-		}
+		BT_ISO_DATA_DBG("End, len %u rx_len %u", buf->len, iso->rx_len);
 
 		if (iso->rx == NULL) {
 			BT_ERR("Unexpected ISO end fragment");
@@ -763,9 +758,7 @@ int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf,
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_DEBUG_ISO_DATA)) {
-		BT_DBG("chan %p len %zu", chan, net_buf_frags_len(buf));
-	}
+	BT_ISO_DATA_DBG("chan %p len %zu", chan, net_buf_frags_len(buf));
 
 	if (chan->state != BT_ISO_STATE_CONNECTED) {
 		BT_DBG("Not connected");


### PR DESCRIPTION
Guard additional debug statements in ISO that deals with TX/RX with CONFIG_BT_DEBUG_ISO_DATA to avoid spamming the log.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>