### PR TITLE
doc: fix embedding of Kconfig links in rst

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -253,8 +253,7 @@ TAB_SIZE               = 8
 
 ALIASES                = "rst=\verbatim embed:rst:leading-asterisk" \
                          endrst=\endverbatim \
-                         "option{1}=\verbatim embed:rst:inline :kconfig:option:`\1` \endverbatim" \
-                         "kconfig{1}=\htmlonly <code>\1</code> \endhtmlonly \xmlonly \verbatim embed:rst:inline :kconfig:option:`\1` \endverbatim \endxmlonly" \
+                         "kconfig{1}=\htmlonly <code>\1</code> \endhtmlonly \xmlonly <verbatim>embed:rst:inline :kconfig:option:`\1`</verbatim> \endxmlonly" \
                          "req{1}=\ref ZEPH_\1 \"ZEPH-\1\"" \
                          "satisfy{1}=\xrefitem satisfy \"Satisfies requirement\" \"Requirement Implementation\" \1" \
                          "verify{1}=\xrefitem verify \"Verifies requirement\" \"Requirement Verification\" \1" \


### PR DESCRIPTION
Kconfig links were not processed correctly in Doxygen content rendered by breathe. Also remove obsolete @option{} (no longer used).

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>