### PR TITLE
Bluetooth: Audio: Clear received_base in audio shell on PA sync lost

### DIFF
--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -1141,6 +1141,7 @@ static void pa_sync_lost(struct bt_audio_broadcast_sink *sink)
 	if (default_sink == sink) {
 		default_sink = NULL;
 		sink_syncable = false;
+		(void)memset(&received_base, 0, sizeof(received_base));
 	}
 }
 #endif /* CONFIG_BT_AUDIO_BROADCAST_SINK */


### PR DESCRIPTION
When the PA sync is lost, we clear the received_base so that once we resync to the PA, we get the BASE again.

This is to make it easier to decode and use the BASE again if the sync was lost, as the previous BASE may have been printed a long time before.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>