### PR TITLE
linker: correct linker script _flash_used calculation

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -266,6 +266,32 @@ config LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT
 
 	  If unsure, say Y.
 
+config LINKER_LAST_SECTION_ID
+	bool "Last section identifier"
+	default y
+	depends on ARM || ARM64 || RISCV
+	help
+	  If enabled, the last section will contain an identifier.
+	  This ensures that the '_flash_used' linker symbol will always be
+	  correctly calculated, even in cases where the location counter may
+	  have been incremented for alignment purposes but no data is placed
+	  after alignment.
+
+	  Note: in cases where the flash is fully used, for example application
+	  specific data is written at the end of the flash area, then writing a
+	  last section identifier may cause rom region overflow.
+	  In such cases this setting should be disabled.
+
+config LINKER_LAST_SECTION_ID_PATTERN
+	hex "Last section identifier pattern"
+	default "0xE015E015"
+	depends on LINKER_LAST_SECTION_ID
+	help
+	  Pattern to fill into last section as identifier.
+	  Default pattern is 0xE015 (end of last section), but any pattern can
+	  be used.
+	  The size of the pattern must not exceed 4 bytes.
+
 endmenu # "Linker Sections"
 
 endmenu

--- a/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -386,12 +386,17 @@ GROUP_END(OCM)
     LINKER_DT_SECTIONS()
 
     /* Must be last in romable region */
-    SECTION_PROLOGUE(.last_section,(NOLOAD),)
+    SECTION_PROLOGUE(.last_section,,)
     {
+#ifdef CONFIG_LINKER_LAST_SECTION_ID
+      /* Fill last section with a word to ensure location counter and actual rom
+       * region data usage match. */
+      LONG(CONFIG_LINKER_LAST_SECTION_ID_PATTERN)
+#endif
     } GROUP_LINK_IN(ROMABLE_REGION)
 
     /* To provide the image size as a const expression,
      * calculate this value here. */
-    _flash_used = LOADADDR(.last_section) - __rom_region_start;
+    _flash_used = LOADADDR(.last_section) + SIZEOF(.last_section) - __rom_region_start;
 
 }

--- a/include/zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -441,12 +441,17 @@ GROUP_END(DTCM)
     LINKER_DT_SECTIONS()
 
 /* Must be last in romable region */
-SECTION_PROLOGUE(.last_section,(NOLOAD),)
+SECTION_PROLOGUE(.last_section,,)
 {
+#ifdef CONFIG_LINKER_LAST_SECTION_ID
+  /* Fill last section with a word to ensure location counter and actual rom
+   * region data usage match. */
+  LONG(CONFIG_LINKER_LAST_SECTION_ID_PATTERN)
+#endif
 } GROUP_LINK_IN(ROMABLE_REGION)
 
 /* To provide the image size as a const expression,
  * calculate this value here. */
-_flash_used = LOADADDR(.last_section) - __rom_region_start;
+_flash_used = LOADADDR(.last_section) + SIZEOF(.last_section) - __rom_region_start;
 
     }

--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -323,12 +323,17 @@ SECTIONS
 
 
     /* Must be last in romable region */
-    SECTION_PROLOGUE(.last_section,(NOLOAD),)
+    SECTION_PROLOGUE(.last_section,,)
     {
+#ifdef CONFIG_LINKER_LAST_SECTION_ID
+      /* Fill last section with a word to ensure location counter and actual rom
+       * region data usage match. */
+      LONG(CONFIG_LINKER_LAST_SECTION_ID_PATTERN)
+#endif
     } GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
     /* To provide the image size as a const expression,
      * calculate this value here. */
-    _flash_used = LOADADDR(.last_section) - __rom_region_start;
+    _flash_used = LOADADDR(.last_section) + SIZEOF(.last_section) - __rom_region_start;
 
 }

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -399,13 +399,18 @@ GROUP_END(DTCM)
  */
 #ifdef CONFIG_XIP
 /* Must be last in romable region */
-SECTION_PROLOGUE(.last_section,(NOLOAD),)
+SECTION_PROLOGUE(.last_section,,)
 {
+#ifdef CONFIG_LINKER_LAST_SECTION_ID
+  /* Fill last section with a word to ensure location counter and actual rom
+   * region data usage match. */
+  LONG(CONFIG_LINKER_LAST_SECTION_ID_PATTERN)
+#endif
 } GROUP_LINK_IN(ROMABLE_REGION)
 
 /* To provide the image size as a const expression,
  * calculate this value here. */
-__rom_region_end = LOADADDR(.last_section);
+__rom_region_end = LOADADDR(.last_section) + SIZEOF(.last_section);
 __rom_region_size = __rom_region_end - __rom_region_start;
 #endif
 

--- a/soc/riscv/riscv-privilege/andes_v5/ae350/linker.ld
+++ b/soc/riscv/riscv-privilege/andes_v5/ae350/linker.ld
@@ -360,13 +360,18 @@ GROUP_END(DTCM)
 	}
 
 /* Must be last in romable region */
-SECTION_PROLOGUE(.last_section,(NOLOAD),)
+SECTION_PROLOGUE(.last_section,,)
 {
+#ifdef CONFIG_LINKER_LAST_SECTION_ID
+  /* Fill last section with a word to ensure location counter and actual rom
+   * region data usage match. */
+  LONG(CONFIG_LINKER_LAST_SECTION_ID_PATTERN)
+#endif
 } GROUP_LINK_IN(ROMABLE_REGION)
 
 /* To provide the image size as a const expression,
  * calculate this value here. */
-__rom_region_end = LOADADDR(.last_section);
+__rom_region_end = LOADADDR(.last_section) + SIZEOF(.last_section);
 __rom_region_size = __rom_region_end - __rom_region_start;
 
 }


### PR DESCRIPTION
Linker scripts contains a `.last_section` section that is placed in rom region as NOLOAD for the purpose of retrieve the actual number of bytes contained in the image. See d85efe0b10f1f8ed4b854717f994062a4bbffe26

However, a previous section may cause the location counter to be incremented for alignment purposes. This can result in the size of the image to be 0x10FA but location counter to be 0x1100 because it has been aligned for next section placement.

By removing NOLOAD and write 0xE015 (end of last section) to the section we ensure that data is written after alignment of location counter, and thereby forces the image size to be in sync with the location counter.

Using 0xE015 also serves as identifier that end of last section is present.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

--------

*Note:* this is labelled `bug` as it fixes a bug that has been identified and reported downstream of Zephyr, but no bug has been filed directly against Zephyr project.