### PR TITLE
net: lwm2m: Add helper macro for filling lwm2m_obj_path structs

### DIFF
--- a/include/zephyr/net/lwm2m_path.h
+++ b/include/zephyr/net/lwm2m_path.h
@@ -41,6 +41,27 @@
 
 #define LWM2M_PATH_MACRO(_1, _2, _3, _4, NAME, ...) NAME
 
-
+/**
+ * @brief Initialize LwM2M object structure
+ *
+ * Accepts at least one and up to four arguments. Fill up @ref lwm2m_obj_path structure
+ * and sets the level. For example:
+ *
+ *   struct lwm2m_obj_path p = LWM2M_OBJ(MY_OBJ, 0, RESOURCE);
+ *
+ * Can also be used in place of function argument to return the structure allocated from stack
+ *
+ *   lwm2m_notify_observer_path(&LWM2M_OBJ(MY_OBJ, inst_id, RESOURCE));
+ *
+ */
+#define LWM2M_OBJ(...) \
+	GET_OBJ_MACRO(__VA_ARGS__, LWM2M_OBJ4, LWM2M_OBJ3, LWM2M_OBJ2, LWM2M_OBJ1)(__VA_ARGS__)
+#define GET_OBJ_MACRO(_1, _2, _3, _4, NAME, ...) NAME
+#define LWM2M_OBJ1(oi) (struct lwm2m_obj_path) {.obj_id = oi, .level = 1}
+#define LWM2M_OBJ2(oi, oii) (struct lwm2m_obj_path) {.obj_id = oi, .obj_inst_id = oii, .level = 2}
+#define LWM2M_OBJ3(oi, oii, ri) (struct lwm2m_obj_path) \
+	{.obj_id = oi, .obj_inst_id = oii, .res_id = ri, .level = 3}
+#define LWM2M_OBJ4(oi, oii, ri, rii) (struct lwm2m_obj_path) \
+	{.obj_id = oi, .obj_inst_id = oii, .res_id = ri, .res_inst_id = rii, .level = 4}
 
 #endif /* ZEPHYR_INCLUDE_NET_LWM2M_PATH_H_ */

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -28,6 +28,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/init.h>
 #include <zephyr/net/http_parser_url.h>
 #include <zephyr/net/lwm2m.h>
+#include <zephyr/net/lwm2m_path.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/sys/printk.h>
@@ -537,12 +538,7 @@ int lwm2m_register_payload_handler(struct lwm2m_message *msg)
 		 * needed to report object version.
 		 */
 		if (obj->instance_count == 0U || lwm2m_engine_shall_report_obj_version(obj)) {
-			struct lwm2m_obj_path path = {
-				.obj_id = obj->obj_id,
-				.level = LWM2M_PATH_LEVEL_OBJECT,
-			};
-
-			ret = engine_put_corelink(&msg->out, &path);
+			ret = engine_put_corelink(&msg->out, &LWM2M_OBJ(obj->obj_id));
 			if (ret < 0) {
 				return ret;
 			}
@@ -554,13 +550,9 @@ int lwm2m_register_payload_handler(struct lwm2m_message *msg)
 
 		SYS_SLIST_FOR_EACH_CONTAINER(engine_obj_inst_list, obj_inst, node) {
 			if (obj_inst->obj->obj_id == obj->obj_id) {
-				struct lwm2m_obj_path path = {
-					.obj_id = obj_inst->obj->obj_id,
-					.obj_inst_id = obj_inst->obj_inst_id,
-					.level = LWM2M_PATH_LEVEL_OBJECT_INST,
-				};
-
-				ret = engine_put_corelink(&msg->out, &path);
+				ret = engine_put_corelink(
+					&msg->out,
+					&LWM2M_OBJ(obj_inst->obj->obj_id, obj_inst->obj_inst_id));
 				if (ret < 0) {
 					return ret;
 				}
@@ -1380,14 +1372,9 @@ static int lwm2m_discover_add_res(struct lwm2m_message *msg, struct lwm2m_engine
 				  struct lwm2m_engine_res *res)
 {
 	int ret;
-	struct lwm2m_obj_path path = {
-		.obj_id = obj_inst->obj->obj_id,
-		.obj_inst_id = obj_inst->obj_inst_id,
-		.res_id = res->res_id,
-		.level = LWM2M_PATH_LEVEL_RESOURCE,
-	};
 
-	ret = engine_put_corelink(&msg->out, &path);
+	ret = engine_put_corelink(
+		&msg->out, &LWM2M_OBJ(obj_inst->obj->obj_id, obj_inst->obj_inst_id, res->res_id));
 	if (ret < 0) {
 		return ret;
 	}
@@ -1402,15 +1389,9 @@ static int lwm2m_discover_add_res(struct lwm2m_message *msg, struct lwm2m_engine
 				continue;
 			}
 
-			path = (struct lwm2m_obj_path){
-				.obj_id = obj_inst->obj->obj_id,
-				.obj_inst_id = obj_inst->obj_inst_id,
-				.res_id = res->res_id,
-				.res_inst_id = res_inst->res_inst_id,
-				.level = LWM2M_PATH_LEVEL_RESOURCE_INST,
-			};
-
-			ret = engine_put_corelink(&msg->out, &path);
+			ret = engine_put_corelink(
+				&msg->out, &LWM2M_OBJ(obj_inst->obj->obj_id, obj_inst->obj_inst_id,
+						      res->res_id, res_inst->res_inst_id));
 			if (ret < 0) {
 				return ret;
 			}
@@ -1477,12 +1458,7 @@ int lwm2m_discover_handler(struct lwm2m_message *msg, bool is_bootstrap)
 		if ((is_bootstrap &&
 		     (obj->instance_count == 0U || lwm2m_engine_shall_report_obj_version(obj))) ||
 		    (!is_bootstrap && msg->path.level == LWM2M_PATH_LEVEL_OBJECT)) {
-			struct lwm2m_obj_path path = {
-				.obj_id = obj->obj_id,
-				.level = LWM2M_PATH_LEVEL_OBJECT,
-			};
-
-			ret = engine_put_corelink(&msg->out, &path);
+			ret = engine_put_corelink(&msg->out, &LWM2M_OBJ(obj->obj_id));
 			if (ret < 0) {
 				return ret;
 			}
@@ -1509,13 +1485,9 @@ int lwm2m_discover_handler(struct lwm2m_message *msg, bool is_bootstrap)
 			 * provided.
 			 */
 			if (msg->path.level <= LWM2M_PATH_LEVEL_OBJECT_INST) {
-				struct lwm2m_obj_path path = {
-					.obj_id = obj_inst->obj->obj_id,
-					.obj_inst_id = obj_inst->obj_inst_id,
-					.level = LWM2M_PATH_LEVEL_OBJECT_INST,
-				};
-
-				ret = engine_put_corelink(&msg->out, &path);
+				ret = engine_put_corelink(
+					&msg->out,
+					&LWM2M_OBJ(obj_inst->obj->obj_id, obj_inst->obj_inst_id));
 				if (ret < 0) {
 					return ret;
 				}


### PR DESCRIPTION
Allows filling up struct lwm2m_obj_path by a macro. For example:
```
  struct lwm2m_obj_path p1 = LWM2M_OBJ(MY_OBJ);
  struct lwm2m_obj_path p2 = LWM2M_OBJ(MY_OBJ, 0, RESOURCE);
```

Similarly, some function calls accept the structure, so it can be initialized from stack and given by a pointer
```
  lwm2m_notify_observer_path(&LWM2M_OBJ(obj_id, 0, RESOURCE_ID));
```
