### PR TITLE
drivers: entropy: Fix MCUX CAAM

### DIFF
--- a/drivers/entropy/Kconfig.mcux
+++ b/drivers/entropy/Kconfig.mcux
@@ -32,11 +32,10 @@ config ENTROPY_MCUX_RNG
 
 config ENTROPY_MCUX_CAAM
 	bool "MCUX CAAM driver"
-	# FIXME: temporarily disabled because this driver hangs
-	# 	 during initialization on rt11xx platforms
-	#default y
+	default y
 	depends on DT_HAS_NXP_IMX_CAAM_ENABLED
 	select ENTROPY_HAS_DRIVER
+	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	help
 	  This option enables the CAAM driver based on the MCUX
 	  CAAM driver.

--- a/drivers/entropy/entropy_mcux_caam.c
+++ b/drivers/entropy/entropy_mcux_caam.c
@@ -17,7 +17,7 @@ struct mcux_entropy_config {
 	CAAM_Type *base;
 };
 
-static caam_job_ring_interface_t jrif;
+static caam_job_ring_interface_t jrif __attribute__((__section__(".nocache")));
 
 static int entropy_mcux_caam_get_entropy(const struct device *dev,
 					 uint8_t *buffer,

--- a/dts/arm/nxp/nxp_rt1160_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm4.dtsi
@@ -554,3 +554,8 @@
 		<&iomuxc_gpio_ad_31_gpio9_io30>,
 		<&iomuxc_gpio_ad_32_gpio9_io31>;
 };
+
+/* CAAM currently does not work on M4 because of cache API issues */
+&caam {
+	status = "disabled";
+};

--- a/dts/arm/nxp/nxp_rt1170_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm4.dtsi
@@ -554,3 +554,8 @@
 		<&iomuxc_gpio_ad_31_gpio9_io30>,
 		<&iomuxc_gpio_ad_32_gpio9_io31>;
 };
+
+/* CAAM currently does not work on M4 because of cache API issues */
+&caam {
+	status = "disabled";
+};

--- a/tests/drivers/entropy/api/Kconfig
+++ b/tests/drivers/entropy/api/Kconfig
@@ -1,0 +1,10 @@
+# Copyright NXP 2022
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Entropy API Test"
+
+source "Kconfig.zephyr"
+source "tests/drivers/entropy/api/Kconfig.mcux"
+
+config RANDOM_BUFFER_NOCACHED
+	bool "Put the buffer of randomly generated numbers in nocache region."

--- a/tests/drivers/entropy/api/Kconfig.mcux
+++ b/tests/drivers/entropy/api/Kconfig.mcux
@@ -1,0 +1,9 @@
+# Copyright NXP 2022
+# SPDX-License-Identifier: Apache-2.0
+
+if ENTROPY_MCUX_CAAM
+
+config RANDOM_BUFFER_NOCACHED
+	default y if NOCACHE_MEMORY
+
+endif

--- a/tests/drivers/entropy/api/src/main.c
+++ b/tests/drivers/entropy/api/src/main.c
@@ -25,6 +25,13 @@
 #define BUFFER_LENGTH           10
 #define RECHECK_RANDOM_ENTROPY  0x10
 
+#ifdef CONFIG_RANDOM_BUFFER_NOCACHED
+__attribute__((__section__(".nocache")))
+static uint8_t buffer[BUFFER_LENGTH] = {0};
+#else
+static uint8_t buffer[BUFFER_LENGTH] = {0};
+#endif
+
 static int random_entropy(const struct device *dev, char *buffer, char num)
 {
 	int ret, i;
@@ -69,7 +76,6 @@ static int random_entropy(const struct device *dev, char *buffer, char num)
 static int get_entropy(void)
 {
 	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
-	uint8_t buffer[BUFFER_LENGTH] = { 0 };
 	int ret;
 
 	if (!device_is_ready(dev)) {


### PR DESCRIPTION
Fix the MCUX CAAM bug affecting RT11XX platforms when using the entropy subsystem

Fixes #50446
Fixes #49440
Fixes #49846