### PR TITLE
list_issues.py tweaks

### DIFF
--- a/scripts/dump_bugs_pickle.py
+++ b/scripts/dump_bugs_pickle.py
@@ -43,7 +43,8 @@ def main() -> None:
     args = parse_args()
     bugs = get_bugs(args)
     for bug in sorted(bugs, key=lambda bug: bug.number):
-        print(f'- :github:`{bug.number}` - {bug.title}')
+        title = bug.title.strip()
+        print(f'- :github:`{bug.number}` - {title}')
 
 if __name__ == '__main__':
     main()

--- a/scripts/release/list_issues.py
+++ b/scripts/release/list_issues.py
@@ -106,11 +106,11 @@ class Issues:
             pass
 
     def issues_since(self, date, state="closed"):
-        self.list_issues("%s/issues?state=%s&since=%s" %
+        self.list_issues("%s/issues?per_page=100&state=%s&since=%s" %
                          (self.github_url, state, date))
 
     def pull_requests(self, base='v1.14-branch', state='closed'):
-        self.list_issues("%s/pulls?state=%s&base=%s" %
+        self.list_issues("%s/pulls?per_page=100&state=%s&base=%s" %
                          (self.github_url, state, base))
 
 

--- a/scripts/release/list_issues.py
+++ b/scripts/release/list_issues.py
@@ -162,7 +162,7 @@ set the env. variable GITHUB_TOKEN please and retry.""")
                 if 'pull_request' not in issue:
                     # * :github:`8193` - STM32 config BUILD_OUTPUT_HEX fail
                     f.write("* :github:`{}` - {}\n".format(
-                        issue['number'], issue['title']))
+                        issue['number'], issue['title'].strip()))
                     count = count + 1
     elif args.issues_in_pulls:
         i.pull_requests(base=args.issues_in_pulls)
@@ -211,7 +211,7 @@ set the env. variable GITHUB_TOKEN please and retry.""")
                     if item:
                         # * :github:`8193` - STM32 config BUILD_OUTPUT_HEX fail
                         f.write("* :github:`{}` - {}\n".format(
-                                item['number'], item['title']))
+                                item['number'], item['title'].strip()))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Two tweaks for `list_issues.py`:
- fetch 100 issues at a time (3.3x boost wohoo)
- strip title names
- strip titles in dump_bugs_pickle as well