### PR TITLE
RFC: Parse Kconfig to get driver API/feature info

### DIFF
--- a/scripts/dts/gen_driver_kconfig_dts.py
+++ b/scripts/dts/gen_driver_kconfig_dts.py
@@ -61,6 +61,12 @@ def compat2kconfig(compat):
     printfile(f'')
     printfile(f'config DT_HAS_{compat_ident}_ENABLED')
     printfile(f'\tdef_bool $(dt_compat_enabled,$(DT_COMPAT_{compat_ident}))')
+    printfile(f'')
+    printfile(f'if DT_HAS_{compat_ident}_ENABLED')
+    printfile(f'config DT_{compat_ident}')
+    printfile(f'\tstring')
+    printfile(f'\tdefault "{compat}"')
+    printfile(f'endif')
 
 def main():
     global kconfig_file

--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -13,6 +13,13 @@ import argparse
 import os
 import sys
 import textwrap
+import pickle
+from pathlib import Path
+ZEPHYR_BASE = str(Path(__file__).resolve().parents[2])
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "dts",
+                                "python-devicetree", "src"))
+
+from devicetree import edtlib
 
 # Zephyr doesn't use tristate symbols. They're supported here just to make the
 # script a bit more generic.
@@ -95,6 +102,15 @@ def main():
 
     # Write the list of parsed Kconfig files to a file
     write_kconfig_filenames(kconf, args.kconfig_list_out)
+
+    EDT_PICKLE = os.environ.get("EDT_PICKLE")
+
+    # The "if" handles a missing dts.
+    if EDT_PICKLE is not None and os.path.isfile(EDT_PICKLE):
+        with open(EDT_PICKLE, 'rb') as f:
+            edt = pickle.load(f)
+    else:
+        edt = None
 
 
 def check_no_promptless_assign(kconf):


### PR DESCRIPTION
The intent of this PR is to show how we can parse Kconfig data to extract driver API and feature information.  We map from devicetree compatible to Kconfig.

If we standardize on the Kconfig symbols names and pattern, we can utilize this as a means to extract info we need for things like multi-api, shell, userspace, docs, testing, etc.