### PR TITLE
soc: intel_adsp/ace: fix multi-level interrupt enabling and IPC interrupt unmasking

### DIFF
--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/ace_v1x-regs.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/ace_v1x-regs.h
@@ -119,8 +119,14 @@ struct mtl_dint {
 #define MTL_DINT ((volatile struct mtl_dint *)DXHIPCIE_REG)
 
 /* Convert between IRQ_CONNECT() numbers and MTL_INTL_* interrupts */
-#define MTL_IRQ_TO_ZEPHYR(n)   (XCHAL_NUM_INTERRUPTS + (n))
-#define MTL_IRQ_FROM_ZEPHYR(n) ((n) - XCHAL_NUM_INTERRUPTS)
+#define ACE_IRQ_NUM_SHIFT 8
+#define ACE_IRQ_NUM_MASK 0xFFU
+
+#define MTL_IRQ_FROM_ZEPHYR(_irq) \
+	(((_irq >> ACE_IRQ_NUM_SHIFT) & ACE_IRQ_NUM_MASK) - 1)
+
+#define MTL_IRQ_TO_ZEPHYR(_irq) \
+	((((_irq + 1) & ACE_IRQ_NUM_MASK) << ACE_IRQ_NUM_SHIFT) + ACE_INTC_IRQ)
 
 /* MTL also has per-core instantiations of a Synopsys interrupt
  * controller.  These inputs (with the same indices as MTL_INTL_*

--- a/soc/xtensa/intel_adsp/common/ipc.c
+++ b/soc/xtensa/intel_adsp/common/ipc.c
@@ -154,11 +154,28 @@ bool intel_adsp_ipc_send_message_sync(const struct device *dev,
 }
 
 #if DT_NODE_EXISTS(INTEL_ADSP_IPC_HOST_DTNODE)
+
+#if defined(CONFIG_SOC_SERIES_INTEL_ACE)
+#include <ace_v1x-regs.h>
+
+static inline void ace_ipc_intc_unmask(void)
+{
+	for (int i = 0; i < CONFIG_MP_NUM_CPUS; i++) {
+		MTL_DINT[i].ie[MTL_INTL_HIPC] = BIT(0);
+	}
+}
+#else
+static inline void ace_ipc_intc_unmask(void) {}
+#endif
+
 static int dt_init(const struct device *dev)
 {
 	IRQ_CONNECT(DT_IRQN(INTEL_ADSP_IPC_HOST_DTNODE), 0, z_intel_adsp_ipc_isr,
 		INTEL_ADSP_IPC_HOST_DEV, 0);
 	irq_enable(DT_IRQN(INTEL_ADSP_IPC_HOST_DTNODE));
+
+	ace_ipc_intc_unmask();
+
 	return intel_adsp_ipc_init(dev);
 }
 


### PR DESCRIPTION
* The ACE specific DesignWare interrupt controller is decoding the multi-level interrupt numbers from device tree incorrectly. This fixes the decoding.
* Also the same driver uses incorrect offset to ISR table for the ISR pointer. So fix that too.
* And on ACE, there is another layer of interrupt masking. So we need to un-mask during IPC init or else we are not going to get any host IPCs.