### PR TITLE
qspi: stm32: Add support for reset cmd on init

### DIFF
--- a/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
@@ -41,6 +41,15 @@ properties:
       type: int
       required: false
       description: The duration (in ms) for the flash memory reset pulse
+    reset-cmd:
+      type: boolean
+      required: false
+      description: Send reset command on initialization
+    reset-cmd-wait:
+      type: int
+      default: 10
+      required: false
+      description: The duration (in us) to wait after reset command
     spi-bus-width:
       type: int
       required: false


### PR DESCRIPTION
If the flash is used in 4-byte addressing, reading SFDP will fail after a system reset if the flash isn't power cycled or hardware reset, since Zephyr will try to use 3-byte addressing while the flash (still) expects 4-byte addressing.

This commit adds the ability to send a reset command to the flash as part of initialization, which complements the existing reset-gpio functionality, and is useful on low-pincount flashes which do not have a hardware reset.

Signed-off-by: Ole Morten Haaland <omh@icsys.no>