### PR TITLE
Bluetooth: controller: correct parameters in conn update complete event

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -270,9 +270,16 @@ static void lp_cu_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	pdu = (struct node_rx_cu *)ntf->pdu;
 
 	pdu->status = ctx->data.cu.error;
-	pdu->interval = ctx->data.cu.interval_max;
-	pdu->latency = ctx->data.cu.latency;
-	pdu->timeout = ctx->data.cu.timeout;
+	if (!ctx->data.cu.error) {
+		pdu->interval = ctx->data.cu.interval_max;
+		pdu->latency = ctx->data.cu.latency;
+		pdu->timeout = ctx->data.cu.timeout;
+	} else {
+		pdu->interval = conn->lll.interval;
+		pdu->latency = conn->lll.latency;
+		pdu->timeout = conn->supervision_reload *
+			conn->lll.interval * 125U / 1000;
+	}
 
 	/* Enqueue notification towards LL */
 	ll_rx_put(ntf->hdr.link, ntf);
@@ -727,10 +734,16 @@ static void rp_cu_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	pdu = (struct node_rx_cu *)ntf->pdu;
 
 	pdu->status = ctx->data.cu.error;
-	pdu->interval = ctx->data.cu.interval_max;
-	pdu->latency = ctx->data.cu.latency;
-	pdu->timeout = ctx->data.cu.timeout;
-
+	if (!ctx->data.cu.error) {
+		pdu->interval = ctx->data.cu.interval_max;
+		pdu->latency = ctx->data.cu.latency;
+		pdu->timeout = ctx->data.cu.timeout;
+	} else {
+		pdu->interval = conn->lll.interval;
+		pdu->latency = conn->lll.latency;
+		pdu->timeout = conn->supervision_reload *
+			conn->lll.interval * 125U / 1000;
+	}
 	/* Enqueue notification towards LL */
 	ll_rx_put(ntf->hdr.link, ntf);
 	ll_rx_sched();


### PR DESCRIPTION
In case a connection update complete event reports an error, the parameters reported should be the ones active on the connection and not the ones requested

Signed-off-by: Erik Brockhoff <erbr@oticon.com>