### PR TITLE
tests: drivers: dac loopback test on stm32 boards

### DIFF
--- a/tests/drivers/dac/dac_loopback/src/test_dac.c
+++ b/tests/drivers/dac/dac_loopback/src/test_dac.c
@@ -26,12 +26,11 @@
  * point is at half of the full scale voltage.
  */
 
-#if defined(CONFIG_BOARD_NUCLEO_L073RZ) || \
-	defined(CONFIG_BOARD_NUCLEO_L152RE) || \
+#if defined(CONFIG_BOARD_NUCLEO_L152RE) || \
 	defined(CONFIG_BOARD_STM32F3_DISCO) || \
-	defined(CONFIG_BOARD_STM32L562E_DK) || \
 	defined(CONFIG_BOARD_NUCLEO_L552ZE_Q) || \
 	defined(CONFIG_BOARD_NUCLEO_WL55JC) || \
+	defined(CONFIG_BOARD_NUCLEO_G474RE) || \
 	defined(CONFIG_BOARD_RONOTH_LODEV)
 
 /*
@@ -50,10 +49,31 @@
 #define ADC_REFERENCE		ADC_REF_INTERNAL
 #define ADC_ACQUISITION_TIME	ADC_ACQ_TIME_DEFAULT
 
-#elif defined(CONFIG_BOARD_NUCLEO_F207ZG) || \
+#elif defined(CONFIG_BOARD_STM32L562E_DK)
+
+/*
+ * DAC output on PA4 (Arduino A2 pin of disco board)
+ * ADC input read from PC4 (Arduino A4 pin of disco board)
+ */
+
+#define DAC_DEVICE_NODE		DT_NODELABEL(dac1)
+#define DAC_CHANNEL_ID		1
+#define DAC_RESOLUTION		12
+
+#define ADC_DEVICE_NODE		DT_NODELABEL(adc1)
+#define ADC_CHANNEL_ID		13
+#define ADC_RESOLUTION		12
+#define ADC_GAIN		ADC_GAIN_1
+#define ADC_REFERENCE		ADC_REF_INTERNAL
+#define ADC_ACQUISITION_TIME	ADC_ACQ_TIME_DEFAULT
+
+#elif defined(CONFIG_BOARD_NUCLEO_L073RZ) || \
+	defined(CONFIG_BOARD_NUCLEO_F091RC) || \
+	defined(CONFIG_BOARD_NUCLEO_F207ZG) || \
 	defined(CONFIG_BOARD_NUCLEO_F429ZI) || \
 	defined(CONFIG_BOARD_NUCLEO_F746ZG) || \
 	defined(CONFIG_BOARD_NUCLEO_G071RB)
+
 /*
  * DAC output on PA4
  * ADC input read from PA0

--- a/tests/drivers/dac/dac_loopback/testcase.yaml
+++ b/tests/drivers/dac/dac_loopback/testcase.yaml
@@ -7,6 +7,7 @@ tests:
     harness_config:
       fixture: dac_adc_loopback
     platform_allow: |
-      frdm_k22f frdm_k64f nucleo_f207zg nucleo_l073rz nucleo_l152re twr_ke18f
-      bl652_dvk bl653_dvk bl654_dvk bl5340_dvk_cpuapp stm32f3_disco stm32l562e_dk
-      nucleo_l552ze_q nucleo_f429zi nucleo_f746zg nucleo_g071rb nucleo_wl55jc
+      frdm_k22f frdm_k64f nucleo_f091rc nucleo_f207zg nucleo_l073rz nucleo_l152re
+      twr_ke18f bl652_dvk bl653_dvk bl654_dvk bl5340_dvk_cpuapp stm32f3_disco
+      stm32l562e_dk nucleo_f429zi nucleo_f746zg nucleo_g071rb nucleo_g474re
+      nucleo_wl55jc


### PR DESCRIPTION
Add configuration to run the tests/drivers/dac/dac_loopback on more stm32 platform

Adapting the ADC input channels for running the testcase tests/drivers/dac/dac_loopback on

-   nucleo_l073rz adc1 input read from A0 --> connect to A2 on CN8
-   nucleo_f091rc adc1 input read from A0 --> connect to A2 on CN8
-   nucleo_g474re adc1 input read from A0 --> connect to A2 on CN8
-   stm32l562e_dk adc1 input 13 from A4 --> connect to A2 on CN19


Add the connection on the hw board and the `dac_adc_loopback` fixture to Pass the test.

Signed-off-by: Francois Ramu <francois.ramu@st.com>