### PR TITLE
MAINTAINERS: update hal_silabs maintainers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2328,8 +2328,11 @@ West:
     - manifest-hal_rpi_pico
 
 "West project: hal_silabs":
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - fkokosinski
   collaborators:
+    - sateeshkotapati
     - yonsch
     - mnkp
     - chrta


### PR DESCRIPTION
This PR updates the maintainers list (adds @sateeshkotapati) for the hal_silabs area and changes its status to `maintained`.