### PR TITLE
device: use IF_ENABLED to initialize PM field

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -924,7 +924,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		.api = (api_ptr),					\
 		.state = (state_ptr),					\
 		.data = (data_ptr),					\
-		COND_CODE_1(CONFIG_PM_DEVICE, (.pm = pm_device,), ())	\
+		IF_ENABLED(CONFIG_PM_DEVICE, (.pm = pm_device,))	\
 		Z_DEVICE_DEFINE_INIT(node_id, dev_name)			\
 	};								\
 	BUILD_ASSERT(sizeof(Z_STRINGIFY(drv_name)) <= Z_DEVICE_MAX_NAME_LEN, \


### PR DESCRIPTION
IF_ENABLED(CONFIG_FOO, (x)) is equivalent to COND_CODE_1(CONFIG_FOO, (x), ()).

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>