### PR TITLE
drivers: Disallow FD frames when not in FD Mode for mcan

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -841,6 +841,16 @@ int can_mcan_send(const struct device *dev,
 		return -ENETUNREACH;
 	}
 
+	if (frame->fd && (can->cccr & CAN_MCAN_CCCR_FDOE) == 0) {
+		LOG_ERR("fd flag set without fd mode enabled.");
+		return -EINVAL;
+	}
+
+	if (frame->brs && (can->cccr & CAN_MCAN_CCCR_BRSE) == 0) {
+		LOG_ERR("brs flag set without fd brs mode enabled.");
+		return -EINVAL;
+	}
+
 	ret = k_sem_take(&data->tx_sem, timeout);
 	if (ret != 0) {
 		return -EAGAIN;


### PR DESCRIPTION
Currently, if you send an FD frame with the mcan driver, but FD mode was not enabled, the hardware will only send the first 8 bytes of the frame, but still with a DLC of FD length. This results in some very weird behavior on the bus, dependning on what other devices are doing. Add a check to ensure an FD send only occurs with FD enabled.

Fixes: #50776

Signed-off-by: Thad House <thadhouse@fb.com>