### PR TITLE
drivers: Correct tx and rx error counts in mcan

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -761,10 +761,10 @@ int can_mcan_get_state(const struct device *dev, enum can_state *state,
 	}
 
 	if (err_cnt != NULL) {
-		err_cnt->rx_err_cnt = (can->ecr & CAN_MCAN_ECR_TEC_MSK) <<
+		err_cnt->tx_err_cnt = (can->ecr & CAN_MCAN_ECR_TEC_MSK) <<
 				      CAN_MCAN_ECR_TEC_POS;
 
-		err_cnt->tx_err_cnt = (can->ecr & CAN_MCAN_ECR_REC_MSK) <<
+		err_cnt->rx_err_cnt = (can->ecr & CAN_MCAN_ECR_REC_MSK) <<
 				      CAN_MCAN_ECR_REC_POS;
 	}
 


### PR DESCRIPTION
TX and RX error counts are swapped in the mcan driver.

Fixes: #50771

Signed-off-by: Thad House <thadhouse@fb.com>