### PR TITLE
west: sign code partition

### DIFF
--- a/boards/xtensa/esp32/esp32.dts
+++ b/boards/xtensa/esp32/esp32.dts
@@ -23,6 +23,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 

--- a/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
+++ b/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
@@ -23,6 +23,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 

--- a/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb.dts
+++ b/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {

--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -104,6 +104,11 @@ function(zephyr_mcuboot_tasks)
   set(confirmed_args)
   set(encrypted_args)
 
+  if(CONFIG_USE_DT_CODE_PARTITION)
+    list(APPEND unconfirmed_args "--use-code-partition")
+    list(APPEND confirmed_args "--use-code-partition")
+  endif()
+
   # Set up .bin outputs.
   if(CONFIG_BUILD_OUTPUT_BIN)
     list(APPEND unconfirmed_args --bin --sbin ${output}.signed.bin)


### PR DESCRIPTION
I have found out, that west is always signing partition named 'image-0'. This generated problem when I tried to design chain loading images structure, with common devicetree, where i just changed `code-partition` in overlay for each. I can think of several solutions to this issue, but in my opinion west build and west sign should follow `CONFIG_USE_DT_CODE_PARTITION`. What do you think?

The change only fails one build which is `samples/boards/esp32/flash_encryption` this is due to fact, that example sets `CONFIG_BOOTLOADER_MCUBOOT` which selects `CONFIG_USE_DT_CODE_PARTITION`, but do not have 'zephyr,code-partition' declared anywhere. I believe the board do not use chosen node, despite selecting config, but debugging this is not scope of this PR. I attached patch adding this node to the board definition.