### PR TITLE
doc: boards: NXP serial port features documented

### DIFF
--- a/boards/arm/lpcxpresso55s06/doc/index.rst
+++ b/boards/arm/lpcxpresso55s06/doc/index.rst
@@ -61,7 +61,8 @@ already supported, which can also be re-used on this lpcxpresso55s06 board:
 +-----------+------------+-------------------------------------+
 | GPIO      | on-chip    | gpio                                |
 +-----------+------------+-------------------------------------+
-| USART     | on-chip    | serial port                         |
+| USART     | on-chip    | serial port-polling;                |
+|           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
 | CLOCK     | on-chip    | clock_control                       |
 +-----------+------------+-------------------------------------+

--- a/boards/arm/lpcxpresso55s16/doc/index.rst
+++ b/boards/arm/lpcxpresso55s16/doc/index.rst
@@ -70,7 +70,8 @@ already supported, which can also be re-used on this lpcxpresso55s16 board:
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
-| USART     | on-chip    | serial port                         |
+| USART     | on-chip    | serial port-polling;                |
+|           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
 | SENSOR    | off-chip   | fxos8700 trigger                    |
 +-----------+------------+-------------------------------------+

--- a/boards/arm/lpcxpresso55s28/doc/index.rst
+++ b/boards/arm/lpcxpresso55s28/doc/index.rst
@@ -70,7 +70,8 @@ already supported, which can also be re-used on this lpcxpresso55s28 board:
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
-| USART     | on-chip    | serial port-polling                 |
+| USART     | on-chip    | serial port-polling;                |
+|           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
 | WWDT      | on-chip    | windowed watchdog timer             |
 +-----------+------------+-------------------------------------+

--- a/boards/arm/lpcxpresso55s36/doc/index.rst
+++ b/boards/arm/lpcxpresso55s36/doc/index.rst
@@ -66,7 +66,8 @@ already supported, which can also be re-used on this lpcxpresso55s36 board:
 +-----------+------------+-------------------------------------+
 | GPIO      | on-chip    | gpio                                |
 +-----------+------------+-------------------------------------+
-| USART     | on-chip    | serial port                         |
+| USART     | on-chip    | serial port-polling;                |
+|           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
 | CLOCK     | on-chip    | clock_control                       |
 +-----------+------------+-------------------------------------+

--- a/boards/arm/lpcxpresso55s69/doc/index.rst
+++ b/boards/arm/lpcxpresso55s69/doc/index.rst
@@ -68,7 +68,8 @@ configuration supports the following hardware features:
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
-| USART     | on-chip    | serial port-polling                 |
+| USART     | on-chip    | serial port-polling;                |
+|           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
 | WWDT      | on-chip    | windowed watchdog timer             |
 +-----------+------------+-------------------------------------+

--- a/boards/arm/mimxrt595_evk/doc/index.rst
+++ b/boards/arm/mimxrt595_evk/doc/index.rst
@@ -77,7 +77,8 @@ already supported, which can also be re-used on this mimxrt595_evk board:
 +-----------+------------+-------------------------------------+
 | GPIO      | on-chip    | gpio                                |
 +-----------+------------+-------------------------------------+
-| USART     | on-chip    | serial port-polling                 |
+| USART     | on-chip    | serial port-polling;                |
+|           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
 | CLOCK     | on-chip    | clock_control                       |
 +-----------+------------+-------------------------------------+

--- a/boards/arm/mimxrt685_evk/doc/index.rst
+++ b/boards/arm/mimxrt685_evk/doc/index.rst
@@ -77,7 +77,8 @@ already supported, which can also be re-used on this mimxrt685_evk board:
 +-----------+------------+-------------------------------------+
 | FLASH     | on-chip    | OctalSPI Flash                      |
 +-----------+------------+-------------------------------------+
-| USART     | on-chip    | serial port-polling                 |
+| USART     | on-chip    | serial port-polling;                |
+|           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+


### PR DESCRIPTION
Updated docs for NXP boards using the nxp_lpc_usart, for supported serial port features.
