### PR TITLE
scripts: build: remove KEEP() from symbols moved with zephyr_code_relocate

### DIFF
--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -45,7 +45,7 @@ from elftools.elf.sections import SymbolTableSection
 
 
 PRINT_TEMPLATE = """
-                KEEP(*({0}))
+                *({0})
 """
 
 SECTION_LOAD_MEMORY_SEQ = """
@@ -495,7 +495,6 @@ def main():
             mem_type = mem_type.split("|", 1)[0]
             code_generation = generate_memcpy_code(mem_type,
                                                list_of_sections, code_generation)
-
     dump_header_file(args.output_code, code_generation)
 
 


### PR DESCRIPTION
The build script parsing files that will be relocated using the zephyr_code_relocate macro was adding KEEP() to all symbols.

This resulted in unnecessary symbols being added to the build, and could result in a linker failure if symbols in the relocated file that the linker would otherwise discard referenced undefined symbols.

This error was observed while relocating portions of the networking subsystem to SRAM, since the network management API was not being compiled but some unused functions in the network subsystem were using the API.