### PR TITLE
[DNM] net: allow relocation of network subsystem to RAM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ set(PARSE_SYSCALLS_TARGET      parse_syscalls_target)
 
 define_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT BRIEF_DOCS " " FULL_DOCS " ")
 set_property(   GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf32-little${ARCH}) # BFD format
+define_property(GLOBAL PROPERTY PROPERTY_CODE_RELOCATION_TARGET
+  BRIEF_DOCS "Code relocation target location" FULL_DOCS " ")
 
 # "zephyr_interface" is a source-less library that encapsulates all the global
 # compiler options needed by all source files. All zephyr libraries,
@@ -814,6 +816,21 @@ foreach(zephyr_lib ${ZEPHYR_LIBS_PROPERTY})
       set_property(TARGET ${zephyr_lib} PROPERTY EXCLUDE_FROM_ALL TRUE)
       list(REMOVE_ITEM ZEPHYR_LIBS_PROPERTY ${zephyr_lib})
       continue()
+    endif()
+    # In order to allow zephyr_library_relocate to be called prior to adding
+    # library sources, we must parse and generate relocation information
+    # once all libraries have been defined
+    get_property(relocation_target TARGET ${zephyr_lib} PROPERTY
+      PROPERTY_CODE_RELOCATION_TARGET)
+    if(NOT "${relocation_target}" STREQUAL "")
+      get_property(lib_source_dir TARGET ${zephyr_lib} PROPERTY SOURCE_DIR)
+      foreach(file ${source_list})
+        if(NOT IS_ABSOLUTE ${file})
+          set(file ${lib_source_dir}/${file})
+        endif()
+        set_property(TARGET code_data_relocation_target APPEND PROPERTY
+          COMPILE_DEFINITIONS "${relocation_target}:${file}")
+      endforeach()
     endif()
   endif()
 

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1281,6 +1281,20 @@ function(zephyr_linker_sources location)
   endforeach()
 endfunction(zephyr_linker_sources)
 
+function(zephyr_library_relocate location)
+  set(options NOCOPY)
+  cmake_parse_arguments(CODE_REL "${options}" "" "" ${ARGN})
+  if(NOT CODE_REL_NOCOPY)
+    set(copy_flag COPY)
+  else()
+    set(copy_flag NOCOPY)
+  endif()
+  # Set current library relocation property. This will be picked up
+  # in the root CMakeLists.txt file to relocate all sources added to
+  # this library
+  set_property(TARGET ${ZEPHYR_CURRENT_LIBRARY}
+    PROPERTY PROPERTY_CODE_RELOCATION_TARGET "${location}:${copy_flag}")
+endfunction()
 
 # Helper function for CONFIG_CODE_DATA_RELOCATION
 # Call this function with 2 arguments file and then memory location.

--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -110,4 +110,30 @@ config ETH_MCUX_PTP_CLOCK_INIT_PRIO
 
 endif # PTP_CLOCK_MCUX
 
+
+# Add relocation options for networking code
+if NET_CODE_RELOCATE
+
+if CPU_CORTEX_M7
+
+# Relocate code to ITCM for M7 cores
+
+choice NET_CODE_RAM
+	default NET_CODE_RAM_ITCM
+
+config NET_CODE_RAM_ITCM
+	bool "ITCM"
+	help
+	  Relocate networking subsystem code to ITCM
+
+endchoice
+
+config NET_CODE_RAM_NAME
+	string
+	default "ITCM" if NET_CODE_RAM_ITCM
+
+endif # CPU_CORTEX_M7
+
+endif # NET_CODE_RELOCATE
+
 endif # ETH_MCUX

--- a/samples/net/zperf/boards/mimxrt1050_evk.conf
+++ b/samples/net/zperf/boards/mimxrt1050_evk.conf
@@ -1,2 +1,3 @@
 # Note: HW accleration does not support IPV6
 CONFIG_ETH_MCUX_HW_ACCELERATION=y
+CONFIG_NET_CODE_RELOCATE=y

--- a/samples/net/zperf/boards/mimxrt1060_evk.conf
+++ b/samples/net/zperf/boards/mimxrt1060_evk.conf
@@ -1,2 +1,3 @@
 # Note: HW accleration does not support IPV6
 CONFIG_ETH_MCUX_HW_ACCELERATION=y
+CONFIG_NET_CODE_RELOCATE=y

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -45,7 +45,7 @@ from elftools.elf.sections import SymbolTableSection
 
 
 PRINT_TEMPLATE = """
-                KEEP(*({0}))
+                *({0})
 """
 
 SECTION_LOAD_MEMORY_SEQ = """
@@ -495,7 +495,6 @@ def main():
             mem_type = mem_type.split("|", 1)[0]
             code_generation = generate_memcpy_code(mem_type,
                                                list_of_sections, code_generation)
-
     dump_header_file(args.output_code, code_generation)
 
 

--- a/subsys/net/CMakeLists.txt
+++ b/subsys/net/CMakeLists.txt
@@ -4,6 +4,10 @@ zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_NET_BUF             buf.c)
 zephyr_library_sources_ifdef(CONFIG_NET_HOSTNAME_ENABLE hostname.c)
 
+if(CONFIG_NET_CODE_RELOCATE)
+  zephyr_library_relocate("${CONFIG_NET_CODE_RAM_NAME}_TEXT")
+endif()
+
 if(CONFIG_NETWORKING)
   add_subdirectory(l2)
   add_subdirectory(pkt_filter)

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -70,6 +70,38 @@ config NETWORKING
 
 if NETWORKING
 
+config NET_CODE_RELOCATE
+	bool "Relocate network subsystem code into RAM"
+	select CODE_DATA_RELOCATION
+	help
+	  Relocate networking subsystem code into RAM using zephyr_code_relocate
+	  macro. This may enable significant performance gains on some
+	  platforms, depending on the speed of their RAM versus FLASH region.
+if NET_CODE_RELOCATE
+
+choice NET_CODE_RAM
+	prompt "Location to relocate networking code to in RAM"
+	default NET_CODE_RAM_SRAM
+	help
+	  Location to relocated networking code to. Defaults to SRAM unless
+	  the platform selects a higher performance RAM region
+
+config NET_CODE_RAM_SRAM
+	bool "SRAM"
+	select CODE_DATA_RELOCATION_SRAM
+	help
+	  Relocate networking subsystem code to SRAM
+
+endchoice
+
+config NET_CODE_RAM_NAME
+	string
+	default "SRAM" if NET_CODE_RAM_SRAM
+	help
+	  Hidden option for RAM bank to relocate networking code into
+
+endif # NET_CODE_RELOCATE
+
 # Such option should not be configured manually but by device drivers
 # which supports PM properly.
 config NET_POWER_MANAGEMENT

--- a/subsys/net/ip/CMakeLists.txt
+++ b/subsys/net/ip/CMakeLists.txt
@@ -13,6 +13,10 @@ zephyr_library_sources(
   utils.c
   )
 
+if(CONFIG_NET_CODE_RELOCATE)
+  zephyr_library_relocate("${CONFIG_NET_CODE_RAM_NAME}_TEXT")
+endif()
+
 if(CONFIG_NET_OFFLOAD)
 zephyr_library_sources(net_context.c net_pkt.c net_tc.c)
 endif()


### PR DESCRIPTION
Enable relocation of network subsystem to RAM. The intent of this feature is to enable SOCs with fast instruction TCM to take advantage of the improved performance available by relocating networking code to this region. This PR enables this feature for the Cortex M7 based iMX RT SOCs with a Kinetis Ethernet controller.

This PR is dependent on the following PRs (and currently integrates the commits from both):
#50791
#50790

Below are some TCP performance results using this PR. Results were obtained using iperf 2.1.5 with the zperf sample running on the Zephyr target. These results relocate the networking stack, L2 ethernet implementation, and NXP ethernet driver to ITCM.

| Board | SHA | TCP RX | TCP TX |
| ----- | ------ | ------- | ------- |
| mimxrt1060_evk | main (fd9e5429a37f24780f5e27c08ecb470d5d36e93a) | 44.2Mbps | 43.7Mbps |
| mimxrt1060_evk | This PR | 94.5Mbps | 71.6Mbps |
| mimxrt1050_evk | main (fd9e5429a37f24780f5e27c08ecb470d5d36e93a) | 60.2Mbps | 68.5Mbps |
| mimxrt1050_evk | This PR | 94.5Mbps | 71.4Mbps|