### PR TITLE
samples: lorawan: verify region compilation

### DIFF
--- a/boards/arm/96b_wistrio/96b_wistrio.yaml
+++ b/boards/arm/96b_wistrio/96b_wistrio.yaml
@@ -11,3 +11,4 @@ supported:
   - gpio
   - i2c
   - eeprom
+  - lora

--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.yaml
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.yaml
@@ -19,3 +19,4 @@ supported:
   - counter
   - eeprom
   - nvs
+  - lora

--- a/boards/arm/lora_e5_dev_board/lora_e5_dev_board.yaml
+++ b/boards/arm/lora_e5_dev_board/lora_e5_dev_board.yaml
@@ -16,3 +16,4 @@ supported:
   - spi
   - uart
   - watchdog
+  - lora

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.yaml
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.yaml
@@ -21,3 +21,4 @@ supported:
   - dma
   - watchdog
   - nvs
+  - lora

--- a/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.yaml
+++ b/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.yaml
@@ -16,3 +16,4 @@ supported:
   - spi
   - uart
   - watchdog
+  - lora

--- a/boards/arm/rak4631_nrf52840/rak4631_nrf52840.yaml
+++ b/boards/arm/rak4631_nrf52840/rak4631_nrf52840.yaml
@@ -18,3 +18,4 @@ supported:
   - usb_cdc
   - usb_device
   - watchdog
+  - lora

--- a/boards/arm/ronoth_lodev/ronoth_lodev.yaml
+++ b/boards/arm/ronoth_lodev/ronoth_lodev.yaml
@@ -15,3 +15,4 @@ supported:
   - watchdog
   - adc
   - dac
+  - lora

--- a/samples/drivers/lora/receive/sample.yaml
+++ b/samples/drivers/lora/receive/sample.yaml
@@ -1,11 +1,11 @@
 common:
    tags: lora
+   depends_on: lora
 sample:
    description: Demonstration of LoRa Receive functionality
    name: LoRa Receive Sample
 tests:
    sample.driver.lora.receive:
-     platform_allow: 96b_wistrio rak4631_nrf52840 nucleo_wl55jc
      harness: console
      harness_config:
       type: one_line

--- a/samples/drivers/lora/send/sample.yaml
+++ b/samples/drivers/lora/send/sample.yaml
@@ -1,11 +1,11 @@
 common:
    tags: lora
+   depends_on: lora
 sample:
    description: Demonstration of LoRa Send functionality
    name: LoRa Send Sample
 tests:
    sample.driver.lora.send:
-     platform_allow: 96b_wistrio rak4631_nrf52840 nucleo_wl55jc
      harness: console
      harness_config:
       type: one_line

--- a/samples/subsys/lorawan/class_a/sample.yaml
+++ b/samples/subsys/lorawan/class_a/sample.yaml
@@ -1,6 +1,6 @@
 common:
   tags: lorawan
-  platform_allow: 96b_wistrio nucleo_wl55jc
+  depends_on: lora
   harness: console
   harness_config:
     type: one_line

--- a/samples/subsys/lorawan/class_a/sample.yaml
+++ b/samples/subsys/lorawan/class_a/sample.yaml
@@ -1,13 +1,42 @@
 common:
-   tags: lorawan
+  tags: lorawan
+  platform_allow: 96b_wistrio nucleo_wl55jc
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "<inf> lorawan_class_a: Joining network over OTAA"
 sample:
-   description: Demonstration of Class-A LoRaWAN functionality
-   name: LoRaWAN Class-A
+  description: Demonstration of Class-A LoRaWAN functionality
+  name: LoRaWAN Class-A
 tests:
-  sample.lorawan.class_a:
-    platform_allow: 96b_wistrio nucleo_wl55jc
-    harness: console
-    harness_config:
-      type: one_line
-      regex:
-        - "<inf> lorawan_class_a: Joining network over OTAA"
+  sample.lorawan.class_a.as923:
+    extra_configs:
+      - CONFIG_LORAMAC_REGION_AS923=y
+  sample.lorawan.class_a.au915:
+    extra_configs:
+      - CONFIG_LORAMAC_REGION_AU915=y
+  sample.lorawan.class_a.cn470:
+    extra_configs:
+      - CONFIG_LORAMAC_REGION_CN470=y
+  sample.lorawan.class_a.cn779:
+    extra_configs:
+      - CONFIG_LORAMAC_REGION_CN779=y
+  sample.lorawan.class_a.eu433:
+    extra_configs:
+      - CONFIG_LORAMAC_REGION_EU433=y
+  sample.lorawan.class_a.eu868:
+    extra_configs:
+      - CONFIG_LORAMAC_REGION_EU868=y
+  sample.lorawan.class_a.kr920:
+    extra_configs:
+      - CONFIG_LORAMAC_REGION_KR920=y
+  sample.lorawan.class_a.in865:
+    extra_configs:
+      - CONFIG_LORAMAC_REGION_IN865=y
+  sample.lorawan.class_a.us915:
+    extra_configs:
+      - CONFIG_LORAMAC_REGION_US915=y
+  sample.lorawan.class_a.ru864:
+    extra_configs:
+      - CONFIG_LORAMAC_REGION_RU864=y


### PR DESCRIPTION
Issue #49960 showed that individual regions can fail to compile when enabled. As requested in #50626, validate that each region compiles in CI.

Improves testing setup by removing the usage of `platform_allow` from LoRa test cases.