### PR TITLE
samples: drivers: espi: Re-enable eSPI SAF for MEC152x board

### DIFF
--- a/samples/drivers/espi/boards/mec15xxevb_assy6853.overlay
+++ b/samples/drivers/espi/boards/mec15xxevb_assy6853.overlay
@@ -14,6 +14,10 @@
 	};
 };
 
+&espi_saf0 {
+	status = "okay";
+};
+
 &spi0 {
 	status = "okay";
 	port_sel = <0>;

--- a/samples/drivers/espi/prj_mec15xxevb_assy6853.conf
+++ b/samples/drivers/espi/prj_mec15xxevb_assy6853.conf
@@ -8,8 +8,6 @@ CONFIG_ESPI_AUTOMATIC_WARNING_ACKNOWLEDGE=n
 # Sample code doesn't handle ACPI host communication
 CONFIG_ESPI_PERIPHERAL_HOST_IO=n
 # Test SAF flash portal read/erase/write on EVB
-# disabled CONFIG_ESPI_SAF since devicetree node for ESPI_SAF is
-# not currently enabled so this will fail to build
-#CONFIG_ESPI_SAF=y
+CONFIG_ESPI_SAF=y
 CONFIG_SPI=y
 CONFIG_SPI_XEC_QMSPI=y

--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -62,7 +62,7 @@ static uint8_t flash_read_buf[MAX_TEST_BUF_SIZE];
 #endif
 
 #ifdef CONFIG_ESPI_SAF
-#define SAF_BASE_ADDR     DT_REG_ADDR(ESPI_SAF_NODE)
+#define SAF_BASE_ADDR   DT_REG_ADDR(DT_NODELABEL(espi_saf0))
 
 #define SAF_TEST_FREQ_HZ 24000000U
 #define SAF_TEST_BUF_SIZE 4096U


### PR DESCRIPTION
Add missing device tree entry for SAF HW block.
Re-enable driver for MEC152x board.

Addresses #49032

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>