### PR TITLE
Bluetooth: Mesh: Add prefix `bt_mesh_` for global variable

### DIFF
--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -238,7 +238,7 @@ static void close_link(enum prov_bearer_link_status reason)
 	void *cb_data = link.cb_data;
 
 	reset_adv_link();
-	cb->link_closed(&pb_adv, cb_data, reason);
+	cb->link_closed(&bt_mesh_pb_adv, cb_data, reason);
 }
 
 static struct net_buf *adv_buf_create(uint8_t retransmits)
@@ -270,7 +270,7 @@ static bool ack_pending(void)
 static void prov_failed(uint8_t err)
 {
 	BT_DBG("%u", err);
-	link.cb->error(&pb_adv, link.cb_data, err);
+	link.cb->error(&bt_mesh_pb_adv, link.cb_data, err);
 	atomic_set_bit(link.flags, ADV_LINK_INVALID);
 }
 
@@ -292,7 +292,7 @@ static void prov_msg_recv(void)
 		return;
 	}
 
-	link.cb->recv(&pb_adv, link.cb_data, link.rx.buf);
+	link.cb->recv(&bt_mesh_pb_adv, link.cb_data, link.rx.buf);
 }
 
 static void protocol_timeout(struct k_work *work)
@@ -786,7 +786,7 @@ static void link_open(struct prov_rx *rx, struct net_buf_simple *buf)
 		return;
 	}
 
-	link.cb->link_opened(&pb_adv, link.cb_data);
+	link.cb->link_opened(&bt_mesh_pb_adv, link.cb_data);
 }
 
 static void link_ack(struct prov_rx *rx, struct net_buf_simple *buf)
@@ -800,7 +800,7 @@ static void link_ack(struct prov_rx *rx, struct net_buf_simple *buf)
 
 		prov_clear_tx();
 
-		link.cb->link_opened(&pb_adv, link.cb_data);
+		link.cb->link_opened(&bt_mesh_pb_adv, link.cb_data);
 	}
 }
 
@@ -912,18 +912,18 @@ static void prov_link_close(enum prov_bearer_link_status status)
 	bearer_ctl_send_unacked(ctl_buf_create(LINK_CLOSE, &status, 1, RETRANSMITS_LINK_CLOSE));
 }
 
-void pb_adv_init(void)
+void bt_mesh_pb_adv_init(void)
 {
 	k_work_init_delayable(&link.prot_timer, protocol_timeout);
 	k_work_init_delayable(&link.tx.retransmit, prov_retransmit);
 }
 
-void pb_adv_reset(void)
+void bt_mesh_pb_adv_reset(void)
 {
 	reset_adv_link();
 }
 
-const struct prov_bearer pb_adv = {
+const struct prov_bearer bt_mesh_pb_adv = {
 	.type = BT_MESH_PROV_ADV,
 	.link_open = prov_link_open,
 	.link_accept = prov_link_accept,

--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -53,7 +53,7 @@ static void link_closed(enum prov_bearer_link_status status)
 
 	reset_state();
 
-	cb->link_closed(&pb_gatt, cb_data, status);
+	cb->link_closed(&bt_mesh_pb_gatt, cb_data, status);
 }
 
 static void protocol_timeout(struct k_work *work)
@@ -94,7 +94,7 @@ int bt_mesh_pb_gatt_recv(struct bt_conn *conn, struct net_buf_simple *buf)
 
 	k_work_reschedule(&link.prot_timer, PROTOCOL_TIMEOUT);
 
-	link.cb->recv(&pb_gatt, link.cb_data, buf);
+	link.cb->recv(&bt_mesh_pb_gatt, link.cb_data, buf);
 
 	return 0;
 }
@@ -110,7 +110,7 @@ int bt_mesh_pb_gatt_start(struct bt_conn *conn)
 	link.conn = bt_conn_ref(conn);
 	k_work_reschedule(&link.prot_timer, PROTOCOL_TIMEOUT);
 
-	link.cb->link_opened(&pb_gatt, link.cb_data);
+	link.cb->link_opened(&bt_mesh_pb_gatt, link.cb_data);
 
 	return 0;
 }
@@ -153,7 +153,7 @@ int bt_mesh_pb_gatt_cli_open(struct bt_conn *conn)
 		return -ENOTCONN;
 	}
 
-	link.cb->link_opened(&pb_gatt, link.cb_data);
+	link.cb->link_opened(&bt_mesh_pb_gatt, link.cb_data);
 
 	return 0;
 }
@@ -226,17 +226,17 @@ static void clear_tx(void)
 	/* No action */
 }
 
-void pb_gatt_init(void)
+void bt_mesh_pb_gatt_init(void)
 {
 	k_work_init_delayable(&link.prot_timer, protocol_timeout);
 }
 
-void pb_gatt_reset(void)
+void bt_mesh_pb_gatt_reset(void)
 {
 	reset_state();
 }
 
-const struct prov_bearer pb_gatt = {
+const struct prov_bearer bt_mesh_pb_gatt = {
 	.type = BT_MESH_PROV_GATT,
 #if defined(CONFIG_BT_MESH_PB_GATT_CLIENT)
 	.link_open = prov_link_open,

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -431,11 +431,11 @@ void bt_mesh_prov_complete(uint16_t net_idx, uint16_t addr)
 void bt_mesh_prov_reset(void)
 {
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_ADV)) {
-		pb_adv_reset();
+		bt_mesh_pb_adv_reset();
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
-		pb_gatt_reset();
+		bt_mesh_pb_gatt_reset();
 	}
 
 	bt_mesh_prov_reset_state(NULL);
@@ -455,11 +455,11 @@ int bt_mesh_prov_init(const struct bt_mesh_prov *prov_info)
 	bt_mesh_prov = prov_info;
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_ADV)) {
-		pb_adv_init();
+		bt_mesh_pb_adv_init();
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT)) {
-		pb_gatt_init();
+		bt_mesh_pb_gatt_init();
 	}
 
 	return bt_mesh_prov_reset_state(NULL);

--- a/subsys/bluetooth/mesh/prov_bearer.h
+++ b/subsys/bluetooth/mesh/prov_bearer.h
@@ -104,11 +104,11 @@ struct prov_bearer {
 	void (*link_close)(enum prov_bearer_link_status status);
 };
 
-extern const struct prov_bearer pb_adv;
-extern const struct prov_bearer pb_gatt;
+extern const struct prov_bearer bt_mesh_pb_adv;
+extern const struct prov_bearer bt_mesh_pb_gatt;
 
-void pb_adv_init(void);
-void pb_gatt_init(void);
+void bt_mesh_pb_adv_init(void);
+void bt_mesh_pb_gatt_init(void);
 
-void pb_adv_reset(void);
-void pb_gatt_reset(void);
+void bt_mesh_pb_adv_reset(void);
+void bt_mesh_pb_gatt_reset(void);

--- a/subsys/bluetooth/mesh/prov_device.c
+++ b/subsys/bluetooth/mesh/prov_device.c
@@ -611,12 +611,12 @@ int bt_mesh_prov_enable(bt_mesh_prov_bearer_t bearers)
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_ADV) &&
 	    (bearers & BT_MESH_PROV_ADV)) {
-		pb_adv.link_accept(bt_mesh_prov_bearer_cb_get(), NULL);
+		bt_mesh_pb_adv.link_accept(bt_mesh_prov_bearer_cb_get(), NULL);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PB_GATT) &&
 	    (bearers & BT_MESH_PROV_GATT)) {
-		pb_gatt.link_accept(bt_mesh_prov_bearer_cb_get(), NULL);
+		bt_mesh_pb_gatt.link_accept(bt_mesh_prov_bearer_cb_get(), NULL);
 	}
 
 	bt_mesh_prov_link.role = &role_device;

--- a/subsys/bluetooth/mesh/provisioner.c
+++ b/subsys/bluetooth/mesh/provisioner.c
@@ -763,7 +763,8 @@ static int bt_mesh_provisioner_open(const struct prov_bearer *bearer,
 int bt_mesh_pb_adv_open(const uint8_t uuid[16], uint16_t net_idx, uint16_t addr,
 			uint8_t attention_duration)
 {
-	return bt_mesh_provisioner_open(&pb_adv, uuid, net_idx, addr, attention_duration);
+	return bt_mesh_provisioner_open(&bt_mesh_pb_adv, uuid,
+					net_idx, addr, attention_duration);
 }
 #endif
 
@@ -771,6 +772,7 @@ int bt_mesh_pb_adv_open(const uint8_t uuid[16], uint16_t net_idx, uint16_t addr,
 int bt_mesh_pb_gatt_open(const uint8_t uuid[16], uint16_t net_idx, uint16_t addr,
 			 uint8_t attention_duration)
 {
-	return bt_mesh_provisioner_open(&pb_gatt, uuid, net_idx, addr, attention_duration);
+	return bt_mesh_provisioner_open(&bt_mesh_pb_gatt, uuid,
+					net_idx, addr, attention_duration);
 }
 #endif


### PR DESCRIPTION
Some variables shadow global, which is difficult to handle when porting to other platforms with shadow warnings turned on.

https://github.com/zephyrproject-rtos/zephyr/pull/50581

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>