### PR TITLE
Allow building SNTP library on `native_posix` boards without enabling POSIX API.

### DIFF
--- a/subsys/net/lib/sntp/Kconfig
+++ b/subsys/net/lib/sntp/Kconfig
@@ -4,7 +4,7 @@
 menuconfig SNTP
 	bool "SNTP (Simple Network Time Protocol)"
 	depends on NET_SOCKETS
-	depends on NET_SOCKETS_POSIX_NAMES || POSIX_API
+	depends on NET_SOCKETS_POSIX_NAMES || POSIX_API || ARCH_POSIX
 	help
 	  Enable SNTP client library
 


### PR DESCRIPTION
On `native_posix` boards, the POSIX API is already available, so enabling
either NET_SOCKETS_POSIX_NAMES or POSIX_API will cause compile-time conflicting
declaration errors. However, without either, the SNTP library won't build, even
if the POSIX API is already available. Fix this by allowing the SNTP library to
build when building directly for a POSIX board.
