### PR TITLE
test: lib: Skip tests/lib/cmsis_dsp/matrix on MEC17.

### DIFF
--- a/tests/lib/cmsis_dsp/matrix/testcase.yaml
+++ b/tests/lib/cmsis_dsp/matrix/testcase.yaml
@@ -136,7 +136,7 @@ tests:
       - native_posix
     tags: cmsis_dsp
     min_flash: 128
-    min_ram: 64
+    min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_F64=y
@@ -147,7 +147,7 @@ tests:
       - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
-    min_ram: 64
+    min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_F64=y


### PR DESCRIPTION
The SRAM for date segment in MEC17 is only 64KB.
    malloc allocated 12.8KB twice,
    calloc allocated 24.9KB.
    Update the test to ZTEST new API also consumes more memory,
    and the memory allocation failed at the last malloc.
    So skip this test on MEC17.

Fixes #50452

Signed-off-by: Kun Li <kun1x.li@intel.com>