### PR TITLE
net: sntp: use zsock_ functions.

### DIFF
--- a/subsys/net/lib/sntp/Kconfig
+++ b/subsys/net/lib/sntp/Kconfig
@@ -4,7 +4,6 @@
 menuconfig SNTP
 	bool "SNTP (Simple Network Time Protocol)"
 	depends on NET_SOCKETS
-	depends on NET_SOCKETS_POSIX_NAMES || POSIX_API
 	help
 	  Enable SNTP client library
 


### PR DESCRIPTION
Now the library does not need to depend on NET_SOCKETS_POSIX_NAMES.

Signed-off-by: Sjors Gielen <github@sjorsgielen.nl>
