### PR TITLE
boards: nucleo_f103rb: Fix openocd configuration

### DIFF
--- a/boards/arm/nucleo_f103rb/support/openocd.cfg
+++ b/boards/arm/nucleo_f103rb/support/openocd.cfg
@@ -1,5 +1,7 @@
 source [find board/st_nucleo_f103rb.cfg]
 
+reset_config connect_assert_srst
+
 $_TARGETNAME configure -event gdb-attach {
         echo "Debugger attaching: halting execution"
         reset halt
@@ -9,4 +11,10 @@ $_TARGETNAME configure -event gdb-attach {
 $_TARGETNAME configure -event gdb-detach {
         echo "Debugger detaching: resuming execution"
         resume
+}
+
+rename init old_init
+proc init {} {
+        old_init
+        reset halt
 }


### PR DESCRIPTION
With latest version of openocd delivered in Zephyr SDK 0.15.0, a new configuration is required to flash and debug this board: "reset_config connect_assert_srst" allows to flash the board The new "init" function allows to run debug.

Fixes #50590 for this specific board

Note that other boards might be also impacted by this new version of openocd but a revert of zephyrproject-rtos/openocd@98d9f11 allows to get back to the previous status.
A new Zephyr SDK release (V0.15.1) will be available with a revert of this commit. Unfortunately this has no impact on nucleo_f103rb. Hence this change.


Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>