### PR TITLE
STM32L5x2 testing the spi and uart with DMA transfer on disco board

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32l562e_dk.overlay
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&spi1 {
-	dmas = <&dmamux1 0 12 0x440
-		&dmamux1 7 11 0x480>;
+&spi3 {
+	dmas = <&dmamux1 0 16 0x440
+		&dmamux1 7 15 0x480>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/uart/uart_async_api/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/stm32l562e_dk.overlay
@@ -5,6 +5,7 @@
  */
 
 &usart3 {
+	pinctrl-0 = <&usart3_tx_pb10 &usart3_rx_pb11>;
 	dmas = <&dmamux1 5 30 0x440>,
 		<&dmamux1 4 29 0x480>;
 	dma-names = "tx", "rx";


### PR DESCRIPTION
This PR configures the DMA channels for the stm32l562e_dk platform to run

    tests/drivers/spi/spi_loopback
    tests/drivers/uart/uart_async_api

The DMA of the stm32l5x2 is accessed through the DMAMUX.
See table (98) in [RM0438](https://www.st.com/resource/en/reference_manual/rm0438-stm32l552xx-and-stm32l562xx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) for selecting request for the DMAMUX channels

Connect the Tx to Rx pins on the target platform (add the corresponding harness_config "fixture") to pass the test.

Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)