### PR TITLE
Bluetooth: Audio: Modify log of non-found stream for config state cal…

### DIFF
--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -518,7 +518,7 @@ static void unicast_client_ep_config_state(struct bt_audio_ep *ep,
 
 	stream = ep->stream;
 	if (stream == NULL) {
-		BT_ERR("No stream active for endpoint");
+		BT_WARN("No stream active for endpoint");
 		return;
 	}
 


### PR DESCRIPTION
…lback

In the unicast client, it is possible for the unicast server to send a notification for ASE when it is in the codec configured state after a reconnect. In that case, the unicast client does not have a coupling between the ASE and the audio stream.

This caused a BT_ERR to trigger, but it is not really an error, but rather a state that the current unicast client cannot handle, so the BT_ERR has been replaced with a BT_WRN.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>