### PR TITLE
json: Fix multidimensional array support

### DIFF
--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -519,8 +519,17 @@ static ptrdiff_t get_elem_size(const struct json_obj_descr *descr)
 	case JSON_TOK_TRUE:
 	case JSON_TOK_FALSE:
 		return sizeof(bool);
-	case JSON_TOK_ARRAY_START:
-		return descr->array.n_elements * get_elem_size(descr->array.element_descr);
+	case JSON_TOK_ARRAY_START: {
+		ptrdiff_t size;
+
+		size = descr->array.n_elements * get_elem_size(descr->array.element_descr);
+		/* Consider additional item count field for array objects */
+		if (descr->field_name_len > 0) {
+			size = size + sizeof(size_t);
+		}
+
+		return size;
+	}
 	case JSON_TOK_OBJECT_START: {
 		ptrdiff_t total = 0;
 		size_t i;
@@ -542,23 +551,25 @@ static int arr_parse(struct json_obj *obj,
 		     const struct json_obj_descr *elem_descr,
 		     size_t max_elements, void *field, void *val)
 {
-	ptrdiff_t elem_size = get_elem_size(elem_descr);
-	void *last_elem = (char *)field + elem_size * max_elements;
-	size_t *elements = NULL;
-	struct json_token value;
+	void *value = val;
+	size_t *elements = (size_t *)((char *)value + elem_descr->offset);
+	ptrdiff_t elem_size;
+	void *last_elem;
+	struct json_token tok;
 
-	if (val) {
-		elements = (size_t *)((char *)val + elem_descr->offset);
+	/* For nested arrays, skip parent descriptor to get elements */
+	if (elem_descr->type == JSON_TOK_ARRAY_START) {
+		elem_descr = elem_descr->array.element_descr;
 	}
+
+	*elements = 0;
+	elem_size = get_elem_size(elem_descr);
+	last_elem = (char *)field + elem_size * max_elements;
 
 	__ASSERT_NO_MSG(elem_size > 0);
 
-	if (elements) {
-		*elements = 0;
-	}
-
-	while (!arr_next(obj, &value)) {
-		if (value.type == JSON_TOK_ARRAY_END) {
+	while (!arr_next(obj, &tok)) {
+		if (tok.type == JSON_TOK_ARRAY_END) {
 			return 0;
 		}
 
@@ -566,13 +577,18 @@ static int arr_parse(struct json_obj *obj,
 			return -ENOSPC;
 		}
 
-		if (decode_value(obj, elem_descr, &value, field, NULL) < 0) {
+		/* For nested arrays, update value to current field,
+		 * so it matches descriptor's offset to length field
+		 */
+		if (elem_descr->type == JSON_TOK_ARRAY_START) {
+			value = field;
+		}
+
+		if (decode_value(obj, elem_descr, &tok, field, value) < 0) {
 			return -EINVAL;
 		}
 
-		if (elements) {
-			(*elements)++;
-		}
+		(*elements)++;
 		field = (char *)field + elem_size;
 	}
 
@@ -835,7 +851,7 @@ static int arr_encode(const struct json_obj_descr *elem_descr,
 		      const void *field, const void *val,
 		      json_append_bytes_t append_bytes, void *data)
 {
-	ptrdiff_t elem_size = get_elem_size(elem_descr);
+	ptrdiff_t elem_size;
 	/*
 	 * NOTE: Since an element descriptor's offset isn't meaningful
 	 * (array elements occur at multiple offsets in `val'), we use
@@ -850,6 +866,13 @@ static int arr_encode(const struct json_obj_descr *elem_descr,
 	if (ret < 0) {
 		return ret;
 	}
+
+	/* For nested arrays, skip parent descriptor to get elements */
+	if (elem_descr->type == JSON_TOK_ARRAY_START) {
+		elem_descr = elem_descr->array.element_descr;
+	}
+
+	elem_size = get_elem_size(elem_descr);
 
 	for (i = 0; i < n_elem; i++) {
 		/*

--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -535,12 +535,10 @@ static ptrdiff_t get_elem_size(const struct json_obj_descr *descr)
 		size_t i;
 
 		for (i = 0; i < descr->object.sub_descr_len; i++) {
-			ptrdiff_t s = get_elem_size(&descr->object.sub_descr[i]);
-
-			total += ROUND_UP(s, 1 << descr->align_shift);
+			total += get_elem_size(&descr->object.sub_descr[i]);
 		}
 
-		return total;
+		return ROUND_UP(total, 1 << descr->align_shift);
 	}
 	default:
 		return -EINVAL;

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -255,14 +255,39 @@ ZTEST(lib_json_test, test_json_limits)
 		     "Integer limits not decoded correctly");
 }
 
+ZTEST(lib_json_test, test_json_encoding_array_array)
+{
+	struct obj_array_array obj_array_array_ts = {
+		.objects_array = {
+			[0] = { { .name = "Sim\303\263n Bol\303\255var", .height = 168 } },
+			[1] = { { .name = "Pel\303\251",                 .height = 173 } },
+			[2] = { { .name = "Usain Bolt",                  .height = 195 } },
+		},
+		.objects_array_len = 3,
+	};
+	char encoded[] = "{\"objects_array\":["
+		"{\"name\":\"Sim\303\263n Bol\303\255var\",\"height\":168},"
+		"{\"name\":\"Pel\303\251\",\"height\":173},"
+		"{\"name\":\"Usain Bolt\",\"height\":195}"
+		"]}";
+	char buffer[sizeof(encoded)];
+	int ret;
+
+	ret = json_obj_encode_buf(array_array_descr, ARRAY_SIZE(array_array_descr),
+				  &obj_array_array_ts, buffer, sizeof(buffer));
+	zassert_equal(ret, 0, "Encoding array returned error");
+	zassert_true(!strcmp(buffer, encoded),
+		     "Encoded array of objects is not consistent");
+}
+
 ZTEST(lib_json_test, test_json_decoding_array_array)
 {
 	int ret;
 	struct obj_array_array obj_array_array_ts;
 	char encoded[] = "{\"objects_array\":["
-			  "[{\"height\":168,\"name\":\"Sim\303\263n Bol\303\255var\"}],"
-			  "[{\"height\":173,\"name\":\"Pel\303\251\"}],"
-			  "[{\"height\":195,\"name\":\"Usain Bolt\"}]]"
+			  "{\"height\":168,\"name\":\"Sim\303\263n Bol\303\255var\"},"
+			  "{\"height\":173,\"name\":\"Pel\303\251\"},"
+			  "{\"height\":195,\"name\":\"Usain Bolt\"}]"
 			  "}";
 
 	ret = json_obj_parse(encoded, sizeof(encoded),

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -260,8 +260,8 @@ ZTEST(lib_json_test, test_json_decoding_array_array)
 	int ret;
 	struct obj_array_array obj_array_array_ts;
 	char encoded[] = "{\"objects_array\":["
-			  "[{\"height\":168,\"name\":\"Simón Bolívar\"}],"
-			  "[{\"height\":173,\"name\":\"Pelé\"}],"
+			  "[{\"height\":168,\"name\":\"Sim\303\263n Bol\303\255var\"}],"
+			  "[{\"height\":173,\"name\":\"Pel\303\251\"}],"
 			  "[{\"height\":195,\"name\":\"Usain Bolt\"}]]"
 			  "}";
 
@@ -275,14 +275,14 @@ ZTEST(lib_json_test, test_json_decoding_array_array)
 		      "Array doesn't have correct number of items");
 
 	zassert_true(!strcmp(obj_array_array_ts.objects_array[0].objects.name,
-			 "Simón Bolívar"), "String not decoded correctly");
+			 "Sim\303\263n Bol\303\255var"), "String not decoded correctly");
 	zassert_equal(obj_array_array_ts.objects_array[0].objects.height, 168,
-		      "Simón Bolívar height not decoded correctly");
+		      "Sim\303\263n Bol\303\255var height not decoded correctly");
 
 	zassert_true(!strcmp(obj_array_array_ts.objects_array[1].objects.name,
-			 "Pelé"), "String not decoded correctly");
+			 "Pel\303\251"), "String not decoded correctly");
 	zassert_equal(obj_array_array_ts.objects_array[1].objects.height, 173,
-		      "Pelé height not decoded correctly");
+		      "Pel\303\251 height not decoded correctly");
 
 	zassert_true(!strcmp(obj_array_array_ts.objects_array[2].objects.name,
 			 "Usain Bolt"), "String not decoded correctly");
@@ -294,23 +294,23 @@ ZTEST(lib_json_test, test_json_obj_arr_encoding)
 {
 	struct obj_array oa = {
 		.elements = {
-			[0] = { .name = "Simón Bolívar",   .height = 168 },
-			[1] = { .name = "Muggsy Bogues",   .height = 160 },
-			[2] = { .name = "Pelé",            .height = 173 },
-			[3] = { .name = "Hakeem Olajuwon", .height = 213 },
-			[4] = { .name = "Alex Honnold",    .height = 180 },
-			[5] = { .name = "Hazel Findlay",   .height = 157 },
-			[6] = { .name = "Daila Ojeda",     .height = 158 },
-			[7] = { .name = "Albert Einstein", .height = 172 },
-			[8] = { .name = "Usain Bolt",      .height = 195 },
-			[9] = { .name = "Paavo Nurmi",     .height = 174 },
+			[0] = { .name = "Sim\303\263n Bol\303\255var", .height = 168 },
+			[1] = { .name = "Muggsy Bogues",               .height = 160 },
+			[2] = { .name = "Pel\303\251",                 .height = 173 },
+			[3] = { .name = "Hakeem Olajuwon",             .height = 213 },
+			[4] = { .name = "Alex Honnold",                .height = 180 },
+			[5] = { .name = "Hazel Findlay",               .height = 157 },
+			[6] = { .name = "Daila Ojeda",                 .height = 158 },
+			[7] = { .name = "Albert Einstein",             .height = 172 },
+			[8] = { .name = "Usain Bolt",                  .height = 195 },
+			[9] = { .name = "Paavo Nurmi",                 .height = 174 },
 		},
 		.num_elements = 10,
 	};
 	const char encoded[] = "{\"elements\":["
-		"{\"name\":\"Simón Bolívar\",\"height\":168},"
+		"{\"name\":\"Sim\303\263n Bol\303\255var\",\"height\":168},"
 		"{\"name\":\"Muggsy Bogues\",\"height\":160},"
-		"{\"name\":\"Pelé\",\"height\":173},"
+		"{\"name\":\"Pel\303\251\",\"height\":173},"
 		"{\"name\":\"Hakeem Olajuwon\",\"height\":213},"
 		"{\"name\":\"Alex Honnold\",\"height\":180},"
 		"{\"name\":\"Hazel Findlay\",\"height\":157},"
@@ -333,8 +333,8 @@ ZTEST(lib_json_test, test_json_arr_obj_decoding)
 {
 	int ret;
 	struct obj_array obj_array_array_ts;
-	char encoded[] = "[{\"height\":168,\"name\":\"Simón Bolívar\"},"
-					"{\"height\":173,\"name\":\"Pelé\"},"
+	char encoded[] = "[{\"height\":168,\"name\":\"Sim\303\263n Bol\303\255var\"},"
+					"{\"height\":173,\"name\":\"Pel\303\251\"},"
 					"{\"height\":195,\"name\":\"Usain Bolt\"}"
 					"]";
 
@@ -347,14 +347,14 @@ ZTEST(lib_json_test, test_json_arr_obj_decoding)
 		      "Array doesn't have correct number of items");
 
 	zassert_true(!strcmp(obj_array_array_ts.elements[0].name,
-			 "Simón Bolívar"), "String not decoded correctly");
+			 "Sim\303\263n Bol\303\255var"), "String not decoded correctly");
 	zassert_equal(obj_array_array_ts.elements[0].height, 168,
-		      "Simón Bolívar height not decoded correctly");
+		      "Sim\303\263n Bol\303\255var height not decoded correctly");
 
 	zassert_true(!strcmp(obj_array_array_ts.elements[1].name,
-			 "Pelé"), "String not decoded correctly");
+			 "Pel\303\251"), "String not decoded correctly");
 	zassert_equal(obj_array_array_ts.elements[1].height, 173,
-		      "Pelé height not decoded correctly");
+		      "Pel\303\251 height not decoded correctly");
 
 	zassert_true(!strcmp(obj_array_array_ts.elements[2].name,
 			 "Usain Bolt"), "String not decoded correctly");
@@ -366,23 +366,23 @@ ZTEST(lib_json_test, test_json_arr_obj_encoding)
 {
 	struct obj_array oa = {
 		.elements = {
-			[0] = { .name = "Simón Bolívar",   .height = 168 },
-			[1] = { .name = "Muggsy Bogues",   .height = 160 },
-			[2] = { .name = "Pelé",            .height = 173 },
-			[3] = { .name = "Hakeem Olajuwon", .height = 213 },
-			[4] = { .name = "Alex Honnold",    .height = 180 },
-			[5] = { .name = "Hazel Findlay",   .height = 157 },
-			[6] = { .name = "Daila Ojeda",     .height = 158 },
-			[7] = { .name = "Albert Einstein", .height = 172 },
-			[8] = { .name = "Usain Bolt",      .height = 195 },
-			[9] = { .name = "Paavo Nurmi",     .height = 174 },
+			[0] = { .name = "Sim\303\263n Bol\303\255var", .height = 168 },
+			[1] = { .name = "Muggsy Bogues",               .height = 160 },
+			[2] = { .name = "Pel\303\251",                 .height = 173 },
+			[3] = { .name = "Hakeem Olajuwon",             .height = 213 },
+			[4] = { .name = "Alex Honnold",                .height = 180 },
+			[5] = { .name = "Hazel Findlay",               .height = 157 },
+			[6] = { .name = "Daila Ojeda",                 .height = 158 },
+			[7] = { .name = "Albert Einstein",             .height = 172 },
+			[8] = { .name = "Usain Bolt",                  .height = 195 },
+			[9] = { .name = "Paavo Nurmi",                 .height = 174 },
 		},
 		.num_elements = 10,
 	};
 	char encoded[] = "["
-		"{\"name\":\"Simón Bolívar\",\"height\":168},"
+		"{\"name\":\"Sim\303\263n Bol\303\255var\",\"height\":168},"
 		"{\"name\":\"Muggsy Bogues\",\"height\":160},"
-		"{\"name\":\"Pelé\",\"height\":173},"
+		"{\"name\":\"Pel\303\251\",\"height\":173},"
 		"{\"name\":\"Hakeem Olajuwon\",\"height\":213},"
 		"{\"name\":\"Alex Honnold\",\"height\":180},"
 		"{\"name\":\"Hazel Findlay\",\"height\":157},"
@@ -408,9 +408,9 @@ ZTEST(lib_json_test, test_json_obj_arr_decoding)
 {
 	struct obj_array oa;
 	char encoded[] = "{\"elements\":["
-		"{\"name\":\"Simón Bolívar\",\"height\":168},"
+		"{\"name\":\"Sim\303\263n Bol\303\255var\",\"height\":168},"
 		"{\"name\":\"Muggsy Bogues\",\"height\":160},"
-		"{\"name\":\"Pelé\",\"height\":173},"
+		"{\"name\":\"Pel\303\251\",\"height\":173},"
 		"{\"name\":\"Hakeem Olajuwon\",\"height\":213},"
 		"{\"name\":\"Alex Honnold\",\"height\":180},"
 		"{\"name\":\"Hazel Findlay\",\"height\":157},"
@@ -421,16 +421,16 @@ ZTEST(lib_json_test, test_json_obj_arr_decoding)
 		"]}";
 	const struct obj_array expected = {
 		.elements = {
-			[0] = { .name = "Simón Bolívar",   .height = 168 },
-			[1] = { .name = "Muggsy Bogues",   .height = 160 },
-			[2] = { .name = "Pelé",            .height = 173 },
-			[3] = { .name = "Hakeem Olajuwon", .height = 213 },
-			[4] = { .name = "Alex Honnold",    .height = 180 },
-			[5] = { .name = "Hazel Findlay",   .height = 157 },
-			[6] = { .name = "Daila Ojeda",     .height = 158 },
-			[7] = { .name = "Albert Einstein", .height = 172 },
-			[8] = { .name = "Usain Bolt",      .height = 195 },
-			[9] = { .name = "Paavo Nurmi",     .height = 174 },
+			[0] = { .name = "Sim\303\263n Bol\303\255var", .height = 168 },
+			[1] = { .name = "Muggsy Bogues",               .height = 160 },
+			[2] = { .name = "Pel\303\251",                 .height = 173 },
+			[3] = { .name = "Hakeem Olajuwon",             .height = 213 },
+			[4] = { .name = "Alex Honnold",                .height = 180 },
+			[5] = { .name = "Hazel Findlay",               .height = 157 },
+			[6] = { .name = "Daila Ojeda",                 .height = 158 },
+			[7] = { .name = "Albert Einstein",             .height = 172 },
+			[8] = { .name = "Usain Bolt",                  .height = 195 },
+			[9] = { .name = "Paavo Nurmi",                 .height = 174 },
 		},
 		.num_elements = 10,
 	};

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -106,6 +106,17 @@ static const struct json_obj_descr array_array_descr[] = {
 				   ARRAY_SIZE(array_descr)),
 };
 
+struct obj_array_2dim {
+	struct obj_array objects_array_array[3];
+	size_t objects_array_array_len;
+};
+
+static const struct json_obj_descr array_2dim_descr[] = {
+	JSON_OBJ_DESCR_ARRAY_ARRAY(struct obj_array_2dim, objects_array_array, 3,
+				   objects_array_array_len, obj_array_descr,
+				   ARRAY_SIZE(obj_array_descr)),
+};
+
 ZTEST(lib_json_test, test_json_encoding)
 {
 	struct test_struct ts = {
@@ -332,7 +343,7 @@ ZTEST(lib_json_test, test_json_obj_arr_encoding)
 		},
 		.num_elements = 10,
 	};
-	const char encoded[] = "{\"elements\":["
+	char encoded[] = "{\"elements\":["
 		"{\"name\":\"Sim\303\263n Bol\303\255var\",\"height\":168},"
 		"{\"name\":\"Muggsy Bogues\",\"height\":160},"
 		"{\"name\":\"Pel\303\251\",\"height\":173},"
@@ -476,6 +487,184 @@ ZTEST(lib_json_test, test_json_obj_arr_decoding)
 		zassert_equal(oa.elements[i].height,
 			      expected.elements[i].height,
 			      "Element %d height not decoded correctly", i);
+	}
+}
+
+ZTEST(lib_json_test, test_json_2dim_arr_obj_encoding)
+{
+	struct obj_array_2dim obj_array_array_ts = {
+		.objects_array_array = {
+			[0] = {
+				.elements = {
+					[0] = {
+						.name = "Sim\303\263n Bol\303\255var",
+						.height = 168
+					},
+					[1] = {
+						.name = "Pel\303\251",
+						.height = 173
+					},
+					[2] = {
+						.name = "Usain Bolt",
+						.height = 195
+					},
+				},
+				.num_elements = 3
+			},
+			[1] = {
+				.elements = {
+					[0] = {
+						.name = "Muggsy Bogues",
+						.height = 160
+					},
+					[1] = {
+						.name = "Hakeem Olajuwon",
+						.height = 213
+					},
+				},
+				.num_elements = 2
+			},
+			[2] = {
+				.elements = {
+					[0] = {
+						.name = "Alex Honnold",
+						.height = 180
+					},
+					[1] = {
+						.name = "Hazel Findlay",
+						.height = 157
+					},
+					[2] = {
+						.name = "Daila Ojeda",
+						.height = 158
+					},
+					[3] = {
+						.name = "Albert Einstein",
+						.height = 172
+					},
+				},
+				.num_elements = 4
+			},
+		},
+		.objects_array_array_len = 3,
+	};
+	char encoded[] = "{\"objects_array_array\":["
+		"[{\"name\":\"Sim\303\263n Bol\303\255var\",\"height\":168},"
+		 "{\"name\":\"Pel\303\251\",\"height\":173},"
+		 "{\"name\":\"Usain Bolt\",\"height\":195}],"
+		"[{\"name\":\"Muggsy Bogues\",\"height\":160},"
+		 "{\"name\":\"Hakeem Olajuwon\",\"height\":213}],"
+		"[{\"name\":\"Alex Honnold\",\"height\":180},"
+		 "{\"name\":\"Hazel Findlay\",\"height\":157},"
+		 "{\"name\":\"Daila Ojeda\",\"height\":158},"
+		 "{\"name\":\"Albert Einstein\",\"height\":172}]"
+		"]}";
+	char buffer[sizeof(encoded)];
+	int ret;
+
+	ret = json_obj_encode_buf(array_2dim_descr, ARRAY_SIZE(array_2dim_descr),
+				  &obj_array_array_ts, buffer, sizeof(buffer));
+	zassert_equal(ret, 0, "Encoding two-dimensional array returned error");
+	zassert_true(!strcmp(buffer, encoded),
+		     "Encoded two-dimensional array is not consistent");
+}
+
+ZTEST(lib_json_test, test_json_2dim_obj_arr_decoding)
+{
+	struct obj_array_2dim oaa;
+	char encoded[] = "{\"objects_array_array\":["
+		"[{\"name\":\"Sim\303\263n Bol\303\255var\",\"height\":168},"
+		 "{\"name\":\"Pel\303\251\",\"height\":173},"
+		 "{\"name\":\"Usain Bolt\",\"height\":195}],"
+		"[{\"name\":\"Muggsy Bogues\",\"height\":160},"
+		 "{\"name\":\"Hakeem Olajuwon\",\"height\":213}],"
+		"[{\"name\":\"Alex Honnold\",\"height\":180},"
+		 "{\"name\":\"Hazel Findlay\",\"height\":157},"
+		 "{\"name\":\"Daila Ojeda\",\"height\":158},"
+		 "{\"name\":\"Albert Einstein\",\"height\":172}]"
+		"]}";
+	const struct obj_array_2dim expected = {
+		.objects_array_array = {
+			[0] = {
+				.elements = {
+					[0] = {
+						.name = "Sim\303\263n Bol\303\255var",
+						.height = 168
+					},
+					[1] = {
+						.name = "Pel\303\251",
+						.height = 173
+					},
+					[2] = {
+						.name = "Usain Bolt",
+						.height = 195
+					},
+				},
+				.num_elements = 3
+			},
+			[1] = {
+				.elements = {
+					[0] = {
+						.name = "Muggsy Bogues",
+						.height = 160
+					},
+					[1] = {
+						.name = "Hakeem Olajuwon",
+						.height = 213
+					},
+				},
+				.num_elements = 2
+			},
+			[2] = {
+				.elements = {
+					[0] = {
+						.name = "Alex Honnold",
+						.height = 180
+					},
+					[1] = {
+						.name = "Hazel Findlay",
+						.height = 157
+					},
+					[2] = {
+						.name = "Daila Ojeda",
+						.height = 158
+					},
+					[3] = {
+						.name = "Albert Einstein",
+						.height = 172
+					},
+				},
+				.num_elements = 4
+			},
+		},
+		.objects_array_array_len = 3,
+	};
+	int ret;
+
+	ret = json_obj_parse(encoded, sizeof(encoded),
+			     array_2dim_descr,
+			     ARRAY_SIZE(array_2dim_descr),
+			     &oaa);
+
+	zassert_equal(ret, 1, "Array of arrays fields not decoded correctly");
+	zassert_equal(oaa.objects_array_array_len, 3,
+		      "Number of subarrays not decoded correctly");
+	zassert_equal(oaa.objects_array_array[0].num_elements, 3,
+		      "Number of object fields not decoded correctly");
+	zassert_equal(oaa.objects_array_array[1].num_elements, 2,
+		      "Number of object fields not decoded correctly");
+	zassert_equal(oaa.objects_array_array[2].num_elements, 4,
+		      "Number of object fields not decoded correctly");
+
+	for (int i = 0; i < expected.objects_array_array_len; i++) {
+		for (int j = 0; j < expected.objects_array_array[i].num_elements; j++) {
+			zassert_true(!strcmp(oaa.objects_array_array[i].elements[j].name,
+					     expected.objects_array_array[i].elements[j].name),
+				     "Element [%d][%d] name not decoded correctly", i, j);
+			zassert_equal(oaa.objects_array_array[i].elements[j].height,
+				      expected.objects_array_array[i].elements[j].height,
+				      "Element [%d][%d] height not decoded correctly", i, j);
+		}
 	}
 }
 


### PR DESCRIPTION
This patch fixes support for encoding and decoding multidimensional arrays
as described by the JSON_OBJ_DESCR_ARRAY_ARRAY() macro.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/50801