### PR TITLE
tests: kernel: timer_behavior: Fix building on targets with small SRAM

### DIFF
--- a/tests/kernel/timer/timer_behavior/Kconfig
+++ b/tests/kernel/timer/timer_behavior/Kconfig
@@ -7,6 +7,11 @@ source "Kconfig.zephyr"
 
 config TIMER_TEST_SAMPLES
 	int "The number of timer samples to gather for statistics"
+	default 1000 if (SRAM_SIZE < 24)
+	default 2000 if (SRAM_SIZE < 32)
+	default 3000 if (SRAM_SIZE < 48)
+	default 5000 if (SRAM_SIZE < 64)
+	default 7000 if (SRAM_SIZE < 96)
 	default 10000
 
 config TIMER_TEST_PERIOD

--- a/tests/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/kernel/timer/timer_behavior/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   kernel.timer.timer:
     tags: kernel timer
+    min_ram: 16
     platform_type:
       - mcu
     # Really want to exclude renode not the physical boards, but no good


### PR DESCRIPTION
In the default configuration of the test, with 10000 timer samples,
the `periodic_data` array is too big to fit in SRAM on many targets.
Use lower counts of samples for those, depending on their SRAM size,
leaving at least 8 kB for other variables, buffers, stacks etc.
Exclude the test for targets with less than 16 kB.