### PR TITLE
ADXL362: Do not clear last bits of 16-bit inactivity time value

### DIFF
--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -324,7 +324,7 @@ static int adxl362_attr_set(const struct device *dev,
 	{
 		uint16_t timeout = val->val1;
 
-		return adxl362_set_reg(dev, (timeout & 0x7FF), ADXL362_REG_TIME_INACT_L, 2);
+		return adxl362_set_reg(dev, timeout, ADXL362_REG_TIME_INACT_L, 2);
 	}
 	default:
 		/* Do nothing */


### PR DESCRIPTION
The inactivity time registers identified by `ADXL362_REG_TIME_INACT_L`
and `ADXL362_REG_TIME_INACT_H` accepts a 16-bit value. (8 in each).
Without this change the last 5 bits of the register value
will be cleared.

Clearing the last bits of the register value greatly reduces the maximum
inactivity time that can be set.