### PR TITLE
doc: release-notes-3.2: add release notes for USB, MODBUS, and display controller drivers

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -730,6 +730,7 @@ Drivers and Sensors
 
   * Restructured the NXP MCUX USB driver.
   * Added USB support for NXP MXRT595.
+  * Fixed detach behavior in nRF USBD and Atmel SAM drivers
 
 * W1
 
@@ -841,6 +842,9 @@ Networking
 
 USB
 ***
+
+  * Minor bug fixes and improvements in class implementations CDC ACM, DFU, and MSC.
+    Otherwise no significant changes.
 
 Devicetree
 **********

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -1432,6 +1432,8 @@ Libraries / Subsystems
 
 * Modbus
 
+  * Added user data entry for ADU callback
+
 * Power management
 
   * Allow multiple subscribers to latency changes in the policy manager.

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -500,6 +500,12 @@ Drivers and Sensors
 
 * Display
 
+  * Renamed EPD controller driver GD7965 to UC81xx.
+  * Improved support for different controllers in ssd16xx and uc81xx drivers.
+  * Added basic read support for ssd16xx compatible EPD controllers.
+  * Revised intel_multibootfb driver
+  * Added MAX7219 display controller driver
+
 * Disk
 
   * Added support for DMA transfers when using STM32 SD host controller


### PR DESCRIPTION
Add release notes for USB, MODBUS, and display controller drivers.