### PR TITLE
stats: shell: enable the stats shell if both stats and shell are enabled

### DIFF
--- a/subsys/stats/Kconfig
+++ b/subsys/stats/Kconfig
@@ -20,7 +20,9 @@ config STATS_NAMES
 
 config STATS_SHELL
 	bool "Statistics Shell Command"
+	default y
 	depends on STATS && SHELL
+	imply STATS_NAMES
 	help
 	  Include a full name string for each statistic in the build.  If this
 	  setting is disabled, statistics are assigned generic names of the


### PR DESCRIPTION
Enable the statistics subsystem shell by default if both statistics and shell are enabled.

Have the statistics shell imply enabling named statistics as this takes out a lot of guesswork regarding which statistics counter is which.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>