### PR TITLE
device.h: a few cleanups

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -1198,7 +1198,7 @@ static int esp_init(const struct device *dev)
 	k_thread_name_set(&esp_rx_thread, "esp_rx");
 
 	/* Retrieve associated network interface so asynchronous messages can be processed early */
-	data->net_iface = NET_IF_GET(Z_DEVICE_DT_DEV_NAME(DT_DRV_INST(0)), 0);
+	data->net_iface = NET_IF_GET(Z_DEVICE_DT_DEV_ID(DT_DRV_INST(0)), 0);
 
 	/* Reset the modem */
 	ret = esp_reset(dev);

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -841,6 +841,10 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 #define Z_DEVICE_EXTRA_HANDLES(...)				\
 	FOR_EACH_NONEMPTY_TERM(IDENTITY, (,), __VA_ARGS__)
 
+/** @brief Linker section were device handles are placed. */
+#define Z_DEVICE_HANDLES_SECTION                                              \
+	__attribute__((__section__(".__device_handles_pass1")))
+
 /**
  * @brief Define device handles.
  *
@@ -882,7 +886,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 	extern Z_DEVICE_HANDLES_CONST device_handle_t			\
 		Z_DEVICE_HANDLE_NAME(node_id, dev_id)[];		\
 	Z_DEVICE_HANDLES_CONST Z_DECL_ALIGN(device_handle_t)		\
-	__attribute__((__section__(".__device_handles_pass1"))) __weak	\
+	Z_DEVICE_HANDLES_SECTION __weak					\
 	Z_DEVICE_HANDLE_NAME(node_id, dev_id)[] = {			\
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (				\
 			DT_DEP_ORD(node_id),				\

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -62,6 +62,13 @@ extern "C" {
  */
 typedef int16_t device_handle_t;
 
+/*
+ * The build assert will fail if device_handle_t changes size, which
+ * means the alignment directives in the linker scripts and in
+ * `gen_handles.py` must be updated.
+ */
+BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
+
 /** @brief Flag value used in lists of device handles to separate
  * distinct groups.
  *
@@ -870,12 +877,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * files, which will be retained in subsequent links both wasting
  * space and resulting in aggregate size changes relative to pass2
  * when all objects will be in the same input section.
- *
- * The build assert will fail if device_handle_t changes size, which
- * means the alignment directives in the linker scripts and in
- * `gen_handles.py` must be updated.
  */
-BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 #define Z_DEVICE_HANDLES_DEFINE(node_id, dev_id, ...)			\
 	extern Z_DEVICE_HANDLES_CONST device_handle_t			\
 		Z_DEVICE_HANDLE_NAME(node_id, dev_id)[];		\

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -83,7 +83,7 @@ typedef int16_t device_handle_t;
  * @brief Expands to the name of a global device object.
  *
  * @details Return the full name of a device object symbol created by
- * DEVICE_DEFINE(), using the dev_name provided to DEVICE_DEFINE().
+ * DEVICE_DEFINE(), using the dev_id provided to DEVICE_DEFINE().
  * This is the name of the global variable storing the device
  * structure, not a pointer to the string in the device's @p name
  * field.
@@ -95,7 +95,7 @@ typedef int16_t device_handle_t;
  * code. In other situations, you are probably looking for
  * device_get_binding().
  *
- * @param name The same @p dev_name token given to DEVICE_DEFINE()
+ * @param name The same @p dev_id token given to DEVICE_DEFINE()
  *
  * @return The full name of the device object defined by DEVICE_DEFINE()
  */
@@ -103,7 +103,7 @@ typedef int16_t device_handle_t;
 
 /* Node paths can exceed the maximum size supported by
  * device_get_binding() in user mode; this macro synthesizes a unique
- * dev_name from a devicetree node while staying within this maximum
+ * dev_id from a devicetree node while staying within this maximum
  * size.
  *
  * The ordinal used in this name can be mapped to the path by
@@ -121,7 +121,7 @@ typedef int16_t device_handle_t;
  * device from a devicetree node, use DEVICE_DT_DEFINE() or
  * DEVICE_DT_INST_DEFINE() instead.
  *
- * @param dev_name A unique token which is used in the name of the
+ * @param dev_id A unique token which is used in the name of the
  * global device structure as a C identifier.
  *
  * @param drv_name A string name for the device, which will be stored
@@ -152,13 +152,12 @@ typedef int16_t device_handle_t;
  *
  * @param api_ptr Pointer to the device's API structure. Can be NULL.
  */
-#define DEVICE_DEFINE(dev_name, drv_name, init_fn, pm_device,		\
-		      data_ptr, cfg_ptr, level, prio, api_ptr)		\
-	Z_DEVICE_STATE_DEFINE(DT_INVALID_NODE, dev_name);		\
-	Z_DEVICE_DEFINE(DT_INVALID_NODE, dev_name, drv_name, init_fn,	\
-			pm_device,					\
-			data_ptr, cfg_ptr, level, prio, api_ptr,	\
-			&Z_DEVICE_STATE_NAME(dev_name))
+#define DEVICE_DEFINE(dev_id, drv_name, init_fn, pm_device, data_ptr, cfg_ptr, \
+		      level, prio, api_ptr)                                    \
+	Z_DEVICE_STATE_DEFINE(DT_INVALID_NODE, dev_id);                        \
+	Z_DEVICE_DEFINE(DT_INVALID_NODE, dev_id, drv_name, init_fn, pm_device, \
+			data_ptr, cfg_ptr, level, prio, api_ptr,               \
+			&Z_DEVICE_STATE_NAME(dev_id))
 
 /**
  * @brief Return a string name for a devicetree node.
@@ -215,16 +214,13 @@ typedef int16_t device_handle_t;
  *
  * @param api_ptr Pointer to the device's API structure. Can be NULL.
  */
-#define DEVICE_DT_DEFINE(node_id, init_fn, pm_device,			\
-			 data_ptr, cfg_ptr, level, prio,		\
-			 api_ptr, ...)					\
-	Z_DEVICE_STATE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id));	\
-	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
-			DEVICE_DT_NAME(node_id), init_fn,		\
-			pm_device,					\
-			data_ptr, cfg_ptr, level, prio,			\
-			api_ptr,					\
-			&Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)),	\
+#define DEVICE_DT_DEFINE(node_id, init_fn, pm_device, data_ptr, cfg_ptr, level,\
+			 prio, api_ptr, ...)                                   \
+	Z_DEVICE_STATE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id));         \
+	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),                \
+			DEVICE_DT_NAME(node_id), init_fn, pm_device, data_ptr, \
+			cfg_ptr, level, prio, api_ptr,                         \
+			&Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)),   \
 			__VA_ARGS__)
 
 /**
@@ -348,9 +344,9 @@ typedef int16_t device_handle_t;
  * @brief Obtain a pointer to a device object by name
  *
  * @details Return the address of a device object created by
- * DEVICE_DEFINE(), using the dev_name provided to DEVICE_DEFINE().
+ * DEVICE_DEFINE(), using the dev_id provided to DEVICE_DEFINE().
  *
- * @param name The same as dev_name provided to DEVICE_DEFINE()
+ * @param name The same as dev_id provided to DEVICE_DEFINE()
  *
  * @return A pointer to the device object created by DEVICE_DEFINE()
  */
@@ -384,7 +380,7 @@ typedef int16_t device_handle_t;
 /**
  * @brief Get a <tt>const struct init_entry*</tt> from a device by name
  *
- * @param name The same as dev_name provided to DEVICE_DEFINE()
+ * @param name The same as dev_id provided to DEVICE_DEFINE()
  *
  * @return A pointer to the init_entry object created for that device
  */
@@ -804,18 +800,18 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 
 /**
  * @brief Synthesize a unique name for the device state associated with
- * dev_name.
+ * dev_id.
  */
-#define Z_DEVICE_STATE_NAME(dev_name) _CONCAT(__devstate_, dev_name)
+#define Z_DEVICE_STATE_NAME(dev_id) _CONCAT(__devstate_, dev_id)
 
 /**
  * @brief Utility macro to define and initialize the device state.
  *
  * @param node_id Devicetree node id of the device.
- * @param dev_name Device name.
+ * @param dev_id Device identifier.
  */
-#define Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
-	static struct device_state Z_DEVICE_STATE_NAME(dev_name)	\
+#define Z_DEVICE_STATE_DEFINE(node_id, dev_id)			\
+	static struct device_state Z_DEVICE_STATE_NAME(dev_id)	\
 	__attribute__((__section__(".z_devstate")))
 
 /**
@@ -823,13 +819,13 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * dependency data.
  *
  * @param node_id Devicetree node id of the device.
- * @param dev_name Device name.
+ * @param dev_id Device identifier.
  */
-#define Z_DEVICE_HANDLE_NAME(node_id, dev_name)				\
+#define Z_DEVICE_HANDLE_NAME(node_id, dev_id)				\
 	_CONCAT(__devicehdl_,						\
 		COND_CODE_1(DT_NODE_EXISTS(node_id),			\
 			    (node_id),					\
-			    (dev_name)))
+			    (dev_id)))
 
 /**
  * @brief Expand extra handles with a comma in between.
@@ -881,14 +877,14 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * `gen_handles.py` must be updated.
  */
 BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
-#define Z_DEVICE_HANDLES_DEFINE(node_id, dev_name, ...)			\
+#define Z_DEVICE_HANDLES_DEFINE(node_id, dev_id, ...)			\
 	extern Z_DEVICE_HANDLES_CONST device_handle_t			\
-		Z_DEVICE_HANDLE_NAME(node_id, dev_name)[];		\
+		Z_DEVICE_HANDLE_NAME(node_id, dev_id)[];		\
 	Z_DEVICE_HANDLES_CONST device_handle_t				\
 	__aligned(sizeof(device_handle_t))				\
 	__attribute__((__weak__,					\
 		       __section__(".__device_handles_pass1")))		\
-	Z_DEVICE_HANDLE_NAME(node_id, dev_name)[] = {			\
+	Z_DEVICE_HANDLE_NAME(node_id, dev_id)[] = {			\
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (				\
 			DT_DEP_ORD(node_id),				\
 			DT_REQUIRES_DEP_ORDS(node_id)			\
@@ -961,11 +957,11 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
  *
  * @param node_id Devicetree node id for the device (DT_INVALID_NODE if a
  *                software device).
- * @param dev_name Name of the defined struct device variable.
+ * @param dev_id Device identifier (used to name the defined struct device).
  * @param drv_name Name of the device.
  * @param init_fn Device init function.
  * @param pm_device Reference to struct pm_device associated with the device.
- *                  (optional).
+ *           (optional).
  * @param data_ptr Reference to device data.
  * @param cfg_ptr Reference to device config.
  * @param level Initialization level.
@@ -974,21 +970,21 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
  * @param state_ptr Reference to device state.
  * @param ... Optional dependencies, manually specified.
  */
-#define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_device,       \
+#define Z_DEVICE_DEFINE(node_id, dev_id, drv_name, init_fn, pm_device,         \
 			data_ptr, cfg_ptr, level, prio, api_ptr, state_ptr,    \
 			...)                                                   \
-	Z_DEVICE_NAME_CHECK(drv_name);                                         \
+	Z_DEVICE_NAME_CHECK(name);                                             \
                                                                                \
-	Z_DEVICE_HANDLES_DEFINE(node_id, dev_name, __VA_ARGS__);               \
+	Z_DEVICE_HANDLES_DEFINE(node_id, dev_id, __VA_ARGS__);                 \
                                                                                \
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))                     \
-	const Z_DECL_ALIGN(struct device) DEVICE_NAME_GET(dev_name)            \
-		Z_DEVICE_SECTION(level, prio) __used = Z_DEVICE_INIT(          \
-			drv_name, pm_device, data_ptr, cfg_ptr, api_ptr,       \
-			state_ptr, Z_DEVICE_HANDLE_NAME(node_id, dev_name));   \
+	const Z_DECL_ALIGN(struct device) DEVICE_NAME_GET(dev_id)              \
+		Z_DEVICE_SECTION(level, prio) __used =                         \
+			Z_DEVICE_INIT(name, pm, data, config, api, state,      \
+				      Z_DEVICE_HANDLE_NAME(node_id, dev_id));  \
                                                                                \
-	Z_INIT_ENTRY_DEFINE(DEVICE_NAME_GET(dev_name), init_fn,                \
-			    (&DEVICE_NAME_GET(dev_name)), level, prio)
+	Z_INIT_ENTRY_DEFINE(DEVICE_NAME_GET(dev_id), init_fn,                  \
+			    (&DEVICE_NAME_GET(dev_id)), level, prio)
 
 #if defined(CONFIG_HAS_DTS) || defined(__DOXYGEN__)
 /**

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -800,6 +800,8 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * @}
  */
 
+/** @cond INTERNAL_HIDDEN */
+
 /* Synthesize a unique name for the device state associated with
  * dev_name.
  */
@@ -943,6 +945,8 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 
 DT_FOREACH_STATUS_OKAY_NODE(Z_MAYBE_DEVICE_DECLARE_INTERNAL)
 #endif /* CONFIG_HAS_DTS */
+
+/** @endcond */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -899,6 +899,9 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 #define Z_DEVICE_DEFINE_INIT(node_id, dev_name)				\
 	.handles = Z_DEVICE_HANDLE_NAME(node_id, dev_name),
 
+#define Z_DEVICE_SECTION(level, prio)					       \
+	__attribute__((__section__(".z_device_" #level STRINGIFY(prio) "_")))
+
 /* Like DEVICE_DEFINE but takes a node_id AND a dev_name, and trailing
  * dependency handles that come from outside devicetree.
  */
@@ -906,9 +909,8 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 			data_ptr, cfg_ptr, level, prio, api_ptr, state_ptr, ...)	\
 	Z_DEVICE_DEFINE_PRE(node_id, dev_name, __VA_ARGS__)		\
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))		\
-		const Z_DECL_ALIGN(struct device)			\
-		DEVICE_NAME_GET(dev_name) __used			\
-	__attribute__((__section__(".z_device_" #level STRINGIFY(prio)"_"))) = { \
+	const Z_DECL_ALIGN(struct device) DEVICE_NAME_GET(dev_name)	\
+	Z_DEVICE_SECTION(level, prio) __used = {			\
 		.name = drv_name,					\
 		.config = (cfg_ptr),					\
 		.api = (api_ptr),					\

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -124,7 +124,7 @@ typedef int16_t device_handle_t;
  * @param dev_id A unique token which is used in the name of the
  * global device structure as a C identifier.
  *
- * @param drv_name A string name for the device, which will be stored
+ * @param name A string name for the device, which will be stored
  * in the device structure's @p name field. This name can be used to
  * look up the device with device_get_binding(). This must be less
  * than Z_DEVICE_MAX_NAME_LEN characters (including terminating NUL)
@@ -133,15 +133,15 @@ typedef int16_t device_handle_t;
  * @param init_fn Pointer to the device's initialization function,
  * which will be run by the kernel during system initialization.
  *
- * @param pm_device Pointer to the device's power management
+ * @param pm Pointer to the device's power management
  * resources, a <tt>struct pm_device</tt>, which will be stored in the
  * device structure's @p pm field. Use NULL if the device does not use
  * PM.
  *
- * @param data_ptr Pointer to the device's private mutable data, which
+ * @param data Pointer to the device's private mutable data, which
  * will be stored in the device structure's @p data field.
  *
- * @param cfg_ptr Pointer to the device's private constant data, which
+ * @param config Pointer to the device's private constant data, which
  * will be stored in the device structure's @p config field.
  *
  * @param level The device's initialization level. See SYS_INIT() for
@@ -150,13 +150,13 @@ typedef int16_t device_handle_t;
  * @param prio The device's priority within its initialization level.
  * See SYS_INIT() for details.
  *
- * @param api_ptr Pointer to the device's API structure. Can be NULL.
+ * @param api Pointer to the device's API structure. Can be NULL.
  */
-#define DEVICE_DEFINE(dev_id, drv_name, init_fn, pm_device, data_ptr, cfg_ptr, \
-		      level, prio, api_ptr)                                    \
+#define DEVICE_DEFINE(dev_id, name, init_fn, pm, data, config, level, prio,    \
+		      api)                                                     \
 	Z_DEVICE_STATE_DEFINE(DT_INVALID_NODE, dev_id);                        \
-	Z_DEVICE_DEFINE(DT_INVALID_NODE, dev_id, drv_name, init_fn, pm_device, \
-			data_ptr, cfg_ptr, level, prio, api_ptr,               \
+	Z_DEVICE_DEFINE(DT_INVALID_NODE, dev_id, name, init_fn, pm, data,      \
+			config, level, prio, api,                              \
 			&Z_DEVICE_STATE_NAME(dev_id))
 
 /**
@@ -195,15 +195,15 @@ typedef int16_t device_handle_t;
  * @param init_fn Pointer to the device's initialization function,
  * which will be run by the kernel during system initialization.
  *
- * @param pm_device Pointer to the device's power management
+ * @param pm Pointer to the device's power management
  * resources, a <tt>struct pm_device</tt>, which will be stored in the
  * device structure's @p pm field. Use NULL if the device does not use
  * PM.
  *
- * @param data_ptr Pointer to the device's private mutable data, which
+ * @param data Pointer to the device's private mutable data, which
  * will be stored in the device structure's @p data field.
  *
- * @param cfg_ptr Pointer to the device's private constant data, which
+ * @param config Pointer to the device's private constant data, which
  * will be stored in the device structure's @p config field.
  *
  * @param level The device's initialization level. See SYS_INIT() for
@@ -212,14 +212,14 @@ typedef int16_t device_handle_t;
  * @param prio The device's priority within its initialization level.
  * See SYS_INIT() for details.
  *
- * @param api_ptr Pointer to the device's API structure. Can be NULL.
+ * @param api Pointer to the device's API structure. Can be NULL.
  */
-#define DEVICE_DT_DEFINE(node_id, init_fn, pm_device, data_ptr, cfg_ptr, level,\
-			 prio, api_ptr, ...)                                   \
+#define DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level, prio, api, \
+			 ...)                                                  \
 	Z_DEVICE_STATE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id));         \
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),                \
-			DEVICE_DT_NAME(node_id), init_fn, pm_device, data_ptr, \
-			cfg_ptr, level, prio, api_ptr,                         \
+			DEVICE_DT_NAME(node_id), init_fn, pm, data, config,    \
+			level, prio, api,                                      \
 			&Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)),   \
 			__VA_ARGS__)
 
@@ -958,21 +958,20 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
  * @param node_id Devicetree node id for the device (DT_INVALID_NODE if a
  *                software device).
  * @param dev_id Device identifier (used to name the defined struct device).
- * @param drv_name Name of the device.
+ * @param name Name of the device.
  * @param init_fn Device init function.
- * @param pm_device Reference to struct pm_device associated with the device.
+ * @param pm Reference to struct pm_device associated with the device.
  *           (optional).
- * @param data_ptr Reference to device data.
- * @param cfg_ptr Reference to device config.
+ * @param data Reference to device data.
+ * @param config Reference to device config.
  * @param level Initialization level.
  * @param prio Initialization priority.
- * @param api_ptr Reference to device API.
- * @param state_ptr Reference to device state.
+ * @param api Reference to device API.
+ * @param state Reference to device state.
  * @param ... Optional dependencies, manually specified.
  */
-#define Z_DEVICE_DEFINE(node_id, dev_id, drv_name, init_fn, pm_device,         \
-			data_ptr, cfg_ptr, level, prio, api_ptr, state_ptr,    \
-			...)                                                   \
+#define Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn, pm, data, config,      \
+			level, prio, api, state, ...)                          \
 	Z_DEVICE_NAME_CHECK(name);                                             \
                                                                                \
 	Z_DEVICE_HANDLES_DEFINE(node_id, dev_id, __VA_ARGS__);                 \

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -890,6 +890,10 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 			(DT_SUPPORTS_DEP_ORDS(node_id)), ())		\
 		}
 
+#define Z_DEVICE_NAME_CHECK(name)                                              \
+	BUILD_ASSERT(sizeof(Z_STRINGIFY(name)) <= Z_DEVICE_MAX_NAME_LEN,       \
+		     Z_STRINGIFY(DEVICE_NAME_GET(name)) " too long")
+
 #define Z_DEVICE_INIT(name_, pm_, data_, config_, api_, state_, handles_)      \
 	{                                                                      \
 		.name = name_,                                                 \
@@ -916,9 +920,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		Z_DEVICE_SECTION(level, prio) __used = Z_DEVICE_INIT(          \
 			drv_name, pm_device, data_ptr, cfg_ptr, api_ptr,       \
 			state_ptr, Z_DEVICE_HANDLE_NAME(node_id, dev_name));   \
-	BUILD_ASSERT(                                                          \
-		sizeof(Z_STRINGIFY(drv_name)) <= Z_DEVICE_MAX_NAME_LEN,        \
-		       Z_STRINGIFY(DEVICE_NAME_GET(drv_name)) " too long");    \
+	Z_DEVICE_NAME_CHECK(drv_name);                                         \
 	Z_INIT_ENTRY_DEFINE(DEVICE_NAME_GET(dev_name), init_fn,                \
 			    (&DEVICE_NAME_GET(dev_name)), level, prio)
 

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -888,7 +888,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 			DEVICE_HANDLE_SEP,				\
 	COND_CODE_1(DT_NODE_EXISTS(node_id),				\
 			(DT_SUPPORTS_DEP_ORDS(node_id)), ())		\
-		};
+		}
 
 #define Z_DEVICE_INIT(name_, pm_, data_, config_, api_, state_, handles_)      \
 	{                                                                      \
@@ -910,7 +910,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 #define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_device,       \
 			data_ptr, cfg_ptr, level, prio, api_ptr, state_ptr,    \
 			...)                                                   \
-	Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, __VA_ARGS__)                \
+	Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, __VA_ARGS__);               \
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))                     \
 	const Z_DECL_ALIGN(struct device) DEVICE_NAME_GET(dev_name)            \
 		Z_DEVICE_SECTION(level, prio) __used = Z_DEVICE_INIT(          \

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -824,14 +824,10 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * @brief Synthesize the name of the object that holds device ordinal and
  * dependency data.
  *
- * @param node_id Devicetree node id of the device.
  * @param dev_id Device identifier.
  */
-#define Z_DEVICE_HANDLES_NAME(node_id, dev_id)				\
-	_CONCAT(__devicehdl_,						\
-		COND_CODE_1(DT_NODE_EXISTS(node_id),			\
-			    (node_id),					\
-			    (dev_id)))
+#define Z_DEVICE_HANDLES_NAME(dev_id)                                          \
+	_CONCAT(__devicehdl_, dev_id)
 
 /**
  * @brief Expand extra handles with a comma in between.
@@ -884,10 +880,9 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  */
 #define Z_DEVICE_HANDLES_DEFINE(node_id, dev_id, ...)                          \
 	extern Z_DEVICE_HANDLES_CONST device_handle_t                          \
-		Z_DEVICE_HANDLES_NAME(node_id, dev_id)[];                      \
+		Z_DEVICE_HANDLES_NAME(dev_id)[];                               \
 	Z_DEVICE_HANDLES_CONST Z_DECL_ALIGN(device_handle_t)                   \
-	Z_DEVICE_HANDLES_SECTION __weak                                        \
-	Z_DEVICE_HANDLES_NAME(node_id, dev_id)[] = {                           \
+	Z_DEVICE_HANDLES_SECTION __weak Z_DEVICE_HANDLES_NAME(dev_id)[] = {    \
 		COND_CODE_1(DT_NODE_EXISTS(node_id),                           \
 			    (DT_DEP_ORD(node_id),                              \
 			     DT_REQUIRES_DEP_ORDS(node_id)),                   \
@@ -1014,8 +1009,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 	Z_DEVICE_HANDLES_DEFINE(node_id, dev_id, __VA_ARGS__);                 \
                                                                                \
 	Z_DEVICE_BASE_DEFINE(node_id, dev_id, name, pm, data, config, level,   \
-			     prio, api, state,                                 \
-			     Z_DEVICE_HANDLES_NAME(node_id, dev_id));          \
+			     prio, api, state, Z_DEVICE_HANDLES_NAME(dev_id)); \
 			                                                       \
 	Z_DEVICE_INIT_ENTRY_DEFINE(dev_id, init_fn, level, prio)
 

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -827,7 +827,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * @param node_id Devicetree node id of the device.
  * @param dev_id Device identifier.
  */
-#define Z_DEVICE_HANDLE_NAME(node_id, dev_id)				\
+#define Z_DEVICE_HANDLES_NAME(node_id, dev_id)				\
 	_CONCAT(__devicehdl_,						\
 		COND_CODE_1(DT_NODE_EXISTS(node_id),			\
 			    (node_id),					\
@@ -884,10 +884,10 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  */
 #define Z_DEVICE_HANDLES_DEFINE(node_id, dev_id, ...)			\
 	extern Z_DEVICE_HANDLES_CONST device_handle_t			\
-		Z_DEVICE_HANDLE_NAME(node_id, dev_id)[];		\
+		Z_DEVICE_HANDLES_NAME(node_id, dev_id)[];		\
 	Z_DEVICE_HANDLES_CONST Z_DECL_ALIGN(device_handle_t)		\
 	Z_DEVICE_HANDLES_SECTION __weak					\
-	Z_DEVICE_HANDLE_NAME(node_id, dev_id)[] = {			\
+	Z_DEVICE_HANDLES_NAME(node_id, dev_id)[] = {			\
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (				\
 			DT_DEP_ORD(node_id),				\
 			DT_REQUIRES_DEP_ORDS(node_id)			\
@@ -1017,7 +1017,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
                                                                                \
 	Z_DEVICE_BASE_DEFINE(node_id, dev_id, name, pm, data, config, level,   \
 			     prio, api, state,                                 \
-			     Z_DEVICE_HANDLE_NAME(node_id, dev_id));           \
+			     Z_DEVICE_HANDLES_NAME(node_id, dev_id));          \
 			                                                       \
 	Z_DEVICE_INIT_ENTRY_DEFINE(dev_id, init_fn, level, prio)
 

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -952,6 +952,30 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 /**
  * @brief Define a struct device
  *
+ * @param node_id Devicetree node id for the device (DT_INVALID_NODE if a
+ *                software device).
+ * @param dev_id Device identifier (used to name the defined struct device).
+ * @param name Name of the device.
+ * @param pm Reference to struct pm_device associated with the device.
+ *           (optional).
+ * @param data Reference to device data.
+ * @param config Reference to device config.
+ * @param level Initialization level.
+ * @param prio Initialization priority.
+ * @param api Reference to device API.
+ * @param ... Optional dependencies, manually specified.
+ */
+#define Z_DEVICE_BASE_DEFINE(node_id, dev_id, name, pm, data, config, level,   \
+			     prio, api, state, handles)                        \
+	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))                     \
+	const Z_DECL_ALIGN(struct device) DEVICE_NAME_GET(dev_id)              \
+		Z_DEVICE_SECTION(level, prio) __used =                         \
+			Z_DEVICE_INIT(name, pm, data, config, api, state,      \
+				      handles)
+
+/**
+ * @brief Define a struct device and all other required objects.
+ *
  * This is the common macro used to define struct device objects. It can be
  * used to define both Devicetree and software devices.
  *
@@ -976,12 +1000,10 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
                                                                                \
 	Z_DEVICE_HANDLES_DEFINE(node_id, dev_id, __VA_ARGS__);                 \
                                                                                \
-	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))                     \
-	const Z_DECL_ALIGN(struct device) DEVICE_NAME_GET(dev_id)              \
-		Z_DEVICE_SECTION(level, prio) __used =                         \
-			Z_DEVICE_INIT(name, pm, data, config, api, state,      \
-				      Z_DEVICE_HANDLE_NAME(node_id, dev_id));  \
-                                                                               \
+	Z_DEVICE_BASE_DEFINE(node_id, dev_id, name, pm, data, config, level,   \
+			     prio, api, state,                                 \
+			     Z_DEVICE_HANDLE_NAME(node_id, dev_id));           \
+			                                                       \
 	Z_INIT_ENTRY_DEFINE(DEVICE_NAME_GET(dev_id), init_fn,                  \
 			    (&DEVICE_NAME_GET(dev_id)), level, prio)
 

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -113,11 +113,6 @@ typedef int16_t device_handle_t;
  */
 #define Z_DEVICE_DT_DEV_NAME(node_id) _CONCAT(dts_ord_, DT_DEP_ORD(node_id))
 
-/* Synthesize a unique name for the device state associated with
- * dev_name.
- */
-#define Z_DEVICE_STATE_NAME(dev_name) _CONCAT(__devstate_, dev_name)
-
 /**
  * @brief Create a device object and set it up for boot time initialization.
  *
@@ -807,6 +802,21 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * @}
  */
 
+/* Synthesize a unique name for the device state associated with
+ * dev_name.
+ */
+#define Z_DEVICE_STATE_NAME(dev_name) _CONCAT(__devstate_, dev_name)
+
+/*
+ * Utility macro to define and initialize the device state.
+ *
+ * @param node_id Devicetree node id of the device.
+ * @param dev_name Device name.
+ */
+#define Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
+	static struct device_state Z_DEVICE_STATE_NAME(dev_name)	\
+	__attribute__((__section__(".z_devstate")))
+
 /* Synthesize the name of the object that holds device ordinal and
  * dependency data. If the object doesn't come from a devicetree
  * node, use dev_name.
@@ -819,16 +829,6 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 
 #define Z_DEVICE_EXTRA_HANDLES(...)				\
 	FOR_EACH_NONEMPTY_TERM(IDENTITY, (,), __VA_ARGS__)
-
-/*
- * Utility macro to define and initialize the device state.
- *
- * @param node_id Devicetree node id of the device.
- * @param dev_name Device name.
- */
-#define Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
-	static struct device_state Z_DEVICE_STATE_NAME(dev_name)	\
-	__attribute__((__section__(".z_devstate")))
 
 /* Initial build provides a record that associates the device object
  * with its devicetree ordinal, and provides the dependency ordinals.

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -974,6 +974,18 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 				      handles)
 
 /**
+ * @brief Define the init entry for a device.
+ *
+ * @param dev_id Device identifier.
+ * @param init_fn Device init function.
+ * @param level Initialization level.
+ * @param prio Initialization priority.
+ */
+#define Z_DEVICE_INIT_ENTRY_DEFINE(dev_id, init_fn, level, prio)               \
+	Z_INIT_ENTRY_DEFINE(DEVICE_NAME_GET(dev_id), init_fn,                  \
+			    (&DEVICE_NAME_GET(dev_id)), level, prio)
+
+/**
  * @brief Define a struct device and all other required objects.
  *
  * This is the common macro used to define struct device objects. It can be
@@ -1004,8 +1016,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 			     prio, api, state,                                 \
 			     Z_DEVICE_HANDLE_NAME(node_id, dev_id));           \
 			                                                       \
-	Z_INIT_ENTRY_DEFINE(DEVICE_NAME_GET(dev_id), init_fn,                  \
-			    (&DEVICE_NAME_GET(dev_id)), level, prio)
+	Z_DEVICE_INIT_ENTRY_DEFINE(dev_id, init_fn, level, prio)
 
 #if defined(CONFIG_HAS_DTS) || defined(__DOXYGEN__)
 /**

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -116,7 +116,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
  * The ordinal used in this name can be mapped to the path by
  * examining zephyr/include/generated/devicetree_generated.h.
  */
-#define Z_DEVICE_DT_DEV_NAME(node_id) _CONCAT(dts_ord_, DT_DEP_ORD(node_id))
+#define Z_DEVICE_DT_DEV_ID(node_id) _CONCAT(dts_ord_, DT_DEP_ORD(node_id))
 
 /**
  * @brief Create a device object and set it up for boot time initialization.
@@ -223,11 +223,11 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
  */
 #define DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level, prio, api, \
 			 ...)                                                  \
-	Z_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_NAME(node_id));                  \
-	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),                \
+	Z_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_ID(node_id));                    \
+	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),                  \
 			DEVICE_DT_NAME(node_id), init_fn, pm, data, config,    \
 			level, prio, api,                                      \
-			&Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)),   \
+			&Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)),     \
 			__VA_ARGS__)
 
 /**
@@ -257,7 +257,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
  *
  * @return The name of the device object as a C identifier
  */
-#define DEVICE_DT_NAME_GET(node_id) DEVICE_NAME_GET(Z_DEVICE_DT_DEV_NAME(node_id))
+#define DEVICE_DT_NAME_GET(node_id) DEVICE_NAME_GET(Z_DEVICE_DT_DEV_ID(node_id))
 
 /**
  * @brief Get a <tt>const struct device*</tt> from a devicetree node

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -882,24 +882,22 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * space and resulting in aggregate size changes relative to pass2
  * when all objects will be in the same input section.
  */
-#define Z_DEVICE_HANDLES_DEFINE(node_id, dev_id, ...)			\
-	extern Z_DEVICE_HANDLES_CONST device_handle_t			\
-		Z_DEVICE_HANDLES_NAME(node_id, dev_id)[];		\
-	Z_DEVICE_HANDLES_CONST Z_DECL_ALIGN(device_handle_t)		\
-	Z_DEVICE_HANDLES_SECTION __weak					\
-	Z_DEVICE_HANDLES_NAME(node_id, dev_id)[] = {			\
-	COND_CODE_1(DT_NODE_EXISTS(node_id), (				\
-			DT_DEP_ORD(node_id),				\
-			DT_REQUIRES_DEP_ORDS(node_id)			\
-		), (							\
-			DEVICE_HANDLE_NULL,				\
-		))							\
-			DEVICE_HANDLE_SEP,				\
-			Z_DEVICE_EXTRA_HANDLES(__VA_ARGS__)		\
-			DEVICE_HANDLE_SEP,				\
-	COND_CODE_1(DT_NODE_EXISTS(node_id),				\
-			(DT_SUPPORTS_DEP_ORDS(node_id)), ())		\
-		}
+#define Z_DEVICE_HANDLES_DEFINE(node_id, dev_id, ...)                          \
+	extern Z_DEVICE_HANDLES_CONST device_handle_t                          \
+		Z_DEVICE_HANDLES_NAME(node_id, dev_id)[];                      \
+	Z_DEVICE_HANDLES_CONST Z_DECL_ALIGN(device_handle_t)                   \
+	Z_DEVICE_HANDLES_SECTION __weak                                        \
+	Z_DEVICE_HANDLES_NAME(node_id, dev_id)[] = {                           \
+		COND_CODE_1(DT_NODE_EXISTS(node_id),                           \
+			    (DT_DEP_ORD(node_id),                              \
+			     DT_REQUIRES_DEP_ORDS(node_id)),                   \
+			    (DEVICE_HANDLE_NULL,))                             \
+		DEVICE_HANDLE_SEP,                                             \
+		Z_DEVICE_EXTRA_HANDLES(__VA_ARGS__)                            \
+		DEVICE_HANDLE_SEP,                                             \
+		COND_CODE_1(DT_NODE_EXISTS(node_id),                           \
+			    (DT_SUPPORTS_DEP_ORDS(node_id)), ())               \
+	}
 
 /**
  * @brief Maximum device name length.

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -881,8 +881,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 #define Z_DEVICE_HANDLES_DEFINE(node_id, dev_id, ...)			\
 	extern Z_DEVICE_HANDLES_CONST device_handle_t			\
 		Z_DEVICE_HANDLE_NAME(node_id, dev_id)[];		\
-	Z_DEVICE_HANDLES_CONST device_handle_t				\
-	__aligned(sizeof(device_handle_t))				\
+	Z_DEVICE_HANDLES_CONST Z_DECL_ALIGN(device_handle_t)		\
 	__attribute__((__weak__,					\
 		       __section__(".__device_handles_pass1")))		\
 	Z_DEVICE_HANDLE_NAME(node_id, dev_id)[] = {			\

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -869,7 +869,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * `gen_handles.py` must be updated.
  */
 BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
-#define Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, ...)			\
+#define Z_DEVICE_HANDLES_DEFINE(node_id, dev_name, ...)			\
 	extern Z_DEVICE_HANDLES_CONST device_handle_t			\
 		Z_DEVICE_HANDLE_NAME(node_id, dev_name)[];		\
 	Z_DEVICE_HANDLES_CONST device_handle_t				\
@@ -910,7 +910,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 #define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_device,       \
 			data_ptr, cfg_ptr, level, prio, api_ptr, state_ptr,    \
 			...)                                                   \
-	Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, __VA_ARGS__);               \
+	Z_DEVICE_HANDLES_DEFINE(node_id, dev_name, __VA_ARGS__);               \
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))                     \
 	const Z_DECL_ALIGN(struct device) DEVICE_NAME_GET(dev_name)            \
 		Z_DEVICE_SECTION(level, prio) __used = Z_DEVICE_INIT(          \

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -161,7 +161,7 @@ typedef int16_t device_handle_t;
  */
 #define DEVICE_DEFINE(dev_name, drv_name, init_fn, pm_device,		\
 		      data_ptr, cfg_ptr, level, prio, api_ptr)		\
-	Z_DEVICE_STATE_DEFINE(DT_INVALID_NODE, dev_name) \
+	Z_DEVICE_STATE_DEFINE(DT_INVALID_NODE, dev_name);		\
 	Z_DEVICE_DEFINE(DT_INVALID_NODE, dev_name, drv_name, init_fn,	\
 			pm_device,					\
 			data_ptr, cfg_ptr, level, prio, api_ptr,	\
@@ -225,7 +225,7 @@ typedef int16_t device_handle_t;
 #define DEVICE_DT_DEFINE(node_id, init_fn, pm_device,			\
 			 data_ptr, cfg_ptr, level, prio,		\
 			 api_ptr, ...)					\
-	Z_DEVICE_STATE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id)) \
+	Z_DEVICE_STATE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id));	\
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
 			DEVICE_DT_NAME(node_id), init_fn,		\
 			pm_device,					\
@@ -828,7 +828,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  */
 #define Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
 	static struct device_state Z_DEVICE_STATE_NAME(dev_name)	\
-	__attribute__((__section__(".z_devstate")));
+	__attribute__((__section__(".z_devstate")))
 
 /* Initial build provides a record that associates the device object
  * with its devicetree ordinal, and provides the dependency ordinals.

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -79,8 +79,6 @@ typedef int16_t device_handle_t;
 /** @brief Flag value used to identify an unknown device. */
 #define DEVICE_HANDLE_NULL 0
 
-#define Z_DEVICE_MAX_NAME_LEN	48
-
 /**
  * @brief Expands to the name of a global device object.
  *
@@ -889,6 +887,8 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 	COND_CODE_1(DT_NODE_EXISTS(node_id),				\
 			(DT_SUPPORTS_DEP_ORDS(node_id)), ())		\
 		}
+
+#define Z_DEVICE_MAX_NAME_LEN	48
 
 #define Z_DEVICE_NAME_CHECK(name)                                              \
 	BUILD_ASSERT(sizeof(Z_STRINGIFY(name)) <= Z_DEVICE_MAX_NAME_LEN,       \

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -882,8 +882,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 	extern Z_DEVICE_HANDLES_CONST device_handle_t			\
 		Z_DEVICE_HANDLE_NAME(node_id, dev_id)[];		\
 	Z_DEVICE_HANDLES_CONST Z_DECL_ALIGN(device_handle_t)		\
-	__attribute__((__weak__,					\
-		       __section__(".__device_handles_pass1")))		\
+	__attribute__((__section__(".__device_handles_pass1"))) __weak	\
 	Z_DEVICE_HANDLE_NAME(node_id, dev_id)[] = {			\
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (				\
 			DT_DEP_ORD(node_id),				\

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -830,12 +830,6 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 	static struct device_state Z_DEVICE_STATE_NAME(dev_name)	\
 	__attribute__((__section__(".z_devstate")));
 
-/* Construct objects that are referenced from struct device. These
- * include power management and dependency handles.
- */
-#define Z_DEVICE_DEFINE_PRE(node_id, dev_name, ...)			\
-	Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, __VA_ARGS__)
-
 /* Initial build provides a record that associates the device object
  * with its devicetree ordinal, and provides the dependency ordinals.
  * These are provided as weak definitions (to prevent the reference
@@ -916,7 +910,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 #define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_device,       \
 			data_ptr, cfg_ptr, level, prio, api_ptr, state_ptr,    \
 			...)                                                   \
-	Z_DEVICE_DEFINE_PRE(node_id, dev_name, __VA_ARGS__)                    \
+	Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, __VA_ARGS__)                \
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))                     \
 	const Z_DECL_ALIGN(struct device) DEVICE_NAME_GET(dev_name)            \
 		Z_DEVICE_SECTION(level, prio) __used = Z_DEVICE_INIT(          \

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -905,24 +905,26 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 /* Like DEVICE_DEFINE but takes a node_id AND a dev_name, and trailing
  * dependency handles that come from outside devicetree.
  */
-#define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_device,\
-			data_ptr, cfg_ptr, level, prio, api_ptr, state_ptr, ...)	\
-	Z_DEVICE_DEFINE_PRE(node_id, dev_name, __VA_ARGS__)		\
-	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))		\
-	const Z_DECL_ALIGN(struct device) DEVICE_NAME_GET(dev_name)	\
-	Z_DEVICE_SECTION(level, prio) __used = {			\
-		.name = drv_name,					\
-		.config = (cfg_ptr),					\
-		.api = (api_ptr),					\
-		.state = (state_ptr),					\
-		.data = (data_ptr),					\
-		IF_ENABLED(CONFIG_PM_DEVICE, (.pm = pm_device,))	\
-		Z_DEVICE_DEFINE_INIT(node_id, dev_name)			\
-	};								\
-	BUILD_ASSERT(sizeof(Z_STRINGIFY(drv_name)) <= Z_DEVICE_MAX_NAME_LEN, \
-		     Z_STRINGIFY(DEVICE_NAME_GET(drv_name)) " too long"); \
-	Z_INIT_ENTRY_DEFINE(DEVICE_NAME_GET(dev_name), init_fn,		\
-		(&DEVICE_NAME_GET(dev_name)), level, prio)
+#define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_device,       \
+			data_ptr, cfg_ptr, level, prio, api_ptr, state_ptr,    \
+			...)                                                   \
+	Z_DEVICE_DEFINE_PRE(node_id, dev_name, __VA_ARGS__)                    \
+	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))                     \
+	const Z_DECL_ALIGN(struct device) DEVICE_NAME_GET(dev_name)            \
+		Z_DEVICE_SECTION(level, prio) __used = {                       \
+			.name = drv_name,                                      \
+			.config = (cfg_ptr),                                   \
+			.api = (api_ptr),                                      \
+			.state = (state_ptr),                                  \
+			.data = (data_ptr),                                    \
+			IF_ENABLED(CONFIG_PM_DEVICE, (.pm = pm_device, ))      \
+			Z_DEVICE_DEFINE_INIT(node_id, dev_name)                \
+		};                                                             \
+	BUILD_ASSERT(                                                          \
+		sizeof(Z_STRINGIFY(drv_name)) <= Z_DEVICE_MAX_NAME_LEN,        \
+		       Z_STRINGIFY(DEVICE_NAME_GET(drv_name)) " too long");    \
+	Z_INIT_ENTRY_DEFINE(DEVICE_NAME_GET(dev_name), init_fn,                \
+			    (&DEVICE_NAME_GET(dev_name)), level, prio)
 
 #if CONFIG_HAS_DTS
 /*

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -154,7 +154,7 @@ typedef int16_t device_handle_t;
  */
 #define DEVICE_DEFINE(dev_id, name, init_fn, pm, data, config, level, prio,    \
 		      api)                                                     \
-	Z_DEVICE_STATE_DEFINE(DT_INVALID_NODE, dev_id);                        \
+	Z_DEVICE_STATE_DEFINE(dev_id);                                         \
 	Z_DEVICE_DEFINE(DT_INVALID_NODE, dev_id, name, init_fn, pm, data,      \
 			config, level, prio, api,                              \
 			&Z_DEVICE_STATE_NAME(dev_id))
@@ -216,7 +216,7 @@ typedef int16_t device_handle_t;
  */
 #define DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level, prio, api, \
 			 ...)                                                  \
-	Z_DEVICE_STATE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id));         \
+	Z_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_NAME(node_id));                  \
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),                \
 			DEVICE_DT_NAME(node_id), init_fn, pm, data, config,    \
 			level, prio, api,                                      \
@@ -807,10 +807,9 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 /**
  * @brief Utility macro to define and initialize the device state.
  *
- * @param node_id Devicetree node id of the device.
  * @param dev_id Device identifier.
  */
-#define Z_DEVICE_STATE_DEFINE(node_id, dev_id)			\
+#define Z_DEVICE_STATE_DEFINE(dev_id)				\
 	static struct device_state Z_DEVICE_STATE_NAME(dev_id)	\
 	__attribute__((__section__(".z_devstate")))
 

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -914,13 +914,16 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 #define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_device,       \
 			data_ptr, cfg_ptr, level, prio, api_ptr, state_ptr,    \
 			...)                                                   \
+	Z_DEVICE_NAME_CHECK(drv_name);                                         \
+                                                                               \
 	Z_DEVICE_HANDLES_DEFINE(node_id, dev_name, __VA_ARGS__);               \
+                                                                               \
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))                     \
 	const Z_DECL_ALIGN(struct device) DEVICE_NAME_GET(dev_name)            \
 		Z_DEVICE_SECTION(level, prio) __used = Z_DEVICE_INIT(          \
 			drv_name, pm_device, data_ptr, cfg_ptr, api_ptr,       \
 			state_ptr, Z_DEVICE_HANDLE_NAME(node_id, dev_name));   \
-	Z_DEVICE_NAME_CHECK(drv_name);                                         \
+                                                                               \
 	Z_INIT_ENTRY_DEFINE(DEVICE_NAME_GET(dev_name), init_fn,                \
 			    (&DEVICE_NAME_GET(dev_name)), level, prio)
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -561,7 +561,7 @@ struct can_device_state {
  */
 #define Z_CAN_DEVICE_STATE_DEFINE(node_id, dev_name)			\
 	static struct can_device_state Z_DEVICE_STATE_NAME(dev_name)	\
-	__attribute__((__section__(".z_devstate")));
+	__attribute__((__section__(".z_devstate")))
 
 /**
  * @brief Define a CAN device init wrapper function

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -559,7 +559,7 @@ struct can_device_state {
 /**
  * @brief Define a statically allocated and section assigned CAN device state
  */
-#define Z_CAN_DEVICE_STATE_DEFINE(node_id, dev_id)			\
+#define Z_CAN_DEVICE_STATE_DEFINE(dev_id)				\
 	static struct can_device_state Z_DEVICE_STATE_NAME(dev_id)	\
 	__attribute__((__section__(".z_devstate")))
 
@@ -604,7 +604,7 @@ struct can_device_state {
  */
 #define CAN_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
 			     prio, api, ...)				\
-	Z_CAN_DEVICE_STATE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id)); \
+	Z_CAN_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_NAME(node_id));	\
 	Z_CAN_INIT_FN(Z_DEVICE_DT_DEV_NAME(node_id), init_fn)		\
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
 			DEVICE_DT_NAME(node_id),			\

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -591,28 +591,25 @@ struct can_device_state {
  *
  * @param node_id   The devicetree node identifier.
  * @param init_fn   Name of the init function of the driver.
- * @param pm_device PM device resources reference (NULL if device does not use PM).
- * @param data_ptr  Pointer to the device's private data.
- * @param cfg_ptr   The address to the structure containing the configuration
+ * @param pm        PM device resources reference (NULL if device does not use PM).
+ * @param data      Pointer to the device's private data.
+ * @param config    The address to the structure containing the configuration
  *                  information for this instance of the driver.
  * @param level     The initialization level. See SYS_INIT() for
  *                  details.
  * @param prio      Priority within the selected initialization level. See
  *                  SYS_INIT() for details.
- * @param api_ptr   Provides an initial pointer to the API function struct
+ * @param api       Provides an initial pointer to the API function struct
  *                  used by the driver. Can be NULL.
  */
-#define CAN_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,		\
-			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, ...)				\
+#define CAN_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
+			     prio, api, ...)				\
 	Z_CAN_DEVICE_STATE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id)); \
 	Z_CAN_INIT_FN(Z_DEVICE_DT_DEV_NAME(node_id), init_fn)		\
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
 			DEVICE_DT_NAME(node_id),			\
 			&UTIL_CAT(Z_DEVICE_DT_DEV_NAME(node_id), _init), \
-			pm_device,					\
-			data_ptr, cfg_ptr, level, prio,			\
-			api_ptr,					\
+			pm, data, config, level, prio, api,		\
 			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)).devstate), \
 			__VA_ARGS__)
 
@@ -625,12 +622,10 @@ struct can_device_state {
 #define CAN_STATS_FORM_ERROR_INC(dev_)
 #define CAN_STATS_ACK_ERROR_INC(dev_)
 
-#define CAN_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,		\
-			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, ...)				\
-	DEVICE_DT_DEFINE(node_id, init_fn, pm_device,			\
-			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, __VA_ARGS__)
+#define CAN_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
+			     prio, api, ...)				\
+	DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
+			 prio, api, __VA_ARGS__)
 
 #endif /* CONFIG_CAN_STATS */
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -559,8 +559,8 @@ struct can_device_state {
 /**
  * @brief Define a statically allocated and section assigned CAN device state
  */
-#define Z_CAN_DEVICE_STATE_DEFINE(node_id, dev_name)			\
-	static struct can_device_state Z_DEVICE_STATE_NAME(dev_name)	\
+#define Z_CAN_DEVICE_STATE_DEFINE(node_id, dev_id)			\
+	static struct can_device_state Z_DEVICE_STATE_NAME(dev_id)	\
 	__attribute__((__section__(".z_devstate")))
 
 /**
@@ -569,8 +569,8 @@ struct can_device_state {
  * This does device instance specific initialization of common data (such as stats)
  * and calls the given init_fn
  */
-#define Z_CAN_INIT_FN(dev_name, init_fn)				\
-	static inline int UTIL_CAT(dev_name, _init)(const struct device *dev) \
+#define Z_CAN_INIT_FN(dev_id, init_fn)					\
+	static inline int UTIL_CAT(dev_id, _init)(const struct device *dev) \
 	{								\
 		struct can_device_state *state =			\
 			CONTAINER_OF(dev->state, struct can_device_state, devstate); \

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -604,13 +604,13 @@ struct can_device_state {
  */
 #define CAN_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
 			     prio, api, ...)				\
-	Z_CAN_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_NAME(node_id));	\
-	Z_CAN_INIT_FN(Z_DEVICE_DT_DEV_NAME(node_id), init_fn)		\
-	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
+	Z_CAN_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_ID(node_id));		\
+	Z_CAN_INIT_FN(Z_DEVICE_DT_DEV_ID(node_id), init_fn)		\
+	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),		\
 			DEVICE_DT_NAME(node_id),			\
-			&UTIL_CAT(Z_DEVICE_DT_DEV_NAME(node_id), _init), \
+			&UTIL_CAT(Z_DEVICE_DT_DEV_ID(node_id), _init),	\
 			pm, data, config, level, prio, api,		\
-			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)).devstate), \
+			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)).devstate), \
 			__VA_ARGS__)
 
 #else /* CONFIG_CAN_STATS */

--- a/include/zephyr/drivers/gpio/gpio_mmio32.h
+++ b/include/zephyr/drivers/gpio/gpio_mmio32.h
@@ -42,9 +42,9 @@ int gpio_mmio32_init(const struct device *dev);
  *
  */
 #define GPIO_MMIO32_INIT(node_id, _address, _mask)					\
-static struct gpio_mmio32_context _CONCAT(Z_DEVICE_DT_DEV_NAME(node_id), _ctx);		\
+static struct gpio_mmio32_context _CONCAT(Z_DEVICE_DT_DEV_ID(node_id), _ctx);		\
 											\
-static const struct gpio_mmio32_config _CONCAT(Z_DEVICE_DT_DEV_NAME(node_id), _cfg) = {	\
+static const struct gpio_mmio32_config _CONCAT(Z_DEVICE_DT_DEV_ID(node_id), _cfg) = {	\
 	.common = {									\
 		 .port_pin_mask = _mask,						\
 	},										\
@@ -55,8 +55,8 @@ static const struct gpio_mmio32_config _CONCAT(Z_DEVICE_DT_DEV_NAME(node_id), _c
 DEVICE_DT_DEFINE(node_id,								\
 		    &gpio_mmio32_init,							\
 		    NULL,								\
-		    &_CONCAT(Z_DEVICE_DT_DEV_NAME(node_id), _ctx),			\
-		    &_CONCAT(Z_DEVICE_DT_DEV_NAME(node_id), _cfg),			\
+		    &_CONCAT(Z_DEVICE_DT_DEV_ID(node_id), _ctx),			\
+		    &_CONCAT(Z_DEVICE_DT_DEV_ID(node_id), _cfg),			\
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
 		    &gpio_mmio32_api)
 

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -491,11 +491,11 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  *
  * @param init_fn Name of the init function of the driver.
  *
- * @param pm_device PM device resources reference (NULL if device does not use PM).
+ * @param pm PM device resources reference (NULL if device does not use PM).
  *
- * @param data_ptr Pointer to the device's private data.
+ * @param data Pointer to the device's private data.
  *
- * @param cfg_ptr The address to the structure containing the
+ * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
  *
  * @param level The initialization level. See SYS_INIT() for
@@ -504,20 +504,17 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  * @param prio Priority within the selected initialization level. See
  * SYS_INIT() for details.
  *
- * @param api_ptr Provides an initial pointer to the API function struct
+ * @param api Provides an initial pointer to the API function struct
  * used by the driver. Can be NULL.
  */
-#define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,		\
-			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, ...)				\
+#define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
+			     prio, api, ...)				\
 	Z_I2C_DEVICE_STATE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id)); \
 	Z_I2C_INIT_FN(Z_DEVICE_DT_DEV_NAME(node_id), init_fn)		\
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
 			DEVICE_DT_NAME(node_id),			\
 			&UTIL_CAT(Z_DEVICE_DT_DEV_NAME(node_id), _init), \
-			pm_device,					\
-			data_ptr, cfg_ptr, level, prio,			\
-			api_ptr,					\
+			pm_device, data, config, level, prio, api,	\
 			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)).devstate), \
 			__VA_ARGS__)
 
@@ -531,12 +528,10 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 	ARG_UNUSED(num_msgs);
 }
 
-#define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,		\
-			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, ...)				\
-	DEVICE_DT_DEFINE(node_id, &init_fn, pm_device,			\
-			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, __VA_ARGS__)
+#define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
+			     prio, api, ...)				\
+	DEVICE_DT_DEFINE(node_id, &init_fn, pm, data, config, level,	\
+			 prio, api, __VA_ARGS__)
 
 #endif /* CONFIG_I2C_STATS */
 

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -457,8 +457,8 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 /**
  * @brief Define a statically allocated and section assigned i2c device state
  */
-#define Z_I2C_DEVICE_STATE_DEFINE(node_id, dev_name)	\
-	static struct i2c_device_state Z_DEVICE_STATE_NAME(dev_name)	\
+#define Z_I2C_DEVICE_STATE_DEFINE(node_id, dev_id)			\
+	static struct i2c_device_state Z_DEVICE_STATE_NAME(dev_id)	\
 	__attribute__((__section__(".z_devstate")))
 
 /**
@@ -467,8 +467,8 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  * This does device instance specific initialization of common data (such as stats)
  * and calls the given init_fn
  */
-#define Z_I2C_INIT_FN(dev_name, init_fn)					\
-	static inline int UTIL_CAT(dev_name, _init)(const struct device *dev) \
+#define Z_I2C_INIT_FN(dev_id, init_fn)					\
+	static inline int UTIL_CAT(dev_id, _init)(const struct device *dev) \
 	{								\
 		struct i2c_device_state *state =			\
 			CONTAINER_OF(dev->state, struct i2c_device_state, devstate); \

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -509,13 +509,13 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  */
 #define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
 			     prio, api, ...)				\
-	Z_I2C_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_NAME(node_id));	\
-	Z_I2C_INIT_FN(Z_DEVICE_DT_DEV_NAME(node_id), init_fn)		\
-	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
+	Z_I2C_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_ID(node_id));		\
+	Z_I2C_INIT_FN(Z_DEVICE_DT_DEV_ID(node_id), init_fn)		\
+	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),		\
 			DEVICE_DT_NAME(node_id),			\
-			&UTIL_CAT(Z_DEVICE_DT_DEV_NAME(node_id), _init), \
+			&UTIL_CAT(Z_DEVICE_DT_DEV_ID(node_id), _init),	\
 			pm_device, data, config, level, prio, api,	\
-			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)).devstate), \
+			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)).devstate), \
 			__VA_ARGS__)
 
 #else /* CONFIG_I2C_STATS */

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -459,7 +459,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  */
 #define Z_I2C_DEVICE_STATE_DEFINE(node_id, dev_name)	\
 	static struct i2c_device_state Z_DEVICE_STATE_NAME(dev_name)	\
-	__attribute__((__section__(".z_devstate")));
+	__attribute__((__section__(".z_devstate")))
 
 /**
  * @brief Define an i2c device init wrapper function

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -457,7 +457,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 /**
  * @brief Define a statically allocated and section assigned i2c device state
  */
-#define Z_I2C_DEVICE_STATE_DEFINE(node_id, dev_id)			\
+#define Z_I2C_DEVICE_STATE_DEFINE(dev_id)				\
 	static struct i2c_device_state Z_DEVICE_STATE_NAME(dev_id)	\
 	__attribute__((__section__(".z_devstate")))
 
@@ -509,7 +509,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  */
 #define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
 			     prio, api, ...)				\
-	Z_I2C_DEVICE_STATE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id)); \
+	Z_I2C_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_NAME(node_id));	\
 	Z_I2C_INIT_FN(Z_DEVICE_DT_DEV_NAME(node_id), init_fn)		\
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
 			DEVICE_DT_NAME(node_id),			\

--- a/include/zephyr/drivers/i3c/devicetree.h
+++ b/include/zephyr/drivers/i3c/devicetree.h
@@ -126,12 +126,12 @@ extern "C" {
  *
  * @param init_fn Name of the init function of the driver.
  *
- * @param pm_device PM device resources reference (NULL if device does not use PM).
+ * @param pm PM device resources reference (NULL if device does not use PM).
  *
- * @param data_ptr Pointer to the device's private data.
+ * @param data Pointer to the device's private data.
  *
- * @param cfg_ptr The address to the structure containing the
- *                configuration information for this instance of the driver.
+ * @param config The address to the structure containing the
+ *               configuration information for this instance of the driver.
  *
  * @param level The initialization level. See SYS_INIT() for
  *              details.
@@ -139,15 +139,13 @@ extern "C" {
  * @param prio Priority within the selected initialization level. See
  *             SYS_INIT() for details.
  *
- * @param api_ptr Provides an initial pointer to the API function struct
- *                used by the driver. Can be NULL.
+ * @param api Provides an initial pointer to the API function struct
+ *            used by the driver. Can be NULL.
  */
-#define I3C_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,		\
-			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, ...)				\
-	DEVICE_DT_DEFINE(node_id, init_fn, pm_device,			\
-			 data_ptr, cfg_ptr, level, prio,		\
-			 api_ptr, __VA_ARGS__)
+#define I3C_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
+			     prio, api, ...)				\
+	DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
+			 prio, api, __VA_ARGS__)
 
 /**
  * @brief Like I3C_TARGET_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -835,47 +835,45 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 #endif
 
 #if defined(CONFIG_NET_VLAN)
-#define Z_ETH_NET_DEVICE_INIT(node_id, dev_id, drv_name, init_fn,	\
-			      pm_action_cb, data, cfg, prio, api, mtu)	\
+#define Z_ETH_NET_DEVICE_INIT(node_id, dev_id, name, init_fn, pm, data,	\
+			      config, prio, api, mtu)			\
 	Z_DEVICE_STATE_DEFINE(node_id, dev_id);				\
-	Z_DEVICE_DEFINE(node_id, dev_id, drv_name, init_fn,		\
-			pm_action_cb, data, cfg, POST_KERNEL,		\
-			prio, api, &Z_DEVICE_STATE_NAME(dev_id));	\
+	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn, pm, data,	\
+			config, POST_KERNEL, prio, api,			\
+			&Z_DEVICE_STATE_NAME(dev_id));			\
 	NET_L2_DATA_INIT(dev_id, 0, NET_L2_GET_CTX_TYPE(ETHERNET_L2));	\
 	NET_IF_INIT(dev_id, 0, ETHERNET_L2, mtu, NET_VLAN_MAX_COUNT)
 
 #else /* CONFIG_NET_VLAN */
 
-#define Z_ETH_NET_DEVICE_INIT(node_id, dev_id, drv_name, init_fn,	\
-			      pm_action_cb, data, cfg, prio, api, mtu)	\
-	Z_NET_DEVICE_INIT(node_id, dev_id, drv_name, init_fn,		\
-			  pm_action_cb, data, cfg, prio, api,		\
-			  ETHERNET_L2, NET_L2_GET_CTX_TYPE(ETHERNET_L2),\
-			  mtu)
+#define Z_ETH_NET_DEVICE_INIT(node_id, dev_id, name, init_fn, pm, data,	\
+			      config, prio, api, mtu)			\
+	Z_NET_DEVICE_INIT(node_id, dev_id, name, init_fn, pm, data,	\
+			  config, prio, api, ETHERNET_L2,		\
+			  NET_L2_GET_CTX_TYPE(ETHERNET_L2), mtu)
 #endif /* CONFIG_NET_VLAN */
 
 /**
  * @brief Create an Ethernet network interface and bind it to network device.
  *
  * @param dev_id Network device id.
- * @param drv_name The name this instance of the driver exposes to
+ * @param name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm_action_cb Pointer to PM action callback.
+ * @param pm Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
- * @param cfg The address to the structure containing the
+ * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
  * @param prio The initialization level at which configuration occurs.
  * @param api Provides an initial pointer to the API function struct
  * used by the driver. Can be NULL.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define ETH_NET_DEVICE_INIT(dev_id, drv_name, init_fn, pm_action_cb,	\
-			    data, cfg, prio, api, mtu)			\
-	Z_ETH_NET_DEVICE_INIT(DT_INVALID_NODE, dev_id, drv_name,	\
-			      init_fn, pm_action_cb, data, cfg, prio,	\
-			      api, mtu)
+#define ETH_NET_DEVICE_INIT(dev_id, name, init_fn, pm, data, config,	\
+			    prio, api, mtu)				\
+	Z_ETH_NET_DEVICE_INIT(DT_INVALID_NODE, dev_id, name, init_fn,	\
+			      pm, data, config, prio, api, mtu)
 
 /**
  * @brief Like ETH_NET_DEVICE_INIT but taking metadata from a devicetree.
@@ -883,22 +881,21 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  *
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_action_cb Pointer to PM action callback.
+ * @param pm Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
- * @param cfg The address to the structure containing the
+ * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
  * @param prio The initialization level at which configuration occurs.
  * @param api Provides an initial pointer to the API function struct
  * used by the driver. Can be NULL.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define ETH_NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_action_cb, data,	\
-			       cfg, prio, api, mtu)			\
+#define ETH_NET_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config,	\
+				 prio, api, mtu)			\
 	Z_ETH_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
-			      DEVICE_DT_NAME(node_id),			\
-			      init_fn, pm_action_cb, data, cfg, prio,	\
-			      api, mtu)
+			      DEVICE_DT_NAME(node_id), init_fn, pm,	\
+			      data, config, prio, api, mtu)
 
 /**
  * @brief Like ETH_NET_DEVICE_DT_DEFINE for an instance of a DT_DRV_COMPAT

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -837,7 +837,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 #if defined(CONFIG_NET_VLAN)
 #define Z_ETH_NET_DEVICE_INIT(node_id, dev_id, name, init_fn, pm, data,	\
 			      config, prio, api, mtu)			\
-	Z_DEVICE_STATE_DEFINE(node_id, dev_id);				\
+	Z_DEVICE_STATE_DEFINE(dev_id);					\
 	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn, pm, data,	\
 			config, POST_KERNEL, prio, api,			\
 			&Z_DEVICE_STATE_NAME(dev_id));			\

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -860,8 +860,8 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  * @param name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm Pointer to PM action callback.
- * Can be NULL if not implemented.
+ * @param pm Reference to struct pm_device associated with the device.
+ * (optional).
  * @param data Pointer to the device's private data.
  * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
@@ -881,8 +881,8 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  *
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm Pointer to PM action callback.
- * Can be NULL if not implemented.
+ * @param pm Reference to struct pm_device associated with the device.
+ * (optional).
  * @param data Pointer to the device's private data.
  * @param config The address to the structure containing the
  * configuration information for this instance of the driver.

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -835,20 +835,20 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 #endif
 
 #if defined(CONFIG_NET_VLAN)
-#define Z_ETH_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,	\
+#define Z_ETH_NET_DEVICE_INIT(node_id, dev_id, drv_name, init_fn,	\
 			      pm_action_cb, data, cfg, prio, api, mtu)	\
-	Z_DEVICE_STATE_DEFINE(node_id, dev_name);			\
-	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
+	Z_DEVICE_STATE_DEFINE(node_id, dev_id);				\
+	Z_DEVICE_DEFINE(node_id, dev_id, drv_name, init_fn,		\
 			pm_action_cb, data, cfg, POST_KERNEL,		\
-			prio, api, &Z_DEVICE_STATE_NAME(dev_name));	\
-	NET_L2_DATA_INIT(dev_name, 0, NET_L2_GET_CTX_TYPE(ETHERNET_L2));\
-	NET_IF_INIT(dev_name, 0, ETHERNET_L2, mtu, NET_VLAN_MAX_COUNT)
+			prio, api, &Z_DEVICE_STATE_NAME(dev_id));	\
+	NET_L2_DATA_INIT(dev_id, 0, NET_L2_GET_CTX_TYPE(ETHERNET_L2));	\
+	NET_IF_INIT(dev_id, 0, ETHERNET_L2, mtu, NET_VLAN_MAX_COUNT)
 
 #else /* CONFIG_NET_VLAN */
 
-#define Z_ETH_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,	\
+#define Z_ETH_NET_DEVICE_INIT(node_id, dev_id, drv_name, init_fn,	\
 			      pm_action_cb, data, cfg, prio, api, mtu)	\
-	Z_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,		\
+	Z_NET_DEVICE_INIT(node_id, dev_id, drv_name, init_fn,		\
 			  pm_action_cb, data, cfg, prio, api,		\
 			  ETHERNET_L2, NET_L2_GET_CTX_TYPE(ETHERNET_L2),\
 			  mtu)
@@ -857,7 +857,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 /**
  * @brief Create an Ethernet network interface and bind it to network device.
  *
- * @param dev_name Network device name.
+ * @param dev_id Network device id.
  * @param drv_name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
@@ -871,9 +871,9 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  * used by the driver. Can be NULL.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define ETH_NET_DEVICE_INIT(dev_name, drv_name, init_fn, pm_action_cb,	\
+#define ETH_NET_DEVICE_INIT(dev_id, drv_name, init_fn, pm_action_cb,	\
 			    data, cfg, prio, api, mtu)			\
-	Z_ETH_NET_DEVICE_INIT(DT_INVALID_NODE, dev_name, drv_name,	\
+	Z_ETH_NET_DEVICE_INIT(DT_INVALID_NODE, dev_id, drv_name,	\
 			      init_fn, pm_action_cb, data, cfg, prio,	\
 			      api, mtu)
 

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -837,7 +837,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 #if defined(CONFIG_NET_VLAN)
 #define Z_ETH_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,	\
 			      pm_action_cb, data, cfg, prio, api, mtu)	\
-	Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
+	Z_DEVICE_STATE_DEFINE(node_id, dev_name);			\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
 			pm_action_cb, data, cfg, POST_KERNEL,		\
 			prio, api, &Z_DEVICE_STATE_NAME(dev_name));	\

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -893,7 +893,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  */
 #define ETH_NET_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config,	\
 				 prio, api, mtu)			\
-	Z_ETH_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
+	Z_ETH_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_ID(node_id),	\
 			      DEVICE_DT_NAME(node_id), init_fn, pm,	\
 			      data, config, prio, api, mtu)
 

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2316,7 +2316,7 @@ struct net_if_api {
 
 #define Z_NET_DEVICE_INIT(node_id, dev_id, name, init_fn, pm, data,	\
 			  config, prio, api, l2, l2_ctx_type, mtu)	\
-	Z_DEVICE_STATE_DEFINE(node_id, dev_id);				\
+	Z_DEVICE_STATE_DEFINE(dev_id);					\
 	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn, pm, data,	\
 			config, POST_KERNEL, prio, api,			\
 			&Z_DEVICE_STATE_NAME(dev_id));			\
@@ -2385,7 +2385,7 @@ struct net_if_api {
 #define Z_NET_DEVICE_INIT_INSTANCE(node_id, dev_id, name, instance,	\
 				   init_fn, pm, data, config, prio,	\
 				   api, l2, l2_ctx_type, mtu)		\
-	Z_DEVICE_STATE_DEFINE(node_id, dev_id);				\
+	Z_DEVICE_STATE_DEFINE(dev_id);					\
 	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn, pm, data,	\
 			config,	POST_KERNEL, prio, api,			\
 			&Z_DEVICE_STATE_NAME(dev_id));			\
@@ -2467,7 +2467,7 @@ struct net_if_api {
 
 #define Z_NET_DEVICE_OFFLOAD_INIT(node_id, dev_id, name, init_fn, pm,	\
 				  data, config, prio, api, mtu)		\
-	Z_DEVICE_STATE_DEFINE(node_id, dev_id);				\
+	Z_DEVICE_STATE_DEFINE(dev_id);					\
 	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn, pm, data,	\
 			config, POST_KERNEL, prio, api,			\
 			&Z_DEVICE_STATE_NAME(dev_id));			\

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2367,7 +2367,7 @@ struct net_if_api {
  */
 #define NET_DEVICE_DT_DEFINE(node_id, init_fn, pm, data,		\
 			     config, prio, api, l2, l2_ctx_type, mtu)	\
-	Z_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
+	Z_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_ID(node_id),	\
 			  DEVICE_DT_NAME(node_id), init_fn, pm, data,	\
 			  config, prio, api, l2, l2_ctx_type, mtu)
 
@@ -2448,7 +2448,7 @@ struct net_if_api {
 				      data, config, prio, api, l2,	\
 				      l2_ctx_type, mtu)			\
 	Z_NET_DEVICE_INIT_INSTANCE(node_id,				\
-				   Z_DEVICE_DT_DEV_NAME(node_id),	\
+				   Z_DEVICE_DT_DEV_ID(node_id),		\
 				   DEVICE_DT_NAME(node_id), instance,	\
 				   init_fn, pm, data, config, prio,	\
 				   api,	l2, l2_ctx_type, mtu)
@@ -2518,7 +2518,7 @@ struct net_if_api {
  */
 #define NET_DEVICE_DT_OFFLOAD_DEFINE(node_id, init_fn, pm, data,	\
 				     config, prio, api, mtu)		\
-	Z_NET_DEVICE_OFFLOAD_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id), \
+	Z_NET_DEVICE_OFFLOAD_INIT(node_id, Z_DEVICE_DT_DEV_ID(node_id), \
 				  DEVICE_DT_NAME(node_id), init_fn, pm, \
 				  data, config,	prio, api, mtu)
 

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2270,42 +2270,42 @@ struct net_if_api {
 		NET_IF_DHCPV4_INIT			\
 	}
 
-#define NET_IF_GET_NAME(dev_name, sfx) __net_if_##dev_name##_##sfx
-#define NET_IF_DEV_GET_NAME(dev_name, sfx) __net_if_dev_##dev_name##_##sfx
+#define NET_IF_GET_NAME(dev_id, sfx) __net_if_##dev_id##_##sfx
+#define NET_IF_DEV_GET_NAME(dev_id, sfx) __net_if_dev_##dev_id##_##sfx
 
-#define NET_IF_GET(dev_name, sfx)					\
-	((struct net_if *)&NET_IF_GET_NAME(dev_name, sfx))
+#define NET_IF_GET(dev_id, sfx)						\
+	((struct net_if *)&NET_IF_GET_NAME(dev_id, sfx))
 
-#define NET_IF_INIT(dev_name, sfx, _l2, _mtu, _num_configs)		\
+#define NET_IF_INIT(dev_id, sfx, _l2, _mtu, _num_configs)		\
 	static STRUCT_SECTION_ITERABLE(net_if_dev,			\
-				NET_IF_DEV_GET_NAME(dev_name, sfx)) = { \
-		.dev = &(DEVICE_NAME_GET(dev_name)),			\
+				NET_IF_DEV_GET_NAME(dev_id, sfx)) = {	\
+		.dev = &(DEVICE_NAME_GET(dev_id)),			\
 		.l2 = &(NET_L2_GET_NAME(_l2)),				\
-		.l2_data = &(NET_L2_GET_DATA(dev_name, sfx)),		\
+		.l2_data = &(NET_L2_GET_DATA(dev_id, sfx)),		\
 		.mtu = _mtu,						\
 	};								\
 	static Z_DECL_ALIGN(struct net_if)				\
-		       NET_IF_GET_NAME(dev_name, sfx)[_num_configs]	\
-		       __used __in_section(_net_if, static,             \
-					   dev_name) = {                \
+		       NET_IF_GET_NAME(dev_id, sfx)[_num_configs]	\
+		       __used __in_section(_net_if, static,		\
+					   dev_id) = {			\
 		[0 ... (_num_configs - 1)] = {				\
-			.if_dev = &(NET_IF_DEV_GET_NAME(dev_name, sfx)), \
+			.if_dev = &(NET_IF_DEV_GET_NAME(dev_id, sfx)),	\
 			NET_IF_CONFIG_INIT				\
 		}							\
 	}
 
-#define NET_IF_OFFLOAD_INIT(dev_name, sfx, _mtu)			\
+#define NET_IF_OFFLOAD_INIT(dev_id, sfx, _mtu)				\
 	static STRUCT_SECTION_ITERABLE(net_if_dev,			\
-				NET_IF_DEV_GET_NAME(dev_name, sfx)) = {	\
-		.dev = &(DEVICE_NAME_GET(dev_name)),			\
+				NET_IF_DEV_GET_NAME(dev_id, sfx)) = {	\
+		.dev = &(DEVICE_NAME_GET(dev_id)),			\
 		.mtu = _mtu,						\
 	};								\
 	static Z_DECL_ALIGN(struct net_if)				\
-		NET_IF_GET_NAME(dev_name, sfx)[NET_IF_MAX_CONFIGS]	\
-		       __used __in_section(_net_if, static,             \
-					   dev_name) = {                \
+		NET_IF_GET_NAME(dev_id, sfx)[NET_IF_MAX_CONFIGS]	\
+		       __used __in_section(_net_if, static,		\
+					   dev_id) = {			\
 		[0 ... (NET_IF_MAX_CONFIGS - 1)] = {			\
-			.if_dev = &(NET_IF_DEV_GET_NAME(dev_name, sfx)), \
+			.if_dev = &(NET_IF_DEV_GET_NAME(dev_id, sfx)),	\
 			NET_IF_CONFIG_INIT				\
 		}							\
 	}
@@ -2314,21 +2314,21 @@ struct net_if_api {
 
 /* Network device initialization macros */
 
-#define Z_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,		\
-			pm_action_cb, data, cfg, prio, api, l2,	\
+#define Z_NET_DEVICE_INIT(node_id, dev_id, drv_name, init_fn,		\
+			pm_action_cb, data, cfg, prio, api, l2,		\
 			l2_ctx_type, mtu)				\
-	Z_DEVICE_STATE_DEFINE(node_id, dev_name);			\
-	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
+	Z_DEVICE_STATE_DEFINE(node_id, dev_id);				\
+	Z_DEVICE_DEFINE(node_id, dev_id, drv_name, init_fn,		\
 			pm_action_cb, data,				\
 			cfg, POST_KERNEL, prio, api,			\
-			&Z_DEVICE_STATE_NAME(dev_name));		\
-	NET_L2_DATA_INIT(dev_name, 0, l2_ctx_type);			\
-	NET_IF_INIT(dev_name, 0, l2, mtu, NET_IF_MAX_CONFIGS)
+			&Z_DEVICE_STATE_NAME(dev_id));			\
+	NET_L2_DATA_INIT(dev_id, 0, l2_ctx_type);			\
+	NET_IF_INIT(dev_id, 0, l2, mtu, NET_IF_MAX_CONFIGS)
 
 /**
  * @brief Create a network interface and bind it to network device.
  *
- * @param dev_name Network device name.
+ * @param dev_id Network device id.
  * @param drv_name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
@@ -2344,11 +2344,11 @@ struct net_if_api {
  * @param l2_ctx_type Type of L2 context data.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_INIT(dev_name, drv_name, init_fn, pm_action_cb,	\
+#define NET_DEVICE_INIT(dev_id, drv_name, init_fn, pm_action_cb,	\
 			data, cfg, prio, api, l2,			\
 			l2_ctx_type, mtu)				\
-	Z_NET_DEVICE_INIT(DT_INVALID_NODE, dev_name, drv_name, init_fn,	\
-			pm_action_cb, data, cfg, prio, api, l2,	\
+	Z_NET_DEVICE_INIT(DT_INVALID_NODE, dev_id, drv_name, init_fn,	\
+			pm_action_cb, data, cfg, prio, api, l2,		\
 			l2_ctx_type, mtu)
 
 /**
@@ -2387,16 +2387,16 @@ struct net_if_api {
 #define NET_DEVICE_DT_INST_DEFINE(inst, ...) \
 	NET_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
-#define Z_NET_DEVICE_INIT_INSTANCE(node_id, dev_name, drv_name,		\
+#define Z_NET_DEVICE_INIT_INSTANCE(node_id, dev_id, drv_name,		\
 				   instance, init_fn, pm_action_cb,	\
 				   data, cfg, prio, api, l2,		\
 				   l2_ctx_type, mtu)			\
-	Z_DEVICE_STATE_DEFINE(node_id, dev_name);			\
-	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
+	Z_DEVICE_STATE_DEFINE(node_id, dev_id);				\
+	Z_DEVICE_DEFINE(node_id, dev_id, drv_name, init_fn,		\
 			pm_action_cb, data, cfg, POST_KERNEL,		\
-			prio, api, &Z_DEVICE_STATE_NAME(dev_name));	\
-	NET_L2_DATA_INIT(dev_name, instance, l2_ctx_type);		\
-	NET_IF_INIT(dev_name, instance, l2, mtu, NET_IF_MAX_CONFIGS)
+			prio, api, &Z_DEVICE_STATE_NAME(dev_id));	\
+	NET_L2_DATA_INIT(dev_id, instance, l2_ctx_type);		\
+	NET_IF_INIT(dev_id, instance, l2, mtu, NET_IF_MAX_CONFIGS)
 
 /**
  * @brief Create multiple network interfaces and bind them to network device.
@@ -2404,7 +2404,7 @@ struct net_if_api {
  * use this macro below and provide a different instance suffix each time
  * (0, 1, 2, ... or a, b, c ... whatever works for you)
  *
- * @param dev_name Network device name.
+ * @param dev_id Network device id.
  * @param drv_name The name this instance of the driver exposes to
  * the system.
  * @param instance Instance identifier.
@@ -2421,10 +2421,10 @@ struct net_if_api {
  * @param l2_ctx_type Type of L2 context data.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_INIT_INSTANCE(dev_name, drv_name, instance, init_fn,	\
-				 pm_action_cb, data, cfg, prio,	\
+#define NET_DEVICE_INIT_INSTANCE(dev_id, drv_name, instance, init_fn,	\
+				 pm_action_cb, data, cfg, prio,		\
 				 api, l2, l2_ctx_type, mtu)		\
-	Z_NET_DEVICE_INIT_INSTANCE(DT_INVALID_NODE, dev_name, drv_name,	\
+	Z_NET_DEVICE_INIT_INSTANCE(DT_INVALID_NODE, dev_id, drv_name,	\
 				   instance, init_fn, pm_action_cb,	\
 				   data, cfg, prio, api, l2,		\
 				   l2_ctx_type, mtu)
@@ -2473,21 +2473,21 @@ struct net_if_api {
 #define NET_DEVICE_DT_INST_DEFINE_INSTANCE(inst, ...) \
 	NET_DEVICE_DT_DEFINE_INSTANCE(DT_DRV_INST(inst), __VA_ARGS__)
 
-#define Z_NET_DEVICE_OFFLOAD_INIT(node_id, dev_name, drv_name, init_fn,	\
+#define Z_NET_DEVICE_OFFLOAD_INIT(node_id, dev_id, drv_name, init_fn,	\
 				  pm_action_cb, data, cfg, prio,	\
 				  api, mtu)				\
-	Z_DEVICE_STATE_DEFINE(node_id, dev_name);			\
-	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
+	Z_DEVICE_STATE_DEFINE(node_id, dev_id);				\
+	Z_DEVICE_DEFINE(node_id, dev_id, drv_name, init_fn,		\
 		pm_action_cb, data, cfg, POST_KERNEL, prio, api,	\
-		&Z_DEVICE_STATE_NAME(dev_name));			\
-	NET_IF_OFFLOAD_INIT(dev_name, 0, mtu)
+		&Z_DEVICE_STATE_NAME(dev_id));				\
+	NET_IF_OFFLOAD_INIT(dev_id, 0, mtu)
 
 /**
  * @brief Create a offloaded network interface and bind it to network device.
  * The offloaded network interface is implemented by a device vendor HAL or
  * similar.
  *
- * @param dev_name Network device name.
+ * @param dev_id Network device id.
  * @param drv_name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
@@ -2501,10 +2501,10 @@ struct net_if_api {
  * used by the driver. Can be NULL.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_OFFLOAD_INIT(dev_name, drv_name, init_fn,		\
+#define NET_DEVICE_OFFLOAD_INIT(dev_id, drv_name, init_fn,		\
 				pm_action_cb, data, cfg, prio, api, mtu)\
-	Z_NET_DEVICE_OFFLOAD_INIT(DT_INVALID_NODE, dev_name, drv_name,	\
-				init_fn, pm_action_cb, data, cfg, prio,\
+	Z_NET_DEVICE_OFFLOAD_INIT(DT_INVALID_NODE, dev_id, drv_name,	\
+				init_fn, pm_action_cb, data, cfg, prio,	\
 				api, mtu)
 
 /**

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2317,7 +2317,7 @@ struct net_if_api {
 #define Z_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,		\
 			pm_action_cb, data, cfg, prio, api, l2,	\
 			l2_ctx_type, mtu)				\
-	Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
+	Z_DEVICE_STATE_DEFINE(node_id, dev_name);			\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
 			pm_action_cb, data,				\
 			cfg, POST_KERNEL, prio, api,			\
@@ -2391,7 +2391,7 @@ struct net_if_api {
 				   instance, init_fn, pm_action_cb,	\
 				   data, cfg, prio, api, l2,		\
 				   l2_ctx_type, mtu)			\
-	Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
+	Z_DEVICE_STATE_DEFINE(node_id, dev_name);			\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
 			pm_action_cb, data, cfg, POST_KERNEL,		\
 			prio, api, &Z_DEVICE_STATE_NAME(dev_name));	\
@@ -2476,7 +2476,7 @@ struct net_if_api {
 #define Z_NET_DEVICE_OFFLOAD_INIT(node_id, dev_name, drv_name, init_fn,	\
 				  pm_action_cb, data, cfg, prio,	\
 				  api, mtu)				\
-	Z_DEVICE_STATE_DEFINE(node_id, dev_name)			\
+	Z_DEVICE_STATE_DEFINE(node_id, dev_name);			\
 	Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn,		\
 		pm_action_cb, data, cfg, POST_KERNEL, prio, api,	\
 		&Z_DEVICE_STATE_NAME(dev_name));			\

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2330,8 +2330,8 @@ struct net_if_api {
  * @param name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm Pointer to PM action callback.
- * Can be NULL if not implemented.
+ * @param pm Reference to struct pm_device associated with the device.
+ * (optional).
  * @param data Pointer to the device's private data.
  * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
@@ -2353,8 +2353,8 @@ struct net_if_api {
  *
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm Pointer to PM action callback.
- * Can be NULL if not implemented.
+ * @param pm Reference to struct pm_device associated with the device.
+ * (optional).
  * @param data Pointer to the device's private data.
  * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
@@ -2403,8 +2403,8 @@ struct net_if_api {
  * the system.
  * @param instance Instance identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm Pointer to PM action callback.
- * Can be NULL if not implemented.
+ * @param pm Reference to struct pm_device associated with the device.
+ * (optional).
  * @param data Pointer to the device's private data.
  * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
@@ -2432,8 +2432,8 @@ struct net_if_api {
  * @param node_id The devicetree node identifier.
  * @param instance Instance identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm Pointer to PM action callback.
- * Can be NULL if not implemented.
+ * @param pm Reference to struct pm_device associated with the device.
+ * (optional).
  * @param data Pointer to the device's private data.
  * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
@@ -2482,8 +2482,8 @@ struct net_if_api {
  * @param name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm Pointer to PM action callback.
- * Can be NULL if not implemented.
+ * @param pm Reference to struct pm_device associated with the device.
+ * (optional).
  * @param data Pointer to the device's private data.
  * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
@@ -2506,8 +2506,8 @@ struct net_if_api {
  *
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm Pointer to PM action callback.
- * Can be NULL if not implemented.
+ * @param pm Reference to struct pm_device associated with the device.
+ * (optional).
  * @param data Pointer to the device's private data.
  * @param config The address to the structure containing the
  * configuration information for this instance of the driver.

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2314,13 +2314,11 @@ struct net_if_api {
 
 /* Network device initialization macros */
 
-#define Z_NET_DEVICE_INIT(node_id, dev_id, drv_name, init_fn,		\
-			pm_action_cb, data, cfg, prio, api, l2,		\
-			l2_ctx_type, mtu)				\
+#define Z_NET_DEVICE_INIT(node_id, dev_id, name, init_fn, pm, data,	\
+			  config, prio, api, l2, l2_ctx_type, mtu)	\
 	Z_DEVICE_STATE_DEFINE(node_id, dev_id);				\
-	Z_DEVICE_DEFINE(node_id, dev_id, drv_name, init_fn,		\
-			pm_action_cb, data,				\
-			cfg, POST_KERNEL, prio, api,			\
+	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn, pm, data,	\
+			config, POST_KERNEL, prio, api,			\
 			&Z_DEVICE_STATE_NAME(dev_id));			\
 	NET_L2_DATA_INIT(dev_id, 0, l2_ctx_type);			\
 	NET_IF_INIT(dev_id, 0, l2, mtu, NET_IF_MAX_CONFIGS)
@@ -2329,13 +2327,13 @@ struct net_if_api {
  * @brief Create a network interface and bind it to network device.
  *
  * @param dev_id Network device id.
- * @param drv_name The name this instance of the driver exposes to
+ * @param name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm_action_cb Pointer to PM action callback.
+ * @param pm Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
- * @param cfg The address to the structure containing the
+ * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
  * @param prio The initialization level at which configuration occurs.
  * @param api Provides an initial pointer to the API function struct
@@ -2344,12 +2342,10 @@ struct net_if_api {
  * @param l2_ctx_type Type of L2 context data.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_INIT(dev_id, drv_name, init_fn, pm_action_cb,	\
-			data, cfg, prio, api, l2,			\
-			l2_ctx_type, mtu)				\
-	Z_NET_DEVICE_INIT(DT_INVALID_NODE, dev_id, drv_name, init_fn,	\
-			pm_action_cb, data, cfg, prio, api, l2,		\
-			l2_ctx_type, mtu)
+#define NET_DEVICE_INIT(dev_id, name, init_fn, pm, data, config, prio,	\
+			api, l2, l2_ctx_type, mtu)			\
+	Z_NET_DEVICE_INIT(DT_INVALID_NODE, dev_id, name, init_fn, pm,	\
+			  data, config, prio, api, l2, l2_ctx_type, mtu)
 
 /**
  * @brief Like NET_DEVICE_INIT but taking metadata from a devicetree node.
@@ -2357,10 +2353,10 @@ struct net_if_api {
  *
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_action_cb Pointer to PM action callback.
+ * @param pm Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
- * @param cfg The address to the structure containing the
+ * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
  * @param prio The initialization level at which configuration occurs.
  * @param api Provides an initial pointer to the API function struct
@@ -2369,12 +2365,11 @@ struct net_if_api {
  * @param l2_ctx_type Type of L2 context data.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_action_cb, data, cfg,	\
-			   prio, api, l2, l2_ctx_type, mtu)		\
+#define NET_DEVICE_DT_DEFINE(node_id, init_fn, pm, data,		\
+			     config, prio, api, l2, l2_ctx_type, mtu)	\
 	Z_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
-			  DEVICE_DT_NAME(node_id), init_fn,		\
-			  pm_action_cb, data, cfg, prio, api, l2,	\
-			  l2_ctx_type, mtu)
+			  DEVICE_DT_NAME(node_id), init_fn, pm, data,	\
+			  config, prio, api, l2, l2_ctx_type, mtu)
 
 /**
  * @brief Like NET_DEVICE_DT_DEFINE for an instance of a DT_DRV_COMPAT compatible
@@ -2387,14 +2382,13 @@ struct net_if_api {
 #define NET_DEVICE_DT_INST_DEFINE(inst, ...) \
 	NET_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
-#define Z_NET_DEVICE_INIT_INSTANCE(node_id, dev_id, drv_name,		\
-				   instance, init_fn, pm_action_cb,	\
-				   data, cfg, prio, api, l2,		\
-				   l2_ctx_type, mtu)			\
+#define Z_NET_DEVICE_INIT_INSTANCE(node_id, dev_id, name, instance,	\
+				   init_fn, pm, data, config, prio,	\
+				   api, l2, l2_ctx_type, mtu)		\
 	Z_DEVICE_STATE_DEFINE(node_id, dev_id);				\
-	Z_DEVICE_DEFINE(node_id, dev_id, drv_name, init_fn,		\
-			pm_action_cb, data, cfg, POST_KERNEL,		\
-			prio, api, &Z_DEVICE_STATE_NAME(dev_id));	\
+	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn, pm, data,	\
+			config,	POST_KERNEL, prio, api,			\
+			&Z_DEVICE_STATE_NAME(dev_id));			\
 	NET_L2_DATA_INIT(dev_id, instance, l2_ctx_type);		\
 	NET_IF_INIT(dev_id, instance, l2, mtu, NET_IF_MAX_CONFIGS)
 
@@ -2405,14 +2399,14 @@ struct net_if_api {
  * (0, 1, 2, ... or a, b, c ... whatever works for you)
  *
  * @param dev_id Network device id.
- * @param drv_name The name this instance of the driver exposes to
+ * @param name The name this instance of the driver exposes to
  * the system.
  * @param instance Instance identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_action_cb Pointer to PM action callback.
+ * @param pm Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
- * @param cfg The address to the structure containing the
+ * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
  * @param prio The initialization level at which configuration occurs.
  * @param api Provides an initial pointer to the API function struct
@@ -2421,13 +2415,12 @@ struct net_if_api {
  * @param l2_ctx_type Type of L2 context data.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_INIT_INSTANCE(dev_id, drv_name, instance, init_fn,	\
-				 pm_action_cb, data, cfg, prio,		\
-				 api, l2, l2_ctx_type, mtu)		\
-	Z_NET_DEVICE_INIT_INSTANCE(DT_INVALID_NODE, dev_id, drv_name,	\
-				   instance, init_fn, pm_action_cb,	\
-				   data, cfg, prio, api, l2,		\
-				   l2_ctx_type, mtu)
+#define NET_DEVICE_INIT_INSTANCE(dev_id, name, instance, init_fn, pm,	\
+				 data, config, prio, api, l2,		\
+				 l2_ctx_type, mtu)			\
+	Z_NET_DEVICE_INIT_INSTANCE(DT_INVALID_NODE, dev_id, name,	\
+				   instance, init_fn, pm, data, config,	\
+				   prio, api, l2, l2_ctx_type, mtu)
 
 /**
  * @brief Like NET_DEVICE_OFFLOAD_INIT but taking metadata from a devicetree.
@@ -2439,10 +2432,10 @@ struct net_if_api {
  * @param node_id The devicetree node identifier.
  * @param instance Instance identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_action_cb Pointer to PM action callback.
+ * @param pm Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
- * @param cfg The address to the structure containing the
+ * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
  * @param prio The initialization level at which configuration occurs.
  * @param api Provides an initial pointer to the API function struct
@@ -2451,15 +2444,14 @@ struct net_if_api {
  * @param l2_ctx_type Type of L2 context data.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_DT_DEFINE_INSTANCE(node_id, instance, init_fn,	\
-				      pm_action_cb, data, cfg, prio,	\
-				      api, l2, l2_ctx_type, mtu)	\
+#define NET_DEVICE_DT_DEFINE_INSTANCE(node_id, instance, init_fn, pm,	\
+				      data, config, prio, api, l2,	\
+				      l2_ctx_type, mtu)			\
 	Z_NET_DEVICE_INIT_INSTANCE(node_id,				\
 				   Z_DEVICE_DT_DEV_NAME(node_id),	\
-				   DEVICE_DT_NAME(node_id),		\
-				   instance, init_fn,			\
-				   pm_action_cb, data, cfg, prio, api,	\
-				   l2, l2_ctx_type, mtu)
+				   DEVICE_DT_NAME(node_id), instance,	\
+				   init_fn, pm, data, config, prio,	\
+				   api,	l2, l2_ctx_type, mtu)
 
 /**
  * @brief Like NET_DEVICE_DT_DEFINE_INSTANCE for an instance of a DT_DRV_COMPAT
@@ -2473,13 +2465,12 @@ struct net_if_api {
 #define NET_DEVICE_DT_INST_DEFINE_INSTANCE(inst, ...) \
 	NET_DEVICE_DT_DEFINE_INSTANCE(DT_DRV_INST(inst), __VA_ARGS__)
 
-#define Z_NET_DEVICE_OFFLOAD_INIT(node_id, dev_id, drv_name, init_fn,	\
-				  pm_action_cb, data, cfg, prio,	\
-				  api, mtu)				\
+#define Z_NET_DEVICE_OFFLOAD_INIT(node_id, dev_id, name, init_fn, pm,	\
+				  data, config, prio, api, mtu)		\
 	Z_DEVICE_STATE_DEFINE(node_id, dev_id);				\
-	Z_DEVICE_DEFINE(node_id, dev_id, drv_name, init_fn,		\
-		pm_action_cb, data, cfg, POST_KERNEL, prio, api,	\
-		&Z_DEVICE_STATE_NAME(dev_id));				\
+	Z_DEVICE_DEFINE(node_id, dev_id, name, init_fn, pm, data,	\
+			config, POST_KERNEL, prio, api,			\
+			&Z_DEVICE_STATE_NAME(dev_id));			\
 	NET_IF_OFFLOAD_INIT(dev_id, 0, mtu)
 
 /**
@@ -2488,24 +2479,24 @@ struct net_if_api {
  * similar.
  *
  * @param dev_id Network device id.
- * @param drv_name The name this instance of the driver exposes to
+ * @param name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm_action_cb Pointer to PM action callback.
+ * @param pm Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
- * @param cfg The address to the structure containing the
+ * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
  * @param prio The initialization level at which configuration occurs.
  * @param api Provides an initial pointer to the API function struct
  * used by the driver. Can be NULL.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_OFFLOAD_INIT(dev_id, drv_name, init_fn,		\
-				pm_action_cb, data, cfg, prio, api, mtu)\
-	Z_NET_DEVICE_OFFLOAD_INIT(DT_INVALID_NODE, dev_id, drv_name,	\
-				init_fn, pm_action_cb, data, cfg, prio,	\
-				api, mtu)
+#define NET_DEVICE_OFFLOAD_INIT(dev_id, name, init_fn, pm, data,	\
+				config,	prio, api, mtu)			\
+	Z_NET_DEVICE_OFFLOAD_INIT(DT_INVALID_NODE, dev_id, name,	\
+				  init_fn, pm, data, config, prio, api,	\
+				  mtu)
 
 /**
  * @brief Like NET_DEVICE_OFFLOAD_INIT but taking metadata from a devicetree
@@ -2515,22 +2506,21 @@ struct net_if_api {
  *
  * @param node_id The devicetree node identifier.
  * @param init_fn Address to the init function of the driver.
- * @param pm_action_cb Pointer to PM action callback.
+ * @param pm Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
- * @param cfg The address to the structure containing the
+ * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
  * @param prio The initialization level at which configuration occurs.
  * @param api Provides an initial pointer to the API function struct
  * used by the driver. Can be NULL.
  * @param mtu Maximum transfer unit in bytes for this network interface.
  */
-#define NET_DEVICE_DT_OFFLOAD_DEFINE(node_id, init_fn, pm_action_cb,	\
-				   data, cfg, prio, api, mtu)		\
+#define NET_DEVICE_DT_OFFLOAD_DEFINE(node_id, init_fn, pm, data,	\
+				     config, prio, api, mtu)		\
 	Z_NET_DEVICE_OFFLOAD_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id), \
-				  DEVICE_DT_NAME(node_id),		\
-				  init_fn, pm_action_cb, data, cfg,	\
-				  prio, api, mtu)
+				  DEVICE_DT_NAME(node_id), init_fn, pm, \
+				  data, config,	prio, api, mtu)
 
 /**
  * @brief Like NET_DEVICE_DT_OFFLOAD_DEFINE for an instance of a DT_DRV_COMPAT

--- a/include/zephyr/net/virtual.h
+++ b/include/zephyr/net/virtual.h
@@ -273,13 +273,11 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
 	return virt->get_capabilities(iface);
 }
 
-#define Z_NET_VIRTUAL_INTERFACE_INIT(node_id, dev_id, drv_name,		\
-				     init_fn, pm_action_cb, data, cfg,	\
-				     prio, api, mtu)			\
-	Z_NET_DEVICE_INIT(node_id, dev_id, drv_name, init_fn,		\
-			  pm_action_cb, data, cfg, prio, api,		\
-			  VIRTUAL_L2, NET_L2_GET_CTX_TYPE(VIRTUAL_L2),	\
-			  mtu)
+#define Z_NET_VIRTUAL_INTERFACE_INIT(node_id, dev_id, name, init_fn,	\
+				     pm, data, config, prio, api, mtu)	\
+	Z_NET_DEVICE_INIT(node_id, dev_id, name, init_fn, pm, data,	\
+			  config, prio, api, VIRTUAL_L2,		\
+			  NET_L2_GET_CTX_TYPE(VIRTUAL_L2), mtu)
 /** @endcond */
 
 /**
@@ -289,13 +287,13 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
  *        when peer IP address is set in IP tunneling driver.
  *
  * @param dev_id Network device id.
- * @param drv_name The name this instance of the driver exposes to
+ * @param name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm_action_cb Pointer to PM action callback.
+ * @param pm Pointer to PM action callback.
  * Can be NULL if not implemented.
  * @param data Pointer to the device's private data.
- * @param cfg The address to the structure containing the
+ * @param config The address to the structure containing the
  * configuration information for this instance of the driver.
  * @param prio The initialization level at which configuration occurs.
  * @param api Provides an initial pointer to the API function struct
@@ -303,12 +301,11 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
  * @param mtu Maximum transfer unit in bytes for this network interface.
  * This is the default value and its value can be tweaked at runtime.
  */
-#define NET_VIRTUAL_INTERFACE_INIT(dev_id, drv_name, init_fn,		\
-				   pm_action_cb,			\
-				   data, cfg, prio, api, mtu)		\
-	Z_NET_VIRTUAL_INTERFACE_INIT(DT_INVALID_NODE, dev_id,		\
-				     drv_name, init_fn, pm_action_cb,	\
-				     data, cfg, prio, api, mtu)
+#define NET_VIRTUAL_INTERFACE_INIT(dev_id, name, init_fn, pm, data,	\
+				   config, prio, api, mtu)		\
+	Z_NET_VIRTUAL_INTERFACE_INIT(DT_INVALID_NODE, dev_id, name,	\
+				     init_fn, pm, data, config, prio,	\
+				     api, mtu)
 
 /**
  * @}

--- a/include/zephyr/net/virtual.h
+++ b/include/zephyr/net/virtual.h
@@ -290,8 +290,8 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
  * @param name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
- * @param pm Pointer to PM action callback.
- * Can be NULL if not implemented.
+ * @param pm Reference to struct pm_device associated with the device.
+ * (optional).
  * @param data Pointer to the device's private data.
  * @param config The address to the structure containing the
  * configuration information for this instance of the driver.

--- a/include/zephyr/net/virtual.h
+++ b/include/zephyr/net/virtual.h
@@ -273,10 +273,10 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
 	return virt->get_capabilities(iface);
 }
 
-#define Z_NET_VIRTUAL_INTERFACE_INIT(node_id, dev_name, drv_name,	\
-				     init_fn, pm_action_cb, data, cfg, \
+#define Z_NET_VIRTUAL_INTERFACE_INIT(node_id, dev_id, drv_name,		\
+				     init_fn, pm_action_cb, data, cfg,	\
 				     prio, api, mtu)			\
-	Z_NET_DEVICE_INIT(node_id, dev_name, drv_name, init_fn,		\
+	Z_NET_DEVICE_INIT(node_id, dev_id, drv_name, init_fn,		\
 			  pm_action_cb, data, cfg, prio, api,		\
 			  VIRTUAL_L2, NET_L2_GET_CTX_TYPE(VIRTUAL_L2),	\
 			  mtu)
@@ -288,7 +288,7 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
  *        The attaching is done automatically when setting up tunneling
  *        when peer IP address is set in IP tunneling driver.
  *
- * @param dev_name Network device name.
+ * @param dev_id Network device id.
  * @param drv_name The name this instance of the driver exposes to
  * the system.
  * @param init_fn Address to the init function of the driver.
@@ -303,10 +303,10 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
  * @param mtu Maximum transfer unit in bytes for this network interface.
  * This is the default value and its value can be tweaked at runtime.
  */
-#define NET_VIRTUAL_INTERFACE_INIT(dev_name, drv_name, init_fn,		\
+#define NET_VIRTUAL_INTERFACE_INIT(dev_id, drv_name, init_fn,		\
 				   pm_action_cb,			\
 				   data, cfg, prio, api, mtu)		\
-	Z_NET_VIRTUAL_INTERFACE_INIT(DT_INVALID_NODE, dev_name,		\
+	Z_NET_VIRTUAL_INTERFACE_INIT(DT_INVALID_NODE, dev_id,		\
 				     drv_name, init_fn, pm_action_cb,	\
 				     data, cfg, prio, api, mtu)
 

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -260,7 +260,7 @@ struct pm_device {
  * @see #PM_DEVICE_DT_INST_DEFINE, #PM_DEVICE_DEFINE
  */
 #define PM_DEVICE_DT_DEFINE(node_id, pm_action_cb)			\
-	Z_PM_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
+	Z_PM_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),	\
 			   pm_action_cb)
 
 /**
@@ -275,7 +275,7 @@ struct pm_device {
  */
 #define PM_DEVICE_DT_INST_DEFINE(idx, pm_action_cb)			\
 	Z_PM_DEVICE_DEFINE(DT_DRV_INST(idx),				\
-			   Z_DEVICE_DT_DEV_NAME(DT_DRV_INST(idx)),	\
+			   Z_DEVICE_DT_DEV_ID(DT_DRV_INST(idx)),	\
 			   pm_action_cb)
 
 /**
@@ -298,7 +298,7 @@ struct pm_device {
  * @kconfig{CONFIG_PM_DEVICE} is disabled).
  */
 #define PM_DEVICE_DT_GET(node_id) \
-	PM_DEVICE_GET(Z_DEVICE_DT_DEV_NAME(node_id))
+	PM_DEVICE_GET(Z_DEVICE_DT_DEV_ID(node_id))
 
 /**
  * @brief Obtain a reference to the device PM resources for the given instance.

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -188,9 +188,9 @@ struct pm_device {
 /**
  * Get the name of device PM resources.
  *
- * @param dev_name Device name.
+ * @param dev_id Device id.
  */
-#define Z_PM_DEVICE_NAME(dev_name) _CONCAT(__pm_device_, dev_name)
+#define Z_PM_DEVICE_NAME(dev_id) _CONCAT(__pm_device_, dev_id)
 
 /**
  * @brief Define device PM slot.
@@ -201,11 +201,11 @@ struct pm_device {
  * is used internally by the PM subsystem to keep track of suspended devices
  * during system power transitions.
  *
- * @param dev_name Device name.
+ * @param dev_id Device id.
  */
-#define Z_PM_DEVICE_DEFINE_SLOT(dev_name)				\
+#define Z_PM_DEVICE_DEFINE_SLOT(dev_id)					\
 	static const Z_DECL_ALIGN(struct device *)			\
-	_CONCAT(__pm_slot_, dev_name) __used				\
+	_CONCAT(__pm_slot_, dev_id) __used				\
 	__attribute__((__section__(".z_pm_device_slots")))
 
 #ifdef CONFIG_PM_DEVICE
@@ -213,25 +213,25 @@ struct pm_device {
  * Define device PM resources for the given node identifier.
  *
  * @param node_id Node identifier (DT_INVALID_NODE if not a DT device).
- * @param dev_name Device name.
+ * @param dev_id Device id.
  * @param pm_action_cb PM control callback.
  */
-#define Z_PM_DEVICE_DEFINE(node_id, dev_name, pm_action_cb)		\
-	Z_PM_DEVICE_DEFINE_SLOT(dev_name);				\
-	static struct pm_device Z_PM_DEVICE_NAME(dev_name) =		\
-	Z_PM_DEVICE_INIT(Z_PM_DEVICE_NAME(dev_name), node_id,		\
+#define Z_PM_DEVICE_DEFINE(node_id, dev_id, pm_action_cb)		\
+	Z_PM_DEVICE_DEFINE_SLOT(dev_id);				\
+	static struct pm_device Z_PM_DEVICE_NAME(dev_id) =		\
+	Z_PM_DEVICE_INIT(Z_PM_DEVICE_NAME(dev_id), node_id,		\
 			 pm_action_cb)
 
 /**
  * Get a reference to the device PM resources.
  *
- * @param dev_name Device name.
+ * @param dev_id Device id.
  */
-#define Z_PM_DEVICE_GET(dev_name) (&Z_PM_DEVICE_NAME(dev_name))
+#define Z_PM_DEVICE_GET(dev_id) (&Z_PM_DEVICE_NAME(dev_id))
 
 #else
-#define Z_PM_DEVICE_DEFINE(node_id, dev_name, pm_action_cb)
-#define Z_PM_DEVICE_GET(dev_name) NULL
+#define Z_PM_DEVICE_DEFINE(node_id, dev_id, pm_action_cb)
+#define Z_PM_DEVICE_GET(dev_id) NULL
 #endif /* CONFIG_PM_DEVICE */
 
 /** @endcond */
@@ -241,13 +241,13 @@ struct pm_device {
  *
  * @note This macro is a no-op if @kconfig{CONFIG_PM_DEVICE} is not enabled.
  *
- * @param dev_name Device name.
+ * @param dev_id Device id.
  * @param pm_action_cb PM control callback.
  *
  * @see #PM_DEVICE_DT_DEFINE, #PM_DEVICE_DT_INST_DEFINE
  */
-#define PM_DEVICE_DEFINE(dev_name, pm_action_cb) \
-	Z_PM_DEVICE_DEFINE(DT_INVALID_NODE, dev_name, pm_action_cb)
+#define PM_DEVICE_DEFINE(dev_id, pm_action_cb) \
+	Z_PM_DEVICE_DEFINE(DT_INVALID_NODE, dev_id, pm_action_cb)
 
 /**
  * Define device PM resources for the given node identifier.
@@ -281,13 +281,13 @@ struct pm_device {
 /**
  * @brief Obtain a reference to the device PM resources for the given device.
  *
- * @param dev_name Device name.
+ * @param dev_id Device id.
  *
  * @return Reference to the device PM resources (NULL if device
  * @kconfig{CONFIG_PM_DEVICE} is disabled).
  */
-#define PM_DEVICE_GET(dev_name) \
-	Z_PM_DEVICE_GET(dev_name)
+#define PM_DEVICE_GET(dev_id) \
+	Z_PM_DEVICE_GET(dev_id)
 
 /**
  * @brief Obtain a reference to the device PM resources for the given node.


### PR DESCRIPTION
`device.h` is often hard to read due to the amount of _macrology_. This PR tries to improve the header a little bit by adding some more auxiliary macros, making in particular `Z_DEVICE_DEFINE` less cluttered. Some documentation has been added for such macros, some names have been shortened or improved, etc.

Note: please review on a per-commit basis.

This is a first round of cleanups to make device model changes/experiments easier. Note that this PR should not introduce any functional changes, if it does, I've missed something.