### PR TITLE
soc: intel_adsp/ace: fix condition to check core power bit

### DIFF
--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -113,7 +113,7 @@ int soc_adsp_halt_cpu(int id)
 		return -EINVAL;
 	}
 
-	CHECKIF(soc_cpus_active[id]) {
+	CHECKIF(!soc_cpus_active[id]) {
 		return -EINVAL;
 	}
 
@@ -130,6 +130,9 @@ int soc_adsp_halt_cpu(int id)
 		__ASSERT(false, "%s secondary core has not powered down", __func__);
 		return -EINVAL;
 	}
+
+	/* Stop sending IPIs to this core */
+	soc_cpus_active[id] = false;
 
 	return 0;
 }


### PR DESCRIPTION
* The conditionals to check if the CPA bit is already set or cleared are incorrect. This results in the code always asserting. So fix those.
* The check for whether the CPU is already active before halting was incorrect. It should only fail if the CPU is not active, but the CHECKIF() conditional was inverted. So invert it.
* Also need to set the entry in the bookkeeping array to false once a CPU is considered powered down.
