### PR TITLE
Bluetooth: Mesh: Add missing adv_main for relay message

### DIFF
--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -321,6 +321,9 @@ void bt_mesh_adv_buf_relay_ready(void)
 			return;
 		}
 	}
+
+	/* Attempt to use the main adv set for the sending of relay messages. */
+	(void)schedule_send(&adv_main);
 }
 
 void bt_mesh_adv_init(void)


### PR DESCRIPTION
By design, adv main set can use to send relay mesh messages but here adv main set is not invoked.

Add in the ended, so, adv main set only can be used when all relay adv sets busy.

and this way does not cause too much delay for adv main set, due to local message will process firstly.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>