### PR TITLE
lib: picolibc: Use smaller default heap size

### DIFF
--- a/lib/libc/picolibc/Kconfig
+++ b/lib/libc/picolibc/Kconfig
@@ -10,8 +10,8 @@ config PICOLIBC_USE_MODULE
 
 config PICOLIBC_HEAP_SIZE
 	int "Picolibc heap size (bytes)"
-	default 1048576 if MMU
-	default 65536 if USERSPACE && MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
+	default 16384 if MMU
+	default 1024 if USERSPACE && MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 	default -1
 	help
 	  Indicates the amount of memory which will be used by the picolibc


### PR DESCRIPTION
The picolibc heap size configuration (`CONFIG_PICOLIBC_HEAP_SIZE`) is used to set the statically allocated malloc heap size when userspace is enabled.

The current default heap size of 1048576 bytes (MMU) and 65536 bytes (MPU) is too large for most platforms that Zephyr supports and may result in the picolibc tests being filtered out due to the increased memory footprint of the compiled image (i.e. SRAM overflow).

This commit updates the default picolibc heap size to a more reasonable 16384 bytes for MMU platforms and 1024 bytes for MPU platforms.

Signed-off-by: Stephanos Ioannidis <stephanos.ioannidis@nordicsemi.no>

Fixes #50841