### PR TITLE
manifest: Update trusted-firmware-m repository version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -235,7 +235,7 @@ manifest:
       groups:
         - debug
     - name: trusted-firmware-m
-      revision: 4c984817d861512edaeca27b83308e9b9915a98a
+      revision: 231235f26f5295ac4faf8c5617dbb9779869d821
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Updates TF-M to fix an issue to now force generation of version 4 DWARF files to prevent issues with pyelftools.

Fixes #50737