### PR TITLE
boards: stm32h735g_disco: Provide a working openocd configuration

### DIFF
--- a/boards/arm/stm32h735g_disco/support/openocd.cfg
+++ b/boards/arm/stm32h735g_disco/support/openocd.cfg
@@ -1,7 +1,30 @@
-source [find interface/stlink.cfg]
+source [find interface/stlink-dap.cfg]
+transport select dapdirect_swd
 
-transport select hla_swd
+set WORKAREASIZE 0x2000
+set CHIPNAME STM32H735IG
+set BOARDNAME STM23H735G_DK
 
 source [find target/stm32h7x.cfg]
 
-reset_config connect_assert_srst
+# Use connect_assert_srst here to be able to program
+# even when core is in sleep mode
+reset_config srst_only srst_nogate connect_assert_srst
+
+$_CHIPNAME.cpu0 configure -event gdb-attach {
+        echo "Debugger attaching: halting execution"
+        gdb_breakpoint_override hard
+}
+
+$_CHIPNAME.cpu0 configure -event gdb-detach {
+        echo "Debugger detaching: resuming execution"
+        resume
+}
+
+# Due to the use of connect_assert_srst, running gdb requires
+# to reset halt just after openocd init.
+rename init old_init
+proc init {} {
+        old_init
+        reset halt
+}


### PR DESCRIPTION
Openocd configuration for this board was broken. Fix it. Tested on both SDK 0.15.0 and SDK 0.15.1-RC1.
Debug is also functional

Fixes #50306

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>