### PR TITLE
gpio/espi: Fix manage_callback() logic

### DIFF
--- a/drivers/espi/espi_utils.h
+++ b/drivers/espi/espi_utils.h
@@ -32,6 +32,8 @@ static inline int espi_manage_callback(sys_slist_t *callbacks,
 				return -EINVAL;
 			}
 		}
+	} else if (!set) {
+		return -EINVAL;
 	}
 
 	if (set) {

--- a/drivers/gpio/gpio_utils.h
+++ b/drivers/gpio/gpio_utils.h
@@ -51,6 +51,8 @@ static inline int gpio_manage_callback(sys_slist_t *callbacks,
 				return -EINVAL;
 			}
 		}
+	} else if (!set) {
+		return -EINVAL;
 	}
 
 	if (set) {


### PR DESCRIPTION
*_manage_callback() returns -EINVAL if it could not remove callback. However if the list is empty success is returned when trying to remove callback.
Discovered this while testing my callback API similar to these.