### PR TITLE
drivers: pwm: Channel > 1 not working on rp2040 (Raspberry Pi Pico)

### DIFF
--- a/drivers/pwm/pwm_rpi_pico.c
+++ b/drivers/pwm/pwm_rpi_pico.c
@@ -113,7 +113,7 @@ static int pwm_rpi_set_cycles(const struct device *dev, uint32_t ch, uint32_t pe
 	pwm_rpi_set_channel_polarity(dev, slice, pico_channel,
 				     (flags & PWM_POLARITY_MASK) == PWM_POLARITY_INVERTED);
 	pwm_set_wrap(slice, period_cycles);
-	pwm_set_chan_level(slice, ch, pulse_cycles);
+	pwm_set_chan_level(slice, pico_channel, pulse_cycles);
 
 	return 0;
 };


### PR DESCRIPTION
pwm_set_chan_level uses slice channels A(=0) or B(=1) and not Zephyr channel (0..15). So PWM doesn't work for channels > 1. There is already a function (pwm_rpi_channel_to_pico_channel) which does the right thing, but it isn't used for pwm_set_chan_level.