### PR TITLE
drivers: pwm: Use a common initialization priority

### DIFF
--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -14,6 +14,12 @@ module = PWM
 module-str = pwm
 source "subsys/logging/Kconfig.template.log_config"
 
+config PWM_INIT_PRIORITY
+	int "PWM initialization priority"
+	default KERNEL_INIT_PRIORITY_DEVICE
+	help
+	  System initialization priority for PWM drivers.
+
 config PWM_SHELL
 	bool "PWM shell"
 	default y

--- a/drivers/pwm/Kconfig.sifive
+++ b/drivers/pwm/Kconfig.sifive
@@ -3,16 +3,9 @@
 # Copyright (c) 2018 SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig PWM_SIFIVE
+config PWM_SIFIVE
 	bool "SiFive Freedom PWM driver"
 	default y
 	depends on DT_HAS_SIFIVE_PWM0_ENABLED
 	help
 	  Enable the PWM driver for the SiFive Freedom platform
-
-config PWM_SIFIVE_INIT_PRIORITY
-	int "Init Priority"
-	default KERNEL_INIT_PRIORITY_DEVICE
-	depends on PWM_SIFIVE
-	help
-	  SiFive PWM Driver Initialization Priority

--- a/drivers/pwm/pwm_b91.c
+++ b/drivers/pwm/pwm_b91.c
@@ -134,7 +134,7 @@ static const struct pwm_driver_api pwm_b91_driver_api = {
 									       \
 	DEVICE_DT_INST_DEFINE(n, pwm_b91_init,				       \
 			      NULL, NULL, &config##n,			       \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			      POST_KERNEL, CONFIG_PWM_INIT_PRIORITY,	       \
 			      &pwm_b91_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_B91_INIT)

--- a/drivers/pwm/pwm_gd32.c
+++ b/drivers/pwm/pwm_gd32.c
@@ -204,7 +204,7 @@ static int pwm_gd32_init(const struct device *dev)
 									       \
 	DEVICE_DT_INST_DEFINE(i, &pwm_gd32_init, NULL, &pwm_gd32_data_##i,     \
 			      &pwm_gd32_config_##i, POST_KERNEL,	       \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	       \
+			      CONFIG_PWM_INIT_PRIORITY,			       \
 			      &pwm_gd32_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_GD32_DEFINE)

--- a/drivers/pwm/pwm_gecko.c
+++ b/drivers/pwm/pwm_gecko.c
@@ -112,7 +112,7 @@ static int pwm_gecko_init(const struct device *dev)
 										\
 	DEVICE_DT_INST_DEFINE(index, &pwm_gecko_init, NULL, NULL,		\
 				&pwm_gecko_config_##index, POST_KERNEL,		\
-				CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+				CONFIG_PWM_INIT_PRIORITY,			\
 				&pwm_gecko_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_GECKO_INIT)

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -169,7 +169,7 @@ static const struct pwm_driver_api imx_pwm_driver_api = {
 	DEVICE_DT_INST_DEFINE(n, &imx_pwm_init, NULL,			\
 			    &imx_pwm_data_##n,				\
 			    &imx_pwm_config_##n, POST_KERNEL,		\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_PWM_INIT_PRIORITY,			\
 			    &imx_pwm_driver_api);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(fsl_imx27_pwm)

--- a/drivers/pwm/pwm_ite_it8xxx2.c
+++ b/drivers/pwm/pwm_ite_it8xxx2.c
@@ -281,7 +281,7 @@ static const struct pwm_driver_api pwm_it8xxx2_api = {
 			      NULL,							\
 			      &pwm_it8xxx2_cfg_##inst,					\
 			      PRE_KERNEL_1,						\
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
+			      CONFIG_PWM_INIT_PRIORITY,					\
 			      &pwm_it8xxx2_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_IT8XXX2_INIT)

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -355,5 +355,5 @@ DEVICE_DT_INST_DEFINE(0, &pwm_led_esp32_init, NULL,
 			&pwm_ledc_esp32_data,
 			&pwm_ledc_esp32_config,
 			POST_KERNEL,
-			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+			CONFIG_PWM_INIT_PRIORITY,
 			&pwm_led_esp32_api);

--- a/drivers/pwm/pwm_mc_esp32.c
+++ b/drivers/pwm/pwm_mc_esp32.c
@@ -568,6 +568,6 @@ static const struct pwm_driver_api mcpwm_esp32_api = {
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(idx, &mcpwm_esp32_init, NULL, &mcpwm_esp32_data_##idx,               \
 			      &mcpwm_esp32_config_##idx, POST_KERNEL,                              \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &mcpwm_esp32_api);
+			      CONFIG_PWM_INIT_PRIORITY, &mcpwm_esp32_api);
 
 DT_INST_FOREACH_STATUS_OKAY(ESP32_MCPWM_INIT)

--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -425,7 +425,7 @@ static int pwm_xec_init(const struct device *dev)
 			      NULL,					\
 			      NULL,					\
 			      &pwm_xec_config_##index, POST_KERNEL,	\
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+			      CONFIG_PWM_INIT_PRIORITY,			\
 			      &pwm_xec_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(XEC_PWM_DEVICE_INIT)

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -205,7 +205,7 @@ static const struct pwm_driver_api pwm_mcux_driver_api = {
 			    NULL,					  \
 			    &pwm_mcux_data_ ## n,			  \
 			    &pwm_mcux_config_ ## n,			  \
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,\
+			    POST_KERNEL, CONFIG_PWM_INIT_PRIORITY,	  \
 			    &pwm_mcux_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_DEVICE_INIT_MCUX)

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -493,7 +493,7 @@ static const struct mcux_ftm_config mcux_ftm_config_##n = { \
 	DEVICE_DT_INST_DEFINE(n, &mcux_ftm_init,		       \
 			    NULL, &mcux_ftm_data_##n, \
 			    &mcux_ftm_config_##n, \
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			    POST_KERNEL, CONFIG_PWM_INIT_PRIORITY, \
 			    &mcux_ftm_driver_api); \
 	FTM_CONFIG_FUNC(n) \
 	FTM_INIT_CFG(n);

--- a/drivers/pwm/pwm_mcux_pwt.c
+++ b/drivers/pwm/pwm_mcux_pwt.c
@@ -343,7 +343,7 @@ static const struct pwm_driver_api mcux_pwt_driver_api = {
 			NULL, &mcux_pwt_data_##n,			\
 			&mcux_pwt_config_##n,				\
 			POST_KERNEL,					\
-			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			CONFIG_PWM_INIT_PRIORITY,			\
 			&mcux_pwt_driver_api);				\
 									\
 	static void mcux_pwt_config_func_##n(const struct device *dev)	\

--- a/drivers/pwm/pwm_mcux_sctimer.c
+++ b/drivers/pwm/pwm_mcux_sctimer.c
@@ -194,7 +194,7 @@ static const struct pwm_driver_api pwm_mcux_sctimer_driver_api = {
 			      NULL,							\
 			      &pwm_mcux_sctimer_data_##n,				\
 			      &pwm_mcux_sctimer_config_##n,				\
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			      POST_KERNEL, CONFIG_PWM_INIT_PRIORITY,			\
 			      &pwm_mcux_sctimer_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_MCUX_SCTIMER_DEVICE_INIT_MCUX)

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -203,7 +203,7 @@ static const struct pwm_driver_api mcux_tpm_driver_api = {
 	DEVICE_DT_INST_DEFINE(n, &mcux_tpm_init, NULL, \
 			    &mcux_tpm_data_##n, \
 			    &mcux_tpm_config_##n, \
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			    POST_KERNEL, CONFIG_PWM_INIT_PRIORITY, \
 			    &mcux_tpm_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(TPM_DEVICE)

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -230,7 +230,7 @@ static int pwm_npcx_init(const struct device *dev)
 	DEVICE_DT_INST_DEFINE(inst,					       \
 			    &pwm_npcx_init, NULL,			       \
 			    &pwm_npcx_data_##inst, &pwm_npcx_cfg_##inst,       \
-			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \
+			    PRE_KERNEL_1, CONFIG_PWM_INIT_PRIORITY,	       \
 			    &pwm_npcx_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(NPCX_PWM_INIT)

--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -385,5 +385,5 @@ DEVICE_DT_INST_DEFINE(0,
 		    &pwm_nrf5_sw_0_data,
 		    &pwm_nrf5_sw_0_config,
 		    POST_KERNEL,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    CONFIG_PWM_INIT_PRIORITY,
 		    &pwm_nrf5_sw_drv_api_funcs);

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -385,7 +385,7 @@ static int pwm_nrfx_pm_action(const struct device *dev,
 			 pwm_nrfx_init, PM_DEVICE_DT_GET(PWM(idx)),	      \
 			 &pwm_nrfx_##idx##_data,			      \
 			 &pwm_nrfx_##idx##_config,			      \
-			 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,     \
+			 POST_KERNEL, CONFIG_PWM_INIT_PRIORITY,		      \
 			 &pwm_nrfx_drv_api_funcs)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pwm0), okay)

--- a/drivers/pwm/pwm_rcar.c
+++ b/drivers/pwm/pwm_rcar.c
@@ -262,7 +262,7 @@ static const struct pwm_driver_api pwm_rcar_driver_api = {
 	};                                                                                         \
 	static struct pwm_rcar_data pwm_rcar_data_##n;                                             \
 	DEVICE_DT_INST_DEFINE(n, pwm_rcar_init, NULL, &pwm_rcar_data_##n, &pwm_rcar_cfg_##n,       \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,                     \
+			      POST_KERNEL, CONFIG_PWM_INIT_PRIORITY,                               \
 			      &pwm_rcar_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_DEVICE_RCAR_INIT)

--- a/drivers/pwm/pwm_rpi_pico.c
+++ b/drivers/pwm/pwm_rpi_pico.c
@@ -177,6 +177,6 @@ static int pwm_rpi_init(const struct device *dev)
 	};											   \
 												   \
 	DEVICE_DT_INST_DEFINE(idx, pwm_rpi_init, NULL, NULL, &pwm_rpi_config_##idx, POST_KERNEL,   \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &pwm_rpi_driver_api);
+			      CONFIG_PWM_INIT_PRIORITY, &pwm_rpi_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_RPI_INIT);

--- a/drivers/pwm/pwm_rv32m1_tpm.c
+++ b/drivers/pwm/pwm_rv32m1_tpm.c
@@ -218,7 +218,7 @@ static const struct pwm_driver_api rv32m1_tpm_driver_api = {
 	DEVICE_DT_INST_DEFINE(n, &rv32m1_tpm_init, NULL, \
 			    &rv32m1_tpm_data_##n, \
 			    &rv32m1_tpm_config_##n, \
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			    POST_KERNEL, CONFIG_PWM_INIT_PRIORITY, \
 			    &rv32m1_tpm_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(TPM_DEVICE)

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -122,7 +122,7 @@ static const struct pwm_driver_api sam_pwm_driver_api = {
 			    &sam_pwm_init, NULL,			\
 			    NULL, &sam_pwm_config_##inst,		\
 			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_PWM_INIT_PRIORITY,			\
 			    &sam_pwm_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SAM_INST_INIT)

--- a/drivers/pwm/pwm_sam0_tcc.c
+++ b/drivers/pwm/pwm_sam0_tcc.c
@@ -167,7 +167,7 @@ static const struct pwm_driver_api pwm_sam0_driver_api = {
 									       \
 	DEVICE_DT_INST_DEFINE(inst, &pwm_sam0_init, NULL,		       \
 			    NULL, &pwm_sam0_config_##inst,		       \
-			    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,   \
+			    POST_KERNEL, CONFIG_PWM_INIT_PRIORITY,	       \
 			    &pwm_sam0_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_SAM0_INIT)

--- a/drivers/pwm/pwm_sifive.c
+++ b/drivers/pwm/pwm_sifive.c
@@ -227,7 +227,7 @@ static const struct pwm_driver_api pwm_sifive_api = {
 			    &pwm_sifive_data_##n,	\
 			    &pwm_sifive_cfg_##n,	\
 			    POST_KERNEL,	\
-			    CONFIG_PWM_SIFIVE_INIT_PRIORITY,	\
+			    CONFIG_PWM_INIT_PRIORITY,	\
 			    &pwm_sifive_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_SIFIVE_INIT)

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -729,7 +729,7 @@ static void pwm_stm32_irq_config_func_##index(const struct device *dev)        \
 	DEVICE_DT_INST_DEFINE(index, &pwm_stm32_init, NULL,                    \
 			    &pwm_stm32_data_##index,                           \
 			    &pwm_stm32_config_##index, POST_KERNEL,            \
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,                \
+			    CONFIG_PWM_INIT_PRIORITY,                          \
 			    &pwm_stm32_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_DEVICE_INIT)

--- a/drivers/pwm/pwm_test.c
+++ b/drivers/pwm/pwm_test.c
@@ -66,7 +66,7 @@ static int vnd_pwm_init(const struct device *dev)
 #define VND_PWM_INIT(n)						  \
 	DEVICE_DT_INST_DEFINE(n, &vnd_pwm_init, NULL,		  \
 			      NULL, NULL, POST_KERNEL,		  \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			      CONFIG_PWM_INIT_PRIORITY,		  \
 			      &vnd_pwm_api);
 
 DT_INST_FOREACH_STATUS_OKAY(VND_PWM_INIT)

--- a/drivers/pwm/pwm_xlnx_axi_timer.c
+++ b/drivers/pwm/pwm_xlnx_axi_timer.c
@@ -203,7 +203,7 @@ static const struct pwm_driver_api xlnx_axi_timer_driver_api = {
 			    NULL, NULL,					\
 			    &xlnx_axi_timer_config_##n,			\
 			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_PWM_INIT_PRIORITY,			\
 			    &xlnx_axi_timer_driver_api)
 
 DT_INST_FOREACH_STATUS_OKAY(XLNX_AXI_TIMER_INIT);


### PR DESCRIPTION
Tidy up PWM drivers to use a common initialization priority as per other peripheral driver types.

See:
https://github.com/zephyrproject-rtos/zephyr/blob/f3fd686b9622c3116a896b0cba49c063d821feb7/drivers/adc/Kconfig#L37-L41
https://github.com/zephyrproject-rtos/zephyr/blob/77e4c6515a1487e9f57ed3af5febb904790dad87/drivers/can/Kconfig#L20-L24
https://github.com/zephyrproject-rtos/zephyr/blob/3f36584c72edf9fd3a54692dd029f85f575eec37/drivers/i2c/Kconfig#L62-L66