### PR TITLE
drivers: gpio: gd32: add dependency on the EXTI

### DIFF
--- a/drivers/gpio/Kconfig.gd32
+++ b/drivers/gpio/Kconfig.gd32
@@ -5,5 +5,6 @@ config GPIO_GD32
 	bool "GD32 GPIO driver"
 	default y
 	depends on DT_HAS_GD_GD32_GPIO_ENABLED
+	select GD32_EXTI
 	help
 	  Enable the GD32 GPIO driver.


### PR DESCRIPTION
The GPIO pin interruption depends on the EXTI.
Add "select" to clarify the dependency.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@gmail.com>
