### PR TITLE
Bluetooth: Controller: Ticker window extension for broadcaster only

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -794,7 +794,7 @@ config BT_TICKER_NEXT_SLOT_GET_MATCH
 config BT_TICKER_EXT
 	bool "Ticker extensions"
 	depends on !BT_TICKER_LOW_LAT && !BT_TICKER_SLOT_AGNOSTIC
-	default y
+	default y if BT_BROADCASTER
 	help
 	  This option enables ticker extensions such as re-scheduling of
 	  ticker nodes with slot_window set to non-zero. Ticker extensions


### PR DESCRIPTION
Enable ticker ticks slow window extensions implementation when broadcaster role is enabled. This feature moves the primary channel advertising event within the specified window when overlapping with other roles.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>