### PR TITLE
Bluetooth: Controller: Remove redundant assertion check

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -399,7 +399,8 @@ static void isr_tx(void *param)
 	}
 }
 
-static void switch_radio_complete_and_b2b_tx(const struct lll_adv_sync *lll, uint8_t phy_s)
+static void switch_radio_complete_and_b2b_tx(const struct lll_adv_sync *lll,
+					     uint8_t phy_s)
 {
 #if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
 	if (lll->cte_started) {

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -338,10 +338,10 @@ uint8_t ll_sync_create_cancel(void **rx)
 		LL_ASSERT(sync_handle <= UINT8_MAX);
 
 		/* Sync is not established yet, so stop sync ticker */
-		int err = ull_ticker_stop_with_mark(
-			TICKER_ID_SCAN_SYNC_BASE + (uint8_t)sync_handle, sync, &sync->lll);
-
-		LL_ASSERT(err == 0 || err == -EALREADY);
+		const int err =
+			ull_ticker_stop_with_mark((TICKER_ID_SCAN_SYNC_BASE +
+						   (uint8_t)sync_handle),
+						  sync, &sync->lll);
 		if (err != 0 && err != -EALREADY) {
 			return BT_HCI_ERR_CMD_DISALLOWED;
 		}


### PR DESCRIPTION
Remove redundant assertion check, and minor indentation fix to correct the alignment of function call.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>