### PR TITLE
doc: Make ascii graphics readable by using @code .. @endcode

### DIFF
--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -37,6 +37,7 @@ enum espi_io_mode {
 };
 
 /**
+ * @code
  *+----------------------------------------------------------------------+
  *|                                                                      |
  *|  eSPI host                           +-------------+                 |
@@ -82,7 +83,7 @@ enum espi_io_mode {
  *|       CH0         |     CH1      |      CH2      |    CH3             |
  *|   eSPI endpoint   |    VWIRE     |      OOB      |   Flash            |
  *+-----------------------------------------------------------------------+
- *
+ * @endcode
  */
 
 /**
@@ -480,6 +481,7 @@ __subsystem struct espi_driver_api {
  * will be used by eSPI master to determine minimum common capabilities with
  * eSPI slave then send via SET_CONFIGURATION command.
  *
+ * @code
  * +--------+   +---------+     +------+          +---------+   +---------+
  * |  eSPI  |   |  eSPI   |     | eSPI |          |  eSPI   |   |  eSPI   |
  * |  slave |   | driver  |     |  bus |          |  driver |   |  host   |
@@ -503,6 +505,7 @@ __subsystem struct espi_driver_api {
  *     |              |            |  accept           |             |
  *     |              |            +------------------>+             |
  *     +              +            +                   +             +
+ * @endcode
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param cfg the device runtime configuration for the eSPI controller.
@@ -871,6 +874,7 @@ static inline int z_impl_espi_flash_erase(const struct device *dev,
 /**
  * Callback model
  *
+ * @code
  *+-------+                  +-------------+   +------+     +---------+
  *|  App  |                  | eSPI driver |   |  HW  |     |eSPI Host|
  *+---+---+                  +-------+-----+   +---+--+     +----+----+
@@ -926,6 +930,7 @@ static inline int z_impl_espi_flash_erase(const struct device *dev,
  *    <------------------------------+             |             |
  *    | App executes                 |             |             |
  *    + power mgmt policy            |             |             |
+ * @endcode
  */
 
 /**

--- a/include/zephyr/drivers/espi_saf.h
+++ b/include/zephyr/drivers/espi_saf.h
@@ -29,6 +29,7 @@ extern "C" {
 
 
 /**
+ * @code
  *+----------------------------------------------------------------------+
  *|                                                                      |
  *|  eSPI host                           +-------------+                 |
@@ -80,6 +81,7 @@ extern "C" {
  * |  Flash  |  Slave Attached Flash   |
  * +---------+                         |
  *                                     |
+ * @endcode
  */
 
 
@@ -177,6 +179,7 @@ __subsystem struct espi_saf_driver_api {
  * will be used by eSPI master to determine minimum common capabilities with
  * eSPI slave then send via SET_CONFIGURATION command.
  *
+ * @code
  * +--------+   +---------+     +------+          +---------+   +---------+
  * |  eSPI  |   |  eSPI   |     | eSPI |          |  eSPI   |   |  eSPI   |
  * |  slave |   | driver  |     |  bus |          |  driver |   |  host   |
@@ -200,6 +203,7 @@ __subsystem struct espi_saf_driver_api {
  *     |              |            |  accept           |             |
  *     |              |            +------------------>+             |
  *     +              +            +                   +             +
+ * @endcode
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param cfg the device runtime configuration for the eSPI controller.
@@ -382,6 +386,7 @@ static inline int z_impl_espi_saf_flash_erase(const struct device *dev,
 /**
  * Callback model
  *
+ * @code
  *+-------+                  +-------------+   +------+     +---------+
  *|  App  |                  | eSPI driver |   |  HW  |     |eSPI Host|
  *+---+---+                  +-------+-----+   +---+--+     +----+----+
@@ -437,6 +442,7 @@ static inline int z_impl_espi_saf_flash_erase(const struct device *dev,
  *    <------------------------------+             |             |
  *    | App executes                 |             |             |
  *    + power mgmt policy            |             |             |
+ * @endcode
  */
 
 /**


### PR DESCRIPTION
Current API is looking like shown below:

https://docs.zephyrproject.org/latest/hardware/peripherals/espi.html 

eSPI channel.

+——————————————————————-&#8212;+ | | | eSPI host +———-&#8212;+ | | +——–&#8212;+ | Power | +——-&#8212;+ | | |Out of band| | management | | GPIO | | | +———&#8212;+ |processor | | controller | | sources | | | | SPI flash | +——–&#8212;+ +———-&#8212;+ +——-&#8212;+ | | | controller | | | | | | +———&#8212;+ | | | | | | | | +—–&#8212;+ +————&#8212;+ | | | | | | | | | | | +–&#8212;+ +—–&#8212;+ +——-&#8212;+ +-&#8212;v–&#8212;+ | | | | | | LPC | | Tunneled | | Tunneled | | | | | | | bridge | | SMBus | | GPIO | | | | | | +—–&#8212;+ +——-&#8212;+ +——-&#8212;+ | | | | | | | | | | | | | —&#8212;+ | | | | | | | | | | | | | | +—&#8212;v–&#8212;+ +&#8212;v—-&#8212;v———-&#8212;v-&#8212;+ | | | | | eSPI Flash | | eSPI protocol block | | | | | | access +&#8212;>+ | | | | | +———&#8212;+ +—————————&#8212;+ | | | | | | | | +——–&#8212;+ | | | | v v | | | XXXXXXXXXXXXXXXXXXXXXXX | | | XXXXXXXXXXXXXXXXXXXXX | | | XXXXXXXXXXXXXXXXXXX | +——————————————————————-&#8212;+ | | v +————–&#8212;+ +——&#8212;+ | | | | | | | Flash | | | | | | | +——&#8212;+ | + + + + | eSPI bus | CH0 CH1 CH2 CH3 | (logical channels) | + + + + | | | | | | | +————–&#8212;+ | +——————————————————————–&#8212;+ | eSPI slave | | | | CH0 | CH1 | CH2 | CH3 | | eSPI endpoint | VWIRE | OOB | Flash | +——————————————————————–&#8212;+
