### PR TITLE
Bluetooth: Controller: EVENT_OVERHEAD_START_US for typical usecases

### DIFF
--- a/subsys/bluetooth/controller/hal/debug.h
+++ b/subsys/bluetooth/controller/hal/debug.h
@@ -7,12 +7,22 @@
 
 #ifdef CONFIG_BT_CTLR_ASSERT_HANDLER
 void bt_ctlr_assert_handle(char *file, uint32_t line);
-#define LL_ASSERT(cond) if (!(cond)) { \
-				bt_ctlr_assert_handle(__FILE__, \
-						      __LINE__); \
-			}
+#define LL_ASSERT(cond) \
+		if (!(cond)) { \
+			BT_ASSERT_PRINT(cond); \
+			bt_ctlr_assert_handle(__FILE__, __LINE__); \
+		}
+#define LL_ASSERT_MSG(cond, fmt, ...) \
+		if (!(cond)) { \
+			BT_ASSERT_PRINT(cond); \
+			BT_ASSERT_PRINT_MSG(fmt, ##__VA_ARGS__); \
+			bt_ctlr_assert_handle(__FILE__, __LINE__); \
+		}
 #else
-#define LL_ASSERT(cond) BT_ASSERT(cond)
+#define LL_ASSERT(cond) \
+		BT_ASSERT(cond)
+#define LL_ASSERT_MSG(cond, fmt, ...) \
+		BT_ASSERT_MSG(cond, fmt, ##__VA_ARGS__)
 #endif
 
 #include "hal/debug_vendor_hal.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -472,10 +472,13 @@ uint32_t lll_preempt_calc(struct ull_hdr *ull, uint8_t ticker_id,
 		 *    duration.
 		 * 3. Increase the preempt to start ticks for future events.
 		 */
-		return 1;
+		LL_ASSERT_MSG(0, "%s: Actual EVENT_OVERHEAD_START_US = %u\n",
+			      __func__, HAL_TICKER_TICKS_TO_US(diff));
+
+		return 1U;
 	}
 
-	return 0;
+	return 0U;
 }
 
 void lll_chan_set(uint32_t chan)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
@@ -8,14 +8,48 @@
 #define EVENT_OVERHEAD_PREEMPT_US     0    /* if <= min, then dynamic preempt */
 #define EVENT_OVERHEAD_PREEMPT_MIN_US 0
 #define EVENT_OVERHEAD_PREEMPT_MAX_US EVENT_OVERHEAD_XTAL_US
-#define EVENT_OVERHEAD_START_US       750
+
+/* Measurement based on drifting roles that can overlap leading to collision
+ * resolutions that consume CPU time between radio events.
+ * Value include max end, start and scheduling CPU usage times.
+ * Measurements based on central_gatt_write and peripheral_gatt_write sample on
+ * nRF52833 SoC.
+ */
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+#if defined(CONFIG_BT_OBSERVER)
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
+/* Active connection in peripheral role with extended scanning on 1M and Coded
+ * PHY, scheduling and receiving auxiliary PDUs.
+ */
+#define EVENT_OVERHEAD_START_US       458
+#else /* !CONFIG_BT_CTLR_PHY_CODED */
+/* Active connection in peripheral role with extended scanning on 1M only,
+ * scheduling and receiving auxiliary PDUs.
+ */
+#define EVENT_OVERHEAD_START_US       428
+#endif /* !CONFIG_BT_CTLR_PHY_CODED */
+#else /* !CONFIG_BT_OBSERVER */
+/* Active connection in peripheral role with legacy scanning on 1M.
+ */
+#define EVENT_OVERHEAD_START_US       275
+#endif /* !CONFIG_BT_OBSERVER */
+#else /* !CONFIG_BT_CTLR_ADV_EXT */
+/* Active connection in peripheral role with additional advertising state.
+ */
+#define EVENT_OVERHEAD_START_US       275
+#endif /* !CONFIG_BT_CTLR_ADV_EXT */
+
 /* Worst-case time margin needed after event end-time in the air
  * (done/preempt race margin + power-down/chain delay)
  */
 #define EVENT_OVERHEAD_END_US         100
+
+/* Sleep Clock Accuracy */
 #define EVENT_JITTER_US               16
+
 /* Inter-Event Space (IES) */
 #define EVENT_TIES_US                 625
+
 /* Ticker resolution margin
  * Needed due to the lack of fine timing resolution in ticker_start
  * and ticker_update. Set to 32 us, which is ~1 tick with 32768 Hz

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -2425,8 +2425,9 @@ static inline void ticker_job_list_inquire(struct ticker_instance *instance)
  *
  * @internal
  */
-static inline void ticker_job_compare_update(struct ticker_instance *instance,
-					     uint8_t ticker_id_old_head)
+static inline uint8_t
+ticker_job_compare_update(struct ticker_instance *instance,
+			  uint8_t ticker_id_old_head)
 {
 	struct ticker_node *ticker;
 	uint32_t ticks_to_expire;
@@ -2443,7 +2444,8 @@ static inline void ticker_job_compare_update(struct ticker_instance *instance,
 
 			instance->ticks_current = cntr_cnt_get();
 		}
-		return;
+
+		return 0U;
 	}
 
 	/* Check if this is the first update. If so, start the counter */
@@ -2459,6 +2461,9 @@ static inline void ticker_job_compare_update(struct ticker_instance *instance,
 
 	ticker = &instance->nodes[instance->ticker_id_head];
 	ticks_to_expire = ticker->ticks_to_expire;
+	if (!ticks_to_expire) {
+		return 1U;
+	}
 
 	/* Iterate few times, if required, to ensure that compare is
 	 * correctly set to a future value. This is required in case
@@ -2485,6 +2490,8 @@ static inline void ticker_job_compare_update(struct ticker_instance *instance,
 	} while ((ticker_ticks_diff_get(ctr_post, ctr) +
 		  HAL_TICKER_CNTR_CMP_OFFSET_MIN) >
 		  ticker_ticks_diff_get(cc, ctr));
+
+	return 0U;
 }
 
 /**
@@ -2506,6 +2513,7 @@ void ticker_job(void *param)
 	struct ticker_instance *instance = param;
 	uint8_t flag_compare_update;
 	uint8_t ticker_id_old_head;
+	uint8_t compare_trigger;
 	uint32_t ticks_previous;
 	uint32_t ticks_elapsed;
 	uint8_t flag_elapsed;
@@ -2607,14 +2615,17 @@ void ticker_job(void *param)
 
 	/* update compare if head changed */
 	if (flag_compare_update) {
-		ticker_job_compare_update(instance, ticker_id_old_head);
+		compare_trigger = ticker_job_compare_update(instance,
+							    ticker_id_old_head);
+	} else {
+		compare_trigger = 0U;
 	}
 
 	/* Permit worker to run */
 	instance->job_guard = 0U;
 
 	/* trigger worker if deferred */
-	if (instance->worker_trigger) {
+	if (instance->worker_trigger || compare_trigger) {
 		instance->sched_cb(TICKER_CALL_ID_JOB, TICKER_CALL_ID_WORKER, 1,
 				   instance);
 	}


### PR DESCRIPTION
Tune the EVENT_OVERHEAD_START_US for typical usecases on
nRF52833 SoC using the central_gatt_write and
peripheral_gatt_write samples.

Manually run the samples for over 30 mins without any
assertions and use the actual profiled value that would
otherwise be printed on assertion.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>