### PR TITLE
boards: shields: frdm_kw41z: No reason to change chosen node

### DIFF
--- a/boards/shields/frdm_kw41z/frdm_kw41z.overlay
+++ b/boards/shields/frdm_kw41z/frdm_kw41z.overlay
@@ -6,7 +6,7 @@
 
 / {
 	chosen {
-		zephyr,bt-uart = &arduino_serial_frdm_kw41z;
+		zephyr,bt-uart = &arduino_serial;
 	};
 };
 


### PR DESCRIPTION
This nodelabel was changed while converting all shields to new nodelabel scheme.
On this particular nodelabel, there was no change to be done, as it doesn't refer to a node defined in the shield.
Revert this chagne.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>