### PR TITLE
ci: release: stop creating releases for RC tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+      - '!v*rc*'
 
 jobs:
   release:

--- a/doc/project/release_process.rst
+++ b/doc/project/release_process.rst
@@ -369,28 +369,6 @@ steps:
             $ git tag -s -m "Zephyr 1.11.0-rc1" v1.11.0-rc1
             $ git push git@github.com:zephyrproject-rtos/zephyr.git v1.11.0-rc1
 
-        #. Once the tag is pushed, a github action will create a draft release
-           in Github with a shortlog since the last tag. The action will also
-           create a SPDX manifest of the Zephyr tree and will add the file as an
-           asset in the release.
-
-           Go to the draft release that was created and edit as needed. If this
-           step fails for a reason, it can be done manually following the steps
-           below:
-
-                #. Create a shortlog of changes between the previous release (use
-                   rc1..rc2 between release candidates)::
-
-                    $ git shortlog v1.10.0..v1.11.0-rc1
-
-                #. Find the new tag at the top of the releases page and edit the release
-                   with the ``Edit tag`` button with the following:
-
-                    * Name it ``Zephyr 1.11.0-rc1``
-                    * Copy the shortlog into the release notes textbox (*don't forget
-                      to quote it properly so it shows as unformatted text in Markdown*)
-                    * Check the "This is a pre-release" checkbox
-
         #. Send an email to the mailing lists (``announce`` and ``devel``)
            with a link to the release
 


### PR DESCRIPTION
Hi, trying to cleanup the https://github.com/zephyrproject-rtos/zephyr/releases page a bit, don't think there's much sense doing GitHub release for RCs, how about dropping them? Tag and announcement should be enough.

-- 8< --

RC releases clutter the release page, there's no reason for keeping them after the release is done, filter them out from the workflow so they don't get created in the first place..