### PR TITLE
doc: release process: only use the overview for the release page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,9 @@ jobs:
           name: zephyr-${{ steps.get_version.outputs.VERSION }}.spdx
           path: zephyr-${{ steps.get_version.outputs.VERSION }}.spdx
 
-      - name: Get Diff since last tag
+      - name: Create empty release notes body
         run: |
-          oldtag=$(git describe --abbrev=0 ${{ github.ref }}^)
-          echo "Changes since ${oldtag}:" > release-notes.txt
-          echo "" >> release-notes.txt
-          echo "" >> release-notes.txt
-          git shortlog ${oldtag}..${{ github.ref }} >> release-notes.txt
+          echo "TODO: add release overview and notes link" > release-notes.txt
 
       - name: Create Release
         id: create_release

--- a/doc/project/release_process.rst
+++ b/doc/project/release_process.rst
@@ -430,8 +430,9 @@ steps:
            and edit the release with the ``Edit tag`` button with the following:
 
             * Name it ``Zephyr 1.11.0``
-            * Copy the full content of ``docs/releases/release-notes-1.11.rst``
-              into the release notes textbox
+            * Copy the overview of ``docs/releases/release-notes-1.11.rst``
+              into the release notes textbox and link to the full release notes
+              file on docs.zephyrproject.org.
 
         #. Send an email to the mailing lists (``announce`` and ``devel``) with a link
            to the release


### PR DESCRIPTION
The release notes process does not quite work in the current form. Let's keep the notes in one place and just copy the overview and a link in the release page.

-- 8< --

Change the release process documentation to only use the overview of the release notes for GitHub releases rather than the full file.

The current instructions of copying the full content are broken (the file does not fit anyway and the formatting is incompatible) and result in a cluttered page anyway (the UI is not really meant for long release notes).