### PR TITLE
ci: release: drop "v" prefix from release names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         id: get_version
         run: |
           echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "TRIMMED_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v1
@@ -42,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Zephyr ${{ github.ref }}
+          release_name: Zephyr ${{ steps.get_version.outputs.TRIMMED_VERSION }}
           body_path: release-notes.txt
           draft: true
           prerelease: true

--- a/doc/project/release_process.rst
+++ b/doc/project/release_process.rst
@@ -401,7 +401,6 @@ steps:
         #. Find the new ``v1.11.0`` tag at the top of the releases page and
            edit the release with the ``Edit tag`` button with the following:
 
-            * Name it ``Zephyr 1.11.0``
             * Copy the overview of ``docs/releases/release-notes-1.11.rst``
               into the release notes textbox and link to the full release notes
               file on docs.zephyrproject.org.


### PR DESCRIPTION
Documentation page says release should be named without the "v" prefix (as in "Zephyr 3.2.0" not "Zephyr v3.2.0"), make the CI do that.

Link: https://docs.zephyrproject.org/latest/project/release_process.html#tagging