### PR TITLE
mgmt: mcumgr: Remove Kconfig values that were deprecated in zephyr 3.1

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -192,6 +192,12 @@ Devicetree
 Libraries / Subsystems
 **********************
 
+* Management
+
+  * MCUMGR functionality deprecated in 3.1 has been removed:
+    CONFIG_FS_MGMT_UL_CHUNK_SIZE, CONFIG_IMG_MGMT_UL_CHUNK_SIZE,
+    CONFIG_OS_MGMT_ECHO_LENGTH
+
 HALs
 ****
 

--- a/doc/services/device_mgmt/mcumgr.rst
+++ b/doc/services/device_mgmt/mcumgr.rst
@@ -404,13 +404,6 @@ directly upgraded to.
 
 .. tip::
 
-    The maximum size of a chunk communicated between the client and server is set
-    with :kconfig:option:`CONFIG_IMG_MGMT_UL_CHUNK_SIZE`. The default is 512 but can be
-    decreased for systems with low amount of RAM down to 128. When this value is
-    changed, the ``mtu`` of the port must be smaller than or equal to this value.
-
-.. tip::
-
     Building with :kconfig:option:`CONFIG_IMG_MGMT_VERBOSE_ERR` enables better error
     messages when failures happen (but increases the application size).
 

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/Kconfig
@@ -52,17 +52,6 @@ config FS_MGMT_MAX_OFFSET_LEN
 	  to be assigned from limited set of allowed values, depending on
 	  the selection made in FS_MGMT_MAX_FILE_SIZE menu.
 
-config FS_MGMT_UL_CHUNK_SIZE
-	int "Maximum chunk size for file uploads (DEPRECATED)"
-	default 512
-	help
-	  DEPRECATED: The chunk is now directly read from received frame buffer
-	  and is no longer copied first into intermediate buffer so the actual
-	  file chunk is as much as MCUMGR_BUF_SIZE can take, less the other
-	  SMP fields.
-	  Limits the maximum chunk size for file uploads, in bytes.  A buffer of
-	  this size gets allocated on the stack during handling of a file upload command.
-
 config FS_MGMT_DL_CHUNK_SIZE_LIMIT
 	bool "Setting custom size of download file chunk"
 	help

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/Kconfig
@@ -29,19 +29,6 @@ config IMG_MGMT_USE_HEAP_FOR_FLASH_IMG_CONTEXT
 	  operation, an issue that should also be addressed within application.
 endif
 
-config IMG_MGMT_UL_CHUNK_SIZE
-	int "Maximum chunk size for image uploads (DEPRECATED)"
-	default 512
-	depends on MCUMGR_CMD_IMG_MGMT
-	help
-	  DEPRECATED: The mcumgr no longer copies chunk of file into intermediate
-	  buffer, instead the request transport buffer is used directly to
-	  process image chunk.
-
-	  Limits the maximum chunk size for image uploads, in bytes.  A buffer of
-	  this size gets allocated on the stack during handling of a image upload
-	  command.
-
 config IMG_MGMT_UPDATABLE_IMAGE_NUMBER
 	int "Number of supported images"
 	default UPDATEABLE_IMAGE_NUMBER

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/Kconfig
@@ -119,20 +119,6 @@ config OS_MGMT_ECHO
 	default y
 	select MGMT_MIN_DECODING_LEVEL_2
 
-if OS_MGMT_ECHO
-
-config OS_MGMT_ECHO_LENGTH
-	int "Echo buffer (DEPRECATED)"
-	default 128
-	help
-	  DEPRECATED: The echo sentence is no longer copied into intermediate
-	  buffer, instead a transport buffer is used to directly copy echo
-	  sentence to response. Echo may still respond with not enough
-	  memory error, in case when it would not be possible to fit source
-	  sentence into response buffer limited by MCUMGR_BUF_SIZE.
-
-endif
-
 config OS_MGMT_MCUMGR_PARAMS
 	bool "MCUMGR Parameters retrieval command"
 


### PR DESCRIPTION
Removes deprecated Kconfig values that have been replaced, includes release notes.

Fixes #50592