### PR TITLE
doc: Fix mixup in k_poll() docs

### DIFF
--- a/doc/kernel/services/polling.rst
+++ b/doc/kernel/services/polling.rst
@@ -58,7 +58,7 @@ acquired. As an example, this means that when :c:func:`k_poll` returns and
 the poll event states that the semaphore is available, the caller of
 :c:func:`k_poll()` must then invoke :c:func:`k_sem_take` to take
 ownership of the semaphore. If the semaphore is contested, there is no
-guarantee that it will be still available when :c:func:`k_sem_give` is
+guarantee that it will be still available when :c:func:`k_sem_take` is
 called.
 
 Implementation


### PR DESCRIPTION
The race being described is all about k_sem_take() timing, not k_sem_give()

Signed-off-by: Andy Ross <andyross@google.com>