### PR TITLE
Bluetooth: hci: use opaque pointer to not drag in DT macros

### DIFF
--- a/include/zephyr/drivers/bluetooth/hci_driver.h
+++ b/include/zephyr/drivers/bluetooth/hci_driver.h
@@ -21,7 +21,10 @@
 #include <zephyr/net/buf.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/hci_vs.h>
-#include <zephyr/device.h>
+
+
+/* Opaque type representing a Zephyr device. */
+struct device;
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Use an opaque type for `struct device` to not have to drag in the whole devicetree machinery. Allows building `id.c` with the unittest board.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>