### PR TITLE
dts: arm: st: f0: Include STM32F070 dts in STM32F072 dts

### DIFF
--- a/dts/arm/st/f0/stm32f072.dtsi
+++ b/dts/arm/st/f0/stm32f072.dtsi
@@ -4,16 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/f0/stm32f0.dtsi>
+#include <st/f0/stm32f070.dtsi>
 
 / {
 	soc {
-		flash-controller@40022000 {
-			flash0: flash@8000000 {
-				erase-block-size = <2048>;
-			};
-		};
-
 		pinctrl: pin-controller@48000000 {
 
 			gpioe: gpio@48001000 {
@@ -41,28 +35,6 @@
 			};
 		};
 
-		spi2: spi@40003800 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
-			interrupts = <26 3>;
-			status = "disabled";
-		};
-
-		usb: usb@40005c00 {
-			compatible = "st,stm32-usb";
-			reg = <0x40005c00 0x400>;
-			interrupts = <31 0>;
-			interrupt-names = "usb";
-			num-bidir-endpoints = <8>;
-			ram-size = <1024>;
-			phys = <&usb_fs_phy>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00800000>;
-			status = "disabled";
-		};
-
 		can1: can@40006400 {
 			compatible = "st,stm32-can";
 			reg = <0x40006400 0x400>;
@@ -84,10 +56,5 @@
 		dma1: dma@40020000 {
 			interrupts = <9 0 10 0 10 0 11 0 11 0 11 0 11 0>;
 		};
-	};
-
-	usb_fs_phy: usbphy {
-		compatible = "usb-nop-xceiv";
-		#phy-cells = <0>;
 	};
 };


### PR DESCRIPTION
Add successive inclusion for STM32F072 dts by including STM32F070 dts instead of STM32F0 dts.
This allows to reuse the definition of
- Flash
- SPI
- USB

from the new parent.