### PR TITLE
tests: subsys: nvs testing on stm32 boards

### DIFF
--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.yaml
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.yaml
@@ -18,6 +18,7 @@ supported:
   - usb_device
   - watchdog
   - counter
+  - nvs
   - adc
   - dac
   - backup_sram

--- a/samples/subsys/nvs/boards/nucleo_f207zg.overlay
+++ b/samples/subsys/nvs/boards/nucleo_f207zg.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		/* Set 2 sectors of 16KB at the sector 2 */
+		storage_partition: partition@08000 {
+			label = "storage";
+			reg = <0x000008000 DT_SIZE_K(32)>;
+		};
+	};
+};


### PR DESCRIPTION
Add configuration to run the  
- tests/subsys/settings/nvs/
- samples/subsys/nvs/

on more stm32 platforms: 
-   nucleo_f746zg
-   nucleo_f207zg
-   nucleo_h743zi


Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)