### PR TITLE
Add a MAINTAINERS entry for release notes

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -499,6 +499,16 @@ Documentation Infrastructure:
   labels:
     - "area: Documentation Infrastructure"
 
+Release Notes:
+  status: maintained
+  maintainers:
+    - laurenmurphyx64
+    - stephanosio
+  files:
+    - doc/releases/release-notes-*
+  labels:
+    - "Release Notes"
+
 "Drivers: ADC":
   status: maintained
   maintainers:

--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -93,9 +93,12 @@ def process_pr(gh, maintainer_file, number):
     log(f"Submitted by: {pr.user.login}")
     log(f"candidate maintainers: {sm}")
 
+    maintainer = "None"
+    maintainers = list(sm.keys())
+
     prop = 0
-    if sm:
-        maintainer = list(sm.keys())[0]
+    if maintainers:
+        maintainer = maintainers[0]
 
         if len(ac) > 1 and list(ac.values())[0] == list(ac.values())[1]:
             log("++ Platform/Drivers takes precedence over subsystem...")
@@ -103,8 +106,10 @@ def process_pr(gh, maintainer_file, number):
                 if 'Documentation' in aa:
                     log("++ With multiple areas of same weight including docs, take something else other than Documentation as the maintainer")
                     for a in all_areas:
-                        if a.name == aa and a.maintainers[0] == maintainer:
-                            maintainer = list(sm.keys())[1]
+                        if (a.name == aa and
+                            a.maintainers and a.maintainers[0] == maintainer and
+                            len(maintainers) > 1):
+                            maintainer = maintainers[1]
                 elif 'Platform' in aa:
                     log(f"Set maintainer of area {aa}")
                     for a in all_areas:
@@ -129,8 +134,7 @@ def process_pr(gh, maintainer_file, number):
         prop = (maint[maintainer] / num_files) * 100
         if prop < 20:
             maintainer = "None"
-    else:
-        maintainer = "None"
+
     log(f"Picked maintainer: {maintainer} ({prop:.2f}% ownership)")
     log("+++++++++++++++++++++++++")
 

--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -101,7 +101,6 @@ def process_pr(gh, maintainer_file, number):
         maintainer = maintainers[0]
 
         if len(ac) > 1 and list(ac.values())[0] == list(ac.values())[1]:
-            log("++ Platform/Drivers takes precedence over subsystem...")
             for aa in ac:
                 if 'Documentation' in aa:
                     log("++ With multiple areas of same weight including docs, take something else other than Documentation as the maintainer")
@@ -111,6 +110,7 @@ def process_pr(gh, maintainer_file, number):
                             len(maintainers) > 1):
                             maintainer = maintainers[1]
                 elif 'Platform' in aa:
+                    log("++ Platform takes precedence over subsystem...")
                     log(f"Set maintainer of area {aa}")
                     for a in all_areas:
                         if a.name == aa:


### PR DESCRIPTION
Add a MAINTAINERS entry so we get the release notes tag on release notes PRs, should make a bit easier to manage release notes review close to release time. Had to fix a couple bugs in the set assignees script as well while testing.