### PR TITLE
Bluetooth: Controller: Fix BIG event counter calc from payload count

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -193,8 +193,7 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	lll->latency_event = lll->latency_prepare - 1U;
 
 	/* Calculate the current event counter value */
-	event_counter = (lll->payload_count / lll->bn) +
-			(lll->latency_event * lll->bn);
+	event_counter = (lll->payload_count / lll->bn) + lll->latency_event;
 
 	/* Update BIS packet counter to next value */
 	lll->payload_count += (lll->latency_prepare * lll->bn);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -203,8 +203,7 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	lll->latency_event = lll->latency_prepare - 1U;
 
 	/* Calculate the current event counter value */
-	event_counter = (lll->payload_count / lll->bn) +
-			(lll->latency_event * lll->bn);
+	event_counter = (lll->payload_count / lll->bn) + lll->latency_event;
 
 	/* Update BIS packet counter to next value */
 	lll->payload_count += (lll->latency_prepare * lll->bn);


### PR DESCRIPTION
Fix the BIG event counter calculation from stored payload counter. Event latency should not be multiplied by burst count.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>