### PR TITLE
dts: bindings: Introduce base sensor device properties (v2)

### DIFF
--- a/dts/bindings/sensor/adi,adt7420.yaml
+++ b/dts/bindings/sensor/adi,adt7420.yaml
@@ -5,7 +5,7 @@ description: ADT7420 16-Bit digital I2C temperature sensor
 
 compatible: "adi,adt7420"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/adi,adxl345-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl345-i2c.yaml
@@ -5,4 +5,4 @@ description: ADXL345 3-axis I2C accelerometer
 
 compatible: "adi,adxl345"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/adi,adxl345-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl345-spi.yaml
@@ -5,4 +5,4 @@ description: ADXL345 3-axis accelerometer with SPI connection
 
 compatible: "adi,adxl345"
 
-include: spi-device.yaml
+include: [sensor-device.yaml, spi-device.yaml]

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -5,7 +5,7 @@ description: ADXL362 3-axis SPI accelerometer
 
 compatible: "adi,adxl362"
 
-include: spi-device.yaml
+include: [sensor-device.yaml, spi-device.yaml]
 
 properties:
     int1-gpios:

--- a/dts/bindings/sensor/adi,adxl372-common.yaml
+++ b/dts/bindings/sensor/adi,adxl372-common.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2022 Analog Devices Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+include: sensor-device.yaml
+
 properties:
     odr:
       type: int

--- a/dts/bindings/sensor/ams,ccs811.yaml
+++ b/dts/bindings/sensor/ams,ccs811.yaml
@@ -5,7 +5,7 @@ description: CCS811 digital air quality sensor
 
 compatible: "ams,ccs811"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     wake-gpios:

--- a/dts/bindings/sensor/ams,ens210.yaml
+++ b/dts/bindings/sensor/ams,ens210.yaml
@@ -6,4 +6,4 @@ description: |
 
 compatible: "ams,ens210"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/ams,iaqcore.yaml
+++ b/dts/bindings/sensor/ams,iaqcore.yaml
@@ -5,4 +5,4 @@ description: iAQ-core indoor air quality sensor
 
 compatible: "ams,iaqcore"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/aosong,dht.yaml
+++ b/dts/bindings/sensor/aosong,dht.yaml
@@ -13,7 +13,7 @@ description: |
 
 compatible: "aosong,dht"
 
-include: base.yaml
+include: sensor-device.yaml
 
 properties:
   dio-gpios:

--- a/dts/bindings/sensor/asahi-kasei,ak8975.yaml
+++ b/dts/bindings/sensor/asahi-kasei,ak8975.yaml
@@ -7,4 +7,4 @@ description: |
 
 compatible: "asahi-kasei,ak8975"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/atmel,sam-tc-qdec.yaml
+++ b/dts/bindings/sensor/atmel,sam-tc-qdec.yaml
@@ -5,7 +5,7 @@ description: Atmel SAM Timer Counter (TC) QDEC node
 compatible: "atmel,sam-tc-qdec"
 
 include:
-    - name: base.yaml
+    - name: sensor-device.yaml
     - name: pinctrl-device.yaml
 
 properties:

--- a/dts/bindings/sensor/avago,apds9960.yaml
+++ b/dts/bindings/sensor/avago,apds9960.yaml
@@ -5,7 +5,7 @@ description: APDS9960 digital proximity, ambient light, RGB, and gesture sensor
 
 compatible: "avago,apds9960"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/bosch,bma280.yaml
+++ b/dts/bindings/sensor/bosch,bma280.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "bosch,bma280"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
   int1-gpios:

--- a/dts/bindings/sensor/bosch,bmc150_magn.yaml
+++ b/dts/bindings/sensor/bosch,bmc150_magn.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "bosch,bmc150_magn"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     drdy-gpios:

--- a/dts/bindings/sensor/bosch,bme280-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bme280-i2c.yaml
@@ -5,4 +5,4 @@ description: BME280 integrated environmental sensor
 
 compatible: "bosch,bme280"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/bosch,bme280-spi.yaml
+++ b/dts/bindings/sensor/bosch,bme280-spi.yaml
@@ -5,4 +5,4 @@ description: BME280 integrated environmental sensor
 
 compatible: "bosch,bme280"
 
-include: spi-device.yaml
+include: [sensor-device.yaml, spi-device.yaml]

--- a/dts/bindings/sensor/bosch,bme680-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bme680-i2c.yaml
@@ -7,4 +7,4 @@ description: |
 
 compatible: "bosch,bme680"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/bosch,bme680-spi.yaml
+++ b/dts/bindings/sensor/bosch,bme680-spi.yaml
@@ -7,4 +7,4 @@ description: |
 
 compatible: "bosch,bme680"
 
-include: spi-device.yaml
+include: [sensor-device.yaml, spi-device.yaml]

--- a/dts/bindings/sensor/bosch,bmg160.yaml
+++ b/dts/bindings/sensor/bosch,bmg160.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "bosch,bmg160"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/bosch,bmi160.yaml
+++ b/dts/bindings/sensor/bosch,bmi160.yaml
@@ -3,6 +3,8 @@
 
 description: BMI160 inertial measurement unit
 
+include: sensor-device.yaml
+
 properties:
     int-gpios:
       type: phandle-array

--- a/dts/bindings/sensor/bosch,bmi270.yaml
+++ b/dts/bindings/sensor/bosch,bmi270.yaml
@@ -6,4 +6,6 @@ description: |
     The BMI270 is an inertial measurement unit. See more info at:
     https://www.bosch-sensortec.com/products/motion-sensors/imus/bmi270.html
 
+include: sensor-device.yaml
+
 compatible: "bosch,bmi270"

--- a/dts/bindings/sensor/bosch,bmm150.yaml
+++ b/dts/bindings/sensor/bosch,bmm150.yaml
@@ -7,4 +7,4 @@ description: |
 
 compatible: "bosch,bmm150"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/bosch,bmp388.yaml
+++ b/dts/bindings/sensor/bosch,bmp388.yaml
@@ -3,6 +3,8 @@
 
 # Common fields for BMP388
 
+include: sensor-device.yaml
+
 properties:
     int-gpios:
       type: phandle-array

--- a/dts/bindings/sensor/espressif,esp32-pcnt.yaml
+++ b/dts/bindings/sensor/espressif,esp32-pcnt.yaml
@@ -67,7 +67,7 @@ description: |
 
 compatible: "espressif,esp32-pcnt"
 
-include: [base.yaml, pinctrl-device.yaml]
+include: [sensor-device.yaml, pinctrl-device.yaml]
 
 child-binding:
   description: PCNT Unit configuration.

--- a/dts/bindings/sensor/honeywell,hmc5883l.yaml
+++ b/dts/bindings/sensor/honeywell,hmc5883l.yaml
@@ -5,7 +5,7 @@ description: Honeywell HMC5883L 3-axis magnetometer sensor
 
 compatible: "honeywell,hmc5883l"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/honeywell,mpr.yaml
+++ b/dts/bindings/sensor/honeywell,mpr.yaml
@@ -6,4 +6,4 @@ description: |
 
 compatible: "honeywell,mpr"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/honeywell,sm351lt.yaml
+++ b/dts/bindings/sensor/honeywell,sm351lt.yaml
@@ -5,7 +5,7 @@ description: SM351LT magnetoresistive sensor
 
 compatible: "honeywell,sm351lt"
 
-include: base.yaml
+include: sensor-device.yaml
 
 properties:
    gpios:

--- a/dts/bindings/sensor/hoperf,hp206c.yaml
+++ b/dts/bindings/sensor/hoperf,hp206c.yaml
@@ -8,4 +8,4 @@ description: |
 
 compatible: "hoperf,hp206c"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/hoperf,th02.yaml
+++ b/dts/bindings/sensor/hoperf,th02.yaml
@@ -7,4 +7,4 @@ description: |
 
 compatible: "hoperf,th02"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/infineon,dps310.yaml
+++ b/dts/bindings/sensor/infineon,dps310.yaml
@@ -6,6 +6,6 @@
 
 description: Infineon DPS310 temperature and pressure sensor
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 compatible: "infineon,dps310"

--- a/dts/bindings/sensor/invensense,icm42605.yaml
+++ b/dts/bindings/sensor/invensense,icm42605.yaml
@@ -6,7 +6,7 @@ description: ICM-42605 motion tracking device
 # ICM-42605 is SPI.
 compatible: "invensense,icm42605"
 
-include: spi-device.yaml
+include: [sensor-device.yaml, spi-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/invensense,icm42670.yaml
+++ b/dts/bindings/sensor/invensense,icm42670.yaml
@@ -6,7 +6,7 @@ description: ICM-42670 motion tracking device
 
 compatible: "invensense,icm42670"
 
-include: spi-device.yaml
+include: [sensor-device.yaml, spi-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/invensense,mpu6050.yaml
+++ b/dts/bindings/sensor/invensense,mpu6050.yaml
@@ -7,7 +7,7 @@ description: MPU-6000 motion tracking device
 # support SPI so stick with I2C variant.
 compatible: "invensense,mpu6050"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/invensense,mpu9250.yaml
+++ b/dts/bindings/sensor/invensense,mpu9250.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "invensense,mpu9250"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     irq-gpios:

--- a/dts/bindings/sensor/isil,isl29035.yaml
+++ b/dts/bindings/sensor/isil,isl29035.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "isil,isl29035"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/ite,it8xxx2-vcmp.yaml
+++ b/dts/bindings/sensor/ite,it8xxx2-vcmp.yaml
@@ -5,7 +5,7 @@ description: ITE, it8xxx2 Voltage Comparator node
 
 compatible: "ite,it8xxx2-vcmp"
 
-include: base.yaml
+include: sensor-device.yaml
 
 properties:
   reg:

--- a/dts/bindings/sensor/lm75.yaml
+++ b/dts/bindings/sensor/lm75.yaml
@@ -5,4 +5,4 @@ description: LM75 Digital Temperature Sensor with 2-Wire Interface.
 
 compatible: "lm75"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/lm77.yaml
+++ b/dts/bindings/sensor/lm77.yaml
@@ -6,7 +6,7 @@ description: |
 
 compatible: "lm77"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/maxim,ds18b20.yaml
+++ b/dts/bindings/sensor/maxim,ds18b20.yaml
@@ -5,7 +5,7 @@ description: Maxim 1-Wire temperature sensor
 
 compatible: "maxim,ds18b20"
 
-include: w1-slave.yaml
+include: [sensor-device.yaml, w1-slave.yaml]
 
 properties:
     resolution:

--- a/dts/bindings/sensor/maxim,max17055.yaml
+++ b/dts/bindings/sensor/maxim,max17055.yaml
@@ -8,7 +8,7 @@ description: Maxim MAX17055 Fuel Gauge
 
 compatible: "maxim,max17055"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     design-capacity:

--- a/dts/bindings/sensor/maxim,max17262.yaml
+++ b/dts/bindings/sensor/maxim,max17262.yaml
@@ -8,7 +8,7 @@ description: Maxim MAX17262 Fuel Gauge
 
 compatible: "maxim,max17262"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     design-voltage:

--- a/dts/bindings/sensor/maxim,max30101.yaml
+++ b/dts/bindings/sensor/maxim,max30101.yaml
@@ -5,4 +5,4 @@ description: MAX30101 heart rate sensor
 
 compatible: "maxim,max30101"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/maxim,max31875.yaml
+++ b/dts/bindings/sensor/maxim,max31875.yaml
@@ -11,7 +11,7 @@ description: |
 
 compatible: "maxim,max31875"
 
-include: "i2c-device.yaml"
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
   conversions-per-second:

--- a/dts/bindings/sensor/maxim,max44009.yaml
+++ b/dts/bindings/sensor/maxim,max44009.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "maxim,max44009"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/maxim,max6675.yaml
+++ b/dts/bindings/sensor/maxim,max6675.yaml
@@ -5,4 +5,4 @@ description: MAX6675 K-thermocouple to digital converter
 
 compatible: "maxim,max6675"
 
-include: spi-device.yaml
+include: [sensor-device.yaml, spi-device.yaml]

--- a/dts/bindings/sensor/meas,ms5607-i2c.yaml
+++ b/dts/bindings/sensor/meas,ms5607-i2c.yaml
@@ -7,4 +7,4 @@ description: |
 
 compatible: "meas,ms5607"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/meas,ms5607-spi.yaml
+++ b/dts/bindings/sensor/meas,ms5607-spi.yaml
@@ -7,4 +7,4 @@ description: |
 
 compatible: "meas,ms5607"
 
-include: spi-device.yaml
+include: [sensor-device.yaml, spi-device.yaml]

--- a/dts/bindings/sensor/meas,ms5837.yaml
+++ b/dts/bindings/sensor/meas,ms5837.yaml
@@ -5,4 +5,4 @@ description: TE Connectivity MS5837 digital pressure sensor
 
 compatible: "meas,ms5837"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/microchip,mcp9808.yaml
+++ b/dts/bindings/sensor/microchip,mcp9808.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "microchip,mcp9808"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -5,7 +5,7 @@ description: Nordic nRF quadrature decoder (QDEC) node
 
 compatible: "nordic,nrf-qdec"
 
-include: [base.yaml, pinctrl-device.yaml]
+include: [sensor-device.yaml, pinctrl-device.yaml]
 
 properties:
     reg:

--- a/dts/bindings/sensor/nordic,nrf-temp.yaml
+++ b/dts/bindings/sensor/nordic,nrf-temp.yaml
@@ -5,7 +5,7 @@ description: Nordic nRF family TEMP node
 
 compatible: "nordic,nrf-temp"
 
-include: base.yaml
+include: sensor-device.yaml
 
 properties:
     reg:

--- a/dts/bindings/sensor/nuvoton,adc-cmp.yaml
+++ b/dts/bindings/sensor/nuvoton,adc-cmp.yaml
@@ -6,6 +6,8 @@ description: |
 
 compatible: "nuvoton,adc-cmp"
 
+include: sensor-device.yaml
+
 properties:
     io-channels:
       type: phandle-array

--- a/dts/bindings/sensor/nxp,fxas21002.yaml
+++ b/dts/bindings/sensor/nxp,fxas21002.yaml
@@ -5,7 +5,7 @@ description: FXAS21002 3-axis gyroscope sensor
 
 compatible: "nxp,fxas21002"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int1-gpios:

--- a/dts/bindings/sensor/nxp,fxos8700.yaml
+++ b/dts/bindings/sensor/nxp,fxos8700.yaml
@@ -5,7 +5,7 @@ description: FXOS8700 6-axis accelerometer/magnetometer sensor
 
 compatible: "nxp,fxos8700"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     reset-gpios:

--- a/dts/bindings/sensor/nxp,kinetis-acmp.yaml
+++ b/dts/bindings/sensor/nxp,kinetis-acmp.yaml
@@ -5,7 +5,7 @@ description: NXP Kinetis Analog Comparator (ACMP)
 
 compatible: "nxp,kinetis-acmp"
 
-include: [base.yaml, pinctrl-device.yaml]
+include: [sensor-device.yaml, pinctrl-device.yaml]
 
 properties:
     interrupts:

--- a/dts/bindings/sensor/nxp,kinetis-temperature.yaml
+++ b/dts/bindings/sensor/nxp,kinetis-temperature.yaml
@@ -5,7 +5,7 @@ description: NXP Kinetis temperature sensor
 
 compatible: "nxp,kinetis-temperature"
 
-include: base.yaml
+include: sensor-device.yaml
 
 properties:
     io-channels:

--- a/dts/bindings/sensor/panasonic,amg88xx.yaml
+++ b/dts/bindings/sensor/panasonic,amg88xx.yaml
@@ -5,7 +5,7 @@ description: Panasonic AMG88XX 8x8 (64) pixel infrared array sensor
 
 compatible: "panasonic,amg88xx"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/plantower,pms7003.yaml
+++ b/dts/bindings/sensor/plantower,pms7003.yaml
@@ -9,4 +9,4 @@ description: |
 
 compatible: "plantower,pms7003"
 
-include: uart-device.yaml
+include: [sensor-device.yaml, uart-device.yaml]

--- a/dts/bindings/sensor/sbs,sbs-gauge.yaml
+++ b/dts/bindings/sensor/sbs,sbs-gauge.yaml
@@ -2,4 +2,4 @@ description: SBS 1.1 compliant fuel gauge (http://www.sbs-forum.org/specs)
 
 compatible: "sbs,sbs-gauge"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/seeed,grove-light.yaml
+++ b/dts/bindings/sensor/seeed,grove-light.yaml
@@ -5,7 +5,7 @@ description: Grove Photo-Resistor Light Sensor
 
 compatible: "seeed,grove-light"
 
-include: base.yaml
+include: sensor-device.yaml
 
 properties:
   io-channels:

--- a/dts/bindings/sensor/seeed,grove-temperature.yaml
+++ b/dts/bindings/sensor/seeed,grove-temperature.yaml
@@ -5,7 +5,7 @@ description: Grove NTC Temperature Sensor
 
 compatible: "seeed,grove-temperature"
 
-include: base.yaml
+include: sensor-device.yaml
 
 properties:
   io-channels:

--- a/dts/bindings/sensor/semtech,sx9500.yaml
+++ b/dts/bindings/sensor/semtech,sx9500.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "semtech,sx9500"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/sensirion,sgp40.yaml
+++ b/dts/bindings/sensor/sensirion,sgp40.yaml
@@ -7,7 +7,7 @@ description: Sensirion SGP40 Multipixel Gas Sensor
 
 compatible: "sensirion,sgp40"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     enable-selftest:

--- a/dts/bindings/sensor/sensirion,sht3xd.yaml
+++ b/dts/bindings/sensor/sensirion,sht3xd.yaml
@@ -5,7 +5,7 @@ description: Sensirion Humidity SHT3x-DIS humidity and temperature sensor
 
 compatible: "sensirion,sht3xd"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     alert-gpios:

--- a/dts/bindings/sensor/sensirion,sht4x.yaml
+++ b/dts/bindings/sensor/sensirion,sht4x.yaml
@@ -7,7 +7,7 @@ description: Sensirion SHT4x humidity and temperature sensor
 
 compatible: "sensirion,sht4x"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     repeatability:

--- a/dts/bindings/sensor/sensirion,shtcx.yaml
+++ b/dts/bindings/sensor/sensirion,shtcx.yaml
@@ -5,7 +5,7 @@ description: Sensirion SHTCx humidity and temperature sensor
 
 compatible: "sensirion,shtcx"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
   chip:

--- a/dts/bindings/sensor/sensor-device.yaml
+++ b/dts/bindings/sensor/sensor-device.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Sensor Device
+
+include: base.yaml
+
+properties:
+  friendly-name:
+    type: string
+    description: |
+      Human readable string describing the sensor. It can be used to
+      distinguish multiple instances of the same model (e.g., lid accelerometer
+      vs. base accelerometer in a laptop) to a host operating system.
+
+      This property is defined in the Generic Sensor Property Usages of the HID
+      Usage Tables specification
+      (https://usb.org/sites/default/files/hut1_3_0.pdf, section 22.5).

--- a/dts/bindings/sensor/silabs,si7006.yaml
+++ b/dts/bindings/sensor/silabs,si7006.yaml
@@ -5,4 +5,4 @@ description: Si7006 temperature and humidity sensor
 
 compatible: "silabs,si7006"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/silabs,si7055.yaml
+++ b/dts/bindings/sensor/silabs,si7055.yaml
@@ -5,4 +5,4 @@ description: Si7055 temperature sensor
 
 compatible: "silabs,si7055"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/silabs,si7060.yaml
+++ b/dts/bindings/sensor/silabs,si7060.yaml
@@ -5,4 +5,4 @@ description: Si7060 temperature sensor
 
 compatible: "silabs,si7060"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/silabs,si7210.yaml
+++ b/dts/bindings/sensor/silabs,si7210.yaml
@@ -5,4 +5,4 @@ description: Si7210 hall effect magnetic position and temperature sensor
 
 compatible: "silabs,si7210"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/st,hts221-common.yaml
+++ b/dts/bindings/sensor/st,hts221-common.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2017, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
+include: sensor-device.yaml
+
 properties:
     drdy-gpios:
       type: phandle-array

--- a/dts/bindings/sensor/st,i3g4250d.yaml
+++ b/dts/bindings/sensor/st,i3g4250d.yaml
@@ -6,4 +6,4 @@ description: |
 
 compatible: "st,i3g4250d"
 
-include: spi-device.yaml
+include: [sensor-device.yaml, spi-device.yaml]

--- a/dts/bindings/sensor/st,iis2dh-i2c.yaml
+++ b/dts/bindings/sensor/st,iis2dh-i2c.yaml
@@ -6,7 +6,7 @@ description: |
 
 compatible: "st,iis2dh"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     drdy-gpios:

--- a/dts/bindings/sensor/st,iis2dh-spi.yaml
+++ b/dts/bindings/sensor/st,iis2dh-spi.yaml
@@ -6,7 +6,7 @@ description: |
 
 compatible: "st,iis2dh"
 
-include: spi-device.yaml
+include: [sensor-device.yaml, spi-device.yaml]
 
 properties:
     drdy-gpios:

--- a/dts/bindings/sensor/st,iis2dlpc-common.yaml
+++ b/dts/bindings/sensor/st,iis2dlpc-common.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2018 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
+include: sensor-device.yaml
+
 properties:
     drdy-gpios:
       type: phandle-array

--- a/dts/bindings/sensor/st,iis2iclx-common.yaml
+++ b/dts/bindings/sensor/st,iis2iclx-common.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2020 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
+include: sensor-device.yaml
+
 properties:
     drdy-gpios:
       type: phandle-array

--- a/dts/bindings/sensor/st,iis2mdc-i2c.yaml
+++ b/dts/bindings/sensor/st,iis2mdc-i2c.yaml
@@ -6,7 +6,7 @@ description: |
 
 compatible: "st,iis2mdc"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     drdy-gpios:

--- a/dts/bindings/sensor/st,iis2mdc-spi.yaml
+++ b/dts/bindings/sensor/st,iis2mdc-spi.yaml
@@ -6,7 +6,7 @@ description: |
 
 compatible: "st,iis2mdc"
 
-include: spi-device.yaml
+include: [sensor-device.yaml, spi-device.yaml]
 
 properties:
     drdy-gpios:

--- a/dts/bindings/sensor/st,iis3dhhc-spi.yaml
+++ b/dts/bindings/sensor/st,iis3dhhc-spi.yaml
@@ -6,7 +6,7 @@ description: |
 
 compatible: "st,iis3dhhc"
 
-include: spi-device.yaml
+include: [sensor-device.yaml, spi-device.yaml]
 
 properties:
     irq-gpios:

--- a/dts/bindings/sensor/st,ism330dhcx-common.yaml
+++ b/dts/bindings/sensor/st,ism330dhcx-common.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2021 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
+include: sensor-device.yaml
+
 properties:
     drdy-gpios:
       type: phandle-array

--- a/dts/bindings/sensor/st,lis2dh-common.yaml
+++ b/dts/bindings/sensor/st,lis2dh-common.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2018 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
+include: sensor-device.yaml
+
 properties:
     irq-gpios:
       type: phandle-array

--- a/dts/bindings/sensor/st,lis2ds12-common.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-common.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2021 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
+include: sensor-device.yaml
+
 properties:
     irq-gpios:
       type: phandle-array

--- a/dts/bindings/sensor/st,lis2dw12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-common.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2021 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
+include: sensor-device.yaml
+
 properties:
     irq-gpios:
       type: phandle-array

--- a/dts/bindings/sensor/st,lis2mdl-common.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-common.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2018 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
+include: sensor-device.yaml
+
 properties:
     irq-gpios:
       type: phandle-array

--- a/dts/bindings/sensor/st,lis3mdl-magn.yaml
+++ b/dts/bindings/sensor/st,lis3mdl-magn.yaml
@@ -5,7 +5,7 @@ description: STMicroelectronics LIS3MDL magnetometer
 
 compatible: "st,lis3mdl-magn"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     irq-gpios:

--- a/dts/bindings/sensor/st,lps22hb-press.yaml
+++ b/dts/bindings/sensor/st,lps22hb-press.yaml
@@ -5,4 +5,4 @@ description: STMicroelectronics LPS22HB pressure sensor
 
 compatible: "st,lps22hb-press"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/st,lps22hh-common.yaml
+++ b/dts/bindings/sensor/st,lps22hh-common.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2021 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
+include: sensor-device.yaml
+
 properties:
     drdy-gpios:
       type: phandle-array

--- a/dts/bindings/sensor/st,lps25hb-press.yaml
+++ b/dts/bindings/sensor/st,lps25hb-press.yaml
@@ -5,4 +5,4 @@ description: STMicroelectronics LPS25HB pressure sensor
 
 compatible: "st,lps25hb-press"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/st,lsm303dlhc-magn.yaml
+++ b/dts/bindings/sensor/st,lsm303dlhc-magn.yaml
@@ -5,4 +5,4 @@ description: STMicroelectronics LSM303DLHC magnetometer sensor
 
 compatible: "st,lsm303dlhc-magn"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/st,lsm6ds0.yaml
+++ b/dts/bindings/sensor/st,lsm6ds0.yaml
@@ -5,4 +5,4 @@ description: STMicroelectronics LSM6DS0 6-axis accelerometer and gyrometer
 
 compatible: "st,lsm6ds0"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
@@ -5,7 +5,7 @@ description: STMicroelectronics LSM6DSL 6-axis accelerometer and gyrometer
 
 compatible: "st,lsm6dsl"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     irq-gpios:

--- a/dts/bindings/sensor/st,lsm6dsl-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-spi.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "st,lsm6dsl"
 
-include: spi-device.yaml
+include: [sensor-device.yaml, spi-device.yaml]
 
 properties:
     irq-gpios:

--- a/dts/bindings/sensor/st,lsm6dso-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-common.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2021 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
+include: sensor-device.yaml
+
 properties:
     irq-gpios:
       type: phandle-array

--- a/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
@@ -5,7 +5,7 @@ description: STMicroelectronics LSM9DS0-GYRO 3-axis gyro
 
 compatible: "st,lsm9ds0-gyro"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     irq-gpios:

--- a/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
@@ -5,7 +5,7 @@ description: STMicroelectronics LSM9DS0 3-axis accelerometer + magnetometer
 
 compatible: "st,lsm9ds0-mfd"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     irq-gpios:

--- a/dts/bindings/sensor/st,stm32-temp-common.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-common.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2022, Wouter Cappelle
 # SPDX-License-Identifier: Apache-2.0
 
+include: sensor-device.yaml
+
 properties:
     io-channels:
       required: true

--- a/dts/bindings/sensor/st,stm32-vbat.yaml
+++ b/dts/bindings/sensor/st,stm32-vbat.yaml
@@ -3,7 +3,7 @@
 
 description: STM32 family VBAT node
 
-include: base.yaml
+include: sensor-device.yaml
 
 compatible: "st,stm32-vbat"
 

--- a/dts/bindings/sensor/st,stts751-i2c.yaml
+++ b/dts/bindings/sensor/st,stts751-i2c.yaml
@@ -6,7 +6,7 @@ description: |
 
 compatible: "st,stts751"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     drdy-gpios:

--- a/dts/bindings/sensor/st,vl53l0x.yaml
+++ b/dts/bindings/sensor/st,vl53l0x.yaml
@@ -5,7 +5,7 @@ description: STMicroelectronics VL53L0X Time of Flight sensor
 
 compatible: "st,vl53l0x"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     xshut-gpios:

--- a/dts/bindings/sensor/ti,bq274xx.yaml
+++ b/dts/bindings/sensor/ti,bq274xx.yaml
@@ -8,7 +8,7 @@ description: Texas Instruments BQ274xx Fuel Gauge
 
 compatible: "ti,bq274xx"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     design-voltage:

--- a/dts/bindings/sensor/ti,fdc2x1x.yaml
+++ b/dts/bindings/sensor/ti,fdc2x1x.yaml
@@ -5,7 +5,7 @@ description: Texas Instruments FDC2X1X capacitive sensor
 
 compatible: "ti,fdc2x1x"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     sd-gpios:

--- a/dts/bindings/sensor/ti,hdc.yaml
+++ b/dts/bindings/sensor/ti,hdc.yaml
@@ -5,7 +5,7 @@ description: Texas Instruments temperature and humidity sensor (e.g. HDC1008)
 
 compatible: "ti,hdc"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     drdy-gpios:

--- a/dts/bindings/sensor/ti,hdc20xx.yaml
+++ b/dts/bindings/sensor/ti,hdc20xx.yaml
@@ -5,7 +5,7 @@ description: Texas Instruments HDC20XX Temperature and Humidity Sensor
 
 compatible: "ti,hdc20xx"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/ti,ina219.yaml
+++ b/dts/bindings/sensor/ti,ina219.yaml
@@ -5,7 +5,7 @@ description: Texas Instruments Bidirectional Current/Power Sensor
 
 compatible: "ti,ina219"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     lsb-microamp:

--- a/dts/bindings/sensor/ti,ina23x-common.yaml
+++ b/dts/bindings/sensor/ti,ina23x-common.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     config:

--- a/dts/bindings/sensor/ti,opt3001.yaml
+++ b/dts/bindings/sensor/ti,opt3001.yaml
@@ -5,4 +5,4 @@ description: Texas Instruments OPT3001 ambient light sensor
 
 compatible: "ti,opt3001"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/ti,tmp007.yaml
+++ b/dts/bindings/sensor/ti,tmp007.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "ti,tmp007"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/ti,tmp108.yaml
+++ b/dts/bindings/sensor/ti,tmp108.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "ti,tmp108"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     alert-gpios:

--- a/dts/bindings/sensor/ti,tmp112.yaml
+++ b/dts/bindings/sensor/ti,tmp112.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "ti,tmp112"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
   conversion-rate:

--- a/dts/bindings/sensor/ti,tmp116.yaml
+++ b/dts/bindings/sensor/ti,tmp116.yaml
@@ -7,4 +7,4 @@ compatible: "ti,tmp116"
 
 bus: tmp116
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/vishay,vcnl4040.yaml
+++ b/dts/bindings/sensor/vishay,vcnl4040.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "vishay,vcnl4040"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/we,wsen-hids-common.yaml
+++ b/dts/bindings/sensor/we,wsen-hids-common.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2022 Würth Elektronik eiSos GmbH & Co. KG
 # SPDX-License-Identifier: Apache-2.0
 
+include: sensor-device.yaml
+
 properties:
     drdy-gpios:
       type: phandle-array

--- a/dts/bindings/sensor/we,wsen-itds.yaml
+++ b/dts/bindings/sensor/we,wsen-itds.yaml
@@ -5,7 +5,7 @@ description: WSEN-ITDS 3-axis accel sensor
 
 compatible: "we,wsen-itds"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     int-gpios:

--- a/dts/bindings/sensor/winsen,mhz19b.yaml
+++ b/dts/bindings/sensor/winsen,mhz19b.yaml
@@ -5,7 +5,7 @@ description: Winsen MHZ-19B CO2 Sensor
 
 compatible: "winsen,mhz19b"
 
-include: uart-device.yaml
+include: [sensor-device.yaml, uart-device.yaml]
 
 properties:
   maximum-range:


### PR DESCRIPTION
Introduces an initial set of devicetree properties to be inherited by
all sensor devices, similar to how we define a base set of devicetree
properties for I2C and SPI devices. These properties will be used by the
future sensor subsystem to manage and expose sensors to a host operating
system, through HID or another protocol.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>

Fixes #48148
cc: @huhebo

This PR differs from #49294 in that it introduces only one base sensor property and migrates all in-tree sensor bindings instead of just ST and NXP. Additional base sensor properties can be added in follow-up PRs.