### PR TITLE
soc: drivers: mcux*: fix usage of concat macro

### DIFF
--- a/drivers/adc/adc_mcux_12b1msps_sar.c
+++ b/drivers/adc/adc_mcux_12b1msps_sar.c
@@ -274,7 +274,6 @@ static const struct adc_driver_api mcux_12b1msps_sar_adc_driver_api = {
 	BUILD_ASSERT(val >= min && val <= max, str)
 #define ASSERT_RT_ADC_CLK_DIV_VALID(val, str) \
 	BUILD_ASSERT(val == 1 || val == 2 || val == 4 || val == 8, str)
-#define TO_RT_ADC_CLOCK_DIV(val) _DO_CONCAT(kADC_ClockDriver, val)
 
 #define ACD_MCUX_12B1MSPS_SAR_INIT(n)						       \
 	static void mcux_12b1msps_sar_adc_config_func_##n(const struct device *dev);     \
@@ -289,7 +288,7 @@ static const struct adc_driver_api mcux_12b1msps_sar_adc_driver_api = {
 		.base = (ADC_Type *)DT_INST_REG_ADDR(n),		       \
 		.clock_src = kADC_ClockSourceAD,			       \
 		.clock_drv =						       \
-			TO_RT_ADC_CLOCK_DIV(DT_INST_PROP(n, clk_divider)),     \
+			_CONCAT(kADC_ClockDriver, DT_INST_PROP(n, clk_divider)),     \
 		.ref_src = kADC_ReferenceVoltageSourceAlt0,		       \
 		.sample_period_mode = DT_INST_PROP(n, sample_period_mode),     \
 		.irq_config_func = mcux_12b1msps_sar_adc_config_func_##n,	\

--- a/drivers/adc/adc_mcux_adc12.c
+++ b/drivers/adc/adc_mcux_adc12.c
@@ -258,8 +258,6 @@ static const struct adc_driver_api mcux_adc12_driver_api = {
 	BUILD_ASSERT(val >= min && val <= max, str)
 #define ASSERT_ADC12_CLK_DIV_VALID(val, str) \
 	BUILD_ASSERT(val == 1 || val == 2 || val == 4 || val == 8, str)
-#define TO_ADC12_CLOCK_SRC(val) _DO_CONCAT(kADC12_ClockSourceAlt, val)
-#define TO_ADC12_CLOCK_DIV(val) _DO_CONCAT(kADC12_ClockDivider, val)
 
 #define ADC12_REF_SRC(n)						\
 	COND_CODE_1(DT_INST_PROP(0, alternate_voltage_reference),	\
@@ -279,9 +277,9 @@ static const struct adc_driver_api mcux_adc12_driver_api = {
 			    "Invalid sample time");			\
 	static const struct mcux_adc12_config mcux_adc12_config_##n = {	\
 		.base = (ADC_Type *)DT_INST_REG_ADDR(n),		\
-		.clock_src = TO_ADC12_CLOCK_SRC(DT_INST_PROP(n, clk_source)),\
+		.clock_src = _CONCAT(kADC12_ClockSourceAlt, DT_INST_PROP(n, clk_source)),\
 		.clock_div =						\
-			TO_ADC12_CLOCK_DIV(DT_INST_PROP(n, clk_divider)),\
+			_CONCAT(kADC12_ClockDivider, DT_INST_PROP(n, clk_divider)),\
 		.ref_src = ADC12_REF_SRC(n),				\
 		.sample_clk_count = DT_INST_PROP(n, sample_time),	\
 		.irq_config_func = mcux_adc12_config_func_##n,		\

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -391,19 +391,13 @@ static const struct adc_driver_api mcux_lpadc_driver_api = {
 	MUX_A(CM_ADCASYNCCLKSEL, val)
 #endif
 
-#define TO_LPADC_REFERENCE_VOLTAGE(val) \
-	_DO_CONCAT(kLPADC_ReferenceVoltageAlt, val)
-
 #if defined(FSL_FEATURE_LPADC_HAS_CTRL_CAL_AVGS)\
 	&& FSL_FEATURE_LPADC_HAS_CTRL_CAL_AVGS
 #define TO_LPADC_CALIBRATION_AVERAGE(val) \
-	_DO_CONCAT(kLPADC_ConversionAverage, val)
+	_CONCAT(kLPADC_ConversionAverage, val)
 #else
 #define TO_LPADC_CALIBRATION_AVERAGE(val) 0
 #endif
-
-#define TO_LPADC_POWER_LEVEL(val) \
-	_DO_CONCAT(kLPADC_PowerLevelAlt, val)
 
 #if CONFIG_PINCTRL
 #define PINCTRL_DEFINE(n) PINCTRL_DT_INST_DEFINE(n);
@@ -433,10 +427,10 @@ static const struct adc_driver_api mcux_lpadc_driver_api = {
 		.clock_source = TO_LPADC_CLOCK_SOURCE(DT_INST_PROP(n, clk_source)),	\
 		.clock_div = DT_INST_PROP(n, clk_divider),					\
 		.voltage_ref =												\
-			TO_LPADC_REFERENCE_VOLTAGE(DT_INST_PROP(n, voltage_ref)),	\
+			_CONCAT(kLPADC_ReferenceVoltageAlt, DT_INST_PROP(n, voltage_ref)),	\
 		.calibration_average =										\
 			TO_LPADC_CALIBRATION_AVERAGE(DT_INST_PROP(n, calibration_average)),	\
-		.power_level = TO_LPADC_POWER_LEVEL(DT_INST_PROP(n, power_level)),	\
+		.power_level = _CONCAT(kLPADC_PowerLevelAlt, DT_INST_PROP(n, power_level)),	\
 		.offset_a = DT_INST_PROP(n, offset_value_a),	\
 		.offset_a = DT_INST_PROP(n, offset_value_b),	\
 		.irq_config_func = mcux_lpadc_config_func_##n,				\

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -150,9 +150,6 @@ static const struct counter_driver_api mcux_lptmr_driver_api = {
 	.get_top_value = mcux_lptmr_get_top_value,
 };
 
-#define TO_LPTMR_CLK_SEL(val) _DO_CONCAT(kLPTMR_PrescalerClock_, val)
-#define TO_LPTMR_PIN_SEL(val) _DO_CONCAT(kLPTMR_PinSelectInput_, val)
-
 /* Prescaler mapping */
 #define LPTMR_PRESCALER_2     kLPTMR_Prescale_Glitch_0
 #define LPTMR_PRESCALER_4     kLPTMR_Prescale_Glitch_1
@@ -170,7 +167,6 @@ static const struct counter_driver_api mcux_lptmr_driver_api = {
 #define LPTMR_PRESCALER_16384 kLPTMR_Prescale_Glitch_13
 #define LPTMR_PRESCALER_32768 kLPTMR_Prescale_Glitch_14
 #define LPTMR_PRESCALER_65536 kLPTMR_Prescale_Glitch_15
-#define TO_LPTMR_PRESCALER(val) _DO_CONCAT(LPTMR_PRESCALER_, val)
 
 /* Glitch filter mapping */
 #define LPTMR_GLITCH_2     kLPTMR_Prescale_Glitch_1
@@ -188,7 +184,6 @@ static const struct counter_driver_api mcux_lptmr_driver_api = {
 #define LPTMR_GLITCH_8192  kLPTMR_Prescale_Glitch_13
 #define LPTMR_GLITCH_16384 kLPTMR_Prescale_Glitch_14
 #define LPTMR_GLITCH_32768 kLPTMR_Prescale_Glitch_15
-#define TO_LPTMR_GLITCH(val) _DO_CONCAT(LPTMR_GLITCH_, val)
 
 /*
  * This driver is single-instance. If the devicetree contains multiple
@@ -211,22 +206,22 @@ static struct mcux_lptmr_config mcux_lptmr_config_0 = {
 		.channels = 0,
 	},
 	.base = (LPTMR_Type *)DT_INST_REG_ADDR(0),
-	.clk_source = TO_LPTMR_CLK_SEL(DT_INST_PROP(0, clk_source)),
+	.clk_source = _CONCAT(kLPTMR_PrescalerClock_, DT_INST_PROP(0, clk_source),
 #if DT_INST_NODE_HAS_PROP(0, input_pin)
 #if DT_INST_PROP(0, prescaler) == 1
 	.bypass_prescaler_glitch = true,
 #else
-	.prescaler_glitch = TO_LPTMR_GLITCH(DT_INST_PROP(0, prescaler)),
+	.prescaler_glitch = _CONCAT(LPTMR_GLITCH_, DT_INST_PROP(0, prescaler),
 #endif
 	.mode = kLPTMR_TimerModePulseCounter,
-	.pin = TO_LPTMR_PIN_SEL(DT_INST_PROP(0, input_pin)),
+	.pin = _CONCAT(kLPTMR_PinSelectInput_, DT_INST_PROP(0, input_pin),
 	.polarity = DT_INST_PROP(0, active_low),
 #else /* !DT_INST_NODE_HAS_PROP(0, input_pin) */
 	.mode = kLPTMR_TimerModeTimeCounter,
 #if DT_INST_PROP(0, prescaler) == 1
 	.bypass_prescaler_glitch = true,
 #else
-	.prescaler_glitch = TO_LPTMR_PRESCALER(DT_INST_PROP(0, prescaler)),
+	.prescaler_glitch = _CONCAT(LPTMR_PRESCALER_, DT_INST_PROP(0, prescaler),
 #endif
 #endif /* !DT_INST_NODE_HAS_PROP(0, input_pin) */
 	.irq_config_func = mcux_lptmr_irq_config_0,

--- a/drivers/dac/dac_mcux_dac.c
+++ b/drivers/dac/dac_mcux_dac.c
@@ -92,16 +92,13 @@ static const struct dac_driver_api mcux_dac_driver_api = {
 	.write_value = mcux_dac_write_value,
 };
 
-#define TO_DAC_VREF_SRC(val) \
-	_DO_CONCAT(kDAC_ReferenceVoltageSourceVref, val)
-
 #define MCUX_DAC_INIT(n) \
 	static struct mcux_dac_data mcux_dac_data_##n;			\
 									\
 	static const struct mcux_dac_config mcux_dac_config_##n = {	\
 		.base = (DAC_Type *)DT_INST_REG_ADDR(n),		\
 		.reference =						\
-		TO_DAC_VREF_SRC(DT_INST_PROP(n, voltage_reference)),	\
+		_CONCAT(kDAC_ReferenceVoltageSourceVref, DT_INST_PROP(n, voltage_reference)),\
 		.low_power = DT_INST_PROP(n, low_power_mode),		\
 	};								\
 									\

--- a/drivers/dac/dac_mcux_dac32.c
+++ b/drivers/dac/dac_mcux_dac32.c
@@ -101,9 +101,6 @@ static const struct dac_driver_api mcux_dac32_driver_api = {
 	.write_value = mcux_dac32_write_value,
 };
 
-#define TO_DAC32_VREF_SRC(val) \
-	_DO_CONCAT(kDAC32_ReferenceVoltageSourceVref, val)
-
 #define MCUX_DAC32_INIT(n) \
 	static struct mcux_dac32_data mcux_dac32_data_##n;		\
 									\
@@ -112,7 +109,7 @@ static const struct dac_driver_api mcux_dac32_driver_api = {
 	static const struct mcux_dac32_config mcux_dac32_config_##n = {	\
 		.base = (DAC_Type *)DT_INST_REG_ADDR(n),		\
 		.reference =						\
-		TO_DAC32_VREF_SRC(DT_INST_PROP(n, voltage_reference)),	\
+		_CONCAT(kDAC32_ReferenceVoltageSourceVref, DT_INST_PROP(n, voltage_reference)),	\
 		.buffered = DT_INST_PROP(n, buffered),			\
 		.low_power = DT_INST_PROP(n, low_power_mode),		\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -452,8 +452,6 @@ static const struct pwm_driver_api mcux_ftm_driver_api = {
 #endif /* CONFIG_PWM_CAPTURE */
 };
 
-#define TO_FTM_PRESCALE_DIVIDE(val) _DO_CONCAT(kFTM_Prescale_Divide_, val)
-
 #ifdef CONFIG_PWM_CAPTURE
 #define FTM_CONFIG_FUNC(n) \
 static void mcux_ftm_config_func_##n(const struct device *dev) \
@@ -478,7 +476,7 @@ static const struct mcux_ftm_config mcux_ftm_config_##n = { \
 	.clock_subsys = (clock_control_subsys_t) \
 		DT_INST_CLOCKS_CELL(n, name), \
 	.ftm_clock_source = kFTM_FixedClock, \
-	.prescale = TO_FTM_PRESCALE_DIVIDE(DT_INST_PROP(n, prescaler)),\
+	.prescale = _CONCAT(kFTM_Prescale_Divide_, DT_INST_PROP(n, prescaler)),\
 	.channel_count = FSL_FEATURE_FTM_CHANNEL_COUNTn((FTM_Type *) \
 		DT_INST_REG_ADDR(n)), \
 	.mode = kFTM_EdgeAlignedPwm, \

--- a/drivers/pwm/pwm_mcux_pwt.c
+++ b/drivers/pwm/pwm_mcux_pwt.c
@@ -318,8 +318,6 @@ static const struct pwm_driver_api mcux_pwt_driver_api = {
 	.disable_capture = mcux_pwt_disable_capture,
 };
 
-#define TO_PWT_PRESCALE_DIVIDE(val) _DO_CONCAT(kPWT_Prescale_Divide_, val)
-
 #define PWT_DEVICE(n) \
 	static void mcux_pwt_config_func_##n(const struct device *dev);	\
 									\
@@ -332,7 +330,7 @@ static const struct pwm_driver_api mcux_pwt_driver_api = {
 		(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),	\
 		.pwt_clock_source = kPWT_BusClock,			\
 		.prescale =						\
-		TO_PWT_PRESCALE_DIVIDE(DT_INST_PROP(n, prescaler)),	\
+		_CONCAT(kPWT_Prescale_Divide_, DT_INST_PROP(n, prescaler)),\
 		.irq_config_func = mcux_pwt_config_func_##n,		\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
 	};								\

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -30,15 +30,11 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 #define LPTMR_PRESCALER_16384 kLPTMR_Prescale_Glitch_13
 #define LPTMR_PRESCALER_32768 kLPTMR_Prescale_Glitch_14
 #define LPTMR_PRESCALER_65536 kLPTMR_Prescale_Glitch_15
-#define TO_LPTMR_PRESCALER(val) _DO_CONCAT(LPTMR_PRESCALER_, val)
-
-/* Prescaler clock mapping */
-#define TO_LPTMR_CLK_SEL(val) _DO_CONCAT(kLPTMR_PrescalerClock_, val)
 
 /* Devicetree properties */
 #define LPTMR_BASE ((LPTMR_Type *)(DT_INST_REG_ADDR(0)))
-#define LPTMR_CLK_SOURCE TO_LPTMR_CLK_SEL(DT_INST_PROP(0, clk_source));
-#define LPTMR_PRESCALER TO_LPTMR_PRESCALER(DT_INST_PROP(0, prescaler));
+#define LPTMR_CLK_SOURCE _CONCAT(kLPTMR_PrescalerClock_, DT_INST_PROP(0, clk_source));
+#define LPTMR_PRESCALER _CONCAT(LPTMR_PRESCALER_, DT_INST_PROP(0, prescaler));
 #define LPTMR_BYPASS_PRESCALER DT_INST_PROP(0, prescaler) == 1
 #define LPTMR_IRQN DT_INST_IRQN(0)
 #define LPTMR_IRQ_PRIORITY DT_INST_IRQ(0, priority)

--- a/drivers/watchdog/wdt_mcux_wdog32.c
+++ b/drivers/watchdog/wdt_mcux_wdog32.c
@@ -184,9 +184,6 @@ static const struct wdt_driver_api mcux_wdog32_api = {
 	.feed = mcux_wdog32_feed,
 };
 
-#define TO_WDOG32_CLK_SRC(val) _DO_CONCAT(kWDOG32_ClockSource, val)
-#define TO_WDOG32_CLK_DIV(val) _DO_CONCAT(kWDOG32_ClockPrescalerDivide, val)
-
 static void mcux_wdog32_config_func_0(const struct device *dev);
 
 static const struct mcux_wdog32_config mcux_wdog32_config_0 = {
@@ -198,10 +195,8 @@ static const struct mcux_wdog32_config mcux_wdog32_config_0 = {
 	.clock_subsys = (clock_control_subsys_t)
 		DT_INST_CLOCKS_CELL(0, name),
 #endif /* DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency) */
-	.clk_source =
-		TO_WDOG32_CLK_SRC(DT_INST_PROP(0, clk_source)),
-	.clk_divider =
-		TO_WDOG32_CLK_DIV(DT_INST_PROP(0, clk_divider)),
+	.clk_source = _CONCAT(kWDOG32_ClockSource, DT_INST_PROP(0, clk_source)),
+	.clk_divider = _CONCAT(kWDOG32_ClockPrescalerDivide, DT_INST_PROP(0, clk_divider)),
 	.irq_config_func = mcux_wdog32_config_func_0,
 };
 

--- a/soc/arm/nxp_kinetis/ke1xf/soc.c
+++ b/soc/arm/nxp_kinetis/ke1xf/soc.c
@@ -22,10 +22,7 @@
 	BUILD_ASSERT(val == 0 || val == 1 || val == 2 || val == 4 ||	\
 		     val == 8 || val == 16 || val == 2 || val == 64, str)
 
-#define TO_SYS_CLK_DIV(val) _DO_CONCAT(kSCG_SysClkDivBy, val)
-
 #define kSCG_AsyncClkDivBy0 kSCG_AsyncClkDisable
-#define TO_ASYNC_CLK_DIV(val) _DO_CONCAT(kSCG_AsyncClkDivBy, val)
 
 #define SCG_CLOCK_NODE(name) DT_CHILD(DT_INST(0, nxp_kinetis_scg), name)
 #define SCG_CLOCK_DIV(name) DT_PROP(SCG_CLOCK_NODE(name), clock_div)
@@ -45,9 +42,9 @@ ASSERT_WITHIN_RANGE(SCG_CLOCK_DIV(core_clk), 1, 16,
 		    "Invalid SCG core clock divider value");
 #endif
 static const scg_sys_clk_config_t scg_sys_clk_config = {
-	.divSlow = TO_SYS_CLK_DIV(SCG_CLOCK_DIV(slow_clk)),
-	.divBus  = TO_SYS_CLK_DIV(SCG_CLOCK_DIV(bus_clk)),
-	.divCore = TO_SYS_CLK_DIV(SCG_CLOCK_DIV(core_clk)),
+	.divSlow = _CONCAT(kSCG_SysClkDivBy, SCG_CLOCK_DIV(slow_clk)),
+	.divBus  = _CONCAT(kSCG_SysClkDivBy, SCG_CLOCK_DIV(bus_clk)),
+	.divCore = _CONCAT(kSCG_SysClkDivBy, SCG_CLOCK_DIV(core_clk)),
 #if DT_SAME_NODE(DT_CLOCKS_CTLR(SCG_CLOCK_NODE(core_clk)), SCG_CLOCK_NODE(sosc_clk))
 	.src     = kSCG_SysClkSrcSysOsc,
 #elif DT_SAME_NODE(DT_CLOCKS_CTLR(SCG_CLOCK_NODE(core_clk)), SCG_CLOCK_NODE(sirc_clk))
@@ -71,8 +68,8 @@ static const scg_sosc_config_t scg_sosc_config = {
 	.freq        = DT_PROP(SCG_CLOCK_NODE(sosc_clk), clock_frequency),
 	.monitorMode = kSCG_SysOscMonitorDisable,
 	.enableMode  = kSCG_SysOscEnable | kSCG_SysOscEnableInLowPower,
-	.div1        = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(soscdiv1_clk)),
-	.div2        = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(soscdiv2_clk)),
+	.div1        = _CONCAT(kSCG_AsyncClkDivBy, SCG_CLOCK_DIV(soscdiv1_clk)),
+	.div2        = _CONCAT(kSCG_AsyncClkDivBy, SCG_CLOCK_DIV(soscdiv2_clk)),
 	.workMode    = DT_PROP(DT_INST(0, nxp_kinetis_scg), sosc_mode)
 };
 #endif /* DT_NODE_HAS_PROP(DT_INST(0, nxp_kinetis_scg), sosc_freq) */
@@ -84,8 +81,8 @@ ASSERT_ASYNC_CLK_DIV_VALID(SCG_CLOCK_DIV(sircdiv2_clk),
 		       "Invalid SCG SIRC divider 2 value");
 static const scg_sirc_config_t scg_sirc_config = {
 	.enableMode = kSCG_SircEnable | kSCG_SircEnableInLowPower,
-	.div1       = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(sircdiv1_clk)),
-	.div2       = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(sircdiv2_clk)),
+	.div1       = _CONCAT(kSCG_AsyncClkDivBy, SCG_CLOCK_DIV(sircdiv1_clk)),
+	.div2       = _CONCAT(kSCG_AsyncClkDivBy, SCG_CLOCK_DIV(sircdiv2_clk)),
 #if MHZ(2) == DT_PROP(SCG_CLOCK_NODE(sirc_clk), clock_frequency)
 	.range      = kSCG_SircRangeLow
 #elif MHZ(8) == DT_PROP(SCG_CLOCK_NODE(sirc_clk), clock_frequency)
@@ -102,8 +99,8 @@ ASSERT_ASYNC_CLK_DIV_VALID(SCG_CLOCK_DIV(fircdiv2_clk),
 		       "Invalid SCG FIRC divider 2 value");
 static const scg_firc_config_t scg_firc_config = {
 	.enableMode = kSCG_FircEnable,
-	.div1       = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(fircdiv1_clk)),
-	.div2       = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(fircdiv2_clk)),
+	.div1       = _CONCAT(kSCG_AsyncClkDivBy, SCG_CLOCK_DIV(fircdiv1_clk)),
+	.div2       = _CONCAT(kSCG_AsyncClkDivBy, SCG_CLOCK_DIV(fircdiv2_clk)),
 #if MHZ(48) == DT_PROP(SCG_CLOCK_NODE(firc_clk), clock_frequency)
 	.range      = kSCG_FircRange48M,
 #elif MHZ(52) == DT_PROP(SCG_CLOCK_NODE(firc_clk), clock_frequency)
@@ -132,8 +129,8 @@ ASSERT_WITHIN_RANGE(SCG_CLOCK_MULT(pll), 16, 47,
 static const scg_spll_config_t scg_spll_config = {
 	.enableMode  = kSCG_SysPllEnable,
 	.monitorMode = kSCG_SysPllMonitorDisable,
-	.div1        = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(splldiv1_clk)),
-	.div2        = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(splldiv2_clk)),
+	.div1        = _CONCAT(kSCG_AsyncClkDivBy, SCG_CLOCK_DIV(splldiv1_clk)),
+	.div2        = _CONCAT(kSCG_AsyncClkDivBy, SCG_CLOCK_DIV(splldiv2_clk)),
 #if DT_SAME_NODE(DT_CLOCKS_CTLR(SCG_CLOCK_NODE(pll)), SCG_CLOCK_NODE(sosc_clk))
 	.src         = kSCG_SysPllSrcSysOsc,
 #elif DT_SAME_NODE(DT_CLOCKS_CTLR(SCG_CLOCK_NODE(pll)), SCG_CLOCK_NODE(firc_clk))


### PR DESCRIPTION
Remove not needed helper macros and use `_CONCAT` macro directly.

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>