### PR TITLE
doc/storage/flash_map: Move to FIXED_PARTITION_ API

### DIFF
--- a/doc/services/storage/flash_map/example_fragment.dts
+++ b/doc/services/storage/flash_map/example_fragment.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2022 Nordic Semiconductor ASA
  */
 /* start-after-here */
 / {
@@ -15,24 +15,19 @@
 					#size-cells = <0x1>;
 
 					boot_partition: partition@0 {
-						label = "mcuboot";
 						reg = <0x0 0x10000>;
 						read-only;
 					};
 					storage_partition: partition@1e000 {
-						label = "storage";
 						reg = <0x1e000 0x2000>;
 					};
 					slot0_partition: partition@20000 {
-						label = "image-0";
 						reg = <0x20000 0x60000>;
 					};
 					slot1_partition: partition@80000 {
-						label = "image-1";
 						reg = <0x80000 0x60000>;
 					};
 					scratch_partition: partition@e0000 {
-						label = "image-scratch";
 						reg = <0xe0000 0x20000>;
 					};
 				};


### PR DESCRIPTION
Rework of documentation that replaces nformation on FLASH_AREA_ macro usage with information on FIXED_PARTITION_ macros.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>