### PR TITLE
mgmt: mcumgr: Add fs_mgmt log output workaround on file write

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -197,6 +197,11 @@ Libraries / Subsystems
   * MCUMGR functionality deprecated in 3.1 has been removed:
     CONFIG_FS_MGMT_UL_CHUNK_SIZE, CONFIG_IMG_MGMT_UL_CHUNK_SIZE,
     CONFIG_OS_MGMT_ECHO_LENGTH
+  * MCUMGR fs_mgmt issue with erasing a file prior to writing the first block
+    of data has been worked around by only truncating/deleting the file data
+    if the file exists. This can help work around an issue whereby logging is
+    enabled and the command is sent on the same UART as the logging system, in
+    which a filesystem error was emitted.
 
 HALs
 ****


### PR DESCRIPTION
    If a file write was attempted with a file that does not exist, over
    the shell/UART when logging was enabled, it would output a fs_unlink
    error, this works around the issue by checking if the file exists and
    needs truncating before performing that action. It also imrproves
    flash endurance slightly by performing a truncate operation instead
    of a delete, but will fall back to a delete if the truncation
    operation fails. This issue can be also be mitigated by altering
    logging settings or adjusting the SMP thread priority.

Fixes #36882

Note that this only fixes the specific issue mentioned, there might be other potential errors emitted if filesystem errors are encountered, however the `mcumgr` client is actually to blame for this as it should be searching through the received data for the mcumgr start header, 0x06 0x09, which it does not do.