### PR TITLE
init: multiple cleanups

### DIFF
--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -80,7 +80,7 @@ struct init_entry {
  * Each init entry is placed in a section with a name crafted so that it allows
  * linker scripts to sort them according to the specified level/priority.
  */
-#define Z_INIT_ENTRY_SECTION(level, prio) \
+#define Z_INIT_ENTRY_SECTION(level, prio)                                      \
 	__attribute__((__section__(".z_init_" #level STRINGIFY(prio)"_")))
 
 /**
@@ -98,12 +98,12 @@ struct init_entry {
  *
  * @see SYS_INIT()
  */
-#define Z_INIT_ENTRY_DEFINE(init_id, init_fn, device, level, prio)	\
-	static const Z_DECL_ALIGN(struct init_entry)			\
-		Z_INIT_ENTRY_NAME(init_id) __used __noasan		\
-		Z_INIT_ENTRY_SECTION(level, prio) = { 			\
-		.init = (init_fn),					\
-		.dev = (device),					\
+#define Z_INIT_ENTRY_DEFINE(init_id, init_fn, device, level, prio)             \
+	static const Z_DECL_ALIGN(struct init_entry)                           \
+		Z_INIT_ENTRY_SECTION(level, prio) __used __noasan              \
+		Z_INIT_ENTRY_NAME(init_id) = {                                 \
+			.init = (init_fn),                                     \
+			.dev = (device),                                       \
 	}
 
 /** @endcond */
@@ -124,7 +124,7 @@ struct init_entry {
  * expressions are **not** permitted (e.g.
  * `CONFIG_KERNEL_INIT_PRIORITY_DEFAULT + 5`).
  */
-#define SYS_INIT(init_fn, level, prio)					\
+#define SYS_INIT(init_fn, level, prio)                                         \
 	SYS_INIT_NAMED(init_fn, init_fn, level, prio)
 
 /**
@@ -140,7 +140,7 @@ struct init_entry {
  *
  * @see SYS_INIT()
  */
-#define SYS_INIT_NAMED(name, init_fn, level, prio)				\
+#define SYS_INIT_NAMED(name, init_fn, level, prio)                             \
 	Z_INIT_ENTRY_DEFINE(name, init_fn, NULL, level, prio)
 
 /** @} */

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -16,22 +16,6 @@
 extern "C" {
 #endif
 
-/*
- * System initialization levels. The PRE_KERNEL_1 and PRE_KERNEL_2 levels are
- * executed in the kernel's initialization context, which uses the interrupt
- * stack. The remaining levels are executed in the kernel's main task.
- */
-
-#define _SYS_INIT_LEVEL_EARLY		0
-#define _SYS_INIT_LEVEL_PRE_KERNEL_1	1
-#define _SYS_INIT_LEVEL_PRE_KERNEL_2	2
-#define _SYS_INIT_LEVEL_POST_KERNEL	3
-#define _SYS_INIT_LEVEL_APPLICATION	4
-
-#ifdef CONFIG_SMP
-#define _SYS_INIT_LEVEL_SMP		5
-#endif
-
 struct device;
 
 /**

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -70,6 +70,15 @@ void z_sys_init_run_level(int32_t level);
 #define Z_INIT_ENTRY_NAME(_entry_name) _CONCAT(__init_, _entry_name)
 
 /**
+ * @brief Init entry section.
+ *
+ * Each init entry is placed in a section with a name crafted so that it allows
+ * linker scripts to sort them according to the specified level/priority.
+ */
+#define Z_INIT_ENTRY_SECTION(level, prio) \
+	__attribute__((__section__(".z_init_" #level STRINGIFY(prio)"_")))
+
+/**
  * @brief Create an init entry object and set it up for boot time initialization
  *
  * @details This macro defines an init entry object that will be automatically
@@ -94,7 +103,7 @@ void z_sys_init_run_level(int32_t level);
 #define Z_INIT_ENTRY_DEFINE(_entry_name, _init_fn, _device, _level, _prio)	\
 	static const Z_DECL_ALIGN(struct init_entry)			\
 		Z_INIT_ENTRY_NAME(_entry_name) __used __noasan			\
-	__attribute__((__section__(".z_init_" #_level STRINGIFY(_prio)"_"))) = { \
+		Z_INIT_ENTRY_SECTION(_level, _prio) = { 			\
 		.init = (_init_fn),					\
 		.dev = (_device),					\
 	}

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -53,8 +53,6 @@ struct init_entry {
 	const struct device *dev;
 };
 
-void z_sys_init_run_level(int32_t level);
-
 /**
  * @brief Construct a namespaced identifier for SYS_INIT instance
  *

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -77,9 +77,9 @@ struct init_entry {
 /**
  * @brief Construct a namespaced identifier for a struct init_entry instance
  *
- * @param entry_name Base unique name
+ * @param init_id Base unique name
  */
-#define Z_INIT_ENTRY_NAME(entry_name) _CONCAT(__init_, entry_name)
+#define Z_INIT_ENTRY_NAME(init_id) _CONCAT(__init_, init_id)
 
 /**
  * @brief Init entry section.
@@ -97,7 +97,7 @@ struct init_entry {
  * configured by the kernel during system initialization. Note that init
  * entries will not be accessible from user mode.
  *
- * @param entry_name Init entry name.
+ * @param init_id Init entry unique identifier.
  * @param init_fn Init function.
  * @param device Device instance (optional).
  * @param level Initialization level.
@@ -105,9 +105,9 @@ struct init_entry {
  *
  * @see SYS_INIT()
  */
-#define Z_INIT_ENTRY_DEFINE(entry_name, init_fn, device, level, prio)	\
+#define Z_INIT_ENTRY_DEFINE(init_id, init_fn, device, level, prio)	\
 	static const Z_DECL_ALIGN(struct init_entry)			\
-		Z_INIT_ENTRY_NAME(entry_name) __used __noasan		\
+		Z_INIT_ENTRY_NAME(init_id) __used __noasan		\
 		Z_INIT_ENTRY_SECTION(level, prio) = { 			\
 		.init = (init_fn),					\
 		.dev = (device),					\

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -70,16 +70,16 @@ struct init_entry {
 /**
  * @brief Construct a namespaced identifier for SYS_INIT instance
  *
- * @param _name Base unique name
+ * @param name Base unique name
  */
-#define Z_SYS_NAME(_name) _CONCAT(sys_init_, _name)
+#define Z_SYS_NAME(name) _CONCAT(sys_init_, name)
 
 /**
  * @brief Construct a namespaced identifier for a struct init_entry instance
  *
- * @param _entry_name Base unique name
+ * @param entry_name Base unique name
  */
-#define Z_INIT_ENTRY_NAME(_entry_name) _CONCAT(__init_, _entry_name)
+#define Z_INIT_ENTRY_NAME(entry_name) _CONCAT(__init_, entry_name)
 
 /**
  * @brief Init entry section.
@@ -97,20 +97,20 @@ struct init_entry {
  * configured by the kernel during system initialization. Note that init
  * entries will not be accessible from user mode.
  *
- * @param _entry_name Init entry name.
- * @param _init_fn Init function.
- * @param _device Device instance (optional).
- * @param _level Initialization level.
- * @param prio Initialization priority within @p _level.
+ * @param entry_name Init entry name.
+ * @param init_fn Init function.
+ * @param device Device instance (optional).
+ * @param level Initialization level.
+ * @param prio Initialization priority within @p level.
  *
  * @see SYS_INIT()
  */
-#define Z_INIT_ENTRY_DEFINE(_entry_name, _init_fn, _device, _level, _prio)	\
+#define Z_INIT_ENTRY_DEFINE(entry_name, init_fn, device, level, prio)	\
 	static const Z_DECL_ALIGN(struct init_entry)			\
-		Z_INIT_ENTRY_NAME(_entry_name) __used __noasan			\
-		Z_INIT_ENTRY_SECTION(_level, _prio) = { 			\
-		.init = (_init_fn),					\
-		.dev = (_device),					\
+		Z_INIT_ENTRY_NAME(entry_name) __used __noasan		\
+		Z_INIT_ENTRY_SECTION(level, prio) = { 			\
+		.init = (init_fn),					\
+		.dev = (device),					\
 	}
 
 /** @endcond */
@@ -121,18 +121,18 @@ struct init_entry {
  * The function will be called during system initialization according to the
  * given level and priority.
  *
- * @param _init_fn Initialization function.
- * @param _level Initialization level. Allowed tokens: `EARLY`, `PRE_KERNEL_1`,
+ * @param init_fn Initialization function.
+ * @param level Initialization level. Allowed tokens: `EARLY`, `PRE_KERNEL_1`,
  * `PRE_KERNEL_2`, `POST_KERNEL`, `APPLICATION` and `SMP` if
  * @kconfig{CONFIG_SMP} is enabled.
- * @param _prio Initialization priority within @p _level. Note that it must be a
+ * @param prio Initialization priority within @p _level. Note that it must be a
  * decimal integer literal without leading zeroes or sign (e.g. `32`), or an
  * equivalent symbolic name (e.g. `#define MY_INIT_PRIO 32`); symbolic
  * expressions are **not** permitted (e.g.
  * `CONFIG_KERNEL_INIT_PRIORITY_DEFAULT + 5`).
  */
-#define SYS_INIT(_init_fn, _level, _prio)					\
-	SYS_INIT_NAMED(_init_fn, _init_fn, _level, _prio)
+#define SYS_INIT(init_fn, level, prio)					\
+	SYS_INIT_NAMED(init_fn, init_fn, level, prio)
 
 /**
  * @brief Register an initialization function (named).
@@ -140,15 +140,15 @@ struct init_entry {
  * @note This macro can be used for cases where the multiple init calls use the
  * same init function.
  *
- * @param _name Unique name for SYS_INIT entry.
- * @param _init_fn See SYS_INIT().
- * @param _level See SYS_INIT().
- * @param _prio See SYS_INIT().
+ * @param name Unique name for SYS_INIT entry.
+ * @param init_fn See SYS_INIT().
+ * @param level See SYS_INIT().
+ * @param prio See SYS_INIT().
  *
  * @see SYS_INIT()
  */
-#define SYS_INIT_NAMED(_name, _init_fn, _level, _prio)				\
-	Z_INIT_ENTRY_DEFINE(Z_SYS_NAME(_name), _init_fn, NULL, _level, _prio)
+#define SYS_INIT_NAMED(name, init_fn, level, prio)				\
+	Z_INIT_ENTRY_DEFINE(Z_SYS_NAME(name), init_fn, NULL, level, prio)
 
 /** @} */
 

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -16,26 +16,56 @@
 extern "C" {
 #endif
 
+/**
+ * @defgroup sys_init System Initialization
+ *
+ * Zephyr offers an infrastructure to call initialization code before `main`.
+ * Such initialization calls can be registered using SYS_INIT() or
+ * SYS_INIT_NAMED() macros. By using a combination of initialization levels and
+ * priorities init sequence can be adjusted as needed. The available
+ * initialization levels are described, in order, below:
+ *
+ * - `EARLY`: Used very early in the boot process, right after entering the C
+ *   domain (``z_cstart()``). This can be used in architectures and SoCs that
+ *   extend or implement architecture code and use drivers or system services
+ *   that have to be initialized before the Kernel calls any architecture
+ *   specific initialization code.
+ * - `PRE_KERNEL_1`: Executed in Kernel's initialization context, which uses
+ *   the interrupt stack. At this point Kernel services are not yet available.
+ * - `PRE_KERNEL_2`: Same as `PRE_KERNEL_1`.
+ * - `POST_KERNEL`: Executed after Kernel is alive. From this point on, Kernel
+ *   primitives can be used.
+ * - `APPLICATION`: Executed just before application code (`main`).
+ * - `SMP`: Only available if @kconfig{CONFIG_SMP} is enabled, specific for
+ *   SMP.
+ *
+ * Initialization priority can take a value in the range of 0 to 99.
+ *
+ * @note The same infrastructure is used by devices.
+ * @{
+ */
+
 struct device;
 
-/**
- * @brief Static init entry structure for each device driver or services
- *
- * @param init init function for the init entry which will take the dev
- * attribute as parameter. See below.
- * @param dev pointer to a device driver instance structure. Can be NULL
- * if the init entry is not used for a device driver but a service.
- */
+/** @brief Structure to store initialization entry information. */
 struct init_entry {
-	/** Initialization function for the init entry which will take
-	 * the dev attribute as parameter. See below.
+	/**
+	 * Initialization function for the init entry.
+	 *
+	 * @param dev Device pointer, NULL if not a device init function.
+	 *
+	 * @retval 0 On success
+	 * @retval -errno If init fails.
 	 */
 	int (*init)(const struct device *dev);
-	/** Pointer to a device driver instance structure. Can be NULL
-	 * if the init entry is not used for a device driver but a services.
+	/**
+	 * If the init entry belongs to a device, this fields stores a
+	 * reference to it, otherwise it is set to NULL.
 	 */
 	const struct device *dev;
 };
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * @brief Construct a namespaced identifier for SYS_INIT instance
@@ -45,7 +75,7 @@ struct init_entry {
 #define Z_SYS_NAME(_name) _CONCAT(sys_init_, _name)
 
 /**
- * @brief Construct a namespaced identifier for @ref init_entry instance
+ * @brief Construct a namespaced identifier for a struct init_entry instance
  *
  * @param _entry_name Base unique name
  */
@@ -61,26 +91,19 @@ struct init_entry {
 	__attribute__((__section__(".z_init_" #level STRINGIFY(prio)"_")))
 
 /**
- * @brief Create an init entry object and set it up for boot time initialization
+ * @brief Create an init entry object.
  *
- * @details This macro defines an init entry object that will be automatically
- * configured by the kernel during system initialization. Note that
- * init entries will not be accessible from user mode. Also this macro should
- * not be used directly, use relevant macro such as SYS_INIT() or
- * DEVICE_DEFINE() instead.
+ * This macro defines an init entry object that will be automatically
+ * configured by the kernel during system initialization. Note that init
+ * entries will not be accessible from user mode.
  *
- * @param _entry_name Init entry name. It is the name this instance exposes to
- * the system.
+ * @param _entry_name Init entry name.
+ * @param _init_fn Init function.
+ * @param _device Device instance (optional).
+ * @param _level Initialization level.
+ * @param prio Initialization priority within @p _level.
  *
- * @param _init_fn Address to the init function of the entry.
- *
- * @param _device A device driver instance pointer or NULL
- *
- * @param _level The initialization level at which configuration
- * occurs.  See SYS_INIT().
- *
- * @param prio The initialization priority of the object, relative to
- * other objects of the same initialization level. See SYS_INIT().
+ * @see SYS_INIT()
  */
 #define Z_INIT_ENTRY_DEFINE(_entry_name, _init_fn, _device, _level, _prio)	\
 	static const Z_DECL_ALIGN(struct init_entry)			\
@@ -90,73 +113,44 @@ struct init_entry {
 		.dev = (_device),					\
 	}
 
+/** @endcond */
+
 /**
- * @ingroup device_model
+ * @brief Register an initialization function.
  *
- * @brief Run an initialization function at boot at specified priority
+ * The function will be called during system initialization according to the
+ * given level and priority.
  *
- * @details This macro lets you run a function at system boot.
- *
- * @param _init_fn Pointer to the boot function to run
- *
- * @param _level The initialization level at which configuration occurs.
- * Must be one of the following symbols, which are listed in the order
- * they are performed by the kernel:
- * \n
- * \li EARLY: Used very early in the boot process, right after entering the C
- * domain (``z_cstart()``). This can be used in architectures and SoCs that
- * extend or implement architecture code and use drivers or system services that
- * have to be initialized before the Kernel calls any architecture specific
- * initialization code.
- * \n
- * \li PRE_KERNEL_1: Used for initialization objects that have no dependencies,
- * such as those that rely solely on hardware present in the processor/SOC.
- * These objects cannot use any kernel services during configuration, since
- * they are not yet available.
- * \n
- * \li PRE_KERNEL_2: Used for initialization objects that rely on objects
- * initialized as part of the PRE_KERNEL_1 level. These objects cannot use any
- * kernel services during configuration, since they are not yet available.
- * \n
- * \li POST_KERNEL: Used for initialization objects that require kernel services
- * during configuration.
- * \n
- * \li POST_KERNEL_SMP: Used for initialization objects that require kernel
- * services during configuration after SMP initialization.
- * \n
- * \li APPLICATION: Used for application components (i.e. non-kernel components)
- * that need automatic configuration. These objects can use all services
- * provided by the kernel during configuration.
- *
- * @param _prio The initialization priority of the object, relative to
- * other objects of the same initialization level. Specified as an integer
- * value in the range 0 to 99; lower values indicate earlier initialization.
- * Must be a decimal integer literal without leading zeroes or sign (e.g. 32),
- * or an equivalent symbolic name (e.g. \#define MY_INIT_PRIO 32); symbolic
- * expressions are *not* permitted
- * (e.g. CONFIG_KERNEL_INIT_PRIORITY_DEFAULT + 5).
+ * @param _init_fn Initialization function.
+ * @param _level Initialization level. Allowed tokens: `EARLY`, `PRE_KERNEL_1`,
+ * `PRE_KERNEL_2`, `POST_KERNEL`, `APPLICATION` and `SMP` if
+ * @kconfig{CONFIG_SMP} is enabled.
+ * @param _prio Initialization priority within @p _level. Note that it must be a
+ * decimal integer literal without leading zeroes or sign (e.g. `32`), or an
+ * equivalent symbolic name (e.g. `#define MY_INIT_PRIO 32`); symbolic
+ * expressions are **not** permitted (e.g.
+ * `CONFIG_KERNEL_INIT_PRIORITY_DEFAULT + 5`).
  */
 #define SYS_INIT(_init_fn, _level, _prio)					\
 	SYS_INIT_NAMED(_init_fn, _init_fn, _level, _prio)
 
 /**
- * @ingroup device_model
+ * @brief Register an initialization function (named).
  *
- * @brief Run an initialization function at boot at specified priority
+ * @note This macro can be used for cases where the multiple init calls use the
+ * same init function.
  *
- * @details This macro lets you run a function at system boot.
+ * @param _name Unique name for SYS_INIT entry.
+ * @param _init_fn See SYS_INIT().
+ * @param _level See SYS_INIT().
+ * @param _prio See SYS_INIT().
  *
- * @param _name Unique name for SYS_INIT entry. Allows specifying multiple init
- *              entries that utilise the same function.
- *
- * @param _init_fn See @ref SYS_INIT
- *
- * @param _level See @ref SYS_INIT
- *
- * @param _prio See @ref SYS_INIT
+ * @see SYS_INIT()
  */
 #define SYS_INIT_NAMED(_name, _init_fn, _level, _prio)				\
 	Z_INIT_ENTRY_DEFINE(Z_SYS_NAME(_name), _init_fn, NULL, _level, _prio)
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -68,16 +68,9 @@ struct init_entry {
 /** @cond INTERNAL_HIDDEN */
 
 /**
- * @brief Construct a namespaced identifier for SYS_INIT instance
+ * @brief Obtain init entry name.
  *
- * @param name Base unique name
- */
-#define Z_SYS_NAME(name) _CONCAT(sys_init_, name)
-
-/**
- * @brief Construct a namespaced identifier for a struct init_entry instance
- *
- * @param init_id Base unique name
+ * @param init_id Init entry unique identifier.
  */
 #define Z_INIT_ENTRY_NAME(init_id) _CONCAT(__init_, init_id)
 
@@ -148,7 +141,7 @@ struct init_entry {
  * @see SYS_INIT()
  */
 #define SYS_INIT_NAMED(name, init_fn, level, prio)				\
-	Z_INIT_ENTRY_DEFINE(Z_SYS_NAME(name), init_fn, NULL, level, prio)
+	Z_INIT_ENTRY_DEFINE(name, init_fn, NULL, level, prio)
 
 /** @} */
 

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -10,18 +10,6 @@
 #include <zephyr/sys/kobject.h>
 #include <zephyr/syscall_handler.h>
 
-extern const struct init_entry __init_start[];
-extern const struct init_entry __init_EARLY_start[];
-extern const struct init_entry __init_PRE_KERNEL_1_start[];
-extern const struct init_entry __init_PRE_KERNEL_2_start[];
-extern const struct init_entry __init_POST_KERNEL_start[];
-extern const struct init_entry __init_APPLICATION_start[];
-extern const struct init_entry __init_end[];
-
-#ifdef CONFIG_SMP
-extern const struct init_entry __init_SMP_start[];
-#endif
-
 extern const struct device __device_start[];
 extern const struct device __device_end[];
 
@@ -39,55 +27,6 @@ void z_device_state_init(void)
 	while (dev < __device_end) {
 		z_object_init(dev);
 		++dev;
-	}
-}
-
-/**
- * @brief Execute all the init entry initialization functions at a given level
- *
- * @details Invokes the initialization routine for each init entry object
- * created by the INIT_ENTRY_DEFINE() macro using the specified level.
- * The linker script places the init entry objects in memory in the order
- * they need to be invoked, with symbols indicating where one level leaves
- * off and the next one begins.
- *
- * @param level init level to run.
- */
-void z_sys_init_run_level(int32_t level)
-{
-	static const struct init_entry *levels[] = {
-		__init_EARLY_start,
-		__init_PRE_KERNEL_1_start,
-		__init_PRE_KERNEL_2_start,
-		__init_POST_KERNEL_start,
-		__init_APPLICATION_start,
-#ifdef CONFIG_SMP
-		__init_SMP_start,
-#endif
-		/* End marker */
-		__init_end,
-	};
-	const struct init_entry *entry;
-
-	for (entry = levels[level]; entry < levels[level+1]; entry++) {
-		const struct device *dev = entry->dev;
-		int rc = entry->init(dev);
-
-		if (dev != NULL) {
-			/* Mark device initialized.  If initialization
-			 * failed, record the error condition.
-			 */
-			if (rc != 0) {
-				if (rc < 0) {
-					rc = -rc;
-				}
-				if (rc > UINT8_MAX) {
-					rc = UINT8_MAX;
-				}
-				dev->state->init_res = rc;
-			}
-			dev->state->initialized = true;
-		}
 	}
 }
 

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -52,6 +52,18 @@ static K_KERNEL_PINNED_STACK_ARRAY_DEFINE(z_idle_stacks,
 					  CONFIG_IDLE_STACK_SIZE);
 #endif /* CONFIG_MULTITHREADING */
 
+extern const struct init_entry __init_start[];
+extern const struct init_entry __init_EARLY_start[];
+extern const struct init_entry __init_PRE_KERNEL_1_start[];
+extern const struct init_entry __init_PRE_KERNEL_2_start[];
+extern const struct init_entry __init_POST_KERNEL_start[];
+extern const struct init_entry __init_APPLICATION_start[];
+extern const struct init_entry __init_end[];
+
+#ifdef CONFIG_SMP
+extern const struct init_entry __init_SMP_start[];
+#endif
+
 /*
  * storage space for the interrupt stack
  *
@@ -192,6 +204,55 @@ extern volatile uintptr_t __stack_chk_guard;
 
 __pinned_bss
 bool z_sys_post_kernel;
+
+/**
+ * @brief Execute all the init entry initialization functions at a given level
+ *
+ * @details Invokes the initialization routine for each init entry object
+ * created by the INIT_ENTRY_DEFINE() macro using the specified level.
+ * The linker script places the init entry objects in memory in the order
+ * they need to be invoked, with symbols indicating where one level leaves
+ * off and the next one begins.
+ *
+ * @param level init level to run.
+ */
+static void z_sys_init_run_level(int32_t level)
+{
+	static const struct init_entry *levels[] = {
+		__init_EARLY_start,
+		__init_PRE_KERNEL_1_start,
+		__init_PRE_KERNEL_2_start,
+		__init_POST_KERNEL_start,
+		__init_APPLICATION_start,
+#ifdef CONFIG_SMP
+		__init_SMP_start,
+#endif
+		/* End marker */
+		__init_end,
+	};
+	const struct init_entry *entry;
+
+	for (entry = levels[level]; entry < levels[level+1]; entry++) {
+		const struct device *dev = entry->dev;
+		int rc = entry->init(dev);
+
+		if (dev != NULL) {
+			/* Mark device initialized.  If initialization
+			 * failed, record the error condition.
+			 */
+			if (rc != 0) {
+				if (rc < 0) {
+					rc = -rc;
+				}
+				if (rc > UINT8_MAX) {
+					rc = UINT8_MAX;
+				}
+				dev->state->init_res = rc;
+			}
+			dev->state->initialized = true;
+		}
+	}
+}
 
 extern void boot_banner(void);
 

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -23,6 +23,17 @@ extern const struct device __device_end[];
 extern const struct device __device_SMP_start[];
 #endif
 
+/* init levels, used as indices for levels array */
+enum init_level {
+	INIT_LEVEL_PRE_KERNEL_1 = 0,
+	INIT_LEVEL_PRE_KERNEL_2,
+	INIT_LEVEL_POST_KERNEL,
+	INIT_LEVEL_APPLICATION,
+#ifdef CONFIG_SMP
+	INIT_LEVEL_SMP,
+#endif
+};
+
 static const struct device *const levels[] = {
 	__device_PRE_KERNEL_1_start,
 	__device_PRE_KERNEL_2_start,
@@ -49,7 +60,8 @@ static const char *get_device_name(const struct device *dev,
 	return name;
 }
 
-static bool device_get_config_level(const struct shell *shell, int level)
+static bool device_get_config_level(const struct shell *shell,
+				    enum init_level level)
 {
 	const struct device *dev;
 	bool devices = false;
@@ -74,32 +86,32 @@ static int cmd_device_levels(const struct shell *shell,
 	bool ret;
 
 	shell_fprintf(shell, SHELL_NORMAL, "PRE KERNEL 1:\n");
-	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_PRE_KERNEL_1);
+	ret = device_get_config_level(shell, INIT_LEVEL_PRE_KERNEL_1);
 	if (ret == false) {
 		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "PRE KERNEL 2:\n");
-	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_PRE_KERNEL_2);
+	ret = device_get_config_level(shell, INIT_LEVEL_PRE_KERNEL_2);
 	if (ret == false) {
 		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "POST_KERNEL:\n");
-	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_POST_KERNEL);
+	ret = device_get_config_level(shell, INIT_LEVEL_POST_KERNEL);
 	if (ret == false) {
 		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "APPLICATION:\n");
-	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_APPLICATION);
+	ret = device_get_config_level(shell, INIT_LEVEL_APPLICATION);
 	if (ret == false) {
 		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
 	}
 
 #ifdef CONFIG_SMP
 	shell_fprintf(shell, SHELL_NORMAL, "SMP:\n");
-	ret = device_get_config_level(shell, _SYS_INIT_LEVEL_SMP);
+	ret = device_get_config_level(shell, INIT_LEVEL_SMP);
 	if (ret == false) {
 		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
 	}

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -60,7 +60,7 @@ static const char *get_device_name(const struct device *dev,
 	return name;
 }
 
-static bool device_get_config_level(const struct shell *shell,
+static bool device_get_config_level(const struct shell *sh,
 				    enum init_level level)
 {
 	const struct device *dev;
@@ -71,49 +71,49 @@ static bool device_get_config_level(const struct shell *shell,
 		if (device_is_ready(dev)) {
 			devices = true;
 
-			shell_fprintf(shell, SHELL_NORMAL, "- %s\n",
+			shell_fprintf(sh, SHELL_NORMAL, "- %s\n",
 				      get_device_name(dev, buf, sizeof(buf)));
 		}
 	}
 	return devices;
 }
 
-static int cmd_device_levels(const struct shell *shell,
+static int cmd_device_levels(const struct shell *sh,
 			      size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 	bool ret;
 
-	shell_fprintf(shell, SHELL_NORMAL, "PRE KERNEL 1:\n");
-	ret = device_get_config_level(shell, INIT_LEVEL_PRE_KERNEL_1);
+	shell_fprintf(sh, SHELL_NORMAL, "PRE KERNEL 1:\n");
+	ret = device_get_config_level(sh, INIT_LEVEL_PRE_KERNEL_1);
 	if (ret == false) {
-		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
+		shell_fprintf(sh, SHELL_NORMAL, "- None\n");
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "PRE KERNEL 2:\n");
-	ret = device_get_config_level(shell, INIT_LEVEL_PRE_KERNEL_2);
+	shell_fprintf(sh, SHELL_NORMAL, "PRE KERNEL 2:\n");
+	ret = device_get_config_level(sh, INIT_LEVEL_PRE_KERNEL_2);
 	if (ret == false) {
-		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
+		shell_fprintf(sh, SHELL_NORMAL, "- None\n");
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "POST_KERNEL:\n");
-	ret = device_get_config_level(shell, INIT_LEVEL_POST_KERNEL);
+	shell_fprintf(sh, SHELL_NORMAL, "POST_KERNEL:\n");
+	ret = device_get_config_level(sh, INIT_LEVEL_POST_KERNEL);
 	if (ret == false) {
-		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
+		shell_fprintf(sh, SHELL_NORMAL, "- None\n");
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "APPLICATION:\n");
-	ret = device_get_config_level(shell, INIT_LEVEL_APPLICATION);
+	shell_fprintf(sh, SHELL_NORMAL, "APPLICATION:\n");
+	ret = device_get_config_level(sh, INIT_LEVEL_APPLICATION);
 	if (ret == false) {
-		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
+		shell_fprintf(sh, SHELL_NORMAL, "- None\n");
 	}
 
 #ifdef CONFIG_SMP
-	shell_fprintf(shell, SHELL_NORMAL, "SMP:\n");
-	ret = device_get_config_level(shell, INIT_LEVEL_SMP);
+	shell_fprintf(sh, SHELL_NORMAL, "SMP:\n");
+	ret = device_get_config_level(sh, INIT_LEVEL_SMP);
 	if (ret == false) {
-		shell_fprintf(shell, SHELL_NORMAL, "- None\n");
+		shell_fprintf(sh, SHELL_NORMAL, "- None\n");
 	}
 #endif /* CONFIG_SMP */
 
@@ -137,7 +137,7 @@ static int cmd_device_list_visitor(const struct device *dev,
 	return 0;
 }
 
-static int cmd_device_list(const struct shell *shell,
+static int cmd_device_list(const struct shell *sh,
 			   size_t argc, char **argv)
 {
 	const struct device *devlist;
@@ -147,14 +147,14 @@ static int cmd_device_list(const struct shell *shell,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_fprintf(shell, SHELL_NORMAL, "devices:\n");
+	shell_fprintf(sh, SHELL_NORMAL, "devices:\n");
 
 	for (dev = devlist; dev < devlist_end; dev++) {
 		char buf[20];
 		const char *name = get_device_name(dev, buf, sizeof(buf));
 		const char *state = "READY";
 
-		shell_fprintf(shell, SHELL_NORMAL, "- %s", name);
+		shell_fprintf(sh, SHELL_NORMAL, "- %s", name);
 		if (!device_is_ready(dev)) {
 			state = "DISABLED";
 		} else {
@@ -168,10 +168,10 @@ static int cmd_device_list(const struct shell *shell,
 #endif /* CONFIG_PM_DEVICE */
 		}
 
-		shell_fprintf(shell, SHELL_NORMAL, " (%s)\n", state);
+		shell_fprintf(sh, SHELL_NORMAL, " (%s)\n", state);
 		if (!k_is_user_context()) {
 			struct cmd_device_list_visitor_context ctx = {
-				.shell = shell,
+				.shell = sh,
 				.buf = buf,
 				.buf_size = sizeof(buf),
 			};

--- a/tests/kernel/threads/no-multithreading/src/main.c
+++ b/tests/kernel/threads/no-multithreading/src/main.c
@@ -75,11 +75,15 @@ ZTEST(no_multithreading, test_cpu_idle)
 	zassert_within(diff, 10, 2, "Unexpected time passed: %d ms", (int)diff);
 }
 
+#define IDX_PRE_KERNEL_1 0
+#define IDX_PRE_KERNEL_2 1
+#define IDX_POST_KERNEL 2
+
 #define SYS_INIT_CREATE(level) \
 	static int pre_kernel_##level##_init_func(const struct device *dev) \
 	{ \
 		ARG_UNUSED(dev); \
-		if (init_order != _SYS_INIT_LEVEL_##level && sys_init_result == 0) { \
+		if (init_order != IDX_##level && sys_init_result == 0) { \
 			sys_init_result = -1; \
 			return -EIO; \
 		} \
@@ -95,7 +99,7 @@ FOR_EACH(SYS_INIT_CREATE, (;), PRE_KERNEL_1, PRE_KERNEL_2, POST_KERNEL);
 
 ZTEST(no_multithreading, test_sys_init)
 {
-	zassert_equal(init_order, _SYS_INIT_LEVEL_PRE_KERNEL_2, "SYS_INIT failed: %d", init_order);
+	zassert_equal(init_order, 3, "SYS_INIT failed: %d", init_order);
 }
 
 ZTEST_SUITE(no_multithreading, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Similar to the initial work done for `device.h` in https://github.com/zephyrproject-rtos/zephyr/pull/50827, now it's the turn for `init.h`.

Summary of the changes:

- Improve Doxygen
- Add some auxiliary macros to improve code readability
- z_sys_init_run_level is no longer sitting in a public header, same as associated internal defines

Note: please review on a per-commit basis.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>