### PR TITLE
tests: drivers: flash: Fix nrf_qspi_nor_4B_addr requirements

### DIFF
--- a/tests/drivers/flash/testcase.yaml
+++ b/tests/drivers/flash/testcase.yaml
@@ -18,6 +18,8 @@ tests:
     tags: flash nrf52 nrf_qspi_fash
     extra_args: OVERLAY_CONFIG=boards/nrf52840_flash_qspi.conf
                 DTC_OVERLAY_FILE=boards/nrf52840dk_mx25l51245g.overlay
+    harness_config:
+      fixture: external_flash
     integration_platforms:
       - nrf52840dk_nrf52840
   drivers.flash.soc_flash_nrf:


### PR DESCRIPTION
The test requires external memory connected but it was not reflected in the yaml description. Therefore, the test was failing instead of being skipped. It is the same story as with #47241

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>