### PR TITLE
boards: arc: emsdp: support latest (v1.2) fpga image version

### DIFF
--- a/boards/arc/emsdp/doc/index.rst
+++ b/boards/arc/emsdp/doc/index.rst
@@ -47,6 +47,9 @@ The following table shows the hardware features supported for different core con
 For hardware feature details, refer to : `ARC EM Software Development Platform
 <https://embarc.org/project/arc-em-software-development-platform-sdp/>`__
 
+**NOTE:** the ARC EM SDP is FPGA based platform, so it could be flashed with different FPGA image
+versions. As of today Zephyr supports v1.2 ARC EM SDP platform package version. The FPGA images
+from older platform package versions have different memory map, and hence are not compatible.
 
 Programming and Debugging
 *************************

--- a/dts/arc/synopsys/emsdp.dtsi
+++ b/dts/arc/synopsys/emsdp.dtsi
@@ -35,9 +35,9 @@
 		interrupt-parent = <&intc>;
 	};
 
-	iccm0: iccm@60000000 {
+	iccm0: iccm@10000000 {
 		compatible = "arc,iccm";
-		reg = <0x60000000 0x20000>;
+		reg = <0x10000000 0x20000>;
 	};
 
 	dccm0: dccm@80000000 {
@@ -46,9 +46,9 @@
 	};
 
 	/* this is (Pseudo SRAM), so treat it like mmio-sram */
-	sram0: memory@10000000 {
+	sram0: memory@40000000 {
 		compatible = "mmio-sram";
-		reg = <0x10000000 0x1000000>;
+		reg = <0x40000000 0x1000000>;
 	};
 
 


### PR DESCRIPTION
Bump the supported ARC EM SDP platform package version to 1.2 The FPGA images from older platform package versions have different memory map, and hence we need to tweak the emsdp memory map in Zephyr.