### PR TITLE
ci: twisterlib: Limit the regex used to extract overlays

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -742,7 +742,7 @@ class ProjectBuilder(FilterBuilder):
 
         # merge overlay files into one variable
         def extract_overlays(args):
-            re_overlay = re.compile('OVERLAY_CONFIG=(.*)')
+            re_overlay = re.compile('^\s*OVERLAY_CONFIG=(.*)')
             other_args = []
             overlays = []
             for arg in args:


### PR DESCRIPTION
This commit changes regular expression used to merge overlays specified for test samples in twister tests.

In cases overlays where passed with prefix it was ignored and overlays where merged regardless. In cases of using overlays for i.e. child images OVERLAY_CONFIG with prefix was not able to be used as it would be applied to base image regards of any prefixes.

Signed-off-by: Piotr Węgliński <piotr.weglinski@nordicsemi.no>