### PR TITLE
Bluetooth: Host: Add function to retreive per_adv_sync obj from index.

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1417,6 +1417,20 @@ struct bt_le_per_adv_sync_param {
  */
 uint8_t bt_le_per_adv_sync_get_index(struct bt_le_per_adv_sync *per_adv_sync);
 
+/**
+ * @brief Get a periodic advertising sync object from the array index.
+ *
+ * This function is to get the periodic advertising sync object from
+ * the array index.
+ * The array has CONFIG_BT_PER_ADV_SYNC_MAX elements.
+ *
+ * @param index The index of the periodic advertising sync object.
+ *              The range of the index value is 0..CONFIG_BT_PER_ADV_SYNC_MAX-1
+ *
+ * @return The periodic advertising sync object of the array index or NULL if invalid index.
+ */
+struct bt_le_per_adv_sync *bt_le_per_adv_sync_lookup_index(uint8_t index);
+
 /** @brief Advertising set info structure. */
 struct bt_le_per_adv_sync_info {
 	/** Periodic Advertiser Address */

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1345,6 +1345,15 @@ uint8_t bt_le_per_adv_sync_get_index(struct bt_le_per_adv_sync *per_adv_sync)
 	return (uint8_t)index;
 }
 
+struct bt_le_per_adv_sync *bt_le_per_adv_sync_lookup_index(uint8_t index)
+{
+	if (index >= ARRAY_SIZE(per_adv_sync_pool)) {
+		return NULL;
+	}
+
+	return &per_adv_sync_pool[index];
+}
+
 int bt_le_per_adv_sync_get_info(struct bt_le_per_adv_sync *per_adv_sync,
 				struct bt_le_per_adv_sync_info *info)
 {


### PR DESCRIPTION
This is a patch I always apply to Zephyr in order to save some RAM in application, this is a shot to get it upstream. 

Gives the application a two way mapping between array index and a per_adv_sync object instead of current only per_adv_sync obj -> index using `bt_le_per_adv_sync_get_index`.

Motivation:
Makes it possible for an application for efficient mapping between index and per_adv_sync object. 
Minimizes RAM usage in application as only an `uint8_t` is needed for storing info about active per_adv_sync objects.

Signed-off-by: Jakob Krantz <jakob.krantz@u-blox.com>