### PR TITLE
ci: twisterlib: Limit the regex used to extract overlays

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -783,8 +783,9 @@ class ProjectBuilder(FilterBuilder):
             args += instance.handler.args
 
         # merge overlay files into one variable
+        # overlays with prefixes won't be merged but pass to cmake as they are
         def extract_overlays(args):
-            re_overlay = re.compile('OVERLAY_CONFIG=(.*)')
+            re_overlay = re.compile(r'^\s*OVERLAY_CONFIG=(.*)')
             other_args = []
             overlays = []
             for arg in args:


### PR DESCRIPTION
This commit changes regular expression used to merge overlays specified for test samples in twister tests.

Overlays with any prefixes will be ignored in merging mechanism and passed as is to cmake command.

Signed-off-by: Piotr Węgliński <piotr.weglinski@nordicsemi.no>