### PR TITLE
rtio: Add macro to define iodev submission queue

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -391,6 +391,16 @@ static inline void rtio_sqe_prep_write(struct rtio_sqe *sqe,
 #define RTIO_CQ_DEFINE(name, len)			\
 	static RTIO_SPSC_DEFINE(name, struct rtio_cqe, len)
 
+
+/**
+ * @brief Statically define and initialize a fixed length iodev submission queue
+ *
+ * @param name Name of the queue.
+ * @param len Queue length, power of 2 required
+ */
+#define RTIO_IODEV_SQ_DEFINE(name, len) \
+	static RTIO_SPSC_DEFINE(name, struct rtio_iodev_sqe, len)
+
 /**
  * @brief Statically define and initialize an RTIO context
  *

--- a/samples/subsys/rtio/sensor_batch_processing/src/vnd_sensor.c
+++ b/samples/subsys/rtio/sensor_batch_processing/src/vnd_sensor.c
@@ -13,16 +13,9 @@
 
 LOG_MODULE_REGISTER(vnd_sensor);
 
-struct vnd_sensor_msg {
-	struct rtio_sqe sqe;
-	struct rtio *r;
-};
-
 struct vnd_sensor_config {
 	uint32_t sample_period;
 	size_t sample_size;
-	struct vnd_sensor_msg *msgs;
-	size_t max_msgs;
 };
 
 struct vnd_sensor_data {
@@ -82,13 +75,13 @@ static void vnd_sensor_iodev_submit(const struct rtio_sqe *sqe, struct rtio *r)
 {
 	struct vnd_sensor_data *data = (struct vnd_sensor_data *) sqe->iodev;
 	const struct device *dev = data->dev;
+	struct rtio_iodev_sqe *iodev_sqe = rtio_spsc_acquire(data->iodev.iodev_sq);
 
-	struct vnd_sensor_msg msg = {
-		.sqe = *sqe,
-		.r = r,
-	};
-
-	if (k_msgq_put(&data->msgq, &msg, K_NO_WAIT) != 0) {
+	if (iodev_sqe != NULL) {
+		iodev_sqe->sqe = sqe;
+		iodev_sqe->r = r;
+		rtio_spsc_produce(data->iodev.iodev_sq);
+	} else {
 		LOG_ERR("%s: Could not put a msg", dev->name);
 		rtio_sqe_err(r, sqe, -EWOULDBLOCK);
 	}
@@ -97,12 +90,13 @@ static void vnd_sensor_iodev_submit(const struct rtio_sqe *sqe, struct rtio *r)
 static void vnd_sensor_handle_int(const struct device *dev)
 {
 	struct vnd_sensor_data *data = dev->data;
-	struct vnd_sensor_msg msg;
+	struct rtio_iodev_sqe *iodev_sqe = rtio_spsc_consume(data->iodev.iodev_sq);
 
-	if (k_msgq_get(&data->msgq, &msg, K_NO_WAIT) != 0) {
-		LOG_ERR("%s: Could not get a msg", dev->name);
+	if (iodev_sqe != NULL) {
+		vnd_sensor_iodev_execute(dev, iodev_sqe->sqe, iodev_sqe->r);
+		rtio_spsc_release(data->iodev.iodev_sq);
 	} else {
-		vnd_sensor_iodev_execute(dev, &msg.sqe, msg.r);
+		LOG_ERR("%s: Could not get a msg", dev->name);
 	}
 }
 
@@ -122,9 +116,6 @@ static int vnd_sensor_init(const struct device *dev)
 
 	data->dev = dev;
 
-	k_msgq_init(&data->msgq, (char *) config->msgs,
-		    sizeof(struct vnd_sensor_msg), config->max_msgs);
-
 	k_timer_init(&data->timer, vnd_sensor_timer_expiry, NULL);
 
 	k_timer_start(&data->timer, K_MSEC(sample_period),
@@ -137,30 +128,25 @@ static const struct rtio_iodev_api vnd_sensor_iodev_api = {
 	.submit = vnd_sensor_iodev_submit,
 };
 
-#define VND_SENSOR_INIT(n)						\
-	static struct vnd_sensor_msg					\
-		vnd_sensor_msgs_##n[DT_INST_PROP(n, max_msgs)];		\
-									\
-	static const struct vnd_sensor_config vnd_sensor_config_##n = {	\
-		.sample_period = DT_INST_PROP(n, sample_period),	\
-		.sample_size = DT_INST_PROP(n, sample_size),		\
-		.msgs = vnd_sensor_msgs_##n,				\
-		.max_msgs = DT_INST_PROP(n, max_msgs),			\
-	};								\
-									\
-	static struct vnd_sensor_data vnd_sensor_data_##n = {		\
-		.iodev = {						\
-			.api = &vnd_sensor_iodev_api,			\
-		},							\
-	};								\
-									\
-	DEVICE_DT_INST_DEFINE(n,					\
-			      vnd_sensor_init,				\
-			      NULL,					\
-			      &vnd_sensor_data_##n,			\
-			      &vnd_sensor_config_##n,			\
-			      POST_KERNEL,				\
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
-			      NULL);
+#define VND_SENSOR_INIT(n)                                                                         \
+                                                                                                   \
+	static const struct vnd_sensor_config vnd_sensor_config_##n = {                            \
+		.sample_period = DT_INST_PROP(n, sample_period),                                   \
+		.sample_size = DT_INST_PROP(n, sample_size),                                       \
+	};                                                                                         \
+                                                                                                   \
+	RTIO_IODEV_SQ_DEFINE(vnd_sensor_iodev_sq_##n, DT_INST_PROP(n, max_msgs));                  \
+                                                                                                   \
+	static struct vnd_sensor_data vnd_sensor_data_##n = {                                      \
+		.iodev =                                                                           \
+			{                                                                          \
+				.api = &vnd_sensor_iodev_api,                                      \
+				.iodev_sq = (struct rtio_iodev_sq *)&vnd_sensor_iodev_sq_##n,     \
+			},                                                                         \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, vnd_sensor_init, NULL, &vnd_sensor_data_##n,                      \
+			      &vnd_sensor_config_##n, POST_KERNEL,                                 \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(VND_SENSOR_INIT)


### PR DESCRIPTION
The iodev submission queue existed but wasn't easily constructed as there was no macro to define it.

Adds a simple macro wrapper around RTIO_SPSC_DEFINE for creating the RTIO IO Device Submission Queue enabling each IO device to have its own pending queue of requests.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>