### PR TITLE
drivers: ethernet: xlnx_gem: fix dev data access missed by #41918

### DIFF
--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -666,7 +666,7 @@ static struct net_stats_eth *eth_xlnx_gem_stats(const struct device *dev)
 {
 	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
 
-	return &data->stats;
+	return &dev_data->stats;
 }
 #endif
 


### PR DESCRIPTION
Fixes a compiler error in eth_xlnx_gem_stats() caused by the automated replacement of device run-time data pointer accesses by #41918. The device run-time data access in eth_xlnx_gem_stats() was likely missed as this function is not usually compiled - its existance depends on CONFIG_NET_STATISTICS_ETHERNET being set.

Signed-off-by: Immo Birnbaum <Immo.Birnbaum@weidmueller.com>