### PR TITLE
dt-bindings: fix MDC clock divider bindings for Xilinx GEM

### DIFF
--- a/include/zephyr/dt-bindings/ethernet/xlnx_gem.h
+++ b/include/zephyr/dt-bindings/ethernet/xlnx_gem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Weidmueller Interface GmbH & Co. KG
+ * Copyright (c) 2021-2022, Weidmueller Interface GmbH & Co. KG
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,21 +9,30 @@
 /* PHY auto-detection alias */
 #define XLNX_GEM_PHY_AUTO_DETECT 0
 
-/* MDC divider values */
-/* The following values are supported by both the Zynq-7000 and the ZynqMP */
-#define XLNX_GEM_MDC_DIVIDER_8   0 /* cpu_1x or LPD_LSBUS_CLK     <  20 MHz */
-#define XLNX_GEM_MDC_DIVIDER_16  1 /* cpu_1x or LPD_LSBUS_CLK  20 -  40 MHz */
-#define XLNX_GEM_MDC_DIVIDER_32  2 /* cpu_1x or LPD_LSBUS_CLK  40 -  80 MHz */
 /*
- * According to the ZynqMP's gem.network_config register documentation,
- * divider /32 is to be used for a 100 MHz LPD LSBUS clock.
+ * MDC divider values
+ *
+ * According to the ZynqMP's gem.network_config register documentation (UG1087),
+ * divider /32 is the reset value. The network_config[mdc_clock_division]
+ * documentation in UG1087 is likely wrong (copied directly from the Zynq-7000),
+ * as it claims that the MDC clock division is applied to the cpu_1x clock
+ * which the UltraScale doesn't have. Contradicting information is provided in
+ * the UltraScale TRM (UG1085), which mentions in chapter 34, section "Configure
+ * the PHY", p. 1074, that the MDC clock division is applied to the IOU_SWITCH_CLK.
+ * Xilinx's emacps driver doesn't (or no longer does) limit the range of dividers
+ * on the UltraScale compared to the Zynq-7000.
+ * -> Contrary to earlier revisions of this driver, all dividers are available
+ *    to both the UltraScale and the Zynq-7000.
  */
-/* The following values are supported by the Zynq-7000 only */
-#define XLNX_GEM_MDC_DIVIDER_48  3 /* cpu_1x                   80 - 120 MHz */
-#define XLNX_GEM_MDC_DIVIDER_64  4 /* cpu_1x                  120 - 160 MHz */
-#define XLNX_GEM_MDC_DIVIDER_96  5 /* cpu_1x                  160 - 240 MHz */
-#define XLNX_GEM_MDC_DIVIDER_128 6 /* cpu_1x                  240 - 320 MHz */
-#define XLNX_GEM_MDC_DIVIDER_224 7 /* cpu_1x                  320 - 540 MHz */
+
+#define XLNX_GEM_MDC_DIVIDER_8   0 /* cpu_1x or IOU_SWITCH_CLK     <  20 MHz */
+#define XLNX_GEM_MDC_DIVIDER_16  1 /* cpu_1x or IOU_SWITCH_CLK  20 -  40 MHz */
+#define XLNX_GEM_MDC_DIVIDER_32  2 /* cpu_1x or IOU_SWITCH_CLK  40 -  80 MHz */
+#define XLNX_GEM_MDC_DIVIDER_48  3 /* cpu_1x or IOU_SWITCH_CLK  80 - 120 MHz */
+#define XLNX_GEM_MDC_DIVIDER_64  4 /* cpu_1x or IOU_SWITCH_CLK 120 - 160 MHz */
+#define XLNX_GEM_MDC_DIVIDER_96  5 /* cpu_1x or IOU_SWITCH_CLK 160 - 240 MHz */
+#define XLNX_GEM_MDC_DIVIDER_128 6 /* cpu_1x or IOU_SWITCH_CLK 240 - 320 MHz */
+#define XLNX_GEM_MDC_DIVIDER_224 7 /* cpu_1x or IOU_SWITCH_CLK 320 - 540 MHz */
 
 /* Link speed values */
 #define XLNX_GEM_LINK_SPEED_10MBIT  1


### PR DESCRIPTION
The original implementation of the GEM's device tree binding implied that:
1) on the UltraScale+, the MDC clock divider is applied to the LPD_LSBUS_CLK. According to the most recent documentation, this is not the case, instead, the MDC divider is applied to the IOU_SWITCH_CLK.
2) any MDC divider greater than 32 is reserved to the Zynq-7000 (in the driver itself, accessibility of the larger dividers was also #ifdef'd), as the Zynq's MDC clock source, the cpu_1x clock, can have significantly higher frequencies than the UltraScale's LPD_LSBUS clock.

The respective documentation in the device tree binding header file is hereby fixed.

Signed-off-by: Immo Birnbaum <Immo.Birnbaum@weidmueller.com>