### PR TITLE
drivers: sensor: support custom userdata on sensor trigger handler

### DIFF
--- a/drivers/sensor/iis2mdc/iis2mdc.h
+++ b/drivers/sensor/iis2mdc/iis2mdc.h
@@ -58,6 +58,7 @@ struct iis2mdc_data {
 	struct gpio_callback gpio_cb;
 
 	sensor_trigger_handler_t handler_drdy;
+	void *handler_userdata;
 
 #if defined(CONFIG_IIS2MDC_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_IIS2MDC_THREAD_STACK_SIZE);
@@ -76,7 +77,8 @@ int iis2mdc_i2c_init(const struct device *dev);
 int iis2mdc_init_interrupt(const struct device *dev);
 int iis2mdc_trigger_set(const struct device *dev,
 			  const struct sensor_trigger *trig,
-			  sensor_trigger_handler_t handler);
+			  sensor_trigger_handler_t handler,
+			  void *userdata);
 #endif /* CONFIG_IIS2MDC_TRIGGER */
 
 #endif /* __MAG_IIS2MDC_H */

--- a/drivers/sensor/iis2mdc/iis2mdc_trigger.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_trigger.c
@@ -29,13 +29,15 @@ static int iis2mdc_enable_int(const struct device *dev, int enable)
 /* link external trigger to event data ready */
 int iis2mdc_trigger_set(const struct device *dev,
 			  const struct sensor_trigger *trig,
-			  sensor_trigger_handler_t handler)
+			  sensor_trigger_handler_t handler,
+			  void *userdata)
 {
 	struct iis2mdc_data *iis2mdc = dev->data;
 	int16_t raw[3];
 
 	if (trig->chan == SENSOR_CHAN_MAGN_XYZ) {
 		iis2mdc->handler_drdy = handler;
+		iis2mdc->handler_userdata = userdata;
 		if (handler) {
 			/* fetch raw data sample: re-trigger lost interrupt */
 			iis2mdc_magnetic_raw_get(iis2mdc->ctx, raw);
@@ -59,7 +61,7 @@ static void iis2mdc_handle_interrupt(const struct device *dev)
 	};
 
 	if (iis2mdc->handler_drdy != NULL) {
-		iis2mdc->handler_drdy(dev, &drdy_trigger);
+		iis2mdc->handler_drdy(dev, &drdy_trigger, iis2mdc->handler_userdata);
 	}
 
 	gpio_pin_interrupt_configure_dt(&config->gpio_drdy,

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -338,7 +338,8 @@ enum sensor_attribute {
  * @param trigger The trigger
  */
 typedef void (*sensor_trigger_handler_t)(const struct device *dev,
-					 const struct sensor_trigger *trigger);
+					 const struct sensor_trigger *trigger,
+					 void *userdata);
 
 /**
  * @typedef sensor_attr_set_t
@@ -370,7 +371,8 @@ typedef int (*sensor_attr_get_t)(const struct device *dev,
  */
 typedef int (*sensor_trigger_set_t)(const struct device *dev,
 				    const struct sensor_trigger *trig,
-				    sensor_trigger_handler_t handler);
+				    sensor_trigger_handler_t handler,
+					void *userdata);
 /**
  * @typedef sensor_sample_fetch_t
  * @brief Callback API for fetching data from a sensor
@@ -480,7 +482,8 @@ static inline int z_impl_sensor_attr_get(const struct device *dev,
  */
 static inline int sensor_trigger_set(const struct device *dev,
 				     const struct sensor_trigger *trig,
-				     sensor_trigger_handler_t handler)
+				     sensor_trigger_handler_t handler,
+					 void *userdata)
 {
 	const struct sensor_driver_api *api =
 		(const struct sensor_driver_api *)dev->api;
@@ -489,7 +492,7 @@ static inline int sensor_trigger_set(const struct device *dev,
 		return -ENOSYS;
 	}
 
-	return api->trigger_set(dev, trig, handler);
+	return api->trigger_set(dev, trig, handler, userdata);
 }
 
 /**


### PR DESCRIPTION
Enables the usage of userdata on a sensor trigger handler.
Since this would be a breaking change of the API, other ideas for a less intrusive implementation would be appreciated.