### PR TITLE
spi: SAM support SPI transfers with DMA

### DIFF
--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -97,6 +97,9 @@
 
 	cs-gpios = <&piod 25 GPIO_ACTIVE_LOW>,
 		   <&piod 27 GPIO_ACTIVE_LOW>;
+
+	dmas = <&xdmac 1 DMA_PERID_SPI0_TX>, <&xdmac 2 DMA_PERID_SPI0_RX>;
+	dma-names = "tx", "rx";
 };
 
 &usart1 {
@@ -189,6 +192,10 @@ zephyr_udc0: &usbhs {
 
 	dma-names = "rx", "tx";
 	dmas = <&xdmac 22 DMA_PERID_SSC_RX>, <&xdmac 23 DMA_PERID_SSC_TX>;
+};
+
+&xdmac {
+	status = "okay";
 };
 
 &can0 {

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained.yaml
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained.yaml
@@ -9,6 +9,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - dma
   - netif:eth
   - adc
   - i2s

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -196,6 +196,9 @@
 
 	cs-gpios = <&piod 25 GPIO_ACTIVE_LOW>,
 		   <&piod 27 GPIO_ACTIVE_LOW>;
+
+	dmas = <&xdmac 1 DMA_PERID_SPI0_TX>, <&xdmac 2 DMA_PERID_SPI0_RX>;
+	dma-names = "tx", "rx";
 };
 
 &usart1 {

--- a/boards/arm/sam_v71_xult/sam_v71_xult.yaml
+++ b/boards/arm/sam_v71_xult/sam_v71_xult.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - dma
   - netif:eth
   - adc
   - arduino_gpio

--- a/boards/arm/tdk_robokit1/tdk_robokit1-common.dtsi
+++ b/boards/arm/tdk_robokit1/tdk_robokit1-common.dtsi
@@ -81,7 +81,8 @@
 &spi0 {
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
-
+	dmas = <&xdmac 0 DMA_PERID_SPI0_TX>, <&xdmac 1 DMA_PERID_SPI0_RX>;
+	dma-names = "tx", "rx";
 	status = "okay";
 };
 
@@ -137,6 +138,11 @@ zephyr_udc0: &usbhs {
 &pwm0 {
 	pinctrl-0 = <&pwm_default>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+
+&xdmac {
 	status = "okay";
 };
 

--- a/boards/arm/tdk_robokit1/tdk_robokit1.yaml
+++ b/boards/arm/tdk_robokit1/tdk_robokit1.yaml
@@ -9,6 +9,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - dma
   - i2c
   - gpio
   - spi

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -209,6 +209,22 @@ static int sam_xdmac_config(const struct device *dev, uint32_t channel,
 	dev_data->dma_channels[channel].data_size = data_size;
 	LOG_DBG("data_size=%d", data_size);
 
+	uint32_t xdmac_inc_cfg = 0;
+
+	if (cfg->head_block->source_addr_adj == DMA_ADDR_ADJ_INCREMENT
+		&& cfg->channel_direction == MEMORY_TO_PERIPHERAL) {
+		xdmac_inc_cfg |= XDMAC_CC_SAM_INCREMENTED_AM;
+	} else {
+		xdmac_inc_cfg |= XDMAC_CC_SAM_FIXED_AM;
+	}
+
+	if (cfg->head_block->dest_addr_adj == DMA_ADDR_ADJ_INCREMENT
+		&& cfg->channel_direction == PERIPHERAL_TO_MEMORY) {
+		xdmac_inc_cfg |= XDMAC_CC_DAM_INCREMENTED_AM;
+	} else {
+		xdmac_inc_cfg |= XDMAC_CC_DAM_FIXED_AM;
+	}
+
 	switch (cfg->channel_direction) {
 	case MEMORY_TO_MEMORY:
 		channel_cfg.cfg =
@@ -222,16 +238,14 @@ static int sam_xdmac_config(const struct device *dev, uint32_t channel,
 			  XDMAC_CC_TYPE_PER_TRAN
 			| XDMAC_CC_CSIZE(burst_size)
 			| XDMAC_CC_DSYNC_MEM2PER
-			| XDMAC_CC_SAM_INCREMENTED_AM
-			| XDMAC_CC_DAM_FIXED_AM;
+			| xdmac_inc_cfg;
 		break;
 	case PERIPHERAL_TO_MEMORY:
 		channel_cfg.cfg =
 			  XDMAC_CC_TYPE_PER_TRAN
 			| XDMAC_CC_CSIZE(burst_size)
 			| XDMAC_CC_DSYNC_PER2MEM
-			| XDMAC_CC_SAM_FIXED_AM
-			| XDMAC_CC_DAM_INCREMENTED_AM;
+			| xdmac_inc_cfg;
 		break;
 	default:
 		LOG_ERR("'channel_direction' value %d is not supported",
@@ -289,11 +303,13 @@ int sam_xdmac_transfer_start(const struct device *dev, uint32_t channel)
 	Xdmac * const xdmac = config->regs;
 
 	if (channel >= DMA_CHANNELS_NO) {
+		LOG_DBG("Channel %d out of range", channel);
 		return -EINVAL;
 	}
 
 	/* Check if the channel is enabled */
 	if (xdmac->XDMAC_GS & (XDMAC_GS_ST0 << channel)) {
+		LOG_DBG("Channel %d already enabled", channel);
 		return -EBUSY;
 	}
 

--- a/drivers/spi/Kconfig.sam
+++ b/drivers/spi/Kconfig.sam
@@ -11,3 +11,12 @@ config SPI_SAM
 	select GPIO
 	help
 	  Enable support for the SAM SPI driver.
+
+if SPI_SAM
+config SPI_SAM_DMA
+	bool "SPI SAM DMA Support"
+	select DMA
+	help
+	  Enable using DMA with SPI for SPI instances that enable dma channels in
+	  their device tree node.
+endif # SPI_SAM

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -373,12 +373,13 @@
 			status = "okay";
 		};
 
-		xdmac: dma-controller@40078000 {
+		xdmac: dma0: dma-controller@40078000 {
 			compatible = "atmel,sam-xdmac";
 			reg = <0x40078000 0x400>;
 			interrupts = <58 0>;
 			peripheral-id = <58>;
 			#dma-cells = <2>;
+			status = "disabled";
 		};
 
 		ssc: ssc@40004000 {

--- a/dts/bindings/spi/atmel,sam-spi.yaml
+++ b/dts/bindings/spi/atmel,sam-spi.yaml
@@ -20,3 +20,27 @@ properties:
       type: int
       description: peripheral ID
       required: true
+
+    loopback:
+      type: boolean
+      description: |
+        Connects TX to RX internally creating a loop back connection. Useful
+        for testing.
+
+    dmas:
+      description: |
+        TX & RX dma specifiers.  Each specifier will have a phandle
+        reference to the dma controller, the channel number, and peripheral
+        trigger source. The channel number is arbitrary but must not be
+        reused. The number of channels available is device dependent.
+
+        For example dmas for TX and RX may look like
+           dmas = <&xdmac 1 DMA_PERID_SPI0_TX>, <&xdmac 2 DMA_PERID_SPI0_RX>;
+
+    dma-names:
+      description: |
+        This should be "tx" and "rx" and should match the order given for
+        dmas.
+
+        For example using the example dmas, an example dma-names would be
+           dma-names = "tx", "rx";

--- a/tests/drivers/spi/spi_loopback/boards/sam_e70_xplained.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/sam_e70_xplained.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ &spi0 {
+	loopback;
+
+	dmas = <&xdmac 1 DMA_PERID_SPI0_TX>, <&xdmac 2 DMA_PERID_SPI0_RX>;
+	dma-names = "tx", "rx";
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+&spi1 {
+	loopback;
+
+	dmas = <&xdmac 3 DMA_PERID_SPI1_TX>, <&xdmac 4 DMA_PERID_SPI1_RX>;
+	dma-names = "tx", "rx";
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/boards/sam_v71_xult.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/sam_v71_xult.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ &spi0 {
+	loopback;
+
+	dmas = <&xdmac 1 DMA_PERID_SPI0_TX>, <&xdmac 2 DMA_PERID_SPI0_RX>;
+	dma-names = "tx", "rx";
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+&spi1 {
+	loopback;
+
+	dmas = <&xdmac 3 DMA_PERID_SPI1_TX>, <&xdmac 4 DMA_PERID_SPI1_RX>;
+	dma-names = "tx", "rx";
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/boards/tdk_robokit1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/tdk_robokit1.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi0 {
+	loopback;
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/overlay-sam-spi-dma.conf
+++ b/tests/drivers/spi/spi_loopback/overlay-sam-spi-dma.conf
@@ -1,0 +1,2 @@
+# enable DMA mode
+CONFIG_SPI_SAM_DMA=y

--- a/tests/drivers/spi/spi_loopback/overlay-sam-spi-dma.overlay
+++ b/tests/drivers/spi/spi_loopback/overlay-sam-spi-dma.overlay
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma0 {
+	status = "okay";
+};
+
+&spi0 {
+	loopback;
+
+	dmas = <&dma0 1 DMA_PERID_SPI0_TX>, <&dma0 2 DMA_PERID_SPI0_RX>;
+	dma-names = "tx", "rx";
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+&spi1 {
+	loopback;
+
+	dmas = <&dma0 3 DMA_PERID_SPI1_TX>, <&dma0 4 DMA_PERID_SPI1_RX>;
+	dma-names = "tx", "rx";
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -16,6 +16,13 @@ tests:
     harness_config:
       fixture: spi_loopback
     platform_allow: frdm_k64f
+  drivers.sam_spi_dma.loopback:
+    tags: dma
+    harness: ztest
+    extra_args: OVERLAY_CONFIG="overlay-sam-spi-dma.conf" DTC_OVERLAY_FILE="overlay-sam-spi-dma.overlay"
+    harness_config:
+      fixture: spi_loopback
+    platform_allow: sam_e70_xplained sam_v71_xult tdk_robokit1
   drivers.stm32_spi_dma.loopback:
     tags: dma
     harness: ztest


### PR DESCRIPTION
For larger transfers DMA can be used enabling other tasks
to continue running. A threshold of 32 byte transfers
is about right and is the set value for using DMA.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>