### PR TITLE
soc: xilinx_zynq7000: restore static SLCR MMU mapping when GEM is active

### DIFF
--- a/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Weidmueller Interface GmbH & Co. KG
+ * Copyright (c) 2021-2022 Weidmueller Interface GmbH & Co. KG
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -35,6 +35,12 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_ADDR(DT_CHOSEN(zephyr_ocm)),
 			      DT_REG_SIZE(DT_CHOSEN(zephyr_ocm)),
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),
+#ifdef CONFIG_DT_HAS_XLNX_GEM_ENABLED
+	MMU_REGION_FLAT_ENTRY("slcr",
+			      DT_REG_ADDR(DT_NODELABEL(slcr)),
+			      DT_REG_SIZE(DT_NODELABEL(slcr)),
+			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),
+#endif
 	/* ARM Arch timer, GIC are covered by the MPCore mapping */
 
 /* GEMs */

--- a/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Weidmueller Interface GmbH & Co. KG
+ * Copyright (c) 2021-2022 Weidmueller Interface GmbH & Co. KG
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -35,6 +35,12 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_ADDR(DT_CHOSEN(zephyr_ocm)),
 			      DT_REG_SIZE(DT_CHOSEN(zephyr_ocm)),
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),
+#ifdef CONFIG_DT_HAS_XLNX_GEM_ENABLED
+	MMU_REGION_FLAT_ENTRY("slcr",
+			      DT_REG_ADDR(DT_NODELABEL(slcr)),
+			      DT_REG_SIZE(DT_NODELABEL(slcr)),
+			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),
+#endif
 	/* ARM Arch timer, GIC are covered by the MPCore mapping */
 
 /* GEMs */


### PR DESCRIPTION
Conditionally re-instate the static MMU page table mapping for the SLCR (I/O and clock config register space) removed by #46648, as the removal of this mapping causes any Zynq-based target (including the simulated qemu_cortex_a9) to crash if the GEM Ethernet controller driver is included in the build (data abort exception upon clock config register access).

PR #46648 introduced a pinctrl driver for the Zynq, which maps the SLCR address space to a virtual address internally. However, this driver is not the only instance that accesses this register space, as the SLCR also contains clock configuration facilities which are accessed by the GEM Ethernet driver upon initial link speed configuration and whenever the link speed changes at run-time (if a PHY is monitored and managed by the driver). The driver currently expects VA=PA MMU mappings for both the respective GEM's own register space and the SLCR. The driver currently doesn't make use of the DEVICE_MMIO API, as this can only map either the respective GEM's register space or the SLCR, but not both.

This re-instatement can be considered temporary, as a clean potential solution exists in the form of a clock controller driver providing an API to the GEM driver which allows it to set the TX clock pre-scalers at run-time. With such a driver available, the GEM driver doesn't need to access the SLCR any more. Until then, a VA=PA MMU mapping for the SLCR is required. The GEM driver could then also be converted to the use of the DEVICE_MMIO API for its own register space.

This static mapping doesn't interfere with the mapping invoked by the pinctrl driver if this driver is active - multiple MMU PTEs can point to the same physical address.

Signed-off-by: Immo Birnbaum <Immo.Birnbaum@weidmueller.com>