### PR TITLE
Use Zephyr SDK 0.15.1

### DIFF
--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: bluetooth-test-prep
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr

--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -27,7 +27,7 @@ jobs:
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.1
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components
       EDTT_PATH: ../tools/edtt

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         platform: ["native_posix"]
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.1
       LLVM_TOOLCHAIN_PATH: /usr/lib/llvm-15
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: zephyr_runner
     needs: clang-build-prep
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
       options: '--entrypoint /bin/bash'
       volumes:
         - /home/runners/zephyrproject:/github/cache/zephyrproject

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: zephyr_runner
     needs: codecov-prep
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         platform: ["native_posix", "qemu_x86", "unit_testing"]
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.1
     steps:
       - name: Apply container owner mismatch workaround
         run: |

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.1
 
     steps:
       - name: Apply container owner mismatch workaround

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -10,7 +10,7 @@ jobs:
   check-errno:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
 

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-tracking-cancel
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.1
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
     steps:
       - name: Apply container owner mismatch workaround

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.1
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-cancel
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -39,7 +39,7 @@ jobs:
       MATRIX_SIZE: 10
       PUSH_MATRIX_SIZE: 15
       DAILY_MATRIX_SIZE: 80
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.1
       TESTS_PER_BUILDER: 700
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}
@@ -130,7 +130,7 @@ jobs:
       matrix:
         subset: ${{fromJSON(needs.twister-build-prep.outputs.subset)}}
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.1
       TWISTER_COMMON: ' --force-color --inline-logs -v -N -M --retry-failed 3 '
       DAILY_OPTIONS: ' -M --build-only --all'
       PR_OPTIONS: ' --clobber-output --integration'

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: zephyr_runner
     needs: twister-build-cleanup
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
       options: '--entrypoint /bin/bash'
       volumes:
         - /home/runners/zephyrproject:/github/cache/zephyrproject
@@ -121,7 +121,7 @@ jobs:
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
       options: '--entrypoint /bin/bash'
       volumes:
         - /home/runners/zephyrproject:/github/cache/zephyrproject

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -500,8 +500,8 @@ that are used to emulate, flash and debug Zephyr applications.
          .. code-block:: bash
 
             cd ~
-            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/zephyr-sdk-0.15.0_linux-x86_64.tar.gz
-            wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/sha256.sum | shasum --check --ignore-missing
+            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_linux-x86_64.tar.gz
+            wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/sha256.sum | shasum --check --ignore-missing
 
          If your host architecture is 64-bit ARM (for example, Raspberry Pi), replace ``x86_64``
          with ``aarch64`` in order to download the 64-bit ARM Linux SDK.
@@ -510,7 +510,7 @@ that are used to emulate, flash and debug Zephyr applications.
 
          .. code-block:: bash
 
-            tar xvf zephyr-sdk-0.15.0_linux-x86_64.tar.gz
+            tar xvf zephyr-sdk-0.15.1_linux-x86_64.tar.gz
 
          .. note::
             It is recommended to extract the Zephyr SDK bundle at one of the following locations:
@@ -522,15 +522,15 @@ that are used to emulate, flash and debug Zephyr applications.
             * ``/opt``
             * ``/usr/local``
 
-            The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.0`` directory and, when
+            The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.1`` directory and, when
             extracted under ``$HOME``, the resulting installation path will be
-            ``$HOME/zephyr-sdk-0.15.0``.
+            ``$HOME/zephyr-sdk-0.15.1``.
 
       #. Run the Zephyr SDK bundle setup script:
 
          .. code-block:: bash
 
-            cd zephyr-sdk-0.15.0
+            cd zephyr-sdk-0.15.1
             ./setup.sh
 
          .. note::
@@ -544,7 +544,7 @@ that are used to emulate, flash and debug Zephyr applications.
 
          .. code-block:: bash
 
-            sudo cp ~/zephyr-sdk-0.15.0/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d
+            sudo cp ~/zephyr-sdk-0.15.1/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d
             sudo udevadm control --reload
 
    .. group-tab:: macOS
@@ -555,8 +555,8 @@ that are used to emulate, flash and debug Zephyr applications.
          .. code-block:: bash
 
             cd ~
-            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/zephyr-sdk-0.15.0_macos-x86_64.tar.gz
-            wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/sha256.sum | shasum --check --ignore-missing
+            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_macos-x86_64.tar.gz
+            wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/sha256.sum | shasum --check --ignore-missing
 
          If your host architecture is 64-bit ARM (Apple Silicon, also known as M1), replace
          ``x86_64`` with ``aarch64`` in order to download the 64-bit ARM macOS SDK.
@@ -565,7 +565,7 @@ that are used to emulate, flash and debug Zephyr applications.
 
          .. code-block:: bash
 
-            tar xvf zephyr-sdk-0.15.0_macos-x86_64.tar.gz
+            tar xvf zephyr-sdk-0.15.1_macos-x86_64.tar.gz
 
          .. note::
             It is recommended to extract the Zephyr SDK bundle at one of the following locations:
@@ -577,15 +577,15 @@ that are used to emulate, flash and debug Zephyr applications.
             * ``/opt``
             * ``/usr/local``
 
-            The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.0`` directory and, when
+            The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.1`` directory and, when
             extracted under ``$HOME``, the resulting installation path will be
-            ``$HOME/zephyr-sdk-0.15.0``.
+            ``$HOME/zephyr-sdk-0.15.1``.
 
       #. Run the Zephyr SDK bundle setup script:
 
          .. code-block:: bash
 
-            cd zephyr-sdk-0.15.0
+            cd zephyr-sdk-0.15.1
             ./setup.sh
 
          .. note::
@@ -604,13 +604,13 @@ that are used to emulate, flash and debug Zephyr applications.
          .. code-block:: console
 
             cd %HOMEPATH%
-            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/zephyr-sdk-0.15.0_windows-x86_64.zip
+            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_windows-x86_64.zip
 
       #. Extract the Zephyr SDK bundle archive:
 
          .. code-block:: console
 
-            unzip zephyr-sdk-0.15.0_windows-x86_64.zip
+            unzip zephyr-sdk-0.15.1_windows-x86_64.zip
 
          .. note::
             It is recommended to extract the Zephyr SDK bundle at one of the following locations:
@@ -618,15 +618,15 @@ that are used to emulate, flash and debug Zephyr applications.
             * ``%HOMEPATH%``
             * ``%PROGRAMFILES%``
 
-            The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.0`` directory and, when
+            The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.1`` directory and, when
             extracted under ``%HOMEPATH%``, the resulting installation path will be
-            ``%HOMEPATH%\zephyr-sdk-0.15.0``.
+            ``%HOMEPATH%\zephyr-sdk-0.15.1``.
 
       #. Run the Zephyr SDK bundle setup script:
 
          .. code-block:: console
 
-            cd zephyr-sdk-0.15.0
+            cd zephyr-sdk-0.15.1
             setup.cmd
 
          .. note::

--- a/doc/develop/getting_started/installation_linux.rst
+++ b/doc/develop/getting_started/installation_linux.rst
@@ -232,10 +232,10 @@ Follow these steps to install the Zephyr SDK:
 
    .. code-block:: bash
 
-      wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/zephyr-sdk-0.15.0_linux-x86_64.tar.gz
-      wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/sha256.sum | shasum --check --ignore-missing
+      wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_linux-x86_64.tar.gz
+      wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/sha256.sum | shasum --check --ignore-missing
 
-   You can change ``0.15.0`` to another version if needed; the `Zephyr SDK
+   You can change ``0.15.1`` to another version if needed; the `Zephyr SDK
    Releases`_ page contains all available SDK releases.
 
    If your host architecture is 64-bit ARM (for example, Raspberry Pi), replace
@@ -246,13 +246,13 @@ Follow these steps to install the Zephyr SDK:
    .. code-block:: bash
 
       cd <sdk download directory>
-      tar xvf zephyr-sdk-0.15.0_linux-x86_64.tar.gz
+      tar xvf zephyr-sdk-0.15.1_linux-x86_64.tar.gz
 
 #. Run the Zephyr SDK bundle setup script:
 
    .. code-block:: bash
 
-      cd zephyr-sdk-0.15.0
+      cd zephyr-sdk-0.15.1
       ./setup.sh
 
    If this fails, make sure Zephyr's dependencies were installed as described
@@ -271,9 +271,9 @@ If you relocate the SDK directory, you need to re-run the setup script.
    * ``/opt``
    * ``/usr/local``
 
-   The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.0`` directory and, when
+   The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.1`` directory and, when
    extracted under ``$HOME``, the resulting installation path will be
-   ``$HOME/zephyr-sdk-0.15.0``.
+   ``$HOME/zephyr-sdk-0.15.1``.
 
    If you install the Zephyr SDK outside any of these locations, you must
    register the Zephyr SDK in the CMake package registry by running the setup

--- a/doc/develop/toolchains/zephyr_sdk.rst
+++ b/doc/develop/toolchains/zephyr_sdk.rst
@@ -65,10 +65,10 @@ Install Zephyr SDK on Linux
 
    .. code-block:: bash
 
-      wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/zephyr-sdk-0.15.0_linux-x86_64.tar.gz
-      wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/sha256.sum | shasum --check --ignore-missing
+      wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_linux-x86_64.tar.gz
+      wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/sha256.sum | shasum --check --ignore-missing
 
-   You can change ``0.15.0`` to another version if needed; the `Zephyr SDK
+   You can change ``0.15.1`` to another version if needed; the `Zephyr SDK
    Releases`_ page contains all available SDK releases.
 
    If your host architecture is 64-bit ARM (for example, Raspberry Pi), replace
@@ -79,13 +79,13 @@ Install Zephyr SDK on Linux
    .. code-block:: bash
 
       cd <sdk download directory>
-      tar xvf zephyr-sdk-0.15.0_linux-x86_64.tar.gz
+      tar xvf zephyr-sdk-0.15.1_linux-x86_64.tar.gz
 
 #. Run the Zephyr SDK bundle setup script:
 
    .. code-block:: bash
 
-      cd zephyr-sdk-0.15.0
+      cd zephyr-sdk-0.15.1
       ./setup.sh
 
    If this fails, make sure Zephyr's dependencies were installed as described
@@ -105,9 +105,9 @@ If you relocate the SDK directory, you need to re-run the setup script.
    * ``/opt``
    * ``/usr/local``
 
-   The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.0`` directory and, when
+   The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.1`` directory and, when
    extracted under ``$HOME``, the resulting installation path will be
-   ``$HOME/zephyr-sdk-0.15.0``.
+   ``$HOME/zephyr-sdk-0.15.1``.
 
 .. _toolchain_zephyr_sdk_install_macos:
 
@@ -119,8 +119,8 @@ Install Zephyr SDK on macOS
    .. code-block:: bash
 
       cd ~
-      wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/zephyr-sdk-0.15.0_macos-x86_64.tar.gz
-      wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/sha256.sum | shasum --check --ignore-missing
+      wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_macos-x86_64.tar.gz
+      wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/sha256.sum | shasum --check --ignore-missing
 
    If your host architecture is 64-bit ARM (Apple Silicon, also known as M1), replace
    ``x86_64`` with ``aarch64`` in order to download the 64-bit ARM macOS SDK.
@@ -129,7 +129,7 @@ Install Zephyr SDK on macOS
 
    .. code-block:: bash
 
-      tar xvf zephyr-sdk-0.15.0_macos-x86_64.tar.gz
+      tar xvf zephyr-sdk-0.15.1_macos-x86_64.tar.gz
 
    .. note::
       It is recommended to extract the Zephyr SDK bundle at one of the following
@@ -142,15 +142,15 @@ Install Zephyr SDK on macOS
       * ``/opt``
       * ``/usr/local``
 
-      The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.0`` directory and, when
+      The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.1`` directory and, when
       extracted under ``$HOME``, the resulting installation path will be
-      ``$HOME/zephyr-sdk-0.15.0``.
+      ``$HOME/zephyr-sdk-0.15.1``.
 
 #. Run the Zephyr SDK bundle setup script:
 
    .. code-block:: bash
 
-      cd zephyr-sdk-0.15.0
+      cd zephyr-sdk-0.15.1
       ./setup.sh
 
    .. note::
@@ -171,13 +171,13 @@ Install Zephyr SDK on Windows
    .. code-block:: console
 
       cd %HOMEPATH%
-      wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/zephyr-sdk-0.15.0_windows-x86_64.zip
+      wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_windows-x86_64.zip
 
 #. Extract the Zephyr SDK bundle archive:
 
    .. code-block:: console
 
-      unzip zephyr-sdk-0.15.0_windows-x86_64.zip
+      unzip zephyr-sdk-0.15.1_windows-x86_64.zip
 
    .. note::
       It is recommended to extract the Zephyr SDK bundle at one of the following
@@ -186,15 +186,15 @@ Install Zephyr SDK on Windows
       * ``%HOMEPATH%``
       * ``%PROGRAMFILES%``
 
-      The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.0`` directory and, when
+      The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.1`` directory and, when
       extracted under ``%HOMEPATH%``, the resulting installation path will be
-      ``%HOMEPATH%\zephyr-sdk-0.15.0``.
+      ``%HOMEPATH%\zephyr-sdk-0.15.1``.
 
 #. Run the Zephyr SDK bundle setup script:
 
    .. code-block:: console
 
-      cd zephyr-sdk-0.15.0
+      cd zephyr-sdk-0.15.1
       setup.cmd
 
    .. note::


### PR DESCRIPTION
This series updates the CI workflows and documentation to use Zephyr SDK 0.15.1.