### PR TITLE
boards: shields: x_nucleo_iks01a1: '-' is not allowed in nodelabels

### DIFF
--- a/boards/shields/x_nucleo_iks01a1/x_nucleo_iks01a1.overlay
+++ b/boards/shields/x_nucleo_iks01a1/x_nucleo_iks01a1.overlay
@@ -12,12 +12,12 @@
 		reg = <0x5f>;
 	};
 
-	lps25hb-press_x_nucleo_iks01a1: lps25hb-press@5d {
+	lps25hb_press_x_nucleo_iks01a1: lps25hb-press@5d {
 		compatible = "st,lps25hb-press";
 		reg = <0x5d>;
 	};
 
-	lis3mdl-magn_x_nucleo_iks01a1: lis3mdl-magn@1e {
+	lis3mdl_magn_x_nucleo_iks01a1: lis3mdl-magn@1e {
 		compatible = "st,lis3mdl-magn";
 		reg = <0x1e>;
 		irq-gpios = <&arduino_header 5 GPIO_ACTIVE_HIGH>; /* DRDY on A5 */

--- a/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
+++ b/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
@@ -20,7 +20,7 @@
 		reg = <0x5f>;
 	};
 
-	lps22hb-press_x_nucleo_iks01a2: lps22hb-press@5d {
+	lps22hb_press_x_nucleo_iks01a2: lps22hb-press@5d {
 		compatible = "st,lps22hb-press";
 		reg = <0x5d>;
 	};


### PR DESCRIPTION
When moving nodelabels to <device_name>_<shields_name> '-' included in <device_name> was then introduced in the  device nodelabel. But '-' isn't an allowed nodelabel character, hence this is breaking compilation with those shields.
Convert '-' to '_'.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>