### PR TITLE
doc: extensions: add custom role 'module_file'

### DIFF
--- a/doc/_extensions/zephyr/link-roles.py
+++ b/doc/_extensions/zephyr/link-roles.py
@@ -9,8 +9,10 @@ from __future__ import unicode_literals
 import re
 import subprocess
 from docutils import nodes
+
 try:
     import west.manifest
+
     try:
         west_manifest = west.manifest.Manifest.from_file()
     except west.util.WestNotFound:
@@ -21,12 +23,13 @@ except ImportError:
 
 def get_github_rev():
     try:
-        output = subprocess.check_output('git describe --exact-match',
-                                         shell=True, stderr=subprocess.DEVNULL)
+        output = subprocess.check_output(
+            "git describe --exact-match", shell=True, stderr=subprocess.DEVNULL
+        )
     except subprocess.CalledProcessError:
-        return 'main'
+        return "main"
 
-    return output.strip().decode('utf-8')
+    return output.strip().decode("utf-8")
 
 
 def setup(app):
@@ -44,8 +47,7 @@ def setup(app):
             # This search tries to look up a project named 'zephyr'.
             # If zephyr is the manifest repository, this raises
             # ValueError, since there isn't any such project.
-            baseurl = west_manifest.get_projects(['zephyr'],
-                                                 allow_paths=False)[0].url
+            baseurl = west_manifest.get_projects(["zephyr"], allow_paths=False)[0].url
             # Spot check that we have a non-empty URL.
             assert baseurl
         except ValueError:
@@ -53,22 +55,22 @@ def setup(app):
 
     # If the search failed, fall back on the mainline URL.
     if baseurl is None:
-        baseurl = 'https://github.com/zephyrproject-rtos/zephyr'
+        baseurl = "https://github.com/zephyrproject-rtos/zephyr"
 
-    app.add_role('zephyr_file', autolink('{}/blob/{}/%s'.format(baseurl, rev)))
-    app.add_role('zephyr_raw', autolink('{}/raw/{}/%s'.format(baseurl, rev)))
+    app.add_role("zephyr_file", autolink("{}/blob/{}/%s".format(baseurl, rev)))
+    app.add_role("zephyr_raw", autolink("{}/raw/{}/%s".format(baseurl, rev)))
 
     # The role just creates new nodes based on information in the
     # arguments; its behavior doesn't depend on any other documents.
     return {
-        'parallel_read_safe': True,
-        'parallel_write_safe': True,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
     }
 
 
 def autolink(pattern):
     def role(name, rawtext, text, lineno, inliner, options={}, content=[]):
-        m = re.search(r'(.*)\s*<(.*)>', text)
+        m = re.search(r"(.*)\s*<(.*)>", text)
         if m:
             link_text = m.group(1)
             link = m.group(2)
@@ -78,4 +80,5 @@ def autolink(pattern):
         url = pattern % (link,)
         node = nodes.reference(rawtext, link_text, refuri=url, **options)
         return [node], []
+
     return role

--- a/doc/_extensions/zephyr/link-roles.py
+++ b/doc/_extensions/zephyr/link-roles.py
@@ -33,32 +33,12 @@ def get_github_rev():
 
 
 def setup(app):
-    rev = get_github_rev()
+    app.add_role("zephyr_file", modulelink("zephyr"))
+    app.add_role("zephyr_raw", modulelink("zephyr", format="raw"))
+    app.add_role("module_file", modulelink())
 
-    # Try to get the zephyr repository's GitHub URL from the manifest.
-    #
-    # This allows building the docs in downstream Zephyr-based
-    # software with forks of the zephyr repository, and getting
-    # :zephyr_file: / :zephyr_raw: output that links to the fork,
-    # instead of mainline zephyr.
-    baseurl = None
-    if west_manifest is not None:
-        try:
-            # This search tries to look up a project named 'zephyr'.
-            # If zephyr is the manifest repository, this raises
-            # ValueError, since there isn't any such project.
-            baseurl = west_manifest.get_projects(["zephyr"], allow_paths=False)[0].url
-            # Spot check that we have a non-empty URL.
-            assert baseurl
-        except ValueError:
-            pass
-
-    # If the search failed, fall back on the mainline URL.
-    if baseurl is None:
-        baseurl = "https://github.com/zephyrproject-rtos/zephyr"
-
-    app.add_role("zephyr_file", autolink("{}/blob/{}/%s".format(baseurl, rev)))
-    app.add_role("zephyr_raw", autolink("{}/raw/{}/%s".format(baseurl, rev)))
+    app.add_config_value("link_roles_manifest_baseurl", None, "env")
+    app.add_config_value("link_roles_manifest_project", None, "env")
 
     # The role just creates new nodes based on information in the
     # arguments; its behavior doesn't depend on any other documents.
@@ -68,8 +48,15 @@ def setup(app):
     }
 
 
-def autolink(pattern):
+def modulelink(default_module=None, format="blob"):
     def role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+        # Set default values
+        module = default_module
+        rev = get_github_rev()
+        config = inliner.document.settings.env.app.config
+        baseurl = config.link_roles_manifest_baseurl
+        trace = f"at '{inliner.parent.source}', line {lineno}"
+
         m = re.search(r"(.*)\s*<(.*)>", text)
         if m:
             link_text = m.group(1)
@@ -77,7 +64,40 @@ def autolink(pattern):
         else:
             link_text = text
             link = text
-        url = pattern % (link,)
+
+        module_match = re.search(r"(.+?):\s*(.+)", link)
+        if module_match:
+            module = module_match.group(1).strip()
+            link = module_match.group(2).strip()
+
+        # Try to get a module repository's GitHub URL from the manifest.
+        #
+        # This allows e.g. building the docs in downstream Zephyr-based
+        # software with forks of the zephyr repository, and getting
+        # :zephyr_file: / :zephyr_raw: output that links to the fork,
+        # instead of mainline zephyr.
+        projects = [p.name for p in west_manifest.projects] if west_manifest else []
+        if module in projects:
+            project = west_manifest.get_projects([module])[0]
+            baseurl = project.url
+            rev = project.revision
+        # No module provided
+        elif module is None:
+            raise ValueError(
+                f"Role 'module_file' must take a module as an argument\n\t{trace}"
+            )
+        # Invalid module provided
+        elif module != config.link_roles_manifest_project:
+            raise ModuleNotFoundError(
+                f"Module {module} not found in the west manifest\n\t{trace}"
+            )
+        # Baseurl for manifest project not set
+        elif baseurl is None:
+            raise ValueError(
+                f"Configuration value `link_roles_manifest_baseurl` not set\n\t{trace}"
+            )
+
+        url = f"{baseurl}/{format}/{rev}/{link}"
         node = nodes.reference(rawtext, link_text, refuri=url, **options)
         return [node], []
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -251,6 +251,11 @@ html_redirect_pages = redirects.REDIRECTS
 
 warnings_filter_config = str(ZEPHYR_BASE / "doc" / "known-warnings.txt")
 
+# -- Options for zephyr.link-roles ----------------------------------------
+
+link_roles_manifest_project = "zephyr"
+link_roles_manifest_baseurl = "https://github.com/zephyrproject-rtos/zephyr"
+
 # -- Options for notfound.extension ---------------------------------------
 
 notfound_urls_prefix = f"/{version}/" if is_release else "/latest/"


### PR DESCRIPTION
Added another custom role `module_file` which functions like `zephyr_file` but for any module in the west manifest.

The new role must take a module as an argument. Example syntax:

```rst
:module_file:`module-name: path/within/module`
```

or with custom link text:

```rst
:module_file:`my link text <module-name: path/within/module>`
```

Signed-off-by: Gaute Svanes Lunde <gaute.lunde@nordicsemi.no>