### PR TITLE
boards: Add support of network interfaces for NRF boards.

### DIFF
--- a/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.yaml
+++ b/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.yaml
@@ -14,3 +14,4 @@ supported:
   - gpio
   - watchdog
   - counter
+  - netif:openthread

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.yaml
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.yaml
@@ -19,3 +19,4 @@ supported:
   - pwm
   - watchdog
   - counter
+  - netif:openthread

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.yaml
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.yaml
@@ -11,3 +11,4 @@ flash: 192
 supported:
   - counter
   - pwm
+  - netif:openthread

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.yaml
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.yaml
@@ -17,3 +17,4 @@ supported:
   - spi
   - watchdog
   - counter
+  - netif:openthread

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp.yaml
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp.yaml
@@ -16,3 +16,4 @@ supported:
   - watchdog
   - usb_cdc
   - usb_device
+  - netif:openthread

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp_ns.yaml
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp_ns.yaml
@@ -14,3 +14,4 @@ supported:
   - watchdog
   - usb_cdc
   - usb_device
+  - netif:openthread

--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.yaml
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.yaml
@@ -9,3 +9,4 @@ toolchain:
   - gnuarmemb
 supported:
   - ble
+  - netif:openthread

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_ns.yaml
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_ns.yaml
@@ -16,3 +16,4 @@ supported:
   - i2c
   - pwm
   - watchdog
+  - netif:modem

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp.yaml
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp.yaml
@@ -15,3 +15,4 @@ supported:
   - watchdog
   - usb_cdc
   - usb_device
+  - netif:openthread

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp_ns.yaml
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp_ns.yaml
@@ -14,3 +14,4 @@ supported:
   - watchdog
   - usb_cdc
   - usb_device
+  - netif:openthread


### PR DESCRIPTION
This changes add to files with boards specification information about support of the network interface.

Signed-off-by: Katarzyna Giądła <katarzyna.giadla@nordicsemi.no>