### PR TITLE
init.h: remove unnecessary includes

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/timing.c
+++ b/arch/arm/core/aarch32/cortex_m/timing.c
@@ -15,6 +15,7 @@
 #include <zephyr/timing/timing.h>
 #include <aarch32/cortex_m/dwt.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/sys_clock.h>
 
 /**
  * @brief Return the current frequency of the cycle counter

--- a/arch/common/sw_isr_common.c
+++ b/arch/common/sw_isr_common.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/sw_isr_table.h>
 #include <zephyr/arch/cpu.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys/__assert.h>
 /*
  * Common code for arches that use software ISR tables (CONFIG_GEN_ISR_TABLES)

--- a/arch/x86/core/spec_ctrl.c
+++ b/arch/x86/core/spec_ctrl.c
@@ -5,12 +5,11 @@
  */
 
 #include <zephyr/init.h>
-#include <zephyr/kernel_structs.h>
+#include <zephyr/kernel.h>
 #include <kernel_arch_data.h>
 #include <kernel_arch_func.h>
 #include <zephyr/arch/x86/msr.h>
 #include <zephyr/arch/x86/cpuid.h>
-#include <zephyr/kernel.h>
 
 /*
  * See:

--- a/boards/arc/hsdk/platform.c
+++ b/boards/arc/hsdk/platform.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/init.h>
 
 #define HSDK_CREG_GPIO_MUX_REG	0xf0001484

--- a/boards/arc/nsim/haps_arcv3_init.c
+++ b/boards/arc/nsim/haps_arcv3_init.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/arch/arc/v2/aux_regs.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
 

--- a/boards/arm/lpcxpresso55s69/pinmux.c
+++ b/boards/arm/lpcxpresso55s69/pinmux.c
@@ -4,6 +4,7 @@
  */
 
 #include <zephyr/init.h>
+#include <zephyr/devicetree.h>
 #include <fsl_common.h>
 #include <fsl_iocon.h>
 #include <soc.h>

--- a/boards/arm/mercury_xu/board.c
+++ b/boards/arm/mercury_xu/board.c
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include <zephyr/arch/cpu.h>
 #include <zephyr/init.h>
 #define MIO_PIN_18	0xff180048
 #define MIO_PIN_19	0xff18004c

--- a/boards/arm/mimxrt685_evk/init.c
+++ b/boards/arm/mimxrt685_evk/init.c
@@ -4,6 +4,7 @@
  */
 
 #include <zephyr/init.h>
+#include <zephyr/devicetree.h>
 #include <fsl_device_registers.h>
 
 static int mimxrt685_evk_init(const struct device *dev)

--- a/boards/arm/thingy52_nrf52832/board.c
+++ b/boards/arm/thingy52_nrf52832/board.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 
 static const struct gpio_dt_spec ccs_gpio =
 	GPIO_DT_SPEC_GET(DT_NODELABEL(ccs_pwr), enable_gpios);

--- a/boards/arm/thingy53_nrf5340/board.c
+++ b/boards/arm/thingy53_nrf5340/board.c
@@ -5,8 +5,8 @@
  */
 
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-
 #include <soc.h>
 
 LOG_MODULE_REGISTER(thingy53_board_init);

--- a/drivers/clock_control/beetle_clock_control.c
+++ b/drivers/clock_control/beetle_clock_control.c
@@ -16,6 +16,7 @@
 
 #include <soc.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/clock_control/arm_clock_control.h>
 

--- a/drivers/clock_control/clock_control_gd32.c
+++ b/drivers/clock_control/clock_control_gd32.c
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/clock_control.h>

--- a/drivers/clock_control/clock_control_lpc11u6x.c
+++ b/drivers/clock_control/clock_control_lpc11u6x.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 
 #include <zephyr/drivers/clock_control/lpc11u6x_clock_control.h>
 

--- a/drivers/clock_control/clock_control_mchp_xec.c
+++ b/drivers/clock_control/clock_control_mchp_xec.c
@@ -12,7 +12,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/mchp_xec_clock_control.h>
 #include <zephyr/dt-bindings/clock/mchp_xec_pcr.h>
-
+#include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(clock_control_xec, LOG_LEVEL_ERR);
 

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -6,9 +6,9 @@
 
 #define DT_DRV_COMPAT nxp_lpc_syscon
 #include <errno.h>
-#include <soc.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <soc.h>
 #include <fsl_clock.h>
 
 #define LOG_LEVEL CONFIG_CLOCK_CONTROL_LOG_LEVEL

--- a/drivers/clock_control/clock_control_r8a7795_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_r8a7795_cpg_mssr.c
@@ -10,6 +10,7 @@
 
 #include <errno.h>
 #include <soc.h>
+#include <zephyr/arch/cpu.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
 #include <zephyr/dt-bindings/clock/renesas_cpg_mssr.h>

--- a/drivers/clock_control/clock_control_r8a7795_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_r8a7795_cpg_mssr.c
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
 #include <zephyr/dt-bindings/clock/renesas_cpg_mssr.h>
 #include <zephyr/dt-bindings/clock/r8a7795_cpg_mssr.h>
+#include <zephyr/irq.h>
 #include "clock_control_renesas_cpg_mssr.h"
 
 #define LOG_LEVEL CONFIG_CLOCK_CONTROL_LOG_LEVEL

--- a/drivers/clock_control/clock_control_renesas_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_renesas_cpg_mssr.c
@@ -8,6 +8,7 @@
 #include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
 #include <zephyr/dt-bindings/clock/renesas_cpg_mssr.h>
 #include <zephyr/irq.h>
+#include <zephyr/kernel.h>
 #include "clock_control_renesas_cpg_mssr.h"
 
 static void rcar_cpg_reset(uint32_t base_address, uint32_t reg, uint32_t bit)

--- a/drivers/clock_control/clock_control_renesas_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_renesas_cpg_mssr.c
@@ -7,6 +7,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
 #include <zephyr/dt-bindings/clock/renesas_cpg_mssr.h>
+#include <zephyr/irq.h>
 #include "clock_control_renesas_cpg_mssr.h"
 
 static void rcar_cpg_reset(uint32_t base_address, uint32_t reg, uint32_t bit)

--- a/drivers/clock_control/clock_stm32g4.c
+++ b/drivers/clock_control/clock_stm32g4.c
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/sys/time_units.h>
 #include "clock_stm32_ll_common.h"
 
 #if defined(STM32_PLL_ENABLED)

--- a/drivers/clock_control/clock_stm32l4_l5_wb_wl.c
+++ b/drivers/clock_control/clock_stm32l4_l5_wb_wl.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/sys/time_units.h>
 #include "clock_stm32_ll_common.h"
 
 #if defined(STM32_PLL_ENABLED)

--- a/drivers/counter/counter_mcux_ctimer.c
+++ b/drivers/counter/counter_mcux_ctimer.c
@@ -10,6 +10,8 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/irq.h>
+
 LOG_MODULE_REGISTER(mcux_ctimer, CONFIG_COUNTER_LOG_LEVEL);
 
 #ifdef CONFIG_COUNTER_MCUX_CTIMER_RESERVE_CHANNEL_FOR_SETTOP

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 #include <fsl_gpt.h>
 #include <zephyr/logging/log.h>
 

--- a/drivers/counter/counter_mcux_pit.c
+++ b/drivers/counter/counter_mcux_pit.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT nxp_kinetis_pit
 
 #include <zephyr/drivers/counter.h>
+#include <zephyr/irq.h>
 #include <fsl_pit.h>
 
 #define LOG_MODULE_NAME counter_pit

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -9,6 +9,7 @@
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/irq.h>
+#include <zephyr/kernel.h>
 #include <fsl_rtc.h>
 #include <zephyr/logging/log.h>
 

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -8,6 +8,7 @@
 #define DT_DRV_COMPAT nxp_kinetis_rtc
 
 #include <zephyr/drivers/counter.h>
+#include <zephyr/irq.h>
 #include <fsl_rtc.h>
 #include <zephyr/logging/log.h>
 

--- a/drivers/counter/counter_mcux_rtc.c
+++ b/drivers/counter/counter_mcux_rtc.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/counter.h>
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys_clock.h>
 #include <fsl_rtc.h>
 #include <zephyr/logging/log.h>
 

--- a/drivers/counter/counter_mcux_snvs.c
+++ b/drivers/counter/counter_mcux_snvs.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(mcux_snvs, CONFIG_COUNTER_LOG_LEVEL);
 #endif
 
 #include <zephyr/drivers/counter.h>
+#include <zephyr/irq.h>
 #include <fsl_snvs_hp.h>
 
 #ifdef MCUX_SNVS_SRTC

--- a/drivers/counter/counter_xlnx_axi_timer.c
+++ b/drivers/counter/counter_xlnx_axi_timer.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT xlnx_xps_timer_1_00_a
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/sys/sys_io.h>

--- a/drivers/counter/counter_xlnx_axi_timer.c
+++ b/drivers/counter/counter_xlnx_axi_timer.c
@@ -9,6 +9,7 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/counter.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(xlnx_axi_timer, CONFIG_COUNTER_LOG_LEVEL);

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -6,6 +6,8 @@
 
 #define DT_DRV_COMPAT arm_cmsdk_dtimer
 
+#include <limits.h>
+
 #include <zephyr/drivers/counter.h>
 #include <zephyr/device.h>
 #include <errno.h>

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -10,8 +10,10 @@
 #include <zephyr/device.h>
 #include <errno.h>
 #include <zephyr/init.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <zephyr/drivers/clock_control/arm_clock_control.h>
+#include <zephyr/irq.h>
 
 #include "dualtimer_cmsdk_apb.h"
 

--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -10,6 +10,7 @@
 #include <zephyr/device.h>
 #include <errno.h>
 #include <zephyr/init.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <zephyr/drivers/clock_control/arm_clock_control.h>
 

--- a/drivers/display/display_dummy.c
+++ b/drivers/display/display_dummy.c
@@ -7,7 +7,9 @@
 
 #define DT_DRV_COMPAT zephyr_dummy_dc
 
+#include <errno.h>
 #include <string.h>
+
 #include <zephyr/drivers/display.h>
 #include <zephyr/device.h>
 

--- a/drivers/display/display_intel_multibootfb.c
+++ b/drivers/display/display_intel_multibootfb.c
@@ -9,6 +9,8 @@
 
 #define DT_DRV_COMPAT intel_multiboot_framebuffer
 
+#include <errno.h>
+
 #include <zephyr/arch/x86/multiboot.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/display.h>

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/display.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 #include <fsl_elcdif.h>
 
 #ifdef CONFIG_HAS_MCUX_CACHE

--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(ssd1306, CONFIG_DISPLAY_LOG_LEVEL);
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/kernel.h>
 
 #include "ssd1306_regs.h"
 #include <zephyr/display/cfb.h>

--- a/drivers/ec_host_cmd_periph/ec_host_cmd_simulator.c
+++ b/drivers/ec_host_cmd_periph/ec_host_cmd_simulator.c
@@ -6,6 +6,8 @@
 
 #define DT_DRV_COMPAT zephyr_sim_ec_host_cmd_periph
 
+#include <errno.h>
+
 #include <zephyr/device.h>
 #include <zephyr/drivers/ec_host_cmd_periph.h>
 #include <string.h>

--- a/drivers/ec_host_cmd_periph/ec_host_cmd_simulator.c
+++ b/drivers/ec_host_cmd_periph/ec_host_cmd_simulator.c
@@ -10,6 +10,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/ec_host_cmd_periph.h>
+#include <zephyr/kernel.h>
 #include <string.h>
 
 #ifndef CONFIG_ARCH_POSIX

--- a/drivers/eeprom/eeprom_tmp116.c
+++ b/drivers/eeprom/eeprom_tmp116.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
+
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/eeprom.h>
 #include <zephyr/drivers/sensor/tmp116.h>

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -6,6 +6,7 @@
  */
 
 #include <zephyr/drivers/entropy.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/atomic.h>
 #include <soc.h>
 #include <hal/nrf_rng.h>

--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/entropy.h>
 #include <errno.h>
 #include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 #include <string.h>
 

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 #include <zephyr/drivers/mdio.h>
 #include <zephyr/net/phy.h>

--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/drivers/flash.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys/util.h>
 #include "spi_nor.h"
 #include "memc_mcux_flexspi.h"

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT	nxp_imx_flexspi_nor
 
 #include <zephyr/drivers/flash.h>
+#include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include "spi_nor.h"

--- a/drivers/flash/flash_page_layout.c
+++ b/drivers/flash/flash_page_layout.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
+
 #include <zephyr/drivers/flash.h>
 
 static int flash_get_page_info(const struct device *dev, off_t offs,

--- a/drivers/flash/soc_flash_b91.c
+++ b/drivers/flash/soc_flash_b91.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/flash.h>
-
+#include <zephyr/kernel.h>
 
 /* driver definitions */
 #define BLOCK_64K_SIZE         (0x10000u)

--- a/drivers/gpio/gpio_b91.c
+++ b/drivers/gpio/gpio_b91.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 #include "gpio_utils.h"
 
 

--- a/drivers/gpio/gpio_emul_sdl.c
+++ b/drivers/gpio/gpio_emul_sdl.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT zephyr_gpio_emul_sdl
 
 #include <zephyr/drivers/gpio/gpio_emul.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
 #include <SDL.h>

--- a/drivers/gpio/gpio_eos_s3.c
+++ b/drivers/gpio/gpio_eos_s3.c
@@ -8,6 +8,7 @@
 
 #include <errno.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <eoss3_hal_gpio.h>
 #include <eoss3_hal_pads.h>

--- a/drivers/gpio/gpio_fxl6408.c
+++ b/drivers/gpio/gpio_fxl6408.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/kernel.h>
 #include "gpio_utils.h"
 #include <zephyr/logging/log.h>
 

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -8,6 +8,7 @@
 
 #include <errno.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <em_gpio.h>
 

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <zephyr/sys/util.h>
 #include <gpio_imx.h>

--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/gpio/ite-it8xxx2-gpio.h>
 #include <zephyr/dt-bindings/interrupt-controller/ite-intc.h>
+#include <zephyr/irq.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
 #include <string.h>

--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -6,6 +6,7 @@
  */
 #include <errno.h>
 #include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/gpio/ite-it8xxx2-gpio.h>
 #include <zephyr/dt-bindings/interrupt-controller/ite-intc.h>

--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -16,6 +16,10 @@
 #include <string.h>
 #include <zephyr/logging/log.h>
 #include "gpio_utils.h"
+
+#include <chip_chipregs.h>
+#include <soc_common.h>
+
 LOG_MODULE_REGISTER(gpio_it8xxx2, LOG_LEVEL_ERR);
 
 #define DT_DRV_COMPAT ite_it8xxx2_gpio

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
 #include <string.h>

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -16,6 +16,8 @@
 #include <string.h>
 #include <zephyr/logging/log.h>
 
+#include <soc.h>
+
 #include "gpio_utils.h"
 
 #define SUPPORTED_FLAGS (GPIO_INPUT | GPIO_OUTPUT | \

--- a/drivers/gpio/gpio_lpc11u6x.c
+++ b/drivers/gpio/gpio_lpc11u6x.c
@@ -18,6 +18,7 @@
 
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 
 #include <soc.h>
 

--- a/drivers/gpio/gpio_mchp_xec_v2.c
+++ b/drivers/gpio/gpio_mchp_xec_v2.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT microchip_xec_gpio_v2
 
 #include <errno.h>
+#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/pinctrl/mchp-xec-pinctrl.h>

--- a/drivers/gpio/gpio_mchp_xec_v2.c
+++ b/drivers/gpio/gpio_mchp_xec_v2.c
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/pinctrl/mchp-xec-pinctrl.h>
 #include <soc.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 
 #include "gpio_utils.h"
 

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -11,6 +11,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/gpio/nxp-kinetis-gpio.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <fsl_common.h>
 #include <fsl_port.h>

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <fsl_common.h>
 #include <fsl_gpio.h>

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -17,6 +17,7 @@
 #include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <fsl_common.h>
 #include "gpio_utils.h"

--- a/drivers/gpio/gpio_mmio32.c
+++ b/drivers/gpio/gpio_mmio32.c
@@ -27,6 +27,7 @@
  */
 
 #include <zephyr/drivers/gpio/gpio_mmio32.h>
+#include <zephyr/irq.h>
 #include <errno.h>
 
 static int gpio_mmio32_config(const struct device *dev,

--- a/drivers/gpio/gpio_neorv32.c
+++ b/drivers/gpio/gpio_neorv32.c
@@ -10,6 +10,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/syscon.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(gpio_neorv32, CONFIG_GPIO_LOG_LEVEL);

--- a/drivers/gpio/gpio_neorv32.c
+++ b/drivers/gpio/gpio_neorv32.c
@@ -13,6 +13,9 @@
 #include <zephyr/irq.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/logging/log.h>
+
+#include <soc.h>
+
 LOG_MODULE_REGISTER(gpio_neorv32, CONFIG_GPIO_LOG_LEVEL);
 
 #include "gpio_utils.h"

--- a/drivers/gpio/gpio_neorv32.c
+++ b/drivers/gpio/gpio_neorv32.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT neorv32_gpio
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/syscon.h>

--- a/drivers/gpio/gpio_pcal6408a.c
+++ b/drivers/gpio/gpio_pcal6408a.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT nxp_pcal6408a
 
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 #include "gpio_utils.h"

--- a/drivers/gpio/gpio_pcf8574.c
+++ b/drivers/gpio/gpio_pcf8574.c
@@ -10,6 +10,7 @@
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pcf8574, CONFIG_GPIO_LOG_LEVEL);
 

--- a/drivers/gpio/gpio_rpi_pico.c
+++ b/drivers/gpio/gpio_rpi_pico.c
@@ -6,6 +6,7 @@
 
 #include <errno.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 
 /* pico-sdk includes */
 #include <hardware/gpio.h>

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <fsl_common.h>
 #include <fsl_port.h>

--- a/drivers/gpio/gpio_smartbond.c
+++ b/drivers/gpio/gpio_smartbond.c
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 
 #include <DA1469xAB.h>
 

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -10,6 +10,7 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <zephyr/sys/sys_io.h>
 #include "gpio_utils.h"

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT ti_stellaris_gpio
 
 #include <errno.h>
+#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <soc.h>

--- a/drivers/i2c/i2c_gecko.c
+++ b/drivers/i2c/i2c_gecko.c
@@ -8,6 +8,7 @@
 
 #include <errno.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 #include <em_cmu.h>
 #include <em_i2c.h>

--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -9,6 +9,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
 #include <zephyr/pm/policy.h>
 #include <errno.h>
 #include <soc.h>

--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
+#include <zephyr/kernel.h>
 #include <zephyr/pm/policy.h>
 #include <errno.h>
 #include <soc.h>

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
+#include <zephyr/kernel.h>
 #include <errno.h>
 #include <soc.h>
 #include <soc_dt.h>

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -9,6 +9,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
 #include <errno.h>
 #include <soc.h>
 #include <soc_dt.h>

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -8,6 +8,7 @@
 
 #include <errno.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 #include <fsl_i2c.h>
 #include <fsl_clock.h>

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/kernel.h>
 #include <fsl_lpi2c.h>
 
 #ifdef CONFIG_PINCTRL

--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/irq.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 #include <zephyr/sys/util.h>
 #include <altera_common.h>

--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -8,6 +8,7 @@
 
 #include <errno.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <zephyr/sys/util.h>
 #include <altera_common.h>

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -70,6 +70,7 @@
 #include <assert.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 
 #include <zephyr/logging/log.h>

--- a/drivers/interrupt_controller/intc_cavs.c
+++ b/drivers/interrupt_controller/intc_cavs.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT intel_cavs_intc
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/irq_nextlevel.h>
 #include "intc_cavs.h"

--- a/drivers/interrupt_controller/intc_cavs.c
+++ b/drivers/interrupt_controller/intc_cavs.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
+#include <zephyr/irq.h>
 #include <zephyr/irq_nextlevel.h>
 #include "intc_cavs.h"
 

--- a/drivers/interrupt_controller/intc_cavs.c
+++ b/drivers/interrupt_controller/intc_cavs.c
@@ -10,6 +10,7 @@
 #include <zephyr/device.h>
 #include <zephyr/irq.h>
 #include <zephyr/irq_nextlevel.h>
+#include <zephyr/sys/arch_interface.h>
 #include "intc_cavs.h"
 
 #if defined(CONFIG_SMP) && (CONFIG_MP_NUM_CPUS > 1)

--- a/drivers/interrupt_controller/intc_gd32_exti.c
+++ b/drivers/interrupt_controller/intc_gd32_exti.c
@@ -11,6 +11,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/interrupt_controller/gd32_exti.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys/util_macro.h>
 
 #include <gd32_exti.h>

--- a/drivers/interrupt_controller/intc_gd32_exti.c
+++ b/drivers/interrupt_controller/intc_gd32_exti.c
@@ -6,6 +6,8 @@
 
 #define DT_DRV_COMPAT gd_gd32_exti
 
+#include <errno.h>
+
 #include <zephyr/device.h>
 #include <zephyr/drivers/interrupt_controller/gd32_exti.h>
 #include <zephyr/sys/__assert.h>

--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -10,6 +10,7 @@
  * NOTE: This driver implements the GICv1 and GICv2 interfaces.
  */
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/sw_isr_table.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sw_isr_table.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>

--- a/drivers/interrupt_controller/intc_sam0_eic.c
+++ b/drivers/interrupt_controller/intc_sam0_eic.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT atmel_sam0_eic
 
 #include <zephyr/device.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <zephyr/drivers/interrupt_controller/sam0_eic.h>
 #include "intc_sam0_eic_priv.h"

--- a/drivers/interrupt_controller/intc_sam0_eic_priv.h
+++ b/drivers/interrupt_controller/intc_sam0_eic_priv.h
@@ -7,6 +7,7 @@
 #ifndef ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_SAM0_EIC_PRIV_H_
 #define ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_SAM0_EIC_PRIV_H_
 
+#include <errno.h>
 #include <zephyr/types.h>
 #include <soc.h>
 

--- a/drivers/mdio/mdio_esp32.c
+++ b/drivers/mdio/mdio_esp32.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/mdio.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
 #include <esp_mac.h>

--- a/drivers/mdio/mdio_sam.c
+++ b/drivers/mdio/mdio_sam.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 #include <zephyr/drivers/mdio.h>
 #include <zephyr/drivers/pinctrl.h>

--- a/drivers/pinctrl/pfc_rcar.c
+++ b/drivers/pinctrl/pfc_rcar.c
@@ -7,6 +7,7 @@
 
 #define DT_DRV_COMPAT renesas_rcar_pfc
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <soc.h>

--- a/drivers/pinctrl/pinctrl_ite_it8xxx2.c
+++ b/drivers/pinctrl/pinctrl_ite_it8xxx2.c
@@ -7,8 +7,10 @@
 #define DT_DRV_COMPAT ite_it8xxx2_pinctrl_func
 
 #include <zephyr/drivers/pinctrl.h>
-
 #include <zephyr/logging/log.h>
+
+#include <chip_chipregs.h>
+
 LOG_MODULE_REGISTER(pinctrl_ite_it8xxx2, LOG_LEVEL_ERR);
 
 #define GPIO_IT8XXX2_REG_BASE \

--- a/drivers/pinctrl/pinctrl_rv32m1.c
+++ b/drivers/pinctrl/pinctrl_rv32m1.c
@@ -8,7 +8,9 @@
 #define DT_DRV_COMPAT openisa_rv32m1_pinmux
 
 #include <zephyr/drivers/pinctrl.h>
+
 #include <fsl_clock.h>
+#include <soc.h>
 
 /* Port register addresses. */
 static PORT_Type *ports[] = {

--- a/drivers/pinctrl/pinctrl_sifive.c
+++ b/drivers/pinctrl/pinctrl_sifive.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT sifive_pinctrl
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/sifive-pinctrl.h>

--- a/drivers/pinmux/pinmux_lpc11u6x.c
+++ b/drivers/pinmux/pinmux_lpc11u6x.c
@@ -20,6 +20,8 @@
  * of pins information.
  */
 
+#include <errno.h>
+
 #include <zephyr/drivers/pinmux.h>
 
 struct pinmux_lpc11u6x_config {

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -6,6 +6,7 @@
 
 #include <errno.h>
 #include <zephyr/drivers/pwm.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 #include <device_imx.h>
 #include <zephyr/drivers/pinctrl.h>

--- a/drivers/pwm/pwm_litex.c
+++ b/drivers/pwm/pwm_litex.c
@@ -10,6 +10,8 @@
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/types.h>
 
+#include <soc.h>
+
 #define REG_EN_ENABLE             0x1
 #define REG_EN_DISABLE            0x0
 

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <errno.h>
 #include <zephyr/drivers/pwm.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <fsl_ftm.h>
 #include <fsl_clock.h>

--- a/drivers/pwm/pwm_mcux_pwt.c
+++ b/drivers/pwm/pwm_mcux_pwt.c
@@ -9,6 +9,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <errno.h>
 #include <zephyr/drivers/pwm.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <fsl_pwt.h>
 #include <fsl_clock.h>

--- a/drivers/pwm/pwm_sifive.c
+++ b/drivers/pwm/pwm_sifive.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT sifive_pwm0
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/device.h>

--- a/drivers/pwm/pwm_xlnx_axi_timer.c
+++ b/drivers/pwm/pwm_xlnx_axi_timer.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT xlnx_xps_timer_1_00_a_pwm
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/sys/sys_io.h>

--- a/drivers/reset/reset_rpi_pico.c
+++ b/drivers/reset/reset_rpi_pico.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT raspberrypi_pico_reset
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/reset.h>
 

--- a/drivers/reset/reset_rpi_pico.c
+++ b/drivers/reset/reset_rpi_pico.c
@@ -6,6 +6,8 @@
 
 #define DT_DRV_COMPAT raspberrypi_pico_reset
 
+#include <limits.h>
+
 #include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/reset.h>

--- a/drivers/sdhc/mcux_sdif.c
+++ b/drivers/sdhc/mcux_sdif.c
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
+#include <zephyr/kernel.h>
 #include <fsl_sdif.h>
 
 LOG_MODULE_REGISTER(sdif, CONFIG_SDHC_LOG_LEVEL);

--- a/drivers/sdhc/mcux_sdif.c
+++ b/drivers/sdhc/mcux_sdif.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 #include <fsl_sdif.h>
 
 LOG_MODULE_REGISTER(sdif, CONFIG_SDHC_LOG_LEVEL);

--- a/drivers/sensor/adxl372/adxl372.h
+++ b/drivers/sensor/adxl372/adxl372.h
@@ -11,6 +11,7 @@
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)

--- a/drivers/sensor/bma280/bma280.h
+++ b/drivers/sensor/bma280/bma280.h
@@ -12,6 +12,7 @@
 #include <zephyr/types.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 
 #define BMA280_REG_CHIP_ID		0x00
 #if DT_INST_PROP(0, is_bmc150)

--- a/drivers/sensor/bmi160/bmi160.h
+++ b/drivers/sensor/bmi160/bmi160.h
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 
 /* registers */

--- a/drivers/sensor/bmi270/bmi270.c
+++ b/drivers/sensor/bmi270/bmi270.c
@@ -9,6 +9,7 @@
 
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/logging/log.h>

--- a/drivers/sensor/bmi270/bmi270_spi.c
+++ b/drivers/sensor/bmi270/bmi270_spi.c
@@ -8,6 +8,7 @@
  * Bus-specific functionality for BMI270s accessed via SPI.
  */
 
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include "bmi270.h"
 

--- a/drivers/sensor/fxas21002/fxas21002.h
+++ b/drivers/sensor/fxas21002/fxas21002.h
@@ -7,6 +7,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 
 #define FXAS21002_REG_STATUS		0x00
 #define FXAS21002_REG_OUTXMSB		0x01

--- a/drivers/sensor/fxos8700/fxos8700.h
+++ b/drivers/sensor/fxos8700/fxos8700.h
@@ -7,6 +7,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 
 #define FXOS8700_REG_STATUS			0x00
 #define FXOS8700_REG_OUTXMSB			0x01

--- a/drivers/sensor/hmc5883l/hmc5883l.h
+++ b/drivers/sensor/hmc5883l/hmc5883l.h
@@ -12,6 +12,7 @@
 #include <zephyr/types.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 
 #define HMC5883L_REG_CONFIG_A           0x00
 #define HMC5883L_ODR_SHIFT              2

--- a/drivers/sensor/icm42605/icm42605.h
+++ b/drivers/sensor/icm42605/icm42605.h
@@ -10,6 +10,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 

--- a/drivers/sensor/icm42670/icm42670.h
+++ b/drivers/sensor/icm42670/icm42670.h
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/kernel.h>
 
 struct icm42670_data {
 	int16_t accel_x;

--- a/drivers/sensor/icm42670/icm42670_spi.c
+++ b/drivers/sensor/icm42670/icm42670_spi.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 #include "icm42670_spi.h"
 #include "icm42670_reg.h"

--- a/drivers/sensor/iis2dh/iis2dh.h
+++ b/drivers/sensor/iis2dh/iis2dh.h
@@ -16,6 +16,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
 #include "iis2dh_reg.h"
 
 /*

--- a/drivers/sensor/iis2mdc/iis2mdc.h
+++ b/drivers/sensor/iis2mdc/iis2mdc.h
@@ -13,6 +13,7 @@
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 #include "iis2mdc_reg.h"
 

--- a/drivers/sensor/iis3dhhc/iis3dhhc.h
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.h
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/spi.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
 #include "iis3dhhc_reg.h"

--- a/drivers/sensor/ina23x/ina230.h
+++ b/drivers/sensor/ina23x/ina230.h
@@ -10,6 +10,7 @@
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/kernel.h>
 
 #define INA230_REG_CONFIG     0x00
 #define INA230_REG_SHUNT_VOLT 0x01

--- a/drivers/sensor/ina23x/ina23x_trigger.h
+++ b/drivers/sensor/ina23x/ina23x_trigger.h
@@ -9,6 +9,7 @@
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
 
 struct ina23x_trigger {
 	struct gpio_callback gpio_cb;

--- a/drivers/sensor/ism330dhcx/ism330dhcx.h
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.h
@@ -16,6 +16,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 #include "ism330dhcx_reg.h"
 

--- a/drivers/sensor/lis3mdl/lis3mdl.h
+++ b/drivers/sensor/lis3mdl/lis3mdl.h
@@ -12,6 +12,7 @@
 #include <zephyr/types.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 
 #define LIS3MDL_REG_WHO_AM_I            0x0F
 #define LIS3MDL_CHIP_ID                 0x3D

--- a/drivers/sensor/lsm6dsl/lsm6dsl.h
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.h
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/types.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)

--- a/drivers/sensor/max17055/max17055.c
+++ b/drivers/sensor/max17055/max17055.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 
 #include <zephyr/logging/log.h>

--- a/drivers/sensor/max17262/max17262.c
+++ b/drivers/sensor/max17262/max17262.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(max17262, CONFIG_SENSOR_LOG_LEVEL);

--- a/drivers/sensor/mcux_acmp/mcux_acmp.c
+++ b/drivers/sensor/mcux_acmp/mcux_acmp.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/sensor/mcux_acmp.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
 #include <fsl_acmp.h>
 #include <zephyr/drivers/pinctrl.h>
 

--- a/drivers/sensor/mpu6050/mpu6050.h
+++ b/drivers/sensor/mpu6050/mpu6050.h
@@ -10,6 +10,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 

--- a/drivers/sensor/ms5607/ms5607_spi.c
+++ b/drivers/sensor/ms5607/ms5607_spi.c
@@ -8,6 +8,7 @@
 
 #include <string.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 #include "ms5607.h"
 

--- a/drivers/sensor/nuvoton_adc_cmp_npcx/adc_cmp_npcx.c
+++ b/drivers/sensor/nuvoton_adc_cmp_npcx/adc_cmp_npcx.c
@@ -7,7 +7,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/adc/adc_npcx_threshold.h>
 #include <zephyr/drivers/sensor/adc_cmp_npcx.h>
-
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(adc_cmp_npcx, CONFIG_SENSOR_LOG_LEVEL);

--- a/drivers/sensor/sm351lt/sm351lt.h
+++ b/drivers/sensor/sm351lt/sm351lt.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
 
 #define SENSOR_ATTR_SM351LT_TRIGGER_TYPE SENSOR_ATTR_PRIV_START
 

--- a/drivers/sensor/stts751/stts751.h
+++ b/drivers/sensor/stts751/stts751.h
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
 #include "stts751_reg.h"

--- a/drivers/sensor/vcnl4040/vcnl4040.h
+++ b/drivers/sensor/vcnl4040/vcnl4040.h
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 
 /* Registers all 16 bits */
 #define VCNL4040_REG_ALS_CONF	0x00

--- a/drivers/serial/uart_apbuart.c
+++ b/drivers/serial/uart_apbuart.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/drivers/uart.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys/time_units.h>
 #include <errno.h>
 
 /* APBUART registers

--- a/drivers/serial/uart_apbuart.c
+++ b/drivers/serial/uart_apbuart.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT gaisler_apbuart
 
 #include <zephyr/drivers/uart.h>
+#include <zephyr/irq.h>
 #include <errno.h>
 
 /* APBUART registers

--- a/drivers/serial/uart_b91.c
+++ b/drivers/serial/uart_b91.c
@@ -10,6 +10,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
 
 
 /* Driver dts compatibility: telink,b91_uart */

--- a/drivers/serial/uart_lpc11u6x.c
+++ b/drivers/serial/uart_lpc11u6x.c
@@ -9,6 +9,7 @@
 
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 
 #include "uart_lpc11u6x.h"
 

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -11,6 +11,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 #include <fsl_uart.h>
 #include <soc.h>
 #ifdef CONFIG_PINCTRL

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -18,6 +18,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 #include <fsl_usart.h>
 #include <soc.h>
 #include <fsl_device_registers.h>

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -9,6 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 #include <errno.h>
 #include <fsl_uart.h>
 #include <zephyr/drivers/pinctrl.h>

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -13,6 +13,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 #include <zephyr/pm/policy.h>
 #ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/irq.h>
+#include <zephyr/kernel.h>
 #include <zephyr/pm/policy.h>
 #ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>

--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -18,6 +18,8 @@
 #include <poll.h>
 
 #include <zephyr/drivers/uart.h>
+#include <zephyr/kernel.h>
+
 #include "cmdline.h" /* native_posix command line options header */
 #include "soc.h"
 

--- a/drivers/serial/uart_rcar.c
+++ b/drivers/serial/uart_rcar.c
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
 
 struct uart_rcar_cfg {

--- a/drivers/serial/uart_rpi_pico.c
+++ b/drivers/serial/uart_rpi_pico.c
@@ -8,6 +8,7 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/reset.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
 
 /* pico-sdk includes */
 #include <hardware/uart.h>

--- a/drivers/serial/uart_rtt.c
+++ b/drivers/serial/uart_rtt.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/drivers/uart.h>
+#include <zephyr/kernel.h>
 #include <SEGGER_RTT.h>
 
 #define DT_DRV_COMPAT segger_rtt_uart

--- a/drivers/serial/uart_rv32m1_lpuart.c
+++ b/drivers/serial/uart_rv32m1_lpuart.c
@@ -11,6 +11,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 #include <fsl_lpuart.h>
 #include <soc.h>
 #ifdef CONFIG_PINCTRL

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -21,6 +21,7 @@
 #include <soc.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
 
 /* Device constant configuration parameters */
 struct uart_sam_dev_cfg {

--- a/drivers/serial/uart_xlnx_uartlite.c
+++ b/drivers/serial/uart_xlnx_uartlite.c
@@ -12,6 +12,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/irq.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/sys_io.h>
 
 /* AXI UART Lite v2 registers offsets (See Xilinx PG142 for details) */

--- a/drivers/serial/uart_xlnx_uartlite.c
+++ b/drivers/serial/uart_xlnx_uartlite.c
@@ -11,6 +11,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys/sys_io.h>
 
 /* AXI UART Lite v2 registers offsets (See Xilinx PG142 for details) */

--- a/drivers/serial/usart_gd32.c
+++ b/drivers/serial/usart_gd32.c
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/reset.h>
 #include <zephyr/drivers/uart.h>
+#include <zephyr/irq.h>
 
 #include <gd32_usart.h>
 

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -21,6 +21,7 @@
 #include <soc.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
 
 /* Device constant configuration parameters */
 struct usart_sam_dev_cfg {

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -14,6 +14,7 @@
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/syscon/syscon.c
+++ b/drivers/syscon/syscon.c
@@ -6,6 +6,8 @@
 
 #define DT_DRV_COMPAT syscon
 
+#include <errno.h>
+
 #include <zephyr/arch/cpu.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/device.h>

--- a/drivers/syscon/syscon.c
+++ b/drivers/syscon/syscon.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT syscon
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -6,6 +6,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/timer/arm_arch_timer.h>
 #include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/arch/cpu.h>

--- a/drivers/timer/cc13x2_cc26x2_rtc_timer.c
+++ b/drivers/timer/cc13x2_cc26x2_rtc_timer.c
@@ -20,6 +20,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
+#include <zephyr/spinlock.h>
 #include <zephyr/sys_clock.h>
 
 #include <driverlib/interrupt.h>

--- a/drivers/timer/cc13x2_cc26x2_rtc_timer.c
+++ b/drivers/timer/cc13x2_cc26x2_rtc_timer.c
@@ -19,6 +19,7 @@
 #include <soc.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys_clock.h>
 
 #include <driverlib/interrupt.h>

--- a/drivers/timer/esp32c3_sys_timer.c
+++ b/drivers/timer/esp32c3_sys_timer.c
@@ -18,6 +18,7 @@
 #include <zephyr/sys_clock.h>
 #include <soc.h>
 #include <zephyr/device.h>
+#include <zephyr/spinlock.h>
 
 #define CYC_PER_TICK ((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec()	\
 			      / (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))

--- a/drivers/timer/leon_gptimer.c
+++ b/drivers/timer/leon_gptimer.c
@@ -14,6 +14,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys_clock.h>
 
 /* GPTIMER subtimer increments each microsecond. */

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -13,6 +13,7 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 
 BUILD_ASSERT(!IS_ENABLED(CONFIG_SMP), "XEC RTOS timer doesn't support SMP");
 BUILD_ASSERT(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC == 32768,

--- a/drivers/timer/mcux_gpt_timer.c
+++ b/drivers/timer/mcux_gpt_timer.c
@@ -12,7 +12,7 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/sys/time_units.h>
-
+#include <zephyr/irq.h>
 
 
 /* GPT is a 32 bit counter, but we use a lower value to avoid integer overflow */

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -9,6 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/time_units.h>
 #include <fsl_lptmr.h>
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/kernel.h>
 #include <fsl_lptmr.h>
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
 #include "fsl_ostimer.h"

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -6,6 +6,8 @@
 
 #define DT_DRV_COMPAT nxp_os_timer
 
+#include <limits.h>
+
 #include <zephyr/device.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -9,6 +9,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
 #include <soc.h>

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <limits.h>
+
 #include <zephyr/device.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -37,6 +37,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
 #include <soc.h>

--- a/drivers/timer/rcar_cmt_timer.c
+++ b/drivers/timer/rcar_cmt_timer.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <soc.h>
 #include <zephyr/drivers/timer/system_timer.h>

--- a/drivers/timer/rcar_cmt_timer.c
+++ b/drivers/timer/rcar_cmt_timer.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
+#include <zephyr/irq.h>
 
 #define DT_DRV_COMPAT renesas_rcar_cmt
 

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -3,6 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include <limits.h>
+
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/timer/system_timer.h>

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -16,6 +16,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/irq.h>
 
 #include <zephyr/spinlock.h>
 

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -9,6 +9,7 @@
 
 #include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include "xlnx_psttc_timer_priv.h"

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -10,6 +10,7 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys_clock.h>
 #include <soc.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include "xlnx_psttc_timer_priv.h"

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -7,6 +7,7 @@
 
 #define DT_DRV_COMPAT xlnx_ttcps
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <soc.h>
 #include <zephyr/drivers/timer/system_timer.h>

--- a/drivers/usb/device/usb_dc_mcux.c
+++ b/drivers/usb/device/usb_dc_mcux.c
@@ -13,6 +13,7 @@
 #include <zephyr/usb/usb_device.h>
 #include <soc.h>
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 #include "usb.h"
 #include "usb_device.h"
 #include "usb_device_config.h"

--- a/drivers/usb/device/usb_dc_native_posix.c
+++ b/drivers/usb/device/usb_dc_native_posix.c
@@ -11,6 +11,7 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/usb/usb_dc.h>
 #include <zephyr/usb/usb_device.h>

--- a/drivers/usb/device/usb_dc_sam_usbhs.c
+++ b/drivers/usb/device/usb_dc_sam_usbhs.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT atmel_sam_usbhs
 
 #include <zephyr/usb/usb_device.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <string.h>
 

--- a/drivers/usb/device/usb_dc_sam_usbhs.c
+++ b/drivers/usb/device/usb_dc_sam_usbhs.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/usb/usb_device.h>
 #include <zephyr/irq.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 #include <string.h>
 

--- a/drivers/watchdog/wdt_fwdgt_gd32.c
+++ b/drivers/watchdog/wdt_fwdgt_gd32.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys_clock.h>
 
 #include <gd32_fwdgt.h>
 

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -11,6 +11,7 @@
 
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys_clock.h>
 #include <soc.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_iwdg.h>

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -10,6 +10,7 @@
 #define DT_DRV_COMPAT st_stm32_watchdog
 
 #include <zephyr/drivers/watchdog.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_iwdg.h>

--- a/drivers/watchdog/wdt_mcux_wdog.c
+++ b/drivers/watchdog/wdt_mcux_wdog.c
@@ -9,6 +9,7 @@
 
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 #include <fsl_wdog.h>
 
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL

--- a/drivers/watchdog/wdt_mcux_wwdt.c
+++ b/drivers/watchdog/wdt_mcux_wwdt.c
@@ -11,6 +11,7 @@
 #define DT_DRV_COMPAT nxp_lpc_wwdt
 
 #include <zephyr/drivers/watchdog.h>
+#include <zephyr/irq.h>
 #include <fsl_wwdt.h>
 #include <fsl_clock.h>
 

--- a/drivers/watchdog/wdt_mcux_wwdt.c
+++ b/drivers/watchdog/wdt_mcux_wwdt.c
@@ -12,6 +12,7 @@
 
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys_clock.h>
 #include <fsl_wwdt.h>
 #include <fsl_clock.h>
 

--- a/drivers/watchdog/wdt_sam.c
+++ b/drivers/watchdog/wdt_sam.c
@@ -20,6 +20,7 @@
  */
 
 #include <zephyr/drivers/watchdog.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -16,6 +16,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys_clock.h>
 
 #include "wdt_wwdg_stm32.h"
 

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -15,6 +15,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 
 #include "wdt_wwdg_stm32.h"
 

--- a/drivers/watchdog/wdt_wwdgt_gd32.c
+++ b/drivers/watchdog/wdt_wwdgt_gd32.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/clock_control/gd32.h>
 #include <zephyr/drivers/reset.h>
 #include <zephyr/drivers/watchdog.h>
+#include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 
 #include <gd32_wwdgt.h>

--- a/drivers/watchdog/wdt_wwdgt_gd32.c
+++ b/drivers/watchdog/wdt_wwdgt_gd32.c
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys_clock.h>
 
 #include <gd32_wwdgt.h>
 

--- a/include/zephyr/arch/arc/v2/arc_connect.h
+++ b/include/zephyr/arch/arc/v2/arc_connect.h
@@ -16,6 +16,7 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
+#include <zephyr/arch/arc/v2/aux_regs.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/arch/arm/aarch32/asm_inline_gcc.h
+++ b/include/zephyr/arch/arm/aarch32/asm_inline_gcc.h
@@ -20,7 +20,6 @@
 
 #include <zephyr/types.h>
 #include <zephyr/arch/arm/aarch32/exc.h>
-#include <zephyr/irq.h>
 
 #if defined(CONFIG_CPU_AARCH32_CORTEX_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A)
 #include <zephyr/arch/arm/aarch32/cortex_a_r/cpu.h>

--- a/include/zephyr/arch/arm/aarch32/cortex_m/cmsis.h
+++ b/include/zephyr/arch/arm/aarch32/cortex_m/cmsis.h
@@ -14,9 +14,9 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_CORTEX_M_CMSIS_H_
 #define ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_CORTEX_M_CMSIS_H_
 
-#include <soc.h>
-
 #include <zephyr/arch/arm/aarch32/cortex_m/nvic.h>
+
+#include <soc.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/arch/arm/aarch32/irq.h
+++ b/include/zephyr/arch/arm/aarch32/irq.h
@@ -16,7 +16,6 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_IRQ_H_
 #define ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_IRQ_H_
 
-#include <zephyr/irq.h>
 #include <zephyr/sw_isr_table.h>
 #include <stdbool.h>
 

--- a/include/zephyr/arch/xtensa/irq.h
+++ b/include/zephyr/arch/xtensa/irq.h
@@ -6,6 +6,8 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_XTENSA_XTENSA_IRQ_H_
 #define ZEPHYR_INCLUDE_ARCH_XTENSA_XTENSA_IRQ_H_
 
+#include <stdint.h>
+
 #include <zephyr/toolchain.h>
 #include <xtensa/config/core-isa.h>
 

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -15,6 +15,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/bbram.h
+++ b/include/zephyr/drivers/bbram.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_BBRAM_H
 #define ZEPHYR_INCLUDE_DRIVERS_BBRAM_H
 
+#include <errno.h>
+
 #include <zephyr/device.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -14,6 +14,7 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <string.h>
+#include <zephyr/sys_clock.h>
 #include <zephyr/sys/util.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -12,6 +12,7 @@
 
 #include <zephyr/types.h>
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 #include <string.h>
 #include <zephyr/sys/util.h>
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -8,6 +8,8 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CAN_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CAN_H_
 
+#include <errno.h>
+
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 #include <string.h>

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -21,8 +21,10 @@
  * @{
  */
 
-#include <zephyr/types.h>
+#include <errno.h>
 #include <stddef.h>
+
+#include <zephyr/types.h>
 #include <zephyr/device.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/slist.h>

--- a/include/zephyr/drivers/coredump.h
+++ b/include/zephyr/drivers/coredump.h
@@ -13,6 +13,7 @@
 #define INCLUDE_ZEPHYR_DRIVERS_COREDUMP_H_
 
 #include <zephyr/device.h>
+#include <zephyr/sys/slist.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -25,6 +25,7 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <zephyr/device.h>
+#include <zephyr/sys_clock.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -20,6 +20,8 @@
  * @{
  */
 
+#include <errno.h>
+
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <zephyr/device.h>

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -24,6 +24,8 @@
  * @{
  */
 
+#include <errno.h>
+
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 

--- a/include/zephyr/drivers/edac.h
+++ b/include/zephyr/drivers/edac.h
@@ -12,6 +12,8 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_EDAC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_EDAC_H_
 
+#include <errno.h>
+
 #include <sys/types.h>
 
 typedef void (*edac_notify_callback_f)(const struct device *dev, void *data);

--- a/include/zephyr/drivers/entropy.h
+++ b/include/zephyr/drivers/entropy.h
@@ -20,6 +20,8 @@
  * @{
  */
 
+#include <errno.h>
+
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 

--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -12,6 +12,8 @@
 #ifndef ZEPHYR_INCLUDE_ESPI_H_
 #define ZEPHYR_INCLUDE_ESPI_H_
 
+#include <errno.h>
+
 #include <zephyr/sys/__assert.h>
 #include <zephyr/types.h>
 #include <zephyr/device.h>

--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -17,6 +17,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/types.h>
 #include <zephyr/device.h>
+#include <zephyr/sys/slist.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/espi_emul.h
+++ b/include/zephyr/drivers/espi_emul.h
@@ -10,6 +10,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/emul.h>
 #include <zephyr/drivers/espi.h>
+#include <zephyr/sys/slist.h>
 #include <zephyr/types.h>
 
 /**

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -20,6 +20,8 @@
  * @{
  */
 
+#include <errno.h>
+
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <sys/types.h>

--- a/include/zephyr/drivers/fpga.h
+++ b/include/zephyr/drivers/fpga.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_FPGA_H_
 #define ZEPHYR_INCLUDE_DRIVERS_FPGA_H_
 
+#include <errno.h>
+
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/device.h>

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -15,6 +15,8 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_GPIO_H_
 #define ZEPHYR_INCLUDE_DRIVERS_GPIO_H_
 
+#include <errno.h>
+
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/slist.h>
 

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -19,6 +19,8 @@
  * @{
  */
 
+#include <errno.h>
+
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -23,6 +23,7 @@
 
 #include <zephyr/types.h>
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -24,6 +24,7 @@
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/slist.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/i2c_emul.h
+++ b/include/zephyr/drivers/i2c_emul.h
@@ -15,6 +15,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/emul.h>
+#include <zephyr/sys/slist.h>
 #include <zephyr/types.h>
 
 /**

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -19,6 +19,8 @@
  * @{
  */
 
+#include <errno.h>
+
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 

--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -18,6 +18,8 @@
  * @{
  */
 
+#include <errno.h>
+
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/devicetree/pinctrl.h>

--- a/include/zephyr/drivers/reset.h
+++ b/include/zephyr/drivers/reset.h
@@ -19,6 +19,8 @@
  * @{
  */
 
+#include <errno.h>
+
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 

--- a/include/zephyr/drivers/sdhc.h
+++ b/include/zephyr/drivers/sdhc.h
@@ -11,6 +11,8 @@
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SDHC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SDHC_H_
+
+#include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/sd/sd_spec.h>
 

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -24,6 +24,7 @@
 #include <zephyr/device.h>
 #include <zephyr/dt-bindings/spi/spi.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/spi_emul.h
+++ b/include/zephyr/drivers/spi_emul.h
@@ -10,6 +10,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/emul.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/sys/slist.h>
 #include <zephyr/types.h>
 
 /**

--- a/include/zephyr/drivers/syscon.h
+++ b/include/zephyr/drivers/syscon.h
@@ -19,6 +19,8 @@
  * @{
  */
 
+#include <errno.h>
+
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 

--- a/include/zephyr/drivers/virtualization/ivshmem.h
+++ b/include/zephyr/drivers/virtualization/ivshmem.h
@@ -16,6 +16,7 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/w1.h
+++ b/include/zephyr/drivers/w1.h
@@ -15,6 +15,7 @@
 
 #include <zephyr/types.h>
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/crc.h>
 #include <zephyr/sys/byteorder.h>
 

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -7,9 +7,10 @@
 #ifndef ZEPHYR_INCLUDE_INIT_H_
 #define ZEPHYR_INCLUDE_INIT_H_
 
+#include <stdint.h>
+#include <stddef.h>
+
 #include <zephyr/toolchain.h>
-#include <zephyr/kernel.h>
-#include <zephyr/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/ipc/ipc_service.h
+++ b/include/zephyr/ipc/ipc_service.h
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/ipc/ipc_service_backend.h
+++ b/include/zephyr/ipc/ipc_service_backend.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_INCLUDE_IPC_SERVICE_IPC_SERVICE_BACKEND_H_
 
 #include <zephyr/ipc/ipc_service.h>
+#include <zephyr/kernel.h>
 #include <stdio.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/sd/sd.h
+++ b/include/zephyr/sd/sd.h
@@ -14,6 +14,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/sdhc.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <zephyr/device.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/sys/kobject.h>
 #include <zephyr/syscall_handler.h>
 
 extern const struct init_entry __init_start[];

--- a/samples/application_development/out_of_tree_driver/hello_world_module/zephyr/hello_world_driver.c
+++ b/samples/application_development/out_of_tree_driver/hello_world_module/zephyr/hello_world_driver.c
@@ -6,6 +6,7 @@
 
 #include "hello_world_driver.h"
 #include <zephyr/types.h>
+#include <zephyr/sys/printk.h>
 #include <zephyr/syscall_handler.h>
 
 /**

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/app_gpio.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/app_gpio.c
@@ -6,6 +6,7 @@
  */
 
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 
 #include "app_gpio.h"
 #include "publisher.h"

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.h
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.h
@@ -8,6 +8,8 @@
 #ifndef _PUBLISHER_H
 #define _PUBLISHER_H
 
+#include <zephyr/kernel.h>
+
 /* Others */
 #define LEVEL_S0   -32768
 #define LEVEL_S25  -16384

--- a/samples/drivers/ht16k33/src/main.c
+++ b/samples/drivers/ht16k33/src/main.c
@@ -7,6 +7,7 @@
 #include <zephyr/drivers/led.h>
 #include <zephyr/drivers/kscan.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(main, CONFIG_LOG_DEFAULT_LEVEL);

--- a/samples/shields/x_nucleo_53l0a1/src/display_7seg.c
+++ b/samples/shields/x_nucleo_53l0a1/src/display_7seg.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/printk.h>
 
 const uint8_t DISPLAY_OFF[4] = { CHAR_OFF, CHAR_OFF, CHAR_OFF, CHAR_OFF };
 const uint8_t TEXT_Err[4] = { CHAR_E, CHAR_r, CHAR_r, CHAR_OFF };

--- a/soc/arc/snps_emsk/soc_config.c
+++ b/soc/arc/snps_emsk/soc_config.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
 

--- a/soc/arc/snps_nsim/smp.c
+++ b/soc/arc/snps_nsim/smp.c
@@ -12,6 +12,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/arch/arc/v2/arc_connect.h>
+#include <zephyr/arch/arc/v2/aux_regs.h>
 
 static int arc_nsim_smp_init(const struct device *dev)
 {

--- a/soc/arm/arm/designstart/soc.c
+++ b/soc/arm/arm/designstart/soc.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/device.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 
 static int arm_designstart_init(const struct device *arg)
 {

--- a/soc/arm/atmel_sam/sam3x/soc.c
+++ b/soc/arm/atmel_sam/sam3x/soc.c
@@ -19,6 +19,7 @@
 #include <soc.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 
 /*
  * PLL clock = Main * (MULA + 1) / DIVA

--- a/soc/arm/atmel_sam/sam4e/soc.c
+++ b/soc/arm/atmel_sam/sam4e/soc.c
@@ -20,6 +20,7 @@
 #include <soc.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 
 /**
  * @brief Setup various clock on SoC at boot time.

--- a/soc/arm/atmel_sam/sam4l/soc.c
+++ b/soc/arm/atmel_sam/sam4l/soc.c
@@ -15,6 +15,7 @@
 #include <zephyr/init.h>
 #include <soc.h>
 #include <zephyr/arch/cpu.h>
+#include <zephyr/irq.h>
 
 /** Watchdog control register first write keys */
 #define WDT_FIRST_KEY     0x55ul

--- a/soc/arm/atmel_sam/sam4s/soc.c
+++ b/soc/arm/atmel_sam/sam4s/soc.c
@@ -19,6 +19,7 @@
 #include <soc.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 
 /**
  * @brief Setup various clock on SoC at boot time.

--- a/soc/arm/atmel_sam/same70/soc.c
+++ b/soc/arm/atmel_sam/same70/soc.c
@@ -16,6 +16,7 @@
 #include <soc.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);

--- a/soc/arm/atmel_sam/samv71/soc.c
+++ b/soc/arm/atmel_sam/samv71/soc.c
@@ -17,6 +17,7 @@
 #include <soc.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);

--- a/soc/arm/bcm_vk/valkyrie/soc.c
+++ b/soc/arm/bcm_vk/valkyrie/soc.c
@@ -7,6 +7,7 @@
 #include <zephyr/init.h>
 #include <soc.h>
 #include <zephyr/arch/cpu.h>
+#include <zephyr/irq.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm/bcm_vk/viper/soc.c
+++ b/soc/arm/bcm_vk/viper/soc.c
@@ -8,6 +8,7 @@
 #include <zephyr/init.h>
 #include <soc.h>
 #include <zephyr/arch/cpu.h>
+#include <zephyr/irq.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm/gigadevice/gd32e10x/soc.c
+++ b/soc/arm/gigadevice/gd32e10x/soc.c
@@ -5,6 +5,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 
 static int gd32e10x_soc_init(const struct device *dev)

--- a/soc/arm/gigadevice/gd32f3x0/soc.c
+++ b/soc/arm/gigadevice/gd32f3x0/soc.c
@@ -5,6 +5,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 
 static int gd32f3x0_init(const struct device *dev)

--- a/soc/arm/gigadevice/gd32f403/soc.c
+++ b/soc/arm/gigadevice/gd32f403/soc.c
@@ -13,6 +13,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/irq.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm/gigadevice/gd32f4xx/soc.c
+++ b/soc/arm/gigadevice/gd32f4xx/soc.c
@@ -5,6 +5,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/irq.h>
 
 static int gd32f4xx_soc_init(const struct device *dev)
 {

--- a/soc/arm/intel_socfpga_std/cyclonev/soc.c
+++ b/soc/arm/intel_socfpga_std/cyclonev/soc.c
@@ -13,6 +13,7 @@
 #include <mmu.h>
 #include <zephyr/arch/arm/aarch32/mmu/arm_mmu.h>
 #include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include "soc.h"
 
 void arch_reserved_pages_update(void)

--- a/soc/arm/intel_socfpga_std/cyclonev/soc.c
+++ b/soc/arm/intel_socfpga_std/cyclonev/soc.c
@@ -12,6 +12,7 @@
 #include <zephyr/sys/util.h>
 #include <mmu.h>
 #include <zephyr/arch/arm/aarch32/mmu/arm_mmu.h>
+#include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
 #include "soc.h"
 
 void arch_reserved_pages_update(void)

--- a/soc/arm/nxp_imx/mcimx6x_m4/soc.c
+++ b/soc/arm/nxp_imx/mcimx6x_m4/soc.c
@@ -9,6 +9,7 @@
 #include <soc.h>
 #include <zephyr/dt-bindings/rdc/imx_rdc.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include "wdog_imx.h"
 
 /* Initialize Resource Domain Controller. */

--- a/soc/arm/nxp_imx/mcimx6x_m4/soc.c
+++ b/soc/arm/nxp_imx/mcimx6x_m4/soc.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/init.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <zephyr/dt-bindings/rdc/imx_rdc.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>

--- a/soc/arm/nxp_imx/mcimx7_m4/soc.c
+++ b/soc/arm/nxp_imx/mcimx7_m4/soc.c
@@ -7,6 +7,7 @@
 #include <zephyr/init.h>
 #include <soc.h>
 #include <zephyr/dt-bindings/rdc/imx_rdc.h>
+#include <zephyr/devicetree.h>
 #include "wdog_imx.h"
 
 /* Initialize clock. */

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -13,6 +13,7 @@
  */
 
 #include <zephyr/init.h>
+#include <zephyr/devicetree.h>
 #include <soc.h>
 #include "flash_clock_setup.h"
 #include "fsl_power.h"

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -16,6 +16,7 @@
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/irq.h>
+#include <zephyr/linker/section_tags.h>
 #include <soc.h>
 #include "flash_clock_setup.h"
 #include "fsl_power.h"

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -12,6 +12,7 @@
  * hardware for the RT5XX platforms.
  */
 
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/irq.h>

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -14,6 +14,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include "flash_clock_setup.h"
 #include "fsl_power.h"

--- a/soc/arm/nxp_lpc/lpc55xxx/soc.h
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.h
@@ -16,7 +16,6 @@
 #define _SOC__H_
 
 #ifndef _ASMLANGUAGE
-#include <zephyr/sys/util.h>
 #include <fsl_common.h>
 
 

--- a/soc/arm/st_stm32/stm32f0/soc.c
+++ b/soc/arm/st_stm32/stm32f0/soc.c
@@ -14,6 +14,7 @@
 #include <stm32_ll_system.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/irq.h>
 #include <zephyr/linker/linker-defs.h>
 #include <string.h>

--- a/soc/arm/st_stm32/stm32f0/soc.c
+++ b/soc/arm/st_stm32/stm32f0/soc.c
@@ -14,6 +14,7 @@
 #include <stm32_ll_system.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 #include <zephyr/linker/linker-defs.h>
 #include <string.h>
 

--- a/soc/arm/st_stm32/stm32f1/soc.c
+++ b/soc/arm/st_stm32/stm32f1/soc.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/irq.h>
 
 /**

--- a/soc/arm/st_stm32/stm32f1/soc.c
+++ b/soc/arm/st_stm32/stm32f1/soc.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm/st_stm32/stm32f2/soc.c
+++ b/soc/arm/st_stm32/stm32f2/soc.c
@@ -17,6 +17,7 @@
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <stm32_ll_system.h>
 #include <zephyr/linker/linker-defs.h>
+#include <zephyr/irq.h>
 #include <string.h>
 
 /**

--- a/soc/arm/st_stm32/stm32f2/soc.c
+++ b/soc/arm/st_stm32/stm32f2/soc.c
@@ -15,6 +15,7 @@
 #include <soc.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <stm32_ll_system.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/irq.h>

--- a/soc/arm/st_stm32/stm32f3/soc.c
+++ b/soc/arm/st_stm32/stm32f3/soc.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/irq.h>
 
 /**

--- a/soc/arm/st_stm32/stm32f3/soc.c
+++ b/soc/arm/st_stm32/stm32f3/soc.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm/st_stm32/stm32f4/soc.c
+++ b/soc/arm/st_stm32/stm32f4/soc.c
@@ -14,6 +14,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/irq.h>
 
 #include <stm32_ll_system.h>

--- a/soc/arm/st_stm32/stm32f4/soc.c
+++ b/soc/arm/st_stm32/stm32f4/soc.c
@@ -14,6 +14,8 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
+
 #include <stm32_ll_system.h>
 
 /**

--- a/soc/arm/st_stm32/stm32f7/soc.c
+++ b/soc/arm/st_stm32/stm32f7/soc.c
@@ -15,6 +15,7 @@
 #include <soc.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/irq.h>
 #include <stm32_ll_system.h>
 

--- a/soc/arm/st_stm32/stm32f7/soc.c
+++ b/soc/arm/st_stm32/stm32f7/soc.c
@@ -15,6 +15,7 @@
 #include <soc.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 #include <stm32_ll_system.h>
 
 /**

--- a/soc/arm/st_stm32/stm32g0/soc.c
+++ b/soc/arm/st_stm32/stm32g0/soc.c
@@ -14,6 +14,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/irq.h>
 #include <zephyr/linker/linker-defs.h>
 #include <string.h>

--- a/soc/arm/st_stm32/stm32g0/soc.c
+++ b/soc/arm/st_stm32/stm32g0/soc.c
@@ -14,6 +14,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 #include <zephyr/linker/linker-defs.h>
 #include <string.h>
 #if defined(SYSCFG_CFGR1_UCPD1_STROBE) || defined(SYSCFG_CFGR1_UCPD2_STROBE)

--- a/soc/arm/st_stm32/stm32g4/soc.c
+++ b/soc/arm/st_stm32/stm32g4/soc.c
@@ -14,6 +14,7 @@
 #include <stm32_ll_system.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 
 #if defined(PWR_CR3_UCPD_DBDIS)
 #include <stm32_ll_bus.h>

--- a/soc/arm/st_stm32/stm32g4/soc.c
+++ b/soc/arm/st_stm32/stm32g4/soc.c
@@ -14,6 +14,7 @@
 #include <stm32_ll_system.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/irq.h>
 
 #if defined(PWR_CR3_UCPD_DBDIS)

--- a/soc/arm/st_stm32/stm32h7/soc_m4.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m4.c
@@ -21,6 +21,7 @@
 #include <stm32_ll_system.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include "stm32_hsem.h"
 
 /**

--- a/soc/arm/st_stm32/stm32h7/soc_m4.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m4.c
@@ -12,6 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_cortex.h>

--- a/soc/arm/st_stm32/stm32h7/soc_m7.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m7.c
@@ -20,6 +20,7 @@
 #include <stm32_ll_system.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include "stm32_hsem.h"
 
 #if defined(CONFIG_STM32H7_DUAL_CORE)

--- a/soc/arm/st_stm32/stm32h7/soc_m7.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m7.c
@@ -12,6 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_pwr.h>

--- a/soc/arm/st_stm32/stm32l0/soc.c
+++ b/soc/arm/st_stm32/stm32l0/soc.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/irq.h>
 #include <zephyr/linker/linker-defs.h>
 #include <string.h>

--- a/soc/arm/st_stm32/stm32l0/soc.c
+++ b/soc/arm/st_stm32/stm32l0/soc.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 #include <zephyr/linker/linker-defs.h>
 #include <string.h>
 #include <stm32_ll_bus.h>

--- a/soc/arm/st_stm32/stm32l1/soc.c
+++ b/soc/arm/st_stm32/stm32l1/soc.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/irq.h>
 #include <zephyr/linker/linker-defs.h>
 #include <string.h>

--- a/soc/arm/st_stm32/stm32l1/soc.c
+++ b/soc/arm/st_stm32/stm32l1/soc.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 #include <zephyr/linker/linker-defs.h>
 #include <string.h>
 #include <stm32_ll_bus.h>

--- a/soc/arm/st_stm32/stm32l4/soc.c
+++ b/soc/arm/st_stm32/stm32l4/soc.c
@@ -14,6 +14,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 

--- a/soc/arm/st_stm32/stm32l4/soc.c
+++ b/soc/arm/st_stm32/stm32l4/soc.c
@@ -14,6 +14,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL

--- a/soc/arm/st_stm32/stm32l5/soc.c
+++ b/soc/arm/st_stm32/stm32l5/soc.c
@@ -15,6 +15,7 @@
 #include <stm32_ll_pwr.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 #include <stm32l5xx_ll_icache.h>
 #include <zephyr/logging/log.h>
 

--- a/soc/arm/st_stm32/stm32l5/soc.c
+++ b/soc/arm/st_stm32/stm32l5/soc.c
@@ -15,6 +15,7 @@
 #include <stm32_ll_pwr.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/irq.h>
 #include <stm32l5xx_ll_icache.h>
 #include <zephyr/logging/log.h>

--- a/soc/arm/st_stm32/stm32mp1/soc.c
+++ b/soc/arm/st_stm32/stm32mp1/soc.c
@@ -16,6 +16,7 @@
 #include <stm32_ll_bus.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/irq.h>
 
 /**

--- a/soc/arm/st_stm32/stm32mp1/soc.c
+++ b/soc/arm/st_stm32/stm32mp1/soc.c
@@ -16,6 +16,7 @@
 #include <stm32_ll_bus.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm/st_stm32/stm32u5/soc.c
+++ b/soc/arm/st_stm32/stm32u5/soc.c
@@ -16,7 +16,7 @@
 #include <stm32_ll_icache.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
-
+#include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL

--- a/soc/arm/st_stm32/stm32u5/soc.c
+++ b/soc/arm/st_stm32/stm32u5/soc.c
@@ -16,6 +16,7 @@
 #include <stm32_ll_icache.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 

--- a/soc/arm/st_stm32/stm32wb/soc.c
+++ b/soc/arm/st_stm32/stm32wb/soc.c
@@ -14,6 +14,7 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);

--- a/soc/arm/st_stm32/stm32wb/soc.c
+++ b/soc/arm/st_stm32/stm32wb/soc.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
 

--- a/soc/arm/st_stm32/stm32wl/soc.c
+++ b/soc/arm/st_stm32/stm32wl/soc.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/irq.h>
 
 #include <stm32wlxx_ll_system.h>

--- a/soc/arm/st_stm32/stm32wl/soc.c
+++ b/soc/arm/st_stm32/stm32wl/soc.c
@@ -13,6 +13,8 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
+
 #include <stm32wlxx_ll_system.h>
 
 /**

--- a/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>

--- a/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
@@ -12,6 +12,7 @@
 
 #include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
 #include <zephyr/arch/arm/aarch32/mmu/arm_mmu.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include "soc.h"
 
 /* System Level Control Registers (SLCR) */

--- a/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
@@ -10,6 +10,7 @@
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
 
+#include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
 #include <zephyr/arch/arm/aarch32/mmu/arm_mmu.h>
 #include "soc.h"
 

--- a/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>

--- a/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
@@ -12,6 +12,7 @@
 
 #include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
 #include <zephyr/arch/arm/aarch32/mmu/arm_mmu.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include "soc.h"
 
 /* System Level Configuration Registers */

--- a/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
@@ -10,6 +10,7 @@
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
 
+#include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
 #include <zephyr/arch/arm/aarch32/mmu/arm_mmu.h>
 #include "soc.h"
 

--- a/soc/riscv/riscv-privilege/gd32vf103/soc.c
+++ b/soc/riscv/riscv-privilege/gd32vf103/soc.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/init.h>
+#include <zephyr/irq.h>
 
 #include <gd32vf103.h>
 

--- a/soc/riscv/riscv-privilege/sifive-freedom/fe310_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fe310_clock.c
@@ -6,6 +6,7 @@
  */
 
 #include <zephyr/init.h>
+#include <zephyr/devicetree.h>
 #include "fe310_prci.h"
 
 #define CORECLK_HZ (DT_PROP(DT_NODELABEL(coreclk), clock_frequency))

--- a/soc/riscv/riscv-privilege/sifive-freedom/fe310_prci.h
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fe310_prci.h
@@ -7,6 +7,8 @@
 #ifndef _SIFIVE_PRCI_H
 #define _SIFIVE_PRCI_H
 
+#include <soc.h>
+
 #define Z_REG32(p, i) (*(volatile uint32_t *) ((p) + (i)))
 #define PRCI_REG(offset) Z_REG32(PRCI_BASE_ADDR, offset)
 

--- a/soc/riscv/riscv-privilege/sifive-freedom/fu540_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fu540_clock.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
 #include "fu540_prci.h"
 
 BUILD_ASSERT(MHZ(1000) == DT_PROP(DT_NODELABEL(coreclk), clock_frequency),

--- a/soc/riscv/riscv-privilege/sifive-freedom/fu540_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fu540_clock.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/init.h>
+#include <zephyr/devicetree.h>
 #include "fu540_prci.h"
 
 BUILD_ASSERT(MHZ(1000) == DT_PROP(DT_NODELABEL(coreclk), clock_frequency),

--- a/soc/riscv/riscv-privilege/sifive-freedom/fu540_prci.h
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fu540_prci.h
@@ -7,6 +7,8 @@
 #ifndef _SIFIVE_FU540_PRCI_H
 #define _SIFIVE_FU540_PRCI_H
 
+#include <soc.h>
+
 #define Z_REG32(p, i) (*(volatile uint32_t *) ((p) + (i)))
 #define PRCI_REG(offset) Z_REG32(PRCI_BASE_ADDR, offset)
 

--- a/soc/riscv/riscv-privilege/sifive-freedom/fu740_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fu740_clock.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
 
 #include "fu740_prci.h"
 

--- a/soc/riscv/riscv-privilege/sifive-freedom/fu740_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fu740_clock.c
@@ -5,6 +5,8 @@
  */
 
 #include <zephyr/init.h>
+#include <zephyr/devicetree.h>
+
 #include "fu740_prci.h"
 
 BUILD_ASSERT(MHZ(1000) == DT_PROP(DT_NODELABEL(coreclk), clock_frequency),

--- a/soc/riscv/riscv-privilege/sifive-freedom/fu740_prci.h
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fu740_prci.h
@@ -7,6 +7,8 @@
 #ifndef _SIFIVE_FU740_PRCI_H
 #define _SIFIVE_FU740_PRCI_H
 
+#include <soc.h>
+
 #define Z_REG32(p, i) (*(volatile uint32_t *) ((p) + (i)))
 #define PRCI_REG(offset) Z_REG32(PRCI_BASE_ADDR, offset)
 

--- a/soc/xtensa/intel_adsp/cavs/irq.c
+++ b/soc/xtensa/intel_adsp/cavs/irq.c
@@ -8,6 +8,7 @@
 #include <xtensa/hal.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #include <adsp_shim.h>
 #include <cavs-idc.h>

--- a/soc/xtensa/intel_adsp/cavs/power.c
+++ b/soc/xtensa/intel_adsp/cavs/power.c
@@ -9,6 +9,7 @@
 #include <zephyr/irq_nextlevel.h>
 #include <xtensa/hal.h>
 #include <zephyr/init.h>
+#include <zephyr/kernel.h>
 
 #include <adsp_shim.h>
 #include <adsp-clk.h>

--- a/soc/xtensa/intel_adsp/common/clk.c
+++ b/soc/xtensa/intel_adsp/common/clk.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 
 #include <adsp-clk.h>
 #include <adsp_shim.h>

--- a/soc/xtensa/intel_adsp/common/clk.c
+++ b/soc/xtensa/intel_adsp/common/clk.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
+#include <zephyr/spinlock.h>
 
 #include <adsp-clk.h>
 #include <adsp_shim.h>

--- a/soc/xtensa/intel_adsp/common/clk.c
+++ b/soc/xtensa/intel_adsp/common/clk.c
@@ -3,6 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include <errno.h>
+
 #include <zephyr/device.h>
 
 #include <adsp-clk.h>

--- a/soc/xtensa/nxp_adsp/common/soc.c
+++ b/soc/xtensa/nxp_adsp/common/soc.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/arch/xtensa/irq.h>
 #include <zephyr/device.h>
 #include <xtensa/xtruntime.h>
 #include <zephyr/irq_nextlevel.h>

--- a/subsys/bluetooth/controller/util/util.c
+++ b/subsys/bluetooth/controller/util/util.c
@@ -6,6 +6,7 @@
  */
 #include <string.h>
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/entropy.h>

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -11,6 +11,7 @@
 #include <zephyr/types.h>
 #include <errno.h>
 #include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <zephyr/fs/fs.h>
 #include <zephyr/fs/fs_sys.h>
 #include <zephyr/sys/check.h>

--- a/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
+++ b/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
@@ -7,6 +7,7 @@
 #include <zephyr/drivers/ec_host_cmd_periph.h>
 #include <zephyr/mgmt/ec_host_cmd.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
 #include <string.h>
 
 #if !DT_HAS_CHOSEN(zephyr_ec_host_interface)

--- a/subsys/mgmt/hawkbit/hawkbit_firmware.c
+++ b/subsys/mgmt/hawkbit/hawkbit_firmware.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/storage/flash_map.h>
+#include <zephyr/sys/printk.h>
 
 #include "hawkbit_firmware.h"
 

--- a/subsys/mgmt/updatehub/updatehub_firmware.c
+++ b/subsys/mgmt/updatehub/updatehub_firmware.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/sys/printk.h>
 #include <zephyr/storage/flash_map.h>
 
 #include "updatehub_firmware.h"

--- a/subsys/pm/pm_stats.c
+++ b/subsys/pm/pm_stats.c
@@ -8,7 +8,7 @@
 #include "pm_stats.h"
 
 #include <zephyr/init.h>
-#include <zephyr/kernel_structs.h>
+#include <zephyr/kernel.h>
 #include <zephyr/stats/stats.h>
 #include <zephyr/sys/printk.h>
 

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
+
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <sys/types.h>

--- a/subsys/storage/flash_map/flash_map_integrity.c
+++ b/subsys/storage/flash_map/flash_map_integrity.c
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
+
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <sys/types.h>

--- a/subsys/storage/flash_map/flash_map_layout.c
+++ b/subsys/storage/flash_map/flash_map_layout.c
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
+
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <sys/types.h>

--- a/subsys/usb/device/usb_descriptor.h
+++ b/subsys/usb/device/usb_descriptor.h
@@ -9,6 +9,8 @@
 #ifndef __USB_DESCRIPTOR_H__
 #define __USB_DESCRIPTOR_H__
 
+#include <zephyr/sys/slist.h>
+
 /*
  * The USB Unicode bString is encoded in UTF16LE, which means it takes up
  * twice the amount of bytes than the same string encoded in ASCII7.

--- a/tests/drivers/clock_control/nrf_clock_calibration/src/mock_temp_nrf5.c
+++ b/tests/drivers/clock_control/nrf_clock_calibration/src/mock_temp_nrf5.c
@@ -5,6 +5,7 @@
  */
 #include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
 
 /* Mock of internal temperature sensor. */
 #ifdef CONFIG_TEMP_NRF5

--- a/west.yml
+++ b/west.yml
@@ -166,7 +166,7 @@ manifest:
       revision: ce57712f3e426bbbb13acaec97b45369f716f43a
       path: modules/lib/loramac-node
     - name: lvgl
-      revision: af95bdfcf6784edd958ea08139c713e2d3dee7af
+      revision: 5ab83099854719ed326b6ecb9b09b07b1eee4818
       path: modules/lib/gui/lvgl
     - name: lz4
       revision: 8e303c264fc21c2116dc612658003a22e933124d


### PR DESCRIPTION
`<zephyr/init.h>` includes `<zephyr/kernel.h>` and `<zephyr/types.h>` for no reason. Removal of both headers (https://github.com/zephyrproject-rtos/zephyr/pull/50987/commits/f019d4027adc4a866d65a502d66a4542acaf4af6) has opened another pandora box: hundreds of files not including what they need, resulting in build errors. Because `kernel.h` carries dozens of headers with it, many of these problems were hidden. One day we should fix the mess in `kernel.h` and inherited headers (`arch` stuff), so that problems like this https://github.com/zephyrproject-rtos/zephyr/pull/51028 can't happen.

This PR tries to resolve all issues reported in CI.

Discovered the issue while working on https://github.com/zephyrproject-rtos/zephyr/pull/50951