### PR TITLE
samples: Bluetooth: Fix peripheral_ht compile error

### DIFF
--- a/samples/bluetooth/broadcaster/sample.yaml
+++ b/samples/bluetooth/broadcaster/sample.yaml
@@ -3,5 +3,5 @@ sample:
 tests:
   sample.bluetooth.broadcaster:
     harness: bluetooth
-    platform_allow: qemu_cortex_m3 qemu_x86
+    platform_allow: qemu_cortex_m3 qemu_x86 nrf51dk_nrf51422 nrf52dk_nrf52832
     tags: bluetooth

--- a/samples/bluetooth/central_ht/sample.yaml
+++ b/samples/bluetooth/central_ht/sample.yaml
@@ -2,6 +2,6 @@ sample:
   name: Bluetooth Central HT
 tests:
   sample.bluetooth.central_ht:
-    arch_allow: x86
     harness: bluetooth
+    platform_allow: qemu_cortex_m3 qemu_x86 nrf51dk_nrf51422 nrf52dk_nrf52832
     tags: bluetooth

--- a/samples/bluetooth/peripheral_ht/sample.yaml
+++ b/samples/bluetooth/peripheral_ht/sample.yaml
@@ -4,7 +4,7 @@ sample:
 tests:
   sample.bluetooth.peripheral_ht:
     harness: bluetooth
-    platform_allow: qemu_cortex_m3 qemu_x86
+    platform_allow: qemu_cortex_m3 qemu_x86 nrf51dk_nrf51422 nrf52dk_nrf52832
     tags: bluetooth
   sample.bluetooth.peripheral_ht.frdm_kw41z_shield:
     harness: bluetooth

--- a/samples/bluetooth/peripheral_ht/src/hts.c
+++ b/samples/bluetooth/peripheral_ht/src/hts.c
@@ -26,7 +26,7 @@
 #include <zephyr/bluetooth/gatt.h>
 
 #ifdef CONFIG_TEMP_NRF5
-static const struct device *const temp_dev = DEVICE_DT_GET_ANY(nordic_nrf_temp);
+static const struct device *temp_dev = DEVICE_DT_GET_ANY(nordic_nrf_temp);
 #else
 static const struct device *temp_dev;
 #endif


### PR DESCRIPTION
Fix peripheral_ht compile error introduced in
commit a202341958c0 ("devices: constify device pointers initialized at compile time").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>