### PR TITLE
soc: intel_adsp: Use build system Python to run fix_elf_addrs.py

### DIFF
--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -29,7 +29,7 @@ zephyr_library_link_libraries(INTEL_ADSP_COMMON)
 target_include_directories(INTEL_ADSP_COMMON INTERFACE include)
 target_link_libraries(INTEL_ADSP_COMMON INTERFACE intel_adsp_common)
 
-set(ELF_FIX ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/fix_elf_addrs.py)
+set(ELF_FIX ${PYTHON_EXECUTABLE} ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/fix_elf_addrs.py)
 set(KERNEL_REMAPPED ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_NAME}-remapped.elf)
 set(EXTMAN ${CMAKE_BINARY_DIR}/zephyr/extman.bin)
 


### PR DESCRIPTION
This commit updates the intel_adsp build script to invoke the `fix_elf_addrs.py` Python script using the Python executable detected by the build system.

This ensures that the script is run using the same Python installation used by the Zephyr build system.

Signed-off-by: Stephanos Ioannidis <stephanos.ioannidis@nordicsemi.no>