### PR TITLE
Bluetooth: Audio: Ensure that stream is in streaming state for ISO recv

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -448,6 +448,19 @@ static void ascs_iso_recv(struct bt_iso_chan *chan,
 		return;
 	}
 
+	/* Since 2 streams can share the same CIS, the CIS may be connected and
+	 * capable of transferring data, without the bt_audio_stream being in
+	 * the streaming state. In that case we simply ignore the data.
+	 */
+	if (stream->ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
+		if (IS_ENABLED(CONFIG_BT_AUDIO_DEBUG_STREAM_DATA)) {
+			BT_DBG("Stream %p is not in the streaming state: %u",
+			       stream, stream->ep->status.state);
+		}
+
+		return;
+	}
+
 	ops = stream->ops;
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_DEBUG_STREAM_DATA)) {

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -95,6 +95,19 @@ static void unicast_client_ep_iso_recv(struct bt_iso_chan *chan,
 		return;
 	}
 
+	/* Since 2 streams can share the same CIS, the CIS may be connected and
+	 * capable of transferring data, without the bt_audio_stream being in
+	 * the streaming state. In that case we simply ignore the data.
+	 */
+	if (stream->ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
+		if (IS_ENABLED(CONFIG_BT_AUDIO_DEBUG_STREAM_DATA)) {
+			BT_DBG("Stream %p is not in the streaming state: %u",
+			       stream, stream->ep->status.state);
+		}
+
+		return;
+	}
+
 	ops = stream->ops;
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_DEBUG_STREAM_DATA)) {


### PR DESCRIPTION
Adds check to verify that the audio stream is actually in the streaming state before handling the
audio data. As per the BAP spec, a stream that
is not in the streaming state shall not send
any data, and this check is to handle any
remote devices that are not working correctly.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/50783