### PR TITLE
Bluetooth: Audio: Fix bad warning when creating MPL OTS objects

### DIFF
--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -474,12 +474,14 @@ static int add_icon_object(struct mpl_mediaplayer *pl)
 	add_param.type.uuid_16.val = BT_UUID_16(icon_type)->val;
 
 	ret = bt_ots_obj_add(bt_mcs_get_ots(), &add_param);
-
-	if (ret) {
+	if (ret < 0) {
 		BT_WARN("Unable to add icon object, error %d", ret);
 		obj.busy = false;
+
+		return ret;
 	}
-	return ret;
+
+	return 0;
 }
 
 /* Add a track segments object to the OTS */
@@ -507,11 +509,14 @@ static int add_current_track_segments_object(struct mpl_mediaplayer *pl)
 	add_param.type.uuid_16.val = BT_UUID_16(segs_type)->val;
 
 	ret = bt_ots_obj_add(bt_mcs_get_ots(), &add_param);
-	if (ret) {
+	if (ret < 0) {
 		BT_WARN("Unable to add track segments object: %d", ret);
 		obj.busy = false;
+
+		return ret;
 	}
-	return ret;
+
+	return 0;
 }
 
 /* Add a single track to the OTS */
@@ -546,13 +551,14 @@ static int add_track_object(struct mpl_track *track)
 	add_param.type.uuid_16.val = BT_UUID_16(track_type)->val;
 
 	ret = bt_ots_obj_add(bt_mcs_get_ots(), &add_param);
-
-	if (ret) {
+	if (ret < 0) {
 		BT_WARN("Unable to add track object: %d", ret);
 		obj.busy = false;
+
+		return ret;
 	}
 
-	return ret;
+	return 0;
 }
 
 /* Add the parent group to the OTS */
@@ -580,11 +586,14 @@ static int add_parent_group_object(struct mpl_mediaplayer *pl)
 	add_param.type.uuid_16.val = BT_UUID_16(group_type)->val;
 
 	ret = bt_ots_obj_add(bt_mcs_get_ots(), &add_param);
-	if (ret) {
+	if (ret < 0) {
 		BT_WARN("Unable to add parent group object");
 		obj.busy = false;
+
+		return ret;
 	}
-	return ret;
+
+	return 0;
 }
 
 /* Add a single group to the OTS */
@@ -620,13 +629,14 @@ static int add_group_object(struct mpl_group *group)
 	add_param.type.uuid_16.val = BT_UUID_16(group_type)->val;
 
 	ret = bt_ots_obj_add(bt_mcs_get_ots(), &add_param);
-
-	if (ret) {
+	if (ret < 0) {
 		BT_WARN("Unable to add group object: %d", ret);
 		obj.busy = false;
+
+		return ret;
 	}
 
-	return ret;
+	return 0;
 }
 
 /* Add all tracks of a group to the OTS */


### PR DESCRIPTION
The return check for adding MPL objects in OTS with bt_ots_obj_add was incorrect, as only negative values indicate an error, and a positive value returns the ID.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/50781