### PR TITLE
dts: ace15: add Intel ALH to device tree

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -334,6 +334,19 @@
 			interrupt-parent = <&ace_intc>;
 		};
 
+		/*
+		 * FIXME this is modeling individual alh channels/instances
+		 * with node labels, which has problems. A better representation
+		 * is discussed here:
+		 *
+		 * https://github.com/zephyrproject-rtos/zephyr/pull/50287#discussion_r974591009
+		 */
+		alh0: alh1: alh@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
 		hub_ulp_domain: hub_ulp_domain {
 			compatible = "intel,adsp-power-domain";
 			lps = <&lps>;


### PR DESCRIPTION
Add Intel ALH device tree entries to ace15

Same as in cavs25