### PR TITLE
drivers: timer: adsp: Improve dticks calculation

### DIFF
--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -96,12 +96,12 @@ static void compare_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 	uint64_t curr;
-	uint32_t dticks;
+	uint64_t dticks;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	curr = count();
-	dticks = (uint32_t)((curr - last_count) / CYC_PER_TICK);
+	dticks = (curr - last_count) / CYC_PER_TICK;
 
 	/* Clear the triggered bit */
 	*WCTCS |= DSP_WCT_CS_TT(COMPARATOR_IDX);
@@ -119,7 +119,7 @@ static void compare_isr(const void *arg)
 
 	k_spin_unlock(&lock, key);
 
-	sys_clock_announce(dticks);
+	sys_clock_announce((int32_t)dticks);
 }
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
@@ -160,10 +160,10 @@ uint32_t sys_clock_elapsed(void)
 		return 0;
 	}
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ret = (count32() - (uint32_t)last_count) / CYC_PER_TICK;
+	uint64_t ret = (count() - last_count) / CYC_PER_TICK;
 
 	k_spin_unlock(&lock, key);
-	return ret;
+	return (uint32_t)ret;
 }
 
 uint32_t sys_clock_cycle_get_32(void)


### PR DESCRIPTION
Changes the type of dticks in compare_isr() from uint32_t to uint64_t.

It has been observed that different compilers generate different code for calculating "last_count" in compare_isr(). XCC has been observed to generate mulitplication instructions which, if "dticks" is 32-bits, may result in the loss of high order "overflow" bits. This in turn could result in an improperly updated "last_count" which would no longer be "in-sync" with the timer-counter register if servicing of interrupts has been delayed for a long enough time.

Signed-off-by: Peter Mitsis <peter.mitsis@intel.com>