### PR TITLE
Bluetooth: Controller: Event overhead values plus Extended Adv duration fix

### DIFF
--- a/subsys/bluetooth/controller/hal/debug.h
+++ b/subsys/bluetooth/controller/hal/debug.h
@@ -7,12 +7,22 @@
 
 #ifdef CONFIG_BT_CTLR_ASSERT_HANDLER
 void bt_ctlr_assert_handle(char *file, uint32_t line);
-#define LL_ASSERT(cond) if (!(cond)) { \
-				bt_ctlr_assert_handle(__FILE__, \
-						      __LINE__); \
-			}
+#define LL_ASSERT(cond) \
+		if (!(cond)) { \
+			BT_ASSERT_PRINT(cond); \
+			bt_ctlr_assert_handle(__FILE__, __LINE__); \
+		}
+#define LL_ASSERT_MSG(cond, fmt, ...) \
+		if (!(cond)) { \
+			BT_ASSERT_PRINT(cond); \
+			BT_ASSERT_PRINT_MSG(fmt, ##__VA_ARGS__); \
+			bt_ctlr_assert_handle(__FILE__, __LINE__); \
+		}
 #else
-#define LL_ASSERT(cond) BT_ASSERT(cond)
+#define LL_ASSERT(cond) \
+		BT_ASSERT(cond)
+#define LL_ASSERT_MSG(cond, fmt, ...) \
+		BT_ASSERT_MSG(cond, fmt, ##__VA_ARGS__)
 #endif
 
 #include "hal/debug_vendor_hal.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -472,10 +472,13 @@ uint32_t lll_preempt_calc(struct ull_hdr *ull, uint8_t ticker_id,
 		 *    duration.
 		 * 3. Increase the preempt to start ticks for future events.
 		 */
-		return 1;
+		LL_ASSERT_MSG(false, "%s: Actual EVENT_OVERHEAD_START_US = %u",
+			      __func__, HAL_TICKER_TICKS_TO_US(diff));
+
+		return 1U;
 	}
 
-	return 0;
+	return 0U;
 }
 
 void lll_chan_set(uint32_t chan)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -193,8 +193,7 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	lll->latency_event = lll->latency_prepare - 1U;
 
 	/* Calculate the current event counter value */
-	event_counter = (lll->payload_count / lll->bn) +
-			(lll->latency_event * lll->bn);
+	event_counter = (lll->payload_count / lll->bn) + lll->latency_event;
 
 	/* Update BIS packet counter to next value */
 	lll->payload_count += (lll->latency_prepare * lll->bn);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -203,8 +203,7 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	lll->latency_event = lll->latency_prepare - 1U;
 
 	/* Calculate the current event counter value */
-	event_counter = (lll->payload_count / lll->bn) +
-			(lll->latency_event * lll->bn);
+	event_counter = (lll->payload_count / lll->bn) + lll->latency_event;
 
 	/* Update BIS packet counter to next value */
 	lll->payload_count += (lll->latency_prepare * lll->bn);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
@@ -8,14 +8,48 @@
 #define EVENT_OVERHEAD_PREEMPT_US     0    /* if <= min, then dynamic preempt */
 #define EVENT_OVERHEAD_PREEMPT_MIN_US 0
 #define EVENT_OVERHEAD_PREEMPT_MAX_US EVENT_OVERHEAD_XTAL_US
-#define EVENT_OVERHEAD_START_US       750
+
+/* Measurement based on drifting roles that can overlap leading to collision
+ * resolutions that consume CPU time between radio events.
+ * Value include max end, start and scheduling CPU usage times.
+ * Measurements based on central_gatt_write and peripheral_gatt_write sample on
+ * nRF52833 SoC.
+ */
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+#if defined(CONFIG_BT_OBSERVER)
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
+/* Active connection in peripheral role with extended scanning on 1M and Coded
+ * PHY, scheduling and receiving auxiliary PDUs.
+ */
+#define EVENT_OVERHEAD_START_US       458
+#else /* !CONFIG_BT_CTLR_PHY_CODED */
+/* Active connection in peripheral role with extended scanning on 1M only,
+ * scheduling and receiving auxiliary PDUs.
+ */
+#define EVENT_OVERHEAD_START_US       428
+#endif /* !CONFIG_BT_CTLR_PHY_CODED */
+#else /* !CONFIG_BT_OBSERVER */
+/* Active connection in peripheral role with legacy scanning on 1M.
+ */
+#define EVENT_OVERHEAD_START_US       275
+#endif /* !CONFIG_BT_OBSERVER */
+#else /* !CONFIG_BT_CTLR_ADV_EXT */
+/* Active connection in peripheral role with additional advertising state.
+ */
+#define EVENT_OVERHEAD_START_US       275
+#endif /* !CONFIG_BT_CTLR_ADV_EXT */
+
 /* Worst-case time margin needed after event end-time in the air
  * (done/preempt race margin + power-down/chain delay)
  */
 #define EVENT_OVERHEAD_END_US         100
+
+/* Sleep Clock Accuracy */
 #define EVENT_JITTER_US               16
+
 /* Inter-Event Space (IES) */
 #define EVENT_TIES_US                 625
+
 /* Ticker resolution margin
  * Needed due to the lack of fine timing resolution in ticker_start
  * and ticker_update. Set to 32 us, which is ~1 tick with 32768 Hz

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1315,6 +1315,14 @@ uint8_t ll_adv_enable(uint8_t enable)
 
 #if !defined(CONFIG_BT_HCI_MESH_EXT)
 	ticks_anchor = ticker_ticks_now_get();
+
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
+	/* NOTE: mesh bsim loopback_group_low_lat test needs both adv and scan
+	 * to not have that start overhead added to pass the test.
+	 */
+	ticks_anchor += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
+#endif /* !CONFIG_BT_TICKER_LOW_LAT */
+
 #else /* CONFIG_BT_HCI_MESH_EXT */
 	if (!at_anchor) {
 		ticks_anchor = ticker_ticks_now_get();

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1938,59 +1938,70 @@ void ull_adv_done(struct node_rx_event_done *done)
 	lll = &adv->lll;
 
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
-	if (done->extra.result == DONE_COMPLETED) {
-		/* Event completed successfully */
-		adv->delay_remain = ULL_ADV_RANDOM_DELAY;
-	} else {
+	if (done->extra.result != DONE_COMPLETED) {
 		/* Event aborted or too late - try to re-schedule */
 		uint32_t ticks_elapsed;
 		uint32_t ticks_now;
+		uint32_t delay_remain;
 
 		const uint32_t prepare_overhead =
 			HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 		const uint32_t ticks_adv_airtime = adv->ticks_at_expire +
 			prepare_overhead;
 
-		ticks_elapsed = 0;
+		ticks_elapsed = 0U;
 
 		ticks_now = cntr_cnt_get();
 		if ((int32_t)(ticks_now - ticks_adv_airtime) > 0) {
 			ticks_elapsed = ticks_now - ticks_adv_airtime;
 		}
 
-		if (adv->delay_remain >= adv->delay + ticks_elapsed) {
+		if (adv->delay_at_expire + ticks_elapsed <= ULL_ADV_RANDOM_DELAY) {
 			/* The perturbation window is still open */
-			adv->delay_remain -= (adv->delay + ticks_elapsed);
+			delay_remain = ULL_ADV_RANDOM_DELAY - (adv->delay_at_expire +
+							       ticks_elapsed);
 		} else {
-			adv->delay_remain = 0;
+			delay_remain = 0U;
 		}
 
 		/* Check if we have enough time to re-schedule */
-		if (adv->delay_remain > prepare_overhead) {
+		if (delay_remain > prepare_overhead) {
 			uint32_t ticks_adjust_minus;
+			uint32_t interval_us = adv->interval * ADV_INT_UNIT_US;
 
 			/* Get negative ticker adjustment needed to pull back ADV one
 			 * interval plus the randomized delay. This means that the ticker
 			 * will be updated to expire in time frame of now + start
 			 * overhead, until 10 ms window is exhausted.
 			 */
-			ticks_adjust_minus = HAL_TICKER_US_TO_TICKS(
-				(uint64_t)adv->interval * ADV_INT_UNIT_US) + adv->delay;
+			ticks_adjust_minus = HAL_TICKER_US_TO_TICKS(interval_us) + adv->delay;
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+			if (adv->remain_duration_us > interval_us) {
+				/* Reset remain_duration_us to value before last ticker expire
+				 * to correct for the re-scheduling
+				 */
+				adv->remain_duration_us += interval_us +
+							   HAL_TICKER_TICKS_TO_US(
+								adv->delay_at_expire);
+			}
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
 
 			/* Apply random delay in range [prepare_overhead..delay_remain].
 			 * NOTE: This ticker_update may fail if update races with
 			 * ticker_stop, e.g. from ull_periph_setup. This is not a problem
 			 * and we can safely ignore the operation result.
 			 */
-			ticker_update_rand(adv, adv->delay_remain - prepare_overhead,
+			ticker_update_rand(adv, delay_remain - prepare_overhead,
 					   prepare_overhead, ticks_adjust_minus, NULL);
+
+			/* Delay from ticker_update_rand is in addition to the last random delay */
+			adv->delay += adv->delay_at_expire;
 
 			/* Score of the event was increased due to the result, but since
 			 * we're getting a another chance we'll set it back.
 			 */
 			adv->lll.hdr.score -= 1;
-		} else {
-			adv->delay_remain = ULL_ADV_RANDOM_DELAY;
 		}
 	}
 #endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
@@ -2282,6 +2293,7 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
 		adv->ticks_at_expire = ticks_at_expire;
+		adv->delay_at_expire = adv->delay;
 #endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 	}
 
@@ -2296,6 +2308,10 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 		if (adv->remain_duration_us && adv->event_counter > 0U) {
+#if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+			/* ticks_drift is always 0 with JIT scheduling, populate manually */
+			ticks_drift = adv->delay_at_expire;
+#endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 			uint32_t interval_us = (uint64_t)adv->interval * ADV_INT_UNIT_US;
 			uint32_t elapsed_us = interval_us * (lazy + 1U) +
 						 HAL_TICKER_TICKS_TO_US(ticks_drift);
@@ -2940,7 +2956,7 @@ static void init_set(struct ll_adv_set *adv)
 	adv->lll.chan_map = BT_LE_ADV_CHAN_MAP_ALL;
 	adv->lll.filter_policy = BT_LE_ADV_FP_NO_FILTER;
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
-	adv->delay_remain = ULL_ADV_RANDOM_DELAY;
+	adv->delay = 0U;
 #endif /* ONFIG_BT_CTLR_JIT_SCHEDULING */
 
 	init_pdu(lll_adv_data_peek(&ll_adv[0].lll), PDU_ADV_TYPE_ADV_IND);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -602,7 +602,9 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 			 *       Advertising sets are non-overlapping
 			 *       for the same event interval.
 			 */
-			ticks_anchor = ticker_ticks_now_get();
+			ticks_anchor =
+				ticker_ticks_now_get() +
+				HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 
 			ticks_slot_overhead =
 				ull_adv_aux_evt_init(aux, &ticks_anchor);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -864,7 +864,8 @@ static uint32_t adv_iso_start(struct ll_adv_iso_set *adv_iso,
 					    EVENT_OVERHEAD_START_US) +
 					(EVENT_TICKER_RES_MARGIN_US << 1));
 	} else {
-		ticks_anchor = ticker_ticks_now_get();
+		ticks_anchor = ticker_ticks_now_get() +
+			       HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 	}
 
 	/* setup to use ISO create prepare function for first radio event */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -873,14 +873,18 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 			 *       when auxiliary and Periodic Advertising have
 			 *       similar event interval.
 			 */
-			ticks_anchor_sync = ticker_ticks_now_get();
+			ticks_anchor_sync =
+				ticker_ticks_now_get() +
+				HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 		} else {
 			/* Auxiliary set will be started due to inclusion of
 			 * sync info field.
 			 */
 			lll_aux = adv->lll.aux;
 			aux = HDR_LLL2ULL(lll_aux);
-			ticks_anchor_aux = ticker_ticks_now_get();
+			ticks_anchor_aux =
+				ticker_ticks_now_get() +
+				HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 			ticks_slot_overhead_aux =
 				ull_adv_aux_evt_init(aux, &ticks_anchor_aux);
 			ticks_anchor_sync = ticks_anchor_aux +

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -38,7 +38,7 @@ struct ll_adv_set {
 #endif
 	uint16_t event_counter;
 	uint16_t max_events;
-	uint32_t ticks_remain_duration;
+	uint32_t remain_duration_us;
 #else /* !CONFIG_BT_CTLR_ADV_EXT */
 	uint16_t interval;
 #endif /* !CONFIG_BT_CTLR_ADV_EXT */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -60,7 +60,7 @@ struct ll_adv_set {
 #endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
 	uint32_t delay;
-	uint32_t delay_remain;
+	uint32_t delay_at_expire;
 	uint32_t ticks_at_expire;
 #endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 };

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -555,6 +555,13 @@ uint8_t ull_scan_enable(struct ll_scan_set *scan)
 
 	ticks_anchor = ticker_ticks_now_get();
 
+#if !defined(CONFIG_BT_TICKER_LOW_LAT)
+	/* NOTE: mesh bsim loopback_group_low_lat test needs both adv and scan
+	 * to not have that start overhead added to pass the test.
+	 */
+	ticks_anchor += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
+#endif /* !CONFIG_BT_TICKER_LOW_LAT */
+
 #if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_CTLR_SCHED_ADVANCED)
 	if (!lll->conn) {
 		uint32_t ticks_ref = 0U;

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -2425,8 +2425,9 @@ static inline void ticker_job_list_inquire(struct ticker_instance *instance)
  *
  * @internal
  */
-static inline void ticker_job_compare_update(struct ticker_instance *instance,
-					     uint8_t ticker_id_old_head)
+static inline uint8_t
+ticker_job_compare_update(struct ticker_instance *instance,
+			  uint8_t ticker_id_old_head)
 {
 	struct ticker_node *ticker;
 	uint32_t ticks_to_expire;
@@ -2443,7 +2444,8 @@ static inline void ticker_job_compare_update(struct ticker_instance *instance,
 
 			instance->ticks_current = cntr_cnt_get();
 		}
-		return;
+
+		return 0U;
 	}
 
 	/* Check if this is the first update. If so, start the counter */
@@ -2459,6 +2461,14 @@ static inline void ticker_job_compare_update(struct ticker_instance *instance,
 
 	ticker = &instance->nodes[instance->ticker_id_head];
 	ticks_to_expire = ticker->ticks_to_expire;
+
+	/* If ticks_to_expire is zero, then immediately trigger the worker.
+	 * Under BT_TICKER_LOW_LAT, mesh loopback test fails pending
+	 * investigation hence immediate trigger not used for BT_TICKER_LOW_LAT.
+	 */
+	if (!IS_ENABLED(CONFIG_BT_TICKER_LOW_LAT) && !ticks_to_expire) {
+		return 1U;
+	}
 
 	/* Iterate few times, if required, to ensure that compare is
 	 * correctly set to a future value. This is required in case
@@ -2485,6 +2495,8 @@ static inline void ticker_job_compare_update(struct ticker_instance *instance,
 	} while ((ticker_ticks_diff_get(ctr_post, ctr) +
 		  HAL_TICKER_CNTR_CMP_OFFSET_MIN) >
 		  ticker_ticks_diff_get(cc, ctr));
+
+	return 0U;
 }
 
 /**
@@ -2506,6 +2518,7 @@ void ticker_job(void *param)
 	struct ticker_instance *instance = param;
 	uint8_t flag_compare_update;
 	uint8_t ticker_id_old_head;
+	uint8_t compare_trigger;
 	uint32_t ticks_previous;
 	uint32_t ticks_elapsed;
 	uint8_t flag_elapsed;
@@ -2607,14 +2620,17 @@ void ticker_job(void *param)
 
 	/* update compare if head changed */
 	if (flag_compare_update) {
-		ticker_job_compare_update(instance, ticker_id_old_head);
+		compare_trigger = ticker_job_compare_update(instance,
+							    ticker_id_old_head);
+	} else {
+		compare_trigger = 0U;
 	}
 
 	/* Permit worker to run */
 	instance->job_guard = 0U;
 
 	/* trigger worker if deferred */
-	if (instance->worker_trigger) {
+	if (instance->worker_trigger || compare_trigger) {
 		instance->sched_cb(TICKER_CALL_ID_JOB, TICKER_CALL_ID_WORKER, 1,
 				   instance);
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
@@ -423,7 +423,7 @@ static void test_advx_main(void)
 	printk("Start advertising using extended commands (duration)...");
 	is_sent = false;
 	num_sent_actual = 0;
-	num_sent_expected = 4;
+	num_sent_expected = 5;
 	ext_adv_param.timeout = 50;
 	ext_adv_param.num_events = 0;
 	err = bt_le_ext_adv_start(adv, &ext_adv_param);
@@ -493,11 +493,11 @@ static void test_advx_main(void)
 	printk("Re-enable advertising using extended commands (duration)...");
 	is_sent = false;
 	num_sent_actual = 0;
-	num_sent_expected = 4;      /* 4 advertising events of (100 ms +
+	num_sent_expected = 5;      /* 5 advertising events with a spacing of (100 ms +
 				     * random_delay of upto 10 ms) transmit in
 				     * the range of 400 to 440 ms
 				     */
-	ext_adv_param.timeout = 50; /* Check there is atmost 4 advertising
+	ext_adv_param.timeout = 50; /* Check there is atmost 5 advertising
 				     * events in a timeout of 500 ms
 				     */
 	ext_adv_param.num_events = 0;


### PR DESCRIPTION
- Remaining duration is now in us instead of ticks to avoid overflow when ticks have higher resolution
- Account for the added random delay when updating remaining duration
- Re-worked JIT re-scheduling update a bit to keep the random delay information and remaining duration correct
- Add EVENT_OVERHEAD_START_US to ticks_anchor when enabling advertising, so the first advertising event is not late due to calculations for aux packets etc.

Signed-off-by: Troels Nilsson <trnn@demant.com>


- Tune the EVENT_OVERHEAD_START_US for typical usecases on
nRF52833 SoC using the central_gatt_write and
peripheral_gatt_write samples.

- Manually run the samples for over 30 mins without any
assertions and use the actual profiled value that would
otherwise be printed on assertion.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>