### PR TITLE
driver: eSPI: drop interrupts enabling during driver initialization

### DIFF
--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -201,7 +201,6 @@ static void espi_init_wui_callback(const struct device *dev,
 	/* Configure MIWU setting and enable its interrupt */
 	npcx_miwu_interrupt_configure(wui, NPCX_MIWU_MODE_EDGE,
 							NPCX_MIWU_TRIG_BOTH);
-	npcx_miwu_irq_enable(wui);
 }
 
 /* eSPI local bus interrupt service functions */
@@ -1120,7 +1119,7 @@ static int espi_npcx_flash_erase(const struct device *dev,
 /* Platform specific espi module functions */
 void npcx_espi_enable_interrupts(const struct device *dev)
 {
-	ARG_UNUSED(dev);
+	const struct espi_npcx_config *const config = dev->config;
 
 	/* Enable eSPI bus interrupt */
 	irq_enable(DT_INST_IRQN(0));
@@ -1129,11 +1128,13 @@ void npcx_espi_enable_interrupts(const struct device *dev)
 	for (int idx = 0; idx < ARRAY_SIZE(vw_in_tbl); idx++) {
 		npcx_miwu_irq_enable(&(vw_in_tbl[idx].vw_wui));
 	}
+
+	npcx_miwu_irq_enable(&config->espi_rst_wui);
 }
 
 void npcx_espi_disable_interrupts(const struct device *dev)
 {
-	ARG_UNUSED(dev);
+	const struct espi_npcx_config *const config = dev->config;
 
 	/* Disable eSPI bus interrupt */
 	irq_disable(DT_INST_IRQN(0));
@@ -1142,6 +1143,8 @@ void npcx_espi_disable_interrupts(const struct device *dev)
 	for (int idx = 0; idx < ARRAY_SIZE(vw_in_tbl); idx++) {
 		npcx_miwu_irq_disable(&(vw_in_tbl[idx].vw_wui));
 	}
+
+	npcx_miwu_irq_disable(&config->espi_rst_wui);
 }
 
 /* eSPI driver registration */

--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -1061,13 +1061,11 @@ int npcx_host_init_subs_core_domain(const struct device *host_bus_dev,
 		    DT_INST_IRQ_BY_NAME(0, kbc_ibf, priority),
 		    host_kbc_ibf_isr,
 		    NULL, 0);
-	irq_enable(DT_INST_IRQ_BY_NAME(0, kbc_ibf, irq));
 
 	IRQ_CONNECT(DT_INST_IRQ_BY_NAME(0, kbc_obe, irq),
 		    DT_INST_IRQ_BY_NAME(0, kbc_obe, priority),
 		    host_kbc_obe_isr,
 		    NULL, 0);
-	irq_enable(DT_INST_IRQ_BY_NAME(0, kbc_obe, irq));
 #endif
 
 	/* Host PM channel (Host IO) sub-device interrupt installation */
@@ -1077,7 +1075,6 @@ int npcx_host_init_subs_core_domain(const struct device *host_bus_dev,
 		    DT_INST_IRQ_BY_NAME(0, pmch_ibf, priority),
 		    host_pmch_ibf_isr,
 		    NULL, 0);
-	irq_enable(DT_INST_IRQ_BY_NAME(0, pmch_ibf, irq));
 #endif
 
 	/* Host Port80 sub-device interrupt installation */
@@ -1086,7 +1083,6 @@ int npcx_host_init_subs_core_domain(const struct device *host_bus_dev,
 		    DT_INST_IRQ_BY_NAME(0, p80_fifo, priority),
 		    host_port80_isr,
 		    NULL, 0);
-	irq_enable(DT_INST_IRQ_BY_NAME(0, p80_fifo, irq));
 #endif
 
 	if (IS_ENABLED(CONFIG_PM)) {


### PR DESCRIPTION
Host interface interrupts should be enabled explicitly via eSPI API after the eSPI configuration and callbacks are set. If we enable them during driver initialization and the host sends a eSPI transaction before the eSPI configuration and callbacks are set, we may encounter unexpected behavior.

(This PR is related  to EC issue No: 246963730)
Signed-off-by: Jun Lin <CHLin56@nuvoton.com>