### PR TITLE
[DNM] Support T32 ISA for Armv8-R

### DIFF
--- a/arch/arm/core/aarch32/cortex_a_r/exc.S
+++ b/arch/arm/core/aarch32/cortex_a_r/exc.S
@@ -47,7 +47,11 @@ GTEXT(z_arm_data_abort)
 	 * construct an exception stack frame.
 	 */
 	srsdb sp!, #\mode
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+	stmfd sp, {r0-r3, r12, lr}
+#else
 	stmfd sp, {r0-r3, r12, lr}^
+#endif
 	sub sp, #24
 
 #if defined(CONFIG_FPU_SHARING)
@@ -112,6 +116,9 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_undef_instruction)
 	push {r0}
 	mrs r0, spsr
 	tst r0, #T_BIT
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+	ite eq
+#endif
 	subeq lr, #4	/* ARM   (!T_BIT) */
 	subne lr, #2	/* Thumb (T_BIT) */
 	pop {r0}
@@ -121,7 +128,11 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_undef_instruction)
 	 * construct an exception stack frame.
 	 */
 	srsdb sp!, #MODE_UND
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+	stmfd sp, {r0-r3, r12, lr}
+#else
 	stmfd sp, {r0-r3, r12, lr}^
+#endif
 	sub sp, #24
 
 	/* Increment exception nesting count */
@@ -219,10 +230,15 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_data_abort)
 	 * the true esf from the one passed to z_arm_fault_data.
 	 */
 	cmp r0, #0
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+	it eq
+#endif
 	ldreq r1, [sp, #24 + FPU_SF_SIZE]
 
 	exception_exit
-
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+	it eq
+#endif
 	streq r1, [sp, #24 + FPU_SF_SIZE]
 
 	b z_arm_exc_exit

--- a/arch/arm/core/aarch32/cortex_a_r/exc_exit.S
+++ b/arch/arm/core/aarch32/cortex_a_r/exc_exit.S
@@ -139,6 +139,9 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_int_exit)
 	ldr r1, [r3, #_kernel_offset_to_current]
 	ldr r0, [r3, #_kernel_offset_to_ready_q_cache]
 	cmp r0, r1
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+	it ne
+#endif
 	blne z_arm_pendsv
 __EXIT_INT:
 #endif /* CONFIG_PREEMPT_ENABLED */
@@ -260,6 +263,10 @@ __EXIT_EXC:
 	 * Restore r0-r3, r12, lr, lr_und and spsr_und from the exception stack
 	 * and return to the current thread.
 	 */
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+	ldmia sp, {r0-r3, r12, lr}
+#else
 	ldmia sp, {r0-r3, r12, lr}^
+#endif
 	add sp, #24
 	rfeia sp!

--- a/arch/arm/core/aarch32/cortex_a_r/reset.S
+++ b/arch/arm/core/aarch32/cortex_a_r/reset.S
@@ -61,10 +61,14 @@ SECTION_SUBSEC_FUNC(TEXT, _reset_section, __start)
     ldr r0, =HACTLR_INIT
     mcr p15, 4, r0, c1, c0, 1
 
-   /* Go to SVC mode */
     mrs r0, cpsr
+   /* Go to SVC mode */
     bic r0, #MODE_MASK
     orr r0, #MODE_SVC
+#if defined (CONFIG_ASSEMBLER_ISA_THUMB2)
+    /* Enable Thumb execution state */
+    orr r0, #T_BIT
+#endif
     msr spsr_cxsf, r0
 
     ldr r0, =EL1_Reset_Handler
@@ -201,27 +205,57 @@ EL1_Reset_Handler:
      */
 
     /* FIQ mode stack */
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+    mov r0, #(MODE_FIQ | I_BIT | F_BIT)
+    msr CPSR_c, r0
+#else
     msr CPSR_c, #(MODE_FIQ | I_BIT | F_BIT)
+#endif
     ldr sp, =(z_arm_fiq_stack + CONFIG_ARMV7_FIQ_STACK_SIZE)
 
     /* IRQ mode stack */
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+    mov r0,  #(MODE_IRQ | I_BIT | F_BIT)
+    msr CPSR_c, r0
+#else
     msr CPSR_c, #(MODE_IRQ | I_BIT | F_BIT)
+#endif
     ldr sp, =(z_interrupt_stacks + CONFIG_ISR_STACK_SIZE)
 
     /* ABT mode stack */
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+    mov r0, #(MODE_ABT | I_BIT | F_BIT)
+    msr CPSR_c, r0
+#else
     msr CPSR_c, #(MODE_ABT | I_BIT | F_BIT)
+#endif
     ldr sp, =(z_arm_abort_stack + CONFIG_ARMV7_EXCEPTION_STACK_SIZE)
 
     /* UND mode stack */
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+    mov r0, #(MODE_UND | I_BIT | F_BIT)
+    msr CPSR_c, r0
+#else
     msr CPSR_c, #(MODE_UND | I_BIT | F_BIT)
+#endif
     ldr sp, =(z_arm_undef_stack + CONFIG_ARMV7_EXCEPTION_STACK_SIZE)
 
     /* SVC mode stack */
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+    mov r0, #(MODE_SVC | I_BIT | F_BIT)
+    msr CPSR_c, r0
+#else
     msr CPSR_c, #(MODE_SVC | I_BIT | F_BIT)
+#endif
     ldr sp, =(z_arm_svc_stack + CONFIG_ARMV7_SVC_STACK_SIZE)
 
     /* SYS mode stack */
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+    mov r0, #(MODE_SYS | I_BIT | F_BIT)
+    msr CPSR_c, r0
+#else
     msr CPSR_c, #(MODE_SYS | I_BIT | F_BIT)
+#endif
     ldr sp, =(z_arm_sys_stack + CONFIG_ARMV7_SYS_STACK_SIZE)
 
 #if defined(CONFIG_PLATFORM_SPECIFIC_INIT)

--- a/arch/arm/core/aarch32/cortex_a_r/vector_table.S
+++ b/arch/arm/core/aarch32/cortex_a_r/vector_table.S
@@ -23,6 +23,10 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 	ldr pc, =z_arm_prefetch_abort    /* prefetch abort offset  0xc */
 	ldr pc, =z_arm_data_abort        /* data abort     offset 0x10 */
 	nop				 /*                offset 0x14 */
+#if CONFIG_ASSEMBLER_ISA_THUMB2
+	nop
+#endif
+
 #ifdef CONFIG_GEN_SW_ISR_TABLE
 	ldr pc, =_isr_wrapper		 /* IRQ            offset 0x18 */
 #else

--- a/arch/arm/core/aarch32/swap_helper.S
+++ b/arch/arm/core/aarch32/swap_helper.S
@@ -125,7 +125,12 @@ out_fp_endif:
 	|| defined(CONFIG_ARMV7_A)
     /* Store rest of process context */
     cps #MODE_SYS
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+    mov ip, sp
+    stm r0, {r4-r11, ip}
+#else
     stm r0, {r4-r11, sp}
+#endif
     cps #MODE_SVC
 
 #if defined(CONFIG_FPU_SHARING)
@@ -399,7 +404,12 @@ _thread_irq_disabled:
 
     /* restore r4-r11 and sp for incoming thread */
     cps #MODE_SYS
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+    ldm r0, {r4-r11, ip}
+    mov sp, ip
+#else
     ldm r0, {r4-r11, sp}
+#endif
     cps #MODE_SVC
 
 #if defined(CONFIG_FPU_SHARING)
@@ -786,6 +796,9 @@ svc_system_thread:
     mrs r0, spsr
     tst r0, #0x20
 
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+    ittt eq
+#endif
     ldreq r1, [lr, #-4]
     biceq r1, #0xff000000
     beq demux
@@ -868,9 +881,17 @@ _do_syscall:
 
     /* If leaving thumb mode, set the return address to thumb mode */
     tst r1, #T_BIT
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+    it ne
+#endif
     orrne r8, #1
 
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+    /* Don't clear T bit if executing in Thumb state */
+    bic r1, #MODE_MASK
+#else
     bic r1, #(MODE_MASK | T_BIT)
+#endif
     orr r1, r1, #MODE_SYS
     str r1, [ip, #(FPU_SF_SIZE + ___basic_sf_t_xpsr_OFFSET)]
 

--- a/arch/arm/core/aarch32/userspace.S
+++ b/arch/arm/core/aarch32/userspace.S
@@ -246,7 +246,12 @@ SECTION_FUNC(TEXT,z_arm_userspace_enter)
 
 #if defined(CONFIG_CPU_AARCH32_CORTEX_R)
     /* change processor mode to unprivileged, with all interrupts enabled. */
+#if defined(CONFIG_ASSEMBLER_ISA_THUMB2)
+    mov ip, #MODE_USR
+    msr CPSR_c, ip
+#else
     msr CPSR_c, #MODE_USR
+#endif
 #else
     /* change processor mode to unprivileged */
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)

--- a/boards/arm/fvp_baser_aemv8r_aarch32/board.cmake
+++ b/boards/arm/fvp_baser_aemv8r_aarch32/board.cmake
@@ -37,3 +37,11 @@ set(ARMFVP_FLAGS
   -C bp.vis.disable_visualisation=1
   -C bp.vis.rate_limit-enable=0
   )
+
+if(CONFIG_ISA_THUMB2)
+  MATH(EXPR NUM_CPUS "${CONFIG_MP_NUM_CPUS}-1")
+  foreach(CPU RANGE ${NUM_CPUS})
+    # Initialize to take exceptions in T32 state after a reset
+    list(APPEND ARMFVP_FLAGS -C cluster0.cpu${CPU}.TEINIT=1)
+  endforeach()
+endif()

--- a/soc/arm/arm/fvp_aemv8r_aarch32/Kconfig.soc
+++ b/soc/arm/arm/fvp_aemv8r_aarch32/Kconfig.soc
@@ -12,5 +12,6 @@ config SOC_FVP_AEMV8R_AARCH32
 	select CPU_HAS_MPU
 	select GIC_V3
 	select GIC_SINGLE_SECURITY_STATE
+	select ISA_THUMB2
 
 endchoice


### PR DESCRIPTION
The Armv8-R architecture supports the A32 and T32 instruction sets. Currently, the architecture assembly code makes use of the A32 (ARM) instructions only. This patch introduces support for the T32 instruction set for the Armv8-R architecture, which can be enabled by selecting `CONFIG_ISA_THUMB2`.

The last commit is for testing purposes only (not intended to be part of the final patch) and enable testing it in `fvp_baser_aemv8r_aarch32` board.

@povergoing @carlocaione @microbuilder could you please have a look and let me know your thoughts on it? I would appreciate your feedback to finish shaping this into a pull-request.