### PR TITLE
soc: arm: nxp_lpc: do not select PINMUX

### DIFF
--- a/soc/arm/nxp_lpc/lpc11u6x/Kconfig.series
+++ b/soc/arm/nxp_lpc/lpc11u6x/Kconfig.series
@@ -9,7 +9,6 @@ config SOC_SERIES_LPC11U6X
 	select CPU_CORTEX_M0PLUS
 	select CPU_CORTEX_M_HAS_SYSTICK
 	select SOC_FAMILY_LPC
-	select PINMUX
 	select PINCTRL
 	select CLOCK_CONTROL
 	help


### PR DESCRIPTION
The platform has support for pinctrl, but it is selecting both pinmux and pinctrl. Legacy applications requiring pinmux should enable it manually.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>