### PR TITLE
include: add missing zephyr/ prefix

### DIFF
--- a/drivers/counter/counter_ace_v1x_art.c
+++ b/drivers/counter/counter_ace_v1x_art.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <devicetree.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/drivers/counter.h>
 #include <soc.h>
 #include <ace_v1x-regs.h>

--- a/drivers/counter/counter_ace_v1x_rtc.c
+++ b/drivers/counter/counter_ace_v1x_rtc.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <devicetree.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/drivers/counter.h>
 #include <soc.h>
 #include <ace_v1x-regs.h>

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <bluetooth/addr.h>
+#include <zephyr/bluetooth/addr.h>
 #include <host/keys.h>
 #include "mocks/conn.h"
 #include "mocks/hci_core.h"

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_invalid_values.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_invalid_values.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <bluetooth/addr.h>
+#include <zephyr/bluetooth/addr.h>
 #include <host/keys.h>
 #include "mocks/conn.h"
 #include "mocks/hci_core.h"

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_no_overwrite.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_no_overwrite.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <bluetooth/addr.h>
+#include <zephyr/bluetooth/addr.h>
 #include <host/keys.h>
 #include "mocks/keys_help_utils.h"
 #include "mocks/hci_core_expects.h"

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_overwrite_oldest.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_overwrite_oldest.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <bluetooth/addr.h>
+#include <zephyr/bluetooth/addr.h>
 #include <host/keys.h>
 #include "mocks/conn.h"
 #include "mocks/hci_core.h"

--- a/tests/bluetooth/host/keys/mocks/conn.h
+++ b/tests/bluetooth/host/keys/mocks/conn.h
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/fff.h>
-#include <bluetooth/addr.h>
+#include <zephyr/bluetooth/addr.h>
 #include <host/conn_internal.h>
 
 typedef void (*bt_conn_foreach_cb) (struct bt_conn *conn, void *data);

--- a/tests/bluetooth/host/keys/mocks/hci_core.h
+++ b/tests/bluetooth/host/keys/mocks/hci_core.h
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/fff.h>
-#include <bluetooth/addr.h>
+#include <zephyr/bluetooth/addr.h>
 
 /* List of fakes used by this unit tester */
 #define HCI_CORE_FFF_FAKES_LIST(FAKE)       \

--- a/tests/bluetooth/host/keys/mocks/hci_core_expects.c
+++ b/tests/bluetooth/host/keys/mocks/hci_core_expects.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <bluetooth/buf.h>
+#include <zephyr/bluetooth/buf.h>
 #include "mocks/hci_core.h"
 #include "mocks/hci_core_expects.h"
 

--- a/tests/bluetooth/host/keys/mocks/id.h
+++ b/tests/bluetooth/host/keys/mocks/id.h
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/fff.h>
-#include <bluetooth/addr.h>
+#include <zephyr/bluetooth/addr.h>
 #include <host/keys.h>
 
 /* List of fakes used by this unit tester */

--- a/tests/bluetooth/host/keys/mocks/keys_help_utils.c
+++ b/tests/bluetooth/host/keys/mocks/keys_help_utils.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <bluetooth/addr.h>
+#include <zephyr/bluetooth/addr.h>
 #include <host/keys.h>
 #include "keys_help_utils.h"
 

--- a/tests/bluetooth/host/keys/mocks/keys_help_utils.h
+++ b/tests/bluetooth/host/keys/mocks/keys_help_utils.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <bluetooth/addr.h>
+#include <zephyr/bluetooth/addr.h>
 
 /* BT (ID, Address) pair */
 struct id_addr_pair {

--- a/tests/bluetooth/host/keys/mocks/rpa.h
+++ b/tests/bluetooth/host/keys/mocks/rpa.h
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/fff.h>
-#include <bluetooth/addr.h>
+#include <zephyr/bluetooth/addr.h>
 
 /* List of fakes used by this unit tester */
 #define RPA_FFF_FAKES_LIST(FAKE)       \


### PR DESCRIPTION
Some files still manage to get into the tree without the zephyr/ include prefix (likely because they lack CI coverage).

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>