### PR TITLE
build: test: Update nrf boards flash and ram yaml values

### DIFF
--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.yaml
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.yaml
@@ -7,7 +7,7 @@ toolchain:
   - xtools
   - zephyr
 ram: 88
-flash: 256
+flash: 1024
 supported:
   - arduino_gpio
   - arduino_i2c


### PR DESCRIPTION
Update ram and flash values in nrf board yaml files.

After evaluating the values it was found that they don't correspond with the available amount reported by the linker.

Some extra margins are given for most values in case the application will have less available in the future.

These values are used for test case filtering.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>