### PR TITLE
Bluetooth: audio: capabilities: Remove redundant direction parameter

### DIFF
--- a/include/zephyr/bluetooth/audio/capabilities.h
+++ b/include/zephyr/bluetooth/audio/capabilities.h
@@ -21,8 +21,6 @@ sys_slist_t *bt_audio_capability_get(enum bt_audio_dir dir);
 
 /** @brief Audio Capability structure. */
 struct bt_audio_capability {
-	/** Capability direction */
-	enum bt_audio_dir dir;
 	/** Capability codec reference */
 	struct bt_codec *codec;
 
@@ -34,21 +32,23 @@ struct bt_audio_capability {
  *
  *  Register Audio Local Capability.
  *
+ *  @param dir Direction of the endpoint to register capability for.
  *  @param cap Capability structure.
  *
  *  @return 0 in case of success or negative value in case of error.
  */
-int bt_audio_capability_register(struct bt_audio_capability *cap);
+int bt_audio_capability_register(enum bt_audio_dir dir, struct bt_audio_capability *cap);
 
 /** @brief Unregister Audio Capability.
  *
  *  Unregister Audio Local Capability.
  *
+ *  @param dir Direction of the endpoint to unregister capability for.
  *  @param cap Capability structure.
  *
  *  @return 0 in case of success or negative value in case of error.
  */
-int bt_audio_capability_unregister(struct bt_audio_capability *cap);
+int bt_audio_capability_unregister(enum bt_audio_dir dir, struct bt_audio_capability *cap);
 
 /** @brief Set the location for an endpoint type
  *

--- a/samples/bluetooth/broadcast_audio_sink/src/main.c
+++ b/samples/bluetooth/broadcast_audio_sink/src/main.c
@@ -149,7 +149,6 @@ static struct bt_audio_broadcast_sink_cb broadcast_sink_cbs = {
 };
 
 static struct bt_audio_capability capabilities = {
-	.dir = BT_AUDIO_DIR_SINK,
 	.codec = &codec,
 };
 
@@ -165,7 +164,7 @@ static int init(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_audio_capability_register(&capabilities);
+	err = bt_audio_capability_register(BT_AUDIO_DIR_SINK, &capabilities);
 	if (err) {
 		printk("Capability register failed (err %d)\n", err);
 		return err;

--- a/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
+++ b/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
@@ -411,25 +411,22 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected,
 };
 
-static struct bt_audio_capability caps[] = {
-	{
-		.dir = BT_AUDIO_DIR_SINK,
-		.codec = &lc3_codec,
-	},
-#if defined(CONFIG_BT_ASCS_ASE_SRC)
-	{
-		.dir = BT_AUDIO_DIR_SOURCE,
-		.codec = &lc3_codec,
-	}
-#endif /* CONFIG_BT_ASCS_ASE_SRC */
+static struct bt_audio_capability caps_sink = {
+	.codec = &lc3_codec,
+};
+
+static struct bt_audio_capability caps_source = {
+	.codec = &lc3_codec,
 };
 
 int bap_unicast_sr_init(void)
 {
 	bt_audio_unicast_server_register_cb(&unicast_server_cb);
 
-	for (size_t i = 0; i < ARRAY_SIZE(caps); i++) {
-		bt_audio_capability_register(&caps[i]);
+	bt_audio_capability_register(BT_AUDIO_DIR_SINK, &caps_sink);
+
+	if (IS_ENABLED(CONFIG_BT_ASCS_ASE_SRC)) {
+		bt_audio_capability_register(BT_AUDIO_DIR_SOURCE, &caps_source);
 	}
 
 	for (size_t i = 0; i < ARRAY_SIZE(streams); i++) {

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -563,15 +563,12 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected,
 };
 
-static struct bt_audio_capability caps[] = {
-	{
-		.dir = BT_AUDIO_DIR_SINK,
-		.codec = &lc3_codec,
-	},
-	{
-		.dir = BT_AUDIO_DIR_SOURCE,
-		.codec = &lc3_codec,
-	}
+static struct bt_audio_capability caps_sink = {
+	.codec = &lc3_codec,
+};
+
+static struct bt_audio_capability caps_source = {
+	.codec = &lc3_codec,
 };
 
 static int set_location(void)
@@ -643,9 +640,8 @@ void main(void)
 
 	bt_audio_unicast_server_register_cb(&unicast_server_cb);
 
-	for (size_t i = 0; i < ARRAY_SIZE(caps); i++) {
-		bt_audio_capability_register(&caps[i]);
-	}
+	bt_audio_capability_register(BT_AUDIO_DIR_SINK, &caps_sink);
+	bt_audio_capability_register(BT_AUDIO_DIR_SOURCE, &caps_source);
 
 	for (size_t i = 0; i < ARRAY_SIZE(streams); i++) {
 		bt_audio_stream_cb_register(&streams[i], &stream_ops);

--- a/subsys/bluetooth/audio/capabilities.c
+++ b/subsys/bluetooth/audio/capabilities.c
@@ -134,7 +134,7 @@ sys_slist_t *bt_audio_capability_get(enum bt_audio_dir dir)
 }
 
 /* Register Audio Capability */
-int bt_audio_capability_register(struct bt_audio_capability *cap)
+int bt_audio_capability_register(enum bt_audio_dir dir, struct bt_audio_capability *cap)
 {
 	static bool pacs_cb_registered;
 	sys_slist_t *lst;
@@ -143,13 +143,13 @@ int bt_audio_capability_register(struct bt_audio_capability *cap)
 		return -EINVAL;
 	}
 
-	lst = bt_audio_capability_get(cap->dir);
+	lst = bt_audio_capability_get(dir);
 	if (!lst) {
 		return -EINVAL;
 	}
 
 	BT_DBG("cap %p dir 0x%02x codec 0x%02x codec cid 0x%04x "
-	       "codec vid 0x%04x", cap, cap->dir, cap->codec->id,
+	       "codec vid 0x%04x", cap, dir, cap->codec->id,
 	       cap->codec->cid, cap->codec->vid);
 
 	if (!pacs_cb_registered) {
@@ -168,14 +168,14 @@ int bt_audio_capability_register(struct bt_audio_capability *cap)
 	sys_slist_append(lst, &cap->_node);
 
 #if defined(CONFIG_BT_PACS)
-	bt_pacs_capabilities_changed(cap->dir);
+	bt_pacs_capabilities_changed(dir);
 #endif /* CONFIG_BT_PACS */
 
 	return 0;
 }
 
 /* Unregister Audio Capability */
-int bt_audio_capability_unregister(struct bt_audio_capability *cap)
+int bt_audio_capability_unregister(enum bt_audio_dir dir, struct bt_audio_capability *cap)
 {
 	sys_slist_t *lst;
 
@@ -183,19 +183,19 @@ int bt_audio_capability_unregister(struct bt_audio_capability *cap)
 		return -EINVAL;
 	}
 
-	lst = bt_audio_capability_get(cap->dir);
+	lst = bt_audio_capability_get(dir);
 	if (!lst) {
 		return -EINVAL;
 	}
 
-	BT_DBG("cap %p dir 0x%02x", cap, cap->dir);
+	BT_DBG("cap %p dir 0x%02x", cap, dir);
 
 	if (!sys_slist_find_and_remove(lst, &cap->_node)) {
 		return -ENOENT;
 	}
 
 #if defined(CONFIG_BT_PACS)
-	bt_pacs_capabilities_changed(cap->dir);
+	bt_pacs_capabilities_changed(dir);
 #endif /* CONFIG_BT_PACS */
 
 	return 0;

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -470,17 +470,12 @@ static const struct bt_audio_unicast_server_cb unicast_server_cb = {
 	.release = lc3_release,
 };
 
-static struct bt_audio_capability caps[] = {
-#if defined(CONFIG_BT_AUDIO_UNICAST_SERVER)
-	{
-		.dir = BT_AUDIO_DIR_SOURCE,
-		.codec = &lc3_codec,
-	},
-#endif /* CONFIG_BT_AUDIO_UNICAST_SERVER */
-	{
-		.dir = BT_AUDIO_DIR_SINK,
-		.codec = &lc3_codec,
-	},
+static struct bt_audio_capability caps_sink = {
+	.codec = &lc3_codec,
+};
+
+static struct bt_audio_capability caps_source = {
+	.codec = &lc3_codec,
 };
 
 #if defined(CONFIG_BT_AUDIO_UNICAST_CLIENT)
@@ -1474,9 +1469,11 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_UNICAST_SERVER) ||
 	    IS_ENABLED(CONFIG_BT_AUDIO_BROADCAST_SINK)) {
-		for (i = 0; i < ARRAY_SIZE(caps); i++) {
-			bt_audio_capability_register(&caps[i]);
-		}
+		bt_audio_capability_register(BT_AUDIO_DIR_SINK, &caps_sink);
+	}
+
+	if (IS_ENABLED(CONFIG_BT_AUDIO_UNICAST_SERVER)) {
+		bt_audio_capability_register(BT_AUDIO_DIR_SOURCE, &caps_source);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_CAPABILITY)) {

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_sink_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_sink_test.c
@@ -131,7 +131,6 @@ static struct bt_audio_broadcast_sink_cb broadcast_sink_cbs = {
 };
 
 static struct bt_audio_capability capabilities = {
-	.dir = BT_AUDIO_DIR_SINK,
 	.codec = &preset_16_2_1.codec,
 };
 
@@ -172,7 +171,7 @@ static int init(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_audio_capability_register(&capabilities);
+	err = bt_audio_capability_register(BT_AUDIO_DIR_SINK, &capabilities);
 	if (err) {
 		FAIL("Capability register failed (err %d)\n", err);
 		return err;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
@@ -233,7 +233,6 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 static void init(void)
 {
 	static struct bt_audio_capability caps = {
-		.dir = BT_AUDIO_DIR_SINK,
 		.codec = &lc3_codec,
 	};
 	int err;
@@ -248,7 +247,7 @@ static void init(void)
 
 	bt_audio_unicast_server_register_cb(&unicast_server_cb);
 
-	err = bt_audio_capability_register(&caps);
+	err = bt_audio_capability_register(BT_AUDIO_DIR_SINK, &caps);
 	if (err != 0) {
 		FAIL("Failed to register capabilities: %d", err);
 		return;


### PR DESCRIPTION
The direction is used to identify the list to append the registered capabilities. There is no need to keep it in the bt_audio_capabilities, it can be provided as a function parameter instead.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>