### PR TITLE
Bluetooth: Audio: Fix ASE race condition

### DIFF
--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -62,6 +62,9 @@ struct bt_audio_ep {
 	struct bt_gatt_subscribe_params subscribe;
 	struct bt_gatt_discover_params discover;
 
+	/* FIXME: Replace with metastate */
+	bool receiver_ready;
+
 	/* TODO: Consider client/server container split */
 	union {
 		struct {


### PR DESCRIPTION
This patch fixes invalid ASE state transition, ASE now waits for Receiver Start Ready before going into the Streaming state.

fixes #50989