### PR TITLE
boards: swan_r5: fix regulator enabling code

### DIFF
--- a/boards/arm/swan_r5/board.c
+++ b/boards/arm/swan_r5/board.c
@@ -9,19 +9,15 @@
 
 static int board_swan_init(const struct device *dev)
 {
-	const struct gpio_dt_spec gpio4 =
-		GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), pull_up_gpios);
 	const struct gpio_dt_spec gpio6 =
 		GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), no_pull_gpios);
 
 	ARG_UNUSED(dev);
 
-	if (!device_is_ready(gpio4.port) ||
-	    !device_is_ready(gpio6.port)) {
+	if (!device_is_ready(gpio6.port)) {
 		return -ENODEV;
 	}
 
-	(void)gpio_pin_configure_dt(&gpio4, (GPIO_PUSH_PULL | GPIO_SPEED_LOW));
 	(void)gpio_pin_configure_dt(&gpio6, (GPIO_NOPULL | GPIO_MODE_ANALOG));
 
 	return 0;

--- a/boards/arm/swan_r5/board.c
+++ b/boards/arm/swan_r5/board.c
@@ -9,16 +9,16 @@
 
 static int board_swan_init(const struct device *dev)
 {
-	const struct gpio_dt_spec gpio6 =
-		GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), no_pull_gpios);
+	const struct gpio_dt_spec dischrg =
+		GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), dischrg_gpios);
 
 	ARG_UNUSED(dev);
 
-	if (!device_is_ready(gpio6.port)) {
+	if (!device_is_ready(dischrg.port)) {
 		return -ENODEV;
 	}
 
-	(void)gpio_pin_configure_dt(&gpio6, (GPIO_NOPULL | GPIO_MODE_ANALOG));
+	(void)gpio_pin_configure_dt(&dischrg, GPIO_OUTPUT_INACTIVE);
 
 	return 0;
 }

--- a/boards/arm/swan_r5/swan_r5.dts
+++ b/boards/arm/swan_r5/swan_r5.dts
@@ -36,9 +36,16 @@
 		};
 	};
 
+
 	zephyr,user {
-		pull-up-gpios = <&gpioe 4 GPIO_PULL_UP>;
 		no-pull-gpios = <&gpioe 6 GPIO_PUSH_PULL>;
+	};
+
+	supply-3v3 {
+		compatible = "regulator-fixed-sync", "regulator-fixed";
+		regulator-name = "supply-3v3";
+		enable-gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>;
+		regulator-boot-on;
 	};
 
 	aliases {

--- a/boards/arm/swan_r5/swan_r5.dts
+++ b/boards/arm/swan_r5/swan_r5.dts
@@ -38,7 +38,7 @@
 
 
 	zephyr,user {
-		no-pull-gpios = <&gpioe 6 GPIO_PUSH_PULL>;
+		dischrg-gpios = <&gpioe 6 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
 	};
 
 	supply-3v3 {

--- a/boards/arm/swan_r5/swan_r5_defconfig
+++ b/boards/arm/swan_r5/swan_r5_defconfig
@@ -24,3 +24,5 @@ CONFIG_HW_STACK_PROTECTION=y
 
 # enable pin controller
 CONFIG_PINCTRL=y
+
+CONFIG_REGULATOR=y


### PR DESCRIPTION
The board.c file is using non-existing GPIO API attributes:
GPIO_SPEED_LOW and GPIO_MODE_ANALOG. The code compiles because we end up
including soc.h (via init.h -> kernel.h -> ...). soc.h pollutes the namespace
with STM32 HAL definitions, but they do not apply in the context of
Zephyr APIs.

Looking at the schematics, PE4 is really a pin controlling a regulator,
so this PR replaces such custom init code with a regulator turned on at
boot time.

The 3V3 bus seems to have a resistor connected to an MCU pin to
discharge the bus (I assume it does by pulling the DISCHRG line low?).
This patch makes it clear that this GPIO is for discharging and uses GPIO attributes appropriately. Since the regulator
is enabled by default, discharging is disabled.

Ref https://dev.blues.io/hardware/swan-datasheet/

Issues discovered as part of https://github.com/zephyrproject-rtos/zephyr/pull/50987

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>