### PR TITLE
aarch32: mmu: include exception vector into default range

### DIFF
--- a/arch/arm/core/aarch32/mmu/arm_mmu.c
+++ b/arch/arm/core/aarch32/mmu/arm_mmu.c
@@ -75,6 +75,12 @@ static const struct arm_mmu_flat_range mmu_zephyr_ranges[] = {
 		   MPERM_R | MPERM_W |
 		   MATTR_CACHE_OUTER_WB_WA | MATTR_CACHE_INNER_WB_WA},
 
+	/* Mark exception vector cacheable, read only and executable */
+	{ .name  = "zephyr_vect",
+	  .start = (uint32_t)_vector_start,
+	  .end   = (uint32_t)_vector_start + 0x1000,
+	  .attrs = MT_STRONGLY_ORDERED | MPERM_R | MPERM_X},
+
 	/* Mark text segment cacheable, read only and executable */
 	{ .name  = "zephyr_code",
 	  .start = (uint32_t)__text_region_start,

--- a/soc/arm/intel_socfpga_std/cyclonev/soc.c
+++ b/soc/arm/intel_socfpga_std/cyclonev/soc.c
@@ -35,11 +35,6 @@ void arch_reserved_pages_update(void)
 
 static const struct arm_mmu_region mmu_regions[] = {
 
-	MMU_REGION_FLAT_ENTRY("vectors",
-		0x00000000,
-		0x1000,
-		MT_STRONGLY_ORDERED | MPERM_R | MPERM_X),
-
 	MMU_REGION_FLAT_ENTRY("mpcore",
 		0xF8F00000,
 		0x2000,

--- a/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
@@ -23,10 +23,6 @@
 
 static const struct arm_mmu_region mmu_regions[] = {
 
-	MMU_REGION_FLAT_ENTRY("vectors",
-			      0x00000000,
-			      0x1000,
-			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_X),
 	MMU_REGION_FLAT_ENTRY("mpcore",
 			      0xF8F00000,
 			      0x2000,

--- a/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
@@ -23,10 +23,6 @@
 
 static const struct arm_mmu_region mmu_regions[] = {
 
-	MMU_REGION_FLAT_ENTRY("vectors",
-			      0x00000000,
-			      0x1000,
-			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_X),
 	MMU_REGION_FLAT_ENTRY("mpcore",
 			      0xF8F00000,
 			      0x2000,


### PR DESCRIPTION
This removes the need to include an entry in the soc's mmu_config mmu_regions.

Signed-off-by: Théophile Ranquet <theophile.ranquet@gmail.com>