### PR TITLE
mgmt: mcumgr: Add dummy shell buffer size Kconfig to shell_mgmt

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/shell_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/lib/cmd/shell_mgmt/Kconfig
@@ -25,6 +25,11 @@ menuconfig MCUMGR_CMD_SHELL_MGMT
 
 if MCUMGR_CMD_SHELL_MGMT
 
+# Show dummy shell buffer size here, will show help text of original prompt so
+# nothing extra is needed here, nor a default value.
+config SHELL_BACKEND_DUMMY_BUF_SIZE
+	int "Shell output buffer size (Size of dummy buffer size)"
+
 config MCUMGR_CMD_SHELL_MGMT_LEGACY_RC_RETURN_CODE
 	bool "Legacy behaviour: Use rc field for shell function return code"
 	help


### PR DESCRIPTION
This adds the dummy shell buffer size to the shell_mgmt configuration to allow ease of changing it.

Fixes #51016