### PR TITLE
aarch32: use vector base address register for v7-A

### DIFF
--- a/arch/arm/core/aarch32/mmu/arm_mmu.c
+++ b/arch/arm/core/aarch32/mmu/arm_mmu.c
@@ -75,6 +75,22 @@ static const struct arm_mmu_flat_range mmu_zephyr_ranges[] = {
 		   MPERM_R | MPERM_W |
 		   MATTR_CACHE_OUTER_WB_WA | MATTR_CACHE_INNER_WB_WA},
 
+	/* If the exception vector was not relocated in
+	 * arch/arm/core/aarch32/prep_c.c, otherwise define an entry in
+	 * mmu_regions in the soc.
+	 */
+#if !defined CONFIG_ARM                                                        \
+	|| defined(CONFIG_CPU_CORTEX_M_HAS_VTOR)                               \
+	|| defined(CONFIG_AARCH32_ARMV8_R)                                     \
+	|| defined(CONFIG_CPU_AARCH32_CORTEX_A)                                \
+	|| !(defined(CONFIG_XIP) && (CONFIG_FLASH_BASE_ADDRESS != 0))          \
+		&& !(!defined(CONFIG_XIP) && (CONFIG_SRAM_BASE_ADDRESS != 0))
+	/* Mark exception vector cacheable, read only and executable */
+	{ .name  = "zephyr_vect",
+	  .start = (uint32_t)_vector_start,
+	  .end   = (uint32_t)_vector_end,
+	  .attrs = MT_STRONGLY_ORDERED | MPERM_R | MPERM_X},
+#endif
 	/* Mark text segment cacheable, read only and executable */
 	{ .name  = "zephyr_code",
 	  .start = (uint32_t)__text_region_start,

--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -53,7 +53,7 @@ static inline void relocate_vector_table(void)
 	__ISB();
 }
 
-#elif defined(CONFIG_AARCH32_ARMV8_R)
+#elif defined(CONFIG_AARCH32_ARMV8_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A)
 
 #define VECTOR_ADDRESS ((uintptr_t)_vector_start)
 

--- a/include/zephyr/arch/arm/aarch32/arch.h
+++ b/include/zephyr/arch/arm/aarch32/arch.h
@@ -40,8 +40,8 @@
 #elif defined(CONFIG_CPU_AARCH32_CORTEX_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A)
 #include <zephyr/arch/arm/aarch32/cortex_a_r/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_a_r/sys_io.h>
-#if defined(CONFIG_AARCH32_ARMV8_R)
 #include <zephyr/arch/arm/aarch32/cortex_a_r/lib_helpers.h>
+#if defined(CONFIG_AARCH32_ARMV8_R)
 #include <zephyr/arch/arm/aarch32/cortex_a_r/armv8_timer.h>
 #else
 #include <zephyr/arch/arm/aarch32/cortex_a_r/timer.h>

--- a/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -115,6 +115,9 @@ SECTIONS
     SECTION_PROLOGUE(rom_start,,)
     {
 
+#ifndef CONFIG_XIP
+        z_mapped_start = .;
+#endif
 /* Located in generated directory. This file is populated by calling
  * zephyr_linker_sources(ROM_START ...). This typically contains the vector
  * table and debug information.
@@ -133,9 +136,6 @@ SECTIONS
     {
         . = ALIGN(_region_min_align);
         __text_region_start = .;
-#ifndef CONFIG_XIP
-        z_mapped_start = .;
-#endif
 
 #include <zephyr/linker/kobject-text.ld>
 

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -745,9 +745,6 @@ void z_phys_map(uint8_t **virt_ptr, uintptr_t phys, size_t size, uint32_t flags)
 		 "wraparound for virtual address %p (size %zu)",
 		 dest_addr, size);
 
-	LOG_DBG("arch_mem_map(%p, 0x%lx, %zu, %x) offset %lu", dest_addr,
-		aligned_phys, aligned_size, flags, addr_offset);
-
 	arch_mem_map(dest_addr, aligned_phys, aligned_size, flags);
 	k_spin_unlock(&z_mm_lock, key);
 

--- a/soc/arm/intel_socfpga_std/cyclonev/soc.c
+++ b/soc/arm/intel_socfpga_std/cyclonev/soc.c
@@ -9,7 +9,6 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
-#include <zephyr/linker/linker-defs.h>
 #include <zephyr/sys/util.h>
 #include <mmu.h>
 #include <zephyr/arch/arm/aarch32/mmu/arm_mmu.h>
@@ -35,11 +34,6 @@ void arch_reserved_pages_update(void)
 }
 
 static const struct arm_mmu_region mmu_regions[] = {
-
-	MMU_REGION_FLAT_ENTRY("vectors",
-		(uintptr_t)_vector_start,
-		0x1000,
-		MT_STRONGLY_ORDERED | MPERM_R | MPERM_X),
 
 	MMU_REGION_FLAT_ENTRY("mpcore",
 		0xF8F00000,

--- a/soc/arm/intel_socfpga_std/cyclonev/soc.c
+++ b/soc/arm/intel_socfpga_std/cyclonev/soc.c
@@ -9,6 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
+#include <zephyr/linker/linker-defs.h>
 #include <zephyr/sys/util.h>
 #include <mmu.h>
 #include <zephyr/arch/arm/aarch32/mmu/arm_mmu.h>
@@ -36,7 +37,7 @@ void arch_reserved_pages_update(void)
 static const struct arm_mmu_region mmu_regions[] = {
 
 	MMU_REGION_FLAT_ENTRY("vectors",
-		0x00000000,
+		(uintptr_t)_vector_start,
 		0x1000,
 		MT_STRONGLY_ORDERED | MPERM_R | MPERM_X),
 

--- a/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
@@ -6,7 +6,6 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
-#include <zephyr/linker/linker-defs.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
 
@@ -24,10 +23,6 @@
 
 static const struct arm_mmu_region mmu_regions[] = {
 
-	MMU_REGION_FLAT_ENTRY("vectors",
-			      (uintptr_t)_vector_start,
-			      0x1000,
-			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_X),
 	MMU_REGION_FLAT_ENTRY("mpcore",
 			      0xF8F00000,
 			      0x2000,

--- a/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
@@ -6,6 +6,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
+#include <zephyr/linker/linker-defs.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
 
@@ -24,7 +25,7 @@
 static const struct arm_mmu_region mmu_regions[] = {
 
 	MMU_REGION_FLAT_ENTRY("vectors",
-			      0x00000000,
+			      (uintptr_t)_vector_start,
 			      0x1000,
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_X),
 	MMU_REGION_FLAT_ENTRY("mpcore",

--- a/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
@@ -6,7 +6,6 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
-#include <zephyr/linker/linker-defs.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
 
@@ -24,10 +23,6 @@
 
 static const struct arm_mmu_region mmu_regions[] = {
 
-	MMU_REGION_FLAT_ENTRY("vectors",
-			      (uintptr_t)_vector_start,
-			      0x1000,
-			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_X),
 	MMU_REGION_FLAT_ENTRY("mpcore",
 			      0xF8F00000,
 			      0x2000,

--- a/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
@@ -6,6 +6,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
+#include <zephyr/linker/linker-defs.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
 
@@ -24,7 +25,7 @@
 static const struct arm_mmu_region mmu_regions[] = {
 
 	MMU_REGION_FLAT_ENTRY("vectors",
-			      0x00000000,
+			      (uintptr_t)_vector_start,
 			      0x1000,
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_X),
 	MMU_REGION_FLAT_ENTRY("mpcore",


### PR DESCRIPTION
Do not spuriously copy the vector to zero unless there are no means to set VBAR.

Signed-off-by: Théophile Ranquet <theophile.ranquet@gmail.com>

Fixes #51024