### PR TITLE
drivers: gpio: it8xxx2: log error instead of printing

### DIFF
--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -611,7 +611,7 @@ static int gpio_ite_pin_interrupt_configure(const struct device *dev,
 	}
 
 	if (mode == GPIO_INT_MODE_LEVEL) {
-		printk("Level trigger mode not supported.\r\n");
+		LOG_ERR("Level trigger mode not supported");
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
printk must not be used to log, we have log API for that.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>