### PR TITLE
dts: arm: stm32: add dts support for ADC2/3 of stm32f7

### DIFF
--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -624,7 +624,7 @@
 
 		adc1: adc@40012000 {
 			compatible = "st,stm32-adc";
-			reg = <0x40012000 0x400>;
+			reg = <0x40012000 0x50>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000100>;
 			interrupts = <18 0>;
 			status = "disabled";
@@ -632,6 +632,24 @@
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+		};
+
+		adc2: adc@40012100 {
+			compatible = "st,stm32-adc";
+			reg = <0x40012100 0x50>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000200>;
+			interrupts = <18 0>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+		};
+
+		adc3: adc@40012200 {
+			compatible = "st,stm32-adc";
+			reg = <0x40012200 0x50>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000400>;
+			interrupts = <18 0>;
+			status = "disabled";
+			#io-channel-cells = <1>;
 		};
 
 		dac1: dac@40007400 {


### PR DESCRIPTION
This PR enables the ADC peripheral 2 & 3 for the stm32F7 soc series from STMicroelectronics.

Signed-off-by: Vincent Genevès <vincent@geneves.fr>