### PR TITLE
tests: kernel/common: IRQ offload test if CONFIG_IRQ_OFFLOAD=y

### DIFF
--- a/tests/kernel/common/CMakeLists.txt
+++ b/tests/kernel/common/CMakeLists.txt
@@ -24,6 +24,11 @@ target_sources(app PRIVATE
 	src/multilib.c
 	src/errno.c
 	src/boot_delay.c
-	src/irq_offload.c
 	src/pow2.c
   )
+
+target_sources_ifdef(
+	CONFIG_IRQ_OFFLOAD
+	app PRIVATE
+	src/irq_offload.c
+)


### PR DESCRIPTION
This changes to compile the IRQ offload test only if CONFIG_IRQ_OFFLOAD=y. For architectures that do not support IRQ offload (or that developers with to disable IRQ offload during bring-up), compiling the code would result in linking errors.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>