### PR TITLE
unittest: Only add main.c if it exists

### DIFF
--- a/cmake/modules/FindDeprecated.cmake
+++ b/cmake/modules/FindDeprecated.cmake
@@ -73,5 +73,12 @@ if(NOT "${Deprecated_FIND_COMPONENTS}" STREQUAL "")
                  "${Deprecated_FIND_COMPONENTS}")
 endif()
 
+if("SOURCES" IN_LIST Deprecated_FIND_COMPONENTS)
+  message(DEPRECATION
+      "Setting SOURCES prior to calling find_package() for unit tests is deprecated."
+      "To add sources after find_package() use:\n"
+      "    target_sources(testbinary PRIVATE <source-file.c>)")
+endif()
+
 set(Deprecated_FOUND True)
 set(DEPRECATED_FOUND True)

--- a/cmake/modules/unittest.cmake
+++ b/cmake/modules/unittest.cmake
@@ -33,7 +33,7 @@ if((NOT DEFINED ZEPHYR_BASE) AND (DEFINED ENV_ZEPHYR_BASE))
   set(ZEPHYR_BASE ${ENV_ZEPHYR_BASE} CACHE PATH "Zephyr base")
 endif()
 
-if(NOT SOURCES)
+if(NOT SOURCES AND EXISTS main.c)
   set(SOURCES main.c)
 endif()
 

--- a/cmake/modules/unittest.cmake
+++ b/cmake/modules/unittest.cmake
@@ -38,6 +38,7 @@ if(NOT SOURCES AND EXISTS main.c)
 endif()
 
 add_executable(testbinary ${SOURCES})
+find_package(Deprecated COMPONENTS SOURCES)
 add_library(test_interface INTERFACE)
 target_link_libraries(testbinary PRIVATE test_interface)
 

--- a/tests/bluetooth/controller/ctrl_api/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_api/CMakeLists.txt
@@ -2,11 +2,13 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
-
 project(bluetooth_ull_llcp_api)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_chmu/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_chmu/CMakeLists.txt
@@ -2,11 +2,13 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
-
 project(bluetooth_ctrl_ull_conn)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_cis_create/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_cis_create/CMakeLists.txt
@@ -2,11 +2,13 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-FILE(GLOB SOURCES
-	src/*.c
-)
-
 project(bluetooth_ull_llcp_cis_create)
 find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+	PRIVATE
+		src/main.c
+		${ll_sw_sources}
+		${mock_sources}
+		${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_cis_terminate/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_cis_terminate/CMakeLists.txt
@@ -2,11 +2,13 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-FILE(GLOB SOURCES
-	src/*.c
-)
-
 project(bluetooth_ull_llcp_cis_terminate)
 find_package(ZephyrUnittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+	PRIVATE
+		src/main.c
+		${ll_sw_sources}
+		${mock_sources}
+		${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_collision/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_collision/CMakeLists.txt
@@ -2,12 +2,14 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
-
 project(bluetooth_ull_llcp_collision)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
 
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_conn_update/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_conn_update/CMakeLists.txt
@@ -2,11 +2,13 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
-
 project(bluetooth_ctrl_ull_conn)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_cte_req/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_cte_req/CMakeLists.txt
@@ -5,12 +5,14 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
-
 project(bluetooth_ull_llcp_le_cte_req)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)
 set(CMAKE_BUILD_TYPE Debug)

--- a/tests/bluetooth/controller/ctrl_data_length_update/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_data_length_update/CMakeLists.txt
@@ -2,9 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
 if(CONFIG_BT_CTLR_PHY_CODED)
   add_compile_definitions(CONFIG_BT_CTLR_PHY_CODED)
 endif(CONFIG_BT_CTLR_PHY_CODED)
@@ -19,4 +16,10 @@ include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
 if(NOT CONFIG_BT_CTLR_PHY)
 list(REMOVE_ITEM ll_sw_sources ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c)
 endif()
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_encrypt/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_encrypt/CMakeLists.txt
@@ -2,11 +2,13 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
-
 project(bluetooth_ull_llcp_encrypt)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_feature_exchange/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/CMakeLists.txt
@@ -2,11 +2,14 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
-
 project(bluetooth_ull_llcp_feature_exchange)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    src/main_hci.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_hci/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_hci/CMakeLists.txt
@@ -2,11 +2,13 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
-
 project(bluetooth_ull_llcp_feature_exchange)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_invalid/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_invalid/CMakeLists.txt
@@ -2,12 +2,14 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
-
 project(bluetooth_ull_llcp_invalid)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
 
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_le_ping/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_le_ping/CMakeLists.txt
@@ -2,11 +2,13 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
-
 project(bluetooth_ull_llcp_le_ping)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_min_used_chans/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/CMakeLists.txt
@@ -2,11 +2,13 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-	src/*.c
-)
-
 project(bluetooth_ull_llcp_min_used_chans)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+	PRIVATE
+		src/main.c
+		${ll_sw_sources}
+		${mock_sources}
+		${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_phy_update/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_phy_update/CMakeLists.txt
@@ -2,11 +2,13 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
-
 project(bluetooth_ull_llcp_phy_update)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_terminate/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_terminate/CMakeLists.txt
@@ -2,11 +2,13 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-	src/*.c
-)
-
 project(bluetooth_ull_llcp_terminate)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+	PRIVATE
+		src/main.c
+		${ll_sw_sources}
+		${mock_sources}
+		${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_tx_buffer_alloc/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_tx_buffer_alloc/CMakeLists.txt
@@ -2,9 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
 if(CONFIG_BT_CTLR_LLCP_PER_CONN_TX_CTRL_BUF_NUM GREATER_EQUAL 0)
   add_compile_definitions(CONFIG_BT_CTLR_LLCP_PER_CONN_TX_CTRL_BUF_NUM=${CONFIG_BT_CTLR_LLCP_PER_CONN_TX_CTRL_BUF_NUM})
 endif(CONFIG_BT_CTLR_LLCP_PER_CONN_TX_CTRL_BUF_NUM)
@@ -12,4 +9,10 @@ endif(CONFIG_BT_CTLR_LLCP_PER_CONN_TX_CTRL_BUF_NUM)
 project(bluetooth_ull_llcp_tx_buffer_alloc)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_tx_queue/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_tx_queue/CMakeLists.txt
@@ -2,11 +2,13 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
-
 project(bluetooth_ull_llcp_tx_queue)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_unsupported/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_unsupported/CMakeLists.txt
@@ -2,10 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
-
 # Propagate NO_ENC to compile
 if(NO_ENC)
   add_compile_definitions(NO_ENC)
@@ -40,4 +36,10 @@ if(NO_PHY)
   list(REMOVE_ITEM ll_sw_sources ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c)
 endif()
 
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/controller/ctrl_version/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_version/CMakeLists.txt
@@ -2,11 +2,13 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES
-  src/*.c
-)
-
 project(bluetooth_ull_llcp_version)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 include(${ZEPHYR_BASE}/tests/bluetooth/controller/common/defaults_cmake.txt)
-target_sources(testbinary PRIVATE ${ll_sw_sources} ${mock_sources} ${common_sources})
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    ${ll_sw_sources}
+    ${mock_sources}
+    ${common_sources}
+)

--- a/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/CMakeLists.txt
+++ b/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/CMakeLists.txt
@@ -2,8 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES src/*.c)
-
 project(bluetooth_bt_buf_get_cmd_complete)
 
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
@@ -12,3 +10,7 @@ add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/buf mocks)
 
 target_link_libraries(testbinary PRIVATE mocks host_mocks)
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+)

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/CMakeLists.txt
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/CMakeLists.txt
@@ -2,8 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES src/*.c)
-
 project(bluetooth_bt_buf_get_evt)
 
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
@@ -12,3 +10,9 @@ add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/buf mocks)
 
 target_link_libraries(testbinary PRIVATE mocks host_mocks)
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    src/test_suite_hci_evt_cmd.c
+    src/test_suite_hci_evt_num_completed_packets.c
+)

--- a/tests/bluetooth/host/buf/bt_buf_get_rx/CMakeLists.txt
+++ b/tests/bluetooth/host/buf/bt_buf_get_rx/CMakeLists.txt
@@ -2,8 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES src/*.c)
-
 project(bluetooth_bt_buf_get_rx)
 
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
@@ -12,3 +10,8 @@ add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/buf mocks)
 
 target_link_libraries(testbinary PRIVATE mocks host_mocks)
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    src/test_suite_invalid_inputs.c
+)

--- a/tests/bluetooth/host/buf/bt_buf_get_type/CMakeLists.txt
+++ b/tests/bluetooth/host/buf/bt_buf_get_type/CMakeLists.txt
@@ -2,8 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES src/*.c)
-
 project(bluetooth_bt_buf_get_type)
 
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
@@ -12,3 +10,7 @@ add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/buf mocks)
 
 target_link_libraries(testbinary PRIVATE mocks host_mocks)
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+)

--- a/tests/bluetooth/host/host_mocks/assert.c
+++ b/tests/bluetooth/host/host_mocks/assert.c
@@ -7,8 +7,6 @@
 #include <zephyr/kernel.h>
 #include "host_mocks/assert.h"
 
-DEFINE_FFF_GLOBALS;
-
 DEFINE_FAKE_VALUE_FUNC(bool, mock_check_if_assert_expected);
 
 void assert_print(const char *fmt, ...)

--- a/tests/bluetooth/host/keys/bt_keys_foreach_bond/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_bond/CMakeLists.txt
@@ -2,12 +2,15 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES src/*.c)
-
 project(bt_keys_foreach_bond)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/keys mocks)
 
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    src/test_suite_foreach_bond_invalid_inputs.c
+)
 target_link_libraries(testbinary PRIVATE mocks host_mocks)

--- a/tests/bluetooth/host/keys/bt_keys_foreach_type/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_type/CMakeLists.txt
@@ -2,8 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES src/*.c)
-
 project(bt_keys_foreach_type)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
 
@@ -11,3 +9,8 @@ add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/keys mocks)
 
 target_link_libraries(testbinary PRIVATE mocks host_mocks)
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    src/test_suite_foreach_type_invalid_inputs.c
+)

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/CMakeLists.txt
@@ -2,12 +2,17 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-FILE(GLOB SOURCES src/*.c)
-
-project(bt_keys_get_addr)
 find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+project(bt_keys_get_addr)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/keys mocks)
 
 target_link_libraries(testbinary PRIVATE mocks host_mocks)
+target_sources(testbinary
+  PRIVATE
+    src/main.c
+    src/test_suite_full_list_invalid_values.c
+    src/test_suite_full_list_no_overwrite.c
+    src/test_suite_full_list_overwrite_oldest.c
+)

--- a/tests/bluetooth/host/keys/mocks/conn.c
+++ b/tests/bluetooth/host/keys/mocks/conn.c
@@ -7,7 +7,5 @@
 #include <zephyr/kernel.h>
 #include "mocks/conn.h"
 
-DEFINE_FFF_GLOBALS;
-
 DEFINE_FAKE_VOID_FUNC(bt_conn_foreach, int, bt_conn_foreach_cb, void *);
 DEFINE_FAKE_VALUE_FUNC(const bt_addr_le_t *, bt_conn_get_dst, const struct bt_conn *);

--- a/tests/bluetooth/host/keys/mocks/id.c
+++ b/tests/bluetooth/host/keys/mocks/id.c
@@ -7,6 +7,4 @@
 #include <zephyr/kernel.h>
 #include "mocks/id.h"
 
-DEFINE_FFF_GLOBALS;
-
 DEFINE_FAKE_VOID_FUNC(bt_id_del, struct bt_keys *);

--- a/tests/bluetooth/host/keys/mocks/rpa.c
+++ b/tests/bluetooth/host/keys/mocks/rpa.c
@@ -7,6 +7,4 @@
 #include <zephyr/kernel.h>
 #include "mocks/rpa.h"
 
-DEFINE_FFF_GLOBALS;
-
 DEFINE_FAKE_VALUE_FUNC(bool, bt_rpa_irk_matches, const uint8_t *, const bt_addr_t *);

--- a/tests/unit/base64/CMakeLists.txt
+++ b/tests/unit/base64/CMakeLists.txt
@@ -3,5 +3,5 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(base64)
-set(SOURCES main.c)
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+target_sources(testbinary PRIVATE main.c)

--- a/tests/unit/cbprintf/CMakeLists.txt
+++ b/tests/unit/cbprintf/CMakeLists.txt
@@ -3,5 +3,5 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(lib_os_cbprintf)
-set(SOURCES main.c)
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+target_sources(testbinary PRIVATE main.c)

--- a/tests/unit/crc/CMakeLists.txt
+++ b/tests/unit/crc/CMakeLists.txt
@@ -3,5 +3,5 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(crc)
-set(SOURCES main.c)
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+target_sources(testbinary PRIVATE main.c)

--- a/tests/unit/intmath/CMakeLists.txt
+++ b/tests/unit/intmath/CMakeLists.txt
@@ -3,7 +3,5 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(base64)
-set(SOURCES
-  main.c
-  )
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+target_sources(testbinary PRIVATE main.c)

--- a/tests/unit/list/CMakeLists.txt
+++ b/tests/unit/list/CMakeLists.txt
@@ -3,10 +3,11 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(list)
-set(SOURCES
-  main.c
-  slist.c
-  dlist.c
-  sflist.c
-  )
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+target_sources(testbinary
+  PRIVATE
+    main.c
+    slist.c
+    dlist.c
+    sflist.c
+)

--- a/tests/unit/math_extras/CMakeLists.txt
+++ b/tests/unit/math_extras/CMakeLists.txt
@@ -3,5 +3,5 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(math_extras)
-set(SOURCES main.c)
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+target_sources(testbinary PRIVATE main.c)

--- a/tests/unit/net_timeout/CMakeLists.txt
+++ b/tests/unit/net_timeout/CMakeLists.txt
@@ -3,5 +3,5 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(lib_net_timeout)
-set(SOURCES main.c)
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+target_sources(testbinary PRIVATE main.c)

--- a/tests/unit/rbtree/CMakeLists.txt
+++ b/tests/unit/rbtree/CMakeLists.txt
@@ -3,5 +3,5 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(rbtree)
-set(SOURCES main.c)
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+target_sources(testbinary PRIVATE main.c)

--- a/tests/unit/timeutil/CMakeLists.txt
+++ b/tests/unit/timeutil/CMakeLists.txt
@@ -4,5 +4,12 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(timeutil)
-set(SOURCES main.c test_gmtime.c test_s32.c test_s64.c test_sync.c)
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+target_sources(testbinary
+  PRIVATE
+    main.c
+    test_gmtime.c
+    test_s32.c
+    test_s64.c
+    test_sync.c
+)

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -3,5 +3,5 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(util)
-set(SOURCES main.c maincxx.cxx ../../../lib/os/dec.c)
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+target_sources(testbinary PRIVATE main.c maincxx.cxx ${ZEPHYR_BASE}/lib/os/dec.c)

--- a/tests/unit/winstream/CMakeLists.txt
+++ b/tests/unit/winstream/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 project(winstream)
 cmake_minimum_required(VERSION 3.20.0)
-set(SOURCES main.c)
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+target_sources(testbinary PRIVATE main.c)

--- a/tests/ztest/base/CMakeLists.txt
+++ b/tests/ztest/base/CMakeLists.txt
@@ -2,14 +2,12 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 if(BOARD STREQUAL unit_testing)
-  # Add the sources
-  list(APPEND SOURCES src/main.c)
+  find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+  project(base)
 
   # This test suite depends on having this CONFIG_ value, so define it
   add_definitions( -DCONFIG_BUGxxxxx )
-
-  find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
-  project(base)
+  target_sources(testbinary PRIVATE src/main.c)
 else()
   find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
   project(base)


### PR DESCRIPTION
Downstream it's easier to write tests that use target_sources after
including the unittest package instead of specifying a list of sources
before. But if we do that, currently, main.c is added and the build
breaks because it doesn't exist.