### PR TITLE
manifest: mcuboot update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -177,7 +177,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 13f63976bca672ee018f9d55f1e31f02f4135b64
+      revision: cfec947e0f8be686d02c73104a3b1ad0b5dcf1e6
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
- add precise check of the image size
- loader: Added post copy hook to swap function
- Add Kconfig option for setting swap using move as default swap algorithm
- zephyr: fixed ram loading for ARM, with correct handling of vector table when code has moved to RAM.

- imgtool: add option to export public PEM

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>