### PR TITLE
drivers: disk: Stop setting sdmmc disk driver kconfig at board level

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -156,7 +156,7 @@ arduino_spi: &spi0 {
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <0>;
 		status = "okay";
-		mmc {
+		sdmmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
 		};

--- a/boards/arm/lpcxpresso55s69/Kconfig.defconfig
+++ b/boards/arm/lpcxpresso55s69/Kconfig.defconfig
@@ -55,10 +55,6 @@ choice TFM_PROFILE_TYPE
 	default TFM_PROFILE_TYPE_MEDIUM
 endchoice
 
-# Enable SD subsystem driver if disk driver is required
-config DISK_DRIVER_SDMMC
-	default y if DISK_DRIVERS
-
 endif # BOARD_LPCXPRESSO55S69_CPU0 || BOARD_LPCXPRESSO55S69_CPU1
 
 if DMA_MCUX_LPC

--- a/boards/arm/mimxrt1020_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1020_evk/Kconfig.defconfig
@@ -12,9 +12,6 @@ choice CODE_LOCATION
 	default CODE_FLEXSPI
 endchoice
 
-config DISK_DRIVER_SDMMC
-	default y if DISK_DRIVERS
-
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -186,7 +186,7 @@ zephyr_udc0: &usb1 {
 	pinctrl-names = "default", "slow", "med", "fast";
 	cd-gpios = <&gpio3 19 GPIO_ACTIVE_LOW>;
 	pwr-gpios = <&gpio3 24 GPIO_ACTIVE_HIGH>;
-	mmc {
+	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
 	};

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -186,7 +186,7 @@ zephyr_udc0: &usb1 {
 	cd-gpios = <&gpio3 19 GPIO_ACTIVE_LOW>;
 	pwr-gpios = <&gpio3 30 GPIO_ACTIVE_HIGH>;
 	no-1-8-v;
-	mmc {
+	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
 	};

--- a/boards/arm/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig.defconfig
@@ -13,8 +13,6 @@ choice CODE_LOCATION
 	default CODE_FLEXSPI
 endchoice
 
-config DISK_DRIVER_SDMMC
-	default y if DISK_DRIVERS
 if FLASH
 
 config FLASH_MCUX_FLEXSPI_HYPERFLASH

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -268,7 +268,7 @@ zephyr_udc0: &usb1 {
 	pinctrl-2 = <&pinmux_usdhc1_med>;
 	pinctrl-3 = <&pinmux_usdhc1_fast>;
 	pinctrl-names = "default", "slow", "med", "fast";
-	mmc {
+	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
 	};

--- a/boards/arm/mimxrt1060_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1060_evk/Kconfig.defconfig
@@ -14,9 +14,6 @@ choice CODE_LOCATION
 	default CODE_FLEXSPI
 endchoice
 
-config DISK_DRIVER_SDMMC
-	default y if DISK_DRIVERS
-
 if FLASH
 
 config FLASH_MCUX_FLEXSPI_NOR

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -226,7 +226,7 @@ zephyr_udc0: &usb1 {
 	pinctrl-2 = <&pinmux_usdhc1_med>;
 	pinctrl-3 = <&pinmux_usdhc1_fast>;
 	pinctrl-names = "default", "slow", "med", "fast";
-	mmc {
+	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
 	};

--- a/boards/arm/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig.defconfig
@@ -12,9 +12,6 @@ choice CODE_LOCATION
 	default CODE_FLEXSPI2
 endchoice
 
-config DISK_DRIVER_SDMMC
-	default y if DISK_DRIVERS
-
 config KSCAN
 	default y if LVGL
 

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -288,7 +288,7 @@ zephyr_udc0: &usb1 {
 	pinctrl-2 = <&pinmux_usdhc1_med>;
 	pinctrl-3 = <&pinmux_usdhc1_fast>;
 	pinctrl-names = "default", "slow", "med", "fast";
-	mmc {
+	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
 	};

--- a/boards/arm/mimxrt1170_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1170_evk/Kconfig.defconfig
@@ -16,9 +16,6 @@ endchoice
 
 if DISK_DRIVERS
 
-config DISK_DRIVER_SDMMC
-	default y
-
 config IMX_USDHC_DAT3_PWR_TOGGLE
 	default y
 

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
@@ -171,7 +171,7 @@
 	status = "okay";
 	detect-dat3;
 	pwr-gpios = <&gpio10 2 GPIO_ACTIVE_LOW>;
-	mmc {
+	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
 	};

--- a/boards/arm/mimxrt685_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt685_evk/Kconfig.defconfig
@@ -43,7 +43,4 @@ config HEAP_MEM_POOL_SIZE
 
 endif # DMA_MCUX_LPC
 
-config DISK_DRIVER_SDMMC
-	default y if DISK_DRIVERS
-
 endif # BOARD_MIMXRT685_EVK

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -434,7 +434,7 @@ i2s1: &flexcomm3 {
 	no-1-8-v;
 	pwr-gpios = <&gpio2 10 GPIO_ACTIVE_HIGH>;
 	cd-gpios = <&gpio2 9 GPIO_ACTIVE_LOW>;
-	mmc {
+	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
 	};

--- a/drivers/disk/Kconfig.sdmmc
+++ b/drivers/disk/Kconfig.sdmmc
@@ -6,6 +6,7 @@ DT_STM32_SDMMC_HAS_DMA := $(dt_nodelabel_has_prop,sdmmc,dmas)
 
 config DISK_DRIVER_SDMMC
 	bool "SDMMC card driver"
+	default y if DT_HAS_ZEPHYR_SDMMC_DISK_ENABLED
 	help
 	  SDMMC card driver.
 


### PR DESCRIPTION
The sdmmc disk driver kconfig should not have to be set at board level. 

This PR adds a default for this kconfig at driver level based on devicetree and removes it from the board level for NXP boards