### PR TITLE
soc: intel_adsp/ace: fix IDC transactions used for sched IPI

### DIFF
--- a/tests/boards/intel_adsp/smoke/src/smpboot.c
+++ b/tests/boards/intel_adsp/smoke/src/smpboot.c
@@ -12,7 +12,7 @@
 #define CPU_START_DELAY 10000
 
 /* IPIs happen  much faster than CPU startup */
-#define CPU_IPI_DELAY 100
+#define CPU_IPI_DELAY 250
 
 BUILD_ASSERT(CONFIG_SMP);
 BUILD_ASSERT(CONFIG_SMP_BOOT_DELAY);


### PR DESCRIPTION
The Inter-DSP Communication (IDC) is being used to send sched IPI to other CPU cores. When a core receives an IDC, it needs to ACK it by clearing the BUSY bit in TDR, and also needs to the BUSY bit in TDA to signal done after processing. These two steps are needed to complete one IDC message. If we do only one (and not both), the other side will not be able to send another IDC message as the hardware still thinks the core is processing the IDC message (and thus will not send another one). So add the step to clear the BUSY bit in TDA so we can have multiple sched IPIs.