### PR TITLE
drivers: eth: sam0: Fix missing devicetree dependency

### DIFF
--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -6,7 +6,8 @@
 menuconfig ETH_SAM_GMAC
 	bool "Atmel SAM Ethernet driver"
 	default y
-	depends on DT_HAS_ATMEL_SAM_GMAC_ENABLED
+	depends on DT_HAS_ATMEL_SAM_GMAC_ENABLED || \
+		   DT_HAS_ATMEL_SAM0_GMAC_ENABLED
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	select MDIO
 	help


### PR DESCRIPTION
The #48905 introduce a regression on gmac ethernet driver. The GMAC driver matches two compatibles. This add missing compatible for SAM0 variant.

Fixes: #50970.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>