### PR TITLE
boards: tdk_robokit1 jlink flasher support

### DIFF
--- a/boards/arm/tdk_robokit1/board.cmake
+++ b/boards/arm/tdk_robokit1/board.cmake
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(jlink "--device=ATSAME70Q21")
 board_runner_args(openocd --cmd-post-verify "atsamv gpnvm set 1")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Adds the needed JLink parameters and cmake includes to support flashing and debugging the tdk_robokit1 with a segger jlink.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>