### PR TITLE
drivers: flash_mcux_flexspi_nor: Add block erase

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -46,6 +46,7 @@ enum {
 	READ_STATUS,
 	WRITE_ENABLE,
 	ERASE_SECTOR,
+	ERASE_BLOCK,
 	PAGE_PROGRAM_INPUT,
 	PAGE_PROGRAM_QUAD_INPUT,
 	READ_ID,
@@ -88,6 +89,11 @@ static const uint32_t flash_flexspi_nor_lut[][4] = {
 
 	[ERASE_SECTOR] = {
 		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR,       kFLEXSPI_1PAD, SPI_NOR_CMD_SE,
+				kFLEXSPI_Command_RADDR_SDR, kFLEXSPI_1PAD, 0x18),
+	},
+
+	[ERASE_BLOCK] = {
+		FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR,       kFLEXSPI_1PAD, SPI_NOR_CMD_BE,
 				kFLEXSPI_Command_RADDR_SDR, kFLEXSPI_1PAD, 0x18),
 	},
 
@@ -251,6 +257,26 @@ static int flash_flexspi_nor_erase_sector(const struct device *dev,
 	return memc_flexspi_transfer(data->controller, &transfer);
 }
 
+static int flash_flexspi_nor_erase_block(const struct device *dev,
+					  off_t offset)
+{
+	struct flash_flexspi_nor_data *data = dev->data;
+
+	flexspi_transfer_t transfer = {
+		.deviceAddress = offset,
+		.port = data->port,
+		.cmdType = kFLEXSPI_Command,
+		.SeqNumber = 1,
+		.seqIndex = ERASE_BLOCK,
+		.data = NULL,
+		.dataSize = 0,
+	};
+
+	LOG_DBG("Erasing block at 0x%08zx", (ssize_t) offset);
+
+	return memc_flexspi_transfer(data->controller, &transfer);
+}
+
 static int flash_flexspi_nor_erase_chip(const struct device *dev)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
@@ -392,7 +418,9 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 		size_t size)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
-	int num_sectors = size / SPI_NOR_SECTOR_SIZE;
+	const size_t num_sectors = size / SPI_NOR_SECTOR_SIZE;
+	const size_t num_blocks = size / SPI_NOR_BLOCK_SIZE;
+
 	int i;
 	unsigned int key = 0;
 
@@ -424,7 +452,17 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 		flash_flexspi_nor_erase_chip(dev);
 		flash_flexspi_nor_wait_bus_busy(dev);
 		memc_flexspi_reset(data->controller);
-	} else {
+	}
+	else if ((0 == (offset % SPI_NOR_BLOCK_SIZE)) && (0 == (size % SPI_NOR_BLOCK_SIZE))){
+		for (i = 0; i < num_blocks; i++) {
+			flash_flexspi_nor_write_enable(dev);
+			flash_flexspi_nor_erase_block(dev, offset);
+			flash_flexspi_nor_wait_bus_busy(dev);
+			memc_flexspi_reset(data->controller);
+			offset += SPI_NOR_BLOCK_SIZE;
+		}
+	}
+	else {
 		for (i = 0; i < num_sectors; i++) {
 			flash_flexspi_nor_write_enable(dev);
 			flash_flexspi_nor_erase_sector(dev, offset);


### PR DESCRIPTION
Change improves to erase time significantly when a block needs to be erased.
The change was tested on an mimxrt1060_evk board.