### PR TITLE
drivers/lora: sx12xx: call user callback before further Rx

### DIFF
--- a/drivers/lora/sx12xx_common.c
+++ b/drivers/lora/sx12xx_common.c
@@ -103,10 +103,10 @@ static void sx12xx_ev_rx_done(uint8_t *payload, uint16_t size, int16_t rssi,
 
 	/* Receiving in asynchronous mode */
 	if (dev_data.async_rx_cb) {
-		/* Start receiving again */
-		Radio.Rx(0);
 		/* Run the callback */
 		dev_data.async_rx_cb(dev_data.dev, payload, size, rssi, snr);
+		/* Start receiving again */
+		Radio.Rx(0);
 		/* Don't run the synchronous code */
 		return;
 	}


### PR DESCRIPTION
Call user callback (cb) before further Rx. The previous code would reset the reception buffer before calling the user callback resulting in an empty buffer (filled with zeros) with correct expected length.

Signed-off-by: Ivan Wagner <ivan.wagner@tecinvent.ch>