### PR TITLE
tests: espressif_esp32: Fix docs generation issue

### DIFF
--- a/tests/boards/espressif_esp32/cache_coex/README.rst
+++ b/tests/boards/espressif_esp32/cache_coex/README.rst
@@ -1,7 +1,7 @@
 .. _cache_coex_test:
 
 Espressif ESP32 PSRAM/SPI Flash co-existence test
-###########
+#################################################
 
 Overview
 ********


### PR DESCRIPTION
Fixes following bug:
...
Warning, treated as error:
../espressif_esp32/cache_coex/README.rst:4:Title underline too short. ...