### PR TITLE
Bluetooth: audio: capabilities: Hide bt_audio_capability_get function

### DIFF
--- a/include/zephyr/bluetooth/audio/capabilities.h
+++ b/include/zephyr/bluetooth/audio/capabilities.h
@@ -16,9 +16,6 @@
 extern "C" {
 #endif
 
-/* Get list of capabilities by type */
-sys_slist_t *bt_audio_capability_get(enum bt_audio_dir dir);
-
 /** @brief Audio Capability structure. */
 struct bt_audio_capability {
 	/** Capability codec reference */
@@ -27,6 +24,29 @@ struct bt_audio_capability {
 	/* Internally used list node */
 	sys_snode_t _node;
 };
+
+/** @typedef bt_audio_foreach_capability_func_t
+ *  @brief Capability iterator callback.
+ *
+ *  @param capability Capability found.
+ *  @param user_data Data given.
+ *
+ *  @return true to continue to the next capability
+ *  @return false to stop the iteration
+ */
+typedef bool (*bt_audio_foreach_capability_func_t)(const struct bt_audio_capability *capability,
+						   void *user_data);
+
+/** @brief Capability iterator.
+ *
+ *  Iterate capabilities with endpoint direction specified.
+ *
+ *  @param dir Direction of the endpoint to look capability for.
+ *  @param func Callback function.
+ *  @param user_data Data to pass to the callback.
+ */
+void bt_audio_foreach_capability(enum bt_audio_dir dir, bt_audio_foreach_capability_func_t func,
+				 void *user_data);
 
 /** @brief Register Audio Capability.
  *

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1223,13 +1223,32 @@ static bool ascs_codec_config_store(struct bt_data *data, void *user_data)
 	return true;
 }
 
+struct codec_lookup_id_data {
+	uint8_t id;
+	struct bt_codec *codec;
+};
+
+static bool codec_lookup_id(const struct bt_audio_capability *capability, void *user_data)
+{
+	struct codec_lookup_id_data *data = user_data;
+
+	if (capability->codec->id == data->id) {
+		data->codec = capability->codec;
+
+		return false;
+	}
+
+	return true;
+}
+
 static int ascs_ep_set_codec(struct bt_audio_ep *ep, uint8_t id, uint16_t cid,
 			     uint16_t vid, struct net_buf_simple *buf,
 			     uint8_t len, struct bt_codec *codec)
 {
-	struct bt_audio_capability *cap;
-	sys_slist_t *capabilities;
 	struct net_buf_simple ad;
+	struct codec_lookup_id_data lookup_data = {
+		.id = id,
+	};
 
 	if (ep == NULL && codec == NULL) {
 		return -EINVAL;
@@ -1238,8 +1257,9 @@ static int ascs_ep_set_codec(struct bt_audio_ep *ep, uint8_t id, uint16_t cid,
 	BT_DBG("ep %p dir %u codec id 0x%02x cid 0x%04x vid 0x%04x len %u",
 	       ep, ep->dir, id, cid, vid, len);
 
-	capabilities = bt_audio_capability_get(ep->dir);
-	if (capabilities == NULL) {
+	bt_audio_foreach_capability(ep->dir, codec_lookup_id, &lookup_data);
+
+	if (lookup_data.codec == NULL) {
 		return -ENOENT;
 	}
 
@@ -1251,13 +1271,7 @@ static int ascs_ep_set_codec(struct bt_audio_ep *ep, uint8_t id, uint16_t cid,
 	codec->cid = cid;
 	codec->vid = vid;
 	codec->data_count = 0;
-
-	SYS_SLIST_FOR_EACH_CONTAINER(capabilities, cap, _node) {
-		if (codec->id == cap->codec->id) {
-			codec->path_id = cap->codec->path_id;
-			break;
-		}
-	}
+	codec->path_id = lookup_data.codec->path_id;
 
 	if (len == 0) {
 		return 0;


### PR DESCRIPTION
This function exposes list pointer, so that it allows the user to modify the internal list. This adds bt_audio_foreach_capability iterator finction that can be used instead.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>