### PR TITLE
net: lib: sockets_tls: Include zephyr_mbedtls_priv.h conditionally

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -52,7 +52,9 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include "sockets_internal.h"
 #include "tls_internal.h"
 
-#include "zephyr_mbedtls_priv.h"
+#if defined(CONFIG_MBEDTLS_BUILTIN)
+#include <zephyr_mbedtls_priv.h>
+#endif
 
 #if defined(CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS)
 #define ALPN_MAX_PROTOCOLS (CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS + 1)


### PR DESCRIPTION
This is a follow-up to commit a418ad4bb4dda1a8add47084111c0362aa90a495.

Since the path to zephyr_mbedtls_priv.h is added to include directories only when CONFIG_MBEDTLS_BUILTIN is enabled, the inclusion of the file needs to be done under the same condition. Otherwise, an error occurs when socket_tls.c is compiled without CONFIG_MBEDTLS_BUILTIN.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>