### PR TITLE
mgmt/mcumgr: Drop zephyr_smp_transport.zst_get_mtu

### DIFF
--- a/include/zephyr/mgmt/mcumgr/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp.h
@@ -27,21 +27,6 @@ struct net_buf;
  */
 typedef int zephyr_smp_transport_out_fn(struct net_buf *nb);
 
-/** @typedef zephyr_smp_transport_get_mtu_fn
- * @brief SMP MTU query function for Zephyr.
- *
- * The supplied net_buf should contain a request received from the peer whose
- * MTU is being queried.  This function takes a net_buf parameter because some
- * transports store connection-specific information in the net_buf user header
- * (e.g., the BLE transport stores the peer address).
- *
- * @param nb                    Contains a request from the relevant peer.
- *
- * @return                      The transport's MTU;
- *                              0 if transmission is currently not possible.
- */
-typedef uint16_t zephyr_smp_transport_get_mtu_fn(const struct net_buf *nb);
-
 /** @typedef zephyr_smp_transport_ud_copy_fn
  * @brief SMP copy buffer user_data function for Zephyr.
  *
@@ -80,7 +65,6 @@ struct zephyr_smp_transport {
 	struct k_fifo zst_fifo;
 
 	zephyr_smp_transport_out_fn *zst_output;
-	zephyr_smp_transport_get_mtu_fn *zst_get_mtu;
 	zephyr_smp_transport_ud_copy_fn *zst_ud_copy;
 	zephyr_smp_transport_ud_free_fn *zst_ud_free;
 
@@ -98,13 +82,11 @@ struct zephyr_smp_transport {
  *
  * @param zst                   The transport to construct.
  * @param output_func           The transport's send function.
- * @param get_mtu_func          The transport's get-MTU function.
  * @param ud_copy_func          The transport buffer user_data copy function.
  * @param ud_free_func          The transport buffer user_data free function.
  */
 void zephyr_smp_transport_init(struct zephyr_smp_transport *zst,
 			       zephyr_smp_transport_out_fn *output_func,
-			       zephyr_smp_transport_get_mtu_fn *get_mtu_func,
 			       zephyr_smp_transport_ud_copy_fn *ud_copy_func,
 			       zephyr_smp_transport_ud_free_fn *ud_free_func);
 

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -127,13 +127,11 @@ zephyr_smp_handle_reqs(struct k_work *work)
 void
 zephyr_smp_transport_init(struct zephyr_smp_transport *zst,
 			  zephyr_smp_transport_out_fn *output_func,
-			  zephyr_smp_transport_get_mtu_fn *get_mtu_func,
 			  zephyr_smp_transport_ud_copy_fn *ud_copy_func,
 			  zephyr_smp_transport_ud_free_fn *ud_free_func)
 {
 	*zst = (struct zephyr_smp_transport) {
 		.zst_output = output_func,
-		.zst_get_mtu = get_mtu_func,
 		.zst_ud_copy = ud_copy_func,
 		.zst_ud_free = ud_free_func,
 	};

--- a/subsys/mgmt/mcumgr/transport/smp_bt.c
+++ b/subsys/mgmt/mcumgr/transport/smp_bt.c
@@ -516,8 +516,7 @@ static int smp_bt_init(const struct device *dev)
 	}
 
 	zephyr_smp_transport_init(&smp_bt_transport, smp_bt_tx_pkt,
-				  smp_bt_get_mtu, smp_bt_ud_copy,
-				  smp_bt_ud_free);
+				  smp_bt_ud_copy, smp_bt_ud_free);
 	return 0;
 }
 

--- a/subsys/mgmt/mcumgr/transport/smp_dummy.c
+++ b/subsys/mgmt/mcumgr/transport/smp_dummy.c
@@ -148,11 +148,6 @@ static void smp_dummy_rx_frag(struct uart_mcumgr_rx_buf *rx_buf)
 	k_work_submit(&smp_dummy_work);
 }
 
-static uint16_t smp_dummy_get_mtu(const struct net_buf *nb)
-{
-	return CONFIG_MCUMGR_SMP_DUMMY_RX_BUF_SIZE;
-}
-
 int dummy_mcumgr_send_raw(const void *data, int len)
 {
 	uint16_t data_size =
@@ -190,7 +185,7 @@ static int smp_dummy_init(const struct device *dev)
 	k_sem_init(&smp_data_ready_sem, 0, 1);
 
 	zephyr_smp_transport_init(&smp_dummy_transport, smp_dummy_tx_pkt_int,
-				  smp_dummy_get_mtu, NULL, NULL);
+				  NULL, NULL);
 	dummy_mgumgr_recv_cb = smp_dummy_rx_frag;
 
 	return 0;

--- a/subsys/mgmt/mcumgr/transport/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/smp_shell.c
@@ -157,11 +157,6 @@ void smp_shell_process(struct smp_shell_data *data)
 	}
 }
 
-static uint16_t smp_shell_get_mtu(const struct net_buf *nb)
-{
-	return CONFIG_MCUMGR_SMP_SHELL_MTU;
-}
-
 static int smp_shell_tx_raw(const void *data, int len)
 {
 	const struct shell *const sh = shell_backend_uart_get_ptr();
@@ -191,7 +186,7 @@ static int smp_shell_tx_pkt(struct net_buf *nb)
 int smp_shell_init(void)
 {
 	zephyr_smp_transport_init(&smp_shell_transport, smp_shell_tx_pkt,
-				  smp_shell_get_mtu, NULL, NULL);
+				  NULL, NULL);
 
 	return 0;
 }

--- a/subsys/mgmt/mcumgr/transport/smp_uart.c
+++ b/subsys/mgmt/mcumgr/transport/smp_uart.c
@@ -74,11 +74,6 @@ static void smp_uart_rx_frag(struct uart_mcumgr_rx_buf *rx_buf)
 	k_work_submit(&smp_uart_work);
 }
 
-static uint16_t smp_uart_get_mtu(const struct net_buf *nb)
-{
-	return CONFIG_MCUMGR_SMP_UART_MTU;
-}
-
 static int smp_uart_tx_pkt(struct net_buf *nb)
 {
 	int rc;
@@ -94,7 +89,7 @@ static int smp_uart_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	zephyr_smp_transport_init(&smp_uart_transport, smp_uart_tx_pkt,
-				  smp_uart_get_mtu, NULL, NULL);
+				  NULL, NULL);
 	uart_mcumgr_register(smp_uart_rx_frag);
 
 	return 0;

--- a/subsys/mgmt/mcumgr/transport/smp_udp.c
+++ b/subsys/mgmt/mcumgr/transport/smp_udp.c
@@ -103,13 +103,6 @@ static int smp_udp6_tx(struct net_buf *nb)
 }
 #endif
 
-static uint16_t smp_udp_get_mtu(const struct net_buf *nb)
-{
-	ARG_UNUSED(nb);
-
-	return CONFIG_MCUMGR_SMP_UDP_MTU;
-}
-
 static int smp_udp_ud_copy(struct net_buf *dst, const struct net_buf *src)
 {
 	struct sockaddr *src_ud = net_buf_user_data(src);
@@ -165,14 +158,12 @@ static int smp_udp_init(const struct device *dev)
 
 #ifdef CONFIG_MCUMGR_SMP_UDP_IPV4
 	zephyr_smp_transport_init(&configs.ipv4.smp_transport,
-				  smp_udp4_tx, smp_udp_get_mtu,
-				  smp_udp_ud_copy, NULL);
+				  smp_udp4_tx,smp_udp_ud_copy, NULL);
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_UDP_IPV6
 	zephyr_smp_transport_init(&configs.ipv6.smp_transport,
-				  smp_udp6_tx, smp_udp_get_mtu,
-				  smp_udp_ud_copy, NULL);
+				  smp_udp6_tx, smp_udp_ud_copy, NULL);
 #endif
 
 	return MGMT_ERR_EOK;


### PR DESCRIPTION
The commit removes zst_get_mtu field from zephyr_smp_transport, removes get_mtu_func parameter from zephyr_smp_transport_init function and removes type zephyr_smp_transport_get_mtu_fn. The zst_get_mtu is no longer called from inside of MCUmgr, as transports are tasked with respecting MTU.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>