### PR TITLE
Use time_t for LwM2M time resources.

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -231,6 +231,7 @@ struct lwm2m_time_series_elem {
 		int16_t i16;
 		int32_t i32;
 		int64_t i64;
+		time_t time;
 		double f;
 		bool b;
 	};
@@ -812,6 +813,16 @@ int lwm2m_engine_set_float(const char *pathstr, const double *value);
 int lwm2m_engine_set_objlnk(const char *pathstr, const struct lwm2m_objlnk *value);
 
 /**
+ * @brief Set resource (instance) value (Time)
+ *
+ * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
+ * @param[in] value Epoch timestamp
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_engine_set_time(const char *pathstr, time_t value);
+
+/**
  * @brief Get resource (instance) value (opaque buffer)
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
@@ -942,6 +953,16 @@ int lwm2m_engine_get_float(const char *pathstr, double *buf);
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_engine_get_objlnk(const char *pathstr, struct lwm2m_objlnk *buf);
+
+/**
+ * @brief Get resource (instance) value (Time)
+ *
+ * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
+ * @param[out] buf time_t pointer to copy data
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_engine_get_time(const char *pathstr, time_t *buf);
 
 
 /**

--- a/subsys/net/lib/lwm2m/ipso_filling_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_filling_sensor.c
@@ -48,8 +48,8 @@ static bool container_full[MAX_INSTANCE_COUNT];
 static double low_threshold[MAX_INSTANCE_COUNT];
 static bool container_empty[MAX_INSTANCE_COUNT];
 static double average_fill_speed[MAX_INSTANCE_COUNT];
-static int64_t forecast_full_date[MAX_INSTANCE_COUNT];
-static int64_t forecast_empty_date[MAX_INSTANCE_COUNT];
+static time_t forecast_full_date[MAX_INSTANCE_COUNT];
+static time_t forecast_empty_date[MAX_INSTANCE_COUNT];
 static bool container_out_of_location[MAX_INSTANCE_COUNT];
 static bool container_out_of_position[MAX_INSTANCE_COUNT];
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_device.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_device.c
@@ -90,8 +90,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 /* resource state variables */
 static uint8_t  error_code_list[DEVICE_ERROR_CODE_MAX];
-static int32_t time_temp;
-static uint32_t time_offset;
+static time_t time_temp;
+static time_t time_offset;
 static uint8_t  binding_mode[DEVICE_STRING_SHORT];
 
 /* only 1 instance of device object exists */
@@ -170,7 +170,10 @@ static int current_time_post_write_cb(uint16_t obj_inst_id, uint16_t res_id,
 				      bool last_block, size_t total_size)
 {
 	if (data_len == 4U) {
-		time_offset = *(int32_t *)data - (int32_t)(k_uptime_get() / 1000);
+		time_offset = *(uint32_t *)data - (uint32_t)(k_uptime_get() / 1000);
+		return 0;
+	} else if (data_len == 8U) {
+		time_offset = *(time_t *)data - (time_t)(k_uptime_get() / 1000);
 		return 0;
 	}
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_location.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_location.c
@@ -42,7 +42,7 @@ static double longitude;
 static double altitude;
 static double radius;
 static double speed;
-static int32_t timestamp;
+static time_t timestamp;
 
 static struct lwm2m_engine_obj location;
 static struct lwm2m_engine_obj_field fields[] = {

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -538,7 +538,7 @@ struct lwm2m_writer {
 	int (*put_s64)(struct lwm2m_output_context *out,
 		       struct lwm2m_obj_path *path, int64_t value);
 	int (*put_time)(struct lwm2m_output_context *out,
-		       struct lwm2m_obj_path *path, int64_t value);
+		       struct lwm2m_obj_path *path, time_t value);
 	int (*put_string)(struct lwm2m_output_context *out,
 			  struct lwm2m_obj_path *path, char *buf,
 			  size_t buflen);
@@ -559,7 +559,7 @@ struct lwm2m_writer {
 struct lwm2m_reader {
 	int (*get_s32)(struct lwm2m_input_context *in, int32_t *value);
 	int (*get_s64)(struct lwm2m_input_context *in, int64_t *value);
-	int (*get_time)(struct lwm2m_input_context *in, int64_t *value);
+	int (*get_time)(struct lwm2m_input_context *in, time_t *value);
 	int (*get_string)(struct lwm2m_input_context *in, uint8_t *buf,
 			  size_t buflen);
 	int (*get_float)(struct lwm2m_input_context *in, double *value);
@@ -727,7 +727,7 @@ static inline int engine_put_float(struct lwm2m_output_context *out,
 }
 
 static inline int engine_put_time(struct lwm2m_output_context *out,
-				  struct lwm2m_obj_path *path, int64_t value)
+				  struct lwm2m_obj_path *path, time_t value)
 {
 	return out->writer->put_time(out, path, value);
 }
@@ -791,7 +791,7 @@ static inline int engine_get_string(struct lwm2m_input_context *in,
 	return in->reader->get_string(in, buf, buflen);
 }
 
-static inline int engine_get_time(struct lwm2m_input_context *in, int64_t *value)
+static inline int engine_get_time(struct lwm2m_input_context *in, time_t *value)
 {
 	return in->reader->get_time(in, value);
 }

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -549,6 +549,11 @@ static int put_s64(struct lwm2m_output_context *out,
 	return json_float_object_write(out, fd, len);
 }
 
+static int put_time(struct lwm2m_output_context *out, struct lwm2m_obj_path *path, time_t value)
+{
+	return put_s64(out, path, (int64_t) value);
+}
+
 static int put_string(struct lwm2m_output_context *out,
 		      struct lwm2m_obj_path *path, char *buf, size_t buflen)
 {
@@ -676,6 +681,17 @@ static int read_int(struct lwm2m_input_context *in, int64_t *value,
 static int get_s64(struct lwm2m_input_context *in, int64_t *value)
 {
 	return read_int(in, value, true);
+}
+
+static int get_time(struct lwm2m_input_context *in, time_t *value)
+{
+	int64_t temp64;
+	int ret;
+
+	ret = read_int(in, &temp64, true);
+	*value = (time_t)temp64;
+
+	return ret;
 }
 
 static int get_s32(struct lwm2m_input_context *in, int32_t *value)
@@ -851,7 +867,7 @@ const struct lwm2m_writer json_writer = {
 	.put_s64 = put_s64,
 	.put_string = put_string,
 	.put_float = put_float,
-	.put_time = put_s64,
+	.put_time = put_time,
 	.put_bool = put_bool,
 	.put_objlnk = put_objlnk,
 };
@@ -860,7 +876,7 @@ const struct lwm2m_reader json_reader = {
 	.get_s32 = get_s32,
 	.get_s64 = get_s64,
 	.get_string = get_string,
-	.get_time = get_s64,
+	.get_time = get_time,
 	.get_float = get_float,
 	.get_bool = get_bool,
 	.get_opaque = get_opaque,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -497,6 +497,12 @@ static int put_s64(struct lwm2m_output_context *out,
 	return len;
 }
 
+
+static int put_time(struct lwm2m_output_context *out, struct lwm2m_obj_path *path, time_t value)
+{
+	return put_s64(out, path, (int64_t)value);
+}
+
 static int put_string(struct lwm2m_output_context *out,
 		      struct lwm2m_obj_path *path, char *buf, size_t buflen)
 {
@@ -622,6 +628,17 @@ static int get_number(struct lwm2m_input_context *in, int64_t *value,
 static int get_s64(struct lwm2m_input_context *in, int64_t *value)
 {
 	return get_number(in, value, 8);
+}
+
+static int get_time(struct lwm2m_input_context *in, time_t *value)
+{
+	int64_t temp64;
+	int ret;
+
+	ret = get_number(in, &temp64, 8);
+	*value = (time_t)temp64;
+
+	return ret;
 }
 
 static int get_s32(struct lwm2m_input_context *in, int32_t *value)
@@ -772,7 +789,7 @@ const struct lwm2m_writer oma_tlv_writer = {
 	.put_s64 = put_s64,
 	.put_string = put_string,
 	.put_float = put_float,
-	.put_time = put_s64,
+	.put_time = put_time,
 	.put_bool = put_bool,
 	.put_opaque = put_opaque,
 	.put_objlnk = put_objlnk,
@@ -782,7 +799,7 @@ const struct lwm2m_reader oma_tlv_reader = {
 	.get_s32 = get_s32,
 	.get_s64 = get_s64,
 	.get_string = get_string,
-	.get_time = get_s64,
+	.get_time = get_time,
 	.get_float = get_float,
 	.get_bool = get_bool,
 	.get_opaque = get_opaque,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -121,6 +121,12 @@ static int put_s64(struct lwm2m_output_context *out,
 	return plain_text_put_format(out, "%lld", value);
 }
 
+static int put_time(struct lwm2m_output_context *out,
+		   struct lwm2m_obj_path *path, time_t value)
+{
+	return plain_text_put_format(out, "%lld", (int64_t)value);
+}
+
 int plain_text_put_float(struct lwm2m_output_context *out,
 			 struct lwm2m_obj_path *path, double *value)
 {
@@ -227,6 +233,17 @@ static int get_s32(struct lwm2m_input_context *in, int32_t *value)
 static int get_s64(struct lwm2m_input_context *in, int64_t *value)
 {
 	return plain_text_read_int(in, value, true);
+}
+
+static int get_time(struct lwm2m_input_context *in, time_t *value)
+{
+	int64_t temp64;
+	int ret;
+
+	ret = plain_text_read_int(in, &temp64, true);
+	*value = (time_t)temp64;
+
+	return ret;
 }
 
 static int get_string(struct lwm2m_input_context *in, uint8_t *value,
@@ -403,7 +420,7 @@ const struct lwm2m_writer plain_text_writer = {
 	.put_s64 = put_s64,
 	.put_string = put_string,
 	.put_float = plain_text_put_float,
-	.put_time = put_s64,
+	.put_time = put_time,
 	.put_bool = put_bool,
 	.put_objlnk = put_objlnk,
 };
@@ -412,7 +429,7 @@ const struct lwm2m_reader plain_text_reader = {
 	.get_s32 = get_s32,
 	.get_s64 = get_s64,
 	.get_string = get_string,
-	.get_time = get_s64,
+	.get_time = get_time,
 	.get_float = get_float,
 	.get_bool = get_bool,
 	.get_opaque = get_opaque,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
@@ -385,7 +385,7 @@ static int put_s64(struct lwm2m_output_context *out, struct lwm2m_obj_path *path
 	return put_value(out, path, value);
 }
 
-static int put_time(struct lwm2m_output_context *out, struct lwm2m_obj_path *path, int64_t value)
+static int put_time(struct lwm2m_output_context *out, struct lwm2m_obj_path *path, time_t value)
 {
 	int ret = put_name_nth_ri(out, path);
 
@@ -397,7 +397,7 @@ static int put_time(struct lwm2m_output_context *out, struct lwm2m_obj_path *pat
 
 	/* Write the value */
 	record->_record_union._record_union_choice = _union_vi;
-	record->_record_union._union_vi = value;
+	record->_record_union._union_vi = (int64_t)value;
 	record->_record_union_present = 1;
 
 	return 0;
@@ -548,6 +548,17 @@ static int get_s64(struct lwm2m_input_context *in, int64_t *value)
 	fd->current = NULL;
 
 	return 0;
+}
+
+static int get_time(struct lwm2m_input_context *in, time_t *value)
+{
+	int64_t temp64;
+	int ret;
+
+	ret = get_s64(in, &temp64);
+	*value = (time_t)temp64;
+
+	return ret;
 }
 
 static int get_float(struct lwm2m_input_context *in, double *value)
@@ -739,7 +750,7 @@ const struct lwm2m_writer senml_cbor_writer = {
 const struct lwm2m_reader senml_cbor_reader = {
 	.get_s32 = get_s32,
 	.get_s64 = get_s64,
-	.get_time = get_s64,
+	.get_time = get_time,
 	.get_string = get_string,
 	.get_float = get_float,
 	.get_bool = get_bool,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.c
@@ -791,6 +791,11 @@ static int put_s64(struct lwm2m_output_context *out, struct lwm2m_obj_path *path
 	return json_float_object_write(out, fd, len);
 }
 
+static int put_time(struct lwm2m_output_context *out, struct lwm2m_obj_path *path, time_t value)
+{
+	return put_s64(out, path, (int64_t)value);
+}
+
 static int put_string(struct lwm2m_output_context *out, struct lwm2m_obj_path *path, char *buf,
 			 size_t buflen)
 {
@@ -1053,6 +1058,17 @@ static int read_int(struct lwm2m_input_context *in, int64_t *value, bool accept_
 static int get_s64(struct lwm2m_input_context *in, int64_t *value)
 {
 	return read_int(in, value, true);
+}
+
+static int get_time(struct lwm2m_input_context *in, time_t *value)
+{
+	int64_t temp64;
+	int ret;
+
+	ret = read_int(in, &temp64, true);
+	*value = (time_t)temp64;
+
+	return ret;
 }
 
 static int get_s32(struct lwm2m_input_context *in, int32_t *value)
@@ -1357,7 +1373,7 @@ const struct lwm2m_writer senml_json_writer = {
 	.put_s32 = put_s32,
 	.put_s64 = put_s64,
 	.put_string = put_string,
-	.put_time = put_s64,
+	.put_time = put_time,
 	.put_float = put_float,
 	.put_bool = put_bool,
 	.put_opaque = put_opaque,
@@ -1369,7 +1385,7 @@ const struct lwm2m_reader senml_json_reader = {
 	.get_s32 = get_s32,
 	.get_s64 = get_s64,
 	.get_string = get_string,
-	.get_time = get_s64,
+	.get_time = get_time,
 	.get_float = get_float,
 	.get_bool = get_bool,
 	.get_opaque = get_opaque,

--- a/tests/net/lib/lwm2m/content_raw_cbor/src/main.c
+++ b/tests/net/lib/lwm2m/content_raw_cbor/src/main.c
@@ -457,7 +457,7 @@ ZTEST(net_content_raw_cbor_nomem, test_put_string_nomem)
 ZTEST(net_content_raw_cbor, test_put_time)
 {
 	int ret;
-	int64_t timestamp = 1;
+	time_t timestamp = 1;
 	struct test_payload_buffer expected_payload = {
 		.data = {
 			(0x06 << 5) | 0x00,
@@ -480,9 +480,11 @@ ZTEST(net_content_raw_cbor, test_put_time)
 
 ZTEST(net_content_raw_cbor_nomem, test_put_time_nomem)
 {
-	int ret;
+	int ret = 0;
+	time_t value = -1;
 
-	ret = cbor_writer.put_time(&test_out, &test_path, UINT64_MAX);
+	ret = cbor_writer.put_time(&test_out, &test_path, value);
+
 	zassert_equal(ret, -ENOMEM, "Invalid error code returned");
 }
 

--- a/tests/net/lib/lwm2m/content_senml_cbor/src/main.c
+++ b/tests/net/lib/lwm2m/content_senml_cbor/src/main.c
@@ -65,7 +65,7 @@ static double test_float;
 static bool test_bool;
 static struct lwm2m_objlnk test_objlnk;
 static uint8_t test_opaque[TEST_OPAQUE_MAX_SIZE];
-static int64_t test_time;
+static time_t test_time;
 
 static struct lwm2m_engine_obj_inst *test_obj_create(uint16_t obj_inst_id)
 {

--- a/tests/net/lib/lwm2m/content_senml_cbor/src/main.c
+++ b/tests/net/lib/lwm2m/content_senml_cbor/src/main.c
@@ -902,7 +902,7 @@ static void test_put_opaque_nomem(void)
 static void test_put_time(void)
 {
 	int ret;
-	int64_t value = 1170111600;
+	time_t value = 1170111600;
 	struct test_payload_buffer expected_payload = {
 		.data = {
 			(0x04 << 5) | 1,
@@ -1469,7 +1469,7 @@ static void test_get_opaque_nodata(void)
 static void test_get_time(void)
 {
 	int ret;
-	int64_t expected_value = 1170111600;
+	time_t expected_value = 1170111600;
 	struct test_payload_buffer payload = {
 		.data = {
 			(0x04 << 5) | 1,


### PR DESCRIPTION
On various locations, LwM2M engine uses 32bit timestamps to represent time.
Generic update is that resource time buffer should be time_t but we keep support still for unit32_t.

### LwM2M engine time API update

- Updated lwm2m_engine_set/get_time API for support time_t.
- Updated LwM2M engine set/get resource time to time resource support time_t and uint32_t input.
- LwM2M engine put and get time API update to use time_t.
- Time series data cache entry have own type for time resource.

### LwM2M object time resource update

Updated Timestamp resource default buffer type to time_t.
