### PR TITLE
drivers: uart: stm32 async uart driver should free next buffer

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1129,6 +1129,14 @@ static int uart_stm32_async_rx_disable(const struct device *dev)
 
 	dma_stop(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
 
+	if (data->rx_next_buffer) {
+		struct uart_event rx_next_buf_release_evt = {
+			.type = UART_RX_BUF_RELEASED,
+			.data.rx_buf.buf = data->rx_next_buffer,
+		};
+		async_user_callback(data, &rx_next_buf_release_evt);
+	}
+
 	data->rx_next_buffer = NULL;
 	data->rx_next_buffer_len = 0;
 


### PR DESCRIPTION
When disabling async rx, the next buffer is not free-ed by the stm32 uart driver.

The current buffer is being released, but the the next buffer is not.
This PR should fix this.
