### PR TITLE
doc: release: note that zephyr- tags won't be used anymore

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -20,6 +20,9 @@ API Changes
 Changes in this release
 =======================
 
+- Starting from this release ``zephyr-`` prefixed tags won't be created
+  anymore. The project will continue using ``v`` tags, for example ``v3.3.0``.
+
 Removed APIs in this release
 ============================
 


### PR DESCRIPTION
Add a note about the project not using zephyr- tags anymore.

(followup of #50918)