### PR TITLE
mgmt/mcumgr: Remove MGMT_MAX_MTU from mgmt.h

### DIFF
--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -15,9 +15,6 @@
 extern "C" {
 #endif
 
-/* MTU for newtmgr responses */
-#define MGMT_MAX_MTU		1024
-
 /** Opcodes; encoded in first byte of header. */
 #define MGMT_OP_READ		0
 #define MGMT_OP_READ_RSP	1


### PR DESCRIPTION
Not used anywhere, MTU depends on transport.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>