### PR TITLE
Rename mgmt_hdr to smp_hdr and make it internal

### DIFF
--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -206,20 +206,6 @@ void mgmt_unregister_group(struct mgmt_group *group);
 const struct mgmt_handler *mgmt_find_handler(uint16_t group_id, uint16_t command_id);
 
 /**
- * @brief Byte-swaps an mcumgr header from network to host byte order.
- *
- * @param hdr The mcumgr header to byte-swap.
- */
-void mgmt_ntoh_hdr(struct mgmt_hdr *hdr);
-
-/**
- * @brief Byte-swaps an mcumgr header from host to network byte order.
- *
- * @param hdr The mcumgr header to byte-swap.
- */
-void mgmt_hton_hdr(struct mgmt_hdr *hdr);
-
-/**
  * @brief Register event callback function.
  *
  * @param cb Callback function.

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -61,23 +61,6 @@ extern "C" {
 #define MGMT_EVT_OP_CMD_STATUS	0x02
 #define MGMT_EVT_OP_CMD_DONE	0x03
 
-struct mgmt_hdr {
-#ifdef CONFIG_LITTLE_ENDIAN
-	uint8_t  nh_op:3;		/* MGMT_OP_[...] */
-	uint8_t  _res1:5;
-#else
-	uint8_t  _res1:5;
-	uint8_t  nh_op:3;		/* MGMT_OP_[...] */
-#endif
-	uint8_t  nh_flags;		/* Reserved for future flags */
-	uint16_t nh_len;		/* Length of the payload */
-	uint16_t nh_group;		/* MGMT_GROUP_ID_[...] */
-	uint8_t  nh_seq;		/* Sequence number */
-	uint8_t  nh_id;			/* Message ID within group */
-};
-
-#define nmgr_hdr mgmt_hdr
-
 /*
  * MGMT_EVT_OP_CMD_STATUS argument
  */

--- a/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
@@ -1,13 +1,11 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/sys/slist.h>
-#include <zephyr/sys/byteorder.h>
-#include <string.h>
-
 #include "mgmt/mgmt.h"
 #include "smp/smp.h"
 
@@ -62,20 +60,6 @@ void
 mgmt_register_group(struct mgmt_group *group)
 {
 	sys_slist_append(&mgmt_group_list, &group->node);
-}
-
-void
-mgmt_ntoh_hdr(struct mgmt_hdr *hdr)
-{
-	hdr->nh_len = sys_be16_to_cpu(hdr->nh_len);
-	hdr->nh_group = sys_be16_to_cpu(hdr->nh_group);
-}
-
-void
-mgmt_hton_hdr(struct mgmt_hdr *hdr)
-{
-	hdr->nh_len = sys_cpu_to_be16(hdr->nh_len);
-	hdr->nh_group = sys_cpu_to_be16(hdr->nh_group);
 }
 
 void

--- a/subsys/mgmt/mcumgr/lib/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/lib/smp/src/smp.c
@@ -20,9 +20,7 @@
 #include "smp/smp.h"
 #include "../../../smp_internal.h"
 
-static void
-cbor_nb_reader_init(struct cbor_nb_reader *cnr,
-		    struct net_buf *nb)
+static void cbor_nb_reader_init(struct cbor_nb_reader *cnr, struct net_buf *nb)
 {
 	/* Skip the smp_hdr */
 	void *new_ptr = net_buf_pull(nb, sizeof(struct smp_hdr));
@@ -32,8 +30,7 @@ cbor_nb_reader_init(struct cbor_nb_reader *cnr,
 			       cnr->nb->len, 1);
 }
 
-static void
-cbor_nb_writer_init(struct cbor_nb_writer *cnw, struct net_buf *nb)
+static void cbor_nb_writer_init(struct cbor_nb_writer *cnw, struct net_buf *nb)
 {
 	net_buf_reset(nb);
 	cnw->nb = nb;
@@ -45,8 +42,7 @@ cbor_nb_writer_init(struct cbor_nb_writer *cnw, struct net_buf *nb)
 /**
  * Converts a request opcode to its corresponding response opcode.
  */
-static uint8_t
-smp_rsp_op(uint8_t req_op)
+static uint8_t smp_rsp_op(uint8_t req_op)
 {
 	if (req_op == MGMT_OP_READ) {
 		return MGMT_OP_READ_RSP;
@@ -132,9 +128,8 @@ static int smp_build_err_rsp(struct smp_streamer *streamer, const struct smp_hdr
  *
  * @return A MGMT_ERR_[...] error code.
  */
-static int
-smp_handle_single_payload(struct mgmt_ctxt *cbuf, const struct smp_hdr *req_hdr,
-			  bool *handler_found)
+static int smp_handle_single_payload(struct mgmt_ctxt *cbuf, const struct smp_hdr *req_hdr,
+				     bool *handler_found)
 {
 	const struct mgmt_handler *handler;
 	mgmt_handler_fn handler_fn;
@@ -189,9 +184,8 @@ smp_handle_single_payload(struct mgmt_ctxt *cbuf, const struct smp_hdr *req_hdr,
  *
  * @return A MGMT_ERR_[...] error code.
  */
-static int
-smp_handle_single_req(struct smp_streamer *streamer, const struct smp_hdr *req_hdr,
-		      bool *handler_found, const char **rsn)
+static int smp_handle_single_req(struct smp_streamer *streamer, const struct smp_hdr *req_hdr,
+				 bool *handler_found, const char **rsn)
 {
 	struct mgmt_ctxt cbuf;
 	struct smp_hdr rsp_hdr;
@@ -230,9 +224,8 @@ smp_handle_single_req(struct smp_streamer *streamer, const struct smp_hdr *req_h
  * @param rsn		The text explanation to @status encoded as "rsn" into CBOR
  *			response.
  */
-static void
-smp_on_err(struct smp_streamer *streamer, const struct smp_hdr *req_hdr,
-		   void *req, void *rsp, int status, const char *rsn)
+static void smp_on_err(struct smp_streamer *streamer, const struct smp_hdr *req_hdr,
+		       void *req, void *rsp, int status, const char *rsn)
 {
 	int rc;
 
@@ -279,8 +272,7 @@ smp_on_err(struct smp_streamer *streamer, const struct smp_hdr *req_hdr,
  *         is not enough bytes to process header, or other MGMT_ERR_[...] code on
  *         failure.
  */
-int
-smp_process_request_packet(struct smp_streamer *streamer, void *vreq)
+int smp_process_request_packet(struct smp_streamer *streamer, void *vreq)
 {
 	struct smp_hdr req_hdr;
 	struct mgmt_evt_op_cmd_done_arg cmd_done_arg;

--- a/subsys/mgmt/mcumgr/smp_internal.h
+++ b/subsys/mgmt/mcumgr/smp_internal.h
@@ -16,7 +16,7 @@
 extern "C" {
 #endif
 
-struct mgmt_hdr {
+struct smp_hdr {
 #ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t  nh_op:3;		/* MGMT_OP_[...] */
 	uint8_t  _res1:5;

--- a/subsys/mgmt/mcumgr/smp_internal.h
+++ b/subsys/mgmt/mcumgr/smp_internal.h
@@ -8,13 +8,31 @@
 #ifndef MGMT_MCUMGR_SMP_INTERNAL_H_
 #define MGMT_MCUMGR_SMP_INTERNAL_H_
 
+#include <stdint.h>
+#include <zephyr/net/buf.h>
+#include <zephyr/mgmt/mcumgr/smp.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+struct mgmt_hdr {
+#ifdef CONFIG_LITTLE_ENDIAN
+	uint8_t  nh_op:3;		/* MGMT_OP_[...] */
+	uint8_t  _res1:5;
+#else
+	uint8_t  _res1:5;
+	uint8_t  nh_op:3;		/* MGMT_OP_[...] */
+#endif
+	uint8_t  nh_flags;		/* Reserved for future flags */
+	uint16_t nh_len;		/* Length of the payload */
+	uint16_t nh_group;		/* MGMT_GROUP_ID_[...] */
+	uint8_t  nh_seq;		/* Sequence number */
+	uint8_t  nh_id;			/* Message ID within group */
+};
+
 struct smp_transport;
 struct zephyr_smp_transport;
-struct net_buf;
 
 /**
  * @brief Enqueues an incoming SMP request packet for processing.

--- a/subsys/mgmt/mcumgr/smp_reassembly.c
+++ b/subsys/mgmt/mcumgr/smp_reassembly.c
@@ -34,15 +34,15 @@ int smp_reassembly_collect(struct smp_transport *smpt, const void *buf, uint16_t
 		 * Collecting the first fragment: need to allocate buffer for it and prepare
 		 * the reassembly context.
 		 */
-		if (len >= sizeof(struct mgmt_hdr)) {
-			uint16_t expected = sys_be16_to_cpu(((struct mgmt_hdr *)buf)->nh_len);
+		if (len >= sizeof(struct smp_hdr)) {
+			uint16_t expected = sys_be16_to_cpu(((struct smp_hdr *)buf)->nh_len);
 
 			/*
 			 * The length field in the header does not count the header size,
 			 * but the reassembly does so the size needs to be added to the number of
 			 * expected bytes.
 			 */
-			expected += sizeof(struct mgmt_hdr);
+			expected += sizeof(struct smp_hdr);
 
 			/* Joining net_bufs not supported yet */
 			if (len > CONFIG_MCUMGR_BUF_SIZE || expected > CONFIG_MCUMGR_BUF_SIZE) {

--- a/tests/subsys/mgmt/mcumgr/smp_reassembly/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/smp_reassembly/src/main.c
@@ -11,6 +11,7 @@
 #include <mgmt/mgmt.h>
 #include <smp/smp.h>
 #include "../../../../../../subsys/mgmt/mcumgr/smp_reassembly.h"
+#include "../../../../../../subsys/mgmt/mcumgr/smp_internal.h"
 
 static struct smp_transport smpt;
 static uint8_t buff[CONFIG_MCUMGR_BUF_SIZE];
@@ -31,7 +32,7 @@ void smp_rx_req(struct smp_transport *smpt, struct net_buf *nb)
 ZTEST(smp_reassembly, test_first)
 {
 	smp_reassembly_init(&smpt);
-	struct mgmt_hdr *mh = (struct mgmt_hdr *)buff;
+	struct smp_hdr *mh = (struct smp_hdr *)buff;
 	int frag_used;
 	int ret;
 	int expected;
@@ -42,16 +43,16 @@ ZTEST(smp_reassembly, test_first)
 		      "Expected -ENOSR error");
 	/* Len not enough to read expected size from header */
 	zassert_equal(-ENODATA,
-		      smp_reassembly_collect(&smpt, buff, sizeof(struct mgmt_hdr) - 1),
+		      smp_reassembly_collect(&smpt, buff, sizeof(struct smp_hdr) - 1),
 		      "Expected -ENODATA error");
 	/* Length extracted from header, plus size of header, is bigger than buffer */
-	mh->nh_len = sys_cpu_to_be16(CONFIG_MCUMGR_BUF_SIZE - sizeof(struct mgmt_hdr) + 1);
+	mh->nh_len = sys_cpu_to_be16(CONFIG_MCUMGR_BUF_SIZE - sizeof(struct smp_hdr) + 1);
 	zassert_equal(-ENOSR,
-		      smp_reassembly_collect(&smpt, buff, sizeof(struct mgmt_hdr) + 1),
+		      smp_reassembly_collect(&smpt, buff, sizeof(struct smp_hdr) + 1),
 		      "Expected -ENOSR error");
 
 	/* Successfully alloc buffer */
-	mh->nh_len = sys_cpu_to_be16(TEST_FRAME_SIZE - sizeof(struct mgmt_hdr));
+	mh->nh_len = sys_cpu_to_be16(TEST_FRAME_SIZE - sizeof(struct smp_hdr));
 	frag_used = 40;
 	expected = TEST_FRAME_SIZE - frag_used;
 	ret = smp_reassembly_collect(&smpt, buff, frag_used);
@@ -78,13 +79,13 @@ ZTEST(smp_reassembly, test_first)
 
 ZTEST(smp_reassembly, test_drops)
 {
-	struct mgmt_hdr *mh = (struct mgmt_hdr *)buff;
+	struct smp_hdr *mh = (struct smp_hdr *)buff;
 	int frag_used;
 	int ret;
 	int expected;
 
 	/* Collect one buffer and drop it */
-	mh->nh_len = sys_cpu_to_be16(TEST_FRAME_SIZE - sizeof(struct mgmt_hdr));
+	mh->nh_len = sys_cpu_to_be16(TEST_FRAME_SIZE - sizeof(struct smp_hdr));
 	frag_used = 40;
 	expected = TEST_FRAME_SIZE - frag_used;
 	ret = smp_reassembly_collect(&smpt, buff, frag_used);
@@ -98,7 +99,7 @@ ZTEST(smp_reassembly, test_drops)
 
 ZTEST(smp_reassembly, test_collection)
 {
-	struct mgmt_hdr *mh = (struct mgmt_hdr *)buff;
+	struct smp_hdr *mh = (struct smp_hdr *)buff;
 	int pkt_used;
 	int ret;
 	int expected;
@@ -111,7 +112,7 @@ ZTEST(smp_reassembly, test_collection)
 
 	/** Collect fragments **/
 	/* First fragment with header */
-	mh->nh_len = sys_cpu_to_be16(TEST_FRAME_SIZE - sizeof(struct mgmt_hdr));
+	mh->nh_len = sys_cpu_to_be16(TEST_FRAME_SIZE - sizeof(struct smp_hdr));
 	frag = 40;
 	ret = smp_reassembly_collect(&smpt, buff, frag);
 	expected = TEST_FRAME_SIZE - frag;
@@ -178,7 +179,7 @@ ZTEST(smp_reassembly, test_no_packet_started)
 
 ZTEST(smp_reassembly, test_ud)
 {
-	struct mgmt_hdr *mh = (struct mgmt_hdr *)buff;
+	struct smp_hdr *mh = (struct smp_hdr *)buff;
 	int frag_used;
 	int ret;
 	int expected;
@@ -191,7 +192,7 @@ ZTEST(smp_reassembly, test_ud)
 	/* After collecting first fragment */
 	mh->nh_len = sys_cpu_to_be16(TEST_FRAME_SIZE);
 	frag_used = 40;
-	expected = TEST_FRAME_SIZE - frag_used + sizeof(struct mgmt_hdr);
+	expected = TEST_FRAME_SIZE - frag_used + sizeof(struct smp_hdr);
 	ret = smp_reassembly_collect(&smpt, buff, frag_used);
 	zassert_equal(expected, ret,
 		      "Expected is %d should be %d\n", ret, expected);


### PR DESCRIPTION
Only SMP protocol layer, with exception to SMP reassembly which is part of transport layer, is supposed to be processing packets, so it has to know how does the header looks like.
The mgmt_hdr is actually SMP protocol header, as described here https://docs.zephyrproject.org/latest/services/device_mgmt/smp_protocol.html#frame-the-envelope, and the name is a little bit misleading as mgmt layer of MCUmgr does not process it.

This PR:
 1) ~moves `mgmt_hton_hdr` and `mgmt_ntoh_hdr` functions to smp,c and renames them `smp_hdr_hton` and `smp_hdr_ntoh` respectively~; removes `mgmt_hton_hdr` and `mgmt_ntoh_hdr`.
 2) moves `mgmt_hdr` definition to smp_internal.h, making it internal
 3) redefines `mgmt_hdr` as `smp_hdr`
 4) fixes tests.
 5) unifies function definition style in smp.c

~~Depends on https://github.com/zephyrproject-rtos/zephyr/pull/50602~~