### PR TITLE
soc: intel_adsp/ace: clear daipctda.busy in idc isr

### DIFF
--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -16,7 +16,8 @@
 
 static void ipc_isr(void *arg)
 {
-	IDC[arch_proc_id()].agents[0].ipc.tdr = BIT(31); /* clear BUSY bit */
+	IDC[arch_proc_id()].agents[0].ipc.tdr = BIT(31); /* clear interrupt source */
+	IDC[arch_proc_id()].agents[0].ipc.tda = 0; /* clear BUSY bit */
 #ifdef CONFIG_SMP
 	void z_sched_ipi(void);
 	z_sched_ipi();


### PR DESCRIPTION
Current implementation of IDC ISR was only clearing interrupt, but did not clear BUSY bit properly. In result, next IDC calls were not triggering interrupt on secondary cores.
This PR adds clearing TDA.BUSY bit accordingly to ACE1.x documentation.
With this change I am able to run multicore scenario and IDC works properly. Without this change, IDC communication stuck.