### PR TITLE
Bluetooth: Mesh: Convert model_ackd_send and model_send to a common API

### DIFF
--- a/include/zephyr/bluetooth/mesh/msg.h
+++ b/include/zephyr/bluetooth/mesh/msg.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+struct bt_mesh_model;
+
 /** Length of a short Mesh MIC. */
 #define BT_MESH_MIC_SHORT 4
 /** Length of a long Mesh MIC. */

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -539,8 +539,8 @@ void bt_mesh_msg_cb_set(void (*cb)(uint32_t opcode, struct bt_mesh_msg_ctx *ctx,
 }
 #endif
 
-int bt_mesh_msg_send(struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf, uint16_t src_addr,
-		const struct bt_mesh_send_cb *cb, void *cb_data)
+int bt_mesh_access_send(struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf, uint16_t src_addr,
+			const struct bt_mesh_send_cb *cb, void *cb_data)
 {
 	struct bt_mesh_net_tx tx = {
 		.ctx = ctx,
@@ -746,7 +746,7 @@ int bt_mesh_model_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		return -EINVAL;
 	}
 
-	return bt_mesh_msg_send(ctx, msg, bt_mesh_model_elem(model)->addr, cb, cb_data);
+	return bt_mesh_access_send(ctx, msg, bt_mesh_model_elem(model)->addr, cb, cb_data);
 }
 
 int bt_mesh_model_publish(struct bt_mesh_model *model)

--- a/subsys/bluetooth/mesh/access.h
+++ b/subsys/bluetooth/mesh/access.h
@@ -74,5 +74,5 @@ void bt_mesh_msg_cb_set(void (*cb)(uint32_t opcode, struct bt_mesh_msg_ctx *ctx,
  *
  * @return 0 on success or negative error code on failure.
  */
-int bt_mesh_msg_send(struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf, uint16_t src_addr,
-		     const struct bt_mesh_send_cb *cb, void *cb_data);
+int bt_mesh_access_send(struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf, uint16_t src_addr,
+			const struct bt_mesh_send_cb *cb, void *cb_data);

--- a/subsys/bluetooth/mesh/msg.h
+++ b/subsys/bluetooth/mesh/msg.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @brief Send a model message.
+ *
+ * Sends a model message with the given context. If the message context is NULL, this
+ * updates the publish message, and publishes with the configured publication parameters.
+ *
+ * @param model Model to send the message on.
+ * @param ctx Message context, or NULL to send with the configured publish parameters.
+ * @param buf Message to send.
+ *
+ * @retval 0 The message was sent successfully.
+ * @retval -ENOTSUP A message context was not provided and publishing is not supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_msg_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		     struct net_buf_simple *buf);
+
+/**
+ * Message response context.
+ */
+struct bt_mesh_msg_rsp_ctx {
+	struct bt_mesh_msg_ack_ctx *ack;       /**< Acknowledged message context. */
+	uint32_t                    op;        /**< Opcode we're waiting for. */
+	void                       *user_data; /**< User specific parameter. */
+	int32_t                     timeout;   /**< Response timeout in milliseconds. */
+};
+
+/** @brief Send an acknowledged model message.
+ *
+ * Sends a model message with the given context. If the message context is NULL, this
+ * updates the publish message, and publishes with the configured publication parameters.
+ *
+ * If a response context is provided, the call blocks for the time specified in
+ * the response context, or until @ref bt_mesh_msg_ack_ctx_rx is called.
+ *
+ * @param model Model to send the message on.
+ * @param ctx Message context, or NULL to send with the configured publish parameters.
+ * @param buf Message to send.
+ * @param rsp Message response context, or NULL if no response is expected.
+ *
+ * @retval 0 The message was sent successfully.
+ * @retval -EBUSY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_msg_ackd_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf, const struct bt_mesh_msg_rsp_ctx *rsp);


### PR DESCRIPTION
Convert model_ackd_send and model_send from health_cli.c to a common API to get rid of code duplication in other client models that implement synchronous messages' sending.