### PR TITLE
drivers: sdhc: have sdhc-spi-slot declare an sd bus

### DIFF
--- a/dts/bindings/sdhc/zephyr,sdhc-spi-slot.yaml
+++ b/dts/bindings/sdhc/zephyr,sdhc-spi-slot.yaml
@@ -3,3 +3,5 @@ description: Generic Zephyr SPI based SDHC controller
 compatible: "zephyr,sdhc-spi-slot"
 
 include: [spi-device.yaml]
+
+bus: sd


### PR DESCRIPTION
The vscode extension, at least, complains if you try to put a `zephyr,sdmmc-disk` node under a `zephyr,sdhc-spi-slot` node because the latter does not declare an sd bus.

I do not know why this doesn't cause test failures.