### PR TITLE
west: runners: blackmagicprobe: fix on windows

### DIFF
--- a/scripts/west_commands/runners/blackmagicprobe.py
+++ b/scripts/west_commands/runners/blackmagicprobe.py
@@ -6,6 +6,7 @@
 # https://github.com/blacksphere/blackmagic/wiki
 
 import signal
+from pathlib import Path
 
 from runners.core import ZephyrBinaryRunner, RunnerCaps
 
@@ -15,7 +16,11 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
     def __init__(self, cfg, gdb_serial, connect_srst=False):
         super().__init__(cfg)
         self.gdb = [cfg.gdb] if cfg.gdb else None
-        self.elf_file = cfg.elf_file
+        # as_posix() because gdb doesn't recognize backslashes as path
+        # separators for the 'load' command we execute in bmp_flash().
+        #
+        # https://github.com/zephyrproject-rtos/zephyr/issues/50789
+        self.elf_file = Path(cfg.elf_file).as_posix()
         self.gdb_serial = gdb_serial
         if connect_srst:
             self.connect_srst_enable_arg = [


### PR DESCRIPTION
We need to give gdb slash-separated paths to ELF files on Windows. Just make sure we always have slash-separated paths. We use this technique in various places around the tree.

Fixes: #50789
Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>