### PR TITLE
twister: Add 'fail-on-skip' argument

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -309,6 +309,10 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
     parser.add_argument("--enable-size-report", action="store_true",
                         help="Enable expensive computation of RAM/ROM segment sizes.")
 
+
+    parser.add_argument("--fail-on-skip", action="store_true",
+        help="twister returns failure when tests are marked skipped")
+
     parser.add_argument(
         "--filter", choices=['buildable', 'runnable'],
         default='buildable',

--- a/scripts/twister
+++ b/scripts/twister
@@ -398,7 +398,13 @@ def main():
                        )
 
     logger.info("Run completed")
-    if runner.results.failed or runner.results.error or (tplan.warnings and options.warnings_as_errors):
+
+    if (
+        runner.results.failed
+        or runner.results.error
+        or (tplan.warnings and options.warnings_as_errors)
+        or (options.fail_on_skip and runner.results.skipped_tests > 0)
+    ):
         return 1
 
     return 0


### PR DESCRIPTION
When any tests are skipped with reason 'ztest skip' and fail-on-skip is specified, twister will return failure.

Signed-off-by: Al Semjonovs <asemjonovs@google.com>