### PR TITLE
soc: nxp: Fix the clock setup for RT595

### DIFF
--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -195,7 +195,7 @@ void z_arm_platform_init(void)
 	SystemInit();
 }
 
-void clock_init(void)
+static void clock_init(void)
 {
 	/* Configure LPOSC 1M */
 	/* Power on LPOSC (1MHz) */
@@ -242,9 +242,6 @@ void clock_init(void)
 	CLOCK_InitAudioPll(&g_audioPllConfig_clock_init);
 	/* Enable Audio PLL clock */
 	CLOCK_InitAudioPfd(kCLOCK_Pfd0, 26);
-
-	/* Set MAINPLLCLKDIV divider to value 5 */
-	CLOCK_SetClkDiv(kCLOCK_DivMainPllClk, 5U);
 
 	/* Set SYSCPUAHBCLKDIV divider to value 2 */
 	CLOCK_SetClkDiv(kCLOCK_DivSysCpuAhbClk, 2U);
@@ -321,7 +318,6 @@ void clock_init(void)
  *
  * @return 0
  */
-
 static int nxp_rt500_init(const struct device *arg)
 {
 	ARG_UNUSED(arg);


### PR DESCRIPTION
The core clock was incorrectly divided down