### PR TITLE
drivers: timer: use sys_read64 to read HPET counter on 64 bits cpu

### DIFF
--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -97,6 +97,11 @@ const int32_t z_sys_timer_irq_for_test = DT_IRQN(DT_INST(0, intel_hpet));
  */
 static inline uint64_t hpet_counter_get(void)
 {
+#ifdef CONFIG_64BIT
+	uint64_t val = sys_read64(MAIN_COUNTER_LOW_REG);
+
+	return val;
+#else
 	uint32_t high;
 	uint32_t low;
 
@@ -106,6 +111,7 @@ static inline uint64_t hpet_counter_get(void)
 	} while (high != sys_read32(MAIN_COUNTER_HIGH_REG));
 
 	return ((uint64_t)high << 32) | low;
+#endif
 }
 
 /**

--- a/tests/kernel/timer/timer_behavior/src/main.c
+++ b/tests/kernel/timer/timer_behavior/src/main.c
@@ -64,6 +64,9 @@ ZTEST(timer_behavior, test_periodic_behavior)
 
 	k_timer_init(&periodic_timer, periodic_fn, NULL);
 
+	/* Tick align */
+	k_usleep(1);
+
 #ifdef CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
 	periodic_start = k_cycle_get_64();
 #else


### PR DESCRIPTION
drivers: timer: use sys_read64 to read HPET counter on 64 bits cpu

For 32 bit processor to read the 64 bits hpet counter, the HPET spec
2.4.7 suggest to read HPET counter high and low then checking the
high bits to decide if it rollovers or not.

But this logic seems to cause problem for 64 bits processor under SMP,
there is a possible one tick earlier under tickless mode. It is likely
to be the cache coherence issue, because a mfence instruction before
reading the timer works.

So we change to read the 64 bits counter by sys_read64 on 64bit
processor to prevent this issue.


Also add a tick align before running the timer behavior test.

Fixes #49611 

