### PR TITLE
logging: workaround hard fault on Cortex-M0 with sys-t/catalog.

### DIFF
--- a/subsys/logging/CMakeLists.txt
+++ b/subsys/logging/CMakeLists.txt
@@ -47,12 +47,17 @@ if(NOT CONFIG_LOG_MODE_MINIMAL)
     log_output_dict.c
   )
 
+  add_subdirectory(backends)
+
+  # For some reason, running sys-t with catalog message on
+  # Cortex-M0 would result in hard fault in mipi_catalog_formatter()
+  # if this is complied before the backends (only with SIZE
+  # optimization). Workaround the issue by placing it here instead
+  # as this is causing CI failures. Actual root-cause is TBD.
   zephyr_sources_ifdef(
     CONFIG_LOG_MIPI_SYST_ENABLE
     log_output_syst.c
   )
-
-  add_subdirectory(backends)
 
   if(CONFIG_LOG_CUSTOM_FORMAT_SUPPORT)
     zephyr_sources(log_output_custom.c)


### PR DESCRIPTION
For some reason, running sys-t with catalog message on Cortex-M0 would result in hard fault in mipi_catalog_formatter() if log_output_syst.c is complied before the backends (and weird enough, only with SIZE optimization). This new ordering was introduced in commit f5587552bb88fe6e57f3be1b30b8fb93fd3e0c32 as it was to group all backend source files under a single directory.

Workaround the issue by compiling file later after backends as this issue is causing CI failures. Actual root-cause is TBD.

Relates #50941

Signed-off-by: Daniel Leung <daniel.leung@intel.com>