### PR TITLE
doc: build: kconfig: subtlety of multiple defs without deps

### DIFF
--- a/doc/build/kconfig/setting.rst
+++ b/doc/build/kconfig/setting.rst
@@ -259,9 +259,24 @@ symbol properties, so the above ``default`` is equivalent to
       	...
       	depends on DEP2
 
+   Symbols without any listed dependencies are treated as having a dependency
+   on the "y" symbol, which is always set. Applying the ORing rule results in
+   the definitions below resolving to a symbol with no dependencies. If ``BAR``
+   is set, ``FOO`` will be enabled regardless of the value of ``DEP1``.
+
+   .. code-block:: none
+
+      config FOO
+      	...
+      	depends on DEP1
+
+      config FOO
+      	...
+      	default y if BAR
+
    When making changes to :file:`Kconfig.defconfig` files, always check the
    symbol's direct dependencies in one of the :ref:`interactive configuration
-   interfaces <menuconfig>` afterwards. It is often necessary to repeat
+   interfaces <menuconfig>` afterwards. It is **required** to repeat
    dependencies from the base definition of the symbol to avoid weakening a
    symbol's dependencies.
 

--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -4751,10 +4751,15 @@ class Symbol(object):
         defined in multiple locations will return a string with all
         definitions.
 
+        Symbols without menu nodes return the repr() result.
+
         The returned string does not end in a newline. An empty string is
         returned for undefined and constant symbols.
         """
-        return self.custom_str(standard_sc_expr_str)
+        if len(self.nodes) == 0:
+            return repr(self)
+        else:
+            return self.custom_str(standard_sc_expr_str)
 
     def custom_str(self, sc_expr_str_fn):
         """


### PR DESCRIPTION
Document a subtlety of the "Dependencies of multiple symbol definitions are ORed together" behaviour when applied to nodes without any explicit `depends on X` listed.

This behaviour can be tested by adding the following to `Kconfig.zephyr` and adding `CONFIG_A=y` to any `prj.conf`.
```
config A
    bool "Test Symbol A"

config B
    bool "Test Symbol B"

config TEST_SYMBOL
    bool "Test symbol"
    depends on B

config TEST_SYMBOL
    default y if A
```
`CONFIG_TEST_SYMBOL` will be enabled despite `CONFIG_B` being disabled.