### PR TITLE
net: shell: Adding network DHCP shell commands: start, stop and restart

### DIFF
--- a/doc/connectivity/networking/api/net_shell.rst
+++ b/doc/connectivity/networking/api/net_shell.rst
@@ -43,3 +43,5 @@ The following net-shell commands are implemented:
    :kconfig:option:`CONFIG_NET_TCP` is set."
    "net vlan", "Show Ethernet virtual LAN information. Only available if
    :kconfig:option:`CONFIG_NET_VLAN` is set."
+   "net dhcp4", "Show DHCPv4 information. Only available if
+   :kconfig:option:`CONFIG_NET_DHCPV4` is set."


### PR DESCRIPTION
Hello

I've added some features that I think it would be nice to have in the shell environment like to start, stop and restart the DHCP client in the operating system.

If you enable the DHCP and autoconfiguration in the Kconfig but the DHCP client doesn't start automatically.

This feature enables to control manually the DHCPv4 client by issuing some commands to the network shell.

Syntax:

net dhcp4 start [index]
net dhcp4 stop [index]
net dhcp4 restart [index]

Where [index] is the network interface index. When no interface is supplied in the command line arguments, the shell choose the default network interface and try to start/stop or restart the dhcp to that interface.

Currently there is no support to DHCP for IPv6, so no command were added to accomplish with this use case, maybe in the future we could control the client on both protocols.

Best regards

Arthur Farias