### PR TITLE
wifi: esp32: fix compilation error if eth stats unset

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -15,7 +15,9 @@ LOG_MODULE_REGISTER(esp32_wifi, CONFIG_WIFI_LOG_LEVEL);
 #include <zephyr/net/wifi_mgmt.h>
 #include <zephyr/device.h>
 #include <soc.h>
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
 #include <ethernet/eth_stats.h>
+#endif
 #include "esp_networking_priv.h"
 #include "esp_private/wifi.h"
 #include "esp_event.h"


### PR DESCRIPTION
Dear maintainers,

I went through this compilation error when I was trying to enable Wi-Fi on my ESP32 to run the wifi shell sample.

Regards,
Gaël

---

The driver intends to make the ethernet stats optional, but it does not guard the header eth_stats if CONFIG_NET_STATISTICS_ETHERNET is unset.

Fixes (if CONFIG_NET_STATISTICS_ETHERNET=n):

	/zephyr/drivers/wifi/esp32/src/esp_wifi_drv.c:18:10: fatal error: ethernet/eth_stats.h: No such file or directory
	   18 | #include <ethernet/eth_stats.h>
	      |          ^~~~~~~~~~~~~~~~~~~~~~
	compilation terminated.

Signed-off-by: Gaël PORTAY <gael.portay@gmail.com>