### PR TITLE
boards: arm: olimex_lora_stm32wl_devkit: fix typo

### DIFF
--- a/boards/arm/olimex_lora_stm32wl_devkit/doc/olimex_lora_stm32wl_devkit.rst
+++ b/boards/arm/olimex_lora_stm32wl_devkit/doc/olimex_lora_stm32wl_devkit.rst
@@ -23,7 +23,7 @@ The board has below hardware features:
 - BB-STM32WL, 256KB Flash, 64KB RAM with external antenna
 - Lithium battery connector 3V (does not include battery)
 - UEXT connector for external sensors
-- BMA280 temperature, humidity, pressure sensor
+- BME280 temperature, humidity, pressure sensor
 - LDR resistor for lighting measurement
 - IIS2MDCTR 3-axis magnetometer for smart parking
 - GPIO connector for prototyping


### PR DESCRIPTION
Hello maintainers,

I found this trivial typo while I was looking for boards embedding a BME280 sensor.

Regards,
Gaël

---
The board embeds a Bosch BME280 temperature, humidity, pressure sensor[1].

[1]: https://www.olimex.com/Products/IoT/LoRa/LoRa-STM32WL-DevKit/open-source-hardware

Signed-off-by: Gaël PORTAY <gael.portay@gmail.com>