### PR TITLE
10-bit addressing not supported by I2C slave driver for STM32 target #51060

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -504,12 +504,13 @@ int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config
 
 	LL_I2C_Enable(i2c);
 
-	LL_I2C_SetOwnAddress1(i2c, config->address << 1,
-			      LL_I2C_OWNADDRESS1_7BIT);
-
+	if (data->slave_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
+		return -ENOTSUP;
+	}
+	LL_I2C_SetOwnAddress1(i2c, config->address << 1U, LL_I2C_OWNADDRESS1_7BIT);
 	data->slave_attached = true;
 
-	LOG_DBG("i2c: slave registered");
+	LOG_DBG("i2c: target registered");
 
 	stm32_i2c_enable_transfer_interrupts(dev);
 	LL_I2C_AcknowledgeNextData(i2c, LL_I2C_ACK);

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -224,19 +224,27 @@ int i2c_stm32_target_register(const struct device *dev,
 
 	if (!data->slave_cfg) {
 		data->slave_cfg = config;
+		if (data->slave_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
+			LL_I2C_SetOwnAddress1(i2c, config->address, LL_I2C_OWNADDRESS1_10BIT);
+			LOG_DBG("i2c: target #1 registered with 10-bit address");
+		} else {
+			LL_I2C_SetOwnAddress1(i2c, config->address << 1U, LL_I2C_OWNADDRESS1_7BIT);
+			LOG_DBG("i2c: target #1 registered with 7-bit address");
+		}
 
-		LL_I2C_SetOwnAddress1(i2c, config->address << 1U,
-				      LL_I2C_OWNADDRESS1_7BIT);
 		LL_I2C_EnableOwnAddress1(i2c);
 
-		LOG_DBG("i2c: slave #1 registered");
+		LOG_DBG("i2c: target #1 registered");
 	} else {
 		data->slave2_cfg = config;
 
+		if (data->slave2_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
+			return -EINVAL;
+		}
 		LL_I2C_SetOwnAddress2(i2c, config->address << 1U,
 				      LL_I2C_OWNADDRESS2_NOMASK);
 		LL_I2C_EnableOwnAddress2(i2c);
-		LOG_DBG("i2c: slave #2 registered");
+		LOG_DBG("i2c: target #2 registered");
 	}
 
 	data->slave_attached = true;


### PR DESCRIPTION
I2C: Add 10-bit addressing support for I2C slave driver for STM32 target.
	This patch adds changes that will help to register STM32 target as a slave with 10-bit addressing enabled