### PR TITLE
tests: semaphore: exclude it on intel_adsp

### DIFF
--- a/tests/kernel/semaphore/semaphore/testcase.yaml
+++ b/tests/kernel/semaphore/semaphore/testcase.yaml
@@ -1,3 +1,7 @@
+common:
+  platform_type:
+    - mcu
+    - native
 tests:
   kernel.semaphore:
     tags: kernel userspace ignore_faults


### PR DESCRIPTION
Because it failed due to the simulator speed doesn't meet
the new ztest fx requirement, it is not a real bug and it 
will pass when the test is given enough time. So we exclude it.

Signed-off-by: Zhao Shuai <shuai1x.zhao@intel.com>