### PR TITLE
samples: drivers: watchdog stm32 wwdg for some boards

### DIFF
--- a/samples/drivers/watchdog/boards/stm32f3_disco.overlay
+++ b/samples/drivers/watchdog/boards/stm32f3_disco.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2021 Thomas Stranger
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&rcc {
+	apb1-prescaler = <8>;
+};

--- a/samples/drivers/watchdog/boards/stm32h7_wwdg.overlay
+++ b/samples/drivers/watchdog/boards/stm32h7_wwdg.overlay
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Thomas Stranger
+ * Copyright (c) 2022 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,7 +12,7 @@
 };
 
 &rcc {
-	apb1-prescaler = <16>;
+	d2ppre1 = <16>;
 };
 
 &wwdg {

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -19,8 +19,12 @@ tests:
     extra_args: DTC_OVERLAY_FILE=boards/stm32_wwdg.overlay
     filter: dt_compat_enabled("st,stm32-window-watchdog")
     platform_allow: b_u585i_iot02a nucleo_f091rc nucleo_f103rb nucleo_f207zg nucleo_f429zi
-        nucleo_f746zg nucleo_g071rb nucleo_g474re nucleo_h743zi nucleo_l073rz nucleo_l152re
+        nucleo_f746zg nucleo_g071rb nucleo_g474re nucleo_l073rz nucleo_l152re
         nucleo_wb55rg nucleo_wl55jc stm32f3_disco stm32l562e_dk disco_l475_iot1
+  sample.drivers.watchdog.stm32h7_wwdg:
+    extra_args: DTC_OVERLAY_FILE=boards/stm32h7_wwdg.overlay
+    filter: dt_compat_enabled("st,stm32-window-watchdog")
+    platform_allow: nucleo_h743zi
   sample.drivers.watchdog.stm32_iwdg:
     extra_args: DTC_OVERLAY_FILE=boards/stm32_iwdg.overlay
     filter: dt_compat_enabled("st,stm32-watchdog")


### PR DESCRIPTION
The WWDG peripheral needs to set a APB1 prescaler  for running  the sample.drivers.watchdog.stm32_wwdg testcase. 
This is done with `apb1-prescaler = <16>; ` by the rcc clock config for all the stm32 platforms in the in the **stm32_wwdg.overlay** 

For stm32h7 serie, the apb1 bus clock is named d2ppre1
There is a specific test case sample.drivers.watchdog.stm32h7_wwdg and overlay **stm32h7_wwdg.overlay** for this serie.

With this, the samples/drivers/watchdog/ PASSED:

```
Watchdog sample application
Attempting to test pre-reset callback
Feeding watchdog 5 times
Feeding watchdog...

Waiting for reset...
*** Booting Zephyr OS build zephyr-v3.2.0-271-gb392c3b8e412  ***
Watchdog sample application
```


Signed-off-by: Francois Ramu <francois.ramu@st.com>