### PR TITLE
net: net_pkt: Allow compilation with custom IEEE 802.15.4 based L2

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -55,7 +55,9 @@ LOG_MODULE_REGISTER(net_pkt, CONFIG_NET_PKT_LOG_LEVEL);
  */
 #define MAX_IP_PROTO_LEN 8
 #else
-#if defined(CONFIG_NET_ETHERNET_BRIDGE) || defined(CONFIG_NET_L2_IEEE802154)
+#if defined(CONFIG_NET_ETHERNET_BRIDGE) || \
+	defined(CONFIG_NET_L2_IEEE802154) || \
+	defined(CONFIG_NET_L2_CUSTOM_IEEE802154)
 #define MAX_IP_PROTO_LEN 0
 #else
 #error "Some packet protocol (e.g. IPv6, IPv4, ETH, IEEE 802.15.4) needs to be selected."


### PR DESCRIPTION
This is a follow up to commit bb86f8b967b2a7277379b87f8959c7ddd11c8402.

Also custom IEEE 802.15.4 based L2 implementations may need to use packet handling without the IP layer. Add support for such cases.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>