### PR TITLE
Bluetooth: host: df: fix wrong connectionless CTE enable cmd length

### DIFF
--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -324,7 +324,7 @@ prepare_cl_cte_rx_enable_cmd_params(struct net_buf **buf, struct bt_le_per_adv_s
 		}
 
 		cp->switch_pattern_len = switch_pattern_len;
-		dest_ant_ids = net_buf_add(*buf, params->num_ant_ids);
+		dest_ant_ids = net_buf_add(*buf, cp->switch_pattern_len);
 		memcpy(dest_ant_ids, ant_ids, cp->switch_pattern_len);
 	}
 


### PR DESCRIPTION
There were a bug in a `prepare_cl_cte_rx_enable_cmd_params` function. The size of command buffer was wrong when CTE enabled in AoD mode. The command buffer was extended by `param->num_ant_ids`, that was zero in case of AoD. Then a dummy antenna switch pattern was copied into the command buffer.

That lead to: memory overwrite, and wrong command buffer length. The command was rejected by Controller.

To fix, use `cp->switch_pattern_len` that was already assigned with correct antenna pattern length.

Fixes: #51126

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>