### PR TITLE
doc: Fix kernel data structures typos

### DIFF
--- a/doc/kernel/data_structures/mpsc_pbuf.rst
+++ b/doc/kernel/data_structures/mpsc_pbuf.rst
@@ -17,7 +17,7 @@ A :dfn:`MPSC Packet Buffer` has the following key properties:
 
 * Allocate, commit scheme used for packet producing.
 * Claim, free scheme used for packet consuming.
-* Allocator ensures that continue memory of requested length is allocated.
+* Allocator ensures that contiguous memory of requested length is allocated.
 * Following policies can be applied when requested space cannot be allocated:
 
   * **Overwrite** - oldest entries are dropped until requested amount of memory can

--- a/doc/kernel/data_structures/rbtree.rst
+++ b/doc/kernel/data_structures/rbtree.rst
@@ -18,7 +18,7 @@ required.
 Unlike a list, where position is explicit, the ordering of nodes
 within an rbtree must be provided as a predicate function by the user.
 A function of type :c:func:`rb_lessthan_t` should be assigned to the
-``lessthan_fn`` field of the :c:struct`rbtree` struct before any tree
+``lessthan_fn`` field of the :c:struct:`rbtree` struct before any tree
 operations are attempted.  This function should, as its name suggests,
 return a boolean True value if the first node argument is "less than"
 the second in the ordering desired by the tree.  Note that "equal" is

--- a/doc/kernel/data_structures/ring_buffers.rst
+++ b/doc/kernel/data_structures/ring_buffers.rst
@@ -154,7 +154,7 @@ its contents are copied to the data buffer, along with its associated metadata
 values (which occupy one additional 32-bit word). If the ring buffer has
 insufficient space to hold the new data item the enqueue operation fails.
 
-A data items is **dequeued** (:c:func:`ring_buf_item_get`) from a ring
+A data item is **dequeued** (:c:func:`ring_buf_item_get`) from a ring
 buffer by removing the oldest enqueued item. The contents of the dequeued data
 item, as well as its two metadata values, are copied to areas supplied by the
 retriever. If the ring buffer is empty, or if the data array supplied by the
@@ -200,7 +200,7 @@ Defining a Ring Buffer
 
 A ring buffer is defined using a variable of type :c:type:`ring_buf`.
 It must then be initialized by calling :c:func:`ring_buf_init` or
-c:func:`ring_buf_item_init`.
+:c:func:`ring_buf_item_init`.
 
 The following code defines and initializes an empty **data item mode** ring
 buffer (which is part of a larger data structure). The ring buffer's data buffer


### PR DESCRIPTION
Add missing colons to properly render C references.

Signed-off-by: Tomasz Moń <tomasz.mon@nordicsemi.no>