### PR TITLE
posix: Kconfig for timer_create wait time

### DIFF
--- a/lib/posix/Kconfig
+++ b/lib/posix/Kconfig
@@ -65,6 +65,14 @@ config MAX_TIMER_COUNT
 	help
 	  Mention maximum number of timers in POSIX compliant application.
 
+config TIMER_CREATE_WAIT
+	int "Time to wait for timer availability (in msec) in POSIX application"
+	default 100
+	range 0 1000
+	help
+	  This controls how long to wait for resources to come available to create
+	  a new timer in POSIX compliant application
+
 config POSIX_MQUEUE
 	bool "POSIX message queue"
 	default y if POSIX_API

--- a/lib/posix/timer.c
+++ b/lib/posix/timer.c
@@ -50,6 +50,7 @@ static void zephyr_timer_wrapper(struct k_timer *ztimer)
 int timer_create(clockid_t clockid, struct sigevent *evp, timer_t *timerid)
 {
 	struct timer_obj *timer;
+	const k_timeout_t alloc_timeout = K_MSEC(CONFIG_TIMER_CREATE_WAIT);
 
 	if (clockid != CLOCK_MONOTONIC || evp == NULL ||
 	    (evp->sigev_notify != SIGEV_NONE &&
@@ -58,7 +59,7 @@ int timer_create(clockid_t clockid, struct sigevent *evp, timer_t *timerid)
 		return -1;
 	}
 
-	if (k_mem_slab_alloc(&posix_timer_slab, (void **)&timer, K_MSEC(100)) == 0) {
+	if (k_mem_slab_alloc(&posix_timer_slab, (void **)&timer, alloc_timeout) == 0) {
 		(void)memset(timer, 0, sizeof(struct timer_obj));
 	} else {
 		errno = ENOMEM;


### PR DESCRIPTION
should be able to configure the time spent waiting for available resources when calling timer_create() to not cause a hiccup in applications that require faster response times than the original hard-coded 100 ms.

Signed-off-by: Nicholas Lowell <nlowell@lexmark.com>