### PR TITLE
wifi: shell: rework usage

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -439,7 +439,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 		  "<PSK (optional: valid only for secure SSIDs)>\n"
 		  "<Security type (optional: valid only for secure SSIDs)>\n"
 		  "0:None, 1:PSK, 2:PSK-256, 3:SAE\n"
-		  "<MFP (optional): 0:Disable, 1:Optional, 2:Required",
+		  "<MFP (optional): 0:Disable, 1:Optional, 2:Required>",
 		  cmd_wifi_connect),
 	SHELL_CMD(disconnect, NULL, "Disconnect from the Wi-Fi AP",
 		  cmd_wifi_disconnect),

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -433,7 +433,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_cmd_ap,
 
 SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 	SHELL_CMD(connect, NULL,
-		  "Connect to a Wi-Fi AP"
+		  "Connect to a Wi-Fi AP\n"
 		  "\"<SSID>\"\n<channel number (optional), "
 		  "0 means all>\n"
 		  "<PSK (optional: valid only for secure SSIDs)>\n"

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -434,8 +434,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_cmd_ap,
 SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 	SHELL_CMD(connect, NULL,
 		  "Connect to a Wi-Fi AP\n"
-		  "\"<SSID>\"\n<channel number (optional), "
-		  "0 means all>\n"
+		  "\"<SSID>\"\n"
+		  "<channel number (optional), 0 means all>\n"
 		  "<PSK (optional: valid only for secure SSIDs)>\n"
 		  "<Security type (optional: valid only for secure SSIDs)>\n"
 		  "0:None, 1:PSK, 2:PSK-256, 3:SAE\n"

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -437,8 +437,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 		  "\"<SSID>\"\n"
 		  "<channel number (optional), 0 means all>\n"
 		  "<PSK (optional: valid only for secure SSIDs)>\n"
-		  "<Security type (optional: valid only for secure SSIDs)>\n"
-		  "0:None, 1:PSK, 2:PSK-256, 3:SAE\n"
+		  "<Security type (optional: valid only for secure SSIDs) "
+		  "0:None, 1:PSK, 2:PSK-256, 3:SAE>\n"
 		  "<MFP (optional): 0:Disable, 1:Optional, 2:Required>",
 		  cmd_wifi_connect),
 	SHELL_CMD(disconnect, NULL, "Disconnect from the Wi-Fi AP",


### PR DESCRIPTION
Dear Maintainers,

Those are  trivial changes to fix the usage for the Wi-Fi connect command and to re indent the parameters to make it more readable (one line per new parameters).

Regards,
Gaël