### PR TITLE
Revert "twister: temporarily disable mec15xx boards"

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -554,9 +554,7 @@ class TestPlan:
 
         toolchain = self.env.toolchain
         platform_filter = self.options.platform
-        # temporary workaround for exclusion of boards. setting twister in
-        # board yaml file to False does not really work. Need a better solution for the future.
-        exclude_platform = ['mec15xxevb_assy6853','mec1501modular_assy6885'] + self.options.exclude_platform
+        exclude_platform = self.options.exclude_platform
         testsuite_filter = self.run_individual_testsuite
         arch_filter = self.options.arch
         tag_filter = self.options.tag


### PR DESCRIPTION
This reverts commit b3ead37efaa55e20bb66e0920211c68a4bcf74c2.

This is no longer needed, pinmux was removed and deprecated.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
