### PR TITLE
Devicetree: edtlib: fix possible AttributeError in Property.description

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1610,8 +1610,8 @@ class Property:
       Convenience for spec.name.
 
     description:
-      Convenience for spec.name with leading and trailing whitespace
-      (including newlines) removed.
+      Convenience for spec.description with leading and trailing whitespace
+      (including newlines) removed. May be None.
 
     type:
       Convenience for spec.type.
@@ -1655,7 +1655,7 @@ class Property:
     @property
     def description(self):
         "See the class docstring"
-        return self.spec.description.strip()
+        return self.spec.description.strip() if self.spec.description else None
 
     @property
     def type(self):


### PR DESCRIPTION
Attempting to access the Python property `Property.description` when `Property.spec.description` is `None` would raise:

```
AttributeError: 'NoneType' object has no attribute 'strip'.
```

Known DT properties that may not have a description (`Property.spec.description` is `None`):

- `compatible` for nodes such as `/`, `/soc`, `/soc/timer@e000e010`, `/leds` or `/pwmleds`
- `reg`        for nodes such as `/soc/timer@e000e010`
- `status`    for nodes such as `/soc/timer@e000e010`
- `gpios`     for nodes such as `/leds/led_0` or ` /buttons/button_0`
- `pwms`    for nodes such as `/pwmleds/pwm_led_0`

This patch checks the `PropertySpec.description` attribute before calling `strip()`: will return `None`, and not raise `AttributeError`.

**NOTE**: I'm not aware of any *legit* `edtlib` use (e.g. by scripts in [zephyr/scripts](https://github.com/zephyrproject-rtos/zephyr/tree/main/scripts)) that may trigger this issue, in particular I've never faced this `AttributeError` when building a Zephyr application. My use-case is slightly different (a shell-like interface to a devicetree and its bindings, [dtsh](https://github.com/dottspina/dtsh))

Thanks.

--
chris