### PR TITLE
twister: fix UnicodeDecodeError on input handling in BinaryHandler

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -192,11 +192,11 @@ class BinaryHandler(Handler):
             reader_t.start()
             reader_t.join(this_timeout)
             if not reader_t.is_alive():
-                line = self.line
-                logger.debug("OUTPUT: {0}".format(line.decode('utf-8').rstrip()))
-                log_out_fp.write(line.decode('utf-8'))
+                line_decoded = self.line.decode('utf-8', "replace")
+                logger.debug("OUTPUT: {0}".format(line_decoded.rstrip()))
+                log_out_fp.write(line_decoded)
                 log_out_fp.flush()
-                harness.handle(line.decode('utf-8').rstrip())
+                harness.handle(line_decoded.rstrip())
                 if harness.state:
                     if not timeout_extended or harness.capture_coverage:
                         timeout_extended = True


### PR DESCRIPTION
In `BinaryHandler` we process input from simulator with `decode('utf-8')` to convert it to string. decode has strict error handling by default - so it raises `UnicodeDecodeError` exception if it can't decode input binary sequence.

So if test start to print some junk to uart console we get UnicodeDecodeError exception which cause the whole twister crash, I.e:

```
Exception in thread Thread-53217:
Traceback (most recent call last):
  File "/PATH_0/Python-3.8.5/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/PATH_0/Python-3.8.5/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/PATH_1/zephyr_verification/sanity_check/zephyr/scripts/pylib/twister/twisterlib/handlers.py", line 196, in _output_handler
    logger.debug("OUTPUT: {0}".format(line.decode('utf-8').rstrip()))
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x94 in position 0: invalid start byte

      **[snip]**

Process Process-5:
Traceback (most recent call last):
  File "/PATH_0/Python-3.8.5/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/PATH_0/Python-3.8.5/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/PATH_1/zephyr_verification/sanity_check/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 992, in pipeline_mgr
    pb.process(pipeline, done_queue, task, lock, results)
  File "/PATH_1/zephyr_verification/sanity_check/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 565, in process
    pipeline.put({
  File "<string>", line 2, in put
  File "/PATH_0/Python-3.8.5/lib/python3.8/multiprocessing/managers.py", line 834, in _callmethod
    conn.send((self._id, methodname, args, kwds))
  File "/PATH_0/Python-3.8.5/lib/python3.8/multiprocessing/connection.py", line 206, in send
    self._send_bytes(_ForkingPickler.dumps(obj))
  File "/PATH_0/Python-3.8.5/lib/python3.8/multiprocessing/connection.py", line 411, in _send_bytes
    self._send(header + buf)
  File "/PATH_0/Python-3.8.5/lib/python3.8/multiprocessing/connection.py", line 368, in _send
    n = write(self._handle, buf)
BrokenPipeError: [Errno 32] Broken pipe
Traceback (most recent call last):
  File "zephyr/scripts/twister", line 410, in <module>
    ret = main()
  File "zephyr/scripts/twister", line 363, in main
    runner.run()
  File "/PATH_1/zephyr_verification/sanity_check/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 915, in run
    inst = done_queue.get_nowait()
  File "<string>", line 2, in get_nowait
  File "/PATH_0/Python-3.8.5/lib/python3.8/multiprocessing/managers.py", line 834, in _callmethod
./jenkins-jobs/zephyr-sanity-check/sanity-check.sh: line 146: 86210 Terminated              zephyr/scripts/${command_wrapper} ${CUSTOM_SANITY_CHECKER_OPTIONS:-} --platform $SC_PLATFORM $target_flags --report-dir $OUT_DIR
```

To fix that switch decode to less strict error handling when it just replace undecoded binary sequence with unicode replacement character.