### PR TITLE
drivers: gpio: remove pinmux dependency in lpc11u6x Kconfig

### DIFF
--- a/drivers/gpio/Kconfig.lpc11u6x
+++ b/drivers/gpio/Kconfig.lpc11u6x
@@ -8,6 +8,5 @@ config GPIO_LPC11U6X
 	default y
 	depends on DT_HAS_NXP_LPC11U6X_GPIO_ENABLED
 	depends on CLOCK_CONTROL_LPC11U6X
-	depends on PINMUX_LPC11U6X
 	help
 	  Enable GPIO driver for LPC11U6x MCUs.


### PR DESCRIPTION
Previous commit removed pinmux from the platform but neglected to remove the dependency in this Kconfig resulting in build failures when target application configures GPIO support.

Fixes #51144

Signed-off-by: David Leach <david.leach@nxp.com>