### PR TITLE
Bluetooth: Mesh: Remove msg_cache_next in rx ctx

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -147,10 +147,10 @@ static bool msg_cache_match(struct net_buf_simple *pdu)
 
 static void msg_cache_add(struct bt_mesh_net_rx *rx)
 {
-	rx->msg_cache_idx = msg_cache_next++;
-	msg_cache[rx->msg_cache_idx].src = rx->ctx.addr;
-	msg_cache[rx->msg_cache_idx].seq = rx->seq;
 	msg_cache_next %= ARRAY_SIZE(msg_cache);
+	msg_cache[msg_cache_next].src = rx->ctx.addr;
+	msg_cache[msg_cache_next].seq = rx->seq;
+	msg_cache_next++;
 }
 
 static void store_iv(bool only_duration)
@@ -848,9 +848,8 @@ void bt_mesh_net_recv(struct net_buf_simple *data, int8_t rssi,
 	 */
 	if (bt_mesh_trans_recv(&buf, &rx) == -EAGAIN) {
 		BT_WARN("Removing rejected message from Network Message Cache");
-		msg_cache[rx.msg_cache_idx].src = BT_MESH_ADDR_UNASSIGNED;
 		/* Rewind the next index now that we're not using this entry */
-		msg_cache_next = rx.msg_cache_idx;
+		msg_cache[--msg_cache_next].src = BT_MESH_ADDR_UNASSIGNED;
 	}
 
 	/* Relay if this was a group/virtual address, or if the destination

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -125,8 +125,8 @@ static bool check_dup(struct net_buf_simple *data)
 		}
 	}
 
-	dup_cache[dup_cache_next++] = val;
 	dup_cache_next %= ARRAY_SIZE(dup_cache);
+	dup_cache[dup_cache_next++] = val;
 
 	return false;
 }
@@ -850,6 +850,7 @@ void bt_mesh_net_recv(struct net_buf_simple *data, int8_t rssi,
 		BT_WARN("Removing rejected message from Network Message Cache");
 		/* Rewind the next index now that we're not using this entry */
 		msg_cache[--msg_cache_next].src = BT_MESH_ADDR_UNASSIGNED;
+		dup_cache[--dup_cache_next] = 0;
 	}
 
 	/* Relay if this was a group/virtual address, or if the destination

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -236,7 +236,6 @@ struct bt_mesh_net_rx {
 	       net_if:2,       /* Network interface */
 	       local_match:1,  /* Matched a local element */
 	       friend_match:1; /* Matched an LPN we're friends for */
-	uint16_t  msg_cache_idx;  /* Index of entry in message cache */
 };
 
 /* Encoding context for Network/Transport data */


### PR DESCRIPTION
Since in bt_mesh_net_recv will call msg_cache_add
and if lpn reject this message, should remove this cache.

But this function sequentially and will not be interrupt by any thread so, we no need a copy var to save this value.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>