### PR TITLE
net: lwm2m: Fix buffer overflow by using CONFIG_LWM2M_VERSION_1_0

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -69,7 +69,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #define CLIENT_EP_LEN		CONFIG_LWM2M_RD_CLIENT_ENDPOINT_NAME_MAX_LENGTH
 
-#define CLIENT_BINDING_LEN sizeof("U")
+#define CLIENT_BINDING_LEN sizeof("UQ")
 #define CLIENT_QUEUE_LEN sizeof("Q")
 
 static void sm_handle_registration_update_failure(void);


### PR DESCRIPTION
By using CONFIG_LWM2M_VERSION_1_0, the function
lwm2m_engine_get_binding() returns the binding
and the queue mode bytes. Therefore the buffer
must be tree bytes long.
The issue is caused by the two inconsistent defines:

lwm2m_registry.c:
    #define BINDING_OPT_MAX_LEN 3 /* "UQ" */
lwm2m_rd_client.c:
    #define CLIENT_BINDING_LEN sizeof("U")

Signed-off-by: Peter Toenz <peter.tonz@husqvarnagroup.com>