### PR TITLE
modem: ppp: gsm: extract access technology

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -391,6 +391,11 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_cereg)
 			gsm.context.data_cellid);
 	}
 
+	if (argc >= 5) {
+		gsm.context.data_act = unquoted_atoi(argv[4], 10);
+		LOG_INF("act: %u", gsm.context.data_act);
+	}
+
 	return 0;
 }
 

--- a/drivers/modem/modem_context.h
+++ b/drivers/modem/modem_context.h
@@ -57,6 +57,7 @@ struct modem_context {
 	int   data_operator;
 	int   data_lac;
 	int   data_cellid;
+	int   data_act;
 #endif
 	int   *data_rssi;
 	bool  is_automatic_oper;

--- a/drivers/modem/modem_shell.c
+++ b/drivers/modem/modem_shell.c
@@ -71,6 +71,7 @@ static int cmd_modem_list(const struct shell *shell, size_t argc,
 				"\tOperator:     %d\n"
 				"\tLAC:          %d\n"
 				"\tCellId:       %d\n"
+				"\tAcT:          %d\n"
 #endif
 				"\tRSSI:         %d\n",
 			       i,
@@ -87,6 +88,7 @@ static int cmd_modem_list(const struct shell *shell, size_t argc,
 			       mdm_ctx->data_operator,
 			       mdm_ctx->data_lac,
 			       mdm_ctx->data_cellid,
+			       mdm_ctx->data_act,
 #endif
 			       mdm_ctx->data_rssi ? *mdm_ctx->data_rssi : 0);
 		}


### PR DESCRIPTION
Some modems supports multiple access technologies. The access technology of the serving cell can be extracted from the +CEREG command, which is already sent to the modem.

The parse function is extended to also parse the access technology value.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/51153.

Signed-off-by: Jeppe Odgaard <jeppe.odgaard@prevas.dk>