### PR TITLE
cmake: sysbuild: Add support for recurive target cmake inclusion

### DIFF
--- a/share/sysbuild/CMakeLists.txt
+++ b/share/sysbuild/CMakeLists.txt
@@ -68,6 +68,20 @@ add_subdirectory(bootloader)
 
 # This allows for board and app specific images to be included.
 include(${BOARD_DIR}/sysbuild.cmake OPTIONAL)
-include(${APP_DIR}/sysbuild.cmake OPTIONAL)
+
+# This allows image specific sysbuild.cmake to be processed.
+list(LENGTH IMAGES images_length)
+while(NOT "${images_length}" EQUAL "${processed_length}")
+  foreach(image ${IMAGES})
+    if(NOT image IN_LIST images_sysbuild_processed)
+      ExternalProject_Get_property(${image} SOURCE_DIR)
+      include(${SOURCE_DIR}/sysbuild.cmake OPTIONAL)
+      list(APPEND images_sysbuild_processed ${image})
+    endif()
+  endforeach()
+
+  list(LENGTH images_sysbuild_processed processed_length)
+  list(LENGTH IMAGES images_length)
+endwhile()
 
 include(cmake/domains.cmake)


### PR DESCRIPTION
Adds support for all sysbuild targets to have a sysbuild.cmake file included and processed as part of sysbuild instead of just the main application.