### PR TITLE
scripts: build: gen_handles: use Z_DECL_ALIGN

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -62,13 +62,6 @@ extern "C" {
  */
 typedef int16_t device_handle_t;
 
-/*
- * The build assert will fail if device_handle_t changes size, which
- * means the alignment directives in the linker scripts and in
- * `gen_handles.py` must be updated.
- */
-BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
-
 /** @brief Flag value used in lists of device handles to separate
  * distinct groups.
  *

--- a/scripts/build/gen_handles.py
+++ b/scripts/build/gen_handles.py
@@ -105,7 +105,7 @@ def c_handle_array(dev, handles, extra_support_handles=0):
         'DEVICE_HANDLE_ENDS',
     ]
     return [
-        'const device_handle_t __aligned(2) __attribute__((__section__(".__device_handles_pass2")))',
+        'const Z_DECL_ALIGN(device_handle_t) __attribute__((__section__(".__device_handles_pass2")))',
         '{:s}[] = {{ {:s} }};'.format(dev.ordinals.sym.name, ', '.join(handles)),
     ]
 


### PR DESCRIPTION
Instead of hardcoding alignment size for pass 2 device handles, use Z_DECL_ALIGN. This makes sure gen_handles.py is always in sync with the type defined in device.h. The build assert in device.h can be removed as a result, since we do not hardcode handles size anywhere else.

Note: this assertion was introduced in #32127, as far as I can see, we do not hardcode the size in any linker script even though the message says, "fix the linker scripts".

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>