### PR TITLE
gicv3: Disable reading GICR_TYPER for Aarch32

### DIFF
--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -507,6 +507,20 @@ static bool arm_gic_aff_matching(uint64_t gicr_aff, uint64_t aff)
 #endif
 }
 
+static inline uint64_t arm_gic_get_typer(mem_addr_t addr)
+{
+	uint64_t val;
+
+#if defined(CONFIG_ARM)
+	val = sys_read32(addr);
+	val |= (uint64_t)sys_read32(addr + 4) << 32;
+#else
+	val = sys_read64(addr);
+#endif
+
+	return val;
+}
+
 static mem_addr_t arm_gic_iterate_rdists(void)
 {
 	uint64_t aff = arm_gic_mpidr_to_affinity(GET_MPIDR());
@@ -514,7 +528,7 @@ static mem_addr_t arm_gic_iterate_rdists(void)
 	for (mem_addr_t rdist_addr = GIC_RDIST_BASE;
 		rdist_addr < GIC_RDIST_BASE + GIC_RDIST_SIZE;
 		rdist_addr += 0x20000) {
-		uint64_t val = sys_read64(rdist_addr + GICR_TYPER);
+		uint64_t val = arm_gic_get_typer(rdist_addr + GICR_TYPER);
 		uint64_t gicr_aff = GICR_TYPER_AFFINITY_VALUE_GET(val);
 
 		if (arm_gic_aff_matching(gicr_aff, aff)) {


### PR DESCRIPTION
GIC_TYPER is a 64 bit register. This is not supported on Aarch32 based platforms.

Signed-off-by: Ayan Kumar Halder <ayankuma@amd.com>