### PR TITLE
toolchain: common: iterable sections: allow using ROM

### DIFF
--- a/include/zephyr/toolchain/common.h
+++ b/include/zephyr/toolchain/common.h
@@ -197,7 +197,7 @@
  */
 
 /**
- * @brief Defines a new iterable section.
+ * @brief Defines a new element for an iterable section.
  *
  * @details
  * Convenience helper combining __in_section() and Z_DECL_ALIGN().
@@ -206,13 +206,16 @@
  *
  * In the linker script, create output sections for these using
  * ITERABLE_SECTION_ROM() or ITERABLE_SECTION_RAM().
+ *
+ * @note In order to store the element in ROM, a const specifier has to
+ * be added to the declaration: const STRUCT_SECTION_ITERABLE(...);
  */
 #define STRUCT_SECTION_ITERABLE(struct_type, name) \
 	Z_DECL_ALIGN(struct struct_type) name \
 	__in_section(_##struct_type, static, name) __used __noasan
 
 /**
- * @brief Defines an alternate data type iterable section.
+ * @brief Defines a new element of alternate data type for an iterable section.
  *
  * @details
  * Special variant of STRUCT_SECTION_ITERABLE(), for placing alternate

--- a/tests/misc/iterable_sections/src/main.c
+++ b/tests/misc/iterable_sections/src/main.c
@@ -51,10 +51,10 @@ struct test_rom {
 };
 
 /* declare in random order to check that the linker is sorting by name */
-STRUCT_SECTION_ITERABLE(test_rom, rom1) = {0x10};
-STRUCT_SECTION_ITERABLE(test_rom, rom3) = {0x30};
-STRUCT_SECTION_ITERABLE(test_rom, rom4) = {0x40};
-STRUCT_SECTION_ITERABLE(test_rom, rom2) = {0x20};
+const STRUCT_SECTION_ITERABLE(test_rom, rom1) = {0x10};
+const STRUCT_SECTION_ITERABLE(test_rom, rom3) = {0x30};
+const STRUCT_SECTION_ITERABLE(test_rom, rom4) = {0x40};
+const STRUCT_SECTION_ITERABLE(test_rom, rom2) = {0x20};
 
 #define ROM_EXPECT 0x10203040
 


### PR DESCRIPTION
The previous macro `STRUCT_SECTION_ITERABLE` was not adding a `const` specifier to the struct declaration, which is why the macro does not work for iterable sections in ROM.

This PR proposes the following changes:

1. Change the macro name to `STRUCT_SECTION_RAM` to make the purpose of the macro more clear. At the same time deprecate the old one.
2. Add a new macro `STRUCT_SECTION_ROM` which adds the const specifier and thus allows to actually store the data in ROM.

I'm open for suggestions for appropriate naming of the macro (hence the RFC in the title).

Ideas so far:
- `STRUCT_SECTION_RAM` as proposed here as a starting point.
- `STRUCT_ADD_RAM` or `STRUCT_RAM_ADD` to make more clear that we are not creating a new section (as the original doc comment suggested), but rather add an element to a section.
- longer name containing the above + `ITERABLE`, even though I think the "iterable" is not really relevant here.

Once we have settled on the name I will fix other related names and update in-tree occurences.

Fixes #51168 