### PR TITLE
intel_adsp: add missing headers

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/timing.c
+++ b/arch/arm/core/aarch32/cortex_m/timing.c
@@ -12,6 +12,7 @@
  */
 
 #include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <zephyr/timing/timing.h>
 #include <aarch32/cortex_m/dwt.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>

--- a/arch/arm/include/aarch32/cortex_m/dwt.h
+++ b/arch/arm/include/aarch32/cortex_m/dwt.h
@@ -21,6 +21,7 @@
 #else
 
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/sys/__assert.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/counter/counter_mchp_xec.c
+++ b/drivers/counter/counter_mchp_xec.c
@@ -22,6 +22,7 @@
  *   when the counters reach zero.
  */
 
+#include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(counter_mchp_xec, CONFIG_COUNTER_LOG_LEVEL);
 

--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -8,6 +8,7 @@
 
 #include <errno.h>
 #include <zephyr/device.h>
+#include <zephyr/irq.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/sys_io.h>
 #include <soc.h>

--- a/drivers/interrupt_controller/intc_dw_ace.c
+++ b/drivers/interrupt_controller/intc_dw_ace.c
@@ -7,6 +7,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/irq_nextlevel.h>
+#include <zephyr/arch/xtensa/irq.h>
 #ifdef CONFIG_DYNAMIC_INTERRUPTS
 #include <zephyr/sw_isr_table.h>
 #endif

--- a/drivers/peci/peci_mchp_xec.c
+++ b/drivers/peci/peci_mchp_xec.c
@@ -8,6 +8,7 @@
 
 #include <errno.h>
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 #ifdef CONFIG_SOC_SERIES_MEC172X
 #include <zephyr/drivers/clock_control/mchp_xec_clock_control.h>
 #include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>

--- a/drivers/ps2/ps2_mchp_xec.c
+++ b/drivers/ps2/ps2_mchp_xec.c
@@ -10,6 +10,7 @@
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <errno.h>
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 #ifdef CONFIG_SOC_SERIES_MEC172X
 #include <zephyr/drivers/clock_control/mchp_xec_clock_control.h>
 #include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>

--- a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
+++ b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
@@ -8,7 +8,9 @@
 #define DT_DRV_COMPAT microchip_xec_tach
 
 #include <errno.h>
+#include <zephyr/kernel.h>
 #include <zephyr/device.h>
+#include <zephyr/arch/cpu.h>
 #ifdef CONFIG_SOC_SERIES_MEC172X
 #include <zephyr/drivers/clock_control/mchp_xec_clock_control.h>
 #include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>

--- a/drivers/watchdog/wdt_mchp_xec.c
+++ b/drivers/watchdog/wdt_mchp_xec.c
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/irq.h>
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wdt_mchp_xec);

--- a/include/zephyr/drivers/kscan.h
+++ b/include/zephyr/drivers/kscan.h
@@ -16,6 +16,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_KB_SCAN_H_
 #define ZEPHYR_INCLUDE_DRIVERS_KB_SCAN_H_
 
+#include <errno.h>
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <zephyr/device.h>

--- a/soc/xtensa/intel_adsp/cavs/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/cavs/multiprocessing.c
@@ -5,6 +5,7 @@
 #include <cavs-idc.h>
 #include <adsp_memory.h>
 #include <adsp_shim.h>
+#include <soc.h>
 
 /* IDC power up message to the ROM firmware.  This isn't documented
  * anywhere, it's basically just a magic number (except the high bit,

--- a/soc/xtensa/intel_adsp/common/boot_complete.c
+++ b/soc/xtensa/intel_adsp/common/boot_complete.c
@@ -5,6 +5,8 @@
 #include <zephyr/arch/xtensa/cache.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
+#include <errno.h>
+#include <soc.h>
 
 #include <mem_window.h>
 

--- a/soc/xtensa/intel_adsp/common/mem_window.c
+++ b/soc/xtensa/intel_adsp/common/mem_window.c
@@ -5,6 +5,7 @@
 #include <zephyr/arch/xtensa/cache.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/arch/cpu.h>
 
 #include <adsp_memory.h>
 #include <adsp_shim.h>


### PR DESCRIPTION
add headers previously included indirectly.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
