### PR TITLE
drivers: watchdog: Fix RP2040 watchdog load time

### DIFF
--- a/drivers/watchdog/wdt_rpi_pico.c
+++ b/drivers/watchdog/wdt_rpi_pico.c
@@ -9,6 +9,7 @@
 #include <hardware/watchdog.h>
 #include <hardware/structs/psm.h>
 #include <zephyr/drivers/watchdog.h>
+#include <zephyr/sys_clock.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wdt_rpi_pico, CONFIG_WDT_LOG_LEVEL);
@@ -101,7 +102,7 @@ static int wdt_rpi_pico_install_timeout(const struct device *dev, const struct w
 
 	if (cfg->window.min != 0U || cfg->window.max == 0U) {
 		return -EINVAL;
-	} else if (cfg->window.max > RPI_PICO_MAX_WDT_TIME) {
+	} else if (cfg->window.max * USEC_PER_MSEC > RPI_PICO_MAX_WDT_TIME) {
 		return -EINVAL;
 	} else if (cfg->callback != NULL) {
 		return -ENOTSUP;
@@ -113,7 +114,7 @@ static int wdt_rpi_pico_install_timeout(const struct device *dev, const struct w
 		return -EINVAL;
 	}
 
-	data->load = (cfg->window.max * RPI_PICO_WDT_TIME_MULTIPLICATION_FACTOR);
+	data->load = (cfg->window.max * USEC_PER_MSEC * RPI_PICO_WDT_TIME_MULTIPLICATION_FACTOR);
 	data->reset_type = (cfg->flags & WDT_FLAG_RESET_MASK);
 
 	return 0;

--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -26,7 +26,6 @@
  */
 #define WDT_ALLOW_CALLBACK 0
 #elif DT_HAS_COMPAT_STATUS_OKAY(raspberrypi_pico_watchdog)
-#define WDT_MAX_WINDOW  600000U
 #define WDT_ALLOW_CALLBACK 0
 #elif DT_HAS_COMPAT_STATUS_OKAY(gd_gd32_wwdgt)
 #define WDT_MAX_WINDOW 24U


### PR DESCRIPTION
RP2040 requires watchdog load time in us, but Zephyr watchdog window values are in ms. Make sure that it is adjusted to hardware requirements.

Signed-off-by: Marcin Jabrzyk <marcin.jabrzyk@gmail.com>