### PR TITLE
drivers: counter: counter_mcux_lpc_rtc: include <zephyr/irq.h>

### DIFF
--- a/drivers/counter/counter_mcux_lpc_rtc.c
+++ b/drivers/counter/counter_mcux_lpc_rtc.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT nxp_lpc_rtc
 
+#include <zephyr/irq.h>
 #include <zephyr/drivers/counter.h>
 #include <fsl_rtc.h>
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
Add include of zephyr/irq.h to mcux lpc RTC counter driver, to
provide a definition of IRQ_CONNECT.

#51185

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>