### PR TITLE
Devicetree: edtlib: fix possible TypeError in Binding.__repr__()

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1824,7 +1824,8 @@ class Binding:
             compat = f" for compatible '{self.compatible}'"
         else:
             compat = ""
-        return f"<Binding {os.path.basename(self.path)}" + compat + ">"
+        basename = os.path.basename(self.path or "")
+        return f"<Binding {basename}" + compat + ">"
 
     @property
     def description(self):


### PR DESCRIPTION
Calling `Binding.__repr__()` when the attribute `Binding.path` is `None` would raise:

```
 TypeError: expected str, bytes or os.PathLike object, not NoneType.
```

Known bindings that may not have a path (`Binding.path` is `None`) include bindings for properties such as `compatible`, `reg`, or `status`.

This patch checks the `Binding.path` attribute before calling `os.path.basename()`.

**NOTE**: AFAIK this issue (the `TypeError`) is never triggered by Zephyr scripts, e.g. at build-time, I've only faced it when debugging [dtsh](https://github.com/dottspina/dtsh). 

Thanks.

--
chris
