### PR TITLE
edtlib: fix possible KeyError in Binding.description

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1695,7 +1695,7 @@ class Binding:
       The absolute path to the file defining the binding.
 
     description:
-      The free-form description of the binding.
+      The free-form description of the binding, or None.
 
     compatible:
       The compatible string the binding matches.
@@ -1829,7 +1829,7 @@ class Binding:
     @property
     def description(self):
         "See the class docstring"
-        return self.raw['description']
+        return self.raw.get('description')
 
     @property
     def compatible(self):


### PR DESCRIPTION
Attempting to access the `Binding.description` property when the description is unavailable would raise:

```
 KeyError: 'description'.
```

Known bindings that won't define a `description` key in the `Binding.raw` dictionary include the `compatible` property's binding of nodes such as `/`, `/soc`, `/leds` or `/pwmleds`. Note that this may also occur when a proper YAML binding file is available (e.g. `pwmleds.yaml`).

This patch simply substitutes the `Binding.raw` dictionary indexing with the `get()` function: will return `None` and not raise `KeyError`.

**NOTE**: AFAIK this issue (the `KeyError`) is never triggered by Zephyr scripts, e.g. at build-time.

Thanks.

--
chris