### PR TITLE
drivers: serial: gecko: fix impmlicit declaration of IRQ_CONNECT

### DIFF
--- a/drivers/serial/leuart_gecko.c
+++ b/drivers/serial/leuart_gecko.c
@@ -8,6 +8,7 @@
 
 #include <errno.h>
 #include <zephyr/drivers/uart.h>
+#include <zephyr/irq.h>
 #include <em_leuart.h>
 #include <em_gpio.h>
 #include <em_cmu.h>

--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -7,6 +7,7 @@
 
 #include <errno.h>
 #include <zephyr/drivers/uart.h>
+#include <zephyr/irq.h>
 #include <em_usart.h>
 #include <em_gpio.h>
 #include <em_cmu.h>


### PR DESCRIPTION
Previously, the build was failing due to implicit declaration of `IRQ_CONNECT`. Simply include `<zephyr/irq.h>` to fix.
