### PR TITLE
drivers: gpio: xlnx: add missing headers

### DIFF
--- a/drivers/gpio/gpio_xlnx_axi.c
+++ b/drivers/gpio/gpio_xlnx_axi.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys/sys_io.h>
 
 #include "gpio_utils.h"

--- a/drivers/gpio/gpio_xlnx_ps.c
+++ b/drivers/gpio/gpio_xlnx_ps.c
@@ -7,8 +7,8 @@
  */
 
 #include <zephyr/devicetree.h>
-
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 #include "gpio_utils.h"
 #include "gpio_xlnx_ps.h"
 #include "gpio_xlnx_ps_bank.h"

--- a/drivers/gpio/gpio_xlnx_ps_bank.c
+++ b/drivers/gpio/gpio_xlnx_ps_bank.c
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 


### PR DESCRIPTION
Add missing headers for sys_* and IRQ related API's.
Failed builds caught in this pr: https://github.com/zephyrproject-rtos/zephyr/pull/49161/checks?check_run_id=8838432912
