### PR TITLE
kernel: idle: fix -Werror=misleading-indentation

### DIFF
--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -47,10 +47,10 @@ void idle(void *unused1, void *unused2, void *unused3)
 		 * lock and/or timer driver.  This is intended as a
 		 * fallback configuration for new platform bringup.
 		 */
-		if (IS_ENABLED(CONFIG_SMP) &&
-		    !IS_ENABLED(CONFIG_SCHED_IPI_SUPPORTED)) {
-			for (volatile int i = 0; i < 100000; i++)
-				;
+		if (IS_ENABLED(CONFIG_SMP) && !IS_ENABLED(CONFIG_SCHED_IPI_SUPPORTED)) {
+			for (volatile int i = 0; i < 100000; i++) {
+				/* Empty loop */
+			}
 			z_swap_unlocked();
 		}
 


### PR DESCRIPTION
Warnings being treated as errors when building zephyr/kernel/CMakeFiles/kernel.dir/idle.c.obj
Error this 'for' clause does not guard...
[-Werror=misleading-indentation]
--> Fixing style error

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/51065

Signed-off-by: Francois Ramu <francois.ramu@st.com>