### PR TITLE
test: log_output: Exclude qemu_arc_hs5x

### DIFF
--- a/tests/subsys/logging/log_output/testcase.yaml
+++ b/tests/subsys/logging/log_output/testcase.yaml
@@ -9,7 +9,7 @@ tests:
     extra_configs:
       - CONFIG_LOG_TIMESTAMP_64BIT=n
   logging.log_output_ts64:
-    platform_exclude: intel_adsp_cavs15
+    platform_exclude: intel_adsp_cavs15 qemu_arc_hs5x
     tags: log_output logging
     extra_configs:
       - CONFIG_LOG_TIMESTAMP_64BIT=y


### PR DESCRIPTION
This platform is failing and breaking main. Exclude until a proper fix is found.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>