### PR TITLE
include: add missing kernel.h for lorawan subsys

### DIFF
--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -15,7 +15,8 @@
  * @{
  */
 
-#include <zephyr/types.h>
+#include <stdint.h>
+#include <zephyr/kernel.h>
 #include <zephyr/device.h>
 
 #ifdef __cplusplus

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <errno.h>
 #include <zephyr/lorawan/lorawan.h>


### PR DESCRIPTION
Header lora.h and lorawan.c files make use of types defined in kernel.h :  including it to avoid undefined struct error

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/51194

Signed-off-by: Francois Ramu <francois.ramu@st.com>