### PR TITLE
kernel: thread: Add casting to pointers in the log message

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -474,8 +474,8 @@ static char *setup_thread_stack(struct k_thread *new_thread,
 
 	LOG_DBG("stack %p for thread %p: obj_size=%zu buf_start=%p "
 		" buf_size %zu stack_ptr=%p",
-		stack, new_thread, stack_obj_size, stack_buf_start,
-		stack_buf_size, stack_ptr);
+		stack, new_thread, stack_obj_size, (void *)stack_buf_start,
+		stack_buf_size, (void *)stack_ptr);
 
 #ifdef CONFIG_INIT_STACKS
 	memset(stack_buf_start, 0xaa, stack_buf_size);


### PR DESCRIPTION
Using char pointers for %p should be avoided in log messages. It will cause issues in configurations where logging strings are removed from the binary and they are not inspected when cbprintf packages from logging string are built. In that case any char pointers are treated as strings and copied into the pacakge body.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>