### PR TITLE
vl53l0x: Add support for interrupt and configurable sampling frequency

### DIFF
--- a/boards/shields/x_nucleo_53l0a1/x_nucleo_53l0a1.overlay
+++ b/boards/shields/x_nucleo_53l0a1/x_nucleo_53l0a1.overlay
@@ -23,6 +23,11 @@
 	vl53l0x_c_x_nucleo_53l0a1: vl53l0x@30 {
 		compatible = "st,vl53l0x";
 		reg = <0x30>;
+		/* NB: this is the default with solder drop U14 fitted
+		/* The following alternate solder drops are possible:
+		 * interrupt-gpios = <&arduino_header 4 0>;  // A4 / U17 fitted
+		 */
+		interrupt-gpios = <&arduino_header 2 0>;  // A2 / U14 fitted
 		xshut-gpios = <&expander1_x_nucleo_53l0a1 15 0>;
 	};
 
@@ -30,11 +35,21 @@
 	vl53l0x_l_x_nucleo_53l0a1: vl53l0x@31 {
 		compatible = "st,vl53l0x";
 		reg = <0x31>;
+		/* NB: By default no solder drop fitted
+		/* The following solder drops are possible:
+		 * interrupt-gpios = <&arduino_header 14 0>;  // D8 / U11 fitted
+		 * interrupt-gpios = <&arduino_header 15 0>;  // D9 / U10 fitted
+		 */
 		xshut-gpios = <&expander2_x_nucleo_53l0a1 14 0>;
 	};
 	vl53l0x_r_x_nucleo_53l0a1: vl53l0x@32 {
 		compatible = "st,vl53l0x";
 		reg = <0x32>;
+		/* NB: By default no solder drop fitted
+		/* The following solder drops are possible:
+		 * interrupt-gpios = <&arduino_header 8 0>;  // D2 / U18 fitted
+		 * interrupt-gpios = <&arduino_header 10 0>;  // D4 / U15 fitted
+		 */
 		xshut-gpios = <&expander2_x_nucleo_53l0a1 15 0>;
 	};
 };

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -48,7 +48,7 @@ struct vl53l0x_config {
 struct vl53l0x_data {
 	bool started;
 	VL53L0X_Dev_t vl53l0x;
-	VL53L0X_RangingMeasurementData_t RangingMeasurementData;
+	VL53L0X_RangingMeasurementData_t measurement;
 };
 
 static int vl53l0x_setup_single_shot(const struct device *dev)
@@ -230,8 +230,7 @@ static int vl53l0x_sample_fetch(const struct device *dev, enum sensor_channel ch
 		}
 	}
 
-	ret = VL53L0X_PerformSingleRangingMeasurement(&drv_data->vl53l0x,
-						      &drv_data->RangingMeasurementData);
+	ret = VL53L0X_PerformSingleRangingMeasurement(&drv_data->vl53l0x, &drv_data->measurement);
 	if (ret < 0) {
 		LOG_ERR("[%s] Could not perform measurment (error=%d)", dev->name, ret);
 		return -EINVAL;
@@ -246,16 +245,15 @@ static int vl53l0x_channel_get(const struct device *dev, enum sensor_channel cha
 	struct vl53l0x_data *drv_data = dev->data;
 
 	if (chan == SENSOR_CHAN_PROX) {
-		if (drv_data->RangingMeasurementData.RangeMilliMeter <=
-		    CONFIG_VL53L0X_PROXIMITY_THRESHOLD) {
+		if (drv_data->measurement.RangeMilliMeter <= CONFIG_VL53L0X_PROXIMITY_THRESHOLD) {
 			val->val1 = 1;
 		} else {
 			val->val1 = 0;
 		}
 		val->val2 = 0;
 	} else if (chan == SENSOR_CHAN_DISTANCE) {
-		val->val1 = drv_data->RangingMeasurementData.RangeMilliMeter / 1000;
-		val->val2 = (drv_data->RangingMeasurementData.RangeMilliMeter % 1000) * 1000;
+		val->val1 = drv_data->measurement.RangeMilliMeter / 1000;
+		val->val2 = (drv_data->measurement.RangeMilliMeter % 1000) * 1000;
 	} else {
 		return -ENOTSUP;
 	}

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -9,6 +9,7 @@
  */
 
 #include "vl53l0x_api.h"
+#include "vl53l0x_api_core.h"
 #include "vl53l0x_platform.h"
 
 #include <errno.h>
@@ -42,13 +43,20 @@ LOG_MODULE_REGISTER(VL53L0X, CONFIG_SENSOR_LOG_LEVEL);
 
 struct vl53l0x_config {
 	struct i2c_dt_spec i2c;
+	struct gpio_dt_spec interrupt;
 	struct gpio_dt_spec xshut;
 };
 
 struct vl53l0x_data {
+	const struct device *dev;
 	bool started;
 	VL53L0X_Dev_t vl53l0x;
 	VL53L0X_RangingMeasurementData_t measurement;
+	VL53L0X_DeviceModes current_mode;
+	struct gpio_callback interrupt_cb;
+	struct k_work interrupt_work;
+	struct k_sem wait_for_interrupt;
+	sensor_trigger_handler_t data_ready_handler;
 };
 
 static inline bool vl53l0x_supports_chan(enum sensor_channel chan)
@@ -63,7 +71,53 @@ static inline bool vl53l0x_supports_chan(enum sensor_channel chan)
 	}
 }
 
-static int vl53l0x_setup_single_shot(const struct device *dev)
+static inline bool vl53l0x_has_interrupt(const struct device *dev)
+{
+	const struct vl53l0x_config *const config = dev->config;
+
+	return config->interrupt.port != NULL;
+}
+
+static void vl53l0x_interrupt_callback(const struct device *port, struct gpio_callback *cb,
+				       uint32_t pin)
+{
+	struct vl53l0x_data *drv_data = CONTAINER_OF(cb, struct vl53l0x_data, interrupt_cb);
+
+	ARG_UNUSED(port);
+	ARG_UNUSED(pin);
+	k_work_submit(&drv_data->interrupt_work);
+	LOG_DBG("[%s] Got interrupt !", drv_data->dev->name);
+}
+
+static void vl53l0x_interrupt_work(struct k_work *work)
+{
+	struct sensor_trigger trig = {
+		.type = SENSOR_TRIG_DATA_READY,
+		.chan = SENSOR_CHAN_DISTANCE,
+	};
+	struct vl53l0x_data *drv_data = CONTAINER_OF(work, struct vl53l0x_data, interrupt_work);
+	uint32_t reason;
+	int r;
+
+	r = VL53L0X_GetInterruptMaskStatus(&drv_data->vl53l0x, &reason);
+	if (r) {
+		LOG_ERR("[%s] VL53L0X_GetInterruptMaskStatus failed", drv_data->dev->name);
+		return;
+	}
+
+	k_sem_give(&drv_data->wait_for_interrupt);
+
+	if (reason == VL53L0X_GPIOFUNCTIONALITY_NEW_MEASURE_READY && drv_data->data_ready_handler) {
+		drv_data->data_ready_handler(drv_data->dev, &trig);
+	}
+
+	r = VL53L0X_ClearInterruptMask(&drv_data->vl53l0x, 0);
+	if (r) {
+		LOG_ERR("[%s] VL53L0X_ClearInterruptMask failed", drv_data->dev->name);
+	}
+}
+
+static int vl53l0x_configure(const struct device *dev)
 {
 	struct vl53l0x_data *drv_data = dev->data;
 	int ret;
@@ -88,12 +142,6 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 					       &isApertureSpads);
 	if (ret) {
 		LOG_ERR("[%s] VL53L0X_PerformRefSpadManagement failed", dev->name);
-		goto exit;
-	}
-
-	ret = VL53L0X_SetDeviceMode(&drv_data->vl53l0x, VL53L0X_DEVICEMODE_SINGLE_RANGING);
-	if (ret) {
-		LOG_ERR("[%s] VL53L0X_SetDeviceMode failed", dev->name);
 		goto exit;
 	}
 
@@ -150,6 +198,19 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 
 exit:
 	return ret;
+}
+
+static int vl53l0x_set_ranging_mode(const struct device *dev, VL53L0X_DeviceModes mode)
+{
+	struct vl53l0x_data *drv_data = dev->data;
+	int ret = VL53L0X_SetDeviceMode(&drv_data->vl53l0x, mode);
+
+	if (ret) {
+		LOG_ERR("[%s] VL53L0X_SetDeviceMode failed", dev->name);
+		return ret;
+	}
+	drv_data->current_mode = mode;
+	return 0;
 }
 
 static int vl53l0x_start(const struct device *dev)
@@ -216,9 +277,31 @@ static int vl53l0x_start(const struct device *dev)
 		return -ENOTSUP;
 	}
 
-	ret = vl53l0x_setup_single_shot(dev);
+	ret = vl53l0x_configure(dev);
 	if (ret < 0) {
 		return -ENOTSUP;
+	}
+
+	ret = vl53l0x_set_ranging_mode(dev, VL53L0X_DEVICEMODE_SINGLE_RANGING);
+	if (ret) {
+		return -EIO;
+	}
+
+	if (vl53l0x_has_interrupt(dev)) {
+		r = VL53L0X_SetGpioConfig(&drv_data->vl53l0x, 0, VL53L0X_DEVICEMODE_SINGLE_RANGING,
+					  VL53L0X_GPIOFUNCTIONALITY_NEW_MEASURE_READY,
+					  VL53L0X_INTERRUPTPOLARITY_HIGH);
+		if (r < 0) {
+			LOG_ERR("[%s] Unable to setup interrupt config on device: %d", dev->name,
+				r);
+			return -EIO;
+		}
+
+		gpio_init_callback(&drv_data->interrupt_cb, vl53l0x_interrupt_callback,
+				   BIT(config->interrupt.pin));
+		gpio_add_callback(config->interrupt.port, &drv_data->interrupt_cb);
+		gpio_pin_interrupt_configure_dt(&config->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
+		LOG_DBG("[%s] Interrupt configured", dev->name);
 	}
 
 	drv_data->started = true;
@@ -229,7 +312,6 @@ static int vl53l0x_start(const struct device *dev)
 static int vl53l0x_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct vl53l0x_data *drv_data = dev->data;
-	VL53L0X_Error ret;
 	int r;
 
 	if (!vl53l0x_supports_chan(chan)) {
@@ -243,9 +325,26 @@ static int vl53l0x_sample_fetch(const struct device *dev, enum sensor_channel ch
 		}
 	}
 
-	ret = VL53L0X_PerformSingleRangingMeasurement(&drv_data->vl53l0x, &drv_data->measurement);
-	if (ret < 0) {
-		LOG_ERR("[%s] Could not perform measurment (error=%d)", dev->name, ret);
+	if (drv_data->current_mode == VL53L0X_DEVICEMODE_SINGLE_RANGING) {
+		r = VL53L0X_StartMeasurement(&drv_data->vl53l0x);
+		if (r) {
+			LOG_ERR("[%s] VL53L0X_PerformSingleMeasurement failed", dev->name);
+			return -EIO;
+		}
+	}
+
+	if (vl53l0x_has_interrupt(dev)) {
+		LOG_DBG("[%s] Waiting for interrupt", dev->name);
+		k_sem_take(&drv_data->wait_for_interrupt, K_FOREVER);
+	} else {
+		LOG_DBG("[%s] Polling for measurement completion", dev->name);
+		VL53L0X_measurement_poll_for_completion(&drv_data->vl53l0x);
+	}
+
+	LOG_DBG("[%s] Getting measurement data", dev->name);
+	r = VL53L0X_GetRangingMeasurementData(&drv_data->vl53l0x, &drv_data->measurement);
+	if (r) {
+		LOG_ERR("[%s] VL53L0X_GetRangingMeasurementData failed", dev->name);
 		return -EINVAL;
 	}
 
@@ -305,7 +404,7 @@ static int vl53l0x_set_sampling_freq(const struct device *dev, const struct sens
 
 	timing = USEC_PER_SEC * USEC_PER_SEC / freq_microhertz;
 
-	r = VL53L0X_SetMeasurementTimingBudgetMicroSeconds(&drv_data->vl53l0x, (uint32_t) timing);
+	r = VL53L0X_SetMeasurementTimingBudgetMicroSeconds(&drv_data->vl53l0x, (uint32_t)timing);
 	if (r) {
 		LOG_ERR("[%s] Unable to set measurement timing budget", dev->name);
 		return r;
@@ -363,11 +462,54 @@ static int vl53l0x_attr_set(const struct device *dev, enum sensor_channel chan,
 	}
 }
 
+int vl53l0x_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
+			sensor_trigger_handler_t handler)
+{
+	struct vl53l0x_data *drv_data = dev->data;
+	bool was_in_continuous_mode =
+		(drv_data->current_mode == VL53L0X_DEVICEMODE_CONTINUOUS_RANGING);
+	bool to_continuous_mode = (handler != NULL);
+
+	if (!vl53l0x_has_interrupt(dev)) {
+		return -ENOTSUP;
+	}
+
+	if (trig->type != SENSOR_TRIG_DATA_READY) {
+		return -ENOTSUP;
+	}
+
+	if (!vl53l0x_supports_chan(trig->chan)) {
+		return -ENOTSUP;
+	}
+
+	drv_data->data_ready_handler = handler;
+
+	if (!was_in_continuous_mode && to_continuous_mode) {
+		if (vl53l0x_set_ranging_mode(dev, VL53L0X_DEVICEMODE_CONTINUOUS_RANGING)) {
+			return -EIO;
+		}
+		if (VL53L0X_StartMeasurement(&drv_data->vl53l0x)) {
+			LOG_ERR("[%s] VL53L0X_StartMeasurement failed", dev->name);
+			return -EIO;
+		}
+	} else if (was_in_continuous_mode && !to_continuous_mode) {
+		if (VL53L0X_StopMeasurement(&drv_data->vl53l0x)) {
+			LOG_ERR("[%s] VL53L0X_StopMeasurement failed", dev->name);
+			return -EIO;
+		}
+		if (vl53l0x_set_ranging_mode(dev, VL53L0X_DEVICEMODE_SINGLE_RANGING)) {
+			return -EIO;
+		}
+	}
+	return 0;
+}
+
 static const struct sensor_driver_api vl53l0x_api_funcs = {
 	.sample_fetch = vl53l0x_sample_fetch,
 	.channel_get = vl53l0x_channel_get,
 	.attr_get = vl53l0x_attr_get,
 	.attr_set = vl53l0x_attr_set,
+	.trigger_set = vl53l0x_trigger_set,
 };
 
 static int vl53l0x_init(const struct device *dev)
@@ -375,6 +517,10 @@ static int vl53l0x_init(const struct device *dev)
 	int r;
 	struct vl53l0x_data *drv_data = dev->data;
 	const struct vl53l0x_config *const config = dev->config;
+
+	k_work_init(&drv_data->interrupt_work, vl53l0x_interrupt_work);
+	k_sem_init(&drv_data->wait_for_interrupt, 0, 1);
+	drv_data->dev = dev;
 
 	/* Initialize the HAL peripheral with the default sensor address,
 	 * ie. the address on power up
@@ -399,7 +545,16 @@ static int vl53l0x_init(const struct device *dev)
 	if (config->xshut.port) {
 		r = gpio_pin_configure_dt(&config->xshut, GPIO_OUTPUT);
 		if (r < 0) {
-			LOG_ERR("[%s] Unable to configure GPIO as output", dev->name);
+			LOG_ERR("[%s] Unable to configure xshut as output", dev->name);
+			return -EIO;
+		}
+	}
+
+	if (vl53l0x_has_interrupt(dev)) {
+		r = gpio_pin_configure_dt(&config->interrupt, GPIO_INPUT);
+		if (r < 0) {
+			LOG_ERR("[%s] Unable to configure interrupt as input", dev->name);
+			return -EIO;
 		}
 	}
 
@@ -425,6 +580,7 @@ static int vl53l0x_init(const struct device *dev)
 #define VL53L0X_INIT(inst)                                                                         \
 	static struct vl53l0x_config vl53l0x_##inst##_config = {                                   \
 		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.interrupt = GPIO_DT_SPEC_INST_GET_OR(inst, interrupt_gpios, {}),                  \
 		.xshut = GPIO_DT_SPEC_INST_GET_OR(inst, xshut_gpios, {})};                         \
                                                                                                    \
 	static struct vl53l0x_data vl53l0x_##inst##_driver;                                        \

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -8,20 +8,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "vl53l0x_api.h"
+#include "vl53l0x_platform.h"
+
 #include <errno.h>
 
-#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/init.h>
-#include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/types.h>
-#include <zephyr/device.h>
-#include <zephyr/logging/log.h>
-
-#include "vl53l0x_api.h"
-#include "vl53l0x_platform.h"
 
 LOG_MODULE_REGISTER(VL53L0X, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -31,14 +31,14 @@ LOG_MODULE_REGISTER(VL53L0X, CONFIG_SENSOR_LOG_LEVEL);
  * There are also examples of use in the L4 cube FW:
  *   http://www.st.com/en/embedded-software/stm32cubel4.html
  */
-#define VL53L0X_INITIAL_ADDR                    0x29
-#define VL53L0X_REG_WHO_AM_I                    0xC0
-#define VL53L0X_CHIP_ID                         0xEEAA
-#define VL53L0X_SETUP_SIGNAL_LIMIT              (0.1 * 65536)
-#define VL53L0X_SETUP_SIGMA_LIMIT               (60 * 65536)
-#define VL53L0X_SETUP_MAX_TIME_FOR_RANGING      33000
-#define VL53L0X_SETUP_PRE_RANGE_VCSEL_PERIOD    18
-#define VL53L0X_SETUP_FINAL_RANGE_VCSEL_PERIOD  14
+#define VL53L0X_INITIAL_ADDR		       0x29
+#define VL53L0X_REG_WHO_AM_I		       0xC0
+#define VL53L0X_CHIP_ID			       0xEEAA
+#define VL53L0X_SETUP_SIGNAL_LIMIT	       (0.1 * 65536)
+#define VL53L0X_SETUP_SIGMA_LIMIT	       (60 * 65536)
+#define VL53L0X_SETUP_MAX_TIME_FOR_RANGING     33000
+#define VL53L0X_SETUP_PRE_RANGE_VCSEL_PERIOD   18
+#define VL53L0X_SETUP_FINAL_RANGE_VCSEL_PERIOD 14
 
 struct vl53l0x_config {
 	struct i2c_dt_spec i2c;
@@ -62,52 +62,40 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 
 	ret = VL53L0X_StaticInit(&drv_data->vl53l0x);
 	if (ret) {
-		LOG_ERR("[%s] VL53L0X_StaticInit failed",
-			dev->name);
+		LOG_ERR("[%s] VL53L0X_StaticInit failed", dev->name);
 		goto exit;
 	}
 
-	ret = VL53L0X_PerformRefCalibration(&drv_data->vl53l0x,
-					    &VhvSettings,
-					    &PhaseCal);
+	ret = VL53L0X_PerformRefCalibration(&drv_data->vl53l0x, &VhvSettings, &PhaseCal);
 	if (ret) {
-		LOG_ERR("[%s] VL53L0X_PerformRefCalibration failed",
-			dev->name);
+		LOG_ERR("[%s] VL53L0X_PerformRefCalibration failed", dev->name);
 		goto exit;
 	}
 
-	ret = VL53L0X_PerformRefSpadManagement(&drv_data->vl53l0x,
-					       (uint32_t *)&refSpadCount,
+	ret = VL53L0X_PerformRefSpadManagement(&drv_data->vl53l0x, (uint32_t *)&refSpadCount,
 					       &isApertureSpads);
 	if (ret) {
-		LOG_ERR("[%s] VL53L0X_PerformRefSpadManagement failed",
-			dev->name);
+		LOG_ERR("[%s] VL53L0X_PerformRefSpadManagement failed", dev->name);
 		goto exit;
 	}
 
-	ret = VL53L0X_SetDeviceMode(&drv_data->vl53l0x,
-				    VL53L0X_DEVICEMODE_SINGLE_RANGING);
+	ret = VL53L0X_SetDeviceMode(&drv_data->vl53l0x, VL53L0X_DEVICEMODE_SINGLE_RANGING);
 	if (ret) {
-		LOG_ERR("[%s] VL53L0X_SetDeviceMode failed",
-			dev->name);
+		LOG_ERR("[%s] VL53L0X_SetDeviceMode failed", dev->name);
+		goto exit;
+	}
+
+	ret = VL53L0X_SetLimitCheckEnable(&drv_data->vl53l0x, VL53L0X_CHECKENABLE_SIGMA_FINAL_RANGE,
+					  1);
+	if (ret) {
+		LOG_ERR("[%s] VL53L0X_SetLimitCheckEnable sigma failed", dev->name);
 		goto exit;
 	}
 
 	ret = VL53L0X_SetLimitCheckEnable(&drv_data->vl53l0x,
-					  VL53L0X_CHECKENABLE_SIGMA_FINAL_RANGE,
-					  1);
+					  VL53L0X_CHECKENABLE_SIGNAL_RATE_FINAL_RANGE, 1);
 	if (ret) {
-		LOG_ERR("[%s] VL53L0X_SetLimitCheckEnable sigma failed",
-			dev->name);
-		goto exit;
-	}
-
-	ret = VL53L0X_SetLimitCheckEnable(&drv_data->vl53l0x,
-					  VL53L0X_CHECKENABLE_SIGNAL_RATE_FINAL_RANGE,
-					  1);
-	if (ret) {
-		LOG_ERR("[%s] VL53L0X_SetLimitCheckEnable signal rate failed",
-			dev->name);
+		LOG_ERR("[%s] VL53L0X_SetLimitCheckEnable signal rate failed", dev->name);
 		goto exit;
 	}
 
@@ -116,43 +104,35 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 					 VL53L0X_SETUP_SIGNAL_LIMIT);
 
 	if (ret) {
-		LOG_ERR("[%s] VL53L0X_SetLimitCheckValue signal rate failed",
-			dev->name);
+		LOG_ERR("[%s] VL53L0X_SetLimitCheckValue signal rate failed", dev->name);
 		goto exit;
 	}
 
-	ret = VL53L0X_SetLimitCheckValue(&drv_data->vl53l0x,
-					 VL53L0X_CHECKENABLE_SIGMA_FINAL_RANGE,
+	ret = VL53L0X_SetLimitCheckValue(&drv_data->vl53l0x, VL53L0X_CHECKENABLE_SIGMA_FINAL_RANGE,
 					 VL53L0X_SETUP_SIGMA_LIMIT);
 	if (ret) {
-		LOG_ERR("[%s] VL53L0X_SetLimitCheckValue sigma failed",
-			dev->name);
+		LOG_ERR("[%s] VL53L0X_SetLimitCheckValue sigma failed", dev->name);
 		goto exit;
 	}
 
 	ret = VL53L0X_SetMeasurementTimingBudgetMicroSeconds(&drv_data->vl53l0x,
 							     VL53L0X_SETUP_MAX_TIME_FOR_RANGING);
 	if (ret) {
-		LOG_ERR("[%s] VL53L0X_SetMeasurementTimingBudgetMicroSeconds failed",
-			dev->name);
+		LOG_ERR("[%s] VL53L0X_SetMeasurementTimingBudgetMicroSeconds failed", dev->name);
 		goto exit;
 	}
 
-	ret = VL53L0X_SetVcselPulsePeriod(&drv_data->vl53l0x,
-					  VL53L0X_VCSEL_PERIOD_PRE_RANGE,
+	ret = VL53L0X_SetVcselPulsePeriod(&drv_data->vl53l0x, VL53L0X_VCSEL_PERIOD_PRE_RANGE,
 					  VL53L0X_SETUP_PRE_RANGE_VCSEL_PERIOD);
 	if (ret) {
-		LOG_ERR("[%s] VL53L0X_SetVcselPulsePeriod pre range failed",
-			dev->name);
+		LOG_ERR("[%s] VL53L0X_SetVcselPulsePeriod pre range failed", dev->name);
 		goto exit;
 	}
 
-	ret = VL53L0X_SetVcselPulsePeriod(&drv_data->vl53l0x,
-					  VL53L0X_VCSEL_PERIOD_FINAL_RANGE,
+	ret = VL53L0X_SetVcselPulsePeriod(&drv_data->vl53l0x, VL53L0X_VCSEL_PERIOD_FINAL_RANGE,
 					  VL53L0X_SETUP_FINAL_RANGE_VCSEL_PERIOD);
 	if (ret) {
-		LOG_ERR("[%s] VL53L0X_SetVcselPulsePeriod final range failed",
-			dev->name);
+		LOG_ERR("[%s] VL53L0X_SetVcselPulsePeriod final range failed", dev->name);
 		goto exit;
 	}
 
@@ -175,8 +155,7 @@ static int vl53l0x_start(const struct device *dev)
 	if (config->xshut.port) {
 		r = gpio_pin_set_dt(&config->xshut, 1);
 		if (r < 0) {
-			LOG_ERR("[%s] Unable to set XSHUT gpio (error %d)",
-				dev->name, r);
+			LOG_ERR("[%s] Unable to set XSHUT gpio (error %d)", dev->name, r);
 			return -EIO;
 		}
 		k_sleep(K_MSEC(2));
@@ -186,8 +165,7 @@ static int vl53l0x_start(const struct device *dev)
 	if (config->i2c.addr != VL53L0X_INITIAL_ADDR) {
 		ret = VL53L0X_SetDeviceAddress(&drv_data->vl53l0x, 2 * config->i2c.addr);
 		if (ret != 0) {
-			LOG_ERR("[%s] Unable to reconfigure I2C address",
-				dev->name);
+			LOG_ERR("[%s] Unable to reconfigure I2C address", dev->name);
 			return -EIO;
 		}
 
@@ -210,14 +188,10 @@ static int vl53l0x_start(const struct device *dev)
 	LOG_DBG("   Device Name : %s", vl53l0x_dev_info.Name);
 	LOG_DBG("   Device Type : %s", vl53l0x_dev_info.Type);
 	LOG_DBG("   Device ID : %s", vl53l0x_dev_info.ProductId);
-	LOG_DBG("   ProductRevisionMajor : %d",
-		vl53l0x_dev_info.ProductRevisionMajor);
-	LOG_DBG("   ProductRevisionMinor : %d",
-		vl53l0x_dev_info.ProductRevisionMinor);
+	LOG_DBG("   ProductRevisionMajor : %d", vl53l0x_dev_info.ProductRevisionMajor);
+	LOG_DBG("   ProductRevisionMinor : %d", vl53l0x_dev_info.ProductRevisionMinor);
 
-	ret = VL53L0X_RdWord(&drv_data->vl53l0x,
-			     VL53L0X_REG_WHO_AM_I,
-			     (uint16_t *) &vl53l0x_id);
+	ret = VL53L0X_RdWord(&drv_data->vl53l0x, VL53L0X_REG_WHO_AM_I, (uint16_t *)&vl53l0x_id);
 	if ((ret < 0) || (vl53l0x_id != VL53L0X_CHIP_ID)) {
 		LOG_ERR("[%s] Issue on device identification", dev->name);
 		return -ENOTSUP;
@@ -226,8 +200,7 @@ static int vl53l0x_start(const struct device *dev)
 	/* sensor init */
 	ret = VL53L0X_DataInit(&drv_data->vl53l0x);
 	if (ret < 0) {
-		LOG_ERR("[%s] VL53L0X_DataInit return error (%d)",
-			dev->name, ret);
+		LOG_ERR("[%s] VL53L0X_DataInit return error (%d)", dev->name, ret);
 		return -ENOTSUP;
 	}
 
@@ -241,16 +214,14 @@ static int vl53l0x_start(const struct device *dev)
 	return 0;
 }
 
-static int vl53l0x_sample_fetch(const struct device *dev,
-				enum sensor_channel chan)
+static int vl53l0x_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct vl53l0x_data *drv_data = dev->data;
 	VL53L0X_Error ret;
 	int r;
 
-	__ASSERT_NO_MSG((chan == SENSOR_CHAN_ALL)
-			|| (chan == SENSOR_CHAN_DISTANCE)
-			|| (chan == SENSOR_CHAN_PROX));
+	__ASSERT_NO_MSG((chan == SENSOR_CHAN_ALL) || (chan == SENSOR_CHAN_DISTANCE) ||
+			(chan == SENSOR_CHAN_PROX));
 
 	if (!drv_data->started) {
 		r = vl53l0x_start(dev);
@@ -262,17 +233,14 @@ static int vl53l0x_sample_fetch(const struct device *dev,
 	ret = VL53L0X_PerformSingleRangingMeasurement(&drv_data->vl53l0x,
 						      &drv_data->RangingMeasurementData);
 	if (ret < 0) {
-		LOG_ERR("[%s] Could not perform measurment (error=%d)",
-			dev->name, ret);
+		LOG_ERR("[%s] Could not perform measurment (error=%d)", dev->name, ret);
 		return -EINVAL;
 	}
 
 	return 0;
 }
 
-
-static int vl53l0x_channel_get(const struct device *dev,
-			       enum sensor_channel chan,
+static int vl53l0x_channel_get(const struct device *dev, enum sensor_channel chan,
 			       struct sensor_value *val)
 {
 	struct vl53l0x_data *drv_data = dev->data;
@@ -329,8 +297,7 @@ static int vl53l0x_init(const struct device *dev)
 	if (config->xshut.port) {
 		r = gpio_pin_configure_dt(&config->xshut, GPIO_OUTPUT);
 		if (r < 0) {
-			LOG_ERR("[%s] Unable to configure GPIO as output",
-				dev->name);
+			LOG_ERR("[%s] Unable to configure GPIO as output", dev->name);
 		}
 	}
 
@@ -353,19 +320,15 @@ static int vl53l0x_init(const struct device *dev)
 	return 0;
 }
 
-#define VL53L0X_INIT(inst)						 \
-	static struct vl53l0x_config vl53l0x_##inst##_config = {	 \
-		.i2c = I2C_DT_SPEC_INST_GET(inst),			 \
-		.xshut = GPIO_DT_SPEC_INST_GET_OR(inst, xshut_gpios, {}) \
-	};								 \
-									 \
-	static struct vl53l0x_data vl53l0x_##inst##_driver;		 \
-									 \
-	DEVICE_DT_INST_DEFINE(inst, vl53l0x_init, NULL,			 \
-			      &vl53l0x_##inst##_driver,			 \
-			      &vl53l0x_##inst##_config,			 \
-			      POST_KERNEL,				 \
-			      CONFIG_SENSOR_INIT_PRIORITY,		 \
+#define VL53L0X_INIT(inst)                                                                         \
+	static struct vl53l0x_config vl53l0x_##inst##_config = {                                   \
+		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.xshut = GPIO_DT_SPEC_INST_GET_OR(inst, xshut_gpios, {})};                         \
+                                                                                                   \
+	static struct vl53l0x_data vl53l0x_##inst##_driver;                                        \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, vl53l0x_init, NULL, &vl53l0x_##inst##_driver,                  \
+			      &vl53l0x_##inst##_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,  \
 			      &vl53l0x_api_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(VL53L0X_INIT)

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -51,6 +51,18 @@ struct vl53l0x_data {
 	VL53L0X_RangingMeasurementData_t measurement;
 };
 
+static inline bool vl53l0x_supports_chan(enum sensor_channel chan)
+{
+	switch (chan) {
+	case SENSOR_CHAN_ALL:
+	case SENSOR_CHAN_DISTANCE:
+	case SENSOR_CHAN_PROX:
+		return true;
+	default:
+		return false;
+	}
+}
+
 static int vl53l0x_setup_single_shot(const struct device *dev)
 {
 	struct vl53l0x_data *drv_data = dev->data;
@@ -220,8 +232,9 @@ static int vl53l0x_sample_fetch(const struct device *dev, enum sensor_channel ch
 	VL53L0X_Error ret;
 	int r;
 
-	__ASSERT_NO_MSG((chan == SENSOR_CHAN_ALL) || (chan == SENSOR_CHAN_DISTANCE) ||
-			(chan == SENSOR_CHAN_PROX));
+	if (!vl53l0x_supports_chan(chan)) {
+		return -ENOTSUP;
+	}
 
 	if (!drv_data->started) {
 		r = vl53l0x_start(dev);

--- a/dts/bindings/sensor/st,vl53l0x.yaml
+++ b/dts/bindings/sensor/st,vl53l0x.yaml
@@ -11,3 +11,7 @@ properties:
     xshut-gpios:
       type: phandle-array
       required: false
+
+    interrupt-gpios:
+      type: phandle-array
+      required: false

--- a/samples/sensor/vl53l0x/src/main.c
+++ b/samples/sensor/vl53l0x/src/main.c
@@ -4,38 +4,82 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
+#include <stdio.h>
+
 #include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
-#include <stdio.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+
+#define SAMPLING_FREQ 25
+
+void print_distance_and_prox(const struct device *dev)
+{
+	struct sensor_value value;
+	int ret;
+
+	ret = sensor_sample_fetch(dev);
+	if (ret) {
+		printf("sensor_sample_fetch failed ret %d\n", ret);
+		return;
+	}
+
+	ret = sensor_channel_get(dev, SENSOR_CHAN_PROX, &value);
+	printf("prox is %d\n", value.val1);
+
+	ret = sensor_channel_get(dev, SENSOR_CHAN_DISTANCE, &value);
+	printf("distance is %.3fm\n", sensor_value_to_double(&value));
+}
+
+void on_new_data_ready(const struct device *dev, const struct sensor_trigger *trig)
+{
+	ARG_UNUSED(trig);
+	print_distance_and_prox(dev);
+}
 
 void main(void)
 {
-	const struct device *const dev = DEVICE_DT_GET_ONE(st_vl53l0x);
-	struct sensor_value value;
 	int ret;
+	bool trigger_enabled = false;
+	const struct device *const dev = DEVICE_DT_GET_ONE(st_vl53l0x);
+	const struct sensor_trigger trigger = {
+		.chan = SENSOR_CHAN_DISTANCE,
+		.type = SENSOR_TRIG_DATA_READY,
+	};
+	const struct sensor_value sampling_freq = {
+		.val1 = SAMPLING_FREQ,
+		.val2 = 0,
+	};
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
 		return;
 	}
 
+	ret = sensor_attr_set(dev, SENSOR_CHAN_DISTANCE, SENSOR_ATTR_SAMPLING_FREQUENCY,
+			      &sampling_freq);
+	if (ret) {
+		printf("Unable to set sampling freq to %dHz\n", SAMPLING_FREQ);
+		return;
+	}
+
+	ret = sensor_trigger_set(dev, &trigger, on_new_data_ready);
+	switch (ret) {
+	case 0:
+		trigger_enabled = true;
+		printf("Trigger enabled\n");
+		break;
+	case -ENOTSUP:
+		printf("Sensor does not support trigger\n");
+		break;
+	default:
+		return;
+	}
+
 	while (1) {
-		ret = sensor_sample_fetch(dev);
-		if (ret) {
-			printk("sensor_sample_fetch failed ret %d\n", ret);
-			return;
+		if (!trigger_enabled) {
+			print_distance_and_prox(dev);
 		}
-
-		ret = sensor_channel_get(dev, SENSOR_CHAN_PROX, &value);
-		printk("prox is %d\n", value.val1);
-
-		ret = sensor_channel_get(dev,
-					 SENSOR_CHAN_DISTANCE,
-					 &value);
-		printf("distance is %.3fm\n", sensor_value_to_double(&value));
-
 		k_sleep(K_MSEC(1000));
 	}
 }


### PR DESCRIPTION
- drivers: sensor: vl53l0x: run clang-format
- drivers: sensor: vl53l0x: add attr_get/set for the sampling frequency
- drivers: sensor: vl53l0x: add support for interrupt-gpios
- boards: shields: x_nucleo_53l0a1: add interrupt-gpios
- samples: sensors: vl53l0x: update to use trigger mode if available
