### PR TITLE
Bluetooth: controller: Support split advertising PDU pools

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -332,8 +332,10 @@ int lll_adv_data_release(struct lll_adv_pdu *pdu)
 
 	last = pdu->last;
 	p = pdu->pdu[last];
-	pdu->pdu[last] = NULL;
-	mem_release(p, &mem_pdu.free);
+	if (p) {
+		pdu->pdu[last] = NULL;
+		mem_release(p, &mem_pdu.free);
+	}
 
 	last++;
 	if (last == DOUBLE_BUFFER_SIZE) {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
@@ -89,6 +89,11 @@ lll_adv_data_latest_peek(const struct lll_adv *const lll)
 }
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
+static inline int lll_adv_aux_data_init(struct lll_adv_pdu *pdu)
+{
+	return lll_adv_data_init(pdu);
+}
+
 static inline struct pdu_adv *lll_adv_aux_data_alloc(struct lll_adv_aux *lll,
 						     uint8_t *idx)
 {
@@ -118,12 +123,24 @@ static inline struct pdu_adv *lll_adv_aux_data_curr_get(struct lll_adv_aux *lll)
 	return (void *)lll->data.pdu[lll->data.first];
 }
 
+static inline struct pdu_adv *lll_adv_aux_scan_rsp_alloc(struct lll_adv *lll,
+							 uint8_t *idx)
+{
+	return lll_adv_pdu_alloc(&lll->scan_rsp, idx);
+}
+
+
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
 int lll_adv_and_extra_data_release(struct lll_adv_pdu *pdu);
 
 #if defined(CONFIG_BT_CTLR_ADV_SYNC_PDU_BACK2BACK)
 void lll_adv_sync_pdu_b2b_update(struct lll_adv_sync *lll, uint8_t idx);
 #endif
+
+static inline int lll_adv_sync_data_init(struct lll_adv_pdu *pdu)
+{
+	return lll_adv_data_init(pdu);
+}
 
 struct pdu_adv *lll_adv_pdu_and_extra_data_alloc(struct lll_adv_pdu *pdu,
 						 void **extra_data,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -726,7 +726,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 	sr_pdu_prev = lll_adv_scan_rsp_peek(lll);
 
 	/* Get reference to next scan response  PDU */
-	sr_pdu = lll_adv_scan_rsp_alloc(lll, &sr_idx);
+	sr_pdu = lll_adv_aux_scan_rsp_alloc(lll, &sr_idx);
 
 	/* Prepare the AD data as parameter to update in PDU */
 	/* Use length = 0 and NULL pointer to retain old data in the PDU.
@@ -2545,7 +2545,7 @@ struct ll_adv_aux_set *ull_adv_aux_acquire(struct lll_adv *lll)
 	lll_aux->adv = lll;
 
 	lll_adv_data_reset(&lll_aux->data);
-	err = lll_adv_data_init(&lll_aux->data);
+	err = lll_adv_aux_data_init(&lll_aux->data);
 	if (err) {
 		return NULL;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -111,7 +111,7 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 		lll_sync->adv = lll;
 
 		lll_adv_data_reset(&lll_sync->data);
-		err = lll_adv_data_init(&lll_sync->data);
+		err = lll_adv_sync_data_init(&lll_sync->data);
 		if (err) {
 			return BT_HCI_ERR_MEM_CAPACITY_EXCEEDED;
 		}


### PR DESCRIPTION
Adds proper support for having more than one PDU pool for the advertising PDUs (to save memory)

- Introduces lll_adv_aux_data_init, lll_adv_aux_scan_rsp_alloc and lll_adv_sync_data_init to indicate if the PDU is a primary/legacy PDU or secondary/auxillary PDU
- Scan response PDUs are initialized later, since the correct pool to draw from depends on whether the advertising is extended or legacy

Signed-off-by: Troels Nilsson <trnn@demant.com>