### PR TITLE
RFC: Add static code analyzer integration

### DIFF
--- a/cmake/modules/FindHostTools.cmake
+++ b/cmake/modules/FindHostTools.cmake
@@ -108,6 +108,8 @@ include(${TOOLCHAIN_ROOT}/cmake/compiler/${COMPILER}/generic.cmake OPTIONAL)
 include(${TOOLCHAIN_ROOT}/cmake/linker/${LINKER}/generic.cmake OPTIONAL)
 include(${TOOLCHAIN_ROOT}/cmake/bintools/${BINTOOLS}/generic.cmake OPTIONAL)
 
+include(${TOOLCHAIN_ROOT}/cmake/sca_integration.cmake OPTIONAL)
+
 # Optional folder for toolchains with may provide a Kconfig file for capabilities settings.
 set_ifndef(TOOLCHAIN_KCONFIG_DIR ${TOOLCHAIN_ROOT}/cmake/toolchain/${ZEPHYR_TOOLCHAIN_VARIANT})
 

--- a/cmake/sca_integration.cmake
+++ b/cmake/sca_integration.cmake
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+
+function(write_sca_export_jsons SCA_IN_TREE_INTEGRATION_DIR SCA_OUT_OF_TREE_INTEGRATION_DIR)
+  # Write current selected toolchain/compiler to export file
+  message(STATUS "Reading '${SCA_IN_TREE_INTEGRATION_DIR}/sca_export.json.in'")
+  # Read the json
+  file(READ ${SCA_IN_TREE_INTEGRATION_DIR}/sca_export.json.in SCA_EXPORT_JSON)
+  #message(STATUS "read result: ${SCA_EXPORT_JSON}")
+  # Modify the json
+  string(TIMESTAMP DATE_TIME "%Y-%m-%d %H:%M:%S")
+  string(JSON SCA_EXPORT_JSON ERROR_VARIABLE ERR_VAR SET ${SCA_EXPORT_JSON} "Build" "TIMESTAMP" \"${DATE_TIME}\")
+  string(JSON SCA_EXPORT_JSON ERROR_VARIABLE ERR_VAR SET ${SCA_EXPORT_JSON} "Build" "C_COMPILER" \"${CMAKE_C_COMPILER}\")
+  string(JSON SCA_EXPORT_JSON ERROR_VARIABLE ERR_VAR SET ${SCA_EXPORT_JSON} "Build" "CXX_COMPILER" \"${CMAKE_CXX_COMPILER}\")
+  string(JSON SCA_EXPORT_JSON ERROR_VARIABLE ERR_VAR SET ${SCA_EXPORT_JSON} "Build" "ASM_COMPILER" \"${CMAKE_ASM_COMPILER}\")
+  string(JSON SCA_EXPORT_JSON ERROR_VARIABLE ERR_VAR SET ${SCA_EXPORT_JSON} "Build" "LINKER" \"${CMAKE_LINKER}\")
+  #message(STATUS "err-var: ${ERR_VAR}")
+  #message(STATUS "json: ${SCA_EXPORT_JSON}")
+
+  # Write the in tree json
+  file(WRITE ${SCA_IN_TREE_INTEGRATION_DIR}/sca_export.json ${SCA_EXPORT_JSON})
+  message(STATUS "Writing '${SCA_IN_TREE_INTEGRATION_DIR}/sca_export.json'")
+
+  # Write the out of tree json
+  if(NOT ${SCA_OUT_OF_TREE_INTEGRATION_DIR} MATCHES ".*-NOTFOUND")
+    file(WRITE ${SCA_OUT_OF_TREE_INTEGRATION_DIR}/sca_export.json ${SCA_EXPORT_JSON})
+    message(STATUS "Writing '${SCA_OUT_OF_TREE_INTEGRATION_DIR}/sca_export.json'")
+  endif()
+endfunction()
+
+function(exec_sca_hook_scripts SCA_INTEGRATION_DIR)
+  if(${SCA_INTEGRATION_DIR} MATCHES ".*-NOTFOUND")
+    message(STATUS "SCA_INTEGRATION_DIR: ${SCA_INTEGRATION_DIR} - bailing out!")
+    return()
+  endif()
+  string(TOLOWER "${SCA_VARIANT}" LC_SCA_VARIANT)
+  set(SCA_VARIANT_HOOKS_DIR  "${SCA_INTEGRATION_DIR}/hooks/${LC_SCA_VARIANT}")
+# Update the SCA configuration if required, run any matching script!
+  set(SCA_UPDATE_SCRIPT_EXTS sh bat py rb pl js ps1)
+  foreach(SCA_UPDATE_SCRIPT_EXT ${SCA_UPDATE_SCRIPT_EXTS})
+    # unset SCA_UPDATE_SCRIPT everytime before find_program to force new search!
+    unset(SCA_UPDATE_SCRIPT CACHE)
+    string(TOLOWER "update.${SCA_UPDATE_SCRIPT_EXT}" SCA_UPDATE_SCRIPT_NAME)
+    find_program(SCA_UPDATE_SCRIPT ${SCA_UPDATE_SCRIPT_NAME} PATHS ${SCA_VARIANT_HOOKS_DIR} NO_CACHE)
+    if(NOT ${SCA_UPDATE_SCRIPT} MATCHES ".*-NOTFOUND")
+      execute_process(COMMAND ${SCA_UPDATE_SCRIPT} ${SCA_INTEGRATION_DIR}/sca_export.json
+      WORKING_DIRECTORY ${SCA_INTEGRATION_DIR}
+      RESULT_VARIABLE SCA_UPDATE_SCRIPT_RETVAL)
+      # In accordance with https://tldp.org/LDP/abs/html/exitcodes.html for the user-defined exit code range
+      if(${SCA_UPDATE_SCRIPT_RETVAL} EQUAL 0)
+        # The script was successful. No further scripts will be executed.
+        break()
+      elseif(${SCA_UPDATE_SCRIPT_RETVAL} EQUAL 111)
+        # The script wants more scripts to be executed.
+      else()
+        # The script was unsuccessful. The build will be terminated.
+        message(FATAL_ERROR "The script '${SCA_UPDATE_SCRIPT_NAME}' returned '${SCA_UPDATE_SCRIPT_RETVAL}'")
+      endif()
+    else()
+        message(STATUS "'${SCA_UPDATE_SCRIPT_NAME}' in '${SCA_VARIANT_HOOKS_DIR}' not found or not an executable!")
+    endif()
+  endforeach()
+endfunction()
+
+function(read_sca_import_json SCA_INTEGRATION_DIR)
+  if(${SCA_INTEGRATION_DIR} MATCHES ".*-NOTFOUND")
+    message(STATUS "SCA_INTEGRATION_DIR: ${SCA_INTEGRATION_DIR} - bailing out!")
+    return()
+  endif()
+# read SCA integration import file
+  message(STATUS "Reading '${SCA_INTEGRATION_DIR}/sca_import.json'")
+  file(READ ${SCA_INTEGRATION_DIR}/sca_import.json SCA_IMPORT_JSON)
+  #message(STATUS ${SCA_IMPORT_JSON})
+
+  # read the variables from the json
+  string(JSON SCA_CONFIG ERROR_VARIABLE ERR_VAR GET ${SCA_IMPORT_JSON} "SCAs" ${SCA_VARIANT})
+  #message(STATUS "SCA_CONFIG: ${SCA_CONFIG}")
+
+  if(${SCA_CONFIG} MATCHES ".*-NOTFOUND")
+    message(STATUS "Config not found!")
+  else()
+    message(STATUS "Config found!")
+    set(SCA_CONFIG_FOUND TRUE PARENT_SCOPE)
+    string(JSON SCA_C_COMPILER ERROR_VARIABLE ERR_VAR GET ${SCA_IMPORT_JSON} "SCAs" ${SCA_VARIANT} "C_COMPILER")
+    message(STATUS "SCA_C_COMPILER: ${SCA_C_COMPILER}")
+
+    string(JSON SCA_CXX_COMPILER ERROR_VARIABLE ERR_VAR GET ${SCA_IMPORT_JSON} "SCAs" ${SCA_VARIANT} "CXX_COMPILER")
+    message(STATUS "SCA_CXX_COMPILER: ${SCA_CXX_COMPILER}")
+
+    string(JSON SCA_ASM_COMPILER ERROR_VARIABLE ERR_VAR GET ${SCA_IMPORT_JSON} "SCAs" ${SCA_VARIANT} "ASM_COMPILER")
+    message(STATUS "SCA_ASM_COMPILER: ${SCA_ASM_COMPILER}")
+
+    string(JSON SCA_LINKER ERROR_VARIABLE ERR_VAR GET ${SCA_IMPORT_JSON} "SCAs" ${SCA_VARIANT} "LINKER")
+    message(STATUS "SCA_LINKER: ${SCA_LINKER}")
+
+    # replace the current selected toolchain/compiler by SCA executables
+    if(${SCA_C_COMPILER})
+      #set(CMAKE_C_COMPILER ${SCA_C_COMPILER})
+    endif()
+    if(${SCA_CXX_COMPILER})
+      #set(CMAKE_CXX_COMPILER ${SCA_CXX_COMPILER})
+    endif()
+    if(${SCA_ASM_COMPILER})
+      #set(CMAKE_ASM_COMPILER ${SCA_ASM_COMPILER})
+    endif()
+    if(${SCA_LINKER})
+      #set(CMAKE_LINKER ${SCA_LINKER})
+    endif()
+  endif()
+endfunction()
+
+if(DEFINED SCA_VARIANT)
+  message(STATUS "*** Start SCA integration for '${SCA_VARIANT}' ***")
+  set(SCA_IN_TREE_INTEGRATION_DIR "${ZEPHYR_BASE}/scripts/sca_integration")
+  if(DEFINED ENV{SCA_INTEGRATION_DIR})
+  set(SCA_OUT_OF_TREE_INTEGRATION_DIR $ENV{SCA_INTEGRATION_DIR})
+  else()
+    set(SCA_OUT_OF_TREE_INTEGRATION_DIR "-NOTFOUND")
+    message(STATUS "No SCA integration folder defined!")
+  endif()
+
+  write_sca_export_jsons(${SCA_IN_TREE_INTEGRATION_DIR} ${SCA_OUT_OF_TREE_INTEGRATION_DIR})
+
+  message(STATUS "Calling 'read_sca_import_json' (out of tree): ${SCA_OUT_OF_TREE_INTEGRATION_DIR}")
+  read_sca_import_json(${SCA_OUT_OF_TREE_INTEGRATION_DIR})
+  if(${SCA_CONFIG_FOUND})
+    message(STATUS "Calling 'exec_sca_hook_scripts' ${SCA_OUT_OF_TREE_INTEGRATION_DIR}")
+    exec_sca_hook_scripts(${SCA_OUT_OF_TREE_INTEGRATION_DIR})
+  else()
+    message(STATUS "Calling 'read_sca_import_json' (in tree): ${SCA_IN_TREE_INTEGRATION_DIR}")
+    read_sca_import_json(${SCA_IN_TREE_INTEGRATION_DIR})
+    if(${SCA_CONFIG_FOUND})
+      message(STATUS "Calling 'exec_sca_hook_scripts' ${SCA_IN_TREE_INTEGRATION_DIR}")
+      exec_sca_hook_scripts(${SCA_IN_TREE_INTEGRATION_DIR})
+    endif()
+  endif()
+  message(STATUS "*** SCA integration for: '${SCA_VARIANT}' done! ***")
+else()
+  message(STATUS "No SCA integration (SCA_VARIANT undefined)")
+endif()
+
+
+

--- a/scripts/sca_integration/hooks/cppcheck/update.bat
+++ b/scripts/sca_integration/hooks/cppcheck/update.bat
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Executing batch as bash: '$0 $@'" >&2
+
+# 'Do some useful processing of sca_export.json as passed in $@ resp. $1
+
+exit 111

--- a/scripts/sca_integration/hooks/cppcheck/update.py
+++ b/scripts/sca_integration/hooks/cppcheck/update.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import json
+
+print( "Exectuing: '" + str(sys.argv[0:]) + "'", file=sys.stderr)
+
+# Do some useful processing of sca_export.json as passed in argv[1]
+
+sys.exit(0)

--- a/scripts/sca_integration/hooks/cppcheck/update.sh
+++ b/scripts/sca_integration/hooks/cppcheck/update.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Executing: '$0 $@'" >&2
+
+# Do some useful processing of sca_export.json as passed in $@ resp. $1
+
+exit 111

--- a/scripts/sca_integration/hooks/cpptest/update.bat
+++ b/scripts/sca_integration/hooks/cpptest/update.bat
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Executing batch as bash: '$0 $@'" >&2
+
+# 'Do some useful processing of sca_export.json as passed in $@ resp. $1
+
+exit 111

--- a/scripts/sca_integration/hooks/cpptest/update.py
+++ b/scripts/sca_integration/hooks/cpptest/update.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+import json
+
+print( "Exectuing: '" + str(sys.argv[0:]) + "'", file=sys.stderr)
+
+# Do some useful processing of sca_export.json as passed in argv[1]
+
+file = open(sys.argv[1])
+data = json.load(file)
+
+print("Write/update 'extern CPPTEST_CC=\"" + data['Build']['C_COMPILER'] + "\"' in your ~/.bashrc or similar", file=sys.stderr)
+
+file.close()
+
+
+sys.exit(0)
+

--- a/scripts/sca_integration/hooks/cpptest/update.sh
+++ b/scripts/sca_integration/hooks/cpptest/update.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Executing: '$0 $@'" >&2
+
+# Do some useful processing of sca_export.json as passed in $@ resp. $1
+
+exit 111

--- a/scripts/sca_integration/out_of_tree_template/sca_integration/hooks/axivion/update.bat
+++ b/scripts/sca_integration/out_of_tree_template/sca_integration/hooks/axivion/update.bat
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Executing batch as bash: '$0 $@'" >&2
+
+# 'Do some useful processing of sca_build_export.json as passed in $@ resp. $1
+
+exit 111

--- a/scripts/sca_integration/out_of_tree_template/sca_integration/hooks/axivion/update.py
+++ b/scripts/sca_integration/out_of_tree_template/sca_integration/hooks/axivion/update.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import sys
+
+print( "Exectuing: '" + str(sys.argv[0:]) + "'", file=sys.stderr)
+
+# Do some useful processing of sca_build_export.json as passed in argv[1]
+
+sys.exit(0)

--- a/scripts/sca_integration/out_of_tree_template/sca_integration/hooks/axivion/update.sh
+++ b/scripts/sca_integration/out_of_tree_template/sca_integration/hooks/axivion/update.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Executing: '$0 $@'" >&2
+
+# Do some useful processing of sca_build_export.json as passed in $@ resp. $1
+
+exit 111

--- a/scripts/sca_integration/out_of_tree_template/sca_integration/hooks/cppcheck/update.bat
+++ b/scripts/sca_integration/out_of_tree_template/sca_integration/hooks/cppcheck/update.bat
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Executing batch as bash: '$0 $@'" >&2
+
+# 'Do some useful processing of sca_build_export.json as passed in $@ resp. $1
+
+exit 111

--- a/scripts/sca_integration/out_of_tree_template/sca_integration/hooks/cppcheck/update.py
+++ b/scripts/sca_integration/out_of_tree_template/sca_integration/hooks/cppcheck/update.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import sys
+
+print( "Exectuing: '" + str(sys.argv[0:]) + "'", file=sys.stderr)
+
+# Do some useful processing of sca_build_export.json as passed in argv[1]
+
+sys.exit(0)

--- a/scripts/sca_integration/out_of_tree_template/sca_integration/hooks/cppcheck/update.sh
+++ b/scripts/sca_integration/out_of_tree_template/sca_integration/hooks/cppcheck/update.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Executing: '$0 $@'" >&2
+
+# Do some useful processing of sca_build_export.json as passed in $@ resp. $1
+
+exit 111

--- a/scripts/sca_integration/out_of_tree_template/sca_integration/sca_import.json
+++ b/scripts/sca_integration/out_of_tree_template/sca_integration/sca_import.json
@@ -1,0 +1,15 @@
+{	"SCAs": {
+		"Axivion" : {
+			"C_COMPILER" : "/opt/bauhaus-suite/bin/ircc",
+			"CXX_COMPILER" : "/opt/bauhaus-suite/bin/ircc",
+			"ASM_COMPILER" : "/opt/bauhaus-suite/bin/ircc",
+			"LINKER" : "/opt/bauhaus-suite/bin/ircc"
+		},
+		"cppcheck" : {
+			"C_COMPILER" : "/opt/cppcheck/bin/cppcheck",
+			"CXX_COMPILER" : "/opt/cppcheck/bin/cppcheck",
+			"ASM_COMPILER" : "/opt/cppcheck/bin/cppcheck",
+			"LINKER" : "/opt/cppcheck/bin/cppcheck"
+		}
+	}
+}

--- a/scripts/sca_integration/sca_export.json
+++ b/scripts/sca_integration/sca_export.json
@@ -1,0 +1,10 @@
+{
+  "Build" : 
+  {
+    "ASM_COMPILER" : "",
+    "CXX_COMPILER" : "",
+    "C_COMPILER" : "/usr/bin/gcc",
+    "LINKER" : "",
+    "TIMESTAMP" : "2022-10-12 07:30:50"
+  }
+}

--- a/scripts/sca_integration/sca_export.json.in
+++ b/scripts/sca_integration/sca_export.json.in
@@ -1,0 +1,8 @@
+{	"Build" : {
+		"TIMESTAMP" : "<unset>",
+		"C_COMPILER" : "<unset>",
+		"CXX_COMPILER" : "<unset>",
+		"ASM_COMPILER" : "<unset>",
+		"LINKER" : "<unset>"
+	}
+}

--- a/scripts/sca_integration/sca_import.json
+++ b/scripts/sca_integration/sca_import.json
@@ -1,0 +1,15 @@
+{	"SCAs": {
+		"cppcheck" : {
+			"C_COMPILER" : "/opt/cppcheck/bin/cppcheck",
+			"CXX_COMPILER" : "/opt/cppcheck/bin/cppcheck",
+			"ASM_COMPILER" : "/opt/cppcheck/bin/cppcheck",
+			"LINKER" : "/opt/cppcheck/bin/cppcheck"
+		},
+		"cpptest" : {
+			"C_COMPILER" : "/opt/cpptest/bin/cpptest",
+			"CXX_COMPILER" : "/opt/cpptest/bin/cpptest",
+			"ASM_COMPILER" : "/opt/cpptest/bin/cpptest",
+			"LINKER" : "/opt/cpptest/bin/cpptest"
+		}
+	}
+}


### PR DESCRIPTION
# Brief
This is a unfinished draft implementation of a static code analyzer (SCA) integration implementation into Zephyr's cmake build system. Its not a full integration than rather an interface:
- sca_export.json
- sca_import.json
- sca configuration update script hooks

# Mechansim and architecture
The idea behind is to replace the actual toolchain in the CMAKE_C_COMPILER etc. variables by the SCA executable's at a late configuration stage of the build system (vai import json file). The actual toolchain information is exported (export json file) and a hook script started, allowing to configure the SCA accordingly.
Multiple SCA's can be added in the import json file. Their configuration getting referenced by SCA_VARIANT=\<sca-variant-name\>.
The hook scripts are organized in a \<sca-integration\>/hooks/\<sca-variant\> subfolder.

By using json type files for the import and export format, the mechanism can easily be extended.

## Integration into build system
There is one main cmake script handling the sca_integration
- sca_integration.cmake.
This script need to be hooked into the build system at the right position/location.

## Configuration folders
There are two equally structured folders, which are considered by the script:
- In tree: $ZEPHYR_BASE/scripts/sca_integration
- Out of tree: $SCA_INTEGRATION_DIR (e.g. $MY_REPO_BASE/scripts/sca_integration)
- The out of tree configuration for the same SCA (-DSCA_VARIANT) will overrule the in tree configuration

## Open points / questions
- [ ] Where is the right spot to integrate such a script?
- [ ] Why are most `CMAKE_<xyz>_COMPILER` variables empty (unless `CMAKE_C_COMPILER`) at the current location where the cmake file is currently called?
- [ ] Write a doc

# Call examples
Even though not really different, two examples for in and out of tree:

## In tree
```
west build -p always -b native_posix ./tests/crypto/rand32/ -- -DSCA_VARIANT=cpptest
```
## Out of tree
```
west build -p always -b native_posix ./tests/middleware/sdp/bin_selector/ -- -DSCA_VARIANT=Axivion
```

To make it even more convenient, a west option --sca /-s or similar could be implemented avoiding the `-- -DSCA_VARIANT=<sca-variant-name>`

# Back porting
The implementation is intended to be back-ported to `2.7-auditable-branch`.

# Existing integrations
The suggestion would be to integrate any analyzer tool where the actual toolchain/compiler need to be replaced by the analyzer in the build system, which then calls the toolchain/compiler before starting its own analysis.

The mechansim would also work for analyzers which intercept the call to the toolchain/compiler at an OS level (as virus scanner do), telling those analyzers which executable to intercept. In that case the import file section for such an analyzer remains basically empty (C_COMPILER, CXX_COMPILER etc. will be missing in the import json).

I would assume that also `sparse` (#43776) could be integrated with that mechanism.

# Further information
## Commit comment 
```
Add a generic way to integrate any static code analyzer into the cmake build script.
- Writing the selected toolchain paths to the sca_export.json
- Reading the static code analyzer toolchain paths from a sca_import.json and replacing the CMAKE_C_COMPILER settings with the values read from the json
- Executing static code analyzer customized scripts updating the analyzers configuration (with the information in sca_export.json)
- Support for a in tree and a out of tree location, allowing to integrate analyzers as part of Zephyr itself and as part of a customer environment using Zephyr as its base.

Signed-off-by: Roman Kellner <rkellner@baumer.com>
```