### PR TITLE
dai: dmic: Add missing include header

### DIFF
--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -12,6 +12,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/devicetree.h>
 


### PR DESCRIPTION
The code was missing #include <zephyr/kernel.h> which caused a compilation error. Missing header has been added.

Signed-off-by: Adrian Warecki <adrian.warecki@intel.com>