### PR TITLE
init: remove the need for a dummy device pointer in SYS_INIT functions

### DIFF
--- a/arch/arc/core/arc_smp.c
+++ b/arch/arc/core/arc_smp.c
@@ -145,9 +145,8 @@ void arch_sched_ipi(void)
 	}
 }
 
-static int arc_smp_init(const struct device *dev)
+static int arc_smp_init(void)
 {
-	ARG_UNUSED(dev);
 	struct arc_connect_bcr bcr;
 
 	/* necessary master core init */

--- a/arch/arc/core/cache.c
+++ b/arch/arc/core/cache.c
@@ -216,9 +216,8 @@ int arch_icache_flush_and_invd_range(void *addr, size_t size)
 	return -ENOTSUP;
 }
 
-static int init_dcache(const struct device *unused)
+static int init_dcache(void)
 {
-	ARG_UNUSED(unused);
 
 	arch_dcache_enable();
 

--- a/arch/arc/core/irq_offload.c
+++ b/arch/arc/core/irq_offload.c
@@ -54,9 +54,8 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 }
 
 /* need to be executed on every core in the system */
-int arc_irq_offload_init(const struct device *unused)
+int arc_irq_offload_init(void)
 {
-	ARG_UNUSED(unused);
 
 	IRQ_CONNECT(IRQ_OFFLOAD_LINE, IRQ_OFFLOAD_PRIO, arc_irq_offload_handler, NULL, 0);
 

--- a/arch/arc/core/mpu/arc_mpu_common_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_common_internal.h
@@ -238,9 +238,8 @@ int arc_core_mpu_buffer_validate(void *addr, size_t size, int write)
  * This function provides the default configuration mechanism for the Memory
  * Protection Unit (MPU).
  */
-static int arc_mpu_init(const struct device *arg)
+static int arc_mpu_init(void)
 {
-	ARG_UNUSED(arg);
 
 	uint32_t num_regions = get_num_regions();
 

--- a/arch/arc/core/mpu/arc_mpu_v4_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v4_internal.h
@@ -814,9 +814,8 @@ int arc_core_mpu_buffer_validate(void *addr, size_t size, int write)
  * This function provides the default configuration mechanism for the Memory
  * Protection Unit (MPU).
  */
-static int arc_mpu_init(const struct device *arg)
+static int arc_mpu_init(void)
 {
-	ARG_UNUSED(arg);
 	uint32_t num_regions;
 	uint32_t i;
 

--- a/arch/arc/core/secureshield/arc_sjli.c
+++ b/arch/arc/core/secureshield/arc_sjli.c
@@ -48,7 +48,7 @@ static void sjli_table_init(void)
 /*
  * @brief initialization of secureshield related functions.
  */
-static int arc_secureshield_init(const struct device *arg)
+static int arc_secureshield_init(void)
 {
 	sjli_table_init();
 

--- a/arch/arm/core/aarch32/cortex_m/debug.c
+++ b/arch/arm/core/aarch32/cortex_m/debug.c
@@ -58,9 +58,8 @@ BUILD_ASSERT(!(CONFIG_CORTEX_M_NULL_POINTER_EXCEPTION_PAGE_SIZE &
 	(CONFIG_CORTEX_M_NULL_POINTER_EXCEPTION_PAGE_SIZE - 1)),
 	"the size of the partition must be power of 2");
 
-static int z_arm_debug_enable_null_pointer_detection(const struct device *arg)
+static int z_arm_debug_enable_null_pointer_detection(void)
 {
-	ARG_UNUSED(arg);
 
 	z_arm_dwt_init();
 	z_arm_dwt_enable_debug_monitor();

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -226,9 +226,8 @@ void z_arm64_flush_fpu_ipi(unsigned int cpu)
 }
 #endif
 
-static int arm64_smp_init(const struct device *dev)
+static int arm64_smp_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/*
 	 * SGI0 is use for sched ipi, this might be changed to use Kconfig

--- a/arch/arm64/core/xen/enlighten.c
+++ b/arch/arm64/core/xen/enlighten.c
@@ -42,9 +42,8 @@ static int xen_map_shared_info(const shared_info_t *shared_page)
 	return HYPERVISOR_memory_op(XENMEM_add_to_physmap, &xatp);
 }
 
-static int xen_enlighten_init(const struct device *dev)
+static int xen_enlighten_init(void)
 {
-	ARG_UNUSED(dev);
 	int ret = 0;
 	shared_info_t *info = (shared_info_t *) shared_info_buf;
 

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -118,9 +118,8 @@ static void ipi_handler(const void *unused)
 #endif
 }
 
-static int riscv_smp_init(const struct device *dev)
+static int riscv_smp_init(void)
 {
-	ARG_UNUSED(dev);
 
 	IRQ_CONNECT(RISCV_MACHINE_SOFT_IRQ, 0, ipi_handler, NULL, 0);
 	irq_enable(RISCV_MACHINE_SOFT_IRQ);

--- a/arch/x86/core/spec_ctrl.c
+++ b/arch/x86/core/spec_ctrl.c
@@ -17,9 +17,8 @@
  */
 
 #if defined(CONFIG_DISABLE_SSBD) || defined(CONFIG_ENABLE_EXTENDED_IBRS)
-static int spec_ctrl_init(const struct device *dev)
+static int spec_ctrl_init(void)
 {
-	ARG_UNUSED(dev);
 
 	uint32_t enable_bits = 0U;
 	uint32_t cpuid7 = z_x86_cpuid_extended_features();

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -702,7 +702,7 @@ void z_x86_dump_page_tables(pentry_t *ptables)
 
 #if DUMP_PAGE_TABLES
 __pinned_func
-static int dump_kernel_tables(const struct device *unused)
+static int dump_kernel_tables(void)
 {
 	z_x86_dump_page_tables(z_x86_kernel_ptables);
 

--- a/boards/arc/em_starterkit/pmodmux.c
+++ b/boards/arc/em_starterkit/pmodmux.c
@@ -123,7 +123,7 @@
 #define PM6_LR_CSS_STAT		((1 << BIT2) << PM6_OFFSET)
 
 
-static int pmod_mux_init(const struct device *dev)
+static int pmod_mux_init(void)
 {
 	volatile uint32_t *mux_regs = (uint32_t *)(PMODMUX_BASE_ADDR);
 

--- a/boards/arc/hsdk/platform.c
+++ b/boards/arc/hsdk/platform.c
@@ -10,9 +10,8 @@
 #define HSDK_CREG_GPIO_MUX_REG	0xf0001484
 #define HSDK_CREG_GPIO_MUX_VAL	0x00000400
 
-static int hsdk_creg_gpio_mux_init(const struct device *dev)
+static int hsdk_creg_gpio_mux_init(void)
 {
-	ARG_UNUSED(dev);
 
 	sys_write32(HSDK_CREG_GPIO_MUX_REG, HSDK_CREG_GPIO_MUX_VAL);
 

--- a/boards/arc/nsim/haps_arcv3_init.c
+++ b/boards/arc/nsim/haps_arcv3_init.c
@@ -30,9 +30,8 @@
 #define AUX_CLN_DATA			0x641
 
 
-static int haps_arcv3_init(const struct device *dev)
+static int haps_arcv3_init(void)
 {
-	ARG_UNUSED(dev);
 
 	z_arc_v2_aux_reg_write(AUX_CLN_ADDR, ARC_CLN_PER0_BASE);
 	z_arc_v2_aux_reg_write(AUX_CLN_DATA, 0xF00);

--- a/boards/arm/96b_wistrio/rf.c
+++ b/boards/arm/96b_wistrio/rf.c
@@ -7,7 +7,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/init.h>
 
-static int rf_init(const struct device *dev)
+static int rf_init(void)
 {
 	const struct gpio_dt_spec rf1 =
 		GPIO_DT_SPEC_GET(DT_NODELABEL(rf_switch), rf1_gpios);
@@ -16,7 +16,6 @@ static int rf_init(const struct device *dev)
 	const struct gpio_dt_spec rf3 =
 		GPIO_DT_SPEC_GET(DT_NODELABEL(rf_switch), rf3_gpios);
 
-	ARG_UNUSED(dev);
 
 	/* configure RFSW8001 GPIOs (110: RF1/RF2 coexistence mode) */
 	if (!device_is_ready(rf1.port) ||

--- a/boards/arm/arduino_nano_33_ble/board.c
+++ b/boards/arm/arduino_nano_33_ble/board.c
@@ -7,9 +7,8 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
 
-static int board_init(const struct device *dev)
+static int board_init(void)
 {
-	ARG_UNUSED(dev);
 
 	int res;
 	static const struct gpio_dt_spec pull_up =

--- a/boards/arm/arduino_portenta_h7/board.c
+++ b/boards/arm/arduino_portenta_h7/board.c
@@ -7,9 +7,8 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
 
-static int board_init(const struct device *dev)
+static int board_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* Set led1 inactive since the Arduino bootloader leaves it active */
 	const struct gpio_dt_spec led1 = GPIO_DT_SPEC_GET(DT_ALIAS(led1), gpios);

--- a/boards/arm/arty/board.c
+++ b/boards/arm/arty/board.c
@@ -60,9 +60,8 @@ bool board_daplink_is_fitted(void)
 	return !NVIC_GetPendingIRQ(DT_IRQN(DAPLINK_QSPI_MUX_NODE));
 }
 
-static int board_init(const struct device *dev)
+static int board_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/*
 	 * Automatically select normal mode unless the DAPLink shield is fitted

--- a/boards/arm/beagle_bcf/board_antenna.c
+++ b/boards/arm/beagle_bcf/board_antenna.c
@@ -41,9 +41,8 @@ const RFCC26XX_HWAttrsV2 RFCC26XX_hwAttrs = {
 /**
  * Antenna switch GPIO init routine.
  */
-static int board_antenna_init(const struct device *dev)
+static int board_antenna_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* set all paths to low */
 	IOCPinTypeGpioOutput(BOARD_RF_HIGH_PA);

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpunet_reset.c
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpunet_reset.c
@@ -23,9 +23,8 @@ static void remoteproc_mgr_config(void)
 #endif /* !CONFIG_TRUSTED_EXECUTION_NONSECURE */
 }
 
-static int remoteproc_mgr_boot(const struct device *dev)
+static int remoteproc_mgr_boot(void)
 {
-	ARG_UNUSED(dev);
 
 	/* Secure domain may configure permissions for the Network MCU. */
 	remoteproc_mgr_config();

--- a/boards/arm/cc3220sf_launchxl/pinmux.c
+++ b/boards/arm/cc3220sf_launchxl/pinmux.c
@@ -89,9 +89,8 @@
 #define I2C_CC32XX_PIN_16_I2C_SCL  0x90F  /*!< PIN 16 is used for I2C_SCL */
 #define I2C_CC32XX_PIN_17_I2C_SDA  0x910  /*!< PIN 17 is used for I2C_SDA */
 
-int pinmux_initialize(const struct device *port)
+int pinmux_initialize(void)
 {
-	ARG_UNUSED(port);
 
 #ifdef CONFIG_UART_CC32XX
 	/* Configure PIN_55 for UART0 UART0_TX */

--- a/boards/arm/cc3235sf_launchxl/pinmux.c
+++ b/boards/arm/cc3235sf_launchxl/pinmux.c
@@ -64,9 +64,8 @@
 #define I2C_CC32XX_PIN_16_I2C_SCL  0x90F  /*!< PIN 16 is used for I2C_SCL */
 #define I2C_CC32XX_PIN_17_I2C_SDA  0x910  /*!< PIN 17 is used for I2C_SDA */
 
-int pinmux_initialize(const struct device *port)
+int pinmux_initialize(void)
 {
-	ARG_UNUSED(port);
 
 #ifdef CONFIG_UART_CC32XX
 	/* Configure PIN_55 for UART0 UART0_TX */

--- a/boards/arm/efm32gg_slwstk6121a/board.c
+++ b/boards/arm/efm32gg_slwstk6121a/board.c
@@ -12,9 +12,8 @@
 #include "em_cmu.h"
 #include "board.h"
 
-static int efm32gg_slwstk6121a_init(const struct device *dev)
+static int efm32gg_slwstk6121a_init(void)
 {
-	ARG_UNUSED(dev);
 
 	const struct device *cur_dev;
 

--- a/boards/arm/efm32gg_stk3701a/board.c
+++ b/boards/arm/efm32gg_stk3701a/board.c
@@ -11,11 +11,10 @@
 #include <zephyr/sys/printk.h>
 #include "em_cmu.h"
 
-static int efm32gg_stk3701a_init(const struct device *dev)
+static int efm32gg_stk3701a_init(void)
 {
 	const struct device *cur_dev;
 
-	ARG_UNUSED(dev);
 
 	/* Enable the board controller to be able to use the serial port */
 	cur_dev = DEVICE_DT_GET(BC_ENABLE_GPIO_NODE);

--- a/boards/arm/efm32hg_slstk3400a/board.c
+++ b/boards/arm/efm32hg_slstk3400a/board.c
@@ -9,11 +9,10 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/printk.h>
 
-static int efm32hg_slstk3400a_init(const struct device *dev)
+static int efm32hg_slstk3400a_init(void)
 {
 	const struct device *bce_dev; /* Board Controller Enable Gpio Device */
 
-	ARG_UNUSED(dev);
 
 	/* Enable the board controller to be able to use the serial port */
 	bce_dev = DEVICE_DT_GET(BC_ENABLE_GPIO_NODE);

--- a/boards/arm/efm32pg_stk3401a/board.c
+++ b/boards/arm/efm32pg_stk3401a/board.c
@@ -9,11 +9,10 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/printk.h>
 
-static int efm32pg_stk3401a_init(const struct device *dev)
+static int efm32pg_stk3401a_init(void)
 {
 	const struct device *bce_dev; /* Board Controller Enable Gpio Device */
 
-	ARG_UNUSED(dev);
 
 	/* Enable the board controller to be able to use the serial port */
 	bce_dev = DEVICE_DT_GET(BC_ENABLE_GPIO_NODE);

--- a/boards/arm/efm32pg_stk3402a/board.c
+++ b/boards/arm/efm32pg_stk3402a/board.c
@@ -9,11 +9,10 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/printk.h>
 
-static int efm32pg_stk3402a_init(const struct device *dev)
+static int efm32pg_stk3402a_init(void)
 {
 	const struct device *bce_dev; /* Board Controller Enable Gpio Device */
 
-	ARG_UNUSED(dev);
 
 	/* Enable the board controller to be able to use the serial port */
 	bce_dev = DEVICE_DT_GET(BC_ENABLE_GPIO_NODE);

--- a/boards/arm/efm32wg_stk3800/board.c
+++ b/boards/arm/efm32wg_stk3800/board.c
@@ -9,11 +9,10 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/printk.h>
 
-static int efm32wg_stk3800_init(const struct device *dev)
+static int efm32wg_stk3800_init(void)
 {
 	const struct device *bce_dev; /* Board Controller Enable Gpio Device */
 
-	ARG_UNUSED(dev);
 
 	/* Enable the board controller to be able to use the serial port */
 	bce_dev = DEVICE_DT_GET(BC_ENABLE_GPIO_NODE);

--- a/boards/arm/efr32_radio/board.c
+++ b/boards/arm/efr32_radio/board.c
@@ -17,11 +17,10 @@
 #define VCOM_ENABLE_GPIO_PIN   5
 #endif /* CONFIG_BOARD_EFR32_RADIO_BRD4180A */
 
-static int efr32_radio_init(const struct device *dev)
+static int efr32_radio_init(void)
 {
 	const struct device *vce_dev; /* Virtual COM Port Enable GPIO Device */
 
-	ARG_UNUSED(dev);
 
 	/* Enable the board controller to be able to use the serial port */
 	vce_dev = DEVICE_DT_GET(VCOM_ENABLE_GPIO_NODE);

--- a/boards/arm/efr32bg_sltb010a/board.c
+++ b/boards/arm/efr32bg_sltb010a/board.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(efr32bg_sltb010a, CONFIG_BOARD_EFR32BG22_LOG_LEVEL);
 
 static int efr32bg_sltb010a_init_clocks(void);
 
-static int efr32bg_sltb010a_init(const struct device *dev)
+static int efr32bg_sltb010a_init(void)
 {
 	int ret;
 
@@ -26,7 +26,6 @@ static int efr32bg_sltb010a_init(const struct device *dev)
 	static struct gpio_dt_spec wake_up_gpio_dev =
 		GPIO_DT_SPEC_GET(DT_NODELABEL(wake_up_trigger), gpios);
 
-	ARG_UNUSED(dev);
 
 	if (!device_is_ready(wake_up_gpio_dev.port)) {
 		LOG_ERR("Wake-up GPIO device was not found!\n");

--- a/boards/arm/efr32mg_sltb004a/board.c
+++ b/boards/arm/efr32mg_sltb004a/board.c
@@ -28,12 +28,11 @@ static int enable_supply(const struct supply_cfg *cfg)
 	return rv;
 }
 
-static int efr32mg_sltb004a_init(const struct device *dev)
+static int efr32mg_sltb004a_init(void)
 {
 	struct supply_cfg cfg;
 	int rc = 0;
 
-	ARG_UNUSED(dev);
 	(void)cfg;
 
 #define CCS811 DT_NODELABEL(ccs811)

--- a/boards/arm/efr32xg24_dk2601b/board.c
+++ b/boards/arm/efr32xg24_dk2601b/board.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(efr32xg24_dk2601b, CONFIG_BOARD_EFR32MG24_LOG_LEVEL);
 
 static int efr32xg24_dk2601b_init_clocks(void);
 
-static int efr32xg24_dk2601b_init(const struct device *dev)
+static int efr32xg24_dk2601b_init(void)
 {
 	int ret;
 
@@ -27,7 +27,6 @@ static int efr32xg24_dk2601b_init(const struct device *dev)
 	static struct gpio_dt_spec wake_up_gpio_dev =
 		GPIO_DT_SPEC_GET(DT_NODELABEL(wake_up_trigger), gpios);
 
-	ARG_UNUSED(dev);
 
 	if (!device_is_ready(wake_up_gpio_dev.port)) {
 		LOG_ERR("Wake-up GPIO device was not found!\n");

--- a/boards/arm/lpcxpresso55s69/pinmux.c
+++ b/boards/arm/lpcxpresso55s69/pinmux.c
@@ -9,9 +9,8 @@
 #include <fsl_iocon.h>
 #include <soc.h>
 
-static int lpcxpresso_55s69_pinmux_init(const struct device *dev)
+static int lpcxpresso_55s69_pinmux_init(void)
 {
-	ARG_UNUSED(dev);
 
 #if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexcomm6), nxp_lpc_i2s, okay)) && \
 		(DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexcomm7), nxp_lpc_i2s, okay)) && \

--- a/boards/arm/mec2016evb_assy6797/pinmux.c
+++ b/boards/arm/mec2016evb_assy6797/pinmux.c
@@ -10,9 +10,8 @@
 
 #include "soc.h"
 
-static int board_pinmux_init(const struct device *dev)
+static int board_pinmux_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* See table 2-4 from the Data sheet*/
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart0), okay)

--- a/boards/arm/mercury_xu/board.c
+++ b/boards/arm/mercury_xu/board.c
@@ -14,7 +14,7 @@
 #define MIO_DEFAULT	0x0
 #define MIO_UART0	0xc0
 
-static int mercury_xu_init(const struct device *port)
+static int mercury_xu_init(void)
 {
 	/* pinmux settings for uart */
 	sys_write32(MIO_UART0, MIO_PIN_38);
@@ -24,7 +24,6 @@ static int mercury_xu_init(const struct device *port)
 	sys_write32(MIO_DEFAULT, MIO_PIN_18);
 	sys_write32(MIO_DEFAULT, MIO_PIN_19);
 
-	ARG_UNUSED(port);
 	return 0;
 }
 

--- a/boards/arm/mimxrt595_evk/board.c
+++ b/boards/arm/mimxrt595_evk/board.c
@@ -45,7 +45,7 @@ static int32_t board_calc_volt_level(void)
 	return volt;
 }
 
-static int board_config_pmic(const struct device *dev)
+static int board_config_pmic(void)
 {
 	uint32_t volt;
 	int ret = 0;
@@ -79,7 +79,7 @@ static int board_config_pmic(const struct device *dev)
 }
 #endif
 
-static int mimxrt595_evk_init(const struct device *dev)
+static int mimxrt595_evk_init(void)
 {
 	/* Set the correct voltage range according to the board. */
 	power_pad_vrange_t vrange = {

--- a/boards/arm/mimxrt685_evk/init.c
+++ b/boards/arm/mimxrt685_evk/init.c
@@ -7,9 +7,8 @@
 #include <zephyr/devicetree.h>
 #include <fsl_device_registers.h>
 
-static int mimxrt685_evk_init(const struct device *dev)
+static int mimxrt685_evk_init(void)
 {
-	ARG_UNUSED(dev);
 
 /* flexcomm1 and flexcomm3 are configured to loopback the TX signal to RX */
 #if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexcomm1), nxp_lpc_i2s, okay)) && \

--- a/boards/arm/mps2_an385/pinmux.c
+++ b/boards/arm/mps2_an385/pinmux.c
@@ -152,9 +152,8 @@ static void arm_mps2_pinmux_defaults(void)
 	CMSDK_AHB_GPIO2_DEV->altfuncset = gpio_2;
 }
 
-static int arm_mps2_pinmux_init(const struct device *port)
+static int arm_mps2_pinmux_init(void)
 {
-	ARG_UNUSED(port);
 
 	arm_mps2_pinmux_defaults();
 

--- a/boards/arm/mps2_an521/pinmux.c
+++ b/boards/arm/mps2_an521/pinmux.c
@@ -152,9 +152,8 @@ static void arm_mps2_pinmux_defaults(void)
 	CMSDK_AHB_GPIO2_DEV->altfuncset = gpio_2;
 }
 
-static int arm_mps2_pinmux_init(const struct device *port)
+static int arm_mps2_pinmux_init(void)
 {
-	ARG_UNUSED(port);
 
 	arm_mps2_pinmux_defaults();
 

--- a/boards/arm/nrf52840dongle_nrf52840/board.c
+++ b/boards/arm/nrf52840dongle_nrf52840/board.c
@@ -7,9 +7,8 @@
 #include <zephyr/init.h>
 #include <hal/nrf_power.h>
 
-static int board_nrf52840dongle_nrf52840_init(const struct device *dev)
+static int board_nrf52840dongle_nrf52840_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* if the nrf52840dongle_nrf52840 board is powered from USB
 	 * (high voltage mode), GPIO output voltage is set to 1.8 volts by

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_cpunet_reset.c
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_cpunet_reset.c
@@ -49,11 +49,10 @@ static void remoteproc_mgr_config(void)
 #endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
 }
 
-static int remoteproc_mgr_boot(const struct device *dev)
+static int remoteproc_mgr_boot(void)
 {
 	int ret;
 
-	ARG_UNUSED(dev);
 
 	ret = core_config();
 	if (ret) {

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpunet_reset.c
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpunet_reset.c
@@ -33,9 +33,8 @@ static void remoteproc_mgr_config(void)
 #endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
 }
 
-static int remoteproc_mgr_boot(const struct device *dev)
+static int remoteproc_mgr_boot(void)
 {
-	ARG_UNUSED(dev);
 
 	/* Secure domain may configure permissions for the Network MCU. */
 	remoteproc_mgr_config();

--- a/boards/arm/nrf9160dk_nrf52840/board.c
+++ b/boards/arm/nrf9160dk_nrf52840/board.c
@@ -159,7 +159,7 @@ static int reset_pin_configure(void)
 }
 #endif /* USE_RESET_GPIO */
 
-static int init(const struct device *dev)
+static int init(void)
 {
 	int rc;
 
@@ -214,7 +214,7 @@ SYS_INIT(init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 #define EXT_MEM_CTRL DT_NODELABEL(external_flash_pins_routing)
 #if DT_NODE_EXISTS(EXT_MEM_CTRL)
 
-static int early_init(const struct device *dev)
+static int early_init(void)
 {
 	/* As soon as possible after the system starts up, enable the analog
 	 * switch that routes signals to the external flash. Otherwise, the

--- a/boards/arm/particle_argon/board.c
+++ b/boards/arm/particle_argon/board.c
@@ -28,9 +28,8 @@ static inline void external_antenna(bool on)
 	gpio_pin_configure_dt(&pcb_gpio, (on ? GPIO_OUTPUT_INACTIVE : GPIO_OUTPUT_ACTIVE));
 }
 
-static int board_particle_argon_init(const struct device *dev)
+static int board_particle_argon_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/*
 	 * On power-up the SKY13351 is left uncontrolled, so neither

--- a/boards/arm/particle_boron/board.c
+++ b/boards/arm/particle_boron/board.c
@@ -27,9 +27,8 @@ static inline void external_antenna(bool on)
 	gpio_pin_configure_dt(&ufl_gpio, (on ? GPIO_OUTPUT_ACTIVE : GPIO_OUTPUT_INACTIVE));
 }
 
-static int board_particle_boron_init(const struct device *dev)
+static int board_particle_boron_init(void)
 {
-	ARG_UNUSED(dev);
 
 	external_antenna(false);
 

--- a/boards/arm/particle_xenon/board.c
+++ b/boards/arm/particle_xenon/board.c
@@ -28,9 +28,8 @@ static inline void external_antenna(bool on)
 	gpio_pin_configure_dt(&pcb_gpio, (on ? GPIO_OUTPUT_INACTIVE : GPIO_OUTPUT_ACTIVE));
 }
 
-static int board_particle_xenon_init(const struct device *dev)
+static int board_particle_xenon_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/*
 	 * On power-up the SKY13351 is left uncontrolled, so neither

--- a/boards/arm/pinetime_devkit0/key_out.c
+++ b/boards/arm/pinetime_devkit0/key_out.c
@@ -15,9 +15,8 @@ LOG_MODULE_REGISTER(pine64_pinetime_key_out);
 
 static const struct gpio_dt_spec key_out = GPIO_DT_SPEC_GET(KEY_OUT_NODE, gpios);
 
-static int pinetime_key_out_init(const struct device *arg)
+static int pinetime_key_out_init(void)
 {
-	ARG_UNUSED(arg);
 	int ret;
 
 	if (!device_is_ready(key_out.port)) {

--- a/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
+++ b/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
@@ -232,9 +232,8 @@ uint32_t sys_clock_cycle_get_32(void)
 	return ret;
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* FIXME switch to 1 MHz once this is fixed in QEMU */
 	nrf_timer_prescaler_set(TIMER, NRF_TIMER_FREQ_2MHz);

--- a/boards/arm/qomu/board.c
+++ b/boards/arm/qomu/board.c
@@ -8,9 +8,8 @@
 #include <soc.h>
 #include "board.h"
 
-static int qomu_board_init(const struct device *arg)
+static int qomu_board_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* IO MUX setup for UART */
 	eos_s3_io_mux(UART_TX_PAD, UART_TX_PAD_CFG);

--- a/boards/arm/quick_feather/board.c
+++ b/boards/arm/quick_feather/board.c
@@ -8,9 +8,8 @@
 #include <soc.h>
 #include <board.h>
 
-static int eos_s3_board_init(const struct device *arg)
+static int eos_s3_board_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* IO MUX setup for UART */
 	eos_s3_io_mux(UART_TX_PAD, UART_TX_PAD_CFG);

--- a/boards/arm/reel_board/board.c
+++ b/boards/arm/reel_board/board.c
@@ -10,9 +10,8 @@
 /* Peripheral voltage ON/OFF GPIO */
 #define PERIPH_PON_PIN		0
 
-static int board_reel_board_init(const struct device *dev)
+static int board_reel_board_init(void)
 {
-	ARG_UNUSED(dev);
 	volatile NRF_GPIO_Type *gpio = NRF_P1;
 
 	/*

--- a/boards/arm/sparkfun_thing_plus_nrf9160/board.c
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/board.c
@@ -10,9 +10,8 @@
 #define GPIO0 DT_NODELABEL(gpio0)
 #define POWER_LATCH_PIN 31
 
-static int board_sparkfun_thing_plus_nrf9160_init(const struct device *dev)
+static int board_sparkfun_thing_plus_nrf9160_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* Get handle of the GPIO device. */
 	const struct device *const gpio = DEVICE_DT_GET(GPIO0);

--- a/boards/arm/stm32l496g_disco/board_adc_vref.c
+++ b/boards/arm/stm32l496g_disco/board_adc_vref.c
@@ -8,7 +8,7 @@
 #include <stm32_ll_adc.h>
 #include <zephyr/devicetree.h>
 
-static int enable_adc_reference(const struct device *dev)
+static int enable_adc_reference(void)
 {
 	uint8_t init_status;
 	/* VREF+ is not connected to VDDA by default */

--- a/boards/arm/swan_r5/board.c
+++ b/boards/arm/swan_r5/board.c
@@ -7,12 +7,11 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/init.h>
 
-static int board_swan_init(const struct device *dev)
+static int board_swan_init(void)
 {
 	const struct gpio_dt_spec dischrg =
 		GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), dischrg_gpios);
 
-	ARG_UNUSED(dev);
 
 	if (!device_is_ready(dischrg.port)) {
 		return -ENODEV;

--- a/boards/arm/thingy52_nrf52832/board.c
+++ b/boards/arm/thingy52_nrf52832/board.c
@@ -11,7 +11,7 @@
 static const struct gpio_dt_spec ccs_gpio =
 	GPIO_DT_SPEC_GET(DT_NODELABEL(ccs_pwr), enable_gpios);
 
-static int pwr_ctrl_init(const struct device *dev)
+static int pwr_ctrl_init(void)
 {
 	int ret;
 

--- a/boards/arm/thingy53_nrf5340/board.c
+++ b/boards/arm/thingy53_nrf5340/board.c
@@ -57,9 +57,8 @@ static void enable_cpunet(void)
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */
 }
 
-static int setup(const struct device *dev)
+static int setup(void)
 {
-	ARG_UNUSED(dev);
 
 #if !defined(CONFIG_TRUSTED_EXECUTION_SECURE)
 	if (IS_ENABLED(CONFIG_SENSOR)) {

--- a/boards/arm/twr_ke18f/pinmux.c
+++ b/boards/arm/twr_ke18f/pinmux.c
@@ -8,9 +8,8 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/pinctrl.h>
 
-static int twr_ke18f_pinmux_init(const struct device *dev)
+static int twr_ke18f_pinmux_init(void)
 {
-	ARG_UNUSED(dev);
 
 	int err; /* Used by pinctrl functions */
 

--- a/boards/arm/ubx_bmd345eval_nrf52840/board.c
+++ b/boards/arm/ubx_bmd345eval_nrf52840/board.c
@@ -11,9 +11,8 @@
 #define MODE_PIN	4 /* P1.04 */
 #define A_SEL_PIN	2 /* P1.02 */
 
-static int bmd345_fem_init(const struct device *dev)
+static int bmd345_fem_init(void)
 {
-	ARG_UNUSED(dev);
 
 	int ret;
 	const struct device *mode_asel_port_dev;

--- a/boards/arm/v2m_beetle/pinmux.c
+++ b/boards/arm/v2m_beetle/pinmux.c
@@ -132,9 +132,8 @@ static void arm_v2m_beetle_pinmux_defaults(void)
 	CMSDK_AHB_GPIO1_DEV->data |= (0x1 << 15);
 }
 
-static int arm_v2m_beetle_pinmux_init(const struct device *port)
+static int arm_v2m_beetle_pinmux_init(void)
 {
-	ARG_UNUSED(port);
 
 	arm_v2m_beetle_pinmux_defaults();
 

--- a/boards/arm/v2m_musca_b1/pinmux.c
+++ b/boards/arm/v2m_musca_b1/pinmux.c
@@ -55,9 +55,8 @@ static void arm_musca_b1_pinmux_defaults(void)
 }
 #endif
 
-static int arm_musca_pinmux_init(const struct device *port)
+static int arm_musca_pinmux_init(void)
 {
-	ARG_UNUSED(port);
 
 	arm_musca_b1_pinmux_defaults();
 

--- a/boards/arm/v2m_musca_s1/pinmux.c
+++ b/boards/arm/v2m_musca_s1/pinmux.c
@@ -54,9 +54,8 @@ static void arm_musca_s1_pinmux_defaults(void)
 }
 #endif
 
-static int arm_musca_pinmux_init(const struct device *port)
+static int arm_musca_pinmux_init(void)
 {
-	ARG_UNUSED(port);
 
 	arm_musca_s1_pinmux_defaults();
 

--- a/boards/common/actinius/actinius_board_common.c
+++ b/boards/common/actinius/actinius_board_common.c
@@ -65,9 +65,8 @@ static int actinius_board_set_charger_enable(void)
 }
 #endif /* CHARGER_ENABLE */
 
-static int actinius_board_init(const struct device *dev)
+static int actinius_board_init(void)
 {
-	ARG_UNUSED(dev);
 
 	int result = 0;
 

--- a/boards/posix/nrf52_bsim/bstests_entry.c
+++ b/boards/posix/nrf52_bsim/bstests_entry.c
@@ -191,18 +191,16 @@ bool bst_irq_sniffer(int irq_number)
 	}
 }
 
-static int bst_fake_device_driver_pre2_init(const struct device *arg)
+static int bst_fake_device_driver_pre2_init(void)
 {
-	ARG_UNUSED(arg);
 	if (current_test && current_test->test_fake_ddriver_prekernel_f) {
 		current_test->test_fake_ddriver_prekernel_f();
 	}
 	return 0;
 }
 
-static int bst_fake_device_driver_post_init(const struct device *arg)
+static int bst_fake_device_driver_post_init(void)
 {
-	ARG_UNUSED(arg);
 	if (current_test && current_test->test_fake_ddriver_postkernel_f) {
 		current_test->test_fake_ddriver_postkernel_f();
 	}

--- a/boards/posix/nrf52_bsim/trace_hook.c
+++ b/boards/posix/nrf52_bsim/trace_hook.c
@@ -59,9 +59,8 @@ void posix_flush_stdout(void)
  *
  * @return 0 if successful, otherwise failed.
  */
-static int printk_init(const struct device *arg)
+static int printk_init(void)
 {
-	ARG_UNUSED(arg);
 
 	extern void __printk_hook_install(int (*fn)(int));
 	__printk_hook_install(print_char);

--- a/boards/riscv/rv32m1_vega/board.c
+++ b/boards/riscv/rv32m1_vega/board.c
@@ -8,13 +8,12 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
 
-static int rv32m1_vega_board_init(const struct device *dev)
+static int rv32m1_vega_board_init(void)
 {
 	const struct device *const gpiob = DEVICE_DT_GET(DT_NODELABEL(gpiob));
 	const struct device *const gpioc = DEVICE_DT_GET(DT_NODELABEL(gpioc));
 	const struct device *const gpiod = DEVICE_DT_GET(DT_NODELABEL(gpiod));
 
-	ARG_UNUSED(dev);
 
 	__ASSERT_NO_MSG(device_is_ready(gpiob));
 	__ASSERT_NO_MSG(device_is_ready(gpioc));

--- a/boards/xtensa/esp32_ethernet_kit/board_init.c
+++ b/boards/xtensa/esp32_ethernet_kit/board_init.c
@@ -8,9 +8,8 @@
 
 #define IP101GRI_RESET_N_PIN	5
 
-static int board_esp32_ethernet_kit_init(const struct device *dev)
+static int board_esp32_ethernet_kit_init(void)
 {
-	ARG_UNUSED(dev);
 	const struct device *gpio = DEVICE_DT_GET(DT_NODELABEL(gpio0));
 
 	if (!device_is_ready(gpio)) {

--- a/boards/xtensa/esp_wrover_kit/board_init.c
+++ b/boards/xtensa/esp_wrover_kit/board_init.c
@@ -11,9 +11,8 @@
 #define LED_B_PIN  DT_GPIO_PIN(DT_ALIAS(led0), gpios)
 #define BL_PIN     5
 
-static int board_esp_wrover_kit_init(const struct device *dev)
+static int board_esp_wrover_kit_init(void)
 {
-	ARG_UNUSED(dev);
 	const struct device *gpio;
 
 	gpio = DEVICE_DT_GET(DT_NODELABEL(gpio0));

--- a/boards/xtensa/heltec_wifi_lora32_v2/board_init.c
+++ b/boards/xtensa/heltec_wifi_lora32_v2/board_init.c
@@ -9,9 +9,8 @@
 #define VEXT_PIN  DT_GPIO_PIN(DT_NODELABEL(vext), gpios)
 #define OLED_RST  DT_GPIO_PIN(DT_NODELABEL(oledrst), gpios)
 
-static int board_heltec_wifi_lora32_v2_init(const struct device *dev)
+static int board_heltec_wifi_lora32_v2_init(void)
 {
-	ARG_UNUSED(dev);
 	const struct device *gpio;
 
 	gpio = DEVICE_DT_GET(DT_NODELABEL(gpio0));

--- a/boards/xtensa/odroid_go/board_init.c
+++ b/boards/xtensa/odroid_go/board_init.c
@@ -8,9 +8,8 @@
 
 #define LED_B_PIN  DT_GPIO_PIN(DT_ALIAS(led0), gpios)
 
-static int board_odroid_go_init(const struct device *dev)
+static int board_odroid_go_init(void)
 {
-	ARG_UNUSED(dev);
 	const struct device *gpio;
 
 	gpio = DEVICE_DT_GET(DT_NODELABEL(gpio0));

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -147,6 +147,11 @@ Stable API changes in this release
   * :c:func:`bt_le_oob_set_sc_flag` for setting/clearing OOB flag in SC pairing
   * :c:func:`bt_le_oob_set_legacy_flag` for setting/clearing OOB flag in legacy paring
 
+* :c:macro:`SYS_INIT` callback no longer requires a :c:struct:`device` argument.
+  The new callback signature is ``int f(void)``. A utility script to
+  automatically migrate existing projects can be found in
+  :zephyr_file:`scripts/utils/migrate_sys_init.py`.
+
 New APIs in this release
 ========================
 

--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -740,9 +740,8 @@ struct k_work_q adc_npcx_work_q;
 static K_KERNEL_STACK_DEFINE(adc_npcx_work_q_stack,
 			CONFIG_ADC_CMP_NPCX_WORKQUEUE_STACK_SIZE);
 
-static int adc_npcx_init_cmp_work_q(const struct device *dev)
+static int adc_npcx_init_cmp_work_q(void)
 {
-	ARG_UNUSED(dev);
 	struct k_work_queue_config cfg = {
 		.name = "adc_cmp_work",
 		.no_yield = false,

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -553,9 +553,8 @@ static const struct bt_hci_driver drv = {
 #endif
 };
 
-static int bt_uart_init(const struct device *unused)
+static int bt_uart_init(void)
 {
-	ARG_UNUSED(unused);
 
 	if (!device_is_ready(h4_dev)) {
 		return -ENODEV;

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -767,9 +767,8 @@ static const struct bt_hci_driver drv = {
 	.send		= h5_queue,
 };
 
-static int bt_uart_init(const struct device *unused)
+static int bt_uart_init(void)
 {
-	ARG_UNUSED(unused);
 
 	if (!device_is_ready(h5_dev)) {
 		return -ENODEV;

--- a/drivers/bluetooth/hci/hci_b91.c
+++ b/drivers/bluetooth/hci/hci_b91.c
@@ -241,9 +241,8 @@ static const struct bt_hci_driver drv = {
 #endif
 };
 
-static int bt_b91_init(const struct device *unused)
+static int bt_b91_init(void)
 {
-	ARG_UNUSED(unused);
 
 	bt_hci_driver_register(&drv);
 

--- a/drivers/bluetooth/hci/hci_esp32.c
+++ b/drivers/bluetooth/hci/hci_esp32.c
@@ -327,9 +327,8 @@ static const struct bt_hci_driver drv = {
 #endif
 };
 
-static int bt_esp32_init(const struct device *unused)
+static int bt_esp32_init(void)
 {
-	ARG_UNUSED(unused);
 
 	bt_hci_driver_register(&drv);
 

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -607,11 +607,10 @@ static const struct bt_hci_driver drv = {
 	.send           = bt_ipm_send,
 };
 
-static int _bt_ipm_init(const struct device *unused)
+static int _bt_ipm_init(void)
 {
 	int err;
 
-	ARG_UNUSED(unused);
 
 	bt_hci_driver_register(&drv);
 

--- a/drivers/bluetooth/hci/rpmsg.c
+++ b/drivers/bluetooth/hci/rpmsg.c
@@ -327,9 +327,8 @@ static const struct bt_hci_driver drv = {
 #endif
 };
 
-static int bt_rpmsg_init(const struct device *unused)
+static int bt_rpmsg_init(void)
 {
-	ARG_UNUSED(unused);
 
 	int err;
 

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -517,9 +517,8 @@ static const struct bt_hci_driver drv = {
 	.send		= bt_spi_send,
 };
 
-static int bt_spi_init(const struct device *unused)
+static int bt_spi_init(void)
 {
-	ARG_UNUSED(unused);
 
 	if (!spi_is_ready_dt(&bus)) {
 		LOG_ERR("SPI device not ready");

--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -245,9 +245,8 @@ static const struct bt_hci_driver drv = {
 	.send		= uc_send,
 };
 
-static int bt_uc_init(const struct device *unused)
+static int bt_uc_init(void)
 {
-	ARG_UNUSED(unused);
 
 	bt_hci_driver_register(&drv);
 

--- a/drivers/console/efi_console.c
+++ b/drivers/console/efi_console.c
@@ -66,10 +66,9 @@ static void efi_console_hook_install(void)
  *
  * @return 0 if successful, otherwise failed.
  */
-static int efi_console_init(const struct device *arg)
+static int efi_console_init(void)
 {
 
-	ARG_UNUSED(arg);
 
 	efi_console_hook_install();
 

--- a/drivers/console/ipm_console.c
+++ b/drivers/console/ipm_console.c
@@ -64,9 +64,8 @@ static void ipm_console_hook_install(void)
 	__printk_hook_install(console_out);
 }
 
-static int ipm_console_init(const struct device *dev)
+static int ipm_console_init(void)
 {
-	ARG_UNUSED(dev);
 
 	LOG_DBG("IPM console initialization");
 

--- a/drivers/console/jailhouse_debug_console.c
+++ b/drivers/console/jailhouse_debug_console.c
@@ -45,9 +45,8 @@ extern void __printk_hook_install(int (*fn)(int));
  * @brief Initialize the console/debug port
  * @return 0 if successful, otherwise failed.
  */
-static int jailhouse_console_init(const struct device *arg)
+static int jailhouse_console_init(void)
 {
-	ARG_UNUSED(arg);
 	__stdout_hook_install(console_out);
 	__printk_hook_install(console_out);
 	return 0;

--- a/drivers/console/native_posix_console.c
+++ b/drivers/console/native_posix_console.c
@@ -256,9 +256,8 @@ static void native_stdio_runner(void *p1, void *p2, void *p3)
 }
 #endif /* CONFIG_NATIVE_POSIX_STDIN_CONSOLE */
 
-static int native_posix_console_init(const struct device *arg)
+static int native_posix_console_init(void)
 {
-	ARG_UNUSED(arg);
 
 #if defined(CONFIG_NATIVE_POSIX_STDOUT_CONSOLE)
 	native_posix_stdout_init();

--- a/drivers/console/ram_console.c
+++ b/drivers/console/ram_console.c
@@ -26,9 +26,8 @@ static int ram_console_out(int character)
 	return character;
 }
 
-static int ram_console_init(const struct device *d)
+static int ram_console_init(void)
 {
-	ARG_UNUSED(d);
 	__printk_hook_install(ram_console_out);
 	__stdout_hook_install(ram_console_out);
 

--- a/drivers/console/rtt_console.c
+++ b/drivers/console/rtt_console.c
@@ -78,9 +78,8 @@ static int rtt_console_out(int character)
 	return character;
 }
 
-static int rtt_console_init(const struct device *d)
+static int rtt_console_init(void)
 {
-	ARG_UNUSED(d);
 
 #ifdef CONFIG_PRINTK
 	__printk_hook_install(rtt_console_out);

--- a/drivers/console/semihost_console.c
+++ b/drivers/console/semihost_console.c
@@ -16,9 +16,8 @@ int arch_printk_char_out(int _c)
 	return 0;
 }
 
-static int semihost_console_init(const struct device *dev)
+static int semihost_console_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/*
 	 * The printk output callback is arch_printk_char_out by default and

--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -607,11 +607,8 @@ static void uart_console_hook_install(void)
  *
  * @return 0 if successful, otherwise failed.
  */
-static int uart_console_init(const struct device *arg)
+static int uart_console_init(void)
 {
-
-	ARG_UNUSED(arg);
-
 	if (!device_is_ready(uart_console_dev)) {
 		return -ENODEV;
 	}

--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -894,9 +894,8 @@ LISTIFY(CONFIG_UART_MUX_DEVICE_COUNT, DEFINE_UART_MUX_CFG_DATA, (;),  _);
 LISTIFY(CONFIG_UART_MUX_DEVICE_COUNT, DEFINE_UART_MUX_DEV_DATA, (;), _);
 LISTIFY(CONFIG_UART_MUX_DEVICE_COUNT, DEFINE_UART_MUX_DEVICE, (;), _);
 
-static int init_uart_mux(const struct device *dev)
+static int init_uart_mux(void)
 {
-	ARG_UNUSED(dev);
 
 	k_work_queue_start(&uart_mux_workq, uart_mux_stack,
 			   K_KERNEL_STACK_SIZEOF(uart_mux_stack),

--- a/drivers/console/winstream_console.c
+++ b/drivers/console/winstream_console.c
@@ -46,9 +46,8 @@ int arch_printk_char_out(int c)
 	return 0;
 }
 
-static int winstream_console_init(const struct device *d)
+static int winstream_console_init(void)
 {
-	ARG_UNUSED(d);
 	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	if (!device_is_ready(dev)) {

--- a/drivers/console/xtensa_sim_console.c
+++ b/drivers/console/xtensa_sim_console.c
@@ -62,9 +62,8 @@ static void xt_sim_console_hook_install(void)
  * @brief Initialize the console/debug port
  * @return 0 if successful, otherwise failed.
  */
-static int xt_sim_console_init(const struct device *arg)
+static int xt_sim_console_init(void)
 {
-	ARG_UNUSED(arg);
 	xt_sim_console_hook_install();
 	return 0;
 }

--- a/drivers/disk/flashdisk.c
+++ b/drivers/disk/flashdisk.c
@@ -462,9 +462,8 @@ DT_INST_FOREACH_STATUS_OKAY(VERIFY_CACHE_SIZE_IS_NOT_ZERO_IF_NOT_READ_ONLY)
 		" has cache size which is not a multiple of its sector size");
 DT_INST_FOREACH_STATUS_OKAY(VERIFY_CACHE_SIZE_IS_MULTIPLY_OF_SECTOR_SIZE)
 
-static int disk_flash_init(const struct device *dev)
+static int disk_flash_init(void)
 {
-	ARG_UNUSED(dev);
 	int err = 0;
 
 	for (int i = 0; i < ARRAY_SIZE(flash_disks); i++) {

--- a/drivers/disk/ramdisk.c
+++ b/drivers/disk/ramdisk.c
@@ -102,9 +102,8 @@ static struct disk_info ram_disk = {
 	.ops = &ram_disk_ops,
 };
 
-static int disk_ram_init(const struct device *dev)
+static int disk_ram_init(void)
 {
-	ARG_UNUSED(dev);
 
 	return disk_access_register(&ram_disk);
 }

--- a/drivers/display/mb_display.c
+++ b/drivers/display/mb_display.c
@@ -396,9 +396,8 @@ struct mb_display *mb_display_get(void)
 	return &display;
 }
 
-static int mb_display_init_on_boot(const struct device *dev)
+static int mb_display_init_on_boot(void)
 {
-	ARG_UNUSED(dev);
 
 	display.lm_dev = DEVICE_DT_GET_ONE(nordic_nrf_led_matrix);
 	if (!device_is_ready(display.lm_dev)) {

--- a/drivers/gpio/gpio_hogs.c
+++ b/drivers/gpio/gpio_hogs.c
@@ -90,7 +90,7 @@ static const struct gpio_hogs gpio_hogs[] = {
 	DT_FOREACH_STATUS_OKAY_NODE(GPIO_HOGS_COND_INIT)
 };
 
-static int gpio_hogs_init(const struct device *dev)
+static int gpio_hogs_init(void)
 {
 	const struct gpio_hogs *hogs;
 	const struct gpio_hog_dt_spec *spec;
@@ -98,7 +98,6 @@ static int gpio_hogs_init(const struct device *dev)
 	int i;
 	int j;
 
-	ARG_UNUSED(dev);
 
 	for (i = 0; i < ARRAY_SIZE(gpio_hogs); i++) {
 		hogs = &gpio_hogs[i];

--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -722,9 +722,8 @@ DEVICE_DT_INST_DEFINE(inst,                                        \
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_ITE_DEV_CFG_DATA)
 
-static int gpio_it8xxx2_init_set(const struct device *arg)
+static int gpio_it8xxx2_init_set(void)
 {
-	ARG_UNUSED(arg);
 
 	if (IS_ENABLED(CONFIG_SOC_IT8XXX2_GPIO_GROUP_K_L_DEFAULT_PULL_DOWN)) {
 		const struct device *const gpiok = DEVICE_DT_GET(DT_NODELABEL(gpiok));

--- a/drivers/hwinfo/hwinfo_sam.c
+++ b/drivers/hwinfo/hwinfo_sam.c
@@ -62,7 +62,7 @@ __ramfunc static void hwinfo_sam_read_device_id(void)
 	}
 }
 
-static int hwinfo_sam_init(const struct device *arg)
+static int hwinfo_sam_init(void)
 {
 	Efc *efc = (Efc *)DT_REG_ADDR(DT_INST(0, atmel_sam_flash_controller));
 	uint32_t fmr;

--- a/drivers/hwinfo/hwinfo_sam_rstc.c
+++ b/drivers/hwinfo/hwinfo_sam_rstc.c
@@ -53,13 +53,12 @@ int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
 	return 0;
 }
 
-static int hwinfo_rstc_init(const struct device *dev)
+static int hwinfo_rstc_init(void)
 {
 	Rstc *regs = (Rstc *)DT_INST_REG_ADDR(0);
 	const struct atmel_sam_pmc_config clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(0);
 	uint32_t mode;
 
-	ARG_UNUSED(dev);
 
 	/* Enable RSTC in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,

--- a/drivers/i3c/i3c_ibi_workq.c
+++ b/drivers/i3c/i3c_ibi_workq.c
@@ -207,9 +207,8 @@ static void i3c_ibi_work_handler(struct k_work *work)
 	}
 }
 
-static int i3c_ibi_work_q_init(const struct device *dev)
+static int i3c_ibi_work_q_init(void)
 {
-	ARG_UNUSED(dev);
 	struct k_work_queue_config cfg = {
 		.name = "i3c_ibi_workq",
 		.no_yield = true,

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -58,7 +58,7 @@ static void arc_shared_intc_init(void)
 }
 
 /* Allow to schedule IRQ to all cores after we bring up all secondary cores */
-static int arc_shared_intc_update_post_smp(const struct device *unused)
+static int arc_shared_intc_update_post_smp(void)
 {
 	__ASSERT(z_arc_v2_core_id() == ARC_MP_PRIMARY_CPU_ID,
 		 "idu interrupts must be updated from primary core");
@@ -134,7 +134,7 @@ void arc_core_private_intc_init(void)
 #endif /* CONFIG_ARC_CONNECT */
 }
 
-static int arc_irq_init(const struct device *unused)
+static int arc_irq_init(void)
 {
 #ifdef CONFIG_ARC_CONNECT
 	arc_shared_intc_init();

--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -228,9 +228,8 @@ static void gic_cpu_init(void)
 /**
  * @brief Initialize the GIC device driver
  */
-int arm_gic_init(const struct device *unused)
+int arm_gic_init(void)
 {
-	ARG_UNUSED(unused);
 
 	/* Init of Distributor interface registers */
 	gic_dist_init();

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -565,9 +565,8 @@ static void __arm_gic_init(void)
 	gicv3_cpuif_init();
 }
 
-int arm_gic_init(const struct device *unused)
+int arm_gic_init(void)
 {
-	ARG_UNUSED(unused);
 
 	gicv3_dist_init();
 

--- a/drivers/interrupt_controller/intc_irqmp.c
+++ b/drivers/interrupt_controller/intc_irqmp.c
@@ -108,9 +108,8 @@ int z_sparc_int_get_source(int irl)
 	return source;
 }
 
-static int irqmp_init(const struct device *dev)
+static int irqmp_init(void)
 {
-	ARG_UNUSED(dev);
 	volatile struct irqmp_regs *regs = get_irqmp_regs();
 
 	regs->ilevel = 0;

--- a/drivers/interrupt_controller/intc_nuclei_eclic.c
+++ b/drivers/interrupt_controller/intc_nuclei_eclic.c
@@ -159,7 +159,7 @@ void riscv_clic_irq_priority_set(uint32_t irq, uint32_t pri, uint32_t flags)
 	ECLIC_CTRL[irq].INTATTR.b.trg = (uint8_t)(flags & CLIC_INTATTR_TRIG_Msk);
 }
 
-static int nuclei_eclic_init(const struct device *dev)
+static int nuclei_eclic_init(void)
 {
 	/* check hardware support required interrupt levels */
 	__ASSERT_NO_MSG(ECLIC_INFO.b.intctlbits >= INTERRUPT_LEVEL);

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -172,9 +172,8 @@ static void plic_irq_handler(const void *arg)
  *
  * @retval 0 on success.
  */
-static int plic_init(const struct device *dev)
+static int plic_init(void)
 {
-	ARG_UNUSED(dev);
 
 	volatile uint32_t *en = (volatile uint32_t *)PLIC_IRQ_EN;
 	volatile uint32_t *prio = (volatile uint32_t *)PLIC_PRIO;

--- a/drivers/interrupt_controller/intc_swerv_pic.c
+++ b/drivers/interrupt_controller/intc_swerv_pic.c
@@ -143,9 +143,8 @@ static void swerv_pic_irq_handler(const void *arg)
 	swerv_pic_write(SWERV_PIC_meigwclr(irq), 0);
 }
 
-static int swerv_pic_init(const struct device *dev)
+static int swerv_pic_init(void)
 {
-	ARG_UNUSED(dev);
 	int i;
 
 	/* Init priority order to 0, 0=lowest to 15=highest */

--- a/drivers/interrupt_controller/intc_vexriscv_litex.c
+++ b/drivers/interrupt_controller/intc_vexriscv_litex.c
@@ -120,9 +120,8 @@ int arch_irq_is_enabled(unsigned int irq)
 	return vexriscv_litex_irq_getmask() & (1 << irq);
 }
 
-static int vexriscv_litex_irq_init(const struct device *dev)
+static int vexriscv_litex_irq_init(void)
 {
-	ARG_UNUSED(dev);
 	__asm__ volatile ("csrrs x0, mie, %0"
 			:: "r"(1 << RISCV_MACHINE_EXT_IRQ));
 	vexriscv_litex_irq_setie(1);

--- a/drivers/ipm/ipm_cavs_idc.c
+++ b/drivers/ipm/ipm_cavs_idc.c
@@ -228,7 +228,7 @@ DEVICE_DT_INST_DEFINE(0, &cavs_idc_init, NULL,
 		    &cavs_idc_driver_api);
 
 #ifdef CONFIG_SCHED_IPI_SUPPORTED
-int cavs_idc_smp_init(const struct device *dev)
+int cavs_idc_smp_init(void)
 {
 	/* Enable IDC for scheduler IPI */
 	cavs_idc_set_enabled(dev, 1);

--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -505,7 +505,7 @@ static bool pcie_dev_cb(pcie_bdf_t bdf, pcie_id_t id, void *cb_data)
 	return (data->found != data->max_dev);
 }
 
-static int pcie_init(const struct device *dev)
+static int pcie_init(void)
 {
 	struct scan_data data;
 	struct pcie_scan_opt opt = {
@@ -514,7 +514,6 @@ static int pcie_init(const struct device *dev)
 		.flags = PCIE_SCAN_RECURSIVE,
 	};
 
-	ARG_UNUSED(dev);
 
 	STRUCT_SECTION_COUNT(pcie_dev, &data.max_dev);
 	/* Don't bother calling pcie_scan() if there are no devices to look for */

--- a/drivers/pinctrl/pinctrl_b91.c
+++ b/drivers/pinctrl/pinctrl_b91.c
@@ -66,9 +66,8 @@
 				       ((pin & 0xf0) ? 1 : 0)))
 
 /* Pinctrl driver initialization */
-static int pinctrl_b91_init(const struct device *dev)
+static int pinctrl_b91_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* set pad_mul_sel register value from dts */
 	reg_gpio_pad_mul_sel |= DT_INST_PROP(0, pad_mul_sel);

--- a/drivers/pinctrl/pinctrl_gd32_afio.c
+++ b/drivers/pinctrl/pinctrl_gd32_afio.c
@@ -62,11 +62,10 @@ static const uint16_t gd32_port_clkids[] = {
  *
  * @retval 0 Always
  */
-static int afio_init(const struct device *dev)
+static int afio_init(void)
 {
 	uint16_t clkid = DT_CLOCKS_CELL(AFIO_NODE, id);
 
-	ARG_UNUSED(dev);
 
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
 			       (clock_control_subsys_t)&clkid);

--- a/drivers/pinctrl/pinctrl_imx.c
+++ b/drivers/pinctrl/pinctrl_imx.c
@@ -60,9 +60,8 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 	return 0;
 }
 
-static int imx_pinctrl_init(const struct device *dev)
+static int imx_pinctrl_init(void)
 {
-	ARG_UNUSED(dev);
 #ifdef CONFIG_SOC_SERIES_IMX_RT
 	CLOCK_EnableClock(kCLOCK_Iomuxc);
 #ifdef CONFIG_SOC_SERIES_IMX_RT10XX

--- a/drivers/pinctrl/pinctrl_lpc_iocon.c
+++ b/drivers/pinctrl/pinctrl_lpc_iocon.c
@@ -50,9 +50,8 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 #if defined(CONFIG_SOC_FAMILY_LPC) && !defined(CONFIG_SOC_SERIES_LPC11U6X)
 /* LPC family (except 11u6x) needs iocon clock to be enabled */
 
-static int pinctrl_clock_init(const struct device *dev)
+static int pinctrl_clock_init(void)
 {
-	ARG_UNUSED(dev);
 	/* Enable IOCon clock */
 	CLOCK_EnableClock(kCLOCK_Iocon);
 	return 0;

--- a/drivers/pinctrl/pinctrl_stm32.c
+++ b/drivers/pinctrl/pinctrl_stm32.c
@@ -74,9 +74,8 @@ static const size_t gpio_ports_cnt = ARRAY_SIZE(gpio_ports);
 
 #if REMAP_PA11 || REMAP_PA12 || REMAP_PA11_PA12
 
-int stm32_pinmux_init_remap(const struct device *dev)
+int stm32_pinmux_init_remap(void)
 {
-	ARG_UNUSED(dev);
 
 #if REMAP_PA11 || REMAP_PA12
 
@@ -117,9 +116,8 @@ SYS_INIT(stm32_pinmux_init_remap, PRE_KERNEL_1,
 #if ((DT_NODE_HAS_PROP(DT_NODELABEL(pinctrl), swj_cfg)) && \
 	(DT_ENUM_IDX(DT_NODELABEL(pinctrl), swj_cfg) != 0))
 
-static int stm32f1_swj_cfg_init(const struct device *dev)
+static int stm32f1_swj_cfg_init(void)
 {
-	ARG_UNUSED(dev);
 
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_AFIO);
 

--- a/drivers/sensor/ite_vcmp_it8xxx2/vcmp_ite_it8xxx2.c
+++ b/drivers/sensor/ite_vcmp_it8xxx2/vcmp_ite_it8xxx2.c
@@ -364,9 +364,8 @@ struct k_work_q vcmp_it8xxx2_work_q;
 static K_KERNEL_STACK_DEFINE(vcmp_it8xxx2_work_q_stack,
 			     CONFIG_VCMP_IT8XXX2_WORKQUEUE_STACK_SIZE);
 
-static int vcmp_it8xxx2_init_work_q(const struct device *dev)
+static int vcmp_it8xxx2_init_work_q(void)
 {
-	ARG_UNUSED(dev);
 	struct k_work_queue_config cfg = {
 		.name = "vcmp_work",
 		.no_yield = false,

--- a/drivers/serial/uart_hvc_xen.c
+++ b/drivers/serial/uart_hvc_xen.c
@@ -280,9 +280,8 @@ int xen_consoleio_putc(int c)
 
 
 
-int consoleio_hooks_set(const struct device *dev)
+int consoleio_hooks_set(void)
 {
-	ARG_UNUSED(dev);
 
 	/* Will be replaced with poll_in/poll_out by uart_console.c later on boot */
 	__stdout_hook_install(xen_consoleio_putc);

--- a/drivers/timer/altera_avalon_timer_hal.c
+++ b/drivers/timer/altera_avalon_timer_hal.c
@@ -73,9 +73,8 @@ uint32_t sys_clock_elapsed(void)
 	return 0;
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 
 	IOWR_ALTERA_AVALON_TIMER_PERIODL(TIMER_0_BASE,
 			k_ticks_to_cyc_floor32(1) & 0xFFFF);

--- a/drivers/timer/apic_timer.c
+++ b/drivers/timer/apic_timer.c
@@ -218,11 +218,10 @@ uint32_t sys_clock_cycle_get_32(void)
 
 #endif
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
 	uint32_t val;
 
-	ARG_UNUSED(dev);
 
 	val = x86_read_loapic(LOAPIC_TIMER_CONFIG);	/* set divider */
 	val &= ~DCR_DIVIDER_MASK;

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -156,7 +156,7 @@ static inline void cpuid(uint32_t *eax, uint32_t *ebx, uint32_t *ecx, uint32_t *
 			 : "a"(*eax), "c"(*ecx));
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
 #ifdef CONFIG_ASSERT
 	uint32_t eax, ebx, ecx, edx;

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -414,9 +414,8 @@ void smp_timer_init(void)
  *
  * @return 0
  */
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* ensure that the timer will not generate interrupts */
 	timer0_control_register_set(0);

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -197,9 +197,8 @@ void smp_timer_init(void)
 }
 #endif
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 
 	IRQ_CONNECT(ARM_ARCH_TIMER_IRQ, ARM_ARCH_TIMER_PRIO,
 		    arm_arch_timer_compare_isr, NULL, ARM_ARCH_TIMER_FLAGS);

--- a/drivers/timer/cc13x2_cc26x2_rtc_timer.c
+++ b/drivers/timer/cc13x2_cc26x2_rtc_timer.c
@@ -233,9 +233,8 @@ uint64_t sys_clock_cycle_get_64(void)
 	return AONRTCCurrent64BitValueGet() / RTC_COUNTS_PER_CYCLE;
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 
 	rtc_last = 0U;
 

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -267,9 +267,8 @@ void sys_clock_disable(void)
 	SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 
 	NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
 	last_load = CYC_PER_TICK - 1;

--- a/drivers/timer/esp32c3_sys_timer.c
+++ b/drivers/timer/esp32c3_sys_timer.c
@@ -135,9 +135,8 @@ uint64_t sys_clock_cycle_get_64(void)
 	return get_systimer_alarm();
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 
 	esp_intr_alloc(DT_IRQN(DT_NODELABEL(systimer0)),
 		0,

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -413,12 +413,11 @@ void sys_clock_idle_exit(void)
 }
 
 __boot_func
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
 	extern int z_clock_hw_cycles_per_sec;
 	uint32_t hz, reg;
 
-	ARG_UNUSED(dev);
 	ARG_UNUSED(hz);
 	ARG_UNUSED(z_clock_hw_cycles_per_sec);
 

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -214,7 +214,7 @@ void smp_timer_init(void)
 }
 
 /* Runs on core 0 only */
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
 	uint64_t curr = count();
 

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -381,11 +381,10 @@ static int timer_init(enum ext_timer_idx ext_timer,
 	return 0;
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
 	int ret;
 
-	ARG_UNUSED(dev);
 
 	/* Enable 32-bit free run timer overflow interrupt */
 	IRQ_CONNECT(FREE_RUN_TIMER_IRQ, 0, free_run_timer_overflow_isr, NULL,

--- a/drivers/timer/leon_gptimer.c
+++ b/drivers/timer/leon_gptimer.c
@@ -103,9 +103,8 @@ static void init_downcounter(volatile struct gptimer_timer_regs *tmr)
 	tmr->ctrl = GPTIMER_CTRL_LD | GPTIMER_CTRL_RS | GPTIMER_CTRL_EN;
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 	const int timer_interrupt = get_timer_irq();
 	volatile struct gptimer_regs *regs = get_regs();
 	volatile struct gptimer_timer_regs *tmr = &regs->timer[0];

--- a/drivers/timer/litex_timer.c
+++ b/drivers/timer/litex_timer.c
@@ -77,9 +77,8 @@ uint32_t sys_clock_elapsed(void)
 	return 0;
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 	IRQ_CONNECT(TIMER_IRQ, DT_INST_IRQ(0, priority),
 			litex_timer_irq_handler, NULL, 0);
 	irq_enable(TIMER_IRQ);

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -398,9 +398,8 @@ void arch_busy_wait(uint32_t usec_to_wait)
 }
 #endif
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 
 #ifdef CONFIG_TICKLESS_KERNEL
 	cached_icr = MAX_TICKS;

--- a/drivers/timer/mcux_gpt_timer.c
+++ b/drivers/timer/mcux_gpt_timer.c
@@ -191,11 +191,10 @@ uint32_t sys_clock_cycle_get_32(void)
  *
  * Enable the hw timer, setting its tick period, and setup its interrupt
  */
-int sys_clock_driver_init(const struct device *dev)
+int sys_clock_driver_init(void)
 {
 	gpt_config_t gpt_config;
 
-	ARG_UNUSED(dev);
 	/* Configure ISR. Use instance 0 of the GPT timer */
 	IRQ_CONNECT(DT_IRQN(GPT_INST), DT_IRQ(GPT_INST, priority),
 		    mcux_imx_gpt_isr, NULL, 0);

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -95,11 +95,10 @@ static void mcux_lptmr_timer_isr(const void *arg)
 	LPTMR_ClearStatusFlags(LPTMR_BASE, kLPTMR_TimerCompareFlag);
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
 	lptmr_config_t config;
 
-	ARG_UNUSED(dev);
 
 	LPTMR_GetDefaultConfig(&config);
 	config.timerMode = kLPTMR_TimerModeTimeCounter;

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -113,9 +113,8 @@ uint64_t sys_clock_cycle_get_64(void)
 	return OSTIMER_GetCurrentTimerValue(base);
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* Configure event timer's ISR */
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -112,9 +112,8 @@ uint32_t sys_clock_cycle_get_32(void)
 	return get_cp0_count();
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 
 	IRQ_CONNECT(MIPS_MACHINE_TIMER_IRQ, 0, timer_isr, NULL, 0);
 	last_count = get_cp0_count();

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -123,9 +123,8 @@ void sys_clock_disable(void)
  *
  * Enable the hw timer, setting its tick period, and setup its interrupt
  */
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 
 	tick_period = 1000000ul / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
 

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -303,9 +303,8 @@ uint64_t npcx_clock_get_sleep_ticks(void)
 }
 #endif /* CONFIG_PM */
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 	int ret;
 	uint32_t sys_tmr_rate;
 	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -684,9 +684,8 @@ void sys_clock_disable(void)
 	NVIC_ClearPendingIRQ(RTC_IRQn);
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 	static const enum nrf_lfclk_start_mode mode =
 		IS_ENABLED(CONFIG_SYSTEM_CLOCK_NO_WAIT) ?
 			CLOCK_CONTROL_NRF_LF_START_NOWAIT :

--- a/drivers/timer/rcar_cmt_timer.c
+++ b/drivers/timer/rcar_cmt_timer.c
@@ -89,13 +89,12 @@ uint32_t sys_clock_cycle_get_32(void)
  * The second one is used for cycles count, the match value is set
  * at max uint32_t.
  */
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
 	const struct device *clk;
 	uint32_t reg_val;
 	int i, ret;
 
-	ARG_UNUSED(dev);
 	clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0));
 	if (!device_is_ready(clk)) {
 		return -ENODEV;

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -220,9 +220,8 @@ uint64_t sys_clock_cycle_get_64(void)
 	return mtime() << CONFIG_RISCV_MACHINE_TIMER_SYSTEM_CLOCK_DIVIDER;
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 
 	set_divider();
 

--- a/drivers/timer/rv32m1_lptmr_timer.c
+++ b/drivers/timer/rv32m1_lptmr_timer.c
@@ -71,11 +71,10 @@ uint32_t sys_clock_elapsed(void)
 	return 0;
 }
 
-static int sys_clock_driver_init(const struct device *unused)
+static int sys_clock_driver_init(void)
 {
 	uint32_t csr, psr, sircdiv; /* LPTMR registers */
 
-	ARG_UNUSED(unused);
 	IRQ_CONNECT(DT_INST_IRQN(0),
 		    0, lptmr_irq_handler, NULL, 0);
 

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -245,11 +245,10 @@ uint32_t sys_clock_cycle_get_32(void)
 	return rtc_count();
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
 	int retval;
 
-	ARG_UNUSED(dev);
 
 #ifdef MCLK
 	MCLK->APBAMASK.reg |= MCLK_APBAMASK_RTC;

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -315,11 +315,10 @@ void stm32_lptim_wait_ready(void)
 #endif
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
 	int err;
 
-	ARG_UNUSED(dev);
 
 	if (!device_is_ready(clk_ctrl)) {
 		return -ENODEV;

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -146,10 +146,9 @@ uint32_t sys_clock_cycle_get_32(void)
 	return read_count();
 }
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
 	uint32_t reg_val;
-	ARG_UNUSED(dev);
 
 	/* Stop timer */
 	sys_write32(XTTCPS_CNT_CNTRL_DIS_MASK,

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -120,9 +120,8 @@ void smp_timer_init(void)
 }
 #endif
 
-static int sys_clock_driver_init(const struct device *dev)
+static int sys_clock_driver_init(void)
 {
-	ARG_UNUSED(dev);
 
 	IRQ_CONNECT(TIMER_IRQ, 0, ccompare_isr, 0, 0);
 	set_ccompare(ccount() + CYC_PER_TICK);

--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -1038,9 +1038,8 @@ static void usb_kinetis_thread_main(void *arg1, void *unused1, void *unused2)
 	}
 }
 
-static int usb_kinetis_init(const struct device *dev)
+static int usb_kinetis_init(void)
 {
-	ARG_UNUSED(dev);
 
 	k_thread_create(&dev_data.thread, dev_data.thread_stack,
 			USBD_THREAD_STACK_SIZE,

--- a/drivers/usb/device/usb_dc_mcux.c
+++ b/drivers/usb/device/usb_dc_mcux.c
@@ -883,9 +883,8 @@ static void usb_isr_handler(void)
 #endif
 }
 
-static int usb_mcux_init(const struct device *dev)
+static int usb_mcux_init(void)
 {
-	ARG_UNUSED(dev);
 
 	k_thread_create(&dev_state.thread, dev_state.thread_stack,
 			CONFIG_USB_MCUX_THREAD_STACK_SIZE,

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1869,7 +1869,7 @@ int usb_dc_wakeup_request(void)
 	return 0;
 }
 
-static int usb_init(const struct device *arg)
+static int usb_init(void)
 {
 	struct nrf_usbd_ctx *ctx = get_usbd_ctx();
 	nrfx_err_t err;

--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -982,9 +982,8 @@ static void udc_rpi_thread_main(void *arg1, void *unused1, void *unused2)
 	}
 }
 
-static int usb_rpi_init(const struct device *dev)
+static int usb_rpi_init(void)
 {
-	ARG_UNUSED(dev);
 
 	k_thread_create(&thread, thread_stack,
 			USBD_THREAD_STACK_SIZE,

--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -1081,9 +1081,8 @@ K_KERNEL_STACK_DEFINE(udc_work_q_stack, CONFIG_UDC_WORKQUEUE_STACK_SIZE);
 
 struct k_work_q udc_work_q;
 
-static int udc_work_q_init(const struct device *dev)
+static int udc_work_q_init(void)
 {
-	ARG_UNUSED(dev);
 
 	k_work_queue_start(&udc_work_q,
 			   udc_work_q_stack,

--- a/drivers/usb/uvb/uvb.c
+++ b/drivers/usb/uvb/uvb.c
@@ -316,7 +316,7 @@ static void uvb_work_handler(struct k_work *work)
 	}
 }
 
-static int uvb_init(const struct device *dev)
+static int uvb_init(void)
 {
 	STRUCT_SECTION_FOREACH(uvb_node, host) {
 		LOG_DBG("Host %p - %s", host, host->name);

--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -287,7 +287,7 @@ const char *gnttabop_error(int16_t status)
 	}
 }
 
-static int gnttab_init(const struct device *d)
+static int gnttab_init(void)
 {
 	grant_ref_t gref;
 	struct xen_add_to_physmap xatp;

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -906,13 +906,17 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * @brief Define the init entry for a device.
  *
  * @param dev_id Device identifier.
- * @param init_fn Device init function.
+ * @param init_fn_ Device init function.
  * @param level Initialization level.
  * @param prio Initialization priority.
  */
-#define Z_DEVICE_INIT_ENTRY_DEFINE(dev_id, init_fn, level, prio)               \
-	Z_INIT_ENTRY_DEFINE(DEVICE_NAME_GET(dev_id), init_fn,                  \
-			    (&DEVICE_NAME_GET(dev_id)), level, prio)
+#define Z_DEVICE_INIT_ENTRY_DEFINE(dev_id, init_fn_, level, prio)              \
+	static const Z_DECL_ALIGN(struct init_entry)                           \
+		Z_INIT_ENTRY_SECTION(level, prio) __used                       \
+		Z_INIT_ENTRY_NAME(DEVICE_NAME_GET(dev_id)) = {                 \
+			.init_fn = {.dev = (init_fn_)},                        \
+			.dev = &DEVICE_NAME_GET(dev_id),                       \
+	}
 
 /**
  * @brief Define a @ref device and all other required objects.

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -47,17 +47,49 @@ extern "C" {
 
 struct device;
 
-/** @brief Structure to store initialization entry information. */
-struct init_entry {
+/**
+ * @brief Initialization function for init entries.
+ *
+ * Init entries support both the system initialization and the device
+ * APIs. Each API has its own init function signature; hence, we have a
+ * union to cover both.
+ */
+union init_function {
 	/**
-	 * Initialization function for the init entry.
-	 *
-	 * @param dev Device pointer, NULL if not a device init function.
+	 * System initialization function.
 	 *
 	 * @retval 0 On success
 	 * @retval -errno If init fails.
 	 */
-	int (*init)(const struct device *dev);
+	int (*sys)(void);
+	/**
+	 * Device initialization function.
+	 *
+	 * @param dev Device instance.
+	 *
+	 * @retval 0 On success
+	 * @retval -errno If device initialization fails.
+	 */
+	int (*dev)(const struct device *dev);
+};
+
+/**
+ * @brief Structure to store initialization entry information.
+ *
+ * @internal
+ * Init entries need to be defined following these rules:
+ *
+ * - Their name must be set using Z_INIT_ENTRY_NAME().
+ * - They must be placed in a special init section, given by
+ *   Z_INIT_ENTRY_SECTION().
+ * - They must be aligned, e.g. using Z_DECL_ALIGN().
+ *
+ * See SYS_INIT_NAMED() for an example.
+ * @endinternal
+ */
+struct init_entry {
+	/** Initialization function. */
+	union init_function init_fn;
 	/**
 	 * If the init entry belongs to a device, this fields stores a
 	 * reference to it, otherwise it is set to NULL.
@@ -82,29 +114,6 @@ struct init_entry {
  */
 #define Z_INIT_ENTRY_SECTION(level, prio)                                      \
 	__attribute__((__section__(".z_init_" #level STRINGIFY(prio)"_")))
-
-/**
- * @brief Create an init entry object.
- *
- * This macro defines an init entry object that will be automatically
- * configured by the kernel during system initialization. Note that init
- * entries will not be accessible from user mode.
- *
- * @param init_id Init entry unique identifier.
- * @param init_fn Init function.
- * @param device Device instance (optional).
- * @param level Initialization level.
- * @param prio Initialization priority within @p level.
- *
- * @see SYS_INIT()
- */
-#define Z_INIT_ENTRY_DEFINE(init_id, init_fn, device, level, prio)             \
-	static const Z_DECL_ALIGN(struct init_entry)                           \
-		Z_INIT_ENTRY_SECTION(level, prio) __used __noasan              \
-		Z_INIT_ENTRY_NAME(init_id) = {                                 \
-			.init = (init_fn),                                     \
-			.dev = (device),                                       \
-	}
 
 /** @endcond */
 
@@ -134,14 +143,18 @@ struct init_entry {
  * same init function.
  *
  * @param name Unique name for SYS_INIT entry.
- * @param init_fn See SYS_INIT().
+ * @param init_fn_ See SYS_INIT().
  * @param level See SYS_INIT().
  * @param prio See SYS_INIT().
  *
  * @see SYS_INIT()
  */
-#define SYS_INIT_NAMED(name, init_fn, level, prio)                             \
-	Z_INIT_ENTRY_DEFINE(name, init_fn, NULL, level, prio)
+#define SYS_INIT_NAMED(name, init_fn_, level, prio)                            \
+	static const Z_DECL_ALIGN(struct init_entry)                           \
+		Z_INIT_ENTRY_SECTION(level, prio) __used                       \
+		Z_INIT_ENTRY_NAME(name) = {                                    \
+			.init_fn = {.sys = (init_fn_)},                        \
+	}
 
 /** @} */
 

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -250,9 +250,9 @@ static void z_sys_init_run_level(enum init_level level)
 
 	for (entry = levels[level]; entry < levels[level+1]; entry++) {
 		const struct device *dev = entry->dev;
-		int rc = entry->init(dev);
 
 		if (dev != NULL) {
+			int rc = entry->init_fn.dev(dev);
 			/* Mark device initialized.  If initialization
 			 * failed, record the error condition.
 			 */
@@ -270,6 +270,8 @@ static void z_sys_init_run_level(enum init_level level)
 				/* Run automatic device runtime enablement */
 				(void)pm_device_runtime_auto_enable(dev);
 			}
+		} else {
+			(void)entry->init_fn.sys();
 		}
 	}
 }

--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -18,9 +18,8 @@ void k_heap_init(struct k_heap *h, void *mem, size_t bytes)
 	SYS_PORT_TRACING_OBJ_INIT(k_heap, h);
 }
 
-static int statics_init(const struct device *unused)
+static int statics_init(void)
 {
-	ARG_UNUSED(unused);
 	STRUCT_SECTION_FOREACH(k_heap, h) {
 #if defined(CONFIG_DEMAND_PAGING) && !defined(CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)
 		/* Some heaps may not present at boot, so we need to wait for

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -49,10 +49,8 @@ static inline void mbox_async_free(struct k_mbox_async *async)
 /*
  * Do run-time initialization of mailbox object subsystem.
  */
-static int init_mbox_module(const struct device *dev)
+static int init_mbox_module(void)
 {
-	ARG_UNUSED(dev);
-
 	/* array of asynchronous message descriptors */
 	static struct k_mbox_async __noinit async_msg[CONFIG_NUM_MBOX_ASYNC_MSGS];
 

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -338,11 +338,10 @@ int k_mem_domain_add_thread(struct k_mem_domain *domain, k_tid_t thread)
 	return ret;
 }
 
-static int init_mem_domain_module(const struct device *arg)
+static int init_mem_domain_module(void)
 {
 	int ret;
 
-	ARG_UNUSED(arg);
 	ARG_UNUSED(ret);
 
 	max_partitions = arch_mem_domain_max_partitions_get();

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -53,10 +53,9 @@ static int create_free_list(struct k_mem_slab *slab)
  *
  * @return 0 on success, fails otherwise.
  */
-static int init_mem_slab_module(const struct device *dev)
+static int init_mem_slab_module(void)
 {
 	int rc = 0;
-	ARG_UNUSED(dev);
 
 	STRUCT_SECTION_FOREACH(k_mem_slab, slab) {
 		rc = create_free_list(slab);

--- a/kernel/system_work_q.c
+++ b/kernel/system_work_q.c
@@ -19,9 +19,8 @@ static K_KERNEL_STACK_DEFINE(sys_work_q_stack,
 
 struct k_work_q k_sys_work_q;
 
-static int k_sys_work_q_init(const struct device *dev)
+static int k_sys_work_q_init(void)
 {
-	ARG_UNUSED(dev);
 	struct k_work_queue_config cfg = {
 		.name = "sysworkq",
 		.no_yield = IS_ENABLED(CONFIG_SYSTEM_WORKQUEUE_NO_YIELD),

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -859,11 +859,10 @@ out:
 extern char __app_shmem_regions_start[];
 extern char __app_shmem_regions_end[];
 
-static int app_shmem_bss_zero(const struct device *unused)
+static int app_shmem_bss_zero(void)
 {
 	struct z_app_region *region, *end;
 
-	ARG_UNUSED(unused);
 
 	end = (struct z_app_region *)&__app_shmem_regions_end;
 	region = (struct z_app_region *)&__app_shmem_regions_start;

--- a/lib/libc/minimal/source/stdlib/malloc.c
+++ b/lib/libc/minimal/source/stdlib/malloc.c
@@ -76,9 +76,8 @@ void *aligned_alloc(size_t alignment, size_t size)
 }
 #endif /* __STDC_VERSION__ >= 201112L */
 
-static int malloc_prepare(const struct device *unused)
+static int malloc_prepare(void)
 {
-	ARG_UNUSED(unused);
 
 	sys_heap_init(&z_malloc_heap, z_malloc_heap_mem, HEAP_BYTES);
 	sys_mutex_init(&z_malloc_heap_mutex);

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -98,9 +98,8 @@
 	#endif /* CONFIG_XTENSA */
 #endif
 
-static int malloc_prepare(const struct device *unused)
+static int malloc_prepare(void)
 {
-	ARG_UNUSED(unused);
 
 #ifdef USE_MALLOC_PREPARE
 #ifdef CONFIG_MMU
@@ -333,9 +332,8 @@ K_SEM_DEFINE(__lock___arc4random_mutex, 1, 1);
 
 #ifdef CONFIG_USERSPACE
 /* Grant public access to all static locks after boot */
-static int newlib_locks_prepare(const struct device *unused)
+static int newlib_locks_prepare(void)
 {
-	ARG_UNUSED(unused);
 
 	/* Initialise recursive locks */
 	k_object_access_all_grant(&__lock___sinit_recursive_mutex);

--- a/lib/libc/picolibc/libc-hooks.c
+++ b/lib/libc/picolibc/libc-hooks.c
@@ -141,9 +141,8 @@ extern char _heap_sentry[];
 
 #ifdef USE_MALLOC_PREPARE
 
-static int malloc_prepare(const struct device *unused)
+static int malloc_prepare(void)
 {
-	ARG_UNUSED(unused);
 
 #ifdef CONFIG_MMU
 
@@ -329,9 +328,8 @@ K_MUTEX_DEFINE(__lock___libc_recursive_mutex);
 
 #ifdef CONFIG_USERSPACE
 /* Grant public access to picolibc lock after boot */
-static int picolibc_locks_prepare(const struct device *unused)
+static int picolibc_locks_prepare(void)
 {
-	ARG_UNUSED(unused);
 
 	/* Initialise recursive locks */
 	k_object_access_all_grant(&__lock___libc_recursive_mutex);

--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -139,9 +139,8 @@ void k_p4wq_add_thread(struct k_p4wq *queue, struct k_thread *thread,
 			queue->flags & K_P4WQ_DELAYED_START ? K_FOREVER : K_NO_WAIT);
 }
 
-static int static_init(const struct device *dev)
+static int static_init(void)
 {
-	ARG_UNUSED(dev);
 
 	STRUCT_SECTION_FOREACH(k_p4wq_initparam, pp) {
 		for (int i = 0; i < pp->num; i++) {

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -710,11 +710,10 @@ int pthread_getname_np(pthread_t thread, char *name, size_t len)
 #endif
 }
 
-static int posix_thread_pool_init(const struct device *dev)
+static int posix_thread_pool_init(void)
 {
 	size_t i;
 
-	ARG_UNUSED(dev);
 
 	for (i = 0; i < CONFIG_MAX_PTHREAD_COUNT; ++i) {
 		posix_thread_pool[i].state = PTHREAD_EXITED;

--- a/modules/canopennode/CO_driver.c
+++ b/modules/canopennode/CO_driver.c
@@ -509,9 +509,8 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule)
 	}
 }
 
-static int canopen_init(const struct device *dev)
+static int canopen_init(void)
 {
-	ARG_UNUSED(dev);
 
 	k_work_queue_start(&canopen_tx_workq, canopen_tx_workq_stack,
 			   K_KERNEL_STACK_SIZEOF(canopen_tx_workq_stack),

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_init_net.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_init_net.c
@@ -9,7 +9,7 @@
 #include "nrf_802154.h"
 #include "nrf_802154_serialization.h"
 
-static int serialization_init(const struct device *dev)
+static int serialization_init(void)
 {
 	/* On NET core we don't use Zephyr's shim layer so we have to call inits manually */
 	nrf_802154_init();

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_temperature_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_temperature_zephyr.c
@@ -52,9 +52,8 @@ static void work_handler(struct k_work *work)
 	k_work_reschedule(&dwork, K_MSEC(CONFIG_NRF_802154_TEMPERATURE_UPDATE_PERIOD));
 }
 
-static int temperature_update_init(const struct device *dev)
+static int temperature_update_init(void)
 {
-	ARG_UNUSED(dev);
 
 	__ASSERT_NO_MSG(device_is_ready(device));
 

--- a/modules/mbedtls/zephyr_init.c
+++ b/modules/mbedtls/zephyr_init.c
@@ -83,9 +83,8 @@ int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len,
 }
 #endif /* CONFIG_MBEDTLS_ZEPHYR_ENTROPY */
 
-static int _mbedtls_init(const struct device *device)
+static int _mbedtls_init(void)
 {
-	ARG_UNUSED(device);
 
 	init_heap();
 

--- a/modules/segger/SEGGER_RTT_zephyr.c
+++ b/modules/segger/SEGGER_RTT_zephyr.c
@@ -22,9 +22,8 @@
 
 K_MUTEX_DEFINE(rtt_term_mutex);
 
-static int rtt_init(const struct device *unused)
+static int rtt_init(void)
 {
-	ARG_UNUSED(unused);
 
 	SEGGER_RTT_Init();
 

--- a/modules/trusted-firmware-m/interface/interface.c
+++ b/modules/trusted-firmware-m/interface/interface.c
@@ -88,9 +88,8 @@ enum tfm_status_e tfm_ns_interface_init(void)
 #include "psa_manifest/sid.h"
 #endif /* TFM_PSA_API */
 
-static int ns_interface_init(const struct device *arg)
+static int ns_interface_init(void)
 {
-	ARG_UNUSED(arg);
 
 	__ASSERT(tfm_ns_interface_init() == TFM_SUCCESS,
 		"TF-M NS interface init failed");

--- a/samples/application_development/code_relocation_nocopy/boards/nrf5340dk_nrf5340_cpuapp/ext_mem_init.c
+++ b/samples/application_development/code_relocation_nocopy/boards/nrf5340dk_nrf5340_cpuapp/ext_mem_init.c
@@ -16,9 +16,8 @@
 
 #define QSPI_NODE DT_NODELABEL(qspi)
 
-static int qspi_ext_mem_init(const struct device *dev)
+static int qspi_ext_mem_init(void)
 {
-	ARG_UNUSED(dev);
 
 	static const nrfx_qspi_config_t qspi_config = {
 		.prot_if = {

--- a/samples/bluetooth/hci_spi/src/main.c
+++ b/samples/bluetooth/hci_spi/src/main.c
@@ -259,9 +259,8 @@ static void bt_tx_thread(void *p1, void *p2, void *p3)
 	}
 }
 
-static int hci_spi_init(const struct device *unused)
+static int hci_spi_init(void)
 {
-	ARG_UNUSED(unused);
 
 	LOG_DBG("");
 

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -326,7 +326,7 @@ void bt_ctlr_assert_handle(char *file, uint32_t line)
 }
 #endif /* CONFIG_BT_CTLR_ASSERT_HANDLER */
 
-static int hci_uart_init(const struct device *unused)
+static int hci_uart_init(void)
 {
 	LOG_DBG("");
 

--- a/samples/boards/nrf/battery/src/battery.c
+++ b/samples/boards/nrf/battery/src/battery.c
@@ -142,7 +142,7 @@ static int divider_setup(void)
 
 static bool battery_ok;
 
-static int battery_setup(const struct device *arg)
+static int battery_setup(void)
 {
 	int rc = divider_setup();
 

--- a/samples/boards/nrf/dynamic_pinctrl/src/remap.c
+++ b/samples/boards/nrf/dynamic_pinctrl/src/remap.c
@@ -28,13 +28,12 @@ static const struct pinctrl_state uart0_alt[] = {
 #endif
 };
 
-static int remap_pins(const struct device *dev)
+static int remap_pins(void)
 {
 	int ret;
 	const struct gpio_dt_spec button = GPIO_DT_SPEC_GET_OR(DT_ALIAS(sw0),
 							       gpios, {0});
 
-	ARG_UNUSED(dev);
 
 	if (!device_is_ready(button.port)) {
 		return -ENODEV;

--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -25,9 +25,8 @@
  * before the threading system starts up between PRE_KERNEL_2 and
  * POST_KERNEL.  Do it at the start of PRE_KERNEL_2.
  */
-static int disable_ds_1(const struct device *dev)
+static int disable_ds_1(void)
 {
-	ARG_UNUSED(dev);
 
 	pm_policy_state_lock_get(PM_STATE_SOFT_OFF, PM_ALL_SUBSTATES);
 	return 0;

--- a/samples/subsys/ipc/openamp/src/main.c
+++ b/samples/subsys/ipc/openamp/src/main.c
@@ -298,7 +298,7 @@ void main(void)
 /* Make sure we clear out the status flag very early (before we bringup the
  * secondary core) so the secondary core see's the proper status
  */
-int init_status_flag(const struct device *arg)
+int init_status_flag(void)
 {
 	virtio_set_status(NULL, 0);
 

--- a/samples/subsys/ipc/rpmsg_service/remote/src/main.c
+++ b/samples/subsys/ipc/rpmsg_service/remote/src/main.c
@@ -83,7 +83,7 @@ void main(void)
 }
 
 /* Make sure we register endpoint before RPMsg Service is initialized. */
-int register_endpoint(const struct device *arg)
+int register_endpoint(void)
 {
 	int status;
 

--- a/samples/subsys/ipc/rpmsg_service/src/main.c
+++ b/samples/subsys/ipc/rpmsg_service/src/main.c
@@ -99,7 +99,7 @@ void main(void)
 }
 
 /* Make sure we register endpoint before RPMsg Service is initialized. */
-int register_endpoint(const struct device *arg)
+int register_endpoint(void)
 {
 	int status;
 

--- a/samples/subsys/usb/hid/src/main.c
+++ b/samples/subsys/usb/hid/src/main.c
@@ -149,7 +149,7 @@ void main(void)
 	k_work_init(&report_send, send_report);
 }
 
-static int composite_pre_init(const struct device *dev)
+static int composite_pre_init(void)
 {
 	hdev = device_get_binding("HID_0");
 	if (hdev == NULL) {

--- a/scripts/utils/migrate_sys_init.py
+++ b/scripts/utils/migrate_sys_init.py
@@ -1,0 +1,86 @@
+"""
+Utility script to migrate SYS_INIT() calls from the old signature
+``int (*init_fn)(const struct device *dev)`` to ``int (*init_fn)(void)``.
+
+.. warning::
+    Review the output carefully! This script may not cover all cases!
+
+Usage::
+
+    python $ZEPHYR_BASE/scripts/utils/migrate_sys_init.py \
+           -p path/to/zephyr-based-project
+
+Copyright (c) 2022 Nordic Semiconductor ASA
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import argparse
+from pathlib import Path
+import re
+
+
+ZEPHYR_BASE = Path(__file__).parents[2]
+
+
+def update_sys_init(project, dry_run):
+    for p in project.glob("**/*"):
+        if not p.is_file() or not p.suffix or p.suffix[1:] not in ("c", "cpp"):
+            continue
+
+        with open(p) as f:
+            lines = f.readlines()
+
+        sys_inits = []
+        for line in lines:
+            m = re.match(r"^SYS_INIT\(([A-Za-z0-9_]+),.*", line)
+            if m:
+                sys_inits.append(m.group(1))
+                continue
+
+            m = re.match(r"^SYS_INIT_NAMED\([A-Za-z0-9_]+,\s?([A-Za-z0-9_]+).*", line)
+            if m:
+                sys_inits.append(m.group(1))
+                continue
+
+        if not sys_inits:
+            continue
+
+        arg = None
+        content = ""
+        update = False
+        for line in lines:
+            m = re.match(
+                r"(.*)int ("
+                + "|".join(sys_inits)
+                + r")\(const\s+struct\s+device\s+\*\s?(.*)\)(.*)",
+                line,
+            )
+            if m:
+                b, sys_init, arg, e = m.groups()
+                content += f"{b}int {sys_init}(void){e}\n"
+                update = True
+            elif arg:
+                m = re.match(r"^\s?ARG_UNUSED\(" + arg + r"\);.*$", line)
+                if m:
+                    arg = None
+                else:
+                    content += line
+            else:
+                content += line
+
+        if update:
+            print(f"Updating {p}{' (dry run)' if dry_run else ''}")
+            if not dry_run:
+                with open(p, "w") as f:
+                    f.write(content)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    parser.add_argument(
+        "-p", "--project", type=Path, required=True, help="Zephyr-based project path"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Dry run")
+    args = parser.parse_args()
+
+    update_sys_init(args.project, args.dry_run)

--- a/soc/arc/snps_arc_iot/soc.c
+++ b/soc/arc/snps_arc_iot/soc.c
@@ -15,9 +15,8 @@
 
 #define CPU_FREQ DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
 
-static int arc_iot_init(const struct device *dev)
+static int arc_iot_init(void)
 {
-	ARG_UNUSED(dev);
 
 	if (arc_iot_pll_fout_config(CPU_FREQ / 1000000) < 0) {
 		return -1;

--- a/soc/arc/snps_emsk/soc_config.c
+++ b/soc/arc/snps_emsk/soc_config.c
@@ -11,9 +11,8 @@
 
 #ifdef CONFIG_UART_NS16550
 
-static int uart_ns16550_init(const struct device *dev)
+static int uart_ns16550_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* On ARC EM Starter kit board,
 	 * send the UART the command to clear the interrupt

--- a/soc/arm/arm/beetle/soc.c
+++ b/soc/arm/arm/beetle/soc.c
@@ -30,11 +30,10 @@
  *
  * @return 0
  */
-static int arm_beetle_init(const struct device *arg)
+static int arm_beetle_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/arm/designstart/soc.c
+++ b/soc/arm/arm/designstart/soc.c
@@ -7,9 +7,8 @@
 #include <zephyr/device.h>
 #include <zephyr/arch/arm/aarch32/nmi.h>
 
-static int arm_designstart_init(const struct device *arg)
+static int arm_designstart_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/*
 	 * Install default handler that simply resets the CPU if

--- a/soc/arm/arm/mps2/soc.c
+++ b/soc/arm/arm/mps2/soc.c
@@ -76,9 +76,8 @@ uint32_t sse_200_platform_get_cpu_id(void)
  *
  * @return 0
  */
-static int arm_mps2_init(const struct device *arg)
+static int arm_mps2_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/*
 	 * Install default handler that simply resets the CPU

--- a/soc/arm/arm/mps3/soc.c
+++ b/soc/arm/arm/mps3/soc.c
@@ -30,9 +30,8 @@ FPGAIO_INIT(2);
  *
  * @return 0
  */
-static int arm_mps3_init(const struct device *arg)
+static int arm_mps3_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/*
 	 * Install default handler that simply resets the CPU

--- a/soc/arm/arm/musca_b1/soc.c
+++ b/soc/arm/arm/musca_b1/soc.c
@@ -52,9 +52,8 @@ uint32_t sse_200_platform_get_cpu_id(void)
  *
  * @return 0
  */
-static int arm_musca_b1_init(const struct device *arg)
+static int arm_musca_b1_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/*
 	 * Install default handler that simply resets the CPU

--- a/soc/arm/arm/musca_s1/soc.c
+++ b/soc/arm/arm/musca_s1/soc.c
@@ -13,9 +13,8 @@
  *
  * @return 0
  */
-static int arm_musca_s1_init(const struct device *arg)
+static int arm_musca_s1_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/*
 	 * Install default handler that simply resets the CPU

--- a/soc/arm/atmel_sam/sam3x/soc.c
+++ b/soc/arm/atmel_sam/sam3x/soc.c
@@ -202,11 +202,10 @@ static ALWAYS_INLINE void clock_init(void)
  *
  * @return 0
  */
-static int atmel_sam3x_init(const struct device *arg)
+static int atmel_sam3x_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/atmel_sam/sam4e/soc.c
+++ b/soc/arm/atmel_sam/sam4e/soc.c
@@ -190,11 +190,10 @@ static ALWAYS_INLINE void clock_init(void)
  *
  * @return 0
  */
-static int atmel_sam4e_init(const struct device *arg)
+static int atmel_sam4e_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/atmel_sam/sam4l/soc.c
+++ b/soc/arm/atmel_sam/sam4l/soc.c
@@ -273,11 +273,10 @@ static ALWAYS_INLINE void clock_init(void)
  *
  * @return 0
  */
-static int atmel_sam4l_init(const struct device *arg)
+static int atmel_sam4l_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/atmel_sam/sam4s/soc.c
+++ b/soc/arm/atmel_sam/sam4s/soc.c
@@ -189,11 +189,10 @@ static ALWAYS_INLINE void clock_init(void)
  *
  * @return 0
  */
-static int atmel_sam4s_init(const struct device *arg)
+static int atmel_sam4s_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/atmel_sam/same70/soc.c
+++ b/soc/arm/atmel_sam/same70/soc.c
@@ -232,11 +232,10 @@ static ALWAYS_INLINE void clock_init(void)
  *
  * @return 0
  */
-static int atmel_same70_init(const struct device *arg)
+static int atmel_same70_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/atmel_sam/same70/soc_config.c
+++ b/soc/arm/atmel_sam/same70/soc_config.c
@@ -20,7 +20,7 @@
  *
  * @return 0
  */
-static int atmel_same70_config(const struct device *dev)
+static int atmel_same70_config(void)
 {
 #ifdef CONFIG_SOC_ATMEL_SAME70_DISABLE_ERASE_PIN
 	/* Disable ERASE function on PB12 pin, this is controlled by Bus Matrix */

--- a/soc/arm/atmel_sam/samv71/soc.c
+++ b/soc/arm/atmel_sam/samv71/soc.c
@@ -233,11 +233,10 @@ static ALWAYS_INLINE void clock_init(void)
  *
  * @return 0
  */
-static int atmel_samv71_init(const struct device *arg)
+static int atmel_samv71_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/atmel_sam/samv71/soc_config.c
+++ b/soc/arm/atmel_sam/samv71/soc_config.c
@@ -21,7 +21,7 @@
  *
  * @return 0
  */
-static int atmel_samv71_config(const struct device *dev)
+static int atmel_samv71_config(void)
 {
 #ifdef CONFIG_SOC_ATMEL_SAMV71_DISABLE_ERASE_PIN
 	/* Disable ERASE function on PB12 pin, this is controlled by Bus

--- a/soc/arm/atmel_sam0/common/bossa.c
+++ b/soc/arm/atmel_sam0/common/bossa.c
@@ -43,7 +43,7 @@ static void bossa_reset(const struct device *dev, uint32_t rate)
 	NVIC_SystemReset();
 }
 
-static int bossa_init(const struct device *unused)
+static int bossa_init(void)
 {
 	const struct device *dev =
 		device_get_binding(CONFIG_BOOTLOADER_BOSSA_DEVICE_NAME);

--- a/soc/arm/atmel_sam0/common/soc_samc2x.c
+++ b/soc/arm/atmel_sam0/common/soc_samc2x.c
@@ -43,11 +43,10 @@ static void gclks_init(void)
 			     | GCLK_GENCTRL_GENEN;
 }
 
-static int atmel_samc_init(const struct device *arg)
+static int atmel_samc_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/atmel_sam0/common/soc_samd2x.c
+++ b/soc/arm/atmel_sam0/common/soc_samd2x.c
@@ -255,11 +255,10 @@ static inline void osc8m_disable(void)
 }
 #endif
 
-static int atmel_samd_init(const struct device *arg)
+static int atmel_samd_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/atmel_sam0/common/soc_samd5x.c
+++ b/soc/arm/atmel_sam0/common/soc_samd5x.c
@@ -105,7 +105,7 @@ static void gclk_connect(uint8_t gclk, uint8_t src, uint8_t div)
 				| GCLK_GENCTRL_GENEN;
 }
 
-static int atmel_samd_init(const struct device *arg)
+static int atmel_samd_init(void)
 {
 	uint32_t key;
 	uint8_t dfll_div;
@@ -118,7 +118,6 @@ static int atmel_samd_init(const struct device *arg)
 		dfll_div = 1;
 	}
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/atmel_sam0/common/soc_saml2x.c
+++ b/soc/arm/atmel_sam0/common/soc_saml2x.c
@@ -243,11 +243,10 @@ static inline void pause_for_debug(void)
 static inline void pause_for_debug(void) {}
 #endif
 
-static int atmel_saml_init(const struct device *arg)
+static int atmel_saml_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/atmel_sam0/common/soc_samr34.c
+++ b/soc/arm/atmel_sam0/common/soc_samr34.c
@@ -13,11 +13,10 @@
  * unexpected behavior and increased current consumption... see Chapter 10 of
  * DS70005356C. We also hold the radio in reset.
  */
-static int soc_pinconf_init(const struct device *dev)
+static int soc_pinconf_init(void)
 {
 	const struct device *const portb = DEVICE_DT_GET(DT_NODELABEL(portb));
 
-	ARG_UNUSED(dev);
 
 	if (!device_is_ready(portb)) {
 		return -ENODEV;

--- a/soc/arm/bcm_vk/valkyrie/soc.c
+++ b/soc/arm/bcm_vk/valkyrie/soc.c
@@ -17,11 +17,10 @@
  *
  * @return 0
  */
-static int valkyrie_init(const struct device *arg)
+static int valkyrie_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/bcm_vk/viper/soc.c
+++ b/soc/arm/bcm_vk/viper/soc.c
@@ -18,12 +18,11 @@
  *
  * @return 0
  */
-static int viper_init(const struct device *arg)
+static int viper_init(void)
 {
 	uint32_t key;
 	uint32_t data;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/cypress/psoc6/soc.c
+++ b/soc/arm/cypress/psoc6/soc.c
@@ -383,9 +383,8 @@ void Cy_SystemInit(void)
 #endif
 }
 
-static int init_cycfg_platform_wraper(const struct device *arg)
+static int init_cycfg_platform_wraper(void)
 {
-	ARG_UNUSED(arg);
 	SystemInit();
 	return 0;
 }

--- a/soc/arm/gigadevice/gd32a50x/soc.c
+++ b/soc/arm/gigadevice/gd32a50x/soc.c
@@ -19,11 +19,10 @@ void z_arm_platform_init(void)
 	}
 }
 
-static int gd32a50x_soc_init(const struct device *dev)
+static int gd32a50x_soc_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(dev);
 
 	key = irq_lock();
 

--- a/soc/arm/gigadevice/gd32e10x/soc.c
+++ b/soc/arm/gigadevice/gd32e10x/soc.c
@@ -8,11 +8,10 @@
 #include <zephyr/irq.h>
 #include <soc.h>
 
-static int gd32e10x_soc_init(const struct device *dev)
+static int gd32e10x_soc_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(dev);
 
 	key = irq_lock();
 

--- a/soc/arm/gigadevice/gd32e50x/soc.c
+++ b/soc/arm/gigadevice/gd32e50x/soc.c
@@ -6,11 +6,10 @@
 #include <zephyr/init.h>
 #include <zephyr/irq.h>
 
-static int gd32e50x_soc_init(const struct device *dev)
+static int gd32e50x_soc_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(dev);
 
 	key = irq_lock();
 

--- a/soc/arm/gigadevice/gd32f3x0/soc.c
+++ b/soc/arm/gigadevice/gd32f3x0/soc.c
@@ -8,11 +8,10 @@
 #include <zephyr/irq.h>
 #include <soc.h>
 
-static int gd32f3x0_init(const struct device *dev)
+static int gd32f3x0_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(dev);
 
 	key = irq_lock();
 

--- a/soc/arm/gigadevice/gd32f403/soc.c
+++ b/soc/arm/gigadevice/gd32f403/soc.c
@@ -23,11 +23,10 @@
  *
  * @return 0
  */
-static int gigadevice_gd32_soc_init(const struct device *arg)
+static int gigadevice_gd32_soc_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/gigadevice/gd32f4xx/soc.c
+++ b/soc/arm/gigadevice/gd32f4xx/soc.c
@@ -7,11 +7,10 @@
 #include <zephyr/init.h>
 #include <zephyr/irq.h>
 
-static int gd32f4xx_soc_init(const struct device *dev)
+static int gd32f4xx_soc_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(dev);
 
 	key = irq_lock();
 

--- a/soc/arm/gigadevice/gd32l23x/soc.c
+++ b/soc/arm/gigadevice/gd32l23x/soc.c
@@ -8,11 +8,10 @@
 #include <zephyr/irq.h>
 #include <soc.h>
 
-static int gd32l23x_init(const struct device *dev)
+static int gd32l23x_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(dev);
 
 	key = irq_lock();
 

--- a/soc/arm/infineon_cat1/psoc6/soc.c
+++ b/soc/arm/infineon_cat1/psoc6/soc.c
@@ -54,9 +54,8 @@ cy_en_sysint_status_t Cy_SysInt_Init(const cy_stc_sysint_t *config, cy_israddres
 	return status;
 }
 
-static int init_cycfg_platform_wraper(const struct device *arg)
+static int init_cycfg_platform_wraper(void)
 {
-	ARG_UNUSED(arg);
 
 	/* Initializes the system */
 	SystemInit();

--- a/soc/arm/intel_socfpga_std/cyclonev/soc.c
+++ b/soc/arm/intel_socfpga_std/cyclonev/soc.c
@@ -70,9 +70,8 @@ const struct arm_mmu_config mmu_config = {
  *
  * @return 0
  */
-static int soc_intel_cyclonev_init(const struct device *arg)
+static int soc_intel_cyclonev_init(void)
 {
-	ARG_UNUSED(arg);
 	NMI_INIT();
 	unsigned int sctlr = __get_SCTLR(); /* modifying some registers prior to initialization */
 

--- a/soc/arm/microchip_mec/mec1501/soc.c
+++ b/soc/arm/microchip_mec/mec1501/soc.c
@@ -71,11 +71,10 @@ static void configure_debug_interface(void)
 #endif /* CONFIG_SOC_MEC1501_DEBUG_WITHOUT_TRACING */
 }
 
-static int soc_init(const struct device *dev)
+static int soc_init(void)
 {
 	uint32_t isave;
 
-	ARG_UNUSED(dev);
 
 	isave = __get_PRIMASK();
 	__disable_irq();

--- a/soc/arm/microchip_mec/mec1701/soc.c
+++ b/soc/arm/microchip_mec/mec1701/soc.c
@@ -10,7 +10,7 @@
 #include <zephyr/kernel.h>
 
 
-static int soc_init(const struct device *dev)
+static int soc_init(void)
 {
 	__IO uint32_t *girc_enable_set;
 

--- a/soc/arm/microchip_mec/mec172x/soc.c
+++ b/soc/arm/microchip_mec/mec172x/soc.c
@@ -38,9 +38,8 @@ static void configure_debug_interface(void)
 #endif /* CONFIG_SOC_MEC172X_DEBUG_DISABLED */
 }
 
-static int soc_init(const struct device *dev)
+static int soc_init(void)
 {
-	ARG_UNUSED(dev);
 
 	configure_debug_interface();
 

--- a/soc/arm/nordic_nrf/nrf51/soc.c
+++ b/soc/arm/nordic_nrf/nrf51/soc.c
@@ -32,11 +32,10 @@ void sys_arch_reboot(int type)
 	NVIC_SystemReset();
 }
 
-static int nordicsemi_nrf51_init(const struct device *arg)
+static int nordicsemi_nrf51_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -49,11 +49,10 @@ void sys_arch_reboot(int type)
 	NVIC_SystemReset();
 }
 
-static int nordicsemi_nrf52_init(const struct device *arg)
+static int nordicsemi_nrf52_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -150,11 +150,9 @@ bool z_arm_on_enter_cpu_idle(void)
 }
 #endif /* CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND */
 
-static int nordicsemi_nrf53_init(const struct device *arg)
+static int nordicsemi_nrf53_init(void)
 {
 	uint32_t key;
-
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/nordic_nrf/nrf53/sync_rtc.c
+++ b/soc/arm/nordic_nrf/nrf53/sync_rtc.c
@@ -226,10 +226,8 @@ static int mbox_rx_init(void *user_data)
 }
 
 /* Setup RTC synchronization. */
-static int sync_rtc_setup(const struct device *unused)
+static int sync_rtc_setup(void)
 {
-	ARG_UNUSED(unused);
-
 	nrfx_err_t err;
 	union rtc_sync_channels channels;
 	int32_t sync_rtc_ch;

--- a/soc/arm/nordic_nrf/nrf91/soc.c
+++ b/soc/arm/nordic_nrf/nrf91/soc.c
@@ -28,11 +28,10 @@
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);
 
-static int nordicsemi_nrf91_init(const struct device *arg)
+static int nordicsemi_nrf91_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/nuvoton_npcx/common/scfg.c
+++ b/soc/arm/nuvoton_npcx/common/scfg.c
@@ -130,7 +130,7 @@ void npcx_host_interface_sel(enum npcx_hif_type hif_type)
 }
 
 /* Pin-control driver registration */
-static int npcx_scfg_init(const struct device *dev)
+static int npcx_scfg_init(void)
 {
 	struct scfg_reg *inst_scfg = HAL_SFCG_INST();
 

--- a/soc/arm/nuvoton_npcx/npcx7/soc.c
+++ b/soc/arm/nuvoton_npcx/npcx7/soc.c
@@ -12,9 +12,8 @@
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
-static int soc_init(const struct device *dev)
+static int soc_init(void)
 {
-	ARG_UNUSED(dev);
 
 	return 0;
 }

--- a/soc/arm/nuvoton_npcx/npcx9/soc.c
+++ b/soc/arm/nuvoton_npcx/npcx9/soc.c
@@ -12,9 +12,8 @@
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
-static int soc_init(const struct device *dev)
+static int soc_init(void)
 {
-	ARG_UNUSED(dev);
 
 	return 0;
 }

--- a/soc/arm/nxp_imx/mcimx6x_m4/soc.c
+++ b/soc/arm/nxp_imx/mcimx6x_m4/soc.c
@@ -277,9 +277,8 @@ static void SOC_ClockInit(void)
  *
  * @return 0
  */
-static int mcimx6x_m4_init(const struct device *arg)
+static int mcimx6x_m4_init(void)
 {
-	ARG_UNUSED(arg);
 
 	unsigned int oldLevel; /* Old interrupt lock level */
 

--- a/soc/arm/nxp_imx/mcimx7_m4/soc.c
+++ b/soc/arm/nxp_imx/mcimx7_m4/soc.c
@@ -222,9 +222,8 @@ static void nxp_mcimx7_mu_config(void)
 }
 #endif /* CONFIG_IPM_IMX */
 
-static int nxp_mcimx7_init(const struct device *arg)
+static int nxp_mcimx7_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* SoC specific RDC settings */
 	SOC_RdcInit();

--- a/soc/arm/nxp_imx/mimx8ml8_m7/soc.c
+++ b/soc/arm/nxp_imx/mimx8ml8_m7/soc.c
@@ -148,9 +148,8 @@ static void SOC_ClockInit(void)
 	CLOCK_EnableClock(kCLOCK_Sec_Debug);
 }
 
-static int nxp_mimx8ml8_init(const struct device *arg)
+static int nxp_mimx8ml8_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* SoC specific RDC settings */
 	SOC_RdcInit();

--- a/soc/arm/nxp_imx/mimx8mm6_m4/soc.c
+++ b/soc/arm/nxp_imx/mimx8mm6_m4/soc.c
@@ -148,9 +148,8 @@ static void SOC_ClockInit(void)
 	CLOCK_EnableClock(kCLOCK_Sec_Debug);
 }
 
-static int nxp_mimx8mm6_init(const struct device *arg)
+static int nxp_mimx8mm6_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* SoC specific RDC settings */
 	SOC_RdcInit();

--- a/soc/arm/nxp_imx/mimx8mq6_m4/soc.c
+++ b/soc/arm/nxp_imx/mimx8mq6_m4/soc.c
@@ -111,9 +111,8 @@ static void SOC_ClockInit(void)
 	CLOCK_EnableClock(kCLOCK_Sec_Debug);
 }
 
-static int nxp_mimx8mq6_init(const struct device *arg)
+static int nxp_mimx8mq6_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* SoC specific RDC settings */
 	SOC_RdcInit();

--- a/soc/arm/nxp_imx/rt/lpm_rt1064.c
+++ b/soc/arm/nxp_imx/rt/lpm_rt1064.c
@@ -335,9 +335,8 @@ void clock_lpm_init(void)
 	XTALOSC24M->OSC_CONFIG1 = tmp_reg;
 }
 
-static int imxrt_lpm_init(const struct device *dev)
+static int imxrt_lpm_init(void)
 {
-	ARG_UNUSED(dev);
 
 	struct clock_callbacks callbacks;
 	uint32_t usb1_pll_pfd0_frac;

--- a/soc/arm/nxp_imx/rt/power_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/power_rt10xx.c
@@ -239,11 +239,10 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 }
 
 /* Initialize power system */
-static int rt10xx_power_init(const struct device *dev)
+static int rt10xx_power_init(void)
 {
 	dcdc_internal_regulator_config_t reg_config;
 
-	ARG_UNUSED(dev);
 
 	/* Ensure clocks to ARM core memory will not be gated in low power mode
 	 * if interrupt is pending

--- a/soc/arm/nxp_imx/rt/power_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/power_rt11xx.c
@@ -320,9 +320,8 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 }
 
 /* Initialize RT11xx Power */
-static int rt11xx_power_init(const struct device *dev)
+static int rt11xx_power_init(void)
 {
-	ARG_UNUSED(dev);
 	/* Drop SOC target voltage to 1.0 V */
 	DCDC_SetVDD1P0BuckModeTargetVoltage(DCDC, kDCDC_1P0BuckTarget1P0V);
 	/* Initialize general power controller */

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -281,9 +281,8 @@ void imxrt_audio_codec_pll_init(uint32_t clock_name, uint32_t clk_src,
  * @return 0
  */
 
-static int imxrt_init(const struct device *arg)
+static int imxrt_init(void)
 {
-	ARG_UNUSED(arg);
 
 	unsigned int oldLevel; /* old interrupt lock level */
 

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -622,9 +622,8 @@ void imxrt_post_init_display_interface(void)
  * @return 0
  */
 
-static int imxrt_init(const struct device *arg)
+static int imxrt_init(void)
 {
-	ARG_UNUSED(arg);
 
 	unsigned int oldLevel; /* old interrupt lock level */
 
@@ -712,7 +711,7 @@ SYS_INIT(imxrt_init, PRE_KERNEL_1, 0);
  *
  * @return 0
  */
-static int second_core_boot(const struct device *arg)
+static int second_core_boot(void)
 {
 	/* Kick CM4 core out of reset */
 	SRC->CTRL_M4CORE = SRC_CTRL_M4CORE_SW_RESET_MASK;

--- a/soc/arm/nxp_imx/rt5xx/power.c
+++ b/soc/arm/nxp_imx/rt5xx/power.c
@@ -92,7 +92,7 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 }
 
 /* Initialize power system */
-static int rt5xx_power_init(const struct device *dev)
+static int rt5xx_power_init(void)
 {
 	int ret = 0;
 

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -442,9 +442,8 @@ void imxrt_post_init_display_interface(void)
  *
  * @return 0
  */
-static int nxp_rt500_init(const struct device *arg)
+static int nxp_rt500_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* old interrupt lock level */
 	unsigned int oldLevel;

--- a/soc/arm/nxp_imx/rt6xx/soc.c
+++ b/soc/arm/nxp_imx/rt6xx/soc.c
@@ -342,9 +342,8 @@ void imxrt_usdhc_dat3_pull(bool pullup)
  * @return 0
  */
 
-static int nxp_rt600_init(const struct device *arg)
+static int nxp_rt600_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* old interrupt lock level */
 	unsigned int oldLevel;

--- a/soc/arm/nxp_kinetis/k2x/soc.c
+++ b/soc/arm/nxp_kinetis/k2x/soc.c
@@ -116,9 +116,8 @@ static ALWAYS_INLINE void clock_init(void)
  * @return 0
  */
 
-static int fsl_frdm_k22f_init(const struct device *arg)
+static int fsl_frdm_k22f_init(void)
 {
-	ARG_UNUSED(arg);
 
 	unsigned int oldLevel; /* old interrupt lock level */
 

--- a/soc/arm/nxp_kinetis/k6x/soc.c
+++ b/soc/arm/nxp_kinetis/k6x/soc.c
@@ -127,9 +127,8 @@ static ALWAYS_INLINE void clock_init(void)
  * @return 0
  */
 
-static int k6x_init(const struct device *arg)
+static int k6x_init(void)
 {
-	ARG_UNUSED(arg);
 
 	unsigned int oldLevel; /* old interrupt lock level */
 #if !defined(CONFIG_ARM_MPU)

--- a/soc/arm/nxp_kinetis/k8x/soc.c
+++ b/soc/arm/nxp_kinetis/k8x/soc.c
@@ -92,9 +92,8 @@ static ALWAYS_INLINE void clk_init(void)
 #endif
 }
 
-static int k8x_init(const struct device *arg)
+static int k8x_init(void)
 {
-	ARG_UNUSED(arg);
 
 	unsigned int old_level; /* old interrupt lock level */
 #if !defined(CONFIG_ARM_MPU)

--- a/soc/arm/nxp_kinetis/ke1xf/soc.c
+++ b/soc/arm/nxp_kinetis/ke1xf/soc.c
@@ -237,10 +237,9 @@ static ALWAYS_INLINE void clk_init(void)
 #endif
 }
 
-static int ke1xf_init(const struct device *arg)
+static int ke1xf_init(void)
 
 {
-	ARG_UNUSED(arg);
 
 	unsigned int old_level; /* old interrupt lock level */
 #if !defined(CONFIG_ARM_MPU)

--- a/soc/arm/nxp_kinetis/kl2x/soc.c
+++ b/soc/arm/nxp_kinetis/kl2x/soc.c
@@ -79,9 +79,8 @@ static ALWAYS_INLINE void clock_init(void)
 #endif
 }
 
-static int kl2x_init(const struct device *arg)
+static int kl2x_init(void)
 {
-	ARG_UNUSED(arg);
 
 	unsigned int oldLevel; /* old interrupt lock level */
 

--- a/soc/arm/nxp_kinetis/kv5x/soc.c
+++ b/soc/arm/nxp_kinetis/kv5x/soc.c
@@ -77,9 +77,8 @@ static ALWAYS_INLINE void clk_init(void)
 	CLOCK_SetSimConfig(&sim_config);
 }
 
-static int kv5x_init(const struct device *arg)
+static int kv5x_init(void)
 {
-	ARG_UNUSED(arg);
 
 	unsigned int old_level; /* old interrupt lock level */
 

--- a/soc/arm/nxp_kinetis/kwx/soc_kw2xd.c
+++ b/soc/arm/nxp_kinetis/kwx/soc_kw2xd.c
@@ -147,9 +147,8 @@ static ALWAYS_INLINE void clock_init(void)
  *
  * @return 0
  */
-static int kw2xd_init(const struct device *arg)
+static int kw2xd_init(void)
 {
-	ARG_UNUSED(arg);
 
 	unsigned int oldLevel; /* old interrupt lock level */
 

--- a/soc/arm/nxp_kinetis/kwx/soc_kw4xz.c
+++ b/soc/arm/nxp_kinetis/kwx/soc_kw4xz.c
@@ -80,9 +80,8 @@ static ALWAYS_INLINE void clock_init(void)
 #endif
 }
 
-static int kwx_init(const struct device *arg)
+static int kwx_init(void)
 {
-	ARG_UNUSED(arg);
 
 	unsigned int oldLevel; /* old interrupt lock level */
 

--- a/soc/arm/nxp_lpc/lpc11u6x/soc.c
+++ b/soc/arm/nxp_lpc/lpc11u6x/soc.c
@@ -30,9 +30,8 @@
  * @return 0
  */
 
-static int nxp_lpc11u6x_init(const struct device *arg)
+static int nxp_lpc11u6x_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* old interrupt lock level */
 	unsigned int old_level;

--- a/soc/arm/nxp_lpc/lpc51u68/soc.c
+++ b/soc/arm/nxp_lpc/lpc51u68/soc.c
@@ -11,7 +11,7 @@
 #include <fsl_power.h>
 #include <fsl_clock.h>
 
-int soc_init(const struct device *arg)
+int soc_init(void)
 {
 	POWER_DisablePD(kPDRUNCFG_PD_FRO_EN);
 	CLOCK_SetupFROClocking(12000000U);

--- a/soc/arm/nxp_lpc/lpc54xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc54xxx/soc.c
@@ -107,9 +107,8 @@ static ALWAYS_INLINE void clock_init(void)
  * @return 0
  */
 
-static int nxp_lpc54114_init(const struct device *arg)
+static int nxp_lpc54114_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* old interrupt lock level */
 	unsigned int oldLevel;
@@ -166,11 +165,10 @@ void z_arm_platform_init(void)
  *
  */
 /* This function is also called at deep sleep resume. */
-int _slave_init(const struct device *arg)
+int _slave_init(void)
 {
 	int32_t temp;
 
-	ARG_UNUSED(arg);
 
 	/* Enable SRAM2, used by other core */
 	SYSCON->AHBCLKCTRLSET[0] = SYSCON_AHBCLKCTRL_SRAM2_MASK;

--- a/soc/arm/nxp_lpc/lpc55xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.c
@@ -232,9 +232,8 @@ DT_FOREACH_STATUS_OKAY(nxp_lpc_ctimer, CTIMER_CLOCK_SETUP)
  * @return 0
  */
 
-static int nxp_lpc55xxx_init(const struct device *arg)
+static int nxp_lpc55xxx_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* old interrupt lock level */
 	unsigned int oldLevel;
@@ -295,11 +294,10 @@ SYS_INIT(nxp_lpc55xxx_init, PRE_KERNEL_1, 0);
  *
  */
 /* This function is also called at deep sleep resume. */
-int _second_core_init(const struct device *arg)
+int _second_core_init(void)
 {
 	int32_t temp;
 
-	ARG_UNUSED(arg);
 
 	/* Setup the reset handler pointer (PC) and stack pointer value.
 	 * This is used once the second core runs its startup code.

--- a/soc/arm/nxp_s32/s32ze/soc.c
+++ b/soc/arm/nxp_s32/s32ze/soc.c
@@ -42,9 +42,8 @@ void z_arm_platform_init(void)
 	}
 }
 
-static int soc_init(const struct device *arg)
+static int soc_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* Install default handler that simply resets the CPU if configured in the
 	 * kernel, NOP otherwise

--- a/soc/arm/quicklogic_eos_s3/soc.c
+++ b/soc/arm/quicklogic_eos_s3/soc.c
@@ -64,11 +64,10 @@ static void eos_s3_cru_init(void)
 
 
 
-static int eos_s3_init(const struct device *arg)
+static int eos_s3_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	/* Clocks setup */
 	eos_s3_lock_enable();

--- a/soc/arm/renesas_rcar/gen3/soc.c
+++ b/soc/arm/renesas_rcar/gen3/soc.c
@@ -16,9 +16,8 @@
  * @return 0
  */
 
-static int soc_init(const struct device *arg)
+static int soc_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise

--- a/soc/arm/renesas_smartbond/da1469x/soc.c
+++ b/soc/arm/renesas_smartbond/da1469x/soc.c
@@ -15,9 +15,8 @@ void sys_arch_reboot(int type)
 	NVIC_SystemReset();
 }
 
-static int renesas_da14699_init(const struct device *dev)
+static int renesas_da14699_init(void)
 {
-	ARG_UNUSED(dev);
 
 	NMI_INIT();
 

--- a/soc/arm/rpi_pico/rp2/soc.c
+++ b/soc/arm/rpi_pico/rp2/soc.c
@@ -27,7 +27,7 @@
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
-static int rp2040_init(const struct device *arg)
+static int rp2040_init(void)
 {
 	uint32_t key;
 
@@ -44,7 +44,6 @@ static int rp2040_init(const struct device *arg)
 
 	unreset_block_wait(RESETS_RESET_BITS);
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/silabs_exx32/common/soc.c
+++ b/soc/arm/silabs_exx32/common/soc.c
@@ -193,9 +193,8 @@ static void swo_init(void)
  *
  * @return 0
  */
-static int silabs_exx32_init(const struct device *arg)
+static int silabs_exx32_init(void)
 {
-	ARG_UNUSED(arg);
 
 	unsigned int oldLevel; /* old interrupt lock level */
 

--- a/soc/arm/st_stm32/common/soc_config.c
+++ b/soc/arm/st_stm32/common/soc_config.c
@@ -23,7 +23,7 @@
  *
  * @return 0
  */
-static int st_stm32_common_config(const struct device *dev)
+static int st_stm32_common_config(void)
 {
 #ifdef CONFIG_LOG_BACKEND_SWO
 	/* Enable SWO trace asynchronous mode */

--- a/soc/arm/st_stm32/stm32c0/soc.c
+++ b/soc/arm/st_stm32/stm32c0/soc.c
@@ -26,11 +26,10 @@
  *
  * @return 0
  */
-static int stm32c0_init(const struct device *arg)
+static int stm32c0_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32f0/soc.c
+++ b/soc/arm/st_stm32/stm32f0/soc.c
@@ -67,11 +67,10 @@ void relocate_vector_table(void)
  *
  * @return 0
  */
-static int stm32f0_init(const struct device *arg)
+static int stm32f0_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32f1/soc.c
+++ b/soc/arm/st_stm32/stm32f1/soc.c
@@ -24,11 +24,10 @@
  *
  * @return 0
  */
-static int stm32f1_init(const struct device *arg)
+static int stm32f1_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32f2/soc.c
+++ b/soc/arm/st_stm32/stm32f2/soc.c
@@ -29,11 +29,10 @@
  *
  * @return 0
  */
-static int stm32f2_init(const struct device *arg)
+static int stm32f2_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	/* Enable ART Flash cache accelerator for both Instruction and Data */
 	LL_FLASH_EnableInstCache();

--- a/soc/arm/st_stm32/stm32f3/soc.c
+++ b/soc/arm/st_stm32/stm32f3/soc.c
@@ -25,11 +25,10 @@
  *
  * @return 0
  */
-static int stm32f3_init(const struct device *arg)
+static int stm32f3_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32f4/soc.c
+++ b/soc/arm/st_stm32/stm32f4/soc.c
@@ -27,11 +27,10 @@
  *
  * @return 0
  */
-static int st_stm32f4_init(const struct device *arg)
+static int st_stm32f4_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	/* Enable ART Flash cache accelerator for both instruction and data */
 	LL_FLASH_EnableInstCache();

--- a/soc/arm/st_stm32/stm32f7/soc.c
+++ b/soc/arm/st_stm32/stm32f7/soc.c
@@ -27,11 +27,10 @@
  *
  * @return 0
  */
-static int st_stm32f7_init(const struct device *arg)
+static int st_stm32f7_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	/* Enable ART Flash cache accelerator */
 	LL_FLASH_EnableART();

--- a/soc/arm/st_stm32/stm32g0/power.c
+++ b/soc/arm/st_stm32/stm32g0/power.c
@@ -81,9 +81,8 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 }
 
 /* Initialize STM32 Power */
-static int stm32_power_init(const struct device *dev)
+static int stm32_power_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* enable Power clock */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);

--- a/soc/arm/st_stm32/stm32g0/soc.c
+++ b/soc/arm/st_stm32/stm32g0/soc.c
@@ -81,11 +81,10 @@ static void stm32g0_disable_dead_battery(void)
  *
  * @return 0
  */
-static int stm32g0_init(const struct device *arg)
+static int stm32g0_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32g4/power.c
+++ b/soc/arm/st_stm32/stm32g4/power.c
@@ -79,9 +79,8 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 }
 
 /* Initialize STM32 Power */
-static int stm32_power_init(const struct device *dev)
+static int stm32_power_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* enable Power clock */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);

--- a/soc/arm/st_stm32/stm32g4/soc.c
+++ b/soc/arm/st_stm32/stm32g4/soc.c
@@ -30,11 +30,10 @@
  *
  * @return 0
  */
-static int stm32g4_init(const struct device *arg)
+static int stm32g4_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32h5/soc.c
+++ b/soc/arm/st_stm32/stm32h5/soc.c
@@ -31,11 +31,10 @@ LOG_MODULE_REGISTER(soc);
  *
  * @return 0
  */
-static int stm32h5_init(const struct device *arg)
+static int stm32h5_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32h7/soc_m4.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m4.c
@@ -32,7 +32,7 @@
  *
  * @return 0
  */
-static int stm32h7_m4_init(const struct device *arg)
+static int stm32h7_m4_init(void)
 {
 	uint32_t key;
 

--- a/soc/arm/st_stm32/stm32h7/soc_m7.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m7.c
@@ -24,7 +24,7 @@
 #include "stm32_hsem.h"
 
 #if defined(CONFIG_STM32H7_DUAL_CORE)
-static int stm32h7_m4_wakeup(const struct device *arg)
+static int stm32h7_m4_wakeup(void)
 {
 
 	/* HW semaphore and SysCfg Clock enable */
@@ -54,11 +54,10 @@ static int stm32h7_m4_wakeup(const struct device *arg)
  *
  * @return 0
  */
-static int stm32h7_init(const struct device *arg)
+static int stm32h7_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32l0/power.c
+++ b/soc/arm/st_stm32/stm32l0/power.c
@@ -83,9 +83,8 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 }
 
 /* Initialize STM32 Power */
-static int stm32_power_init(const struct device *dev)
+static int stm32_power_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* Enable Power clock */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);

--- a/soc/arm/st_stm32/stm32l0/soc.c
+++ b/soc/arm/st_stm32/stm32l0/soc.c
@@ -29,11 +29,10 @@
  *
  * @return 0
  */
-static int stm32l0_init(const struct device *arg)
+static int stm32l0_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32l1/soc.c
+++ b/soc/arm/st_stm32/stm32l1/soc.c
@@ -28,11 +28,10 @@
  *
  * @return 0
  */
-static int stm32l1_init(const struct device *arg)
+static int stm32l1_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -146,9 +146,8 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 }
 
 /* Initialize STM32 Power */
-static int stm32_power_init(const struct device *dev)
+static int stm32_power_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* enable Power clock */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);

--- a/soc/arm/st_stm32/stm32l4/soc.c
+++ b/soc/arm/st_stm32/stm32l4/soc.c
@@ -30,11 +30,10 @@ LOG_MODULE_REGISTER(soc);
  *
  * @return 0
  */
-static int stm32l4_init(const struct device *arg)
+static int stm32l4_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32l5/power.c
+++ b/soc/arm/st_stm32/stm32l5/power.c
@@ -98,9 +98,8 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 }
 
 /* Initialize STM32 Power */
-static int stm32_power_init(const struct device *dev)
+static int stm32_power_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* enable Power clock */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);

--- a/soc/arm/st_stm32/stm32l5/soc.c
+++ b/soc/arm/st_stm32/stm32l5/soc.c
@@ -31,11 +31,10 @@ LOG_MODULE_REGISTER(soc);
  *
  * @return 0
  */
-static int stm32l5_init(const struct device *arg)
+static int stm32l5_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	/* Enable ICACHE */
 	while (LL_ICACHE_IsActiveFlag_BUSY()) {

--- a/soc/arm/st_stm32/stm32mp1/soc.c
+++ b/soc/arm/st_stm32/stm32mp1/soc.c
@@ -27,11 +27,10 @@
  *
  * @return 0
  */
-static int stm32m4_init(const struct device *arg)
+static int stm32m4_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32u5/power.c
+++ b/soc/arm/st_stm32/stm32u5/power.c
@@ -127,9 +127,8 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 }
 
 /* Initialize STM32 Power */
-static int stm32_power_init(const struct device *dev)
+static int stm32_power_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* enable Power clock */
 	LL_AHB3_GRP1_EnableClock(LL_AHB3_GRP1_PERIPH_PWR);

--- a/soc/arm/st_stm32/stm32u5/soc.c
+++ b/soc/arm/st_stm32/stm32u5/soc.c
@@ -31,11 +31,10 @@ LOG_MODULE_REGISTER(soc);
  *
  * @return 0
  */
-static int stm32u5_init(const struct device *arg)
+static int stm32u5_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32wb/power.c
+++ b/soc/arm/st_stm32/stm32wb/power.c
@@ -148,9 +148,8 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 }
 
 /* Initialize STM32 Power */
-static int stm32_power_init(const struct device *dev)
+static int stm32_power_init(void)
 {
-	ARG_UNUSED(dev);
 
 #ifdef CONFIG_DEBUG
 	/* Enable the Debug Module during STOP mode */

--- a/soc/arm/st_stm32/stm32wb/soc.c
+++ b/soc/arm/st_stm32/stm32wb/soc.c
@@ -28,11 +28,10 @@ LOG_MODULE_REGISTER(soc);
  *
  * @return 0
  */
-static int stm32wb_init(const struct device *arg)
+static int stm32wb_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/arm/st_stm32/stm32wl/power.c
+++ b/soc/arm/st_stm32/stm32wl/power.c
@@ -102,9 +102,8 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 }
 
 /* Initialize STM32 Power */
-static int stm32_power_init(const struct device *dev)
+static int stm32_power_init(void)
 {
-	ARG_UNUSED(dev);
 
 #ifdef CONFIG_DEBUG
 	/* Enable the Debug Module during STOP mode */

--- a/soc/arm/st_stm32/stm32wl/soc.c
+++ b/soc/arm/st_stm32/stm32wl/soc.c
@@ -26,11 +26,10 @@
  *
  * @return 0
  */
-static int stm32wl_init(const struct device *arg)
+static int stm32wl_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(arg);
 
 	/* Enable CPU data and instruction cache */
 	LL_FLASH_EnableInstCache();

--- a/soc/arm/ti_lm3s6965/soc.c
+++ b/soc/arm/ti_lm3s6965/soc.c
@@ -30,9 +30,8 @@
  * @return 0
  */
 
-static int ti_lm3s6965_init(const struct device *arg)
+static int ti_lm3s6965_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise

--- a/soc/arm/ti_lm3s6965/soc_config.c
+++ b/soc/arm/ti_lm3s6965/soc_config.c
@@ -24,7 +24,7 @@
 #define RCGC1_UART1_EN 0x00000002
 #define RCGC1_UART2_EN 0x00000004
 
-static int uart_stellaris_init(const struct device *dev)
+static int uart_stellaris_init(void)
 {
 #ifdef CONFIG_UART_STELLARIS_PORT_0
 	RCGC1 |= RCGC1_UART0_EN;
@@ -52,7 +52,7 @@ SYS_INIT(uart_stellaris_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 #define RCGC2_PHY_EN   0x40000000
 #define RCGC2_EMAC_EN  0x10000000
 
-static int eth_stellaris_init(const struct device *dev)
+static int eth_stellaris_init(void)
 {
 	RCGC2 |= (RCGC2_PHY_EN | RCGC2_EMAC_EN);
 	return 0;

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
@@ -136,11 +136,10 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 #endif /* CONFIG_PM */
 
 /* Initialize TI Power module */
-static int power_initialize(const struct device *dev)
+static int power_initialize(void)
 {
 	unsigned int ret;
 
-	ARG_UNUSED(dev);
 
 	ret = irq_lock();
 	Power_init();
@@ -154,7 +153,7 @@ static int power_initialize(const struct device *dev)
  * This needs to be called during POST_KERNEL in order for "Booting Zephyr"
  * message to show up
  */
-static int unlatch_pins(const struct device *dev)
+static int unlatch_pins(void)
 {
 	/* Get the reason for reset. */
 	uint32_t rSrc = SysCtrlResetSourceGet();

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/soc.c
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/soc.c
@@ -8,9 +8,8 @@
 
 #include <driverlib/setup.h>
 
-static int ti_cc13x2_cc26x2_init(const struct device *dev)
+static int ti_cc13x2_cc26x2_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* Performs necessary trim of the device. */
 	SetupTrimDevice();

--- a/soc/arm/ti_simplelink/cc13x2x7_cc26x2x7/power.c
+++ b/soc/arm/ti_simplelink/cc13x2x7_cc26x2x7/power.c
@@ -136,11 +136,10 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 #endif /* CONFIG_PM */
 
 /* Initialize TI Power module */
-static int power_initialize(const struct device *dev)
+static int power_initialize(void)
 {
 	unsigned int ret;
 
-	ARG_UNUSED(dev);
 
 	ret = irq_lock();
 	Power_init();
@@ -154,7 +153,7 @@ static int power_initialize(const struct device *dev)
  * This needs to be called during POST_KERNEL in order for "Booting Zephyr"
  * message to show up
  */
-static int unlatch_pins(const struct device *dev)
+static int unlatch_pins(void)
 {
 	/* Get the reason for reset. */
 	uint32_t rSrc = SysCtrlResetSourceGet();

--- a/soc/arm/ti_simplelink/cc13x2x7_cc26x2x7/soc.c
+++ b/soc/arm/ti_simplelink/cc13x2x7_cc26x2x7/soc.c
@@ -8,9 +8,8 @@
 
 #include <driverlib/setup.h>
 
-static int ti_cc13x2_cc26x2_init(const struct device *dev)
+static int ti_cc13x2_cc26x2_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/* Performs necessary trim of the device. */
 	SetupTrimDevice();

--- a/soc/arm/ti_simplelink/cc32xx/soc.c
+++ b/soc/arm/ti_simplelink/cc32xx/soc.c
@@ -18,9 +18,8 @@ void sys_arch_reboot(int type)
 	MAP_PRCMMCUReset(!!type);
 }
 
-static int ti_cc32xx_init(const struct device *arg)
+static int ti_cc32xx_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* Note: This function also performs CC3220 Initialization */
 	MAP_PRCMCC3200MCUInit();

--- a/soc/arm/ti_simplelink/msp432p4xx/soc.c
+++ b/soc/arm/ti_simplelink/msp432p4xx/soc.c
@@ -9,9 +9,8 @@
 #include <zephyr/init.h>
 #include <soc.h>
 
-static int ti_msp432p4xx_init(const struct device *arg)
+static int ti_msp432p4xx_init(void)
 {
-	ARG_UNUSED(arg);
 
 	SystemInit();
 

--- a/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
@@ -78,9 +78,8 @@ const struct arm_mmu_config mmu_config = {
  *
  * @return 0
  */
-static int soc_xlnx_zynq7000_init(const struct device *arg)
+static int soc_xlnx_zynq7000_init(void)
 {
-	ARG_UNUSED(arg);
 	NMI_INIT();
 
 	return 0;

--- a/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
@@ -78,9 +78,8 @@ const struct arm_mmu_config mmu_config = {
  *
  * @return 0
  */
-static int soc_xlnx_zynq7000s_init(const struct device *arg)
+static int soc_xlnx_zynq7000s_init(void)
 {
-	ARG_UNUSED(arg);
 	NMI_INIT();
 
 	return 0;

--- a/soc/arm/xilinx_zynqmp/soc.c
+++ b/soc/arm/xilinx_zynqmp/soc.c
@@ -17,9 +17,8 @@
  * @return 0
  */
 
-static int soc_init(const struct device *arg)
+static int soc_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* Install default handler that simply resets the CPU
 	 * if configured in the kernel, NOP otherwise

--- a/soc/arm64/bcm_vk/viper/soc.c
+++ b/soc/arm64/bcm_vk/viper/soc.c
@@ -17,12 +17,11 @@
  *
  * @return 0
  */
-static int viper_init(const struct device *arg)
+static int viper_init(void)
 {
 	uint32_t key;
 	uint32_t data;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/riscv/openisa_rv32m1/soc.c
+++ b/soc/riscv/openisa_rv32m1/soc.c
@@ -216,11 +216,10 @@ static void rv32m1_setup_peripheral_clocks(void)
  *
  * @return 0
  */
-static int soc_rv32m1_init(const struct device *arg)
+static int soc_rv32m1_init(void)
 {
 	unsigned int key;
 
-	ARG_UNUSED(arg);
 
 	key = irq_lock();
 

--- a/soc/riscv/riscv-ite/it8xxx2/soc.c
+++ b/soc/riscv/riscv-ite/it8xxx2/soc.c
@@ -156,9 +156,8 @@ static void chip_configure_pll(const struct pll_config_t *pll)
 	}
 }
 
-static int chip_change_pll(const struct device *dev)
+static int chip_change_pll(void)
 {
-	ARG_UNUSED(dev);
 
 	if (IS_ENABLED(CONFIG_ITE_IT8XXX2_INTC)) {
 		ite_intc_save_and_disable_interrupts();
@@ -273,9 +272,8 @@ void soc_interrupt_init(void)
 	ite_intc_init();
 }
 
-static int ite_it8xxx2_init(const struct device *arg)
+static int ite_it8xxx2_init(void)
 {
-	ARG_UNUSED(arg);
 	struct gpio_it8xxx2_regs *const gpio_regs = GPIO_IT8XXX2_REG_BASE;
 	struct gctrl_it8xxx2_regs *const gctrl_regs = GCTRL_IT8XXX2_REGS_BASE;
 

--- a/soc/riscv/riscv-privilege/andes_v5/l2_cache.c
+++ b/soc/riscv/riscv-privilege/andes_v5/l2_cache.c
@@ -88,13 +88,12 @@ static void andes_v5_l2c_enable(void)
 	}
 }
 
-static int andes_v5_l2c_init(const struct device *dev)
+static int andes_v5_l2c_init(void)
 {
 #if DT_NODE_HAS_STATUS(DT_INST(0, syscon), okay)
 	uint32_t system_cfg;
 	const struct device *const syscon_dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 
-	ARG_UNUSED(dev);
 
 	if (device_is_ready(syscon_dev)) {
 		syscon_read_reg(syscon_dev, SMU_SYSTEMCFG, &system_cfg);

--- a/soc/riscv/riscv-privilege/andes_v5/pma.c
+++ b/soc/riscv/riscv-privilege/andes_v5/pma.c
@@ -238,7 +238,7 @@ void pma_init_per_core(void)
 #endif /* CONFIG_NOCACHE_MEMORY */
 }
 
-static int pma_init(const struct device *arg)
+static int pma_init(void)
 {
 	unsigned long mmsc_cfg;
 

--- a/soc/riscv/riscv-privilege/gd32vf103/soc.c
+++ b/soc/riscv/riscv-privilege/gd32vf103/soc.c
@@ -9,11 +9,10 @@
 
 #include <gd32vf103.h>
 
-static int gigadevice_gd32v_soc_init(const struct device *dev)
+static int gigadevice_gd32v_soc_init(void)
 {
 	uint32_t key;
 
-	ARG_UNUSED(dev);
 
 	key = irq_lock();
 

--- a/soc/riscv/riscv-privilege/opentitan/soc.c
+++ b/soc/riscv/riscv-privilege/opentitan/soc.c
@@ -10,9 +10,8 @@
 
 #define RV_TIMER_BASE (DT_REG_ADDR(DT_NODELABEL(mtimer)))
 
-static int soc_opentitan_init(const struct device *arg)
+static int soc_opentitan_init(void)
 {
-	ARG_UNUSED(arg);
 
 	/* Initialize the Machine Timer, so it behaves as a regular one. */
 	sys_write32(1u, RV_TIMER_BASE + RV_TIMER_CTRL_REG_OFFSET);

--- a/soc/riscv/riscv-privilege/sifive-freedom/fe310_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fe310_clock.c
@@ -13,9 +13,8 @@
 BUILD_ASSERT(DT_PROP(DT_NODELABEL(tlclk), clock_div) == 1,
 	"Unsupported TLCLK divider");
 
-static int fe310_clock_init(const struct device *dev)
+static int fe310_clock_init(void)
 {
-	ARG_UNUSED(dev);
 
 	/*
 	 * HFXOSC (16 MHz) is used to produce coreclk (and therefore tlclk /

--- a/soc/riscv/riscv-privilege/sifive-freedom/fu540_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fu540_clock.c
@@ -18,9 +18,8 @@ BUILD_ASSERT(DT_PROP(DT_NODELABEL(tlclk), clock_div) == 2,
  * Switch the clock source to 1GHz PLL from 33.333MHz oscillator on the HiFive
  * Unleashed board.
  */
-static int fu540_clock_init(const struct device *dev)
+static int fu540_clock_init(void)
 {
-	ARG_UNUSED(dev);
 
 	PRCI_REG(PRCI_COREPLLCFG0) =
 		PLL_R(0) |   /* input divider: Fin / (0 + 1) = 33.33MHz */

--- a/soc/riscv/riscv-privilege/sifive-freedom/fu740_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fu740_clock.c
@@ -30,9 +30,8 @@ static inline void wait_controller_cycle(void)
  *
  * Note: Valid PLL VCO range is 2400MHz to 4800MHz
  */
-static int fu740_clock_init(const struct device *dev)
+static int fu740_clock_init(void)
 {
-	ARG_UNUSED(dev);
 
 	PRCI_REG(PRCI_COREPLLCFG) =
 		PLL_R(0) |   /* input divider: Fin / (0 + 1) = 26MHz */

--- a/soc/riscv/riscv-privilege/telink_b91/soc.c
+++ b/soc/riscv/riscv-privilege/telink_b91/soc.c
@@ -70,11 +70,10 @@
  *
  * @return 0
  */
-static int soc_b91_init(const struct device *arg)
+static int soc_b91_init(void)
 {
 	unsigned int cclk = DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency);
 
-	ARG_UNUSED(arg);
 
 	/* system init */
 	sys_init(POWER_MODE, VBAT_TYPE);

--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -47,7 +47,7 @@ static void ipc_isr(void *arg)
 
 unsigned int soc_num_cpus;
 
-static __imr int soc_num_cpus_init(const struct device *dev)
+static __imr int soc_num_cpus_init(void)
 {
 	/* Need to set soc_num_cpus early to arch_num_cpus() works properly */
 	soc_num_cpus = ((sys_read32(DFIDCCP) >> CAP_INST_SHIFT) & CAP_INST_MASK) + 1;

--- a/soc/xtensa/intel_adsp/common/boot_complete.c
+++ b/soc/xtensa/intel_adsp/common/boot_complete.c
@@ -10,9 +10,8 @@
 
 #include <mem_window.h>
 
-int boot_complete(const struct device *d)
+int boot_complete(void)
 {
-	ARG_UNUSED(d);
 	uint32_t *win;
 	const struct mem_win_config *config;
 	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(mem_window0));

--- a/soc/xtensa/intel_adsp/common/soc.c
+++ b/soc/xtensa/intel_adsp/common/soc.c
@@ -12,7 +12,7 @@ extern void adsp_clock_init(void);
 extern void soc_mp_init(void);
 #endif
 
-static __imr int soc_init(const struct device *dev)
+static __imr int soc_init(void)
 {
 	power_init();
 

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -1756,7 +1756,7 @@ int bt_bap_broadcast_sink_delete(struct bt_bap_broadcast_sink *sink)
 	return 0;
 }
 
-static int broadcast_sink_init(const struct device *dev)
+static int broadcast_sink_init(void)
 {
 	static struct bt_le_per_adv_sync_cb cb = {
 		.synced = pa_synced,

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -826,9 +826,8 @@ static const struct bt_hci_driver drv = {
 	.send	= hci_driver_send,
 };
 
-static int hci_driver_init(const struct device *unused)
+static int hci_driver_init(void)
 {
-	ARG_UNUSED(unused);
 
 	bt_hci_driver_register(&drv);
 

--- a/subsys/bluetooth/host/long_wq.c
+++ b/subsys/bluetooth/host/long_wq.c
@@ -26,9 +26,8 @@ int bt_long_wq_submit(struct k_work *work)
 	return k_work_submit_to_queue(&bt_long_wq, work);
 }
 
-static int long_wq_init(const struct device *d)
+static int long_wq_init(void)
 {
-	ARG_UNUSED(d);
 
 	const struct k_work_queue_config cfg = {.name = "BT_LW_WQ"};
 

--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -366,9 +366,8 @@ static const struct log_backend_api monitor_log_api = {
 LOG_BACKEND_DEFINE(bt_monitor, monitor_log_api, true);
 #endif /* CONFIG_LOG_MODE_MINIMAL */
 
-static int bt_monitor_init(const struct device *d)
+static int bt_monitor_init(void)
 {
-	ARG_UNUSED(d);
 
 #if defined(CONFIG_BT_DEBUG_MONITOR_RTT)
 	static uint8_t rtt_up_buf[RTT_BUF_SIZE];

--- a/subsys/bluetooth/services/bas.c
+++ b/subsys/bluetooth/services/bas.c
@@ -57,9 +57,8 @@ BT_GATT_SERVICE_DEFINE(bas,
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
 );
 
-static int bas_init(const struct device *dev)
+static int bas_init(void)
 {
-	ARG_UNUSED(dev);
 
 	return 0;
 }

--- a/subsys/bluetooth/services/hrs.c
+++ b/subsys/bluetooth/services/hrs.c
@@ -83,9 +83,8 @@ BT_GATT_SERVICE_DEFINE(hrs_svc,
 			       NULL, NULL, NULL),
 );
 
-static int hrs_init(const struct device *dev)
+static int hrs_init(void)
 {
-	ARG_UNUSED(dev);
 
 	hrs_blsc = 0x01;
 

--- a/subsys/bluetooth/services/ots/ots.c
+++ b/subsys/bluetooth/services/ots/ots.c
@@ -641,7 +641,7 @@ struct bt_ots *bt_ots_free_instance_get(void)
 	return &BT_GATT_OTS_INSTANCE_LIST_START[instance_cnt++];
 }
 
-static int bt_gatt_ots_instances_prepare(const struct device *dev)
+static int bt_gatt_ots_instances_prepare(void)
 {
 	uint32_t index;
 	struct bt_ots *instance;

--- a/subsys/bluetooth/services/ots/ots_l2cap.c
+++ b/subsys/bluetooth/services/ots/ots_l2cap.c
@@ -208,7 +208,7 @@ static struct bt_l2cap_server l2cap_server = {
 	.accept	= l2cap_accept,
 };
 
-static int bt_gatt_ots_l2cap_init(const struct device *arg)
+static int bt_gatt_ots_l2cap_init(void)
 {
 	int err;
 

--- a/subsys/debug/gdbstub.c
+++ b/subsys/debug/gdbstub.c
@@ -821,9 +821,8 @@ int z_gdb_main_loop(struct gdb_ctx *ctx)
 	return 0;
 }
 
-int gdb_init(const struct device *arg)
+int gdb_init(void)
 {
-	ARG_UNUSED(arg);
 
 	if (z_gdb_backend_init() == -1) {
 		LOG_ERR("Could not initialize gdbstub backend.");

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -521,9 +521,8 @@ static const struct fs_file_system_t fatfs_fs = {
 #endif
 };
 
-static int fatfs_init(const struct device *dev)
+static int fatfs_init(void)
 {
-	ARG_UNUSED(dev);
 
 	return fs_register(FS_FATFS, &fatfs_fs);
 }

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -876,7 +876,7 @@ int fs_unregister(int type, const struct fs_file_system_t *fs)
 	return rc;
 }
 
-static int fs_init(const struct device *dev)
+static int fs_init(void)
 {
 	k_mutex_init(&mutex);
 	sys_dlist_init(&fs_mnt_list);

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -1034,9 +1034,8 @@ static void mount_init(struct fs_mount_t *mp)
 	}
 }
 
-static int littlefs_init(const struct device *dev)
+static int littlefs_init(void)
 {
-	ARG_UNUSED(dev);
 	static struct fs_mount_t *partitions[] = {
 		DT_INST_FOREACH_STATUS_OKAY(REFERENCE_MOUNT)
 	};

--- a/subsys/ipc/ipc_service/backends/ipc_icmsg_me_follower.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icmsg_me_follower.c
@@ -365,7 +365,7 @@ DT_INST_FOREACH_STATUS_OKAY(DEFINE_BACKEND_DEVICE)
 
 #if defined(CONFIG_IPC_SERVICE_BACKEND_ICMSG_ME_SHMEM_RESET)
 #define BACKEND_CONFIG_DEFINE(i) BACKEND_CONFIG_POPULATE(i),
-static int shared_memory_prepare(const struct device *arg)
+static int shared_memory_prepare(void)
 {
 	const struct icmsg_config_t *backend_config;
 	const struct icmsg_config_t backend_configs[] = {

--- a/subsys/ipc/ipc_service/backends/ipc_icmsg_me_initiator.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icmsg_me_initiator.c
@@ -267,7 +267,7 @@ DT_INST_FOREACH_STATUS_OKAY(DEFINE_BACKEND_DEVICE)
 
 #if defined(CONFIG_IPC_SERVICE_BACKEND_ICMSG_ME_SHMEM_RESET)
 #define BACKEND_CONFIG_DEFINE(i) BACKEND_CONFIG_POPULATE(i),
-static int shared_memory_prepare(const struct device *arg)
+static int shared_memory_prepare(void)
 {
 	const struct icmsg_config_t *backend_config;
 	const struct icmsg_config_t backend_configs[] = {

--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -776,7 +776,7 @@ DT_INST_FOREACH_STATUS_OKAY(DEFINE_BACKEND_DEVICE)
 #define BACKEND_CONFIG_INIT(n) &backend_config_##n,
 
 #if defined(CONFIG_IPC_SERVICE_BACKEND_RPMSG_SHMEM_RESET)
-static int shared_memory_prepare(const struct device *arg)
+static int shared_memory_prepare(void)
 {
 	static const struct backend_config_t *config[] = {
 		DT_INST_FOREACH_STATUS_OKAY(BACKEND_CONFIG_INIT)

--- a/subsys/ipc/rpmsg_service/rpmsg_backend.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_backend.c
@@ -283,7 +283,7 @@ int rpmsg_backend_init(struct metal_io_region **io, struct virtio_device *vdev)
 /* Make sure we clear out the status flag very early (before we bringup the
  * secondary core) so the secondary core see's the proper status
  */
-int init_status_flag(const struct device *arg)
+int init_status_flag(void)
 {
 	virtio_set_status(NULL, 0);
 

--- a/subsys/ipc/rpmsg_service/rpmsg_service.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_service.c
@@ -75,11 +75,9 @@ static void ns_bind_cb(struct rpmsg_device *rdev,
 
 #endif
 
-static int rpmsg_service_init(const struct device *dev)
+static int rpmsg_service_init(void)
 {
 	int32_t err;
-
-	(void)dev;
 
 	LOG_DBG("RPMsg service initialization start");
 

--- a/subsys/logging/backends/log_backend_adsp_hda.c
+++ b/subsys/logging/backends/log_backend_adsp_hda.c
@@ -358,9 +358,8 @@ void adsp_hda_log_cavstool_hook(uint32_t written)
 
 }
 
-int adsp_hda_log_cavstool_init(const struct device *dev)
+int adsp_hda_log_cavstool_init(void)
 {
-	ARG_UNUSED(dev);
 
 	hda_ipc_msg(INTEL_ADSP_IPC_HOST_DEV, IPCCMD_HDA_RESET, CHANNEL, IPC_TIMEOUT);
 	hda_ipc_msg(INTEL_ADSP_IPC_HOST_DEV, IPCCMD_HDA_CONFIG,

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -885,10 +885,8 @@ static void log_process_thread_func(void *dummy1, void *dummy2, void *dummy3)
 K_KERNEL_STACK_DEFINE(logging_stack, CONFIG_LOG_PROCESS_THREAD_STACK_SIZE);
 struct k_thread logging_thread;
 
-static int enable_logger(const struct device *arg)
+static int enable_logger(void)
 {
-	ARG_UNUSED(arg);
-
 	if (IS_ENABLED(CONFIG_LOG_PROCESS_THREAD)) {
 		k_timer_init(&log_process_thread_timer,
 				log_process_thread_timer_expiry_fn, NULL);

--- a/subsys/logging/log_frontend_dict_uart.c
+++ b/subsys/logging/log_frontend_dict_uart.c
@@ -341,9 +341,8 @@ void log_frontend_init(void)
 }
 
 /* Cannot be started in log_frontend_init because it is called before kernel is ready. */
-static int log_frontend_uart_start_timer(const struct device *unused)
+static int log_frontend_uart_start_timer(void)
 {
-	ARG_UNUSED(unused);
 	k_timeout_t t = K_MSEC(CONFIG_LOG_FRONTEND_DICT_UART_DROPPED_NOTIFY_PERIOD);
 
 	k_timer_start(&dropped_timer, t, t);

--- a/subsys/logging/log_output_syst.c
+++ b/subsys/logging/log_output_syst.c
@@ -874,9 +874,8 @@ void log_output_msg_syst_process(const struct log_output *output,
 	}
 }
 
-static int syst_init(const struct device *arg)
+static int syst_init(void)
 {
-	ARG_UNUSED(arg);
 
 	MIPI_SYST_INIT_STATE(&log_syst_header,
 			     mipi_syst_platform_init, (void *)0);

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -685,9 +685,8 @@ int lorawan_start(void)
 	return 0;
 }
 
-static int lorawan_init(const struct device *dev)
+static int lorawan_init(void)
 {
-	ARG_UNUSED(dev);
 
 	sys_slist_init(&dl_callbacks);
 

--- a/subsys/lorawan/services/lorawan_services.c
+++ b/subsys/lorawan/services/lorawan_services.c
@@ -159,9 +159,8 @@ int lorawan_services_reschedule_work(struct k_work_delayable *dwork, k_timeout_t
 	return k_work_reschedule_for_queue(&services_workq, dwork, delay);
 }
 
-static int lorawan_services_init(const struct device *dev)
+static int lorawan_services_init(void)
 {
-	ARG_UNUSED(dev);
 
 	sys_slist_init(&msg_list);
 	k_sem_init(&msg_sem, 1, 1);

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_espi.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_espi.c
@@ -148,9 +148,8 @@ struct ec_host_cmd_backend *ec_host_cmd_backend_get_espi(const struct device *de
 }
 
 #if DT_NODE_EXISTS(DT_CHOSEN(zephyr_host_cmd_backend))
-static int host_cmd_init(const struct device *arg)
+static int host_cmd_init(void)
 {
-	ARG_UNUSED(arg);
 	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_host_cmd_backend));
 
 	ec_host_cmd_init(ec_host_cmd_backend_get_espi(dev));

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_ite.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_ite.c
@@ -513,9 +513,8 @@ struct ec_host_cmd_backend *ec_host_cmd_backend_get_shi_ite(void)
 }
 
 #if DT_NODE_EXISTS(DT_CHOSEN(zephyr_host_cmd_backend))
-static int host_cmd_init(const struct device *arg)
+static int host_cmd_init(void)
 {
-	ARG_UNUSED(arg);
 
 	ec_host_cmd_init(ec_host_cmd_backend_get_shi_ite());
 	return 0;

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
@@ -984,9 +984,8 @@ struct ec_host_cmd_backend *ec_host_cmd_backend_get_shi_npcx(void)
 }
 
 #if DT_NODE_EXISTS(DT_CHOSEN(zephyr_host_cmd_backend))
-static int host_cmd_init(const struct device *arg)
+static int host_cmd_init(void)
 {
-	ARG_UNUSED(arg);
 
 	ec_host_cmd_init(ec_host_cmd_backend_get_shi_npcx());
 	return 0;

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_simulator.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_simulator.c
@@ -76,9 +76,8 @@ int ec_host_cmd_backend_sim_data_received(const uint8_t *buffer, size_t len)
 	return 0;
 }
 
-static int host_cmd_init(const struct device *arg)
+static int host_cmd_init(void)
 {
-	ARG_UNUSED(arg);
 
 	ec_host_cmd_init(&ec_host_cmd_sim);
 	return 0;

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_uart.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_uart.c
@@ -303,9 +303,8 @@ struct ec_host_cmd_backend *ec_host_cmd_backend_get_uart(const struct device *de
 }
 
 #if DT_NODE_EXISTS(DT_CHOSEN(zephyr_host_cmd_backend))
-static int host_cmd_init(const struct device *arg)
+static int host_cmd_init(void)
 {
-	ARG_UNUSED(arg);
 	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_host_cmd_backend));
 
 	ec_host_cmd_init(ec_host_cmd_backend_get_uart(dev));

--- a/subsys/mgmt/mcumgr/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/mgmt/src/mgmt.c
@@ -129,9 +129,8 @@ int32_t mgmt_callback_notify(uint32_t event, void *data, size_t data_size)
 #endif
 
 /* Processes all registered MCUmgr handlers at start up and registers them */
-static int mcumgr_handlers_init(const struct device *dev)
+static int mcumgr_handlers_init(void)
 {
-	ARG_UNUSED(dev);
 
 	STRUCT_SECTION_FOREACH(mcumgr_handler, handler) {
 		if (handler->init) {

--- a/subsys/mgmt/mcumgr/transport/src/smp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp.c
@@ -229,7 +229,7 @@ void smp_rx_clear(struct smp_transport *zst)
 	}
 }
 
-static int smp_init(const struct device *dev)
+static int smp_init(void)
 {
 	k_work_queue_init(&smp_work_queue);
 

--- a/subsys/mgmt/mcumgr/transport/src/smp_dummy.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_dummy.c
@@ -185,9 +185,8 @@ static int smp_dummy_tx_pkt_int(struct net_buf *nb)
 	return rc;
 }
 
-static int smp_dummy_init(const struct device *dev)
+static int smp_dummy_init(void)
 {
-	ARG_UNUSED(dev);
 
 	k_sem_init(&smp_data_ready_sem, 0, 1);
 

--- a/subsys/mgmt/mcumgr/transport/src/smp_uart.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_uart.c
@@ -90,9 +90,8 @@ static int smp_uart_tx_pkt(struct net_buf *nb)
 	return rc;
 }
 
-static int smp_uart_init(const struct device *dev)
+static int smp_uart_init(void)
 {
-	ARG_UNUSED(dev);
 
 	smp_transport_init(&smp_uart_transport, smp_uart_tx_pkt,
 			   smp_uart_get_mtu, NULL, NULL, NULL);

--- a/subsys/mgmt/mcumgr/transport/src/smp_udp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_udp.c
@@ -172,9 +172,8 @@ static void smp_udp_receive_thread(void *p1, void *p2, void *p3)
 	}
 }
 
-static int smp_udp_init(const struct device *dev)
+static int smp_udp_init(void)
 {
-	ARG_UNUSED(dev);
 
 #ifdef CONFIG_MCUMGR_TRANSPORT_UDP_IPV4
 	smp_transport_init(&configs.ipv4.smp_transport,

--- a/subsys/mgmt/osdp/src/osdp.c
+++ b/subsys/mgmt/osdp/src/osdp.c
@@ -177,9 +177,8 @@ void osdp_refresh(void *arg1, void *arg2, void *arg3)
 	}
 }
 
-static int osdp_init(const struct device *arg)
+static int osdp_init(void)
 {
-	ARG_UNUSED(arg);
 	int len;
 	uint8_t c, *key = NULL, key_buf[16];
 	struct osdp *ctx;

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -485,7 +485,7 @@ static inline int services_init(void)
 	return status;
 }
 
-static int net_init(const struct device *unused)
+static int net_init(void)
 {
 	net_hostname_init();
 

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -908,9 +908,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 
 SHELL_CMD_REGISTER(wifi, &wifi_commands, "Wi-Fi commands", NULL);
 
-static int wifi_shell_init(const struct device *unused)
+static int wifi_shell_init(void)
 {
-	ARG_UNUSED(unused);
 
 	context.sh = NULL;
 	context.all = 0U;

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -495,9 +495,8 @@ int net_config_init_app(const struct device *dev, const char *app_info)
 }
 
 #if defined(CONFIG_NET_CONFIG_AUTO_INIT)
-static int init_app(const struct device *dev)
+static int init_app(void)
 {
-	ARG_UNUSED(dev);
 
 	(void)net_config_init_app(NULL, "Initializing network");
 

--- a/subsys/net/lib/conn_mgr/conn_mgr.c
+++ b/subsys/net/lib/conn_mgr/conn_mgr.c
@@ -200,11 +200,10 @@ void net_conn_mgr_resend_status(void)
 	}
 }
 
-static int conn_mgr_init(const struct device *dev)
+static int conn_mgr_init(void)
 {
 	int i;
 
-	ARG_UNUSED(dev);
 
 	for (i = 0; i < ARRAY_SIZE(iface_states); i++) {
 		iface_states[i] = 0;

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -668,9 +668,8 @@ ipv4_out:
 	return !ok;
 }
 
-static int llmnr_responder_init(const struct device *dev)
+static int llmnr_responder_init(void)
 {
-	ARG_UNUSED(dev);
 
 	net_mgmt_init_event_callback(&mgmt_cb, llmnr_iface_event_handler,
 				     NET_EVENT_IF_UP);

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -679,9 +679,8 @@ ipv4_out:
 	return !ok;
 }
 
-static int mdns_responder_init(const struct device *dev)
+static int mdns_responder_init(void)
 {
-	ARG_UNUSED(dev);
 
 	net_mgmt_init_event_callback(&mgmt_cb, mdns_iface_event_handler,
 				     NET_EVENT_IF_UP);

--- a/subsys/net/lib/lwm2m/ipso_accelerometer.c
+++ b/subsys/net/lib/lwm2m/ipso_accelerometer.c
@@ -142,7 +142,7 @@ static struct lwm2m_engine_obj_inst *accel_create(uint16_t obj_inst_id)
 	return &inst[avail];
 }
 
-static int ipso_accel_init(const struct device *dev)
+static int ipso_accel_init(void)
 {
 	accel.obj_id = IPSO_OBJECT_ACCELEROMETER_ID;
 	accel.version_major = ACCEL_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/ipso_buzzer.c
+++ b/subsys/net/lib/lwm2m/ipso_buzzer.c
@@ -243,7 +243,7 @@ static struct lwm2m_engine_obj_inst *buzzer_create(uint16_t obj_inst_id)
 	return &inst[avail];
 }
 
-static int ipso_buzzer_init(const struct device *dev)
+static int ipso_buzzer_init(void)
 {
 	buzzer.obj_id = IPSO_OBJECT_BUZZER_ID;
 	buzzer.version_major = BUZZER_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/ipso_current_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_current_sensor.c
@@ -213,7 +213,7 @@ static struct lwm2m_engine_obj_inst *current_sensor_create(uint16_t obj_inst_id)
 	return &inst[index];
 }
 
-static int ipso_current_sensor_init(const struct device *dev)
+static int ipso_current_sensor_init(void)
 {
 	sensor.obj_id = IPSO_OBJECT_ID;
 	sensor.version_major = CURRENT_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/ipso_filling_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_filling_sensor.c
@@ -228,7 +228,7 @@ static struct lwm2m_engine_obj_inst *filling_sensor_create(uint16_t obj_inst_id)
 	return &inst[index];
 }
 
-static int init(const struct device *dev)
+static int init(void)
 {
 	fill_sensor.obj_id = IPSO_OBJECT_ID;
 	fill_sensor.version_major = FILLING_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/ipso_generic_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_generic_sensor.c
@@ -222,7 +222,7 @@ static struct lwm2m_engine_obj_inst *generic_sensor_create(uint16_t obj_inst_id)
 	return &inst[index];
 }
 
-static int ipso_generic_sensor_init(const struct device *dev)
+static int ipso_generic_sensor_init(void)
 {
 	sensor.obj_id = IPSO_OBJECT_ID;
 	sensor.version_major = GENERIC_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/ipso_humidity_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_humidity_sensor.c
@@ -203,7 +203,7 @@ humidity_sensor_create(uint16_t obj_inst_id)
 	return &inst[index];
 }
 
-static int ipso_humidity_sensor_init(const struct device *dev)
+static int ipso_humidity_sensor_init(void)
 {
 	sensor.obj_id = IPSO_OBJECT_ID;
 	sensor.version_major = HUMIDITY_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/ipso_light_control.c
+++ b/subsys/net/lib/lwm2m/ipso_light_control.c
@@ -186,7 +186,7 @@ static struct lwm2m_engine_obj_inst *light_control_create(uint16_t obj_inst_id)
 	return &inst[avail];
 }
 
-static int ipso_light_control_init(const struct device *dev)
+static int ipso_light_control_init(void)
 {
 	light_control.obj_id = IPSO_OBJECT_LIGHT_CONTROL_ID;
 	light_control.version_major = LIGHT_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/ipso_onoff_switch.c
+++ b/subsys/net/lib/lwm2m/ipso_onoff_switch.c
@@ -234,7 +234,7 @@ static struct lwm2m_engine_obj_inst *switch_create(uint16_t obj_inst_id)
 	return &inst[avail];
 }
 
-static int ipso_switch_init(const struct device *dev)
+static int ipso_switch_init(void)
 {
 	onoff_switch.obj_id = IPSO_OBJECT_ONOFF_SWITCH_ID;
 	onoff_switch.version_major = SWITCH_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/ipso_pressure_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_pressure_sensor.c
@@ -206,7 +206,7 @@ pressure_sensor_create(uint16_t obj_inst_id)
 	return &inst[index];
 }
 
-static int ipso_pressure_sensor_init(const struct device *dev)
+static int ipso_pressure_sensor_init(void)
 {
 	sensor.obj_id = IPSO_OBJECT_ID;
 	sensor.version_major = PRESSURE_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/ipso_push_button.c
+++ b/subsys/net/lib/lwm2m/ipso_push_button.c
@@ -171,7 +171,7 @@ static struct lwm2m_engine_obj_inst *button_create(uint16_t obj_inst_id)
 	return &inst[avail];
 }
 
-static int ipso_button_init(const struct device *dev)
+static int ipso_button_init(void)
 {
 	onoff_switch.obj_id = IPSO_OBJECT_PUSH_BUTTON_ID;
 	onoff_switch.version_major = BUTTON_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/ipso_temp_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_temp_sensor.c
@@ -206,7 +206,7 @@ static struct lwm2m_engine_obj_inst *temp_sensor_create(uint16_t obj_inst_id)
 	return &inst[index];
 }
 
-static int ipso_temp_sensor_init(const struct device *dev)
+static int ipso_temp_sensor_init(void)
 {
 	temp_sensor.obj_id = IPSO_OBJECT_TEMP_SENSOR_ID;
 	temp_sensor.version_major = TEMP_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/ipso_timer.c
+++ b/subsys/net/lib/lwm2m/ipso_timer.c
@@ -351,7 +351,7 @@ static struct lwm2m_engine_obj_inst *timer_inst_create(uint16_t obj_inst_id)
 	return &inst[avail];
 }
 
-static int ipso_timer_init(const struct device *dev)
+static int ipso_timer_init(void)
 {
 	timer.obj_id = IPSO_OBJECT_TIMER_ID;
 	timer.version_major = TIMER_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/ipso_voltage_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_voltage_sensor.c
@@ -214,7 +214,7 @@ static struct lwm2m_engine_obj_inst *voltage_sensor_create(uint16_t obj_inst_id)
 	return &inst[index];
 }
 
-static int ipso_voltage_sensor_init(const struct device *dev)
+static int ipso_voltage_sensor_init(void)
 {
 	sensor.obj_id = IPSO_OBJECT_ID;
 	sensor.version_major = VOLTAGE_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1021,7 +1021,7 @@ int lwm2m_engine_resume(void)
 	return 0;
 }
 
-static int lwm2m_engine_init(const struct device *dev)
+static int lwm2m_engine_init(void)
 {
 	int i;
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_access_control.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_access_control.c
@@ -420,7 +420,7 @@ static struct lwm2m_engine_obj_inst *ac_create(uint16_t obj_inst_id)
 	return &inst[avail];
 }
 
-static int ac_control_init(const struct device *dev)
+static int ac_control_init(void)
 {
 	ac_obj.obj_id = LWM2M_OBJECT_ACCESS_CONTROL_ID;
 	ac_obj.version_major = ACCESS_CONTROL_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_binaryappdata.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_binaryappdata.c
@@ -104,7 +104,7 @@ static struct lwm2m_engine_obj_inst *lwm2m_binaryappdata_create(uint16_t obj_ins
 	return &inst[avail];
 }
 
-static int lwm2m_binaryappdata_init(const struct device *dev)
+static int lwm2m_binaryappdata_init(void)
 {
 	int ret = 0;
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_connmon.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_connmon.c
@@ -164,7 +164,7 @@ static struct lwm2m_engine_obj_inst *connmon_create(uint16_t obj_inst_id)
 	return &inst;
 }
 
-static int lwm2m_connmon_init(const struct device *dev)
+static int lwm2m_connmon_init(void)
 {
 	struct lwm2m_engine_obj_inst *obj_inst = NULL;
 	int ret = 0;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_device.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_device.c
@@ -268,7 +268,7 @@ static struct lwm2m_engine_obj_inst *device_create(uint16_t obj_inst_id)
 	return &inst;
 }
 
-static int lwm2m_device_init(const struct device *dev)
+static int lwm2m_device_init(void)
 {
 	struct lwm2m_engine_obj_inst *obj_inst = NULL;
 	int ret = 0;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_event_log.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_event_log.c
@@ -78,7 +78,7 @@ static struct lwm2m_engine_obj_inst *lwm2m_event_log_create(uint16_t obj_inst_id
 	return &inst;
 }
 
-static int lwm2m_event_log_init(const struct device *dev)
+static int lwm2m_event_log_init(void)
 {
 	struct lwm2m_engine_obj_inst *obj_inst = NULL;
 	int ret = 0;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -441,7 +441,7 @@ static struct lwm2m_engine_obj_inst *firmware_create(uint16_t obj_inst_id)
 	return &inst[obj_inst_id];
 }
 
-static int lwm2m_firmware_init(const struct device *dev)
+static int lwm2m_firmware_init(void)
 {
 	struct lwm2m_engine_obj_inst *obj_inst = NULL;
 	int ret = 0;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_gateway.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_gateway.c
@@ -143,7 +143,7 @@ static struct lwm2m_engine_obj_inst *lwm2m_gw_create(uint16_t obj_inst_id)
 	return &inst[index];
 }
 
-static int lwm2m_gw_init(const struct device *dev)
+static int lwm2m_gw_init(void)
 {
 	int ret = 0;
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_location.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_location.c
@@ -93,7 +93,7 @@ static struct lwm2m_engine_obj_inst *location_create(uint16_t obj_inst_id)
 	return &inst;
 }
 
-static int ipso_location_init(const struct device *dev)
+static int ipso_location_init(void)
 {
 	int ret;
 	struct lwm2m_engine_obj_inst *obj_inst = NULL;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_portfolio.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_portfolio.c
@@ -110,7 +110,7 @@ static struct lwm2m_engine_obj_inst *portfolio_create(uint16_t obj_inst_id)
 	return &inst[avail];
 }
 
-static int lwm2m_portfolio_init(const struct device *dev)
+static int lwm2m_portfolio_init(void)
 {
 	portfolio.obj_id = LWM2M_OBJECT_PORTFOLIO_ID;
 	portfolio.version_major = PORTFOLIO_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_security.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_security.c
@@ -212,7 +212,7 @@ int lwm2m_security_index_to_inst_id(int index)
 	return inst[index].obj_inst_id;
 }
 
-static int lwm2m_security_init(const struct device *dev)
+static int lwm2m_security_init(void)
 {
 	struct lwm2m_engine_obj_inst *obj_inst = NULL;
 	int ret = 0;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_server.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_server.c
@@ -340,7 +340,7 @@ static struct lwm2m_engine_obj_inst *server_create(uint16_t obj_inst_id)
 	return &inst[index];
 }
 
-static int lwm2m_server_init(const struct device *dev)
+static int lwm2m_server_init(void)
 {
 	int ret = 0;
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
@@ -780,7 +780,7 @@ static struct lwm2m_engine_obj_inst *swmgmt_create(uint16_t obj_inst_id)
 	return &inst[index];
 }
 
-static int lwm2m_swmgmt_init(const struct device *dev)
+static int lwm2m_swmgmt_init(void)
 {
 	swmgmt.obj_id = LWM2M_OBJECT_SOFTWARE_MANAGEMENT_ID;
 	swmgmt.version_major = SWMGMT_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1556,10 +1556,8 @@ int lwm2m_rd_client_init(void)
 
 }
 
-static int sys_lwm2m_rd_client_init(const struct device *dev)
+static int sys_lwm2m_rd_client_init(void)
 {
-	ARG_UNUSED(dev);
-
 	return lwm2m_rd_client_init();
 }
 

--- a/subsys/net/lib/lwm2m/ucifi_battery.c
+++ b/subsys/net/lib/lwm2m/ucifi_battery.c
@@ -135,7 +135,7 @@ static struct lwm2m_engine_obj_inst *battery_create(uint16_t obj_inst_id)
 	return &inst[index];
 }
 
-static int ucifi_battery_init(const struct device *dev)
+static int ucifi_battery_init(void)
 {
 	battery.obj_id = UCIFI_OBJECT_BATTERY_ID;
 	battery.version_major = BATTERY_VERSION_MAJOR;

--- a/subsys/net/lib/lwm2m/ucifi_lpwan.c
+++ b/subsys/net/lib/lwm2m/ucifi_lpwan.c
@@ -163,7 +163,7 @@ static struct lwm2m_engine_obj_inst *lpwan_create(uint16_t obj_inst_id)
 	return &inst[index];
 }
 
-static int ucifi_lpwan_init(const struct device *dev)
+static int ucifi_lpwan_init(void)
 {
 	lpwan.obj_id = LWM2M_UCIFI_LPWAN_ID;
 	lpwan.version_major = LPWAN_VERSION_MAJOR;

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -335,9 +335,8 @@ static int dtls_get_remaining_timeout(struct tls_context *ctx)
 #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
 
 /* Initialize TLS internals. */
-static int tls_init(const struct device *unused)
+static int tls_init(void)
 {
-	ARG_UNUSED(unused);
 
 #if !defined(CONFIG_ENTROPY_HAS_DRIVER)
 	NET_WARN("No entropy device on the system, "

--- a/subsys/net/lib/tls_credentials/tls_credentials.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials.c
@@ -16,7 +16,7 @@ static struct tls_credential credentials[CONFIG_TLS_MAX_CREDENTIALS_NUMBER];
 /* A mutex for protecting access to the credentials array. */
 static struct k_mutex credential_lock;
 
-static int credentials_init(const struct device *unused)
+static int credentials_init(void)
 {
 	(void)memset(credentials, 0, sizeof(credentials));
 

--- a/subsys/net/lib/tls_credentials/tls_credentials_trusted.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials_trusted.c
@@ -122,7 +122,7 @@ static unsigned int tls_credential_toc_find_slot(psa_storage_uid_t uid)
 	return CRED_MAX_SLOTS;
 }
 
-static int credentials_init(const struct device *unused)
+static int credentials_init(void)
 {
 	struct psa_storage_info_t info;
 	unsigned int sync = 0;

--- a/subsys/net/lib/zperf/zperf_common.c
+++ b/subsys/net/lib/zperf/zperf_common.c
@@ -210,9 +210,8 @@ void zperf_async_work_submit(struct k_work *work)
 	k_work_submit_to_queue(&zperf_work_q, work);
 }
 
-static int zperf_init(const struct device *unused)
+static int zperf_init(void)
 {
-	ARG_UNUSED(unused);
 
 	k_work_queue_init(&zperf_work_q);
 	k_work_queue_start(&zperf_work_q, zperf_work_q_stack,

--- a/subsys/pm/pm_stats.c
+++ b/subsys/pm/pm_stats.c
@@ -31,9 +31,8 @@ static char names[CONFIG_MP_MAX_NUM_CPUS][PM_STATE_COUNT][PM_STAT_NAME_LEN];
 static uint32_t time_start[CONFIG_MP_MAX_NUM_CPUS];
 static uint32_t time_stop[CONFIG_MP_MAX_NUM_CPUS];
 
-static int pm_stats_init(const struct device *dev)
+static int pm_stats_init(void)
 {
-	ARG_UNUSED(dev);
 
 	unsigned int num_cpus = arch_num_cpus();
 

--- a/subsys/random/rand32_xoshiro128.c
+++ b/subsys/random/rand32_xoshiro128.c
@@ -42,7 +42,7 @@ static inline uint32_t rotl(const uint32_t x, int k)
 	return (x << k) | (x >> (32 - k));
 }
 
-static int xoshiro128_initialize(const struct device *dev)
+static int xoshiro128_initialize(void)
 {
 	if (!device_is_ready(entropy_driver)) {
 		return -ENODEV;

--- a/subsys/shell/backends/shell_dummy.c
+++ b/subsys/shell/backends/shell_dummy.c
@@ -98,9 +98,8 @@ const struct shell_transport_api shell_dummy_transport_api = {
 	.read = read
 };
 
-static int enable_shell_dummy(const struct device *arg)
+static int enable_shell_dummy(void)
 {
-	ARG_UNUSED(arg);
 	bool log_backend = CONFIG_SHELL_DUMMY_INIT_LOG_LEVEL > 0;
 	uint32_t level = (CONFIG_SHELL_DUMMY_INIT_LOG_LEVEL > LOG_LEVEL_DBG) ?
 		      CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_DUMMY_INIT_LOG_LEVEL;

--- a/subsys/shell/backends/shell_mqtt.c
+++ b/subsys/shell/backends/shell_mqtt.c
@@ -812,9 +812,8 @@ const struct shell_transport_api shell_mqtt_transport_api = { .init = init,
 							      .write = write,
 							      .read = read };
 
-static int enable_shell_mqtt(const struct device *arg)
+static int enable_shell_mqtt(void)
 {
-	ARG_UNUSED(arg);
 
 	bool log_backend = CONFIG_SHELL_MQTT_INIT_LOG_LEVEL > 0;
 	uint32_t level = (CONFIG_SHELL_MQTT_INIT_LOG_LEVEL > LOG_LEVEL_DBG) ?

--- a/subsys/shell/backends/shell_rtt.c
+++ b/subsys/shell/backends/shell_rtt.c
@@ -107,9 +107,8 @@ const struct shell_transport_api shell_rtt_transport_api = {
 	.read = read
 };
 
-static int enable_shell_rtt(const struct device *arg)
+static int enable_shell_rtt(void)
 {
-	ARG_UNUSED(arg);
 	bool log_backend = CONFIG_SHELL_RTT_INIT_LOG_LEVEL > 0;
 	uint32_t level = (CONFIG_SHELL_RTT_INIT_LOG_LEVEL > LOG_LEVEL_DBG) ?
 		      CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_RTT_INIT_LOG_LEVEL;

--- a/subsys/shell/backends/shell_telnet.c
+++ b/subsys/shell/backends/shell_telnet.c
@@ -526,9 +526,8 @@ const struct shell_transport_api shell_telnet_transport_api = {
 	.read = read
 };
 
-static int enable_shell_telnet(const struct device *arg)
+static int enable_shell_telnet(void)
 {
-	ARG_UNUSED(arg);
 
 	bool log_backend = CONFIG_SHELL_TELNET_INIT_LOG_LEVEL > 0;
 	uint32_t level = (CONFIG_SHELL_TELNET_INIT_LOG_LEVEL > LOG_LEVEL_DBG) ?

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -338,9 +338,8 @@ const struct shell_transport_api shell_uart_transport_api = {
 #endif /* CONFIG_MCUMGR_TRANSPORT_SHELL */
 };
 
-static int enable_shell_uart(const struct device *arg)
+static int enable_shell_uart(void)
 {
-	ARG_UNUSED(arg);
 	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
 	bool log_backend = CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > 0;
 	uint32_t level =

--- a/subsys/testsuite/ztest/src/ztress.c
+++ b/subsys/testsuite/ztest/src/ztress.c
@@ -451,7 +451,7 @@ uint32_t ztress_optimized_ticks(uint32_t id)
  * cpu load (e.g. busy simulator) running that would influence the result.
  *
  */
-static int ztress_cpu_clock_to_sys_clock_check(const struct device *unused)
+static int ztress_cpu_clock_to_sys_clock_check(void)
 {
 	static volatile int cnt = 2000;
 	uint32_t t = sys_clock_tick_get_32();

--- a/subsys/tracing/sysview/sysview.c
+++ b/subsys/tracing/sysview/sysview.c
@@ -65,9 +65,8 @@ void sys_trace_idle(void)
 	SEGGER_SYSVIEW_OnIdle();
 }
 
-static int sysview_init(const struct device *arg)
+static int sysview_init(void)
 {
-	ARG_UNUSED(arg);
 
 	SEGGER_SYSVIEW_Conf();
 	if (IS_ENABLED(CONFIG_SEGGER_SYSTEMVIEW_BOOT_ENABLE)) {

--- a/subsys/tracing/tracing_core.c
+++ b/subsys/tracing/tracing_core.c
@@ -87,9 +87,8 @@ static void tracing_set_state(enum tracing_state state)
 	atomic_set(&tracing_state, state);
 }
 
-static int tracing_init(const struct device *arg)
+static int tracing_init(void)
 {
-	ARG_UNUSED(arg);
 
 	tracing_buffer_init();
 

--- a/subsys/tracing/tracing_tracking.c
+++ b/subsys/tracing/tracing_tracking.c
@@ -124,9 +124,8 @@ void sys_track_k_event_init(struct k_event *event)
 }
 #endif
 
-static int sys_track_static_init(const struct device *arg)
+static int sys_track_static_init(void)
 {
-	ARG_UNUSED(arg);
 
 	SYS_PORT_TRACING_TYPE_MASK(k_timer,
 			SYS_TRACK_STATIC_INIT(k_timer));

--- a/subsys/usb/device/class/bluetooth.c
+++ b/subsys/usb/device/class/bluetooth.c
@@ -449,7 +449,7 @@ USBD_DEFINE_CFG_DATA(bluetooth_config) = {
 	.endpoint = bluetooth_ep_data,
 };
 
-static int bluetooth_init(const struct device *dev)
+static int bluetooth_init(void)
 {
 	int ret;
 

--- a/subsys/usb/device/class/bt_h4.c
+++ b/subsys/usb/device/class/bt_h4.c
@@ -221,7 +221,7 @@ USBD_DEFINE_CFG_DATA(bt_h4_config) = {
 	.endpoint = bt_h4_ep_data,
 };
 
-static int bt_h4_init(const struct device *dev)
+static int bt_h4_init(void)
 {
 	int ret;
 

--- a/subsys/usb/device/class/dfu/usb_dfu.c
+++ b/subsys/usb/device/class/dfu/usb_dfu.c
@@ -898,11 +898,10 @@ static void dfu_work_handler(struct k_work *item)
 	}
 }
 
-static int usb_dfu_init(const struct device *dev)
+static int usb_dfu_init(void)
 {
 	const struct flash_area *fa;
 
-	ARG_UNUSED(dev);
 
 	k_work_init(&dfu_work, dfu_work_handler);
 	k_poll_signal_init(&dfu_signal);

--- a/subsys/usb/device/class/msc.c
+++ b/subsys/usb/device/class/msc.c
@@ -953,11 +953,10 @@ static void mass_thread_main(int arg1, int unused)
  *
  * @return negative errno code on fatal failure, 0 otherwise
  */
-static int mass_storage_init(const struct device *dev)
+static int mass_storage_init(void)
 {
 	uint32_t block_size = 0U;
 
-	ARG_UNUSED(dev);
 
 	if (disk_access_init(disk_pdrv) != 0) {
 		LOG_ERR("Storage init ERROR !!!! - Aborting USB init");

--- a/subsys/usb/device/class/netusb/function_rndis.c
+++ b/subsys/usb/device/class/netusb/function_rndis.c
@@ -1030,9 +1030,8 @@ static struct usb_os_descriptor os_desc = {
 };
 #endif /* CONFIG_USB_DEVICE_OS_DESC */
 
-static int rndis_init(const struct device *arg)
+static int rndis_init(void)
 {
-	ARG_UNUSED(arg);
 
 	LOG_DBG("RNDIS initialization");
 

--- a/subsys/usb/device/usb_device.c
+++ b/subsys/usb/device/usb_device.c
@@ -1686,7 +1686,7 @@ out:
  * This function configures the USB device stack based on USB descriptor and
  * usb_cfg_data.
  */
-static int usb_device_init(const struct device *dev)
+static int usb_device_init(void)
 {
 	uint8_t *device_descriptor;
 

--- a/subsys/usb/device/usb_work_q.c
+++ b/subsys/usb/device/usb_work_q.c
@@ -14,9 +14,8 @@ K_KERNEL_STACK_DEFINE(z_usb_work_q_stack, CONFIG_USB_WORKQUEUE_STACK_SIZE);
 
 struct k_work_q z_usb_work_q;
 
-static int z_usb_work_q_init(const struct device *dev)
+static int z_usb_work_q_init(void)
 {
-	ARG_UNUSED(dev);
 
 	k_work_queue_start(&z_usb_work_q,
 			   z_usb_work_q_stack,

--- a/subsys/usb/device_next/class/bt_hci.c
+++ b/subsys/usb/device_next/class/bt_hci.c
@@ -588,7 +588,7 @@ static struct usbd_bt_hci_desc bt_hci_desc_##n = {				\
 BT_HCI_DESCRIPTOR_DEFINE(0)
 BT_HCI_CLASS_DATA_DEFINE(0)
 
-static int bt_hci_preinit(const struct device *dev)
+static int bt_hci_preinit(void)
 {
 	int ret;
 

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -931,7 +931,7 @@ static int cdc_acm_config_get(const struct device *dev,
 }
 #endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
-static int usbd_cdc_acm_init_wq(const struct device *dev)
+static int usbd_cdc_acm_init_wq(void)
 {
 	k_work_queue_init(&cdc_acm_work_q);
 	k_work_queue_start(&cdc_acm_work_q, cdc_acm_stack,

--- a/subsys/usb/device_next/usbd_core.c
+++ b/subsys/usb/device_next/usbd_core.c
@@ -202,7 +202,7 @@ int usbd_device_shutdown_core(struct usbd_contex *const uds_ctx)
 	return udc_shutdown(uds_ctx->dev);
 }
 
-static int usbd_pre_init(const struct device *unused)
+static int usbd_pre_init(void)
 {
 	k_thread_create(&usbd_thread_data, usbd_stack,
 			K_KERNEL_STACK_SIZEOF(usbd_stack),

--- a/subsys/usb/host/usbh_core.c
+++ b/subsys/usb/host/usbh_core.c
@@ -144,7 +144,7 @@ int usbh_init_device_intl(struct usbh_contex *const uhs_ctx)
 	return 0;
 }
 
-static int uhs_pre_init(const struct device *unused)
+static int uhs_pre_init(void)
 {
 	k_thread_create(&usbh_thread_data, usbh_stack,
 			K_KERNEL_STACK_SIZEOF(usbh_stack),

--- a/tests/drivers/clock_control/nrf_lf_clock_start/src/main.c
+++ b/tests/drivers/clock_control/nrf_lf_clock_start/src/main.c
@@ -113,9 +113,8 @@ ZTEST_SUITE(nrf_lf_clock_start, NULL, test_init, NULL, NULL, NULL);
  * started in PRE_KERNEL_2). Reading of the clock state in the ZTEST setup
  * function turns out to be too late.
  */
-static int get_lfclk_state(const struct device *dev)
+static int get_lfclk_state(void)
 {
-	ARG_UNUSED(dev);
 
 	/* Do clock state read as early as possible. When RC is already running
 	 * and XTAL has been started then LFSRCSTAT register content might be

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -148,23 +148,23 @@ static int add_init_record(bool pre_kernel)
 }
 
 __pinned_func
-static int pre1_fn(const struct device *dev)
+static int pre1_fn(void)
 {
 	return add_init_record(true);
 }
 
 __pinned_func
-static int pre2_fn(const struct device *dev)
+static int pre2_fn(void)
 {
 	return add_init_record(true);
 }
 
-static int post_fn(const struct device *dev)
+static int post_fn(void)
 {
 	return add_init_record(false);
 }
 
-static int app_fn(const struct device *dev)
+static int app_fn(void)
 {
 	return add_init_record(false);
 }
@@ -175,9 +175,8 @@ SYS_INIT(post_fn, POST_KERNEL, 0);
 SYS_INIT(app_fn, APPLICATION, 0);
 
 /* This is an error case which driver initializes failed in SYS_INIT .*/
-static int null_driver_init(const struct device *dev)
+static int null_driver_init(void)
 {
-	ARG_UNUSED(dev);
 	return -EINVAL;
 }
 
@@ -238,7 +237,7 @@ ZTEST(device, test_device_list)
 
 static int sys_init_counter;
 
-static int init_fn(const struct device *dev)
+static int init_fn(void)
 {
 	sys_init_counter++;
 	return 0;

--- a/tests/kernel/early_sleep/src/main.c
+++ b/tests/kernel/early_sleep/src/main.c
@@ -65,9 +65,8 @@ static int ticks_to_sleep(int ticks)
 }
 
 
-static int test_early_sleep_post_kernel(const struct device *unused)
+static int test_early_sleep_post_kernel(void)
 {
-	ARG_UNUSED(unused);
 	actual_post_kernel_sleep_ticks = ticks_to_sleep(TEST_TICKS_TO_SLEEP);
 	return 0;
 }
@@ -75,9 +74,8 @@ static int test_early_sleep_post_kernel(const struct device *unused)
 SYS_INIT(test_early_sleep_post_kernel,
 		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 
-static int test_early_sleep_app(const struct device *unused)
+static int test_early_sleep_app(void)
 {
-	ARG_UNUSED(unused);
 	actual_app_sleep_ticks = ticks_to_sleep(TEST_TICKS_TO_SLEEP);
 	return 0;
 }

--- a/tests/kernel/threads/no-multithreading/src/main.c
+++ b/tests/kernel/threads/no-multithreading/src/main.c
@@ -80,9 +80,8 @@ ZTEST(no_multithreading, test_cpu_idle)
 #define IDX_POST_KERNEL 2
 
 #define SYS_INIT_CREATE(level) \
-	static int pre_kernel_##level##_init_func(const struct device *dev) \
+	static int pre_kernel_##level##_init_func(void) \
 	{ \
-		ARG_UNUSED(dev); \
 		if (init_order != IDX_##level && sys_init_result == 0) { \
 			sys_init_result = -1; \
 			return -EIO; \

--- a/tests/lib/cpp/cxx/src/main.cpp
+++ b/tests/lib/cpp/cxx/src/main.cpp
@@ -100,7 +100,7 @@ static struct foo foos[5];
 BUILD_ASSERT(ARRAY_SIZE(foos) == 5, "expected 5 elements");
 
 /* Check that SYS_INIT() compiles. */
-static int test_init(const struct device *dev)
+static int test_init(void)
 {
 	return 0;
 }

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -87,16 +87,16 @@ ZTEST(devicetree_devices, test_init_get)
 		      DEVICE_DT_GET(TEST_NOLABEL), NULL);
 
 	/* Check init functions */
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->init, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->init, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->init, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->init, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->init, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->init, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->init, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->init, dev_init);
-	zassert_equal(DEVICE_INIT_GET(manual_dev)->init, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->init, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->init_fn.dev, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->init_fn.dev, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->init_fn.dev, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->init_fn.dev, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->init_fn.dev, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->init_fn.dev, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->init_fn.dev, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->init_fn.dev, dev_init);
+	zassert_equal(DEVICE_INIT_GET(manual_dev)->init_fn.dev, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->init_fn.dev, dev_init);
 }
 
 ZTEST(devicetree_devices, test_init_order)

--- a/tests/subsys/fs/fat_fs_dual_drive/src/disk_access_test_drv.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/disk_access_test_drv.c
@@ -88,9 +88,8 @@ static struct disk_info ram_disk = {
 	.ops = &ram_disk_ops,
 };
 
-static int disk_ram_test_init(const struct device *dev)
+static int disk_ram_test_init(void)
 {
-	ARG_UNUSED(dev);
 
 	return disk_access_register(&ram_disk);
 }

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: 4e0e053f5ea413ef0cb20000729038d921ac2746
+      revision: ae1db23f32dde779cdfc4afaa9a60ea219310a64
       path: modules/hal/ti
       groups:
         - hal
@@ -170,7 +170,7 @@ manifest:
       revision: ce57712f3e426bbbb13acaec97b45369f716f43a
       path: modules/lib/loramac-node
     - name: lvgl
-      revision: 5ab83099854719ed326b6ecb9b09b07b1eee4818
+      revision: 1557cb3e4d5c8dc7bb2e8610b686b5acb157903c
       path: modules/lib/gui/lvgl
     - name: lz4
       revision: 8e303c264fc21c2116dc612658003a22e933124d
@@ -214,7 +214,7 @@ manifest:
       groups:
         - debug
     - name: sof
-      revision: 7fcde7cfe8187834ae17643a873bb794298658c5
+      revision: ac71254757478f79aa88807c168e88aee70a330b
       path: modules/audio/sof
     - name: tflite-micro
       revision: 9156d050927012da87079064db59d07f03b8baf6
@@ -226,7 +226,7 @@ manifest:
       groups:
         - crypto
     - name: TraceRecorderSource
-      revision: d92607521335eaaaedb01b241cdd26fda48a5ca6
+      revision: bc839bf94904bcdb91b33760e918afbef82e3ab4
       path: modules/debug/TraceRecorder
       groups:
         - debug


### PR DESCRIPTION
**NOTE**: This is a breaking change! All `SYS_INIT` functions will need
to be converted to the new signature. See the script offered in https://github.com/zephyrproject-rtos/zephyr/pull/51217/commits/c5c637c8408696eafde9c27b7c84b2dd653dc41e.

The init infrastructure, found in `init.h`, is currently used by:

- `SYS_INIT`: to call functions before `main`
- `DEVICE_*`: to initialize devices

They are all sorted according to an initialization level + a priority.
`SYS_INIT` calls are really orthogonal to devices, however, the required
function signature requires a `const struct device *dev` as a first
argument. The only reason for that is because the same init machinery is
used by devices, so we have something like:

```c
struct init_entry {
	int (*init)(const struct device *dev);
	/* only set by DEVICE_*, otherwise NULL */
	const struct device *dev;
}
```

As a result, we end up with such weird/ugly pattern:

```c
static int my_init(const struct device *dev)
{
	/* always NULL! add ARG_UNUSED to avoid compiler warning */
	ARG_UNUSED(dev);
	...
}
```

This is really a result of poor internals isolation. This patch proposes
a to make init entries more flexible so that they can accept sytem
initialization calls like this:

```c
static int my_init(void)
{
	...
}
```

This is achieved using a union:

```c
union init_function {
	/* for SYS_INIT, used when init_entry.dev == NULL */
	int (*sys)(void);
	/* for DEVICE*, used when init_entry.dev != NULL */
	int (*dev)(const struct device *dev);
};

struct init_entry {
	/* stores init function (either for SYS_INIT or DEVICE*) */
	union init_function init_fn;
	/* stores device pointer for DEVICE*, NULL for SYS_INIT. Allows
	 * to know which union entry to call.
	 */
	const struct device *dev;
}
```

This solution **does not increase ROM usage**, and allows to offer clean
public APIs for both SYS_INIT and DEVICE*. Note that however, init
machinery keeps a coupling with devices.

**NOTE**: This is a breaking change! All `SYS_INIT` functions will need
to be converted to the new signature. See the script offered in https://github.com/zephyrproject-rtos/zephyr/pull/51217/commits/c5c637c8408696eafde9c27b7c84b2dd653dc41e.