### PR TITLE
drivers: counter: add missing includes

### DIFF
--- a/drivers/counter/counter_andes_atcpit100.c
+++ b/drivers/counter/counter_andes_atcpit100.c
@@ -5,6 +5,9 @@
  */
 
 #include <zephyr/drivers/counter.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/irq.h>
+#include <zephyr/arch/cpu.h>
 #include <string.h>
 
 #define DT_DRV_COMPAT andestech_atcpit100

--- a/drivers/counter/counter_esp32_rtc.c
+++ b/drivers/counter/counter_esp32_rtc.c
@@ -15,6 +15,8 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/counter.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/kernel.h>
 
 #if defined(CONFIG_SOC_ESP32C3)
 #include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>

--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -15,6 +15,8 @@
 #include <hal/timer_hal.h>
 #include <string.h>
 #include <zephyr/drivers/counter.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/kernel.h>
 #ifndef CONFIG_SOC_ESP32C3
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #else

--- a/drivers/counter/counter_imx_epit.c
+++ b/drivers/counter/counter_imx_epit.c
@@ -7,6 +7,7 @@
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/device.h>
+#include <zephyr/irq.h>
 #include "clock_freq.h"
 #include "epit.h"
 

--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys/atomic.h>
 
 #include <stm32_ll_tim.h>

--- a/drivers/counter/counter_mcux_lpc_rtc.c
+++ b/drivers/counter/counter_mcux_lpc_rtc.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT nxp_lpc_rtc
 
 #include <zephyr/drivers/counter.h>
+#include <zephyr/irq.h>
 #include <fsl_rtc.h>
 #include <zephyr/logging/log.h>
 

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT nxp_kinetis_lptmr
 
 #include <zephyr/drivers/counter.h>
+#include <zephyr/irq.h>
 #include <fsl_lptmr.h>
 
 struct mcux_lptmr_config {

--- a/drivers/counter/counter_mcux_qtmr.c
+++ b/drivers/counter/counter_mcux_qtmr.c
@@ -15,6 +15,7 @@
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 #include <fsl_qtmr.h>
 #include <zephyr/logging/log.h>
 

--- a/drivers/counter/counter_sam0_tc32.c
+++ b/drivers/counter/counter_sam0_tc32.c
@@ -9,6 +9,7 @@
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/device.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
Noticed CI failures in https://github.com/zephyrproject-rtos/zephyr/pull/50352 caused by missing includes in some of the counter drivers. This PR adds the missing headers.

Signed-off-by: Pawel Czarnecki <pczarnecki@antmicro.com>