### PR TITLE
tests: drivers: disk: Replace the MAX function with if and else

### DIFF
--- a/tests/drivers/disk/disk_access/src/main.c
+++ b/tests/drivers/disk/disk_access/src/main.c
@@ -94,7 +94,12 @@ static void test_sector_read(uint8_t *buf, uint32_t num_sectors)
 	rc = read_sector(buf, 0, num_sectors);
 	zassert_equal(rc, 0, "Failed to read from sector zero");
 	/* Read from a sector in the "middle" of the disk */
-	sector = MAX(((disk_sector_count / 2) - num_sectors), 0);
+	if (disk_sector_count / 2 > num_sectors) {
+		sector = disk_sector_count / 2 - num_sectors;
+	} else {
+		sector = 0;
+	}
+
 	rc = read_sector(buf, sector, num_sectors);
 	zassert_equal(rc, 0, "Failed to read from mid disk sector");
 	/* Read from the last sector */
@@ -147,7 +152,12 @@ static void test_sector_write(uint8_t *wbuf, uint8_t *rbuf, uint32_t num_sectors
 	rc = write_sector_checked(wbuf, rbuf, 0, num_sectors);
 	zassert_equal(rc, 0, "Failed to write to sector zero");
 	/* Write to a sector in the "middle" of the disk */
-	sector = MAX(((disk_sector_count / 2) - num_sectors), 0);
+	if (disk_sector_count / 2 > num_sectors) {
+		sector = disk_sector_count / 2 - num_sectors;
+	} else {
+		sector = 0;
+	}
+
 	rc = write_sector_checked(wbuf, rbuf, sector, num_sectors);
 	zassert_equal(rc, 0, "Failed to write to mid disk sector");
 	/* Write to the last sector */


### PR DESCRIPTION
As the parameter of "MAX" is uint32, the nagetive number will be bigger than 0. The MAX function does not work as expected. So change it to if/else form.

Fixes #51146

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>