### PR TITLE
arch: smp: Allow for number of cpus to be determined at runtime

### DIFF
--- a/include/zephyr/arch/arc/arch_inlines.h
+++ b/include/zephyr/arch/arc/arch_inlines.h
@@ -36,5 +36,10 @@ static ALWAYS_INLINE uint32_t arch_proc_id(void)
 	return arch_curr_cpu()->id;
 }
 
+static ALWAYS_INLINE unsigned int arch_num_cpus(void)
+{
+	return CONFIG_MP_MAX_NUM_CPUS;
+}
+
 #endif /* !_ASMLANGUAGE */
 #endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_ARCH_INLINES_H_ */

--- a/include/zephyr/arch/arm/aarch32/arch_inlines.h
+++ b/include/zephyr/arch/arm/aarch32/arch_inlines.h
@@ -26,4 +26,9 @@ static ALWAYS_INLINE uint32_t arch_proc_id(void)
 	return arch_curr_cpu()->id;
 }
 
+static ALWAYS_INLINE unsigned int arch_num_cpus(void)
+{
+	return CONFIG_MP_MAX_NUM_CPUS;
+}
+
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_ARCH_INLINES_H */

--- a/include/zephyr/arch/arm64/arch_inlines.h
+++ b/include/zephyr/arch/arm64/arch_inlines.h
@@ -33,5 +33,10 @@ static ALWAYS_INLINE uint32_t arch_proc_id(void)
 	return (uint32_t)cpu_mpid;
 }
 
+static ALWAYS_INLINE unsigned int arch_num_cpus(void)
+{
+	return CONFIG_MP_MAX_NUM_CPUS;
+}
+
 #endif /* !_ASMLANGUAGE */
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM64_ARCH_INLINES_H */

--- a/include/zephyr/arch/riscv/arch_inlines.h
+++ b/include/zephyr/arch/riscv/arch_inlines.h
@@ -30,5 +30,10 @@ static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 	return &_kernel.cpus[arch_proc_id()];
 }
 
+static ALWAYS_INLINE unsigned int arch_num_cpus(void)
+{
+	return CONFIG_MP_MAX_NUM_CPUS;
+}
+
 #endif /* !_ASMLANGUAGE */
 #endif /* ZEPHYR_INCLUDE_ARCH_RISCV_ARCH_INLINES_H_ */

--- a/include/zephyr/arch/x86/arch_inlines.h
+++ b/include/zephyr/arch/x86/arch_inlines.h
@@ -35,6 +35,11 @@ static ALWAYS_INLINE uint32_t arch_proc_id(void)
 	return arch_curr_cpu()->id;
 }
 
+static ALWAYS_INLINE unsigned int arch_num_cpus(void)
+{
+	return CONFIG_MP_MAX_NUM_CPUS;
+}
+
 #endif /* CONFIG_X86_64 */
 
 #endif /* !_ASMLANGUAGE */

--- a/include/zephyr/arch/xtensa/arch_inlines.h
+++ b/include/zephyr/arch/xtensa/arch_inlines.h
@@ -50,6 +50,11 @@ static ALWAYS_INLINE uint32_t arch_proc_id(void)
 	return prid;
 }
 
+static ALWAYS_INLINE unsigned int arch_num_cpus(void)
+{
+	return CONFIG_MP_MAX_NUM_CPUS;
+}
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_ARCH_INLINES_H_ */

--- a/include/zephyr/sys/arch_interface.h
+++ b/include/zephyr/sys/arch_interface.h
@@ -459,6 +459,17 @@ static inline uint32_t arch_proc_id(void);
  * This will invoke z_sched_ipi() on other CPUs in the system.
  */
 void arch_sched_ipi(void);
+
+/**
+ * @brief Returns the number of CPUs
+ *
+ * For most systems this will be the same as CONFIG_MP_MAX_NUM_CPUS,
+ * however some systems may determine this at runtime instead.
+ *
+ * @return the number of CPUs
+ */
+static inline unsigned int arch_num_cpus(void);
+
 #endif /* CONFIG_SMP */
 
 /** @} */

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -879,6 +879,14 @@ config MP_NUM_CPUS
 	  Number of multiprocessing-capable cores available to the
 	  multicpu API and SMP features.
 
+config MP_MAX_NUM_CPUS
+	int "Maximum number of CPUs/cores"
+	default MP_NUM_CPUS
+	range 1 4
+	help
+	  Maximum number of multiprocessing-capable cores available to the
+	  multicpu API and SMP features.
+
 config SCHED_IPI_SUPPORTED
 	bool
 	help


### PR DESCRIPTION
Introduce a Kconfig (MP_MAX_NUM_CPUS) and an api arch_num_cpus() to allow for systems that might determine the number of CPUs available to Zephyr at runtime.

CONFIG_MP_MAX_NUM_CPUS is intented to be use for any array initialization and such that need to occur at build time.  For most systems arch_num_cpus() will just report the value of CONFIG_MP_MAX_NUM_CPUS.

The intent is to phase out CONFIG_NP_NUM_CPUS.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>