### PR TITLE
samples: fat_fs: update overlays for nrf52840 and esp_wrover_kit

### DIFF
--- a/samples/subsys/fs/fat_fs/boards/esp_wrover_kit.overlay
+++ b/samples/subsys/fs/fat_fs/boards/esp_wrover_kit.overlay
@@ -23,9 +23,13 @@
 	cs-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 
 	sdhc0: sdhc@0 {
-		compatible = "zephyr,mmc-spi-slot";
+		compatible = "zephyr,sdhc-spi-slot";
 		reg = <0>;
 		status = "okay";
 		spi-max-frequency = <400000>;
+		mmc {
+                    compatible = "zephyr,sdmmc-disk";
+                    status = "okay";
+                };
         };
 };

--- a/samples/subsys/fs/fat_fs/boards/nrf52840_blip.overlay
+++ b/samples/subsys/fs/fat_fs/boards/nrf52840_blip.overlay
@@ -9,9 +9,13 @@
         cs-gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
 
         sdhc0: sdhc@0 {
-                compatible = "zephyr,mmc-spi-slot";
+                compatible = "zephyr,sdhc-spi-slot";
                 reg = <0>;
                 status = "okay";
+                mmc {
+                    compatible = "zephyr,sdmmc-disk";
+                    status = "okay";
+                };
                 spi-max-frequency = <24000000>;
         };
 };


### PR DESCRIPTION
Update nrf52840 and esp_wrover overlays to use new sdmmc bindings.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>