### PR TITLE
manifest: update hal atmel

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: 43c73d862a78cd5a18a6e24b58cf6980016dbe9e
+      revision: pull/27/head
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
Update hal atmel intruduces c20/c21 series support.

Signed-off-by: Kamil Serwus <kserwus@gmail.com>