### PR TITLE
Pre-zync synchronization fixes

### DIFF
--- a/include/zephyr/net/ethernet_bridge.h
+++ b/include/zephyr/net/ethernet_bridge.h
@@ -34,6 +34,7 @@ struct eth_bridge {
 	struct k_mutex lock;
 	sys_slist_t interfaces;
 	sys_slist_t listeners;
+	bool initialized;
 };
 
 #define ETH_BRIDGE_INITIALIZER(obj) \

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -136,7 +136,7 @@ struct k_sem *bt_conn_get_pkts(struct bt_conn *conn)
 	 * dedicated ISO buffers.
 	 */
 	if (conn->type == BT_CONN_TYPE_ISO) {
-		if (bt_dev.le.iso_mtu && bt_dev.le.iso_pkts.limit) {
+		if (bt_dev.le.iso_mtu && bt_dev.le.iso_limit != 0) {
 			return &bt_dev.le.iso_pkts;
 		}
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2618,6 +2618,7 @@ static void read_buffer_size_v2_complete(struct net_buf *buf)
 		bt_dev.le.iso_mtu);
 
 	k_sem_init(&bt_dev.le.iso_pkts, rp->iso_max_num, rp->iso_max_num);
+	bt_dev.le.iso_limit = rp->iso_max_num;
 #endif /* CONFIG_BT_ISO */
 }
 

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -242,6 +242,7 @@ struct bt_dev_le {
 #endif /* CONFIG_BT_CONN */
 #if defined(CONFIG_BT_ISO)
 	uint16_t		iso_mtu;
+	uint8_t			iso_limit;
 	struct k_sem		iso_pkts;
 #endif /* CONFIG_BT_ISO */
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -732,7 +732,7 @@ static uint16_t iso_chan_max_data_len(const struct bt_iso_chan *chan,
 	max_data_len = chan->qos->tx->sdu;
 
 	/* Ensure that the SDU fits when using all the buffers */
-	max_controller_data_len = bt_dev.le.iso_mtu * bt_dev.le.iso_pkts.limit;
+	max_controller_data_len = bt_dev.le.iso_mtu * bt_dev.le.iso_limit;
 
 	/* Update the max_data_len to take the max_controller_data_len into account */
 	max_data_len = MIN(max_data_len, max_controller_data_len);

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -876,10 +876,13 @@ struct net_route_entry_mcast *net_route_mcast_add(struct net_if *iface,
 {
 	int i;
 
+	k_mutex_lock(&lock, K_FOREVER);
+
 	if ((!net_if_flag_is_set(iface, NET_IF_FORWARD_MULTICASTS)) ||
 			(!net_ipv6_is_addr_mcast(group)) ||
 			(net_ipv6_is_addr_mcast_iface(group)) ||
 			(net_ipv6_is_addr_mcast_link(group))) {
+		k_mutex_unlock(&lock);
 		return NULL;
 	}
 
@@ -898,6 +901,7 @@ struct net_route_entry_mcast *net_route_mcast_add(struct net_if *iface,
 		}
 	}
 
+	k_mutex_unlock(&lock);
 	return NULL;
 }
 

--- a/subsys/portability/cmsis_rtos_v1/cmsis_mutex.c
+++ b/subsys/portability/cmsis_rtos_v1/cmsis_mutex.c
@@ -61,12 +61,12 @@ osStatus osMutexWait(osMutexId mutex_id, uint32_t timeout)
 		status = k_mutex_lock(mutex, K_MSEC(timeout));
 	}
 
-	if (status == -EBUSY) {
-		return osErrorResource;
-	} else if (status == -EAGAIN) {
+	if (timeout != 0 && (status == -EAGAIN || status == -EBUSY)) {
 		return osErrorTimeoutResource;
-	} else {
+	} else if (status == 0) {
 		return osOK;
+	} else {
+		return osErrorResource;
 	}
 }
 
@@ -85,12 +85,9 @@ osStatus osMutexRelease(osMutexId mutex_id)
 		return osErrorISR;
 	}
 
-	/* Mutex was not obtained before or was not owned by current thread */
-	if ((mutex->lock_count == 0) || (mutex->owner != _current)) {
+	if (k_mutex_unlock(mutex) != 0) {
 		return osErrorResource;
 	}
-
-	k_mutex_unlock(mutex);
 
 	return osOK;
 }

--- a/subsys/portability/cmsis_rtos_v1/cmsis_semaphore.c
+++ b/subsys/portability/cmsis_rtos_v1/cmsis_semaphore.c
@@ -69,8 +69,10 @@ int32_t osSemaphoreWait(osSemaphoreId semaphore_id, uint32_t timeout)
 	 */
 	if (status == 0) {
 		return k_sem_count_get(semaphore) + 1;
-	} else {
+	} else if (status == -EBUSY || status == -EAGAIN) {
 		return 0;
+	} else {
+		return -1;
 	}
 }
 

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -1308,8 +1308,11 @@ static bool try_queue_no_yield(struct k_work_q *wq)
 /* Verify that no-yield policy works */
 ZTEST(work_1cpu, test_1cpu_queue_no_yield)
 {
+	/* This test needs two slots available in the sem! */
+	k_sem_init(&sync_sem, 0, 2);
 	zassert_equal(try_queue_no_yield(&coophi_queue), true);
 	zassert_equal(try_queue_no_yield(&cooplo_queue), false);
+	k_sem_init(&sync_sem, 0, 1);
 }
 
 /* Basic functionality with the system work queue. */

--- a/tests/net/lib/dns_addremove/src/main.c
+++ b/tests/net/lib/dns_addremove/src/main.c
@@ -157,6 +157,15 @@ static void *test_init(void)
 {
 	struct net_if_addr *ifaddr;
 
+#if defined(CONFIG_NET_IPV4)
+	dns_resolve_init(&resv_ipv4, NULL, NULL);
+	dns_resolve_init(&resv_ipv4_2, NULL, NULL);
+#endif
+#if defined(CONFIG_NET_IPV6)
+	dns_resolve_init(&resv_ipv6, NULL, NULL);
+	dns_resolve_init(&resv_ipv6_2, NULL, NULL);
+#endif
+
 	iface1 = net_if_get_by_index(0);
 	zassert_is_null(iface1, "iface1");
 


### PR DESCRIPTION
Pushing up some early fixes from the Zync work to make review easier for the final PR.  These are all genuine mixups, bugs or misfeatures in the existing code that don't have anything to do with zync other than that's how they were discovered.  In most cases the impact seems to have been benign, though the broken locking in the network and bluetooth code looks like the kind of thing security folks would worry about.

They aren't otherwise related to each other, but I have them all in one PR for my own convenience.  Hopefully they won't be controversial or involve much discussion, but if there's desire these can be split up as needed.
