### PR TITLE
twister: count errors identified during evaluation of tests

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -316,6 +316,7 @@ if __name__ == "__main__":
 
     args = parse_args()
     files = []
+    errors = 0
     if args.commits:
         repo = Repo(repository_path)
         commit = repo.git.diff("--name-only", args.commits)
@@ -342,11 +343,12 @@ if __name__ == "__main__":
         n = ts.get("name")
         a = ts.get("arch")
         p = ts.get("platform")
+        if ts.get('status') == 'error':
+            logging.info(f"Error found: {n} on {p} ({ts.get('reason')})")
+            errors += 1
         if (n, a, p,) not in dup_free_set:
             dup_free.append(ts)
             dup_free_set.add((n, a, p,))
-        else:
-            logging.info(f"skipped {n} on {p}")
 
     logging.info(f'Total tests to be run: {len(dup_free)}')
     with open(".testplan", "w") as tp:
@@ -376,3 +378,5 @@ if __name__ == "__main__":
         data['testsuites'] = dup_free
         with open(args.output_file, 'w', newline='') as json_file:
             json.dump(data, json_file, indent=4, separators=(',',':'))
+
+    sys.exit(errors)

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -943,6 +943,8 @@ class TwisterRunner:
                 self.results.skipped_filter += 1
                 self.results.skipped_configs += 1
                 self.results.skipped_cases += len(instance.testsuite.testcases)
+            elif instance.status == 'error':
+                self.results.error += 1
 
     def update_counting_after_pipeline(self):
         '''

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -51,8 +51,10 @@ class Filters:
     TESTSUITE = 'testsuite filter'
     # filters realted to platform definition
     PLATFORM = 'Platform related filter'
-    # in case a testcase was quarantined.
+    # in case a test suite was quarantined.
     QUARENTINE = 'Quarantine filter'
+    # in case a test suite is skipped intentionally .
+    SKIP = 'Skip filter'
 
 
 class TestPlan:
@@ -663,7 +665,7 @@ class TestPlan:
                     instance.add_filter("Not part of integration platforms", Filters.TESTSUITE)
 
                 if ts.skip:
-                    instance.add_filter("Skip filter", Filters.TESTSUITE)
+                    instance.add_filter("Skip filter", Filters.SKIP)
 
                 if tag_filter and not ts.tags.intersection(tag_filter):
                     instance.add_filter("Command line testsuite tag filter", Filters.CMD_LINE)
@@ -784,7 +786,7 @@ class TestPlan:
                 and "Quarantine" not in filtered_instance.reason:
                 # Do not treat this as error if filter type is command line
                 filters = {t['type'] for t in filtered_instance.filters}
-                if Filters.CMD_LINE in filters:
+                if Filters.CMD_LINE in filters or Filters.SKIP in filters:
                     continue
                 filtered_instance.status = "error"
                 filtered_instance.reason += " but is one of the integration platforms"

--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -387,7 +387,7 @@ tests:
   logging.log_api_deferred_override_level.tagged_args:
     # Testing on selected platforms as it enables all logs in the application
     # and it cannot be handled on many platforms.
-    platform_allow: qemu_cortex_m3 qemu_cortex_a9
+    platform_allow: qemu_cortex_m3 qemu_cortex_a9 native_posix
     toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
@@ -397,7 +397,7 @@ tests:
   logging.log_api_deferred_override_level_rt_filtering.tagged_args:
     # Testing on selected platforms as it enables all logs in the application
     # and it cannot be handled on many platforms.
-    platform_allow: qemu_cortex_m3 qemu_cortex_a9
+    platform_allow: qemu_cortex_m3 qemu_cortex_a9 native_posix
     toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y


### PR DESCRIPTION
Some tests report errors based on configuration, those need to be
captured.

Fixes #51202.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
