### PR TITLE
doc: Add missing kconfig option prefix

### DIFF
--- a/doc/hardware/peripherals/flash.rst
+++ b/doc/hardware/peripherals/flash.rst
@@ -11,7 +11,7 @@ Overview
 Offsets used by the user API are expressed in relation to
 the flash memory beginning address. This rule shall be applied to
 all flash controller regular memory that layout is accessible via
-API for retrieving the layout of pages (see option:`CONFIG_FLASH_PAGE_LAYOUT`).
+API for retrieving the layout of pages (see :kconfig:option:`CONFIG_FLASH_PAGE_LAYOUT`).
 
 An exception from the rule may be applied to a vendor-specific flash
 dedicated-purpose region (such a region obviously can't be covered under

--- a/doc/kernel/usermode/memory_domain.rst
+++ b/doc/kernel/usermode/memory_domain.rst
@@ -305,7 +305,7 @@ There are a few memory partitions which are pre-defined by the system:
 
  - ``z_libc_partition`` - Contains globals required by the C library and runtime.
    Required when using either the Minimal C library or the Newlib C Library.
-   Required when option:`CONFIG_STACK_CANARIES` is enabled.
+   Required when :kconfig:option:`CONFIG_STACK_CANARIES` is enabled.
 
 Library-specific partitions are listed in ``include/app_memory/partitions.h``.
 For example, to use the MBEDTLS library from user mode, the


### PR DESCRIPTION
Kconfig options have to be prefixed with :kconfig:option: in order to appear as links in generated html output.

Signed-off-by: Tomasz Moń <tomasz.mon@nordicsemi.no>