### PR TITLE
net: lwm2m: Rename timer object instance create function

### DIFF
--- a/subsys/net/lib/lwm2m/ipso_timer.c
+++ b/subsys/net/lib/lwm2m/ipso_timer.c
@@ -275,7 +275,7 @@ static int timer_trigger_cb(uint16_t obj_inst_id,
 	return start_timer(&timer_data[i]);
 }
 
-static struct lwm2m_engine_obj_inst *timer_create(uint16_t obj_inst_id)
+static struct lwm2m_engine_obj_inst *timer_inst_create(uint16_t obj_inst_id)
 {
 	int index, avail = -1, i = 0, j = 0;
 
@@ -362,7 +362,7 @@ static int ipso_timer_init(const struct device *dev)
 	timer.fields = fields;
 	timer.field_count = ARRAY_SIZE(fields);
 	timer.max_instance_count = MAX_INSTANCE_COUNT;
-	timer.create_cb = timer_create;
+	timer.create_cb = timer_inst_create;
 	lwm2m_register_obj(&timer);
 
 	return 0;


### PR DESCRIPTION
There is a regression with `ipso_timer.c`. The function `timer_create` is declared in POSIX `time.h` as well as a static function in `ipso_timer.c` with different signatures and purposes.

The issue was introduced with commit 73a637eda003dff929d2023ce33f45337872117f when first including`timer.h` into `lwm2ms.h`.

**Steps to reproduce:** Build lwm2m sample for the `native_posix` board:
```
west build -d build -b native_posix -palways zephyr/samples/net/lwm2m_client
```

This changes the naming convention used in most of the IPSO objects `lwm2m_engine_obj` `create_db` callback. If requested I can also refactor this for all IPSO objects in the form of `create_inst_<object_name>` within this PR.