### PR TITLE
net: if: Improve interface status reporting

### DIFF
--- a/drivers/ethernet/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa_ksz8xxx.c
@@ -998,7 +998,7 @@ static void dsa_iface_init(struct net_if *iface)
 	}
 
 	pdev->iface_init_count++;
-	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	net_if_carrier_off(iface);
 
 	/*
 	 * Start DSA work to monitor status of ports (read from switch IC)

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -563,7 +563,7 @@ static void enc424j600_iface_init(struct net_if *iface)
 	context->iface = iface;
 	ethernet_init(iface);
 
-	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	net_if_carrier_off(iface);
 	context->iface_initialized = true;
 }
 

--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -295,7 +295,7 @@ static void eth_esp32_iface_init(struct net_if *iface)
 	}
 
 	/* Do not start the interface until PHY link is up */
-	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	net_if_carrier_off(iface);
 }
 
 static const struct ethernet_api eth_esp32_api = {

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -519,7 +519,7 @@ static void eth_iface_init(struct net_if *iface)
 	dev_data->link_up = false;
 	ethernet_init(iface);
 
-	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	net_if_carrier_off(iface);
 
 	/* Generate MAC address, possibly used for filtering */
 	generate_mac(dev_data->mac_addr);

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1203,7 +1203,7 @@ static void eth_iface_init(struct net_if *iface)
 	dsa_register_master_tx(iface, &eth_tx);
 #endif
 	ethernet_init(iface);
-	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	net_if_carrier_off(iface);
 
 	context->config_func();
 }

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1964,7 +1964,7 @@ static void eth0_iface_init(struct net_if *iface)
 	}
 
 	/* Do not start the interface until PHY link is up */
-	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	net_if_carrier_off(iface);
 
 	init_done = true;
 }

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -956,7 +956,7 @@ static void eth_iface_init(struct net_if *iface)
 
 	ethernet_init(iface);
 
-	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	net_if_carrier_off(iface);
 
 	if (is_first_init) {
 		const struct eth_stm32_hal_dev_cfg *cfg = dev->config;

--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -226,7 +226,7 @@ static void eth_xlnx_gem_iface_init(struct net_if *iface)
 	dev_data->iface = iface;
 	net_if_set_link_addr(iface, dev_data->mac_addr, 6, NET_LINK_ETHERNET);
 	ethernet_init(iface);
-	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	net_if_carrier_off(iface);
 
 	/*
 	 * Initialize the (delayed) work items for RX pending, TX done

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1271,7 +1271,7 @@ static void wncm14a2a_modem_reset(void)
 	int ret = 0, retry_count = 0, counter = 0;
 
 	/* bring down network interface */
-	net_if_flag_clear(ictx.iface, NET_IF_UP);
+	net_if_carrier_off(ictx.iface);
 
 restart:
 	/* stop RSSI delay work */
@@ -1372,7 +1372,7 @@ restart:
 	}
 
 	/* Set iface up */
-	net_if_up(ictx.iface);
+	net_if_carrier_on(ictx.iface);
 
 error:
 	return;

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -954,14 +954,14 @@ use_random_mac:
 
 	memset(ppp->buf, 0, sizeof(ppp->buf));
 
-	/* If we have a GSM modem with PPP support or interface autostart is disabled
-	 * from Kconfig, then do not start the interface automatically but only
-	 * after the modem is ready or when manually started.
+	/* If the interface autostart is disabled from Kconfig, then do not
+	 * start the interface automatically but only after manually started.
 	 */
-	if (IS_ENABLED(CONFIG_MODEM_GSM_PPP) ||
-	    IS_ENABLED(CONFIG_PPP_NET_IF_NO_AUTO_START)) {
+	if (IS_ENABLED(CONFIG_PPP_NET_IF_NO_AUTO_START)) {
 		net_if_flag_set(iface, NET_IF_NO_AUTO_START);
 	}
+
+	net_if_carrier_off(iface);
 }
 
 #if defined(CONFIG_NET_STATISTICS_PPP)

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -429,7 +429,7 @@ static void esp32_wifi_init(struct net_if *iface)
 	net_if_set_link_addr(iface, dev_data->mac_addr, 6, NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
-	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	net_if_carrier_off(iface);
 
 	esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, eth_esp32_rx);
 }

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -700,8 +700,9 @@ MODEM_CMD_DEFINE(on_cmd_ready)
 					    cmd_handler_data);
 	k_sem_give(&dev->sem_if_ready);
 
-	if (net_if_is_up(dev->net_iface)) {
-		net_if_down(dev->net_iface);
+
+	if (net_if_is_carrier_ok(dev->net_iface)) {
+		net_if_carrier_off(dev->net_iface);
 		LOG_ERR("Unexpected reset");
 	}
 
@@ -1037,15 +1038,15 @@ static void esp_init_work(struct k_work *work)
 
 	LOG_INF("ESP Wi-Fi ready");
 
-	net_if_up(dev->net_iface);
+	net_if_carrier_on(dev->net_iface);
 }
 
 static int esp_reset(const struct device *dev)
 {
 	struct esp_data *data = dev->data;
 
-	if (net_if_is_up(data->net_iface)) {
-		net_if_down(data->net_iface);
+	if (net_if_is_carrier_ok(data->net_iface)) {
+		net_if_carrier_off(data->net_iface);
 	}
 
 #if DT_INST_NODE_HAS_PROP(0, power_gpios)
@@ -1083,7 +1084,7 @@ static int esp_reset(const struct device *dev)
 
 static void esp_iface_init(struct net_if *iface)
 {
-	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	net_if_carrier_off(iface);
 	esp_offload_init(iface);
 }
 

--- a/include/zephyr/net/net_event.h
+++ b/include/zephyr/net/net_event.h
@@ -36,6 +36,9 @@ extern "C" {
 enum net_event_if_cmd {
 	NET_EVENT_IF_CMD_DOWN = 1,
 	NET_EVENT_IF_CMD_UP,
+	NET_EVENT_IF_CMD_ADMIN_DOWN,
+	NET_EVENT_IF_CMD_ADMIN_UP,
+
 };
 
 #define NET_EVENT_IF_DOWN				\
@@ -43,6 +46,13 @@ enum net_event_if_cmd {
 
 #define NET_EVENT_IF_UP					\
 	(_NET_EVENT_IF_BASE | NET_EVENT_IF_CMD_UP)
+
+#define NET_EVENT_IF_ADMIN_DOWN				\
+	(_NET_EVENT_IF_BASE | NET_EVENT_IF_CMD_ADMIN_DOWN)
+
+#define NET_EVENT_IF_ADMIN_UP				\
+	(_NET_EVENT_IF_BASE | NET_EVENT_IF_CMD_ADMIN_UP)
+
 
 /* IPv6 Events */
 #define _NET_IPV6_LAYER		NET_MGMT_LAYER_L3

--- a/include/zephyr/net/virtual.h
+++ b/include/zephyr/net/virtual.h
@@ -237,8 +237,8 @@ static inline void net_virtual_init(struct net_if *iface)
 #endif
 
 /**
- * @brief Take virtual network interface down. This is called
- *        if the underlying interface is going down.
+ * @brief Update the carrier state of the virtual network interface.
+ *        This is called if the underlying interface is going down.
  *
  * @param iface Network interface
  */
@@ -246,6 +246,21 @@ static inline void net_virtual_init(struct net_if *iface)
 void net_virtual_disable(struct net_if *iface);
 #else
 static inline void net_virtual_disable(struct net_if *iface)
+{
+	ARG_UNUSED(iface);
+}
+#endif
+
+/**
+ * @brief Update the carrier state of the virtual network interface.
+ *        This is called if the underlying interface is going up.
+ *
+ * @param iface Network interface
+ */
+#if defined(CONFIG_NET_L2_VIRTUAL)
+void net_virtual_enable(struct net_if *iface);
+#else
+static inline void net_virtual_enable(struct net_if *iface)
 {
 	ARG_UNUSED(iface);
 }

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4015,6 +4015,14 @@ void net_if_foreach(net_if_cb_t cb, void *user_data)
 	}
 }
 
+static inline bool is_iface_offloaded(struct net_if *iface)
+{
+	return (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
+		net_if_is_ip_offloaded(iface)) ||
+	       (IS_ENABLED(CONFIG_NET_SOCKETS_OFFLOAD) &&
+		net_if_is_socket_offloaded(iface));
+}
+
 int net_if_up(struct net_if *iface)
 {
 	int status = 0;
@@ -4028,10 +4036,7 @@ int net_if_up(struct net_if *iface)
 		goto out;
 	}
 
-	if ((IS_ENABLED(CONFIG_NET_OFFLOAD) &&
-	     net_if_is_ip_offloaded(iface)) ||
-	    (IS_ENABLED(CONFIG_NET_SOCKETS_OFFLOAD) &&
-	     net_if_is_socket_offloaded(iface))) {
+	if (is_iface_offloaded(iface)) {
 		net_if_flag_set(iface, NET_IF_UP);
 		goto notify;
 	}
@@ -4107,7 +4112,7 @@ int net_if_down(struct net_if *iface)
 	leave_mcast_all(iface);
 	leave_ipv4_mcast_all(iface);
 
-	if (net_if_is_ip_offloaded(iface)) {
+	if (is_iface_offloaded(iface)) {
 		goto done;
 	}
 

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4189,19 +4189,6 @@ out:
 	return status;
 }
 
-void net_if_carrier_down(struct net_if *iface)
-{
-	NET_DBG("iface %p", iface);
-
-	k_mutex_lock(&lock, K_FOREVER);
-
-	net_if_flag_clear(iface, NET_IF_UP);
-
-	net_mgmt_event_notify(NET_EVENT_IF_DOWN, iface);
-
-	k_mutex_unlock(&lock);
-}
-
 int net_if_down(struct net_if *iface)
 {
 	int status = 0;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4030,6 +4030,7 @@ static void notify_iface_up(struct net_if *iface)
 {
 	net_if_flag_set(iface, NET_IF_RUNNING);
 	net_mgmt_event_notify(NET_EVENT_IF_UP, iface);
+	net_virtual_enable(iface);
 
 	/* If the interface is only having point-to-point traffic then we do
 	 * not need to run DAD etc for it.
@@ -4045,6 +4046,7 @@ static void notify_iface_down(struct net_if *iface)
 {
 	net_if_flag_clear(iface, NET_IF_RUNNING);
 	net_mgmt_event_notify(NET_EVENT_IF_DOWN, iface);
+	net_virtual_disable(iface);
 
 	if (!is_iface_offloaded(iface) &&
 	    !(l2_flags_get(iface) & NET_L2_POINT_TO_POINT)) {
@@ -4230,8 +4232,6 @@ int net_if_down(struct net_if *iface)
 	if (status < 0) {
 		goto out;
 	}
-
-	net_virtual_disable(iface);
 
 done:
 	net_if_flag_clear(iface, NET_IF_UP);

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -243,7 +243,7 @@ static bool net_if_tx(struct net_if *iface, struct net_pkt *pkt)
 
 	context = net_pkt_context(pkt);
 
-	if (net_if_flag_is_set(iface, NET_IF_UP)) {
+	if (net_if_flag_is_set(iface, NET_IF_LOWER_UP)) {
 		if (IS_ENABLED(CONFIG_NET_TCP) &&
 		    net_pkt_family(pkt) != AF_UNSPEC) {
 			net_pkt_set_queued(pkt, false);
@@ -445,7 +445,7 @@ enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt)
 
 	k_mutex_lock(&lock, K_FOREVER);
 
-	if (!net_if_flag_is_set(iface, NET_IF_UP) ||
+	if (!net_if_flag_is_set(iface, NET_IF_LOWER_UP) ||
 	    net_if_flag_is_set(iface, NET_IF_SUSPENDED)) {
 		/* Drop packet if interface is not up */
 		NET_WARN("iface %p is down", iface);

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -44,7 +44,6 @@
 
 extern void net_if_init(void);
 extern void net_if_post_init(void);
-extern void net_if_carrier_down(struct net_if *iface);
 extern void net_if_stats_reset(struct net_if *iface);
 extern void net_if_stats_reset_all(void);
 extern void net_process_rx_packet(struct net_pkt *pkt);

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -195,8 +195,8 @@ static void ipsp_connected(struct bt_l2cap_chan *chan)
 	net_ipv6_nbr_add(conn->iface, &in6, &ll, false,
 			 NET_IPV6_NBR_STATE_STATIC);
 
-	/* Set iface up */
-	net_if_up(conn->iface);
+	/* Leave dormant state (iface goes up if set to admin up) */
+	net_if_dormant_off(conn->iface);
 }
 
 static void ipsp_disconnected(struct bt_l2cap_chan *chan)
@@ -205,8 +205,8 @@ static void ipsp_disconnected(struct bt_l2cap_chan *chan)
 
 	NET_DBG("Channel %p disconnected", chan);
 
-	/* Set iface down */
-	net_if_carrier_down(conn->iface);
+	/* Enter dormant state (iface goes down) */
+	net_if_dormant_on(conn->iface);
 
 #if defined(CONFIG_NET_L2_BT_MGMT)
 	if (chan->conn != default_conn) {
@@ -301,7 +301,7 @@ static void bt_iface_init(struct net_if *iface)
 
 	conn->iface = iface;
 
-	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	net_if_dormant_on(iface);
 
 #if defined(CONFIG_NET_L2_BT_ZEP1656)
 	/* Workaround Linux bug, see:

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -1065,10 +1065,10 @@ static void carrier_on_off(struct k_work *work)
 
 	if (eth_carrier_up) {
 		ethernet_mgmt_raise_carrier_on_event(ctx->iface);
-		net_if_up(ctx->iface);
+		net_if_carrier_on(ctx->iface);
 	} else {
 		ethernet_mgmt_raise_carrier_off_event(ctx->iface);
-		net_if_carrier_down(ctx->iface);
+		net_if_carrier_off(ctx->iface);
 	}
 }
 

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -210,7 +210,7 @@ static void lcp_finished(struct ppp_fsm *fsm)
 	/* take the remainder down */
 	ppp_mgmt_raise_carrier_off_event(ctx->iface);
 
-	net_if_carrier_down(ctx->iface);
+	net_if_carrier_off(ctx->iface);
 }
 
 #if defined(CONFIG_NET_L2_PPP_OPTION_MRU)

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -282,7 +282,7 @@ static void carrier_on_off(struct k_work *work)
 
 	if (ppp_carrier_up) {
 		ppp_mgmt_raise_carrier_on_event(ctx->iface);
-		net_if_up(ctx->iface);
+		net_if_carrier_on(ctx->iface);
 	} else {
 		if (ppp_lcp) {
 			ppp_lcp->close(ctx, "Shutdown");
@@ -291,7 +291,7 @@ static void carrier_on_off(struct k_work *work)
 			ppp_change_phase(ctx, PPP_DEAD);
 
 			ppp_mgmt_raise_carrier_off_event(ctx->iface);
-			net_if_carrier_down(ctx->iface);
+			net_if_carrier_off(ctx->iface);
 		}
 	}
 }

--- a/subsys/usb/device/class/netusb/netusb.c
+++ b/subsys/usb/device/class/netusb/netusb.c
@@ -99,7 +99,7 @@ void netusb_enable(const struct netusb_function *func)
 
 	netusb.func = func;
 
-	net_if_up(netusb.iface);
+	net_if_carrier_on(netusb.iface);
 	netusb_connect_media();
 }
 
@@ -114,7 +114,7 @@ void netusb_disable(void)
 	netusb.func = NULL;
 
 	netusb_disconnect_media();
-	net_if_down(netusb.iface);
+	net_if_carrier_off(netusb.iface);
 }
 
 bool netusb_enabled(void)
@@ -131,7 +131,7 @@ static void netusb_init(struct net_if *iface)
 	netusb.iface = iface;
 
 	ethernet_init(iface);
-	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	net_if_carrier_off(iface);
 
 	net_if_set_link_addr(iface, mac, sizeof(mac), NET_LINK_ETHERNET);
 

--- a/tests/net/virtual/src/main.c
+++ b/tests/net/virtual/src/main.c
@@ -546,7 +546,7 @@ static bool add_to_arp(struct net_if *iface, struct in_addr *addr)
 #endif
 }
 
-ZTEST(net_virtual, test_virtual_1_attach_and_detach)
+ZTEST(net_virtual, test_virtual_01_attach_and_detach)
 {
 	struct net_if *iface = virtual_interfaces[0];
 	int ret;
@@ -578,7 +578,76 @@ ZTEST(net_virtual, test_virtual_1_attach_and_detach)
 		      net_if_get_by_iface(iface));
 }
 
-ZTEST(net_virtual, test_virtual_2_set_mtu)
+ZTEST(net_virtual, test_virtual_02_real_iface_down)
+{
+	struct net_if *iface = virtual_interfaces[0];
+	int ret;
+
+	/* Attach virtual interface on top of Ethernet */
+
+	ret = net_virtual_interface_attach(iface, eth_interfaces[0]);
+	zassert_equal(ret, 0, "Cannot attach %d on top of %d (%d)",
+		      net_if_get_by_iface(iface),
+		      net_if_get_by_iface(eth_interfaces[0]),
+		      ret);
+
+	zassert_false(net_if_is_up(iface),
+		      "Virtual interface %d should be down",
+		      net_if_get_by_iface(iface));
+
+	ret = net_if_up(iface);
+	zassert_equal(ret, 0, "Cannot take virtual interface %d up (%d)",
+		      net_if_get_by_iface(iface), ret);
+
+	zassert_true(net_if_is_up(iface),
+		     "Virtual interface %d should be up",
+		     net_if_get_by_iface(iface));
+	zassert_true(net_if_is_up(eth_interfaces[0]),
+		     "Real interface %d should be up",
+		     net_if_get_by_iface(iface));
+
+	/* Virtual interface should go down if the underlying iface is down */
+	ret = net_if_down(eth_interfaces[0]);
+	zassert_equal(ret, 0, "Cannot take real interface %d down (%d)",
+		      net_if_get_by_iface(eth_interfaces[0]), ret);
+
+	zassert_false(net_if_is_up(iface),
+		      "Virtual interface %d should be down",
+		      net_if_get_by_iface(iface));
+	zassert_false(net_if_is_carrier_ok(iface),
+		      "Virtual interface %d should be in carrier off",
+		      net_if_get_by_iface(iface));
+	zassert_equal(net_if_oper_state(iface), NET_IF_OPER_LOWERLAYERDOWN,
+		      "Wrong operational state on %d (%d)",
+		      net_if_get_by_iface(iface), net_if_oper_state(iface));
+
+	/* Virtual interface should be brought up if the underlying iface is
+	 * back up
+	 */
+	ret = net_if_up(eth_interfaces[0]);
+	zassert_equal(ret, 0, "Cannot take real interface %d u (%d)",
+		      net_if_get_by_iface(eth_interfaces[0]), ret);
+
+	zassert_true(net_if_is_up(iface),
+		     "Virtual interface %d should be up",
+		     net_if_get_by_iface(iface));
+	zassert_true(net_if_is_carrier_ok(iface),
+		     "Virtual interface %d should be in carrier on",
+		     net_if_get_by_iface(iface));
+
+	ret = net_virtual_interface_attach(iface,
+					   NULL);
+	zassert_equal(ret, 0, "Cannot deattach %d from %d (%d)",
+		      net_if_get_by_iface(iface),
+		      net_if_get_by_iface(eth_interfaces[0]),
+		      ret);
+
+	zassert_false(net_if_is_up(iface), "Virtual interface %d is still up",
+		      net_if_get_by_iface(iface));
+}
+
+
+ZTEST(net_virtual, test_virtual_03_set_mtu)
 {
 	struct virtual_interface_req_params params = { 0 };
 	struct net_if *iface = virtual_interfaces[0];
@@ -605,7 +674,7 @@ ZTEST(net_virtual, test_virtual_2_set_mtu)
 		      net_if_get_by_iface(iface), params.mtu, ret);
 }
 
-ZTEST(net_virtual, test_virtual_3_get_mtu)
+ZTEST(net_virtual, test_virtual_04_get_mtu)
 {
 	struct virtual_interface_req_params params = { 0 };
 	struct net_if *iface = virtual_interfaces[0];
@@ -623,7 +692,7 @@ ZTEST(net_virtual, test_virtual_3_get_mtu)
 		      net_if_get_by_iface(iface), params.mtu, MTU);
 }
 
-ZTEST(net_virtual, test_virtual_4_set_peer)
+ZTEST(net_virtual, test_virtual_05_set_peer)
 {
 	struct virtual_interface_req_params params = { 0 };
 	struct net_if *iface = virtual_interfaces[0];
@@ -668,7 +737,7 @@ ZTEST(net_virtual, test_virtual_4_set_peer)
 		      ret);
 }
 
-ZTEST(net_virtual, test_virtual_5_get_peer)
+ZTEST(net_virtual, test_virtual_06_get_peer)
 {
 	struct virtual_interface_req_params params = { 0 };
 	struct net_if *iface = virtual_interfaces[0];
@@ -697,7 +766,7 @@ ZTEST(net_virtual, test_virtual_5_get_peer)
 	}
 }
 
-ZTEST(net_virtual, test_virtual_6_verify_name)
+ZTEST(net_virtual, test_virtual_07_verify_name)
 {
 #define NAME "foobar"
 #define NAME2 "123456789"
@@ -720,7 +789,7 @@ ZTEST(net_virtual, test_virtual_6_verify_name)
 			  "Cannot get name");
 }
 
-ZTEST(net_virtual, test_virtual_7_send_data_to_tunnel)
+ZTEST(net_virtual, test_virtual_08_send_data_to_tunnel)
 {
 	struct virtual_interface_req_params params = { 0 };
 	struct net_if *iface = virtual_interfaces[0];
@@ -994,12 +1063,12 @@ static void test_virtual_recv_data_from_tunnel(int remote_ip,
 	net_context_put(udp_ctx);
 }
 
-ZTEST(net_virtual, test_virtual_8_recv_data_from_tunnel_ok)
+ZTEST(net_virtual, test_virtual_09_recv_data_from_tunnel_ok)
 {
 	test_virtual_recv_data_from_tunnel(2, true);
 }
 
-ZTEST(net_virtual, test_virtual_9_recv_data_from_tunnel_fail)
+ZTEST(net_virtual, test_virtual_10_recv_data_from_tunnel_fail)
 {
 	test_virtual_recv_data_from_tunnel(3, false);
 }


### PR DESCRIPTION
Extend interface state management as described in https://www.kernel.org/doc/html/latest/networking/operstates.html and https://www.rfc-editor.org/rfc/rfc2863.

With those changes, `net_if_up()`/`net_if_down()` are only supposed to be called by the application layer, not drivers/L2s. The existing codebase was refactored to reflect that.

Drivers/L2s have not two new flags to reflect their status - `NET_IF_LOWER_UP` and `NET_IF_DORMANT`, along with the helper functions. The combination of those two, along with the administrative state of the interface is translated into the operational state, which indicates the interface's readiness to accept application data.

Resolves #28998