### PR TITLE
drivers: uart_native_posix: Fix reading file input

### DIFF
--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -339,7 +339,7 @@ static int np_uart_stdin_poll_in(const struct device *dev,
 	}
 
 	n = read(in_f, p_char, 1);
-	if (n == -1) {
+	if ((n == -1) || (n == 0)) {
 		return -1;
 	}
 


### PR DESCRIPTION
If the read function returns value of zero, there is no more data in the file and the function should return value of -1.