### PR TITLE
include: add missing include

### DIFF
--- a/drivers/eeprom/eeprom_stm32.c
+++ b/drivers/eeprom/eeprom_stm32.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/drivers/eeprom.h>
 #include <soc.h>
+#include <zephyr/kernel.h>
 
 #define LOG_LEVEL CONFIG_EEPROM_LOG_LEVEL
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
kernel.h is missing from eeprom driver.

Signed-off-by: Marco Peter <marco.peter@joylab.ch>