### PR TITLE
doc: Verify write access in syscall example

### DIFF
--- a/doc/kernel/usermode/syscalls.rst
+++ b/doc/kernel/usermode/syscalls.rst
@@ -414,7 +414,7 @@ bytes processed. This too should use a stack copy:
 
         Z_OOPS(z_user_from_copy(&size, size_ptr, sizeof(size));
         ret = z_impl_in_out_syscall(&size);
-        *size_ptr = size;
+        Z_OOPS(z_user_to_copy(size_ptr, &size, sizeof(size)));
         return ret;
     }
 


### PR DESCRIPTION
Use z_user_to_copy() instead of directly writing to the user provided pointer to validate that the user has write permission to underlying memory location.

It is important to verify the memory not only for reads, but also for writes, as otherwise the function can be abused by usermode code to write to privileged read/write, unprivileged read-only memory partition.

Signed-off-by: Tomasz Moń <tomasz.mon@nordicsemi.no>