### PR TITLE
tests: drivers: eeprom testing on stm32 platforms

### DIFF
--- a/boards/arm/nucleo_l073rz/doc/index.rst
+++ b/boards/arm/nucleo_l073rz/doc/index.rst
@@ -100,6 +100,8 @@ The Zephyr nucleo_l073rz board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | RNG       | on-chip    | Random Number Generator             |
 +-----------+------------+-------------------------------------+
+| EEPROM    | on-chip    | eeprom                              |
++-----------+------------+-------------------------------------+
 | die-temp  | on-chip    | die temperature sensor              |
 +-----------+------------+-------------------------------------+
 

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -61,6 +61,7 @@
 		sw0 = &user_button;
 		pwm-led0 = &green_pwm_led;
 		watchdog0 = &iwdg;
+		eeprom-0 = &eeprom;
 	};
 };
 
@@ -157,5 +158,9 @@
 };
 
 &rng {
+	status = "okay";
+};
+
+&eeprom {
 	status = "okay";
 };

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
@@ -20,3 +20,4 @@ supported:
   - dac
   - pwm
   - rng
+  - eeprom

--- a/tests/drivers/eeprom/testcase.yaml
+++ b/tests/drivers/eeprom/testcase.yaml
@@ -1,6 +1,8 @@
 tests:
   peripheral.eeprom:
-    platform_allow: native_posix native_posix_64 qemu_x86
+    platform_allow: |
+      native_posix native_posix_64 qemu_x86
+      nucleo_l152re nucleo_l073rz
     tags: drivers userspace
   peripheral.eeprom.generic:
     build_only: true


### PR DESCRIPTION
Add the testcase for running the test of the
stm32 eeprom driver on stm32 platforms like the nucleo_l152re board.

This PR completes (and requires) the https://github.com/zephyrproject-rtos/zephyr/pull/51246 and should detect such failure in the future.


Signed-off-by: Francois Ramu <francois.ramu@st.com>