### PR TITLE
Bluetooh: Host: conn: Resume adv after disconn for periph role only

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1152,7 +1152,7 @@ void bt_conn_unref(struct bt_conn *conn)
 	__ASSERT(old > 0, "Conn reference counter is 0");
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->type == BT_CONN_TYPE_LE &&
-	    atomic_get(&conn->ref) == 0) {
+	    conn->role == BT_CONN_ROLE_PERIPHERAL && atomic_get(&conn->ref) == 0) {
 		bt_le_adv_resume();
 	}
 }


### PR DESCRIPTION
Zephyrs Host has by default enabled automatic resume of advertising in case of disconnection when peripheral role is enabled.

The feature becomes a bit problematic in case of multirole usage. For example assume a use case where a device is working as peripheral and central, where it may establish single connection for each role.

In case there are two connections established and connection in central role is dropped by peer, Host will automatically resume advertising. After that an application can resume scanning, e.g. in disconnected callback. That should not happen.

If one of connections was used for central role, it should not be stolen by Host to run peripheral role. Host should verify if a disconnected connection role was peripheral and then resume advertising.

This approach will not break backward compatibility and change correct resume behavior. What more, Host will follow an application decisions about use of connection objects.

Partially fixes: #50438

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>