### PR TITLE
net: shell: fix memory leak in udp_rcvd()

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -4959,6 +4959,8 @@ static void udp_rcvd(struct net_context *context, struct net_pkt *pkt,
 			PR_SHELL(udp_shell, "%02x ", byte);
 		}
 		PR_SHELL(udp_shell, "\n");
+
+		net_pkt_unref(pkt);
 	}
 }
 


### PR DESCRIPTION
Without pkt_unref(), the shell command "net udp bind" will fail to receive after a few packets ("net allocs" shows that memory is still allocated).

Signed-off-by: Andreas Müller <andreas.mueller@husqvarnagroup.com>