### PR TITLE
stm32U5 has a 12bit  adc4 instance

### DIFF
--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -110,6 +110,12 @@
 	status = "okay";
 };
 
+&adc4 {
+	pinctrl-0 = <&adc4_in18_pb0>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &iwdg {
 	status = "okay";
 };

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -95,6 +95,7 @@ static const uint32_t table_resolution[] = {
 	defined(STM32F3X_ADC_V2_5)
 	RES(12),
 #elif defined(CONFIG_SOC_SERIES_STM32U5X)
+	RES(6),
 	RES(8),
 	RES(10),
 	RES(12),
@@ -707,17 +708,20 @@ static int start_read(const struct device *dev,
 		resolution = table_resolution[0];
 		break;
 #elif defined(CONFIG_SOC_SERIES_STM32U5X)
-	case 8:
+	case 6:
 		resolution = table_resolution[0];
 		break;
-	case 10:
+	case 8:
 		resolution = table_resolution[1];
 		break;
-	case 12:
+	case 10:
 		resolution = table_resolution[2];
 		break;
-	case 14:
+	case 12:
 		resolution = table_resolution[3];
+		break;
+	case 14:
+		resolution = table_resolution[4];
 		break;
 #elif !defined(CONFIG_SOC_SERIES_STM32H7X)
 	case 6:

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -809,7 +809,15 @@ static int start_read(const struct device *dev,
 	while (LL_ADC_IsActiveFlag_CCRDY(adc) == 0) {
 	}
 	LL_ADC_ClearFlag_CCRDY(adc);
-
+#elif defined(CONFIG_SOC_SERIES_STM32U5X)
+	if (adc != ADC4) {
+		LL_ADC_REG_SetSequencerRanks(adc, table_rank[0], channel);
+		LL_ADC_REG_SetSequencerLength(adc, table_seq_len[0]);
+	} else {
+		LL_ADC_REG_SetSequencerConfigurable(adc, LL_ADC_REG_SEQ_FIXED);
+		LL_ADC_REG_SetSequencerLength(adc,
+					      BIT(__LL_ADC_CHANNEL_TO_DECIMAL_NB(channel)));
+	}
 #else
 	LL_ADC_REG_SetSequencerRanks(adc, table_rank[0], channel);
 	LL_ADC_REG_SetSequencerLength(adc, table_seq_len[0]);

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -540,6 +540,7 @@
 			status = "disabled";
 			vref-mv = <3300>;
 			#io-channel-cells = <1>;
+			has-vbat-channel;
 			has-temp-channel;
 			has-vref-channel;
 		};
@@ -551,6 +552,7 @@
 			interrupts = <113 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			has-vbat-channel;
 			has-temp-channel;
 			has-vref-channel;
 		};

--- a/samples/sensor/stm32_vbat_sensor/boards/b_u585i_iot02a.overlay
+++ b/samples/sensor/stm32_vbat_sensor/boards/b_u585i_iot02a.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Application overlay for creating vbat sensor device instance
+ */
+
+/ {
+	stm-vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <4>;
+		io-channels = <&adc4 14>;
+		status = "okay";
+	};
+};

--- a/samples/sensor/stm32_vbat_sensor/boards/nucleo_u575zi_q.overlay
+++ b/samples/sensor/stm32_vbat_sensor/boards/nucleo_u575zi_q.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Application overlay for creating vbat sensor device instance
+ */
+
+/ {
+	stm-vbat {
+		compatible = "st,stm32-vbat";
+		ratio = <4>;
+		io-channels = <&adc4 14>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Configure the ADC4 peripheral of the stm32U5 serie
-  12 bit resolution
- 19 external analog input channel
-  internal channels including temperature senor and Vbat monitoring channels

Adding an sample to measure the Vbat voltage of the stm32U5  nucleo or disco kit platforms

Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)