### PR TITLE
net: dns: Always init the resolver

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1501,5 +1501,10 @@ void dns_init_resolver(void)
 	if (ret < 0) {
 		NET_WARN("Cannot initialize DNS resolver (%d)", ret);
 	}
+#else
+	/* We must always call init even if there are no servers configured so
+	 * that DNS mutex gets initialized properly.
+	 */
+	(void)dns_resolve_init(dns_resolve_get_default(), NULL, NULL);
 #endif
 }


### PR DESCRIPTION
If user has not specified any DNS servers in
CONFIG_DNS_SERVER_IP_ADDRESSES, then the DNS resolver will not be initialized properly. So fix this by always calling dns_resolve_init() so that DNS mutex get properly initialized.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>