### PR TITLE
drivers: dma: Fix for DW DMA link list alignment

### DIFF
--- a/drivers/dma/dma_dw_common.h
+++ b/drivers/dma/dma_dw_common.h
@@ -232,7 +232,7 @@ struct dw_dma_dev_data {
 	struct dma_context dma_ctx;
 	struct dw_drv_plat_data *channel_data;
 	struct dw_dma_chan_data chan[DW_MAX_CHAN];
-	struct dw_lli lli_pool[DW_MAX_CHAN][CONFIG_DMA_DW_LLI_POOL_SIZE];
+	struct dw_lli lli_pool[DW_MAX_CHAN][CONFIG_DMA_DW_LLI_POOL_SIZE] __aligned(64);
 
 	ATOMIC_DEFINE(channels_atomic, DW_MAX_CHAN);
 };


### PR DESCRIPTION
For Intel ACE1.x the GPDMA link list structure should be aligned to 64 bytes to avoid the link list entry fetch crossing the 64 bytes address alignment.

Signed-off-by: Serhiy Katsyuba <serhiy.katsyuba@intel.com>