### PR TITLE
drivers: can: sja1000: configure PHY from devicetree

### DIFF
--- a/drivers/can/can_sja1000.h
+++ b/drivers/can/can_sja1000.h
@@ -83,8 +83,9 @@ struct can_sja1000_config {
 		.phase_seg1 = DT_PROP_OR(node_id, phase_seg1, 0),                                  \
 		.phase_seg2 = DT_PROP_OR(node_id, phase_seg2, 0),                                  \
 		.sample_point = DT_PROP_OR(node_id, sample_point, 0),                              \
-		.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(node_id, 1000000), .ocr = _ocr,      \
-		.cdr = _cdr, .custom = _custom,                                                    \
+		.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(node_id, 1000000),                   \
+		.phy = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(node_id, phys)),                           \
+		.ocr = _ocr, .cdr = _cdr, .custom = _custom,                                       \
 	}
 
 #define CAN_SJA1000_DT_CONFIG_INST_GET(inst, _custom, _read_reg, _write_reg, _ocr, _cdr)           \


### PR DESCRIPTION
The phys property was not considered during initialization of the driver config, so that the transceiver was not enabled properly in case it has an enable/standby pin.

Fixes: #51276