### PR TITLE
Various CI fixes for Oct 2022

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -24,7 +24,7 @@ jobs:
         pip3 install -U PyGithub>=1.55
 
     - name: Check out source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Run assignment script
       env:

--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -11,17 +11,13 @@ on:
       - "soc/posix/**"
       - "arch/posix/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  bluetooth-test-prep:
+  bluetooth-test:
     runs-on: ubuntu-20.04
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-  bluetooth-test-build:
-    runs-on: ubuntu-20.04
-    needs: bluetooth-test-prep
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -42,7 +42,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bluetooth-test-results
           path: |
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload Event Details
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: event
           path: |

--- a/.github/workflows/bug_snapshot.yaml
+++ b/.github/workflows/bug_snapshot.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -39,7 +39,7 @@ jobs:
           # hotfix, until we have a better way to deal with existing data
           rm -rf zephyr zephyr-testing
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -76,7 +76,7 @@ jobs:
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
           string(REPLACE "/" "_" repo ${{github.repository}})
           string(REPLACE "-" "_" repo2 ${repo})
-          message("::set-output name=repo::${repo2}")
+          file(APPEND $ENV{GITHUB_OUTPUT} "repo=${repo2}\n")
       - name: use cache
         id: cache-ccache
         uses: zephyrproject-rtos/action-s3-cache@v1
@@ -104,12 +104,12 @@ jobs:
 
           # We can limit scope to just what has changed
           if [ -s testplan.json ]; then
-            echo "::set-output name=report_needed::1";
+            echo "report_needed=1" >> $GITHUB_OUTPUT
             # Full twister but with options based on changes
             ./scripts/twister --force-color --inline-logs -M -N -v --load-tests testplan.json --retry-failed 2
           else
             # if nothing is run, skip reporting step
-            echo "::set-output name=report_needed::0";
+            echo "report_needed=0" >> $GITHUB_OUTPUT
           fi
 
       - name: ccache stats post

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -2,17 +2,13 @@ name: Build with Clang/LLVM
 
 on: pull_request_target
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  clang-build-prep:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
   clang-build:
     runs-on: zephyr_runner
-    needs: clang-build-prep
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload Unit Test Results
         if: always() && steps.twister.outputs.report_needed != 0
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Unit Test Results (Subset ${{ matrix.platform }})
           path: twister-out/twister.xml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload Unit Test Results in HTML
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: HTML Unit Test Results
           if-no-files-found: ignore

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -54,7 +54,7 @@ jobs:
         run: |
           string(REPLACE "/" "_" repo ${{github.repository}})
           string(REPLACE "-" "_" repo2 ${repo})
-          message("::set-output name=repo::${repo2}")
+          file(APPEND $ENV{GITHUB_OUTPUT} "repo=${repo2}\n")
 
       - name: use cache
         id: cache-ccache
@@ -144,8 +144,8 @@ jobs:
               set(MERGELIST "${MERGELIST} -a ${f}")
             endif()
           endforeach()
-          message("::set-output name=mergefiles::${MERGELIST}")
-          message("::set-output name=covfiles::${FILELIST}")
+          file(APPEND $ENV{GITHUB_OUTPUT} "mergefiles=${MERGELIST}\n")
+          file(APPEND $ENV{GITHUB_OUTPUT} "covfiles=${FILELIST}\n")
 
       - name: Merge coverage files
         run: |

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -34,7 +34,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Download Artifacts

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -4,19 +4,13 @@ on:
   schedule:
     - cron: '25 */3 * * 1-5'
 
-jobs:
-  codecov-prep:
-    runs-on: ubuntu-20.04
-    if: github.repository == 'zephyrproject-rtos/zephyr'
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
+jobs:
   codecov:
     runs-on: zephyr_runner
-    needs: codecov-prep
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload Coverage Results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Coverage Data (Subset ${{ matrix.platform }})
           path: coverage/reports/${{ matrix.platform }}.info

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -14,7 +14,7 @@ jobs:
         fetch-depth: 0
 
     - name: cache-pip
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-doc-pip

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -8,7 +8,7 @@ jobs:
     name: Run coding guidelines checks on patch series (PR)
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -8,7 +8,7 @@ jobs:
     name: Check MAINTAINERS file
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -28,7 +28,7 @@ jobs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Checkout the code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -34,7 +34,7 @@ jobs:
         fetch-depth: 0
 
     - name: cache-pip
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-doc-pip

--- a/.github/workflows/daily_test_version.yml
+++ b/.github/workflows/daily_test_version.yml
@@ -28,7 +28,7 @@ jobs:
         pip3 install gitpython
 
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -29,7 +29,7 @@ jobs:
             python-version: 3.6
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -36,7 +36,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux
       if: startsWith(runner.os, 'Linux')
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}
@@ -44,7 +44,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}
     - name: cache-pip-mac
       if: startsWith(runner.os, 'macOS')
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/Library/Caches/pip
         # Trailing '-' was just to get a different cache name
@@ -53,7 +53,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
     - name: cache-pip-win
       if: startsWith(runner.os, 'Windows')
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -31,7 +31,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -107,7 +107,7 @@ jobs:
         echo "Documentation will be available shortly at: ${DOC_URL}" >> $GITHUB_STEP_SUMMARY
 
     - name: upload-pr-number
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: github.event_name == 'pull_request'
       with:
         name: pr_num

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: install-pkgs
       run: |
@@ -124,7 +124,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: install-pkgs
       run: |

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -54,7 +54,7 @@ jobs:
         echo "${PWD}/doxygen-${DOXYGEN_VERSION}/bin" >> $GITHUB_PATH
 
     - name: cache-pip
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-${{ hashFiles('scripts/requirements-doc.txt') }}
@@ -132,7 +132,7 @@ jobs:
         apt-get install -y python3-pip ninja-build doxygen graphviz librsvg2-bin
 
     - name: cache-pip
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-${{ hashFiles('scripts/requirements-doc.txt') }}

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -24,7 +24,7 @@ jobs:
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run errno.py
         run: |

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -46,7 +46,7 @@ jobs:
           sudo pip3 install -U setuptools wheel pip gitpython
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -13,19 +13,14 @@ on:
       # same commit
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  footprint-tracking-cancel:
-    runs-on: ubuntu-20.04
-    if: github.repository == 'zephyrproject-rtos/zephyr'
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
   footprint-tracking:
     runs-on: ubuntu-20.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
-    needs: footprint-tracking-cancel
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -32,7 +32,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -2,19 +2,14 @@ name: Footprint Delta
 
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  footprint-cancel:
-    runs-on: ubuntu-20.04
-    if: github.repository == 'zephyrproject-rtos/zephyr'
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
   footprint-delta:
     runs-on: ubuntu-20.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
-    needs: footprint-cancel
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
       options: '--entrypoint /bin/bash'
@@ -24,11 +19,6 @@ jobs:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.1
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Apply container owner mismatch workaround
         run: |
           # FIXME: The owner UID of the GITHUB_WORKSPACE directory may not

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         directory-to-scan: 'scan/'
     - name: Artifact Upload
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: scancode
         path: ./artifacts

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -10,7 +10,7 @@ jobs:
     name: Manifest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: zephyrproject/zephyr
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,8 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+        run: |
+          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v1

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -13,19 +13,13 @@ on:
     # Run at 00:00 on Wednesday and Saturday
     - cron: '0 0 * * 3,6'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  twister-build-cleanup:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-
   twister-build-prep:
-
     runs-on: zephyr_runner
-    needs: twister-build-cleanup
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.24.5
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Checkout
         if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -146,7 +146,7 @@ jobs:
           rm -rf zephyr zephyr-testing
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -250,7 +250,7 @@ jobs:
 
       - name: Upload Unit Test Results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Unit Test Results (Subset ${{ matrix.subset }})
           if-no-files-found: ignore
@@ -280,7 +280,7 @@ jobs:
 
       - name: Upload Unit Test Results in HTML
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: HTML Unit Test Results
           if-no-files-found: ignore

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -106,9 +106,9 @@ jobs:
           else
             size=0
           fi
-          echo "::set-output name=subset::${subset}";
-          echo "::set-output name=size::${size}";
-          echo "::set-output name=fullrun::${TWISTER_FULL}";
+          echo "subset=${subset}" >> $GITHUB_OUTPUT
+          echo "size=${size}" >> $GITHUB_OUTPUT
+          echo "fullrun=${TWISTER_FULL}" >> $GITHUB_OUTPUT
 
   twister-build:
     runs-on: zephyr_runner
@@ -184,7 +184,7 @@ jobs:
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
           string(REPLACE "/" "_" repo ${{github.repository}})
           string(REPLACE "-" "_" repo2 ${repo})
-          message("::set-output name=repo::${repo2}")
+          file(APPEND $ENV{GITHUB_OUTPUT} "repo=${repo2}\n")
 
       - name: use cache
         id: cache-ccache

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -27,7 +27,7 @@ jobs:
         os: [ubuntu-20.04]
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -34,7 +34,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux
       if: startsWith(runner.os, 'Linux')
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -29,7 +29,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -37,7 +37,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux
       if: startsWith(runner.os, 'Linux')
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}
@@ -45,7 +45,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}
     - name: cache-pip-mac
       if: startsWith(runner.os, 'macOS')
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/Library/Caches/pip
         # Trailing '-' was just to get a different cache name
@@ -54,7 +54,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
     - name: cache-pip-win
       if: startsWith(runner.os, 'Windows')
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -32,7 +32,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -30,7 +30,7 @@ jobs:
             python-version: 3.6
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
This series includes various CI fixes:

* Use the "concurrency" mechanism to ensure that only one instance of a workflow executes.
* Update deprecated `set-output` stdout command to use `$GITHUB_OUTPUT` file.
* Use the latest core actions based on Node.js 16 (old Node.js 12-based actions are now deprecated).