### PR TITLE
Rework PMIC Regulator Mode Setting API

### DIFF
--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -191,6 +191,7 @@ arduino_serial: &flexcomm12 {
 			enable-val = <PCA9420_MODECFG_2_SW1_EN_VAL>;
 			min-uV = <500000>;
 			max-uV = <1800000>;
+			regulator-boot-on;
 		};
 
 		pca9420_sw2: sw2_buck {
@@ -207,6 +208,7 @@ arduino_serial: &flexcomm12 {
 			enable-val = <PCA9420_MODECFG_2_SW2_EN_VAL>;
 			min-uV = <1500000>;
 			max-uV = <3300000>;
+			regulator-boot-on;
 		};
 
 		pca9420_ldo1: ldo1_reg {
@@ -223,6 +225,7 @@ arduino_serial: &flexcomm12 {
 			enable-val = <PCA9420_MODECFG_2_LDO1_EN_VAL>;
 			min-uV = <1700000>;
 			max-uV = <1900000>;
+			regulator-boot-on;
 		};
 
 		pca9420_ldo2: ldo2_reg {
@@ -239,6 +242,7 @@ arduino_serial: &flexcomm12 {
 			enable-val = <PCA9420_MODECFG_2_LDO2_EN_VAL>;
 			min-uV = <1500000>;
 			max-uV = <3300000>;
+			regulator-boot-on;
 		};
 
 

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -265,6 +265,7 @@ i2s1: &flexcomm3 {
 			enable-val = <PCA9420_MODECFG_2_SW1_EN_VAL>;
 			min-uV = <500000>;
 			max-uV = <1800000>;
+			regulator-boot-on;
 		};
 
 		pca9420_sw2: sw2_buck {
@@ -281,6 +282,7 @@ i2s1: &flexcomm3 {
 			enable-val = <PCA9420_MODECFG_2_SW2_EN_VAL>;
 			min-uV = <1500000>;
 			max-uV = <3300000>;
+			regulator-boot-on;
 		};
 
 		pca9420_ldo1: ldo1_reg {
@@ -297,6 +299,7 @@ i2s1: &flexcomm3 {
 			enable-val = <PCA9420_MODECFG_2_LDO1_EN_VAL>;
 			min-uV = <1700000>;
 			max-uV = <1900000>;
+			regulator-boot-on;
 		};
 
 		pca9420_ldo2: ldo2_reg {
@@ -313,6 +316,7 @@ i2s1: &flexcomm3 {
 			enable-val = <PCA9420_MODECFG_2_LDO2_EN_VAL>;
 			min-uV = <1500000>;
 			max-uV = <3300000>;
+			regulator-boot-on;
 		};
 
 

--- a/dts/bindings/regulator/regulator-pmic.yaml
+++ b/dts/bindings/regulator/regulator-pmic.yaml
@@ -3,9 +3,10 @@
 
 description: PMIC controlled regulator
 
-include: regulator.yaml
 
 compatible: "regulator-pmic"
+
+include: base.yaml
 
 properties:
   regulator-initial-mode:
@@ -38,6 +39,10 @@ properties:
       to the modesel-reg.
 
 child-binding:
+  include:
+    - name: regulator.yaml
+      property-allowlist:
+        - regulator-boot-on
   description: Voltage output of PMIC controller regulator
   properties:
       voltage-range:

--- a/include/zephyr/drivers/regulator/consumer.h
+++ b/include/zephyr/drivers/regulator/consumer.h
@@ -106,9 +106,7 @@ int regulator_get_current_limit(const struct device *dev);
  * @brief Select mode of regulator
  * Regulators can support multiple modes in order to permit different voltage
  * configuration or better power savings. This API will apply a mode for
- * the regulator, and also configure the remainder of the regulator APIs,
- * such as those disabling, changing voltage/current targets, or querying
- * voltage/current targets to target that mode.
+ * the regulator.
  * @param dev: regulator to switch mode for
  * @param mode: Mode to select for this regulator. Only modes present
  * in the regulator-allowed-modes property are permitted.

--- a/include/zephyr/drivers/regulator/consumer.h
+++ b/include/zephyr/drivers/regulator/consumer.h
@@ -114,6 +114,53 @@ int regulator_get_current_limit(const struct device *dev);
  */
 int regulator_set_mode(const struct device *dev, uint32_t mode);
 
+/**
+ * @brief Set target voltage for regulator mode
+ * Part of the extended regulator consumer API.
+ * sets the target voltage for a given regulator mode. This mode does
+ * not need to be the active mode. This API can be used to configure
+ * voltages for a mode, then the regulator can be switched to that mode
+ * with the regulator_set_mode api.
+ * @param dev: regulator to set voltage for
+ * @param mode: target mode to configure voltage for
+ * @param min_uV: minimum voltage acceptable, in uV
+ * @param max_uV: maximum voltage acceptable, in uV
+ * @return 0 on success, or errno on error
+ */
+int regulator_set_mode_voltage(const struct device *dev, uint32_t mode,
+	uint32_t min_uV, uint32_t max_uV);
+
+/**
+ * @brief Get target voltage for regulator mode
+ * Part of the extended regulator consumer API.
+ * gets the target voltage for a given regulator mode. This mode does
+ * not need to be the active mode. This API can be used to read voltages
+ * from a regulator mode other than the default.
+ * @param dev: regulator to query voltage from
+ * @param mode: target mode to query voltage from
+ * @return voltage level in uV
+ */
+int regulator_get_mode_voltage(const struct device *dev, uint32_t mode);
+
+/**
+ * @brief Disable regulator for a given mode
+ * Part of the extended regulator consumer API.
+ * Disables the regulator in a given mode. Does not implement the
+ * onoff service, as this is incompatible with multiple mode operation
+ * @param dev: regulator to disable
+ * @param mode: mode to change regulator state in
+ */
+int regulator_mode_disable(const struct device *dev, uint32_t mode);
+
+/**
+ * @brief Enable regulator for a given mode
+ * Part of the extended regulator consumer API.
+ * Enables the regulator in a given mode. Does not implement the
+ * onoff service, as this is incompatible with multiple mode operation
+ * @param dev: regulator to enable
+ * @param mode: mode to change regulator state in
+ */
+int regulator_mode_enable(const struct device *dev, uint32_t mode);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Rework PMIC regulator mode setting API to better support real world use cases.

The previous mode setting API would change the regulator to a target mode, and then allow the user to configure the regulator's voltage and current settings. This does not fit well with real world uses, which may require the user to change regulator settings before selecting a new mode, to ensure the mode's settings are actually valid (for example, when the regulator provides power to the core itself)

The new regulator APIs for mode setting are loosely based on Linux's APIs for configuring regulators, which allow users to configure regulator voltage directly, or configure voltage for a specific mode. This PR adds the following APIs:
- `regulator_set_mode_voltage`: set voltage target for a given (inactive) mode
- `regualtor_get_mode_voltage`: get voltage for a given (inactive) mode
- `regulator_set_mode_enable`: enable a regulator in a given mode (does not use on/off service)
- `regulator_set_mode_disable`: disable a regulator in a given mode (does not use on/off service)

Additionally, all non mode related APIs were changed to only target the default mode of the PMIC. This includes `regulator_enable`, `regulator_disable`, `regulator_set_voltage`, `regulator_get_voltage`, and current limit APIs

In addition, this PR enables the `regulator-boot-on` property for PMICs. Many PMICs will be on at boot time, and this property allows the on/off service to correctly track the state of the PMIC.