### PR TITLE
soc: intel adsp: misc fix here and there

### DIFF
--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_memory.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_memory.h
@@ -91,12 +91,12 @@ struct ace_l2mcap {
 
 #define ACE_L2MCAP ((volatile struct ace_l2mcap *)DFL2MM_REG)
 
-static inline uint32_t ace_hpsram_get_bank_count(void)
+static ALWAYS_INLINE uint32_t ace_hpsram_get_bank_count(void)
 {
 	return ACE_L2MCAP->l2hss;
 }
 
-static inline uint32_t ace_lpsram_get_bank_count(void)
+static ALWAYS_INLINE uint32_t ace_lpsram_get_bank_count(void)
 {
 	return ACE_L2MCAP->l2uss;
 }

--- a/soc/xtensa/intel_adsp/ace/sram.c
+++ b/soc/xtensa/intel_adsp/ace/sram.c
@@ -32,6 +32,8 @@ __imr void hp_sram_init(uint32_t memory_size)
 			z_idelay(DELAY_COUNT);
 		}
 	}
+
+	bbzero((void *)L2_SRAM_BASE, L2_SRAM_SIZE);
 }
 
 __imr void lp_sram_init(void)
@@ -42,4 +44,6 @@ __imr void lp_sram_init(void)
 	for (uint32_t idx = 0; idx < lpsram_ebb_quantity; ++idx) {
 		*(l2usbpmptr + idx * 2) = 0;
 	}
+
+	bbzero((void *)LP_SRAM_BASE, LP_SRAM_SIZE);
 }

--- a/soc/xtensa/intel_adsp/common/boot.c
+++ b/soc/xtensa/intel_adsp/common/boot.c
@@ -136,7 +136,6 @@ __imr void parse_manifest(void)
 
 extern void hp_sram_init(uint32_t memory_size);
 extern void lp_sram_init(void);
-extern void hp_sram_pm_banks(uint32_t banks);
 
 __imr void boot_core0(void)
 {

--- a/soc/xtensa/intel_adsp/common/boot.c
+++ b/soc/xtensa/intel_adsp/common/boot.c
@@ -89,6 +89,10 @@ static __imr void parse_module(struct sof_man_fw_header *hdr,
 		switch (mod->segment[i].flags.r.type) {
 		case SOF_MAN_SEGMENT_TEXT:
 		case SOF_MAN_SEGMENT_DATA:
+			if (mod->segment[i].flags.r.load == 0) {
+				continue;
+			}
+
 			bias = mod->segment[i].file_offset -
 				SOF_MAN_ELF_TEXT_OFFSET;
 


### PR DESCRIPTION
See individual commits for details:
* soc: intel_adsp/ace: zero out memory at ram init
* soc: intel_adsp/common: only memcpy segment if needed
* soc: intel_adsp/ace: always inline funcs to get memory bank cnt
* soc: intel_adsp/common: remove reference to hp_sram_pm_banks