### PR TITLE
LE Audio: Media and MCC shell control point improvements

### DIFF
--- a/subsys/bluetooth/shell/mcc.c
+++ b/subsys/bluetooth/shell/mcc.c
@@ -1759,56 +1759,7 @@ static int cmd_mcc_otc_read_current_group_object(const struct shell *sh,
 	}
 	return result;
 }
-
-static int cmd_mcc_ots_select_first(const struct shell *sh, size_t argc,
-				    char *argv[])
-{
-	int result;
-
-	result = bt_ots_client_select_first(0, default_conn);
-	if (result) {
-		shell_error(sh, "Fail: %d", result);
-	}
-	return result;
-}
-
-static int cmd_mcc_ots_select_last(const struct shell *sh, size_t argc,
-				   char *argv[])
-{
-	int result;
-
-	result = bt_ots_client_select_last(0, default_conn);
-	if (result) {
-		shell_error(sh, "Fail: %d", result);
-	}
-	return result;
-}
-
-static int cmd_mcc_ots_select_next(const struct shell *sh, size_t argc,
-				   char *argv[])
-{
-	int result;
-
-	result = bt_ots_client_select_next(0, default_conn);
-	if (result) {
-		shell_error(sh, "Fail: %d", result);
-	}
-	return result;
-}
-
-static int cmd_mcc_ots_select_prev(const struct shell *sh, size_t argc,
-				   char *argv[])
-{
-	int result;
-
-	result = bt_ots_client_select_prev(0, default_conn);
-	if (result) {
-		shell_error(sh, "Fail: %d", result);
-	}
-	return result;
-}
 #endif /* CONFIG_BT_MCC_OTS */
-
 
 static int cmd_mcc(const struct shell *sh, size_t argc, char **argv)
 {

--- a/subsys/bluetooth/shell/mcc.c
+++ b/subsys/bluetooth/shell/mcc.c
@@ -927,32 +927,425 @@ int cmd_mcc_read_media_state(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_set_cp(const struct shell *sh, size_t argc, char *argv[])
+int cmd_mcc_play(const struct shell *sh, size_t argc, char *argv[])
 {
-	int result;
-	struct mpl_cmd cmd;
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_PLAY,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
 
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC play failed: %d", err);
+	}
 
-	if (argc > 1) {
-		cmd.opcode = strtol(argv[1], NULL, 0);
-	} else {
-		shell_error(sh, "Invalid parameter");
+	return err;
+}
+
+int cmd_mcc_pause(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_PAUSE,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC pause failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_fast_rewind(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_FAST_REWIND,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC fast rewind failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_fast_forward(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_FAST_FORWARD,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC fast forward failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_stop(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_STOP,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC stop failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_move_relative(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_MOVE_RELATIVE,
+		.use_param = true,
+	};
+	long offset;
+	int err;
+
+	err = 0;
+	offset = shell_strtol(argv[1], 10, &err);
+	if (err != 0) {
+		shell_error(sh, "Failed to parse offset: %d", err);
+
+		return err;
+	}
+
+	if (!IN_RANGE(offset, INT32_MIN, INT32_MAX)) {
+		shell_error(sh, "Invalid offset: %ld", offset);
+
 		return -ENOEXEC;
 	}
 
-	if (argc > 2) {
-		cmd.use_param = true;
-		cmd.param = strtol(argv[2], NULL, 0);
-	} else {
-		cmd.use_param = false;
-		cmd.param = 0;
+	cmd.param = (int32_t)offset;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC move relative failed: %d", err);
 	}
 
-	result = bt_mcc_send_cmd(default_conn, &cmd);
-	if (result) {
-		shell_print(sh, "Fail: %d", result);
+	return err;
+}
+
+int cmd_mcc_prev_segment(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_PREV_SEGMENT,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC previous segment failed: %d", err);
 	}
-	return result;
+
+	return err;
+}
+
+int cmd_mcc_next_segment(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_NEXT_SEGMENT,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC next segment failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_first_segment(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_FIRST_SEGMENT,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC first segment failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_last_segment(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_LAST_SEGMENT,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC last segment failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_goto_segment(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_GOTO_SEGMENT,
+		.use_param = true,
+	};
+	long segment;
+	int err;
+
+	err = 0;
+	segment = shell_strtol(argv[1], 10, &err);
+	if (err != 0) {
+		shell_error(sh, "Failed to parse segment: %d", err);
+
+		return err;
+	}
+
+	if (!IN_RANGE(segment, INT32_MIN, INT32_MAX)) {
+		shell_error(sh, "Invalid segment: %ld", segment);
+
+		return -ENOEXEC;
+	}
+
+	cmd.param = (int32_t)segment;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC goto segment failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_prev_track(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_PREV_TRACK,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC previous track failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_next_track(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_NEXT_TRACK,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC next track failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_first_track(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_FIRST_TRACK,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC first track failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_last_track(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_LAST_TRACK,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC last track failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_goto_track(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_GOTO_TRACK,
+		.use_param = true,
+	};
+	long track;
+	int err;
+
+	err = 0;
+	track = shell_strtol(argv[1], 10, &err);
+	if (err != 0) {
+		shell_error(sh, "Failed to parse track: %d", err);
+
+		return err;
+	}
+
+	if (!IN_RANGE(track, INT32_MIN, INT32_MAX)) {
+		shell_error(sh, "Invalid track: %ld", track);
+
+		return -ENOEXEC;
+	}
+
+	cmd.param = (int32_t)track;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC goto track failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_prev_group(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_PREV_GROUP,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC previous group failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_next_group(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_NEXT_GROUP,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC next group failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_first_group(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_FIRST_GROUP,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC first group failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_last_group(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_LAST_GROUP,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC last group failed: %d", err);
+	}
+
+	return err;
+}
+
+int cmd_mcc_goto_group(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_GOTO_GROUP,
+		.use_param = true,
+	};
+	long group;
+	int err;
+
+	err = 0;
+	group = shell_strtol(argv[1], 10, &err);
+	if (err != 0) {
+		shell_error(sh, "Failed to parse group: %d", err);
+
+		return err;
+	}
+
+	if (!IN_RANGE(group, INT32_MIN, INT32_MAX)) {
+		shell_error(sh, "Invalid group: %ld", group);
+
+		return -ENOEXEC;
+	}
+
+	cmd.param = (int32_t)group;
+
+	err = bt_mcc_send_cmd(default_conn, &cmd);
+	if (err != 0) {
+		shell_error(sh, "MCC goto group failed: %d", err);
+	}
+
+	return err;
 }
 
 int cmd_mcc_read_opcodes_supported(const struct shell *sh, size_t argc,
@@ -1474,9 +1867,51 @@ SHELL_STATIC_SUBCMD_SET_CREATE(mcc_cmds,
 		      cmd_mcc_read_playing_orders_supported, 1, 0),
 	SHELL_CMD_ARG(read_media_state, NULL, "Read Media State",
 		      cmd_mcc_read_media_state, 1, 0),
-	SHELL_CMD_ARG(set_cp, NULL, "Set opcode/operation <opcode> [argument]",
-		      cmd_mcc_set_cp, 2, 1),
-	SHELL_CMD_ARG(read_opcodes_supported, NULL, "Read Opcodes Supported",
+	SHELL_CMD_ARG(play, NULL, "Send the play command", cmd_mcc_play, 1, 0),
+	SHELL_CMD_ARG(pause, NULL, "Send the pause command",
+		      cmd_mcc_pause, 1, 0),
+	SHELL_CMD_ARG(fast_rewind, NULL, "Send the fast rewind command",
+		      cmd_mcc_fast_rewind, 1, 0),
+	SHELL_CMD_ARG(fast_forward, NULL, "Send the fast forward command",
+		      cmd_mcc_fast_forward, 1, 0),
+	SHELL_CMD_ARG(stop, NULL, "Send the stop command", cmd_mcc_stop, 1, 0),
+	SHELL_CMD_ARG(move_relative, NULL,
+		      "Send the move relative command <int32_t: offset>",
+		      cmd_mcc_move_relative, 2, 0),
+	SHELL_CMD_ARG(prev_segment, NULL, "Send the prev segment command",
+		      cmd_mcc_prev_segment, 1, 0),
+	SHELL_CMD_ARG(next_segment, NULL, "Send the next segment command",
+		      cmd_mcc_next_segment, 1, 0),
+	SHELL_CMD_ARG(first_segment, NULL, "Send the first segment command",
+		      cmd_mcc_first_segment, 1, 0),
+	SHELL_CMD_ARG(last_segment, NULL, "Send the last segment command",
+		      cmd_mcc_last_segment, 1, 0),
+	SHELL_CMD_ARG(goto_segment, NULL,
+		      "Send the goto segment command <int32_t: segment>",
+		      cmd_mcc_goto_segment, 2, 0),
+	SHELL_CMD_ARG(prev_track, NULL, "Send the prev track command",
+		      cmd_mcc_prev_track, 1, 0),
+	SHELL_CMD_ARG(next_track, NULL, "Send the next track command",
+		      cmd_mcc_next_track, 1, 0),
+	SHELL_CMD_ARG(first_track, NULL, "Send the first track command",
+		      cmd_mcc_first_track, 1, 0),
+	SHELL_CMD_ARG(last_track, NULL, "Send the last track command",
+		      cmd_mcc_last_track, 1, 0),
+	SHELL_CMD_ARG(goto_track, NULL,
+		      "Send the goto track command  <int32_t: track>",
+		      cmd_mcc_goto_track, 2, 0),
+	SHELL_CMD_ARG(prev_group, NULL, "Send the prev group command",
+		      cmd_mcc_prev_group, 1, 0),
+	SHELL_CMD_ARG(next_group, NULL, "Send the next group command",
+		      cmd_mcc_next_group, 1, 0),
+	SHELL_CMD_ARG(first_group, NULL, "Send the first group command",
+		      cmd_mcc_first_group, 1, 0),
+	SHELL_CMD_ARG(last_group, NULL, "Send the last group command",
+		      cmd_mcc_last_group, 1, 0),
+	SHELL_CMD_ARG(goto_group, NULL,
+		      "Send the goto group command <int32_t: group>",
+		      cmd_mcc_goto_group, 2, 0),
+	SHELL_CMD_ARG(read_opcodes_supported, NULL, "Send the Read Opcodes Supported",
 		      cmd_mcc_read_opcodes_supported, 1, 0),
 #ifdef CONFIG_BT_MCC_OTS
 	SHELL_CMD_ARG(send_search_raw, NULL, "Send search <search control item sequence>",

--- a/subsys/bluetooth/shell/mcc.c
+++ b/subsys/bluetooth/shell/mcc.c
@@ -555,7 +555,7 @@ static void mcc_otc_read_current_group_object_cb(struct bt_conn *conn, int err,
 #endif /* CONFIG_BT_MCC_OTS */
 
 
-int cmd_mcc_init(const struct shell *sh, size_t argc, char **argv)
+static int cmd_mcc_init(const struct shell *sh, size_t argc, char **argv)
 {
 	int result;
 
@@ -621,7 +621,8 @@ int cmd_mcc_init(const struct shell *sh, size_t argc, char **argv)
 	return result;
 }
 
-int cmd_mcc_discover_mcs(const struct shell *sh, size_t argc, char **argv)
+static int cmd_mcc_discover_mcs(const struct shell *sh, size_t argc,
+				char **argv)
 {
 	int result;
 	int subscribe = 1;
@@ -642,8 +643,8 @@ int cmd_mcc_discover_mcs(const struct shell *sh, size_t argc, char **argv)
 	return result;
 }
 
-int cmd_mcc_read_player_name(const struct shell *sh, size_t argc,
-			     char *argv[])
+static int cmd_mcc_read_player_name(const struct shell *sh, size_t argc,
+				    char *argv[])
 {
 	int result;
 
@@ -655,8 +656,8 @@ int cmd_mcc_read_player_name(const struct shell *sh, size_t argc,
 }
 
 #ifdef CONFIG_BT_MCC_OTS
-int cmd_mcc_read_icon_obj_id(const struct shell *sh, size_t argc,
-			     char *argv[])
+static int cmd_mcc_read_icon_obj_id(const struct shell *sh, size_t argc,
+				    char *argv[])
 {
 	int result;
 
@@ -668,7 +669,8 @@ int cmd_mcc_read_icon_obj_id(const struct shell *sh, size_t argc,
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
-int cmd_mcc_read_icon_url(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_read_icon_url(const struct shell *sh, size_t argc,
+				 char *argv[])
 {
 	int result;
 
@@ -679,8 +681,8 @@ int cmd_mcc_read_icon_url(const struct shell *sh, size_t argc, char *argv[])
 	return result;
 }
 
-int cmd_mcc_read_track_title(const struct shell *sh, size_t argc,
-			     char *argv[])
+static int cmd_mcc_read_track_title(const struct shell *sh, size_t argc,
+				    char *argv[])
 {
 	int result;
 
@@ -691,8 +693,8 @@ int cmd_mcc_read_track_title(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_read_track_duration(const struct shell *sh, size_t argc,
-				char *argv[])
+static int cmd_mcc_read_track_duration(const struct shell *sh, size_t argc,
+				       char *argv[])
 {
 	int result;
 
@@ -703,8 +705,8 @@ int cmd_mcc_read_track_duration(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_read_track_position(const struct shell *sh, size_t argc,
-				char *argv[])
+static int cmd_mcc_read_track_position(const struct shell *sh, size_t argc,
+				       char *argv[])
 {
 	int result;
 
@@ -715,8 +717,8 @@ int cmd_mcc_read_track_position(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_set_track_position(const struct shell *sh, size_t argc,
-			       char *argv[])
+static int cmd_mcc_set_track_position(const struct shell *sh, size_t argc,
+				      char *argv[])
 {
 	int result;
 	int32_t pos = strtol(argv[1], NULL, 0);
@@ -731,8 +733,8 @@ int cmd_mcc_set_track_position(const struct shell *sh, size_t argc,
 }
 
 
-int cmd_mcc_read_playback_speed(const struct shell *sh, size_t argc,
-				char *argv[])
+static int cmd_mcc_read_playback_speed(const struct shell *sh, size_t argc,
+				       char *argv[])
 {
 	int result;
 
@@ -744,8 +746,8 @@ int cmd_mcc_read_playback_speed(const struct shell *sh, size_t argc,
 }
 
 
-int cmd_mcc_set_playback_speed(const struct shell *sh, size_t argc,
-			       char *argv[])
+static int cmd_mcc_set_playback_speed(const struct shell *sh, size_t argc,
+				      char *argv[])
 {
 	int result;
 	int8_t speed = strtol(argv[1], NULL, 0);
@@ -757,8 +759,8 @@ int cmd_mcc_set_playback_speed(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_read_seeking_speed(const struct shell *sh, size_t argc,
-			       char *argv[])
+static int cmd_mcc_read_seeking_speed(const struct shell *sh, size_t argc,
+				      char *argv[])
 {
 	int result;
 
@@ -771,8 +773,8 @@ int cmd_mcc_read_seeking_speed(const struct shell *sh, size_t argc,
 
 
 #ifdef CONFIG_BT_MCC_OTS
-int cmd_mcc_read_track_segments_obj_id(const struct shell *sh,
-				       size_t argc, char *argv[])
+static int cmd_mcc_read_track_segments_obj_id(const struct shell *sh,
+					      size_t argc, char *argv[])
 {
 	int result;
 
@@ -784,8 +786,8 @@ int cmd_mcc_read_track_segments_obj_id(const struct shell *sh,
 }
 
 
-int cmd_mcc_read_current_track_obj_id(const struct shell *sh, size_t argc,
-				      char *argv[])
+static int cmd_mcc_read_current_track_obj_id(const struct shell *sh,
+					     size_t argc, char *argv[])
 {
 	int result;
 
@@ -796,8 +798,8 @@ int cmd_mcc_read_current_track_obj_id(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_set_current_track_obj_id(const struct shell *sh, size_t argc,
-				      char *argv[])
+static int cmd_mcc_set_current_track_obj_id(const struct shell *sh, size_t argc,
+					    char *argv[])
 {
 	int result;
 	uint64_t id = strtoul(argv[1], NULL, 0);
@@ -811,8 +813,8 @@ int cmd_mcc_set_current_track_obj_id(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_read_next_track_obj_id(const struct shell *sh, size_t argc,
-				   char *argv[])
+static int cmd_mcc_read_next_track_obj_id(const struct shell *sh, size_t argc,
+					  char *argv[])
 {
 	int result;
 
@@ -823,8 +825,8 @@ int cmd_mcc_read_next_track_obj_id(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_set_next_track_obj_id(const struct shell *sh, size_t argc,
-				  char *argv[])
+static int cmd_mcc_set_next_track_obj_id(const struct shell *sh, size_t argc,
+					 char *argv[])
 {
 	int result;
 	uint64_t id = strtoul(argv[1], NULL, 0);
@@ -838,8 +840,8 @@ int cmd_mcc_set_next_track_obj_id(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_read_parent_group_obj_id(const struct shell *sh, size_t argc,
-				     char *argv[])
+static int cmd_mcc_read_parent_group_obj_id(const struct shell *sh, size_t argc,
+					    char *argv[])
 {
 	int result;
 
@@ -850,8 +852,8 @@ int cmd_mcc_read_parent_group_obj_id(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_read_current_group_obj_id(const struct shell *sh, size_t argc,
-				      char *argv[])
+static int cmd_mcc_read_current_group_obj_id(const struct shell *sh,
+					     size_t argc, char *argv[])
 {
 	int result;
 
@@ -862,8 +864,8 @@ int cmd_mcc_read_current_group_obj_id(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_set_current_group_obj_id(const struct shell *sh, size_t argc,
-				      char *argv[])
+static int cmd_mcc_set_current_group_obj_id(const struct shell *sh, size_t argc,
+					    char *argv[])
 {
 	int result;
 	uint64_t id = strtoul(argv[1], NULL, 0);
@@ -878,8 +880,8 @@ int cmd_mcc_set_current_group_obj_id(const struct shell *sh, size_t argc,
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
-int cmd_mcc_read_playing_order(const struct shell *sh, size_t argc,
-			       char *argv[])
+static int cmd_mcc_read_playing_order(const struct shell *sh, size_t argc,
+				      char *argv[])
 {
 	int result;
 
@@ -890,8 +892,8 @@ int cmd_mcc_read_playing_order(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_set_playing_order(const struct shell *sh, size_t argc,
-			      char *argv[])
+static int cmd_mcc_set_playing_order(const struct shell *sh, size_t argc,
+				     char *argv[])
 {
 	int result;
 	uint8_t order = strtol(argv[1], NULL, 0);
@@ -903,8 +905,8 @@ int cmd_mcc_set_playing_order(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_read_playing_orders_supported(const struct shell *sh, size_t argc,
-					  char *argv[])
+static int cmd_mcc_read_playing_orders_supported(const struct shell *sh,
+						 size_t argc, char *argv[])
 {
 	int result;
 
@@ -915,8 +917,8 @@ int cmd_mcc_read_playing_orders_supported(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_read_media_state(const struct shell *sh, size_t argc,
-			     char *argv[])
+static int cmd_mcc_read_media_state(const struct shell *sh, size_t argc,
+				    char *argv[])
 {
 	int result;
 
@@ -927,7 +929,7 @@ int cmd_mcc_read_media_state(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_play(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_play(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_PLAY,
@@ -944,7 +946,7 @@ int cmd_mcc_play(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_pause(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_pause(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_PAUSE,
@@ -961,7 +963,8 @@ int cmd_mcc_pause(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_fast_rewind(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_fast_rewind(const struct shell *sh, size_t argc,
+			       char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_FAST_REWIND,
@@ -978,7 +981,8 @@ int cmd_mcc_fast_rewind(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_fast_forward(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_fast_forward(const struct shell *sh, size_t argc,
+				char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_FAST_FORWARD,
@@ -995,7 +999,7 @@ int cmd_mcc_fast_forward(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_stop(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_stop(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_STOP,
@@ -1012,7 +1016,8 @@ int cmd_mcc_stop(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_move_relative(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_move_relative(const struct shell *sh, size_t argc,
+				 char *argv[])
 {
 	struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_MOVE_RELATIVE,
@@ -1045,7 +1050,8 @@ int cmd_mcc_move_relative(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_prev_segment(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_prev_segment(const struct shell *sh, size_t argc,
+				char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_PREV_SEGMENT,
@@ -1062,7 +1068,8 @@ int cmd_mcc_prev_segment(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_next_segment(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_next_segment(const struct shell *sh, size_t argc,
+				char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_NEXT_SEGMENT,
@@ -1079,7 +1086,8 @@ int cmd_mcc_next_segment(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_first_segment(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_first_segment(const struct shell *sh, size_t argc,
+				 char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_FIRST_SEGMENT,
@@ -1096,7 +1104,8 @@ int cmd_mcc_first_segment(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_last_segment(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_last_segment(const struct shell *sh, size_t argc,
+				char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_LAST_SEGMENT,
@@ -1113,7 +1122,8 @@ int cmd_mcc_last_segment(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_goto_segment(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_goto_segment(const struct shell *sh, size_t argc,
+				char *argv[])
 {
 	struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_GOTO_SEGMENT,
@@ -1146,7 +1156,7 @@ int cmd_mcc_goto_segment(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_prev_track(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_prev_track(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_PREV_TRACK,
@@ -1163,7 +1173,7 @@ int cmd_mcc_prev_track(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_next_track(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_next_track(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_NEXT_TRACK,
@@ -1180,7 +1190,8 @@ int cmd_mcc_next_track(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_first_track(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_first_track(const struct shell *sh, size_t argc,
+			       char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_FIRST_TRACK,
@@ -1197,7 +1208,7 @@ int cmd_mcc_first_track(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_last_track(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_last_track(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_LAST_TRACK,
@@ -1214,7 +1225,7 @@ int cmd_mcc_last_track(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_goto_track(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_goto_track(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_GOTO_TRACK,
@@ -1247,7 +1258,7 @@ int cmd_mcc_goto_track(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_prev_group(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_prev_group(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_PREV_GROUP,
@@ -1264,7 +1275,7 @@ int cmd_mcc_prev_group(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_next_group(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_next_group(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_NEXT_GROUP,
@@ -1281,7 +1292,8 @@ int cmd_mcc_next_group(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_first_group(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_first_group(const struct shell *sh, size_t argc,
+			       char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_FIRST_GROUP,
@@ -1298,7 +1310,7 @@ int cmd_mcc_first_group(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_last_group(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_last_group(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_LAST_GROUP,
@@ -1315,7 +1327,7 @@ int cmd_mcc_last_group(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_goto_group(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_goto_group(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct mpl_cmd cmd = {
 		.opcode = BT_MCS_OPC_GOTO_GROUP,
@@ -1348,8 +1360,8 @@ int cmd_mcc_goto_group(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-int cmd_mcc_read_opcodes_supported(const struct shell *sh, size_t argc,
-				   char *argv[])
+static int cmd_mcc_read_opcodes_supported(const struct shell *sh, size_t argc,
+					  char *argv[])
 {
 	int result;
 
@@ -1361,7 +1373,8 @@ int cmd_mcc_read_opcodes_supported(const struct shell *sh, size_t argc,
 }
 
 #ifdef CONFIG_BT_MCC_OTS
-int cmd_mcc_send_search_raw(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_send_search_raw(const struct shell *sh, size_t argc,
+				   char *argv[])
 {
 	int result;
 	struct mpl_search search;
@@ -1377,8 +1390,8 @@ int cmd_mcc_send_search_raw(const struct shell *sh, size_t argc, char *argv[])
 	return result;
 }
 
-int cmd_mcc_send_search_ioptest(const struct shell *sh, size_t argc,
-				char *argv[])
+static int cmd_mcc_send_search_ioptest(const struct shell *sh, size_t argc,
+				       char *argv[])
 {
 	/* Implementation follows Media control service testspec 0.9.0r13 */
 	/* Testcase MCS/SR/SCP/BV-01-C [Search Control Point], rounds 1 - 9 */
@@ -1477,8 +1490,8 @@ int cmd_mcc_send_search_ioptest(const struct shell *sh, size_t argc,
 }
 
 #if defined(CONFIG_BT_MCC_LOG_LEVEL_DBG) && defined(CONFIG_BT_TESTING)
-int cmd_mcc_test_send_search_iop_invalid_type(const struct shell *sh,
-					      size_t argc, char *argv[])
+static int cmd_mcc_test_send_search_iop_invalid_type(const struct shell *sh,
+						     size_t argc, char *argv[])
 {
 	int result;
 	struct mpl_search search;
@@ -1499,8 +1512,8 @@ int cmd_mcc_test_send_search_iop_invalid_type(const struct shell *sh,
 	return result;
 }
 
-int cmd_mcc_test_send_search_invalid_sci_len(const struct shell *sh,
-					     size_t argc, char *argv[])
+static int cmd_mcc_test_send_search_invalid_sci_len(const struct shell *sh,
+						    size_t argc, char *argv[])
 {
 	/* Reproduce a search that caused hard fault when sent from peer */
 	/* in IOP testing */
@@ -1525,8 +1538,8 @@ int cmd_mcc_test_send_search_invalid_sci_len(const struct shell *sh,
 }
 #endif /* CONFIG_BT_MCC_LOG_LEVEL_DBG && CONFIG_BT_TESTING */
 
-int cmd_mcc_read_search_results_obj_id(const struct shell *sh, size_t argc,
-				       char *argv[])
+static int cmd_mcc_read_search_results_obj_id(const struct shell *sh,
+					      size_t argc, char *argv[])
 {
 	int result;
 
@@ -1538,8 +1551,8 @@ int cmd_mcc_read_search_results_obj_id(const struct shell *sh, size_t argc,
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
-int cmd_mcc_read_content_control_id(const struct shell *sh, size_t argc,
-				     char *argv[])
+static int cmd_mcc_read_content_control_id(const struct shell *sh, size_t argc,
+					   char *argv[])
 {
 	int result;
 
@@ -1552,8 +1565,8 @@ int cmd_mcc_read_content_control_id(const struct shell *sh, size_t argc,
 
 
 #ifdef CONFIG_BT_MCC_OTS
-int cmd_mcc_otc_read_features(const struct shell *sh, size_t argc,
-			      char *argv[])
+static int cmd_mcc_otc_read_features(const struct shell *sh, size_t argc,
+				     char *argv[])
 {
 	int result;
 
@@ -1565,7 +1578,7 @@ int cmd_mcc_otc_read_features(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_otc_read(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_otc_read(const struct shell *sh, size_t argc, char *argv[])
 {
 	int result;
 
@@ -1577,8 +1590,8 @@ int cmd_mcc_otc_read(const struct shell *sh, size_t argc, char *argv[])
 	return result;
 }
 
-int cmd_mcc_otc_read_metadata(const struct shell *sh, size_t argc,
-			      char *argv[])
+static int cmd_mcc_otc_read_metadata(const struct shell *sh, size_t argc,
+				     char *argv[])
 {
 	int result;
 
@@ -1591,7 +1604,7 @@ int cmd_mcc_otc_read_metadata(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_otc_select(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_mcc_otc_select(const struct shell *sh, size_t argc, char *argv[])
 {
 	int result;
 	uint64_t id;
@@ -1611,8 +1624,8 @@ int cmd_mcc_otc_select(const struct shell *sh, size_t argc, char *argv[])
 	return result;
 }
 
-int cmd_mcc_otc_select_first(const struct shell *sh, size_t argc,
-			     char *argv[])
+static int cmd_mcc_otc_select_first(const struct shell *sh, size_t argc,
+				    char *argv[])
 {
 	int result;
 
@@ -1624,8 +1637,8 @@ int cmd_mcc_otc_select_first(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_otc_select_last(const struct shell *sh, size_t argc,
-			    char *argv[])
+static int cmd_mcc_otc_select_last(const struct shell *sh, size_t argc,
+				   char *argv[])
 {
 	int result;
 
@@ -1637,8 +1650,8 @@ int cmd_mcc_otc_select_last(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_otc_select_next(const struct shell *sh, size_t argc,
-			    char *argv[])
+static int cmd_mcc_otc_select_next(const struct shell *sh, size_t argc,
+				   char *argv[])
 {
 	int result;
 
@@ -1650,8 +1663,8 @@ int cmd_mcc_otc_select_next(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_otc_select_prev(const struct shell *sh, size_t argc,
-			    char *argv[])
+static int cmd_mcc_otc_select_prev(const struct shell *sh, size_t argc,
+				   char *argv[])
 {
 	int result;
 
@@ -1663,8 +1676,8 @@ int cmd_mcc_otc_select_prev(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_otc_read_icon_object(const struct shell *sh, size_t argc,
-				 char *argv[])
+static int cmd_mcc_otc_read_icon_object(const struct shell *sh, size_t argc,
+					char *argv[])
 {
 	/* Assumes the Icon Object has already been selected by ID */
 
@@ -1677,8 +1690,8 @@ int cmd_mcc_otc_read_icon_object(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_otc_read_track_segments_object(const struct shell *sh,
-					   size_t argc, char *argv[])
+static int cmd_mcc_otc_read_track_segments_object(const struct shell *sh,
+						  size_t argc, char *argv[])
 {
 	/* Assumes the Segment Object has already been selected by ID */
 
@@ -1691,8 +1704,8 @@ int cmd_mcc_otc_read_track_segments_object(const struct shell *sh,
 	return result;
 }
 
-int cmd_mcc_otc_read_current_track_object(const struct shell *sh,
-					  size_t argc, char *argv[])
+static int cmd_mcc_otc_read_current_track_object(const struct shell *sh,
+						 size_t argc, char *argv[])
 {
 	/* Assumes the Curent Track Object has already been selected by ID */
 
@@ -1705,8 +1718,8 @@ int cmd_mcc_otc_read_current_track_object(const struct shell *sh,
 	return result;
 }
 
-int cmd_mcc_otc_read_next_track_object(const struct shell *sh,
-					  size_t argc, char *argv[])
+static int cmd_mcc_otc_read_next_track_object(const struct shell *sh,
+					      size_t argc, char *argv[])
 {
 	/* Assumes the Next Track Object has already been selected by ID */
 
@@ -1719,8 +1732,8 @@ int cmd_mcc_otc_read_next_track_object(const struct shell *sh,
 	return result;
 }
 
-int cmd_mcc_otc_read_parent_group_object(const struct shell *sh,
-					 size_t argc, char *argv[])
+static int cmd_mcc_otc_read_parent_group_object(const struct shell *sh,
+						size_t argc, char *argv[])
 {
 	/* Assumes the Parent Group Object has already been selected by ID */
 
@@ -1733,8 +1746,8 @@ int cmd_mcc_otc_read_parent_group_object(const struct shell *sh,
 	return result;
 }
 
-int cmd_mcc_otc_read_current_group_object(const struct shell *sh,
-					  size_t argc, char *argv[])
+static int cmd_mcc_otc_read_current_group_object(const struct shell *sh,
+						 size_t argc, char *argv[])
 {
 	/* Assumes the Current Group Object has already been selected by ID */
 
@@ -1747,8 +1760,8 @@ int cmd_mcc_otc_read_current_group_object(const struct shell *sh,
 	return result;
 }
 
-int cmd_mcc_ots_select_first(const struct shell *sh, size_t argc,
-			     char *argv[])
+static int cmd_mcc_ots_select_first(const struct shell *sh, size_t argc,
+				    char *argv[])
 {
 	int result;
 
@@ -1759,8 +1772,8 @@ int cmd_mcc_ots_select_first(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_ots_select_last(const struct shell *sh, size_t argc,
-			    char *argv[])
+static int cmd_mcc_ots_select_last(const struct shell *sh, size_t argc,
+				   char *argv[])
 {
 	int result;
 
@@ -1771,8 +1784,8 @@ int cmd_mcc_ots_select_last(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_ots_select_next(const struct shell *sh, size_t argc,
-			    char *argv[])
+static int cmd_mcc_ots_select_next(const struct shell *sh, size_t argc,
+				   char *argv[])
 {
 	int result;
 
@@ -1783,8 +1796,8 @@ int cmd_mcc_ots_select_next(const struct shell *sh, size_t argc,
 	return result;
 }
 
-int cmd_mcc_ots_select_prev(const struct shell *sh, size_t argc,
-			    char *argv[])
+static int cmd_mcc_ots_select_prev(const struct shell *sh, size_t argc,
+				   char *argv[])
 {
 	int result;
 

--- a/subsys/bluetooth/shell/media_controller.c
+++ b/subsys/bluetooth/shell/media_controller.c
@@ -374,7 +374,7 @@ static void content_ctrl_id_cb(struct media_player *plr, int err, uint8_t ccid)
 	shell_print(ctx_shell, "Player: %p, Content Control ID: %u", plr, ccid);
 }
 
-int cmd_media_init(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_media_init(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 
@@ -720,25 +720,453 @@ static int cmd_media_read_media_state(const struct shell *sh, size_t argc, char 
 	return err;
 }
 
-static int cmd_media_send_command(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_media_play(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct mpl_cmd cmd;
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_PLAY,
+		.use_param = false,
+		.param = 0,
+	};
 	int err;
 
-	cmd.opcode = strtol(argv[1], NULL, 0);
-
-	if (argc > 2) {
-		cmd.use_param = true;
-		cmd.param = strtol(argv[2], NULL, 0);
-	} else {
-		cmd.use_param = false;
-		cmd.param = 0;
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller play failed: %d", err);
 	}
 
-	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	return err;
+}
 
-	if (err) {
-		shell_error(ctx_shell, "Command send failed (%d)", err);
+static int cmd_media_pause(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_PAUSE,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller pause failed: %d", err);
+	}
+
+	return err;
+}
+
+static int cmd_media_fast_rewind(const struct shell *sh, size_t argc,
+				 char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_FAST_REWIND,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller fast rewind failed: %d", err);
+	}
+
+	return err;
+}
+
+static int cmd_media_fast_forward(const struct shell *sh, size_t argc,
+				  char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_FAST_FORWARD,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller fast forward failed: %d",
+			    err);
+	}
+
+	return err;
+}
+
+static int cmd_media_stop(const struct shell *sh, size_t argc, char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_STOP,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller stop failed: %d", err);
+	}
+
+	return err;
+}
+
+static int cmd_media_move_relative(const struct shell *sh, size_t argc,
+				   char *argv[])
+{
+	struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_MOVE_RELATIVE,
+		.use_param = true,
+	};
+	long offset;
+	int err;
+
+	err = 0;
+	offset = shell_strtol(argv[1], 10, &err);
+	if (err != 0) {
+		shell_error(sh, "Failed to parse offset: %d", err);
+
+		return err;
+	}
+
+	if (!IN_RANGE(offset, INT32_MIN, INT32_MAX)) {
+		shell_error(sh, "Invalid offset: %ld", offset);
+
+		return -ENOEXEC;
+	}
+
+	cmd.param = (int32_t)offset;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller move relative failed: %d",
+			    err);
+	}
+
+	return err;
+}
+
+static int cmd_media_prev_segment(const struct shell *sh, size_t argc,
+				  char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_PREV_SEGMENT,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller previous segment failed: %d",
+			    err);
+	}
+
+	return err;
+}
+
+static int cmd_media_next_segment(const struct shell *sh, size_t argc,
+				  char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_NEXT_SEGMENT,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller next segment failed: %d",
+			    err);
+	}
+
+	return err;
+}
+
+static int cmd_media_first_segment(const struct shell *sh, size_t argc,
+				   char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_FIRST_SEGMENT,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller first segment failed: %d",
+			    err);
+	}
+
+	return err;
+}
+
+static int cmd_media_last_segment(const struct shell *sh, size_t argc,
+				  char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_LAST_SEGMENT,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller last segment failed: %d",
+			    err);
+	}
+
+	return err;
+}
+
+static int cmd_media_goto_segment(const struct shell *sh, size_t argc,
+				  char *argv[])
+{
+	struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_GOTO_SEGMENT,
+		.use_param = true,
+	};
+	long segment;
+	int err;
+
+	err = 0;
+	segment = shell_strtol(argv[1], 10, &err);
+	if (err != 0) {
+		shell_error(sh, "Failed to parse segment: %d", err);
+
+		return err;
+	}
+
+	if (!IN_RANGE(segment, INT32_MIN, INT32_MAX)) {
+		shell_error(sh, "Invalid segment: %ld", segment);
+
+		return -ENOEXEC;
+	}
+
+	cmd.param = (int32_t)segment;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller goto segment failed: %d",
+			    err);
+	}
+
+	return err;
+}
+
+static int cmd_media_prev_track(const struct shell *sh, size_t argc,
+				char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_PREV_TRACK,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller previous track failed: %d",
+			    err);
+	}
+
+	return err;
+}
+
+static int cmd_media_next_track(const struct shell *sh, size_t argc,
+				char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_NEXT_TRACK,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller next track failed: %d",
+			    err);
+	}
+
+	return err;
+}
+
+static int cmd_media_first_track(const struct shell *sh, size_t argc,
+				 char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_FIRST_TRACK,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller first track failed: %d",
+			    err);
+	}
+
+	return err;
+}
+
+static int cmd_media_last_track(const struct shell *sh, size_t argc,
+				char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_LAST_TRACK,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller last track failed: %d", err);
+	}
+
+	return err;
+}
+
+static int cmd_media_goto_track(const struct shell *sh, size_t argc,
+				char *argv[])
+{
+	struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_GOTO_TRACK,
+		.use_param = true,
+	};
+	long track;
+	int err;
+
+	err = 0;
+	track = shell_strtol(argv[1], 10, &err);
+	if (err != 0) {
+		shell_error(sh, "Failed to parse track: %d", err);
+
+		return err;
+	}
+
+	if (!IN_RANGE(track, INT32_MIN, INT32_MAX)) {
+		shell_error(sh, "Invalid track: %ld", track);
+
+		return -ENOEXEC;
+	}
+
+	cmd.param = (int32_t)track;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller goto track failed: %d",
+			    err);
+	}
+
+	return err;
+}
+
+static int cmd_media_prev_group(const struct shell *sh, size_t argc,
+				char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_PREV_GROUP,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller previous group failed: %d",
+			    err);
+	}
+
+	return err;
+}
+
+static int cmd_media_next_group(const struct shell *sh, size_t argc,
+				char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_NEXT_GROUP,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller next group failed: %d", err);
+	}
+
+	return err;
+}
+
+static int cmd_media_first_group(const struct shell *sh, size_t argc,
+				 char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_FIRST_GROUP,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller first group failed: %d", err);
+	}
+
+	return err;
+}
+
+static int cmd_media_last_group(const struct shell *sh, size_t argc,
+				char *argv[])
+{
+	const struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_LAST_GROUP,
+		.use_param = false,
+		.param = 0,
+	};
+	int err;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller last group failed: %d", err);
+	}
+
+	return err;
+}
+
+static int cmd_media_goto_group(const struct shell *sh, size_t argc,
+				char *argv[])
+{
+	struct mpl_cmd cmd = {
+		.opcode = BT_MCS_OPC_GOTO_GROUP,
+		.use_param = true,
+	};
+	long group;
+	int err;
+
+	err = 0;
+	group = shell_strtol(argv[1], 10, &err);
+	if (err != 0) {
+		shell_error(sh, "Failed to parse group: %d", err);
+
+		return err;
+	}
+
+	if (!IN_RANGE(group, INT32_MIN, INT32_MAX)) {
+		shell_error(sh, "Invalid group: %ld", group);
+
+		return -ENOEXEC;
+	}
+
+	cmd.param = (int32_t)group;
+
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
+	if (err != 0) {
+		shell_error(sh, "Media Controller goto group failed: %d",
+			    err);
 	}
 
 	return err;
@@ -756,7 +1184,7 @@ static int cmd_media_read_commands_supported(const struct shell *sh, size_t argc
 }
 
 #ifdef CONFIG_BT_OTS
-int cmd_media_set_search(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_media_set_search(const struct shell *sh, size_t argc, char *argv[])
 {
 	/* TODO: Currently takes the raw search as input - add parameters
 	 * and build the search item here
@@ -869,8 +1297,52 @@ SHELL_STATIC_SUBCMD_SET_CREATE(media_cmds,
 		      cmd_media_read_playing_orders_supported, 1, 0),
 	SHELL_CMD_ARG(read_media_state, NULL, "Read Media State",
 		      cmd_media_read_media_state, 1, 0),
-	SHELL_CMD_ARG(send_command, NULL, "Send command <opcode> [argument]",
-		      cmd_media_send_command, 2, 1),
+	SHELL_CMD_ARG(play, NULL, "Send the play command", cmd_media_play, 1,
+		      0),
+	SHELL_CMD_ARG(pause, NULL, "Send the pause command",
+		      cmd_media_pause, 1, 0),
+	SHELL_CMD_ARG(fast_rewind, NULL, "Send the fast rewind command",
+		      cmd_media_fast_rewind, 1, 0),
+	SHELL_CMD_ARG(fast_forward, NULL, "Send the fast forward command",
+		      cmd_media_fast_forward, 1, 0),
+	SHELL_CMD_ARG(stop, NULL, "Send the stop command", cmd_media_stop, 1,
+		      0),
+	SHELL_CMD_ARG(move_relative, NULL,
+		      "Send the move relative command <int32_t: offset>",
+		      cmd_media_move_relative, 2, 0),
+	SHELL_CMD_ARG(prev_segment, NULL, "Send the prev segment command",
+		      cmd_media_prev_segment, 1, 0),
+	SHELL_CMD_ARG(next_segment, NULL, "Send the next segment command",
+		      cmd_media_next_segment, 1, 0),
+	SHELL_CMD_ARG(first_segment, NULL, "Send the first segment command",
+		      cmd_media_first_segment, 1, 0),
+	SHELL_CMD_ARG(last_segment, NULL, "Send the last segment command",
+		      cmd_media_last_segment, 1, 0),
+	SHELL_CMD_ARG(goto_segment, NULL,
+		      "Send the goto segment command <int32_t: segment>",
+		      cmd_media_goto_segment, 2, 0),
+	SHELL_CMD_ARG(prev_track, NULL, "Send the prev track command",
+		      cmd_media_prev_track, 1, 0),
+	SHELL_CMD_ARG(next_track, NULL, "Send the next track command",
+		      cmd_media_next_track, 1, 0),
+	SHELL_CMD_ARG(first_track, NULL, "Send the first track command",
+		      cmd_media_first_track, 1, 0),
+	SHELL_CMD_ARG(last_track, NULL, "Send the last track command",
+		      cmd_media_last_track, 1, 0),
+	SHELL_CMD_ARG(goto_track, NULL,
+		      "Send the goto track command  <int32_t: track>",
+		      cmd_media_goto_track, 2, 0),
+	SHELL_CMD_ARG(prev_group, NULL, "Send the prev group command",
+		      cmd_media_prev_group, 1, 0),
+	SHELL_CMD_ARG(next_group, NULL, "Send the next group command",
+		      cmd_media_next_group, 1, 0),
+	SHELL_CMD_ARG(first_group, NULL, "Send the first group command",
+		      cmd_media_first_group, 1, 0),
+	SHELL_CMD_ARG(last_group, NULL, "Send the last group command",
+		      cmd_media_last_group, 1, 0),
+	SHELL_CMD_ARG(goto_group, NULL,
+		      "Send the goto group command <int32_t: group>",
+		      cmd_media_goto_group, 2, 0),
 	SHELL_CMD_ARG(read_commands_supported, NULL, "Read Commands Supported",
 		      cmd_media_read_commands_supported, 1, 0),
 #ifdef CONFIG_BT_OTS


### PR DESCRIPTION
Adds explicit functions for the control point operations so that it is easier to use the `mcc` and `media` shell commands. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/50782