### PR TITLE
soc: nxp: Fix boot issue on RT595

### DIFF
--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -16,7 +16,7 @@
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/irq.h>
-#include <zephyr/linker/section_tags.h>
+#include <zephyr/linker/sections.h>
 #include <soc.h>
 #include "flash_clock_setup.h"
 #include "fsl_power.h"


### PR DESCRIPTION
Include the correct header file. This was uncovered due to a recent change where zephyr/kernel.h include was removed from init.h

