### PR TITLE
tests: create test for dynamic loadable logging backends

### DIFF
--- a/tests/subsys/logging/log_core_additional/src/log_test.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test.c
@@ -182,6 +182,26 @@ static bool log_test_process(void)
  */
 
 #ifndef CONFIG_USERSPACE
+
+/**
+ * @brief Create Tests for Dynamic Loadable Logging Backends
+ *
+ * @details Test the three APIs, log_backend_activate, log_backend_is_active and
+ *          log_backend_deactivate.
+ *
+ * @addtogroup logging
+ */
+ZTEST(test_log_core_additional, test_log_backend)
+{
+	log_init();
+
+	zassert_false(log_backend_is_active(&backend1));
+	log_backend_activate(&backend1, NULL);
+	zassert_true(log_backend_is_active(&backend1));
+	log_backend_deactivate(&backend1);
+	zassert_false(log_backend_is_active(&backend1));
+}
+
 ZTEST(test_log_core_additional, test_log_domain_id)
 {
 	log_setup(false);


### PR DESCRIPTION
Test the three APIs, log_backend_activate,
log_backend_is_active and log_backend_deactivate.

Signed-off-by: Zhao Shuai <shuai1x.zhao@intel.com>