### PR TITLE
add t1_test to kernel cases

### DIFF
--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: base userspace
+  tags: base userspace t1_test
   min_flash: 33
   timeout: 120
 tests:

--- a/tests/kernel/condvar/condvar_api/testcase.yaml
+++ b/tests/kernel/condvar/condvar_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.condvar:
-    tags: kernel userspace condition_variables ignore_faults
+    tags: kernel userspace condition_variables ignore_faults t1_test

--- a/tests/kernel/context/testcase.yaml
+++ b/tests/kernel/context/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.context:
-    tags: kernel
+    tags: kernel t1_test
   kernel.context.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel linker_generator

--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: device userspace
+  tags: device userspace t1_test
   integration_platforms:
     - native_posix
 tests:

--- a/tests/kernel/early_sleep/testcase.yaml
+++ b/tests/kernel/early_sleep/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.common.sleep:
-    tags: kernel sleep
+    tags: kernel sleep t1_test
   kernel.common.sleep.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel sleep linker_generator

--- a/tests/kernel/events/event_api/testcase.yaml
+++ b/tests/kernel/events/event_api/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.events:
-    tags: kernel
+    tags: kernel t1_test
   kernel.events.linker_generator:
     platform_allow: qemu_x86
     tags: kernel linker_generator

--- a/tests/kernel/events/sys_event/testcase.yaml
+++ b/tests/kernel/events/sys_event/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.events.usage:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: kernel userspace ignore_faults
+    tags: kernel userspace ignore_faults t1_test

--- a/tests/kernel/fatal/exception/testcase.yaml
+++ b/tests/kernel/fatal/exception/testcase.yaml
@@ -3,7 +3,7 @@ tests:
     extra_args: CONF_FILE=prj.conf
     platform_exclude: twr_ke18f
     filter: CONFIG_ARCH_HAS_STACK_PROTECTION
-    tags: kernel ignore_faults userspace
+    tags: kernel ignore_faults userspace t1_test
   kernel.common.stack_protection_no_userspace:
     extra_args: CONF_FILE=protection_no_userspace.conf
     filter: CONFIG_ARCH_HAS_STACK_PROTECTION
@@ -23,4 +23,4 @@ tests:
     extra_args: CONF_FILE=sentinel.conf
     # FIXME: See issue #39948
     platform_exclude: qemu_cortex_a9
-    tags: kernel ignore_faults
+    tags: kernel ignore_faults t1_test

--- a/tests/kernel/fatal/message_capture/testcase.yaml
+++ b/tests/kernel/fatal/message_capture/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.logging.message_capture:
-    tags: kernel
+    tags: kernel t1_test
     harness: console
     harness_config:
       type: multi_line

--- a/tests/kernel/fifo/fifo_api/testcase.yaml
+++ b/tests/kernel/fifo/fifo_api/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.fifo:
-    tags: kernel
+    tags: kernel t1_test
   kernel.fifo.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel linker_generator

--- a/tests/kernel/fifo/fifo_timeout/testcase.yaml
+++ b/tests/kernel/fifo/fifo_timeout/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.fifo.timeout:
-    tags: kernel
+    tags: kernel t1_test
   kernel.fifo.timeout.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel linker_generator

--- a/tests/kernel/fifo/fifo_usage/testcase.yaml
+++ b/tests/kernel/fifo/fifo_usage/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.fifo.usage:
-    tags: kernel
+    tags: kernel t1_test
   kernel.fifo.usage.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel linker_generator

--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   arch.interrupt:
     # nios2 excluded, see #22956
     arch_exclude: nios2
-    tags: kernel interrupt
+    tags: kernel interrupt t1_test
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
 
   arch.interrupt.linker_generator:

--- a/tests/kernel/lifo/lifo_api/testcase.yaml
+++ b/tests/kernel/lifo/lifo_api/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.lifo:
-    tags: kernel
+    tags: kernel t1_test
   kernel.lifo.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel linker_generator

--- a/tests/kernel/lifo/lifo_usage/testcase.yaml
+++ b/tests/kernel/lifo/lifo_usage/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   kernel.lifo.usage:
     # see #26646
     platform_exclude: m2gl025_miv
-    tags: kernel
+    tags: kernel t1_test
     min_ram: 20
   kernel.lifo.usage.linker_generator:
     platform_exclude: m2gl025_miv

--- a/tests/kernel/mbox/mbox_api/testcase.yaml
+++ b/tests/kernel/mbox/mbox_api/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.mailbox.api:
-    tags: kernel
+    tags: kernel t1_test
   kernel.mailbox.api.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel linker_generator

--- a/tests/kernel/mbox/mbox_usage/testcase.yaml
+++ b/tests/kernel/mbox/mbox_usage/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.mailbox.usage:
-    tags: kernel
+    tags: kernel t1_test
   kernel.mailbox.usage.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel linker_generator

--- a/tests/kernel/mem_heap/k_heap_api/testcase.yaml
+++ b/tests/kernel/mem_heap/k_heap_api/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.k_heap_api:
-    tags: k_heap_api kernel
+    tags: k_heap_api kernel t1_test
   kernel.k_heap_api.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: k_heap_api kernel linker_generator

--- a/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
+++ b/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.memory_heap:
-    tags: kernel
+    tags: kernel t1_test
     extra_configs:
       - CONFIG_IRQ_OFFLOAD=y
   kernel.memory_heap_no_multithreading:

--- a/tests/kernel/mem_protect/futex/testcase.yaml
+++ b/tests/kernel/mem_protect/futex/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.futex:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: kernel userspace
+    tags: kernel userspace t1_test

--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -7,7 +7,7 @@ tests:
     # gets propagated to new Zephyr-SDK.
     platform_exclude: twr_ke18f qemu_arc_hs qemu_arc_em
     extra_args: CONFIG_TEST_HW_STACK_PROTECTION=n
-    tags: kernel security userspace ignore_faults
+    tags: kernel security userspace ignore_faults t1_test
   kernel.memory_protection.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     arch_allow: arc

--- a/tests/kernel/mem_protect/obj_validation/testcase.yaml
+++ b/tests/kernel/mem_protect/obj_validation/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.memory_protection.obj_validation:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: kernel security userspace
+    tags: kernel security userspace t1_test

--- a/tests/kernel/mem_protect/protection/testcase.yaml
+++ b/tests/kernel/mem_protect/protection/testcase.yaml
@@ -2,4 +2,4 @@ tests:
   kernel.memory_protection.protection:
     platform_exclude: twr_ke18f
     filter: CONFIG_SRAM_REGION_PERMISSIONS
-    tags: kernel security ignore_faults
+    tags: kernel security ignore_faults t1_test

--- a/tests/kernel/mem_protect/stack_random/testcase.yaml
+++ b/tests/kernel/mem_protect/stack_random/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.memory_protection.stack_random:
     arch_exclude: posix
-    tags: kernel memory_protection
+    tags: kernel memory_protection t1_test

--- a/tests/kernel/mem_protect/stackprot/testcase.yaml
+++ b/tests/kernel/mem_protect/stackprot/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.memory_protection.stackprot:
     arch_exclude: nios2 xtensa posix sparc
-    tags: kernel ignore_faults userspace
+    tags: kernel ignore_faults userspace t1_test

--- a/tests/kernel/mem_protect/sys_sem/testcase.yaml
+++ b/tests/kernel/mem_protect/sys_sem/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   kernel.memory_protection.sys_sem:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: kernel userspace
+    tags: kernel userspace t1_test
     testcases:
     - sem_take_no_wait
     - sem_take_timeout_forever
@@ -19,7 +19,7 @@ tests:
   kernel.memory_protection.sys_sem.nouser:
     extra_configs:
     - CONFIG_TEST_USERSPACE=n
-    tags: kernel
+    tags: kernel t1_test
     testcases:
     - sem_take_no_wait
     - sem_take_timeout_forever

--- a/tests/kernel/mem_protect/syscalls/testcase.yaml
+++ b/tests/kernel/mem_protect/syscalls/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   kernel.memory_protection.syscalls:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: kernel security userspace ignore_faults
+    tags: kernel security userspace ignore_faults t1_test
     # FIXME: This test may fail for qemu_arc_em on certain host systems.
     #        See foss-for-synopsys-dwc-arc-processors/qemu#66.
     platform_exclude: qemu_arc_em

--- a/tests/kernel/mem_protect/userspace/testcase.yaml
+++ b/tests/kernel/mem_protect/userspace/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   kernel.memory_protection.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_args: CONFIG_TEST_HW_STACK_PROTECTION=n
-    tags: kernel security userspace ignore_faults
+    tags: kernel security userspace ignore_faults t1_test
   kernel.memory_protection.userspace.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     arch_allow: arc

--- a/tests/kernel/mem_slab/mslab/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.memory_slabs:
-    tags: kernel
+    tags: kernel t1_test
   kernel.memory_slabs.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel linker_generator

--- a/tests/kernel/mem_slab/mslab_api/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_api/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.memory_slabs.api:
-    tags: kernel
+    tags: kernel t1_test
   kernel.memory_slabs.api_no_multithreading:
     tags: kernel
     platform_allow: qemu_cortex_m3 qemu_cortex_m0 nsim_em nsim_em7d_v22 nsim_hs

--- a/tests/kernel/mem_slab/mslab_concept/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_concept/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.memory_slabs.concept:
-    tags: kernel
+    tags: kernel t1_test
     timeout: 80
   kernel.memory_slabs.concept.linker_generator:
     platform_allow: qemu_cortex_m3

--- a/tests/kernel/mem_slab/mslab_stats/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_stats/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.memory_slab.stats:
-    tags: kernel
+    tags: kernel t1_test

--- a/tests/kernel/mem_slab/mslab_threadsafe/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_threadsafe/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.memory_slabs.threadsafe:
-    tags: kernel
+    tags: kernel t1_test
   kernel.memory_slabs.threadsafe.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel linker_generator

--- a/tests/kernel/msgq/msgq_api/testcase.yaml
+++ b/tests/kernel/msgq/msgq_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.message_queue:
-    tags: kernel userspace
+    tags: kernel userspace t1_test

--- a/tests/kernel/msgq/msgq_usage/testcase.yaml
+++ b/tests/kernel/msgq/msgq_usage/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.message_queue_usage:
-    tags: kernel
+    tags: kernel t1_test
   kernel.message_queue_usage.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel linker_generator

--- a/tests/kernel/mutex/mutex_api/testcase.yaml
+++ b/tests/kernel/mutex/mutex_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.mutex:
-    tags: kernel userspace
+    tags: kernel userspace t1_test

--- a/tests/kernel/mutex/mutex_error_case/testcase.yaml
+++ b/tests/kernel/mutex/mutex_error_case/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.mutex_error_case:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: kernel userspace ignore_faults
+    tags: kernel userspace ignore_faults t1_test

--- a/tests/kernel/mutex/sys_mutex/testcase.yaml
+++ b/tests/kernel/mutex/sys_mutex/testcase.yaml
@@ -1,14 +1,14 @@
 tests:
   system.mutex:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: kernel userspace
+    tags: kernel userspace t1_test
     testcases:
       - mutex
       - user_access
       - supervisor_access
 
   system.mutex.nouser:
-    tags: kernel
+    tags: kernel t1_test
     extra_configs:
       - CONFIG_TEST_USERSPACE=n
     testcases:

--- a/tests/kernel/obj_tracking/testcase.yaml
+++ b/tests/kernel/obj_tracking/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.objects.tracking:
-    tags: kernel
+    tags: kernel t1_test
     platform_exclude: qemu_x86_tiny

--- a/tests/kernel/pending/testcase.yaml
+++ b/tests/kernel/pending/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.objects:
-    tags: kernel
+    tags: kernel t1_test

--- a/tests/kernel/pipe/pipe/testcase.yaml
+++ b/tests/kernel/pipe/pipe/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.pipe:
-      tags: kernel userspace ignore_faults
+      tags: kernel userspace ignore_faults t1_test

--- a/tests/kernel/pipe/pipe_api/testcase.yaml
+++ b/tests/kernel/pipe/pipe_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.pipe.api:
-      tags: kernel userspace
+      tags: kernel userspace t1_test

--- a/tests/kernel/poll/testcase.yaml
+++ b/tests/kernel/poll/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   kernel.poll:
-    tags: kernel userspace ignore_faults
+    tags: kernel userspace ignore_faults t1_test
     # FIXME: qemu_arc_hs6x is excluded due to a run-time failure, see #49492
     platform_exclude: nrf52dk_nrf52810 qemu_arc_hs6x

--- a/tests/kernel/profiling/profiling_api/testcase.yaml
+++ b/tests/kernel/profiling/profiling_api/testcase.yaml
@@ -4,4 +4,4 @@ tests:
     platform_exclude: em_starterkit
       litex_vexriscv rv32m1_vega_zero_riscy rv32m1_vega_ri5cy
       nrf5340dk_nrf5340_cpunet
-    tags: kernel
+    tags: kernel t1_test

--- a/tests/kernel/queue/testcase.yaml
+++ b/tests/kernel/queue/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.queue:
-    tags: kernel userspace ignore_faults
+    tags: kernel userspace ignore_faults t1_test

--- a/tests/kernel/sched/deadline/testcase.yaml
+++ b/tests/kernel/sched/deadline/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.scheduler.deadline:
-    tags: kernel
+    tags: kernel t1_test
   kernel.scheduler.deadline.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel linker_generator

--- a/tests/kernel/sched/metairq/testcase.yaml
+++ b/tests/kernel/sched/metairq/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.scheduler.metairq:
-    tags: kernel
+    tags: kernel t1_test
     platform_exclude: nrf52dk_nrf52810
   kernel.scheduler.metairq.linker_generator:
     platform_allow: qemu_cortex_m3

--- a/tests/kernel/sched/preempt/testcase.yaml
+++ b/tests/kernel/sched/preempt/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.scheduler.preempt:
-    tags: kernel
+    tags: kernel t1_test
     platform_exclude: nrf52dk_nrf52810
   kernel.scheduler.preempt.linker_generator:
     platform_allow: qemu_cortex_m3

--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -6,38 +6,38 @@ tests:
     filter: not CONFIG_SCHED_MULTIQ
     extra_configs:
       - CONFIG_TIMESLICING=y
-    tags: kernel threads sched userspace ignore_faults
+    tags: kernel threads sched userspace ignore_faults t1_test
   kernel.scheduler.no_timeslicing:
     filter: not CONFIG_SCHED_MULTIQ
     extra_configs:
       - CONFIG_TIMESLICING=n
-    tags: kernel threads sched userspace ignore_faults
+    tags: kernel threads sched userspace ignore_faults t1_test
   kernel.scheduler.slice_perthread:
     filter: not CONFIG_SCHED_MULTIQ
     extra_configs:
       - CONFIG_TIMESLICING=y
       - CONFIG_TIMESLICE_PER_THREAD=y
-    tags: kernel threads sched userspace ignore_faults
+    tags: kernel threads sched userspace ignore_faults t1_test
   kernel.scheduler.multiq:
     extra_args: CONF_FILE=prj_multiq.conf
     extra_configs:
       - CONFIG_TIMESLICING=y
-    tags: kernel threads sched userspace ignore_faults
+    tags: kernel threads sched userspace ignore_faults t1_test
   kernel.scheduler.multiq_no_timeslicing:
     extra_args: CONF_FILE=prj_multiq.conf
     extra_configs:
       - CONFIG_TIMESLICING=n
-    tags: kernel threads sched userspacei ignore_faults
+    tags: kernel threads sched userspacei ignore_faults t1_test
   kernel.scheduler.dumb_timeslicing:
     extra_args: CONF_FILE=prj_dumb.conf
     extra_configs:
       - CONFIG_TIMESLICING=y
-    tags: kernel threads sched userspace ignore_faults
+    tags: kernel threads sched userspace ignore_faults t1_test
   kernel.scheduler.dumb_no_timeslicing:
     extra_args: CONF_FILE=prj_dumb.conf
     extra_configs:
       - CONFIG_TIMESLICING=n
-    tags: kernel threads sched userspace ignore_faults
+    tags: kernel threads sched userspace ignore_faults t1_test
   kernel.scheduler.linker_generator:
     platform_allow: qemu_cortex_m3
     filter: not CONFIG_SCHED_MULTIQ

--- a/tests/kernel/semaphore/semaphore/testcase.yaml
+++ b/tests/kernel/semaphore/semaphore/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.semaphore:
-    tags: kernel userspace ignore_faults
+    tags: kernel userspace ignore_faults t1_test

--- a/tests/kernel/semaphore/sys_sem/testcase.yaml
+++ b/tests/kernel/semaphore/sys_sem/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.semaphore.usage:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: kernel userspace ignore_faults
+    tags: kernel userspace ignore_faults t1_test

--- a/tests/kernel/sleep/testcase.yaml
+++ b/tests/kernel/sleep/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.common.timing:
-    tags: kernel sleep
+    tags: kernel sleep t1_test

--- a/tests/kernel/stack/stack/testcase.yaml
+++ b/tests/kernel/stack/stack/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.stack.usage:
-    tags: kernel userspace ignore_faults
+    tags: kernel userspace ignore_faults t1_test

--- a/tests/kernel/threads/dynamic_thread/testcase.yaml
+++ b/tests/kernel/threads/dynamic_thread/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.threads.dynamic:
-    tags: kernel threads userspace ignore_faults
+    tags: kernel threads userspace ignore_faults t1_test
     filter: CONFIG_ARCH_HAS_USERSPACE

--- a/tests/kernel/threads/thread_apis/testcase.yaml
+++ b/tests/kernel/threads/thread_apis/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.threads.apis:
-    tags: kernel threads userspace ignore_faults
+    tags: kernel threads userspace ignore_faults t1_test
     min_flash: 34
   kernel.threads.apis.pinonly:
     tags: kernel threads userspace ignore_faults

--- a/tests/kernel/threads/thread_error_case/testcase.yaml
+++ b/tests/kernel/threads/thread_error_case/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   kernel.threads.error.case:
-    tags: kernel threads userspace ignore_faults
+    tags: kernel threads userspace ignore_faults t1_test
     filter: CONFIG_USERSPACE

--- a/tests/kernel/threads/thread_init/testcase.yaml
+++ b/tests/kernel/threads/thread_init/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.threads.init:
-    tags: kernel threads userspace
+    tags: kernel threads userspace t1_test

--- a/tests/kernel/threads/thread_stack/testcase.yaml
+++ b/tests/kernel/threads/thread_stack/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.threads.thread_stack:
-    tags: kernel security userspace ignore_faults
+    tags: kernel security userspace ignore_faults t1_test
     min_ram: 16
   kernel.threads.armv8m_mpu_stack_guard:
     min_ram: 16

--- a/tests/kernel/threads/tls/testcase.yaml
+++ b/tests/kernel/threads/tls/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
   kernel.threads.tls:
-    tags: kernel threads
+    tags: kernel threads t1_test
     filter: CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
   kernel.threads.tls.userspace:
-    tags: kernel threads userspace
+    tags: kernel threads userspace t1_test
     filter: CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_ARCH_HAS_USERSPACE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
       - CONFIG_TEST_USERSPACE=y

--- a/tests/kernel/tickless/tickless_concept/testcase.yaml
+++ b/tests/kernel/tickless/tickless_concept/testcase.yaml
@@ -5,4 +5,4 @@ tests:
     # consistently when coverage is enabled. Disable until 14173 is fixed.
     platform_exclude: litex_vexriscv rv32m1_vega_zero_riscy rv32m1_vega_ri5cy
       nrf5340dk_nrf5340_cpunet nucleo_l073rz
-    tags: kernel
+    tags: kernel t1_test

--- a/tests/kernel/timer/cycle64/testcase.yaml
+++ b/tests/kernel/timer/cycle64/testcase.yaml
@@ -11,7 +11,7 @@
 # timeout as necessary.
 tests:
   kernel.timer.cycle64:
-    tags: kernel timer
+    tags: kernel timer t1_test
     filter: CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
     platform_exclude: native_posix
     timeout: 140

--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -1,12 +1,12 @@
 tests:
   kernel.timer:
-    tags: kernel timer userspace
+    tags: kernel timer userspace t1_test
   kernel.timer.tickless:
     extra_args: CONF_FILE="prj_tickless.conf"
     arch_exclude: nios2 posix
     platform_exclude: litex_vexriscv rv32m1_vega_zero_riscy rv32m1_vega_ri5cy
       nrf5340dk_nrf5340_cpunet
-    tags: kernel timer userspace
+    tags: kernel timer userspace t1_test
   kernel.timer.no_multitheading:
     tags: kernel timer
     platform_allow: qemu_cortex_m3 nsim_em nsim_em7d_v22 nsim_hs nsim_hs_mpuv6

--- a/tests/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/kernel/timer/timer_behavior/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.timer.timer:
-    tags: kernel timer
+    tags: kernel timer t1_test
     min_ram: 16
     platform_type:
       - mcu

--- a/tests/kernel/timer/timer_error_case/testcase.yaml
+++ b/tests/kernel/timer/timer_error_case/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   kernel.timer.error_case:
-    tags: kernel timer userspace ignore_faults
+    tags: kernel timer userspace ignore_faults t1_test

--- a/tests/kernel/timer/timer_monotonic/testcase.yaml
+++ b/tests/kernel/timer/timer_monotonic/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.timer.monotonic:
-    tags: kernel timer
+    tags: kernel timer t1_test
     # FIXME: This test may fail for qemu_arc_hs on certain host systems.
     #        See foss-for-synopsys-dwc-arc-processors/qemu#67.
     platform_exclude: qemu_arc_hs

--- a/tests/kernel/usage/thread_runtime_stats/testcase.yaml
+++ b/tests/kernel/usage/thread_runtime_stats/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   kernel.usage:
-    tags: kernel
+    tags: kernel t1_test
 # The following architectures are excluded as they have boards that
 # exhibit precision timing anomalies related to emulation.
 #     posix, riscv32, sparc

--- a/tests/kernel/workq/user_work/testcase.yaml
+++ b/tests/kernel/workq/user_work/testcase.yaml
@@ -2,4 +2,4 @@ tests:
   kernel.work.user:
     min_flash: 34
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: kernel userspace
+    tags: kernel userspace t1_test

--- a/tests/kernel/workq/work/testcase.yaml
+++ b/tests/kernel/workq/work/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   kernel.work.api:
     min_flash: 34
-    tags: kernel
+    tags: kernel t1_test
     # this platform fails to run due to #40376, all
     # the related CI checks got blocked, so exclude it.
     platform_exclude: hifive1

--- a/tests/kernel/workq/work_queue/testcase.yaml
+++ b/tests/kernel/workq/work_queue/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   kernel.workqueue:
     min_flash: 34
-    tags: kernel
+    tags: kernel t1_test
   kernel.workqueue.linker_generator:
     platform_allow: qemu_cortex_m3
     min_flash: 34

--- a/tests/kernel/xip/testcase.yaml
+++ b/tests/kernel/xip/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   arch.common.xip:
     filter: CONFIG_XIP
-    tags: kernel xip
+    tags: kernel xip t1_test
   arch.common.xip.linker_generator:
     platform_allow: qemu_cortex_m3
     filter: CONFIG_XIP


### PR DESCRIPTION
according to #51286 we need tag the t1 cases as t1_test

cases with explicit arch/platfrom requirement are excluded cases with platform_allow are excluded

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>