### PR TITLE
drivers: eeprom: add missing include to nxp eeprom driver

### DIFF
--- a/drivers/eeprom/eeprom_lpc11u6x.c
+++ b/drivers/eeprom/eeprom_lpc11u6x.c
@@ -16,6 +16,7 @@
  *       EEPROM functions.
  */
 
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/eeprom.h>
 #include <iap.h>
 


### PR DESCRIPTION
The include <zephyr/kernel.h> is missing from eeprom driver, causing build error. 
This is fixing it like PR # 51246 or #51220.

Signed-off-by: Francois Ramu <francois.ramu@st.com>