### PR TITLE
driver: eSPI: npcx: support multiple bytes mode for Port80

### DIFF
--- a/drivers/espi/Kconfig.npcx
+++ b/drivers/espi/Kconfig.npcx
@@ -41,6 +41,13 @@ config ESPI_NPCX_BYPASS_CH_ENABLE_FATAL_ERROR
 	  a wrong state and therefore response with FATAL_ERROR on an incoming
 	  transaction.
 
+config ESPI_NPCX_PERIPHERAL_DEBUG_PORT_80_MULTI_BYTE
+	bool "Host can write 1/2/4 bytes of Port80 data in a eSPI transaction"
+	depends on SOC_SERIES_NPCX9 && ESPI_PERIPHERAL_DEBUG_PORT_80
+	help
+	  EC can accept 1/2/4 bytes of Port 80 data written from the Host in an
+	  eSPI transaction.
+
 # The default value 'y' for the existing options if ESPI_NPCX is selected.
 if ESPI_NPCX
 

--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -192,15 +192,16 @@ struct host_sub_npcx_data host_sub_data;
 #define EC_CFG_IDX_DATA_IO_ADDR_L  0x63
 
 /* Index of Special Logical Device Configuration (Shared Memory Module) */
-#define EC_CFG_IDX_SHM_CFG         0xF1
-#define EC_CFG_IDX_SHM_WND1_ADDR_0 0xF4
-#define EC_CFG_IDX_SHM_WND1_ADDR_1 0xF5
-#define EC_CFG_IDX_SHM_WND1_ADDR_2 0xF6
-#define EC_CFG_IDX_SHM_WND1_ADDR_3 0xF7
-#define EC_CFG_IDX_SHM_WND2_ADDR_0 0xF8
-#define EC_CFG_IDX_SHM_WND2_ADDR_1 0xF9
-#define EC_CFG_IDX_SHM_WND2_ADDR_2 0xFA
-#define EC_CFG_IDX_SHM_WND2_ADDR_3 0xFB
+#define EC_CFG_IDX_SHM_CFG             0xF1
+#define EC_CFG_IDX_SHM_WND1_ADDR_0     0xF4
+#define EC_CFG_IDX_SHM_WND1_ADDR_1     0xF5
+#define EC_CFG_IDX_SHM_WND1_ADDR_2     0xF6
+#define EC_CFG_IDX_SHM_WND1_ADDR_3     0xF7
+#define EC_CFG_IDX_SHM_WND2_ADDR_0     0xF8
+#define EC_CFG_IDX_SHM_WND2_ADDR_1     0xF9
+#define EC_CFG_IDX_SHM_WND2_ADDR_2     0xFA
+#define EC_CFG_IDX_SHM_WND2_ADDR_3     0xFB
+#define EC_CFG_IDX_SHM_DP80_ADDR_RANGE 0xFD
 
 /* Host sub-device local inline functions */
 static inline uint8_t host_shd_mem_wnd_size_sl(uint32_t size)
@@ -482,14 +483,57 @@ static void host_port80_isr(const void *arg)
 	};
 	uint8_t status = inst_shm->DP80STS;
 
-	LOG_DBG("%s: p80 status 0x%02X", __func__, status);
+	if (!IS_ENABLED(CONFIG_ESPI_NPCX_PERIPHERAL_DEBUG_PORT_80_MULTI_BYTE)) {
+		LOG_DBG("%s: p80 status 0x%02X", __func__, status);
 
-	/* Read out port80 data continuously if FIFO is not empty */
-	while (IS_BIT_SET(inst_shm->DP80STS, NPCX_DP80STS_FNE)) {
-		LOG_DBG("p80: %04x", inst_shm->DP80BUF);
-		evt.evt_data = inst_shm->DP80BUF;
-		espi_send_callbacks(host_sub_data.callbacks,
-				host_sub_data.host_bus_dev, evt);
+		/* Read out port80 data continuously if FIFO is not empty */
+		while (IS_BIT_SET(inst_shm->DP80STS, NPCX_DP80STS_FNE)) {
+			LOG_DBG("p80: %04x", inst_shm->DP80BUF);
+			evt.evt_data = inst_shm->DP80BUF;
+			espi_send_callbacks(host_sub_data.callbacks, host_sub_data.host_bus_dev,
+					    evt);
+		}
+
+	} else {
+		uint16_t port80_buf[16];
+		uint8_t count = 0;
+		uint32_t code = 0;
+
+		while (IS_BIT_SET(inst_shm->DP80STS, NPCX_DP80STS_FNE) &&
+		       count < ARRAY_SIZE(port80_buf)) {
+			port80_buf[count++] = inst_shm->DP80BUF;
+		}
+
+		for (uint8_t i = 0; i < count; i++) {
+			uint8_t offset;
+			uint32_t buf_data;
+
+			buf_data = port80_buf[i];
+			offset = GET_FIELD(buf_data, NPCX_DP80BUF_OFFS_FIELD);
+			code |= (buf_data & 0xFF) << (8 * offset);
+
+			if (i == count - 1) {
+				evt.evt_data = code;
+				espi_send_callbacks(host_sub_data.callbacks,
+						    host_sub_data.host_bus_dev, evt);
+				break;
+			}
+
+			/* peek the offset of the next byte */
+			buf_data = port80_buf[i + 1];
+			offset = GET_FIELD(buf_data, NPCX_DP80BUF_OFFS_FIELD);
+			/*
+			 * If the peeked next byte's offset is 0 means it is the start
+			 * of the new code. Pass the current code to Port80
+			 * common layer.
+			 */
+			if (offset == 0) {
+				evt.evt_data = code;
+				espi_send_callbacks(host_sub_data.callbacks,
+						    host_sub_data.host_bus_dev, evt);
+				code = 0;
+			}
+		}
 	}
 
 	/* If FIFO is overflow, show error msg */
@@ -975,6 +1019,9 @@ void npcx_host_init_subs_host_domain(void)
 		host_c2h_write_io_cfg_reg(EC_CFG_IDX_SHM_WND2_ADDR_0,
 		CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION_PORT_NUM & 0xff);
 #endif
+		if (IS_ENABLED(CONFIG_ESPI_NPCX_PERIPHERAL_DEBUG_PORT_80_MULTI_BYTE)) {
+			host_c2h_write_io_cfg_reg(EC_CFG_IDX_SHM_DP80_ADDR_RANGE, 0x0f);
+		}
 	/* Enable SHM direct memory access */
 	host_c2h_write_io_cfg_reg(EC_CFG_IDX_CTRL, 0x01);
 	}

--- a/soc/arm/nuvoton_npcx/common/reg/reg_def.h
+++ b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
@@ -955,6 +955,7 @@ struct shm_reg {
 #define NPCX_DP80CTL_RFIFO               4
 #define NPCX_DP80CTL_CIEN                5
 #define NPCX_DP80CTL_DP80_HF_CFG         7
+#define NPCX_DP80BUF_OFFS_FIELD          FIELD(8, 3)
 
 /*
  * Keyboard and Mouse Controller (KBC) device registers


### PR DESCRIPTION
eSPI PUT_IOWR_SHORT protocol can send 1/2/4 bytes of data in a single transaction. This allows the host to send max 32-bits Port80 code at one time. This CL sets bits OFS0_SEL~OFS3_SEL in the DPAR1 register to let the EC hardware put the full Port80 code to DP80BUF FIFO. It also groups the N-byte code into a single 32-bits variable when necessary by analyzing the offset field in the DP80BUF register.

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>
