### PR TITLE
samples: external_lib: Add building on windows support

### DIFF
--- a/samples/application_development/external_lib/README.rst
+++ b/samples/application_development/external_lib/README.rst
@@ -5,7 +5,34 @@ External Library
 
 Overview
 ********
+
 A simple example that demonstrates how to include an external static library
 into the Zephyr build system.
 The demonstrates both how to build the external library using a different build
 system and how to include the built static library.
+
+Windows Note
+************
+
+To use this sample on a Windows host operating system, GNU Make needs to be in
+your path. This can be setup using chocolatey or by manually installing it.
+
+Chocolatey Method
+=================
+
+Install make using the following command:
+
+.. code-block:: bash
+
+   choco install make
+
+Once installed, build the application as normal.
+
+Manual Install Method
+=====================
+
+The pre-built make application can be downloaded from
+https://gnuwin32.sourceforge.net/packages/make.htm by either getting both the
+``Binaries`` and ``Dependencies`` and extracting them to the same folder, or
+getting the ``Complete package`` setup. Once installed and in the path, build
+the application as normal.

--- a/samples/application_development/external_lib/mylib/Makefile
+++ b/samples/application_development/external_lib/mylib/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2017 Intel Corporation
+# Copyright (c) 2022 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -8,10 +9,19 @@ PREFIX ?= .
 OBJ_DIR ?= $(PREFIX)/obj
 LIB_DIR ?= $(PREFIX)/lib
 
+ifeq ($(findstring Windows, $(OS)),Windows)
+	DEL := rmdir /S /Q
+	MKDIR := mkdir
+else
+	DEL := rm -rf
+	MKDIR := mkdir -p
+endif
+
 all:
-	mkdir -p $(OBJ_DIR) $(LIB_DIR)
+	-$(MKDIR) "$(OBJ_DIR)"
+	-$(MKDIR) "$(LIB_DIR)"
 	$(CC) -c $(CFLAGS) -MD -Iinclude src/mylib.c -o $(OBJ_DIR)/mylib.o
 	$(AR) -rcs $(LIB_DIR)/libmylib.a $(OBJ_DIR)/mylib.o
 
 clean:
-	rm -rf $(OBJ_DIR) $(LIB_DIR)
+	$(DEL) "$(OBJ_DIR)" "$(LIB_DIR)"


### PR DESCRIPTION
Adds support for building the external_lib sample application on a windows host operating system.

Fixes #51290