### PR TITLE
tests: bluetooth: host: Fix CI failures with bt_keys_get_addr() UT

### DIFF
--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/main.c
@@ -163,7 +163,9 @@ static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixt
 
 	/* Skip tests if not all startup suite hasn't been executed */
 	if (strcmp(test->test_suite_name, "bt_keys_get_addr_startup")) {
-		zassume_true(all_startup_checks_executed == true, NULL);
+		if (all_startup_checks_executed != true) {
+			ztest_test_skip();
+		}
 	}
 
 	CONN_FFF_FAKES_LIST(RESET_FAKE);


### PR DESCRIPTION
CI tests were failing due to a recent change to zassume_true() implementation.
While the test case is still skipped when assumption fails, but it is now causing the final execution result to fail.

zassume_true() was replaced by ztest_test_skip() combined with a conditional 'if' statement to get the required effect.

Signed-off-by: Ahmed Moheb <ahmed.moheb@nordicsemi.no>