### PR TITLE
tests: bluetooth: host: keys: Add new predicate function

### DIFF
--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/main.c
@@ -24,15 +24,10 @@ const struct id_addr_pair testing_id_addr_pair_lut[] = {
 /* This list will hold returned references while filling keys pool */
 struct bt_keys *returned_keys_refs[CONFIG_BT_MAX_PAIRED];
 
-static bool all_startup_checks_executed;
+extern bool all_startup_checks_executed;
 
 BUILD_ASSERT(ARRAY_SIZE(testing_id_addr_pair_lut) == CONFIG_BT_MAX_PAIRED);
 BUILD_ASSERT(ARRAY_SIZE(testing_id_addr_pair_lut) == ARRAY_SIZE(returned_keys_refs));
-
-static bool startup_suite_predicate(const void *global_state)
-{
-	return (all_startup_checks_executed == false);
-}
 
 ZTEST_SUITE(bt_keys_get_addr_startup, startup_suite_predicate, NULL, NULL, NULL, NULL);
 
@@ -51,7 +46,7 @@ ZTEST(bt_keys_get_addr_startup, test_keys_pool_list_is_empty_at_startup)
 		     "List isn't empty, make sure to run this test just after a fresh start");
 }
 
-ZTEST_SUITE(bt_keys_get_addr_populate_non_existing_keys, NULL, NULL, NULL, NULL, NULL);
+ZTEST_SUITE(bt_keys_get_addr_populate_non_existing_keys, non_startup_suite_predicate, NULL, NULL, NULL, NULL);
 
 /*
  *  Test filling the keys pool with (ID, Address) pairs
@@ -122,7 +117,7 @@ static void test_case_setup(void *f)
 	zassert_true(rv == 0, "Failed to fill keys pool list, error code %d", -rv);
 }
 
-ZTEST_SUITE(bt_keys_get_addr_get_existing_keys, NULL, NULL, test_case_setup, NULL, NULL);
+ZTEST_SUITE(bt_keys_get_addr_get_existing_keys, non_startup_suite_predicate, NULL, test_case_setup, NULL, NULL);
 
 /*
  *  Test getting a valid key reference by a matching ID and address pair
@@ -160,12 +155,6 @@ ZTEST(bt_keys_get_addr_get_existing_keys, test_get_key_by_matched_id_and_address
 
 static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-
-	/* Skip tests if not all startup suite hasn't been executed */
-	if (strcmp(test->test_suite_name, "bt_keys_get_addr_startup")) {
-		zassume_true(all_startup_checks_executed == true, NULL);
-	}
-
 	CONN_FFF_FAKES_LIST(RESET_FAKE);
 	HCI_CORE_FFF_FAKES_LIST(RESET_FAKE);
 }

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_invalid_values.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_invalid_values.c
@@ -20,6 +20,8 @@ extern const struct id_addr_pair testing_id_addr_pair_lut[CONFIG_BT_MAX_PAIRED];
 /* This list holds returned references while filling keys pool */
 extern struct bt_keys *returned_keys_refs[CONFIG_BT_MAX_PAIRED];
 
+extern bool all_startup_checks_executed;
+
 static int bt_unpair_unreachable_custom_fake(uint8_t id, const bt_addr_le_t *addr)
 {
 	ARG_UNUSED(id);
@@ -53,7 +55,7 @@ static void test_case_setup(void *f)
 	zassert_true(rv == 0, "Failed to fill keys pool list, error code %d", -rv);
 }
 
-ZTEST_SUITE(bt_keys_find_key_in_use_invalid_cases, NULL, NULL, test_case_setup, NULL, NULL);
+ZTEST_SUITE(bt_keys_find_key_in_use_invalid_cases, non_startup_suite_predicate, NULL, test_case_setup, NULL, NULL);
 
 /*
  *  Test adding extra (ID, Address) pair while the keys pool list is full, but while looking

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_no_overwrite.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_no_overwrite.c
@@ -17,6 +17,8 @@ extern const struct id_addr_pair testing_id_addr_pair_lut[CONFIG_BT_MAX_PAIRED];
 /* This list holds returned references while filling keys pool */
 extern struct bt_keys *returned_keys_refs[CONFIG_BT_MAX_PAIRED];
 
+extern bool all_startup_checks_executed;
+
 /* Setup test variables */
 static void test_case_setup(void *f)
 {
@@ -30,7 +32,7 @@ static void test_case_setup(void *f)
 	zassert_true(rv == 0, "Failed to fill keys pool list, error code %d", -rv);
 }
 
-ZTEST_SUITE(bt_keys_get_addr_full_list_no_overwrite, NULL, NULL, test_case_setup, NULL, NULL);
+ZTEST_SUITE(bt_keys_get_addr_full_list_no_overwrite, non_startup_suite_predicate, NULL, test_case_setup, NULL, NULL);
 
 /*
  *  Test adding extra (ID, Address) pair while the keys pool list is full.

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_overwrite_oldest.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_overwrite_oldest.c
@@ -19,6 +19,8 @@ extern const struct id_addr_pair testing_id_addr_pair_lut[CONFIG_BT_MAX_PAIRED];
 /* This list holds returned references while filling keys pool */
 extern struct bt_keys *returned_keys_refs[CONFIG_BT_MAX_PAIRED];
 
+extern bool all_startup_checks_executed;
+
 /* Pointer to the current set of oldest testing parameter */
 struct id_addr_pair const *oldest_params_vector;
 
@@ -114,7 +116,7 @@ static void test_case_setup(void *f)
 	zassert_true(rv == 0, "Failed to fill keys pool list, error code %d", -rv);
 }
 
-ZTEST_SUITE(bt_keys_get_addr_full_list_overwrite_oldest, NULL, NULL, test_case_setup, NULL, NULL);
+ZTEST_SUITE(bt_keys_get_addr_full_list_overwrite_oldest, non_startup_suite_predicate, NULL, test_case_setup, NULL, NULL);
 
 /*
  *  Test adding extra (ID, Address) pair while the keys pool list is full while all keys are in

--- a/tests/bluetooth/host/keys/testing_common_defs.h
+++ b/tests/bluetooth/host/keys/testing_common_defs.h
@@ -17,3 +17,15 @@
 #define BT_ADDR_LE_3 ((bt_addr_le_t[]) { { 0, { { 0x0C, 0x89, 0x67, 0x45, 0x23, 0x01 } } } })
 #define BT_ADDR_LE_4 ((bt_addr_le_t[]) { { 0, { { 0x0D, 0x89, 0x67, 0x45, 0x23, 0x01 } } } })
 #define BT_ADDR_LE_5 ((bt_addr_le_t[]) { { 0, { { 0x0E, 0x89, 0x67, 0x45, 0x23, 0x01 } } } })
+
+bool all_startup_checks_executed;
+
+static inline bool non_startup_suite_predicate(const void *global_state)
+{
+	return (all_startup_checks_executed == true);
+}
+
+static inline bool startup_suite_predicate(const void *global_state)
+{
+	return (all_startup_checks_executed == false);
+}


### PR DESCRIPTION
-Remove zassume_true rule to stop failing CI see https://github.com/zephyrproject-rtos/zephyr/actions/runs/3245887043/jobs/5323991930
-Add non_startup_suite_predicate function to determine running tests
-Move predicate functions to testing_common_defs

Signed-off-by: Sean Madigan <sean.madigan@nordicsemi.no>