### PR TITLE
[RFC] device: s/DEVIC_DT_GET_ANY/DEVICE_DT_GET_ONE_OR_NULL

### DIFF
--- a/doc/build/dts/howtos.rst
+++ b/doc/build/dts/howtos.rst
@@ -113,7 +113,7 @@ device is to use :c:func:`DEVICE_DT_GET`:
 
 There are variants of :c:func:`DEVICE_DT_GET` such as
 :c:func:`DEVICE_DT_GET_OR_NULL`, :c:func:`DEVICE_DT_GET_ONE` or
-:c:func:`DEVICE_DT_GET_ANY`. This idiom fetches the device pointer at
+:c:func:`DEVICE_DT_GET_ONE_OR_NULL`. This idiom fetches the device pointer at
 build-time, which means there is no runtime penalty. This method is useful if
 you want to store the device pointer as configuration data. But because the
 device may not be initialized, or may have failed to initialize, you must verify

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -40,6 +40,7 @@
 #include <zephyr/linker/sections.h>
 #include <zephyr/sys/device_mmio.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -297,10 +298,21 @@ typedef int16_t device_handle_t;
  * @param compat lowercase-and-underscores devicetree compatible
  * @return a pointer to a device, or NULL
  */
-#define DEVICE_DT_GET_ANY(compat)					    \
+#define DEVICE_DT_GET_ONE_OR_NULL(compat)				    \
 	COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(compat),			    \
 		    (DEVICE_DT_GET(DT_COMPAT_GET_ANY_STATUS_OKAY(compat))), \
 		    (NULL))
+
+/**
+ * @brief Get a <tt>const struct device*</tt> from a devicetree compatible
+ *
+ * @param compat lowercase-and-underscores devicetree compatible
+ * @return a pointer to a device, or NULL
+ *
+ * @deprecated Use DEVICE_DT_GET_ONE_OR_NULL() instead.
+ */
+#define DEVICE_DT_GET_ANY(compat) __DEPRECATED_MACRO \
+	DEVICE_DT_GET_ONE_OR_NULL(compat)
 
 /**
  * @brief Get a <tt>const struct device*</tt> from a devicetree compatible

--- a/samples/bluetooth/mesh_demo/src/microbit.c
+++ b/samples/bluetooth/mesh_demo/src/microbit.c
@@ -35,7 +35,7 @@ static const struct gpio_dt_spec button_b =
 static const struct device *const nvm =
 	DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 static const struct device *const pwm =
-	DEVICE_DT_GET_ANY(nordic_nrf_sw_pwm);
+	DEVICE_DT_GET_ONE_OR_NULL(nordic_nrf_sw_pwm);
 
 static struct k_work button_work;
 

--- a/samples/bluetooth/peripheral_ht/src/hts.c
+++ b/samples/bluetooth/peripheral_ht/src/hts.c
@@ -26,7 +26,7 @@
 #include <zephyr/bluetooth/gatt.h>
 
 #ifdef CONFIG_TEMP_NRF5
-static const struct device *temp_dev = DEVICE_DT_GET_ANY(nordic_nrf_temp);
+static const struct device *temp_dev = DEVICE_DT_GET_ONE_OR_NULL(nordic_nrf_temp);
 #else
 static const struct device *temp_dev;
 #endif

--- a/samples/drivers/ipm/ipm_mcux/remote/src/main_remote.c
+++ b/samples/drivers/ipm/ipm_mcux/remote/src/main_remote.c
@@ -21,7 +21,7 @@ void main(void)
 {
 	const struct device *ipm;
 
-	ipm = DEVICE_DT_GET_ANY(nxp_lpc_mailbox);
+	ipm = DEVICE_DT_GET_ONE_OR_NULL(nxp_lpc_mailbox);
 	if (!(ipm && device_is_ready(ipm))) {
 		while (1) {
 		}

--- a/samples/drivers/ipm/ipm_mcux/src/main_master.c
+++ b/samples/drivers/ipm/ipm_mcux/src/main_master.c
@@ -35,7 +35,7 @@ void main(void)
 	printk("Hello World from MASTER! %s\n", CONFIG_ARCH);
 
 	/* Get IPM device handle */
-	ipm = DEVICE_DT_GET_ANY(nxp_lpc_mailbox);
+	ipm = DEVICE_DT_GET_ONE_OR_NULL(nxp_lpc_mailbox);
 	if (!(ipm && device_is_ready(ipm))) {
 		printk("Could not get IPM device handle!\n");
 		while (1) {

--- a/samples/drivers/ipm/ipm_mhu_dual_core/src/main.c
+++ b/samples/drivers/ipm/ipm_mhu_dual_core/src/main.c
@@ -49,7 +49,7 @@ void main(void)
 {
 	printk("IPM MHU sample on %s\n", CONFIG_BOARD);
 
-	mhu0 = DEVICE_DT_GET_ANY(arm_mhu);
+	mhu0 = DEVICE_DT_GET_ONE_OR_NULL(arm_mhu);
 	if (!(mhu0 && device_is_ready(mhu0))) {
 		printk("CPU %d, get MHU0 fail!\n",
 				sse_200_platform_get_cpu_id());

--- a/samples/drivers/led_apa102/src/main.c
+++ b/samples/drivers/led_apa102/src/main.c
@@ -56,7 +56,7 @@ void main(void)
 	const struct device *strip;
 	size_t i, time;
 
-	strip = DEVICE_DT_GET_ANY(apa_apa102);
+	strip = DEVICE_DT_GET_ONE_OR_NULL(apa_apa102);
 	if (!strip) {
 		LOG_ERR("LED strip device not found");
 		return;

--- a/samples/drivers/led_lp3943/src/main.c
+++ b/samples/drivers/led_lp3943/src/main.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(app);
 
 void main(void)
 {
-	const struct device *const led_dev = DEVICE_DT_GET_ANY(ti_lp3943);
+	const struct device *const led_dev = DEVICE_DT_GET_ONE_OR_NULL(ti_lp3943);
 	int i, ret;
 
 	if (!led_dev) {

--- a/samples/drivers/led_lp503x/src/main.c
+++ b/samples/drivers/led_lp503x/src/main.c
@@ -211,7 +211,7 @@ static int run_channel_test(const struct device *lp503x_dev)
 
 void main(void)
 {
-	const struct device *const lp503x_dev = DEVICE_DT_GET_ANY(ti_lp503x);
+	const struct device *const lp503x_dev = DEVICE_DT_GET_ONE_OR_NULL(ti_lp503x);
 
 	int err;
 	uint8_t led;

--- a/samples/drivers/led_lp5562/src/main.c
+++ b/samples/drivers/led_lp5562/src/main.c
@@ -164,7 +164,7 @@ static int turn_off_all_leds(const struct device *dev)
 
 void main(void)
 {
-	const struct device *const dev = DEVICE_DT_GET_ANY(ti_lp5562);
+	const struct device *const dev = DEVICE_DT_GET_ONE_OR_NULL(ti_lp5562);
 	int i, ret;
 
 	if (!dev) {

--- a/samples/drivers/led_lpd8806/src/main.c
+++ b/samples/drivers/led_lpd8806/src/main.c
@@ -38,7 +38,7 @@ static const struct led_rgb black = {
 
 struct led_rgb strip_colors[STRIP_NUM_LEDS];
 
-static const struct device *const strip = DEVICE_DT_GET_ANY(greeled_lpd8806);
+static const struct device *const strip = DEVICE_DT_GET_ONE_OR_NULL(greeled_lpd8806);
 
 const struct led_rgb *color_at(size_t time, size_t i)
 {

--- a/samples/drivers/led_pca9633/src/main.c
+++ b/samples/drivers/led_pca9633/src/main.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(main);
 
 void main(void)
 {
-	const struct device *const led_dev = DEVICE_DT_GET_ANY(nxp_pca9633);
+	const struct device *const led_dev = DEVICE_DT_GET_ONE_OR_NULL(nxp_pca9633);
 	int i, ret;
 
 	if (!led_dev) {

--- a/samples/sensor/bme280/src/main.c
+++ b/samples/sensor/bme280/src/main.c
@@ -16,7 +16,7 @@
  */
 static const struct device *get_bme280_device(void)
 {
-	const struct device *const dev = DEVICE_DT_GET_ANY(bosch_bme280);
+	const struct device *const dev = DEVICE_DT_GET_ONE_OR_NULL(bosch_bme280);
 
 	if (dev == NULL) {
 		/* No such node, or the node does not have status "okay". */

--- a/samples/sensor/bmg160/src/main.c
+++ b/samples/sensor/bmg160/src/main.c
@@ -172,7 +172,7 @@ static void test_trigger_mode(const struct device *bmg160)
 
 void main(void)
 {
-	const struct device *const bmg160 = DEVICE_DT_GET_ANY(bosch_bmg160);
+	const struct device *const bmg160 = DEVICE_DT_GET_ONE_OR_NULL(bosch_bmg160);
 #if defined(CONFIG_BMG160_RANGE_RUNTIME)
 	struct sensor_value attr;
 #endif

--- a/samples/sensor/ds18b20/src/main.c
+++ b/samples/sensor/ds18b20/src/main.c
@@ -15,7 +15,7 @@
  */
 static const struct device *get_ds18b20_device(void)
 {
-	const struct device *const dev = DEVICE_DT_GET_ANY(maxim_ds18b20);
+	const struct device *const dev = DEVICE_DT_GET_ONE_OR_NULL(maxim_ds18b20);
 
 	if (dev == NULL) {
 		/* No such node, or the node does not have status "okay". */

--- a/samples/sensor/fxas21002/src/main.c
+++ b/samples/sensor/fxas21002/src/main.c
@@ -19,7 +19,7 @@ static void trigger_handler(const struct device *dev,
 void main(void)
 {
 	struct sensor_value gyro[3];
-	const struct device *const dev = DEVICE_DT_GET_ANY(nxp_fxas21002);
+	const struct device *const dev = DEVICE_DT_GET_ONE_OR_NULL(nxp_fxas21002);
 
 	if (dev == NULL || !device_is_ready(dev)) {
 		printf("Could not get fxas21002 device\n");

--- a/samples/sensor/lis2dh/src/main.c
+++ b/samples/sensor/lis2dh/src/main.c
@@ -65,7 +65,7 @@ static void trigger_handler(const struct device *dev,
 
 void main(void)
 {
-	const struct device *const sensor = DEVICE_DT_GET_ANY(st_lis2dh);
+	const struct device *const sensor = DEVICE_DT_GET_ONE_OR_NULL(st_lis2dh);
 
 	if (sensor == NULL) {
 		printf("No device found\n");

--- a/samples/sensor/max30101/src/main.c
+++ b/samples/sensor/max30101/src/main.c
@@ -11,7 +11,7 @@
 void main(void)
 {
 	struct sensor_value green;
-	const struct device *const dev = DEVICE_DT_GET_ANY(maxim_max30101);
+	const struct device *const dev = DEVICE_DT_GET_ONE_OR_NULL(maxim_max30101);
 
 	if (dev == NULL) {
 		printf("Could not get max30101 device\n");

--- a/samples/sensor/mcp9808/src/main.c
+++ b/samples/sensor/mcp9808/src/main.c
@@ -106,7 +106,7 @@ static void trigger_handler(const struct device *dev,
 
 void main(void)
 {
-	const struct device *const dev = DEVICE_DT_GET_ANY(microchip_mcp9808);
+	const struct device *const dev = DEVICE_DT_GET_ONE_OR_NULL(microchip_mcp9808);
 	int rc;
 
 	if (dev == NULL) {

--- a/samples/sensor/ms5837/src/main.c
+++ b/samples/sensor/ms5837/src/main.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(main);
 void main(void)
 {
 	struct sensor_value oversampling_rate = { 8192, 0 };
-	const struct device *const dev = DEVICE_DT_GET_ANY(meas_ms5837);
+	const struct device *const dev = DEVICE_DT_GET_ONE_OR_NULL(meas_ms5837);
 
 	if (dev == NULL) {
 		LOG_ERR("Could not find MS5837 device, aborting test.");

--- a/samples/sensor/sgp40_sht4x/src/main.c
+++ b/samples/sensor/sgp40_sht4x/src/main.c
@@ -27,8 +27,8 @@ void main(void)
 	struct sensor_value comp_t;
 	struct sensor_value comp_rh;
 #endif
-	const struct device *const sht = DEVICE_DT_GET_ANY(sensirion_sht4x);
-	const struct device *const sgp = DEVICE_DT_GET_ANY(sensirion_sgp40);
+	const struct device *const sht = DEVICE_DT_GET_ONE_OR_NULL(sensirion_sht4x);
+	const struct device *const sgp = DEVICE_DT_GET_ONE_OR_NULL(sensirion_sgp40);
 	struct sensor_value temp, hum, gas;
 
 	if (!device_is_ready(sht)) {

--- a/samples/sensor/tmp108/src/main.c
+++ b/samples/sensor/tmp108/src/main.c
@@ -135,12 +135,12 @@ void main(void)
 
 	printf("TI TMP108 Example, %s\n", CONFIG_ARCH);
 
-	temp_sensor = DEVICE_DT_GET_ANY(ti_tmp108);
+	temp_sensor = DEVICE_DT_GET_ONE_OR_NULL(ti_tmp108);
 
 	if (!temp_sensor) {
 		printf("warning: tmp108 device not found checking for compatible ams device\n");
 
-		temp_sensor = DEVICE_DT_GET_ANY(ams_as6212);
+		temp_sensor = DEVICE_DT_GET_ONE_OR_NULL(ams_as6212);
 
 		if (!temp_sensor) {
 			printf("error: tmp108 compatible devices not found\n");

--- a/samples/sensor/tmp112/src/main.c
+++ b/samples/sensor/tmp112/src/main.c
@@ -56,7 +56,7 @@ static void do_main(const struct device *dev)
 
 void main(void)
 {
-	const struct device *const dev = DEVICE_DT_GET_ANY(ti_tmp112);
+	const struct device *const dev = DEVICE_DT_GET_ONE_OR_NULL(ti_tmp112);
 
 	__ASSERT(dev != NULL, "Failed to get device binding");
 	__ASSERT(device_is_ready(dev), "Device %s is not ready", dev->name);

--- a/tests/drivers/sensor/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/sensor/sbs_gauge/src/test_sbs_gauge.c
@@ -10,7 +10,7 @@
 
 const struct device *get_fuel_gauge_device(void)
 {
-	const struct device *const dev = DEVICE_DT_GET_ANY(sbs_sbs_gauge);
+	const struct device *const dev = DEVICE_DT_GET_ONE_OR_NULL(sbs_sbs_gauge);
 
 	zassert_true(device_is_ready(dev), "Fuel Gauge not found");
 


### PR DESCRIPTION
When it comes to obtain devices, we have some inconsistencies in macro names:

- `DEVICE_DT_GET(node_id)`: Obtain device for `node_id`, will produce link
  time error if not found.
- `DEVICE_DT_GET_OR_NULL(node_id)`: Obtain device for `node_id`, will
  return NULL if not found.
- `DEVICE_DT_GET_ANY(compat)`: Obtain any device with compatible `compat`,
  will return NULL if none found.
- `DEVICE_DT_GET_ONE(compat)`: Obtain any device with compatible `compat`,
  will produce compile error if none found.

This PR proposes to convert `DEVICE_DT_GET_ANY` to
`DEVICE_DT_GET_ONE_OR_NULL`, to be aligned with the regular
`DEVICE_DT_GET/OR_NULL` counterparts. The names make it clear we want any
device for the given compatible, otherwise we get NULL.

`DEVICE_DT_GET_ANY` is kept, but marked as deprecated.