### PR TITLE
Bluetooth: controller: llcp: increase memory for procedures

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -615,7 +615,7 @@ config BT_CTLR_LLCP_COMMON_TX_CTRL_BUF_NUM
 
 config BT_CTLR_LLCP_LOCAL_PROC_CTX_BUF_NUM
 	int "Number of local control procedure contexts to be available across all connections"
-	default 4 if (BT_AUTO_PHY_UPDATE=y || BT_AUTO_DATA_LEN_UPDATE=y) && BT_CTLR_LLCP_CONN < 4
+	default 6 if (BT_AUTO_PHY_UPDATE=y || BT_AUTO_DATA_LEN_UPDATE=y) && BT_CTLR_LLCP_CONN < 4
 	default 2 if BT_CTLR_LLCP_CONN = 1
 	default BT_CTLR_LLCP_CONN if BT_CTLR_LLCP_CONN > 1
 	range 2 255


### PR DESCRIPTION
The default number of buffers (contexts) for locally initiated procedures was 4. Per default the host initiates 3 procedures when opening a connection, allowing the application to initiate only 1 additional procedure in parallel. This commit increases the default to 6, if auto phy-update and dle is enabled,
 increasing the robustness for an application.

Fixes #50587

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>