### PR TITLE
Fix advertising not resuming in extended mode

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1438,8 +1438,13 @@ void bt_le_adv_resume(void)
 		return;
 	}
 
-	if (!(atomic_test_bit(adv->flags, BT_ADV_PERSIST) &&
-	      !atomic_test_bit(adv->flags, BT_ADV_ENABLED))) {
+	if (!atomic_test_bit(adv->flags, BT_ADV_PERSIST)) {
+		return;
+	}
+
+	if (!(IS_ENABLED(CONFIG_BT_EXT_ADV) &&
+		BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) &&
+	      atomic_test_bit(adv->flags, BT_ADV_ENABLED)) {
 		return;
 	}
 


### PR DESCRIPTION
Flag CONFIG_BT_EXT_ADV is only relevant and used in legacy mode. It should not be taken into account when using extended advertising.