### PR TITLE
smp: Move arrays to use CONFIG_MP_MAX_NUM_CPUS

### DIFF
--- a/arch/arc/core/arc_smp.c
+++ b/arch/arc/core/arc_smp.c
@@ -20,7 +20,7 @@
 volatile struct {
 	arch_cpustart_t fn;
 	void *arg;
-} arc_cpu_init[CONFIG_MP_NUM_CPUS];
+} arc_cpu_init[CONFIG_MP_MAX_NUM_CPUS];
 
 /*
  * arc_cpu_wake_flag is used to sync up master core and slave cores
@@ -36,7 +36,7 @@ volatile char *arc_cpu_sp;
  * _curr_cpu is used to record the struct of _cpu_t of each cpu.
  * for efficient usage in assembly
  */
-volatile _cpu_t *_curr_cpu[CONFIG_MP_NUM_CPUS];
+volatile _cpu_t *_curr_cpu[CONFIG_MP_MAX_NUM_CPUS];
 
 /* Called from Zephyr initialization */
 void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,

--- a/arch/arc/core/irq_manage.c
+++ b/arch/arc/core/irq_manage.c
@@ -32,7 +32,7 @@
  */
 #if defined(CONFIG_ARC_FIRQ_STACK)
 #if defined(CONFIG_SMP)
-K_KERNEL_STACK_ARRAY_DEFINE(_firq_interrupt_stack, CONFIG_MP_NUM_CPUS,
+K_KERNEL_STACK_ARRAY_DEFINE(_firq_interrupt_stack, CONFIG_MP_MAX_NUM_CPUS,
 			    CONFIG_ARC_FIRQ_STACK_SIZE);
 #else
 K_KERNEL_STACK_DEFINE(_firq_interrupt_stack, CONFIG_ARC_FIRQ_STACK_SIZE);

--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -265,7 +265,7 @@ int arch_float_enable(struct k_thread *thread, unsigned int options)
 
 #if !defined(CONFIG_MULTITHREADING)
 
-K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS, CONFIG_ISR_STACK_SIZE);
+K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS, CONFIG_ISR_STACK_SIZE);
 K_THREAD_STACK_DECLARE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
 
 extern void z_main_no_multithreading_entry_wrapper(void *p1, void *p2, void *p3,

--- a/arch/arm/include/aarch32/cortex_m/stack.h
+++ b/arch/arm/include/aarch32/cortex_m/stack.h
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
+K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 			     CONFIG_ISR_STACK_SIZE);
 
 /**

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -11,7 +11,7 @@
 volatile struct {
 	arch_cpustart_t fn;
 	void *arg;
-} riscv_cpu_init[CONFIG_MP_NUM_CPUS];
+} riscv_cpu_init[CONFIG_MP_MAX_NUM_CPUS];
 
 volatile uintptr_t riscv_cpu_wake_flag;
 volatile void *riscv_cpu_sp;

--- a/arch/xtensa/core/irq_offload.c
+++ b/arch/xtensa/core/irq_offload.c
@@ -12,7 +12,7 @@
 static struct {
 	irq_offload_routine_t fn;
 	const void *arg;
-} offload_params[CONFIG_MP_NUM_CPUS];
+} offload_params[CONFIG_MP_MAX_NUM_CPUS];
 
 static void irq_offload_isr(const void *param)
 {

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -22,7 +22,7 @@ extern "C" {
 
 extern void z_xtensa_fatal_error(unsigned int reason, const z_arch_esf_t *esf);
 
-K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
+K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 			     CONFIG_ISR_STACK_SIZE);
 
 static ALWAYS_INLINE void arch_kernel_init(void)

--- a/drivers/interrupt_controller/intc_esp32.c
+++ b/drivers/interrupt_controller/intc_esp32.c
@@ -78,7 +78,7 @@ void default_intr_handler(void *arg)
 	printk("Unhandled interrupt %d on cpu %d!\n", (int)arg, esp_core_id());
 }
 
-static struct intr_alloc_table_entry intr_alloc_table[ESP_INTC_INTS_NUM * CONFIG_MP_NUM_CPUS];
+static struct intr_alloc_table_entry intr_alloc_table[ESP_INTC_INTS_NUM * CONFIG_MP_MAX_NUM_CPUS];
 
 static void set_interrupt_handler(int n, intc_handler_t f, void *arg)
 {
@@ -92,10 +92,10 @@ static void set_interrupt_handler(int n, intc_handler_t f, void *arg)
 static struct vector_desc_t *vector_desc_head; /* implicitly initialized to NULL */
 
 /* This bitmask has an 1 if the int should be disabled when the flash is disabled. */
-static uint32_t non_iram_int_mask[CONFIG_MP_NUM_CPUS];
+static uint32_t non_iram_int_mask[CONFIG_MP_MAX_NUM_CPUS];
 /* This bitmask has 1 in it if the int was disabled using esp_intr_noniram_disable. */
-static uint32_t non_iram_int_disabled[CONFIG_MP_NUM_CPUS];
-static bool non_iram_int_disabled_flag[CONFIG_MP_NUM_CPUS];
+static uint32_t non_iram_int_disabled[CONFIG_MP_MAX_NUM_CPUS];
+static bool non_iram_int_disabled_flag[CONFIG_MP_MAX_NUM_CPUS];
 
 /*
  * Inserts an item into vector_desc list so that the list is sorted

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -15,7 +15,7 @@
 #include <string.h>
 
 /* Redistributor base addresses for each core */
-mem_addr_t gic_rdists[CONFIG_MP_NUM_CPUS];
+mem_addr_t gic_rdists[CONFIG_MP_MAX_NUM_CPUS];
 
 #if defined(CONFIG_ARMV8_A_NS) || defined(CONFIG_GIC_SINGLE_SECURITY_STATE)
 #define IGROUPR_VAL	0xFFFFFFFFU

--- a/drivers/interrupt_controller/intc_gicv3_its.c
+++ b/drivers/interrupt_controller/intc_gicv3_its.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(intc_gicv3_its, LOG_LEVEL_ERR);
 #define GITS_BASER_NR_REGS              8
 
 /* convenient access to all redistributors base address */
-extern mem_addr_t gic_rdists[CONFIG_MP_NUM_CPUS];
+extern mem_addr_t gic_rdists[CONFIG_MP_MAX_NUM_CPUS];
 
 #define SIZE_256                        256
 #define SIZE_4K                         KB(4)

--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -156,7 +156,7 @@ struct _cpu {
 typedef struct _cpu _cpu_t;
 
 struct z_kernel {
-	struct _cpu cpus[CONFIG_MP_NUM_CPUS];
+	struct _cpu cpus[CONFIG_MP_MAX_NUM_CPUS];
 
 #ifdef CONFIG_PM
 	int32_t idle; /* Number of ticks for kernel idling */

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -154,9 +154,9 @@ extern struct k_thread z_main_thread;
 
 
 #ifdef CONFIG_MULTITHREADING
-extern struct k_thread z_idle_threads[CONFIG_MP_NUM_CPUS];
+extern struct k_thread z_idle_threads[CONFIG_MP_MAX_NUM_CPUS];
 #endif
-K_KERNEL_PINNED_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
+K_KERNEL_PINNED_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 				    CONFIG_ISR_STACK_SIZE);
 
 #ifdef CONFIG_GEN_PRIV_STACKS

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -45,10 +45,10 @@ struct k_thread z_main_thread;
 
 #ifdef CONFIG_MULTITHREADING
 __pinned_bss
-struct k_thread z_idle_threads[CONFIG_MP_NUM_CPUS];
+struct k_thread z_idle_threads[CONFIG_MP_MAX_NUM_CPUS];
 
 static K_KERNEL_PINNED_STACK_ARRAY_DEFINE(z_idle_stacks,
-					  CONFIG_MP_NUM_CPUS,
+					  CONFIG_MP_MAX_NUM_CPUS,
 					  CONFIG_IDLE_STACK_SIZE);
 #endif /* CONFIG_MULTITHREADING */
 
@@ -84,7 +84,7 @@ extern const struct init_entry __init_SMP_start[];
  * switches to the init thread.
  */
 K_KERNEL_PINNED_STACK_ARRAY_DEFINE(z_interrupt_stacks,
-				   CONFIG_MP_NUM_CPUS,
+				   CONFIG_MP_MAX_NUM_CPUS,
 				   CONFIG_ISR_STACK_SIZE);
 
 extern void idle(void *unused1, void *unused2, void *unused3);

--- a/samples/arch/smp/pktqueue/src/main.h
+++ b/samples/arch/smp/pktqueue/src/main.h
@@ -14,7 +14,7 @@
 #define QUEUE_NUM 2
 
 /* Amount of execution threads per pair of queues*/
-#define THREADS_NUM (CONFIG_MP_NUM_CPUS+1)
+#define THREADS_NUM (CONFIG_MP_MAX_NUM_CPUS+1)
 
 /* Amount of packet headers in a queue */
 #define SIZE_OF_QUEUE 5000

--- a/soc/xtensa/esp32/esp32-mp.c
+++ b/soc/xtensa/esp32/esp32-mp.c
@@ -38,7 +38,7 @@ struct cpustart_rec {
 
 volatile struct cpustart_rec *start_rec;
 static void *appcpu_top;
-static bool cpus_active[CONFIG_MP_NUM_CPUS];
+static bool cpus_active[CONFIG_MP_MAX_NUM_CPUS];
 static struct k_spinlock loglock;
 
 extern void z_sched_ipi(void);

--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -67,7 +67,7 @@ struct core_state {
 	uint32_t intenable;
 };
 
-static struct core_state core_desc[CONFIG_MP_NUM_CPUS] = { 0 };
+static struct core_state core_desc[CONFIG_MP_MAX_NUM_CPUS] = { 0 };
 
 struct lpsram_header {
 	uint32_t alt_reset_vector;

--- a/soc/xtensa/intel_adsp/common/clk.c
+++ b/soc/xtensa/intel_adsp/common/clk.c
@@ -13,7 +13,7 @@
 #include <adsp-clk.h>
 #include <adsp_shim.h>
 
-static struct cavs_clock_info platform_clocks[CONFIG_MP_NUM_CPUS];
+static struct cavs_clock_info platform_clocks[CONFIG_MP_MAX_NUM_CPUS];
 static struct k_spinlock lock;
 
 int cavs_clock_freq_enc[] = CAVS_CLOCK_FREQ_ENC;

--- a/soc/xtensa/intel_adsp/common/include/soc.h
+++ b/soc/xtensa/intel_adsp/common/include/soc.h
@@ -25,7 +25,7 @@ extern void z_soc_mp_asm_entry(void);
 extern void soc_mp_startup(uint32_t cpu);
 extern void soc_start_core(int cpu_num);
 
-extern bool soc_cpus_active[CONFIG_MP_NUM_CPUS];
+extern bool soc_cpus_active[CONFIG_MP_MAX_NUM_CPUS];
 
 /* Legacy cache APIs still used in a few places */
 #define SOC_DCACHE_FLUSH(addr, size)		\

--- a/soc/xtensa/intel_adsp/common/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/common/multiprocessing.c
@@ -50,7 +50,7 @@ uint32_t _loader_storage_manifest_start;
  * to be absolutely sure we don't try to IPI a CPU that isn't ready to
  * start, or else we'll launch it into garbage and crash the DSP.
  */
-bool soc_cpus_active[CONFIG_MP_NUM_CPUS];
+bool soc_cpus_active[CONFIG_MP_MAX_NUM_CPUS];
 
 #define NOP4 "nop; nop; nop; nop;"
 #define NOP32 NOP4 NOP4 NOP4 NOP4 NOP4 NOP4 NOP4 NOP4

--- a/subsys/debug/thread_analyzer.c
+++ b/subsys/debug/thread_analyzer.c
@@ -126,7 +126,7 @@ static void thread_analyze_cb(const struct k_thread *cthread, void *user_data)
 	cb(&info);
 }
 
-K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
+K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 			     CONFIG_ISR_STACK_SIZE);
 
 static void isr_stacks(void)

--- a/subsys/pm/pm_stats.c
+++ b/subsys/pm/pm_stats.c
@@ -24,12 +24,12 @@ STATS_NAME(pm_stats, state_last_cycles)
 STATS_NAME(pm_stats, state_total_cycles)
 STATS_NAME_END(pm_stats);
 
-static STATS_SECT_DECL(pm_stats) stats[CONFIG_MP_NUM_CPUS][PM_STATE_COUNT];
+static STATS_SECT_DECL(pm_stats) stats[CONFIG_MP_MAX_NUM_CPUS][PM_STATE_COUNT];
 
 #define PM_STAT_NAME_LEN sizeof("pm_cpu_XXX_state_X_stats")
-static char names[CONFIG_MP_NUM_CPUS][PM_STATE_COUNT][PM_STAT_NAME_LEN];
-static uint32_t time_start[CONFIG_MP_NUM_CPUS];
-static uint32_t time_stop[CONFIG_MP_NUM_CPUS];
+static char names[CONFIG_MP_MAX_NUM_CPUS][PM_STATE_COUNT][PM_STAT_NAME_LEN];
+static uint32_t time_start[CONFIG_MP_MAX_NUM_CPUS];
+static uint32_t time_stop[CONFIG_MP_MAX_NUM_CPUS];
 
 static int pm_stats_init(const struct device *dev)
 {

--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -193,7 +193,7 @@ static void shell_stack_dump(const struct k_thread *thread, void *user_data)
 		thread, tname ? tname : "NA", size, unused, size - unused, size, pcnt);
 }
 
-K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
+K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 			     CONFIG_ISR_STACK_SIZE);
 
 static int cmd_kernel_stacks(const struct shell *shell,

--- a/subsys/testsuite/ztest/src/ztress.c
+++ b/subsys/testsuite/ztest/src/ztress.c
@@ -46,7 +46,7 @@ static uint32_t exec_cnt[CONFIG_ZTRESS_MAX_THREADS];
 static k_timeout_t backoff[CONFIG_ZTRESS_MAX_THREADS];
 static k_timeout_t init_backoff[CONFIG_ZTRESS_MAX_THREADS];
 K_THREAD_STACK_ARRAY_DEFINE(stacks, CONFIG_ZTRESS_MAX_THREADS, CONFIG_ZTRESS_STACK_SIZE);
-static k_tid_t idle_tid[CONFIG_MP_NUM_CPUS];
+static k_tid_t idle_tid[CONFIG_MP_MAX_NUM_CPUS];
 
 #define THREAD_NAME(i, _) STRINGIFY(ztress_##i)
 

--- a/subsys/tracing/user/tracing_user.c
+++ b/subsys/tracing/user/tracing_user.c
@@ -10,7 +10,7 @@
 #include <zephyr/kernel_structs.h>
 #include <ksched.h>
 
-static int nested_interrupts[CONFIG_MP_NUM_CPUS];
+static int nested_interrupts[CONFIG_MP_MAX_NUM_CPUS];
 
 void __weak sys_trace_thread_create_user(struct k_thread *thread) {}
 void __weak sys_trace_thread_abort_user(struct k_thread *thread) {}

--- a/tests/boards/intel_adsp/smoke/src/cpus.c
+++ b/tests/boards/intel_adsp/smoke/src/cpus.c
@@ -33,11 +33,11 @@ static void run_on_cpu_threadfn(void *a, void *b, void *c)
 static struct k_thread thread_har;
 static K_THREAD_STACK_DEFINE(tstack_har, HAR_STACKSZ);
 
-static struct k_thread run_on_threads[CONFIG_MP_NUM_CPUS];
-static K_THREAD_STACK_ARRAY_DEFINE(run_on_stacks, CONFIG_MP_NUM_CPUS, RUN_ON_STACKSZ);
-static volatile bool run_on_flags[CONFIG_MP_NUM_CPUS];
+static struct k_thread run_on_threads[CONFIG_MP_MAX_NUM_CPUS];
+static K_THREAD_STACK_ARRAY_DEFINE(run_on_stacks, CONFIG_MP_MAX_NUM_CPUS, RUN_ON_STACKSZ);
+static volatile bool run_on_flags[CONFIG_MP_MAX_NUM_CPUS];
 
-static uint32_t clk_ratios[CONFIG_MP_NUM_CPUS];
+static uint32_t clk_ratios[CONFIG_MP_MAX_NUM_CPUS];
 
 static void run_on_cpu(int cpu, void (*fn)(void *), void *arg, bool wait)
 {


### PR DESCRIPTION
Move to use CONFIG_MP_MAX_NUM_CPUS for array size declarations instead of CONFIG_MP_NUM_CPUS.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>