### PR TITLE
drivers/flash/gd32_vX: add missing kernel header

### DIFF
--- a/drivers/flash/flash_gd32_v1.c
+++ b/drivers/flash/flash_gd32_v1.c
@@ -7,7 +7,7 @@
 #include "flash_gd32.h"
 
 #include <zephyr/logging/log.h>
-
+#include <zephyr/kernel.h>
 #include <gd32_fmc.h>
 
 LOG_MODULE_DECLARE(flash_gd32);

--- a/drivers/flash/flash_gd32_v2.c
+++ b/drivers/flash/flash_gd32_v2.c
@@ -7,7 +7,7 @@
 #include "flash_gd32.h"
 
 #include <zephyr/logging/log.h>
-
+#include <zephyr/kernel.h>
 #include <gd32_fmc.h>
 
 LOG_MODULE_DECLARE(flash_gd32);

--- a/drivers/flash/flash_gd32_v3.c
+++ b/drivers/flash/flash_gd32_v3.c
@@ -7,7 +7,7 @@
 #include "flash_gd32.h"
 
 #include <zephyr/logging/log.h>
-
+#include <zephyr/kernel.h>
 #include <gd32_fmc.h>
 
 LOG_MODULE_DECLARE(flash_gd32);


### PR DESCRIPTION
Added missing zephyr/kernel.h inclusion

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>