### PR TITLE
drivers: usb: usb_dc_sam0: Add missing kernel include

### DIFF
--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -10,6 +10,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(usb_dc_sam0);
 
+#include <zephyr/kernel.h>
 #include <zephyr/usb/usb_device.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <soc.h>


### PR DESCRIPTION
Fix warnings and undefined symbols reported by CI.

This was discovered on #51307.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>