### PR TITLE
Bluetooth: Mesh: Remove unnecessary memory copy

### DIFF
--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -506,17 +506,7 @@ static int encrypt_friend_pdu(struct bt_mesh_friend *frnd, struct net_buf *buf,
 
 	buf->data[0] = (cred->nid | (iv_index & 1) << 7);
 
-	if (bt_mesh_net_encrypt(cred->enc, &buf->b, iv_index, false)) {
-		BT_ERR("Encrypting failed");
-		return -EINVAL;
-	}
-
-	if (bt_mesh_net_obfuscate(buf->data, iv_index, cred->privacy)) {
-		BT_ERR("Obfuscating failed");
-		return -EINVAL;
-	}
-
-	return 0;
+	return bt_mesh_encrypt_and_obfuscate(&buf->b, cred, iv_index, false);
 }
 
 static struct net_buf *encode_friend_ctl(struct bt_mesh_friend *frnd,

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -289,6 +289,10 @@ void bt_mesh_net_pending_seq_store(void);
 void bt_mesh_net_clear(void);
 void bt_mesh_net_settings_commit(void);
 
+int bt_mesh_encrypt_and_obfuscate(struct net_buf_simple *buf,
+				  const struct bt_mesh_net_cred *cred,
+				  uint32_t iv_index, bool proxy);
+
 static inline void send_cb_finalize(const struct bt_mesh_send_cb *cb,
 				    void *cb_data)
 {


### PR DESCRIPTION
When Bluetooth Mesh network layer received message, there are no need memcpy for this, 
a better way is to decrypt the data into the target buf, same problem for relay.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>