### PR TITLE
doc: develop: test: twister: remove outdated comment

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -31,9 +31,6 @@ only builds a test and doesn't run it:
 - You or some higher level automation invoked twister with
   ``--build-only``.
 
-These also affect the outputs of ``--testcase-report`` and
-``--detailed-report``, see their respective ``--help`` sections.
-
 To run the script in the local tree, follow the steps below:
 
 .. tabs::


### PR DESCRIPTION
The options `--testcase-report` and `--detailed-report` are not existing anymore.
