### PR TITLE
include: add missing zephyr/irq.h include

### DIFF
--- a/arch/arc/core/arc_smp.c
+++ b/arch/arc/core/arc_smp.c
@@ -14,6 +14,7 @@
 #include <zephyr/kernel_structs.h>
 #include <ksched.h>
 #include <zephyr/init.h>
+#include <zephyr/irq.h>
 
 #define MP_PRIMARY_CPU_ID 0
 

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -22,6 +22,7 @@
 #include <zephyr/drivers/interrupt_controller/gic.h>
 #include <zephyr/drivers/pm_cpu_ops.h>
 #include <zephyr/sys/arch_interface.h>
+#include <zephyr/irq.h>
 #include "boot.h"
 
 #define SGI_SCHED_IPI	0

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -7,6 +7,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <ksched.h>
+#include <zephyr/irq.h>
 
 volatile struct {
 	arch_cpustart_t fn;

--- a/arch/xtensa/core/irq_offload.c
+++ b/arch/xtensa/core/irq_offload.c
@@ -6,6 +6,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/irq_offload.h>
 #include <zsr.h>
+#include <zephyr/irq.h>
 
 #define CURR_CPU (IS_ENABLED(CONFIG_SMP) ? arch_curr_cpu()->id : 0)
 

--- a/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
+++ b/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
@@ -12,6 +12,7 @@
 #include <zephyr/sys_clock.h>
 #include <hal/nrf_timer.h>
 #include <zephyr/spinlock.h>
+#include <zephyr/irq.h>
 
 #define TIMER NRF_TIMER0
 

--- a/drivers/adc/adc_cc32xx.c
+++ b/drivers/adc/adc_cc32xx.c
@@ -29,6 +29,7 @@
 
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(adc_cc32xx);
 
 #define ISR_MASK (ADC_DMA_DONE | ADC_FIFO_OVERFLOW | ADC_FIFO_UNDERFLOW	\

--- a/drivers/adc/adc_gd32.c
+++ b/drivers/adc/adc_gd32.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/reset.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/irq.h>
 
 #include <gd32_adc.h>
 #include <gd32_rcu.h>

--- a/drivers/adc/adc_ite_it8xxx2.c
+++ b/drivers/adc/adc_ite_it8xxx2.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(adc_ite_it8xxx2);
 #include <soc_dt.h>
 #include <errno.h>
 #include <assert.h>
+#include <zephyr/irq.h>
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"

--- a/drivers/adc/adc_mchp_xec.c
+++ b/drivers/adc/adc_mchp_xec.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(adc_mchp_xec);
 #include <zephyr/drivers/pinctrl.h>
 #include <soc.h>
 #include <errno.h>
+#include <zephyr/irq.h>
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"

--- a/drivers/adc/adc_mchp_xec_v2.c
+++ b/drivers/adc/adc_mchp_xec_v2.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(adc_mchp_xec);
 #include <zephyr/drivers/pinctrl.h>
 #include <soc.h>
 #include <errno.h>
+#include <zephyr/irq.h>
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"

--- a/drivers/adc/adc_mcux_12b1msps_sar.c
+++ b/drivers/adc/adc_mcux_12b1msps_sar.c
@@ -16,6 +16,7 @@
 
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(adc_mcux_12b1msps_sar);
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER

--- a/drivers/adc/adc_mcux_adc12.c
+++ b/drivers/adc/adc_mcux_adc12.c
@@ -15,6 +15,7 @@
 
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(adc_mcux_adc12);
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER

--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -17,6 +17,7 @@
 
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(adc_mcux_adc16);
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -24,6 +24,7 @@
 
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(nxp_mcux_lpadc);
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER

--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -19,6 +19,7 @@
 #include "adc_context.h"
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(adc_npcx, CONFIG_ADC_LOG_LEVEL);
 
 /* ADC speed/delay values during initialization */

--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -11,6 +11,7 @@
 
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(adc_nrfx_adc);
 
 #define DT_DRV_COMPAT nordic_nrf_adc

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -11,6 +11,7 @@
 
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(adc_nrfx_saadc);
 
 #define DT_DRV_COMPAT nordic_nrf_saadc

--- a/drivers/adc/adc_rpi_pico.c
+++ b/drivers/adc/adc_rpi_pico.c
@@ -11,6 +11,7 @@
 #include <zephyr/logging/log.h>
 
 #include <hardware/adc.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(adc_rpi, CONFIG_ADC_LOG_LEVEL);
 

--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/pinctrl.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(adc_sam0, CONFIG_ADC_LOG_LEVEL);
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER

--- a/drivers/adc/adc_sam_afec.c
+++ b/drivers/adc/adc_sam_afec.c
@@ -28,6 +28,7 @@
 
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(adc_sam_afec);
 
 #define NUM_CHANNELS 12

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -31,6 +31,7 @@
 LOG_MODULE_REGISTER(adc_stm32);
 
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/irq.h>
 
 #if defined(CONFIG_SOC_SERIES_STM32F3X)
 #if defined(ADC1_V2_5)

--- a/drivers/audio/dmic_nrfx_pdm.c
+++ b/drivers/audio/dmic_nrfx_pdm.c
@@ -11,6 +11,7 @@
 #include <nrfx_pdm.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(dmic_nrfx_pdm, CONFIG_AUDIO_DMIC_LOG_LEVEL);
 
 struct dmic_nrfx_pdm_drv_data {

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/bluetooth/hci_driver.h>
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/irq.h>
 
 #include "app_conf.h"
 #include "stm32_wpan_common.h"

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -15,6 +15,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <fsl_flexcan.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #endif
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #include "can_mcan.h"
 

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(can_rcar, CONFIG_CAN_LOG_LEVEL);
 

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -10,6 +10,7 @@
 #include <soc.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #include "can_mcan.h"
 

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -17,6 +17,7 @@
 #include <stdbool.h>
 #include <zephyr/drivers/can.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #include "can_stm32.h"
 

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -13,6 +13,7 @@
 #include <soc.h>
 #include <stm32_ll_rcc.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #include "can_mcan.h"
 

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -12,6 +12,7 @@
 #include <zephyr/kernel.h>
 #include <stm32_ll_rcc.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #include "can_mcan.h"
 

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -13,6 +13,7 @@
 #include <nrfx_clock.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(clock_control, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -26,6 +26,7 @@
 #include <zephyr/sys/timeutil.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #include "stm32_hsem.h"
 

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -16,6 +16,7 @@
 
 #define LOG_MODULE_NAME counter_rtc
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_COUNTER_LOG_LEVEL);
 
 #define ERR(...) LOG_INST_ERR( \

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -10,6 +10,7 @@
 #define LOG_LEVEL CONFIG_COUNTER_LOG_LEVEL
 #define LOG_MODULE_NAME counter_timer
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 
 #define TIMER_CLOCK 16000000

--- a/drivers/counter/counter_sam_tc.c
+++ b/drivers/counter/counter_sam_tc.c
@@ -33,6 +33,7 @@
 #include <zephyr/drivers/pinctrl.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(counter_sam_tc, CONFIG_COUNTER_LOG_LEVEL);
 
 #define MAX_ALARMS_PER_TC_CHANNEL 2

--- a/drivers/dac/dac_sam.c
+++ b/drivers/dac/dac_sam.c
@@ -21,6 +21,7 @@
 #include <zephyr/drivers/pinctrl.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(dac_sam, CONFIG_DAC_LOG_LEVEL);
 
 BUILD_ASSERT(IS_ENABLED(CONFIG_SOC_SERIES_SAME70) ||

--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <zephyr/devicetree.h>
 
 #include <zephyr/drivers/dai.h>
+#include <zephyr/irq.h>
 
 #include "dmic.h"
 

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <stm32_ll_rcc.h>
 

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -18,6 +18,7 @@
 #endif
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(display_mcux_elcdif, CONFIG_DISPLAY_LOG_LEVEL);
 

--- a/drivers/display/display_nrf_led_matrix.c
+++ b/drivers/display/display_nrf_led_matrix.c
@@ -17,6 +17,7 @@
 #endif
 #include <nrf_peripherals.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(nrf_led_matrix, CONFIG_DISPLAY_LOG_LEVEL);
 
 #define MATRIX_NODE  DT_INST(0, nordic_nrf_led_matrix)

--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -18,6 +18,7 @@
 #include "dma_dw_common.h"
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(dma_dw, CONFIG_DMA_LOG_LEVEL);
 
 /* Device constant configuration parameters */

--- a/drivers/dma/dma_gd32.c
+++ b/drivers/dma/dma_gd32.c
@@ -14,6 +14,7 @@
 #include <zephyr/logging/log.h>
 
 #include <gd32_dma.h>
+#include <zephyr/irq.h>
 
 #ifdef CONFIG_SOC_SERIES_GD32F4XX
 #define CHXCTL_PERIEN_OFFSET	  ((uint32_t)25U)

--- a/drivers/dma/dma_intel_adsp_gpdma.c
+++ b/drivers/dma/dma_intel_adsp_gpdma.c
@@ -32,6 +32,7 @@
 
 #define LOG_LEVEL CONFIG_DMA_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(dma_intel_adsp_gpdma);
 
 

--- a/drivers/dma/dma_iproc_pax_v1.c
+++ b/drivers/dma/dma_iproc_pax_v1.c
@@ -22,6 +22,7 @@
 
 #define LOG_LEVEL CONFIG_DMA_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(dma_iproc_pax);
 
 /* Driver runtime data for PAX DMA and RM */

--- a/drivers/dma/dma_iproc_pax_v2.c
+++ b/drivers/dma/dma_iproc_pax_v2.c
@@ -22,6 +22,7 @@
 
 #define LOG_LEVEL CONFIG_DMA_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(dma_iproc_pax_v2);
 
 /* Driver runtime data for PAX DMA and RM */

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -21,6 +21,7 @@
 #include "dma_mcux_edma.h"
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #define DT_DRV_COMPAT nxp_mcux_edma
 

--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -14,6 +14,7 @@
 #include <fsl_dma.h>
 #include <fsl_inputmux.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #define DT_DRV_COMPAT nxp_lpc_dma
 

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -18,6 +18,7 @@
 #include "altera_msgdma.h"
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(dma_nios2, CONFIG_DMA_LOG_LEVEL);
 
 /* Device configuration parameters */

--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/dma.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(dma_sam0, CONFIG_DMA_LOG_LEVEL);
 
 #define DMA_REGS	((Dmac *)DT_INST_REG_ADDR(0))

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -21,6 +21,7 @@
 
 #define LOG_LEVEL CONFIG_DMA_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(dma_sam_xdmac);
 
 #define XDMAC_INT_ERR (XDMAC_CIE_RBIE | XDMAC_CIE_WBIE | XDMAC_CIE_ROIE)

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -18,6 +18,7 @@
 #include <zephyr/drivers/dma/dma_stm32.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(dma_stm32, CONFIG_DMA_LOG_LEVEL);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_dma_v1)

--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -19,6 +19,7 @@
 #include <zephyr/drivers/dma/dma_stm32.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(dma_stm32, CONFIG_DMA_LOG_LEVEL);
 
 #define DT_DRV_COMPAT st_stm32u5_dma

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -10,6 +10,7 @@
 #include <zephyr/sys/atomic.h>
 #include <soc.h>
 #include <hal/nrf_rng.h>
+#include <zephyr/irq.h>
 
 #define DT_DRV_COMPAT	nordic_nrf_rng
 

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -26,6 +26,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/irq.h>
 #include "stm32_hsem.h"
 
 #define IRQN		DT_INST_IRQN(0)

--- a/drivers/espi/espi_it8xxx2.c
+++ b/drivers/espi/espi_it8xxx2.c
@@ -15,6 +15,7 @@
 #include "espi_utils.h"
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(espi, CONFIG_ESPI_LOG_LEVEL);
 
 #define ESPI_IT8XXX2_GET_GCTRL_BASE \

--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/espi.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 #include "espi_utils.h"
 
 /* Minimum delay before acknowledging a virtual wire */

--- a/drivers/espi/espi_mchp_xec_host_v2.c
+++ b/drivers/espi/espi_mchp_xec_host_v2.c
@@ -17,6 +17,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/irq.h>
 #include "espi_utils.h"
 #include "espi_mchp_xec_v2.h"
 

--- a/drivers/espi/espi_mchp_xec_v2.c
+++ b/drivers/espi/espi_mchp_xec_v2.c
@@ -17,6 +17,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/irq.h>
 #include "espi_utils.h"
 #include "espi_mchp_xec_v2.h"
 

--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -21,6 +21,7 @@
 #include "soc_miwu.h"
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(espi, CONFIG_ESPI_LOG_LEVEL);
 
 struct espi_npcx_config {

--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -125,6 +125,7 @@
 #include "soc_miwu.h"
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(host_sub_npcx, LOG_LEVEL_ERR);
 
 struct host_sub_npcx_config {

--- a/drivers/ethernet/eth_cyclonev.c
+++ b/drivers/ethernet/eth_cyclonev.c
@@ -27,6 +27,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "phy_cyclonev.c"
 #include <ethernet/eth_stats.h>
 #include <sys/types.h>
+#include <zephyr/irq.h>
 #define TX_AVAIL_WAIT	    K_MSEC(1)
 #define INC_WRAP(idx, size) ({ idx = (idx + 1) % size; })
 

--- a/drivers/ethernet/eth_dwmac_mmu.c
+++ b/drivers/ethernet/eth_dwmac_mmu.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/kernel.h>
 #include <zephyr/cache.h>
 #include <zephyr/net/ethernet.h>
+#include <zephyr/irq.h>
 
 #include "eth_dwmac_priv.h"
 

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -24,6 +24,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
 
 #include "eth_dwmac_priv.h"
 

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/net/ethernet.h>
 #include <ethernet/eth_stats.h>
 #include <zephyr/drivers/pcie/pcie.h>
+#include <zephyr/irq.h>
 #include "eth_e1000_priv.h"
 
 #if defined(CONFIG_ETH_E1000_PTP_CLOCK)

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(eth_gecko, CONFIG_ETHERNET_LOG_LEVEL);
 #include <zephyr/net/ethernet.h>
 #include <ethernet/eth_stats.h>
 #include <em_cmu.h>
+#include <zephyr/irq.h>
 
 #include "phy_gecko.h"
 #include "eth_gecko_priv.h"

--- a/drivers/ethernet/eth_liteeth.c
+++ b/drivers/ethernet/eth_liteeth.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/net/net_pkt.h>
 
 #include <zephyr/sys/printk.h>
+#include <zephyr/irq.h>
 
 #include "eth.h"
 

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -31,6 +31,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/net/ethernet.h>
 #include <ethernet/eth_stats.h>
 #include <zephyr/pm/device.h>
+#include <zephyr/irq.h>
 
 #if defined(CONFIG_PTP_CLOCK_MCUX)
 #include <zephyr/drivers/ptp_clock.h>

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -54,6 +54,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr/drivers/ptp_clock.h>
 #include <zephyr/net/gptp.h>
+#include <zephyr/irq.h>
 
 #ifdef __DCACHE_PRESENT
 static bool dcache_enabled;

--- a/drivers/ethernet/eth_smsc911x.c
+++ b/drivers/ethernet/eth_smsc911x.c
@@ -28,6 +28,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <string.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/net/ethernet.h>
+#include <zephyr/irq.h>
 #include "ethernet/eth_stats.h"
 
 #ifdef CONFIG_SHARED_IRQ

--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/device.h>
 #include <soc.h>
 #include <ethernet/eth_stats.h>
+#include <zephyr/irq.h>
 #include "eth_stellaris_priv.h"
 
 static void eth_stellaris_assign_mac(const struct device *dev)

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -28,6 +28,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
 
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
 #include <zephyr/drivers/ptp_clock.h>

--- a/drivers/ethernet/eth_xlnx_gem_priv.h
+++ b/drivers/ethernet/eth_xlnx_gem_priv.h
@@ -15,6 +15,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 #include <zephyr/net/net_pkt.h>
+#include <zephyr/irq.h>
 
 #include "phy_xlnx_gem.h"
 

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -19,6 +19,7 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 
 #include "spi_nor.h"
 #include "jesd216.h"

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -38,6 +38,7 @@
 #include "jesd216.h"
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(flash_stm32_qspi, CONFIG_FLASH_LOG_LEVEL);
 
 #define STM32_QSPI_FIFO_THRESHOLD         8

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -14,6 +14,7 @@
 #include <soc.h>
 #include <string.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(qspi_nor, CONFIG_FLASH_LOG_LEVEL);
 
 #include "spi_nor.h"

--- a/drivers/gpio/gpio_andes_atcgpio100.c
+++ b/drivers/gpio/gpio_andes_atcgpio100.c
@@ -17,6 +17,7 @@
 #include <zephyr/dt-bindings/gpio/andestech-atcgpio100.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/sys_io.h>
+#include <zephyr/irq.h>
 
 #include "gpio_utils.h"
 

--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -22,6 +22,7 @@
 
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26XX.h>
+#include <zephyr/irq.h>
 
 #include "gpio_utils.h"
 

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -24,6 +24,7 @@
 #include <driverlib/gpio.h>
 #include <driverlib/rom_map.h>
 #include <driverlib/interrupt.h>
+#include <zephyr/irq.h>
 
 #include "gpio_utils.h"
 

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -15,6 +15,7 @@
 #include <soc.h>
 #include <zephyr/drivers/clock_control/arm_clock_control.h>
 #include <zephyr/drivers/gpio/gpio_cmsdk_ahb.h>
+#include <zephyr/irq.h>
 
 #include "gpio_utils.h"
 

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -20,6 +20,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 
 #ifdef CONFIG_IOAPIC
 #include <zephyr/drivers/interrupt_controller/ioapic.h>

--- a/drivers/gpio/gpio_intel.c
+++ b/drivers/gpio/gpio_intel.c
@@ -26,6 +26,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/speculation.h>
+#include <zephyr/irq.h>
 
 #include "gpio_utils.h"
 

--- a/drivers/gpio/gpio_mchp_mss.c
+++ b/drivers/gpio/gpio_mchp_mss.c
@@ -12,6 +12,7 @@
 #include <soc.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/irq.h>
 
 #include "gpio_utils.h"
 

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+#include <zephyr/irq.h>
 #include "gpio_utils.h"
 
 struct gpio_nrfx_data {

--- a/drivers/gpio/gpio_rcar.c
+++ b/drivers/gpio/gpio_rcar.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
+#include <zephyr/irq.h>
 
 #include "gpio_utils.h"
 

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -13,6 +13,7 @@
 #include <soc.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/gpio/atmel-sam-gpio.h>
+#include <zephyr/irq.h>
 
 #include "gpio_utils.h"
 

--- a/drivers/gpio/gpio_sam4l.c
+++ b/drivers/gpio/gpio_sam4l.c
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <soc.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/irq.h>
 
 #include "gpio_utils.h"
 

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -16,6 +16,7 @@
 #include <soc.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/irq.h>
 
 #include "gpio_utils.h"
 

--- a/drivers/i2c/i2c_andes_atciic100.c
+++ b/drivers/i2c/i2c_andes_atciic100.c
@@ -10,6 +10,7 @@
 
 #include <string.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/irq.h>
 #include "i2c_andes_atciic100.h"
 
 #define DT_DRV_COMPAT andestech_atciic100

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(i2c_cc13xx_cc26xx);
 
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26X2.h>
+#include <zephyr/irq.h>
 
 #include "i2c-priv.h"
 

--- a/drivers/i2c/i2c_cc32xx.c
+++ b/drivers/i2c/i2c_cc32xx.c
@@ -22,6 +22,7 @@
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_cc32xx);
 
 #include "i2c-priv.h"

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -35,6 +35,7 @@
 #include "i2c_dw_registers.h"
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_dw);
 
 #include "i2c-priv.h"

--- a/drivers/i2c/i2c_gd32.c
+++ b/drivers/i2c/i2c_gd32.c
@@ -19,6 +19,7 @@
 #include <gd32_i2c.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_gd32, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c-priv.h"

--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/pinctrl.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_imx);
 
 #include "i2c-priv.h"

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -19,6 +19,7 @@
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_ll_stm32);
 
 #include "i2c-priv.h"

--- a/drivers/i2c/i2c_lpc11u6x.c
+++ b/drivers/i2c/i2c_lpc11u6x.c
@@ -9,6 +9,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 #include "i2c_lpc11u6x.h"
 
 #define DEV_BASE(dev) (((struct lpc11u6x_i2c_config *)(dev->config))->base)

--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_mchp, CONFIG_I2C_LOG_LEVEL);
 
 #define SPEED_100KHZ_BUS    0

--- a/drivers/i2c/i2c_mchp_xec_v2.c
+++ b/drivers/i2c/i2c_mchp_xec_v2.c
@@ -18,6 +18,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_mchp, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c-priv.h"

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -17,6 +17,7 @@
 #include <zephyr/drivers/pinctrl.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_mcux);
 
 #include "i2c-priv.h"

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -16,6 +16,7 @@
 #endif
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(mcux_flexcomm);
 
 #include "i2c-priv.h"

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/kernel.h>
+#include <zephyr/irq.h>
 #include <fsl_lpi2c.h>
 
 #ifdef CONFIG_PINCTRL

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -74,6 +74,7 @@
 #include <soc.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_npcx, LOG_LEVEL_ERR);
 
 /* I2C controller mode */

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -13,6 +13,7 @@
 #include <nrfx_twi.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_nrfx_twi, CONFIG_I2C_LOG_LEVEL);
 
 #define I2C_TRANSFER_TIMEOUT_MSEC		K_MSEC(500)

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -15,6 +15,7 @@
 #include <zephyr/sys/util.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_nrfx_twim, CONFIG_I2C_LOG_LEVEL);
 
 #define I2C_TRANSFER_TIMEOUT_MSEC		K_MSEC(500)

--- a/drivers/i2c/i2c_rcar.c
+++ b/drivers/i2c/i2c_rcar.c
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_rcar);
 
 #include "i2c-priv.h"

--- a/drivers/i2c/i2c_rv32m1_lpi2c.c
+++ b/drivers/i2c/i2c_rv32m1_lpi2c.c
@@ -12,6 +12,7 @@
 
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 #include <fsl_lpi2c.h>
 #include <zephyr/logging/log.h>
 #ifdef CONFIG_PINCTRL

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/pinctrl.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_sam0, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c-priv.h"

--- a/drivers/i2c/i2c_sam4l_twim.c
+++ b/drivers/i2c/i2c_sam4l_twim.c
@@ -26,6 +26,7 @@
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_sam_twim);
 
 #include "i2c-priv.h"

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -26,6 +26,7 @@
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_sam_twi);
 
 #include "i2c-priv.h"

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -24,6 +24,7 @@
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_sam_twihs);
 
 #include "i2c-priv.h"

--- a/drivers/i2s/i2s_litex.c
+++ b/drivers/i2s/i2s_litex.c
@@ -12,6 +12,7 @@
 #include <zephyr/sys/__assert.h>
 #include "i2s_litex.h"
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(i2s_litex);
 

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -19,6 +19,7 @@
 
 #include "i2s_ll_stm32.h"
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2s_ll_stm32);
 
 /* FIXME change to

--- a/drivers/i2s/i2s_mcux_flexcomm.c
+++ b/drivers/i2s/i2s_mcux_flexcomm.c
@@ -14,6 +14,7 @@
 #include <fsl_i2s.h>
 #include <fsl_dma.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 #ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
 #endif

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -29,6 +29,7 @@
 #define LOG_DOMAIN dev_i2s_mcux
 #define LOG_LEVEL CONFIG_I2S_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(LOG_DOMAIN);
 

--- a/drivers/i2s/i2s_nrfx.c
+++ b/drivers/i2s/i2s_nrfx.c
@@ -12,6 +12,7 @@
 #include <nrfx_i2s.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2s_nrfx, CONFIG_I2S_LOG_LEVEL);
 
 struct stream_cfg {

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -33,6 +33,7 @@
 #define LOG_DOMAIN dev_i2s_sam_ssc
 #define LOG_LEVEL CONFIG_I2S_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(LOG_DOMAIN);
 
 #if __DCACHE_PRESENT == 1

--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr/random/rand32.h>
 #include <zephyr/net/ieee802154_radio.h>
+#include <zephyr/irq.h>
 #if defined(CONFIG_NET_L2_OPENTHREAD)
 #include <zephyr/net/openthread.h>
 #endif

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -41,6 +41,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/random/rand32.h>
 
 #include <zephyr/net/ieee802154_radio.h>
+#include <zephyr/irq.h>
 
 #include "ieee802154_nrf5.h"
 #include "nrf_802154.h"

--- a/drivers/interrupt_controller/intc_dw.c
+++ b/drivers/interrupt_controller/intc_dw.c
@@ -17,6 +17,7 @@
 #include <zephyr/irq_nextlevel.h>
 #include "intc_dw.h"
 #include <soc.h>
+#include <zephyr/irq.h>
 
 static ALWAYS_INLINE void dw_ictl_dispatch_child_isrs(uint32_t intr_status,
 						      uint32_t isr_base_offset)

--- a/drivers/interrupt_controller/intc_dw_ace.c
+++ b/drivers/interrupt_controller/intc_dw_ace.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/interrupt_controller/dw_ace.h>
 #include <soc.h>
 #include <adsp_interrupt.h>
+#include <zephyr/irq.h>
 #include "intc_dw.h"
 
 /* ACE device interrupts are all packed into a single line on Xtensa's

--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -25,6 +25,7 @@
 #include <stm32_ll_exti.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/drivers/interrupt_controller/exti_stm32.h>
+#include <zephyr/irq.h>
 
 #include "stm32_hsem.h"
 

--- a/drivers/interrupt_controller/intc_mchp_ecia_xec.c
+++ b/drivers/interrupt_controller/intc_mchp_ecia_xec.c
@@ -20,6 +20,7 @@
 #include <zephyr/drivers/clock_control/mchp_xec_clock_control.h>
 #include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>
 #include <zephyr/dt-bindings/interrupt-controller/mchp-xec-ecia.h>
+#include <zephyr/irq.h>
 
 /* defined at the SoC layer */
 #define MCHP_FIRST_GIRQ			MCHP_FIRST_GIRQ_NOS

--- a/drivers/interrupt_controller/intc_miwu.c
+++ b/drivers/interrupt_controller/intc_miwu.c
@@ -57,6 +57,7 @@
 #include "soc_gpio.h"
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(intc_miwu, LOG_LEVEL_ERR);
 
 /* MIWU module instances */

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -19,6 +19,7 @@
 
 #include <zephyr/sw_isr_table.h>
 #include <zephyr/drivers/interrupt_controller/riscv_plic.h>
+#include <zephyr/irq.h>
 
 #define PLIC_MAX_PRIO	DT_INST_PROP(0, riscv_max_priority)
 #define PLIC_PRIO	DT_INST_REG_ADDR_BY_NAME(0, prio)

--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -13,6 +13,7 @@
 #include <zephyr/shared_irq.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/sys_io.h>
+#include <zephyr/irq.h>
 
 #ifdef CONFIG_IOAPIC
 #include <zephyr/drivers/interrupt_controller/ioapic.h>

--- a/drivers/interrupt_controller/intc_swerv_pic.c
+++ b/drivers/interrupt_controller/intc_swerv_pic.c
@@ -14,6 +14,7 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/init.h>
 #include <zephyr/sw_isr_table.h>
+#include <zephyr/irq.h>
 
 #define SWERV_PIC_MAX_NUM	CONFIG_NUM_IRQS
 #define SWERV_PIC_MAX_ID	(SWERV_PIC_MAX_NUM + RISCV_MAX_GENERIC_IRQ)

--- a/drivers/ipm/ipm_cavs_idc.c
+++ b/drivers/ipm/ipm_cavs_idc.c
@@ -10,6 +10,7 @@
 #include <zephyr/arch/common/sys_io.h>
 
 #include <soc.h>
+#include <zephyr/irq.h>
 #include "ipm_cavs_idc.h"
 
 #ifdef CONFIG_SCHED_IPI_SUPPORTED

--- a/drivers/ipm/ipm_imx.c
+++ b/drivers/ipm/ipm_imx.c
@@ -11,6 +11,7 @@
 #include <zephyr/device.h>
 #include <soc.h>
 #include <zephyr/drivers/ipm.h>
+#include <zephyr/irq.h>
 #if IS_ENABLED(CONFIG_IPM_IMX_REV2)
 #include "fsl_mu.h"
 #else

--- a/drivers/ipm/ipm_mcux.c
+++ b/drivers/ipm/ipm_mcux.c
@@ -12,6 +12,7 @@
 #include <fsl_mailbox.h>
 #include <fsl_clock.h>
 #include <soc.h>
+#include <zephyr/irq.h>
 
 #define MCUX_IPM_DATA_REGS 1
 #define MCUX_IPM_MAX_ID_VAL 0

--- a/drivers/ipm/ipm_mhu.c
+++ b/drivers/ipm/ipm_mhu.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <zephyr/device.h>
 #include <soc.h>
+#include <zephyr/irq.h>
 #include "ipm_mhu.h"
 
 #define IPM_MHU_REGS(dev) \

--- a/drivers/ipm/ipm_nrfx_ipc.c
+++ b/drivers/ipm/ipm_nrfx_ipc.c
@@ -13,6 +13,7 @@
 
 #define LOG_LEVEL CONFIG_IPM_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(ipm_nrfx_ipc);
 
 struct ipm_nrf_data {

--- a/drivers/ipm/ipm_stm32_hsem.c
+++ b/drivers/ipm/ipm_stm32_hsem.c
@@ -14,6 +14,7 @@
 #include "stm32_hsem.h"
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(ipm_stm32_hsem, CONFIG_IPM_LOG_LEVEL);
 
 #define HSEM_CPU1                   1

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -16,6 +16,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(ipm_stm32_ipcc, CONFIG_IPM_LOG_LEVEL);
 
 #define MBX_STRUCT(dev)					\

--- a/drivers/kscan/kscan_mchp_xec.c
+++ b/drivers/kscan/kscan_mchp_xec.c
@@ -21,6 +21,7 @@
 #include <soc.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #define LOG_LEVEL CONFIG_KSCAN_LOG_LEVEL
 LOG_MODULE_REGISTER(kscan_mchp_xec);

--- a/drivers/lora/sx126x_stm32wl.c
+++ b/drivers/lora/sx126x_stm32wl.c
@@ -13,6 +13,7 @@
 #include <stm32wlxx_ll_rcc.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_DECLARE(sx126x, CONFIG_LORA_LOG_LEVEL);
 
 void sx126x_reset(struct sx126x_data *dev_data)

--- a/drivers/mbox/mbox_nrfx_ipc.c
+++ b/drivers/mbox/mbox_nrfx_ipc.c
@@ -9,6 +9,7 @@
 
 #define LOG_LEVEL CONFIG_MBOX_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(mbox_nrfx_ipc);
 
 #define DT_DRV_COMPAT nordic_mbox_nrf_ipc

--- a/drivers/neural_net/intel_gna.c
+++ b/drivers/neural_net/intel_gna.c
@@ -25,6 +25,7 @@
 
 #define LOG_LEVEL CONFIG_NEURAL_NET_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(neural_net);
 
 #if LOG_LEVEL >= LOG_LEVEL_DBG

--- a/drivers/pcie/endpoint/pcie_ep_iproc.c
+++ b/drivers/pcie/endpoint/pcie_ep_iproc.c
@@ -9,6 +9,7 @@
 
 #define LOG_LEVEL CONFIG_PCIE_EP_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(iproc_pcie);
 
 #include "pcie_ep_iproc.h"

--- a/drivers/peci/peci_ite_it8xxx2.c
+++ b/drivers/peci/peci_ite_it8xxx2.c
@@ -17,6 +17,7 @@
 #include <soc_dt.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(peci_ite_it8xxx2, CONFIG_PECI_LOG_LEVEL);
 

--- a/drivers/peci/peci_mchp_xec.c
+++ b/drivers/peci/peci_mchp_xec.c
@@ -19,6 +19,7 @@
 #endif
 #include <soc.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(peci_mchp_xec, CONFIG_PECI_LOG_LEVEL);
 
 /* Maximum PECI core clock is the main clock 48Mhz */

--- a/drivers/peci/peci_npcx.c
+++ b/drivers/peci/peci_npcx.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/pinctrl.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(peci_npcx, CONFIG_PECI_LOG_LEVEL);
 
 #define PECI_TIMEOUT		 K_MSEC(300)

--- a/drivers/ps2/ps2_mchp_xec.c
+++ b/drivers/ps2/ps2_mchp_xec.c
@@ -21,6 +21,7 @@
 #include <zephyr/drivers/ps2.h>
 #include <soc.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 #define LOG_LEVEL CONFIG_PS2_LOG_LEVEL
 LOG_MODULE_REGISTER(ps2_mchp_xec);

--- a/drivers/ps2/ps2_npcx_controller.c
+++ b/drivers/ps2/ps2_npcx_controller.c
@@ -20,6 +20,7 @@
 #include <zephyr/dt-bindings/clock/npcx_clock.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(ps2_npcx_ctrl, CONFIG_PS2_LOG_LEVEL);
 
 #define NPCX_PS2_CH_COUNT 4

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -22,6 +22,7 @@
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(pwm_stm32, CONFIG_PWM_LOG_LEVEL);
 

--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -27,6 +27,7 @@ LOG_MODULE_REGISTER(usdhc, CONFIG_SDHC_LOG_LEVEL);
 
 #include <fsl_usdhc.h>
 #include <fsl_cache.h>
+#include <zephyr/irq.h>
 
 enum transfer_callback_status {
 	TRANSFER_CMD_COMPLETE = BIT(0),

--- a/drivers/sensor/mcux_acmp/mcux_acmp.c
+++ b/drivers/sensor/mcux_acmp/mcux_acmp.c
@@ -14,6 +14,7 @@
 #include <zephyr/kernel.h>
 #include <fsl_acmp.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(mcux_acmp, CONFIG_SENSOR_LOG_LEVEL);
 

--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #include <zephyr/logging/log.h>
 #include <hal/nrf_temp.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(temp_nrf5, CONFIG_SENSOR_LOG_LEVEL);
 

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -13,6 +13,7 @@
 #include <hal/nrf_gpio.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(qdec_nrfx, CONFIG_SENSOR_LOG_LEVEL);
 
 #define DT_DRV_COMPAT nordic_nrf_qdec

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -19,6 +19,7 @@
 
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26X2.h>
+#include <zephyr/irq.h>
 
 struct uart_cc13xx_cc26xx_config {
 	uint32_t reg;

--- a/drivers/serial/uart_cc32xx.c
+++ b/drivers/serial/uart_cc32xx.c
@@ -16,6 +16,7 @@
 #include <driverlib/rom_map.h>
 #include <driverlib/prcm.h>
 #include <driverlib/uart.h>
+#include <zephyr/irq.h>
 
 struct uart_cc32xx_dev_config {
 	unsigned long base;

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -19,6 +19,7 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/linker/sections.h>
+#include <zephyr/irq.h>
 
 /* UART registers struct */
 struct uart_cmsdk_apb {

--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -21,6 +21,7 @@
 #include <zephyr/drivers/uart.h>
 #include <uart_imx.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
 
 #define UART_STRUCT(dev) \
 	((UART_Type *)((const struct imx_uart_config *const)(dev)->config)->base)

--- a/drivers/serial/uart_mchp_xec.c
+++ b/drivers/serial/uart_mchp_xec.c
@@ -32,6 +32,7 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/spinlock.h>
+#include <zephyr/irq.h>
 
 /* Clock source is 1.8432 MHz derived from PLL 48 MHz */
 #define XEC_UART_CLK_SRC_1P8M		0

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <fsl_lpsci.h>
 #include <soc.h>
+#include <zephyr/irq.h>
 
 struct mcux_lpsci_config {
 	UART0_Type *base;

--- a/drivers/serial/uart_msp432p4xx.c
+++ b/drivers/serial/uart_msp432p4xx.c
@@ -18,6 +18,7 @@
 #include <driverlib/rom.h>
 #include <driverlib/rom_map.h>
 #include <driverlib/uart.h>
+#include <zephyr/irq.h>
 
 struct uart_msp432p4xx_config {
 	unsigned long base;

--- a/drivers/serial/uart_neorv32.c
+++ b/drivers/serial/uart_neorv32.c
@@ -13,6 +13,7 @@
 #include <zephyr/sys/sys_io.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(uart_neorv32, CONFIG_UART_LOG_LEVEL);
 
 /* NEORV32 UART registers offsets */

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -19,6 +19,7 @@
 #include "soc_power.h"
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(uart_npcx, CONFIG_UART_LOG_LEVEL);
 
 /* Driver config */

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -10,6 +10,7 @@
 
 #include <zephyr/drivers/uart.h>
 #include <zephyr/pm/device.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 #include <hal/nrf_uart.h>
 

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -17,6 +17,7 @@
 #include <soc.h>
 #include <helpers/nrfx_gppi.h>
 #include <zephyr/linker/devicetree_regions.h>
+#include <zephyr/irq.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(uart_nrfx_uarte, CONFIG_UART_LOG_LEVEL);

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -32,6 +32,7 @@
 #include <zephyr/pm/policy.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/spinlock.h>
+#include <zephyr/irq.h>
 
 #include "uart_ns16550.h"
 

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -14,6 +14,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/sys/device_mmio.h>
+#include <zephyr/irq.h>
 #if IS_ENABLED(CONFIG_PINCTRL)
 #include <zephyr/drivers/pinctrl.h>
 #endif

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <string.h>
+#include <zephyr/irq.h>
 
 #ifndef SERCOM_USART_CTRLA_MODE_USART_INT_CLK
 #define SERCOM_USART_CTRLA_MODE_USART_INT_CLK SERCOM_USART_CTRLA_MODE(0x1)

--- a/drivers/serial/uart_sifive.c
+++ b/drivers/serial/uart_sifive.c
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <soc.h>
+#include <zephyr/irq.h>
 
 #define RXDATA_EMPTY   (1 << 31)   /* Receive FIFO Empty */
 #define RXDATA_MASK    0xFF        /* Receive Data Mask */

--- a/drivers/serial/uart_smartbond.c
+++ b/drivers/serial/uart_smartbond.c
@@ -12,6 +12,7 @@
 #include <zephyr/spinlock.h>
 #include <zephyr/sys/byteorder.h>
 #include <DA1469xAB.h>
+#include <zephyr/irq.h>
 
 #define IIR_NO_INTR		1
 #define IIR_THR_EMPTY		2

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -27,6 +27,7 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/linker/sections.h>
+#include <zephyr/irq.h>
 
 /* definitions */
 

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -40,6 +40,7 @@
 #endif /* CONFIG_PM */
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(uart_stm32, CONFIG_UART_LOG_LEVEL);
 
 /* This symbol takes the value 1 if one of the device instances */

--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -32,6 +32,7 @@
 #include <zephyr/linker/sections.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/sys/sys_io.h>
+#include <zephyr/irq.h>
 
 #ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>

--- a/drivers/serial/uart_xmc4xxx.c
+++ b/drivers/serial/uart_xmc4xxx.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/irq.h>
 
 struct uart_xmc4xxx_config {
 	XMC_USIC_CH_t *uart;

--- a/drivers/spi/spi_andes_atcspi200.c
+++ b/drivers/spi/spi_andes_atcspi200.c
@@ -6,6 +6,8 @@
 
 #include "spi_andes_atcspi200.h"
 
+#include <zephyr/irq.h>
+
 #define DT_DRV_COMPAT andestech_atcspi200
 
 typedef void (*atcspi200_cfg_func_t)(void);

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -42,6 +42,7 @@ LOG_MODULE_REGISTER(spi_dw);
 #endif
 
 #include <zephyr/drivers/spi.h>
+#include <zephyr/irq.h>
 
 #include "spi_dw.h"
 #include "spi_context.h"

--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -17,6 +17,7 @@
 #include <gd32_spi.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(spi_gd32);
 
 #include "spi_context.h"

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -24,6 +24,7 @@ LOG_MODULE_REGISTER(spi_ll_stm32);
 #endif
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
 
 #include "spi_ll_stm32.h"
 

--- a/drivers/spi/spi_mchp_mss_qspi.c
+++ b/drivers/spi/spi_mchp_mss_qspi.c
@@ -11,6 +11,7 @@
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(mss_qspi, CONFIG_SPI_LOG_LEVEL);
 #include "spi_context.h"

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -19,6 +19,7 @@
 
 #define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(spi_mcux_dspi);
 
 #include "spi_context.h"

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -19,6 +19,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #endif
 #include <zephyr/sys_clock.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(spi_mcux_flexcomm, CONFIG_SPI_LOG_LEVEL);
 

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <fsl_lpspi.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 #ifdef CONFIG_SPI_MCUX_LPSPI_DMA
 #include <zephyr/drivers/dma.h>
 #endif

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -11,6 +11,7 @@
 #include <nrfx_spi.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(spi_nrfx_spi, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -18,6 +18,7 @@
 #include <zephyr/linker/devicetree_regions.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(spi_nrfx_spim, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -10,6 +10,7 @@
 #include <nrfx_spis.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(spi_nrfx_spis, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"

--- a/drivers/spi/spi_pl022.c
+++ b/drivers/spi/spi_pl022.c
@@ -17,6 +17,7 @@
 
 #define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(spi_pl022);
 
 #include "spi_context.h"

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -18,6 +18,7 @@
 
 #define LOG_LEVEL CONFIG_SPI_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(spi_rv32m1_lpspi);
 
 #include "spi_context.h"

--- a/drivers/spi/spi_xec_qmspi_ldma.c
+++ b/drivers/spi/spi_xec_qmspi_ldma.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(spi_xec, CONFIG_SPI_LOG_LEVEL);
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
 #include <soc.h>
+#include <zephyr/irq.h>
 
 #include "spi_context.h"
 

--- a/drivers/spi/spi_xlnx_axi_quadspi.c
+++ b/drivers/spi/spi_xlnx_axi_quadspi.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/spi.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(xlnx_quadspi, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"

--- a/drivers/timer/altera_avalon_timer_hal.c
+++ b/drivers/timer/altera_avalon_timer_hal.c
@@ -9,6 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <altera_common.h>
+#include <zephyr/irq.h>
 
 #include "altera_avalon_timer_regs.h"
 #include "altera_avalon_timer.h"

--- a/drivers/timer/apic_timer.c
+++ b/drivers/timer/apic_timer.c
@@ -8,6 +8,7 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/drivers/interrupt_controller/loapic.h>
+#include <zephyr/irq.h>
 
 BUILD_ASSERT(!IS_ENABLED(CONFIG_SMP), "APIC timer doesn't support SMP");
 

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -7,6 +7,7 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/drivers/interrupt_controller/loapic.h>
+#include <zephyr/irq.h>
 
 #define IA32_TSC_DEADLINE_MSR 0x6e0
 #define IA32_TSC_ADJUST_MSR   0x03b

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -9,6 +9,7 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/arch/arc/v2/aux_regs.h>
+#include <zephyr/irq.h>
 /*
  * note: This implementation assumes Timer0 is present. Be sure
  * to build the ARC CPU with Timer0.

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -8,6 +8,7 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 
 #define COUNTER_MAX 0x00ffffff
 #define TIMER_STOPPED 0xff000000

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -12,6 +12,7 @@
 #include <cavs-idc.h>
 #include <adsp_shim.h>
 #include <adsp_interrupt.h>
+#include <zephyr/irq.h>
 
 #define DT_DRV_COMPAT intel_adsp_timer
 

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -13,6 +13,7 @@
 #include <zephyr/sys_clock.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(timer, LOG_LEVEL_ERR);
 
 BUILD_ASSERT(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC == 32768,

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -11,6 +11,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/time_units.h>
 #include <fsl_lptmr.h>
+#include <zephyr/irq.h>
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 	     "No LPTMR instance enabled in devicetree");

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -43,6 +43,7 @@
 #include <soc.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(itim, LOG_LEVEL_ERR);
 
 #define NPCX_ITIM32_MAX_CNT 0xffffffff

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/timer/nrf_rtc_timer.h>
 #include <zephyr/sys_clock.h>
 #include <hal/nrf_rtc.h>
+#include <zephyr/irq.h>
 
 #define EXT_CHAN_COUNT CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT
 #define CHAN_COUNT (EXT_CHAN_COUNT + 1)

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
+#include <zephyr/irq.h>
 
 /* andestech,machine-timer */
 #if DT_HAS_COMPAT_STATUS_OKAY(andestech_machine_timer)

--- a/drivers/timer/rv32m1_lptmr_timer.c
+++ b/drivers/timer/rv32m1_lptmr_timer.c
@@ -11,6 +11,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <soc.h>
+#include <zephyr/irq.h>
 
 /*
  * This is just a getting started point.

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -22,6 +22,7 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/irq.h>
 
 /* RTC registers. */
 #define RTC0 ((RtcMode0 *) DT_INST_REG_ADDR(0))

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -7,6 +7,7 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
+#include <zephyr/irq.h>
 
 #define TIMER_IRQ UTIL_CAT(XCHAL_TIMER,		\
 			   UTIL_CAT(CONFIG_XTENSA_TIMER_ID, _INTERRUPT))

--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -25,6 +25,7 @@
 #include <zephyr/devicetree.h>
 #define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(usb_dc_dw);
 
 /* Number of SETUP back-to-back packets */

--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -18,6 +18,7 @@
 
 #define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(usb_dc_kinetis);
 
 #define NUM_OF_EP_MAX		DT_INST_PROP(0, num_bidir_endpoints)

--- a/drivers/usb/device/usb_dc_mcux.c
+++ b/drivers/usb/device/usb_dc_mcux.c
@@ -31,6 +31,7 @@
 
 #define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(usb_dc_mcux);
 
 static void usb_isr_handler(void);

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -27,6 +27,7 @@
 
 #define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(usb_nrfx);
 
 /* USB device controller access from devicetree */

--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -13,6 +13,7 @@
 #include <zephyr/usb/usb_device.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(udc_rpi, CONFIG_USB_DRIVER_LOG_LEVEL);
 

--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(usb_dc_sam0);
 #include <zephyr/drivers/pinctrl.h>
 #include <soc.h>
 #include <string.h>
+#include <zephyr/irq.h>
 
 #define NVM_USB_PAD_TRANSN_POS 45
 #define NVM_USB_PAD_TRANSN_SIZE 5

--- a/drivers/usb/device/usb_dc_sam_usbc.c
+++ b/drivers/usb/device/usb_dc_sam_usbc.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(usb_dc_sam_usbc, CONFIG_USB_DRIVER_LOG_LEVEL);
 #include <string.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
 
 #define EP_UDINT_MASK           0x000FF000
 

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -29,6 +29,7 @@
 
 #define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(usb_dc_stm32);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otgfs) && DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs)

--- a/drivers/usbc/tcpc/ucpd_stm32.c
+++ b/drivers/usbc/tcpc/ucpd_stm32.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(ucpd_stm32, CONFIG_USBC_LOG_LEVEL);
 #include <stddef.h>
 #include <zephyr/math/ilog2.h>
 #include <stm32g0xx_ll_system.h>
+#include <zephyr/irq.h>
 
 #include "ucpd_stm32_priv.h"
 

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -16,6 +16,7 @@
 
 #include <zephyr/drivers/video.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/irq.h>
 
 struct video_mcux_csi_config {
 	CSI_Type *base;

--- a/drivers/watchdog/wdt_cc32xx.c
+++ b/drivers/watchdog/wdt_cc32xx.c
@@ -24,6 +24,7 @@
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_ctrl.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(wdt_cc32xx);
 
 struct wdt_cc32xx_data {

--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -13,6 +13,7 @@
 #include <em_cmu.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(wdt_gecko, CONFIG_WDT_LOG_LEVEL);
 
 #ifdef cmuClock_CORELE

--- a/drivers/watchdog/wdt_mcux_imx_wdog.c
+++ b/drivers/watchdog/wdt_mcux_imx_wdog.c
@@ -11,6 +11,7 @@
 
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(wdt_mcux_wdog);
 
 #define WDOG_TMOUT_SEC(x)  (((x * 2) / MSEC_PER_SEC) - 1)

--- a/drivers/watchdog/wdt_mcux_wdog32.c
+++ b/drivers/watchdog/wdt_mcux_wdog32.c
@@ -15,6 +15,7 @@
 
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(wdt_mcux_wdog32);
 
 #define MIN_TIMEOUT 1

--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -9,6 +9,7 @@
 
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(wdt_nrfx);
 
 struct wdt_nrfx_data {

--- a/drivers/watchdog/wdt_sam0.c
+++ b/drivers/watchdog/wdt_sam0.c
@@ -12,6 +12,7 @@
 
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(wdt_sam0);
 
 #define WDT_REGS ((Wdt *)DT_INST_REG_ADDR(0))

--- a/drivers/watchdog/wdt_sifive.c
+++ b/drivers/watchdog/wdt_sifive.c
@@ -16,6 +16,7 @@
 
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(wdt_sifive);
 
 #define WDOGCFG_SCALE_MAX     0xf

--- a/drivers/xen/events.c
+++ b/drivers/xen/events.c
@@ -13,6 +13,7 @@
 #include <errno.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 
 LOG_MODULE_REGISTER(xen_events);
 

--- a/samples/boards/nrf/nrfx/src/main.c
+++ b/samples/boards/nrf/nrfx/src/main.c
@@ -15,6 +15,7 @@
 #endif
 
 #include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
 LOG_MODULE_REGISTER(nrfx_sample, LOG_LEVEL_INF);
 
 #define INPUT_PIN	DT_GPIO_PIN(DT_ALIAS(sw0), gpios)

--- a/samples/boards/nrf/nrfx_prs/src/main.c
+++ b/samples/boards/nrf/nrfx_prs/src/main.c
@@ -12,6 +12,7 @@
 #include <nrfx_spim.h>
 #include <nrfx_uarte.h>
 #include <drivers/src/prs/nrfx_prs.h>
+#include <zephyr/irq.h>
 
 #define TRANSFER_LENGTH 10
 

--- a/samples/subsys/debug/fuzz/src/main.c
+++ b/samples/subsys/debug/fuzz/src/main.c
@@ -3,6 +3,7 @@
  */
 #include <zephyr/kernel.h>
 #include <string.h>
+#include <zephyr/irq.h>
 
 /* Fuzz testing is coverage-based, so we want to hide a failure case
  * (a write through a null pointer in this case) down inside a call

--- a/soc/arm/cypress/common/cypress_psoc6_dt.h
+++ b/soc/arm/cypress/common/cypress_psoc6_dt.h
@@ -13,6 +13,7 @@
 #define _CYPRESS_PSOC6_DT_H_
 
 #include <zephyr/devicetree.h>
+#include <zephyr/irq.h>
 
 /*
  * Devicetree macros related to interrupt

--- a/soc/arm/cypress/psoc6/soc.c
+++ b/soc/arm/cypress/psoc6/soc.c
@@ -8,6 +8,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/irq.h>
 
 #include "cy_syslib.h"
 #include "cy_gpio.h"

--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -13,6 +13,7 @@
 #include <adsp_ipc_regs.h>
 #include <adsp_memory.h>
 #include <adsp_interrupt.h>
+#include <zephyr/irq.h>
 
 #define CORE_POWER_CHECK_NUM 32
 #define ACE_INTC_IRQ DT_IRQN(DT_NODELABEL(ace_intc))

--- a/soc/xtensa/intel_adsp/cavs/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/cavs/multiprocessing.c
@@ -6,6 +6,7 @@
 #include <adsp_memory.h>
 #include <adsp_shim.h>
 #include <soc.h>
+#include <zephyr/irq.h>
 
 /* IDC power up message to the ROM firmware.  This isn't documented
  * anywhere, it's basically just a magic number (except the high bit,

--- a/soc/xtensa/intel_adsp/common/ipc.c
+++ b/soc/xtensa/intel_adsp/common/ipc.c
@@ -6,6 +6,7 @@
 #include <intel_adsp_ipc.h>
 #include <adsp_ipc_regs.h>
 #include <adsp_interrupt.h>
+#include <zephyr/irq.h>
 
 
 void intel_adsp_ipc_set_message_handler(const struct device *dev,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -14,6 +14,7 @@
 #include <zephyr/device.h>
 
 #include <zephyr/drivers/entropy.h>
+#include <zephyr/irq.h>
 
 #include "hal/swi.h"
 #include "hal/ccm.h"

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -15,6 +15,7 @@
 #include <zephyr/device.h>
 
 #include <zephyr/drivers/entropy.h>
+#include <zephyr/irq.h>
 
 #include "hal/swi.h"
 #include "hal/ccm.h"

--- a/tests/boards/native_posix/cpu_wait/src/main.c
+++ b/tests/boards/native_posix/cpu_wait/src/main.c
@@ -10,6 +10,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <zephyr/irq.h>
 #include "board_soc.h"
 
 /**

--- a/tests/kernel/interrupt/src/regular_isr.c
+++ b/tests/kernel/interrupt/src/regular_isr.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/interrupt_util.h>
+#include <zephyr/irq.h>
 
 /*
  * Other arch has already been tested in testcase of gen_isr_table,


### PR DESCRIPTION
Change automated searching for files using "IRQ_CONNECT()" API not including <zephyr/irq.h>.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>