### PR TITLE
doc: mgmt: mcumgr: Add SMP groups to separate heading

### DIFF
--- a/doc/services/device_mgmt/index.rst
+++ b/doc/services/device_mgmt/index.rst
@@ -11,3 +11,15 @@ Device Management
     smp_protocol.rst
     dfu.rst
     ota.rst
+
+SMP Groups
+==========
+
+.. toctree::
+    :maxdepth: 1
+
+    smp_groups/smp_group_0.rst
+    smp_groups/smp_group_1.rst
+    smp_groups/smp_group_2.rst
+    smp_groups/smp_group_8.rst
+    smp_groups/smp_group_9.rst


### PR DESCRIPTION
This adds the SMP groups to a separate heading and makes them visible in the contents list so that they can be selected without having to go to a specific page to find them.