### PR TITLE
drivers: can: npl: ensure CANFD_FDF flag is defined

### DIFF
--- a/drivers/can/can_native_posix_linux_socketcan.c
+++ b/drivers/can/can_native_posix_linux_socketcan.c
@@ -35,6 +35,11 @@
 
 #include "can_native_posix_linux_socketcan.h"
 
+#ifndef CANFD_FDF
+/* Linux kernels before v5.14 do not define CANFD_FDF */
+#define CANFD_FDF 0x04
+#endif /* CANFD_FDF */
+
 int linux_socketcan_iface_open(const char *if_name)
 {
 	struct sockaddr_can addr;


### PR DESCRIPTION
Linux kernels before v5.14 do not define the CANFD_FDF flag. The flag is disregarded within the Linux kernel. It is just there for being able to reuse the canfd_frame struct for classic CAN frames in Linux user-space applications.

Define the CANFD_FDF flag locally if not already defined to allow compiling against older Linux kernel headers.

See the following Linux kernel commit for further details: 02546884221279da2725e87e35348290470363d7

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>