### PR TITLE
device: restore init_res bit field

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -354,9 +354,9 @@ struct device_state {
 	 *
 	 * Device initialization functions return a negative errno code if they
 	 * fail. In Zephyr, errno values do not exceed 255, so we can store the
-	 * positive result value in a uint8_t type.
+	 * positive result value using 8 bits.
 	 */
-	uint8_t init_res;
+	unsigned int init_res : 8;
 
 	/** Indicates the device initialization function has been
 	 * invoked.


### PR DESCRIPTION
After b5f3cf80066822336ed24f7e61b7f0bb0fa62cd8 some platforms (qemu_riscv32_xip) are not able to boot. Re-introduce the bit field for init_res, using `unsigned int` (valids are signed/unsigned int, and bool).

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>