### PR TITLE
cmake: Deprecate 'xtools' toolchain variant

### DIFF
--- a/cmake/modules/FindDeprecated.cmake
+++ b/cmake/modules/FindDeprecated.cmake
@@ -68,6 +68,16 @@ if("CROSS_COMPILE" IN_LIST Deprecated_FIND_COMPONENTS)
   endif()
 endif()
 
+if("XTOOLS" IN_LIST Deprecated_FIND_COMPONENTS)
+  list(REMOVE_ITEM Deprecated_FIND_COMPONENTS XTOOLS)
+  # This code was deprecated after Zephyr v3.3.0
+  # When removing support for `xtools`, remember to also remove:
+  # cmake/toolchain/xtools (folder with files)
+  # doc/develop/toolchains/crosstool_ng.rst and update the index.rst file.
+  message(DEPRECATION "XTOOLS toolchain variant is deprecated. "
+                      "Please set ZEPHYR_TOOLCHAIN_VARIANT to 'zephyr'")
+endif()
+
 if(NOT "${Deprecated_FIND_COMPONENTS}" STREQUAL "")
   message(STATUS "The following deprecated component(s) could not be found: "
                  "${Deprecated_FIND_COMPONENTS}")

--- a/cmake/toolchain/xtools/generic.cmake
+++ b/cmake/toolchain/xtools/generic.cmake
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+find_package(Deprecated COMPONENTS XTOOLS)
+
 zephyr_get(XTOOLS_TOOLCHAIN_PATH)
 assert(    XTOOLS_TOOLCHAIN_PATH      "XTOOLS_TOOLCHAIN_PATH is not set")
 


### PR DESCRIPTION
The `xtools` toolchain variant (aka. Crosstool-NG) was originally introduced to be used with the Crosstool-NG-based Zephyr SDK toolchains (i.e. sdk-ng).

This is no longer necessary because the current Zephyr SDK (sdk-ng) already has its own `zephyr` toolchain variant, which fully replaces the `xtools` toolchain variant, and the `xtools` toolchain variant serves no purpose at all.

Related to #51332