### PR TITLE
tests: cmsis_dsp: Remove invalid mps3_an547 integration platform spec

### DIFF
--- a/boards/arm/mps3_an547/mps3_an547.yaml
+++ b/boards/arm/mps3_an547/mps3_an547.yaml
@@ -8,6 +8,8 @@ identifier: mps3_an547
 name: Arm MPS3-AN547
 type: mcu
 arch: arm
+ram: 512
+flash: 512
 simulation: qemu
 toolchain:
   - gnuarmemb

--- a/boards/arm/mps3_an547/mps3_an547_ns.yaml
+++ b/boards/arm/mps3_an547/mps3_an547_ns.yaml
@@ -8,6 +8,8 @@ identifier: mps3_an547_ns
 name: Arm MPS3-AN547_ns
 type: mcu
 arch: arm
+ram: 2048
+flash: 384
 simulation: qemu
 toolchain:
   - gnuarmemb

--- a/tests/lib/cmsis_dsp/transform/testcase.yaml
+++ b/tests/lib/cmsis_dsp/transform/testcase.yaml
@@ -70,7 +70,6 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
-      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 64
@@ -95,7 +94,6 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
-      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 64
@@ -168,7 +166,6 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
-      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 64
@@ -218,7 +215,6 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
-      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 96
@@ -243,7 +239,6 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
-      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 64


### PR DESCRIPTION
This commit removes the `mps3_an547` board from the integration
platform list for the tests whose minimum flash size requirement exceed
the size of the flash available on the board.

Fixes #51301