### PR TITLE
drivers: flash: soc_flash_xmc4xxx: Add missing kernel.h header

### DIFF
--- a/drivers/flash/soc_flash_xmc4xxx.c
+++ b/drivers/flash/soc_flash_xmc4xxx.c
@@ -8,8 +8,10 @@
 
 #define FLASH_WRITE_BLK_SZ DT_PROP(DT_INST(0, infineon_xmc4xxx_nv_flash), write_block_size)
 
+#include <stdint.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/kernel.h>
 
 #include <xmc_flash.h>
 


### PR DESCRIPTION
Fixes build of sample after commit a6a4400b8621bc618c60561c5bdd90b2e8ce09e0. 
west build -p -b xmc45_relax_kit samples/drivers/flash_shell

Signed-off-by: Andriy Gelman <andriy.gelman@gmail.com>