### PR TITLE
drivers: intc_dw: fixed misnumbered value of reserved slots in structure

### DIFF
--- a/drivers/interrupt_controller/intc_dw.h
+++ b/drivers/interrupt_controller/intc_dw.h
@@ -80,7 +80,7 @@ struct dw_ictl_registers {
 	uint32_t irq_plevel;		/* offset d8 */
 	uint32_t Reserved18;		/* offset dc */
 	uint32_t APB_ICTL_COMP_VERSION;	/* offset e0 */
-	uint32_t Reserved19[99];
+	uint32_t Reserved19[199];
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
The number of unused elements should be 199, not 99. mistyped in
previous commit.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
