### PR TITLE
include: Add missed 'zephyr' prefix while including header files

### DIFF
--- a/tests/bluetooth/host/CMakeLists.txt
+++ b/tests/bluetooth/host/CMakeLists.txt
@@ -10,7 +10,6 @@ add_library(host_mocks STATIC
 target_include_directories(host_mocks PUBLIC
   ${ZEPHYR_BASE}/subsys/bluetooth
   ${ZEPHYR_BASE}/subsys/bluetooth/host
-  ${ZEPHYR_BASE}/include/zephyr/bluetooth
   ${ZEPHYR_BASE}/tests/bluetooth/host
 )
 

--- a/tests/bluetooth/host/host_mocks/print_utils.h
+++ b/tests/bluetooth/host/host_mocks/print_utils.h
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <addr.h>
+#include <zephyr/bluetooth/addr.h>
 
 const char *bt_addr_str_real(const bt_addr_t *addr);
 const char *bt_addr_le_str_real(const bt_addr_le_t *addr);

--- a/tests/bluetooth/host/keys/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/CMakeLists.txt
@@ -19,7 +19,6 @@ target_include_directories(mocks PUBLIC
   ${ZEPHYR_BASE}/tests/bluetooth/host
   ${ZEPHYR_BASE}/subsys/bluetooth
   ${ZEPHYR_BASE}/subsys/bluetooth/host
-  ${ZEPHYR_BASE}/include/zephyr/bluetooth
 )
 
 target_link_libraries(mocks PRIVATE test_interface)

--- a/tests/bluetooth/host/keys/bt_keys_foreach_bond/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_bond/src/main.c
@@ -5,8 +5,8 @@
  */
 
 #include <zephyr/kernel.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/addr.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/addr.h>
 #include <host/keys.h>
 #include "mocks/keys_help_utils.h"
 #include "testing_common_defs.h"

--- a/tests/bluetooth/host/keys/bt_keys_foreach_bond/src/test_suite_foreach_bond_invalid_inputs.c
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_bond/src/test_suite_foreach_bond_invalid_inputs.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/bluetooth.h>
 #include "host_mocks/assert.h"
 #include "mocks/keys_help_utils.h"
 

--- a/tests/bluetooth/host/keys/bt_keys_foreach_type/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_type/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/bluetooth.h>
 #include <host/keys.h>
 #include "mocks/keys_help_utils.h"
 #include "testing_common_defs.h"

--- a/tests/bluetooth/host/keys/bt_keys_foreach_type/src/test_suite_foreach_type_invalid_inputs.c
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_type/src/test_suite_foreach_type_invalid_inputs.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/bluetooth.h>
 #include <host/keys.h>
 #include "host_mocks/assert.h"
 #include "mocks/keys_help_utils.h"


### PR DESCRIPTION
Add missed 'zephyr' prefix to files paths while including. Also, remove that paths from libraries include paths to generate compilation error if shortened path is used.

Signed-off-by: Ahmed Moheb <ahmed.moheb@nordicsemi.no>