### PR TITLE
dts: bindings: serial: stm32: restore tx-rx-swap property

### DIFF
--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -25,6 +25,12 @@ properties:
         only TX pin is used afterwards and should be configured.
         RX/TX conflicts must be handled on user side.
 
+    tx-rx-swap:
+      type: boolean
+      required: false
+      description:
+        Swap the TX and RX pins. Used in case of a cross wired connection.
+
     tx-invert:
       type: boolean
       required: false


### PR DESCRIPTION
As part of a previous refactor in #49364, this property was removed from the STM32 USART binding. The driver code to support this feature was not changed. This commit simply adds the property back to the new base .yaml for device trees which use the property.

Tested on a proprietary board using the STM32U5 on USART1.
