### PR TITLE
drivers: sensor: Refactor drivers to use SENSOR_DEVICE_DT_INST_DEFINE

### DIFF
--- a/drivers/sensor/adt7420/adt7420.c
+++ b/drivers/sensor/adt7420/adt7420.c
@@ -222,7 +222,7 @@ static int adt7420_init(const struct device *dev)
 		   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))	\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, adt7420_init, NULL, &adt7420_data_##inst,		\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, adt7420_init, NULL, &adt7420_data_##inst,	\
 			      &adt7420_config_##inst, POST_KERNEL,			\
 			      CONFIG_SENSOR_INIT_PRIORITY, &adt7420_driver_api);	\
 

--- a/drivers/sensor/adxl345/adxl345.c
+++ b/drivers/sensor/adxl345/adxl345.c
@@ -281,7 +281,7 @@ static int adxl345_init(const struct device *dev)
 		COND_CODE_1(DT_INST_ON_BUS(inst, spi), (ADXL345_CONFIG_SPI(inst)),      \
 			    (ADXL345_CONFIG_I2C(inst)));                                \
                                                                                         \
-	DEVICE_DT_INST_DEFINE(inst, adxl345_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, adxl345_init, NULL,				\
 			      &adxl345_data_##inst, &adxl345_config_##inst, POST_KERNEL,\
 			      CONFIG_SENSOR_INIT_PRIORITY, &adxl345_api_funcs);		\
 

--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -763,7 +763,7 @@ static int adxl362_init(const struct device *dev)
 			   (.interrupt = GPIO_DT_SPEC_INST_GET_OR(inst, int1_gpios, { 0 }),))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, adxl362_init, NULL, &adxl362_data_##inst,			\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, adxl362_init, NULL, &adxl362_data_##inst,		\
 			&adxl362_config_##inst, POST_KERNEL,					\
 			CONFIG_SENSOR_INIT_PRIORITY, &adxl362_api_funcs);			\
 

--- a/drivers/sensor/adxl372/adxl372.c
+++ b/drivers/sensor/adxl372/adxl372.c
@@ -801,7 +801,7 @@ static int adxl372_init(const struct device *dev)
  */
 
 #define ADXL372_DEVICE_INIT(inst)					\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			      adxl372_init,				\
 			      NULL,					\
 			      &adxl372_data_##inst,			\

--- a/drivers/sensor/ak8975/ak8975.c
+++ b/drivers/sensor/ak8975/ak8975.c
@@ -147,7 +147,7 @@ int ak8975_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, ak8975_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, ak8975_init, NULL,				\
 			      &ak8975_data_##inst, &ak8975_config_##inst,		\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,			\
 			      &ak8975_driver_api);					\

--- a/drivers/sensor/amg88xx/amg88xx.c
+++ b/drivers/sensor/amg88xx/amg88xx.c
@@ -145,7 +145,7 @@ static const struct sensor_driver_api amg88xx_driver_api = {
 			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, amg88xx_init, NULL,						\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, amg88xx_init, NULL,					\
 			      &amg88xx_data_##inst, &amg88xx_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &amg88xx_driver_api);		\
 

--- a/drivers/sensor/ams_iAQcore/iAQcore.c
+++ b/drivers/sensor/ams_iAQcore/iAQcore.c
@@ -117,7 +117,7 @@ static int iaq_core_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, iaq_core_init, NULL, &iaq_core_data_##inst,		\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, iaq_core_init, NULL, &iaq_core_data_##inst,	\
 			      &iaq_core_config_##inst, POST_KERNEL,			\
 			      CONFIG_SENSOR_INIT_PRIORITY, &iaq_core_driver_api);	\
 

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -524,6 +524,6 @@ static struct apds9960_data apds9960_data;
 
 PM_DEVICE_DT_INST_DEFINE(0, apds9960_pm_action);
 
-DEVICE_DT_INST_DEFINE(0, apds9960_init,
+SENSOR_DEVICE_DT_INST_DEFINE(0, apds9960_init,
 	      PM_DEVICE_DT_INST_GET(0), &apds9960_data, &apds9960_config,
 	      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &apds9960_driver_api);

--- a/drivers/sensor/bma280/bma280.c
+++ b/drivers/sensor/bma280/bma280.c
@@ -171,7 +171,7 @@ int bma280_init(const struct device *dev)
 			   (.int1_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int1_gpios, { 0 }),))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, bma280_init, NULL, &bma280_data_##inst,			\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, bma280_init, NULL, &bma280_data_##inst,		\
 			      &bma280_config##inst, POST_KERNEL,				\
 			      CONFIG_SENSOR_INIT_PRIORITY, &bma280_driver_api);			\
 

--- a/drivers/sensor/bmc150_magn/bmc150_magn.c
+++ b/drivers/sensor/bmc150_magn/bmc150_magn.c
@@ -596,7 +596,7 @@ static int bmc150_magn_init(const struct device *dev)
 			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, drdy_gpios, { 0 }),))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, bmc150_magn_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, bmc150_magn_init, NULL,				\
 		&bmc150_magn_data_##inst, &bmc150_magn_config_##inst, POST_KERNEL,		\
 		CONFIG_SENSOR_INIT_PRIORITY, &bmc150_magn_api_funcs);				\
 

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -446,7 +446,7 @@ static int bme280_pm_action(const struct device *dev,
 									\
 	PM_DEVICE_DT_INST_DEFINE(inst, bme280_pm_action);		\
 									\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			 bme280_chip_init,				\
 			 PM_DEVICE_DT_INST_GET(inst),			\
 			 &bme280_data_##inst,				\

--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -464,7 +464,7 @@ static const struct sensor_driver_api bme680_api_funcs = {
 		COND_CODE_1(DT_INST_ON_BUS(inst, spi),			\
 			    (BME680_CONFIG_SPI(inst)),			\
 			    (BME680_CONFIG_I2C(inst)));			\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			 bme680_init,					\
 			 NULL,						\
 			 &bme680_data_##inst,				\

--- a/drivers/sensor/bmg160/bmg160.c
+++ b/drivers/sensor/bmg160/bmg160.c
@@ -348,7 +348,7 @@ int bmg160_init(const struct device *dev)
 												\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, bmg160_init, NULL,						\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, bmg160_init, NULL,					\
 			      &bmg160_data_##inst, &bmg160_config_##inst,			\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &bmg160_api);		\
 

--- a/drivers/sensor/bmi160/bmi160.c
+++ b/drivers/sensor/bmi160/bmi160.c
@@ -983,7 +983,7 @@ int bmi160_init(const struct device *dev)
 #endif
 
 #define BMI160_DEVICE_INIT(inst)					\
-	DEVICE_DT_INST_DEFINE(inst, bmi160_init, NULL,			\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, bmi160_init, NULL,		\
 			      &bmi160_data_##inst, &bmi160_cfg_##inst,	\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,	\
 			      &bmi160_api);

--- a/drivers/sensor/bmi270/bmi270.c
+++ b/drivers/sensor/bmi270/bmi270.c
@@ -755,7 +755,7 @@ static const struct sensor_driver_api bmi270_driver_api = {
 			    (BMI270_CONFIG_SPI(inst)),			\
 			    (BMI270_CONFIG_I2C(inst)));			\
 									\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			      bmi270_init,				\
 			      NULL,					\
 			      &bmi270_drv_##inst,			\

--- a/drivers/sensor/bmm150/bmm150.c
+++ b/drivers/sensor/bmm150/bmm150.c
@@ -597,7 +597,7 @@ static int bmm150_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, bmm150_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, bmm150_init, NULL,				\
 			      &bmm150_data_##inst, &bmm150_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &bmm150_api_funcs);		\
 

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -721,7 +721,7 @@ static int bmp388_init(const struct device *dev)
 		.iir_filter = DT_INST_ENUM_IDX(inst, iir_filter),	   \
 	};								   \
 	PM_DEVICE_DT_INST_DEFINE(inst, bmp388_pm_action);		   \
-	DEVICE_DT_INST_DEFINE(						   \
+	SENSOR_DEVICE_DT_INST_DEFINE(					   \
 		inst,							   \
 		bmp388_init,						   \
 		PM_DEVICE_DT_INST_GET(inst),				   \

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -788,7 +788,7 @@ static const struct sensor_driver_api bq274xx_battery_driver_api = {
 										\
 	PM_DEVICE_DT_INST_DEFINE(index, bq274xx_pm_action);			\
 										\
-	DEVICE_DT_INST_DEFINE(index, &bq274xx_gauge_init,			\
+	SENSOR_DEVICE_DT_INST_DEFINE(index, &bq274xx_gauge_init,		\
 			    PM_DEVICE_DT_INST_GET(index),			\
 			    &bq274xx_driver_##index,				\
 			    &bq274xx_config_##index, POST_KERNEL,		\

--- a/drivers/sensor/ccs811/ccs811.c
+++ b/drivers/sensor/ccs811/ccs811.c
@@ -580,7 +580,7 @@ out:
 		.wake_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, wake_gpios, { 0 }),			\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(0, ccs811_init, NULL,						\
+	SENSOR_DEVICE_DT_INST_DEFINE(0, ccs811_init, NULL,					\
 			      &ccs811_data_##inst, &ccs811_config_##inst,			\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,				\
 			      &ccs811_driver_api);						\

--- a/drivers/sensor/dht/dht.c
+++ b/drivers/sensor/dht/dht.c
@@ -241,7 +241,7 @@ static int dht_init(const struct device *dev)
 		.dio_gpio = GPIO_DT_SPEC_INST_GET(inst, dio_gpios),			\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, &dht_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, &dht_init, NULL,				\
 			      &dht_data_##inst, &dht_config_##inst,			\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &dht_api);	\
 

--- a/drivers/sensor/dps310/dps310.c
+++ b/drivers/sensor/dps310/dps310.c
@@ -721,7 +721,7 @@ static const struct sensor_driver_api dps310_api_funcs = {
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, dps310_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, dps310_init, NULL,				\
 			      &dps310_data_##inst, &dps310_cfg_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &dps310_api_funcs);		\
 

--- a/drivers/sensor/ds18b20/ds18b20.c
+++ b/drivers/sensor/ds18b20/ds18b20.c
@@ -225,7 +225,7 @@ static int ds18b20_init(const struct device *dev)
 	static struct ds18b20_data ds18b20_data_##inst;			\
 	static const struct ds18b20_config ds18b20_config_##inst =	\
 		DS18B20_CONFIG_INIT(inst);				\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			      ds18b20_init,				\
 			      NULL,					\
 			      &ds18b20_data_##inst,			\

--- a/drivers/sensor/ens210/ens210.c
+++ b/drivers/sensor/ens210/ens210.c
@@ -344,7 +344,7 @@ static int ens210_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, ens210_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, ens210_init, NULL,				\
 			      &ens210_data_##inst, &ens210_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &en210_driver_api);		\
 

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -1018,7 +1018,7 @@ static int fdc2x1x_init(const struct device *dev)
 									   \
 	PM_DEVICE_DT_INST_DEFINE(n, fdc2x1x_device_pm_action);		   \
 									   \
-	DEVICE_DT_INST_DEFINE(n,					   \
+	SENSOR_DEVICE_DT_INST_DEFINE(n,					   \
 			      fdc2x1x_init,				   \
 			      PM_DEVICE_DT_INST_GET(n),			   \
 			      &fdc2x1x_data_##n,			   \

--- a/drivers/sensor/fxas21002/fxas21002.c
+++ b/drivers/sensor/fxas21002/fxas21002.c
@@ -295,7 +295,7 @@ static const struct sensor_driver_api fxas21002_driver_api = {
 									      { 0 }),))))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, fxas21002_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, fxas21002_init, NULL,				\
 			      &fxas21002_data_##inst, &fxas21002_config_##inst,			\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,				\
 			      &fxas21002_driver_api);						\

--- a/drivers/sensor/fxos8700/fxos8700.c
+++ b/drivers/sensor/fxos8700/fxos8700.c
@@ -611,7 +611,7 @@ static const struct sensor_driver_api fxos8700_driver_api = {
 									\
 	static struct fxos8700_data fxos8700_data_##n;			\
 									\
-	DEVICE_DT_INST_DEFINE(n,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(n,					\
 			    fxos8700_init,				\
 			    NULL,					\
 			    &fxos8700_data_##n,				\

--- a/drivers/sensor/grove/light_sensor.c
+++ b/drivers/sensor/grove/light_sensor.c
@@ -121,7 +121,7 @@ static int gls_init(const struct device *dev)
 		.adc_channel = DT_INST_IO_CHANNELS_INPUT(inst),			\
 	};									\
 										\
-	DEVICE_DT_INST_DEFINE(inst, &gls_init, NULL,				\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, &gls_init, NULL,			\
 			      &gls_data_##inst, &gls_cfg_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &gls_api);		\
 

--- a/drivers/sensor/grove/temperature_sensor.c
+++ b/drivers/sensor/grove/temperature_sensor.c
@@ -126,7 +126,7 @@ static int gts_init(const struct device *dev)
 		.adc_channel = DT_INST_IO_CHANNELS_INPUT(inst),			\
 	};									\
 										\
-	DEVICE_DT_INST_DEFINE(inst, &gts_init, NULL,				\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, &gts_init, NULL,			\
 			      &gts_data_##inst, &gts_cfg_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &gts_api);		\
 

--- a/drivers/sensor/hmc5883l/hmc5883l.c
+++ b/drivers/sensor/hmc5883l/hmc5883l.c
@@ -165,7 +165,7 @@ int hmc5883l_init(const struct device *dev)
 			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, hmc5883l_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, hmc5883l_init, NULL,					\
 			      &hmc5883l_data_##inst, &hmc5883l_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &hmc5883l_driver_api);		\
 

--- a/drivers/sensor/hp206c/hp206c.c
+++ b/drivers/sensor/hp206c/hp206c.c
@@ -320,7 +320,7 @@ static int hp206c_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, hp206c_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, hp206c_init, NULL,				\
 			      &hp206c_data_##inst, &hp206c_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &hp206c_api);		\
 

--- a/drivers/sensor/hts221/hts221.c
+++ b/drivers/sensor/hts221/hts221.c
@@ -207,7 +207,7 @@ int hts221_init(const struct device *dev)
  */
 
 #define HTS221_DEVICE_INIT(inst)					\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			      hts221_init,				\
 			      NULL,					\
 			      &hts221_data_##inst,			\

--- a/drivers/sensor/i3g4250d/i3g4250d.c
+++ b/drivers/sensor/i3g4250d/i3g4250d.c
@@ -216,7 +216,7 @@ static int i3g4250d_init(const struct device *dev)
 					SPI_MODE_CPHA | SPI_WORD_SET(8) | SPI_LINES_SINGLE,      \
 					0),                                                      \
 	};                                                                       \
-	DEVICE_DT_INST_DEFINE(inst,                                              \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,                                                   \
 				i3g4250d_init,                                               \
 				NULL,                                                        \
 				&i3g4250d_data_##inst,                                       \

--- a/drivers/sensor/icm42605/icm42605.c
+++ b/drivers/sensor/icm42605/icm42605.c
@@ -444,7 +444,7 @@ static const struct sensor_driver_api icm42605_driver_api = {
 #define ICM42605_INIT(index)						\
 	ICM42605_DEFINE_CONFIG(index);					\
 	static struct icm42605_data icm42605_driver_##index;		\
-	DEVICE_DT_INST_DEFINE(index, icm42605_init,			\
+	SENSOR_DEVICE_DT_INST_DEFINE(index, icm42605_init,		\
 			    NULL,					\
 			    &icm42605_driver_##index,			\
 			    &icm42605_cfg_##index, POST_KERNEL,		\

--- a/drivers/sensor/icm42670/icm42670.c
+++ b/drivers/sensor/icm42670/icm42670.c
@@ -699,7 +699,7 @@ static const struct sensor_driver_api icm42670_driver_api = {
 		.gpio_int = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),                      \
 	};                                                                                         \
 												   \
-	DEVICE_DT_INST_DEFINE(inst, icm42670_init, NULL, &icm42670_driver_##inst,                  \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, icm42670_init, NULL, &icm42670_driver_##inst,           \
 			      &icm42670_cfg_##inst, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,      \
 			      &icm42670_driver_api);
 

--- a/drivers/sensor/iis2dh/iis2dh.c
+++ b/drivers/sensor/iis2dh/iis2dh.c
@@ -318,7 +318,7 @@ static int iis2dh_init(const struct device *dev)
 			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, drdy_gpios, { 0 }),))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, iis2dh_init, NULL,						\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, iis2dh_init, NULL,					\
 			      &iis2dh_data_##inst, &iis2dh_device_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &iis2dh_driver_api);			\
 

--- a/drivers/sensor/iis2dlpc/iis2dlpc.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc.c
@@ -369,7 +369,7 @@ static int iis2dlpc_init(const struct device *dev)
  */
 
 #define IIS2DLPC_DEVICE_INIT(inst)					\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			    iis2dlpc_init,				\
 			    NULL,					\
 			    &iis2dlpc_data_##inst,			\

--- a/drivers/sensor/iis2iclx/iis2iclx.c
+++ b/drivers/sensor/iis2iclx/iis2iclx.c
@@ -629,7 +629,7 @@ static int iis2iclx_init(const struct device *dev)
  */
 
 #define IIS2ICLX_DEVICE_INIT(inst)					\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			    iis2iclx_init,				\
 			    NULL,					\
 			    &iis2iclx_data_##inst,			\

--- a/drivers/sensor/iis2mdc/iis2mdc.c
+++ b/drivers/sensor/iis2mdc/iis2mdc.c
@@ -325,7 +325,7 @@ static int iis2mdc_init(const struct device *dev)
  */
 
 #define IIS2MDC_DEVICE_INIT(inst)					\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			    iis2mdc_init,				\
 			    NULL,					\
 			    &iis2mdc_data_##inst,			\

--- a/drivers/sensor/iis3dhhc/iis3dhhc.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.c
@@ -237,7 +237,7 @@ static int iis3dhhc_init(const struct device *dev)
 					    SPI_WORD_SET(8), 0U),				\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, iis3dhhc_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, iis3dhhc_init, NULL,					\
 			      &iis3dhhc_data_##inst, &iis3dhhc_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &iis3dhhc_api_funcs);		\
 

--- a/drivers/sensor/ina219/ina219.c
+++ b/drivers/sensor/ina219/ina219.c
@@ -302,7 +302,7 @@ static const struct sensor_driver_api ina219_api = {
 								\
 	PM_DEVICE_DT_INST_DEFINE(n, ina219_pm_action);		\
 								\
-	DEVICE_DT_INST_DEFINE(n,				\
+	SENSOR_DEVICE_DT_INST_DEFINE(n,				\
 			      ina219_init,			\
 			      PM_DEVICE_DT_INST_GET(n),		\
 			      &ina219_data_##n,			\

--- a/drivers/sensor/ina23x/ina230.c
+++ b/drivers/sensor/ina23x/ina230.c
@@ -337,7 +337,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 0,
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios), \
 			    (INA230_CFG_IRQ(inst)), ())		    \
 	};							    \
-	DEVICE_DT_INST_DEFINE(inst,				    \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,			    \
 			      &ina230_init,			    \
 			      NULL,				    \
 			      &drv_data_##inst,			    \

--- a/drivers/sensor/ina23x/ina237.c
+++ b/drivers/sensor/ina23x/ina237.c
@@ -450,7 +450,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 0,
 		.alert_config = DT_INST_PROP_OR(inst, alert_config, 0x01),	\
 		.gpio_alert = GPIO_DT_SPEC_INST_GET_OR(inst, irq_gpios, {0}),	\
 	};							    \
-	DEVICE_DT_INST_DEFINE(inst,				    \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,			    \
 			      &ina237_init,			    \
 			      NULL,				    \
 			      &ina237_data_##inst,		    \

--- a/drivers/sensor/isl29035/isl29035.c
+++ b/drivers/sensor/isl29035/isl29035.c
@@ -154,7 +154,7 @@ static int isl29035_init(const struct device *dev)
 			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, &isl29035_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, &isl29035_init, NULL,				\
 			      &isl29035_data_##inst, &isl29035_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &isl29035_api);			\
 

--- a/drivers/sensor/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.c
@@ -784,7 +784,7 @@ static int ism330dhcx_init(const struct device *dev)
 			    .int_pin = DT_INST_PROP_OR(inst, int_pin, 0),))			\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, ism330dhcx_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, ism330dhcx_init, NULL,				\
 			      &ism330dhcx_data_##inst, &ism330dhcx_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &ism330dhcx_api_funcs);		\
 

--- a/drivers/sensor/ite_tach_it8xxx2/tach_ite_it8xxx2.c
+++ b/drivers/sensor/ite_tach_it8xxx2/tach_ite_it8xxx2.c
@@ -234,7 +234,7 @@ static const struct sensor_driver_api tach_it8xxx2_driver_api = {
 									       \
 	static struct tach_it8xxx2_data tach_it8xxx2_data_##inst;	       \
 									       \
-	DEVICE_DT_INST_DEFINE(inst,					       \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				       \
 			      tach_it8xxx2_init,			       \
 			      NULL,					       \
 			      &tach_it8xxx2_data_##inst,		       \

--- a/drivers/sensor/ite_vcmp_it8xxx2/vcmp_ite_it8xxx2.c
+++ b/drivers/sensor/ite_vcmp_it8xxx2/vcmp_ite_it8xxx2.c
@@ -368,7 +368,7 @@ static const struct sensor_driver_api vcmp_ite_it8xxx2_api = {
 		.adc_ch_cfg.channel_id = (uint8_t)DT_INST_IO_CHANNELS_INPUT(inst),	\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst,							\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,						\
 			      vcmp_it8xxx2_init,					\
 			      NULL,							\
 			      &vcmp_it8xxx2_data_##inst,				\

--- a/drivers/sensor/lis2dh/lis2dh.c
+++ b/drivers/sensor/lis2dh/lis2dh.c
@@ -478,7 +478,7 @@ static int lis2dh_pm_action(const struct device *dev,
 
 #define LIS2DH_DEVICE_INIT(inst)					\
 	PM_DEVICE_DT_INST_DEFINE(inst, lis2dh_pm_action);		\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			    lis2dh_init,				\
 			    PM_DEVICE_DT_INST_GET(inst),		\
 			    &lis2dh_data_##inst,			\

--- a/drivers/sensor/lis2ds12/lis2ds12.c
+++ b/drivers/sensor/lis2ds12/lis2ds12.c
@@ -332,7 +332,7 @@ static int lis2ds12_init(const struct device *dev)
  */
 
 #define LIS2DS12_DEVICE_INIT(inst)					\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			    lis2ds12_init,				\
 			    NULL,					\
 			    &lis2ds12_data_##inst,			\

--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -445,7 +445,7 @@ static int lis2dw12_init(const struct device *dev)
  */
 
 #define LIS2DW12_DEVICE_INIT(inst)					\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			    lis2dw12_init,				\
 			    NULL,					\
 			    &lis2dw12_data_##inst,			\

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -491,7 +491,7 @@ static int lis2mdl_pm_action(const struct device *dev,
 #define LIS2MDL_DEVICE_INIT(inst)					\
 	PM_DEVICE_DT_INST_DEFINE(inst, lis2mdl_pm_action);		\
 									\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			    lis2mdl_init,				\
 			    PM_DEVICE_DT_INST_GET(inst),		\
 			    &lis2mdl_data_##inst,			\

--- a/drivers/sensor/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/lis3mdl/lis3mdl.c
@@ -172,7 +172,7 @@ int lis3mdl_init(const struct device *dev)
 			   (.irq_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, irq_gpios, { 0 }),))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, lis3mdl_init, NULL,						\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, lis3mdl_init, NULL,					\
 			      &lis3mdl_data_##inst, &lis3mdl_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &lis3mdl_driver_api);		\
 

--- a/drivers/sensor/lm75/lm75.c
+++ b/drivers/sensor/lm75/lm75.c
@@ -110,7 +110,7 @@ static struct lm75_data lm75_data_##inst;                           \
 static const struct lm75_config lm75_config_##inst = {              \
 	.i2c = I2C_DT_SPEC_INST_GET(inst),                          \
 };                                                                  \
-DEVICE_DT_INST_DEFINE(inst, lm75_init, NULL, &lm75_data_##inst,     \
+SENSOR_DEVICE_DT_INST_DEFINE(inst, lm75_init, NULL, &lm75_data_##inst,     \
 		      &lm75_config_##inst, POST_KERNEL,             \
 		      CONFIG_SENSOR_INIT_PRIORITY, &lm75_driver_api);
 

--- a/drivers/sensor/lm77/lm77.c
+++ b/drivers/sensor/lm77/lm77.c
@@ -414,7 +414,7 @@ static int lm77_pm_action(const struct device *dev,
 									\
 	PM_DEVICE_DT_INST_DEFINE(n, lm77_pm_action);			\
 									\
-	DEVICE_DT_INST_DEFINE(n, lm77_init,				\
+	SENSOR_DEVICE_DT_INST_DEFINE(n, lm77_init,			\
 			      PM_DEVICE_DT_INST_GET(n),			\
 			      &lm77_data_##n,				\
 			      &lm77_config_##n, POST_KERNEL,		\

--- a/drivers/sensor/lps22hb/lps22hb.c
+++ b/drivers/sensor/lps22hb/lps22hb.c
@@ -151,7 +151,7 @@ static int lps22hb_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, lps22hb_init, NULL,						\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, lps22hb_init, NULL,					\
 			      &lps22hb_data_##inst, &lps22hb_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &lps22hb_api_funcs);			\
 

--- a/drivers/sensor/lps22hh/lps22hh.c
+++ b/drivers/sensor/lps22hh/lps22hh.c
@@ -345,7 +345,7 @@ static int lps22hh_init(const struct device *dev)
 		    (COND_CODE_1(DT_INST_ON_BUS(inst, i3c),			\
 				 (LPS22HH_CONFIG_I3C_OR_I2C(inst)),		\
 				 (LPS22HH_CONFIG_I2C(inst)))));			\
-	DEVICE_DT_INST_DEFINE(inst, lps22hh_init, NULL, &lps22hh_data_##inst,	\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, lps22hh_init, NULL, &lps22hh_data_##inst,	\
 			      &lps22hh_config_##inst, POST_KERNEL,		\
 			      CONFIG_SENSOR_INIT_PRIORITY, &lps22hh_driver_api);
 

--- a/drivers/sensor/lps25hb/lps25hb.c
+++ b/drivers/sensor/lps25hb/lps25hb.c
@@ -178,7 +178,7 @@ static int lps25hb_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, lps25hb_init, NULL,						\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, lps25hb_init, NULL,					\
 			      &lps25hb_data_##inst, &lps25hb_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &lps25hb_api_funcs);			\
 

--- a/drivers/sensor/lsm303dlhc_magn/lsm303dlhc_magn.c
+++ b/drivers/sensor/lsm303dlhc_magn/lsm303dlhc_magn.c
@@ -133,7 +133,7 @@ static int lsm303dlhc_magn_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, lsm303dlhc_magn_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, lsm303dlhc_magn_init, NULL,				\
 			      &lsm303dlhc_magn_data_##inst, &lsm303dlhc_magn_config_##inst,	\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,				\
 			      &lsm303dlhc_magn_driver_api);					\

--- a/drivers/sensor/lsm6ds0/lsm6ds0.c
+++ b/drivers/sensor/lsm6ds0/lsm6ds0.c
@@ -486,7 +486,7 @@ static int lsm6ds0_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, lsm6ds0_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, lsm6ds0_init, NULL,				\
 			      &lsm6ds0_data_##inst, &lsm6ds0_config_##inst, POST_KERNEL,\
 			      CONFIG_SENSOR_INIT_PRIORITY, &lsm6ds0_api_funcs);		\
 

--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -840,7 +840,7 @@ static int lsm6dsl_init(const struct device *dev)
  */
 
 #define LSM6DSL_DEVICE_INIT(inst)					\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			    lsm6dsl_init,				\
 			    NULL,					\
 			    &lsm6dsl_data_##inst,			\

--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -858,7 +858,7 @@ static int lsm6dso_init(const struct device *dev)
  */
 
 #define LSM6DSO_DEVICE_INIT(inst)					\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			    lsm6dso_init,				\
 			    NULL,					\
 			    &lsm6dso_data_##inst,			\

--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.c
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.c
@@ -343,7 +343,7 @@ static int lsm9ds0_gyro_init(const struct device *dev)
 			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, irq_gpios, { 0 }),))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, lsm9ds0_gyro_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, lsm9ds0_gyro_init, NULL,				\
 			      &lsm9ds0_gyro_data_##inst, &lsm9ds0_gyro_config_##inst,		\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,				\
 			      &lsm9ds0_gyro_api_funcs);						\

--- a/drivers/sensor/lsm9ds0_mfd/lsm9ds0_mfd.c
+++ b/drivers/sensor/lsm9ds0_mfd/lsm9ds0_mfd.c
@@ -758,7 +758,7 @@ int lsm9ds0_mfd_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, lsm9ds0_mfd_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, lsm9ds0_mfd_init, NULL,				\
 			      &lsm9ds0_mfd_data_##inst, &lsm9ds0_mfd_config_##inst, POST_KERNEL,\
 			      CONFIG_SENSOR_INIT_PRIORITY, &lsm9ds0_mfd_api_funcs);		\
 

--- a/drivers/sensor/max17055/max17055.c
+++ b/drivers/sensor/max17055/max17055.c
@@ -409,7 +409,7 @@ static const struct sensor_driver_api max17055_battery_driver_api = {
 		.v_empty = DT_INST_PROP(index, v_empty),				   \
 	};										   \
 											   \
-	DEVICE_DT_INST_DEFINE(index, &max17055_gauge_init,				   \
+	SENSOR_DEVICE_DT_INST_DEFINE(index, &max17055_gauge_init,			   \
 			      NULL,							   \
 			      &max17055_driver_##index,					   \
 			      &max17055_config_##index, POST_KERNEL,			   \

--- a/drivers/sensor/max17262/max17262.c
+++ b/drivers/sensor/max17262/max17262.c
@@ -331,7 +331,7 @@ static const struct sensor_driver_api max17262_battery_driver_api = {
 		.charge_voltage = DT_INST_PROP(n, charge_voltage),	\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, &max17262_gauge_init,			\
+	SENSOR_DEVICE_DT_INST_DEFINE(n, &max17262_gauge_init,		\
 			    NULL,					\
 			    &max17262_data_##n,				\
 			    &max17262_config_##n, POST_KERNEL,		\

--- a/drivers/sensor/max30101/max30101.c
+++ b/drivers/sensor/max30101/max30101.c
@@ -244,7 +244,7 @@ static struct max30101_config max30101_config = {
 
 static struct max30101_data max30101_data;
 
-DEVICE_DT_INST_DEFINE(0, max30101_init, NULL,
+SENSOR_DEVICE_DT_INST_DEFINE(0, max30101_init, NULL,
 		    &max30101_data, &max30101_config,
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &max30101_driver_api);

--- a/drivers/sensor/max31875/max31875.c
+++ b/drivers/sensor/max31875/max31875.c
@@ -268,7 +268,7 @@ static int max31875_init(const struct device *dev)
 		.resolution = DT_INST_ENUM_IDX(inst, resolution),			  \
 		.data_format = DT_INST_PROP(inst, extended_mode),			  \
 	};										  \
-	DEVICE_DT_INST_DEFINE(inst, max31875_init, NULL, &max31875_data_##inst,		  \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, max31875_init, NULL, &max31875_data_##inst,	  \
 			      &max31875_config_##inst, POST_KERNEL,			  \
 			      CONFIG_SENSOR_INIT_PRIORITY, &max31875_driver_api);
 

--- a/drivers/sensor/max44009/max44009.c
+++ b/drivers/sensor/max44009/max44009.c
@@ -190,7 +190,7 @@ int max44009_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, max44009_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, max44009_init, NULL,					\
 			      &max44009_data_##inst, &max44009_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &max44009_driver_api);		\
 

--- a/drivers/sensor/max6675/max6675.c
+++ b/drivers/sensor/max6675/max6675.c
@@ -107,7 +107,7 @@ static int max6675_init(const struct device *dev)
 					    SPI_WORD_SET(8U),		\
 					    0U),			\
 	};								\
-	DEVICE_DT_INST_DEFINE(n, &max6675_init, NULL,			\
+	SENSOR_DEVICE_DT_INST_DEFINE(n, &max6675_init, NULL,		\
 			      &max6675_data_##n, &max6675_config_##n,	\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,	\
 			      &max6675_api);

--- a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
+++ b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
@@ -180,7 +180,7 @@ static const struct sensor_driver_api tach_xec_driver_api = {
 									\
 	XEC_TACH_CONFIG(id);						\
 									\
-	DEVICE_DT_INST_DEFINE(id,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(id,				\
 			    tach_xec_init,				\
 			    NULL,					\
 			    &tach_xec_data_##id,			\

--- a/drivers/sensor/mcp9808/mcp9808.c
+++ b/drivers/sensor/mcp9808/mcp9808.c
@@ -134,7 +134,7 @@ int mcp9808_init(const struct device *dev)
 			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, mcp9808_init, NULL,						\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, mcp9808_init, NULL,					\
 			      &mcp9808_data_##inst, &mcp9808_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &mcp9808_api_funcs);			\
 

--- a/drivers/sensor/mcux_acmp/mcux_acmp.c
+++ b/drivers/sensor/mcux_acmp/mcux_acmp.c
@@ -524,7 +524,7 @@ static const struct mcux_acmp_config mcux_acmp_config_##n = {		\
 									\
 	PINCTRL_DT_INST_DEFINE(n);					\
 									\
-	DEVICE_DT_INST_DEFINE(n, &mcux_acmp_init,			\
+	SENSOR_DEVICE_DT_INST_DEFINE(n, &mcux_acmp_init,		\
 			      NULL,					\
 			      &mcux_acmp_data_##n,			\
 			      &mcux_acmp_config_##n, POST_KERNEL,	\

--- a/drivers/sensor/mhz19b/mhz19b.c
+++ b/drivers/sensor/mhz19b/mhz19b.c
@@ -341,7 +341,8 @@ static int mhz19b_init(const struct device *dev)
 		.cb = mhz19b_uart_isr,								\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, mhz19b_init, NULL, &mhz19b_data_##inst, &mhz19b_cfg_##inst, \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, mhz19b_init, NULL,					\
+			      &mhz19b_data_##inst, &mhz19b_cfg_##inst,				\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &mhz19b_api_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(MHZ19B_INIT)

--- a/drivers/sensor/mpr/mpr.c
+++ b/drivers/sensor/mpr/mpr.c
@@ -135,7 +135,7 @@ static const struct sensor_driver_api mpr_api_funcs = {
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, mpr_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, mpr_init, NULL,				\
 			      &mpr_data_##inst, &mpr_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &mpr_api_funcs);		\
 

--- a/drivers/sensor/mpu6050/mpu6050.c
+++ b/drivers/sensor/mpu6050/mpu6050.c
@@ -231,7 +231,7 @@ int mpu6050_init(const struct device *dev)
 			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, mpu6050_init, NULL,						\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, mpu6050_init, NULL,					\
 			      &mpu6050_data_##inst, &mpu6050_config_##inst,			\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,				\
 			      &mpu6050_driver_api);						\

--- a/drivers/sensor/mpu9250/mpu9250.c
+++ b/drivers/sensor/mpu9250/mpu9250.c
@@ -358,7 +358,7 @@ static int mpu9250_init(const struct device *dev)
 		  (.int_pin = GPIO_DT_SPEC_INST_GET(inst, irq_gpios)))	\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(inst, mpu9250_init, NULL,			\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, mpu9250_init, NULL,		\
 			      &mpu9250_data_##inst, &mpu9250_cfg_##inst,\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,	\
 			      &mpu9250_driver_api);

--- a/drivers/sensor/ms5607/ms5607.c
+++ b/drivers/sensor/ms5607/ms5607.c
@@ -345,7 +345,7 @@ static const struct sensor_driver_api ms5607_api_funcs = {
 		COND_CODE_1(DT_INST_ON_BUS(inst, spi),			\
 			    (MS5607_CONFIG_SPI(inst)),			\
 			    (MS5607_CONFIG_I2C(inst)));			\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			ms5607_init,					\
 			NULL,						\
 			&ms5607_data_##inst,				\

--- a/drivers/sensor/ms5837/ms5837.c
+++ b/drivers/sensor/ms5837/ms5837.c
@@ -311,7 +311,7 @@ static int ms5837_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, ms5837_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, ms5837_init, NULL,				\
 			      &ms5837_data_##inst, &ms5837_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &ms5837_api_funcs);		\
 

--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -137,7 +137,7 @@ static int temp_nrf5_init(const struct device *dev)
 #define NRF_TEMP_DEFINE(inst)								\
 	static struct temp_nrf5_data temp_nrf5_data_##inst;				\
 											\
-	DEVICE_DT_INST_DEFINE(inst, temp_nrf5_init, NULL,				\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, temp_nrf5_init, NULL,			\
 			      &temp_nrf5_data_##inst, NULL, POST_KERNEL,		\
 			      CONFIG_SENSOR_INIT_PRIORITY, &temp_nrf5_driver_api);	\
 

--- a/drivers/sensor/nuvoton_adc_cmp_npcx/adc_cmp_npcx.c
+++ b/drivers/sensor/nuvoton_adc_cmp_npcx/adc_cmp_npcx.c
@@ -262,7 +262,7 @@ static const struct sensor_driver_api adc_cmp_npcx_api = {
 		.comparison = DT_INST_STRING_TOKEN_OR(inst,                   \
 			comparison, ADC_CMP_NPCX_UNDEFINED)                   \
 	};                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, adc_cmp_npcx_init, NULL,                  \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, adc_cmp_npcx_init, NULL,           \
 			      &adc_cmp_npcx_data_##inst,                      \
 			      &adc_cmp_npcx_config_##inst, PRE_KERNEL_2,      \
 			      CONFIG_SENSOR_INIT_PRIORITY,                    \

--- a/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
+++ b/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
@@ -380,7 +380,7 @@ static const struct sensor_driver_api tach_npcx_driver_api = {
 									       \
 	static struct tach_npcx_data tach_data_##inst;                         \
 									       \
-	DEVICE_DT_INST_DEFINE(inst,                                            \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,                                     \
 			      tach_npcx_init,                                  \
 			      NULL,                                            \
 			      &tach_data_##inst,                               \

--- a/drivers/sensor/nxp_kinetis_temp/temp_kinetis.c
+++ b/drivers/sensor/nxp_kinetis_temp/temp_kinetis.c
@@ -212,7 +212,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) <= 1,
 		},							\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(inst, temp_kinetis_init,			\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, temp_kinetis_init,		\
 			    NULL,					\
 			    &temp_kinetis_data_0,			\
 			    &temp_kinetis_config_0, POST_KERNEL,	\

--- a/drivers/sensor/opt3001/opt3001.c
+++ b/drivers/sensor/opt3001/opt3001.c
@@ -166,7 +166,7 @@ int opt3001_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, opt3001_init, NULL,						\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, opt3001_init, NULL,					\
 			      &opt3001_data_##inst, &opt3001_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &opt3001_driver_api);		\
 

--- a/drivers/sensor/pcnt_esp32/pcnt_esp32.c
+++ b/drivers/sensor/pcnt_esp32/pcnt_esp32.c
@@ -415,7 +415,7 @@ static struct pcnt_esp32_data pcnt_esp32_data = {
 #endif /* CONFIG_PCNT_ESP32_TRIGGER */
 };
 
-DEVICE_DT_INST_DEFINE(0, &pcnt_esp32_init, NULL,
+SENSOR_DEVICE_DT_INST_DEFINE(0, &pcnt_esp32_init, NULL,
 			&pcnt_esp32_data,
 			&pcnt_esp32_config,
 			POST_KERNEL,

--- a/drivers/sensor/pms7003/pms7003.c
+++ b/drivers/sensor/pms7003/pms7003.c
@@ -191,7 +191,7 @@ static int pms7003_init(const struct device *dev)
 		.uart_dev = DEVICE_DT_GET(DT_INST_BUS(inst)),					\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, &pms7003_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, &pms7003_init, NULL,					\
 			      &pms7003_data_##inst, &pms7003_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &pms7003_api);			\
 

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -287,6 +287,6 @@ static const struct sensor_driver_api qdec_nrfx_driver_api = {
 
 PM_DEVICE_DT_INST_DEFINE(0, qdec_nrfx_pm_action);
 
-DEVICE_DT_INST_DEFINE(0, qdec_nrfx_init,
+SENSOR_DEVICE_DT_INST_DEFINE(0, qdec_nrfx_init,
 		PM_DEVICE_DT_INST_GET(0), NULL, NULL, POST_KERNEL,
 		CONFIG_SENSOR_INIT_PRIORITY, &qdec_nrfx_driver_api);

--- a/drivers/sensor/qdec_sam/qdec_sam.c
+++ b/drivers/sensor/qdec_sam/qdec_sam.c
@@ -130,7 +130,7 @@ static const struct sensor_driver_api qdec_sam_driver_api = {
 									\
 	static struct qdec_sam_dev_data qdec##n##_sam_data;		\
 									\
-	DEVICE_DT_INST_DEFINE(n, qdec_sam_initialize, NULL,		\
+	SENSOR_DEVICE_DT_INST_DEFINE(n, qdec_sam_initialize, NULL,	\
 			    &qdec##n##_sam_data, &qdec##n##_sam_config, \
 			    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,	\
 			    &qdec_sam_driver_api);

--- a/drivers/sensor/qdec_stm32/qdec_stm32.c
+++ b/drivers/sensor/qdec_stm32/qdec_stm32.c
@@ -154,7 +154,7 @@ static const struct sensor_driver_api qdec_stm32_driver_api = {
 											\
 	static struct qdec_stm32_dev_data qdec##n##_stm32_data;				\
 											\
-	DEVICE_DT_INST_DEFINE(n, qdec_stm32_initialize, NULL,				\
+	SENSOR_DEVICE_DT_INST_DEFINE(n, qdec_stm32_initialize, NULL,			\
 				&qdec##n##_stm32_data, &qdec##n##_stm32_config,		\
 				POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,		\
 				&qdec_stm32_driver_api);

--- a/drivers/sensor/sbs_gauge/sbs_gauge.c
+++ b/drivers/sensor/sbs_gauge/sbs_gauge.c
@@ -284,7 +284,7 @@ static const struct sensor_driver_api sbs_gauge_driver_api = {
 		.i2c = I2C_DT_SPEC_INST_GET(index), \
 	}; \
 \
-	DEVICE_DT_INST_DEFINE(index, \
+	SENSOR_DEVICE_DT_INST_DEFINE(index, \
 			    &sbs_gauge_init, \
 			    NULL, \
 			    &sbs_gauge_driver_##index, \

--- a/drivers/sensor/sgp40/sgp40.c
+++ b/drivers/sensor/sgp40/sgp40.c
@@ -258,7 +258,7 @@ static const struct sensor_driver_api sgp40_api = {
 								\
 	PM_DEVICE_DT_INST_DEFINE(n, sgp40_pm_action);		\
 								\
-	DEVICE_DT_INST_DEFINE(n,				\
+	SENSOR_DEVICE_DT_INST_DEFINE(n,				\
 			      sgp40_init,			\
 			      PM_DEVICE_DT_INST_GET(n),	\
 			      &sgp40_data_##n,			\

--- a/drivers/sensor/sht3xd/sht3xd.c
+++ b/drivers/sensor/sht3xd/sht3xd.c
@@ -219,7 +219,7 @@ static int sht3xd_init(const struct device *dev)
 		.bus = I2C_DT_SPEC_INST_GET(inst),				\
 		SHT3XD_TRIGGER_INIT(inst)					\
 	};									\
-	DEVICE_DT_INST_DEFINE(inst, sht3xd_init, NULL,				\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, sht3xd_init, NULL,			\
 		&sht3xd0_data_##inst, &sht3xd0_cfg_##inst,			\
 		POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,			\
 		&sht3xd_driver_api);

--- a/drivers/sensor/sht4x/sht4x.c
+++ b/drivers/sensor/sht4x/sht4x.c
@@ -216,7 +216,7 @@ static const struct sensor_driver_api sht4x_api = {
 		.repeatability = DT_INST_PROP(n, repeatability)	\
 	};							\
 								\
-	DEVICE_DT_INST_DEFINE(n,				\
+	SENSOR_DEVICE_DT_INST_DEFINE(n,				\
 			      sht4x_init,			\
 			      NULL,				\
 			      &sht4x_data_##n,			\

--- a/drivers/sensor/shtcx/shtcx.c
+++ b/drivers/sensor/shtcx/shtcx.c
@@ -249,7 +249,7 @@ static int shtcx_init(const struct device *dev)
 	static struct shtcx_data shtcx_data_##inst;			\
 	static struct shtcx_config shtcx_config_##inst =		\
 		SHTCX_CONFIG(inst);					\
-	DEVICE_DT_INST_DEFINE(inst,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				\
 			      shtcx_init,				\
 			      NULL,					\
 			      &shtcx_data_##inst,			\

--- a/drivers/sensor/si7006/si7006.c
+++ b/drivers/sensor/si7006/si7006.c
@@ -173,7 +173,7 @@ static int si7006_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, si7006_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, si7006_init, NULL,				\
 			      &si7006_data_##inst, &si7006_config_##inst,		\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &si7006_api);	\
 

--- a/drivers/sensor/si7055/si7055.c
+++ b/drivers/sensor/si7055/si7055.c
@@ -151,7 +151,7 @@ static int si7055_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, si7055_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, si7055_init, NULL,				\
 			      &si7055_data_##inst, &si7055_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &si7055_api);		\
 

--- a/drivers/sensor/si7060/si7060.c
+++ b/drivers/sensor/si7060/si7060.c
@@ -135,7 +135,7 @@ static int si7060_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, si7060_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, si7060_init, NULL,				\
 			      &si7060_data_##inst, &si7060_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &si7060_api);		\
 

--- a/drivers/sensor/si7210/si7210.c
+++ b/drivers/sensor/si7210/si7210.c
@@ -539,7 +539,7 @@ static int si7210_init(const struct device *dev)
 		.bus = I2C_DT_SPEC_INST_GET(inst), \
 	}; \
 	PM_DEVICE_DT_INST_DEFINE(inst, si7210_pm_action); \
-	DEVICE_DT_INST_DEFINE(inst, si7210_init, PM_DEVICE_DT_INST_GET(inst), \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, si7210_init, PM_DEVICE_DT_INST_GET(inst), \
 		&si7210_data_##inst, &si7210_config_##inst, POST_KERNEL, \
 		CONFIG_SENSOR_INIT_PRIORITY, &si7210_api_funcs);
 

--- a/drivers/sensor/sm351lt/sm351lt.c
+++ b/drivers/sensor/sm351lt/sm351lt.c
@@ -253,7 +253,7 @@ static int sm351lt_init(const struct device *dev)
 		.int_gpio = GPIO_DT_SPEC_INST_GET(inst, gpios),	     \
 	};							     \
 								     \
-	DEVICE_DT_INST_DEFINE(inst,				     \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,			     \
 			    sm351lt_init,			     \
 			    NULL,				     \
 			    &sm351lt_data_##inst,		     \

--- a/drivers/sensor/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/stm32_temp/stm32_temp.c
@@ -162,7 +162,7 @@ static int stm32_temp_init(const struct device *dev)
 			     .is_ntc = DT_INST_PROP(inst, ntc)))				\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, stm32_temp_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, stm32_temp_init, NULL,				\
 			      &stm32_temp_dev_data_##inst, &stm32_temp_dev_config_##inst,	\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,				\
 			      &stm32_temp_driver_api);						\

--- a/drivers/sensor/stm32_vbat/stm32_vbat.c
+++ b/drivers/sensor/stm32_vbat/stm32_vbat.c
@@ -123,7 +123,7 @@ static int stm32_vbat_init(const struct device *dev)
 		.ratio = DT_INST_PROP(inst, ratio),						\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, stm32_vbat_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, stm32_vbat_init, NULL,				\
 			      &stm32_vbat_dev_data_##inst, &stm32_vbat_dev_config_##inst,	\
 			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,				\
 			      &stm32_vbat_driver_api);						\

--- a/drivers/sensor/stts751/stts751.c
+++ b/drivers/sensor/stts751/stts751.c
@@ -211,7 +211,7 @@ static int stts751_init(const struct device *dev)
 			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, drdy_gpios, { 0 }),))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, stts751_init, NULL,						\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, stts751_init, NULL,					\
 			      &stts751_data_##inst, &stts751_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &stts751_api_funcs);			\
 

--- a/drivers/sensor/sx9500/sx9500.c
+++ b/drivers/sensor/sx9500/sx9500.c
@@ -139,7 +139,7 @@ int sx9500_init(const struct device *dev)
 			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, sx9500_init, NULL,						\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, sx9500_init, NULL,					\
 			      &sx9500_data_##inst, &sx9500_config_##inst, POST_KERNEL,		\
 			      CONFIG_SENSOR_INIT_PRIORITY, &sx9500_api_funcs);			\
 

--- a/drivers/sensor/th02/th02.c
+++ b/drivers/sensor/th02/th02.c
@@ -143,7 +143,7 @@ static int th02_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, th02_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, th02_init, NULL,				\
 			      &th02_data_##inst, &th02_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &th02_driver_api);		\
 

--- a/drivers/sensor/ti_hdc/ti_hdc.c
+++ b/drivers/sensor/ti_hdc/ti_hdc.c
@@ -175,7 +175,7 @@ static int ti_hdc_init(const struct device *dev)
 		.drdy = GPIO_DT_SPEC_INST_GET_OR(inst, drdy_gpios, { 0 }),		\
 	};										\
 											\
-	DEVICE_DT_INST_DEFINE(inst, ti_hdc_init, NULL,					\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, ti_hdc_init, NULL,				\
 			      &ti_hdc_data_##inst, &ti_hdc_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &ti_hdc_driver_api);		\
 

--- a/drivers/sensor/tmp007/tmp007.c
+++ b/drivers/sensor/tmp007/tmp007.c
@@ -134,7 +134,7 @@ int tmp007_init(const struct device *dev)
 			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))	\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, tmp007_init, NULL,						\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, tmp007_init, NULL,					\
 			      &tmp007_data_##inst, &tmp007_config_##inst, POST_KERNEL,		\
 			      CONFIG_SENSOR_INIT_PRIORITY, &tmp007_driver_api);			\
 

--- a/drivers/sensor/tmp108/tmp108.c
+++ b/drivers/sensor/tmp108/tmp108.c
@@ -394,7 +394,7 @@ static int tmp108_init(const struct device *dev)
 						       alert_gpios, { 0 }),\
 		.reg_def = t##_CONF					   \
 	};								   \
-	DEVICE_DT_INST_DEFINE(inst,					   \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,				   \
 			      &tmp108_init,				   \
 			      NULL,					   \
 			      &tmp108_prv_data_##inst##t,		   \

--- a/drivers/sensor/tmp112/tmp112.c
+++ b/drivers/sensor/tmp112/tmp112.c
@@ -209,7 +209,7 @@ int tmp112_init(const struct device *dev)
 		.extended_mode = DT_INST_PROP(inst, extended_mode),	    \
 	};								    \
 									    \
-	DEVICE_DT_INST_DEFINE(inst, tmp112_init, NULL, &tmp112_data_##inst, \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, tmp112_init, NULL, &tmp112_data_##inst, \
 			      &tmp112_config_##inst, POST_KERNEL,	    \
 			      CONFIG_SENSOR_INIT_PRIORITY, &tmp112_driver_api);
 

--- a/drivers/sensor/tmp116/tmp116.c
+++ b/drivers/sensor/tmp116/tmp116.c
@@ -291,7 +291,7 @@ static int tmp116_init(const struct device *dev)
 	static const struct tmp116_dev_config tmp116_config_##_num = { \
 		.bus = I2C_DT_SPEC_INST_GET(_num) \
 	}; \
-	DEVICE_DT_INST_DEFINE(_num, tmp116_init, NULL,			\
+	SENSOR_DEVICE_DT_INST_DEFINE(_num, tmp116_init, NULL, \
 		&tmp116_data_##_num, &tmp116_config_##_num, POST_KERNEL, \
 		CONFIG_SENSOR_INIT_PRIORITY, &tmp116_driver_api);
 

--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -357,7 +357,7 @@ static const struct sensor_driver_api vcnl4040_driver_api = {
 												\
 	PM_DEVICE_DT_INST_DEFINE(inst, vcnl4040_pm_action);					\
 												\
-	DEVICE_DT_INST_DEFINE(inst, vcnl4040_init, PM_DEVICE_DT_INST_GET(inst),			\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, vcnl4040_init, PM_DEVICE_DT_INST_GET(inst),		\
 			      &vcnl4040_data_##inst, &vcnl4040_config_##inst, POST_KERNEL,	\
 			      CONFIG_SENSOR_INIT_PRIORITY, &vcnl4040_driver_api);		\
 

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -361,7 +361,7 @@ static int vl53l0x_init(const struct device *dev)
 									 \
 	static struct vl53l0x_data vl53l0x_##inst##_driver;		 \
 									 \
-	DEVICE_DT_INST_DEFINE(inst, vl53l0x_init, NULL,			 \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, vl53l0x_init, NULL,		 \
 			      &vl53l0x_##inst##_driver,			 \
 			      &vl53l0x_##inst##_config,			 \
 			      POST_KERNEL,				 \

--- a/drivers/sensor/wsen_hids/wsen_hids.c
+++ b/drivers/sensor/wsen_hids/wsen_hids.c
@@ -213,7 +213,7 @@ static int hids_init(const struct device *dev)
  */
 
 #define HIDS_DEVICE_INIT(inst)                                                         \
-	DEVICE_DT_INST_DEFINE(inst,                                                    \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst,                                             \
 			      hids_init,                                               \
 			      NULL,                                                    \
 			      &hids_data_##inst,                                       \

--- a/drivers/sensor/wsen_itds/itds.c
+++ b/drivers/sensor/wsen_itds/itds.c
@@ -403,7 +403,7 @@ static const struct itds_device_config itds_config_##idx = {		\
 	WSEN_ITDS_CFG_IRQ(idx)						\
 };									\
 									\
-DEVICE_DT_INST_DEFINE(idx, itds_init, NULL,				\
+SENSOR_DEVICE_DT_INST_DEFINE(idx, itds_init, NULL,			\
 		    &itds_data_##idx, &itds_config_##idx,		\
 		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,		\
 		    &itds_api);						\

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -692,6 +692,50 @@ static inline int sensor_value_from_double(struct sensor_value *val, double inp)
 }
 
 /**
+ * @brief Like DEVICE_DT_DEFINE() with sensor specifics.
+ *
+ * @details Defines a device which implements the sensor API.
+ *
+ * @param node_id The devicetree node identifier.
+ *
+ * @param init_fn Name of the init function of the driver.
+ *
+ * @param pm_device PM device resources reference (NULL if device does not use
+ * PM).
+ *
+ * @param data_ptr Pointer to the device's private data.
+ *
+ * @param cfg_ptr The address to the structure containing the configuration
+ * information for this instance of the driver.
+ *
+ * @param level The initialization level. See SYS_INIT() for details.
+ *
+ * @param prio Priority within the selected initialization level. See
+ * SYS_INIT() for details.
+ *
+ * @param api_ptr Provides an initial pointer to the API function struct used
+ * by the driver. Can be NULL.
+ */
+#define SENSOR_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,		\
+				data_ptr, cfg_ptr, level, prio,		\
+				api_ptr, ...)				\
+	DEVICE_DT_DEFINE(node_id, init_fn, pm_device,			\
+			 data_ptr, cfg_ptr, level, prio,		\
+			 api_ptr, __VA_ARGS__);
+
+/**
+ * @brief Like SENSOR_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT
+ * compatible
+ *
+ * @param inst instance number. This is replaced by
+ * <tt>DT_DRV_COMPAT(inst)</tt> in the call to SENSOR_DEVICE_DT_DEFINE().
+ *
+ * @param ... other parameters as expected by SENSOR_DEVICE_DT_DEFINE().
+ */
+#define SENSOR_DEVICE_DT_INST_DEFINE(inst, ...)				\
+	SENSOR_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
+
+/**
  * @}
  */
 


### PR DESCRIPTION
Refactors all sensor drivers to use SENSOR_DEVICE_DT_INST_DEFINE, which is a sensor-specific variant of DEVICE_DT_INST_DEFINE that provides a common place to instantiate additional data structures for the future sensor subsystem and/or sensor driver stats.

This approach was inspired by I2C_DEVICE_DT_INST_DEFINE to streamline adding I2C stats support across all I2C drivers.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>

cc: @huhebo

This PR is another piece of #49294