### PR TITLE
driver: adc_cmp: npcx: enable adding dedicated work queue

### DIFF
--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -75,7 +75,7 @@ struct adc_npcx_threshold_control {
 	/* Sets the threshold value to which measured data is compared. */
 	uint16_t thrval;
 	/*
-	 * Pointer of work queue thread to be notified when threshold assertion
+	 * Pointer of work queue item to be notified when threshold assertion
 	 * occurs.
 	 */
 	struct k_work *work;
@@ -98,6 +98,11 @@ struct adc_npcx_threshold_data {
 	/* This array holds current configuration for each threshold. */
 	struct adc_npcx_threshold_control
 			control[DT_INST_PROP(0, threshold_count)];
+	/*
+	 * Pointer of work queue thread to be notified when threshold assertion
+	 * occurs.
+	 */
+	struct k_work_q *work_q;
 };
 
 /* Driver data */
@@ -224,9 +229,11 @@ static void adc_npcx_isr(const struct device *dev)
 			/* Clear threshold status */
 			thrcts |= BIT(i);
 			inst->THRCTS = thrcts;
-			/* Notify work thread */
 			if (t_data->control[i].work) {
-				k_work_submit(t_data->control[i].work);
+				/* Notify work thread */
+				k_work_submit_to_queue(t_data->work_q ?
+					t_data->work_q : &k_sys_work_q,
+					t_data->control[i].work);
 			}
 		}
 	}
@@ -726,6 +733,32 @@ static struct adc_npcx_data adc_npcx_data_0 = {
 	ADC_CONTEXT_INIT_LOCK(adc_npcx_data_0, ctx),
 	ADC_CONTEXT_INIT_SYNC(adc_npcx_data_0, ctx),
 };
+
+#if defined(CONFIG_ADC_CMP_NPCX_WORKQUEUE)
+struct k_work_q adc_npcx_work_q;
+
+static K_KERNEL_STACK_DEFINE(adc_npcx_work_q_stack,
+			CONFIG_ADC_CMP_NPCX_WORKQUEUE_STACK_SIZE);
+
+static int adc_npcx_init_cmp_work_q(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	struct k_work_queue_config cfg = {
+		.name = "adc_cmp_work",
+		.no_yield = false,
+	};
+
+	k_work_queue_start(&adc_npcx_work_q,
+			   adc_npcx_work_q_stack,
+			   K_KERNEL_STACK_SIZEOF(adc_npcx_work_q_stack),
+			   CONFIG_ADC_CMP_NPCX_WORKQUEUE_PRIORITY, &cfg);
+
+	threshold_data_0.work_q = &adc_npcx_work_q;
+	return 0;
+}
+
+SYS_INIT(adc_npcx_init_cmp_work_q, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY);
+#endif
 
 DEVICE_DT_INST_DEFINE(0,
 		    adc_npcx_init, NULL,

--- a/drivers/sensor/nuvoton_adc_cmp_npcx/Kconfig
+++ b/drivers/sensor/nuvoton_adc_cmp_npcx/Kconfig
@@ -13,4 +13,32 @@ config ADC_CMP_NPCX
 	  This option enables threshold interruption using sensor
 	  trigger API.
 
+if ADC_CMP_NPCX
+
+config ADC_CMP_NPCX_WORKQUEUE
+	bool "NPCX ADC threshold detection uses internal work queue"
+	help
+	  Threshold detection ISR utilizes system work queue for calling
+	  trigger handlers; set this option to use dedicated work queue instead.
+
+if ADC_CMP_NPCX_WORKQUEUE
+
+config ADC_CMP_NPCX_WORKQUEUE_PRIORITY
+	int "Nuvoton NPCX ADC trheshold detection work queue priority"
+	default SYSTEM_WORKQUEUE_PRIORITY
+	help
+	  This option sets internal ADC NPCX threshold detection workqueue
+	  priority.
+
+config ADC_CMP_NPCX_WORKQUEUE_STACK_SIZE
+	int "Nuvoton NPCX ADC trheshold detection work queue stack size"
+	default 768
+	help
+	  This option sets internal ADC NPCX threshold detection workqueue
+	  stack size.
+
+endif # ADC_CMP_NPCX_WORKQUEUE
+
+endif # ADC_CMP_NPCX
+
 endif # ADC_NPCX

--- a/drivers/sensor/nuvoton_adc_cmp_npcx/adc_cmp_npcx.c
+++ b/drivers/sensor/nuvoton_adc_cmp_npcx/adc_cmp_npcx.c
@@ -264,7 +264,7 @@ static const struct sensor_driver_api adc_cmp_npcx_api = {
 	};                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, adc_cmp_npcx_init, NULL,                  \
 			      &adc_cmp_npcx_data_##inst,                      \
-			      &adc_cmp_npcx_config_##inst, PRE_KERNEL_2,      \
+			      &adc_cmp_npcx_config_##inst, POST_KERNEL,       \
 			      CONFIG_SENSOR_INIT_PRIORITY,                    \
 			      &adc_cmp_npcx_api);
 DT_INST_FOREACH_STATUS_OKAY(NPCX_ADC_CMP_INIT)


### PR DESCRIPTION
Currently ADC comparator utilizes system work queue for submitting notifications, due to this, driver response is impacted when system work queue is heavily being used. These changes will make driver to instantiate its dedicated work queue and allow users to start using it to process its notifications.