### PR TITLE
modules: mbedtls: Provide `mbedtls_hardware_poll()` conditionally

### DIFF
--- a/modules/mbedtls/zephyr_init.c
+++ b/modules/mbedtls/zephyr_init.c
@@ -45,6 +45,7 @@ static void init_heap(void)
 #define init_heap(...)
 #endif /* CONFIG_MBEDTLS_ENABLE_HEAP && MBEDTLS_MEMORY_BUFFER_ALLOC_C */
 
+#if defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY)
 static const struct device *const entropy_dev =
 			DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_entropy));
 
@@ -80,6 +81,7 @@ int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len,
 
 	return 0;
 }
+#endif /* CONFIG_MBEDTLS_ZEPHYR_ENTROPY */
 
 static int _mbedtls_init(const struct device *device)
 {


### PR DESCRIPTION
This is a follow-up to commit c7327f5f707bfb367a78be05325469f2e950171a.

Wrap implementation of the `mbedtls_hardware_poll()` function in `#if defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY)` so that the function is provided only when that option is activated.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>