### PR TITLE
drivers: spi_context: fix some printk warnings

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -312,7 +312,8 @@ void spi_context_buffers_setup(struct spi_context *ctx,
 		" tx buf/len %p/%zu, rx buf/len %p/%zu",
 		ctx->current_tx, ctx->tx_count,
 		ctx->current_rx, ctx->rx_count,
-		ctx->tx_buf, ctx->tx_len, ctx->rx_buf, ctx->rx_len);
+		(void *)ctx->tx_buf, ctx->tx_len,
+		(void *)ctx->rx_buf, ctx->rx_len);
 }
 
 static ALWAYS_INLINE
@@ -340,7 +341,7 @@ void spi_context_update_tx(struct spi_context *ctx, uint8_t dfs, uint32_t len)
 		ctx->tx_buf += dfs * len;
 	}
 
-	LOG_DBG("tx buf/len %p/%zu", ctx->tx_buf, ctx->tx_len);
+	LOG_DBG("tx buf/len %p/%zu", (void *)ctx->tx_buf, ctx->tx_len);
 }
 
 static ALWAYS_INLINE
@@ -387,7 +388,7 @@ void spi_context_update_rx(struct spi_context *ctx, uint8_t dfs, uint32_t len)
 		ctx->rx_buf += dfs * len;
 	}
 
-	LOG_DBG("rx buf/len %p/%zu", ctx->rx_buf, ctx->rx_len);
+	LOG_DBG("rx buf/len %p/%zu", (void *)ctx->rx_buf, ctx->rx_len);
 }
 
 static ALWAYS_INLINE


### PR DESCRIPTION
Hello Maintainers,

This trivial PR fixes some "printf" warnings if printing pointer of character buffers.

For example:

```
 [00:00:00.688,000] <dbg> esp32_spi: spi_context_buffers_setup: tx_bufs 0x3ffe7148 - rx_bufs 0x3ffe7140 - 1
--- 582 messages dropped ---
[00:00:00.689,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: current_tx %p (%zu), current_rx %p (%zu), tx buf/len %p/%zu, rx buf/len %p/%zu" argument:5
--- 894 messages dropped ---
[00:00:00.689,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: current_tx %p (%zu), current_rx %p (%zu), tx buf/len %p/%zu, rx buf/len %p/%zu" argument:7
--- 284 messages dropped ---
[00:00:00.689,000] <dbg> esp32_spi: spi_context_buffers_setup: current_tx 0x3ffe7130 (2), current_rx 0x3ffe7130 (2), tx buf/len 0x3ffe7150/1, rx buf/len 0x3ffe7150/1
[00:00:00.689,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: tx buf/len %p/%zu" argument:1
[00:00:00.689,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len 0x3ffe71b8/1
[00:00:00.689,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: rx buf/len %p/%zu" argument:1
[00:00:00.689,000] <dbg> esp32_spi: spi_context_update_rx: rx buf/len 0x3ffe71b8/1
[00:00:00.689,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: tx buf/len %p/%zu" argument:1
[00:00:00.689,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len (nil)/0
[00:00:00.689,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: rx buf/len %p/%zu" argument:1
[00:00:00.689,000] <dbg> esp32_spi: spi_context_update_rx: rx buf/len (nil)/0
[00:00:00.689,000] <inf> sx127x: SX127x version 0x00 found
[00:00:00.709,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: rx buf/len %p/%zu" argument:1
[00:00:00.756,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: current_tx %p (%zu), current_rx %p (%zu), tx buf/len %p/%zu, rx buf/len %p/%zu" argument:5
[00:00:00.779,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: tx buf/len %p/%zu" argument:1
[00:00:00.779,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len (nil)/0
[00:00:00.779,000] <dbg> esp32_spi: spi_context_buffers_setup: tx_bufs 0x3ffe7078 - rx_bufs 0x3ffe7070 - 1
[00:00:00.779,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: current_tx %p (%zu), current_rx %p (%zu), tx buf/len %p/%zu, rx buf/len %p/%zu" argument:5
[00:00:00.779,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: current_tx %p (%zu), current_rx %p (%zu), tx buf/len %p/%zu, rx buf/len %p/%zu" argument:7
[00:00:00.779,000] <dbg> esp32_spi: spi_context_buffers_setup: current_tx 0x3ffe7060 (2), current_rx 0x3ffe7060 (2), tx buf/len 0x3ffe7080/1, rx buf/len 0x3ffe7080/1
[00:00:00.779,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: tx buf/len %p/%zu" argument:1
[00:00:00.779,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len 0x3ffe70f0/1
[00:00:00.779,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: rx buf/len %p/%zu" argument:1
[00:00:00.779,000] <dbg> esp32_spi: spi_context_update_rx: rx buf/len 0x3ffe70f0/1
[00:00:00.779,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: tx buf/len %p/%zu" argument:1
[00:00:00.779,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len (nil)/0
[00:00:00.779,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: rx buf/len %p/%zu" argument:1
[00:00:00.779,000] <dbg> esp32_spi: spi_context_update_rx: rx buf/len (nil)/0
[00:00:00.779,000] <dbg> esp32_spi: spi_context_buffers_setup: tx_bufs 0x3ffe7078 - rx_bufs (nil) - 1
[00:00:00.779,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: current_tx %p (%zu), current_rx %p (%zu), tx buf/len %p/%zu, rx buf/len %p/%zu" argument:5
[00:00:00.779,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: current_tx %p (%zu), current_rx %p (%zu), tx buf/len %p/%zu, rx buf/len %p/%zu" argument:7
[00:00:00.779,000] <dbg> esp32_spi: spi_context_buffers_setup: current_tx 0x3ffe7060 (2), current_rx (nil) (0), tx buf/len 0x3ffe7080/1, rx buf/len (nil)/0
[00:00:00.779,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: tx buf/len %p/%zu" argument:1
[00:00:00.779,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len 0x3ffe70f0/1
[00:00:00.779,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: tx buf/len %p/%zu" argument:1
[00:00:00.779,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len (nil)/0
[00:00:00.779,000] <dbg> lorawan: lorawan_init: LoRaMAC Initialized
```

Is stripped to:

```
--- 290 messages dropped ---
[00:00:00.699,000] <dbg> esp32_spi: spi_context_buffers_setup: current_tx 0x3ffe70a0 (2), current_rx (nil) (0), tx buf/len 0x3ffe70c0/1, rx buf/len (nil)/0
--- 380 messages dropped ---
[00:00:00.699,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len 0x3ffe7130/1
--- 71 messages dropped ---
[00:00:00.699,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len (nil)/0
--- 129 messages dropped ---
[00:00:00.699,000] <dbg> esp32_spi: spi_context_buffers_setup: tx_bufs 0x3ffe7098 - rx_bufs 0x3ffe7090 - 1
[00:00:00.699,000] <dbg> esp32_spi: spi_context_buffers_setup: current_tx 0x3ffe7080 (2), current_rx 0x3ffe7080 (2), tx buf/len 0x3ffe70a0/1, rx buf/len 0x3ffe70a0/1
[00:00:00.699,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len 0x3ffe7110/1
[00:00:00.699,000] <dbg> esp32_spi: spi_context_update_rx: rx buf/len 0x3ffe7110/1
[00:00:00.699,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len (nil)/0
[00:00:00.699,000] <dbg> esp32_spi: spi_context_update_rx: rx buf/len (nil)/0
[00:00:00.699,000] <dbg> esp32_spi: spi_context_buffers_setup: tx_bufs 0x3ffe7098 - rx_bufs 0x3ffe7090 - 1
[00:00:00.718,000] <dbg> esp32_spi: spi_context_buffers_setup: current_tx 0x3ffe7080 (2), current_rx 0x3ffe7080 (2), tx buf/len 0x3ffe70a0/1, rx buf/len 0x3ffe70a0/1
[00:00:00.731,000] <dbg> esp32_spi: spi_context_buffers_setup: current_tx 0x3ffe7080 (2), current_rx 0x3ffe7080 (2), tx buf/len 0x3ffe70a0/1, rx buf/len 0x3ffe70a0/1
[00:00:00.747,000] <dbg> esp32_spi: spi_context_buffers_setup: current_tx 0x3ffe7060 (2), current_rx (nil) (0), tx buf/len 0x3ffe7080/1, rx buf/len (nil)/0
[00:00:00.747,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len 0x3ffe70f0/1
[00:00:00.747,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len (nil)/0
[00:00:00.747,000] <dbg> esp32_spi: spi_context_buffers_setup: tx_bufs 0x3ffe7098 - rx_bufs (nil) - 1
[00:00:00.747,000] <dbg> esp32_spi: spi_context_buffers_setup: current_tx 0x3ffe7080 (2), current_rx (nil) (0), tx buf/len 0x3ffe70a0/1, rx buf/len (nil)/0
[00:00:00.747,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len 0x3ffe7110/1
[00:00:00.747,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len (nil)/0
[00:00:00.747,000] <dbg> esp32_spi: spi_context_buffers_setup: tx_bufs 0x3ffe7078 - rx_bufs 0x3ffe7070 - 1
[00:00:00.747,000] <dbg> esp32_spi: spi_context_buffers_setup: current_tx 0x3ffe7060 (2), current_rx 0x3ffe7060 (2), tx buf/len 0x3ffe7080/1, rx buf/len 0x3ffe7080/1
[00:00:00.747,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len 0x3ffe70f0/1
[00:00:00.747,000] <dbg> esp32_spi: spi_context_update_rx: rx buf/len 0x3ffe70f0/1
[00:00:00.747,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len (nil)/0
[00:00:00.747,000] <dbg> esp32_spi: spi_context_update_rx: rx buf/len (nil)/0
[00:00:00.747,000] <dbg> esp32_spi: spi_context_buffers_setup: tx_bufs 0x3ffe7078 - rx_bufs (nil) - 1
[00:00:00.747,000] <dbg> esp32_spi: spi_context_buffers_setup: current_tx 0x3ffe7060 (2), current_rx (nil) (0), tx buf/len 0x3ffe7080/1, rx buf/len (nil)/0
[00:00:00.747,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len 0x3ffe70f0/1
[00:00:00.747,000] <dbg> esp32_spi: spi_context_update_tx: tx buf/len (nil)/0
[00:00:00.747,000] <dbg> lorawan: lorawan_init: LoRaMAC Initialized
```

After applying that change.

Regards,
Gaël

---

This casts the char * buffers to void * before giving them to the printf function to fix the warning below:

Fixes:

	<wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations.

Signed-off-by: Gaël PORTAY <gael.portay@gmail.com>