### PR TITLE
timer: HPET is also a lock free readable timer

### DIFF
--- a/drivers/timer/Kconfig.hpet
+++ b/drivers/timer/Kconfig.hpet
@@ -12,6 +12,7 @@ config HPET_TIMER
 	imply TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 	select TICKLESS_CAPABLE
 	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	select SYSTEM_CLOCK_LOCK_FREE_COUNT
 	help
 	  This option selects High Precision Event Timer (HPET) as a
 	  system timer.


### PR DESCRIPTION
Mark the timer as having a lock free read of the cycle count so that spin lock debugging can include lock time asserts.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>