### PR TITLE
arm: soc: nxp_lpc: Enable sctimer for LPC55S36

### DIFF
--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -353,8 +353,14 @@
 		};
 	};
 
-
-
+	sc_timer: pwm@85000 {
+		compatible = "nxp,sctimer-pwm";
+		reg = <0x85000 0x1000>;
+		interrupts = <12 0>;
+		status = "disabled";
+		prescaler = <2>;
+		#pwm-cells = <3>;
+	};
 };
 
 &nvic {


### PR DESCRIPTION
This is required to enable the PWM driver.

Signed-off-by: Guy Morand <guy.morand@bytesatwork.ch>