### PR TITLE
drivers: pwm: pwm_mcux_sctimer: Fix stopping PWM

### DIFF
--- a/drivers/pwm/pwm_mcux_sctimer.c
+++ b/drivers/pwm/pwm_mcux_sctimer.c
@@ -73,11 +73,6 @@ static int mcux_sctimer_pwm_set_cycles(const struct device *dev,
 			base->OUTPUT |= (1UL << channel);
 		}
 
-		/* Make sure the PWM is setup */
-		if (data->period_cycles[channel] != 0) {
-			SCTIMER_StartTimer(config->base, kSCTIMER_Counter_U);
-		}
-
 		return 0;
 	}
 


### PR DESCRIPTION
When the pulse was set to 0, the PWM controller was never correctly stopped and used the last configured pulse instead.

We now configure the device and apply the new duty cycle everytime.

Signed-off-by: Guy Morand <guy.morand@bytesatwork.ch>