### PR TITLE
Add support GPIO input with interrupt for NXP S32Z27

### DIFF
--- a/boards/arm/s32z270dc2_r52/doc/index.rst
+++ b/boards/arm/s32z270dc2_r52/doc/index.rst
@@ -36,6 +36,8 @@ The boards support the following hardware features:
 | SIUL2     | on-chip    | pinctrl                             |
 |           |            |                                     |
 |           |            | gpio                                |
+|           |            |                                     |
+|           |            | external interrupt controller       |
 +-----------+------------+-------------------------------------+
 | LINFlexD  | on-chip    | serial                              |
 +-----------+------------+-------------------------------------+

--- a/drivers/gpio/gpio_s32.c
+++ b/drivers/gpio/gpio_s32.c
@@ -12,17 +12,38 @@
 #include <Siul2_Port_Ip.h>
 #include <Siul2_Dio_Ip.h>
 
+#ifdef CONFIG_NXP_S32_EIRQ
+#include <zephyr/drivers/interrupt_controller/intc_eirq_nxp_s32.h>
+
+struct eirq_nxp_s32_info {
+	const struct device *eirq_dev;
+	uint8_t num_lines;
+	struct gpio_pin_line {
+		uint8_t pin;
+		uint8_t line;
+	} gpio_pin_lines[];
+};
+#endif
+
 struct gpio_s32_config {
 	/* gpio_driver_config needs to be first */
 	struct gpio_driver_config common;
 
 	Siul2_Dio_Ip_GpioType *gpio_base;
 	Siul2_Port_Ip_PortType *port_base;
+
+#ifdef CONFIG_NXP_S32_EIRQ
+	struct eirq_nxp_s32_info *eirq_info;
+#endif
 };
 
 struct gpio_s32_data {
 	/* gpio_driver_data needs to be first */
 	struct gpio_driver_data common;
+
+#ifdef CONFIG_NXP_S32_EIRQ
+	sys_slist_t callbacks;
+#endif
 };
 
 static int s32_gpio_configure(const struct device *dev, gpio_pin_t pin,
@@ -131,34 +152,159 @@ static int s32_gpio_port_toggle_bits(const struct device *port,
 	return 0;
 }
 
+#ifdef CONFIG_NXP_S32_EIRQ
+
+static uint8_t s32_gpio_pin_to_line(const struct eirq_nxp_s32_info *eirq_info, uint8_t pin)
+{
+	uint8_t i;
+
+	for (i = 0; i < eirq_info->num_lines; i++) {
+		if (eirq_info->gpio_pin_lines[i].pin == pin) {
+			return eirq_info->gpio_pin_lines[i].line;
+		}
+	}
+
+	return SIUL2_ICU_IP_NUM_OF_CHANNELS;
+}
+
+static int s32_gpio_eirq_get_trigger(Siul2_Icu_Ip_EdgeType *edge_type,
+					enum gpio_int_mode mode,
+					enum gpio_int_trig trigger)
+{
+	if (mode == GPIO_INT_MODE_DISABLED) {
+		*edge_type = SIUL2_ICU_DISABLE;
+		return 0;
+	}
+
+	if (mode == GPIO_INT_MODE_LEVEL) {
+		return -ENOTSUP;
+	}
+
+	switch (trigger) {
+	case GPIO_INT_TRIG_LOW:
+		*edge_type = SIUL2_ICU_FALLING_EDGE;
+		break;
+	case GPIO_INT_TRIG_HIGH:
+		*edge_type = SIUL2_ICU_RISING_EDGE;
+		break;
+	case GPIO_INT_TRIG_BOTH:
+		*edge_type = SIUL2_ICU_BOTH_EDGES;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static void s32_gpio_isr(uint8_t pin, void *arg)
+{
+	const struct device *dev = (struct device *)arg;
+	struct gpio_s32_data *data = dev->data;
+
+	gpio_fire_callbacks(&data->callbacks, dev, BIT(pin));
+}
+#endif /* CONFIG_NXP_S32_EIRQ */
+
 static int s32_gpio_pin_interrupt_configure(const struct device *dev,
 					    gpio_pin_t pin,
 					    enum gpio_int_mode mode,
 					    enum gpio_int_trig trig)
 {
+#ifdef CONFIG_NXP_S32_EIRQ
+	const struct gpio_s32_config *config = dev->config;
+	const struct eirq_nxp_s32_info *eirq_info = config->eirq_info;
+
+	uint8_t eirq_line;
+
+	Siul2_Icu_Ip_EdgeType edge_type;
+
+	if (eirq_info == NULL) {
+		/*
+		 * There is no external interrupt device for
+		 * the GPIO port or exists but is not enabled
+		 */
+		return -ENOTSUP;
+	}
+
+	eirq_line = s32_gpio_pin_to_line(eirq_info, pin);
+
+	if (eirq_line == SIUL2_ICU_IP_NUM_OF_CHANNELS) {
+		/*
+		 * GPIO pin cannot be used for processing
+		 * external interrupt signal
+		 */
+		return -ENOTSUP;
+	}
+
+	if (s32_gpio_eirq_get_trigger(&edge_type, mode, trig)) {
+		return -ENOTSUP;
+	}
+
+	if (edge_type == SIUL2_ICU_DISABLE) {
+		eirq_nxp_s32_disable_interrupt(eirq_info->eirq_dev, eirq_line);
+		eirq_nxp_s32_unset_callback(eirq_info->eirq_dev, eirq_line);
+	} else {
+		if (eirq_nxp_s32_set_callback(eirq_info->eirq_dev, eirq_line,
+						s32_gpio_isr, pin, (void *)dev)) {
+			return -EBUSY;
+		}
+
+		eirq_nxp_s32_enable_interrupt(eirq_info->eirq_dev, eirq_line, edge_type);
+	}
+
+	return 0;
+#else
 	ARG_UNUSED(dev);
 	ARG_UNUSED(pin);
 	ARG_UNUSED(mode);
 	ARG_UNUSED(trig);
 
 	return -ENOTSUP;
+#endif
 }
 
 static int s32_gpio_manage_callback(const struct device *dev,
 				    struct gpio_callback *cb, bool set)
 {
+#ifdef CONFIG_NXP_S32_EIRQ
+	struct gpio_s32_data *data = dev->data;
+
+	return gpio_manage_callback(&data->callbacks, cb, set);
+#else
 	ARG_UNUSED(dev);
 	ARG_UNUSED(cb);
 	ARG_UNUSED(set);
 
 	return -ENOTSUP;
+#endif
 }
 
 static uint32_t s32_gpio_get_pending_int(const struct device *dev)
 {
+#ifdef CONFIG_NXP_S32_EIRQ
+	const struct gpio_s32_config *config = dev->config;
+	const struct eirq_nxp_s32_info *eirq_info = config->eirq_info;
+
+	if (eirq_info == NULL) {
+		/*
+		 * There is no external interrupt device for
+		 * the GPIO port or exists but is not enabled
+		 */
+		return 0;
+	}
+
+	/*
+	 * Return all pending lines of the interrupt controller
+	 * that GPIO port belongs to
+	 */
+	return eirq_nxp_s32_get_pending(eirq_info->eirq_dev);
+
+#else
 	ARG_UNUSED(dev);
 
 	return -ENOTSUP;
+#endif
 }
 
 static const struct gpio_driver_api gpio_s32_driver_api = {
@@ -204,13 +350,49 @@ static const struct gpio_driver_api gpio_s32_driver_api = {
 #define GPIO_S32_PORT_REG_ADDR(n)						\
 	((Siul2_Port_Ip_PortType *)DT_INST_REG_ADDR_BY_NAME(n, mscr))
 
+#ifdef CONFIG_NXP_S32_EIRQ
+#define GPIO_S32_EIRQ_NODE(n)							\
+	DT_INST_PHANDLE(n, interrupt_parent)
+
+#define GPIO_S32_EIRQ_PIN_LINE(idx, n)						\
+	{									\
+		.pin  = DT_INST_IRQ_BY_IDX(n, idx, gpio_pin),			\
+		.line = DT_INST_IRQ_BY_IDX(n, idx, eirq_line),			\
+	}
+
+#define GPIO_S32_SET_EIRQ_INFO(n)						\
+	BUILD_ASSERT((DT_NODE_HAS_PROP(DT_DRV_INST(n), interrupt_parent) ==	\
+			DT_NODE_HAS_PROP(DT_DRV_INST(n), interrupts)),		\
+			"interrupts and interrupt-parent must be set when"	\
+			" using external interrupts");				\
+	IF_ENABLED(DT_NODE_HAS_STATUS(GPIO_S32_EIRQ_NODE(n), okay),		\
+		(static struct eirq_nxp_s32_info eirq_nxp_s32_info_##n = {	\
+			.eirq_dev = DEVICE_DT_GET(GPIO_S32_EIRQ_NODE(n)),	\
+			.gpio_pin_lines = {					\
+				LISTIFY(DT_NUM_IRQS(DT_DRV_INST(n)),		\
+					GPIO_S32_EIRQ_PIN_LINE, (,), n)		\
+			},							\
+			.num_lines = DT_NUM_IRQS(DT_DRV_INST(n))		\
+		};								\
+		))
+
+#define GPIO_S32_GET_EIRQ_INFO(n)						\
+	.eirq_info = UTIL_AND(DT_NODE_HAS_STATUS(GPIO_S32_EIRQ_NODE(n), okay),	\
+				&eirq_nxp_s32_info_##n)
+#else
+#define GPIO_S32_SET_EIRQ_INFO(n)
+#define GPIO_S32_GET_EIRQ_INFO(n)
+#endif /* CONFIG_NXP_S32_EIRQ */
+
 #define GPIO_S32_DEVICE_INIT(n)							\
+	GPIO_S32_SET_EIRQ_INFO(n)						\
 	static const struct gpio_s32_config gpio_s32_config_##n = {		\
 		.common = {							\
 			.port_pin_mask = GPIO_S32_PORT_PIN_MASK(n),		\
 		},								\
 		.gpio_base = GPIO_S32_REG_ADDR(n),				\
 		.port_base = GPIO_S32_PORT_REG_ADDR(n),				\
+		GPIO_S32_GET_EIRQ_INFO(n)					\
 	};									\
 	static struct gpio_s32_data gpio_s32_data_##n;				\
 	static int gpio_s32_init_##n(const struct device *dev)			\

--- a/drivers/gpio/gpio_s32.c
+++ b/drivers/gpio/gpio_s32.c
@@ -7,7 +7,7 @@
 #define DT_DRV_COMPAT nxp_s32_gpio
 
 #include <zephyr/drivers/gpio.h>
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #include <Siul2_Port_Ip.h>
 #include <Siul2_Dio_Ip.h>

--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -30,6 +30,7 @@ zephyr_library_sources_ifdef(CONFIG_INTC_ESP32C3            intc_esp32c3.c)
 zephyr_library_sources_ifdef(CONFIG_SWERV_PIC               intc_swerv_pic.c)
 zephyr_library_sources_ifdef(CONFIG_VEXRISCV_LITEX_IRQ      intc_vexriscv_litex.c)
 zephyr_library_sources_ifdef(CONFIG_NUCLEI_ECLIC            intc_nuclei_eclic.c)
+zephyr_library_sources_ifdef(CONFIG_NXP_S32_EIRQ            intc_eirq_nxp_s32.c)
 
 if(CONFIG_INTEL_VTD_ICTL)
   zephyr_library_include_directories(${ZEPHYR_BASE}/arch/x86/include)

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -81,4 +81,6 @@ source "drivers/interrupt_controller/Kconfig.gd32_exti"
 
 source "drivers/interrupt_controller/Kconfig.plic"
 
+source "drivers/interrupt_controller/Kconfig.nxp_s32"
+
 endmenu

--- a/drivers/interrupt_controller/Kconfig.nxp_s32
+++ b/drivers/interrupt_controller/Kconfig.nxp_s32
@@ -1,0 +1,11 @@
+# Configuration for NXP S32 external interrupt controller
+
+# Copyright 2022 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config NXP_S32_EIRQ
+	bool "External interrupt controller driver for NXP S32 MCUs"
+	default y
+	depends on DT_HAS_NXP_S32_SIUL2_EIRQ_ENABLED
+	help
+	  External interrupt controller driver for NXP S32 MCUs

--- a/drivers/interrupt_controller/intc_eirq_nxp_s32.c
+++ b/drivers/interrupt_controller/intc_eirq_nxp_s32.c
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/irq.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/interrupt_controller/intc_eirq_nxp_s32.h>
+
+#include <Siul2_Icu_Ip_Irq.h>
+
+#define NXP_S32_NUM_CHANNELS		SIUL2_ICU_IP_NUM_OF_CHANNELS
+/*
+ * The macros from low level driver contains a bracket so
+ * it cannot be used for some Zephyr macros (e.g LISTIFY).
+ * This just does remove the bracket to be used for such macro.
+ */
+#define NXP_S32_NUM_CHANNELS_DEBRACKET	__DEBRACKET SIUL2_ICU_IP_NUM_OF_CHANNELS
+
+struct eirq_nxp_s32_config {
+	uint8_t instance;
+	mem_addr_t disr0;
+	mem_addr_t direr0;
+
+	const Siul2_Icu_Ip_ConfigType *icu_cfg;
+	const struct pinctrl_dev_config *pincfg;
+};
+
+/* Wrapper callback for each EIRQ line, from low level driver callback to GPIO callback */
+struct eirq_nxp_s32_cb {
+	eirq_nxp_s32_callback_t cb;
+	uint8_t pin;
+	void *data;
+};
+
+struct eirq_nxp_s32_data {
+	struct eirq_nxp_s32_cb *cb;
+};
+
+int eirq_nxp_s32_set_callback(const struct device *dev, uint8_t line,
+				eirq_nxp_s32_callback_t cb, uint8_t pin, void *arg)
+{
+	struct eirq_nxp_s32_data *data = dev->data;
+
+	__ASSERT(line < NXP_S32_NUM_CHANNELS, "Interrupt line is out of range");
+
+	if (data->cb[line].cb) {
+		return -EBUSY;
+	}
+
+	data->cb[line].cb   = cb;
+	data->cb[line].pin  = pin;
+	data->cb[line].data = arg;
+
+	return 0;
+}
+
+void eirq_nxp_s32_unset_callback(const struct device *dev, uint8_t line)
+{
+	struct eirq_nxp_s32_data *data = dev->data;
+
+	__ASSERT(line < NXP_S32_NUM_CHANNELS, "Interrupt line is out of range");
+
+	data->cb[line].cb    = NULL;
+	data->cb[line].pin   = 0;
+	data->cb[line].data  = NULL;
+}
+
+void eirq_nxp_s32_enable_interrupt(const struct device *dev, uint8_t line,
+					Siul2_Icu_Ip_EdgeType edge_type)
+{
+	const struct eirq_nxp_s32_config *config = dev->config;
+
+	__ASSERT(line < NXP_S32_NUM_CHANNELS, "Interrupt line is out of range");
+
+	Siul2_Icu_Ip_SetActivationCondition(config->instance, line, edge_type);
+	Siul2_Icu_Ip_EnableNotification(config->instance, line);
+	Siul2_Icu_Ip_EnableInterrupt(config->instance, line);
+}
+
+void eirq_nxp_s32_disable_interrupt(const struct device *dev, uint8_t line)
+{
+	const struct eirq_nxp_s32_config *config = dev->config;
+
+	__ASSERT(line < NXP_S32_NUM_CHANNELS, "Interrupt line is out of range");
+
+	Siul2_Icu_Ip_DisableInterrupt(config->instance, line);
+	Siul2_Icu_Ip_DisableNotification(config->instance, line);
+	Siul2_Icu_Ip_SetActivationCondition(config->instance, line, SIUL2_ICU_DISABLE);
+}
+
+uint32_t eirq_nxp_s32_get_pending(const struct device *dev)
+{
+	const struct eirq_nxp_s32_config *config = dev->config;
+
+	return sys_read32(config->disr0) & sys_read32(config->direr0);
+}
+
+static void eirq_nxp_s32_callback(const struct device *dev, uint8 line)
+{
+	const struct eirq_nxp_s32_data *data = dev->data;
+
+	if (data->cb[line].cb != NULL) {
+		data->cb[line].cb(data->cb[line].pin, data->cb[line].data);
+	}
+}
+
+static int eirq_nxp_s32_init(const struct device *dev)
+{
+	const struct eirq_nxp_s32_config *config = dev->config;
+	int err;
+
+	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+	if (err) {
+		return err;
+	}
+
+	if (Siul2_Icu_Ip_Init(config->instance, config->icu_cfg)) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+#define EIRQ_NXP_S32_NODE(n)	DT_NODELABEL(eirq##n)
+
+#define EIRQ_NXP_S32_CALLBACK(line, n)								\
+	void nxp_s32_icu_##n##_eirq_line_##line##_callback(void)				\
+	{											\
+		const struct device *dev = DEVICE_DT_GET(EIRQ_NXP_S32_NODE(n));			\
+												\
+		eirq_nxp_s32_callback(dev, line);						\
+	}
+
+#define EIRQ_NXP_S32_CHANNEL_CONFIG(idx, n)							\
+	{											\
+		.hwChannel = idx,								\
+		.digFilterEn = DT_PROP_OR(DT_CHILD(EIRQ_NXP_S32_NODE(n), line_##idx),		\
+						filter_enable, 0),				\
+		.maxFilterCnt = DT_PROP_OR(DT_CHILD(EIRQ_NXP_S32_NODE(n), line_##idx),		\
+						filter_counter, 0),				\
+		.intSel = SIUL2_ICU_IRQ,							\
+		.intEdgeSel = SIUL2_ICU_DISABLE,						\
+		.callback = NULL,								\
+		.Siul2ChannelNotification = nxp_s32_icu_##n##_eirq_line_##idx##_callback,	\
+		.callbackParam = 0U								\
+	}
+
+#define EIRQ_NXP_S32_CHANNELS_CONFIG(n)								\
+	static const Siul2_Icu_Ip_ChannelConfigType eirq_##n##_channel_nxp_s32_cfg[] = {	\
+		LISTIFY(NXP_S32_NUM_CHANNELS_DEBRACKET,	EIRQ_NXP_S32_CHANNEL_CONFIG, (,), n)	\
+	}
+
+#define EIRQ_NXP_S32_INSTANCE_CONFIG(n)								\
+	static const Siul2_Icu_Ip_InstanceConfigType eirq_##n##_instance_nxp_s32_cfg = {	\
+		.intFilterClk = DT_PROP_OR(EIRQ_NXP_S32_NODE(n),				\
+						filter_prescaler, (0)),				\
+		.altIntFilterClk = 0U,								\
+	}
+
+#define EIRQ_NXP_S32_COMBINE_CONFIG(n)								\
+	static const Siul2_Icu_Ip_ConfigType eirq_##n##_nxp_s32_cfg = {				\
+		.numChannels	 = NXP_S32_NUM_CHANNELS,					\
+		.pInstanceConfig = &eirq_##n##_instance_nxp_s32_cfg,				\
+		.pChannelsConfig = &eirq_##n##_channel_nxp_s32_cfg,				\
+	}
+
+#define EIRQ_NXP_S32_CONFIG(n)									\
+	LISTIFY(NXP_S32_NUM_CHANNELS_DEBRACKET, EIRQ_NXP_S32_CALLBACK, (), n)			\
+	EIRQ_NXP_S32_CHANNELS_CONFIG(n);							\
+	EIRQ_NXP_S32_INSTANCE_CONFIG(n);							\
+	EIRQ_NXP_S32_COMBINE_CONFIG(n);
+
+#define EIRQ_NXP_S32_INIT_DEVICE(n)								\
+	EIRQ_NXP_S32_CONFIG(n)									\
+	PINCTRL_DT_DEFINE(EIRQ_NXP_S32_NODE(n));						\
+	static const struct eirq_nxp_s32_config eirq_nxp_s32_conf_##n = {			\
+		.instance = n,									\
+		.disr0    = (mem_addr_t)DT_REG_ADDR_BY_NAME(EIRQ_NXP_S32_NODE(n), disr0),	\
+		.direr0   = (mem_addr_t)DT_REG_ADDR_BY_NAME(EIRQ_NXP_S32_NODE(n), direr0),	\
+		.icu_cfg  = (Siul2_Icu_Ip_ConfigType *)&eirq_##n##_nxp_s32_cfg,			\
+		.pincfg   = PINCTRL_DT_DEV_CONFIG_GET(EIRQ_NXP_S32_NODE(n))			\
+	};											\
+	static struct eirq_nxp_s32_cb eirq_nxp_s32_cb_##n[NXP_S32_NUM_CHANNELS];		\
+	static struct eirq_nxp_s32_data eirq_nxp_s32_data_##n = {				\
+		.cb = eirq_nxp_s32_cb_##n,							\
+	};											\
+	static int eirq_nxp_s32_init##n(const struct device *dev);				\
+	DEVICE_DT_DEFINE(EIRQ_NXP_S32_NODE(n),							\
+		eirq_nxp_s32_init##n,								\
+		NULL,										\
+		&eirq_nxp_s32_data_##n,								\
+		&eirq_nxp_s32_conf_##n,								\
+		PRE_KERNEL_1,									\
+		CONFIG_INTC_INIT_PRIORITY,							\
+		NULL);										\
+	static int eirq_nxp_s32_init##n(const struct device *dev)				\
+	{											\
+		int err;									\
+												\
+		err = eirq_nxp_s32_init(dev);							\
+		if (err) {									\
+			return err;								\
+		}										\
+												\
+		IRQ_CONNECT(DT_IRQN(EIRQ_NXP_S32_NODE(n)),					\
+			DT_IRQ(EIRQ_NXP_S32_NODE(n), priority),					\
+			SIUL2_##n##_ICU_EIRQ_SINGLE_INT_HANDLER,				\
+			DEVICE_DT_GET(EIRQ_NXP_S32_NODE(n)),					\
+			DT_IRQ(EIRQ_NXP_S32_NODE(n), flags));					\
+												\
+		irq_enable(DT_IRQN(EIRQ_NXP_S32_NODE(n)));					\
+												\
+		return 0;									\
+	}
+
+#if DT_NODE_HAS_STATUS(EIRQ_NXP_S32_NODE(0), okay)
+EIRQ_NXP_S32_INIT_DEVICE(0)
+#endif
+
+#if DT_NODE_HAS_STATUS(EIRQ_NXP_S32_NODE(1), okay)
+EIRQ_NXP_S32_INIT_DEVICE(1)
+#endif
+
+#if DT_NODE_HAS_STATUS(EIRQ_NXP_S32_NODE(4), okay)
+EIRQ_NXP_S32_INIT_DEVICE(4)
+#endif
+
+#if DT_NODE_HAS_STATUS(EIRQ_NXP_S32_NODE(5), okay)
+EIRQ_NXP_S32_INIT_DEVICE(5)
+#endif

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -195,6 +195,16 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
+			eirq0: eirq0@40520010 {
+				compatible = "nxp,s32-siul2-eirq";
+				reg = <0x40520010 0x04>, <0x40520018 0x04>;
+				reg-names = "disr0", "direr0";
+				interrupts = <GIC_SPI 514 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				status = "disabled";
+			};
+
 			gpioa: gpio@40521702 {
 				compatible = "nxp,s32-gpio";
 				reg = <0x40521702 0x02>, <0x40520240 0x40>;
@@ -231,6 +241,16 @@
 			reg = <0x40d20000 0x10000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			eirq1: eirq1@40d20010 {
+				compatible = "nxp,s32-siul2-eirq";
+				reg = <0x40d20010 0x04>, <0x40d20018 0x04>;
+				reg-names = "disr0", "direr0";
+				interrupts = <GIC_SPI 515 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				status = "disabled";
+			};
 
 			gpioc: gpio@40d21700 {
 				compatible = "nxp,s32-gpio";
@@ -293,6 +313,16 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
+			eirq4: eirq4@42520010 {
+				compatible = "nxp,s32-siul2-eirq";
+				reg = <0x42520010 0x04>, <0x42520018 0x04>;
+				reg-names = "disr0", "direr0";
+				interrupts = <GIC_SPI 516 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				status = "disabled";
+			};
+
 			gpioh: gpio@42521708 {
 				compatible = "nxp,s32-gpio";
 				reg = <0x42521708 0x02>, <0x42520380 0x40>;
@@ -350,6 +380,16 @@
 			reg = <0x42d20000 0x10000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			eirq5: eirq5@42d20010 {
+				compatible = "nxp,s32-siul2-eirq";
+				reg = <0x42d20010 0x04>, <0x42d20018 0x04>;
+				reg-names = "disr0", "direr0";
+				interrupts = <GIC_SPI 517 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				status = "disabled";
+			};
 
 			gpiom: gpio@42d21710 {
 				compatible = "nxp,s32-gpio";

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -209,6 +209,9 @@
 				compatible = "nxp,s32-gpio";
 				reg = <0x40521702 0x02>, <0x40520240 0x40>;
 				reg-names = "pgpdo", "mscr";
+				interrupt-parent = <&eirq0>;
+				interrupts = <1 1>, <3 0>, <5 2>, <12 3>,
+						<13 4>, <14 5>, <15 6>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -219,6 +222,8 @@
 				compatible = "nxp,s32-gpio";
 				reg = <0x40521700 0x02>, <0x40520280 0x40>;
 				reg-names = "pgpdo", "mscr";
+				interrupt-parent = <&eirq0>;
+				interrupts = <0 7>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <15>;
@@ -256,6 +261,8 @@
 				compatible = "nxp,s32-gpio";
 				reg = <0x40d21700 0x02>, <0x40d20280 0x40>;
 				reg-names = "pgpdo", "mscr";
+				interrupt-parent = <&eirq1>;
+				interrupts = <3 0>, <5 1>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -297,6 +304,9 @@
 				compatible = "nxp,s32-gpio";
 				reg = <0x40d21708 0x02>, <0x40d20380 0x40>;
 				reg-names = "pgpdo", "mscr";
+				interrupt-parent = <&eirq1>;
+				interrupts = <0 2>, <1 3>, <4 4>,
+						<5 5>, <10 6>, <11 7>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <12>;
@@ -338,6 +348,8 @@
 				compatible = "nxp,s32-gpio";
 				reg = <0x4252170e 0x02>, <0x425203c0 0x40>;
 				reg-names = "pgpdo", "mscr";
+				interrupt-parent = <&eirq4>;
+				interrupts = <11 0>, <13 1>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -348,6 +360,8 @@
 				compatible = "nxp,s32-gpio";
 				reg = <0x4252170c 0x02>, <0x42520400 0x40>;
 				reg-names = "pgpdo", "mscr";
+				interrupt-parent = <&eirq4>;
+				interrupts = <12 2>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -358,6 +372,9 @@
 				compatible = "nxp,s32-gpio";
 				reg = <0x42521712 0x02>, <0x42520440 0x40>;
 				reg-names = "pgpdo", "mscr";
+				interrupt-parent = <&eirq4>;
+				interrupts = <4 3>, <6 4>, <9 5>,
+						<11 6>, <13 7>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -395,6 +412,8 @@
 				compatible = "nxp,s32-gpio";
 				reg = <0x42d21710 0x02>, <0x42d20480 0x40>;
 				reg-names = "pgpdo", "mscr";
+				interrupt-parent = <&eirq5>;
+				interrupts = <1 0>, <3 1>, <5 2>, <7 3>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -406,6 +425,8 @@
 				compatible = "nxp,s32-gpio";
 				reg = <0x42d21716 0x02>, <0x42d204c0 0x40>;
 				reg-names = "pgpdo", "mscr";
+				interrupt-parent = <&eirq5>;
+				interrupts = <0 4>, <2 5>, <5 6>, <6 7>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <10>;

--- a/dts/bindings/gpio/nxp,s32-gpio.yaml
+++ b/dts/bindings/gpio/nxp,s32-gpio.yaml
@@ -14,6 +14,13 @@ properties:
     reg-names:
       required: true
 
+    interrupts:
+      required: false
+      description: |
+        For GPIO ports that have pins can be used for processing
+        external interrupt signal, this is a list of GPIO pins and
+        respective external interrupt lines (<gpio-pin eirq-line>).
+
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/interrupt-controller/nxp,s32-siul2-eirq.yaml
+++ b/dts/bindings/interrupt-controller/nxp,s32-siul2-eirq.yaml
@@ -1,0 +1,62 @@
+# Copyright 2022 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP S32 SIUL2 External Interrupts Request controller
+
+compatible: "nxp,s32-siul2-eirq"
+
+include: [interrupt-controller.yaml, pinctrl-device.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  reg-names:
+    required: true
+
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true
+
+  filter-prescaler:
+    type: int
+    required: false
+    description: |
+      Setting the prescaler which selects the clock for all digital filters.
+      Valid range: 0 - 15.
+
+child-binding:
+  description: |
+    NXP S32 SIUL2 External Interrupt line configuration. For each
+    interrupt line that has specific requirements about digital
+    glitch filter, a node using this binding must be added, the
+    name must be "line_<line_number>". For example:
+
+      line_0: line_0 {
+          filter-enable;
+          filter-counter = <5>;
+      };
+
+    If the controller has no child node, the digital filter will be
+    disabled for all external interrupt lines.
+
+  properties:
+    filter-enable:
+      type: boolean
+      required: true
+      description: |
+        Enable digital glitch filter to filter out glitches on the input pad.
+
+    filter-counter:
+      type: int
+      required: true
+      description: |
+        Configuring the filter counter associated with digital glitch filter.
+        Valid range: 0 - 15.
+
+interrupt-cells:
+  - gpio-pin
+  - eirq-line

--- a/include/zephyr/drivers/interrupt_controller/intc_eirq_nxp_s32.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_eirq_nxp_s32.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @brief Driver for External interrupt/event controller in NXP S32 MCUs
+ *
+ */
+
+#ifndef ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_EIRQ_NXP_S32_H_
+#define ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_EIRQ_NXP_S32_H_
+
+#include <Siul2_Icu_Ip.h>
+
+/* Wrapper callback for EIRQ line */
+typedef void (*eirq_nxp_s32_callback_t)(uint8_t pin, void *arg);
+
+/**
+ * @brief Unset EIRQ callback for line
+ *
+ * @param dev EIRQ device
+ * @param line EIRQ line
+ */
+void eirq_nxp_s32_unset_callback(const struct device *dev, uint8_t line);
+
+/**
+ * @brief Set EIRQ callback for line
+ *
+ * @param dev  EIRQ device
+ * @param line EIRQ line
+ * @param cb   Callback
+ * @param pin  GPIO pin
+ * @param arg  Callback data
+ *
+ * @retval 0 on SUCCESS
+ * @retval -EBUSY if callback for the line is already set
+ */
+int eirq_nxp_s32_set_callback(const struct device *dev, uint8_t line,
+				eirq_nxp_s32_callback_t cb, uint8_t pin, void *arg);
+
+/**
+ * @brief Set edge event and enable interrupt for EIRQ line
+ *
+ * @param dev  EIRQ device
+ * @param line EIRQ line
+ * @param edge_type Type of edge event
+ */
+void eirq_nxp_s32_enable_interrupt(const struct device *dev, uint8_t line,
+					Siul2_Icu_Ip_EdgeType edge_type);
+
+/**
+ * @brief Disable interrupt for EIRQ line
+ *
+ * @param dev  EIRQ device
+ * @param line EIRQ line
+ */
+void eirq_nxp_s32_disable_interrupt(const struct device *dev, uint8_t line);
+
+/**
+ * @brief Get pending interrupt for EIRQ device
+ *
+ * @param dev EIRQ device
+ * @return A mask contains pending flags
+ */
+uint32_t eirq_nxp_s32_get_pending(const struct device *dev);
+
+#endif /* ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_EIRQ_NXP_S32_H_ */

--- a/tests/drivers/gpio/gpio_api_1pin/boards/s32z270dc2_rtu0_r52.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/s32z270dc2_rtu0_r52.overlay
@@ -20,6 +20,21 @@
 	};
 };
 
+&pinctrl {
+	eirq0_default: eirq0_default {
+		group1 {
+			pinmux = <PA3_EIRQ_0>;
+			input-enable;
+		};
+	};
+};
+
+&eirq0 {
+	pinctrl-0 = <&eirq0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &gpioa {
 	status = "okay";
 };

--- a/tests/drivers/gpio/gpio_api_1pin/boards/s32z270dc2_rtu1_r52.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/s32z270dc2_rtu1_r52.overlay
@@ -20,6 +20,21 @@
 	};
 };
 
+&pinctrl {
+	eirq0_default: eirq0_default {
+		group1 {
+			pinmux = <PA3_EIRQ_0>;
+			input-enable;
+		};
+	};
+};
+
+&eirq0 {
+	pinctrl-0 = <&eirq0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &gpioa {
 	status = "okay";
 };

--- a/tests/drivers/gpio/gpio_basic_api/boards/s32z270dc2_rtu0_r52.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/s32z270dc2_rtu0_r52.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/s32/S32Z27-BGA594-pinctrl.h>
+
+/ {
+	/* Pin 1 and 3 of J69 must be connected on the board */
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpioa 11 0>;
+		in-gpios = <&gpioa 12 0>;
+	};
+};
+
+&pinctrl {
+	eirq0_default: eirq0_default {
+		group1 {
+			pinmux = <PA12_EIRQ_3>;
+			input-enable;
+		};
+	};
+};
+
+&eirq0 {
+	pinctrl-0 = <&eirq0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&gpioa {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/s32z270dc2_rtu1_r52.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/s32z270dc2_rtu1_r52.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/s32/S32Z27-BGA594-pinctrl.h>
+
+/ {
+	/* Pin 1 and 3 of J69 must be connected on the board */
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpioa 11 0>;
+		in-gpios = <&gpioa 12 0>;
+	};
+};
+
+&pinctrl {
+	eirq0_default: eirq0_default {
+		group1 {
+			pinmux = <PA12_EIRQ_3>;
+			input-enable;
+		};
+	};
+};
+
+&eirq0 {
+	pinctrl-0 = <&eirq0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&gpioa {
+	status = "okay";
+};

--- a/west.yml
+++ b/west.yml
@@ -88,7 +88,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 9bc1e797921b2a4b246ce7647dc426549985e76a
+      revision: 6d48547251d471ecdca9560f297296a1f33ad16c
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This PR introduces GPIO input with interrupt for SoC NXP S32Z27
The update in hal_nxp: https://github.com/zephyrproject-rtos/hal_nxp/pull/200