### PR TITLE
drivers: clock_control: stm32: add missing headers

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.h
+++ b/drivers/clock_control/clock_stm32_ll_common.h
@@ -8,6 +8,10 @@
 #ifndef ZEPHYR_DRIVERS_CLOCK_CONTROL_STM32_LL_CLOCK_H_
 #define ZEPHYR_DRIVERS_CLOCK_CONTROL_STM32_LL_CLOCK_H_
 
+#include <stdint.h>
+
+#include <zephyr/device.h>
+
 #include <stm32_ll_utils.h>
 
 #if CONFIG_CLOCK_STM32_MCO1_SRC_NOCLOCK


### PR DESCRIPTION
clock_stm32_ll_common.h was missing <stdint.h> and <zephyr/device.h>. It turns out things worked because <zephyr/init.h> (included later in some sources) has a forward declaration of struct device.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>