### PR TITLE
Aarch32: Use inline assembly for accessing IO

### DIFF
--- a/include/zephyr/arch/arm/aarch32/cortex_a_r/sys_io.h
+++ b/include/zephyr/arch/arm/aarch32/cortex_a_r/sys_io.h
@@ -26,7 +26,9 @@ extern "C" {
 
 static ALWAYS_INLINE uint8_t sys_read8(mem_addr_t addr)
 {
-	uint8_t val = *(volatile uint8_t *)addr;
+	uint8_t val;
+
+	__asm__ volatile("ldrb %0, [%1]" : "=r" (val) : "r" (addr));
 
 	__DMB();
 	return val;
@@ -35,12 +37,14 @@ static ALWAYS_INLINE uint8_t sys_read8(mem_addr_t addr)
 static ALWAYS_INLINE void sys_write8(uint8_t data, mem_addr_t addr)
 {
 	__DMB();
-	*(volatile uint8_t *)addr = data;
+	__asm__ volatile("strb %0, [%1]" : : "r" (data), "r" (addr));
 }
 
 static ALWAYS_INLINE uint16_t sys_read16(mem_addr_t addr)
 {
-	uint16_t val = *(volatile uint16_t *)addr;
+	uint16_t val;
+
+	__asm__ volatile("ldrh %0, [%1]" : "=r" (val) : "r" (addr));
 
 	__DMB();
 	return val;
@@ -49,12 +53,14 @@ static ALWAYS_INLINE uint16_t sys_read16(mem_addr_t addr)
 static ALWAYS_INLINE void sys_write16(uint16_t data, mem_addr_t addr)
 {
 	__DMB();
-	*(volatile uint16_t *)addr = data;
+	__asm__ volatile("strh %0, [%1]" : : "r" (data), "r" (addr));
 }
 
 static ALWAYS_INLINE uint32_t sys_read32(mem_addr_t addr)
 {
-	uint32_t val = *(volatile uint32_t *)addr;
+	uint32_t val;
+
+	__asm__ volatile("ldr %0, [%1]" : "=r" (val) : "r" (addr));
 
 	__DMB();
 	return val;
@@ -63,12 +69,14 @@ static ALWAYS_INLINE uint32_t sys_read32(mem_addr_t addr)
 static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 {
 	__DMB();
-	*(volatile uint32_t *)addr = data;
+	__asm__ volatile("str %0, [%1]" : : "r" (data), "r" (addr));
 }
 
 static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
 {
-	uint64_t val = *(volatile uint64_t *)addr;
+	uint64_t val;
+
+	__asm__ volatile("ldrd %Q0, %R0, [%1]" : "=r" (val) : "r" (addr));
 
 	__DMB();
 	return val;


### PR DESCRIPTION
The reasons for using inline assembly is as follows:-
1. Prevent the compiler from doing funny optimizations. For eg generating four ldrb instructions to read a 32 bit word. This may cause an abort on certain MMIO registers.
2. Prevent the compiler from generating post indexing instructions. These instructions are not supported on hypervisor when used to access emulated MMIO regions.

Thus, we have used inline assembly similar to aarch64. Also, see the linux commit id '195bbcac2e5c12f7fb99cdcc492c3000c5537f4a' for reference.

Signed-off-by: Ayan Kumar Halder <ayankuma@amd.com>