### PR TITLE
boards: heltec_wifi_lora32_v2: enable lora

### DIFF
--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2-pinctrl.dtsi
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2-pinctrl.dtsi
@@ -20,6 +20,17 @@
 		};
 	};
 
+	spim3_default: spim3_default {
+		group1 {
+			pinmux = <SPIM3_MISO_GPIO19>,
+				 <SPIM3_SCLK_GPIO5>;
+		};
+		group2 {
+			pinmux = <SPIM3_MOSI_GPIO27>;
+			output-low;
+		};
+	};
+
 	i2c0_default: i2c0_default {
 		group1 {
 			pinmux = <I2C0_SDA_GPIO4>,

--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
@@ -18,6 +18,7 @@
 		led0 = &led0;
 		sw0 = &button0;
 		watchdog0 = &wdt0;
+		lora0 = &lora0;
 	};
 
 	leds {
@@ -56,7 +57,6 @@
 	};
 };
 
-
 &cpu0 {
 	clock-frequency = <ESP32_CLK_CPU_240M>;
 };
@@ -87,6 +87,29 @@
 	scl-gpios = <&gpio0 15 GPIO_OPEN_DRAIN>;
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
+};
+
+&spi3 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+	pinctrl-0 = <&spim3_default>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+	lora0: lora@0 {
+		compatible = "semtech,sx1276";
+		reg = <0>;
+		reset-gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		dio-gpios =
+			/* SX1276 D0 -> GPIO26 */
+			<&gpio0 26 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+			/* SX1276 D1 -> GPIO35 */
+			<&gpio1 3 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
+			/* SX1276 D1 -> GPIO34 */
+			<&gpio1 2 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+		spi-max-frequency = <1000000>;
+		power-amplifier-output = "pa-boost";
+	};
 };
 
 &flash0 {


### PR DESCRIPTION
Dear Maintainers,

This PR enables and defines the lora node (Semtech SX1276) connected through the SPI, including the first three DIO PINs. 

One can compile and test LoRa on an Heltec WiFi LoRa32 V2 board.

For example:

First build:

	$ west build -p -b heltec_wifi_lora32_v2 zephyr/samples/subsys/shell/shell_module/ -- -DSHIELD=ssd1306_128x64

Then, enable `CONFIG_SPI`, `CONFIG_LORA`, `CONFIG_LORA_SX127X` via the `menuconfig`:

	$ west build -t menuconfig

Finally, flash and run:

	$ west flash && picocom -b 115200 /dev/ttUSB0
	(...)
	uart:~$ lora config freq 868000000

On first board:

	$ lora config freq 868000000
	uart:~$ lora recv
	00000000: 68 65 6c 6c 6f                                   |hello            |
	RSSI: -133 dBm, SNR:-13 dBm

On second board:

	$ lora config freq 868000000
	uart:~$ lora send hello

Regards,
Gaël

--- 

This enables the support for the Semtech SX1276 chip on board (see the pinout[1] and schematic[2] documents).

The chip is connected to SPI as follow:

| PIN  | GPIO   |
| ---- | -------|
| CS#  | GPIO18 |
| CLK  | GPIO5  |
| MOSI | GPIO27 |
| MISO | GPIO19 |
| RST# | GPIO14 |

Additionally, the LoRa DIO PINs are connected as follow:

| PIN  | GPIO   |
| ---- | -------|
| DIO0 | GPIO26 |
| DIO1 | GPIO35 |
| DIO2 | GPIO34 |

_Note_: The first three DIO PINs are connected to the ESP32 MCU only.

[1]: https://resource.heltec.cn/download/WiFi_LoRa_32/WIFI_LoRa_32_V2.1.pdf
[2]: https://resource.heltec.cn/download/WiFi_LoRa_32/V2/WIFI_LoRa_32_V2(868-915).PDF

Signed-off-by: Gaël PORTAY <gael.portay@gmail.com>