### PR TITLE
drivers: i2c: esp32: set timeout to allow clock stretching

### DIFF
--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(i2c_esp32, CONFIG_I2C_LOG_LEVEL);
 #include "i2c-priv.h"
 
 #define I2C_FILTER_CYC_NUM_DEF 7	/* Number of apb cycles filtered by default */
-#define I2C_CLR_BUS_SCL_NUM 9	/* Number of SCL clocks to restore SDA signal */
+#define I2C_CLR_BUS_SCL_NUM 9		/* Number of SCL clocks to restore SDA signal */
 #define I2C_CLR_BUS_HALF_PERIOD_US 5	/* Period of SCL clock to restore SDA signal */
 #define I2C_TRANSFER_TIMEOUT_MSEC 500	/* Transfer timeout period */
 
@@ -315,7 +315,6 @@ static int IRAM_ATTR i2c_esp32_transmit(const struct device *dev)
 	return ret;
 }
 
-
 static void IRAM_ATTR i2c_esp32_master_start(const struct device *dev)
 {
 	struct i2c_esp32_data *data = (struct i2c_esp32_data *const)(dev)->data;
@@ -435,7 +434,7 @@ static int IRAM_ATTR i2c_esp32_master_read(const struct device *dev, struct i2c_
 }
 
 static int IRAM_ATTR i2c_esp32_read_msg(const struct device *dev,
-	struct i2c_msg *msg, uint16_t addr)
+					struct i2c_msg *msg, uint16_t addr)
 {
 	int ret = 0;
 	struct i2c_esp32_data *data = (struct i2c_esp32_data *const)(dev)->data;
@@ -512,7 +511,7 @@ static int IRAM_ATTR i2c_esp32_master_write(const struct device *dev, struct i2c
 }
 
 static int IRAM_ATTR i2c_esp32_write_msg(const struct device *dev,
-		struct i2c_msg *msg, uint16_t addr)
+					 struct i2c_msg *msg, uint16_t addr)
 {
 	struct i2c_esp32_data *data = (struct i2c_esp32_data *const)(dev)->data;
 	int ret = 0;
@@ -545,7 +544,7 @@ static int IRAM_ATTR i2c_esp32_write_msg(const struct device *dev,
 }
 
 static int IRAM_ATTR i2c_esp32_transfer(const struct device *dev, struct i2c_msg *msgs,
-			      uint8_t num_msgs, uint16_t addr)
+					uint8_t num_msgs, uint16_t addr)
 {
 	struct i2c_esp32_data *data = (struct i2c_esp32_data *const)(dev)->data;
 	struct i2c_msg *current, *next;
@@ -710,49 +709,43 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 #define I2C_ESP32_GET_PIN_INFO(idx)
 #endif /* SOC_I2C_SUPPORT_HW_CLR_BUS */
 
-#define I2C_ESP32_FREQUENCY(bitrate)				       \
-	 (bitrate == I2C_BITRATE_STANDARD ? KHZ(100)	       \
-	: bitrate == I2C_BITRATE_FAST     ? KHZ(400)	       \
+#define I2C_ESP32_FREQUENCY(bitrate)					\
+	 (bitrate == I2C_BITRATE_STANDARD ? KHZ(100)			\
+	: bitrate == I2C_BITRATE_FAST     ? KHZ(400)			\
 	: bitrate == I2C_BITRATE_FAST_PLUS  ? MHZ(1) : 0)
-#define I2C_FREQUENCY(idx)						       \
+
+#define I2C_FREQUENCY(idx)						\
 	I2C_ESP32_FREQUENCY(DT_PROP(I2C(idx), clock_frequency))
 
-#define ESP32_I2C_INIT(idx)		\
-					\
-	PINCTRL_DT_DEFINE(I2C(idx));	\
-					\
-	static struct i2c_esp32_data i2c_esp32_data_##idx = {		  \
-		.hal = {	\
-			.dev = (i2c_dev_t *) DT_REG_ADDR(I2C(idx)),	\
-		},	\
-		.cmd_sem = Z_SEM_INITIALIZER(                            \
-			i2c_esp32_data_##idx.cmd_sem, 0, 1),                 \
-		.transfer_sem = Z_SEM_INITIALIZER(                        \
-			i2c_esp32_data_##idx.transfer_sem, 1, 1)		      \
-	};							\
-								\
-	static const struct i2c_esp32_config i2c_esp32_config_##idx = {	       \
-	.index = idx, \
-	.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(I2C(idx))), \
-	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(I2C(idx)),	\
-	.clock_subsys = (clock_control_subsys_t)DT_CLOCKS_CELL(I2C(idx), offset), \
-	I2C_ESP32_GET_PIN_INFO(idx)	\
-	.mode = { \
-		.tx_lsb_first = DT_PROP(I2C(idx), tx_lsb), \
-		.rx_lsb_first = DT_PROP(I2C(idx), rx_lsb), \
-	}, \
-	.irq_source = ETS_I2C_EXT##idx##_INTR_SOURCE,	\
-	.bitrate = I2C_FREQUENCY(idx),	\
-	.default_config = I2C_MODE_CONTROLLER,				\
-	};								       \
-	I2C_DEVICE_DT_DEFINE(I2C(idx),					       \
-		      i2c_esp32_init,					       \
-		      NULL,				       \
-		      &i2c_esp32_data_##idx,				       \
-		      &i2c_esp32_config_##idx,				       \
-		      POST_KERNEL,					       \
-		      CONFIG_I2C_INIT_PRIORITY,	       \
-		      &i2c_esp32_driver_api);
+#define ESP32_I2C_INIT(idx)									   \
+												   \
+	PINCTRL_DT_DEFINE(I2C(idx));								   \
+												   \
+	static struct i2c_esp32_data i2c_esp32_data_##idx = {					   \
+		.hal = {									   \
+			.dev = (i2c_dev_t *) DT_REG_ADDR(I2C(idx)),				   \
+		},										   \
+		.cmd_sem = Z_SEM_INITIALIZER(i2c_esp32_data_##idx.cmd_sem, 0, 1),		   \
+		.transfer_sem = Z_SEM_INITIALIZER(i2c_esp32_data_##idx.transfer_sem, 1, 1),	   \
+	};											   \
+												   \
+	static const struct i2c_esp32_config i2c_esp32_config_##idx = {				   \
+		.index = idx,									   \
+		.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(I2C(idx))),				   \
+		.pcfg = PINCTRL_DT_DEV_CONFIG_GET(I2C(idx)),					   \
+		.clock_subsys = (clock_control_subsys_t)DT_CLOCKS_CELL(I2C(idx), offset),	   \
+		I2C_ESP32_GET_PIN_INFO(idx)							   \
+		.mode = {									   \
+			.tx_lsb_first = DT_PROP(I2C(idx), tx_lsb),				   \
+			.rx_lsb_first = DT_PROP(I2C(idx), rx_lsb),				   \
+		},										   \
+		.irq_source = ETS_I2C_EXT##idx##_INTR_SOURCE,					   \
+		.bitrate = I2C_FREQUENCY(idx),							   \
+		.default_config = I2C_MODE_CONTROLLER,						   \
+	};											   \
+	I2C_DEVICE_DT_DEFINE(I2C(idx), i2c_esp32_init, NULL, &i2c_esp32_data_##idx,		   \
+			     &i2c_esp32_config_##idx, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,	   \
+			     &i2c_esp32_driver_api);
 
 #if DT_NODE_HAS_STATUS(I2C(0), okay)
 #ifndef SOC_I2C_SUPPORT_HW_CLR_BUS
@@ -763,9 +756,9 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 #if DT_NODE_HAS_PROP(I2C(0), sda_gpios) || DT_NODE_HAS_PROP(I2C(0), scl_gpios)
 #error "Properties <sda-gpios> and <scl-gpios> are not required for this target."
 #endif
-#endif
+#endif /* !SOC_I2C_SUPPORT_HW_CLR_BUS */
 ESP32_I2C_INIT(0);
-#endif
+#endif /* DT_NODE_HAS_STATUS(I2C(0), okay) */
 
 #if DT_NODE_HAS_STATUS(I2C(1), okay)
 #ifndef SOC_I2C_SUPPORT_HW_CLR_BUS
@@ -776,6 +769,6 @@ ESP32_I2C_INIT(0);
 #if DT_NODE_HAS_PROP(I2C(1), sda_gpios) || DT_NODE_HAS_PROP(I2C(1), scl_gpios)
 #error "Properties <sda-gpios> and <scl-gpios> are not required for this target."
 #endif
-#endif
+#endif /* !SOC_I2C_SUPPORT_HW_CLR_BUS */
 ESP32_I2C_INIT(1);
-#endif
+#endif /* DT_NODE_HAS_STATUS(I2C(1), okay) */

--- a/dts/bindings/i2c/espressif,esp32-i2c.yaml
+++ b/dts/bindings/i2c/espressif,esp32-i2c.yaml
@@ -46,3 +46,13 @@ properties:
       type: boolean
       required: false
       description: Set I2C RX data as LSB
+
+    scl-timeout-us:
+      type: int
+      required: false
+      description: |
+        Timeout for unchanged SCL during clock stretching of the I2C target in
+        microseconds.
+
+        If not set or 0, the timeout is disabled or set to the maximum possible
+        value if the MCU does not support disabling the timeout.


### PR DESCRIPTION
The ESP32 series MCUs allow to set a timeout which triggers an error if the SCL line is unchanged for the specified amount of time.

By default, the ESP-IDF HAL sets the timeout to an arbitrary value of 10 times the bus cycle.

This is not sufficient for chips like the TI bq76952, which pulls the SCL line low (clock stretching) for several 100 µs.

The timeout should also not be dependent on the chosen bitrate, as it is defined by the time a chip needs for internal calculation before it can provide requested data or continue communication.

This commit adds a property to devicetree to allow configuration of the scl timeout. This value is set via direct register access, as the ESP-IDF HAL does not provide access to the enable bit and does not give any information about the maximum size of the timeout (defined in I2C clock cycles in the register).

Fixes #51351

## Remarks / Questions

1. As mentioned in the comment, the `I2C_TIME_OUT_EN` did not work as expected for the ESP32-C3. Maybe someone from Espressif can double-check internally if clearing this bit should disable the timeout. The communication only worked with the value set to `0x1F`. The documentation is not very detailed, so maybe my understanding is wrong.
2. The timeout value for ESP32-C3 is only 5 bits wide, which means that the maximum number of clock cycles can be `0x1F = 31`. With an I2C peripheral clock speed of 40 MHz, that would result in a maximum timeout of less than 1 µs, if my calculation is correct. However, in reality it does not time out for >200 µs (see logic analyzer screenshots in the issue). And if the maximum timeout was actually 1µs it would probably not be able to communicate with the bq76952 at all. What did I understand wrong? Or does using the maximum value actually completely disable the timeout feature?