### PR TITLE
Bluetooth: audio: ascs: Make ascs_ep_set_metadata static

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1862,9 +1862,8 @@ static int ascs_verify_metadata(const struct net_buf_simple *buf,
 	return result.err;
 }
 
-int ascs_ep_set_metadata(struct bt_audio_ep *ep,
-			 struct net_buf_simple *buf, uint8_t len,
-			 struct bt_codec *codec)
+static int ascs_ep_set_metadata(struct bt_audio_ep *ep, struct net_buf_simple *buf, uint8_t len,
+				struct bt_codec *codec)
 {
 	struct net_buf_simple meta_ltv;
 	int err;

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -361,6 +361,3 @@ static inline const char *bt_ascs_reason_str(uint8_t reason)
 }
 
 void ascs_ep_set_state(struct bt_audio_ep *ep, uint8_t state);
-int ascs_ep_set_metadata(struct bt_audio_ep *ep,
-			 struct net_buf_simple *buf, uint8_t len,
-			 struct bt_codec *codec);


### PR DESCRIPTION
This changes ascs_ep_set_metadata to be static as it's not used outside of ascs.c.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>