### PR TITLE
kernel: tls: don't use TLS for thread ptr if tracing is enabled

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -515,7 +515,7 @@ __syscall void k_wakeup(k_tid_t thread);
 __attribute_const__
 __syscall k_tid_t z_current_get(void);
 
-#ifdef CONFIG_THREAD_LOCAL_STORAGE
+#if defined(CONFIG_THREAD_LOCAL_STORAGE) && !defined(CONFIG_TRACING)
 /* Thread-local cache of current thread ID, set in z_thread_entry() */
 extern __thread k_tid_t z_tls_current;
 #endif
@@ -529,7 +529,7 @@ extern __thread k_tid_t z_tls_current;
 __attribute_const__
 static inline k_tid_t k_current_get(void)
 {
-#ifdef CONFIG_THREAD_LOCAL_STORAGE
+#if defined(CONFIG_THREAD_LOCAL_STORAGE) && !defined(CONFIG_TRACING)
 	return z_tls_current;
 #else
 	return z_current_get();

--- a/lib/os/thread_entry.c
+++ b/lib/os/thread_entry.c
@@ -13,7 +13,7 @@
 
 #include <zephyr/kernel.h>
 
-#ifdef CONFIG_THREAD_LOCAL_STORAGE
+#if defined(CONFIG_THREAD_LOCAL_STORAGE) && !defined(CONFIG_TRACING)
 __thread k_tid_t z_tls_current;
 #endif
 
@@ -30,7 +30,7 @@ __thread k_tid_t z_tls_current;
 FUNC_NORETURN void z_thread_entry(k_thread_entry_t entry,
 				 void *p1, void *p2, void *p3)
 {
-#ifdef CONFIG_THREAD_LOCAL_STORAGE
+#if defined(CONFIG_THREAD_LOCAL_STORAGE) && !defined(CONFIG_TRACING)
 	z_tls_current = z_current_get();
 #endif
 	entry(p1, p2, p3);


### PR DESCRIPTION
When tracing is enabled, do not use thread local storage to store thread pointer, and revert to getting current thread pointer via z_current_get(). This is due to tracing being used in swap code for marking threads being swapped in and out, and the very first time a thread is swapped in, the thread pointer in TLS has not been setup yet. This means that the tracing function will be passing thread pointer with random value around (for example, to _get_thread_name()), which might result in memory access faults. On the other hand, since the location of thread local variables are generated by compiler. It is not a good idea to pre-calculate the location to populate the thread pointer in the TLS area, as the compiler can change it between toolchain version... not to mention that the location is also architecture specific. So workaround this by not using TLS for thread pointers when tracing is enabled.

Also, on x86 and x86_64, populate CPU registers needed for TLS at the first switch to main.