### PR TITLE
Make tracing work on x86-64 when TLS is enabled

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -379,6 +379,22 @@ z_x86_switch:
  */
 
 __resume:
+#ifdef CONFIG_THREAD_LOCAL_STORAGE
+	/*
+	 * Write the TLS base pointer to FS_BASE MSR,
+	 * where GCC emits code to access TLS data via
+	 * offset to FS.
+	 * Since wrmsr write EDX:EAX to MSR indicated by
+	 * ECX, the high 32-bit needs to be loaded into
+	 * RDX and right shifted by 32 bits so EDX has
+	 * the higher 32-bit value.
+	 */
+	movl $X86_FS_BASE, %ecx
+	movq _thread_offset_to_tls(%rdi), %rax
+	movq _thread_offset_to_tls(%rdi), %rdx
+	shrq $32, %rdx
+	wrmsr
+#endif
 #if (!defined(CONFIG_X86_KPTI) && defined(CONFIG_USERSPACE)) \
 		|| defined(CONFIG_INSTRUMENT_THREAD_SWITCHING)
 	pushq %rdi	/* Caller-saved, stash it */
@@ -421,22 +437,6 @@ __resume:
 	movq $0xB9, _thread_offset_to_rip(%rdi)
 #endif
 
-#ifdef CONFIG_THREAD_LOCAL_STORAGE
-	/*
-	 * Write the TLS base pointer to FS_BASE MSR,
-	 * where GCC emits code to access TLS data via
-	 * offset to FS.
-	 * Since wrmsr write EDX:EAX to MSR indicated by
-	 * ECX, the high 32-bit needs to be loaded into
-	 * RDX and right shifted by 32 bits so EDX has
-	 * the higher 32-bit value.
-	 */
-	movl $X86_FS_BASE, %ecx
-	movq _thread_offset_to_tls(%rdi), %rax
-	movq _thread_offset_to_tls(%rdi), %rdx
-	shrq $32, %rdx
-	wrmsr
-#endif
 
 	movq _thread_offset_to_rbx(%rdi), %rbx
 	movq _thread_offset_to_rbp(%rdi), %rbp

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1058,6 +1058,12 @@ void z_thread_mark_switched_out(void)
 #endif
 
 #ifdef CONFIG_TRACING
+#ifdef CONFIG_THREAD_LOCAL_STORAGE
+	/* Dummy thread won't have TLS set up to run arbitrary code */
+	if (!_current_cpu->current ||
+	    (_current_cpu->current->base.thread_state & _THREAD_DUMMY) != 0)
+		return;
+#endif
 	SYS_PORT_TRACING_FUNC(k_thread, switched_out);
 #endif
 }


### PR DESCRIPTION
x86-64 had two separate bugs dealing with tracing:
  1. General use of the thread_switched_out hook at thread creation. In this case, zephyr switches from the dummy thread to a real thread, but hasn't set up TLS yet. Check for this case in `z_thread_mark_switched_out` to fix this for all architectures.
  2. The call to `z_thread_mark_switched_in` for x86_64 happened before the TLS base pointer was stored in the FS_BASE MSR. Move that assignment to the start of `__resume`.
 
Closes #51318