### PR TITLE
soc: ace: add external IPC completion to ipc done handler

### DIFF
--- a/soc/xtensa/intel_adsp/common/include/intel_adsp_ipc.h
+++ b/soc/xtensa/intel_adsp/common/include/intel_adsp_ipc.h
@@ -54,8 +54,13 @@ typedef bool (*intel_adsp_ipc_handler_t)(const struct device *dev, void *arg,
  *
  * @param dev IPC device.
  * @param arg Registered argument from intel_adsp_ipc_set_done_handler().
+ * @return True if IPC completion will be done externally, otherwise false.
+ * @note Returning True will cause this API to skip writing IPC registers
+ * signalling IPC message completion and those actions should be done by
+ * external code manually. Returning false from the handler will perform
+ * writing to IPC registers signalling message completion normally by this API.
  */
-typedef void (*intel_adsp_ipc_done_t)(const struct device *dev, void *arg);
+typedef bool (*intel_adsp_ipc_done_t)(const struct device *dev, void *arg);
 
 struct intel_adsp_ipc_data {
 	struct k_sem sem;

--- a/soc/xtensa/intel_adsp/common/ipc.c
+++ b/soc/xtensa/intel_adsp/common/ipc.c
@@ -65,10 +65,19 @@ void z_intel_adsp_ipc_isr(const void *devarg)
 		(regs->idd & INTEL_ADSP_IPC_DONE) : (regs->ida & INTEL_ADSP_IPC_DONE);
 
 	if (done) {
+		bool external_completion = false;
+
 		if (devdata->done_notify != NULL) {
-			devdata->done_notify(dev, devdata->done_arg);
+			external_completion = devdata->done_notify(dev, devdata->done_arg);
 		}
 		k_sem_give(&devdata->sem);
+
+		/* IPC completion registers will be set externally */
+		if (external_completion) {
+			k_spin_unlock(&devdata->lock, key);
+			return;
+		}
+
 		if (IS_ENABLED(CONFIG_SOC_INTEL_CAVS_V15)) {
 			regs->idd = INTEL_ADSP_IPC_DONE;
 		} else {

--- a/tests/boards/intel_adsp/smoke/src/hostipc.c
+++ b/tests/boards/intel_adsp/smoke/src/hostipc.c
@@ -22,11 +22,12 @@ static bool ipc_message(const struct device *dev, void *arg,
 	return data == RETURN_MSG_SYNC_VAL;
 }
 
-static void ipc_done(const struct device *dev, void *arg)
+static bool ipc_done(const struct device *dev, void *arg)
 {
 	zassert_is_null(arg, "wrong done arg");
 	zassert_false(done_flag, "done called unexpectedly");
 	done_flag = true;
+	return false;
 }
 
 ZTEST(intel_adsp, test_host_ipc)


### PR DESCRIPTION
Sometimes IPC message acknowledgement should be done by external code to provide sufficient timing (example assemble code related to powering down). Added bool return type to ipc message done handler that if callback function returns true, IPC API skips writing IPC message completion bits.

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>