### PR TITLE
  include: drivers: peci: Add missing subsystem macro

### DIFF
--- a/include/zephyr/drivers/peci.h
+++ b/include/zephyr/drivers/peci.h
@@ -199,7 +199,7 @@ typedef int (*peci_transfer_t)(const struct device *dev, struct peci_msg *msg);
 typedef int (*peci_disable_t)(const struct device *dev);
 typedef int (*peci_enable_t)(const struct device *dev);
 
-struct peci_driver_api {
+__subsystem struct peci_driver_api {
 	peci_config_t config;
 	peci_disable_t disable;
 	peci_enable_t enable;

--- a/samples/drivers/peci/boards/mec172xevb_assy6906.overlay
+++ b/samples/drivers/peci/boards/mec172xevb_assy6906.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/ {
+	aliases {
+		peci-0 = &peci0;
+	};
+};


### PR DESCRIPTION
Add subsystem macro for peci driver API.
Add MEC172x overlay to samples/drivers/peci 

Fixes #45222

