### PR TITLE
driver: UART: npcx: remove unnecessary guard CONFIG_UART_INTERRUPT_DRIVEN

### DIFF
--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -60,7 +60,7 @@ struct uart_npcx_data {
 #endif
 };
 
-#if defined(CONFIG_PM) && defined(CONFIG_UART_INTERRUPT_DRIVEN)
+#ifdef CONFIG_PM
 static void uart_npcx_pm_policy_state_lock_get(struct uart_npcx_data *data,
 					       enum uart_pm_policy_state_flag flag)
 {
@@ -76,7 +76,7 @@ static void uart_npcx_pm_policy_state_lock_put(struct uart_npcx_data *data,
 		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
 	}
 }
-#endif /* defined(CONFIG_PM) && defined(CONFIG_UART_INTERRUPT_DRIVEN) */
+#endif
 
 /* UART local functions */
 static int uart_set_npcx_baud_rate(struct uart_reg *const inst, int baud_rate, int src_clk)


### PR DESCRIPTION
Currently, uart_npcx_pm_policy_state_lock* functions are guarded by CONFIG_UART_INTERRUPT_DRIVEN && CONFIG_PM. However, it is unnecessary to guard them with CONFIG_UART_INTERRUPT_DRIVEN as the polling mode UART driver also uses these functions.
This commit removes it and leaves those functions guarded by CONFIG_PM only.

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>