### PR TITLE
tests: devicetree: device: Add bl5340 and bt610 exclusions

### DIFF
--- a/tests/lib/devicetree/devices/testcase.yaml
+++ b/tests/lib/devicetree/devices/testcase.yaml
@@ -5,4 +5,5 @@ tests:
     # will mostly likely be the fastest.
     integration_platforms:
       - native_posix
-    platform_exclude: hsdk hsdk_2cores thingy52_nrf52832 bbc_microbit bbc_microbit_v2
+    platform_exclude: hsdk hsdk_2cores thingy52_nrf52832 bbc_microbit bbc_microbit_v2 bt610
+       bl5340_dvk_cpuapp bl5340_dvk_cpuapp_ns


### PR DESCRIPTION
Adds bt610 and bl5340_dvk_cpuapp* targets to exclusion list for tests as these boards enabled i2c by default for GPIO usage which conflicts with the test.

Fixes #51375