### PR TITLE
boards: arm: stm32f3 disco has stm32cubeprogrammer as runner

### DIFF
--- a/boards/arm/stm32f3_disco/board.cmake
+++ b/boards/arm/stm32f3_disco/board.cmake
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=STM32F303VC" "--speed=4000")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)


### PR DESCRIPTION
Adds the stm32cubeprogrammer as runner of the stm32f3_disco
This will help testing the platform and others with twister and more

Change the ../map.yaml if needed


Signed-off-by: Francois Ramu <francois.ramu@st.com>