### PR TITLE
doc: clarify where application can use ExternalZephyrProject_Add

### DIFF
--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -392,8 +392,9 @@ Adding Zephyr applications to sysbuild
 **************************************
 
 You can use the ``ExternalZephyrProject_Add()`` function to add Zephyr
-applications as sysbuild domains. Call this CMake function from your main
-:file:`CMakeLists.txt` file, or any other CMake file you know will run.
+applications as sysbuild domains. Call this CMake function from your
+application's :file:`sysbuild.cmake` file, or any other CMake file you know will
+run as part sysbuild CMake invocation.
 
 Targeting the same board
 ========================


### PR DESCRIPTION
The sysbuild documentation refers to CMakeLists.txt which can lead the user to believe this call can be added to the <sample>/CMakeLists.txt file.

This file is sourced as part of the Zephyr CMake build and not sysbuild CMake build.

Therefore change the description to sysbuild.cmake.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>