### PR TITLE
device: align device state

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -750,7 +750,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * @param dev_id Device identifier.
  */
 #define Z_DEVICE_STATE_DEFINE(dev_id)                                          \
-	static struct device_state Z_DEVICE_STATE_NAME(dev_id)                 \
+	static Z_DECL_ALIGN(struct device_state) Z_DEVICE_STATE_NAME(dev_id)   \
 		__attribute__((__section__(".z_devstate")))
 
 /**

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -354,9 +354,9 @@ struct device_state {
 	 *
 	 * Device initialization functions return a negative errno code if they
 	 * fail. In Zephyr, errno values do not exceed 255, so we can store the
-	 * positive result value using 8 bits.
+	 * positive result value in a uint8_t type.
 	 */
-	unsigned int init_res : 8;
+	uint8_t init_res;
 
 	/** Indicates the device initialization function has been
 	 * invoked.


### PR DESCRIPTION
Device state (struct device_state) was not aligned, required since all
states are gathered together in the z_devstate section. This was causing
boot failures on certain platforms depending on the layout of the struct
device_state.

Reverted hotfix 2da3e4199b767387f4f7d11990634e84e448b695

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>