### PR TITLE
[RFC] device: improve compile time diagnostics

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -290,8 +290,10 @@ typedef int16_t device_handle_t;
  * @param node_id devicetree node identifier
  *
  * @return a @ref device reference for the node identifier, which may be `NULL`.
+ *
+ * @deprecated Use DEVICE_DT_GET() together with DEVICE_DT_DECLARE_MAYBE().
  */
-#define DEVICE_DT_GET_OR_NULL(node_id)                                         \
+#define DEVICE_DT_GET_OR_NULL(node_id) __DEPRECATED_MACRO                      \
 	COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay),                         \
 		    (DEVICE_DT_GET(node_id)), (NULL))
 

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -318,6 +318,17 @@ typedef int16_t device_handle_t;
 		extern const struct device DEVICE_DT_NAME_GET(node_id)
 
 /**
+ * @brief Declare a devicetree device object that may exist.
+ *
+ * This macro can be useful in cases where the device is optional. Application
+ * should then be prepared to handle `NULL` from DEVICE_DT_GET().
+ *
+ * @param node_id Devicetree node identifier.
+ */
+#define DEVICE_DT_DECLARE_MAYBE(node_id)                                       \
+		extern const struct device DEVICE_DT_NAME_GET(node_id)
+
+/**
  * @brief Declare a static device object
  *
  * This macro can be used at the top-level to declare a device, such

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -305,6 +305,19 @@ typedef int16_t device_handle_t;
 #define DEVICE_GET(dev_id) (&DEVICE_NAME_GET(dev_id))
 
 /**
+ * @brief Declare a devicetree device object.
+ *
+ * This macro will assert at build time if the given @p node_id is not found or
+ * not enabled in Devicetree.
+ *
+ * @param node_id Devicetree node identifier.
+ */
+#define DEVICE_DT_DECLARE(node_id)                                             \
+		BUILD_ASSERT(DT_NODE_HAS_STATUS(node_id, okay),                \
+			     Z_DT_CHECK_MSG(node_id));                         \
+		extern const struct device DEVICE_DT_NAME_GET(node_id)
+
+/**
  * @brief Declare a static device object
  *
  * This macro can be used at the top-level to declare a device, such

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -275,8 +275,10 @@ typedef int16_t device_handle_t;
  *
  * @param compat lowercase-and-underscores devicetree compatible
  * @return a pointer to a device
+ *
+ * @deprecated Use DEVICE_DT_GET_ANY() together with DEVICE_DT_DECLARE().
  */
-#define DEVICE_DT_GET_ONE(compat)                                              \
+#define DEVICE_DT_GET_ONE(compat) __DEPRECATED_MACRO                           \
 	COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(compat),                         \
 		    (DEVICE_DT_GET(DT_COMPAT_GET_ANY_STATUS_OKAY(compat))),    \
 		    (ZERO_OR_COMPILE_ERROR(0)))

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -318,6 +318,21 @@ typedef int16_t device_handle_t;
 		extern const struct device DEVICE_DT_NAME_GET(node_id)
 
 /**
+ * @brief Declare a devicetree device object from a compatible.
+ *
+ * This macro will assert at build time if there is no device with the given
+ * @p compat is found enabled in Devicetree.
+ *
+ * @param compat Devicetree compatible.
+ */
+#define DEVICE_DT_DECLARE_ANY(compat)                                          \
+		BUILD_ASSERT(DT_HAS_COMPAT_STATUS_OKAY(compat),                \
+			     "No device with " STRINGIFY(compat)               \
+			     " compatible found enabled in Devicetree");       \
+		extern const struct device DEVICE_DT_NAME_GET(                 \
+			DT_COMPAT_GET_ANY_STATUS_OKAY(compat))
+
+/**
  * @brief Declare a devicetree device object that may exist.
  *
  * This macro can be useful in cases where the device is optional. Application

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -981,7 +981,8 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
                                                                                \
 	Z_DEVICE_INIT_ENTRY_DEFINE(dev_id, init_fn, level, prio)
 
-#if defined(CONFIG_HAS_DTS) || defined(__DOXYGEN__)
+#if (defined(CONFIG_HAS_DTS) && defined(CONFIG_DEVICE_DT_AUTO_DECLARE))||      \
+	defined(__DOXYGEN__)
 /**
  * @brief Declare a device for each status "okay" devicetree node.
  *

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -212,7 +212,8 @@ typedef int16_t device_handle_t;
  * @brief Get a @ref device reference from a devicetree node identifier.
  *
  * Returns a pointer to a device object created from a devicetree node, if any
- * device was allocated by a driver.
+ * device was allocated by a driver. If the Devicetree node is not enabled, this
+ * returns NULL.
  *
  * If no such device was allocated, this will fail at linker time. If you get an
  * error that looks like `undefined reference to __device_dts_ord_<N>`, that is
@@ -223,7 +224,9 @@ typedef int16_t device_handle_t;
  *
  * @return A pointer to the device object created for that node
  */
-#define DEVICE_DT_GET(node_id) (&DEVICE_DT_NAME_GET(node_id))
+#define DEVICE_DT_GET(node_id) \
+	COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay),                         \
+		    ((&DEVICE_DT_NAME_GET(node_id))), (NULL))
 
 /**
  * @brief Get a @ref device reference for an instance of a `DT_DRV_COMPAT`

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -3918,6 +3918,17 @@
 #define DT_COMPAT_ON_BUS_INTERNAL(compat, bus) \
 	IS_ENABLED(UTIL_CAT(DT_CAT(DT_COMPAT_, compat), _BUS_##bus))
 
+/**
+ * @brief Error message for node existence checks
+ *
+ * @param node_id Devicetree node identifier
+ */
+#define Z_DT_CHECK_MSG(node_id)                                                \
+	COND_CODE_1(DT_NODE_EXISTS(node_id),                                   \
+		    ("Node " DT_NODE_PATH(node_id) " is not enabled in "       \
+		     "devicetree"),                                            \
+		    ("Node " STRINGIFY(node_id) " not found in devicetree"))
+
 /** @endcond */
 
 /* have these last so they have access to all previously defined macros */

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -331,7 +331,9 @@ struct gpio_dt_spec {
  * @brief Static initializer for a @p gpio_dt_spec
  *
  * This returns a static initializer for a @p gpio_dt_spec structure given a
- * devicetree node identifier, a property specifying a GPIO and an index.
+ * devicetree node identifier, a property specifying a GPIO and an index. If the
+ * given @p node_id is not found or not enabled, this returns an empty
+ * initializer.
  *
  * Example devicetree fragment:
  *
@@ -362,11 +364,13 @@ struct gpio_dt_spec {
  * @return static initializer for a struct gpio_dt_spec for the property
  */
 #define GPIO_DT_SPEC_GET_BY_IDX(node_id, prop, idx)			       \
-	{								       \
-		.port = DEVICE_DT_GET(DT_GPIO_CTLR_BY_IDX(node_id, prop, idx)),\
-		.pin = DT_GPIO_PIN_BY_IDX(node_id, prop, idx),		       \
-		.dt_flags = DT_GPIO_FLAGS_BY_IDX(node_id, prop, idx),	       \
-	}
+	COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay),			       \
+		    ({							       \
+			.port = DEVICE_DT_GET(				       \
+				DT_GPIO_CTLR_BY_IDX(node_id, prop, idx)),      \
+			.pin = DT_GPIO_PIN_BY_IDX(node_id, prop, idx),	       \
+			.dt_flags = DT_GPIO_FLAGS_BY_IDX(node_id, prop, idx),  \
+		    }), ({}))
 
 /**
  * @brief Like GPIO_DT_SPEC_GET_BY_IDX(), with a fallback to a default value

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -302,6 +302,32 @@ struct gpio_dt_spec {
 };
 
 /**
+ * @brief Declare GPIO controller device
+ *
+ * This macro will assert if either the @p node_id is not found or not enabled
+ * in devicetree, or, if the controller given in @p prop and @p idx is not found
+ * or not enabled in Devicetree.
+ *
+ * @param node_id devicetree node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param idx logical index into "prop"
+ */
+#define GPIO_DT_SPEC_DECLARE_BY_IDX(node_id, prop, idx)                        \
+	BUILD_ASSERT(DT_NODE_EXISTS(node_id), Z_DT_CHECK_MSG(node_id));        \
+	DEVICE_DT_DECLARE(DT_GPIO_CTLR_BY_IDX(node_id, prop, idx))
+
+/**
+ * @brief Declare GPIO controller device
+ *
+ * Equivalent to GPIO_DT_SPEC_DECLARE_BY_IDX(node_id, prop, 0).
+ *
+ * @param node_id devicetree node identifier
+ * @param prop lowercase-and-underscores property name
+ */
+#define GPIO_DT_SPEC_DECLARE(node_id, prop)                                    \
+	GPIO_DT_SPEC_DECLARE_BY_IDX(node_id, prop, 0)
+
+/**
  * @brief Static initializer for a @p gpio_dt_spec
  *
  * This returns a static initializer for a @p gpio_dt_spec structure given a

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -961,4 +961,18 @@ config HAS_DYNAMIC_DEVICE_HANDLES
 
 endmenu
 
+config DEVICE_DT_AUTO_DECLARE
+	bool "Automatically declare devicetree devices"
+	default y
+	help
+	  Devicetree devices are defined with external visibility. Therefore,
+	  they can be accessed from other modules provided you declare them
+	  first using DEVICE_DT_DECLARE. Declaration also comes with build-time
+	  assertions to inform about potential problems such as accessing
+	  non-existing or disabled devices. If using this option, all potential
+	  devicetree devices will be declared in zephyr/device.h, but then it is
+	  user responsability to use them properly or deal with build/link time
+	  issues. This option is now enabled by default since it has been the
+	  behavior in Zephyr since the introduction of devicetree devices.
+
 rsource "Kconfig.vm"

--- a/samples/basic/blinky/src/main.c
+++ b/samples/basic/blinky/src/main.c
@@ -13,6 +13,8 @@
 /* The devicetree node identifier for the "led0" alias. */
 #define LED0_NODE DT_ALIAS(led0)
 
+GPIO_DT_SPEC_DECLARE(LED0_NODE, gpios);
+
 /*
  * A build error on this line means your board is unsupported.
  * See the sample documentation for information on how to fix this.

--- a/samples/sensor/adt7420/src/main.c
+++ b/samples/sensor/adt7420/src/main.c
@@ -169,9 +169,11 @@ static void process(const struct device *dev)
 	}
 }
 
+DEVICE_DT_DECLARE_ANY(adi_adt7420);
+
 void main(void)
 {
-	const struct device *const dev = DEVICE_DT_GET_ONE(adi_adt7420);
+	const struct device *const dev = DEVICE_DT_GET_ANY(adi_adt7420);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");


### PR DESCRIPTION
## Introduction

I was disappointed when https://github.com/zephyrproject-rtos/zephyr/pull/50055 couldn't finally make in because of C language limitations. Macrobatics may sound fun, but let's be honest: they are a pain and offer a terrible developer experience (I'm actually not enjoying Zephyr development that much as in other C projects because of that).

In this PR, I've prepared a quick PoC that shows a potential alternative. I'm pretty sure I'm missing something, so let's see what others think.

The main idea relies on stopping us from automatically declaring all "potential" DT devices, done here today:

https://github.com/zephyrproject-rtos/zephyr/blob/6851a33a6421757623c68a03c11b8b3e9083fe43/include/zephyr/device.h#L945-L960

Instead, force the declaration with `DEVICE_DT_DECLARE`, and in exchange, you get compiler errors that actually make sense.

Now:
```c
/* this header pre-defines all potential devicetree devices,
 * reason why DEVICE_DT_GET automagically works
 */
#include <zephyr/device.h>

int main(void)
{
	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(mydev));
}
```

With this proposal:
```c
/* this header no longer pre-defines any potential device
 * (only if CONFIG_DEVICE_DT_AUTO_DECLARE=n, to allow for smooth transition)
 */
#include <zephyr/device.h>

/* Application explicitly declares what is needed,
 * this will build assert if device does not exist/is disabled in DT
 */
DEVICE_DT_DECLARE(DT_NODELABEL(mydev));

int main(void)
{
	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(mydev));
}
```

 Declarations allow us to have an insertion point for build asserts. Combined with some other tricks (see `drivers: gpio: GPIO_DT_SPEC_GET_BY_IDX may be an empty initializer`, `drivers: gpio: add GPIO_DT_SPEC_DECLARE(_BY_IDX)` and `device: DEVICE_DT_GET may return NULL` commits), we can obtain much better compile time error messages when dealing with devices. As a result, some macros like `DEVICE_DT_GET_OR_NULL` or `DEVICE_DT_GET_ONE` become obsolete as well, see the respective commits/examples.

Note: do not expect Python or Rust quality error messages, but at least they make more sense (and you won't need to scroll up through obscure error messages).

## Examples

### `samples/basic/blinky`

```
west build -b esp32 samples/basic/blinky -p
```

Before:
```
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/samples/basic/blinky/src/main.c:7:
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/device.h:83:41: error: '__device_dts_ord_DT_N_ALIAS_led0_P_gpios_IDX_0_PH_ORD' undeclared here (not in a funct
ion) 
   83 | #define DEVICE_NAME_GET(dev_id) _CONCAT(__device_, dev_id)
      |                                         ^~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/toolchain/common.h:132:26: note: in definition of macro '_DO_CONCAT'
  132 | #define _DO_CONCAT(x, y) x ## y
      |                          ^
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/device.h:83:33: note: in expansion of macro '_CONCAT'
   83 | #define DEVICE_NAME_GET(dev_id) _CONCAT(__device_, dev_id)
      |                                 ^~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/device.h:209:37: note: in expansion of macro 'DEVICE_NAME_GET'
  209 | #define DEVICE_DT_NAME_GET(node_id) DEVICE_NAME_GET(Z_DEVICE_DT_DEV_ID(node_id))
      |                                     ^~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/device.h:226:34: note: in expansion of macro 'DEVICE_DT_NAME_GET'
  226 | #define DEVICE_DT_GET(node_id) (&DEVICE_DT_NAME_GET(node_id))
      |                                  ^~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/drivers/gpio.h:340:25: note: in expansion of macro 'DEVICE_DT_GET'
  340 |                 .port = DEVICE_DT_GET(DT_GPIO_CTLR_BY_IDX(node_id, prop, idx)),\
      |                         ^~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/drivers/gpio.h:376:9: note: in expansion of macro 'GPIO_DT_SPEC_GET_BY_IDX'
  376 |         GPIO_DT_SPEC_GET_BY_IDX(node_id, prop, 0)
      |         ^~~~~~~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/samples/basic/blinky/src/main.c:20:40: note: in expansion of macro 'GPIO_DT_SPEC_GET'
   20 | static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
      |                                        ^~~~~~~~~~~~~~~~
In file included from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/arch/xtensa/arch.h:18,
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/arch/cpu.h:27,
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/kernel_includes.h:33:
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/devicetree.h:230:32: error: 'DT_N_ALIAS_led0_P_gpios_IDX_0_VAL_pin' undeclared here (not in a function)
  230 | #define DT_ALIAS(alias) DT_CAT(DT_N_ALIAS_, alias)
      |                                ^~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/devicetree.h:3901:9: note: in definition of macro 'DT_CAT7'
 3901 |         a1 ## a2 ## a3 ## a4 ## a5 ## a6 ## a7
      |         ^~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/devicetree/gpio.h:164:9: note: in expansion of macro 'DT_PHA_BY_IDX'
  164 |         DT_PHA_BY_IDX(node_id, gpio_pha, idx, pin)
      |         ^~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/drivers/gpio.h:341:24: note: in expansion of macro 'DT_GPIO_PIN_BY_IDX'
  341 |                 .pin = DT_GPIO_PIN_BY_IDX(node_id, prop, idx),                 \
      |                        ^~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/drivers/gpio.h:376:9: note: in expansion of macro 'GPIO_DT_SPEC_GET_BY_IDX'
  376 |         GPIO_DT_SPEC_GET_BY_IDX(node_id, prop, 0)
      |         ^~~~~~~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/samples/basic/blinky/src/main.c:20:40: note: in expansion of macro 'GPIO_DT_SPEC_GET'
   20 | static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
      |                                        ^~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/devicetree.h:230:25: note: in expansion of macro 'DT_CAT'
  230 | #define DT_ALIAS(alias) DT_CAT(DT_N_ALIAS_, alias)
      |                         ^~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/samples/basic/blinky/src/main.c:14:19: note: in expansion of macro 'DT_ALIAS'
   14 | #define LED0_NODE DT_ALIAS(led0)
      |                   ^~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/samples/basic/blinky/src/main.c:20:57: note: in expansion of macro 'LED0_NODE'
   20 | static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
      |                                                         ^~~~~~~~~
ninja: build stopped: subcommand failed.
```

With the changes proposed in this PR, the compile time diagnostics are improved:

```
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/toolchain/gcc.h:77:36: error: static assertion failed: "Node DT_N_ALIAS_led0 not found in devicetree"
   77 | #define BUILD_ASSERT(EXPR, MSG...) _Static_assert(EXPR, "" MSG)
      |                                    ^~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/drivers/gpio.h:316:9: note: in expansion of macro 'BUILD_ASSERT'
  316 |         BUILD_ASSERT(DT_NODE_EXISTS(node_id), Z_DT_CHECK_MSG(node_id));        \
      |         ^~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/drivers/gpio.h:328:9: note: in expansion of macro 'GPIO_DT_SPEC_DECLARE_BY_IDX'
  328 |         GPIO_DT_SPEC_DECLARE_BY_IDX(node_id, prop, 0)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/samples/basic/blinky/src/main.c:16:1: note: in expansion of macro 'GPIO_DT_SPEC_DECLARE'
   16 | GPIO_DT_SPEC_DECLARE(LED0_NODE, gpios);
      | ^~~~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/toolchain/gcc.h:77:36: error: static assertion failed: "Node DT_N_ALIAS_led0_P_gpios_IDX_0_PH not found in devicetree"
   77 | #define BUILD_ASSERT(EXPR, MSG...) _Static_assert(EXPR, "" MSG)
      |                                    ^~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/device.h:323:17: note: in expansion of macro 'BUILD_ASSERT'
  323 |                 BUILD_ASSERT(DT_NODE_HAS_STATUS(node_id, okay),                \
      |                 ^~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/drivers/gpio.h:317:9: note: in expansion of macro 'DEVICE_DT_DECLARE'
  317 |         DEVICE_DT_DECLARE(DT_GPIO_CTLR_BY_IDX(node_id, prop, idx))
      |         ^~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/drivers/gpio.h:328:9: note: in expansion of macro 'GPIO_DT_SPEC_DECLARE_BY_IDX'
  328 |         GPIO_DT_SPEC_DECLARE_BY_IDX(node_id, prop, 0)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/samples/basic/blinky/src/main.c:16:1: note: in expansion of macro 'GPIO_DT_SPEC_DECLARE'
   16 | GPIO_DT_SPEC_DECLARE(LED0_NODE, gpios);
      | ^~~~~~~~~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
```
---

```
west build -b nrf52840dk_nrf52840 samples/basic/blinky -p
```

with the following patch:
```diff
diff --git a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
index 2b0096458e..f6f182e159 100644
--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -139,7 +139,7 @@
 };
 
 &gpio0 {
-       status = "okay";
+       status = "disabled";
 };
 
 &gpio1 {
```

Before:
```
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/device.h:83:41: error: '__device_dts_ord_11' undeclared here (not in a function); did you mean '__device_dts_ord_15'?
   83 | #define DEVICE_NAME_GET(dev_id) _CONCAT(__device_, dev_id)
      |                                         ^~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/toolchain/common.h:132:26: note: in definition of macro '_DO_CONCAT'
  132 | #define _DO_CONCAT(x, y) x ## y
      |                          ^
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/device.h:83:33: note: in expansion of macro '_CONCAT'
   83 | #define DEVICE_NAME_GET(dev_id) _CONCAT(__device_, dev_id)
      |                                 ^~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/device.h:209:37: note: in expansion of macro 'DEVICE_NAME_GET'
  209 | #define DEVICE_DT_NAME_GET(node_id) DEVICE_NAME_GET(Z_DEVICE_DT_DEV_ID(node_id))
      |                                     ^~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/device.h:226:34: note: in expansion of macro 'DEVICE_DT_NAME_GET'
  226 | #define DEVICE_DT_GET(node_id) (&DEVICE_DT_NAME_GET(node_id))
      |                                  ^~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/drivers/gpio.h:340:25: note: in expansion of macro 'DEVICE_DT_GET'
  340 |                 .port = DEVICE_DT_GET(DT_GPIO_CTLR_BY_IDX(node_id, prop, idx)),\
      |                         ^~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/drivers/gpio.h:376:9: note: in expansion of macro 'GPIO_DT_SPEC_GET_BY_IDX'
  376 |         GPIO_DT_SPEC_GET_BY_IDX(node_id, prop, 0)
      |         ^~~~~~~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/samples/basic/blinky/src/main.c:20:40: note: in expansion of macro 'GPIO_DT_SPEC_GET'
   20 | static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
      |                                        ^~~~~~~~~~~~~~~~
[58/163] Building C object zephyr/arch/arch/arm/core/aarch32/cortex_m/CMakeFiles/arch__arm__core__aarch32__cortex_m.dir/fault.c.obj
ninja: build stopped: subcommand failed.
```

After:
```
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/toolchain/gcc.h:77:36: error: static assertion failed: "Node /soc/gpio@50000000 is not enabled in devicetree"
   77 | #define BUILD_ASSERT(EXPR, MSG...) _Static_assert(EXPR, "" MSG)
      |                                    ^~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/device.h:323:17: note: in expansion of macro 'BUILD_ASSERT'
  323 |                 BUILD_ASSERT(DT_NODE_HAS_STATUS(node_id, okay),                \
      |                 ^~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/drivers/gpio.h:317:9: note: in expansion of macro 'DEVICE_DT_DECLARE'
  317 |         DEVICE_DT_DECLARE(DT_GPIO_CTLR_BY_IDX(node_id, prop, idx))
      |         ^~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/drivers/gpio.h:328:9: note: in expansion of macro 'GPIO_DT_SPEC_DECLARE_BY_IDX'
  328 |         GPIO_DT_SPEC_DECLARE_BY_IDX(node_id, prop, 0)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/samples/basic/blinky/src/main.c:16:1: note: in expansion of macro 'GPIO_DT_SPEC_DECLARE'
   16 | GPIO_DT_SPEC_DECLARE(LED0_NODE, gpios);
      | ^~~~~~~~~~~~~~~~~~~~
[79/163] Building C object zephyr/arch/arch/arm/core/aarch32/mpu/CMakeFiles/arch__arm__core__aarch32__mpu.dir/arm_mpu.c.obj
ninja: build stopped: subcommand failed.
```

### `samples/sensor/adt7420`

```
west build -b nrf52840dk_nrf52840 samples/sensor/adt7420 -p
```

Before:
```
In file included from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util_macro.h:34,
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/atomic.h:16,
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/kernel_includes.h:21,
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/kernel.h:17,
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/samples/sensor/adt7420/src/main.c:7:
/home/gmarull/ws/nordic/zephyrproject/zephyr/samples/sensor/adt7420/src/main.c: In function 'main':
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util.h:78:55: error: size of unnamed array is negative
   78 | #define ZERO_OR_COMPILE_ERROR(cond) ((int) sizeof(char[1 - 2 * !(cond)]) - 1)
      |                                                       ^
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util_internal.h:72:26: note: in definition of macro '__DEBRACKET'
   72 | #define __DEBRACKET(...) __VA_ARGS__
      |                          ^~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util_internal.h:64:9: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   64 |         __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |         ^~~~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util_internal.h:59:9: note: in expansion of macro '__COND_CODE'
   59 |         __COND_CODE(_XXXX##_flag, _if_1_code, _else_code)
      |         ^~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util_macro.h:157:9: note: in expansion of macro 'Z_COND_CODE_1'
  157 |         Z_COND_CODE_1(_flag, _if_1_code, _else_code)
      |         ^~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/device.h:277:9: note: in expansion of macro 'COND_CODE_1'
  277 |         COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(compat),                         \
      |         ^~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/device.h:279:22: note: in expansion of macro 'ZERO_OR_COMPILE_ERROR'
  279 |                     (ZERO_OR_COMPILE_ERROR(0)))
      |                      ^~~~~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/samples/sensor/adt7420/src/main.c:174:42: note: in expansion of macro 'DEVICE_DT_GET_ONE'
  174 |         const struct device *const dev = DEVICE_DT_GET_ONE(adi_adt7420);
      |                                          ^~~~~~~~~~~~~~~~~
[56/170] Building C object zephyr/CMakeFiles/zephyr.dir/subsys/pm/pm.c.obj
ninja: build stopped: subcommand failed.
```

After (see last patch):
```
In file included from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/toolchain.h:50,
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/kernel_includes.h:19,
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/kernel.h:17,
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/samples/sensor/adt7420/src/main.c:7:
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/toolchain/gcc.h:77:36: error: static assertion failed: "No device with adi_adt7420 compatible found enabled in Devicetree"
   77 | #define BUILD_ASSERT(EXPR, MSG...) _Static_assert(EXPR, "" MSG)
      |                                    ^~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/device.h:340:17: note: in expansion of macro 'BUILD_ASSERT'
  340 |                 BUILD_ASSERT(DT_HAS_COMPAT_STATUS_OKAY(compat),                \
      |                 ^~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/samples/sensor/adt7420/src/main.c:172:1: note: in expansion of macro 'DEVICE_DT_DECLARE_ANY'
  172 | DEVICE_DT_DECLARE_ANY(adi_adt7420);
      | ^~~~~~~~~~~~~~~~~~~~~
[57/170] Building C object zephyr/CMakeFiles/zephyr.dir/subsys/pm/pm.c.obj
ninja: build stopped: subcommand failed.
```

## Notes

GCC options `-ftrack-macro-expansion=0 -fno-diagnostics-show-caret` hide macro expansion messages, shortening warnings significantly, e.g.

```
dic/zephyrproject/zephyr/samples/basic/blinky/src/main.c
/home/gmarull/ws/nordic/zephyrproject/zephyr/samples/basic/blinky/src/main.c:16:1: error: static assertion failed: "Node /soc/gpio@50000000 is not enabled in devicetree"
```

Ref. https://stackoverflow.com/questions/30255294/how-to-hide-extra-output-from-pragma-message

## Other references

- LVGL also forces explicit declaration for fonts/images, see https://docs.lvgl.io/latest/en/html/overview/font.html#add-new-font