### PR TITLE
linker: intel_adsp: discard GNU-stack notes

### DIFF
--- a/soc/xtensa/intel_adsp/ace/ace-link.ld
+++ b/soc/xtensa/intel_adsp/ace/ace-link.ld
@@ -453,6 +453,8 @@ SECTIONS {
 
 #include <zephyr/linker/debug-sections.ld>
 
+   /DISCARD/ : { *(.note.GNU-stack) }
+
   .xtensa.info 0 : { *(.xtensa.info) }
   .xt.insn 0 : {
     KEEP (*(.xt.insn))


### PR DESCRIPTION
discard GNU-stack notes coming from linker when building with clang.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
