### PR TITLE
doc: fix ST B_U585I typo

### DIFF
--- a/boards/arm/b_u585i_iot02a/doc/index.rst
+++ b/boards/arm/b_u585i_iot02a/doc/index.rst
@@ -175,7 +175,7 @@ The Zephyr b_u585i_iot02a board configuration supports the following hardware fe
 | GPIO      | on-chip    | gpio                                |
 +-----------+------------+-------------------------------------+
 | RNG       | on-chip    | True Random number generator        |
-+-------------+------------+-----------------------------------+
++-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |


### PR DESCRIPTION
This commit fixes the ST B_U585I_IOT02A Discovery kit "Supported Features" table that is not well formatted.

Signed-off-by: Thomas Antonini <antonini.thomas@gmail.com>