### PR TITLE
twister: Update path structure for out-of-tree tests

### DIFF
--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -48,5 +48,6 @@ jobs:
         ZEPHYR_BASE: ./
         ZEPHYR_TOOLCHAIN_VARIANT: zephyr
       run: |
+        west init -l . || true
         echo "Run twister tests"
         PYTHONPATH=./scripts/tests pytest ./scripts/tests/twister

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -24,6 +24,19 @@ ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 if not ZEPHYR_BASE:
     sys.exit("$ZEPHYR_BASE environment variable undefined")
 
+try:
+    subproc = subprocess.run(['west', 'topdir'], check = True, stdout=subprocess.PIPE)
+    if subproc.returncode == 0:
+        topdir = subproc.stdout.strip().decode()
+        logger.debug(f"Project's top directory: {topdir}")
+except FileNotFoundError:
+    topdir = ZEPHYR_BASE
+    logger.warning(f"West is not installed. Using ZEPHYR_BASE {ZEPHYR_BASE} as project's top directory")
+except subprocess.CalledProcessError as e:
+    topdir = ZEPHYR_BASE
+    logger.warning(e)
+    logger.warning(f"Using ZEPHYR_BASE {ZEPHYR_BASE} as project's top directory")
+
 # Use this for internal comparisons; that's what canonicalization is
 # for. Don't use it when invoking other components of the build system
 # to avoid confusing and hard to trace inconsistencies in error messages
@@ -31,7 +44,7 @@ if not ZEPHYR_BASE:
 # components directly.
 # Note "normalization" is different from canonicalization, see os.path.
 canonical_zephyr_base = os.path.realpath(ZEPHYR_BASE)
-
+canonical_topdir = os.path.realpath(topdir)
 
 def parse_arguments(args):
     parser = argparse.ArgumentParser(

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -12,7 +12,7 @@ import mmap
 import glob
 from typing import List
 from twisterlib.mixins import DisablePyTestCollectionMixin
-from twisterlib.environment import canonical_zephyr_base
+from twisterlib.environment import canonical_topdir
 from twisterlib.error import TwisterException, TwisterRuntimeError
 
 logger = logging.getLogger('twister')
@@ -407,13 +407,17 @@ class TestSuite(DisablePyTestCollectionMixin):
     def get_unique(testsuite_root, workdir, name):
 
         canonical_testsuite_root = os.path.realpath(testsuite_root)
-        if Path(canonical_zephyr_base) in Path(canonical_testsuite_root).parents:
-            # This is in ZEPHYR_BASE, so include path in name for uniqueness
-            # FIXME: We should not depend on path of test for unique names.
-            relative_ts_root = os.path.relpath(canonical_testsuite_root,
-                                               start=canonical_zephyr_base)
-        else:
-            relative_ts_root = ""
+        relative_ts_root = os.path.relpath(canonical_testsuite_root,
+                                               start=canonical_topdir)
+        # Include path in name for name uniqueness.
+        # Replace all '..' with a single 'external' for external tests.
+        # FIXME: We should not depend on path of test for unique names.
+        is_external = Path(canonical_topdir) not in Path(canonical_testsuite_root).parents
+        if is_external:
+            relative_ts_parts = Path(relative_ts_root).parts
+            if ".." in relative_ts_parts:
+                relative_ts_parts = tuple(part for part in relative_ts_parts if part != "..")
+                relative_ts_root = os.path.join("external", *relative_ts_parts)
 
         # workdir can be "."
         unique = os.path.normpath(os.path.join(relative_ts_root, workdir, name))

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -33,7 +33,7 @@ def test_check_build_or_run(class_testplan, monkeypatch, all_testsuites_dict, pl
     Scenario 2: Test if build_only is enabled when the OS is Windows"""
 
     class_testplan.testsuites = all_testsuites_dict
-    testsuite = class_testplan.testsuites.get('scripts/tests/twister/test_data/testsuites/tests/test_a/test_a.check_1')
+    testsuite = class_testplan.testsuites.get('zephyr/scripts/tests/twister/test_data/testsuites/tests/test_a/test_a.check_1')
     print(testsuite)
 
     class_testplan.platforms = platforms_list
@@ -69,7 +69,7 @@ def test_create_overlay(class_testplan, all_testsuites_dict, platforms_list, ena
     """Test correct content is written to testcase_extra.conf based on if conditions
     TO DO: Add extra_configs to the input list"""
     class_testplan.testsuites = all_testsuites_dict
-    testcase = class_testplan.testsuites.get('scripts/tests/twister/test_data/testsuites/samples/test_app/sample_test.app')
+    testcase = class_testplan.testsuites.get('zephyr/scripts/tests/twister/test_data/testsuites/samples/test_app/sample_test.app')
     class_testplan.platforms = platforms_list
     platform = class_testplan.get_platform("demo_board_2")
 
@@ -80,7 +80,7 @@ def test_create_overlay(class_testplan, all_testsuites_dict, platforms_list, ena
 def test_calculate_sizes(class_testplan, all_testsuites_dict, platforms_list):
     """ Test Calculate sizes method for zephyr elf"""
     class_testplan.testsuites = all_testsuites_dict
-    testcase = class_testplan.testsuites.get('scripts/tests/twister/test_data/testsuites/samples/test_app/sample_test.app')
+    testcase = class_testplan.testsuites.get('zephyr/scripts/tests/twister/test_data/testsuites/samples/test_app/sample_test.app')
     class_testplan.platforms = platforms_list
     platform = class_testplan.get_platform("demo_board_2")
     testinstance = TestInstance(testcase, platform, class_testplan.env.outdir)

--- a/scripts/tests/twister/test_testplan_class.py
+++ b/scripts/tests/twister/test_testplan_class.py
@@ -26,7 +26,7 @@ def test_testplan_add_testsuites(class_testplan):
     class_testplan.TESTSUITE_FILENAME = 'test_data.yaml'
     class_testplan.add_testsuites()
 
-    tests_rel_dir = 'scripts/tests/twister/test_data/testsuites/tests/'
+    tests_rel_dir = 'zephyr/scripts/tests/twister/test_data/testsuites/tests/'
     expected_testsuites = ['test_b.check_1',
                           'test_b.check_2',
                           'test_c.check_1',

--- a/scripts/tests/twister/test_testsuite.py
+++ b/scripts/tests/twister/test_testsuite.py
@@ -93,10 +93,10 @@ TESTDATA_3 = [
             '/scripts/tests/twister/test_data/testsuites/test_b/test_b.check_1'
         ),
         (
-            os.path.join(ZEPHYR_BASE, '/scripts/tests'),
-            os.path.join(ZEPHYR_BASE, '/scripts/tests'),
+            os.path.join(ZEPHYR_BASE, 'scripts/tests'),
+            os.path.join(ZEPHYR_BASE, 'scripts/tests'),
             'test_b.check_1',
-            'test_b.check_1'
+            'scripts/tests/test_b.check_1'
         ),
         (
             ZEPHYR_BASE,

--- a/scripts/tests/twister/test_testsuite.py
+++ b/scripts/tests/twister/test_testsuite.py
@@ -84,7 +84,7 @@ TESTDATA_3 = [
             ZEPHYR_BASE,
             ZEPHYR_BASE,
             'test_a.check_1',
-            'test_a.check_1'
+            'zephyr/test_a.check_1'
         ),
         (
             ZEPHYR_BASE,
@@ -96,13 +96,13 @@ TESTDATA_3 = [
             os.path.join(ZEPHYR_BASE, 'scripts/tests'),
             os.path.join(ZEPHYR_BASE, 'scripts/tests'),
             'test_b.check_1',
-            'scripts/tests/test_b.check_1'
+            'zephyr/scripts/tests/test_b.check_1'
         ),
         (
             ZEPHYR_BASE,
             ZEPHYR_BASE,
             'test_a.check_1.check_2',
-            'test_a.check_1.check_2'
+            'zephyr/test_a.check_1.check_2'
         ),
 ]
 @pytest.mark.parametrize("testsuite_root, suite_path, name, expected", TESTDATA_3)

--- a/scripts/tests/twister/test_testsuite.py
+++ b/scripts/tests/twister/test_testsuite.py
@@ -104,6 +104,30 @@ TESTDATA_3 = [
             'test_a.check_1.check_2',
             'zephyr/test_a.check_1.check_2'
         ),
+        (
+            os.path.join(ZEPHYR_BASE, '..', 'module_A', 'samples', 'hello_world'),
+            os.path.join(ZEPHYR_BASE, '..', 'module_A', 'samples', 'hello_world'),
+            'test_c.check_1',
+            'module_A/samples/hello_world/test_c.check_1'
+        ),
+        (
+            os.path.join(ZEPHYR_BASE, '..', 'module_A'),
+            os.path.join(ZEPHYR_BASE, '..', 'module_A', 'samples', 'hello_world'),
+            'test_c.check_2',
+            'module_A/samples/hello_world/test_c.check_2'
+        ),
+        (
+            os.path.join(ZEPHYR_BASE, '..', '..', 'my_own_zephyr', 'samples', 'hello_world'),
+            os.path.join(ZEPHYR_BASE, '..', '..', 'my_own_zephyr', 'samples', 'hello_world'),
+            'test_c.check_1',
+            'external/my_own_zephyr/samples/hello_world/test_c.check_1'
+        ),
+        (
+            os.path.join(ZEPHYR_BASE, '..', '..', 'my_own_zephyr'),
+            os.path.join(ZEPHYR_BASE, '..', '..', 'my_own_zephyr', 'samples', 'hello_world'),
+            'test_c.check_2',
+            'external/my_own_zephyr/samples/hello_world/test_c.check_2'
+        ),
 ]
 @pytest.mark.parametrize("testsuite_root, suite_path, name, expected", TESTDATA_3)
 def test_get_unique(testsuite_root, suite_path, name, expected):


### PR DESCRIPTION
With the patch a relative path between a test and west's project top directory is always calculated instead of being relative to zephyr base. The test names and results structur change by addition of one level. This way the names/structure conventon for tests from zephyr and modules is alligned.
For external tests ".." parts are replaced with "external". This allows to maintain unified folder structure also for results of external tests. Without this patch the folder/name allignment is lost for external and module test becaming depandant on a way how twister was called.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>