### PR TITLE
bluetooth: host: Check BT_DEV_ENABLE bit with bt_rand() calls

### DIFF
--- a/subsys/bluetooth/host/crypto.c
+++ b/subsys/bluetooth/host/crypto.c
@@ -35,6 +35,10 @@ static int prng_reseed(struct tc_hmac_prng_struct *h)
 	int64_t extra;
 	int ret;
 
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_ENABLE)) {
+		return -EAGAIN;
+	}
+
 	ret = bt_hci_le_rand(seed, sizeof(seed));
 	if (ret) {
 		return ret;
@@ -56,6 +60,10 @@ int prng_init(void)
 {
 	uint8_t perso[8];
 	int ret;
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_ENABLE)) {
+		return -EAGAIN;
+	}
 
 	ret = bt_hci_le_rand(perso, sizeof(perso));
 	if (ret) {
@@ -96,6 +104,10 @@ int bt_rand(void *buf, size_t len)
 #else /* !CONFIG_BT_HOST_CRYPTO_PRNG */
 int bt_rand(void *buf, size_t len)
 {
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_ENABLE)) {
+		return -EAGAIN;
+	}
+
 	return bt_hci_le_rand(buf, len);
 }
 #endif /* CONFIG_BT_HOST_CRYPTO_PRNG */


### PR DESCRIPTION
Check if BT_DEV_ENABLE flag in bt_dev.flags is set before generating a random number.

Signed-off-by: Ahmed Moheb <ahmed.moheb@nordicsemi.no>