### PR TITLE
Multiple SocketCAN instance support.

### DIFF
--- a/boards/arm/rddrone_fmuk66/rddrone_fmuk66.dts
+++ b/boards/arm/rddrone_fmuk66/rddrone_fmuk66.dts
@@ -35,7 +35,8 @@
 		zephyr,console = &lpuart0;
 		zephyr,shell-uart = &lpuart0;
 		zephyr,uart-pipe = &lpuart0;
-		zephyr,canbus = &flexcan0;
+		zephyr,canbus0 = &flexcan0;
+		zephyr,canbus1 = &flexcan1;
 	};
 
 	leds {

--- a/drivers/net/canbus.c
+++ b/drivers/net/canbus.c
@@ -7,6 +7,8 @@
  *
  */
 
+#define DT_DRV_COMPAT net_canbus
+
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/canbus.h>
 #include <zephyr/net/socketcan.h>
@@ -158,6 +160,19 @@ static const struct net_canbus_config net_canbus_cfg = {
 	.can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus))
 };
 
-NET_DEVICE_INIT(net_canbus, "NET_CANBUS", net_canbus_init, NULL, &net_canbus_ctx, &net_canbus_cfg,
-		CONFIG_NET_CANBUS_INIT_PRIORITY, &net_canbus_api, CANBUS_RAW_L2,
-		NET_L2_GET_CTX_TYPE(CANBUS_RAW_L2), CAN_MTU);
+#define NET_CANBUS_INIT(n)					\
+static struct net_canbus_context net_canbus##n##_ctx;		\
+								\
+static const struct net_canbus_config net_canbus##n##_cfg = {	\
+	.can_dev = DEVICE_DT_GET(DT_PARENT(DT_DRV_INST(n)))	\
+};								\
+								\
+NET_DEVICE_DT_INST_DEFINE(n, net_canbus_init, NULL,		\
+			&net_canbus##n##_ctx,			\
+			&net_canbus##n##_cfg,			\
+			CONFIG_NET_CANBUS_INIT_PRIORITY,	\
+			&net_canbus_api, CANBUS_RAW_L2,		\
+			NET_L2_GET_CTX_TYPE(CANBUS_RAW_L2),	\
+			CAN_MTU);				\
+
+DT_INST_FOREACH_STATUS_OKAY(NET_CANBUS_INIT)

--- a/dts/arm/nxp/nxp_k66.dtsi
+++ b/dts/arm/nxp/nxp_k66.dtsi
@@ -34,6 +34,10 @@
 			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
+			net_canbus1 {
+				compatible = "net-canbus";
+				status = "okay";
+			};
 		  };
 	};
 };

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -506,6 +506,10 @@
 			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
+			net_canbus0 {
+				compatible = "net-canbus";
+				status = "okay";
+			};
 		};
 
 		edma0: dma-controller@40008000 {

--- a/samples/net/sockets/can/src/main.c
+++ b/samples/net/sockets/can/src/main.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(net_socket_can_sample, LOG_LEVEL_DBG);
 #define PRIORITY  k_thread_priority_get(k_current_get())
 #define STACKSIZE 1024
 #define SLEEP_PERIOD K_SECONDS(1)
+#define SOCKETCAN_NODE_0 DT_INST(0, net_canbus)
 
 static k_tid_t tx_tid;
 static K_THREAD_STACK_DEFINE(tx_stack, STACKSIZE);
@@ -171,7 +172,7 @@ static int setup_socket(void)
 
 	socketcan_from_can_filter(&zfilter, &sfilter);
 
-	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(CANBUS_RAW));
+	iface = net_if_lookup_by_dev(DEVICE_DT_GET(SOCKETCAN_NODE_0));
 	if (!iface) {
 		LOG_ERR("No CANBUS network interface found!");
 		return -ENOENT;
@@ -256,7 +257,7 @@ cleanup:
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus0));
 	int ret;
 	int fd;
 


### PR DESCRIPTION
Adding support for multiple socketCAN interfaces by
making use of instances of DT_DRV_COMPAT for
network devices instead of a single network interface
Each socketCAN instance has a corresponding
DT Node named net_canbus<0>,<1>.

The net_canbus DT Node needs to be a child of the CAN DT Node.
The CAN and socketCAN devices can be accessed
by applications by parent child DT macros.
SocketCAN applications can access socketCAN node and
hence the network interface with its node id.


Tested on RDDRONE board.


Signed-off-by: Benjamin Perseghetti <bperseghetti@rudislabs.com>
Co-authored-by: Sumit Batra <sumit.batra@nxp.com>