### PR TITLE
assert: Add no-op stub for __ASSERT_POST_ACTION

### DIFF
--- a/include/zephyr/sys/__assert.h
+++ b/include/zephyr/sys/__assert.h
@@ -134,11 +134,13 @@ void assert_post_action(const char *file, unsigned int line);
 #define __ASSERT(test, fmt, ...) { }
 #define __ASSERT_EVAL(expr1, expr2, test, fmt, ...) expr1
 #define __ASSERT_NO_MSG(test) { }
+#define __ASSERT_POST_ACTION() { }
 #endif
 #else
 #define __ASSERT(test, fmt, ...) { }
 #define __ASSERT_EVAL(expr1, expr2, test, fmt, ...) expr1
 #define __ASSERT_NO_MSG(test) { }
+#define __ASSERT_POST_ACTION() { }
 #endif
 
 #endif /* ZEPHYR_INCLUDE_SYS___ASSERT_H_ */


### PR DESCRIPTION
Add a no-op stub for __ASSERT_POST_ACTION.
This allows code to reference __ASSERT_POST_ACTION even when Zephyr asserts are off.

Signed-off-by: Rob Barnes <robbarnes@google.com>
