### PR TITLE
toolchain: Check if __STDC_VERSION__ is defined

### DIFF
--- a/include/zephyr/toolchain.h
+++ b/include/zephyr/toolchain.h
@@ -95,7 +95,7 @@
  * @def TOOLCHAIN_HAS_C_GENERIC
  * @brief Indicate if toolchain supports C Generic.
  */
-#if __STDC_VERSION__ >= 201112L
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 /* _Generic is introduced in C11, so it is supported. */
 # ifdef TOOLCHAIN_HAS_C_GENERIC
 #  undef TOOLCHAIN_HAS_C_GENERIC


### PR DESCRIPTION
Check if __STDC_VERSION__ is defined before referencing it. This will avoid 
a compilation failure if __STDC_VERSION__ is not defined for any reason.

Signed-off-by: Rob Barnes <robbarnes@google.com>