### PR TITLE
twister: fix the mis-placed drain logic.

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -333,19 +333,6 @@ class DeviceHandler(Handler):
 
         ser.flush()
 
-        # turns out the ser.flush() is not enough to clear serial leftover from last case
-        # explicitly readline() can do it reliably
-        old_timeout = ser.timeout
-        # wait for 1s if no serial output
-        ser.timeout = 1
-        # or read 1000 lines at most
-        # if the leftovers are more than 1000 lines, user should realize that once
-        # saw the caught ones and fix it.
-        leftover_lines = ser.readlines(1000)
-        for line in leftover_lines:
-            logger.debug(f"leftover log of previous test: {line}")
-        ser.timeout = old_timeout
-
         while ser.isOpen():
             if halt_event.is_set():
                 logger.debug('halted')
@@ -537,6 +524,19 @@ class DeviceHandler(Handler):
             return
 
         ser.flush()
+
+        # turns out the ser.flush() is not enough to clear serial leftover from last case
+        # explicitly readline() can do it reliably
+        old_timeout = ser.timeout
+        # wait for 1s if no serial output
+        ser.timeout = 1
+        # or read 1000 lines at most
+        # if the leftovers are more than 1000 lines, user should realize that once
+        # saw the caught ones and fix it.
+        leftover_lines = ser.readlines(1000)
+        for line in leftover_lines:
+            logger.debug(f"leftover log of previous test: {line}")
+        ser.timeout = old_timeout
 
         harness_name = self.instance.testsuite.harness.capitalize()
         harness_import = HarnessImporter(harness_name)


### PR DESCRIPTION
The logic to drain the leftover logs of previous test should be
put before the monitor_serial(). It was misplaced when re-adding
this logic back.

Signed-off-by: Ming Shao <ming.shao@intel.com>


The original working patch before re-adding is here https://github.com/zephyrproject-rtos/zephyr/pull/46132.

