### PR TITLE
driver: i2c: npcx: do bus recovery when the transaction timeout

### DIFF
--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -1011,7 +1011,7 @@ int npcx_i2c_ctrl_transfer(const struct device *i2c_dev, struct i2c_msg *msgs,
 		}
 	}
 
-	if (data->oper_state == NPCX_I2C_ERROR_RECOVERY) {
+	if (data->oper_state == NPCX_I2C_ERROR_RECOVERY || ret == -ETIMEDOUT) {
 		int recovery_error = i2c_ctrl_recovery(i2c_dev);
 		/*
 		 * Recovery failed, return it immediately. Otherwise, the upper


### PR DESCRIPTION
When there is a timeout for an i2c transaction, the i2c driver should do the recovery logic to make the bus and driver state machine go back to idle. Otherwise, it will cause the following transaction to fail because the state machine keeps in an inappropriate state.

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>