### PR TITLE
tests: cmsis_dsp: MVE correlate out-of-bounds access workaround

### DIFF
--- a/tests/lib/cmsis_dsp/filtering/src/misc_f32.c
+++ b/tests/lib/cmsis_dsp/filtering/src/misc_f32.c
@@ -23,10 +23,19 @@ static void test_arm_correlate_f32(
 	size_t in1_length, size_t in2_length, const uint32_t *ref,
 	size_t ref_length)
 {
-	float32_t *output;
+	/*
+	 * FIXME: The MVE `arm_correlate_f32` implementation may write to
+	 *        negative indices of the output buffer, so the beginning of
+	 *        the output buffer is offset by a few elements to prevent the
+	 *        memory block header from getting corrupted. For more details,
+	 *        refer to the CMSIS-DSP bug ARM-software/CMSIS-DSP#59.
+	 */
+
+	float32_t *output, *output_buf;
 
 	/* Allocate output buffer */
-	output = calloc(ref_length, sizeof(float32_t));
+	output_buf = calloc(ref_length + 16, sizeof(float32_t));
+	output = output_buf + 8;
 
 	/* Run test function */
 	arm_correlate_f32(
@@ -45,7 +54,7 @@ static void test_arm_correlate_f32(
 		ASSERT_MSG_ERROR_LIMIT_EXCEED);
 
 	/* Free output buffer */
-	free(output);
+	free(output_buf);
 }
 
 #define DEFINE_CORRELATE_TEST(a, b) \

--- a/tests/lib/cmsis_dsp/filtering/src/misc_q31.c
+++ b/tests/lib/cmsis_dsp/filtering/src/misc_q31.c
@@ -22,10 +22,19 @@ static void test_arm_correlate_q31(
 	size_t in1_length, size_t in2_length, const q31_t *ref,
 	size_t ref_length)
 {
-	q31_t *output;
+	/*
+	 * FIXME: The MVE `arm_correlate_q31` implementation may write to
+	 *        negative indices of the output buffer, so the beginning of
+	 *        the output buffer is offset by a few elements to prevent the
+	 *        memory block header from getting corrupted. For more details,
+	 *        refer to the CMSIS-DSP bug ARM-software/CMSIS-DSP#59.
+	 */
+
+	q31_t *output, *output_buf;
 
 	/* Allocate output buffer */
-	output = calloc(ref_length, sizeof(q31_t));
+	output_buf = calloc(ref_length + 16, sizeof(q31_t));
+	output = output_buf + 8;
 
 	/* Run test function */
 	arm_correlate_q31(in_com1, in1_length, in_com2, in2_length, output);
@@ -41,7 +50,7 @@ static void test_arm_correlate_q31(
 		ASSERT_MSG_ABS_ERROR_LIMIT_EXCEED);
 
 	/* Free output buffer */
-	free(output);
+	free(output_buf);
 }
 
 #define DEFINE_CORRELATE_TEST(a, b) \


### PR DESCRIPTION
The MVE `arm_correlate_f32` and `arm_correlate_q31` implementations may write to negative indices of the output buffer (refer to the upstream CMSIS-DSP bug ARM-software/CMSIS-DSP#59).

This commit adds a workaround for the above bug by overallocating the output buffer memory and offsetting the output buffer supplied to the function.

Revert this commit when this bug is fixed.

Signed-off-by: Stephanos Ioannidis <stephanos.ioannidis@nordicsemi.no>

Fixes #51468