### PR TITLE
include: add more missing headers

### DIFF
--- a/drivers/flash/soc_flash_cc13xx_cc26xx.c
+++ b/drivers/flash/soc_flash_cc13xx_cc26xx.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/kernel.h>
 #include <string.h>
 
 #include <driverlib/flash.h>

--- a/drivers/flash/soc_flash_cc13xx_cc26xx.c
+++ b/drivers/flash/soc_flash_cc13xx_cc26xx.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <string.h>
 

--- a/drivers/i2s/i2s_litex.c
+++ b/drivers/i2s/i2s_litex.c
@@ -6,6 +6,7 @@
 
 #include <string.h>
 #include <zephyr/drivers/i2s.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 #include <soc.h>
 #include <zephyr/sys/util.h>

--- a/drivers/i2s/i2s_litex.h
+++ b/drivers/i2s/i2s_litex.h
@@ -10,6 +10,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2s.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
 
 /* i2s configuration mask*/
 #define I2S_CONF_FORMAT_OFFSET 0

--- a/drivers/memc/memc_stm32_sdram.c
+++ b/drivers/memc/memc_stm32_sdram.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT st_stm32_fmc_sdram
 
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 
 #include <zephyr/logging/log.h>

--- a/drivers/mipi_dsi/mipi_dsi.c
+++ b/drivers/mipi_dsi/mipi_dsi.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
+
 #include <zephyr/drivers/mipi_dsi.h>
 
 ssize_t mipi_dsi_generic_read(const struct device *dev, uint8_t channel,

--- a/drivers/peci/peci_npcx.c
+++ b/drivers/peci/peci_npcx.c
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/peci.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/kernel.h>
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>

--- a/drivers/serial/uart_smartbond.c
+++ b/drivers/serial/uart_smartbond.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/sys/byteorder.h>
 #include <DA1469xAB.h>

--- a/drivers/watchdog/wdt_mcux_imx_wdog.c
+++ b/drivers/watchdog/wdt_mcux_imx_wdog.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT nxp_imx_wdog
 
 #include <zephyr/drivers/watchdog.h>
+#include <zephyr/sys_clock.h>
 #include <fsl_wdog.h>
 
 #define LOG_LEVEL CONFIG_WDT_LOG_LEVEL


### PR DESCRIPTION
Add more missing headers, should fix all missing headers issues reported in https://github.com/zephyrproject-rtos/zephyr/runs/8975045217

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>