### PR TITLE
twister: Add fiters to SYS-T related tests

### DIFF
--- a/samples/subsys/logging/syst/sample.yaml
+++ b/samples/subsys/logging/syst/sample.yaml
@@ -20,6 +20,13 @@ tests:
       regex:
         - "SYS-T RAW DATA: "
         - "SYST Sample Execution Completed"
+    # "TOOLCHAIN_HAS_NEWLIB == 1" filter was applied
+    # because of following chain of dependencies:
+    # LOG_MIPI_SYST_ENABLE=y --> CONFIG_MIPI_SYST_LIB --> \
+    # --> REQUIRES_FULL_LIBC --> NEWLIB_LIBC.
+    #
+    # Not all compillers announced in Zephyr support NewLib.
+    filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   sample.logger.syst.immediate:
     toolchain_exclude: xcc
     extra_args: OVERLAY_CONFIG=overlay_immediate.conf
@@ -34,6 +41,7 @@ tests:
       regex:
         - "SYS-T RAW DATA: "
         - "SYST Sample Execution Completed"
+    filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   sample.logger.syst.catalog.deferred:
     toolchain_exclude: xcc
     extra_args: OVERLAY_CONFIG=overlay_deferred.conf
@@ -49,6 +57,7 @@ tests:
         - "SYS-T RAW DATA: "
     extra_configs:
       - CONFIG_LOG_MIPI_SYST_USE_CATALOG=y
+    filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   sample.logger.syst.catalog.immediate:
     toolchain_exclude: xcc
     integration_platforms:
@@ -63,6 +72,7 @@ tests:
         - "SYS-T RAW DATA: "
     extra_configs:
       - CONFIG_LOG_MIPI_SYST_USE_CATALOG=y
+    filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   sample.logger.syst.deferred_cpp:
     toolchain_exclude: xcc
     extra_args: OVERLAY_CONFIG=overlay_deferred.conf
@@ -79,6 +89,7 @@ tests:
         - "SYS-T RAW DATA: "
     extra_configs:
       - CONFIG_CPLUSPLUS=y
+    filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   sample.logger.syst.immediate_cpp:
     toolchain_exclude: xcc
     integration_platforms:
@@ -94,6 +105,7 @@ tests:
         - "SYS-T RAW DATA: "
     extra_configs:
       - CONFIG_CPLUSPLUS=y
+    filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   sample.logger.syst.catalog.deferred_cpp:
     toolchain_exclude: xcc
     extra_args: OVERLAY_CONFIG=overlay_deferred.conf
@@ -110,6 +122,7 @@ tests:
     extra_configs:
       - CONFIG_LOG_MIPI_SYST_USE_CATALOG=y
       - CONFIG_CPLUSPLUS=y
+    filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   sample.logger.syst.catalog.immediate_cpp:
     toolchain_exclude: xcc
     integration_platforms:
@@ -125,3 +138,4 @@ tests:
     extra_configs:
       - CONFIG_LOG_MIPI_SYST_USE_CATALOG=y
       - CONFIG_CPLUSPLUS=y
+    filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED

--- a/tests/subsys/logging/log_switch_format/testcase.yaml
+++ b/tests/subsys/logging/log_switch_format/testcase.yaml
@@ -12,6 +12,13 @@ tests:
       - sam_e70_xplained
       - qemu_cortex_a53
     extra_args: OVERLAY_CONFIG=overlay_deferred.conf
+    # "TOOLCHAIN_HAS_NEWLIB == 1" filter was applied
+    # because of following chain of dependencies:
+    # LOG_MIPI_SYST_ENABLE=y --> CONFIG_MIPI_SYST_LIB --> \
+    # --> REQUIRES_FULL_LIBC --> NEWLIB_LIBC.
+    #
+    # Not all compillers announced in Zephyr support NewLib.
+    filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   logging.log_switch_format.immediate:
     extra_args: OVERLAY_CONFIG=overlay_immediate.conf
     integration_platforms:
@@ -19,6 +26,7 @@ tests:
       - qemu_x86
       - sam_e70_xplained
       - qemu_cortex_a53
+    filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED
   logging.log_switch_format.custom_output:
     extra_args: OVERLAY_CONFIG=overlay_custom_output.conf
     integration_platforms:
@@ -26,3 +34,4 @@ tests:
       - qemu_x86
       - sam_e70_xplained
       - qemu_cortex_a53
+    filter: (TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_PICOLIBC_SUPPORTED

--- a/tests/subsys/logging/log_syst/testcase.yaml
+++ b/tests/subsys/logging/log_syst/testcase.yaml
@@ -1,8 +1,16 @@
+common:
+    filter: not CONFIG_64BIT
 tests:
   logging.log_syst.mipi_syst:
     tags: log_syst logging
     arch_exclude: mips nios2 posix sparc
-    filter: not CONFIG_64BIT
+    # "TOOLCHAIN_HAS_NEWLIB == 1" filter was applied
+    # because of following chain of dependencies:
+    # LOG_MIPI_SYST_ENABLE=y --> CONFIG_MIPI_SYST_LIB --> \
+    # --> REQUIRES_FULL_LIBC --> NEWLIB_LIBC.
+    #
+    # Not all compillers announced in Zephyr support NewLib.
+    filter: TOOLCHAIN_HAS_NEWLIB == 1 or CONFIG_PICOLIBC_SUPPORTED
     integration_platforms:
       - mps2_an385
       - qemu_x86
@@ -13,7 +21,7 @@ tests:
   logging.log_syst.text:
     tags: log_syst logging
     arch_exclude: mips nios2 posix sparc
-    filter: not CONFIG_64BIT
+    filter: TOOLCHAIN_HAS_NEWLIB == 1 or CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_LOG_MIPI_SYST_ENABLE=n
       - CONFIG_LOG_BACKEND_MOCK_OUTPUT_SYST=n


### PR DESCRIPTION
New filter "TOOLCHAIN_HAS_NEWLIB == 1" was applied because of following chain of dependencies:
LOG_MIPI_SYST_ENABLE=y --> CONFIG_MIPI_SYST_LIB --> \ --> REQUIRES_FULL_LIBC --> NEWLIB_LIBC.

Not all compillers announced in Zephyr support NewLib.

Signed-off-by: Nikolay Agishev <agishev@synopsys.com>