### PR TITLE
Add stm32u5 ospi manager clock in dts

### DIFF
--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -60,6 +60,7 @@
 			compatible = "st,stm32-ospi";
 			reg = <0x52005000 0x1000>;
 			interrupts = <92 0>;
+			clock-names = "ospix", "ospi-ker";
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00004000>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;
@@ -71,6 +72,7 @@
 			compatible = "st,stm32-ospi";
 			reg = <0x5200a000 0x1000>;
 			interrupts = <150 0>;
+			clock-names = "ospix", "ospi-ker";
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x000080000>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -50,6 +50,7 @@
 			compatible = "st,stm32-ospi";
 			reg = <0x52005000 0x1000>;
 			interrupts = <92 0>;
+			clock-names = "ospix", "ospi-ker";
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00004000>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;
@@ -61,6 +62,7 @@
 			compatible = "st,stm32-ospi";
 			reg = <0x5200a000 0x1000>;
 			interrupts = <150 0>;
+			clock-names = "ospix", "ospi-ker";
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x000080000>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -378,6 +378,7 @@
 			compatible = "st,stm32-ospi";
 			reg = <0x44021000 0x400>;
 			interrupts = <76 0>;
+			clock-names = "ospix", "ospi-ker";
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000100>,
 					<&rcc STM32_SRC_SYSCLK OSPI_SEL(0)>;
 			#address-cells = <1>;

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -492,8 +492,10 @@
 			compatible = "st,stm32-ospi";
 			reg = <0x420d1400 0x400>;
 			interrupts = <76 0>;
+			clock-names = "ospix", "ospi-ker", "ospi-mgr";
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2_2 0x00000010>,
-				<&rcc STM32_SRC_SYSCLK OCTOSPI_SEL(0)>;
+				<&rcc STM32_SRC_SYSCLK OCTOSPI_SEL(0)>,
+				<&rcc STM32_CLOCK_BUS_AHB2 0x00200000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -503,8 +505,10 @@
 			compatible = "st,stm32-ospi";
 			reg = <0x420d2400 0x400>;
 			interrupts = <120 0>;
+			clock-names = "ospix", "ospi-ker", "ospi-mgr";
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2_2 0x00000100>,
-				<&rcc STM32_SRC_SYSCLK OCTOSPI_SEL(0)>;
+				<&rcc STM32_SRC_SYSCLK OCTOSPI_SEL(0)>,
+				<&rcc STM32_CLOCK_BUS_AHB2 0x00200000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";

--- a/dts/bindings/ospi/st,stm32-ospi.yaml
+++ b/dts/bindings/ospi/st,stm32-ospi.yaml
@@ -37,6 +37,9 @@ properties:
     pinctrl-names:
       required: true
 
+    clock-names:
+      required: true
+
     dmas:
       description: |
         Optional DMA channel specifier, required for DMA transactions.


### PR DESCRIPTION
The OSPI manager clock was enabled directly using the macro __HAL_RCC_OSPIM_CLK_ENABLE.
This PR fixes it so that this activation is done through the dts.
The different OSPI clocks are now referenced through their (new) names instead of their indexes to make things clearer.