### PR TITLE
clock_control: stm32: Fix clock_mux and related tests

### DIFF
--- a/drivers/clock_control/clock_stm32_mux.c
+++ b/drivers/clock_control/clock_stm32_mux.c
@@ -25,8 +25,8 @@ static int stm32_clk_mux_init(const struct device *dev)
 {
 	const struct stm32_clk_mux_config *cfg = dev->config;
 
-	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-			     (clock_control_subsys_t) &cfg->pclken) != 0) {
+	if (clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+			     (clock_control_subsys_t) &cfg->pclken, NULL) != 0) {
 		LOG_ERR("Could not enable clock mux");
 		return -EIO;
 	}

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/src/test_stm32_clock_configuration.c
@@ -37,27 +37,27 @@ ZTEST(stm32_sysclck_config, test_sysclk_src)
 
 #if STM32_SYSCLK_SRC_PLL
 	zassert_equal(RCC_SYSCLKSOURCE_STATUS_PLLCLK, sys_clk_src,
-			"Expected sysclk src: PLL. Actual sysclk src: %d",
-			sys_clk_src);
+			"Expected sysclk src: PLL (0x%x). Actual: 0x%x",
+			RCC_SYSCLKSOURCE_STATUS_PLLCLK, sys_clk_src);
 #elif STM32_SYSCLK_SRC_HSE
 	zassert_equal(RCC_SYSCLKSOURCE_STATUS_HSE, sys_clk_src,
-			"Expected sysclk src: HSE. Actual sysclk src: %d",
-			sys_clk_src);
+			"Expected sysclk src: HSE (0x%x). Actual: 0x%x",
+			RCC_SYSCLKSOURCE_STATUS_HSE, sys_clk_src);
 #elif STM32_SYSCLK_SRC_HSI
 	zassert_equal(RCC_SYSCLKSOURCE_STATUS_HSI, sys_clk_src,
-			"Expected sysclk src: HSI. Actual sysclk src: %d",
-			sys_clk_src);
+			"Expected sysclk src: HSI (0x%x). Actual: 0x%x",
+			RCC_SYSCLKSOURCE_STATUS_HSI, sys_clk_src);
 #elif STM32_SYSCLK_SRC_MSI
 	zassert_equal(RCC_SYSCLKSOURCE_STATUS_MSI, sys_clk_src,
-			"Expected sysclk src: MSI. Actual sysclk src: %d",
-			sys_clk_src);
+			"Expected sysclk src: MSI (0x%x). Actual: 0x%x",
+			RCC_SYSCLKSOURCE_STATUS_MSI, sys_clk_src);
 #else
 	/* Case not expected */
 	zassert_true((STM32_SYSCLK_SRC_PLL ||
 		      STM32_SYSCLK_SRC_HSE ||
 		      STM32_SYSCLK_SRC_HSI ||
 		      STM32_SYSCLK_SRC_MSI),
-		      "Not expected. sys_clk_src: %d\n", sys_clk_src);
+		      "Not expected. sys_clk_src: 0x%x\n", sys_clk_src);
 #endif
 
 }

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration.c
@@ -75,7 +75,7 @@ ZTEST(stm32_common_devices_clocks, test_i2c_clk_config)
 					"Expected I2C src: SYSCLK (0x%lx). Actual I2C src: 0x%x",
 					RCC_I2C1CLKSOURCE_SYSCLK, dev_actual_clk_src);
 		} else {
-			zassert_true(0, "Unexpected domain clk (%d)", dev_actual_clk_src);
+			zassert_true(0, "Unexpected domain clk (0x%x)", dev_actual_clk_src);
 		}
 
 		/* Test get_rate(srce clk) */

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_core/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_core/src/test_stm32_clock_configuration.c
@@ -28,27 +28,27 @@ ZTEST(stm32_syclck_config, test_sysclk_src)
 
 #if STM32_SYSCLK_SRC_PLL
 	zassert_equal(RCC_SYSCLKSOURCE_STATUS_PLLCLK, sys_clk_src,
-			"Expected sysclk src: PLL. Actual sysclk src: %d",
-			sys_clk_src);
+			"Expected sysclk src: PLL (0x%x). Actual: 0x%x",
+			RCC_SYSCLKSOURCE_STATUS_PLLCLK, sys_clk_src);
 #elif STM32_SYSCLK_SRC_HSE
 	zassert_equal(RCC_SYSCLKSOURCE_STATUS_HSE, sys_clk_src,
-			"Expected sysclk src: HSE. Actual sysclk src: %d",
-			sys_clk_src);
+			"Expected sysclk src: HSE (0x%x). Actual: 0x%x",
+			RCC_SYSCLKSOURCE_STATUS_HSE, sys_clk_src);
 #elif STM32_SYSCLK_SRC_HSI
 	zassert_equal(RCC_SYSCLKSOURCE_STATUS_HSI, sys_clk_src,
-			"Expected sysclk src: HSI. Actual sysclk src: %d",
-			sys_clk_src);
+			"Expected sysclk src: HSI (0x%x). Actual: 0x%x",
+			RCC_SYSCLKSOURCE_STATUS_HSI, sys_clk_src);
 #elif STM32_SYSCLK_SRC_CSI
 	zassert_equal(RCC_SYSCLKSOURCE_STATUS_CSI, sys_clk_src,
-			"Expected sysclk src: CSI. Actual sysclk src: %d",
-			sys_clk_src);
+			"Expected sysclk src: CSI (0x%x). Actual: 0x%x",
+			RCC_SYSCLKSOURCE_STATUS_CSI, sys_clk_src);
 #else
 	/* Case not expected */
 	zassert_true((STM32_SYSCLK_SRC_PLL ||
 		      STM32_SYSCLK_SRC_HSE ||
 		      STM32_SYSCLK_SRC_HSI ||
 		      STM32_SYSCLK_SRC_CSI),
-		      "Not expected. sys_clk_src: %d\n", sys_clk_src);
+		      "Not expected. sys_clk_src: 0x%x\n", sys_clk_src);
 #endif
 
 }

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/boards/spi1_per_ck_hse.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/boards/spi1_per_ck_hse.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after core_init.overlay file.
+ */
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
+	hse-bypass;
+	status = "okay";
+};
+
+&perck {
+	clocks = <&rcc STM32_SRC_HSE CKPER_SEL(2)>;
+	status = "okay";
+};
+
+&spi1 {
+	/delete-property/ clocks;
+	clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>,
+		 <&rcc STM32_SRC_CKPER SPI123_SEL(4)>;
+	status = "okay";
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/src/test_stm32_clock_configuration.c
@@ -64,18 +64,18 @@ ZTEST(stm32h7_devices_clocks, test_spi_clk_config)
 
 		if (pclken[1].bus == STM32_SRC_PLL1_Q) {
 			zassert_equal(spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_PLL,
-					"Expected SPI src: PLLQ (%d). Actual SPI src: %d",
+					"Expected SPI src: PLL1 Q (0x%x). Actual: 0x%x",
 					spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_PLL);
 		} else if (pclken[1].bus == STM32_SRC_PLL3_P) {
 			zassert_equal(spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_PLL3,
-					"Expected SPI src: PLLQ (%d). Actual SPI src: %d",
+					"Expected SPI src: PLL3 P (0x%x). Actual: 0x%x",
 					spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_PLL3);
 		} else if (pclken[1].bus == STM32_SRC_CKPER) {
 			zassert_equal(spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_CLKP,
-					"Expected SPI src: PLLQ (%d). Actual SPI src: %d",
+					"Expected SPI src: PERCLK (0x%x). Actual: 0x%x",
 					spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_CLKP);
 		} else {
-			zassert_true(0, "Unexpected domain_clk src(%d)", pclken[1].bus);
+			zassert_true(0, "Unexpected domain_clk src(0x%x)", pclken[1].bus);
 		}
 
 		/* Test get_rate(domain_clk) */
@@ -86,7 +86,7 @@ ZTEST(stm32h7_devices_clocks, test_spi_clk_config)
 
 		spi1_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI1);
 		zassert_equal(spi1_dt_clk_freq, spi1_actual_clk_freq,
-				"Expected SPI clk: (%d). Actual SPI clk: %d",
+				"Expected SPI clk: 0x%x. Actual SPI clk: 0x%x",
 				spi1_dt_clk_freq, spi1_actual_clk_freq);
 	} else {
 		/* No domain clock available, get rate from reg_clk */
@@ -99,11 +99,11 @@ ZTEST(stm32h7_devices_clocks, test_spi_clk_config)
 
 		spi1_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI1);
 		zassert_equal(spi1_dt_clk_freq, spi1_actual_clk_freq,
-				"Expected SPI clk: (%d). Actual SPI clk: %d",
+				"Expected SPI clk: %d. Actual SPI clk: %d",
 				spi1_dt_clk_freq, spi1_actual_clk_freq);
 	}
 
-	TC_PRINT("SPI1 clock freq: %d(MHz)\n", spi1_actual_clk_freq / (1000*1000));
+	TC_PRINT("SPI1 clock freq: %d MHz\n", spi1_actual_clk_freq / (1000*1000));
 
 	/* Test clock_off(reg_clk) */
 	r = clock_control_off(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/src/test_stm32_clock_configuration.c
@@ -74,6 +74,32 @@ ZTEST(stm32h7_devices_clocks, test_spi_clk_config)
 			zassert_equal(spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_CLKP,
 					"Expected SPI src: PERCLK (0x%x). Actual: 0x%x",
 					spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_CLKP);
+
+			/* Check perclk configuration */
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(perck), okay)
+			uint32_t perclk_dt_domain_clk, perclk_actual_domain_clk;
+
+			perclk_dt_domain_clk = DT_CLOCKS_CELL_BY_IDX(DT_NODELABEL(perck), 0, bus);
+
+			perclk_actual_domain_clk = __HAL_RCC_GET_CLKP_SOURCE();
+
+			if (perclk_dt_domain_clk == STM32_SRC_HSI_KER) {
+				zassert_equal(perclk_actual_domain_clk, RCC_CLKPSOURCE_HSI,
+						"Expected PERCK src: HSI_KER (0x%x). Actual: 0x%x",
+						perclk_actual_domain_clk, RCC_CLKPSOURCE_HSI);
+			} else if (perclk_dt_domain_clk == STM32_SRC_CSI_KER) {
+				zassert_equal(perclk_actual_domain_clk, RCC_CLKPSOURCE_CSI,
+						"Expected PERCK src: CSI_KER (0x%x). Actual: 0x%x",
+						perclk_actual_domain_clk, RCC_CLKPSOURCE_CSI);
+			} else if (perclk_dt_domain_clk == STM32_SRC_HSE) {
+				zassert_equal(perclk_actual_domain_clk, RCC_CLKPSOURCE_HSE,
+						"Expected PERCK src: HSE (0x%x). Actual: 0x%x",
+						perclk_actual_domain_clk, RCC_CLKPSOURCE_HSE);
+			} else {
+				zassert_true(0, "Unexpected PERCK domain_clk src (0x%x)",
+									perclk_dt_domain_clk);
+			}
+#endif
 		} else {
 			zassert_true(0, "Unexpected domain_clk src(0x%x)", pclken[1].bus);
 		}

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/src/test_stm32_clock_configuration.c
@@ -38,7 +38,7 @@ ZTEST(stm32h7_devices_clocks, test_spi_clk_config)
 	static const struct stm32_pclken pclken[] = STM32_DT_CLOCKS(DT_NODELABEL(spi1));
 	struct stm32_pclken spi1_reg_clk_cfg = pclken[0];
 
-	uint32_t spi1_actual_domain_clk, spi1_dt_domain_clk;
+	uint32_t spi1_actual_domain_clk;
 	uint32_t spi1_dt_clk_freq, spi1_actual_clk_freq;
 	int r;
 
@@ -60,27 +60,22 @@ ZTEST(stm32h7_devices_clocks, test_spi_clk_config)
 		zassert_true((r == 0), "Could not enable SPI domain_clk");
 		TC_PRINT("SPI1 domain_clk on\n");
 
-		/* Test domain_clk is configured as device's source clock */
-		spi1_dt_domain_clk = COND_CODE_1(DT_CLOCKS_HAS_NAME(DT_NODELABEL(spi1), kernel),
-						  (DT_CLOCKS_CELL_BY_NAME(DT_NODELABEL(spi1),
-									  kernel, bus)),
-						  (DT_NO_CLOCK));
 		spi1_actual_domain_clk = __HAL_RCC_GET_SPI1_SOURCE();
 
-		if (spi1_dt_domain_clk == STM32_SRC_PLL1_Q) {
+		if (pclken[1].bus == STM32_SRC_PLL1_Q) {
 			zassert_equal(spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_PLL,
 					"Expected SPI src: PLLQ (%d). Actual SPI src: %d",
 					spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_PLL);
-		} else if (spi1_dt_domain_clk == STM32_SRC_PLL3_P) {
+		} else if (pclken[1].bus == STM32_SRC_PLL3_P) {
 			zassert_equal(spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_PLL3,
 					"Expected SPI src: PLLQ (%d). Actual SPI src: %d",
 					spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_PLL3);
-		} else if (spi1_dt_domain_clk == STM32_SRC_CKPER) {
+		} else if (pclken[1].bus == STM32_SRC_CKPER) {
 			zassert_equal(spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_CLKP,
 					"Expected SPI src: PLLQ (%d). Actual SPI src: %d",
 					spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_CLKP);
 		} else {
-			zassert_true(1, "Unexpected domain_clk src(%d)", spi1_dt_domain_clk);
+			zassert_true(0, "Unexpected domain_clk src(%d)", pclken[1].bus);
 		}
 
 		/* Test get_rate(domain_clk) */

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/testcase.yaml
@@ -12,3 +12,5 @@ tests:
     extra_args: DTC_OVERLAY_FILE="boards/core_init.overlay;boards/spi1_per_ck_d1ppre_1.overlay"
   drivers.stm32_clock_configuration.h7_dev.spi1_per_ck_hsi:
     extra_args: DTC_OVERLAY_FILE="boards/core_init.overlay;boards/spi1_per_ck_hsi.overlay"
+  drivers.stm32_clock_configuration.h7_dev.spi1_per_ck_hse:
+    extra_args: DTC_OVERLAY_FILE="boards/core_init.overlay;boards/spi1_per_ck_hse.overlay"

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_core/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_core/src/test_stm32_clock_configuration.c
@@ -28,20 +28,20 @@ ZTEST(stm32_syclck_config, test_sysclk_src)
 
 #if STM32_SYSCLK_SRC_PLL
 	zassert_equal(RCC_SYSCLKSOURCE_STATUS_PLLCLK, sys_clk_src,
-			"Expected sysclk src: PLL1. Actual sysclk src: %d",
-			sys_clk_src);
+			"Expected sysclk src: PLL1 (0x%x). Actual: 0x%x",
+			RCC_SYSCLKSOURCE_STATUS_PLLCLK, sys_clk_src);
 #elif STM32_SYSCLK_SRC_HSE
 	zassert_equal(RCC_SYSCLKSOURCE_STATUS_HSE, sys_clk_src,
-			"Expected sysclk src: HSE. Actual sysclk src: %d",
-			sys_clk_src);
+			"Expected sysclk src: HSE (0x%x). Actual: 0x%x",
+			RCC_SYSCLKSOURCE_STATUS_HSE, sys_clk_src);
 #elif STM32_SYSCLK_SRC_HSI
 	zassert_equal(RCC_SYSCLKSOURCE_STATUS_HSI, sys_clk_src,
-			"Expected sysclk src: HSI. Actual sysclk src: %d",
-			sys_clk_src);
+			"Expected sysclk src: HSI (0x%x). Actual: 0x%x",
+			RCC_SYSCLKSOURCE_STATUS_HSI, sys_clk_src);
 #elif STM32_SYSCLK_SRC_MSIS
 	zassert_equal(RCC_SYSCLKSOURCE_STATUS_MSI, sys_clk_src,
-			"Expected sysclk src: MSI. Actual sysclk src: %d",
-			sys_clk_src);
+			"Expected sysclk src: MSI (0x%x). Actual: 0x%x",
+			RCC_SYSCLKSOURCE_STATUS_MSI, sys_clk_src);
 #else
 	/* Case not expected */
 	zassert_true((STM32_SYSCLK_SRC_PLL ||

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_devices/src/test_stm32_clock_configuration.c
@@ -62,14 +62,14 @@ ZTEST(stm32u5_devices_clocks, test_spi_clk_config)
 
 		if (pclken[1].bus == STM32_SRC_HSI16) {
 			zassert_equal(spi1_actual_domain_clk, RCC_SPI1CLKSOURCE_HSI,
-					"Expected SPI src: HSI (%d). Actual SPI src: %d",
+					"Expected SPI src: HSI (0x%x). Actual: 0x%x",
 					RCC_SPI1CLKSOURCE_HSI, spi1_actual_domain_clk);
 		} else if (pclken[1].bus == STM32_SRC_SYSCLK) {
 			zassert_equal(spi1_actual_domain_clk, RCC_SPI1CLKSOURCE_SYSCLK,
-					"Expected SPI src: SYSCLK (%d). Actual SPI src: %d",
+					"Expected SPI src: SYSCLK (0x%x). Actual: 0x%x",
 					RCC_SPI1CLKSOURCE_SYSCLK, spi1_actual_domain_clk);
 		} else {
-			zassert_true(1, "Unexpected clk src(%d)", spi1_actual_domain_clk);
+			zassert_true(1, "Unexpected clk src (0x%x)", spi1_actual_domain_clk);
 		}
 
 		/* Test get_rate(source clk) */
@@ -80,7 +80,7 @@ ZTEST(stm32u5_devices_clocks, test_spi_clk_config)
 
 		spi1_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI1);
 		zassert_equal(spi1_dt_clk_freq, spi1_actual_clk_freq,
-				"Expected SPI clk: (%d). Actual SPI clk: %d",
+				"Expected SPI clk: %d. Actual: %d",
 				spi1_dt_clk_freq, spi1_actual_clk_freq);
 	} else {
 		/* No domain clock available, get rate from gating clock */
@@ -93,7 +93,7 @@ ZTEST(stm32u5_devices_clocks, test_spi_clk_config)
 
 		spi1_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI1);
 		zassert_equal(spi1_dt_clk_freq, spi1_actual_clk_freq,
-				"Expected SPI clk: (%d). Actual SPI clk: %d",
+				"Expected SPI clk freq: %d. Actual: %d",
 				spi1_dt_clk_freq, spi1_actual_clk_freq);
 	}
 


### PR DESCRIPTION
There was a bug in `drivers/clock_control/clock_stm32_mux.c` which gone undetected because of missing tests.
During the debug some issues were also detected in existing tests.

- Fix the driver
- Fix the tests and enhance logs readability
- Add a dedicated, explicit test case.