### PR TITLE
bindings: add missing binding file for ite,it8xxx2-usbpd

### DIFF
--- a/dts/bindings/usb-c/ite,it8xxx2-usbpd.yaml
+++ b/dts/bindings/usb-c/ite,it8xxx2-usbpd.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+description: ITE it8xxx2 USB-C Power Delivery port
+
+compatible: "ite,it8xxx2-usbpd"
+
+include: [base.yaml]


### PR DESCRIPTION
This commit adds missing binding file for the ite,it8xxx2-usbpd. Without this file, the DT_HAS_*_ENABLED macro wasn't defined and couldn't be used in the Kconfigs.

Device tree nodes were introduced by commit 32906a18ec712a4d2ce8a0e1fb6a22b8ad725148