### PR TITLE
ace: power: fix d0i3 restore

### DIFF
--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -15,8 +15,8 @@
 #define LPSCTL_BATTR_MASK       GENMASK(16, 12)
 #define SRAM_ALIAS_BASE         0xA0000000
 #define SRAM_ALIAS_MASK         0xF0000000
-#define MEMCTL_INIT_BIT         BIT(23)
-#define MEMCTL_DEFAULT_VALUE    (MEMCTL_L0IBUF_EN | MEMCTL_INIT_BIT)
+#define MEMCTL_DEFAULT_VALUE    (MEMCTL_INV_EN | MEMCTL_ICWU_MASK | MEMCTL_DCWA_MASK | \
+				 MEMCTL_DCWU_MASK | MEMCTL_L0IBUF_EN)
 
 __imr void power_init(void)
 {
@@ -122,7 +122,7 @@ void power_gate_entry(uint32_t core_id)
 	lpsheader->adsp_lpsram_magic = LPSRAM_MAGIC_VALUE;
 	lpsheader->lp_restore_vector = &dsp_restore_vector;
 	soc_cpus_active[core_id] = false;
-	xthal_dcache_all_writeback();
+	z_xtensa_cache_flush_inv_all();
 	z_xt_ints_on(ALL_USED_INT_LEVELS_MASK);
 	k_cpu_idle();
 	z_xt_ints_off(0xffffffff);


### PR DESCRIPTION
The restore vector after power gating was configuring the MEMCTL register incorrectly. This caused an FW crash during the cache prefetch.

Additionally, since lp sram cache issue was fixed, xtensa hal function can be replace with zephyr equivalent.

Signed-off-by: Tomasz Leman <tomasz.m.leman@intel.com>