### PR TITLE
MAINTAINERS: Add manuargue to the NXP platforms collaborator list

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1827,6 +1827,7 @@ NXP Platforms:
     - yvanderv
     - EmilioCBen
     - decsny
+    - manuargue
   files:
     - boards/arm/mimx*/
     - boards/arm/frdm_k*/


### PR DESCRIPTION
Add manuargue to the NXP platforms collaborator list

Signed-off-by: David Leach <david.leach@nxp.com>