### PR TITLE
ztest: Make cpu hold time configurable

### DIFF
--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -29,6 +29,17 @@ config ZTEST_TEST_DELAY_MS
 	  Add a delay between between tests to manage output on the console on
 	  systems that can't handle the rapid output rate.
 
+config ZTEST_CPU_HOLD_TIME_MS
+	int "Time in milliseconds to hold other CPUs for 1cpu type tests"
+	default 3000
+	help
+	  This option is used to specify the maximum time in milliseconds for
+	  which a 1cpu type test may execute on a multicpu system. The default
+	  value ought to suffice for most such tests; however slower platforms
+	  (which may include simulators) may need to set this to a larger
+	  value. Please be aware that increasing it for long-running test cases
+	  may overload the CI system. Modify with caution.
+
 config ZTEST_FAIL_FAST
 	bool "Abort on first failing test"
 	help

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -131,7 +131,7 @@ static void cpu_hold(void *arg1, void *arg2, void *arg3)
 	 * logic views it as one "job") and cause other test failures.
 	 */
 	dt = k_uptime_get_32() - start_ms;
-	zassert_true(dt < 3000,
+	zassert_true(dt < CONFIG_ZTEST_CPU_HOLD_TIME_MS,
 		     "1cpu test took too long (%d ms)", dt);
 	arch_irq_unlock(key);
 }

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -152,7 +152,8 @@ static void cpu_hold(void *arg1, void *arg2, void *arg3)
 	 * logic views it as one "job") and cause other test failures.
 	 */
 	dt = k_uptime_get_32() - start_ms;
-	zassert_true(dt < 3000, "1cpu test took too long (%d ms)", dt);
+	zassert_true(dt < CONFIG_ZTEST_CPU_HOLD_TIME_MS,
+		     "1cpu test took too long (%d ms)", dt);
 	arch_irq_unlock(key);
 }
 


### PR DESCRIPTION
3000 milliseconds may not always be enough time for all 1cpu type tests to finish on all platforms. Making the CPU hold time configurable allows for additional flexibility.

Signed-off-by: Peter Mitsis <peter.mitsis@intel.com>