### PR TITLE
Driver: PECI: npcx: fix missing header inclusion

### DIFF
--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -1011,7 +1011,7 @@ int npcx_i2c_ctrl_transfer(const struct device *i2c_dev, struct i2c_msg *msgs,
 		}
 	}
 
-	if (data->oper_state == NPCX_I2C_ERROR_RECOVERY) {
+	if (data->oper_state == NPCX_I2C_ERROR_RECOVERY || ret == -ETIMEDOUT) {
 		int recovery_error = i2c_ctrl_recovery(i2c_dev);
 		/*
 		 * Recovery failed, return it immediately. Otherwise, the upper

--- a/drivers/peci/peci_npcx.c
+++ b/drivers/peci/peci_npcx.c
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/peci.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/kernel.h>
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>


### PR DESCRIPTION
Add the missing zephyr/kernel.h header inclusion to fix the compiler error.
This is required due to the removal of kernel.h from init.h
    
fixes: #51464

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>