### PR TITLE
dts: bindings: nordic,nrf21540-fem: add supply voltage parameter

### DIFF
--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -120,6 +120,7 @@
 		ant-sel-gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
 		mode-gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
 		spi-if = <&nrf_radio_fem_spi>;
+		supply-voltage-mv = <3000>;
 	};
 
 	/* These aliases are provided for compatibility with samples */

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
@@ -58,6 +58,7 @@
 		mode-gpios  = <&gpio1 12 GPIO_ACTIVE_HIGH>;
 		pdn-gpios   = <&gpio1 10 GPIO_ACTIVE_HIGH>;
 		tx-en-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
+		supply-voltage-mv = <3000>;
 	};
 
 	aliases {

--- a/dts/bindings/net/wireless/nordic,nrf21540-fem.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf21540-fem.yaml
@@ -135,3 +135,11 @@ properties:
             Default value is based on Table 6 of the nRF21540 Product
             Specification (v1.0), and can be overridden for tuned
             configurations.
+    supply-voltage-mv:
+        type: int
+        required: false
+        description: |
+            nRF21540 supply voltage in mV.
+
+            This is used if compensation for nRF21540 supply voltage is supported
+            by software.


### PR DESCRIPTION
This commit adds an optional property to the nRF21540 Front-End Module devicetree description that specifies supply voltage in mV. This property can be used by the nRF21540 driver to compensate the value of achieved gain for different supply voltage.

Signed-off-by: Artur Hadasz <artur.hadasz@nordicsemi.no>
Signed-off-by: Jędrzej Ciupis <jedrzej.ciupis@nordicsemi.no>