### PR TITLE
kconfig: wrap description in guiconfig

### DIFF
--- a/scripts/kconfig/guiconfig.py
+++ b/scripts/kconfig/guiconfig.py
@@ -590,7 +590,7 @@ def _create_kconfig_desc(parent):
 
     frame = ttk.Frame(parent)
 
-    desc = Text(frame, height=12, wrap="none", borderwidth=0,
+    desc = Text(frame, height=12, wrap="word", borderwidth=0,
                 state="disabled")
     desc.grid(column=0, row=0, sticky="nsew")
 


### PR DESCRIPTION
Modify description frame to wrap the text so the window doesn't have to be scrolled horizontally.

Signed-off-by: Filip Zajdel <filip.zajdel@nordicsemi.no>