### PR TITLE
shell: added SHELL_AUTOSTART configuration option

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -245,6 +245,11 @@ config SHELL_LOG_FORMAT_TIMESTAMP
 	help
 	  Enable timestamp formatting.
 
+config SHELL_AUTOSTART
+	bool "Auto-start shell at boot"
+	default y
+	help
+	  If enabled, shell will be automatically started.
 
 source "subsys/shell/modules/Kconfig"
 

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1321,10 +1321,12 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 					   log_level);
 	}
 
-	/* Enable shell and print prompt. */
-	err = shell_start(shell);
-	if (err != 0) {
-		return;
+	if (IS_ENABLED(CONFIG_SHELL_AUTOSTART)) {
+		/* Enable shell and print prompt. */
+		err = shell_start(shell);
+		if (err != 0) {
+			return;
+		}
 	}
 
 	while (true) {


### PR DESCRIPTION
In some applications, there is a need to don't start the shell by default, but run it later on some special condition. When SHELL_AUTOSTART is set to n, the shell is not started after boot but can be enabled later from the application code.

Signed-off-by: Wojciech Slenska <wsl@trackunit.com>