### PR TITLE
canbus: isotp: various 64 bit fixes

### DIFF
--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -1177,7 +1177,7 @@ static int send(struct isotp_send_ctx *ctx, const struct device *can_dev,
 	z_init_timeout(&ctx->timeout);
 
 	len = get_ctx_data_length(ctx);
-	LOG_DBG("Send %d bytes to addr 0x%x and listen on 0x%x", len,
+	LOG_DBG("Send %zu bytes to addr 0x%x and listen on 0x%x", len,
 		ctx->tx_addr.ext_id, ctx->rx_addr.ext_id);
 	if (len > ISOTP_CAN_DL - (tx_addr->use_ext_addr ? 2 : 1)) {
 		ret = attach_fc_filter(ctx);

--- a/tests/subsys/canbus/isotp/conformance/src/main.c
+++ b/tests/subsys/canbus/isotp/conformance/src/main.c
@@ -125,9 +125,9 @@ uint8_t data_buf[128];
 CAN_MSGQ_DEFINE(frame_msgq, 10);
 struct k_sem send_compl_sem;
 
-void send_complette_cb(int error_nr, void *arg)
+void send_complete_cb(int error_nr, void *arg)
 {
-	int expected_err_nr = (int) arg;
+	int expected_err_nr = POINTER_TO_INT(arg);
 
 	zassert_equal(error_nr, expected_err_nr,
 		      "Unexpected error nr. expect: %d, got %d",
@@ -151,7 +151,7 @@ static int check_data(const uint8_t *frame, const uint8_t *desired, size_t lengt
 	if (ret) {
 		printk("desired bytes:\n");
 		print_hex(desired, length);
-		printk("\nreceived (%d bytes):\n", length);
+		printk("\nreceived (%zu bytes):\n", length);
 		print_hex(frame, length);
 		printk("\n");
 	}
@@ -164,7 +164,7 @@ static void send_sf(void)
 	int ret;
 
 	ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SIZE_SF,
-			 &rx_addr, &tx_addr, send_complette_cb, ISOTP_N_OK);
+			 &rx_addr, &tx_addr, send_complete_cb, INT_TO_POINTER(ISOTP_N_OK));
 	zassert_equal(ret, 0, "Send returned %d", ret);
 }
 
@@ -194,7 +194,7 @@ static void send_test_data(const uint8_t *data, size_t len)
 	int ret;
 
 	ret = isotp_send(&send_ctx, can_dev, data, len, &rx_addr, &tx_addr,
-			 send_complette_cb, ISOTP_N_OK);
+			 send_complete_cb, INT_TO_POINTER(ISOTP_N_OK));
 	zassert_equal(ret, 0, "Send returned %d", ret);
 }
 
@@ -389,8 +389,8 @@ ZTEST(isotp_conformance, test_send_sf_ext)
 		     filter_id);
 
 	ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SIZE_SF_EXT,
-			 &rx_addr_ext, &tx_addr_ext, send_complette_cb,
-			  ISOTP_N_OK);
+			 &rx_addr_ext, &tx_addr_ext, send_complete_cb,
+			 INT_TO_POINTER(ISOTP_N_OK));
 	zassert_equal(ret, 0, "Send returned %d", ret);
 
 	check_frame_series(&des_frame, 1, &frame_msgq);
@@ -445,8 +445,8 @@ ZTEST(isotp_conformance, test_send_sf_fixed)
 		     filter_id);
 
 	ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SIZE_SF,
-			 &rx_addr_fixed, &tx_addr_fixed, send_complette_cb,
-			 ISOTP_N_OK);
+			 &rx_addr_fixed, &tx_addr_fixed, send_complete_cb,
+			 INT_TO_POINTER(ISOTP_N_OK));
 	zassert_equal(ret, 0, "Send returned %d", ret);
 
 	check_frame_series(&des_frame, 1, &frame_msgq);
@@ -717,8 +717,8 @@ ZTEST(isotp_conformance, test_send_timeouts)
 	/* Test timeout for consecutive FC frames */
 	k_sem_reset(&send_compl_sem);
 	ret = isotp_send(&send_ctx, can_dev, random_data, sizeof(random_data),
-			 &tx_addr, &rx_addr, send_complette_cb,
-			 (void *)ISOTP_N_TIMEOUT_BS);
+			 &tx_addr, &rx_addr, send_complete_cb,
+			 INT_TO_POINTER(ISOTP_N_TIMEOUT_BS));
 	zassert_equal(ret, ISOTP_N_OK, "Send returned %d", ret);
 
 	send_frame_series(&fc_cts_frame, 1, rx_addr.std_id);
@@ -734,8 +734,8 @@ ZTEST(isotp_conformance, test_send_timeouts)
 	/* Test timeout reset with WAIT frame */
 	k_sem_reset(&send_compl_sem);
 	ret = isotp_send(&send_ctx, can_dev, random_data, sizeof(random_data),
-			 &tx_addr, &rx_addr, send_complette_cb,
-			 (void *)ISOTP_N_TIMEOUT_BS);
+			 &tx_addr, &rx_addr, send_complete_cb,
+			 INT_TO_POINTER(ISOTP_N_TIMEOUT_BS));
 	zassert_equal(ret, ISOTP_N_OK, "Send returned %d", ret);
 
 	ret = k_sem_take(&send_compl_sem, K_MSEC(800));
@@ -908,8 +908,8 @@ ZTEST(isotp_conformance, test_sender_fc_errors)
 
 	k_sem_reset(&send_compl_sem);
 	ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SEND_LENGTH,
-			 &tx_addr, &rx_addr, send_complette_cb,
-			 (void *)ISOTP_N_INVALID_FS);
+			 &tx_addr, &rx_addr, send_complete_cb,
+			 INT_TO_POINTER(ISOTP_N_INVALID_FS));
 	zassert_equal(ret, ISOTP_N_OK, "Send returned %d", ret);
 
 	check_frame_series(&ff_frame, 1, &frame_msgq);
@@ -932,8 +932,8 @@ ZTEST(isotp_conformance, test_sender_fc_errors)
 
 	k_sem_reset(&send_compl_sem);
 	ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SEND_LENGTH,
-			 &tx_addr, &rx_addr, send_complette_cb,
-			 (void *)ISOTP_N_BUFFER_OVERFLW);
+			 &tx_addr, &rx_addr, send_complete_cb,
+			 INT_TO_POINTER(ISOTP_N_BUFFER_OVERFLW));
 
 	check_frame_series(&ff_frame, 1, &frame_msgq);
 	fc_frame.data[0] = FC_PCI_BYTE_1(FC_PCI_OVFLW);
@@ -944,8 +944,8 @@ ZTEST(isotp_conformance, test_sender_fc_errors)
 	/* wft overrun */
 	k_sem_reset(&send_compl_sem);
 	ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SEND_LENGTH,
-			 &tx_addr, &rx_addr, send_complette_cb,
-			 (void *)ISOTP_N_WFT_OVRN);
+			 &tx_addr, &rx_addr, send_complete_cb,
+			 INT_TO_POINTER(ISOTP_N_WFT_OVRN));
 
 	check_frame_series(&ff_frame, 1, &frame_msgq);
 	fc_frame.data[0] = FC_PCI_BYTE_1(FC_PCI_WAIT);

--- a/tests/subsys/canbus/isotp/implementation/src/main.c
+++ b/tests/subsys/canbus/isotp/implementation/src/main.c
@@ -50,7 +50,7 @@ struct isotp_recv_ctx recv_ctx;
 struct isotp_send_ctx send_ctx;
 uint8_t data_buf[128];
 
-void send_complette_cb(int error_nr, void *arg)
+void send_complete_cb(int error_nr, void *arg)
 {
 	zassert_equal(error_nr, ISOTP_N_OK, "Sending failed (%d)", error_nr);
 }
@@ -60,7 +60,7 @@ static void send_sf(const struct device *can_dev)
 	int ret;
 
 	ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SIZE_SF,
-			 &rx_addr, &tx_addr, send_complette_cb, NULL);
+			 &rx_addr, &tx_addr, send_complete_cb, NULL);
 	zassert_equal(ret, 0, "Send returned %d", ret);
 }
 
@@ -110,7 +110,7 @@ static void send_test_data(const struct device *can_dev, const uint8_t *data,
 	int ret;
 
 	ret = isotp_send(&send_ctx, can_dev, data, len, &rx_addr, &tx_addr,
-			  send_complette_cb, NULL);
+			  send_complete_cb, NULL);
 	zassert_equal(ret, 0, "Send returned %d", ret);
 }
 
@@ -168,7 +168,7 @@ static void check_data(const uint8_t *recv_data, const uint8_t *send_data, size_
 	if (ret) {
 		printk("expected bytes:\n");
 		print_hex(send_data, len);
-		printk("\nreceived (%d bytes):\n", len);
+		printk("\nreceived (%zu bytes):\n", len);
 		print_hex(recv_data, len);
 		printk("\n");
 	}


### PR DESCRIPTION
- Fix the format specifier for logging size_t values.
- Fix typo in function name while here.
- Avoid casting integers to pointers and vice versa.