### PR TITLE
Bluetooth: Audio: Factor out bt_audio_iso pool

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1297,8 +1297,6 @@ struct bt_audio_stream {
 	const struct bt_codec *codec;
 	/** QoS Configuration */
 	struct bt_codec_qos *qos;
-	/** ISO channel reference */
-	struct bt_iso_chan *iso;
 	/** Audio stream operations */
 	struct bt_audio_stream_ops *ops;
 

--- a/subsys/bluetooth/audio/CMakeLists.txt
+++ b/subsys/bluetooth/audio/CMakeLists.txt
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-zephyr_library_sources(audio.c)
+zephyr_library_sources(
+	audio.c
+	audio_iso.c
+)
 
 if (CONFIG_BT_VOCS OR CONFIG_BT_VOCS_CLIENT)
 	zephyr_library_sources(vocs.c)

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -32,6 +32,7 @@
 #include "../host/conn_internal.h"
 
 #include "audio_internal.h"
+#include "audio_iso.h"
 #include "endpoint.h"
 #include "unicast_server.h"
 #include "pacs_internal.h"
@@ -54,10 +55,6 @@ struct bt_ascs_ase {
 struct bt_ascs {
 	struct bt_conn *conn;
 	struct bt_ascs_ase ases[ASE_COUNT];
-	/* A single iso_channel may be used for 1 or 2 ases.
-	 * Controlled by the client.
-	 */
-	struct bt_audio_iso isos[ASE_COUNT];
 };
 
 static struct bt_ascs sessions[CONFIG_BT_MAX_CONN];
@@ -68,33 +65,6 @@ static void ase_status_changed(struct bt_audio_ep *ep, uint8_t old_state,
 			       uint8_t state)
 {
 	k_work_submit(&ep->work);
-}
-
-static void ascs_ep_unbind_audio_iso(struct bt_audio_ep *ep)
-{
-	struct bt_audio_iso *audio_iso = ep->iso;
-	struct bt_audio_stream *stream = ep->stream;
-
-	if (audio_iso != NULL) {
-		struct bt_iso_chan_qos *qos;
-
-		qos = audio_iso->iso_chan.qos;
-
-		BT_ASSERT_MSG(stream != NULL, "Stream was NULL");
-
-		stream->iso = NULL;
-		if (audio_iso->sink_stream == stream) {
-			audio_iso->sink_stream = NULL;
-			qos->rx = NULL;
-		} else if (audio_iso->source_stream == stream) {
-			audio_iso->source_stream = NULL;
-			qos->tx = NULL;
-		} else {
-			BT_ERR("Stream %p not linked to audio_iso %p", stream, audio_iso);
-		}
-	}
-
-	ep->iso = NULL;
 }
 
 void ascs_ep_set_state(struct bt_audio_ep *ep, uint8_t state)
@@ -290,12 +260,6 @@ void ascs_ep_set_state(struct bt_audio_ep *ep, uint8_t state)
 			break;
 		}
 	}
-
-	if (state_changed &&
-	    state == BT_AUDIO_EP_STATE_CODEC_CONFIGURED &&
-	    old_state != BT_AUDIO_EP_STATE_IDLE) {
-		ascs_ep_unbind_audio_iso(ep);
-	}
 }
 
 static void ascs_codec_data_add(struct net_buf_simple *buf, const char *prefix,
@@ -438,29 +402,26 @@ static void ascs_iso_recv(struct bt_iso_chan *chan,
 			  const struct bt_iso_recv_info *info,
 			  struct net_buf *buf)
 {
-	struct bt_audio_iso *audio_iso = CONTAINER_OF(chan, struct bt_audio_iso,
-						      iso_chan);
-	struct bt_audio_stream *stream = audio_iso->sink_stream;
+	struct bt_audio_iso *iso = CONTAINER_OF(chan, struct bt_audio_iso, chan);
 	const struct bt_audio_stream_ops *ops;
+	struct bt_audio_stream *stream;
+	struct bt_audio_ep *ep;
 
-	if (stream == NULL) {
-		BT_ERR("Could not lookup stream by iso %p", chan);
-		return;
-	} else if (stream->ep == NULL) {
-		BT_ERR("Stream not associated with an ep");
+	ep = iso->rx.ep;
+	if (ep == NULL) {
+		BT_ERR("iso %p not bound with ep", chan);
 		return;
 	}
 
-	/* Since 2 streams can share the same CIS, the CIS may be connected and
-	 * capable of transferring data, without the bt_audio_stream being in
-	 * the streaming state. In that case we simply ignore the data.
-	 */
-	if (stream->ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
-		if (IS_ENABLED(CONFIG_BT_AUDIO_DEBUG_STREAM_DATA)) {
-			BT_DBG("Stream %p is not in the streaming state: %u",
-			       stream, stream->ep->status.state);
-		}
+	if (ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
+		BT_DBG("ep %p is not in the streaming state: %s",
+		       ep, bt_audio_ep_state_str(ep->status.state));
+		return;
+	}
 
+	stream = ep->stream;
+	if (stream == NULL) {
+		BT_ERR("No stream for ep %p", ep);
 		return;
 	}
 
@@ -468,7 +429,7 @@ static void ascs_iso_recv(struct bt_iso_chan *chan,
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_DEBUG_STREAM_DATA)) {
 		BT_DBG("stream %p ep %p len %zu",
-		       stream, stream->ep, net_buf_frags_len(buf));
+		       stream, ep, net_buf_frags_len(buf));
 	}
 
 	if (ops != NULL && ops->recv != NULL) {
@@ -480,13 +441,27 @@ static void ascs_iso_recv(struct bt_iso_chan *chan,
 
 static void ascs_iso_sent(struct bt_iso_chan *chan)
 {
-	struct bt_audio_iso *audio_iso = CONTAINER_OF(chan, struct bt_audio_iso,
-						      iso_chan);
-	struct bt_audio_stream *stream = audio_iso->source_stream;
-	struct bt_audio_stream_ops *ops = stream->ops;
+	struct bt_audio_iso *iso = CONTAINER_OF(chan, struct bt_audio_iso, chan);
+	const struct bt_audio_stream_ops *ops;
+	struct bt_audio_stream *stream;
+	struct bt_audio_ep *ep;
+
+	ep = iso->tx.ep;
+	if (ep == NULL) {
+		BT_ERR("iso %p not bound with ep", chan);
+		return;
+	}
+
+	stream = ep->stream;
+	if (stream == NULL) {
+		BT_ERR("No stream for ep %p", ep);
+		return;
+	}
+
+	ops = stream->ops;
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_DEBUG_STREAM_DATA)) {
-		BT_DBG("stream %p ep %p", stream, stream->ep);
+		BT_DBG("stream %p ep %p", stream, ep);
 	}
 
 	if (ops != NULL && ops->sent != NULL) {
@@ -509,43 +484,24 @@ static int ase_stream_start(struct bt_audio_stream *stream)
 	return err;
 }
 
-static void ascs_iso_connected(struct bt_iso_chan *chan)
+static void ascs_ep_iso_connected(struct bt_audio_ep *ep)
 {
-	struct bt_audio_iso *audio_iso = CONTAINER_OF(chan, struct bt_audio_iso,
-						      iso_chan);
-	struct bt_audio_stream *source_stream = audio_iso->source_stream;
-	struct bt_audio_stream *sink_stream = audio_iso->sink_stream;
 	struct bt_audio_stream *stream;
-	struct bt_audio_ep *ep;
 	int err;
 
-	if (sink_stream != NULL && sink_stream->iso == chan) {
-		stream = sink_stream;
-	} else if (source_stream != NULL && source_stream->iso == chan) {
-		stream = source_stream;
-	} else {
-		stream = NULL;
-	}
-
-	if (stream == NULL) {
-		BT_ERR("Could not lookup stream by iso %p", chan);
-		return;
-	} else if (stream->ep == NULL) {
-		BT_ERR("Stream not associated with an ep");
-		return;
-	}
-
-	ep = stream->ep;
-
-	BT_DBG("stream %p ep %p dir %u", stream, ep, ep->dir);
-
 	if (ep->status.state != BT_AUDIO_EP_STATE_ENABLING) {
-		BT_DBG("endpoint not in enabling state: %s",
-		       bt_audio_ep_state_str(ep->status.state));
+		BT_DBG("ep %p not in enabling state: %s",
+		       ep, bt_audio_ep_state_str(ep->status.state));
 		return;
 	}
 
 	if (ep->dir == BT_AUDIO_DIR_SOURCE && !ep->receiver_ready) {
+		return;
+	}
+
+	stream = ep->stream;
+	if (stream == NULL) {
+		BT_ERR("No stream for ep %p", ep);
 		return;
 	}
 
@@ -555,35 +511,38 @@ static void ascs_iso_connected(struct bt_iso_chan *chan)
 	}
 }
 
-static void ascs_iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
+static void ascs_iso_connected(struct bt_iso_chan *chan)
 {
-	struct bt_audio_iso *audio_iso = CONTAINER_OF(chan, struct bt_audio_iso,
-						      iso_chan);
-	struct bt_audio_stream *source_stream = audio_iso->source_stream;
-	struct bt_audio_stream *sink_stream = audio_iso->sink_stream;
-	const struct bt_audio_stream_ops *ops;
-	struct bt_audio_stream *stream;
-	struct bt_audio_ep *ep;
+	struct bt_audio_iso *iso = CONTAINER_OF(chan, struct bt_audio_iso, chan);
 
-	if (sink_stream != NULL && sink_stream->iso == chan) {
-		stream = sink_stream;
-	} else if (source_stream != NULL && source_stream->iso == chan) {
-		stream = source_stream;
-	} else {
-		stream = NULL;
+	if (iso->rx.ep == NULL && iso->tx.ep == NULL) {
+		BT_ERR("iso %p not bound with ep", chan);
+		return;
 	}
 
+	if (iso->rx.ep != NULL) {
+		ascs_ep_iso_connected(iso->rx.ep);
+	}
+
+	if (iso->tx.ep != NULL) {
+		ascs_ep_iso_connected(iso->tx.ep);
+	}
+}
+
+static void ascs_ep_iso_disconnected(struct bt_audio_ep *ep, uint8_t reason)
+{
+	const struct bt_audio_stream_ops *ops;
+	struct bt_audio_stream *stream;
+
+	stream = ep->stream;
 	if (stream == NULL) {
-		BT_ERR("Could not lookup stream by iso %p", chan);
-		return;
-	} else if (stream->ep == NULL) {
-		BT_ERR("Stream not associated with an ep");
+		BT_ERR("No stream for ep %p", ep);
 		return;
 	}
 
 	ops = stream->ops;
 
-	BT_DBG("stream %p ep %p reason 0x%02x", stream, stream->ep, reason);
+	BT_DBG("stream %p ep %p reason 0x%02x", stream, ep, reason);
 
 	if (ops != NULL && ops->stopped != NULL) {
 		ops->stopped(stream);
@@ -591,8 +550,9 @@ static void ascs_iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 		BT_WARN("No callback for stopped set");
 	}
 
-	ep = stream->ep;
 	if (ep->status.state == BT_AUDIO_EP_STATE_RELEASING) {
+		bt_audio_iso_unbind_ep(ep->iso, ep);
+
 		/* Trigger a call to ase_process to handle the cleanup */
 		k_work_submit(&ep->work);
 	} else {
@@ -611,6 +571,24 @@ static void ascs_iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 		if (err != 0) {
 			BT_ERR("Could not make stream listen: %d", err);
 		}
+	}
+}
+
+static void ascs_iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
+{
+	struct bt_audio_iso *iso = CONTAINER_OF(chan, struct bt_audio_iso, chan);
+
+	if (iso->rx.ep == NULL && iso->tx.ep == NULL) {
+		BT_ERR("iso %p not bound with ep", chan);
+		return;
+	}
+
+	if (iso->rx.ep != NULL) {
+		ascs_ep_iso_disconnected(iso->rx.ep, reason);
+	}
+
+	if (iso->tx.ep != NULL) {
+		ascs_ep_iso_disconnected(iso->tx.ep, reason);
 	}
 }
 
@@ -858,57 +836,54 @@ BT_CONN_CB_DEFINE(conn_cb) = {
 	.disconnected = disconnected,
 };
 
-static void audio_iso_init(struct bt_audio_iso *audio_iso)
+struct audio_iso_find_params {
+	struct bt_conn *acl;
+	uint8_t cig_id;
+	uint8_t cis_id;
+};
+
+static bool audio_iso_find_func(struct bt_audio_iso *iso, void *user_data)
 {
-	/* Setup points for both sink and source
-	 * This is due to the limitation in the ISO API where pointers like
-	 * the `qos->tx` shall be initialized before the CIS is connected if
-	 * ever want to use it for TX, and ditto for RX. They cannot be
-	 * initialized after the CIS has been connected
-	 */
-	audio_iso->iso_chan.ops = &ascs_iso_ops;
-	audio_iso->iso_chan.qos = &audio_iso->iso_qos;
+	struct audio_iso_find_params *params = user_data;
+	const struct bt_audio_ep *ep;
 
-	audio_iso->iso_chan.qos->tx = &audio_iso->source_io_qos;
-	audio_iso->iso_chan.qos->tx->path = &audio_iso->source_path;
-	audio_iso->iso_chan.qos->tx->path->cc = audio_iso->source_path_cc;
-
-	audio_iso->iso_chan.qos->rx = &audio_iso->sink_io_qos;
-	audio_iso->iso_chan.qos->rx->path = &audio_iso->sink_path;
-	audio_iso->iso_chan.qos->rx->path->cc = audio_iso->sink_path_cc;
-}
-
-static struct bt_audio_iso *audio_iso_get_or_new(struct bt_ascs *ascs, uint8_t cig_id,
-						 uint8_t cis_id)
-{
-	struct bt_audio_iso *free_audio_iso = NULL;
-
-	BT_DBG("ascs %p cig_id 0x%02x cis_id 0x%02x", ascs, cis_id, cis_id);
-
-	for (size_t i = 0; i < ARRAY_SIZE(ascs->isos); i++) {
-		struct bt_audio_iso *audio_iso = &ascs->isos[i];
-		const struct bt_audio_ep *ep;
-
-		if (audio_iso->sink_stream == NULL && audio_iso->source_stream == NULL) {
-			free_audio_iso = audio_iso;
-			continue;
-		} else if (audio_iso->sink_stream && audio_iso->sink_stream->ep) {
-			ep = audio_iso->sink_stream->ep;
-		} else if (audio_iso->source_stream && audio_iso->source_stream->ep) {
-			ep = audio_iso->source_stream->ep;
-		} else {
-			/* XXX: Stream not associated with endpoint. Should we assert??? */
-			continue;
-		}
-
-		if (ep->cig_id == cig_id && ep->cis_id == cis_id) {
-			return audio_iso;
-		}
+	if (iso->rx.ep != NULL) {
+		ep = iso->rx.ep;
+	} else if (iso->tx.ep != NULL) {
+		ep = iso->tx.ep;
+	} else {
+		return false;
 	}
 
-	audio_iso_init(free_audio_iso);
+	return ep->stream->conn == params->acl &&
+	       ep->cig_id == params->cig_id &&
+	       ep->cis_id == params->cis_id;
+}
 
-	return free_audio_iso;
+static struct bt_audio_iso *audio_iso_get_or_new(struct bt_ascs *ascs,
+						 uint8_t cig_id,
+						 uint8_t cis_id)
+{
+	struct bt_audio_iso *iso;
+	struct audio_iso_find_params params = {
+		.acl = ascs->conn,
+		.cig_id = cig_id,
+		.cis_id = cis_id,
+	};
+
+	iso = bt_audio_iso_find(audio_iso_find_func, &params);
+	if (iso) {
+		return iso;
+	}
+
+	iso = bt_audio_iso_new();
+	if (!iso) {
+		return NULL;
+	}
+
+	bt_audio_iso_init(iso, &ascs_iso_ops);
+
+	return iso;
 }
 
 static void ase_stream_add(struct bt_ascs *ascs, struct bt_ascs_ase *ase,
@@ -918,7 +893,6 @@ static void ase_stream_add(struct bt_ascs *ascs, struct bt_ascs_ase *ase,
 	ase->ep.stream = stream;
 	stream->conn = ascs->conn;
 	stream->ep = &ase->ep;
-	stream->iso = &ase->ep.iso->iso_chan;
 }
 
 static struct bt_ascs *ascs_get(struct bt_conn *conn)
@@ -938,7 +912,6 @@ static void ase_process(struct k_work *work)
 {
 	struct bt_audio_ep *ep = CONTAINER_OF(work, struct bt_audio_ep, work);
 	struct bt_ascs_ase *ase = CONTAINER_OF(ep, struct bt_ascs_ase, ep);
-	const struct bt_audio_iso *audio_iso = ep->iso;
 	struct bt_audio_stream *stream = ep->stream;
 	const uint8_t ep_state = ep->status.state;
 	struct bt_conn *conn = ase->ascs->conn;
@@ -958,10 +931,8 @@ static void ase_process(struct k_work *work)
 		 "stream is NULL");
 
 	if (ep_state == BT_AUDIO_EP_STATE_RELEASING) {
-
-		if (audio_iso == NULL ||
-		    audio_iso->iso_chan.state == BT_ISO_STATE_DISCONNECTED) {
-			ascs_ep_unbind_audio_iso(ep);
+		if (ep->iso == NULL ||
+		    ep->iso->chan.state == BT_ISO_STATE_DISCONNECTED) {
 			bt_audio_stream_detach(stream);
 			ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_IDLE);
 		} else {
@@ -980,8 +951,8 @@ static void ase_process(struct k_work *work)
 		 * the CIS is connected
 		 */
 		if (ep->dir == BT_AUDIO_DIR_SINK &&
-		    audio_iso != NULL &&
-		    audio_iso->iso_chan.state == BT_ISO_STATE_CONNECTED) {
+		    ep->iso != NULL &&
+		    ep->iso->chan.state == BT_ISO_STATE_CONNECTED) {
 			ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_STREAMING);
 		}
 	}
@@ -999,37 +970,6 @@ static uint8_t ase_attr_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 	}
 
 	return BT_GATT_ITER_CONTINUE;
-}
-
-static int ascs_ep_stream_bind_audio_iso(struct bt_audio_stream *stream,
-					 struct bt_audio_iso *audio_iso)
-{
-	const enum bt_audio_dir dir = stream->ep->dir;
-
-	BT_DBG("stream %p, dir %u audio_iso %p", stream, dir, audio_iso);
-
-	if (dir == BT_AUDIO_DIR_SOURCE) {
-		if (audio_iso->source_stream == NULL) {
-			audio_iso->source_stream = stream;
-		} else if (audio_iso->source_stream != stream) {
-			BT_WARN("Bound with source_stream %p already", audio_iso->source_stream);
-			return -EADDRINUSE;
-		}
-	} else if (dir == BT_AUDIO_DIR_SINK) {
-		if (audio_iso->sink_stream == NULL) {
-			audio_iso->sink_stream = stream;
-		} else if (audio_iso->sink_stream != stream) {
-			BT_WARN("Bound with sink_stream %p already", audio_iso->sink_stream);
-			return -EADDRINUSE;
-		}
-	} else {
-		__ASSERT(false, "Invalid dir: %u", dir);
-	}
-
-	stream->iso = &audio_iso->iso_chan;
-	stream->ep->iso = audio_iso;
-
-	return 0;
 }
 
 void ascs_ep_init(struct bt_audio_ep *ep, uint8_t id)
@@ -1444,9 +1384,8 @@ static int ase_stream_qos(struct bt_audio_stream *stream,
 			  uint8_t cig_id,
 			  uint8_t cis_id)
 {
-	struct bt_audio_iso *audio_iso;
+	struct bt_audio_iso *iso;
 	struct bt_audio_ep *ep;
-	int err;
 
 	BT_DBG("stream %p ep %p qos %p", stream, stream->ep, qos);
 
@@ -1486,16 +1425,21 @@ static int ase_stream_qos(struct bt_audio_stream *stream,
 		}
 	}
 
-	audio_iso = audio_iso_get_or_new(ascs, cig_id, cis_id);
-	if (audio_iso == NULL) {
+	iso = audio_iso_get_or_new(ascs, cig_id, cis_id);
+	if (iso == NULL) {
 		BT_ERR("Could not allocate audio_iso");
 		return -ENOMEM;
 	}
 
-	err = ascs_ep_stream_bind_audio_iso(stream, audio_iso);
-	if (err < 0) {
-		return err;
+	if (bt_audio_iso_get_ep(iso, ep->dir) != NULL) {
+		BT_ERR("iso %p already in use in dir %u",
+		       &iso->chan, ep->dir);
+		bt_audio_iso_unref(iso);
+		return -EALREADY;
 	}
+
+	bt_audio_iso_bind_ep(iso, ep);
+	bt_audio_iso_unref(iso);
 
 	stream->qos = qos;
 
@@ -1567,10 +1511,10 @@ static void ase_qos(struct bt_ascs_ase *ase, const struct bt_ascs_qos *qos)
 		 * the CIS ID in the QoS procedure).
 		 */
 		if (ep->dir == BT_AUDIO_DIR_SINK) {
-			bt_audio_codec_to_iso_path(&ep->iso->sink_path,
+			bt_audio_codec_to_iso_path(&ep->iso->rx.path,
 						   stream->codec);
 		} else {
-			bt_audio_codec_to_iso_path(&ep->iso->source_path,
+			bt_audio_codec_to_iso_path(&ep->iso->tx.path,
 						   stream->codec);
 		}
 	}
@@ -1971,7 +1915,6 @@ static ssize_t ascs_enable(struct bt_ascs *ascs, struct net_buf_simple *buf)
 
 static void ase_start(struct bt_ascs_ase *ase)
 {
-	struct bt_audio_stream *stream;
 	struct bt_audio_ep *ep;
 
 	BT_DBG("ase %p", ase);
@@ -2001,11 +1944,10 @@ static void ase_start(struct bt_ascs_ase *ase)
 
 	ep->receiver_ready = true;
 
-	stream = ep->stream;
-	if (stream->iso->state == BT_ISO_STATE_CONNECTED) {
+	if (ep->iso->chan.state == BT_ISO_STATE_CONNECTED) {
 		int err;
 
-		err = ase_stream_start(stream);
+		err = ase_stream_start(ep->stream);
 		if (err) {
 			BT_ERR("Start failed: %d", err);
 			ascs_cp_rsp_add(ASE_ID(ase), BT_ASCS_START_OP, err,

--- a/subsys/bluetooth/audio/audio_iso.c
+++ b/subsys/bluetooth/audio/audio_iso.c
@@ -1,0 +1,204 @@
+/* audio_iso.c - Audio ISO handling */
+
+/*
+ * Copyright (c) 2022 Codecoup
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "audio_iso.h"
+#include "endpoint.h"
+
+/* TODO: Optimize the ISO_POOL_SIZE */
+#define ISO_POOL_SIZE CONFIG_BT_ISO_MAX_CHAN
+
+static struct bt_audio_iso iso_pool[ISO_POOL_SIZE];
+
+struct bt_audio_iso *bt_audio_iso_new(void)
+{
+	struct bt_audio_iso *iso = NULL;
+
+	for (size_t i = 0; i < ARRAY_SIZE(iso_pool); i++) {
+		if (atomic_cas(&iso_pool[i].ref, 0, 1)) {
+			iso = &iso_pool[i];
+			break;
+		}
+	}
+
+	if (!iso) {
+		return NULL;
+	}
+
+	(void)memset(iso, 0, offsetof(struct bt_audio_iso, ref));
+
+	return iso;
+}
+
+struct bt_audio_iso *bt_audio_iso_ref(struct bt_audio_iso *iso)
+{
+	atomic_val_t old;
+
+	__ASSERT_NO_MSG(iso != NULL);
+
+	/* Reference counter must be checked to avoid incrementing ref from
+	 * zero, then we should return NULL instead.
+	 * Loop on clear-and-set in case someone has modified the reference
+	 * count since the read, and start over again when that happens.
+	 */
+	do {
+		old = atomic_get(&iso->ref);
+
+		if (!old) {
+			return NULL;
+		}
+	} while (!atomic_cas(&iso->ref, old, old + 1));
+
+	return iso;
+}
+
+void bt_audio_iso_unref(struct bt_audio_iso *iso)
+{
+	atomic_val_t old;
+
+	__ASSERT_NO_MSG(iso != NULL);
+
+	old = atomic_dec(&iso->ref);
+
+	__ASSERT(old > 0, "iso reference counter is 0");
+}
+
+void bt_audio_iso_foreach(bt_audio_iso_func_t func, void *user_data)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(iso_pool); i++) {
+		struct bt_audio_iso *iso = bt_audio_iso_ref(&iso_pool[i]);
+		bool iter;
+
+		if (!iso) {
+			continue;
+		}
+
+		iter = func(iso, user_data);
+		bt_audio_iso_unref(iso);
+
+		if (!iter) {
+			return;
+		}
+	}
+}
+
+struct bt_audio_iso_find_param {
+	struct bt_audio_iso *iso;
+	bt_audio_iso_func_t func;
+	void *user_data;
+};
+
+static bool bt_audio_iso_find_cb(struct bt_audio_iso *iso, void *user_data)
+{
+	struct bt_audio_iso_find_param *param = user_data;
+	bool found;
+
+	found = param->func(iso, param->user_data);
+	if (found) {
+		param->iso = bt_audio_iso_ref(iso);
+	}
+
+	return !found;
+}
+
+struct bt_audio_iso *bt_audio_iso_find(bt_audio_iso_func_t func,
+				       void *user_data)
+{
+	struct bt_audio_iso_find_param param = {
+		.iso = NULL,
+		.func = func,
+		.user_data = user_data,
+	};
+
+	bt_audio_iso_foreach(bt_audio_iso_find_cb, &param);
+
+	return param.iso;
+}
+
+void bt_audio_iso_init(struct bt_audio_iso *iso, struct bt_iso_chan_ops *ops)
+{
+	iso->chan.ops = ops;
+	iso->chan.qos = &iso->qos;
+
+	/* Setup points for both Tx and Rx
+	 * This is due to the limitation in the ISO API where pointers like
+	 * the `qos->tx` shall be initialized before the CIS is connected if
+	 * ever want to use it for TX, and ditto for RX. They cannot be
+	 * initialized after the CIS has been connected
+	 */
+	iso->chan.qos->rx = &iso->rx.qos;
+	iso->chan.qos->rx->path = &iso->rx.path;
+	iso->chan.qos->rx->path->cc = iso->rx.cc;
+
+	iso->chan.qos->tx = &iso->tx.qos;
+	iso->chan.qos->tx->path = &iso->tx.path;
+	iso->chan.qos->tx->path->cc = iso->tx.cc;
+}
+
+void bt_audio_iso_bind_ep(struct bt_audio_iso *iso, struct bt_audio_ep *ep)
+{
+	struct bt_iso_chan_qos *qos;
+
+	__ASSERT_NO_MSG(ep != NULL);
+	__ASSERT_NO_MSG(iso != NULL);
+	__ASSERT(ep->iso == NULL, "ep %p bound with iso %p already", ep, ep->iso);
+	__ASSERT(ep->dir == BT_AUDIO_DIR_SINK || ep->dir == BT_AUDIO_DIR_SOURCE,
+		 "invalid dir: %u", ep->dir);
+
+	qos = iso->chan.qos;
+
+	if (ep->dir == BT_AUDIO_DIR_SINK) {
+		__ASSERT(iso->rx.ep == NULL,
+			 "iso %p bound with ep %p", iso, iso->rx.ep);
+		iso->rx.ep = ep;
+	} else {
+		__ASSERT(iso->tx.ep == NULL,
+			 "iso %p bound with ep %p", iso, iso->tx.ep);
+		iso->tx.ep = ep;
+	}
+
+	ep->iso = bt_audio_iso_ref(iso);
+}
+
+void bt_audio_iso_unbind_ep(struct bt_audio_iso *iso, struct bt_audio_ep *ep)
+{
+	struct bt_iso_chan_qos *qos;
+
+	__ASSERT_NO_MSG(ep != NULL);
+	__ASSERT_NO_MSG(iso != NULL);
+	__ASSERT(ep->iso, "ep %p not bound with iso", iso, ep);
+	__ASSERT(ep->dir == BT_AUDIO_DIR_SINK || ep->dir == BT_AUDIO_DIR_SOURCE,
+		 "Invalid dir: %u", ep->dir);
+
+	qos = iso->chan.qos;
+
+	if (ep->dir == BT_AUDIO_DIR_SINK) {
+		__ASSERT(iso->rx.ep == ep,
+			 "iso %p not bound with ep %p", iso, ep);
+		iso->rx.ep = NULL;
+	} else  {
+		__ASSERT(iso->tx.ep == ep,
+			 "iso %p not bound with ep %p", iso, ep);
+		iso->tx.ep = NULL;
+	}
+
+	bt_audio_iso_unref(ep->iso);
+	ep->iso = NULL;
+}
+
+struct bt_audio_ep *bt_audio_iso_get_ep(struct bt_audio_iso *iso,
+					enum bt_audio_dir dir)
+{
+	__ASSERT(dir == BT_AUDIO_DIR_SINK || dir == BT_AUDIO_DIR_SOURCE,
+		 "invalid dir: %u", dir);
+
+	if (dir == BT_AUDIO_DIR_SINK) {
+		return iso->rx.ep;
+	} else {
+		return iso->tx.ep;
+	}
+}

--- a/subsys/bluetooth/audio/audio_iso.h
+++ b/subsys/bluetooth/audio/audio_iso.h
@@ -1,0 +1,44 @@
+/* @file
+ * @brief Internal APIs for Audio ISO handling
+ *
+ * Copyright (c) 2022 Codecoup
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/bluetooth/audio/audio.h>
+
+struct bt_audio_iso_ep {
+	struct bt_audio_ep *ep;
+	struct bt_iso_chan_path path;
+	struct bt_iso_chan_io_qos qos;
+	uint8_t cc[CONFIG_BT_CODEC_MAX_DATA_COUNT * CONFIG_BT_CODEC_MAX_DATA_LEN];
+};
+
+struct bt_audio_iso {
+	struct bt_iso_chan chan;
+	struct bt_iso_chan_qos qos;
+
+	struct bt_audio_iso_ep rx;
+	struct bt_audio_iso_ep tx;
+
+	/* Must be at the end so that everything else in the structure can be
+	 * memset to zero without affecting the ref.
+	 */
+	atomic_t ref;
+};
+
+typedef bool (*bt_audio_iso_func_t)(struct bt_audio_iso *iso, void *user_data);
+
+struct bt_audio_iso *bt_audio_iso_new(void);
+struct bt_audio_iso *bt_audio_iso_ref(struct bt_audio_iso *iso);
+void bt_audio_iso_unref(struct bt_audio_iso *iso);
+void bt_audio_iso_foreach(bt_audio_iso_func_t func, void *user_data);
+struct bt_audio_iso *bt_audio_iso_find(bt_audio_iso_func_t func,
+				       void *user_data);
+void bt_audio_iso_init(struct bt_audio_iso *iso, struct bt_iso_chan_ops *ops);
+void bt_audio_iso_bind_ep(struct bt_audio_iso *iso, struct bt_audio_ep *ep);
+void bt_audio_iso_unbind_ep(struct bt_audio_iso *iso, struct bt_audio_ep *ep);
+struct bt_audio_ep *bt_audio_iso_get_ep(struct bt_audio_iso *iso,
+					enum bt_audio_dir dir);

--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -18,6 +18,7 @@
 #include "../host/conn_internal.h"
 #include "../host/iso_internal.h"
 
+#include "audio_iso.h"
 #include "endpoint.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_AUDIO_DEBUG_BROADCAST_SINK)
@@ -36,8 +37,6 @@
  */
 #define INVALID_BROADCAST_ID 0xFFFFFFFF
 
-static struct bt_audio_iso broadcast_sink_iso
-	[CONFIG_BT_AUDIO_BROADCAST_SNK_COUNT][BROADCAST_SNK_STREAM_CNT];
 static struct bt_audio_ep broadcast_sink_eps
 	[CONFIG_BT_AUDIO_BROADCAST_SNK_COUNT][BROADCAST_SNK_STREAM_CNT];
 static struct bt_audio_broadcast_sink broadcast_sinks[CONFIG_BT_AUDIO_BROADCAST_SNK_COUNT];
@@ -120,16 +119,19 @@ static void broadcast_sink_iso_recv(struct bt_iso_chan *chan,
 				    const struct bt_iso_recv_info *info,
 				    struct net_buf *buf)
 {
-	struct bt_audio_iso *audio_iso = CONTAINER_OF(chan, struct bt_audio_iso,
-						      iso_chan);
-	struct bt_audio_stream *stream = audio_iso->sink_stream;
+	struct bt_audio_iso *iso = CONTAINER_OF(chan, struct bt_audio_iso, chan);
 	const struct bt_audio_stream_ops *ops;
+	struct bt_audio_stream *stream;
+	struct bt_audio_ep *ep = iso->rx.ep;
 
-	if (stream == NULL) {
-		BT_ERR("Could not lookup stream by iso %p", chan);
+	if (ep == NULL) {
+		BT_ERR("iso %p not bound with ep", chan);
 		return;
-	} else if (stream->ep == NULL) {
-		BT_ERR("Stream not associated with an ep");
+	}
+
+	stream = ep->stream;
+	if (stream == NULL) {
+		BT_ERR("No stream for ep %p", ep);
 		return;
 	}
 
@@ -137,7 +139,7 @@ static void broadcast_sink_iso_recv(struct bt_iso_chan *chan,
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_DEBUG_STREAM_DATA)) {
 		BT_DBG("stream %p ep %p len %zu",
-		       stream, stream->ep, net_buf_frags_len(buf));
+		       stream, ep, net_buf_frags_len(buf));
 	}
 
 	if (ops != NULL && ops->recv != NULL) {
@@ -149,16 +151,19 @@ static void broadcast_sink_iso_recv(struct bt_iso_chan *chan,
 
 static void broadcast_sink_iso_connected(struct bt_iso_chan *chan)
 {
-	struct bt_audio_iso *audio_iso = CONTAINER_OF(chan, struct bt_audio_iso,
-						      iso_chan);
-	struct bt_audio_stream *stream = audio_iso->sink_stream;
+	struct bt_audio_iso *iso = CONTAINER_OF(chan, struct bt_audio_iso, chan);
 	const struct bt_audio_stream_ops *ops;
+	struct bt_audio_stream *stream;
+	struct bt_audio_ep *ep = iso->rx.ep;
 
-	if (stream == NULL) {
-		BT_ERR("Could not lookup stream by iso %p", chan);
+	if (ep == NULL) {
+		BT_ERR("iso %p not bound with ep", chan);
 		return;
-	} else if (stream->ep == NULL) {
-		BT_ERR("Stream not associated with an ep");
+	}
+
+	stream = ep->stream;
+	if (stream == NULL) {
+		BT_ERR("No stream for ep %p", ep);
 		return;
 	}
 
@@ -166,7 +171,7 @@ static void broadcast_sink_iso_connected(struct bt_iso_chan *chan)
 
 	BT_DBG("stream %p", stream);
 
-	broadcast_sink_set_ep_state(stream->ep, BT_AUDIO_EP_STATE_STREAMING);
+	broadcast_sink_set_ep_state(ep, BT_AUDIO_EP_STATE_STREAMING);
 
 	if (ops != NULL && ops->started != NULL) {
 		ops->started(stream);
@@ -178,25 +183,28 @@ static void broadcast_sink_iso_connected(struct bt_iso_chan *chan)
 static void broadcast_sink_iso_disconnected(struct bt_iso_chan *chan,
 					    uint8_t reason)
 {
-	struct bt_audio_iso *audio_iso = CONTAINER_OF(chan, struct bt_audio_iso,
-						      iso_chan);
-	struct bt_audio_stream *stream = audio_iso->sink_stream;
+	struct bt_audio_iso *iso = CONTAINER_OF(chan, struct bt_audio_iso, chan);
 	const struct bt_audio_stream_ops *ops;
+	struct bt_audio_stream *stream;
+	struct bt_audio_ep *ep = iso->rx.ep;
 	struct bt_audio_broadcast_sink *sink;
 
-	if (stream == NULL) {
-		BT_ERR("Could not lookup ep by iso %p", chan);
+	if (ep == NULL) {
+		BT_ERR("iso %p not bound with ep", chan);
 		return;
-	} else if (stream->ep == NULL) {
-		BT_ERR("Stream not associated with an ep");
+	}
+
+	stream = ep->stream;
+	if (stream == NULL) {
+		BT_ERR("No stream for ep %p", ep);
 		return;
 	}
 
 	ops = stream->ops;
 
-	BT_DBG("stream %p ep %p reason 0x%02x", stream, stream->ep, reason);
+	BT_DBG("stream %p ep %p reason 0x%02x", stream, ep, reason);
 
-	broadcast_sink_set_ep_state(stream->ep, BT_AUDIO_EP_STATE_IDLE);
+	broadcast_sink_set_ep_state(ep, BT_AUDIO_EP_STATE_IDLE);
 
 	if (ops != NULL && ops->stopped != NULL) {
 		ops->stopped(stream);
@@ -874,23 +882,13 @@ bool bt_audio_ep_is_broadcast_snk(const struct bt_audio_ep *ep)
 	return false;
 }
 
-static void broadcast_sink_ep_init(struct bt_audio_ep *ep,
-				   struct bt_audio_iso *iso)
+static void broadcast_sink_ep_init(struct bt_audio_ep *ep)
 {
-	struct bt_iso_chan *iso_chan;
-
 	BT_DBG("ep %p", ep);
 
 	(void)memset(ep, 0, sizeof(*ep));
 	ep->dir = BT_AUDIO_DIR_SINK;
-	ep->iso = iso;
-
-	iso_chan = &iso->iso_chan;
-
-	iso_chan->ops = &broadcast_sink_iso_ops;
-	iso_chan->qos = &ep->iso->iso_qos;
-	iso_chan->qos->rx = &iso->sink_io_qos;
-	iso_chan->qos->tx = NULL;
+	ep->iso = NULL;
 }
 
 static struct bt_audio_ep *broadcast_sink_new_ep(uint8_t index)
@@ -900,11 +898,7 @@ static struct bt_audio_ep *broadcast_sink_new_ep(uint8_t index)
 
 		/* If ep->stream is NULL the endpoint is unallocated */
 		if (ep->stream == NULL) {
-			/* Initialize - It is up to the caller to allocate the
-			 * stream pointer.
-			 */
-			broadcast_sink_ep_init(ep,
-					       &broadcast_sink_iso[index][i]);
+			broadcast_sink_ep_init(ep);
 			return ep;
 		}
 	}
@@ -916,8 +910,8 @@ static int bt_audio_broadcast_sink_setup_stream(uint8_t index,
 						struct bt_audio_stream *stream,
 						struct bt_codec *codec)
 {
-	static struct bt_iso_chan_io_qos sink_chan_io_qos;
 	static struct bt_codec_qos codec_qos;
+	struct bt_audio_iso *iso;
 	struct bt_audio_ep *ep;
 
 	if (stream->group != NULL) {
@@ -931,18 +925,22 @@ static int bt_audio_broadcast_sink_setup_stream(uint8_t index,
 		return -ENOMEM;
 	}
 
+	iso = bt_audio_iso_new();
+	if (iso == NULL) {
+		BT_DBG("Could not allocate iso");
+		return -ENOMEM;
+	}
+
+	bt_audio_iso_init(iso, &broadcast_sink_iso_ops);
+	bt_audio_iso_bind_ep(iso, ep);
+
+	bt_audio_codec_qos_to_iso_qos(iso->chan.qos->rx, &codec_qos);
+	bt_audio_codec_to_iso_path(iso->chan.qos->rx->path, codec);
+
+	bt_audio_iso_unref(iso);
+
 	bt_audio_stream_attach(NULL, stream, ep, codec);
-	ep->iso->sink_stream = stream;
-	/* TODO: The values of sink_chan_io_qos and codec_qos are not used,
-	 * but the `rx` and `qos` pointers need to be set. This should be fixed.
-	 */
-	stream->iso->qos->rx = &sink_chan_io_qos;
-	stream->iso->qos->rx->path = &ep->iso->sink_path;
-	stream->iso->qos->rx->path->cc = ep->iso->sink_path_cc;
-	stream->iso->qos->tx = NULL;
 	stream->qos = &codec_qos;
-	bt_audio_codec_qos_to_iso_qos(stream->iso->qos->rx, &codec_qos);
-	bt_audio_codec_to_iso_path(stream->iso->qos->rx->path, codec);
 
 	return 0;
 }
@@ -953,13 +951,13 @@ static void broadcast_sink_cleanup_streams(struct bt_audio_broadcast_sink *sink)
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&sink->streams, stream, next, _node) {
 		if (stream->ep != NULL) {
+			bt_audio_iso_unbind_ep(stream->ep->iso, stream->ep);
 			stream->ep->stream = NULL;
 			stream->ep = NULL;
 		}
 
 		stream->qos = NULL;
 		stream->codec = NULL;
-		stream->iso = NULL;
 		stream->group = NULL;
 
 		sys_slist_remove(&sink->streams, NULL, &stream->_node);
@@ -1083,7 +1081,7 @@ int bt_audio_broadcast_sink_sync(struct bt_audio_broadcast_sink *sink,
 			return err;
 		}
 
-		sink->bis[i] = &stream->ep->iso->iso_chan;
+		sink->bis[i] = bt_audio_stream_iso_chan_get(stream);
 		sys_slist_append(&sink->streams, &stream->_node);
 		sink->stream_count++;
 	}

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/kernel.h>
 #include <zephyr/types.h>
 
 #include "ascs_internal.h"
@@ -80,6 +81,9 @@ struct bt_audio_ep {
 	struct bt_audio_unicast_group *unicast_group;
 	struct bt_audio_broadcast_source *broadcast_source;
 	struct bt_audio_broadcast_sink *broadcast_sink;
+
+	/* ASCS ASE Control Point Work */
+	struct k_work work;
 };
 
 struct bt_audio_unicast_group {

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -32,24 +32,6 @@ struct bt_audio_broadcast_source;
 struct bt_audio_broadcast_sink;
 struct bt_audio_ep;
 
-struct bt_audio_iso {
-	struct bt_iso_chan iso_chan;
-	struct bt_iso_chan_qos iso_qos;
-	struct bt_iso_chan_io_qos sink_io_qos;
-	struct bt_iso_chan_io_qos source_io_qos;
-	struct bt_iso_chan_path sink_path;
-	/* TODO: The sink/source path CC will basically be a duplicate of
-	 * bt_codec.data, but since struct bt_codec stores the information as an
-	 * array of bt_codec_data, and ISO expect a uint8_t array, we need to
-	 * duplicate the data. This should be optimized.
-	 */
-	uint8_t sink_path_cc[CONFIG_BT_CODEC_MAX_DATA_COUNT * CONFIG_BT_CODEC_MAX_DATA_LEN];
-	struct bt_iso_chan_path	source_path;
-	uint8_t source_path_cc[CONFIG_BT_CODEC_MAX_DATA_COUNT * CONFIG_BT_CODEC_MAX_DATA_LEN];
-	struct bt_audio_stream *sink_stream;
-	struct bt_audio_stream *source_stream;
-};
-
 struct bt_audio_ep {
 	uint8_t  dir;
 	uint8_t  cig_id;

--- a/subsys/bluetooth/audio/stream.h
+++ b/subsys/bluetooth/audio/stream.h
@@ -55,3 +55,5 @@ bool bt_audio_valid_stream_qos(const struct bt_audio_stream *stream,
 			     const struct bt_codec_qos *qos);
 
 int bt_audio_stream_iso_listen(struct bt_audio_stream *stream);
+
+struct bt_iso_chan *bt_audio_stream_iso_chan_get(struct bt_audio_stream *stream);

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -1625,46 +1625,6 @@ static void unicast_client_ep_reset(struct bt_conn *conn)
 	}
 }
 
-void bt_unicast_client_ep_attach(struct bt_audio_ep *ep,
-				 struct bt_audio_stream *stream)
-{
-	BT_DBG("ep %p stream %p", ep, stream);
-
-	if (ep == NULL || stream == NULL || ep->stream == stream) {
-		return;
-	}
-
-	if (ep->stream) {
-		BT_ERR("ep %p attached to another stream %p", ep, ep->stream);
-		return;
-	}
-
-	ep->stream = stream;
-	stream->ep = ep;
-
-	if (stream->iso == NULL) {
-		stream->iso = &ep->iso->iso_chan;
-	}
-}
-
-void bt_unicast_client_ep_detach(struct bt_audio_ep *ep,
-				 struct bt_audio_stream *stream)
-{
-	BT_DBG("ep %p stream %p", ep, stream);
-
-	if (ep == NULL || stream == NULL || !ep->stream) {
-		return;
-	}
-
-	if (ep->stream != stream) {
-		BT_ERR("ep %p attached to another stream %p", ep, ep->stream);
-		return;
-	}
-
-	ep->stream = NULL;
-	stream->ep = NULL;
-}
-
 int bt_unicast_client_config(struct bt_audio_stream *stream,
 			     const struct bt_codec *codec)
 {

--- a/subsys/bluetooth/audio/unicast_client_internal.h
+++ b/subsys/bluetooth/audio/unicast_client_internal.h
@@ -33,10 +33,6 @@ int bt_unicast_client_ep_qos(struct bt_audio_ep *ep, struct net_buf_simple *buf,
 int bt_unicast_client_ep_send(struct bt_conn *conn, struct bt_audio_ep *ep,
 		   struct net_buf_simple *buf);
 
-void bt_unicast_client_ep_attach(struct bt_audio_ep *ep, struct bt_audio_stream *stream);
-
-void bt_unicast_client_ep_detach(struct bt_audio_ep *ep, struct bt_audio_stream *stream);
-
 /**
  * @brief Get a new a audio_iso that is a match for the provided stream
  *

--- a/subsys/bluetooth/audio/unicast_client_internal.h
+++ b/subsys/bluetooth/audio/unicast_client_internal.h
@@ -33,32 +33,4 @@ int bt_unicast_client_ep_qos(struct bt_audio_ep *ep, struct net_buf_simple *buf,
 int bt_unicast_client_ep_send(struct bt_conn *conn, struct bt_audio_ep *ep,
 		   struct net_buf_simple *buf);
 
-/**
- * @brief Get a new a audio_iso that is a match for the provided stream
- *
- * This will first attempt to find a audio_iso where the stream's direction
- * is not yet used, and where the opposing direction is for the same stream
- * group and ACL connection.
- *
- * If no such one is available, it will use the first completely free audio_iso
- * available, or return NULL if not such one is found.
- *
- * @param stream Pointer to a stream used to find a corresponding audio_iso
- *
- * @return An audio_iso struct fit for the stream, or NULL.
- */
-struct bt_audio_iso *bt_unicast_client_new_audio_iso(
-	const struct bt_audio_unicast_group *unicast_group,
-	const struct bt_audio_stream *stream,
-	enum bt_audio_dir dir);
-
-struct bt_audio_iso *bt_unicast_client_audio_iso_by_stream(const struct bt_audio_stream *stream);
-
-void bt_unicast_client_stream_bind_audio_iso(struct bt_audio_stream *stream,
-					     struct bt_audio_iso *audio_iso,
-					     enum bt_audio_dir dir);
-void bt_unicast_client_stream_unbind_audio_iso(struct bt_audio_stream *stream);
-
-void bt_unicast_client_ep_bind_audio_iso(struct bt_audio_ep *ep,
-					 struct bt_audio_iso *audio_iso);
-void bt_unicast_client_ep_unbind_audio_iso(struct bt_audio_ep *ep);
+struct bt_audio_iso *bt_unicast_client_new_audio_iso(void);

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -1814,20 +1814,15 @@ static int cmd_send(const struct shell *sh, size_t argc, char *argv[])
 	int ret, len;
 	struct net_buf *buf;
 
-	if (default_stream->iso->qos->tx == NULL) {
-		shell_error(sh, "Stream %p cannot send", default_stream);
-		return -ENOEXEC;
-	}
-
 	if (argc > 1) {
 		len = hex2bin(argv[1], strlen(argv[1]), data, sizeof(data));
-		if (len > default_stream->iso->qos->tx->sdu) {
+		if (len > default_preset->preset.qos.sdu) {
 			shell_print(sh, "Unable to send: len %d > %u MTU",
-				    len, default_stream->iso->qos->tx->sdu);
+				    len, default_preset->preset.qos.sdu);
 			return -ENOEXEC;
 		}
 	} else {
-		len = MIN(default_stream->iso->qos->tx->sdu, sizeof(data));
+		len = MIN(default_preset->preset.qos.sdu, sizeof(data));
 		memset(data, 0xff, len);
 	}
 


### PR DESCRIPTION
This adds common bt_audio_iso pool that will be used across all the
roles/profiles. The pool range is dependent on the CONFIG_BT_ISO_MAX_CHAN
which is the maximum number of ISO connections the host can maintain.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>