### PR TITLE
net: sockets: socketpair: do not allow blocking IO in ISR context

### DIFF
--- a/subsys/net/lib/sockets/socketpair.c
+++ b/subsys/net/lib/sockets/socketpair.c
@@ -460,6 +460,11 @@ static ssize_t spair_write(void *obj, const void *buffer, size_t count)
 	}
 
 	if (will_block) {
+		if (k_is_in_isr()) {
+			errno = EAGAIN;
+			res = -1;
+			goto out;
+		}
 
 		for (int signaled = false, result = -1; !signaled;
 			result = -1) {
@@ -646,6 +651,11 @@ static ssize_t spair_read(void *obj, void *buffer, size_t count)
 	}
 
 	if (will_block) {
+		if (k_is_in_isr()) {
+			errno = EAGAIN;
+			res = -1;
+			goto out;
+		}
 
 		for (int signaled = false, result = -1; !signaled;
 			result = -1) {


### PR DESCRIPTION
Using a socketpair for communication in an ISR is not a great solution, but the implementation should be robust in that case as well.

It is not acceptible to block in ISR context, so robustness here means to return -1 to indicate an error, setting errno to `EAGAIN` (which is synonymous with `EWOULDBLOCK`).

Fixes #25417