### PR TITLE
ci: manifest: Trigger unconditionally

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -1,8 +1,6 @@
 name: Manifest
 on:
   pull_request_target:
-    paths:
-      - 'west.yml'
 
 jobs:
   contribs:


### PR DESCRIPTION
The GitHub Actions trigger-on-file-change mechanism may fail to trigger for very large PRs (300+ files changed).

This commit updates the manifest workflow such that it runs on all pull requests, regardless of whether `west.yml` is modified.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>