### PR TITLE
smp: Add BUILD_ASSERT to make sure Kconfig values are the same

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -36,6 +36,10 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(os, CONFIG_KERNEL_LOG_LEVEL);
 
+
+BUILD_ASSERT(CONFIG_MP_NUM_CPUS == CONFIG_MP_MAX_NUM_CPUS,
+	     "CONFIG_MP_NUM_CPUS and CONFIG_MP_MAX_NUM_CPUS need to be set the same");
+
 /* the only struct z_kernel instance */
 struct z_kernel _kernel;
 


### PR DESCRIPTION
Add check to ensure that CONFIG_MP_NUM_CPUS and CONFIG_MP_MAX_NUM_CPUS are set the same.  This will at least cause a build issue for out of tree users.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>