### PR TITLE
soc: stm32wb: Set BT_USER_PHY_UPDATE as supported

### DIFF
--- a/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.series
@@ -10,4 +10,7 @@ source "soc/arm/st_stm32/stm32wb/Kconfig.defconfig.stm32wb*"
 config SOC_SERIES
 	default "stm32wb"
 
+config BT_USER_PHY_UPDATE
+	default y if BT
+
 endif # SOC_SERIES_STM32WBX


### PR DESCRIPTION
STM32WB Controller supports application to initiate the "PHY Update Procedure" (BT_USER_PHY_UPDATE) while it doesn't support it to be automatically triggered on connection establishment (BT_AUTO_PHY_UPDATE).

Default BT_USER_PHY_UPDATE to true, which automatically defaults BT_AUTO_PHY_UPDATE to false.

Partially fixes #49584

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>