### PR TITLE
drivers: gpio: expose gpio_utils.h to external GPIO drivers

### DIFF
--- a/drivers/gpio/gpio_andes_atcgpio100.c
+++ b/drivers/gpio/gpio_andes_atcgpio100.c
@@ -19,7 +19,7 @@
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/irq.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #define DT_DRV_COMPAT andestech_atcgpio100
 

--- a/drivers/gpio/gpio_b91.c
+++ b/drivers/gpio/gpio_b91.c
@@ -9,7 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/irq.h>
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 
 /* Driver dts compatibility: telink,b91_gpio */

--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -24,7 +24,7 @@
 #include <ti/drivers/power/PowerCC26XX.h>
 #include <zephyr/irq.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 /* bits 16-18 in iocfg registers correspond to interrupt settings */
 #define IOCFG_INT_MASK    0x00070000

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -26,7 +26,7 @@
 #include <driverlib/interrupt.h>
 #include <zephyr/irq.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 /* Reserved */
 #define PIN_XX  0xFF

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -17,7 +17,7 @@
 #include <zephyr/drivers/gpio/gpio_cmsdk_ahb.h>
 #include <zephyr/irq.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 /**
  * @brief GPIO driver for ARM CMSDK AHB GPIO

--- a/drivers/gpio/gpio_creg_gpio.c
+++ b/drivers/gpio/gpio_creg_gpio.c
@@ -19,7 +19,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(creg_gpio, CONFIG_GPIO_LOG_LEVEL);
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 /** Runtime driver data */
 struct creg_gpio_drv_data {

--- a/drivers/gpio/gpio_cy8c95xx.c
+++ b/drivers/gpio/gpio_cy8c95xx.c
@@ -19,7 +19,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(cy8c95xx, CONFIG_GPIO_LOG_LEVEL);
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 /** Cache of the output configuration and data of the pins. */
 struct cy8c95xx_pin_state {

--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -12,7 +12,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/gpio/snps-designware-gpio.h>
 #include "gpio_dw.h"
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #include <zephyr/pm/device.h>
 #include <zephyr/sys/sys_io.h>

--- a/drivers/gpio/gpio_emul.c
+++ b/drivers/gpio/gpio_emul.c
@@ -13,7 +13,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/pm/device.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/gpio/gpio_eos_s3.c
+++ b/drivers/gpio/gpio_eos_s3.c
@@ -14,7 +14,7 @@
 #include <eoss3_hal_pads.h>
 #include <eoss3_hal_pad_config.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #define MAX_GPIOS		8U
 #define GPIOS_MASK		(BIT(MAX_GPIOS) - 1)

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -28,7 +28,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(gpio_esp32, CONFIG_LOG_DEFAULT_LEVEL);

--- a/drivers/gpio/gpio_fxl6408.c
+++ b/drivers/gpio/gpio_fxl6408.c
@@ -7,7 +7,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/kernel.h>
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(fxl6408, CONFIG_FXL6408_LOG_LEVEL);

--- a/drivers/gpio/gpio_gd32.c
+++ b/drivers/gpio/gpio_gd32.c
@@ -14,7 +14,7 @@
 
 #include <gd32_gpio.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #ifdef CONFIG_GD32_HAS_AF_PINMUX
 /** SYSCFG DT node */

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -12,7 +12,7 @@
 #include <soc.h>
 #include <em_gpio.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #if CONFIG_GPIO_GECKO_COMMON_INIT_PRIORITY >= CONFIG_GPIO_INIT_PRIORITY
 #error CONFIG_GPIO_GECKO_COMMON_INIT_PRIORITY must be less than \

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -18,7 +18,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #endif
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 struct imx_gpio_config {
 	/* gpio_driver_config needs to be first */

--- a/drivers/gpio/gpio_intel.c
+++ b/drivers/gpio/gpio_intel.c
@@ -28,7 +28,7 @@
 #include <zephyr/sys/speculation.h>
 #include <zephyr/irq.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 BUILD_ASSERT(DT_INST_IRQN(0) == 14);
 

--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -15,7 +15,7 @@
 #include <zephyr/sys/util.h>
 #include <string.h>
 #include <zephyr/logging/log.h>
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #include <chip_chipregs.h>
 #include <soc_common.h>

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -18,7 +18,7 @@
 
 #include <soc.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #define SUPPORTED_FLAGS (GPIO_INPUT | GPIO_OUTPUT | \
 			GPIO_OUTPUT_INIT_LOW | GPIO_OUTPUT_INIT_HIGH | \

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(gpio_lmp90xxx);
 
 #include <zephyr/drivers/adc/lmp90xxx.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 struct gpio_lmp90xxx_config {
 	/* gpio_driver_config needs to be first */

--- a/drivers/gpio/gpio_lpc11u6x.c
+++ b/drivers/gpio/gpio_lpc11u6x.c
@@ -22,7 +22,7 @@
 
 #include <soc.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 /* Offset from syscon base address. */
 #define LPC11U6X_PINTSEL_REGS	0x178

--- a/drivers/gpio/gpio_mchp_mss.c
+++ b/drivers/gpio/gpio_mchp_mss.c
@@ -14,7 +14,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/irq.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 
 #define MSS_GPIO_INPUT_MODE               0x02

--- a/drivers/gpio/gpio_mchp_xec.c
+++ b/drivers/gpio/gpio_mchp_xec.c
@@ -13,7 +13,7 @@
 #include <zephyr/sys/sys_io.h>
 #include <soc.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #define XEC_GPIO_EDGE_DLY_COUNT		4
 

--- a/drivers/gpio/gpio_mchp_xec_v2.c
+++ b/drivers/gpio/gpio_mchp_xec_v2.c
@@ -15,7 +15,7 @@
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr/irq.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #define XEC_GPIO_EDGE_DLY_COUNT		4
 

--- a/drivers/gpio/gpio_mcp230xx.c
+++ b/drivers/gpio/gpio_mcp230xx.c
@@ -17,7 +17,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 #include "gpio_mcp23xxx.h"
 
 #define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL

--- a/drivers/gpio/gpio_mcp23s17.c
+++ b/drivers/gpio/gpio_mcp23s17.c
@@ -19,7 +19,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 #include "gpio_mcp23s17.h"
 
 #define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL

--- a/drivers/gpio/gpio_mcp23sxx.c
+++ b/drivers/gpio/gpio_mcp23sxx.c
@@ -17,7 +17,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 #include "gpio_mcp23xxx.h"
 
 #define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL

--- a/drivers/gpio/gpio_mcp23xxx.c
+++ b/drivers/gpio/gpio_mcp23xxx.c
@@ -15,7 +15,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/gpio.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 #include "gpio_mcp23xxx.h"
 
 #define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -16,7 +16,7 @@
 #include <fsl_common.h>
 #include <fsl_port.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 struct gpio_mcux_config {
 	/* gpio_driver_config needs to be first */

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -18,7 +18,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #endif
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 struct gpio_pin_gaps {
 	uint8_t start;

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -20,7 +20,7 @@
 #include <zephyr/irq.h>
 #include <soc.h>
 #include <fsl_common.h>
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 #include <fsl_gpio.h>
 #include <fsl_pint.h>
 #include <fsl_inputmux.h>

--- a/drivers/gpio/gpio_nct38xx_port.c
+++ b/drivers/gpio/gpio_nct38xx_port.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/gpio.h>
 
 #include "gpio_nct38xx.h"
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(gpio_ntc38xx, CONFIG_GPIO_LOG_LEVEL);

--- a/drivers/gpio/gpio_neorv32.c
+++ b/drivers/gpio/gpio_neorv32.c
@@ -18,7 +18,7 @@
 
 LOG_MODULE_REGISTER(gpio_neorv32, CONFIG_GPIO_LOG_LEVEL);
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 /* Maximum number of GPIOs supported */
 #define MAX_GPIOS 32

--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -11,7 +11,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <soc.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 #include "soc_gpio.h"
 #include "soc_miwu.h"
 

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -10,7 +10,8 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
 #include <zephyr/irq.h>
-#include "gpio_utils.h"
+
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 struct gpio_nrfx_data {
 	/* gpio_driver_data needs to be first */

--- a/drivers/gpio/gpio_pca953x.c
+++ b/drivers/gpio/gpio_pca953x.c
@@ -21,7 +21,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pca953x, CONFIG_GPIO_LOG_LEVEL);
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 /* PCA953X Register addresses */
 #define PCA953X_INPUT_PORT		0x00

--- a/drivers/gpio/gpio_pca95xx.c
+++ b/drivers/gpio/gpio_pca95xx.c
@@ -22,7 +22,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/gpio/gpio_pcal6408a.c
+++ b/drivers/gpio/gpio_pcal6408a.c
@@ -9,7 +9,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pcal6408a, CONFIG_GPIO_LOG_LEVEL);

--- a/drivers/gpio/gpio_pcf8574.c
+++ b/drivers/gpio/gpio_pcf8574.c
@@ -6,7 +6,7 @@
 
 #define DT_DRV_COMPAT nxp_pcf8574
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>

--- a/drivers/gpio/gpio_psoc6.c
+++ b/drivers/gpio/gpio_psoc6.c
@@ -14,7 +14,7 @@
 #include <soc.h>
 #include <zephyr/drivers/gpio.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 #include "cy_gpio.h"
 #include "cy_sysint.h"
 

--- a/drivers/gpio/gpio_rcar.c
+++ b/drivers/gpio/gpio_rcar.c
@@ -16,7 +16,7 @@
 #include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
 #include <zephyr/irq.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 typedef void (*init_func_t)(const struct device *dev);
 

--- a/drivers/gpio/gpio_rpi_pico.c
+++ b/drivers/gpio/gpio_rpi_pico.c
@@ -13,7 +13,7 @@
 #include <hardware/regs/intctrl.h>
 #include <hardware/structs/iobank0.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #define DT_DRV_COMPAT raspberrypi_pico_gpio
 

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -17,7 +17,7 @@
 #include <fsl_port.h>
 #include <zephyr/drivers/clock_control.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 struct gpio_rv32m1_config {
 	/* gpio_driver_config needs to be first */

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -15,7 +15,7 @@
 #include <zephyr/dt-bindings/gpio/atmel-sam-gpio.h>
 #include <zephyr/irq.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 typedef void (*config_func_t)(const struct device *dev);
 

--- a/drivers/gpio/gpio_sam0.c
+++ b/drivers/gpio/gpio_sam0.c
@@ -14,7 +14,7 @@
 #include <soc.h>
 #include <zephyr/drivers/interrupt_controller/sam0_eic.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #ifndef PORT_PMUX_PMUXE_A_Val
 #define PORT_PMUX_PMUXE_A_Val (0)

--- a/drivers/gpio/gpio_sam4l.c
+++ b/drivers/gpio/gpio_sam4l.c
@@ -15,7 +15,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/irq.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 typedef void (*config_func_t)(const struct device *dev);
 

--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -18,7 +18,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/irq.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 typedef void (*sifive_cfg_func_t)(void);
 

--- a/drivers/gpio/gpio_smartbond.c
+++ b/drivers/gpio/gpio_smartbond.c
@@ -6,7 +6,7 @@
 
 #define DT_DRV_COMPAT renesas_smartbond_gpio
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #include <stdint.h>
 #include <zephyr/drivers/gpio.h>

--- a/drivers/gpio/gpio_sn74hc595.c
+++ b/drivers/gpio/gpio_sn74hc595.c
@@ -16,7 +16,7 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(gpio_sn74hc595, CONFIG_GPIO_LOG_LEVEL);

--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -13,7 +13,7 @@
 #include <zephyr/irq.h>
 #include <soc.h>
 #include <zephyr/sys/sys_io.h>
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 typedef void (*config_func_t)(const struct device *dev);
 

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -25,7 +25,7 @@
 
 #include "stm32_hsem.h"
 #include "gpio_stm32.h"
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 /**
  * @brief Common GPIO driver for STM32 MCUs.

--- a/drivers/gpio/gpio_stmpe1600.c
+++ b/drivers/gpio/gpio_stmpe1600.c
@@ -19,7 +19,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 #define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -24,7 +24,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sx1509b, CONFIG_GPIO_LOG_LEVEL);
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 /* Number of pins supported by the device */
 #define NUM_PINS 16

--- a/drivers/gpio/gpio_xlnx_axi.c
+++ b/drivers/gpio/gpio_xlnx_axi.c
@@ -11,7 +11,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/sys/sys_io.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 /* AXI GPIO v2 register offsets (See Xilinx PG144 for details) */
 #define GPIO_DATA_OFFSET  0x0000

--- a/drivers/gpio/gpio_xlnx_ps.c
+++ b/drivers/gpio/gpio_xlnx_ps.c
@@ -9,7 +9,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/irq.h>
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 #include "gpio_xlnx_ps.h"
 #include "gpio_xlnx_ps_bank.h"
 

--- a/drivers/gpio/gpio_xlnx_ps_bank.c
+++ b/drivers/gpio/gpio_xlnx_ps_bank.c
@@ -11,7 +11,7 @@
 #include <zephyr/devicetree.h>
 
 #include <zephyr/drivers/gpio.h>
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 #include "gpio_xlnx_ps_bank.h"
 
 #define LOG_MODULE_NAME gpio_xlnx_ps_bank

--- a/drivers/gpio/gpio_xmc4xxx.c
+++ b/drivers/gpio/gpio_xmc4xxx.c
@@ -12,7 +12,7 @@
 #include <zephyr/dt-bindings/gpio/infineon-xmc4xxx-gpio.h>
 #include <xmc_gpio.h>
 
-#include "gpio_utils.h"
+#include <zephyr/drivers/gpio/gpio_utils.h>
 
 struct gpio_xmc4xxx_config {
 	/* gpio_driver_config needs to be first, required by Zephyr */

--- a/include/zephyr/drivers/gpio/gpio_utils.h
+++ b/include/zephyr/drivers/gpio/gpio_utils.h
@@ -4,12 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file Header where utility code can be found for GPIO drivers
- */
 
-#ifndef ZEPHYR_DRIVERS_GPIO_GPIO_UTILS_H_
-#define ZEPHYR_DRIVERS_GPIO_GPIO_UTILS_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_UTILS_H_
+#define ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_UTILS_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -83,4 +80,4 @@ static inline void gpio_fire_callbacks(sys_slist_t *list,
 	}
 }
 
-#endif /* ZEPHYR_DRIVERS_GPIO_GPIO_UTILS_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_UTILS_H_ */


### PR DESCRIPTION
Expose "gpio_utils.h" header for external GPIO drivers.

Fixes #48609.

Signed-off-by: Balaji Kulkarni <balaji.kulkarni92@gmail.com>