### PR TITLE
Update NXP OS timer to use wakeup source property

### DIFF
--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -123,7 +123,9 @@ static int sys_clock_driver_init(const struct device *dev)
 
 	base = (OSTIMER_Type *)DT_INST_REG_ADDR(0);
 
-	EnableDeepSleepIRQ(DT_INST_IRQN(0));
+	if (DT_INST_PROP(0, wakeup_source)) {
+		EnableDeepSleepIRQ(DT_INST_IRQN(0));
+	}
 
 	/* Initialize the OS timer, setting clock configuration. */
 	OSTIMER_Init(base);

--- a/tests/subsys/pm/power_mgmt_soc/boards/mimxrt685_evk_cm33.overlay
+++ b/tests/subsys/pm/power_mgmt_soc/boards/mimxrt685_evk_cm33.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2022, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&os_timer {
+	status = "okay";
+	wakeup-source;
+};


### PR DESCRIPTION
Enable the OS Timer to be a wakeup source only if configured through device tree property.
