### PR TITLE
cmake/target_arm: Use NO_SPLIT for TOOLCHAIN_LD_FLAGS

### DIFF
--- a/cmake/compiler/gcc/target_arm.cmake
+++ b/cmake/compiler/gcc/target_arm.cmake
@@ -1,18 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-list(APPEND TOOLCHAIN_C_FLAGS   -mcpu=${GCC_M_CPU})
-list(APPEND TOOLCHAIN_LD_FLAGS  -mcpu=${GCC_M_CPU})
+
+set(ARM_C_FLAGS)
+
+list(APPEND ARM_C_FLAGS   -mcpu=${GCC_M_CPU})
 
 if(CONFIG_COMPILER_ISA_THUMB2)
-  list(APPEND TOOLCHAIN_C_FLAGS   -mthumb)
-  list(APPEND TOOLCHAIN_LD_FLAGS  -mthumb)
+  list(APPEND ARM_C_FLAGS   -mthumb)
 endif()
 
-list(APPEND TOOLCHAIN_C_FLAGS -mabi=aapcs)
-list(APPEND TOOLCHAIN_LD_FLAGS -mabi=aapcs)
+list(APPEND ARM_C_FLAGS -mabi=aapcs)
 
 if(CONFIG_FPU)
-  list(APPEND TOOLCHAIN_C_FLAGS   -mfpu=${GCC_M_FPU})
-  list(APPEND TOOLCHAIN_LD_FLAGS  -mfpu=${GCC_M_FPU})
+  list(APPEND ARM_C_FLAGS   -mfpu=${GCC_M_FPU})
 
   if(CONFIG_DCLS AND NOT CONFIG_FP_HARDABI)
     # If the processor is equipped with VFP and configured in DCLS topology,
@@ -22,20 +21,18 @@ if(CONFIG_FPU)
   endif()
 
   if    (CONFIG_FP_HARDABI OR FORCE_FP_HARDABI)
-    list(APPEND TOOLCHAIN_C_FLAGS   -mfloat-abi=hard)
-    list(APPEND TOOLCHAIN_LD_FLAGS  -mfloat-abi=hard)
+    list(APPEND ARM_C_FLAGS   -mfloat-abi=hard)
   elseif(CONFIG_FP_SOFTABI)
-    list(APPEND TOOLCHAIN_C_FLAGS   -mfloat-abi=softfp)
-    list(APPEND TOOLCHAIN_LD_FLAGS  -mfloat-abi=softfp)
+    list(APPEND ARM_C_FLAGS   -mfloat-abi=softfp)
   endif()
 endif()
 
 if(CONFIG_FP16)
   if    (CONFIG_FP16_IEEE)
-    list(APPEND TOOLCHAIN_C_FLAGS   -mfp16-format=ieee)
-    list(APPEND TOOLCHAIN_LD_FLAGS  -mfp16-format=ieee)
+    list(APPEND ARM_C_FLAGS   -mfp16-format=ieee)
   elseif(CONFIG_FP16_ALT)
-    list(APPEND TOOLCHAIN_C_FLAGS   -mfp16-format=alternative)
-    list(APPEND TOOLCHAIN_LD_FLAGS  -mfp16-format=alternative)
+    list(APPEND ARM_C_FLAGS   -mfp16-format=alternative)
   endif()
 endif()
+list(APPEND TOOLCHAIN_C_FLAGS ${ARM_C_FLAGS})
+list(APPEND TOOLCHAIN_LD_FLAGS NO_SPLIT ${ARM_C_FLAGS})


### PR DESCRIPTION
The whole set of architecture flags must be specified together as they might not make sense in isolation, e.g. -mfloat-abi=hard requires a -mcpu value that might have an FPU. Use the NO_SPLIT feature to bind all of the linker options together so that the linker can compute the correct linker paths for toolchain-provided libraries like libc and libgcc.

Signed-off-by: Keith Packard <keithp@keithp.com>