### PR TITLE
boards: arduino_nano_33_ble: Support TRACE32 (GDB-Frontend)

### DIFF
--- a/boards/arm/arduino_nano_33_ble/board.cmake
+++ b/boards/arm/arduino_nano_33_ble/board.cmake
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
+board_runner_args(trace32
+  "--startup-args"
+    "elfFile=${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}"
+)
 
 include(${ZEPHYR_BASE}/boards/common/bossac.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/trace32.board.cmake)

--- a/boards/arm/arduino_nano_33_ble/doc/index.rst
+++ b/boards/arm/arduino_nano_33_ble/doc/index.rst
@@ -145,6 +145,57 @@ Type the following command will start debugging.
    :maybe-skip-config:
    :goals: debug
 
+Debugging with TRACE32 (GDB Front-End)
+======================================
+
+Lauterbach provides `GDB Debug version TRACE32 for Arduino Nano 33 BLE`_.
+That license ties to Arduino Nano 33 BLE hardware serial number,
+it also works with the ZephyrRTOS.
+
+Follow the instruction of the tutorial for Arduino
+`Lauterbach TRACE32 GDB Front-End Debugger for Nano 33 BLE`
+to install the TRACE32.
+
+After installing the TRACE32, You should set the environmental variable ``T32_DIR``.
+If you installed TRACE32 into the home directory, run the following command.
+(It is a good idea to put in the login script.)
+
+.. code-block:: bash
+
+    export T32_DIR="~/T32Arduino"
+
+
+The TRACE32 is `TRACE32 as GDB Front-End`_ version.
+Required to run the GDB server before launching TRACE32 with the following command.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: arduino_nano_33_ble
+   :goals: debugserver
+   :compact:
+
+Execute the following command after launching the GDB server to run the TRACE32
+and connect the GDB server.
+
+.. code-block:: bash
+
+    west debug --runner=trace32 -- gdbRemote=:3333
+
+The TRACE32 script handles arguments after the ``--`` sign.
+You can set the following options.
+
+========== ========== ==================================================================
+      Name Required?  Description
+---------- ---------- ------------------------------------------------------------------
+ gdbRemote  Required  | Set the GDB server address or device file of the serial port.
+                      | It can take <hostname>:<port> or <devicename>.
+                      | e.g.) ``gdbRemote=localhost:3333``, ``gdbRemote=/dev/ttyACM0``
+  terminal  Optional  | Set the device file of the serial port connected to the target console.
+                      | e.g.) ``terminal=/dev/ttyACM1``
+userScript  Optional  | Set user script that runs after system script execute done.
+                      | e.g.) ``userScript="./user.cmm"``
+========== ========== ==================================================================
+
 References
 **********
 
@@ -161,3 +212,12 @@ References
 
 .. _schematic:
     https://content.arduino.cc/assets/NANO33BLE_V2.0_sch.pdf
+
+.. _GDB Debug version TRACE32 for Arduino Nano 33 BLE:
+    https://www.lauterbach.com/frames.html?register_arduino.php
+
+.. _Lauterbach TRACE32 GDB Front-End Debugger for Nano 33 BLE:
+    https://docs.arduino.cc/tutorials/nano-33-ble-sense/trace-32
+
+.. _TRACE32 as GDB Front-End:
+    https://www2.lauterbach.com/pdf/frontend_gdb.pdf

--- a/boards/arm/arduino_nano_33_ble/support/debug.cmm
+++ b/boards/arm/arduino_nano_33_ble/support/debug.cmm
@@ -1,0 +1,8 @@
+; Copyright 2022 TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
+; SPDX-License-Identifier: Apache-2.0
+
+ENTRY %LINE &args
+
+DO ~~~~/startup.cmm command=debug &args
+
+ENDDO

--- a/boards/arm/arduino_nano_33_ble/support/startup.cmm
+++ b/boards/arm/arduino_nano_33_ble/support/startup.cmm
@@ -1,0 +1,138 @@
+; Copyright 2022 TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
+; SPDX-License-Identifier: Apache-2.0
+
+GLOBAL &GDBPORT
+GLOBAL &TERMPORT
+
+;
+; parse arguments
+;
+ENTRY %LINE &args
+&command=STRing.SCANAndExtract("&args","command=","debug")
+&elfFile=STRing.SCANAndExtract("&args","elfFile=","")
+&gdbRemote=STRing.SCANAndExtract("&args","gdbRemote=","")
+&termComPort=STRing.SCANAndExtract("&args","terminal=","")
+&userScript=STRing.SCANAndExtract("&args","userScript=","")
+
+IF "&command"=="flash"
+(
+  ; Execute the application and quit
+  QUIT -1
+)
+
+IF "&elfFile"==""
+(
+  PRINT %ERROR "Missing ELF file path"
+  PLIST
+  STOP
+  ENDDO
+)
+
+;
+; process system-wide settings
+;
+IF OS.FILE("~~/system-settings.cmm")
+  DO "~~/system-settings.cmm"
+
+;
+; CPU setup
+;
+SYStem.Down
+IF PRACTICE.CoMmanD.AVAILable(SYStem.CPU.NANO33BLE)
+  SYStem.CPU NANO33BLE
+ELSE
+  SYStem.CPU NRF52840QI
+
+;
+; RTOS setup
+;
+IF OS.FILE("~~/demo/arm/kernel/zephyr/v2-x/zephyr.t32")&&OS.FILE("~~/demo/arm/kernel/zephyr/v2-x/zephyr.men")
+(
+  TASK.CONFIG ~~/demo/arm/kernel/zephyr/v2-x/zephyr.t32
+  MENU.ReProgram ~~/demo/arm/kernel/zephyr/v2-x/zephyr.men
+)
+
+;
+; connect to the target
+;
+IF INTERFACE.GDB()
+(
+  IF ("&gdbRemote"=="")&&("&GDBPORT"!="")
+    &gdbRemote="&GDBPORT"
+
+  IF "&gdbRemote"!=""
+  (
+    PRINT "Use gdb remote: &gdbRemote"
+  )
+  ELSE
+  (
+    PRINT %ERROR "GDB Port not defined."
+    PLIST
+    STOP
+    ENDDO
+  )
+
+  TITLE "TRACE32 PowerView front-end debugger for Nano 33 BLE (remote=&gdbRemote)"
+
+  IF !SYStem.Up()
+  (
+    SYStem.PORT &gdbRemote
+    Break.CONFIG.METHOD.Program Onchip
+    SYStem.Option MMUSPACES ON
+
+    ON ERROR CONTinue
+    ERROR.RESet
+    SYStem.Mode Attach
+    ON ERROR nothing
+    IF ERROR.OCCURRED()
+    (
+      PRINT %ERROR  "Error while connecting to the target."
+      PLIST
+      STOP
+      ENDDO
+    )
+  )
+)
+ELSE
+(
+  SYStem.CONFIG.DEBUGPORTTYPE SWD
+  SYStem.UP
+)
+
+;
+; load ELF
+;
+Data.LOAD.Elf "&elfFile"
+
+;
+; Window initialization
+;
+IF ("&userScript"!="")&&FILE.EXIST("&userScript")
+(
+  DO "&userScript"
+)
+ELSE
+(
+  ; Setup minimal debug environment
+  WinCLEAR
+  SETUP.Var.%SpotLight
+  WinPOS 0. 0. 120. 30.
+  List.auto
+  WinPOS 125. 0. 80. 10.
+  Frame.view
+  WinPOS 125. 18.
+  Register.view /SpotLight
+
+  IF "&termComPort"!=""
+  (
+    SUBTITLE " &termComPort"
+    TERM.RESet
+    TERM.METHOD COM &termComPort 115200 8 NONE 1STOP NONE
+    TERM.Mode VT100
+    WinPOS 104.88 35.286 91. 24. 0. 0. W001
+    TERM.view
+    SUBTITLE ""
+  )
+)
+
+ENDDO


### PR DESCRIPTION
Lauterbach provides the particular version of the TRACE32 limited to use with the Arduino Nano 33 BLE.
https://docs.arduino.cc/tutorials/nano-33-ble/trace-32
The license of it ties to Arduino Nano 33 BLE hardware serial number. It also works with the ZephyrRTOS.

Add configuration for GDB-Frontend version of TRACE32.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>