### PR TITLE
boards: arduino_nano_33_ble: add support for blackmagicprobe

### DIFF
--- a/boards/arm/arduino_nano_33_ble/board.cmake
+++ b/boards/arm/arduino_nano_33_ble/board.cmake
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 include(${ZEPHYR_BASE}/boards/common/bossac.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)


### PR DESCRIPTION
Add support to debugging and flashing with the blackmagicprobe.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>