### PR TITLE
samples: blinky_pwm: fix missing project renaming

### DIFF
--- a/samples/basic/blinky_pwm/CMakeLists.txt
+++ b/samples/basic/blinky_pwm/CMakeLists.txt
@@ -2,6 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(blink_led)
+project(blinky_pwm)
 
 target_sources(app PRIVATE src/main.c)


### PR DESCRIPTION
The commit bfb1040612b69307ec177ca87cf31ee591527757 has renamed the sample blink_led to blinky_pwm, however, the project still have the former name: blink_led.

This renames the project to its new name: blinky_pwm.

Signed-off-by: Gaël PORTAY <gael.portay@gmail.com>