### PR TITLE
samples: modbus: print returned error code

### DIFF
--- a/samples/subsys/modbus/rtu_client/src/main.c
+++ b/samples/subsys/modbus/rtu_client/src/main.c
@@ -53,7 +53,7 @@ void main(void)
 	err = modbus_write_holding_regs(client_iface, node, 0, holding_reg,
 					ARRAY_SIZE(holding_reg));
 	if (err != 0) {
-		LOG_ERR("FC16 failed");
+		LOG_ERR("FC16 failed with %d", err);
 		return;
 	}
 


### PR DESCRIPTION
This prints the returned error code, just like the other calls do.

Signed-off-by: Gaël PORTAY <gael.portay@gmail.com>