### PR TITLE
include: add a few more missing headers

### DIFF
--- a/drivers/display/display_rm68200.c
+++ b/drivers/display/display_rm68200.c
@@ -9,6 +9,7 @@
 #include <zephyr/drivers/display.h>
 #include <zephyr/drivers/mipi_dsi.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(rm68200, CONFIG_DISPLAY_LOG_LEVEL);

--- a/drivers/mipi_dsi/dsi_mcux.c
+++ b/drivers/mipi_dsi/dsi_mcux.c
@@ -11,6 +11,8 @@
 #include <fsl_clock.h>
 #include <zephyr/logging/log.h>
 
+#include <soc.h>
+
 LOG_MODULE_REGISTER(dsi_mcux, CONFIG_MIPI_DSI_LOG_LEVEL);
 
 #define MIPI_DPHY_REF_CLK DT_INST_PROP(0, dphy_ref_frequency)


### PR DESCRIPTION
More missing headers: kernel.h (rm68200 display) and soc.h (mcux mipi-dsi).