### PR TITLE
shell: uart: added SHELL_BACKEND_SERIAL_AUTOSTART configuration option

### DIFF
--- a/include/zephyr/shell/shell_uart.h
+++ b/include/zephyr/shell/shell_uart.h
@@ -81,6 +81,16 @@ struct shell_uart {
  */
 const struct shell *shell_backend_uart_get_ptr(void);
 
+/**
+ * @brief This function enables shell uart backend
+ *
+ * Function can be used to enable uart shell, useful when
+ * SHELL_BACKEND_SERIAL_AUTOSTART is disabled.
+ *
+ * @returns Standard error code.
+ */
+int shell_backend_uart_enable(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -25,10 +25,17 @@ config SHELL_BACKEND_SERIAL
 
 if SHELL_BACKEND_SERIAL
 
+config SHELL_BACKEND_SERIAL_AUTOSTART
+	bool "Auto-start shell serial backend at boot"
+	default y
+	help
+	  If enabled, shell serial backend will be automatically started.
+
 config SHELL_BACKEND_SERIAL_INIT_PRIORITY
 	int "Initialization priority"
 	default 0
 	range 0 99
+	depends on SHELL_BACKEND_SERIAL_AUTOSTART
 	help
 	  Initialization priority for UART backend. This must be bigger than
 	  the initialization priority of the used serial device.

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -332,15 +332,24 @@ static int enable_shell_uart(const struct device *arg)
 		smp_shell_init();
 	}
 
-	shell_init(&shell_uart, dev, cfg_flags, log_backend, level);
-
-	return 0;
+	return shell_init(&shell_uart, dev, cfg_flags, log_backend, level);
 }
 
+#if CONFIG_SHELL_BACKEND_SERIAL_AUTOSTART
 SYS_INIT(enable_shell_uart, POST_KERNEL,
 	 CONFIG_SHELL_BACKEND_SERIAL_INIT_PRIORITY);
+#endif
 
 const struct shell *shell_backend_uart_get_ptr(void)
 {
 	return &shell_uart;
+}
+
+int shell_backend_uart_enable(void)
+{
+#if CONFIG_SHELL_BACKEND_SERIAL_AUTOSTART
+	return 0;
+#else
+	return enable_shell_uart(NULL);
+#endif
 }


### PR DESCRIPTION
In some applications, there is a need to don't start the shell by default, but run it later on some special condition.

When SHELL_BACKEND_SERIAL_AUTOSTART is set to n, the shell is not started after boot but can be enabled later from the application code.

Contains proposal from https://github.com/zephyrproject-rtos/zephyr/pull/51507