### PR TITLE
mgmt: mcumgr: Deprecate returning rc responses when status is OK.

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -364,6 +364,12 @@ Libraries / Subsystems
     Private headers for above areas can be accessed, when required, using paths:
     ``mgmt/mcumgr/mgmt/<mcumgr_subarea>/``.
 
+  * MCUmgr responses where ``rc`` (result code) is 0 (no error) will no longer
+    be present in responses and in cases where there is only an ``rc`` result,
+    the resultant response will now be an empty CBOR map. The old behaviour can
+    be restored by enabling
+    :kconfig:option:`CONFIG_MCUMGR_SMP_LEGACY_RC_BEHAVIOUR`.
+
 * LwM2M
 
   * The ``lwm2m_senml_cbor_*`` files have been regenerated using zcbor 0.6.0.

--- a/doc/services/device_mgmt/smp_groups/smp_group_0.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_0.rst
@@ -87,7 +87,7 @@ CBOR data of successful response:
         (str)"r"        : (str)
     }
 
-In case of error the CBOR data takes form:
+In case of error the CBOR data takes the form:
 
 .. code-block:: none
 
@@ -104,6 +104,7 @@ where:
     | "r"                   | Replying echo string                              |
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
 
 Task statistics command
@@ -125,7 +126,7 @@ Task statistics request header fields:
     | ``0``  | ``0``        |  ``2``         |
     +--------+--------------+----------------+
 
-The command sends empty CBOR map as data.
+The command sends an empty CBOR map as data.
 
 
 Task statistics response
@@ -142,7 +143,7 @@ Task statistics response header fields:
     | ``1``  | ``0``        |  ``2``         |
     +--------+--------------+----------------+
 
-CBOR data of response:
+CBOR data of successful response:
 
 .. code-block:: none
 
@@ -161,9 +162,15 @@ CBOR data of response:
             }
             ...
         }
-        (str)"rc" : (int)
     }
 
+In case of error the CBOR data takes the form:
+
+.. code-block:: none
+
+    {
+        (str)"rc"       : (int)
+    }
 
 where:
 
@@ -192,6 +199,7 @@ where:
     | "next_checkin"        | set to 0 by Zephyr                                |
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
 
 .. note::
@@ -218,7 +226,7 @@ Memory pool statistics request header fields:
     | ``0``  | ``0``        |  ``3``         |
     +--------+--------------+----------------+
 
-The command sends empty CBOR map as data.
+The command sends an empty CBOR map as data.
 
 Memory pool statistics response
 ===============================
@@ -234,7 +242,7 @@ Memory pool statistics response header fields:
     | ``1``  | ``0``        |  ``3``         |
     +--------+--------------+----------------+
 
-CBOR data of response:
+CBOR data of successful response:
 
 .. code-block:: none
 
@@ -246,7 +254,14 @@ CBOR data of response:
             (str)"min'      : (int)
         }
         ...
-        (str)"rc" : (int)
+    }
+
+In case of error the CBOR data takes the form:
+
+.. code-block:: none
+
+    {
+        (str)"rc"       : (int)
     }
 
 where:
@@ -268,6 +283,7 @@ where:
     |                       | during run-time                                   |
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
 
 Date-time command
@@ -298,7 +314,7 @@ Date-time request header fields:
     | ``0``  | ``0``        |  ``4``         |
     +--------+--------------+----------------+
 
-The command sends empty CBOR map as data.
+The command sends an empty CBOR map as data.
 
 Data-time get response
 ----------------------
@@ -314,13 +330,20 @@ Date-time get response header fields:
     | ``1``  | ``0``        |  ``4``         |
     +--------+--------------+----------------+
 
-CBOR data of response:
+CBOR data of successful response:
 
 .. code-block:: none
 
     {
         (str)"datetime" : (str)
-        (opt,str)"rc"   : (int)
+    }
+
+In case of error the CBOR data takes the form:
+
+.. code-block:: none
+
+    {
+        (str)"rc"       : (int)
     }
 
 where:
@@ -333,7 +356,7 @@ where:
     |                       | yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ                 |
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`;          |
-    |                       | may not appear if 0                               |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
 
 
@@ -388,7 +411,8 @@ Date-time set response header fields:
     | ``1``  | ``0``        |  ``4``         |
     +--------+--------------+----------------+
 
-CBOR data of response:
+The command sends an empty CBOR map as data if successful. In case of error the
+CBOR data takes the form:
 
 .. code-block:: none
 
@@ -403,6 +427,7 @@ where:
 
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
 
 System reset
@@ -431,7 +456,7 @@ System reset request header fields:
     | ``2``  | ``0``        |  ``5``         |
     +--------+--------------+----------------+
 
-Normally the command sends empty CBOR map as data, but if previous
+Normally the command sends an empty CBOR map as data, but if previous
 reset attempt has been responded with "rc" code equal ``10`` (busy),
 then following map may be send to force the reset:
 
@@ -465,12 +490,13 @@ System reset response header fields
     | ``3``  | ``0``        |  ``5``         |
     +--------+--------------+----------------+
 
-CBOR data of response:
+The command sends an empty CBOR map as data if successful. In case of error the
+CBOR data takes the form:
 
 .. code-block:: none
 
     {
-        (opt,str)"rc"       : (int)
+        (str)"rc"       : (int)
     }
 
 where:
@@ -480,7 +506,7 @@ where:
 
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`;          |
-    |                       | may not appear if 0                               |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
 
 MCUMGR Parameters
@@ -502,7 +528,7 @@ MCUMGR parameters request header fields:
     | ``0``  | ``0``        |  ``6``         |
     +--------+--------------+----------------+
 
-The command sends empty CBOR map as data.
+The command sends an empty CBOR map as data.
 
 MCUMGR Parameters Response
 ==========================
@@ -518,14 +544,21 @@ MCUMGR parameters response header fields
     | ``2``  | ``0``        |  ``6``         |
     +--------+--------------+----------------+
 
-CBOR data of response:
+CBOR data of successful response:
 
 .. code-block:: none
 
     {
         (str)"buf_size"     : (uint)
         (str)"buf_count"    : (uint)
-        (opt,str)"rc"       : (int)
+    }
+
+In case of error the CBOR data takes the form:
+
+.. code-block:: none
+
+    {
+        (str)"rc"       : (int)
     }
 
 where:
@@ -540,5 +573,5 @@ where:
     | "buf_count"           | Number of SMP buffers supported                   |
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`;          |
-    |                       | may not appear if 0                               |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+

--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -125,7 +125,7 @@ CBOR data of successful response:
         (str,opt)"splitStatus" : (int)
     }
 
-In case of error the CBOR data takes form:
+In case of error the CBOR data takes the form:
 
 .. code-block:: none
 
@@ -180,6 +180,7 @@ where:
     |                       | with application part; this is unused by Zephyr   |
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
     | "rsn"                 | optional string that clarifies reason for an      |
     |                       | error; specifically useful for error code ``1``,  |
@@ -319,13 +320,19 @@ Set state of image request header fields:
     | ``3``  | ``1``        |  ``1``         |
     +--------+--------------+----------------+
 
-CBOR data of response:
-
+CBOR data of successful response:
 
 .. code-block:: none
 
     {
         (str,opt)"off"  : (uint)
+    }
+
+In case of error the CBOR data takes the form:
+
+.. code-block:: none
+
+    {
         (str)"rc"       : (int)
         (str,opt)"rsn"  : (str)
     }
@@ -339,6 +346,7 @@ where:
     | "off"                 | offset of last successfully written byte of update|
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
     | "rsn"                 | Optional string that clarifies reason for an      |
     |                       | error; specifically useful for error code ``1``,  |
@@ -405,7 +413,8 @@ Image erase response header fields:
     | ``3``  | ``1``        |  ``5``         |
     +--------+--------------+----------------+
 
-CBOR data of response:
+The command sends an empty CBOR map as data if successful. In case of error the
+CBOR data takes the form:
 
 .. code-block:: none
 
@@ -421,6 +430,7 @@ where:
 
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
     | "rsn"                 | Optional string that clarifies reason for an      |
     |                       | error; specifically useful for error code ``1``,  |

--- a/doc/services/device_mgmt/smp_groups/smp_group_2.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_2.rst
@@ -41,7 +41,7 @@ Statistics group data request header:
     | ``0``  | ``2``        |  ``0``         |
     +--------+--------------+----------------+
 
-CBOR Payload of request:
+CBOR data of request:
 
 .. code-block:: none
 
@@ -72,7 +72,7 @@ Statistics group data response header:
     | ``1``  | ``2``        |  ``0``         |
     +--------+--------------+----------------+
 
-CBOR Payload of response:
+CBOR data of successful response:
 
 .. code-block:: none
 
@@ -82,6 +82,13 @@ CBOR Payload of response:
             (str)<entry_name> : (uint)
             ...
         }
+    }
+
+In case of error the CBOR data takes the form:
+
+.. code-block:: none
+
+    {
         (str)"rc"       : (int)
     }
 
@@ -102,6 +109,7 @@ where:
     |                       | to unsigned integer type, in a CBOR meaning       |
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
 
 Statistics: list of groups
@@ -129,7 +137,7 @@ Statistics group list request header:
     | ``0``  | ``2``        |  ``1``         |
     +--------+--------------+----------------+
 
-The command sends empty CBOR map as data.
+The command sends an empty CBOR map as data.
 
 Statistics: list of groups response
 ===================================
@@ -145,8 +153,7 @@ Statistics group list request header:
     | ``1``  | ``2``        |  ``1``         |
     +--------+--------------+----------------+
 
-
-CBOR Payload of response:
+CBOR data of successful response:
 
 .. code-block:: none
 
@@ -154,6 +161,13 @@ CBOR Payload of response:
         (str)"stat_list" :  [
             (str)<stat_group_name>, ...
         ]
+    }
+
+In case of error the CBOR data takes the form:
+
+.. code-block:: none
+
+    {
         (str)"rc"       : (int)
     }
 
@@ -167,4 +181,5 @@ where:
     |                       | array may be empty if there are no groups         |
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+

--- a/doc/services/device_mgmt/smp_groups/smp_group_8.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_8.rst
@@ -102,11 +102,10 @@ CBOR data of successful response:
     {
         (str)"off"      : (uint)
         (str)"data"     : (byte str)
-        (str)"rc"       : (int)
         (str,opt)"len"  : (uint)
     }
 
-In case of error the CBOR data takes form:
+In case of error the CBOR data takes the form:
 
 .. code-block:: none
 
@@ -130,6 +129,7 @@ where:
     |                       | when "off" is 0                                   |
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
 
 In case when "rc" is not 0, success, the other fields will not appear.
@@ -218,13 +218,20 @@ File upload response header:
     | ``3``  | ``8``        |  ``0``         |
     +--------+--------------+----------------+
 
-CBOR data of request:
+CBOR data of successful response:
 
 .. code-block:: none
 
     {
-        (str,opt)"off"      : (uint)
-        (str)"rc"           : (int)
+        (str)"off"      : (uint)
+    }
+
+In case of error the CBOR data takes the form:
+
+.. code-block:: none
+
+    {
+        (str)"rc"       : (int)
     }
 
 where:
@@ -233,10 +240,10 @@ where:
     :align: center
 
     +-----------------------+---------------------------------------------------+
-    | "off"                 | offset of last successfully written data;         |
-    |                       | appears only when "rc" is 0                       |
+    | "off"                 | offset of last successfully written data.         |
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
 
 File status
@@ -314,8 +321,8 @@ where:
     +-----------------------+---------------------------------------------------+
     | "len"                 | length of file (in bytes)                         |
     +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes` (only     |
-    |                       | present if an error occurred)                     |
+    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
 
 In case when "rc" is not 0, success, the other fields will not appear.
@@ -417,7 +424,7 @@ CBOR data of successful response:
         (str)"output"   : (uint or bstr)
     }
 
-In case of error the CBOR data takes form:
+In case of error the CBOR data takes the form:
 
 .. code-block:: none
 
@@ -431,8 +438,8 @@ where:
     :align: center
 
     +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes` (only     |
-    |                       | present if an error occurred)                     |
+    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
     | "type"                | type of hash/checksum that was performed          |
     |                       | :ref:`mcumgr_group_8_hash_checksum_types`         |

--- a/doc/services/device_mgmt/smp_groups/smp_group_9.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_9.rst
@@ -86,7 +86,7 @@ CBOR data of successful response:
         (str)"ret"          : (int)
     }
 
-In case of error the CBOR data takes form:
+In case of error the CBOR data takes the form:
 
 .. code-block:: none
 
@@ -100,15 +100,13 @@ where:
     :align: center
 
     +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes` (only     |
-    |                       | present if an error occurred)                     |
+    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
     | "o"                   | command output                                    |
     +-----------------------+---------------------------------------------------+
     | "ret"                 | return code from shell command execution          |
     +-----------------------+---------------------------------------------------+
-
-In case when "rc" is not 0, success, the other fields will not appear.
 
 .. note::
     In older versions of Zephyr, "rc" was used for both the mcumgr status code

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -125,6 +125,18 @@ config MCUMGR_SMP_COMMAND_STATUS_HOOKS
 	  This will enable SMP command status notification hooks for when an SMP message is
 	  received or processed.
 
+config MCUMGR_SMP_LEGACY_RC_BEHAVIOUR
+	bool "Legacy rc (result code) response behaviour"
+	help
+	  This will enable legacy result code response behaviour of having rc
+	  present in responses when the status is 0. With this option disabled,
+	  mcumgr acts with new behaviour and will only return rc is the result
+	  code is non-zero (i.e. an error occurred).
+
+	  If a command only returns a result code, this will mean that the
+	  response will be empty with the new behaviour enabled, as opposed to
+	  the old behaviour where the rc field will be present in the response.
+
 menu "Command Handlers"
 
 rsource "grp/Kconfig"

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -303,7 +303,8 @@ img_mgmt_erase(struct smp_streamer *ctxt)
 		return rc;
 	}
 
-	if (zcbor_tstr_put_lit(zse, "rc") && zcbor_int32_put(zse, 0)) {
+	if (IS_ENABLED(CONFIG_MCUMGR_SMP_LEGACY_RC_BEHAVIOUR) && zcbor_tstr_put_lit(zse, "rc") &&
+	    zcbor_int32_put(zse, 0)) {
 		return MGMT_ERR_EOK;
 	}
 
@@ -314,12 +315,15 @@ static int
 img_mgmt_upload_good_rsp(struct smp_streamer *ctxt)
 {
 	zcbor_state_t *zse = ctxt->writer->zs;
-	bool ok;
+	bool ok = true;
 
-	ok = zcbor_tstr_put_lit(zse, "rc")			&&
-	     zcbor_int32_put(zse, MGMT_ERR_EOK)			&&
-	     zcbor_tstr_put_lit(zse, "off")			&&
-	     zcbor_size_put(zse, g_img_mgmt_state.off);
+	if (IS_ENABLED(CONFIG_MCUMGR_SMP_LEGACY_RC_BEHAVIOUR)) {
+		ok = zcbor_tstr_put_lit(zse, "rc")		&&
+		     zcbor_int32_put(zse, MGMT_ERR_EOK);
+	}
+
+	ok = ok && zcbor_tstr_put_lit(zse, "off")		&&
+		   zcbor_size_put(zse, g_img_mgmt_state.off);
 
 	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }

--- a/subsys/mgmt/mcumgr/grp/stat_mgmt/src/stat_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/stat_mgmt/src/stat_mgmt.c
@@ -157,12 +157,17 @@ stat_mgmt_show(struct smp_streamer *ctxt)
 		return MGMT_ERR_EUNKNOWN;
 	}
 
-	ok = zcbor_tstr_put_lit(zse, "rc")		&&
-	     zcbor_int32_put(zse, MGMT_ERR_EOK)		&&
-	     zcbor_tstr_put_lit(zse, "name")		&&
-	     zcbor_tstr_encode(zse, &value)		&&
-	     zcbor_tstr_put_lit(zse, "fields")		&&
-	     zcbor_map_start_encode(zse, counter);
+	if (IS_ENABLED(CONFIG_MCUMGR_SMP_LEGACY_RC_BEHAVIOUR)) {
+		ok = zcbor_tstr_put_lit(zse, "rc")		&&
+		     zcbor_int32_put(zse, MGMT_ERR_EOK);
+	}
+
+	if (ok) {
+		ok = zcbor_tstr_put_lit(zse, "name")		&&
+		     zcbor_tstr_encode(zse, &value)		&&
+		     zcbor_tstr_put_lit(zse, "fields")		&&
+		     zcbor_map_start_encode(zse, counter);
+	}
 
 	if (ok) {
 		int rc = stat_mgmt_foreach_entry(zse, stat_name,


### PR DESCRIPTION
This change deprecates the previous mcumgr behaviour of return result codes when the status is 0 (OK), instead it will skip the rc field for these responses. If there is only an rc field with status 0 to return, then mcumgr will now instead just return an empty map.

Fixes #42590

- [X] Remove rc responses when status is 0
- [X] Add deprecation warning/notice
- [X] Release notes update
- [X] Documentation update
- [X] Manual tests (mcumgr command line tool functions fine with new behaviour)