### PR TITLE
doc: mgmt: mcumgr: Improve descriptions and add links

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h
@@ -23,7 +23,7 @@ extern "C" {
  * Structure provided in the #MGMT_EVT_OP_FS_MGMT_FILE_ACCESS notification callback: This callback
  * function is used to notify the application about a pending file read/write request and to
  * authorise or deny it. Access will be allowed so long as all notification handlers return
- * MGMT_ERR_EOK, if one returns an error then access will be denied.
+ * #MGMT_ERR_EOK, if one returns an error then access will be denied.
  */
 struct fs_mgmt_file_access {
 	/** True if the request is for uploading data to the file, otherwise false */

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -12,9 +12,14 @@
 #include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>
 #include <zephyr/mgmt/mcumgr/smp/smp.h>
 #include <zephyr/mgmt/mcumgr/grp/img_mgmt/image.h>
-
 #include <zcbor_common.h>
 
+/**
+ * @brief MCUmgr img_mgmt API
+ * @defgroup mcumgr_img_mgmt MCUmgr img_mgmt API
+ * @ingroup mcumgr
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,7 +29,7 @@ extern "C" {
 #define IMG_MGMT_HASH_LEN	32
 #define IMG_MGMT_DATA_SHA_LEN	32 /* SHA256 */
 
-/*
+/**
  * Image state flags
  */
 #define IMG_MGMT_STATE_F_PENDING	0x01
@@ -35,7 +40,7 @@ extern "C" {
 /* 255.255.65535.4294967295\0 */
 #define IMG_MGMT_VER_MAX_STR_LEN	(sizeof("255.255.65535.4294967295"))
 
-/*
+/**
  * Swap Types for image management state machine
  */
 #define IMG_MGMT_SWAP_TYPE_NONE		0
@@ -54,12 +59,14 @@ extern "C" {
 #define IMG_MGMT_ID_CORELOAD	4
 #define IMG_MGMT_ID_ERASE	5
 
-/*
+/**
  * IMG_MGMT_ID_UPLOAD statuses.
  */
-#define IMG_MGMT_ID_UPLOAD_STATUS_START		0
-#define IMG_MGMT_ID_UPLOAD_STATUS_ONGOING	1
-#define IMG_MGMT_ID_UPLOAD_STATUS_COMPLETE	2
+enum img_mgmt_id_upload_t {
+	IMG_MGMT_ID_UPLOAD_STATUS_START		= 0,
+	IMG_MGMT_ID_UPLOAD_STATUS_ONGOING,
+	IMG_MGMT_ID_UPLOAD_STATUS_COMPLETE,
+};
 
 extern int boot_current_slot;
 extern struct img_mgmt_state g_img_mgmt_state;
@@ -239,6 +246,10 @@ extern const char *img_mgmt_err_str_image_bad_flash_addr;
 #define IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, rsn)
 #define IMG_MGMT_UPLOAD_ACTION_RC_RSN(action) NULL
 #endif
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_callbacks.h
@@ -25,7 +25,7 @@ extern "C" {
  * Structure provided in the #MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK notification callback: This callback
  * function is used to notify the application about a pending firmware upload packet from a client
  * and authorise or deny it. Upload will be allowed so long as all notification handlers return
- * MGMT_ERR_EOK, if one returns an error then the upload will be denied.
+ * #MGMT_ERR_EOK, if one returns an error then the upload will be denied.
  */
 struct img_mgmt_upload_check {
 	/** Action to take */

--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -53,23 +53,22 @@ extern "C" {
  *
  * This callback function is used to notify an application or system about a mcumgr mgmt event.
  *
- * @param event		MGMT_EVT_OP_[...].
- * @param rc		MGMT_ERR_[...] of the previous handler calls, if it is an error then it
+ * @param event		#mcumgr_op_t.
+ * @param rc		#mcumgr_err_t of the previous handler calls, if it is an error then it
  *			will be the first error that was returned by a handler (i.e. this handler
  *			is being called for a notification only, the return code will be ignored).
  * @param abort_more	Set to true to abort further processing by additional handlers.
  * @param data		Optional event argument.
  * @param data_size	Size of optional event argument (0 if no data is provided).
  *
- * @return		MGMT_ERR_[...] of the status to return to the calling code (only checked
+ * @return		#mcumgr_err_t of the status to return to the calling code (only checked
  *			when failed is false).
  */
 typedef int32_t (*mgmt_cb)(uint32_t event, int32_t rc, bool *abort_more, void *data,
 			   size_t data_size);
 
 /**
- * MGMT event callback group IDs. Note that this is not a 1:1 mapping with MGMT_GROUP_ID_[...]
- * values.
+ * MGMT event callback group IDs. Note that this is not a 1:1 mapping with #mcumgr_group_t values.
  */
 enum mgmt_cb_groups {
 	MGMT_EVT_GRP_ALL			= 0,
@@ -169,17 +168,17 @@ struct mgmt_callback {
  * Arguments for #MGMT_EVT_OP_CMD_RECV, #MGMT_EVT_OP_CMD_STATUS and #MGMT_EVT_OP_CMD_DONE
  */
 struct mgmt_evt_op_cmd_arg {
-	/** MGMT_GROUP_ID_[...] */
+	/** #mcumgr_group_t */
 	uint16_t group;
 
 	/** Message ID within group */
 	uint8_t id;
 
 	union {
-		/** MGMT_ERR_[...], used in #MGMT_EVT_OP_CMD_DONE */
+		/** #mcumgr_err_t, used in #MGMT_EVT_OP_CMD_DONE */
 		int err;
 
-		/** IMG_MGMT_ID_UPLOAD_STATUS_[...], used in #MGMT_EVT_OP_CMD_STATUS */
+		/** #img_mgmt_id_upload_t, used in #MGMT_EVT_OP_CMD_STATUS */
 		int status;
 	};
 };
@@ -187,11 +186,11 @@ struct mgmt_evt_op_cmd_arg {
 /**
  * @brief This function is called to notify registered callbacks about mcumgr notifications/events.
  *
- * @param event		MGMT_EVT_OP_[...].
+ * @param event		#mcumgr_op_t.
  * @param data		Optional event argument.
  * @param data_size	Size of optional event argument (0 if none).
  *
- * @return		MGMT_ERR_[...] either MGMT_ERR_EOK if all handlers returned it, or the
+ * @return		#mcumgr_err_t either #MGMT_ERR_EOK if all handlers returned it, or the
  *			error code of the first handler that returned an error.
  */
 int32_t mgmt_callback_notify(uint32_t event, void *data, size_t data_size);

--- a/include/zephyr/mgmt/mcumgr/mgmt/mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/mgmt.h
@@ -16,51 +16,116 @@
 extern "C" {
 #endif
 
+/**
+ * @brief MCUmgr mgmt API
+ * @defgroup mcumgr_mgmt_api MCUmgr mgmt API
+ * @ingroup mcumgr
+ * @{
+ */
+
 /** Opcodes; encoded in first byte of header. */
-#define MGMT_OP_READ		0
-#define MGMT_OP_READ_RSP	1
-#define MGMT_OP_WRITE		2
-#define MGMT_OP_WRITE_RSP	3
+enum mcumgr_op_t {
+	/** Read op-code */
+	MGMT_OP_READ		= 0,
+
+	/** Read response op-code */
+	MGMT_OP_READ_RSP,
+
+	/** Write op-code */
+	MGMT_OP_WRITE,
+
+	/** Write response op-code */
+	MGMT_OP_WRITE_RSP,
+};
 
 /**
- * The first 64 groups are reserved for system level mcumgr commands.
- * Per-user commands are then defined after group 64.
+ * MCUmgr groups. The first 64 groups are reserved for system level mcumgr
+ * commands. Per-user commands are then defined after group 64.
  */
-#define MGMT_GROUP_ID_OS	0
-#define MGMT_GROUP_ID_IMAGE	1
-#define MGMT_GROUP_ID_STAT	2
-#define MGMT_GROUP_ID_CONFIG	3
-#define MGMT_GROUP_ID_LOG	4
-#define MGMT_GROUP_ID_CRASH	5
-#define MGMT_GROUP_ID_SPLIT	6
-#define MGMT_GROUP_ID_RUN	7
-#define MGMT_GROUP_ID_FS	8
-#define MGMT_GROUP_ID_SHELL	9
+enum mcumgr_group_t {
+	/** OS (operating system) group */
+	MGMT_GROUP_ID_OS	= 0,
 
-/** Zephyr-specific groups decrease from PERUSER to avoid collision with user defined groups. */
-#define ZEPHYR_MGMT_GRP_BASE	(MGMT_GROUP_ID_PERUSER - 1)
+	/** Image management group, used for uploading firmware images */
+	MGMT_GROUP_ID_IMAGE,
 
-/** Basic group */
-#define ZEPHYR_MGMT_GRP_BASIC	ZEPHYR_MGMT_GRP_BASE
+	/** Statistic management group, used for retieving statistics */
+	MGMT_GROUP_ID_STAT,
 
-#define MGMT_GROUP_ID_PERUSER	64
+	/** System configuration group (unused) */
+	MGMT_GROUP_ID_CONFIG,
+
+	/** Log management group (unused) */
+	MGMT_GROUP_ID_LOG,
+
+	/** Crash group (unused) */
+	MGMT_GROUP_ID_CRASH,
+
+	/** Split image management group (unused) */
+	MGMT_GROUP_ID_SPLIT,
+
+	/** Run group (unused) */
+	MGMT_GROUP_ID_RUN,
+
+	/** FS (file system) group, used for performing file IO operations */
+	MGMT_GROUP_ID_FS,
+
+	/** Shell management group, used for executing shell commands */
+	MGMT_GROUP_ID_SHELL,
+
+	/** User groups defined from 64 onwards */
+	MGMT_GROUP_ID_PERUSER	= 64,
+
+	/** Zephyr-specific groups decrease from PERUSER to avoid collision with upstream and
+	 *  user-defined groups.
+	 *  Zephyr-specific: Basic group
+	 */
+	ZEPHYR_MGMT_GRP_BASIC	= (MGMT_GROUP_ID_PERUSER - 1),
+};
 
 /**
- * mcumgr error codes.
+ * MCUmgr error codes.
  */
-#define MGMT_ERR_EOK		0
-#define MGMT_ERR_EUNKNOWN	1
-#define MGMT_ERR_ENOMEM		2
-#define MGMT_ERR_EINVAL		3
-#define MGMT_ERR_ETIMEOUT	4
-#define MGMT_ERR_ENOENT		5
-#define MGMT_ERR_EBADSTATE	6	/* Current state disallows command. */
-#define MGMT_ERR_EMSGSIZE	7	/* Response too large. */
-#define MGMT_ERR_ENOTSUP	8	/* Command not supported. */
-#define MGMT_ERR_ECORRUPT	9	/* Corrupt */
-#define MGMT_ERR_EBUSY		10	/* Command blocked by processing of other command */
-#define MGMT_ERR_EACCESSDENIED	11	/* Access to specific function or resource denied */
-#define MGMT_ERR_EPERUSER	256
+enum mcumgr_err_t {
+	/** No error (success). */
+	MGMT_ERR_EOK		= 0,
+
+	/** Unknown error. */
+	MGMT_ERR_EUNKNOWN,
+
+	/** Insufficient memory (likely not enough space for CBOR object). */
+	MGMT_ERR_ENOMEM,
+
+	/** Error in input value. */
+	MGMT_ERR_EINVAL,
+
+	/** Operation timed out. */
+	MGMT_ERR_ETIMEOUT,
+
+	/** No such file/entry. */
+	MGMT_ERR_ENOENT,
+
+	/** Current state disallows command. */
+	MGMT_ERR_EBADSTATE,
+
+	/** Response too large. */
+	MGMT_ERR_EMSGSIZE,
+
+	/** Command not supported. */
+	MGMT_ERR_ENOTSUP,
+
+	/** Corrupt */
+	MGMT_ERR_ECORRUPT,
+
+	/** Command blocked by processing of other command */
+	MGMT_ERR_EBUSY,
+
+	/** Access to specific function, command or resource denied */
+	MGMT_ERR_EACCESSDENIED,
+
+	/** User errors defined from 256 onwards */
+	MGMT_ERR_EPERUSER	= 256
+};
 
 #define MGMT_HDR_SIZE		8
 
@@ -101,7 +166,7 @@ typedef void (*mgmt_reset_buf_fn)(void *buf, void *arg);
  *
  * @param ctxt	The mcumgr context to use.
  *
- * @return 0 if a response was successfully encoded, MGMT_ERR_[...] code on failure.
+ * @return 0 if a response was successfully encoded, #mcumgr_err_t code on failure.
  */
 typedef int (*mgmt_handler_fn)(struct smp_streamer *ctxt);
 
@@ -152,6 +217,10 @@ void mgmt_unregister_group(struct mgmt_group *group);
  *		NULL on failure.
  */
 const struct mgmt_handler *mgmt_find_handler(uint16_t group_id, uint16_t command_id);
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/mgmt/mcumgr/smp/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp/smp.h
@@ -89,7 +89,7 @@ struct smp_streamer {
  * @param streamer	The streamer providing the required SMP callbacks.
  * @param req		The request packet to process.
  *
- * @return 0 on success, MGMT_ERR_[...] code on failure.
+ * @return 0 on success, #mcumgr_err_t code on failure.
  */
 int smp_process_request_packet(struct smp_streamer *streamer, void *req);
 

--- a/include/zephyr/mgmt/mcumgr/transport/smp.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp.h
@@ -14,6 +14,13 @@
 extern "C" {
 #endif
 
+/**
+ * @brief MCUmgr transport SMP API
+ * @defgroup mcumgr_transport_smp MCUmgr transport SMP API
+ * @ingroup mcumgr
+ * @{
+ */
+
 struct smp_transport;
 struct zephyr_smp_transport;
 struct net_buf;
@@ -25,7 +32,7 @@ struct net_buf;
  *
  * @param nb                    The net_buf to transmit.
  *
- * @return                      0 on success, MGMT_ERR_[...] code on failure.
+ * @return                      0 on success, #mcumgr_err_t code on failure.
  */
 typedef int (*smp_transport_out_fn)(struct net_buf *nb);
 /* use smp_transport_out_fn instead */
@@ -59,7 +66,7 @@ typedef uint16_t zephyr_smp_transport_get_mtu_fn(const struct net_buf *nb);
  * @param dst                   Source buffer user_data pointer.
  * @param src                   Destination buffer user_data pointer.
  *
- * @return                      0 on success, MGMT_ERR_[...] code on failure.
+ * @return                      0 on success, #mcumgr_err_t code on failure.
  */
 typedef int (*smp_transport_ud_copy_fn)(struct net_buf *dst,
 					const struct net_buf *src);
@@ -188,6 +195,10 @@ void smp_rx_remove_invalid(struct smp_transport *zst, void *arg);
  * @param zst	The transport to use.
  */
 void smp_rx_clear(struct smp_transport *zst);
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
    Makes the MCUmgr documentation on sphinx more readable and usable.

This has highlighted a bug in the zephyr mcumgr documentation which has mixed up 2 group IDs, and shows that things in the documentation e.g. IDs should not be manually generated and should automatically generated tables instead.