### PR TITLE
net: lwm2m: Don't assume time_t data type size

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -829,10 +829,10 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst, struct lwm2m_eng
 
 			if (write_buf_len == sizeof(time_t)) {
 				*(time_t *)write_buf = temp_time;
-				len = 8;
+				len = sizeof(time_t);
 			} else if (write_buf_len == sizeof(uint32_t)) {
 				*(uint32_t *)write_buf = (uint32_t)temp_time;
-				len = 4;
+				len = sizeof(uint32_t);
 			} else {
 				LOG_ERR("Time resource buf len not supported %d", write_buf_len);
 				ret = -EINVAL;


### PR DESCRIPTION
sizeof(time_t) can vary depending on architecture/libc being in use, therefore LwM2M should not assume time_t data type size. Instead of using magic numbers, use a proper sizeof.

Fixes #51559

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>