### PR TITLE
Bluetooth: Log refactor

### DIFF
--- a/drivers/bluetooth/hci/hci_b91.c
+++ b/drivers/bluetooth/hci/hci_b91.c
@@ -142,7 +142,7 @@ static void hci_b91_host_rcv_pkt(uint8_t *data, uint16_t len)
 	uint8_t pkt_indicator;
 	struct net_buf *buf;
 
-	BT_HEXDUMP_DBG(data, len, "host packet data:");
+	LOG_HEXDUMP_DBG(data, len, "host packet data:");
 
 	pkt_indicator = *data++;
 	len -= sizeof(pkt_indicator);
@@ -198,7 +198,7 @@ static int bt_b91_send(struct net_buf *buf)
 		goto done;
 	}
 
-	BT_HEXDUMP_DBG(buf->data, buf->len, "Final HCI buffer:");
+	LOG_HEXDUMP_DBG(buf->data, buf->len, "Final HCI buffer:");
 
 	if (k_sem_take(&hci_send_sem, HCI_BT_B91_TIMEOUT) == 0) {
 		b91_bt_host_send_packet(type, buf->data, buf->len);

--- a/drivers/bluetooth/hci/hci_esp32.c
+++ b/drivers/bluetooth/hci/hci_esp32.c
@@ -191,7 +191,7 @@ static int hci_esp_host_rcv_pkt(uint8_t *data, uint16_t len)
 	struct net_buf *buf = NULL;
 	size_t remaining = len;
 
-	BT_HEXDUMP_DBG(data, len, "host packet data:");
+	LOG_HEXDUMP_DBG(data, len, "host packet data:");
 
 	pkt_indicator = *data++;
 	remaining -= sizeof(pkt_indicator);
@@ -256,7 +256,7 @@ static int bt_esp32_send(struct net_buf *buf)
 	}
 	net_buf_push_u8(buf, pkt_indicator);
 
-	BT_HEXDUMP_DBG(buf->data, buf->len, "Final HCI buffer:");
+	LOG_HEXDUMP_DBG(buf->data, buf->len, "Final HCI buffer:");
 
 	if (!esp_vhci_host_check_send_available()) {
 		BT_WARN("Controller not ready to receive packets");

--- a/drivers/bluetooth/hci/rpmsg.c
+++ b/drivers/bluetooth/hci/rpmsg.c
@@ -196,7 +196,7 @@ static void bt_rpmsg_rx(const uint8_t *data, size_t len)
 	struct net_buf *buf = NULL;
 	size_t remaining = len;
 
-	BT_HEXDUMP_DBG(data, len, "RPMsg data:");
+	LOG_HEXDUMP_DBG(data, len, "RPMsg data:");
 
 	pkt_indicator = *data++;
 	remaining -= sizeof(pkt_indicator);
@@ -224,7 +224,7 @@ static void bt_rpmsg_rx(const uint8_t *data, size_t len)
 
 		bt_recv(buf);
 
-		BT_HEXDUMP_DBG(buf->data, buf->len, "RX buf payload:");
+		LOG_HEXDUMP_DBG(buf->data, buf->len, "RX buf payload:");
 	}
 }
 
@@ -251,7 +251,7 @@ static int bt_rpmsg_send(struct net_buf *buf)
 	}
 	net_buf_push_u8(buf, pkt_indicator);
 
-	BT_HEXDUMP_DBG(buf->data, buf->len, "Final HCI buffer:");
+	LOG_HEXDUMP_DBG(buf->data, buf->len, "Final HCI buffer:");
 	err = ipc_service_send(&hci_ept, buf->data, buf->len);
 	if (err < 0) {
 		BT_ERR("Failed to send (err %d)", err);

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -512,7 +512,7 @@ static uint8_t aics_client_read_desc_cb(struct bt_conn *conn, uint8_t err,
 	}
 
 	if (data) {
-		BT_HEXDUMP_DBG(data, length, "Input description read");
+		LOG_HEXDUMP_DBG(data, length, "Input description read");
 
 		/* Truncate if too large */
 		if (length > sizeof(desc) - 1) {

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -25,6 +25,7 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_ASCS)
 #define LOG_MODULE_NAME bt_ascs
 #include "common/log.h"
+#include "common/assert.h"
 
 #include "../host/hci_core.h"
 #include "../host/conn_internal.h"

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -314,7 +314,7 @@ static void ascs_codec_data_add(struct net_buf_simple *buf, const char *prefix,
 
 		BT_DBG("#%u: %s type 0x%02x len %u", i, prefix, d->type,
 		       d->data_len);
-		BT_HEXDUMP_DBG(d->data, d->data_len, prefix);
+		LOG_HEXDUMP_DBG(d->data, d->data_len, prefix);
 
 		cc = net_buf_simple_add(buf, sizeof(*cc));
 		cc->len = d->data_len + sizeof(cc->type);
@@ -1174,7 +1174,7 @@ static bool ascs_codec_config_store(struct bt_data *data, void *user_data)
 	cdata->data.data = cdata->value;
 	(void)memcpy(cdata->value, data->data, data->data_len);
 
-	BT_HEXDUMP_DBG(cdata->value, data->data_len, "data");
+	LOG_HEXDUMP_DBG(cdata->value, data->data_len, "data");
 
 	codec->data_count++;
 

--- a/subsys/bluetooth/audio/bass.c
+++ b/subsys/bluetooth/audio/bass.c
@@ -1146,7 +1146,7 @@ static ssize_t write_control_point(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 	}
 
-	BT_HEXDUMP_DBG(data, len, "Data");
+	LOG_HEXDUMP_DBG(data, len, "Data");
 
 	switch (opcode) {
 	case BT_BASS_OP_SCAN_STOP:

--- a/subsys/bluetooth/audio/bass_client.c
+++ b/subsys/bluetooth/audio/bass_client.c
@@ -186,7 +186,7 @@ static uint8_t notify_handler(struct bt_conn *conn,
 		return BT_GATT_ITER_STOP;
 	}
 
-	BT_HEXDUMP_DBG(data, length, "Receive state notification:");
+	LOG_HEXDUMP_DBG(data, length, "Receive state notification:");
 
 	index = lookup_index_by_handle(handle);
 	if (index < 0) {

--- a/subsys/bluetooth/audio/capabilities.c
+++ b/subsys/bluetooth/audio/capabilities.c
@@ -25,6 +25,7 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_AUDIO_DEBUG_CAPABILITIES)
 #define LOG_MODULE_NAME bt_audio_capability
 #include "common/log.h"
+#include "common/assert.h"
 
 static sys_slist_t snks;
 static sys_slist_t srcs;

--- a/subsys/bluetooth/audio/csis.c
+++ b/subsys/bluetooth/audio/csis.c
@@ -239,8 +239,8 @@ static ssize_t read_set_sirk(struct bt_conn *conn,
 			}
 
 			sirk = &enc_sirk;
-			BT_HEXDUMP_DBG(enc_sirk.value, sizeof(enc_sirk.value),
-				       "Encrypted Set SIRK");
+			LOG_HEXDUMP_DBG(enc_sirk.value, sizeof(enc_sirk.value),
+					"Encrypted Set SIRK");
 		} else if (cb_rsp == BT_CSIS_READ_SIRK_REQ_RSP_REJECT) {
 			return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
 		} else if (cb_rsp == BT_CSIS_READ_SIRK_REQ_RSP_OOB_ONLY) {
@@ -256,8 +256,7 @@ static ssize_t read_set_sirk(struct bt_conn *conn,
 
 	BT_DBG("Set sirk %sencrypted",
 	       sirk->type ==  BT_CSIS_SIRK_TYPE_PLAIN ? "not " : "");
-	BT_HEXDUMP_DBG(csis->srv.set_sirk.value,
-		       sizeof(csis->srv.set_sirk.value), "Set SIRK");
+	LOG_HEXDUMP_DBG(csis->srv.set_sirk.value, sizeof(csis->srv.set_sirk.value), "Set SIRK");
 	return bt_gatt_attr_read(conn, attr, buf, len, offset,
 				 sirk, sizeof(*sirk));
 }
@@ -762,6 +761,5 @@ int bt_csis_lock(struct bt_csis *csis, bool lock, bool force)
 
 void bt_csis_print_sirk(const struct bt_csis *csis)
 {
-	BT_HEXDUMP_DBG(&csis->srv.set_sirk, sizeof(csis->srv.set_sirk),
-		       "Set SIRK");
+	LOG_HEXDUMP_DBG(&csis->srv.set_sirk, sizeof(csis->srv.set_sirk), "Set SIRK");
 }

--- a/subsys/bluetooth/audio/csis_client.c
+++ b/subsys/bluetooth/audio/csis_client.c
@@ -376,9 +376,8 @@ static uint8_t sirk_notify_func(struct bt_conn *conn,
 				if (IS_ENABLED(CONFIG_BT_CSIS_CLIENT_ENC_SIRK_SUPPORT)) {
 					int err;
 
-					BT_HEXDUMP_DBG(sirk->value,
-						       sizeof(*sirk),
-						       "Encrypted Set SIRK");
+					LOG_HEXDUMP_DBG(sirk->value, sizeof(*sirk),
+							"Encrypted Set SIRK");
 					err = sirk_decrypt(conn, sirk->value,
 							   dst_sirk);
 					if (err != 0) {
@@ -393,8 +392,7 @@ static uint8_t sirk_notify_func(struct bt_conn *conn,
 				(void)memcpy(dst_sirk, sirk->value, sizeof(sirk->value));
 			}
 
-			BT_HEXDUMP_DBG(dst_sirk, BT_CSIS_SET_SIRK_SIZE,
-				       "Set SIRK");
+			LOG_HEXDUMP_DBG(dst_sirk, BT_CSIS_SET_SIRK_SIZE, "Set SIRK");
 
 			/* TODO: Notify app */
 		} else {
@@ -449,7 +447,7 @@ static uint8_t size_notify_func(struct bt_conn *conn,
 	} else {
 		BT_DBG("Notification/Indication on unknown CSIS inst");
 	}
-	BT_HEXDUMP_DBG(data, length, "Value");
+	LOG_HEXDUMP_DBG(data, length, "Value");
 
 	return BT_GATT_ITER_CONTINUE;
 }
@@ -505,7 +503,7 @@ static uint8_t lock_notify_func(struct bt_conn *conn,
 	} else {
 		BT_DBG("Notification/Indication on unknown CSIS inst");
 	}
-	BT_HEXDUMP_DBG(data, length, "Value");
+	LOG_HEXDUMP_DBG(data, length, "Value");
 
 	return BT_GATT_ITER_CONTINUE;
 }
@@ -818,7 +816,7 @@ static uint8_t csis_client_discover_insts_read_rank_cb(struct bt_conn *conn,
 
 		discover_complete(client, err);
 	} else if (data != NULL) {
-		BT_HEXDUMP_DBG(data, length, "Data read");
+		LOG_HEXDUMP_DBG(data, length, "Data read");
 
 		if (length == 1) {
 			(void)memcpy(&client->csis_insts[cur_inst->cli.idx].cli.rank,
@@ -854,7 +852,7 @@ static uint8_t csis_client_discover_insts_read_set_size_cb(struct bt_conn *conn,
 	} else if (data != NULL) {
 		struct bt_csis_client_set_info *set_info;
 
-		BT_HEXDUMP_DBG(data, length, "Data read");
+		LOG_HEXDUMP_DBG(data, length, "Data read");
 
 		set_info = &client->set_member.insts[cur_inst->cli.idx].info;
 
@@ -889,8 +887,8 @@ static int parse_sirk(struct bt_csis_client_inst *client,
 			if (IS_ENABLED(CONFIG_BT_CSIS_CLIENT_ENC_SIRK_SUPPORT)) {
 				int err;
 
-				BT_HEXDUMP_DBG(sirk->value, sizeof(sirk->value),
-					       "Encrypted Set SIRK");
+				LOG_HEXDUMP_DBG(sirk->value, sizeof(sirk->value),
+						"Encrypted Set SIRK");
 				err = sirk_decrypt(client->conn, sirk->value,
 						   set_sirk);
 				if (err != 0) {
@@ -908,8 +906,7 @@ static int parse_sirk(struct bt_csis_client_inst *client,
 		}
 
 		if (set_sirk != NULL) {
-			BT_HEXDUMP_DBG(set_sirk, BT_CSIS_SET_SIRK_SIZE,
-				       "Set SIRK");
+			LOG_HEXDUMP_DBG(set_sirk, BT_CSIS_SET_SIRK_SIZE, "Set SIRK");
 		}
 	} else {
 		BT_DBG("Invalid length");
@@ -936,7 +933,7 @@ static uint8_t csis_client_discover_insts_read_set_sirk_cb(struct bt_conn *conn,
 
 		discover_complete(client, err);
 	} else if (data != NULL) {
-		BT_HEXDUMP_DBG(data, length, "Data read");
+		LOG_HEXDUMP_DBG(data, length, "Data read");
 
 		cb_err = parse_sirk(client, data, length);
 

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -174,7 +174,7 @@ static uint8_t mcc_read_player_name_cb(struct bt_conn *conn, uint8_t err,
 	} else if (!data) {
 		cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	} else {
-		BT_HEXDUMP_DBG(data, length, "Player name read");
+		LOG_HEXDUMP_DBG(data, length, "Player name read");
 
 		if (length >= sizeof(name)) {
 			length = sizeof(name) - 1;
@@ -209,7 +209,7 @@ static uint8_t mcc_read_icon_obj_id_cb(struct bt_conn *conn, uint8_t err,
 	} else if ((!pid) || (length != BT_OTS_OBJ_ID_SIZE)) {
 		cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	} else {
-		BT_HEXDUMP_DBG(pid, length, "Icon Object ID");
+		LOG_HEXDUMP_DBG(pid, length, "Icon Object ID");
 		id = sys_get_le48(pid);
 		BT_DBG_OBJ_ID("Icon Object ID: ", id);
 	}
@@ -238,7 +238,7 @@ static uint8_t mcc_read_icon_url_cb(struct bt_conn *conn, uint8_t err,
 	} else if (length >= sizeof(url)) {
 		cb_err = BT_ATT_ERR_INSUFFICIENT_RESOURCES;
 	} else {
-		BT_HEXDUMP_DBG(data, length, "Icon URL");
+		LOG_HEXDUMP_DBG(data, length, "Icon URL");
 		(void)memcpy(&url, data, length);
 		url[length] = '\0';
 		BT_DBG("Icon URL: %s", url);
@@ -264,7 +264,7 @@ static uint8_t mcc_read_track_title_cb(struct bt_conn *conn, uint8_t err,
 	} else if (!data) {
 		cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	} else {
-		BT_HEXDUMP_DBG(data, length, "Track title");
+		LOG_HEXDUMP_DBG(data, length, "Track title");
 		if (length >= sizeof(title)) {
 			/* If the description is too long; clip it. */
 			length = sizeof(title) - 1;
@@ -297,7 +297,7 @@ static uint8_t mcc_read_track_duration_cb(struct bt_conn *conn, uint8_t err,
 	} else {
 		dur = sys_get_le32((uint8_t *)data);
 		BT_DBG("Track duration: %d", dur);
-		BT_HEXDUMP_DBG(data, sizeof(int32_t), "Track duration");
+		LOG_HEXDUMP_DBG(data, sizeof(int32_t), "Track duration");
 	}
 
 	if (mcc_cb && mcc_cb->read_track_duration) {
@@ -323,7 +323,7 @@ static uint8_t mcc_read_track_position_cb(struct bt_conn *conn, uint8_t err,
 	} else  {
 		pos = sys_get_le32((uint8_t *)data);
 		BT_DBG("Track position: %d", pos);
-		BT_HEXDUMP_DBG(data, sizeof(pos), "Track position");
+		LOG_HEXDUMP_DBG(data, sizeof(pos), "Track position");
 	}
 
 	if (mcc_cb && mcc_cb->read_track_position) {
@@ -348,8 +348,7 @@ static void mcs_write_track_position_cb(struct bt_conn *conn, uint8_t err,
 	} else {
 		pos = sys_get_le32((uint8_t *)params->data);
 		BT_DBG("Track position: %d", pos);
-		BT_HEXDUMP_DBG(params->data, sizeof(pos),
-			       "Track position in callback");
+		LOG_HEXDUMP_DBG(params->data, sizeof(pos), "Track position in callback");
 	}
 
 	if (mcc_cb && mcc_cb->set_track_position) {
@@ -373,7 +372,7 @@ static uint8_t mcc_read_playback_speed_cb(struct bt_conn *conn, uint8_t err,
 	} else {
 		speed = *(int8_t *)data;
 		BT_DBG("Playback speed: %d", speed);
-		BT_HEXDUMP_DBG(data, sizeof(int8_t), "Playback speed");
+		LOG_HEXDUMP_DBG(data, sizeof(int8_t), "Playback speed");
 	}
 
 	if (mcc_cb && mcc_cb->read_playback_speed) {
@@ -421,7 +420,7 @@ static uint8_t mcc_read_seeking_speed_cb(struct bt_conn *conn, uint8_t err,
 	} else {
 		speed = *(int8_t *)data;
 		BT_DBG("Seeking speed: %d", speed);
-		BT_HEXDUMP_DBG(data, sizeof(int8_t), "Seeking speed");
+		LOG_HEXDUMP_DBG(data, sizeof(int8_t), "Seeking speed");
 	}
 
 	if (mcc_cb && mcc_cb->read_seeking_speed) {
@@ -448,7 +447,7 @@ static uint8_t mcc_read_segments_obj_id_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG("length: %d, data: %p", length, data);
 		cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	} else {
-		BT_HEXDUMP_DBG(pid, length, "Segments Object ID");
+		LOG_HEXDUMP_DBG(pid, length, "Segments Object ID");
 		id = sys_get_le48(pid);
 		BT_DBG_OBJ_ID("Segments Object ID: ", id);
 		cb_err = 0;
@@ -477,7 +476,7 @@ static uint8_t mcc_read_current_track_obj_id_cb(struct bt_conn *conn, uint8_t er
 		BT_DBG("length: %d, data: %p", length, data);
 		cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	} else {
-		BT_HEXDUMP_DBG(pid, length, "Current Track Object ID");
+		LOG_HEXDUMP_DBG(pid, length, "Current Track Object ID");
 		id = sys_get_le48(pid);
 		BT_DBG_OBJ_ID("Current Track Object ID: ", id);
 		cb_err = 0;
@@ -529,7 +528,7 @@ static uint8_t mcc_read_next_track_obj_id_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG("length: %d, data: %p", length, data);
 		cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	} else {
-		BT_HEXDUMP_DBG(pid, length, "Next Track Object ID");
+		LOG_HEXDUMP_DBG(pid, length, "Next Track Object ID");
 		id = sys_get_le48(pid);
 		BT_DBG_OBJ_ID("Next Track Object ID: ", id);
 	}
@@ -578,7 +577,7 @@ static uint8_t mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, uint8_t err
 		BT_DBG("length: %d, data: %p", length, data);
 		cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	} else {
-		BT_HEXDUMP_DBG(pid, length, "Parent Group Object ID");
+		LOG_HEXDUMP_DBG(pid, length, "Parent Group Object ID");
 		id = sys_get_le48(pid);
 		BT_DBG_OBJ_ID("Parent Group Object ID: ", id);
 	}
@@ -605,7 +604,7 @@ static uint8_t mcc_read_current_group_obj_id_cb(struct bt_conn *conn, uint8_t er
 		BT_DBG("length: %d, data: %p", length, data);
 		cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	} else {
-		BT_HEXDUMP_DBG(pid, length, "Current Group Object ID");
+		LOG_HEXDUMP_DBG(pid, length, "Current Group Object ID");
 		id = sys_get_le48(pid);
 		BT_DBG_OBJ_ID("Current Group Object ID: ", id);
 	}
@@ -656,7 +655,7 @@ static uint8_t mcc_read_playing_order_cb(struct bt_conn *conn, uint8_t err,
 	} else {
 		order = *(uint8_t *)data;
 		BT_DBG("Playing order: %d", order);
-		BT_HEXDUMP_DBG(data, sizeof(order), "Playing order");
+		LOG_HEXDUMP_DBG(data, sizeof(order), "Playing order");
 	}
 
 	if (mcc_cb && mcc_cb->read_playing_order) {
@@ -704,7 +703,7 @@ static uint8_t mcc_read_playing_orders_supported_cb(struct bt_conn *conn, uint8_
 	} else {
 		orders = sys_get_le16((uint8_t *)data);
 		BT_DBG("Playing orders_supported: %d", orders);
-		BT_HEXDUMP_DBG(data, sizeof(orders), "Playing orders supported");
+		LOG_HEXDUMP_DBG(data, sizeof(orders), "Playing orders supported");
 	}
 
 	if (mcc_cb && mcc_cb->read_playing_orders_supported) {
@@ -730,7 +729,7 @@ static uint8_t mcc_read_media_state_cb(struct bt_conn *conn, uint8_t err,
 	} else {
 		state = *(uint8_t *)data;
 		BT_DBG("Media state: %d", state);
-		BT_HEXDUMP_DBG(data, sizeof(uint8_t), "Media state");
+		LOG_HEXDUMP_DBG(data, sizeof(uint8_t), "Media state");
 	}
 
 	if (mcc_cb && mcc_cb->read_media_state) {
@@ -791,7 +790,7 @@ static uint8_t mcc_read_opcodes_supported_cb(struct bt_conn *conn, uint8_t err,
 	} else {
 		operations = sys_get_le32((uint8_t *)data);
 		BT_DBG("Opcodes supported: %d", operations);
-		BT_HEXDUMP_DBG(data, sizeof(operations), "Opcodes_supported");
+		LOG_HEXDUMP_DBG(data, sizeof(operations), "Opcodes_supported");
 	}
 
 	if (mcc_cb && mcc_cb->read_opcodes_supported) {
@@ -1991,8 +1990,7 @@ int bt_mcc_set_track_position(struct bt_conn *conn, int32_t pos)
 	cur_mcs_inst->write_params.handle = cur_mcs_inst->track_position_handle;
 	cur_mcs_inst->write_params.func = mcs_write_track_position_cb;
 
-	BT_HEXDUMP_DBG(cur_mcs_inst->write_params.data, sizeof(pos),
-		       "Track position sent");
+	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, sizeof(pos), "Track position sent");
 
 	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
 	if (!err) {
@@ -2051,8 +2049,7 @@ int bt_mcc_set_playback_speed(struct bt_conn *conn, int8_t speed)
 	cur_mcs_inst->write_params.handle = cur_mcs_inst->playback_speed_handle;
 	cur_mcs_inst->write_params.func = mcs_write_playback_speed_cb;
 
-	BT_HEXDUMP_DBG(cur_mcs_inst->write_params.data, sizeof(speed),
-		       "Playback speed");
+	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, sizeof(speed), "Playback speed");
 
 	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
 	if (!err) {
@@ -2170,7 +2167,7 @@ int bt_mcc_set_current_track_obj_id(struct bt_conn *conn, uint64_t obj_id)
 	cur_mcs_inst->write_params.handle = cur_mcs_inst->current_track_obj_id_handle;
 	cur_mcs_inst->write_params.func = mcs_write_current_track_obj_id_cb;
 
-	BT_HEXDUMP_DBG(cur_mcs_inst->write_params.data, BT_OTS_OBJ_ID_SIZE, "Object Id");
+	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, BT_OTS_OBJ_ID_SIZE, "Object Id");
 
 	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
 	if (!err) {
@@ -2233,7 +2230,7 @@ int bt_mcc_set_next_track_obj_id(struct bt_conn *conn, uint64_t obj_id)
 	cur_mcs_inst->write_params.handle = cur_mcs_inst->next_track_obj_id_handle;
 	cur_mcs_inst->write_params.func = mcs_write_next_track_obj_id_cb;
 
-	BT_HEXDUMP_DBG(cur_mcs_inst->write_params.data, BT_OTS_OBJ_ID_SIZE, "Object Id");
+	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, BT_OTS_OBJ_ID_SIZE, "Object Id");
 
 	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
 	if (!err) {
@@ -2323,7 +2320,7 @@ int bt_mcc_set_current_group_obj_id(struct bt_conn *conn, uint64_t obj_id)
 	cur_mcs_inst->write_params.handle = cur_mcs_inst->current_group_obj_id_handle;
 	cur_mcs_inst->write_params.func = mcs_write_current_group_obj_id_cb;
 
-	BT_HEXDUMP_DBG(cur_mcs_inst->write_params.data, BT_OTS_OBJ_ID_SIZE, "Object Id");
+	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, BT_OTS_OBJ_ID_SIZE, "Object Id");
 
 	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
 	if (!err) {
@@ -2383,8 +2380,7 @@ int bt_mcc_set_playing_order(struct bt_conn *conn, uint8_t order)
 	cur_mcs_inst->write_params.handle = cur_mcs_inst->playing_order_handle;
 	cur_mcs_inst->write_params.func = mcs_write_playing_order_cb;
 
-	BT_HEXDUMP_DBG(cur_mcs_inst->write_params.data, sizeof(order),
-		       "Playing order");
+	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, sizeof(order), "Playing order");
 
 	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
 	if (!err) {
@@ -2476,8 +2472,7 @@ int bt_mcc_send_cmd(struct bt_conn *conn, const struct mpl_cmd *cmd)
 	cur_mcs_inst->write_params.handle = cur_mcs_inst->cp_handle;
 	cur_mcs_inst->write_params.func = mcs_write_cp_cb;
 
-	BT_HEXDUMP_DBG(cur_mcs_inst->write_params.data, sizeof(*cmd),
-		       "Command sent");
+	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, sizeof(*cmd), "Command sent");
 
 	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
 	if (!err) {
@@ -2537,8 +2532,7 @@ int bt_mcc_send_search(struct bt_conn *conn, const struct mpl_search *search)
 	cur_mcs_inst->write_params.handle = cur_mcs_inst->scp_handle;
 	cur_mcs_inst->write_params.func = mcs_write_scp_cb;
 
-	BT_HEXDUMP_DBG(cur_mcs_inst->write_params.data, search->len,
-		       "Search sent");
+	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, search->len, "Search sent");
 
 	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
 	if (!err) {
@@ -2632,7 +2626,7 @@ int on_icon_content(struct bt_ots_client *otc_inst, struct bt_conn *conn,
 	BT_DBG("Received Media Player Icon content, %i bytes at offset %i",
 		len, offset);
 
-	BT_HEXDUMP_DBG(data_p, len, "Icon content");
+	LOG_HEXDUMP_DBG(data_p, len, "Icon content");
 
 	if (len > net_buf_simple_tailroom(&otc_obj_buf)) {
 		BT_WARN("Can not fit whole object");
@@ -2761,7 +2755,7 @@ int on_current_track_content(struct bt_ots_client *otc_inst,
 	BT_DBG("Received Current Track content, %i bytes at offset %i",
 	       len, offset);
 
-	BT_HEXDUMP_DBG(data_p, len, "Track content");
+	LOG_HEXDUMP_DBG(data_p, len, "Track content");
 
 	if (len > net_buf_simple_tailroom(&otc_obj_buf)) {
 		BT_WARN("Can not fit whole object");
@@ -2793,7 +2787,7 @@ int on_next_track_content(struct bt_ots_client *otc_inst,
 	BT_DBG("Received Next Track content, %i bytes at offset %i",
 	       len, offset);
 
-	BT_HEXDUMP_DBG(data_p, len, "Track content");
+	LOG_HEXDUMP_DBG(data_p, len, "Track content");
 
 	if (len > net_buf_simple_tailroom(&otc_obj_buf)) {
 		BT_WARN("Can not fit whole object");
@@ -2852,7 +2846,7 @@ int on_parent_group_content(struct bt_ots_client *otc_inst,
 	BT_DBG("Received Parent Group content, %i bytes at offset %i",
 		len, offset);
 
-	BT_HEXDUMP_DBG(data_p, len, "Group content");
+	LOG_HEXDUMP_DBG(data_p, len, "Group content");
 
 	if (len > net_buf_simple_tailroom(&otc_obj_buf)) {
 		BT_WARN("Can not fit whole object");
@@ -2898,7 +2892,7 @@ int on_current_group_content(struct bt_ots_client *otc_inst,
 	BT_DBG("Received Current Group content, %i bytes at offset %i",
 		len, offset);
 
-	BT_HEXDUMP_DBG(data_p, len, "Group content");
+	LOG_HEXDUMP_DBG(data_p, len, "Group content");
 
 	if (len > net_buf_simple_tailroom(&otc_obj_buf)) {
 		BT_WARN("Can not fit whole object");

--- a/subsys/bluetooth/audio/mcs.c
+++ b/subsys/bluetooth/audio/mcs.c
@@ -560,7 +560,7 @@ static ssize_t write_search_control_point(struct bt_conn *conn,
 	memcpy(&search.search, (char *)buf, len);
 	search.len = len;
 	BT_DBG("Search length: %d", len);
-	BT_HEXDUMP_DBG(&search.search, search.len, "Search content");
+	LOG_HEXDUMP_DBG(&search.search, search.len, "Search content");
 
 	media_proxy_sctrl_send_search(&search);
 

--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -343,8 +343,7 @@ static uint32_t setup_segments_object(struct mpl_track *track)
 			seg = seg->next;
 		}
 
-		BT_HEXDUMP_DBG(obj.content->data, obj.content->len,
-			       "Segments Object");
+		LOG_HEXDUMP_DBG(obj.content->data, obj.content->len, "Segments Object");
 		BT_DBG("Segments object length: %d", obj.content->len);
 	} else {
 		BT_ERR("No seg!");
@@ -406,8 +405,7 @@ static uint32_t setup_parent_group_object(struct mpl_group *group)
 		if (next_size > obj.content->size) {
 			BT_WARN("Not room for full group in object");
 		}
-		BT_HEXDUMP_DBG(obj.content->data, obj.content->len,
-			       "Parent Group Object");
+		LOG_HEXDUMP_DBG(obj.content->data, obj.content->len, "Parent Group Object");
 		BT_DBG("Group object length: %d", obj.content->len);
 	}
 	return obj.content->len;
@@ -439,8 +437,7 @@ static uint32_t setup_group_object(struct mpl_group *group)
 		if (next_size > obj.content->size) {
 			BT_WARN("Not room for full group in object");
 		}
-		BT_HEXDUMP_DBG(obj.content->data, obj.content->len,
-			       "Group Object");
+		LOG_HEXDUMP_DBG(obj.content->data, obj.content->len, "Group Object");
 		BT_DBG("Group object length: %d", obj.content->len);
 	}
 	return obj.content->len;
@@ -2651,7 +2648,7 @@ static void parse_search(const struct mpl_search *search)
 			index += sci.len - 1;
 
 			BT_DBG("SCI # %d: type: %d", sci_num, sci.type);
-			BT_HEXDUMP_DBG(sci.param, sci.len-1, "param:");
+			LOG_HEXDUMP_DBG(sci.param, sci.len - 1, "param:");
 			sci_num++;
 		}
 	}
@@ -2677,7 +2674,7 @@ void send_search(const struct mpl_search *search)
 		BT_WARN("Search too long: %d", search->len);
 	}
 
-	BT_HEXDUMP_DBG(search->search, search->len, "Search");
+	LOG_HEXDUMP_DBG(search->search, search->len, "Search");
 
 	parse_search(search);
 }

--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -759,7 +759,7 @@ static ssize_t read_current_calls(struct bt_conn *conn,
 	}
 
 	if (offset == 0) {
-		BT_HEXDUMP_DBG(read_buf.data, read_buf.len, "Current calls");
+		LOG_HEXDUMP_DBG(read_buf.data, read_buf.len, "Current calls");
 	}
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset,
@@ -881,7 +881,7 @@ static ssize_t read_call_state(struct bt_conn *conn,
 	}
 
 	if (offset == 0) {
-		BT_HEXDUMP_DBG(read_buf.data, read_buf.len, "Call state");
+		LOG_HEXDUMP_DBG(read_buf.data, read_buf.len, "Call state");
 	}
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset,

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -538,7 +538,7 @@ static uint8_t notify_handler(struct bt_conn *conn,
 
 		BT_DBG("Index %u", inst_index);
 
-		BT_HEXDUMP_DBG(data, length, "notify handler value");
+		LOG_HEXDUMP_DBG(data, length, "notify handler value");
 
 		if (handle == tbs_inst->call_state_sub_params.value_handle) {
 			call_state_notify_handler(conn, tbs_inst, data, length);
@@ -700,7 +700,7 @@ static uint8_t read_technology_cb(struct bt_conn *conn, uint8_t err,
 	if (err != 0) {
 		BT_DBG("err: 0x%02X", err);
 	} else if (data != NULL) {
-		BT_HEXDUMP_DBG(data, length, "Data read");
+		LOG_HEXDUMP_DBG(data, length, "Data read");
 		if (length == sizeof(technology)) {
 			(void)memcpy(&technology, data, length);
 			BT_DBG("%s (0x%02x)", bt_tbs_technology_str(technology), technology);
@@ -768,7 +768,7 @@ static uint8_t read_signal_strength_cb(struct bt_conn *conn, uint8_t err,
 	if (err != 0) {
 		BT_DBG("err: 0x%02X", err);
 	} else if (data != NULL) {
-		BT_HEXDUMP_DBG(data, length, "Data read");
+		LOG_HEXDUMP_DBG(data, length, "Data read");
 		if (length == sizeof(signal_strength)) {
 			(void)memcpy(&signal_strength, data, length);
 			BT_DBG("0x%02x", signal_strength);
@@ -805,7 +805,7 @@ static uint8_t read_signal_interval_cb(struct bt_conn *conn, uint8_t err,
 	if (err != 0) {
 		BT_DBG("err: 0x%02X", err);
 	} else if (data != NULL) {
-		BT_HEXDUMP_DBG(data, length, "Data read");
+		LOG_HEXDUMP_DBG(data, length, "Data read");
 		if (length == sizeof(signal_interval)) {
 			(void)memcpy(&signal_interval, data, length);
 			BT_DBG("0x%02x", signal_interval);
@@ -905,7 +905,7 @@ static uint8_t read_ccid_cb(struct bt_conn *conn, uint8_t err,
 	if (err != 0) {
 		BT_DBG("err: 0x%02X", err);
 	} else if (data != NULL) {
-		BT_HEXDUMP_DBG(data, length, "Data read");
+		LOG_HEXDUMP_DBG(data, length, "Data read");
 		if (length == sizeof(ccid)) {
 			(void)memcpy(&ccid, data, length);
 			BT_DBG("0x%02x", ccid);
@@ -942,7 +942,7 @@ static uint8_t read_status_flags_cb(struct bt_conn *conn, uint8_t err,
 	if (err != 0) {
 		BT_DBG("err: 0x%02X", err);
 	} else if (data != NULL) {
-		BT_HEXDUMP_DBG(data, length, "Data read");
+		LOG_HEXDUMP_DBG(data, length, "Data read");
 		if (length == sizeof(status_flags)) {
 			(void)memcpy(&status_flags, data, length);
 			BT_DBG("0x%04x", status_flags);
@@ -1092,7 +1092,7 @@ static uint8_t read_optional_opcodes_cb(struct bt_conn *conn, uint8_t err,
 	if (err != 0) {
 		BT_DBG("err: 0x%02X", err);
 	} else if (data != NULL) {
-		BT_HEXDUMP_DBG(data, length, "Data read");
+		LOG_HEXDUMP_DBG(data, length, "Data read");
 		if (length == sizeof(optional_opcodes)) {
 			(void)memcpy(&optional_opcodes, data, length);
 			BT_DBG("0x%04x", optional_opcodes);

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -977,7 +977,7 @@ static void unicast_client_codec_data_add(struct net_buf_simple *buf,
 
 		BT_DBG("#%u: %s type 0x%02x len %u", i, prefix, d->type,
 		       d->data_len);
-		BT_HEXDUMP_DBG(d->data, d->data_len, prefix);
+		LOG_HEXDUMP_DBG(d->data, d->data_len, prefix);
 
 		cc = net_buf_simple_add(buf, sizeof(*cc));
 		cc->len = d->data_len + sizeof(cc->type);
@@ -1015,7 +1015,7 @@ static bool unicast_client_codec_config_store(struct bt_data *data,
 	cdata->data.data = cdata->value;
 	(void)memcpy(cdata->value, data->data, data->data_len);
 
-	BT_HEXDUMP_DBG(cdata->value, data->data_len, "data");
+	LOG_HEXDUMP_DBG(cdata->value, data->data_len, "data");
 
 	codec->data_count++;
 
@@ -1100,7 +1100,7 @@ static bool unicast_client_codec_metadata_store(struct bt_data *data,
 	meta->data.data = meta->value;
 	(void)memcpy(meta->value, data->data, data->data_len);
 
-	BT_HEXDUMP_DBG(meta->value, data->data_len, "data");
+	LOG_HEXDUMP_DBG(meta->value, data->data_len, "data");
 
 	codec->meta_count++;
 

--- a/subsys/bluetooth/audio/vocs_client.c
+++ b/subsys/bluetooth/audio/vocs_client.c
@@ -312,7 +312,7 @@ static uint8_t vcs_client_read_output_desc_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG("Description read failed: %d", err);
 	} else {
 		if (data) {
-			BT_HEXDUMP_DBG(data, length, "Output description read");
+			LOG_HEXDUMP_DBG(data, length, "Output description read");
 
 			if (length > sizeof(desc) - 1) {
 				BT_DBG("Description truncated from %u to %zu octets",

--- a/subsys/bluetooth/common/assert.h
+++ b/subsys/bluetooth/common/assert.h
@@ -1,0 +1,41 @@
+/* Copyright (c) 2022 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#if defined(CONFIG_BT_ASSERT_VERBOSE)
+#define BT_ASSERT_PRINT(test)	      __ASSERT_LOC(test)
+#define BT_ASSERT_PRINT_MSG(fmt, ...) __ASSERT_MSG_INFO(fmt, ##__VA_ARGS__)
+#else
+#define BT_ASSERT_PRINT(test)
+#define BT_ASSERT_PRINT_MSG(fmt, ...)
+#endif /* CONFIG_BT_ASSERT_VERBOSE */
+
+#if defined(CONFIG_BT_ASSERT_PANIC)
+#define BT_ASSERT_DIE k_panic
+#else
+#define BT_ASSERT_DIE k_oops
+#endif /* CONFIG_BT_ASSERT_PANIC */
+
+#if defined(CONFIG_BT_ASSERT)
+#define BT_ASSERT(cond)                                                                            \
+	do {                                                                                       \
+		if (!(cond)) {                                                                     \
+			BT_ASSERT_PRINT(cond);                                                     \
+			BT_ASSERT_DIE();                                                           \
+		}                                                                                  \
+	} while (0)
+
+#define BT_ASSERT_MSG(cond, fmt, ...)                                                              \
+	do {                                                                                       \
+		if (!(cond)) {                                                                     \
+			BT_ASSERT_PRINT(cond);                                                     \
+			BT_ASSERT_PRINT_MSG(fmt, ##__VA_ARGS__);                                   \
+			BT_ASSERT_DIE();                                                           \
+		}                                                                                  \
+	} while (0)
+#else
+#define BT_ASSERT(cond)		      __ASSERT_NO_MSG(cond)
+#define BT_ASSERT_MSG(cond, msg, ...) __ASSERT(cond, msg, ##__VA_ARGS__)
+#endif /* CONFIG_BT_ASSERT*/

--- a/subsys/bluetooth/common/log.h
+++ b/subsys/bluetooth/common/log.h
@@ -13,7 +13,6 @@
 
 #include <zephyr/linker/sections.h>
 #include <offsets.h>
-#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>
 
@@ -41,42 +40,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 #define BT_ERR(fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)
 #define BT_WARN(fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
 #define BT_INFO(fmt, ...) LOG_INF(fmt, ##__VA_ARGS__)
-
-#if defined(CONFIG_BT_ASSERT_VERBOSE)
-#define BT_ASSERT_PRINT(test) __ASSERT_LOC(test)
-#define BT_ASSERT_PRINT_MSG(fmt, ...) __ASSERT_MSG_INFO(fmt, ##__VA_ARGS__)
-#else
-#define BT_ASSERT_PRINT(test)
-#define BT_ASSERT_PRINT_MSG(fmt, ...)
-#endif /* CONFIG_BT_ASSERT_VERBOSE */
-
-#if defined(CONFIG_BT_ASSERT_PANIC)
-#define BT_ASSERT_DIE k_panic
-#else
-#define BT_ASSERT_DIE k_oops
-#endif /* CONFIG_BT_ASSERT_PANIC */
-
-#if defined(CONFIG_BT_ASSERT)
-#define BT_ASSERT(cond)                          \
-	do {                                     \
-		if (!(cond)) {                   \
-			BT_ASSERT_PRINT(cond);   \
-			BT_ASSERT_DIE();         \
-		}                                \
-	} while (0)
-
-#define BT_ASSERT_MSG(cond, fmt, ...)                              \
-	do {                                                       \
-		if (!(cond)) {                                     \
-			BT_ASSERT_PRINT(cond);                     \
-			BT_ASSERT_PRINT_MSG(fmt, ##__VA_ARGS__);   \
-			BT_ASSERT_DIE();                           \
-		}                                                  \
-	} while (0)
-#else
-#define BT_ASSERT(cond) __ASSERT_NO_MSG(cond)
-#define BT_ASSERT_MSG(cond, msg, ...) __ASSERT(cond, msg, ##__VA_ARGS__)
-#endif/* CONFIG_BT_ASSERT*/
 
 /* NOTE: These helper functions always encodes into the same buffer storage.
  * It is the responsibility of the user of this function to copy the information

--- a/subsys/bluetooth/common/log.h
+++ b/subsys/bluetooth/common/log.h
@@ -78,9 +78,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 #define BT_ASSERT_MSG(cond, msg, ...) __ASSERT(cond, msg, ##__VA_ARGS__)
 #endif/* CONFIG_BT_ASSERT*/
 
-#define BT_HEXDUMP_DBG(_data, _length, _str) \
-		LOG_HEXDUMP_DBG((const uint8_t *)_data, _length, _str)
-
 /* NOTE: These helper functions always encodes into the same buffer storage.
  * It is the responsibility of the user of this function to copy the information
  * in this string if needed.

--- a/subsys/bluetooth/controller/hal/debug.h
+++ b/subsys/bluetooth/controller/hal/debug.h
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+ #include "common/assert.h"
+
 #ifdef CONFIG_BT_CTLR_ASSERT_HANDLER
 void bt_ctlr_assert_handle(char *file, uint32_t line);
 #define LL_ASSERT(cond) \

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/cntr.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/cntr.c
@@ -10,8 +10,6 @@
 
 #include "hal/cntr.h"
 
-#define LOG_MODULE_NAME bt_ctlr_cntr
-#include "common/log.h"
 #include "hal/debug.h"
 #include <zephyr/dt-bindings/interrupt-controller/openisa-intmux.h>
 #include "ll_irqs.h"

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/mayfly.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/mayfly.c
@@ -14,8 +14,6 @@
 #include "util/memq.h"
 #include "util/mayfly.h"
 
-#define LOG_MODULE_NAME bt_ctlr_rv32m1_mayfly
-#include "common/log.h"
 #include "hal/debug.h"
 
 #if defined(CONFIG_BT_LL_SW_SPLIT)

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/radio/radio.c
@@ -29,6 +29,7 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_openisa_radio
 #include "common/log.h"
+#include "common/assert.h"
 #include <soc.h>
 #include "hal/debug.h"
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ticker.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ticker.c
@@ -15,8 +15,6 @@
 
 #include "ticker/ticker.h"
 
-#define LOG_MODULE_NAME bt_ctlr_rv32m1_ticker
-#include "common/log.h"
 #include "hal/debug.h"
 
 #if defined(CONFIG_BT_LL_SW_SPLIT)

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -41,8 +41,6 @@
 #include "lll_adv_internal.h"
 #include "lll_prof_internal.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_openisa_lll_adv
-#include "common/log.h"
 #include "hal/debug.h"
 
 static int init_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_central.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_central.c
@@ -29,8 +29,6 @@
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_openisa_lll_central
-#include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_peripheral.c
@@ -29,8 +29,6 @@
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_openisa_lll_periph
-#include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -35,8 +35,6 @@
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
-#define LOG_MODULE_NAME bt_ctlr_llsw_openisa_lll_scan
-#include "common/log.h"
 #include <soc.h>
 #include "hal/debug.h"
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_test.c
@@ -25,7 +25,6 @@
 #include "ll_test.h"
 
 #include "hal/debug.h"
-#include "common/log.h"
 
 #define CNTR_MIN_DELTA 3
 

--- a/subsys/bluetooth/host/a2dp.c
+++ b/subsys/bluetooth/host/a2dp.c
@@ -24,6 +24,7 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_A2DP)
 #define LOG_MODULE_NAME bt_a2dp
 #include "common/log.h"
+#include "common/assert.h"
 
 #include "hci_core.h"
 #include "conn_internal.h"

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -28,6 +28,7 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_CONN)
 #define LOG_MODULE_NAME bt_conn
 #include "common/log.h"
+#include "common/assert.h"
 
 #include "hci_core.h"
 #include "id.h"

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -800,7 +800,7 @@ static void db_hash_gen(bool store)
 	 */
 	sys_mem_swap(db_hash.hash, sizeof(db_hash.hash));
 
-	BT_HEXDUMP_DBG(db_hash.hash, sizeof(db_hash.hash), "Hash: ");
+	LOG_HEXDUMP_DBG(db_hash.hash, sizeof(db_hash.hash), "Hash: ");
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS) && store) {
 		db_hash_store();
@@ -830,8 +830,7 @@ static void db_hash_process(struct k_work *work)
 			return;
 		}
 
-		BT_HEXDUMP_DBG(db_hash.hash, sizeof(db_hash.hash),
-			       "New Hash: ");
+		LOG_HEXDUMP_DBG(db_hash.hash, sizeof(db_hash.hash), "New Hash: ");
 
 		/* GATT database has been modified since last boot, likely due
 		 * to a firmware update or a dynamic service that was not
@@ -5869,8 +5868,7 @@ static int db_hash_set(const char *name, size_t len_rd,
 		return len;
 	}
 
-	BT_HEXDUMP_DBG(db_hash.stored_hash, sizeof(db_hash.stored_hash),
-		       "Stored Hash: ");
+	LOG_HEXDUMP_DBG(db_hash.stored_hash, sizeof(db_hash.stored_hash), "Stored Hash: ");
 
 	return 0;
 }

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -31,6 +31,7 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_CORE)
 #define LOG_MODULE_NAME bt_hci_core
 #include "common/log.h"
+#include "common/assert.h"
 
 #include "common/rpa.h"
 #include "keys.h"

--- a/subsys/bluetooth/host/hfp_hf.c
+++ b/subsys/bluetooth/host/hfp_hf.c
@@ -17,6 +17,7 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HFP_HF)
 #define LOG_MODULE_NAME bt_hfp_hf
 #include "common/log.h"
+#include "common/assert.h"
 
 #include <zephyr/bluetooth/rfcomm.h>
 #include <zephyr/bluetooth/hfp_hf.h>

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -23,6 +23,7 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_ISO)
 #define LOG_MODULE_NAME bt_iso
 #include "common/log.h"
+#include "common/assert.h"
 
 #define iso_chan(_iso) ((_iso)->iso.chan);
 

--- a/subsys/bluetooth/host/sdp.c
+++ b/subsys/bluetooth/host/sdp.c
@@ -19,6 +19,7 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_SDP)
 #define LOG_MODULE_NAME bt_sdp
 #include "common/log.h"
+#include "common/assert.h"
 
 #include "hci_core.h"
 #include "conn_internal.h"

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -150,8 +150,7 @@ static int set(const char *name, size_t len_rd, settings_read_cb read_cb,
 				       " (err %zd)", len);
 			} else {
 				BT_ERR("Invalid length ID address in storage");
-				BT_HEXDUMP_DBG(&bt_dev.id_addr, len,
-					       "data read");
+				LOG_HEXDUMP_DBG(&bt_dev.id_addr, len, "data read");
 			}
 			(void)memset(bt_dev.id_addr, 0,
 				     sizeof(bt_dev.id_addr));

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -913,7 +913,7 @@ static int mod_set_bind(struct bt_mesh_model *mod, size_t len_rd,
 		return len;
 	}
 
-	BT_HEXDUMP_DBG(mod->keys, len, "val");
+	LOG_HEXDUMP_DBG(mod->keys, len, "val");
 
 	BT_DBG("Decoded %zu bound keys for model", len / sizeof(mod->keys[0]));
 	return 0;
@@ -938,7 +938,7 @@ static int mod_set_sub(struct bt_mesh_model *mod, size_t len_rd,
 		return len;
 	}
 
-	BT_HEXDUMP_DBG(mod->groups, len, "val");
+	LOG_HEXDUMP_DBG(mod->groups, len, "val");
 
 	BT_DBG("Decoded %zu subscribed group addresses for model",
 	       len / sizeof(mod->groups[0]));

--- a/subsys/bluetooth/mesh/cfg.c
+++ b/subsys/bluetooth/mesh/cfg.c
@@ -355,7 +355,7 @@ static void store_pending_cfg(void)
 		BT_ERR("Failed to store configuration value");
 	} else {
 		BT_DBG("Stored configuration value");
-		BT_HEXDUMP_DBG(&val, sizeof(val), "raw value");
+		LOG_HEXDUMP_DBG(&val, sizeof(val), "raw value");
 	}
 }
 

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -51,7 +51,7 @@ int bt_mesh_settings_set(settings_read_cb read_cb, void *cb_arg,
 		return len;
 	}
 
-	BT_HEXDUMP_DBG(out, len, "val");
+	LOG_HEXDUMP_DBG(out, len, "val");
 
 	if (len != read_len) {
 		BT_ERR("Unexpected value length (%zd != %zu)", len, read_len);


### PR DESCRIPTION
We are trying to remove `common/log.h` in favor of standard Zephyr log functions. This PR a part of this effort.

In this PR we:
- Remove `BT_HEXDUMP_DBG`
- Move out `BT_ASSERT` macros into `common/assert.h`