### PR TITLE
boards: arm: stm32f3 boards without FPU by default

### DIFF
--- a/boards/arm/stm32373c_eval/stm32373c_eval_defconfig
+++ b/boards/arm/stm32373c_eval/stm32373c_eval_defconfig
@@ -6,9 +6,6 @@ CONFIG_SOC_SERIES_STM32F3X=y
 # Platform Configuration
 CONFIG_SOC_STM32F373XC=y
 
-# Floating Point Options
-CONFIG_FPU=y
-
 # Enable MPU
 CONFIG_ARM_MPU=y
 

--- a/boards/arm/stm32f3_disco/stm32f3_disco_defconfig
+++ b/boards/arm/stm32f3_disco/stm32f3_disco_defconfig
@@ -3,9 +3,6 @@
 CONFIG_SOC_SERIES_STM32F3X=y
 CONFIG_SOC_STM32F303XC=y
 
-# Floating Point Options
-CONFIG_FPU=y
-
 # Enable MPU
 CONFIG_ARM_MPU=y
 


### PR DESCRIPTION
Remove the CONFIG_FPU for the stm32f3_disco and stm32373c eval boards.

The FPU exists like on many other stm32 series
but CONFIG_FPU has not to be defined here.

Signed-off-by: Francois Ramu <francois.ramu@st.com>