### PR TITLE
samples: compression: lz4 requires more than 64kB of RAM

### DIFF
--- a/samples/compression/lz4/sample.yaml
+++ b/samples/compression/lz4/sample.yaml
@@ -3,7 +3,7 @@ sample:
   description: lz4 data compression library
 common:
   tags: compression lz4
-  min_ram: 40
+  min_ram: 64
   filter: TOOLCHAIN_HAS_NEWLIB == 1
   harness: console
   harness_config:


### PR DESCRIPTION
Set the min_ram limit to 64kB so that with new ztest lib can run the sample on board with enough ram.
Smaller ram platforms are not used anymore.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/51520

Signed-off-by: Francois Ramu <francois.ramu@st.com>