### PR TITLE
soc: xtensa: intel_adsp: Convert CONFIG_MP_NUM_CPUS handling

### DIFF
--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -130,7 +130,7 @@ int soc_adsp_halt_cpu(int id)
 		return -EINVAL;
 	}
 
-	CHECKIF(id <= 0 || id >= CONFIG_MP_NUM_CPUS) {
+	CHECKIF(id <= 0 || id >= arch_num_cpus()) {
 		return -EINVAL;
 	}
 

--- a/soc/xtensa/intel_adsp/cavs/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/cavs/CMakeLists.txt
@@ -11,7 +11,7 @@ zephyr_library_sources(
     power.c
     )
 
-if(CONFIG_SMP OR CONFIG_MP_NUM_CPUS GREATER 1)
+if(CONFIG_SMP OR CONFIG_MP_MAX_NUM_CPUS GREATER 1)
     zephyr_library_sources(multiprocessing.c)
 endif()
 

--- a/soc/xtensa/intel_adsp/cavs/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/cavs/multiprocessing.c
@@ -17,7 +17,7 @@
 	 (0x1 << 24) | /* "ROM control version" = 1 */	  \
 	 (0x2 << 0))   /* "Core wake version" = 2 */
 
-#define IDC_ALL_CORES (BIT(CONFIG_MP_NUM_CPUS) - 1)
+#define IDC_CORE_MASK(num_cpus) (BIT(num_cpus) - 1)
 
 #define CAVS15_ROM_IDC_DELAY 500
 
@@ -113,7 +113,7 @@ void soc_start_core(int cpu_num)
 	unsigned int num_cpus = arch_num_cpus();
 
 	for (int c = 0; c < num_cpus; c++) {
-		IDC[c].busy_int |= IDC_ALL_CORES;
+		IDC[c].busy_int |= IDC_CORE_MASK(num_cpus);
 	}
 
 	/* Send power-up message to the other core.  Start address
@@ -172,8 +172,8 @@ __imr void soc_mp_init(void)
 	unsigned int num_cpus = arch_num_cpus();
 
 	for (int core = 0; core < num_cpus; core++) {
-		IDC[core].busy_int |= IDC_ALL_CORES;
-		IDC[core].done_int &= ~IDC_ALL_CORES;
+		IDC[core].busy_int |= IDC_CORE_MASK(num_cpus);
+		IDC[core].done_int &= ~IDC_CORE_MASK(num_cpus);
 
 		/* Also unmask the IDC interrupt for every core in the
 		 * L2 mask register.

--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -21,7 +21,7 @@ zephyr_library_sources(
 
 zephyr_library_sources_ifdef(CONFIG_ADSP_CLOCK clk.c)
 
-if(CONFIG_SMP OR CONFIG_MP_NUM_CPUS GREATER 1)
+if(CONFIG_SMP OR CONFIG_MP_MAX_NUM_CPUS GREATER 1)
   zephyr_library_sources(multiprocessing.c)
 endif()
 


### PR DESCRIPTION
Move runtime checks to use arch_num_cpus() and build checks to use CONFIG_MP_MAX_NUM_CPUS.  This is to allow runtime determination of the number of CPUs in the future.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>