### PR TITLE
interrupt_controller: gic: Rework usage of CONFIG_MP_NUM_CPUS

### DIFF
--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -20,8 +20,8 @@ static const uint64_t cpu_mpid_list[] = {
 	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))
 };
 
-BUILD_ASSERT(ARRAY_SIZE(cpu_mpid_list) >= CONFIG_MP_NUM_CPUS,
-		"The count of CPU Cores nodes in dts is less than CONFIG_MP_NUM_CPUS\n");
+BUILD_ASSERT(ARRAY_SIZE(cpu_mpid_list) >= CONFIG_MP_MAX_NUM_CPUS,
+		"The count of CPU Cores nodes in dts is less than CONFIG_MP_MAX_NUM_CPUS\n");
 
 void arm_gic_irq_enable(unsigned int irq)
 {

--- a/drivers/interrupt_controller/intc_gicv3_its.c
+++ b/drivers/interrupt_controller/intc_gicv3_its.c
@@ -198,7 +198,8 @@ static int its_alloc_tables(struct gicv3_its_data *data)
 			page_cnt = ROUND_UP(entry_size << device_ids, page_size) / page_size;
 			break;
 		case GITS_BASER_TYPE_COLLECTION:
-			page_cnt = ROUND_UP(entry_size * CONFIG_MP_NUM_CPUS, page_size) / page_size;
+			page_cnt =
+				ROUND_UP(entry_size * CONFIG_MP_MAX_NUM_CPUS, page_size)/page_size;
 			break;
 		default:
 			continue;

--- a/include/zephyr/drivers/interrupt_controller/gic.h
+++ b/include/zephyr/drivers/interrupt_controller/gic.h
@@ -261,7 +261,7 @@
 #define GIC_INTID_SPURIOUS		1023
 
 /* Fixme: update from platform specific define or dt */
-#define GIC_NUM_CPU_IF			CONFIG_MP_NUM_CPUS
+#define GIC_NUM_CPU_IF			CONFIG_MP_MAX_NUM_CPUS
 
 #ifndef _ASMLANGUAGE
 


### PR DESCRIPTION
Replace usage of CONFIG_MP_NUM_CPUS with CONFIG_MP_MAX_NUM_CPUS for init and declaration as we phase out CONFIG_MP_NUM_CPUS usage.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>