### PR TITLE
arch: x86: Convert to CONFIG_MP_MAX_NUM_CPUS

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -148,7 +148,7 @@ x86_ap_start:
 
 	movl $x86_cpuboot, %ebp
 	xorl %ebx, %ebx
-1:	cmpl $CONFIG_MP_NUM_CPUS, %ebx
+1:	cmpl $CONFIG_MP_MAX_NUM_CPUS, %ebx
 	jz unknown_loapic_id
 	cmpb %al, x86_cpu_loapics(%ebx)
 	je go64				/* proceed to 64-bit mode */


### PR DESCRIPTION
Convert CONFIG_MP_NUM_CPUS to CONFIG_MP_MAX_NUM_CPUS as we work on phasing out CONFIG_MP_NUM_CPUS.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>