### PR TITLE
arch: arm64: Convert to CONFIG_MP_MAX_NUM_CPUS

### DIFF
--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -64,8 +64,8 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	master_core_mpid = MPIDR_TO_CORE(GET_MPIDR());
 
 	cpu_count = ARRAY_SIZE(cpu_node_list);
-	__ASSERT(cpu_count == CONFIG_MP_NUM_CPUS,
-		"The count of CPU Cores nodes in dts is not equal to CONFIG_MP_NUM_CPUS\n");
+	__ASSERT(cpu_count == CONFIG_MP_MAX_NUM_CPUS,
+		"The count of CPU Cores nodes in dts is not equal to CONFIG_MP_MAX_NUM_CPUS\n");
 
 	for (i = 0, j = 0; i < cpu_count; i++) {
 		if (cpu_node_list[i] == master_core_mpid) {


### PR DESCRIPTION
Convert CONFIG_MP_NUM_CPUS to CONFIG_MP_MAX_NUM_CPUS as we work on phasing out CONFIG_MP_NUM_CPUS.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>