### PR TITLE
kernel: Convert away from CONFIG_MP_NUM_CPUS

### DIFF
--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -84,7 +84,7 @@ struct k_spinlock {
 bool z_spin_lock_valid(struct k_spinlock *l);
 bool z_spin_unlock_valid(struct k_spinlock *l);
 void z_spin_lock_set_owner(struct k_spinlock *l);
-BUILD_ASSERT(CONFIG_MP_NUM_CPUS <= 4, "Too many CPUs for mask");
+BUILD_ASSERT(CONFIG_MP_MAX_NUM_CPUS <= 4, "Too many CPUs for mask");
 
 # ifdef CONFIG_KERNEL_COHERENCE
 bool z_spin_lock_mem_coherent(struct k_spinlock *l);

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -343,7 +343,7 @@ static void init_idle_thread(int i)
 
 #ifdef CONFIG_THREAD_NAME
 
-#if CONFIG_MP_NUM_CPUS > 1
+#if CONFIG_MP_MAX_NUM_CPUS > 1
 	char tname[8];
 	snprintk(tname, 8, "idle %02d", i);
 #else

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -279,7 +279,7 @@ static void signal_pending_ipi(void)
 	 * this code.
 	 */
 #if defined(CONFIG_SMP) && defined(CONFIG_SCHED_IPI_SUPPORTED)
-	if (CONFIG_MP_NUM_CPUS > 1) {
+	if (arch_num_cpus() > 1) {
 		if (_kernel.pending_ipi) {
 			_kernel.pending_ipi = false;
 			arch_sched_ipi();
@@ -608,7 +608,7 @@ static bool thread_active_elsewhere(struct k_thread *thread)
 static void flag_ipi(void)
 {
 #if defined(CONFIG_SMP) && defined(CONFIG_SCHED_IPI_SUPPORTED)
-	if (CONFIG_MP_NUM_CPUS > 1) {
+	if (arch_num_cpus() > 1) {
 		_kernel.pending_ipi = true;
 	}
 #endif
@@ -1611,7 +1611,7 @@ static inline int z_vrfy_k_is_preempt_thread(void)
 #ifdef CONFIG_SCHED_CPU_MASK
 # ifdef CONFIG_SMP
 /* Right now we use a single byte for this mask */
-BUILD_ASSERT(CONFIG_MP_NUM_CPUS <= 8, "Too many CPUs for mask word");
+BUILD_ASSERT(CONFIG_MP_MAX_NUM_CPUS <= 8, "Too many CPUs for mask word");
 # endif
 
 


### PR DESCRIPTION
Move runtime code to use arch_num_cpus() instead of CONFIG_MP_NUM_CPUS and use CONFIG_MP_MAX_NUM_CPUS for ifdef and BUILD_ASSERT macros.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>