### PR TITLE
bluetooth: host: id: Fix copy BT_HCI_OP_VS_READ_STATIC_ADDRS response

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -1454,7 +1454,7 @@ uint8_t bt_read_static_addr(struct bt_hci_vs_static_addr addrs[], uint8_t size)
 	}
 
 	for (i = 0; i < cnt; i++) {
-		memcpy(&addrs[i], rp->a, sizeof(struct bt_hci_vs_static_addr));
+		memcpy(&addrs[i], &rp->a[i], sizeof(struct bt_hci_vs_static_addr));
 	}
 
 	net_buf_unref(rsp);


### PR DESCRIPTION
Fix copying addresses returned in response to command BT_HCI_OP_VS_READ_STATIC_ADDRS for reading controller static addresses. The loop was iterating only over the destination locations while keeping the source address pointing to the first location of the command response.

Signed-off-by: Ahmed Moheb <ahmed.moheb@nordicsemi.no>