### PR TITLE
boards: arm: nrf52840_papyr: Update documentation link

### DIFF
--- a/boards/arm/nrf52840_papyr/doc/nrf52840_papyr.rst
+++ b/boards/arm/nrf52840_papyr/doc/nrf52840_papyr.rst
@@ -33,7 +33,7 @@ the following devices:
 
      Electronut Labs Papyr (Credit: Electronut Labs)
 
-More information about the board is available at https://docs.electronut.in/papyr/.
+More information about the board is available at https://gitlab.com/electronutlabs-public/papyr.
 
 Hardware
 ********


### PR DESCRIPTION
"Electronut Labs Papyr" documentation page contains an outdated link in the overview section. I found that their documentation is moved to https://gitlab.com/electronutlabs-public/papyr.

Updated the above [link](https://gitlab.com/electronutlabs-public/papyr)  in the doc page.

Fixes #51588 

Signed-off-by: Peeyush Kumar <peeyush.ei@gmail.com>