### PR TITLE
Bluetooth: Audio: Fix codec configuration parameter

### DIFF
--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -40,6 +40,8 @@ static uint8_t pack_bt_codec_cc(const struct bt_codec *codec, uint8_t cc[])
 		 * and that based on the Kconfigs we can assume that the length
 		 * will always fit in `cc`
 		 */
+		cc[len++] = data->data_len + 1;
+		cc[len++] = data->type;
 		(void)memcpy(cc + len, data->data, data->data_len);
 		len += data->data_len;
 	}

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -206,7 +206,7 @@ static int hci_le_setup_iso_data_path(const struct bt_conn *iso, uint8_t dir,
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SETUP_ISO_PATH, sizeof(*cp));
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SETUP_ISO_PATH, sizeof(*cp) + path->cc_len);
 	if (!buf) {
 		return -ENOBUFS;
 	}


### PR DESCRIPTION
Fix wrong Codec_Configuration and Codec_Configuration_Length when setup ISO data path.

Signed-off-by: Hang Fan <fanhang@xiaomi.com>