### PR TITLE
doc: Add note about -z option to btproxy.

### DIFF
--- a/doc/connectivity/bluetooth/bluetooth-tools.rst
+++ b/doc/connectivity/bluetooth/bluetooth-tools.rst
@@ -119,6 +119,10 @@ one additional step using ``btproxy``:
    You might need to replace :literal:`-i 0` with the index of the Controller
    you wish to proxy.
 
+   If you see ``Received unknown host packet type 0x00`` when running QEMU, then
+   add :literal:`-z` to the ``btproxy`` command line to ignore any null bytes
+   transmitted at startup.
+
 Once the hardware is connected and ready to use, you can then proceed to
 building and running a sample:
 


### PR DESCRIPTION
When running bluetooth samples with qemu_cortex_m3, it will sometimes send a null byte at startup. By default, btproxy will detect this as an invalid HCI payload and terminate. The `-z` option can be used to work around this.

@jhedberg FYI -- looks like you added this to btproxy in the first place. https://github.com/bluez/bluez/commit/6f4988bd1e4446b32b9f42250a06d6749f56714c