### PR TITLE
logging: log_backend_fs: added LOG_BACKEND_FS_AUTOSTART configuration

### DIFF
--- a/subsys/logging/backends/Kconfig.fs
+++ b/subsys/logging/backends/Kconfig.fs
@@ -17,6 +17,13 @@ backend = FS
 backend-str = fs
 source "subsys/logging/Kconfig.template.log_format_config"
 
+config LOG_BACKEND_FS_AUTOSTART
+	bool "Automatically start fs backend"
+	default y
+	help
+	  When enabled automatically start the file system backend on
+	  application start.
+
 config LOG_BACKEND_FS_OVERWRITE
 	bool "Old log files overwrite"
 	default y

--- a/subsys/logging/backends/log_backend_fs.c
+++ b/subsys/logging/backends/log_backend_fs.c
@@ -501,5 +501,6 @@ static const struct log_backend_api log_backend_fs_api = {
 	.format_set = format_set,
 };
 
-LOG_BACKEND_DEFINE(log_backend_fs, log_backend_fs_api, true);
+LOG_BACKEND_DEFINE(log_backend_fs, log_backend_fs_api,
+		   IS_ENABLED(CONFIG_LOG_BACKEND_FS_AUTOSTART));
 #endif


### PR DESCRIPTION
This configuration option gives the possibility to not enable the fs backend on startup.
Backend can be enabled in runtime using log_backend_init and log_backend_enable functions.
Implementation is based on log_backend_net.

Signed-off-by: Wojciech Slenska <wsl@trackunit.com>