### PR TITLE
mgmt: mcumgr: transport: smp_bt: Fix deadlock on disconnect with data

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -243,16 +243,19 @@ Libraries / Subsystems
 
 * Management
 
-  * MCUMGR functionality deprecated in 3.1 has been removed:
+  * MCUmgr functionality deprecated in 3.1 has been removed:
     CONFIG_FS_MGMT_UL_CHUNK_SIZE, CONFIG_IMG_MGMT_UL_CHUNK_SIZE,
     CONFIG_OS_MGMT_ECHO_LENGTH
-  * MCUMGR fs_mgmt issue with erasing a file prior to writing the first block
+  * MCUmgr fs_mgmt issue with erasing a file prior to writing the first block
     of data has been worked around by only truncating/deleting the file data
     if the file exists. This can help work around an issue whereby logging is
     enabled and the command is sent on the same UART as the logging system, in
     which a filesystem error was emitted.
   * A MCUmgr bug when using the smp_svr sample with Bluetooth transport that
     could have caused a stack overflow has been fixed.
+  * A MCUmgr issue with Bluetooth transport that could cause a deadlock of the
+    mcumgr thread if the remote device disconnected before the output message
+    was sent has been fixed.
 
 * LwM2M
 

--- a/subsys/mgmt/mcumgr/transport/smp_bt.c
+++ b/subsys/mgmt/mcumgr/transport/smp_bt.c
@@ -387,9 +387,26 @@ static int smp_bt_tx_pkt(struct net_buf *nb)
 		.data = nb->data,
 	};
 	bool sent = false;
+	struct bt_conn_info info;
 
 	conn = smp_bt_conn_from_pkt(nb);
 	if (conn == NULL) {
+		rc = MGMT_ERR_ENOENT;
+		goto cleanup;
+	}
+
+	/* Verify that the device is connected, the necessity for this check is that the remote
+	 * device might have sent a command and disconnected before the command has been processed
+	 * completely, if this happens then the the connection details will still be valid due to
+	 * the incremented connection reference count, but the connection has actually been
+	 * dropped, this avoids waiting for a semaphore that will never be given which would
+	 * otherwise cause a deadlock.
+	 */
+	rc = bt_conn_get_info(conn, &info);
+
+	if (rc != 0 || info.state != BT_CONN_STATE_CONNECTED) {
+		/* Remote device has disconnected */
+		bt_conn_unref(conn);
 		rc = MGMT_ERR_ENOENT;
 		goto cleanup;
 	}
@@ -414,7 +431,6 @@ static int smp_bt_tx_pkt(struct net_buf *nb)
 		notify_param.len = mtu_size;
 
 		rc = bt_gatt_notify_cb(conn, &notify_param);
-		k_sem_take(&smp_notify_sem, K_FOREVER);
 
 		if (rc == -ENOMEM) {
 			if (sent == false) {
@@ -443,7 +459,10 @@ static int smp_bt_tx_pkt(struct net_buf *nb)
 			off += mtu_size;
 			notify_param.data = &nb->data[off];
 			sent = true;
+
+			k_sem_take(&smp_notify_sem, K_FOREVER);
 		} else {
+			/* No connection, cannot continue */
 			rc = MGMT_ERR_EUNKNOWN;
 			break;
 		}


### PR DESCRIPTION
This fixes an issue with the bluetooth transport whereby if a device drops the connection prior to receiving all the output data it could cause a deadlock.

Fixes #51594