### PR TITLE
Drivers: sensors: iis2dh: Add macro DT_DRV_COMPAT to iis2dh_trigger.c

### DIFF
--- a/drivers/sensor/iis2dh/iis2dh_trigger.c
+++ b/drivers/sensor/iis2dh/iis2dh_trigger.c
@@ -8,6 +8,8 @@
  * https://www.st.com/resource/en/datasheet/iis2dh.pdf
  */
 
+#define DT_DRV_COMPAT st_iis2dh
+
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/gpio.h>


### PR DESCRIPTION
Without this define,  the structure iis2dh_device_config is defined incorrectly.

The structure is defined in iis2dh.h file as follows: struct iis2dh_device_config {
#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
	struct spi_dt_spec spi;
#endif
#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
	struct i2c_dt_spec i2c;
#endif
	uint8_t pm;
#ifdef CONFIG_IIS2DH_TRIGGER
	struct gpio_dt_spec int_gpio;
#endif /* CONFIG_IIS2DH_TRIGGER */
};

without the macro
#define DT_DRV_COMPAT st_iis2dh

the structure is defined as
struct iis2dh_device_config {
 uint8_t pm;
 struct gpio_dt_spec int_gpio;
};
which results in accessing the wrong data when calling iis2dh_init_interrupt function (or any other functions in this file)