### PR TITLE
soc: raptor_lake: Cleanup CMakeLists

### DIFF
--- a/soc/x86/raptor_lake/CMakeLists.txt
+++ b/soc/x86/raptor_lake/CMakeLists.txt
@@ -1,6 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
-
 zephyr_cc_option(-march=goldmont)


### PR DESCRIPTION
Cleanup CMakeLists fixing error message:
...
No SOURCES given to Zephyr library: soc__x86__raptor_lake ...
...