### PR TITLE
doc: samples: can: update sample path for mcp2515 board and isotp sample code block

### DIFF
--- a/boards/shields/mcp2515/doc/index.rst
+++ b/boards/shields/mcp2515/doc/index.rst
@@ -227,14 +227,14 @@ when you invoke ``west build`` or ``cmake`` in your Zephyr application. For
 example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/drivers/can
+   :zephyr-app: samples/drivers/can/counter
    :tool: all
    :board: nrf52dk_nrf52832
    :shield: dfrobot_can_bus_v2_0
    :goals: build flash
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/drivers/can
+   :zephyr-app: samples/drivers/can/counter
    :tool: all
    :board: nrf52840dk_nrf52840
    :shield: keyestudio_can_bus_ks0411

--- a/samples/subsys/canbus/isotp/README.rst
+++ b/samples/subsys/canbus/isotp/README.rst
@@ -20,7 +20,7 @@ or Nucleo-F746ZG board.
 For the NXP TWR-KE18F board:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/drivers/can
+   :zephyr-app: samples/subsys/canbus/isotp
    :board: twr_ke18f
    :goals: build flash
 


### PR DESCRIPTION
Update the path of the can counter sample in the mcp2515 shild docs,
as well as the path of the subsys/canbus/isotp code example in the docs.

Fixes: #51752