### PR TITLE
boards: Fix Adafruit Feather M0 Basic Proto board metadata

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.yaml
+++ b/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.yaml
@@ -3,7 +3,7 @@ name: Adafruit Feather M0 Basic Proto
 type: mcu
 arch: arm
 ram: 32
-flash: 256
+flash: 232
 toolchain:
   - zephyr
   - gnuarmemb


### PR DESCRIPTION
Available flash to the test system is limited by the code partition defined in the device tree file.

Signed-off-by: Miguel Dardenne <miguel.dardenne@gmail.com>