### PR TITLE
Minor fixes from picolibc integration work

### DIFF
--- a/arch/x86/core/ia32/gdbstub.c
+++ b/arch/x86/core/ia32/gdbstub.c
@@ -175,7 +175,7 @@ size_t arch_gdb_reg_readone(struct gdb_ctx *ctx, uint8_t *buf, size_t buflen,
 		 * "info registers all".
 		 */
 		if (buflen >= 2) {
-			strncpy(buf, "xx", 2);
+			memcpy(buf, "xx", 2);
 			ret = 2;
 		} else {
 			ret = 0;

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -337,7 +337,7 @@ static uint8_t *recv_cb(uint8_t *buf, size_t *off)
 				int count = 0;
 
 				while (bytes && buf) {
-					char msg[8 + 1];
+					char msg[6 + 10 + 1];
 
 					snprintk(msg, sizeof(msg),
 						 ">slip %2d", count);

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -27,7 +27,7 @@ void sys_trace_k_thread_switched_out(void)
 	ctf_bounded_string_t name = { "unknown" };
 	struct k_thread *thread;
 
-	thread = k_current_get();
+	thread = z_current_get();
 	_get_thread_name(thread, &name);
 
 	ctf_top_thread_switched_out((uint32_t)(uintptr_t)thread, name);
@@ -38,7 +38,7 @@ void sys_trace_k_thread_switched_in(void)
 	struct k_thread *thread;
 	ctf_bounded_string_t name = { "unknown" };
 
-	thread = k_current_get();
+	thread = z_current_get();
 	_get_thread_name(thread, &name);
 
 	ctf_top_thread_switched_in((uint32_t)(uintptr_t)thread, name);


### PR DESCRIPTION
Here are a few minor fixes that I've made while working on picolibc integration testing

Removing -ffreestanding and letting gcc use knowledge of standard C APIs:

1. arch/x86: Use memcpy instead of strncpy in arch_gdb_reg_readone as that's "more correct".
2. drivers/net: Increase a snprintk buffer to guarantee no overflow given even invalid 'count' value. 

Enabling thread local storage:

1. subsys/tracing: Use `z_current_get()` in thread_switch_in/thread_switch_out trace hooks. As these are called from inside the task switching code, the state of the thread local storage pointer is not well defined and may provide incorrect values for `k_current_get()`.

These are all of the non-picolibc related fixes that aren't in testing or module code so far.