### PR TITLE
Bluetooth: Controller: Fix ticker slot reserved check

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -841,6 +841,7 @@ void ull_central_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 	struct pdu_adv *pdu_tx;
 	uint8_t peer_addr_type;
 	uint32_t ticker_status;
+	uint32_t ticks_at_stop;
 	struct node_rx_cc *cc;
 	struct ll_conn *conn;
 	memq_link_t *link;
@@ -988,10 +989,13 @@ void ull_central_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 
 	/* Stop Scanner */
 	ticker_id_scan = TICKER_ID_SCAN_BASE + ull_scan_handle_get(scan);
-	ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR,
-				    TICKER_USER_ID_ULL_HIGH,
-				    ticker_id_scan, ticker_op_stop_scan_cb,
-				    scan);
+	ticks_at_stop = ftr->ticks_anchor +
+			HAL_TICKER_US_TO_TICKS(conn_offset_us) -
+			ticks_slot_offset;
+	ticker_status = ticker_stop_abs(TICKER_INSTANCE_ID_CTLR,
+					TICKER_USER_ID_ULL_HIGH,
+					ticker_id_scan, ticks_at_stop,
+					ticker_op_stop_scan_cb, scan);
 	LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 		  (ticker_status == TICKER_STATUS_BUSY));
 

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -86,6 +86,7 @@ void ull_periph_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 	struct ll_adv_set *adv;
 	uint32_t ticker_status;
 	uint8_t peer_addr_type;
+	uint32_t ticks_at_stop;
 	uint16_t win_delay_us;
 	struct node_rx_cc *cc;
 	struct ll_conn *conn;
@@ -439,9 +440,13 @@ void ull_periph_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 
 	/* Stop Advertiser */
 	ticker_id_adv = TICKER_ID_ADV_BASE + ull_adv_handle_get(adv);
-	ticker_status = ticker_stop(TICKER_INSTANCE_ID_CTLR,
-				    TICKER_USER_ID_ULL_HIGH,
-				    ticker_id_adv, ticker_op_stop_adv_cb, adv);
+	ticks_at_stop = ftr->ticks_anchor +
+			HAL_TICKER_US_TO_TICKS(conn_offset_us) -
+			ticks_slot_offset;
+	ticker_status = ticker_stop_abs(TICKER_INSTANCE_ID_CTLR,
+					TICKER_USER_ID_ULL_HIGH,
+					ticker_id_adv, ticks_at_stop,
+					ticker_op_stop_adv_cb, adv);
 	ticker_op_stop_adv_cb(ticker_status, adv);
 
 	/* Stop Direct Adv Stop */

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -1002,7 +1002,9 @@ void ticker_worker(void *param)
 		 * with other ticker nodes
 		 */
 		if (ticker->ticks_slot != 0U &&
-		   (slot_reserved || ticker_resolve_collision(node, ticker))) {
+		   (slot_reserved ||
+		    (instance->ticks_slot_previous > ticks_expired) ||
+		    ticker_resolve_collision(node, ticker))) {
 #if defined(CONFIG_BT_TICKER_EXT)
 			struct ticker_ext *ext_data = ticker->ext_data;
 


### PR DESCRIPTION
Fix ticker slot reserved check to handle deferred execution of ticker worker where ticks_elapsed is greater than ticks_slot_previous. In which case, each ticker expiring be checked for overlap with previous slot reservation.

This fixes:
ASSERTION FAIL [0] @ WEST_TOPDIR/zephyr/subsys/bluetooth/ controller/ll_sw/nordic/lll/lll.c:476
lll_preempt_calc: Actual EVENT_OVERHEAD_START_US = 3906

Flash erase operation exposed the assertion, CPU being halted deferred the ticker_worker collision resolution and ticker expiry was not individually checked for overlap with previous expired ticker reservation.

Fixes #51600.

Fix missing first connection event due to first connection
event ticks_slot of central and peripheral overlapping with
the initiator window ticks_slot and advertising ticks_slot,
respectively.

Use ticker_stop_abs interface so that when the ticker is
stopped the ticks_slot_previous is truncated to the actual
ticks used as requested by the supplied absolute ticks.

Relates to commit https://github.com/zephyrproject-rtos/zephyr/commit/8a294a62d4843fb5ecbca5e193b44a970e5bf3d1 ("Bluetooth: controller: legacy: Fix missing first conn event").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>