### PR TITLE
codeowners, maintainers: update my status on a few areas

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -170,7 +170,6 @@
 /boards/riscv/rv32m1_vega/                @dleach02
 /boards/riscv/beaglev_starlight_jh7100/   @rajnesh-kanwal
 /boards/riscv/adp_xc7k_ae350/             @cwshu @kevinwang821020 @jimmyzhe
-/boards/riscv/gd32*/                      @gmarull
 /boards/riscv/longan_nano/                @soburi
 /boards/riscv/neorv32/                    @henrikbrixandersen
 /boards/shields/                          @erwango
@@ -335,7 +334,6 @@
 /drivers/led_strip/                       @mbolivar-nordic
 /drivers/lora/                            @Mani-Sadhasivam
 /drivers/mbox/                            @carlocaione
-/drivers/memc/                            @gmarull
 /drivers/misc/                            @tejlmand
 /drivers/misc/ft8xx/                      @hubertmis
 /drivers/mm/                              @dcpleung
@@ -358,7 +356,6 @@
 /drivers/pwm/*rpi_pico*                   @burumaj
 /drivers/pwm/*rv32m1*                     @henrikbrixandersen
 /drivers/pwm/*sam0*                       @nzmichaelh
-/drivers/pwm/*stm32*                      @gmarull
 /drivers/pwm/*test*                       @JordanYates
 /drivers/pwm/*xlnx*                       @henrikbrixandersen
 /drivers/pwm/pwm_capture.c                @henrikbrixandersen
@@ -446,8 +443,6 @@
 /drivers/i2c/i2c_dw*                      @dcpleung
 /drivers/i2c/*tca954x*                    @kurddt
 /drivers/*/*xec*                          @franciscomunoz @albertofloyd @sjvasanth1
-/drivers/mipi_dsi/                        @gmarull
-/drivers/mipi_dsi/mipi_dsi.c              @gmarull
 /drivers/w1/                              @str4t0m
 /drivers/watchdog/*gecko*                 @oanerer
 /drivers/watchdog/*sifive*                @katsuster

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -457,7 +457,6 @@ Display drivers:
   status: odd fixes
   collaborators:
     - jfischer-no
-    - gmarull
   files:
     - drivers/display/
     - dts/bindings/display/
@@ -859,7 +858,6 @@ Release Notes:
     - albertofloyd
   collaborators:
     - VenkatKotakonda
-    - gmarull
   files:
     - drivers/kscan/
     - include/zephyr/drivers/kscan.h
@@ -1014,7 +1012,6 @@ Release Notes:
     - anangl
   collaborators:
     - henrikbrixandersen
-    - gmarull
   files:
     - drivers/pwm/
     - dts/bindings/pwm/
@@ -1043,7 +1040,6 @@ Release Notes:
     - MaureenHelm
   collaborators:
     - avisconti
-    - gmarull
     - teburd
   files:
     - drivers/sensor/
@@ -1701,8 +1697,8 @@ GD32 Platforms:
   status: maintained
   maintainers:
     - nandojve
-    - gmarull
   collaborators:
+    - gmarull
     - soburi
     - cameled
   files:
@@ -1917,7 +1913,6 @@ STM32 Platforms:
   collaborators:
     - ABOSTM
     - FRASTM
-    - gmarull
     - GeorgeCGV
   files:
     - boards/arm/nucleo_*/
@@ -2266,8 +2261,8 @@ West:
   status: maintained
   maintainers:
     - nandojve
-    - gmarull
   collaborators:
+    - gmarull
     - soburi
   files:
     - modules/hal_gigadevice/
@@ -2416,7 +2411,6 @@ West:
   status: odd fixes
   collaborators:
     - cfriedt
-    - gmarull
   files: []
   labels:
     - manifest-hal_ti


### PR DESCRIPTION
This patch updates my status on areas where unfortunately I no longer have time or interest to contribute:

- Removed my collaborator status from STM32, display, sensors, kscan, PWM and hal_ti
- Downgraded my status from maintainer to collaborator for the GD32 platform

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>