### PR TITLE
west: sign: remove -i 3 parameter

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -460,9 +460,9 @@ class RimageSigner(Signer):
             no_manifest = False
 
         if no_manifest:
-            extra_ri_args = ['-i', '3']
+            extra_ri_args = [ ]
         else:
-            extra_ri_args = ['-i', '3', '-e']
+            extra_ri_args = ['-e']
 
         sign_base = [tool_path]
 


### PR DESCRIPTION
in some builds there is need to pass different value for -i parameter and current code will override it to 3
Also in rimage i parameter is by default set to 3