### PR TITLE
Bluetooth: tests: use a single definition of the fff global

### DIFF
--- a/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/src/main.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/src/main.c
@@ -8,9 +8,12 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/buf.h>
 #include <host/hci_core.h>
+#include <zephyr/fff.h>
 #include "mocks/net_buf.h"
 #include "mocks/net_buf_expects.h"
 #include "mocks/buf_help_utils.h"
+
+DEFINE_FFF_GLOBALS;
 
 static void tc_setup(void *f)
 {

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/src/main.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/src/main.c
@@ -6,9 +6,12 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/buf.h>
+#include <zephyr/fff.h>
 #include "mocks/net_buf.h"
 #include "mocks/net_buf_expects.h"
 #include "mocks/buf_help_utils.h"
+
+DEFINE_FFF_GLOBALS;
 
 /* Rows count equals number of events x 2 */
 #define TEST_PARAMETERS_LUT_ROWS_COUNT		60

--- a/tests/bluetooth/host/buf/bt_buf_get_rx/src/main.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_rx/src/main.c
@@ -6,9 +6,12 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/buf.h>
+#include <zephyr/fff.h>
 #include "mocks/net_buf.h"
 #include "mocks/net_buf_expects.h"
 #include "mocks/buf_help_utils.h"
+
+DEFINE_FFF_GLOBALS;
 
 static void tc_setup(void *f)
 {

--- a/tests/bluetooth/host/buf/bt_buf_get_type/src/main.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_type/src/main.c
@@ -7,6 +7,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/buf.h>
+#include <zephyr/fff.h>
+
+DEFINE_FFF_GLOBALS;
 
 /* Rows count equals number of types */
 #define TEST_PARAMETERS_LUT_ROWS_COUNT		7

--- a/tests/bluetooth/host/buf/mocks/net_buf.c
+++ b/tests/bluetooth/host/buf/mocks/net_buf.c
@@ -9,8 +9,6 @@
 #include <zephyr/bluetooth/buf.h>
 #include <mocks/net_buf.h>
 
-DEFINE_FFF_GLOBALS;
-
 static uint8_t *fixed_data_alloc(struct net_buf *buf, size_t *size,
 			      k_timeout_t timeout)
 {

--- a/tests/bluetooth/host/host_mocks/assert.c
+++ b/tests/bluetooth/host/host_mocks/assert.c
@@ -7,8 +7,6 @@
 #include <zephyr/kernel.h>
 #include "host_mocks/assert.h"
 
-DEFINE_FFF_GLOBALS;
-
 DEFINE_FAKE_VALUE_FUNC(bool, mock_check_if_assert_expected);
 
 void assert_print(const char *fmt, ...)

--- a/tests/bluetooth/host/keys/bt_keys_foreach_bond/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_bond/src/main.c
@@ -8,8 +8,11 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/addr.h>
 #include <host/keys.h>
+#include <zephyr/fff.h>
 #include "mocks/keys_help_utils.h"
 #include "testing_common_defs.h"
+
+DEFINE_FFF_GLOBALS;
 
 /* This LUT contains different combinations of ID and Address pairs */
 const struct id_addr_pair testing_id_addr_pair_lut[] = {

--- a/tests/bluetooth/host/keys/bt_keys_foreach_type/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_type/src/main.c
@@ -4,11 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <host/keys.h>
+#include <zephyr/fff.h>
 #include "mocks/keys_help_utils.h"
 #include "testing_common_defs.h"
+
+DEFINE_FFF_GLOBALS;
 
 /* This LUT contains different combinations of ID, Address with no key type */
 static const struct id_addr_type testing_id_addr_type_no_type_lut[] = {

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/main.c
@@ -7,11 +7,14 @@
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/addr.h>
 #include <host/keys.h>
+#include <zephyr/fff.h>
 #include "mocks/conn.h"
 #include "mocks/hci_core.h"
 #include "mocks/keys_help_utils.h"
 #include "host_mocks/print_utils.h"
 #include "testing_common_defs.h"
+
+DEFINE_FFF_GLOBALS;
 
 /* This LUT contains different combinations of ID and Address pairs */
 const struct id_addr_pair testing_id_addr_pair_lut[] = {

--- a/tests/bluetooth/host/keys/mocks/conn.c
+++ b/tests/bluetooth/host/keys/mocks/conn.c
@@ -7,7 +7,5 @@
 #include <zephyr/kernel.h>
 #include "mocks/conn.h"
 
-DEFINE_FFF_GLOBALS;
-
 DEFINE_FAKE_VOID_FUNC(bt_conn_foreach, int, bt_conn_foreach_cb, void *);
 DEFINE_FAKE_VALUE_FUNC(const bt_addr_le_t *, bt_conn_get_dst, const struct bt_conn *);

--- a/tests/bluetooth/host/keys/mocks/hci_core.c
+++ b/tests/bluetooth/host/keys/mocks/hci_core.c
@@ -7,6 +7,4 @@
 #include <zephyr/kernel.h>
 #include "mocks/hci_core.h"
 
-DEFINE_FFF_GLOBALS;
-
 DEFINE_FAKE_VALUE_FUNC(int, bt_unpair, uint8_t, const bt_addr_le_t *);

--- a/tests/bluetooth/host/keys/mocks/id.c
+++ b/tests/bluetooth/host/keys/mocks/id.c
@@ -7,6 +7,4 @@
 #include <zephyr/kernel.h>
 #include "mocks/id.h"
 
-DEFINE_FFF_GLOBALS;
-
 DEFINE_FAKE_VOID_FUNC(bt_id_del, struct bt_keys *);

--- a/tests/bluetooth/host/keys/mocks/rpa.c
+++ b/tests/bluetooth/host/keys/mocks/rpa.c
@@ -7,6 +7,4 @@
 #include <zephyr/kernel.h>
 #include "mocks/rpa.h"
 
-DEFINE_FFF_GLOBALS;
-
 DEFINE_FAKE_VALUE_FUNC(bool, bt_rpa_irk_matches, const uint8_t *, const bt_addr_t *);


### PR DESCRIPTION
Linking fails on ubuntu 22.04 because of multiple definitions of the `fff` global, which is defined by `DEFINE_FFF_GLOBALS`.

Only define it in the tests' `main.c` instead of the mocks.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>