### PR TITLE
tests: net: Add min flash requirment for overflowing tests

### DIFF
--- a/tests/net/socket/offload_dispatcher/testcase.yaml
+++ b/tests/net/socket/offload_dispatcher/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: netif
+  min_flash: 240
 tests:
   net.socket.offload.dispatcher:
     tags: net socket

--- a/tests/net/socket/tls/testcase.yaml
+++ b/tests/net/socket/tls/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   depends_on: netif
   min_ram: 32
+  min_flash: 260
   tags: net socket tls
   filter: TOOLCHAIN_HAS_NEWLIB == 1
   integration_platforms:


### PR DESCRIPTION
These tests turn on mbedtls and require ajusting min flash requirements to prevent twister from trying to build them on platforms without required amount of flash.
Fixes: #51421

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>