### PR TITLE
dts: x86: intel: Add missing #address-cells and #size-cells

### DIFF
--- a/dts/x86/intel/apollo_lake.dtsi
+++ b/dts/x86/intel/apollo_lake.dtsi
@@ -29,6 +29,8 @@
 	};
 
 	intc: ioapic@fec00000  {
+		#address-cells = <1>;
+		#size-cells = <1>;
 		compatible = "intel,ioapic";
 		reg = <0xfec00000 0x1000>;
 		interrupt-controller;

--- a/dts/x86/intel/atom.dtsi
+++ b/dts/x86/intel/atom.dtsi
@@ -26,6 +26,8 @@
 	};
 
 	intc: ioapic@fec00000  {
+		#address-cells = <1>;
+		#size-cells = <1>;
 		compatible = "intel,ioapic";
 		reg = <0xfec00000 0x1000>;
 		interrupt-controller;

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -34,6 +34,8 @@
 	};
 
 	intc: ioapic@fec00000  {
+		#address-cells = <1>;
+		#size-cells = <1>;
 		compatible = "intel,ioapic";
 		reg = <0xfec00000 0x1000>;
 		interrupt-controller;

--- a/dts/x86/intel/lakemont.dtsi
+++ b/dts/x86/intel/lakemont.dtsi
@@ -22,6 +22,8 @@
 	};
 
 	intc: ioapic@fec00000  {
+		#address-cells = <1>;
+		#size-cells = <1>;
 		compatible = "intel,ioapic";
 		reg = <0xfec00000 0x1000>;
 		interrupt-controller;

--- a/dts/x86/intel/raptor_lake.dtsi
+++ b/dts/x86/intel/raptor_lake.dtsi
@@ -28,6 +28,8 @@
 	};
 
 	intc: ioapic@fec00000  {
+		#address-cells = <1>;
+		#size-cells = <1>;
 		compatible = "intel,ioapic";
 		reg = <0xfec00000 0x1000>;
 		interrupt-controller;


### PR DESCRIPTION
Some dtc versions give the following warning without this change:

build/zephyr/zephyr.dts:29.24-35.4: Warning (interrupt_provider): /ioapic@fec00000: Missing #address-cells in interrupt provider

It seems that this warning comes at least with dtc version 1.6.1, but not with 1.5.0.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>