### PR TITLE
net: lwm2m: Fix connection resume without DTLS

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -251,10 +251,6 @@ int lwm2m_engine_connection_resume(struct lwm2m_ctx *client_ctx)
 			return ret;
 		}
 
-		if (!client_ctx->use_dtls) {
-			return 0;
-		}
-
 		LOG_DBG("Resume suspended connection");
 		return lwm2m_socket_start(client_ctx);
 	}


### PR DESCRIPTION
LwM2M connection resume was missing socket connection when DTLS is disabled.

Fixes #51566

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>