### PR TITLE
Bluetooth: controller: Add a workaround to use DLE with multiple connections                         

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -469,6 +469,10 @@ conn_is_valid:
 #endif /* !CONFIG_BT_CTLR_DATA_LENGTH */
 #endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 
+	// Checkme: Workaround to use DLE with multiple peripherals
+	max_tx_time = PDU_DC_PAYLOAD_TIME_MAX; /* 2120 us */
+	max_rx_time = PDU_DC_PAYLOAD_TIME_MAX; /* 2120 us */
+
 	conn->ull.ticks_slot =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US +
 				       ready_delay_us +


### PR DESCRIPTION
(still under test)

Only increase max tx and rx time

Opened github issue:
https://github.com/zephyrproject-rtos/zephyr/issues/51509