### PR TITLE
Bluetooth: extended adv reports with legacy content discardable

### DIFF
--- a/drivers/bluetooth/hci/rpmsg.c
+++ b/drivers/bluetooth/hci/rpmsg.c
@@ -45,6 +45,17 @@ static bool is_hci_event_discardable(const uint8_t *evt_data)
 		switch (subevt_type) {
 		case BT_HCI_EVT_LE_ADVERTISING_REPORT:
 			return true;
+#if defined(CONFIG_BT_EXT_ADV)
+		case BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT:
+		{
+			const struct bt_hci_evt_le_ext_advertising_report *ext_adv =
+				(void *)&evt_data[3];
+
+			return (ext_adv->num_reports == 1) &&
+				   ((ext_adv->adv_info[0].evt_type &
+					 BT_HCI_LE_ADV_EVT_TYPE_LEGACY) != 0);
+		}
+#endif
 		default:
 			return false;
 		}

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -136,11 +136,13 @@ config BT_BUF_EVT_RX_COUNT
 
 config BT_BUF_EVT_DISCARDABLE_SIZE
 	int "Maximum supported discardable HCI Event buffer length"
-	range 43 255
+	range 43 255 if !BT_EXT_ADV
+	range 58 255 if BT_EXT_ADV
 	# LE Extended Advertising Report event
 	default 255 if BT_BREDR
 	# Le Advertising Report event
-	default 43
+	default 43 if !BT_EXT_ADV
+	default 58 if BT_EXT_ADV
 	help
 	  Maximum support discardable HCI event size of buffers in the separate
 	  discardable event buffer pool. This value does not include the


### PR DESCRIPTION
To avoid legacy extended adv repots blocking important events or work, mark them as discaradble.

I don't intend to follow up this PR, I just made it to explain what I mean in the issue I created: https://github.com/zephyrproject-rtos/zephyr/issues/51650