### PR TITLE
driver: uart: allow esp32c3 usb-serial to work with wifi

### DIFF
--- a/drivers/serial/Kconfig.esp32
+++ b/drivers/serial/Kconfig.esp32
@@ -26,3 +26,13 @@ config SERIAL_ESP32_USB
 	  USB host. The USB stack is built into the chip and accessed
 	  by the firmware through a simplified API similar to a "normal"
 	  UART peripheral.
+
+config ESP_PHY_ENABLE_USB
+	bool "Enable USB when phy init"
+	depends on SERIAL_ESP32_USB
+	default y if SOC_ESP32C3
+	default n
+	help
+	  When using USB Serial/JTAG/OTG/CDC, PHY should enable USB, otherwise USB module
+	  can not work properly. Notice: Enabling this configuration option will slightly
+	  impact wifi performance.


### PR DESCRIPTION
ESP32-C3 usb-serial interface does not work when Wi-Fi is enabled. This fixes that by allowing hal_espressif to proper handle this pin when PHY is enabled.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>