### PR TITLE
Bluetooth: Host: Fix missing term callback for PA syncs

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -104,6 +104,9 @@ Bluetooth
 
 * Host
 
+  * Fixed missing calls to bt_le_per_adv_sync_cb.term when deleting a periodic
+    advertising sync object.
+
 * Mesh
 
 * Controller

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -930,12 +930,15 @@ void bt_hci_le_per_adv_sync_established(struct net_buf *buf)
 			const uint8_t reason = unexpected_evt ? BT_HCI_ERR_UNSPECIFIED
 							      : evt->status;
 
-			/* Store the event data in the sync object for the
-			 * callback
-			 */
-			bt_addr_le_copy(&pending_per_adv_sync->addr,
-					&evt->adv_addr);
-			pending_per_adv_sync->sid = evt->sid;
+			if (atomic_test_bit(pending_per_adv_sync->flags,
+					    BT_PER_ADV_SYNC_SYNCING_USE_LIST)) {
+				/* Update the addr and sid for the callback
+				 * Already set if not using the sync list
+				 */
+				bt_addr_le_copy(&pending_per_adv_sync->addr,
+						&evt->adv_addr);
+				pending_per_adv_sync->sid = evt->sid;
+			}
 
 			per_adv_sync_terminated(pending_per_adv_sync, reason);
 		}

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -855,6 +855,29 @@ static int per_adv_sync_terminate(uint16_t handle)
 				    NULL);
 }
 
+static void per_adv_sync_terminated(struct bt_le_per_adv_sync *per_adv_sync,
+				    uint8_t reason)
+{
+	/* Terminate the PA sync and notify app */
+	const struct bt_le_per_adv_sync_term_info term_info = {
+		.addr = &per_adv_sync->addr,
+		.sid = per_adv_sync->sid,
+		.reason = reason,
+	};
+	struct bt_le_per_adv_sync_cb *listener;
+
+	/* Deleting before callback, so the caller will be able
+	 * to restart sync in the callback.
+	 */
+	per_adv_sync_delete(per_adv_sync);
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs, listener, node) {
+		if (listener->term) {
+			listener->term(per_adv_sync, &term_info);
+		}
+	}
+}
+
 void bt_hci_le_per_adv_sync_established(struct net_buf *buf)
 {
 	struct bt_hci_evt_le_per_adv_sync_established *evt =
@@ -904,26 +927,17 @@ void bt_hci_le_per_adv_sync_established(struct net_buf *buf)
 
 	if (unexpected_evt || evt->status != BT_HCI_ERR_SUCCESS) {
 		if (pending_per_adv_sync) {
-			struct bt_le_per_adv_sync_term_info term_info;
+			const uint8_t reason = unexpected_evt ? BT_HCI_ERR_UNSPECIFIED
+							      : evt->status;
 
-			/* Terminate the pending PA sync and notify app */
-			term_info.addr = &evt->adv_addr;
-			term_info.sid = evt->sid;
-			term_info.reason = unexpected_evt ? BT_HCI_ERR_UNSPECIFIED : evt->status;
-
-			/* Deleting before callback, so the caller will be able
-			 * to restart sync in the callback.
+			/* Store the event data in the sync object for the
+			 * callback
 			 */
-			per_adv_sync_delete(pending_per_adv_sync);
+			bt_addr_le_copy(&pending_per_adv_sync->addr,
+					&evt->adv_addr);
+			pending_per_adv_sync->sid = evt->sid;
 
-			SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs,
-						     listener,
-						     node) {
-				if (listener->term) {
-					listener->term(pending_per_adv_sync,
-						       &term_info);
-				}
-			}
+			per_adv_sync_terminated(pending_per_adv_sync, reason);
 		}
 		return;
 	}
@@ -979,9 +993,7 @@ void bt_hci_le_per_adv_sync_lost(struct net_buf *buf)
 {
 	struct bt_hci_evt_le_per_adv_sync_lost *evt =
 		(struct bt_hci_evt_le_per_adv_sync_lost *)buf->data;
-	struct bt_le_per_adv_sync_term_info term_info;
 	struct bt_le_per_adv_sync *per_adv_sync;
-	struct bt_le_per_adv_sync_cb *listener;
 
 	per_adv_sync = bt_hci_get_per_adv_sync(sys_le16_to_cpu(evt->handle));
 
@@ -991,22 +1003,8 @@ void bt_hci_le_per_adv_sync_lost(struct net_buf *buf)
 		return;
 	}
 
-	term_info.addr = &per_adv_sync->addr;
-	term_info.sid = per_adv_sync->sid;
 	/* There is no status in the per. adv. sync lost event */
-	term_info.reason = BT_HCI_ERR_UNSPECIFIED;
-
-	/* Deleting before callback, so the caller will be able to restart
-	 * sync in the callback
-	 */
-	per_adv_sync_delete(per_adv_sync);
-
-
-	SYS_SLIST_FOR_EACH_CONTAINER(&pa_sync_cbs, listener, node) {
-		if (listener->term) {
-			listener->term(per_adv_sync, &term_info);
-		}
-	}
+	per_adv_sync_terminated(per_adv_sync, BT_HCI_ERR_UNSPECIFIED);
 }
 
 #if defined(CONFIG_BT_CONN)
@@ -1557,7 +1555,8 @@ int bt_le_per_adv_sync_delete(struct bt_le_per_adv_sync *per_adv_sync)
 		err = bt_le_per_adv_sync_terminate(per_adv_sync);
 
 		if (!err) {
-			per_adv_sync_delete(per_adv_sync);
+			per_adv_sync_terminated(per_adv_sync,
+						BT_HCI_ERR_LOCALHOST_TERM_CONN);
 		}
 	} else if (get_pending_per_adv_sync() == per_adv_sync) {
 		err = bt_le_per_adv_sync_create_cancel(per_adv_sync);

--- a/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
@@ -58,6 +58,7 @@ static const struct bt_data per_ad_data2[] = {
 static uint8_t chan_map[] = { 0x1F, 0XF1, 0x1F, 0xF1, 0x1F };
 
 static bool volatile is_iso_connected;
+static bool volatile deleting_pa_sync;
 static void iso_connected(struct bt_iso_chan *chan);
 static void iso_disconnected(struct bt_iso_chan *chan, uint8_t reason);
 static void iso_recv(struct bt_iso_chan *chan,
@@ -395,7 +396,11 @@ static void pa_terminated_cb(struct bt_le_per_adv_sync *sync,
 	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated\n",
 	       bt_le_per_adv_sync_get_index(sync), le_addr);
 
-	FAIL("PA terminated unexpectedly\n");
+	if (!deleting_pa_sync) {
+		FAIL("PA terminated unexpectedly\n");
+	} else {
+		deleting_pa_sync = false;
+	}
 }
 
 static bool volatile is_sync_recv;
@@ -618,6 +623,7 @@ static void test_iso_recv_main(void)
 	k_sleep(K_MSEC(5000));
 
 	printk("Deleting Periodic Advertising Sync...");
+	deleting_pa_sync = true;
 	err = bt_le_per_adv_sync_delete(sync);
 	if (err) {
 		FAIL("Failed to delete periodic advertising sync (err %d)\n",
@@ -766,6 +772,7 @@ static void test_iso_recv_main(void)
 	printk("success.\n");
 
 	printk("Deleting Periodic Advertising Sync...");
+	deleting_pa_sync = true;
 	err = bt_le_per_adv_sync_delete(sync);
 	if (err) {
 		FAIL("Failed to delete periodic advertising sync (err %d)\n",
@@ -923,6 +930,7 @@ static void test_iso_recv_vs_dp_main(void)
 	printk("success.\n");
 
 	printk("Deleting Periodic Advertising Sync... ");
+	deleting_pa_sync = true;
 	err = bt_le_per_adv_sync_delete(sync);
 	if (err) {
 		FAIL("Failed to delete periodic advertising sync (err %d)\n",


### PR DESCRIPTION
When deleting a PA sync with bt_le_per_adv_sync_delete Zephyr should call the `term` callback for the PA sync as per the documentation for the callback.

This was not done in the case that the PA sync was terminated by local request.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>