### PR TITLE
samples/boards/nrf: Fix onoff_level_lighting_vnd_ap sample

### DIFF
--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/smp_svr.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/smp_svr.c
@@ -6,16 +6,14 @@
  */
 
 #include <zephyr/sys/__assert.h>
-#include <zephyr/bluetooth/conn.h>
-#include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/gatt.h>
-#include <zephyr/mgmt/mcumgr/buf.h>
-#include <zephyr/mgmt/mcumgr/smp_bt.h>
 #include <zephyr/stats/stats.h>
 #include <stdlib.h>
 #include <string.h>
 #include <zephyr/kernel.h>
 
+#ifdef CONFIG_MCUMGR_CMD_FS_MGMT
+#include "fs_mgmt/fs_mgmt.h"
+#endif
 #ifdef CONFIG_MCUMGR_CMD_IMG_MGMT
 #include "img_mgmt/img_mgmt.h"
 #endif


### PR DESCRIPTION
Remove inclusion of moved and non needed header.
Other unneeded headers have been also removed.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>