### PR TITLE
Make LittleFS Flash driver integration a configuration option

### DIFF
--- a/subsys/fs/Kconfig.littlefs
+++ b/subsys/fs/Kconfig.littlefs
@@ -6,8 +6,6 @@
 config FILE_SYSTEM_LITTLEFS
 	bool "LittleFS support"
 	depends on FILE_SYSTEM
-	depends on FLASH_MAP
-	depends on FLASH_PAGE_LAYOUT
 	depends on ZEPHYR_LITTLEFS_MODULE
 	help
 	  Enables LittleFS file system support.
@@ -105,8 +103,18 @@ config FS_LITTLEFS_HEAP_PER_ALLOC_OVERHEAD_SIZE
 
 endif # FS_LITTLEFS_FC_HEAP_SIZE <= 0
 
+config FS_LITTLEFS_FLASH_DEV
+	bool "Support for littlefs on flash memory devices"
+	default y
+	depends on FLASH
+	depends on FLASH_MAP
+	help
+	  Enable this option to provide support for littlefs on the flash
+	  memory devices (like for example MCU embedded or (Q)SPI flash).
+
 config FS_LITTLEFS_BLK_DEV
 	bool "Support for littlefs on block devices"
+	depends on DISK_ACCESS
 	help
 	  Enable this option to provide support for littlefs on the block
 	  devices (like for example SD card).


### PR DESCRIPTION
Not all systems use LittleFS on Flash memory. They may use SD card or eMMC as physical media, hence adding Flash driver is unwanted payload. Some SoCs do not have Flash driver in Zehpyr, that was actually the reason to create this PR.
Added configuration option to enable/disable LittleFS Flash memory interface, just like there's configuration option for disk access layer interface. For backward compatibility reasons, have Flash driver interface enabled by default.