### PR TITLE
Bluetooth: shell: fix compiler warning

### DIFF
--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -522,6 +522,7 @@ static int cmd_write_without_rsp(const struct shell *sh,
 	}
 
 	repeat = 0U;
+	err = 0;
 
 	if (argc > 4) {
 		repeat = strtoul(argv[4], NULL, 16);


### PR DESCRIPTION
Compiler thinks `err` is not initialized when
`CONFIG_DEBUG_OPTIMIZATIONS=y`.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>