### PR TITLE
ci: workflows: Make backport_issue_check only working in the upstream

### DIFF
--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -9,6 +9,7 @@ jobs:
   backport:
     name: Backport Issue Check
     runs-on: ubuntu-20.04
+    if: github.repository == 'zephyrproject-rtos/zephyr'
 
     steps:
       - name: Check out source code


### PR DESCRIPTION
This check makes no sense outside of the upstream zephyr CI and causes downstream CIs, which are forked from the upstream, to fail.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>