### PR TITLE
Use `CONFIG_(BIG|LITTLE)_ENDIAN` instead of `__BYTE_ORDER__` for endianness checks

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -166,6 +166,14 @@ config BIG_ENDIAN
 	  modifying it.  The option is used to select linker script OUTPUT_FORMAT
 	  and command line option for gen_isr_tables.py.
 
+config LITTLE_ENDIAN
+	# Hidden Kconfig option representing the default little-endian architecture
+	# This is just the opposite of BIG_ENDIAN and is used for non-negative
+	# conditional compilation
+	bool
+	depends on !BIG_ENDIAN
+	default y
+
 config 64BIT
 	bool
 	help

--- a/drivers/w1/w1_net.c
+++ b/drivers/w1/w1_net.c
@@ -183,7 +183,7 @@ int z_impl_w1_search_bus(const struct device *dev, uint8_t command,
 		 * Only big-endian targets need to swap, such that struct's
 		 * bytes are stored in big-endian byte order.
 		 */
-		if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) {
+		if (IS_ENABLED(CONFIG_BIG_ENDIAN)) {
 			sys_memcpy_swap(&found_rom, &found_rom_inv_64, 8);
 		} else {
 			*(uint64_t *)&found_rom = found_rom_inv_64;

--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -89,10 +89,10 @@ struct _thread_base {
 	 */
 	union {
 		struct {
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#ifdef CONFIG_BIG_ENDIAN
 			uint8_t sched_locked;
 			int8_t prio;
-#else /* LITTLE and PDP */
+#else /* Little Endian */
 			int8_t prio;
 			uint8_t sched_locked;
 #endif

--- a/include/zephyr/net/ptp_time.h
+++ b/include/zephyr/net/ptp_time.h
@@ -40,16 +40,14 @@ struct net_ptp_time {
 	/** Seconds encoded on 48 bits. */
 	union {
 		struct {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 			uint32_t low;
 			uint16_t high;
 			uint16_t unused;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-			uint16_t unused;
-			uint16_t high;
-			uint32_t low;
 #else
-#error "Unknown byte order"
+			uint16_t unused;
+			uint16_t high;
+			uint32_t low;
 #endif
 		} _sec;
 		uint64_t second;
@@ -77,16 +75,14 @@ struct net_ptp_extended_time {
 	/** Seconds encoded on 48 bits. */
 	union {
 		struct {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 			uint32_t low;
 			uint16_t high;
 			uint16_t unused;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-			uint16_t unused;
-			uint16_t high;
-			uint32_t low;
 #else
-#error "Unknown byte order"
+			uint16_t unused;
+			uint16_t high;
+			uint32_t low;
 #endif
 		} _sec;
 		uint64_t second;
@@ -95,16 +91,14 @@ struct net_ptp_extended_time {
 	/** Fractional nanoseconds on 48 bits. */
 	union {
 		struct {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 			uint32_t low;
 			uint16_t high;
 			uint16_t unused;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-			uint16_t unused;
-			uint16_t high;
-			uint32_t low;
 #else
-#error "Unknown byte order"
+			uint16_t unused;
+			uint16_t high;
+			uint32_t low;
 #endif
 		} _fns;
 		uint64_t fract_nsecond;

--- a/include/zephyr/sys/byteorder.h
+++ b/include/zephyr/sys/byteorder.h
@@ -168,7 +168,7 @@
  *  @return 48-bit integer in big-endian format.
  */
 
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 #define sys_le16_to_cpu(val) (val)
 #define sys_cpu_to_le16(val) (val)
 #define sys_le24_to_cpu(val) (val)
@@ -189,7 +189,7 @@
 #define sys_cpu_to_be48(val) __bswap_48(val)
 #define sys_be64_to_cpu(val) __bswap_64(val)
 #define sys_cpu_to_be64(val) __bswap_64(val)
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 #define sys_le16_to_cpu(val) __bswap_16(val)
 #define sys_cpu_to_le16(val) __bswap_16(val)
 #define sys_le24_to_cpu(val) __bswap_24(val)
@@ -210,8 +210,6 @@
 #define sys_cpu_to_be48(val) (val)
 #define sys_be64_to_cpu(val) (val)
 #define sys_cpu_to_be64(val) (val)
-#else
-#error "Unknown byte order"
 #endif
 
 /**

--- a/include/zephyr/toolchain.h
+++ b/include/zephyr/toolchain.h
@@ -117,14 +117,21 @@
 
 /*
  * Ensure that __BYTE_ORDER__ and related preprocessor definitions are defined,
- * as these are often used without checking for definition and doing so can
- * cause unexpected behaviours.
+ * and that they match the Kconfig option that is used in the code itself to
+ * check for endianness.
  */
 #ifndef _LINKER
 #if !defined(__BYTE_ORDER__) || !defined(__ORDER_BIG_ENDIAN__) || \
     !defined(__ORDER_LITTLE_ENDIAN__)
 
 #error "__BYTE_ORDER__ is not defined"
+
+#else
+
+#if (defined(CONFIG_BIG_ENDIAN) && (__BYTE_ORDER__ != __ORDER_BIG_ENDIAN__)) || \
+    (defined(CONFIG_LITTLE_ENDIAN) && (__BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__))
+#error "Endiannes mismatch"
+#endif
 
 #endif
 #endif /* !_LINKER */

--- a/include/zephyr/usb/usb_ch9.h
+++ b/include/zephyr/usb/usb_ch9.h
@@ -23,11 +23,11 @@ extern "C" {
 #endif
 
 struct usb_req_type_field {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t recipient : 5;
 	uint8_t type : 2;
 	uint8_t direction : 1;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 	uint8_t direction : 1;
 	uint8_t type : 2;
 	uint8_t recipient : 5;

--- a/modules/canopennode/CO_driver_target.h
+++ b/modules/canopennode/CO_driver_target.h
@@ -39,12 +39,10 @@ extern "C" {
 #define CO_USE_LEDS 1
 #endif
 
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 #define CO_LITTLE_ENDIAN
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#define CO_BIG_ENDIAN
 #else
-#error "Unsupported endianness"
+#define CO_BIG_ENDIAN
 #endif
 
 typedef bool          bool_t;

--- a/modules/littlefs/zephyr_lfs_config.h
+++ b/modules/littlefs/zephyr_lfs_config.h
@@ -147,20 +147,9 @@ static inline int lfs_scmp(uint32_t a, uint32_t b)
 /* Convert between 32-bit little-endian and native order */
 static inline uint32_t lfs_fromle32(uint32_t a)
 {
-#if (defined(BYTE_ORDER) && defined(ORDER_LITTLE_ENDIAN) &&             \
-	BYTE_ORDER == ORDER_LITTLE_ENDIAN) ||                           \
-	(defined(__BYTE_ORDER) && defined(__ORDER_LITTLE_ENDIAN) &&     \
-	__BYTE_ORDER   == __ORDER_LITTLE_ENDIAN) ||                     \
-	(defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
-	__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#if defined(CONFIG_LITTLE_ENDIAN)
 	return a;
-#elif !defined(LFS_NO_INTRINSICS) && (                               \
-	(defined(BYTE_ORDER) && defined(ORDER_BIG_ENDIAN) &&         \
-	BYTE_ORDER == ORDER_BIG_ENDIAN) ||                           \
-	(defined(__BYTE_ORDER) && defined(__ORDER_BIG_ENDIAN) &&     \
-	__BYTE_ORDER == __ORDER_BIG_ENDIAN) ||                       \
-	(defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
-	__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+#elif !defined(LFS_NO_INTRINSICS)
 	return __builtin_bswap32(a);
 #else
 	return (((uint8_t *)&a)[0] <<  0) |
@@ -178,21 +167,10 @@ static inline uint32_t lfs_tole32(uint32_t a)
 /* Convert between 32-bit big-endian and native order */
 static inline uint32_t lfs_frombe32(uint32_t a)
 {
-#if !defined(LFS_NO_INTRINSICS) && ( \
-	(defined(BYTE_ORDER) && defined(ORDER_LITTLE_ENDIAN) &&         \
-	BYTE_ORDER == ORDER_LITTLE_ENDIAN) ||                           \
-	(defined(__BYTE_ORDER) && defined(__ORDER_LITTLE_ENDIAN) &&     \
-	__BYTE_ORDER == __ORDER_LITTLE_ENDIAN) ||                       \
-	(defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
-	__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
-	return __builtin_bswap32(a);
-#elif (defined(BYTE_ORDER) && defined(ORDER_BIG_ENDIAN) &&           \
-	BYTE_ORDER == ORDER_BIG_ENDIAN) ||                           \
-	(defined(__BYTE_ORDER) && defined(__ORDER_BIG_ENDIAN) &&     \
-	__BYTE_ORDER == __ORDER_BIG_ENDIAN) ||                       \
-	(defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
-	__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#if defined(CONFIG_BIG_ENDIAN)
 	return a;
+#elif !defined(LFS_NO_INTRINSICS)
+	return __builtin_bswap32(a);
 #else
 	return (((uint8_t *)&a)[0] << 24) |
 	       (((uint8_t *)&a)[1] << 16) |

--- a/modules/littlefs/zephyr_lfs_config.h
+++ b/modules/littlefs/zephyr_lfs_config.h
@@ -147,13 +147,12 @@ static inline int lfs_scmp(uint32_t a, uint32_t b)
 /* Convert between 32-bit little-endian and native order */
 static inline uint32_t lfs_fromle32(uint32_t a)
 {
-#if !defined(LFS_NO_INTRINSICS) && (                                    \
-	(defined(BYTE_ORDER) && defined(ORDER_LITTLE_ENDIAN) &&         \
+#if (defined(BYTE_ORDER) && defined(ORDER_LITTLE_ENDIAN) &&             \
 	BYTE_ORDER == ORDER_LITTLE_ENDIAN) ||                           \
 	(defined(__BYTE_ORDER) && defined(__ORDER_LITTLE_ENDIAN) &&     \
 	__BYTE_ORDER   == __ORDER_LITTLE_ENDIAN) ||                     \
 	(defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
-	__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
+	__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 	return a;
 #elif !defined(LFS_NO_INTRINSICS) && (                               \
 	(defined(BYTE_ORDER) && defined(ORDER_BIG_ENDIAN) &&         \
@@ -187,13 +186,12 @@ static inline uint32_t lfs_frombe32(uint32_t a)
 	(defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
 	__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
 	return __builtin_bswap32(a);
-#elif !defined(LFS_NO_INTRINSICS) && (                               \
-	(defined(BYTE_ORDER) && defined(ORDER_BIG_ENDIAN) &&         \
+#elif (defined(BYTE_ORDER) && defined(ORDER_BIG_ENDIAN) &&           \
 	BYTE_ORDER == ORDER_BIG_ENDIAN) ||                           \
 	(defined(__BYTE_ORDER) && defined(__ORDER_BIG_ENDIAN) &&     \
 	__BYTE_ORDER == __ORDER_BIG_ENDIAN) ||                       \
 	(defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
-	__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+	__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
 	return a;
 #else
 	return (((uint8_t *)&a)[0] << 24) |

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -6562,6 +6562,12 @@ sub process {
 			      "Use of the '$1' macro makes the build non-deterministic\n" . $herecurr);
 		}
 
+# check for uses of __BYTE_ORDER__
+		while ($line =~ /\b(__BYTE_ORDER__)\b/g) {
+			ERROR("BYTE_ORDER",
+			      "Use of the '$1' macro is disallowed. Use CONFIG_BIG_ENDIAN instead\n" . $herecurr);
+		}
+
 # check for use of yield()
 		if ($line =~ /\byield\s*\(\s*\)/) {
 			WARN("YIELD",

--- a/subsys/bluetooth/audio/csis.c
+++ b/subsys/bluetooth/audio/csis.c
@@ -133,7 +133,7 @@ static int sirk_encrypt(struct bt_conn *conn,
 					   0x3c, 0xe5, 0xce, 0xd9};
 		static bool swapped;
 
-		if (!swapped && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)) {
+		if (!swapped && IS_ENABLED(CONFIG_LITTLE_ENDIAN)) {
 			/* Swap test_k to little endian */
 			sys_mem_swap(test_k, 16);
 			swapped = true;

--- a/subsys/bluetooth/audio/csis_client.c
+++ b/subsys/bluetooth/audio/csis_client.c
@@ -246,7 +246,7 @@ static int sirk_decrypt(struct bt_conn *conn,
 
 		BT_DBG("Decrypting with sample data K");
 
-		if (!swapped && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) {
+		if (!swapped && IS_ENABLED(CONFIG_LITTLE_ENDIAN)) {
 			/* Swap test_k to little endian */
 			sys_mem_swap(test_k, 16);
 			swapped = true;

--- a/subsys/bluetooth/audio/csis_crypto.c
+++ b/subsys/bluetooth/audio/csis_crypto.c
@@ -79,7 +79,7 @@ int bt_csis_sih(const uint8_t sirk[BT_CSIS_SET_SIRK_SIZE], uint32_t r,
 
 	BT_DBG("BE: r' %s", bt_hex(res, sizeof(res)));
 
-	if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) {
+	if (IS_ENABLED(CONFIG_LITTLE_ENDIAN)) {
 		/* Swap to Big Endian (BE) */
 		sys_memcpy_swap(sirk_tmp, sirk, BT_CSIS_SET_SIRK_SIZE);
 	} else {
@@ -205,7 +205,7 @@ int bt_csis_sef(const uint8_t k[BT_CSIS_CRYPTO_KEY_SIZE],
 
 	BT_DBG("SIRK %s", bt_hex(sirk, BT_CSIS_SET_SIRK_SIZE));
 
-	if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) {
+	if (IS_ENABLED(CONFIG_LITTLE_ENDIAN)) {
 		/* Swap because aes_cmac is big endian
 		 * and we are little endian
 		 */
@@ -229,7 +229,7 @@ int bt_csis_sef(const uint8_t k[BT_CSIS_CRYPTO_KEY_SIZE],
 
 	BT_DBG("BE: k1 result %s", bt_hex(k1_out, sizeof(k1_out)));
 
-	if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) {
+	if (IS_ENABLED(CONFIG_LITTLE_ENDIAN)) {
 		/* Swap result back to little endian */
 		sys_mem_swap(k1_out, sizeof(k1_out));
 	}

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -297,21 +297,19 @@ struct pdu_adv_connect_ind {
 		uint16_t latency;
 		uint16_t timeout;
 		uint8_t  chan_map[PDU_CHANNEL_MAP_SIZE];
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 		uint8_t  hop:5;
 		uint8_t  sca:3;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-		uint8_t  sca:3;
-		uint8_t  hop:5;
 #else
-#error "Unsupported endianness"
-#endif
+		uint8_t  sca:3;
+		uint8_t  hop:5;
+#endif /* CONFIG_LITTLE_ENDIAN */
 
 	} __packed;
 } __packed;
 
 struct pdu_adv_ext_hdr {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t adv_addr:1;
 	uint8_t tgt_addr:1;
 	uint8_t cte_info:1;
@@ -320,31 +318,27 @@ struct pdu_adv_ext_hdr {
 	uint8_t sync_info:1;
 	uint8_t tx_pwr:1;
 	uint8_t rfu:1;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint8_t rfu:1;
-	uint8_t tx_pwr:1;
-	uint8_t sync_info:1;
-	uint8_t aux_ptr:1;
-	uint8_t adi:1;
-	uint8_t cte_info:1;
-	uint8_t tgt_addr:1;
-	uint8_t adv_addr:1;
 #else
-#error "Unsupported endianness"
-#endif
+	uint8_t rfu:1;
+	uint8_t tx_pwr:1;
+	uint8_t sync_info:1;
+	uint8_t aux_ptr:1;
+	uint8_t adi:1;
+	uint8_t cte_info:1;
+	uint8_t tgt_addr:1;
+	uint8_t adv_addr:1;
+#endif /* CONFIG_LITTLE_ENDIAN */
 	uint8_t data[0];
 } __packed;
 
 struct pdu_adv_com_ext_adv {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t ext_hdr_len:6;
 	uint8_t adv_mode:2;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint8_t adv_mode:2;
-	uint8_t ext_hdr_len:6;
 #else
-#error "Unsupported endianness"
-#endif
+	uint8_t adv_mode:2;
+	uint8_t ext_hdr_len:6;
+#endif /* CONFIG_LITTLE_ENDIAN */
 	union {
 		struct pdu_adv_ext_hdr ext_hdr;
 		uint8_t ext_hdr_adv_data[0];
@@ -360,29 +354,25 @@ enum pdu_adv_mode {
 #define PDU_ADV_SID_COUNT 16
 
 struct pdu_adv_adi {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint16_t did:12;
 	uint16_t sid:4;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint16_t sid:4;
-	uint16_t did:12;
 #else
-#error "Unsupported endianness"
-#endif
+	uint16_t sid:4;
+	uint16_t did:12;
+#endif /* CONFIG_LITTLE_ENDIAN */
 } __packed;
 
 struct pdu_adv_aux_ptr {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t  chan_idx:6;
 	uint8_t  ca:1;
 	uint8_t  offs_units:1;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint8_t  offs_units:1;
-	uint8_t  ca:1;
-	uint8_t  chan_idx:6;
 #else
-#error "Unsupported endianness"
-#endif
+	uint8_t  offs_units:1;
+	uint8_t  ca:1;
+	uint8_t  chan_idx:6;
+#endif /* CONFIG_LITTLE_ENDIAN */
 	/* offs:13
 	 * phy:3
 	 * NOTE: This layout as bitfields is not portable for BE using
@@ -408,33 +398,29 @@ enum pdu_adv_aux_phy {
 };
 
 struct pdu_cte_info {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t  time:5;
 	uint8_t  rfu:1;
 	uint8_t  type:2;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint8_t  type:2;
-	uint8_t  rfu:1;
-	uint8_t  time:5;
 #else
-#error "Unsupported endianness"
-#endif
+	uint8_t  type:2;
+	uint8_t  rfu:1;
+	uint8_t  time:5;
+#endif /* CONFIG_LITTLE_ENDIAN */
 } __packed;
 
 struct pdu_adv_sync_info {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint16_t offs:13;
 	uint16_t offs_units:1;
 	uint16_t offs_adjust:1;
 	uint16_t rfu:1;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint16_t rfu:1;
-	uint16_t offs_adjust:1;
-	uint16_t offs_units:1;
-	uint16_t offs:13;
 #else
-#error "Unsupported endianness"
-#endif
+	uint16_t rfu:1;
+	uint16_t offs_adjust:1;
+	uint16_t offs_units:1;
+	uint16_t offs:13;
+#endif /* CONFIG_LITTLE_ENDIAN */
 	uint16_t interval;
 	uint8_t  sca_chm[PDU_CHANNEL_MAP_SIZE];
 	uint32_t aa;
@@ -472,21 +458,19 @@ enum pdu_adv_type {
 } __packed;
 
 struct pdu_adv {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t type:4;
 	uint8_t rfu:1;
 	uint8_t chan_sel:1;
 	uint8_t tx_addr:1;
 	uint8_t rx_addr:1;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint8_t rx_addr:1;
-	uint8_t tx_addr:1;
-	uint8_t chan_sel:1;
-	uint8_t rfu:1;
-	uint8_t type:4;
 #else
-#error "Unsupported endianness"
-#endif
+	uint8_t rx_addr:1;
+	uint8_t tx_addr:1;
+	uint8_t chan_sel:1;
+	uint8_t rfu:1;
+	uint8_t type:4;
+#endif /* CONFIG_LITTLE_ENDIAN */
 
 	uint8_t len;
 
@@ -698,17 +682,15 @@ struct pdu_data_llctrl_min_used_chans_ind {
 } __packed;
 
 struct pdu_data_llctrl_cte_req {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t min_cte_len_req : 5;
 	uint8_t rfu : 1;
 	uint8_t cte_type_req : 2;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint8_t cte_type_req : 2;
-	uint8_t rfu : 1;
-	uint8_t min_cte_len_req : 5;
 #else
-#error "Unsupported endianness"
-#endif
+	uint8_t cte_type_req : 2;
+	uint8_t rfu : 1;
+	uint8_t min_cte_len_req : 5;
+#endif /* CONFIG_LITTLE_ENDIAN */
 } __packed;
 
 struct pdu_data_llctrl_cte_rsp {
@@ -739,15 +721,13 @@ struct pdu_data_llctrl_cis_req {
 	uint16_t p_max_pdu;
 	uint8_t  nse;
 	uint8_t  sub_interval[3];
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t  c_bn:4;
 	uint8_t  p_bn:4;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint8_t  p_bn:4;
-	uint8_t  c_bn:4;
 #else
-#error "Unsupported endianness"
-#endif
+	uint8_t  p_bn:4;
+	uint8_t  c_bn:4;
+#endif /* CONFIG_LITTLE_ENDIAN */
 	uint8_t  c_ft;
 	uint8_t  p_ft;
 	uint16_t iso_interval;
@@ -833,7 +813,7 @@ struct profile {
 #endif /* CONFIG_BT_CTLR_PROFILE_ISR */
 
 struct pdu_data {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t ll_id:2;
 	uint8_t nesn:1;
 	uint8_t sn:1;
@@ -844,7 +824,7 @@ struct pdu_data {
 #else
 	uint8_t rfu:3;
 #endif
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX) || defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX)
 	uint8_t rfu:2;
 	uint8_t cp:1;
@@ -855,9 +835,7 @@ struct pdu_data {
 	uint8_t sn:1;
 	uint8_t nesn:1;
 	uint8_t ll_id:2;
-#else
-#error "Unsupported endianness"
-#endif
+#endif /* CONFIG_LITTLE_ENDIAN */
 
 	uint8_t len;
 
@@ -888,15 +866,13 @@ struct pdu_data {
  * To be used when referring to component without knowing CIS or BIS type
  */
 struct pdu_iso {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t ll_id:2;
 	uint8_t hdr_other:6;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint8_t hdr_other:6;
-	uint8_t ll_id:2;
 #else
-#error "Unsupported endianness"
-#endif /* __BYTE_ORDER__ */
+	uint8_t hdr_other:6;
+	uint8_t ll_id:2;
+#endif /* CONFIG_LITTLE_ENDIAN */
 	uint8_t length;
 	uint8_t payload[0];
 } __packed;
@@ -906,7 +882,7 @@ struct pdu_iso {
 #define PDU_ISO_SEG_TIMEOFFSET_SIZE 3
 
 struct pdu_iso_sdu_sh {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t sc:1;
 	uint8_t cmplt:1;
 	uint8_t rfu:6;
@@ -916,18 +892,16 @@ struct pdu_iso_sdu_sh {
 	uint32_t timeoffset:24;
 	uint32_t payload:8;
 
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint8_t rfu:6;
-	uint8_t cmplt:1;
-	uint8_t sc:1;
-
-	uint8_t length;
-	/* Note, timeoffset only available in first segment of sdu */
-	uint32_t payload:8;
-	uint32_t timeoffset:24;
 #else
-#error "Unsupported endianness"
-#endif /* __BYTE_ORDER__ */
+	uint8_t rfu:6;
+	uint8_t cmplt:1;
+	uint8_t sc:1;
+
+	uint8_t length;
+	/* Note, timeoffset only available in first segment of sdu */
+	uint32_t payload:8;
+	uint32_t timeoffset:24;
+#endif /* CONFIG_LITTLE_ENDIAN */
 } __packed;
 
 enum pdu_cis_llid {
@@ -940,7 +914,7 @@ enum pdu_cis_llid {
 };
 
 struct pdu_cis {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t ll_id:2;
 	uint8_t nesn:1;
 	uint8_t sn:1;
@@ -948,17 +922,15 @@ struct pdu_cis {
 	uint8_t rfu0:1;
 	uint8_t npi:1;
 	uint8_t rfu1:1;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint8_t rfu1:1;
-	uint8_t npi:1;
-	uint8_t rfu0:1;
-	uint8_t cie:1;
-	uint8_t sn:1;
-	uint8_t nesn:1;
-	uint8_t ll_id:2;
 #else
-#error "Unsupported endianness"
-#endif /* __BYTE_ORDER__ */
+	uint8_t rfu1:1;
+	uint8_t npi:1;
+	uint8_t rfu0:1;
+	uint8_t cie:1;
+	uint8_t sn:1;
+	uint8_t nesn:1;
+	uint8_t ll_id:2;
+#endif /* CONFIG_LITTLE_ENDIAN */
 	uint8_t length;
 	uint8_t payload[0];
 } __packed;
@@ -1000,19 +972,17 @@ enum pdu_bis_llid {
 };
 
 struct pdu_bis {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t ll_id:2;
 	uint8_t cssn:3;
 	uint8_t cstf:1;
 	uint8_t rfu:2;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint8_t rfu:2;
-	uint8_t cstf:1;
-	uint8_t cssn:3;
-	uint8_t ll_id:2;
 #else
-#error "Unsupported endianness"
-#endif /* __BYTE_ORDER__ */
+	uint8_t rfu:2;
+	uint8_t cstf:1;
+	uint8_t cssn:3;
+	uint8_t ll_id:2;
+#endif /* CONFIG_LITTLE_ENDIAN */
 	uint8_t len;
 	union {
 		uint8_t payload[0];
@@ -1021,7 +991,7 @@ struct pdu_bis {
 } __packed;
 
 struct pdu_big_info {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint32_t offs:14;
 	uint32_t offs_units:1;
 	uint32_t iso_interval:12;
@@ -1042,30 +1012,28 @@ struct pdu_big_info {
 
 	uint32_t sdu_interval:20;
 	uint32_t max_sdu:12;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint32_t num_bis:5;
-	uint32_t iso_interval:12;
-	uint32_t offs_units:1;
-	uint32_t offs:14;
-
-	uint32_t pto:4;
-	uint32_t sub_interval:20;
-	uint32_t bn:3;
-	uint32_t nse:5;
-
-	uint32_t max_pdu:8;
-	uint32_t irc:4;
-	uint32_t spacing:20;
-
-	uint8_t  rfu;
-
-	uint32_t seed_access_addr;
-
-	uint32_t max_sdu:12;
-	uint32_t sdu_interval:20;
 #else
-#error "Unsupported endianness"
-#endif /* __BYTE_ORDER__ */
+	uint32_t num_bis:5;
+	uint32_t iso_interval:12;
+	uint32_t offs_units:1;
+	uint32_t offs:14;
+
+	uint32_t pto:4;
+	uint32_t sub_interval:20;
+	uint32_t bn:3;
+	uint32_t nse:5;
+
+	uint32_t max_pdu:8;
+	uint32_t irc:4;
+	uint32_t spacing:20;
+
+	uint8_t  rfu;
+
+	uint32_t seed_access_addr;
+
+	uint32_t max_sdu:12;
+	uint32_t sdu_interval:20;
+#endif /* CONFIG_LITTLE_ENDIAN */
 
 	uint16_t base_crc_init;
 
@@ -1081,7 +1049,7 @@ struct pdu_big_info {
 #define PDU_BIG_PAYLOAD_COUNT_MAX   28
 
 struct pdu_dtm {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t type:4;
 	uint8_t rfu0:1;
 #if defined(CONFIG_BT_CTLR_DF_CTE_TX)
@@ -1090,7 +1058,7 @@ struct pdu_dtm {
 #else
 	uint8_t rfu1:3;
 #endif
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 #if defined(CONFIG_BT_CTLR_DF_CTE_TX)
 	uint8_t rfu1:2;
 	uint8_t cp:1;
@@ -1099,9 +1067,7 @@ struct pdu_dtm {
 #endif
 	uint8_t rfu0:1;
 	uint8_t type:4;
-#else
-#error "Unsupported endianness"
-#endif
+#endif /* CONFIG_LITTLE_ENDIAN */
 	uint8_t length;
 #if defined(CONFIG_BT_CTLR_DF_CTE_TX)
 	union {

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -62,11 +62,10 @@ extern "C" {
 #define MGMT_EVT_OP_CMD_DONE	0x03
 
 struct mgmt_hdr {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t  nh_op:3;		/* MGMT_OP_[...] */
 	uint8_t  _res1:5;
-#endif
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 	uint8_t  _res1:5;
 	uint8_t  nh_op:3;		/* MGMT_OP_[...] */
 #endif

--- a/subsys/mgmt/mcumgr/lib/protocol.md
+++ b/subsys/mgmt/mcumgr/lib/protocol.md
@@ -34,11 +34,10 @@ Frames in SMP have the following header format:
 
 ```
 struct mgmt_hdr {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
     uint8_t  nh_op:3;           /* MGMT_OP_[...] */
     uint8_t  _res1:5;
-#endif
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
     uint8_t  _res1:5;
     uint8_t  nh_op:3;           /* MGMT_OP_[...] */
 #endif

--- a/subsys/net/ip/icmpv6.h
+++ b/subsys/net/ip/icmpv6.h
@@ -73,11 +73,11 @@ struct net_icmpv6_nd_opt_6co {
 struct net_icmpv6_nd_opt_route_info {
 	uint8_t prefix_len;
 	struct {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 		uint8_t reserved_2 :3;
 		uint8_t prf        :2;
 		uint8_t reserved_1 :3;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 		uint8_t reserved_1 :3;
 		uint8_t prf        :2;
 		uint8_t reserved_2 :3;

--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -150,11 +150,10 @@ struct tcphdr {
 	uint16_t th_dport;
 	uint32_t th_seq;
 	uint32_t th_ack;
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t th_x2:4;	/* unused */
 	uint8_t th_off:4;	/* data offset, in units of 32-bit words */
-#endif
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 	uint8_t th_off:4;
 	uint8_t th_x2:4;
 #endif

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -488,12 +488,10 @@ int z_vrfy_net_addr_pton(sa_family_t family, const char *src,
 #endif /* CONFIG_USERSPACE */
 
 
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 #define CHECKSUM_BIG_ENDIAN 0
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#define CHECKSUM_BIG_ENDIAN 1
 #else
-#error "Unknown byte order"
+#define CHECKSUM_BIG_ENDIAN 1
 #endif
 
 static uint16_t offset_based_swap8(const uint8_t *data)

--- a/subsys/net/l2/ieee802154/ieee802154_frame.h
+++ b/subsys/net/l2/ieee802154/ieee802154_frame.h
@@ -86,7 +86,7 @@ enum ieee802154_version {
  */
 struct ieee802154_fcf_seq {
 	struct {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 		uint16_t frame_type : 3;
 		uint16_t security_enabled : 1;
 		uint16_t frame_pending : 1;
@@ -98,7 +98,7 @@ struct ieee802154_fcf_seq {
 		uint16_t dst_addr_mode : 2;
 		uint16_t frame_version : 2;
 		uint16_t src_addr_mode : 2;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 		uint16_t reserved : 1;
 		uint16_t pan_id_comp : 1;
 		uint16_t ar : 1;
@@ -173,11 +173,11 @@ enum ieee802154_key_id_mode {
 
 /* See section 7.6.2.2 */
 struct ieee802154_security_control_field {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t security_level : 3;
 	uint8_t key_id_mode : 2;
 	uint8_t reserved : 3;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 	uint8_t reserved : 3;
 	uint8_t key_id_mode : 2;
 	uint8_t security_level : 3;
@@ -233,10 +233,10 @@ struct ieee802154_mfr {
 };
 
 struct ieee802154_gts_dir {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t mask : 7;
 	uint8_t reserved : 1;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 	uint8_t reserved : 1;
 	uint8_t mask : 7;
 #endif
@@ -244,23 +244,23 @@ struct ieee802154_gts_dir {
 
 struct ieee802154_gts {
 	uint16_t short_address;
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	uint8_t starting_slot : 4;
 	uint8_t length : 4;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 	uint8_t length : 4;
 	uint8_t starting_slot : 4;
 #endif
 } __packed;
 
 struct ieee802154_gts_spec {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	/* Descriptor Count */
 	uint8_t desc_count : 3;
 	uint8_t reserved : 4;
 	/* GTS Permit */
 	uint8_t permit : 1;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 	/* GTS Permit */
 	uint8_t permit : 1;
 	uint8_t reserved : 4;
@@ -270,14 +270,14 @@ struct ieee802154_gts_spec {
 } __packed;
 
 struct ieee802154_pas_spec {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	/* Number of Short Addresses Pending */
 	uint8_t nb_sap : 3;
 	uint8_t reserved_1 : 1;
 	/* Number of Extended Addresses Pending */
 	uint8_t nb_eap : 3;
 	uint8_t reserved_2 : 1;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 	uint8_t reserved_1 : 1;
 	/* Number of Extended Addresses Pending */
 	uint8_t nb_eap : 3;
@@ -288,7 +288,7 @@ struct ieee802154_pas_spec {
 } __packed;
 
 struct ieee802154_beacon_sf {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 	/* Beacon Order*/
 	uint16_t bc_order : 4;
 	/* Superframe Order*/
@@ -302,7 +302,7 @@ struct ieee802154_beacon_sf {
 	uint16_t coordinator : 1;
 	/* Association Permit */
 	uint16_t association : 1;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 	/* Superframe Order*/
 	uint16_t sf_order : 4;
 	/* Beacon Order*/
@@ -329,7 +329,7 @@ struct ieee802154_beacon {
 /* See section 7.3.1 */
 struct ieee802154_cmd_assoc_req {
 	struct {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 		uint8_t reserved_1 : 1;
 		uint8_t dev_type : 1;
 		uint8_t power_src : 1;
@@ -337,7 +337,7 @@ struct ieee802154_cmd_assoc_req {
 		uint8_t reserved_2 : 2;
 		uint8_t sec_capability : 1;
 		uint8_t alloc_addr : 1;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 		uint8_t alloc_addr : 1;
 		uint8_t sec_capability : 1;
 		uint8_t reserved_2 : 2;
@@ -396,12 +396,12 @@ struct ieee802154_cmd_coord_realign {
 /* GTS request, see section 7.3.9 */
 struct ieee802154_gts_request {
 	struct {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef CONFIG_LITTLE_ENDIAN
 		uint8_t length : 4;
 		uint8_t direction : 1;
 		uint8_t type : 1;
 		uint8_t reserved : 2;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#else
 		uint8_t reserved : 2;
 		uint8_t type : 1;
 		uint8_t direction : 1;


### PR DESCRIPTION
See commit messages.

**Please Ignore the compliance check failure, it's just checkpatch doing its job with the new check**

Note that this PR includes the following fix: https://github.com/littlefs-project/littlefs/pull/742