### PR TITLE
net: sockets: Prevent compiler error if warnings being treated as errors

### DIFF
--- a/include/zephyr/sys/fdtable.h
+++ b/include/zephyr/sys/fdtable.h
@@ -10,6 +10,7 @@
 #include <sys/types.h>
 /* FIXME: For native_posix ssize_t, off_t. */
 #include <zephyr/fs/fs.h>
+#include <zephyr/sys/mutex.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -8,6 +8,8 @@
 #define _SOCKETS_INTERNAL_H_
 
 #include <zephyr/sys/fdtable.h>
+#include <zephyr/net/net_context.h>
+#include <zephyr/net/socket.h>
 
 #define SOCK_EOF 1
 #define SOCK_NONBLOCK 2


### PR DESCRIPTION
If gcc compiler option **-Werror** is used the warning,

_declared inside parameter list will not be visible 
outside of this definition or declaration_

is treated as error, for

sockets_internal.h:18:28: ‘struct net_context’
sockets_internal.h:19:32: ‘struct zsock_pollfd’
fdtable.h:108:17: ‘struct k_mutex’

Signed-off-by: Christoph Schnetzler <christoph.schnetzler@husqvarnagroup.com>