### PR TITLE
Building  without -ffreestanding

### DIFF
--- a/samples/bluetooth/eddystone/src/main.c
+++ b/samples/bluetooth/eddystone/src/main.c
@@ -490,7 +490,7 @@ static ssize_t write_adv_data(struct bt_conn *conn,
 		 */
 		slot->ad[2].data_len = MIN(slot->ad[2].data_len,
 					   len + EDS_URL_WRITE_OFFSET);
-		memcpy(&slot->ad[2].data + EDS_URL_WRITE_OFFSET, buf,
+		memcpy((uint8_t *) slot->ad[2].data + EDS_URL_WRITE_OFFSET, buf,
 		       slot->ad[2].data_len - EDS_URL_WRITE_OFFSET);
 
 		/* Restart slot */

--- a/tests/bluetooth/at/src/main.c
+++ b/tests/bluetooth/at/src/main.c
@@ -61,8 +61,7 @@ ZTEST(at_tests, test_at)
 
 	zassert_true(net_buf_tailroom(buf) >= len,
 		    "Allocated buffer is too small");
-	strncpy((char *)buf->data, example_data, len);
-	net_buf_add(buf, len);
+	net_buf_add_mem(buf, example_data, len);
 
 	zassert_equal(at_parse_input(&at, buf), 0, "Parsing failed");
 }


### PR DESCRIPTION
Two bugs in standard C library function usage:

 1. samples/bluetooth was smashing memory past the end of a struct.
 2. tests/bluetooth was using strncpy where memcpy should have been used.