### PR TITLE
Fixes for building with picolibc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,11 @@ if(NOT CONFIG_PICOLIBC)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:compiler,freestanding>>)
 endif()
 
+if (CONFIG_PICOLIBC AND NOT CONFIG_PICOLIBC_IO_FLOAT)
+  # @Intent: Set compiler specific flag to disable printf-related optimizations
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,no_printf_return_value>>)
+endif()
+
 # @Intent: Set compiler specific flag for tentative definitions, no-common
 zephyr_compile_options($<TARGET_PROPERTY:compiler,no_common>)
 

--- a/boards/x86/qemu_x86/Kconfig.defconfig
+++ b/boards/x86/qemu_x86/Kconfig.defconfig
@@ -109,6 +109,6 @@ config X86_EXTRA_PAGE_TABLE_PAGES
 
 config DEMAND_PAGING_PAGE_FRAMES_RESERVE
 	# Need to accommodate the heap for newlib in libc-hook.c
-	default 6 if NEWLIB_LIBC
+	default 6 if NEWLIB_LIBC || PICOLIBC
 
 endif # BOARD_QEMU_X86_TINY

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -74,6 +74,8 @@ set_property(TARGET compiler-cpp PROPERTY no_exceptions)
 # Flag for disabling rtti in C++
 set_property(TARGET compiler-cpp PROPERTY no_rtti)
 
+# Flag for disabling optimizations around printf return value
+set_compiler_property(PROPERTY no_printf_return_value)
 
 ###################################################
 # This section covers all remaining C / C++ flags #

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -111,6 +111,8 @@ if (NOT CONFIG_NEWLIB_LIBC AND
   set_compiler_property(APPEND PROPERTY nostdinc_include ${NOSTDINC})
 endif()
 
+set_compiler_property(PROPERTY no_printf_return_value -fno-printf-return-value)
+
 set_compiler_property(TARGET compiler-cpp PROPERTY nostdincxx "-nostdinc++")
 
 # Required C++ flags when using gcc

--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -792,9 +792,9 @@ int cbpprintf(cbprintf_cb out, void *ctx, void *packaged)
 #ifdef CONFIG_PICOLIBC
 
 #define fprintfcb(stream, ...) fprintf(stream, __VA_ARGS__)
-#define vfprintfcb(stream, format, ap) (stream, format, ap)
+#define vfprintfcb(stream, format, ap) vfprintf(stream, format, ap)
 #define printfcb(format, ...) printf(format, __VA_ARGS__)
-#define vprintfcb(format, ap) vfprintf(format, ap)
+#define vprintfcb(format, ap) vprintf(format, ap)
 #define snprintfcb(str, size, ...) snprintf(str, size, __VA_ARGS__)
 #define vsnprintfcb(str, size, format, ap) vsnprintf(str, size, format, ap)
 

--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -3,6 +3,10 @@
 zephyr_library()
 zephyr_library_sources(libc-hooks.c)
 
+# define __LINUX_ERRNO_EXTENSIONS__ so we get errno defines like -ESHUTDOWN
+# used by the network stack
+zephyr_compile_definitions(__LINUX_ERRNO_EXTENSIONS__)
+
 if(NOT CONFIG_PICOLIBC_USE_MODULE)
 
   # Use picolibc provided with the toolchain


### PR DESCRIPTION
I found a couple of minor issues in Zephyr's picolibc support:

 1. scrambled printfcb wrapper macros
 2. Need to use -fno-printf-return-value when using smaller printf variants to avoid gcc optimizations around sprintf return values.
 3. Zephyr wants errno values covered under the `__LINUX_ERRNO_EXTENSIONS__` definition.
 4. qemu_x86_tiny needs to handle picolibc like newlib and let it use any available heap for malloc.