### PR TITLE
tests: power_mgmt_multicore: Convert away from CONFIG_MP_NUM_CPUS

### DIFF
--- a/tests/subsys/pm/power_mgmt_multicore/src/main.c
+++ b/tests/subsys/pm/power_mgmt_multicore/src/main.c
@@ -8,7 +8,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/pm/pm.h>
 
-BUILD_ASSERT(CONFIG_MP_NUM_CPUS == 2, "Invalid number of cpus");
+BUILD_ASSERT(CONFIG_MP_MAX_NUM_CPUS == 2, "Invalid number of cpus");
 
 #define NUM_OF_ITERATIONS (5)
 


### PR DESCRIPTION
Move BUILD_ASSERT to use CONFIG_MP_MAX_NUM_CPUS as we phase out usage of CONFIG_MP_NUM_CPUS.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>