### PR TITLE
tests: intel_adsp: smoke: Convert CONFIG_MP_NUM_CPUS handling

### DIFF
--- a/tests/boards/intel_adsp/smoke/src/cpus.c
+++ b/tests/boards/intel_adsp/smoke/src/cpus.c
@@ -41,7 +41,7 @@ static uint32_t clk_ratios[CONFIG_MP_MAX_NUM_CPUS];
 
 static void run_on_cpu(int cpu, void (*fn)(void *), void *arg, bool wait)
 {
-	__ASSERT_NO_MSG(cpu < CONFIG_MP_NUM_CPUS);
+	__ASSERT_NO_MSG(cpu < arch_num_cpus());
 
 	/* Highest priority isn't actually guaranteed to preempt
 	 * whatever's running, but we assume the test hasn't laid
@@ -156,7 +156,7 @@ static void halt_and_restart(int cpu)
 {
 	printk("halt/restart core %d...\n", cpu);
 	static bool alive_flag;
-	uint32_t all_cpus = BIT(CONFIG_MP_NUM_CPUS) - 1;
+	uint32_t all_cpus = BIT(arch_num_cpus()) - 1;
 	int ret;
 
 	/* On older hardware we need to get the host to turn the core

--- a/tests/boards/intel_adsp/smoke/src/smpboot.c
+++ b/tests/boards/intel_adsp/smoke/src/smpboot.c
@@ -43,7 +43,7 @@ ZTEST(intel_adsp_boot, test_1st_smp_boot_delay)
 {
 	unsigned int num_cpus = arch_num_cpus();
 
-	if (CONFIG_MP_NUM_CPUS < 2) {
+	if (arch_num_cpus() < 2) {
 		ztest_test_skip();
 	}
 
@@ -74,7 +74,7 @@ ZTEST(intel_adsp_boot, test_1st_smp_boot_delay)
 
 ZTEST(intel_adsp_boot, test_3rd_post_boot_ipi)
 {
-	if (CONFIG_MP_NUM_CPUS < 2) {
+	if (arch_num_cpus() < 2) {
 		ztest_test_skip();
 	}
 


### PR DESCRIPTION
Move runtime checks to use arch_num_cpus().  This is to allow runtime determination of the number of CPUs in the future.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>