### PR TITLE
boards: nxp: Enable RTC on RT595 EVK

### DIFF
--- a/boards/arm/mimxrt595_evk/doc/index.rst
+++ b/boards/arm/mimxrt595_evk/doc/index.rst
@@ -98,6 +98,8 @@ already supported, which can also be re-used on this mimxrt595_evk board:
 +-----------+------------+-------------------------------------+
 | FLEXSPI   | on-chip    | flash programming                   |
 +-----------+------------+-------------------------------------+
+| RTC       | on-chip    | counter                             |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 

--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -103,6 +103,10 @@
 	status = "okay";
 };
 
+&rtc {
+	status = "okay";
+};
+
 &flexcomm0 {
 	compatible = "nxp,lpc-usart";
 	status = "okay";


### PR DESCRIPTION
Enable RTC on RT595 EVK
