### PR TITLE
tests: timer: timer_behavior:  add a tick align

### DIFF
--- a/tests/kernel/timer/timer_behavior/src/main.c
+++ b/tests/kernel/timer/timer_behavior/src/main.c
@@ -64,6 +64,9 @@ ZTEST(timer_behavior, test_periodic_behavior)
 
 	k_timer_init(&periodic_timer, periodic_fn, NULL);
 
+	/* Tick align */
+	k_usleep(1);
+
 #ifdef CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
 	periodic_start = k_cycle_get_64();
 #else


### PR DESCRIPTION
Add a tick align to reduce errors of calculating the spending cycles.

Signed-off-by: Enjia Mai <enjia.mai@intel.com>

Fixes #51322