### PR TITLE
dts: bindings: clean up redundant required false attributes

### DIFF
--- a/doc/build/dts/bindings.rst
+++ b/doc/build/dts/bindings.rst
@@ -336,14 +336,12 @@ Here are some more examples.
        # Describes an optional property like 'keys = "foo", "bar";'
        keys:
            type: string-array
-           required: false
            description: Keys for bar-device
 
        # Describes an optional property like 'maximum-speed = "full-speed";'
        # the enum specifies known values that the string property may take
        maximum-speed:
            type: string
-           required: false
            description: Configures USB controllers to work up to a specific speed.
            enum:
               - "low-speed"
@@ -355,7 +353,6 @@ Here are some more examples.
        # the enum specifies known values that the int property may take
        resolution:
          type: int
-         required: false
          enum:
           - 8
           - 16
@@ -371,28 +368,23 @@ Here are some more examples.
 
        int-with-default:
            type: int
-           required: false
            default: 123
            description: Value for int register, default is power-up configuration.
 
        array-with-default:
            type: array
-           required: false
            default: [1, 2, 3] # Same as 'array-with-default = <1 2 3>'
 
        string-with-default:
            type: string
-           required: false
            default: "foo"
 
        string-array-with-default:
            type: string-array
-           required: false
            default: ["foo", "bar"] # Same as 'string-array-with-default = "foo", "bar"'
 
        uint8-array-with-default:
            type: uint8-array
-           required: false
            default: [0x12, 0x34] # Same as 'uint8-array-with-default = [12 34]'
 
 Property entry syntax
@@ -422,6 +414,10 @@ Required properties
 
 If a node matches a binding but is missing any property which the binding
 defines with ``required: true``, the build fails.
+
+Note: A property is implicitly optional unless ``required: true`` is
+specified. Using ``required: false`` is therefore redundant and strongly
+discouraged.
 
 Property types
 ++++++++++++++
@@ -514,8 +510,7 @@ If property ``foo`` is missing in a matching node, then the output will be as
 if ``foo = <3>;`` had appeared in the DTS (except YAML data types are used for
 the default value).
 
-Note that it only makes sense to combine ``default:`` with ``required: false``.
-Combining it with ``required: true`` will raise an error.
+Note that combining ``default:`` with ``required: true`` will raise an error.
 
 For rules related to ``default`` in upstream Zephyr bindings, see
 :ref:`dt-bindings-default-rules`.
@@ -705,7 +700,6 @@ nodes, even though they have the same compatible:
    properties:
      uses-clock-stretching:
        type: boolean
-       required: false
    on-bus: i2c
 
 Only ``sensor@79`` can have a ``use-clock-stretching`` property. The

--- a/dts/bindings/adc/adc-controller.yaml
+++ b/dts/bindings/adc/adc-controller.yaml
@@ -12,11 +12,9 @@ properties:
       required: true
 
     "#address-cells":
-      required: false
       const: 1
 
     "#size-cells":
-      required: false
       const: 0
 
 child-binding:
@@ -105,7 +103,6 @@ child-binding:
 
       zephyr,vref-mv:
         type: int
-        required: false
         description: |
           This property can be used to specify the voltage (in millivolts)
           of the reference selected for this channel, so that applications
@@ -126,14 +123,12 @@ child-binding:
 
       zephyr,input-positive:
         type: int
-        required: false
         description: |
           Positive ADC input. Used only for drivers that select
           the ADC_CONFIGURABLE_INPUTS Kconfig option.
 
       zephyr,input-negative:
         type: int
-        required: false
         description: |
           Negative ADC input. Used only for drivers that select
           the ADC_CONFIGURABLE_INPUTS Kconfig option.
@@ -142,13 +137,11 @@ child-binding:
 
       zephyr,resolution:
         type: int
-        required: false
         description: |
           ADC resolution to be used for the channel.
 
       zephyr,oversampling:
         type: int
-        required: false
         description: |
           Oversampling setting to be used for the channel.
           When specified, each sample is averaged from 2^N conversion results

--- a/dts/bindings/adc/arduino,uno-adc.yaml
+++ b/dts/bindings/adc/arduino,uno-adc.yaml
@@ -22,11 +22,9 @@ properties:
 
     io-channel-map-mask:
       type: compound
-      required: false
 
     io-channel-map-pass-thru:
       type: compound
-      required: false
 
     "#io-channel-cells":
       type: int

--- a/dts/bindings/adc/atmel,sam0-adc.yaml
+++ b/dts/bindings/adc/atmel,sam0-adc.yaml
@@ -37,7 +37,6 @@ properties:
 
     calib-offset:
       type: int
-      required: false
       description: |
         bit position offset in NVM SW Calib for start of ADC0 BIASCOMP field.
         This property is expected to be set on SAM{D,E}5x family of SoCs.

--- a/dts/bindings/adc/gd,gd32-adc.yaml
+++ b/dts/bindings/adc/gd,gd32-adc.yaml
@@ -30,7 +30,6 @@ properties:
 
     rcu-clock-source:
       type: int
-      required: false
       description: |
         Some GD32 ADC have additional clock source, like IRC14M or IRC28M.
         This property used to select the clock and related prescaler, valid

--- a/dts/bindings/adc/nxp,kinetis-adc12.yaml
+++ b/dts/bindings/adc/nxp,kinetis-adc12.yaml
@@ -26,7 +26,6 @@ properties:
 
     alternate-voltage-reference:
       type: boolean
-      required: false
       description: use alternate voltage reference source
 
     sample-time:

--- a/dts/bindings/adc/nxp,kinetis-adc16.yaml
+++ b/dts/bindings/adc/nxp,kinetis-adc16.yaml
@@ -13,7 +13,6 @@ properties:
 
     channel-mux-b:
       type: boolean
-      required: false
       description: |
         Use alternate set (b instead of a) of ADC channels
 
@@ -22,7 +21,6 @@ properties:
 
     periodic-trigger:
       type: boolean
-      required: false
       description: if periodic trigger enabled
 
     "#io-channel-cells":
@@ -30,12 +28,10 @@ properties:
 
     clk-source:
       type: int
-      required: false
       description: use alternate clock reference source
 
     long-sample:
       type: int
-      required: false
       enum:
         - 0
         - 1
@@ -46,17 +42,14 @@ properties:
 
     continuous-convert:
       type: boolean
-      required: false
       description: If use continuous convert
 
     high-speed:
       type: boolean
-      required: false
       description: If use high speed
 
     hw-trigger-src:
       type: int
-      required: false
       description: hardware trigger source (See ADCxTRGSEL field in user manual for more details)
 
 io-channel-cells:

--- a/dts/bindings/adc/raspberrypi,pico-adc.yaml
+++ b/dts/bindings/adc/raspberrypi,pico-adc.yaml
@@ -13,7 +13,6 @@ properties:
 
     vref-mv:
       type: int
-      required: false
       default: 3300
       description: |
         Indicate the reference voltage of the ADC in mV.

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -29,7 +29,6 @@ properties:
 
     vref-mv:
       type: int
-      required: false
       default: 3300
       description: Indicates the reference voltage of the ADC in mV (on the target board).
 

--- a/dts/bindings/adc/ti,lmp90xxx-base.yaml
+++ b/dts/bindings/adc/ti,lmp90xxx-base.yaml
@@ -7,7 +7,6 @@ bus: lmp90xxx
 properties:
     drdyb-gpios:
       type: phandle-array
-      required: false
       description: Data Ready Bar
 
     "#io-channel-cells":

--- a/dts/bindings/adc/ti,lmp90xxx-current.yaml
+++ b/dts/bindings/adc/ti,lmp90xxx-current.yaml
@@ -5,5 +5,4 @@ include: ti,lmp90xxx-base.yaml
 properties:
     rtd-current:
       type: int
-      required: false
       description: RTD current in microampere

--- a/dts/bindings/adc/voltage-divider.yaml
+++ b/dts/bindings/adc/voltage-divider.yaml
@@ -23,7 +23,6 @@ properties:
 
     full-ohms:
       type: int
-      required: false
       description: |
         Resistance of the full path through the voltage divider.
 
@@ -32,7 +31,6 @@ properties:
 
     power-gpios:
       type: phandle-array
-      required: false
       description: |
         Control power to the voltage divider inputs.
 

--- a/dts/bindings/adc/zephyr,adc-emul.yaml
+++ b/dts/bindings/adc/zephyr,adc-emul.yaml
@@ -15,7 +15,6 @@ properties:
 
     ref-internal-mv:
         type: int
-        required: false
         default: 0
         description:
           Internal reference voltage in mV. If not provided or set to zero,
@@ -23,7 +22,6 @@ properties:
 
     ref-vdd-mv:
         type: int
-        required: false
         default: 0
         description:
           VDD reference voltage in mV. If not provided or set to zero,
@@ -31,7 +29,6 @@ properties:
 
     ref-external0-mv:
         type: int
-        required: false
         default: 0
         description:
           External 0 reference voltage in mV. If not provided or set to zero,
@@ -39,7 +36,6 @@ properties:
 
     ref-external1-mv:
         type: int
-        required: false
         default: 0
         description:
           External 1 reference voltage in mV. If not provided or set to zero,

--- a/dts/bindings/audio/nordic,nrf-pdm.yaml
+++ b/dts/bindings/audio/nordic,nrf-pdm.yaml
@@ -17,7 +17,6 @@ properties:
     clk-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -37,7 +36,6 @@ properties:
     din-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -47,7 +45,6 @@ properties:
 
     clock-source:
       type: string
-      required: false
       default: "PCLK32M_HFXO"
       description: |
         Clock source to be used by the PDM peripheral. The following options
@@ -66,7 +63,6 @@ properties:
 
     queue-size:
       type: int
-      required: false
       default: 4
       description: |
         Size of the queue of received audio data blocks to be used

--- a/dts/bindings/can/can-controller.yaml
+++ b/dts/bindings/can/can-controller.yaml
@@ -13,26 +13,21 @@ properties:
       description: Resynchronization jump width (ISO 11898-1)
     prop-seg:
       type: int
-      required: false
       description: Time quantums of propagation segment (ISO 11898-1)
     phase-seg1:
       type: int
-      required: false
       description: Time quantums of phase buffer 1 segment (ISO 11898-1)
     phase-seg2:
       type: int
-      required: false
       description: Time quantums of phase buffer 2 segment (ISO 11898-1)
     sample-point:
       type: int
-      required: false
       description: >
         Sample point in permille.
         This param is required if segments are not given.
         If the sample point is given, the segments are ignored.
     phys:
       type: phandle
-      required: false
       description: |
         Actively controlled CAN transceiver.
 

--- a/dts/bindings/can/can-fd-controller.yaml
+++ b/dts/bindings/can/can-fd-controller.yaml
@@ -13,24 +13,19 @@ properties:
       description: Resynchronization jump width for the data phase. (ISO11898-1:2015)
     prop-seg-data:
       type: int
-      required: false
       description: Time quantums of propagation segment for the data phase. (ISO11898-1:2015)
     phase-seg1-data:
       type: int
-      required: false
       description: Time quantums of phase buffer 1 segment for the data phase. (ISO11898-1:2015)
     phase-seg2-data:
       type: int
-      required: false
       description: Time quantums of phase buffer 2 segment for the data phase. (ISO11898-1:2015)
     sample-point-data:
       type: int
-      required: false
       description: >
         Sample point in permille for the data phase.
         This param is required if segments are not given.
         If the sample point is given, the segments are ignored.
     tx-delay-comp-offset:
       type: int
-      required: false
       default: 0

--- a/dts/bindings/can/espressif,esp32-twai.yaml
+++ b/dts/bindings/can/espressif,esp32-twai.yaml
@@ -25,7 +25,6 @@ properties:
 
     clkout-divider:
       type: int
-      required: false
       description: |
         Clock divider for the CLKOUT signal. If not set, the CLKOUT signal is turned off.
 

--- a/dts/bindings/can/st,stm32-can.yaml
+++ b/dts/bindings/can/st,stm32-can.yaml
@@ -22,5 +22,4 @@ properties:
 
     master-can-reg:
       type: int
-      required: false
       description: master can reg when different from current instance

--- a/dts/bindings/can/st,stm32-fdcan.yaml
+++ b/dts/bindings/can/st,stm32-fdcan.yaml
@@ -16,7 +16,6 @@ properties:
 
     clk-divider:
       type: int
-      required: false
       enum:
         - 1
         - 2

--- a/dts/bindings/clock/espressif,esp32-rtc.yaml
+++ b/dts/bindings/clock/espressif,esp32-rtc.yaml
@@ -18,7 +18,6 @@ properties:
 
     xtal-div:
       type: int
-      required: false
       description: Divisor value for XTAL Clock, CPU_CLK = XTAL_FREQ / xtal-div
 
     "#clock-cells":

--- a/dts/bindings/clock/fixed-clock.yaml
+++ b/dts/bindings/clock/fixed-clock.yaml
@@ -15,7 +15,6 @@ properties:
 
     clocks:
       type: array
-      required: false
       description: input clock source
 
     "#clock-cells":

--- a/dts/bindings/clock/intel,adsp-shim-clkctl.yaml
+++ b/dts/bindings/clock/intel,adsp-shim-clkctl.yaml
@@ -8,17 +8,14 @@ compatible: "intel,adsp-shim-clkctl"
 properties:
     adsp-clkctl-clk-wovcro:
         type: int
-        required: false
         description: Index of WOVCRO clock encoding in the encoding array (if wovcro-supported is true).
 
     adsp-clkctl-clk-lpro:
         type: int
-        required: false
         description: Index of LPRO clock encoding in the encoding array.
 
     adsp-clkctl-clk-hpro:
         type: int
-        required: false
         description: Index of HPRO clock encoding in the encoding array.
 
     adsp-clkctl-freq-enc:
@@ -28,7 +25,6 @@ properties:
 
     adsp-clkctl-freq-mask:
         type: array
-        required: false
         description: Array that encodes needed masks to enable each clock.
 
     adsp-clkctl-freq-default:

--- a/dts/bindings/clock/microchip,xec-pcr.yaml
+++ b/dts/bindings/clock/microchip,xec-pcr.yaml
@@ -21,7 +21,6 @@ properties:
 
     slow-clock-div:
       type: int
-      required: false
       description: |
         PWM and TACH clock domain divided down from 48 MHz AHB clock. The
         default value is 480 for 100 kHz.
@@ -38,7 +37,6 @@ properties:
 
     xtal-single-ended:
       type: boolean
-      required: false
       description: Use single ended crystal connection to XTAL2 pin.
 
     "#clock-cells":

--- a/dts/bindings/clock/nordic,nrf-clock.yaml
+++ b/dts/bindings/clock/nordic,nrf-clock.yaml
@@ -16,7 +16,6 @@ properties:
 
     hfclkaudio-frequency:
       type: int
-      required: false
       description: |
         Frequency of the HFCLKAUDIO clock in Hz. Adjustable with 3.3 ppm
         resolution in two frequency bands - 11.176 MHz to 11.402 MHz, and

--- a/dts/bindings/clock/nuvoton,npcx-pcc.yaml
+++ b/dts/bindings/clock/nuvoton,npcx-pcc.yaml
@@ -177,7 +177,6 @@ properties:
 
     apb4-prescaler:
         type: int
-        required: false
         description: |
           APB4 prescaler. It sets the APB4 bus frequency, APB4_CLK, by dividing
           OFMCLK(MCLK) and needs to meet the following requirements.
@@ -207,7 +206,6 @@ properties:
           - 10
 
     ram-pd-depth:
-        required: false
         type: int
         enum:
           - 12

--- a/dts/bindings/clock/nxp,kinetis-ke1xf-sim.yaml
+++ b/dts/bindings/clock/nxp,kinetis-ke1xf-sim.yaml
@@ -13,10 +13,8 @@ properties:
 
     clkout-source:
       type: int
-      required: false
       description: clkout clock source
 
     clkout-divider:
       type: int
-      required: false
       description: clkout divider

--- a/dts/bindings/clock/nxp,kinetis-scg.yaml
+++ b/dts/bindings/clock/nxp,kinetis-scg.yaml
@@ -14,7 +14,6 @@ properties:
     sosc-mode:
       type: int
       description: system oscillator mode
-      required: false
 
     "#clock-cells":
       const: 1

--- a/dts/bindings/clock/nxp,kinetis-sim.yaml
+++ b/dts/bindings/clock/nxp,kinetis-sim.yaml
@@ -23,17 +23,14 @@ properties:
 
     clkout-source:
       type: int
-      required: false
       description: clkout clock source
 
     clkout-divider:
       type: int
-      required: false
       description: clkout divider
 
     "#clock-cells":
       type: int
-      required: false
       const: 3
 
 clock-cells:

--- a/dts/bindings/clock/st,stm32-hse-clock.yaml
+++ b/dts/bindings/clock/st,stm32-hse-clock.yaml
@@ -10,7 +10,6 @@ include: [fixed-clock.yaml]
 properties:
     hse-bypass:
       type: boolean
-      required: false
       description: |
         HSE crystal oscillator bypass
         Set to the property to by-pass the oscillator with an external clock.

--- a/dts/bindings/clock/st,stm32-lse-clock.yaml
+++ b/dts/bindings/clock/st,stm32-lse-clock.yaml
@@ -23,7 +23,6 @@ properties:
 
     lse-bypass:
       type: boolean
-      required: false
       description: |
         LSE crystal oscillator bypass
         Set the property to by-pass the oscillator with an external clock.

--- a/dts/bindings/clock/st,stm32-msi-clock.yaml
+++ b/dts/bindings/clock/st,stm32-msi-clock.yaml
@@ -30,7 +30,6 @@ properties:
 
     msi-pll-mode:
       type: boolean
-      required: false
       description: |
         MSI clock PLL enable
         Enables the PLL part of the MSI clock source.

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -124,7 +124,6 @@ properties:
 
     undershoot-prevention:
       type: boolean
-      required: false
       description: |
         On some parts, it could be required to set up highest core frequencies
         (>80MHz) in two steps in order to prevent undershoot.

--- a/dts/bindings/clock/st,stm32f1-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f1-pll-clock.yaml
@@ -36,12 +36,10 @@ properties:
 
     xtpre:
       type: boolean
-      required: false
       description: |
           Otpional HSE divider for PLL entry
 
     usbpre:
       type: int
-      required: false
       description: |
           Otpional HSE divider for PLL entry

--- a/dts/bindings/clock/st,stm32f2-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f2-pll-clock.yaml
@@ -55,7 +55,6 @@ properties:
 
     div-q:
       type: int
-      required: false
       description: |
           PLL division factor for PLL48CK
           Valid range: 2 - 15

--- a/dts/bindings/clock/st,stm32f4-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f4-pll-clock.yaml
@@ -57,7 +57,6 @@ properties:
 
     div-q:
       type: int
-      required: false
       description: |
           Main PLL (PLL) division factor for USB OTG FS, SDMMC and random number
           generator clocks.

--- a/dts/bindings/clock/st,stm32f7-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f7-pll-clock.yaml
@@ -53,7 +53,6 @@ properties:
 
     div-q:
       type: int
-      required: false
       description: |
           PLL division factor for PLL48CK
           Valid range: 2 - 15

--- a/dts/bindings/clock/st,stm32g0-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32g0-pll-clock.yaml
@@ -46,14 +46,12 @@ properties:
 
     div-p:
       type: int
-      required: false
       description: |
           PLL division factor for PLL P output
           Valid range: 2 - 32
 
     div-q:
       type: int
-      required: false
       description: |
           PLL division factor for PLL Q output
           Valid range: 2 - 8

--- a/dts/bindings/clock/st,stm32g4-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32g4-pll-clock.yaml
@@ -46,7 +46,6 @@ properties:
 
     div-p:
       type: int
-      required: false
       description: |
           Main PLL division factor for ADC
           Valid range: 2 - 31

--- a/dts/bindings/clock/st,stm32h7-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32h7-pll-clock.yaml
@@ -50,21 +50,18 @@ properties:
 
     div-p:
       type: int
-      required: false
       description: |
           PLL division factor for pllx_p_ck
           Valid range: 1 - 128
 
     div-q:
       type: int
-      required: false
       description: |
           PLL division factor for pllx_q_ck
           Valid range: 1 - 128
 
     div-r:
       type: int
-      required: false
       description: |
           PLL division factor for pllx_r_ck
           Valid range: 1 - 128

--- a/dts/bindings/clock/st,stm32l4-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32l4-pll-clock.yaml
@@ -50,7 +50,6 @@ properties:
 
     div-p:
       type: int
-      required: false
       description: |
           Main PLL division factor for PLLSAI3CLK
       enum:
@@ -59,7 +58,6 @@ properties:
 
     div-q:
       type: int
-      required: false
       description: |
           Main PLL division factor for PLL48M1CLK (48 MHz clock).
       enum:

--- a/dts/bindings/clock/st,stm32u5-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32u5-pll-clock.yaml
@@ -53,14 +53,12 @@ properties:
 
     div-p:
       type: int
-      required: false
       description: |
           PLLx DIVP division factor
           Valid range: 1 - 128
 
     div-q:
       type: int
-      required: false
       description: |
           PLLx DIVQ division factor
           Valid range: 1 - 128

--- a/dts/bindings/clock/st,stm32wb-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32wb-pll-clock.yaml
@@ -51,14 +51,12 @@ properties:
 
     div-p:
       type: int
-      required: false
       description: |
           Main PLL division factor for PLLPCLK
           Valid range: 2 - 32
 
     div-q:
       type: int
-      required: false
       description: |
           Main PLL division factor for PLLQCLK
           Valid range: 2 - 8

--- a/dts/bindings/clock/st,stm32wl-hse-clock.yaml
+++ b/dts/bindings/clock/st,stm32wl-hse-clock.yaml
@@ -10,14 +10,12 @@ include: [fixed-clock.yaml]
 properties:
     hse-tcxo:
       type: boolean
-      required: false
       description: |
         When set, TCXO is selected as external source clock for HSE.
         Otherwise, external cyrstal is selected as HSE source clock.
 
     hse-div2:
       type: boolean
-      required: false
       description: |
         When set HSE output clock is divided by 2.
         Otherwise, no prescaler is used.

--- a/dts/bindings/clock/st,stm32wl-rcc.yaml
+++ b/dts/bindings/clock/st,stm32wl-rcc.yaml
@@ -16,7 +16,6 @@ include:
 properties:
     cpu2-prescaler:
       type: int
-      required: false
       enum:
         - 1
         - 2

--- a/dts/bindings/coredump/zephyr,coredump.yaml
+++ b/dts/bindings/coredump/zephyr,coredump.yaml
@@ -10,7 +10,6 @@ description: Pseudo-device to help capturing desired data into core dumps
 properties:
     memory-regions:
       type: array
-      required: false
       description: Start address and size of memory regions to be collected in a core dump
 
     coredump-type:

--- a/dts/bindings/counter/espressif,esp32-timer.yaml
+++ b/dts/bindings/counter/espressif,esp32-timer.yaml
@@ -52,6 +52,5 @@ properties:
         forced to 2.
       type: int
       default: 2
-      required: false
 
 compatible: "espressif,esp32-timer"

--- a/dts/bindings/counter/nxp,imx-tmr.yaml
+++ b/dts/bindings/counter/nxp,imx-tmr.yaml
@@ -58,7 +58,6 @@ properties:
 
   secondary_source:
     type: string
-    required: false
     description: Secondary source of the timer, see qtmr_input_source_t enumerator type
       of the MCUXpresso SDK
     enum:
@@ -69,15 +68,12 @@ properties:
 
   filter_count:
     type: int
-    required: false
     description: Fault filter count (0-255).
 
   filter_period:
     type: int
-    required: false
     description: Fault filter period (0-255).
 
   freq:
     type: int
-    required: false
     description: clock frequency (only used for external clock sources)

--- a/dts/bindings/cpu/cdns,tensilica-xtensa-lx6.yaml
+++ b/dts/bindings/cpu/cdns,tensilica-xtensa-lx6.yaml
@@ -11,4 +11,3 @@ properties:
     clock-source:
       type: int
       description: cpu clock source
-      required: false

--- a/dts/bindings/cpu/cdns,tensilica-xtensa-lx7.yaml
+++ b/dts/bindings/cpu/cdns,tensilica-xtensa-lx7.yaml
@@ -11,4 +11,3 @@ properties:
     clock-source:
       type: int
       description: cpu clock source
-      required: false

--- a/dts/bindings/cpu/cpu.yaml
+++ b/dts/bindings/cpu/cpu.yaml
@@ -8,17 +8,13 @@ include: base.yaml
 properties:
     clock-frequency:
       type: int
-      required: false
       description: Clock frequency in Hz
     cpu-power-states:
        type: phandles
-       required: false
        description: List of power management states supported by this cpu
     i-cache-line-size:
       type: int
-      required: false
       description: i-cache line size
     d-cache-line-size:
       type: int
-      required: false
       description: d-cache line size

--- a/dts/bindings/cpu/espressif,riscv.yaml
+++ b/dts/bindings/cpu/espressif,riscv.yaml
@@ -11,4 +11,3 @@ properties:
     clock-source:
       type: int
       description: cpu clock source
-      required: false

--- a/dts/bindings/dac/atmel,sam-dac.yaml
+++ b/dts/bindings/dac/atmel,sam-dac.yaml
@@ -21,7 +21,6 @@ properties:
 
     prescaler:
       type: int
-      required: false
       default: 15
       description: |
         Peripheral Clock to DAC Clock Ratio. Prescaler value is calcuated as

--- a/dts/bindings/dac/atmel,sam0-dac.yaml
+++ b/dts/bindings/dac/atmel,sam0-dac.yaml
@@ -21,7 +21,6 @@ properties:
 
     reference:
       type: string
-      required: false
       description: Reference voltage source
       enum:
         - "intref"

--- a/dts/bindings/dac/gd,gd32-dac.yaml
+++ b/dts/bindings/dac/gd,gd32-dac.yaml
@@ -26,7 +26,6 @@ properties:
       type: int
       default: 0
       description: Reset value of DAC output. Defaults to 0, the SoC default.
-      required: false
 
     "#io-channel-cells":
       const: 1

--- a/dts/bindings/dac/microchip,mcp4728.yaml
+++ b/dts/bindings/dac/microchip,mcp4728.yaml
@@ -31,7 +31,6 @@ properties:
 
     gain:
       type: array
-      required: false
       default: [0, 0, 0, 0]
       description: |
         Gain selection bit.

--- a/dts/bindings/dac/nxp,kinetis-dac.yaml
+++ b/dts/bindings/dac/nxp,kinetis-dac.yaml
@@ -18,7 +18,6 @@ properties:
 
     low-power-mode:
       type: boolean
-      required: false
       description: Enable low-power mode
 
     "#io-channel-cells":

--- a/dts/bindings/dac/nxp,kinetis-dac32.yaml
+++ b/dts/bindings/dac/nxp,kinetis-dac32.yaml
@@ -18,12 +18,10 @@ properties:
 
     low-power-mode:
       type: boolean
-      required: false
       description: Enable low-power mode
 
     buffered:
       type: boolean
-      required: false
       description: Enable output buffer
 
     "#io-channel-cells":

--- a/dts/bindings/debug/arm,itm.yaml
+++ b/dts/bindings/debug/arm,itm.yaml
@@ -9,5 +9,4 @@ include: [base.yaml, pinctrl-device.yaml]
 properties:
     swo-ref-frequency:
       type: int
-      required: false
       description: Reference clock frequency for SWO if different than CPU clock.

--- a/dts/bindings/display/ftdi,ft800.yaml
+++ b/dts/bindings/display/ftdi,ft800.yaml
@@ -10,7 +10,6 @@ include: spi-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: false
       description: Optional IRQ line of FT800 controller
 
     pclk:

--- a/dts/bindings/display/ilitek,ili9xxx-common.yaml
+++ b/dts/bindings/display/ilitek,ili9xxx-common.yaml
@@ -9,7 +9,6 @@ include: [spi-device.yaml, display-controller.yaml]
 properties:
     reset-gpios:
       type: phandle-array
-      required: false
       description: RESET pin.
 
         The RESET pin of ILI9340 is active low.

--- a/dts/bindings/display/maxim,max7219.yaml
+++ b/dts/bindings/display/maxim,max7219.yaml
@@ -11,7 +11,6 @@ include: spi-device.yaml
 properties:
     scan-limit:
       type: int
-      required: false
       default: 7
       enum:
         - 0
@@ -28,7 +27,6 @@ properties:
         scan-limit is 1, and so on.
     intensity:
       type: int
-      required: false
       default: 0
       enum:
         - 0
@@ -50,6 +48,5 @@ properties:
       description: Intensity for MAX7219.
     num-cascading:
       type: int
-      required: false
       default: 1
       description: Number of cascading MAX7219.

--- a/dts/bindings/display/nordic,nrf-led-matrix.yaml
+++ b/dts/bindings/display/nordic,nrf-led-matrix.yaml
@@ -58,7 +58,6 @@ properties:
 
     pwm:
       type: phandle
-      required: false
       description: |
         Reference to a PWM instance for generating pulse signals on column
         GPIOs. If not provided, GPIOTE and PPI channels are allocated and

--- a/dts/bindings/display/raydium,rm68200.yaml
+++ b/dts/bindings/display/raydium,rm68200.yaml
@@ -13,14 +13,12 @@ include: [mipi-dsi-device.yaml, display-controller.yaml]
 properties:
     reset-gpios:
       type: phandle-array
-      required: false
       description: |
         The RESETn pin is asserted to disable the sensor causing a hard
         reset.  The sensor receives this as an active-low signal.
 
     bl-gpios:
       type: phandle-array
-      required: false
       description: |
         The BLn pin is asserted to control the backlight of the panel.
         The sensor receives this as an active-high signal.

--- a/dts/bindings/display/sharp,ls0xx.yaml
+++ b/dts/bindings/display/sharp,ls0xx.yaml
@@ -10,7 +10,6 @@ include: [spi-device.yaml, display-controller.yaml]
 properties:
     extcomin-gpios:
       type: phandle-array
-      required: false
       description: EXTCOMIN pin
 
         The EXTCOMIN pin is where a square pulse for toggling VCOM will
@@ -18,7 +17,6 @@ properties:
 
     extcomin-frequency:
       type: int
-      required: false
       description: EXTCOMIN pin toggle frequency
 
         The frequency with which the EXTCOMIN pin should be toggled. See
@@ -27,7 +25,6 @@ properties:
 
     disp-en-gpios:
       type: phandle-array
-      required: false
       description: DISPLAY pin
 
         The DISPLAY pin controls if the LCD displays memory contents or

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -11,7 +11,6 @@ include: [spi-device.yaml, display-controller.yaml]
 properties:
     reset-gpios:
       type: phandle-array
-      required: false
       description: |
         RESET pin.
 
@@ -21,7 +20,6 @@ properties:
 
     cmd-data-gpios:
       type: phandle-array
-      required: false
       description: |
         D/CX pin. If configured, 4-lines serial interface is used, otherwise
         3-lines serial interface is used and a D/CX bit (9-bit) is added to
@@ -53,12 +51,10 @@ properties:
 
     vrhs:
       type: int
-      required: false
       description: VRH Setting
 
     vdvs:
       type: int
-      required: false
       description: VDV Setting
 
     mdac:

--- a/dts/bindings/display/solomon,ssd1306fb-common.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb-common.yaml
@@ -26,17 +26,14 @@ properties:
 
     segment-remap:
       type: boolean
-      required: false
       description: Last column address is mapped to first segment
 
     com-invdir:
       type: boolean
-      required: false
       description: Scan direction is from last COM output to first COM output
 
     com-sequential:
       type: boolean
-      required: false
       description: Sequential COM pin configuration
 
     prechargep:
@@ -46,7 +43,6 @@ properties:
 
     reset-gpios:
       type: phandle-array
-      required: false
       description: RESET pin.
 
         The RESET pin of SSD1306 is active low.

--- a/dts/bindings/display/solomon,ssd16xxfb.yaml
+++ b/dts/bindings/display/solomon,ssd16xxfb.yaml
@@ -20,32 +20,26 @@ properties:
 
     gdv:
       type: uint8-array
-      required: false
       description: Gate driving voltage values
 
     sdv:
       type: uint8-array
-      required: false
       description: Source driving voltage values
 
     vcom:
       type: int
-      required: false
       description: VCOM voltage
 
     border-waveform:
       type: int
-      required: false
       description: Border waveform
 
     softstart:
       type: uint8-array
-      required: false
       description: Booster soft start values
 
     orientation-flipped:
       type: boolean
-      required: false
       description: Last column address is mapped to first segment
 
     reset-gpios:
@@ -77,7 +71,6 @@ properties:
 
     lut-initial:
       type: uint8-array
-      required: false
       description: |
         Initial LUT used when initializing the device and performing
         clearing the screen using a full refresh operation. The
@@ -86,11 +79,9 @@ properties:
 
     lut-default:
       type: uint8-array
-      required: false
 
     tssv:
       type: int
-      required: false
       description: Temperature Sensor Selection Value
 
         Display controller can have integrated temperature sensor or
@@ -99,10 +90,8 @@ properties:
 
     dummy-line:
       type: int
-      required: false
       description: Dummy line period override.
 
     gate-line-width:
       type: int
-      required: false
       description: Gate line width override.

--- a/dts/bindings/display/st,stm32-ltdc.yaml
+++ b/dts/bindings/display/st,stm32-ltdc.yaml
@@ -10,21 +10,18 @@ include: [display-controller.yaml,  pinctrl-device.yaml]
 properties:
     disp-on-gpios:
       type: phandle-array
-      required: false
       description: |
         Display on/off GPIO pin.
         Configure the GPIO polarity (active high/active low) according to LCD datasheet.
 
     bl-ctrl-gpios:
       type: phandle-array
-      required: false
       description: |
         Backlight on/off GPIO pin.
         Configure the GPIO polarity (active high/active low) according to LCD datasheet.
 
     ext-sdram:
       type: phandle
-      required: false
       description: |
         External SDRAM in which frame buffer will be stored.
         If not defined, internal RAM will be used.
@@ -102,15 +99,12 @@ properties:
 
     def-back-color-red:
       type: int
-      required: false
       description: Default display background color - red
 
     def-back-color-green:
       type: int
-      required: false
       description: Default display background color - green
 
     def-back-color-blue:
       type: int
-      required: false
       description: Default display background color - blue

--- a/dts/bindings/display/ultrachip,uc81xx-common.yaml
+++ b/dts/bindings/display/ultrachip,uc81xx-common.yaml
@@ -36,7 +36,6 @@ properties:
 
     softstart:
       type: uint8-array
-      required: false
       description: Booster Soft Start (BTST) values
 
 child-binding:
@@ -63,57 +62,46 @@ child-binding:
   properties:
     pwr:
       type: uint8-array
-      required: false
       description: Power Setting (PWR) values
 
     cdi:
       type: int
-      required: false
       description: |
         VCOM and data interval value. This value is optional but must
         be provided to enable border refresh control.
 
     tcon:
       type: int
-      required: false
       description: TCON setting value
 
     pll:
       type: int
-      required: false
       description: PLL / frame rate control
 
     vdcs:
       type: int
-      required: false
       description: VCOM DC settings
 
     lutc:
       type: uint8-array
-      required: false
       description: VCOM LUT
 
     lutww:
       type: uint8-array
-      required: false
       description: White-to-white LUT
 
     lutkw:
       type: uint8-array
-      required: false
       description: Black-to-white LUT
 
     lutwk:
       type: uint8-array
-      required: false
       description: White-to-black LUT
 
     lutkk:
       type: uint8-array
-      required: false
       description: White-to-black LUT
 
     lutbd:
       type: uint8-array
-      required: false
       description: Border LUT

--- a/dts/bindings/dma/brcm,iproc-pax-dma-v1.yaml
+++ b/dts/bindings/dma/brcm,iproc-pax-dma-v1.yaml
@@ -29,7 +29,6 @@ properties:
     interrupts:
       type: array
       description: Ring manager line interrupt number
-      required: false
     pcie-ep:
       type: phandle
       description: Pcie endpoint handle

--- a/dts/bindings/dma/brcm,iproc-pax-dma-v2.yaml
+++ b/dts/bindings/dma/brcm,iproc-pax-dma-v2.yaml
@@ -29,7 +29,6 @@ properties:
     interrupts:
       type: array
       description: Ring manager line interrupt number
-      required: false
     pcie-ep:
       type: phandle
       description: Pcie endpoint handle

--- a/dts/bindings/dma/dma-controller.yaml
+++ b/dts/bindings/dma/dma-controller.yaml
@@ -15,7 +15,6 @@ properties:
 
     dma-channel-mask:
       type: int
-      required: false
       description: |
         Bitmask of available DMA channels in ascending order that are
         not reserved by firmware and are available to the
@@ -23,15 +22,12 @@ properties:
 
     dma-channels:
       type: int
-      required: false
       description: Number of DMA channels supported by the controller
 
     dma-requests:
       type: int
-      required: false
       description: Number of DMA request signals supported by the controller.
 
     dma-buf-alignment:
       type: int
-      required: false
       description: Memory alignment requirement for DMA buffers used by the controller.

--- a/dts/bindings/dma/dmamux-controller.yaml
+++ b/dts/bindings/dma/dmamux-controller.yaml
@@ -20,7 +20,6 @@ properties:
 
     dma-generators:
       type: int
-      required: false
       description: Number of DMAMUX Request generator supported by the controller
 
     dma-requests:

--- a/dts/bindings/dma/st,stm32-dma.yaml
+++ b/dts/bindings/dma/st,stm32-dma.yaml
@@ -24,12 +24,10 @@ properties:
 
     st,mem2mem:
       type: boolean
-      required: false
       description: If the DMA controller V1 supports memory to memory transfer
 
     dma-offset:
       type: int
-      required: false
       description: |
         offset in the table of channels when mapping to a DMAMUX
         for 1st dma instance, offset is 0,

--- a/dts/bindings/dsa/microchip,ksz8794.yaml
+++ b/dts/bindings/dsa/microchip,ksz8794.yaml
@@ -10,7 +10,6 @@ include: [microchip_dsa.yaml]
 properties:
     workaround:
         type: int
-        required: false
         description: |
           Define the applied workaround for the switch used for
           short connections. Use bitmask to select the workaround or more
@@ -19,7 +18,6 @@ properties:
           0x04: 2) CAT-5E/6 Short Cable with a Link Issue for the KSZ8795 Family
     mii-lowspeed-drivestrength:
         type: int
-        required: false
         description: |
           Define the Low-Speed Interface Drive Strength for MII and RMMI
           Supported values 2,4,8,12,16,20,24,28mA

--- a/dts/bindings/dsa/microchip_dsa.yaml
+++ b/dts/bindings/dsa/microchip_dsa.yaml
@@ -8,27 +8,22 @@ include: [spi-device.yaml]
 properties:
     dsa-master-port:
        type: phandle
-       required: false
        description: Phandle to master port.
     dsa-slave-ports:
        type: int
-       required: false
        description: Number of slave ports on the switch
     spi-cpha:
        type: boolean
-       required: false
        description: |
           Set to indicate phase starts with asserted half-phase (CPHA=1).
           For this driver using this property requires also using cpol.
     spi-cpol:
         type: boolean
-        required: false
         description: |
           Set to indicate clock leading edge is falling (CPOL=1).
           For this driver using this property requires also using cpha.
     reset-gpios:
         type: phandle-array
-        required: false
         description: |
           The pin is asserted for 10ms during boot to reset the KSZ8794.
 
@@ -37,6 +32,5 @@ child-binding:
     properties:
         local-mac-address:
             type: uint8-array
-            required: false
             description: |
               Specifies the MAC address that was assigned to the port

--- a/dts/bindings/edac/intel,ibecc.yaml
+++ b/dts/bindings/edac/intel,ibecc.yaml
@@ -6,7 +6,3 @@ description: EDAC In-Band Error Correcting Code (IBECC)
 compatible: "intel,ibecc"
 
 include: base.yaml
-
-properties:
-    reg:
-      required: false

--- a/dts/bindings/espi/microchip,xec-espi-host-dev.yaml
+++ b/dts/bindings/espi/microchip,xec-espi-host-dev.yaml
@@ -13,12 +13,6 @@ properties:
     reg:
       required: true
 
-    interrupts:
-      required: false
-
-    interrupt-names:
-      required: false
-
     ldn:
       type: int
       required: true
@@ -26,18 +20,15 @@ properties:
 
     girqs:
       type: array
-      required: false
       description: array of GIRQ and bit positions
 
     pcrs:
       type: array
-      required: false
       description: PCR sleep register index and bit position
 
 # optional properties application to different host facing devices
     host-io:
       type: int
-      required: false
       description: |
         Logical device Host I/O (x86) base. Refer to SoC documentation for the
         number of I/O decoders implemented by a device (1 or 2) and the fixed
@@ -45,7 +36,6 @@ properties:
 
     host-io-addr-mask:
       type: int
-      required: false
       description: |
         Host I/O address mask. This value is fixed for all HW and is only
         used by Port80 BIOS debug alias device to specify the byte lane the
@@ -53,7 +43,6 @@ properties:
 
     host-mem:
       type: int
-      required: false
       description: |
         Logical device Host memory (x86) base address. Refer to SoC
         documentation for which logical devices implement a memory decoder
@@ -61,7 +50,6 @@ properties:
 
     emi-mems:
       type: array
-      required: false
       description: |
         Each EMI host device supports Host access to two SoC data memory
         regions. Each region requires three configuration parameters:

--- a/dts/bindings/espi/microchip,xec-espi-saf-v2.yaml
+++ b/dts/bindings/espi/microchip,xec-espi-saf-v2.yaml
@@ -26,27 +26,22 @@ properties:
     poll-timeout:
       type: int
       description: poll flash busy timeout in 32KHz periods
-      required: false
 
     poll-interval:
       type: int
       description: interval between flash busy poll in 20 ns units
-      required: false
 
     consec-rd-timeout:
       type: int
       description: timeout after last read to resume supended operations in 20 ns units
-      required: false
 
     sus-chk-delay:
       type: int
       description: hold off poll after suspend in 20 ns units
-      required: false
 
     sus-rsm-interval:
       type: int
       description: force suspended erase or program to resume in 32KHz periods
-      required: false
 
     "#girq-cells":
       type: int

--- a/dts/bindings/espi/microchip,xec-espi-saf.yaml
+++ b/dts/bindings/espi/microchip,xec-espi-saf.yaml
@@ -16,29 +16,23 @@ properties:
     io_girq:
       type: int
       description: soc group irq index for eSPI I/O
-      required: false
 
     poll_timeout:
       type: int
       description: poll flash busy timeout in 32KHz periods
-      required: false
 
     poll_interval:
       type: int
       description: interval between flash busy poll in 20 ns units
-      required: false
 
     consec_rd_timeout:
       type: int
       description: timeout after last read to resume supended operations in 20 ns units
-      required: false
 
     sus_chk_delay:
       type: int
       description: hold off poll after suspend in 20 ns units
-      required: false
 
     sus_rsm_interval:
       type: int
       description: force suspended erase or program to resume in 32KHz periods
-      required: false

--- a/dts/bindings/espi/microchip,xec-espi-vw-routing.yaml
+++ b/dts/bindings/espi/microchip,xec-espi-vw-routing.yaml
@@ -17,7 +17,6 @@ child-binding:
 
        vw-girq:
         type: array
-        required: false
         description: |
             Routing of MSVW source to aggregated GIRQs
 

--- a/dts/bindings/ethernet/ethernet,fixed-link.yaml
+++ b/dts/bindings/ethernet/ethernet,fixed-link.yaml
@@ -14,5 +14,4 @@ child-binding:
             - 10
        full-duplex:
           type: boolean
-          required: false
           description: The fixed link operates in full duplex mode

--- a/dts/bindings/ethernet/ethernet-phy.yaml
+++ b/dts/bindings/ethernet/ethernet-phy.yaml
@@ -20,11 +20,9 @@ properties:
       description: MDIO driver node
     no-reset:
       type: boolean
-      required: false
       description: Do not reset the PHY during initialization
     fixed-link:
       type: string
-      required: false
       description: This link is fixed and does not require PHY configuration
       enum:
         - "10BASE-T Half-Duplex"

--- a/dts/bindings/ethernet/ethernet.yaml
+++ b/dts/bindings/ethernet/ethernet.yaml
@@ -8,11 +8,9 @@ include: base.yaml
 properties:
     local-mac-address:
       type: uint8-array
-      required: false
       description: Specifies the MAC address that was assigned to the network device
     zephyr,random-mac-address:
       type: boolean
-      required: false
       description: |
         Use a random MAC address generated when the driver is initialized.
         Note that using this choice and rebooting a board may leave stale

--- a/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
+++ b/dts/bindings/ethernet/nxp,kinetis-ethernet.yaml
@@ -18,10 +18,8 @@ properties:
       required: true
     reset-gpios:
       type: phandle-array
-      required: false
       description: GPIO to reset PHY. Reset signal is assumed active low.
     int-gpios:
       type: phandle-array
-      required: false
       description:
         interrupt GPIO for PHY. Will be pulled high before reset is asserted.

--- a/dts/bindings/ethernet/wiznet,w5500.yaml
+++ b/dts/bindings/ethernet/wiznet,w5500.yaml
@@ -18,7 +18,6 @@ properties:
         as active low.
     reset-gpios:
       type: phandle-array
-      required: false
       description: Reset pin.
 
         The reset pin of W5500 is active low.

--- a/dts/bindings/ethernet/xlnx,gem.yaml
+++ b/dts/bindings/ethernet/xlnx,gem.yaml
@@ -41,7 +41,6 @@ properties:
 
     init-mdio-phy:
       type: boolean
-      required: false
       description: |
         Activates the management of a PHY associated with the controller in-
         stance. If this parameter is activated at the board level, the de-
@@ -83,7 +82,6 @@ properties:
 
     advertise-lower-link-speeds:
       type: boolean
-      required: false
       description: |
         Indicates to a driver instance which manages an associated PHY on
         the MDIO bus to include link speeds lower than the nominal value
@@ -92,7 +90,6 @@ properties:
 
     handle-rx-in-isr:
       type: boolean
-      required: false
       description: |
         Moves the handling of the frame received interrupt including the
         transfer of packet data from the DMA to network packet buffers and
@@ -104,7 +101,6 @@ properties:
 
     handle-tx-in-workq:
       type: boolean
-      required: false
       description: |
         Moves the handling of the frame transmission done interrupt into the
         context of the system work queue. By default, TX done handling is per-
@@ -153,7 +149,6 @@ properties:
 
     hw-tx-buffer-size-full:
       type: boolean
-      required: false
       description: |
         When set, the hardware TX data buffer will make use of the full 4 kB
         that are available. If unset, the hardware TX data buffer will be
@@ -189,7 +184,6 @@ properties:
 
     ignore-ipg-rxer:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Ignore IPG rx_er. When set, rx_er has no
         effect on the GEM's operation when rx_dv is low. Set this when using
@@ -197,14 +191,12 @@ properties:
 
     disable-reject-nsp:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Receive bad preamble. When set, frames with
         non-standard preamble will not be rejected.
 
     ipg-stretch:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enable IPG stretch. When set, the transmit
         IPG can be increased above 96 bit times depending on the previous
@@ -212,7 +204,6 @@ properties:
 
     sgmii-mode:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enable SGMII mode. Changes the behaviour of
         the auto-negotiation advertisement and link partner ability registers
@@ -221,7 +212,6 @@ properties:
 
     disable-reject-fcs-crc-errors:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Disable rejection of FCS/CRC errors.
         When set, frames with FCS/CRC errors will not be rejected. FCS error
@@ -231,14 +221,12 @@ properties:
 
     rx-halfdup-while-tx:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enable frames to be received in half-duplex
         mode while transmitting.
 
     rx-checksum-offload:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enable RX IP/TCP/UDP checksum offload to
         hardware. Frames with bad IP, TCP or UDP checksums will be discarded.
@@ -246,7 +234,6 @@ properties:
 
     tx-checksum-offload:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enable TX IP/TCP/UDP checksum offload to
         hardware. This option is NOT supported by the QEMU implementation
@@ -254,7 +241,6 @@ properties:
 
     disable-pause-copy:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Do not copy received pause frames to memory.
         Set this option in order to prevent valid pause frames from being
@@ -267,7 +253,6 @@ properties:
 
     discard-rx-fcs:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Remove FCS of received frames.
         When set, received frames will be written to memory without their
@@ -276,7 +261,6 @@ properties:
 
     discard-rx-length-errors:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Discard frames with length field errors.
         When set, frames with a measured length shorter than the extracted
@@ -286,7 +270,6 @@ properties:
 
     pause-frame:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enable pause. When set, transmission will
         pause if a non zero 802.3 classic pause frame is received and PFC
@@ -294,28 +277,24 @@ properties:
 
     tbi:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enable TBI. When set, the TBI interface is en-
         bled instead of the GMII/MII interface.
 
     ext-address-match:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enable external address match. When set, the
         external address match interface can be used to copy frames to memory.
 
     long-frame-rx-support:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enable reception of 1536 byte frames.
         Normally, the GEM rejects any frame above 1518 bytes.
 
     unicast-hash:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enable unicast hash. When set, unicast frames
         will be accepted when the 6 bit hash function of the destination
@@ -323,7 +302,6 @@ properties:
 
     multicast-hash:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enable multicast hash. When set, mutlicast
         frames will be accepted when the 6 bit hash function of the desti-
@@ -331,47 +309,40 @@ properties:
 
     reject-broadcast:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Reject broadcast frames. When set, frames
         addressed to the all-ones broadcast address will be rejected.
 
     promiscuous-mode:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enable promiscuous mode. When set, all valid
         frames will be accepted.
 
     discard-non-vlan:
       type: boolean
-      required: false
       description: Optional feature flag - Discard non-VLAN frames. When set,
         only VLAN tagged frames will be passed to the address matching logic.
 
     full-duplex:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enables full duplex reception and transmission.
 
     discard-rx-frame-ahb-unavail:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Discard received packets when no AHB resource
         is available.
 
     ahb-packet-endian-swap:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enable AHB packet data endianness swap to big
         endian. If this flag is not set, data will be little endian.
 
     ahb-md-endian-swap:
       type: boolean
-      required: false
       description: |
         Optional feature flag - Enable AHB management descriptor data endian-
         ness swap to big endian. If this flag is not set, data will be little

--- a/dts/bindings/flash_controller/nordic,nrf-qspi.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf-qspi.yaml
@@ -40,7 +40,6 @@ properties:
   sck-pin:
     type: int
     deprecated: true
-    required: false
     description: |
       IMPORTANT: This option will only be used if the new pin control driver
       is not enabled.
@@ -58,7 +57,6 @@ properties:
           sck-pin = <34>;  /* 32 + 2 */
   io-pins:
     type: array
-    required: false
     description: |
       IMPORTANT: This option will only be used if the new pin control driver
       is not enabled.
@@ -76,7 +74,6 @@ properties:
       sck-pin property's.
   csn-pins:
     type: array
-    required: false
     description: |
       IMPORTANT: This option will only be used if the new pin control driver
       is not enabled.

--- a/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
@@ -34,7 +34,6 @@ properties:
       description: Flash Memory size in bits
     reset-gpios:
       type: phandle-array
-      required: false
       description: RESETn pin
     spi-bus-width:
       type: int
@@ -66,7 +65,6 @@ properties:
         - 2
     writeoc:
       type: string
-      required: false
       enum:
         - "PP"            # Page program, PP (0x02) up to 256 bytes
         - "PP_1_1_2"      # Dual page program, PP 1-1-2 (0xA2)
@@ -90,7 +88,6 @@ properties:
         * OSPI_QUAD_MODE -> PP 1-4-4 (0x38)
     four-byte-opcodes:
       type: boolean
-      required: false
       description: |
         Some NOR-Flash ICs use different opcodes when operating in
         4 byte addressing mode.

--- a/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
@@ -35,29 +35,23 @@ properties:
       description: Flash Memory size in bits
     reset-gpios:
       type: phandle-array
-      required: false
       description: RESETn pin
     reset-gpios-duration:
       type: int
-      required: false
       description: The duration (in ms) for the flash memory reset pulse
     reset-cmd:
       type: boolean
-      required: false
       description: Send reset command on initialization
     reset-cmd-wait:
       type: int
       default: 10
-      required: false
       description: The duration (in us) to wait after reset command
     spi-bus-width:
       type: int
-      required: false
       description: The width of (Q)SPI bus to which flash memory is connected.
                    Now only value of 4 (when using SIO[0123]) is supported.
     writeoc:
       type: string
-      required: false
       enum:
         - "PP_1_1_4"      # Quad data line SPI, PP 1-1-4 (0x32)
         - "PP_1_4_4"      # Quad data line SPI, PP 1-4-4 (0x38)

--- a/dts/bindings/flash_controller/st,stm32wb-flash-controller.yaml
+++ b/dts/bindings/flash_controller/st,stm32wb-flash-controller.yaml
@@ -8,9 +8,7 @@ properties:
     single-bank:
       type: boolean
       description: dual-bank mode not enabled (page erase 4096k)
-      required: false
 
     dual-bank:
       type: boolean
       description: dual-bank mode enabled (page erase 2048k)
-      required: false

--- a/dts/bindings/flash_controller/zephyr,sim-flash.yaml
+++ b/dts/bindings/flash_controller/zephyr,sim-flash.yaml
@@ -10,4 +10,3 @@ properties:
     erase-value:
       type: int
       description: Value of erased flash cell
-      required: false

--- a/dts/bindings/gpio/gpio-controller.yaml
+++ b/dts/bindings/gpio/gpio-controller.yaml
@@ -14,7 +14,6 @@ properties:
       description: Number of items to expect in a GPIO specifier
     ngpios:
       type: int
-      required: false
       default: 32
       description: |
           This property indicates the number of in-use slots of available slots
@@ -28,7 +27,6 @@ properties:
           holes in the slot range, this value should be the max slot number-1.
     gpio-reserved-ranges:
       type: array
-      required: false
       description: |
           If not all the GPIOs at offsets 0...N-1 are usable for ngpios = <N>, then
           this property contains an additional set of tuples which specify which GPIOs
@@ -39,7 +37,6 @@ properties:
           GPIO offsets 3, 4, and 10 are not usable, even if ngpios = <18>.
     gpio-line-names:
       type: string-array
-      required: false
       description: |
           This is an array of strings defining the names of the GPIO lines
           going out of the GPIO controller

--- a/dts/bindings/gpio/gpio-nexus.yaml
+++ b/dts/bindings/gpio/gpio-nexus.yaml
@@ -10,11 +10,9 @@ properties:
 
     gpio-map-mask:
       type: compound
-      required: false
 
     gpio-map-pass-thru:
       type: compound
-      required: false
 
     "#gpio-cells":
       type: int

--- a/dts/bindings/gpio/microchip,mpfs-gpio.yaml
+++ b/dts/bindings/gpio/microchip,mpfs-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    interrupts:
-      required: false
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/microchip,xec-gpio-v2.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio-v2.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    interrupts:
-      required: false
-
     port-id:
       type: int
       required: true

--- a/dts/bindings/gpio/microchip,xec-gpio.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    interrupts:
-      required: false
-
     port-id:
       type: int
       required: true

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -15,7 +15,6 @@ properties:
       const: 2
 
     sense-edge-mask:
-      required: false
       type: int
       description: |
         Mask of pins that use the GPIO sense mechanism for edge detection.

--- a/dts/bindings/gpio/nuvoton,nct38xx-gpio-port.yaml
+++ b/dts/bindings/gpio/nuvoton,nct38xx-gpio-port.yaml
@@ -23,7 +23,6 @@ properties:
 
     pinmux_mask:
       type: int
-      required: false
       description: |
         NCT38XX series port 0 has Pin Multiplexing functionality. However, not
         every GPIOs have pinmux controller functionality. This property

--- a/dts/bindings/gpio/nuvoton,npcx-gpio.yaml
+++ b/dts/bindings/gpio/nuvoton,npcx-gpio.yaml
@@ -30,7 +30,6 @@ properties:
 
     lvol-maps:
         type: phandles
-        required: false
         description: |
             Mapping table between Low-Voltage controllers and 8 IOs belong to
             this device. Please notice not all IOs support Low-Voltage detection.

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -11,17 +11,12 @@ properties:
     reg:
       required: true
 
-    interrupts:
-      required: false
-
     rdc:
      type: int
-     required: false
      description: Set the RDC permission for this peripheral
 
     pinmux:
       type: phandles
-      required: false
       description: |
         IMX pin selection peripheral does not follow specific
         pattern for which GPIO port uses which pinmux. Use this property to specify

--- a/dts/bindings/gpio/nxp,lpc11u6x-gpio.yaml
+++ b/dts/bindings/gpio/nxp,lpc11u6x-gpio.yaml
@@ -19,7 +19,6 @@ properties:
 
     base:
       type: int
-      required: false
       default: 0
       description: index of the first GPIO for this port.
 

--- a/dts/bindings/gpio/nxp,pca95xx.yaml
+++ b/dts/bindings/gpio/nxp,pca95xx.yaml
@@ -10,17 +10,14 @@ include: [gpio-controller.yaml, i2c-device.yaml]
 properties:
     has-pud:
       type: boolean
-      required: false
       description: Supports pull-up/pull-down
 
     has-interrupt-mask-reg:
       type: boolean
-      required: false
       description: Has Interrupt mask register (PCAL95xx)
 
     interrupt-gpios:
       type: phandle-array
-      required: false
       description: Interrupt GPIO pin (active-low open-drain)
 
     "#gpio-cells":

--- a/dts/bindings/gpio/nxp,pcal6408a.yaml
+++ b/dts/bindings/gpio/nxp,pcal6408a.yaml
@@ -14,13 +14,11 @@ properties:
 
     int-gpios:
       type: phandle-array
-      required: false
       description: |
         GPIO connected to the controller INT pin. This pin is active-low.
 
     reset-gpios:
       type: phandle-array
-      required: false
       description: |
         GPIO connected to the controller RESET pin. This pin is active-low.
 

--- a/dts/bindings/gpio/nxp,pcf8574.yaml
+++ b/dts/bindings/gpio/nxp,pcf8574.yaml
@@ -14,7 +14,6 @@ properties:
 
     int-gpios:
       type: phandle-array
-      required: false
       description: |
         GPIO connected to the controller INT pin. This pin is active-low.
 

--- a/dts/bindings/gpio/nxp,s32-gpio.yaml
+++ b/dts/bindings/gpio/nxp,s32-gpio.yaml
@@ -15,7 +15,6 @@ properties:
       required: true
 
     interrupts:
-      required: false
       description: |
         For GPIO ports that have pins can be used for processing
         external interrupt signal, this is a list of GPIO pins and

--- a/dts/bindings/gpio/semtech,sx1509b.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b.yaml
@@ -17,14 +17,12 @@ properties:
 
     nint-gpios:
       type: phandle-array
-      required: false
       description: |
         Connection for the NINT signal. This signal is active-low when
         produced by sx1509b GPIO node.
 
     init-out-low:
       type: int
-      required: false
       default: 0
       description: |
         Bit mask identifying pins that should be initialized as outputs
@@ -32,7 +30,6 @@ properties:
 
     init-out-high:
       type: int
-      required: false
       default: 0
       description: |
         Bit mask identifying pins that should be initialized as outputs

--- a/dts/bindings/gpio/silabs,gecko-gpio.yaml
+++ b/dts/bindings/gpio/silabs,gecko-gpio.yaml
@@ -13,5 +13,4 @@ properties:
 
     location-swo:
       type: int
-      required: false
       description: Serial Wire Output (SWO) PIN location

--- a/dts/bindings/gpio/ti,tca6424a.yaml
+++ b/dts/bindings/gpio/ti,tca6424a.yaml
@@ -10,14 +10,12 @@ include: [gpio-controller.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false
       description: |
           GPIO connected to the controller INT pin. This pin is active-low
           and open-drain.
 
     reset-gpios:
       type: phandle-array
-      required: false
       description: |
           GPIO connected to the controller RESET pin. This pin is active-low.
 

--- a/dts/bindings/gpio/ti,tca9538.yaml
+++ b/dts/bindings/gpio/ti,tca9538.yaml
@@ -20,7 +20,6 @@ properties:
 
     nint-gpios:
       type: phandle-array
-      required: false
       description: |
         Connection for the NINT signal. This signal is active-low when
         produced by tca9538 GPIO node.

--- a/dts/bindings/i2c/espressif,esp32-i2c.yaml
+++ b/dts/bindings/i2c/espressif,esp32-i2c.yaml
@@ -12,9 +12,6 @@ properties:
     reg:
       required: true
 
-    interrupts:
-      required: false
-
     pinctrl-0:
       required: true
 
@@ -23,7 +20,6 @@ properties:
 
     scl-gpios:
       type: phandle-array
-      required: false
       description: |
         GPIO to which the I2C SCL signal is routed. This is only required
         if the target SoC does not have support in hardware for clearing
@@ -31,7 +27,6 @@ properties:
 
     sda-gpios:
       type: phandle-array
-      required: false
       description: |
         GPIO to which the I2C SDA signal is routed. This is only required
         if the target SoC does not have support in hardware for clearing
@@ -39,17 +34,14 @@ properties:
 
     tx-lsb:
       type: boolean
-      required: false
       description: Set I2C TX data as LSB
 
     rx-lsb:
       type: boolean
-      required: false
       description: Set I2C RX data as LSB
 
     scl-timeout-us:
       type: int
-      required: false
       description: |
         Timeout for unchanged SCL during clock stretching of the I2C target in
         microseconds.

--- a/dts/bindings/i2c/i2c-controller.yaml
+++ b/dts/bindings/i2c/i2c-controller.yaml
@@ -16,5 +16,4 @@ properties:
       const: 0
     clock-frequency:
       type: int
-      required: false
       description: Initial clock frequency in Hz

--- a/dts/bindings/i2c/ite,enhance-i2c.yaml
+++ b/dts/bindings/i2c/ite,enhance-i2c.yaml
@@ -10,7 +10,6 @@ include: ite,common-i2c.yaml
 properties:
     prescale-scl-low:
       type: int
-      required: false
       description: |
         This option is used to configure the I2C speed prescaler for
         the SCL low period. When set to >= 1, it will increase the

--- a/dts/bindings/i2c/ite,it8xxx2-i2c.yaml
+++ b/dts/bindings/i2c/ite,it8xxx2-i2c.yaml
@@ -9,7 +9,6 @@ include: ite,common-i2c.yaml
 
 properties:
     fifo-enable:
-      required: false
       type: boolean
       description: |
         FIFO1 supports channel A.

--- a/dts/bindings/i2c/nordic,nrf-twi-common.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi-common.yaml
@@ -16,7 +16,6 @@ properties:
     sda-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -36,7 +35,6 @@ properties:
     scl-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.

--- a/dts/bindings/i2c/nordic,nrf-twim.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twim.yaml
@@ -28,7 +28,6 @@ include: nordic,nrf-twi-common.yaml
 properties:
     zephyr,concat-buf-size:
         type: int
-        required: false
         default: 16
         description: |
             Size of a concatenation buffer that the driver is to use for merging
@@ -43,7 +42,6 @@ properties:
 
     zephyr,flash-buf-max-size:
         type: int
-        required: false
         default: 16
         description: |
             TWIM peripherals cannot perform write transactions from buffers

--- a/dts/bindings/i2c/nordic,nrf-twis.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twis.yaml
@@ -32,10 +32,8 @@ include: nordic,nrf-twi-common.yaml
 properties:
     address-0:
       type: int
-      required: false
       description: TWI slave address 0
 
     address-1:
       type: int
-      required: false
       description: TWI slave address 1

--- a/dts/bindings/i2c/nxp,imx-lpi2c.yaml
+++ b/dts/bindings/i2c/nxp,imx-lpi2c.yaml
@@ -15,18 +15,15 @@ properties:
       required: true
 
     bus-idle-timeout:
-      required: false
       type: int
       description: Bus idle timeout in nanoseconds
 
     scl-gpios:
       type: phandle-array
-      required: false
       description: |
         GPIO to which the I2C SCL signal is routed. This is only needed for I2C bus recovery support.
 
     sda-gpios:
       type: phandle-array
-      required: false
       description: |
         GPIO to which the I2C SDA signal is routed. This is only needed for I2C bus recovery support.

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -8,8 +8,5 @@ compatible: "snps,designware-i2c"
 include: [i2c-controller.yaml, pinctrl-device.yaml, pcie-device.yaml]
 
 properties:
-    reg:
-      required: false
-
     interrupts:
       required: true

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -22,7 +22,6 @@ properties:
 
     timings:
         type: array
-        required: false
         description: |
             An optional table of pre-computed i2c timing values with the
             matching clock configuration.

--- a/dts/bindings/i2c/ti,tca954x-base.yaml
+++ b/dts/bindings/i2c/ti,tca954x-base.yaml
@@ -49,7 +49,6 @@ include: [i2c-device.yaml]
 properties:
   reset-gpios:
     type: phandle-array
-    required: false
     description: |
       GPIO connected to the controller RESET pin. This pin is active-low.
 

--- a/dts/bindings/i2s/nordic,nrf-i2s.yaml
+++ b/dts/bindings/i2s/nordic,nrf-i2s.yaml
@@ -17,7 +17,6 @@ properties:
     sck-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -37,7 +36,6 @@ properties:
     lrck-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -48,7 +46,6 @@ properties:
     sdout-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -59,7 +56,6 @@ properties:
     sdin-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -70,7 +66,6 @@ properties:
     mck-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -80,7 +75,6 @@ properties:
 
     clock-source:
       type: string
-      required: false
       default: "PCLK32M_HFXO"
       description: |
         Clock source to be used by the I2S peripheral for the master clock

--- a/dts/bindings/i2s/nxp,mcux-i2s.yaml
+++ b/dts/bindings/i2s/nxp,mcux-i2s.yaml
@@ -29,42 +29,34 @@ properties:
 
     nxp,tx-sync-mode:
       type: boolean
-      required: false
       description: tx sync mode
 
     nxp,rx-sync-mode:
       type: boolean
-      required: false
       description: rx sync mode
 
     pre-div:
       type: int
-      required: false
       description: pre divider
 
     podf:
       type: int
-      required: false
       description: post-divider fraction
 
     pll-clocks:
       type: phandle-array
-      required: false
       description: pll settings
       specifier-space: pll-clock
 
     pll-clock-names:
-      required: false
       type: string-array
       description: Provided names of pll-clock specifiers
 
     pinmuxes:
       type: phandle-array
-      required: false
       specifier-space: pinmux
       description: iomux settings
 
     nxp,tx-channel:
       type: int
-      required: false
       description: tx channel the maximum number is SOC dependent

--- a/dts/bindings/i3c/i3c-controller.yaml
+++ b/dts/bindings/i3c/i3c-controller.yaml
@@ -19,14 +19,12 @@ properties:
 
     i3c-scl-hz:
       type: int
-      required: false
       description: |
         Frequency of the SCL signal used for I3C transfers. When undefined,
         use the controller default or as specified by the I3C specification.
 
     i2c-scl-hz:
       type: int
-      required: false
       description: |
         Frequency of the SCL signal used for I2C transfers. When undefined
         and there are I2C devices attached to the bus, look at the Legacy

--- a/dts/bindings/i3c/i3c-device.yaml
+++ b/dts/bindings/i3c/i3c-device.yaml
@@ -59,6 +59,5 @@ properties:
 
     assigned-address:
       type: int
-      required: false
       description: |
         Dynamic address to be assigned to the device.

--- a/dts/bindings/i3c/nxp,mcux-i3c.yaml
+++ b/dts/bindings/i3c/nxp,mcux-i3c.yaml
@@ -18,7 +18,6 @@ properties:
 
     i3c-od-scl-hz:
       type: int
-      required: false
       description: |
         Open Drain Frequency for the I3C controller. When undefined, use
         the controller default or as specified by the I3C specification.

--- a/dts/bindings/ieee802154/atmel,rf2xx.yaml
+++ b/dts/bindings/ieee802154/atmel,rf2xx.yaml
@@ -25,12 +25,10 @@ properties:
 
     dig2-gpios:
       type: phandle-array
-      required: false
       description: RX and TX Frame Time Stamping(TX_ARET)
 
     clkm-gpios:
       type: phandle-array
-      required: false
       description: Master clock signal output
 
     local-mac-address:

--- a/dts/bindings/ieee802154/decawave,dw1000.yaml
+++ b/dts/bindings/ieee802154/decawave,dw1000.yaml
@@ -28,10 +28,8 @@ properties:
 
     tx-ant-delay:
       type: int
-      required: false
       description: Transmitter antenna delay.
 
     rx-ant-delay:
       type: int
-      required: false
       description: Receiver antenna delay.

--- a/dts/bindings/interrupt-controller/nuvoton,npcx-miwu-int-map.yaml
+++ b/dts/bindings/interrupt-controller/nuvoton,npcx-miwu-int-map.yaml
@@ -28,5 +28,4 @@ child-binding:
           description: group bit-mask for miwu interrupts
        groups:
           type: array
-          required: false
           description: groups shared the same interrupt

--- a/dts/bindings/interrupt-controller/nxp,s32-siul2-eirq.yaml
+++ b/dts/bindings/interrupt-controller/nxp,s32-siul2-eirq.yaml
@@ -23,7 +23,6 @@ properties:
 
   filter-prescaler:
     type: int
-    required: false
     description: |
       Setting the prescaler which selects the clock for all digital filters.
       Valid range: 0 - 15.

--- a/dts/bindings/ipc/zephyr,ipc-openamp-static-vrings.yaml
+++ b/dts/bindings/ipc/zephyr,ipc-openamp-static-vrings.yaml
@@ -31,7 +31,6 @@ properties:
 
   zephyr,priority:
     type: array
-    required: false
     description: |
       WQ priority for the instance. This property is an array composed by the
       priority level and the type of priority (PRIO_COOP for cooperative or
@@ -47,7 +46,6 @@ properties:
 
   zephyr,buffer-size:
     type: int
-    required: false
     description: |
       The size of the buffer used to send data between host and remote. Default
       value is RPMSG_BUFFER_SIZE. This property must be the same for host and remote.

--- a/dts/bindings/kscan/focaltech,ft5336.yaml
+++ b/dts/bindings/kscan/focaltech,ft5336.yaml
@@ -10,4 +10,3 @@ include: [kscan.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false

--- a/dts/bindings/kscan/goodix,gt911.yaml
+++ b/dts/bindings/kscan/goodix,gt911.yaml
@@ -10,7 +10,5 @@ include: [kscan.yaml, i2c-device.yaml]
 properties:
     irq-gpios:
       type: phandle-array
-      required: false
     reset-gpios:
       type: phandle-array
-      required: false

--- a/dts/bindings/kscan/hynitron,cst816s.yaml
+++ b/dts/bindings/kscan/hynitron,cst816s.yaml
@@ -10,7 +10,6 @@ include: i2c-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: false
       description: |
         The irq signal defaults to active low as produced by the
         sensor. The property value should ensure the flags properly
@@ -18,7 +17,6 @@ properties:
 
     rst-gpios:
       type: phandle-array
-      required: false
       description: |
         The reset signal defaults to active low to the
         sensor. The property value should ensure the flags properly

--- a/dts/bindings/kscan/microchip,cap1203.yaml
+++ b/dts/bindings/kscan/microchip,cap1203.yaml
@@ -10,4 +10,3 @@ include: [kscan.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false

--- a/dts/bindings/kscan/microchip,xec-kscan.yaml
+++ b/dts/bindings/kscan/microchip,xec-kscan.yaml
@@ -18,12 +18,6 @@ properties:
     reg:
       required: true
 
-    pinctrl-0:
-      required: false
-
-    pinctrl-names:
-      required: false
-
     interrupts:
       required: true
 

--- a/dts/bindings/led/gpio-leds.yaml
+++ b/dts/bindings/led/gpio-leds.yaml
@@ -41,7 +41,6 @@ child-binding:
           type: phandle-array
           required: true
        label:
-          required: false
           type: string
           description: |
             Human readable string describing the LED. It can be used by an

--- a/dts/bindings/led/holtek,ht16k33.yaml
+++ b/dts/bindings/led/holtek,ht16k33.yaml
@@ -9,5 +9,4 @@ bus: ht16k33
 properties:
     irq-gpios:
       type: phandle-array
-      required: false
       description: IRQ pin

--- a/dts/bindings/led/led-controller.yaml
+++ b/dts/bindings/led/led-controller.yaml
@@ -7,11 +7,9 @@ child-binding:
     description: LED child node
     properties:
         label:
-          required: false
           type: string
           description: Human readable string describing the LED
         index:
-          required: false
           type: int
           description: |
             Index of the LED on a controller. It can be used by drivers or
@@ -21,7 +19,6 @@ child-binding:
             the controller.
         color-mapping:
           type: array
-          required: false
           description: |
             Channel to color mapping of a multicolor LED. If a LED supports
             several colors, then the color-mapping property can be used to

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -13,7 +13,6 @@ child-binding:
           type: phandle-array
 
         label:
-          required: false
           type: string
           description: |
             Human readable string describing the LED. It can be used by an

--- a/dts/bindings/led/ti,lp503x.yaml
+++ b/dts/bindings/led/ti,lp503x.yaml
@@ -10,12 +10,10 @@ include: ["i2c-device.yaml", "led-controller.yaml"]
 properties:
     max_curr_opt:
       type: boolean
-      required: false
       description: |
         If enabled the maximum current output is set to 35 mA (25.5 mA else).
     log_scale_en:
       type: boolean
-      required: false
       description: |
         If enabled a logarithmic dimming scale curve is used for LED brightness
         control. A linear dimming scale curve is used else.

--- a/dts/bindings/led_strip/worldsemi,ws2812-spi.yaml
+++ b/dts/bindings/led_strip/worldsemi,ws2812-spi.yaml
@@ -26,12 +26,10 @@ properties:
 
   spi-cpol:
     type: boolean
-    required: false
     description: Set SPI clock polarity.
 
   spi-cpha:
     type: boolean
-    required: false
     description: Set SPI clock phase.
 
   spi-one-frame:

--- a/dts/bindings/led_strip/ws2812.yaml
+++ b/dts/bindings/led_strip/ws2812.yaml
@@ -55,7 +55,6 @@ properties:
 
   reset-delay:
     type: int
-    required: false
     default: 8
     description: |
       Minimum delay to wait (in microseconds) to make sure that the strip has

--- a/dts/bindings/lora/semtech,sx126x-base.yaml
+++ b/dts/bindings/lora/semtech,sx126x-base.yaml
@@ -7,7 +7,6 @@ include: spi-device.yaml
 properties:
     reset-gpios:
       type: phandle-array
-      required: false
       description: |
         GPIO connected to the modem's NRESET signal.
 
@@ -16,40 +15,34 @@ properties:
 
     busy-gpios:
       type: phandle-array
-      required: false
       description: |
         GPIO connected to the modem's BUSY signal.
 
     antenna-enable-gpios:
       type: phandle-array
-      required: false
       description: |
         Antenna power enable pin.
 
     tx-enable-gpios:
       type: phandle-array
-      required: false
       description: |
         Antenna switch TX enable GPIO. If set, the driver tracks the
         state of the radio and controls the RF switch.
 
     rx-enable-gpios:
       type: phandle-array
-      required: false
       description: |
         Antenna switch RX enable GPIO. If set, the driver tracks the
         state of the radio and controls the RF switch.
 
     dio1-gpios:
       type: phandle-array
-      required: false
       description: |
         GPIO connected to DIO1. This GPIO will be used as a generic
         IRQ line from the chip.
 
     dio2-tx-enable:
       type: boolean
-      required: false
       description: |
         Use DIO2 to drive an RF switch selecting between the TX and RX
         paths. When enabled, DIO2 goes high when the chip is
@@ -57,7 +50,6 @@ properties:
 
     dio3-tcxo-voltage:
       type: int
-      required: false
       description: |
         TCXO supply voltage controlled by DIO3 if present.
 
@@ -65,6 +57,5 @@ properties:
 
     tcxo-power-startup-delay-ms:
       type: int
-      required: false
       description: |
         Startup delay to let the TCXO stabilize after TCXO power on.

--- a/dts/bindings/lora/semtech,sx127x-base.yaml
+++ b/dts/bindings/lora/semtech,sx127x-base.yaml
@@ -24,7 +24,6 @@ properties:
 
     power-amplifier-output:
       type: string
-      required: false
       description: |
         Selects power amplifier output pin. This is required when neither
         'rfo-enable-gpios' nor 'pa-boost-enable-gpios' is specified. In other
@@ -35,36 +34,30 @@ properties:
 
     antenna-enable-gpios:
       type: phandle-array
-      required: false
       description: |
         Antenna power enable pin.
 
     rfi-enable-gpios:
       type: phandle-array
-      required: false
       description: |
         RFI antenna input enable pin.
 
     rfo-enable-gpios:
       type: phandle-array
-      required: false
       description: |
         RFO antenna output enable pin.
 
     pa-boost-enable-gpios:
       type: phandle-array
-      required: false
       description: |
         PA_BOOST antenna output enable pin.
 
     tcxo-power-gpios:
       type: phandle-array
-      required: false
       description: |
         TCXO power enable pin.
 
     tcxo-power-startup-delay-ms:
       type: int
-      required: false
       description: |
         Delay which has to be applied after enabling TCXO power.

--- a/dts/bindings/mdio/mdio-controller.yaml
+++ b/dts/bindings/mdio/mdio-controller.yaml
@@ -9,7 +9,6 @@ bus: mdio
 
 properties:
     protocol:
-      required: false
       type: string
       description: |
         MDIO bus framing protocol to use for communication. Most devices

--- a/dts/bindings/memory-controllers/st,stm32-fmc-nor-psram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-fmc-nor-psram.yaml
@@ -171,7 +171,6 @@ child-binding:
 
     st,timing-ext:
       type: array
-      required: false # required when 'EXTMOD' is enabled
       default: [0xF, 0xF, 0xFF, 0xF, 0x0] # reset state
       description: |
         SRAM/NOR-Flash (write) timing register (FMC_BWTRx).

--- a/dts/bindings/memory-controllers/st,stm32h7-fmc.yaml
+++ b/dts/bindings/memory-controllers/st,stm32h7-fmc.yaml
@@ -34,7 +34,6 @@ include: ["st,stm32-fmc.yaml"]
 properties:
     st,mem-swap:
       type: string
-      required: false
       default: "disable" # reset state
       enum:
         - "disable"

--- a/dts/bindings/misc/nuvoton,npcx-booter-variant.yaml
+++ b/dts/bindings/misc/nuvoton,npcx-booter-variant.yaml
@@ -8,7 +8,6 @@ compatible: "nuvoton,npcx-booter-variant"
 properties:
     hif-type-auto:
         type: boolean
-        required: false
         description: |
             The host interface type (LPC/eSPI/SHI) is configured by booter
             if true; otherwise, it should be configured by the firmware.

--- a/dts/bindings/misc/zephyr,flash-disk.yaml
+++ b/dts/bindings/misc/zephyr,flash-disk.yaml
@@ -22,7 +22,6 @@ properties:
 
     sector-size:
       type: int
-      required: false
       default: 512
       description: |
         Emulated block device sector size in bytes.

--- a/dts/bindings/misc/zephyr,modbus-serial.yaml
+++ b/dts/bindings/misc/zephyr,modbus-serial.yaml
@@ -10,7 +10,6 @@ include: uart-device.yaml
 properties:
     de-gpios:
       type: phandle-array
-      required: false
       description: Driver enable pin.
 
         Driver enable pin (DE) of the RS-485 transceiver.
@@ -19,7 +18,6 @@ properties:
 
     re-gpios:
       type: phandle-array
-      required: false
       description: Receiver enable pin.
 
         Receiver enable pin (nRE) of the RS-485 transceiver.

--- a/dts/bindings/mmc/st,stm32-sdmmc.yaml
+++ b/dts/bindings/mmc/st,stm32-sdmmc.yaml
@@ -19,17 +19,14 @@ properties:
 
     cd-gpios:
         type: phandle-array
-        required: false
         description: Card Detect pin
 
     pwr-gpios:
         type: phandle-array
-        required: false
         description: Power pin
 
     bus-width:
         type: int
-        required: false
         default: 1
         description: |
             bus width for SDMMC access, defaults to the minimum necessary

--- a/dts/bindings/modem/quectel,bg9x.yaml
+++ b/dts/bindings/modem/quectel,bg9x.yaml
@@ -18,8 +18,6 @@ properties:
 
     mdm-dtr-gpios:
       type: phandle-array
-      required: false
 
     mdm-wdisable-gpios:
       type: phandle-array
-      required: false

--- a/dts/bindings/modem/swir,hl7800.yaml
+++ b/dts/bindings/modem/swir,hl7800.yaml
@@ -41,7 +41,6 @@ properties:
 
     mdm-gpio2-gpios:
         type: phandle-array
-        required: false
 
     mdm-gpio6-gpios:
         type: phandle-array

--- a/dts/bindings/modem/u-blox,sara-r4.yaml
+++ b/dts/bindings/modem/u-blox,sara-r4.yaml
@@ -14,8 +14,6 @@ properties:
 
     mdm-reset-gpios:
       type: phandle-array
-      required: false
 
     mdm-vint-gpios:
       type: phandle-array
-      required: false

--- a/dts/bindings/modem/wnc,m14a2a.yaml
+++ b/dts/bindings/modem/wnc,m14a2a.yaml
@@ -30,5 +30,4 @@ properties:
 
     mdm-send-ok-gpios:
       type: phandle-array
-      required: false
       description: UART RTS pin if no HW flow control (set to always enabled)

--- a/dts/bindings/mtd/atmel,at2x-base.yaml
+++ b/dts/bindings/mtd/atmel,at2x-base.yaml
@@ -22,7 +22,6 @@ properties:
       description: EEPROM write cycle timeout in milliseconds
     wp-gpios:
       type: phandle-array
-      required: false
       description: |
         GPIO to which the write-protect pin of the chip is connected.
 

--- a/dts/bindings/mtd/atmel,at45.yaml
+++ b/dts/bindings/mtd/atmel,at45.yaml
@@ -35,7 +35,6 @@ properties:
 
   use-udpd:
     type: boolean
-    required: false
     description: |
       When set, the driver will use the Ultra-Deep Power-Down command instead
       of the default Deep Power-Down one to put the chip into low power mode.
@@ -47,7 +46,6 @@ properties:
 
   enter-dpd-delay:
     type: int
-    required: false
     default: 0
     description: |
       Time, in nanoseconds, needed by the chip to enter the Deep Power-Down
@@ -56,7 +54,6 @@ properties:
 
   exit-dpd-delay:
     type: int
-    required: false
     default: 0
     description: |
       Time, in nanoseconds, needed by the chip to exit from the Deep Power-Down
@@ -65,7 +62,6 @@ properties:
 
   reset-gpios:
     type: phandle-array
-    required: false
     description: |
       The RESET pin of AT45 is active low.
       If connected directly the MCU pin should be configured
@@ -73,7 +69,6 @@ properties:
 
   wp-gpios:
     type: phandle-array
-    required: false
     description: |
       The WP pin of AT45 is active low.
       If connected directly the MCU pin should be configured

--- a/dts/bindings/mtd/eeprom-base.yaml
+++ b/dts/bindings/mtd/eeprom-base.yaml
@@ -8,9 +8,7 @@ include: base.yaml
 properties:
     size:
       type: int
-      required: false
       description: Total EEPROM size in bytes
     read-only:
       type: boolean
-      required: false
       description: Disable writes to the EEPROM

--- a/dts/bindings/mtd/fixed-partitions.yaml
+++ b/dts/bindings/mtd/fixed-partitions.yaml
@@ -5,12 +5,10 @@ compatible: "fixed-partitions"
 properties:
     "#address-cells":
         type: int
-        required: false
         description: number of address cells in reg property
 
     "#size-cells":
         type: int
-        required: false
         description: number of size cells in reg property
 
 child-binding:
@@ -18,11 +16,9 @@ child-binding:
     properties:
        label:
           type: string
-          required: false
           description: Human readable string describing the device (used as device_get_binding() argument)
        read-only:
           type: boolean
-          required: false
           description: if the partition is read-only or not
        reg:
           type: array

--- a/dts/bindings/mtd/jedec,jesd216.yaml
+++ b/dts/bindings/mtd/jedec,jesd216.yaml
@@ -20,17 +20,14 @@
 properties:
   jedec-id:
     type: uint8-array
-    required: false
     description: JEDEC ID as manufacturer ID, memory type, memory density
 
   size:
     type: int
-    required: false
     description: flash capacity in bits
 
   sfdp-bfp:
     type: uint8-array
-    required: false
     description: |
       Contains the 32-bit words in little-endian byte order from the
       JESD216 Serial Flash Discoverable Parameters Basic Flash
@@ -48,7 +45,6 @@ properties:
       - "S2B1v4"
       - "S2B1v5"
       - "S2B1v6"
-    required: false
     description: |
       Quad Enable Requirements value from JESD216 BFP DW15.
 
@@ -59,7 +55,6 @@ properties:
 
   enter-4byte-addr:
     type: int
-    required: false
     description: |
       Enter 4-Byte Addressing value from JESD216 BFP DW16
 

--- a/dts/bindings/mtd/jedec,spi-nor-common.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor-common.yaml
@@ -16,7 +16,6 @@ include: "jedec,jesd216.yaml"
 properties:
   requires-ulbpr:
     type: boolean
-    required: false
     description: |
       Indicates the device requires the ULBPR (0x98) command.
 
@@ -27,7 +26,6 @@ properties:
 
   has-dpd:
     type: boolean
-    required: false
     description: |
       Indicates the device supports the DPD (0xB9) command.
 
@@ -40,7 +38,6 @@ properties:
 
   dpd-wakeup-sequence:
     type: array
-    required: false
     description: |
       Specifies wakeup durations for devices without RDPD.
 
@@ -57,7 +54,6 @@ properties:
 
   t-enter-dpd:
     type: int
-    required: false
     description: |
       Duration required to complete the DPD command.
 
@@ -69,7 +65,6 @@ properties:
 
   t-exit-dpd:
     type: int
-    required: false
     description: |
       Duration required to complete the RDPD command.
 
@@ -81,7 +76,6 @@ properties:
 
   has-lock:
     type: int
-    required: false
     description: |
       Bit mask of bits of the status register that should be cleared on
       startup.

--- a/dts/bindings/mtd/jedec,spi-nor.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor.yaml
@@ -14,13 +14,10 @@ include: [spi-device.yaml, "jedec,spi-nor-common.yaml"]
 properties:
   wp-gpios:
     type: phandle-array
-    required: false
     description: WPn pin
   hold-gpios:
     type: phandle-array
-    required: false
     description: HOLDn pin
   reset-gpios:
     type: phandle-array
-    required: false
     description: RESETn pin

--- a/dts/bindings/mtd/nordic,qspi-nor.yaml
+++ b/dts/bindings/mtd/nordic,qspi-nor.yaml
@@ -19,13 +19,11 @@ properties:
 
   size:
     type: int
-    required: false
     description: |
       The size in bits. Set this or size-in-bytes, but not both.
 
   size-in-bytes:
     type: int
-    required: false
     description: |
       The size in bytes. Set this or size, but not both.
 
@@ -35,7 +33,6 @@ properties:
 
   readoc:
     type: string
-    required: false
     enum:
       - "fastread"        # Single data line SPI, FAST_READ (0x0B)
       - "read2o"          # Dual data line SPI, READ2O (0x3B)
@@ -48,7 +45,6 @@ properties:
 
   writeoc:
     type: string
-    required: false
     enum:
       - "pp"            # Single data line SPI, PP (0x02)
       - "pp2o"          # Dual data line SPI, PP2O (0xA2)
@@ -60,21 +56,18 @@ properties:
 
   address-size-32:
     type: boolean
-    required: false
     description: |
       Set to indicate that 32-bit addressing is to be used.
       If not specified 24-bit addressing will be used.
 
   ppsize-512:
     type: boolean
-    required: false
     description: |
       Set to indicate that the write opcode operates on 512-byte pages.
       If not specified the write opcode operates on 256-byte pages.
 
   sck-delay:
     type: int
-    required: false
     default: 0
     description: |
       Number of clock cycles CSn must be asserted before it can go low
@@ -82,21 +75,18 @@ properties:
 
   rx-delay:
     type: int
-    required: false
     description: |
       Number of clock cycles from the rising edge of the SPI clock
       until the input serial data is sampled.
 
   cpha:
     type: boolean
-    required: false
     description: |
       Set to indicate phase starts with asserted half-phase (CPHA=1).
       For this driver using this property requires also using cpol.
 
   cpol:
     type: boolean
-    required: false
     description: |
       Set to indicate clock leading edge is falling (CPOL=1).
       For this driver using this property requires also using cpha.

--- a/dts/bindings/mtd/nxp,imx-flexspi-device.yaml
+++ b/dts/bindings/mtd/nxp,imx-flexspi-device.yaml
@@ -8,7 +8,6 @@ include: [spi-device.yaml, "jedec,jesd216.yaml"]
 properties:
     cs-interval-unit:
       type: int
-      required: false
       default: 1
       enum:
         - 1
@@ -20,7 +19,6 @@ properties:
 
     cs-interval:
       type: int
-      required: false
       default: 0
       description: |
         Minimum interval between chip select deassertion and assertion. See the
@@ -29,7 +27,6 @@ properties:
 
     cs-setup-time:
       type: int
-      required: false
       default: 3
       description: |
         Chip select setup time, in serial clock cycles. See the TCSS field in
@@ -38,7 +35,6 @@ properties:
 
     cs-hold-time:
       type: int
-      required: false
       default: 3
       description: |
         Chip select hold time, in serial clock cycles. See the TCSH field in
@@ -47,7 +43,6 @@ properties:
 
     data-valid-time:
       type: int
-      required: false
       default: 0
       description: |
         Data valid time, in nanoseconds. See the registers DLLACR through
@@ -55,7 +50,6 @@ properties:
 
     column-space:
       type: int
-      required: false
       default: 0
       description: |
         Column address bit width. Set to zero if the flash does not support
@@ -65,7 +59,6 @@ properties:
 
     word-addressable:
       type: boolean
-      required: false
       description: |
         Don't transmit the least significant address bit when the flash is word
         addressable. See the WA field in registers FLASHA1CR0 through
@@ -73,7 +66,6 @@ properties:
 
     ahb-write-wait-unit:
       type: int
-      required: false
       default: 2
       enum:
         - 2
@@ -91,7 +83,6 @@ properties:
 
     ahb-write-wait-interval:
       type: int
-      required: false
       default: 0
       description: |
         Time to wait between AHB triggered command sequences. See the AWRWAIT

--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -8,9 +8,7 @@ properties:
     erase-block-size:
      type: int
      description: address alignment required by flash erase operations
-     required: false
 
     write-block-size:
      type: int
      description: address alignment required by flash write operations
-     required: false

--- a/dts/bindings/mtd/zephyr,emu-eeprom.yaml
+++ b/dts/bindings/mtd/zephyr,emu-eeprom.yaml
@@ -20,11 +20,9 @@ properties:
       description: Flash partition used to store the emulated EEPROM data
     rambuf:
       type: boolean
-      required: false
       description: Enable a ram buffer of EEPROM size for improved read speed
     partition-erase:
       type: boolean
-      required: false
       description: |
         Delay erase until complete partition is used. This enables a
         ram buffer to allow data to be copied during the partition erase. If

--- a/dts/bindings/net/wireless/generic-fem-two-ctrl-pins.yaml
+++ b/dts/bindings/net/wireless/generic-fem-two-ctrl-pins.yaml
@@ -24,13 +24,11 @@ include: base.yaml
 properties:
     ctx-gpios:
         type: phandle-array
-        required: false
         description: |
             SoC GPIO connected to the CTX input pin on the FEM device.
 
     crx-gpios:
         type: phandle-array
-        required: false
         description: |
             SoC GPIO connected to the CRX input pin on the FEM device.
 

--- a/dts/bindings/net/wireless/nordic,nrf-radio.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf-radio.yaml
@@ -136,7 +136,6 @@ properties:
 
     dfe-antenna-num:
       type: int
-      required: false
       description: |
         Number of available antennas for the Direction Finding Extension.
 
@@ -145,7 +144,6 @@ properties:
 
     dfe-pdu-antenna:
       type: int
-      required: false
       description: |
         Antenna switch pattern to be used for transmission of PDU before start
         of transmission of Constant Tone Extension.
@@ -158,7 +156,6 @@ properties:
 
     dfegpio0-gpios:
       type: phandle-array
-      required: false
       description: |
         Pin select for DFE pin 0. This should only be set if dfe-supported
         is true.
@@ -176,43 +173,36 @@ properties:
 
     dfegpio1-gpios:
       type: phandle-array
-      required: false
       description: |
         Pin select for DFE pin 1. See description for dfegpio0-gpios.
 
     dfegpio2-gpios:
       type: phandle-array
-      required: false
       description: |
         Pin select for DFE pin 2. See description for dfegpio0-gpios.
 
     dfegpio3-gpios:
       type: phandle-array
-      required: false
       description: |
         Pin select for DFE pin 3. See description for dfegpio0-gpios.
 
     dfegpio4-gpios:
       type: phandle-array
-      required: false
       description: |
         Pin select for DFE pin 4. See description for dfegpio0-gpios.
 
     dfegpio5-gpios:
       type: phandle-array
-      required: false
       description: |
         Pin select for DFE pin 5. See description for dfegpio0-gpios.
 
     dfegpio6-gpios:
       type: phandle-array
-      required: false
       description: |
         Pin select for DFE pin 6. See description for dfegpio0-gpios.
 
     dfegpio7-gpios:
       type: phandle-array
-      required: false
       description: |
         Pin select for DFE pin 7. See description for dfegpio0-gpios.
 

--- a/dts/bindings/net/wireless/nordic,nrf21540-fem.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf21540-fem.yaml
@@ -69,32 +69,26 @@ include: base.yaml
 properties:
     tx-en-gpios:
         type: phandle-array
-        required: false
         description: |
             GPIO of the SOC controlling TX_EN pin of the nRF21540
     rx-en-gpios:
         type: phandle-array
-        required: false
         description: |
             GPIO of the SOC controlling RX_EN pin of the nRF21540
     pdn-gpios:
         type: phandle-array
-        required: false
         description: |
             GPIO of the SOC controlling PDN pin of the nRF21540
     ant-sel-gpios:
         type: phandle-array
-        required: false
         description: |
             GPIO of the SOC controlling ANT-SEL pin of the nRF21540
     mode-gpios:
         type: phandle-array
-        required: false
         description: |
             GPIO of the SOC controlling MODE pin of the nRF21540
     spi-if:
         type: phandle
-        required: false
         description: |
             Reference to the nordic,nrf21540-fem-spi SPI bus interface.
 
@@ -137,7 +131,6 @@ properties:
             configurations.
     supply-voltage-mv:
         type: int
-        required: false
         description: |
             nRF21540 supply voltage in mV.
 

--- a/dts/bindings/phy/can-transceiver-gpio.yaml
+++ b/dts/bindings/phy/can-transceiver-gpio.yaml
@@ -10,7 +10,6 @@ include: can-transceiver.yaml
 properties:
     enable-gpios:
       type: phandle-array
-      required: false
       description: |
         GPIO to use to enable/disable the CAN transceiver. This GPIO is driven
         active when the CAN transceiver is enabled and inactive when the CAN
@@ -18,7 +17,6 @@ properties:
 
     standby-gpios:
       type: phandle-array
-      required: false
       description: |
         GPIO to use to put the CAN transceiver into standby. This GPIO is driven
         inactive when the CAN transceiver is enabled and active when the CAN

--- a/dts/bindings/pinctrl/gd,gd32-afio.yaml
+++ b/dts/bindings/pinctrl/gd,gd32-afio.yaml
@@ -17,7 +17,6 @@ properties:
     required: true
 
   enable-cps:
-    required: false
     type: boolean
     description: |
       Enable the I/O compensation cell. This option should be enabled when the

--- a/dts/bindings/pinctrl/gd,gd32-pinctrl-af.yaml
+++ b/dts/bindings/pinctrl/gd,gd32-pinctrl-af.yaml
@@ -97,7 +97,6 @@ child-binding:
       The grandchild nodes group pins that share the same pin configuration.
     properties:
       slew-rate:
-        required: false
         type: string
         default: "max-speed-2mhz"
         enum:

--- a/dts/bindings/pinctrl/gd,gd32-pinctrl-afio.yaml
+++ b/dts/bindings/pinctrl/gd,gd32-pinctrl-afio.yaml
@@ -119,7 +119,6 @@ child-binding:
       The grandchild nodes group pins that share the same pin configuration.
     properties:
       slew-rate:
-        required: false
         type: string
         default: "max-speed-2mhz"
         enum:

--- a/dts/bindings/pinctrl/infineon,xmc4xxx-pinctrl.yaml
+++ b/dts/bindings/pinctrl/infineon,xmc4xxx-pinctrl.yaml
@@ -99,7 +99,6 @@ child-binding:
 
         invert-input:
           description: Inverts the input.
-          required: false
           type: boolean
 
         hwctrl:

--- a/dts/bindings/pinctrl/ite,it8xxx2-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ite,it8xxx2-pinctrl.yaml
@@ -83,7 +83,6 @@ child-binding:
               ITE IT8XXX2 pin's configuration (pinctrl node, pin and function).
 
         gpio-voltage:
-          required: false
           type: string
           description: |
               Pin input voltage selection 3.3V or 1.8V. All gpio pins support 3.3V.

--- a/dts/bindings/pinctrl/microchip,xec-pinctrl.yaml
+++ b/dts/bindings/pinctrl/microchip,xec-pinctrl.yaml
@@ -93,7 +93,6 @@ child-binding:
             description: Pinmux selection
 
         slew-rate:
-          required: false
           type: string
           default: "low-speed"
           enum:
@@ -106,7 +105,6 @@ child-binding:
             slew rate adjustment.
 
         drive-strength:
-          required: false
           type: string
           default: "1x"
           enum:

--- a/dts/bindings/pinctrl/nuvoton,npcx-leakage-io.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-leakage-io.yaml
@@ -10,7 +10,6 @@ include: [base.yaml]
 properties:
   leak-gpios:
     type: phandle-array
-    required: false
     description: |
       Array of IOs that have leakage current. The user can overwrite this
       property at the board level DT file to save more power consumption.

--- a/dts/bindings/pinctrl/nuvoton,npcx-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-pinctrl.yaml
@@ -55,11 +55,9 @@ child-binding:
     properties:
       pinmux:
         type: phandle
-        required: false
         description: Configurations of pinmux selection
       periph-pupd:
         type: array
-        required: false
         description: |
           A map to PUPD_ENn register/bit that enable pull-up/down of NPCX peripheral devices.
           Please don't overwrite this property in the board-level DT driver.
@@ -70,21 +68,17 @@ child-binding:
           Please don't overwrite this property in the board-level DT driver.
       psl-polarity:
         type: phandle
-        required: false
         description: |
           A map to DEVALTn that configures detection polarity of PSL input pads.
           Please don't overwrite this property in the board-level DT driver.
       pinmux-locked:
-        required: false
         type: boolean
         description: Lock pinmux selection
       pinmux-gpio:
-        required: false
         type: boolean
         description: Inverse pinmux selection to GPIO
       psl-in-mode:
         type: string
-        required: false
         description: |
           The assertion detection mode of PSL input selection
           - "level": Select the detection mode to level detection
@@ -94,7 +88,6 @@ child-binding:
           - "edge"
       psl-in-pol:
         type: string
-        required: false
         description: |
           The assertion detection polarity of PSL input selection
           - "low-falling": Select the detection polarity to low/falling

--- a/dts/bindings/pinctrl/nxp,imx-iomuxc.yaml
+++ b/dts/bindings/pinctrl/nxp,imx-iomuxc.yaml
@@ -34,7 +34,6 @@ child-binding:
         daisy_val: value to write to input_reg
         cfg_reg: register that will configure pin pull, drive strength, and open drain
     gpr:
-      required: false
       type: array
       description: |
         An array of values defining the GPR bit write required, if one exists.
@@ -50,7 +49,6 @@ child-binding:
     # macro cannot work using preprocessor equality statements (like DT_ENUM_IDX(prop) == val),
     # so we cannot use an enum and instead must use individual properties.
     pin-pue:
-      required: false
       type: boolean
       description: |
           RT11xx parts have multiple types of IOMUXC registers defined, with
@@ -58,7 +56,6 @@ child-binding:
           to the pinctrl driver the type of register this pinmux represents,
           and should not be modified by the user.
     pin-pdrv:
-      required: false
       type: boolean
       description: |
           RT11xx parts have multiple types of IOMUXC registers defined, with
@@ -66,7 +63,6 @@ child-binding:
           to the pinctrl driver the type of register this pinmux represents,
           and should not be modified by the user.
     pin-lpsr:
-      required: false
       type: boolean
       description: |
           RT11xx parts have multiple types of IOMUXC registers defined, with
@@ -74,7 +70,6 @@ child-binding:
           to the pinctrl driver the type of register this pinmux represents,
           and should not be modified by the user.
     pin-snvs:
-      required: false
       type: boolean
       description: |
           RT11xx parts have multiple types of IOMUXC registers defined, with

--- a/dts/bindings/pinctrl/nxp,imx7d-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,imx7d-pinctrl.yaml
@@ -77,7 +77,6 @@ child-binding:
           0 FAST — Fast Frequency Slew Rate
           1 SLOW — Slow Frequency Slew Rate
       bias-pull-up-value:
-        required: false
         type: string
         default: "100k"
         enum:

--- a/dts/bindings/pinctrl/nxp,lpc-iocon-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,lpc-iocon-pinctrl.yaml
@@ -75,7 +75,6 @@ child-binding:
           Pin mux selection for this group. See the SOC level pinctrl header
           file in NXP's HAL for a defined list of these options.
       slew-rate:
-        required: false
         default: "standard"
         type: string
         enum:

--- a/dts/bindings/pinctrl/nxp,mcux-rt-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,mcux-rt-pinctrl.yaml
@@ -99,7 +99,6 @@ child-binding:
           110 DSE_6_R0_6 — 32 Ohm @3.3V, 43 Ohm @1.8V
           111 DSE_7_R0_7 — 26 Ohm @3.3V, 37 Ohm @1.8V
       bias-pull-up-value:
-        required: false
         type: string
         default: "47k"
         enum:
@@ -118,7 +117,6 @@ child-binding:
           11 PUS_2_22K_Ohm_Pull_Up — 22K Ohm Pull Up
 
       bias-pull-down-value:
-        required: false
         type: string
         default: "100k"
         enum:
@@ -139,7 +137,6 @@ child-binding:
           0 SRE_0_Slow_Slew_Rate — Slow Slew Rate
           1 SRE_1_Fast_Slew_Rate — Fast Slew Rate
       nxp,speed:
-        required: false
         type: string
         enum:
           - "50-mhz"

--- a/dts/bindings/pinctrl/nxp,mcux-rt11xx-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,mcux-rt11xx-pinctrl.yaml
@@ -71,7 +71,6 @@ child-binding:
           Pin mux selections for this group. See the soc level iomuxc DTSI file
           for a defined list of these options.
       drive-strength:
-        required: false
         type: string
         enum:
           - "normal"
@@ -81,7 +80,6 @@ child-binding:
           0 (normal) - sets pin to normal drive strength
           1 (high) - sets pin to high drive strength
       slew-rate:
-        required: false
         type: string
         enum:
           - "fast"

--- a/dts/bindings/pinctrl/nxp,s32ze-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,s32ze-pinctrl.yaml
@@ -94,7 +94,6 @@ child-binding:
           encode all the pin muxing information in a 32-bit value.
 
       slew-rate:
-        required: false
         enum: [0, 4, 5, 6, 7]
         default: 4
         description: |

--- a/dts/bindings/pinctrl/pincfg-node-group.yaml
+++ b/dts/bindings/pinctrl/pincfg-node-group.yaml
@@ -23,141 +23,115 @@ child-binding:
 
     properties:
       bias-disable:
-        required: false
         type: boolean
         description: disable any pin bias
 
       bias-high-impedance:
-        required: false
         type: boolean
         description: high impedance mode ("third-state", "floating")
 
       bias-bus-hold:
-        required: false
         type: boolean
         description: latch weakly
 
       bias-pull-up:
-        required: false
         type: boolean
         description: enable pull-up resistor
 
       bias-pull-down:
-        required: false
         type: boolean
         description: enable pull-down resistor
 
       bias-pull-pin-default:
-        required: false
         type: boolean
         description: use pin's default pull state
 
       drive-push-pull:
-        required: false
         type: boolean
         description: drive actively high and low
 
       drive-open-drain:
-        required: false
         type: boolean
         description: drive with open drain (hardware AND)
 
       drive-open-source:
-        required: false
         type: boolean
         description: drive with open source (hardware OR)
 
       drive-strength:
-        required: false
         type: int
         description: maximum sink or source current in mA
 
       drive-strength-microamp:
-        required: false
         type: int
         description: maximum sink or source current in μA
 
       input-enable:
-        required: false
         type: boolean
         description: |
           enable input on pin (no effect on output, such as enabling an input
           buffer)
 
       input-disable:
-        required: false
         type: boolean
         description: |
           disable input on pin (no effect on output, such as disabling an input
           buffer)
 
       input-schmitt-enable:
-        required: false
         type: boolean
         description: enable schmitt-trigger mode
 
       input-schmitt-disable:
-        required: false
         type: boolean
         description: disable schmitt-trigger mode
 
       input-debounce:
-        required: false
         type: int
         description: |
           Takes the debounce time in μsec, as argument or 0 to disable debouncing
 
       power-source:
-        required: false
         type: int
         description: select between different power supplies
 
       low-power-enable:
-        required: false
         type: boolean
         description: enable low power mode
 
       low-power-disable:
-        required: false
         type: boolean
         description: disable low power mode
 
       output-disable:
-        required: false
         type: boolean
         description: disable output on a pin (such as disable an output buffer)
 
       output-enable:
-        required: false
         type: boolean
         description: |
           enable output on a pin without actively driving it (such as enabling
           an output buffer)
 
       output-low:
-        required: false
         type: boolean
         description: set the pin to output mode with low level
 
       output-high:
-        required: false
         type: boolean
         description: set the pin to output mode with high level
 
       sleep-hardware-state:
-        required: false
         type: boolean
         description: |
           indicate this is sleep related state which will be programmed into
           the registers for the sleep state
 
       slew-rate:
-        required: false
         type: int
         description: set the slew rate
 
       skew-delay:
-        required: false
         type: int
         description: |
           This affects the expected clock skew on input pins and the delay

--- a/dts/bindings/pinctrl/pincfg-node.yaml
+++ b/dts/bindings/pinctrl/pincfg-node.yaml
@@ -18,141 +18,115 @@ child-binding:
 
     properties:
       bias-disable:
-        required: false
         type: boolean
         description: disable any pin bias
 
       bias-high-impedance:
-        required: false
         type: boolean
         description: high impedance mode ("third-state", "floating")
 
       bias-bus-hold:
-        required: false
         type: boolean
         description: latch weakly
 
       bias-pull-up:
-        required: false
         type: boolean
         description: enable pull-up resistor
 
       bias-pull-down:
-        required: false
         type: boolean
         description: enable pull-down resistor
 
       bias-pull-pin-default:
-        required: false
         type: boolean
         description: use pin's default pull state
 
       drive-push-pull:
-        required: false
         type: boolean
         description: drive actively high and low
 
       drive-open-drain:
-        required: false
         type: boolean
         description: drive with open drain (hardware AND)
 
       drive-open-source:
-        required: false
         type: boolean
         description: drive with open source (hardware OR)
 
       drive-strength:
-        required: false
         type: int
         description: maximum sink or source current in mA
 
       drive-strength-microamp:
-        required: false
         type: int
         description: maximum sink or source current in μA
 
       input-enable:
-        required: false
         type: boolean
         description: |
           enable input on pin (no effect on output, such as enabling an input
           buffer)
 
       input-disable:
-        required: false
         type: boolean
         description: |
           disable input on pin (no effect on output, such as disabling an input
           buffer)
 
       input-schmitt-enable:
-        required: false
         type: boolean
         description: enable schmitt-trigger mode
 
       input-schmitt-disable:
-        required: false
         type: boolean
         description: disable schmitt-trigger mode
 
       input-debounce:
-        required: false
         type: int
         description: |
           Takes the debounce time in μsec, as argument or 0 to disable debouncing
 
       power-source:
-        required: false
         type: int
         description: select between different power supplies
 
       low-power-enable:
-        required: false
         type: boolean
         description: enable low power mode
 
       low-power-disable:
-        required: false
         type: boolean
         description: disable low power mode
 
       output-disable:
-        required: false
         type: boolean
         description: disable output on a pin (such as disable an output buffer)
 
       output-enable:
-        required: false
         type: boolean
         description: |
           enable output on a pin without actively driving it (such as enabling
           an output buffer)
 
       output-low:
-        required: false
         type: boolean
         description: set the pin to output mode with low level
 
       output-high:
-        required: false
         type: boolean
         description: set the pin to output mode with high level
 
       sleep-hardware-state:
-        required: false
         type: boolean
         description: |
           indicate this is sleep related state which will be programmed into
           the registers for the sleep state
 
       slew-rate:
-        required: false
         type: int
         description: set the slew rate
 
       skew-delay:
-        required: false
         type: int
         description: |
           This affects the expected clock skew on input pins and the delay

--- a/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
@@ -30,19 +30,16 @@ properties:
 
     remap-pa11:
       type: boolean
-      required: false
       description: Remaps the PA11 pin to operate as PA9 pin.
         Use of this property is restricted to STM32G0 SoCs.
 
     remap-pa12:
       type: boolean
-      required: false
       description: Remaps the PA12 pin to operate as PA10 pin.
         Use of this property is restricted to STM32G0 SoCs.
 
     remap-pa11-pa12:
       type: boolean
-      required: false
       description: Remaps the PA11/PA12 pin to operate as PA9/PA10 pin.
         Use of this property is restricted to STM32F070x SoCs.
 
@@ -93,7 +90,6 @@ child-binding:
             };
 
         slew-rate:
-          required: false
           type: string
           default: "low-speed"
           enum:

--- a/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
@@ -30,7 +30,6 @@ properties:
 
     swj-cfg:
         type: string
-        required: false
         default: "full" # reset state
         enum:
           - "full"
@@ -104,7 +103,6 @@ child-binding:
             };
 
         slew-rate:
-          required: false
           type: string
           default: "max-speed-10mhz"
           enum:

--- a/dts/bindings/pinctrl/xlnx,pinctrl-zynq.yaml
+++ b/dts/bindings/pinctrl/xlnx,pinctrl-zynq.yaml
@@ -84,7 +84,6 @@ child-binding:
     properties:
       groups:
         type: string-array
-        required: false
         description: |
           Specify list of pin groups to select for this configuration node.
 
@@ -126,7 +125,6 @@ child-binding:
 
       pins:
         type: string-array
-        required: false
         description: |
           Specify list of pin names to select for this configuration node. Valid pin names are
           "MIO0" to "MIO53".
@@ -136,7 +134,6 @@ child-binding:
 
       function:
         type: string
-        required: false
         enum: ["ethernet0", "ethernet1", "mdio0", "mdio1", "qspi0", "qspi1", "qspi_fbclk",
                "qspi_cs1", "spi0", "spi0_ss", "spi1", "spi1_ss", "sdio0", "sdio0_pc",
                "sdio0_cd", "sdio0_wp", "sdio1", "sdio1_pc", "sdio1_cd", "sdio1_wp",

--- a/dts/bindings/power-domain/power-domain-gpio.yaml
+++ b/dts/bindings/power-domain/power-domain-gpio.yaml
@@ -21,12 +21,10 @@ properties:
 
   startup-delay-us:
     type: int
-    required: false
     default: 0
     description: Startup time, in microseconds
 
   off-on-delay-us:
     type: int
-    required: false
     default: 0
     description: Off delay time, in microseconds

--- a/dts/bindings/power/zephyr,power-state.yaml
+++ b/dts/bindings/power/zephyr,power-state.yaml
@@ -20,17 +20,14 @@ properties:
             - "soft-off"
     substate-id:
         type: int
-        required: false
         description: Platform specific identification.
     min-residency-us:
         type: int
-        required: false
         description: |
             Minimum residency duration in microseconds. It is the minimum time for a
             given idle state to be worthwhile energywise. It includes the time to enter
             in this state.
     exit-latency-us:
         type: int
-        required: false
         description: |
             Worst case latency in microseconds required to exit the idle state.

--- a/dts/bindings/pwm/espressif,esp32-mcpwm.yaml
+++ b/dts/bindings/pwm/espressif,esp32-mcpwm.yaml
@@ -93,21 +93,18 @@ properties:
 
   prescale-timer0:
     type: int
-    required: false
     description: |
       8 bit timer prescale for timer 0.
       Period of PT0_clk = Period of PWM_clk * (PWM_TIMER0_PRESCALE + 1).
 
   prescale-timer1:
     type: int
-    required: false
     description: |
       8 bit timer prescale for timer 1.
       Period of PT1_clk = Period of PWM_clk * (PWM_TIMER1_PRESCALE + 1).
 
   prescale-timer2:
     type: int
-    required: false
     description: |
       8 bit timer prescale for timer 2.
       Period of PT2_clk = Period of PWM_clk * (PWM_TIMER2_PRESCALE + 1).

--- a/dts/bindings/pwm/ite,it8xxx2-pwm.yaml
+++ b/dts/bindings/pwm/ite,it8xxx2-pwm.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    interrupts:
-      required: false
-
     channel:
       type: int
       required: true
@@ -47,7 +44,6 @@ properties:
 
     pwm-output-frequency:
       type: int
-      required: false
       description: PWM output frequency for operation
 
     pinctrl-0:

--- a/dts/bindings/pwm/ite,it8xxx2-pwmprs.yaml
+++ b/dts/bindings/pwm/ite,it8xxx2-pwmprs.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    interrupts:
-      required: false

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -10,13 +10,11 @@ properties:
 
     center-aligned:
       type: boolean
-      required: false
       description: Set this to use center-aligned (up and down) counter mode.
 
     ch0-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -36,7 +34,6 @@ properties:
     ch0-inverted:
       type: boolean
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -48,7 +45,6 @@ properties:
     ch1-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -59,7 +55,6 @@ properties:
     ch1-inverted:
       type: boolean
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -71,7 +66,6 @@ properties:
     ch2-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -82,7 +76,6 @@ properties:
     ch2-inverted:
       type: boolean
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -94,7 +87,6 @@ properties:
     ch3-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -105,7 +97,6 @@ properties:
     ch3-inverted:
       type: boolean
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.

--- a/dts/bindings/pwm/nuvoton,npcx-pwm.yaml
+++ b/dts/bindings/pwm/nuvoton,npcx-pwm.yaml
@@ -22,7 +22,6 @@ properties:
             A index to indicate PWM module that generates a single PWM signal.
             Please don't overwrite it in the board-level DT driver.
     clock-bus:
-        required: false
         type: string
         description: |
             Select a specific input clock source for the PWM module. If this

--- a/dts/bindings/pwm/nxp,sctimer-pwm.yaml
+++ b/dts/bindings/pwm/nxp,sctimer-pwm.yaml
@@ -10,7 +10,6 @@ include: [pwm-controller.yaml, pinctrl-device.yaml, base.yaml]
 properties:
     prescaler:
       type: int
-      required: false
       default: 1
       description: prescaling factor from the SCT clock. Default to 1 which is the reset value
       enum:

--- a/dts/bindings/pwm/raspberrypi,pico-pwm.yaml
+++ b/dts/bindings/pwm/raspberrypi,pico-pwm.yaml
@@ -16,7 +16,6 @@ properties:
 
     divider-int-0:
       type: int
-      required: false
       default: 1
       description: |
         The integral part of the divider for pwm slice 0.
@@ -25,7 +24,6 @@ properties:
 
     divider-frac-0:
       type: int
-      required: false
       default: 0
       description: |
         The fractional part of the divider for pwm slice 0.
@@ -34,85 +32,71 @@ properties:
 
     divider-int-1:
       type: int
-      required: false
       default: 1
       description: See divider-int-0 for help
 
     divider-frac-1:
       type: int
-      required: false
       default: 0
       description: See divider-frac-0 for help
 
     divider-int-2:
       type: int
-      required: false
       default: 1
       description: See divider-int-0 for help
 
     divider-frac-2:
       type: int
-      required: false
       default: 0
       description: See divider-frac-0 for help
 
     divider-int-3:
       type: int
-      required: false
       default: 1
       description: See divider-int-0 for help
 
     divider-frac-3:
       type: int
-      required: false
       default: 0
       description: See divider-frac-0 for help
 
     divider-int-4:
       type: int
-      required: false
       default: 1
       description: See divider-int-0 for help
 
     divider-frac-4:
       type: int
-      required: false
       default: 0
       description: See divider-frac-0 for help
 
     divider-int-5:
       type: int
-      required: false
       default: 1
       description: See divider-int-0 for help
 
     divider-frac-5:
       type: int
-      required: false
       default: 0
       description: See divider-frac-0 for help
 
     divider-int-6:
       type: int
-      required: false
       default: 1
       description: See divider-int-0 for help
 
     divider-frac-6:
       type: int
-      required: false
       default: 0
       description: See divider-frac-0 for help
 
     divider-int-7:
       type: int
-      required: false
       default: 1
       description: See divider-int-0 for help
 
     divider-frac-7:
       type: int
-      required: false
       default: 0
       description: See divider-frac-0 for help
 

--- a/dts/bindings/pwm/silabs,gecko-pwm.yaml
+++ b/dts/bindings/pwm/silabs,gecko-pwm.yaml
@@ -12,7 +12,6 @@ properties:
 
     prescaler:
       type: int
-      required: false
       default: 1
       description: prescaling factor from the HFPERCLK clock
       enum:

--- a/dts/bindings/pwm/telink,b91-pwm.yaml
+++ b/dts/bindings/pwm/telink,b91-pwm.yaml
@@ -21,32 +21,26 @@ properties:
 
     clk32k-ch0-enable:
       type: boolean
-      required: false
       description: Enable 32K Source Clock for PWM Channel 0
 
     clk32k-ch1-enable:
       type: boolean
-      required: false
       description: Enable 32K Source Clock for PWM Channel 1
 
     clk32k-ch2-enable:
       type: boolean
-      required: false
       description: Enable 32K Source Clock for PWM Channel 2
 
     clk32k-ch3-enable:
       type: boolean
-      required: false
       description: Enable 32K Source Clock for PWM Channel 3
 
     clk32k-ch4-enable:
       type: boolean
-      required: false
       description: Enable 32K Source Clock for PWM Channel 4
 
     clk32k-ch5-enable:
       type: boolean
-      required: false
       description: Enable 32K Source Clock for PWM Channel 5
 
     channels:

--- a/dts/bindings/qspi/st,stm32-qspi.yaml
+++ b/dts/bindings/qspi/st,stm32-qspi.yaml
@@ -53,7 +53,6 @@ properties:
 
     flash-id:
       type: int
-      required: false
       description: |
         FLash ID number. This number, if defined, helps to select the right
         QSPI GPIO banks (defined as 'quadspi_bk[12]' in pinctrl property)

--- a/dts/bindings/regulator/nxp,pca9420.yaml
+++ b/dts/bindings/regulator/nxp,pca9420.yaml
@@ -11,14 +11,12 @@ include: base.yaml
 properties:
   regulator-initial-mode:
       type: int
-      required: false
       description: |
         Initial operating mode of the regulator. Regulators modes can be
         used for better power saving, or different voltage configurations,
         and are hardware specific.
   regulator-allowed-modes:
       type: array
-      required: false
       description: |
         Array of operating modes that software may configure for the
         regulator at runtime. The set of possible operating modes depends on
@@ -26,14 +24,12 @@ properties:
 
   modesel-reg:
     type: int
-    required: false
     description: |
       Mode selection register. This register is used by the regulator driver
       to select the target mode of the regulator
 
   modesel-mask:
     type: int
-    required: false
     description: |
       Mode selection mask. Applied to a mode selection when it is written
       to the modesel-reg.
@@ -94,13 +90,11 @@ child-binding:
              Maximum voltage in microvolts that this regulator supports
       enable-inverted:
           type: boolean
-          required: false
           description: |
             If the enable bit should be zero to turn the regulator on, add this
             property.
       current-levels:
           type: array
-          required: false
           description: |
             Array of current limit values in uA, followed by the register value
             that must be written to enable the current limit. For example,
@@ -108,20 +102,17 @@ child-binding:
             to set a current limit of 800mA
       num-current-levels:
           type: int
-          required: false
           default: 0
           description: |
             Number of current limit levels this regulator supports. If left as
             default, regulator current support will be disabled.
       ilim-reg:
           type: int
-          required: false
           description: |
             Register to write the register value given in current-levels into
             to set the current limit
       ilim-mask:
           type: int
-          required: false
           description: |
             Mask to apply to the current-levels value before writing it to the
             ilim-reg value to set the current limit

--- a/dts/bindings/regulator/regulator-fixed.yaml
+++ b/dts/bindings/regulator/regulator-fixed.yaml
@@ -36,12 +36,10 @@ properties:
 
   startup-delay-us:
     type: int
-    required: false
     default: 0
     description: Startup time, in microseconds
 
   off-on-delay-us:
     type: int
-    required: false
     default: 0
     description: Off delay time, in microseconds

--- a/dts/bindings/reserved-memory/memory-region.yaml
+++ b/dts/bindings/reserved-memory/memory-region.yaml
@@ -6,11 +6,9 @@
 
 properties:
     memory-regions:
-      required: false
       type: phandle-array
       description: List of memory region phandles
 
     memory-region-names:
-      required: false
       type: string-array
       description: A list of names, one for each corresponding phandle in memory-region

--- a/dts/bindings/reset/raspberrypi,pico-reset.yaml
+++ b/dts/bindings/reset/raspberrypi,pico-reset.yaml
@@ -12,11 +12,9 @@ properties:
       required: true
     reg-width:
       type: int
-      required: false
       description: The width of the reset registers in bytes. Default is 4 bytes.
     active-low:
       type: int
-      required: false
       description: Set if reset is active low. Default is 0, which means active-high.
     "#reset-cells":
       const: 1

--- a/dts/bindings/reset/reset-device.yaml
+++ b/dts/bindings/reset/reset-device.yaml
@@ -6,10 +6,8 @@ description: This file needs to be included by devices that need a reset control
 properties:
   resets:
     type: phandle-array
-    required: false
     description: Reset information
 
   reset-names:
     type: string-array
-    required: false
     description: Name of each reset

--- a/dts/bindings/riscv/riscv,cpus.yaml
+++ b/dts/bindings/riscv/riscv,cpus.yaml
@@ -6,7 +6,6 @@ include: cpu.yaml
 properties:
   mmu-type:
     description: Memory Management Unit (MMU)
-    required: false
     type: string
     enum:
       - riscv,sv32

--- a/dts/bindings/riscv/sifive-common.yaml
+++ b/dts/bindings/riscv/sifive-common.yaml
@@ -8,5 +8,4 @@ include: riscv,cpus.yaml
 properties:
     hardware-exec-breakpoint-count:
       type: int
-      required: false
       description: Number of hardware break points

--- a/dts/bindings/rng/espressif,esp32-trng.yaml
+++ b/dts/bindings/rng/espressif,esp32-trng.yaml
@@ -14,6 +14,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    interrupts:
-      required: false

--- a/dts/bindings/rng/nxp,css-v2.yaml
+++ b/dts/bindings/rng/nxp,css-v2.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    interrupts:
-      required: false

--- a/dts/bindings/rng/nxp,lpc-rng.yaml
+++ b/dts/bindings/rng/nxp,lpc-rng.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    interrupts:
-      required: false

--- a/dts/bindings/rng/st,stm32-rng.yaml
+++ b/dts/bindings/rng/st,stm32-rng.yaml
@@ -16,7 +16,6 @@ properties:
 
     nist-config:
       type: int
-      required: false
       description: |
            This property is used to configure the RNG_CR for the NIST certification
            The validation conditions are following the refMan
@@ -30,14 +29,12 @@ properties:
 
     health-test-magic:
       type: int
-      required: false
       description: |
            Magic Number to be written to Health Test Configuration Register (HTCR)
            prior to real configuration, if any.
 
     health-test-config:
       type: int
-      required: false
       description: |
            Heath Test Configuration, necessary to have proper RNG behavior,
            when available.

--- a/dts/bindings/rtc/maxim,ds3231.yaml
+++ b/dts/bindings/rtc/maxim,ds3231.yaml
@@ -16,7 +16,6 @@ properties:
 
   32k-gpios:
     type: phandle-array
-    required: false
     description: |
 
       32 KiHz open drain output
@@ -27,7 +26,6 @@ properties:
 
   isw-gpios:
     type: phandle-array
-    required: false
     description: |
 
       interrupt/square wave open drain output

--- a/dts/bindings/rtc/microchip,mcp7940n.yaml
+++ b/dts/bindings/rtc/microchip,mcp7940n.yaml
@@ -16,7 +16,6 @@ properties:
 
   int-gpios:
     type: phandle-array
-    required: false
     description: |
 
       Host input connected to the MCP7940N MFP open drain output pin

--- a/dts/bindings/rtc/nordic,nrf-rtc.yaml
+++ b/dts/bindings/rtc/nordic,nrf-rtc.yaml
@@ -26,7 +26,6 @@ properties:
     ppi-wrap:
       type: boolean
       description: Enable wrapping with PPI
-      required: false
 
    # If enabled then counter based on nRF RTC peripheral supports only maximal
    # top value. That results in code optimizations and availability of one more
@@ -34,4 +33,3 @@ properties:
     fixed-top:
       type: boolean
       description: Enable fixed top value
-      required: false

--- a/dts/bindings/rtc/nxp,kinetis-lptmr.yaml
+++ b/dts/bindings/rtc/nxp,kinetis-lptmr.yaml
@@ -24,10 +24,8 @@ properties:
 
     input-pin:
       type: int
-      required: false
       description: Pulse counter input pin (0 to 3).
 
     active-low:
       type: boolean
-      required: false
       description: Pulse counter input pin is active-low

--- a/dts/bindings/rtc/rtc.yaml
+++ b/dts/bindings/rtc/rtc.yaml
@@ -8,12 +8,10 @@ include: base.yaml
 properties:
     clock-frequency:
       type: int
-      required: false
       description: Clock frequency information for RTC operation
     interrupts:
       required: true
 
     prescaler:
       type: int
-      required: false
       description: RTC frequency equals clock-frequency divided by the prescaler value

--- a/dts/bindings/rtc/xlnx,xps-timer-1.00.a.yaml
+++ b/dts/bindings/rtc/xlnx,xps-timer-1.00.a.yaml
@@ -23,7 +23,6 @@ properties:
 
     xlnx,gen0-assert:
       type: int
-      required: false
       enum:
         - 0
         - 1
@@ -33,7 +32,6 @@ properties:
 
     xlnx,gen1-assert:
       type: int
-      required: false
       enum:
         - 0
         - 1
@@ -52,7 +50,6 @@ properties:
 
     xlnx,trig0-assert:
       type: int
-      required: false
       enum:
         - 0
         - 1
@@ -62,7 +59,6 @@ properties:
 
     xlnx,trig1-assert:
       type: int
-      required: false
       enum:
         - 0
         - 1

--- a/dts/bindings/sdhc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/sdhc/nxp,imx-usdhc.yaml
@@ -13,28 +13,24 @@ properties:
 
   data-timeout:
     type: int
-    required: false
     default: 0xF
     description: |
       Data timeout, as multiple of the SD clock. See DTOCV field of USDHC
 
   read-watermark:
     type: int
-    required: false
     default: 0x80
     description: |
       Number of words used as read watermark level in FIFO queue for USDHC
 
   write-watermark:
     type: int
-    required: false
     default: 0x80
     description: |
       Number of words used as write watermark level in FIFO queue for USDHC
 
   max_current_330:
     type: int
-    required: false
     default: 0
     description: |
       Max drive current in mA at 3.3V. A value of zero indicates no maximum
@@ -44,7 +40,6 @@ properties:
 
   pwr-gpios:
     type: phandle-array
-    required: false
     description: |
       Power pin
       This pin defaults to active high when consumed by the SD card. The
@@ -53,7 +48,6 @@ properties:
 
   cd-gpios:
     type: phandle-array
-    required: false
     description: |
       Detect pin
       This pin defaults to active low when produced by the SD card. The
@@ -62,14 +56,12 @@ properties:
 
   no-1-8-v:
     type: boolean
-    required: false
     description: |
       When the external SD card circuit does not support 1.8V, add this
       property to disable 1.8v card voltage of SD card controller.
 
   detect-dat3:
     type: boolean
-    required: false
     description: |
       Enable the host to detect an SD card via the DAT3 line of the SD card
       connection. Requires the board to define a function to pull DAT3 low or

--- a/dts/bindings/sdhc/nxp,lpc-sdif.yaml
+++ b/dts/bindings/sdhc/nxp,lpc-sdif.yaml
@@ -13,7 +13,6 @@ properties:
 
   data-timeout:
     type: int
-    required: false
     default: 0xFFFFFF
     description: |
       Data timeout, as multiple of the SD clock. See DATA_TIMEOUT field of SDIF.
@@ -21,7 +20,6 @@ properties:
 
   response-timeout:
     type: int
-    required: false
     default: 0xFF
     description: |
       Response timeout, as multiple of the SD clock. See RESPONSE_TIMEOUT field
@@ -29,7 +27,6 @@ properties:
 
   cd-debounce-clocks:
     type: int
-    required: false
     default: 0xFFFFFF
     description: |
       Number of SD host clocks to use as a chip detect debounce filter. See

--- a/dts/bindings/sdhc/sdhc.yaml
+++ b/dts/bindings/sdhc/sdhc.yaml
@@ -10,7 +10,6 @@ bus: sd
 properties:
   max-current-330:
     type: int
-    required: false
     default: 0
     description: |
       Max drive current in mA at 3.3V. A value of zero indicates no maximum
@@ -18,7 +17,6 @@ properties:
 
   max-current-300:
     type: int
-    required: false
     default: 0
     description: |
       Max drive current in mA at 3.0V. A value of zero indicates no maximum
@@ -26,7 +24,6 @@ properties:
 
   max-current-180:
     type: int
-    required: false
     default: 0
     description: |
       Max drive current in mA at 1.8V. A value of zero indicates no maximum
@@ -34,7 +31,6 @@ properties:
 
   max-bus-freq:
     type: int
-    required: false
     default: 400000
     description: |
       Maximum bus frequency for SD card. This should be the highest frequency
@@ -42,7 +38,6 @@ properties:
 
   min-bus-freq:
     type: int
-    required: false
     default: 400000
     description: |
       Minimum bus frequency for SD card. This should be the frequency that
@@ -50,7 +45,6 @@ properties:
 
   power-delay-ms:
     type: int
-    required: false
     default: 500
     description: |
       time in ms for SDHC to delay when toggling power to the SD card. This

--- a/dts/bindings/sensor/adi,adt7420.yaml
+++ b/dts/bindings/sensor/adi,adt7420.yaml
@@ -10,7 +10,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false
       description: |
         The INT signal defaults to active low open drain, so requires a
         pull-up on the board or in the flags cell of this entry.

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -10,7 +10,6 @@ include: [sensor-device.yaml, spi-device.yaml]
 properties:
     int1-gpios:
       type: phandle-array
-      required: false
       description: |
         The INT1 signal defaults to active high as produced by the
         sensor.  The property value should ensure the flags properly

--- a/dts/bindings/sensor/adi,adxl372-common.yaml
+++ b/dts/bindings/sensor/adi,adxl372-common.yaml
@@ -6,7 +6,6 @@ include: sensor-device.yaml
 properties:
     odr:
       type: int
-      required: false
       default: 0
       description: |
             Accelerometer sampling frequency (ODR). Default is power on reset value.
@@ -24,7 +23,6 @@ properties:
 
     bw:
       type: int
-      required: false
       default: 12
       description: |
             Low-Pass (Antialiasing) Filter corner frequency. Default is power on reset value.
@@ -44,7 +42,6 @@ properties:
 
     hpf:
       type: int
-      required: false
       default: 4
       description: |
             High-Pass Filter corner frequency. Default is power on reset value.

--- a/dts/bindings/sensor/adi,adxl372-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl372-i2c.yaml
@@ -10,7 +10,6 @@ include: ["i2c-device.yaml", "adi,adxl372-common.yaml"]
 properties:
     int1-gpios:
       type: phandle-array
-      required: false
       description: |
         The INT1 signal defaults to active high as produced by the
         sensor.  The property value should ensure the flags properly

--- a/dts/bindings/sensor/adi,adxl372-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl372-spi.yaml
@@ -11,7 +11,6 @@ include: ["spi-device.yaml", "adi,adxl372-common.yaml"]
 properties:
     int1-gpios:
       type: phandle-array
-      required: false
       description: |
         The INT1 signal defaults to active high as produced by the
         sensor.  The property value should ensure the flags properly

--- a/dts/bindings/sensor/ams,as6212.yaml
+++ b/dts/bindings/sensor/ams,as6212.yaml
@@ -12,7 +12,6 @@ include: i2c-device.yaml
 properties:
     alert-gpios:
       type: phandle-array
-      required: false
       description: |
         Identifies the ALERT signal, which is active-low open drain when
         produced by the sensor.

--- a/dts/bindings/sensor/ams,ccs811.yaml
+++ b/dts/bindings/sensor/ams,ccs811.yaml
@@ -10,21 +10,18 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     wake-gpios:
       type: phandle-array
-      required: false
       description: |
         The WAKEn pin is asserted to communicate with the sensor.  The
         sensor receives this as an active-low signal.
 
     reset-gpios:
       type: phandle-array
-      required: false
       description: |
         The RESETn pin is asserted to disable the sensor causing a hard
         reset.  The sensor receives this as an active-low signal.
 
     irq-gpios:
       type: phandle-array
-      required: false
       description: |
         The INTn pin signals that a new reading is available.  The
         sensor generates an active-low level signal which remains

--- a/dts/bindings/sensor/bosch,bma280.yaml
+++ b/dts/bindings/sensor/bosch,bma280.yaml
@@ -12,14 +12,12 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
   int1-gpios:
     type: phandle-array
-    required: false
     description: |
       Identifies pin for the INT1 signal on the sensor.  The sensor
       INT2 signal is not supported by the driver.
 
   is-bmc150:
     type: boolean
-    required: false
     description: |
       Specifies that the driver should adapt to the accelerometer
       capability provided by the BMC150 6-axis eCompass.  This affects

--- a/dts/bindings/sensor/bosch,bmc150_magn.yaml
+++ b/dts/bindings/sensor/bosch,bmc150_magn.yaml
@@ -12,4 +12,3 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     drdy-gpios:
       type: phandle-array
-      required: false

--- a/dts/bindings/sensor/bosch,bmg160.yaml
+++ b/dts/bindings/sensor/bosch,bmg160.yaml
@@ -12,4 +12,3 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false

--- a/dts/bindings/sensor/bosch,bmi160.yaml
+++ b/dts/bindings/sensor/bosch,bmi160.yaml
@@ -8,7 +8,6 @@ include: sensor-device.yaml
 properties:
     int-gpios:
       type: phandle-array
-      required: false
       description: |
         This property specifies the connection for INT1, because the
         Zephyr driver maps all interrupts to INT1.  The signal defaults

--- a/dts/bindings/sensor/bosch,bmp388.yaml
+++ b/dts/bindings/sensor/bosch,bmp388.yaml
@@ -8,11 +8,9 @@ include: sensor-device.yaml
 properties:
     int-gpios:
       type: phandle-array
-      required: false
 
     odr:
       type: string
-      required: false
       description: |
         Default output data rate in Hz. Only the following values are allowed:
           200   - 200     - 5ms  (default; chip reset value)
@@ -54,7 +52,6 @@ properties:
 
     osr-press:
       type: int
-      required: false
       description: |
         Default pressure oversampling rate. Only the following values are
         allowed:
@@ -75,7 +72,6 @@ properties:
 
     osr-temp:
       type: int
-      required: false
       description: |
         Default temperature oversampling rate. Only the following values are
         allowed:
@@ -96,7 +92,6 @@ properties:
 
     iir-filter:
       type: int
-      required: false
       description: |
         Default IIR filter coefficient. The default 0 is the chip reset value.
       default: 0

--- a/dts/bindings/sensor/espressif,esp32-pcnt.yaml
+++ b/dts/bindings/sensor/espressif,esp32-pcnt.yaml
@@ -92,7 +92,6 @@ child-binding:
 
     filter:
       type: int
-      required: false
       description: Pulse length (ns) to be ignored
 
   child-binding:
@@ -110,7 +109,6 @@ child-binding:
 
       sig-pos-mode:
         type: int
-        required: false
         enum:
         - 0
         - 1
@@ -124,7 +122,6 @@ child-binding:
 
       sig-neg-mode:
         type: int
-        required: false
         enum:
         - 0
         - 1
@@ -138,7 +135,6 @@ child-binding:
 
       ctrl-h-mode:
         type: int
-        required: false
         enum:
         - 0
         - 1
@@ -152,7 +148,6 @@ child-binding:
 
       ctrl-l-mode:
         type: int
-        required: false
         enum:
         - 0
         - 1

--- a/dts/bindings/sensor/honeywell,hmc5883l.yaml
+++ b/dts/bindings/sensor/honeywell,hmc5883l.yaml
@@ -10,7 +10,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false
       description: DRDY pin
 
         This pin is active low, with an internal pullup in the sensor.

--- a/dts/bindings/sensor/invensense,icm42605.yaml
+++ b/dts/bindings/sensor/invensense,icm42605.yaml
@@ -19,7 +19,6 @@ properties:
 
     accel-hz:
       type: int
-      required: false
       default: 12
       description: |
         Default frequency of accelerometer. (Unit - Hz)
@@ -41,7 +40,6 @@ properties:
 
     gyro-hz:
       type: int
-      required: false
       default: 12
       description: |
         Default frequency of gyroscope. (Unit - Hz)
@@ -60,7 +58,6 @@ properties:
 
     accel-fs:
       type: int
-      required: false
       default: 16
       description: |
         Default full scale of accelerometer. (Unit - g)
@@ -73,7 +70,6 @@ properties:
 
     gyro-fs:
       type: int
-      required: false
       default: 2000
       description: |
         Default full scale of gyroscope. (Unit - DPS)

--- a/dts/bindings/sensor/invensense,mpu6050.yaml
+++ b/dts/bindings/sensor/invensense,mpu6050.yaml
@@ -12,7 +12,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false
       description: |
         The INT signal default configuration is active-high.  The
         property value should ensure the flags properly describe the

--- a/dts/bindings/sensor/invensense,mpu9250.yaml
+++ b/dts/bindings/sensor/invensense,mpu9250.yaml
@@ -12,7 +12,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     irq-gpios:
       type: phandle-array
-      required: false
       description: |
         The INT signal default configuration is active-high.  The
         property value should ensure the flags properly describe the

--- a/dts/bindings/sensor/isil,isl29035.yaml
+++ b/dts/bindings/sensor/isil,isl29035.yaml
@@ -12,7 +12,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false
       description: |
         The INT pin defaults to active low when produced by the sensor.
         The property value should ensure the flags properly describe the

--- a/dts/bindings/sensor/lm77.yaml
+++ b/dts/bindings/sensor/lm77.yaml
@@ -11,7 +11,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false
       description: |
         Identifies the INT signal, which is active-low open drain by default
         when produced by the sensor.

--- a/dts/bindings/sensor/maxim,max44009.yaml
+++ b/dts/bindings/sensor/maxim,max44009.yaml
@@ -12,4 +12,3 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false

--- a/dts/bindings/sensor/microchip,mcp9808.yaml
+++ b/dts/bindings/sensor/microchip,mcp9808.yaml
@@ -12,7 +12,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false
       description: |
         The alert pin defaults to active low when produced by the
         sensor, and is open-drain.  A pull-up may be appropriate.  The
@@ -21,7 +20,6 @@ properties:
 
     resolution:
       type: int
-      required: false
       default: 3
       description: |
         Sensor resolution. Default is 0.0625C (0b11),

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -17,7 +17,6 @@ properties:
     a-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -37,7 +36,6 @@ properties:
     b-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -48,7 +46,6 @@ properties:
     led-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -58,7 +55,6 @@ properties:
 
     enable-pin:
       type: int
-      required: false
       description: |
         The enable pin to use, to enable a connected QDEC device. The
         pin numbering scheme is the same as the a-pin property's.

--- a/dts/bindings/sensor/nuvoton,adc-cmp.yaml
+++ b/dts/bindings/sensor/nuvoton,adc-cmp.yaml
@@ -17,13 +17,11 @@ properties:
 
     threshold-mv:
       type: int
-      required: false
       description: |
         Value in millivolts present on ADC data as threshold assert.
 
     comparison:
       type: string
-      required: false
       description: |
         Determines the condition to be met between ADC data and
         threshold assert value that will trigger comparator event.

--- a/dts/bindings/sensor/nxp,fxas21002-common.yaml
+++ b/dts/bindings/sensor/nxp,fxas21002-common.yaml
@@ -8,7 +8,6 @@ include: sensor-device.yaml
 properties:
     reset-gpios:
       type: phandle-array
-      required: false
       description: |
         RST pin
         This pin defaults to active low when consumed by the sensor.
@@ -17,7 +16,6 @@ properties:
 
     int1-gpios:
       type: phandle-array
-      required: false
       description: |
         INT1 pin
         This pin defaults to active low when produced by the sensor.
@@ -26,7 +24,6 @@ properties:
 
     int2-gpios:
       type: phandle-array
-      required: false
       description: |
         INT2 pin
         This pin defaults to active low when produced by the sensor.

--- a/dts/bindings/sensor/nxp,fxos8700-common.yaml
+++ b/dts/bindings/sensor/nxp,fxos8700-common.yaml
@@ -8,7 +8,6 @@ include: sensor-device.yaml
 properties:
     reset-gpios:
       type: phandle-array
-      required: false
       description: |
         RST pin
         This pin defaults to active high when consumed by the sensor.
@@ -17,7 +16,6 @@ properties:
 
     int1-gpios:
       type: phandle-array
-      required: false
       description: |
         INT1 pin
         This pin defaults to active low when produced by the sensor.
@@ -26,7 +24,6 @@ properties:
 
     int2-gpios:
       type: phandle-array
-      required: false
       description: |
         INT2 pin
         This pin defaults to active low when produced by the sensor.
@@ -35,7 +32,6 @@ properties:
 
     range:
       type: int
-      required: false
       default: 8
       description: Range in g
       enum:
@@ -45,7 +41,6 @@ properties:
 
     power-mode:
       type: int
-      required: false
       default: 0
       description: Power mode
       enum:
@@ -56,13 +51,11 @@ properties:
 
     pulse-cfg:
       type: int
-      required: false
       default: 0x3f
       description: Pulse configuration register
 
     pulse-thsx:
       type: int
-      required: false
       default: 0x20
       description: |
         Pulse X-axis threshold
@@ -73,7 +66,6 @@ properties:
 
     pulse-thsy:
       type: int
-      required: false
       default: 0x20
       description: |
         Pulse Y-axis threshold
@@ -84,7 +76,6 @@ properties:
 
     pulse-thsz:
       type: int
-      required: false
       default: 0x40
       description: |
         Pulse Z-axis threshold
@@ -95,7 +86,6 @@ properties:
 
     pulse-tmlt:
       type: int
-      required: false
       default: 0x18
       description: |
         Pulse time limit
@@ -108,7 +98,6 @@ properties:
 
     pulse-ltcy:
       type: int
-      required: false
       default: 0x28
       description: |
         Pulse latency
@@ -120,7 +109,6 @@ properties:
 
     pulse-wind:
       type: int
-      required: false
       default: 0x3c
       description: |
         Pulse window
@@ -136,13 +124,11 @@ properties:
 
     mag-vecm-cfg:
       type: int
-      required: false
       default: 0x4e
       description: Magnetic vector-magnitude configuration register
 
     mag-vecm-ths-msb:
       type: int
-      required: false
       default: 0x00
       description: |
         Magnetic vector-magnitude threshold most significant byte.
@@ -150,7 +136,6 @@ properties:
 
     mag-vecm-ths-lsb:
       type: int
-      required: false
       default: 0x5a
       description: |
         Magnetic vector-magnitude threshold least significant byte.

--- a/dts/bindings/sensor/nxp,kinetis-acmp.yaml
+++ b/dts/bindings/sensor/nxp,kinetis-acmp.yaml
@@ -16,43 +16,36 @@ properties:
 
     nxp,enable-output-pin:
       type: boolean
-      required: false
       description: |
         Make the comparator output (CMP0) available on a packaged pin.
 
     nxp,use-unfiltered-output:
       type: boolean
-      required: false
       description: |
         Use the unfiltered comparator output for CMP0.
 
     nxp,high-speed-mode:
       type: boolean
-      required: false
       description: |
         Enable high speed comparison mode.
 
     nxp,enable-sample:
       type: boolean
-      required: false
       description: |
         Enable external sample signal as clock input.
 
     nxp,filter-count:
       type: int
-      required: false
       description: |
         Filter sample count (0 to 7).
 
     nxp,filter-period:
       type: int
-      required: false
       description: |
         Filter sample period in bus clock cycles (0 to 255).
 
     nxp,window-mode:
       type: boolean
-      required: false
       description: |
         Enable windowing mode.
 

--- a/dts/bindings/sensor/semtech,sx9500.yaml
+++ b/dts/bindings/sensor/semtech,sx9500.yaml
@@ -12,7 +12,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false
       description: |
         Connection for the NIRQ signal.  This signal is active-low when
         produced by the sensor.

--- a/dts/bindings/sensor/sensirion,sht3xd.yaml
+++ b/dts/bindings/sensor/sensirion,sht3xd.yaml
@@ -10,7 +10,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     alert-gpios:
       type: phandle-array
-      required: false
       description: |
         ALERT pin.
 

--- a/dts/bindings/sensor/sensirion,shtcx.yaml
+++ b/dts/bindings/sensor/sensirion,shtcx.yaml
@@ -31,7 +31,6 @@ properties:
 
   clock-stretching:
     type: boolean
-    required: false
     description: |
       Specifies that the driver should clock stretching i2c communication to
       read the sensor values.

--- a/dts/bindings/sensor/st,hts221-common.yaml
+++ b/dts/bindings/sensor/st,hts221-common.yaml
@@ -6,7 +6,6 @@ include: sensor-device.yaml
 properties:
     drdy-gpios:
       type: phandle-array
-      required: false
       description: DRDY pin
 
         This pin defaults to active high when produced by the sensor.

--- a/dts/bindings/sensor/st,iis2dh-i2c.yaml
+++ b/dts/bindings/sensor/st,iis2dh-i2c.yaml
@@ -11,7 +11,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     drdy-gpios:
       type: phandle-array
-      required: false
       description: DRDY pin
 
         This pin defaults to active high when produced by the sensor.

--- a/dts/bindings/sensor/st,iis2dh-spi.yaml
+++ b/dts/bindings/sensor/st,iis2dh-spi.yaml
@@ -11,7 +11,6 @@ include: [sensor-device.yaml, spi-device.yaml]
 properties:
     drdy-gpios:
       type: phandle-array
-      required: false
       description: DRDY pin
 
         This pin defaults to active high when produced by the sensor.

--- a/dts/bindings/sensor/st,iis2dlpc-common.yaml
+++ b/dts/bindings/sensor/st,iis2dlpc-common.yaml
@@ -6,7 +6,6 @@ include: sensor-device.yaml
 properties:
     drdy-gpios:
       type: phandle-array
-      required: false
       description: |
         DRDY pin
 
@@ -16,7 +15,6 @@ properties:
 
     drdy-int:
       type: int
-      required: false
       default: 1
       enum:
         - 1 # drdy is generated from INT1
@@ -30,7 +28,6 @@ properties:
 
     range:
       type: int
-      required: false
       default: 2
       description: Range in g. Default is power-up configuration.
       enum:
@@ -41,7 +38,6 @@ properties:
 
     power-mode:
       type: int
-      required: false
       default: 0
       description: Specify the sensor power mode. Default is power-up configuration.
       enum:
@@ -57,7 +53,6 @@ properties:
 
     tap-mode:
       type: int
-      required: false
       default: 0
       description: Tap mode. Default is power-up configuration.
       enum:
@@ -66,7 +61,6 @@ properties:
 
     tap-threshold:
       type: array
-      required: false
       default: [0, 0, 0]
       description: |
         Tap X/Y/Z axes threshold. Default is power-up configuration.
@@ -86,7 +80,6 @@ properties:
 
     tap-shock:
       type: int
-      required: false
       default: 0x0
       description: |
         Tap shock value. Default is power-up configuration.
@@ -97,7 +90,6 @@ properties:
 
     tap-latency:
       type: int
-      required: false
       default: 0x0
       description: |
         Tap latency. Default is power-up configuration.
@@ -108,7 +100,6 @@ properties:
 
     tap-quiet:
       type: int
-      required: false
       default: 0x0
       description: |
         Expected quiet time after a tap detection. Default is power-up configuration.

--- a/dts/bindings/sensor/st,iis2iclx-common.yaml
+++ b/dts/bindings/sensor/st,iis2iclx-common.yaml
@@ -6,7 +6,6 @@ include: sensor-device.yaml
 properties:
     drdy-gpios:
       type: phandle-array
-      required: false
       description: DRDY pin
 
         This pin defaults to active high when produced by the sensor.
@@ -15,7 +14,6 @@ properties:
 
     int-pin:
       type: int
-      required: false
       default: 1
       enum:
         - 1 # drdy is generated from INT1
@@ -29,7 +27,6 @@ properties:
 
     range:
       type: int
-      required: false
       default: 3
       description: Range in g. Default is power-up configuration.
       enum:
@@ -40,7 +37,6 @@ properties:
 
     odr:
       type: int
-      required: false
       default: 0
       description:
           Specify the default accelerometer output data rate expressed in samples per second (Hz).

--- a/dts/bindings/sensor/st,iis2mdc-i2c.yaml
+++ b/dts/bindings/sensor/st,iis2mdc-i2c.yaml
@@ -11,7 +11,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     drdy-gpios:
       type: phandle-array
-      required: false
       description: DRDY pin
 
         This pin defaults to active high when produced by the sensor.

--- a/dts/bindings/sensor/st,iis2mdc-spi.yaml
+++ b/dts/bindings/sensor/st,iis2mdc-spi.yaml
@@ -11,7 +11,6 @@ include: [sensor-device.yaml, spi-device.yaml]
 properties:
     drdy-gpios:
       type: phandle-array
-      required: false
       description: DRDY pin
 
         This pin defaults to active high when produced by the sensor.

--- a/dts/bindings/sensor/st,iis3dhhc-spi.yaml
+++ b/dts/bindings/sensor/st,iis3dhhc-spi.yaml
@@ -11,7 +11,6 @@ include: [sensor-device.yaml, spi-device.yaml]
 properties:
     irq-gpios:
       type: phandle-array
-      required: false
       description: DRDY pin
 
         This pin defaults to active high when produced by the sensor.

--- a/dts/bindings/sensor/st,ism330dhcx-common.yaml
+++ b/dts/bindings/sensor/st,ism330dhcx-common.yaml
@@ -6,7 +6,6 @@ include: sensor-device.yaml
 properties:
     drdy-gpios:
       type: phandle-array
-      required: false
       description: |
         DRDY gpio pin
 
@@ -16,7 +15,6 @@ properties:
 
     int-pin:
       type: int
-      required: false
       default: 1
       description: |
         Select DRDY pin number (1 or 2).
@@ -35,7 +33,6 @@ properties:
 
     accel-odr:
       type: int
-      required: false
       default: 0
       description: |
         Specify the default accelerometer output data rate expressed in samples per second (Hz).
@@ -68,7 +65,6 @@ properties:
 
     accel-range:
       type: int
-      required: false
       default: 2
       description: |
         Range in g. Default is power-up configuration.
@@ -86,7 +82,6 @@ properties:
 
     gyro-odr:
       type: int
-      required: false
       default: 0
       description: |
         Specify the default gyro output data rate expressed in samples per second (Hz).
@@ -119,7 +114,6 @@ properties:
 
     gyro-range:
       type: int
-      required: false
       default: 125
       description: |
         Range in dps. Default is power-up configuration.

--- a/dts/bindings/sensor/st,lis2dh-common.yaml
+++ b/dts/bindings/sensor/st,lis2dh-common.yaml
@@ -6,7 +6,6 @@ include: sensor-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: false
       description: |
         The INT1 and (optional) INT2 signal connections.  These signals
         are active-high as produced by the sensor.
@@ -33,7 +32,6 @@ properties:
 
     anym-mode:
       type: int
-      required: false
       default: 0
       description: |
         Select the interrupt mode for any movement.

--- a/dts/bindings/sensor/st,lis2ds12-common.yaml
+++ b/dts/bindings/sensor/st,lis2ds12-common.yaml
@@ -6,7 +6,6 @@ include: sensor-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: false
       description: |
         DRDY pin
 
@@ -16,7 +15,6 @@ properties:
 
     range:
       type: int
-      required: false
       default: 2
       description: |
         Range in g. Default is power-up configuration.
@@ -29,7 +27,6 @@ properties:
 
     power-mode:
       type: int
-      required: false
       default: 0
       description: |
         Specify the sensor power mode. Default is power-down mode
@@ -42,7 +39,6 @@ properties:
 
     odr:
       type: int
-      required: false
       default: 0
       description: |
           Specify the default output data rate expressed in samples per second (Hz).

--- a/dts/bindings/sensor/st,lis2dw12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-common.yaml
@@ -6,7 +6,6 @@ include: sensor-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: false
       description: |
         DRDY pin
 
@@ -16,7 +15,6 @@ properties:
 
     int-pin:
       type: int
-      required: false
       default: 1
       enum:
         - 1
@@ -34,7 +32,6 @@ properties:
 
     range:
       type: int
-      required: false
       default: 2
       description: |
         Range in g. Default is power-up configuration.
@@ -52,7 +49,6 @@ properties:
 
     odr:
       type: int
-      required: false
       description: |
         Output data rate in Hz. Default value is 12.5Hz if this is not set.
         The output data rates which are represented with fractional
@@ -74,7 +70,6 @@ properties:
 
     bw-filt:
       type: int
-      required: false
       default: 0
       description: |
         Digital filtering cutoff bandwidth. Default is power-up configuration.
@@ -92,7 +87,6 @@ properties:
 
     power-mode:
       type: int
-      required: false
       default: 0
       description: |
         Specify the sensor power mode. Default is power-up configuration.
@@ -116,7 +110,6 @@ properties:
 
     tap-mode:
       type: int
-      required: false
       default: 0
       description: |
         Tap mode. Default is power-up configuration.
@@ -130,7 +123,6 @@ properties:
 
     tap-threshold:
       type: array
-      required: false
       default: [0, 0, 0]
       description: |
         Tap X/Y/Z axes threshold. Default is power-up configuration.
@@ -150,7 +142,6 @@ properties:
 
     tap-shock:
       type: int
-      required: false
       default: 0x0
       description: |
         Tap shock value. Default is power-up configuration.
@@ -161,7 +152,6 @@ properties:
 
     tap-latency:
       type: int
-      required: false
       default: 0x0
       description: |
         Tap latency. Default is power-up configuration.
@@ -172,7 +162,6 @@ properties:
 
     tap-quiet:
       type: int
-      required: false
       default: 0x0
       description: |
         Expected quiet time after a tap detection. Default is power-up configuration.
@@ -219,7 +208,6 @@ properties:
     ff-duration:
       type: int
       default: 30
-      required: false
       description: |
         The freefall duration value represented in milliseconds.
         If the accelerometer readings of the all axes are lower
@@ -234,7 +222,6 @@ properties:
     ff-threshold:
       type: int
       default: 3
-      required: false
       description: |
         The freefall threshold value represented in mg.
         If the accelerometer readings of the all axes are lower

--- a/dts/bindings/sensor/st,lis2mdl-common.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-common.yaml
@@ -6,7 +6,6 @@ include: sensor-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: false
       description: IRQ pin
 
         This pin defaults to active high when produced by the sensor.

--- a/dts/bindings/sensor/st,lis3mdl-magn.yaml
+++ b/dts/bindings/sensor/st,lis3mdl-magn.yaml
@@ -9,7 +9,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
     irq-gpios:
-      required: false
       type: phandle-array
       description: DRDY pin
 

--- a/dts/bindings/sensor/st,lps22hh-common.yaml
+++ b/dts/bindings/sensor/st,lps22hh-common.yaml
@@ -6,7 +6,6 @@ include: sensor-device.yaml
 properties:
     drdy-gpios:
       type: phandle-array
-      required: false
       description: |
         DRDY pin
 
@@ -16,7 +15,6 @@ properties:
 
     odr:
       type: int
-      required: false
       default: 0
       description: |
           Specify the default output data rate expressed in samples per second (Hz).

--- a/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-i2c.yaml
@@ -11,4 +11,3 @@ properties:
     irq-gpios:
       # This signal is active high when produced by the sensor
       type: phandle-array
-      required: false

--- a/dts/bindings/sensor/st,lsm6dsl-spi.yaml
+++ b/dts/bindings/sensor/st,lsm6dsl-spi.yaml
@@ -13,4 +13,3 @@ properties:
     irq-gpios:
       # This signal is active high when produced by the sensor
       type: phandle-array
-      required: false

--- a/dts/bindings/sensor/st,lsm6dso-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-common.yaml
@@ -6,7 +6,6 @@ include: sensor-device.yaml
 properties:
     irq-gpios:
       type: phandle-array
-      required: false
       description: |
         DRDY pin
 
@@ -16,7 +15,6 @@ properties:
 
     int-pin:
       type: int
-      required: false
       default: 1
       enum:
         - 1 # drdy is generated from INT1
@@ -31,7 +29,6 @@ properties:
 
     accel-pm:
       type: int
-      required: false
       default: 0
       description: |
         Specify the accelerometer power mode.
@@ -43,7 +40,6 @@ properties:
 
     accel-range:
       type: int
-      required: false
       default: 0
       description: |
         Range in g. Default is power-up configuration.
@@ -55,7 +51,6 @@ properties:
 
     accel-odr:
       type: int
-      required: false
       default: 0
       description: |
         Specify the default accelerometer output data rate expressed in samples per second (Hz).
@@ -75,7 +70,6 @@ properties:
 
     gyro-pm:
       type: int
-      required: false
       default: 0
       description: |
         Specify the gyrometer power mode.
@@ -86,7 +80,6 @@ properties:
 
     gyro-range:
       type: int
-      required: false
       default: 0
       description: |
         Range in dps. Default is power-up configuration.
@@ -99,7 +92,6 @@ properties:
 
     gyro-odr:
       type: int
-      required: false
       default: 0
       description: |
         Specify the default gyro output data rate expressed in samples per second (Hz).

--- a/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-gyro-i2c.yaml
@@ -10,4 +10,3 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     irq-gpios:
       type: phandle-array
-      required: false

--- a/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
+++ b/dts/bindings/sensor/st,lsm9ds0-mfd-i2c.yaml
@@ -10,4 +10,3 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     irq-gpios:
       type: phandle-array
-      required: false

--- a/dts/bindings/sensor/st,stm32-qdec.yaml
+++ b/dts/bindings/sensor/st,stm32-qdec.yaml
@@ -18,12 +18,10 @@ properties:
 
      st,input-polarity-inverted:
        type: boolean
-       required: false
        description: Encoder is triggered by a falling edge on the input pin
 
      st,input-filter-level:
        type: int
-       required: false
        description: |
          Intensity of the filter applied to the input signal. This is
          implemented by scaling the sampling frequency and adding a counter

--- a/dts/bindings/sensor/st,stm32-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-cal.yaml
@@ -41,7 +41,6 @@ properties:
 
     ts-cal-resolution:
       type: int
-      required: false
       description: |
         Temperature calibration resolution with which the ts-cal1-temp and
         ts-cal2-temp are measured.

--- a/dts/bindings/sensor/st,stts751-i2c.yaml
+++ b/dts/bindings/sensor/st,stts751-i2c.yaml
@@ -11,7 +11,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     drdy-gpios:
       type: phandle-array
-      required: false
       description: DRDY pin
 
         This pin defaults to active high when produced by the sensor.

--- a/dts/bindings/sensor/st,vl53l0x.yaml
+++ b/dts/bindings/sensor/st,vl53l0x.yaml
@@ -10,4 +10,3 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     xshut-gpios:
       type: phandle-array
-      required: false

--- a/dts/bindings/sensor/ti,bq274xx.yaml
+++ b/dts/bindings/sensor/ti,bq274xx.yaml
@@ -33,7 +33,6 @@ properties:
 
     int-gpios:
       type: phandle-array
-      required: false
       description: |
         The INT signal defaults to active low open drain, so requires a
         pull-up on the board. By default it acts as an output and signals

--- a/dts/bindings/sensor/ti,fdc2x1x.yaml
+++ b/dts/bindings/sensor/ti,fdc2x1x.yaml
@@ -10,7 +10,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     sd-gpios:
       type: phandle-array
-      required: false
       description: |
         The SD pin defaults to active high when consumed by the sensor.
         The property value should ensure the flags properly describe
@@ -18,7 +17,6 @@ properties:
 
     intb-gpios:
       type: phandle-array
-      required: false
       description: |
         The INTB pin defaults to active low when produced by the sensor.
         The property value should ensure the flags properly describe
@@ -51,7 +49,6 @@ properties:
 
     rr-sequence:
       type: int
-      required: false
       default: 0
       description: |
         Auto-Scan Sequence Configuration.
@@ -72,7 +69,6 @@ properties:
 
     active-channel:
       type: int
-      required: false
       default: 0
       description: |
         Selects channel for continuous conversions.
@@ -110,7 +106,6 @@ properties:
 
     sensor-activate-sel:
       type: string
-      required: false
       default: "low-power"
       description: |
         Sensor Activation Mode Selection.
@@ -129,7 +124,6 @@ properties:
 
     ref-clk-src:
       type: string
-      required: false
       default: "internal"
       description: |
         Select Reference Frequency Source.
@@ -144,7 +138,6 @@ properties:
 
     current-drive:
       type: string
-      required: false
       default: "normal"
       description: |
         Select Current Sensor Drive.
@@ -163,7 +156,6 @@ properties:
 
     output-gain:
       type: int
-      required: false
       default: 0
       description: |
         Output gain control (FDC2112, FDC2114 only)
@@ -195,7 +187,6 @@ child-binding:
 
       offset:
         type: int
-        required: false
         default: 0
         description: |
           Channel X Conversion Offset (FDC2112 and FDC2212 only).

--- a/dts/bindings/sensor/ti,hdc.yaml
+++ b/dts/bindings/sensor/ti,hdc.yaml
@@ -10,7 +10,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     drdy-gpios:
       type: phandle-array
-      required: false
       description: Data ready pin.
 
         The DRDYn pin of HDC sensor is open-drain, active low.

--- a/dts/bindings/sensor/ti,hdc20xx.yaml
+++ b/dts/bindings/sensor/ti,hdc20xx.yaml
@@ -10,7 +10,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false
       description: DRDY/INT pin.
 
         The DRDY/INT pin of HDC20xx sensor is open-drain, active low. If

--- a/dts/bindings/sensor/ti,ina219.yaml
+++ b/dts/bindings/sensor/ti,ina219.yaml
@@ -22,7 +22,6 @@ properties:
         Value of the shunt resistor in milliOhm
     brng:
       type: int
-      required: false
       default: 1
       description: |
         Bus Voltage Range
@@ -37,7 +36,6 @@ properties:
         - 1
     pg:
       type: int
-      required: false
       default: 3
       description: |
         Programmable Gain
@@ -57,7 +55,6 @@ properties:
         - 3
     badc:
       type: int
-      required: false
       default: 3
       description: |
         Bus ADC configuration
@@ -94,7 +91,6 @@ properties:
         - 15
     sadc:
       type: int
-      required: false
       default: 3
       description: |
         Shunt ADC configuration

--- a/dts/bindings/sensor/ti,ina230.yaml
+++ b/dts/bindings/sensor/ti,ina230.yaml
@@ -18,14 +18,12 @@ include: ti,ina23x-common.yaml
 properties:
     mask:
       type: int
-      required: false
       default: 0
       # default all alert sources to disabled
       description: Mask register, default matches the power-on reset value
 
     alert-limit:
       type: int
-      required: false
       default: 0
       # default alert limit is 0V
       description: Alert register, default matches the power-on reset value

--- a/dts/bindings/sensor/ti,ina237.yaml
+++ b/dts/bindings/sensor/ti,ina237.yaml
@@ -24,5 +24,4 @@ properties:
 
     alert-config:
       type: int
-      required: false
       description: Diag alert register, default matches the power-on reset value

--- a/dts/bindings/sensor/ti,ina23x-common.yaml
+++ b/dts/bindings/sensor/ti,ina23x-common.yaml
@@ -41,5 +41,4 @@ properties:
 
     alert-gpios:
       type: phandle-array
-      required: false
       description: Alert pin

--- a/dts/bindings/sensor/ti,tmp007.yaml
+++ b/dts/bindings/sensor/ti,tmp007.yaml
@@ -12,7 +12,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false
       description: |
         Identifies the ALERT signal, which is active-low open drain when
         produced by the sensor.

--- a/dts/bindings/sensor/ti,tmp108.yaml
+++ b/dts/bindings/sensor/ti,tmp108.yaml
@@ -13,7 +13,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     alert-gpios:
       type: phandle-array
-      required: false
       description: |
         Identifies the ALERT signal, which is active-low open drain when
         produced by the sensor.

--- a/dts/bindings/sensor/vishay,vcnl4040.yaml
+++ b/dts/bindings/sensor/vishay,vcnl4040.yaml
@@ -12,7 +12,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false
       description: |
         The INT pin signals that a programmable interrupt function
         for ALS and PS with upper and lower thresholds has been
@@ -21,7 +20,6 @@ properties:
 
     led-current:
       type: int
-      required: false
       default: 50
       # default of 50 mA is POR (0b000) for PS_MS[LED_I] register
       description: LED current in mA
@@ -37,7 +35,6 @@ properties:
 
     led-duty-cycle:
       type: int
-      required: false
       default: 40
       # default of 40 Hz is POR (0b00) for PS_CONF1[PS_Duty] register
       description: LED duty cycle in Hz
@@ -49,7 +46,6 @@ properties:
 
     proximity-it:
       type: string
-      required: false
       default: "1"
       # default of 1 is POR (0b000) for PS_CONF2[PS_IT] register
       description: Proximity integration time in T
@@ -65,7 +61,6 @@ properties:
 
     proximity-trigger:
       type: string
-      required: false
       default: "disabled"
       # default of "disabled" is POR (0b00) for PS_CONF2[PS_INT] register
       description: Proximity trigger type
@@ -77,7 +72,6 @@ properties:
 
     als-it:
       type: int
-      required: false
       default: 80
       # default of 80 is POR (0b00) for ALS_CONF[ALS_IT] register
       description: ALS integration time in ms

--- a/dts/bindings/sensor/we,wsen-hids-common.yaml
+++ b/dts/bindings/sensor/we,wsen-hids-common.yaml
@@ -6,7 +6,6 @@ include: sensor-device.yaml
 properties:
     drdy-gpios:
       type: phandle-array
-      required: false
       description: |
         Data-ready interrupt pin.
         Interrupt is active high by default.

--- a/dts/bindings/sensor/we,wsen-itds.yaml
+++ b/dts/bindings/sensor/we,wsen-itds.yaml
@@ -10,7 +10,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
     int-gpios:
       type: phandle-array
-      required: false
       description: |
         This property specifies the connection for INT0, the driver maps
         all interrupts to INT0 as default. The signal to output high when

--- a/dts/bindings/sensor/winsen,mhz19b.yaml
+++ b/dts/bindings/sensor/winsen,mhz19b.yaml
@@ -19,6 +19,5 @@ properties:
 
   abc-on:
     type: boolean
-    required: false
     description: |
       Enable ABC self-calibration function

--- a/dts/bindings/serial/arm,sbsa-uart.yaml
+++ b/dts/bindings/serial/arm,sbsa-uart.yaml
@@ -9,4 +9,3 @@ properties:
       required: true
 
     interrupts:
-      required: false

--- a/dts/bindings/serial/espressif,esp32-uart.yaml
+++ b/dts/bindings/serial/espressif,esp32-uart.yaml
@@ -8,9 +8,6 @@ properties:
     reg:
       required: true
 
-    interrupts:
-      required: false
-
     pinctrl-0:
       required: true
 

--- a/dts/bindings/serial/espressif,esp32-usb-serial.yaml
+++ b/dts/bindings/serial/espressif,esp32-usb-serial.yaml
@@ -7,6 +7,3 @@ include: uart-controller.yaml
 properties:
   reg:
     required: true
-
-  interrupts:
-    required: false

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -12,10 +12,8 @@ properties:
 
     pcp:
       type: int
-      required: false
       description: custom clock (PRV_CLOCK_PARAMS, if supported)
 
     dlf:
       type: int
-      required: false
       description: divisor latch fraction (DLF, if supported)

--- a/dts/bindings/serial/nxp,imx-iuart.yaml
+++ b/dts/bindings/serial/nxp,imx-iuart.yaml
@@ -9,9 +9,6 @@ properties:
     reg:
       required: true
 
-    interrupts:
-      required: false
-
     clocks:
       required: true
 

--- a/dts/bindings/serial/quicklogic,usbserialport_s3b.yaml
+++ b/dts/bindings/serial/quicklogic,usbserialport_s3b.yaml
@@ -10,6 +10,3 @@ include: uart-controller.yaml
 properties:
     reg:
       required: true
-
-    interrupts:
-      required: false

--- a/dts/bindings/serial/renesas,smartbond-uart.yaml
+++ b/dts/bindings/serial/renesas,smartbond-uart.yaml
@@ -38,5 +38,4 @@ properties:
 
     hw-flow-control-supported:
       type: boolean
-      required: false
       description: Set to indicate RTS/CTS flow control is supported.

--- a/dts/bindings/serial/segger,rtt-uart.yaml
+++ b/dts/bindings/serial/segger,rtt-uart.yaml
@@ -15,7 +15,6 @@ properties:
         Size of the RTT up buffer for transmission
         Not used for RTT channel 0 as channel 0 is initialized at compile time,
         see SEGGER_RTT_BUFFER_SIZE_UP.
-      required: false
 
     rx-buffer-size:
       type: int
@@ -24,4 +23,3 @@ properties:
         Size of the RTT down buffer for reception
         Not used for RTT channel 0 as channel 0 is initialized at compile time,
         see SEGGER_RTT_BUFFER_SIZE_DOWN.
-      required: false

--- a/dts/bindings/serial/silabs,gecko-usart.yaml
+++ b/dts/bindings/serial/silabs,gecko-usart.yaml
@@ -31,10 +31,8 @@ properties:
 
     location-rts:
       type: array
-      required: false
       description: RTS pin configuration defined as <location port pin>
 
     location-cts:
       type: array
-      required: false
       description: CTS pin configuration defined as <location port pin>

--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -18,7 +18,6 @@ properties:
 
     single-wire:
       type: boolean
-      required: false
       description: |
         Enable the single wire half-duplex communication.
         Using this mode, TX and RX lines are internally connected and
@@ -27,20 +26,17 @@ properties:
 
     tx-rx-swap:
       type: boolean
-      required: false
       description:
         Swap the TX and RX pins. Used in case of a cross wired connection.
 
     tx-invert:
       type: boolean
-      required: false
       description: |
         Invert the binary logic of tx pin. When enabled, physical logic levels are inverted and
         we use 1=Low, 0=High instead of 1=High, 0=Low.
 
     rx-invert:
       type: boolean
-      required: false
       description: |
         Invert the binary logic of rx pin. When enabled, physical logic levels are inverted and
         we use 1=Low, 0=High instead of 1=High, 0=Low.
@@ -53,7 +49,6 @@ properties:
 
     wakeup-line:
       type: int
-      required: false
       description: |
         EXTI line number matching the device wakeup interrupt mask register.
         This property is required on stm32 devices where the wakeup interrupt signal could be

--- a/dts/bindings/serial/uart-controller.yaml
+++ b/dts/bindings/serial/uart-controller.yaml
@@ -7,18 +7,14 @@ bus: uart
 properties:
     clock-frequency:
       type: int
-      required: false
       description: Clock frequency information for UART operation
     current-speed:
       type: int
-      required: false
       description: Initial baud rate setting for UART
     hw-flow-control:
       type: boolean
-      required: false
       description: Set to enable RTS/CTS flow control at boot time
     parity:
-      required: false
       type: string
       description: |
         Configures the parity of the adapter. Enumeration id 0 for none, 1 for odd

--- a/dts/bindings/spi/espressif,esp32-spi.yaml
+++ b/dts/bindings/spi/espressif,esp32-spi.yaml
@@ -8,9 +8,6 @@ properties:
     reg:
       required: true
 
-    interrupts:
-      required: false
-
     pinctrl-0:
       required: true
 
@@ -19,7 +16,6 @@ properties:
 
     half-duplex:
       type: boolean
-      required: false
       description: |
         Enable half-duplex communication mode.
 
@@ -27,12 +23,10 @@ properties:
 
     dummy-comp:
       type: boolean
-      required: false
       description: Enable dummy SPI compensation cycles
 
     sio:
       type: boolean
-      required: false
       description: |
         Enable 3-wire mode
 
@@ -40,22 +34,18 @@ properties:
 
     dma-enabled:
       type: boolean
-      required: false
       description: Enable SPI DMA support
 
     dma-clk:
       type: int
-      required: false
       description: DMA clock source
 
     dma-host:
       type: int
-      required: false
       description: DMA Host - 0 -> SPI2, 1 -> SPI3
 
     clk-as-cs:
       type: boolean
-      required: false
       description: |
         Support to toggle the CS while the clock toggles
 
@@ -63,12 +53,10 @@ properties:
 
     positive-cs:
       type: boolean
-      required: false
       description: Make CS positive during a transaction instead of negative
 
     use-iomux:
       type: boolean
-      required: false
       description: |
         Some pins are allowed to bypass the GPIO Matrix and use the IO_MUX
         routing mechanism instead, this avoids extra routing latency and makes

--- a/dts/bindings/spi/microchip-xec-qmspi-v2.yaml
+++ b/dts/bindings/spi/microchip-xec-qmspi-v2.yaml
@@ -34,7 +34,6 @@ properties:
 
     lines:
       type: int
-      required: false
       description: |
         QMSPI data lines 1, 2, or 4. 1 data line is full-duplex
         MOSI and MISO or half-duplex on MOSI only. Lines set to 2
@@ -47,7 +46,6 @@ properties:
 
     port-sel:
       type: int
-      required: false
       description: |
         SPI Port 0, 1, or 2. Port 0 is the shared SPI, port 1 is
         the private SPI, and port 2 is the internal SPI port for
@@ -56,14 +54,12 @@ properties:
 
     chip-select:
       type: int
-      required: false
       description: |
         Use QMSPI CS0# or CS1#. Port 0 supports both chip selects.
         Ports 1 and 2 implement CS0# only. Defaults to CS0#.
 
     dcsckon:
       type: int
-      required: false
       description: |
         Delay in QMSPI main clocks from CS# assertion to first clock edge.
         If not present use hardware default value. Refer to chip documention
@@ -71,7 +67,6 @@ properties:
 
     dckcsoff:
       type: int
-      required: false
       description: |
         Delay in QMSPI main clocks from last clock edge to CS# de-assertion.
         If not presetn use hardware default value. Refer to chip documention
@@ -79,7 +74,6 @@ properties:
 
     dldh:
       type: int
-      required: false
       description: |
         Delay in QMSPI main clocks from CS# de-assertion to driving HOLD#
         and WP#. If not present use hardware default value. Refer to chip
@@ -87,7 +81,6 @@ properties:
 
     dcsda:
       type: int
-      required: false
       description: |
         Delay in QMSPI main clocks from CS# de-assertion to CS# assertion.
         If not present use hardware default value. Refer to chip documention
@@ -95,21 +88,18 @@ properties:
 
     cs1-freq:
       type: int
-      required: false
       description: |
         Allows different frequencies for CS#0 and CS1# devices. This applies
         to ports implementing CS1#.
 
     tctradj:
       type: int
-      required: false
       description: |
         An optional signed 8-bit value for adjusting the QMSPI control signal
         timing tap.
 
     tsckadj:
       type: int
-      required: false
       description: |
         An optional signed 8-bit value for adjusting the QMSPI clock signal
         timing tap.

--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -30,7 +30,6 @@ properties:
     sck-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -50,7 +49,6 @@ properties:
     mosi-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.
@@ -61,7 +59,6 @@ properties:
     miso-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.

--- a/dts/bindings/spi/nordic,nrf-spi.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi.yaml
@@ -10,10 +10,8 @@ include: nordic,nrf-spi-common.yaml
 properties:
     miso-pull-up:
       type: boolean
-      required: false
       description: Enable pull-up on MISO line
 
     miso-pull-down:
       type: boolean
-      required: false
       description: Enable pull-down on MISO line

--- a/dts/bindings/spi/nordic,nrf-spim.yaml
+++ b/dts/bindings/spi/nordic,nrf-spim.yaml
@@ -10,17 +10,14 @@ include: ["nordic,nrf-spi-common.yaml", "memory-region.yaml"]
 properties:
     miso-pull-up:
       type: boolean
-      required: false
       description: Enable pull-up on MISO line
 
     miso-pull-down:
       type: boolean
-      required: false
       description: Enable pull-down on MISO line
 
     anomaly-58-workaround:
       type: boolean
-      required: false
       description: |
         Enables the workaround for the nRF52832 SoC SPIM PAN 58 anomaly.
         Must be used in conjunction with
@@ -28,14 +25,12 @@ properties:
 
     rx-delay-supported:
       type: boolean
-      required: false
       description: |
         Indicates if the SPIM instance has the capability of delaying MISO
         sampling. This property needs to be defined at SoC level DTS files.
 
     rx-delay:
       type: int
-      required: false
       enum:
         - 0
         - 1

--- a/dts/bindings/spi/nordic,nrf-spis.yaml
+++ b/dts/bindings/spi/nordic,nrf-spis.yaml
@@ -11,7 +11,6 @@ properties:
     csn-pin:
       type: int
       deprecated: true
-      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled.

--- a/dts/bindings/spi/nxp,imx-flexspi.yaml
+++ b/dts/bindings/spi/nxp,imx-flexspi.yaml
@@ -16,48 +16,41 @@ properties:
 
     ahb-bufferable:
       type: boolean
-      required: false
       description: |
         Enable AHB bufferable write access by setting register field
         AHBCR[BUFFERABLEEN].
 
     ahb-cacheable:
       type: boolean
-      required: false
       description: |
         Enable AHB cacheable read access by setting register field
         AHBCR[CACHEABLEEN].
 
     ahb-prefetch:
       type: boolean
-      required: false
       description: |
         Enable AHB read prefetch by setting register field AHBCR[PREFETCHEN].
 
     ahb-read-addr-opt:
       type: boolean
-      required: false
       description: |
         Remove burst start address alignment limitation by setting register
         field AHBCR[READADDROPT].
 
     combination-mode:
       type: boolean
-      required: false
       description: |
         Combine port A and port B data pins to support octal mode access by
         setting register field MCR0[COMBINATIONEN].
 
     sck-differential-clock:
       type: boolean
-      required: false
       description: |
         Enable/disable SCKB pad use as SCKA differential clock output,
         when enabled, Port B flash access is not available.
 
     rx-clock-source:
       type: int
-      required: false
       default: 0
       enum:
         - 0 # Loopback internally

--- a/dts/bindings/spi/nxp,imx-lpspi.yaml
+++ b/dts/bindings/spi/nxp,imx-lpspi.yaml
@@ -19,21 +19,18 @@ properties:
 
     pcs-sck-delay:
       type: int
-      required: false
       description: |
         Delay in nanoseconds from the chip select assert to the first clock
         edge. If not set, the minimum supported delay is used.
 
     sck-pcs-delay:
       type: int
-      required: false
       description: |
         Delay in nanoseconds from the last clock edge to the chip select
         deassert. If not set, the minimum supported delay is used.
 
     transfer-delay:
       type: int
-      required: false
       description: |
         Delay in nanoseconds from the chip select deassert to the next chip
         select assert. If not set, the minimum supported delay is used.

--- a/dts/bindings/spi/nxp,kinetis-dspi.yaml
+++ b/dts/bindings/spi/nxp,kinetis-dspi.yaml
@@ -19,21 +19,18 @@ properties:
 
     pcs-sck-delay:
       type: int
-      required: false
       description: |
         Delay in nanoseconds from the chip select assert to the first clock
         edge. If not set, the minimum supported delay is used.
 
     sck-pcs-delay:
       type: int
-      required: false
       description: |
         Delay in nanoseconds from the last clock edge to the chip select
         deassert. If not set, the minimum supported delay is used.
 
     transfer-delay:
       type: int
-      required: false
       description: |
         Delay in nanoseconds from the chip select deassert to the next chip
         select assert. If not set, the minimum supported delay is used.
@@ -44,32 +41,27 @@ properties:
 
     nxp,rx-tx-chn-share:
       type: boolean
-      required: false
       description: If the edma channel shared with tx and rx
 
     ctar:
       type: int
-      required: false
       description: |
         ctar register selection range form 0-1 for master mode, 0 for slave mode
 
     sample-point:
       type: int
-      required: false
       description: |
         Controls when the DSPI master samples SIN in the Modified Transfer Format.
         This field is valid only when the CPHA bit in the CTAR register is 0.
 
     continuous-sck:
       type: boolean
-      required: false
       description: |
         continuous SCK enable. Note that the continuous SCK is only
         supported for CPHA = 1.
 
     rx-fifo-overwrite:
       type: boolean
-      required: false
       description: |
         receive FIFO overflow overwrite enable. If ROOE = 0, the incoming
         data is ignored and the data from the transfer that generated the overflow
@@ -78,18 +70,15 @@ properties:
 
     modified-timing-format:
       type: boolean
-      required: false
       description: |
         Enables a modified transfer format to be used if true.
 
     tx-fifo-size:
       type: int
-      required: false
       description: |
         tx fifo size
 
     rx-fifo-size:
       type: int
-      required: false
       description: |
         rx fifo size

--- a/dts/bindings/spi/nxp,lpc-spi.yaml
+++ b/dts/bindings/spi/nxp,lpc-spi.yaml
@@ -10,21 +10,18 @@ include: [spi-controller.yaml, "nxp,lpc-flexcomm.yaml"]
 properties:
     pre-delay:
       type: int
-      required: false
       description: |
         Delay in nanoseconds inserted between chip select assert to the first
         clock edge. If not set, no additional delay is inserted.
 
     post-delay:
       type: int
-      required: false
       description: |
         Delay in nanoseconds inserted between the last clock edge to the chip
         select deassert. If not set, no additional delay is inserted.
 
     frame-delay:
       type: int
-      required: false
       description: |
         Delay in nanoseconds inserted between data frames when chip select is
         asserted and the EOF flag is set. If not set, no additional delay is
@@ -32,14 +29,12 @@ properties:
 
     transfer-delay:
       type: int
-      required: false
       description: |
         Delay in nanoseconds inserted between transfers when chip select is
         deasserted. If not set, no additional delay is inserted.
 
     def-char:
       type: int
-      required: false
       description: |
           Default character clocked out when the TX buffer pointer is NULL.
           Applies to SPI master and slave configurations.

--- a/dts/bindings/spi/spi-controller.yaml
+++ b/dts/bindings/spi/spi-controller.yaml
@@ -10,7 +10,6 @@ bus: spi
 properties:
     clock-frequency:
       type: int
-      required: false
       description: |
         Clock frequency the SPI peripheral is being driven at, in Hz.
     "#address-cells":
@@ -21,7 +20,6 @@ properties:
       const: 0
     cs-gpios:
       type: phandle-array
-      required: false
       description: |
         An array of chip select GPIOs to use. Each element
         in the array specifies a GPIO. The index in the array

--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -17,7 +17,6 @@ properties:
     duplex:
       type: int
       default: 0
-      required: false
       description: |
         Duplex mode, full or half. By default it's always full duplex thus 0
         as this is, by far, the most common mode.
@@ -31,7 +30,6 @@ properties:
     frame-format:
       type: int
       default: 0
-      required: false
       description: |
         Motorola or TI frame format. By default it's always Motorola's,
         thus 0 as this is, by far, the most common format.

--- a/dts/bindings/spi/telink,b91-spi.yaml
+++ b/dts/bindings/spi/telink,b91-spi.yaml
@@ -35,7 +35,6 @@ properties:
 
     cs1-pin:
       type: string
-      required: false
       enum:
         - "0"
         - "PSPI_CSN_PC4"
@@ -46,7 +45,6 @@ properties:
 
     cs2-pin:
       type: string
-      required: false
       enum:
         - "0"
         - "PSPI_CSN_PC4"

--- a/dts/bindings/spi/zephyr,spi-bitbang.yaml
+++ b/dts/bindings/spi/zephyr,spi-bitbang.yaml
@@ -16,14 +16,12 @@ properties:
 
     mosi-gpios:
       type: phandle-array
-      required: false
       description: |
         MOSI gpio info. Output pin for Master Out Slave In.
         If this is not provided then the driver will transmit 0s
 
     miso-gpios:
       type: phandle-array
-      required: false
       description: |
         MISO gpio info. Input pin for Master In Slave Out.
         If this is not provided the driver will read 0s

--- a/dts/bindings/syscon/syscon.yaml
+++ b/dts/bindings/syscon/syscon.yaml
@@ -12,5 +12,4 @@ properties:
       required: true
     reg-io-width:
       type: int
-      required: false
       description: The width of the registers in the syscon region in bytes. Default is 4 bytes.

--- a/dts/bindings/tach/nuvoton,npcx-tach.yaml
+++ b/dts/bindings/tach/nuvoton,npcx-tach.yaml
@@ -18,15 +18,12 @@ properties:
         required: true
     sample-clk:
         type: int
-        required: false
         description: |
           sampling clock frequency of tachometer. Please notice that it must be
           fixed to 32768 if bus in clocks property is NPCX_CLOCK_BUS_LFCLK.
     port:
         type: int
-        required: false
         description: selected port of tachometer (port-A is 0 and port-B is 1)
     pulses-per-round:
         type: int
-        required: false
         description: number of pulses (holes) per round of tachometer's input (encoder)

--- a/dts/bindings/tcpc/st,stm32-ucpd.yaml
+++ b/dts/bindings/tcpc/st,stm32-ucpd.yaml
@@ -20,7 +20,6 @@ properties:
       required: true
 
     psc-ucpdclk:
-      required: false
       default: 2
       type: int
       enum:
@@ -39,7 +38,6 @@ properties:
         the range from 6 to 9 MHz.
 
     ifrgap:
-      required: false
       type: int
       default: 17
       description: |
@@ -50,7 +48,6 @@ properties:
         Valid range: 2 - 32
 
     transwin:
-      required: false
       type: int
       default: 8
       description: |
@@ -59,7 +56,6 @@ properties:
         Valid range: 2 - 32
 
     hbitclkdiv:
-      required: false
       type: int
       default: 14
       description: |

--- a/dts/bindings/test/vnd,busy-sim.yaml
+++ b/dts/bindings/test/vnd,busy-sim.yaml
@@ -15,6 +15,5 @@ properties:
 
     active-gpios:
       type: phandle-array
-      required: false
       description: |
         Debug pin is set to active state when cpu load is active.

--- a/dts/bindings/test/vnd,enum-int-required-false-holder.yaml
+++ b/dts/bindings/test/vnd,enum-int-required-false-holder.yaml
@@ -10,7 +10,6 @@ include: [base.yaml]
 properties:
   val:
     type: int
-    required: false
     enum:
       - 5
       - 6

--- a/dts/bindings/test/vnd,enum-required-false-holder.yaml
+++ b/dts/bindings/test/vnd,enum-required-false-holder.yaml
@@ -10,7 +10,6 @@ include: [base.yaml]
 properties:
   val:
     type: string
-    required: false
     enum:
       - "zero"
       - "one"

--- a/dts/bindings/test/vnd,gpio-device.yaml
+++ b/dts/bindings/test/vnd,gpio-device.yaml
@@ -17,7 +17,6 @@ properties:
 
     label:
         type: string
-        required: false
 
     "#gpio-cells":
       const: 2

--- a/dts/bindings/test/vnd,gpio-expander-i2c.yaml
+++ b/dts/bindings/test/vnd,gpio-expander-i2c.yaml
@@ -16,4 +16,3 @@ include:
 properties:
     label:
         type: string
-        required: false

--- a/dts/bindings/test/vnd,i2c-device.yaml
+++ b/dts/bindings/test/vnd,i2c-device.yaml
@@ -13,4 +13,3 @@ include:
 properties:
     label:
         type: string
-        required: false

--- a/dts/bindings/test/vnd,i2c.yaml
+++ b/dts/bindings/test/vnd,i2c.yaml
@@ -13,4 +13,3 @@ include:
 properties:
     label:
         type: string
-        required: false

--- a/dts/bindings/test/vnd,i3c-device.yaml
+++ b/dts/bindings/test/vnd,i3c-device.yaml
@@ -15,4 +15,3 @@ include:
 properties:
     label:
         type: string
-        required: false

--- a/dts/bindings/test/vnd,i3c-i2c-device.yaml
+++ b/dts/bindings/test/vnd,i3c-i2c-device.yaml
@@ -15,4 +15,3 @@ include:
 properties:
     label:
         type: string
-        required: false

--- a/dts/bindings/test/vnd,i3c.yaml
+++ b/dts/bindings/test/vnd,i3c.yaml
@@ -15,4 +15,3 @@ include:
 properties:
     label:
         type: string
-        required: false

--- a/dts/bindings/test/vnd,reset.yaml
+++ b/dts/bindings/test/vnd,reset.yaml
@@ -10,7 +10,6 @@ include: [base.yaml, reset-controller.yaml]
 properties:
     reg-width:
       type: int
-      required: false
       description: Register width
     "#reset-cells":
       const: 1

--- a/dts/bindings/test/vnd,serial.yaml
+++ b/dts/bindings/test/vnd,serial.yaml
@@ -10,9 +10,7 @@ properties:
 
     baud-rate:
       type: int
-      required: false
 
     buffer-size:
       type: int
-      required: false
       description: "Size of buffer to capture output data or to queue input data."

--- a/dts/bindings/test/vnd,spi-device.yaml
+++ b/dts/bindings/test/vnd,spi-device.yaml
@@ -13,4 +13,3 @@ include:
 properties:
     label:
         type: string
-        required: false

--- a/dts/bindings/test/vnd,spi.yaml
+++ b/dts/bindings/test/vnd,spi.yaml
@@ -13,4 +13,3 @@ include:
 properties:
     label:
         type: string
-        required: false

--- a/dts/bindings/test/vnd,string-token.yaml
+++ b/dts/bindings/test/vnd,string-token.yaml
@@ -8,7 +8,6 @@ compatible: "vnd,string-token"
 properties:
   val:
     type: string
-    required: false
     enum:
       - token_zero
       - token_one

--- a/dts/bindings/timer/andestech,atcpit100.yaml
+++ b/dts/bindings/timer/andestech,atcpit100.yaml
@@ -26,7 +26,6 @@ properties:
     prescaler:
       type: int
       default: 1
-      required: false
       description: |
         The prescaler value defines the counter frequency
         (clock-frequency/prescaler) in atcpit100 counter driver, the prescaler

--- a/dts/bindings/timer/atmel,sam-tc.yaml
+++ b/dts/bindings/timer/atmel,sam-tc.yaml
@@ -22,21 +22,18 @@ properties:
 
     channel:
       type: int
-      required: false
       description: |
         Timer / Counter channel to use, channel 0 is the default.
         Valid range: 0 - 2
 
     clk:
       type: int
-      required: false
       description: |
         Clock source selection as defined by TCCLKS bit-field of TC_CMR
         register. Consult the datasheet for the details.
 
     nodivclk:
       type: boolean
-      required: false
       description: |
         If set to true the `clk` property is ignored. Instead the TC module is
         driven directly via MCLK. Only supported on sam4e, same70, same70b,
@@ -44,7 +41,6 @@ properties:
 
     reg-cmr:
       type: int
-      required: false
       description: |
         Alternate value of the CMR (Channel Mode Register) register.
         If specified this value will be written to the register during driver
@@ -56,7 +52,6 @@ properties:
 
     reg-rc:
       type: int
-      required: false
       description: |
         Register C compare/match value. RC can be used as compare/match unit
         for an specific timer unit. Their use depends on how timer channel

--- a/dts/bindings/timer/atmel,sam0-tc32.yaml
+++ b/dts/bindings/timer/atmel,sam0-tc32.yaml
@@ -24,7 +24,6 @@ properties:
 
   prescaler:
     type: int
-    required: false
     description: Timer prescaler
     enum:
       - 1

--- a/dts/bindings/timer/intel,adsp-timer.yaml
+++ b/dts/bindings/timer/intel,adsp-timer.yaml
@@ -8,12 +8,6 @@ compatible: "intel,adsp-timer"
 include: base.yaml
 
 properties:
-    reg:
-      required: false
-
-    interrupts:
-      required: false
-
     syscon:
       type: phandle
       required: true

--- a/dts/bindings/timer/intel,hpet.yaml
+++ b/dts/bindings/timer/intel,hpet.yaml
@@ -16,5 +16,4 @@ properties:
 
     no-legacy-irq:
       type: boolean
-      required: false
       description: Do not set legacy IRQ bit

--- a/dts/bindings/timer/nuclei,systimer.yaml
+++ b/dts/bindings/timer/nuclei,systimer.yaml
@@ -20,7 +20,6 @@ properties:
 
     clk-divider:
       type: int
-      required: false
       description: |
         clk-divider specifies the division ratio to the CPU frequency that
         clock used by the system timer.

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -14,9 +14,6 @@ properties:
     clocks:
       required: true
 
-    interrupts:
-      required: false
-
     st,prescaler:
       type: int
       required: true
@@ -26,7 +23,6 @@ properties:
 
     st,countermode:
         type: int
-        required: false
         default: 0 # STM32_TIM_COUNTERMODE_UP - reset state
         description: |
           Sets timer counter mode.

--- a/dts/bindings/usb-c/usb-c-connector.yaml
+++ b/dts/bindings/usb-c/usb-c-connector.yaml
@@ -38,7 +38,6 @@ properties:
 
     try-power-role:
         type: string
-        required: false
         enum:
           - "sink"
           - "source"
@@ -48,7 +47,6 @@ properties:
 
     data-role:
         type: string
-        required: false
         enum:
           - "host"
           - "device"
@@ -61,7 +59,6 @@ properties:
 
     typec-power-opmode:
         type: string
-        required: false
         enum:
           - "default"
           - "1.5A"
@@ -78,13 +75,11 @@ properties:
 
     pd-disable:
         type: boolean
-        required: false
         description: |
           Disables power delivery when true
 
     source-pdos:
         type: array
-        required: false
         description: |
           An array of source Power Data Objects (PDOs).
           Use tht following macros to define the PDOs, defined in
@@ -97,7 +92,6 @@ properties:
 
     sink-pdos:
         type: array
-        required: false
         description: |
           An array of sink Power Data Objects (PDOs).
           Use tht following macros to define the PDOs, defined in
@@ -110,7 +104,6 @@ properties:
 
     sink-vdos:
         type: array
-        required: false
         description: |
           An array of sink Vendor Defined Objects (VDOs).
           Use tht following macros to define the VDOs, defined in
@@ -127,7 +120,6 @@ properties:
 
     sink-vdos-v1:
         type: array
-        required: false
         description: |
           An array of sink Vendor Defined Objects (VDOs).
           Use tht following macros to define the VDOs, defined in
@@ -141,7 +133,6 @@ properties:
 
     op-sink-microwatt:
         type: int
-        required: false
         description: |
           Minimum power, in microwatts, needed by the sink. A Capability
           Mismatch is sent to the Source if the power can't be met.

--- a/dts/bindings/usb-c/zephyr,usb-c-vbus-adc.yaml
+++ b/dts/bindings/usb-c/zephyr,usb-c-vbus-adc.yaml
@@ -12,4 +12,3 @@ include: [base.yaml, voltage-divider.yaml]
 properties:
     discharge-gpios:
        type: phandle-array
-       required: false

--- a/dts/bindings/usb/st,stm32-otgfs.yaml
+++ b/dts/bindings/usb/st,stm32-otgfs.yaml
@@ -29,7 +29,6 @@ properties:
 
     phys:
       type: phandle
-      required: false
       description: PHY provider specifier
 
     clocks:

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -29,7 +29,6 @@ properties:
 
     phys:
       type: phandle
-      required: false
       description: PHY provider specifier
 
     clocks:

--- a/dts/bindings/usb/st,stm32-usb.yaml
+++ b/dts/bindings/usb/st,stm32-usb.yaml
@@ -23,19 +23,16 @@ properties:
 
     disconnect-gpios:
       type: phandle-array
-      required: false
       description: |
         Some boards use a USB DISCONNECT pin to enable
         the pull-up resistor on USB Data Positive signal.
 
     phys:
       type: phandle
-      required: false
       description: PHY provider specifier
 
     enable-pin-remap:
       type: boolean
-      required: false
       description: |
         For STM32F0 series SoCs on QFN28 and TSSOP20 packages
         enable PIN pair PA11/12 mapped instead of PA9/10 (e.g. stm32f070x6).

--- a/dts/bindings/usb/usb-audio-hp.yaml
+++ b/dts/bindings/usb/usb-audio-hp.yaml
@@ -13,7 +13,6 @@ properties:
   resolution:
     type: int
     default: 16
-    required: false
     enum:
      - 8
      - 16
@@ -22,55 +21,42 @@ properties:
 # channel configuration options
   channel-l:
     type: boolean
-    required: false
     description: Enable (l) channel.
   channel-r:
     type: boolean
-    required: false
     description: Enable (r) channel.
   channel-c:
     type: boolean
-    required: false
     description: Enable (c) channel.
   channel-lfe:
     type: boolean
-    required: false
     description: Enable (lfe) channel.
   channel-ls:
     type: boolean
-    required: false
     description: Enable (ls) channel.
   channel-rs:
     type: boolean
-    required: false
     description: Enable (rs) channel.
   channel-lc:
     type: boolean
-    required: false
     description: Enable (lc) channel.
   channel-rc:
     type: boolean
-    required: false
     description: Enable (rc) channel.
   channel-s:
     type: boolean
-    required: false
     description: Enable (s) channel.
   channel-sl:
     type: boolean
-    required: false
     description: Enable (sl) channel.
   channel-sr:
     type: boolean
-    required: false
     description: Enable (sr) channel.
   channel-t:
     type: boolean
-    required: false
     description: Enable (t) channel.
   channel-cfg:
     type: boolean
-    required: false
     description: Enable (cfg) channel.
 # feature unit configuration options
   feature-mute:
@@ -79,43 +65,36 @@ properties:
     description: Enable Mute feature.
   feature-volume:
     type: boolean
-    required: false
     description: |
       Enable Volume feature.
       Currently not supported.
   feature-tone-control:
     type: boolean
-    required: false
     description: |
       Enable Tone Control (Bass, Mid, Treble) feature.
       Currently not supported.
   feature-graphic-equalizer:
     type: boolean
-    required: false
     description: |
       Enable  Graphic Equalizer feature.
       Currently not supported.
   feature-automatic-gain-control:
     type: boolean
-    required: false
     description: |
       Enable Autoamtic Gain Control feature.
       Currently not supported.
   feature-delay:
     type: boolean
-    required: false
     description: |
       Enable Delay feature.
       Currently not supported.
   feature-bass-boost:
     type: boolean
-    required: false
     description: |
       Enable Bass Boost feature.
       Currently not supported.
   feature-loudness:
     type: boolean
-    required: false
     description: |
       Enable Loudness feature.
       Currently not supported.

--- a/dts/bindings/usb/usb-audio-hs.yaml
+++ b/dts/bindings/usb/usb-audio-hs.yaml
@@ -13,14 +13,12 @@ properties:
   mic-resolution:
     type: int
     default: 16
-    required: false
     enum:
      - 8
      - 16
      - 24
      - 32
   mic-sync-type:
-    required: false
     default: "Synchronous"
     type: string
     description: |
@@ -35,7 +33,6 @@ properties:
   hp-resolution:
     type: int
     default: 16
-    required: false
     enum:
      - 8
      - 16
@@ -44,55 +41,42 @@ properties:
 # microphone channel configuration options
   mic-channel-l:
     type: boolean
-    required: false
     description: Enable (l) channel.
   mic-channel-r:
     type: boolean
-    required: false
     description: Enable (r) channel.
   mic-channel-c:
     type: boolean
-    required: false
     description: Enable (c) channel.
   mic-channel-lfe:
     type: boolean
-    required: false
     description: Enable (lfe) channel.
   mic-channel-ls:
     type: boolean
-    required: false
     description: Enable (ls) channel.
   mic-channel-rs:
     type: boolean
-    required: false
     description: Enable (rs) channel.
   mic-channel-lc:
     type: boolean
-    required: false
     description: Enable (lc) channel.
   mic-channel-rc:
     type: boolean
-    required: false
     description: Enable (rc) channel.
   mic-channel-s:
     type: boolean
-    required: false
     description: Enable (s) channel.
   mic-channel-sl:
     type: boolean
-    required: false
     description: Enable (sl) channel.
   mic-channel-sr:
     type: boolean
-    required: false
     description: Enable (sr) channel.
   mic-channel-t:
     type: boolean
-    required: false
     description: Enable (t) channel.
   mic-channel-cfg:
     type: boolean
-    required: false
     description: Enable (cfg) channel.
 # microphone feature unit configuration options
   mic-feature-mute:
@@ -101,98 +85,78 @@ properties:
     description: Enable Mute feature.
   mic-feature-volume:
     type: boolean
-    required: false
     description: |
       Enable Volume feature.
       Currently not supported.
   mic-feature-tone-control:
     type: boolean
-    required: false
     description: |
       Enable Tone Control (Bass, Mid, Treble) feature.
       Currently not supported.
   mic-feature-graphic-equalizer:
     type: boolean
-    required: false
     description: |
       Enable  Graphic Equalizer feature.
       Currently not supported.
   mic-feature-automatic-gain-control:
     type: boolean
-    required: false
     description: |
       Enable Autoamtic Gain Control feature.
       Currently not supported.
   mic-feature-delay:
     type: boolean
-    required: false
     description: |
       Enable Delay feature.
       Currently not supported.
   mic-feature-bass-boost:
     type: boolean
-    required: false
     description: |
       Enable Bass Boost feature.
       Currently not supported.
   mic-feature-loudness:
     type: boolean
-    required: false
     description: |
       Enable Loudness feature.
       Currently not supported.
 # headphones channel configuration options
   hp-channel-l:
     type: boolean
-    required: false
     description: Enable (l) channel.
   hp-channel-r:
     type: boolean
-    required: false
     description: Enable (r) channel.
   hp-channel-c:
     type: boolean
-    required: false
     description: Enable (c) channel.
   hp-channel-lfe:
     type: boolean
-    required: false
     description: Enable (lfe) channel.
   hp-channel-ls:
     type: boolean
-    required: false
     description: Enable (ls) channel.
   hp-channel-rs:
     type: boolean
-    required: false
     description: Enable (rs) channel.
   hp-channel-lc:
     type: boolean
-    required: false
     description: Enable (lc) channel.
   hp-channel-rc:
     type: boolean
-    required: false
     description: Enable (rc) channel.
   hp-channel-s:
     type: boolean
-    required: false
     description: Enable (s) channel.
   hp-channel-sl:
     type: boolean
-    required: false
     description: Enable (sl) channel.
   hp-channel-sr:
     type: boolean
-    required: false
     description: Enable (sr) channel.
   hp-channel-t:
     type: boolean
-    required: false
     description: Enable (t) channel.
   hp-channel-cfg:
     type: boolean
-    required: false
     description: Enable (cfg) channel.
 # headphones feature unit configuration options
   hp-feature-mute:
@@ -201,43 +165,36 @@ properties:
     description: Enable Mute feature.
   hp-feature-volume:
     type: boolean
-    required: false
     description: |
       Enable Volume feature.
       Currently not supported.
   hp-feature-tone-control:
     type: boolean
-    required: false
     description: |
       Enable Tone Control (Bass, Mid, Treble) feature.
       Currently not supported.
   hp-feature-graphic-equalizer:
     type: boolean
-    required: false
     description: |
       Enable  Graphic Equalizer feature.
       Currently not supported.
   hp-feature-automatic-gain-control:
     type: boolean
-    required: false
     description: |
       Enable Autoamtic Gain Control feature.
       Currently not supported.
   hp-feature-delay:
     type: boolean
-    required: false
     description: |
       Enable Delay feature.
       Currently not supported.
   hp-feature-bass-boost:
     type: boolean
-    required: false
     description: |
       Enable Bass Boost feature.
       Currently not supported.
   hp-feature-loudness:
     type: boolean
-    required: false
     description: |
       Enable Loudness feature.
       Currently not supported.

--- a/dts/bindings/usb/usb-audio-mic.yaml
+++ b/dts/bindings/usb/usb-audio-mic.yaml
@@ -13,14 +13,12 @@ properties:
   resolution:
     type: int
     default: 16
-    required: false
     enum:
      - 8
      - 16
      - 24
      - 32
   sync-type:
-    required: false
     default: "Synchronous"
     type: string
     description: |
@@ -35,55 +33,42 @@ properties:
 # channel configuration options
   channel-l:
     type: boolean
-    required: false
     description: Enable (l) channel.
   channel-r:
     type: boolean
-    required: false
     description: Enable (r) channel.
   channel-c:
     type: boolean
-    required: false
     description: Enable (c) channel.
   channel-lfe:
     type: boolean
-    required: false
     description: Enable (lfe) channel.
   channel-ls:
     type: boolean
-    required: false
     description: Enable (ls) channel.
   channel-rs:
     type: boolean
-    required: false
     description: Enable (rs) channel.
   channel-lc:
     type: boolean
-    required: false
     description: Enable (lc) channel.
   channel-rc:
     type: boolean
-    required: false
     description: Enable (rc) channel.
   channel-s:
     type: boolean
-    required: false
     description: Enable (s) channel.
   channel-sl:
     type: boolean
-    required: false
     description: Enable (sl) channel.
   channel-sr:
     type: boolean
-    required: false
     description: Enable (sr) channel.
   channel-t:
     type: boolean
-    required: false
     description: Enable (t) channel.
   channel-cfg:
     type: boolean
-    required: false
     description: Enable (cfg) channel.
 # feature unit configuration options
   feature-mute:
@@ -92,43 +77,36 @@ properties:
     description: Enable Mute feature.
   feature-volume:
     type: boolean
-    required: false
     description: |
       Enable Volume feature.
       Currently not supported.
   feature-tone-control:
     type: boolean
-    required: false
     description: |
       Enable Tone Control (Bass, Mid, Treble) feature.
       Currently not supported.
   feature-graphic-equalizer:
     type: boolean
-    required: false
     description: |
       Enable  Graphic Equalizer feature.
       Currently not supported.
   feature-automatic-gain-control:
     type: boolean
-    required: false
     description: |
       Enable Autoamtic Gain Control feature.
       Currently not supported.
   feature-delay:
     type: boolean
-    required: false
     description: |
       Enable Delay feature.
       Currently not supported.
   feature-bass-boost:
     type: boolean
-    required: false
     description: |
       Enable Bass Boost feature.
       Currently not supported.
   feature-loudness:
     type: boolean
-    required: false
     description: |
       Enable Loudness feature.
       Currently not supported.

--- a/dts/bindings/usb/usb-controller.yaml
+++ b/dts/bindings/usb/usb-controller.yaml
@@ -10,7 +10,6 @@ bus: usb
 properties:
     maximum-speed:
       type: string
-      required: false
       description: Configures USB controllers to work up to a specific
                    speed. Valid arguments are "super-speed", "high-speed",
                    "full-speed" and "low-speed". If this is not passed
@@ -24,5 +23,4 @@ properties:
 
     vbus-gpios:
       type: phandle-array
-      required: false
       description: Control VBUS via GPIO pin.

--- a/dts/bindings/usb/usb-ep.yaml
+++ b/dts/bindings/usb/usb-ep.yaml
@@ -15,14 +15,12 @@ properties:
 
     num-in-endpoints:
       type: int
-      required: false
       description: |
         Number of IN endpoints supported by hardware
         (including EP0 IN)
 
     num-out-endpoints:
       type: int
-      required: false
       description: |
         Number of OUT endpoints supported by hardware
         (including EP0 OUT)

--- a/dts/bindings/video/ovti,ov2640.yaml
+++ b/dts/bindings/video/ovti,ov2640.yaml
@@ -8,7 +8,6 @@ compatible: "ovti,ov2640"
 properties:
     reset-gpios:
       type: phandle-array
-      required: false
       description: |
         The RESETn pin is asserted to disable the sensor causing a hard
         reset.  The sensor receives this as an active-low signal.

--- a/dts/bindings/video/ovti,ov7725.yaml
+++ b/dts/bindings/video/ovti,ov7725.yaml
@@ -8,7 +8,6 @@ compatible: "ovti,ov7725"
 properties:
     reset-gpios:
       type: phandle-array
-      required: false
       description: |
         The RESETn pin is asserted to disable the sensor causing a hard
         reset.  The sensor receives this as an active-low signal.

--- a/dts/bindings/w1/maxim,ds2477_85_common.yaml
+++ b/dts/bindings/w1/maxim,ds2477_85_common.yaml
@@ -66,7 +66,6 @@ properties:
 
   standard-slew:
     type: int
-    required: false
     default: 150
     enum:
       - 50
@@ -81,7 +80,6 @@ properties:
 
   overdrive-slew:
     type: int
-    required: false
     default: 50
     enum:
       - 50

--- a/dts/bindings/w1/maxim,ds2484.yaml
+++ b/dts/bindings/w1/maxim,ds2484.yaml
@@ -10,6 +10,5 @@ include: [i2c-device.yaml, w1-master.yaml]
 properties:
   slpz-gpios:
     type: phandle-array
-    required: false
     description: |
       Enable sleep mode, only available on DS4284. Active low.

--- a/dts/bindings/watchdog/espressif,esp32-watchdog.yaml
+++ b/dts/bindings/watchdog/espressif,esp32-watchdog.yaml
@@ -12,6 +12,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    interrupts:
-      required: false

--- a/dts/bindings/wifi/espressif,esp-at.yaml
+++ b/dts/bindings/wifi/espressif,esp-at.yaml
@@ -10,15 +10,12 @@ include: uart-device.yaml
 properties:
     power-gpios:
       type: phandle-array
-      required: false
 
     reset-gpios:
       type: phandle-array
-      required: false
 
     target-speed:
       type: int
-      required: false
       description:
         UART baudrate which will be requested using AT commands and to which
         UART interface will be reconfigured during initialization phase.

--- a/dts/bindings/wifi/inventek,eswifi-uart.yaml
+++ b/dts/bindings/wifi/inventek,eswifi-uart.yaml
@@ -15,4 +15,3 @@ properties:
 
     wakeup-gpios:
       type: phandle-array
-      required: false

--- a/dts/bindings/wifi/inventek,eswifi.yaml
+++ b/dts/bindings/wifi/inventek,eswifi.yaml
@@ -18,8 +18,6 @@ properties:
 
     wakeup-gpios:
       type: phandle-array
-      required: false
 
     boot0-gpios:
       type: phandle-array
-      required: false


### PR DESCRIPTION
DTS property attributes are (by default) not required.

Explicitly specifying `required: false` is redundant. Perhaps a warning to that effect would be useful.

Note: this is a non-breaking tree-wide change, and should follow that process.
