### PR TITLE
net: if: fix type qualifiers ignored on function return type

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -651,7 +651,7 @@ enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt);
  *
  * @return a pointer to the iface L2
  */
-static inline const struct net_l2 * const net_if_l2(struct net_if *iface)
+static inline const struct net_l2 *net_if_l2(struct net_if *iface)
 {
 	if (!iface || !iface->if_dev) {
 		return NULL;


### PR DESCRIPTION
if compiler option -Wextra and -Werror is enabled the compilation fails due to ignored-qualifiers warning.

The 'const' qualifier on return type has no effect.

Signed-off-by: Christoph Schnetzler christoph.schnetzler@husqvarnagroup.com