### PR TITLE
Bluetooth: Audio: Add support for multiple subgroups for BAP broadcas…

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.baps
+++ b/subsys/bluetooth/audio/Kconfig.baps
@@ -162,8 +162,12 @@ config BT_AUDIO_BROADCAST_SINK
 if BT_AUDIO_BROADCAST_SINK
 
 config BT_AUDIO_BROADCAST_SNK_SUBGROUP_COUNT
-	int # hidden: TODO: Update once the API supports it
+	int "Basic Audio Profile Broadcast Sink subgroup count"
 	default 1
+	range 1 BT_ISO_MAX_CHAN
+	help
+	  This option sets the maximum number of subgroups per broadcast sink
+	  to support.
 
 config BT_AUDIO_BROADCAST_SNK_COUNT
 	int "Basic Audio Broadcaster Sink count"


### PR DESCRIPTION
…t sink

The broadcast sink supports multiple subgroups, but was not possible due to the Kconfig option.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>