### PR TITLE
bluetooth: Add le power control feature kconfigs

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -90,6 +90,9 @@ config BT_CTLR_READ_ISO_LINK_QUALITY_SUPPORT
 		   BT_CTLR_PERIPHERAL_ISO_SUPPORT
 	bool
 
+config BT_CTLR_LE_POWER_CONTROL_SUPPORT
+	bool
+
 config BT_CTLR
 	bool "Bluetooth Controller"
 	help

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -604,6 +604,15 @@ config BT_CONN_PARAM_UPDATE_TIMEOUT
 	  "The Peripheral device should not perform a Connection Parameter
 	  Update procedure within 5 seconds after establishing a connection."
 
+config BT_TRANSMIT_POWER_CONTROL
+	bool "Transmit Power Control [EXPERIMENTAL]"
+	depends on !BT_CTLR || BT_CTLR_LE_POWER_CONTROL_SUPPORT
+	select EXPERIMENTAL
+	help
+	  Enable support for controlling transmit power. The controller shall
+	  support LE Power Control Request feature that defined in the Bluetooth
+	  Core specification, Version 5.3 | Vol 6, Part B, Section 4.6.31.
+
 endif # BT_CONN
 
 if BT_OBSERVER


### PR DESCRIPTION
LE Power Control feature (Blutooth Core Spec v5.3| Vol 6,Part B, Section 4.6.31) support kconfigs are defined. A link layer controller that supports the feature can select BT_CTLR_LE_POWER_CONTROL_SUPPORT kconfig.

The additional BT_TRANSMIT_POWER_CONTROL kconfig is added to allow user to enable and disable the feature.

Signed-off-by: Ilhan Ates <ilhan.ates@nordicsemi.no>

**Note: This PR is subset of one existing [PR ](https://github.com/zephyrproject-rtos/zephyr/pull/48451) reviewed before. That PR needs to wait a bit more. For now, we aim to provide enable/disable the feature in controller side for the first phase.** 