### PR TITLE
samples: tfm_secure_partition: Add library configuration to sample.yaml

### DIFF
--- a/samples/tfm_integration/tfm_secure_partition/sample.yaml
+++ b/samples/tfm_integration/tfm_secure_partition/sample.yaml
@@ -18,6 +18,6 @@ sample:
 tests:
   sample.tfm.secure_partition:
     tags: tfm
-  sample.tfm.secure_partition.ipc:
+  sample.tfm.secure_partition.lib:
     tags: tfm
-    extra_args: "CONFIG_TFM_IPC=y"
+    extra_args: "CONFIG_TFM_LIBRARY=y"


### PR DESCRIPTION
Add library model configuration to tfm_secure_partition model. IPC model is now the default, so add back the library configuration for the sample as an additional configuration to the default.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>