### PR TITLE
Extend settings_runtime_commit to support all commits

### DIFF
--- a/subsys/settings/src/settings_runtime.c
+++ b/subsys/settings/src/settings_runtime.c
@@ -58,17 +58,5 @@ int settings_runtime_get(const char *name, void *data, size_t len)
 
 int settings_runtime_commit(const char *name)
 {
-	struct settings_handler_static *ch;
-	const char *name_key;
-
-	ch = settings_parse_and_lookup(name, &name_key);
-	if (!ch) {
-		return -EINVAL;
-	}
-
-	if (ch->h_commit) {
-		return ch->h_commit();
-	} else {
-		return 0;
-	}
+	return settings_commit_subtree(name);
 }


### PR DESCRIPTION
This replaces settings_runtime_commit() with a wrapper for settings_commit_subtree(), extending the functionality to support global commit and nested subtree commits.

Fixes #51703