### PR TITLE
Bluetooth: controller: llcp: update rx parameters upon receipt of PDU

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -97,6 +97,8 @@ void ull_dle_max_time_get(struct ll_conn *conn, uint16_t *max_rx_time,
 				    uint16_t *max_tx_time);
 
 uint8_t ull_dle_update_eff(struct ll_conn *conn);
+uint8_t ull_dle_update_eff_tx(struct ll_conn *conn);
+uint8_t ull_dle_update_eff_rx(struct ll_conn *conn);
 
 void ull_dle_local_tx_update(struct ll_conn *conn, uint16_t tx_octets, uint16_t tx_time);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -942,11 +942,12 @@ static void rp_comm_rx_decode(struct ll_conn *conn, struct proc_ctx *ctx, struct
 	case PDU_DATA_LLCTRL_TYPE_LENGTH_REQ:
 		llcp_pdu_decode_length_req(conn, pdu);
 		/* On reception of REQ mark RSP open for local piggy-back
-		 * Pause data tx, to ensure we can later (on RSP tx ack) update DLE without
+		 * Pause data tx, to ensure we can later (on RSP tx ack) update TX DLE without
 		 * conflicting with out-going LL Data PDUs
 		 * See BT Core 5.2 Vol6: B-4.5.10 & B-5.1.9
 		 */
 		llcp_tx_pause_data(conn, LLCP_TX_QUEUE_PAUSE_DATA_DATA_LENGTH);
+		ctx->data.dle.ntf_dle = ull_dle_update_eff_rx(conn);
 		break;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RSP)
@@ -1276,8 +1277,9 @@ static void rp_comm_st_wait_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, u
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 		case PROC_DATA_LENGTH_UPDATE: {
 			/* Apply changes in data lengths/times */
-			uint8_t dle_changed = ull_dle_update_eff(conn);
+			uint8_t dle_changed = ull_dle_update_eff_tx(conn);
 
+			dle_changed |= ctx->data.dle.ntf_dle;
 			llcp_tx_resume_data(conn, LLCP_TX_QUEUE_PAUSE_DATA_DATA_LENGTH);
 
 			if (dle_changed && !llcp_ntf_alloc_is_available()) {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -197,6 +197,12 @@ struct proc_ctx {
 		} pu;
 #endif /* CONFIG_BT_CTLR_PHY */
 
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
+		struct {
+			uint8_t ntf_dle;
+		} dle;
+#endif
+
 		/* Connection Update & Connection Parameter Request */
 		struct {
 			uint8_t error;


### PR DESCRIPTION
According to specification, when executing a remote procedure the rx parameters used need to be updated when the REQ from the peer is received. Currently this is done only when an ACK is received on the RSP PDU send out.
This commit updates the RX parameters upon receipt of the REQ PDU

Fixes #51693 

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>