### PR TITLE
dma: gpdma: fix cfg_hi and cfg_lo initialization

### DIFF
--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -179,7 +179,8 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 
 	/* default channel config */
 	chan_data->direction = cfg->channel_direction;
-
+	chan_data->cfg_lo = 0;
+	chan_data->cfg_hi = 0;
 
 	/* setup a list of lli structs. we don't need to allocate */
 	chan_data->lli = &dev_data->lli_pool[channel][0]; /* TODO allocate here */


### PR DESCRIPTION
If cfg_hi and cfg_lo are not set to zero in config setting, different dma slot value is bitwise ORred to the previous set value. Thus fix it.

Signed-off-by: Jaska Uimonen <jaska.uimonen@linux.intel.com>