### PR TITLE
net: lwm2m: We should not use read callbacks to generate new data

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -966,7 +966,15 @@ int lwm2m_engine_get_time(const char *pathstr, time_t *buf);
 /**
  * @brief Set resource (instance) read callback
  *
- * LwM2M clients can use this to set the callback function for resource reads.
+ * LwM2M clients can use this to set the callback function for resource reads when data
+ * handling in the LwM2M engine needs to be bypassed.
+ * For example reading back opaque binary data from external storage.
+ *
+ * This callback should not generally be used for any data that might be observed as
+ * engine does not have any knowledge of data changes.
+ *
+ * When separate buffer for data should be used, use lwm2m_engine_set_res_buf() instead
+ * to set the storage.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] cb Read resource callback


### PR DESCRIPTION
When read callbacks are used, it bypasses LwM2M engine data handling and therefore LwM2M observation cannot work properly.

Read callbacks should be used only on special cases.