### PR TITLE
qemu_x86_64: Use Qemu Q35 machine feature (ICH9)

### DIFF
--- a/boards/x86/qemu_x86/board.cmake
+++ b/boards/x86/qemu_x86/board.cmake
@@ -60,6 +60,7 @@ endif()
 set(QEMU_FLAGS_${ARCH}
   -m ${QEMU_MEMORY_SIZE_MB}
   -cpu ${QEMU_CPU_TYPE_${ARCH}}${QEMU_CPU_FLAGS}
+  -machine q35
   -device isa-debug-exit,iobase=0xf4,iosize=0x04
   ${REBOOT_FLAG}
   -nographic


### PR DESCRIPTION
Using very old machine does not make sense anymore. Switch to the new Q35 (https://wiki.qemu.org/Features/Q35). Among other things it allows to test SMBus and watchdog.