### PR TITLE
drivers: usb: mcux: mark endpoint unoccupied on disable

### DIFF
--- a/drivers/usb/device/usb_dc_mcux.c
+++ b/drivers/usb/device/usb_dc_mcux.c
@@ -457,6 +457,7 @@ int usb_dc_ep_disable(const uint8_t ep)
 	}
 
 	dev_state.eps[ep_abs_idx].ep_enabled = false;
+	dev_state.eps[ep_abs_idx].ep_occupied = false;
 
 	return 0;
 }


### PR DESCRIPTION
In `usb_dc_ep_disable()` mark an endpoint as unoccupied in addition to being disabled. This allows the endpoint to get enabled properly with a subsequent call to `usb_dc_ep_enable()`

See: zephyrproject-rtos/zephyr#51685

Signed-off-by: Milind Paranjpe <mparanjpe@yahoo.com>