### PR TITLE
drivers: usb: mcux: Deinit then Init endpoint HAL during config

### DIFF
--- a/drivers/usb/device/usb_dc_mcux.c
+++ b/drivers/usb/device/usb_dc_mcux.c
@@ -246,6 +246,7 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data *const cfg)
 	struct k_mem_block *block;
 	struct usb_ep_ctrl_data *eps = &dev_state.eps[ep_abs_idx];
 	usb_status_t status;
+	uint8_t ep;
 
 	ep_init.zlt = 0U;
 	ep_init.endpointAddress = cfg->ep_addr;
@@ -261,6 +262,14 @@ int usb_dc_ep_configure(const struct usb_dc_ep_cfg_data *const cfg)
 	if (dev_state.eps[ep_abs_idx].ep_enabled) {
 		LOG_WRN("Endpoint already configured");
 		return 0;
+	}
+
+	ep = cfg->ep_addr;
+	status = dev_state.dev_struct.controllerInterface->deviceControl(
+			dev_state.dev_struct.controllerHandle,
+			kUSB_DeviceControlEndpointDeinit, &ep);
+	if (kStatus_USB_Success != status) {
+		LOG_WRN("Failed to un-initialize endpoint (status=%d)", (int)status);
 	}
 
 	block = &(eps->block);


### PR DESCRIPTION
The USB device subsystem driver's `set_interface()` function calls `usb_dc_ep_configure()` followed by `usb_dc_ep_enable()`. When switching between alternate settings of a configuration's interface, `set_endpoint()` can be followed by `reset_endpoint()` on an endpoint. Some time later, `set_endpoint()` can be called again on the same endpoint. This results in the HAL's `kUSB_DeviceControlEndpointInit` function being called twice in a row, which causes a memory allocation error. A simple solution is to call the HAL's `kUSB_DeviceControlEndpointDeinit` function before calling `kUSB_DeviceControlEndpointInit`. This overcomes the memory allocation error.

Signed-off-by: Milind Paranjpe <mparanjpe@yahoo.com>