### PR TITLE
intel_adsp: strip rimage main.mod when CONFIG_BUILD_OUTPUT_STRIPPED

### DIFF
--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -99,3 +99,15 @@ add_custom_target(
       ${CMAKE_BINARY_DIR}/zephyr/main.mod
       ${CMAKE_BINARY_DIR}/zephyr/main.mod 2>${NULL_FILE}
 )
+
+if(CONFIG_BUILD_OUTPUT_STRIPPED)
+add_custom_command(
+  TARGET gen_modules POST_BUILD
+    COMMAND $<TARGET_PROPERTY:bintools,strip_command>
+            $<TARGET_PROPERTY:bintools,strip_flag>
+            $<TARGET_PROPERTY:bintools,strip_flag_all>
+            $<TARGET_PROPERTY:bintools,strip_flag_infile>${CMAKE_BINARY_DIR}/zephyr/main.mod
+            $<TARGET_PROPERTY:bintools,strip_flag_outfile>${CMAKE_BINARY_DIR}/zephyr/main-stripped.mod
+            $<TARGET_PROPERTY:bintools,strip_flag_final>
+)
+endif()


### PR DESCRIPTION
Be consistent with zephyr.strip

This will help with reproducibility issues like the one in https://github.com/thesofproject/sof-bin/pull/106

Use the `strip_command` introduced by commit c060b075a62e ("cmake: toolchain: bintools abstraction")

boot.mod is already deterministic because it has no debug symbols; no need to strip it.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>