### PR TITLE
Kconfig: enable CONFIG_BUILD_OUTPUT_STRIPPED by default

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -543,6 +543,7 @@ endif # BUILD_OUTPUT_UF2
 
 config BUILD_OUTPUT_STRIPPED
 	bool "Build a stripped binary"
+	default y
 	help
 	  Build a stripped binary zephyr/zephyr.strip in the build directory.
 	  The name of this file can be customized with CONFIG_KERNEL_BIN_NAME.


### PR DESCRIPTION
zephyr.strip is deterministic / reproducible while zephyr.elf is not because it has absolute filesystem paths. Create zephyr.strip by default.

This helps investigation of reproducibility issues like the one recently fixed by commit f896fc2306 ("scripts: gen_handles: Sort the device handles")

The extra disk space and build time are minimal and dwarfed by the security value: having a reproducible binary that can be checksummed makes it trivial to verify a Software Bill of Materials (https://www.cisa.gov/sbom) and help with supply chain attacks.

See also https://reproducible-builds.org/

Signed-off-by: Marc Herbert <marc.herbert@intel.com>