### PR TITLE
drivers/mm: Only disable unused RAM on Kconfig on Intel ADSP MTL

### DIFF
--- a/drivers/mm/Kconfig
+++ b/drivers/mm/Kconfig
@@ -17,6 +17,16 @@ config MM_DRV_PAGE_SIZE
 	help
 	  Size of memory pages.
 
+config MM_DRV_INTEL_ADSP_TLB_REMAP_UNUSED_RAM
+	bool "Power off unused RAM"
+	help
+	  Allows TLB driver to remap unused RAM - unused
+	  being defined as memory ranging from linker script
+	  defined "unused_l2_sram_start_marke" to end of RAM.
+	  Note that unused memory will be powered off by
+	  default. Disable this option if dynamically
+	  managing memory, such as by usinga heap allocator.
+
 config MM_DRV_INTEL_ADSP_MTL_TLB
 	bool "Intel Audio DSP TLB Driver for Meteor Lake"
 	default y

--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -84,6 +84,7 @@ SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF(
 		L2_SRAM_PAGES_NUM,
 		(uint8_t *) L2_SRAM_BASE);
 
+#ifdef CONFIG_MM_DRV_INTEL_ADSP_TLB_REMAP_UNUSED_RAM
 /* Define a marker which is placed by the linker script just after
  * last explicitly defined section. All .text, .data, .bss and .heap
  * sections should be placed before this marker in the memory.
@@ -94,6 +95,14 @@ __attribute__((__section__(".unused_ram_start_marker")))
 static int unused_l2_sram_start_marker = 0xba0babce;
 #define UNUSED_L2_START_ALIGNED ROUND_UP(POINTER_TO_UINT(&unused_l2_sram_start_marker), \
 					 CONFIG_MM_DRV_PAGE_SIZE)
+#else
+/* If memory is not going to be remaped (and thus powered off by)
+ * the driver, just define the unused memory start as the end of
+ * the memory.
+ */
+#define UNUSED_L2_START_ALIGNED ROUND_UP((L2_SRAM_BASE + L2_SRAM_SIZE), \
+					 CONFIG_MM_DRV_PAGE_SIZE)
+#endif
 
 /**
  * Calculate TLB entry based on physical address.
@@ -682,6 +691,7 @@ static int sys_mm_drv_mm_init(const struct device *dev)
 		hpsram_ref[i] = SRAM_BANK_SIZE / CONFIG_MM_DRV_PAGE_SIZE;
 	}
 
+#ifdef CONFIG_MM_DRV_INTEL_ADSP_TLB_REMAP_UNUSED_RAM
 	/*
 	 * find virtual address range which are unused
 	 * in the system
@@ -703,6 +713,7 @@ static int sys_mm_drv_mm_init(const struct device *dev)
 
 	ret = sys_mm_drv_unmap_region(UINT_TO_POINTER(UNUSED_L2_START_ALIGNED),
 				      unused_size);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Disabling by default can confuse things that dynamically manage RAM, such as newlib heap. So this patch shields this behaviour befault a non-default Kconfig.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>