### PR TITLE
Bluetooth: Shell: Select BT_TICKER_NEXT_SLOT_GET when BT_LL_SW_SPLIT

### DIFF
--- a/subsys/bluetooth/shell/Kconfig
+++ b/subsys/bluetooth/shell/Kconfig
@@ -6,6 +6,7 @@
 config BT_SHELL
 	bool "Bluetooth shell"
 	select SHELL
+	select BT_TICKER_NEXT_SLOT_GET if BT_LL_SW_SPLIT
 	help
 	  Activate shell module that provides Bluetooth commands to the
 	  console.


### PR DESCRIPTION
Select BT_TICKER_NEXT_SLOT_GET when BT_LL_SW_SPLIT enabled and building applications with shell support (BT_SHELL).

Fixes #51631.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>