### PR TITLE
tests: add missing 'picolibc' tag to cpp test

### DIFF
--- a/tests/subsys/cpp/cxx/testcase.yaml
+++ b/tests/subsys/cpp/cxx/testcase.yaml
@@ -21,6 +21,7 @@ tests:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_NEWLIB_LIBC_NANO=y
   cpp.main.picolibc:
+    tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_PICOLIBC=y


### PR DESCRIPTION
All other picolibc-related tests have this tag.
This allows easy exclusion of picolibc-related tests from a twister run.
