### PR TITLE
shell: shell_log_backend: take buffer size from config

### DIFF
--- a/include/zephyr/shell/shell_log_backend.h
+++ b/include/zephyr/shell/shell_log_backend.h
@@ -72,7 +72,8 @@ int z_shell_log_backend_output_func(uint8_t *data, size_t length, void *ctx);
 	LOG_OUTPUT_DEFINE(_name##_log_output, z_shell_log_backend_output_func,\
 			  _buf, _size); \
 	static struct shell_log_backend_control_block _name##_control_block; \
-	static uint32_t __aligned(Z_LOG_MSG2_ALIGNMENT) _name##_buf[128]; \
+	static uint32_t __aligned(Z_LOG_MSG2_ALIGNMENT) \
+			_name##_buf[_queue_size / sizeof(uint32_t)]; \
 	const struct mpsc_pbuf_buffer_config _name##_mpsc_buffer_config = { \
 		.buf = _name##_buf, \
 		.size = ARRAY_SIZE(_name##_buf), \

--- a/subsys/shell/Kconfig.template.shell_log_queue_size
+++ b/subsys/shell/Kconfig.template.shell_log_queue_size
@@ -4,8 +4,8 @@ config $(module)_LOG_MESSAGE_QUEUE_SIZE
 	int "Log message queue size"
 	default $(default-size)
 	help
-	  Amount of messages that can enqueued in order to be processed by shell
-	  thread. Too small queue may lead to logger thread being blocked
+	  Size of buffer for messages that can be enqueued in order to be processed
+	  by shell thread. Too small queue may lead to the logger thread being blocked
 	  (see $(module)_LOG_MESSAGE_QUEUE_TIMEOUT). Too big queue on relatively
-	  slow shell transport may lead to situation where logs are dropped
+	  slow shell transport may lead to situations where logs are dropped
 	  because all log messages are enqueued.

--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -82,7 +82,7 @@ module = SHELL_BACKEND_SERIAL
 default-timeout = 100
 source "subsys/shell/Kconfig.template.shell_log_queue_timeout"
 
-default-size = 10
+default-size = 512
 source "subsys/shell/Kconfig.template.shell_log_queue_size"
 
 choice


### PR DESCRIPTION
Use LOG_MESSAGE_QUEUE_SIZE config instead of hardcoded value. LOG_MESSAGE_QUEUE_SIZE default value has been changed to 512, so it is now matching to the hardcoded value.

Signed-off-by: Wojciech Slenska <wsl@trackunit.com>