### PR TITLE
Bluetooth: Controller: Ext header max size reservation and BIS access address fixes

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1463,7 +1463,8 @@ uint8_t ll_adv_enable(uint8_t enable)
 				ticks_anchor + ticks_slot +
 				HAL_TICKER_US_TO_TICKS(
 					MAX(EVENT_MAFS_US,
-					    EVENT_OVERHEAD_START_US) +
+					    EVENT_OVERHEAD_START_US) -
+					EVENT_OVERHEAD_START_US +
 					(EVENT_TICKER_RES_MARGIN_US << 1));
 
 			ticks_slot_overhead_aux =
@@ -1503,7 +1504,8 @@ uint8_t ll_adv_enable(uint8_t enable)
 					ticks_anchor_aux + ticks_slot_aux +
 					HAL_TICKER_US_TO_TICKS(
 						MAX(EVENT_MAFS_US,
-						    EVENT_OVERHEAD_START_US) +
+						    EVENT_OVERHEAD_START_US) -
+						EVENT_OVERHEAD_START_US +
 						(EVENT_TICKER_RES_MARGIN_US << 1));
 
 				ret = ull_adv_sync_start(adv, sync,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -2475,7 +2475,8 @@ uint32_t ull_adv_aux_evt_init(struct ll_adv_aux_set *aux,
 		*ticks_anchor = ticks_anchor_aux;
 		*ticks_anchor += HAL_TICKER_US_TO_TICKS(
 					MAX(EVENT_MAFS_US,
-					    EVENT_OVERHEAD_START_US) +
+					    EVENT_OVERHEAD_START_US) -
+					EVENT_OVERHEAD_START_US +
 					(EVENT_TICKER_RES_MARGIN_US << 1));
 	}
 #endif /* CONFIG_BT_CTLR_SCHED_ADVANCED */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -105,6 +105,7 @@ uint8_t ll_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
 	uint32_t ret;
 	uint8_t err;
 	uint8_t bn;
+	int res;
 
 	adv_iso = adv_iso_get(big_handle);
 
@@ -296,7 +297,8 @@ uint8_t ll_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
 	lll_adv_iso->sdu_interval = sdu_interval;
 	lll_adv_iso->max_sdu = max_sdu;
 
-	util_saa_le32(lll_adv_iso->seed_access_addr, big_handle);
+	res = util_saa_le32(lll_adv_iso->seed_access_addr, big_handle);
+	LL_ASSERT(!res);
 
 	lll_csrand_get(lll_adv_iso->base_crc_init,
 		       sizeof(lll_adv_iso->base_crc_init));

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -860,7 +860,8 @@ static uint32_t adv_iso_start(struct ll_adv_iso_set *adv_iso,
 	if (!err) {
 		ticks_anchor += HAL_TICKER_US_TO_TICKS(
 					MAX(EVENT_MAFS_US,
-					    EVENT_OVERHEAD_START_US) +
+					    EVENT_OVERHEAD_START_US) -
+					EVENT_OVERHEAD_START_US +
 					(EVENT_TICKER_RES_MARGIN_US << 1));
 	} else {
 		ticks_anchor = ticker_ticks_now_get() +

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -892,6 +892,7 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 				HAL_TICKER_US_TO_TICKS(
 					MAX(EVENT_MAFS_US,
 					    EVENT_OVERHEAD_START_US) -
+					EVENT_OVERHEAD_START_US +
 					(EVENT_TICKER_RES_MARGIN_US << 1));
 		}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -52,6 +52,8 @@ static uint8_t adv_type_check(struct ll_adv_set *adv);
 static inline struct ll_adv_sync_set *sync_acquire(void);
 static inline void sync_release(struct ll_adv_sync_set *sync);
 static inline uint16_t sync_handle_get(struct ll_adv_sync_set *sync);
+static uint32_t ull_adv_sync_pdu_time_get(const struct ll_adv_sync_set *sync,
+					  const struct pdu_adv *pdu);
 static inline uint8_t sync_remove(struct ll_adv_sync_set *sync,
 				  struct ll_adv_set *adv, uint8_t enable);
 static uint8_t sync_chm_update(uint8_t handle);
@@ -1071,8 +1073,7 @@ uint32_t ull_adv_sync_start(struct ll_adv_set *adv,
 	lll_sync = &sync->lll;
 	ter_pdu = lll_adv_sync_data_peek(lll_sync, NULL);
 
-	/* Calculate the PDU Tx Time and hence the radio event length */
-	time_us = ull_adv_sync_time_get(sync, ter_pdu->len);
+	time_us = ull_adv_sync_pdu_time_get(sync, ter_pdu);
 
 	/* TODO: active_to_start feature port */
 	sync->ull.ticks_active_to_start = 0U;
@@ -1118,7 +1119,7 @@ uint8_t ull_adv_sync_time_update(struct ll_adv_sync_set *sync,
 	uint32_t time_us;
 	uint32_t ret;
 
-	time_us = ull_adv_sync_time_get(sync, pdu->len);
+	time_us = ull_adv_sync_pdu_time_get(sync, pdu);
 	time_ticks = HAL_TICKER_US_TO_TICKS(time_us);
 	if (sync->ull.ticks_slot > time_ticks) {
 		ticks_minus = sync->ull.ticks_slot - time_ticks;
@@ -1886,6 +1887,23 @@ static inline uint16_t sync_handle_get(struct ll_adv_sync_set *sync)
 {
 	return mem_index_get(sync, ll_adv_sync_pool,
 			     sizeof(struct ll_adv_sync_set));
+}
+
+static uint32_t ull_adv_sync_pdu_time_get(const struct ll_adv_sync_set *sync,
+					  const struct pdu_adv *pdu)
+{
+	uint8_t len;
+
+	/* Calculate the PDU Tx Time and hence the radio event length,
+	 * Always use maximum length for common extended header format so that
+	 * ACAD could be update when periodic advertising is active and the
+	 * time reservation need not be updated everytime avoiding overlapping
+	 * with other active states/roles.
+	 */
+	len = pdu->len - pdu->adv_ext_ind.ext_hdr_len -
+	      PDU_AC_EXT_HEADER_SIZE_MIN + PDU_AC_EXT_HEADER_SIZE_MAX;
+
+	return ull_adv_sync_time_get(sync, len);
 }
 
 static uint8_t sync_stop(struct ll_adv_sync_set *sync)

--- a/subsys/bluetooth/controller/util/util.c
+++ b/subsys/bluetooth/controller/util/util.c
@@ -219,16 +219,21 @@ again:
 }
 
 #if defined(CONFIG_BT_CTLR_ADV_ISO)
-void util_saa_le32(uint8_t *dst, uint8_t handle)
+int util_saa_le32(uint8_t *dst, uint8_t handle)
 {
 	/* Refer to Bluetooth Core Specification Version 5.2 Vol 6, Part B,
 	 * section 2.1.2 Access Address
 	 */
 	uint32_t saa, saa_15, saa_16;
 	uint8_t bits;
+	int err;
 
-	/* Get random number */
-	lll_csrand_get(dst, sizeof(uint32_t));
+	/* Get access address */
+	err = util_aa_le32(dst);
+	if (err) {
+		return err;
+	}
+
 	saa = sys_get_le32(dst);
 
 	/* SAA_19 = SAA_15 */
@@ -264,6 +269,8 @@ void util_saa_le32(uint8_t *dst, uint8_t handle)
 	saa |= (handle * 0x03);
 
 	sys_put_le32(saa, dst);
+
+	return 0;
 }
 #endif /* CONFIG_BT_CTLR_ADV_ISO */
 

--- a/subsys/bluetooth/controller/util/util.h
+++ b/subsys/bluetooth/controller/util/util.h
@@ -15,5 +15,5 @@
 
 uint8_t util_ones_count_get(const uint8_t *octets, uint8_t octets_len);
 int util_aa_le32(uint8_t *dst);
-void util_saa_le32(uint8_t *dst, uint8_t handle);
+int util_saa_le32(uint8_t *dst, uint8_t handle);
 void util_bis_aa_le32(uint8_t bis, uint8_t *saa, uint8_t *dst);


### PR DESCRIPTION
Fix BIS access address generation to follow the requirements
in Bluetooth Core Specification v5.3, Vol 6, PartB, Section
2.1.2 Access Address.

Ensure maximum size of common extended header format be
reserved when CONFIG_BT_CTLR_ADV_RESERVE_MAX=n is used so
that changes to ACAD, like channel map update does not need
frequent update to periodic advertising auxiliary channel
PDU time reservations.

When calculating the offsets between primary advertising
PDU, auxiliary PDU, Periodic Advertising PDU, and BIS PDU,
the values used as anchor points for starting the periodic
interval for auxiliary, periodic and BIG events, should be
ensured to have the minimum auxiliary frame spacing T_MAFS
between the PDUs. EVENT_OVERHEAD_START_US has to be reduced
as this value is used to offset the start of the radio
event on air.

Reverts commit https://github.com/zephyrproject-rtos/zephyr/commit/b867f0e8a629880e9a1536c084d8f3785a42754b ("Bluetooth: Controller: Fix T_MAFS between broadcasting roles").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>