### PR TITLE
drivers: can: add support for CAN emulation in QEMU

### DIFF
--- a/arch/x86/core/early_serial.c
+++ b/arch/x86/core/early_serial.c
@@ -88,7 +88,7 @@ void z_x86_early_serial_init(void)
 {
 #if defined(DEVICE_MMIO_IS_IN_RAM) && !defined(CONFIG_UART_NS16550_ACCESS_IOPORT)
 #ifdef X86_SOC_EARLY_SERIAL_PCIDEV
-	struct pcie_mbar mbar;
+	struct pcie_bar mbar;
 	pcie_get_mbar(X86_SOC_EARLY_SERIAL_PCIDEV, 0, &mbar);
 	pcie_set_cmd(X86_SOC_EARLY_SERIAL_PCIDEV, PCIE_CONF_CMDSTAT_MEM, true);
 	device_map(&mmio, mbar.phys_addr, mbar.size, K_MEM_CACHE_NONE);

--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -13,6 +13,7 @@
 #define DT_FLASH_SIZE		DT_SIZE_K(4096)
 
 #include <intel/ia32.dtsi>
+#include <zephyr/dt-bindings/pcie/pcie.h>
 
 / {
 	model = "QEMU X86 emulator";
@@ -41,6 +42,30 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,flash-controller = &sim_flash;
 		zephyr,ieee802154 = &ieee802154;
+		zephyr,canbus = &can0;
+	};
+
+	pcie0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "intel,pcie";
+		ranges;
+
+		can0: can@1800 {
+			compatible = "kvaser,pcican";
+			status = "okay";
+			reg = <PCIE_BDF(0,2,0) PCIE_ID(0x10e8,0x8406)>;
+			interrupts = <11 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			sjw = <1>;
+			bus-speed = <125000>;
+			sample-point = <875>;
+
+			can-transceiver {
+				max-bitrate = <1000000>;
+			};
+		};
+
 	};
 
 	soc {

--- a/boards/x86/qemu_x86/qemu_x86.yaml
+++ b/boards/x86/qemu_x86/qemu_x86.yaml
@@ -12,5 +12,6 @@ supported:
   - nvs
   - netif:serial-net
   - eeprom
+  - can
 testing:
   default: true

--- a/boards/x86/qemu_x86/qemu_x86_64.yaml
+++ b/boards/x86/qemu_x86/qemu_x86_64.yaml
@@ -6,6 +6,8 @@ toolchain:
   - zephyr
   - xtools
 simulation: qemu
+supported:
+  - can
 testing:
   default: true
   ignore_tags:

--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -269,6 +269,22 @@ elseif(QEMU_NET_STACK)
   endif()
 endif(QEMU_PIPE_STACK)
 
+if(CONFIG_CAN)
+  # Add CAN bus 0
+  list(APPEND QEMU_FLAGS -object can-bus,id=canbus0)
+
+  if(NOT "${CONFIG_CAN_QEMU_IFACE_NAME}" STREQUAL "")
+    # Connect CAN bus 0 to host SocketCAN interface
+    list(APPEND QEMU_FLAGS
+      -object can-host-socketcan,id=canhost0,if=${CONFIG_CAN_QEMU_IFACE_NAME},canbus=canbus0)
+  endif()
+
+  if(CONFIG_CAN_KVASER_PCI)
+    # Emulate a single-channel Kvaser PCIcan card connected to CAN bus 0
+    list(APPEND QEMU_FLAGS -device kvaser_pci,canbus=canbus0)
+  endif()
+endif()
+
 if(CONFIG_X86_64 AND NOT CONFIG_QEMU_UEFI_BOOT)
   # QEMU doesn't like 64-bit ELF files. Since we don't use any >4GB
   # addresses, converting it to 32-bit is safe enough for emulation.

--- a/doc/kernel/drivers/index.rst
+++ b/doc/kernel/drivers/index.rst
@@ -606,7 +606,7 @@ may be used directly:
    void some_init_code(...)
    {
       ...
-      struct pcie_mbar mbar;
+      struct pcie_bar mbar;
       bool bar_found = pcie_get_mbar(bdf, index, &mbar);
 
       device_map(DEVICE_MMIO_RAM_PTR(dev), mbar.phys_addr, mbar.size, K_MEM_CACHE_NONE);

--- a/drivers/can/CMakeLists.txt
+++ b/drivers/can/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 
 zephyr_library_sources_ifdef(CONFIG_CAN_SJA1000      can_sja1000.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_ESP32_TWAI   can_esp32_twai.c)
+zephyr_library_sources_ifdef(CONFIG_CAN_KVASER_PCI   can_kvaser_pci.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE        can_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_SHELL        can_shell.c)

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -89,6 +89,15 @@ config CAN_AUTO_BUS_OFF_RECOVERY
 	  recessive bits). When this option is enabled, the recovery API is not
 	  available.
 
+config CAN_QEMU_IFACE_NAME
+	string "SocketCAN interface name for QEMU"
+	default ""
+	depends on QEMU_TARGET
+	help
+	  The SocketCAN interface name for QEMU. This value, if set, is given as "if" parameter to
+	  the "-object can-host-socketcan" qemu command line option. The CAN interface must be
+	  configured before starting QEMU.
+
 source "drivers/can/Kconfig.sam"
 source "drivers/can/Kconfig.stm32"
 source "drivers/can/Kconfig.stm32fd"

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -101,6 +101,7 @@ source "drivers/can/Kconfig.loopback"
 source "drivers/can/Kconfig.native_posix_linux"
 source "drivers/can/Kconfig.sja1000"
 source "drivers/can/Kconfig.esp32"
+source "drivers/can/Kconfig.kvaser"
 
 source "drivers/can/transceiver/Kconfig"
 

--- a/drivers/can/Kconfig.kvaser
+++ b/drivers/can/Kconfig.kvaser
@@ -1,0 +1,13 @@
+# Kvaser PCIcan configuration options
+
+# Copyright (c) 2022 Henrik Brix Andersen <henrik@brixandersen.dk>
+# SPDX-License-Identifier: Apache-2.0
+
+config CAN_KVASER_PCI
+	bool "Kvaser PCIcan driver"
+	default y
+	depends on DT_HAS_KVASER_PCICAN_ENABLED
+	select PCIE
+	select CAN_SJA1000
+	help
+	  This enables support for the Kvaser PCIcan.

--- a/drivers/can/can_kvaser_pci.c
+++ b/drivers/can/can_kvaser_pci.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2022 Henrik Brix Andersen <henrik@brixandersen.dk>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT kvaser_pcican
+
+#include "can_sja1000.h"
+
+#include <zephyr/drivers/can.h>
+#include <zephyr/drivers/pcie/pcie.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+LOG_MODULE_REGISTER(can_kvaser_pci, CONFIG_CAN_LOG_LEVEL);
+
+/* AMCC S5920 I/O BAR registers */
+#define S5920_INTCSR_REG       0x38
+#define S5920_INTCSR_ADDINT_EN BIT(13)
+#define S5920_PTCR_REG	       0x60
+
+/* Xilinx I/O BAR registers */
+#define XLNX_VERINT_REG		0x07
+#define XLNX_VERINT_VERSION_POS 4U
+
+struct can_kvaser_pci_config {
+	pcie_bdf_t pcie_bdf;
+	pcie_id_t pcie_id;
+	void (*irq_config_func)(const struct device *dev);
+};
+
+struct can_kvaser_pci_data {
+	io_port_t sja1000_base;
+};
+
+static uint8_t can_kvaser_pci_read_reg(const struct device *dev, uint8_t reg)
+{
+	struct can_sja1000_data *sja1000_data = dev->data;
+	struct can_kvaser_pci_data *kvaser_data = sja1000_data->custom;
+	io_port_t addr = kvaser_data->sja1000_base + reg;
+
+	return sys_in8(addr);
+}
+
+static void can_kvaser_pci_write_reg(const struct device *dev, uint8_t reg, uint8_t val)
+{
+	struct can_sja1000_data *sja1000_data = dev->data;
+	struct can_kvaser_pci_data *kvaser_data = sja1000_data->custom;
+	io_port_t addr = kvaser_data->sja1000_base + reg;
+
+	sys_out8(val, addr);
+}
+
+static int can_kvaser_pci_get_core_clock(const struct device *dev, uint32_t *rate)
+{
+	ARG_UNUSED(dev);
+
+	/* The internal clock operates at half of the oscillator frequency */
+	*rate = MHZ(16) / 2;
+
+	return 0;
+}
+
+static int can_kvaser_pci_init(const struct device *dev)
+{
+	const struct can_sja1000_config *sja1000_config = dev->config;
+	const struct can_kvaser_pci_config *kvaser_config = sja1000_config->custom;
+	struct can_sja1000_data *sja1000_data = dev->data;
+	struct can_kvaser_pci_data *kvaser_data = sja1000_data->custom;
+	struct pcie_bar iobar;
+	static io_port_t amcc_base;
+	static io_port_t xlnx_base;
+	uint32_t intcsr;
+	int err;
+
+	if (!pcie_probe(kvaser_config->pcie_bdf, kvaser_config->pcie_id)) {
+		LOG_ERR("failed to probe PCI(e)");
+		return -ENODEV;
+	}
+
+	pcie_set_cmd(kvaser_config->pcie_bdf, PCIE_CONF_CMDSTAT_IO, true);
+
+	/* AMCC S5920 registers */
+	if (!pcie_probe_iobar(kvaser_config->pcie_bdf, 0, &iobar)) {
+		LOG_ERR("failed to probe AMCC S5920 I/O BAR");
+		return -ENODEV;
+	}
+
+	amcc_base = iobar.phys_addr;
+
+	/* SJA1000 registers */
+	if (!pcie_probe_iobar(kvaser_config->pcie_bdf, 1, &iobar)) {
+		LOG_ERR("failed to probe SJA1000 I/O BAR");
+		return -ENODEV;
+	}
+
+	kvaser_data->sja1000_base = iobar.phys_addr;
+
+	/* Xilinx registers */
+	if (!pcie_probe_iobar(kvaser_config->pcie_bdf, 2, &iobar)) {
+		LOG_ERR("failed to probe Xilinx I/O BAR");
+		return -ENODEV;
+	}
+
+	xlnx_base = iobar.phys_addr;
+	LOG_DBG("Xilinx version: %d",
+		sys_in8(xlnx_base + XLNX_VERINT_REG) >> XLNX_VERINT_VERSION_POS);
+
+	/*
+	 * Initialization sequence as per Kvaser PCIcan Hardware Reference Manual (UG 98048
+	 * v3.0.0).
+	 */
+
+	/* AMCC S5920 PCI Pass-Thru Configuration Register (PTCR) */
+	sys_out32(0x80808080UL, amcc_base + S5920_PTCR_REG);
+
+	/* AMCC S5920 PCI Interrupt Control/Status Register (INTCSR) */
+	intcsr = sys_in32(amcc_base + S5920_INTCSR_REG);
+	intcsr |= S5920_INTCSR_ADDINT_EN;
+	sys_out32(intcsr, amcc_base + S5920_INTCSR_REG);
+
+	err = can_sja1000_init(dev);
+	if (err != 0) {
+		LOG_ERR("failed to initialize controller (err %d)", err);
+		return err;
+	}
+
+	kvaser_config->irq_config_func(dev);
+
+	return 0;
+}
+
+const struct can_driver_api can_kvaser_pci_driver_api = {
+	.get_capabilities = can_sja1000_get_capabilities,
+	.start = can_sja1000_start,
+	.stop = can_sja1000_stop,
+	.set_mode = can_sja1000_set_mode,
+	.set_timing = can_sja1000_set_timing,
+	.send = can_sja1000_send,
+	.add_rx_filter = can_sja1000_add_rx_filter,
+	.remove_rx_filter = can_sja1000_remove_rx_filter,
+	.get_state = can_sja1000_get_state,
+	.set_state_change_callback = can_sja1000_set_state_change_callback,
+	.get_core_clock = can_kvaser_pci_get_core_clock,
+	.get_max_filters = can_sja1000_get_max_filters,
+	.get_max_bitrate = can_sja1000_get_max_bitrate,
+#ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
+	.recover = can_sja1000_recover,
+#endif /* !CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
+	.timing_min = CAN_SJA1000_TIMING_MIN_INITIALIZER,
+	.timing_max = CAN_SJA1000_TIMING_MAX_INITIALIZER,
+};
+
+#define CAN_KVASER_PCI_OCR                                                                         \
+	(CAN_SJA1000_OCR_OCMODE_NORMAL | CAN_SJA1000_OCR_OCTN0 | CAN_SJA1000_OCR_OCTP0 |           \
+	 CAN_SJA1000_OCR_OCTN1 | CAN_SJA1000_OCR_OCTP1)
+
+#define CAN_KVASER_PCI_CDR (CAN_SJA1000_CDR_CD_DIV2 | CAN_SJA1000_CDR_CLOCK_OFF)
+
+#define CAN_KVASER_PCI_INIT(inst)                                                                  \
+	static void can_kvaser_pci_config_func_##inst(const struct device *dev);                   \
+                                                                                                   \
+	static const struct can_kvaser_pci_config can_kvaser_pci_config_##inst = {                 \
+		.pcie_bdf = DT_INST_REG_ADDR(inst),                                                \
+		.pcie_id = DT_INST_REG_SIZE(inst),                                                 \
+		.irq_config_func = can_kvaser_pci_config_func_##inst                               \
+	};                                                                                         \
+                                                                                                   \
+	static const struct can_sja1000_config can_sja1000_config_##inst =                         \
+		CAN_SJA1000_DT_CONFIG_INST_GET(inst, &can_kvaser_pci_config_##inst,                \
+					       can_kvaser_pci_read_reg, can_kvaser_pci_write_reg,  \
+					       CAN_KVASER_PCI_OCR, CAN_KVASER_PCI_CDR);            \
+                                                                                                   \
+	static struct can_kvaser_pci_config can_kvaser_pci_data_##inst;                            \
+                                                                                                   \
+	static struct can_sja1000_data can_sja1000_data_##inst =                                   \
+		CAN_SJA1000_DATA_INITIALIZER(&can_kvaser_pci_data_##inst);                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, can_kvaser_pci_init, NULL, &can_sja1000_data_##inst,           \
+			      &can_sja1000_config_##inst, POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,   \
+			      &can_kvaser_pci_driver_api);                                         \
+                                                                                                   \
+	static void can_kvaser_pci_config_func_##inst(const struct device *dev)                    \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), can_sja1000_isr,      \
+			    DEVICE_DT_INST_GET(inst), DT_INST_IRQ(inst, sense));                   \
+		irq_enable(DT_INST_IRQN(inst));                                                    \
+	}
+
+DT_INST_FOREACH_STATUS_OKAY(CAN_KVASER_PCI_INIT)

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -238,7 +238,7 @@ int e1000_probe(const struct device *ddev)
 	const pcie_bdf_t bdf = PCIE_BDF(0, 3, 0);
 	struct e1000_dev *dev = ddev->data;
 	uint32_t ral, rah;
-	struct pcie_mbar mbar;
+	struct pcie_bar mbar;
 
 	if (!pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
 				     PCI_DEVICE_ID_I82540EM))) {

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -849,7 +849,7 @@ static int i2c_dw_initialize(const struct device *dev)
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
 	if (rom->pcie) {
-		struct pcie_mbar mbar;
+		struct pcie_bar mbar;
 
 		if (!pcie_probe(rom->pcie_bdf, rom->pcie_id)) {
 			return -EINVAL;

--- a/drivers/pcie/host/msi.c
+++ b/drivers/pcie/host/msi.c
@@ -84,7 +84,7 @@ static bool map_msix_table_entries(pcie_bdf_t bdf,
 {
 	uint32_t table_offset;
 	uint8_t table_bir;
-	struct pcie_mbar bar;
+	struct pcie_bar bar;
 	uintptr_t mapped_table;
 	int i;
 

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -333,7 +333,7 @@ static int uart_ns16550_configure(const struct device *dev,
 #ifndef CONFIG_UART_NS16550_ACCESS_IOPORT
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
 	if (dev_cfg->pcie) {
-		struct pcie_mbar mbar;
+		struct pcie_bar mbar;
 
 		if (!pcie_probe(dev_cfg->pcie_bdf, dev_cfg->pcie_id)) {
 			ret = -EINVAL;

--- a/drivers/virtualization/virt_ivshmem.c
+++ b/drivers/virtualization/virt_ivshmem.c
@@ -108,7 +108,7 @@ static const struct ivshmem_reg no_reg;
 static bool ivshmem_configure(const struct device *dev)
 {
 	struct ivshmem *data = dev->data;
-	struct pcie_mbar mbar_regs, mbar_mem;
+	struct pcie_bar mbar_regs, mbar_mem;
 
 	if (!pcie_get_mbar(data->bdf, IVSHMEM_PCIE_REG_BAR_IDX, &mbar_regs)) {
 #ifdef CONFIG_IVSHMEM_DOORBELL

--- a/dts/bindings/can/kvaser,pcican.yaml
+++ b/dts/bindings/can/kvaser,pcican.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 Henrik Brix Andersen <henrik@brixandersen.dk>
+# SPDX-License-Identifier: Apache-2.0
+
+description: Kvaser PCIcan
+
+compatible: "kvaser,pcican"
+
+include: can-controller.yaml
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: true

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -310,6 +310,7 @@ kobol	Kobol Innovations Pte. Ltd.
 koe	Kaohsiung Opto-Electronics Inc.
 kontron	Kontron S&T AG
 kosagi	Sutajio Ko-Usagi PTE Ltd.
+kvaser	Kvaser
 kvg	Kverneland Group
 kyo	Kyocera Corporation
 lacie	LaCie

--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -36,7 +36,7 @@ typedef uint32_t pcie_bdf_t;
  */
 typedef uint32_t pcie_id_t;
 
-struct pcie_mbar {
+struct pcie_bar {
 	uintptr_t phys_addr;
 	size_t size;
 };
@@ -91,18 +91,18 @@ extern bool pcie_probe(pcie_bdf_t bdf, pcie_id_t id);
  * @brief Get the MBAR at a specific BAR index
  * @param bdf the PCI(e) endpoint
  * @param bar_index 0-based BAR index
- * @param mbar Pointer to struct pcie_mbar
+ * @param mbar Pointer to struct pcie_bar
  * @return true if the mbar was found and is valid, false otherwise
  */
 extern bool pcie_get_mbar(pcie_bdf_t bdf,
 			  unsigned int bar_index,
-			  struct pcie_mbar *mbar);
+			  struct pcie_bar *mbar);
 
 /**
  * @brief Probe the nth MMIO address assigned to an endpoint.
  * @param bdf the PCI(e) endpoint
  * @param index (0-based) index
- * @param mbar Pointer to struct pcie_mbar
+ * @param mbar Pointer to struct pcie_bar
  * @return true if the mbar was found and is valid, false otherwise
  *
  * A PCI(e) endpoint has 0 or more memory-mapped regions. This function
@@ -113,7 +113,35 @@ extern bool pcie_get_mbar(pcie_bdf_t bdf,
  */
 extern bool pcie_probe_mbar(pcie_bdf_t bdf,
 			    unsigned int index,
-			    struct pcie_mbar *mbar);
+			    struct pcie_bar *mbar);
+
+/**
+ * @brief Get the I/O BAR at a specific BAR index
+ * @param bdf the PCI(e) endpoint
+ * @param bar_index 0-based BAR index
+ * @param iobar Pointer to struct pcie_bar
+ * @return true if the I/O BAR was found and is valid, false otherwise
+ */
+extern bool pcie_get_iobar(pcie_bdf_t bdf,
+			   unsigned int bar_index,
+			   struct pcie_bar *iobar);
+
+/**
+ * @brief Probe the nth I/O BAR address assigned to an endpoint.
+ * @param bdf the PCI(e) endpoint
+ * @param index (0-based) index
+ * @param iobar Pointer to struct pcie_bar
+ * @return true if the I/O BAR was found and is valid, false otherwise
+ *
+ * A PCI(e) endpoint has 0 or more I/O regions. This function
+ * allows the caller to enumerate them by calling with index=0..n.
+ * Value of n has to be below 6, as there is a maximum of 6 BARs. The indices
+ * are order-preserving with respect to the endpoint BARs: e.g., index 0
+ * will return the lowest-numbered I/O BAR on the endpoint.
+ */
+extern bool pcie_probe_iobar(pcie_bdf_t bdf,
+			     unsigned int index,
+			     struct pcie_bar *iobar);
 
 /**
  * @brief Set or reset bits in the endpoint command/status register.

--- a/samples/drivers/can/counter/sample.yaml
+++ b/samples/drivers/can/counter/sample.yaml
@@ -4,7 +4,7 @@ tests:
   sample.drivers.can.counter:
     tags: can
     depends_on: can
-    filter: dt_chosen_enabled("zephyr,canbus")
+    filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")
     harness: console
     harness_config:
       type: one_line

--- a/samples/modules/canopennode/sample.yaml
+++ b/samples/modules/canopennode/sample.yaml
@@ -19,7 +19,7 @@ tests:
     platform_exclude: nucleo_h723zg nucleo_h743zi nucleo_h745zi_q nucleo_h753zi
   sample.modules.canopennode.program_download:
     build_only: true
-    platform_exclude: native_posix native_posix_64 rcar_h3ulcb_cr7
+    platform_exclude: native_posix native_posix_64 rcar_h3ulcb_cr7 qemu_x86 qemu_x86_64
     filter: dt_label_with_parent_compat_enabled("slot0_partition", "fixed-partitions") and
             dt_label_with_parent_compat_enabled("slot1_partition", "fixed-partitions") and
             dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions") and

--- a/samples/net/sockets/can/sample.yaml
+++ b/samples/net/sockets/can/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: SocketCAN sample
 common:
   tags: net socket can
-  filter: dt_chosen_enabled("zephyr,canbus")
+  filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")
   depends_on: can
   harness: console
 tests:

--- a/tests/drivers/can/api/testcase.yaml
+++ b/tests/drivers/can/api/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   drivers.can.api:
     tags: drivers can
     depends_on: can
-    filter: dt_chosen_enabled("zephyr,canbus")
+    filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")
   drivers.can.api.mcp2515:
     tags: drivers can
     depends_on: arduino_spi arduino_gpio

--- a/tests/subsys/canbus/isotp/conformance/testcase.yaml
+++ b/tests/subsys/canbus/isotp/conformance/testcase.yaml
@@ -2,5 +2,5 @@ tests:
   canbus.isotp.conformance:
     tags: can isotp
     depends_on: can
-    filter: dt_chosen_enabled("zephyr,canbus")
+    filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")
     platform_exclude: native_posix native_posix_64

--- a/tests/subsys/canbus/isotp/implementation/testcase.yaml
+++ b/tests/subsys/canbus/isotp/implementation/testcase.yaml
@@ -2,5 +2,5 @@ tests:
   canbus.isotp.implementation:
     tags: can isotp
     depends_on: can
-    filter: dt_chosen_enabled("zephyr,canbus")
+    filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")
     platform_exclude: native_posix native_posix_64


### PR DESCRIPTION
- drivers: pcie: reintroduce support for I/O BARs
- dts: bindings: can: add Kvaser PCIcan devicetree binding
- drivers: can: add driver for the Kvaser PCIcan CAN controller PCI card
- drivers: can: add support for configuring CAN emulation in QEMU
- boards: x86: qemu: add Kvaser PCIcan devicetree node
- samples: modules: canopennode: exclude qemu_x86 from storage build
- drivers: can: skip all CAN loopback mode tests for kvaser,pcican