### PR TITLE
shell: shell_log_backend: added check for msg allocation

### DIFF
--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -123,7 +123,7 @@ static void dropped(const struct log_backend *const backend, uint32_t cnt)
 	atomic_add(&log_backend->control_block->dropped_cnt, cnt);
 }
 
-static void copy_to_pbuffer(struct mpsc_pbuf_buffer *mpsc_buffer,
+static bool copy_to_pbuffer(struct mpsc_pbuf_buffer *mpsc_buffer,
 			    union log_msg_generic *msg, uint32_t timeout)
 {
 	size_t wlen;
@@ -133,7 +133,7 @@ static void copy_to_pbuffer(struct mpsc_pbuf_buffer *mpsc_buffer,
 	dst = mpsc_pbuf_alloc(mpsc_buffer, wlen, K_MSEC(timeout));
 	if (!dst) {
 		/* No space to store the log */
-		return;
+		return false;
 	}
 
 	/* First word contains internal mpsc packet flags and when copying
@@ -148,6 +148,8 @@ static void copy_to_pbuffer(struct mpsc_pbuf_buffer *mpsc_buffer,
 	memcpy(dst_data, src_data, (wlen - hdr_wlen) * sizeof(uint32_t));
 
 	mpsc_pbuf_commit(mpsc_buffer, dst);
+
+	return true;
 }
 
 static void process_log_msg(const struct shell *sh,
@@ -233,13 +235,13 @@ static void process(const struct log_backend *const backend,
 		if (IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE)) {
 			process_log_msg(sh, log_output, msg, true, colors);
 		} else {
-			copy_to_pbuffer(mpsc_buffer, msg,
-					log_backend->timeout);
-
-			if (IS_ENABLED(CONFIG_MULTITHREADING)) {
-				signal =
-				    &sh->ctx->signals[SHELL_SIGNAL_LOG_MSG];
-				k_poll_signal_raise(signal, 0);
+			if (copy_to_pbuffer(mpsc_buffer, msg, log_backend->timeout)) {
+				if (IS_ENABLED(CONFIG_MULTITHREADING)) {
+					signal = &sh->ctx->signals[SHELL_SIGNAL_LOG_MSG];
+					k_poll_signal_raise(signal, 0);
+				}
+			} else {
+				dropped(backend, 1);
 			}
 		}
 


### PR DESCRIPTION
When the message buffer cannot be allocated, dropped package counter should be incremented.

For the following code
```  
    char buff[256];
    for (size_t i = 0; i < sizeof(buff); i++)
        buff[i] = '0' + i % 10;
    buff[sizeof(buff) - 1] = 0;

    while (1)
    {
        for (int i = 0; i < 5; i++)
            LOG_INF("%i. %s", i, buff);

        LOG_INF("end");
        k_sleep(K_MSEC(5000));
    }
```
Output without this patch is
```
[00:00:55.130,000] <inf> app: 0. 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234
[00:00:55.130,000] <inf> app: 3. 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234
[00:00:55.130,000] <inf> app: end
```
So messages are dropped, but there is no information about dropped packages.

With this fix output is following, so user know that there was some more logs, but has been dropped.
```
[00:02:30.320,000] <inf> app: 0. 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234
[00:02:30.320,000] <inf> app: 1. 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234
--- 3 messages dropped ---
[00:02:30.320,000] <inf> app: end
```