### PR TITLE
mgmt: mcumgr: Fix Bluetooth transport issues

### DIFF
--- a/subsys/mgmt/mcumgr/transport/Kconfig
+++ b/subsys/mgmt/mcumgr/transport/Kconfig
@@ -30,13 +30,15 @@ config MCUMGR_BUF_USER_DATA_SIZE
 	int "Size of mcumgr buffer user data"
 	default 24 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV6
 	default 8 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV4
+	default 5 if MCUMGR_SMP_BT
 	default 4
 	help
 	  The size, in bytes, of user data to allocate for each mcumgr buffer.
 
 	  Different mcumgr transports impose different requirements for this
-	  setting. A value of 4 is sufficient for UART, shell, and bluetooth.
-	  For UDP, the userdata must be large enough to hold a IPv4/IPv6 address.
+	  setting. A value of 4 is sufficient for UART and shell, a value of 5
+	  is sufficient for Bluetooth. For UDP, the userdata must be large
+	  enough to hold a IPv4/IPv6 address.
 
 rsource "Kconfig.dummy"
 

--- a/subsys/mgmt/mcumgr/transport/smp_dummy.c
+++ b/subsys/mgmt/mcumgr/transport/smp_dummy.c
@@ -190,7 +190,7 @@ static int smp_dummy_init(const struct device *dev)
 	k_sem_init(&smp_data_ready_sem, 0, 1);
 
 	smp_transport_init(&smp_dummy_transport, smp_dummy_tx_pkt_int,
-			   smp_dummy_get_mtu, NULL, NULL);
+			   smp_dummy_get_mtu, NULL, NULL, NULL);
 	dummy_mgumgr_recv_cb = smp_dummy_rx_frag;
 
 	return 0;

--- a/subsys/mgmt/mcumgr/transport/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/smp_shell.c
@@ -191,7 +191,7 @@ static int smp_shell_tx_pkt(struct net_buf *nb)
 int smp_shell_init(void)
 {
 	smp_transport_init(&smp_shell_transport, smp_shell_tx_pkt,
-			   smp_shell_get_mtu, NULL, NULL);
+			   smp_shell_get_mtu, NULL, NULL, NULL);
 
 	return 0;
 }

--- a/subsys/mgmt/mcumgr/transport/smp_uart.c
+++ b/subsys/mgmt/mcumgr/transport/smp_uart.c
@@ -94,7 +94,7 @@ static int smp_uart_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	smp_transport_init(&smp_uart_transport, smp_uart_tx_pkt,
-			   smp_uart_get_mtu, NULL, NULL);
+			   smp_uart_get_mtu, NULL, NULL, NULL);
 	uart_mcumgr_register(smp_uart_rx_frag);
 
 	return 0;

--- a/subsys/mgmt/mcumgr/transport/smp_udp.c
+++ b/subsys/mgmt/mcumgr/transport/smp_udp.c
@@ -166,13 +166,13 @@ static int smp_udp_init(const struct device *dev)
 #ifdef CONFIG_MCUMGR_SMP_UDP_IPV4
 	smp_transport_init(&configs.ipv4.smp_transport,
 			   smp_udp4_tx, smp_udp_get_mtu,
-			   smp_udp_ud_copy, NULL);
+			   smp_udp_ud_copy, NULL, NULL);
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_UDP_IPV6
 	smp_transport_init(&configs.ipv6.smp_transport,
 			   smp_udp6_tx, smp_udp_get_mtu,
-			   smp_udp_ud_copy, NULL);
+			   smp_udp_ud_copy, NULL, NULL);
 #endif
 
 	return MGMT_ERR_EOK;


### PR DESCRIPTION
This fixes issues with the Bluetooth SMP transport whereby deadlocks could arise from connection references being held in long-lasting mcumgr command processing functions.

Fixes #51653
Fixes #51714