### PR TITLE
usb-c: Add missing errno.h include to usbc_tcpc.h

### DIFF
--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -24,6 +24,7 @@
 
 #include <zephyr/types.h>
 #include <zephyr/device.h>
+#include <errno.h>
 
 #include "usbc_tc.h"
 #include "usbc_pd.h"


### PR DESCRIPTION
Add missing errno.h include to usbc_tcpc.h which is needed for the return of -ENOSYS.

Signed-off-by: Sam Hurst <sbh1187@gmail.com>