### PR TITLE
Bluetooth: audio: pacs: Hotfix invalid PACS length

### DIFF
--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -109,19 +109,19 @@ static bool build_pac_records(const struct bt_pacs_cap *cap, void *user_data)
 	struct net_buf_simple *buf = data->buf;
 	struct net_buf_simple_state state;
 	struct bt_pac_ltv_data *cc, *meta;
-	struct bt_pac *pac;
+	struct bt_pac_codec *pac_codec;
 	ssize_t len;
 
 	net_buf_simple_save(buf, &state);
 
-	if (net_buf_simple_tailroom(buf) < sizeof(*pac)) {
+	if (net_buf_simple_tailroom(buf) < sizeof(*pac_codec)) {
 		goto fail;
 	}
 
-	pac = net_buf_simple_add(buf, sizeof(*pac));
-	pac->codec.id = codec->id;
-	pac->codec.cid = sys_cpu_to_le16(codec->cid);
-	pac->codec.vid = sys_cpu_to_le16(codec->vid);
+	pac_codec = net_buf_simple_add(buf, sizeof(*pac_codec));
+	pac_codec->id = codec->id;
+	pac_codec->cid = sys_cpu_to_le16(codec->cid);
+	pac_codec->vid = sys_cpu_to_le16(codec->vid);
 
 	if (net_buf_simple_tailroom(buf) < sizeof(*cc)) {
 		goto fail;

--- a/subsys/bluetooth/audio/pacs_internal.h
+++ b/subsys/bluetooth/audio/pacs_internal.h
@@ -41,7 +41,6 @@ struct bt_pac {
 
 struct bt_pacs_read_rsp {
 	uint8_t  num_pac;		/* Number of PAC Records*/
-	struct bt_pac pac[0];
 } __packed;
 
 struct bt_pacs_context {

--- a/subsys/bluetooth/audio/pacs_internal.h
+++ b/subsys/bluetooth/audio/pacs_internal.h
@@ -33,12 +33,6 @@ struct bt_pac_ltv_data {
 	struct bt_pac_ltv data[0];
 } __packed;
 
-struct bt_pac {
-	struct bt_pac_codec codec;	/* Codec ID */
-	struct bt_pac_ltv_data cc;	/* Codec Specific Capabilities */
-	struct bt_pac_ltv_data meta;	/* Metadata */
-} __packed;
-
 struct bt_pacs_read_rsp {
 	uint8_t  num_pac;		/* Number of PAC Records*/
 } __packed;

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -2513,19 +2513,19 @@ static uint8_t unicast_client_read_func(struct bt_conn *conn, uint8_t err,
 
 	while (rsp->num_pac) {
 		struct unicast_client_pac *bpac;
-		struct bt_pac *pac;
+		struct bt_pac_codec *pac_codec;
 		struct bt_pac_ltv_data *meta, *cc;
 		void *cc_ltv, *meta_ltv;
 
 		BT_DBG("pac #%u", params->num_caps);
 
-		if (buf.len < sizeof(*pac)) {
+		if (buf.len < sizeof(*pac_codec)) {
 			BT_ERR("Malformed PAC: remaining len %u expected %zu",
-			       buf.len, sizeof(*pac));
+			       buf.len, sizeof(*pac_codec));
 			break;
 		}
 
-		pac = net_buf_simple_pull_mem(&buf, sizeof(*pac));
+		pac_codec = net_buf_simple_pull_mem(&buf, sizeof(*pac_codec));
 
 		if (buf.len < sizeof(*cc)) {
 			BT_ERR("Malformed PAC: remaining len %u expected %zu",
@@ -2563,9 +2563,9 @@ static uint8_t unicast_client_read_func(struct bt_conn *conn, uint8_t err,
 			break;
 		}
 
-		if (unicast_client_ep_set_codec(NULL, pac->codec.id,
-						sys_le16_to_cpu(pac->codec.cid),
-						sys_le16_to_cpu(pac->codec.vid),
+		if (unicast_client_ep_set_codec(NULL, pac_codec->id,
+						sys_le16_to_cpu(pac_codec->cid),
+						sys_le16_to_cpu(pac_codec->vid),
 						cc_ltv, cc->len,
 						&bpac->codec)) {
 			BT_ERR("Unable to parse Codec");
@@ -2577,8 +2577,8 @@ static uint8_t unicast_client_read_func(struct bt_conn *conn, uint8_t err,
 			break;
 		}
 
-		BT_DBG("pac %p codec 0x%02x config count %u meta count %u ",
-		       pac, bpac->codec.id, bpac->codec.data_count,
+		BT_DBG("codec 0x%02x config count %u meta count %u ",
+		       bpac->codec.id, bpac->codec.data_count,
 		       bpac->codec.meta_count);
 
 		params->func(conn, &bpac->codec, NULL, params);

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -2563,10 +2563,6 @@ static uint8_t unicast_client_read_func(struct bt_conn *conn, uint8_t err,
 			break;
 		}
 
-		bpac->codec.id = pac->codec.id;
-		bpac->codec.cid = sys_le16_to_cpu(pac->codec.cid);
-		bpac->codec.vid = sys_le16_to_cpu(pac->codec.vid);
-
 		if (unicast_client_ep_set_codec(NULL, pac->codec.id,
 						sys_le16_to_cpu(pac->codec.cid),
 						sys_le16_to_cpu(pac->codec.vid),


### PR DESCRIPTION
This fixes adding 2 redundant bytes... to the PAC records. As a result we end up with broken PAC record.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>