### PR TITLE
cmake: sysbuild: import image kconfig settings to image target

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1461,9 +1461,13 @@ function(import_kconfig prefix kconfig_fragment)
     list(APPEND keys "${CONF_VARIABLE_NAME}")
   endforeach()
 
-  foreach(outvar ${ARGN})
-    set(${outvar} "${keys}" PARENT_SCOPE)
-  endforeach()
+  if(ARGC GREATER 2)
+    if(ARGC GREATER 3)
+    # Two mandatory arguments and one optional, anything after that is an error.
+      message(FATAL_ERROR "Unexpected argument after '<keys>': import_kconfig(... ${ARGV3})")
+    endif()
+    set(${ARGV2} "${keys}" PARENT_SCOPE)
+  endif()
 endfunction()
 
 ########################################################


### PR DESCRIPTION
Load image kconfig setting into image target properties.
This allows sysbuild to evaluate and check image configuration as part
of CMake invocation.

sysbuild_get() is updated to support reading of CMake cache or Kconfig
settings for an image.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>
