### PR TITLE
ARC: disallow build for secure configuration with firq

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -171,6 +171,7 @@ config ARC_FIRQ
 	bool "FIRQ enable"
 	depends on ISA_ARCV2
 	depends on NUM_IRQ_PRIO_LEVELS > 1
+	depends on !ARC_HAS_SECURE
 	default y
 	help
 	  Fast interrupts are supported (FIRQ). If FIRQ enabled, for interrupts

--- a/include/zephyr/arch/arc/arch.h
+++ b/include/zephyr/arch/arc/arch.h
@@ -77,6 +77,11 @@
 #error "Unsupported configuration: ARC_FIRQ_STACK and (RGF_NUM_BANKS < 2)"
 #endif
 
+/* In case of ARC 2+2 secure mode enabled the firq are not supported by HW */
+#if defined(CONFIG_ARC_FIRQ) && defined(CONFIG_ARC_HAS_SECURE)
+#error "Unsupported configuration: ARC_FIRQ and ARC_HAS_SECURE"
+#endif
+
 #if defined(CONFIG_SMP) && !defined(CONFIG_MULTITHREADING)
 #error "Non-multithreading mode isn't supported on SMP targets"
 #endif


### PR DESCRIPTION
Such configuration isn't supported by HW as in case of ARC 2+2 secure mode enabled the firq are not supported by HW.