### PR TITLE
rtio: MPSC queues for iodevs

### DIFF
--- a/include/zephyr/rtio/rtio_executor_concurrent.h
+++ b/include/zephyr/rtio/rtio_executor_concurrent.h
@@ -37,20 +37,18 @@ int rtio_concurrent_submit(struct rtio *r);
 /**
  * @brief Report a SQE has completed successfully
  *
- * @param r RTIO context to use
- * @param sqe RTIO SQE to report success
+ * @param sqe RTIO IODev SQE to report success
  * @param result Result of the SQE
  */
-void rtio_concurrent_ok(struct rtio *r, const struct rtio_sqe *sqe, int result);
+void rtio_concurrent_ok(struct rtio_iodev_sqe *sqe, int result);
 
 /**
  * @brief Report a SQE has completed with error
  *
- * @param r RTIO context to use
- * @param sqe RTIO SQE to report success
+ * @param sqe RTIO IODev SQE to report success
  * @param result Result of the SQE
  */
-void rtio_concurrent_err(struct rtio *r, const struct rtio_sqe *sqe, int result);
+void rtio_concurrent_err(struct rtio_iodev_sqe *sqe, int result);
 
 /**
  * @brief Concurrent Executor
@@ -76,8 +74,8 @@ struct rtio_concurrent_executor {
 	/* Array of task statuses */
 	uint8_t *task_status;
 
-	/* Array of struct rtio_sqe *'s one per task' */
-	struct rtio_sqe **task_cur;
+	/* Array of struct rtio_iodev_sqe *'s one per task' */
+	struct rtio_iodev_sqe *task_cur;
 };
 
 /**
@@ -101,7 +99,7 @@ static const struct rtio_executor_api z_rtio_concurrent_api = {
  * @param concurrency Allowed concurrency (number of concurrent tasks).
  */
 #define RTIO_EXECUTOR_CONCURRENT_DEFINE(name, concurrency)                                         \
-	static struct rtio_sqe *_task_cur_##name[(concurrency)];                                   \
+	static struct rtio_iodev_sqe _task_cur_##name[(concurrency)];                              \
 	uint8_t _task_status_##name[(concurrency)];                                                \
 	static struct rtio_concurrent_executor name = {                                            \
 		.ctx = { .api = &z_rtio_concurrent_api },                                          \

--- a/include/zephyr/rtio/rtio_executor_simple.h
+++ b/include/zephyr/rtio/rtio_executor_simple.h
@@ -36,26 +36,25 @@ int rtio_simple_submit(struct rtio *r);
 /**
  * @brief Report a SQE has completed successfully
  *
- * @param r RTIO context to use
- * @param sqe RTIO SQE to report success
+ * @param iodev_sqe RTIO IODEV SQE to report success
  * @param result Result of the SQE
  */
-void rtio_simple_ok(struct rtio *r, const struct rtio_sqe *sqe, int result);
+void rtio_simple_ok(struct rtio_iodev_sqe *iodev_sqe, int result);
 
 /**
  * @brief Report a SQE has completed with error
  *
- * @param r RTIO context to use
- * @param sqe RTIO SQE to report success
+ * @param iodev_sqe RTIO IODEV SQE to report success
  * @param result Result of the SQE
  */
-void rtio_simple_err(struct rtio *r, const struct rtio_sqe *sqe, int result);
+void rtio_simple_err(struct rtio_iodev_sqe *iodev_sqe, int result);
 
 /**
  * @brief Simple Executor
  */
 struct rtio_simple_executor {
 	struct rtio_executor ctx;
+	struct rtio_iodev_sqe task;
 };
 
 /**

--- a/include/zephyr/rtio/rtio_mpsc.h
+++ b/include/zephyr/rtio/rtio_mpsc.h
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/kernel.h>
 
 /**
  * @brief RTIO Multiple Producer Single Consumer (MPSC) Queue API
@@ -51,6 +52,21 @@ struct rtio_mpsc {
 	struct rtio_mpsc_node *tail;
 	struct rtio_mpsc_node stub;
 };
+
+
+/**
+ * @brief Static initializer for a mpsc queue
+ *
+ * Since the queue is
+ *
+ * @param symbol name of the queue
+ */
+#define RTIO_MPSC_INIT(symbol)                                 \
+	{                                                      \
+		.head = (struct rtio_mpsc_node *)&symbol.stub, \
+		.tail = (struct rtio_mpsc_node *)&symbol.stub, \
+		.stub.next = NULL,                             \
+	}
 
 /**
  * @brief Initialize queue

--- a/include/zephyr/rtio/rtio_mpsc.h
+++ b/include/zephyr/rtio/rtio_mpsc.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2010-2011 Dmitry Vyukov
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#ifndef ZEPHYR_RTIO_MPSC_H_
+#define ZEPHYR_RTIO_MPSC_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <zephyr/sys/atomic.h>
+
+/**
+ * @brief RTIO Multiple Producer Single Consumer (MPSC) Queue API
+ * @defgroup rtio_mpsc RTIO MPSC API
+ * @ingroup rtio
+ * @{
+ */
+
+/**
+ * @file rtio_mpsc.h
+ *
+ * @brief A wait-free intrusive multi producer single consumer (MPSC) queue using
+ * a singly linked list. Ordering is First-In-First-Out.
+ *
+ * Based on the well known and widely used wait-free MPSC queue described by
+ * Dmitry Vyukov with some slight changes to account for needs of an
+ * RTOS on a variety of archs. Both consumer and producer are wait free. No CAS
+ * loop or lock is needed.
+ *
+ * An MPSC queue is safe to produce or consume in an ISR with O(1) push/pop.
+ *
+ * @warning MPSC is *not* safe to consume in multiple execution contexts.
+ */
+
+/**
+ * @brief Queue member
+ */
+struct rtio_mpsc_node {
+	atomic_ptr_t next;
+};
+
+/**
+ * @brief MPSC Queue
+ */
+struct rtio_mpsc {
+	atomic_ptr_t head;
+	struct rtio_mpsc_node *tail;
+	struct rtio_mpsc_node stub;
+};
+
+/**
+ * @brief Initialize queue
+ *
+ * @param q Queue to initialize or reset
+ */
+static inline void rtio_mpsc_init(struct rtio_mpsc *q)
+{
+	atomic_ptr_set(&q->head, &q->stub);
+	q->tail = &q->stub;
+	atomic_ptr_set(&q->stub.next, NULL);
+}
+
+/**
+ * @brief Push a node
+ *
+ * @param q Queue to push the node to
+ * @param n Node to push into the queue
+ */
+static inline void rtio_mpsc_push(struct rtio_mpsc *q, struct rtio_mpsc_node *n)
+{
+	struct rtio_mpsc_node *prev;
+	int key;
+
+	atomic_ptr_set(&n->next, NULL);
+
+	key = arch_irq_lock();
+	prev = atomic_ptr_set(&q->head, n);
+	atomic_ptr_set(&prev->next, n);
+	arch_irq_unlock(key);
+}
+
+/**
+ * @brief Pop a node off of the list
+ *
+ * @retval NULL When no node is available
+ * @retval node When node is available
+ */
+static inline struct rtio_mpsc_node *rtio_mpsc_pop(struct rtio_mpsc *q)
+{
+	struct rtio_mpsc_node *head;
+	struct rtio_mpsc_node *tail = q->tail;
+	struct rtio_mpsc_node *next = atomic_ptr_get(&tail->next);
+
+	/* Skip over the stub/sentinel */
+	if (tail == &q->stub) {
+		if (next == NULL) {
+			return NULL;
+		}
+
+		q->tail = next;
+		tail = next;
+		next = atomic_ptr_get(&next->next);
+	}
+
+	/* If next is non-NULL then a valid node is found, return it */
+	if (next != NULL) {
+		q->tail = next;
+		return tail;
+	}
+
+	head = atomic_ptr_get(&q->head);
+
+	/* If next is NULL, and the tail != HEAD then the queue has pending
+	 * updates that can't yet be accessed.
+	 */
+	if (tail != head) {
+		return NULL;
+	}
+
+	rtio_mpsc_push(q, &q->stub);
+
+	next = atomic_ptr_get(&tail->next);
+
+	if (next != NULL) {
+		q->tail = next;
+		return tail;
+	}
+
+	return NULL;
+}
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_RTIO_MPSC_H_ */

--- a/include/zephyr/rtio/rtio_spsc.h
+++ b/include/zephyr/rtio/rtio_spsc.h
@@ -75,11 +75,9 @@ struct rtio_spsc {
 /**
  * @brief Statically initialize an rtio_spsc
  *
- * @param name Name of the spsc symbol to be provided
- * @param type Type stored in the spsc
  * @param sz Size of the spsc, must be power of 2 (ex: 2, 4, 8)
  */
-#define RTIO_SPSC_INITIALIZER(name, type, sz)	  \
+#define RTIO_SPSC_INITIALIZER(sz)		  \
 	{ ._spsc = {				  \
 		  .acquire = 0,			  \
 		  .consume = 0,			  \
@@ -110,7 +108,7 @@ struct rtio_spsc {
  * @param sz Size of the spsc, must be power of 2 (ex: 2, 4, 8)
  */
 #define RTIO_SPSC_DEFINE(name, type, sz)                                                           \
-	RTIO_SPSC_DECLARE(name, type, sz) name = RTIO_SPSC_INITIALIZER(name, type, sz);
+	RTIO_SPSC_DECLARE(name, type, sz) name = RTIO_SPSC_INITIALIZER(sz);
 
 /**
  * @brief Size of the SPSC queue

--- a/samples/subsys/rtio/sensor_batch_processing/src/vnd_sensor.c
+++ b/samples/subsys/rtio/sensor_batch_processing/src/vnd_sensor.c
@@ -22,7 +22,6 @@ struct vnd_sensor_data {
 	struct rtio_iodev iodev;
 	struct k_timer timer;
 	const struct device *dev;
-	struct k_msgq msgq;
 	uint32_t sample_number;
 };
 
@@ -53,9 +52,10 @@ static int vnd_sensor_iodev_read(const struct device *dev, uint8_t *buf,
 }
 
 static void vnd_sensor_iodev_execute(const struct device *dev,
-		const struct rtio_sqe *sqe, struct rtio *r)
+		struct rtio_iodev_sqe *iodev_sqe)
 {
 	int result;
+	const struct rtio_sqe *sqe = iodev_sqe->sqe;
 
 	if (sqe->op == RTIO_OP_RX) {
 		result = vnd_sensor_iodev_read(dev, sqe->buf, sqe->buf_len);
@@ -65,36 +65,28 @@ static void vnd_sensor_iodev_execute(const struct device *dev,
 	}
 
 	if (result < 0) {
-		rtio_sqe_err(r, sqe, result);
+		rtio_iodev_sqe_err(iodev_sqe, result);
 	} else {
-		rtio_sqe_ok(r, sqe, result);
+		rtio_iodev_sqe_ok(iodev_sqe, result);
 	}
 }
 
-static void vnd_sensor_iodev_submit(const struct rtio_sqe *sqe, struct rtio *r)
+static void vnd_sensor_iodev_submit(struct rtio_iodev_sqe *iodev_sqe)
 {
-	struct vnd_sensor_data *data = (struct vnd_sensor_data *) sqe->iodev;
-	const struct device *dev = data->dev;
-	struct rtio_iodev_sqe *iodev_sqe = rtio_spsc_acquire(data->iodev.iodev_sq);
+	struct vnd_sensor_data *data = (struct vnd_sensor_data *) iodev_sqe->sqe->iodev;
 
-	if (iodev_sqe != NULL) {
-		iodev_sqe->sqe = sqe;
-		iodev_sqe->r = r;
-		rtio_spsc_produce(data->iodev.iodev_sq);
-	} else {
-		LOG_ERR("%s: Could not put a msg", dev->name);
-		rtio_sqe_err(r, sqe, -EWOULDBLOCK);
-	}
+	rtio_mpsc_push(&data->iodev.iodev_sq, &iodev_sqe->q);
 }
 
 static void vnd_sensor_handle_int(const struct device *dev)
 {
 	struct vnd_sensor_data *data = dev->data;
-	struct rtio_iodev_sqe *iodev_sqe = rtio_spsc_consume(data->iodev.iodev_sq);
+	struct rtio_mpsc_node *node = rtio_mpsc_pop(&data->iodev.iodev_sq);
 
-	if (iodev_sqe != NULL) {
-		vnd_sensor_iodev_execute(dev, iodev_sqe->sqe, iodev_sqe->r);
-		rtio_spsc_release(data->iodev.iodev_sq);
+	if (node != NULL) {
+		struct rtio_iodev_sqe *iodev_sqe = CONTAINER_OF(node, struct rtio_iodev_sqe, q);
+
+		vnd_sensor_iodev_execute(dev, iodev_sqe);
 	} else {
 		LOG_ERR("%s: Could not get a msg", dev->name);
 	}
@@ -116,6 +108,8 @@ static int vnd_sensor_init(const struct device *dev)
 
 	data->dev = dev;
 
+	rtio_mpsc_init(&data->iodev.iodev_sq);
+
 	k_timer_init(&data->timer, vnd_sensor_timer_expiry, NULL);
 
 	k_timer_start(&data->timer, K_MSEC(sample_period),
@@ -135,13 +129,10 @@ static const struct rtio_iodev_api vnd_sensor_iodev_api = {
 		.sample_size = DT_INST_PROP(n, sample_size),                                       \
 	};                                                                                         \
                                                                                                    \
-	RTIO_IODEV_SQ_DEFINE(vnd_sensor_iodev_sq_##n, DT_INST_PROP(n, max_msgs));                  \
-                                                                                                   \
 	static struct vnd_sensor_data vnd_sensor_data_##n = {                                      \
 		.iodev =                                                                           \
 			{                                                                          \
 				.api = &vnd_sensor_iodev_api,                                      \
-				.iodev_sq = (struct rtio_iodev_sq *)&vnd_sensor_iodev_sq_##n,     \
 			},                                                                         \
 	};                                                                                         \
                                                                                                    \

--- a/tests/subsys/rtio/rtio_api/src/main.c
+++ b/tests/subsys/rtio/rtio_api/src/main.c
@@ -167,7 +167,6 @@ static void t1_consume(void *p1, void *p2, void *p3)
 		if (val != NULL) {
 			rtio_spsc_release(ezspsc);
 		} else {
-			printk("consumer yield\n");
 			k_yield();
 		}
 	}
@@ -182,7 +181,6 @@ static void t2_produce(void *p1, void *p2, void *p3)
 	for (int i = 0; i < SMP_ITERATIONS; i++) {
 		val = NULL;
 		retries = 0;
-		printk("producer acquiring\n");
 		while (val == NULL && retries < MAX_RETRIES) {
 			val = rtio_spsc_acquire(ezspsc);
 			retries++;
@@ -191,7 +189,6 @@ static void t2_produce(void *p1, void *p2, void *p3)
 			*val = SMP_ITERATIONS;
 			rtio_spsc_produce(ezspsc);
 		} else {
-			printk("producer yield\n");
 			k_yield();
 		}
 	}

--- a/tests/subsys/rtio/rtio_api/testcase.yaml
+++ b/tests/subsys/rtio/rtio_api/testcase.yaml
@@ -1,4 +1,5 @@
 common:
+  platform_exclude: m2gl025_miv
   platform_key:
     - arch
     - simulation


### PR DESCRIPTION
Rather than a fixed size queue, and with it the possibility of running
out of pre-allocated spots, each iodev now holds a wait-free mpsc
queue head.
    
This changes the parameter of iodev submit to be a struct
containing the 3 pointers for the rtio context, the submission queue entry,
and the queue pointer needed for the mpsc queue.
    
This solves the problem involving busy iodevs working with real
devices. For example a busy SPI bus driver could enqueue, without locking,
a request to start once the current request is done.
    
The queue entries are expected to be owned and allocated by the
executor rather than the iodev. This helps simplify potential
tuning knobs to one place, the RTIO context and its executor an
application directly uses.
    
As the test case shows iodevs can operate effectively lock free
with the mpsc queue and a single atomic denoting the current task.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>