### PR TITLE
boards: arm: Correct LED flags for XIAO board.

### DIFF
--- a/boards/arm/seeeduino_xiao/seeeduino_xiao.dts
+++ b/boards/arm/seeeduino_xiao/seeeduino_xiao.dts
@@ -24,15 +24,15 @@
 	leds {
 		compatible = "gpio-leds";
 		led: led_0 {
-			gpios = <&porta 17 0>;
+			gpios = <&porta 17 GPIO_ACTIVE_LOW>;
 			label = "LED";
 		};
 		rx_led: led_1 {
-			gpios = <&porta 18 0>;
+			gpios = <&porta 18 GPIO_ACTIVE_LOW>;
 			label = "RX_LED";
 		};
 		tx_led: led_2 {
-			gpios = <&porta 19 0>;
+			gpios = <&porta 19 GPIO_ACTIVE_LOW>;
 			label = "TX_LED";
 		};
 	};


### PR DESCRIPTION
LEDs on the XIAO are active low, so set the flags appropriately.

Signed-off-by: Peter Johanson <peter@peterjohanson.com>

![Schematic portion](https://user-images.githubusercontent.com/202695/198815615-5c26f758-d1bb-457a-85b4-7b79928c76b9.png)

