### PR TITLE
posix: pthread: remove duplicate assignment in pthread_exit

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -369,7 +369,6 @@ void pthread_exit(void *retval)
 
 	pthread_mutex_lock(&self->state_lock);
 	if (self->state == PTHREAD_JOINABLE) {
-		self->retval = retval;
 		self->state = PTHREAD_EXITED;
 		self->retval = retval;
 		pthread_cond_broadcast(&self->state_cond);


### PR DESCRIPTION
The `self->retval` field was assigned twice.
