### PR TITLE
posix: correct struct label for pthread_attr_t

### DIFF
--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -33,7 +33,7 @@ typedef unsigned long timer_t;
 
 #ifdef CONFIG_PTHREAD_IPC
 /* Thread attributes */
-typedef struct pthread_attr_t {
+typedef struct pthread_attr {
 	int priority;
 	void *stack;
 	size_t stacksize;


### PR DESCRIPTION
Normally, for typedef'ed structures, the struct label should not end in `_t`.
