### PR TITLE
west.yml: bump hal_ti to not re-declare pthread_self()

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -135,7 +135,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: 000b944a788b6005d7776198e1348f5c8a657259
+      revision: a5ffc6dc73c2ee4c4eaa813418453cd3094c33dd
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
Ensure CI runs successfully for zephyrproject-rtos/hal_ti#44.

We can repurpose this PR to update `west.yml` after the above PR has been merged (assuming CI is successful).
