### PR TITLE
samples: blinky_pwm: Fix sample for rpi_pico

### DIFF
--- a/samples/basic/blinky_pwm/boards/rpi_pico.overlay
+++ b/samples/basic/blinky_pwm/boards/rpi_pico.overlay
@@ -1,0 +1,9 @@
+&pwm_led0 {
+	status = "okay";
+};
+
+&pwm {
+	status = "okay";
+	divider-frac-4 = <255>;
+	divider-int-4 = <255>;
+};


### PR DESCRIPTION
The RP2040 needs a DTS overlay for the PWM to work with the blinky_pwm examples. This commit adds the required overlay.

Fixes #51546

Signed-off-by: Yonatan Schachter <yonatan.schachter@gmail.com>