### PR TITLE
hal: nxp: Check Kconfig before including HAL

### DIFF
--- a/modules/hal_nxp/CMakeLists.txt
+++ b/modules/hal_nxp/CMakeLists.txt
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR} hal_nxp)
-add_subdirectory_ifdef(CONFIG_USB_DEVICE_DRIVER usb)
+if(CONFIG_HAS_MCUX OR CONFIG_HAS_IMX_HAL OR CONFIG_HAS_S32_HAL)
+  add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR} hal_nxp)
+  add_subdirectory_ifdef(CONFIG_USB_DEVICE_DRIVER usb)
 
-zephyr_include_directories(.)
+  zephyr_include_directories(.)
+endif()


### PR DESCRIPTION
hal_nxp was added to cmake's include directories globally, without checking if the hal is enabled. This made all Zephyr builds end up including hal_nxp, even for other vendors.

Signed-off-by: Yonatan Schachter <yonatan.schachter@gmail.com>