### PR TITLE
drivers: modem: gsm: Fix set gsm->state in gsm_ppp_stop

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1210,6 +1210,7 @@ void gsm_ppp_stop(const struct device *dev)
 		gsm->modem_off_cb(gsm->dev, gsm->user_data);
 	}
 
+	gsm->state = GSM_PPP_STOP;
 	gsm->net_state = GSM_NET_INIT;
 	gsm_ppp_unlock(gsm);
 }


### PR DESCRIPTION
The driver should set the `gsm->state` to GSM_PPP_STOP when `gsm_ppp_stop()` is run. This commit fixes that.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/51505

Signed-off-by: Jeppe Odgaard <jeppe.odgaard@prevas.dk>