### PR TITLE
drivers: flashdisk: support read-only flashdisks

### DIFF
--- a/drivers/disk/Kconfig.flash
+++ b/drivers/disk/Kconfig.flash
@@ -9,6 +9,14 @@ config DISK_DRIVER_FLASH
 	  Flash device is used for the file system.
 
 if DISK_DRIVER_FLASH
+
+config FLASHDISK_VERIFY_PAGE_LAYOUT
+	bool "Verify flashdisk partition layout"
+	default y
+	help
+	  Enable runtime zephyr,flash-disk partition page layout constraints
+	  verification. Disable to reduce code size.
+
 module = FLASHDISK
 module-str = flashdisk
 source "subsys/logging/Kconfig.template.log_config"

--- a/dts/bindings/misc/zephyr,flash-disk.yaml
+++ b/dts/bindings/misc/zephyr,flash-disk.yaml
@@ -35,4 +35,5 @@ properties:
         adequately chosen. On storage backends with uniform erase-blocks it
         should be at least the erase-block-size, on storage backends with
         non-uniform erase-blocks it should be at least the largest
-        erase-block-size.
+        erase-block-size. The cache-size property is ignored if the partition
+        is read-only.


### PR DESCRIPTION
Treat the flashdisk as read-only when cache-size is set to 0. This allows users to save RAM when the application does not write to the flashdisk, e.g. when a predefined FAT filesystem is used.

Fail with error if any of flashdisk partition assumptions are not met:
  * uniform page size through the whole partition
  * flashdisk starts at page boundary
  * flashdisk ends at page boundary

Read-only flashdisks are not subject to above conditions because the cache buffer is not used for read-only flashdisks.