### PR TITLE
drivers: can: loopback: various fixes

### DIFF
--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -46,9 +46,9 @@ struct can_loopback_data {
 		      CONFIG_CAN_LOOPBACK_TX_THREAD_STACK_SIZE);
 };
 
-static void dispatch_frame(const struct device *dev,
-			   const struct can_frame *frame,
-			   struct can_loopback_filter *filter)
+static void receive_frame(const struct device *dev,
+			  const struct can_frame *frame,
+			  struct can_loopback_filter *filter)
 {
 	struct can_frame frame_tmp = *frame;
 
@@ -82,9 +82,9 @@ static void tx_thread(void *arg1, void *arg2, void *arg3)
 
 		for (int i = 0; i < CONFIG_CAN_MAX_FILTER; i++) {
 			filter = &data->filters[i];
-			if (filter->rx_cb &&
+			if (filter->rx_cb != NULL &&
 			    can_utils_filter_match(&frame.frame, &filter->filter)) {
-				dispatch_frame(dev, &frame.frame, filter);
+				receive_frame(dev, &frame.frame, filter);
 			}
 		}
 

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -203,6 +203,11 @@ static void can_loopback_remove_rx_filter(const struct device *dev, int filter_i
 {
 	struct can_loopback_data *data = dev->data;
 
+	if (filter_id >= ARRAY_SIZE(data->filters)) {
+		LOG_ERR("filter ID %d out-of-bounds", filter_id);
+		return;
+	}
+
 	LOG_DBG("Remove filter ID: %d", filter_id);
 	k_mutex_lock(&data->mtx, K_FOREVER);
 	data->filters[filter_id].rx_cb = NULL;

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -72,6 +72,12 @@ static void tx_thread(void *arg1, void *arg2, void *arg3)
 
 	while (1) {
 		k_msgq_get(&data->tx_msgq, &frame, K_FOREVER);
+		frame.cb(dev, 0, frame.cb_arg);
+
+		if (!data->loopback) {
+			continue;
+		}
+
 		k_mutex_lock(&data->mtx, K_FOREVER);
 
 		for (int i = 0; i < CONFIG_CAN_MAX_FILTER; i++) {
@@ -83,7 +89,6 @@ static void tx_thread(void *arg1, void *arg2, void *arg3)
 		}
 
 		k_mutex_unlock(&data->mtx);
-		frame.cb(dev, 0, frame.cb_arg);
 	}
 }
 
@@ -132,10 +137,6 @@ static int can_loopback_send(const struct device *dev,
 
 	if (!data->started) {
 		return -ENETDOWN;
-	}
-
-	if (!data->loopback) {
-		return 0;
 	}
 
 	loopback_frame.frame = *frame;

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -144,8 +144,12 @@ static int can_loopback_send(const struct device *dev,
 	loopback_frame.cb_arg = user_data;
 
 	ret = k_msgq_put(&data->tx_msgq, &loopback_frame, timeout);
+	if (ret < 0) {
+		LOG_DBG("TX queue full (err %d)", ret);
+		return -EAGAIN;
+	}
 
-	return  ret ? -EAGAIN : 0;
+	return 0;
 }
 
 


### PR DESCRIPTION
Fix various minor issues in the CAN loopback driver. These were discovered while working on #51800:
- drivers: can: loopback: process TX callbacks in non-loopback mode
- drivers: can: loopback: rename receive function
- drivers: can: loopback: add log message for full TX msgq
- drivers: can: loopback: guard against out-of-bounds filter IDs
