### PR TITLE
UART0 RTS and CTS pins have been swapped for nrf9160dk_nrf52840

### DIFF
--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840-pinctrl.dtsi
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840-pinctrl.dtsi
@@ -7,11 +7,11 @@
 	uart0_default: uart0_default {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 0, 5)>,
-				<NRF_PSEL(UART_RTS, 1, 8)>;
+				<NRF_PSEL(UART_RTS, 0, 7)>;
 		};
 		group2 {
 			psels = <NRF_PSEL(UART_RX, 0, 3)>,
-				<NRF_PSEL(UART_CTS, 0, 7)>;
+				<NRF_PSEL(UART_CTS, 1, 8)>;
 			bias-pull-up;
 		};
 	};
@@ -20,8 +20,8 @@
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 0, 5)>,
 				<NRF_PSEL(UART_RX, 0, 3)>,
-				<NRF_PSEL(UART_RTS, 1, 8)>,
-				<NRF_PSEL(UART_CTS, 0, 7)>;
+				<NRF_PSEL(UART_RTS, 0, 7)>,
+				<NRF_PSEL(UART_CTS, 1, 8)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
The UART0 RTS and CTS pins are swapped. On the real board, nrf52840 and VCOM1 on J-Link OB do not operate properly without these changes. The transmission works in only one direction, from nRF52 to J-Link. I guess these signals were originally confused on the schematic. After the changes, UART and VCOM1 work properly.