### PR TITLE
drivers: console: uart_console.c: suggestion to add new line for unix or linux host

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -429,6 +429,7 @@ static void uart_console_isr(const struct device *unused, void *user_data)
 {
 	ARG_UNUSED(unused);
 	ARG_UNUSED(user_data);
+	static uint8_t last_char = '\0';
 
 	while (uart_irq_update(uart_console_dev) &&
 	       uart_irq_is_pending(uart_console_dev)) {
@@ -501,6 +502,11 @@ static void uart_console_isr(const struct device *unused, void *user_data)
 			case ESC:
 				atomic_set_bit(&esc_state, ESC_ESC);
 				break;
+			case '\n':
+				if (last_char == '\r') {
+					/* break to avoid double line*/
+					break;
+				}
 			case '\r':
 				cmd->line[cur + end] = '\0';
 				uart_poll_out(uart_console_dev, '\r');
@@ -519,6 +525,7 @@ static void uart_console_isr(const struct device *unused, void *user_data)
 				break;
 			}
 
+			last_char = byte;
 			continue;
 		}
 


### PR DESCRIPTION
This is a suggestion to use console_getline() for uart, that is connected to pc with unix or linux OS.
Add case '\n', so that new line can be detected.

Signed-off-by shun.jing.goh@gmail.com