### PR TITLE
MAINTAINERS: update gd32 maintainers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1696,11 +1696,11 @@ State machine framework:
 GD32 Platforms:
   status: maintained
   maintainers:
+    - cameled
     - nandojve
   collaborators:
     - gmarull
     - soburi
-    - cameled
   files:
     - boards/arm/gd32*/
     - boards/riscv/gd32*/


### PR DESCRIPTION
Promote HaiLong Yang @cameled as gd32 maintainer.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>