### PR TITLE
boards: b_u585i_iot02a: Add note on disabling TZ

### DIFF
--- a/boards/arm/b_u585i_iot02a/doc/index.rst
+++ b/boards/arm/b_u585i_iot02a/doc/index.rst
@@ -349,6 +349,60 @@ Finally, to flash the board, run:
 
    $ west flash
 
+
+Disabling TrustZone |reg| on the board
+======================================
+
+If you have flashed a sample to the board that enables TrustZone, you will need
+to disable it before you can flash and run a new non-TrustZone sample on the
+board.
+
+To disable TrustZone, it's necessary to change AT THE SAME TIME the ``TZEN``
+and ``RDP`` bits. ``TZEN`` needs to get set from 1 to 0 and ``RDP``,
+needs to be set from ``DC`` to ``AA`` (step 3 below).
+
+This is docummented in the `AN5347, in section 9`_, "TrustZone deactivation".
+
+However, it's possible that the ``RDP`` bit is not yet set to ``DC``, so you
+first need to set it to ``DC`` (step 2).
+
+Finally you need to set the "Write Protection 1 & 2" bytes properly, otherwise
+some memory regions won't be erasable and mass erase will fail (step 4).
+
+The following command sequence will fully deactivate TZ:
+
+Step 1:
+
+Ensure U23 BOOT0 switch is set to 1 (switch is on the left, assuming you read
+"BOOT0" silkscreen label from left to right). You need to press "Reset" (B2 RST
+switch) after changing the switch to make the change effective.
+
+Step 2:
+
+.. code-block:: console
+
+   $ STM32_Programmer_CLI -c port=/dev/ttyACM0 -ob rdp=0xDC
+
+Step 3:
+
+.. code-block:: console
+
+   $ STM32_Programmer_CLI -c port=/dev/ttyACM0 -tzenreg
+
+Step 4:
+
+.. code-block:: console
+
+   $ STM32_Programmer_CLI -c port=/dev/ttyACM0 -ob wrp1a_pstrt=0x7f
+   $ STM32_Programmer_CLI -c port=/dev/ttyACM0 -ob wrp1a_pend=0x0
+   $ STM32_Programmer_CLI -c port=/dev/ttyACM0 -ob wrp1b_pstrt=0x7f
+   $ STM32_Programmer_CLI -c port=/dev/ttyACM0 -ob wrp1b_pend=0x0
+   $ STM32_Programmer_CLI -c port=/dev/ttyACM0 -ob wrp2a_pstrt=0x7f
+   $ STM32_Programmer_CLI -c port=/dev/ttyACM0 -ob wrp2a_pend=0x0
+   $ STM32_Programmer_CLI -c port=/dev/ttyACM0 -ob wrp2b_pstrt=0x7f
+   $ STM32_Programmer_CLI -c port=/dev/ttyACM0 -ob wrp2b_pend=0x0
+
+
 .. _B U585I IOT02A Discovery kit website:
    https://www.st.com/en/evaluation-tools/b-u585i-iot02a.html
 
@@ -366,3 +420,6 @@ Finally, to flash the board, run:
 
 .. _STMicroelectronics customized version of OpenOCD:
    https://github.com/STMicroelectronics/OpenOCD
+
+.. _AN5347, in section 9:
+   https://www.st.com/resource/en/application_note/dm00625692-stm32l5-series-trustzone-features-stmicroelectronics.pdf


### PR DESCRIPTION
Adds a note on how to disable TrustZone on the board, to be able to reflash non TrustZone samples. Without this step, flashing will fail for non TF-M or TrustZone sample applications.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>