### PR TITLE
samples: psa_crypto: Add twister regex for attestation token

### DIFF
--- a/samples/tfm_integration/psa_crypto/sample.yaml
+++ b/samples/tfm_integration/psa_crypto/sample.yaml
@@ -13,6 +13,9 @@ tests:
         harness_config:
           type: multi_line
           regex:
+            - "System IAT size is: (.*)"
+            - "Requesting IAT with (.*) byte challenge."
+            - "IAT data received: (.*)"
             - "Retrieving public key for key #1"
             - "Signature verified"
             - "Destroyed persistent key #1"


### PR DESCRIPTION
So far running twister tests didn't fail even though the sample failed to receive the initial attestation token data.
Therefore this adds the regex lines that the samples prints if the IAT data were received.

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>