### PR TITLE
drivers: timer: intel_adsp: Update driver to use dts Kconfig symbol

### DIFF
--- a/drivers/timer/Kconfig.cavs
+++ b/drivers/timer/Kconfig.cavs
@@ -16,6 +16,8 @@ config CAVS_TIMER
 
 config INTEL_ADSP_TIMER
 	bool "Intel Audio DSP timer"
+	default y
+	depends on DT_HAS_INTEL_ADSP_TIMER_ENABLED
 	select CAVS_TIMER
 	select TICKLESS_CAPABLE
 	select TIMER_HAS_64BIT_CYCLE_COUNTER

--- a/soc/xtensa/intel_adsp/ace/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/ace/Kconfig.defconfig.series
@@ -45,9 +45,6 @@ config XTENSA_TIMER
 config XTENSA_TIMER_ID
 	default 0
 
-config INTEL_ADSP_TIMER
-	default y
-
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 400000000 if XTENSA_TIMER
 	default 19200000 if INTEL_ADSP_TIMER

--- a/soc/xtensa/intel_adsp/cavs/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs/Kconfig.defconfig.series
@@ -28,9 +28,6 @@ config SMP
 config XTENSA_TIMER
 	default n
 
-config INTEL_ADSP_TIMER
-	default y
-
 config KERNEL_ENTRY
 	default "_MainEntry"
 


### PR DESCRIPTION
Update Intel ADSP timer driver to use DT_HAS_<compat>_ENABLED Kconfig symbol to expose the driver and enable it by default based on devicetree.

We remove setting 'default y' for the timer driver in Kconfig.defconfig.series as that is now handled in the driver Kconfig.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>