### PR TITLE
ITE: drivers/i2c: Fix mutex bug

### DIFF
--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -876,6 +876,8 @@ static int i2c_enhance_transfer(const struct device *dev,
 			 * (No external pull-up), drop the transaction.
 			 */
 			if (i2c_bus_not_available(dev)) {
+				/* Unlock mutex of i2c controller */
+				k_mutex_unlock(&data->mutex);
 				return -EIO;
 			}
 		}


### PR DESCRIPTION
When an error occurs, the driver will miss unlocking a mutex.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>