### PR TITLE
cmake: lookup strip tool and set CMAKE_STRIP for host-gnu target

### DIFF
--- a/cmake/bintools/host-gnu/target.cmake
+++ b/cmake/bintools/host-gnu/target.cmake
@@ -8,6 +8,7 @@ find_program(CMAKE_AR      ar     )
 find_program(CMAKE_RANLIB  ranlib )
 find_program(CMAKE_READELF readelf)
 find_program(CMAKE_NM      nm)
+find_program(CMAKE_STRIP   strip)
 
 find_program(CMAKE_GDB     gdb    )
 


### PR DESCRIPTION
Fixes: #51821

Set CMAKE_STRIP using `find_program(CMAKE_STRIP strip)` to support strip when building on native posix.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>