### PR TITLE
Bluetooth: Controller: Fix ticks_current initialization

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -2747,7 +2747,7 @@ uint32_t ticker_init(uint8_t instance_index, uint8_t count_node, void *node,
 	instance->trigger_set_cb = trigger_set_cb;
 
 	instance->ticker_id_head = TICKER_NULL;
-	instance->ticks_current = 0U;
+	instance->ticks_current = cntr_cnt_get();
 	instance->ticks_elapsed_first = 0U;
 	instance->ticks_elapsed_last = 0U;
 


### PR DESCRIPTION
Fix ticker instance ticks_current initialization to be acquired from the RTC counter value. The RTC counter may have run in previous use of ticker before bt_disable hence keep the instance ticks_current equal to RTC counter value when ticker_init() is called again.

Relates to commit 4349a475a8f5 ("Bluetooth: Controller: Add deinit() infrastructure").

Fixes #51815.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>