### PR TITLE
e1000: Fix hardcoded BDF

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -66,12 +66,9 @@
 			};
 		};
 
-	};
-
-	soc {
-		eth0: eth@febc0000 {
+		eth0: eth@1000 {
 			compatible = "intel,e1000";
-			reg = <0xfebc0000 0x100>;
+			reg = <PCIE_BDF(0, 2, 0) PCIE_ID(0x8086, 0x100e)>;
 			interrupts = <11 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -286,6 +286,9 @@ int e1000_probe(const struct device *ddev)
 	return 0;
 }
 
+BUILD_ASSERT(DT_INST_IRQN(0) != PCIE_IRQ_DETECT,
+	     "Dynamic IRQ allocation is not supported");
+
 static void e1000_iface_init(struct net_if *iface)
 {
 	struct e1000_dev *dev = net_if_get_device(iface)->data;

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -230,18 +230,16 @@ static void e1000_isr(const struct device *ddev)
 	}
 }
 
-#define PCI_VENDOR_ID_INTEL	0x8086
-#define PCI_DEVICE_ID_I82540EM	0x100e
 
 int e1000_probe(const struct device *ddev)
 {
-	const pcie_bdf_t bdf = PCIE_BDF(0, 2, 0);
+	/* PCI ID is decoded into REG_SIZE */
+	pcie_bdf_t bdf = pcie_bdf_lookup(DT_INST_REG_SIZE(0));
 	struct e1000_dev *dev = ddev->data;
 	uint32_t ral, rah;
 	struct pcie_bar mbar;
 
-	if (!pcie_probe(bdf, PCIE_ID(PCI_VENDOR_ID_INTEL,
-				     PCI_DEVICE_ID_I82540EM))) {
+	if (bdf == PCIE_BDF_NONE) {
 		return -ENODEV;
 	}
 

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -235,7 +235,7 @@ static void e1000_isr(const struct device *ddev)
 
 int e1000_probe(const struct device *ddev)
 {
-	const pcie_bdf_t bdf = PCIE_BDF(0, 3, 0);
+	const pcie_bdf_t bdf = PCIE_BDF(0, 2, 0);
 	struct e1000_dev *dev = ddev->data;
 	uint32_t ral, rah;
 	struct pcie_bar mbar;


### PR DESCRIPTION
Correct e1000 hardcoded BDF, making it possible to use the same driver when Qemu parameters change.

Fixes #51829