### PR TITLE
actions: Upload test results to opensearch service

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -259,21 +259,39 @@ jobs:
           if-no-files-found: ignore
           path: |
             twister-out/twister.xml
+            twister-out/twister.json
             module_tests/twister.xml
             testplan.json
 
   twister-test-results:
     name: "Publish Unit Tests Results"
+    env:
+      OPENSEARCH_USER: ${{ secrets.OPENSEARCH_USER }}
+      OPENSEARCH_PASS: ${{ secrets.OPENSEARCH_PASS }}
     needs: twister-build
     runs-on: ubuntu-20.04
       # the build-and-test job might be skipped, we don't need to run this job then
     if: success() || failure()
 
     steps:
+      # Needed for opensearch and upload script
+      - if: github.event_name == 'push'
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:
           path: artifacts
+
+      - if: github.event_name == 'push'
+        name: Upload to opensearch
+        run: |
+          pip3 install opensearch-py
+          python3 ./scripts/ci/upload_test_results.py artifacts/*/*/twister.json
 
       - name: Merge Test Results
         run: |

--- a/scripts/ci/upload_test_results.py
+++ b/scripts/ci/upload_test_results.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import json
+import argparse
+from opensearchpy import OpenSearch
+from opensearchpy.helpers import bulk
+
+host = "dashboards.staging.zephyrproject.io"
+port = 443
+
+def main():
+    args = parse_args()
+    if args.user and args.password:
+        auth = (args.user, args.password)
+    else:
+        auth = (os.environ['OPENSEARCH_USER'], os.environ['OPENSEARCH_PASS'])
+
+    client = OpenSearch(
+            hosts = [{'host': host, 'port': port}],
+            http_auth=auth,
+            use_ssl=True,
+            verify_certs = False,
+            ssl_assert_hostname = False,
+            ssl_show_warn = False,
+    )
+    # Create an index with non-default settings.
+    index_name = 'zephyr-main-2'
+
+    for f in args.files:
+        with open(f, "r") as j:
+            data = json.load(j)
+            bulk_data = []
+            for t in data['testsuites']:
+                t['environment'] = data['environment']
+                bulk_data.append({
+                            "_index": index_name,
+                            "_id": t['run_id'],
+                            "_source": t
+                            }
+                        )
+
+        bulk(client, bulk_data)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-u', '--user', help='username')
+    parser.add_argument('-p', '--password', help='password')
+    parser.add_argument('files', metavar='FILE', nargs='+', help='file with test data.')
+
+    args = parser.parse_args()
+
+    return args
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
On push, upload test results to opensearch for analysis and reporting.
Goal is to use this data to understand test coverage better and use this
services for all test reporting, also for results coming from testing on
hardware.
Opensearch is currenly being used for evaluation, we are considering
the switch to elasticsearch later.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
