### PR TITLE
boards: arm: stm32l562e_dk_ns: Fix boot regression

### DIFF
--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_ns.dts
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_ns.dts
@@ -18,6 +18,7 @@
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot1_ns_partition;
 	};
 


### PR DESCRIPTION
The #49984 accidentally removed zephyr,flash node. Without that, board not boot NS image. Add missing node to fix the issue.

Signed-off-by: Gerson Fernando Budke <gerson.budke@ossystems.com.br>