### PR TITLE
timer: Revert "timer: HPET is also a lock free readable timer"

### DIFF
--- a/drivers/timer/Kconfig.hpet
+++ b/drivers/timer/Kconfig.hpet
@@ -12,7 +12,6 @@ config HPET_TIMER
 	imply TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 	select TICKLESS_CAPABLE
 	select TIMER_HAS_64BIT_CYCLE_COUNTER
-	select SYSTEM_CLOCK_LOCK_FREE_COUNT
 	help
 	  This option selects High Precision Event Timer (HPET) as a
 	  system timer.


### PR DESCRIPTION
This seems to have caused CI failures and its unclear why just yet so revert instead.

This reverts commit cbee9e9fdd8060d0ca4e91037b3f99f631e4b1a5.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>