### PR TITLE
mgmt: mcumgr: Replace mgmt_ctxt struct with smp_streamer

### DIFF
--- a/subsys/mgmt/mcumgr/lib/README.md
+++ b/subsys/mgmt/mcumgr/lib/README.md
@@ -103,8 +103,8 @@ An mcumgr request or response consists of the following two components:
 How these two components are encoded and parsed depends on the transfer
 encoding used.
 
-The mcumgr header structure is defined in `mgmt/include/mgmt/mgmt.h` as
-`struct mgmt_hdr`.
+The mcumgr header structure is defined in `subsys/mgmt/mcumgr/smp_internal.h`
+as `struct smp_hdr`.
 
 The contents of the CBOR key-value map are specified per command type.
 

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/fs_mgmt.c
@@ -149,7 +149,7 @@ done:
 /**
  * Command handler: fs file (read)
  */
-static int fs_mgmt_file_download(struct mgmt_ctxt *ctxt)
+static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 {
 	uint8_t file_data[FS_MGMT_DL_CHUNK_SIZE];
 	char path[CONFIG_FS_MGMT_PATH_SIZE + 1];
@@ -157,8 +157,8 @@ static int fs_mgmt_file_download(struct mgmt_ctxt *ctxt)
 	size_t bytes_read = 0;
 	size_t file_len;
 	int rc;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 	bool ok;
 	struct zcbor_string name = { 0 };
 	size_t decoded;
@@ -281,7 +281,7 @@ done:
 /**
  * Command handler: fs file (write)
  */
-static int fs_mgmt_file_upload(struct mgmt_ctxt *ctxt)
+static int fs_mgmt_file_upload(struct smp_streamer *ctxt)
 {
 	char file_name[CONFIG_FS_MGMT_PATH_SIZE + 1];
 	unsigned long long len = ULLONG_MAX;
@@ -289,8 +289,8 @@ static int fs_mgmt_file_upload(struct mgmt_ctxt *ctxt)
 	size_t new_off;
 	bool ok;
 	int rc;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 	struct zcbor_string name = { 0 };
 	struct zcbor_string file_data = { 0 };
 	size_t decoded = 0;
@@ -373,13 +373,13 @@ static int fs_mgmt_file_upload(struct mgmt_ctxt *ctxt)
 /**
  * Command handler: fs stat (read)
  */
-static int fs_mgmt_file_status(struct mgmt_ctxt *ctxt)
+static int fs_mgmt_file_status(struct smp_streamer *ctxt)
 {
 	char path[CONFIG_FS_MGMT_PATH_SIZE + 1];
 	size_t file_len;
 	int rc;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 	bool ok;
 	struct zcbor_string name = { 0 };
 	size_t decoded;
@@ -425,7 +425,7 @@ static int fs_mgmt_file_status(struct mgmt_ctxt *ctxt)
 /**
  * Command handler: fs hash/checksum (read)
  */
-static int fs_mgmt_file_hash_checksum(struct mgmt_ctxt *ctxt)
+static int fs_mgmt_file_hash_checksum(struct smp_streamer *ctxt)
 {
 	char path[CONFIG_FS_MGMT_PATH_SIZE + 1];
 	char type_arr[HASH_CHECKSUM_TYPE_SIZE + 1] = FS_MGMT_CHECKSUM_HASH_DEFAULT;
@@ -434,8 +434,8 @@ static int fs_mgmt_file_hash_checksum(struct mgmt_ctxt *ctxt)
 	uint64_t off = 0;
 	size_t file_len;
 	int rc;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 	bool ok;
 	struct zcbor_string type = { 0 };
 	struct zcbor_string name = { 0 };

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -11,6 +11,7 @@
 #include "img_mgmt_config.h"
 #include "image.h"
 #include "mgmt/mgmt.h"
+#include "smp/smp.h"
 #include <zcbor_common.h>
 
 struct image_version;
@@ -253,7 +254,7 @@ int img_mgmt_vercmp(const struct image_version *a, const struct image_version *b
 #ifdef CONFIG_IMG_MGMT_VERBOSE_ERR
 #define IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, rsn) ((action)->rc_rsn = (rsn))
 #define IMG_MGMT_UPLOAD_ACTION_RC_RSN(action) ((action)->rc_rsn)
-int img_mgmt_error_rsp(struct mgmt_ctxt *ctxt, int rc, const char *rsn);
+int img_mgmt_error_rsp(struct smp_streamer *ctxt, int rc, const char *rsn);
 extern const char *img_mgmt_err_str_app_reject;
 extern const char *img_mgmt_err_str_hdr_malformed;
 extern const char *img_mgmt_err_str_magic_mismatch;

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -255,12 +255,12 @@ void img_mgmt_reset_upload(void)
  * Command handler: image erase
  */
 static int
-img_mgmt_erase(struct mgmt_ctxt *ctxt)
+img_mgmt_erase(struct smp_streamer *ctxt)
 {
 	struct image_version ver;
 	int rc;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 	bool ok;
 	uint32_t slot = 1;
 	size_t decoded = 0;
@@ -306,9 +306,9 @@ img_mgmt_erase(struct mgmt_ctxt *ctxt)
 }
 
 static int
-img_mgmt_upload_good_rsp(struct mgmt_ctxt *ctxt)
+img_mgmt_upload_good_rsp(struct smp_streamer *ctxt)
 {
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 	bool ok;
 
 	ok = zcbor_tstr_put_lit(zse, "rc")			&&
@@ -352,10 +352,10 @@ img_mgmt_upload_log(bool is_first, bool is_last, int status)
  * Command handler: image upload
  */
 static int
-img_mgmt_upload(struct mgmt_ctxt *ctxt)
+img_mgmt_upload(struct smp_streamer *ctxt)
 {
 	struct mgmt_evt_op_cmd_status_arg cmd_status_arg;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 	bool ok;
 	size_t decoded = 0;
 	struct img_mgmt_upload_req req = {

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_priv.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_priv.h
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 #include <inttypes.h>
 #include "img_mgmt/img_mgmt.h"
+#include "smp/smp.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -134,12 +135,11 @@ int img_mgmt_upload_inspect(const struct img_mgmt_upload_req *req,
 
 #define ERASED_VAL_32(x) (((x) << 24) | ((x) << 16) | ((x) << 8) | (x))
 int img_mgmt_erased_val(int slot, uint8_t *erased_val);
-struct mgmt_ctxt;
 
 int img_mgmt_find_by_hash(uint8_t *find, struct image_version *ver);
 int img_mgmt_find_by_ver(struct image_version *find, uint8_t *hash);
-int img_mgmt_state_read(struct mgmt_ctxt *ctxt);
-int img_mgmt_state_write(struct mgmt_ctxt *njb);
+int img_mgmt_state_read(struct smp_streamer *ctxt);
+int img_mgmt_state_write(struct smp_streamer *njb);
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
@@ -192,7 +192,7 @@ err:
  * Command handler: image state read
  */
 int
-img_mgmt_state_read(struct mgmt_ctxt *ctxt)
+img_mgmt_state_read(struct smp_streamer *ctxt)
 {
 	char vers_str[IMG_MGMT_VER_MAX_STR_LEN];
 	uint8_t hash[IMAGE_HASH_LEN]; /* SHA256 hash */
@@ -200,7 +200,7 @@ img_mgmt_state_read(struct mgmt_ctxt *ctxt)
 	uint32_t flags;
 	uint8_t state_flags;
 	int i;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 	bool ok;
 	struct zcbor_string zhash = { .value = hash, .len = IMAGE_HASH_LEN };
 
@@ -260,7 +260,7 @@ img_mgmt_state_read(struct mgmt_ctxt *ctxt)
  * Command handler: image state write
  */
 int
-img_mgmt_state_write(struct mgmt_ctxt *ctxt)
+img_mgmt_state_write(struct smp_streamer *ctxt)
 {
 	bool confirm = false;
 	int slot;
@@ -274,7 +274,7 @@ img_mgmt_state_write(struct mgmt_ctxt *ctxt)
 		ZCBOR_MAP_DECODE_KEY_VAL(confirm, zcbor_bool_decode, &confirm)
 	};
 
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 
 	ok = zcbor_map_decode_bulk(zsd, image_list_decode,
 		ARRAY_SIZE(image_list_decode), &decoded) == 0;

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
@@ -58,13 +58,13 @@ struct thread_iterator_info {
  * Command handler: os echo
  */
 #ifdef CONFIG_OS_MGMT_ECHO
-static int os_mgmt_echo(struct mgmt_ctxt *ctxt)
+static int os_mgmt_echo(struct smp_streamer *ctxt)
 {
 	struct zcbor_string value = { 0 };
 	struct zcbor_string key;
 	bool ok;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 
 	if (!zcbor_map_start_decode(zsd)) {
 		return MGMT_ERR_EUNKNOWN;
@@ -247,9 +247,9 @@ static void os_mgmt_taskstat_encode_one(const struct k_thread *thread, void *use
 /**
  * Command handler: os taskstat
  */
-static int os_mgmt_taskstat_read(struct mgmt_ctxt *ctxt)
+static int os_mgmt_taskstat_read(struct smp_streamer *ctxt)
 {
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 	struct thread_iterator_info iterator_ctx = {
 		.zse = zse,
 		.thread_idx = 0,
@@ -286,7 +286,7 @@ static void os_mgmt_reset_cb(struct k_timer *timer)
 	k_work_submit(&os_mgmt_reset_work);
 }
 
-static int os_mgmt_reset(struct mgmt_ctxt *ctxt)
+static int os_mgmt_reset(struct smp_streamer *ctxt)
 {
 #ifdef CONFIG_OS_MGMT_RESET_HOOK
 	int rc;
@@ -309,9 +309,9 @@ static int os_mgmt_reset(struct mgmt_ctxt *ctxt)
 
 #ifdef CONFIG_OS_MGMT_MCUMGR_PARAMS
 static int
-os_mgmt_mcumgr_params(struct mgmt_ctxt *ctxt)
+os_mgmt_mcumgr_params(struct smp_streamer *ctxt)
 {
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 	bool ok;
 
 	ok = zcbor_tstr_put_lit(zse, "buf_size")		&&

--- a/subsys/mgmt/mcumgr/lib/cmd/shell_mgmt/src/shell_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/shell_mgmt/src/shell_mgmt.c
@@ -38,15 +38,15 @@ shell_get_output(size_t *len)
  * Command handler: shell exec
  */
 static int
-shell_mgmt_exec(struct mgmt_ctxt *ctxt)
+shell_mgmt_exec(struct smp_streamer *ctxt)
 {
 	int rc;
 	bool ok;
 	char line[SHELL_MGMT_MAX_LINE_LEN + 1];
 	size_t len = 0;
 	struct zcbor_string cmd_out;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 
 	if (!zcbor_map_start_decode(zsd)) {
 		return MGMT_ERR_EINVAL;

--- a/subsys/mgmt/mcumgr/lib/cmd/stat_mgmt/src/stat_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/stat_mgmt/src/stat_mgmt.c
@@ -113,11 +113,11 @@ stat_mgmt_cb_encode(zcbor_state_t *zse, struct stat_mgmt_entry *entry)
  * Command handler: stat show
  */
 static int
-stat_mgmt_show(struct mgmt_ctxt *ctxt)
+stat_mgmt_show(struct smp_streamer *ctxt)
 {
 	struct zcbor_string value = { 0 };
-	zcbor_state_t *zse = ctxt->cnbe->zs;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 	char stat_name[STAT_MGMT_MAX_NAME_LEN];
 	bool ok;
 	size_t counter = 0;
@@ -179,10 +179,10 @@ stat_mgmt_show(struct mgmt_ctxt *ctxt)
  * Command handler: stat list
  */
 static int
-stat_mgmt_list(struct mgmt_ctxt *ctxt)
+stat_mgmt_list(struct smp_streamer *ctxt)
 {
 	const struct stats_hdr *cur = NULL;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 	bool ok;
 	size_t counter = 0;
 

--- a/subsys/mgmt/mcumgr/lib/cmd/zephyr_basic/src/basic_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/zephyr_basic/src/basic_mgmt.c
@@ -34,7 +34,7 @@ static int storage_erase(void)
 	return rc;
 }
 
-static int storage_erase_handler(struct mgmt_ctxt *ctxt)
+static int storage_erase_handler(struct smp_streamer *ctxt)
 {
 	int rc = storage_erase();
 

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -9,6 +9,7 @@
 
 #include <inttypes.h>
 #include <zephyr/sys/slist.h>
+#include <smp/smp.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -109,18 +110,6 @@ typedef void *(*mgmt_alloc_rsp_fn)(const void *src_buf, void *arg);
  */
 typedef void (*mgmt_reset_buf_fn)(void *buf, void *arg);
 
-/**
- * @brief Context required by command handlers for parsing requests and writing
- *		responses.
- */
-struct mgmt_ctxt {
-	struct cbor_nb_writer *cnbe;
-	struct cbor_nb_reader *cnbd;
-#ifdef CONFIG_MGMT_VERBOSE_ERR_RESPONSE
-	const char *rc_rsn;
-#endif
-};
-
 #ifdef CONFIG_MGMT_VERBOSE_ERR_RESPONSE
 #define MGMT_CTXT_SET_RC_RSN(mc, rsn) ((mc->rc_rsn) = (rsn))
 #define MGMT_CTXT_RC_RSN(mc) ((mc)->rc_rsn)
@@ -138,7 +127,7 @@ struct mgmt_ctxt {
  *
  * @return 0 if a response was successfully encoded, MGMT_ERR_[...] code on failure.
  */
-typedef int (*mgmt_handler_fn)(struct mgmt_ctxt *ctxt);
+typedef int (*mgmt_handler_fn)(struct smp_streamer *ctxt);
 
 /**
  * @brief Read handler and write handler for a single command ID.

--- a/subsys/mgmt/mcumgr/lib/protocol.md
+++ b/subsys/mgmt/mcumgr/lib/protocol.md
@@ -33,7 +33,7 @@ option at the struct level, as shown below.
 Frames in SMP have the following header format:
 
 ```
-struct mgmt_hdr {
+struct smp_hdr {
 #ifdef CONFIG_LITTLE_ENDIAN
     uint8_t  nh_op:3;           /* MGMT_OP_[...] */
     uint8_t  _res1:5;

--- a/subsys/mgmt/mcumgr/lib/smp/include/smp/smp.h
+++ b/subsys/mgmt/mcumgr/lib/smp/include/smp/smp.h
@@ -68,6 +68,10 @@ struct smp_streamer {
 	struct smp_transport *smpt;
 	struct cbor_nb_reader *reader;
 	struct cbor_nb_writer *writer;
+
+#ifdef CONFIG_MGMT_VERBOSE_ERR_RESPONSE
+	const char *rc_rsn;
+#endif
 };
 
 /**


### PR DESCRIPTION
This replaces an intermediatory structure with a different one which allows command functions to access the full contents of the streamer structure that would be otherwise unavailable. This is a foundation for allowing asynchronous mcumgr messages from the server.

Required for https://github.com/zephyrproject-rtos/zephyr/issues/50428

- [X] Remove mgmt_ctxt and replace with smp_streamer
- [X] Check mcumgr functionality works
- [x] Stable API change request
- [X] Documentation update