### PR TITLE
drivers: sensor: Remove brackets from sensor info shell command output 

### DIFF
--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -216,12 +216,16 @@ static int cmd_get_sensor_info(const struct shell *sh, size_t argc,
 	ARG_UNUSED(argv);
 
 #ifdef CONFIG_SENSOR_INFO
+	const char *null_str = "(null)";
+
 	STRUCT_SECTION_FOREACH(sensor_info, sensor) {
 		shell_print(sh,
-			    "device name: %s, vendor: [%s], model: [%s], "
-			    "friendly name: [%s]",
-			    sensor->dev->name, sensor->vendor, sensor->model,
-			    sensor->friendly_name);
+			    "device name: %s, vendor: %s, model: %s, "
+			    "friendly name: %s",
+			    sensor->dev->name,
+			    sensor->vendor ? sensor->vendor : null_str,
+			    sensor->model ? sensor->model : null_str,
+			    sensor->friendly_name ? sensor->friendly_name : null_str);
 	}
 	return 0;
 #else

--- a/samples/sensor/sensor_shell/README.rst
+++ b/samples/sensor/sensor_shell/README.rst
@@ -14,7 +14,7 @@ Build the sample app by choosing the target board that has sensors drivers
 enabled, for example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/subsys/shell/sensor_module
+   :zephyr-app: samples/sensor/sensor_shell
    :board: reel_board
    :goals: build flash
 

--- a/samples/sensor/sensor_shell/README.rst
+++ b/samples/sensor/sensor_shell/README.rst
@@ -63,7 +63,7 @@ This command depends on enabling :kconfig:option:`CONFIG_SENSOR_INFO`.
 .. code-block:: console
 
    uart:~$ sensor info
-   device name: apds9960@39, vendor: [Avago Technologies], model: [apds9960], friendly name: []
-   device name: mma8652fc@1d, vendor: [NXP Semiconductors], model: [fxos8700], friendly name: []
-   device name: ti_hdc@43, vendor: [Texas Instruments], model: [hdc], friendly name: []
-   device name: temp@4000c000, vendor: [Nordic Semiconductor], model: [nrf-temp], friendly name: []
+   device name: apds9960@39, vendor: Avago Technologies, model: apds9960, friendly name: (null)
+   device name: mma8652fc@1d, vendor: NXP Semiconductors, model: fxos8700, friendly name: (null)
+   device name: ti_hdc@43, vendor: Texas Instruments, model: hdc, friendly name: (null)
+   device name: temp@4000c000, vendor: Nordic Semiconductor, model: nrf-temp, friendly name: (null)


### PR DESCRIPTION
Brackets were originally used in the sensor info shell command output to
make it obvious when a field is a null string, however they incorrectly
suggest that a field is an array. Remove the brackets and conditionally
print "(null)" instead.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>