### PR TITLE
ci: Limit workflow scope to v2.7-branch

### DIFF
--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -6,10 +6,14 @@ name: Devicetree script tests
 
 on:
   push:
+    branches:
+    - v2.7-branch
     paths:
     - 'scripts/dts/**'
     - '.github/workflows/devicetree_checks.yml'
   pull_request:
+    branches:
+    - v2.7-branch
     paths:
     - 'scripts/dts/**'
     - '.github/workflows/devicetree_checks.yml'

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -2,7 +2,11 @@ name: Run tests with twister
 
 on:
   push:
+    branches:
+    - v2.7-branch
   pull_request_target:
+    branches:
+    - v2.7-branch
   schedule:
     # Run at 00:00 on Saturday
     - cron: '20 0 * * 6'

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -5,12 +5,16 @@ name: Twister TestSuite
 
 on:
   push:
+    branches:
+    - v2.7-branch
     paths:
     - 'scripts/pylib/twister/**'
     - 'scripts/twister'
     - 'scripts/tests/twister/**'
     - '.github/workflows/twister_tests.yml'
   pull_request:
+    branches:
+    - v2.7-branch
     paths:
     - 'scripts/pylib/twister/**'
     - 'scripts/twister'

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -5,11 +5,15 @@ name: Zephyr West Command Tests
 
 on:
   push:
+    branches:
+    - v2.7-branch
     paths:
     - 'scripts/west-commands.yml'
     - 'scripts/west_commands/**'
     - '.github/workflows/west_cmds.yml'
   pull_request:
+    branches:
+    - v2.7-branch
     paths:
     - 'scripts/west-commands.yml'
     - 'scripts/west_commands/**'


### PR DESCRIPTION
This commit updates the CI workflows to limit their event trigger scope to the v2.7-branch in order to prevent the workflows from running when the backport branches are pushed.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>