### PR TITLE
ci: Limit workflow scope branches

### DIFF
--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -6,10 +6,16 @@ name: Devicetree script tests
 
 on:
   push:
+    branches:
+    - main
+    - v*-branch
     paths:
     - 'scripts/dts/**'
     - '.github/workflows/devicetree_checks.yml'
   pull_request:
+    branches:
+    - main
+    - v*-branch
     paths:
     - 'scripts/dts/**'
     - '.github/workflows/devicetree_checks.yml'

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -5,12 +5,18 @@ name: Twister TestSuite
 
 on:
   push:
+    branches:
+    - main
+    - v*-branch
     paths:
     - 'scripts/pylib/twister/**'
     - 'scripts/twister'
     - 'scripts/tests/twister/**'
     - '.github/workflows/twister_tests.yml'
   pull_request:
+    branches:
+    - main
+    - v*-branch
     paths:
     - 'scripts/pylib/twister/**'
     - 'scripts/twister'

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -5,11 +5,17 @@ name: Zephyr West Command Tests
 
 on:
   push:
+    branches:
+    - main
+    - v*-branch
     paths:
     - 'scripts/west-commands.yml'
     - 'scripts/west_commands/**'
     - '.github/workflows/west_cmds.yml'
   pull_request:
+    branches:
+    - main
+    - v*-branch
     paths:
     - 'scripts/west-commands.yml'
     - 'scripts/west_commands/**'


### PR DESCRIPTION
This commit updates the CI workflows that trigger on both push and pull request events to limit their event trigger scope to the main and the release branches.

This prevents these workflows from simultaneously triggering on both push and pull request events when a pull request is created from an upstream branch to another upstream branch (e.g. pull requests from the backport branches to the release branches).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>