### PR TITLE
Bluetooth: Shell: Add back erroneously removed ll-addr command

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -3651,6 +3651,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 #endif /* CONFIG_BT_HCI_MESH_EXT */
 
 #if defined(CONFIG_BT_LL_SW_SPLIT)
+	SHELL_CMD(ll-addr, NULL, "<random|public>", cmd_ll_addr_read),
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_BROADCASTER)
 	SHELL_CMD_ARG(advx, NULL,


### PR DESCRIPTION
Add back erroneously removed ll-addr command, when removing legacy Controller, which is provided when using Zephyr Bluetooth Low Energy Controller to read the random and public address set by the Host, and used by the Controller.

Relates to commit b67a31e411a7 ("Bluetooth: controller: Remove legacy LL").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>