### PR TITLE
drivers: sensor: bmm150: Add I2C-base or SPI-base interface in build …

### DIFF
--- a/drivers/sensor/bmm150/CMakeLists.txt
+++ b/drivers/sensor/bmm150/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-
-zephyr_library_sources(bmm150.c)
+zephyr_library_sources(bmm150.c bmm150_i2c.c bmm150_spi.c)

--- a/drivers/sensor/bmm150/bmm150.h
+++ b/drivers/sensor/bmm150/bmm150.h
@@ -9,6 +9,47 @@
 #ifndef ZEPHYR_DRIVERS_SENSOR_BMM150_BMM150_H_
 #define ZEPHYR_DRIVERS_SENSOR_BMM150_BMM150_H_
 
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/i2c.h>
+
+#define DT_DRV_COMPAT bosch_bmm150
+
+#define BMM150_BUS_SPI DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#define BMM150_BUS_I2C DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+
+union bmm150_bus {
+#if BMM150_BUS_SPI
+	struct spi_dt_spec spi;
+#endif
+#if BMM150_BUS_I2C
+	struct i2c_dt_spec i2c;
+#endif
+};
+
+typedef int (*bmm150_bus_check_fn)(const union bmm150_bus *bus);
+typedef int (*bmm150_reg_read_fn)(const union bmm150_bus *bus,
+				  uint8_t start, uint8_t *buf, int size);
+typedef int (*bmm150_reg_write_fn)(const union bmm150_bus *bus,
+				   uint8_t reg, uint8_t val);
+
+struct bmm150_bus_io {
+	bmm150_bus_check_fn check;
+	bmm150_reg_read_fn read;
+	bmm150_reg_write_fn write;
+};
+
+#if BMM150_BUS_SPI
+#define BMM150_SPI_OPERATION (SPI_WORD_SET(8) | SPI_TRANSFER_MSB |	\
+			      SPI_MODE_CPOL | SPI_MODE_CPHA)
+extern const struct bmm150_bus_io bmm150_bus_io_spi;
+#endif
+
+#if BMM150_BUS_I2C
+extern const struct bmm150_bus_io bmm150_bus_io_i2c;
+#endif
 
 #include <zephyr/types.h>
 #include <zephyr/drivers/i2c.h>
@@ -41,6 +82,8 @@
 
 #define BMM150_REG_POWER           0x4B
 #define BMM150_MASK_POWER_CTL      BIT(0)
+#define BMM150_MASK_SOFT_RESET     (BIT(1) | BIT(7))
+#define BMM150_SOFT_RESET          0x81
 
 #define BMM150_REG_OPMODE_ODR      0x4C
 #define BMM150_MASK_OPMODE         (BIT(2) | BIT(1))
@@ -66,7 +109,7 @@
 #define BMM150_REGVAL_TO_REPXY(regval)     (((regval) * 2) + 1)
 #define BMM150_REGVAL_TO_REPZ(regval)      ((regval) + 1)
 #define BMM150_REPXY_TO_REGVAL(rep)        (((rep) - 1) / 2)
-#define BMM150_REPZ_TO_REGVAL(rep)         ((rep) - 1)
+#define BMM150_REPZ_TO_REGVAL(rep)         BMM150_REPXY_TO_REGVAL(rep)
 
 #define BMM150_REG_INT                     0x4D
 
@@ -92,11 +135,6 @@
 	#define BMM150_MAGN_SET_ATTR
 #endif
 
-
-struct bmm150_config {
-	struct i2c_dt_spec i2c;
-};
-
 struct bmm150_trim_regs {
 	int8_t x1;
 	int8_t y1;
@@ -113,6 +151,11 @@ struct bmm150_trim_regs {
 	int8_t xy2;
 	uint8_t xy1;
 } __packed;
+
+struct bmm150_config {
+	union bmm150_bus bus;
+	const struct bmm150_bus_io *bus_io;
+};
 
 struct bmm150_data {
 	struct k_sem sem;
@@ -152,5 +195,8 @@ enum bmm150_presets {
 #elif defined(CONFIG_BMM150_PRESET_HIGH_ACCURACY)
 	#define BMM150_DEFAULT_PRESET BMM150_HIGH_ACCURACY_PRESET
 #endif
+
+int bmm150_reg_update_byte(const struct device *dev, uint8_t reg,
+			   uint8_t mask, uint8_t value);
 
 #endif /* __SENSOR_BMM150_H__ */

--- a/drivers/sensor/bmm150/bmm150_i2c.c
+++ b/drivers/sensor/bmm150/bmm150_i2c.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016, 2017 Intel Corporation
+ * Copyright (c) 2017 IpTronix S.r.l.
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Bus-specific functionality for BMM150s accessed via I2C.
+ */
+
+#include "bmm150.h"
+
+#if BMM150_BUS_I2C
+
+static int bmm150_bus_check_i2c(const union bmm150_bus *bus)
+{
+	return i2c_is_ready_dt(&bus->i2c) ? 0 : -ENODEV;
+}
+
+static int bmm150_reg_read_i2c(const union bmm150_bus *bus,
+			       uint8_t start, uint8_t *buf, int size)
+{
+	return i2c_burst_read_dt(&bus->i2c, start, buf, size);
+}
+
+static int bmm150_reg_write_i2c(const union bmm150_bus *bus,
+				uint8_t reg, uint8_t val)
+{
+	return i2c_reg_write_byte_dt(&bus->i2c, reg, val);
+}
+
+const struct bmm150_bus_io bmm150_bus_io_i2c = {
+	.check = bmm150_bus_check_i2c,
+	.read = bmm150_reg_read_i2c,
+	.write = bmm150_reg_write_i2c,
+};
+
+#endif /* BMM150_BUS_I2C */

--- a/drivers/sensor/bmm150/bmm150_spi.c
+++ b/drivers/sensor/bmm150/bmm150_spi.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2016, 2017 Intel Corporation
+ * Copyright (c) 2017 IpTronix S.r.l.
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Bus-specific functionality for BMM150s accessed via SPI.
+ */
+
+#include <zephyr/logging/log.h>
+#include "bmm150.h"
+
+#if BMM150_BUS_SPI
+
+LOG_MODULE_DECLARE(BMM150, CONFIG_SENSOR_LOG_LEVEL);
+
+static int bmm150_bus_check_spi(const union bmm150_bus *bus)
+{
+	return spi_is_ready_dt(&bus->spi) ? 0 : -ENODEV;
+}
+
+static int bmm150_reg_read_spi(const union bmm150_bus *bus,
+			       uint8_t start, uint8_t *buf, int size)
+{
+	uint8_t addr;
+	const struct spi_buf tx_buf = {
+		.buf = &addr,
+		.len = 1
+	};
+	const struct spi_buf_set tx = {
+		.buffers = &tx_buf,
+		.count = 1
+	};
+	struct spi_buf rx_buf[2];
+	const struct spi_buf_set rx = {
+		.buffers = rx_buf,
+		.count = ARRAY_SIZE(rx_buf)
+	};
+	int i;
+
+	rx_buf[0].buf = NULL;
+	rx_buf[0].len = 1;
+
+	rx_buf[1].len = 1;
+
+	for (i = 0; i < size; i++) {
+		int ret;
+
+		addr = (start + i) | 0x80;
+		rx_buf[1].buf = &buf[i];
+
+		ret = spi_transceive_dt(&bus->spi, &tx, &rx);
+		if (ret) {
+			LOG_DBG("spi_transceive FAIL %d\n", ret);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static int bmm150_reg_write_spi(const union bmm150_bus *bus,
+				uint8_t reg, uint8_t val)
+{
+	uint8_t cmd[] = { reg & 0x7F, val };
+	const struct spi_buf tx_buf = {
+		.buf = cmd,
+		.len = sizeof(cmd)
+	};
+	const struct spi_buf_set tx = {
+		.buffers = &tx_buf,
+		.count = 1
+	};
+	int ret;
+
+	ret = spi_write_dt(&bus->spi, &tx);
+	if (ret) {
+		LOG_DBG("spi_write FAIL %d\n", ret);
+		return ret;
+	}
+	return 0;
+}
+
+const struct bmm150_bus_io bmm150_bus_io_spi = {
+	.check = bmm150_bus_check_spi,
+	.read = bmm150_reg_read_spi,
+	.write = bmm150_reg_write_spi,
+};
+
+#endif /* BMM150_BUS_SPI */

--- a/dts/bindings/sensor/bosch,bmm150-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bmm150-i2c.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2019, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    Bosch BMM150 Geomagnetic sensor.  See more info at:
+    https://www.bosch-sensortec.com/bst/products/all_products/bmm150
+
+compatible: "bosch,bmm150"
+
+include: ["i2c-device.yaml", "bosch,bmm150.yaml"]

--- a/dts/bindings/sensor/bosch,bmm150-spi.yaml
+++ b/dts/bindings/sensor/bosch,bmm150-spi.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2019, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    Bosch BMM150 Geomagnetic sensor.  See more info at:
+    https://www.bosch-sensortec.com/bst/products/all_products/bmm150
+
+compatible: "bosch,bmm150"
+
+include: ["spi-device.yaml", "bosch,bmm150.yaml"]

--- a/dts/bindings/sensor/bosch,bmm150.yaml
+++ b/dts/bindings/sensor/bosch,bmm150.yaml
@@ -1,10 +1,6 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
-description: |
-    Bosch BMM150 Geomagnetic sensor.  See more info at:
-    https://www.bosch-sensortec.com/bst/products/all_products/bmm150
+# Common fields for BMM150
 
-compatible: "bosch,bmm150"
-
-include: [sensor-device.yaml, i2c-device.yaml]
+include: sensor-device.yaml

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -354,3 +354,9 @@ test_spi_max31865: max31865@2a {
 	high-threshold = <32767>;
 	filter-50hz;
 };
+
+test_spi_bmm150: bmm150@2b {
+	compatible = "bosch,bmm150";
+	reg = <0x2b>;
+	spi-max-frequency = <0>;
+};


### PR DESCRIPTION
…time

move DT_DRV_COMPAT to bmm150.h. so that can be decide which interface to use. define struct bmm150_bus_io interface for bmm150_i2c.c and bmm150_spi.c in bmm150.h. redefined bus operation interface in bmm150.c, this allow the driver to decide which interface to use during construction.

Signed-off-by: Weiwei Guo <guoweiwei@syriusrobotics.com>