### PR TITLE
usb: dfu: Reduce default bwPollTimeout value

### DIFF
--- a/subsys/usb/device/class/dfu/Kconfig
+++ b/subsys/usb/device/class/dfu/Kconfig
@@ -34,7 +34,7 @@ config USB_DFU_DETACH_TIMEOUT
 
 config USB_DFU_DEFAULT_POLLTIMEOUT
 	int "Default value for bwPollTimeout"
-	default 256
+	default 8
 	range 0 1000
 	help
 	  Default value for bwPollTimeout (in ms)


### PR DESCRIPTION
The bwPollTimeout name is somewhat confusing as it refers to minimum polling period. The bwPollTImeout is essentially a mechanism allowing device to ratelimit DFU_GETSTATUS requests from host.

Setting bwPollTimeout to relatively high values effectively slows down DFU download process. The slowdown is not observed if the time between DFU_DNLOAD and DFU_GETSTATUS is enough for the device to process the write. That is, the bwPollTimeout does not effect DFU download if the first DFU_GETSTATUS after DFU_DNLOAD reports dfuDNLOAD-IDLE state. Otherwise the host must wait bwPollTimeout ms before issuing next DFU_GETSTATUS, which slows the communicaiton to not more than 1 download block (CONFIG_USB_REQUEST_BUFFER_SIZE) every bwPollTimeout ms.

The bwPollTimeout ideally should report an estimate how much longer the download operation will take. Zephyr does not have such estimate and therefore defaults to using fixed value. Reduce default bwPollTimeout from 256 to 8 ms to allow significantly faster DFU downloads on devices where the time between DFU_DNLOAD and DFU_GETSTATUS is too short to process download block at the expense of unnecessary bus traffic if processing download block takes longer than 8 ms.

Signed-off-by: Tomasz Moń <tomasz.mon@nordicsemi.no>