### PR TITLE
[DNM] [RFC] mgmt: mcumgr: Add test async functionality

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/fs_mgmt.c
@@ -92,7 +92,7 @@ fs_mgmt_file_rsp(zcbor_state_t *zse, int rc, uint64_t off)
  * Command handler: fs file (read)
  */
 static int
-fs_mgmt_file_download(struct mgmt_ctxt *ctxt)
+fs_mgmt_file_download(struct smp_streamer *ctxt)
 {
 	uint8_t file_data[FS_MGMT_DL_CHUNK_SIZE];
 	char path[CONFIG_FS_MGMT_PATH_SIZE + 1];
@@ -100,8 +100,8 @@ fs_mgmt_file_download(struct mgmt_ctxt *ctxt)
 	size_t bytes_read;
 	size_t file_len;
 	int rc;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 	bool ok;
 	struct zcbor_string name = { 0 };
 	size_t decoded;
@@ -163,7 +163,7 @@ fs_mgmt_file_download(struct mgmt_ctxt *ctxt)
  * Command handler: fs file (write)
  */
 static int
-fs_mgmt_file_upload(struct mgmt_ctxt *ctxt)
+fs_mgmt_file_upload(struct smp_streamer *ctxt)
 {
 	char file_name[CONFIG_FS_MGMT_PATH_SIZE + 1];
 	unsigned long long len = ULLONG_MAX;
@@ -171,8 +171,8 @@ fs_mgmt_file_upload(struct mgmt_ctxt *ctxt)
 	size_t new_off;
 	bool ok;
 	int rc;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 	struct zcbor_string name = { 0 };
 	struct zcbor_string file_data = { 0 };
 	size_t decoded = 0;
@@ -256,13 +256,13 @@ fs_mgmt_file_upload(struct mgmt_ctxt *ctxt)
  * Command handler: fs stat (read)
  */
 static int
-fs_mgmt_file_status(struct mgmt_ctxt *ctxt)
+fs_mgmt_file_status(struct smp_streamer *ctxt)
 {
 	char path[CONFIG_FS_MGMT_PATH_SIZE + 1];
 	size_t file_len;
 	int rc;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 	bool ok;
 	struct zcbor_string name = { 0 };
 	size_t decoded;
@@ -309,7 +309,7 @@ fs_mgmt_file_status(struct mgmt_ctxt *ctxt)
  * Command handler: fs hash/checksum (read)
  */
 static int
-fs_mgmt_file_hash_checksum(struct mgmt_ctxt *ctxt)
+fs_mgmt_file_hash_checksum(struct smp_streamer *ctxt)
 {
 	char path[CONFIG_FS_MGMT_PATH_SIZE + 1];
 	char type_arr[HASH_CHECKSUM_TYPE_SIZE + 1] = FS_MGMT_CHECKSUM_HASH_DEFAULT;
@@ -318,8 +318,8 @@ fs_mgmt_file_hash_checksum(struct mgmt_ctxt *ctxt)
 	uint64_t off = 0;
 	size_t file_len;
 	int rc;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 	bool ok;
 	struct zcbor_string type = { 0 };
 	struct zcbor_string name = { 0 };

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -11,6 +11,7 @@
 #include "img_mgmt_config.h"
 #include "image.h"
 #include "mgmt/mgmt.h"
+#include "smp/smp.h"
 #include <zcbor_common.h>
 
 struct image_version;
@@ -253,7 +254,7 @@ int img_mgmt_vercmp(const struct image_version *a, const struct image_version *b
 #ifdef CONFIG_IMG_MGMT_VERBOSE_ERR
 #define IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, rsn) ((action)->rc_rsn = (rsn))
 #define IMG_MGMT_UPLOAD_ACTION_RC_RSN(action) ((action)->rc_rsn)
-int img_mgmt_error_rsp(struct mgmt_ctxt *ctxt, int rc, const char *rsn);
+int img_mgmt_error_rsp(struct smp_streamer *ctxt, int rc, const char *rsn);
 extern const char *img_mgmt_err_str_app_reject;
 extern const char *img_mgmt_err_str_hdr_malformed;
 extern const char *img_mgmt_err_str_magic_mismatch;

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -246,12 +246,12 @@ img_mgmt_find_by_hash(uint8_t *find, struct image_version *ver)
  * Command handler: image erase
  */
 static int
-img_mgmt_erase(struct mgmt_ctxt *ctxt)
+img_mgmt_erase(struct smp_streamer *ctxt)
 {
 	struct image_version ver;
 	int rc;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 	bool ok;
 	uint32_t slot = 1;
 	size_t decoded = 0;
@@ -295,9 +295,9 @@ img_mgmt_erase(struct mgmt_ctxt *ctxt)
 }
 
 static int
-img_mgmt_upload_good_rsp(struct mgmt_ctxt *ctxt)
+img_mgmt_upload_good_rsp(struct smp_streamer *ctxt)
 {
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 	bool ok;
 
 	ok = zcbor_tstr_put_lit(zse, "rc")			&&
@@ -341,10 +341,10 @@ img_mgmt_upload_log(bool is_first, bool is_last, int status)
  * Command handler: image upload
  */
 static int
-img_mgmt_upload(struct mgmt_ctxt *ctxt)
+img_mgmt_upload(struct smp_streamer *ctxt)
 {
 	struct mgmt_evt_op_cmd_status_arg cmd_status_arg;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 	bool ok;
 	size_t decoded = 0;
 	struct img_mgmt_upload_req req = {

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_priv.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_priv.h
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 #include <inttypes.h>
 #include "img_mgmt/img_mgmt.h"
+#include "smp/smp.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -134,12 +135,11 @@ int img_mgmt_upload_inspect(const struct img_mgmt_upload_req *req,
 
 #define ERASED_VAL_32(x) (((x) << 24) | ((x) << 16) | ((x) << 8) | (x))
 int img_mgmt_erased_val(int slot, uint8_t *erased_val);
-struct mgmt_ctxt;
 
 int img_mgmt_find_by_hash(uint8_t *find, struct image_version *ver);
 int img_mgmt_find_by_ver(struct image_version *find, uint8_t *hash);
-int img_mgmt_state_read(struct mgmt_ctxt *ctxt);
-int img_mgmt_state_write(struct mgmt_ctxt *njb);
+int img_mgmt_state_read(struct smp_streamer *ctxt);
+int img_mgmt_state_write(struct smp_streamer *njb);
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
@@ -192,7 +192,7 @@ err:
  * Command handler: image state read
  */
 int
-img_mgmt_state_read(struct mgmt_ctxt *ctxt)
+img_mgmt_state_read(struct smp_streamer *ctxt)
 {
 	char vers_str[IMG_MGMT_VER_MAX_STR_LEN];
 	uint8_t hash[IMAGE_HASH_LEN]; /* SHA256 hash */
@@ -200,7 +200,7 @@ img_mgmt_state_read(struct mgmt_ctxt *ctxt)
 	uint32_t flags;
 	uint8_t state_flags;
 	int i;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 	bool ok;
 	struct zcbor_string zhash = { .value = hash, .len = IMAGE_HASH_LEN };
 
@@ -260,7 +260,7 @@ img_mgmt_state_read(struct mgmt_ctxt *ctxt)
  * Command handler: image state write
  */
 int
-img_mgmt_state_write(struct mgmt_ctxt *ctxt)
+img_mgmt_state_write(struct smp_streamer *ctxt)
 {
 	bool confirm = false;
 	int slot;
@@ -274,7 +274,7 @@ img_mgmt_state_write(struct mgmt_ctxt *ctxt)
 		ZCBOR_MAP_DECODE_KEY_VAL(confirm, zcbor_bool_decode, &confirm)
 	};
 
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 
 	ok = zcbor_map_decode_bulk(zsd, image_list_decode,
 		ARRAY_SIZE(image_list_decode), &decoded) == 0;

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/include/os_mgmt/os_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/include/os_mgmt/os_mgmt.h
@@ -23,6 +23,9 @@ extern "C" {
 #define OS_MGMT_ID_RESET		5
 #define OS_MGMT_ID_MCUMGR_PARAMS	6
 
+/* Test for async - not to be committed */
+#define OS_MGMT_ID_ASYNC_TEST		10
+
 #ifdef CONFIG_OS_MGMT_RESET_HOOK
 /** @typedef os_mgmt_on_reset_evt_cb
  * @brief Function to be called on os mgmt reset event.

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
@@ -49,13 +49,13 @@ struct thread_iterator_info {
  */
 #ifdef CONFIG_OS_MGMT_ECHO
 static int
-os_mgmt_echo(struct mgmt_ctxt *ctxt)
+os_mgmt_echo(struct smp_streamer *ctxt)
 {
 	struct zcbor_string value = { 0 };
 	struct zcbor_string key;
 	bool ok;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 
 	if (!zcbor_map_start_decode(zsd)) {
 		return MGMT_ERR_EUNKNOWN;
@@ -238,9 +238,9 @@ static void os_mgmt_taskstat_encode_one(const struct k_thread *thread, void *use
 /**
  * Command handler: os taskstat
  */
-static int os_mgmt_taskstat_read(struct mgmt_ctxt *ctxt)
+static int os_mgmt_taskstat_read(struct smp_streamer *ctxt)
 {
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 	struct thread_iterator_info iterator_ctx = {
 		.zse = zse,
 		.thread_idx = 0,
@@ -267,7 +267,7 @@ static int os_mgmt_taskstat_read(struct mgmt_ctxt *ctxt)
  * Command handler: os reset
  */
 static int
-os_mgmt_reset(struct mgmt_ctxt *ctxt)
+os_mgmt_reset(struct smp_streamer *ctxt)
 {
 #ifdef CONFIG_OS_MGMT_RESET_HOOK
 	int rc;
@@ -288,9 +288,9 @@ os_mgmt_reset(struct mgmt_ctxt *ctxt)
 
 #ifdef CONFIG_OS_MGMT_MCUMGR_PARAMS
 static int
-os_mgmt_mcumgr_params(struct mgmt_ctxt *ctxt)
+os_mgmt_mcumgr_params(struct smp_streamer *ctxt)
 {
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 	bool ok;
 
 	ok = zcbor_tstr_put_lit(zse, "buf_size")		&&

--- a/subsys/mgmt/mcumgr/lib/cmd/shell_mgmt/src/shell_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/shell_mgmt/src/shell_mgmt.c
@@ -38,15 +38,15 @@ shell_get_output(size_t *len)
  * Command handler: shell exec
  */
 static int
-shell_mgmt_exec(struct mgmt_ctxt *ctxt)
+shell_mgmt_exec(struct smp_streamer *ctxt)
 {
 	int rc;
 	bool ok;
 	char line[SHELL_MGMT_MAX_LINE_LEN + 1];
 	size_t len = 0;
 	struct zcbor_string cmd_out;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 
 	if (!zcbor_map_start_decode(zsd)) {
 		return MGMT_ERR_EINVAL;

--- a/subsys/mgmt/mcumgr/lib/cmd/stat_mgmt/src/stat_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/stat_mgmt/src/stat_mgmt.c
@@ -113,11 +113,11 @@ stat_mgmt_cb_encode(zcbor_state_t *zse, struct stat_mgmt_entry *entry)
  * Command handler: stat show
  */
 static int
-stat_mgmt_show(struct mgmt_ctxt *ctxt)
+stat_mgmt_show(struct smp_streamer *ctxt)
 {
 	struct zcbor_string value = { 0 };
-	zcbor_state_t *zse = ctxt->cnbe->zs;
-	zcbor_state_t *zsd = ctxt->cnbd->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
+	zcbor_state_t *zsd = ctxt->reader->zs;
 	char stat_name[STAT_MGMT_MAX_NAME_LEN];
 	bool ok;
 	size_t counter = 0;
@@ -179,10 +179,10 @@ stat_mgmt_show(struct mgmt_ctxt *ctxt)
  * Command handler: stat list
  */
 static int
-stat_mgmt_list(struct mgmt_ctxt *ctxt)
+stat_mgmt_list(struct smp_streamer *ctxt)
 {
 	const struct stats_hdr *cur = NULL;
-	zcbor_state_t *zse = ctxt->cnbe->zs;
+	zcbor_state_t *zse = ctxt->writer->zs;
 	bool ok;
 	size_t counter = 0;
 

--- a/subsys/mgmt/mcumgr/lib/cmd/zephyr_basic/src/basic_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/zephyr_basic/src/basic_mgmt.c
@@ -34,7 +34,7 @@ static int storage_erase(void)
 	return rc;
 }
 
-static int storage_erase_handler(struct mgmt_ctxt *ctxt)
+static int storage_erase_handler(struct smp_streamer *ctxt)
 {
 	int rc = storage_erase();
 

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -9,6 +9,7 @@
 
 #include <inttypes.h>
 #include <zephyr/sys/slist.h>
+#include <smp/smp.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -126,18 +127,6 @@ typedef void *(*mgmt_alloc_rsp_fn)(const void *src_buf, void *arg);
  */
 typedef void (*mgmt_reset_buf_fn)(void *buf, void *arg);
 
-/**
- * @brief Context required by command handlers for parsing requests and writing
- *		responses.
- */
-struct mgmt_ctxt {
-	struct cbor_nb_writer *cnbe;
-	struct cbor_nb_reader *cnbd;
-#ifdef CONFIG_MGMT_VERBOSE_ERR_RESPONSE
-	const char *rc_rsn;
-#endif
-};
-
 #ifdef CONFIG_MGMT_VERBOSE_ERR_RESPONSE
 #define MGMT_CTXT_SET_RC_RSN(mc, rsn) ((mc->rc_rsn) = (rsn))
 #define MGMT_CTXT_RC_RSN(mc) ((mc)->rc_rsn)
@@ -155,7 +144,7 @@ struct mgmt_ctxt {
  *
  * @return 0 if a response was successfully encoded, MGMT_ERR_[...] code on failure.
  */
-typedef int (*mgmt_handler_fn)(struct mgmt_ctxt *ctxt);
+typedef int (*mgmt_handler_fn)(struct smp_streamer *ctxt);
 
 /**
  * @brief Read handler and write handler for a single command ID.

--- a/subsys/mgmt/mcumgr/lib/smp/include/smp/smp.h
+++ b/subsys/mgmt/mcumgr/lib/smp/include/smp/smp.h
@@ -68,6 +68,10 @@ struct smp_streamer {
 	struct smp_transport *smpt;
 	struct cbor_nb_reader *reader;
 	struct cbor_nb_writer *writer;
+
+#ifdef CONFIG_MGMT_VERBOSE_ERR_RESPONSE
+	const char *rc_rsn;
+#endif
 };
 
 /**

--- a/subsys/mgmt/mcumgr/lib/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/lib/smp/src/smp.c
@@ -133,7 +133,7 @@ smp_build_err_rsp(struct smp_streamer *streamer, const struct mgmt_hdr *req_hdr,
  * @return A MGMT_ERR_[...] error code.
  */
 static int
-smp_handle_single_payload(struct mgmt_ctxt *cbuf, const struct mgmt_hdr *req_hdr,
+smp_handle_single_payload(struct smp_streamer *cbuf, const struct mgmt_hdr *req_hdr,
 			  bool *handler_found)
 {
 	const struct mgmt_handler *handler;
@@ -160,14 +160,14 @@ smp_handle_single_payload(struct mgmt_ctxt *cbuf, const struct mgmt_hdr *req_hdr
 
 	if (handler_fn) {
 		*handler_found = true;
-		zcbor_map_start_encode(cbuf->cnbe->zs, CONFIG_MGMT_MAX_MAIN_MAP_ENTRIES);
+		zcbor_map_start_encode(cbuf->writer->zs, CONFIG_MGMT_MAX_MAIN_MAP_ENTRIES);
 		mgmt_evt(MGMT_EVT_OP_CMD_RECV, req_hdr->nh_group, req_hdr->nh_id, NULL);
 
 		MGMT_CTXT_SET_RC_RSN(cbuf, NULL);
 		rc = handler_fn(cbuf);
 
 		/* End response payload. */
-		if (!zcbor_map_end_encode(cbuf->cnbe->zs, CONFIG_MGMT_MAX_MAIN_MAP_ENTRIES) &&
+		if (!zcbor_map_end_encode(cbuf->writer->zs, CONFIG_MGMT_MAX_MAIN_MAP_ENTRIES) &&
 		    rc == 0) {
 			rc = MGMT_ERR_EMSGSIZE;
 		}
@@ -193,20 +193,15 @@ static int
 smp_handle_single_req(struct smp_streamer *streamer, const struct mgmt_hdr *req_hdr,
 		      bool *handler_found, const char **rsn)
 {
-	struct mgmt_ctxt cbuf;
 	struct mgmt_hdr rsp_hdr;
 	struct cbor_nb_writer *nbw = streamer->writer;
-	struct cbor_nb_reader *nbr = streamer->reader;
 	zcbor_state_t *zsp = nbw->zs;
 	int rc;
 
-	cbuf.cnbe = nbw;
-	cbuf.cnbd = nbr;
-
 	/* Process the request and write the response payload. */
-	rc = smp_handle_single_payload(&cbuf, req_hdr, handler_found);
+	rc = smp_handle_single_payload(streamer, req_hdr, handler_found);
 	if (rc != 0) {
-		*rsn = MGMT_CTXT_RC_RSN(&cbuf);
+		*rsn = MGMT_CTXT_RC_RSN(cbuf);
 		return rc;
 	}
 


### PR DESCRIPTION
    This demonstrates asynchronous notification support from the SMP
    server, using os_mgmt as a base whereby after receiving a command,
    a message is relayed back after 3 seconds.

Uses https://github.com/zephyrproject-rtos/zephyr/pull/51856 to access streamer object
Proof of concept for https://github.com/zephyrproject-rtos/zephyr/issues/50428

UART demo:
```
out:  \x06\tAAwCAAACAAABCr//H98=\n

in:  \x06\tABQDAAAKAAABCr9mc3RhdHVzAP8Eaw==\n
    Op:  3
    Flags:  0
    Length:  10
    Group:  0
    Sequence:  1
    ID:  10
        Text:  "status"
        number:  0

in:  \x06\tABNoZWxsbywgdGVzdCBkYXRhqKzC\n
Decoded:  "hello, test data\xA8"
```