### PR TITLE
tests: lib: cmsis_dsp testcases with min ram for execution

### DIFF
--- a/tests/lib/cmsis_dsp/complexmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/complexmath/testcase.yaml
@@ -8,7 +8,7 @@ tests:
       - native_posix
     tags: cmsis_dsp
     min_flash: 128
-    min_ram: 64
+    min_ram: 144
   libraries.cmsis_dsp.complexmath.fpu:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
@@ -18,4 +18,4 @@ tests:
     extra_configs:
       - CONFIG_FPU=y
     min_flash: 128
-    min_ram: 64
+    min_ram: 144

--- a/tests/lib/cmsis_dsp/matrix/testcase.yaml
+++ b/tests/lib/cmsis_dsp/matrix/testcase.yaml
@@ -189,7 +189,7 @@ tests:
     tags: cmsis_dsp
     platform_exclude: frdm_kw41z
     min_flash: 128
-    min_ram: 128
+    min_ram: 144
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_BINARY_Q15=y
@@ -201,7 +201,7 @@ tests:
     tags: cmsis_dsp fpu
     platform_exclude: frdm_kw41z
     min_flash: 128
-    min_ram: 128
+    min_ram: 144
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_BINARY_Q15=y

--- a/tests/lib/cmsis_dsp/support/testcase.yaml
+++ b/tests/lib/cmsis_dsp/support/testcase.yaml
@@ -8,7 +8,7 @@ tests:
       - native_posix
     tags: cmsis_dsp
     min_flash: 128
-    min_ram: 64
+    min_ram: 128
   libraries.cmsis_dsp.support.fpu:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
@@ -16,6 +16,6 @@ tests:
       - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
-    min_ram: 64
+    min_ram: 128
     extra_configs:
       - CONFIG_FPU=y

--- a/tests/lib/cmsis_dsp/transform/testcase.yaml
+++ b/tests/lib/cmsis_dsp/transform/testcase.yaml
@@ -207,7 +207,7 @@ tests:
       - native_posix
     tags: cmsis_dsp
     min_flash: 1024
-    min_ram: 96
+    min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CF64=y
@@ -217,7 +217,7 @@ tests:
       - mps2_an521_remote
     tags: cmsis_dsp fpu
     min_flash: 1024
-    min_ram: 96
+    min_ram: 128
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CF64=y


### PR DESCRIPTION
Since the new  CONFIG_ZTEST_NEW_API the ram fr execution must be adjusted (higher)
to avoid buffer allocation failures with some target boards.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/51138

Completes the https://github.com/zephyrproject-rtos/zephyr/pull/50804

Signed-off-by: Francois Ramu <francois.ramu@st.com>