### PR TITLE
arm64: Add comment that `arch_curr_cpu` and `get_cpu` must be synced

### DIFF
--- a/arch/arm64/core/macro_priv.inc
+++ b/arch/arm64/core/macro_priv.inc
@@ -23,6 +23,7 @@
 
 /*
  * Get CPU pointer
+ * Note: keep in sync with `arch_curr_cpu` in include/zephyr/arch/arm64/arch_inlines.h
  */
 
 .macro get_cpu xreg0

--- a/include/zephyr/arch/arm64/arch_inlines.h
+++ b/include/zephyr/arch/arm64/arch_inlines.h
@@ -14,6 +14,7 @@
 #include <zephyr/arch/arm64/tpidrro_el0.h>
 #include <zephyr/sys/__assert.h>
 
+/* Note: keep in sync with `get_cpu` in arch/arm64/core/macro_priv.inc */
 static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {
 	return (_cpu_t *)(read_tpidrro_el0() & TPIDRROEL0_CURR_CPU);


### PR DESCRIPTION
The is code duplication as one is in C, and the other is an assembly macro. As there is no easy way to find out about this duplication, adding a comment seems the best way to go.
