### PR TITLE
Bluetooth: Audio: Fix unicast client ep reset

### DIFF
--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -1600,7 +1600,7 @@ static void unicast_client_reset(struct bt_audio_ep *ep)
 
 	bt_audio_stream_reset(ep->stream);
 
-	(void)memset(ep, 0, offsetof(struct bt_audio_ep, subscribe));
+	(void)memset(ep, 0, sizeof(*ep));
 }
 
 static void unicast_client_ep_reset(struct bt_conn *conn)


### PR DESCRIPTION
The endpoint was only partially memset on disconnect, which left the handles untouched. This meant that the reset endpoint would still get returned by
unicast_client_ep_find.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

This change is necessary due to this change: https://github.com/zephyrproject-rtos/zephyr/commit/2241efedfb7b1720422be3d5d5c96d2ea147ee1d#diff-843656b66e3073bddaa09adc334ac5abc2dbb2cb12aa7735b20c2aa922a99eb2R56-R66 which moved the handles, but there is there is no reason not to memset the entire endpoint. 