### PR TITLE
cmake: emu: qemu: do not enable CAN bus on NIOS2 and LEON3

### DIFF
--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -269,7 +269,7 @@ elseif(QEMU_NET_STACK)
   endif()
 endif(QEMU_PIPE_STACK)
 
-if(CONFIG_CAN)
+if(CONFIG_CAN AND NOT (CONFIG_NIOS2 OR CONFIG_SOC_LEON3))
   # Add CAN bus 0
   list(APPEND QEMU_FLAGS -object can-bus,id=canbus0)
 


### PR DESCRIPTION
QEMU for NIOS2 and LEON3 do not provide support for the "can-bus" object type. Skip configuring CAN bus command line arguments for these.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>