### PR TITLE
boards: x86: qemu: fix CAN devicetree node address

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -51,7 +51,7 @@
 		compatible = "intel,pcie";
 		ranges;
 
-		can0: can@1800 {
+		can0: can@1000 {
 			compatible = "kvaser,pcican";
 			status = "okay";
 			reg = <PCIE_BDF(0,2,0) PCIE_ID(0x10e8,0x8406)>;


### PR DESCRIPTION
Fix the CAN devicetree node address to match the PCIe BDF.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>