### PR TITLE
sparse: fix sparse warnings found in sof compilation

### DIFF
--- a/drivers/console/winstream_console.c
+++ b/drivers/console/winstream_console.c
@@ -55,7 +55,8 @@ static int winstream_console_init(const struct device *d)
 		return -ENODEV;
 	}
 	const struct mem_win_config *config = dev->config;
-	void *buf = arch_xtensa_uncached_ptr((void *)config->mem_base);
+	void *buf =
+		arch_xtensa_uncached_ptr((__sparse_force void __sparse_cache *)config->mem_base);
 
 	winstream = sys_winstream_init(buf, config->size);
 

--- a/soc/xtensa/intel_adsp/cavs/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/cavs/multiprocessing.c
@@ -73,7 +73,7 @@ void soc_start_core(int cpu_num)
 	 * such that the standard system bootstrap out of IMR can
 	 * place it there.  But this is fine for now.
 	 */
-	void **lpsram = z_soc_uncached_ptr((void *)LP_SRAM_BASE);
+	void **lpsram = z_soc_uncached_ptr((__sparse_force void __sparse_cache *)LP_SRAM_BASE);
 	uint8_t tramp[] = {
 		0x06, 0x01, 0x00, /* J <PC+8>  (jump to L32R) */
 		0,                /* (padding to align entry_addr) */

--- a/soc/xtensa/intel_adsp/common/boot_complete.c
+++ b/soc/xtensa/intel_adsp/common/boot_complete.c
@@ -22,7 +22,7 @@ int boot_complete(const struct device *d)
 	}
 	config = dev->config;
 
-	win = z_soc_uncached_ptr((void *)config->mem_base);
+	win = z_soc_uncached_ptr((__sparse_force void __sparse_cache *)config->mem_base);
 	/* Software protocol: "firmware entered" has the value 5 */
 	win[0] = 5;
 


### PR DESCRIPTION
Add proper sparse_force cast to assigments into sparse_cache pointers.

Signed-off-by: Jaska Uimonen <jaska.uimonen@linux.intel.com>