### PR TITLE
soc: intel_adsp: ipc: Do not send message until previous one is acked

### DIFF
--- a/soc/xtensa/intel_adsp/common/include/intel_adsp_ipc.h
+++ b/soc/xtensa/intel_adsp/common/include/intel_adsp_ipc.h
@@ -69,6 +69,7 @@ struct intel_adsp_ipc_data {
 	void *handler_arg;
 	intel_adsp_ipc_done_t done_notify;
 	void *done_arg;
+	bool tx_ack_pending;
 };
 
 void z_intel_adsp_ipc_isr(const void *devarg);


### PR DESCRIPTION
Fix a bug where an IPC message is sent while the peer/host ack for the previous message has not yet been processed. There is existing logic to check 'idr' INTEL_ADSP_IPC_BUSY bit, but this leaves the following race:

 - DSP: msg A sent by DSP to host
 - HOST: IRQ, msg A acked, host sets DONE bit -> ADSP_IPC_BUSY cleared
 - DSP: msg B sent by DSP to host, IPC_BUSY is clear so proceeding to send -> e.g. 'devdata->sem' is reset --> BUG!
 - DSP: IRQ, msg A done -> e.g. call to 'sem_give(&devdata->sem)' which is wrong as the semaphore was just reset in previous step for msg B

Add additional state to track handling of the acks. This allows to postpone sending message B (in above example), until message A is fully processed.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>