### PR TITLE
drivers: ieee802154_nrf5: Removed csl placeholder window

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -62,9 +62,7 @@ static struct nrf5_802154_data nrf5_data;
 #define FRAME_PENDING_BYTE 1
 #define FRAME_PENDING_BIT (1 << 4)
 
-#define DRX_SLOT_PH 0 /* Placeholder delayed reception window ID */
-#define DRX_SLOT_RX 1 /* Actual delayed reception window ID */
-#define PH_DURATION 10 /* Duration of the placeholder window, in microseconds */
+#define DRX_SLOT_RX 0 /* Delayed reception window ID */
 
 #if defined(CONFIG_IEEE802154_NRF5_UICR_EUI64_ENABLE)
 #if defined(CONFIG_SOC_NRF5340_CPUAPP)
@@ -836,17 +834,13 @@ static void nrf5_receive_at(uint32_t start, uint32_t duration, uint8_t channel, 
 
 static void nrf5_config_csl_period(uint16_t period)
 {
-	nrf_802154_receive_at_cancel(DRX_SLOT_PH);
-	nrf_802154_receive_at_cancel(DRX_SLOT_RX);
-
 	nrf_802154_csl_writer_period_set(period);
 
-	/* A placeholder reception window is scheduled so that the radio driver is able to inject
-	 * the proper CSL Phase in the transmitted CSL Information Elements.
+	/* Update the CSL anchor time to match the nearest requested CSL window, so that
+	 * the proper CSL Phase in the transmitted CSL Information Elements can be injected.
 	 */
 	if (period > 0) {
-		nrf5_receive_at(nrf5_data.csl_rx_time, PH_DURATION, nrf_802154_channel_get(),
-				DRX_SLOT_PH);
+		nrf_802154_csl_writer_anchor_time_set(nrf5_data.csl_rx_time);
 	}
 }
 
@@ -854,9 +848,16 @@ static void nrf5_schedule_rx(uint8_t channel, uint32_t start, uint32_t duration)
 {
 	nrf5_receive_at(start, duration, channel, DRX_SLOT_RX);
 
-	/* The placeholder reception window is rescheduled for the next period */
-	nrf_802154_receive_at_cancel(DRX_SLOT_PH);
-	nrf5_receive_at(nrf5_data.csl_rx_time, PH_DURATION, channel, DRX_SLOT_PH);
+	/* Update the CSL anchor time to match the nearest requested CSL window, so that
+	 * the proper CSL Phase in the transmitted CSL Information Elements can be injected.
+     *
+	 * Note that even if the nrf5_schedule_rx function is not called in time (for example
+	 * due to the call being blocked by higher priority threads) and the delayed reception window
+	 * is not scheduled, the CSL phase will still be calculated as if the following reception windows
+	 * were at times anchor_time + n * csl_period. The previously set anchor_time will be used
+	 * for calculations.
+	 */
+	nrf_802154_csl_writer_anchor_time_set(nrf5_data.csl_rx_time);
 }
 #endif /* CONFIG_IEEE802154_CSL_ENDPOINT */
 
@@ -1022,7 +1023,7 @@ void nrf_802154_receive_failed(nrf_802154_rx_error_t error, uint32_t id)
 	const struct device *dev = net_if_get_device(nrf5_data.iface);
 
 #if defined(CONFIG_IEEE802154_CSL_ENDPOINT)
-	if ((id == DRX_SLOT_PH) || (id == DRX_SLOT_RX)) {
+	if (id == DRX_SLOT_RX) {
 		__ASSERT_NO_MSG(nrf5_data.event_handler);
 		nrf5_data.event_handler(dev, IEEE802154_EVENT_SLEEP, NULL);
 		if (error == NRF_802154_RX_ERROR_DELAYED_TIMEOUT) {


### PR DESCRIPTION
After introducing new CSL phase calculation method it was used in ieee802154_nrf5.c and the placeholder windows could be deleted.