### PR TITLE
west: build: add build.gdb option

### DIFF
--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -386,6 +386,15 @@ You can :ref:`configure <west-config-cmd>` ``west build`` using these options.
            to the source directory. If the current working directory is inside
            the source directory this will be set to an empty string.
          - ``app``: The name of the source directory.
+   * - ``build.gdb``
+     - String. If present and nonempty, this is the path to the GDB executable
+       that will be used by default if you use commands like ``west debug`` and
+       ``west attach`` on the generated build directory. For example, you can
+       set this to the path to the ``arm-zephyr-eabi-gdb-py`` executable in the
+       :ref:`toolchain_zephyr_sdk` to debug Arm Cortex-M applications with
+       Python available from within GDB by default. Be careful with this option
+       if you switch architectures often, as GDB binaries for different target
+       architectures than the board you are currently debugging will not work.
    * - ``build.generator``
      - String, default ``Ninja``. The `CMake Generator`_ to use to create a
        build system. (To set a generator for a single build, see the

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -458,6 +458,11 @@ class Build(Forceable):
             cmake_opts = ['-DBOARD={}'.format(board)]
         else:
             cmake_opts = []
+
+        gdb = config_get('gdb', None)
+        if gdb:
+            cmake_opts.append(f'-DCMAKE_GDB={gdb}')
+
         if self.args.cmake_opts:
             cmake_opts.extend(self.args.cmake_opts)
 


### PR DESCRIPTION
This provides a way to set the default GDB which will be used for debugging within a given build directory. The main use case is to make sure GDB with python is used by default.

You can still override this on a build-specific basis using:

```
  west build ... -- -DCMAKE_GDB=/some/other/gdb
  west debug
```
