### PR TITLE
Split img_mgmt.h

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/image_info.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/image_info.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018-2021 mcumgr authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef H_IMG_MGMT_INFO_
+#define H_IMG_MGMT_INFO_
+
+#include <inttypes.h>
+#include "image.h"
+#include "mgmt/mgmt.h"
+#include <zcbor_common.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* 255.255.65535.4294967295\0 */
+#define IMG_MGMT_VER_MAX_STR_LEN	(sizeof("255.255.65535.4294967295"))
+
+/*
+ * @brief Read info of an image give the slot number
+ *
+ * @param image_slot	 Image slot to read info from
+ * @param image_version  Image version to be filled up
+ * @param hash		   Ptr to the read image hash
+ * @param flags		  Ptr to flags filled up from the image
+ */
+int img_mgmt_read_info(int image_slot, struct image_version *ver, uint8_t *hash, uint32_t *flags);
+
+/**
+ * @brief Get the current running image version
+ *
+ * @param image_version Given image version
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int img_mgmt_my_version(struct image_version *ver);
+
+/**
+ * @brief Get image version in string from image_version
+ *
+ * @param image_version Structure filled with image version
+ *					  information
+ * @param dst		   Destination string created from the given
+ *					  in image version
+ *
+ * @return Non-negative on success, negative value on error.
+ */
+int img_mgmt_ver_str(const struct image_version *ver, char *dst);
+
+/**
+ * Compares two image version numbers in a semver-compatible way.
+ *
+ * @param a	The first version to compare.
+ * @param b	The second version to compare.
+ *
+ * @return	-1 if a < b
+ * @return	0 if a = b
+ * @return	1 if a > b
+ */
+int img_mgmt_vercmp(const struct image_version *a, const struct image_version *b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_IMG_MGMT_INFO_ */

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/image_state.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/image_state.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2018-2021 mcumgr authors
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef H_IMG_MGMT_IMAGE_STATE__
+#define H_IMG_MGMT_IMAGE_STATE_
+
+#include <inttypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Image state flags
+ */
+#define IMG_MGMT_STATE_F_PENDING	0x01
+#define IMG_MGMT_STATE_F_CONFIRMED	0x02
+#define IMG_MGMT_STATE_F_ACTIVE		0x04
+#define IMG_MGMT_STATE_F_PERMANENT	0x08
+
+/*
+ * Swap Types for image management state machine
+ */
+#define IMG_MGMT_SWAP_TYPE_NONE		0
+#define IMG_MGMT_SWAP_TYPE_TEST		1
+#define IMG_MGMT_SWAP_TYPE_PERM		2
+#define IMG_MGMT_SWAP_TYPE_REVERT	3
+#define IMG_MGMT_SWAP_TYPE_UNKNOWN	255
+
+/**
+ * @brief Check if the image slot is in use
+ *
+ * @param slot Slot to check if its in use
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int img_mgmt_slot_in_use(int slot);
+
+/**
+ * @brief Check if the DFU status is pending
+ *
+ * @return 1 if there's pending DFU otherwise 0.
+ */
+int img_mgmt_state_any_pending(void);
+
+/**
+ * @brief Collects information about the specified image slot
+ *
+ * @param query_slot Slot to read state flags from
+ *
+ * @return return the state flags
+ */
+uint8_t img_mgmt_state_flags(int query_slot);
+
+/**
+ * @brief Sets the pending flag for the specified image slot.  That is, the system
+ * will swap to the specified image on the next reboot.  If the permanent
+ * argument is specified, the system doesn't require a confirm after the swap
+ * occurs.
+ *
+ * @param slot	   Image slot to set pending
+ * @param permanent  If set no confirm is required after image swap
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int img_mgmt_state_set_pending(int slot, int permanent);
+
+/**
+ * Confirms the current image state.  Prevents a fallback from occurring on the
+ * next reboot if the active image is currently being tested.
+ *
+ * @return 0 on success, non -zero on failure
+ */
+int img_mgmt_state_confirm(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_IMG_MGMT_IMAGE_STATE_ */

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -13,18 +13,12 @@
 #include "mgmt/mgmt.h"
 #include <zcbor_common.h>
 
-struct image_version;
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define IMG_MGMT_HASH_STR	48
 #define IMG_MGMT_HASH_LEN	32
 #define IMG_MGMT_DATA_SHA_LEN	32 /* SHA256 */
-
-/* 255.255.65535.4294967295\0 */
-#define IMG_MGMT_VER_MAX_STR_LEN	(sizeof("255.255.65535.4294967295"))
 
 /**
  * Command IDs for image management group.
@@ -95,37 +89,6 @@ void img_mgmt_register_group(void);
  */
 void img_mgmt_unregister_group(void);
 
-/*
- * @brief Read info of an image give the slot number
- *
- * @param image_slot	 Image slot to read info from
- * @param image_version  Image version to be filled up
- * @param hash		   Ptr to the read image hash
- * @param flags		  Ptr to flags filled up from the image
- */
-int img_mgmt_read_info(int image_slot, struct image_version *ver, uint8_t *hash, uint32_t *flags);
-
-/**
- * @brief Get the current running image version
- *
- * @param image_version Given image version
- *
- * @return 0 on success, non-zero on failure
- */
-int img_mgmt_my_version(struct image_version *ver);
-
-/**
- * @brief Get image version in string from image_version
- *
- * @param image_version Structure filled with image version
- *					  information
- * @param dst		   Destination string created from the given
- *					  in image version
- *
- * @return Non-negative on success, negative value on error.
- */
-int img_mgmt_ver_str(const struct image_version *ver, char *dst);
-
 /** @brief Generic callback function for events */
 typedef void (*img_mgmt_dfu_cb)(void);
 
@@ -172,18 +135,6 @@ void img_mgmt_dfu_stopped(void);
 void img_mgmt_dfu_started(void);
 void img_mgmt_dfu_pending(void);
 void img_mgmt_dfu_confirmed(void);
-
-/**
- * Compares two image version numbers in a semver-compatible way.
- *
- * @param a	The first version to compare.
- * @param b	The second version to compare.
- *
- * @return	-1 if a < b
- * @return	0 if a = b
- * @return	1 if a > b
- */
-int img_mgmt_vercmp(const struct image_version *a, const struct image_version *b);
 
 #ifdef CONFIG_IMG_MGMT_VERBOSE_ERR
 #define IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, rsn) ((action)->rc_rsn = (rsn))

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -60,9 +60,6 @@ extern "C" {
 #define IMG_MGMT_ID_UPLOAD_STATUS_ONGOING	1
 #define IMG_MGMT_ID_UPLOAD_STATUS_COMPLETE	2
 
-extern int boot_current_slot;
-extern struct img_mgmt_state g_img_mgmt_state;
-
 /** Represents an individual upload request. */
 struct img_mgmt_upload_req {
 	uint32_t image;	/* 0 by default */

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -23,25 +23,8 @@ extern "C" {
 #define IMG_MGMT_HASH_LEN	32
 #define IMG_MGMT_DATA_SHA_LEN	32 /* SHA256 */
 
-/*
- * Image state flags
- */
-#define IMG_MGMT_STATE_F_PENDING	0x01
-#define IMG_MGMT_STATE_F_CONFIRMED	0x02
-#define IMG_MGMT_STATE_F_ACTIVE		0x04
-#define IMG_MGMT_STATE_F_PERMANENT	0x08
-
 /* 255.255.65535.4294967295\0 */
 #define IMG_MGMT_VER_MAX_STR_LEN	(sizeof("255.255.65535.4294967295"))
-
-/*
- * Swap Types for image management state machine
- */
-#define IMG_MGMT_SWAP_TYPE_NONE		0
-#define IMG_MGMT_SWAP_TYPE_TEST		1
-#define IMG_MGMT_SWAP_TYPE_PERM		2
-#define IMG_MGMT_SWAP_TYPE_REVERT	3
-#define IMG_MGMT_SWAP_TYPE_UNKNOWN	255
 
 /**
  * Command IDs for image management group.
@@ -82,6 +65,7 @@ struct img_mgmt_state {
 	uint8_t data_sha_len;
 	uint8_t data_sha[IMG_MGMT_DATA_SHA_LEN];
 } __packed;
+
 
 /** Describes what to do during processing of an upload request. */
 struct img_mgmt_upload_action {
@@ -141,52 +125,6 @@ int img_mgmt_my_version(struct image_version *ver);
  * @return Non-negative on success, negative value on error.
  */
 int img_mgmt_ver_str(const struct image_version *ver, char *dst);
-
-/**
- * @brief Check if the image slot is in use
- *
- * @param slot Slot to check if its in use
- *
- * @return 0 on success, non-zero on failure
- */
-int img_mgmt_slot_in_use(int slot);
-
-/**
- * @brief Check if the DFU status is pending
- *
- * @return 1 if there's pending DFU otherwise 0.
- */
-int img_mgmt_state_any_pending(void);
-
-/**
- * @brief Collects information about the specified image slot
- *
- * @param query_slot Slot to read state flags from
- *
- * @return return the state flags
- */
-uint8_t img_mgmt_state_flags(int query_slot);
-
-/**
- * @brief Sets the pending flag for the specified image slot.  That is, the system
- * will swap to the specified image on the next reboot.  If the permanent
- * argument is specified, the system doesn't require a confirm after the swap
- * occurs.
- *
- * @param slot	   Image slot to set pending
- * @param permanent  If set no confirm is required after image swap
- *
- * @return 0 on success, non-zero on failure
- */
-int img_mgmt_state_set_pending(int slot, int permanent);
-
-/**
- * Confirms the current image state.  Prevents a fallback from occurring on the
- * next reboot if the active image is currently being tested.
- *
- * @return 0 on success, non -zero on failure
- */
-int img_mgmt_state_confirm(void);
 
 /** @brief Generic callback function for events */
 typedef void (*img_mgmt_dfu_cb)(void);

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -19,6 +19,7 @@
 
 #include "img_mgmt/image.h"
 #include "img_mgmt/img_mgmt.h"
+#include "img_mgmt/image_state.h"
 #include "img_mgmt/img_mgmt_config.h"
 #include "img_mgmt_priv.h"
 

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_priv.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_priv.c
@@ -17,8 +17,8 @@ LOG_MODULE_REGISTER(mcumgr_img_mgmt, CONFIG_MCUMGR_IMG_MGMT_LOG_LEVEL);
 #include <zephyr/dfu/mcuboot.h>
 #include <zephyr/dfu/flash_img.h>
 #include <mgmt/mgmt.h>
-#include <img_mgmt/img_mgmt.h>
 #include <img_mgmt/image.h>
+#include <img_mgmt/image_state.h>
 #include "img_mgmt_priv.h"
 
 #define SLOT0_PARTITION		slot0_partition

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_priv.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_priv.h
@@ -16,6 +16,8 @@
 extern "C" {
 #endif
 
+extern struct img_mgmt_state g_img_mgmt_state;
+
 /**
  * @brief Ensures the spare slot (slot 1) is fully erased.
  *

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
@@ -10,8 +10,9 @@
 
 #include <string.h>
 #include "img_mgmt/img_mgmt.h"
-#include "img_mgmt/image_state.h"
 #include "img_mgmt/image.h"
+#include "img_mgmt/image_state.h"
+#include "img_mgmt/image_info.h"
 #include "img_mgmt_priv.h"
 #include "img_mgmt/img_mgmt_impl.h"
 #include <zcbor_common.h>

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
@@ -10,6 +10,7 @@
 
 #include <string.h>
 #include "img_mgmt/img_mgmt.h"
+#include "img_mgmt/image_state.h"
 #include "img_mgmt/image.h"
 #include "img_mgmt_priv.h"
 #include "img_mgmt/img_mgmt_impl.h"

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_util.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_util.c
@@ -8,7 +8,7 @@
 #include <string.h>
 
 #include "img_mgmt/image.h"
-#include "img_mgmt/img_mgmt.h"
+#include "img_mgmt/image_info.h"
 
 int
 img_mgmt_ver_str(const struct image_version *ver, char *dst)


### PR DESCRIPTION
The PR splits img_mgmt.h to
 * img_mgmt.h -- general image management functions, image management registration callbacks and required types;
 * image_info.h -- image information API (version processing, hash, etc);
 * image_state.h -- bootable state of image.

Callbacks should get their own header but they are in progress in other PR, so not touching.

DNM till the https://github.com/zephyrproject-rtos/zephyr/pull/50936 gets in.

