### PR TITLE
cmake: linker: lld: add missing -no-pie flag

### DIFF
--- a/cmake/linker/lld/target_base.cmake
+++ b/cmake/linker/lld/target_base.cmake
@@ -11,6 +11,7 @@ macro(toolchain_ld_base)
   # TOOLCHAIN_LD_FLAGS comes from compiler/clang/target.cmake
   # LINKERFLAGPREFIX comes from linker/lld/target.cmake
   zephyr_ld_options(
+    -no-pie
     ${TOOLCHAIN_LD_FLAGS}
   )
 


### PR DESCRIPTION
See also https://github.com/zephyrproject-rtos/zephyr/pull/38903

This is required when building tests for native_posix on ubuntu 22.04 using clang-14 from the normal deb repository.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>