### PR TITLE
boards: arm: nxp: Include board flash and device configuration data from board CMakeLists

### DIFF
--- a/boards/arm/mimxrt1010_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1010_evk/CMakeLists.txt
@@ -1,0 +1,26 @@
+#
+# Copyright 2022 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
+if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
+  zephyr_library()
+  if(NOT DEFINED CONFIG_BOARD_MIMXRT1010_EVK)
+    message(WARNING "It appears you are using the board definition for "
+     "the MIMXRT1010-EVK, but targeting a custom board. You may need to "
+     "update your flash configuration data blocks")
+  endif()
+  if(CONFIG_BOOT_FLEXSPI_NOR)
+    # Include flash configuration block for RT1010 EVK from NXP's HAL.
+    # This configuration block may need modification if another flash chip is
+    # used on your custom board. See NXP AN12238 for more information.
+    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
+    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
+    set(RT1010_BOARD_DIR
+      "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk/boards/evkmimxrt1010")
+    zephyr_library_sources(${RT1010_BOARD_DIR}/xip/evkmimxrt1010_flexspi_nor_config.c)
+    zephyr_library_include_directories(${RT1010_BOARD_DIR}/xip)
+  endif()
+endif()

--- a/boards/arm/mimxrt1015_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1015_evk/CMakeLists.txt
@@ -1,0 +1,26 @@
+#
+# Copyright 2022 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
+if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
+  zephyr_library()
+  if(NOT DEFINED CONFIG_BOARD_MIMXRT1015_EVK)
+    message(WARNING "It appears you are using the board definition for "
+     "the MIMXRT1015-EVK, but targeting a custom board. You may need to "
+     "update your flash configuration data blocks")
+  endif()
+  if(CONFIG_BOOT_FLEXSPI_NOR)
+    # Include flash configuration block for RT1015 EVK from NXP's HAL.
+    # This configuration block may need modification if another flash chip is
+    # used on your custom board. See NXP AN12238 for more information.
+    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
+    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
+    set(RT1015_BOARD_DIR
+      "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk/boards/evkmimxrt1015")
+    zephyr_library_sources(${RT1015_BOARD_DIR}/xip/evkmimxrt1015_flexspi_nor_config.c)
+    zephyr_library_include_directories(${RT1015_BOARD_DIR}/xip)
+  endif()
+endif()

--- a/boards/arm/mimxrt1020_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1020_evk/CMakeLists.txt
@@ -1,38 +1,33 @@
 #
-# Copyright 2018-2022 NXP
+# Copyright 2022 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if (CONFIG_DISPLAY)
-message(WARNING "
-CONFIG_DISPLAY: Running this firmware on a board without a display may damage the board
-")
-endif()
 
 if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
   zephyr_library()
-  if(NOT DEFINED CONFIG_BOARD_MIMXRT1064_EVK)
+  if(NOT DEFINED CONFIG_BOARD_MIMXRT1020_EVK)
     message(WARNING "It appears you are using the board definition for "
-     "the MIMXRT1064-EVK, but targeting a custom board. You may need to "
+     "the MIMXRT1020-EVK, but targeting a custom board. You may need to "
      "update your flash configuration or device configuration data blocks")
   endif()
-  set(RT1064_BOARD_DIR
-    "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk/boards/evkmimxrt1064")
+  set(RT1020_BOARD_DIR
+    "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk/boards/evkmimxrt1020")
   if(CONFIG_BOOT_FLEXSPI_NOR)
-    # Include flash configuration block for RT1064 EVK from NXP's HAL.
+    # Include flash configuration block for RT1020 EVK from NXP's HAL.
     # This configuration block may need modification if another flash chip is
     # used on your custom board. See NXP AN12238 for more information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
-    zephyr_library_sources(${RT1064_BOARD_DIR}/xip/evkmimxrt1064_flexspi_nor_config.c)
-    zephyr_library_include_directories(${RT1064_BOARD_DIR}/xip)
+    zephyr_library_sources(${RT1020_BOARD_DIR}/xip/evkmimxrt1020_flexspi_nor_config.c)
+    zephyr_library_include_directories(${RT1020_BOARD_DIR}/xip)
   endif()
   if(CONFIG_DEVICE_CONFIGURATION_DATA)
-    # Include device configuration data block for RT1064 EVK from NXP's HAL.
+    # Include device configuration data block for RT1020 EVK from NXP's HAL.
     # This configuration block may need modification if another SDRAM chip
     # is used on your custom board.
     zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
-    zephyr_library_sources(${RT1064_BOARD_DIR}/dcd.c)
+    zephyr_library_sources(${RT1020_BOARD_DIR}/dcd.c)
   endif()
 endif()

--- a/boards/arm/mimxrt1024_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1024_evk/CMakeLists.txt
@@ -1,38 +1,33 @@
 #
-# Copyright 2018-2022 NXP
+# Copyright 2022 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if (CONFIG_DISPLAY)
-message(WARNING "
-CONFIG_DISPLAY: Running this firmware on a board without a display may damage the board
-")
-endif()
 
 if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
   zephyr_library()
-  if(NOT DEFINED CONFIG_BOARD_MIMXRT1064_EVK)
+  if(NOT DEFINED CONFIG_BOARD_MIMXRT1024_EVK)
     message(WARNING "It appears you are using the board definition for "
-     "the MIMXRT1064-EVK, but targeting a custom board. You may need to "
+     "the MIMXRT1024-EVK, but targeting a custom board. You may need to "
      "update your flash configuration or device configuration data blocks")
   endif()
-  set(RT1064_BOARD_DIR
-    "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk/boards/evkmimxrt1064")
+  set(RT1024_BOARD_DIR
+    "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk/boards/evkmimxrt1024")
   if(CONFIG_BOOT_FLEXSPI_NOR)
-    # Include flash configuration block for RT1064 EVK from NXP's HAL.
+    # Include flash configuration block for RT1024 EVK from NXP's HAL.
     # This configuration block may need modification if another flash chip is
     # used on your custom board. See NXP AN12238 for more information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
-    zephyr_library_sources(${RT1064_BOARD_DIR}/xip/evkmimxrt1064_flexspi_nor_config.c)
-    zephyr_library_include_directories(${RT1064_BOARD_DIR}/xip)
+    zephyr_library_sources(${RT1024_BOARD_DIR}/xip/evkmimxrt1024_flexspi_nor_config.c)
+    zephyr_library_include_directories(${RT1024_BOARD_DIR}/xip)
   endif()
   if(CONFIG_DEVICE_CONFIGURATION_DATA)
-    # Include device configuration data block for RT1064 EVK from NXP's HAL.
+    # Include device configuration data block for RT1024 EVK from NXP's HAL.
     # This configuration block may need modification if another SDRAM chip
     # is used on your custom board.
     zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
-    zephyr_library_sources(${RT1064_BOARD_DIR}/dcd.c)
+    zephyr_library_sources(${RT1024_BOARD_DIR}/dcd.c)
   endif()
 endif()

--- a/boards/arm/mimxrt1050_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1050_evk/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, NXP
+# Copyright 2017-2022 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -8,4 +8,37 @@ if (CONFIG_DISPLAY)
 message(WARNING "
 CONFIG_DISPLAY: Running this firmware on a board without a display may damage the board
 ")
+endif()
+
+if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
+  zephyr_library()
+  if(CONFIG_BOARD_MIMXRT1050_EVK)
+    set(FLASH_CONF evkbimxrt1050_flexspi_nor_config.c)
+  elseif(CONFIG_BOARD_MIMXRT1050_EVK_QSPI)
+    set(FLASH_CONF evkbimxrt1050_flexspi_nor_qspi_config.c)
+  else()
+    message(WARNING "It appears you are using the board definition for "
+     "the MIMXRT1050-EVK, but targeting a custom board. You may need to "
+     "update your flash configuration or device configuration data blocks")
+    # Default EVK configuration uses hyperflash, so use that file
+    set(FLASH_CONF evkbimxrt1050_flexspi_nor_config.c)
+  endif()
+  set(RT1050_BOARD_DIR
+    "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk/boards/evkbimxrt1050")
+  if(CONFIG_BOOT_FLEXSPI_NOR)
+    # Include flash configuration block for RT1050 EVK from NXP's HAL.
+    # This configuration block may need modification if another flash chip is
+    # used on your custom board. See NXP AN12238 for more information.
+    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
+    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
+    zephyr_library_sources(${RT1050_BOARD_DIR}/xip/${FLASH_CONF})
+    zephyr_library_include_directories(${RT1050_BOARD_DIR}/xip)
+  endif()
+  if(CONFIG_DEVICE_CONFIGURATION_DATA)
+    # Include device configuration data block for RT1050 EVK from NXP's HAL.
+    # This configuration block may need modification if another SDRAM chip
+    # is used on your custom board.
+    zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
+    zephyr_library_sources(${RT1050_BOARD_DIR}/dcd.c)
+  endif()
 endif()

--- a/boards/arm/mimxrt1060_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1060_evk/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, NXP
+# Copyright 2018-2022 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -8,4 +8,42 @@ if (CONFIG_DISPLAY)
 message(WARNING "
 CONFIG_DISPLAY: Running this firmware on a board without a display may damage the board
 ")
+endif()
+
+if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
+  zephyr_library()
+  if(CONFIG_BOARD_MIMXRT1060_EVK)
+    set(FLASH_CONF evkmimxrt1060_flexspi_nor_config.c)
+    set(BOARD_NAME evkmimxrt1060)
+  elseif(CONFIG_BOARD_MIMXRT1060_EVK_HYPERFLASH)
+    message(ERROR "This board appears to lack a flash configuration block")
+  elseif(CONFIG_BOARD_MIMXRT1060_EVKB)
+    set(FLASH_CONF evkbmimxrt1060_flexspi_nor_config.c)
+    set(BOARD_NAME evkbmimxrt1060)
+  else()
+    message(WARNING "It appears you are using the board definition for "
+     "the MIMXRT1060-EVK, but targeting a custom board. You may need to "
+     "update your flash configuration or device configuration data blocks")
+    # Default EVK configuration uses qspi, so use that file
+    set(FLASH_CONF evkbmimxrt1060_flexspi_nor_config.c)
+    set(BOARD_NAME evkbmimxrt1060)
+  endif()
+  set(RT1060_BOARD_DIR
+    "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk/boards/${BOARD_NAME}")
+  if(CONFIG_BOOT_FLEXSPI_NOR)
+    # Include flash configuration block for RT1060 EVK from NXP's HAL.
+    # This configuration block may need modification if another flash chip is
+    # used on your custom board. See NXP AN12238 for more information.
+    zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
+    zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
+    zephyr_library_sources(${RT1060_BOARD_DIR}/xip/${FLASH_CONF})
+    zephyr_library_include_directories(${RT1060_BOARD_DIR}/xip)
+  endif()
+  if(CONFIG_DEVICE_CONFIGURATION_DATA)
+    # Include device configuration data block for RT1060 EVK from NXP's HAL.
+    # This configuration block may need modification if another SDRAM chip
+    # is used on your custom board.
+    zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
+    zephyr_library_sources(${RT1060_BOARD_DIR}/dcd.c)
+  endif()
 endif()

--- a/boards/arm/mimxrt1060_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1060_evk/CMakeLists.txt
@@ -16,7 +16,11 @@ if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
     set(FLASH_CONF evkmimxrt1060_flexspi_nor_config.c)
     set(BOARD_NAME evkmimxrt1060)
   elseif(CONFIG_BOARD_MIMXRT1060_EVK_HYPERFLASH)
-    message(ERROR "This board appears to lack a flash configuration block")
+    # No flash configuration block exists for the RT1060 with HyperFlash in
+    # the SDK, but we can reuse the block for the RT1050 as both boards use
+    # the same HyperFlash chip
+    set(FLASH_CONF evkbimxrt1050_flexspi_nor_config.c)
+    set(BOARD_NAME evkbimxrt1050)
   elseif(CONFIG_BOARD_MIMXRT1060_EVKB)
     set(FLASH_CONF evkbmimxrt1060_flexspi_nor_config.c)
     set(BOARD_NAME evkbmimxrt1060)

--- a/boards/arm/mimxrt1060_evk/board.cmake
+++ b/boards/arm/mimxrt1060_evk/board.cmake
@@ -9,6 +9,8 @@ board_runner_args(jlink "--device=MIMXRT1062xxx6A")
 
 if ((${CONFIG_BOARD_MIMXRT1060_EVK}) OR (${CONFIG_BOARD_MIMXRT1060_EVKB}))
     board_runner_args(jlink "--loader=BankAddr=0x60000000&Loader=QSPI")
+elseif (${CONFIG_BOARD_MIMXRT1060_EVK_HYPERFLASH})
+    board_runner_args(jlink "--loader=BankAddr=0x60000000&Loader=HyperFlash")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/mimxrt1160_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1160_evk/CMakeLists.txt
@@ -1,38 +1,33 @@
 #
-# Copyright 2018-2022 NXP
+# Copyright 2022 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if (CONFIG_DISPLAY)
-message(WARNING "
-CONFIG_DISPLAY: Running this firmware on a board without a display may damage the board
-")
-endif()
-
 if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
   zephyr_library()
-  if(NOT DEFINED CONFIG_BOARD_MIMXRT1064_EVK)
+  if(NOT (DEFINED CONFIG_BOARD_MIMXRT1160_EVK_CM7)
+    OR (DEFINED CONFIG_BOARD_MIMXRT1160_EVK_CM4))
     message(WARNING "It appears you are using the board definition for "
-     "the MIMXRT1064-EVK, but targeting a custom board. You may need to "
+     "the MIMXRT1160-EVK, but targeting a custom board. You may need to "
      "update your flash configuration or device configuration data blocks")
   endif()
-  set(RT1064_BOARD_DIR
-    "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk/boards/evkmimxrt1064")
+  set(RT1160_BOARD_DIR
+    "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk/boards/evkmimxrt1160")
   if(CONFIG_BOOT_FLEXSPI_NOR)
-    # Include flash configuration block for RT1064 EVK from NXP's HAL.
+    # Include flash configuration block for RT1160 EVK from NXP's HAL.
     # This configuration block may need modification if another flash chip is
     # used on your custom board. See NXP AN12238 for more information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
-    zephyr_library_sources(${RT1064_BOARD_DIR}/xip/evkmimxrt1064_flexspi_nor_config.c)
-    zephyr_library_include_directories(${RT1064_BOARD_DIR}/xip)
+    zephyr_library_sources(${RT1160_BOARD_DIR}/xip/evkmimxrt1160_flexspi_nor_config.c)
+    zephyr_library_include_directories(${RT1160_BOARD_DIR}/xip)
   endif()
   if(CONFIG_DEVICE_CONFIGURATION_DATA)
-    # Include device configuration data block for RT1064 EVK from NXP's HAL.
+    # Include device configuration data block for RT1160 EVK from NXP's HAL.
     # This configuration block may need modification if another SDRAM chip
     # is used on your custom board.
     zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
-    zephyr_library_sources(${RT1064_BOARD_DIR}/dcd.c)
+    zephyr_library_sources(${RT1160_BOARD_DIR}/dcd.c)
   endif()
 endif()

--- a/boards/arm/mimxrt1170_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1170_evk/CMakeLists.txt
@@ -1,38 +1,33 @@
 #
-# Copyright 2018-2022 NXP
+# Copyright 2022 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if (CONFIG_DISPLAY)
-message(WARNING "
-CONFIG_DISPLAY: Running this firmware on a board without a display may damage the board
-")
-endif()
-
 if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
   zephyr_library()
-  if(NOT DEFINED CONFIG_BOARD_MIMXRT1064_EVK)
+  if(NOT (DEFINED CONFIG_BOARD_MIMXRT1170_EVK_CM7)
+    OR (DEFINED CONFIG_BOARD_MIMXRT1170_EVK_CM4))
     message(WARNING "It appears you are using the board definition for "
-     "the MIMXRT1064-EVK, but targeting a custom board. You may need to "
+     "the MIMXRT1170-EVK, but targeting a custom board. You may need to "
      "update your flash configuration or device configuration data blocks")
   endif()
-  set(RT1064_BOARD_DIR
-    "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk/boards/evkmimxrt1064")
+  set(RT1170_BOARD_DIR
+    "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk/boards/evkmimxrt1170")
   if(CONFIG_BOOT_FLEXSPI_NOR)
-    # Include flash configuration block for RT1064 EVK from NXP's HAL.
+    # Include flash configuration block for RT1170 EVK from NXP's HAL.
     # This configuration block may need modification if another flash chip is
     # used on your custom board. See NXP AN12238 for more information.
     zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
     zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
-    zephyr_library_sources(${RT1064_BOARD_DIR}/xip/evkmimxrt1064_flexspi_nor_config.c)
-    zephyr_library_include_directories(${RT1064_BOARD_DIR}/xip)
+    zephyr_library_sources(${RT1170_BOARD_DIR}/xip/evkmimxrt1170_flexspi_nor_config.c)
+    zephyr_library_include_directories(${RT1170_BOARD_DIR}/xip)
   endif()
   if(CONFIG_DEVICE_CONFIGURATION_DATA)
-    # Include device configuration data block for RT1064 EVK from NXP's HAL.
+    # Include device configuration data block for RT1170 EVK from NXP's HAL.
     # This configuration block may need modification if another SDRAM chip
     # is used on your custom board.
     zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
-    zephyr_library_sources(${RT1064_BOARD_DIR}/dcd.c)
+    zephyr_library_sources(${RT1170_BOARD_DIR}/dcd.c)
   endif()
 endif()

--- a/boards/arm/mimxrt595_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt595_evk/CMakeLists.txt
@@ -1,8 +1,25 @@
 #
-# Copyright 2022, NXP
+# Copyright 2022 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
 zephyr_library()
 zephyr_library_sources(board.c)
+
+if(CONFIG_NXP_IMX_RT5XX_BOOT_HEADER)
+  if(NOT DEFINED CONFIG_BOARD_MIMXRT595_EVK)
+    message(WARNING "It appears you are using the board definition for "
+     "the MIMXRT595-EVK, but targeting a custom board. You may need to "
+     "update your flash configuration block data")
+  endif()
+  # Include flash configuration block for R595 EVK from NXP's HAL.
+  # This configuration block may need modification if another flash chip is
+  # used on your custom board. See NXP AN13304 for more information.
+  zephyr_compile_definitions(BOOT_HEADER_ENABLE=1)
+  zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
+  set(RT595_BOARD_DIR
+    "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk/boards/evkmimxrt595")
+  zephyr_library_sources(${RT595_BOARD_DIR}/flash_config/flash_config.c)
+  zephyr_library_include_directories(${RT595_BOARD_DIR}/flash_config)
+endif()

--- a/boards/arm/mimxrt685_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt685_evk/CMakeLists.txt
@@ -1,8 +1,25 @@
 #
-# Copyright (c) 2020, NXP
+# Copyright 2020-2022 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
 zephyr_library()
 zephyr_library_sources(init.c)
+
+if(CONFIG_NXP_IMX_RT6XX_BOOT_HEADER)
+  if(NOT DEFINED CONFIG_BOARD_MIMXRT685_EVK)
+    message(WARNING "It appears you are using the board definition for "
+     "the MIMXRT685-EVK, but targeting a custom board. You may need to "
+     "update your flash configuration block data")
+  endif()
+  # Include flash configuration block for R685 EVK from NXP's HAL.
+  # This configuration block may need modification if another flash chip is
+  # used on your custom board. See NXP AN13386 for more information.
+  zephyr_compile_definitions(BOOT_HEADER_ENABLE=1)
+  zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
+  set(RT685_BOARD_DIR
+    "${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk/boards/evkmimxrt685")
+  zephyr_library_sources(${RT685_BOARD_DIR}/flash_config/flash_config.c)
+  zephyr_library_include_directories(${RT685_BOARD_DIR}/flash_config)
+endif()

--- a/boards/arm/mm_feather/CMakeLists.txt
+++ b/boards/arm/mm_feather/CMakeLists.txt
@@ -4,5 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_sources_ifdef(CONFIG_BOOT_FLEXSPI_NOR flexspi_nor_config.c)
-zephyr_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA mmfeather_sdram_ini_dcd.c)
+if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
+  zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
+  zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
+  zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
+  zephyr_sources_ifdef(CONFIG_BOOT_FLEXSPI_NOR flexspi_nor_config.c)
+  zephyr_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA mmfeather_sdram_ini_dcd.c)
+endif()

--- a/boards/arm/mm_swiftio/CMakeLists.txt
+++ b/boards/arm/mm_swiftio/CMakeLists.txt
@@ -4,5 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_sources_ifdef(CONFIG_BOOT_FLEXSPI_NOR flexspi_nor_config.c)
-zephyr_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA mmswiftio_sdram_ini_dcd.c)
+if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
+  zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
+  zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
+  zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
+  zephyr_sources_ifdef(CONFIG_BOOT_FLEXSPI_NOR flexspi_nor_config.c)
+  zephyr_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA mmswiftio_sdram_ini_dcd.c)
+endif()

--- a/boards/arm/teensy4/CMakeLists.txt
+++ b/boards/arm/teensy4/CMakeLists.txt
@@ -5,5 +5,10 @@
 #
 
 zephyr_library()
-zephyr_library_sources(flexspi_nor_config.c)
-zephyr_library_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA teensy4_sdram_ini_dcd.c)
+if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
+  zephyr_compile_definitions(XIP_BOOT_HEADER_ENABLE=1)
+  zephyr_compile_definitions(XIP_BOOT_HEADER_DCD_ENABLE=1)
+  zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
+  zephyr_library_sources(flexspi_nor_config.c)
+  zephyr_library_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA teensy4_sdram_ini_dcd.c)
+endif()

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -13,7 +13,9 @@
 #include <fsl_clock.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#ifdef CONFIG_NXP_IMX_RT_BOOT_HEADER
 #include <fsl_flexspi_nor_boot.h>
+#endif
 #include <zephyr/dt-bindings/clock/imx_ccm.h>
 #include <fsl_iomuxc.h>
 #if CONFIG_USB_DC_NXP_EHCI

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -16,7 +16,9 @@
 #include <fsl_dcdc.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#ifdef CONFIG_NXP_IMX_RT_BOOT_HEADER
 #include <fsl_flexspi_nor_boot.h>
+#endif
 #include <zephyr/dt-bindings/clock/imx_ccm_rev2.h>
 #if CONFIG_USB_DC_NXP_EHCI
 #include "usb_phy.h"

--- a/west.yml
+++ b/west.yml
@@ -88,7 +88,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 6d48547251d471ecdca9560f297296a1f33ad16c
+      revision: 53b8bc406a40e2166679cf1a3381f9eb5de96082
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
For NXP's flashless SOCs, initialization data must be linked into the build image, for use by the bootrom. This data is used to initialize boot critical devices such as external flash and SDRAM. The initialization files for these boards are stored in NXP's HAL, since they are updated with each MCUXpresso SDK release. However, these files were previously included from the HAL transparently by the board name.

This approach presents challenges for a customer bringing up a custom board using Zephyr, as it isn't immediately obvious this initialization data is present. However, in order to keep these configuration blocks synchronized with the SDK, the relevant files must be stored in the HAL for NXP EVKs.

This PR modified NXP's HAL to remove this board specific inclusion code, and instead includes the required files directly from NXP's HAL in board level CMakeLists. A warning is also printed if the board name is not defined, so that a customer will be aware of this step in board bringup.