### PR TITLE
dts: xtensa: intel: fix alh base addr for cavs25

### DIFF
--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -287,9 +287,9 @@
 		 *
 		 * https://github.com/zephyrproject-rtos/zephyr/pull/50287#discussion_r974591009
 		 */
-		alh0: alh1: alh@24400 {
+		alh0: alh1: alh@71000 {
 			compatible = "intel,alh-dai";
-			reg = <0x00024400 0x00024600>;
+			reg = <0x00071000 0x00071200>;
 
 			status = "okay";
 		};


### PR DESCRIPTION
Cavs25 alh definition is currently the same as in ace platform, which is wrong, thus fix it.

Signed-off-by: Jaska Uimonen <jaska.uimonen@linux.intel.com>