### PR TITLE
soc: atmel_sam: add support for SAM E70 q19 parts

### DIFF
--- a/dts/arm/atmel/same70q19.dtsi
+++ b/dts/arm/atmel/same70q19.dtsi
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <atmel/same70.dtsi>
+#include "dma_atmel_same70.h"
+
+/ {
+	sram0: memory@20400000 {
+		reg = <0x20400000 DT_SIZE_K(256)>;
+	};
+
+	soc {
+		flash-controller@400e0c00 {
+			flash0: flash@400000 {
+				reg = <0x00400000 DT_SIZE_K(512)>;
+			};
+		};
+	};
+};

--- a/dts/arm/atmel/same70q19b.dtsi
+++ b/dts/arm/atmel/same70q19b.dtsi
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <atmel/same70b.dtsi>
+#include "dma_atmel_same70.h"
+
+/ {
+	sram0: memory@20400000 {
+		reg = <0x20400000 DT_SIZE_K(256)>;
+	};
+
+	soc {
+		flash-controller@400e0c00 {
+			flash0: flash@400000 {
+				reg = <0x00400000 DT_SIZE_K(512)>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Add dtsi support for the ATSAME70Q19(b) parts. These contain 256k SRAM and 512k of program flash.

Signed-off-by: Perry Hung <perry@genrad.io>