### PR TITLE
modules/audio/sof: Merge INT_MIN patch from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - debug
     - name: sof
-      revision: 9b564ea205b9597d29971cac0b5dcd9312db84d4
+      revision: pull/20/head
       path: modules/audio/sof
     - name: tflite-micro
       revision: 9156d050927012da87079064db59d07f03b8baf6


### PR DESCRIPTION
This PR includes an upstream patch avoiding a conflicting use of INT_MAX

Signed-off-by: Keith Packard <keithp@keithp.com>