### PR TITLE
modules/hal/openisa: Support building without -ffreestanding

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -98,7 +98,7 @@ manifest:
       groups:
         - hal
     - name: hal_openisa
-      revision: 40d049f69c50b58ea20473bee14cf93f518bf262
+      revision: d1e61c0c654d8ca9e73d27fca3a7eb3b7881cb6a
       path: modules/hal/openisa
       groups:
         - hal


### PR DESCRIPTION
With -ffreestanding disabled, Zephyr SDK 0.15.0 generates a potentially uninitialized variable warning that appears to be a false positive. Disable the warning around the affected code.

Signed-off-by: Keith Packard <keithp@keithp.com>