### PR TITLE
DNM: arch/arc: Let toolchain select tp-regno

### DIFF
--- a/arch/arc/CMakeLists.txt
+++ b/arch/arc/CMakeLists.txt
@@ -12,13 +12,6 @@ zephyr_cc_option(-fno-delete-null-pointer-checks)
 
 zephyr_cc_option_ifdef(CONFIG_ARC_USE_UNALIGNED_MEM_ACCESS -munaligned-access)
 
-if(CONFIG_ISA_ARCV2)
-  # Instruct compiler to use register R26 as thread pointer
-  # for thread local storage.
-  # For ARCv3 the register is fixed to r30, so we don't need to specify it
-  zephyr_cc_option_ifdef(CONFIG_THREAD_LOCAL_STORAGE -mtp-regno=26)
-endif()
-
 add_subdirectory(core)
 
 if(COMPILER STREQUAL arcmwdt)


### PR DESCRIPTION
Zephyr cannot unilaterally set the -mtp-regno option as any libraries used from the toolchain must be built with the same option. This means that builds enabling thread local storage will fail when using a toolchain which does not specify a tp-regno value. That is better than potentially using toolchain library code which overwrites the selected register.

Signed-off-by: Keith Packard <keithp@keithp.com>

See also https://github.com/zephyrproject-rtos/gcc/pull/17 which makes the Zephyr SDK use register 25 by default.