### PR TITLE
toolchain: Replace GCC_VERSION and BUILD_ASSERT macros in gcc.h

### DIFF
--- a/include/zephyr/toolchain.h
+++ b/include/zephyr/toolchain.h
@@ -68,19 +68,19 @@
 #endif
 
 /**
- * @def GCC_VERSION
+ * @def TOOLCHAIN_GCC_VERSION
  * @brief GCC version in xxyyzz for xx.yy.zz. Zero if not GCC compatible.
  */
-#ifndef GCC_VERSION
-#define GCC_VERSION 0
+#ifndef TOOLCHAIN_GCC_VERSION
+#define TOOLCHAIN_GCC_VERSION 0
 #endif
 
 /**
- * @def CLANG_VERSION
+ * @def TOOLCHAIN_CLANG_VERSION
  * @brief Clang version in xxyyzz for xx.yy.zz. Zero if not Clang compatible.
  */
-#ifndef CLANG_VERSION
-#define CLANG_VERSION 0
+#ifndef TOOLCHAIN_CLANG_VERSION
+#define TOOLCHAIN_CLANG_VERSION 0
 #endif
 
 /**

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -14,19 +14,19 @@
  * Macros to abstract compiler capabilities for GCC toolchain.
  */
 
-#define GCC_VERSION \
+#define TOOLCHAIN_GCC_VERSION \
 	((__GNUC__ * 10000) + (__GNUC_MINOR__ * 100) + __GNUC_PATCHLEVEL__)
 
 /* GCC supports #pragma diagnostics since 4.6.0 */
-#if !defined(TOOLCHAIN_HAS_PRAGMA_DIAG) && (GCC_VERSION >= 40600)
+#if !defined(TOOLCHAIN_HAS_PRAGMA_DIAG) && (TOOLCHAIN_GCC_VERSION >= 40600)
 #define TOOLCHAIN_HAS_PRAGMA_DIAG 1
 #endif
 
-#if !defined(TOOLCHAIN_HAS_C_GENERIC) && (GCC_VERSION >= 40900)
+#if !defined(TOOLCHAIN_HAS_C_GENERIC) && (TOOLCHAIN_GCC_VERSION >= 40900)
 #define TOOLCHAIN_HAS_C_GENERIC 1
 #endif
 
-#if !defined(TOOLCHAIN_HAS_C_AUTO_TYPE) && (GCC_VERSION >= 40900)
+#if !defined(TOOLCHAIN_HAS_C_AUTO_TYPE) && (TOOLCHAIN_GCC_VERSION >= 40900)
 #define TOOLCHAIN_HAS_C_AUTO_TYPE 1
 #endif
 
@@ -64,6 +64,7 @@
 #endif
 
 
+#undef BUILD_ASSERT /* clear out common version */
 /* C++11 has static_assert built in */
 #if defined(__cplusplus) && (__cplusplus >= 201103L)
 #define BUILD_ASSERT(EXPR, MSG...) static_assert(EXPR, "" MSG)

--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -14,13 +14,13 @@
 #define __fallthrough __attribute__((fallthrough))
 #endif
 
-#define CLANG_VERSION \
+#define TOOLCHAIN_CLANG_VERSION \
 	((__clang_major__ * 10000) + (__clang_minor__ * 100) + \
 	  __clang_patchlevel__)
 
 #define TOOLCHAIN_HAS_PRAGMA_DIAG 1
 
-#if CLANG_VERSION >= 30800
+#if TOOLCHAIN_CLANG_VERSION >= 30800
 #define TOOLCHAIN_HAS_C_GENERIC 1
 #define TOOLCHAIN_HAS_C_AUTO_TYPE 1
 #endif


### PR DESCRIPTION
GCC_VERSION is defined in a few modules, and those headers are often included first, so we need to replace that definition with the Zephyr-specific one.

BUILD_ASSERT is also defined in include/toolchain/common.h, which might get included before gcc.h. We want to use the gcc-specific one instead of the general one.

Signed-off-by: Keith Packard <keithp@keithp.com>