### PR TITLE
ARC: MWDT: add _Generic and __auto_type types and __fallthrough attribute

### DIFF
--- a/include/zephyr/toolchain/mwdt.h
+++ b/include/zephyr/toolchain/mwdt.h
@@ -82,6 +82,9 @@
 
 #define __no_optimization __attribute__((optnone))
 
+#define TOOLCHAIN_HAS_C_GENERIC                 1
+#define TOOLCHAIN_HAS_C_AUTO_TYPE               1
+
 #include <zephyr/toolchain/gcc.h>
 
 #undef BUILD_ASSERT

--- a/include/zephyr/toolchain/mwdt.h
+++ b/include/zephyr/toolchain/mwdt.h
@@ -81,6 +81,7 @@
 
 
 #define __no_optimization __attribute__((optnone))
+#define __fallthrough     __attribute__((fallthrough))
 
 #define TOOLCHAIN_HAS_C_GENERIC                 1
 #define TOOLCHAIN_HAS_C_AUTO_TYPE               1


### PR DESCRIPTION
As we set the minimal required version of ARC MWDT to 2022.06 we can mark _Generic and __auto_type types supported and we can add __fallthrough attribute.