### PR TITLE
tfm: mbedtls: Fix build warning

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -230,7 +230,7 @@ manifest:
       groups:
         - debug
     - name: trusted-firmware-m
-      revision: cf34a76dd700235a8a29ada58a1a474d4d1166f7
+      revision: 887798f6e67203e6a77059a86edf41bb136a3c0b
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
/__w/zephyr/modules/crypto/mbedtls/library/aes.c:307:23: warning: 'RT0' defined but not used [-Wunused-const-variable=] 307 | static const uint32_t RT0[256] = { RT };
      |                       ^~~
/__w/zephyr/modules/crypto/mbedtls/library/aes.c:200:28: warning:
'RSb' defined but not used [-Wunused-const-variable=]
  200 | static const unsigned char RSb[256] =
      |                            ^~~
[360/437] Building C object

Fixes #51025

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>