### PR TITLE
logging: fixes for xtensa

### DIFF
--- a/boards/xtensa/qemu_xtensa/qemu_xtensa.yaml
+++ b/boards/xtensa/qemu_xtensa/qemu_xtensa.yaml
@@ -11,4 +11,3 @@ testing:
   ignore_tags:
      - net
      - bluetooth
-     - logging

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -94,6 +94,16 @@ struct log_msg {
 	uint8_t data[];
 };
 
+/**
+ * @cond INTERNAL_HIDDEN
+ */
+BUILD_ASSERT(sizeof(struct log_msg) % Z_LOG_MSG2_ALIGNMENT == 0,
+	     "Log msg size must aligned");
+/**
+ * @endcond
+ */
+
+
 struct log_msg_generic_hdr {
 	LOG_MSG2_GENERIC_HDR;
 };

--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -30,6 +30,15 @@
 #endif
 #endif
 
+#ifdef __xtensa__
+#define Z_PKG_HDR_EXT_XTENSA_ALIGNMENT 8
+#ifdef CONFIG_CBPRINTF_PACKAGE_HEADER_STORE_CREATION_FLAGS
+#define Z_PKG_DESC_XTENSA_PADDING 1
+#else
+#define Z_PKG_DESC_XTENSA_PADDING 0
+#endif
+#endif /* __xtensa__ */
+
 /**
  * @brief cbprintf package descriptor.
  */
@@ -50,6 +59,16 @@ struct cbprintf_package_desc {
 	/** Flags used to create the package */
 	uint32_t pkg_flags;
 #endif
+#ifdef __xtensa__
+	/*
+	 * On Xtensa, the first argument needs to be aligned to 8-byte.
+	 * With 32-bit pointers, we need another 4 bytes padding so
+	 * that whole struct cbprintf_package_hdr_ext is of multiple of
+	 * 8 bytes.
+	 */
+	uint32_t xtensa_padding[Z_PKG_DESC_XTENSA_PADDING];
+#endif
+
 } __packed;
 
 /** @brief cbprintf package header
@@ -66,19 +85,9 @@ union cbprintf_package_hdr {
 	void *raw2[2];
 #endif
 
-#ifdef CONFIG_CBPRINTF_PACKAGE_HEADER_STORE_CREATION_FLAGS
-#ifdef __xtensa__
-	/*
-	 * On Xtensa, the first argument needs to be aligned to 8-byte.
-	 * With 32-bit pointers, we need another 4 bytes padding so
-	 * that whole struct cbprintf_package_hdr_ext is of multiple of
-	 * 8 bytes.
-	 */
-	uint32_t xtensa_padding;
-#endif
-#endif
-
 } __packed;
+
+
 
 /** @brief cbprintf package header with format string pointer.
  *
@@ -96,6 +105,20 @@ struct cbprintf_package_hdr_ext {
 	 * to pointer size.
 	 */
 } __packed;
+
+
+/**
+ * @cond INTERNAL_HIDDEN
+ *
+ * Assert that the package hdr does indeed align properly.
+ */
+#ifdef __xtensa__
+BUILD_ASSERT(sizeof(struct cbprintf_package_hdr_ext) % Z_PKG_HDR_EXT_XTENSA_ALIGNMENT == 0,
+	     "Package header size on Xtensa must be aligned");
+#endif
+/**
+ * @endcond
+ */
 
 /* Z_C_GENERIC is used there */
 #include <zephyr/sys/cbprintf_internal.h>
@@ -120,6 +143,7 @@ extern "C" {
 #endif
 
 BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
+
 
 /**@defgroup CBPRINTF_PACKAGE_FLAGS Package flags.
  * @{

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -25,13 +25,13 @@ LOG_MODULE_REGISTER(test, CONFIG_SAMPLE_MODULE_LOG_LEVEL);
 #ifdef CONFIG_LOG_USE_TAGGED_ARGUMENTS
 /* The extra sizeof(int) is the end of arguments tag. */
 #define LOG_SIMPLE_MSG_LEN \
-	ROUND_UP(sizeof(struct log_msg_hdr) + \
+	ROUND_UP(sizeof(struct log_msg) + \
 		 sizeof(struct cbprintf_package_hdr_ext) + \
-		 sizeof(int), sizeof(long long))
+		 sizeof(int), CBPRINTF_PACKAGE_ALIGNMENT)
 #else
 #define LOG_SIMPLE_MSG_LEN \
-	ROUND_UP(sizeof(struct log_msg_hdr) + \
-		 sizeof(struct cbprintf_package_hdr_ext), sizeof(long long))
+	ROUND_UP(sizeof(struct log_msg) + \
+		 sizeof(struct cbprintf_package_hdr_ext), CBPRINTF_PACKAGE_ALIGNMENT)
 #endif
 
 #ifdef CONFIG_LOG_TIMESTAMP_64BIT
@@ -352,10 +352,10 @@ static size_t get_long_hexdump(void)
 		/* First message */
 		ROUND_UP(LOG_SIMPLE_MSG_LEN + 2 * sizeof(int) + STR_SIZE("test %d %d") +
 			 extra_msg_sz,
-			 sizeof(long long)) -
+			 CBPRINTF_PACKAGE_ALIGNMENT) -
 		/* Hexdump message excluding data */
 		ROUND_UP(LOG_SIMPLE_MSG_LEN + STR_SIZE("hexdump") + extra_hexdump_sz,
-			 sizeof(long long)) - 2 * sizeof(int);
+			 CBPRINTF_PACKAGE_ALIGNMENT) - CBPRINTF_PACKAGE_ALIGNMENT;
 }
 
 /*


### PR DESCRIPTION
Enables logging testing for qemu_xtensa along with the fixes needed to
correctly run the tests.

Several tests in log_api rely on being able to calculate the size of
the message in the mpsc_pbuf to know when an overflow occurs. The
size being calculated assumed a ROUND_UP size alignment to sizeof(long
long). On xtensa this is actually 16 bytes as defined by
CBPRINTF_PACKAGE_ALIGNMENT.

Changes the size calculation for SIMPLE_MSG_LEN to account for this.

The second issue was a misaligned package that would cause reading
from the incorrect memory when going to format the package with cbpprintf.

Fixes the padding used to align the package in cbprintf.h and adds a build
assert ensuring correct alignment when building against xtensa in both
cbprintf.h and log_msg.h.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>
