### PR TITLE
arch/arc: Detect arcv2 TLS register automatically

### DIFF
--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -123,8 +123,14 @@ static inline void arch_setup_callee_saved_regs(struct k_thread *thread,
 
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 #ifdef CONFIG_ISA_ARCV2
-	/* R26 is used for thread pointer for ARCv2 */
-	regs->r26 = thread->tls;
+#if __ARC_TLS_REGNO__ <= 0
+#error Compiler not configured for thread local storage
+#endif
+#define _REGNO(n) r ## n
+#define REGNO(n) _REGNO(n)
+#define TLSREG REGNO(__ARC_TLS_REGNO__)
+	/* __ARC_TLS_REGNO__ is used for thread pointer for ARCv2 */
+	regs->TLSREG = thread->tls;
 #else
 	/* R30 is used for thread pointer for ARCv3 */
 	regs->r30 = thread->tls;


### PR DESCRIPTION
The compiler defines `__ARC_TLS_REGNO__` as the number of the register used for TLS variables. Use that instead of hard-coding a specific register.

Signed-off-by: Keith Packard <keithp@keithp.com>

I couldn't see any other dependencies on the thread register number in the tree; with this, we should be able to switch which register is used.