### PR TITLE
Bluetooth: Controller: Explicitly set all bits of used radio registers

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -206,15 +206,15 @@ void radio_reset(void)
 {
 	irq_disable(RADIO_IRQn);
 
-	nrf_radio_power_set(
-		NRF_RADIO,
-		(RADIO_POWER_POWER_Disabled << RADIO_POWER_POWER_Pos) &
-			RADIO_POWER_POWER_Msk);
-	nrf_radio_power_set(
-		NRF_RADIO,
-		(RADIO_POWER_POWER_Enabled << RADIO_POWER_POWER_Pos) &
-			RADIO_POWER_POWER_Msk);
+	/* nRF SoC generic radio reset/initializations
+	 * Note: Only registers whose bits are partially modified across
+	 *       functions are assigned back the power-on reset values.
+	 *       Ignore other registers for reset which will have all bits
+	 *       explicitly assigned by functions in this file.
+	 */
+	NRF_RADIO->PCNF1 = HAL_RADIO_RESET_VALUE_PCNF1;
 
+	/* nRF SoC specific reset/initializations, if any */
 	hal_radio_reset();
 
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)
@@ -231,7 +231,50 @@ void radio_reset(void)
 
 void radio_stop(void)
 {
+	/* nRF SoC specific radio stop/cleanup, if any */
 	hal_radio_stop();
+
+	/* nRF SoC generic radio stop/cleanup
+	 * TODO: Initialize NRF_RADIO registers used by Controller to power-on
+	 *       reset values.
+	 *       This is required in case NRF_RADIO is share/used between
+	 *       Bluetooth radio events by application defined radio protocols.
+	 *       The application too shall restore the registers it uses to the
+	 *       power-on reset values once it has stopped using the radio.
+	 *
+	 *       Registers used for Bluetooth Low Energy Controller:
+	 *       - MODE
+	 *       - MODECNF0
+	 *       - TXPOWER
+	 *       - FREQUENCY
+	 *       - DATAWHITEIV
+	 *       - PCNF0
+	 *       - PCNF1
+	 *       - TXADDRESS
+	 *       - RXADDRESSES
+	 *       - PREFIX0
+	 *       - BASE0
+	 *       - PACKETPTR
+	 *       - CRCCNF
+	 *       - CRCPOLY
+	 *       - CRCINIT
+	 *       - DAB
+	 *       - DAP
+	 *       - DACNF
+	 *       - BCC
+	 *       - TIFS
+	 *       - SHORTS
+	 *
+	 *       Additional registers used for Direction Finding feature:
+	 *       - SWITCHPATTERN
+	 *       - DFEMODE
+	 *       - CTEINLINECONF
+	 *       - DFECTRL1
+	 *       - DEFCTRL2
+	 *       - CLEARPATTERN
+	 *       - PSEL.DFEGPIO[n]
+	 *       - DFEPACKET.PTR
+	 */
 }
 
 void radio_phy_set(uint8_t phy, uint8_t flags)
@@ -243,10 +286,19 @@ void radio_phy_set(uint8_t phy, uint8_t flags)
 	NRF_RADIO->MODE = (mode << RADIO_MODE_MODE_Pos) & RADIO_MODE_MODE_Msk;
 
 #if defined(CONFIG_BT_CTLR_RADIO_ENABLE_FAST)
-	NRF_RADIO->MODECNF0 |= (RADIO_MODECNF0_RU_Fast <<
+	NRF_RADIO->MODECNF0 = ((RADIO_MODECNF0_DTX_Center <<
+				RADIO_MODECNF0_DTX_Pos) &
+			       RADIO_MODECNF0_DTX_Msk) |
+			      ((RADIO_MODECNF0_RU_Fast <<
 				RADIO_MODECNF0_RU_Pos) &
-			       RADIO_MODECNF0_RU_Msk;
-#endif /* CONFIG_BT_CTLR_RADIO_ENABLE_FAST */
+			       RADIO_MODECNF0_RU_Msk);
+#else /* !CONFIG_BT_CTLR_RADIO_ENABLE_FAST */
+#if !defined(CONFIG_SOC_SERIES_NRF51X)
+	NRF_RADIO->MODECNF0 = (RADIO_MODECNF0_DTX_Center <<
+			       RADIO_MODECNF0_DTX_Pos) &
+			      RADIO_MODECNF0_DTX_Msk;
+#endif /* !CONFIG_SOC_SERIES_NRF51X */
+#endif /* !CONFIG_BT_CTLR_RADIO_ENABLE_FAST */
 }
 
 void radio_tx_power_set(int8_t power)
@@ -992,7 +1044,7 @@ uint32_t radio_filter_match_get(void)
 
 void radio_bc_configure(uint32_t n)
 {
-	nrf_radio_bcc_set(NRF_RADIO, n);
+	NRF_RADIO->BCC = n;
 	NRF_RADIO->SHORTS |= RADIO_SHORTS_ADDRESS_BCSTART_Msk;
 }
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
@@ -251,14 +251,6 @@ void radio_df_mode_set_aod(void)
 	radio_df_mode_set(NRF_RADIO_DFE_OP_MODE_AOD);
 }
 
-static void radio_df_cte_inline_set_disabled(void)
-{
-	NRF_RADIO->CTEINLINECONF &= ~RADIO_CTEINLINECONF_CTEINLINECTRLEN_Msk;
-	NRF_RADIO->CTEINLINECONF |= ((RADIO_CTEINLINECONF_CTEINLINECTRLEN_Disabled <<
-				      RADIO_CTEINLINECONF_CTEINLINECTRLEN_Pos)
-				     & RADIO_CTEINLINECONF_CTEINLINECTRLEN_Msk);
-}
-
 static inline void radio_df_ctrl_set(uint8_t cte_len,
 				     uint8_t switch_spacing,
 				     uint8_t sample_spacing,
@@ -388,8 +380,14 @@ void radio_df_ant_switch_pattern_clear(void)
 
 void radio_df_reset(void)
 {
-	radio_df_mode_set(RADIO_DFEMODE_DFEOPMODE_Disabled);
-	radio_df_cte_inline_set_disabled();
+	/* Initialize to NRF_RADIO reset values
+	 * Note: Only registers that turn off the DF feature and those
+	 *       registers whose bits are partially modified across functions
+	 *       are assigned back the power-on reset values.
+	 */
+	NRF_RADIO->DFEMODE = HAL_RADIO_RESET_VALUE_DFEMODE;
+	NRF_RADIO->CTEINLINECONF = HAL_RADIO_RESET_VALUE_CTEINLINECONF;
+
 	radio_df_ant_switch_pattern_clear();
 }
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2022 Nordic Semiconductor ASA
  * Copyright (c) 2018 Ioannis Glaropoulos
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -82,4 +82,13 @@
 #else
 #error "PPI or DPPI abstractions missing."
 #endif
+
 #include "radio_nrf5_txp.h"
+
+/* Common NRF_RADIO power-on reset value. Refer to Product Specification,
+ * RADIO Registers section for the documented reset values.
+ *
+ * NOTE: Only implementation used values defined here.
+ *       In the future if MDK or nRFx header include these, use them instead.
+ */
+#define HAL_RADIO_RESET_VALUE_PCNF1 0x00000000UL

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52811.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52811.h
@@ -387,6 +387,15 @@
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 
+/* SoC specific NRF_RADIO power-on reset value. Refer to Product Specification,
+ * RADIO Registers section for the documented reset values.
+ *
+ * NOTE: Only implementation used values defined here.
+ *       In the future if MDK or nRFx header include these, use them instead.
+ */
+#define HAL_RADIO_RESET_VALUE_DFEMODE       0x00000000UL
+#define HAL_RADIO_RESET_VALUE_CTEINLINECONF 0x00002800UL
+
 static inline void hal_radio_reset(void)
 {
 	/* TODO: Add any required setup for each radio event

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52820.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52820.h
@@ -387,6 +387,15 @@
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 
+/* SoC specific NRF_RADIO power-on reset value. Refer to Product Specification,
+ * RADIO Registers section for the documented reset values.
+ *
+ * NOTE: Only implementation used values defined here.
+ *       In the future if MDK or nRFx header include these, use them instead.
+ */
+#define HAL_RADIO_RESET_VALUE_DFEMODE       0x00000000UL
+#define HAL_RADIO_RESET_VALUE_CTEINLINECONF 0x00002800UL
+
 static inline void hal_radio_reset(void)
 {
 	/* TODO: Add any required setup for each radio event

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52833.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52833.h
@@ -387,6 +387,15 @@
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 
+/* SoC specific NRF_RADIO power-on reset value. Refer to Product Specification,
+ * RADIO Registers section for the documented reset values.
+ *
+ * NOTE: Only implementation used values defined here.
+ *       In the future if MDK or nRFx header include these, use them instead.
+ */
+#define HAL_RADIO_RESET_VALUE_DFEMODE       0x00000000UL
+#define HAL_RADIO_RESET_VALUE_CTEINLINECONF 0x00002800UL
+
 static inline void hal_radio_reset(void)
 {
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5340.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5340.h
@@ -394,6 +394,15 @@
 #define RADIO_TXPOWER_TXPOWER_Pos3dBm (0x03UL)
 #endif
 
+/* SoC specific NRF_RADIO power-on reset value. Refer to Product Specification,
+ * RADIO Registers section for the documented reset values.
+ *
+ * NOTE: Only implementation used values defined here.
+ *       In the future if MDK or nRFx header include these, use them instead.
+ */
+#define HAL_RADIO_RESET_VALUE_DFEMODE       0x00000000UL
+#define HAL_RADIO_RESET_VALUE_CTEINLINECONF 0x00002800UL
+
 static inline void hal_radio_tx_power_high_voltage_clear(void);
 
 static inline void hal_radio_reset(void)


### PR DESCRIPTION
Explicitly set all bits of used radio registers when configuring radio events, removing the dependency on having the power-on reset value and removing the need to ensuring power-on reset values being set in the radio peripheral.

This will ensure the Controller has radio register value correctly configured irrespective of changes across SoCs' radio register power-on reset values.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>