### PR TITLE
samples: subsys: littlefs on nucleo_h743zi

### DIFF
--- a/samples/subsys/fs/littlefs/boards/nucleo_h743zi.overlay
+++ b/samples/subsys/fs/littlefs/boards/nucleo_h743zi.overlay
@@ -38,9 +38,9 @@
 			   #address-cells = <1>;
 			   #size-cells = <1>;
 
-			   partition@0 {
+			   storage_partition: partition@0 {
 			       label = "storage";
-			       reg = <0x01000000 DT_SIZE_M(8)>;
+			       reg = <0 DT_SIZE_M(8)>;
 			   };
 		};
 	};


### PR DESCRIPTION
This commit fixes the overlay file for running the samples/subsys/fs/littlefs on the nucleo_h743zi platform.
The storage_partition is moved to the qspi_nor flash instead of the internal flash.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/51870

Signed-off-by: Francois Ramu <francois.ramu@st.com>