### PR TITLE
drivers: dmic: remove invalid assert on dmic->created

### DIFF
--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -746,7 +746,6 @@ static int dai_dmic_set_config(const struct device *dev,
 		return -EINVAL;
 	}
 
-	__ASSERT_NO_MSG(dmic->created);
 	key = k_spin_lock(&dmic->lock);
 
 #if CONFIG_DAI_INTEL_DMIC_TPLG_PARAMS


### PR DESCRIPTION
struct dai_intel_dmic never had a "created" member, so this assert seems to be accidentally left in the code. Remove it to allow building builds with dmic driver with asserts enabled.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>