### PR TITLE
drivers: ethernet: Fix hanging configuration option

### DIFF
--- a/drivers/ethernet/Kconfig
+++ b/drivers/ethernet/Kconfig
@@ -59,8 +59,6 @@ source "drivers/ethernet/Kconfig.cyclonev"
 
 source "drivers/ethernet/phy/Kconfig"
 
-endif # "Ethernet Drivers"
-
 config ETH_INIT_PRIORITY
 	int "Ethernet driver init priority"
 	default 80
@@ -69,3 +67,5 @@ config ETH_INIT_PRIORITY
 	  Do not mess with it unless you know what you are doing.
 	  Note that the priority needs to be lower than the net stack
 	  so that it can start before the networking sub-system.
+
+endif # "Ethernet Drivers"

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -294,7 +294,7 @@ ETH_NET_DEVICE_INIT(eth1_offloading_disabled_test,
 		    "eth1_offloading_disabled_test",
 		    eth_init, NULL,
 		    &eth_context_offloading_disabled, NULL,
-		    CONFIG_ETH_INIT_PRIORITY,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &api_funcs_offloading_disabled,
 		    NET_ETH_MTU);
 
@@ -302,7 +302,7 @@ ETH_NET_DEVICE_INIT(eth0_offloading_enabled_test,
 		    "eth0_offloading_enabled_test",
 		    eth_init, NULL,
 		    &eth_context_offloading_enabled, NULL,
-		    CONFIG_ETH_INIT_PRIORITY,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &api_funcs_offloading_enabled,
 		    NET_ETH_MTU);
 

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -104,12 +104,12 @@ static int eth_fake_init(const struct device *dev)
 
 ETH_NET_DEVICE_INIT(eth_fake1, "eth_fake1", eth_fake_init,
 		    NULL, &eth_fake_data1, NULL,
-		    CONFIG_ETH_INIT_PRIORITY, &eth_fake_api_funcs,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &eth_fake_api_funcs,
 		    NET_ETH_MTU);
 
 ETH_NET_DEVICE_INIT(eth_fake2, "eth_fake2", eth_fake_init,
 		    NULL, &eth_fake_data2, NULL,
-		    CONFIG_ETH_INIT_PRIORITY, &eth_fake_api_funcs,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &eth_fake_api_funcs,
 		    NET_ETH_MTU);
 
 static int setup_socket(struct net_if *iface, int type, int proto)

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -992,7 +992,7 @@ static int eth_fake_init(const struct device *dev)
 }
 
 ETH_NET_DEVICE_INIT(eth_fake, "eth_fake", eth_fake_init, NULL,
-		    &eth_fake_data, NULL, CONFIG_ETH_INIT_PRIORITY,
+		    &eth_fake_data, NULL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &eth_fake_api_funcs, NET_ETH_MTU);
 
 static void iface_cb(struct net_if *iface, void *user_data)

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -173,7 +173,7 @@ static int eth_vlan_init(const struct device *dev)
 
 ETH_NET_DEVICE_INIT(eth_vlan_test, "eth_vlan_test",
 		    eth_vlan_init, NULL,
-		    &eth_vlan_context, NULL, CONFIG_ETH_INIT_PRIORITY,
+		    &eth_vlan_context, NULL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &api_funcs, NET_ETH_MTU);
 
 static int eth_init(const struct device *dev)
@@ -190,7 +190,7 @@ static int eth_init(const struct device *dev)
  * purposes create it here.
  */
 NET_DEVICE_INIT(eth_test, "eth_test", eth_init, NULL,
-		&eth_vlan_context, NULL, CONFIG_ETH_INIT_PRIORITY,
+		&eth_vlan_context, NULL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		&api_funcs, ETHERNET_L2, NET_L2_GET_CTX_TYPE(ETHERNET_L2),
 		NET_ETH_MTU);
 


### PR DESCRIPTION
This is rather preference issue.

At the moment  CONFIG_ETH_INIT_PRIORITY is defined for every sample, even for hello_world.
When selecting configuration with menuconfig it looks unrelated to currently selected configuration options.

For the tests which are disabling ETH_DRIVER and using fake devices use standard DEVICE priority.

Test with:
```
zephyrproject$ west build -b native_posix zephyr/samples/hello_world/ -p -t menuconfig
```

```
                                      Zephyr Kernel Configuration
[ ] LoRa support [EXPERIMENTAL]  ----
[*] Console drivers  --->
[ ] Embedded Controller Host Command peripheral support  ----
(80) Ethernet driver init priority
[ ] MDIO Drivers  ----
...
```