### PR TITLE
bluetooth: audio: tbs_client: Remove unused read_buf

### DIFF
--- a/subsys/bluetooth/audio/tbs_internal.h
+++ b/subsys/bluetooth/audio/tbs_internal.h
@@ -357,7 +357,6 @@ struct bt_tbs_instance {
 	struct bt_gatt_subscribe_params termination_sub_params;
 	struct bt_gatt_discover_params termination_sub_disc_params;
 	struct bt_gatt_read_params read_params;
-	uint8_t read_buf[BT_ATT_MAX_ATTRIBUTE_LEN];
 	struct net_buf_simple net_buf;
 };
 #endif /* CONFIG_BT_TBS_CLIENT */


### PR DESCRIPTION
The read_buf array in struct bt_tbs_instance is not referenced from anywhere, so there is no need for it.

Signed-off-by: Kim Sekkelund <ksek@oticon.com>