### PR TITLE
drivers: eeprom: mchp_xec: add missing kernel.h include

### DIFF
--- a/drivers/eeprom/eeprom_mchp_xec.c
+++ b/drivers/eeprom/eeprom_mchp_xec.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/eeprom.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 
 #ifdef CONFIG_PINCTRL


### PR DESCRIPTION
Add missing kernel.h include.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>