### PR TITLE
boards: nrf5340dk_nrf5340: Add chosen node for nrf-802154 spinel

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -14,6 +14,7 @@
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,bt-hci-rpmsg-ipc = &ipc0;
+		nordic,802154-spinel-ipc = &ipc0;
 	};
 
 	leds {

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
@@ -19,6 +19,7 @@
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,bt-hci-rpmsg-ipc = &ipc0;
+		nordic,802154-spinel-ipc = &ipc0;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
 		zephyr,code-partition = &slot0_partition;

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -13,6 +13,7 @@
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,bt-hci-rpmsg-ipc = &ipc0;
+		nordic,802154-spinel-ipc = &ipc0;
 	};
 
 	buttons {

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
@@ -19,6 +19,7 @@
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,bt-hci-rpmsg-ipc = &ipc0;
+		nordic,802154-spinel-ipc = &ipc0;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
 		zephyr,code-partition = &slot0_partition;

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
@@ -45,7 +45,8 @@ static struct ipc_ept_cfg ept_cfg = {
 
 nrf_802154_ser_err_t nrf_802154_backend_init(void)
 {
-	const struct device *const ipc_instance = DEVICE_DT_GET(DT_NODELABEL(ipc0));
+	const struct device *const ipc_instance =
+		DEVICE_DT_GET(DT_CHOSEN(nordic_802154_spinel_ipc));
 	int err;
 
 	err = ipc_service_open_instance(ipc_instance);


### PR DESCRIPTION
Currently, the nrf-802154-spinel IPC service requires that the IPC service node has a specific name (`ipc0`). This makes it impossible to overwrite the IPC service node to be used by the Spinel serialization without completely redefining the `ipc0` node. Create a `chosen` property called `nordic,802154-spinel-ipc` that can be reassigned with any IPC service node.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>