### PR TITLE
boards: x86: qemu: initialize flash simulator before EEPROM emulator

### DIFF
--- a/boards/x86/qemu_x86/Kconfig.defconfig
+++ b/boards/x86/qemu_x86/Kconfig.defconfig
@@ -1,5 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if BOARD_QEMU_X86 || BOARD_QEMU_X86_64 || BOARD_QEMU_X86_LAKEMONT || BOARD_QEMU_X86_TINY
+
+# The EEPROM emulator must be initialized after the flash simulator
+config EEPROM_INIT_PRIORITY
+	default 60
+	depends on EEPROM
+
+endif # BOARD_QEMU_X86 || BOARD_QEMU_X86_64 || BOARD_QEMU_X86_LAKEMONT || BOARD_QEMU_X86_TINY
+
 if BOARD_QEMU_X86
 
 config BUILD_OUTPUT_BIN


### PR DESCRIPTION
On the x86 QEMU boards the EEPROM emulator uses the simulated flash as backend.

Change the default initialization priority for the EEPROM drivers to ensure the flash simulator is ready before initializing the EEPROM emulator.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>