### PR TITLE
drivers: pinctrl: Prevent dangling state pointer initialization

### DIFF
--- a/drivers/pinctrl/common.c
+++ b/drivers/pinctrl/common.c
@@ -12,7 +12,7 @@ int pinctrl_lookup_state(const struct pinctrl_dev_config *config, uint8_t id,
 	if (config->state_cnt == 0) {
 		return -ENOENT;
 	}
-	
+
 	*state = &config->states[0];
 	while (*state <= &config->states[config->state_cnt - 1U]) {
 		if (id == (*state)->id) {

--- a/drivers/pinctrl/common.c
+++ b/drivers/pinctrl/common.c
@@ -9,6 +9,10 @@
 int pinctrl_lookup_state(const struct pinctrl_dev_config *config, uint8_t id,
 			 const struct pinctrl_state **state)
 {
+	if (config->state_cnt == 0) {
+		return -ENOENT;
+	}
+	
 	*state = &config->states[0];
 	while (*state <= &config->states[config->state_cnt - 1U]) {
 		if (id == (*state)->id) {


### PR DESCRIPTION
When no states are configured and apply state is used, `pinctrl_lookup_state` should not create dangling pointers. This also avoids potential undefined behavior with negative array indexing.

I ran into this in a situation, where the pinctrl states were on the bus not the node for the driver. `pinctrl_apply_state` returned -ENOENT without anything nefarious happening since the dangling pointer was used in `pinctrl_lookup_state`. 

![Screen Shot 2022-11-03 at 1 00 52 PM](https://user-images.githubusercontent.com/8592049/199810059-c911be64-1de6-487b-93e3-01f873ebca14.png)
