### PR TITLE
Add -lc -lgcc from picolibc toolchain library after module libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,6 +595,9 @@ endforeach()
 set(ZEPHYR_CURRENT_MODULE_DIR)
 set(ZEPHYR_CURRENT_CMAKE_DIR)
 
+get_property(LIBC_LINK_LIBRARIES TARGET zephyr_interface PROPERTY LIBC_LINK_LIBRARIES)
+zephyr_link_libraries(${LIBC_LINK_LIBRARIES})
+
 set(syscall_list_h   ${CMAKE_CURRENT_BINARY_DIR}/include/generated/syscall_list.h)
 set(syscalls_json    ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/syscalls.json)
 set(struct_tags_json ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/struct_tags.json)

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -112,6 +112,10 @@ function(zephyr_link_libraries)
   target_link_libraries(zephyr_interface INTERFACE ${ARGV})
 endfunction()
 
+function(zephyr_libc_link_libraries)
+  set_property(TARGET zephyr_interface APPEND PROPERTY LIBC_LINK_LIBRARIES ${ARGV})
+endfunction()
+
 # See this file section 3.1. target_cc_option
 function(zephyr_cc_option)
   foreach(arg ${ARGV})

--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT CONFIG_PICOLIBC_USE_MODULE)
 
   zephyr_compile_options(--specs=picolibc.specs)
   zephyr_compile_definitions(_POSIX_C_SOURCE=200809)
-  zephyr_link_libraries(-T/dev/null --specs=picolibc.specs c -lgcc)
+  zephyr_libc_link_libraries(-T/dev/null --specs=picolibc.specs c -lgcc)
   if(CONFIG_PICOLIBC_IO_FLOAT)
     zephyr_compile_definitions(PICOLIBC_DOUBLE_PRINTF_SCANF)
     zephyr_link_libraries(-DPICOLIBC_DOUBLE_PRINTF_SCANF)


### PR DESCRIPTION
Hacks like

https://github.com/zephyrproject-rtos/zephyr/blob/29047f11ed0188a2a53a3b34c598d6c177645893/modules/openthread/CMakeLists.txt#L444-L448

shouldn't be required -- instead, the C library should be added to the end of the link command, rather than some place in the middle. Create a special set of link libraries which are to be added after the rest of the system and then use that for picolibc.