### PR TITLE
Rt685 update clock init

### DIFF
--- a/boards/arm/mimxrt685_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt685_evk/Kconfig.defconfig
@@ -43,4 +43,8 @@ config HEAP_MEM_POOL_SIZE
 
 endif # DMA_MCUX_LPC
 
+choice CODE_LOCATION
+	default CODE_FLEXSPI
+endchoice
+
 endif # BOARD_MIMXRT685_EVK

--- a/soc/arm/nxp_imx/rt6xx/CMakeLists.txt
+++ b/soc/arm/nxp_imx/rt6xx/CMakeLists.txt
@@ -12,6 +12,10 @@ zephyr_sources_ifdef(CONFIG_PM
   power.c
   )
 
+zephyr_sources_ifdef(CONFIG_CODE_FLEXSPI
+  flash_clock_setup.c
+  )
+
 zephyr_library_include_directories(
   ${ZEPHYR_BASE}/kernel/include
   ${ZEPHYR_BASE}/arch/${ARCH}/include
@@ -24,3 +28,7 @@ zephyr_linker_sources_ifdef(CONFIG_NXP_IMX_RT6XX_BOOT_HEADER
 
 zephyr_linker_sources_ifdef(CONFIG_USB_DEVICE_DRIVER
   SECTIONS usb.ld)
+
+if(CONFIG_CODE_FLEXSPI)
+zephyr_code_relocate(flash_clock_setup.c RAM)
+endif()

--- a/soc/arm/nxp_imx/rt6xx/Kconfig.series
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.series
@@ -10,5 +10,6 @@ config SOC_SERIES_IMX_RT6XX
 	select CPU_CORTEX_M_HAS_DWT
 	select SOC_FAMILY_IMX
 	select CLOCK_CONTROL
+	select CODE_DATA_RELOCATION_SRAM if CODE_FLEXSPI
 	help
 	  Enable support for i.MX RT6XX Series MCU series

--- a/soc/arm/nxp_imx/rt6xx/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.soc
@@ -109,5 +109,11 @@ config IMAGE_VECTOR_TABLE_OFFSET
 
 endif # NXP_IMX_RT6XX_BOOT_HEADER
 
+choice CODE_LOCATION
+	prompt "Code location selection"
+	default CODE_FLEXSPI
+config CODE_FLEXSPI
+	bool "Link code into external FlexSPI-controlled memory"
+endchoice
 
 endif # SOC_SERIES_IMX_RT6XX

--- a/soc/arm/nxp_imx/rt6xx/flash_clock_setup.c
+++ b/soc/arm/nxp_imx/rt6xx/flash_clock_setup.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * To be explicitly clear, the following set of functions
+ * cannot execute in place from flash and are instead
+ * relocated into internal SRAM.
+ */
+
+#include "fsl_power.h"
+#include "flash_clock_setup.h"
+
+#define FLEXSPI_DLL_LOCK_RETRY (10)
+
+static void flash_deinit(FLEXSPI_Type *base)
+{
+	/* Wait until FLEXSPI is not busy */
+	while (!((base->STS0 & FLEXSPI_STS0_ARBIDLE_MASK) &&
+		 (base->STS0 & FLEXSPI_STS0_SEQIDLE_MASK))) {
+	}
+	/* Disable module during the reset procedure */
+	base->MCR0 |= FLEXSPI_MCR0_MDIS_MASK;
+}
+
+static void flash_init(FLEXSPI_Type *base)
+{
+	uint32_t status;
+	uint32_t lastStatus;
+	uint32_t retry;
+	uint32_t mask = 0;
+
+	/* Enable FLEXSPI module */
+	base->MCR0 &= ~FLEXSPI_MCR0_MDIS_MASK;
+
+	base->MCR0 |= FLEXSPI_MCR0_SWRESET_MASK;
+	while (base->MCR0 & FLEXSPI_MCR0_SWRESET_MASK) {
+	}
+
+	/* Need to wait DLL locked if DLL enabled */
+	if (0U != (base->DLLCR[0] & FLEXSPI_DLLCR_DLLEN_MASK)) {
+		lastStatus = base->STS2;
+		retry      = FLEXSPI_DLL_LOCK_RETRY;
+		/* Flash on port A */
+		if (((base->FLSHCR0[0] & FLEXSPI_FLSHCR0_FLSHSZ_MASK) > 0) ||
+		    ((base->FLSHCR0[1] & FLEXSPI_FLSHCR0_FLSHSZ_MASK) > 0)) {
+			mask |= FLEXSPI_STS2_AREFLOCK_MASK | FLEXSPI_STS2_ASLVLOCK_MASK;
+		}
+		/* Flash on port B */
+		if (((base->FLSHCR0[2] & FLEXSPI_FLSHCR0_FLSHSZ_MASK) > 0) ||
+		    ((base->FLSHCR0[3] & FLEXSPI_FLSHCR0_FLSHSZ_MASK) > 0)) {
+			mask |= FLEXSPI_STS2_BREFLOCK_MASK | FLEXSPI_STS2_BSLVLOCK_MASK;
+		}
+		/* Wait slave delay line locked and slave reference delay line locked. */
+		do {
+			status = base->STS2;
+			if ((status & mask) == mask) {
+				/* Locked */
+				retry = 100;
+				break;
+			} else if (status == lastStatus) {
+				/* Same delay cell number in calibration */
+				retry--;
+			} else {
+				retry = FLEXSPI_DLL_LOCK_RETRY;
+				lastStatus = status;
+			}
+		} while (retry > 0);
+		/* According to ERR011377, need to delay at least 100 NOPs
+		 * to ensure the DLL is locked.
+		 */
+		for (; retry > 0U; retry--) {
+			__NOP();
+		}
+	}
+}
+
+void flexspi_setup_clock(FLEXSPI_Type *base, uint32_t src, uint32_t divider)
+{
+	if (base == FLEXSPI) {
+		if ((CLKCTL0->FLEXSPIFCLKSEL != CLKCTL0_FLEXSPIFCLKSEL_SEL(src)) ||
+		   ((CLKCTL0->FLEXSPIFCLKDIV & CLKCTL0_FLEXSPIFCLKDIV_DIV_MASK) !=
+		    (divider - 1))) {
+			/* Always deinit FLEXSPI and init FLEXSPI for the flash to make sure the
+			 * flash works correctly after the FLEXSPI root clock changed as the
+			 * default FLEXSPI configuration may does not work for the new root
+			 * clock frequency.
+			 */
+			flash_deinit(base);
+
+			/* Disable clock before changing clock source */
+			CLKCTL0->PSCCTL0_CLR = CLKCTL0_PSCCTL0_CLR_FLEXSPI_OTFAD_CLK_MASK;
+			/* Update flexspi clock */
+			CLKCTL0->FLEXSPIFCLKSEL = CLKCTL0_FLEXSPIFCLKSEL_SEL(src);
+			/* Reset the divider counter */
+			CLKCTL0->FLEXSPIFCLKDIV |= CLKCTL0_FLEXSPIFCLKDIV_RESET_MASK;
+			CLKCTL0->FLEXSPIFCLKDIV = CLKCTL0_FLEXSPIFCLKDIV_DIV(divider - 1);
+			while ((CLKCTL0->FLEXSPIFCLKDIV) & CLKCTL0_FLEXSPIFCLKDIV_REQFLAG_MASK) {
+			}
+			/* Enable FLEXSPI clock again */
+			CLKCTL0->PSCCTL0_SET = CLKCTL0_PSCCTL0_SET_FLEXSPI_OTFAD_CLK_MASK;
+
+			flash_init(base);
+		}
+	} else {
+		return;
+	}
+}
+
+/* This function is used to change FlexSPI clock to a stable source before clock
+ * sources(Such as PLL and Main clock) updating in case XIP (execute code on
+ * FLEXSPI memory.)
+ */
+void flexspi_clock_safe_config(void)
+{
+	/* Move FLEXSPI clock source from main clock to FRO192M / 2 to avoid instruction/data
+	 * fetch issue in XIP when updating PLL and main clock.
+	 */
+	flexspi_setup_clock(FLEXSPI, 3U, 1U);
+}

--- a/soc/arm/nxp_imx/rt6xx/flash_clock_setup.h
+++ b/soc/arm/nxp_imx/rt6xx/flash_clock_setup.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2022 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#ifndef _FLASH_CLOCK_SETUP_H_
+#define _FLASH_CLOCK_SETUP_H_
+
+#include "fsl_common.h"
+
+void flexspi_clock_safe_config(void);
+void flexspi_setup_clock(FLEXSPI_Type *base, uint32_t src, uint32_t divider);
+
+#endif /* _FLASH_CLOCK_SETUP_H_ */

--- a/soc/arm/nxp_imx/rt6xx/soc.c
+++ b/soc/arm/nxp_imx/rt6xx/soc.c
@@ -25,11 +25,17 @@
 #include <fsl_common.h>
 #include <fsl_device_registers.h>
 
+#ifdef CONFIG_CODE_FLEXSPI
+#include "flash_clock_setup.h"
+#endif
+
 #if CONFIG_USB_DC_NXP_LPCIP3511
 #include "usb_phy.h"
 #include "usb.h"
 #endif
 
+/* Core clock frequency: 250105263Hz */
+#define CLOCK_INIT_CORE_CLOCK                     250105263U
 
 #define SYSTEM_IS_XIP_FLEXSPI() \
 	((((uint32_t)nxp_rt600_init >= 0x08000000U) &&		\
@@ -67,6 +73,9 @@ const clock_audio_pll_config_t g_audioPllConfig = {
 #define BOARD_USB_PHY_TXCAL45DP (0x06U)
 #define BOARD_USB_PHY_TXCAL45DM (0x06U)
 #endif
+
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
 
 #ifdef CONFIG_NXP_IMX_RT6XX_BOOT_HEADER
 extern char z_main_stack[];
@@ -186,6 +195,15 @@ static ALWAYS_INLINE void clock_init(void)
 	POWER_DisablePD(kPDRUNCFG_PD_SFRO);
 	CLOCK_EnableSfroClk();
 
+#ifdef CONFIG_CODE_FLEXSPI
+	/*
+	 * Call function flexspi_clock_safe_config() to move FlexSPI clock to a stable
+	 * clock source to avoid instruction/data fetch issue when updating PLL and Main
+	 * clock if XIP(execute code on FLEXSPI memory).
+	 */
+	flexspi_clock_safe_config();
+#endif
+
 	/* Let CPU run on FFRO for safe switching. */
 	CLOCK_AttachClk(kFFRO_to_MAIN_CLK);
 
@@ -284,6 +302,17 @@ static ALWAYS_INLINE void clock_init(void)
 	CLOCK_AttachClk(kFFRO_to_I3C_CLK);
 	CLOCK_AttachClk(kLPOSC_to_I3C_TC_CLK);
 #endif
+
+#ifdef CONFIG_CODE_FLEXSPI
+	/*
+	 * Call function flexspi_setup_clock() to set user configured clock source/divider
+	 * for FlexSPI.
+	 */
+	flexspi_setup_clock(FLEXSPI, 1U, 9U);
+#endif
+
+	/* Set SystemCoreClock variable. */
+	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
 
 #endif /* CONFIG_SOC_MIMXRT685S_CM33 */
 }


### PR DESCRIPTION
Updated the clock_init file in the SOC of the RT6xx
to align with the latest SDK.
Added support for safe flash clock initialization in the RT6xx. 