### PR TITLE
 cmake: compute and display the reproducible checksum by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1679,6 +1679,7 @@ if(CONFIG_BUILD_OUTPUT_STRIPPED)
             $<TARGET_PROPERTY:bintools,strip_flag_infile>${KERNEL_ELF_NAME}
             $<TARGET_PROPERTY:bintools,strip_flag_outfile>${KERNEL_STRIP_NAME}
             $<TARGET_PROPERTY:bintools,strip_flag_final>
+    COMMAND ${CMAKE_COMMAND} -E sha256sum ${KERNEL_STRIP_NAME}
     )
   list(APPEND
     post_build_byproducts

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -575,6 +575,7 @@ endif # BUILD_OUTPUT_UF2
 
 config BUILD_OUTPUT_STRIPPED
 	bool "Build a stripped binary"
+	default y
 	help
 	  Build a stripped binary zephyr/zephyr.strip in the build directory.
 	  The name of this file can be customized with CONFIG_KERNEL_BIN_NAME.


### PR DESCRIPTION
Two commits, second commit message copied below.

tl;dr

- This PR makes a huge difference for people who care about security and reproducible builds more generally.
- This PR makes no observable difference for people who don't care,
- The reproducible `zephyr.strip` is only a means to an end. Alternative ways to achieve the same purpose are welcome... as long as they don't require hundreds times more lines of code. This PR adds 2 lines.

If 0.5% additional `build/` disk space is considered too much then one alternative is to delete `zephyr.strip` immediately after checksumming it. However the easiest way to automate #50205 is to compare `zephyr.strip` files.

An earlier and incomplete version of this was previously (and negatively) reviewed by a few people in
- #51737

----------


Temporary bugs, corner cases and obsolete toolchains aside, the Zephyr
build is reproducible most of the time: #50205 and #14593

This means two different build machines using the same toolchain will
always produce the same binary output. These 2 lines make
it trivial to verify that binary outputs are indeed the same by adding this
single line in the build logs:

```
[16/16] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
             RAM:       53280 B         3 MB      1.69%
        IDT_LIST:          0 GB         2 KB      0.00%
fdd2ddf2ad7d5da5bbd79b41cef8d7b161a896b983cdaef549a8281111d8e205  zephyr.strip
```

The second commit enables that feature by default because build
reproducibility matters for (at least) two important reasons:

- Security / supply chain attacks, see https://www.cisa.gov/sbom, #50205,
  https://reproducible-builds.org/ and many others.
- Making sure build configurations are strictly identical when trying to
  reproduce elusive issues or when issuing releases.

It was of course already possible to _manually_ make this Kconfig change
and manually compute this checksum. However this can be impossible when
dealing with an automated build system that does not archive all
_intermediate_ (#5009) files like `zephyr.elf`. Tweaking the build
configuration can also be difficult and error-prone for people who are
not Zephyr developers.

Most automated CI systems preserve build logs by default.

Displaying the reproducible checksum by default accelerates the
discovery of reproducibility bugs like #48195.

When measured with `west build -p -b qemu_x86 samples/hello_world/`, the
additional `build/zephyr/zephyr.strip` disk space required is 43
kilobytes compared to a total of 11 Megabytes. Measuring a more
realistic SOF example, `zephyr.strip` weighed 690 kb which was about
0.1% of a total `build/` directory weighing 65M.

To measure the build time cost I ran "west build -p -b qemu_x86
samples/hello_world/" many times in a loop with and without this PR on
my Linux workstation. Stripping and checksumming made literally no time
difference compared to the "noise" observed when building the same
configuration. This is not surprising considering how small
`zephyr.strip` is: so the extra cost is most likely dominated by process
creation and the total number of processes created during a Zephyr build
dwarfs the few extra processes required by this feature.

More surprisingly, I measured incremental builds by running
`touch kernel/timer.c; west build ...` in a loop and I could not
observe any visible time difference either.
