### PR TITLE
dma: hda: dwdma: adsp: ace: Extend DMA api functionality

### DIFF
--- a/drivers/dma/dma_dw_common.h
+++ b/drivers/dma/dma_dw_common.h
@@ -221,12 +221,6 @@ struct dw_dma_chan_data {
  */
 static const uint32_t burst_elems[] = {1, 2, 4, 8};
 
-#if CONFIG_DMA_HW_LLI
-#define DW_DMA_BUFFER_PERIOD_COUNT	4
-#else
-#define DW_DMA_BUFFER_PERIOD_COUNT	2
-#endif
-
 /* Device run time data */
 struct dw_dma_dev_data {
 	struct dma_context dma_ctx;

--- a/drivers/dma/dma_intel_adsp_gpdma.c
+++ b/drivers/dma/dma_intel_adsp_gpdma.c
@@ -5,6 +5,8 @@
  */
 
 #include <zephyr/drivers/dma.h>
+#include <zephyr/cache.h>
+
 #define DT_DRV_COMPAT intel_adsp_gpdma
 
 #define GPDMA_CTL_OFFSET 0x0004
@@ -265,16 +267,36 @@ out:
 
 int intel_adsp_gpdma_get_status(const struct device *dev, uint32_t channel, struct dma_status *stat)
 {
-	uint32_t llp_l, llp_u;
+	uint32_t llp_l = 0;
+	uint32_t llp_u = 0;
 
 	if (channel >= DW_MAX_CHAN) {
 		return -EINVAL;
 	}
 
 	intel_adsp_gpdma_llp_read(dev, channel, &llp_l, &llp_u);
-	stat->total_copied = (llp_u << 32) | llp_l;
+	stat->total_copied = ((uint64_t)llp_u << 32) | llp_l;
 
 	return dw_dma_get_status(dev, channel, stat);
+}
+
+int intel_adsp_gpdma_get_attribute(const struct device *dev, uint32_t type, uint32_t *value)
+{
+	switch (type) {
+	case DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT:
+		*value = sys_cache_data_line_size_get();
+		break;
+	case DMA_ATTR_BUFFER_SIZE_ALIGNMENT:
+		*value = DMA_BUF_SIZE_ALIGNMENT(DT_COMPAT_GET_ANY_STATUS_OKAY(intel_adsp_gpdma));
+		break;
+	case DMA_ATTR_COPY_ALIGNMENT:
+		*value = DMA_COPY_ALIGNMENT(DT_COMPAT_GET_ANY_STATUS_OKAY(intel_adsp_gpdma));
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
 static const struct dma_driver_api intel_adsp_gpdma_driver_api = {
@@ -285,6 +307,7 @@ static const struct dma_driver_api intel_adsp_gpdma_driver_api = {
 	.suspend = dw_dma_suspend,
 	.resume = dw_dma_resume,
 	.get_status = intel_adsp_gpdma_get_status,
+	.get_attribute = intel_adsp_gpdma_get_attribute,
 };
 
 #define INTEL_ADSP_GPDMA_CHAN_ARB_DATA(inst)				\

--- a/drivers/dma/dma_intel_adsp_gpdma.c
+++ b/drivers/dma/dma_intel_adsp_gpdma.c
@@ -263,6 +263,20 @@ out:
 	return 0;
 }
 
+int intel_adsp_gpdma_get_status(const struct device *dev, uint32_t channel, struct dma_status *stat)
+{
+	uint32_t llp_l, llp_u;
+
+	if (channel >= DW_MAX_CHAN) {
+		return -EINVAL;
+	}
+
+	intel_adsp_gpdma_llp_read(dev, channel, &llp_l, &llp_u);
+	stat->total_copied = (llp_u << 32) | llp_l;
+
+	return dw_dma_get_status(dev, channel, stat);
+}
+
 static const struct dma_driver_api intel_adsp_gpdma_driver_api = {
 	.config = intel_adsp_gpdma_config,
 	.reload = intel_adsp_gpdma_copy,
@@ -270,7 +284,7 @@ static const struct dma_driver_api intel_adsp_gpdma_driver_api = {
 	.stop = intel_adsp_gpdma_stop,
 	.suspend = dw_dma_suspend,
 	.resume = dw_dma_resume,
-	.get_status = dw_dma_get_status,
+	.get_status = intel_adsp_gpdma_get_status,
 };
 
 #define INTEL_ADSP_GPDMA_CHAN_ARB_DATA(inst)				\

--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -265,3 +265,24 @@ int intel_adsp_hda_dma_init(const struct device *dev)
 
 	return 0;
 }
+
+int intel_adsp_hda_dma_get_attribute(const struct device *dev, uint32_t type, uint32_t *value)
+{
+	switch (type) {
+	case DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT:
+		*value = DMA_BUF_ADDR_ALIGNMENT(
+				DT_COMPAT_GET_ANY_STATUS_OKAY(intel_adsp_hda_link_out));
+		break;
+	case DMA_ATTR_BUFFER_SIZE_ALIGNMENT:
+		*value = DMA_BUF_SIZE_ALIGNMENT(
+				DT_COMPAT_GET_ANY_STATUS_OKAY(intel_adsp_hda_link_out));
+		break;
+	case DMA_ATTR_COPY_ALIGNMENT:
+		*value = DMA_COPY_ALIGNMENT(DT_COMPAT_GET_ANY_STATUS_OKAY(intel_adsp_hda_link_out));
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}

--- a/drivers/dma/dma_intel_adsp_hda.h
+++ b/drivers/dma/dma_intel_adsp_hda.h
@@ -58,5 +58,6 @@ int intel_adsp_hda_dma_stop(const struct device *dev, uint32_t channel);
 
 int intel_adsp_hda_dma_init(const struct device *dev);
 
+int intel_adsp_hda_dma_get_attribute(const struct device *dev, uint32_t type, uint32_t *value);
 
 #endif /* ZEPHYR_DRIVERS_DMA_INTEL_ADSP_HDA_COMMON_H_ */

--- a/drivers/dma/dma_intel_adsp_hda_host_in.c
+++ b/drivers/dma/dma_intel_adsp_hda_host_in.c
@@ -15,6 +15,7 @@ static const struct dma_driver_api intel_adsp_hda_dma_host_in_api = {
 	.start = intel_adsp_hda_dma_start,
 	.stop = intel_adsp_hda_dma_stop,
 	.get_status = intel_adsp_hda_dma_status,
+	.get_attribute = intel_adsp_hda_dma_get_attribute,
 	.chan_filter = intel_adsp_hda_dma_chan_filter,
 };
 

--- a/drivers/dma/dma_intel_adsp_hda_host_out.c
+++ b/drivers/dma/dma_intel_adsp_hda_host_out.c
@@ -19,6 +19,7 @@ static const struct dma_driver_api intel_adsp_hda_dma_host_out_api = {
 	.start = intel_adsp_hda_dma_start,
 	.stop = intel_adsp_hda_dma_stop,
 	.get_status = intel_adsp_hda_dma_status,
+	.get_attribute = intel_adsp_hda_dma_get_attribute,
 	.chan_filter = intel_adsp_hda_dma_chan_filter,
 };
 

--- a/drivers/dma/dma_intel_adsp_hda_link_in.c
+++ b/drivers/dma/dma_intel_adsp_hda_link_in.c
@@ -20,6 +20,7 @@ static const struct dma_driver_api intel_adsp_hda_dma_link_in_api = {
 	.stop = intel_adsp_hda_dma_stop,
 	.suspend = intel_adsp_hda_dma_stop,
 	.get_status = intel_adsp_hda_dma_status,
+	.get_attribute = intel_adsp_hda_dma_get_attribute,
 	.chan_filter = intel_adsp_hda_dma_chan_filter,
 };
 

--- a/drivers/dma/dma_intel_adsp_hda_link_out.c
+++ b/drivers/dma/dma_intel_adsp_hda_link_out.c
@@ -20,6 +20,7 @@ static const struct dma_driver_api intel_adsp_hda_dma_link_out_api = {
 	.stop = intel_adsp_hda_dma_stop,
 	.suspend = intel_adsp_hda_dma_stop,
 	.get_status = intel_adsp_hda_dma_status,
+	.get_attribute = intel_adsp_hda_dma_get_attribute,
 	.chan_filter = intel_adsp_hda_dma_chan_filter,
 };
 

--- a/dts/bindings/dma/dma-controller.yaml
+++ b/dts/bindings/dma/dma-controller.yaml
@@ -31,3 +31,13 @@ properties:
     dma-buf-addr-alignment:
       type: int
       description: Memory address alignment requirement for DMA buffers used by the controller.
+
+    dma-buf-size-alignment:
+      type: int
+      required: false
+      description: Memory size alignment requirement for DMA buffers used by the controller.
+
+    dma-copy-alignment:
+      type: int
+      required: false
+      description: Minimal chunk of data possible to be copied by the controller.

--- a/dts/bindings/dma/dma-controller.yaml
+++ b/dts/bindings/dma/dma-controller.yaml
@@ -28,6 +28,6 @@ properties:
       type: int
       description: Number of DMA request signals supported by the controller.
 
-    dma-buf-alignment:
+    dma-buf-addr-alignment:
       type: int
-      description: Memory alignment requirement for DMA buffers used by the controller.
+      description: Memory address alignment requirement for DMA buffers used by the controller.

--- a/dts/bindings/dma/intel,adsp-gpdma.yaml
+++ b/dts/bindings/dma/intel,adsp-gpdma.yaml
@@ -11,3 +11,9 @@ properties:
     shim:
       type: array
       required: true
+
+    dma-buf-size-alignment:
+      required: true
+
+    dma-copy-alignment:
+      required: true

--- a/dts/bindings/dma/intel,adsp-hda.yaml
+++ b/dts/bindings/dma/intel,adsp-hda.yaml
@@ -15,5 +15,5 @@ properties:
     "#dma-cells":
       const: 1
 
-    "dma-buf-alignment":
+    "dma-buf-addr-alignment":
       required: true

--- a/dts/bindings/dma/intel,adsp-hda.yaml
+++ b/dts/bindings/dma/intel,adsp-hda.yaml
@@ -17,3 +17,9 @@ properties:
 
     "dma-buf-addr-alignment":
       required: true
+
+    "dma-buf-size-alignment":
+      required: true
+
+    "dma-copy-alignment":
+      required: true

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -347,6 +347,8 @@
 			reg = <0x00072400 0x20>;
 			dma-channels = <9>;
 			dma-buf-addr-alignment = <128>;
+			dma-buf-size-alignment = <32>;
+			dma-copy-alignment = <32>;
 			status = "okay";
 		};
 
@@ -356,6 +358,8 @@
 			reg = <0x00072600 0x20>;
 			dma-channels = <10>;
 			dma-buf-addr-alignment = <128>;
+			dma-buf-size-alignment = <32>;
+			dma-copy-alignment = <32>;
 			status = "okay";
 		};
 
@@ -365,6 +369,8 @@
 			reg = <0x00072800 0x40>;
 			dma-channels = <9>;
 			dma-buf-addr-alignment = <128>;
+			dma-buf-size-alignment = <32>;
+			dma-copy-alignment = <32>;
 			status = "okay";
 		};
 
@@ -374,6 +380,8 @@
 			reg = <0x00072c00 0x40>;
 			dma-channels = <10>;
 			dma-buf-addr-alignment = <128>;
+			dma-buf-size-alignment = <32>;
+			dma-copy-alignment = <32>;
 			status = "okay";
 		};
 

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -415,6 +415,8 @@
 			shim = <0x0007c800 0x1000>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
+			dma-buf-size-alignment = <4>;
+			dma-copy-alignment = <4>;
 			status = "okay";
 		};
 
@@ -425,6 +427,8 @@
 			shim = <0x0007d800 0x1000>;
 			interrupts = <0x20 0 0>;
 			interrupt-parent = <&core_intc>;
+			dma-buf-size-alignment = <4>;
+			dma-copy-alignment = <4>;
 			status = "okay";
 		};
 

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -346,7 +346,7 @@
 			#dma-cells = <1>;
 			reg = <0x00072400 0x20>;
 			dma-channels = <9>;
-			dma-buf-alignment = <128>;
+			dma-buf-addr-alignment = <128>;
 			status = "okay";
 		};
 
@@ -355,7 +355,7 @@
 			#dma-cells = <1>;
 			reg = <0x00072600 0x20>;
 			dma-channels = <10>;
-			dma-buf-alignment = <128>;
+			dma-buf-addr-alignment = <128>;
 			status = "okay";
 		};
 
@@ -364,7 +364,7 @@
 			#dma-cells = <1>;
 			reg = <0x00072800 0x40>;
 			dma-channels = <9>;
-			dma-buf-alignment = <128>;
+			dma-buf-addr-alignment = <128>;
 			status = "okay";
 		};
 
@@ -373,7 +373,7 @@
 			#dma-cells = <1>;
 			reg = <0x00072c00 0x40>;
 			dma-channels = <10>;
-			dma-buf-alignment = <128>;
+			dma-buf-addr-alignment = <128>;
 			status = "okay";
 		};
 

--- a/dts/xtensa/intel/intel_adsp_cavs.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs.dtsi
@@ -36,6 +36,8 @@
 			reg = <0x00072400 0x20>;
 			dma-channels = <4>;
 			dma-buf-addr-alignment = <128>;
+			dma-buf-size-alignment = <32>;
+			dma-copy-alignment = <32>;
 
 			status = "okay";
 		};
@@ -46,6 +48,8 @@
 			reg = <0x00072600 0x20>;
 			dma-channels = <4>;
 			dma-buf-addr-alignment = <128>;
+			dma-buf-size-alignment = <32>;
+			dma-copy-alignment = <32>;
 
 			status = "okay";
 		};
@@ -56,6 +60,8 @@
 			reg = <0x00072800 0x40>;
 			dma-channels = <9>;
 			dma-buf-addr-alignment = <128>;
+			dma-buf-size-alignment = <32>;
+			dma-copy-alignment = <32>;
 
 			status = "okay";
 		};
@@ -66,6 +72,8 @@
 			reg = <0x00072c00 0x40>;
 			dma-channels = <7>;
 			dma-buf-addr-alignment = <128>;
+			dma-buf-size-alignment = <32>;
+			dma-copy-alignment = <32>;
 
 			status = "okay";
 		};

--- a/dts/xtensa/intel/intel_adsp_cavs.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs.dtsi
@@ -35,7 +35,7 @@
 			#dma-cells = <1>;
 			reg = <0x00072400 0x20>;
 			dma-channels = <4>;
-			dma-buf-alignment = <128>;
+			dma-buf-addr-alignment = <128>;
 
 			status = "okay";
 		};
@@ -45,7 +45,7 @@
 			#dma-cells = <1>;
 			reg = <0x00072600 0x20>;
 			dma-channels = <4>;
-			dma-buf-alignment = <128>;
+			dma-buf-addr-alignment = <128>;
 
 			status = "okay";
 		};
@@ -55,7 +55,7 @@
 			#dma-cells = <1>;
 			reg = <0x00072800 0x40>;
 			dma-channels = <9>;
-			dma-buf-alignment = <128>;
+			dma-buf-addr-alignment = <128>;
 
 			status = "okay";
 		};
@@ -65,7 +65,7 @@
 			#dma-cells = <1>;
 			reg = <0x00072c00 0x40>;
 			dma-channels = <7>;
-			dma-buf-alignment = <128>;
+			dma-buf-addr-alignment = <128>;
 
 			status = "okay";
 		};

--- a/dts/xtensa/intel/intel_adsp_cavs.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs.dtsi
@@ -15,6 +15,8 @@
 			shim = <0x00078400 0x100>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&cavs_intc3>;
+			dma-buf-size-alignment = <4>;
+			dma-copy-alignment = <4>;
 
 			status = "okay";
 		};
@@ -26,6 +28,8 @@
 			shim = <0x00078500 0x100>;
 			interrupts = <0x0F 0 0>;
 			interrupt-parent = <&cavs_intc3>;
+			dma-buf-size-alignment = <4>;
+			dma-copy-alignment = <4>;
 
 			status = "okay";
 		};

--- a/dts/xtensa/intel/intel_adsp_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs15.dtsi
@@ -191,6 +191,8 @@
 			reg = <0x00002400 0x20>;
 			dma-channels = <2>;
 			dma-buf-addr-alignment = <128>;
+			dma-buf-size-alignment = <32>;
+			dma-copy-alignment = <32>;
 
 			status = "okay";
 		};
@@ -201,6 +203,8 @@
 			reg = <0x00002600 0x20>;
 			dma-channels = <2>;
 			dma-buf-addr-alignment = <128>;
+			dma-buf-size-alignment = <32>;
+			dma-copy-alignment = <32>;
 
 			status = "okay";
 		};
@@ -211,6 +215,8 @@
 			reg = <0x00002800 0x40>;
 			dma-channels = <6>;
 			dma-buf-addr-alignment = <128>;
+			dma-buf-size-alignment = <32>;
+			dma-copy-alignment = <32>;
 
 			status = "okay";
 		};
@@ -221,6 +227,8 @@
 			reg = <0x00002c00 0x40>;
 			dma-channels = <7>;
 			dma-buf-addr-alignment = <128>;
+			dma-buf-size-alignment = <32>;
+			dma-copy-alignment = <32>;
 
 			status = "okay";
 		};

--- a/dts/xtensa/intel/intel_adsp_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs15.dtsi
@@ -170,6 +170,8 @@
 			shim = <0x00000c00 0x080>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&cavs_intc3>;
+			dma-buf-size-alignment = <4>;
+			dma-copy-alignment = <4>;
 
 			status = "okay";
 		};
@@ -181,6 +183,8 @@
 			shim = <0x00000c80 0x080>;
 			interrupts = <0x0F 0 0>;
 			interrupt-parent = <&cavs_intc3>;
+			dma-buf-size-alignment = <4>;
+			dma-copy-alignment = <4>;
 
 			status = "okay";
 		};

--- a/dts/xtensa/intel/intel_adsp_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs15.dtsi
@@ -190,7 +190,7 @@
 			#dma-cells = <1>;
 			reg = <0x00002400 0x20>;
 			dma-channels = <2>;
-			dma-buf-alignment = <128>;
+			dma-buf-addr-alignment = <128>;
 
 			status = "okay";
 		};
@@ -200,7 +200,7 @@
 			#dma-cells = <1>;
 			reg = <0x00002600 0x20>;
 			dma-channels = <2>;
-			dma-buf-alignment = <128>;
+			dma-buf-addr-alignment = <128>;
 
 			status = "okay";
 		};
@@ -210,7 +210,7 @@
 			#dma-cells = <1>;
 			reg = <0x00002800 0x40>;
 			dma-channels = <6>;
-			dma-buf-alignment = <128>;
+			dma-buf-addr-alignment = <128>;
 
 			status = "okay";
 		};
@@ -220,7 +220,7 @@
 			#dma-cells = <1>;
 			reg = <0x00002c00 0x40>;
 			dma-channels = <7>;
-			dma-buf-alignment = <128>;
+			dma-buf-addr-alignment = <128>;
 
 			status = "okay";
 		};

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -642,7 +642,7 @@ static inline uint32_t dma_burst_index(uint32_t burst)
 }
 
 /**
- * Get the device tree property describing the buffer alignment
+ * Get the device tree property describing the buffer address alignment
  *
  * Useful when statically defining or allocating buffers for DMA usage where
  * memory alignment often matters.
@@ -650,7 +650,7 @@ static inline uint32_t dma_burst_index(uint32_t burst)
  * @param node Node identifier, e.g. DT_NODELABEL(dma_0)
  * @return alignment Memory byte alignment required for DMA buffers
  */
-#define DMA_BUF_ALIGNMENT(node) DT_PROP(node, dma_buf_alignment)
+#define DMA_BUF_ADDR_ALIGNMENT(node) DT_PROP(node, dma_buf_addr_alignment)
 
 /**
  * @}

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -226,6 +226,7 @@ struct dma_status {
 	uint32_t free;
 	uint32_t write_position;
 	uint32_t read_position;
+	uint64_t total_copied;
 };
 
 /**

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -653,6 +653,25 @@ static inline uint32_t dma_burst_index(uint32_t burst)
 #define DMA_BUF_ADDR_ALIGNMENT(node) DT_PROP(node, dma_buf_addr_alignment)
 
 /**
+ * Get the device tree property describing the buffer size alignment
+ *
+ * Useful when statically defining or allocating buffers for DMA usage where
+ * memory alignment often matters.
+ *
+ * @param node Node identifier, e.g. DT_NODELABEL(dma_0)
+ * @return alignment Memory byte alignment required for DMA buffers
+ */
+#define DMA_BUF_SIZE_ALIGNMENT(node) DT_PROP(node, dma_buf_size_alignment)
+
+/**
+ * Get the device tree property describing the minimal chunk of data possible to be copied
+ *
+ * @param node Node identifier, e.g. DT_NODELABEL(dma_0)
+ * @return minimal Minimal chunk of data possible to be copied
+ */
+#define DMA_COPY_ALIGNMENT(node) DT_PROP(node, dma_copy_alignment)
+
+/**
  * @}
  */
 

--- a/subsys/logging/backends/log_backend_adsp_hda.c
+++ b/subsys/logging/backends/log_backend_adsp_hda.c
@@ -22,7 +22,7 @@ static uint32_t hda_log_chan;
 /*
  * HDA requires 128 byte aligned data and 128 byte aligned transfers.
  */
-#define ALIGNMENT DMA_BUF_ALIGNMENT(DT_NODELABEL(hda_host_in))
+#define ALIGNMENT DMA_BUF_ADDR_ALIGNMENT(DT_NODELABEL(hda_host_in))
 static __aligned(ALIGNMENT) uint8_t hda_log_buf[CONFIG_LOG_BACKEND_ADSP_HDA_SIZE];
 static volatile uint32_t hda_log_buffered;
 static struct k_timer hda_log_timer;

--- a/tests/boards/intel_adsp/hda/src/dma.c
+++ b/tests/boards/intel_adsp/hda/src/dma.c
@@ -14,7 +14,7 @@
 #define TRANSFER_SIZE 256
 #define TRANSFER_COUNT 8
 
-#define ALIGNMENT DMA_BUF_ALIGNMENT(DT_NODELABEL(hda_host_in))
+#define ALIGNMENT DMA_BUF_ADDR_ALIGNMENT(DT_NODELABEL(hda_host_in))
 static __aligned(ALIGNMENT) uint8_t dma_buf[DMA_BUF_SIZE];
 
 #define HDA_HOST_IN_BASE DT_PROP_BY_IDX(DT_NODELABEL(hda_host_in), reg, 0)

--- a/tests/boards/intel_adsp/hda/src/smoke.c
+++ b/tests/boards/intel_adsp/hda/src/smoke.c
@@ -20,7 +20,7 @@
 #define HDA_BUF_SIZE 256
 #define TRANSFER_COUNT 8
 
-#define ALIGNMENT DT_PROP(DT_NODELABEL(hda_host_in), dma_buf_alignment)
+#define ALIGNMENT DT_PROP(DT_NODELABEL(hda_host_in), dma_buf_addr_alignment)
 static __aligned(ALIGNMENT) uint8_t hda_buf[HDA_BUF_SIZE];
 
 static volatile int msg_cnt;

--- a/tests/drivers/adc/adc_dma/boards/frdm_k64f.overlay
+++ b/tests/drivers/adc/adc_dma/boards/frdm_k64f.overlay
@@ -12,7 +12,7 @@
 };
 
 &edma0 {
-	dma-buf-alignment = <4>;
+	dma-buf-addr-alignment = <4>;
 };
 
 test_dma: &edma0 { };

--- a/tests/drivers/adc/adc_dma/boards/frdm_k82f.overlay
+++ b/tests/drivers/adc/adc_dma/boards/frdm_k82f.overlay
@@ -12,7 +12,7 @@
 };
 
 &edma0 {
-        dma-buf-alignment = <4>;
+        dma-buf-addr-alignment = <4>;
 };
 
 test_dma: &edma0 { };

--- a/tests/drivers/adc/adc_dma/src/test_adc.c
+++ b/tests/drivers/adc/adc_dma/src/test_adc.c
@@ -38,7 +38,7 @@
 #define SAMPLE_INTERVAL_US (10000U)
 
 #define BUFFER_SIZE 24
-#define ALIGNMENT DMA_BUF_ALIGNMENT(DT_NODELABEL(test_dma))
+#define ALIGNMENT DMA_BUF_ADDR_ALIGNMENT(DT_NODELABEL(test_dma))
 static ZTEST_BMEM __aligned(ALIGNMENT) int16_t m_sample_buffer[BUFFER_SIZE];
 static ZTEST_BMEM __aligned(ALIGNMENT) int16_t m_sample_buffer2[2][BUFFER_SIZE];
 static int current_buf_inx;

--- a/west.yml
+++ b/west.yml
@@ -214,7 +214,7 @@ manifest:
       groups:
         - debug
     - name: sof
-      revision: 9b564ea205b9597d29971cac0b5dcd9312db84d4
+      revision: 6f5f7258ad2738df78e600568d38fc261e2a118d
       path: modules/audio/sof
     - name: tflite-micro
       revision: 9156d050927012da87079064db59d07f03b8baf6


### PR DESCRIPTION
This PR adds:
- new fields containing linear link position to the dma_status structure. 
- reading of the linear link position in the status function in adsp gpdma driver. 
- new get_attribute function to the dma api.
- get attribute function in dwdma and alh drivers.

PR at SOF side: https://github.com/thesofproject/sof/pull/6538