### PR TITLE
Bluetooth: Mesh: Fix args parsing in cmd_net_key_add function

### DIFF
--- a/subsys/bluetooth/mesh/shell/cfg.c
+++ b/subsys/bluetooth/mesh/shell/cfg.c
@@ -407,7 +407,7 @@ static int cmd_net_key_add(const struct shell *sh, size_t argc, char *argv[])
 	if (has_key_val) {
 		size_t len;
 
-		len = hex2bin(argv[3], strlen(argv[3]), key_val, sizeof(key_val));
+		len = hex2bin(argv[2], strlen(argv[2]), key_val, sizeof(key_val));
 		(void)memset(key_val, 0, sizeof(key_val) - len);
 	} else {
 		memcpy(key_val, bt_mesh_shell_default_key, sizeof(key_val));


### PR DESCRIPTION
cmd_net_key_add has only 2 arguments.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>