### PR TITLE
drivers/sensor: lsm6dso: Add drdy_pulsed property in DT

### DIFF
--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -894,6 +894,7 @@ static int lsm6dso_init(const struct device *dev)
 	.gyro_pm = DT_INST_PROP(inst, gyro_pm),				\
 	.gyro_odr = DT_INST_PROP(inst, gyro_odr),			\
 	.gyro_range = DT_INST_PROP(inst, gyro_range),			\
+	.drdy_pulsed = DT_INST_PROP(inst, drdy_pulsed),                 \
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),		\
 		(LSM6DSO_CFG_IRQ(inst)), ())
 

--- a/drivers/sensor/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/lsm6dso/lsm6dso.h
@@ -58,6 +58,7 @@ struct lsm6dso_config {
 	uint8_t gyro_pm;
 	uint8_t gyro_odr;
 	uint8_t gyro_range;
+	uint8_t drdy_pulsed;
 #ifdef CONFIG_LSM6DSO_TRIGGER
 	const struct gpio_dt_spec gpio_drdy;
 	uint8_t int_pin;

--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -287,10 +287,16 @@ int lsm6dso_init_interrupt(const struct device *dev)
 		return -EIO;
 	}
 
-	/* enable interrupt on int1/int2 in pulse mode */
-	if (lsm6dso_int_notification_set(ctx, LSM6DSO_ALL_INT_PULSED) < 0) {
-		LOG_DBG("Could not set pulse mode");
-		return -EIO;
+
+	/* set data ready mode on int1/int2 */
+	LOG_DBG("drdy_pulsed is %d", (int)cfg->drdy_pulsed);
+	lsm6dso_dataready_pulsed_t mode = cfg->drdy_pulsed ? LSM6DSO_DRDY_PULSED :
+							     LSM6DSO_DRDY_LATCHED;
+
+	ret = lsm6dso_data_ready_mode_set(ctx, mode);
+	if (ret < 0) {
+		LOG_ERR("drdy_pulsed config error %d", (int)cfg->drdy_pulsed);
+		return ret;
 	}
 
 	return gpio_pin_interrupt_configure_dt(&cfg->gpio_drdy,

--- a/dts/bindings/sensor/st,lsm6dso-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dso-common.yaml
@@ -116,3 +116,9 @@ properties:
         - 8  # 1667Hz
         - 9  # 3333Hz
         - 10 # 6667Hz
+
+    drdy-pulsed:
+      type: boolean
+      description: |
+        Selects the pulsed mode for data-ready interrupt when enabled,
+        and the latched mode when disabled.


### PR DESCRIPTION
Add drdy_pulsed property in Device Tree in order to select how data ready irq should behave (either pulsed or latched mode). Moreover change/fix the API called to set drdy irq mode. (fix #51944)

