### PR TITLE
ci: manifest: Drop west label for manifest updates

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -23,5 +23,5 @@ jobs:
           checkout-path: 'zephyrproject/zephyr'
           label-prefix: 'manifest-'
           verbosity-level: '1'
-          labels: 'manifest, west'
+          labels: 'manifest'
           dnm-labels: 'DNM'


### PR DESCRIPTION
This commit updates the manifest workflow to not label the pull requests updating the west manifest (`west.yml`) with the `west` label because the `manifest` label alone is enough for this purpose and the `west` label can be easily confused with the `area: West` label.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>