### PR TITLE
drivers: clock_control: stm32u5 enables the VCO input and EPOD

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -390,6 +390,62 @@ static void set_regu_voltage(uint32_t hclk_freq)
 	}
 }
 
+#if defined(STM32_PLL_ENABLED)
+/*
+ * Dynamic voltage scaling:
+ * Enable the Booster mode before enabling then PLL for sysclock above 55MHz
+ * The goal of this function is to set the epod prescaler, so that epod clock freq
+ * is between 4MHz and 16MHz.
+ * Up to now only MSI as PLL1 source clock can be > 16MHz, requiring a epod prescaler > 1
+ * For HSI16, epod prescaler is default (div1, not divided).
+ * Once HSE is > 16MHz, the epod prescaler would also be also required.
+ */
+static void set_epod_booster(void)
+{
+	/* Reset Epod Prescaler in case it was set earlier with another DIV value */
+	LL_PWR_DisableEPODBooster();
+	while (LL_PWR_IsActiveFlag_BOOST() == 1) {
+	}
+
+	LL_RCC_SetPll1EPodPrescaler(LL_RCC_PLL1MBOOST_DIV_1);
+
+	if (MHZ(55) <= CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) {
+		/*
+		 * Set EPOD clock prescaler based on PLL1 input freq
+		 * (MSI/PLLM  or HSE/PLLM when HSE is > 16MHz
+		 * Booster clock frequency should be between 4 and 16MHz
+		 * This is done in following steps:
+		 * Read MSI Frequency or HSE oscillaor freq
+		 * Divide PLL1 input freq (MSI/PLL or HSE/PLLM)
+		 * by the targeted freq (8MHz).
+		 * Make sure value is not higher than 16
+		 * Shift in the register space (/2)
+		 */
+		int tmp;
+
+		if (IS_ENABLED(STM32_PLL_SRC_MSIS)) {
+			tmp = __LL_RCC_CALC_MSIS_FREQ(LL_RCC_MSIRANGESEL_RUN,
+			 STM32_MSIS_RANGE << RCC_ICSCR1_MSISRANGE_Pos);
+		} else if (IS_ENABLED(STM32_PLL_SRC_HSE) && (MHZ(16) < STM32_HSE_FREQ)) {
+			tmp = STM32_HSE_FREQ;
+		} else {
+			return;
+		}
+
+		tmp = MIN(tmp / STM32_PLL_M_DIVISOR / 8000000, 16);
+		tmp = tmp / 2;
+
+		/* Configure the epod clock frequency between 4 and 16 MHz */
+		LL_RCC_SetPll1EPodPrescaler(tmp << RCC_PLL1CFGR_PLL1MBOOST_Pos);
+
+		/* Enable EPOD booster and wait for booster ready flag set */
+		LL_PWR_EnableEPODBooster();
+		while (LL_PWR_IsActiveFlag_BOOST() == 0) {
+		}
+	}
+}
+#endif /* STM32_PLL_ENABLED */
+
 __unused
 static void clock_switch_to_hsi(void)
 {
@@ -432,8 +488,7 @@ static int set_up_plls(void)
 
 	LL_RCC_PLL1_Disable();
 
-	/* Configure PLL source */
-	/* Can be HSE , HSI  MSI */
+	/* Configure PLL source : Can be HSE, HSI, MSIS */
 	if (IS_ENABLED(STM32_PLL_SRC_HSE)) {
 		/* Main PLL configuration and activation */
 		LL_RCC_PLL1_SetMainSource(LL_RCC_PLL1SOURCE_HSE);
@@ -447,6 +502,13 @@ static int set_up_plls(void)
 		return -ENOTSUP;
 	}
 
+	/*
+	 * Configure the EPOD booster
+	 * before increasing the system clock freq
+	 * and after pll clock source is set
+	 */
+	set_epod_booster();
+
 	r = get_vco_input_range(STM32_PLL_M_DIVISOR, &vco_input_range, PLL1_ID);
 	if (r < 0) {
 		return r;
@@ -454,6 +516,7 @@ static int set_up_plls(void)
 
 	LL_RCC_PLL1_SetDivider(STM32_PLL_M_DIVISOR);
 
+	/* Set VCO Input before enabling the PLL, depends on freq used for PLL1 */
 	LL_RCC_PLL1_SetVCOInputRange(vco_input_range);
 
 	LL_RCC_PLL1_SetN(STM32_PLL_N_MULTIPLIER);


### PR DESCRIPTION
With the stm32U5, when the sysclock is > 55 MHz, the EPOD booster must be configured before the PLL1 is enabled
(see sequence in the refMan). The VCO is in range 1 or 2. This is the case when sysclock is on PLL1 sourced by MSI.

Replaces the https://github.com/zephyrproject-rtos/zephyr/pull/44083

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/41606

Signed-off-by: Francois Ramu <francois.ramu@st.com>