### PR TITLE
ci: Do not run on third-party repositories 

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -8,6 +8,7 @@ concurrency:
 
 jobs:
   clang-build:
+    if: github.repository_owner == 'zephyrproject-rtos'
     runs-on: zephyr-runner-linux-x64-4xlarge
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.24.5

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   codecov:
+    if: github.repository == 'zephyrproject-rtos/zephyr'
     runs-on: zephyr-runner-linux-x64-4xlarge
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.24.5

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   twister-build-prep:
+    if: github.repository_owner == 'zephyrproject-rtos'
     runs-on: zephyr-runner-linux-x64-4xlarge
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.24.5


### PR DESCRIPTION
This series updates the CI workflows that, by design, cannot run on the downstream repositories to not run on them.