### PR TITLE
tests: bluetooth: mesh_shell: Disable BT_EXT_ADV for qemu_cortex_m3

### DIFF
--- a/tests/bluetooth/mesh_shell/testcase.yaml
+++ b/tests/bluetooth/mesh_shell/testcase.yaml
@@ -1,6 +1,10 @@
+common:
+  tags: bluetooth
+  harness: keyboard
 tests:
   bluetooth.mesh.mesh_shell:
-    platform_allow: qemu_cortex_m3 qemu_x86 nrf51dk_nrf51422
+    platform_allow: qemu_x86 nrf51dk_nrf51422
     platform_exclude: nrf52dk_nrf52810
-    tags: bluetooth
-    harness: keyboard
+  bluetooth.mesh.mesh_shell.legacy_adv:
+    platform_allow: qemu_cortex_m3
+    extra_args: CONFIG_BT_EXT_ADV=n


### PR DESCRIPTION
mesh_shell sample doesn't fit into flash with the extended advertising.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>