### PR TITLE
Bluetooth: ascs: Handle CIS disconnection in non-releasing state

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -933,6 +933,9 @@ static void ase_process(struct k_work *work)
 	if (ep_state == BT_AUDIO_EP_STATE_RELEASING) {
 		if (ep->iso == NULL ||
 		    ep->iso->chan.state == BT_ISO_STATE_DISCONNECTED) {
+			if (ep->iso != NULL) {
+				bt_audio_iso_unbind_ep(ep->iso, ep);
+			}
 			bt_audio_stream_detach(stream);
 			ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_IDLE);
 		} else {


### PR DESCRIPTION
Unbind ISO when goint to idle state if there's still reference kept. It may happen that we get CIS disconnection being in non-releasing state, so we have to handle that case. This fixes regression that was introduced in 3fa456905d0cebdca377165c320abd09bf751e3f.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>