### PR TITLE
MEC15xx pinctrl - remaining pins and registers

### DIFF
--- a/drivers/peci/peci_mchp_xec.c
+++ b/drivers/peci/peci_mchp_xec.c
@@ -444,6 +444,7 @@ static int peci_xec_init(const struct device *dev)
 {
 	const struct peci_xec_config * const cfg = dev->config;
 	struct peci_regs * const regs = cfg->regs;
+	struct ecs_regs * const ecs_regs = (struct ecs_regs *)(DT_REG_ADDR(DT_NODELABEL(ecs)));
 
 #ifdef CONFIG_PINCTRL
 	int ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
@@ -459,6 +460,8 @@ static int peci_xec_init(const struct device *dev)
 #endif
 
 	peci_clr_slp_en(dev);
+
+	ecs_regs->PECI_DIS = 0x00u;
 
 	/* Reset PECI interface */
 	regs->CONTROL |= MCHP_PECI_CTRL_RST;

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -67,6 +67,10 @@
 	};
 
 	soc {
+		ecs: ecs@4000fc00 {
+			compatible = "microchip,xec-ecs";
+			reg = <0x4000fc00 0x200>;
+		};
 		pcr: pcr@40080100 {
 			reg = <0x40080100 0x100 0x4000a400 0x100>;
 			reg-names = "pcrr", "vbatr";

--- a/dts/bindings/hwinfo/microchip,xec-ecs.yaml
+++ b/dts/bindings/hwinfo/microchip,xec-ecs.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2022 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Microchip EC Subsystem
+
+compatible: "microchip,xec-ecs"
+
+include: base.yaml
+
+properties:
+    reg:
+        required: true


### PR DESCRIPTION
Based on [issue #50665](https://github.com/zephyrproject-rtos/zephyr/issues/50665) the special pins and registers configured earlier in mec15xx pinmux have been updated.