### PR TITLE
doc: POSIX arch: Add link to POSIX OS abstraction

### DIFF
--- a/boards/posix/doc/arch_soc.rst
+++ b/boards/posix/doc/arch_soc.rst
@@ -25,7 +25,7 @@ target hardware in the early phases of development.
 .. note::
 
    The POSIX architecture is not related and should not be confused with the
-   POSIX OS abstraction.
+   :ref:`POSIX OS abstraction<posix_support>`.
    The later provides an adapatation shim that enables running applications
    which require POSIX APIs on Zephyr.
 

--- a/doc/services/portability/posix.rst
+++ b/doc/services/portability/posix.rst
@@ -1,3 +1,5 @@
+.. _posix_support:
+
 POSIX Support
 #############
 


### PR DESCRIPTION
In the note about the relationship between the POSIX arch and the POSIX OS abstraction, add a link.

