### PR TITLE
tests: sys_sem: no k_thread_access_grant call if not userspace

### DIFF
--- a/tests/kernel/mem_protect/sys_sem/src/main.c
+++ b/tests/kernel/mem_protect/sys_sem/src/main.c
@@ -570,6 +570,7 @@ ZTEST_USER(sys_sem_1cpu, test_sem_multiple_threads_wait)
 
 void *sys_sem_setup(void)
 {
+#ifdef CONFIG_USERSPACE
 	k_thread_access_grant(k_current_get(),
 			      &stack_1, &stack_2, &stack_3,
 			      &sem_tid, &sem_tid_1, &sem_tid_2);
@@ -578,6 +579,7 @@ void *sys_sem_setup(void)
 		k_thread_access_grant(k_current_get(),
 			&multiple_tid[i], &multiple_stack[i]);
 	}
+#endif
 
 	return NULL;
 }


### PR DESCRIPTION
The sys_sem.nouser test does not enable userspace which makes k_thread_access_grant() no-op. However, XCC would still emit LOOP instructions for the for-loop. Since there is nothing to do, the XCC assembler complains about it being an empty loop and errors out. So guard the k_thread_access_grant() calls so they are only compiled if userspace is enabled.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>