### PR TITLE
drivers: flash: sam0: init offset should be other then 0

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -193,6 +193,7 @@ Drivers and Sensors
 * Flash
 
   * NRF: Added CONFIG_SOC_FLASH_NRF_TIMEOUT_MULTIPLIER to allow tweaking the timeout of flash operations.
+  * SAM0: Fixes flash to write date at first block.
 
 * GPIO
 

--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -206,9 +206,9 @@ static int flash_sam0_commit(const struct device *dev)
 	int page;
 	off_t offset = ctx->offset;
 
-	ctx->offset = 0;
+	ctx->offset = -1;
 
-	if (offset == 0) {
+	if (offset == -1) {
 		return 0;
 	}
 
@@ -472,7 +472,11 @@ static const struct flash_driver_api flash_sam0_api = {
 #endif
 };
 
-static struct flash_sam0_data flash_sam0_data_0;
+static struct flash_sam0_data flash_sam0_data_0 = {
+#if CONFIG_SOC_FLASH_SAM0_EMULATE_BYTE_PAGES
+	.offset = -1,
+#endif
+};
 
 DEVICE_DT_INST_DEFINE(0, flash_sam0_init, NULL,
 		    &flash_sam0_data_0, NULL, POST_KERNEL,


### PR DESCRIPTION
This fixes problem if somebody wanted use
CONFIG_SOC_FLASH_SAM0_EMULATE_BYTE_PAGES and write some bytes at 0 -page size offset. Before changes program will truncate all data becouse initial offset was set to 0 and buffer wasn't be filled.

Signed-off-by: Kamil Serwus <kserwus@gmail.com>