### PR TITLE
tests: kernel: mem_protect: fix incorrect skip on mem_map test

### DIFF
--- a/tests/kernel/mem_protect/mem_map/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_map/testcase.yaml
@@ -8,7 +8,6 @@ tests:
     tags: kernel mmu ignore_faults
     filter: CONFIG_MMU and CONFIG_X86_64 and not CONFIG_COVERAGE
     extra_sections: _TRANSPLANTED_FUNC
-    platform_allow: qemu_x86_64
   kernel.memory_protection.mem_map.x86_64.coverage:
     tags: kernel mmu ignore_faults
     filter: CONFIG_MMU and CONFIG_X86_64 and CONFIG_COVERAGE


### PR DESCRIPTION
The mem_map test was skipped on all the phsical x86 boards when running twister to test them.
This error happens when migrating the new ztest. Remove the incorrect platform allow to fix this error.

Signed-off-by: Enjia Mai <enjia.mai@intel.com>