### PR TITLE
testsuite: coverage: create kconfig option for gcov dump heap size

### DIFF
--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -51,6 +51,14 @@ config COVERAGE_GCOV
 	  gen_gcov_files.py which creates the required .gcda files. These
 	  can be read by gcov utility. For more details see gcovr.com .
 
+config COVERAGE_GCOV_HEAP_SIZE
+	int "Size of heap allocated for gcov coverage data dump"
+	default 32768 if X86 || SOC_SERIES_MPS2
+	default 16384
+	help
+	  This option configures the heap size allocated for gcov coverage
+	  data to be dumped over serial.
+
 config COVERAGE_DUMP
 	bool "Dump coverage data on exit"
 	depends on COVERAGE_GCOV

--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -10,18 +10,7 @@
 #include <errno.h>
 #include "coverage.h"
 
-
-#if defined(CONFIG_X86) || defined(CONFIG_SOC_SERIES_MPS2)
-#define MALLOC_MAX_HEAP_SIZE 32768
-#define MALLOC_MIN_BLOCK_SIZE 128
-#else
-#define MALLOC_MAX_HEAP_SIZE 16384
-#define MALLOC_MIN_BLOCK_SIZE 64
-#endif
-
-
-K_HEAP_DEFINE(gcov_heap, MALLOC_MAX_HEAP_SIZE);
-
+K_HEAP_DEFINE(gcov_heap, CONFIG_COVERAGE_GCOV_HEAP_SIZE);
 
 static struct gcov_info *gcov_info_head;
 


### PR DESCRIPTION
The heap size for serial dump of gcov data is currently defined by MALLOC_MAX_HEAP_SIZE, which cannot be adjusted by kconfig. This commit adds a new kconfig option, CONFIG_COVERAGE_GCOV_HEAP_SIZE, which retains the behavior or MALLOC_MAX_HEAP_SIZE by default.

Signed-off-by: Jason Wright <jwright@synchron.com>

Closes #49234