### PR TITLE
tests: kernel: schedule_api: fix filter

### DIFF
--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -33,6 +33,7 @@ tests:
     extra_configs:
       - CONFIG_TIMESLICING=n
   kernel.scheduler.linker_generator:
+    filter: not CONFIG_SCHED_MULTIQ
     platform_allow: qemu_cortex_m3
     extra_configs:
       - CONFIG_TIMESLICING=y


### PR DESCRIPTION
Readd filter that was removed by mistake in a commit fixing meta-data.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
