### PR TITLE
twister: minor json report additions

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -698,8 +698,13 @@ class TwisterEnv:
                                      universal_newlines=True,
                                      cwd=ZEPHYR_BASE)
             if subproc.returncode == 0:
-                self.version = subproc.stdout.strip()
-                logger.info(f"Zephyr version: {self.version}")
+                _version = subproc.stdout.strip()
+                if _version:
+                    self.version = _version
+                    logger.info(f"Zephyr version: {self.version}")
+                else:
+                    self.version = "Unknown"
+                    logger.error("Coult not determine version")
         except OSError:
             logger.info("Cannot read zephyr version.")
 

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -13,6 +13,7 @@ import subprocess
 import shutil
 import re
 import argparse
+from datetime import datetime, timezone
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
@@ -662,6 +663,8 @@ class TwisterEnv:
     def __init__(self, options=None) -> None:
         self.version = None
         self.toolchain = None
+        self.commit_date = None
+        self.run_date = None
         self.options = options
         if options and options.ninja:
             self.generator_cmd = "ninja"
@@ -690,6 +693,7 @@ class TwisterEnv:
     def discover(self):
         self.check_zephyr_version()
         self.get_toolchain()
+        self.run_date = datetime.now(timezone.utc).isoformat(timespec='seconds')
 
     def check_zephyr_version(self):
         try:
@@ -708,6 +712,14 @@ class TwisterEnv:
         except OSError:
             logger.info("Cannot read zephyr version.")
 
+        subproc = subprocess.run(["git", "show", "-s", "--format=%cI", "HEAD"],
+                                     stdout=subprocess.PIPE,
+                                     universal_newlines=True,
+                                     cwd=ZEPHYR_BASE)
+        if subproc.returncode == 0:
+            self.commit_date = subproc.stdout.strip()
+        else:
+            self.commit_date = "Unknown"
 
     @staticmethod
     def run_cmake_script(args=[]):

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -237,7 +237,9 @@ class Reporting:
         report = {}
         report["environment"] = {"os": os.name,
                                  "zephyr_version": version,
-                                 "toolchain": self.env.toolchain
+                                 "toolchain": self.env.toolchain,
+                                 "commit_date": self.env.commit_date,
+                                 "run_date": self.env.run_date
                                  }
         suites = []
 


### PR DESCRIPTION
add both run and commit date and deal with issues getting version.

- twister: do not recorde a null version
- twister: set both commit and run date in json report
