### PR TITLE
MAINTAINERS: Promote attie-argentum as Atmel collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1863,6 +1863,7 @@ Microchip SAM Platforms:
   maintainers:
     - nandojve
   collaborators:
+    - attie-argentum
     - mnkp
     - stephanosio
   files:


### PR DESCRIPTION
@attie-argentum has been collaborating with SAM0 SoC for a few time. He seems to have good knowledge and it is motivated to assume more responsabilities on the project. This add @attie-argentum as a collaborator for Microchip SAM platforms.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>