### PR TITLE
include: posix: move pthread impl detail to posix_internal.h

### DIFF
--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -21,40 +21,9 @@
 extern "C" {
 #endif
 
-enum pthread_state {
-	/* The thread structure is unallocated and available for reuse. */
-	PTHREAD_TERMINATED = 0,
-	/* The thread is running and joinable. */
-	PTHREAD_JOINABLE,
-	/* The thread is running and detached. */
-	PTHREAD_DETACHED,
-	/* A joinable thread exited and its return code is available. */
-	PTHREAD_EXITED
-};
-
-struct posix_thread {
-	struct k_thread thread;
-
-	/* List of keys that thread has called pthread_setspecific() on */
-	sys_slist_t key_list;
-
-	/* Exit status */
-	void *retval;
-
-	/* Pthread cancellation */
-	int cancel_state;
-	int cancel_pending;
-	pthread_mutex_t cancel_lock;
-
-	/* Pthread State */
-	enum pthread_state state;
-	pthread_mutex_t state_lock;
-	pthread_cond_t state_cond;
-};
-
 /* Pthread detach/joinable */
-#define PTHREAD_CREATE_JOINABLE     PTHREAD_JOINABLE
-#define PTHREAD_CREATE_DETACHED     PTHREAD_DETACHED
+#define PTHREAD_CREATE_JOINABLE     1
+#define PTHREAD_CREATE_DETACHED     2
 
 /* Pthread cancellation */
 #define _PTHREAD_CANCEL_POS	0

--- a/lib/posix/posix_internal.h
+++ b/lib/posix/posix_internal.h
@@ -7,6 +7,37 @@
 #ifndef ZEPHYR_LIB_POSIX_POSIX_INTERNAL_H_
 #define ZEPHYR_LIB_POSIX_POSIX_INTERNAL_H_
 
+enum pthread_state {
+	/* The thread structure is unallocated and available for reuse. */
+	PTHREAD_TERMINATED = 0,
+	/* The thread is running and joinable. */
+	PTHREAD_JOINABLE = PTHREAD_CREATE_JOINABLE,
+	/* The thread is running and detached. */
+	PTHREAD_DETACHED = PTHREAD_CREATE_DETACHED,
+	/* A joinable thread exited and its return code is available. */
+	PTHREAD_EXITED
+};
+
+struct posix_thread {
+	struct k_thread thread;
+
+	/* List of keys that thread has called pthread_setspecific() on */
+	sys_slist_t key_list;
+
+	/* Exit status */
+	void *retval;
+
+	/* Pthread cancellation */
+	int cancel_state;
+	int cancel_pending;
+	pthread_mutex_t cancel_lock;
+
+	/* Pthread State */
+	enum pthread_state state;
+	pthread_mutex_t state_lock;
+	pthread_cond_t state_cond;
+};
+
 struct posix_thread *to_posix_thread(pthread_t pthread);
 
 #endif


### PR DESCRIPTION
The `struct pthread` and `enum pthread_state` are actually implementation details specific to Zephyr.

Let's limit the scope where that level of detail is visible.
