### PR TITLE
unittest: update coverage flags for non gcc toolchains

### DIFF
--- a/cmake/compiler/clang/generic.cmake
+++ b/cmake/compiler/clang/generic.cmake
@@ -5,6 +5,7 @@ if(DEFINED TOOLCHAIN_HOME)
 endif()
 
 find_program(CMAKE_C_COMPILER clang ${find_program_clang_args})
+find_program(CMAKE_CXX_COMPILER clang++ ${find_program_clang_args})
 find_program(CMAKE_LLVM_COV llvm-cov ${find_program_clang_args})
 set(CMAKE_GCOV "${CMAKE_LLVM_COV} gcov")
 

--- a/cmake/linker/lld/linker_flags.cmake
+++ b/cmake/linker/lld/linker_flags.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2022 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Since lld is a drop in replacement for ld, we can just use ld's flags
+include(${ZEPHYR_BASE}/cmake/linker/ld/${COMPILER}/linker_flags.cmake OPTIONAL)

--- a/cmake/modules/FindDeprecated.cmake
+++ b/cmake/modules/FindDeprecated.cmake
@@ -74,10 +74,12 @@ if(NOT "${Deprecated_FIND_COMPONENTS}" STREQUAL "")
 endif()
 
 if("SOURCES" IN_LIST Deprecated_FIND_COMPONENTS)
-  message(DEPRECATION
-      "Setting SOURCES prior to calling find_package() for unit tests is deprecated."
-      "To add sources after find_package() use:\n"
-      "    target_sources(testbinary PRIVATE <source-file.c>)")
+  if(SOURCES)
+    message(DEPRECATION
+        "Setting SOURCES prior to calling find_package() for unit tests is deprecated."
+        " To add sources after find_package() use:\n"
+        "    target_sources(testbinary PRIVATE <source-file.c>)")
+  endif()
 endif()
 
 set(Deprecated_FOUND True)

--- a/cmake/modules/FindHostTools.cmake
+++ b/cmake/modules/FindHostTools.cmake
@@ -66,7 +66,7 @@ find_program(BOSSAC bossac)
 find_program(IMGTOOL imgtool)
 
 # Pick host system's toolchain if we are targeting posix
-if("${ARCH}" STREQUAL "posix")
+if("${ARCH}" STREQUAL "posix" OR "${ARCH}" STREQUAL "unit_testing")
   if(NOT "${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "llvm")
     set(ZEPHYR_TOOLCHAIN_VARIANT "host")
   endif()

--- a/cmake/modules/unittest.cmake
+++ b/cmake/modules/unittest.cmake
@@ -2,13 +2,17 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-enable_language(C CXX ASM)
-
 include(root)
 include(boards)
 include(arch)
 include(configuration_files)
 include(kconfig)
+
+find_package(TargetTools)
+
+enable_language(C CXX ASM)
+
+include(${ZEPHYR_BASE}/cmake/target_toolchain_flags.cmake)
 
 # Parameters:
 #   SOURCES: list of source files, default main.c
@@ -33,12 +37,13 @@ if((NOT DEFINED ZEPHYR_BASE) AND (DEFINED ENV_ZEPHYR_BASE))
   set(ZEPHYR_BASE ${ENV_ZEPHYR_BASE} CACHE PATH "Zephyr base")
 endif()
 
+find_package(Deprecated COMPONENTS SOURCES)
+
 if(NOT SOURCES AND EXISTS main.c)
   set(SOURCES main.c)
 endif()
 
 add_executable(testbinary ${SOURCES})
-find_package(Deprecated COMPONENTS SOURCES)
 add_library(test_interface INTERFACE)
 target_link_libraries(testbinary PRIVATE test_interface)
 
@@ -89,16 +94,9 @@ target_link_libraries(testbinary PRIVATE
   )
 
 if(COVERAGE)
-  target_compile_options(test_interface INTERFACE
-    -fno-default-inline
-    -fno-inline
-    -fprofile-arcs
-    -ftest-coverage
-    )
+  target_compile_options(test_interface INTERFACE $<TARGET_PROPERTY:compiler,coverage>)
 
-  target_link_libraries(testbinary PRIVATE
-    -lgcov
-    )
+  target_link_libraries(testbinary PRIVATE $<TARGET_PROPERTY:linker,coverage>)
 endif()
 
 if(LIBS)

--- a/tests/unit/crc/CMakeLists.txt
+++ b/tests/unit/crc/CMakeLists.txt
@@ -2,6 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-project(crc)
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(crc)
 target_sources(testbinary PRIVATE main.c)


### PR DESCRIPTION
When building with clang, the unittests were giving us an error:
```
error: undefined symbol: llvm_gcda_start_file
```

This seems to be from linking in `gcov` regardless of the toolchain.