### PR TITLE
Bluetooth: Host: Add auto conn param update retry count and timeout

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -628,7 +628,6 @@ config BT_CONN_PARAM_UPDATE_TIMEOUT
 	int "Peripheral connection parameter update timeout in milliseconds"
 	default 5000
 	range 0 65535
-
 	help
 	  The value is a timeout used by peripheral device to wait until it
 	  starts the first connection parameters update procedure after a
@@ -640,6 +639,23 @@ config BT_CONN_PARAM_UPDATE_TIMEOUT
 	  Core specification: Core 4.2 Vol 3, Part C, 9.3.12.2:
 	  "The Peripheral device should not perform a Connection Parameter
 	  Update procedure within 5 seconds after establishing a connection."
+
+config BT_CONN_PARAM_RETRY_COUNT
+	int "Peripheral connection parameter update retry attempts"
+	default 3
+	range 0 255
+	help
+	  This value corresponds to number of times to retry connection
+	  parameter update to attain the preferred value set in GATT
+	  characteristics in the Peripheral.
+
+config BT_CONN_PARAM_RETRY_TIMEOUT
+	int "Peripheral connection parameter update retry timeout in milliseconds"
+	default 5000
+	range 0 65535
+	help
+	  The value is a timeout used by peripheral device to wait until retry
+	  to attempt requesting again the preferred connection parameters.
 
 endif # BT_CONN
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -33,6 +33,7 @@ enum {
 	BT_CONN_BR_PAIRING_INITIATOR,         /* local host starts authentication */
 	BT_CONN_CLEANUP,                      /* Disconnected, pending cleanup */
 	BT_CONN_PERIPHERAL_PARAM_UPDATE,      /* If periph param update timer fired */
+	BT_CONN_PERIPHERAL_PARAM_AUTO_UPDATE, /* If periph param auto update on timer fired */
 	BT_CONN_PERIPHERAL_PARAM_SET,         /* If periph param were set from app */
 	BT_CONN_PERIPHERAL_PARAM_L2CAP,       /* If should force L2CAP for CPUP */
 	BT_CONN_FORCE_PAIR,                   /* Pairing even with existing keys. */
@@ -67,6 +68,10 @@ struct bt_conn_le {
 	uint16_t timeout;
 	uint16_t pending_latency;
 	uint16_t pending_timeout;
+
+#if defined(CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS)
+	uint8_t  conn_param_retry_countdown;
+#endif
 
 	uint8_t features[8];
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -26,54 +26,54 @@ typedef enum __packed {
 /* bt_conn flags: the flags defined here represent connection parameters */
 enum {
 	BT_CONN_AUTO_CONNECT,
-	BT_CONN_BR_LEGACY_SECURE,	/* 16 digits legacy PIN tracker */
-	BT_CONN_USER,			/* user I/O when pairing */
-	BT_CONN_BR_PAIRING,		/* BR connection in pairing context */
-	BT_CONN_BR_NOBOND,		/* SSP no bond pairing tracker */
-	BT_CONN_BR_PAIRING_INITIATOR,	/* local host starts authentication */
-	BT_CONN_CLEANUP,                /* Disconnected, pending cleanup */
-	BT_CONN_PERIPHERAL_PARAM_UPDATE,/* If periph param update timer fired */
-	BT_CONN_PERIPHERAL_PARAM_SET,	/* If periph param were set from app */
-	BT_CONN_PERIPHERAL_PARAM_L2CAP,	/* If should force L2CAP for CPUP */
-	BT_CONN_FORCE_PAIR,             /* Pairing even with existing keys. */
+	BT_CONN_BR_LEGACY_SECURE,             /* 16 digits legacy PIN tracker */
+	BT_CONN_USER,                         /* user I/O when pairing */
+	BT_CONN_BR_PAIRING,                   /* BR connection in pairing context */
+	BT_CONN_BR_NOBOND,                    /* SSP no bond pairing tracker */
+	BT_CONN_BR_PAIRING_INITIATOR,         /* local host starts authentication */
+	BT_CONN_CLEANUP,                      /* Disconnected, pending cleanup */
+	BT_CONN_PERIPHERAL_PARAM_UPDATE,      /* If periph param update timer fired */
+	BT_CONN_PERIPHERAL_PARAM_SET,         /* If periph param were set from app */
+	BT_CONN_PERIPHERAL_PARAM_L2CAP,       /* If should force L2CAP for CPUP */
+	BT_CONN_FORCE_PAIR,                   /* Pairing even with existing keys. */
 #if defined(CONFIG_BT_GATT_CLIENT)
-	BT_CONN_ATT_MTU_EXCHANGED,	/* If ATT MTU has been exchanged. */
+	BT_CONN_ATT_MTU_EXCHANGED,            /* If ATT MTU has been exchanged. */
 #endif /* CONFIG_BT_GATT_CLIENT */
 
-	BT_CONN_AUTO_FEATURE_EXCH,	/* Auto-initiated LE Feat done */
-	BT_CONN_AUTO_VERSION_INFO,      /* Auto-initiated LE version done */
+	BT_CONN_AUTO_FEATURE_EXCH,            /* Auto-initiated LE Feat done */
+	BT_CONN_AUTO_VERSION_INFO,            /* Auto-initiated LE version done */
 
-	BT_CONN_CTE_RX_ENABLED,          /* CTE receive and sampling is enabled */
-	BT_CONN_CTE_RX_PARAMS_SET,       /* CTE parameters are set */
-	BT_CONN_CTE_TX_PARAMS_SET,       /* CTE transmission parameters are set */
-	BT_CONN_CTE_REQ_ENABLED,         /* CTE request procedure is enabled */
-	BT_CONN_CTE_RSP_ENABLED,         /* CTE response procedure is enabled */
+	BT_CONN_CTE_RX_ENABLED,               /* CTE receive and sampling is enabled */
+	BT_CONN_CTE_RX_PARAMS_SET,            /* CTE parameters are set */
+	BT_CONN_CTE_TX_PARAMS_SET,            /* CTE transmission parameters are set */
+	BT_CONN_CTE_REQ_ENABLED,              /* CTE request procedure is enabled */
+	BT_CONN_CTE_RSP_ENABLED,              /* CTE response procedure is enabled */
 
 	/* Total number of flags - must be at the end of the enum */
 	BT_CONN_NUM_FLAGS,
 };
 
 struct bt_conn_le {
-	bt_addr_le_t		dst;
+	bt_addr_le_t dst;
 
-	bt_addr_le_t		init_addr;
-	bt_addr_le_t		resp_addr;
+	bt_addr_le_t init_addr;
+	bt_addr_le_t resp_addr;
 
-	uint16_t			interval;
-	uint16_t			interval_min;
-	uint16_t			interval_max;
+	uint16_t interval;
+	uint16_t interval_min;
+	uint16_t interval_max;
 
-	uint16_t			latency;
-	uint16_t			timeout;
-	uint16_t			pending_latency;
-	uint16_t			pending_timeout;
+	uint16_t latency;
+	uint16_t timeout;
+	uint16_t pending_latency;
+	uint16_t pending_timeout;
 
-	uint8_t			features[8];
+	uint8_t features[8];
 
-	struct bt_keys		*keys;
+	struct bt_keys *keys;
 
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
-	struct bt_conn_le_phy_info      phy;
+	struct bt_conn_le_phy_info phy;
 #endif
 
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)


### PR DESCRIPTION
Add implementation to retry the automatic peripheral
perferred connection parameter request with a configurable
retry countdown and retry back-off timeout.

Fixes #51984.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>