### PR TITLE
Bluetooth: Controller: Add Long Control PDU support

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -657,6 +657,11 @@ void lll_conn_rx_pkt_set(struct lll_conn *lll)
 	max_rx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
 #endif /* !CONFIG_BT_CTLR_DATA_LENGTH */
 
+	if ((PDU_DC_CTRL_RX_SIZE_MAX > PDU_DC_PAYLOAD_SIZE_MIN) &&
+	    (max_rx_octets < PDU_DC_CTRL_RX_SIZE_MAX)) {
+		max_rx_octets = PDU_DC_CTRL_RX_SIZE_MAX;
+	}
+
 #if defined(CONFIG_BT_CTLR_PHY)
 	phy = lll->phy_rx;
 #else /* !CONFIG_BT_CTLR_PHY */
@@ -708,6 +713,11 @@ void lll_conn_tx_pkt_set(struct lll_conn *lll, struct pdu_data *pdu_data_tx)
 #else /* !CONFIG_BT_CTLR_DATA_LENGTH */
 	max_tx_octets = PDU_DC_PAYLOAD_SIZE_MIN;
 #endif /* !CONFIG_BT_CTLR_DATA_LENGTH */
+
+	if ((PDU_DC_CTRL_TX_SIZE_MAX > PDU_DC_PAYLOAD_SIZE_MIN) &&
+	    (max_tx_octets < PDU_DC_CTRL_TX_SIZE_MAX)) {
+		max_tx_octets = PDU_DC_CTRL_TX_SIZE_MAX;
+	}
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	phy = lll->phy_tx;
@@ -788,7 +798,9 @@ void lll_conn_pdu_tx_prep(struct lll_conn *lll, struct pdu_data **pdu_data_tx)
 
 		max_tx_octets = ull_conn_lll_max_tx_octets_get(lll);
 
-		if (p->len > max_tx_octets) {
+		if (((PDU_DC_CTRL_TX_SIZE_MAX <= PDU_DC_PAYLOAD_SIZE_MIN) ||
+		     (p->ll_id != PDU_DATA_LLID_CTRL)) &&
+		    (p->len > max_tx_octets)) {
 			p->len = max_tx_octets;
 			p->md = 1U;
 		} else if ((link->next != lll->memq_tx.tail) ||

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -102,6 +102,76 @@
 #define PDU_DC_PAYLOAD_TIME_MAX       2120
 #endif /* !CONFIG_BT_CTLR_DF */
 
+/* Data channel control PDU maximum payload size */
+#if defined(CONFIG_BT_CONN)
+#if defined(CONFIG_BT_CTLR_CONN_ISO)
+#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_PERIPHERAL)
+/* Isochronous Central and Peripheral */
+#define PDU_DC_CTRL_TX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(cis_req)
+#define PDU_DC_CTRL_RX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(cis_req)
+#elif defined(CONFIG_BT_CENTRAL)
+/* Isochronous Central */
+#define PDU_DC_CTRL_TX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(cis_req)
+#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
+#define PDU_DC_CTRL_RX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(conn_param_req)
+#elif defined(CONFIG_BT_CTLR_LE_ENC)
+#define PDU_DC_CTRL_RX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(enc_rsp)
+#else /* !CONFIG_BT_CTLR_LE_ENC */
+#define PDU_DC_CTRL_RX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(cis_rsp)
+#endif /* !CONFIG_BT_CTLR_LE_ENC */
+#elif defined(CONFIG_BT_PERIPHERAL)
+/* Isochronous Peripheral */
+#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
+#define PDU_DC_CTRL_TX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(conn_param_req)
+#elif defined(CONFIG_BT_CTLR_LE_ENC)
+#define PDU_DC_CTRL_TX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(enc_rsp)
+#else /* !CONFIG_BT_CTLR_LE_ENC */
+#define PDU_DC_CTRL_TX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(cis_rsp)
+#endif /* !CONFIG_BT_CTLR_LE_ENC */
+#define PDU_DC_CTRL_RX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(cis_req)
+#endif /* !CONFIG_BT_PERIPHERAL */
+
+#elif defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
+/* Central and Peripheral with Connection Parameter Request */
+#define PDU_DC_CTRL_TX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(conn_param_req)
+#define PDU_DC_CTRL_RX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(conn_param_req)
+
+#elif defined(CONFIG_BT_CTLR_LE_ENC)
+#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_PERIPHERAL)
+/* Central and Peripheral with encryption */
+#define PDU_DC_CTRL_TX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(enc_req)
+#define PDU_DC_CTRL_RX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(enc_req)
+#elif defined(CONFIG_BT_CENTRAL)
+/* Central with encryption */
+#define PDU_DC_CTRL_TX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(enc_req)
+#define PDU_DC_CTRL_RX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(enc_rsp)
+#elif defined(CONFIG_BT_PERIPHERAL)
+/* Peripheral with encryption */
+#define PDU_DC_CTRL_TX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(enc_rsp)
+#define PDU_DC_CTRL_RX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(enc_req)
+#endif /* !CONFIG_BT_PERIPHERAL */
+
+#else /* !CONFIG_BT_CTLR_LE_ENC */
+#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_PERIPHERAL)
+/* Central and Peripheral without encryption */
+#define PDU_DC_CTRL_TX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(conn_update_ind)
+#define PDU_DC_CTRL_RX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(conn_update_ind)
+#elif defined(CONFIG_BT_CENTRAL)
+/* Central without encryption */
+#define PDU_DC_CTRL_TX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(conn_update_ind)
+#define PDU_DC_CTRL_RX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(feature_rsp)
+#elif defined(CONFIG_BT_PERIPHERAL)
+/* Peripheral without encryption */
+#define PDU_DC_CTRL_TX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(feature_rsp)
+#define PDU_DC_CTRL_RX_SIZE_MAX       PDU_DATA_LLCTRL_LEN(conn_update_ind)
+#endif /* !CONFIG_BT_PERIPHERAL */
+#endif /* !CONFIG_BT_CTLR_LE_ENC */
+
+#else /* !CONFIG_BT_CONN */
+#define PDU_DC_CTRL_TX_SIZE_MAX       0U
+#define PDU_DC_CTRL_RX_SIZE_MAX       0U
+#endif /* !CONFIG_BT_CONN */
+
 /* Link Layer header size of Data PDU. Assumes pdu_data is packed */
 #define PDU_DC_LL_HEADER_SIZE  (offsetof(struct pdu_data, lldata))
 

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -406,11 +406,14 @@ static MFIFO_DEFINE(pdu_rx_free, sizeof(void *), PDU_RX_CNT);
 #define PDU_DATA_SIZE MAX((PDU_DC_LL_HEADER_SIZE + LL_LENGTH_OCTETS_RX_MAX), \
 			  (PDU_BIS_LL_HEADER_SIZE + LL_BIS_OCTETS_RX_MAX))
 
+#define PDU_CTRL_SIZE (PDU_DC_LL_HEADER_SIZE + PDU_DC_CTRL_RX_SIZE_MAX)
+
 #define NODE_RX_HEADER_SIZE (offsetof(struct node_rx_pdu, pdu))
 
 #define PDU_RX_NODE_POOL_ELEMENT_SIZE MROUND(NODE_RX_HEADER_SIZE + \
 					     MAX(MAX(PDU_ADV_SIZE, \
-						     PDU_DATA_SIZE), \
+						     MAX(PDU_DATA_SIZE, \
+							 PDU_CTRL_SIZE)), \
 						 PDU_RX_USER_PDU_OCTETS_MAX))
 
 #if defined(CONFIG_BT_CTLR_ADV_ISO_SET)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -207,7 +207,7 @@ static uint8_t force_md_cnt_calc(struct lll_conn *lll_conn, uint32_t tx_rate);
 #endif /* !CONFIG_BT_LL_SW_LLCP_LEGACY */
 #define CONN_TX_CTRL_BUF_SIZE MROUND(offsetof(struct node_tx, pdu) + \
 				     offsetof(struct pdu_data, llctrl) + \
-				     sizeof(struct pdu_data_llctrl))
+				     PDU_DC_CTRL_TX_SIZE_MAX)
 
 /* Terminate procedure state values */
 #define TERM_REQ   1


### PR DESCRIPTION
Add long control PDU size support, also the implementation now allocates control PDU size restricted to the supported biggest control PDU that is enabled in the application build. Features that are covered based on the increasing control PDU sizes are ClearText connections, Encrypted Connections, Connection Parameter Request support and Create CIS control Procedure (Connected Central ISO) support.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>