### PR TITLE
boards: nrf9160dk: add missing kernel include

### DIFF
--- a/boards/arm/nrf9160dk_nrf9160/nrf52840_reset.c
+++ b/boards/arm/nrf9160dk_nrf9160/nrf52840_reset.c
@@ -8,6 +8,7 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
 
 #define RESET_NODE DT_NODELABEL(nrf52840_reset)
 


### PR DESCRIPTION
Include <zephyr/kernel.h> needed for k_sleep() and K_MSEC().

Signed-off-by: Tomasz Moń <tomasz.mon@nordicsemi.no>