### PR TITLE
Bluetooth: controller: fix post DLE/PHY update event length

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -459,6 +459,14 @@ config BT_CTLR_CENTRAL_SPACING
 	  (active clock jitter) + 17040 (PDU rx) = (radio event overheads +
 	  34234) microseconds.
 
+config BT_CTLR_SLOT_RESERVATION_UPDATE
+	bool "Update event length reservation after PHY or DLE update"
+	depends on !BT_LL_SW_LLCP_LEGACY && (BT_CTLR_DATA_LENGTH || BT_CTLR_PHY)
+	default y
+	help
+	  Updates the event length reservation after a completed Data Length Update
+	  and/or PHY Update procedure to avoid overlap of radio events
+
 config BT_CTLR_LLL_PRIO
 	int "Lower Link Layer (Radio) IRQ priority" if (BT_CTLR_ULL_LLL_PRIO_SUPPORT && !BT_CTLR_ZLI)
 	range 0 3 if SOC_SERIES_NRF51X

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -136,10 +136,12 @@ struct lll_conn {
 	struct ccm ccm_tx;
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
+#if defined(CONFIG_BT_CTLR_SLOT_RESERVATION_UPDATE)
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH) || defined(CONFIG_BT_CTLR_PHY)
 	uint8_t evt_len_upd:1;
 	uint8_t evt_len_upd_delayed:1;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH || CONFIG_BT_CTLR_PHY */
+#endif /* CONFIG_BT_CTLR_SLOT_RESERVATION_UPDATE */
 
 #if defined(CONFIG_BT_CTLR_CONN_RSSI)
 	uint8_t  rssi_latest;

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -102,7 +102,9 @@ struct lll_conn {
 		struct data_pdu_length local;
 		struct data_pdu_length remote;
 		struct data_pdu_length eff;
+#if defined(CONFIG_BT_CTLR_PHY)
 		uint16_t default_tx_time;
+#endif
 		uint16_t default_tx_octets;
 		uint8_t update;
 	} dle;
@@ -133,6 +135,11 @@ struct lll_conn {
 	struct ccm ccm_rx;
 	struct ccm ccm_tx;
 #endif /* CONFIG_BT_CTLR_LE_ENC */
+
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH) || defined(CONFIG_BT_CTLR_PHY)
+	uint8_t evt_len_upd:1;
+	uint8_t evt_len_upd_delayed:1;
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH || CONFIG_BT_CTLR_PHY */
 
 #if defined(CONFIG_BT_CTLR_CONN_RSSI)
 	uint8_t  rssi_latest;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1871,7 +1871,7 @@ void ull_conn_done(struct node_rx_event_done *done)
 		lazy = lll->latency_event + 1U;
 	}
 
-#if !defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
+#if !defined(CONFIG_BT_LL_SW_LLCP_LEGACY) && defined(CONFIG_BT_CTLR_SLOT_RESERVATION_UPDATE)
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH) || defined(CONFIG_BT_CTLR_PHY)
 	if (lll->evt_len_upd) {
 		uint32_t ready_delay, rx_time, tx_time, ticks_slot;
@@ -1912,10 +1912,10 @@ void ull_conn_done(struct node_rx_event_done *done)
 		conn->ull.ticks_slot = ticks_slot;
 	}
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH || CONFIG_BT_CTLR_PHY */
-#else /* !CONFIG_BT_LL_SW_LLCP_LEGACY */
+#else /* !CONFIG_BT_LL_SW_LLCP_LEGACY && CONFIG_BT_CTLR_SLOT_RESERVATION_UPDATE */
 	ticks_slot_plus = 0;
 	ticks_slot_minus = 0;
-#endif /* !CONFIG_BT_LL_SW_LLCP_LEGACY */
+#endif /* !CONFIG_BT_LL_SW_LLCP_LEGACY && CONFIG_BT_CTLR_SLOT_RESERVATION_UPDATE */
 
 	/* update conn ticker */
 	if (ticks_drift_plus || ticks_drift_minus ||
@@ -8276,9 +8276,11 @@ uint8_t ull_dle_update_eff(struct ll_conn *conn)
 	/* Note that we must use bitwise or and not logical or */
 	dle_changed = ull_dle_update_eff_rx(conn);
 	dle_changed |= ull_dle_update_eff_tx(conn);
+#if defined(CONFIG_BT_CTLR_SLOT_RESERVATION_UPDATE)
 	if (dle_changed) {
 		conn->lll.evt_len_upd = 1U;
 	}
+#endif
 
 
 	return dle_changed;
@@ -8312,10 +8314,12 @@ uint8_t ull_dle_update_eff_rx(struct ll_conn *conn)
 		conn->lll.dle.eff.max_rx_octets = eff_rx_octets;
 		dle_changed = 1U;
 	}
+#if defined(CONFIG_BT_CTLR_SLOT_RESERVATION_UPDATE)
 	/* we delay the update of event length to after the DLE procedure is finishede */
 	if (dle_changed) {
 		conn->lll.evt_len_upd_delayed = 1;
 	}
+#endif
 
 	return dle_changed;
 }
@@ -8350,11 +8354,13 @@ uint8_t ull_dle_update_eff_tx(struct ll_conn *conn)
 		dle_changed = 1U;
 	}
 
+#if defined(CONFIG_BT_CTLR_SLOT_RESERVATION_UPDATE)
 	if (dle_changed) {
 		conn->lll.evt_len_upd = 1U;
 	}
 	conn->lll.evt_len_upd |= conn->lll.evt_len_upd_delayed;
 	conn->lll.evt_len_upd_delayed = 0;
+#endif
 
 	return dle_changed;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -303,7 +303,9 @@ static uint8_t pu_update_eff_times(struct ll_conn *conn, struct proc_ctx *ctx)
 	    (lll->dle.eff.max_rx_time > max_rx_time)) {
 		lll->dle.eff.max_tx_time = eff_tx_time;
 		lll->dle.eff.max_rx_time = eff_rx_time;
+#if defined(CONFIG_BT_CTLR_SLOT_RESERVATION_UPDATE)
 		lll->evt_len_upd = 1U;
+#endif /* CONFIG_BT_CTLR_SLOT_RESERVATION_UPDATE */
 		return 1U;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -303,6 +303,7 @@ static uint8_t pu_update_eff_times(struct ll_conn *conn, struct proc_ctx *ctx)
 	    (lll->dle.eff.max_rx_time > max_rx_time)) {
 		lll->dle.eff.max_tx_time = eff_tx_time;
 		lll->dle.eff.max_rx_time = eff_rx_time;
+		lll->evt_len_upd = 1U;
 		return 1U;
 	}
 

--- a/tests/bluetooth/controller/mock_ctrl/src/lll.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/lll.c
@@ -59,3 +59,9 @@ uint32_t lll_radio_tx_ready_delay_get(uint8_t phy, uint8_t flags)
 void lll_disable(void *param)
 {
 }
+
+
+uint32_t lll_radio_rx_ready_delay_get(uint8_t phy, uint8_t flags)
+{
+	return 0;
+}


### PR DESCRIPTION
Fix the controller implementation to perform connection event length reservation based on the completed Data Length Update and/or PHY Update Procedure.

Note: some optimisation is possible with regards to the length allocated, currently the maximum rx and tx time are used, which leaves a lot of unused airtime in case that the 2M phy is used. If necessary this will be fixed in a separate PR
fixes #21995
fixes #52393
Fixes #53049

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>