### PR TITLE
scripts: west_commands: sign: multi-image support

### DIFF
--- a/doc/develop/west/sign.rst
+++ b/doc/develop/west/sign.rst
@@ -7,6 +7,16 @@ The ``west sign`` :ref:`extension <west-extensions>` command can be used to
 sign a Zephyr application binary for consumption by a bootloader using an
 external tool. Run ``west sign -h`` for command line help.
 
+By default ``west sign`` will sign the image assuming that it is running in
+the partition with label ``image-0`` and limit the size of the binary to the
+size of the partition with label ``image-1``.
+
+If :kconfig:option:`CONFIG_USE_DT_CODE_PARTITION` ``=y``, ``west sign`` will
+use ``zephyr,code-partition`` as the location of the running image and an
+optional ``zephyr,secondary-code-partition`` as the size limit of the image.
+This can be required when building multi-image applications, see
+:literal:`tests/subsys/dfu/mcuboot_multi`.
+
 MCUboot / imgtool
 *****************
 

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -217,7 +217,8 @@ class ImgtoolSigner(Signer):
         vtoff = self.get_cfg(command, build_conf, 'CONFIG_ROM_START_OFFSET')
         # Flash device write alignment and the partition's slot size
         # come from devicetree:
-        flash = self.edt_flash_node(b, args.quiet)
+        edt = self.edt_load(b, args.quiet)
+        flash = self.edt_flash_node(edt)
         align, addr, size = self.edt_flash_params(flash)
 
         if not build_conf.getboolean('CONFIG_BOOTLOADER_MCUBOOT'):
@@ -311,7 +312,7 @@ class ImgtoolSigner(Signer):
             return None
 
     @staticmethod
-    def edt_flash_node(b, quiet=False):
+    def edt_load(b, quiet=False):
         # Get the EDT Node corresponding to the zephyr,flash chosen DT
         # node; 'b' is the build directory as a pathlib object.
 
@@ -327,7 +328,10 @@ class ImgtoolSigner(Signer):
         # Load the devicetree.
         with open(edt_pickle, 'rb') as f:
             edt = pickle.load(f)
+        return edt
 
+    @staticmethod
+    def edt_flash_node(edt):
         # By convention, the zephyr,flash chosen node contains the
         # partition information about the zephyr image to sign.
         flash = edt.chosen_node('zephyr,flash')

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -341,9 +341,15 @@ class ImgtoolSigner(Signer):
         partitions = {
             node.label: node for p in partition_nodes for node in p.children.values()
         }
+        # Assume that `image-1` corresponds with secondary partition for now.
+        secondary = partitions.get('image-1', None)
         # Determine the primary partition.
         if dt_code_partition:
             primary = edt.chosen_nodes['zephyr,code-partition']
+            # Override the default secondary partition if
+            # `secondary-code-partition` exists
+            secondary = edt.chosen_nodes.get('zephyr,secondary-code-partition',
+                                             secondary)
         else:
             # Assume that `image-0` corresponds with the primary partition and
             # check that it exists.
@@ -351,8 +357,6 @@ class ImgtoolSigner(Signer):
                 log.die("DT zephyr,flash chosen node has no image-0 partition,",
                         "can't determine its address")
             primary = partitions['image-0']
-        # Assume that `image-1` corresponds with secondary partition.
-        secondary = partitions.get('image-1', None)
         # Return the retrieved partitions.
         return primary, secondary
 


### PR DESCRIPTION
`west sign` does not currently behave correctly when MCUboot is using multiple images. This is because it is hardcoded to use the `image-0` partition for the start address and `image-1` for the partition size. The first assumption is incorrect for a second image, and the second assumption is incorrect when the images are not the same size. This can result in `imgtool` failing with an insufficient space error.

This PR updates `west sign` to use `zephyr,code-partition` if `CONFIG_USE_DT_CODE_PARTITION=y`, and adds a new chosen to select the secondary partition if desired. `zephyr,secondary-code-partition` is currently only used for this purpose, but could be used in the future to link primary and secondary images together, which is currently done through hardcoded names. 

See:
https://github.com/zephyrproject-rtos/zephyr/blob/ad5c3a1ae3d2e148e6f000565551c6547d6d5e80/subsys/dfu/boot/mcuboot_priv.h#L13-L19
which doesn't match the expected labels of MCUboot itself:
https://github.com/zephyrproject-rtos/mcuboot/blob/cfec947e0f8be686d02c73104a3b1ad0b5dcf1e6/boot/zephyr/include/sysflash/sysflash.h#L11-L40

