### PR TITLE
stm32f7: fix locations of stm32-temp-cal registers

### DIFF
--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -698,8 +698,8 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1FF07A2C>;
-		ts-cal2-addr = <0x1FF07A2E>;
+		ts-cal1-addr = <0x1FF0F44C>;
+		ts-cal2-addr = <0x1FF0F44E>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3300>;

--- a/dts/arm/st/f7/stm32f723.dtsi
+++ b/dts/arm/st/f7/stm32f723.dtsi
@@ -47,6 +47,10 @@
 		};
 	};
 
+	die_temp: dietemp {
+		ts-cal1-addr = <0x1FF07A2C>;
+		ts-cal2-addr = <0x1FF07A2E>;
+	};
 };
 
 /delete-node/ &otghs_fs_phy;

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -87,9 +87,4 @@
 			status = "disabled";
 		};
 	};
-
-	die_temp: dietemp {
-		ts-cal1-addr = <0x1FF0F44C>;
-		ts-cal2-addr = <0x1FF0F44E>;
-	};
 };


### PR DESCRIPTION
The only supported device in the F7 family with temp-cal registers at 0x1FF07A2C is the stm32f723. All other devices use 0x1FF0F44C.

part               | DS#       | TS_CAL1       | TS_CAL2
-------------------|-----------|---------------|--------------
722/723            | [DS11853] | `0x1FF0 7A2C` | `0x1FF0 7A2E`
745/746            | [DS10916] | `0x1FF0 F44C` | `0x1FF0 F44E`
750                | [DS12535] | `0x1FF0 F44C` | `0x1FF0 F44E`
756                | [DS10915] | `0x1FF0 F44C` | `0x1FF0 F44E`
765/767/768/769    | [DS11532] | `0x1FF0 F44C` | `0x1FF0 F44E`

[DS11853]: https://www.st.com/resource/en/datasheet/stm32f722ve.pdf
[DS10916]: https://www.st.com/resource/en/datasheet/stm32f746ng.pdf
[DS12535]: https://www.st.com/resource/en/datasheet/stm32f750v8.pdf
[DS10915]: https://www.st.com/resource/en/datasheet/stm32f756ng.pdf
[DS11532]: https://www.st.com/resource/en/datasheet/stm32f765zg.pdf