### PR TITLE
drivers: pwm: mcux: ftm: fix cycle count if timer overflow missed

### DIFF
--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -325,6 +325,8 @@ static void mcux_ftm_capture_second_edge(const struct device *dev,
 				status = -ERANGE;
 			}
 		}
+	} else if (first_cnv > second_cnv) {
+		cycles = config->base->MOD - first_cnv + second_cnv;
 	} else {
 		cycles = second_cnv - first_cnv;
 	}


### PR DESCRIPTION
Fix the calculation of the captured number of cycles when the first edge is captured at a timer value just below MOD and the second edge is captured at a timer value just above 0.

In this case, the timer overflow interrupt may not yet have fired, causing the number of detected overflows to be zero, but the counter value for the first edge is larger than that for the second edge.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>