### PR TITLE
Fix builds when CONFIG_MP_MAX_NUM_CPUS=1

### DIFF
--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -133,6 +133,7 @@ void arch_sched_ipi(void)
 	}
 }
 
+#if CONFIG_MP_MAX_NUM_CPUS > 1
 int soc_adsp_halt_cpu(int id)
 {
 	int retry = CORE_POWER_CHECK_NUM;
@@ -168,3 +169,4 @@ int soc_adsp_halt_cpu(int id)
 
 	return 0;
 }
+#endif

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -84,7 +84,7 @@ static int cleanup_test(struct unit_test *test)
 
 #ifdef KERNEL
 
-#ifdef CONFIG_SMP
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
 #define MAX_NUM_CPUHOLD (CONFIG_MP_MAX_NUM_CPUS - 1)
 #define CPUHOLD_STACK_SZ (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
 static struct k_thread cpuhold_threads[MAX_NUM_CPUHOLD];
@@ -132,11 +132,11 @@ static void cpu_hold(void *arg1, void *arg2, void *arg3)
 		     "1cpu test took too long (%d ms)", dt);
 	arch_irq_unlock(key);
 }
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_SMP && (CONFIG_MP_MAX_NUM_CPUS > 1) */
 
 void z_impl_z_test_1cpu_start(void)
 {
-#ifdef CONFIG_SMP
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
 	unsigned int num_cpus = arch_num_cpus();
 
 	cpuhold_active = 1;
@@ -164,7 +164,7 @@ void z_impl_z_test_1cpu_start(void)
 
 void z_impl_z_test_1cpu_stop(void)
 {
-#ifdef CONFIG_SMP
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
 	unsigned int num_cpus = arch_num_cpus();
 
 	cpuhold_active = 0;

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -105,7 +105,7 @@ static int cleanup_test(struct ztest_unit_test *test)
 
 #ifdef KERNEL
 
-#ifdef CONFIG_SMP
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
 #define MAX_NUM_CPUHOLD (CONFIG_MP_MAX_NUM_CPUS - 1)
 #define CPUHOLD_STACK_SZ (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
 static struct k_thread cpuhold_threads[MAX_NUM_CPUHOLD];
@@ -154,11 +154,11 @@ static void cpu_hold(void *arg1, void *arg2, void *arg3)
 		     "1cpu test took too long (%d ms)", dt);
 	arch_irq_unlock(key);
 }
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_SMP && (CONFIG_MP_MAX_NUM_CPUS > 1) */
 
 void z_impl_z_test_1cpu_start(void)
 {
-#ifdef CONFIG_SMP
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
 	unsigned int num_cpus = arch_num_cpus();
 
 	cpuhold_active = 1;
@@ -184,7 +184,7 @@ void z_impl_z_test_1cpu_start(void)
 
 void z_impl_z_test_1cpu_stop(void)
 {
-#ifdef CONFIG_SMP
+#if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
 	unsigned int num_cpus = arch_num_cpus();
 
 	cpuhold_active = 0;


### PR DESCRIPTION
We get compiler warnings in some cases when CONFIG_MP_MAX_NUM_CPUS=1.  This fixes those case.