### PR TITLE
samples: modules: chre: Flush log messages after initialization

### DIFF
--- a/samples/modules/chre/src/main.cpp
+++ b/samples/modules/chre/src/main.cpp
@@ -4,6 +4,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/logging/log_ctrl.h>
 
 #include "apps.hpp"
 #include "chre/core/event_loop_manager.h"
@@ -28,6 +29,13 @@ int main(void)
 	printk("Hello CHRE!\n");
 
 	k_msleep(500);
+	/*
+	 * Flush all log messages that resulted from initialization to avoid
+	 * getting them mingled with those printk messages below.
+	 */
+	while (IS_ENABLED(CONFIG_LOG_PROCESS_THREAD) && log_data_pending()) {
+		k_msleep(100);
+	}
 	printk("Starting EchoApp... %s\n", boolToString(eventLoop.startNanoapp(echo_app)));
 	printk("Nanoapp count=%u\n", eventLoop.getNanoappCount());
 	printk("Finding instance ID... %s\n", boolToString(eventLoop.findNanoappInstanceIdByAppId(1, &instanceId)));


### PR DESCRIPTION
On targets where POST_KERNEL initialization routines, executed after the logging thread has started, take significant amount of time, log messages produced during CHRE initialization may collide with printk messages output by the sample. Prevent this by flushing all log messages right after the initialization is performed.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>