### PR TITLE
boards: arm: nordic nrf91* nrf53* nrf52* nrf51*: Remove scratch areas

### DIFF
--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -259,15 +259,11 @@ fem_spi: &spi3 {
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x00067000>;
+			reg = <0x0000C000 0x00076000>;
 		};
-		slot1_partition: partition@73000 {
+		slot1_partition: partition@82000 {
 			label = "image-1";
-			reg = <0x00073000 0x00067000>;
-		};
-		scratch_partition: partition@da000 {
-			label = "image-scratch";
-			reg = <0x000da000 0x0001e000>;
+			reg = <0x00082000 0x00076000>;
 		};
 
 		/*

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
@@ -158,15 +158,11 @@
 		};
 		slot0_partition: partition@8000 {
 			label = "image-0";
-			reg = <0x00008000 0x1a000>;
+			reg = <0x00008000 0x1b000>;
 		};
-		slot1_partition: partition@22000 {
+		slot1_partition: partition@23000 {
 			label = "image-1";
-			reg = <0x00022000 0x1a000>;
-		};
-		scratch_partition: partition@3c000 {
-			label = "image-scratch";
-			reg = <0x0003c000 0x2000>;
+			reg = <0x00023000 0x1b000>;
 		};
 		storage_partition: partition@3e000 {
 			label = "storage";

--- a/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
+++ b/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
@@ -95,15 +95,11 @@
 		};
 		slot0_partition: partition@8000 {
 			label = "image-0";
-			reg = <0x00008000 0x1a000>;
+			reg = <0x00008000 0x1b000>;
 		};
-		slot1_partition: partition@22000 {
+		slot1_partition: partition@23000 {
 			label = "image-1";
-			reg = <0x00022000 0x1a000>;
-		};
-		scratch_partition: partition@3c000 {
-			label = "image-scratch";
-			reg = <0x0003c000 0x2000>;
+			reg = <0x00023000 0x1b000>;
 		};
 		storage_partition: partition@3e000 {
 			label = "storage";

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -217,15 +217,11 @@ arduino_spi: &spi3 {
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x32000>;
+			reg = <0x0000C000 0x37000>;
 		};
-		slot1_partition: partition@3e000 {
+		slot1_partition: partition@43000 {
 			label = "image-1";
-			reg = <0x0003E000 0x32000>;
-		};
-		scratch_partition: partition@70000 {
-			label = "image-scratch";
-			reg = <0x00070000 0xA000>;
+			reg = <0x00043000 0x37000>;
 		};
 		storage_partition: partition@7a000 {
 			label = "storage";

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
@@ -154,19 +154,15 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0xd000>;
+			reg = <0x0000C000 0xe000>;
 		};
-		slot1_partition: partition@19000 {
+		slot1_partition: partition@1a000 {
 			label = "image-1";
-			reg = <0x00019000 0xd000>;
+			reg = <0x0001a000 0xe000>;
 		};
-		scratch_partition: partition@26000 {
-			label = "image-scratch";
-			reg = <0x00026000 0x3000>;
-		};
-		storage_partition: partition@29000 {
+		storage_partition: partition@28000 {
 			label = "storage";
-			reg = <0x00029000 0x00007000>;
+			reg = <0x00028000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -264,15 +264,11 @@ arduino_spi: &spi3 {
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x00067000>;
+			reg = <0x0000C000 0x00076000>;
 		};
-		slot1_partition: partition@73000 {
+		slot1_partition: partition@82000 {
 			label = "image-1";
-			reg = <0x00073000 0x00067000>;
-		};
-		scratch_partition: partition@da000 {
-			label = "image-scratch";
-			reg = <0x000da000 0x0001e000>;
+			reg = <0x00082000 0x00076000>;
 		};
 
 		/*

--- a/boards/arm/nrf52840dongle_nrf52840/fstab-debugger.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/fstab-debugger.dts
@@ -22,15 +22,11 @@
 
 		slot0_partition: partition@12000 {
 			label = "image-0";
-			reg = <0x00012000 0x00069000>;
+			reg = <0x00012000 0x00075000>;
 		};
-		slot1_partition: partition@7b000 {
+		slot1_partition: partition@87000 {
 			label = "image-1";
-			reg = <0x0007b000 0x00069000>;
-		};
-		scratch_partition: partition@e4000 {
-			label = "image-scratch";
-			reg = <0x000e4000 0x00018000>;
+			reg = <0x00087000 0x00075000>;
 		};
 		storage_partition: partition@fc000 {
 			label = "storage";

--- a/boards/arm/nrf52840dongle_nrf52840/fstab-stock.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/fstab-stock.dts
@@ -23,19 +23,11 @@
 
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 0x0005e000>;
+			reg = <0x00010000 0x00068000>;
 		};
-		slot1_partition: partition@6e000 {
+		slot1_partition: partition@78000 {
 			label = "image-1";
-			reg = <0x0006e000 0x0005e000>;
-		};
-		storage_partition: partition@cc000 {
-			label = "storage";
-			reg = <0x000cc000 0x00004000>;
-		};
-		scratch_partition: partition@d0000 {
-			label = "image-scratch";
-			reg = <0x000d0000 0x00010000>;
+			reg = <0x00078000 0x00068000>;
 		};
 
 		/* Nordic nRF5 bootloader <0xe0000 0x1c000>

--- a/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
+++ b/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
@@ -129,19 +129,15 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0xd000>;
+			reg = <0x0000C000 0xe000>;
 		};
 		slot1_partition: partition@19000 {
 			label = "image-1";
-			reg = <0x00019000 0xd000>;
+			reg = <0x00020000 0xe000>;
 		};
-		scratch_partition: partition@26000 {
-			label = "image-scratch";
-			reg = <0x00026000 0x3000>;
-		};
-		storage_partition: partition@29000 {
+		storage_partition: partition@28000 {
 			label = "storage";
-			reg = <0x00029000 0x00007000>;
+			reg = <0x00028000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
@@ -132,19 +132,15 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0xd000>;
+			reg = <0x0000C000 0xe000>;
 		};
-		slot1_partition: partition@19000 {
+		slot1_partition: partition@1a000 {
 			label = "image-1";
-			reg = <0x00019000 0xd000>;
+			reg = <0x0001a000 0xe000>;
 		};
-		scratch_partition: partition@26000 {
-			label = "image-scratch";
-			reg = <0x00026000 0x3000>;
-		};
-		storage_partition: partition@29000 {
+		storage_partition: partition@28000 {
 			label = "storage";
-			reg = <0x00029000 0x00007000>;
+			reg = <0x00028000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
@@ -213,15 +213,11 @@ arduino_spi: &spi2 {
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x32000>;
+			reg = <0x0000C000 0x37000>;
 		};
-		slot1_partition: partition@3e000 {
+		slot1_partition: partition@43000 {
 			label = "image-1";
-			reg = <0x0003E000 0x32000>;
-		};
-		scratch_partition: partition@70000 {
-			label = "image-scratch";
-			reg = <0x00070000 0xa000>;
+			reg = <0x00043000 0x37000>;
 		};
 		storage_partition: partition@7a000 {
 			label = "storage";

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -252,13 +252,10 @@ arduino_spi: &spi4 {
 		slot1_ns_partition: partition@c0000 {
 			label = "image-1-nonsecure";
 		};
-		scratch_partition: partition@f0000 {
-			label = "image-scratch";
-			reg = <0x000f0000 0xa000>;
-		};
-		storage_partition: partition@fa000 {
+		/* 0xf0000 to 0xf7fff reserved for TF-M partitions */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fa000 0x00006000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
@@ -178,15 +178,11 @@ arduino_spi: &spi0 {
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x12000>;
+			reg = <0x0000C000 0x17000>;
 		};
-		slot1_partition: partition@1e000 {
+		slot1_partition: partition@23000 {
 			label = "image-1";
-			reg = <0x0001E000 0x12000>;
-		};
-		scratch_partition: partition@30000 {
-			label = "image-scratch";
-			reg = <0x00030000 0xa000>;
+			reg = <0x00023000 0x17000>;
 		};
 		storage_partition: partition@3a000 {
 			label = "storage";

--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
@@ -183,15 +183,11 @@
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x00067000>;
+			reg = <0x0000C000 0x00076000>;
 		};
-		slot1_partition: partition@73000 {
+		slot1_partition: partition@82000 {
 			label = "image-1";
-			reg = <0x00073000 0x00067000>;
-		};
-		scratch_partition: partition@da000 {
-			label = "image-scratch";
-			reg = <0x000da000 0x0001e000>;
+			reg = <0x00082000 0x00076000>;
 		};
 
 		/*

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -246,13 +246,10 @@ arduino_spi: &spi3 {
 		slot1_ns_partition: partition@c0000 {
 			label = "image-1-nonsecure";
 		};
-		scratch_partition: partition@f0000 {
-			label = "image-scratch";
-			reg = <0x000f0000 0xa000>;
-		};
-		storage_partition: partition@fa000 {
+		/* 0xf0000 to 0xf7fff reserved for TF-M partitions */
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000fa000 0x00006000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -215,6 +215,30 @@ Boards & SoC Support
 
 * Removed support for these Xtensa boards:
 
+* Made these changes in ARM boards:
+
+  * The scratch partition has been removed for the following Nordic boards and
+    flash used by this area re-assigned to other partitions to free up space
+    and rely upon the swap-using-move algorithm in MCUboot (which does not
+    suffer from the same faults or stuck image issues as swap-using-scratch
+    does):
+    ``nrf21540dk_nrf52840``
+    ``nrf51dk_nrf51422``
+    ``nrf51dongle_nrf51422``
+    ``nrf52833dk_nrf52833``
+    ``nrf52840dk_nrf52811``
+    ``nrf52840dk_nrf52840``
+    ``nrf52840dongle_nrf52840``
+    ``nrf52dk_nrf52805``
+    ``nrf52dk_nrf52810``
+    ``nrf52dk_nrf52832``
+    ``nrf5340dk_nrf5340``
+    ``nrf9160dk_nrf52840``
+    ``nrf9160dk_nrf9160``
+
+    Note that MCUboot and MCUboot image updates from pre-Zephyr 3.3 might be
+    incompatible with Zephyr 3.3 onwards and vice versa.
+
 * Made these changes in other boards:
 
 * Added support for these following shields:

--- a/tests/subsys/dfu/mcuboot_multi/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/dfu/mcuboot_multi/nrf52840dk_nrf52840.overlay
@@ -5,7 +5,6 @@
  */
 
 
-/delete-node/ &scratch_partition;
 /delete-node/ &storage_partition;
 /delete-node/ &slot0_partition;
 /delete-node/ &slot1_partition;

--- a/tests/subsys/settings/fcb/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/settings/fcb/nrf52840dk_nrf52840.overlay
@@ -5,7 +5,6 @@
  */
 
 /delete-node/ &storage_partition;
-/delete-node/ &scratch_partition;
 
 &flash0 {
 

--- a/tests/subsys/settings/fcb/nrf52dk_nrf52832.overlay
+++ b/tests/subsys/settings/fcb/nrf52dk_nrf52832.overlay
@@ -5,7 +5,7 @@
  */
 
 /delete-node/ &storage_partition;
-/delete-node/ &scratch_partition;
+/delete-node/ &slot1_partition;
 
 &flash0 {
 

--- a/tests/subsys/settings/functional/fcb/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/settings/functional/fcb/boards/nrf52840dk_nrf52840.overlay
@@ -5,7 +5,6 @@
  */
 
 /delete-node/ &storage_partition;
-/delete-node/ &scratch_partition;
 
 &flash0 {
 

--- a/tests/subsys/settings/functional/fcb/boards/nrf52dk_nrf52832.overlay
+++ b/tests/subsys/settings/functional/fcb/boards/nrf52dk_nrf52832.overlay
@@ -5,7 +5,7 @@
  */
 
 /delete-node/ &storage_partition;
-/delete-node/ &scratch_partition;
+/delete-node/ &slot1_partition;
 
 &flash0 {
 

--- a/tests/subsys/settings/functional/file/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/settings/functional/file/nrf52840dk_nrf52840.overlay
@@ -5,7 +5,6 @@
  */
 
 /delete-node/ &storage_partition;
-/delete-node/ &scratch_partition;
 
 &flash0 {
 

--- a/tests/subsys/settings/functional/file/nrf52dk_nrf52832.overlay
+++ b/tests/subsys/settings/functional/file/nrf52dk_nrf52832.overlay
@@ -5,7 +5,7 @@
  */
 
 /delete-node/ &storage_partition;
-/delete-node/ &scratch_partition;
+/delete-node/ &slot1_partition;
 
 &flash0 {
 


### PR DESCRIPTION
    The scratch partition is not needed since MCUboot now operates in
    swap using move mode instead of swap with scratch, as a result, the
    main partitions on Nordic nRF51, nRF52, nRF53 and nRF91 boards can be
    expanded to help in fitting large applications to them.