### PR TITLE
lorawan: enable run-time config of region/freq

### DIFF
--- a/doc/connectivity/lora_lorawan/index.rst
+++ b/doc/connectivity/lora_lorawan/index.rst
@@ -56,8 +56,6 @@ Related configuration options can be found under
 
 * :kconfig:option:`CONFIG_LORAWAN_SYSTEM_MAX_RX_ERROR`
 
-* :kconfig:option:`CONFIG_LORAMAC_REGION_UNKNOWN`
-
 * :kconfig:option:`CONFIG_LORAMAC_REGION_AS923`
 
 * :kconfig:option:`CONFIG_LORAMAC_REGION_AU915`

--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -62,6 +62,22 @@ enum lorawan_datarate {
 };
 
 /**
+ * @brief LoRaWAN region types.
+ */
+enum lorawan_region {
+	LORAWAN_REGION_AS923,
+	LORAWAN_REGION_AU915,
+	LORAWAN_REGION_CN470,
+	LORAWAN_REGION_CN779,
+	LORAWAN_REGION_EU433,
+	LORAWAN_REGION_EU868,
+	LORAWAN_REGION_KR920,
+	LORAWAN_REGION_IN865,
+	LORAWAN_REGION_US915,
+	LORAWAN_REGION_RU864,
+};
+
+/**
  * @brief LoRaWAN message types.
  */
 enum lorawan_message_type {
@@ -289,6 +305,18 @@ enum lorawan_datarate lorawan_get_min_datarate(void);
  */
 void lorawan_get_payload_sizes(uint8_t *max_next_payload_size,
 			       uint8_t *max_payload_size);
+
+/**
+ * @brief Set the region and frequency to be used
+ *
+ * Control the LoRa region and frequency settings. This should be called before
+ * @a lorawan_start(). If you only have support for a single region selected via
+ * Kconfig, this function does not need to be called at all.
+ *
+ * @param region The region to be selected
+ * @return 0 if successful, negative errno otherwise
+ */
+int lorawan_set_region(enum lorawan_region region);
 
 #ifdef __cplusplus
 }

--- a/samples/subsys/lorawan/class_a/sample.yaml
+++ b/samples/subsys/lorawan/class_a/sample.yaml
@@ -40,3 +40,7 @@ tests:
   sample.lorawan.class_a.ru864:
     extra_configs:
       - CONFIG_LORAMAC_REGION_RU864=y
+  sample.lorawan.class_a.multiregion:
+    extra_configs:
+      - CONFIG_LORAMAC_REGION_EU868=y
+      - CONFIG_LORAMAC_REGION_US915=y

--- a/samples/subsys/lorawan/class_a/src/main.c
+++ b/samples/subsys/lorawan/class_a/src/main.c
@@ -65,6 +65,17 @@ void main(void)
 		return;
 	}
 
+#if defined(CONFIG_LORAMAC_REGION_EU868)
+	/* If more than one region Kconfig is selected, app should set region
+	 * before calling lorawan_start()
+	 */
+	ret = lorawan_set_region(LORAWAN_REGION_EU868);
+	if (ret < 0) {
+		LOG_ERR("lorawan_set_region failed: %d", ret);
+		return;
+	}
+#endif
+
 	ret = lorawan_start();
 	if (ret < 0) {
 		LOG_ERR("lorawan_start failed: %d", ret);

--- a/subsys/lorawan/Kconfig
+++ b/subsys/lorawan/Kconfig
@@ -26,15 +26,6 @@ config LORAWAN_SYSTEM_MAX_RX_ERROR
 	  System Max Rx timing error value in ms to be used by LoRaWAN stack
 	  for calculating the RX1/RX2 window timing.
 
-choice LORAMAC_REGION
-	prompt "LoRaWAN Region Selection"
-	default LORAMAC_REGION_UNKNOWN
-	help
-	  Select the LoRaWAN region.
-
-config LORAMAC_REGION_UNKNOWN
-	bool "Unknown region"
-
 config LORAMAC_REGION_AS923
 	bool "Asia 923MHz Frequency band"
 
@@ -64,8 +55,6 @@ config LORAMAC_REGION_US915
 
 config LORAMAC_REGION_RU864
 	bool "Russia 864MHz Frequency band"
-
-endchoice
 
 rsource "nvm/Kconfig"
 

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -15,29 +15,26 @@
 #include <Region.h>
 #include "nvm/lorawan_nvm.h"
 
-BUILD_ASSERT(!IS_ENABLED(CONFIG_LORAMAC_REGION_UNKNOWN),
-	     "Unknown region specified for LoRaWAN in Kconfig");
-
 #ifdef CONFIG_LORAMAC_REGION_AS923
-#define LORAWAN_REGION LORAMAC_REGION_AS923
+#define DEFAULT_LORAWAN_REGION LORAMAC_REGION_AS923
 #elif CONFIG_LORAMAC_REGION_AU915
-#define LORAWAN_REGION LORAMAC_REGION_AU915
+#define DEFAULT_LORAWAN_REGION LORAMAC_REGION_AU915
 #elif CONFIG_LORAMAC_REGION_CN470
-#define LORAWAN_REGION LORAMAC_REGION_CN470
+#define DEFAULT_LORAWAN_REGION LORAMAC_REGION_CN470
 #elif CONFIG_LORAMAC_REGION_CN779
-#define LORAWAN_REGION LORAMAC_REGION_CN779
+#define DEFAULT_LORAWAN_REGION LORAMAC_REGION_CN779
 #elif CONFIG_LORAMAC_REGION_EU433
-#define LORAWAN_REGION LORAMAC_REGION_EU433
+#define DEFAULT_LORAWAN_REGION LORAMAC_REGION_EU433
 #elif CONFIG_LORAMAC_REGION_EU868
-#define LORAWAN_REGION LORAMAC_REGION_EU868
+#define DEFAULT_LORAWAN_REGION LORAMAC_REGION_EU868
 #elif CONFIG_LORAMAC_REGION_KR920
-#define LORAWAN_REGION LORAMAC_REGION_KR920
+#define DEFAULT_LORAWAN_REGION LORAMAC_REGION_KR920
 #elif CONFIG_LORAMAC_REGION_IN865
-#define LORAWAN_REGION LORAMAC_REGION_IN865
+#define DEFAULT_LORAWAN_REGION LORAMAC_REGION_IN865
 #elif CONFIG_LORAMAC_REGION_US915
-#define LORAWAN_REGION LORAMAC_REGION_US915
+#define DEFAULT_LORAWAN_REGION LORAMAC_REGION_US915
 #elif CONFIG_LORAMAC_REGION_RU864
-#define LORAWAN_REGION LORAMAC_REGION_RU864
+#define DEFAULT_LORAWAN_REGION LORAMAC_REGION_RU864
 #else
 #error "At least one LoRaWAN region should be selected"
 #endif
@@ -72,6 +69,8 @@ static LoRaMacEventInfoStatus_t last_mcps_confirm_status;
 static LoRaMacEventInfoStatus_t last_mlme_confirm_status;
 static LoRaMacEventInfoStatus_t last_mcps_indication_status;
 static LoRaMacEventInfoStatus_t last_mlme_indication_status;
+
+static LoRaMacRegion_t selected_region = DEFAULT_LORAWAN_REGION;
 
 static uint8_t (*get_battery_level_user)(void);
 static void (*dr_change_cb)(enum lorawan_datarate dr);
@@ -284,6 +283,80 @@ static LoRaMacStatus_t lorawan_join_abp(
 	LoRaMacMibSetRequestConfirm(&mib_req);
 
 	return LORAMAC_STATUS_OK;
+}
+
+int lorawan_set_region(enum lorawan_region region)
+{
+	switch (region) {
+
+#if defined(CONFIG_LORAMAC_REGION_AS923)
+	case LORAWAN_REGION_AS923:
+		selected_region = LORAMAC_REGION_AS923;
+		break;
+#endif
+
+#if defined(CONFIG_LORAMAC_REGION_AU915)
+	case LORAWAN_REGION_AU915:
+		selected_region = LORAMAC_REGION_AU915;
+		break;
+#endif
+
+#if defined(CONFIG_LORAMAC_REGION_CN470)
+	case LORAWAN_REGION_CN470:
+		selected_region = LORAMAC_REGION_CN470;
+		break;
+#endif
+
+#if defined(CONFIG_LORAMAC_REGION_CN779)
+	case LORAWAN_REGION_CN779:
+		selected_region = LORAMAC_REGION_CN779;
+		break;
+#endif
+
+#if defined(CONFIG_LORAMAC_REGION_EU433)
+	case LORAWAN_REGION_EU433:
+		selected_region = LORAMAC_REGION_EU433;
+		break;
+#endif
+
+#if defined(CONFIG_LORAMAC_REGION_EU868)
+	case LORAWAN_REGION_EU868:
+		selected_region = LORAMAC_REGION_EU868;
+		break;
+#endif
+
+#if defined(CONFIG_LORAMAC_REGION_KR920)
+	case LORAWAN_REGION_KR920:
+		selected_region = LORAMAC_REGION_KR920;
+		break;
+#endif
+
+#if defined(CONFIG_LORAMAC_REGION_IN865)
+	case LORAWAN_REGION_IN865:
+		selected_region = LORAMAC_REGION_IN865;
+		break;
+#endif
+
+#if defined(CONFIG_LORAMAC_REGION_US915)
+	case LORAWAN_REGION_US915:
+		selected_region = LORAMAC_REGION_US915;
+		break;
+#endif
+
+#if defined(CONFIG_LORAMAC_REGION_RU864)
+	case LORAWAN_REGION_RU864:
+		selected_region = LORAMAC_REGION_RU864;
+		break;
+#endif
+
+	default:
+		LOG_ERR("No support for region %d!", region);
+		return -ENOTSUP;
+	}
+
+	LOG_DBG("Selected region %d", region);
+
+	return 0;
 }
 
 int lorawan_join(const struct lorawan_join_config *join_cfg)
@@ -576,6 +649,21 @@ int lorawan_start(void)
 	GetPhyParams_t phy_params;
 	PhyParam_t phy_param;
 
+	status = LoRaMacInitialization(&mac_primitives, &mac_callbacks,
+				       selected_region);
+	if (status != LORAMAC_STATUS_OK) {
+		LOG_ERR("LoRaMacInitialization failed: %s",
+			lorawan_status2str(status));
+		return -EINVAL;
+	}
+
+	LOG_DBG("LoRaMAC Initialized");
+
+	if (!IS_ENABLED(CONFIG_LORAWAN_NVM_NONE)) {
+		lorawan_nvm_init();
+		lorawan_nvm_data_restore();
+	}
+
 	status = LoRaMacStart();
 	if (status != LORAMAC_STATUS_OK) {
 		LOG_ERR("Failed to start the LoRaMAC stack: %s",
@@ -585,7 +673,7 @@ int lorawan_start(void)
 
 	/* Retrieve the default TX datarate for selected region */
 	phy_params.Attribute = PHY_DEF_TX_DR;
-	phy_param = RegionGetPhyParam(LORAWAN_REGION, &phy_params);
+	phy_param = RegionGetPhyParam(selected_region, &phy_params);
 	default_datarate = phy_param.Value;
 	current_datarate = default_datarate;
 
@@ -600,8 +688,6 @@ int lorawan_start(void)
 static int lorawan_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
-
-	LoRaMacStatus_t status;
 
 	sys_slist_init(&dl_callbacks);
 
@@ -620,21 +706,7 @@ static int lorawan_init(const struct device *dev)
 
 	mac_callbacks.MacProcessNotify = mac_process_notify;
 
-	status = LoRaMacInitialization(&mac_primitives, &mac_callbacks,
-				       LORAWAN_REGION);
-	if (status != LORAMAC_STATUS_OK) {
-		LOG_ERR("LoRaMacInitialization failed: %s",
-			lorawan_status2str(status));
-		return -EINVAL;
-	}
-
-	if (!IS_ENABLED(CONFIG_LORAWAN_NVM_NONE)) {
-		lorawan_nvm_init();
-		lorawan_nvm_data_restore();
-	}
-
-	LOG_DBG("LoRaMAC Initialized");
-
 	return 0;
 }
+
 SYS_INIT(lorawan_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);


### PR DESCRIPTION
This commit adds support for compiling in support for several different regions/frequencies and dynamically choosing which to use in run-time. This commit introduces no API breakages - if a prj.conf contains only a single region Kconfig, the new function lorawan_set_region() does not need to be called.

Signed-off-by: Benjamin Lindqvist <benjamin@eub.se>