### PR TITLE
drivers: i3c: i3c/i2c attach/detach api

### DIFF
--- a/drivers/i3c/i3c_ccc.c
+++ b/drivers/i3c/i3c_ccc.c
@@ -115,6 +115,7 @@ int i3c_ccc_do_rstdaa_all(const struct device *controller)
 
 int i3c_ccc_do_setdasa(const struct i3c_device_desc *target)
 {
+	struct i3c_driver_data *bus_data = (struct i3c_driver_data *)target->bus->data;
 	struct i3c_ccc_payload ccc_payload;
 	struct i3c_ccc_target_payload ccc_tgt_payload;
 	uint8_t dyn_addr;
@@ -133,6 +134,14 @@ int i3c_ccc_do_setdasa(const struct i3c_device_desc *target)
 	dyn_addr = (target->init_dynamic_addr ?
 				target->init_dynamic_addr : target->static_addr) << 1;
 
+	/* check that initial dynamic address is free before setting it */
+	if ((target->init_dynamic_addr != 0) &&
+		(target->init_dynamic_addr != target->static_addr)) {
+		if (!i3c_addr_slots_is_free(&bus_data->attached_dev.addr_slots, dyn_addr >> 1)) {
+			return -EINVAL;
+		}
+	}
+
 	ccc_tgt_payload.addr = target->static_addr;
 	ccc_tgt_payload.rnw = 0;
 	ccc_tgt_payload.data = &dyn_addr;
@@ -148,6 +157,7 @@ int i3c_ccc_do_setdasa(const struct i3c_device_desc *target)
 
 int i3c_ccc_do_setnewda(const struct i3c_device_desc *target, struct i3c_ccc_address new_da)
 {
+	struct i3c_driver_data *bus_data = (struct i3c_driver_data *)target->bus->data;
 	struct i3c_ccc_payload ccc_payload;
 	struct i3c_ccc_target_payload ccc_tgt_payload;
 	uint8_t new_dyn_addr;
@@ -164,6 +174,13 @@ int i3c_ccc_do_setnewda(const struct i3c_device_desc *target, struct i3c_ccc_add
 	 * (aka left-justified). So shift left by 1;
 	 */
 	new_dyn_addr = new_da.addr << 1;
+
+	/* check that initial dynamic address is free before setting it */
+	if (target->dynamic_addr != new_da.addr) {
+		if (!i3c_addr_slots_is_free(&bus_data->attached_dev.addr_slots, new_da.addr)) {
+			return -EINVAL;
+		}
+	}
 
 	ccc_tgt_payload.addr = target->dynamic_addr;
 	ccc_tgt_payload.rnw = 0;

--- a/drivers/i3c/i3c_ccc.c
+++ b/drivers/i3c/i3c_ccc.c
@@ -146,6 +146,38 @@ int i3c_ccc_do_setdasa(const struct i3c_device_desc *target)
 	return i3c_do_ccc(target->bus, &ccc_payload);
 }
 
+int i3c_ccc_do_setnewda(const struct i3c_device_desc *target, struct i3c_ccc_address new_da)
+{
+	struct i3c_ccc_payload ccc_payload;
+	struct i3c_ccc_target_payload ccc_tgt_payload;
+	uint8_t new_dyn_addr;
+
+	__ASSERT_NO_MSG(target != NULL);
+	__ASSERT_NO_MSG(target->bus != NULL);
+
+	if (target->dynamic_addr == 0U) {
+		return -EINVAL;
+	}
+
+	/*
+	 * Note that the 7-bit address needs to start at bit 1
+	 * (aka left-justified). So shift left by 1;
+	 */
+	new_dyn_addr = new_da.addr << 1;
+
+	ccc_tgt_payload.addr = target->dynamic_addr;
+	ccc_tgt_payload.rnw = 0;
+	ccc_tgt_payload.data = &new_dyn_addr;
+	ccc_tgt_payload.data_len = 1;
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+	ccc_payload.ccc.id = I3C_CCC_SETNEWDA;
+	ccc_payload.targets.payloads = &ccc_tgt_payload;
+	ccc_payload.targets.num_targets = 1;
+
+	return i3c_do_ccc(target->bus, &ccc_payload);
+}
+
 int i3c_ccc_do_events_all_set(const struct device *controller,
 			      bool enable, struct i3c_ccc_events *events)
 {

--- a/drivers/i3c/i3c_ccc.c
+++ b/drivers/i3c/i3c_ccc.c
@@ -130,7 +130,8 @@ int i3c_ccc_do_setdasa(const struct i3c_device_desc *target)
 	 * Note that the 7-bit address needs to start at bit 1
 	 * (aka left-justified). So shift left by 1;
 	 */
-	dyn_addr = target->static_addr << 1;
+	dyn_addr = (target->init_dynamic_addr ?
+				target->init_dynamic_addr : target->static_addr) << 1;
 
 	ccc_tgt_payload.addr = target->static_addr;
 	ccc_tgt_payload.rnw = 0;

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -444,20 +444,18 @@ struct cdns_i3c_xfer {
 
 /* Driver config */
 struct cdns_i3c_config {
+	struct i3c_driver_config common;
 	/** base address of the controller */
 	uintptr_t base;
 	/** input frequency to the I3C Cadence */
 	uint32_t input_frequency;
 	/** Interrupt configuration function. */
 	void (*irq_config_func)(const struct device *dev);
-	/** I3C/I2C device list struct. */
-	struct i3c_dev_list device_list;
 };
 
 /* Driver instance data */
 struct cdns_i3c_data {
-	struct i3c_config_controller ctrl_config;
-	struct i3c_addr_slots addr_slots;
+	struct i3c_driver_data common;
 	struct cdns_i3c_hw_config hw_cfg;
 	struct k_mutex bus_lock;
 	struct cdns_i3c_i2c_dev_data cdns_i3c_i2c_priv_data[I3C_MAX_DEVS];
@@ -642,7 +640,7 @@ static void cdns_i3c_set_prescalers(const struct device *dev)
 {
 	struct cdns_i3c_data *data = dev->data;
 	const struct cdns_i3c_config *config = dev->config;
-	struct i3c_config_controller *ctrl_config = &data->ctrl_config;
+	struct i3c_config_controller *ctrl_config = &data->common.ctrl_config;
 
 	/* These formulas are from section 6.2.1 of the Cadence I3C Master User Guide. */
 	uint32_t prescl_i3c = DIV_ROUND_UP(config->input_frequency,
@@ -715,124 +713,25 @@ static uint32_t prepare_rr0_dev_address(uint16_t addr)
 /**
  * @brief Program Retaining Registers with device lists
  *
- * This will reprogram all retaining registers with I3C devices, I2C devices,
- * and the controller itself.
+ * This will program the retaining register with the controller itself
  *
  * @param dev Pointer to controller device driver instance.
  */
-static void cdns_i3c_program_retaining_regs(const struct device *dev)
+static void cdns_i3c_program_controller_retaining_reg(const struct device *dev)
 {
 	const struct cdns_i3c_config *config = dev->config;
 	struct cdns_i3c_data *data = dev->data;
-
-	/* Clear all retaining regs */
-	sys_write32(DEVS_CTRL_DEV_CLR_ALL, config->base + DEVS_CTRL);
-
-	uint32_t dev_id_rr0;
-	uint32_t dev_id_rr1;
-	uint32_t dev_id_rr2;
-
-	/* program I2C devices */
-	for (int i = 0; i < config->device_list.num_i2c; i++) {
-		struct i3c_i2c_device_desc *i2c_device = &(config->device_list.i2c[i]);
-		struct cdns_i3c_i2c_dev_data *cdns_i2c_device_data = i2c_device->controller_priv;
-
-		if (cdns_i2c_device_data == NULL) {
-			LOG_ERR("%s: device not attached", dev->name);
-		}
-
-		/* Mark the address as I2C device */
-		i3c_addr_slots_mark_i2c(&data->addr_slots, i2c_device->addr);
-
-		dev_id_rr0 = prepare_rr0_dev_address(i2c_device->addr);
-		dev_id_rr2 = DEV_ID_RR2_LVR(i2c_device->lvr);
-
-		sys_write32(dev_id_rr0, config->base + DEV_ID_RR0(cdns_i2c_device_data->id));
-		sys_write32(0, config->base + DEV_ID_RR1(cdns_i2c_device_data->id));
-		sys_write32(dev_id_rr2, config->base + DEV_ID_RR2(cdns_i2c_device_data->id));
-
-		sys_write32(sys_read32(config->base + DEVS_CTRL) |
-				    DEVS_CTRL_DEV_ACTIVE(cdns_i2c_device_data->id),
-			    config->base + DEVS_CTRL);
-	}
-
-	/* program I3C devices */
-	for (int i = 0; i < config->device_list.num_i3c; i++) {
-		struct i3c_device_desc *i3c_device = &(config->device_list.i3c[i]);
-		struct cdns_i3c_i2c_dev_data *cdns_i3c_device_data = i3c_device->controller_priv;
-
-		if (cdns_i3c_device_data == NULL) {
-			LOG_ERR("%s: %s: device not attached", dev->name, i3c_device->dev->name);
-			continue;
-		}
-
-		/*
-		 * Use the desired dynamic address as the new dynamic address
-		 * if the slot is free.
-		 */
-		uint8_t dynamic_addr;
-
-		if (i3c_device->init_dynamic_addr != 0U) {
-			/* initial dynamic address is requested */
-			if (i3c_device->static_addr != 0) {
-				if (i3c_addr_slots_is_free(&data->addr_slots,
-							   i3c_device->init_dynamic_addr)) {
-					/* Set DA during ENTDAA */
-					dynamic_addr = i3c_device->init_dynamic_addr;
-				} else {
-					/* address is not free, get the next one */
-					dynamic_addr =
-						i3c_addr_slots_next_free_find(&data->addr_slots);
-				}
-			} else {
-				/* Use the init dynamic address as it's DA, but the RR will need to
-				 * be first set with it's SA to run SETDASA, the RR address will
-				 * need be updated after SETDASA with the request dynamic address
-				 */
-				dynamic_addr = i3c_device->static_addr;
-			}
-		} else {
-			/* no init dynamic address is requested */
-			if (i3c_device->static_addr != 0) {
-				/* static exists, set DA with same SA during SETDASA*/
-				dynamic_addr = i3c_device->static_addr;
-			} else {
-				/* pick a DA to use */
-				dynamic_addr = i3c_addr_slots_next_free_find(&data->addr_slots);
-			}
-		}
-		/* Mark the address as I3C device */
-		i3c_addr_slots_mark_i3c(&data->addr_slots, dynamic_addr);
-
-		dev_id_rr0 = DEV_ID_RR0_IS_I3C | prepare_rr0_dev_address(dynamic_addr);
-		dev_id_rr1 = DEV_ID_RR1_PID_MSB((i3c_device->pid & 0xFFFFFFFF0000) >> 16);
-		dev_id_rr2 = DEV_ID_RR2_PID_LSB(i3c_device->pid & 0xFFFF);
-
-		sys_write32(dev_id_rr0, config->base + DEV_ID_RR0(cdns_i3c_device_data->id));
-		sys_write32(dev_id_rr1, config->base + DEV_ID_RR1(cdns_i3c_device_data->id));
-		sys_write32(dev_id_rr2, config->base + DEV_ID_RR2(cdns_i3c_device_data->id));
-
-		/** Mark Devices as active, devices that will be found and marked active during DAA,
-		 * it will be given the exact DA programmed in it's RR if the PID matches and marked
-		 * as active duing ENTDAA, otherwise they get set as active here
-		 */
-		if (i3c_device->static_addr != 0) {
-			sys_write32(sys_read32(config->base + DEVS_CTRL) |
-					    DEVS_CTRL_DEV_ACTIVE(cdns_i3c_device_data->id),
-				    config->base + DEVS_CTRL);
-		}
-	}
-
 	/* Set controller retaining register */
 	uint8_t controller_da = I3C_CONTROLLER_ADDR;
 
-	if (!i3c_addr_slots_is_free(&data->addr_slots, controller_da)) {
-		controller_da = i3c_addr_slots_next_free_find(&data->addr_slots);
+	if (!i3c_addr_slots_is_free(&data->common.attached_dev.addr_slots, controller_da)) {
+		controller_da =
+			i3c_addr_slots_next_free_find(&data->common.attached_dev.addr_slots);
 		LOG_DBG("%s: 0x%02x DA selected for controller", dev->name, controller_da);
 	}
 	sys_write32(prepare_rr0_dev_address(controller_da), config->base + DEV_ID_RR0(0));
 	/* Mark the address as I3C device */
-	i3c_addr_slots_mark_i3c(&data->addr_slots, controller_da);
+	i3c_addr_slots_mark_i3c(&data->common.attached_dev.addr_slots, controller_da);
 }
 
 #ifdef CONFIG_I3C_USE_IBI
@@ -918,7 +817,7 @@ static int cdns_i3c_target_ibi_raise_hj(const struct device *dev)
 {
 	const struct cdns_i3c_config *config = dev->config;
 	struct cdns_i3c_data *data = dev->data;
-	struct i3c_config_controller *ctrl_config = &data->ctrl_config;
+	struct i3c_config_controller *ctrl_config = &data->common.ctrl_config;
 
 	/* HJ requests should not be done by primary controllers */
 	if (!ctrl_config->is_secondary) {
@@ -1199,7 +1098,7 @@ static int cdns_i3c_do_daa(const struct device *dev)
 {
 	struct cdns_i3c_data *data = dev->data;
 	const struct cdns_i3c_config *config = dev->config;
-	struct i3c_config_controller *ctrl_config = &data->ctrl_config;
+	struct i3c_config_controller *ctrl_config = &data->common.ctrl_config;
 
 	/* DAA should not be done by secondary controllers */
 	if (ctrl_config->is_secondary) {
@@ -1251,7 +1150,8 @@ static int cdns_i3c_do_daa(const struct device *dev)
 					LOG_INF("%s: PID 0x%012llx is not in registered device "
 						"list, given DA 0x%02x",
 						dev->name, pid, dyn_addr);
-					i3c_addr_slots_mark_i3c(&data->addr_slots, dyn_addr);
+					i3c_addr_slots_mark_i3c(
+						&data->common.attached_dev.addr_slots, dyn_addr);
 				} else {
 					target->dynamic_addr = dyn_addr;
 					target->bcr = bcr;
@@ -1295,7 +1195,7 @@ static int cdns_i3c_do_daa(const struct device *dev)
 static int cdns_i3c_i2c_api_configure(const struct device *dev, uint32_t config)
 {
 	struct cdns_i3c_data *data = dev->data;
-	struct i3c_config_controller *ctrl_config = &data->ctrl_config;
+	struct i3c_config_controller *ctrl_config = &data->common.ctrl_config;
 
 	switch (I2C_SPEED_GET(config)) {
 	case I2C_SPEED_STANDARD:
@@ -1344,8 +1244,8 @@ static int cdns_i3c_configure(const struct device *dev, enum i3c_config_type typ
 		return -EINVAL;
 	}
 
-	data->ctrl_config.scl.i3c = ctrl_cfg->scl.i3c;
-	data->ctrl_config.scl.i2c = ctrl_cfg->scl.i2c;
+	data->common.ctrl_config.scl.i3c = ctrl_cfg->scl.i3c;
+	data->common.ctrl_config.scl.i2c = ctrl_cfg->scl.i2c;
 	cdns_i3c_set_prescalers(dev);
 
 	return 0;
@@ -1558,10 +1458,11 @@ static int cdns_i3c_master_get_rr_slot(const struct device *dev, uint8_t dyn_add
 	return -EINVAL;
 }
 
-static int cdns_i3c_attach_device(const struct device *dev, struct i3c_device_desc *desc)
+static int cdns_i3c_attach_device(const struct device *dev, struct i3c_device_desc *desc,
+				  uint8_t addr)
 {
+	const struct cdns_i3c_config *config = dev->config;
 	struct cdns_i3c_data *data = dev->data;
-
 	int slot = cdns_i3c_master_get_rr_slot(dev, desc->dynamic_addr);
 
 	if (slot < 0) {
@@ -1574,6 +1475,24 @@ static int cdns_i3c_attach_device(const struct device *dev, struct i3c_device_de
 	data->cdns_i3c_i2c_priv_data[slot].id = slot;
 	desc->controller_priv = &(data->cdns_i3c_i2c_priv_data[slot]);
 	data->free_rr_slots &= ~BIT(slot);
+
+	uint32_t dev_id_rr0 = DEV_ID_RR0_IS_I3C | prepare_rr0_dev_address(addr);
+	uint32_t dev_id_rr1 = DEV_ID_RR1_PID_MSB((desc->pid & 0xFFFFFFFF0000) >> 16);
+	uint32_t dev_id_rr2 = DEV_ID_RR2_PID_LSB(desc->pid & 0xFFFF);
+
+	sys_write32(dev_id_rr0, config->base + DEV_ID_RR0(slot));
+	sys_write32(dev_id_rr1, config->base + DEV_ID_RR1(slot));
+	sys_write32(dev_id_rr2, config->base + DEV_ID_RR2(slot));
+
+	/** Mark Devices as active, devices that will be found and marked active during DAA,
+	 * it will be given the exact DA programmed in it's RR if the PID matches and marked
+	 * as active duing ENTDAA, otherwise they get set as active here. If dynamic address
+	 * is set, then it assumed that it was already initialized by the primary controller.
+	 */
+	if ((desc->static_addr != 0) || (desc->dynamic_addr != 0)) {
+		sys_write32(sys_read32(config->base + DEVS_CTRL) | DEVS_CTRL_DEV_ACTIVE(slot),
+			    config->base + DEVS_CTRL);
+	}
 
 	k_mutex_unlock(&data->bus_lock);
 
@@ -1592,22 +1511,40 @@ static int cdns_i3c_reattach_device(const struct device *dev, struct i3c_device_
 		return -EINVAL;
 	}
 
-	if (!i3c_addr_slots_is_free(&data->addr_slots, desc->dynamic_addr)) {
-		LOG_ERR("%s: %s: dynamic address 0x%02x is not free", dev->name, desc->dev->name,
-			desc->dynamic_addr);
-		return -EADDRNOTAVAIL;
+	k_mutex_lock(&data->bus_lock, K_FOREVER);
+
+	uint32_t dev_id_rr0 = DEV_ID_RR0_IS_I3C | prepare_rr0_dev_address(desc->dynamic_addr);
+	uint32_t dev_id_rr1 = DEV_ID_RR1_PID_MSB((desc->pid & 0xFFFFFFFF0000) >> 16);
+	uint32_t dev_id_rr2 = DEV_ID_RR2_PID_LSB(desc->pid & 0xFFFF) | DEV_ID_RR2_BCR(desc->bcr) |
+			      DEV_ID_RR2_DCR(desc->dcr);
+
+	sys_write32(dev_id_rr0, config->base + DEV_ID_RR0(cdns_i3c_device_data->id));
+	sys_write32(dev_id_rr1, config->base + DEV_ID_RR1(cdns_i3c_device_data->id));
+	sys_write32(dev_id_rr2, config->base + DEV_ID_RR2(cdns_i3c_device_data->id));
+
+	k_mutex_unlock(&data->bus_lock);
+
+	return 0;
+}
+
+static int cdns_i3c_detach_device(const struct device *dev, struct i3c_device_desc *desc)
+{
+	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_i2c_dev_data *cdns_i3c_device_data = desc->controller_priv;
+
+	if (cdns_i3c_device_data == NULL) {
+		LOG_ERR("%s: %s: device not attached", dev->name, desc->dev->name);
+		return -EINVAL;
 	}
 
 	k_mutex_lock(&data->bus_lock, K_FOREVER);
 
-	uint32_t rr0 = DEV_ID_RR0_IS_I3C | prepare_rr0_dev_address(desc->dynamic_addr);
-
-	if (old_dyn_addr) {
-		/* mark the old address as free */
-		i3c_addr_slots_mark_free(&data->addr_slots, old_dyn_addr);
-	}
-	sys_write32(rr0, config->base + DEV_ID_RR0(cdns_i3c_device_data->id));
-	i3c_addr_slots_mark_i3c(&data->addr_slots, desc->dynamic_addr);
+	sys_write32(sys_read32(config->base + DEVS_CTRL) |
+			    DEVS_CTRL_DEV_CLR(cdns_i3c_device_data->id),
+		    config->base + DEVS_CTRL);
+	data->free_rr_slots |= BIT(cdns_i3c_device_data->id);
+	desc->controller_priv = NULL;
 
 	k_mutex_unlock(&data->bus_lock);
 
@@ -1616,6 +1553,7 @@ static int cdns_i3c_reattach_device(const struct device *dev, struct i3c_device_
 
 static int cdns_i3c_i2c_attach_device(const struct device *dev, struct i3c_i2c_device_desc *desc)
 {
+	const struct cdns_i3c_config *config = dev->config;
 	struct cdns_i3c_data *data = dev->data;
 
 	int slot = cdns_i3c_master_get_rr_slot(dev, 0);
@@ -1627,9 +1565,43 @@ static int cdns_i3c_i2c_attach_device(const struct device *dev, struct i3c_i2c_d
 
 	k_mutex_lock(&data->bus_lock, K_FOREVER);
 
+	uint32_t dev_id_rr0 = prepare_rr0_dev_address(desc->addr);
+	uint32_t dev_id_rr2 = DEV_ID_RR2_LVR(desc->lvr);
+
+	sys_write32(dev_id_rr0, config->base + DEV_ID_RR0(slot));
+	sys_write32(0, config->base + DEV_ID_RR1(slot));
+	sys_write32(dev_id_rr2, config->base + DEV_ID_RR2(slot));
+
 	data->cdns_i3c_i2c_priv_data[slot].id = slot;
 	desc->controller_priv = &(data->cdns_i3c_i2c_priv_data[slot]);
 	data->free_rr_slots &= ~BIT(slot);
+
+	sys_write32(sys_read32(config->base + DEVS_CTRL) | DEVS_CTRL_DEV_ACTIVE(slot),
+		    config->base + DEVS_CTRL);
+
+	k_mutex_unlock(&data->bus_lock);
+
+	return 0;
+}
+
+static int cdns_i3c_i2c_detach_device(const struct device *dev, struct i3c_i2c_device_desc *desc)
+{
+	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_data *data = dev->data;
+	struct cdns_i3c_i2c_dev_data *cdns_i2c_device_data = desc->controller_priv;
+
+	if (cdns_i2c_device_data == NULL) {
+		LOG_ERR("%s: device not attached", dev->name);
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&data->bus_lock, K_FOREVER);
+
+	sys_write32(sys_read32(config->base + DEVS_CTRL) |
+			    DEVS_CTRL_DEV_CLR(cdns_i2c_device_data->id),
+		    config->base + DEVS_CTRL);
+	data->free_rr_slots |= BIT(cdns_i2c_device_data->id);
+	desc->controller_priv = NULL;
 
 	k_mutex_unlock(&data->bus_lock);
 
@@ -1752,6 +1724,7 @@ static int cdns_i3c_transfer(const struct device *dev, struct i3c_device_desc *t
 static void cdns_i3c_handle_ibi(const struct device *dev, uint32_t ibir)
 {
 	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_data *data = dev->data;
 
 	uint8_t ibi_data[CONFIG_I3C_IBI_MAX_PAYLOAD_SIZE];
 
@@ -1767,7 +1740,8 @@ static void cdns_i3c_handle_ibi(const struct device *dev, uint32_t ibir)
 
 	uint32_t dev_id_rr0 = sys_read32(config->base + DEV_ID_RR0(slave_id + 1));
 	uint8_t dyn_addr = DEV_ID_RR0_GET_DEV_ADDR(dev_id_rr0);
-	struct i3c_device_desc *desc = i3c_dev_list_i3c_addr_find(&config->device_list, dyn_addr);
+	struct i3c_device_desc *desc =
+		i3c_dev_list_i3c_addr_find(&data->common.attached_dev, dyn_addr);
 
 	/*
 	 * Check for NAK or error conditions.
@@ -2079,7 +2053,7 @@ static int cdns_i3c_config_get(const struct device *dev, enum i3c_config_type ty
 		goto out_configure;
 	}
 
-	(void)memcpy(config, &data->ctrl_config, sizeof(data->ctrl_config));
+	(void)memcpy(config, &data->common.ctrl_config, sizeof(data->common.ctrl_config));
 
 out_configure:
 	return ret;
@@ -2195,7 +2169,7 @@ static struct i3c_device_desc *cdns_i3c_device_find(const struct device *dev,
 {
 	const struct cdns_i3c_config *config = dev->config;
 
-	return i3c_dev_list_find(&config->device_list, id);
+	return i3c_dev_list_find(&config->common.dev_list, id);
 }
 
 /**
@@ -2213,9 +2187,9 @@ static struct i3c_device_desc *cdns_i3c_device_find(const struct device *dev,
  */
 static struct i3c_i2c_device_desc *cdns_i3c_i2c_device_find(const struct device *dev, uint16_t addr)
 {
-	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_data *data = dev->data;
 
-	return i3c_dev_list_i2c_addr_find(&config->device_list, addr);
+	return i3c_dev_list_i2c_addr_find(&data->common.attached_dev, addr);
 }
 
 /**
@@ -2314,13 +2288,10 @@ static int cdns_i3c_bus_init(const struct device *dev)
 {
 	struct cdns_i3c_data *data = dev->data;
 	const struct cdns_i3c_config *config = dev->config;
-	struct i3c_config_controller *ctrl_config = &data->ctrl_config;
+	struct i3c_config_controller *ctrl_config = &data->common.ctrl_config;
 
-	int ret = i3c_addr_slots_init(&data->addr_slots, &config->device_list);
-
-	if (ret != 0) {
-		return ret;
-	}
+	/* Clear all retaining regs */
+	sys_write32(DEVS_CTRL_DEV_CLR_ALL, config->base + DEVS_CTRL);
 
 	uint32_t conf0 = sys_read32(config->base + CONF_STATUS0);
 
@@ -2346,7 +2317,7 @@ static int cdns_i3c_bus_init(const struct device *dev)
 	/* determine prescaler timings for i3c and i2c scl */
 	cdns_i3c_set_prescalers(dev);
 
-	enum i3c_bus_mode mode = i3c_bus_mode(&config->device_list);
+	enum i3c_bus_mode mode = i3c_bus_mode(&config->common.dev_list);
 
 	LOG_DBG("%s: i3c bus mode %d", dev->name, mode);
 	int cdns_mode;
@@ -2418,22 +2389,19 @@ static int cdns_i3c_bus_init(const struct device *dev)
 	sys_write32(MST_INT_IBIR_THR | MST_INT_RX_UNF | MST_INT_HALTED | MST_INT_TX_OVF,
 		    config->base + MST_IER);
 
-	/* attach i3c devices */
-	for (int i = 0; i < config->device_list.num_i3c; i++) {
-		cdns_i3c_attach_device(dev, &config->device_list.i3c[i]);
-	}
-	/* attach i2c devices */
-	for (int i = 0; i < config->device_list.num_i2c; i++) {
-		cdns_i3c_i2c_attach_device(dev, &config->device_list.i2c[i]);
+	int ret = i3c_addr_slots_init(dev);
+
+	if (ret != 0) {
+		return ret;
 	}
 
 	/* Program retaining regs. */
-	cdns_i3c_program_retaining_regs(dev);
+	cdns_i3c_program_controller_retaining_reg(dev);
 
 	/* only primary controllers are responsible for initializing the bus */
 	if (!ctrl_config->is_secondary) {
 		/* Perform bus initialization */
-		ret = i3c_bus_init(dev, &config->device_list);
+		ret = i3c_bus_init(dev, &config->common.dev_list);
 		/* Bus Initialization Complete, allow HJ ACKs */
 		sys_write32(CTRL_HJ_ACK | sys_read32(config->base + CTRL), config->base + CTRL);
 	}
@@ -2448,7 +2416,11 @@ static struct i3c_driver_api api = {
 	.configure = cdns_i3c_configure,
 	.config_get = cdns_i3c_config_get,
 
+	.attach_i3c_device = cdns_i3c_attach_device,
 	.reattach_i3c_device = cdns_i3c_reattach_device,
+	.detach_i3c_device = cdns_i3c_detach_device,
+	.attach_i2c_device = cdns_i3c_i2c_attach_device,
+	.detach_i2c_device = cdns_i3c_i2c_detach_device,
 
 	.do_daa = cdns_i3c_do_daa,
 	.do_ccc = cdns_i3c_do_ccc,
@@ -2477,14 +2449,14 @@ static struct i3c_driver_api api = {
 		.base = DT_INST_REG_ADDR(n),                                                       \
 		.input_frequency = DT_INST_PROP(n, input_clock_frequency),                         \
 		.irq_config_func = cdns_i3c_config_func_##n,                                       \
-		.device_list.i3c = cdns_i3c_device_array_##n,                                      \
-		.device_list.num_i3c = ARRAY_SIZE(cdns_i3c_device_array_##n),                      \
-		.device_list.i2c = cdns_i3c_i2c_device_array_##n,                                  \
-		.device_list.num_i2c = ARRAY_SIZE(cdns_i3c_i2c_device_array_##n),                  \
+		.common.dev_list.i3c = cdns_i3c_device_array_##n,                                  \
+		.common.dev_list.num_i3c = ARRAY_SIZE(cdns_i3c_device_array_##n),                  \
+		.common.dev_list.i2c = cdns_i3c_i2c_device_array_##n,                              \
+		.common.dev_list.num_i2c = ARRAY_SIZE(cdns_i3c_i2c_device_array_##n),              \
 	};                                                                                         \
 	static struct cdns_i3c_data i3c_data_##n = {                                               \
-		.ctrl_config.scl.i3c = DT_INST_PROP_OR(n, i3c_scl_hz, 0),                          \
-		.ctrl_config.scl.i2c = DT_INST_PROP_OR(n, i2c_scl_hz, 0),                          \
+		.common.ctrl_config.scl.i3c = DT_INST_PROP_OR(n, i3c_scl_hz, 0),                   \
+		.common.ctrl_config.scl.i2c = DT_INST_PROP_OR(n, i2c_scl_hz, 0),                   \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(n, cdns_i3c_bus_init, NULL, &i3c_data_##n, &i3c_config_##n,          \
 			      POST_KERNEL, CONFIG_I3C_CONTROLLER_INIT_PRIORITY, &api);             \

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -402,23 +402,13 @@ static int i3c_bus_setdasa(const struct device *dev,
 			continue;
 		}
 
-		/*
-		 * If there is a desired dynamic address and it is
-		 * not the same as the static address, wait till
-		 * ENTDAA to do address assignment as this is
-		 * no longer SETDASA.
-		 */
-		if ((desc->init_dynamic_addr != 0U) &&
-		    (desc->init_dynamic_addr != desc->static_addr)) {
-			*need_daa = true;
-			continue;
-		}
-
 		LOG_DBG("SETDASA for 0x%x", desc->static_addr);
 
 		ret = i3c_ccc_do_setdasa(desc);
 		if (ret == 0) {
-			desc->dynamic_addr = desc->static_addr;
+			desc->dynamic_addr = (desc->init_dynamic_addr ? desc->init_dynamic_addr
+								      : desc->static_addr);
+			i3c_reattach_i3c_device(desc, desc->static_addr);
 		} else {
 			LOG_ERR("SETDASA error on address 0x%x (%d)",
 				desc->static_addr, ret);

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -80,65 +80,61 @@ i3c_addr_slots_status(struct i3c_addr_slots *slots,
 }
 
 
-int i3c_addr_slots_init(struct i3c_addr_slots *slots,
-			const struct i3c_dev_list *dev_list)
+int i3c_addr_slots_init(const struct device *dev)
 {
+	struct i3c_driver_data *data =
+		(struct i3c_driver_data *)dev->data;
+	const struct i3c_driver_config *config =
+		(const struct i3c_driver_config *)dev->config;
 	int i, ret = 0;
 	struct i3c_device_desc *i3c_dev;
 	struct i3c_i2c_device_desc *i2c_dev;
 
-	__ASSERT_NO_MSG(slots != NULL);
+	__ASSERT_NO_MSG(dev != NULL);
 
-	(void)memset(slots, 0, sizeof(*slots));
+	(void)memset(&data->attached_dev.addr_slots, 0, sizeof(data->attached_dev.addr_slots));
+	sys_slist_init(&data->attached_dev.devices.i3c);
+	sys_slist_init(&data->attached_dev.devices.i2c);
 
 	for (i = 0; i <= 7; i++) {
 		/* Addresses 0 to 7 are reserved */
-		i3c_addr_slots_set(slots, i, I3C_ADDR_SLOT_STATUS_RSVD);
+		i3c_addr_slots_set(&data->attached_dev.addr_slots, i, I3C_ADDR_SLOT_STATUS_RSVD);
 
 		/*
 		 * Addresses within a single bit error of broadcast address
 		 * are also reserved.
 		 */
-		i3c_addr_slots_set(slots, I3C_BROADCAST_ADDR ^ BIT(i),
+		i3c_addr_slots_set(&data->attached_dev.addr_slots, I3C_BROADCAST_ADDR ^ BIT(i),
 				   I3C_ADDR_SLOT_STATUS_RSVD);
 
 	}
 
 	/* The broadcast address is reserved */
-	i3c_addr_slots_set(slots, I3C_BROADCAST_ADDR,
+	i3c_addr_slots_set(&data->attached_dev.addr_slots, I3C_BROADCAST_ADDR,
 			   I3C_ADDR_SLOT_STATUS_RSVD);
+
+	/*
+	 * Mark all I2C addresses first.
+	 */
+	for (i = 0; i < config->dev_list.num_i2c; i++) {
+		i2c_dev = &config->dev_list.i2c[i];
+		ret = i3c_attach_i2c_device(i2c_dev);
+		if (ret != 0) {
+			/* Address slot is not free */
+			ret = -EINVAL;
+			goto out;
+		}
+	}
 
 	/*
 	 * If there is a static address for the I3C devices, check
 	 * if this address is free, and there is no other devices of
 	 * the same (pre-assigned) address on the bus.
 	 */
-	for (i = 0; i < dev_list->num_i3c; i++) {
-		i3c_dev = &dev_list->i3c[i];
-		if (i3c_dev->static_addr != 0U) {
-			if (i3c_addr_slots_is_free(slots, i3c_dev->static_addr)) {
-				/*
-				 * Mark address slot as I3C device for now to
-				 * detect address collisons. This marking may be
-				 * released during address assignment.
-				 */
-				i3c_addr_slots_mark_i3c(slots, i3c_dev->static_addr);
-			} else {
-				/* Address slot is not free */
-				ret = -EINVAL;
-				goto out;
-			}
-		}
-	}
-
-	/*
-	 * Mark all I2C addresses.
-	 */
-	for (i = 0; i < dev_list->num_i2c; i++) {
-		i2c_dev = &dev_list->i2c[i];
-		if (i3c_addr_slots_is_free(slots, i2c_dev->addr)) {
-			i3c_addr_slots_mark_i2c(slots, i2c_dev->addr);
-		} else {
+	for (i = 0; i < config->dev_list.num_i3c; i++) {
+		i3c_dev = &config->dev_list.i3c[i];
+		ret = i3c_attach_i3c_device(i3c_dev);
+		if (ret != 0) {
 			/* Address slot is not free */
 			ret = -EINVAL;
 			goto out;
@@ -185,6 +181,7 @@ struct i3c_device_desc *i3c_dev_list_find(const struct i3c_dev_list *dev_list,
 
 	__ASSERT_NO_MSG(dev_list != NULL);
 
+	/* this only searches known I3C PIDs */
 	for (i = 0; i < dev_list->num_i3c; i++) {
 		struct i3c_device_desc *desc = &dev_list->i3c[i];
 
@@ -197,16 +194,16 @@ struct i3c_device_desc *i3c_dev_list_find(const struct i3c_dev_list *dev_list,
 	return ret;
 }
 
-struct i3c_device_desc *i3c_dev_list_i3c_addr_find(const struct i3c_dev_list *dev_list,
+struct i3c_device_desc *i3c_dev_list_i3c_addr_find(struct i3c_dev_attached_list *dev_list,
 						   uint8_t addr)
 {
-	int i;
+	sys_snode_t *node;
 	struct i3c_device_desc *ret = NULL;
 
 	__ASSERT_NO_MSG(dev_list != NULL);
 
-	for (i = 0; i < dev_list->num_i3c; i++) {
-		struct i3c_device_desc *desc = &dev_list->i3c[i];
+	SYS_SLIST_FOR_EACH_NODE(&dev_list->devices.i3c, node) {
+		struct i3c_device_desc *desc = (void *)node;
 
 		if (desc->dynamic_addr == addr) {
 			ret = desc;
@@ -217,16 +214,16 @@ struct i3c_device_desc *i3c_dev_list_i3c_addr_find(const struct i3c_dev_list *de
 	return ret;
 }
 
-struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(const struct i3c_dev_list *dev_list,
-						       uint16_t addr)
+struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(struct i3c_dev_attached_list *dev_list,
+							   uint16_t addr)
 {
-	int i;
+	sys_snode_t *node;
 	struct i3c_i2c_device_desc *ret = NULL;
 
 	__ASSERT_NO_MSG(dev_list != NULL);
 
-	for (i = 0; i < dev_list->num_i2c; i++) {
-		struct i3c_i2c_device_desc *desc = &dev_list->i2c[i];
+	SYS_SLIST_FOR_EACH_NODE(&dev_list->devices.i2c, node) {
+		struct i3c_i2c_device_desc *desc = (void *)node;
 
 		if (desc->addr == addr) {
 			ret = desc;
@@ -235,6 +232,198 @@ struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(const struct i3c_dev_list
 	}
 
 	return ret;
+}
+
+int i3c_determine_default_addr(struct i3c_device_desc *target, uint8_t *addr)
+{
+	struct i3c_driver_data *data = (struct i3c_driver_data *)target->bus->data;
+
+	/* If dynamic addr is set, then it assumed that it was assigned by a primary controller */
+	if (target->dynamic_addr == 0) {
+		/* It is assumed that SETDASA or ENTDAA will be run after this */
+		if (target->init_dynamic_addr != 0U) {
+			/* initial dynamic address is requested */
+			if (target->static_addr == 0) {
+				/* SA is set to 0, so DA will be set with ENTDAA */
+				if (i3c_addr_slots_is_free(&data->attached_dev.addr_slots,
+							   target->init_dynamic_addr)) {
+					/* Set DA during ENTDAA */
+					*addr = target->init_dynamic_addr;
+				} else {
+					/* address is not free, get the next one */
+					*addr = i3c_addr_slots_next_free_find(
+						&data->attached_dev.addr_slots);
+				}
+			} else {
+				/* Use the init dynamic address as it's DA, but the RR will need to
+				 * be first set with it's SA to run SETDASA, the RR address will
+				 * need be updated after SETDASA with the request dynamic address
+				 */
+				if (i3c_addr_slots_is_free(&data->attached_dev.addr_slots,
+							   target->static_addr)) {
+					*addr = target->static_addr;
+				} else {
+					/* static address has already been taken */
+					return -EINVAL;
+				}
+			}
+		} else {
+			/* no init dynamic address is requested */
+			if (target->static_addr != 0) {
+				if (i3c_addr_slots_is_free(&data->attached_dev.addr_slots,
+							   target->static_addr)) {
+					/* static exists, set DA with same SA during SETDASA*/
+					*addr = target->static_addr;
+				} else {
+					/* static address has already been taken */
+					return -EINVAL;
+				}
+			} else {
+				/* pick a DA to use */
+				*addr = i3c_addr_slots_next_free_find(
+					&data->attached_dev.addr_slots);
+			}
+		}
+	} else {
+		*addr = target->dynamic_addr;
+	}
+
+	return 0;
+}
+
+int i3c_attach_i3c_device(struct i3c_device_desc *target)
+{
+	struct i3c_driver_data *data = (struct i3c_driver_data *)target->bus->data;
+	const struct i3c_driver_api *api = (const struct i3c_driver_api *)target->bus->api;
+	sys_snode_t *node;
+	uint8_t addr = 0;
+	int status = 0;
+
+	/* check to see if the device has already been attached */
+	if (!sys_slist_is_empty(&data->attached_dev.devices.i3c)) {
+		SYS_SLIST_FOR_EACH_NODE(&data->attached_dev.devices.i3c, node) {
+			if (node == &target->node) {
+				return -EINVAL;
+			}
+		}
+	}
+
+	status = i3c_determine_default_addr(target, &addr);
+	if (status != 0) {
+		return status;
+	}
+
+	sys_slist_append(&data->attached_dev.devices.i3c, &target->node);
+
+	if (api->attach_i3c_device != NULL) {
+		status = api->attach_i3c_device(target->bus, target, addr);
+	}
+
+	i3c_addr_slots_mark_i3c(&data->attached_dev.addr_slots, addr);
+
+	return status;
+}
+
+int i3c_reattach_i3c_device(struct i3c_device_desc *target, uint8_t old_dyn_addr)
+{
+	struct i3c_driver_data *data = (struct i3c_driver_data *)target->bus->data;
+	const struct i3c_driver_api *api = (const struct i3c_driver_api *)target->bus->api;
+	int status = 0;
+
+	if (!i3c_addr_slots_is_free(&data->attached_dev.addr_slots, target->dynamic_addr)) {
+		return -EINVAL;
+	}
+
+	if (api->reattach_i3c_device != NULL) {
+		status = api->reattach_i3c_device(target->bus, target, old_dyn_addr);
+	}
+
+	if (old_dyn_addr) {
+		/* mark the old address as free */
+		i3c_addr_slots_mark_free(&data->attached_dev.addr_slots, old_dyn_addr);
+	}
+
+	i3c_addr_slots_mark_i3c(&data->attached_dev.addr_slots, target->dynamic_addr);
+
+	return status;
+}
+
+int i3c_detach_i3c_device(struct i3c_device_desc *target)
+{
+	struct i3c_driver_data *data = (struct i3c_driver_data *)target->bus->data;
+	const struct i3c_driver_api *api = (const struct i3c_driver_api *)target->bus->api;
+	int status = 0;
+
+	if (!sys_slist_is_empty(&data->attached_dev.devices.i3c)) {
+		if (!sys_slist_find_and_remove(&data->attached_dev.devices.i3c, &target->node)) {
+			return -EINVAL;
+		}
+	} else {
+		return -EINVAL;
+	}
+
+	if (api->detach_i3c_device != NULL) {
+		status = api->detach_i3c_device(target->bus, target);
+	}
+
+	i3c_addr_slots_mark_free(&data->attached_dev.addr_slots,
+				 target->dynamic_addr ? target->dynamic_addr : target->static_addr);
+
+	return status;
+}
+
+int i3c_attach_i2c_device(struct i3c_i2c_device_desc *target)
+{
+	struct i3c_driver_data *data = (struct i3c_driver_data *)target->bus->data;
+	const struct i3c_driver_api *api = (const struct i3c_driver_api *)target->bus->api;
+	sys_snode_t *node;
+	int status = 0;
+
+	/* check to see if the device has already been attached */
+	if (!sys_slist_is_empty(&data->attached_dev.devices.i2c)) {
+		SYS_SLIST_FOR_EACH_NODE(&data->attached_dev.devices.i2c, node) {
+			if (node == &target->node) {
+				return -EINVAL;
+			}
+		}
+	}
+
+	if (!i3c_addr_slots_is_free(&data->attached_dev.addr_slots, target->addr)) {
+		return -EINVAL;
+	}
+
+	sys_slist_append(&data->attached_dev.devices.i2c, &target->node);
+
+	if (api->attach_i2c_device != NULL) {
+		status = api->attach_i2c_device(target->bus, target);
+	}
+
+	i3c_addr_slots_mark_i2c(&data->attached_dev.addr_slots, target->addr);
+
+	return status;
+}
+
+int i3c_detach_i2c_device(struct i3c_i2c_device_desc *target)
+{
+	struct i3c_driver_data *data = (struct i3c_driver_data *)target->bus->data;
+	const struct i3c_driver_api *api = (const struct i3c_driver_api *)target->bus->api;
+	int status = 0;
+
+	if (!sys_slist_is_empty(&data->attached_dev.devices.i2c)) {
+		if (!sys_slist_find_and_remove(&data->attached_dev.devices.i2c, &target->node)) {
+			return -EINVAL;
+		}
+	} else {
+		return -EINVAL;
+	}
+
+	if (api->detach_i2c_device != NULL) {
+		status = api->detach_i2c_device(target->bus, target);
+	}
+
+	i3c_addr_slots_mark_free(&data->attached_dev.addr_slots, target->addr);
+
+	return status;
 }
 
 int i3c_dev_list_daa_addr_helper(struct i3c_addr_slots *addr_slots,
@@ -408,8 +597,16 @@ static int i3c_bus_setdasa(const struct device *dev,
 		if (ret == 0) {
 			desc->dynamic_addr = (desc->init_dynamic_addr ? desc->init_dynamic_addr
 								      : desc->static_addr);
-			i3c_reattach_i3c_device(desc, desc->static_addr);
+			if (desc->dynamic_addr != desc->static_addr) {
+				if (i3c_reattach_i3c_device(desc, desc->static_addr) != 0) {
+					LOG_ERR("Failed to reattach %s (%d)", desc->dev->name, ret);
+				}
+			}
 		} else {
+			/* SETDASA failed, detach it from the controller */
+			if (i3c_detach_i3c_device(desc) != 0) {
+				LOG_ERR("Failed to detach %s (%d)", desc->dev->name, ret);
+			}
 			LOG_ERR("SETDASA error on address 0x%x (%d)",
 				desc->static_addr, ret);
 			continue;

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -488,9 +488,26 @@ __subsystem struct i3c_driver_api {
 	int (*recover_bus)(const struct device *dev);
 
 	/**
+	 * I3C Device Attach
+	 *
+	 * Optional API.
+	 *
+	 * @see i3c_attach_i3c_device
+	 *
+	 * @param dev Pointer to controller device driver instance.
+	 * @param target Pointer to target device descriptor.
+	 * @param addr Address to attach with
+	 *
+	 * @return @see i3c_attach_i3c_device
+	 */
+	int (*attach_i3c_device)(const struct device *dev,
+			struct i3c_device_desc *target,
+			uint8_t addr);
+
+	/**
 	 * I3C Address Update
 	 *
-	 * Optional Controller only API.
+	 * Optional API.
 	 *
 	 * @see i3c_reattach_i3c_device
 	 *
@@ -503,6 +520,51 @@ __subsystem struct i3c_driver_api {
 	int (*reattach_i3c_device)(const struct device *dev,
 			struct i3c_device_desc *target,
 			uint8_t old_dyn_addr);
+
+	/**
+	 * I3C Device Detach
+	 *
+	 * Optional API.
+	 *
+	 * @see i3c_detach_i3c_device
+	 *
+	 * @param dev Pointer to controller device driver instance.
+	 * @param target Pointer to target device descriptor.
+	 *
+	 * @return @see i3c_detach_i3c_device
+	 */
+	int (*detach_i3c_device)(const struct device *dev,
+			struct i3c_device_desc *target);
+
+	/**
+	 * I2C Device Attach
+	 *
+	 * Optional API.
+	 *
+	 * @see i3c_attach_i2c_device
+	 *
+	 * @param dev Pointer to controller device driver instance.
+	 * @param target Pointer to target device descriptor.
+	 *
+	 * @return @see i3c_attach_i2c_device
+	 */
+	int (*attach_i2c_device)(const struct device *dev,
+			struct i3c_i2c_device_desc *target);
+
+	/**
+	 * I2C Device Detach
+	 *
+	 * Optional API.
+	 *
+	 * @see i3c_detach_i2c_device
+	 *
+	 * @param dev Pointer to controller device driver instance.
+	 * @param target Pointer to target device descriptor.
+	 *
+	 * @return @see i3c_detach_i2c_device
+	 */
+	int (*detach_i2c_device)(const struct device *dev,
+			struct i3c_i2c_device_desc *target);
 
 	/**
 	 * Perform Dynamic Address Assignment via ENTDAA.
@@ -889,19 +951,49 @@ struct i3c_i2c_device_desc {
 /**
  * @brief Structure for describing attached devices for a controller.
  *
- * This contains arrays of attached I3C and I2C devices.
+ * This contains slists of attached I3C and I2C devices.
+ *
+ * This is a helper struct that can be used by controller device
+ * driver to aid in device management.
+ */
+struct i3c_dev_attached_list {
+	/**
+	 * Address slots:
+	 * - Aid in dynamic address assignment.
+	 * - Quick way to find out if a target address is
+	 *   a I3C or I2C device.
+	 */
+	struct i3c_addr_slots addr_slots;
+
+	struct {
+		/**
+		 * Linked list of attached I3C devices.
+		 */
+		sys_slist_t i3c;
+
+		/**
+		 * Linked list of attached I2C devices.
+		 */
+		sys_slist_t i2c;
+	} devices;
+};
+
+/**
+ * @brief Structure for describing known devices for a controller.
+ *
+ * This contains arrays of known I3C and I2C devices.
  *
  * This is a helper struct that can be used by controller device
  * driver to aid in device management.
  */
 struct i3c_dev_list {
 	/**
-	 * Pointer to array of attached I3C devices.
+	 * Pointer to array of known I3C devices.
 	 */
 	struct i3c_device_desc * const i3c;
 
 	/**
-	 * Pointer to array of attached I2C devices.
+	 * Pointer to array of known I2C devices.
 	 */
 	struct i3c_i2c_device_desc * const i2c;
 
@@ -914,6 +1006,28 @@ struct i3c_dev_list {
 	 * Number of I2C devices in array.
 	 */
 	const uint8_t num_i2c;
+};
+
+/**
+ * This structure is common to all I3C drivers and is expected to be
+ * the first element in the object pointed to by the config field
+ * in the device structure.
+ */
+struct i3c_driver_config {
+	/** I3C/I2C device list struct. */
+	struct i3c_dev_list dev_list;
+};
+
+/**
+ * This structure is common to all I3C drivers and is expected to be the first
+ * element in the driver's struct driver_data declaration.
+ */
+struct i3c_driver_data {
+	/** Controller Configuration */
+	struct i3c_config_controller ctrl_config;
+
+	/** Attached I3C/I2C devices and addresses */
+	struct i3c_dev_attached_list attached_dev;
 };
 
 /**
@@ -934,8 +1048,8 @@ struct i3c_device_desc *i3c_dev_list_find(const struct i3c_dev_list *dev_list,
 /**
  * @brief Find a I3C target device descriptor by dynamic address.
  *
- * This finds the I3C target device descriptor in the device list
- * matching the dynamic address (@p addr)
+ * This finds the I3C target device descriptor in the attached
+ * device list matching the dynamic address (@p addr)
  *
  * @param dev_list Pointer to the device list struct.
  * @param addr Dynamic address to be matched.
@@ -943,14 +1057,14 @@ struct i3c_device_desc *i3c_dev_list_find(const struct i3c_dev_list *dev_list,
  * @return Pointer the the I3C target device descriptor, or
  *         NULL if none is found.
  */
-struct i3c_device_desc *i3c_dev_list_i3c_addr_find(const struct i3c_dev_list *dev_list,
+struct i3c_device_desc *i3c_dev_list_i3c_addr_find(struct i3c_dev_attached_list *dev_list,
 						   uint8_t addr);
 
 /**
  * @brief Find a I2C target device descriptor by address.
  *
- * This finds the I2C target device descriptor in the device list
- * matching the address (@p addr)
+ * This finds the I2C target device descriptor in the attached
+ * device list matching the address (@p addr)
  *
  * @param dev_list Pointer to the device list struct.
  * @param addr Address to be matched.
@@ -958,8 +1072,23 @@ struct i3c_device_desc *i3c_dev_list_i3c_addr_find(const struct i3c_dev_list *de
  * @return Pointer the the I2C target device descriptor, or
  *         NULL if none is found.
  */
-struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(const struct i3c_dev_list *dev_list,
-						       uint16_t addr);
+struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(struct i3c_dev_attached_list *dev_list,
+							   uint16_t addr);
+
+/**
+ * @brief Helper function to find the default address an i3c device is attached with
+ *
+ * This is a helper function to find the default address the
+ * device will be loaded with. This could be either it's static
+ * address, a requested dynamic address, or just a dynamic address
+ * that is available
+ * @param[in] target The pointer of the device descriptor
+ * @param[out] addr Address to be assigned to target device.
+ *
+ * @retval 0 if successful.
+ * @retval -EINVAL if the expected default address is already in use
+ */
+int i3c_determine_default_addr(struct i3c_device_desc *target, uint8_t *addr);
 
 /**
  * @brief Helper function to find a usable address during ENTDAA.
@@ -1101,6 +1230,27 @@ static inline int i3c_recover_bus(const struct device *dev)
 }
 
 /**
+ * @brief Attach an I3C device
+ *
+ * Called to attach a I3C device to the addresses. This is
+ * typically called before a SETDASA or ENTDAA to reserve
+ * the addresses. This will also call the optional api to
+ * update any registers within the driver if implemented.
+ *
+ * @warning
+ * Use cases involving multiple writers to the i3c/i2c devices must prevent
+ * concurrent write operations, either by preventing all writers from
+ * being preempted or by using a mutex to govern writes to the i3c/i2c devices.
+ *
+ * @param target Pointer to the target device descriptor
+ *
+ * @retval 0 If successful.
+ * @retval -EINVAL If address is not available or if the device
+ *     has already been attached before
+ */
+int i3c_attach_i3c_device(struct i3c_device_desc *target);
+
+/**
  * @brief Reattach I3C device
  *
  * called after every time an I3C device has its address
@@ -1108,8 +1258,14 @@ static inline int i3c_recover_bus(const struct device *dev)
  * down and has lost its address, or it can happen when a
  * device had a static address and has been assigned a
  * dynamic address with SETDASA or a dynamic address has
- * been updated with SETNEWDA.
- * This method is optional.
+ * been updated with SETNEWDA. This will also call the
+ * optional api to update any registers within the driver
+ * if implemented.
+ *
+ * @warning
+ * Use cases involving multiple writers to the i3c/i2c devices must prevent
+ * concurrent write operations, either by preventing all writers from
+ * being preempted or by using a mutex to govern writes to the i3c/i2c devices.
  *
  * @param target Pointer to the target device descriptor
  * @param old_dyn_addr The old dynamic address of target device, 0 if
@@ -1118,18 +1274,67 @@ static inline int i3c_recover_bus(const struct device *dev)
  * @retval 0 If successful.
  * @retval -EINVAL If address is not available
  */
-static inline int i3c_reattach_i3c_device(struct i3c_device_desc *target,
-			uint8_t old_dyn_addr)
-{
-	const struct i3c_driver_api *api =
-		(const struct i3c_driver_api *)target->bus->api;
+int i3c_reattach_i3c_device(struct i3c_device_desc *target, uint8_t old_dyn_addr);
 
-	if (api->reattach_i3c_device == NULL) {
-		return -ENOSYS;
-	}
+/**
+ * @brief Detach I3C Device
+ *
+ * called to remove an I3C device and to free up the address
+ * that it used. If it's dynamic address was not set, then it
+ * assumed that SETDASA failed and will free it's static addr.
+ * This will also call the optional api to update any registers
+ * within the driver if implemented.
+ *
+ * @warning
+ * Use cases involving multiple writers to the i3c/i2c devices must prevent
+ * concurrent write operations, either by preventing all writers from
+ * being preempted or by using a mutex to govern writes to the i3c/i2c devices.
+ *
+ * @param target Pointer to the target device descriptor
+ *
+ * @retval 0 If successful.
+ * @retval -EINVAL If device is already detached
+ */
+int i3c_detach_i3c_device(struct i3c_device_desc *target);
 
-	return api->reattach_i3c_device(target->bus, target, old_dyn_addr);
-}
+/**
+ * @brief Attach an I2C device
+ *
+ * Called to attach a I2C device to the addresses. This will
+ * also call the optional api to update any registers within
+ * the driver if implemented.
+ *
+ * @warning
+ * Use cases involving multiple writers to the i3c/i2c devices must prevent
+ * concurrent write operations, either by preventing all writers from
+ * being preempted or by using a mutex to govern writes to the i3c/i2c devices.
+ *
+ * @param target Pointer to the target device descriptor
+ *
+ * @retval 0 If successful.
+ * @retval -EINVAL If address is not available or if the device
+ *     has already been attached before
+ */
+int i3c_attach_i2c_device(struct i3c_i2c_device_desc *target);
+
+/**
+ * @brief Detach I2C Device
+ *
+ * called to remove an I2C device and to free up the address
+ * that it used. This will also call the optional api to
+ * update any registers within the driver if implemented.
+ *
+ * @warning
+ * Use cases involving multiple writers to the i3c/i2c devices must prevent
+ * concurrent write operations, either by preventing all writers from
+ * being preempted or by using a mutex to govern writes to the i3c/i2c devices.
+ *
+ * @param target Pointer to the target device descriptor
+ *
+ * @retval 0 If successful.
+ * @retval -EINVAL If device is already detached
+ */
+int i3c_detach_i2c_device(struct i3c_i2c_device_desc *target);
 
 /**
  * @brief Perform Dynamic Address Assignment on the I3C bus.

--- a/include/zephyr/drivers/i3c/addresses.h
+++ b/include/zephyr/drivers/i3c/addresses.h
@@ -49,14 +49,12 @@ struct i3c_addr_slots {
  * This clears out the assigned address bits, and set the reserved
  * address bits according to the I3C specification.
  *
- * @param slots Pointer to address slots struct.
- * @param dev_list Pointer to device list struct.
+ * @param dev Pointer to controller device driver instance.
  *
  * @retval 0 if successful.
  * @retval -EINVAL if duplicate addresses.
  */
-int i3c_addr_slots_init(struct i3c_addr_slots *slots,
-			const struct i3c_dev_list *dev_list);
+int i3c_addr_slots_init(const struct device *dev);
 
 /**
  * @brief Set the address status of a device.

--- a/include/zephyr/drivers/i3c/ccc.h
+++ b/include/zephyr/drivers/i3c/ccc.h
@@ -870,6 +870,22 @@ int i3c_ccc_do_rstdaa_all(const struct device *controller);
 int i3c_ccc_do_setdasa(const struct i3c_device_desc *target);
 
 /**
+ * @brief Set New Dynamic Address for a target
+ *
+ * Helper function to do SETNEWDA(Set New Dynamic Address) for a particular target.
+ *
+ * Note this does not update @p target with the new dynamic address.
+ *
+ * @param[in] target Pointer to the target device descriptor where
+ *                   the device is configured with a static address.
+ * @param[in] new_da Pointer to the new_da struct.
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_setnewda(const struct i3c_device_desc *target,
+			  struct i3c_ccc_address new_da);
+
+/**
  * @brief Broadcast ENEC/DISEC to enable/disable target events.
  *
  * Helper function to broadcast Target Events Command to enable or


### PR DESCRIPTION
There are some needs to attach and reattach i3c/i2c devices at runtime
Some I2C devices can have special registers where the address can be
changed at runtime. Also some I3C devices can be powered off at runtime
freeing up the address space they take up.  These new APIs allow for these
to be changed at runtime. This also moves some config/data in to a common
i3c config/data structure which would allow the api to operate on to be
common for all I3C drivers.

Based/Depends on: https://github.com/zephyrproject-rtos/zephyr/pull/51538

Signed-off-by: Ryan McClelland <ryanmcclelland@meta.com>