### PR TITLE
intel_adsp: Move power domains under lps node for now

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -166,6 +166,52 @@
 		lps: lps@71ac0 {
 			compatible = "intel,adsp-lps";
 			reg = <0x00071ac0 0x100>;
+
+			hub_ulp_domain: hub_ulp_domain {
+				compatible = "intel,adsp-power-domain";
+				lps = <&lps>;
+				bit-position = <15>;
+			};
+			hub_hp_domain: hub_hpp_domain {
+				compatible = "intel,adsp-power-domain";
+				lps = <&lps>;
+				bit-position = <6>;
+			};
+			io0_domain: io0_domain {
+				compatible = "intel,adsp-power-domain";
+				lps = <&lps>;
+				bit-position = <8>;
+			};
+			io1_domain: io1_domain {
+				compatible = "intel,adsp-power-domain";
+				lps = <&lps>;
+				bit-position = <9>;
+			};
+			io2_domain: io2_domain {
+				compatible = "intel,adsp-power-domain";
+				lps = <&lps>;
+				bit-position = <10>;
+			};
+			io3_domain: io3_domain {
+				compatible = "intel,adsp-power-domain";
+				lps = <&lps>;
+				bit-position = <11>;
+			};
+			hst_domain: hst_domain {
+				compatible = "intel,adsp-power-domain";
+				lps = <&lps>;
+				bit-position = <4>;
+			};
+			ml0_domain: ml0_domain {
+				compatible = "intel,adsp-power-domain";
+				lps = <&lps>;
+				bit-position = <12>;
+			};
+			ml1_domain: ml1_domain {
+				compatible = "intel,adsp-power-domain";
+				lps = <&lps>;
+				bit-position = <13>;
+			};
 		};
 
 		sspbase: ssp_base@28800 {
@@ -385,50 +431,5 @@
 			status = "okay";
 		};
 
-		hub_ulp_domain: hub_ulp_domain {
-			compatible = "intel,adsp-power-domain";
-			lps = <&lps>;
-			bit-position = <15>;
-		};
-		hub_hp_domain: hub_hpp_domain {
-			compatible = "intel,adsp-power-domain";
-			lps = <&lps>;
-			bit-position = <6>;
-		};
-		io0_domain: io0_domain {
-			compatible = "intel,adsp-power-domain";
-			lps = <&lps>;
-			bit-position = <8>;
-		};
-		io1_domain: io1_domain {
-			compatible = "intel,adsp-power-domain";
-			lps = <&lps>;
-			bit-position = <9>;
-		};
-		io2_domain: io2_domain {
-			compatible = "intel,adsp-power-domain";
-			lps = <&lps>;
-			bit-position = <10>;
-		};
-		io3_domain: io3_domain {
-			compatible = "intel,adsp-power-domain";
-			lps = <&lps>;
-			bit-position = <11>;
-		};
-		hst_domain: hst_domain {
-			compatible = "intel,adsp-power-domain";
-			lps = <&lps>;
-			bit-position = <4>;
-		};
-		ml0_domain: ml0_domain {
-			compatible = "intel,adsp-power-domain";
-			lps = <&lps>;
-			bit-position = <12>;
-		};
-		ml1_domain: ml1_domain {
-			compatible = "intel,adsp-power-domain";
-			lps = <&lps>;
-			bit-position = <13>;
-		};
 	};
 };


### PR DESCRIPTION
As the power domain nodes don't represent something accessible via a MMIO register move those under the lps node to address warnings generated when building the DTS.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>