### PR TITLE
soc: arm: nxp_imx: Use CMSIS SystemInit() for platform initialization

### DIFF
--- a/boards/arm/mimxrt1010_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1010_evk/CMakeLists.txt
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+zephyr_library()
+zephyr_library_sources(init.c)
 
 if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
-  zephyr_library()
   if(NOT DEFINED CONFIG_BOARD_MIMXRT1010_EVK)
     message(WARNING "It appears you are using the board definition for "
      "the MIMXRT1010-EVK, but targeting a custom board. You may need to "

--- a/boards/arm/mimxrt1010_evk/init.c
+++ b/boards/arm/mimxrt1010_evk/init.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ #include <soc.h>
+
+void SystemInitHook(void)
+{
+#ifdef CONFIG_CODE_FLEXSPI
+	/* AT25SF128A SPI Flash on the RT1010-EVK requires special alignment
+	 * considerations, so set the READADDROPT bit in the FlexSPI so it
+	 * will fetch more data than each AHB burst requires to meet alignment
+	 * requirements
+	 *
+	 * Without this, the FlexSPI will return corrupted data during early
+	 * boot, causing a hardfault. This can also be resolved by enabling
+	 * the instruction cache in very early boot.
+	 */
+	FLEXSPI->AHBCR |= FLEXSPI_AHBCR_READADDROPT_MASK;
+#endif /* CONFIG_CODE_FLEXSPI */
+}

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -609,6 +609,7 @@ config SOC_SERIES_IMX_RT10XX
 	bool "i.MX RT 10XX Series"
 	select CPU_CORTEX_M7
 	select CPU_CORTEX_M_HAS_DWT
+	select PLATFORM_SPECIFIC_INIT
 
 config SOC_SERIES_IMX_RT11XX
 	bool "i.MX RT 11XX Series"

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -290,26 +290,6 @@ static int imxrt_init(const struct device *arg)
 	/* disable interrupts */
 	oldLevel = irq_lock();
 
-	/* Watchdog disable */
-	if ((WDOG1->WCR & WDOG_WCR_WDE_MASK) != 0) {
-		WDOG1->WCR &= ~WDOG_WCR_WDE_MASK;
-	}
-
-	if ((WDOG2->WCR & WDOG_WCR_WDE_MASK) != 0) {
-		WDOG2->WCR &= ~WDOG_WCR_WDE_MASK;
-	}
-
-	RTWDOG->CNT = 0xD928C520U; /* 0xD928C520U is the update key */
-	RTWDOG->TOVAL = 0xFFFF;
-	RTWDOG->CS = (uint32_t) ((RTWDOG->CS) & ~RTWDOG_CS_EN_MASK)
-		| RTWDOG_CS_UPDATE_MASK;
-
-	/* Disable Systick which might be enabled by bootrom */
-	if ((SysTick->CTRL & SysTick_CTRL_ENABLE_Msk) != 0) {
-		SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
-	}
-
-	SCB_EnableICache();
 	if ((SCB->CCR & SCB_CCR_DC_Msk) == 0) {
 		SCB_EnableDCache();
 	}
@@ -339,6 +319,8 @@ void z_arm_platform_init(void)
 	/* Zero BSS region */
 	memset(&__ocram_bss_start, 0, (&__ocram_bss_end - &__ocram_bss_start));
 #endif
+	/* Call CMSIS SystemInit */
+	SystemInit();
 }
 #endif
 


### PR DESCRIPTION
Move RT10xx series SOCs to use CMSIS SystemInit() in early boot. This standardizes the initialization flow to align with MCUXpresso SDK, and any updates that may be made there.

Additionally, set FlexSPI read address option bit (READADDROPT) in early boot for FlexSPI on RT1010. This fixes an issue where the FlexSPI fetch would return invalid data, resulting an a HardFault.