### PR TITLE
drivers/dai/intel/ssp: Skip setting config when playback/capture is a…

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -1541,9 +1541,9 @@ static int dai_ssp_set_config_blob(struct dai_intel_ssp *dp, const struct dai_co
 	uint32_t ssc0, sstsa, ssrsa;
 
 	/* set config only once for playback or capture */
-	if (dp->sref > 1) {
+	if (ssp->state[DAI_DIR_PLAYBACK] > DAI_STATE_READY ||
+	    ssp->state[DAI_DIR_CAPTURE] > DAI_STATE_READY)
 		return 0;
-	}
 
 	ssc0 = blob->i2s_driver_config.i2s_config.ssc0;
 	sstsa = blob->i2s_driver_config.i2s_config.sstsa;


### PR DESCRIPTION
…ctive

The reference count, dp->sref, is never incremented for the SSP DAI as we use the runtime PM API's to probe/remove the DAI during resume/suspend. Therefore, use the DAI state to check if the DAI is active in any direction before proceesing to set the config. This fixes the IO errors seen during simultaenous playback and capture on the same SSP.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>