### PR TITLE
Refactor llcp pdu length validation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -797,8 +797,8 @@ struct pdu_data_llctrl {
 		struct pdu_data_llctrl_min_used_chans_ind min_used_chans_ind;
 		struct pdu_data_llctrl_cte_req cte_req;
 		struct pdu_data_llctrl_cte_rsp cte_rsp;
-		struct pdu_data_llctrl_clock_accuracy_req sca_req;
-		struct pdu_data_llctrl_clock_accuracy_rsp sca_rsp;
+		struct pdu_data_llctrl_clock_accuracy_req clock_accuracy_req;
+		struct pdu_data_llctrl_clock_accuracy_rsp clock_accuracy_rsp;
 		struct pdu_data_llctrl_cis_req cis_req;
 		struct pdu_data_llctrl_cis_rsp cis_rsp;
 		struct pdu_data_llctrl_cis_ind cis_ind;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -1210,308 +1210,190 @@ static bool pdu_is_terminate(struct pdu_data *pdu)
 	return pdu->llctrl.opcode == PDU_DATA_LLCTRL_TYPE_TERMINATE_IND;
 }
 
+#define VALIDATE_PDU_LEN(pdu, type) (pdu->len == PDU_DATA_LLCTRL_LEN(type))
+
 #if defined(CONFIG_BT_PERIPHERAL)
 static bool pdu_validate_conn_update_ind(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.conn_update_ind) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, conn_update_ind);
 }
 
 static bool pdu_validate_chan_map_ind(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.chan_map_ind) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, chan_map_ind);
 }
 #endif /* CONFIG_BT_PERIPHERAL */
 
 static bool pdu_validate_terminate_ind(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.terminate_ind) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, terminate_ind);
 }
 
 #if defined(CONFIG_BT_CTLR_LE_ENC) && defined(CONFIG_BT_PERIPHERAL)
 static bool pdu_validate_enc_req(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.enc_req) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, enc_req);
 }
 #endif /* CONFIG_BT_CTLR_LE_ENC && CONFIG_BT_PERIPHERAL */
 
 #if defined(CONFIG_BT_CTLR_LE_ENC) && defined(CONFIG_BT_CENTRAL)
 static bool pdu_validate_enc_rsp(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.enc_rsp) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, enc_rsp);
 }
 
 static bool pdu_validate_start_enc_req(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.start_enc_req) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, start_enc_req);
 }
 #endif /* CONFIG_BT_CTLR_LE_ENC && CONFIG_BT_CENTRAL */
 
 #if defined(CONFIG_BT_CTLR_LE_ENC) && defined(CONFIG_BT_PERIPHERAL)
 static bool pdu_validate_start_enc_rsp(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.start_enc_rsp) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, start_enc_rsp);
 }
 #endif
 
 static bool pdu_validate_unknown_rsp(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.unknown_rsp) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, unknown_rsp);
 }
 
 #if defined(CONFIG_BT_PERIPHERAL)
 static bool pdu_validate_feature_req(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.feature_req) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, feature_req);
 }
 #endif
 
 #if defined(CONFIG_BT_CENTRAL)
 static bool pdu_validate_feature_rsp(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.feature_rsp) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, feature_rsp);
 }
 #endif
 
 #if defined(CONFIG_BT_CTLR_LE_ENC) && defined(CONFIG_BT_PERIPHERAL)
 static bool pdu_validate_pause_enc_req(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.pause_enc_req) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, pause_enc_req);
 }
 #endif /* CONFIG_BT_CTLR_LE_ENC && CONFIG_BT_PERIPHERAL */
 
 #if defined(CONFIG_BT_CTLR_LE_ENC) && defined(CONFIG_BT_CENTRAL)
 static bool pdu_validate_pause_enc_rsp(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.pause_enc_rsp) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, pause_enc_rsp);
 }
 #endif
 
 static bool pdu_validate_version_ind(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.version_ind) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, version_ind);
 }
 
 static bool pdu_validate_reject_ind(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.reject_ind) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, reject_ind);
 }
 
 #if defined(CONFIG_BT_CTLR_PER_INIT_FEAT_XCHG) && defined(CONFIG_BT_CENTRAL)
 static bool pdu_validate_per_init_feat_xchg(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.per_init_feat_xchg) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, per_init_feat_xchg);
 }
 #endif /* CONFIG_BT_CTLR_PER_INIT_FEAT_XCHG && CONFIG_BT_CENTRAL */
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 static bool pdu_validate_conn_param_req(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.conn_param_req) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, conn_param_req);
 }
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 
 static bool pdu_validate_conn_param_rsp(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.conn_param_rsp) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, conn_param_rsp);
 }
 
 static bool pdu_validate_reject_ext_ind(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.reject_ext_ind) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, reject_ext_ind);
 }
 
 #if defined(CONFIG_BT_CTLR_LE_PING)
 static bool pdu_validate_ping_req(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.ping_req) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, ping_req);
 }
 #endif /* CONFIG_BT_CTLR_LE_PING */
 
 static bool pdu_validate_ping_rsp(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.ping_rsp) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, ping_rsp);
 }
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 static bool pdu_validate_length_req(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.length_req) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, length_req);
 }
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 static bool pdu_validate_length_rsp(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.length_rsp) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, length_rsp);
 }
 
 #if defined(CONFIG_BT_CTLR_PHY)
 static bool pdu_validate_phy_req(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.phy_req) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, phy_req);
 }
 #endif /* CONFIG_BT_CTLR_PHY */
 
 static bool pdu_validate_phy_rsp(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.phy_rsp) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, phy_rsp);
 }
 
 static bool pdu_validate_phy_upd_ind(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.phy_upd_ind) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, phy_upd_ind);
 }
 
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN) && defined(CONFIG_BT_CENTRAL)
 static bool pdu_validate_min_used_chan_ind(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.min_used_chans_ind) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, min_used_chans_ind);
 }
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN && CONFIG_BT_CENTRAL */
 
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_REQ)
 static bool pdu_validate_cte_req(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.cte_req) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, cte_req);
 }
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_REQ */
 
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RSP)
 static bool pdu_validate_cte_resp(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.cte_rsp) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, cte_rsp);
 }
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RSP */
 
 #if defined(CONFIG_BT_CTLR_SCA_UPDATE)
 static bool pdu_validate_clock_accuracy_req(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.sca_req) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, clock_accuracy_req);
 }
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 static bool pdu_validate_clock_accuracy_rsp(struct pdu_data *pdu)
 {
-	if (pdu->len != sizeof(pdu->llctrl.sca_rsp) + 1) {
-		return false;
-	}
-
-	return true;
+	return VALIDATE_PDU_LEN(pdu, clock_accuracy_rsp);
 }
 
 typedef bool (*pdu_param_validate_t)(struct pdu_data *pdu);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -912,10 +912,10 @@ void llcp_pdu_decode_cis_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pd
  */
 void llcp_pdu_encode_clock_accuracy_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
-	struct pdu_data_llctrl_clock_accuracy_req *p = &pdu->llctrl.sca_req;
+	struct pdu_data_llctrl_clock_accuracy_req *p = &pdu->llctrl.clock_accuracy_req;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, sca_req) +
+	pdu->len = offsetof(struct pdu_data_llctrl, clock_accuracy_req) +
 		   sizeof(struct pdu_data_llctrl_clock_accuracy_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CLOCK_ACCURACY_REQ;
 	/* Currently we do not support variable SCA, so we always 'report' current SCA */
@@ -924,10 +924,10 @@ void llcp_pdu_encode_clock_accuracy_req(struct proc_ctx *ctx, struct pdu_data *p
 
 void llcp_pdu_encode_clock_accuracy_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
-	struct pdu_data_llctrl_clock_accuracy_rsp *p = &pdu->llctrl.sca_rsp;
+	struct pdu_data_llctrl_clock_accuracy_rsp *p = &pdu->llctrl.clock_accuracy_rsp;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, sca_rsp) +
+	pdu->len = offsetof(struct pdu_data_llctrl, clock_accuracy_rsp) +
 		   sizeof(struct pdu_data_llctrl_clock_accuracy_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CLOCK_ACCURACY_RSP;
 	/* Currently we do not support variable SCA, so we always 'report' current SCA */
@@ -936,14 +936,14 @@ void llcp_pdu_encode_clock_accuracy_rsp(struct proc_ctx *ctx, struct pdu_data *p
 
 void llcp_pdu_decode_clock_accuracy_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
-	struct pdu_data_llctrl_clock_accuracy_req *p = &pdu->llctrl.sca_req;
+	struct pdu_data_llctrl_clock_accuracy_req *p = &pdu->llctrl.clock_accuracy_req;
 
 	ctx->data.sca_update.sca = p->sca;
 }
 
 void llcp_pdu_decode_clock_accuracy_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
-	struct pdu_data_llctrl_clock_accuracy_rsp *p = &pdu->llctrl.sca_rsp;
+	struct pdu_data_llctrl_clock_accuracy_rsp *p = &pdu->llctrl.clock_accuracy_rsp;
 
 	ctx->data.sca_update.sca = p->sca;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -61,16 +61,14 @@
 void llcp_pdu_encode_ping_req(struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, ping_req) +
-		   sizeof(struct pdu_data_llctrl_ping_req);
+	pdu->len = PDU_DATA_LLCTRL_LEN(ping_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_PING_REQ;
 }
 
 void llcp_pdu_encode_ping_rsp(struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, ping_rsp) +
-		   sizeof(struct pdu_data_llctrl_ping_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(ping_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_PING_RSP;
 }
 #endif /* CONFIG_BT_CTLR_LE_PING */
@@ -81,8 +79,7 @@ void llcp_pdu_encode_ping_rsp(struct pdu_data *pdu)
 void llcp_pdu_encode_unknown_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, unknown_rsp) +
-		   sizeof(struct pdu_data_llctrl_unknown_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(unknown_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_UNKNOWN_RSP;
 
 	pdu->llctrl.unknown_rsp.type = ctx->unknown_response.type;
@@ -98,8 +95,7 @@ void llcp_ntf_encode_unknown_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
 	struct pdu_data_llctrl_unknown_rsp *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, unknown_rsp) +
-		   sizeof(struct pdu_data_llctrl_unknown_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(unknown_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_UNKNOWN_RSP;
 	p = &pdu->llctrl.unknown_rsp;
 	p->type = ctx->unknown_response.type;
@@ -130,8 +126,7 @@ void llcp_pdu_encode_feature_req(struct ll_conn *conn, struct pdu_data *pdu)
 	struct pdu_data_llctrl_feature_req *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, feature_req) +
-		   sizeof(struct pdu_data_llctrl_feature_req);
+	pdu->len = PDU_DATA_LLCTRL_LEN(feature_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_FEATURE_REQ;
 
 #if defined(CONFIG_BT_CTLR_PER_INIT_FEAT_XCHG) && defined(CONFIG_BT_PERIPHERAL)
@@ -150,8 +145,7 @@ void llcp_pdu_encode_feature_rsp(struct ll_conn *conn, struct pdu_data *pdu)
 	uint64_t feature_rsp = LL_FEAT;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, feature_rsp) +
-		   sizeof(struct pdu_data_llctrl_feature_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(feature_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_FEATURE_RSP;
 
 	p = &pdu->llctrl.feature_rsp;
@@ -170,8 +164,7 @@ void llcp_ntf_encode_feature_rsp(struct ll_conn *conn, struct pdu_data *pdu)
 	struct pdu_data_llctrl_feature_rsp *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, feature_rsp) +
-		   sizeof(struct pdu_data_llctrl_feature_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(feature_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_FEATURE_RSP;
 	p = &pdu->llctrl.feature_rsp;
 
@@ -212,8 +205,7 @@ void llcp_pdu_encode_min_used_chans_ind(struct proc_ctx *ctx, struct pdu_data *p
 	struct pdu_data_llctrl_min_used_chans_ind *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, min_used_chans_ind) +
-		   sizeof(struct pdu_data_llctrl_min_used_chans_ind);
+	pdu->len = PDU_DATA_LLCTRL_LEN(min_used_chans_ind);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_MIN_USED_CHAN_IND;
 	p = &pdu->llctrl.min_used_chans_ind;
 	p->phys = ctx->data.muc.phys;
@@ -238,8 +230,7 @@ void llcp_pdu_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 	struct pdu_data_llctrl_terminate_ind *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, terminate_ind) +
-		   sizeof(struct pdu_data_llctrl_terminate_ind);
+	pdu->len = PDU_DATA_LLCTRL_LEN(terminate_ind);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_TERMINATE_IND;
 	p = &pdu->llctrl.terminate_ind;
 	p->error_code = ctx->data.term.error_code;
@@ -250,8 +241,7 @@ void llcp_ntf_encode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 	struct pdu_data_llctrl_terminate_ind *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, terminate_ind) +
-		   sizeof(struct pdu_data_llctrl_terminate_ind);
+	pdu->len = PDU_DATA_LLCTRL_LEN(terminate_ind);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_TERMINATE_IND;
 	p = &pdu->llctrl.terminate_ind;
 	p->error_code = ctx->data.term.error_code;
@@ -272,8 +262,7 @@ void llcp_pdu_encode_version_ind(struct pdu_data *pdu)
 	struct pdu_data_llctrl_version_ind *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, version_ind) +
-		   sizeof(struct pdu_data_llctrl_version_ind);
+	pdu->len = PDU_DATA_LLCTRL_LEN(version_ind);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_VERSION_IND;
 
 	p = &pdu->llctrl.version_ind;
@@ -289,8 +278,7 @@ void llcp_ntf_encode_version_ind(struct ll_conn *conn, struct pdu_data *pdu)
 	struct pdu_data_llctrl_version_ind *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, version_ind) +
-		   sizeof(struct pdu_data_llctrl_version_ind);
+	pdu->len = PDU_DATA_LLCTRL_LEN(version_ind);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_VERSION_IND;
 
 	p = &pdu->llctrl.version_ind;
@@ -328,8 +316,7 @@ void llcp_pdu_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 	struct pdu_data_llctrl_enc_req *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len =
-		offsetof(struct pdu_data_llctrl, enc_req) + sizeof(struct pdu_data_llctrl_enc_req);
+	pdu->len = PDU_DATA_LLCTRL_LEN(enc_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_ENC_REQ;
 
 	p = &pdu->llctrl.enc_req;
@@ -351,8 +338,7 @@ void llcp_ntf_encode_enc_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 	struct pdu_data_llctrl_enc_req *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len =
-		offsetof(struct pdu_data_llctrl, enc_req) + sizeof(struct pdu_data_llctrl_enc_req);
+	pdu->len = PDU_DATA_LLCTRL_LEN(enc_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_ENC_REQ;
 
 	p = &pdu->llctrl.enc_req;
@@ -366,8 +352,7 @@ void llcp_pdu_encode_enc_rsp(struct pdu_data *pdu)
 	struct pdu_data_llctrl_enc_rsp *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len =
-		offsetof(struct pdu_data_llctrl, enc_rsp) + sizeof(struct pdu_data_llctrl_enc_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(enc_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_ENC_RSP;
 
 	p = &pdu->llctrl.enc_rsp;
@@ -381,8 +366,7 @@ void llcp_pdu_encode_enc_rsp(struct pdu_data *pdu)
 void llcp_pdu_encode_start_enc_req(struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, start_enc_req) +
-		   sizeof(struct pdu_data_llctrl_start_enc_req);
+	pdu->len = PDU_DATA_LLCTRL_LEN(start_enc_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_START_ENC_REQ;
 }
 #endif /* CONFIG_BT_PERIPHERAL */
@@ -390,8 +374,7 @@ void llcp_pdu_encode_start_enc_req(struct pdu_data *pdu)
 void llcp_pdu_encode_start_enc_rsp(struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, start_enc_rsp) +
-		   sizeof(struct pdu_data_llctrl_start_enc_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(start_enc_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_START_ENC_RSP;
 }
 
@@ -399,8 +382,7 @@ void llcp_pdu_encode_start_enc_rsp(struct pdu_data *pdu)
 void llcp_pdu_encode_pause_enc_req(struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, pause_enc_req) +
-		   sizeof(struct pdu_data_llctrl_pause_enc_req);
+	pdu->len = PDU_DATA_LLCTRL_LEN(pause_enc_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_PAUSE_ENC_REQ;
 }
 #endif /* CONFIG_BT_CENTRAL */
@@ -408,8 +390,7 @@ void llcp_pdu_encode_pause_enc_req(struct pdu_data *pdu)
 void llcp_pdu_encode_pause_enc_rsp(struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, pause_enc_rsp) +
-		   sizeof(struct pdu_data_llctrl_pause_enc_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(pause_enc_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_PAUSE_ENC_RSP;
 }
 #endif /* CONFIG_BT_CTLR_LE_ENC */
@@ -417,8 +398,7 @@ void llcp_pdu_encode_pause_enc_rsp(struct pdu_data *pdu)
 void llcp_pdu_encode_reject_ind(struct pdu_data *pdu, uint8_t error_code)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, reject_ind) +
-		   sizeof(struct pdu_data_llctrl_reject_ind);
+	pdu->len = PDU_DATA_LLCTRL_LEN(reject_ind);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_REJECT_IND;
 	pdu->llctrl.reject_ind.error_code = error_code;
 }
@@ -426,8 +406,7 @@ void llcp_pdu_encode_reject_ind(struct pdu_data *pdu, uint8_t error_code)
 void llcp_pdu_encode_reject_ext_ind(struct pdu_data *pdu, uint8_t reject_opcode, uint8_t error_code)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, reject_ext_ind) +
-		   sizeof(struct pdu_data_llctrl_reject_ext_ind);
+	pdu->len = PDU_DATA_LLCTRL_LEN(reject_ext_ind);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_REJECT_EXT_IND;
 	pdu->llctrl.reject_ext_ind.reject_opcode = reject_opcode;
 	pdu->llctrl.reject_ext_ind.error_code = error_code;
@@ -444,8 +423,7 @@ void llcp_ntf_encode_reject_ext_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 	struct pdu_data_llctrl_reject_ext_ind *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, reject_ext_ind) +
-		   sizeof(struct pdu_data_llctrl_reject_ext_ind);
+	pdu->len = PDU_DATA_LLCTRL_LEN(reject_ext_ind);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_REJECT_EXT_IND;
 
 	p = (void *)&pdu->llctrl.reject_ext_ind;
@@ -461,8 +439,7 @@ void llcp_ntf_encode_reject_ext_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 void llcp_pdu_encode_phy_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len =
-		offsetof(struct pdu_data_llctrl, phy_req) + sizeof(struct pdu_data_llctrl_phy_req);
+	pdu->len = PDU_DATA_LLCTRL_LEN(phy_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_PHY_REQ;
 	pdu->llctrl.phy_req.rx_phys = ctx->data.pu.rx;
 	pdu->llctrl.phy_req.tx_phys = ctx->data.pu.tx;
@@ -478,8 +455,7 @@ void llcp_pdu_decode_phy_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 void llcp_pdu_encode_phy_rsp(struct ll_conn *conn, struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len =
-		offsetof(struct pdu_data_llctrl, phy_rsp) + sizeof(struct pdu_data_llctrl_phy_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(phy_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_PHY_RSP;
 	pdu->llctrl.phy_rsp.rx_phys = conn->phy_pref_rx;
 	pdu->llctrl.phy_rsp.tx_phys = conn->phy_pref_tx;
@@ -496,8 +472,7 @@ void llcp_pdu_decode_phy_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 void llcp_pdu_encode_phy_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, phy_upd_ind) +
-		   sizeof(struct pdu_data_llctrl_phy_upd_ind);
+	pdu->len = PDU_DATA_LLCTRL_LEN(phy_upd_ind);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_PHY_UPD_IND;
 	pdu->llctrl.phy_upd_ind.instant = sys_cpu_to_le16(ctx->data.pu.instant);
 	pdu->llctrl.phy_upd_ind.c_to_p_phy = ctx->data.pu.c_to_p_phy;
@@ -520,8 +495,7 @@ void llcp_pdu_encode_conn_param_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 	struct pdu_data_llctrl_conn_param_req *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, conn_param_req) +
-		   sizeof(struct pdu_data_llctrl_conn_param_req);
+	pdu->len = PDU_DATA_LLCTRL_LEN(conn_param_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CONN_PARAM_REQ;
 
 	p = (void *)&pdu->llctrl.conn_param_req;
@@ -544,8 +518,7 @@ void llcp_pdu_encode_conn_param_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
 	struct pdu_data_llctrl_conn_param_req *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, conn_param_rsp) +
-		   sizeof(struct pdu_data_llctrl_conn_param_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(conn_param_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CONN_PARAM_RSP;
 
 	p = (void *)&pdu->llctrl.conn_param_rsp;
@@ -607,8 +580,7 @@ void llcp_pdu_encode_conn_update_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
 	struct pdu_data_llctrl_conn_update_ind *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, conn_update_ind) +
-		   sizeof(struct pdu_data_llctrl_conn_update_ind);
+	pdu->len = PDU_DATA_LLCTRL_LEN(conn_update_ind);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CONN_UPDATE_IND;
 
 	p = (void *)&pdu->llctrl.conn_update_ind;
@@ -641,8 +613,7 @@ void llcp_pdu_encode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu_data *
 	struct pdu_data_llctrl_chan_map_ind *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, chan_map_ind) +
-		   sizeof(struct pdu_data_llctrl_chan_map_ind);
+	pdu->len = PDU_DATA_LLCTRL_LEN(chan_map_ind);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CHAN_MAP_IND;
 	p = &pdu->llctrl.chan_map_ind;
 	p->instant = sys_cpu_to_le16(ctx->data.chmu.instant);
@@ -664,8 +635,7 @@ void llcp_pdu_encode_length_req(struct ll_conn *conn, struct pdu_data *pdu)
 	struct pdu_data_llctrl_length_req *p = &pdu->llctrl.length_req;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, length_req) +
-		   sizeof(struct pdu_data_llctrl_length_req);
+	pdu->len = PDU_DATA_LLCTRL_LEN(length_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_LENGTH_REQ;
 	p->max_rx_octets = sys_cpu_to_le16(conn->lll.dle.local.max_rx_octets);
 	p->max_tx_octets = sys_cpu_to_le16(conn->lll.dle.local.max_tx_octets);
@@ -678,8 +648,7 @@ void llcp_pdu_encode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu)
 	struct pdu_data_llctrl_length_rsp *p = &pdu->llctrl.length_rsp;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, length_rsp) +
-		   sizeof(struct pdu_data_llctrl_length_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(length_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_LENGTH_RSP;
 	p->max_rx_octets = sys_cpu_to_le16(conn->lll.dle.local.max_rx_octets);
 	p->max_tx_octets = sys_cpu_to_le16(conn->lll.dle.local.max_tx_octets);
@@ -692,8 +661,7 @@ void llcp_ntf_encode_length_change(struct ll_conn *conn, struct pdu_data *pdu)
 	struct pdu_data_llctrl_length_rsp *p = &pdu->llctrl.length_rsp;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, length_rsp) +
-		   sizeof(struct pdu_data_llctrl_length_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(length_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_LENGTH_RSP;
 	p->max_rx_octets = sys_cpu_to_le16(conn->lll.dle.eff.max_rx_octets);
 	p->max_tx_octets = sys_cpu_to_le16(conn->lll.dle.eff.max_tx_octets);
@@ -782,8 +750,7 @@ void llcp_pdu_encode_cte_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 	struct pdu_data_llctrl_cte_req *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len =
-		offsetof(struct pdu_data_llctrl, cte_req) + sizeof(struct pdu_data_llctrl_cte_req);
+	pdu->len = PDU_DATA_LLCTRL_LEN(cte_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CTE_REQ;
 
 	p = &pdu->llctrl.cte_req;
@@ -804,8 +771,7 @@ void llcp_pdu_decode_cte_rsp(struct proc_ctx *ctx, const struct pdu_data *pdu)
 void llcp_ntf_encode_cte_req(struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len =
-		offsetof(struct pdu_data_llctrl, cte_rsp) + sizeof(struct pdu_data_llctrl_cte_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(cte_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CTE_RSP;
 
 	/* Received LL_CTE_RSP PDU didn't have CTE */
@@ -823,8 +789,7 @@ void llcp_pdu_decode_cte_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 void llcp_pdu_encode_cte_rsp(const struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len =
-		 offsetof(struct pdu_data_llctrl, cte_rsp) + sizeof(struct pdu_data_llctrl_cte_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(cte_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CTE_RSP;
 
 	/* Set content of a PDU header first byte, that is not changed by LLL */
@@ -871,8 +836,7 @@ void llcp_pdu_encode_cis_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
 	struct pdu_data_llctrl_cis_rsp *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len =
-		offsetof(struct pdu_data_llctrl, cis_rsp) + sizeof(struct pdu_data_llctrl_cis_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(cis_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CIS_RSP;
 
 	p = &pdu->llctrl.cis_rsp;
@@ -887,9 +851,7 @@ void llcp_pdu_encode_cis_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pd
 	struct pdu_data_llctrl_cis_terminate_ind *p;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len =
-		offsetof(struct pdu_data_llctrl, cis_terminate_ind) +
-		sizeof(struct pdu_data_llctrl_cis_terminate_ind);
+	pdu->len = PDU_DATA_LLCTRL_LEN(cis_terminate_ind);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CIS_TERMINATE_IND;
 
 	p = &pdu->llctrl.cis_terminate_ind;
@@ -915,8 +877,7 @@ void llcp_pdu_encode_clock_accuracy_req(struct proc_ctx *ctx, struct pdu_data *p
 	struct pdu_data_llctrl_clock_accuracy_req *p = &pdu->llctrl.clock_accuracy_req;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, clock_accuracy_req) +
-		   sizeof(struct pdu_data_llctrl_clock_accuracy_req);
+	pdu->len = PDU_DATA_LLCTRL_LEN(clock_accuracy_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CLOCK_ACCURACY_REQ;
 	/* Currently we do not support variable SCA, so we always 'report' current SCA */
 	p->sca = lll_clock_sca_local_get();
@@ -927,8 +888,7 @@ void llcp_pdu_encode_clock_accuracy_rsp(struct proc_ctx *ctx, struct pdu_data *p
 	struct pdu_data_llctrl_clock_accuracy_rsp *p = &pdu->llctrl.clock_accuracy_rsp;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, clock_accuracy_rsp) +
-		   sizeof(struct pdu_data_llctrl_clock_accuracy_rsp);
+	pdu->len = PDU_DATA_LLCTRL_LEN(clock_accuracy_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CLOCK_ACCURACY_RSP;
 	/* Currently we do not support variable SCA, so we always 'report' current SCA */
 	p->sca = lll_clock_sca_local_get();

--- a/tests/bluetooth/controller/common/src/helper_pdu.c
+++ b/tests/bluetooth/controller/common/src/helper_pdu.c
@@ -485,10 +485,10 @@ void helper_pdu_encode_sca_req(struct pdu_data *pdu, void *param)
 	struct pdu_data_llctrl_clock_accuracy_req *p = param;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, sca_req) +
+	pdu->len = offsetof(struct pdu_data_llctrl, clock_accuracy_req) +
 		sizeof(struct pdu_data_llctrl_clock_accuracy_req);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CLOCK_ACCURACY_REQ;
-	pdu->llctrl.sca_req.sca = p->sca;
+	pdu->llctrl.clock_accuracy_req.sca = p->sca;
 }
 
 void helper_pdu_encode_sca_rsp(struct pdu_data *pdu, void *param)
@@ -496,10 +496,10 @@ void helper_pdu_encode_sca_rsp(struct pdu_data *pdu, void *param)
 	struct pdu_data_llctrl_clock_accuracy_rsp *p = param;
 
 	pdu->ll_id = PDU_DATA_LLID_CTRL;
-	pdu->len = offsetof(struct pdu_data_llctrl, sca_rsp) +
+	pdu->len = offsetof(struct pdu_data_llctrl, clock_accuracy_rsp) +
 		sizeof(struct pdu_data_llctrl_clock_accuracy_rsp);
 	pdu->llctrl.opcode = PDU_DATA_LLCTRL_TYPE_CLOCK_ACCURACY_RSP;
-	pdu->llctrl.sca_rsp.sca = p->sca;
+	pdu->llctrl.clock_accuracy_rsp.sca = p->sca;
 }
 
 void helper_pdu_verify_version_ind(const char *file, uint32_t line, struct pdu_data *pdu,


### PR DESCRIPTION
Using a macro instead of repeated code for length validation 