### PR TITLE
drivers: watchdog: stm32 iwdg: max prescaler value

### DIFF
--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -21,7 +21,12 @@
 #include "wdt_iwdg_stm32.h"
 
 #define IWDG_PRESCALER_MIN	(4U)
-#define IWDG_PRESCALER_MAX	(256U)
+
+#if defined(LL_IWDG_PRESCALER_1024)
+#define IWDG_PRESCALER_MAX (1024U)
+#else
+#define IWDG_PRESCALER_MAX (256U)
+#endif
 
 #define IWDG_RELOAD_MIN		(0x0000U)
 #define IWDG_RELOAD_MAX		(0x0FFFU)
@@ -41,7 +46,7 @@
 
 /*
  * Status register needs 5 LSI clock cycles divided by prescaler to be updated.
- * With highest prescaler (256) and considering clock variation, we will wait
+ * With highest prescaler and considering clock variation, we will wait
  * maximum 6 cycles (48 ms at 32 kHz) for register update.
  */
 #define IWDG_SR_UPDATE_TIMEOUT	(6U * IWDG_PRESCALER_MAX * \


### PR DESCRIPTION
In some stm32 MUCs maximum prescaler value can be 1024.

Signed-off-by: Wojciech Slenska <wsl@trackunit.com>