### PR TITLE
net: sockets_tls: Fix memory leak in socket

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1730,7 +1730,7 @@ static int ztls_socket(int family, int type, int proto)
 	ret = protocol_check(family, type, &proto);
 	if (ret < 0) {
 		errno = -ret;
-		return -1;
+		goto free_fd;
 	}
 
 	ctx = tls_alloc();


### PR DESCRIPTION
Fix file descriptor leak on unsupported socket protocols passed to `ztls_socket()`.