### PR TITLE
footprint: Add unicast_audio_{server, client} samples to tracking

### DIFF
--- a/scripts/footprint/plan.txt
+++ b/scripts/footprint/plan.txt
@@ -19,6 +19,8 @@ bt_peripheral,default,nrf52840dk_nrf52840,samples/bluetooth/peripheral,
 bt_central_hr,default,nrf52840dk_nrf52840,samples/bluetooth/central_hr,
 bt_mesh_demo,default,bbc_microbit,samples/bluetooth/mesh_demo,
 bt_hap_ha,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/hap_ha,
+bt_unicast_audio_client,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/unicast_audio_client,
+bt_unicast_audio_server,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/unicast_audio_server,
 bt_hci_rpmsg,default,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,
 bt_hci_rpmsg,iso-broadcast,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,-DCONF_FILE=nrf5340_cpunet_iso_broadcast.conf
 bt_hci_rpmsg,iso-receive,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,-DCONF_FILE=nrf5340_cpunet_iso_receive.conf


### PR DESCRIPTION
Add a Bluetooth unicast audio samples to track their footprint.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>