### PR TITLE
Bluetooth: Audio: CAP test: Fix sim_id

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/cap.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/cap.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="vcs"
+SIMULATION_ID="cap"
 VERBOSITY_LEVEL=2
 PROCESS_IDS=""; EXIT_CODE=0
 


### PR DESCRIPTION
The cap test was reusing another test sim_id which causes trouble at random when tests are parallelized. Fix it by giving it its own id.
