### PR TITLE
tests: kernel: workq: work: Tweak test for fast system clock

### DIFF
--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -894,11 +894,14 @@ ZTEST(work_1cpu, test_1cpu_drain_wait)
 	 */
 	ctx->submit_rc = INT_MAX;
 	k_timer_init(&ctx->timer, test_drain_wait_cb, NULL);
-	k_timer_start(&ctx->timer, K_TICKS(1), K_NO_WAIT);
+	k_timer_start(&ctx->timer, K_MSEC(10), K_NO_WAIT);
 
 	/* Wait to drain */
 	rc = k_work_queue_drain(&coophi_queue, false);
 	zassert_equal(rc, 1);
+
+	/* Wait until timer expires. */
+	(void)k_timer_status_sync(&ctx->timer);
 
 	/* Verify completion */
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);


### PR DESCRIPTION
Test assumes that system clock is slow enough so 1 tick timeout will not expire before k_timer_start function exists. That is not the case when system clock is fast (relatively to the cpu clock). Increase the timeout and add synchronization point.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>