### PR TITLE
Bluetooth: Audio: Add missing unbind of audio_iso for broadcast sink

### DIFF
--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -108,6 +108,7 @@ static void broadcast_sink_set_ep_state(struct bt_audio_ep *ep, uint8_t state)
 		struct bt_audio_stream *stream = ep->stream;
 
 		if (stream != NULL) {
+			bt_audio_iso_unbind_ep(ep->iso, ep);
 			stream->ep = NULL;
 			stream->codec = NULL;
 			ep->stream = NULL;


### PR DESCRIPTION
When a BIS disconnected, we removed the references between the endpoint and the stream. This made it impossible to later unbind the audio_iso when
broadcast_sink_cleanup_streams was called.

Fixed by unbind the audio_iso when we remove the reference.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>