### PR TITLE
drivers: gpio: add two shared priority symbols for I2C and SPI devices 

### DIFF
--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -26,6 +26,20 @@ config GPIO_INIT_PRIORITY
 	help
 	  GPIO driver device initialization priority.
 
+config GPIO_I2C_INIT_PRIORITY
+	int "GPIO I2C devices init priority"
+	default 60
+	help
+	  Initialization priority for I2C GPIO devices, should be lower (higher
+	  value) than I2C_INIT_PRIORITY.
+
+config GPIO_SPI_INIT_PRIORITY
+	int "GPIO SPI devices init priority"
+	default 60
+	help
+	  Initialization priority for SPI GPIO devices, should be lower (higher
+	  value) than SPI_INIT_PRIORITY.
+
 config GPIO_GET_DIRECTION
 	bool "Support for querying GPIO direction [EXPERIMENTAL]"
 	select EXPERIMENTAL

--- a/drivers/gpio/Kconfig.cy8c95xx
+++ b/drivers/gpio/Kconfig.cy8c95xx
@@ -3,20 +3,10 @@
 # Copyright (c) 2021 Synopsys
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig GPIO_CY8C95XX
+config GPIO_CY8C95XX
 	bool "CY8C95XX I2C GPIO chip"
 	default y
 	depends on DT_HAS_CYPRESS_CY8C95XX_GPIO_PORT_ENABLED
 	depends on I2C
 	help
 	  Enable driver for CY8C95XX I2C GPIO chip.
-
-if GPIO_CY8C95XX
-
-config GPIO_CY8C95XX_INIT_PRIORITY
-	int "Init priority"
-	default 70
-	help
-	  Device driver initialization priority.
-
-endif # GPIO_CY8C95XX

--- a/drivers/gpio/Kconfig.fxl6408
+++ b/drivers/gpio/Kconfig.fxl6408
@@ -1,20 +1,13 @@
 # Copyright (c) 2021 Abel Sensors
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig GPIO_FXL6408
+config GPIO_FXL6408
 	bool "FXL6408 I2C-based GPIO chip"
 	default y
 	depends on DT_HAS_FCS_FXL6408_ENABLED
 	depends on I2C
 	help
 	  Enable driver for FXL6408 I2C-based GPIO chip.
-
-config GPIO_FXL6408_INIT_PRIORITY
-	int "Init priority"
-	default 80
-	depends on GPIO_FXL6408
-	help
-	  Device driver initialization priority.
 
 module = FXL6408
 module-str = fxl6408

--- a/drivers/gpio/Kconfig.mcp23s17
+++ b/drivers/gpio/Kconfig.mcp23s17
@@ -3,20 +3,10 @@
 # Copyright (c) 2020 Geanix ApS
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig GPIO_MCP23S17
+config GPIO_MCP23S17
 	bool "MCP23S17 SPI-based GPIO chip"
 	default y
 	depends on DT_HAS_MICROCHIP_MCP23S17_ENABLED
 	depends on SPI
 	help
 	  Enable driver for MCP23S17 SPI-based GPIO chip.
-
-if GPIO_MCP23S17
-
-config GPIO_MCP23S17_INIT_PRIORITY
-	int "Init priority"
-	default 75
-	help
-	  Device driver initialization priority.
-
-endif #GPIO_MCP23S17

--- a/drivers/gpio/Kconfig.mcp23xxx
+++ b/drivers/gpio/Kconfig.mcp23xxx
@@ -9,7 +9,7 @@ config GPIO_MCP23XXX
 	  Enable support for the Microchip 23xxx I2C/SPI IO
 	  expanders.
 
-menuconfig GPIO_MCP230XX
+config GPIO_MCP230XX
 	bool "MCP230XX I2C-based GPIO chip"
 	default y
 	depends on DT_HAS_MICROCHIP_MCP230XX_ENABLED
@@ -18,17 +18,7 @@ menuconfig GPIO_MCP230XX
 	help
 	  Enable driver for MCP230XX I2C-based GPIO chip.
 
-if GPIO_MCP230XX
-
-config GPIO_MCP230XX_INIT_PRIORITY
-	int "MCP230XX GPIO expander init priority"
-	default 75
-	help
-	  Device driver initialization priority.
-
-endif #GPIO_MCP230XX
-
-menuconfig GPIO_MCP23SXX
+config GPIO_MCP23SXX
 	bool "MCP23SXX SPI-based GPIO chip"
 	default y
 	depends on DT_HAS_MICROCHIP_MCP23SXX_ENABLED
@@ -36,13 +26,3 @@ menuconfig GPIO_MCP23SXX
 	select GPIO_MCP23XXX
 	help
 	  Enable driver for MCP23SXX SPI-based GPIO chip.
-
-if GPIO_MCP23SXX
-
-config GPIO_MCP23SXX_INIT_PRIORITY
-	int "MCP23SXX GPIO expander init priority"
-	default 75
-	help
-	  Device driver initialization priority.
-
-endif #GPIO_MCP23SXX

--- a/drivers/gpio/Kconfig.nct38xx
+++ b/drivers/gpio/Kconfig.nct38xx
@@ -13,19 +13,12 @@ config GPIO_NCT38XX
 
 if GPIO_NCT38XX
 
-config GPIO_NCT38XX_INIT_PRIORITY
-	int "NCT38XX GPIO init priority"
-	default 30
-	help
-	  Device driver initialization priority. The priority should be lower
-	  than I2C device.
-
 config GPIO_NCT38XX_PORT_INIT_PRIORITY
 	int "NCT38XX GPIO port init priority"
-	default 40
+	default 61
 	help
 	  Device driver initialization priority. The priority should be lower
-	  than I2C & GPIO_NCT38XX_INIT_PRIORITY device.
+	  than I2C & GPIO_I2C_INIT_PRIORITY device.
 
 config GPIO_NCT38XX_INTERRUPT
 	bool "NCT38XX GPIO interrupt"
@@ -34,7 +27,7 @@ config GPIO_NCT38XX_INTERRUPT
 
 config GPIO_NCT38XX_ALERT_INIT_PRIORITY
 	int "NCT38XX GPIO alert handler init priority"
-	default 40
+	default 61
 	depends on GPIO_NCT38XX_INTERRUPT
 	help
 	  NCT38XX alert handler initialization priority. This initialization

--- a/drivers/gpio/Kconfig.npm6001
+++ b/drivers/gpio/Kconfig.npm6001
@@ -8,11 +8,3 @@ config GPIO_NPM6001
 	select I2C
 	help
 	  Enable the nPM6001 GPIO driver.
-
-config GPIO_NPM6001_INIT_PRIORITY
-	int "nPM6001 GPIO driver initialization priority"
-	depends on GPIO_NPM6001
-	default 60
-	help
-	  Initialization priority for the nPM6001 GPIO driver. It must be
-	  greater than the I2C controller init priority.

--- a/drivers/gpio/Kconfig.pca953x
+++ b/drivers/gpio/Kconfig.pca953x
@@ -4,20 +4,10 @@
 # Copyright (c) 2021 Laird Connectivity
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig GPIO_PCA953X
+config GPIO_PCA953X
 	bool "PCA953X I2C GPIO chip"
 	default y
 	depends on DT_HAS_TI_TCA9538_ENABLED
 	select I2C
 	help
 	  Enable driver for PCA953X I2C GPIO chip.
-
-if GPIO_PCA953X
-
-config GPIO_PCA953X_INIT_PRIORITY
-	int "Init priority"
-	default 70
-	help
-	  Device driver initialization priority.
-
-endif # GPIO_PCA953X

--- a/drivers/gpio/Kconfig.pca95xx
+++ b/drivers/gpio/Kconfig.pca95xx
@@ -11,13 +11,6 @@ menuconfig GPIO_PCA95XX
 	help
 	  Enable driver for PCA95XX I2C-based GPIO chip.
 
-config GPIO_PCA95XX_INIT_PRIORITY
-	int "Init priority"
-	default 70
-	depends on GPIO_PCA95XX
-	help
-	  Device driver initialization priority.
-
 config GPIO_PCA95XX_INTERRUPT
 	bool "Interrupt enable"
 	depends on GPIO_PCA95XX

--- a/drivers/gpio/Kconfig.pcal6408a
+++ b/drivers/gpio/Kconfig.pcal6408a
@@ -3,17 +3,10 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig GPIO_PCAL6408A
+config GPIO_PCAL6408A
 	bool "PCAL6408A I2C GPIO chip"
 	default y
 	depends on DT_HAS_NXP_PCAL6408A_ENABLED
 	depends on I2C
 	help
 	  Enable driver for PCAL6408A I2C GPIO chip.
-
-config GPIO_PCAL6408A_INIT_PRIORITY
-	int "Init priority"
-	default 70
-	depends on GPIO_PCAL6408A
-	help
-	  Device driver initialization priority.

--- a/drivers/gpio/Kconfig.pcf8574
+++ b/drivers/gpio/Kconfig.pcf8574
@@ -3,17 +3,10 @@
 # Copyright (c) 2022 Ithinx
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig GPIO_PCF8574
+config GPIO_PCF8574
 	bool "PCF8574 I2C GPIO chip"
 	default y
 	depends on DT_HAS_NXP_PCF8574_ENABLED
 	select I2C
 	help
 	  Enable driver for PCF8574 I2C GPIO chip.
-
-config GPIO_PCF8574_INIT_PRIORITY
-	int "Init priority"
-	default 70
-	depends on GPIO_PCF8574
-	help
-	  Device driver initialization priority.

--- a/drivers/gpio/Kconfig.rt1718s
+++ b/drivers/gpio/Kconfig.rt1718s
@@ -12,19 +12,12 @@ menuconfig GPIO_RT1718S
 
 if GPIO_RT1718S
 
-config RT1718S_INIT_PRIORITY
-	int "RT1718S GPIO init priority"
-	default 60
-	help
-	  RT1718S device driver initialization priority. The priority should be
-	  lower than I2C device.
-
 config GPIO_RT1718S_PORT_INIT_PRIORITY
 	int "RT1718S GPIO port init priority"
 	default 61
 	help
 	  RT1718S GPIO driver initialization priority. The priority should be lower
-	  than I2C & RT1718S_INIT_PRIORITY device.
+	  than I2C & GPIO_I2C_INIT_PRIORITY device.
 
 config GPIO_RT1718S_INTERRUPT
 	bool "RT1718S alert handler"

--- a/drivers/gpio/Kconfig.sn74hc595
+++ b/drivers/gpio/Kconfig.sn74hc595
@@ -8,13 +8,3 @@ config GPIO_SN74HC595
 	depends on SPI
 	help
 	  Use SN74HC595 as GPIO extender
-
-if GPIO_SN74HC595
-
-config GPIO_SN74HC595_INIT_PRIORITY
-	int "Init priority"
-	default 71
-	help
-	  Device driver initialization priority.
-
-endif

--- a/drivers/gpio/Kconfig.stmpe1600
+++ b/drivers/gpio/Kconfig.stmpe1600
@@ -3,17 +3,10 @@
 # Copyright (c) 2021 Titouan Christophe
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig GPIO_STMPE1600
+config GPIO_STMPE1600
 	bool "STMPE1600 I2C-based GPIO chip"
 	default y
 	depends on DT_HAS_ST_STMPE1600_ENABLED
 	depends on I2C
 	help
 	  Enable driver for STMPE1600 I2C-based GPIO chip.
-
-config GPIO_STMPE1600_INIT_PRIORITY
-	int "Init priority"
-	default 70
-	depends on GPIO_STMPE1600
-	help
-	  Device driver initialization priority.

--- a/drivers/gpio/Kconfig.sx1509b
+++ b/drivers/gpio/Kconfig.sx1509b
@@ -13,12 +13,6 @@ menuconfig GPIO_SX1509B
 
 if GPIO_SX1509B
 
-config GPIO_SX1509B_INIT_PRIORITY
-	int "Init priority"
-	default 70
-	help
-	  Device driver initialization priority.
-
 config GPIO_SX1509B_INTERRUPT
 	bool "Interrupt enable"
 	help

--- a/drivers/gpio/Kconfig.tca6424a
+++ b/drivers/gpio/Kconfig.tca6424a
@@ -3,17 +3,10 @@
 # Copyright (c) 2022 Chromium OS Authors
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig GPIO_TCA6424A
+config GPIO_TCA6424A
 	bool "TCA6424A driver"
 	default y
 	depends on DT_HAS_TI_TCA6424A_ENABLED
 	depends on I2C
 	help
 	  Enable driver for TCA6424A IO expander chip.
-
-config GPIO_TCA6424A_INIT_PRIORITY
-	int "Init priority"
-	default 70
-	depends on GPIO_TCA6424A
-	help
-	  Device driver initialization priority.

--- a/drivers/gpio/gpio_cy8c95xx.c
+++ b/drivers/gpio/gpio_cy8c95xx.c
@@ -20,6 +20,7 @@
 LOG_MODULE_REGISTER(cy8c95xx, CONFIG_GPIO_LOG_LEVEL);
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
+#include "gpio_i2c_priority_check.h"
 
 /** Cache of the output configuration and data of the pins. */
 struct cy8c95xx_pin_state {

--- a/drivers/gpio/gpio_cy8c95xx.c
+++ b/drivers/gpio/gpio_cy8c95xx.c
@@ -295,7 +295,7 @@ static struct cy8c95xx_drv_data cy8c95xx_##idx##_drvdata = { \
 }; \
 DEVICE_DT_INST_DEFINE(idx, cy8c95xx_init, NULL, \
 				&cy8c95xx_##idx##_drvdata, &cy8c95xx_##idx##_cfg, \
-				POST_KERNEL, CONFIG_GPIO_CY8C95XX_INIT_PRIORITY, \
+				POST_KERNEL, CONFIG_GPIO_I2C_INIT_PRIORITY, \
 				&api_table);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_PORT_INIT)

--- a/drivers/gpio/gpio_fxl6408.c
+++ b/drivers/gpio/gpio_fxl6408.c
@@ -10,6 +10,8 @@
 #include <zephyr/drivers/gpio/gpio_utils.h>
 #include <zephyr/logging/log.h>
 
+#include "gpio_i2c_priority_check.h"
+
 LOG_MODULE_REGISTER(fxl6408, CONFIG_FXL6408_LOG_LEVEL);
 #define DT_DRV_COMPAT             fcs_fxl6408
 

--- a/drivers/gpio/gpio_fxl6408.c
+++ b/drivers/gpio/gpio_fxl6408.c
@@ -434,7 +434,7 @@ static const struct gpio_driver_api gpio_fxl_driver = {
 	DEVICE_DT_INST_DEFINE(inst, gpio_fxl6408_init, NULL,                   \
 		&gpio_fxl6408_##inst##_drvdata,                                \
 		&gpio_fxl6408_##inst##_cfg, POST_KERNEL,                       \
-		CONFIG_GPIO_FXL6408_INIT_PRIORITY,                             \
+		CONFIG_GPIO_I2C_INIT_PRIORITY,                                 \
 		&gpio_fxl_driver);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_FXL6408_DEVICE_INSTANCE)

--- a/drivers/gpio/gpio_i2c_priority_check.h
+++ b/drivers/gpio/gpio_i2c_priority_check.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2022 The ChromiumOS Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/toolchain/common.h>
+
+BUILD_ASSERT(CONFIG_GPIO_I2C_INIT_PRIORITY > CONFIG_I2C_INIT_PRIORITY,
+	     "GPIO_I2C_INIT_PRIORITY has to be lower (higher value) than I2C_PRIORITY");

--- a/drivers/gpio/gpio_mcp230xx.c
+++ b/drivers/gpio/gpio_mcp230xx.c
@@ -19,6 +19,7 @@
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
 #include "gpio_mcp23xxx.h"
+#include "gpio_i2c_priority_check.h"
 
 #define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/gpio/gpio_mcp230xx.c
+++ b/drivers/gpio/gpio_mcp230xx.c
@@ -99,6 +99,6 @@ static int mcp230xx_bus_is_ready(const struct device *dev)
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, gpio_mcp23xxx_init, NULL, &mcp230xx_##inst##_drvdata,          \
 		&mcp230xx_##inst##_config, POST_KERNEL,                                            \
-		CONFIG_GPIO_MCP230XX_INIT_PRIORITY, &gpio_mcp23xxx_api_table);
+		CONFIG_GPIO_I2C_INIT_PRIORITY, &gpio_mcp23xxx_api_table);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_MCP230XX_DEVICE)

--- a/drivers/gpio/gpio_mcp23s17.c
+++ b/drivers/gpio/gpio_mcp23s17.c
@@ -21,6 +21,7 @@
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
 #include "gpio_mcp23s17.h"
+#include "gpio_spi_priority_check.h"
 
 #define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/gpio/gpio_mcp23s17.c
+++ b/drivers/gpio/gpio_mcp23s17.c
@@ -402,7 +402,7 @@ static int mcp23s17_init(const struct device *dev)
 			      &mcp23s17_##inst##_drvdata,		 \
 			      &mcp23s17_##inst##_config,		 \
 			      POST_KERNEL,				 \
-			      CONFIG_GPIO_MCP23S17_INIT_PRIORITY,	 \
+			      CONFIG_GPIO_SPI_INIT_PRIORITY,		 \
 			      &api_table);
 
 DT_INST_FOREACH_STATUS_OKAY(MCP23S17_INIT)

--- a/drivers/gpio/gpio_mcp23sxx.c
+++ b/drivers/gpio/gpio_mcp23sxx.c
@@ -139,6 +139,6 @@ static int mcp23sxx_bus_is_ready(const struct device *dev)
 	};                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, gpio_mcp23xxx_init, NULL, &mcp23sxx_##inst##_drvdata,        \
 			      &mcp23sxx_##inst##_config, POST_KERNEL,                         \
-			      CONFIG_GPIO_MCP23SXX_INIT_PRIORITY, &gpio_mcp23xxx_api_table);
+			      CONFIG_GPIO_SPI_INIT_PRIORITY, &gpio_mcp23xxx_api_table);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_MCP23SXX_DEVICE)

--- a/drivers/gpio/gpio_mcp23sxx.c
+++ b/drivers/gpio/gpio_mcp23sxx.c
@@ -19,6 +19,7 @@
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
 #include "gpio_mcp23xxx.h"
+#include "gpio_spi_priority_check.h"
 
 #define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/gpio/gpio_nct38xx.c
+++ b/drivers/gpio/gpio_nct38xx.c
@@ -90,6 +90,6 @@ static int nct38xx_gpio_init(const struct device *dev)
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, nct38xx_gpio_init, NULL, &gpio_nct38xx_data_##inst,            \
 			      &gpio_nct38xx_cfg_##inst, POST_KERNEL,                               \
-			      CONFIG_GPIO_NCT38XX_INIT_PRIORITY, NULL);
+			      CONFIG_GPIO_I2C_INIT_PRIORITY, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_NCT38XX_DEVICE_INSTANCE)

--- a/drivers/gpio/gpio_nct38xx.c
+++ b/drivers/gpio/gpio_nct38xx.c
@@ -13,6 +13,7 @@
 #include <zephyr/sys/util_macro.h>
 
 #include "gpio_nct38xx.h"
+#include "gpio_i2c_priority_check.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(gpio_ntc38xx, CONFIG_GPIO_LOG_LEVEL);

--- a/drivers/gpio/gpio_nct38xx_alert.c
+++ b/drivers/gpio/gpio_nct38xx_alert.c
@@ -123,7 +123,7 @@ static int nct38xx_alert_init(const struct device *dev)
 }
 
 /* NCT38XX alert driver must be initialized after NCT38XX GPIO driver */
-BUILD_ASSERT(CONFIG_GPIO_NCT38XX_ALERT_INIT_PRIORITY > CONFIG_GPIO_NCT38XX_INIT_PRIORITY);
+BUILD_ASSERT(CONFIG_GPIO_NCT38XX_ALERT_INIT_PRIORITY > CONFIG_GPIO_I2C_INIT_PRIORITY);
 
 #define NCT38XX_DEV_AND_COMMA(node_id, prop, idx)                                                  \
 	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(node_id, prop, idx)),

--- a/drivers/gpio/gpio_nct38xx_alert.c
+++ b/drivers/gpio/gpio_nct38xx_alert.c
@@ -13,6 +13,7 @@
 #include <zephyr/sys/util_macro.h>
 
 #include "gpio_nct38xx.h"
+#include "gpio_i2c_priority_check.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(gpio_ntc38xx, CONFIG_GPIO_LOG_LEVEL);

--- a/drivers/gpio/gpio_nct38xx_port.c
+++ b/drivers/gpio/gpio_nct38xx_port.c
@@ -576,7 +576,7 @@ static int gpio_nct38xx_port_init(const struct device *dev)
 }
 
 /* NCT38XX GPIO port driver must be initialized after NCT38XX GPIO driver */
-BUILD_ASSERT(CONFIG_GPIO_NCT38XX_PORT_INIT_PRIORITY > CONFIG_GPIO_NCT38XX_INIT_PRIORITY);
+BUILD_ASSERT(CONFIG_GPIO_NCT38XX_PORT_INIT_PRIORITY > CONFIG_GPIO_I2C_INIT_PRIORITY);
 
 #define GPIO_NCT38XX_PORT_DEVICE_INSTANCE(inst)                                                    \
 	static const struct gpio_nct38xx_port_config gpio_nct38xx_port_cfg_##inst = {              \

--- a/drivers/gpio/gpio_nct38xx_port.c
+++ b/drivers/gpio/gpio_nct38xx_port.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT nuvoton_nct38xx_gpio_port
 
 #include "gpio_nct38xx.h"
+#include "gpio_i2c_priority_check.h"
 #include <zephyr/drivers/gpio/gpio_utils.h>
 
 #include <zephyr/drivers/gpio.h>

--- a/drivers/gpio/gpio_npm6001.c
+++ b/drivers/gpio/gpio_npm6001.c
@@ -239,7 +239,7 @@ static int gpio_npm6001_init(const struct device *dev)
                                                                                \
 	DEVICE_DT_INST_DEFINE(n, &gpio_npm6001_init, NULL,                     \
 			      &gpio_npm6001_data##n, &gpio_npm6001_config##n,  \
-			      POST_KERNEL, CONFIG_GPIO_NPM6001_INIT_PRIORITY,  \
+			      POST_KERNEL, CONFIG_GPIO_I2C_INIT_PRIORITY,      \
 			      &gpio_npm6001_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_NPM6001_DEFINE)

--- a/drivers/gpio/gpio_npm6001.c
+++ b/drivers/gpio/gpio_npm6001.c
@@ -15,6 +15,8 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
+#include "gpio_i2c_priority_check.h"
+
 /* nPM6001 GPIO related registers */
 #define NPM6001_GPIOOUTSET 0x69U
 #define NPM6001_GPIOOUTCLR 0x6AU

--- a/drivers/gpio/gpio_nxp_s32.c
+++ b/drivers/gpio/gpio_nxp_s32.c
@@ -405,7 +405,7 @@ static const struct gpio_driver_api gpio_nxp_s32_driver_api = {
 			&gpio_nxp_s32_data_##n,					\
 			&gpio_nxp_s32_config_##n,				\
 			POST_KERNEL,						\
-			CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,			\
+			CONFIG_GPIO_INIT_PRIORITY,				\
 			&gpio_nxp_s32_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_NXP_S32_DEVICE_INIT)

--- a/drivers/gpio/gpio_pca953x.c
+++ b/drivers/gpio/gpio_pca953x.c
@@ -481,7 +481,7 @@ static const struct gpio_driver_api api_table = {
 		&pca953x_drvdata_##n,						\
 		&pca953x_cfg_##n,						\
 		POST_KERNEL,							\
-		CONFIG_GPIO_PCA953X_INIT_PRIORITY,				\
+		CONFIG_GPIO_I2C_INIT_PRIORITY,					\
 		&api_table);
 
 #define DT_DRV_COMPAT ti_tca9538

--- a/drivers/gpio/gpio_pca953x.c
+++ b/drivers/gpio/gpio_pca953x.c
@@ -22,6 +22,7 @@
 LOG_MODULE_REGISTER(pca953x, CONFIG_GPIO_LOG_LEVEL);
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
+#include "gpio_i2c_priority_check.h"
 
 /* PCA953X Register addresses */
 #define PCA953X_INPUT_PORT		0x00

--- a/drivers/gpio/gpio_pca95xx.c
+++ b/drivers/gpio/gpio_pca95xx.c
@@ -767,7 +767,7 @@ DEVICE_DT_INST_DEFINE(inst,						\
 	NULL,								\
 	&gpio_pca95xx_##inst##_drvdata,					\
 	&gpio_pca95xx_##inst##_cfg,					\
-	POST_KERNEL, CONFIG_GPIO_PCA95XX_INIT_PRIORITY,			\
+	POST_KERNEL, CONFIG_GPIO_I2C_INIT_PRIORITY,			\
 	&gpio_pca95xx_drv_api_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_PCA95XX_DEVICE_INSTANCE)

--- a/drivers/gpio/gpio_pca95xx.c
+++ b/drivers/gpio/gpio_pca95xx.c
@@ -23,6 +23,7 @@
 #include <zephyr/drivers/i2c.h>
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
+#include "gpio_i2c_priority_check.h"
 
 #define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/gpio/gpio_pcal6408a.c
+++ b/drivers/gpio/gpio_pcal6408a.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio/gpio_utils.h>
+#include "gpio_i2c_priority_check.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pcal6408a, CONFIG_GPIO_LOG_LEVEL);

--- a/drivers/gpio/gpio_pcal6408a.c
+++ b/drivers/gpio/gpio_pcal6408a.c
@@ -625,7 +625,7 @@ static const struct gpio_driver_api pcal6408a_drv_api = {
 			      NULL,					   \
 			      &pcal6408a_data##idx, &pcal6408a_cfg##idx,   \
 			      POST_KERNEL,				   \
-			      CONFIG_GPIO_PCAL6408A_INIT_PRIORITY,	   \
+			      CONFIG_GPIO_I2C_INIT_PRIORITY,		   \
 			      &pcal6408a_drv_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_PCAL6408A_INST)

--- a/drivers/gpio/gpio_pcf8574.c
+++ b/drivers/gpio/gpio_pcf8574.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT nxp_pcf8574
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
+#include "gpio_i2c_priority_check.h"
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>

--- a/drivers/gpio/gpio_pcf8574.c
+++ b/drivers/gpio/gpio_pcf8574.c
@@ -392,6 +392,6 @@ static const struct gpio_driver_api pcf8574_drv_api = {
 		.dev = DEVICE_DT_INST_GET(idx),                                                    \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(idx, pcf8574_init, NULL, &pcf8574_data##idx, &pcf8574_cfg##idx,      \
-			      POST_KERNEL, CONFIG_GPIO_PCF8574_INIT_PRIORITY, &pcf8574_drv_api);
+			      POST_KERNEL, CONFIG_GPIO_I2C_INIT_PRIORITY, &pcf8574_drv_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_PCF8574_INST);

--- a/drivers/gpio/gpio_rt1718s.c
+++ b/drivers/gpio/gpio_rt1718s.c
@@ -139,6 +139,6 @@ static int rt1718s_init(const struct device *dev)
 		.dev = DEVICE_DT_INST_GET(inst),                                                   \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, rt1718s_init, NULL, &rt1718s_data_##inst, &rt1718s_cfg_##inst, \
-			      POST_KERNEL, CONFIG_RT1718S_INIT_PRIORITY, NULL);
+			      POST_KERNEL, GPIO_I2C_INIT_PRIORITY, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_RT1718S_DEVICE_INSTANCE)

--- a/drivers/gpio/gpio_rt1718s_port.c
+++ b/drivers/gpio/gpio_rt1718s_port.c
@@ -361,7 +361,7 @@ static int gpio_rt1718s_port_init(const struct device *dev)
 }
 
 /* RT1718S GPIO port driver must be initialized after RT1718S chip driver */
-BUILD_ASSERT(CONFIG_GPIO_RT1718S_PORT_INIT_PRIORITY > CONFIG_RT1718S_INIT_PRIORITY);
+BUILD_ASSERT(CONFIG_GPIO_RT1718S_PORT_INIT_PRIORITY > GPIO_I2C_INIT_PRIORITY);
 
 #define GPIO_RT1718S_PORT_DEVICE_INSTANCE(inst)                                                    \
 	static const struct gpio_rt1718s_port_config gpio_rt1718s_port_cfg_##inst = {              \

--- a/drivers/gpio/gpio_sn74hc595.c
+++ b/drivers/gpio/gpio_sn74hc595.c
@@ -18,12 +18,10 @@
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
 
+#include "gpio_spi_priority_check.h"
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(gpio_sn74hc595, CONFIG_GPIO_LOG_LEVEL);
-
-#if CONFIG_SPI_INIT_PRIORITY >= CONFIG_GPIO_SPI_INIT_PRIORITY
-#error SPI_INIT_PRIORITY must be lower than GPIO_SPI_INIT_PRIORITY
-#endif
 
 struct gpio_sn74hc595_config {
 	/* gpio_driver_config needs to be first */

--- a/drivers/gpio/gpio_sn74hc595.c
+++ b/drivers/gpio/gpio_sn74hc595.c
@@ -21,8 +21,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(gpio_sn74hc595, CONFIG_GPIO_LOG_LEVEL);
 
-#if CONFIG_SPI_INIT_PRIORITY >= CONFIG_GPIO_SN74HC595_INIT_PRIORITY
-#error SPI_INIT_PRIORITY must be lower than SN74HC595_INIT_PRIORITY
+#if CONFIG_SPI_INIT_PRIORITY >= CONFIG_GPIO_SPI_INIT_PRIORITY
+#error SPI_INIT_PRIORITY must be lower than GPIO_SPI_INIT_PRIORITY
 #endif
 
 struct gpio_sn74hc595_config {
@@ -206,6 +206,6 @@ static int gpio_sn74hc595_init(const struct device *dev)
 												\
 	DEVICE_DT_DEFINE(DT_DRV_INST(n), &gpio_sn74hc595_init, NULL,				\
 			 &sn74hc595_data_##n, &sn74hc595_config_##n, POST_KERNEL,		\
-			 CONFIG_GPIO_SN74HC595_INIT_PRIORITY, &gpio_sn74hc595_drv_api_funcs);
+			 CONFIG_GPIO_SPI_INIT_PRIORITY, &gpio_sn74hc595_drv_api_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(SN74HC595_INIT)

--- a/drivers/gpio/gpio_spi_priority_check.h
+++ b/drivers/gpio/gpio_spi_priority_check.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2022 The ChromiumOS Authors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/toolchain/common.h>
+
+BUILD_ASSERT(CONFIG_GPIO_SPI_INIT_PRIORITY > CONFIG_SPI_INIT_PRIORITY,
+	     "GPIO_SPI_INIT_PRIORITY has to be lower (higher value) than SPI_PRIORITY");

--- a/drivers/gpio/gpio_stmpe1600.c
+++ b/drivers/gpio/gpio_stmpe1600.c
@@ -20,6 +20,7 @@
 #include <zephyr/drivers/i2c.h>
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
+#include "gpio_i2c_priority_check.h"
 
 #define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/gpio/gpio_stmpe1600.c
+++ b/drivers/gpio/gpio_stmpe1600.c
@@ -315,7 +315,7 @@ static const struct gpio_driver_api stmpe1600_drv_api = {
 			      &stmpe1600_##inst##_drvdata,	     \
 			      &stmpe1600_##inst##_config,	     \
 			      POST_KERNEL,			     \
-			      CONFIG_GPIO_STMPE1600_INIT_PRIORITY,   \
+			      CONFIG_GPIO_I2C_INIT_PRIORITY,	     \
 			      &stmpe1600_drv_api);
 
 DT_INST_FOREACH_STATUS_OKAY(STMPE1600_INIT)

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -25,6 +25,7 @@
 LOG_MODULE_REGISTER(sx1509b, CONFIG_GPIO_LOG_LEVEL);
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
+#include "gpio_i2c_priority_check.h"
 
 /* Number of pins supported by the device */
 #define NUM_PINS 16

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -740,6 +740,6 @@ int sx1509b_led_intensity_pin_set(const struct device *dev, gpio_pin_t pin,
                                                                                \
 	DEVICE_DT_INST_DEFINE(inst, sx1509b_init, NULL, &sx1509b_drvdata##inst,\
 			      &sx1509b_cfg##inst, POST_KERNEL,                 \
-			      CONFIG_GPIO_SX1509B_INIT_PRIORITY, &api_table);
+			      CONFIG_GPIO_I2C_INIT_PRIORITY, &api_table);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_SX1509B_DEFINE)

--- a/drivers/gpio/gpio_tca6424a.c
+++ b/drivers/gpio/gpio_tca6424a.c
@@ -571,6 +571,6 @@ static int tca6424a_init(const struct device *dev)
 		.dev = DEVICE_DT_INST_GET(idx),                                                    \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(idx, tca6424a_init, NULL, &tca6424a_data##idx, &tca6424a_cfg##idx,   \
-			      POST_KERNEL, CONFIG_GPIO_TCA6424A_INIT_PRIORITY, &tca6424a_drv_api);
+			      POST_KERNEL, CONFIG_GPIO_I2C_INIT_PRIORITY, &tca6424a_drv_api);
 
 DT_INST_FOREACH_STATUS_OKAY(TCA6424A_INST)

--- a/drivers/gpio/gpio_tca6424a.c
+++ b/drivers/gpio/gpio_tca6424a.c
@@ -13,6 +13,8 @@
 #include <zephyr/sys/util.h>
 LOG_MODULE_REGISTER(gpio_tca6424a, CONFIG_GPIO_LOG_LEVEL);
 
+#include "gpio_i2c_priority_check.h"
+
 /* TCA6424A auto increment register addresses */
 #define TCA6424A_REG_INPUT			0x80
 #define TCA6424A_REG_OUTPUT			0x84

--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -37,7 +37,7 @@ config SPI_EXTENDED_MODES
 
 config SPI_INIT_PRIORITY
 	int "Init priority"
-	default 70
+	default KERNEL_INIT_PRIORITY_DEVICE
 	help
 	  Device driver initialization priority.
 


### PR DESCRIPTION
There's few SPI and I2C GPIO controllers being added, each one adding a custom initialization priority symbol. Adding two shared priority symbols for I2C and SPI devices respectively to remove some config options.

Those new options are hardcoded with the bus priority+1, took the chance to also changed the default SPI controller priority to `KERNEL_INIT_PRIORITY_DEVICE`, matching how other bus controllers are defined.

Keeping two symbols separate just in case some application needs an usual setup, like bitbanging SPI on an I2C port expander or something like that.