### PR TITLE
boards: arm: nrf9160dk_nrf52840: RTS/CTS pins removed

### DIFF
--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840-pinctrl.dtsi
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840-pinctrl.dtsi
@@ -6,12 +6,10 @@
 &pinctrl {
 	uart0_default: uart0_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 5)>,
-				<NRF_PSEL(UART_RTS, 1, 8)>;
+			psels = <NRF_PSEL(UART_TX, 0, 5)>;
 		};
 		group2 {
-			psels = <NRF_PSEL(UART_RX, 0, 3)>,
-				<NRF_PSEL(UART_CTS, 0, 7)>;
+			psels = <NRF_PSEL(UART_RX, 0, 3)>;
 			bias-pull-up;
 		};
 	};
@@ -19,9 +17,7 @@
 	uart0_sleep: uart0_sleep {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 0, 5)>,
-				<NRF_PSEL(UART_RX, 0, 3)>,
-				<NRF_PSEL(UART_RTS, 1, 8)>,
-				<NRF_PSEL(UART_CTS, 0, 7)>;
+				<NRF_PSEL(UART_RX, 0, 3)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
Since the on-board J-Link does not support flow control (according to [this](https://github.com/zephyrproject-rtos/zephyr/pull/51802#issuecomment-1297175538)) I assume that the correct workaround will be just to remove RTS/CTS pins. 

Please see [this PR](https://github.com/zephyrproject-rtos/zephyr/pull/51802) for more info