### PR TITLE
espi: auto enable the ESPI SAF XEC based on the device tree

### DIFF
--- a/drivers/espi/Kconfig.xec
+++ b/drivers/espi/Kconfig.xec
@@ -63,13 +63,17 @@ config ESPI_FLASH_BUFFER_SIZE
 
 config ESPI_SAF_XEC
 	bool "XEC Microchip ESPI SAF driver"
+	default y
 	depends on SOC_SERIES_MEC1501X
+	depends on DT_HAS_MICROCHIP_XEC_ESPI_SAF_ENABLED
 	help
 	  Enable the Microchip XEC SAF ESPI driver for MEC15xx family.
 
 config ESPI_SAF_XEC_V2
 	bool "XEC Microchip ESPI SAF V2 driver"
+	default y
 	depends on SOC_SERIES_MEC172X
+	depends on DT_HAS_MICROCHIP_XEC_ESPI_SAF_V2_ENABLED
 	help
 	  Enable the Microchip XEC SAF ESPI driver for MEC172x series.
 


### PR DESCRIPTION
The SAF XEC driver for eSPI was not enabled by default so sample code for espi was failing. This commit changes the behavior to match current scheme of enabling the drivers based on the status of required device tree nodes.

Signed-off-by: Michał Barnaś <mb@semihalf.com>