### PR TITLE
subsys/cpp: minimal libc doesn't support libstdc++, select full libc

### DIFF
--- a/subsys/cpp/Kconfig
+++ b/subsys/cpp/Kconfig
@@ -67,7 +67,7 @@ config CPP_MAIN
 
 config LIB_CPLUSPLUS
 	bool "Link with STD C++ library"
-	depends on !MINIMAL_LIBC
+	select REQUIRES_FULL_LIBC
 	help
 	  Link with STD C++ Library.
 


### PR DESCRIPTION
C++ support requires a toolchain-provided C library with associated libstdc++ library. We don't have a symbol for requiring this, but we can at least exclude using the minimal C library by requiring a full libc.

This allows all of the C++ tests to be run as a part of a standard twister run. I expect this will uncover regressions in some of those which haven't been run recently.

Signed-off-by: Keith Packard <keithp@keithp.com>