### PR TITLE
drivers: can: sam: select CACHE_MANAGEMENT for SAM M_CAN

### DIFF
--- a/drivers/can/Kconfig.sam
+++ b/drivers/can/Kconfig.sam
@@ -7,3 +7,4 @@ config CAN_SAM
 	default y
 	depends on DT_HAS_ATMEL_SAM_CAN_ENABLED
 	select CAN_MCAN
+	select CACHE_MANAGEMENT


### PR DESCRIPTION
A regression was introduced in ef804d8408f371f1785755dbe5f172fc0ecc58cb when the M_CAN driver was swapped to use the generic dcache API, but cache management was not enabled on SAM devices.

Enable cache management on SAM devices when CAN_SAM is selected.

Fixes: #52085 

Signed-off-by: Perry Hung <perry@genrad.com>