### PR TITLE
List boards per vendor

### DIFF
--- a/boards/arm/frdm_k22f/frdm_k22f.yaml
+++ b/boards/arm/frdm_k22f/frdm_k22f.yaml
@@ -2,6 +2,8 @@ identifier: frdm_k22f
 name: NXP FRDM-K22F
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 ram: 64
 toolchain:
   - zephyr

--- a/boards/arm/frdm_k64f/frdm_k64f.yaml
+++ b/boards/arm/frdm_k64f/frdm_k64f.yaml
@@ -2,6 +2,8 @@ identifier: frdm_k64f
 name: NXP FRDM-K64F
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 ram: 256
 flash: 1024
 toolchain:

--- a/boards/arm/frdm_k82f/frdm_k82f.yaml
+++ b/boards/arm/frdm_k82f/frdm_k82f.yaml
@@ -2,6 +2,8 @@ identifier: frdm_k82f
 name: NXP FRDM-K82F
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/frdm_kl25z/frdm_kl25z.yaml
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.yaml
@@ -2,6 +2,8 @@ identifier: frdm_kl25z
 name: NXP FRDM-KL25Z
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 ram: 16
 flash: 128
 toolchain:

--- a/boards/arm/frdm_kw41z/frdm_kw41z.yaml
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.yaml
@@ -2,6 +2,8 @@ identifier: frdm_kw41z
 name: NXP FRDM-KW41Z
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 ram: 128
 flash: 512
 toolchain:

--- a/boards/arm/lpcxpresso11u68/lpcxpresso11u68.yaml
+++ b/boards/arm/lpcxpresso11u68/lpcxpresso11u68.yaml
@@ -1,5 +1,7 @@
 identifier: lpcxpresso11u68
 name: NXP LPCxpresso 11U68
+board_vendor: nxp
+soc_vendor: nxp
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/lpcxpresso51u68/lpcxpresso51u68.yaml
+++ b/boards/arm/lpcxpresso51u68/lpcxpresso51u68.yaml
@@ -7,6 +7,8 @@
 identifier: lpcxpresso51u68
 name: NXP LPCXpresso51u68
 type: mcu
+board_vendor: nxp
+soc_vendor: nxp
 arch: arm
 ram: 64
 flash: 256

--- a/boards/arm/lpcxpresso54114/lpcxpresso54114_m0.yaml
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114_m0.yaml
@@ -7,6 +7,8 @@
 identifier: lpcxpresso54114_m0
 name: NXP LPCXpresso54114 M0
 type: mcu
+board_vendor: nxp
+soc_vendor: nxp
 arch: arm
 ram: 32
 flash: 64

--- a/boards/arm/lpcxpresso54114/lpcxpresso54114_m4.yaml
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114_m4.yaml
@@ -7,6 +7,8 @@
 identifier: lpcxpresso54114_m4
 name: NXP LPCXpresso54114 M4
 type: mcu
+board_vendor: nxp
+soc_vendor: nxp
 arch: arm
 ram: 64
 flash: 256

--- a/boards/arm/lpcxpresso55s06/lpcxpresso55s06.yaml
+++ b/boards/arm/lpcxpresso55s06/lpcxpresso55s06.yaml
@@ -6,6 +6,8 @@
 identifier: lpcxpresso55s06
 name: NXP LPCXpresso55S06
 type: mcu
+board_vendor: nxp
+soc_vendor: nxp
 arch: arm
 ram: 96
 flash: 256

--- a/boards/arm/lpcxpresso55s16/lpcxpresso55s16.yaml
+++ b/boards/arm/lpcxpresso55s16/lpcxpresso55s16.yaml
@@ -7,6 +7,8 @@
 identifier: lpcxpresso55s16
 name: NXP LPCXpresso55S16
 type: mcu
+board_vendor: nxp
+soc_vendor: nxp
 arch: arm
 ram: 96
 flash: 256

--- a/boards/arm/lpcxpresso55s28/lpcxpresso55s28.yaml
+++ b/boards/arm/lpcxpresso55s28/lpcxpresso55s28.yaml
@@ -7,6 +7,8 @@
 identifier: lpcxpresso55s28
 name: NXP LPCXpresso55S28
 type: mcu
+board_vendor: nxp
+soc_vendor: nxp
 arch: arm
 ram: 64
 flash: 256

--- a/boards/arm/lpcxpresso55s36/lpcxpresso55s36.yaml
+++ b/boards/arm/lpcxpresso55s36/lpcxpresso55s36.yaml
@@ -7,6 +7,8 @@
 identifier: lpcxpresso55s36
 name: NXP LPCXpresso55S36
 type: mcu
+board_vendor: nxp
+soc_vendor: nxp
 arch: arm
 ram: 96
 flash: 256

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.yaml
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.yaml
@@ -7,6 +7,8 @@
 identifier: lpcxpresso55s69_cpu0
 name: NXP LPCXpresso55S69
 type: mcu
+board_vendor: nxp
+soc_vendor: nxp
 arch: arm
 ram: 64
 flash: 256

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.yaml
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.yaml
@@ -7,6 +7,8 @@
 identifier: lpcxpresso55s69_cpu1
 name: NXP LPCXpresso55S69
 type: mcu
+board_vendor: nxp
+soc_vendor: nxp
 arch: arm
 ram: 64
 flash: 256

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_ns.yaml
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_ns.yaml
@@ -7,6 +7,8 @@
 identifier: lpcxpresso55s69_ns
 name: NXP LPCXpresso55S69
 type: mcu
+board_vendor: nxp
+soc_vendor: nxp
 arch: arm
 ram: 136
 flash: 96

--- a/boards/arm/mimx8mm_evk/mimx8mm_evk.yaml
+++ b/boards/arm/mimx8mm_evk/mimx8mm_evk.yaml
@@ -8,6 +8,8 @@ identifier: mimx8mm_evk
 name: NXP i.MX8M Mini EVK
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 ram: 32
 flash: 32
 toolchain:

--- a/boards/arm/mimx8mp_evk/mimx8mp_evk_ddr.yaml
+++ b/boards/arm/mimx8mp_evk/mimx8mp_evk_ddr.yaml
@@ -8,6 +8,8 @@ identifier: mimx8mp_evk_ddr
 name: NXP i.MX8M Plus EVK (DDR)
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 ram: 2048
 flash: 2048
 toolchain:

--- a/boards/arm/mimx8mp_evk/mimx8mp_evk_itcm.yaml
+++ b/boards/arm/mimx8mp_evk/mimx8mp_evk_itcm.yaml
@@ -8,6 +8,8 @@ identifier: mimx8mp_evk_itcm
 name: NXP i.MX8M Plus EVK (ITCM)
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 ram: 128
 flash: 128
 toolchain:

--- a/boards/arm/mimx8mq_evk/mimx8mq_evk_cm4.yaml
+++ b/boards/arm/mimx8mq_evk/mimx8mq_evk_cm4.yaml
@@ -8,6 +8,8 @@ identifier: mimx8mq_evk_cm4
 name: NXP i.MX8MQ EVK CM4
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 ram: 32
 flash: 32
 toolchain:

--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.yaml
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt1010_evk
 name: NXP MIMXRT1010-EVK
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.yaml
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt1015_evk
 name: NXP MIMXRT1015-EVK
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.yaml
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt1020_evk
 name: NXP MIMXRT1020-EVK
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.yaml
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt1024_evk
 name: NXP MIMXRT1024-EVK
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt1050_evk
 name: NXP MIMXRT1050-EVK
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt1050_evk_qspi
 name: NXP MIMXRT1050-EVK-QSPI
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt1060_evk
 name: NXP MIMXRT1060-EVK
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt1060_evk_hyperflash
 name: NXP MIMXRT1060-EVK-HYPERFLASH
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evkb.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evkb.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt1060_evkb
 name: NXP MIMXRT1060-EVKB
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt1064_evk
 name: NXP MIMXRT1064-EVK
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm4.yaml
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm4.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt1160_evk_cm4
 name: NXP MIMXRT1160-EVK CM4
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.yaml
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt1160_evk_cm7
 name: NXP MIMXRT1160-EVK CM7
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm4.yaml
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm4.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt1170_evk_cm4
 name: NXP MIMXRT1170-EVK CM4
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.yaml
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt1170_evk_cm7
 name: NXP MIMXRT1170-EVK CM7
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.yaml
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt595_evk_cm33
 name: NXP MIMXRT595-EVK
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.yaml
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.yaml
@@ -8,6 +8,8 @@ identifier: mimxrt685_evk_cm33
 name: NXP MIMXRT685-EVK
 type: mcu
 arch: arm
+board_vendor: NXP
+soc_vendor: NXP
 toolchain:
   - zephyr
   - gnuarmemb

--- a/boards/arm64/mimx8mm_evk/mimx8mm_evk_a53.yaml
+++ b/boards/arm64/mimx8mm_evk/mimx8mm_evk_a53.yaml
@@ -2,6 +2,8 @@ identifier: mimx8mm_evk_a53
 name: NXP i.MX8M Mini EVK A53
 type: mcu
 arch: arm64
+board_vendor: nxp
+soc_vendor: nxp
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm64/mimx8mm_evk/mimx8mm_evk_a53_smp.yaml
+++ b/boards/arm64/mimx8mm_evk/mimx8mm_evk_a53_smp.yaml
@@ -2,6 +2,8 @@ identifier: mimx8mm_evk_a53_smp
 name: NXP i.MX8M Mini EVK A53 with SMP kernel
 type: mcu
 arch: arm64
+board_vendor: nxp
+soc_vendor: nxp
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm64/mimx8mn_evk/mimx8mn_evk_a53.yaml
+++ b/boards/arm64/mimx8mn_evk/mimx8mn_evk_a53.yaml
@@ -2,6 +2,8 @@ identifier: mimx8mn_evk_a53
 name: NXP i.MX8M Nano EVK A53
 type: mcu
 arch: arm64
+board_vendor: nxp
+soc_vendor: nxp
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm64/mimx8mn_evk/mimx8mn_evk_a53_smp.yaml
+++ b/boards/arm64/mimx8mn_evk/mimx8mn_evk_a53_smp.yaml
@@ -2,6 +2,8 @@ identifier: mimx8mn_evk_a53_smp
 name: NXP i.MX8M Nano EVK A53 with SMP kernel
 type: mcu
 arch: arm64
+board_vendor: nxp
+soc_vendor: nxp
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm64/mimx8mp_evk/mimx8mp_evk_a53.yaml
+++ b/boards/arm64/mimx8mp_evk/mimx8mp_evk_a53.yaml
@@ -2,6 +2,8 @@ identifier: mimx8mp_evk_a53
 name: NXP i.MX8M Plus EVK A53
 type: mcu
 arch: arm64
+board_vendor: nxp
+soc_vendor: nxp
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm64/mimx8mp_evk/mimx8mp_evk_a53_smp.yaml
+++ b/boards/arm64/mimx8mp_evk/mimx8mp_evk_a53_smp.yaml
@@ -2,6 +2,8 @@ identifier: mimx8mp_evk_a53_smp
 name: NXP i.MX8M Plus EVK A53 with SMP kernel
 type: mcu
 arch: arm64
+board_vendor: nxp
+soc_vendor: nxp
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm64/nxp_ls1046ardb/nxp_ls1046ardb.yaml
+++ b/boards/arm64/nxp_ls1046ardb/nxp_ls1046ardb.yaml
@@ -2,6 +2,8 @@ identifier: nxp_ls1046ardb
 name: NXP LS1046ARDB on single CPU Core (NON-SMP)
 type: mcu
 arch: arm64
+board_vendor: nxp
+soc_vendor: nxp
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm64/nxp_ls1046ardb/nxp_ls1046ardb_smp_2cores.yaml
+++ b/boards/arm64/nxp_ls1046ardb/nxp_ls1046ardb_smp_2cores.yaml
@@ -2,6 +2,8 @@ identifier: nxp_ls1046ardb_smp_2cores
 name: NXP LS1046ARDB SMP on CPU Core2 and Core3
 type: mcu
 arch: arm64
+board_vendor: nxp
+soc_vendor: nxp
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm64/nxp_ls1046ardb/nxp_ls1046ardb_smp_4cores.yaml
+++ b/boards/arm64/nxp_ls1046ardb/nxp_ls1046ardb_smp_4cores.yaml
@@ -2,6 +2,8 @@ identifier: nxp_ls1046ardb_smp_4cores
 name: NXP LS1046ARDB SMP on four CPU Cores
 type: mcu
 arch: arm64
+board_vendor: nxp
+soc_vendor: nxp
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/xtensa/nxp_adsp_imx8/nxp_adsp_imx8.yaml
+++ b/boards/xtensa/nxp_adsp_imx8/nxp_adsp_imx8.yaml
@@ -2,6 +2,8 @@ identifier: nxp_adsp_imx8
 name: i.MX8 DSP
 type: mcu
 arch: xtensa
+board_vendor: nxp
+soc_vendor: nxp
 toolchain:
   - zephyr
 testing:

--- a/boards/xtensa/nxp_adsp_imx8m/nxp_adsp_imx8m.yaml
+++ b/boards/xtensa/nxp_adsp_imx8m/nxp_adsp_imx8m.yaml
@@ -2,6 +2,8 @@ identifier: nxp_adsp_imx8m
 name: i.MX8M DSP
 type: mcu
 arch: xtensa
+board_vendor: nxp
+soc_vendor: nxp
 toolchain:
   - zephyr
 testing:

--- a/boards/xtensa/nxp_adsp_imx8x/nxp_adsp_imx8x.yaml
+++ b/boards/xtensa/nxp_adsp_imx8x/nxp_adsp_imx8x.yaml
@@ -2,6 +2,8 @@ identifier: nxp_adsp_imx8x
 name: i.MX8X DSP
 type: mcu
 arch: xtensa
+board_vendor: nxp
+soc_vendor: nxp
 toolchain:
   - zephyr
 testing:


### PR DESCRIPTION
This PR proposes adding switches to 'west boards' to filter the board list on a board vendor or SoC vendor basis. 
Two commits make up this PR:

 - code change to west's boards as well as to list_boards.py
 - changes to the yaml files for which NXP is the vendor.

The switches and yaml file fields proposed are optional.