### PR TITLE
dfu/mcuboot: Add missing include

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -283,6 +283,9 @@ Drivers and Sensors
 
 * DFU
 
+  * Remove :c:macro:`BOOT_TRAILER_IMG_STATUS_OFFS` in favor a two new functions;
+    :c:func:`boot_get_area_trailer_status_offset` and :c:func:`boot_get_trailer_status_offset`
+
 * Disk
 
 * Display

--- a/include/zephyr/dfu/mcuboot.h
+++ b/include/zephyr/dfu/mcuboot.h
@@ -18,6 +18,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <sys/types.h>
 
 #include <zephyr/types.h>
 
@@ -79,9 +80,7 @@ extern "C" {
 
 #define BOOT_IMG_VER_STRLEN_MAX 25  /* 255.255.65535.4294967295\0 */
 
-#define BOOT_TRAILER_IMG_STATUS_OFFS(bank_area) ((bank_area)->fa_size -\
-						  BOOT_MAGIC_SZ -\
-						  BOOT_MAX_ALIGN * 2)
+
 /**
  * @brief MCUboot image header representation for image version
  *
@@ -262,6 +261,23 @@ int boot_request_upgrade_multi(int image_index, int permanent);
  * @return 0 on success, negative errno code on fail.
  */
 int boot_erase_img_bank(uint8_t area_id);
+
+/**
+ * @brief Get the offset of the status in the image bank
+ *
+ * @param area_id flash_area ID of image bank to get the status offset
+ * @return a positive offset on success, negative errno code on fail
+ */
+ssize_t boot_get_area_trailer_status_offset(uint8_t area_id);
+
+/**
+ * @brief Get the offset of the status from an image bank size
+ *
+ * @param area_size size of image bank
+ * @return offset of the status. When negative the status will not fit
+ * the given size
+ */
+ssize_t boot_get_trailer_status_offset(size_t area_size);
 
 #ifdef __cplusplus
 }

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -251,3 +251,30 @@ int boot_erase_img_bank(uint8_t area_id)
 
 	return rc;
 }
+
+ssize_t boot_get_trailer_status_offset(size_t area_size)
+{
+	return (ssize_t)area_size - BOOT_MAGIC_SZ - BOOT_MAX_ALIGN * 2;
+}
+
+ssize_t boot_get_area_trailer_status_offset(uint8_t area_id)
+{
+	int rc;
+	const struct flash_area *fa;
+	ssize_t offset;
+
+	rc = flash_area_open(area_id, &fa);
+	if (rc) {
+		return rc;
+	}
+
+	offset = boot_get_trailer_status_offset(fa->fa_size);
+
+	flash_area_close(fa);
+
+	if (offset < 0) {
+		return -EFAULT;
+	}
+
+	return offset;
+}

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -54,9 +54,11 @@ int flash_img_buffered_write(struct flash_img_context *ctx, const uint8_t *data,
 	}
 
 #ifdef CONFIG_IMG_ERASE_PROGRESSIVELY
+	ssize_t status_offset = boot_get_trailer_status_offset(
+		ctx->flash_area->fa_size);
 	rc = stream_flash_erase_page(&ctx->stream,
 				ctx->flash_area->fa_off +
-				BOOT_TRAILER_IMG_STATUS_OFFS(ctx->flash_area));
+				status_offset);
 	if (rc) {
 		return rc;
 	}

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -466,7 +466,7 @@ img_mgmt_erase_image_data(unsigned int off, unsigned int num_bytes)
 	 */
 
 	/* erase the image trailer area if it was not erased */
-	off = BOOT_TRAILER_IMG_STATUS_OFFS(fa);
+	off = boot_get_trailer_status_offset(fa->fa_size);
 	if (off >= erase_size) {
 		rc = flash_get_page_info_by_offs(dev, fa->fa_off + off, &page);
 


### PR DESCRIPTION
dfu/mcuboot.h uses some definitions of bootutil/bootutil_public.h but does not include the header.
fix #52095

Signed-off-by: Guillaume Lager <g.lager@innoseis.com>