### PR TITLE
tests: cmsis_dsp: transform: Remove MPS2 AN521 from intg. platforms

### DIFF
--- a/tests/lib/cmsis_dsp/transform/testcase.yaml
+++ b/tests/lib/cmsis_dsp/transform/testcase.yaml
@@ -19,7 +19,6 @@ tests:
   libraries.cmsis_dsp.transform.cq15.fpu:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
-      - mps2_an521_remote
       - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 512
@@ -44,7 +43,6 @@ tests:
   libraries.cmsis_dsp.transform.rq15.fpu:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
-      - mps2_an521_remote
       - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 512
@@ -68,8 +66,6 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CQ31=y
   libraries.cmsis_dsp.transform.cq31.fpu:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
-    integration_platforms:
-      - mps2_an521_remote
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 64
@@ -92,8 +88,6 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RQ31=y
   libraries.cmsis_dsp.transform.rq31.fpu:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
-    integration_platforms:
-      - mps2_an521_remote
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 64
@@ -116,7 +110,6 @@ tests:
   libraries.cmsis_dsp.transform.cf16.fpu:
     filter: (CMSIS_DSP_FLOAT16 and (CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1)
     integration_platforms:
-      - mps2_an521_remote
       - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 512
@@ -140,7 +133,6 @@ tests:
   libraries.cmsis_dsp.transform.rf16.fpu:
     filter: (CMSIS_DSP_FLOAT16 and (CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1)
     integration_platforms:
-      - mps2_an521_remote
       - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 512
@@ -164,8 +156,6 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CF32=y
   libraries.cmsis_dsp.transform.cf32.fpu:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
-    integration_platforms:
-      - mps2_an521_remote
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 64
@@ -189,7 +179,6 @@ tests:
   libraries.cmsis_dsp.transform.rf32.fpu:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
-      - mps2_an521_remote
       - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 512
@@ -213,8 +202,6 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CF64=y
   libraries.cmsis_dsp.transform.cf64.fpu:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
-    integration_platforms:
-      - mps2_an521_remote
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 128
@@ -237,8 +224,6 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RF64=y
   libraries.cmsis_dsp.transform.rf64.fpu:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
-    integration_platforms:
-      - mps2_an521_remote
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 64


### PR DESCRIPTION
This commit removes the `mps2_an521_remote` board from the integration platform list of the CMSIS-DSP transform tests because this board no longer has a sufficient code memory (FLASH) to fit these tests after the resizing done in the PR #52052 for TF-M compatibility.

Consider adding `mps2_an386` as an integration platform for these tests once the support for it is added to Zephyr (refer to the issue #45319).

Signed-off-by: Stephanos Ioannidis <stephanos.ioannidis@nordicsemi.no>

---

This fixes the following failures in the CI:

```
INFO: Error found: tests/lib/cmsis_dsp/transform/libraries.cmsis_dsp.transform.cq15.fpu on mps2_an521_remote (Not enough FLASH but is one of the integration platforms)
INFO: Error found: tests/lib/cmsis_dsp/transform/libraries.cmsis_dsp.transform.rq15.fpu on mps2_an521_remote (Not enough FLASH but is one of the integration platforms)
INFO: Error found: tests/lib/cmsis_dsp/transform/libraries.cmsis_dsp.transform.cq31.fpu on mps2_an521_remote (Not enough FLASH but is one of the integration platforms)
INFO: Error found: tests/lib/cmsis_dsp/transform/libraries.cmsis_dsp.transform.rq31.fpu on mps2_an521_remote (Not enough FLASH but is one of the integration platforms)
INFO: Error found: tests/lib/cmsis_dsp/transform/libraries.cmsis_dsp.transform.cf16.fpu on mps2_an521_remote (Not enough FLASH but is one of the integration platforms)
INFO: Error found: tests/lib/cmsis_dsp/transform/libraries.cmsis_dsp.transform.rf16.fpu on mps2_an521_remote (Not enough FLASH but is one of the integration platforms)
INFO: Error found: tests/lib/cmsis_dsp/transform/libraries.cmsis_dsp.transform.cf32.fpu on mps2_an521_remote (Not enough FLASH but is one of the integration platforms)
INFO: Error found: tests/lib/cmsis_dsp/transform/libraries.cmsis_dsp.transform.rf32.fpu on mps2_an521_remote (Not enough FLASH but is one of the integration platforms)
INFO: Error found: tests/lib/cmsis_dsp/transform/libraries.cmsis_dsp.transform.cf64.fpu on mps2_an521_remote (Not enough FLASH but is one of the integration platforms)
INFO: Error found: tests/lib/cmsis_dsp/transform/libraries.cmsis_dsp.transform.rf64.fpu on mps2_an521_remote (Not enough FLASH but is one of the integration platforms)
```