### PR TITLE
pcie: Add runtime lookup of BDF values

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -66,9 +66,12 @@
 			};
 		};
 
-		eth0: eth@1000 {
+		eth0: eth0 {
 			compatible = "intel,e1000";
-			reg = <PCIE_BDF(0, 2, 0) PCIE_ID(0x8086, 0x100e)>;
+
+			vendor-id = <0x8086>;
+			device-id = <0x100e>;
+
 			interrupts = <11 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 

--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -51,10 +51,11 @@
 		compatible = "intel,pcie";
 		ranges;
 
-		can0: can@1000 {
+		can0: can0 {
 			compatible = "kvaser,pcican";
 			status = "okay";
-			reg = <PCIE_BDF(0,2,0) PCIE_ID(0x10e8,0x8406)>;
+			vendor-id = <0x10e8>;
+			device-id = <0x8406>;
 			interrupts = <11 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 			sjw = <1>;

--- a/drivers/can/can_kvaser_pci.c
+++ b/drivers/can/can_kvaser_pci.c
@@ -25,9 +25,8 @@ LOG_MODULE_REGISTER(can_kvaser_pci, CONFIG_CAN_LOG_LEVEL);
 #define XLNX_VERINT_VERSION_POS 4U
 
 struct can_kvaser_pci_config {
-	pcie_bdf_t pcie_bdf;
-	pcie_id_t pcie_id;
 	void (*irq_config_func)(const struct device *dev);
+	struct pcie_dev *pcie;
 };
 
 struct can_kvaser_pci_data {
@@ -74,15 +73,15 @@ static int can_kvaser_pci_init(const struct device *dev)
 	uint32_t intcsr;
 	int err;
 
-	if (!pcie_probe(kvaser_config->pcie_bdf, kvaser_config->pcie_id)) {
-		LOG_ERR("failed to probe PCI(e)");
+	if (kvaser_config->pcie->bdf == PCIE_BDF_NONE) {
+		LOG_ERR("failed to find PCIe device");
 		return -ENODEV;
 	}
 
-	pcie_set_cmd(kvaser_config->pcie_bdf, PCIE_CONF_CMDSTAT_IO, true);
+	pcie_set_cmd(kvaser_config->pcie->bdf, PCIE_CONF_CMDSTAT_IO, true);
 
 	/* AMCC S5920 registers */
-	if (!pcie_probe_iobar(kvaser_config->pcie_bdf, 0, &iobar)) {
+	if (!pcie_probe_iobar(kvaser_config->pcie->bdf, 0, &iobar)) {
 		LOG_ERR("failed to probe AMCC S5920 I/O BAR");
 		return -ENODEV;
 	}
@@ -90,7 +89,7 @@ static int can_kvaser_pci_init(const struct device *dev)
 	amcc_base = iobar.phys_addr;
 
 	/* SJA1000 registers */
-	if (!pcie_probe_iobar(kvaser_config->pcie_bdf, 1, &iobar)) {
+	if (!pcie_probe_iobar(kvaser_config->pcie->bdf, 1, &iobar)) {
 		LOG_ERR("failed to probe SJA1000 I/O BAR");
 		return -ENODEV;
 	}
@@ -98,7 +97,7 @@ static int can_kvaser_pci_init(const struct device *dev)
 	kvaser_data->sja1000_base = iobar.phys_addr;
 
 	/* Xilinx registers */
-	if (!pcie_probe_iobar(kvaser_config->pcie_bdf, 2, &iobar)) {
+	if (!pcie_probe_iobar(kvaser_config->pcie->bdf, 2, &iobar)) {
 		LOG_ERR("failed to probe Xilinx I/O BAR");
 		return -ENODEV;
 	}
@@ -160,10 +159,10 @@ const struct can_driver_api can_kvaser_pci_driver_api = {
 
 #define CAN_KVASER_PCI_INIT(inst)                                                                  \
 	static void can_kvaser_pci_config_func_##inst(const struct device *dev);                   \
+	DEVICE_PCIE_INST_DECLARE(inst);                                                            \
                                                                                                    \
 	static const struct can_kvaser_pci_config can_kvaser_pci_config_##inst = {                 \
-		.pcie_bdf = DT_INST_REG_ADDR(inst),                                                \
-		.pcie_id = DT_INST_REG_SIZE(inst),                                                 \
+		DEVICE_PCIE_INST_INIT(inst, pcie),                                                 \
 		.irq_config_func = can_kvaser_pci_config_func_##inst                               \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -234,17 +234,16 @@ static void e1000_isr(const struct device *ddev)
 int e1000_probe(const struct device *ddev)
 {
 	/* PCI ID is decoded into REG_SIZE */
-	pcie_bdf_t bdf = pcie_bdf_lookup(DT_INST_REG_SIZE(0));
 	struct e1000_dev *dev = ddev->data;
 	uint32_t ral, rah;
 	struct pcie_bar mbar;
 
-	if (bdf == PCIE_BDF_NONE) {
+	if (dev->pcie->bdf == PCIE_BDF_NONE) {
 		return -ENODEV;
 	}
 
-	pcie_probe_mbar(bdf, 0, &mbar);
-	pcie_set_cmd(bdf, PCIE_CONF_CMDSTAT_MEM |
+	pcie_probe_mbar(dev->pcie->bdf, 0, &mbar);
+	pcie_set_cmd(dev->pcie->bdf, PCIE_CONF_CMDSTAT_MEM |
 		     PCIE_CONF_CMDSTAT_MASTER, true);
 
 	device_map(&dev->address, mbar.phys_addr, mbar.size,
@@ -317,7 +316,11 @@ static void e1000_iface_init(struct net_if *iface)
 	LOG_DBG("done");
 }
 
-static struct e1000_dev e1000_dev;
+DEVICE_PCIE_INST_DECLARE(0);
+
+static struct e1000_dev e1000_dev = {
+	DEVICE_PCIE_INST_INIT(0, pcie),
+};
 
 static const struct ethernet_api e1000_api = {
 	.iface_api.init		= e1000_iface_init,

--- a/drivers/ethernet/eth_e1000_priv.h
+++ b/drivers/ethernet/eth_e1000_priv.h
@@ -78,6 +78,10 @@ struct e1000_dev {
 	volatile struct e1000_tx tx __aligned(16);
 	volatile struct e1000_rx rx __aligned(16);
 	mm_reg_t address;
+
+	/* BDF & DID/VID */
+	struct pcie_dev *pcie;
+
 	/* If VLAN is enabled, there can be multiple VLAN interfaces related to
 	 * this physical device. In that case, this iface pointer value is not
 	 * really used for anything.

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -851,12 +851,12 @@ static int i2c_dw_initialize(const struct device *dev)
 	if (rom->pcie) {
 		struct pcie_bar mbar;
 
-		if (!pcie_probe(rom->pcie_bdf, rom->pcie_id)) {
+		if (rom->pcie->bdf == PCIE_BDF_NONE) {
 			return -EINVAL;
 		}
 
-		pcie_probe_mbar(rom->pcie_bdf, 0, &mbar);
-		pcie_set_cmd(rom->pcie_bdf, PCIE_CONF_CMDSTAT_MEM, true);
+		pcie_probe_mbar(rom->pcie->bdf, 0, &mbar);
+		pcie_set_cmd(rom->pcie->bdf, PCIE_CONF_CMDSTAT_MEM, true);
 
 		device_map(DEVICE_MMIO_RAM_PTR(dev), mbar.phys_addr,
 			   mbar.size, K_MEM_CACHE_NONE);
@@ -913,12 +913,14 @@ static int i2c_dw_initialize(const struct device *dev)
 #endif
 
 #define I2C_DW_INIT_PCIE0(n)
-#define I2C_DW_INIT_PCIE1(n)                                                  \
-		.pcie = true,                                                 \
-		.pcie_bdf = DT_INST_REG_ADDR(n),                              \
-		.pcie_id = DT_INST_REG_SIZE(n),
+#define I2C_DW_INIT_PCIE1(n) DEVICE_PCIE_INST_INIT(n, pcie),
 #define I2C_DW_INIT_PCIE(n) \
 	_CONCAT(I2C_DW_INIT_PCIE, DT_INST_ON_BUS(n, pcie))(n)
+
+#define I2C_DEFINE_PCIE0(n)
+#define I2C_DEFINE_PCIE1(n) DEVICE_PCIE_INST_DECLARE(n)
+#define I2C_PCIE_DEFINE(n) \
+	_CONCAT(I2C_DEFINE_PCIE, DT_INST_ON_BUS(n, pcie))(n)
 
 #define I2C_DW_IRQ_FLAGS_SENSE0(n) 0
 #define I2C_DW_IRQ_FLAGS_SENSE1(n) DT_INST_IRQ(n, sense)
@@ -940,31 +942,37 @@ static int i2c_dw_initialize(const struct device *dev)
 #define I2C_DW_IRQ_CONFIG_PCIE1(n)                                            \
 	static void i2c_config_##n(const struct device *port)                 \
 	{                                                                     \
-		ARG_UNUSED(port);                                             \
 		BUILD_ASSERT(DT_INST_IRQN(n) == PCIE_IRQ_DETECT,              \
 			     "Only runtime IRQ configuration is supported");  \
 		BUILD_ASSERT(IS_ENABLED(CONFIG_DYNAMIC_INTERRUPTS),           \
 			     "DW I2C PCI needs CONFIG_DYNAMIC_INTERRUPTS");   \
-		unsigned int irq = pcie_alloc_irq(DT_INST_REG_ADDR(n));       \
+		const struct i2c_dw_rom_config * const dev_cfg = port->config;\
+		unsigned int irq = pcie_alloc_irq(dev_cfg->pcie->bdf);        \
 		if (irq == PCIE_CONF_INTR_IRQ_NONE) {                         \
 			return;                                               \
 		}                                                             \
-		pcie_connect_dynamic_irq(DT_INST_REG_ADDR(n), irq,	      \
+		pcie_connect_dynamic_irq(dev_cfg->pcie->bdf, irq,	      \
 				     DT_INST_IRQ(n, priority),		      \
 				    (void (*)(const void *))i2c_dw_isr,       \
 				    DEVICE_DT_INST_GET(n),                    \
 				    I2C_DW_IRQ_FLAGS(n));                     \
-		pcie_irq_enable(DT_INST_REG_ADDR(n), irq);                    \
+		pcie_irq_enable(dev_cfg->pcie->bdf, irq);                     \
 	}
 
 #define I2C_DW_IRQ_CONFIG(n) \
 	_CONCAT(I2C_DW_IRQ_CONFIG_PCIE, DT_INST_ON_BUS(n, pcie))(n)
 
+#define I2C_CONFIG_REG_INIT_PCIE0(n) DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),
+#define I2C_CONFIG_REG_INIT_PCIE1(n)
+#define I2C_CONFIG_REG_INIT(n) \
+	_CONCAT(I2C_CONFIG_REG_INIT_PCIE, DT_INST_ON_BUS(n, pcie))(n)
+
 #define I2C_DEVICE_INIT_DW(n)                                                 \
 	PINCTRL_DW_DEFINE(n);                                                 \
+	I2C_PCIE_DEFINE(n);                                                   \
 	static void i2c_config_##n(const struct device *port);                \
 	static const struct i2c_dw_rom_config i2c_config_dw_##n = {           \
-		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),                         \
+		I2C_CONFIG_REG_INIT(n)                                        \
 		.config_func = i2c_config_##n,                                \
 		.bitrate = DT_INST_PROP(n, clock_frequency),                  \
 		PINCTRL_DW_CONFIG(n)                                          \

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -95,9 +95,7 @@ struct i2c_dw_rom_config {
 #endif
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
-	bool		pcie;
-	pcie_bdf_t	pcie_bdf;
-	pcie_id_t	pcie_id;
+	struct pcie_dev *pcie;
 #endif /* I2C_DW_PCIE_ENABLED */
 };
 
@@ -105,7 +103,6 @@ struct i2c_dw_dev_config {
 	DEVICE_MMIO_RAM;
 	struct k_sem		device_sync_sem;
 	uint32_t app_config;
-
 
 	uint8_t			*xfr_buf;
 	uint32_t		xfr_len;

--- a/drivers/pcie/host/ptm.c
+++ b/drivers/pcie/host/ptm.c
@@ -16,6 +16,8 @@ LOG_MODULE_REGISTER(pcie);
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 
+#define DT_DRV_COMPAT ptm_root
+
 #include <zephyr/drivers/pcie/pcie.h>
 #include "ptm.h"
 

--- a/drivers/pcie/host/ptm.c
+++ b/drivers/pcie/host/ptm.c
@@ -27,18 +27,18 @@ static int pcie_ptm_root_setup(const struct device *dev, uint32_t base)
 	union ptm_cap_reg cap;
 	union ptm_ctrl_reg ctrl;
 
-	cap.raw = pcie_conf_read(config->bdf, base + PTM_CAP_REG_OFFSET);
+	cap.raw = pcie_conf_read(config->pcie->bdf, base + PTM_CAP_REG_OFFSET);
 	if ((cap.root == 0) || ((cap.root == 1) && (cap.responder == 0))) {
-		LOG_ERR("PTM root not supported on 0x%x", config->bdf);
+		LOG_ERR("PTM root not supported on 0x%x", config->pcie->bdf);
 		return -ENOTSUP;
 	}
 
 	ctrl.ptm_enable = 1;
 	ctrl.root_select = 1;
 
-	pcie_conf_write(config->bdf, base + PTM_CTRL_REG_OFFSET, ctrl.raw);
+	pcie_conf_write(config->pcie->bdf, base + PTM_CTRL_REG_OFFSET, ctrl.raw);
 
-	LOG_DBG("PTM root 0x%x enabled", config->bdf);
+	LOG_DBG("PTM root 0x%x enabled", config->pcie->bdf);
 
 	return 0;
 }
@@ -48,9 +48,9 @@ static int pcie_ptm_root_init(const struct device *dev)
 	const struct pcie_ptm_root_config *config = dev->config;
 	uint32_t reg;
 
-	reg = pcie_get_ext_cap(config->bdf, PCIE_EXT_CAP_ID_PTM);
+	reg = pcie_get_ext_cap(config->pcie->bdf, PCIE_EXT_CAP_ID_PTM);
 	if (reg == 0) {
-		LOG_ERR("PTM capability not exposed on 0x%x", config->bdf);
+		LOG_ERR("PTM capability not exposed on 0x%x", config->pcie->bdf);
 		return -ENODEV;
 	}
 
@@ -58,8 +58,9 @@ static int pcie_ptm_root_init(const struct device *dev)
 }
 
 #define PCIE_PTM_ROOT_INIT(index)					\
+	DEVICE_PCIE_INST_DECLARE(index);                                \
 	static const struct pcie_ptm_root_config ptm_config_##index = {	\
-		.bdf = DT_INST_REG_ADDR(index),				\
+		DEVICE_PCIE_INST_INIT(index, pcie),                     \
 	};								\
 	DEVICE_DT_INST_DEFINE(index, &pcie_ptm_root_init, NULL, NULL,	\
 			      &ptm_config_##index, PRE_KERNEL_1,	\

--- a/drivers/pcie/host/ptm.h
+++ b/drivers/pcie/host/ptm.h
@@ -38,7 +38,7 @@ union ptm_ctrl_reg {
 };
 
 struct pcie_ptm_root_config {
-	pcie_bdf_t bdf;
+	struct pcie_dev *pcie;
 };
 
 #endif /* ZEPHYR_DRIVERS_PCIE_HOST_PTM_H_ */

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -237,9 +237,7 @@ struct uart_ns16550_device_config {
 #endif
 	uint8_t reg_interval;
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
-	bool pcie;
-	pcie_bdf_t pcie_bdf;
-	pcie_id_t pcie_id;
+	struct pcie_dev *pcie;
 #endif
 };
 
@@ -335,13 +333,13 @@ static int uart_ns16550_configure(const struct device *dev,
 	if (dev_cfg->pcie) {
 		struct pcie_bar mbar;
 
-		if (!pcie_probe(dev_cfg->pcie_bdf, dev_cfg->pcie_id)) {
+		if (dev_cfg->pcie->bdf == PCIE_BDF_NONE) {
 			ret = -EINVAL;
 			goto out;
 		}
 
-		pcie_probe_mbar(dev_cfg->pcie_bdf, 0, &mbar);
-		pcie_set_cmd(dev_cfg->pcie_bdf, PCIE_CONF_CMDSTAT_MEM, true);
+		pcie_probe_mbar(dev_cfg->pcie->bdf, 0, &mbar);
+		pcie_set_cmd(dev_cfg->pcie->bdf, PCIE_CONF_CMDSTAT_MEM, true);
 
 		device_map(DEVICE_MMIO_RAM_PTR(dev), mbar.phys_addr, mbar.size,
 			   K_MEM_CACHE_NONE);
@@ -1061,21 +1059,21 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 #define UART_NS16550_IRQ_CONFIG_PCIE1(n)                                      \
 	static void irq_config_func##n(const struct device *dev)              \
 	{                                                                     \
-		ARG_UNUSED(dev);                                              \
 		BUILD_ASSERT(DT_INST_IRQN(n) == PCIE_IRQ_DETECT,              \
 			     "Only runtime IRQ configuration is supported");  \
 		BUILD_ASSERT(IS_ENABLED(CONFIG_DYNAMIC_INTERRUPTS),           \
 			     "NS16550 PCIe requires dynamic interrupts");     \
-		unsigned int irq = pcie_alloc_irq(DT_INST_REG_ADDR(n));       \
+		const struct uart_ns16550_device_config *dev_cfg = dev->config;\
+		unsigned int irq = pcie_alloc_irq(dev_cfg->pcie->bdf);        \
 		if (irq == PCIE_CONF_INTR_IRQ_NONE) {                         \
 			return;                                               \
 		}                                                             \
-		pcie_connect_dynamic_irq(DT_INST_REG_ADDR(n), irq,	      \
+		pcie_connect_dynamic_irq(dev_cfg->pcie->bdf, irq,	      \
 				     DT_INST_IRQ(n, priority),		      \
 				    (void (*)(const void *))uart_ns16550_isr, \
 				    DEVICE_DT_INST_GET(n),                    \
 				    UART_NS16550_IRQ_FLAGS(n));               \
-		pcie_irq_enable(DT_INST_REG_ADDR(n), irq);                    \
+		pcie_irq_enable(dev_cfg->pcie->bdf, irq);                    \
 	}
 
 #ifdef CONFIG_UART_NS16550_ACCESS_IOPORT
@@ -1109,12 +1107,14 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 #endif
 
 #define DEV_CONFIG_PCIE0(n)
-#define DEV_CONFIG_PCIE1(n)              \
-	.pcie = true,                    \
-	.pcie_bdf = DT_INST_REG_ADDR(n), \
-	.pcie_id = DT_INST_REG_SIZE(n),
+#define DEV_CONFIG_PCIE1(n) DEVICE_PCIE_INST_INIT(n, pcie)
 #define DEV_CONFIG_PCIE_INIT(n) \
 	_CONCAT(DEV_CONFIG_PCIE, DT_INST_ON_BUS(n, pcie))(n)
+
+#define DEV_DECLARE_PCIE0(n)
+#define DEV_DECLARE_PCIE1(n) DEVICE_PCIE_INST_DECLARE(n)
+#define DEV_PCIE_DECLARE(n) \
+	_CONCAT(DEV_DECLARE_PCIE, DT_INST_ON_BUS(n, pcie))(n)
 
 #define DEV_DATA_FLOW_CTRL0 UART_CFG_FLOW_CTRL_NONE
 #define DEV_DATA_FLOW_CTRL1 UART_CFG_FLOW_CTRL_RTS_CTS
@@ -1129,6 +1129,7 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 
 #define UART_NS16550_DEVICE_INIT(n)                                                  \
 	UART_NS16550_IRQ_FUNC_DECLARE(n);                                            \
+	DEV_PCIE_DECLARE(n);                                                         \
 	static const struct uart_ns16550_device_config uart_ns16550_dev_cfg_##n = {  \
 		DEV_CONFIG_REG_INIT(n)                                               \
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clock_frequency), (             \

--- a/drivers/virtualization/virt_ivshmem.c
+++ b/drivers/virtualization/virt_ivshmem.c
@@ -45,7 +45,7 @@ static bool ivshmem_configure_interrupts(const struct device *dev)
 
 	key = irq_lock();
 
-	n_vectors = pcie_msi_vectors_allocate(data->bdf,
+	n_vectors = pcie_msi_vectors_allocate(data->pcie->bdf,
 					      CONFIG_IVSHMEM_INT_PRIORITY,
 					      data->vectors,
 					      CONFIG_IVSHMEM_MSI_X_VECTORS);
@@ -61,7 +61,7 @@ static bool ivshmem_configure_interrupts(const struct device *dev)
 		data->params[i].dev = dev;
 		data->params[i].vector = i;
 
-		if (!pcie_msi_vector_connect(data->bdf,
+		if (!pcie_msi_vector_connect(data->pcie->bdf,
 					     &data->vectors[i],
 					     ivshmem_doorbell,
 					     &data->params[i], 0)) {
@@ -72,7 +72,7 @@ static bool ivshmem_configure_interrupts(const struct device *dev)
 
 	LOG_DBG("%u MSI-X Vectors connected", n_vectors);
 
-	if (!pcie_msi_enable(data->bdf, data->vectors, n_vectors, 0)) {
+	if (!pcie_msi_enable(data->pcie->bdf, data->vectors, n_vectors, 0)) {
 		LOG_ERR("Could not enable MSI-X");
 		goto out;
 	}
@@ -110,7 +110,7 @@ static bool ivshmem_configure(const struct device *dev)
 	struct ivshmem *data = dev->data;
 	struct pcie_bar mbar_regs, mbar_mem;
 
-	if (!pcie_get_mbar(data->bdf, IVSHMEM_PCIE_REG_BAR_IDX, &mbar_regs)) {
+	if (!pcie_get_mbar(data->pcie->bdf, IVSHMEM_PCIE_REG_BAR_IDX, &mbar_regs)) {
 #ifdef CONFIG_IVSHMEM_DOORBELL
 		LOG_ERR("ivshmem regs bar not found");
 		return false;
@@ -120,13 +120,13 @@ static bool ivshmem_configure(const struct device *dev)
 			   sizeof(struct ivshmem_reg), K_MEM_CACHE_NONE);
 #endif /* CONFIG_IVSHMEM_DOORBELL */
 	} else {
-		pcie_set_cmd(data->bdf, PCIE_CONF_CMDSTAT_MEM, true);
+		pcie_set_cmd(data->pcie->bdf, PCIE_CONF_CMDSTAT_MEM, true);
 
 		device_map(DEVICE_MMIO_RAM_PTR(dev), mbar_regs.phys_addr,
 			   mbar_regs.size, K_MEM_CACHE_NONE);
 	}
 
-	if (!pcie_get_mbar(data->bdf, IVSHMEM_PCIE_SHMEM_BAR_IDX, &mbar_mem)) {
+	if (!pcie_get_mbar(data->pcie->bdf, IVSHMEM_PCIE_SHMEM_BAR_IDX, &mbar_mem)) {
 		LOG_ERR("ivshmem mem bar not found");
 		return false;
 	}
@@ -227,24 +227,24 @@ static int ivshmem_init(const struct device *dev)
 	struct ivshmem *data = dev->data;
 	static bool bdf_lookup_done;
 
-	if ((data->bdf == PCIE_BDF_NONE) && bdf_lookup_done) {
+	if ((data->pcie->bdf == PCIE_BDF_NONE) && bdf_lookup_done) {
 		LOG_ERR("One instance of ivshmem with pcie_bdf_lookup() already initialized.\n"
 			"Using more than one with PCIE_BDF_NONE parameter might conflict\n"
 			"with already initialized instances.");
 		return -ENOTSUP;
 	}
-	if ((data->bdf == PCIE_BDF_NONE) && !bdf_lookup_done) {
-		if (data->dev_ven_id) {
-			data->bdf = pcie_bdf_lookup(data->dev_ven_id);
-		} else {
-			data->bdf = pcie_bdf_lookup(PCIE_ID(IVSHMEM_VENDOR_ID, IVSHMEM_DEVICE_ID));
+	if ((data->pcie->bdf == PCIE_BDF_NONE) && !bdf_lookup_done) {
+		if (data->pcie->id == PCIE_ID_NONE) {
+			data->pcie->id = PCIE_ID(IVSHMEM_VENDOR_ID,
+						 IVSHMEM_DEVICE_ID);
+			data->pcie->bdf = pcie_bdf_lookup(data->pcie->id);
 		}
-		if (data->bdf == PCIE_BDF_NONE) {
+		if (data->pcie->bdf == PCIE_BDF_NONE) {
 			LOG_WRN("ivshmem device not found");
 			return -ENOTSUP;
 		}
 	}
-	LOG_DBG("ivshmem found at bdf 0x%x", data->bdf);
+	LOG_DBG("ivshmem found at bdf 0x%x", data->pcie->bdf);
 	bdf_lookup_done = true;
 
 	if (!ivshmem_configure(dev)) {
@@ -254,9 +254,9 @@ static int ivshmem_init(const struct device *dev)
 }
 
 #define IVSHMEM_DEVICE_INIT(n) \
+	DEVICE_PCIE_INST_DECLARE(n); \
 	static struct ivshmem ivshmem_data_##n = { \
-		.bdf = DT_INST_REG_ADDR_BY_IDX(n, 0), \
-		.dev_ven_id = DT_INST_REG_SIZE_BY_IDX(n, 0) \
+		DEVICE_PCIE_INST_INIT(n, pcie), \
 	}; \
 	DEVICE_DT_INST_DEFINE(n, &ivshmem_init, NULL, \
 			      &ivshmem_data_##n, NULL, \

--- a/drivers/virtualization/virt_ivshmem.h
+++ b/drivers/virtualization/virt_ivshmem.h
@@ -24,8 +24,7 @@ struct ivshmem_param {
 
 struct ivshmem {
 	DEVICE_MMIO_RAM;
-	pcie_bdf_t bdf;
-	uint32_t dev_ven_id;
+	struct pcie_dev *pcie;
 	uintptr_t shmem;
 	size_t size;
 #ifdef CONFIG_IVSHMEM_DOORBELL

--- a/dts/bindings/can/kvaser,pcican.yaml
+++ b/dts/bindings/can/kvaser,pcican.yaml
@@ -5,11 +5,8 @@ description: Kvaser PCIcan
 
 compatible: "kvaser,pcican"
 
-include: can-controller.yaml
+include: [can-controller.yaml, pcie-device.yaml]
 
 properties:
-    reg:
-      required: true
-
     interrupts:
       required: true

--- a/dts/bindings/ethernet/intel,e1000.yaml
+++ b/dts/bindings/ethernet/intel,e1000.yaml
@@ -5,11 +5,8 @@ description: Intel E1000 Ethernet controller
 
 compatible: "intel,e1000"
 
-include: base.yaml
+include: [base.yaml, pcie-device.yaml]
 
 properties:
-    reg:
-      required: true
-
     interrupts:
       required: true

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -5,11 +5,11 @@ description: Synopsys DesignWare I2C node
 
 compatible: "snps,designware-i2c"
 
-include: [i2c-controller.yaml, pinctrl-device.yaml]
+include: [i2c-controller.yaml, pinctrl-device.yaml, pcie-device.yaml]
 
 properties:
     reg:
-      required: true
+      required: false
 
     interrupts:
       required: true

--- a/dts/bindings/pcie/host/pcie-device.yaml
+++ b/dts/bindings/pcie/host/pcie-device.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for PCIe devices
+
+properties:
+    vendor-id:
+      type: int
+      description: Vendor ID of the device
+    device-id:
+      type: int
+      description: Device ID of the device

--- a/dts/bindings/pcie/host/ptm-root.yaml
+++ b/dts/bindings/pcie/host/ptm-root.yaml
@@ -3,8 +3,4 @@
 
 # Common fields for PCIe PTM root
 
-include: base.yaml
-
-properties:
-    reg:
-      required: true
+include: [base.yaml, pcie-device.yaml]

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -2,12 +2,9 @@ description: ns16550 UART
 
 compatible: "ns16550"
 
-include: uart-controller.yaml
+include: [uart-controller.yaml, pcie-device.yaml]
 
 properties:
-    reg:
-      required: true
-
     reg-shift:
       type: int
       required: true

--- a/dts/bindings/virtualization/qemu,ivshmem.yaml
+++ b/dts/bindings/virtualization/qemu,ivshmem.yaml
@@ -5,4 +5,4 @@ description: ivShMem device properties
 
 compatible: "qemu,ivshmem"
 
-include: base.yaml
+include: [base.yaml, pcie-device.yaml]

--- a/dts/x86/intel/apollo_lake.dtsi
+++ b/dts/x86/intel/apollo_lake.dtsi
@@ -41,12 +41,13 @@
 		compatible = "intel,pcie";
 		ranges;
 
-		uart0: uart@c000 {
+		uart0: uart0 {
 			compatible = "ns16550";
 
-			reg = <PCIE_BDF(0,0x18,0) PCIE_ID(0x8086,0x5abc)>;
-			reg-shift = <2>;
+			vendor-id = <0x8086>;
+			device-id = <0x5abc>;
 
+			reg-shift = <2>;
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -54,26 +55,13 @@
 			current-speed = <115200>;
 		};
 
-		uart1: uart@c100 {
+		uart1: uart1 {
 			compatible = "ns16550";
 
-			reg = <PCIE_BDF(0,0x18,1) PCIE_ID(0x8086,0x5abe)>;
+			vendor-id = <0x8086>;
+			device-id = <0x5abe>;
+
 			reg-shift = <2>;
-
-			clock-frequency = <1843200>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-
-			status = "okay";
-			current-speed = <115200>;
-		};
-
-		uart2: uart@c200 {
-			compatible = "ns16550";
-
-			reg = <PCIE_BDF(0,0x18,2) PCIE_ID(0x8086,0x5ac0)>;
-			reg-shift = <2>;
-
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -82,12 +70,28 @@
 			current-speed = <115200>;
 		};
 
-		uart3: uart@c300 {
+		uart2: uart2 {
 			compatible = "ns16550";
 
-			reg = <PCIE_BDF(0,0x18,3) PCIE_ID(0x8086,0x5aee)>;
-			reg-shift = <2>;
+			vendor-id = <0x8086>;
+			device-id = <0x5ac0>;
 
+			reg-shift = <2>;
+			clock-frequency = <1843200>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			status = "okay";
+			current-speed = <115200>;
+		};
+
+		uart3: uart3 {
+			compatible = "ns16550";
+
+			vendor-id = <0x8086>;
+			device-id = <0x5aee>;
+
+			reg-shift = <2>;
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;

--- a/dts/x86/intel/apollo_lake.dtsi
+++ b/dts/x86/intel/apollo_lake.dtsi
@@ -100,96 +100,104 @@
 			current-speed = <115200>;
 		};
 
-		i2c0: i2c@b000 {
+		i2c0: i2c0 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x16,0) PCIE_ID(0x8086,0x5aac)>;
+			vendor-id = <0x8086>;
+			device-id = <0x5aac>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c1: i2c@b100 {
+		i2c1: i2c1 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x16,1) PCIE_ID(0x8086,0x5aae)>;
+			vendor-id = <0x8086>;
+			device-id = <0x5aae>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c2: i2c@b200 {
+		i2c2: i2c2 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x16,2) PCIE_ID(0x8086,0x5ab0)>;
+			vendor-id = <0x8086>;
+			device-id = <0x5ab0>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c3: i2c@b300 {
+		i2c3: i2c3 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x16,3) PCIE_ID(0x8086,0x5ab2)>;
+			vendor-id = <0x8006>;
+			device-id = <0x5ab2>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c4: i2c@b800 {
+		i2c4: i2c4 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x17,0) PCIE_ID(0x8086,0x5ab4)>;
+			vendor-id = <0x8086>;
+			device-id = <0x5ab4>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c5: i2c@b900 {
+		i2c5: i2c5{
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x17,1) PCIE_ID(0x8086,0x5ab6)>;
+			vendor-id = <0x8086>;
+			device-id = <0x5ab6>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c6: i2c@ba00 {
+		i2c6: i2c6 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x17,2) PCIE_ID(0x8086,0x5ab8)>;
+			vendor-id = <0x8086>;
+			device-id = <0x5ab8>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c7: i2c@bb00 {
+		i2c7: i2c7 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x17,3) PCIE_ID(0x8086,0x5aba)>;
+			vendor-id = <0x8086>;
+			device-id = <0x5aba>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -54,12 +54,13 @@
 			status = "okay";
 		};
 
-		uart0: uart@f000 {
+		uart0: uart0 {
 			compatible = "ns16550";
 
-			reg = <PCIE_BDF(0,0x1e,0) PCIE_ID(0x8086,0x4b28)>;
-			reg-shift = <2>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b28>;
 
+			reg-shift = <2>;
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -67,26 +68,13 @@
 			current-speed = <115200>;
 		};
 
-		uart1: uart@f100 {
+		uart1: uart1 {
 			compatible = "ns16550";
 
-			reg = <PCIE_BDF(0,0x1e,1) PCIE_ID(0x8086,0x4b29)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b29>;
+
 			reg-shift = <2>;
-
-			clock-frequency = <1843200>;
-			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
-			interrupt-parent = <&intc>;
-
-			status = "okay";
-			current-speed = <115200>;
-		};
-
-		uart2: uart@ca00 {
-			compatible = "ns16550";
-
-			reg = <PCIE_BDF(0,0x19,2) PCIE_ID(0x8086,0x4b4d)>;
-			reg-shift = <2>;
-
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -95,12 +83,28 @@
 			current-speed = <115200>;
 		};
 
-		uart_pse_0: uart@8800 {
+		uart2: uart2 {
 			compatible = "ns16550";
 
-			reg = <PCIE_BDF(0,0x11,0) PCIE_ID(0x8086,0x4b96)>;
-			reg-shift = <2>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b4d>;
 
+			reg-shift = <2>;
+			clock-frequency = <1843200>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			status = "okay";
+			current-speed = <115200>;
+		};
+
+		uart_pse_0: uart_pse_0 {
+			compatible = "ns16550";
+
+			vendor-id = <0x8086>;
+			device-id = <0x4b96>;
+
+			reg-shift = <2>;
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -109,12 +113,13 @@
 			current-speed = <115200>;
 		};
 
-		uart_pse_1: uart@8900 {
+		uart_pse_1: uart_pse_1 {
 			compatible = "ns16550";
 
-			reg = <PCIE_BDF(0,0x11,1) PCIE_ID(0x8086,0x4b97)>;
-			reg-shift = <2>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b97>;
 
+			reg-shift = <2>;
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -123,12 +128,13 @@
 			current-speed = <115200>;
 		};
 
-		uart_pse_2: uart@8a00 {
+		uart_pse_2: uart_pse_2 {
 			compatible = "ns16550";
 
-			reg = <PCIE_BDF(0,0x11,2) PCIE_ID(0x8086,0x4b98)>;
-			reg-shift = <2>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b98>;
 
+			reg-shift = <2>;
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -137,12 +143,13 @@
 			current-speed = <115200>;
 		};
 
-		uart_pse_3: uart@8b00 {
+		uart_pse_3: uart_pse_3 {
 			compatible = "ns16550";
 
-			reg = <PCIE_BDF(0,0x11,3) PCIE_ID(0x8086,0x4b99)>;
-			reg-shift = <2>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b99>;
 
+			reg-shift = <2>;
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -151,12 +158,13 @@
 			current-speed = <115200>;
 		};
 
-		uart_pse_4: uart@8c00 {
+		uart_pse_4: uart_pse_4 {
 			compatible = "ns16550";
 
-			reg = <PCIE_BDF(0,0x11,4) PCIE_ID(0x8086,0x4b9a)>;
-			reg-shift = <2>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b9a>;
 
+			reg-shift = <2>;
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -165,12 +173,13 @@
 			current-speed = <115200>;
 		};
 
-		uart_pse_5: uart@8d00 {
+		uart_pse_5: uart_pse_5 {
 			compatible = "ns16550";
 
-			reg = <PCIE_BDF(0,0x11,5) PCIE_ID(0x8086,0x4b9b)>;
-			reg-shift = <2>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b9b>;
 
+			reg-shift = <2>;
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -188,180 +188,195 @@
 			current-speed = <115200>;
 		};
 
-		i2c0: i2c@a800 {
+		i2c0: i2c0 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x15,0) PCIE_ID(0x8086,0x4b78)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b78>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c1: i2c@a900 {
+		i2c1: i2c1 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x15,1) PCIE_ID(0x8086,0x4b79)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b79>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c2: i2c@aa00 {
+		i2c2: i2c2 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x15,2) PCIE_ID(0x8086,0x4b7a)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b7a>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c3: i2c@ab00 {
+		i2c3: i2c3 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x15,3) PCIE_ID(0x8086,0x4b7b)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b7b>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c4: i2c@c800 {
+		i2c4: i2c4 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x19,0) PCIE_ID(0x8086,0x4b4b)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b4b>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c5: i2c@c900 {
+		i2c5: i2c5 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x19,1) PCIE_ID(0x8086,0x4b4c)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b4c>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c6: i2c@8000 {
+		i2c6: i2c6 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x10,0) PCIE_ID(0x8086,0x4b44)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b44>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c7: i2c@8100 {
+		i2c7: i2c7 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x10,1) PCIE_ID(0x8086,0x4b45)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b45>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c_pse_0: i2c@d800 {
+		i2c_pse_0: i2c_pse_0 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x1b,0) PCIE_ID(0x8086,0x4bb9)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4bb9>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c_pse_1: i2c@d900 {
+		i2c_pse_1: i2c_pse_1 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x1b,1) PCIE_ID(0x8086,0x4bba)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4bba>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c_pse_2: i2c@da00 {
+		i2c_pse_2: i2c_pse_2 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x1b,2) PCIE_ID(0x8086,0x4bbb)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4bbb>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c_pse_3: i2c@db00 {
+		i2c_pse_3: i2c_pse_3 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x1b,3) PCIE_ID(0x8086,0x4bbc)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4bbc>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c_pse_4: i2c@dc00 {
+		i2c_pse_4: i2c_pse_4 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x1b,4) PCIE_ID(0x8086,0x4bbd)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4bbd>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c_pse_5: i2c@dd00 {
+		i2c_pse_5: i2c_pse_5 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x1b,5) PCIE_ID(0x8086,0x4bbe)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4bbe>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";
 		};
 
-		i2c_pse_6: i2c@de00 {
+		i2c_pse_6: i2c_pse_6 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <PCIE_BDF(0,0x1b,6) PCIE_ID(0x8086,0x4bbf)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4bbf>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -46,10 +46,11 @@
 		compatible = "intel,pcie";
 		ranges;
 
-		ptm_root0: ptm_root@e000 {
+		ptm_root0: ptm_root0 {
 			compatible = "ptm-root";
 
-			reg = <PCIE_BDF(0,0x1c,0) PCIE_ID(0x8086,0x4b38)>;
+			vendor-id = <0x8086>;
+			device-id = <0x4b38>;
 
 			status = "okay";
 		};

--- a/include/zephyr/linker/common-ram.ld
+++ b/include/zephyr/linker/common-ram.ld
@@ -110,6 +110,10 @@
 	NETWORK_RAM_SECTIONS
 #endif /* NETWORKING */
 
+#if defined(CONFIG_PCIE)
+	ITERABLE_SECTION_RAM(pcie_dev, 4)
+#endif /* PCIE */
+
 #if defined(CONFIG_UART_MUX)
 	SECTION_DATA_PROLOGUE(uart_mux,,SUBALIGN(4))
 	{

--- a/soc/x86/apollo_lake/soc.h
+++ b/soc/x86/apollo_lake/soc.h
@@ -29,7 +29,6 @@
 
 #include <zephyr/drivers/pcie/pcie.h>
 
-/* This expands to "PCIE_BDF(0, 0x18, 0)" on this platform */
-#define X86_SOC_EARLY_SERIAL_PCIDEV DT_REG_ADDR(DT_CHOSEN(zephyr_console))
+#define X86_SOC_EARLY_SERIAL_PCIDEV PCIE_BDF(0, 0x18, 0) /* uart0 */
 
 #endif /* __SOC_H_ */

--- a/soc/x86/elkhart_lake/soc.h
+++ b/soc/x86/elkhart_lake/soc.h
@@ -29,7 +29,7 @@
 
 #if DT_ON_BUS(DT_CHOSEN(zephyr_console), pcie)
 #include <zephyr/drivers/pcie/pcie.h>
-#define X86_SOC_EARLY_SERIAL_PCIDEV DT_REG_ADDR(DT_CHOSEN(zephyr_console))
+#define X86_SOC_EARLY_SERIAL_PCIDEV PCIE_BDF(0, 0x19, 2) /* uart2 */
 #else
 #define X86_SOC_EARLY_SERIAL_MMIO8_ADDR DT_REG_ADDR(DT_CHOSEN(zephyr_console))
 #endif

--- a/tests/drivers/virtualization/ivshmem/app.overlay
+++ b/tests/drivers/virtualization/ivshmem/app.overlay
@@ -12,10 +12,12 @@
 		compatible = "intel,pcie";
 		ranges;
 
-		ivshmem0: ivshmem@800 {
+		ivshmem0: ivshmem0 {
 			compatible = "qemu,ivshmem";
 
-			reg = <PCIE_BDF_NONE PCIE_ID(0x1af4,0x1110)>;
+			vendor-id = <0x1af4>;
+			device-id = <0x1110>;
+
 			status = "okay";
 		};
 	};


### PR DESCRIPTION
The BDF values can differ on the same platform, based on e.g. BIOS
configuration, and in the case of qemu the command line parameters. It's
therefore more reliable to always look up the BDF value based on the
known Vendor and Device IDs.

Fixes #26109