### PR TITLE
manifest: remove submodules true for hal_telink

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -131,7 +131,6 @@ manifest:
     - name: hal_telink
       revision: 38573af589173259801ae6c2b34b7d4c9e626746
       path: modules/hal/telink
-      submodules: true
       groups:
         - hal
     - name: hal_ti


### PR DESCRIPTION
Fixes: #52113

The PR #45903 included a `submodules: true` for the hal_telink project.

However, that project contains a submodule with binary libraries.

This is circumventing the rules regarding binary blobs in the Zephyr project as specified here:
https://docs.zephyrproject.org/latest/contribute/bin_blobs.html
Therefore remove the submodules field.

Links to the submodule with binary blobs:
https://github.com/zephyrproject-rtos/hal_telink/tree/95431ef5ec667ae5b1a0e4b59d1a5753396bd169/tlsr9/ble/proj_lib pointing to this submodule with binary blobs:
https://github.com/telink-semi/zephyr_hal_telink_b91_ble_lib/tree/0a49c9bf3cfe4684cc27fbaa6ad070186703e452

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>