### PR TITLE
lwm2m: swmgmt: fix observations not working for resources

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
@@ -202,6 +202,45 @@ static void *callback_read_not_defined(uint16_t obj_inst_id, uint16_t res_id, ui
 	return NULL;
 }
 
+static void set_sw_update_state(struct lwm2m_swmgmt_data *instance, uint8_t state)
+{
+	int ret;
+	char obj_path[LWM2M_MAX_PATH_STR_LEN];
+
+	(void)snprintk(obj_path, sizeof(obj_path), "%d/%d/%d", LWM2M_OBJECT_SOFTWARE_MANAGEMENT_ID,
+		       instance->obj_inst_id, SWMGMT_UPDATE_STATE_ID);
+	ret = lwm2m_engine_set_u8(obj_path, state);
+	if (ret != 0) {
+		LOG_ERR("Could not set state");
+	}
+}
+
+static void set_sw_update_result(struct lwm2m_swmgmt_data *instance, uint8_t result)
+{
+	int ret;
+	char obj_path[LWM2M_MAX_PATH_STR_LEN];
+
+	(void)snprintk(obj_path, sizeof(obj_path), "%d/%d/%d", LWM2M_OBJECT_SOFTWARE_MANAGEMENT_ID,
+		       instance->obj_inst_id, SWMGMT_UPDATE_RESULT_ID);
+	ret = lwm2m_engine_set_u8(obj_path, result);
+	if (ret != 0) {
+		LOG_ERR("Could not set result");
+	}
+}
+
+static void set_sw_update_act_state(struct lwm2m_swmgmt_data *instance, bool state)
+{
+	int ret;
+	char obj_path[LWM2M_MAX_PATH_STR_LEN];
+
+	(void)snprintk(obj_path, sizeof(obj_path), "%d/%d/%d", LWM2M_OBJECT_SOFTWARE_MANAGEMENT_ID,
+		       instance->obj_inst_id, SWMGMT_ACTIVATION_UPD_STATE_ID);
+	ret = lwm2m_engine_set_bool(obj_path, state);
+	if (ret != 0) {
+		LOG_ERR("Could not set activation state");
+	}
+}
+
 static struct lwm2m_swmgmt_data swmgmt_data[MAX_INSTANCE_COUNT] = { 0 };
 
 static struct lwm2m_swmgmt_data *find_index(uint16_t obj_inst_id)
@@ -350,8 +389,8 @@ static int handle_event(struct lwm2m_swmgmt_data *instance, uint8_t event)
 	case UPD_STATE_INITIAL:
 		switch (event) {
 		case EVENT_PKG_URI_WRITE:
-			instance->update_state = UPD_STATE_DOWNLOAD_STARTED;
-			instance->update_result = UPD_RES_DOWNLOADING;
+			set_sw_update_state(instance, UPD_STATE_DOWNLOAD_STARTED);
+			set_sw_update_result(instance, UPD_RES_DOWNLOADING);
 			ret = 0;
 			break;
 		default:
@@ -362,11 +401,11 @@ static int handle_event(struct lwm2m_swmgmt_data *instance, uint8_t event)
 	case UPD_STATE_DOWNLOAD_STARTED:
 		switch (event) {
 		case EVENT_PKG_WRITTEN:
-			instance->update_state = UPD_STATE_DOWNLOADED;
-			instance->update_result = UPD_RES_INITIAL;
+			set_sw_update_state(instance, UPD_STATE_DOWNLOADED);
+			set_sw_update_result(instance, UPD_RES_INITIAL);
 			break;
 		case EVENT_DOWNLOAD_FAILED:
-			instance->update_state = UPD_STATE_INITIAL;
+			set_sw_update_state(instance, UPD_STATE_INITIAL);
 
 			/* Inform the instance of DOWNLOAD_FAILED by calling
 			 * write_package_cb with a bunch of NULL parameters
@@ -381,12 +420,12 @@ static int handle_event(struct lwm2m_swmgmt_data *instance, uint8_t event)
 	case UPD_STATE_DOWNLOADED:
 		switch (event) {
 		case (EVENT_PKG_INTEGRITY_VERIFIED):
-			instance->update_state = UPD_STATE_DELIVERED;
-			instance->update_result = UPD_RES_INITIAL;
+			set_sw_update_state(instance, UPD_STATE_DELIVERED);
+			set_sw_update_result(instance, UPD_RES_INITIAL);
 			break;
 		case (EVENT_PKG_INTEGRITY_FAILED):
-			instance->update_state = UPD_STATE_INITIAL;
-			instance->update_result = UPD_RES_PACKAGE_INTEGRITY_CHECK_FAILURE;
+			set_sw_update_state(instance, UPD_STATE_INITIAL);
+			set_sw_update_result(instance, UPD_RES_PACKAGE_INTEGRITY_CHECK_FAILURE);
 			break;
 		default:
 			ret = -EINVAL;
@@ -407,20 +446,20 @@ static int handle_event(struct lwm2m_swmgmt_data *instance, uint8_t event)
 			break;
 
 		case EVENT_INSTALL_SUCCESSFUL:
-			instance->update_state = UPD_STATE_INSTALLED;
-			instance->update_result = UPD_RES_SW_SUCCESSFULLY_INSTALLED;
+			set_sw_update_state(instance, UPD_STATE_INSTALLED);
+			set_sw_update_result(instance, UPD_RES_SW_SUCCESSFULLY_INSTALLED);
 			instance->next_package_is_upgrade = false;
 			break;
 
 		case EVENT_INSTALL_FAIL:
-			instance->update_state = UPD_STATE_DELIVERED;
-			instance->update_result = UPD_RES_SW_INSTALLATION_FAILURE;
+			set_sw_update_state(instance, UPD_STATE_DELIVERED);
+			set_sw_update_result(instance, UPD_RES_SW_INSTALLATION_FAILURE);
 			break;
 
 		case EVENT_DELETE_PACKAGE:
 			ret = instance->delete_package_cb(instance->obj_inst_id, NULL, 0);
 			if (ret == 0) {
-				instance->update_state = UPD_STATE_INITIAL;
+				set_sw_update_state(instance, UPD_STATE_INITIAL);
 				/* update_result unchanged */
 			}
 			break;
@@ -435,24 +474,24 @@ static int handle_event(struct lwm2m_swmgmt_data *instance, uint8_t event)
 		case EVENT_ACTIVATE:
 			ret = instance->activate_cb(instance->obj_inst_id, NULL, 0);
 			if (ret == 0) {
-				instance->activation_state = true;
+				set_sw_update_act_state(instance, true);
 			}
 			break;
 		case EVENT_DEACTIVATE:
 			ret = instance->deactivate_cb(instance->obj_inst_id, NULL, 0);
 			if (ret == 0) {
-				instance->activation_state = false;
+				set_sw_update_act_state(instance, false);
 			}
 			break;
 		case EVENT_FOR_UPDATE:
 			instance->next_package_is_upgrade = true;
-			instance->update_state = UPD_STATE_INITIAL;
-			instance->update_result = UPD_RES_INITIAL;
+			set_sw_update_state(instance, UPD_STATE_INITIAL);
+			set_sw_update_result(instance, UPD_RES_INITIAL);
 		case EVENT_DELETE_PACKAGE:
 			ret = instance->delete_package_cb(instance->obj_inst_id, NULL, 0);
 			if (ret == 0) {
-				instance->update_state = UPD_STATE_INITIAL;
-				instance->update_result = UPD_RES_INITIAL;
+				set_sw_update_state(instance, UPD_STATE_INITIAL);
+				set_sw_update_result(instance, UPD_RES_INITIAL);
 			}
 			break;
 		default:
@@ -540,17 +579,17 @@ static int package_write_cb(uint16_t obj_inst_id, uint16_t res_id, uint16_t res_
 		handle_event(instance, EVENT_DOWNLOAD_FAILED);
 		switch (ret) {
 		case -ENOMEM:
-			instance->update_result = UPD_RES_OUT_OF_MEMORY_DURING_DOWNLOAD;
+			set_sw_update_result(instance, UPD_RES_OUT_OF_MEMORY_DURING_DOWNLOAD);
 			break;
 		case -ENOSPC:
-			instance->update_result = UPD_RES_NOT_ENOUGH_STORAGE;
+			set_sw_update_result(instance, UPD_RES_NOT_ENOUGH_STORAGE);
 			ret = -EFBIG;
 			break;
 		case -EFAULT:
-			instance->update_result = UPD_RES_PACKAGE_INTEGRITY_CHECK_FAILURE;
+			set_sw_update_result(instance, UPD_RES_PACKAGE_INTEGRITY_CHECK_FAILURE);
 			break;
 		default:
-			instance->update_result = UPD_RES_LOST_CONNECTION_DURING_DOWNLOAD;
+			set_sw_update_result(instance, UPD_RES_LOST_CONNECTION_DURING_DOWNLOAD);
 			break;
 		}
 
@@ -592,15 +631,15 @@ static void set_update_result(uint16_t obj_inst_id, int error_code)
 
 	handle_event(instance, EVENT_DOWNLOAD_FAILED);
 	if (error_code == -ENOMEM) {
-		instance->update_result = UPD_RES_OUT_OF_MEMORY_DURING_DOWNLOAD;
+		set_sw_update_result(instance, UPD_RES_OUT_OF_MEMORY_DURING_DOWNLOAD);
 	} else if (error_code == -ENOSPC) {
-		instance->update_result = UPD_RES_NOT_ENOUGH_STORAGE;
+		set_sw_update_result(instance, UPD_RES_NOT_ENOUGH_STORAGE);
 	} else if (error_code == -EFAULT) {
-		instance->update_result = UPD_RES_PACKAGE_INTEGRITY_CHECK_FAILURE;
+		set_sw_update_result(instance, UPD_RES_PACKAGE_INTEGRITY_CHECK_FAILURE);
 	} else if (error_code == -ENOTSUP) {
-		instance->update_result = UPD_RES_INVALID_URI;
+		set_sw_update_result(instance, UPD_RES_INVALID_URI);
 	} else {
-		instance->update_result = UPD_RES_LOST_CONNECTION_DURING_DOWNLOAD;
+		set_sw_update_result(instance, UPD_RES_LOST_CONNECTION_DURING_DOWNLOAD);
 	}
 }
 


### PR DESCRIPTION
The pointers to resource values should not be used
directly to update the values.
This will break observations if the server is trying to
observe changes during a software update.