### PR TITLE
runners: trace32: mypy fixes

### DIFF
--- a/scripts/west_commands/runners/trace32.py
+++ b/scripts/west_commands/runners/trace32.py
@@ -31,7 +31,7 @@ class TRACE32BinaryRunner(ZephyrBinaryRunner):
                  cfg: RunnerConfig,
                  t32_cfg: Path,
                  arch: str,
-                 startup_args: List[str] = None,
+                 startup_args: Optional[List[str]] = None,
                  timeout: int = 60) -> None:
         super(TRACE32BinaryRunner, self).__init__(cfg)
         self.arch = arch
@@ -134,7 +134,8 @@ class TRACE32BinaryRunner(ZephyrBinaryRunner):
         self.logger.info(f'Launching TRACE32: {" ".join(cmd)}')
         self.check_call(cmd)
 
-    def get_launch_command(self, command_name: str, cfg: Path = None) -> List[str]:
+    def get_launch_command(self, command_name: str,
+                           cfg: Optional[Path] = None) -> List[str]:
         cmd = [
             str(self.t32_exec),
             '-c', str(cfg if cfg else self.t32_cfg),


### PR DESCRIPTION
Fixes for the following issues that a new version of mypy started reporting recently:

runners/trace32.py:34: error: Incompatible default for argument "startup_args" (default has type "None", argument has type "List[str]") [assignment]

runners/trace32.py:137: error: Incompatible default for argument "cfg" (default has type "None", argument has type "Path") [assignment]

runners/trace32.py:34: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>