### PR TITLE
dts: spi: Add property for cs delay

### DIFF
--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -42,3 +42,10 @@ properties:
       enum:
         - 0
         - 32768
+    spi-cs-delay-us:
+       type: int
+       description: |
+         Additional delay, in microseconds, to add after asserting CS and before
+         de-asserting CS.  SPI drivers may specify this delay in their code as
+         well.  The value in the device tree, if present, will override the
+         default from driver or application code.

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -252,13 +252,14 @@ struct spi_cs_control {
  * This macro is not available in C++.
  *
  * @param node_id Devicetree node identifier for a device on a SPI bus
- * @param delay_ The @p delay field to set in the @p spi_cs_control
+ * @param delay_ The default @p delay field to set in the @p spi_cs_control, if
+ *   the value is not specified in the device tree.
  * @return a pointer to the @p spi_cs_control structure
  */
 #define SPI_CS_CONTROL_PTR_DT(node_id, delay_)			  \
 	(&(struct spi_cs_control) {				  \
 		.gpio = SPI_CS_GPIOS_DT_SPEC_GET(node_id),	  \
-		.delay = (delay_),				  \
+		.delay = DT_PROP_OR(node_id, spi_cs_delay_us, (delay_)), \
 	})
 
 /**
@@ -273,7 +274,8 @@ struct spi_cs_control {
  * This macro is not available in C++.
  *
  * @param inst Devicetree node instance number
- * @param delay_ The @p delay field to set in the @p spi_cs_control
+ * @param delay_ The default @p delay field to set in the @p spi_cs_control,
+ *   if the value is not specified in the device tree.
  * @return a pointer to the @p spi_cs_control structure
  */
 #define SPI_CS_CONTROL_PTR_DT_INST(inst, delay_)		\
@@ -337,8 +339,9 @@ struct spi_config {
  * @param node_id Devicetree node identifier for the SPI device whose
  *                struct spi_config to create an initializer for
  * @param operation_ the desired @p operation field in the struct spi_config
- * @param delay_ the desired @p delay field in the struct spi_config's
- *               spi_cs_control, if there is one
+ * @param delay_ the default @p delay field in the struct spi_config's
+ *               spi_cs_control, if there is one.  This can be specified in the
+ *               device tree, which will override the default supplied here.
  */
 #define SPI_CONFIG_DT(node_id, operation_, delay_)			\
 	{								\
@@ -363,8 +366,9 @@ struct spi_config {
  *
  * @param inst Devicetree instance number
  * @param operation_ the desired @p operation field in the struct spi_config
- * @param delay_ the desired @p delay field in the struct spi_config's
- *               spi_cs_control, if there is one
+ * @param delay_ the default @p delay field in the struct spi_config's
+ *               spi_cs_control, if there is one.  This can be specified in the
+ *               device tree, which will override the default supplied here.
  */
 #define SPI_CONFIG_DT_INST(inst, operation_, delay_)	\
 	SPI_CONFIG_DT(DT_DRV_INST(inst), operation_, delay_)
@@ -398,8 +402,9 @@ struct spi_dt_spec {
  * @param node_id Devicetree node identifier for the SPI device whose
  *                struct spi_dt_spec to create an initializer for
  * @param operation_ the desired @p operation field in the struct spi_config
- * @param delay_ the desired @p delay field in the struct spi_config's
- *               spi_cs_control, if there is one
+ * @param delay_ the default @p delay field in the struct spi_config's
+ *               spi_cs_control, if there is one.  This can be specified in the
+ *               device tree, which will override the default supplied here.
  */
 #define SPI_DT_SPEC_GET(node_id, operation_, delay_)		     \
 	{							     \
@@ -417,8 +422,9 @@ struct spi_dt_spec {
  *
  * @param inst Devicetree instance number
  * @param operation_ the desired @p operation field in the struct spi_config
- * @param delay_ the desired @p delay field in the struct spi_config's
- *               spi_cs_control, if there is one
+ * @param delay_ the default @p delay field in the struct spi_config's
+ *               spi_cs_control, if there is one.  This can be specified in the
+ *               device tree, which will override the default supplied here.
  */
 #define SPI_DT_SPEC_INST_GET(inst, operation_, delay_) \
 	SPI_DT_SPEC_GET(DT_DRV_INST(inst), operation_, delay_)


### PR DESCRIPTION
This is a common field for the configuration of CS lines in the SPI layer.  But, there is no way to set it from the device tree.

Add the property "spi-cs-delay-us" for this.  This is added to the spi client device node, as the delay is set per device.  Linux has similar SPI delay properties, but doesn't use the same kind of delay, so it can't be exactly the same.

Update the macros for getting SPI devices from the device tree to look for this property.

Previously, delay needed to be explicitly added by the driver as a macro argument.  Keep the interface the same, but change the semantics so the macro delay argument is the default delay value.  The device tree property spi-cs-delay will, if set, override the default.

There are only two users of this delay in the Zephyr code base.  One is eswifi and the other is spi_nor.  The former has a fixed value specified in the driver code and the latter uses a config variable.

This change should work fine with both.  It offers an improvement to the spi-nor driver: it doesn't require delay to be the same for every spi-nor device.

I'm not clear why these users need the delay.  This feature was originally created in PR #145, "SPI API update".  No discussion or background information is present in the commit messages or PR.  It just appeared as a new feature out of nowhere, with no users, when the API changed.

The first and only users didn't appear until over a year later, in PR #10988 for spi-nor and PR #10464 for cswifi.  I saw no discussion or code comments about why the delay might be needed.