### PR TITLE
Bluetooth: Controller: Replace Central connection spacing Kconfig

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -440,25 +440,24 @@ config BT_CTLR_SCHED_ADVANCED
 	  Disabling this feature will lead to overlapping role in timespace
 	  leading to skipped events amongst active roles.
 
-config BT_CTLR_SCHED_ADVANCED_CENTRAL_CONN_SPACING
-	int "Advanced scheduling central preferred connection spacing"
+config BT_CTLR_CENTRAL_SPACING
+	int "Central Connection Spacing"
 	depends on BT_CTLR_SCHED_ADVANCED
 	default 0
+	range 0 65535
 	help
-	  The central preferred connection spacing defines an additional spacing
-	  in microseconds, added to the fixed ~1250 us spacing obtained by enabling
-	  BT_CTLR_SCHED_ADVANCED. Specifying 0 (default) will obtain a spacing of
-	  ~1250 us, whereas specifying 1250 will yield a spacing of ~2500 us.
-	  The spacing is defined as the distance in time between the anchor points
-	  of the established central role connections.
-	  The precision is determined by the resolution of the platform dependent
-	  ticker clock.
-	  When specifying values above 6.25 ms, the spacing may be unobtainable if
-	  the connection interval becomes smaller than the total spacing. In that
-	  case, modulo is applied and a total spacing of 15 ms on a 10 ms connection
-	  interval yields 5 ms spacing.
-	  For multiple connections, it may become impossible to honor the preferred
-	  spacing, in which case overlapping will occur.
+	  The preferred connection spacing between multiple simultaneous central
+	  roles in microseconds. The Controller will calculate the required time
+	  reservation using the data length and PHY currently in use. The
+	  greater of the preferred spacing and the calculated time reservation
+	  will be used.
+	  The precision is determined by the resolution of the platform
+	  dependent ticker clock.
+	  The upper range is a ceil value permitting any tuning of Controller's
+	  radio handling overheads and to allow Coded PHY S8 coding scheme PDU
+	  time, i.e. radio event overheads + 17040 (PDU Tx) + 150 (tIFS) + 4
+	  (active clock jitter) + 17040 (PDU rx) = (radio event overheads +
+	  34234) microseconds.
 
 config BT_CTLR_LLL_PRIO
 	int "Lower Link Layer (Radio) IRQ priority" if (BT_CTLR_ULL_LLL_PRIO_SUPPORT && !BT_CTLR_ZLI)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -460,7 +460,7 @@ uint32_t lll_preempt_calc(struct ull_hdr *ull, uint8_t ticker_id,
 	uint32_t diff;
 
 	ticks_now = ticker_ticks_now_get();
-	diff = ticks_now - ticks_at_event;
+	diff = ticker_ticks_diff_get(ticks_now, ticks_at_event);
 	if (diff & BIT(HAL_TICKER_CNTR_MSBIT)) {
 		return 0;
 	}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -51,12 +51,6 @@
 /* Maximum primary Advertising Radio Channels to scan */
 #define ADV_CHAN_MAX 3U
 
-#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_CTLR_SCHED_ADVANCED)
-#define CONN_SPACING CONFIG_BT_CTLR_SCHED_ADVANCED_CENTRAL_CONN_SPACING
-#else
-#define CONN_SPACING 0U
-#endif /* CONFIG_BT_CENTRAL && CONFIG_BT_CTLR_SCHED_ADVANCED */
-
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);
 static int resume_prepare_cb(struct lll_prepare_param *p);
@@ -294,13 +288,13 @@ void lll_scan_prepare_connect_req(struct lll_scan *lll, struct pdu_adv *pdu_tx,
 		*conn_space_us = conn_offset_us;
 		pdu_tx->connect_ind.win_offset = sys_cpu_to_le16(0);
 	} else {
-		uint32_t win_offset_us = lll->conn_win_offset_us +
-					 CONN_SPACING;
+		uint32_t win_offset_us = lll->conn_win_offset_us;
 
 		while ((win_offset_us & ((uint32_t)1 << 31)) ||
 		       (win_offset_us < conn_offset_us)) {
 			win_offset_us += conn_interval_us;
 		}
+
 		*conn_space_us = win_offset_us;
 		pdu_tx->connect_ind.win_offset =
 			sys_cpu_to_le16((win_offset_us - conn_offset_us) /

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -876,7 +876,10 @@ static struct ull_hdr *ull_hdr_get_cb(uint8_t ticker_id, uint32_t *ticks_slot)
 
 		conn = ll_conn_get(ticker_id - TICKER_ID_CONN_BASE);
 		if (conn && !conn->lll.role) {
-			*ticks_slot = conn->ull.ticks_slot;
+			*ticks_slot =
+				MAX(conn->ull.ticks_slot,
+				    HAL_TICKER_US_TO_TICKS(
+					    CONFIG_BT_CTLR_CENTRAL_SPACING));
 
 			return &conn->ull;
 		}

--- a/tests/bluetooth/bsim_bt/bsim_test_multiple/prj.conf
+++ b/tests/bluetooth/bsim_bt/bsim_test_multiple/prj.conf
@@ -40,6 +40,8 @@ CONFIG_BT_CTLR_RX_BUFFERS=6
 # when connected to a single peer device (peripheral_identity sample) have
 # room for window widening and do not overlap with each other in that single
 # peer device. This can be tuned based on connection interval and clock
-# accuracy, current value here is sufficient for 500ppm at 1 second interval.
+# accuracy, current value here is sufficient for 500ppm at 1 second interval and
+# considering required connection event length for 251 byte PDU on 2M PHY.
+# (Event Overhead + Radio Ready Delay + Rx window + 1064 + 154 + 1064)
 CONFIG_BT_CTLR_ADVANCED_FEATURES=y
-CONFIG_BT_CTLR_SCHED_ADVANCED_CENTRAL_CONN_SPACING=1000
+CONFIG_BT_CTLR_CENTRAL_SPACING=3750


### PR DESCRIPTION
Replace the BT_CTLR_ADVANCED_SCHEDULING_CENTRAL_CONN_SPACING Kconfig with BT_CTLR_CENTRAL_SPACING to configure the the spacing from the beginning of a central connection event to beginning of the next central connection when supporting multiple simulataneous central connections.

If the BT_CTLR_CENTRAL_SPACING in microseconds is smaller then the required time reservation for a connection event, for given maximum data length and PHY in use, then the calculated time reservation will be used as the spacing between consecution central connection events.

The change fixes an issue wherein use of old Kconfig with higher values causes new central connections to be placed in between already connected central role if there was free time space available to fit the new connections time reservation.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>