### PR TITLE
uart: ns16550: move command macro to public header

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -34,7 +34,7 @@
 #include <zephyr/spinlock.h>
 #include <zephyr/irq.h>
 
-#include "uart_ns16550.h"
+#include <zephyr/drivers/serial/uart_ns16550.h>
 
 #define INST_HAS_PCP_HELPER(inst) DT_INST_NODE_HAS_PROP(inst, pcp) ||
 #define INST_HAS_DLF_HELPER(inst) DT_INST_NODE_HAS_PROP(inst, dlf) ||

--- a/drivers/serial/uart_ns16550.h
+++ b/drivers/serial/uart_ns16550.h
@@ -11,6 +11,8 @@
 #ifndef ZEPHYR_DRIVERS_SERIAL_UART_NS16550_H_
 #define ZEPHYR_DRIVERS_SERIAL_UART_NS16550_H_
 
-#define CMD_SET_DLF	0x01
+#include <zephyr/drivers/serial/uart_ns16550.h>
+
+#warning this header is deprecated, include <zephyr/drivers/serial/uart_ns16550.h> instead
 
 #endif /* ZEPHYR_DRIVERS_SERIAL_UART_NS16550_H_ */

--- a/include/zephyr/drivers/serial/uart_ns16550.h
+++ b/include/zephyr/drivers/serial/uart_ns16550.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2015 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Public header file for the NS16550 UART
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SERIAL_UART_NS16550_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SERIAL_UART_NS16550_H_
+
+/**
+ * @brief Set DLF
+ *
+ * @note This only applies to Synopsys Designware UART IP block.
+ */
+#define CMD_SET_DLF	0x01
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SERIAL_UART_NS16550_H_ */


### PR DESCRIPTION
This moves the CMD_SET_DLF command macro to public header so application can use it without weird include path to include the "private" header file under drivers/serial.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>