### PR TITLE
intel_adsp: Sort SoC nodes by address

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -89,11 +89,6 @@
 		zephyr,memory-region = "IMR1";
 	};
 
-	sha: adsp-sha@17DF00 {
-		compatible = "intel,adsp-sha";
-		reg = <0x17DF00 0xd0>;
-	};
-
 	soc {
 		core_intc: core_intc@0 {
 			compatible = "cdns,xtensa-core-intc";
@@ -102,12 +97,164 @@
 			#interrupt-cells = <3>;
 		};
 
-		adsp_host_ipc: ace_host_ipc@73000 {
-			compatible = "intel,adsp-host-ipc";
-			status = "okay";
-			reg = <0x73000 0x30>;
-			interrupts = <0 0 0>;
+		dmic0: dmic0@10000 {
+			compatible = "intel,dai-dmic";
+			reg = <0x10000 0x8000>;
+			shim = <0xC000>;
+			fifo = <0x0008>;
+			interrupts = <0x08 0 0>;
 			interrupt-parent = <&ace_intc>;
+		};
+
+		dmic1: dmic1@10000 {
+			compatible = "intel,dai-dmic";
+			reg = <0x10000 0x8000>;
+			shim = <0xC000>;
+			fifo = <0x0108>;
+			interrupts = <0x09 0 0>;
+			interrupt-parent = <&ace_intc>;
+		};
+
+		/*
+		 * FIXME this is modeling individual alh channels/instances
+		 * with node labels, which has problems. A better representation
+		 * is discussed here:
+		 *
+		 * https://github.com/zephyrproject-rtos/zephyr/pull/50287#discussion_r974591009
+		 */
+		alh0: alh0@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		alh1: alh1@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		ssp0: ssp@28000 {
+			compatible = "intel,ssp-dai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x00028000 0x1000
+				   0x00079C00 0x200>;
+			interrupts = <0x00 0 0>;
+			interrupt-parent = <&ace_intc>;
+			dmas = <&lpgpdma0 2
+					&lpgpdma0 3>;
+			dma-names = "tx", "rx";
+			power-domain = <&io0_domain>;
+			status = "okay";
+		};
+
+		sspbase: ssp_base@28800 {
+			compatible = "intel,ssp-sspbase";
+			reg = <0x28800 0x1000>;
+		};
+
+		ssp1: ssp@29000 {
+			compatible = "intel,ssp-dai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x00029000 0x1000
+				   0x00079C00 0x200>;
+			interrupts = <0x01 0 0>;
+			interrupt-parent = <&ace_intc>;
+			dmas = <&lpgpdma0 4
+					&lpgpdma0 5>;
+			dma-names = "tx", "rx";
+			power-domain = <&io0_domain>;
+			status = "okay";
+		};
+
+		ssp2: ssp@2a000 {
+			compatible = "intel,ssp-dai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x0002a000 0x1000
+				   0x00079C00 0x200>;
+			interrupts = <0x02 0 0>;
+			interrupt-parent = <&ace_intc>;
+			dmas = <&lpgpdma0 6
+					&lpgpdma0 7>;
+			dma-names = "tx", "rx";
+			power-domain = <&io0_domain>;
+			status = "okay";
+		};
+
+		ssp3: ssp@2b000 {
+			compatible = "intel,ssp-dai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x0002b000 0x1000
+				   0x00079C00 0x200>;
+			interrupts = <0x03 0 0>;
+			interrupt-parent = <&ace_intc>;
+			dmas = <&lpgpdma0 8
+					&lpgpdma0 9>;
+			dma-names = "tx", "rx";
+			power-domain = <&io0_domain>;
+			status = "okay";
+		};
+
+		ssp4: ssp@2c000 {
+			compatible = "intel,ssp-dai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x0002c000 0x1000
+				   0x00079C00 0x200>;
+			interrupts = <0x04 0 0>;
+			interrupt-parent = <&ace_intc>;
+			dmas = <&lpgpdma0 10
+					&lpgpdma0 11>;
+			dma-names = "tx", "rx";
+			power-domain = <&io0_domain>;
+			status = "okay";
+		};
+
+		ssp5: ssp@2d000 {
+			compatible = "intel,ssp-dai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x0002d000 0x1000
+				   0x00079C00 0x200>;
+			interrupts = <0x04 0 0>;
+			interrupt-parent = <&ace_intc>;
+			dmas = <&lpgpdma0 12
+					&lpgpdma0 13>;
+			dma-names = "tx", "rx";
+			power-domain = <&io0_domain>;
+			status = "okay";
+		};
+
+		mem_window0: mem_window@70200 {
+			compatible = "intel,adsp-mem-window";
+			reg = <0x70200 0x8>;
+			offset = <0x4000>;
+			memory = <&sram0>;
+			initialize;
+			read-only;
+		};
+
+		mem_window1: mem_window@70208 {
+			compatible = "intel,adsp-mem-window";
+			reg = <0x70208 0x8>;
+			memory = <&sram0>;
+		};
+
+		mem_window2: mem_window@70210 {
+			compatible = "intel,adsp-mem-window";
+			reg = <0x70210 0x8>;
+			memory = <&sram0>;
+		};
+
+		mem_window3: mem_window@70218 {
+			compatible = "intel,adsp-mem-window";
+			reg = <0x70218 0x8>;
+			memory = <&sram0>;
+			read-only;
 		};
 
 		adsp_idc: ace_idc@70400 {
@@ -115,52 +262,6 @@
 			reg = <0x70400 0x0400>;
 			interrupts = <24 0 0>;
 			interrupt-parent = <&ace_intc>;
-		};
-
-		/* This is actually an array of per-core designware
-		 * controllers, but the special setup and extra
-		 * masking layer makes it easier for MTL to handle
-		 * this internally.
-		 */
-		ace_intc: ace_intc@7ac00  {
-			compatible = "intel,ace-intc";
-			reg = <0x7ac00 0xc00>;
-			interrupt-controller;
-			#interrupt-cells = <3>;
-			interrupts = <4 0 0>;
-			num-irqs = <28>;
-			interrupt-parent = <&core_intc>;
-		};
-
-		ace_timestamp: ace_timestamp@72040 {
-			compatible = "intel,ace-timestamp";
-			reg = <0x72040 0x0032>;
-		};
-
-		ace_art_counter: ace_art_counter@72058 {
-			compatible = "intel,ace-art-counter";
-			reg = <0x72058 0x0064>;
-		};
-
-		ace_rtc_counter: ace_rtc_counter@72008 {
-			compatible = "intel,ace-rtc-counter";
-			reg = <0x72008 0x0064>;
-		};
-
-		shim: shim@71f00 {
-			compatible = "intel,adsp-shim";
-			reg = <0x71f00 0x100>;
-		};
-
-		tts: tts@72000 {
-			compatible = "intel,adsp-tts";
-			reg = <0x72000 0x70>;
-			status = "okay";
-		};
-
-		timer: timer {
-			compatible = "intel,adsp-timer";
-			syscon = <&tts>;
 		};
 
 		lps: lps@71ac0 {
@@ -214,44 +315,89 @@
 			};
 		};
 
-		sspbase: ssp_base@28800 {
-			compatible = "intel,ssp-sspbase";
-			reg = <0x28800 0x1000>;
+		shim: shim@71f00 {
+			compatible = "intel,adsp-shim";
+			reg = <0x71f00 0x100>;
 		};
 
-		mem_window0: mem_window@70200 {
-			compatible = "intel,adsp-mem-window";
-			reg = <0x70200 0x8>;
-			offset = <0x4000>;
-			memory = <&sram0>;
-			initialize;
-			read-only;
-		};
-		mem_window1: mem_window@70208 {
-			compatible = "intel,adsp-mem-window";
-			reg = <0x70208 0x8>;
-			memory = <&sram0>;
+		tts: tts@72000 {
+			compatible = "intel,adsp-tts";
+			reg = <0x72000 0x70>;
+			status = "okay";
 		};
 
-		mem_window2: mem_window@70210 {
-			compatible = "intel,adsp-mem-window";
-			reg = <0x70210 0x8>;
-			memory = <&sram0>;
+		ace_rtc_counter: ace_rtc_counter@72008 {
+			compatible = "intel,ace-rtc-counter";
+			reg = <0x72008 0x0064>;
 		};
 
-		mem_window3: mem_window@70218 {
-			compatible = "intel,adsp-mem-window";
-			reg = <0x70218 0x8>;
-			memory = <&sram0>;
-			read-only;
+		ace_timestamp: ace_timestamp@72040 {
+			compatible = "intel,ace-timestamp";
+			reg = <0x72040 0x0032>;
 		};
 
-		tlb: tlb@17e000 {
-			compatible = "intel,adsp-mtl-tlb";
-			reg = <0x17e000 0x1000>;
-			paddr-size = <12>;
-			exec-bit-idx = <14>;
-			write-bit-idx= <15>;
+		ace_art_counter: ace_art_counter@72058 {
+			compatible = "intel,ace-art-counter";
+			reg = <0x72058 0x0064>;
+		};
+
+		hda_link_out: dma@72400 {
+			compatible = "intel,adsp-hda-link-out";
+			#dma-cells = <1>;
+			reg = <0x00072400 0x20>;
+			dma-channels = <9>;
+			dma-buf-alignment = <128>;
+			status = "okay";
+		};
+
+		hda_link_in: dma@72600 {
+			compatible = "intel,adsp-hda-link-in";
+			#dma-cells = <1>;
+			reg = <0x00072600 0x20>;
+			dma-channels = <10>;
+			dma-buf-alignment = <128>;
+			status = "okay";
+		};
+
+		hda_host_out: dma@72800 {
+			compatible = "intel,adsp-hda-host-out";
+			#dma-cells = <1>;
+			reg = <0x00072800 0x40>;
+			dma-channels = <9>;
+			dma-buf-alignment = <128>;
+			status = "okay";
+		};
+
+		hda_host_in: dma@72c00 {
+			compatible = "intel,adsp-hda-host-in";
+			#dma-cells = <1>;
+			reg = <0x00072c00 0x40>;
+			dma-channels = <10>;
+			dma-buf-alignment = <128>;
+			status = "okay";
+		};
+
+		adsp_host_ipc: ace_host_ipc@73000 {
+			compatible = "intel,adsp-host-ipc";
+			status = "okay";
+			reg = <0x73000 0x30>;
+			interrupts = <0 0 0>;
+			interrupt-parent = <&ace_intc>;
+		};
+
+		/* This is actually an array of per-core designware
+		 * controllers, but the special setup and extra
+		 * masking layer makes it easier for MTL to handle
+		 * this internally.
+		 */
+		ace_intc: ace_intc@7ac00  {
+			compatible = "intel,ace-intc";
+			reg = <0x7ac00 0xc00>;
+			interrupt-controller;
+			#interrupt-cells = <3>;
+			interrupts = <4 0 0>;
+			num-irqs = <28>;
+			interrupt-parent = <&core_intc>;
 		};
 
 		lpgpdma0: dma@7c000 {
@@ -274,168 +420,22 @@
 			status = "okay";
 		};
 
-		ssp0:ssp@28000 {
-			compatible = "intel,ssp-dai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x00028000 0x1000
-				   0x00079C00 0x200>;
-			interrupts = <0x00 0 0>;
-			interrupt-parent = <&ace_intc>;
-			dmas = <&lpgpdma0 2
-					&lpgpdma0 3>;
-			dma-names = "tx", "rx";
-			power-domain = <&io0_domain>;
-			status = "okay";
+		sha: adsp-sha@17df00 {
+			compatible = "intel,adsp-sha";
+			reg = <0x17df00 0xd0>;
 		};
 
-		ssp1:ssp@29000 {
-			compatible = "intel,ssp-dai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x00029000 0x1000
-				   0x00079C00 0x200>;
-			interrupts = <0x01 0 0>;
-			interrupt-parent = <&ace_intc>;
-			dmas = <&lpgpdma0 4
-					&lpgpdma0 5>;
-			dma-names = "tx", "rx";
-			power-domain = <&io0_domain>;
-			status = "okay";
+		tlb: tlb@17e000 {
+			compatible = "intel,adsp-mtl-tlb";
+			reg = <0x17e000 0x1000>;
+			paddr-size = <12>;
+			exec-bit-idx = <14>;
+			write-bit-idx= <15>;
 		};
 
-		ssp2:ssp@2a000 {
-			compatible = "intel,ssp-dai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x0002a000 0x1000
-				   0x00079C00 0x200>;
-			interrupts = <0x02 0 0>;
-			interrupt-parent = <&ace_intc>;
-			dmas = <&lpgpdma0 6
-					&lpgpdma0 7>;
-			dma-names = "tx", "rx";
-			power-domain = <&io0_domain>;
-			status = "okay";
+		timer: timer {
+			compatible = "intel,adsp-timer";
+			syscon = <&tts>;
 		};
-
-		ssp3:ssp@2b000 {
-			compatible = "intel,ssp-dai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x0002b000 0x1000
-				   0x00079C00 0x200>;
-			interrupts = <0x03 0 0>;
-			interrupt-parent = <&ace_intc>;
-			dmas = <&lpgpdma0 8
-					&lpgpdma0 9>;
-			dma-names = "tx", "rx";
-			power-domain = <&io0_domain>;
-			status = "okay";
-		};
-
-		ssp4:ssp@2c000 {
-			compatible = "intel,ssp-dai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x0002c000 0x1000
-				   0x00079C00 0x200>;
-			interrupts = <0x04 0 0>;
-			interrupt-parent = <&ace_intc>;
-			dmas = <&lpgpdma0 10
-					&lpgpdma0 11>;
-			dma-names = "tx", "rx";
-			power-domain = <&io0_domain>;
-			status = "okay";
-		};
-
-		ssp5:ssp@2d000 {
-			compatible = "intel,ssp-dai";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x0002d000 0x1000
-				   0x00079C00 0x200>;
-			interrupts = <0x04 0 0>;
-			interrupt-parent = <&ace_intc>;
-			dmas = <&lpgpdma0 12
-					&lpgpdma0 13>;
-			dma-names = "tx", "rx";
-			power-domain = <&io0_domain>;
-			status = "okay";
-		};
-
-		hda_host_out: dma@72800 {
-			compatible = "intel,adsp-hda-host-out";
-			#dma-cells = <1>;
-			reg = <0x00072800 0x40>;
-			dma-channels = <9>;
-			dma-buf-alignment = <128>;
-			status = "okay";
-		};
-
-		hda_host_in: dma@72c00 {
-			compatible = "intel,adsp-hda-host-in";
-			#dma-cells = <1>;
-			reg = <0x00072c00 0x40>;
-			dma-channels = <10>;
-			dma-buf-alignment = <128>;
-			status = "okay";
-		};
-
-		hda_link_out: dma@72400 {
-			compatible = "intel,adsp-hda-link-out";
-			#dma-cells = <1>;
-			reg = <0x00072400 0x20>;
-			dma-channels = <9>;
-			dma-buf-alignment = <128>;
-			status = "okay";
-		};
-
-		hda_link_in: dma@72600 {
-			compatible = "intel,adsp-hda-link-in";
-			#dma-cells = <1>;
-			reg = <0x00072600 0x20>;
-			dma-channels = <10>;
-			dma-buf-alignment = <128>;
-			status = "okay";
-		};
-
-		dmic0: dmic0@10000 {
-			compatible = "intel,dai-dmic";
-			reg = <0x10000 0x8000>;
-			shim = <0xC000>;
-			fifo = <0x0008>;
-			interrupts = <0x08 0 0>;
-			interrupt-parent = <&ace_intc>;
-		};
-
-		dmic1: dmic1@10000 {
-			compatible = "intel,dai-dmic";
-			reg = <0x10000 0x8000>;
-			shim = <0xC000>;
-			fifo = <0x0108>;
-			interrupts = <0x09 0 0>;
-			interrupt-parent = <&ace_intc>;
-		};
-
-		/*
-		 * FIXME this is modeling individual alh channels/instances
-		 * with node labels, which has problems. A better representation
-		 * is discussed here:
-		 *
-		 * https://github.com/zephyrproject-rtos/zephyr/pull/50287#discussion_r974591009
-		 */
-		alh0: alh0@24400 {
-			compatible = "intel,alh-dai";
-			reg = <0x00024400 0x00024600>;
-			status = "okay";
-		};
-
-		alh1: alh1@24400 {
-			compatible = "intel,alh-dai";
-			reg = <0x00024400 0x00024600>;
-			status = "okay";
-		};
-
 	};
 };


### PR DESCRIPTION
Sort SoC nodes by address to make it easier to find them.  As part of this also move the intel-sha node under SoC where it belongs.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>