### PR TITLE
Bluetooth: Controller: Fix ticker ticks diff calculation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -460,7 +460,7 @@ uint32_t lll_preempt_calc(struct ull_hdr *ull, uint8_t ticker_id,
 	uint32_t diff;
 
 	ticks_now = ticker_ticks_now_get();
-	diff = ticks_now - ticks_at_event;
+	diff = ticker_ticks_diff_get(ticks_now, ticks_at_event);
 	if (diff & BIT(HAL_TICKER_CNTR_MSBIT)) {
 		return 0;
 	}


### PR DESCRIPTION
Fix ticks difference calculation to determine delayed prepare callback. Without the use of masking by
ticker_ticks_diff_get, the diff value can be higher than the supported 24-bit value. i.e. ticker_ticks_now_get() rolls over in 24-bit value, whereas ticks_at_event is free running value of 32-bits.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>