### PR TITLE
soc: nxp_s32: update baremetal drivers version

### DIFF
--- a/soc/arm/nxp_s32/common/osif.c
+++ b/soc/arm/nxp_s32/common/osif.c
@@ -8,7 +8,7 @@
 #include <OsIf_Cfg_TypesDef.h>
 
 #if defined(CONFIG_SOC_S32Z27_R52)
-#include <S32Z27_MSCM.h>
+#include <S32Z2_MSCM.h>
 #endif
 
 /* Required by OsIf timer initialization but not used with Zephyr, so no values configured */

--- a/soc/arm/nxp_s32/s32ze/pinctrl_soc.h
+++ b/soc/arm/nxp_s32/s32ze/pinctrl_soc.h
@@ -10,7 +10,7 @@
 #include "pinctrl_soc_common.h"
 
 #if defined(CONFIG_SOC_S32Z27_R52)
-#include "S32Z27_SIUL2.h"
+#include "S32Z2_SIUL2.h"
 #else
 #error "SoC not supported"
 #endif
@@ -47,6 +47,6 @@
 	.receiverSel = PORT_RECEIVER_ENABLE_SINGLE_ENDED,			\
 	.currentReferenceControl = PORT_CURRENT_REFERENCE_CONTROL_DISABLED,	\
 	.rxCurrentBoost = PORT_RX_CURRENT_BOOST_DISABLED,			\
-	.safeMode = SIUL2_PORT_IP_SAFE_MODE_DISABLED,
+	.safeMode = PORT_SAFE_MODE_DISABLED,
 
 #endif /* ZEPHYR_SOC_ARM_NXP_S32_S32ZE_PINCTRL_SOC_H_ */

--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 53b8bc406a40e2166679cf1a3381f9eb5de96082
+      revision: 138742f66576f2e2235a072425e71b8d1360c0d3
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
HAL for NXP S32 is updated to a newer version (https://github.com/zephyrproject-rtos/hal_nxp/pull/204), hence some headers and macro definitions for this SoC must be updated accordingly.