### PR TITLE
driver: watchdog: multiple doxygen improvements

### DIFF
--- a/include/zephyr/drivers/watchdog.h
+++ b/include/zephyr/drivers/watchdog.h
@@ -5,11 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @brief Public API for watchdog drivers.
- */
-
 #ifndef ZEPHYR_INCLUDE_DRIVERS_WATCHDOG_H_
 #define ZEPHYR_INCLUDE_DRIVERS_WATCHDOG_H_
 
@@ -29,38 +24,40 @@ extern "C" {
 #endif
 
 /**
- * @brief Pause watchdog timer when CPU is in sleep state.
- */
-#define WDT_OPT_PAUSE_IN_SLEEP		BIT(0)
-
-/**
- * @brief Pause watchdog timer when CPU is halted by the debugger.
- */
-#define WDT_OPT_PAUSE_HALTED_BY_DBG	BIT(1)
-
-/**
- * @brief Watchdog reset flag bit field mask shift.
- */
-#define WDT_FLAG_RESET_SHIFT		(0)
-/**
- * @brief Watchdog reset flag bit field mask.
- */
-#define WDT_FLAG_RESET_MASK		(0x3 << WDT_FLAG_RESET_SHIFT)
-
-/**
- * @name Watchdog Reset Behavior.
- * Reset behavior after timeout.
+ * @name Watchdog options
+ * @anchor WDT_OPT
  * @{
  */
-/** No reset */
-#define WDT_FLAG_RESET_NONE		(0 << WDT_FLAG_RESET_SHIFT)
-/** CPU core reset */
-#define WDT_FLAG_RESET_CPU_CORE		(1 << WDT_FLAG_RESET_SHIFT)
-/** Global SoC reset */
-#define WDT_FLAG_RESET_SOC		(2 << WDT_FLAG_RESET_SHIFT)
+
+/** @brief Pause watchdog timer when CPU is in sleep state. */
+#define WDT_OPT_PAUSE_IN_SLEEP		BIT(0)
+
+/** @brief Pause watchdog timer when CPU is halted by the debugger. */
+#define WDT_OPT_PAUSE_HALTED_BY_DBG	BIT(1)
+
+/** @} */
+
 /**
- * @}
+ * @name Watchdog behavior flags
+ * @anchor WDT_FLAGS
+ * @{
  */
+
+/** @cond INTERNAL_HIDDEN */
+/** @brief Watchdog reset flag bit field mask shift. */
+#define WDT_FLAG_RESET_SHIFT		(0)
+/** @brief Watchdog reset flag bit field mask. */
+#define WDT_FLAG_RESET_MASK		(0x3 << WDT_FLAG_RESET_SHIFT)
+/** @endcond */
+
+/** Reset: none */
+#define WDT_FLAG_RESET_NONE		(0 << WDT_FLAG_RESET_SHIFT)
+/** Reset: CPU core */
+#define WDT_FLAG_RESET_CPU_CORE		(1 << WDT_FLAG_RESET_SHIFT)
+/** Reset: SoC */
+#define WDT_FLAG_RESET_SOC		(2 << WDT_FLAG_RESET_SHIFT)
+
+/** @} */
 
 /**
  * @brief Watchdog timeout window.
@@ -69,72 +66,71 @@ extern "C" {
  * otherwise the watchdog will trigger. If the watchdog instance does not
  * support window timeouts then min value must be equal to 0.
  *
- * @param min Lower limit of watchdog feed timeout in milliseconds.
- * @param max Upper limit of watchdog feed timeout in milliseconds.
- *
- * @note If specified values can not be precisely set they are always
- *	 rounded up.
+ * @note If specified values can not be precisely set they are always rounded
+ * up.
  */
 struct wdt_window {
+	/** Lower limit of watchdog feed timeout in milliseconds. */
 	uint32_t min;
+	/** Upper limit of watchdog feed timeout in milliseconds. */
 	uint32_t max;
 };
 
-/** Watchdog callback. */
+/**
+ * @brief Watchdog callback.
+ *
+ * @param dev Watchdog device instance.
+ * @param channel_id Channel identifier.
+ */
 typedef void (*wdt_callback_t)(const struct device *dev, int channel_id);
 
-/**
- * @brief Watchdog timeout configuration struct.
- *
- * @param window Timing parameters of watchdog timeout.
- * @param callback Timeout callback. Passing NULL means that no callback
- *		   will be run.
- * @param next Pointer to the next timeout configuration. This pointer is used
- *	       for watchdogs with staged timeouts functionality. Value must be
- *	       NULL for single stage timeout.
- * @param flags Bit field with following parts:
- *
- *     reset        [ 0 : 1 ]   - perform specified reset after timeout/callback
- */
+/** @brief Watchdog timeout configuration. */
 struct wdt_timeout_cfg {
+	/** Timing parameters of watchdog timeout. */
 	struct wdt_window window;
+	/** Timeout callback (can be `NULL`). */
 	wdt_callback_t callback;
-#ifdef CONFIG_WDT_MULTISTAGE
+#if defined(CONFIG_WDT_MULTISTAGE) || defined(__DOXYGEN__)
+	/**
+	 * Pointer to the next timeout configuration.
+	 *
+	 * This field is only available if @kconfig{CONFIG_WDT_MULTISTAGE} is
+	 * enabled (watchdogs with staged timeouts functionality). Value must be
+	 * `NULL` for single stage timeout.
+	 */
 	struct wdt_timeout_cfg *next;
 #endif
+	/** Flags (see @ref WDT_FLAGS). */
 	uint8_t flags;
 };
 
+/** @cond INTERNAL_HIDDEN */
+
 /**
- * @typedef wdt_api_setup
  * @brief Callback API for setting up watchdog instance.
- * See wdt_setup() for argument descriptions
+ * @see wdt_setup().
  */
 typedef int (*wdt_api_setup)(const struct device *dev, uint8_t options);
 
 /**
- * @typedef wdt_api_disable
  * @brief Callback API for disabling watchdog instance.
- * See wdt_disable() for argument descriptions
+ * @see wdt_disable().
  */
 typedef int (*wdt_api_disable)(const struct device *dev);
 
 /**
- * @typedef wdt_api_install_timeout
  * @brief Callback API for installing new timeout.
- * See wdt_install_timeout() for argument descriptions
+ * @see wdt_install_timeout().
  */
 typedef int (*wdt_api_install_timeout)(const struct device *dev,
 				       const struct wdt_timeout_cfg *cfg);
 
 /**
- * @typedef wdt_api_feed
  * @brief Callback API for feeding specified watchdog timeout.
- * See (wdt_feed) for argument descriptions
+ * @see wdt_feed().
  */
 typedef int (*wdt_api_feed)(const struct device *dev, int channel_id);
 
-/** @cond INTERNAL_HIDDEN */
 __subsystem struct wdt_driver_api {
 	wdt_api_setup setup;
 	wdt_api_disable disable;
@@ -153,12 +149,13 @@ __subsystem struct wdt_driver_api {
  * After successful return, all installed timeouts are valid and must be
  * serviced periodically by calling wdt_feed().
  *
- * @param dev Pointer to the device structure for the driver instance.
- * @param options Configuration options as defined by the WDT_OPT_* constants
+ * @param dev Watchdog device instance.
+ * @param options Configuration options (see @ref WDT_OPT).
  *
  * @retval 0 If successful.
  * @retval -ENOTSUP If any of the set options is not supported.
  * @retval -EBUSY If watchdog instance has been already setup.
+ * @retval -errno In case of any other failure.
  */
 __syscall int wdt_setup(const struct device *dev, uint8_t options);
 
@@ -177,11 +174,12 @@ static inline int z_impl_wdt_setup(const struct device *dev, uint8_t options)
  * timeouts. To set up a new watchdog, install timeouts and call wdt_setup()
  * again. Not all watchdogs can be restarted after they are disabled.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @param dev Watchdog device instance.
  *
  * @retval 0 If successful.
  * @retval -EFAULT If watchdog instance is not enabled.
  * @retval -EPERM If watchdog can not be disabled directly by application code.
+ * @retval -errno In case of any other failure.
  */
 __syscall int wdt_disable(const struct device *dev);
 
@@ -194,26 +192,26 @@ static inline int z_impl_wdt_disable(const struct device *dev)
 }
 
 /**
- * @brief Install new timeout.
+ * @brief Install a new timeout.
  *
- * This function must be used before wdt_setup(). Changes applied here
+ * @note This function must be used before wdt_setup(). Changes applied here
  * have no effects until wdt_setup() is called.
  *
- * @param dev Pointer to the device structure for the driver instance.
- * @param cfg Pointer to timeout configuration structure.
+ * @param dev Watchdog device instance.
+ * @param[in] cfg Timeout configuration.
  *
  * @retval channel_id If successful, a non-negative value indicating the index
- *                    of the channel to which the timeout was assigned. This
- *                    value is supposed to be used as the parameter in calls to
- *                    wdt_feed().
+ * of the channel to which the timeout was assigned. This value is supposed to
+ * be used as the parameter in calls to wdt_feed().
  * @retval -EBUSY If timeout can not be installed while watchdog has already
- *		  been setup.
+ * been setup.
  * @retval -ENOMEM If no more timeouts can be installed.
  * @retval -ENOTSUP If any of the set flags is not supported.
  * @retval -EINVAL If any of the window timeout value is out of possible range.
- *		   This value is also returned if watchdog supports only one
- *		   timeout value for all timeouts and the supplied timeout
- *		   window differs from windows for alarms installed so far.
+ * This value is also returned if watchdog supports only one timeout value for
+ * all timeouts and the supplied timeout window differs from windows for alarms
+ * installed so far.
+ * @retval -errno In case of any other failure.
  */
 static inline int wdt_install_timeout(const struct device *dev,
 				      const struct wdt_timeout_cfg *cfg)
@@ -227,14 +225,15 @@ static inline int wdt_install_timeout(const struct device *dev,
 /**
  * @brief Feed specified watchdog timeout.
  *
- * @param dev Pointer to the device structure for the driver instance.
- * @param channel_id Index of the fed channel.
+ * @param dev Watchdog device instance.
+ * @param channel_id Channel index.
  *
  * @retval 0 If successful.
- * @retval -EAGAIN If completing the feed operation would stall the
- *                 caller, for example due to an in-progress watchdog
- *                 operation such as a previous @c wdt_feed().
+ * @retval -EAGAIN If completing the feed operation would stall the caller, for
+ * example due to an in-progress watchdog operation such as a previous
+ * wdt_feed() call.
  * @retval -EINVAL If there is no installed timeout for supplied channel.
+ * @retval -errno In case of any other failure.
  */
 __syscall int wdt_feed(const struct device *dev, int channel_id);
 
@@ -250,10 +249,8 @@ static inline int z_impl_wdt_feed(const struct device *dev, int channel_id)
 }
 #endif
 
-/**
- * @}
- */
+/** @} */
 
 #include <syscalls/watchdog.h>
 
-#endif /* _ZEPHYR_WATCHDOG_H__ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_WATCHDOG_H_ */


### PR DESCRIPTION
- Fix incorrect struct fields documentation (`@param` can't be used)
- Removed redundant `@file` entry, public APIs may be split into multiple headers.
- Grouped and anchored options and flags, so they can be referenced.
- Guarded some internal fields with `INTERNAL_HIDDEN`.
- Exposed conditional struct fields, using `__DOXYGEN__`.
- Use `@see` in cases where used was instructed to look at other function calls.
- Added `errno` `@retval` to all functions. In case of external watchdogs, communication errors may be propagated.
- Other minor/typo fixes

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>