### PR TITLE
SMP support for hardware RISC-V boards, including Microchip's PolarFire SoC Icicle Kit

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -171,6 +171,14 @@ config GEN_IRQ_VECTOR_TABLE
 config NUM_IRQS
 	int
 
+config RV_BOOT_HART
+	int "Starting HART ID"
+	default 0
+	help
+	  This option sets the starting HART ID for the SMP core.
+	  For RISC-V systems such as MPFS and FU540 this would be set to 1 to
+	  skip the E51 HART 0 as it is not usable in SMP configurations.
+
 config RISCV_PMP
 	bool "RISC-V PMP Support"
 	select THREAD_STACK_INFO

--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -39,14 +39,9 @@ SECTION_FUNC(reset, __reset)
  */
 SECTION_FUNC(TEXT, __initialize)
 	csrr a0, mhartid
-	beqz a0, boot_first_core
-
-	li t0, CONFIG_MP_MAX_NUM_CPUS
-	blt a0, t0, boot_secondary_core
-
-loop_unconfigured_cores:
-	wfi
-	j loop_unconfigured_cores
+	li t0, CONFIG_RV_BOOT_HART
+	beq a0, t0, boot_first_core
+	j boot_secondary_core
 
 boot_first_core:
 
@@ -112,3 +107,7 @@ boot_secondary_core:
 #else
 	j loop_unconfigured_cores
 #endif
+
+loop_unconfigured_cores:
+	wfi
+	j loop_unconfigured_cores

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -25,18 +25,25 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	riscv_cpu_init[cpu_num].arg = arg;
 
 	riscv_cpu_sp = Z_KERNEL_STACK_BUFFER(stack) + sz;
-	riscv_cpu_wake_flag = cpu_num;
+	riscv_cpu_wake_flag = _kernel.cpus[cpu_num].arch.hartid;
 
 	while (riscv_cpu_wake_flag != 0U) {
 		;
 	}
 }
 
-void z_riscv_secondary_cpu_init(int cpu_num)
+void z_riscv_secondary_cpu_init(int hartid)
 {
+	unsigned int i;
+	unsigned int cpu_num = 0;
+
+	for (i = 0; i < CONFIG_MP_MAX_NUM_CPUS; i++) {
+		if (_kernel.cpus[i].arch.hartid == hartid) {
+			cpu_num = i;
+		}
+	}
 	csr_write(mscratch, &_kernel.cpus[cpu_num]);
 #ifdef CONFIG_SMP
-	_kernel.cpus[cpu_num].arch.hartid = csr_read(mhartid);
 	_kernel.cpus[cpu_num].arch.online = true;
 #endif
 #ifdef CONFIG_THREAD_LOCAL_STORAGE

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -36,6 +36,20 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 	_kernel.cpus[0].arch.hartid = csr_read(mhartid);
 	_kernel.cpus[0].arch.online = true;
 #endif
+#if ((CONFIG_MP_MAX_NUM_CPUS) > 1)
+	unsigned int cpu_node_list[] = {
+		DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))
+	};
+	unsigned int cpu_num, hart_x;
+
+	for (cpu_num = 1, hart_x = 0; cpu_num < arch_num_cpus(); cpu_num++) {
+		if (cpu_node_list[hart_x] == _kernel.cpus[0].arch.hartid) {
+			hart_x++;
+		}
+		_kernel.cpus[cpu_num].arch.hartid = cpu_node_list[hart_x];
+		hart_x++;
+	}
+#endif
 #ifdef CONFIG_RISCV_PMP
 	z_riscv_pmp_init();
 #endif

--- a/include/zephyr/arch/riscv/structs.h
+++ b/include/zephyr/arch/riscv/structs.h
@@ -14,7 +14,7 @@ struct _cpu_arch {
 	unsigned long user_exc_tmp0;
 	unsigned long user_exc_tmp1;
 #endif
-#ifdef CONFIG_SMP
+#if defined(CONFIG_SMP) || (CONFIG_MP_MAX_NUM_CPUS > 1)
 	unsigned long hartid;
 	bool online;
 #endif


### PR DESCRIPTION
SMP support for RISC-V implementations based on the experience of implementing SMP on The PolarFire Soc Icicle Kit. The changes provide support for heterogeneous core complexes by:
- Configuration option to choose the boot hart,
- Allowing selections of CPUs for MP and SMP applications using Devicetree overlays.

The changes in this PR where first published in the pr #46188
Some of the most prominent feedback was that the configuration options where too general, as such, changes were applied to the RISC-V layer.
This PR depends upon PR #54143