### PR TITLE
tests: kernel: timer: starve: Add proper timeout value

### DIFF
--- a/tests/kernel/timer/starve/testcase.yaml
+++ b/tests/kernel/timer/starve/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   kernel.timer.starve:
     slow: true
+    timeout: 3600
     tags: kernel timer


### PR DESCRIPTION
The test in its default configuration needs 3600 seconds to complete, so use such timeout value in testcase.yaml so that twister called with --enable-slow option can successfully execute it.

Fixes #52057