### PR TITLE
mgmt/mcumgr: Fix MCUMGR_BUF_USER_DATA_SIZE selection for BT

### DIFF
--- a/subsys/mgmt/mcumgr/transport/Kconfig
+++ b/subsys/mgmt/mcumgr/transport/Kconfig
@@ -30,13 +30,13 @@ config MCUMGR_BUF_USER_DATA_SIZE
 	int "Size of mcumgr buffer user data"
 	default 24 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV6
 	default 8 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV4
-	default 5 if MCUMGR_SMP_BT
+	default 8 if MCUMGR_SMP_BT
 	default 4
 	help
 	  The size, in bytes, of user data to allocate for each mcumgr buffer.
 
 	  Different mcumgr transports impose different requirements for this
-	  setting. A value of 4 is sufficient for UART and shell, a value of 5
+	  setting. A value of 4 is sufficient for UART and shell, a value of 8
 	  is sufficient for Bluetooth. For UDP, the userdata must be large
 	  enough to hold a IPv4/IPv6 address.
 


### PR DESCRIPTION
Rounded up struct smp_bt_user_data takes 8 bytes; this fixes static assert failing with message:
  CONFIG_MCUMGR_BUF_USER_DATA_SIZE not large enough to fit Bluetooth
  user data

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

From build log:
```
                 from <redacted>/zephyr/subsys/mgmt/mcumgr/transport/smp_bt.c:12:
<redacted>/zephyr/subsys/mgmt/mcumgr/transport/smp_bt.c:71:1: error: static assertion failed: "CONFIG_MCUMGR_BUF_USER_DATA_SIZE not large enough to fit Bluetooth user data"
   71 | BUILD_ASSERT(sizeof(struct smp_bt_user_data) <= CONFIG_MCUMGR_BUF_USER_DATA_SIZE,
      | ^~~~~~~~~~~~
```