### PR TITLE
scripts: west_commands: runners: Added optional remote jlink (--ip) flag

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -99,7 +99,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                             action=partial(depr_action,
                                            replacement='-i/--dev-id'),
                             help='Deprecated: use -i/--dev-id instead')
-        parser.add_argument('--remote', required=False, dest='ip',
+        parser.add_argument('--ip', required=False, dest='ip',
                             help='use a remote JLink Server')
         parser.add_argument('--iface', default='swd',
                             help='interface to use, default is swd')


### PR DESCRIPTION
Adds an optional argument to the West JLink runner, '--ip' which allows flash to be perfomed to a JLink remote server.
The option is useful for in environments where flash to USB is not possible, i.e. inside WSL2.

To use this option JLink Remote Server needs to be running and a device connected.

This was verified by:
1. Running JLink Remote Server in windows environment.
2. Connecting a Nordic developer kit to the JLink Remote Server.
3. Starting a WSL 2 environment.
4. Within WSL2 starting a docker container with the zephyr toolchain
5. Building a zephyr application
6. When built using west command
```
west flash -r jlink --ip 192.168.5.193
```

Result:
JLink Remote Server status changes to show the connection to the developer board
Output from west
```
-- west flash: rebuilding
ninja: no work to do.
-- west flash: using runner jlink
-- runners.jlink: JLink version: 7.82
-- runners.jlink: Command: ['/opt/SEGGER/JLink_V782/JLinkExe', '-ip', '192.168.5.193', '-nogui', '1', '-if', 'swd', '-speed', '4000', '-device', 'nRF52840_xxAA', '-CommanderScript', '/tmp/tmpbpvd7y0zjlink/runner.jlink', '-nogui', '1']
-- runners.jlink: Flashing file: /workarea/build/zephyr/zephyr.hex
```