### PR TITLE
mgmt/mcumgr: Fix documentation for hash_checksum_mgmt_list_cb

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/hash_checksum_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/hash_checksum_mgmt.h
@@ -50,7 +50,7 @@ struct hash_checksum_mgmt_group {
 	hash_checksum_mgmt_handler_fn function;
 };
 
-/** @typedef hash_checksum_mgmt_handler_fn
+/** @typedef hash_checksum_mgmt_list_cb
  * @brief Function that gets called with hash/checksum details
  *
  * @param group         Details about a supported hash/checksum


### PR DESCRIPTION
Incorrectly hash_checksum_mgmt_handler_fn has been referenced in documentation for hash_checksum_mgmt_list_cb, causing documentation generation error, because parameter list does not match.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>