### PR TITLE
shell: kernel: right-align stack usage percentages

### DIFF
--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -189,7 +189,7 @@ static void shell_stack_dump(const struct k_thread *thread, void *user_data)
 
 	shell_print(
 		(const struct shell *)user_data, "%p %-" STRINGIFY(THREAD_MAX_NAM_LEN) "s "
-		"(real size %4zu):\tunused %4zu\tusage %4zu / %4zu (%u %%)",
+		"(real size %4zu):\tunused %4zu\tusage %4zu / %4zu (%2u %%)",
 		thread, tname ? tname : "NA", size, unused, size - unused, size, pcnt);
 }
 
@@ -223,7 +223,7 @@ static int cmd_kernel_stacks(const struct shell *shell,
 		__ASSERT_NO_MSG(err == 0);
 
 		shell_print(shell,
-			    "%p IRQ %02d %s(real size %4zu):\tunused %4zu\tusage %4zu / %4zu (%zu %%)",
+			    "%p IRQ %02d %s(real size %4zu):\tunused %4zu\tusage %4zu / %4zu (%2zu %%)",
 			    &z_interrupt_stacks[i], i, pad, size, unused, size - unused, size,
 			    ((size - unused) * 100U) / size);
 	}


### PR DESCRIPTION
For better readability.

Before:

```
0x20024098 shell_telnet                     (real size 2048):	unused 1400	usage  648 / 2048 (31 %)
0x20024658 rx_q[0]                          (real size 1600):	unused 1448	usage  152 / 1600 (9 %)
0x20024800 tcp_work                         (real size 1024):	unused  840	usage  184 / 1024 (17 %)
0x20020720 stm_eth                          (real size 1504):	unused 1296	usage  208 / 1504 (13 %)
0x20024b58 sysworkq                         (real size 1024):	unused  840	usage  184 / 1024 (17 %)
0x20023d88 shell_uart                       (real size 2048):	unused 1104	usage  944 / 2048 (46 %)
0x20023840 logging                          (real size 2048):	unused 1424	usage  624 / 2048 (30 %)
0x20024930 idle                             (real size  320):	unused  272	usage   48 /  320 (15 %)
0x20024a40 main                             (real size  960):	unused  240	usage  720 /  960 (75 %)
0x2003da80 IRQ 00                           (real size 2112):	unused 1516	usage  596 / 2112 (28 %)
```

After:

```
0x20024098 shell_telnet                     (real size 2048):	unused 1400	usage  648 / 2048 (31 %)
0x20024658 rx_q[0]                          (real size 1600):	unused 1448	usage  152 / 1600 ( 9 %)
0x20024800 tcp_work                         (real size 1024):	unused  840	usage  184 / 1024 (17 %)
0x20020720 stm_eth                          (real size 1504):	unused 1296	usage  208 / 1504 (13 %)
0x20024b58 sysworkq                         (real size 1024):	unused  840	usage  184 / 1024 (17 %)
0x20023d88 shell_uart                       (real size 2048):	unused 1104	usage  944 / 2048 (46 %)
0x20023840 logging                          (real size 2048):	unused 1424	usage  624 / 2048 (30 %)
0x20024930 idle                             (real size  320):	unused  272	usage   48 /  320 (15 %)
0x20024a40 main                             (real size  960):	unused  240	usage  720 /  960 (75 %)
0x2003da80 IRQ 00                           (real size 2112):	unused 1516	usage  596 / 2112 (28 %)
```
