### PR TITLE
drivers: usb_dc_rpi_pico: fixed buffer status handling

### DIFF
--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -10,6 +10,7 @@
 #include <hardware/structs/usb.h>
 #include <hardware/resets.h>
 
+#include <zephyr/kernel.h>
 #include <zephyr/usb/usb_device.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/logging/log.h>
@@ -136,7 +137,7 @@ static void udc_rpi_handle_buff_status(void)
 {
 	struct udc_rpi_ep_state *ep_state;
 	enum usb_dc_ep_cb_status_code status_code;
-	uint8_t status = usb_hw->buf_status;
+	uint32_t status = usb_hw->buf_status;
 	unsigned int bit = 1U;
 	struct cb_msg msg;
 


### PR DESCRIPTION
The buf_status register is 32 bit wide but was saved in a uint8_t. This caused some buffers never to be handled which results in the pico getting stuck in the interrupt handler.

Fixes: #50983.