### PR TITLE
Bluetooth: Controller: Fix advertising disable on connection complete

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1179,9 +1179,19 @@ void ll_rx_dequeue(void)
 				aux = HDR_LLL2ULL(lll->aux);
 				aux->is_started = 0U;
 			}
-#endif /* CONFIG_BT_CTLR_ADV_EXT */
 
+			/* If Extended Advertising Commands used, reset
+			 * is_enabled when advertising set terminated event is
+			 * dequeued. Otherwise, legacy advertising commands used
+			 * then reset is_enabled here.
+			 */
+			if (!lll->node_rx_adv_term) {
+				adv->is_enabled = 0U;
+			}
+#else /* !CONFIG_BT_CTLR_ADV_EXT */
 			adv->is_enabled = 0U;
+#endif /* !CONFIG_BT_CTLR_ADV_EXT */
+
 #else /* !CONFIG_BT_PERIPHERAL */
 			ARG_UNUSED(cc);
 #endif /* !CONFIG_BT_PERIPHERAL */


### PR DESCRIPTION
Fix advertising set's is_enabled flag to be reset when connection complete is dequeued for connectable advertising started using legacy advertising enable HCI commands. And reset the is_enabled flag when advertising set terminated is dequeued for connectable advertising enabled using Extended Advertising HCI commands.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>