### PR TITLE
drivers: regulator: improve Doxygen documentation, fix includes

### DIFF
--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -13,8 +13,7 @@
  * @{
  */
 
-#include <zephyr/types.h>
-#include <zephyr/drivers/gpio.h>
+#include <zephyr/device.h>
 #include <zephyr/sys/onoff.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @brief API for voltage and current regulators.
- */
-
 #ifndef ZEPHYR_INCLUDE_DRIVERS_REGULATOR_H_
 #define ZEPHYR_INCLUDE_DRIVERS_REGULATOR_H_
 
@@ -26,34 +21,34 @@
 extern "C" {
 #endif
 
-/**
- * @brief Driver-specific API functions to support regulator control.
- */
+/** @cond INTERNAL_HIDDEN */
+
+/** @brief Driver-specific API functions to support regulator control. */
 __subsystem struct regulator_driver_api {
 	int (*enable)(const struct device *dev, struct onoff_client *cli);
 	int (*disable)(const struct device *dev);
 };
 
+/** @endcond */
+
 /**
  * @brief Enable a regulator.
  *
- * Reference-counted request that a regulator be turned on.  This is
- * an asynchronous operation; if successfully initiated the result
- * will be communicated through the @p cli parameter.
+ * Reference-counted request that a regulator be turned on. This is an
+ * asynchronous operation; if successfully initiated the result will be
+ * communicated through the @p cli parameter.
  *
- * A regulator is considered "on" when it has reached a stable/usable
- * state.
+ * A regulator is considered "on" when it has reached a stable/usable state.
  *
- * @note This function is *isr-ok* and *pre-kernel-ok*.
+ * @funcprops \isr_ok \pre_kernel_ok
  *
- * @param reg a regulator device
+ * @param reg Regulator device instance
+ * @param cli On-off client instance. This is used to notify the caller when the
+ * attempt to turn on the regulator has completed (can be `NULL`).
  *
- * @param cli used to notify the caller when the attempt to turn on
- * the regulator has completed.
- *
- * @return non-negative on successful initiation of the request.
- * Negative values indicate failures from onoff_request() or
- * individual regulator drivers.
+ * @retval 0 If enable request has been successfully initiated.
+ * @retval -errno Negative errno in case of failure (can be from onoff_request()
+ * or individual regulator drivers).
  */
 static inline int regulator_enable(const struct device *reg,
 				   struct onoff_client *cli)
@@ -70,20 +65,19 @@ static inline int regulator_enable(const struct device *reg,
  * Release a regulator after a previous regulator_enable() completed
  * successfully.
  *
- * If the release removes the last dependency on the regulator it will
- * begin a transition to its "off" state.  There is currently no
- * mechanism to notify when the regulator has completely turned off.
+ * If the release removes the last dependency on the regulator it will begin a
+ * transition to its "off" state. There is currently no mechanism to notify when
+ * the regulator has completely turned off.
  *
- * This must be invoked at most once for each successful
- * regulator_enable().
+ * This must be invoked at most once for each successful regulator_enable().
  *
- * @note This function is *isr-ok*.
+ * @funcprops \isr_ok
  *
- * @param reg a regulator device
+ * @param reg Regulator device instance.
  *
- * @return non-negative on successful completion of the release
- * request.  Negative values indicate failures from onoff_release() or
- * individual regulator drivers.
+ * @retval 0 If enable request has been successfully initiated.
+ * @retval -errno Negative errno in case of failure (can be from onoff_release()
+ * or individual regulator drivers).
  */
 static inline int regulator_disable(const struct device *reg)
 {
@@ -97,8 +91,6 @@ static inline int regulator_disable(const struct device *reg)
 }
 #endif
 
-/**
- * @}
- */
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_REGULATOR_H_ */

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -41,7 +41,7 @@ __subsystem struct regulator_driver_api {
  *
  * @funcprops \isr_ok \pre_kernel_ok
  *
- * @param reg Regulator device instance
+ * @param dev Regulator device instance
  * @param cli On-off client instance. This is used to notify the caller when the
  * attempt to turn on the regulator has completed (can be `NULL`).
  *
@@ -49,13 +49,13 @@ __subsystem struct regulator_driver_api {
  * @retval -errno Negative errno in case of failure (can be from onoff_request()
  * or individual regulator drivers).
  */
-static inline int regulator_enable(const struct device *reg,
+static inline int regulator_enable(const struct device *dev,
 				   struct onoff_client *cli)
 {
 	const struct regulator_driver_api *api =
-		(const struct regulator_driver_api *)reg->api;
+		(const struct regulator_driver_api *)dev->api;
 
-	return api->enable(reg, cli);
+	return api->enable(dev, cli);
 }
 
 /**
@@ -72,18 +72,18 @@ static inline int regulator_enable(const struct device *reg,
  *
  * @funcprops \isr_ok
  *
- * @param reg Regulator device instance.
+ * @param dev Regulator device instance.
  *
  * @retval 0 If enable request has been successfully initiated.
  * @retval -errno Negative errno in case of failure (can be from onoff_release()
  * or individual regulator drivers).
  */
-static inline int regulator_disable(const struct device *reg)
+static inline int regulator_disable(const struct device *dev)
 {
 	const struct regulator_driver_api *api =
-		(const struct regulator_driver_api *)reg->api;
+		(const struct regulator_driver_api *)dev->api;
 
-	return api->disable(reg);
+	return api->disable(dev);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Docs:
- Remove redundant `@file`
- Hide driver-specific code using `INTERNAL_HIDDEN`.
- Use standard `@funcprops`
- Use `@retval` for return codes, and clarify them as well. Added -errno
  case, since external regulators may propagate e.g. bus errors.

Others:
- Fix includes
- Other minor changes, see commits for more details

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>