### PR TITLE
drivers: pinctrl: fix lookup when there are no states

### DIFF
--- a/drivers/pinctrl/common.c
+++ b/drivers/pinctrl/common.c
@@ -10,7 +10,7 @@ int pinctrl_lookup_state(const struct pinctrl_dev_config *config, uint8_t id,
 			 const struct pinctrl_state **state)
 {
 	*state = &config->states[0];
-	while (*state <= &config->states[config->state_cnt - 1U]) {
+	while (*state < &config->states[config->state_cnt]) {
 		if (id == (*state)->id) {
 			return 0;
 		}


### PR DESCRIPTION
Right now it is possible that some devices define 0 pinctrl states in
devicetree, because pinctrl-N entries may still be optional for backward
compatibility. If the programmer makes a mistake and forgets them,
application could experience runtime crashes because
pinctrl_lookup_states assumes you have at least one state, so it does
not perform any bounds checking. Change the while condition so that it
is skipped if states count is zero.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>