### PR TITLE
arch: common: allow access to the rom start area

### DIFF
--- a/arch/common/rom_start_offset.ld
+++ b/arch/common/rom_start_offset.ld
@@ -4,5 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+KEEP(*(.rom_start_area))
+KEEP(*(".rom_start_area.*"))
+
 . = CONFIG_ROM_START_OFFSET;
 . = ALIGN(4);


### PR DESCRIPTION
When using a bootloader it can be advantageous to have direct access to the area that is created when a rom_start_offset is selected. The PR makes this area available as a section rom_start_area. Users can use __in_section_unique(rom_start_area) to place and access data in this area.

Signed-off-by: Laczen JMS <laczenjms@gmail.com>