### PR TITLE
net: wifi_mgmt: Add support for power save configuration

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -245,4 +245,75 @@ static inline const char *wifi_link_mode_txt(enum wifi_link_mode link_mode)
 	}
 }
 
+enum wifi_ps {
+	WIFI_PS_DISABLED = 0,
+	WIFI_PS_ENABLED,
+};
+
+static const char * const wifi_ps2str[] = {
+	[WIFI_PS_DISABLED] = "Power save disabled",
+	[WIFI_PS_ENABLED] = "Power save enabled",
+};
+
+enum wifi_ps_mode {
+	WIFI_PS_MODE_LEGACY = 0,
+	/* This has to be configured before connecting to the AP,
+	 * as support for ADDTS action frames is not available.
+	 */
+	WIFI_PS_MODE_WMM,
+};
+
+static const char * const wifi_ps_mode2str[] = {
+	[WIFI_PS_MODE_LEGACY] = "Legacy power save",
+	[WIFI_PS_MODE_WMM] = "WMM power save",
+};
+
+enum wifi_twt_operation {
+	WIFI_TWT_SETUP = 0,
+	WIFI_TWT_TEARDOWN,
+};
+
+static const char * const wifi_twt_operation2str[] = {
+	[WIFI_TWT_SETUP] = "TWT setup",
+	[WIFI_TWT_TEARDOWN] = "TWT teardown",
+};
+
+enum wifi_twt_negotiation_type {
+	WIFI_TWT_INDIVIDUAL = 0,
+	WIFI_TWT_BROADCAST,
+	WIFI_TWT_WAKE_TBTT
+};
+
+static const char * const wifi_twt_negotiation_type2str[] = {
+	[WIFI_TWT_INDIVIDUAL] = "TWT individual negotiation",
+	[WIFI_TWT_BROADCAST] = "TWT broadcast negotiation",
+	[WIFI_TWT_WAKE_TBTT] = "TWT wake TBTT negotiation",
+};
+
+enum wifi_twt_setup_cmd {
+	/* TWT Requests */
+	WIFI_TWT_SETUP_CMD_REQUEST = 0,
+	WIFI_TWT_SETUP_CMD_SUGGEST,
+	WIFI_TWT_SETUP_CMD_DEMAND,
+	/* TWT Responses */
+	WIFI_TWT_SETUP_CMD_GROUPING,
+	WIFI_TWT_SETUP_CMD_ACCEPT,
+	WIFI_TWT_SETUP_CMD_ALTERNATE,
+	WIFI_TWT_SETUP_CMD_DICTATE,
+	WIFI_TWT_SETUP_CMD_REJECT,
+};
+
+static const char * const wifi_twt_setup_cmd2str[] = {
+	/* TWT Requests */
+	[WIFI_TWT_SETUP_CMD_REQUEST] = "TWT request",
+	[WIFI_TWT_SETUP_CMD_SUGGEST] = "TWT suggest",
+	[WIFI_TWT_SETUP_CMD_DEMAND] = "TWT demand",
+	/* TWT Responses */
+	[WIFI_TWT_SETUP_CMD_GROUPING] = "TWT grouping",
+	[WIFI_TWT_SETUP_CMD_ACCEPT] = "TWT accept",
+	[WIFI_TWT_SETUP_CMD_ALTERNATE] = "TWT alternate",
+	[WIFI_TWT_SETUP_CMD_DICTATE] = "TWT dictate",
+	[WIFI_TWT_SETUP_CMD_REJECT] = "TWT reject",
+};
+
 #endif /* ZEPHYR_INCLUDE_NET_WIFI_H_ */

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -36,6 +36,10 @@ enum net_request_wifi_cmd {
 	NET_REQUEST_WIFI_CMD_AP_ENABLE,
 	NET_REQUEST_WIFI_CMD_AP_DISABLE,
 	NET_REQUEST_WIFI_CMD_IFACE_STATUS,
+	NET_REQUEST_WIFI_CMD_PS,
+	NET_REQUEST_WIFI_CMD_PS_MODE,
+	NET_REQUEST_WIFI_CMD_TWT,
+	NET_REQUEST_WIFI_CMD_PS_CONFIG,
 };
 
 #define NET_REQUEST_WIFI_SCAN					\
@@ -68,12 +72,33 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_AP_DISABLE);
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_IFACE_STATUS);
 
+#define NET_REQUEST_WIFI_PS				\
+	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_PS)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PS);
+
+#define NET_REQUEST_WIFI_PS_MODE			\
+	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_PS_MODE)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_MODE);
+
+#define NET_REQUEST_WIFI_TWT			\
+	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_TWT)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_TWT);
+
+#define NET_REQUEST_WIFI_PS_CONFIG				\
+	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_PS_CONFIG)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_CONFIG);
+
 enum net_event_wifi_cmd {
 	NET_EVENT_WIFI_CMD_SCAN_RESULT = 1,
 	NET_EVENT_WIFI_CMD_SCAN_DONE,
 	NET_EVENT_WIFI_CMD_CONNECT_RESULT,
 	NET_EVENT_WIFI_CMD_DISCONNECT_RESULT,
 	NET_EVENT_WIFI_CMD_IFACE_STATUS,
+	NET_EVENT_WIFI_CMD_TWT,
 };
 
 #define NET_EVENT_WIFI_SCAN_RESULT				\
@@ -91,6 +116,8 @@ enum net_event_wifi_cmd {
 #define NET_EVENT_WIFI_IFACE_STATUS						\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_IFACE_STATUS)
 
+#define NET_EVENT_WIFI_TWT					\
+	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_TWT)
 
 /* Each result is provided to the net_mgmt_event_callback
  * via its info attribute (see net_mgmt.h)
@@ -144,6 +171,66 @@ struct wifi_iface_status {
 	int rssi;
 };
 
+struct wifi_ps_params {
+	enum wifi_ps enabled;
+};
+
+struct wifi_ps_mode_params {
+	enum wifi_ps_mode mode;
+};
+
+struct wifi_twt_params {
+	enum wifi_twt_operation operation;
+	enum wifi_twt_negotiation_type negotiation_type;
+	enum wifi_twt_setup_cmd setup_cmd;
+	/* Map requests to responses */
+	uint8_t dialog_token;
+	/* Map setup with teardown */
+	uint8_t flow_id;
+	union {
+		struct {
+			/* Interval = Wake up time + Sleeping time */
+			uint32_t twt_interval_ms;
+			bool responder;
+			bool trigger;
+			bool implicit;
+			bool announce;
+			/* Wake up time */
+			uint8_t twt_wake_interval_ms;
+		} setup;
+		struct {
+			/* Only for Teardown */
+			bool teardown_all;
+		} teardown;
+	};
+};
+
+/* Flow ID is only 3 bits */
+#define WIFI_MAX_TWT_FLOWS 8
+#define WIFI_MAX_TWT_INTERVAL_MS 0x7FFFFFFF
+struct wifi_twt_flow_info {
+	/* Interval = Wake up time + Sleeping time */
+	uint32_t  twt_interval_ms;
+	/* Map requests to responses */
+	uint8_t dialog_token;
+	/* Map setup with teardown */
+	uint8_t flow_id;
+	enum wifi_twt_negotiation_type negotiation_type;
+	bool responder;
+	bool trigger;
+	bool implicit;
+	bool announce;
+	/* Wake up time */
+	uint8_t twt_wake_interval_ms;
+};
+
+struct wifi_ps_config {
+	struct wifi_twt_flow_info twt_flows[WIFI_MAX_TWT_FLOWS];
+	bool enabled;
+	enum wifi_ps_mode mode;
+	char num_twt_flows;
+};
+
 #include <zephyr/net/net_if.h>
 
 typedef void (*scan_result_cb_t)(struct net_if *iface, int status,
@@ -177,6 +264,10 @@ struct net_wifi_mgmt_offload {
 #ifdef CONFIG_NET_STATISTICS_WIFI
 	int (*get_stats)(const struct device *dev, struct net_stats_wifi *stats);
 #endif /* CONFIG_NET_STATISTICS_WIFI */
+	int (*set_power_save)(const struct device *dev, struct wifi_ps_params *params);
+	int (*set_power_save_mode)(const struct device *dev, struct wifi_ps_mode_params *params);
+	int (*set_twt)(const struct device *dev, struct wifi_twt_params *params);
+	int (*get_power_save_config)(const struct device *dev, struct wifi_ps_config *config);
 };
 
 /* Make sure that the network interface API is properly setup inside
@@ -188,6 +279,8 @@ void wifi_mgmt_raise_connect_result_event(struct net_if *iface, int status);
 void wifi_mgmt_raise_disconnect_result_event(struct net_if *iface, int status);
 void wifi_mgmt_raise_iface_status_event(struct net_if *iface,
 		struct wifi_iface_status *iface_status);
+void wifi_mgmt_raise_twt_event(struct net_if *iface,
+		struct wifi_twt_params *twt_params);
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -228,3 +228,82 @@ static int wifi_iface_stats(uint32_t mgmt_request, struct net_if *iface,
 }
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_STATS_GET_WIFI, wifi_iface_stats);
 #endif /* CONFIG_NET_STATISTICS_WIFI */
+
+static int wifi_set_power_save(uint32_t mgmt_request, struct net_if *iface,
+			  void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api =
+		(struct net_wifi_mgmt_offload *) dev->api;
+	struct wifi_ps_params *ps_params = data;
+
+	if (off_api == NULL || off_api->set_power_save == NULL) {
+		return -ENOTSUP;
+	}
+
+	return off_api->set_power_save(dev, ps_params);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_PS, wifi_set_power_save);
+
+static int wifi_get_power_save_config(uint32_t mgmt_request, struct net_if *iface,
+			  void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api =
+		(struct net_wifi_mgmt_offload *) dev->api;
+	struct wifi_ps_config *ps_config = data;
+
+	if (off_api == NULL || off_api->get_power_save_config == NULL) {
+		return -ENOTSUP;
+	}
+
+	if (!data || len != sizeof(*ps_config)) {
+		return -EINVAL;
+	}
+
+	return off_api->get_power_save_config(dev, ps_config);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_CONFIG, wifi_get_power_save_config);
+
+static int wifi_set_power_save_mode(uint32_t mgmt_request, struct net_if *iface,
+			  void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api =
+		(struct net_wifi_mgmt_offload *) dev->api;
+	struct wifi_ps_mode_params *ps_mode_params = data;
+
+	if (off_api == NULL || off_api->set_power_save_mode == NULL) {
+		return -ENOTSUP;
+	}
+
+	return off_api->set_power_save_mode(dev, ps_mode_params);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_MODE, wifi_set_power_save_mode);
+
+static int wifi_set_twt(uint32_t mgmt_request, struct net_if *iface,
+			  void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api =
+		(struct net_wifi_mgmt_offload *) dev->api;
+	struct wifi_twt_params *twt_params = data;
+
+	if (off_api == NULL || off_api->set_twt == NULL) {
+		return -ENOTSUP;
+	}
+
+	return off_api->set_twt(dev, twt_params);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_TWT, wifi_set_twt);
+
+void wifi_mgmt_raise_twt_event(struct net_if *iface, struct wifi_twt_params *twt_params)
+{
+	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_TWT,
+					iface, twt_params,
+					sizeof(struct wifi_twt_params));
+}

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -425,15 +425,16 @@ static int cmd_wifi_ap_disable(const struct shell *sh, size_t argc,
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(wifi_cmd_ap,
-	SHELL_CMD(enable, NULL, "<SSID> <SSID length> [channel] [PSK]",
-		  cmd_wifi_ap_enable),
 	SHELL_CMD(disable, NULL,
 		  "Disable Access Point mode",
 		  cmd_wifi_ap_disable),
+	SHELL_CMD(enable, NULL, "<SSID> <SSID length> [channel] [PSK]",
+		  cmd_wifi_ap_enable),
 	SHELL_SUBCMD_SET_END
 );
 
 SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
+	SHELL_CMD(ap, &wifi_cmd_ap, "Access Point mode commands", NULL),
 	SHELL_CMD(connect, NULL,
 		  "Connect to a Wi-Fi AP\n"
 		  "\"<SSID>\"\n"
@@ -447,9 +448,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 	SHELL_CMD(disconnect, NULL, "Disconnect from the Wi-Fi AP",
 		  cmd_wifi_disconnect),
 	SHELL_CMD(scan, NULL, "Scan for Wi-Fi APs", cmd_wifi_scan),
-	SHELL_CMD(status, NULL, "Status of the Wi-Fi interface", cmd_wifi_status),
 	SHELL_CMD(statistics, NULL, "Wi-Fi interface statistics", cmd_wifi_stats),
-	SHELL_CMD(ap, &wifi_cmd_ap, "Access Point mode commands", NULL),
+	SHELL_CMD(status, NULL, "Status of the Wi-Fi interface", cmd_wifi_status),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
Add support for configuring power-save in Wi-Fi chipsets, supports Legacy, WMM and TWT.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>