### PR TITLE
drivers: can: kvaser_pci: Fix incorrect RAM context struct type

### DIFF
--- a/drivers/can/can_kvaser_pci.c
+++ b/drivers/can/can_kvaser_pci.c
@@ -172,7 +172,7 @@ const struct can_driver_api can_kvaser_pci_driver_api = {
 					       can_kvaser_pci_read_reg, can_kvaser_pci_write_reg,  \
 					       CAN_KVASER_PCI_OCR, CAN_KVASER_PCI_CDR);            \
                                                                                                    \
-	static struct can_kvaser_pci_config can_kvaser_pci_data_##inst;                            \
+	static struct can_kvaser_pci_data can_kvaser_pci_data_##inst;                              \
                                                                                                    \
 	static struct can_sja1000_data can_sja1000_data_##inst =                                   \
 		CAN_SJA1000_DATA_INITIALIZER(&can_kvaser_pci_data_##inst);                         \


### PR DESCRIPTION
The can_kvaser_pci_data_##inst type was supposed to be can_kvaser_pci_data and not can_kvaser_pci_config. This got unnoticed because there were no struct members to pre-initialize, and a reference to the struct was stored using a void pointer.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>