### PR TITLE
drivers: mcp230xx: fix for multiple instances

### DIFF
--- a/drivers/gpio/gpio_mcp230xx.c
+++ b/drivers/gpio/gpio_mcp230xx.c
@@ -82,25 +82,23 @@ static int mcp230xx_bus_is_ready(const struct device *dev)
 		/* Default for registers according to datasheet */                                 \
 		.reg_cache.iodir = 0xFFFF, .reg_cache.ipol = 0x0,   .reg_cache.gpinten = 0x0,      \
 		.reg_cache.defval = 0x0,   .reg_cache.intcon = 0x0, .reg_cache.iocon = 0x0,        \
-		.reg_cache.gppu = 0x0,	   .reg_cache.intf = 0x0,   .reg_cache.intcap = 0x0,       \
-		.reg_cache.gpio = 0x0,	   .reg_cache.olat = 0x0,                                  \
+		.reg_cache.gppu = 0x0,     .reg_cache.intf = 0x0,   .reg_cache.intcap = 0x0,       \
+		.reg_cache.gpio = 0x0,     .reg_cache.olat = 0x0,                                  \
 	};                                                                                         \
-	static struct mcp23xxx_config mcp230xx_##inst##_config = {     \
-		.config = {					       \
-			.port_pin_mask =			       \
-				GPIO_PORT_PIN_MASK_FROM_DT_INST(n),    \
-		},						       \
-		.bus =  \
-	{                                                                                          \
-		.i2c = I2C_DT_SPEC_INST_GET(n)                                          \
-	}, \
-		.ngpios =  DT_INST_PROP(n, ngpios),			       \
-		.read_fn = mcp230xx_read_port_regs,              \
-		.write_fn = mcp230xx_write_port_regs,              \
-		.bus_fn = mcp230xx_bus_is_ready              \
-	};                           \
+	static struct mcp23xxx_config mcp230xx_##inst##_config = {                                 \
+		.config = {                                                                        \
+			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),                       \
+		},                                                                                 \
+		.bus = {                                                                           \
+			.i2c = I2C_DT_SPEC_INST_GET(n),                                            \
+		},                                                                                 \
+		.ngpios =  DT_INST_PROP(n, ngpios),                                                \
+		.read_fn = mcp230xx_read_port_regs,                                                \
+		.write_fn = mcp230xx_write_port_regs,                                              \
+		.bus_fn = mcp230xx_bus_is_ready,                                                   \
+	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(n, gpio_mcp23xxx_init, NULL, &mcp230xx_##inst##_drvdata,             \
-			      &mcp230xx_##inst##_config, POST_KERNEL,                              \
-			      CONFIG_GPIO_MCP230XX_INIT_PRIORITY, &gpio_mcp23xxx_api_table);
+		&mcp230xx_##inst##_config, POST_KERNEL,                                            \
+		CONFIG_GPIO_MCP230XX_INIT_PRIORITY, &gpio_mcp23xxx_api_table);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_MCP230XX_DEVICE)

--- a/drivers/gpio/gpio_mcp230xx.c
+++ b/drivers/gpio/gpio_mcp230xx.c
@@ -77,7 +77,7 @@ static int mcp230xx_bus_is_ready(const struct device *dev)
 
 #define DT_DRV_COMPAT microchip_mcp230xx
 
-#define GPIO_MCP230XX_DEVICE(n)                                                                    \
+#define GPIO_MCP230XX_DEVICE(inst)                                                                 \
 	static struct mcp23xxx_drv_data mcp230xx_##inst##_drvdata = {                              \
 		/* Default for registers according to datasheet */                                 \
 		.reg_cache.iodir = 0xFFFF, .reg_cache.ipol = 0x0,   .reg_cache.gpinten = 0x0,      \
@@ -87,17 +87,17 @@ static int mcp230xx_bus_is_ready(const struct device *dev)
 	};                                                                                         \
 	static struct mcp23xxx_config mcp230xx_##inst##_config = {                                 \
 		.config = {                                                                        \
-			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),                       \
+			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(inst),                    \
 		},                                                                                 \
 		.bus = {                                                                           \
-			.i2c = I2C_DT_SPEC_INST_GET(n),                                            \
+			.i2c = I2C_DT_SPEC_INST_GET(inst),                                         \
 		},                                                                                 \
-		.ngpios =  DT_INST_PROP(n, ngpios),                                                \
+		.ngpios =  DT_INST_PROP(inst, ngpios),                                             \
 		.read_fn = mcp230xx_read_port_regs,                                                \
 		.write_fn = mcp230xx_write_port_regs,                                              \
 		.bus_fn = mcp230xx_bus_is_ready,                                                   \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(n, gpio_mcp23xxx_init, NULL, &mcp230xx_##inst##_drvdata,             \
+	DEVICE_DT_INST_DEFINE(inst, gpio_mcp23xxx_init, NULL, &mcp230xx_##inst##_drvdata,          \
 		&mcp230xx_##inst##_config, POST_KERNEL,                                            \
 		CONFIG_GPIO_MCP230XX_INIT_PRIORITY, &gpio_mcp23xxx_api_table);
 

--- a/drivers/gpio/gpio_mcp230xx.c
+++ b/drivers/gpio/gpio_mcp230xx.c
@@ -85,7 +85,7 @@ static int mcp230xx_bus_is_ready(const struct device *dev)
 		.reg_cache.gppu = 0x0,     .reg_cache.intf = 0x0,   .reg_cache.intcap = 0x0,       \
 		.reg_cache.gpio = 0x0,     .reg_cache.olat = 0x0,                                  \
 	};                                                                                         \
-	static struct mcp23xxx_config mcp230xx_##inst##_config = {                                 \
+	static const struct mcp23xxx_config mcp230xx_##inst##_config = {                           \
 		.config = {                                                                        \
 			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(inst),                    \
 		},                                                                                 \


### PR DESCRIPTION
Parts of the macro used `inst`, others `n` for the instance number; only `n` was actually defined (so `inst` expanded to the empty string, causing name errors with more than one instance).

Unify everything to `inst`.