### PR TITLE
LE Audio: MCC notification and discovery fixes

### DIFF
--- a/include/zephyr/bluetooth/audio/mcc.h
+++ b/include/zephyr/bluetooth/audio/mcc.h
@@ -923,7 +923,7 @@ int bt_mcc_otc_read_current_group_object(struct bt_conn *conn);
 int bt_mcc_otc_read_parent_group_object(struct bt_conn *conn);
 
 #if defined(CONFIG_BT_MCC_SHELL)
-struct bt_ots_client *bt_mcc_otc_inst(void);
+struct bt_ots_client *bt_mcc_otc_inst(struct bt_conn *conn);
 #endif /* defined(CONFIG_BT_MCC_SHELL) */
 #endif /* CONFIG_BT_OTS_CLIENT */
 

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -120,6 +120,8 @@ struct mcs_instance_t {
 		       sizeof(((struct mpl_cmd *)0)->param)];
 #endif /* CONFIG_BT_MCC_OTS */
 
+	struct bt_gatt_discover_params  discover_params;
+	struct bt_gatt_read_params      read_params;
 	struct bt_gatt_write_params     write_params;
 	bool busy;
 
@@ -127,11 +129,6 @@ struct mcs_instance_t {
 	struct bt_ots_client otc;
 #endif /* CONFIG_BT_MCC_OTS */
 };
-
-static struct bt_gatt_discover_params  discover_params;
-static struct bt_gatt_read_params      read_params;
-
-static struct mcs_instance_t *cur_mcs_inst;
 
 static struct mcs_instance_t mcs_inst;
 static struct bt_uuid_16 uuid = BT_UUID_INIT_16(0);
@@ -173,10 +170,11 @@ static uint8_t mcc_read_player_name_cb(struct bt_conn *conn, uint8_t err,
 				       struct bt_gatt_read_params *params,
 				       const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	char name[CONFIG_BT_MCC_MEDIA_PLAYER_NAME_MAX];
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	BT_DBG("err: 0x%02x, length: %d, data: %p", err, length, data);
 
 	if (err) {
@@ -208,11 +206,12 @@ static uint8_t mcc_read_icon_obj_id_cb(struct bt_conn *conn, uint8_t err,
 				       struct bt_gatt_read_params *params,
 				       const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	uint8_t *pid = (uint8_t *)data;
 	uint64_t id = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	BT_DBG("err: 0x%02x, length: %d, data: %p", err, length, data);
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
@@ -236,10 +235,11 @@ static uint8_t mcc_read_icon_url_cb(struct bt_conn *conn, uint8_t err,
 				    struct bt_gatt_read_params *params,
 				    const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	char url[CONFIG_BT_MCC_ICON_URL_MAX];
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	BT_DBG("err: 0x%02x, length: %d, data: %p", err, length, data);
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
@@ -265,10 +265,11 @@ static uint8_t mcc_read_track_title_cb(struct bt_conn *conn, uint8_t err,
 				       struct bt_gatt_read_params *params,
 				       const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	char title[CONFIG_BT_MCC_TRACK_TITLE_MAX];
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if (!data) {
@@ -295,10 +296,11 @@ static uint8_t mcc_read_track_duration_cb(struct bt_conn *conn, uint8_t err,
 					  struct bt_gatt_read_params *params,
 					  const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	int32_t dur = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if ((!data) || (length != sizeof(dur))) {
@@ -321,10 +323,11 @@ static uint8_t mcc_read_track_position_cb(struct bt_conn *conn, uint8_t err,
 					  struct bt_gatt_read_params *params,
 					  const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	int32_t pos = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if ((!data) || (length != sizeof(pos))) {
@@ -346,10 +349,11 @@ static uint8_t mcc_read_track_position_cb(struct bt_conn *conn, uint8_t err,
 static void mcs_write_track_position_cb(struct bt_conn *conn, uint8_t err,
 					struct bt_gatt_write_params *params)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, write_params);
 	int cb_err = err;
 	int32_t pos = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if (!params->data || params->length != sizeof(pos)) {
@@ -370,10 +374,11 @@ static uint8_t mcc_read_playback_speed_cb(struct bt_conn *conn, uint8_t err,
 					  struct bt_gatt_read_params *params,
 					  const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	int8_t speed = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if ((!data) || (length != sizeof(speed))) {
@@ -395,10 +400,11 @@ static uint8_t mcc_read_playback_speed_cb(struct bt_conn *conn, uint8_t err,
 static void mcs_write_playback_speed_cb(struct bt_conn *conn, uint8_t err,
 					struct bt_gatt_write_params *params)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, write_params);
 	int cb_err = err;
 	int8_t speed = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if (!params->data || params->length != sizeof(speed)) {
@@ -418,10 +424,11 @@ static uint8_t mcc_read_seeking_speed_cb(struct bt_conn *conn, uint8_t err,
 					 struct bt_gatt_read_params *params,
 					 const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	int8_t speed = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if ((!data) || (length != sizeof(speed))) {
@@ -445,11 +452,12 @@ static uint8_t mcc_read_segments_obj_id_cb(struct bt_conn *conn, uint8_t err,
 					   struct bt_gatt_read_params *params,
 					   const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err;
 	uint8_t *pid = (uint8_t *)data;
 	uint64_t id = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 		cb_err = err;
@@ -474,11 +482,12 @@ static uint8_t mcc_read_current_track_obj_id_cb(struct bt_conn *conn, uint8_t er
 						struct bt_gatt_read_params *params,
 						const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err;
 	uint8_t *pid = (uint8_t *)data;
 	uint64_t id = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 		cb_err = err;
@@ -502,10 +511,11 @@ static uint8_t mcc_read_current_track_obj_id_cb(struct bt_conn *conn, uint8_t er
 static void mcs_write_current_track_obj_id_cb(struct bt_conn *conn, uint8_t err,
 					      struct bt_gatt_write_params *params)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, write_params);
 	int cb_err = err;
 	uint64_t obj_id = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if (!params->data || params->length != BT_OTS_OBJ_ID_SIZE) {
@@ -525,11 +535,12 @@ static uint8_t mcc_read_next_track_obj_id_cb(struct bt_conn *conn, uint8_t err,
 					     struct bt_gatt_read_params *params,
 					     const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	uint8_t *pid = (uint8_t *)data;
 	uint64_t id = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if (length == 0) {
@@ -553,10 +564,11 @@ static uint8_t mcc_read_next_track_obj_id_cb(struct bt_conn *conn, uint8_t err,
 static void mcs_write_next_track_obj_id_cb(struct bt_conn *conn, uint8_t err,
 					   struct bt_gatt_write_params *params)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, write_params);
 	int cb_err = err;
 	uint64_t obj_id = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if (!params->data || params->length != BT_OTS_OBJ_ID_SIZE) {
@@ -576,11 +588,12 @@ static uint8_t mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, uint8_t err
 					       struct bt_gatt_read_params *params,
 					       const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	uint8_t *pid = (uint8_t *)data;
 	uint64_t id = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if (!pid || (length != BT_OTS_OBJ_ID_SIZE)) {
@@ -603,11 +616,12 @@ static uint8_t mcc_read_current_group_obj_id_cb(struct bt_conn *conn, uint8_t er
 						struct bt_gatt_read_params *params,
 						const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	uint8_t *pid = (uint8_t *)data;
 	uint64_t id = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if (!pid || (length != BT_OTS_OBJ_ID_SIZE)) {
@@ -629,10 +643,11 @@ static uint8_t mcc_read_current_group_obj_id_cb(struct bt_conn *conn, uint8_t er
 static void mcs_write_current_group_obj_id_cb(struct bt_conn *conn, uint8_t err,
 					      struct bt_gatt_write_params *params)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, write_params);
 	int cb_err = err;
 	uint64_t obj_id = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if (!params->data || params->length != BT_OTS_OBJ_ID_SIZE) {
@@ -653,10 +668,11 @@ static uint8_t mcc_read_playing_order_cb(struct bt_conn *conn, uint8_t err,
 					 struct bt_gatt_read_params *params,
 					 const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	uint8_t order = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if ((!data) || (length != sizeof(order))) {
@@ -678,10 +694,11 @@ static uint8_t mcc_read_playing_order_cb(struct bt_conn *conn, uint8_t err,
 static void mcs_write_playing_order_cb(struct bt_conn *conn, uint8_t err,
 				       struct bt_gatt_write_params *params)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, write_params);
 	int cb_err = err;
 	uint8_t order = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if (!params->data || params->length != sizeof(order)) {
@@ -701,10 +718,11 @@ static uint8_t mcc_read_playing_orders_supported_cb(struct bt_conn *conn, uint8_
 						    struct bt_gatt_read_params *params,
 						    const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	uint16_t orders = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if (!data || length != sizeof(orders)) {
@@ -727,10 +745,11 @@ static uint8_t mcc_read_media_state_cb(struct bt_conn *conn, uint8_t err,
 				       struct bt_gatt_read_params *params,
 				       const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	uint8_t state = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if (!data || length != sizeof(state)) {
@@ -752,10 +771,11 @@ static uint8_t mcc_read_media_state_cb(struct bt_conn *conn, uint8_t err,
 static void mcs_write_cp_cb(struct bt_conn *conn, uint8_t err,
 			    struct bt_gatt_write_params *params)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, write_params);
 	int cb_err = err;
 	struct mpl_cmd cmd = {0};
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
@@ -786,10 +806,11 @@ static uint8_t mcc_read_opcodes_supported_cb(struct bt_conn *conn, uint8_t err,
 					     struct bt_gatt_read_params *params,
 					     const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	int32_t operations = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
@@ -814,10 +835,11 @@ static uint8_t mcc_read_opcodes_supported_cb(struct bt_conn *conn, uint8_t err,
 static void mcs_write_scp_cb(struct bt_conn *conn, uint8_t err,
 			     struct bt_gatt_write_params *params)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, write_params);
 	int cb_err = err;
 	struct mpl_search search = {0};
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
@@ -840,11 +862,12 @@ static uint8_t mcc_read_search_results_obj_id_cb(struct bt_conn *conn, uint8_t e
 						 struct bt_gatt_read_params *params,
 						 const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	uint8_t *pid = (uint8_t *)data;
 	uint64_t id = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
 	} else if (length == 0) {
@@ -871,10 +894,11 @@ static uint8_t mcc_read_content_control_id_cb(struct bt_conn *conn, uint8_t err,
 					      struct bt_gatt_read_params *params,
 					      const void *data, uint16_t length)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params, struct mcs_instance_t, read_params);
 	int cb_err = err;
 	uint8_t ccid = 0;
 
-	cur_mcs_inst->busy = false;
+	mcs_inst->busy = false;
 
 	if (err) {
 		BT_DBG("err: 0x%02x", err);
@@ -898,8 +922,9 @@ static uint8_t mcs_notify_handler(struct bt_conn *conn,
 				  struct bt_gatt_subscribe_params *params,
 				  const void *data, uint16_t length)
 {
+	struct bt_gatt_read_params *read_params;
 	uint16_t handle = params->value_handle;
-	struct mcs_instance_t *inst;
+	struct mcs_instance_t *mcs_inst;
 
 	if (data == NULL) {
 		BT_DBG("[UNSUBSCRIBED] 0x%04X", params->value_handle);
@@ -908,146 +933,147 @@ static uint8_t mcs_notify_handler(struct bt_conn *conn,
 		return BT_GATT_ITER_CONTINUE;
 	}
 
-	inst = lookup_inst_by_conn(conn);
-	if (inst == NULL) {
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not find MCS instance from conn %p", conn);
+
 		return BT_GATT_ITER_CONTINUE;
 	}
 
+	/* TODO: Work around for using CONTAINER_OF when re-using the
+	 * read callbacks for notifications. The handling of the values
+	 * should be put into separate functions instead of using the
+	 * read callbacks
+	 */
+	read_params = &mcs_inst->read_params;
+
 	BT_DBG("Notification, handle: %d", handle);
 
-	if (inst != NULL) {
-		if (handle == inst->player_name_handle) {
-			BT_DBG("Player Name notification");
-			mcc_read_player_name_cb(conn, 0, NULL, data, length);
+	if (handle == mcs_inst->player_name_handle) {
+		BT_DBG("Player Name notification");
+		mcc_read_player_name_cb(conn, 0, NULL, data, length);
 
-		} else if (handle == inst->track_changed_handle) {
-			/* The Track Changed characteristic can only be */
-			/* notified, so that is handled directly here */
+	} else if (handle == mcs_inst->track_changed_handle) {
+		/* The Track Changed characteristic can only be */
+		/* notified, so that is handled directly here */
+		int cb_err = 0;
 
-			int cb_err = 0;
+		BT_DBG("Track Changed notification");
+		BT_DBG("data: %p, length: %u", data, length);
 
-			BT_DBG("Track Changed notification");
-			BT_DBG("data: %p, length: %u", data, length);
-
-			if (length != 0) {
-				BT_DBG("Non-zero length: %u", length);
-				cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
-			}
-
-			if (mcc_cb && mcc_cb->track_changed_ntf) {
-				mcc_cb->track_changed_ntf(conn, cb_err);
-			}
-
-		} else if (handle == inst->track_title_handle) {
-			BT_DBG("Track Title notification");
-			mcc_read_track_title_cb(conn, 0, NULL, data, length);
-
-		} else if (handle == inst->track_duration_handle) {
-			BT_DBG("Track Duration notification");
-			mcc_read_track_duration_cb(conn, 0, NULL, data, length);
-
-		} else if (handle == inst->track_position_handle) {
-			BT_DBG("Track Position notification");
-			mcc_read_track_position_cb(conn, 0, NULL, data, length);
-
-		} else if (handle == inst->playback_speed_handle) {
-			BT_DBG("Playback Speed notification");
-			mcc_read_playback_speed_cb(conn, 0, NULL, data, length);
-
-		} else if (handle == inst->seeking_speed_handle) {
-			BT_DBG("Seeking Speed notification");
-			mcc_read_seeking_speed_cb(conn, 0, NULL, data, length);
-
-#ifdef CONFIG_BT_MCC_OTS
-		} else if (handle == inst->current_track_obj_id_handle) {
-			BT_DBG("Current Track notification");
-			mcc_read_current_track_obj_id_cb(conn, 0, NULL, data,
-							 length);
-
-		} else if (handle == inst->next_track_obj_id_handle) {
-			BT_DBG("Next Track notification");
-			mcc_read_next_track_obj_id_cb(conn, 0, NULL, data,
-						      length);
-
-		} else if (handle == inst->parent_group_obj_id_handle) {
-			BT_DBG("Parent Group notification");
-			mcc_read_parent_group_obj_id_cb(conn, 0, NULL, data,
-							 length);
-
-		} else if (handle == inst->current_group_obj_id_handle) {
-			BT_DBG("Current Group notification");
-			mcc_read_current_group_obj_id_cb(conn, 0, NULL, data,
-							 length);
-#endif /* CONFIG_BT_MCC_OTS */
-
-		} else if (handle == inst->playing_order_handle) {
-			BT_DBG("Playing Order notification");
-			mcc_read_playing_order_cb(conn, 0, NULL, data, length);
-
-		} else if (handle == inst->media_state_handle) {
-			BT_DBG("Media State notification");
-			mcc_read_media_state_cb(conn, 0, NULL, data, length);
-
-		} else if (handle == inst->cp_handle) {
-			/* The control point is is a special case - only */
-			/* writable and notifiable.  Handle directly here. */
-
-			int cb_err = 0;
-			struct mpl_cmd_ntf ntf = {0};
-
-			BT_DBG("Control Point notification");
-			if (length == sizeof(ntf.requested_opcode) + sizeof(ntf.result_code)) {
-				ntf.requested_opcode = *(uint8_t *)data;
-				ntf.result_code = *((uint8_t *)data +
-						    sizeof(ntf.requested_opcode));
-				BT_DBG("Command: %d, result: %d",
-				       ntf.requested_opcode, ntf.result_code);
-			} else {
-				BT_DBG("length: %d, data: %p", length, data);
-				cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
-			}
-
-			if (mcc_cb && mcc_cb->cmd_ntf) {
-				mcc_cb->cmd_ntf(conn, cb_err, &ntf);
-			}
-
-		} else if (handle == inst->opcodes_supported_handle) {
-			BT_DBG("Opcodes Supported notification");
-			mcc_read_opcodes_supported_cb(conn, 0, NULL, data,
-						      length);
-
-#ifdef CONFIG_BT_MCC_OTS
-		} else if (handle == inst->scp_handle) {
-			/* The search control point is a special case - only */
-			/* writable and notifiable.  Handle directly here. */
-
-			int cb_err = 0;
-			uint8_t result_code = 0;
-
-			BT_DBG("Search Control Point notification");
-			if (length == sizeof(result_code)) {
-				result_code = *(uint8_t *)data;
-				BT_DBG("Result: %d", result_code);
-			} else {
-				BT_DBG("length: %d, data: %p", length, data);
-				cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
-			}
-
-			if (mcc_cb && mcc_cb->search_ntf) {
-				mcc_cb->search_ntf(conn, cb_err, result_code);
-			}
-
-		} else if (handle == inst->search_results_obj_id_handle) {
-			BT_DBG("Search Results notification");
-			mcc_read_search_results_obj_id_cb(conn, 0, NULL, data,
-							  length);
-#endif /* CONFIG_BT_MCC_OTS */
-
-		} else {
-			BT_DBG("Unknown handle: %d (0x%04X)", handle, handle);
+		if (length != 0) {
+			BT_DBG("Non-zero length: %u", length);
+			cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 		}
+
+		if (mcc_cb && mcc_cb->track_changed_ntf) {
+			mcc_cb->track_changed_ntf(conn, cb_err);
+		}
+
+	} else if (handle == mcs_inst->track_title_handle) {
+		BT_DBG("Track Title notification");
+		mcc_read_track_title_cb(conn, 0, read_params, data, length);
+
+	} else if (handle == mcs_inst->track_duration_handle) {
+		BT_DBG("Track Duration notification");
+		mcc_read_track_duration_cb(conn, 0, read_params, data, length);
+
+	} else if (handle == mcs_inst->track_position_handle) {
+		BT_DBG("Track Position notification");
+		mcc_read_track_position_cb(conn, 0, read_params, data, length);
+
+	} else if (handle == mcs_inst->playback_speed_handle) {
+		BT_DBG("Playback Speed notification");
+		mcc_read_playback_speed_cb(conn, 0, read_params, data, length);
+
+	} else if (handle == mcs_inst->seeking_speed_handle) {
+		BT_DBG("Seeking Speed notification");
+		mcc_read_seeking_speed_cb(conn, 0, read_params, data, length);
+
+#ifdef CONFIG_BT_MCC_OTS
+	} else if (handle == mcs_inst->current_track_obj_id_handle) {
+		BT_DBG("Current Track notification");
+		mcc_read_current_track_obj_id_cb(conn, 0, read_params, data,
+						 length);
+
+	} else if (handle == mcs_inst->next_track_obj_id_handle) {
+		BT_DBG("Next Track notification");
+		mcc_read_next_track_obj_id_cb(conn, 0, read_params, data,
+					      length);
+
+	} else if (handle == mcs_inst->parent_group_obj_id_handle) {
+		BT_DBG("Parent Group notification");
+		mcc_read_parent_group_obj_id_cb(conn, 0, read_params, data,
+						length);
+
+	} else if (handle == mcs_inst->current_group_obj_id_handle) {
+		BT_DBG("Current Group notification");
+		mcc_read_current_group_obj_id_cb(conn, 0, read_params, data,
+						 length);
+#endif /* CONFIG_BT_MCC_OTS */
+
+	} else if (handle == mcs_inst->playing_order_handle) {
+		BT_DBG("Playing Order notification");
+		mcc_read_playing_order_cb(conn, 0, read_params, data, length);
+
+	} else if (handle == mcs_inst->media_state_handle) {
+		BT_DBG("Media State notification");
+		mcc_read_media_state_cb(conn, 0, read_params, data, length);
+
+	} else if (handle == mcs_inst->cp_handle) {
+		/* The control point is is a special case - only */
+		/* writable and notifiable.  Handle directly here. */
+		struct mpl_cmd_ntf ntf = {0};
+		int cb_err = 0;
+
+		BT_DBG("Control Point notification");
+		if (length == sizeof(ntf.requested_opcode) + sizeof(ntf.result_code)) {
+			ntf.requested_opcode = *(uint8_t *)data;
+			ntf.result_code = *((uint8_t *)data +
+						sizeof(ntf.requested_opcode));
+			BT_DBG("Command: %d, result: %d",
+				ntf.requested_opcode, ntf.result_code);
+		} else {
+			BT_DBG("length: %d, data: %p", length, data);
+			cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+		}
+
+		if (mcc_cb && mcc_cb->cmd_ntf) {
+			mcc_cb->cmd_ntf(conn, cb_err, &ntf);
+		}
+
+	} else if (handle == mcs_inst->opcodes_supported_handle) {
+		BT_DBG("Opcodes Supported notification");
+		mcc_read_opcodes_supported_cb(conn, 0, read_params, data,
+					      length);
+
+#ifdef CONFIG_BT_MCC_OTS
+	} else if (handle == mcs_inst->scp_handle) {
+		/* The search control point is a special case - only */
+		/* writable and notifiable.  Handle directly here. */
+		int cb_err = 0;
+		uint8_t result_code = 0;
+
+		BT_DBG("Search Control Point notification");
+		if (length == sizeof(result_code)) {
+			result_code = *(uint8_t *)data;
+			BT_DBG("Result: %d", result_code);
+		} else {
+			BT_DBG("length: %d, data: %p", length, data);
+			cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+		}
+
+		if (mcc_cb && mcc_cb->search_ntf) {
+			mcc_cb->search_ntf(conn, cb_err, result_code);
+		}
+
+	} else if (handle == mcs_inst->search_results_obj_id_handle) {
+		BT_DBG("Search Results notification");
+		mcc_read_search_results_obj_id_cb(conn, 0, read_params, data,
+						  length);
+#endif /* CONFIG_BT_MCC_OTS */
 	} else {
-		BT_DBG("Could not find MCS instance from conn %p", conn);
+		BT_DBG("Unknown handle: %d (0x%04X)", handle, handle);
 	}
 
 	return BT_GATT_ITER_CONTINUE;
@@ -1062,7 +1088,12 @@ static void discovery_complete(struct bt_conn *conn, int err)
 	 * For now, reset instance on error.
 	 */
 	if (err) {
-		cur_mcs_inst = NULL;
+		struct mcs_instance_t *mcs_inst;
+
+		mcs_inst = lookup_inst_by_conn(conn);
+		if (mcs_inst != NULL) {
+			(void)memset(mcs_inst, 0, sizeof(*mcs_inst));
+		}
 	}
 
 	if (mcc_cb && mcc_cb->discover_mcs) {
@@ -1075,6 +1106,9 @@ static uint8_t discover_otc_char_func(struct bt_conn *conn,
 				      const struct bt_gatt_attr *attr,
 				      struct bt_gatt_discover_params *params)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params,
+						       struct mcs_instance_t,
+						       discover_params);
 	int err = 0;
 	struct bt_gatt_chrc *chrc;
 	struct bt_gatt_subscribe_params *sub_params = NULL;
@@ -1093,38 +1127,38 @@ static uint8_t discover_otc_char_func(struct bt_conn *conn,
 		chrc = (struct bt_gatt_chrc *)attr->user_data;
 		if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_FEATURE)) {
 			BT_DBG("OTS Features");
-			cur_mcs_inst->otc.feature_handle = chrc->value_handle;
+			mcs_inst->otc.feature_handle = chrc->value_handle;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_NAME)) {
 			BT_DBG("Object Name");
-			cur_mcs_inst->otc.obj_name_handle = chrc->value_handle;
+			mcs_inst->otc.obj_name_handle = chrc->value_handle;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_TYPE)) {
 			BT_DBG("Object Type");
-			cur_mcs_inst->otc.obj_type_handle = chrc->value_handle;
+			mcs_inst->otc.obj_type_handle = chrc->value_handle;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_SIZE)) {
 			BT_DBG("Object Size");
-			cur_mcs_inst->otc.obj_size_handle = chrc->value_handle;
+			mcs_inst->otc.obj_size_handle = chrc->value_handle;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_ID)) {
 			BT_DBG("Object ID");
-			cur_mcs_inst->otc.obj_id_handle = chrc->value_handle;
+			mcs_inst->otc.obj_id_handle = chrc->value_handle;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_PROPERTIES)) {
 			BT_DBG("Object properties %d", chrc->value_handle);
-			cur_mcs_inst->otc.obj_properties_handle = chrc->value_handle;
+			mcs_inst->otc.obj_properties_handle = chrc->value_handle;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_ACTION_CP)) {
 			BT_DBG("Object Action Control Point");
-			cur_mcs_inst->otc.oacp_handle = chrc->value_handle;
-			sub_params = &cur_mcs_inst->otc.oacp_sub_params;
-			sub_params->disc_params = &cur_mcs_inst->otc.oacp_sub_disc_params;
+			mcs_inst->otc.oacp_handle = chrc->value_handle;
+			sub_params = &mcs_inst->otc.oacp_sub_params;
+			sub_params->disc_params = &mcs_inst->otc.oacp_sub_disc_params;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_LIST_CP)) {
 			BT_DBG("Object List Control Point");
-			cur_mcs_inst->otc.olcp_handle = chrc->value_handle;
-			sub_params = &cur_mcs_inst->otc.olcp_sub_params;
-			sub_params->disc_params = &cur_mcs_inst->otc.olcp_sub_disc_params;
+			mcs_inst->otc.olcp_handle = chrc->value_handle;
+			sub_params = &mcs_inst->otc.olcp_sub_params;
+			sub_params->disc_params = &mcs_inst->otc.olcp_sub_disc_params;
 		}
 
 		if (sub_params) {
 			/* With ccc_handle == 0 it will use auto discovery */
 			sub_params->ccc_handle = 0;
-			sub_params->end_handle = cur_mcs_inst->otc.end_handle;
+			sub_params->end_handle = mcs_inst->otc.end_handle;
 			sub_params->value = BT_GATT_CCC_INDICATE;
 			sub_params->value_handle = chrc->value_handle;
 			sub_params->notify = bt_ots_client_indicate_handler;
@@ -1136,8 +1170,8 @@ static uint8_t discover_otc_char_func(struct bt_conn *conn,
 	}
 
 	/* No more attributes found */
-	cur_mcs_inst->otc.cb = &otc_cb;
-	bt_ots_client_register(&cur_mcs_inst->otc);
+	mcs_inst->otc.cb = &otc_cb;
+	bt_ots_client_register(&mcs_inst->otc);
 
 	BT_DBG("Setup complete for included OTS");
 	(void)memset(params, 0, sizeof(*params));
@@ -1163,6 +1197,10 @@ static uint8_t discover_include_func(struct bt_conn *conn,
 	int err = 0;
 
 	if (attr) {
+		struct mcs_instance_t *mcs_inst = CONTAINER_OF(params,
+							       struct mcs_instance_t,
+							       discover_params);
+
 		BT_DBG("[ATTRIBUTE] handle 0x%04X", attr->handle);
 
 		__ASSERT(params->type == BT_GATT_DISCOVER_INCLUDE,
@@ -1180,18 +1218,18 @@ static uint8_t discover_include_func(struct bt_conn *conn,
 
 		/* We have the included OTS service (MCS includes only one) */
 		BT_DBG("Discover include complete for GMCS: OTS");
-		cur_mcs_inst->otc.start_handle = include->start_handle;
-		cur_mcs_inst->otc.end_handle = include->end_handle;
+		mcs_inst->otc.start_handle = include->start_handle;
+		mcs_inst->otc.end_handle = include->end_handle;
 		(void)memset(params, 0, sizeof(*params));
 
 		/* Discover characteristics of the included OTS */
-		discover_params.start_handle = cur_mcs_inst->otc.start_handle;
-		discover_params.end_handle = cur_mcs_inst->otc.end_handle;
-		discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
-		discover_params.func = discover_otc_char_func;
+		mcs_inst->discover_params.start_handle = mcs_inst->otc.start_handle;
+		mcs_inst->discover_params.end_handle = mcs_inst->otc.end_handle;
+		mcs_inst->discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
+		mcs_inst->discover_params.func = discover_otc_char_func;
 
 		BT_DBG("Start discovery of OTS characteristics");
-		err = bt_gatt_discover(conn, &discover_params);
+		err = bt_gatt_discover(conn, &mcs_inst->discover_params);
 		if (err) {
 			BT_DBG("Discovery of OTS chars. failed");
 			discovery_complete(conn, err);
@@ -1208,17 +1246,17 @@ static uint8_t discover_include_func(struct bt_conn *conn,
 }
 
 /* Start discovery of included services */
-static void discover_included(struct bt_conn *conn)
+static void discover_included(struct mcs_instance_t *mcs_inst, struct bt_conn *conn)
 {
 	int err;
 
-	discover_params.start_handle = cur_mcs_inst->start_handle;
-	discover_params.end_handle = cur_mcs_inst->end_handle;
-	discover_params.type = BT_GATT_DISCOVER_INCLUDE;
-	discover_params.func = discover_include_func;
+	mcs_inst->discover_params.start_handle = mcs_inst->start_handle;
+	mcs_inst->discover_params.end_handle = mcs_inst->end_handle;
+	mcs_inst->discover_params.type = BT_GATT_DISCOVER_INCLUDE;
+	mcs_inst->discover_params.func = discover_include_func;
 
 	BT_DBG("Start discovery of included services");
-	err = bt_gatt_discover(conn, &discover_params);
+	err = bt_gatt_discover(conn, &mcs_inst->discover_params);
 	if (err) {
 		BT_DBG("Discovery of included service failed: %d", err);
 		discovery_complete(conn, err);
@@ -1226,7 +1264,8 @@ static void discover_included(struct bt_conn *conn)
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
-static bool subscribe_next_mcs_char(struct bt_conn *conn);
+static bool subscribe_next_mcs_char(struct mcs_instance_t *mcs_inst,
+				    struct bt_conn *conn);
 
 /* This function will subscribe to GMCS CCCDs.
  * After this, the function will start discovery of included services.
@@ -1234,6 +1273,9 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn);
 static void subscribe_mcs_char_func(struct bt_conn *conn, uint8_t err,
 				    struct bt_gatt_subscribe_params *params)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params->disc_params,
+						       struct mcs_instance_t,
+						       discover_params);
 	bool subscription_done;
 
 	if (err) {
@@ -1247,13 +1289,13 @@ static void subscribe_mcs_char_func(struct bt_conn *conn, uint8_t err,
 	       params->value_handle, params->ccc_handle);
 
 	/* Subscribe to next characteristic */
-	subscription_done = subscribe_next_mcs_char(conn);
+	subscription_done = subscribe_next_mcs_char(mcs_inst, conn);
 
 	if (subscription_done) {
 		params->subscribe = NULL;
 #ifdef CONFIG_BT_MCC_OTS
 		/* Start discovery of included services to find OTS */
-		discover_included(conn);
+		discover_included(mcs_inst, conn);
 #else
 		/* If OTS is not configured, discovery ends here */
 		discovery_complete(conn, 0);
@@ -1262,17 +1304,18 @@ static void subscribe_mcs_char_func(struct bt_conn *conn, uint8_t err,
 }
 
 /* Subscribe to a characteristic - helper function */
-static int do_subscribe(struct bt_conn *conn, uint16_t handle,
-			 struct bt_gatt_subscribe_params *sub_params)
+static int do_subscribe(struct mcs_instance_t *mcs_inst, struct bt_conn *conn,
+			uint16_t handle,
+			struct bt_gatt_subscribe_params *sub_params)
 {
 	/* With ccc_handle == 0 it will use auto discovery */
 	sub_params->ccc_handle = 0;
-	sub_params->end_handle = cur_mcs_inst->end_handle;
+	sub_params->end_handle = mcs_inst->end_handle;
 	sub_params->value_handle = handle;
 	sub_params->notify = mcs_notify_handler;
 	sub_params->subscribe = subscribe_mcs_char_func;
 	/* disc_params pointer is also used as subscription flag */
-	sub_params->disc_params = &discover_params;
+	sub_params->disc_params = &mcs_inst->discover_params;
 
 	BT_DBG("Subscring to handle %d", handle);
 	return bt_gatt_subscribe(conn, sub_params);
@@ -1281,10 +1324,11 @@ static int do_subscribe(struct bt_conn *conn, uint16_t handle,
 /* Subscribe to the next GMCS CCCD.
  * @return true if there are no more characteristics to subscribe to
  */
-static bool subscribe_next_mcs_char(struct bt_conn *conn)
+static bool subscribe_next_mcs_char(struct mcs_instance_t *mcs_inst,
+				    struct bt_conn *conn)
 {
 	struct bt_gatt_subscribe_params *sub_params = NULL;
-	int err = 0;
+	uint16_t handle;
 
 	/* The characteristics may be in any order on the server, and
 	 * not all of them may exist => need to check all.
@@ -1294,213 +1338,108 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 	 *   already subscribed to it (set in do_subscribe() ).
 	 */
 
-	if (cur_mcs_inst->player_name_handle &&
-	    cur_mcs_inst->player_name_sub_params.value &&
-	    cur_mcs_inst->player_name_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->player_name_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->player_name_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-
-	if (cur_mcs_inst->track_changed_handle &&
-	    cur_mcs_inst->track_changed_sub_params.value &&
-	    cur_mcs_inst->track_changed_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->track_changed_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->track_changed_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-	if (cur_mcs_inst->track_title_handle &&
-	    cur_mcs_inst->track_title_sub_params.value &&
-	    cur_mcs_inst->track_title_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->track_title_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->track_title_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-
-	if (cur_mcs_inst->track_duration_handle &&
-	    cur_mcs_inst->track_duration_sub_params.value &&
-	    cur_mcs_inst->track_duration_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->track_duration_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->track_duration_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-
-	if (cur_mcs_inst->track_position_handle &&
-	    cur_mcs_inst->track_position_sub_params.value &&
-	    cur_mcs_inst->track_position_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->track_position_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->track_position_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-
-	if (cur_mcs_inst->playback_speed_handle &&
-	    cur_mcs_inst->playback_speed_sub_params.value &&
-	    cur_mcs_inst->playback_speed_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->playback_speed_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->playback_speed_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-
-	if (cur_mcs_inst->seeking_speed_handle &&
-	    cur_mcs_inst->seeking_speed_sub_params.value &&
-	    cur_mcs_inst->seeking_speed_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->seeking_speed_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->seeking_speed_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-
+	if (mcs_inst->player_name_handle &&
+	    mcs_inst->player_name_sub_params.value &&
+	    mcs_inst->player_name_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->player_name_sub_params;
+		handle = mcs_inst->player_name_handle;
+	} else if (mcs_inst->track_changed_handle &&
+		   mcs_inst->track_changed_sub_params.value &&
+		   mcs_inst->track_changed_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->track_changed_sub_params;
+		handle = mcs_inst->track_changed_handle;
+	} else if (mcs_inst->track_title_handle &&
+		   mcs_inst->track_title_sub_params.value &&
+		   mcs_inst->track_title_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->track_title_sub_params;
+		handle = mcs_inst->track_title_handle;
+	} else if (mcs_inst->track_duration_handle &&
+		   mcs_inst->track_duration_sub_params.value &&
+		   mcs_inst->track_duration_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->track_duration_sub_params;
+		handle = mcs_inst->track_duration_handle;
+	} else if (mcs_inst->track_position_handle &&
+		   mcs_inst->track_position_sub_params.value &&
+		   mcs_inst->track_position_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->track_position_sub_params;
+		handle = mcs_inst->track_position_handle;
+	} else if (mcs_inst->playback_speed_handle &&
+		   mcs_inst->playback_speed_sub_params.value &&
+		   mcs_inst->playback_speed_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->playback_speed_sub_params;
+		handle = mcs_inst->playback_speed_handle;
+	} else if (mcs_inst->seeking_speed_handle &&
+		   mcs_inst->seeking_speed_sub_params.value &&
+		   mcs_inst->seeking_speed_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->seeking_speed_sub_params;
+		handle = mcs_inst->seeking_speed_handle;
 #ifdef CONFIG_BT_MCC_OTS
-	if (cur_mcs_inst->current_track_obj_id_handle &&
-	    cur_mcs_inst->current_track_obj_sub_params.value &&
-	    cur_mcs_inst->current_track_obj_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->current_track_obj_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->current_track_obj_id_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-
-	if (cur_mcs_inst->next_track_obj_id_handle &&
-	    cur_mcs_inst->next_track_obj_sub_params.value &&
-	    cur_mcs_inst->next_track_obj_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->next_track_obj_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->next_track_obj_id_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-
-	if (cur_mcs_inst->parent_group_obj_id_handle &&
-	    cur_mcs_inst->parent_group_obj_sub_params.value &&
-	    cur_mcs_inst->parent_group_obj_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->parent_group_obj_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->parent_group_obj_id_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-
-	if (cur_mcs_inst->current_group_obj_id_handle &&
-	    cur_mcs_inst->current_group_obj_sub_params.value &&
-	    cur_mcs_inst->current_group_obj_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->current_group_obj_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->current_group_obj_id_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-
+	} else if (mcs_inst->current_track_obj_id_handle &&
+		   mcs_inst->current_track_obj_sub_params.value &&
+		   mcs_inst->current_track_obj_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->current_track_obj_sub_params;
+		handle = mcs_inst->current_track_obj_id_handle;
+	} else if (mcs_inst->next_track_obj_id_handle &&
+		   mcs_inst->next_track_obj_sub_params.value &&
+		   mcs_inst->next_track_obj_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->next_track_obj_sub_params;
+		handle = mcs_inst->next_track_obj_id_handle;
+	} else if (mcs_inst->parent_group_obj_id_handle &&
+		   mcs_inst->parent_group_obj_sub_params.value &&
+		   mcs_inst->parent_group_obj_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->parent_group_obj_sub_params;
+		handle = mcs_inst->parent_group_obj_id_handle;
+	} else if (mcs_inst->current_group_obj_id_handle &&
+		   mcs_inst->current_group_obj_sub_params.value &&
+		   mcs_inst->current_group_obj_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->current_group_obj_sub_params;
+		handle = mcs_inst->current_group_obj_id_handle;
 #endif /* CONFIG_BT_MCC_OTS */
-
-	if (cur_mcs_inst->playing_order_handle &&
-	    cur_mcs_inst->playing_order_sub_params.value &&
-	    cur_mcs_inst->playing_order_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->playing_order_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->playing_order_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-
-	if (cur_mcs_inst->media_state_handle &&
-	    cur_mcs_inst->media_state_sub_params.value &&
-	    cur_mcs_inst->media_state_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->media_state_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->media_state_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-
-	if (cur_mcs_inst->cp_handle &&
-	    cur_mcs_inst->cp_sub_params.value &&
-	    cur_mcs_inst->cp_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->cp_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->cp_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-
-	if (cur_mcs_inst->opcodes_supported_handle &&
-	    cur_mcs_inst->opcodes_supported_sub_params.value &&
-	    cur_mcs_inst->opcodes_supported_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->opcodes_supported_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->opcodes_supported_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
-	}
-
+	} else if (mcs_inst->playing_order_handle &&
+		   mcs_inst->playing_order_sub_params.value &&
+		   mcs_inst->playing_order_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->playing_order_sub_params;
+		handle = mcs_inst->playing_order_handle;
+	} else if (mcs_inst->media_state_handle &&
+		  mcs_inst->media_state_sub_params.value &&
+		  mcs_inst->media_state_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->media_state_sub_params;
+		handle = mcs_inst->media_state_handle;
+	} else if (mcs_inst->cp_handle &&
+		   mcs_inst->cp_sub_params.value &&
+		   mcs_inst->cp_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->cp_sub_params;
+		handle = mcs_inst->cp_handle;
+	} else if (mcs_inst->opcodes_supported_handle &&
+		   mcs_inst->opcodes_supported_sub_params.value &&
+		   mcs_inst->opcodes_supported_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->opcodes_supported_sub_params;
+		handle = mcs_inst->opcodes_supported_handle;
 #ifdef CONFIG_BT_MCC_OTS
-	if (cur_mcs_inst->scp_handle &&
-	    cur_mcs_inst->scp_sub_params.value &&
-	    cur_mcs_inst->scp_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->scp_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->scp_handle, sub_params);
-		if (err) {
-			BT_DBG("Could not subscribe: %d", err);
-			discovery_complete(conn, err);
-		}
-		return false;
+	} else if (mcs_inst->scp_handle &&
+		   mcs_inst->scp_sub_params.value &&
+		   mcs_inst->scp_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->scp_sub_params;
+		handle = mcs_inst->scp_handle;
+	} else if (mcs_inst->search_results_obj_id_handle &&
+		   mcs_inst->search_results_obj_sub_params.value &&
+		   mcs_inst->search_results_obj_sub_params.disc_params == NULL) {
+		sub_params = &mcs_inst->search_results_obj_sub_params;
+		handle = mcs_inst->search_results_obj_id_handle;
+#endif /* CONFIG_BT_MCC_OTS */
 	}
 
-	if (cur_mcs_inst->search_results_obj_id_handle &&
-	    cur_mcs_inst->search_results_obj_sub_params.value &&
-	    cur_mcs_inst->search_results_obj_sub_params.disc_params == NULL) {
-		sub_params = &cur_mcs_inst->search_results_obj_sub_params;
-		err = do_subscribe(conn, cur_mcs_inst->search_results_obj_id_handle, sub_params);
+	if (sub_params != NULL) {
+		const int err = do_subscribe(mcs_inst, conn, handle,
+					     sub_params);
+
 		if (err) {
 			BT_DBG("Could not subscribe: %d", err);
 			discovery_complete(conn, err);
 		}
+
 		return false;
 	}
-#endif /* CONFIG_BT_MCC_OTS */
 
 	/* If we have come here, there are no more characteristics to
 	 * subscribe to, and we are done.
@@ -1516,6 +1455,9 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 				      const struct bt_gatt_attr *attr,
 				      struct bt_gatt_discover_params *params)
 {
+	struct mcs_instance_t *mcs_inst = CONTAINER_OF(params,
+						       struct mcs_instance_t,
+						       discover_params);
 	struct bt_gatt_chrc *chrc;
 	bool subscription_done = true;
 
@@ -1534,151 +1476,151 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 
 		if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PLAYER_NAME)) {
 			BT_DBG("Player name, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->player_name_handle = chrc->value_handle;
+			mcs_inst->player_name_handle = chrc->value_handle;
 			/* Use discovery params pointer as subscription flag */
-			cur_mcs_inst->player_name_sub_params.disc_params = NULL;
+			mcs_inst->player_name_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->player_name_sub_params.value = BT_GATT_CCC_NOTIFY;
+				mcs_inst->player_name_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
 #ifdef CONFIG_BT_MCC_OTS
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_ICON_OBJ_ID)) {
 			BT_DBG("Icon Object, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->icon_obj_id_handle = chrc->value_handle;
+			mcs_inst->icon_obj_id_handle = chrc->value_handle;
 #endif /* CONFIG_BT_MCC_OTS */
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_ICON_URL)) {
 			BT_DBG("Icon URL, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->icon_url_handle = chrc->value_handle;
+			mcs_inst->icon_url_handle = chrc->value_handle;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_CHANGED)) {
 			BT_DBG("Track Changed, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->track_changed_handle = chrc->value_handle;
-			cur_mcs_inst->track_changed_sub_params.disc_params = NULL;
+			mcs_inst->track_changed_handle = chrc->value_handle;
+			mcs_inst->track_changed_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->track_changed_sub_params.value = BT_GATT_CCC_NOTIFY;
+				mcs_inst->track_changed_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_TITLE)) {
 			BT_DBG("Track Title, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->track_title_handle = chrc->value_handle;
-			cur_mcs_inst->track_title_sub_params.disc_params = NULL;
+			mcs_inst->track_title_handle = chrc->value_handle;
+			mcs_inst->track_title_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->track_title_sub_params.value = BT_GATT_CCC_NOTIFY;
+				mcs_inst->track_title_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_DURATION)) {
 			BT_DBG("Track Duration, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->track_duration_handle = chrc->value_handle;
-			cur_mcs_inst->track_duration_sub_params.disc_params = NULL;
+			mcs_inst->track_duration_handle = chrc->value_handle;
+			mcs_inst->track_duration_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->track_duration_sub_params.value = BT_GATT_CCC_NOTIFY;
+				mcs_inst->track_duration_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_POSITION)) {
 			BT_DBG("Track Position, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->track_position_handle = chrc->value_handle;
-			cur_mcs_inst->track_position_sub_params.disc_params = NULL;
+			mcs_inst->track_position_handle = chrc->value_handle;
+			mcs_inst->track_position_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->track_position_sub_params.value = BT_GATT_CCC_NOTIFY;
+				mcs_inst->track_position_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PLAYBACK_SPEED)) {
 			BT_DBG("Playback Speed, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->playback_speed_handle = chrc->value_handle;
-			cur_mcs_inst->playback_speed_sub_params.disc_params = NULL;
+			mcs_inst->playback_speed_handle = chrc->value_handle;
+			mcs_inst->playback_speed_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->playback_speed_sub_params.value = BT_GATT_CCC_NOTIFY;
+				mcs_inst->playback_speed_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_SEEKING_SPEED)) {
 			BT_DBG("Seeking Speed, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->seeking_speed_handle = chrc->value_handle;
-			cur_mcs_inst->seeking_speed_sub_params.disc_params = NULL;
+			mcs_inst->seeking_speed_handle = chrc->value_handle;
+			mcs_inst->seeking_speed_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->seeking_speed_sub_params.value = BT_GATT_CCC_NOTIFY;
+				mcs_inst->seeking_speed_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
 #ifdef CONFIG_BT_MCC_OTS
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_SEGMENTS_OBJ_ID)) {
 			BT_DBG("Track Segments Object, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->segments_obj_id_handle = chrc->value_handle;
+			mcs_inst->segments_obj_id_handle = chrc->value_handle;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_CURRENT_TRACK_OBJ_ID)) {
 			BT_DBG("Current Track Object, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->current_track_obj_id_handle = chrc->value_handle;
-			cur_mcs_inst->current_track_obj_sub_params.disc_params = NULL;
+			mcs_inst->current_track_obj_id_handle = chrc->value_handle;
+			mcs_inst->current_track_obj_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->current_track_obj_sub_params.value =
+				mcs_inst->current_track_obj_sub_params.value =
 					BT_GATT_CCC_NOTIFY;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_NEXT_TRACK_OBJ_ID)) {
 			BT_DBG("Next Track Object, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->next_track_obj_id_handle = chrc->value_handle;
-			cur_mcs_inst->next_track_obj_sub_params.disc_params = NULL;
+			mcs_inst->next_track_obj_id_handle = chrc->value_handle;
+			mcs_inst->next_track_obj_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->next_track_obj_sub_params.value = BT_GATT_CCC_NOTIFY;
+				mcs_inst->next_track_obj_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PARENT_GROUP_OBJ_ID)) {
 			BT_DBG("Parent Group Object, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->parent_group_obj_id_handle = chrc->value_handle;
-			cur_mcs_inst->parent_group_obj_sub_params.disc_params = NULL;
+			mcs_inst->parent_group_obj_id_handle = chrc->value_handle;
+			mcs_inst->parent_group_obj_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->parent_group_obj_sub_params.value =
+				mcs_inst->parent_group_obj_sub_params.value =
 					BT_GATT_CCC_NOTIFY;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_CURRENT_GROUP_OBJ_ID)) {
 			BT_DBG("Group Object, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->current_group_obj_id_handle = chrc->value_handle;
-			cur_mcs_inst->current_group_obj_sub_params.disc_params = NULL;
+			mcs_inst->current_group_obj_id_handle = chrc->value_handle;
+			mcs_inst->current_group_obj_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->current_group_obj_sub_params.value =
+				mcs_inst->current_group_obj_sub_params.value =
 					BT_GATT_CCC_NOTIFY;
 			}
 #endif /* CONFIG_BT_MCC_OTS */
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PLAYING_ORDER)) {
 			BT_DBG("Playing Order, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->playing_order_handle = chrc->value_handle;
-			cur_mcs_inst->playing_order_sub_params.disc_params = NULL;
+			mcs_inst->playing_order_handle = chrc->value_handle;
+			mcs_inst->playing_order_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->playing_order_sub_params.value = BT_GATT_CCC_NOTIFY;
+				mcs_inst->playing_order_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PLAYING_ORDERS)) {
 			BT_DBG("Playing Orders supported, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->playing_orders_supported_handle = chrc->value_handle;
+			mcs_inst->playing_orders_supported_handle = chrc->value_handle;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_MEDIA_STATE)) {
 			BT_DBG("Media State, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->media_state_handle = chrc->value_handle;
-			cur_mcs_inst->media_state_sub_params.disc_params = NULL;
+			mcs_inst->media_state_handle = chrc->value_handle;
+			mcs_inst->media_state_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->media_state_sub_params.value = BT_GATT_CCC_NOTIFY;
+				mcs_inst->media_state_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_MEDIA_CONTROL_POINT)) {
 			BT_DBG("Media Control Point, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->cp_handle = chrc->value_handle;
-			cur_mcs_inst->cp_sub_params.disc_params = NULL;
+			mcs_inst->cp_handle = chrc->value_handle;
+			mcs_inst->cp_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->cp_sub_params.value = BT_GATT_CCC_NOTIFY;
+				mcs_inst->cp_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_MEDIA_CONTROL_OPCODES)) {
 			BT_DBG("Media control opcodes supported, UUID: %s",
 			       bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->opcodes_supported_handle = chrc->value_handle;
-			cur_mcs_inst->opcodes_supported_sub_params.disc_params = NULL;
+			mcs_inst->opcodes_supported_handle = chrc->value_handle;
+			mcs_inst->opcodes_supported_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->opcodes_supported_sub_params.value =
+				mcs_inst->opcodes_supported_sub_params.value =
 					BT_GATT_CCC_NOTIFY;
 			}
 #ifdef CONFIG_BT_MCC_OTS
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_SEARCH_CONTROL_POINT)) {
 			BT_DBG("Search control point, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->scp_handle = chrc->value_handle;
-			cur_mcs_inst->scp_sub_params.disc_params = NULL;
+			mcs_inst->scp_handle = chrc->value_handle;
+			mcs_inst->scp_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->scp_sub_params.value = BT_GATT_CCC_NOTIFY;
+				mcs_inst->scp_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_SEARCH_RESULTS_OBJ_ID)) {
 			BT_DBG("Search Results object, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->search_results_obj_id_handle = chrc->value_handle;
-			cur_mcs_inst->search_results_obj_sub_params.disc_params = NULL;
+			mcs_inst->search_results_obj_id_handle = chrc->value_handle;
+			mcs_inst->search_results_obj_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				cur_mcs_inst->search_results_obj_sub_params.value =
+				mcs_inst->search_results_obj_sub_params.value =
 					BT_GATT_CCC_NOTIFY;
 			}
 #endif /* CONFIG_BT_MCC_OTS */
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_CCID)) {
 			BT_DBG("Content Control ID, UUID: %s", bt_uuid_str(chrc->uuid));
-			cur_mcs_inst->content_control_id_handle = chrc->value_handle;
+			mcs_inst->content_control_id_handle = chrc->value_handle;
 		}
 
 
@@ -1696,14 +1638,14 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 	 * to avoid queuing many ATT requests that requires buffers.
 	 */
 	if (subscribe_all) {
-		subscription_done = subscribe_next_mcs_char(conn);
+		subscription_done = subscribe_next_mcs_char(mcs_inst, conn);
 	}
 
 	if (subscription_done) {
 		/* Not subscribing, or there was nothing to subscribe to */
 #ifdef CONFIG_BT_MCC_OTS
 		/* Start discovery of included services to find OTS */
-		discover_included(conn);
+		discover_included(mcs_inst, conn);
 #else
 		/* If OTS is not configured, discovery ends here */
 		discovery_complete(conn, 0);
@@ -1724,6 +1666,9 @@ static uint8_t discover_primary_func(struct bt_conn *conn,
 	struct bt_gatt_service_val *prim_service;
 
 	if (attr) {
+		struct mcs_instance_t *mcs_inst = CONTAINER_OF(params,
+							       struct mcs_instance_t,
+							       discover_params);
 		int err;
 		/* Found an attribute */
 		BT_DBG("[ATTRIBUTE] handle 0x%04X", attr->handle);
@@ -1741,19 +1686,18 @@ static uint8_t discover_primary_func(struct bt_conn *conn,
 		prim_service = (struct bt_gatt_service_val *)attr->user_data;
 		BT_DBG("UUID: %s", bt_uuid_str(prim_service->uuid));
 
-		cur_mcs_inst = &mcs_inst;
-		cur_mcs_inst->start_handle = attr->handle + 1;
-		cur_mcs_inst->end_handle = prim_service->end_handle;
+		mcs_inst->start_handle = attr->handle + 1;
+		mcs_inst->end_handle = prim_service->end_handle;
 
 		/* Start discovery of characteristics */
-		discover_params.uuid = NULL;
-		discover_params.start_handle = cur_mcs_inst->start_handle;
-		discover_params.end_handle = cur_mcs_inst->end_handle;
-		discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
-		discover_params.func = discover_mcs_char_func;
+		mcs_inst->discover_params.uuid = NULL;
+		mcs_inst->discover_params.start_handle = mcs_inst->start_handle;
+		mcs_inst->discover_params.end_handle = mcs_inst->end_handle;
+		mcs_inst->discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
+		mcs_inst->discover_params.func = discover_mcs_char_func;
 
 		BT_DBG("Start discovery of GMCS characteristics");
-		err = bt_gatt_discover(conn, &discover_params);
+		err = bt_gatt_discover(conn, &mcs_inst->discover_params);
 		if (err) {
 			BT_DBG("Discovery failed: %d", err);
 			discovery_complete(conn, err);
@@ -1763,7 +1707,7 @@ static uint8_t discover_primary_func(struct bt_conn *conn,
 
 	/* No attribute of the searched for type found */
 	BT_DBG("Could not find an GMCS instance on the server");
-	cur_mcs_inst = NULL;
+
 	discovery_complete(conn, -ENODATA);
 	return BT_GATT_ITER_STOP;
 }
@@ -1804,51 +1748,70 @@ int bt_mcc_init(struct bt_mcc_cb *cb)
  */
 int bt_mcc_discover_mcs(struct bt_conn *conn, bool subscribe)
 {
+	struct mcs_instance_t *mcs_inst;
+
 	CHECKIF(!conn) {
 		return -EINVAL;
-	} else if (cur_mcs_inst) {
+	}
+
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		/* TODO: Need to find existing or new MCS instance here */
+		return -EINVAL;
+	}
+
+	if (mcs_inst->busy) {
 		return -EBUSY;
 	}
 
 	subscribe_all = subscribe;
-	memset(&discover_params, 0, sizeof(discover_params));
-	memset(&mcs_inst, 0, sizeof(mcs_inst));
+	memset(mcs_inst, 0, sizeof(*mcs_inst));
 	(void)memcpy(&uuid, BT_UUID_GMCS, sizeof(uuid));
 
-	discover_params.func = discover_primary_func;
-	discover_params.uuid = &uuid.uuid;
-	discover_params.type = BT_GATT_DISCOVER_PRIMARY;
-	discover_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
-	discover_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
+	mcs_inst->discover_params.func = discover_primary_func;
+	mcs_inst->discover_params.uuid = &uuid.uuid;
+	mcs_inst->discover_params.type = BT_GATT_DISCOVER_PRIMARY;
+	mcs_inst->discover_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
+	mcs_inst->discover_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 
 	BT_DBG("start discovery of GMCS primary service");
-	return bt_gatt_discover(conn, &discover_params);
+	return bt_gatt_discover(conn, &mcs_inst->discover_params);
 }
-
 
 int bt_mcc_read_player_name(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->player_name_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->player_name_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_player_name_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->player_name_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_player_name_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->player_name_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
@@ -1857,27 +1820,38 @@ int bt_mcc_read_player_name(struct bt_conn *conn)
 #ifdef CONFIG_BT_MCC_OTS
 int bt_mcc_read_icon_obj_id(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->icon_obj_id_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->icon_obj_id_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_icon_obj_id_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->icon_obj_id_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_icon_obj_id_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->icon_obj_id_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
@@ -1885,226 +1859,314 @@ int bt_mcc_read_icon_obj_id(struct bt_conn *conn)
 
 int bt_mcc_read_icon_url(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->icon_url_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->icon_url_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_icon_url_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->icon_url_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_icon_url_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->icon_url_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_read_track_title(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->track_title_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->track_title_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_track_title_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->track_title_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_track_title_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->track_title_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_read_track_duration(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->track_duration_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->track_duration_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_track_duration_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->track_duration_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_track_duration_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->track_duration_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_read_track_position(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->track_position_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->track_position_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_track_position_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->track_position_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_track_position_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->track_position_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_set_track_position(struct bt_conn *conn, int32_t pos)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->track_position_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->track_position_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	(void)memcpy(cur_mcs_inst->write_buf, &pos, sizeof(pos));
+	(void)memcpy(mcs_inst->write_buf, &pos, sizeof(pos));
 
-	cur_mcs_inst->write_params.offset = 0;
-	cur_mcs_inst->write_params.data = cur_mcs_inst->write_buf;
-	cur_mcs_inst->write_params.length = sizeof(pos);
-	cur_mcs_inst->write_params.handle = cur_mcs_inst->track_position_handle;
-	cur_mcs_inst->write_params.func = mcs_write_track_position_cb;
+	mcs_inst->write_params.offset = 0;
+	mcs_inst->write_params.data = mcs_inst->write_buf;
+	mcs_inst->write_params.length = sizeof(pos);
+	mcs_inst->write_params.handle = mcs_inst->track_position_handle;
+	mcs_inst->write_params.func = mcs_write_track_position_cb;
 
-	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, sizeof(pos), "Track position sent");
+	LOG_HEXDUMP_DBG(mcs_inst->write_params.data, sizeof(pos), "Track position sent");
 
-	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
+	err = bt_gatt_write(conn, &mcs_inst->write_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_read_playback_speed(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->playback_speed_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->playback_speed_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_playback_speed_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->playback_speed_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_playback_speed_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->playback_speed_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_set_playback_speed(struct bt_conn *conn, int8_t speed)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->playback_speed_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->playback_speed_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	(void)memcpy(cur_mcs_inst->write_buf, &speed, sizeof(speed));
+	(void)memcpy(mcs_inst->write_buf, &speed, sizeof(speed));
 
-	cur_mcs_inst->write_params.offset = 0;
-	cur_mcs_inst->write_params.data = cur_mcs_inst->write_buf;
-	cur_mcs_inst->write_params.length = sizeof(speed);
-	cur_mcs_inst->write_params.handle = cur_mcs_inst->playback_speed_handle;
-	cur_mcs_inst->write_params.func = mcs_write_playback_speed_cb;
+	mcs_inst->write_params.offset = 0;
+	mcs_inst->write_params.data = mcs_inst->write_buf;
+	mcs_inst->write_params.length = sizeof(speed);
+	mcs_inst->write_params.handle = mcs_inst->playback_speed_handle;
+	mcs_inst->write_params.func = mcs_write_playback_speed_cb;
 
-	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, sizeof(speed), "Playback speed");
+	LOG_HEXDUMP_DBG(mcs_inst->write_params.data, sizeof(speed), "Playback speed");
 
-	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
+	err = bt_gatt_write(conn, &mcs_inst->write_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_read_seeking_speed(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->seeking_speed_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->seeking_speed_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_seeking_speed_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->seeking_speed_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_seeking_speed_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->seeking_speed_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
@@ -2112,243 +2174,331 @@ int bt_mcc_read_seeking_speed(struct bt_conn *conn)
 #ifdef CONFIG_BT_MCC_OTS
 int bt_mcc_read_segments_obj_id(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->segments_obj_id_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->segments_obj_id_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_segments_obj_id_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->segments_obj_id_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_segments_obj_id_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->segments_obj_id_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_read_current_track_obj_id(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->current_track_obj_id_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->current_track_obj_id_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_current_track_obj_id_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->current_track_obj_id_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_current_track_obj_id_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->current_track_obj_id_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_set_current_track_obj_id(struct bt_conn *conn, uint64_t obj_id)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
 	CHECKIF(obj_id < BT_OTS_OBJ_ID_MIN || obj_id > BT_OTS_OBJ_ID_MAX) {
-		BT_DBG("Object ID invalid");
+		BT_DBG("Object ID 0x%016x invalid", obj_id);
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->current_track_obj_id_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->current_track_obj_id_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	sys_put_le48(obj_id, cur_mcs_inst->write_buf);
-	cur_mcs_inst->write_params.offset = 0;
-	cur_mcs_inst->write_params.data = cur_mcs_inst->write_buf;
-	cur_mcs_inst->write_params.length = BT_OTS_OBJ_ID_SIZE;
-	cur_mcs_inst->write_params.handle = cur_mcs_inst->current_track_obj_id_handle;
-	cur_mcs_inst->write_params.func = mcs_write_current_track_obj_id_cb;
+	sys_put_le48(obj_id, mcs_inst->write_buf);
+	mcs_inst->write_params.offset = 0;
+	mcs_inst->write_params.data = mcs_inst->write_buf;
+	mcs_inst->write_params.length = BT_OTS_OBJ_ID_SIZE;
+	mcs_inst->write_params.handle = mcs_inst->current_track_obj_id_handle;
+	mcs_inst->write_params.func = mcs_write_current_track_obj_id_cb;
 
-	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, BT_OTS_OBJ_ID_SIZE, "Object Id");
+	LOG_HEXDUMP_DBG(mcs_inst->write_params.data, BT_OTS_OBJ_ID_SIZE, "Object Id");
 
-	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
+	err = bt_gatt_write(conn, &mcs_inst->write_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_read_next_track_obj_id(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->next_track_obj_id_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->next_track_obj_id_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_next_track_obj_id_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->next_track_obj_id_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_next_track_obj_id_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->next_track_obj_id_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_set_next_track_obj_id(struct bt_conn *conn, uint64_t obj_id)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
 	CHECKIF(obj_id < BT_OTS_OBJ_ID_MIN || obj_id > BT_OTS_OBJ_ID_MAX) {
-		BT_DBG("Object ID invalid");
+		BT_DBG("Object ID 0x%016x invalid", obj_id);
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->next_track_obj_id_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->next_track_obj_id_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	sys_put_le48(obj_id, cur_mcs_inst->write_buf);
-	cur_mcs_inst->write_params.offset = 0;
-	cur_mcs_inst->write_params.data = cur_mcs_inst->write_buf;
-	cur_mcs_inst->write_params.length = BT_OTS_OBJ_ID_SIZE;
-	cur_mcs_inst->write_params.handle = cur_mcs_inst->next_track_obj_id_handle;
-	cur_mcs_inst->write_params.func = mcs_write_next_track_obj_id_cb;
+	sys_put_le48(obj_id, mcs_inst->write_buf);
+	mcs_inst->write_params.offset = 0;
+	mcs_inst->write_params.data = mcs_inst->write_buf;
+	mcs_inst->write_params.length = BT_OTS_OBJ_ID_SIZE;
+	mcs_inst->write_params.handle = mcs_inst->next_track_obj_id_handle;
+	mcs_inst->write_params.func = mcs_write_next_track_obj_id_cb;
 
-	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, BT_OTS_OBJ_ID_SIZE, "Object Id");
+	LOG_HEXDUMP_DBG(mcs_inst->write_params.data, BT_OTS_OBJ_ID_SIZE, "Object Id");
 
-	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
+	err = bt_gatt_write(conn, &mcs_inst->write_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_read_parent_group_obj_id(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->parent_group_obj_id_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->parent_group_obj_id_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_parent_group_obj_id_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->parent_group_obj_id_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_parent_group_obj_id_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->parent_group_obj_id_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_read_current_group_obj_id(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->current_group_obj_id_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->current_group_obj_id_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_current_group_obj_id_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->current_group_obj_id_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_current_group_obj_id_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->current_group_obj_id_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_set_current_group_obj_id(struct bt_conn *conn, uint64_t obj_id)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
 	CHECKIF(obj_id < BT_OTS_OBJ_ID_MIN || obj_id > BT_OTS_OBJ_ID_MAX) {
-		BT_DBG("Object ID invalid");
+		BT_DBG("Object ID 0x%016x invalid", obj_id);
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->current_group_obj_id_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->current_group_obj_id_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	sys_put_le48(obj_id, cur_mcs_inst->write_buf);
-	cur_mcs_inst->write_params.offset = 0;
-	cur_mcs_inst->write_params.data = cur_mcs_inst->write_buf;
-	cur_mcs_inst->write_params.length = BT_OTS_OBJ_ID_SIZE;
-	cur_mcs_inst->write_params.handle = cur_mcs_inst->current_group_obj_id_handle;
-	cur_mcs_inst->write_params.func = mcs_write_current_group_obj_id_cb;
+	sys_put_le48(obj_id, mcs_inst->write_buf);
+	mcs_inst->write_params.offset = 0;
+	mcs_inst->write_params.data = mcs_inst->write_buf;
+	mcs_inst->write_params.length = BT_OTS_OBJ_ID_SIZE;
+	mcs_inst->write_params.handle = mcs_inst->current_group_obj_id_handle;
+	mcs_inst->write_params.func = mcs_write_current_group_obj_id_cb;
 
-	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, BT_OTS_OBJ_ID_SIZE, "Object Id");
+	LOG_HEXDUMP_DBG(mcs_inst->write_params.data, BT_OTS_OBJ_ID_SIZE, "Object Id");
 
-	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
+	err = bt_gatt_write(conn, &mcs_inst->write_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
@@ -2356,178 +2506,245 @@ int bt_mcc_set_current_group_obj_id(struct bt_conn *conn, uint64_t obj_id)
 
 int bt_mcc_read_playing_order(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->playing_order_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->playing_order_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_playing_order_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->playing_order_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_playing_order_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->playing_order_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_set_playing_order(struct bt_conn *conn, uint8_t order)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->playing_order_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->playing_order_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	(void)memcpy(cur_mcs_inst->write_buf, &order, sizeof(order));
+	(void)memcpy(mcs_inst->write_buf, &order, sizeof(order));
 
-	cur_mcs_inst->write_params.offset = 0;
-	cur_mcs_inst->write_params.data = cur_mcs_inst->write_buf;
-	cur_mcs_inst->write_params.length = sizeof(order);
-	cur_mcs_inst->write_params.handle = cur_mcs_inst->playing_order_handle;
-	cur_mcs_inst->write_params.func = mcs_write_playing_order_cb;
+	mcs_inst->write_params.offset = 0;
+	mcs_inst->write_params.data = mcs_inst->write_buf;
+	mcs_inst->write_params.length = sizeof(order);
+	mcs_inst->write_params.handle = mcs_inst->playing_order_handle;
+	mcs_inst->write_params.func = mcs_write_playing_order_cb;
 
-	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, sizeof(order), "Playing order");
+	LOG_HEXDUMP_DBG(mcs_inst->write_params.data, sizeof(order), "Playing order");
 
-	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
+	err = bt_gatt_write(conn, &mcs_inst->write_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_read_playing_orders_supported(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->playing_orders_supported_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->playing_orders_supported_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_playing_orders_supported_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->playing_orders_supported_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_playing_orders_supported_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->playing_orders_supported_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_read_media_state(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->media_state_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->media_state_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_media_state_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->media_state_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_media_state_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->media_state_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_send_cmd(struct bt_conn *conn, const struct mpl_cmd *cmd)
 {
+	struct mcs_instance_t *mcs_inst;
+	size_t length;
 	int err;
-	int length = sizeof(cmd->opcode);
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->cp_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->cp_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	(void)memcpy(cur_mcs_inst->write_buf, &cmd->opcode, length);
+	length = sizeof(cmd->opcode);
+	(void)memcpy(mcs_inst->write_buf, &cmd->opcode, length);
 	if (cmd->use_param) {
 		length += sizeof(cmd->param);
-		(void)memcpy(&cur_mcs_inst->write_buf[sizeof(cmd->opcode)], &cmd->param,
+		(void)memcpy(&mcs_inst->write_buf[sizeof(cmd->opcode)], &cmd->param,
 		       sizeof(cmd->param));
 	}
 
-	cur_mcs_inst->write_params.offset = 0;
-	cur_mcs_inst->write_params.data = cur_mcs_inst->write_buf;
-	cur_mcs_inst->write_params.length = length;
-	cur_mcs_inst->write_params.handle = cur_mcs_inst->cp_handle;
-	cur_mcs_inst->write_params.func = mcs_write_cp_cb;
+	mcs_inst->write_params.offset = 0;
+	mcs_inst->write_params.data = mcs_inst->write_buf;
+	mcs_inst->write_params.length = length;
+	mcs_inst->write_params.handle = mcs_inst->cp_handle;
+	mcs_inst->write_params.func = mcs_write_cp_cb;
 
-	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, sizeof(*cmd), "Command sent");
+	LOG_HEXDUMP_DBG(mcs_inst->write_params.data, sizeof(*cmd), "Command sent");
 
-	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
+	err = bt_gatt_write(conn, &mcs_inst->write_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_read_opcodes_supported(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->opcodes_supported_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->opcodes_supported_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_opcodes_supported_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->opcodes_supported_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_opcodes_supported_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->opcodes_supported_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
@@ -2535,59 +2752,81 @@ int bt_mcc_read_opcodes_supported(struct bt_conn *conn)
 #ifdef CONFIG_BT_MCC_OTS
 int bt_mcc_send_search(struct bt_conn *conn, const struct mpl_search *search)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->scp_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->scp_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	(void)memcpy(cur_mcs_inst->write_buf, &search->search, search->len);
+	(void)memcpy(mcs_inst->write_buf, &search->search, search->len);
 
-	cur_mcs_inst->write_params.offset = 0;
-	cur_mcs_inst->write_params.data = cur_mcs_inst->write_buf;
-	cur_mcs_inst->write_params.length = search->len;
-	cur_mcs_inst->write_params.handle = cur_mcs_inst->scp_handle;
-	cur_mcs_inst->write_params.func = mcs_write_scp_cb;
+	mcs_inst->write_params.offset = 0;
+	mcs_inst->write_params.data = mcs_inst->write_buf;
+	mcs_inst->write_params.length = search->len;
+	mcs_inst->write_params.handle = mcs_inst->scp_handle;
+	mcs_inst->write_params.func = mcs_write_scp_cb;
 
-	LOG_HEXDUMP_DBG(cur_mcs_inst->write_params.data, search->len, "Search sent");
+	LOG_HEXDUMP_DBG(mcs_inst->write_params.data, search->len, "Search sent");
 
-	err = bt_gatt_write(conn, &cur_mcs_inst->write_params);
+	err = bt_gatt_write(conn, &mcs_inst->write_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
 
 int bt_mcc_read_search_results_obj_id(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->search_results_obj_id_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->search_results_obj_id_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_search_results_obj_id_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->search_results_obj_id_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_search_results_obj_id_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->search_results_obj_id_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
@@ -2595,27 +2834,38 @@ int bt_mcc_read_search_results_obj_id(struct bt_conn *conn)
 
 int bt_mcc_read_content_control_id(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	if (!cur_mcs_inst->content_control_id_handle) {
-		BT_DBG("Handle not set");
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
 		return -EINVAL;
-	} else if (cur_mcs_inst->busy) {
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
 		return -EBUSY;
+	} else if (mcs_inst->content_control_id_handle == 0) {
+		BT_DBG("handle not set");
+
+		return -EINVAL;
 	}
 
-	read_params.func = mcc_read_content_control_id_cb;
-	read_params.handle_count = 1;
-	read_params.single.handle = cur_mcs_inst->content_control_id_handle;
-	read_params.single.offset = 0U;
+	mcs_inst->read_params.func = mcc_read_content_control_id_cb;
+	mcs_inst->read_params.handle_count = 1;
+	mcs_inst->read_params.single.handle = mcs_inst->content_control_id_handle;
+	mcs_inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(conn, &read_params);
+	err = bt_gatt_read(conn, &mcs_inst->read_params);
 	if (!err) {
-		cur_mcs_inst->busy = true;
+		mcs_inst->busy = true;
 	}
 	return err;
 }
@@ -2973,13 +3223,27 @@ void on_object_metadata(struct bt_ots_client *otc_inst,
 
 int bt_mcc_otc_read_object_metadata(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
 
-	err = bt_ots_client_read_object_metadata(&cur_mcs_inst->otc, conn,
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
+		return -EINVAL;
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
+		return -EBUSY;
+	}
+
+	err = bt_ots_client_read_object_metadata(&mcs_inst->otc, conn,
 						 BT_OTS_METADATA_REQ_ALL);
 	if (err) {
 		BT_DBG("Error reading the object: %d", err);
@@ -2991,16 +3255,29 @@ int bt_mcc_otc_read_object_metadata(struct bt_conn *conn)
 
 int bt_mcc_otc_read_icon_object(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
-	/* TODO: Add handling for busy - either MCS or OTS */
 
-	cur_mcs_inst->otc.cb->obj_data_read = on_icon_content;
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
 
-	err = bt_ots_client_read_object_data(&cur_mcs_inst->otc, conn);
+		return -EINVAL;
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
+		return -EBUSY;
+	}
+
+	mcs_inst->otc.cb->obj_data_read = on_icon_content;
+
+	err = bt_ots_client_read_object_data(&mcs_inst->otc, conn);
 	if (err) {
 		BT_DBG("Error reading the object: %d", err);
 	}
@@ -3010,17 +3287,30 @@ int bt_mcc_otc_read_icon_object(struct bt_conn *conn)
 
 int bt_mcc_otc_read_track_segments_object(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
-	/* TODO: Add handling for busy - either MCS or OTS */
+
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
+		return -EINVAL;
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
+		return -EBUSY;
+	}
 
 	/* TODO: Assumes object is already selected */
-	cur_mcs_inst->otc.cb->obj_data_read = on_track_segments_content;
+	mcs_inst->otc.cb->obj_data_read = on_track_segments_content;
 
-	err = bt_ots_client_read_object_data(&cur_mcs_inst->otc, conn);
+	err = bt_ots_client_read_object_data(&mcs_inst->otc, conn);
 	if (err) {
 		BT_DBG("Error reading the object: %d", err);
 	}
@@ -3030,17 +3320,30 @@ int bt_mcc_otc_read_track_segments_object(struct bt_conn *conn)
 
 int bt_mcc_otc_read_current_track_object(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
-	/* TODO: Add handling for busy - either MCS or OTS */
+
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
+		return -EINVAL;
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
+		return -EBUSY;
+	}
 
 	/* TODO: Assumes object is already selected */
-	cur_mcs_inst->otc.cb->obj_data_read = on_current_track_content;
+	mcs_inst->otc.cb->obj_data_read = on_current_track_content;
 
-	err = bt_ots_client_read_object_data(&cur_mcs_inst->otc, conn);
+	err = bt_ots_client_read_object_data(&mcs_inst->otc, conn);
 	if (err) {
 		BT_DBG("Error reading the object: %d", err);
 	}
@@ -3050,17 +3353,30 @@ int bt_mcc_otc_read_current_track_object(struct bt_conn *conn)
 
 int bt_mcc_otc_read_next_track_object(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
-	/* TODO: Add handling for busy - either MCS or OTS */
+
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
+		return -EINVAL;
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
+		return -EBUSY;
+	}
 
 	/* TODO: Assumes object is already selected */
-	cur_mcs_inst->otc.cb->obj_data_read = on_next_track_content;
+	mcs_inst->otc.cb->obj_data_read = on_next_track_content;
 
-	err = bt_ots_client_read_object_data(&cur_mcs_inst->otc, conn);
+	err = bt_ots_client_read_object_data(&mcs_inst->otc, conn);
 	if (err) {
 		BT_DBG("Error reading the object: %d", err);
 	}
@@ -3070,19 +3386,32 @@ int bt_mcc_otc_read_next_track_object(struct bt_conn *conn)
 
 int bt_mcc_otc_read_parent_group_object(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
-	/* TODO: Add handling for busy - either MCS or OTS */
+
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
+		return -EINVAL;
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
+		return -EBUSY;
+	}
 
 	/* TODO: Assumes object is already selected */
 
 	/* Reuse callback for current group */
-	cur_mcs_inst->otc.cb->obj_data_read = on_parent_group_content;
+	mcs_inst->otc.cb->obj_data_read = on_parent_group_content;
 
-	err = bt_ots_client_read_object_data(&cur_mcs_inst->otc, conn);
+	err = bt_ots_client_read_object_data(&mcs_inst->otc, conn);
 	if (err) {
 		BT_DBG("Error reading the object: %d", err);
 	}
@@ -3092,17 +3421,30 @@ int bt_mcc_otc_read_parent_group_object(struct bt_conn *conn)
 
 int bt_mcc_otc_read_current_group_object(struct bt_conn *conn)
 {
+	struct mcs_instance_t *mcs_inst;
 	int err;
 
-	CHECKIF(!conn || !cur_mcs_inst) {
+	CHECKIF(conn == NULL) {
+		BT_DBG("conn is NULL");
+
 		return -EINVAL;
 	}
-	/* TODO: Add handling for busy - either MCS or OTS */
+
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+
+		return -EINVAL;
+	} else if (mcs_inst->busy) {
+
+		BT_DBG("mcs_inst busy");
+		return -EBUSY;
+	}
 
 	/* TODO: Assumes object is already selected */
-	cur_mcs_inst->otc.cb->obj_data_read = on_current_group_content;
+	mcs_inst->otc.cb->obj_data_read = on_current_group_content;
 
-	err = bt_ots_client_read_object_data(&cur_mcs_inst->otc, conn);
+	err = bt_ots_client_read_object_data(&mcs_inst->otc, conn);
 	if (err) {
 		BT_DBG("Error reading the object: %d", err);
 	}
@@ -3111,9 +3453,16 @@ int bt_mcc_otc_read_current_group_object(struct bt_conn *conn)
 }
 
 #if defined(CONFIG_BT_MCC_SHELL)
-struct bt_ots_client *bt_mcc_otc_inst(void)
+struct bt_ots_client *bt_mcc_otc_inst(struct bt_conn *conn)
 {
-	return &cur_mcs_inst->otc;
+	struct mcs_instance_t *mcs_inst;
+
+	mcs_inst = lookup_inst_by_conn(conn);
+	if (mcs_inst == NULL) {
+		return NULL;
+	}
+
+	return &mcs_inst->otc;
 }
 #endif /* defined(CONFIG_BT_MCC_SHELL) */
 

--- a/subsys/bluetooth/shell/mcc.c
+++ b/subsys/bluetooth/shell/mcc.c
@@ -1164,7 +1164,8 @@ int cmd_mcc_otc_read_features(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	result = bt_ots_client_read_feature(bt_mcc_otc_inst(), default_conn);
+	result = bt_ots_client_read_feature(bt_mcc_otc_inst(default_conn),
+					    default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -1175,7 +1176,8 @@ int cmd_mcc_otc_read(const struct shell *sh, size_t argc, char *argv[])
 {
 	int result;
 
-	result = bt_ots_client_read_object_data(bt_mcc_otc_inst(), default_conn);
+	result = bt_ots_client_read_object_data(bt_mcc_otc_inst(default_conn),
+						default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -1187,7 +1189,7 @@ int cmd_mcc_otc_read_metadata(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	result = bt_ots_client_read_object_metadata(bt_mcc_otc_inst(),
+	result = bt_ots_client_read_object_metadata(bt_mcc_otc_inst(default_conn),
 						    default_conn,
 						    BT_OTS_METADATA_REQ_ALL);
 	if (result) {
@@ -1208,7 +1210,8 @@ int cmd_mcc_otc_select(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	result = bt_ots_client_select_id(bt_mcc_otc_inst(), default_conn, id);
+	result = bt_ots_client_select_id(bt_mcc_otc_inst(default_conn),
+					 default_conn, id);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -1220,7 +1223,8 @@ int cmd_mcc_otc_select_first(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	result = bt_ots_client_select_first(bt_mcc_otc_inst(), default_conn);
+	result = bt_ots_client_select_first(bt_mcc_otc_inst(default_conn),
+					    default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -1232,7 +1236,8 @@ int cmd_mcc_otc_select_last(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	result = bt_ots_client_select_last(bt_mcc_otc_inst(), default_conn);
+	result = bt_ots_client_select_last(bt_mcc_otc_inst(default_conn),
+					   default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -1244,7 +1249,8 @@ int cmd_mcc_otc_select_next(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	result = bt_ots_client_select_next(bt_mcc_otc_inst(), default_conn);
+	result = bt_ots_client_select_next(bt_mcc_otc_inst(default_conn),
+					   default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
 	}
@@ -1256,7 +1262,8 @@ int cmd_mcc_otc_select_prev(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	result = bt_ots_client_select_prev(bt_mcc_otc_inst(), default_conn);
+	result = bt_ots_client_select_prev(bt_mcc_otc_inst(default_conn),
+					   default_conn);
 	if (result) {
 		shell_error(sh, "Fail: %d", result);
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mcc_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mcc_test.c
@@ -577,7 +577,8 @@ static void select_read_meta(int64_t id)
 
 	/* TODO: Fix the instance pointer - it is neither valid nor used */
 	UNSET_FLAG(object_selected);
-	err = bt_ots_client_select_id(bt_mcc_otc_inst(), default_conn, id);
+	err = bt_ots_client_select_id(bt_mcc_otc_inst(default_conn),
+				      default_conn, id);
 	if (err) {
 		FAIL("Failed to select object\n");
 		return;
@@ -588,7 +589,8 @@ static void select_read_meta(int64_t id)
 
 	/* TODO: Fix the instance pointer - it is neither valid nor used */
 	UNSET_FLAG(metadata_read);
-	err = bt_ots_client_read_object_metadata(bt_mcc_otc_inst(), default_conn,
+	err = bt_ots_client_read_object_metadata(bt_mcc_otc_inst(default_conn),
+						 default_conn,
 						 BT_OTS_METADATA_REQ_ALL);
 	if (err) {
 		FAIL("Failed to read object metadata\n");


### PR DESCRIPTION
Fixes a segmentation fault after reboot for the MCC as well as making it possible to call bt_mcc_discover_mcs more than once. 