### PR TITLE
tests/samples: fix some missing tags

### DIFF
--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: Counter RTC Driver Sample
 tests:
   sample.drivers.counter.alarm:
-    tags: drivers
+    tags: drivers counter
     harness: console
     platform_allow: nucleo_f746zg nrf51dk_nrf51422 nrf52dk_nrf52832
                         nrf52840dk_nrf52840 nrf9160dk_nrf9160 atsamd20_xpro

--- a/samples/drivers/i2c_fujitsu_fram/sample.yaml
+++ b/samples/drivers/i2c_fujitsu_fram/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: Demo for Fujitsu MB85RC256V FRAM (I2C)
 tests:
   sample.drivers.i2c.fujitsu_fram:
-    tags: drivers
+    tags: drivers i2c
     depends_on: i2c
     filter: dt_nodelabel_enabled("i2c0")
     harness: console

--- a/samples/drivers/kscan/sample.yaml
+++ b/samples/drivers/kscan/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: KSCAN driver sample
 tests:
   sample.drivers.kscan:
-    tags: drivers
+    tags: drivers kscan
     harness: console
     harness_config:
         type: multi_line

--- a/samples/drivers/kscan_touch/sample.yaml
+++ b/samples/drivers/kscan_touch/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: KSCAN touch driver api sample
 tests:
   sample.drivers.kscan_touch:
-    tags: drivers
+    tags: drivers kscan_touch
     harness: console
     harness_config:
         type: multi_line

--- a/samples/drivers/misc/ft800/sample.yaml
+++ b/samples/drivers/misc/ft800/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: FT800 display sample
 tests:
   sample.display.ft800:
-    tags: drivers
+    tags: drivers display
     depends_on: spi
     platform_allow: nrf52840dk_nrf52840
     extra_args: SHIELD=ftdi_vm800c

--- a/samples/drivers/misc/grove_display/sample.yaml
+++ b/samples/drivers/misc/grove_display/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: Grove LCD Sample
 tests:
   sample.drivers.misc.grove_display:
-    tags: drivers
+    tags: drivers display
     harness: grove
     depends_on: i2c
     filter: dt_compat_enabled("seeed,grove-lcd-rgb")

--- a/samples/drivers/peci/sample.yaml
+++ b/samples/drivers/peci/sample.yaml
@@ -6,7 +6,7 @@ tests:
     # but HW setup is not documented, hence qualifying as unsupported.
     platform_exclude: mec15xxevb_assy6853
     filter: dt_alias_exists("peci-0")
-    tags: drivers
+    tags: drivers peci
     harness: console
     harness_config:
         type: multi_line

--- a/samples/drivers/ps2/sample.yaml
+++ b/samples/drivers/ps2/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: PS2 driver  sample
 tests:
   sample.drivers.espi.ps2:
-    tags: drivers
+    tags: drivers ps2
     harness: console
     harness_config:
         type: multi_line

--- a/samples/sensor/adc_cmp_npcx/sample.yaml
+++ b/samples/sensor/adc_cmp_npcx/sample.yaml
@@ -5,7 +5,7 @@ common:
   platform_allow: npcx9m6f_evb
   integration_platforms:
     - npcx9m6f_evb
-  tags: drivers
+  tags: drivers adc
 tests:
   sample.sensor.adc_cmp:
     harness: console

--- a/samples/sensor/mcux_acmp/sample.yaml
+++ b/samples/sensor/mcux_acmp/sample.yaml
@@ -5,7 +5,7 @@ common:
   platform_allow: twr_ke18f mimxrt1170_evk_cm7 mimxrt1170_evk_cm4
   integration_platforms:
     - twr_ke18f
-  tags: drivers
+  tags: drivers sensor
 tests:
   sample.sensor.mcux_acmp:
     harness: console

--- a/tests/drivers/build_all/counter/testcase.yaml
+++ b/tests/drivers/build_all/counter/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   build_only: true
-  tags: drivers
+  tags: drivers counter
 tests:
   drivers.counter.build.xlnx:
     platform_allow: arty_a7_arm_designstart_m1

--- a/tests/drivers/build_all/eeprom/testcase.yaml
+++ b/tests/drivers/build_all/eeprom/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   build_only: true
-  tags: drivers
+  tags: drivers eeprom
 tests:
   drivers.eeprom.build:
     min_ram: 32

--- a/tests/drivers/build_all/ethernet/testcase.yaml
+++ b/tests/drivers/build_all/ethernet/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   build_only: true
-  tags: drivers
+  tags: drivers ethernet
 tests:
   net.ethernet.build:
     min_flash: 42

--- a/tests/drivers/build_all/gpio/testcase.yaml
+++ b/tests/drivers/build_all/gpio/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   build_only: true
-  tags: drivers
+  tags: drivers gpio
 tests:
   drivers.gpio.build:
     min_ram: 32

--- a/tests/drivers/build_all/led/testcase.yaml
+++ b/tests/drivers/build_all/led/testcase.yaml
@@ -2,4 +2,4 @@ tests:
   drivers.led.build:
     build_only: true
     min_ram: 32
-    tags: drivers
+    tags: drivers led

--- a/tests/drivers/build_all/led_strip/testcase.yaml
+++ b/tests/drivers/build_all/led_strip/testcase.yaml
@@ -2,5 +2,5 @@ tests:
   drivers.led_strip.build:
     build_only: true
     min_ram: 32
-    tags: drivers
+    tags: drivers led_strip
     depends_on: gpio spi

--- a/tests/drivers/clock_control/cavs_clock/testcase.yaml
+++ b/tests/drivers/clock_control/cavs_clock/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   drivers.clock.cavs_clock_control:
-    tags: drivers
+    tags: drivers clock
     platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20 intel_adsp_cavs25

--- a/tests/drivers/clock_control/clock_control_api/testcase.yaml
+++ b/tests/drivers/clock_control/clock_control_api/testcase.yaml
@@ -1,9 +1,9 @@
 tests:
   drivers.clock.clock_control_nrf5:
-    tags: drivers
+    tags: drivers cloc
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf9160dk_nrf9160
   drivers.clock.clock_control_nrf5_lfclk_rc:
-    tags: drivers
+    tags: drivers clock
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
     extra_args: CONF_FILE="nrf_lfclk_rc.conf"

--- a/tests/drivers/clock_control/nrf_clock_calibration/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_clock_calibration/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   drivers.clock.nrf5_clock_calibration:
-    tags: drivers
+    tags: drivers clock
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840

--- a/tests/drivers/clock_control/nrf_lf_clock_start/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_lf_clock_start/testcase.yaml
@@ -1,6 +1,7 @@
+common:
+  tags: drivers clock
 tests:
   drivers.clock.nrf_lf_clock_start_xtal_stable:
-    tags: drivers
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
                         nrf5340dk_nrf5340_cpunet
@@ -9,7 +10,6 @@ tests:
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL=y
 
   drivers.clock.nrf_lf_clock_start_xtal_available:
-    tags: drivers
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
                         nrf5340dk_nrf5340_cpunet
@@ -18,7 +18,6 @@ tests:
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL=y
 
   drivers.clock.nrf_lf_clock_start_xtal_no_wait:
-    tags: drivers
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
                         nrf5340dk_nrf5340_cpunet
@@ -27,7 +26,6 @@ tests:
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL=y
 
   drivers.clock.nrf_lf_clock_start_rc_stable:
-    tags: drivers
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpunet
     extra_configs:
@@ -35,7 +33,6 @@ tests:
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
 
   drivers.clock.nrf_lf_clock_start_rc_available:
-    tags: drivers
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpunet
     extra_configs:
@@ -43,7 +40,6 @@ tests:
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
 
   drivers.clock.nrf_lf_clock_start_rc_no_wait:
-    tags: drivers
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpunet
     extra_configs:
@@ -51,7 +47,6 @@ tests:
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
 
   drivers.clock.nrf_lf_clock_start_synth_stable:
-    tags: drivers
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpunet
     extra_configs:
@@ -59,7 +54,6 @@ tests:
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_SYNTH=y
 
   drivers.clock.nrf_lf_clock_start_synth_available:
-    tags: drivers
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpunet
     extra_configs:
@@ -67,7 +61,6 @@ tests:
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_SYNTH=y
 
   drivers.clock.nrf_lf_clock_start_synth_no_wait:
-    tags: drivers
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpunet
     extra_configs:

--- a/tests/drivers/clock_control/nrf_onoff_and_bt/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_onoff_and_bt/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   drivers.clock.nrf_onoff_and_bt:
-    tags: drivers
+    tags: drivers clock
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840

--- a/tests/drivers/clock_control/onoff/testcase.yaml
+++ b/tests/drivers/clock_control/onoff/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   drivers.clock.clock_control_onoff:
-    tags: drivers
+    tags: drivers clock
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf9160dk_nrf9160

--- a/tests/drivers/counter/counter_basic_api/testcase.yaml
+++ b/tests/drivers/counter/counter_basic_api/testcase.yaml
@@ -1,12 +1,12 @@
 tests:
   drivers.counter.basic_api:
-    tags: drivers
+    tags: drivers counter
     depends_on: counter
     min_ram: 16
     platform_exclude: nucleo_f302r8
     timeout: 600
   drivers.counter.basic_api.nrf_zli:
-    tags: drivers
+    tags: drivers counter
     depends_on: counter
     platform_allow: nrf52840dk_nrf52840
     timeout: 400

--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/testcase.yaml
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   drivers.counter.nrf_rtc:
-    tags: drivers
+    tags: drivers counter
     depends_on: counter
     platform_allow: nrf52840dk_nrf52840

--- a/tests/drivers/counter/counter_seconds/testcase.yaml
+++ b/tests/drivers/counter/counter_seconds/testcase.yaml
@@ -1,11 +1,11 @@
 tests:
   drivers.counter.cmos:
-    tags: drivers
+    tags: drivers counter
     arch_allow: x86
     extra_configs:
       - CONFIG_COUNTER_CMOS=y
     filter: CONFIG_X86_PC_COMPATIBLE
 
   drivers.counter.mcux.snvs.rtc:
-    tags: drivers
+    tags: drivers counter
     platform_allow: mimxrt1064_evk

--- a/tests/drivers/counter/maxim_ds3231_api/testcase.yaml
+++ b/tests/drivers/counter/maxim_ds3231_api/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   drivers.counter.maxim_ds3231:
-    tags: drivers
+    tags: drivers counter
     depends_on: counter i2c
     min_ram: 16
     timeout: 400

--- a/tests/drivers/flash_simulator/testcase.yaml
+++ b/tests/drivers/flash_simulator/testcase.yaml
@@ -1,16 +1,14 @@
+common:
+  tags: drivers flash
 tests:
   drivers.flash.flash_simulator:
     platform_allow: qemu_x86 native_posix native_posix_64
-    tags: drivers
   drivers.flash.flash_simulator.qemu_erase_value_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/qemu_x86_ev_0x00.overlay
     platform_allow: qemu_x86
-    tags: drivers
   drivers.flash.flash_simulator.posix_erase_value_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/native_posix_ev_0x00.overlay
     platform_allow: native_posix
-    tags: drivers
   drivers.flash.flash_simulator.posix_64_erase_value_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/native_posix_64_ev_0x00.overlay
     platform_allow: native_posix_64
-    tags: drivers

--- a/tests/drivers/hwinfo/api/testcase.yaml
+++ b/tests/drivers/hwinfo/api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   drivers.hwinfo.api:
-    tags: drivers
+    tags: drivers hwinfo

--- a/tests/drivers/mm/sys_mm_drv_api/testcase.yaml
+++ b/tests/drivers/mm/sys_mm_drv_api/testcase.yaml
@@ -1,3 +1,3 @@
 tests:
   drivers.mm.sys_mm_drv_api:
-    tags: drivers
+    tags: drivers mm

--- a/tests/drivers/timer/nrf_rtc_timer/testcase.yaml
+++ b/tests/drivers/timer/nrf_rtc_timer/testcase.yaml
@@ -1,10 +1,10 @@
 tests:
   drivers.timer.nrf_rtc_timer:
-    tags: drivers
+    tags: drivers timer
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_ZERO_LATENCY_IRQS=y
 
   drivers.timer.nrf_rtc_timer_no_zli:
-    tags: drivers
+    tags: drivers timer
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52_bsim

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -3,16 +3,14 @@ common:
     adafruit_itsybitsy_m4_express atsame54_xpro atsamd21_xpro adafruit_trinket_m0
     arduino_nano_33_iot arduino_zero atsamd21_xpro adafruit_feather_m0_basic_proto
     adafruit_feather_m0_lora arduino_mkrzero atsaml21_xpro atsamr34_xpro
-
+  tags: drivers uart
 tests:
   drivers.uart.async_api:
-    tags: drivers
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC and not CONFIG_UART_MCUX_LPUART
     harness: ztest
     harness_config:
       fixture: gpio_loopback
   drivers.uart.async_api.nrf_uart:
-    tags: drivers
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC
     harness: ztest
     platform_allow: nrf52840dk_nrf52840
@@ -20,7 +18,6 @@ tests:
       fixture: gpio_loopback
     extra_args: DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840.overlay;boards/nrf_uart.overlay"
   drivers.uart.async_api.rtt:
-    tags: drivers
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_HAS_SEGGER_RTT and not CONFIG_UART_MCUX_LPUART
     extra_args: DTC_OVERLAY_FILE=boards/segger_rtt.overlay
     extra_configs:
@@ -28,7 +25,6 @@ tests:
       - CONFIG_UART_RTT=y
     build_only: true
   drivers.uart.async_api.lpuart:
-    tags: drivers
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_UART_MCUX_LPUART
     harness: ztest
     depends_on: dma

--- a/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
+++ b/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
@@ -1,10 +1,10 @@
 common:
+  tags: drivers uart
   harness: ztest
   harness_config:
     fixture: gpio_loopback
 tests:
   drivers.uart.uart_mix_poll:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
@@ -12,7 +12,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
 
   drivers.uart.uart_mix_poll_fifo:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
@@ -20,7 +19,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
 
   drivers.uart.uart_mix_poll_async_api:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_ASYNC_API=y
@@ -32,7 +30,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
 
   drivers.uart.uart_mix_poll_async_api_const:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_args: TEST_CONST_BUFFER=1
     extra_configs:
@@ -46,7 +43,6 @@ tests:
       - CONFIG_UART_ASYNC_TX_CACHE_SIZE=2
 
   drivers.uart.uart_mix_poll_async_api_low_power:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_ASYNC_API=y
@@ -58,9 +54,7 @@ tests:
       - CONFIG_NRFX_TIMER2=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
 
-
   drivers.uart.uart_mix_poll_with_ppi:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
@@ -68,7 +62,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
 
   drivers.uart.uart_mix_poll_fifo_with_ppi:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
@@ -76,7 +69,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
 
   drivers.uart.uart_mix_poll_async_api_with_ppi:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_ASYNC_API=y
@@ -88,7 +80,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
 
   drivers.uart.uart_mix_poll_async_api_with_ppi_low_power:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_ASYNC_API=y

--- a/tests/drivers/uart/uart_pm/testcase.yaml
+++ b/tests/drivers/uart/uart_pm/testcase.yaml
@@ -1,10 +1,10 @@
 common:
+  tags: drivers uart
   harness: ztest
   harness_config:
     fixture: gpio_loopback
 tests:
   drivers.uart.pm:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
@@ -12,7 +12,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
 
   drivers.uart.pm.no_rxpin:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
@@ -21,7 +20,6 @@ tests:
     extra_args: DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840.overlay;nrf_rx_disable.overlay"
 
   drivers.uart.pm.enhanced_poll:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
@@ -29,7 +27,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
 
   drivers.uart.pm.int_driven:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
@@ -38,7 +35,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
 
   drivers.uart.pm.int_driven.enhanced_poll:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
@@ -47,7 +43,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
 
   drivers.uart.pm.async:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
@@ -59,7 +54,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
 
   drivers.uart.pm.async.enhanced_poll:
-    tags: drivers
     platform_allow: nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n


### PR DESCRIPTION
Many driver samples or tests only had 'drivers' as the tag, without a
tag indicating what driver that is exactly, so add some missing tags.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
