### PR TITLE
boards: esp32: enable BOOT button

### DIFF
--- a/boards/xtensa/esp32/esp32.dts
+++ b/boards/xtensa/esp32/esp32.dts
@@ -15,7 +15,16 @@
 	aliases {
 		uart-0 = &uart0;
 		i2c-0 = &i2c0;
+		sw0 = &button0;
 		watchdog0 = &wdt0;
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio0 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "BOOT Button";
+		};
 	};
 
 	chosen {


### PR DESCRIPTION
Dear Maintainers,

This enables the BOOT gpio-key mapped to GPIO0.

That was tested using the sample `button`.

```
*** Booting Zephyr OS build zephyr-v3.2.0-1554-g2c0cc7c50de6 ***
Set up button at gpio@3ff44000 pin 0
Press the button
Button pressed at 616159166
Button pressed at 768068396
Button pressed at 866654642
Button pressed at 1156844450
Button pressed at 1301995781
Button pressed at 1394476403
Button pressed at 1471127792
```

Regards,
Gaël