### PR TITLE
boards: heltec_wifi_lora32_v2: fix indentations

### DIFF
--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
@@ -37,14 +37,12 @@
 			gpios = <&gpio0 16 (GPIO_PULL_UP | GPIO_ACTIVE_HIGH)>;
 			label = "OLED Reset";
 		};
-
 	};
 
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
-			gpios = < &gpio0 0 (GPIO_PULL_UP | \
-			   GPIO_ACTIVE_LOW)>;
+			gpios = <&gpio0 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "PRG Button";
 		};
 	};


### PR DESCRIPTION
Hello Maintainers,

I figured out that `esp32.dts` and `heltec_wifi_lora32_v2.dts` are almost identical files and I found some trivial indentation violations.

This PR simply fixes them.

Regards,
Gaël