### PR TITLE
drivers: ina23x: a few improvements/fixes

### DIFF
--- a/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
+++ b/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
@@ -145,8 +145,7 @@
 			INA230_AVG_MODE_1)>;
 		/* Set current LSB to 1mA */
 		current-lsb = <1>;
-		/* Set shunt resistor value to 15 milliohms */
-		rshunt = <15>;
+		rshunt-milliohms = <15>;
 	};
 };
 

--- a/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
+++ b/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
@@ -143,8 +143,7 @@
 			INA230_CONV_TIME_1100,
 			INA230_CONV_TIME_1100,
 			INA230_AVG_MODE_1)>;
-		/* Set current LSB to 1mA */
-		current-lsb = <1>;
+		current-lsb-microamps = <1000>;
 		rshunt-milliohms = <15>;
 	};
 };

--- a/drivers/sensor/ina23x/ina230.c
+++ b/drivers/sensor/ina23x/ina230.c
@@ -7,10 +7,11 @@
 
 #define DT_DRV_COMPAT ti_ina230
 
-#include <zephyr/logging/log.h>
-#include <zephyr/drivers/sensor.h>
 #include "ina230.h"
 #include "ina23x_common.h"
+
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/sensor.h>
 
 LOG_MODULE_REGISTER(INA230, CONFIG_SENSOR_LOG_LEVEL);
 

--- a/drivers/sensor/ina23x/ina230.c
+++ b/drivers/sensor/ina23x/ina230.c
@@ -277,9 +277,6 @@ static const struct sensor_driver_api ina230_driver_api = {
 	.channel_get = ina230_channel_get,
 };
 
-BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 0,
-	     "No compatible ina230 instances found");
-
 #ifdef CONFIG_INA230_TRIGGER
 #define INA230_CFG_IRQ(inst)				\
 	.trig_enabled = true,				\

--- a/drivers/sensor/ina23x/ina230.c
+++ b/drivers/sensor/ina23x/ina230.c
@@ -265,7 +265,7 @@ static const struct sensor_driver_api ina230_driver_api = {
 	.trig_enabled = true,				\
 	.mask = DT_INST_PROP(inst, mask),		\
 	.alert_limit = DT_INST_PROP(inst, alert_limit),	\
-	.gpio_alert = GPIO_DT_SPEC_INST_GET(inst, irq_gpios)
+	.alert_gpio = GPIO_DT_SPEC_INST_GET(inst, alert_gpios)
 #else
 #define INA230_CFG_IRQ(inst)
 #endif /* CONFIG_INA230_TRIGGER */
@@ -277,7 +277,7 @@ static const struct sensor_driver_api ina230_driver_api = {
 		.config = DT_INST_PROP(inst, config),		    \
 		.current_lsb = DT_INST_PROP(inst, current_lsb_microamps),\
 		.rshunt = DT_INST_PROP(inst, rshunt_milliohms),	    \
-		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios), \
+		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, alert_gpios),\
 			    (INA230_CFG_IRQ(inst)), ())		    \
 	};							    \
 	SENSOR_DEVICE_DT_INST_DEFINE(inst,			    \

--- a/drivers/sensor/ina23x/ina230.c
+++ b/drivers/sensor/ina23x/ina230.c
@@ -34,12 +34,6 @@ LOG_MODULE_REGISTER(INA230, CONFIG_SENSOR_LOG_LEVEL);
  */
 #define INA230_POWER_VALUE_LSB 25
 
-/**
- * @brief sensor value get
- *
- * @retval 0 for success
- * @retval -ENOTSUP for unsupported channels
- */
 static int ina230_channel_get(const struct device *dev,
 			      enum sensor_channel chan,
 			      struct sensor_value *val)
@@ -102,12 +96,6 @@ static int ina230_channel_get(const struct device *dev,
 	return 0;
 }
 
-/**
- * @brief sensor sample fetch
- *
- * @retval 0 for success
- * @retval -ENOTSUP for unsupported channels
- */
 static int ina230_sample_fetch(const struct device *dev,
 			       enum sensor_channel chan)
 {
@@ -149,13 +137,6 @@ static int ina230_sample_fetch(const struct device *dev,
 	return 0;
 }
 
-/**
- * @brief sensor attribute set
- *
- * @retval 0 for success
- * @retval -ENOTSUP for unsupported channels
- * @retval -EIO for i2c write failure
- */
 static int ina230_attr_set(const struct device *dev, enum sensor_channel chan,
 			   enum sensor_attribute attr,
 			   const struct sensor_value *val)
@@ -178,13 +159,6 @@ static int ina230_attr_set(const struct device *dev, enum sensor_channel chan,
 	}
 }
 
-/**
- * @brief sensor attribute get
- *
- * @retval 0 for success
- * @retval -ENOTSUP for unsupported channels
- * @retval -EIO for i2c read failure
- */
 static int ina230_attr_get(const struct device *dev, enum sensor_channel chan,
 			   enum sensor_attribute attr,
 			   struct sensor_value *val)
@@ -229,12 +203,6 @@ static int ina230_attr_get(const struct device *dev, enum sensor_channel chan,
 	return 0;
 }
 
-/**
- * @brief sensor calibrate
- *
- * @retval 0 for success
- * @retval -EIO for i2c write failure
- */
 static int ina230_calibrate(const struct device *dev)
 {
 	const struct ina230_config *config = dev->config;
@@ -251,12 +219,6 @@ static int ina230_calibrate(const struct device *dev)
 	return 0;
 }
 
-/**
- * @brief Initialize the INA230
- *
- * @retval 0 for success
- * @retval -EINVAL on error
- */
 static int ina230_init(const struct device *dev)
 {
 	const struct ina230_config *const config = dev->config;

--- a/drivers/sensor/ina23x/ina230.c
+++ b/drivers/sensor/ina23x/ina230.c
@@ -22,11 +22,8 @@ LOG_MODULE_REGISTER(INA230, CONFIG_SENSOR_LOG_LEVEL);
  */
 #define INA230_INTERNAL_FIXED_SCALING_VALUE 5120
 
-/**
- * @brief The LSB value for the bus voltage register.
- *
- */
-#define INA230_BUS_VOLTAGE_LSB 125
+/** @brief The LSB value for the bus voltage register, in microvolts/LSB. */
+#define INA230_BUS_VOLTAGE_UV_LSB 1250U
 
 /**
  * @brief The LSB value for the power register.
@@ -40,19 +37,15 @@ static int ina230_channel_get(const struct device *dev,
 {
 	struct ina230_data *data = dev->data;
 	const struct ina230_config *const config = dev->config;
+	uint32_t bus_uv;
 
 	switch (chan) {
 	case SENSOR_CHAN_VOLTAGE:
-		if (config->current_lsb == INA23X_CURRENT_LSB_1MA) {
-			uint32_t bus_mv = ((data->bus_voltage *
-					 INA230_BUS_VOLTAGE_LSB) / 100);
+		bus_uv = data->bus_voltage * INA230_BUS_VOLTAGE_UV_LSB;
 
-			val->val1 = bus_mv / 1000U;
-			val->val2 = (bus_mv % 1000) * 1000;
-		} else {
-			val->val1 = data->bus_voltage;
-			val->val2 = 0;
-		}
+		/* convert to fractional volts (units for voltage channel) */
+		val->val1 = bus_uv / 1000000U;
+		val->val2 = bus_uv % 1000000U;
 		break;
 
 	case SENSOR_CHAN_CURRENT:

--- a/drivers/sensor/ina23x/ina230.c
+++ b/drivers/sensor/ina23x/ina230.c
@@ -293,7 +293,7 @@ static const struct sensor_driver_api ina230_driver_api = {
 		.bus = I2C_DT_SPEC_INST_GET(inst),		    \
 		.config = DT_INST_PROP(inst, config),		    \
 		.current_lsb = DT_INST_PROP(inst, current_lsb),	    \
-		.rshunt = DT_INST_PROP(inst, rshunt),		    \
+		.rshunt = DT_INST_PROP(inst, rshunt_milliohms),	    \
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios), \
 			    (INA230_CFG_IRQ(inst)), ())		    \
 	};							    \

--- a/drivers/sensor/ina23x/ina230.h
+++ b/drivers/sensor/ina23x/ina230.h
@@ -48,7 +48,7 @@ struct ina230_data {
 struct ina230_config {
 	struct i2c_dt_spec bus;
 	uint16_t config;
-	uint16_t current_lsb;
+	uint32_t current_lsb;
 	uint16_t rshunt;
 #ifdef CONFIG_INA230_TRIGGER
 	bool trig_enabled;

--- a/drivers/sensor/ina23x/ina230.h
+++ b/drivers/sensor/ina23x/ina230.h
@@ -8,9 +8,20 @@
 #ifndef ZEPHYR_DRIVERS_SENSOR_INA23X_INA230_H_
 #define ZEPHYR_DRIVERS_SENSOR_INA23X_INA230_H_
 
+#ifdef CONFIG_INA230_TRIGGER
+#include <stdbool.h>
+#endif
+#include <stdint.h>
+
+#include <zephyr/device.h>
+#ifdef CONFIG_INA230_TRIGGER
 #include <zephyr/drivers/gpio.h>
+#endif
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor.h>
+#ifdef CONFIG_INA230_TRIGGER
 #include <zephyr/kernel.h>
+#endif
 
 #define INA230_REG_CONFIG     0x00
 #define INA230_REG_SHUNT_VOLT 0x01

--- a/drivers/sensor/ina23x/ina230.h
+++ b/drivers/sensor/ina23x/ina230.h
@@ -53,7 +53,7 @@ struct ina230_config {
 #ifdef CONFIG_INA230_TRIGGER
 	bool trig_enabled;
 	uint16_t mask;
-	const struct gpio_dt_spec gpio_alert;
+	const struct gpio_dt_spec alert_gpio;
 	uint16_t alert_limit;
 #endif  /* CONFIG_INA230_TRIGGER */
 };

--- a/drivers/sensor/ina23x/ina230_trigger.c
+++ b/drivers/sensor/ina23x/ina230_trigger.c
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "ina230.h"
+
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/logging/log.h>
-
-#include "ina230.h"
 
 LOG_MODULE_DECLARE(INA230, CONFIG_SENSOR_LOG_LEVEL);
 

--- a/drivers/sensor/ina23x/ina230_trigger.c
+++ b/drivers/sensor/ina23x/ina230_trigger.c
@@ -50,14 +50,14 @@ int ina230_trigger_mode_init(const struct device *dev)
 	int ret;
 
 	/* setup alert gpio interrupt */
-	if (!device_is_ready(config->gpio_alert.port)) {
+	if (!device_is_ready(config->alert_gpio.port)) {
 		LOG_ERR("Alert GPIO device not ready");
 		return -ENODEV;
 	}
 
 	ina230->dev = dev;
 
-	ret = gpio_pin_configure_dt(&config->gpio_alert, GPIO_INPUT);
+	ret = gpio_pin_configure_dt(&config->alert_gpio, GPIO_INPUT);
 	if (ret < 0) {
 		LOG_ERR("Could not configure gpio");
 		return ret;
@@ -65,14 +65,14 @@ int ina230_trigger_mode_init(const struct device *dev)
 
 	gpio_init_callback(&ina230->gpio_cb,
 			   ina230_gpio_callback,
-			   BIT(config->gpio_alert.pin));
+			   BIT(config->alert_gpio.pin));
 
-	ret = gpio_add_callback(config->gpio_alert.port, &ina230->gpio_cb);
+	ret = gpio_add_callback(config->alert_gpio.port, &ina230->gpio_cb);
 	if (ret < 0) {
 		LOG_ERR("Could not set gpio callback");
 		return ret;
 	}
 
-	return gpio_pin_interrupt_configure_dt(&config->gpio_alert,
+	return gpio_pin_interrupt_configure_dt(&config->alert_gpio,
 					       GPIO_INT_EDGE_BOTH);
 }

--- a/drivers/sensor/ina23x/ina237.c
+++ b/drivers/sensor/ina23x/ina237.c
@@ -23,11 +23,8 @@ LOG_MODULE_REGISTER(INA237, CONFIG_SENSOR_LOG_LEVEL);
  */
 #define INA237_INTERNAL_FIXED_SCALING_VALUE 8192
 
-/**
- * @brief The LSB value for the bus voltage register.
- *
- */
-#define INA237_BUS_VOLTAGE_LSB 3125
+/** @brief The LSB value for the bus voltage register, in microvolts/LSB. */
+#define INA237_BUS_VOLTAGE_UV_LSB 3125
 
 /**
  * @brief The LSB value for the power register.
@@ -41,19 +38,14 @@ static int ina237_channel_get(const struct device *dev,
 {
 	struct ina237_data *data = dev->data;
 	const struct ina237_config *config = dev->config;
+	uint32_t bus_uv;
 
 	switch (chan) {
 	case SENSOR_CHAN_VOLTAGE:
-		if (config->current_lsb == INA23X_CURRENT_LSB_1MA) {
-			uint32_t bus_mv = ((data->bus_voltage *
-					 INA237_BUS_VOLTAGE_LSB) / 1000);
+		bus_uv = data->bus_voltage * INA237_BUS_VOLTAGE_UV_LSB;
 
-			val->val1 = bus_mv / 1000U;
-			val->val2 = (bus_mv % 1000) * 1000;
-		} else {
-			val->val1 = data->bus_voltage;
-			val->val2 = 0;
-		}
+		val->val1 = bus_uv / 1000000U;
+		val->val2 = bus_uv % 1000000U;
 		break;
 
 	case SENSOR_CHAN_CURRENT:

--- a/drivers/sensor/ina23x/ina237.c
+++ b/drivers/sensor/ina23x/ina237.c
@@ -333,7 +333,7 @@ static int ina237_init(const struct device *dev)
 
 		k_work_init(&data->trigger.conversion_work, ina237_trigger_work_handler);
 
-		ret = ina23x_trigger_mode_init(&data->trigger, &config->gpio_alert);
+		ret = ina23x_trigger_mode_init(&data->trigger, &config->alert_gpio);
 		if (ret < 0) {
 			LOG_ERR("Failed to init trigger mode");
 			return ret;
@@ -382,7 +382,7 @@ static const struct sensor_driver_api ina237_driver_api = {
 		.current_lsb = DT_INST_PROP(inst, current_lsb_microamps),	\
 		.rshunt = DT_INST_PROP(inst, rshunt_milliohms),			\
 		.alert_config = DT_INST_PROP_OR(inst, alert_config, 0x01),	\
-		.gpio_alert = GPIO_DT_SPEC_INST_GET_OR(inst, irq_gpios, {0}),	\
+		.alert_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, alert_gpios, {0}),	\
 	};							    \
 	SENSOR_DEVICE_DT_INST_DEFINE(inst,			    \
 			      &ina237_init,			    \

--- a/drivers/sensor/ina23x/ina237.c
+++ b/drivers/sensor/ina23x/ina237.c
@@ -35,12 +35,6 @@ LOG_MODULE_REGISTER(INA237, CONFIG_SENSOR_LOG_LEVEL);
  */
 #define INA237_POWER_VALUE_LSB 2
 
-/**
- * @brief sensor value get
- *
- * @retval 0 for success
- * @retval -ENOTSUP for unsupported channels
- */
 static int ina237_channel_get(const struct device *dev,
 			      enum sensor_channel chan,
 			      struct sensor_value *val)
@@ -217,13 +211,6 @@ static int ina237_sample_fetch(const struct device *dev,
 	}
 }
 
-/**
- * @brief sensor attribute set
- *
- * @retval 0 for success
- * @retval -ENOTSUP for unsupported channels
- * @retval -EIO for i2c write failure
- */
 static int ina237_attr_set(const struct device *dev, enum sensor_channel chan,
 			   enum sensor_attribute attr,
 			   const struct sensor_value *val)
@@ -242,13 +229,6 @@ static int ina237_attr_set(const struct device *dev, enum sensor_channel chan,
 	}
 }
 
-/**
- * @brief sensor attribute get
- *
- * @retval 0 for success
- * @retval -ENOTSUP for unsupported channels
- * @retval -EIO for i2c read failure
- */
 static int ina237_attr_get(const struct device *dev, enum sensor_channel chan,
 			   enum sensor_attribute attr,
 			   struct sensor_value *val)
@@ -281,12 +261,6 @@ static int ina237_attr_get(const struct device *dev, enum sensor_channel chan,
 	return 0;
 }
 
-/**
- * @brief sensor calibrate
- *
- * @retval 0 for success
- * @retval -EIO for i2c write failure
- */
 static int ina237_calibrate(const struct device *dev)
 {
 	const struct ina237_config *config = dev->config;
@@ -303,10 +277,6 @@ static int ina237_calibrate(const struct device *dev)
 	return 0;
 }
 
-/**
- * @brief sensor trigger work handler
- *
- */
 static void ina237_trigger_work_handler(struct k_work *work)
 {
 	struct ina23x_trigger *trigg = CONTAINER_OF(work, struct ina23x_trigger, conversion_work);
@@ -334,12 +304,6 @@ static void ina237_trigger_work_handler(struct k_work *work)
 	}
 }
 
-/**
- * @brief Initialize the INA237
- *
- * @retval 0 for success
- * @retval negative errno code on fail
- */
 static int ina237_init(const struct device *dev)
 {
 	struct ina237_data *data = dev->data;
@@ -407,12 +371,6 @@ static int ina237_init(const struct device *dev)
 	return 0;
 }
 
-/**
- * @brief sensor trigger set
- *
- * @retval 0 for success
- * @retval negative errno code on fail
- */
 static int ina237_trigger_set(const struct device *dev,
 			      const struct sensor_trigger *trig,
 			      sensor_trigger_handler_t handler)

--- a/drivers/sensor/ina23x/ina237.c
+++ b/drivers/sensor/ina23x/ina237.c
@@ -402,7 +402,7 @@ static const struct sensor_driver_api ina237_driver_api = {
 		.config = DT_INST_PROP(inst, config),				\
 		.adc_config = DT_INST_PROP(inst, adc_config),			\
 		.current_lsb = DT_INST_PROP(inst, current_lsb),			\
-		.rshunt = DT_INST_PROP(inst, rshunt),				\
+		.rshunt = DT_INST_PROP(inst, rshunt_milliohms),			\
 		.alert_config = DT_INST_PROP_OR(inst, alert_config, 0x01),	\
 		.gpio_alert = GPIO_DT_SPEC_INST_GET_OR(inst, irq_gpios, {0}),	\
 	};							    \

--- a/drivers/sensor/ina23x/ina237.c
+++ b/drivers/sensor/ina23x/ina237.c
@@ -395,9 +395,6 @@ static const struct sensor_driver_api ina237_driver_api = {
 	.channel_get = ina237_channel_get,
 };
 
-BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 0,
-	     "No compatible ina237 instances found");
-
 #define INA237_DRIVER_INIT(inst)						\
 	static struct ina237_data ina237_data_##inst;				\
 	static const struct ina237_config ina237_config_##inst = {		\

--- a/drivers/sensor/ina23x/ina237.c
+++ b/drivers/sensor/ina23x/ina237.c
@@ -6,12 +6,13 @@
 
 #define DT_DRV_COMPAT ti_ina237
 
+#include "ina237.h"
+#include "ina23x_common.h"
+
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/dt-bindings/sensor/ina237.h>
 #include <zephyr/sys/byteorder.h>
-#include "ina237.h"
-#include "ina23x_common.h"
 
 LOG_MODULE_REGISTER(INA237, CONFIG_SENSOR_LOG_LEVEL);
 

--- a/drivers/sensor/ina23x/ina237.h
+++ b/drivers/sensor/ina23x/ina237.h
@@ -50,7 +50,7 @@ struct ina237_config {
 	uint16_t adc_config;
 	uint32_t current_lsb;
 	uint16_t rshunt;
-	const struct gpio_dt_spec gpio_alert;
+	const struct gpio_dt_spec alert_gpio;
 	uint16_t alert_config;
 };
 

--- a/drivers/sensor/ina23x/ina237.h
+++ b/drivers/sensor/ina23x/ina237.h
@@ -48,7 +48,7 @@ struct ina237_config {
 	struct i2c_dt_spec bus;
 	uint16_t config;
 	uint16_t adc_config;
-	uint16_t current_lsb;
+	uint32_t current_lsb;
 	uint16_t rshunt;
 	const struct gpio_dt_spec gpio_alert;
 	uint16_t alert_config;

--- a/drivers/sensor/ina23x/ina237.h
+++ b/drivers/sensor/ina23x/ina237.h
@@ -7,8 +7,14 @@
 #ifndef ZEPHYR_DRIVERS_SENSOR_INA23X_INA237_H_
 #define ZEPHYR_DRIVERS_SENSOR_INA23X_INA237_H_
 
-#include <zephyr/drivers/i2c.h>
 #include "ina23x_trigger.h"
+
+#include <stdint.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor.h>
 
 #define INA237_REG_CONFIG     0x00
 #define INA237_REG_ADC_CONFIG 0x01

--- a/drivers/sensor/ina23x/ina23x_common.c
+++ b/drivers/sensor/ina23x/ina23x_common.c
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/sys/byteorder.h>
 #include "ina23x_common.h"
+
+#include <zephyr/sys/byteorder.h>
 
 int ina23x_reg_read_24(const struct i2c_dt_spec *bus, uint8_t reg, uint32_t *val)
 {

--- a/drivers/sensor/ina23x/ina23x_common.h
+++ b/drivers/sensor/ina23x/ina23x_common.h
@@ -7,7 +7,10 @@
 #ifndef ZEPHYR_DRIVERS_SENSOR_INA23X_COMMON_H_
 #define ZEPHYR_DRIVERS_SENSOR_INA23X_COMMON_H_
 
+#include <stdint.h>
+
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/sys/util_macro.h>
 
 /**
  * @brief Macro used to test if the current's sign bit is set

--- a/drivers/sensor/ina23x/ina23x_trigger.c
+++ b/drivers/sensor/ina23x/ina23x_trigger.c
@@ -20,16 +20,16 @@ static void ina23x_gpio_callback(const struct device *port,
 	k_work_submit(&trigg->conversion_work);
 }
 
-int ina23x_trigger_mode_init(struct ina23x_trigger *trigg, const struct gpio_dt_spec *gpio_alert)
+int ina23x_trigger_mode_init(struct ina23x_trigger *trigg, const struct gpio_dt_spec *alert_gpio)
 {
 	int ret;
 
-	if (!device_is_ready(gpio_alert->port)) {
+	if (!device_is_ready(alert_gpio->port)) {
 		LOG_ERR("Alert GPIO device not ready");
 		return -ENODEV;
 	}
 
-	ret = gpio_pin_configure_dt(gpio_alert, GPIO_INPUT);
+	ret = gpio_pin_configure_dt(alert_gpio, GPIO_INPUT);
 	if (ret < 0) {
 		LOG_ERR("Could not configure gpio");
 		return ret;
@@ -37,14 +37,14 @@ int ina23x_trigger_mode_init(struct ina23x_trigger *trigg, const struct gpio_dt_
 
 	gpio_init_callback(&trigg->gpio_cb,
 			   ina23x_gpio_callback,
-			   BIT(gpio_alert->pin));
+			   BIT(alert_gpio->pin));
 
-	ret = gpio_add_callback(gpio_alert->port, &trigg->gpio_cb);
+	ret = gpio_add_callback(alert_gpio->port, &trigg->gpio_cb);
 	if (ret < 0) {
 		LOG_ERR("Could not set gpio callback");
 		return ret;
 	}
 
-	return gpio_pin_interrupt_configure_dt(gpio_alert,
+	return gpio_pin_interrupt_configure_dt(alert_gpio,
 					       GPIO_INT_EDGE_FALLING);
 }

--- a/drivers/sensor/ina23x/ina23x_trigger.c
+++ b/drivers/sensor/ina23x/ina23x_trigger.c
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/logging/log.h>
 #include "ina23x_trigger.h"
+
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(INA23X_TRIGGER, CONFIG_SENSOR_LOG_LEVEL);
 

--- a/drivers/sensor/ina23x/ina23x_trigger.h
+++ b/drivers/sensor/ina23x/ina23x_trigger.h
@@ -18,6 +18,6 @@ struct ina23x_trigger {
 };
 
 int ina23x_trigger_mode_init(struct ina23x_trigger *trigg,
-			     const struct gpio_dt_spec *gpio_alert);
+			     const struct gpio_dt_spec *alert_gpio);
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_INA23X_TRIGGER_H_ */

--- a/dts/bindings/sensor/ti,ina230.yaml
+++ b/dts/bindings/sensor/ti,ina230.yaml
@@ -29,8 +29,3 @@ properties:
       default: 0
       # default alert limit is 0V
       description: Alert register, default matches the power-on reset value
-
-    irq-gpios:
-      type: phandle-array
-      required: false
-      description: IRQ Alert pin

--- a/dts/bindings/sensor/ti,ina237.yaml
+++ b/dts/bindings/sensor/ti,ina237.yaml
@@ -26,8 +26,3 @@ properties:
       type: int
       required: false
       description: Diag alert register, default matches the power-on reset value
-
-    irq-gpios:
-      type: phandle-array
-      required: false
-      description: IRQ Alert pin

--- a/dts/bindings/sensor/ti,ina23x-common.yaml
+++ b/dts/bindings/sensor/ti,ina23x-common.yaml
@@ -27,7 +27,7 @@ properties:
         results in Current, Voltage, and Power registers
         being read in counts.
 
-    rshunt:
+    rshunt-milliohms:
       type: int
       required: true
       description: Shunt resistor value in milliohms

--- a/dts/bindings/sensor/ti,ina23x-common.yaml
+++ b/dts/bindings/sensor/ti,ina23x-common.yaml
@@ -17,15 +17,22 @@ properties:
         delay for initial ADC conversion, shunt full scale range
         for INA237.
 
-    current-lsb:
+    current-lsb-microamps:
       type: int
       required: true
       description: |
-        Value of Current LSB in milliamps. When set to 1mA,
-        Current is read in A, Bus Voltage in V, Shunt
-        Voltage in V, and Power in mW. Any other value
-        results in Current, Voltage, and Power registers
-        being read in counts.
+        This value should be selected so that measurement resolution is
+        maximized, that is:
+
+          current-lsb(A) = maximum expected current(A) / 2^15
+
+        (sensor has 15 bits). For example, if maximum expected current is 15A:
+
+          current-lsb(A) = 15A / 2^15 ~= 457uA
+
+        Rounded values may be used for convenience, e.g. 500uA/LSB or 1mA/LSB
+        while keeping a good measurement resolution. The units are in uA/LSB
+        so that low maximum currents can be measured with enough resolution.
 
     rshunt-milliohms:
       type: int

--- a/dts/bindings/sensor/ti,ina23x-common.yaml
+++ b/dts/bindings/sensor/ti,ina23x-common.yaml
@@ -38,3 +38,8 @@ properties:
       type: int
       required: true
       description: Shunt resistor value in milliohms
+
+    alert-gpios:
+      type: phandle-array
+      required: false
+      description: Alert pin

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -591,7 +591,7 @@ test_i2c_ina230: ina230@4f {
 	compatible = "ti,ina230";
 	reg = <0x4f>;
 	config = <0>;
-	current-lsb = <1>;
+	current-lsb-microamps = <1000>;
 	rshunt-milliohms = <0>;
 	mask = <0>;
 	alert-limit = <0>;
@@ -608,7 +608,7 @@ test_i2c_ina231: ina231@51 {
 	compatible = "ti,ina230";
 	reg = <0x51>;
 	config = <0>;
-	current-lsb = <1>;
+	current-lsb-microamps = <1000>;
 	rshunt-milliohms = <0>;
 	mask = <0>;
 	alert-limit = <0>;
@@ -619,7 +619,7 @@ test_i2c_ina237: ina237@52 {
 	compatible = "ti,ina237";
 	reg = <0x52>;
 	config = <0>;
-	current-lsb = <1>;
+	current-lsb-microamps = <1000>;
 	adc-config = <0>;
 	rshunt-milliohms = <0>;
 	alert-config = <0>;

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -592,7 +592,7 @@ test_i2c_ina230: ina230@4f {
 	reg = <0x4f>;
 	config = <0>;
 	current-lsb = <1>;
-	rshunt = <0>;
+	rshunt-milliohms = <0>;
 	mask = <0>;
 	alert-limit = <0>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -609,7 +609,7 @@ test_i2c_ina231: ina231@51 {
 	reg = <0x51>;
 	config = <0>;
 	current-lsb = <1>;
-	rshunt = <0>;
+	rshunt-milliohms = <0>;
 	mask = <0>;
 	alert-limit = <0>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -621,7 +621,7 @@ test_i2c_ina237: ina237@52 {
 	config = <0>;
 	current-lsb = <1>;
 	adc-config = <0>;
-	rshunt = <0>;
+	rshunt-milliohms = <0>;
 	alert-config = <0>;
 	irq-gpios = <&test_gpio 0 0>;
 };

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -595,7 +595,7 @@ test_i2c_ina230: ina230@4f {
 	rshunt-milliohms = <0>;
 	mask = <0>;
 	alert-limit = <0>;
-	irq-gpios = <&test_gpio 0 0>;
+	alert-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_lm77: lm77@50 {
@@ -612,7 +612,7 @@ test_i2c_ina231: ina231@51 {
 	rshunt-milliohms = <0>;
 	mask = <0>;
 	alert-limit = <0>;
-	irq-gpios = <&test_gpio 0 0>;
+	alert-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_ina237: ina237@52 {
@@ -623,7 +623,7 @@ test_i2c_ina237: ina237@52 {
 	adc-config = <0>;
 	rshunt-milliohms = <0>;
 	alert-config = <0>;
-	irq-gpios = <&test_gpio 0 0>;
+	alert-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_max31875: max31875@53 {


### PR DESCRIPTION
- Fixed includes
- Specify current LSB in microamps, so that we can measure low currents with good precision (now 1mA/LSB was hardcoded)
- Fixed power calculations (assumed 1mA/LSB, ignoring DT value)
- Some DT bindings improvements, e.g. units in `rhsunt-milliohms` (following dtschema), use `alert-gpios` to indicate ALERT pin
- Other minor cleanups (e.g. Doxygen, asserts)