### PR TITLE
[v3.2-branch] manifest: Remove submodules true for hal_telink

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -136,7 +136,6 @@ manifest:
     - name: hal_telink
       revision: 38573af589173259801ae6c2b34b7d4c9e626746
       path: modules/hal/telink
-      submodules: true
       groups:
         - hal
     - name: hal_ti


### PR DESCRIPTION
Disables submodules for the hal_telink repository as it contains a disallowed binary blob.

Fixes #52113

Signed-off-by: Jamie McCrae <jamie.mccrae@nordicsemi.no>