### PR TITLE
pcie: Write MSI-X vectors using `sys_write32`

### DIFF
--- a/drivers/pcie/host/msi.c
+++ b/drivers/pcie/host/msi.c
@@ -207,10 +207,10 @@ static void enable_msix(pcie_bdf_t bdf,
 		uint32_t map = pcie_msi_map(irq, &vectors[i], 1);
 		uint32_t mdr = pcie_msi_mdr(irq, &vectors[i]);
 
-		vectors[i].msix_vector->msg_addr = map;
-		vectors[i].msix_vector->msg_up_addr = 0;
-		vectors[i].msix_vector->msg_data = mdr;
-		vectors[i].msix_vector->vector_ctrl = 0;
+		sys_write32(map, (mm_reg_t) &vectors[i].msix_vector->msg_addr);
+		sys_write32(0, (mm_reg_t) &vectors[i].msix_vector->msg_up_addr);
+		sys_write32(mdr, (mm_reg_t) &vectors[i].msix_vector->msg_data);
+		sys_write32(0, (mm_reg_t) &vectors[i].msix_vector->vector_ctrl);
 	}
 
 	mcr = pcie_conf_read(bdf, base + PCIE_MSIX_MCR);

--- a/include/zephyr/drivers/pcie/msi.h
+++ b/include/zephyr/drivers/pcie/msi.h
@@ -39,7 +39,7 @@ struct msix_vector {
 	uint32_t msg_up_addr;
 	uint32_t msg_data;
 	uint32_t vector_ctrl;
-};
+} __packed;
 
 struct msi_vector {
 	pcie_bdf_t bdf;


### PR DESCRIPTION
It was previously written as regular members of a struct, which allows the C compiler to do things the way it wants. On ARM64, gcc would typically write field by pairs (`STP`), which would generate aborts.

By using `sys_write32`, we force it the right way.