### PR TITLE
bluetooth: Fix occasional BSim mesh test failure

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/advertiser/tx_cb_multi.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/advertiser/tx_cb_multi.sh
@@ -5,4 +5,4 @@
 source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
 # test tx callbacks sequence for multiple advs
-RunTest mesh_adv_tx_cb adv_tx_cb_multi
+RunTest mesh_adv_tx_cb_multi adv_tx_cb_multi

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/advertiser/tx_cb_single.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/advertiser/tx_cb_single.sh
@@ -5,4 +5,4 @@
 source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
 # test tx callbacks parameters and xmit sequence for single adv
-RunTest mesh_adv_tx_cb adv_tx_cb_single adv_rx_xmit
+RunTest mesh_adv_tx_cb_single adv_tx_cb_single adv_rx_xmit


### PR DESCRIPTION
Two tests were using the same simulation id, causing occasional failures when all tests were run in parallel

Signed-off-by: Troels Nilsson <trnn@demant.com>