### PR TITLE
MAINTAINERS.yaml: Add Guillaume Gautier as STM32 collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1930,6 +1930,7 @@ STM32 Platforms:
   collaborators:
     - ABOSTM
     - FRASTM
+    - gautierg-st
     - GeorgeCGV
   files:
     - boards/arm/nucleo_*/


### PR DESCRIPTION
Add gautierg-st as STM32 collaborator.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>


Contributions:
https://github.com/zephyrproject-rtos/zephyr/issues?q=author%3Agautierg-st+