### PR TITLE
Bluetooth: doc: Note on thread safety

### DIFF
--- a/doc/connectivity/bluetooth/bluetooth-dev.rst
+++ b/doc/connectivity/bluetooth/bluetooth-dev.rst
@@ -10,6 +10,15 @@ documentation.
 Additional information that is only relevant to Bluetooth applications can be
 found in this page.
 
+Thread safety
+*************
+
+Calling into the Bluetooth API is intended to be thread safe, unless otherwise
+noted in the documentation of the API function. The effort to ensure that this
+is the case for all API calls is an ongoing one, but the overall goal is
+formally stated in this paragraph. Bug reports and Pull Requests that move the
+subsystem in the direction of such goal are welcome.
+
 .. _bluetooth-hw-setup:
 
 Hardware setup


### PR DESCRIPTION
Add a thread safety section.

As requested here https://github.com/zephyrproject-rtos/zephyr/issues/51774#issuecomment-1310207785.

Signed-off-by: Théo Battrel <theo.battrel@nordicsemi.no>
Co-authored-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemi.no>