### PR TITLE
intel_adsp: include toolchain.h in adsp_memory.h

### DIFF
--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_memory.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_memory.h
@@ -8,6 +8,7 @@
 
 
 #include <zephyr/devicetree.h>
+#include <zephyr/toolchain.h>
 #include <adsp-vectors.h>
 #include <mem_window.h>
 


### PR DESCRIPTION
MTL SOF is not compiling when 8d0eb is applied
Fix - some zephyr/toolchain include missing

Signed-off-by: Marcin Szkudlinski <marcin.szkudlinski@intel.com>