### PR TITLE
tests: kernel: fifo_timeout: Do not print status messages during tests

### DIFF
--- a/tests/kernel/fifo/fifo_timeout/src/main.c
+++ b/tests/kernel/fifo/fifo_timeout/src/main.c
@@ -185,7 +185,7 @@ static int test_multiple_threads_pending(struct timeout_order_data *test_data,
 			} else {
 				TC_ERROR(
 				" *** thread %d woke up, expected %d\n",
-				data->timeout_order, ii);
+				data->q_order, j);
 				return TC_FAIL;
 			}
 		}

--- a/tests/kernel/fifo/fifo_timeout/src/main.c
+++ b/tests/kernel/fifo/fifo_timeout/src/main.c
@@ -8,6 +8,8 @@
 #include <zephyr/irq_offload.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(test);
 
 /*
  * @file
@@ -160,7 +162,7 @@ static int test_multiple_threads_pending(struct timeout_order_data *test_data,
 
 		zassert_not_null(data, NULL);
 		if (data->timeout_order == ii) {
-			TC_PRINT(" thread (q order: %d, t/o: %d, fifo %p)\n",
+			LOG_DBG(" thread (q order: %d, t/o: %d, fifo %p)",
 				data->q_order, data->timeout, data->fifo);
 		} else {
 			/* Get the index of the thread which should have
@@ -179,8 +181,8 @@ static int test_multiple_threads_pending(struct timeout_order_data *test_data,
 			}
 
 			if (k_ms_to_ticks_ceil32(diff_ms) == 1) {
-				TC_PRINT(
-				" thread (q order: %d, t/o: %d, fifo %p)\n",
+				LOG_DBG(
+				" thread (q order: %d, t/o: %d, fifo %p)",
 				data->q_order, data->timeout, data->fifo);
 			} else {
 				TC_ERROR(
@@ -242,7 +244,7 @@ static int test_multiple_threads_get_data(struct timeout_order_data *test_data,
 		}
 
 		if (data->q_order == ii) {
-			TC_PRINT(" thread (q order: %d, t/o: %d, fifo %p)\n",
+			LOG_DBG(" thread (q order: %d, t/o: %d, fifo %p)",
 				data->q_order, data->timeout, data->fifo);
 		}
 	}
@@ -259,8 +261,8 @@ static int test_multiple_threads_get_data(struct timeout_order_data *test_data,
 		return TC_FAIL;
 	}
 
-	TC_PRINT(" thread (q order: %d, t/o: %d, fifo %p)\n",
-		 data->q_order, data->timeout, data->fifo);
+	LOG_DBG(" thread (q order: %d, t/o: %d, fifo %p)",
+		data->q_order, data->timeout, data->fifo);
 
 	return TC_PASS;
 }


### PR DESCRIPTION
... to avoid undesirable delays in waking up of the threads on
scheduled timeouts. In specific configurations such additional load
of the CPU can be even harmful to the test. This was observed for
nRF platforms where the UART_NRF_DK_SERIAL_WORKAROUND Kconfig option
was enabled.
All calls to TC_PRINT() in this test suite are replaced with calls to
LOG_DBG(), so the status messages are not printed by default, but they
can be enabled if needed by changing CONFIG_LOG_DEFAULT_LEVEL.

On the occasion, correct also one misleading error message.

Fixes #52009.