### PR TITLE
drivers: spi: fix return value of spi_transceive for STM32 slaves

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -807,6 +807,12 @@ static int transceive_dma(const struct device *dev,
 	dma_stop(data->dma_rx.dma_dev, data->dma_rx.channel);
 	dma_stop(data->dma_tx.dma_dev, data->dma_tx.channel);
 
+#ifdef CONFIG_SPI_SLAVE
+	if (spi_context_is_slave(&data->ctx) && !ret) {
+		ret = data->ctx.recv_frames;
+	}
+#endif /* CONFIG_SPI_SLAVE */
+
 end:
 	spi_context_release(&data->ctx, ret);
 


### PR DESCRIPTION
Return correctly the number of received bytes for a spi_transceive on a STM32 SPI slave.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/52216

Signed-off-by: Benedikt Schmidt <benedikt.schmidt@embedded-solutions.at>