### PR TITLE
mgmt/mcumgr: Correct serial frame size

### DIFF
--- a/include/zephyr/mgmt/mcumgr/serial.h
+++ b/include/zephyr/mgmt/mcumgr/serial.h
@@ -8,7 +8,7 @@
  * @file
  * @brief Utility functions used by the UART and shell mcumgr transports.
  *
- * Mcumgr packets sent over serial are fragmented into frames of 128 bytes or
+ * Mcumgr packets sent over serial are fragmented into frames of 127 bytes or
  * fewer.
  *
  * The initial frame in a packet has the following format:
@@ -68,7 +68,7 @@ extern "C" {
 
 #define MCUMGR_SERIAL_HDR_PKT       0x0609
 #define MCUMGR_SERIAL_HDR_FRAG      0x0414
-#define MCUMGR_SERIAL_MAX_FRAME     128
+#define MCUMGR_SERIAL_MAX_FRAME     127
 
 #define MCUMGR_SERIAL_HDR_PKT_1     (MCUMGR_SERIAL_HDR_PKT >> 8)
 #define MCUMGR_SERIAL_HDR_PKT_2     (MCUMGR_SERIAL_HDR_PKT & 0xff)


### PR DESCRIPTION
Zephyr has been using 128 byte frame size instead of 127. This change only affects buffer size as Base64 encodig, together with preamble and terminating new line character, has been only able to use 127 bytes of frame anyway,

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>