### PR TITLE
soc: xtensa: intel_adsp: ace: Rework setting soc_num_cpus

### DIFF
--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -47,12 +47,18 @@ static void ipc_isr(void *arg)
 
 unsigned int soc_num_cpus;
 
-void soc_mp_init(void)
+static __imr int soc_num_cpus_init(const struct device *dev)
 {
 	/* Need to set soc_num_cpus early to arch_num_cpus() works properly */
 	soc_num_cpus = ((sys_read32(DFIDCCP) >> CAP_INST_SHIFT) & CAP_INST_MASK) + 1;
 	soc_num_cpus = MIN(CONFIG_MP_MAX_NUM_CPUS, soc_num_cpus);
 
+	return 0;
+}
+SYS_INIT(soc_num_cpus_init, EARLY, 1);
+
+void soc_mp_init(void)
+{
 	IRQ_CONNECT(ACE_IRQ_TO_ZEPHYR(ACE_INTL_IDCA), 0, ipc_isr, 0, 0);
 
 	irq_enable(ACE_IRQ_TO_ZEPHYR(ACE_INTL_IDCA));


### PR DESCRIPTION
Move setting soc_num_cpus into its own SYS_INIT function such that we can ensure it happens as one of the first things.  We need soc_num_cpus set before soc_mp_init is called but also before interrupt controller init functions might be called.

Also, by having it in its own function, it ensures that soc_num_cpus gets set regardless of how CONFIG_MP_MAX_NUM_CPUS is set.  Since if CONFIG_MP_MAX_NUM_CPUS=1, we do not call soc_mp_init().

Signed-off-by: Kumar Gala <kumar.gala@intel.com>