### PR TITLE
modules: mbedtls: Explicitly add include mbedTLS directories

### DIFF
--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -28,6 +28,10 @@ if(CONFIG_MBEDTLS_BUILTIN)
     zephyr_cc_option(-fmacro-prefix-map=${ZEPHYR_CURRENT_MODULE_DIR}/library/=)
   endif()
 
+  zephyr_include_directories(
+    ${ZEPHYR_CURRENT_MODULE_DIR}/include
+  )
+
   zephyr_library_sources(
     zephyr_init.c
     ${mbedtls_sources}


### PR DESCRIPTION
Explicitly add mbedTLS include directories to enable modules based on it.

Signed-off-by: Patrick Wildt <pwildt@google.com>