### PR TITLE
arch: arm: mpu: Add support for disabling the background address map

### DIFF
--- a/arch/arm/core/aarch32/mpu/Kconfig
+++ b/arch/arm/core/aarch32/mpu/Kconfig
@@ -82,6 +82,12 @@ config MPU_ALLOW_FLASH_WRITE
 	help
 	  Enable this to allow MPU RWX access to flash memory
 
+config MPU_DISABLE_BACKGROUND_MAP
+	bool "Disables the default background address map"
+	help
+	  Enable this to turn off the default background MPU address map. Your
+	  SoC definition should likely provide its own custom MPU regions.
+
 config CUSTOM_SECTION_ALIGN
 	bool "Custom Section Align"
 	help

--- a/arch/arm/core/aarch32/mpu/arm_mpu.c
+++ b/arch/arm/core/aarch32/mpu/arm_mpu.c
@@ -180,9 +180,13 @@ void arm_core_mpu_disable(void)
 void arm_core_mpu_enable(void)
 {
 	/* Enable MPU and use the default memory map as a
-	 * background region for privileged software access.
+	 * background region for privileged software access if desired.
 	 */
+#if defined(CONFIG_MPU_DISABLE_BACKGROUND_MAP)
+	MPU->CTRL = MPU_CTRL_ENABLE_Msk;
+#else
 	MPU->CTRL = MPU_CTRL_ENABLE_Msk | MPU_CTRL_PRIVDEFENA_Msk;
+#endif
 
 	/* Make sure that all the registers are set before proceeding */
 	__DSB();


### PR DESCRIPTION
Arm provides a default address map defining default behaviors for certain address ranges, which can be overlayed with additional regions in the MPU. Users may also turn off this background map, so that only regions explicitly programmed in the MPU are allowed.

This provides a Kconfig so that platforms using a non-standard address map may disable the background address map and provide their own explicit MPU regions.

Signed-off-by: Benjamin Gwin <bgwin@google.com>