### PR TITLE
xtensa: linker: Use zephyr's convention for rodata

### DIFF
--- a/include/zephyr/linker/utils.h
+++ b/include/zephyr/linker/utils.h
@@ -35,16 +35,12 @@ static inline bool linker_is_in_rodata(const void *addr)
 
 #if defined(CONFIG_ARM) || defined(CONFIG_ARC) || defined(CONFIG_X86) || \
 	defined(CONFIG_ARM64) || defined(CONFIG_NIOS2) || \
-	defined(CONFIG_RISCV) || defined(CONFIG_SPARC) || defined(CONFIG_MIPS)
+	defined(CONFIG_RISCV) || defined(CONFIG_SPARC) || \
+	defined(CONFIG_MIPS) || defined(CONFIG_XTENSA)
 	extern char __rodata_region_start[];
 	extern char __rodata_region_end[];
 	#define RO_START __rodata_region_start
 	#define RO_END __rodata_region_end
-#elif defined(CONFIG_XTENSA)
-	extern const char _rodata_start[];
-	extern const char _rodata_end[];
-	#define RO_START _rodata_start
-	#define RO_END _rodata_end
 #else
 	#define RO_START 0
 	#define RO_END 0

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -158,7 +158,7 @@ SECTIONS
    */
   SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
   {
-    _rodata_start = ABSOLUTE(.);
+    __rodata_region_start = ABSOLUTE(.);
 
     . = ALIGN(4);
     #include <snippets-rodata.ld>
@@ -189,7 +189,7 @@ SECTIONS
     *(.dynamic)
     *(.gnu.version_d)
     . = ALIGN(4);
-    _rodata_end = ABSOLUTE(.);
+    __rodata_region_end = ABSOLUTE(.);
     /* Literals are also RO data. */
     _lit4_start = ABSOLUTE(.);
     *(*.lit4)

--- a/soc/xtensa/esp32_net/linker.ld
+++ b/soc/xtensa/esp32_net/linker.ld
@@ -150,7 +150,7 @@ SECTIONS
 
   SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
   {
-    _rodata_start = ABSOLUTE(.);
+    __rodata_region_start = ABSOLUTE(.);
 
     . = ALIGN(4);
     #include <snippets-rodata.ld>
@@ -181,7 +181,7 @@ SECTIONS
     *(.dynamic)
     *(.gnu.version_d)
     . = ALIGN(4);
-    _rodata_end = ABSOLUTE(.);
+    __rodata_region_end = ABSOLUTE(.);
     /* Literals are also RO data. */
     _lit4_start = ABSOLUTE(.);
     *(*.lit4)

--- a/soc/xtensa/esp32s2/linker.ld
+++ b/soc/xtensa/esp32s2/linker.ld
@@ -131,7 +131,7 @@ SECTIONS
    */
   SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
   {
-    _rodata_start = ABSOLUTE(.);
+    __rodata_region_start = ABSOLUTE(.);
 
     . = ALIGN(4);
     #include <snippets-rodata.ld>
@@ -162,7 +162,7 @@ SECTIONS
     *(.xt_except_desc_end)
     *(.dynamic)
     *(.gnu.version_d)
-    _rodata_end = ABSOLUTE(.);
+    __rodata_region_end = ABSOLUTE(.);
     /* Literals are also RO data. */
     _lit4_start = ABSOLUTE(.);
     *(*.lit4)

--- a/soc/xtensa/intel_adsp/ace/ace-link.ld
+++ b/soc/xtensa/intel_adsp/ace/ace-link.ld
@@ -250,7 +250,7 @@ SECTIONS {
 
   .rodata : ALIGN(4096)
   {
-    _rodata_start = .;
+    __rodata_region_start = .;
     *(.rodata)
     *(.rodata.*)
     *(.gnu.linkonce.r.*)
@@ -285,7 +285,7 @@ SECTIONS {
     LONG(_bss_start)
     LONG(_bss_end)
     _bss_table_end = .;
-    _rodata_end = .;
+    __rodata_region_end = .;
   } >ram
 
   .module_init : {

--- a/soc/xtensa/intel_adsp/cavs/include/xtensa-cavs-linker.ld
+++ b/soc/xtensa/intel_adsp/cavs/include/xtensa-cavs-linker.ld
@@ -276,7 +276,7 @@ SECTIONS {
 
   .rodata : ALIGN(4096)
   {
-    _rodata_start = .;
+    __rodata_region_start = .;
     *(.rodata)
     *(.rodata.*)
     *(.gnu.linkonce.r.*)
@@ -311,7 +311,7 @@ SECTIONS {
     LONG(_bss_start)
     LONG(_bss_end)
     _bss_table_end = .;
-    _rodata_end = .;
+    __rodata_region_end = .;
   } >RAM
 
   .module_init : {

--- a/soc/xtensa/nxp_adsp/imx8/linker.ld
+++ b/soc/xtensa/nxp_adsp/imx8/linker.ld
@@ -302,7 +302,7 @@ SECTIONS
 
   .rodata : ALIGN(4)
   {
-    _rodata_start = ABSOLUTE(.);
+    __rodata_region_start = ABSOLUTE(.);
     *(.rodata)
     *(.rodata.*)
     *(.gnu.linkonce.r.*)
@@ -333,7 +333,7 @@ SECTIONS
     LONG(_bss_start)
     LONG(_bss_end)
     _bss_table_end = ABSOLUTE(.);
-    _rodata_end = ABSOLUTE(.);
+    __rodata_region_end = ABSOLUTE(.);
   } >sdram0 :sdram0_phdr
 
   .module_init : ALIGN(4)

--- a/soc/xtensa/nxp_adsp/imx8m/linker.ld
+++ b/soc/xtensa/nxp_adsp/imx8m/linker.ld
@@ -302,7 +302,7 @@ SECTIONS
 
   .rodata : ALIGN(4)
   {
-    _rodata_start = ABSOLUTE(.);
+    __rodata_region_start = ABSOLUTE(.);
     *(.rodata)
     *(.rodata.*)
     *(.gnu.linkonce.r.*)
@@ -333,7 +333,7 @@ SECTIONS
     LONG(_bss_start)
     LONG(_bss_end)
     _bss_table_end = ABSOLUTE(.);
-    _rodata_end = ABSOLUTE(.);
+    __rodata_region_end = ABSOLUTE(.);
   } >sdram0 :sdram0_phdr
 
   .module_init : ALIGN(4)

--- a/soc/xtensa/sample_controller/include/xtensa-sample-controller.ld
+++ b/soc/xtensa/sample_controller/include/xtensa-sample-controller.ld
@@ -440,7 +440,7 @@ SECTIONS
 
   .rodata : ALIGN(4)
   {
-    _rodata_start = ABSOLUTE(.);
+    __rodata_region_start = ABSOLUTE(.);
     *(.rodata)
     *(.rodata.*)
     *(.gnu.linkonce.r.*)
@@ -482,7 +482,7 @@ SECTIONS
     LONG(_bss_start)
     LONG(_bss_end)
     _bss_table_end = ABSOLUTE(.);
-    _rodata_end = ABSOLUTE(.);
+    __rodata_region_end = ABSOLUTE(.);
   } >RAM :sram0_phdr
 
   .sram.text : ALIGN(4)


### PR DESCRIPTION
Zephyr maps start/end of rodata section with variables using __rodata_region namespace. The exception was Xtensa.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>