### PR TITLE
usb: audio: fix net_buf leak

### DIFF
--- a/subsys/usb/device/class/audio/audio.c
+++ b/subsys/usb/device/class/audio/audio.c
@@ -828,9 +828,8 @@ int usb_audio_send(const struct device *dev, struct net_buf *buffer,
 	/** buffer passed to *priv because completion callback
 	 * needs to release it to the pool
 	 */
-	usb_transfer(ep, buffer->data, len, USB_TRANS_WRITE | USB_TRANS_NO_ZLP,
+	return usb_transfer(ep, buffer->data, len, USB_TRANS_WRITE | USB_TRANS_NO_ZLP,
 		     audio_write_cb, buffer);
-	return 0;
 }
 
 size_t usb_audio_get_in_frame_size(const struct device *dev)


### PR DESCRIPTION
This PR tries to fix leakage in `usb_audio_send()`. In case of `usb_transfer()` failed due to endpoint busy for example, `usb_audio_send()` still returns 0. In that situation, `net_buf` will get released neither by `audio_write_cb()` nor by caller.
