### PR TITLE
drivers: i2c: stm32: Implement PM_DEVICE mode support

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -339,7 +339,7 @@ static int i2c_stm32_init(const struct device *dev)
 	 * So that they can enter master mode properly.
 	 * Issue described in ES096 2.14.7
 	 */
-	I2C_TypeDef * i2c = cfg->i2c;
+	I2C_TypeDef *i2c = cfg->i2c;
 
 	LL_I2C_EnableReset(i2c);
 	LL_I2C_DisableReset(i2c);

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -19,6 +19,7 @@
 #include <zephyr/sys/__assert.h>
 #include <soc.h>
 #include <zephyr/init.h>
+#include <zephyr/drivers/interrupt_controller/exti_stm32.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/reset.h>

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -16,8 +16,6 @@
 
 #include <stm32_ll_usart.h>
 
-#define STM32_EXTI_LINE_NONE	0xFFFFFFFFU
-
 /* device config */
 struct uart_stm32_config {
 	/* USART instance */

--- a/include/zephyr/drivers/interrupt_controller/exti_stm32.h
+++ b/include/zephyr/drivers/interrupt_controller/exti_stm32.h
@@ -23,6 +23,8 @@
 
 #include <zephyr/types.h>
 
+#define STM32_EXTI_LINE_NONE	0xFFFFFFFFU
+
 /**
  * @brief enable EXTI interrupt for specific line
  *


### PR DESCRIPTION
I2C device can be used as wakeup source when defining the property `wakeup-line` in the I2C node.
Common `STM32_EXTI_LINE_NONE` for declaration and setting of wakeup EXTI line when configured.