### PR TITLE
dts: bindings: serial: smartbond: Fix baudrates

### DIFF
--- a/dts/bindings/serial/renesas,smartbond-uart.yaml
+++ b/dts/bindings/serial/renesas,smartbond-uart.yaml
@@ -21,8 +21,6 @@ properties:
         Initial baud rate setting for UART. Only a fixed set of baud
         rates are selectable on these devices.
       enum:
-        - 1200
-        - 2400
         - 4800
         - 9600
         - 14400
@@ -32,9 +30,10 @@ properties:
         - 57600
         - 115200
         - 230400
-        - 460800
+        - 500000
         - 921600
         - 1000000
+        - 2000000
 
     hw-flow-control-supported:
       type: boolean


### PR DESCRIPTION
Serial speeds listed in device tree did not reflect what driver supports.

2M and 500K were missing while
1200, 2400 and 460800 were present while not supported.

This change synchronized dts with driver code:
drivers/serial/uart_smartbond.c

Signed-off-by: Jerzy Kasenberg <jerzy.kasenberg@codecoup.pl>