### PR TITLE
boards: mps2_an521: clean up memory map

### DIFF
--- a/boards/arm/mps2_an521/mps2_an521.dts
+++ b/boards/arm/mps2_an521/mps2_an521.dts
@@ -27,8 +27,15 @@
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
-		zephyr,sram = &sram2_3;
-		zephyr,flash = &sram1;
+
+		/*
+		 * These SRAM and flash settings give the entire available
+		 * code and data memories to this secure firmware image.
+		 * This may conflict with mps2_an521_remote firmware. Use
+		 * caution when using both targets simultaneously.
+		 */
+		zephyr,sram = &ssram2_3;
+		zephyr,flash = &ssram1;
 	};
 
 	leds {
@@ -77,22 +84,26 @@
 	/*
 	 * The memory regions defined below are according to AN521:
 	 * https://documentation-service.arm.com/static/5fa12fe9b1a7c5445f29017f
-	 * Please see tables from 3-1 to 3-4.
+	 *
+	 * Please see tables mentioned in individual comments below for details.
 	 */
 
-	sram1: memory@10000000 {
+	ssram1: memory@10000000 {
+		/* Table 3-2, row 6. */
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x10000000 DT_SIZE_M(4)>;
-		zephyr,memory-region = "SRAM1";
+		zephyr,memory-region = "SSRAM1";
 	};
 
-	sram2_3: memory@38000000 {
+	ssram2_3: memory@38000000 {
+		/* Table 3-4, rows 16 and 17. */
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x38000000 DT_SIZE_M(4)>;
-		zephyr,memory-region = "SRAM2_3";
+		zephyr,memory-region = "SSRAM2_3";
 	};
 
 	psram: memory@80000000 {
+		/* Table 3-6, row 1. */
 		device_type = "memory";
 		reg = <0x80000000 DT_SIZE_M(16)>;
 	};

--- a/boards/arm/mps2_an521/mps2_an521_ns.dts
+++ b/boards/arm/mps2_an521/mps2_an521_ns.dts
@@ -76,22 +76,26 @@
 	/*
 	 * The memory regions defined below are according to AN521:
 	 * https://documentation-service.arm.com/static/5fa12fe9b1a7c5445f29017f
-	 * Please see tables from 3-1 to 3-4.
+	 *
+	 * Please see tables mentioned in individual comments below for details.
 	 */
 
-	sram1: memory@0 {
+	ssram1: memory@0 {
+		/* Table 3-2, row 1. */
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x0 DT_SIZE_M(4)>;
-		zephyr,memory-region = "SRAM1";
+		zephyr,memory-region = "SSRAM1";
 	};
 
-	sram2_3: memory@28000000 {
+	ssram2_3: memory@28000000 {
+		/* Table 3-4, rows 8 and 9. */
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x28000000 DT_SIZE_M(4)>;
-		zephyr,memory-region = "SRAM2_3";
+		zephyr,memory-region = "SSRAM2_3";
 	};
 
 	psram: memory@80000000 {
+		/* Table 3-6, row 1. */
 		device_type = "memory";
 		reg = <0x80000000 DT_SIZE_M(16)>;
 	};
@@ -101,16 +105,22 @@
 		#size-cells = <1>;
 		ranges;
 
-		/* The memory regions defined below must match what the TF-M
+		/* This code memory region must match what the TF-M
 		 * project has defined for that board - a single image boot is
 		 * assumed. Please see the memory layout in:
-		 * https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tree/platform/ext/target/mps2/an521/partition/flash_layout.h
+		 *
+		 * https://github.com/zephyrproject-rtos/trusted-firmware-m/blob/master/platform/ext/target/arm/mps2/an521/partition/flash_layout.h
 		 */
-
 		code: memory@100000 {
 			reg = <0x00100000 DT_SIZE_K(512)>;
 		};
 
+		/* This ram memory region's size is chosen to avoid conflict
+		 * with the mps2_an521_remote board's RAM region.
+		 *
+		 * Its available address space must be compatible with what
+		 * TF-M assigns to NS firmware.
+		 */
 		ram: memory@28100000 {
 			reg = <0x28100000 DT_SIZE_K(512)>;
 		};

--- a/boards/arm/mps2_an521/mps2_an521_remote.dts
+++ b/boards/arm/mps2_an521/mps2_an521_remote.dts
@@ -76,22 +76,26 @@
 	/*
 	 * The memory regions defined below are according to AN521:
 	 * https://documentation-service.arm.com/static/5fa12fe9b1a7c5445f29017f
-	 * Please see tables from 3-1 to 3-4.
+	 *
+	 * Please see tables mentioned in individual comments below for details.
 	 */
 
-	sram1: memory@0 {
+	ssram1: memory@0 {
+		/* Table 3-2, row 1. */
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x0 DT_SIZE_M(4)>;
-		zephyr,memory-region = "SRAM1";
+		zephyr,memory-region = "SSRAM1";
 	};
 
-	sram2_3: memory@28000000 {
+	ssram2_3: memory@28000000 {
+		/* Table 3-4, rows 8 and 9. */
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x28000000 DT_SIZE_M(4)>;
-		zephyr,memory-region = "SRAM2_3";
+		zephyr,memory-region = "SSRAM2_3";
 	};
 
 	psram: memory@80000000 {
+		/* Table 3-6, row 1. */
 		device_type = "memory";
 		reg = <0x80000000 DT_SIZE_M(16)>;
 	};
@@ -101,16 +105,24 @@
 		#size-cells = <1>;
 		ranges;
 
-		/* The memory regions defined below are selected to remain
+		/* The code memory region defined below is selected to remain
 		 * compatible with what TF-M has defined for a single boot image,
 		 * where 468 KB memory at the bottom of the 4 MB code region is
-		 * marked as 'Unused'.
+		 * marked as 'Unused'. Please see the memory layout in:
+		 *
+		 * https://github.com/zephyrproject-rtos/trusted-firmware-m/blob/master/platform/ext/target/arm/mps2/an521/partition/flash_layout.h
 		 */
 
 		code: memory@38B000 {
 			reg = <0x0038B000 DT_SIZE_K(468)>;
 		};
 
+		/* This ram memory region's base address is chosen to avoid
+		 * conflict with the mps2_an521_ns board's RAM region.
+		 *
+		 * Its available address space must be compatible with what
+		 * TF-M assigns to NS firmware.
+		 */
 		ram: memory@28180000 {
 			reg = <0x28180000 DT_SIZE_K(512)>;
 		};

--- a/tests/kernel/mem_heap/shared_multi_heap/boards/mps2_an521.overlay
+++ b/tests/kernel/mem_heap/shared_multi_heap/boards/mps2_an521.overlay
@@ -7,10 +7,10 @@
 / {
 	/delete-node/ memory@38000000;
 
-	sram2_3: memory@38000000 {
+	ssram2_3: memory@38000000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x38000000 0x100000>;
-		zephyr,memory-region = "SRAM2_3";
+		zephyr,memory-region = "SSRAM2_3";
 	};
 
 	res0: memory@38100000 {


### PR DESCRIPTION
Fix comments in board DTS files referring to AN521 tables defining memory areas, and choose node label names that more accurately reflect the entries of interest in those tables.

@microbuilder this reflects the first couple of things we talked about. I thought about how to plumb the cpu1 start address from DT all the way through, but I think that's going to require system devicetree. It's an interesting use case that I hadn't considered, though, and will definitely affect the design.