### PR TITLE
mgmt: mcumgr: Replace SMP get MTU function with get details function

### DIFF
--- a/include/zephyr/mgmt/mcumgr/transport/smp.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp.h
@@ -18,6 +18,22 @@ struct smp_transport;
 struct zephyr_smp_transport;
 struct net_buf;
 
+
+/**
+ * @brief TODO
+ *
+ * @param mtu			
+ * @param ud_size		
+ * @param max_instances		
+ * @param async_supported	
+*/
+struct smp_transport_details_t {
+	uint32_t mtu;
+	uint8_t ud_size;
+	int16_t max_instances;
+	bool async_supported;
+};
+
 /** @typedef smp_transport_out_fn
  * @brief SMP transmit callback for transport
  *
@@ -31,8 +47,8 @@ typedef int (*smp_transport_out_fn)(struct net_buf *nb);
 /* use smp_transport_out_fn instead */
 typedef int zephyr_smp_transport_out_fn(struct net_buf *nb);
 
-/** @typedef smp_transport_get_mtu_fn
- * @brief SMP MTU query callback for transport
+/** @typedef smp_transport_get_details_fn
+ * @brief SMP details query callback for transport TODO
  *
  * The supplied net_buf should contain a request received from the peer whose
  * MTU is being queried.  This function takes a net_buf parameter because some
@@ -44,7 +60,8 @@ typedef int zephyr_smp_transport_out_fn(struct net_buf *nb);
  * @return                      The transport's MTU;
  *                              0 if transmission is currently not possible.
  */
-typedef uint16_t (*smp_transport_get_mtu_fn)(const struct net_buf *nb);
+typedef void (*smp_transport_get_details_fn)(const struct net_buf *nb,
+					     struct smp_transport_details_t *details);
 /* use smp_transport_get_mtu_fn instead */
 typedef uint16_t zephyr_smp_transport_get_mtu_fn(const struct net_buf *nb);
 
@@ -104,7 +121,7 @@ struct smp_transport {
 	struct k_fifo fifo;
 
 	smp_transport_out_fn output;
-	smp_transport_get_mtu_fn get_mtu;
+	smp_transport_get_details_fn get_details;
 	smp_transport_ud_copy_fn ud_copy;
 	smp_transport_ud_free_fn ud_free;
 	smp_transport_query_valid_check_fn query_valid_check;
@@ -118,6 +135,7 @@ struct smp_transport {
 #endif
 };
 
+#if 0
 /* Deprecated, use smp_transport instead */
 struct zephyr_smp_transport {
 	/* Must be the first member. */
@@ -139,6 +157,7 @@ struct zephyr_smp_transport {
 	} __reassembly;
 #endif
 };
+#endif
 
 /**
  * @brief Initializes a Zephyr SMP transport object.
@@ -152,11 +171,12 @@ struct zephyr_smp_transport {
  */
 void smp_transport_init(struct smp_transport *smpt,
 			smp_transport_out_fn output_func,
-			smp_transport_get_mtu_fn get_mtu_func,
+			smp_transport_get_details_fn get_details_func,
 			smp_transport_ud_copy_fn ud_copy_func,
 			smp_transport_ud_free_fn ud_free_func,
 			smp_transport_query_valid_check_fn query_valid_check_func);
 
+#if 0
 __deprecated static inline
 void zephyr_smp_transport_init(struct zephyr_smp_transport *smpt,
 			       zephyr_smp_transport_out_fn *output_func,
@@ -170,6 +190,7 @@ void zephyr_smp_transport_init(struct zephyr_smp_transport *smpt,
 			   (smp_transport_ud_copy_fn)ud_copy_func,
 			   (smp_transport_ud_free_fn)ud_free_func, NULL);
 }
+#endif
 
 /**
  * @brief	Used to remove queued requests for an SMP transport that are no longer valid. A

--- a/subsys/mgmt/mcumgr/transport/src/smp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp.c
@@ -137,14 +137,14 @@ smp_handle_reqs(struct k_work *work)
 void
 smp_transport_init(struct smp_transport *smpt,
 		   smp_transport_out_fn output_func,
-		   smp_transport_get_mtu_fn get_mtu_func,
+		   smp_transport_get_details_fn get_details_func,
 		   smp_transport_ud_copy_fn ud_copy_func,
 		   smp_transport_ud_free_fn ud_free_func,
 		   smp_transport_query_valid_check_fn query_valid_check_func)
 {
 	*smpt = (struct smp_transport) {
 		.output = output_func,
-		.get_mtu = get_mtu_func,
+		.get_details = get_details_func,
 		.ud_copy = ud_copy_func,
 		.ud_free = ud_free_func,
 		.query_valid_check = query_valid_check_func,

--- a/subsys/mgmt/mcumgr/transport/src/smp_bt.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_bt.c
@@ -400,6 +400,19 @@ static uint16_t smp_bt_get_mtu(const struct net_buf *nb)
 	return mtu - 3;
 }
 
+static void smp_bt_get_details(const struct net_buf *nb, struct smp_transport_details_t *details)
+{
+	if (nb == NULL) {
+		details->mtu = 0;
+	} else {
+		details->mtu = smp_bt_get_mtu(nb);
+	}
+
+	details->ud_size = sizeof(struct smp_bt_user_data);
+	details->max_instances = CONFIG_BT_MAX_CONN;
+	details->async_supported = true;
+}
+
 static void smp_bt_ud_free(void *ud)
 {
 	struct smp_bt_user_data *user_data = ud;
@@ -651,7 +664,7 @@ static int smp_bt_init(const struct device *dev)
 	}
 
 	smp_transport_init(&smp_bt_transport, smp_bt_tx_pkt,
-			   smp_bt_get_mtu, smp_bt_ud_copy,
+			   smp_bt_get_details, smp_bt_ud_copy,
 			   smp_bt_ud_free, smp_bt_query_valid_check);
 	return 0;
 }

--- a/subsys/mgmt/mcumgr/transport/src/smp_dummy.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_dummy.c
@@ -149,9 +149,13 @@ static void smp_dummy_rx_frag(struct uart_mcumgr_rx_buf *rx_buf)
 	k_work_submit(&smp_dummy_work);
 }
 
-static uint16_t smp_dummy_get_mtu(const struct net_buf *nb)
+static void smp_dummy_get_details(const struct net_buf *nb, struct smp_transport_details_t *details)
 {
-	return CONFIG_MCUMGR_SMP_DUMMY_RX_BUF_SIZE;
+	ARG_UNUSED(nb);
+	details->mtu = CONFIG_MCUMGR_SMP_DUMMY_RX_BUF_SIZE;
+	details->ud_size = 0;
+	details->max_instances = 1;
+	details->async_supported = true;
 }
 
 int dummy_mcumgr_send_raw(const void *data, int len)
@@ -191,7 +195,7 @@ static int smp_dummy_init(const struct device *dev)
 	k_sem_init(&smp_data_ready_sem, 0, 1);
 
 	smp_transport_init(&smp_dummy_transport, smp_dummy_tx_pkt_int,
-			   smp_dummy_get_mtu, NULL, NULL, NULL);
+			   smp_dummy_get_details, NULL, NULL, NULL);
 	dummy_mgumgr_recv_cb = smp_dummy_rx_frag;
 
 	return 0;

--- a/subsys/mgmt/mcumgr/transport/src/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_shell.c
@@ -158,9 +158,13 @@ void smp_shell_process(struct smp_shell_data *data)
 	}
 }
 
-static uint16_t smp_shell_get_mtu(const struct net_buf *nb)
+static void smp_shell_get_details(const struct net_buf *nb, struct smp_transport_details_t *details)
 {
-	return CONFIG_MCUMGR_SMP_SHELL_MTU;
+	ARG_UNUSED(nb);
+	details->mtu = CONFIG_MCUMGR_SMP_SHELL_MTU;
+	details->ud_size = 0;
+	details->max_instances = 1;
+	details->async_supported = true;
 }
 
 static int smp_shell_tx_raw(const void *data, int len)
@@ -192,7 +196,7 @@ static int smp_shell_tx_pkt(struct net_buf *nb)
 int smp_shell_init(void)
 {
 	smp_transport_init(&smp_shell_transport, smp_shell_tx_pkt,
-			   smp_shell_get_mtu, NULL, NULL, NULL);
+			   smp_shell_get_details, NULL, NULL, NULL);
 
 	return 0;
 }

--- a/subsys/mgmt/mcumgr/transport/src/smp_uart.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_uart.c
@@ -75,9 +75,13 @@ static void smp_uart_rx_frag(struct uart_mcumgr_rx_buf *rx_buf)
 	k_work_submit(&smp_uart_work);
 }
 
-static uint16_t smp_uart_get_mtu(const struct net_buf *nb)
+static void smp_uart_get_details(const struct net_buf *nb, struct smp_transport_details_t *details)
 {
-	return CONFIG_MCUMGR_SMP_UART_MTU;
+	ARG_UNUSED(nb);
+	details->mtu = CONFIG_MCUMGR_SMP_UART_MTU;
+	details->ud_size = 0;
+	details->max_instances = 1;
+	details->async_supported = true;
 }
 
 static int smp_uart_tx_pkt(struct net_buf *nb)
@@ -95,7 +99,7 @@ static int smp_uart_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	smp_transport_init(&smp_uart_transport, smp_uart_tx_pkt,
-			   smp_uart_get_mtu, NULL, NULL, NULL);
+			   smp_uart_get_details, NULL, NULL, NULL);
 	uart_mcumgr_register(smp_uart_rx_frag);
 
 	return 0;

--- a/subsys/mgmt/mcumgr/transport/src/smp_udp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_udp.c
@@ -104,11 +104,14 @@ static int smp_udp6_tx(struct net_buf *nb)
 }
 #endif
 
-static uint16_t smp_udp_get_mtu(const struct net_buf *nb)
+static void smp_udp_get_details(const struct net_buf *nb, struct smp_transport_details_t *details)
 {
 	ARG_UNUSED(nb);
 
-	return CONFIG_MCUMGR_SMP_UDP_MTU;
+	details->mtu = CONFIG_MCUMGR_SMP_UDP_MTU;
+	details->ud_size = sizeof(struct sockaddr);
+	details->max_instances = CONFIG_NET_MAX_CONN;
+	details->async_supported = true;
 }
 
 static int smp_udp_ud_copy(struct net_buf *dst, const struct net_buf *src)
@@ -166,13 +169,13 @@ static int smp_udp_init(const struct device *dev)
 
 #ifdef CONFIG_MCUMGR_SMP_UDP_IPV4
 	smp_transport_init(&configs.ipv4.smp_transport,
-			   smp_udp4_tx, smp_udp_get_mtu,
+			   smp_udp4_tx, smp_udp_get_details,
 			   smp_udp_ud_copy, NULL, NULL);
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_UDP_IPV6
 	smp_transport_init(&configs.ipv6.smp_transport,
-			   smp_udp6_tx, smp_udp_get_mtu,
+			   smp_udp6_tx, smp_udp_get_details,
 			   smp_udp_ud_copy, NULL, NULL);
 #endif
 


### PR DESCRIPTION
Replaces the mcumgr SMP function to get the transport MTU to instead return a structure with additional details in.

Fixes #51857