### PR TITLE
Bluetooth: Mesh: Fix static oob zero padding

### DIFF
--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -313,7 +313,7 @@ int bt_mesh_input_string(const char *str)
 		return -EINVAL;
 	}
 
-	strcpy((char *)bt_mesh_prov_link.auth, str);
+	memcpy(bt_mesh_prov_link.auth, str, strlen(str));
 
 	bt_mesh_prov_link.role->input_complete();
 

--- a/subsys/bluetooth/mesh/prov_device.c
+++ b/subsys/bluetooth/mesh/prov_device.c
@@ -160,10 +160,10 @@ static void prov_start(const uint8_t *data)
 	}
 
 	if (atomic_test_bit(bt_mesh_prov_link.flags, OOB_STATIC_KEY)) {
-		memcpy(bt_mesh_prov_link.auth + 16 - bt_mesh_prov->static_val_len,
-		       bt_mesh_prov->static_val, bt_mesh_prov->static_val_len);
-		(void)memset(bt_mesh_prov_link.auth, 0,
-			     sizeof(bt_mesh_prov_link.auth) - bt_mesh_prov->static_val_len);
+		memcpy(bt_mesh_prov_link.auth, bt_mesh_prov->static_val,
+				bt_mesh_prov->static_val_len);
+		memset(bt_mesh_prov_link.auth + bt_mesh_prov->static_val_len, 0,
+				sizeof(bt_mesh_prov_link.auth) - bt_mesh_prov->static_val_len);
 	}
 }
 

--- a/subsys/bluetooth/mesh/provisioner.c
+++ b/subsys/bluetooth/mesh/provisioner.c
@@ -698,11 +698,9 @@ int bt_mesh_auth_method_set_static(const uint8_t *static_val, uint8_t size)
 
 	prov_set_method(AUTH_METHOD_STATIC, 0, 0);
 
-	memcpy(bt_mesh_prov_link.auth + 16 - size, static_val, size);
-	if (size < 16) {
-		(void)memset(bt_mesh_prov_link.auth, 0,
-			     sizeof(bt_mesh_prov_link.auth) - size);
-	}
+	memcpy(bt_mesh_prov_link.auth, static_val, size);
+	memset(bt_mesh_prov_link.auth + size, 0, sizeof(bt_mesh_prov_link.auth) - size);
+
 	return 0;
 }
 


### PR DESCRIPTION
The sample in the Provisioning protocol spec chapter is in big endian. Static OOB value should append zeroes on the little endian platforms.
Fix memory corruption if input oob string is 16 bytes.
