### PR TITLE
net: Fix variable buffer length configuration

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -112,6 +112,13 @@ Stable API changes in this release
   Applications using the existing callback system will need to be upgraded to
   use the new API by following the :ref:`migration guide <mcumgr_cb_migration>`
 
+* :c:func:`net_pkt_get_frag`, :c:func:`net_pkt_get_reserve_tx_data` and
+  :c:func:`net_pkt_get_reserve_rx_data` functions are now requiring to specify
+  the minimum fragment length to allocate, so that they work correctly also in
+  case :kconfig:option:`CONFIG_NET_BUF_VARIABLE_DATA_SIZE` is enabled.
+  Applications using this APIs will need to be updated to provide the expected
+  fragment length.
+
 New APIs in this release
 ========================
 

--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -6,6 +6,7 @@
 menuconfig ETH_SAM_GMAC
 	bool "Atmel SAM Ethernet driver"
 	default y
+	depends on NET_BUF_FIXED_DATA_SIZE
 	depends on DT_HAS_ATMEL_SAM_GMAC_ENABLED || \
 		   DT_HAS_ATMEL_SAM0_GMAC_ENABLED
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT

--- a/drivers/ethernet/eth_dwmac.c
+++ b/drivers/ethernet/eth_dwmac.c
@@ -359,7 +359,7 @@ static void dwmac_rx_refill_thread(void *arg1, void *unused1, void *unused2)
 
 		/* get a new fragment if the previous one was consumed */
 		if (!frag) {
-			frag = net_pkt_get_reserve_rx_data(K_FOREVER);
+			frag = net_pkt_get_reserve_rx_data(RX_FRAG_SIZE, K_FOREVER);
 			if (!frag) {
 				LOG_ERR("net_pkt_get_reserve_rx_data() returned NULL");
 				k_sem_give(&p->free_rx_descs);

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -477,7 +477,8 @@ static int rx_descriptors_init(Gmac *gmac, struct gmac_queue *queue)
 	rx_desc_list->tail = 0U;
 
 	for (int i = 0; i < rx_desc_list->len; i++) {
-		rx_buf = net_pkt_get_reserve_rx_data(K_NO_WAIT);
+		rx_buf = net_pkt_get_reserve_rx_data(CONFIG_NET_BUF_DATA_SIZE,
+						     K_NO_WAIT);
 		if (rx_buf == NULL) {
 			free_rx_bufs(rx_frag_list, rx_desc_list->len);
 			LOG_ERR("Failed to reserve data net buffers");
@@ -1308,7 +1309,7 @@ static struct net_pkt *frame_get(struct gmac_queue *queue)
 			dcache_invalidate((uint32_t)frag_data, frag->size);
 
 			/* Get a new data net buffer from the buffer pool */
-			new_frag = net_pkt_get_frag(rx_frame, K_NO_WAIT);
+			new_frag = net_pkt_get_frag(rx_frame, CONFIG_NET_BUF_DATA_SIZE, K_NO_WAIT);
 			if (new_frag == NULL) {
 				queue->err_rx_frames_dropped++;
 				net_pkt_unref(rx_frame);

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -136,7 +136,7 @@ static uint8_t *upipe_rx(uint8_t *buf, size_t *off)
 			goto flush;
 		}
 
-		frag = net_pkt_get_frag(pkt, K_NO_WAIT);
+		frag = net_pkt_get_frag(pkt, upipe->rx_len, K_NO_WAIT);
 		if (!frag) {
 			LOG_DBG("No fragment available");
 			goto out;

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -68,6 +68,18 @@ struct slip_context {
 #endif
 };
 
+#if defined(CONFIG_SLIP_TAP)
+#define _SLIP_MTU 1500
+#else
+#define _SLIP_MTU 576
+#endif /* CONFIG_SLIP_TAP */
+
+#if defined(CONFIG_NET_BUF_FIXED_DATA_SIZE)
+#define SLIP_FRAG_LEN CONFIG_NET_BUF_DATA_SIZE
+#else
+#define SLIP_FRAG_LEN _SLIP_MTU
+#endif /* CONFIG_NET_BUF_FIXED_DATA_SIZE */
+
 static inline void slip_writeb(unsigned char c)
 {
 	uint8_t buf[1] = { c };
@@ -260,7 +272,8 @@ static inline int slip_input_byte(struct slip_context *slip,
 				return 0;
 			}
 
-			slip->last = net_pkt_get_frag(slip->rx, K_NO_WAIT);
+			slip->last = net_pkt_get_frag(slip->rx, SLIP_FRAG_LEN,
+						      K_NO_WAIT);
 			if (!slip->last) {
 				LOG_ERR("[%p] cannot allocate 1st data buffer",
 					slip);
@@ -288,7 +301,7 @@ static inline int slip_input_byte(struct slip_context *slip,
 		/* We need to allocate a new buffer */
 		struct net_buf *buf;
 
-		buf = net_pkt_get_reserve_rx_data(K_NO_WAIT);
+		buf = net_pkt_get_reserve_rx_data(SLIP_FRAG_LEN, K_NO_WAIT);
 		if (!buf) {
 			LOG_ERR("[%p] cannot allocate next data buf", slip);
 			net_pkt_unref(slip->rx);
@@ -454,7 +467,6 @@ static const struct ethernet_api slip_if_api = {
 
 #define _SLIP_L2_LAYER ETHERNET_L2
 #define _SLIP_L2_CTX_TYPE NET_L2_GET_CTX_TYPE(ETHERNET_L2)
-#define _SLIP_MTU 1500
 
 ETH_NET_DEVICE_INIT(slip, CONFIG_SLIP_DRV_NAME,
 		    slip_init, NULL,
@@ -471,7 +483,6 @@ static const struct dummy_api slip_if_api = {
 
 #define _SLIP_L2_LAYER DUMMY_L2
 #define _SLIP_L2_CTX_TYPE NET_L2_GET_CTX_TYPE(DUMMY_L2)
-#define _SLIP_MTU 576
 
 NET_DEVICE_INIT(slip, CONFIG_SLIP_DRV_NAME, slip_init, NULL,
 		&slip_context_data, NULL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -1322,30 +1322,33 @@ static inline bool net_pkt_filter_recv_ok(struct net_pkt *pkt)
  */
 
 struct net_buf *net_pkt_get_reserve_data_debug(struct net_buf_pool *pool,
+					       size_t min_len,
 					       k_timeout_t timeout,
 					       const char *caller,
 					       int line);
 
-#define net_pkt_get_reserve_data(pool, timeout)				\
-	net_pkt_get_reserve_data_debug(pool, timeout, __func__, __LINE__)
+#define net_pkt_get_reserve_data(pool, min_len, timeout)				\
+	net_pkt_get_reserve_data_debug(pool, min_len, timeout, __func__, __LINE__)
 
-struct net_buf *net_pkt_get_reserve_rx_data_debug(k_timeout_t timeout,
+struct net_buf *net_pkt_get_reserve_rx_data_debug(size_t min_len,
+						  k_timeout_t timeout,
 						  const char *caller,
 						  int line);
-#define net_pkt_get_reserve_rx_data(timeout)				\
-	net_pkt_get_reserve_rx_data_debug(timeout, __func__, __LINE__)
+#define net_pkt_get_reserve_rx_data(min_len, timeout)				\
+	net_pkt_get_reserve_rx_data_debug(min_len, timeout, __func__, __LINE__)
 
-struct net_buf *net_pkt_get_reserve_tx_data_debug(k_timeout_t timeout,
+struct net_buf *net_pkt_get_reserve_tx_data_debug(size_t min_len,
+						  k_timeout_t timeout,
 						  const char *caller,
 						  int line);
-#define net_pkt_get_reserve_tx_data(timeout)				\
-	net_pkt_get_reserve_tx_data_debug(timeout, __func__, __LINE__)
+#define net_pkt_get_reserve_tx_data(min_len, timeout)				\
+	net_pkt_get_reserve_tx_data_debug(min_len, timeout, __func__, __LINE__)
 
-struct net_buf *net_pkt_get_frag_debug(struct net_pkt *pkt,
+struct net_buf *net_pkt_get_frag_debug(struct net_pkt *pkt, size_t min_len,
 				       k_timeout_t timeout,
 				       const char *caller, int line);
-#define net_pkt_get_frag(pkt, timeout)					\
-	net_pkt_get_frag_debug(pkt, timeout, __func__, __LINE__)
+#define net_pkt_get_frag(pkt, min_len, timeout)					\
+	net_pkt_get_frag_debug(pkt, min_len, timeout, __func__, __LINE__)
 
 void net_pkt_unref_debug(struct net_pkt *pkt, const char *caller, int line);
 #define net_pkt_unref(pkt) net_pkt_unref_debug(pkt, __func__, __LINE__)
@@ -1404,6 +1407,7 @@ void net_pkt_print_frags(struct net_pkt *pkt);
  * @details Normally this version is not useful for applications
  * but is mainly used by network fragmentation code.
  *
+ * @param min_len Minimum length of the requested fragment.
  * @param timeout Affects the action taken should the net buf pool be empty.
  *        If K_NO_WAIT, then return immediately. If K_FOREVER, then
  *        wait as long as necessary. Otherwise, wait up to the specified time.
@@ -1411,7 +1415,7 @@ void net_pkt_print_frags(struct net_pkt *pkt);
  * @return Network buffer if successful, NULL otherwise.
  */
 #if !defined(NET_PKT_DEBUG_ENABLED)
-struct net_buf *net_pkt_get_reserve_rx_data(k_timeout_t timeout);
+struct net_buf *net_pkt_get_reserve_rx_data(size_t min_len, k_timeout_t timeout);
 #endif
 
 /**
@@ -1421,6 +1425,7 @@ struct net_buf *net_pkt_get_reserve_rx_data(k_timeout_t timeout);
  * @details Normally this version is not useful for applications
  * but is mainly used by network fragmentation code.
  *
+ * @param min_len Minimum length of the requested fragment.
  * @param timeout Affects the action taken should the net buf pool be empty.
  *        If K_NO_WAIT, then return immediately. If K_FOREVER, then
  *        wait as long as necessary. Otherwise, wait up to the specified time.
@@ -1428,7 +1433,7 @@ struct net_buf *net_pkt_get_reserve_rx_data(k_timeout_t timeout);
  * @return Network buffer if successful, NULL otherwise.
  */
 #if !defined(NET_PKT_DEBUG_ENABLED)
-struct net_buf *net_pkt_get_reserve_tx_data(k_timeout_t timeout);
+struct net_buf *net_pkt_get_reserve_tx_data(size_t min_len, k_timeout_t timeout);
 #endif
 
 /**
@@ -1436,6 +1441,7 @@ struct net_buf *net_pkt_get_reserve_tx_data(k_timeout_t timeout);
  * buffer pool or from global DATA pool.
  *
  * @param pkt Network packet.
+ * @param min_len Minimum length of the requested fragment.
  * @param timeout Affects the action taken should the net buf pool be empty.
  *        If K_NO_WAIT, then return immediately. If K_FOREVER, then
  *        wait as long as necessary. Otherwise, wait up to the specified time.
@@ -1443,7 +1449,8 @@ struct net_buf *net_pkt_get_reserve_tx_data(k_timeout_t timeout);
  * @return Network buffer if successful, NULL otherwise.
  */
 #if !defined(NET_PKT_DEBUG_ENABLED)
-struct net_buf *net_pkt_get_frag(struct net_pkt *pkt, k_timeout_t timeout);
+struct net_buf *net_pkt_get_frag(struct net_pkt *pkt, size_t min_len,
+				 k_timeout_t timeout);
 #endif
 
 /**

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -239,7 +239,8 @@ static void dataInit(void)
 	tx_pkt = net_pkt_alloc(K_NO_WAIT);
 	__ASSERT_NO_MSG(tx_pkt != NULL);
 
-	tx_payload = net_pkt_get_reserve_tx_data(K_NO_WAIT);
+	tx_payload = net_pkt_get_reserve_tx_data(IEEE802154_MAX_PHY_PACKET_SIZE,
+						 K_NO_WAIT);
 	__ASSERT_NO_MSG(tx_payload != NULL);
 
 	net_pkt_append_buffer(tx_pkt, tx_payload);

--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -1394,16 +1394,18 @@ static bool uncompress_IPHC_header(struct net_pkt *pkt)
 		cursor = frag->data + diff;
 		memmove(cursor, frag->data, frag->len - diff);
 	} else {
+		size_t frag_len = nhc ? NET_IPV6UDPH_LEN : NET_IPV6H_LEN;
+
 		NET_DBG("Not enough tailroom. Get new fragment");
 		cursor =  pkt->buffer->data;
-		frag = net_pkt_get_frag(pkt, NET_6LO_RX_PKT_TIMEOUT);
+		frag = net_pkt_get_frag(pkt, frag_len, NET_6LO_RX_PKT_TIMEOUT);
 		if (!frag) {
 			NET_ERR("Can't get frag for uncompression");
 			return false;
 		}
 
 		net_buf_pull(pkt->buffer, compressed_hdr_size);
-		net_buf_add(frag, nhc ? NET_IPV6UDPH_LEN : NET_IPV6H_LEN);
+		net_buf_add(frag, frag_len);
 	}
 
 	ipv6 = (struct net_ipv6_hdr *)(frag->data);
@@ -1537,7 +1539,7 @@ static inline int compress_ipv6_header(struct net_pkt *pkt)
 		return 0;
 	}
 
-	buffer = net_pkt_get_frag(pkt, K_FOREVER);
+	buffer = net_pkt_get_frag(pkt, 1, K_FOREVER);
 	if (!buffer) {
 		return -ENOBUFS;
 	}

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -85,6 +85,7 @@ LOG_MODULE_REGISTER(net_pkt, CONFIG_NET_PKT_LOG_LEVEL);
 /* Make sure that IP + TCP/UDP/ICMP headers fit into one fragment. This
  * makes possible to cast a fragment pointer to protocol header struct.
  */
+#if defined(CONFIG_NET_BUF_FIXED_DATA_SIZE)
 #if CONFIG_NET_BUF_DATA_SIZE < (MAX_IP_PROTO_LEN + MAX_NEXT_PROTO_LEN)
 #if defined(STRING2)
 #undef STRING2
@@ -98,6 +99,7 @@ LOG_MODULE_REGISTER(net_pkt, CONFIG_NET_PKT_LOG_LEVEL);
 #pragma message "Minimum len " STRING(MAX_IP_PROTO_LEN + MAX_NEXT_PROTO_LEN)
 #error "Too small net_buf fragment size"
 #endif
+#endif /* CONFIG_NET_BUF_FIXED_DATA_SIZE */
 
 #if CONFIG_NET_PKT_RX_COUNT <= 0
 #error "Minimum value for CONFIG_NET_PKT_RX_COUNT is 1"

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -368,26 +368,31 @@ void net_pkt_print_frags(struct net_pkt *pkt)
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 struct net_buf *net_pkt_get_reserve_data_debug(struct net_buf_pool *pool,
+					       size_t min_len,
 					       k_timeout_t timeout,
 					       const char *caller,
 					       int line)
 #else /* NET_LOG_LEVEL >= LOG_LEVEL_DBG */
 struct net_buf *net_pkt_get_reserve_data(struct net_buf_pool *pool,
-					 k_timeout_t timeout)
+					 size_t min_len, k_timeout_t timeout)
 #endif /* NET_LOG_LEVEL >= LOG_LEVEL_DBG */
 {
 	struct net_buf *frag;
 
-	/*
-	 * The reserve_head variable in the function will tell
-	 * the size of the link layer headers if there are any.
-	 */
-
 	if (k_is_in_isr()) {
-		frag = net_buf_alloc(pool, K_NO_WAIT);
-	} else {
-		frag = net_buf_alloc(pool, timeout);
+		timeout = K_NO_WAIT;
 	}
+
+#if defined(CONFIG_NET_BUF_FIXED_DATA_SIZE)
+	if (min_len > CONFIG_NET_BUF_DATA_SIZE) {
+		NET_ERR("Requested too large fragment. Increase CONFIG_NET_BUF_DATA_SIZE.");
+		return NULL;
+	}
+
+	frag = net_buf_alloc(pool, timeout);
+#else
+	frag = net_buf_alloc_len(pool, min_len, timeout);
+#endif /* CONFIG_NET_BUF_FIXED_DATA_SIZE */
 
 	if (!frag) {
 		return NULL;
@@ -412,11 +417,11 @@ struct net_buf *net_pkt_get_reserve_data(struct net_buf_pool *pool,
  * the data.
  */
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
-struct net_buf *net_pkt_get_frag_debug(struct net_pkt *pkt,
+struct net_buf *net_pkt_get_frag_debug(struct net_pkt *pkt, size_t min_len,
 				       k_timeout_t timeout,
 				       const char *caller, int line)
 #else
-struct net_buf *net_pkt_get_frag(struct net_pkt *pkt,
+struct net_buf *net_pkt_get_frag(struct net_pkt *pkt, size_t min_len,
 				 k_timeout_t timeout)
 #endif
 {
@@ -427,52 +432,54 @@ struct net_buf *net_pkt_get_frag(struct net_pkt *pkt,
 	if (context && context->data_pool) {
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 		return net_pkt_get_reserve_data_debug(context->data_pool(),
-						      timeout, caller, line);
+						      min_len, timeout,
+						      caller, line);
 #else
-		return net_pkt_get_reserve_data(context->data_pool(), timeout);
+		return net_pkt_get_reserve_data(context->data_pool(), min_len,
+						timeout);
 #endif /* NET_LOG_LEVEL >= LOG_LEVEL_DBG */
 	}
 #endif /* CONFIG_NET_CONTEXT_NET_PKT_POOL */
 
 	if (pkt->slab == &rx_pkts) {
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
-		return net_pkt_get_reserve_rx_data_debug(timeout,
+		return net_pkt_get_reserve_rx_data_debug(min_len, timeout,
 							 caller, line);
 #else
-		return net_pkt_get_reserve_rx_data(timeout);
+		return net_pkt_get_reserve_rx_data(min_len, timeout);
 #endif
 	}
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
-	return net_pkt_get_reserve_tx_data_debug(timeout, caller, line);
+	return net_pkt_get_reserve_tx_data_debug(min_len, timeout, caller, line);
 #else
-	return net_pkt_get_reserve_tx_data(timeout);
+	return net_pkt_get_reserve_tx_data(min_len, timeout);
 #endif
 }
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
-struct net_buf *net_pkt_get_reserve_rx_data_debug(k_timeout_t timeout,
+struct net_buf *net_pkt_get_reserve_rx_data_debug(size_t min_len, k_timeout_t timeout,
 						  const char *caller, int line)
 {
-	return net_pkt_get_reserve_data_debug(&rx_bufs, timeout, caller, line);
+	return net_pkt_get_reserve_data_debug(&rx_bufs, min_len, timeout, caller, line);
 }
 
-struct net_buf *net_pkt_get_reserve_tx_data_debug(k_timeout_t timeout,
+struct net_buf *net_pkt_get_reserve_tx_data_debug(size_t min_len, k_timeout_t timeout,
 						  const char *caller, int line)
 {
-	return net_pkt_get_reserve_data_debug(&tx_bufs, timeout, caller, line);
+	return net_pkt_get_reserve_data_debug(&tx_bufs, min_len, timeout, caller, line);
 }
 
 #else /* NET_LOG_LEVEL >= LOG_LEVEL_DBG */
 
-struct net_buf *net_pkt_get_reserve_rx_data(k_timeout_t timeout)
+struct net_buf *net_pkt_get_reserve_rx_data(size_t min_len, k_timeout_t timeout)
 {
-	return net_pkt_get_reserve_data(&rx_bufs, timeout);
+	return net_pkt_get_reserve_data(&rx_bufs, min_len, timeout);
 }
 
-struct net_buf *net_pkt_get_reserve_tx_data(k_timeout_t timeout)
+struct net_buf *net_pkt_get_reserve_tx_data(size_t min_len, k_timeout_t timeout)
 {
-	return net_pkt_get_reserve_data(&tx_bufs, timeout);
+	return net_pkt_get_reserve_data(&tx_bufs, min_len, timeout);
 }
 
 #endif /* NET_LOG_LEVEL >= LOG_LEVEL_DBG */

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3657,7 +3657,11 @@ static int cmd_net_mem(const struct shell *shell, size_t argc, char *argv[])
 
 	net_pkt_get_info(&rx, &tx, &rx_data, &tx_data);
 
+#if defined(CONFIG_NET_BUF_FIXED_DATA_SIZE)
 	PR("Fragment length %d bytes\n", CONFIG_NET_BUF_DATA_SIZE);
+#else
+	PR("Fragment data pool size %d bytes\n", CONFIG_NET_BUF_DATA_POOL_SIZE);
+#endif /* CONFIG_NET_BUF_FIXED_DATA_SIZE */
 
 	PR("Network buffer pools:\n");
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -92,7 +92,7 @@ static int tcp_pkt_linearize(struct net_pkt *pkt, size_t pos, size_t len)
 		goto out;
 	}
 
-	buf = net_pkt_get_frag(pkt, TCP_PKT_ALLOC_TIMEOUT);
+	buf = net_pkt_get_frag(pkt, len, TCP_PKT_ALLOC_TIMEOUT);
 
 	if (!buf || buf->size < len) {
 		if (buf) {

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -40,7 +40,11 @@ static int tcp_window =
 #if (CONFIG_NET_TCP_MAX_RECV_WINDOW_SIZE != 0)
 	CONFIG_NET_TCP_MAX_RECV_WINDOW_SIZE;
 #else
+#if defined(CONFIG_NET_BUF_FIXED_DATA_SIZE)
 	(CONFIG_NET_BUF_RX_COUNT * CONFIG_NET_BUF_DATA_SIZE) / 3;
+#else
+	CONFIG_NET_BUF_DATA_POOL_SIZE / 3;
+#endif /* CONFIG_NET_BUF_FIXED_DATA_SIZE */
 #endif
 #ifdef CONFIG_NET_TCP_RANDOMIZED_RTO
 #define TCP_RTO_MS (conn->rto)
@@ -2113,8 +2117,12 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt)
 			/* Adjust the window so that we do not run out of bufs
 			 * while waiting acks.
 			 */
+#if defined(CONFIG_NET_BUF_FIXED_DATA_SIZE)
 			max_win = (CONFIG_NET_BUF_TX_COUNT *
 				   CONFIG_NET_BUF_DATA_SIZE) / 3;
+#else
+			max_win = CONFIG_NET_BUF_DATA_POOL_SIZE / 3;
+#endif /* CONFIG_NET_BUF_FIXED_DATA_SIZE */
 		}
 
 		if (sndbuf_opt > 0) {

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -50,6 +50,12 @@ extern int net_bt_shell_init(void);
 #define net_bt_shell_init(...)
 #endif
 
+#if defined(CONFIG_NET_BUF_FIXED_DATA_SIZE)
+#define IPSP_FRAG_LEN CONFIG_NET_BUF_DATA_SIZE
+#else
+#define IPSP_FRAG_LEN L2CAP_IPSP_MTU
+#endif /* CONFIG_NET_BUF_FIXED_DATA_SIZE */
+
 struct bt_if_conn {
 	struct net_if *iface;
 	struct bt_l2cap_le_chan ipsp_chan;
@@ -259,7 +265,7 @@ static struct net_buf *ipsp_alloc_buf(struct bt_l2cap_chan *chan)
 {
 	NET_DBG("Channel %p requires buffer", chan);
 
-	return net_pkt_get_reserve_rx_data(BUF_TIMEOUT);
+	return net_pkt_get_reserve_rx_data(IPSP_FRAG_LEN, BUF_TIMEOUT);
 }
 
 static const struct bt_l2cap_chan_ops ipsp_ops = {

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -508,8 +508,11 @@ static struct net_buf *ethernet_fill_header(struct ethernet_context *ctx,
 {
 	struct net_buf *hdr_frag;
 	struct net_eth_hdr *hdr;
+	size_t hdr_len = IS_ENABLED(CONFIG_NET_VLAN) ?
+			 sizeof(struct net_eth_vlan_hdr) :
+			 sizeof(struct net_eth_hdr);
 
-	hdr_frag = net_pkt_get_frag(pkt, NET_BUF_TIMEOUT);
+	hdr_frag = net_pkt_get_frag(pkt, hdr_len, NET_BUF_TIMEOUT);
 	if (!hdr_frag) {
 		return NULL;
 	}

--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -460,7 +460,8 @@ int ppp_send_pkt(struct ppp_fsm *fsm, struct net_if *iface,
 	} else {
 		struct net_buf *buf;
 
-		buf = net_pkt_get_reserve_tx_data(PPP_BUF_ALLOC_TIMEOUT);
+		buf = net_pkt_get_reserve_tx_data(sizeof(uint16_t) + len,
+						  PPP_BUF_ALLOC_TIMEOUT);
 		if (!buf) {
 			LOG_ERR("failed to allocate buffer");
 			goto out_of_mem;

--- a/tests/net/6lo/src/main.c
+++ b/tests/net/6lo/src/main.c
@@ -219,6 +219,12 @@ static const char user_data[] =
 		"0123456789012345678901234567890123456789"
 		"0123456789012345678901234567890123456789";
 
+#if defined(CONFIG_NET_BUF_FIXED_DATA_SIZE)
+#define TEST_FRAG_LEN CONFIG_NET_BUF_DATA_SIZE
+#else
+#define TEST_FRAG_LEN 128
+#endif /* CONFIG_NET_BUF_FIXED_DATA_SIZE */
+
 struct user_data_small {
 	char data[SIZE_OF_SMALL_DATA];
 };
@@ -474,7 +480,7 @@ static struct net_pkt *create_pkt(struct net_6lo_data *data)
 	net_pkt_lladdr_dst(pkt)->addr = dst_mac;
 	net_pkt_lladdr_dst(pkt)->len = 8U;
 
-	frag = net_pkt_get_frag(pkt, K_FOREVER);
+	frag = net_pkt_get_frag(pkt, NET_IPV6UDPH_LEN, K_FOREVER);
 	if (!frag) {
 		net_pkt_unref(pkt);
 		return NULL;
@@ -536,7 +542,7 @@ static struct net_pkt *create_pkt(struct net_6lo_data *data)
 		net_pkt_frag_add(pkt, frag);
 
 		if (remaining > 0) {
-			frag = net_pkt_get_frag(pkt, K_FOREVER);
+			frag = net_pkt_get_frag(pkt, TEST_FRAG_LEN, K_FOREVER);
 		}
 	}
 

--- a/tests/net/6lo/testcase.yaml
+++ b/tests/net/6lo/testcase.yaml
@@ -9,3 +9,7 @@ tests:
   net.6lo.preempt:
     extra_configs:
       - CONFIG_NET_TC_THREAD_PREEMPTIVE=y
+  net.6lo.variable_buf_size:
+    extra_configs:
+      - CONFIG_NET_BUF_VARIABLE_DATA_SIZE=y
+      - CONFIG_NET_BUF_DATA_POOL_SIZE=4096

--- a/tests/net/ieee802154/6lo_fragment/src/main.c
+++ b/tests/net/ieee802154/6lo_fragment/src/main.c
@@ -245,7 +245,7 @@ static struct net_pkt *create_pkt(struct net_fragment_data *data)
 
 	net_pkt_set_ip_hdr_len(pkt, NET_IPV6H_LEN);
 
-	buf = net_pkt_get_frag(pkt, K_FOREVER);
+	buf = net_pkt_get_frag(pkt, NET_IPV6UDPH_LEN, K_FOREVER);
 	if (!buf) {
 		net_pkt_unref(pkt);
 		return NULL;
@@ -285,7 +285,7 @@ static struct net_pkt *create_pkt(struct net_fragment_data *data)
 		net_pkt_frag_add(pkt, buf);
 
 		if (remaining > 0) {
-			buf = net_pkt_get_frag(pkt, K_FOREVER);
+			buf = net_pkt_get_frag(pkt, CONFIG_NET_BUF_DATA_SIZE, K_FOREVER);
 		}
 	}
 
@@ -493,7 +493,7 @@ static bool test_fragment(struct net_fragment_data *data)
 	while (buf) {
 		buf = ieee802154_6lo_fragment(&ctx, &frame_buf, data->iphc);
 
-		dfrag = net_pkt_get_frag(f_pkt, K_FOREVER);
+		dfrag = net_pkt_get_frag(f_pkt, frame_buf.len, K_FOREVER);
 		if (!dfrag) {
 			goto end;
 		}
@@ -524,7 +524,7 @@ reassemble:
 			goto end;
 		}
 
-		dfrag = net_pkt_get_frag(rxpkt, K_FOREVER);
+		dfrag = net_pkt_get_frag(rxpkt, buf->len, K_FOREVER);
 		if (!dfrag) {
 			goto end;
 		}

--- a/tests/net/ieee802154/l2/src/ieee802154_fake_driver.c
+++ b/tests/net/ieee802154/l2/src/ieee802154_fake_driver.c
@@ -48,7 +48,7 @@ static inline void insert_frag(struct net_pkt *pkt, struct net_buf *frag)
 {
 	struct net_buf *new_frag;
 
-	new_frag = net_pkt_get_frag(pkt, K_SECONDS(1));
+	new_frag = net_pkt_get_frag(pkt, frag->len, K_SECONDS(1));
 	if (!new_frag) {
 		return;
 	}

--- a/tests/net/ieee802154/l2/src/ieee802154_test.c
+++ b/tests/net/ieee802154/l2/src/ieee802154_test.c
@@ -464,7 +464,7 @@ static bool test_ack_reply(struct ieee802154_pkt_test *t)
 	NET_INFO("- Sending ACK reply to a data packet\n");
 
 	pkt = net_pkt_rx_alloc(K_FOREVER);
-	frag = net_pkt_get_frag(pkt, K_FOREVER);
+	frag = net_pkt_get_frag(pkt, sizeof(data_pkt), K_FOREVER);
 
 	memcpy(frag->data, data_pkt, sizeof(data_pkt));
 	frag->len = sizeof(data_pkt);

--- a/tests/net/ipv6/testcase.yaml
+++ b/tests/net/ipv6/testcase.yaml
@@ -1,4 +1,11 @@
+common:
+  tags: net ipv6
+  depends_on: netif
 tests:
   net.ipv6:
-    tags: net ipv6
-    depends_on: netif
+    extra_configs:
+      - CONFIG_NET_BUF_FIXED_DATA_SIZE=y
+  net.ipv6.variable_buf_size:
+    extra_configs:
+      - CONFIG_NET_BUF_VARIABLE_DATA_SIZE=y
+      - CONFIG_NET_BUF_DATA_POOL_SIZE=4096

--- a/tests/net/tcp/testcase.yaml
+++ b/tests/net/tcp/testcase.yaml
@@ -8,3 +8,7 @@ tests:
   net.tcp.no_recv_queue:
     extra_configs:
       - CONFIG_NET_TCP_RECV_QUEUE_TIMEOUT=0
+  net.tcp.variable_buf_size:
+    extra_configs:
+      - CONFIG_NET_BUF_VARIABLE_DATA_SIZE=y
+      - CONFIG_NET_BUF_DATA_POOL_SIZE=4096

--- a/tests/subsys/openthread/radio_test.c
+++ b/tests/subsys/openthread/radio_test.c
@@ -244,7 +244,7 @@ static void create_ack_frame(void)
 	const int8_t rssi = -80;
 
 	packet = net_pkt_alloc(K_NO_WAIT);
-	buf = net_pkt_get_reserve_tx_data(K_NO_WAIT);
+	buf = net_pkt_get_reserve_tx_data(ACK_PKT_LENGTH, K_NO_WAIT);
 	net_pkt_append_buffer(packet, buf);
 
 	buf->len = ACK_PKT_LENGTH;
@@ -724,7 +724,8 @@ uint8_t alloc_pkt(struct net_pkt **out_packet, uint8_t buf_ct, uint8_t offset)
 
 	packet = net_pkt_alloc(K_NO_WAIT);
 	for (buf_num = 0; buf_num < buf_ct; buf_num++) {
-		buf = net_pkt_get_reserve_tx_data(K_NO_WAIT);
+		buf = net_pkt_get_reserve_tx_data(IEEE802154_MAX_PHY_PACKET_SIZE,
+						  K_NO_WAIT);
 		net_pkt_append_buffer(packet, buf);
 
 		for (int i = 0; i < buf->size; i++) {


### PR DESCRIPTION
This PR fixes build errors and net_pkt fragment allocation issue when CONFIG_NET_BUF_VARIABLE_DATA_SIZE is enabled.

The most problematic case was the `net_pkt_get_reserve_data()` function, used in `net_pkt_get_frag()` for example, which blindly assumed that fixed-sized buffers are used. The problem with this function is that it does not specify the fragment length to allocate, which did not work well in variable-length scenario. ~~Because of this, I propose a new Kconfig which allows to specify the default fragment length for this configuration: https://github.com/zephyrproject-rtos/zephyr/commit/db8b2959d216710ae4d42318eec4ad6dc09fb311~~. I propose to modify the APIs slightly, to include the information about the minimal fragment length to allocate.

~~This approach appealed to me as the lowest hanging fruit to make the variable-length configuration work. I'm open for discussion though, as I am aware the solution is not ideal. An alternative, perhaps better way to tackle the problem would be to modify certain `net_pkt` APIs, `net_pkt_get_frag()`, `net_pkt_get_reserve_tx_data()` etc. to allow to specify minimal fragment length required to allocate. This would allow to allocate the exact buffer size in variable-length scenario, and verify if the fixed-sized buffer is large enough to meet the requirements otherwise. This however indicates a stable API change including changes in multiple drivers/libraries. I'm not sure if we want to go down that road.~~

Fixes #50188