### PR TITLE
net: ppp: Revert interface management changes

### DIFF
--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -954,14 +954,14 @@ use_random_mac:
 
 	memset(ppp->buf, 0, sizeof(ppp->buf));
 
-	/* If the interface autostart is disabled from Kconfig, then do not
-	 * start the interface automatically but only after manually started.
+	/* If we have a GSM modem with PPP support or interface autostart is disabled
+	 * from Kconfig, then do not start the interface automatically but only
+	 * after the modem is ready or when manually started.
 	 */
-	if (IS_ENABLED(CONFIG_PPP_NET_IF_NO_AUTO_START)) {
+	if (IS_ENABLED(CONFIG_MODEM_GSM_PPP) ||
+	    IS_ENABLED(CONFIG_PPP_NET_IF_NO_AUTO_START)) {
 		net_if_flag_set(iface, NET_IF_NO_AUTO_START);
 	}
-
-	net_if_carrier_off(iface);
 }
 
 #if defined(CONFIG_NET_STATISTICS_PPP)

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -210,7 +210,7 @@ static void lcp_finished(struct ppp_fsm *fsm)
 	/* take the remainder down */
 	ppp_mgmt_raise_carrier_off_event(ctx->iface);
 
-	net_if_carrier_off(ctx->iface);
+	net_if_down(ctx->iface);
 }
 
 #if defined(CONFIG_NET_L2_PPP_OPTION_MRU)

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -282,7 +282,7 @@ static void carrier_on_off(struct k_work *work)
 
 	if (ppp_carrier_up) {
 		ppp_mgmt_raise_carrier_on_event(ctx->iface);
-		net_if_carrier_on(ctx->iface);
+		net_if_up(ctx->iface);
 	} else {
 		if (ppp_lcp) {
 			ppp_lcp->close(ctx, "Shutdown");
@@ -291,7 +291,7 @@ static void carrier_on_off(struct k_work *work)
 			ppp_change_phase(ctx, PPP_DEAD);
 
 			ppp_mgmt_raise_carrier_off_event(ctx->iface);
-			net_if_carrier_off(ctx->iface);
+			net_if_down(ctx->iface);
 		}
 	}
 }


### PR DESCRIPTION
This reverts changes introduced in commit dd535f611d6c81275e64f2fe849a033e7e49f8bb, as they broke the gsm_ppp driver integration with PPP L2. Apparently, a more thorough refactoring is needed to use the new interface management scheme with PPP.

Fixes #52139

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>