### PR TITLE
ipc: ipc_service: icmsg: Increase reliability of bonding

### DIFF
--- a/include/zephyr/ipc/icmsg.h
+++ b/include/zephyr/ipc/icmsg.h
@@ -37,6 +37,8 @@ struct icmsg_data_t {
 	void *ctx;
 
 	/* General */
+	const struct icmsg_config_t *cfg;
+	struct k_work_delayable notify_work;
 	struct k_work mbox_work;
 	atomic_t state;
 };

--- a/subsys/ipc/ipc_service/backends/Kconfig
+++ b/subsys/ipc/ipc_service/backends/Kconfig
@@ -89,5 +89,13 @@ config SYSTEM_WORKQUEUE_PRIORITY
 	depends on IPC_SERVICE_ICMSG
 	range -256 -1
 
+config IPC_SERVICE_BACKEND_ICMSG_BOND_NOTIFY_REPEAT_TO_MS
+	int "Bond notification timeout in miliseconds"
+	range 1 100
+	default 1
+	help
+	  Time to wait for remote bonding notification before the
+	  notification is repeated.
+
 rsource "Kconfig.icmsg_me"
 rsource "Kconfig.rpmsg"


### PR DESCRIPTION
This commit changes the way bonding between endpoints is processed. There is no more blind attempt to read the buffer without mbox notification. On second side the notification is repeated multiple times until valid bonding is detected.

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>