### PR TITLE
twister: simulation_only testsuite option

### DIFF
--- a/boards/posix/native_posix/native_posix.yaml
+++ b/boards/posix/native_posix/native_posix.yaml
@@ -3,6 +3,7 @@ name: Native 32-bit POSIX port
 type: native
 simulation: native
 arch: posix
+simulation: posix
 ram: 65536
 flash: 65536
 toolchain:

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -39,7 +39,8 @@ class TwisterConfigParser:
                        "harness": {"type": "str", "default": "test"},
                        "harness_config": {"type": "map", "default": {}},
                        "seed": {"type": "int", "default": 0},
-                       "sysbuild": {"type": "bool", "default": False}
+                       "sysbuild": {"type": "bool", "default": False},
+                       "simulation_only": {"type": "bool", "default": False}
                        }
 
     def __init__(self, filename, schema):

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -356,6 +356,9 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         help="Upon test failure, print relevant log data to stdout "
              "instead of just a path to it.")
 
+    parser.add_argument("--ignore-platform-key", action="store_true",
+                        help="Do not filter based on platform key")
+
     parser.add_argument(
         "-j", "--jobs", type=int,
         help="Number of jobs for building, defaults to number of CPU threads, "

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -642,6 +642,7 @@ class TestPlan:
                     platform_scope = list(filter(lambda item: item.name in ts.platform_allow, \
                                              self.platforms))
 
+
             # list of instances per testsuite, aka configurations.
             instance_list = []
             for plat in platform_scope:
@@ -745,6 +746,11 @@ class TestPlan:
 
                 if plat.only_tags and not set(plat.only_tags) & ts.tags:
                     instance.add_filter("Excluded tags per platform (only_tags)", Filters.PLATFORM)
+
+                # if --all or -K are not provided, only build/run on simulators superceding above
+                # logic
+                if ts.simulation_only and plat.simulation == 'na' and not force_platform and not all_filter:
+                    instance.add_filter("Excluded non-simulation platform (simulation_only)", Filters.PLATFORM)
 
                 test_configuration = ".".join([instance.platform.name,
                                                instance.testsuite.id])

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -130,8 +130,8 @@ mapping:
       "type":
         type: str
         enum: ["unit"]
-      "simulation_only":
-        type: bool
+      "platform_hint":
+        type: ["arch", "soc_family", "soc", "board"]
         required: false
       "skip":
         type: bool

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -130,6 +130,9 @@ mapping:
       "type":
         type: str
         enum: ["unit"]
+      "simulation_only":
+        type: bool
+        required: false
       "skip":
         type: bool
         required: false
@@ -296,3 +299,6 @@ mapping:
           "sysbuild":
             type: bool
             required: false
+          "simulation_only":
+             type: bool
+             required: false

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -130,9 +130,12 @@ mapping:
       "type":
         type: str
         enum: ["unit"]
-      "platform_hint":
-        type: ["arch", "soc_family", "soc", "board"]
+      "platform_key":
+        type: seq
         required: false
+        sequence:
+          - type: str
+          - enum: ["arch", "simulation", "toolchain", "type"]
       "skip":
         type: bool
         required: false

--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -3,6 +3,7 @@ common:
     - qemu
     - native
   tags: log_api logging
+  simulation_only: True
   integration_platforms:
     - native_posix
 tests:

--- a/tests/subsys/rtio/rtio_api/testcase.yaml
+++ b/tests/subsys/rtio/rtio_api/testcase.yaml
@@ -1,20 +1,23 @@
+common:
+  simulation_only: True
+  tags: rtio
+  integration_platforms:
+    - native_posix
 tests:
   subsys.rtio.api:
     filter: not CONFIG_ARCH_HAS_USERSPACE
-    tags: rtio
   subsys.rtio.api.submit_sem:
     filter: not CONFIG_ARCH_HAS_USERSPACE
-    tags: rtio
     extra_configs:
       - CONFIG_RTIO_SUBMIT_SEM=y
   subsys.rtio.api.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y
-    tags: rtio userspace
+    tags: userspace
   subsys.rtio.api.userspace.submit_sem:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y
       - CONFIG_RTIO_SUBMIT_SEM=y
-    tags: rtio userspace
+    tags: userspace

--- a/tests/subsys/rtio/rtio_api/testcase.yaml
+++ b/tests/subsys/rtio/rtio_api/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  simulation_only: True
+  platform_key:
+    - arch
+    - simulation
   tags: rtio
   integration_platforms:
     - native_posix


### PR DESCRIPTION
Adds an option to inform twister a testsuite should only be built and
run for simulation platforms greatly reducing the build and runtime cost
for libraries and non-hardware specific code that needs to be built and
tested in CI on real hardware.

This is respected even if a platform filter is given for example -p intel_adsp_cavs25.
The only way to have the simulation_only rule be disregarded is with the force platform (-K)
or --all option being passed to twister.

Marks the rtio_api and log_api test suites as a simulation_only to show
how the rules are used.

Adds posix as a simulator type and sets native_posix as a simulation platform.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>