### PR TITLE
clang-format: remove space before colon

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,6 +25,7 @@ AttributeMacros:
   - __printf_like
   - __syscall
   - __subsystem
+BitFieldColonSpacing: After
 BreakBeforeBraces: Linux
 ColumnLimit: 100
 ConstructorInitializerIndentWidth: 8


### PR DESCRIPTION
Describe the bug:
During CI, the space before bitfield will cause error.
clang-format result is different from the rules in CI, so code formatted by clang-format could not pass CI.

Related issue:
#51973 

@chrta Mentioned that in clang-format 12, BitFieldColonSpacing is introduced.
Thanks.

```C
typedef union {
	struct {
		uint8_t : 3;	       /* bit [0:2] reserved */
                ...
	};
	uint8_t all;
} __attribute__((__packed__)) aht20_status;
```
The space is added by clang-format. It should be
```C
		uint8_t: 3;	       /* bit [0:2] reserved */
```



**To Reproduce**
This can be checked offline by
```shell
git format-patch HEAD~
# then a patch with 0001-xxxxxx will be generated
./scripts/checkpatch.pl 0001*
```

**Expected behavior**
Code pass test

**Impact**
That space will create inconsistency during CI coding style checking and .clang-format

**Logs and console output**
Here is the result.
[https://github.com/zephyrproject-rtos/zephyr/actions/runs/3395127653/jobs/5646003818](https://github.com/zephyrproject-rtos/zephyr/actions/runs/3395127653/jobs/5646003818)

```diff
-:89: ERROR:SPACING: space prohibited before that ':' (ctx:WxW)
#89: FILE: drivers/sensor/aht20/aht20.c:35:
+		uint8_t : 3;		/* bit [0:2] */
 		        ^
```
**Testing Environment**
```
clang-format --version
Debian clang-format version 14.0.6-2
```

