### PR TITLE
usb: Make EP0 max packet size configurable

### DIFF
--- a/soc/arm/renesas_smartbond/da1469x/Kconfig.defconfig.series
+++ b/soc/arm/renesas_smartbond/da1469x/Kconfig.defconfig.series
@@ -17,4 +17,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SRAM_VECTOR_TABLE
 	default y
 
+config USB_EP0_MAX_PACKET_SIZE
+	default 8
+
 endif # SOC_SERIES_DA1469X

--- a/subsys/usb/device/Kconfig
+++ b/subsys/usb/device/Kconfig
@@ -72,6 +72,18 @@ config USB_DEVICE_BLUETOOTH_BIG_BUF
 	default y if BT_BUF_EVT_RX_SIZE > 125 # 2 byte header
 	default y if BT_BUF_CMD_TX_SIZE > 124 # 3 byte header
 
+config USB_EP0_MAX_PACKET_SIZE
+	int "Maximum size of endpoint 0 packet size"
+	default 64
+	help
+	  Maximum size of endpoint 0 packet size. This value goes to
+	  device descriptor and is used for EP0 configuration.
+	  It is bMaxPacketSize0 field (byte 7 of the device descriptor).
+	  Valid values for:
+	  - low speed devices: 8
+	  - full speed devices: 8, 16, 32, 64
+	  - high speed device: 64
+
 config USB_REQUEST_BUFFER_SIZE
 	int "Set buffer size for Standard, Class and Vendor request handlers"
 	range 64 512 if USB_DEVICE_NETWORK_RNDIS

--- a/subsys/usb/device/class/dfu/usb_dfu.c
+++ b/subsys/usb/device/class/dfu/usb_dfu.c
@@ -160,7 +160,7 @@ struct dev_dfu_mode_descriptor dfu_mode_desc = {
 		.bDeviceClass = 0,
 		.bDeviceSubClass = 0,
 		.bDeviceProtocol = 0,
-		.bMaxPacketSize0 = USB_MAX_CTRL_MPS,
+		.bMaxPacketSize0 = CONFIG_USB_EP0_MAX_PACKET_SIZE,
 		.idVendor = sys_cpu_to_le16((uint16_t)CONFIG_USB_DEVICE_VID),
 		.idProduct =
 			sys_cpu_to_le16((uint16_t)CONFIG_USB_DEVICE_DFU_PID),

--- a/subsys/usb/device/usb_descriptor.c
+++ b/subsys/usb/device/usb_descriptor.c
@@ -70,7 +70,7 @@ USBD_DEVICE_DESCR_DEFINE(primary) struct common_descriptor common_desc = {
 		.bDeviceSubClass = 0,
 		.bDeviceProtocol = 0,
 #endif
-		.bMaxPacketSize0 = USB_MAX_CTRL_MPS,
+		.bMaxPacketSize0 = CONFIG_USB_EP0_MAX_PACKET_SIZE,
 		.idVendor = sys_cpu_to_le16((uint16_t)CONFIG_USB_DEVICE_VID),
 		.idProduct = sys_cpu_to_le16((uint16_t)CONFIG_USB_DEVICE_PID),
 		.bcdDevice = sys_cpu_to_le16(USB_BCD_DRN),

--- a/subsys/usb/device/usb_device.c
+++ b/subsys/usb/device/usb_device.c
@@ -252,7 +252,7 @@ static void usb_data_to_host(void)
 		if (!usb_dev.data_buf_residue && chunk &&
 		    usb_dev.setup.wLength > usb_dev.data_buf_len) {
 			/* Send less data as requested during the Setup stage */
-			if (!(usb_dev.data_buf_len % USB_MAX_CTRL_MPS)) {
+			if (!(usb_dev.data_buf_len % CONFIG_USB_EP0_MAX_PACKET_SIZE)) {
 				/* Transfers a zero-length packet */
 				LOG_DBG("ZLP, requested %u , length %u ",
 					usb_dev.setup.wLength,
@@ -1549,7 +1549,7 @@ int usb_enable(usb_dc_status_callback status_cb)
 	}
 
 	/* Configure control EP */
-	ep0_cfg.ep_mps = USB_MAX_CTRL_MPS;
+	ep0_cfg.ep_mps = CONFIG_USB_EP0_MAX_PACKET_SIZE;
 	ep0_cfg.ep_type = USB_DC_EP_CONTROL;
 
 	ep0_cfg.ep_addr = USB_CONTROL_EP_OUT;


### PR DESCRIPTION
So far max packet size for endpoint 0 was set always to 64.
USB specification allows other values (8, 16, 32, 64).
Some devices may not support value 64 so this change
adds USB_EP0_MAX_PACKET_SIZE Kconfig value that
is used in places were hardcoded value USB_MAX_CTRL_MPS
was previously used.

Second commit updates SmartBond (tm) SOC configuration
to use correct value when building for this family.

resolves #52253 