### PR TITLE
clock_control: stm32 Add extern C to allow includes from C++.

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.h
+++ b/drivers/clock_control/clock_stm32_ll_common.h
@@ -61,6 +61,10 @@
 #define z_pllr(v) LL_RCC_PLLR_DIV_ ## v
 #define pllr(v) z_pllr(v)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(STM32_PLL_ENABLED)
 void config_pll_sysclock(void);
 uint32_t get_pllout_frequency(void);
@@ -73,5 +77,9 @@ void config_enable_default_clocks(void);
 
 /* function exported to the soc power.c */
 int stm32_clock_control_init(const struct device *dev);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_DRIVERS_CLOCK_CONTROL_STM32_LL_CLOCK_H_ */


### PR DESCRIPTION
The stm32_clock_control_init is needed for implementation of custom pm_state_exit_post_ops, 
so `clock_stm32_ll_common.h` should be "includable" from application.

Signed-off-by: Artur Lipowski <Artur.Lipowski@hidglobal.com>