### PR TITLE
bluetooth: mesh: check id in connection callbacks

### DIFF
--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -99,8 +99,8 @@ static void gatt_connected(struct bt_conn *conn, uint8_t err)
 	struct bt_conn_info info;
 
 	bt_conn_get_info(conn, &info);
-	if (info.role != BT_CONN_ROLE_PERIPHERAL ||
-	    !service_registered || bt_mesh_is_provisioned()) {
+	if (info.role != BT_CONN_ROLE_PERIPHERAL || !service_registered ||
+	    bt_mesh_is_provisioned() || info.id != BT_ID_DEFAULT) {
 		return;
 	}
 
@@ -114,8 +114,8 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 	struct bt_conn_info info;
 
 	bt_conn_get_info(conn, &info);
-	if (info.role != BT_CONN_ROLE_PERIPHERAL ||
-	    !service_registered) {
+	if (info.role != BT_CONN_ROLE_PERIPHERAL || !service_registered ||
+	    info.id != BT_ID_DEFAULT) {
 		return;
 	}
 

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -832,8 +832,8 @@ static void gatt_connected(struct bt_conn *conn, uint8_t err)
 	struct bt_conn_info info;
 
 	bt_conn_get_info(conn, &info);
-	if (info.role != BT_CONN_ROLE_PERIPHERAL ||
-	    !service_registered) {
+	if (info.role != BT_CONN_ROLE_PERIPHERAL || !service_registered ||
+	    info.id != BT_ID_DEFAULT) {
 		return;
 	}
 
@@ -858,7 +858,7 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 	struct bt_mesh_proxy_client *client;
 
 	bt_conn_get_info(conn, &info);
-	if (info.role != BT_CONN_ROLE_PERIPHERAL) {
+	if (info.role != BT_CONN_ROLE_PERIPHERAL || info.id != BT_ID_DEFAULT) {
 		return;
 	}
 


### PR DESCRIPTION
When application uses multiple identities mesh stack keeps reacting on connection events not related to the own identity (BT_ID_DEFAULT) causing it to trigger additional advertising and this leads to errors. Though not harmful, this also leads to mesh stack counting connections wrongly and consuming internal resources.

This commit fixes the issue described above by checking the connection id before proceeding further

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@nordicsemi.no>