### PR TITLE
boards: arm: stm32wb55 nucleo board actual flash size

### DIFF
--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.yaml
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.yaml
@@ -7,7 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 ram: 192
-flash: 1024
+flash: 808
 supported:
   - gpio
   - i2c


### PR DESCRIPTION
Adjust the flash size of the nucleo_wb55rg board from STMicroelectronics to the exact flash as defined by the DTS of the stm32wb55Xg.

Signed-off-by: Francois Ramu <francois.ramu@st.com>