### PR TITLE
doc: mgmt: mcumgr: Fix formatting

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h
@@ -20,7 +20,7 @@ extern "C" {
  */
 
 /**
- * Structure provided in the MGMT_EVT_OP_FS_MGMT_FILE_ACCESS notification callback: This callback
+ * Structure provided in the #MGMT_EVT_OP_FS_MGMT_FILE_ACCESS notification callback: This callback
  * function is used to notify the application about a pending file read/write request and to
  * authorise or deny it. Access will be allowed so long as all notification handlers return
  * MGMT_ERR_EOK, if one returns an error then access will be denied.

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_callbacks.h
@@ -22,7 +22,7 @@ extern "C" {
  */
 
 /**
- * Structure provided in the MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK notification callback: This callback
+ * Structure provided in the #MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK notification callback: This callback
  * function is used to notify the application about a pending firmware upload packet from a client
  * and authorise or deny it. Upload will be allowed so long as all notification handlers return
  * MGMT_ERR_EOK, if one returns an error then the upload will be denied.

--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -93,13 +93,13 @@ enum smp_all_events {
  * MGMT event opcodes for base SMP command processing.
  */
 enum smp_group_events {
-	/** Callback when a command is received, data is mgmt_evt_op_cmd_arg. */
+	/** Callback when a command is received, data is mgmt_evt_op_cmd_arg(). */
 	MGMT_EVT_OP_CMD_RECV			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_SMP, 0),
 
-	/** Callback when a a status is updated, data is mgmt_evt_op_cmd_arg. */
+	/** Callback when a a status is updated, data is mgmt_evt_op_cmd_arg(). */
 	MGMT_EVT_OP_CMD_STATUS			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_SMP, 1),
 
-	/** Callback when a command has been processed, data is mgmt_evt_op_cmd_arg. */
+	/** Callback when a command has been processed, data is mgmt_evt_op_cmd_arg(). */
 	MGMT_EVT_OP_CMD_DONE			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_SMP, 2),
 
 	/** Used to enable all smp_group events. */
@@ -110,7 +110,7 @@ enum smp_group_events {
  * MGMT event opcodes for filesystem management group.
  */
 enum fs_mgmt_group_events {
-	/** Callback when a file has been accessed, data is fs_mgmt_file_access. */
+	/** Callback when a file has been accessed, data is fs_mgmt_file_access(). */
 	MGMT_EVT_OP_FS_MGMT_FILE_ACCESS		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_FS, 0),
 
 	/** Used to enable all fs_mgmt_group events. */
@@ -121,7 +121,7 @@ enum fs_mgmt_group_events {
  * MGMT event opcodes for image management group.
  */
 enum img_mgmt_group_events {
-	/** Callback when a client sends a file upload chunk, data is img_mgmt_upload_check. */
+	/** Callback when a client sends a file upload chunk, data is img_mgmt_upload_check(). */
 	MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 0),
 
 	/** Callback when a DFU operation is stopped. */
@@ -166,7 +166,7 @@ struct mgmt_callback {
 };
 
 /**
- * MGMT_EVT_OP_CMD_RECV, MGMT_EVT_OP_CMD_STATUS, MGMT_EVT_OP_CMD_DONE arguments
+ * Arguments for #MGMT_EVT_OP_CMD_RECV, #MGMT_EVT_OP_CMD_STATUS and #MGMT_EVT_OP_CMD_DONE
  */
 struct mgmt_evt_op_cmd_arg {
 	/** MGMT_GROUP_ID_[...] */
@@ -176,10 +176,10 @@ struct mgmt_evt_op_cmd_arg {
 	uint8_t id;
 
 	union {
-		/** MGMT_ERR_[...], used in MGMT_EVT_OP_CMD_DONE */
+		/** MGMT_ERR_[...], used in #MGMT_EVT_OP_CMD_DONE */
 		int err;
 
-		/** IMG_MGMT_ID_UPLOAD_STATUS_[...], used in MGMT_EVT_OP_CMD_STATUS */
+		/** IMG_MGMT_ID_UPLOAD_STATUS_[...], used in #MGMT_EVT_OP_CMD_STATUS */
 		int status;
 	};
 };

--- a/include/zephyr/mgmt/mcumgr/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp.h
@@ -84,10 +84,10 @@ typedef void zephyr_smp_transport_ud_free_fn(void *ud);
  * @brief Function for checking if queued data is still valid.
  *
  * This function is used to check if queued SMP data is still valid e.g. on a remote device
- * disconnecting, this is triggered when ``smp_rx_clear`` is called.
+ * disconnecting, this is triggered when smp_rx_remove_invalid() is called.
  *
  * @param nb			net buf containing queued request.
- * @param arg			Argument provided when calling smp_rx_clear() function.
+ * @param arg			Argument provided when calling smp_rx_remove_invalid() function.
  *
  * @return			false if data is no longer valid/should be freed, true otherwise.
  */
@@ -173,12 +173,12 @@ void zephyr_smp_transport_init(struct zephyr_smp_transport *smpt,
 
 /**
  * @brief	Used to remove queued requests for an SMP transport that are no longer valid. A
- *		``smp_transport_query_valid_check_fn`` function must be registered for this to
- *		function. If the ``smp_transport_query_valid_check_fn`` function returns false
+ *		smp_transport_query_valid_check_fn() function must be registered for this to
+ *		function. If the smp_transport_query_valid_check_fn() function returns false
  *		during a callback, the queried command will classed as invalid and dropped.
  *
  * @param zst	The transport to use.
- * @param arg	Argument provided to callback ``smp_transport_query_valid_check_fn`` function.
+ * @param arg	Argument provided to callback smp_transport_query_valid_check_fn() function.
  */
 void smp_rx_remove_invalid(struct smp_transport *zst, void *arg);
 


### PR DESCRIPTION
This add links to the MCUmgr documentation so that it will be automatically linked in sphinx and fixes a link to the wrong function.

Generated doc link: https://builds.zephyrproject.io/zephyr/pr/52286/docs/