### PR TITLE
drivers: timer: nrf_rtc_timer: Add test function for shifting time

### DIFF
--- a/drivers/timer/Kconfig.nrf_rtc
+++ b/drivers/timer/Kconfig.nrf_rtc
@@ -34,6 +34,12 @@ config NRF_RTC_TIMER_LOCK_ZERO_LATENCY_IRQS
 	  handler and call nrf_rtc_timer API from destroying the internal state
 	  in nrf_rtc_timer.
 
+config NRF_RTC_TIMER_TRIGGER_OVERFLOW
+	bool "Trigger overflow"
+	help
+	  When enabled, a function can be used to trigger RTC overflow and
+	  effectively shift time into the future.
+
 choice
 	prompt "Clock startup policy"
 	default SYSTEM_CLOCK_WAIT_FOR_STABILITY

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -42,6 +42,7 @@ BUILD_ASSERT(CHAN_COUNT <= RTC_CH_COUNT, "Not enough compare channels");
 static volatile uint32_t overflow_cnt;
 static volatile uint64_t anchor;
 static uint64_t last_count;
+static bool sys_busy;
 
 struct z_nrf_rtc_timer_chan_data {
 	z_nrf_rtc_timer_compare_handler_t callback;
@@ -542,6 +543,41 @@ void z_nrf_rtc_timer_chan_free(int32_t chan)
 }
 
 
+int z_nrf_rtc_timer_trigger_overflow(void)
+{
+	uint32_t mcu_critical_state;
+	int err = 0;
+
+	if (!IS_ENABLED(CONFIG_NRF_RTC_TIMER_TRIGGER_OVERFLOW) ||
+	    (CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT > 0)) {
+		return -ENOTSUP;
+	}
+
+	mcu_critical_state = full_int_lock();
+	if (sys_busy) {
+		err = -EBUSY;
+		goto bail;
+	}
+
+	if (counter() >= (COUNTER_SPAN - 100)) {
+		err = -EAGAIN;
+		goto bail;
+	}
+
+	nrf_rtc_task_trigger(RTC, NRF_RTC_TASK_TRIGGER_OVERFLOW);
+	k_busy_wait(80);
+
+	uint64_t now = z_nrf_rtc_timer_read();
+
+	if (err == 0) {
+		sys_clock_timeout_handler(0, now, NULL);
+	}
+bail:
+	full_int_unlock(mcu_critical_state);
+
+	return err;
+}
+
 void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -553,6 +589,10 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
 	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+	/* If timeout is set to max we assume that system is idle and timeout
+	 * is set to forever.
+	 */
+	sys_busy = (ticks < (MAX_TICKS - 1));
 
 	uint32_t unannounced = z_nrf_rtc_timer_read() - last_count;
 
@@ -632,8 +672,7 @@ static int sys_clock_driver_init(const struct device *dev)
 	}
 
 	uint32_t initial_timeout = IS_ENABLED(CONFIG_TICKLESS_KERNEL) ?
-		(COUNTER_HALF_SPAN - 1) :
-		(counter() + CYC_PER_TICK);
+		MAX_TICKS : (counter() + CYC_PER_TICK);
 
 	compare_set(0, initial_timeout, sys_clock_timeout_handler, NULL);
 

--- a/include/zephyr/drivers/timer/nrf_rtc_timer.h
+++ b/include/zephyr/drivers/timer/nrf_rtc_timer.h
@@ -166,6 +166,22 @@ uint64_t z_nrf_rtc_timer_get_ticks(k_timeout_t t);
  * @retval -EBUSY if synchronization is not yet completed.
  */
 int z_nrf_rtc_timer_nrf53net_offset_get(void);
+
+/** @brief Move RTC counter forward using TRIGOVRFLW hardware feature.
+ *
+ * RTC has a hardware feature which can force counter to jump to 0xFFFFF0 value
+ * which is close to overflow. Function is using this feature and updates
+ * driver internal to perform time shift to the future. Operation can only be
+ * performed when there are no active alarms set. It should be used for testing
+ * only.
+ *
+ * @retval 0 on successful shift.
+ * @retval -EBUSY if there are active alarms.
+ * @retval -EAGAIN if current counter value is too close to overflow.
+ * @retval -ENOTSUP if option is disabled in Kconfig or additional channels are enabled.
+ */
+int z_nrf_rtc_timer_trigger_overflow(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
RTC is 24 bit width and k_timer is 64 bit. It is hard to test corner cases but RTC hardware feature can help here. There is a task which moves counter to 0xfffff0 which is close to overflow. However, there is an internal driver state that also needs to be aligned to shift the time properly. Adding optional function which triggers overflow and updates internal state. This can be used for testing corner cases.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>