### PR TITLE
Removing usage of DTS label property from documentation for MCUmgr and samples

### DIFF
--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -36,24 +36,21 @@ is supposed to run from the "primary slot" and update is supposed to be
 uploaded to the "secondary slot";  the mcuboot is responsible in swapping
 slots on boot.
 This means that pair of slots is dedicated to single upgradable application.
-In case of Zephyr this gets a little bit confusing because DTS will use
-"slot0_partition" and "slot1_partition", as label of ``fixed-partition`` dedicated
-to single application, but will name them as "image-0" and "image-1" respectively.
 
 Currently Zephyr supports at most two images, in which case mapping is as follows:
 
 .. table::
     :align: center
 
-    +-------------+-------------------+---------------+
-    | Image       | Slot labels       | Slot  Names   |
-    +=============+===================+===============+
-    | 1           | "slot0_partition" |   "image-0"   |
-    |             | "slot1_partition" |   "image-1"   |
-    +-------------+-------------------+---------------+
-    | 2           | "slot2_partition" |   "image-2"   |
-    |             | "slot3_partition" |   "image-3"   |
-    +-------------+-------------------+---------------+
+    +-------------+-------------------+
+    | Image       | Slot labels       |
+    +=============+===================+
+    | 1           | "slot0_partition" |
+    |             | "slot1_partition" |
+    +-------------+-------------------+
+    | 2           | "slot2_partition" |
+    |             | "slot3_partition" |
+    +-------------+-------------------+
 
 State of images
 ***************

--- a/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
@@ -267,32 +267,32 @@ Direct image upload and Image mapping to MCUboot slot
 =====================================================
 
 Currently the mcumgr supports, for direct upload, 4 target images, of which first two are mapped
-into MCUboot primary (slot-0) and secondary (slot-1) respectively.
+into MCUboot primary and secondary respectively.
 
 The mcumgr ``image upload`` command may be provided optional ``-e -n <image>`` parameter that will
 select target image for upload; when parameter is no provided, 0 is assumed, which means "default
-behaviour", and it performs upload to the "image-1", the MCUboot secondary slot.
+behaviour", and it performs upload to the MCUboot secondary slot.
 
 For clarity, here is DTS label to slot to ``<image>`` translation table:
 
-    +-----------+--------+------------+
-    | DTS label | Slot   | -n <image> |
-    +===========+========+============+
-    | "image-0" | slot-0 |     1      |
-    +-----------+--------+------------+
-    | "image-1" | slot-1 |     0, 1   |
-    +-----------+--------+------------+
-    | "image-2" |        |     2      |
-    +-----------+--------+------------+
-    | "image-3" |        |     3      |
-    +-----------+--------+------------+
+    +------------+------------------------+
+    | -n <image> | DTS Node Label         |
+    +============+========================+
+    |     1      | ``slot0_partition``    |
+    +------------+------------------------+
+    |    0, 2    | ``slot1_partition``    |
+    +------------+------------------------+
+    |     3      | ``slot2_partition``    |
+    +------------+------------------------+
+    |     4      | ``slot3_partition``    |
+    +------------+------------------------+
 
 .. note::
 
-   The ``-e`` option actually means "no erase", and is provided to the mcumgr
+   The ``-e`` option actually means "no erase", and is provided to the mcumgr-cli
    to prevent it from sending erase command to target, before updating image.
    The options is always needed when ``-n`` is used for image selection,
-   as the erase command is hardcoded to erase slot-1 ("image-1"),
+   as the erase command is hardcoded to erase slot1_partition
    regardless of which slot is uploaded at the time.
 
 Upload the signed image


### PR DESCRIPTION
Two fixes:
 1) SMP protocol documentation fixes, where usage of "image-?" DTS node label property has been removed or replaced with DTS node label;
 2) smp_svr README fix for the same issue;