### PR TITLE
boards: arm: thingy53: Enable USB-CDC for console

### DIFF
--- a/boards/arm/thingy53_nrf5340/Kconfig
+++ b/boards/arm/thingy53_nrf5340/Kconfig
@@ -29,6 +29,10 @@ config BOARD_ENABLE_DCDC_HV
 	select SOC_DCDC_NRF53X_HV
 	default y
 
+config BOARD_SERIAL_BACKEND_CDC_ACM
+	bool "USB CDC"
+	default y
+
 config BOARD_ENABLE_CPUNET
 	bool "NRF53 Network MCU"
 	select SOC_NRF_GPIO_FORWARDER_FOR_NRF5340 if \

--- a/boards/arm/thingy53_nrf5340/Kconfig.defconfig
+++ b/boards/arm/thingy53_nrf5340/Kconfig.defconfig
@@ -82,6 +82,53 @@ config REGULATOR
 
 endif # !TRUSTED_EXECUTION_SECURE
 
+if BOARD_SERIAL_BACKEND_CDC_ACM
+
+config USB_DEVICE_PRODUCT
+	default "Thingy:53 Application"
+
+config USB_DEVICE_VID
+	default 0x1915
+
+config USB_DEVICE_PID
+	default 0x530C
+
+config USB_DEVICE_STACK
+	default y
+
+config USB_CDC_ACM
+	default y
+
+config UART_CONSOLE
+	default CONSOLE
+
+config USB_DEVICE_INITIALIZE_AT_BOOT
+	default y if !MCUBOOT
+
+config SHELL_BACKEND_SERIAL_CHECK_DTR
+	default SHELL
+
+config USB_DEVICE_REMOTE_WAKEUP
+	default n
+
+if LOG
+
+# Logger cannot use itself to log
+config USB_CDC_ACM_LOG_LEVEL
+	default 0
+
+# Set USB log level to error only
+config USB_DEVICE_LOG_LEVEL
+	default 1
+
+# Wait 4000ms at startup for logging
+config LOG_PROCESS_THREAD_STARTUP_DELAY_MS
+	default 4000
+
+endif # LOG
+
+endif # BOARD_SERIAL_BACKEND_CDC_ACM
+
 endif # BOARD_THINGY53_NRF5340_CPUAPP || BOARD_THINGY53_NRF5340_CPUAPP_NS
 
 if BOARD_THINGY53_NRF5340_CPUNET

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -7,11 +7,11 @@
 
 / {
 	chosen {
-		zephyr,console = &uart0;
-		zephyr,shell-uart = &uart0;
-		zephyr,uart-mcumgr = &uart0;
-		zephyr,bt-mon-uart = &uart0;
-		zephyr,bt-c2h-uart = &uart0;
+		zephyr,console = &cdc_acm_uart;
+		zephyr,shell-uart = &cdc_acm_uart;
+		zephyr,uart-mcumgr = &cdc_acm_uart;
+		zephyr,bt-mon-uart = &cdc_acm_uart;
+		zephyr,bt-c2h-uart = &cdc_acm_uart;
 		zephyr,bt-hci-rpmsg-ipc = &ipc0;
 		nordic,802154-spinel-ipc = &ipc0;
 		zephyr,ieee802154 = &ieee802154;
@@ -212,8 +212,9 @@
 
 /* UART0 GPIOs can be configured for other use-cases */
 &uart0 {
+	/* Disabled by default */
 	current-speed = <115200>;
-	status = "okay";
+	status = "disabled";
 	pinctrl-0 = <&uart0_default>;
 	pinctrl-1 = <&uart0_sleep>;
 	pinctrl-names = "default", "sleep";
@@ -300,6 +301,10 @@
 zephyr_udc0: &usbd {
 	compatible = "nordic,nrf-usbd";
 	status = "okay";
+
+	cdc_acm_uart: cdc_acm_uart {
+		compatible = "zephyr,cdc-acm-uart";
+	};
 };
 
 / {


### PR DESCRIPTION
This enables the USB-CDC port for console output by default when
configuring for the thingy53_nrf5340_cpuapp board. This is needed
as the UART on this board is not connected.

Fixes #52291