### PR TITLE
compiler: arcmwdt: Remove unsupported compile flags (-fno-pic and -fno-pie)

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -175,11 +175,9 @@ set_property(TARGET compiler-cpp PROPERTY required "-Hcplus" "-Hoff=Stackcheck_a
 # Compiler flag for turning off thread-safe initialization of local statics
 set_property(TARGET compiler-cpp PROPERTY no_threadsafe_statics "-fno-threadsafe-statics")
 
-#Compiler flags for disabling position independent code / executable
-set_compiler_property(PROPERTY no_position_independent
-                      -fno-pic
-                      -fno-pie
-)
+# ARC MWDT does not support -fno-pic and -fno-pie flags,
+# but it has PIE disabled by default - so no extra flags are required here.
+set_compiler_property(PROPERTY no_position_independent "")
 
 #################################
 # This section covers asm flags #


### PR DESCRIPTION
Clang version used by ARCMWDT does not support -fno-pic and -fno-pie flags.
Flags were added into arcmwdt branch by
'commit 8259931fce1b ("xcc-clang: Do not used unavailable options")'. Initially they were set in common CMakeLists.txt via zephyr_cc_option() function, which filtered them out, and they did not used in builing process.

Signed-off-by: Nikolay Agishev <agishev@synopsys.com>