### PR TITLE
drivers: regulator: regulator_shell: Fix missing include

### DIFF
--- a/drivers/regulator/regulator_shell.c
+++ b/drivers/regulator/regulator_shell.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdlib.h>
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/drivers/uart.h>


### PR DESCRIPTION
Fixes a missing include for the atoi() function.

Fixes #52296