### PR TITLE
drivers: entropy: PSA crypto RNG driver default

### DIFF
--- a/drivers/entropy/Kconfig.psa_crypto
+++ b/drivers/entropy/Kconfig.psa_crypto
@@ -6,6 +6,8 @@
 config ENTROPY_PSA_CRYPTO_RNG
 	bool "PSA Crypto Random source Entropy driver"
 	depends on BUILD_WITH_TFM
+	depends on DT_HAS_ZEPHYR_PSA_CRYPTO_RNG_ENABLED
 	select ENTROPY_HAS_DRIVER
+	default y
 	help
 	  Enable the PSA Crypto source Entropy driver.


### PR DESCRIPTION
Enable the PSA RNG driver by default. This option
will only be enabled when BUILD_WITH_TFM is enabled and a device with the required compatible field
(zephyr,psa-crypto-rng) is defined in the device tree. When a vendor includes such a device and enables the ENTROPY_GENERATOR subsystem it is fair to assume
that wants to use the PSA Crypto RNG driver.

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>