### PR TITLE
posix: headers: fix remaining newlib picolibc zephyr pthread inconsistencies

### DIFF
--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -9,7 +9,7 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
 #include <stdlib.h>
 #include <limits.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 
 #include <zephyr/kernel.h>
 /* Define sockaddr, etc, before simplelink.h */

--- a/include/zephyr/posix/fcntl.h
+++ b/include/zephyr/posix/fcntl.h
@@ -7,9 +7,14 @@
 #ifndef ZEPHYR_POSIX_FCNTL_H_
 #define ZEPHYR_POSIX_FCNTL_H_
 
-#define O_CREAT    0x0200
+#ifdef CONFIG_PICOLIBC
+#define O_CREAT 0x0040
+#else
+#define O_CREAT 0x0200
+#endif
+
 #define O_APPEND   0x0400
-#define O_EXCL     0x0800
+#define O_EXCL	   0x0800
 #define O_NONBLOCK 0x4000
 
 #define F_DUPFD 0

--- a/include/zephyr/posix/fcntl.h
+++ b/include/zephyr/posix/fcntl.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_POSIX_FCNTL_H_
+#define ZEPHYR_POSIX_FCNTL_H_
+
+#define O_CREAT    0x0200
+#define O_APPEND   0x0400
+#define O_EXCL     0x0800
+#define O_NONBLOCK 0x4000
+
+#define F_DUPFD 0
+#define F_GETFL 3
+#define F_SETFL 4
+
+int open(const char *name, int flags, ...);
+
+#endif /* ZEPHYR_POSIX_FCNTL_H_ */

--- a/include/zephyr/posix/fcntl.h
+++ b/include/zephyr/posix/fcntl.h
@@ -13,6 +13,12 @@
 #define O_CREAT 0x0200
 #endif
 
+#define O_ACCMODE (O_RDONLY | O_WRONLY | O_RDWR)
+
+#define O_RDONLY 00
+#define O_WRONLY 01
+#define O_RDWR	 02
+
 #define O_APPEND   0x0400
 #define O_EXCL	   0x0800
 #define O_NONBLOCK 0x4000

--- a/include/zephyr/posix/fcntl.h
+++ b/include/zephyr/posix/fcntl.h
@@ -17,5 +17,6 @@
 #define F_SETFL 4
 
 int open(const char *name, int flags, ...);
+int fcntl(int fildes, int cmd, ...);
 
 #endif /* ZEPHYR_POSIX_FCNTL_H_ */

--- a/include/zephyr/posix/posix_sched.h
+++ b/include/zephyr/posix/posix_sched.h
@@ -16,9 +16,11 @@ extern "C" {
 /* Priority based preemptive scheduling policy */
 #define SCHED_RR 2
 
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC)
 struct sched_param {
 	int sched_priority;
 };
+#endif
 
 /**
  * @brief Yield the processor

--- a/include/zephyr/posix/posix_sched.h
+++ b/include/zephyr/posix/posix_sched.h
@@ -11,14 +11,10 @@ extern "C" {
 #endif
 
 /* Cooperative scheduling policy */
-#ifndef SCHED_FIFO
-#define SCHED_FIFO 0
-#endif /* SCHED_FIFO */
+#define SCHED_FIFO 1
 
 /* Priority based preemptive scheduling policy */
-#ifndef SCHED_RR
-#define SCHED_RR 1
-#endif /* SCHED_RR */
+#define SCHED_RR 2
 
 struct sched_param {
 	int sched_priority;

--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -36,7 +36,7 @@ typedef unsigned long timer_t;
 typedef struct pthread_attr {
 	int priority;
 	void *stack;
-	size_t stacksize;
+	uint32_t stacksize;
 	uint32_t flags;
 	uint32_t delayedstart;
 	uint32_t schedpolicy;

--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -11,6 +11,10 @@
 #include <sys/types.h>
 #endif
 
+#ifdef CONFIG_NEWLIB_LIBC
+#include <sys/_pthreadtypes.h>
+#endif
+
 #include <zephyr/kernel.h>
 
 #ifdef __cplusplus
@@ -33,7 +37,7 @@ typedef unsigned long timer_t;
 
 #ifdef CONFIG_PTHREAD_IPC
 /* Thread attributes */
-typedef struct pthread_attr {
+struct pthread_attr {
 	int priority;
 	void *stack;
 	uint32_t stacksize;
@@ -42,7 +46,11 @@ typedef struct pthread_attr {
 	uint32_t schedpolicy;
 	int32_t detachstate;
 	uint32_t initialized;
-} pthread_attr_t;
+};
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC)
+typedef struct pthread_attr pthread_attr_t;
+#endif
+BUILD_ASSERT(sizeof(pthread_attr_t) >= sizeof(struct pthread_attr));
 
 typedef uint32_t pthread_t;
 
@@ -52,15 +60,24 @@ typedef struct k_sem sem_t;
 /* Mutex */
 typedef uint32_t pthread_mutex_t;
 
-typedef struct pthread_mutexattr {
+struct pthread_mutexattr {
 	int type;
-} pthread_mutexattr_t;
+};
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC)
+typedef struct pthread_mutexattr pthread_mutexattr_t;
+#endif
+BUILD_ASSERT(sizeof(pthread_mutexattr_t) >= sizeof(struct pthread_mutexattr));
 
 /* Condition variables */
 typedef uint32_t pthread_cond_t;
 
-typedef struct pthread_condattr {
-} pthread_condattr_t;
+struct pthread_condattr {
+};
+
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC)
+typedef struct pthread_condattr pthread_condattr_t;
+#endif
+BUILD_ASSERT(sizeof(pthread_condattr_t) >= sizeof(struct pthread_condattr));
 
 /* Barrier */
 typedef struct pthread_barrier {

--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_POSIX_SYS_TYPES_H_
-#define ZEPHYR_INCLUDE_POSIX_SYS_TYPES_H_
+#ifndef ZEPHYR_INCLUDE_POSIX_TYPES_H_
+#define ZEPHYR_INCLUDE_POSIX_TYPES_H_
 
 #ifndef CONFIG_ARCH_POSIX
 #include <sys/types.h>
@@ -88,4 +88,4 @@ typedef struct pthread_rwlock_obj {
 }
 #endif
 
-#endif	/* ZEPHYR_INCLUDE_POSIX_SYS_TYPES_H_ */
+#endif	/* ZEPHYR_INCLUDE_POSIX_TYPES_H_ */

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -31,7 +31,10 @@ extern "C" {
 #define PTHREAD_CANCEL_DISABLE	BIT(_PTHREAD_CANCEL_POS)
 
 /* Passed to pthread_once */
-#define PTHREAD_ONCE_INIT 1
+#define PTHREAD_ONCE_INIT                                                                          \
+	{                                                                                          \
+		1, 0                                                                               \
+	}
 
 /* The minimum allowable stack size */
 #define PTHREAD_STACK_MIN Z_KERNEL_STACK_SIZE_ADJUST(0)

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -22,8 +22,8 @@ extern "C" {
 #endif
 
 /* Pthread detach/joinable */
-#define PTHREAD_CREATE_JOINABLE     1
-#define PTHREAD_CREATE_DETACHED     2
+#define PTHREAD_CREATE_DETACHED 0
+#define PTHREAD_CREATE_JOINABLE 1
 
 /* Pthread cancellation */
 #define _PTHREAD_CANCEL_POS	0

--- a/include/zephyr/posix/pthread_key.h
+++ b/include/zephyr/posix/pthread_key.h
@@ -15,7 +15,12 @@
 extern "C" {
 #endif
 
-typedef uint32_t pthread_once_t;
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC)
+typedef struct {
+	int is_initialized;
+	int init_executed;
+} pthread_once_t;
+#endif
 
 /* pthread_key */
 typedef uint32_t pthread_key_t;

--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -43,4 +43,4 @@ typedef struct sigevent {
 }
 #endif
 
-#endif /* POSIX__SIGNAL_H */
+#endif /* ZEPHYR_INCLUDE_POSIX_SIGNAL_H_ */

--- a/include/zephyr/posix/sys/eventfd.h
+++ b/include/zephyr/posix/sys/eventfd.h
@@ -11,7 +11,7 @@
 #include <zephyr/sys/fdtable.h>
 #include <sys/types.h>
 
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/posix/sys/stat.h
+++ b/include/zephyr/posix/sys/stat.h
@@ -40,10 +40,6 @@ extern "C" {
 #define O_WRONLY	     01
 #define O_RDWR		     02
 
-#define SEEK_SET	0	/* Seek from beginning of file.  */
-#define SEEK_CUR	1	/* Seek from current position.  */
-#define SEEK_END	2	/* Seek from end of file.  */
-
 struct stat {
 	unsigned long st_size;
 	unsigned long st_blksize;

--- a/include/zephyr/posix/sys/stat.h
+++ b/include/zephyr/posix/sys/stat.h
@@ -1,54 +1,235 @@
 /*
- * Copyright (c) 2018 Intel Corporation
- *
- * SPDX-License-Identifier: Apache-2.0
- */
+Copyright (c) 1982, 1986, 1993
+The Regents of the University of California.  All rights reserved.
 
-#ifndef ZEPHYR_POSIX_SYS_STAT_H_
-#define ZEPHYR_POSIX_SYS_STAT_H_
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+ */
+#ifndef	_SYS_STAT_H
+#define	_SYS_STAT_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define S_IFBLK	 0060000
-#define S_IFCHR	 0020000
-#define S_IFIFO	 0010000
-#define S_IFREG	 0100000
-#define S_IFDIR	 0040000
-#define S_IFLNK	 0120000
-#define S_IFSOCK 0140000
+#include <time.h>
+#include <sys/cdefs.h>
+#include <sys/types.h>
+#include <sys/_timespec.h>
 
-#define S_IRWXU 00700
-#define S_IRUSR 00400
-#define S_IWUSR 00200
-#define S_IXUSR 00100
+/* dj's stat defines _STAT_H_ */
+#ifndef _STAT_H_
 
-#define S_IRWXG 00070
-#define S_IRGRP 00040
-#define S_IWGRP 00020
-#define S_IXGRP 00010
+/* It is intended that the layout of this structure not change when the
+   sizes of any of the basic types change (short, int, long) [via a compile
+   time option].  */
 
-#define S_IRWXO 00007
-#define S_IROTH 00004
-#define S_IWOTH 00002
-#define S_IXOTH 00001
-
-/* File open modes */
-#define O_ACCMODE	   0003
-#define O_RDONLY	     00
-#define O_WRONLY	     01
-#define O_RDWR		     02
-
-struct stat {
-	unsigned long st_size;
-	unsigned long st_blksize;
-	unsigned long st_blocks;
-	unsigned long st_mode;
+#ifdef __CYGWIN__
+#include <cygwin/stat.h>
+#ifdef _LIBC
+#define stat64 stat
+#endif
+#else
+struct	stat 
+{
+  dev_t		st_dev;
+  ino_t		st_ino;
+  mode_t	st_mode;
+  nlink_t	st_nlink;
+  uid_t		st_uid;
+  gid_t		st_gid;
+#if defined(__linux) && defined(__x86_64__)
+    int __pad0;
+#endif
+  dev_t		st_rdev;
+#if defined(__linux) && !defined(__x86_64__)
+    unsigned short int __pad2;
+#endif
+  off_t		st_size;
+#if defined(__linux)
+  blksize_t	st_blksize;
+  blkcnt_t	st_blocks;
+  struct timespec st_atim;
+  struct timespec st_mtim;
+  struct timespec st_ctim;
+#define st_atime st_atim.tv_sec      /* Backward compatibility */
+#define st_mtime st_mtim.tv_sec
+#define st_ctime st_ctim.tv_sec
+#if defined(__linux) && defined(__x86_64__)
+    __uint64_t __glibc_reserved[3];
+#endif
+#else
+#if defined(__rtems__)
+  struct timespec st_atim;
+  struct timespec st_mtim;
+  struct timespec st_ctim;
+  blksize_t     st_blksize;
+  blkcnt_t	st_blocks;
+#else
+  /* SysV/sco doesn't have the rest... But Solaris, eabi does.  */
+#if defined(__svr4__) && !defined(__PPC__) && !defined(__sun__)
+  time_t	st_atime;
+  time_t	st_mtime;
+  time_t	st_ctime;
+#else
+  struct timespec st_atim;
+  struct timespec st_mtim;
+  struct timespec st_ctim;
+  blksize_t     st_blksize;
+  blkcnt_t	st_blocks;
+#if !defined(__rtems__)
+  long		st_spare4[2];
+#endif
+#endif
+#endif
+#endif
 };
 
+#if !(defined(__svr4__) && !defined(__PPC__) && !defined(__sun__))
+#define st_atime st_atim.tv_sec
+#define st_ctime st_ctim.tv_sec
+#define st_mtime st_mtim.tv_sec
+#endif
+
+#endif
+
+#define	_IFMT		0170000	/* type of file */
+#define		_IFDIR	0040000	/* directory */
+#define		_IFCHR	0020000	/* character special */
+#define		_IFBLK	0060000	/* block special */
+#define		_IFREG	0100000	/* regular */
+#define		_IFLNK	0120000	/* symbolic link */
+#define		_IFSOCK	0140000	/* socket */
+#define		_IFIFO	0010000	/* fifo */
+
+#define 	S_BLKSIZE  1024 /* size of a block */
+
+#define	S_ISUID		0004000	/* set user id on execution */
+#define	S_ISGID		0002000	/* set group id on execution */
+#define	S_ISVTX		0001000	/* save swapped text even after use */
+#if __BSD_VISIBLE
+#define	S_IREAD		0000400	/* read permission, owner */
+#define	S_IWRITE 	0000200	/* write permission, owner */
+#define	S_IEXEC		0000100	/* execute/search permission, owner */
+#define	S_ENFMT 	0002000	/* enforcement-mode locking */
+#endif	/* !_BSD_VISIBLE */
+
+#define	S_IFMT		_IFMT
+#define	S_IFDIR		_IFDIR
+#define	S_IFCHR		_IFCHR
+#define	S_IFBLK		_IFBLK
+#define	S_IFREG		_IFREG
+#define	S_IFLNK		_IFLNK
+#define	S_IFSOCK	_IFSOCK
+#define	S_IFIFO		_IFIFO
+
+#ifdef _WIN32
+/* The Windows header files define _S_ forms of these, so we do too
+   for easier portability.  */
+#define _S_IFMT		_IFMT
+#define _S_IFDIR	_IFDIR
+#define _S_IFCHR	_IFCHR
+#define _S_IFIFO	_IFIFO
+#define _S_IFREG	_IFREG
+#define _S_IREAD	0000400
+#define _S_IWRITE	0000200
+#define _S_IEXEC	0000100
+#endif
+
+#define	S_IRWXU 	(S_IRUSR | S_IWUSR | S_IXUSR)
+#define		S_IRUSR	0000400	/* read permission, owner */
+#define		S_IWUSR	0000200	/* write permission, owner */
+#define		S_IXUSR 0000100/* execute/search permission, owner */
+#define	S_IRWXG		(S_IRGRP | S_IWGRP | S_IXGRP)
+#define		S_IRGRP	0000040	/* read permission, group */
+#define		S_IWGRP	0000020	/* write permission, grougroup */
+#define		S_IXGRP 0000010/* execute/search permission, group */
+#define	S_IRWXO		(S_IROTH | S_IWOTH | S_IXOTH)
+#define		S_IROTH	0000004	/* read permission, other */
+#define		S_IWOTH	0000002	/* write permission, other */
+#define		S_IXOTH 0000001/* execute/search permission, other */
+
+#if __BSD_VISIBLE
+#define ACCESSPERMS (S_IRWXU | S_IRWXG | S_IRWXO) /* 0777 */
+#define ALLPERMS (S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO) /* 07777 */
+#define DEFFILEMODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) /* 0666 */
+#endif
+
+#define	S_ISBLK(m)	(((m)&_IFMT) == _IFBLK)
+#define	S_ISCHR(m)	(((m)&_IFMT) == _IFCHR)
+#define	S_ISDIR(m)	(((m)&_IFMT) == _IFDIR)
+#define	S_ISFIFO(m)	(((m)&_IFMT) == _IFIFO)
+#define	S_ISREG(m)	(((m)&_IFMT) == _IFREG)
+#define	S_ISLNK(m)	(((m)&_IFMT) == _IFLNK)
+#define	S_ISSOCK(m)	(((m)&_IFMT) == _IFSOCK)
+
+#if defined(__CYGWIN__) || defined(__rtems__)
+/* Special tv_nsec values for futimens(2) and utimensat(2). */
+#define UTIME_NOW	-2L
+#define UTIME_OMIT	-1L
+#endif
+
+int	chmod (const char *__path, mode_t __mode );
+int     fchmod (int __fd, mode_t __mode);
+int	fstat (int __fd, struct stat *__sbuf );
+int	mkdir (const char *_path, mode_t __mode );
+int	mkfifo (const char *__path, mode_t __mode );
+int	stat (const char *__restrict __path, struct stat *__restrict __sbuf );
+mode_t	umask (mode_t __mask );
+
+#if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__) && !defined(__INSIDE_CYGWIN__)
+int	lstat (const char *__restrict __path, struct stat *__restrict __buf );
+int	mknod (const char *__path, mode_t __mode, dev_t __dev );
+#endif
+
+#if __ATFILE_VISIBLE && !defined(__INSIDE_CYGWIN__)
+int	fchmodat (int, const char *, mode_t, int);
+int	fstatat (int, const char *__restrict , struct stat *__restrict, int);
+int	mkdirat (int, const char *, mode_t);
+int	mkfifoat (int, const char *, mode_t);
+int	mknodat (int, const char *, mode_t, dev_t);
+int	utimensat (int, const char *, const struct timespec [2], int);
+#endif
+#if __POSIX_VISIBLE >= 200809 && !defined(__INSIDE_CYGWIN__)
+int	futimens (int, const struct timespec [2]);
+#endif
+
+/* Provide prototypes for most of the _<systemcall> names that are
+   provided in newlib for some compilers.  */
+#ifdef _LIBC
+int	_fstat (int __fd, struct stat *__sbuf );
+int	_stat (const char *__restrict __path, struct stat *__restrict __sbuf );
+int	_mkdir (const char *_path, mode_t __mode );
+#ifdef __LARGE64_FILES
+struct stat64;
+int	_stat64 (const char *__restrict __path, struct stat64 *__restrict __sbuf );
+int	_fstat64 (int __fd, struct stat64 *__sbuf );
+#endif
+#endif
+
+#endif /* !_STAT_H_ */
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* ZEPHYR_POSIX_SYS_STAT_H_ */
+#endif /* _SYS_STAT_H */

--- a/include/zephyr/posix/sys/stat.h
+++ b/include/zephyr/posix/sys/stat.h
@@ -39,6 +39,41 @@ extern "C" {
 #include <sys/types.h>
 #include <sys/_timespec.h>
 
+#ifndef _DEV_T_DECLARED
+typedef int dev_t;
+#define _DEV_T_DECLARED
+#endif
+
+#ifndef _INO_T_DECLARED
+typedef int ino_t;
+#define _INO_T_DECLARED
+#endif
+
+#ifndef _NLINK_T_DECLARED
+typedef unsigned short nlink_t;
+#define _NLINK_T_DECLARED
+#endif
+
+#ifndef _UID_T_DECLARED
+typedef unsigned short uid_t;
+#define _UID_T_DECLARED
+#endif
+
+#ifndef _GID_T_DECLARED
+typedef unsigned short gid_t;
+#define _GID_T_DECLARED
+#endif
+
+#ifndef _BLKSIZE_T_DECLARED
+typedef unsigned long blksize_t;
+#define _BLKSIZE_T_DECLARED
+#endif
+
+#ifndef _BLKCNT_T_DECLARED
+typedef unsigned long blkcnt_t;
+#define _BLKCNT_T_DECLARED
+#endif
+
 /* dj's stat defines _STAT_H_ */
 #ifndef _STAT_H_
 

--- a/include/zephyr/posix/sys/stat.h
+++ b/include/zephyr/posix/sys/stat.h
@@ -1,33 +1,34 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
 /*
-Copyright (c) 1982, 1986, 1993
-The Regents of the University of California.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-3. Neither the name of the University nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
+ * Copyright (c) 1982, 1986, 1993
+ * The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
  */
-#ifndef	_SYS_STAT_H
-#define	_SYS_STAT_H
+#ifndef ZEPHYR_POSIX_SYS_STAT_H_
+#define ZEPHYR_POSIX_SYS_STAT_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,9 +42,11 @@ extern "C" {
 /* dj's stat defines _STAT_H_ */
 #ifndef _STAT_H_
 
-/* It is intended that the layout of this structure not change when the
-   sizes of any of the basic types change (short, int, long) [via a compile
-   time option].  */
+/*
+ * It is intended that the layout of this structure not change when the
+ * sizes of any of the basic types change (short, int, long) [via a compile
+ * time option].
+ */
 
 #ifdef __CYGWIN__
 #include <cygwin/stat.h>
@@ -51,55 +54,54 @@ extern "C" {
 #define stat64 stat
 #endif
 #else
-struct	stat 
-{
-  dev_t		st_dev;
-  ino_t		st_ino;
-  mode_t	st_mode;
-  nlink_t	st_nlink;
-  uid_t		st_uid;
-  gid_t		st_gid;
+struct stat {
+	dev_t st_dev;
+	ino_t st_ino;
+	mode_t st_mode;
+	nlink_t st_nlink;
+	uid_t st_uid;
+	gid_t st_gid;
 #if defined(__linux) && defined(__x86_64__)
-    int __pad0;
+	int __pad0;
 #endif
-  dev_t		st_rdev;
+	dev_t st_rdev;
 #if defined(__linux) && !defined(__x86_64__)
-    unsigned short int __pad2;
+	unsigned short int __pad2;
 #endif
-  off_t		st_size;
+	off_t st_size;
 #if defined(__linux)
-  blksize_t	st_blksize;
-  blkcnt_t	st_blocks;
-  struct timespec st_atim;
-  struct timespec st_mtim;
-  struct timespec st_ctim;
-#define st_atime st_atim.tv_sec      /* Backward compatibility */
+	blksize_t st_blksize;
+	blkcnt_t st_blocks;
+	struct timespec st_atim;
+	struct timespec st_mtim;
+	struct timespec st_ctim;
+#define st_atime st_atim.tv_sec /* Backward compatibility */
 #define st_mtime st_mtim.tv_sec
 #define st_ctime st_ctim.tv_sec
 #if defined(__linux) && defined(__x86_64__)
-    __uint64_t __glibc_reserved[3];
+	__uint64_t __glibc_reserved[3];
 #endif
 #else
 #if defined(__rtems__)
-  struct timespec st_atim;
-  struct timespec st_mtim;
-  struct timespec st_ctim;
-  blksize_t     st_blksize;
-  blkcnt_t	st_blocks;
+	struct timespec st_atim;
+	struct timespec st_mtim;
+	struct timespec st_ctim;
+	blksize_t st_blksize;
+	blkcnt_t st_blocks;
 #else
-  /* SysV/sco doesn't have the rest... But Solaris, eabi does.  */
+	/* SysV/sco doesn't have the rest... But Solaris, eabi does.  */
 #if defined(__svr4__) && !defined(__PPC__) && !defined(__sun__)
-  time_t	st_atime;
-  time_t	st_mtime;
-  time_t	st_ctime;
+	time_t st_atime;
+	time_t st_mtime;
+	time_t st_ctime;
 #else
-  struct timespec st_atim;
-  struct timespec st_mtim;
-  struct timespec st_ctim;
-  blksize_t     st_blksize;
-  blkcnt_t	st_blocks;
+	struct timespec st_atim;
+	struct timespec st_mtim;
+	struct timespec st_ctim;
+	blksize_t st_blksize;
+	blkcnt_t st_blocks;
 #if !defined(__rtems__)
-  long		st_spare4[2];
+	long st_spare4[2];
 #endif
 #endif
 #endif
@@ -114,117 +116,121 @@ struct	stat
 
 #endif
 
-#define	_IFMT		0170000	/* type of file */
-#define		_IFDIR	0040000	/* directory */
-#define		_IFCHR	0020000	/* character special */
-#define		_IFBLK	0060000	/* block special */
-#define		_IFREG	0100000	/* regular */
-#define		_IFLNK	0120000	/* symbolic link */
-#define		_IFSOCK	0140000	/* socket */
-#define		_IFIFO	0010000	/* fifo */
+#define _IFMT	0170000 /* type of file */
+#define _IFDIR	0040000 /* directory */
+#define _IFCHR	0020000 /* character special */
+#define _IFBLK	0060000 /* block special */
+#define _IFREG	0100000 /* regular */
+#define _IFLNK	0120000 /* symbolic link */
+#define _IFSOCK 0140000 /* socket */
+#define _IFIFO	0010000 /* fifo */
 
-#define 	S_BLKSIZE  1024 /* size of a block */
+#define S_BLKSIZE 1024 /* size of a block */
 
-#define	S_ISUID		0004000	/* set user id on execution */
-#define	S_ISGID		0002000	/* set group id on execution */
-#define	S_ISVTX		0001000	/* save swapped text even after use */
+#define S_ISUID 0004000 /* set user id on execution */
+#define S_ISGID 0002000 /* set group id on execution */
+#define S_ISVTX 0001000 /* save swapped text even after use */
 #if __BSD_VISIBLE
-#define	S_IREAD		0000400	/* read permission, owner */
-#define	S_IWRITE 	0000200	/* write permission, owner */
-#define	S_IEXEC		0000100	/* execute/search permission, owner */
-#define	S_ENFMT 	0002000	/* enforcement-mode locking */
-#endif	/* !_BSD_VISIBLE */
+#define S_IREAD	 0000400 /* read permission, owner */
+#define S_IWRITE 0000200 /* write permission, owner */
+#define S_IEXEC	 0000100 /* execute/search permission, owner */
+#define S_ENFMT	 0002000 /* enforcement-mode locking */
+#endif			 /* !_BSD_VISIBLE */
 
-#define	S_IFMT		_IFMT
-#define	S_IFDIR		_IFDIR
-#define	S_IFCHR		_IFCHR
-#define	S_IFBLK		_IFBLK
-#define	S_IFREG		_IFREG
-#define	S_IFLNK		_IFLNK
-#define	S_IFSOCK	_IFSOCK
-#define	S_IFIFO		_IFIFO
+#define S_IFMT	 _IFMT
+#define S_IFDIR	 _IFDIR
+#define S_IFCHR	 _IFCHR
+#define S_IFBLK	 _IFBLK
+#define S_IFREG	 _IFREG
+#define S_IFLNK	 _IFLNK
+#define S_IFSOCK _IFSOCK
+#define S_IFIFO	 _IFIFO
 
 #ifdef _WIN32
-/* The Windows header files define _S_ forms of these, so we do too
-   for easier portability.  */
-#define _S_IFMT		_IFMT
-#define _S_IFDIR	_IFDIR
-#define _S_IFCHR	_IFCHR
-#define _S_IFIFO	_IFIFO
-#define _S_IFREG	_IFREG
-#define _S_IREAD	0000400
-#define _S_IWRITE	0000200
-#define _S_IEXEC	0000100
+/*
+ * The Windows header files define _S_ forms of these, so we do too
+ * for easier portability.
+ */
+#define _S_IFMT	  _IFMT
+#define _S_IFDIR  _IFDIR
+#define _S_IFCHR  _IFCHR
+#define _S_IFIFO  _IFIFO
+#define _S_IFREG  _IFREG
+#define _S_IREAD  0000400
+#define _S_IWRITE 0000200
+#define _S_IEXEC  0000100
 #endif
 
-#define	S_IRWXU 	(S_IRUSR | S_IWUSR | S_IXUSR)
-#define		S_IRUSR	0000400	/* read permission, owner */
-#define		S_IWUSR	0000200	/* write permission, owner */
-#define		S_IXUSR 0000100/* execute/search permission, owner */
-#define	S_IRWXG		(S_IRGRP | S_IWGRP | S_IXGRP)
-#define		S_IRGRP	0000040	/* read permission, group */
-#define		S_IWGRP	0000020	/* write permission, grougroup */
-#define		S_IXGRP 0000010/* execute/search permission, group */
-#define	S_IRWXO		(S_IROTH | S_IWOTH | S_IXOTH)
-#define		S_IROTH	0000004	/* read permission, other */
-#define		S_IWOTH	0000002	/* write permission, other */
-#define		S_IXOTH 0000001/* execute/search permission, other */
+#define S_IRWXU (S_IRUSR | S_IWUSR | S_IXUSR)
+#define S_IRUSR 0000400 /* read permission, owner */
+#define S_IWUSR 0000200 /* write permission, owner */
+#define S_IXUSR 0000100 /* execute/search permission, owner */
+#define S_IRWXG (S_IRGRP | S_IWGRP | S_IXGRP)
+#define S_IRGRP 0000040 /* read permission, group */
+#define S_IWGRP 0000020 /* write permission, grougroup */
+#define S_IXGRP 0000010 /* execute/search permission, group */
+#define S_IRWXO (S_IROTH | S_IWOTH | S_IXOTH)
+#define S_IROTH 0000004 /* read permission, other */
+#define S_IWOTH 0000002 /* write permission, other */
+#define S_IXOTH 0000001 /* execute/search permission, other */
 
 #if __BSD_VISIBLE
-#define ACCESSPERMS (S_IRWXU | S_IRWXG | S_IRWXO) /* 0777 */
-#define ALLPERMS (S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO) /* 07777 */
+#define ACCESSPERMS (S_IRWXU | S_IRWXG | S_IRWXO)				/* 0777 */
+#define ALLPERMS    (S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO) /* 07777 */
 #define DEFFILEMODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) /* 0666 */
 #endif
 
-#define	S_ISBLK(m)	(((m)&_IFMT) == _IFBLK)
-#define	S_ISCHR(m)	(((m)&_IFMT) == _IFCHR)
-#define	S_ISDIR(m)	(((m)&_IFMT) == _IFDIR)
-#define	S_ISFIFO(m)	(((m)&_IFMT) == _IFIFO)
-#define	S_ISREG(m)	(((m)&_IFMT) == _IFREG)
-#define	S_ISLNK(m)	(((m)&_IFMT) == _IFLNK)
-#define	S_ISSOCK(m)	(((m)&_IFMT) == _IFSOCK)
+#define S_ISBLK(m)  (((m)&_IFMT) == _IFBLK)
+#define S_ISCHR(m)  (((m)&_IFMT) == _IFCHR)
+#define S_ISDIR(m)  (((m)&_IFMT) == _IFDIR)
+#define S_ISFIFO(m) (((m)&_IFMT) == _IFIFO)
+#define S_ISREG(m)  (((m)&_IFMT) == _IFREG)
+#define S_ISLNK(m)  (((m)&_IFMT) == _IFLNK)
+#define S_ISSOCK(m) (((m)&_IFMT) == _IFSOCK)
 
 #if defined(__CYGWIN__) || defined(__rtems__)
 /* Special tv_nsec values for futimens(2) and utimensat(2). */
-#define UTIME_NOW	-2L
-#define UTIME_OMIT	-1L
+#define UTIME_NOW  -2L
+#define UTIME_OMIT -1L
 #endif
 
-int	chmod (const char *__path, mode_t __mode );
-int     fchmod (int __fd, mode_t __mode);
-int	fstat (int __fd, struct stat *__sbuf );
-int	mkdir (const char *_path, mode_t __mode );
-int	mkfifo (const char *__path, mode_t __mode );
-int	stat (const char *__restrict __path, struct stat *__restrict __sbuf );
-mode_t	umask (mode_t __mask );
+int chmod(const char *__path, mode_t __mode);
+int fchmod(int __fd, mode_t __mode);
+int fstat(int __fd, struct stat *__sbuf);
+int mkdir(const char *_path, mode_t __mode);
+int mkfifo(const char *__path, mode_t __mode);
+int stat(const char *__restrict __path, struct stat *__restrict __sbuf);
+mode_t umask(mode_t __mask);
 
-#if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__) && !defined(__INSIDE_CYGWIN__)
-int	lstat (const char *__restrict __path, struct stat *__restrict __buf );
-int	mknod (const char *__path, mode_t __mode, dev_t __dev );
+#if defined(__SPU__) || defined(__rtems__) || defined(__CYGWIN__) && !defined(__INSIDE_CYGWIN__)
+int lstat(const char *__restrict __path, struct stat *__restrict __buf);
+int mknod(const char *__path, mode_t __mode, dev_t __dev);
 #endif
 
 #if __ATFILE_VISIBLE && !defined(__INSIDE_CYGWIN__)
-int	fchmodat (int, const char *, mode_t, int);
-int	fstatat (int, const char *__restrict , struct stat *__restrict, int);
-int	mkdirat (int, const char *, mode_t);
-int	mkfifoat (int, const char *, mode_t);
-int	mknodat (int, const char *, mode_t, dev_t);
-int	utimensat (int, const char *, const struct timespec [2], int);
+int fchmodat(int __fd, const char *__path, mode_t __mode, int __flag);
+int fstatat(int __fd, const char *__restrict __path, struct stat *__restrict __buf, int __flag);
+int mkdirat(int __fd, const char *__path, mode_t __mode);
+int mkfifoat(int __fd, const char *__path, mode_t __mode);
+int mknodat(int __fd, const char *__path, mode_t __mode, dev_t __dev);
+int utimensat(int __fd, const char *__path, const struct timespec __times[2], int __flag);
 #endif
 #if __POSIX_VISIBLE >= 200809 && !defined(__INSIDE_CYGWIN__)
-int	futimens (int, const struct timespec [2]);
+int futimens(int __fd, const struct timespec __times[2]);
 #endif
 
-/* Provide prototypes for most of the _<systemcall> names that are
-   provided in newlib for some compilers.  */
+/*
+ * Provide prototypes for most of the _<systemcall> names that are
+ * provided in newlib for some compilers.
+ */
 #ifdef _LIBC
-int	_fstat (int __fd, struct stat *__sbuf );
-int	_stat (const char *__restrict __path, struct stat *__restrict __sbuf );
-int	_mkdir (const char *_path, mode_t __mode );
+int _fstat(int __fd, struct stat *__sbuf);
+int _stat(const char *__restrict __path, struct stat *__restrict __sbuf);
+int _mkdir(const char *_path, mode_t __mode);
 #ifdef __LARGE64_FILES
 struct stat64;
-int	_stat64 (const char *__restrict __path, struct stat64 *__restrict __sbuf );
-int	_fstat64 (int __fd, struct stat64 *__sbuf );
+int _stat64(const char *__restrict __path, struct stat64 *__restrict __sbuf);
+int _fstat64(int __fd, struct stat64 *__sbuf);
 #endif
 #endif
 
@@ -232,4 +238,4 @@ int	_fstat64 (int __fd, struct stat64 *__sbuf );
 #ifdef __cplusplus
 }
 #endif
-#endif /* _SYS_STAT_H */
+#endif /* ZEPHYR_POSIX_SYS_STAT_H_ */

--- a/include/zephyr/posix/sys/stat.h
+++ b/include/zephyr/posix/sys/stat.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_POSIX_SYS_STAT_H_
+#define ZEPHYR_POSIX_SYS_STAT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define S_IFBLK	 0060000
+#define S_IFCHR	 0020000
+#define S_IFIFO	 0010000
+#define S_IFREG	 0100000
+#define S_IFDIR	 0040000
+#define S_IFLNK	 0120000
+#define S_IFSOCK 0140000
+
+#define S_IRWXU 00700
+#define S_IRUSR 00400
+#define S_IWUSR 00200
+#define S_IXUSR 00100
+
+#define S_IRWXG 00070
+#define S_IRGRP 00040
+#define S_IWGRP 00020
+#define S_IXGRP 00010
+
+#define S_IRWXO 00007
+#define S_IROTH 00004
+#define S_IWOTH 00002
+#define S_IXOTH 00001
+
+/* File open modes */
+#define O_ACCMODE	   0003
+#define O_RDONLY	     00
+#define O_WRONLY	     01
+#define O_RDWR		     02
+
+#define SEEK_SET	0	/* Seek from beginning of file.  */
+#define SEEK_CUR	1	/* Seek from current position.  */
+#define SEEK_END	2	/* Seek from end of file.  */
+
+struct stat {
+	unsigned long st_size;
+	unsigned long st_blksize;
+	unsigned long st_blocks;
+	unsigned long st_mode;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_POSIX_SYS_STAT_H_ */

--- a/include/zephyr/posix/unistd.h
+++ b/include/zephyr/posix/unistd.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_INCLUDE_POSIX_UNISTD_H_
 
 #include "posix_types.h"
-#include "sys/stat.h"
+#include <zephyr/posix/sys/stat.h>
 #ifdef CONFIG_NETWORKING
 /* For zsock_gethostname() */
 #include <zephyr/net/socket.h>

--- a/lib/libc/minimal/include/fcntl.h
+++ b/lib/libc/minimal/include/fcntl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Linaro Limited
+ * Copyright (c) 2022 Meta
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,15 +7,10 @@
 #ifndef ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_FCNTL_H_
 #define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_FCNTL_H_
 
-#define O_CREAT    0x0200
-#define O_APPEND   0x0400
-#define O_EXCL     0x0800
-#define O_NONBLOCK 0x4000
-
-#define F_DUPFD 0
-#define F_GETFL 3
-#define F_SETFL 4
-
-int open(const char *name, int flags, ...);
+#ifndef CONFIG_POSIX_API
+#pragma message("#include <fcntl.h> without CONFIG_POSIX_API is deprecated. "                      \
+		"Please use CONFIG_POSIX_API or #include <zephyr/posix/fcntl.h>")
+#endif
+#include <zephyr/posix/fcntl.h>
 
 #endif /* ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_FCNTL_H_ */

--- a/lib/libc/minimal/include/stdio.h
+++ b/lib/libc/minimal/include/stdio.h
@@ -30,6 +30,10 @@ typedef int  FILE;
 #define stdout ((FILE *) 2)
 #define stderr ((FILE *) 3)
 
+#define SEEK_SET	0	/* Seek from beginning of file.  */
+#define SEEK_CUR	1	/* Seek from current position.  */
+#define SEEK_END	2	/* Seek from end of file.  */
+
 int __printf_like(1, 2) printf(const char *ZRESTRICT format, ...);
 int __printf_like(3, 4) snprintf(char *ZRESTRICT str, size_t len,
 				 const char *ZRESTRICT format, ...);

--- a/lib/libc/minimal/include/sys/stat.h
+++ b/lib/libc/minimal/include/sys/stat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2022 Meta
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,43 +7,10 @@
 #ifndef ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_STAT_H_
 #define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_STAT_H_
 
-#ifdef __cplusplus
-extern "C" {
+#ifndef CONFIG_POSIX_API
+#pragma message("#include <sys/stat.h> without CONFIG_POSIX_API is deprecated. "                   \
+		"Please use CONFIG_POSIX_API or #include <zephyr/posix/sys/stat.h>")
 #endif
+#include <zephyr/posix/sys/stat.h>
 
-#define S_IRWXU 00700
-#define S_IRUSR 00400
-#define S_IWUSR 00200
-#define S_IXUSR 00100
-
-#define S_IRWXG 00070
-#define S_IRGRP 00040
-#define S_IWGRP 00020
-#define S_IXGRP 00010
-
-#define S_IRWXO 00007
-#define S_IROTH 00004
-#define S_IWOTH 00002
-#define S_IXOTH 00001
-
-/* File open modes */
-#define O_ACCMODE	   0003
-#define O_RDONLY	     00
-#define O_WRONLY	     01
-#define O_RDWR		     02
-
-#define SEEK_SET	0	/* Seek from beginning of file.  */
-#define SEEK_CUR	1	/* Seek from current position.  */
-#define SEEK_END	2	/* Seek from end of file.  */
-
-struct stat {
-	unsigned long st_size;
-	unsigned long st_blksize;
-	unsigned long st_blocks;
-};
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif	/* ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_STAT_H_ */
+#endif /* ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SYS_STAT_H_ */

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <malloc.h>
 #include <zephyr/sys/__assert.h>
-#include <sys/stat.h>
+#include <zephyr/posix/sys/stat.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/errno_private.h>

--- a/lib/libc/picolibc/libc-hooks.c
+++ b/lib/libc/picolibc/libc-hooks.c
@@ -7,7 +7,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/stat.h>
+#include <zephyr/posix/sys/stat.h>
 #include <sys/time.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/linker/linker-defs.h>

--- a/lib/posix/CMakeLists.txt
+++ b/lib/posix/CMakeLists.txt
@@ -7,6 +7,14 @@ if(CONFIG_POSIX_API)
   target_include_directories(posix_subsys INTERFACE ${ZEPHYR_BASE}/include/zephyr/posix)
 endif()
 
+if(CONFIG_POSIX_API OR CONFIG_PTHREAD_IPC OR CONFIG_POSIX_CLOCK OR
+  CONFIG_POSIX_MQUEUE OR CONFIG_POSIX_FS OR CONFIG_EVENTFD OR CONFIG_GETOPT)
+  # This is a temporary workaround so that Newlib declares the appropriate
+  # types for us. POSIX features to be formalized as part of #51211
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:-D_POSIX_THREADS>)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:-D_POSIX_THREADS>)
+endif()
+
 zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_POSIX_API perror.c)
 zephyr_library_sources_ifdef(CONFIG_PTHREAD_IPC pthread_common.c)

--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -11,7 +11,7 @@
 #include <zephyr/posix/dirent.h>
 #include <string.h>
 #include <zephyr/sys/fdtable.h>
-#include <sys/stat.h>
+#include <zephyr/posix/sys/stat.h>
 #include <fcntl.h>
 #include <zephyr/fs/fs.h>
 

--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <zephyr/sys/fdtable.h>
 #include <zephyr/posix/sys/stat.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 #include <zephyr/fs/fs.h>
 
 BUILD_ASSERT(PATH_MAX >= MAX_FILE_NAME, "PATH_MAX is less than MAX_FILE_NAME");

--- a/lib/posix/posix_internal.h
+++ b/lib/posix/posix_internal.h
@@ -25,12 +25,12 @@ struct posix_cond {
 };
 
 enum pthread_state {
-	/* The thread structure is unallocated and available for reuse. */
-	PTHREAD_TERMINATED = 0,
-	/* The thread is running and joinable. */
-	PTHREAD_JOINABLE = PTHREAD_CREATE_JOINABLE,
 	/* The thread is running and detached. */
 	PTHREAD_DETACHED = PTHREAD_CREATE_DETACHED,
+	/* The thread is running and joinable. */
+	PTHREAD_JOINABLE = PTHREAD_CREATE_JOINABLE,
+	/* The thread structure is unallocated and available for reuse. */
+	PTHREAD_TERMINATED,
 	/* A joinable thread exited and its return code is available. */
 	PTHREAD_EXITED
 };

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -22,7 +22,7 @@
 
 K_MUTEX_DEFINE(pthread_once_lock);
 
-static const pthread_attr_t init_pthread_attrs = {
+static const struct pthread_attr init_pthread_attrs = {
 	.priority = LOWEST_POSIX_THREAD_PRIORITY,
 	.stack = NULL,
 	.stacksize = 0,
@@ -100,9 +100,9 @@ static int32_t posix_to_zephyr_priority(uint32_t priority, int policy)
  *
  * See IEEE 1003.1
  */
-int pthread_attr_setschedparam(pthread_attr_t *attr,
-			       const struct sched_param *schedparam)
+int pthread_attr_setschedparam(pthread_attr_t *_attr, const struct sched_param *schedparam)
 {
+	struct pthread_attr *attr = (struct pthread_attr *)_attr;
 	int priority = schedparam->sched_priority;
 
 	if ((attr == NULL) || (attr->initialized == 0U) ||
@@ -119,9 +119,10 @@ int pthread_attr_setschedparam(pthread_attr_t *attr,
  *
  * See IEEE 1003.1
  */
-int pthread_attr_setstack(pthread_attr_t *attr, void *stackaddr,
-			  size_t stacksize)
+int pthread_attr_setstack(pthread_attr_t *_attr, void *stackaddr, size_t stacksize)
 {
+	struct pthread_attr *attr = (struct pthread_attr *)_attr;
+
 	if (stackaddr == NULL) {
 		return EACCES;
 	}
@@ -147,7 +148,7 @@ static void zephyr_thread_wrapper(void *arg1, void *arg2, void *arg3)
  *
  * See IEEE 1003.1
  */
-int pthread_create(pthread_t *newthread, const pthread_attr_t *attr,
+int pthread_create(pthread_t *newthread, const pthread_attr_t *_attr,
 		   void *(*threadroutine)(void *), void *arg)
 {
 	int rv;
@@ -157,6 +158,7 @@ int pthread_create(pthread_t *newthread, const pthread_attr_t *attr,
 	k_spinlock_key_t cancel_key;
 	pthread_condattr_t cond_attr;
 	struct posix_thread *thread;
+	const struct pthread_attr *attr = (const struct pthread_attr *)_attr;
 
 	/*
 	 * FIXME: Pthread attribute must be non-null and it provides stack
@@ -355,9 +357,9 @@ int pthread_once(pthread_once_t *once, void (*init_func)(void))
 {
 	k_mutex_lock(&pthread_once_lock, K_FOREVER);
 
-	if (*once == PTHREAD_ONCE_INIT) {
+	if (once->is_initialized != 0 && once->init_executed == 0) {
 		init_func();
-		*once = 0;
+		once->init_executed = 1;
 	}
 
 	k_mutex_unlock(&pthread_once_lock);
@@ -502,8 +504,10 @@ int pthread_detach(pthread_t thread)
  *
  * See IEEE 1003.1
  */
-int pthread_attr_getdetachstate(const pthread_attr_t *attr, int *detachstate)
+int pthread_attr_getdetachstate(const pthread_attr_t *_attr, int *detachstate)
 {
+	const struct pthread_attr *attr = (const struct pthread_attr *)_attr;
+
 	if ((attr == NULL) || (attr->initialized == 0U)) {
 		return EINVAL;
 	}
@@ -517,8 +521,10 @@ int pthread_attr_getdetachstate(const pthread_attr_t *attr, int *detachstate)
  *
  * See IEEE 1003.1
  */
-int pthread_attr_setdetachstate(pthread_attr_t *attr, int detachstate)
+int pthread_attr_setdetachstate(pthread_attr_t *_attr, int detachstate)
 {
+	struct pthread_attr *attr = (struct pthread_attr *)_attr;
+
 	if ((attr == NULL) || (attr->initialized == 0U) ||
 	    (detachstate != PTHREAD_CREATE_DETACHED &&
 	     detachstate != PTHREAD_CREATE_JOINABLE)) {
@@ -535,8 +541,10 @@ int pthread_attr_setdetachstate(pthread_attr_t *attr, int detachstate)
  *
  * See IEEE 1003.1
  */
-int pthread_attr_getschedpolicy(const pthread_attr_t *attr, int *policy)
+int pthread_attr_getschedpolicy(const pthread_attr_t *_attr, int *policy)
 {
+	const struct pthread_attr *attr = (const struct pthread_attr *)_attr;
+
 	if ((attr == NULL) || (attr->initialized == 0U)) {
 		return EINVAL;
 	}
@@ -551,8 +559,10 @@ int pthread_attr_getschedpolicy(const pthread_attr_t *attr, int *policy)
  *
  * See IEEE 1003.1
  */
-int pthread_attr_setschedpolicy(pthread_attr_t *attr, int policy)
+int pthread_attr_setschedpolicy(pthread_attr_t *_attr, int policy)
 {
+	struct pthread_attr *attr = (struct pthread_attr *)_attr;
+
 	if ((attr == NULL) || (attr->initialized == 0U) ||
 	    (policy != SCHED_RR && policy != SCHED_FIFO)) {
 		return EINVAL;
@@ -567,8 +577,10 @@ int pthread_attr_setschedpolicy(pthread_attr_t *attr, int policy)
  *
  * See IEEE 1003.1
  */
-int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *stacksize)
+int pthread_attr_getstacksize(const pthread_attr_t *_attr, size_t *stacksize)
 {
+	const struct pthread_attr *attr = (const struct pthread_attr *)_attr;
+
 	if ((attr == NULL) || (attr->initialized == 0U)) {
 		return EINVAL;
 	}
@@ -583,8 +595,10 @@ int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *stacksize)
  *
  * See IEEE 1003.1
  */
-int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize)
+int pthread_attr_setstacksize(pthread_attr_t *_attr, size_t stacksize)
 {
+	struct pthread_attr *attr = (struct pthread_attr *)_attr;
+
 	if ((attr == NULL) || (attr->initialized == 0U)) {
 		return EINVAL;
 	}
@@ -602,9 +616,10 @@ int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize)
  *
  * See IEEE 1003.1
  */
-int pthread_attr_getstack(const pthread_attr_t *attr,
-				 void **stackaddr, size_t *stacksize)
+int pthread_attr_getstack(const pthread_attr_t *_attr, void **stackaddr, size_t *stacksize)
 {
+	const struct pthread_attr *attr = (const struct pthread_attr *)_attr;
+
 	if ((attr == NULL) || (attr->initialized == 0U)) {
 		return EINVAL;
 	}
@@ -619,9 +634,10 @@ int pthread_attr_getstack(const pthread_attr_t *attr,
  *
  * See IEEE 1003.1
  */
-int pthread_attr_getschedparam(const pthread_attr_t *attr,
-			       struct sched_param *schedparam)
+int pthread_attr_getschedparam(const pthread_attr_t *_attr, struct sched_param *schedparam)
 {
+	struct pthread_attr *attr = (struct pthread_attr *)_attr;
+
 	if ((attr == NULL) || (attr->initialized == 0U)) {
 		return EINVAL;
 	}
@@ -635,8 +651,10 @@ int pthread_attr_getschedparam(const pthread_attr_t *attr,
  *
  * See IEEE 1003.1
  */
-int pthread_attr_destroy(pthread_attr_t *attr)
+int pthread_attr_destroy(pthread_attr_t *_attr)
 {
+	struct pthread_attr *attr = (struct pthread_attr *)_attr;
+
 	if ((attr != NULL) && (attr->initialized != 0U)) {
 		attr->initialized = false;
 		return 0;

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <stdio.h>
 #include <zephyr/sys/atomic.h>
@@ -690,3 +691,18 @@ int pthread_getname_np(pthread_t thread, char *name, size_t len)
 	return 0;
 #endif
 }
+
+static int posix_thread_pool_init(const struct device *dev)
+{
+	size_t i;
+
+	ARG_UNUSED(dev);
+
+	for (i = 0; i < CONFIG_MAX_PTHREAD_COUNT; ++i) {
+		posix_thread_pool[i].state = PTHREAD_EXITED;
+	}
+
+	return 0;
+}
+
+SYS_INIT(posix_thread_pool_init, PRE_KERNEL_1, 0);

--- a/lib/posix/pthread_mutex.c
+++ b/lib/posix/pthread_mutex.c
@@ -21,7 +21,7 @@ int64_t timespec_to_timeoutms(const struct timespec *abstime);
 /*
  *  Default mutex attrs.
  */
-static const pthread_mutexattr_t def_attr = {
+static const struct pthread_mutexattr def_attr = {
 	.type = PTHREAD_MUTEX_DEFAULT,
 };
 
@@ -174,11 +174,11 @@ int pthread_mutex_timedlock(pthread_mutex_t *m,
  *
  * See IEEE 1003.1
  */
-int pthread_mutex_init(pthread_mutex_t *mu,
-				     const pthread_mutexattr_t *attr)
+int pthread_mutex_init(pthread_mutex_t *mu, const pthread_mutexattr_t *_attr)
 {
 	k_spinlock_key_t key;
 	struct posix_mutex *m;
+	const struct pthread_mutexattr *attr = (const struct pthread_mutexattr *)_attr;
 
 	*mu = PTHREAD_MUTEX_INITIALIZER;
 	key = k_spin_lock(&z_pthread_spinlock);
@@ -301,8 +301,9 @@ int pthread_mutexattr_getprotocol(const pthread_mutexattr_t *attr,
  *
  * See IEEE 1003.1
  */
-int pthread_mutexattr_gettype(const pthread_mutexattr_t *attr, int *type)
+int pthread_mutexattr_gettype(const pthread_mutexattr_t *_attr, int *type)
 {
+	const struct pthread_mutexattr *attr = (const struct pthread_mutexattr *)_attr;
 	*type = attr->type;
 	return 0;
 }
@@ -312,8 +313,9 @@ int pthread_mutexattr_gettype(const pthread_mutexattr_t *attr, int *type)
  *
  * See IEEE 1003.1
  */
-int pthread_mutexattr_settype(pthread_mutexattr_t *attr, int type)
+int pthread_mutexattr_settype(pthread_mutexattr_t *_attr, int type)
 {
+	struct pthread_mutexattr *attr = (struct pthread_mutexattr *)_attr;
 	int retc = EINVAL;
 
 	if ((type == PTHREAD_MUTEX_NORMAL) ||

--- a/tests/net/socket/socketpair/src/test_socketpair_block.c
+++ b/tests/net/socket/socketpair/src/test_socketpair_block.c
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef CONFIG_ARCH_POSIX
 #include <fcntl.h>
+#else
+#include <zephyr/posix/fcntl.h>
+#endif
+
 #include <string.h>
 
 #include <zephyr/logging/log.h>

--- a/tests/net/socket/socketpair/src/test_socketpair_closed_ends.c
+++ b/tests/net/socket/socketpair/src/test_socketpair_closed_ends.c
@@ -2,7 +2,11 @@
  *
  * Copyright (c) 2020 Friedt Professional Engineering Services, Inc
  */
+#ifdef CONFIG_ARCH_POSIX
 #include <fcntl.h>
+#else
+#include <zephyr/posix/fcntl.h>
+#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);

--- a/tests/net/socket/socketpair/src/test_socketpair_expected_failures.c
+++ b/tests/net/socket/socketpair/src/test_socketpair_expected_failures.c
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef CONFIG_ARCH_POSIX
 #include <fcntl.h>
+#else
+#include <zephyr/posix/fcntl.h>
+#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);

--- a/tests/net/socket/socketpair/src/test_socketpair_fcntl.c
+++ b/tests/net/socket/socketpair/src/test_socketpair_fcntl.c
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef CONFIG_ARCH_POSIX
 #include <fcntl.h>
+#else
+#include <zephyr/posix/fcntl.h>
+#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);

--- a/tests/net/socket/socketpair/src/test_socketpair_happy_path.c
+++ b/tests/net/socket/socketpair/src/test_socketpair_happy_path.c
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef CONFIG_ARCH_POSIX
 #include <fcntl.h>
+#else
+#include <zephyr/posix/fcntl.h>
+#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);

--- a/tests/net/socket/socketpair/src/test_socketpair_nonblock.c
+++ b/tests/net/socket/socketpair/src/test_socketpair_nonblock.c
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef CONFIG_ARCH_POSIX
 #include <fcntl.h>
+#else
+#include <zephyr/posix/fcntl.h>
+#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);

--- a/tests/net/socket/socketpair/src/test_socketpair_poll.c
+++ b/tests/net/socket/socketpair/src/test_socketpair_poll.c
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef CONFIG_ARCH_POSIX
 #include <fcntl.h>
+#else
+#include <zephyr/posix/fcntl.h>
+#endif
+
 #include <string.h>
 
 #include <zephyr/logging/log.h>

--- a/tests/net/socket/socketpair/src/test_socketpair_unsupported_calls.c
+++ b/tests/net/socket/socketpair/src/test_socketpair_unsupported_calls.c
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef CONFIG_ARCH_POSIX
 #include <fcntl.h>
+#else
+#include <zephyr/posix/fcntl.h>
+#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);

--- a/tests/posix/common/src/mqueue.c
+++ b/tests/posix/common/src/mqueue.c
@@ -76,11 +76,7 @@ ZTEST(posix_apis, test_posix_mqueue)
 
 	for (i = 0; i < N_THR; i++) {
 		/* Creating threads */
-		if (pthread_attr_init(&attr[i]) != 0) {
-			zassert_equal(pthread_attr_destroy(&attr[i]), 0);
-			zassert_false(pthread_attr_init(&attr[i]),
-				      "pthread attr init failed");
-		}
+		zassert_ok(pthread_attr_init(&attr[i]));
 		pthread_attr_setstack(&attr[i], &stacks[i][0], STACKSZ);
 
 		if (i % 2) {

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -319,9 +319,10 @@ ZTEST(posix_apis, test_posix_pthread_execution)
 
 		/* TESTPOINTS: Retrieve set stack attributes and compare */
 		pthread_attr_setstack(&attr[i], &stack_e[i][0], STACKS);
+		stackaddr = NULL;
 		pthread_attr_getstack(&attr[i], &stackaddr, &stacksize);
-		zassert_equal_ptr(attr[i].stack, stackaddr,
-				"stack attribute addresses do not match!");
+		zassert_equal_ptr(&stack_e[i][0], stackaddr,
+				  "stack attribute addresses do not match!");
 		zassert_equal(STACKS, stacksize, "stack sizes do not match!");
 
 		pthread_attr_getstacksize(&attr[i], &stacksize);
@@ -446,7 +447,7 @@ ZTEST(posix_apis, test_posix_pthread_error_condition)
 	zassert_equal(pthread_setschedparam(PTHREAD_INVALID, policy, &param), ESRCH,
 		      "set schedparam with NULL error");
 
-	attr.initialized = 0U;
+	attr = (pthread_attr_t){0};
 	zassert_equal(pthread_attr_getdetachstate(&attr, &detach),
 		      EINVAL, "get detach state error");
 
@@ -571,7 +572,7 @@ ZTEST(posix_apis, test_posix_pthread_create_negative)
 	ret = pthread_attr_init(&attr1);
 	zassert_false(ret, "attr1 initialized failed");
 
-	attr1.stack = NULL;
+	attr1 = (pthread_attr_t){0};
 	ret = pthread_create(&pthread1, &attr1, create_thread1, (void *)1);
 	zassert_equal(ret, EINVAL, "create successful with NULL attr");
 

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -453,12 +453,9 @@ ZTEST(posix_apis, test_posix_pthread_error_condition)
 	/* Initialise thread attribute to ensure won't be return with init error */
 	zassert_false(pthread_attr_init(&attr),
 		      "Unable to create pthread object attr");
-	zassert_false(pthread_attr_setschedpolicy(&attr, 0),
+	zassert_false(pthread_attr_setschedpolicy(&attr, SCHED_FIFO),
 		      "set scheduling policy error");
-	zassert_false(pthread_attr_setschedpolicy(&attr, 1),
-		      "set scheduling policy error");
-	zassert_equal(pthread_attr_setschedpolicy(&attr, 2),
-		      EINVAL, "set scheduling policy error");
+	zassert_false(pthread_attr_setschedpolicy(&attr, SCHED_RR), "set scheduling policy error");
 	zassert_false(pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE),
 		      "set detach state error");
 	zassert_false(pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED),

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -459,9 +459,9 @@ ZTEST(posix_apis, test_posix_pthread_error_condition)
 		      "set scheduling policy error");
 	zassert_equal(pthread_attr_setschedpolicy(&attr, 2),
 		      EINVAL, "set scheduling policy error");
-	zassert_false(pthread_attr_setdetachstate(&attr, 1),
+	zassert_false(pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE),
 		      "set detach state error");
-	zassert_false(pthread_attr_setdetachstate(&attr, 2),
+	zassert_false(pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED),
 		      "set detach state error");
 	zassert_equal(pthread_attr_setdetachstate(&attr, 3),
 		      EINVAL, "set detach state error");


### PR DESCRIPTION
17 commits that close the last posix-related gaps from Zephyr to Newlib.

**Note: Compliance failures are false positives.**

* tests: posix: common: remove duplicate call to pthread_attr_init
* libc: minimal: include: move sys/stat.h to posix
* libc: minimal: include: move fcntl.h to posix
* posix: fcntl: declare fcntl(2) in fcntl.h
* posix: newlib compatible PTHREAD_CREATE_DETACHED and JOINABLE
* posix: pthread_attr_t: match size of newlib variant
* posix: sched: use newlib-compatible SCHED_RR FIFO definitions
* include: posix: types: fix name on header guard
* tests: posix: common: avoid direct pthread_attr_t field access
* include: posix: signal: fix header guard
* posix: headers: harmonize remaining types with newlib
* posix: fcntl.h: conditionally define constants to agree with picolibc / newlib
* posix: sys/stat.h: move O_ACCMODE, RD WRONLY, RDWR to fcntl.h
* libc: minimal: stdio.h: define SEEK_SET, SEEK_CUR, SEEK_END
* posix: sys/stat.h: adopt the sys/stat.h header from picolibc
* posix: sys/stat.h: format for coding style compliance
* posix: sys/stat.h: declare missing types in sys/stat.h