### PR TITLE
Bluetooth: Audio: Fix broadcast assistant recv state pointer value

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -285,9 +285,15 @@ static uint8_t read_recv_state_cb(struct bt_conn *conn, uint8_t err,
 		} else {
 			if (broadcast_assistant_cbs != NULL &&
 			    broadcast_assistant_cbs->recv_state != NULL) {
-				broadcast_assistant_cbs->recv_state(conn,
-								    cb_err,
-								    &recv_state);
+				if (active_recv_state) {
+					broadcast_assistant_cbs->recv_state(conn,
+									    cb_err,
+									    &recv_state);
+				} else {
+					broadcast_assistant_cbs->recv_state(conn,
+									    cb_err,
+									    NULL);
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
When reporting a receive state to the upper layers, the broadcast assistant should report NULL if there is not a receive state active. The "activeness" of a receive state is determined by the length of the characteristic - If it is 0 then there is no receive state active.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>