### PR TITLE
samples: Bluetooth: Increase timeout for broadcast audio source

### DIFF
--- a/samples/bluetooth/broadcast_audio_source/src/main.c
+++ b/samples/bluetooth/broadcast_audio_source/src/main.c
@@ -33,7 +33,7 @@ static bool stopping;
 static K_SEM_DEFINE(sem_started, 0U, ARRAY_SIZE(streams));
 static K_SEM_DEFINE(sem_stopped, 0U, ARRAY_SIZE(streams));
 
-#define BROADCAST_SOURCE_LIFETIME  30U /* seconds */
+#define BROADCAST_SOURCE_LIFETIME  120U /* seconds */
 
 static void stream_started_cb(struct bt_audio_stream *stream)
 {


### PR DESCRIPTION
Increase the time between resets from 30s to 120s. This make it easier to properly use, while still get the chance to test the stop functionality.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>