### PR TITLE
Bluetooth: Controller: Fix BIS subevent channel indices 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv.h
@@ -27,6 +27,7 @@ struct lll_adv_iso {
 	uint16_t latency_event;
 	uint16_t data_chan_prn_s;
 	uint16_t data_chan_remap_idx;
+	uint8_t  next_chan_use;
 
 	uint64_t payload_count:39;
 	uint64_t enc:1;

--- a/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
@@ -54,6 +54,8 @@ struct lll_sync_iso {
 
 	uint8_t stream_curr:5;
 
+	uint8_t next_chan_use;
+
 	uint8_t chm_chan_map[PDU_CHANNEL_MAP_SIZE];
 	uint8_t chm_chan_count:6;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -503,6 +503,7 @@ static void isr_tx_common(void *param,
 		/* control subevent to use bis = 0 and se_n = 1 */
 		bis = 0U;
 		data_chan_use = lll->ctrl_chan_use;
+
 	} else {
 		struct lll_adv_iso_stream *stream;
 		uint16_t stream_handle;
@@ -618,14 +619,25 @@ static void isr_tx_common(void *param,
 		pdu->payload[3] = lll->bis_curr;
 #endif /* TEST_WITH_DUMMY_PDU */
 
-		/* Calculate the radio channel to use for ISO event */
-		data_chan_use =
-			lll_chan_iso_subevent(data_chan_id,
-					      lll->data_chan_map,
-					      lll->data_chan_count,
-					      &lll->data_chan_prn_s,
-					      &lll->data_chan_remap_idx);
+		if ((lll->bn_curr == 1U) && (lll->irc_curr == 1U)) {
+			const uint16_t event_counter =
+				(lll->payload_count / lll->bn) - 1U;
 
+			/* Calculate the radio channel to use for next BIS */
+			data_chan_use = lll_chan_iso_event(event_counter,
+						data_chan_id,
+						lll->data_chan_map,
+						lll->data_chan_count,
+						&lll->data_chan_prn_s,
+						&lll->data_chan_remap_idx);
+		} else {
+			/* Calculate the radio channel to use for subevent */
+			data_chan_use =	lll_chan_iso_subevent(data_chan_id,
+						lll->data_chan_map,
+						lll->data_chan_count,
+						&lll->data_chan_prn_s,
+						&lll->data_chan_remap_idx);
+		}
 	}
 	pdu->rfu = 0U;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -598,6 +598,8 @@ static void isr_tx_common(void *param,
 		} else {
 			pdu = (void *)tx->pdu;
 		}
+		pdu->cssn = lll->cssn;
+		pdu->cstf = 0U;
 
 #else /* TEST_WITH_DUMMY_PDU */
 		pdu = radio_pkt_scratch_get();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -44,9 +44,9 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param);
 static void isr_rx_estab(void *param);
 static void isr_rx(void *param);
 static void isr_rx_iso_data_valid(const struct lll_sync_iso *const lll,
-				  uint8_t bis_idx, struct node_rx_pdu *node_rx);
+				  uint16_t handle, struct node_rx_pdu *node_rx);
 static void isr_rx_iso_data_invalid(const struct lll_sync_iso *const lll,
-				    uint8_t bis_idx, uint8_t bn,
+				    uint8_t bn, uint16_t handle,
 				    struct node_rx_pdu *node_rx);
 static void isr_rx_ctrl_recv(struct lll_sync_iso *lll, struct pdu_bis *pdu);
 
@@ -530,7 +530,7 @@ static void isr_rx(void *param)
 		    ((payload_index >= lll->payload_tail) ||
 		     (payload_index < lll->payload_head))) {
 			ull_iso_pdu_rx_alloc();
-			isr_rx_iso_data_valid(lll, bis_idx, node_rx);
+			isr_rx_iso_data_valid(lll, handle, node_rx);
 
 			lll->payload[bis_idx][payload_index] = node_rx;
 		}
@@ -698,8 +698,8 @@ isr_rx_find_subevent:
 					pdu->ll_id = PDU_BIS_LLID_COMPLETE_END;
 					pdu->len = 0U;
 
-					isr_rx_iso_data_invalid(lll, bis_idx,
-								bn, node_rx);
+					isr_rx_iso_data_invalid(lll, bn, handle,
+								node_rx);
 
 					iso_rx_put(node_rx->hdr.link, node_rx);
 				}
@@ -898,12 +898,12 @@ isr_rx_next_subevent:
 }
 
 static void isr_rx_iso_data_valid(const struct lll_sync_iso *const lll,
-				  uint8_t bis_idx, struct node_rx_pdu *node_rx)
+				  uint16_t handle, struct node_rx_pdu *node_rx)
 {
 	struct node_rx_iso_meta *iso_meta;
 
 	node_rx->hdr.type = NODE_RX_TYPE_ISO_PDU;
-	node_rx->hdr.handle = lll->stream_handle[bis_idx];
+	node_rx->hdr.handle = handle;
 
 	iso_meta = &node_rx->hdr.rx_iso_meta;
 	iso_meta->payload_number = lll->payload_count + (lll->bn_curr - 1U) +
@@ -916,13 +916,13 @@ static void isr_rx_iso_data_valid(const struct lll_sync_iso *const lll,
 }
 
 static void isr_rx_iso_data_invalid(const struct lll_sync_iso *const lll,
-				    uint8_t bis_idx, uint8_t bn,
+				    uint8_t bn, uint16_t handle,
 				    struct node_rx_pdu *node_rx)
 {
 	struct node_rx_iso_meta *iso_meta;
 
 	node_rx->hdr.type = NODE_RX_TYPE_ISO_PDU;
-	node_rx->hdr.handle = lll->stream_handle[bis_idx];
+	node_rx->hdr.handle = handle;
 
 	iso_meta = &node_rx->hdr.rx_iso_meta;
 	iso_meta->payload_number = lll->payload_count - bn - 1U;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -271,6 +271,9 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	radio_crc_configure(PDU_CRC_POLYNOMIAL, sys_get_le24(crc_init));
 	lll_chan_set(data_chan_use);
 
+	/* By design, there shall alway be one free node rx available for
+	 * setting up radio for new PDU reception.
+	 */
 	node_rx = ull_iso_pdu_rx_alloc_peek(1U);
 	LL_ASSERT(node_rx);
 	radio_pkt_rx_set(node_rx->pdu);
@@ -477,6 +480,12 @@ static void isr_rx(void *param)
 		    lll->ctrl) {
 			lll->cssn_curr = lll->cssn_next;
 
+			/* By design, there shall alway be one free node rx
+			 * available for setting up radio for new PDU reception.
+			 * Control procedure handling does not consume any
+			 * node rx, hence checking for one free node rx is
+			 * sufficient.
+			 */
 			node_rx = ull_iso_pdu_rx_alloc_peek(1U);
 			LL_ASSERT(node_rx);
 
@@ -487,7 +496,7 @@ static void isr_rx(void *param)
 
 			isr_rx_ctrl_recv(lll, pdu);
 		} else {
-			/* check if there are 2 free rx buffers, one will be
+			/* Check if there are 2 free rx buffers, one will be
 			 * consumed to receive the current PDU, and the other
 			 * is to ensure a PDU can be setup for the radio DMA to
 			 * receive in the next sub_interval/iso_interval.
@@ -673,7 +682,7 @@ isr_rx_find_subevent:
 
 				iso_rx_put(node_rx->hdr.link, node_rx);
 			} else {
-				/* check if there are 2 free rx buffers, one
+				/* Check if there are 2 free rx buffers, one
 				 * will be consumed to generate PDU with invalid
 				 * status, and the other is to ensure a PDU can
 				 * be setup for the radio DMA to receive in the
@@ -805,6 +814,9 @@ isr_rx_next_subevent:
 	}
 	lll_chan_set(data_chan_use);
 
+	/* By design, there shall alway be one free node rx available for
+	 * setting up radio for new PDU reception.
+	 */
 	node_rx = ull_iso_pdu_rx_alloc_peek(1U);
 	LL_ASSERT(node_rx);
 	radio_pkt_rx_set(node_rx->pdu);

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -110,10 +110,11 @@ static void *datapath_free;
  * - mem_iso_rx:      Backing data pool for PDU buffer elements
  * - mem_link_iso_rx: Pool of memq_link_t elements
  *
+ * One extra rx buffer is reserved for empty ISO PDU reception.
  * Two extra links are reserved for use by the ll_iso_rx and ull_iso_rx memq.
  */
-static RXFIFO_DEFINE(iso_rx, NODE_RX_HEADER_SIZE + ISO_RX_BUFFER_SIZE,
-			     CONFIG_BT_CTLR_ISO_RX_BUFFERS, 2);
+static RXFIFO_DEFINE(iso_rx, ((NODE_RX_HEADER_SIZE) + (ISO_RX_BUFFER_SIZE)),
+			     (CONFIG_BT_CTLR_ISO_RX_BUFFERS + 1U), 2U);
 
 static MEMQ_DECLARE(ll_iso_rx);
 #if defined(CONFIG_BT_CTLR_ISO_VENDOR_DATA_PATH)


### PR DESCRIPTION
From Bluetooth Core Specification v5.3 Vol 6 Part B Section
4.4.6.8 Channel indices,

The subevent number se_n shall be set to the values 1 to
NSE, in order, for the subevents on a given BIS - the same
values shall be used for all the BISes in a BIG - and to 1
for the control subevent.

Hence, fix implementation to reset back to se_n to 1 when
next BIS PDUs are transmitted in the subevents.

Updated implementation to save power consumption by
scheduling BIG event starting at the first BIS selected for
synchronization. Also, skip reception of any unselected
BISes in between multiple BISes that the Broadcaster is
transmitting.

Relates to #52055.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>