### PR TITLE
Implementing CIS supervision and establishment timeout

### DIFF
--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -392,14 +392,17 @@ static inline struct net_buf *encode_node(struct node_rx_pdu *node_rx,
 #if defined(CONFIG_BT_CTLR_CONN_ISO)
 		uint8_t handle = node_rx->hdr.handle;
 		struct ll_iso_stream_hdr *hdr = NULL;
+		struct ll_conn_iso_stream *cis = NULL;
+		struct ll_iso_datapath *dp = NULL;
 
 		if (IS_CIS_HANDLE(handle)) {
-			struct ll_conn_iso_stream *cis =
-				ll_conn_iso_stream_get(handle);
+			cis = ll_conn_iso_stream_get(handle);
 			hdr = &cis->hdr;
 		}
 
-		struct ll_iso_datapath *dp = hdr->datapath_out;
+		if (cis && !cis->teardown) {
+			dp = hdr->datapath_out;
+		}
 
 		if (dp && dp->path_id == BT_HCI_DATAPATH_ID_HCI) {
 			/* If HCI datapath pass to ISO AL here */

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -496,7 +496,10 @@ struct event_done_extra {
 #endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 	union {
 		struct {
-			uint16_t trx_cnt;
+			union {
+				uint32_t trx_performed_mask;
+				uint16_t trx_cnt;
+			};
 			uint8_t  crc_valid:1;
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING) && \
 	defined(CONFIG_BT_CTLR_CTEINLINE_SUPPORT)

--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -74,4 +74,6 @@ struct lll_conn_iso_group {
 
 int lll_conn_iso_init(void);
 int lll_conn_iso_reset(void);
+void lll_conn_iso_done(struct lll_conn_iso_group *cig, uint32_t trx_performed,
+		       uint16_t prog_to_anchor_us, uint8_t mic_state);
 void lll_conn_iso_flush(uint16_t handle, struct lll_conn_iso_stream *lll);

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -284,8 +284,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn->connect_expire = CONN_ESTAB_COUNTDOWN;
 	conn->supervision_expire = 0U;
 	conn_interval_us = (uint32_t)interval * CONN_INT_UNIT_US;
-	conn->supervision_reload = RADIO_CONN_EVENTS(timeout * 10000U,
-							 conn_interval_us);
+	conn->supervision_timeout = timeout;
 
 #if defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
 	conn->procedure_expire = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -286,8 +286,11 @@ void ull_conn_iso_done(struct node_rx_event_done *done)
 {
 	struct lll_conn_iso_group *lll;
 	struct ll_conn_iso_group *cig;
+	struct ll_conn_iso_stream *cis;
 	uint32_t ticks_drift_minus;
 	uint32_t ticks_drift_plus;
+	uint16_t handle_iter;
+	uint8_t cis_idx;
 
 	/* Get reference to ULL context */
 	cig = CONTAINER_OF(done->param, struct ll_conn_iso_group, ull);
@@ -300,19 +303,58 @@ void ull_conn_iso_done(struct node_rx_event_done *done)
 
 	ticks_drift_plus  = 0;
 	ticks_drift_minus = 0;
+	handle_iter = UINT16_MAX;
+	cis = NULL;
 
-	if (done->extra.trx_cnt) {
-		if (IS_ENABLED(CONFIG_BT_CTLR_PERIPHERAL_ISO) && lll->role) {
-			ull_drift_ticks_get(done, &ticks_drift_plus,
-					    &ticks_drift_minus);
+	/* Check all CISes for supervison/establishment timeout */
+	for (cis_idx = 0; cis_idx < cig->lll.num_cis; cis_idx++) {
+		cis = ll_conn_iso_stream_get_by_group(cig, &handle_iter);
+		LL_ASSERT(cis);
+
+		if (cis->lll.handle != LLL_HANDLE_INVALID) {
+			/* CIS was setup and is now expected to be going */
+			if (!(done->extra.trx_performed_mask &
+			      (1U << LL_CIS_IDX_FROM_HANDLE(cis->lll.handle)))) {
+				/* We did NOT have successful transaction on established CIS,
+				 * or CIS was not yet established, so handle timeout
+				 */
+				if (!cis->event_expire) {
+					struct ll_conn *conn = ll_conn_get(cis->lll.acl_handle);
+
+					cis->event_expire =
+						RADIO_CONN_EVENTS(
+							conn->supervision_timeout * 10U * 1000U,
+							cig->iso_interval * CONN_INT_UNIT_US) + 1;
+				}
+
+				if (--cis->event_expire == 0) {
+					/* Stop CIS and defer cleanup to after teardown. */
+					ull_conn_iso_cis_stop(cis, NULL,
+							      cis->established ?
+							      BT_HCI_ERR_CONN_TIMEOUT :
+							      BT_HCI_ERR_CONN_FAIL_TO_ESTAB);
+
+				}
+			} else {
+				cis->event_expire = 0;
+			}
 		}
 	}
 
-	/* Update CIG ticker to compensate for drift */
-	if (ticks_drift_plus || ticks_drift_minus) {
+	if (done->extra.trx_performed_mask &&
+	    IS_ENABLED(CONFIG_BT_CTLR_PERIPHERAL_ISO) && lll->role) {
+		ull_drift_ticks_get(done, &ticks_drift_plus,
+				    &ticks_drift_minus);
+	}
+
+	/* Update CIG ticker to compensate for drift.
+	 * Since all CISes in a CIG 'belong to' the same ACL,
+	 * any CIS found in the above for-loop will do to dereference the ACL
+	 */
+	if (cis && (ticks_drift_plus || ticks_drift_minus)) {
 		uint8_t ticker_id = TICKER_ID_CONN_ISO_BASE +
 				    ll_conn_iso_group_handle_get(cig);
-		struct ll_conn *conn = lll->hdr.parent;
+		struct ll_conn *conn = ll_connected_get(cis->lll.acl_handle);
 		uint32_t ticker_status;
 
 		ticker_status = ticker_update(TICKER_INSTANCE_ID_CTLR,
@@ -644,6 +686,9 @@ void ull_conn_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire, uint16_t 
 	cis->lll.offset = cis_offs_to_cig_ref;
 	cis->lll.handle = cis_handle;
 	cis->lll.active = 1U;
+
+	/* Connection establishment timeout */
+	cis->event_expire = CONN_ESTAB_COUNTDOWN;
 
 	/* Check if another CIS was already started and CIG ticker is
 	 * running. If so, we just return with updated offset and

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
@@ -24,6 +24,7 @@ struct ll_conn_iso_stream {
 				   * notified.
 				   */
 	uint16_t teardown:1;       /* 1 if CIS teardown has been initiated */
+	uint16_t trx_performed:1;  /* 1 if CIS had a transaction */
 	uint16_t p_max_sdu:12;     /* Maximum SDU size P_To_C */
 	uint16_t c_max_sdu:12;     /* Maximum SDU size C_To_P */
 	union {
@@ -33,6 +34,7 @@ struct ll_conn_iso_stream {
 			uint16_t instant;
 		} central;
 	};
+	uint16_t event_expire;     /* Supervision & Connect Timeout event counter */
 };
 
 struct ll_conn_iso_group {

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -38,7 +38,7 @@ struct ll_conn {
 	struct lll_conn lll;
 
 	uint16_t connect_expire;
-	uint16_t supervision_reload;
+	uint16_t supervision_timeout;
 	uint16_t supervision_expire;
 	uint16_t procedure_reload;
 	uint16_t procedure_expire;
@@ -537,7 +537,7 @@ struct ll_conn {
 #endif /* CONFIG_BT_CTLR_LE_PING */
 
 	uint16_t connect_expire;
-	uint16_t supervision_reload;
+	uint16_t supervision_timeout;
 	uint16_t supervision_expire;
 	uint32_t connect_accept_to;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -220,7 +220,11 @@ static void lp_comm_tx(struct ll_conn *conn, struct proc_ctx *ctx)
 		 * NOTE: As the supervision timeout is at most 32s the normal procedure response
 		 * timeout of 40s will never come into play for the ACL Termination procedure.
 		 */
-		llcp_lr_prt_restart_with_value(conn, conn->supervision_reload);
+		const uint32_t conn_interval_us = conn->lll.interval * CONN_INT_UNIT_US;
+		const uint16_t sto_reload = RADIO_CONN_EVENTS(
+			(conn->supervision_timeout * 10U * 1000U),
+			conn_interval_us);
+		llcp_lr_prt_restart_with_value(conn, sto_reload);
 	}
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -152,8 +152,7 @@ static bool cu_have_params_changed(struct ll_conn *conn, uint16_t interval, uint
 	struct lll_conn *lll = &conn->lll;
 
 	if ((interval != lll->interval) || (latency != lll->latency) ||
-	    (RADIO_CONN_EVENTS(timeout * 10000U, lll->interval * CONN_INT_UNIT_US) !=
-	     conn->supervision_reload)) {
+	    (timeout != conn->supervision_timeout)) {
 		return true;
 	}
 	return false;
@@ -301,8 +300,7 @@ static void lp_cu_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	} else {
 		pdu->interval = conn->lll.interval;
 		pdu->latency = conn->lll.latency;
-		pdu->timeout = conn->supervision_reload *
-			conn->lll.interval * 125U / 1000;
+		pdu->timeout = conn->supervision_timeout;
 	}
 
 	/* Enqueue notification towards LL */
@@ -759,8 +757,7 @@ static void rp_cu_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	} else {
 		pdu->interval = conn->lll.interval;
 		pdu->latency = conn->lll.latency;
-		pdu->timeout = conn->supervision_reload *
-			conn->lll.interval * 125U / 1000;
+		pdu->timeout = conn->supervision_timeout;
 	}
 	/* Enqueue notification towards LL */
 	ll_rx_put(ntf->hdr.link, ntf);

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -91,7 +91,6 @@ void ull_periph_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 	uint16_t max_rx_time;
 	uint16_t win_offset;
 	memq_link_t *link;
-	uint16_t timeout;
 	uint8_t chan_sel;
 	void *node;
 
@@ -204,9 +203,7 @@ void ull_periph_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 		CONN_INT_UNIT_US;
 
 	/* procedure timeouts */
-	timeout = sys_le16_to_cpu(pdu_adv->connect_ind.timeout);
-	conn->supervision_reload =
-		RADIO_CONN_EVENTS((timeout * 10U * 1000U), conn_interval_us);
+	conn->supervision_timeout = sys_le16_to_cpu(pdu_adv->connect_ind.timeout);
 
 #if defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
 	conn->procedure_reload =
@@ -286,7 +283,7 @@ void ull_periph_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 
 	cc->interval = lll->interval;
 	cc->latency = lll->latency;
-	cc->timeout = timeout;
+	cc->timeout = conn->supervision_timeout;
 	cc->sca = conn->periph.sca;
 
 	lll->handle = ll_conn_handle_get(conn);

--- a/tests/bluetooth/controller/common/src/helper_util.c
+++ b/tests/bluetooth/controller/common/src/helper_util.c
@@ -269,6 +269,8 @@ void test_setup(struct ll_conn *conn)
 
 	ll_reset();
 	conn->lll.event_counter = 0;
+	conn->lll.interval = 6;
+	conn->supervision_timeout = 600;
 	event_active[0] = 0;
 
 	memset(emul_conn_pool, 0x00, sizeof(emul_conn_pool));

--- a/tests/bluetooth/controller/ctrl_conn_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_conn_update/src/main.c
@@ -195,7 +195,7 @@ static void setup(void)
 
 	lll->interval = 0;
 	lll->latency = 0;
-	conn.supervision_reload = 1U;
+	conn.supervision_timeout = 1U;
 	lll->event_counter = 0;
 }
 
@@ -2467,6 +2467,7 @@ void test_conn_update_periph_rem_apm_accept_right_away(void)
 #if defined(CONFIG_BT_CTLR_USER_CPR_ANCHOR_POINT_MOVE)
 	struct node_tx *tx;
 	uint16_t instant;
+	uint8_t error = 0U;
 	/* Default conn_param_req PDU */
 	struct pdu_data_llctrl_conn_param_req conn_param_req_apm = { .interval_min = INTVL_MIN,
 								 .interval_max = INTVL_MAX,
@@ -2494,7 +2495,6 @@ void test_conn_update_periph_rem_apm_accept_right_away(void)
 								 .offset3 = 0xffffU,
 								 .offset4 = 0xffffU,
 								 .offset5 = 0xffffU };
-	uint8_t error = 0;
 
 	/* Prepare mocked call to ull_handle_cpr_anchor_point_move */
 	/* No APM deferance, accept with error == 0 */
@@ -2509,8 +2509,7 @@ void test_conn_update_periph_rem_apm_accept_right_away(void)
 
 	conn.lll.interval = conn_param_req_apm.interval_max;
 	conn.lll.latency = conn_param_req_apm.latency;
-	conn.supervision_reload = RADIO_CONN_EVENTS(TIMEOUT * 10000U, conn.lll.interval *
-						    CONN_INT_UNIT_US);
+	conn.supervision_timeout = TIMEOUT;
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -2638,7 +2637,6 @@ void test_conn_update_periph_rem_apm_reject_right_away(void)
 	ztest_returns_value(ull_handle_cpr_anchor_point_move, false);
 	ztest_return_data(ull_handle_cpr_anchor_point_move, status, &error);
 
-
 	/* Role */
 	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
 
@@ -2647,8 +2645,7 @@ void test_conn_update_periph_rem_apm_reject_right_away(void)
 
 	conn.lll.interval = conn_param_req_apm.interval_max;
 	conn.lll.latency = conn_param_req_apm.latency;
-	conn.supervision_reload = RADIO_CONN_EVENTS(TIMEOUT * 10000U, conn.lll.interval *
-						    CONN_INT_UNIT_US);
+	conn.supervision_timeout = TIMEOUT;
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -2740,6 +2737,7 @@ void test_conn_update_periph_rem_apm_accept_defered(void)
 	};
 	struct node_tx *tx;
 	uint16_t instant;
+	uint8_t error = 0U;
 	/* Default conn_param_req PDU */
 	struct pdu_data_llctrl_conn_param_req conn_param_req_apm = { .interval_min = INTVL_MIN,
 								 .interval_max = INTVL_MAX,
@@ -2767,7 +2765,6 @@ void test_conn_update_periph_rem_apm_accept_defered(void)
 								 .offset3 = 0xffffU,
 								 .offset4 = 0xffffU,
 								 .offset5 = 0xffffU };
-	uint8_t error = 0;
 
 	/* Prepare mocked call to ull_handle_cpr_anchor_point_move */
 	/* Defer APM */
@@ -2782,8 +2779,7 @@ void test_conn_update_periph_rem_apm_accept_defered(void)
 
 	conn.lll.interval = conn_param_req_apm.interval_max;
 	conn.lll.latency = conn_param_req_apm.latency;
-	conn.supervision_reload = RADIO_CONN_EVENTS(TIMEOUT * 10000U, conn.lll.interval *
-						    CONN_INT_UNIT_US);
+	conn.supervision_timeout = TIMEOUT;
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -2796,7 +2792,6 @@ void test_conn_update_periph_rem_apm_accept_defered(void)
 
 	/* Done */
 	event_done(&conn);
-
 
 	/* Run a few events */
 	for (int i = 0; i < 10; i++) {
@@ -2906,6 +2901,7 @@ void test_conn_update_periph_rem_apm_reject_defered(void)
 {
 #if defined(CONFIG_BT_CTLR_USER_CPR_ANCHOR_POINT_MOVE)
 	struct node_tx *tx;
+	uint8_t error = 0U;
 	/* Default conn_param_req PDU */
 	struct pdu_data_llctrl_conn_param_req conn_param_req_apm = { .interval_min = INTVL_MIN,
 								 .interval_max = INTVL_MAX,
@@ -2923,13 +2919,11 @@ void test_conn_update_periph_rem_apm_reject_defered(void)
 		.reject_opcode = PDU_DATA_LLCTRL_TYPE_CONN_PARAM_REQ,
 		.error_code = BT_HCI_ERR_UNSUPP_LL_PARAM_VAL
 	};
-	uint8_t error = 0U;
 
 	/* Prepare mocked call to ull_handle_cpr_anchor_point_move */
 	/* Defer APM */
 	ztest_returns_value(ull_handle_cpr_anchor_point_move, true);
 	ztest_return_data(ull_handle_cpr_anchor_point_move, status, &error);
-
 
 	/* Role */
 	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
@@ -2939,8 +2933,7 @@ void test_conn_update_periph_rem_apm_reject_defered(void)
 
 	conn.lll.interval = conn_param_req_apm.interval_max;
 	conn.lll.latency = conn_param_req_apm.latency;
-	conn.supervision_reload = RADIO_CONN_EVENTS(TIMEOUT * 10000U, conn.lll.interval *
-						    CONN_INT_UNIT_US);
+	conn.supervision_timeout = TIMEOUT;
 
 	/* Prepare */
 	event_prepare(&conn);


### PR DESCRIPTION
This implements CIS supervision timeout as well as CIS establishment timeout.
It changes also the way supervision timeout is stored and accessed for ACL. This in order to not have to do time vs. interval math for individual CIS's 

This is work that has been in use for two months, with which just over 500 EBQ tests are passing.