### PR TITLE
net: shell: Allow to specify ping payload size 

### DIFF
--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -555,7 +555,24 @@ int net_icmpv4_send_echo_request(struct net_if *iface,
 	echo_req->sequence   = htons(sequence);
 
 	net_pkt_set_data(pkt, &icmpv4_access);
-	net_pkt_write(pkt, data, data_size);
+
+	if (data != NULL && data_size > 0) {
+		net_pkt_write(pkt, data, data_size);
+	} else if (data == NULL && data_size > 0) {
+		/* Generate payload. */
+		if (data_size >= sizeof(uint32_t)) {
+			uint32_t time_stamp = htonl(k_cycle_get_32());
+
+			net_pkt_write(pkt, &time_stamp, sizeof(time_stamp));
+			data_size -= sizeof(time_stamp);
+		}
+
+		for (size_t i = 0; i < data_size; i++) {
+			net_pkt_write_u8(pkt, (uint8_t)i);
+		}
+	} else {
+		/* No payload. */
+	}
 
 	net_pkt_cursor_init(pkt);
 

--- a/subsys/net/ip/icmpv4.h
+++ b/subsys/net/ip/icmpv4.h
@@ -69,8 +69,10 @@ int net_icmpv4_send_error(struct net_pkt *pkt, uint8_t type, uint8_t code);
  * @param tos IPv4 Type-of-service field value. Represents combined DSCP and ECN
  * values.
  * @param data Arbitrary payload data that will be included in the
- * Echo Reply verbatim. May be zero.
- * @param data_size Size of the Payload Data in bytes. May be zero.
+ * Echo Reply verbatim. May be NULL.
+ * @param data_size Size of the Payload Data in bytes. May be zero. In case data
+ * pointer is NULL, the function will generate the payload up to the requested
+ * size.
  *
  * @return Return 0 if the sending succeed, <0 otherwise.
  */

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -380,7 +380,24 @@ int net_icmpv6_send_echo_request(struct net_if *iface,
 	echo_req->sequence   = htons(sequence);
 
 	net_pkt_set_data(pkt, &icmpv6_access);
-	net_pkt_write(pkt, data, data_size);
+
+	if (data != NULL && data_size > 0) {
+		net_pkt_write(pkt, data, data_size);
+	} else if (data == NULL && data_size > 0) {
+		/* Generate payload. */
+		if (data_size >= sizeof(uint32_t)) {
+			uint32_t time_stamp = htonl(k_cycle_get_32());
+
+			net_pkt_write(pkt, &time_stamp, sizeof(time_stamp));
+			data_size -= sizeof(time_stamp);
+		}
+
+		for (size_t i = 0; i < data_size; i++) {
+			net_pkt_write_u8(pkt, (uint8_t)i);
+		}
+	} else {
+		/* No payload. */
+	}
 
 	net_pkt_cursor_init(pkt);
 	net_ipv6_finalize(pkt, IPPROTO_ICMPV6);

--- a/subsys/net/ip/icmpv6.h
+++ b/subsys/net/ip/icmpv6.h
@@ -201,8 +201,10 @@ int net_icmpv6_send_error(struct net_pkt *pkt, uint8_t type, uint8_t code,
  * @param tc IPv6 Traffic Class field value. Represents combined DSCP and
  * ECN values.
  * @param data Arbitrary payload data that will be included in the
- * Echo Reply verbatim. May be zero.
- * @param data_size Size of the Payload Data in bytes. May be zero.
+ * Echo Reply verbatim. May be NULL.
+ * @param data_size Size of the Payload Data in bytes. May be zero. In case data
+ * pointer is NULL, the function will generate the payload up to the requested
+ * size.
  *
  * @return Return 0 if the sending succeed, <0 otherwise.
  */


### PR DESCRIPTION
* Add -s parameter to the net ping command, allowing to specify the payload size for the Echo Request.
* Modify `net_icmpv4_send_echo_request()` and `net_icmpv6_send_echo_request()` to allow to autogenerate Echo Request payload.
* Fix Echo Reply processing for shorter requests.

Resolves #49843