### PR TITLE
arm: cache: management functions

### DIFF
--- a/arch/arm/core/aarch32/cache.c
+++ b/arch/arm/core/aarch32/cache.c
@@ -1,108 +1,109 @@
 /*
- * Copyright (c) 2013-2014 Wind River Systems, Inc.
- * Copyright (c) 2020-2022 Qualcomm Innovation Center, Inc.
- *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/* cache.c - cache support for AARCH32 CPUs */
+
 /**
  * @file
- * @brief Cache manipulation
+ * @brief cache manipulation
  *
- * This module contains functions for manipulation caches.
+ * This module contains functions for manipulation of the cache.
+ * Based on ARM documentation from:
+ *   - https://developer.arm.com/documentation/ddi0301/h/Babhejba
  */
 
-#include <zephyr/arch/cpu.h>
 #include <zephyr/cache.h>
-#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
-void arch_dcache_enable(void)
-{
-	SCB_EnableDCache();
-}
-
-void arch_dcache_disable(void)
-{
-	SCB_DisableDCache();
-}
-
-void arch_icache_enable(void)
-{
-	SCB_EnableICache();
-}
-
-void arch_icache_disable(void)
-{
-	SCB_DisableICache();
-}
-
-static void arch_dcache_flush(void *start_addr, size_t size)
-{
-	SCB_CleanDCache_by_Addr(start_addr, size);
-}
-
-static void arch_dcache_invd(void *start_addr, size_t size)
-{
-	SCB_InvalidateDCache_by_Addr(start_addr, size);
-}
-
-static void arch_dcache_flush_and_invd(void *start_addr, size_t size)
-{
-	SCB_CleanInvalidateDCache_by_Addr(start_addr, size);
-}
-
-static void arch_icache_invd(void *start_addr, size_t size)
-{
-	SCB_InvalidateICache_by_Addr(start_addr, size);
-}
-
+/*
+ * operation for data cache by virtual address to PoC
+ * ops:  K_CACHE_INVD: invalidate
+ *	 K_CACHE_WB: clean
+ *	 K_CACHE_WB_INVD: clean and invalidate
+ */
 int arch_dcache_range(void *addr, size_t size, int op)
 {
-	if (op == K_CACHE_INVD) {
-		arch_dcache_invd(addr, size);
-	} else if (op == K_CACHE_WB) {
-		arch_dcache_flush(addr, size);
-	} else if (op == K_CACHE_WB_INVD) {
-		arch_dcache_flush_and_invd(addr, size);
-	} else {
-		return -ENOTSUP;
-	}
+	uintptr_t start_addr = (uintptr_t)addr;
+	uintptr_t end_addr = (uintptr_t)addr + size;
 
+	start_addr /= CONFIG_DCACHE_LINE_SIZE;
+	start_addr *= CONFIG_DCACHE_LINE_SIZE;
+
+	for (; start_addr < end_addr; start_addr += CONFIG_DCACHE_LINE_SIZE) {
+		switch (op) {
+		case K_CACHE_WB:
+			__asm__ volatile("mcr p15, #0, %0, c7, c10, #1" : : "r"(start_addr));
+			break;
+		case K_CACHE_WB_INVD:
+			__asm__ volatile("mcr p15, #0, %0, c7, c14, #1" : : "r"(start_addr));
+			break;
+		case K_CACHE_INVD:
+			__asm__ volatile("mcr p15, #0, %0, c7, c6, #1" : : "r"(start_addr));
+			break;
+		default:
+			return -ENOTSUP;
+		}
+	}
+	__DSB();
 	return 0;
 }
 
+/*
+ * operation for all data cache
+ * ops:  K_CACHE_INVD: invalidate
+ *	 K_CACHE_WB: clean
+ *	 K_CACHE_WB_INVD: clean and invalidate
+ */
 int arch_dcache_all(int op)
 {
-	if (op == K_CACHE_INVD) {
-		SCB_InvalidateDCache();
-	} else if (op == K_CACHE_WB) {
-		SCB_CleanDCache();
-	} else if (op == K_CACHE_WB_INVD) {
-		SCB_CleanInvalidateDCache();
-	} else {
+	switch (op) {
+	case K_CACHE_WB:
+		__asm__ volatile("mcr p15, #0, %0, c7, c10, #0" : : "r"(0));
+		break;
+	case K_CACHE_WB_INVD:
+		__asm__ volatile("mcr p15, #0, %0, c7, c14, #0" : : "r"(0));
+		break;
+	case K_CACHE_INVD:
+		__asm__ volatile("mcr p15, #0, %0, c7, c6, #0" : : "r"(0));
+		break;
+	default:
 		return -ENOTSUP;
 	}
-
+	__DSB();
 	return 0;
 }
 
-int arch_icache_all(int op)
-{
-	if (op == K_CACHE_INVD) {
-		SCB_InvalidateICache();
-	} else {
-		return -ENOTSUP;
-	}
-
-	return 0;
-}
-
+/*
+ * operation for instruction cache by virtual address to PoC
+ * ops:  K_CACHE_INVD: invalidate
+ */
 int arch_icache_range(void *addr, size_t size, int op)
 {
-	if (op == K_CACHE_INVD) {
-		arch_icache_invd(addr, size);
-	} else {
-		return -ENOTSUP;
-	}
+	uintptr_t start_addr = (uintptr_t)addr;
+	uintptr_t end_addr = (uintptr_t)addr + size;
 
+	start_addr /= CONFIG_DCACHE_LINE_SIZE;
+	start_addr *= CONFIG_DCACHE_LINE_SIZE;
+
+	if (op != K_CACHE_WB_INVD)
+		return -ENOTSUP;
+
+	for (; start_addr < end_addr; start_addr += CONFIG_DCACHE_LINE_SIZE)
+		__asm__ volatile("mcr p15, #0, %0, c7, c5, #1" : : "r"(start_addr));
+	__ISB();
+	return 0;
+}
+
+/*
+ * operation for all instruction cache
+ * ops:  K_CACHE_INVD: invalidate
+ */
+int arch_icache_all(int op)
+{
+	if (op != K_CACHE_WB_INVD)
+		return -ENOTSUP;
+
+	__asm__ volatile("mcr p15, #0, %0, c7, c5, #0" : : "r"(0));
+	__ISB();
 	return 0;
 }


### PR DESCRIPTION
Provides cache management functions which do not depend on cmsis hal modules.

Signed-off-by: Théophile Ranquet <theophile.ranquet@gmail.com>

This happened quite by mistake as I was working on a 3.1 codebase where this was somehow not already present (I am not sure why?).

These work, and seem to have the added benefit of not depending on an external module.

I am putting this out here in case there is any interest, but I have not determined the preexisting implementation to be lacking in any way.