### PR TITLE
drivers: uart_nrfx_uarte: Fix call to HW_RX_COUNTING_ENABLED()

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -662,9 +662,7 @@ static int uarte_nrfx_rx_counting_init(const struct device *dev)
 			nrfx_timer_enable(&cfg->timer);
 			nrfx_timer_clear(&cfg->timer);
 		}
-	}
 
-	if (HW_RX_COUNTING_ENABLED(data)) {
 		ret = gppi_channel_alloc(&data->async->rx_cnt.ppi);
 		if (ret != NRFX_SUCCESS) {
 			LOG_ERR("Failed to allocate PPI Channel, "
@@ -672,9 +670,7 @@ static int uarte_nrfx_rx_counting_init(const struct device *dev)
 			data->async->hw_rx_counting = false;
 			nrfx_timer_uninit(&cfg->timer);
 		}
-	}
 
-	if (HW_RX_COUNTING_ENABLED(data)) {
 #if CONFIG_HAS_HW_NRF_PPI
 		ret = nrfx_ppi_channel_assign(
 			data->async->rx_cnt.ppi,

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1956,10 +1956,11 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 		nrf_uarte_enable(uarte);
 
 #ifdef UARTE_ANY_ASYNC
-		if (HW_RX_COUNTING_ENABLED(data)) {
-			nrfx_timer_enable(&cfg->timer);
-		}
 		if (data->async) {
+			if (HW_RX_COUNTING_ENABLED(data)) {
+				nrfx_timer_enable(&cfg->timer);
+			}
+
 			return 0;
 		}
 #endif


### PR DESCRIPTION
Since the macro references `data->async->hw_rx_counting`, it cannot
be called when `data->async` is NULL, and this could happen when the
PM_DEVICE_ACTION_RESUME action was requested for an instance that uses
the interrupt-driven API while for another instance that uses the
asynchronous API the hardware counting of bytes was configured.
Prevent this by calling the macro from a proper `if` block.

On the occasion, remove a few redundant calls to `HW_RX_COUNTING_ENABLED()` in another place.