### PR TITLE
dts: arm: st: add STM32F302xC device tree

### DIFF
--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -73,6 +73,22 @@
 			};
 		};
 
+		timers4: timers@40000800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000004>;
+			interrupts = <30 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+		};
+
 		adc1: adc@50000000 {
 			compatible = "st,stm32-adc";
 			reg = <0x50000000 0x400>;

--- a/dts/arm/st/f3/stm32f302Xc.dtsi
+++ b/dts/arm/st/f3/stm32f302Xc.dtsi
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 Seco Spa
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/f3/stm32f302.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(40)>;
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(256)>;
+			};
+		};
+
+		dma2: dma@40020400 {
+			compatible = "st,stm32-dma-v2bis";
+			#dma-cells = <2>;
+			reg = <0x40020400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x2>;
+			interrupts = <56 0 57 0 58 0 59 0 60 0>;
+			status = "disabled";
+		};
+
+		uart5: serial@40005000 {
+			compatible = "st,stm32-uart";
+			reg = <0x40005000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00100000>;
+			interrupts = <53 0>;
+			status = "disabled";
+		};
+
+		pinctrl: pin-controller@48000000 {
+			gpioe: gpio@48001000 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x48001000 0x400>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00200000>;
+			};
+		};
+	};
+};
+
+/delete-node/ &i2c3;

--- a/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f302xc
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.defconfig.stm32f302xc
@@ -1,0 +1,14 @@
+# ST Microelectronics STM32F302XC MCU
+
+# Copyright (c) 2022, SECO Spa
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32F302XC
+
+config SOC
+	default "stm32f302xc"
+
+config NUM_IRQS
+	default 82
+
+endif # SOC_STM32F302XC

--- a/soc/arm/st_stm32/stm32f3/Kconfig.soc
+++ b/soc/arm/st_stm32/stm32f3/Kconfig.soc
@@ -10,6 +10,10 @@ choice
 config SOC_STM32F302X8
 	bool "STM32F302X8"
 
+config SOC_STM32F302XC
+	bool "STM32F302XC"
+	select CPU_HAS_ARM_MPU
+
 config SOC_STM32F303X8
 	bool "STM32F303X8"
 


### PR DESCRIPTION
Add ST Micro STM32F302xC family of microcontrollers.

Signed-off-by: Ettore Chimenti <ek5.chimenti@gmail.com>