### PR TITLE
drivers: wifi: eswifi: Offload sockets accessing invalid net_context

### DIFF
--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -221,7 +221,6 @@ int __eswifi_off_start_client(struct eswifi_dev *eswifi,
 		LOG_ERR("Unable to start TCP/UDP client");
 		return -EIO;
 	}
-	net_context_set_state(socket->context, NET_CONTEXT_CONNECTED);
 
 	return 0;
 }


### PR DESCRIPTION
This change fixes a regression from commit 1cbc0acd7e5f5d8c56bc66a475a76358db12a1b6.

Socket offload uses a dummy socket context, and setting the socket state in this dummy context is invalid.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/52317

Signed-off-by: Brian Dunlay <brian@nubix.io>