### PR TITLE
xtensa: remove xtensa asm unused header

### DIFF
--- a/arch/xtensa/core/xtensa-asm2-util.S
+++ b/arch/xtensa/core/xtensa-asm2-util.S
@@ -5,7 +5,6 @@
  */
 #include <xtensa-asm2-s.h>
 #include <offsets.h>
-#include <zephyr/toolchain.h>
 #include <zsr.h>
 
 /*


### PR DESCRIPTION
1. this header is no use for asm

2. if use xclib(enable `CONFIG_EXTERNAL_LIBC`), this header will include xclib stdbool, and expand to typedef.

see this path: `zephyr/toolchain.h` ----> `zephyr/toolchain/xcc.h` ---> `stdbool.h`. this `stdbool.h` is belong to xclib. 

```
// xclib stdbool.h

#ifndef _STDBOOL
#define _STDBOOL
#ifndef _YVALS
  #include <yvals.h>
#endif /* _YVALS */

```
`stdbool.h` include `yvals.h`, this header use so much `typedef`
```
typedef _MACH_I32 _Int32t;
typedef unsigned _MACH_I32 _Uint32t;
```
and we know asm do not support `typedef`, so this will make build errors.

Signed-off-by: honglin leng <a909204013@gmail.com>