### PR TITLE
ci: doc-build: remove unnecessary libclang dependency and update Ubuntu image.

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -35,7 +35,7 @@ env:
 jobs:
   doc-build-html:
     name: "Documentation Build (HTML)"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     concurrency:
       group: doc-build-html-${{ github.ref }}

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -48,7 +48,7 @@ jobs:
     - name: install-pkgs
       run: |
         sudo apt-get update
-        sudo apt-get install -y ninja-build graphviz libclang1-9 libclang-cpp9
+        sudo apt-get install -y ninja-build graphviz
         wget --no-verbose https://downloads.sourceforge.net/project/doxygen/rel-${DOXYGEN_VERSION}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
         tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
         echo "${PWD}/doxygen-${DOXYGEN_VERSION}/bin" >> $GITHUB_PATH

--- a/.github/workflows/doc-publish-pr.yml
+++ b/.github/workflows/doc-publish-pr.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   doc-publish:
     name: Publish Documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: |
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   doc-publish:
     name: Publish Documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: |
       github.event.workflow_run.event != 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&


### PR DESCRIPTION
Doxygen 1.9.4 no longer needs libclang. Also updated to ubuntu-22.04.