### PR TITLE
<RFC> ARC: MWDT: rework GNU helper tools usage

### DIFF
--- a/cmake/bintools/arcmwdt/target.cmake
+++ b/cmake/bintools/arcmwdt/target.cmake
@@ -22,17 +22,18 @@ find_program(CMAKE_GDB     ${CROSS_COMPILE}mdb     PATHS ${TOOLCHAIN_HOME} NO_DE
 
 # MWDT binutils don't support required features like section renaming, so we
 # temporarily had to use GNU objcopy instead
-find_program(CMAKE_OBJCOPY arc-elf32-objcopy)
-if (NOT CMAKE_OBJCOPY)
-  find_program(CMAKE_OBJCOPY arc-linux-objcopy)
+if(CONFIG_ISA_ARCV3)
+  set(ARCMWDT_Z_HELPER_TARGET       arc64-zephyr-elf)
+else()
+  set(ARCMWDT_Z_HELPER_TARGET         arc-zephyr-elf)
 endif()
 
-if (NOT CMAKE_OBJCOPY)
-  find_program(CMAKE_OBJCOPY objcopy)
-endif()
+set(ARCMWDT_Z_HELPER_PATH ${ZEPHYR_SDK_INSTALL_DIR}/${ARCMWDT_Z_HELPER_TARGET}/bin)
 
+find_program(CMAKE_OBJCOPY ${ARCMWDT_Z_HELPER_TARGET}-objcopy PATHS ${ARCMWDT_Z_HELPER_PATH})
 if(NOT CMAKE_OBJCOPY)
-  message(FATAL_ERROR "Zephyr unable to find any GNU objcopy (ARC or host one)")
+  message(FATAL_ERROR "Zephyr unable to find any GNU objcopy from Zephyr SDK. Please check that \
+  you have specified ZEPHYR_SDK_INSTALL_DIR correctly. Current value: '${ZEPHYR_SDK_INSTALL_DIR}'")
 endif()
 
 include(${ZEPHYR_BASE}/cmake/bintools/arcmwdt/target_bintools.cmake)

--- a/cmake/compiler/arcmwdt/generic.cmake
+++ b/cmake/compiler/arcmwdt/generic.cmake
@@ -4,18 +4,20 @@
 
 # MWDT compiler (CCAC) can't be used for preprocessing the DTS sources as it has
 # weird restrictions about file extensions. Synopsys Jira issue: P10019563-38578
-# Let's temporarily use GNU compiler instead.
-find_program(CMAKE_DTS_PREPROCESSOR arc-elf32-gcc)
-if (NOT CMAKE_DTS_PREPROCESSOR)
-  find_program(CMAKE_DTS_PREPROCESSOR arc-linux-gcc)
+# Let's temporarily use GNU compiler instead. The preferred comiler is from Zephyr SDK
+if(CONFIG_ISA_ARCV3)
+  set(ARCMWDT_Z_HELPER_TARGET       arc64-zephyr-elf)
+else()
+  set(ARCMWDT_Z_HELPER_TARGET         arc-zephyr-elf)
 endif()
 
-if (NOT CMAKE_DTS_PREPROCESSOR)
-  find_program(CMAKE_DTS_PREPROCESSOR gcc)
-endif()
+set(ARCMWDT_Z_HELPER_PATH ${ZEPHYR_SDK_INSTALL_DIR}/${ARCMWDT_Z_HELPER_TARGET}/bin)
 
+find_program(CMAKE_DTS_PREPROCESSOR ${ARCMWDT_Z_HELPER_TARGET}-gcc PATHS ${ARCMWDT_Z_HELPER_PATH})
 if(NOT CMAKE_DTS_PREPROCESSOR)
-  message(FATAL_ERROR "Zephyr was unable to find any GNU compiler (ARC or host one) for DTS preprocessing")
+  message(FATAL_ERROR "Zephyr was unable to find GNU compiler from Zephyr SDK for DTS \
+  preprocessing. Please check that you have specified ZEPHYR_SDK_INSTALL_DIR correctly. \
+  Current value: '${ZEPHYR_SDK_INSTALL_DIR}'")
 endif()
 
 find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}ccac PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)


### PR DESCRIPTION
As of today in case of Zephyr we still use few tools from GNU toolchain even when building with MWDT toolchain - GNU compiler for DTS preprocessing and objcopy for section renaming.

Currently we were trying to find any GNU compiler & objcopy which start to cause compatibility issues for new targets - line not every objcopy knows new ARC targets.

Let's use ARC GNU tools from Zephyr SDK as we still usually require it when building with MWDT for other tools like DTC (device tree compiler)