### PR TITLE
drivers: ivshmem: Remove unnecessary BDF lookup code

### DIFF
--- a/drivers/virtualization/virt_ivshmem.c
+++ b/drivers/virtualization/virt_ivshmem.c
@@ -225,27 +225,13 @@ static const struct ivshmem_driver_api ivshmem_api = {
 static int ivshmem_init(const struct device *dev)
 {
 	struct ivshmem *data = dev->data;
-	static bool bdf_lookup_done;
 
-	if ((data->pcie->bdf == PCIE_BDF_NONE) && bdf_lookup_done) {
-		LOG_ERR("One instance of ivshmem with pcie_bdf_lookup() already initialized.\n"
-			"Using more than one with PCIE_BDF_NONE parameter might conflict\n"
-			"with already initialized instances.");
+	if (data->pcie->bdf == PCIE_BDF_NONE) {
+		LOG_WRN("ivshmem device not found");
 		return -ENOTSUP;
 	}
-	if ((data->pcie->bdf == PCIE_BDF_NONE) && !bdf_lookup_done) {
-		if (data->pcie->id == PCIE_ID_NONE) {
-			data->pcie->id = PCIE_ID(IVSHMEM_VENDOR_ID,
-						 IVSHMEM_DEVICE_ID);
-			data->pcie->bdf = pcie_bdf_lookup(data->pcie->id);
-		}
-		if (data->pcie->bdf == PCIE_BDF_NONE) {
-			LOG_WRN("ivshmem device not found");
-			return -ENOTSUP;
-		}
-	}
+
 	LOG_DBG("ivshmem found at bdf 0x%x", data->pcie->bdf);
-	bdf_lookup_done = true;
 
 	if (!ivshmem_configure(dev)) {
 		return -EIO;

--- a/drivers/virtualization/virt_ivshmem.h
+++ b/drivers/virtualization/virt_ivshmem.h
@@ -10,9 +10,6 @@
 #include <zephyr/drivers/pcie/pcie.h>
 #include <zephyr/drivers/pcie/msi.h>
 
-#define IVSHMEM_VENDOR_ID		0x1AF4
-#define IVSHMEM_DEVICE_ID		0x1110
-
 #define IVSHMEM_PCIE_REG_BAR_IDX	0
 #define IVSHMEM_PCIE_SHMEM_BAR_IDX	2
 


### PR DESCRIPTION
There was a bunch of BDF lookup code in the ivshmem driver originating from issues with not being able to have multiple PCIE_BDF_NONE entries in DTS. Now that devices are always looked up based on VID/DID this should not be an issue, and hence the additional code is not needed.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>