### PR TITLE
Do not unlock control register at the end of initialization in STM32 flash driver

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -396,7 +396,7 @@ static int stm32_flash_init(const struct device *dev)
 	}
 #endif
 
-	return flash_stm32_write_protection(dev, false);
+	return 0;
 }
 
 DEVICE_DT_INST_DEFINE(0, stm32_flash_init, NULL,


### PR DESCRIPTION
Unlocking CR at the end of initialization was added in commit a9183cd5180eccbfecb263de950213db0ad4359f. It was probably copied from previous flash driver implementation.

Unlocking and locking CR in write and erase functions was added in commit 6e4cdb0c9930e10395e4a476eb86e656389ec74c. Since we always unlock the register before writing or erasing, and lock it after the operation is finished, there is no need to unlock it after initialization.

Best regards,
Patryk