### PR TITLE
pcie: Implement a more refined device scanning procedure

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -116,6 +116,9 @@ Deprecated in this release
 
   :kconfig:option:`CONFIG_SETTINGS_FS_MAX_LINES` in favor of :kconfig:option:`CONFIG_SETTINGS_FILE_MAX_LINES`
 
+* PCIe APIs :c:func:`pcie_probe` and :c:func:`pcie_bdf_lookup` have been
+  deprecated in favor of a centralized scan of available PCIe devices.
+
 Stable API changes in this release
 ==================================
 

--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -29,7 +29,7 @@ bool pcie_probe(pcie_bdf_t bdf, pcie_id_t id)
 
 	data = pcie_conf_read(bdf, PCIE_CONF_ID);
 
-	if (data == PCIE_ID_NONE) {
+	if (!PCIE_ID_IS_VALID(data)) {
 		return false;
 	}
 
@@ -356,7 +356,7 @@ pcie_bdf_t pcie_bdf_lookup(pcie_id_t id)
 				uint32_t data;
 
 				data = pcie_conf_read(bdf, PCIE_CONF_ID);
-				if (data == PCIE_ID_NONE) {
+				if (!PCIE_ID_IS_VALID(data)) {
 					continue;
 				}
 
@@ -386,7 +386,7 @@ static int pcie_init(const struct device *dev)
 				uint32_t id;
 
 				id = pcie_conf_read(bdf, PCIE_CONF_ID);
-				if (id == PCIE_ID_NONE) {
+				if (!PCIE_ID_IS_VALID(id)) {
 					continue;
 				}
 

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -147,7 +147,7 @@ static void show(const struct shell *sh, pcie_bdf_t bdf, bool dump)
 
 	data = pcie_conf_read(bdf, PCIE_CONF_ID);
 
-	if (data == PCIE_ID_NONE) {
+	if (!PCIE_ID_IS_VALID(data)) {
 		return;
 	}
 

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -186,18 +186,37 @@ static void show(const struct shell *sh, pcie_bdf_t bdf, bool dump)
 	}
 }
 
+struct scan_cb_data {
+	const struct shell *sh;
+	bool dump;
+};
+
+static bool scan_cb(pcie_bdf_t bdf, pcie_id_t id, void *cb_data)
+{
+	struct scan_cb_data *data = cb_data;
+
+	show(data->sh, bdf, data->dump);
+
+	return true;
+}
+
 static int cmd_pcie_ls(const struct shell *sh, size_t argc, char **argv)
 {
 	pcie_bdf_t bdf = PCIE_BDF_NONE;
-	bool dump = false;
-	int bus;
-	int dev;
-	int func;
+	struct scan_cb_data data = {
+		.sh = sh,
+		.dump = false,
+	};
+	struct pcie_scan_opt scan_opt = {
+		.cb = scan_cb,
+		.cb_data = &data,
+		.flags = (PCIE_SCAN_RECURSIVE | PCIE_SCAN_CB_ALL),
+	};
 
 	for (int i = 1; i < argc; i++) {
 		/* Check dump argument */
 		if (strncmp(argv[i], "dump", 4) == 0) {
-			dump = true;
+			data.dump = true;
 			continue;
 		}
 
@@ -214,17 +233,11 @@ static int cmd_pcie_ls(const struct shell *sh, size_t argc, char **argv)
 
 	/* Show only specified device */
 	if (bdf != PCIE_BDF_NONE) {
-		show(sh, bdf, dump);
+		show(sh, bdf, data.dump);
 		return 0;
 	}
 
-	for (bus = 0; bus <= PCIE_MAX_BUS; ++bus) {
-		for (dev = 0; dev <= PCIE_MAX_DEV; ++dev) {
-			for (func = 0; func <= PCIE_MAX_FUNC; ++func) {
-				show(sh, PCIE_BDF(bus, dev, func), dump);
-			}
-		}
-	}
+	pcie_scan(&scan_opt);
 
 	return 0;
 }

--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -11,6 +11,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/dt-bindings/pcie/pcie.h>
 #include <zephyr/types.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -151,10 +152,13 @@ struct pcie_bar {
  * This function is used to look up the BDF for a device given its
  * vendor and device ID.
  *
+ * @deprecated
+ * @see DEVICE_PCIE_DECLARE
+ *
  * @param id PCI(e) vendor & device ID encoded using PCIE_ID()
  * @return The BDF for the device, or PCIE_BDF_NONE if it was not found
  */
-extern pcie_bdf_t pcie_bdf_lookup(pcie_id_t id);
+__deprecated extern pcie_bdf_t pcie_bdf_lookup(pcie_id_t id);
 
 /**
  * @brief Read a 32-bit word from an endpoint's configuration space.
@@ -222,11 +226,14 @@ int pcie_scan(const struct pcie_scan_opt *opt);
 /**
  * @brief Probe for the presence of a PCI(e) endpoint.
  *
+ * @deprecated
+ * @see DEVICE_PCIE_DECLARE
+ *
  * @param bdf the endpoint to probe
  * @param id the endpoint ID to expect, or PCIE_ID_NONE for "any device"
  * @return true if the device is present, false otherwise
  */
-extern bool pcie_probe(pcie_bdf_t bdf, pcie_id_t id);
+__deprecated extern bool pcie_probe(pcie_bdf_t bdf, pcie_id_t id);
 
 /**
  * @brief Get the MBAR at a specific BAR index

--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -37,6 +37,16 @@ typedef uint32_t pcie_bdf_t;
  */
 typedef uint32_t pcie_id_t;
 
+/* Helper macro to exclude invalid PCIe identifiers. We should really only
+ * need to look for PCIE_ID_NONE, but because of some broken PCI host controllers
+ * we have try cases where both VID & DID are zero or just one of them is
+ * zero (0x0000) and the other is all ones (0xFFFF).
+ */
+#define PCIE_ID_IS_VALID(id) ((id != PCIE_ID_NONE) && \
+			      (id != PCIE_ID(0x0000, 0x0000)) && \
+			      (id != PCIE_ID(0xFFFF, 0x0000)) && \
+			      (id != PCIE_ID(0x0000, 0xFFFF)))
+
 struct pcie_dev {
 	pcie_bdf_t bdf;
 	pcie_id_t  id;


### PR DESCRIPTION
This set of patches implements and takes into use a more refined scanning procedure than the brute-force approach, where the code has been scanning for all possible combinations of BDF (Bus, Device, Function) values. We can do much better than the brute-force approach by doing more careful inspection of the available endpoints this includes things like:

- Check if host controller 0 (BDF(0, 0, 0)) is a multifunction device. If so, the function numbers are all potential host controllers with corresponding bus numbers
- Look for PCI-to-PCI bridge endpoints, and inspect the "secondary bus number" register to get the bus number of bus behind this bridge.
- Only iterate all possible functions of a device if the multifunction bit is set in the endpoint's header type register.

This set of patches introduces a new `pcie_scan()` API which implements the approach procedure, with a flexible set of options that can be used to control the scanning flow, depending on what kind of scan is needed.