### PR TITLE
stm32L4s5 disco kit has ospi for quad Nor-flash access 

### DIFF
--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -18,6 +18,8 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,flash-controller = &mx25r6435f;
 	};
 
 	leds {
@@ -45,6 +47,7 @@
 		sw0 = &user_button;
 		watchdog0 = &iwdg;
 		accel0 = &lsm6dsl;
+		spi-flash0 = &mx25r6435f;
 	};
 };
 
@@ -227,5 +230,48 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &rng {
+	status = "okay";
+};
+
+&octospi1 {
+	pinctrl-0 = <&octospim_p1_clk_pe10 &octospim_p1_ncs_pe11
+		     &octospim_p1_io0_pe12 &octospim_p1_io1_pe13
+		     &octospim_p1_io2_pe14 &octospim_p1_io3_pe15>;
+	pinctrl-names = "default";
+
+	dmas = <&dma1 0 40 0x480>; /* request 40 for OCTOSPI1 */
+	dma-names = "tx_rx";
+
+	status = "okay";
+
+	mx25r6435f: ospi-nor-flash@0 {
+		compatible = "st,stm32-ospi-nor";
+		reg = <0>;
+		ospi-max-frequency = <DT_FREQ_M(26)>; /* for Voltage Range 2 */
+		size = <DT_SIZE_M(8)>; /* 64 Megabits = 8 Megabytes */
+		spi-bus-width = <OSPI_QUAD_MODE>;
+		data-rate = <OSPI_STR_TRANSFER>;
+		writeoc="PP_1_4_4";
+
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			store_partition: partition@000 {
+				label = "store";
+				reg = <0x00000000 DT_SIZE_M(8)>;
+			};
+		};
+	};
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dmamux1 {
 	status = "okay";
 };

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -6,6 +6,9 @@
 
 #include <mem.h>
 #include <st/l4/stm32l4.dtsi>
+#include <zephyr/dt-bindings/flash_controller/ospi.h>
+
+/delete-node/ &quadspi;
 
 / {
 	sram0: memory@20000000 {
@@ -309,6 +312,34 @@
 		adc1: adc@50040000 {
 			has-temp-channel;
 			has-vref-channel;
+		};
+
+		octospi1: octospi@a0001000 {
+			compatible = "st,stm32-ospi";
+			reg = <0xa0001000 0x400>;
+			interrupts = <71 0>;
+			clock-names = "ospix", "ospi-ker", "ospi-mgr";
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000100>,
+				<&rcc STM32_SRC_SYSCLK OSPI_SEL(0)>,
+				<&rcc STM32_CLOCK_BUS_AHB2 0x00100000>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		octospi2: octospi@a0001400 {
+			compatible = "st,stm32-ospi";
+			reg = <0xa0001400 0x400>;
+			interrupts = <76 0>;
+			clock-names = "ospix", "ospi-ker", "ospi-mgr";
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000200>,
+				<&rcc STM32_SRC_SYSCLK OSPI_SEL(0)>,
+				<&rcc STM32_CLOCK_BUS_AHB2 0x00100000>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
 		};
 	};
 

--- a/samples/drivers/jesd216/boards/b_l4s5i_iot01a.conf
+++ b/samples/drivers/jesd216/boards/b_l4s5i_iot01a.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2022 STMicroelectronics
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_FLASH_STM32_OSPI=y
+CONFIG_SPI_NOR_SFDP_RUNTIME=y
+CONFIG_SPI_NOR=n


### PR DESCRIPTION
Add the support of the OCTOSPI peripheral to the stm32L4 plus serie
The stm32L4S5 serie has two octospi peripherals with in octospiM to multiplex IO pins.

See the stm32L4S5  refman [RM0432](https://www.st.com/content/ccc/resource/technical/document/reference_manual/group0/81/c8/d7/84/ba/20/48/5f/DM00310109/files/DM00310109.pdf/jcr:content/translations/en.DM00310109.pdf)  quad NOR-flash

The stm32l4s5r disco_kit b_l4s5i_iot01a  has a [MX25R6435F](https://www.mxic.com.tw/Lists/Datasheet/Attachments/8868/MX25R6435F,%20Wide%20Range,%2064Mb,%20v1.6.pdf) quad NOR-flash.
On the b_l4s5i_iot01a  board, the NOR flash is connected on 4 SPI IO lines and uses the QUAD-SPI mode to transfer data over the octospi1 peripheral.

The DMA (through DMAMUX) is enabled to operate transfer on the octoSPI bus.

Requires https://github.com/zephyrproject-rtos/zephyr/pull/47962  for jedec SDFP support

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/52276

Signed-off-by: Francois Ramu <francois.ramu@st.com>