### PR TITLE
sys: util: add intermediate cast to void* in CONTAINER_OF

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -208,7 +208,7 @@ extern "C" {
  * @return a pointer to the structure that contains @p ptr
  */
 #define CONTAINER_OF(ptr, type, field) \
-	((type *)(((char *)(ptr)) - offsetof(type, field)))
+	((type *)(void*)(((char *)(ptr)) - offsetof(type, field)))
 
 /**
  * @brief Value of @p x rounded up to the next multiple of @p align,

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -208,7 +208,7 @@ extern "C" {
  * @return a pointer to the structure that contains @p ptr
  */
 #define CONTAINER_OF(ptr, type, field) \
-	((type *)(void*)(((char *)(ptr)) - offsetof(type, field)))
+	((type *)(void *)(((char *)(ptr)) - offsetof(type, field)))
 
 /**
  * @brief Value of @p x rounded up to the next multiple of @p align,


### PR DESCRIPTION
This is caught by PC-Lint and should probably be here.

Does anyone see any issues with this change?

Closes #42082 

Signed-off-by: Martin Schröder <info@swedishembedded.com>