### PR TITLE
drivers: lpuart: enable rs485 mode

### DIFF
--- a/dts/bindings/serial/nxp,kinetis-lpuart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpuart.yaml
@@ -17,3 +17,16 @@ properties:
         Enable loopback mode on LPUART peripheral. When present, RX pin is
         disconnected, and transmitter output is internally connected to
         the receiver input.
+
+    nxp,rs485-mode:
+      type: boolean
+      required: false
+      description: |
+        Set to enable RTS signal, which can be used to enable the driver
+        of an external RS-485 transceiver. Note hw-flow-control should be
+        set to false.
+
+    nxp,rs485-de-active-low:
+      type: boolean
+      required: false
+      description: RTS polarity at RS485 mode.

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -108,6 +108,7 @@ enum uart_config_flow_control {
 	UART_CFG_FLOW_CTRL_NONE,
 	UART_CFG_FLOW_CTRL_RTS_CTS,
 	UART_CFG_FLOW_CTRL_DTR_DSR,
+	UART_CFG_FLOW_CTRL_RS485,
 };
 
 /**


### PR DESCRIPTION
NXP LPUART IP supports rs485 mode when transceiver driver enable using RTS. Allow setting rs485 mode up via the `nxp,rs485-mode` dts property. `nxp,rs485-de-active-low` dts property can be used for set RTS polarity.

I have tested this feature on [NXP MIMXRT1064-EVK](https://docs.zephyrproject.org/latest/boards/arm/mimxrt1064_evk/doc/index.html). I run [echo-bot](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/drivers/uart/echo_bot), which have additional file `boards/mimxrt1064_evk.overlay`:
```
/ {
  chosen {
    zephyr,shell-uart = &lpuart3;
  };
};

&csi {
  /* Some pins are shared between CSI and LPUART3 */
  status = "disabled";
};

&pinctrl {
  pinmux_lpuart3_rs485: pinmux_lpuart3_rs485 {
    group0 {
      pinmux = < &iomuxc_gpio_ad_b1_06_lpuart3_tx >,
               < &iomuxc_gpio_ad_b1_07_lpuart3_rx >,
               < &iomuxc_gpio_ad_b1_05_lpuart3_rts_b >;
      drive-strength = "r0-6";
      slew-rate = "slow";
      nxp,speed = "100-mhz";
    };
  };
};

&lpuart3 {
  status = "okay";
  pinctrl-0 = < &pinmux_lpuart3_rs485 >;
  nxp,rs485-mode;
};
```
In first i checked this overlay without `nxp,rs485-mode` (connected MCU to USB-UART converter), then i used RS485. 
Transceiver driver connect according table:

| Signal | Pin                     |
| -------|-------------------|
| TXD    | GPIO_AD_B1_06 |
| RXD    | GPIO_AD_B1_07 |
| DE      | GPIO_AD_B1_05 |

`nxp,rs485-de-active-low` working was tested additional using logic analyzer.

Original sample `echo-bot` (without DTS overlay) was tested also.

I checked this patch using `twister` with option `--platform mimxrt1064_evk`.

Also i use this improvement on my proprietary board at last six month. My proprietary board have two UART: one use `nxp,rs485-mode`, other no.