### PR TITLE
gitignore: ignore files generated by check_compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,13 @@ TAGS
 tags
 
 .idea
+
+# from check_compliance.py
+Gitlint.txt
+checkpatch.txt
+Kconfig.txt
+KconfigBasic.txt
+Codeowners.txt
+Nits.txt
+pylint.txt
+Identity.txt


### PR DESCRIPTION
ignore many files generated by the check_compliance script.

Fixes #51611

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
