### PR TITLE
samples: drivers: flash_shell: disambiguate flash shell app

### DIFF
--- a/samples/drivers/flash_shell/README.rst
+++ b/samples/drivers/flash_shell/README.rst
@@ -25,19 +25,19 @@ Sample Output
 
 .. code-block:: console
 
-    uart:~$ flash page_count
+    uart:~$ flash_sample page_count
     Flash device contains 1024 pages.
-    uart:~$ flash page_erase 1023
+    uart:~$ flash_sample page_erase 1023
     Erasing page 1023 (start offset 0xffc00, size 0x400)
-    uart:~$ flash page_write 1023 8 17 19 28 39
+    uart:~$ flash_sample page_write 1023 8 17 19 28 39
     Reading back written bytes:
     11 13 1c 27
-    uart:~$ flash page_write 1023 4 77 9 1 2
+    uart:~$ flash_sample page_write 1023 4 77 9 1 2
     Reading back written bytes:
     4d 09 01 02
-    uart:~$ flash page_read 1023 4 12
+    uart:~$ flash_sample page_read 1023 4 12
     4d 09 01 02 | 11 13 1c 27
     ff ff ff ff
-    uart:~$ flash page_read 1023 0 16
+    uart:~$ flash_sample page_read 1023 0 16
     ff ff ff ff | 4d 09 01 02
     11 13 1c 27 | ff ff ff ff

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -763,4 +763,4 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_flash,
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 
-SHELL_CMD_REGISTER(flash, &sub_flash, "Flash related commands.", NULL);
+SHELL_CMD_REGISTER(flash_sample, &sub_flash, "Flash related commands.", NULL);


### PR DESCRIPTION
Both `drivers/flash/flash_shell.c` and `samples/drivers/flash_shell/src/main.c` provide a flash shell utility called `flash`.

Rename the latter to disambiguate.