### PR TITLE
Test pushing more than 1 byte in uart_fifo_fill_call()

### DIFF
--- a/drivers/serial/uart_xmc4xxx.c
+++ b/drivers/serial/uart_xmc4xxx.c
@@ -138,7 +138,7 @@ static int uart_xmc4xxx_fifo_fill(const struct device *dev, const uint8_t *tx_da
 	for (i = 0; i < len; i++) {
 		bool fifo_full;
 
-		XMC_UART_CH_Transmit(config->uart, tx_data[0]);
+		XMC_UART_CH_Transmit(config->uart, tx_data[i]);
 		if (config->fifo_tx_size == 0) {
 			return 1;
 		}


### PR DESCRIPTION
Currently the test only pushes 1 byte in each call to uart_fifo_fill(). This doesn't test cases where the driver can accept more than 1 byte in the fifo.
Instead, try to push all the bytes in the uart_fifo_fill() call. Internally the driver may only accept 1 byte, in which case the test will be equivalent as before the patch.
