### PR TITLE
ci: twister: checkout tree when merging results

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -276,7 +276,7 @@ jobs:
 
     steps:
       # Needed for opensearch and upload script
-      - if: github.event_name == 'push'
+      - if: github.event_name == 'push' || github.event_name == 'schedule'
         name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Needed for the script used to upload results to opensearch.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
