### PR TITLE
shell: Add shell_read()

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -658,8 +658,8 @@ struct shell_transport_api {
 	/**
 	 * @brief Function for reading data from the transport interface.
 	 *
-	 * @param[in]  p_transport  Pointer to the transfer instance.
-	 * @param[in]  p_data       Pointer to the destination buffer.
+	 * @param[in]  transport    Pointer to the transfer instance.
+	 * @param[in]  data         Pointer to the destination buffer.
 	 * @param[in]  length       Destination buffer length.
 	 * @param[out] cnt          Pointer to the received bytes counter.
 	 *

--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -1226,6 +1226,27 @@ int shell_obscure_set(const struct shell *shell, bool obscure);
 int shell_mode_delete_set(const struct shell *shell, bool val);
 
 /**
+ * @brief Read shell input data. Can only be called from shell command context!
+ *
+ * @param[in]  shell    Pointer to the shell instance to read data for.
+ * @param[in]  data     Pointer to the destination buffer.
+ * @param[in]  length   Destination buffer length.
+ * @param[in]  timeout  Amount of time to wait for the data, or one of the
+ *                      special values K_NO_WAIT and K_FOREVER.
+ * @param[out] cnt      Pointer to the received bytes counter.
+ *
+ * @retval -EACCES Shell input is bypassed.
+ * @retval -EBUSY Shell is not in command context.
+ * @retval -EAGAIN Waiting period timed out.
+ * @retval -EINTR Waiting has been interrupted.
+ * @retval -ENOMEM Thread resource pool insufficient memory (user mode only)
+ * @retval -EIO Reading the transport failed.
+ */
+int shell_read(const struct shell *shell,
+		void *data, size_t length,
+		k_timeout_t timeout,
+		size_t *cnt);
+/**
  * @}
  */
 

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -218,7 +218,7 @@ static int cmd_backends(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-static int cmd_bacskpace_mode_backspace(const struct shell *shell, size_t argc,
+static int cmd_backspace_mode_backspace(const struct shell *shell, size_t argc,
 					char **argv)
 {
 	ARG_UNUSED(argc);
@@ -229,7 +229,7 @@ static int cmd_bacskpace_mode_backspace(const struct shell *shell, size_t argc,
 	return 0;
 }
 
-static int cmd_bacskpace_mode_delete(const struct shell *shell, size_t argc,
+static int cmd_backspace_mode_delete(const struct shell *shell, size_t argc,
 				      char **argv)
 {
 	ARG_UNUSED(argc);
@@ -431,9 +431,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_shell_stats,
 
 SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_backspace_mode,
 	SHELL_CMD_ARG(backspace, NULL, SHELL_HELP_BACKSPACE_MODE_BACKSPACE,
-			cmd_bacskpace_mode_backspace, 1, 0),
+			cmd_backspace_mode_backspace, 1, 0),
 	SHELL_CMD_ARG(delete, NULL, SHELL_HELP_BACKSPACE_MODE_DELETE,
-			cmd_bacskpace_mode_delete, 1, 0),
+			cmd_backspace_mode_delete, 1, 0),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
@jakub-uC, here's my untested stab at `shell_read()`.

If it works it would be suitable for basic interactive commands.

However, my problem is that I'm trying to implement interrupting a long-running command (an actuator running physical testing) with Ctrl-C from the shell, and that means I need to be able to wait both for shell input and for completion of my process. I tried to make it possible to run `shell_read()` in another thread, so it could signal an interruption to my process, and that would work in theory, but then `shell_read()` wouldn't be able to terminate together with the shell command (only on the next input, which may never come), since there's no way to explicitly cancel a poll.

And of course, I might be doing this completely wrong, misinterpreting the poll API, as well as other things :man_shrugging: :see_no_evil:

Would appreciate your comments and advice. Thanks!