### PR TITLE
usb: device: Disable all endpoints on stack disable

### DIFF
--- a/drivers/usb/device/usb_dc_native_posix.c
+++ b/drivers/usb/device/usb_dc_native_posix.c
@@ -298,8 +298,8 @@ int usb_dc_ep_disable(const uint8_t ep)
 {
 	LOG_DBG("ep %x", ep);
 
-	if (!usbip_ctrl.attached || !usbip_ep_is_valid(ep)) {
-		LOG_ERR("Not attached / Invalid endpoint: EP 0x%x", ep);
+	if (!usbip_ep_is_valid(ep)) {
+		LOG_ERR("Invalid endpoint: EP 0x%x", ep);
 		return -EINVAL;
 	}
 

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1578,10 +1578,6 @@ int usb_dc_ep_disable(const uint8_t ep)
 {
 	struct nrf_usbd_ep_ctx *ep_ctx;
 
-	if (!dev_attached() || !dev_ready()) {
-		return -ENODEV;
-	}
-
 	ep_ctx = endpoint_ctx(ep);
 	if (!ep_ctx) {
 		return -EINVAL;


### PR DESCRIPTION
Disable all enabled endpoints on stack disable to allow re-enabling USB device stack.

drivers: usb_dc_nrfx: Always allow endpoint disable. There is no point in allowing endpoint disable only when device is attached and ready. Remove the pointless check as it is actually harmful and prevents endpoints disable on USB stack disable.

Fixes: #52339

Cannot be merged before #51871