### PR TITLE
doc: mgmt: mcumgr: Clarify sha256 hash details in img_mgmt

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -45,6 +45,13 @@ Changes in this release
   Bluetooth subsystem, enable `CONFIG_BT_(module name)_LOG_LEVEL_DBG` instead of
   `CONFIG_BT_DEBUG_(module name)`.
 
+* MCUmgr img_mgmt now requires that a full sha256 hash to be used when
+  uploading an image to keep track of the progress, where the sha256 hash
+  is of the whole file being uploaded (different to the hash used when getting
+  image states). Use of a truncated hash or non-sha256 hash will still work
+  but will cause issues and failures in client software with future updates
+  to Zephyr/MCUmgr such as image verification.
+
 Removed APIs in this release
 ============================
 

--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -153,12 +153,10 @@ where:
     +-----------------------+---------------------------------------------------+
     | "hash"                | hash of an upload; this is used to identify       |
     |                       | an upload session, for example to allow mcumgr    |
-    |                       | library to continue broken session                |
-    |                       |                                                   |
-    |                       | .. note::                                         |
-    |                       |    By default mcumgr-cli uses here a few          |
-    |                       |    characters of sha256 of the first uploaded     |
-    |                       |    chunk.                                         |
+    |                       | library to continue broken session. This must be  |
+    |                       | a full sha256 of the whole image being uploaded,  |
+    |                       | and is optionally used for image verification     |
+    |                       | purposes.                                         |
     +-----------------------+---------------------------------------------------+
     | "bootable"            | true if image has bootable flag set;              |
     |                       | this field does not have to be present if false   |


### PR DESCRIPTION
Clarifies that a full SHA256 hash is required for the hash in img_mgmt.

Fixes #52412