### PR TITLE
board: *_x86: Allow pcie0 to be referenced 

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -45,7 +45,7 @@
 		zephyr,canbus = &can0;
 	};
 
-	pcie0 {
+	pcie0: pcie0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "intel,pcie";

--- a/dts/x86/intel/apollo_lake.dtsi
+++ b/dts/x86/intel/apollo_lake.dtsi
@@ -35,7 +35,7 @@
 		#interrupt-cells = <3>;
 	};
 
-	pcie0 {
+	pcie0: pcie0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "intel,pcie";

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -40,7 +40,7 @@
 		#interrupt-cells = <3>;
 	};
 
-	pcie0 {
+	pcie0: pcie0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "intel,pcie";

--- a/dts/x86/intel/raptor_lake.dtsi
+++ b/dts/x86/intel/raptor_lake.dtsi
@@ -34,7 +34,7 @@
 		#interrupt-cells = <3>;
 	};
 
-	pcie0 {
+	pcie0: pcie0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "intel,pcie";


### PR DESCRIPTION
Changing pcie0 to pcie0: pcie0 allows it to be referenced as &pcie0. I am not sure why this is required. Otherwise I get error:

...
parse error: undefined node label 'pcie0'
...