### PR TITLE
scripts: requirements: extras: add ZCBOR

### DIFF
--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -29,3 +29,6 @@ PyGithub
 
 # used to generate devicetree dependency graphs
 graphviz
+
+# used to generate CBOR encoders and decoders, e.g. lwm2m_senml_cbor.
+zcbor>=0.6.0


### PR DESCRIPTION
Add ZCBOR to the requirements-extras.txt and require at least version 0.6.0 which is the current version of the ZCBOR C library.

Signed-off-by: Veijo Pesonen <veijo.pesonen@nordicsemi.no>