### PR TITLE
compiler: arcmwdt: Correct inclusion of C++ system headers

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -117,9 +117,8 @@ set_compiler_property(PROPERTY cstd -std=)
 
 if (NOT CONFIG_ARCMWDT_LIBC)
   set_compiler_property(PROPERTY nostdinc -Hno_default_include -Hnoarcexlib)
+  set_compiler_property(APPEND PROPERTY nostdinc_include ${NOSTDINC})
 endif()
-
-set_compiler_property(APPEND PROPERTY nostdinc_include ${NOSTDINC})
 
 # C++ std options
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp98 "-std=c++98")
@@ -187,3 +186,6 @@ set_compiler_property(PROPERTY no_position_independent
 
 # Required ASM flags when using mwdt
 set_property(TARGET asm PROPERTY required "-Hasmcpp")
+
+# Pass includes directly into assembly build
+set_property(TARGET asm PROPERTY required "-I${TOOLCHAIN_HOME}/arc/inc")

--- a/cmake/compiler/arcmwdt/target.cmake
+++ b/cmake/compiler/arcmwdt/target.cmake
@@ -24,10 +24,11 @@ string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 
 set(NOSTDINC "")
 
-list(APPEND NOSTDINC ${TOOLCHAIN_HOME}/arc/inc)
-
-if(CONFIG_ARCMWDT_LIBC AND CONFIG_LIB_CPLUSPLUS)
-  list(APPEND NOSTDINC ${TOOLCHAIN_HOME}/arc/lib/src/c++/inc)
+# In case of using minimal libc, add path to target-specific headers,
+# which are omitted in "lib/libc/minimal/include" path
+# (stddef.h and stdarg.h).
+if(NOT CONFIG_ARCMWDT_LIBC)
+ list(APPEND NOSTDINC ${TOOLCHAIN_HOME}/arc/inc)
 endif()
 
 # For CMake to be able to test if a compiler flag is supported by the


### PR DESCRIPTION
In some cases, CCAC cannot process -isystem flag for C++ headers. Usually this happens when headers contain an "include_next" directive.
MWDT R&D team advised to remove the "isystem" flag from the building process to avoid build faults.

Signed-off-by: Nikolay Agishev <agishev@synopsys.com>