### PR TITLE
doc: extensions: kconfig: fix module prefix handling and allow to copy link to results

### DIFF
--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -354,8 +354,9 @@ def kconfig_build_resources(app: Sphinx) -> None:
 
                 filename = node.filename
                 for name, path in module_paths.items():
+                    path += "/"
                     if node.filename.startswith(path):
-                        filename = node.filename.replace(path, f"<module:{name}>")
+                        filename = node.filename.replace(path, f"<module:{name}>/")
                         break
 
                 db.append(

--- a/doc/_extensions/zephyr/kconfig/static/kconfig.css
+++ b/doc/_extensions/zephyr/kconfig/static/kconfig.css
@@ -5,14 +5,37 @@
 
 /* Kconfig search */
 
-#__kconfig-search input {
+#__kconfig-search .input-container {
     border-radius: 5px;
     border: 1px solid rgba(149, 157, 165, 0.2);
     box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px !important;
-    font-size: 18px;
     margin-bottom: 0.5rem;
-    padding: 0.75rem;
     width: 100%;
+    height: 60px;
+}
+
+#__kconfig-search .input-container input {
+    font-size: 18px;
+    width: 90%;
+    height: 100%;
+    padding: 0.75rem;
+    border: none;
+    box-shadow: none !important;
+    background-color: white;
+}
+
+#__kconfig-search .input-container input:focus,
+#__kconfig-search .input-container input:active {
+    outline: none;
+}
+
+#__kconfig-search .input-container button {
+    font-size: 22px;
+    float: right;
+    width: 10%;
+    height: 100%;
+    border: none;
+    background-color: white;
 }
 
 #__kconfig-search select {

--- a/doc/_extensions/zephyr/kconfig/static/kconfig.mjs
+++ b/doc/_extensions/zephyr/kconfig/static/kconfig.mjs
@@ -344,8 +344,12 @@ function doSearchFromURL() {
         return;
     }
 
-    const option = rawOption.replace(/[^A-Za-z0-9_]+/g, '');
-    input.value = '^' + option + '$';
+    const option = decodeURIComponent(rawOption);
+    if (option.startsWith('!')) {
+        input.value = option.substring(1);
+    } else {
+        input.value = '^' + option + '$';
+    }
 
     searchOffset = 0;
     doSearch();
@@ -360,10 +364,32 @@ function setupKconfigSearch() {
     }
 
     /* create input field */
+    const inputContainer = document.createElement('div');
+    inputContainer.className = 'input-container'
+    container.appendChild(inputContainer)
+
     input = document.createElement('input');
     input.placeholder = 'Type a Kconfig option name (RegEx allowed)';
     input.type = 'text';
-    container.appendChild(input);
+    inputContainer.appendChild(input);
+
+    const copyLinkButton = document.createElement('button');
+    copyLinkButton.title = "Copy link to results";
+    copyLinkButton.onclick = () => {
+        if (!window.isSecureContext) {
+            console.error("Cannot copy outside of a secure context");
+            return;
+        }
+
+        const copyURL = window.location.protocol + '//' + window.location.host +
+        window.location.pathname + '#!' + input.value;
+
+        navigator.clipboard.writeText(encodeURI(copyURL));
+    }
+    inputContainer.appendChild(copyLinkButton)
+
+    const copyLinkText = document.createTextNode('🔗');
+    copyLinkButton.appendChild(copyLinkText);
 
     /* create search tools container */
     searchTools = document.createElement('div');


### PR DESCRIPTION
First commit fixes an issue with module prefixes. Second commit adds the option to copy a link to results:

![image](https://user-images.githubusercontent.com/25011557/203056929-80904ff0-3a7a-4b21-b203-363e91c498c9.png)
