### PR TITLE
drivers: counter: stm32u5 LL driver has no const TIM_TypeDef

### DIFF
--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -36,7 +36,7 @@ static void(*const set_timer_compare[TIMER_MAX_CH])(TIM_TypeDef *,
 };
 
 /** Channel to compare get function mapping. */
-#if !defined(CONFIG_SOC_SERIES_STM32F4X)
+#if !defined(CONFIG_SOC_SERIES_STM32F4X) && !defined(CONFIG_SOC_SERIES_STM32U5X)
 static uint32_t(*const get_timer_compare[TIMER_MAX_CH])(const TIM_TypeDef *) = {
 	LL_TIM_OC_GetCompareCH1, LL_TIM_OC_GetCompareCH2,
 	LL_TIM_OC_GetCompareCH3, LL_TIM_OC_GetCompareCH4,
@@ -46,7 +46,7 @@ static uint32_t(*const get_timer_compare[TIMER_MAX_CH])(TIM_TypeDef *) = {
 	LL_TIM_OC_GetCompareCH1, LL_TIM_OC_GetCompareCH2,
 	LL_TIM_OC_GetCompareCH3, LL_TIM_OC_GetCompareCH4,
 };
-#endif
+#endif /* ! STM32F4X && ! STM3U5X */
 /** Channel to interrupt enable function mapping. */
 static void(*const enable_it[TIMER_MAX_CH])(TIM_TypeDef *) = {
 	LL_TIM_EnableIT_CC1, LL_TIM_EnableIT_CC2,
@@ -61,7 +61,7 @@ static void(*const disable_it[TIMER_MAX_CH])(TIM_TypeDef *) = {
 
 #ifdef CONFIG_ASSERT
 /** Channel to interrupt enable check function mapping. */
-#if !defined(CONFIG_SOC_SERIES_STM32F4X)
+#if !defined(CONFIG_SOC_SERIES_STM32F4X) && !defined(CONFIG_SOC_SERIES_STM32U5X)
 static uint32_t(*const check_it_enabled[TIMER_MAX_CH])(const TIM_TypeDef *) = {
 	LL_TIM_IsEnabledIT_CC1, LL_TIM_IsEnabledIT_CC2,
 	LL_TIM_IsEnabledIT_CC3, LL_TIM_IsEnabledIT_CC4,
@@ -71,8 +71,8 @@ static uint32_t(*const check_it_enabled[TIMER_MAX_CH])(TIM_TypeDef *) = {
 	LL_TIM_IsEnabledIT_CC1, LL_TIM_IsEnabledIT_CC2,
 	LL_TIM_IsEnabledIT_CC3, LL_TIM_IsEnabledIT_CC4,
 };
-#endif
-#endif
+#endif  /* ! STM32F4X && ! STM3U5X */
+#endif /* CONFIG_ASSERT */
 
 /** Channel to interrupt flag clear function mapping. */
 static void(*const clear_it_flag[TIMER_MAX_CH])(TIM_TypeDef *) = {


### PR DESCRIPTION
In the stm32U5 LL module, the ll timer function prototypes does not have const TIM_TypeDef parameter, 
especially for all the LL_TIM_OC_GetCompareCHx 
See ../modules/hal/stm32/stm32cube/stm32u5xx/drivers/include/stm32u5xx_ll_tim.h.
This is like to the stm32F4 serie and different fom other stm32 series. 
And defines a particular get_timer_compare[] table.

This PR is fixing build warning : 
```
warning: initialization of 'uint32_t (*)(const TIM_TypeDef *)' {aka 'unsigned int (*)(const TIM_TypeDef *)'} 
from incompatible pointer type 'uint32_t (*)(TIM_TypeDef *)' 
{aka 'unsigned int (*)(TIM_TypeDef *)'} [-Wincompatible-pointer-types]

   41 |         LL_TIM_OC_GetCompareCH1, LL_TIM_OC_GetCompareCH2,
      |         ^~~~~~~~~~~~~~~~~~~~~~~
./drivers/counter/counter_ll_stm32_timer.c:41:9: note: (near initialization for 'get_timer_compare[0]')
```


Signed-off-by: Francois Ramu <francois.ramu@st.com>