### PR TITLE
Bluetooth: Audio: Fix null pointer access in mcc.c

### DIFF
--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -951,7 +951,7 @@ static uint8_t mcs_notify_handler(struct bt_conn *conn,
 
 	if (handle == mcs_inst->player_name_handle) {
 		BT_DBG("Player Name notification");
-		mcc_read_player_name_cb(conn, 0, NULL, data, length);
+		mcc_read_player_name_cb(conn, 0, read_params, data, length);
 
 	} else if (handle == mcs_inst->track_changed_handle) {
 		/* The Track Changed characteristic can only be */


### PR DESCRIPTION
One of the notification callback functions did not properly get the `read_params` pointer, causing an invalid result of CONTAINER_OF as it would use a NULL pointer.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>