### PR TITLE
scripts: compliance: check for binary files

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1058,6 +1058,29 @@ class Identity(ComplianceTest):
                 self.failure(failure)
 
 
+class BinaryFiles(ComplianceTest):
+    """
+    Check that the diff contains no binary files.
+    """
+    name = "BinaryFiles"
+    doc = "No binary files allowed."
+    path_hint = "<git-top>"
+
+    def run(self):
+        BINARY_ALLOW_PATHS = ("doc/", "boards/", "samples/")
+        # svg files are always detected as binary, see .gitattributes
+        BINARY_ALLOW_EXT = (".jpg", ".jpeg", ".png", ".svg")
+
+        for stat in git("diff", "--numstat", "--diff-filter=A",
+                        COMMIT_RANGE).splitlines():
+            added, deleted, fname = stat.split("\t")
+            if added == "-" and deleted == "-":
+                if (fname.startswith(BINARY_ALLOW_PATHS) and
+                    fname.endswith(BINARY_ALLOW_EXT)):
+                    continue
+                self.failure(f"Binary file not allowed: {fname}")
+
+
 def init_logs(cli_arg):
     # Initializes logging
 


### PR DESCRIPTION
Hi, this is to help catching unintentional binary files in PRs (context https://github.com/zephyrproject-rtos/zephyr/pull/52416).

Example:

```
~/zephyrproject/zephyr$ ./scripts/ci/check_compliance.py -m BinaryFiles -c v3.2.0..main
Running BinaryFiles      tests in /usr/local/google/home/fabiobaltieri/zephyrproject/zephyr ...

Complete results in compliance.xml
~/zephyrproject/zephyr$ ./scripts/ci/check_compliance.py -m BinaryFiles -c 6ff0b79d74^..6ff0b79d74
Running BinaryFiles      tests in /usr/local/google/home/fabiobaltieri/zephyrproject/zephyr ...
1 checks failed
ERROR   : Test BinaryFiles failed: 
binary file not allowed: mcuboot_zephyr.bin

Complete results in compliance.xml
~/zephyrproject/zephyr$ ./scripts/ci/check_compliance.py -m BinaryFiles -c 6ff0b79d74..6ff0b79d74^
Running BinaryFiles      tests in /usr/local/google/home/fabiobaltieri/zephyrproject/zephyr ...

Complete results in compliance.xml
```

Only look for added files and allows images with known extension in `doc/` and `boards/`.

Uses `git diff --numstat` to detect if a file is binary, note that git detects `svg` files as binary since we set `*.svg -diff` in `.gitattributes`.