### PR TITLE
Bluetooth: Audio: Fix mcc.c `conn` logging statements

### DIFF
--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -935,7 +935,8 @@ static uint8_t mcs_notify_handler(struct bt_conn *conn,
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not find MCS instance from conn %p", conn);
+		BT_DBG("Could not find MCS instance from conn %p",
+		       (void *)conn);
 
 		return BT_GATT_ITER_CONTINUE;
 	}
@@ -1791,7 +1792,7 @@ int bt_mcc_read_player_name(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -1831,7 +1832,7 @@ int bt_mcc_read_icon_obj_id(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -1870,7 +1871,7 @@ int bt_mcc_read_icon_url(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -1908,7 +1909,7 @@ int bt_mcc_read_track_title(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -1946,7 +1947,7 @@ int bt_mcc_read_track_duration(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -1984,7 +1985,7 @@ int bt_mcc_read_track_position(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2022,7 +2023,7 @@ int bt_mcc_set_track_position(struct bt_conn *conn, int32_t pos)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2065,7 +2066,7 @@ int bt_mcc_read_playback_speed(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2103,7 +2104,7 @@ int bt_mcc_set_playback_speed(struct bt_conn *conn, int8_t speed)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2146,7 +2147,7 @@ int bt_mcc_read_seeking_speed(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2185,7 +2186,7 @@ int bt_mcc_read_segments_obj_id(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2223,7 +2224,7 @@ int bt_mcc_read_current_track_obj_id(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2266,7 +2267,7 @@ int bt_mcc_set_current_track_obj_id(struct bt_conn *conn, uint64_t obj_id)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2308,7 +2309,7 @@ int bt_mcc_read_next_track_obj_id(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2351,7 +2352,7 @@ int bt_mcc_set_next_track_obj_id(struct bt_conn *conn, uint64_t obj_id)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2393,7 +2394,7 @@ int bt_mcc_read_parent_group_obj_id(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2431,7 +2432,7 @@ int bt_mcc_read_current_group_obj_id(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2474,7 +2475,7 @@ int bt_mcc_set_current_group_obj_id(struct bt_conn *conn, uint64_t obj_id)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2517,7 +2518,7 @@ int bt_mcc_read_playing_order(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2555,7 +2556,7 @@ int bt_mcc_set_playing_order(struct bt_conn *conn, uint8_t order)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2598,7 +2599,7 @@ int bt_mcc_read_playing_orders_supported(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2636,7 +2637,7 @@ int bt_mcc_read_media_state(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2675,7 +2676,7 @@ int bt_mcc_send_cmd(struct bt_conn *conn, const struct mpl_cmd *cmd)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2724,7 +2725,7 @@ int bt_mcc_read_opcodes_supported(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2763,7 +2764,7 @@ int bt_mcc_send_search(struct bt_conn *conn, const struct mpl_search *search)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2806,7 +2807,7 @@ int bt_mcc_read_search_results_obj_id(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -2845,7 +2846,7 @@ int bt_mcc_read_content_control_id(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -3234,7 +3235,7 @@ int bt_mcc_otc_read_object_metadata(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -3266,7 +3267,7 @@ int bt_mcc_otc_read_icon_object(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -3298,7 +3299,7 @@ int bt_mcc_otc_read_track_segments_object(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -3331,7 +3332,7 @@ int bt_mcc_otc_read_current_track_object(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -3364,7 +3365,7 @@ int bt_mcc_otc_read_next_track_object(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -3397,7 +3398,7 @@ int bt_mcc_otc_read_parent_group_object(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {
@@ -3432,7 +3433,7 @@ int bt_mcc_otc_read_current_group_object(struct bt_conn *conn)
 
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst == NULL) {
-		BT_DBG("Could not lookup mcs_inst from conn %p", conn);
+		BT_DBG("Could not lookup mcs_inst from conn %p", (void *)conn);
 
 		return -EINVAL;
 	} else if (mcs_inst->busy) {


### PR DESCRIPTION
mcc.c does not include `conn_internal.h` so it does not know the `bt_conn` struct, causing logging issues when trying to log a `bt_conn` pointer.

Fixed by casting the `conn` pointers to `(void *)`.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>