### PR TITLE
Bluetooth: Mesh: Only settings load post mesh init

### DIFF
--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -46,6 +46,11 @@ int bt_mesh_provision(const uint8_t net_key[16], uint16_t net_idx,
 		      const uint8_t dev_key[16])
 {
 	int err;
+
+	if (!atomic_test_bit(bt_mesh.flags, BT_MESH_INIT)) {
+		return -ENODEV;
+	}
+
 	struct bt_mesh_cdb_subnet *subnet = NULL;
 
 	BT_INFO("Primary Element: 0x%04x", addr);
@@ -173,7 +178,8 @@ int bt_mesh_provision_gatt(const uint8_t uuid[16], uint16_t net_idx, uint16_t ad
 
 void bt_mesh_reset(void)
 {
-	if (!atomic_test_bit(bt_mesh.flags, BT_MESH_VALID)) {
+	if (!atomic_test_bit(bt_mesh.flags, BT_MESH_VALID) ||
+	    !atomic_test_bit(bt_mesh.flags, BT_MESH_INIT)) {
 		return;
 	}
 
@@ -182,6 +188,7 @@ void bt_mesh_reset(void)
 	bt_mesh.seq = 0U;
 
 	memset(bt_mesh.flags, 0, sizeof(bt_mesh.flags));
+	atomic_set_bit(bt_mesh.flags, BT_MESH_INIT);
 
 	/* If this fails, the work handler will return early on the next
 	 * execution, as the device is not provisioned. If the device is
@@ -337,6 +344,10 @@ int bt_mesh_init(const struct bt_mesh_prov *prov,
 		 const struct bt_mesh_comp *comp)
 {
 	int err;
+
+	if (atomic_test_and_set_bit(bt_mesh.flags, BT_MESH_INIT)) {
+		return -EALREADY;
+	}
 
 	err = bt_mesh_test();
 	if (err) {

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -167,6 +167,7 @@ struct bt_mesh_lpn {
 
 /* bt_mesh_net.flags */
 enum {
+	BT_MESH_INIT,            /* We have been initialized */
 	BT_MESH_VALID,           /* We have been provisioned */
 	BT_MESH_SUSPENDED,       /* Network is temporarily suspended */
 	BT_MESH_IVU_IN_PROGRESS, /* IV Update in Progress */

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -63,6 +63,10 @@ int bt_mesh_settings_set(settings_read_cb read_cb, void *cb_arg,
 
 static int mesh_commit(void)
 {
+	if (!atomic_test_bit(bt_mesh.flags, BT_MESH_INIT)) {
+		return 0;
+	}
+
 	if (!atomic_test_bit(bt_dev.flags, BT_DEV_ENABLE)) {
 		/* The Bluetooth mesh settings loader calls bt_mesh_start() immediately
 		 * after loading the settings. This is not intended to work before


### PR DESCRIPTION
Prevent mesh stored settings from triggering unless bt_mesh_init has been called.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>