### PR TITLE
twister/ci: optimize CI runs for default platforms

### DIFF
--- a/boards/arc/nsim/nsim_em.yaml
+++ b/boards/arc/nsim/nsim_em.yaml
@@ -2,6 +2,7 @@ identifier: nsim_em
 name: EM Nsim simulator
 type: sim
 simulation: nsim
+simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/arc/nsim/nsim_em7d_v22.yaml
+++ b/boards/arc/nsim/nsim_em7d_v22.yaml
@@ -2,6 +2,7 @@ identifier: nsim_em7d_v22
 name: EM Nsim simulator
 type: sim
 simulation: nsim
+simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/arc/nsim/nsim_hs.yaml
+++ b/boards/arc/nsim/nsim_hs.yaml
@@ -2,6 +2,7 @@ identifier: nsim_hs
 name: HS nSIM simulator
 type: sim
 simulation: nsim
+simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/arc/nsim/nsim_hs5x.yaml
+++ b/boards/arc/nsim/nsim_hs5x.yaml
@@ -2,6 +2,7 @@ identifier: nsim_hs5x
 name: HS5x nSIM simulator
 type: sim
 simulation: nsim
+simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/arc/nsim/nsim_hs5x_smp.yaml
+++ b/boards/arc/nsim/nsim_hs5x_smp.yaml
@@ -2,6 +2,7 @@ identifier: nsim_hs5x_smp
 name: Multi-core HS5x nSIM simulator
 type: sim
 simulation: mdb-nsim
+simulation_exec: mdb
 arch: arc
 toolchain:
   - zephyr

--- a/boards/arc/nsim/nsim_hs6x.yaml
+++ b/boards/arc/nsim/nsim_hs6x.yaml
@@ -2,6 +2,7 @@ identifier: nsim_hs6x
 name: HS6x nSIM simulator
 type: sim
 simulation: nsim
+simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - arcmwdt

--- a/boards/arc/nsim/nsim_hs6x_smp.yaml
+++ b/boards/arc/nsim/nsim_hs6x_smp.yaml
@@ -2,6 +2,7 @@ identifier: nsim_hs6x_smp
 name: Multi-core HS6x nSIM simulator
 type: sim
 simulation: mdb-nsim
+simulation_exec: mdb
 arch: arc
 toolchain:
   - cross-compile

--- a/boards/arc/nsim/nsim_hs_flash_xip.yaml
+++ b/boards/arc/nsim/nsim_hs_flash_xip.yaml
@@ -2,6 +2,7 @@ identifier: nsim_hs_flash_xip
 name: HS nSIM simulator
 type: sim
 simulation: nsim
+simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/arc/nsim/nsim_hs_mpuv6.yaml
+++ b/boards/arc/nsim/nsim_hs_mpuv6.yaml
@@ -2,6 +2,7 @@ identifier: nsim_hs_mpuv6
 name: HS (with MPU v6) nSIM simulator
 type: sim
 simulation: nsim
+simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/arc/nsim/nsim_hs_smp.yaml
+++ b/boards/arc/nsim/nsim_hs_smp.yaml
@@ -2,6 +2,7 @@ identifier: nsim_hs_smp
 name: Multi-core HS nSIM simulator
 type: sim
 simulation: mdb-nsim
+simulation_exec: mdb
 arch: arc
 toolchain:
   - zephyr

--- a/boards/arc/nsim/nsim_hs_sram.yaml
+++ b/boards/arc/nsim/nsim_hs_sram.yaml
@@ -2,6 +2,7 @@ identifier: nsim_hs_sram
 name: HS nSIM simulator
 type: sim
 simulation: nsim
+simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr

--- a/boards/arc/nsim/nsim_sem.yaml
+++ b/boards/arc/nsim/nsim_sem.yaml
@@ -3,6 +3,7 @@ name: SEM Nsim simulator
 type: sim
 arch: arc
 simulation: nsim
+simulation_exec: nsimdrv
 toolchain:
   - zephyr
   - arcmwdt

--- a/boards/arc/nsim/nsim_sem_mpu_stack_guard.yaml
+++ b/boards/arc/nsim/nsim_sem_mpu_stack_guard.yaml
@@ -3,6 +3,7 @@ name: SEM Nsim simulator
 type: sim
 arch: arc
 simulation: nsim
+simulation_exec: nsimdrv
 toolchain:
   - zephyr
   - arcmwdt

--- a/boards/posix/native_posix/native_posix.yaml
+++ b/boards/posix/native_posix/native_posix.yaml
@@ -1,6 +1,7 @@
 identifier: native_posix
 name: Native 32-bit POSIX port
 type: native
+simulation: native
 arch: posix
 ram: 65536
 flash: 65536

--- a/boards/posix/nrf52_bsim/nrf52_bsim.yaml
+++ b/boards/posix/nrf52_bsim/nrf52_bsim.yaml
@@ -2,6 +2,7 @@ identifier: nrf52_bsim
 name: NRF52 BabbleSim board
 type: native
 arch: posix
+simulation: native
 env:
   - BSIM_OUT_PATH
 toolchain:

--- a/boards/riscv/hifive1/hifive1.yaml
+++ b/boards/riscv/hifive1/hifive1.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
 ram: 16
 simulation: renode
+simulation_exec: renode
 supported:
   - pwm
   - gpio

--- a/boards/riscv/hifive_unleashed/hifive_unleashed.yaml
+++ b/boards/riscv/hifive_unleashed/hifive_unleashed.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
 ram: 3840
 simulation: renode
+simulation_exec: renode
 testing:
   ignore_tags:
     - net

--- a/boards/riscv/m2gl025_miv/m2gl025_miv.yaml
+++ b/boards/riscv/m2gl025_miv/m2gl025_miv.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
 ram: 64
 simulation: renode
+simulation_exec: renode
 testing:
   default: true
   ignore_tags:

--- a/boards/sparc/generic_leon3/generic_leon3.yaml
+++ b/boards/sparc/generic_leon3/generic_leon3.yaml
@@ -2,6 +2,7 @@ identifier: generic_leon3
 name: Generic LEON3 system
 type: mcu
 simulation: tsim
+simulation_exec: tsim
 arch: sparc
 ram: 4096
 flash: 2048

--- a/boards/sparc/gr716a_mini/gr716a_mini.yaml
+++ b/boards/sparc/gr716a_mini/gr716a_mini.yaml
@@ -2,6 +2,7 @@ identifier: gr716a_mini
 name: GR716-MINI Development Board
 type: mcu
 simulation: tsim
+simulation_exec: tsim
 arch: sparc
 toolchain:
   - zephyr

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -38,6 +38,7 @@ except ImportError as capture_error:
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
 
+SUPPORTED_SIMS = ["mdb-nsim", "nsim", "renode", "qemu", "tsim", "armfvp", "xt-sim", "native"]
 
 class HarnessImporter:
 
@@ -76,6 +77,7 @@ class Handler:
         self.generator = None
         self.generator_cmd = None
         self.suite_name_check = True
+        self.ready = False
 
         self.args = []
         self.terminated = False
@@ -310,6 +312,21 @@ class BinaryHandler(Handler):
 
         self._final_handle_actions(harness, handler_time)
 
+
+class SimulationHandler(BinaryHandler):
+    def __init__(self, instance, type_str):
+        """Constructor
+
+        @param instance Test Instance
+        """
+        super().__init__(instance, type_str)
+
+        if type_str == 'renode':
+            self.pid_fn = os.path.join(instance.build_dir, "renode.pid")
+        elif type_str == 'native':
+            self.call_make_run = False
+            self.binary = os.path.join(instance.build_dir, "zephyr", "zephyr.exe")
+            self.ready = True
 
 class DeviceHandler(Handler):
 

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -38,6 +38,7 @@ class Platform:
         self.arch = ""
         self.type = "na"
         self.simulation = "na"
+        self.simulation_exec = None
         self.supported_toolchains = []
         self.env = []
         self.env_satisfied = True
@@ -67,6 +68,7 @@ class Platform:
         self.arch = data['arch']
         self.type = data.get('type', "na")
         self.simulation = data.get('simulation', "na")
+        self.simulation_exec = data.get('simulation_exec')
         self.supported_toolchains = data.get("toolchain", [])
         self.env = data.get("env", [])
         self.env_satisfied = True

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -544,7 +544,7 @@ class ProjectBuilder(FilterBuilder):
 
         elif op == "gather_metrics":
             self.gather_metrics(self.instance)
-            if self.instance.run and self.instance.handler:
+            if self.instance.run and self.instance.handler.ready:
                 pipeline.put({"op": "run", "test": self.instance})
             else:
                 pipeline.put({"op": "report", "test": self.instance})
@@ -730,7 +730,7 @@ class ProjectBuilder(FilterBuilder):
             elif instance.status in ["skipped", "filtered"]:
                 more_info = instance.reason
             else:
-                if instance.handler and instance.run:
+                if instance.handler.ready and instance.run:
                     more_info = instance.handler.type_str
                     htime = instance.execution_time
                     if htime:
@@ -775,7 +775,7 @@ class ProjectBuilder(FilterBuilder):
         instance = self.instance
         args = self.testsuite.extra_args[:]
 
-        if instance.handler:
+        if instance.handler.ready:
             args += instance.handler.args
 
         # merge overlay files into one variable
@@ -817,7 +817,7 @@ class ProjectBuilder(FilterBuilder):
 
         instance = self.instance
 
-        if instance.handler:
+        if instance.handler.ready:
             if instance.handler.type_str == "device":
                 instance.handler.duts = self.duts
 

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -203,21 +203,12 @@ class TestInstance:
                         self.platform.simulation in ["mdb-nsim", "nsim", "renode", "qemu", "tsim", "armfvp", "xt-sim"] or \
                         filter == 'runnable')
 
-        if self.platform.simulation == "nsim":
-            if not shutil.which("nsimdrv"):
-                target_ready = False
+        for sim in ['nsim', 'mdb-nsim', 'renode', 'tsim']:
+            if self.platform.simulation == sim and self.platform.simulation_exec:
+                if not shutil.which(self.platform.simulation_exec):
+                    target_ready = False
+                break
 
-        if self.platform.simulation == "mdb-nsim":
-            if not shutil.which("mdb"):
-                target_ready = False
-
-        if self.platform.simulation == "renode":
-            if not shutil.which("renode"):
-                target_ready = False
-
-        if self.platform.simulation == "tsim":
-            if not shutil.which("tsim-leon3"):
-                target_ready = False
 
         testsuite_runnable = self.testsuite_runnable(self.testsuite, fixtures)
 

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -14,7 +14,7 @@ import glob
 from twisterlib.testsuite import TestCase
 from twisterlib.error import BuildError
 from twisterlib.size_calc import SizeCalculator
-from twisterlib.handlers import BinaryHandler, QEMUHandler, DeviceHandler
+from twisterlib.handlers import Handler, SimulationHandler, BinaryHandler, QEMUHandler, DeviceHandler, SUPPORTED_SIMS
 
 
 logger = logging.getLogger('twister')
@@ -139,43 +139,30 @@ class TestInstance:
             return
 
         options = env.options
-        args = []
-        handler = None
-        if self.platform.simulation == "qemu":
-            handler = QEMUHandler(self, "qemu")
-            args.append(f"QEMU_PIPE={handler.get_fifo()}")
+        handler = Handler(self, "")
+        if self.platform.simulation:
+            if self.platform.simulation == "qemu":
+                handler = QEMUHandler(self, "qemu")
+                handler.args.append(f"QEMU_PIPE={handler.get_fifo()}")
+                handler.ready = True
+            else:
+                handler = SimulationHandler(self, self.platform.simulation)
+
+            if self.platform.simulation_exec and shutil.which(self.platform.simulation_exec):
+                handler.ready = True
         elif self.testsuite.type == "unit":
             handler = BinaryHandler(self, "unit")
             handler.binary = os.path.join(self.build_dir, "testbinary")
             if options.enable_coverage:
-                args.append("COVERAGE=1")
+                handler.args.append("COVERAGE=1")
             handler.call_make_run = False
-        elif self.platform.type == "native":
-            handler = BinaryHandler(self, "native")
-            handler.call_make_run = False
-            handler.binary = os.path.join(self.build_dir, "zephyr", "zephyr.exe")
-        elif self.platform.simulation == "renode":
-            if shutil.which("renode"):
-                handler = BinaryHandler(self, "renode")
-                handler.pid_fn = os.path.join(self.build_dir, "renode.pid")
-        elif self.platform.simulation == "tsim":
-            handler = BinaryHandler(self, "tsim")
+            handler.ready = True
         elif options.device_testing:
             handler = DeviceHandler(self, "device")
             handler.call_make_run = False
-        elif self.platform.simulation == "nsim":
-            if shutil.which("nsimdrv"):
-                handler = BinaryHandler(self, "nsim")
-        elif self.platform.simulation == "mdb-nsim":
-            if shutil.which("mdb"):
-                handler = BinaryHandler(self, "nsim")
-        elif self.platform.simulation == "armfvp":
-            handler = BinaryHandler(self, "armfvp")
-        elif self.platform.simulation == "xt-sim":
-            handler = BinaryHandler(self,  "xt-sim")
+            handler.ready = True
 
         if handler:
-            handler.args = args
             handler.options = options
             handler.generator_cmd = env.generator_cmd
             handler.generator = env.generator
@@ -200,14 +187,16 @@ class TestInstance:
 
         target_ready = bool(self.testsuite.type == "unit" or \
                         self.platform.type == "native" or \
-                        self.platform.simulation in ["mdb-nsim", "nsim", "renode", "qemu", "tsim", "armfvp", "xt-sim"] or \
+                        self.platform.simulation in SUPPORTED_SIMS or \
                         filter == 'runnable')
 
-        for sim in ['nsim', 'mdb-nsim', 'renode', 'tsim']:
+        for sim in ['nsim', 'mdb-nsim', 'renode', 'tsim', 'native']:
             if self.platform.simulation == sim and self.platform.simulation_exec:
                 if not shutil.which(self.platform.simulation_exec):
                     target_ready = False
                 break
+            else:
+                target_ready = True
 
 
         testsuite_runnable = self.testsuite_runnable(self.testsuite, fixtures)

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -14,6 +14,7 @@ from collections import OrderedDict
 from itertools import islice
 import logging
 import copy
+import shutil
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
@@ -597,7 +598,17 @@ class TestPlan:
         elif arch_filter:
             platforms = list(filter(lambda p: p.arch in arch_filter, self.platforms))
         elif default_platforms:
-            platforms = list(filter(lambda p: p.default, self.platforms))
+            _platforms = list(filter(lambda p: p.default, self.platforms))
+            platforms = []
+            # default platforms that can't be run are dropped from the list of
+            # the default platforms list. Default platforms should always be
+            # runnable.
+            for p in _platforms:
+                if p.simulation and p.simulation_exec:
+                    if shutil.which(p.simulation_exec):
+                        platforms.append(p)
+                else:
+                    platforms.append(p)
         else:
             platforms = self.platforms
 

--- a/scripts/schemas/twister/platform-schema.yaml
+++ b/scripts/schemas/twister/platform-schema.yaml
@@ -24,7 +24,7 @@ mapping:
     enum: ["mcu", "qemu", "sim", "unit", "native"]
   "simulation":
     type: str
-    enum: ["qemu", "simics", "xt-sim", "renode", "nsim", "mdb-nsim", "tsim", "armfvp"]
+    enum: ["qemu", "simics", "xt-sim", "renode", "nsim", "mdb-nsim", "tsim", "armfvp", "native"]
   "simulation_exec":
     type: str
   "arch":

--- a/scripts/schemas/twister/platform-schema.yaml
+++ b/scripts/schemas/twister/platform-schema.yaml
@@ -25,6 +25,8 @@ mapping:
   "simulation":
     type: str
     enum: ["qemu", "simics", "xt-sim", "renode", "nsim", "mdb-nsim", "tsim", "armfvp"]
+  "simulation_exec":
+    type: str
   "arch":
     type: str
   "toolchain":

--- a/tests/ztest/fail/testcase.yaml
+++ b/tests/ztest/fail/testcase.yaml
@@ -1,53 +1,45 @@
 # Copyright (c) 2022 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
+common:
+  tags: ztest
+  # test has dependencies on host libc
+  platform_allow: native_posix
 tests:
   testing.fail.unit.assert_after:
-    type: unit
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_ASSERT_AFTER=y
   testing.fail.unit.assert_teardown:
-    type: unit
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_ASSERT_TEARDOWN=y
   testing.fail.unit.assume_after:
-    type: unit
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_ASSUME_AFTER=y
   testing.fail.unit.assume_teardown:
-    type: unit
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_ASSUME_TEARDOWN=y
   testing.fail.unit.pass_after:
-    type: unit
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_PASS_AFTER=y
   testing.fail.unit.pass_teardown:
-    type: unit
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_PASS_TEARDOWN=y
   testing.fail.zephyr.assert_after:
-    platform_allow: native_posix
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_ASSERT_AFTER=y
   testing.fail.zephyr.assert_teardown:
-    platform_allow: native_posix
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_ASSERT_TEARDOWN=y
   testing.fail.zephyr.assume_after:
-    platform_allow: native_posix
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_ASSUME_AFTER=y
   testing.fail.zephyr.assume_teardown:
-    platform_allow: native_posix
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_ASSUME_TEARDOWN=y
   testing.fail.zephyr.pass_after:
-    platform_allow: native_posix
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_PASS_AFTER=y
   testing.fail.zephyr.pass_teardown:
-    platform_allow: native_posix
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_PASS_TEARDOWN=y
   testing.fail.unit.fail_on_bad_assumption:
@@ -55,6 +47,5 @@ tests:
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_UNEXPECTED_ASSUME=y
   testing.fail.zephyr.fail_on_bad_assumption:
-    platform_allow: native_posix
     extra_configs:
       - CONFIG_ZTEST_FAIL_TEST_UNEXPECTED_ASSUME=y


### PR DESCRIPTION
Default platforms should always be runnable, if we are missing the simulator in the environment, treat them as any other platform.
This improves CI response times, we will not spend time building code we are not executing, code that is being tested using some other means, i.e. qemu.

- tests: ztest: fix filtering of tests
- boards: add simulation executable for 3rd party sims
- twister: treat default platforms without a mean to run as any other
