### PR TITLE
unittest: add C++ support

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/arch/cpu.h
+++ b/subsys/testsuite/ztest/include/zephyr/arch/cpu.h
@@ -6,17 +6,27 @@
 
 /* This file exists as a hack around Zephyr's dependencies */
 
+#include <inttypes.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Architecture thread structure */
 struct _callee_saved {
+#ifdef CONFIG_CPLUSPLUS
+	/* C++ does not allow empty structs, add an extra 1 byte */
+	uint8_t c;
+#endif
 };
 
 typedef struct _callee_saved _callee_saved_t;
 
 struct _thread_arch {
+#ifdef CONFIG_CPLUSPLUS
+	/* C++ does not allow empty structs, add an extra 1 byte */
+	uint8_t c;
+#endif
 };
 
 typedef struct _thread_arch _thread_arch_t;


### PR DESCRIPTION
Some of the struct in the unit test's cpu.h header were empty which isn't allowed in C++.