### PR TITLE
soc: lpcxpresso55S36 added PowerInit in clock_init.

### DIFF
--- a/soc/arm/nxp_lpc/lpc55xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.c
@@ -58,6 +58,12 @@ const pll_setup_t pll0Setup = {
 
 static ALWAYS_INLINE void clock_init(void)
 {
+
+#if defined(CONFIG_SOC_LPC55S36)
+	/* Power Management Controller initialization */
+	POWER_PowerInit();
+#endif
+
 #if defined(CONFIG_SOC_LPC55S06) || defined(CONFIG_SOC_LPC55S16) || \
 	defined(CONFIG_SOC_LPC55S28) || defined(CONFIG_SOC_LPC55S36) || \
 	defined(CONFIG_SOC_LPC55S69_CPU0)


### PR DESCRIPTION
Added a missing SDK function POWER_PowerInit
to the clock_init function of the soc in lpc55S36.

Signed-off-by: Emilio Benavente <emilio.benavente@nxp.com>