### PR TITLE
MAINTAINERS: Add fredrikdanebjer to Bluetooth Audio

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -250,6 +250,7 @@ Bluetooth Audio:
     - rymanluk
     - sjanc
     - asbjornsabo
+    - fredrikdanebjer
   files:
     - subsys/bluetooth/audio/
     - include/zephyr/bluetooth/audio/


### PR DESCRIPTION
Add fredrikdanebjer as a collaborator for Bluetooth Audio.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

Fredrik has had limited amount of PR for LE Audio:
https://github.com/zephyrproject-rtos/zephyr/pull/51699
https://github.com/zephyrproject-rtos/zephyr/pull/47625
https://github.com/zephyrproject-rtos/zephyr/pull/47333
https://github.com/zephyrproject-rtos/zephyr/pull/47254

But he is committed to do more. Fredrik also attends the weekly LE Audio Zephyr meetings, as well as some of the F2F meetings held for the project. 