### PR TITLE
MAINTAINERS: Add szymon-czapracki to Bluetooth Audio

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -249,6 +249,7 @@ Bluetooth Audio:
     - MariuszSkamra
     - rymanluk
     - sjanc
+    - szymon-czapracki
     - asbjornsabo
   files:
     - subsys/bluetooth/audio/


### PR DESCRIPTION
Add szymon-czapracki as a collaborator for Bluetooth Audio.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

Szymon has contributed the following:
https://github.com/zephyrproject-rtos/zephyr/pull/51037
https://github.com/zephyrproject-rtos/zephyr/pull/50251
https://github.com/zephyrproject-rtos/zephyr/pull/50249
https://github.com/zephyrproject-rtos/zephyr/pull/51027
https://github.com/zephyrproject-rtos/zephyr/pull/49415
https://github.com/zephyrproject-rtos/zephyr/pull/49414
https://github.com/zephyrproject-rtos/zephyr/pull/49163
https://github.com/zephyrproject-rtos/zephyr/pull/49158
https://github.com/zephyrproject-rtos/zephyr/pull/44794
https://github.com/zephyrproject-rtos/zephyr/pull/43574

To LE Audio. 

He also attends the weekly LE Audio Zephyr meetings, as well as some of the F2F meetings held for the project.