### PR TITLE
arm64: implement `arch_system_halt`

### DIFF
--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -13,9 +13,10 @@
  * exceptions
  */
 
+#include <zephyr/drivers/pm_cpu_ops.h>
+#include <zephyr/exc_handle.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/exc_handle.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
@@ -276,5 +277,19 @@ FUNC_NORETURN void arch_syscall_oops(void *ssf_ptr)
 {
 	z_arm64_fatal_error(K_ERR_KERNEL_OOPS, ssf_ptr);
 	CODE_UNREACHABLE;
+}
+#endif
+
+#if defined(CONFIG_PM_CPU_OPS_PSCI)
+FUNC_NORETURN void arch_system_halt(unsigned int reason)
+{
+	ARG_UNUSED(reason);
+
+	(void)arch_irq_lock();
+	(void)pm_system_off();
+
+	for (;;) {
+		/* Spin endlessly as fallback */
+	}
 }
 #endif

--- a/drivers/pm_cpu_ops/pm_cpu_ops_psci.c
+++ b/drivers/pm_cpu_ops/pm_cpu_ops_psci.c
@@ -66,6 +66,20 @@ int pm_cpu_on(unsigned long cpuid,
 	return psci_to_dev_err(ret);
 }
 
+int pm_system_off(void)
+{
+	int ret;
+
+	if (psci_data.conduit == SMCCC_CONDUIT_NONE) {
+		return -EINVAL;
+	}
+
+	/* A compliant PSCI implementation will never return from this call */
+	ret = psci_data.invoke_psci_fn(PSCI_0_2_FN_SYSTEM_OFF, 0, 0, 0);
+
+	return psci_to_dev_err(ret);
+}
+
 static unsigned long __invoke_psci_fn_hvc(unsigned long function_id,
 					  unsigned long arg0,
 					  unsigned long arg1,

--- a/include/zephyr/drivers/pm_cpu_ops.h
+++ b/include/zephyr/drivers/pm_cpu_ops.h
@@ -51,6 +51,18 @@ int pm_cpu_off(void);
  */
 int pm_cpu_on(unsigned long cpuid, uintptr_t entry_point);
 
+/**
+ * @brief Power down the system
+ *
+ * This call is used to power down the whole system.
+ *
+ * A compliant PSCI implementation will never return, but some real-world
+ * implementations do return errors in some cases.
+ *
+ * @retval does not return on success, a negative errno otherwise
+ * @retval -ENOTSUP If the operation is not supported
+ */
+int pm_system_off(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When PSCI is enabled, implement `arch_system_halt` using `SYSTEM_OFF`.

Issue: there is nothing testing that. The only test that seems to use `arch_system_halt` is `tests/kernel/fatal/no-multithreading/`.
I tried adding `qemu_cortex_a53` in `platform_allow`, but unfortunately, `CONFIG_MULTITHREADING=n` leads to:
```
zephyr/arch/arm64/core/isr_wrapper.S:133: undefined reference to `z_get_next_switch_handle'
```

So unless I missed something, `CONFIG_MULTITHREADING=n` seems broken on arm64.