### PR TITLE
drivers: clock_control_nrf: Fix releasing/stopping of HFCLK

### DIFF
--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -295,12 +295,21 @@ static void generic_hfclk_start(void)
 
 static void generic_hfclk_stop(void)
 {
-	if (atomic_and(&hfclk_users, ~HF_USER_GENERIC) & HF_USER_BT) {
-		/* bt still requesting the clock. */
-		return;
+	/* It's not enough to use only atomic_and() here for synchronization,
+	 * as the thread could be preempted right after that function but
+	 * before hfclk_stop() is called and the preempting code could request
+	 * the HFCLK again. Then, the HFCLK would be stopped inappropriately
+	 * and hfclk_user would be left with an incorrect value.
+	 */
+	unsigned int key = irq_lock();
+
+	hfclk_users &= ~HF_USER_GENERIC;
+	/* Skip stopping if BT is still requesting the clock. */
+	if (!(hfclk_users & HF_USER_BT)) {
+		hfclk_stop();
 	}
 
-	hfclk_stop();
+	irq_unlock(key);
 }
 
 
@@ -316,12 +325,18 @@ void z_nrf_clock_bt_ctlr_hf_request(void)
 
 void z_nrf_clock_bt_ctlr_hf_release(void)
 {
-	if (atomic_and(&hfclk_users, ~HF_USER_BT) & HF_USER_GENERIC) {
-		/* generic still requesting the clock. */
-		return;
+	/* It's not enough to use only atomic_and() here for synchronization,
+	 * see the explanation in generic_hfclk_stop().
+	 */
+	unsigned int key = irq_lock();
+
+	hfclk_users &= ~HF_USER_BT;
+	/* Skip stopping if generic is still requesting the clock. */
+	if (!(hfclk_users & HF_USER_GENERIC)) {
+		hfclk_stop();
 	}
 
-	hfclk_stop();
+	irq_unlock(key);
 }
 
 static int stop(const struct device *dev, clock_control_subsys_t subsys,

--- a/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
+++ b/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
@@ -103,6 +103,7 @@ ZTEST(nrf_onoff_and_bt, test_onoff_interrupted)
 	int backoff;
 
 	iteration = 0;
+	test_end = false;
 
 	k_timer_start(&timer1, K_MSEC(1), K_NO_WAIT);
 
@@ -190,6 +191,7 @@ ZTEST(nrf_onoff_and_bt, test_bt_interrupted)
 	int backoff;
 
 	iteration = 0;
+	test_end = false;
 
 	k_timer_start(&timer2, K_MSEC(1), K_NO_WAIT);
 

--- a/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
+++ b/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
@@ -19,18 +19,20 @@ LOG_MODULE_REGISTER(test);
 static bool test_end;
 
 static const struct device *const entropy = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+static const struct device *const clock_dev = DEVICE_DT_GET_ONE(nordic_nrf_clock);
 static struct onoff_manager *hf_mgr;
+static struct onoff_client cli;
 static uint32_t iteration;
 
-static void before(void *data)
+static void *setup(void)
 {
-	ARG_UNUSED(data);
 	zassert_true(device_is_ready(entropy));
+	zassert_true(device_is_ready(clock_dev));
 
 	hf_mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
 	zassert_true(hf_mgr);
 
-	iteration = 0;
+	return NULL;
 }
 
 static void bt_timeout_handler(struct k_timer *timer)
@@ -50,9 +52,9 @@ static void bt_timeout_handler(struct k_timer *timer)
 		static bool long_timeout;
 
 		if (!on) {
-			timeout = Z_TIMEOUT_US(200);
+			timeout = K_USEC(200);
 		} else {
-			timeout = Z_TIMEOUT_US(long_timeout ? 300 : 100);
+			timeout = long_timeout ? K_USEC(300) : K_USEC(100);
 			long_timeout = !long_timeout;
 		}
 		k_timer_start(timer, timeout, K_NO_WAIT);
@@ -93,8 +95,6 @@ static void check_hf_status(const struct device *dev, bool exp_on,
  */
 ZTEST(nrf_onoff_and_bt, test_onoff_interrupted)
 {
-	const struct device *const clock_dev = DEVICE_DT_GET_ONE(nordic_nrf_clock);
-	struct onoff_client cli;
 	uint64_t start_time = k_uptime_get();
 	uint64_t elapsed;
 	uint64_t checkpoint = 1000;
@@ -102,11 +102,11 @@ ZTEST(nrf_onoff_and_bt, test_onoff_interrupted)
 	uint8_t rand;
 	int backoff;
 
-	zassert_true(device_is_ready(clock_dev), "Device is not ready");
+	iteration = 0;
 
 	k_timer_start(&timer1, K_MSEC(1), K_NO_WAIT);
 
-	while (1) {
+	do {
 		iteration++;
 
 		err = entropy_get_entropy(entropy, &rand, 1);
@@ -131,13 +131,9 @@ ZTEST(nrf_onoff_and_bt, test_onoff_interrupted)
 			printk("test continues\n");
 			checkpoint += 1000;
 		}
+	} while (elapsed <= TEST_TIME_MS);
 
-		if (elapsed > TEST_TIME_MS) {
-			test_end = true;
-			break;
-		}
-	}
-
+	test_end = true;
 	k_msleep(100);
 	check_hf_status(clock_dev, false, true);
 }
@@ -145,7 +141,6 @@ ZTEST(nrf_onoff_and_bt, test_onoff_interrupted)
 static void onoff_timeout_handler(struct k_timer *timer)
 {
 	static bool on;
-	static struct onoff_client cli;
 	static uint32_t cnt;
 	int err;
 
@@ -166,9 +161,9 @@ static void onoff_timeout_handler(struct k_timer *timer)
 		static bool long_timeout;
 
 		if (!on) {
-			timeout = Z_TIMEOUT_US(200);
+			timeout = K_USEC(200);
 		} else {
-			timeout = Z_TIMEOUT_US(long_timeout ? 300 : 100);
+			timeout = long_timeout ? K_USEC(300) : K_USEC(100);
 			long_timeout = !long_timeout;
 		}
 		k_timer_start(timer, timeout, K_NO_WAIT);
@@ -187,7 +182,6 @@ K_TIMER_DEFINE(timer2, onoff_timeout_handler, NULL);
  */
 ZTEST(nrf_onoff_and_bt, test_bt_interrupted)
 {
-	const struct device *const clock_dev = DEVICE_DT_GET_ONE(nordic_nrf_clock);
 	uint64_t start_time = k_uptime_get();
 	uint64_t elapsed;
 	uint64_t checkpoint = 1000;
@@ -195,11 +189,11 @@ ZTEST(nrf_onoff_and_bt, test_bt_interrupted)
 	uint8_t rand;
 	int backoff;
 
-	zassert_true(device_is_ready(clock_dev), "Device is not ready");
+	iteration = 0;
 
 	k_timer_start(&timer2, K_MSEC(1), K_NO_WAIT);
 
-	while (1) {
+	do {
 		iteration++;
 
 		err = entropy_get_entropy(entropy, &rand, 1);
@@ -221,14 +215,10 @@ ZTEST(nrf_onoff_and_bt, test_bt_interrupted)
 			printk("test continues\n");
 			checkpoint += 1000;
 		}
+	} while (elapsed <= TEST_TIME_MS);
 
-		if (elapsed > TEST_TIME_MS) {
-			test_end = true;
-			break;
-		}
-	}
-
+	test_end = true;
 	k_msleep(100);
 	check_hf_status(clock_dev, false, true);
 }
-ZTEST_SUITE(nrf_onoff_and_bt, NULL, NULL, before, NULL, NULL);
+ZTEST_SUITE(nrf_onoff_and_bt, NULL, setup, NULL, NULL, NULL);

--- a/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
+++ b/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
@@ -18,8 +18,6 @@ LOG_MODULE_REGISTER(test);
 
 static bool test_end;
 
-#include <hal/nrf_gpio.h>
-
 static const struct device *const entropy = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 static struct onoff_manager *hf_mgr;
 static uint32_t iteration;
@@ -39,13 +37,10 @@ static void bt_timeout_handler(struct k_timer *timer)
 {
 	static bool on;
 
-	nrf_gpio_cfg_output(27);
 	if (on) {
 		on = false;
-		nrf_gpio_pin_clear(27);
 		z_nrf_clock_bt_ctlr_hf_release();
 	} else {
-		nrf_gpio_pin_set(27);
 		on = true;
 		z_nrf_clock_bt_ctlr_hf_request();
 	}


### PR DESCRIPTION
After switching to the new ZTEST API, the `test_bt_interrupted` test in the `nrf_onoff_and_bt` suite for the clock_control driver started failing. This revealed a bug in this test (see the "tests: clock_control: nrf_onoff_and_bt: Add clearing of `test_end`" commit for details) and after it was fixed, it turned out that the HFCLK stopping routines in the clock_control_nrf driver do not entirely work as they are supposed to (and as that broken test falsely confirmed).
This PR fixes both the test (with some additional clean-up) and the driver.