### PR TITLE
Add support for NXP S32 I3C driver

### DIFF
--- a/boards/arm/s32z270dc2_r52/doc/index.rst
+++ b/boards/arm/s32z270dc2_r52/doc/index.rst
@@ -43,6 +43,8 @@ The boards support the following hardware features:
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
+| I3C       | on-chip    | i3c                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
@@ -52,3 +52,15 @@
 &spi9 {
 	clock-frequency = <100000000>;
 };
+
+&i3c0 {
+	clock-frequency = <133333333>;
+};
+
+&i3c1 {
+	clock-frequency = <133333333>;
+};
+
+&i3c2 {
+	clock-frequency = <133333333>;
+};

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.yaml
@@ -11,3 +11,4 @@ toolchain:
 supported:
   - uart
   - gpio
+  - i3c

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.yaml
@@ -11,3 +11,4 @@ toolchain:
 supported:
   - uart
   - gpio
+  - i3c

--- a/drivers/i3c/CMakeLists.txt
+++ b/drivers/i3c/CMakeLists.txt
@@ -23,3 +23,8 @@ zephyr_library_sources_ifdef(
   CONFIG_I3C_MCUX
   i3c_mcux.c
 )
+
+zephyr_library_sources_ifdef(
+  CONFIG_NXP_S32_I3C
+  i3c_nxp_s32.c
+)

--- a/drivers/i3c/Kconfig.nxp
+++ b/drivers/i3c/Kconfig.nxp
@@ -17,3 +17,24 @@ config I3C_MCUX
 	default y
 	help
 	  Enable mcux I3C driver.
+
+module = NXP_S32_I3C
+module-str = nxp-s32-i3c
+source "subsys/logging/Kconfig.template.log_config"
+
+config NXP_S32_I3C
+	bool "NXP S32 I3C driver"
+	depends on DT_HAS_NXP_S32_I3C_ENABLED
+	default y
+	help
+	  Enable NXP S32 I3C driver.
+
+if NXP_S32_I3C
+
+config NXP_S32_I3C_INTERRUPT
+	bool "Set if using interrupt-mode for I3C communication"
+	default y
+	help
+	Set if using interrupt-mode for I3C communication
+
+endif

--- a/drivers/i3c/i3c_nxp_s32.c
+++ b/drivers/i3c/i3c_nxp_s32.c
@@ -1,0 +1,491 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/i3c.h>
+#include <zephyr/drivers/pinctrl.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(i3c_nxp_s32, CONFIG_NXP_S32_I3C_LOG_LEVEL);
+
+#include <I3c_Ip.h>
+
+struct nxp_s32_i3c_config {
+
+	uint8_t instance;
+
+	uint32_t functional_clk;
+
+	I3c_Ip_MasterConfigType *i3c_master_cfg;
+
+	const struct pinctrl_dev_config *pincfg;
+
+	/** I3C/I2C device list struct. */
+	struct i3c_dev_list device_list;
+
+	/** Interrupt configuration function. */
+	void (*irq_config_func)(const struct device *dev);
+};
+
+struct nxp_s32_i3c_data {
+
+	/** Controller configuration parameters */
+	struct i3c_config_controller ctrl_config;
+
+	/** Address slots */
+	struct i3c_addr_slots addr_slots;
+
+	struct k_mutex lock;
+
+	I3c_Ip_TransferConfigType i3c_transfer_cfg;
+
+	uint32_t i3c_od_scl_hz;
+};
+
+/**
+ * Find a registered I2C target device.
+ *
+ * Controller only API.
+ *
+ * This returns the I2C device descriptor of the I2C device
+ * matching the device address @p addr.
+ *
+ * @param dev Pointer to controller device driver instance.
+ * @param id I2C target device address.
+ *
+ * @return @see i3c_i2c_device_find.
+ */
+static
+struct i3c_i2c_device_desc *nxp_s32_i3c_i2c_device_find(const struct device *dev, uint16_t addr)
+{
+	const struct nxp_s32_i3c_config *config = dev->config;
+
+	return i3c_dev_list_i2c_addr_find(&config->device_list, addr);
+}
+
+#ifdef CONFIG_NXP_S32_I3C_INTERRUPT
+
+#define TIMEOUT_MS 1000
+
+static int nxp_s32_i3c_transfer_using_interrupt(uint8_t instance, struct i2c_msg *msg,
+					bool read_request, struct nxp_s32_i3c_data *data)
+{
+	I3c_Ip_StatusType status;
+
+	int64_t timeout, current_time;
+
+	if (read_request) {
+		status = I3c_Ip_MasterReceive(instance, msg->buf,
+					msg->len, &data->i3c_transfer_cfg);
+	} else {
+		status = I3c_Ip_MasterSend(instance, msg->buf,
+					msg->len, &data->i3c_transfer_cfg);
+	}
+
+	if (status) {
+		return -EIO;
+	}
+
+	timeout = k_uptime_get() + TIMEOUT_MS;
+
+	/*
+	 * I3C LL callbacks were not intended to inform that a transfer process
+	 * was actually done for transfer next messages. It is encouraged to check
+	 * status of current transfer instead.
+	 */
+	do {
+		status = I3c_Ip_MasterGetTransferStatus(instance, NULL);
+		current_time = k_uptime_get();
+	} while ((status != I3C_IP_STATUS_SUCCESS) &&
+			(status != I3C_IP_STATUS_ERROR) && (current_time < timeout));
+
+	if (current_time >= timeout) {
+		return -ETIMEDOUT;
+	}
+
+	if (status == I3C_IP_STATUS_ERROR) {
+		return -EIO;
+	}
+
+	return 0;
+}
+#else
+static int nxp_s32_i3c_transfer_polling(uint8_t instance, struct i2c_msg *msg,
+					bool read_request, struct nxp_s32_i3c_data *data)
+{
+	I3c_Ip_StatusType status;
+
+	if (read_request) {
+		status = I3c_Ip_MasterReceiveBlocking(instance, msg->buf,
+							msg->len, &data->i3c_transfer_cfg);
+	} else {
+		status = I3c_Ip_MasterSendBlocking(instance, msg->buf,
+							msg->len, &data->i3c_transfer_cfg);
+	}
+
+	if (status != I3C_IP_STATUS_SUCCESS) {
+
+		if (status == I3C_IP_STATUS_TIMEOUT) {
+			return -ETIMEDOUT;
+		}
+		return -EIO;
+	}
+
+	return 0;
+}
+#endif
+
+/**
+ * @brief Transfer messages in I2C mode.
+ *
+ * @see i3c_i2c_transfer
+ *
+ * @param dev Pointer to device driver instance.
+ * @param target Pointer to target device descriptor.
+ * @param msgs Pointer to I2C messages.
+ * @param num_msgs Number of messages to transfers.
+ *
+ * @return @see i3c_i2c_transfer
+ */
+static int nxp_s32_i3c_i2c_transfer(const struct device *dev,
+					struct i3c_i2c_device_desc *i2c_dev,
+					struct i2c_msg *msgs, uint8_t num_msgs)
+{
+	const struct nxp_s32_i3c_config *config = dev->config;
+	struct nxp_s32_i3c_data *data = dev->data;
+	struct i2c_msg *current_msg;
+
+	int ret = 0;
+	bool read_request;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	current_msg = msgs;
+
+	data->i3c_transfer_cfg.SlaveAddress = i2c_dev->addr;
+	data->i3c_transfer_cfg.BusType = I3C_IP_TRANSFER_BYTES;
+	data->i3c_transfer_cfg.BusType = I3C_IP_BUS_TYPE_I2C;
+
+	for (int i = 0; i < num_msgs; i++) {
+
+		if (!!(current_msg->flags & I2C_MSG_ADDR_10_BITS)) {
+			ret = -ENOTSUP;
+			break;
+		}
+
+		/*
+		 * No need to check I2C_MSG_RESTART flag because I3c LL driver
+		 * always requests a START to be emitted before a transfer.
+		 */
+
+		data->i3c_transfer_cfg.SendStop = !!(current_msg->flags & I2C_MSG_STOP);
+
+		if (current_msg->flags & I2C_MSG_READ) {
+			read_request = true;
+			data->i3c_transfer_cfg.Direction = I3C_IP_READ;
+		} else {
+			read_request = false;
+			data->i3c_transfer_cfg.Direction = I3C_IP_WRITE;
+		}
+
+#ifdef CONFIG_NXP_S32_I3C_INTERRUPT
+		ret = nxp_s32_i3c_transfer_using_interrupt(config->instance, current_msg,
+									read_request, data);
+#else
+		ret = nxp_s32_i3c_transfer_polling(config->instance, current_msg,
+								read_request, data);
+#endif
+
+		if (ret) {
+			/* A Timeout or Errors occurred */
+			break;
+		}
+
+		current_msg++;
+	}
+
+	k_mutex_unlock(&data->lock);
+
+	return ret;
+}
+
+/**
+ * @brief Configure I3C hardware.
+ *
+ * @param dev Pointer to controller device driver instance.
+ * @param type Type of configuration parameters being passed
+ *             in @p config.
+ * @param config Pointer to the configuration parameters.
+ *
+ * @retval 0 If successful.
+ * @retval -EINVAL If invalid configure parameters.
+ * @retval -EIO General Input/Output errors.
+ * @retval -ENOSYS If not implemented.
+ */
+static int nxp_s32_i3c_configure(const struct device *dev,
+				enum i3c_config_type type, void *config)
+{
+	const struct nxp_s32_i3c_config *dev_config = dev->config;
+	struct nxp_s32_i3c_data *dev_data = dev->data;
+
+	struct i3c_config_controller *ctrl_cfg = config;
+
+	I3c_Ip_MasterBaudRateType i3c_baud_cfg;
+
+	if (type != I3C_CONFIG_CONTROLLER) {
+		return -EINVAL;
+	}
+
+	/*
+	 * Check for valid configuration parameters.
+	 *
+	 * Currently, must be the primary controller.
+	 */
+	if ((!ctrl_cfg->is_primary) || (ctrl_cfg->scl.i2c == 0U) || (ctrl_cfg->scl.i3c == 0U)) {
+		return -EINVAL;
+	}
+
+	i3c_baud_cfg.I2cBaudRate	= ctrl_cfg->scl.i2c;
+	i3c_baud_cfg.OpenDrainBaudRate	= dev_data->i3c_od_scl_hz;
+	i3c_baud_cfg.PushPullBaudRate	= ctrl_cfg->scl.i3c;
+
+	k_mutex_lock(&dev_data->lock, K_FOREVER);
+
+	if (I3c_Ip_MasterSetBaudRate(dev_config->instance,
+					dev_config->functional_clk,
+					&i3c_baud_cfg, I3C_IP_BUS_TYPE_I2C)) {
+
+		k_mutex_unlock(&dev_data->lock);
+		LOG_ERR("Cannot configure I3C host since the bus is not in idle state\n");
+		return -EIO;
+	}
+
+#if CONFIG_NXP_S32_I3C_LOG_LEVEL_DBG
+	I3c_Ip_MasterGetBaudRate(dev_config->instance, dev_config->functional_clk, &i3c_baud_cfg);
+
+	LOG_DBG("Push-pull baudrate = %d,"
+		" Open-drain baudrate = %d, I2C baudrate = %d\n",
+		i3c_baud_cfg.PushPullBaudRate,
+		i3c_baud_cfg.OpenDrainBaudRate, i3c_baud_cfg.I2cBaudRate);
+#endif
+
+	k_mutex_unlock(&dev_data->lock);
+
+	return 0;
+}
+
+/**
+ * @brief Initialize the hardware.
+ *
+ * @param dev Pointer to controller device driver instance.
+ */
+static int nxp_s32_i3c_init(const struct device *dev)
+{
+	const struct nxp_s32_i3c_config *config = dev->config;
+	struct nxp_s32_i3c_data *data = dev->data;
+	int ret = 0;
+
+	ret = i3c_addr_slots_init(&data->addr_slots, &config->device_list);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+	if (ret != 0) {
+		return ret;
+	}
+
+	k_mutex_init(&data->lock);
+
+	/* Currently can only act as primary controller. */
+	data->ctrl_config.is_primary = true;
+
+	/* HDR mode not supported at the moment. */
+	data->ctrl_config.supported_hdr = 0U;
+
+	I3c_Ip_MasterInit(config->instance, config->i3c_master_cfg);
+
+	/* Configuring baudrate according to devicetree properties, the default
+	 * value will be used in otherwise.
+	 */
+	if (data->ctrl_config.scl.i3c == 0U) {
+		data->ctrl_config.scl.i3c = KHZ(12500);
+	}
+
+	if (data->ctrl_config.scl.i2c == 0U) {
+		data->ctrl_config.scl.i2c = KHZ(400);
+	}
+
+	if (data->i3c_od_scl_hz == 0U) {
+		data->i3c_od_scl_hz = KHZ(2500);
+	}
+
+	ret = nxp_s32_i3c_configure(dev, I3C_CONFIG_CONTROLLER, &data->ctrl_config);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Configure interrupt */
+	config->irq_config_func(dev);
+
+	return 0;
+}
+
+static int nxp_s32_i3c_i2c_api_configure(const struct device *dev, uint32_t dev_config)
+{
+	/* Use i3c_configure API instead */
+	return -ENOSYS;
+}
+
+static int nxp_s32_i3c_i2c_api_transfer(const struct device *dev,
+					struct i2c_msg *msgs,
+					uint8_t num_msgs, uint16_t addr)
+{
+	struct i3c_i2c_device_desc *i2c_dev = nxp_s32_i3c_i2c_device_find(dev, addr);
+	int ret;
+
+	if (i2c_dev == NULL) {
+		ret = -ENODEV;
+	} else {
+		ret = nxp_s32_i3c_i2c_transfer(dev, i2c_dev, msgs, num_msgs);
+	}
+
+	return ret;
+}
+
+void nxp_s32_i3c_master_callback(const struct device *dev, I3c_Ip_MasterEventType event)
+{
+	const struct nxp_s32_i3c_config *config = dev->config;
+
+	uint32_t merrwarn;
+
+	if (event == I3C_IP_MASTER_EVENT_ERROR) {
+		merrwarn = I3c_Ip_MasterGetError(config->instance);
+		LOG_ERR("Errors occurred, MERRWARN = 0x%x\n", merrwarn);
+	}
+}
+
+static const struct i3c_driver_api nxp_s32_i3c_driver_api = {
+	.i2c_api.configure = nxp_s32_i3c_i2c_api_configure,
+	.i2c_api.transfer = nxp_s32_i3c_i2c_api_transfer,
+
+	.configure = nxp_s32_i3c_configure,
+};
+
+#define NXP_S32_I3C_NODE(n)		DT_NODELABEL(i3c##n)
+
+#ifdef CONFIG_NXP_S32_I3C_INTERRUPT
+#define NXP_S32_I3C_DECLARE_INTERRUPT(n)						\
+	extern void I3c##n##_Isr(void);							\
+	static void i3c_s32_config_func_##n(const struct device *dev)			\
+	{										\
+		IRQ_CONNECT(DT_IRQN(NXP_S32_I3C_NODE(n)),				\
+		DT_IRQ(NXP_S32_I3C_NODE(n), priority),					\
+		I3c##n##_Isr,								\
+		DEVICE_DT_GET(NXP_S32_I3C_NODE(n)),					\
+		DT_IRQ_BY_IDX(NXP_S32_I3C_NODE(n), 0, flags));				\
+		irq_enable(DT_IRQN(NXP_S32_I3C_NODE(n)));				\
+	}
+
+#define NXP_S32_I3C_CONFIG_INTERRUPT(n)							\
+	.irq_config_func = i3c_s32_config_func_##n
+#else
+#define NXP_S32_I3C_DECLARE_INTERRUPT(n)
+#define NXP_S32_I3C_CONFIG_INTERRUPT(n)
+#endif /* CONFIG_NXP_S32_I3C_INTERRUPT */
+
+#define NXP_S32_I3C_DEFINE_CALLBACK(n)							\
+	void nxp_s32_i3c_##n##_master_callback(I3c_Ip_MasterEventType Event)		\
+	{										\
+		const struct device *dev = DEVICE_DT_GET(NXP_S32_I3C_NODE(n));		\
+											\
+		nxp_s32_i3c_master_callback(dev, Event);				\
+	}
+
+#define NXP_S32_I3C_S32_CONFIG(n)							\
+	static I3c_Ip_MasterStateType nxp_s32_i3c_##n##_state =				\
+	{										\
+		0U,									\
+		NULL_PTR,								\
+		NULL_PTR,								\
+		I3C_IP_STATUS_SUCCESS,							\
+		{									\
+			0x00,								\
+			(boolean)FALSE,							\
+			I3C_IP_WRITE,							\
+			I3C_IP_TRANSFER_BYTES,						\
+			I3C_IP_BUS_TYPE_I2C						\
+		},									\
+		I3C_IP_USING_INTERRUPTS,						\
+		(boolean)FALSE,								\
+		(I3c_Ip_MasterCallbackType)nxp_s32_i3c_##n##_master_callback,		\
+	};										\
+											\
+	static const I3c_Ip_MasterConfigType nxp_s32_i3c_##n##_config =			\
+	{										\
+		I3C_IP_MASTER_ON,							\
+		(boolean)TRUE,								\
+		I3C_IP_MASTER_HIGH_KEEPER_NONE,						\
+		0U,									\
+		0U,									\
+		0U,									\
+		0U,									\
+		(boolean)FALSE,								\
+		0U,									\
+		(boolean)FALSE,								\
+		(boolean)FALSE,								\
+		&nxp_s32_i3c_##n##_state,						\
+	};
+
+#define NXP_S32_I3C_INIT_DEVICE(n)							\
+	NXP_S32_I3C_DEFINE_CALLBACK(n)							\
+	NXP_S32_I3C_DECLARE_INTERRUPT(n)						\
+	NXP_S32_I3C_S32_CONFIG(n)							\
+	PINCTRL_DT_DEFINE(NXP_S32_I3C_NODE(n));						\
+	static struct nxp_s32_i3c_data nxp_s32_i3c_data_##n;				\
+	static struct i3c_device_desc s32_i3c_device_array[] =				\
+		I3C_DEVICE_ARRAY_DT(NXP_S32_I3C_NODE(n));				\
+	static struct i3c_i2c_device_desc s32_i3c_i2c_device_array[] =			\
+		I3C_I2C_DEVICE_ARRAY_DT(NXP_S32_I3C_NODE(n));				\
+	static const struct nxp_s32_i3c_config nxp_s32_i3c_config_##n = {		\
+		.instance	 = n,							\
+		.functional_clk  = DT_PROP(NXP_S32_I3C_NODE(n), clock_frequency),	\
+		.i3c_master_cfg  = (I3c_Ip_MasterConfigType *)&nxp_s32_i3c_##n##_config,\
+		.device_list.i3c = s32_i3c_device_array,				\
+		.device_list.num_i3c = ARRAY_SIZE(s32_i3c_device_array),		\
+		.device_list.i2c = s32_i3c_i2c_device_array,				\
+		.device_list.num_i2c = ARRAY_SIZE(s32_i3c_i2c_device_array),		\
+		.pincfg = PINCTRL_DT_DEV_CONFIG_GET(NXP_S32_I3C_NODE(n)),		\
+		NXP_S32_I3C_CONFIG_INTERRUPT(n)						\
+	};										\
+	static struct nxp_s32_i3c_data nxp_s32_i3c_data_##n = {				\
+		.ctrl_config = {							\
+			.scl = {							\
+				.i3c = DT_PROP_OR(NXP_S32_I3C_NODE(n), i3c_scl_hz, 0),	\
+				.i2c = DT_PROP_OR(NXP_S32_I3C_NODE(n), i2c_scl_hz, 0),	\
+			},								\
+		},									\
+		.i3c_od_scl_hz = DT_PROP_OR(NXP_S32_I3C_NODE(n), i3c_od_scl_hz, 0),	\
+	};										\
+	DEVICE_DT_DEFINE(NXP_S32_I3C_NODE(n),						\
+			nxp_s32_i3c_init,						\
+			NULL,								\
+			&nxp_s32_i3c_data_##n,						\
+			&nxp_s32_i3c_config_##n,					\
+			POST_KERNEL,							\
+			CONFIG_I3C_CONTROLLER_INIT_PRIORITY,				\
+			&nxp_s32_i3c_driver_api);
+
+#if DT_NODE_HAS_STATUS(NXP_S32_I3C_NODE(0), okay)
+NXP_S32_I3C_INIT_DEVICE(0)
+#endif
+
+#if DT_NODE_HAS_STATUS(NXP_S32_I3C_NODE(1), okay)
+NXP_S32_I3C_INIT_DEVICE(1)
+#endif
+
+#if DT_NODE_HAS_STATUS(NXP_S32_I3C_NODE(2), okay)
+NXP_S32_I3C_INIT_DEVICE(2)
+#endif

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -533,5 +533,32 @@
 			#size-cells = <0>;
 			status = "disabled";
 		};
+
+		i3c0: i3c@401d0000 {
+			compatible = "nxp,s32-i3c";
+			reg = <0x401d0000 0x10000>;
+			#address-cells = <3>;
+			#size-cells = <0>;
+			interrupts = <GIC_SPI 252 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		i3c1: i3c@409d0000 {
+			compatible = "nxp,s32-i3c";
+			reg = <0x409d0000 0x10000>;
+			#address-cells = <3>;
+			#size-cells = <0>;
+			interrupts = <GIC_SPI 253 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		i3c2: i3c@421d0000 {
+			compatible = "nxp,s32-i3c";
+			reg = <0x421d0000 0x10000>;
+			#address-cells = <3>;
+			#size-cells = <0>;
+			interrupts = <GIC_SPI 254 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/bindings/i3c/nxp,s32-i3c.yaml
+++ b/dts/bindings/i3c/nxp,s32-i3c.yaml
@@ -1,0 +1,33 @@
+# Copyright 2022 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP S32 I3C controller
+
+compatible: "nxp,s32-i3c"
+
+include: [i3c-controller.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  clock-frequency:
+    required: true
+    type: int
+    description: |
+      Functional clock (in Hz) for I3C operation.
+
+  interrupts:
+    required: true
+
+  i3c-od-scl-hz:
+    type: int
+    required: false
+    description: |
+      Open Drain frequency (in Hz) for the I3C controller. The frequency
+      is fixed and cannot be changed. This is together with Push-pull and
+      I2c frequency which can be set via i3c_configure API to change the
+      baudrate at run time.
+
+      When undefined, the default value will be used as specified by the
+      I3C specification.

--- a/samples/boards/nxp_s32/i3c_at24c01_eeprom/CMakeLists.txt
+++ b/samples/boards/nxp_s32/i3c_at24c01_eeprom/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright 2022 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(i3c_at24c01_eeprom)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/boards/nxp_s32/i3c_at24c01_eeprom/README.rst
+++ b/samples/boards/nxp_s32/i3c_at24c01_eeprom/README.rst
@@ -1,0 +1,33 @@
+.. nxp_s32_i3c_eeprom
+
+NXP_S32 I3C EEPROM
+##################
+
+Overview
+********
+This is a sample app to read and write the Microchip AT24C01C-XHM EEPROM chip via
+I3C driver.
+
+This assumes the slave address of EEPROM is 0x50.
+
+Building and Running
+********************
+
+This project can be built and executed on as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/boards/nxp_s32/i3c_at24c01_eeprom
+   :board: s32z270dc2_rtu0_r52
+   :goals: build flash
+   :compact:
+
+Sample Output
+=============
+
+.. code-block:: console
+
+   Wrote 0x1 to address 0x10
+   Read 0x1 from address 0x10
+   Wrote 20 bytes to address starting from 0x10
+   Read 20 bytes from starting address 0x10
+   EEPROM read/write successful

--- a/samples/boards/nxp_s32/i3c_at24c01_eeprom/boards/s32z270dc2_rtu0_r52.overlay
+++ b/samples/boards/nxp_s32/i3c_at24c01_eeprom/boards/s32z270dc2_rtu0_r52.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Pins 3 and 5, 4 and 6 of J32 must be connected on the board */
+&pinctrl {
+	i3c2_default: i3c2_default {
+		group1 {
+			pinmux = <(PJ11_I3C_2_SDA0_I | PJ11_I3C_2_SDA0_O)>,
+				<(PJ10_I3C_2_SCL_I | PJ10_I3C_2_SCL_O)>;
+			input-enable;
+			output-enable;
+			drive-open-drain;
+		};
+	};
+};
+
+&i3c2 {
+	/* Just configure to reach i2c rate around 400Khz */
+	i2c-scl-hz = <400000>;
+	i3c-scl-hz = <6000000>;
+	i3c-od-scl-hz = <2000000>;
+
+	pinctrl-0 = <&i3c2_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom: eeprom@500000000000000050 {
+		compatible = "atmel,at24-i3c";
+		reg = <0x50 00 0x50>;
+	};
+};

--- a/samples/boards/nxp_s32/i3c_at24c01_eeprom/boards/s32z270dc2_rtu1_r52.overlay
+++ b/samples/boards/nxp_s32/i3c_at24c01_eeprom/boards/s32z270dc2_rtu1_r52.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Pins 3 and 5, 4 and 6 of J32 must be connected on the board */
+&pinctrl {
+	i3c2_default: i3c2_default {
+		group1 {
+			pinmux = <(PJ11_I3C_2_SDA0_I | PJ11_I3C_2_SDA0_O)>,
+				<(PJ10_I3C_2_SCL_I | PJ10_I3C_2_SCL_O)>;
+			input-enable;
+			output-enable;
+			drive-open-drain;
+		};
+	};
+};
+
+&i3c2 {
+	/* Just configure to reach i2c rate around 400Khz */
+	i2c-scl-hz = <400000>;
+	i3c-scl-hz = <6000000>;
+	i3c-od-scl-hz = <2000000>;
+
+	pinctrl-0 = <&i3c2_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom: eeprom@500000000000000050 {
+		compatible = "atmel,at24-i3c";
+		reg = <0x50 00 0x50>;
+	};
+};

--- a/samples/boards/nxp_s32/i3c_at24c01_eeprom/dts/bindings/atmel,at24-i3c.yaml
+++ b/samples/boards/nxp_s32/i3c_at24c01_eeprom/dts/bindings/atmel,at24-i3c.yaml
@@ -1,0 +1,8 @@
+# Copyright 2022 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: Atmel AT24 (or compatible) I2C EEPROM on I3C bus
+
+compatible: "atmel,at24-i3c"
+
+include: [i3c-device.yaml]

--- a/samples/boards/nxp_s32/i3c_at24c01_eeprom/prj.conf
+++ b/samples/boards/nxp_s32/i3c_at24c01_eeprom/prj.conf
@@ -1,0 +1,6 @@
+# Copyright 2022 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_I3C=y

--- a/samples/boards/nxp_s32/i3c_at24c01_eeprom/sample.yaml
+++ b/samples/boards/nxp_s32/i3c_at24c01_eeprom/sample.yaml
@@ -1,0 +1,14 @@
+# Copyright 2022 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+sample:
+  name: Sample for communitcate Microchip AT24C01C-XHM EEPROM through I3C driver.
+tests:
+  sample.boards.nxp_s32.i3c.at24c01c.eeprom:
+    tags: i3c
+    platform_allow: s32z270dc2_rtu0_r52 s32z270dc2_rtu1_r52
+    harness: console
+    harness_config:
+        type: one_line
+        regex:
+            - "EEPROM read/write successful"

--- a/samples/boards/nxp_s32/i3c_at24c01_eeprom/src/main.c
+++ b/samples/boards/nxp_s32/i3c_at24c01_eeprom/src/main.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/i3c.h>
+#include <zephyr/device.h>
+#include <string.h>
+
+/**
+ * @file Sample app using the Microchip AT24C01C-XHM EEPROM through I3C driver.
+ */
+
+#define I3C_DEV_NODE	DT_NODELABEL(i3c2)
+#define I2C_SLAVE_ADDR	0x50
+
+/* Starting EEP address for writing to / reading from */
+#define EEP_START_ADDR 0x10
+#define NUM_BYTES	20
+
+uint8_t read_data[NUM_BYTES];
+
+#define DATA_TO_WRITE(n, _) (n + 1)
+
+uint8_t data_to_write[NUM_BYTES] = {
+	LISTIFY(NUM_BYTES, DATA_TO_WRITE, (,))
+};
+
+static int write_bytes(const struct device *dev, uint8_t addr, uint8_t *data, uint8_t num_bytes)
+{
+	uint8_t i, curr_addr;
+	int err;
+
+	uint8_t write_buf[2];
+	struct i2c_msg msg[2];
+
+	err = 0;
+	curr_addr = addr;
+
+	for (i = 0; i < num_bytes; i++) {
+
+		write_buf[0] = curr_addr;
+		write_buf[1] = data[i];
+
+		msg[0].buf = write_buf;
+		msg[0].len = 2;
+		msg[0].flags = I2C_MSG_WRITE | I2C_MSG_STOP;
+
+		err = i2c_transfer(dev, msg, 1, I2C_SLAVE_ADDR);
+		if (err) {
+			break;
+		}
+
+		curr_addr++;
+
+		k_sleep(K_MSEC(2));
+	}
+
+	return err;
+}
+
+static int read_bytes(const struct device *dev, uint8_t addr, uint8_t *data, uint8_t num_bytes)
+{
+	uint8_t i, curr_addr;
+	int err;
+	struct i2c_msg msg[2];
+
+	err = 0;
+	curr_addr = addr;
+
+	/* Read data */
+	for (i = 0; i < num_bytes; i++) {
+
+		/* Send a byte that contain the memory address will be read */
+		msg[0].buf = &curr_addr;
+		msg[0].len = 1;
+		msg[0].flags = I2C_MSG_WRITE;
+
+		msg[1].buf = &data[i];
+		msg[1].len = 1;
+		msg[1].flags = I2C_MSG_READ | I2C_MSG_STOP;
+
+		err = i2c_transfer(dev, msg, 2, I2C_SLAVE_ADDR);
+		if (err) {
+			break;
+		}
+
+		curr_addr++;
+
+		k_sleep(K_MSEC(2));
+	}
+
+	return err;
+}
+
+void main(void)
+{
+	const struct device *i3c_dev;
+	int err;
+
+	i3c_dev = DEVICE_DT_GET(I3C_DEV_NODE);
+
+	if (!i3c_dev) {
+		printk("Cannot get device\n");
+		return;
+	}
+
+	if (!device_is_ready(i3c_dev)) {
+		printk("Device is not ready\n");
+		return;
+	}
+
+	err = write_bytes(i3c_dev, EEP_START_ADDR, &data_to_write[0], 1);
+	if (err) {
+		printk("Error writing a byte to EEPROM, error code (%d)\n", err);
+		return;
+	}
+
+	printk("Wrote 0x%X to address 0x%X\n", data_to_write[0], EEP_START_ADDR);
+
+	err = read_bytes(i3c_dev, EEP_START_ADDR, &read_data[0], 1);
+	if (err) {
+		printk("Error reading a byte from EEPROM, error code (%d)\n", err);
+		return;
+	}
+
+	printk("Read 0x%X from address 0x%X\n", read_data[0], EEP_START_ADDR);
+
+	/* Compare data */
+	if (memcmp(read_data, data_to_write, 1)) {
+		printk("Sent and received data is not the same");
+		return;
+	}
+
+	err = write_bytes(i3c_dev, EEP_START_ADDR, data_to_write, NUM_BYTES);
+	if (err) {
+		printk("Error writing %d bytes to EEPROM, error code (%d)\n", NUM_BYTES, err);
+		return;
+	}
+
+	printk("Wrote %d bytes to address starting from 0x%X\n",
+			NUM_BYTES, EEP_START_ADDR);
+
+	err = read_bytes(i3c_dev, EEP_START_ADDR, read_data, NUM_BYTES);
+	if (err) {
+		printk("Error reading %d bytes from EEPROM! error code (%d)\n", NUM_BYTES, err);
+		return;
+	}
+
+	printk("Read %d bytes from starting address 0x%X\n",
+			NUM_BYTES, EEP_START_ADDR);
+
+	/* Compare data */
+	if (memcmp(read_data, data_to_write, NUM_BYTES)) {
+		printk("Sent and received data is not the same");
+		return;
+	}
+
+	printk("EEPROM read/write successful\n");
+}

--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 138742f66576f2e2235a072425e71b8d1360c0d3
+      revision: pull/207/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This PR introduces NXP S32 I3C driver for SoC NXP S32Z27 and enable its usage for board s32z270dc2.

The initial version only adds support for minimal APIs to allow an I3C primary controller can configure and
communicate with I2C targets on I3C bus.

A sample demonstrates for transferring data between an i3c primary controller and an i2c target (EEPROM) is also added, for this board.