### PR TITLE
soc: xtensa: ipc: unmask intc for core 0 only

### DIFF
--- a/soc/xtensa/intel_adsp/common/ipc.c
+++ b/soc/xtensa/intel_adsp/common/ipc.c
@@ -171,11 +171,7 @@ bool intel_adsp_ipc_send_message_sync(const struct device *dev,
 #if defined(CONFIG_SOC_SERIES_INTEL_ACE)
 static inline void ace_ipc_intc_unmask(void)
 {
-	unsigned int num_cpus = arch_num_cpus();
-
-	for (int i = 0; i < num_cpus; i++) {
-		ACE_DINT[i].ie[ACE_INTL_HIPC] = BIT(0);
-	}
+	ACE_DINT[0].ie[ACE_INTL_HIPC] = BIT(0);
 }
 #else
 static inline void ace_ipc_intc_unmask(void) {}


### PR DESCRIPTION
In ACE architecture, only core 0 should receive IPC interrupts from host. 

Unmasking secondary core IPC interrupts was causing race condition in ipc irq handler after enabling secondary core.
When secondary core entered ipc irq handler first, it cleared BUSY bit. Then Core0 handler quit the handler without servicing IPC.