### PR TITLE
Bluetooth: controller: Add support for Read/Write Conn. Accept Timeout

### DIFF
--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -508,6 +508,21 @@ struct bt_hci_write_local_name {
 	uint8_t local_name[248];
 } __packed;
 
+#define BT_HCI_OP_READ_CONN_ACCEPT_TIMEOUT      BT_OP(BT_OGF_BASEBAND, 0x0015)
+struct bt_hci_rp_read_conn_accept_timeout {
+	uint8_t  status;
+	uint16_t conn_accept_timeout;
+} __packed;
+
+#define BT_HCI_OP_WRITE_CONN_ACCEPT_TIMEOUT     BT_OP(BT_OGF_BASEBAND, 0x0016)
+struct bt_hci_cp_write_conn_accept_timeout {
+	uint16_t conn_accept_timeout;
+} __packed;
+
+struct bt_hci_rp_write_conn_accept_timeout {
+	uint8_t  status;
+} __packed;
+
 #define BT_HCI_OP_WRITE_PAGE_TIMEOUT            BT_OP(BT_OGF_BASEBAND, 0x0018)
 
 #define BT_HCI_OP_WRITE_SCAN_ENABLE             BT_OP(BT_OGF_BASEBAND, 0x001a)

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -324,6 +324,9 @@ void ll_iso_tx_mem_release(void *tx);
 int ll_iso_tx_mem_enqueue(uint16_t handle, void *tx, void *link);
 void ll_iso_link_tx_release(void *link);
 
+uint8_t ll_conn_iso_accept_timeout_get(uint16_t *timeout);
+uint8_t ll_conn_iso_accept_timeout_set(uint16_t timeout);
+
 /* External co-operation */
 void ll_timeslice_ticker_id_get(uint8_t * const instance_index,
 				uint8_t * const ticker_id);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -75,6 +75,12 @@ static void *cis_free;
 static struct ll_conn_iso_group cig_pool[CONFIG_BT_CTLR_CONN_ISO_GROUPS];
 static void *cig_free;
 
+/* BT. 5.3 Spec - Vol 4, Part E, Sect 6.7 */
+#define CONN_ACCEPT_TIMEOUT_DEFAULT 0x1F40
+#define CONN_ACCEPT_TIMEOUT_MAX     0xB540
+#define CONN_ACCEPT_TIMEOUT_MIN     0x0001
+static uint16_t conn_accept_timeout;
+
 struct ll_conn_iso_group *ll_conn_iso_group_acquire(void)
 {
 	return mem_acquire(&cig_free);
@@ -228,6 +234,25 @@ struct ll_conn_iso_stream *ll_conn_iso_stream_get_by_group(struct ll_conn_iso_gr
 	}
 
 	return NULL;
+}
+
+uint8_t ll_conn_iso_accept_timeout_get(uint16_t *timeout)
+{
+	*timeout = conn_accept_timeout;
+
+	return 0;
+}
+
+uint8_t ll_conn_iso_accept_timeout_set(uint16_t timeout)
+{
+	if (!IN_RANGE(timeout, CONN_ACCEPT_TIMEOUT_MIN,
+			       CONN_ACCEPT_TIMEOUT_MAX)) {
+		return BT_HCI_ERR_INVALID_LL_PARAM;
+	}
+
+	conn_accept_timeout = timeout;
+
+	return 0;
 }
 
 void ull_conn_iso_cis_established(struct ll_conn_iso_stream *cis)
@@ -477,6 +502,8 @@ static int init_reset(void)
 		cis->cis_id = 0;
 		cis->group  = NULL;
 	}
+
+	conn_accept_timeout = CONN_ACCEPT_TIMEOUT_DEFAULT;
 
 	/* Initialize LLL */
 	err = lll_conn_iso_init();

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -219,9 +219,17 @@ void ull_periph_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 	ull_cp_prt_reload_set(conn, conn_interval_us);
 #endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 
-#if (!defined(CONFIG_BT_LL_SW_LLCP_LEGACY))
+#if !defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
+#if defined(CONFIG_BT_CTLR_CONN_ISO)
+	uint16_t conn_accept_timeout;
+
+	(void)ll_conn_iso_accept_timeout_get(&conn_accept_timeout);
+	conn->connect_accept_to = conn_accept_timeout * 625U;
+#else
 	conn->connect_accept_to = DEFAULT_CONNECTION_ACCEPT_TIMEOUT_US;
-#endif /* !defined(CONFIG_BT_LL_SW_LLCP_LEGACY) */
+#endif /* CONFIG_BT_CTLR_CONN_ISO */
+#endif /* !CONFIG_BT_LL_SW_LLCP_LEGACY */
+
 #if defined(CONFIG_BT_CTLR_LE_PING)
 	/* APTO in no. of connection events */
 	conn->apto_reload = RADIO_CONN_EVENTS((30 * 1000 * 1000),


### PR DESCRIPTION
Implement HCI commands HCI_Read_Connection_Accept_Timeout and HCI_Write_Connection_Accept_Timeout, and enable the feature in supported commands.
Remove hardcoded use of default accept timeout in new LLCP code, and use configurable value instead.

This makes EBQ test /HCI/CIN/BV-03-C pass.

Signed-off-by: Morten Priess <mtpr@oticon.com>