### PR TITLE
Fix: -Wextra warnings

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/fault.c
+++ b/arch/arm/core/aarch32/cortex_m/fault.c
@@ -46,7 +46,7 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 /* Prefix. Indicates that this is an EXC_RETURN value.
  * This field reads as 0b11111111.
  */
-#define EXC_RETURN_INDICATOR_PREFIX     (0xFF << 24)
+#define EXC_RETURN_INDICATOR_PREFIX     (0xFFLU << 24)
 /* bit[0]: Exception Secure. The security domain the exception was taken to. */
 #define EXC_RETURN_EXCEPTION_SECURE_Pos 0
 #define EXC_RETURN_EXCEPTION_SECURE_Msk \
@@ -900,7 +900,7 @@ static inline z_arch_esf_t *get_esf(uint32_t msp, uint32_t psp, uint32_t exc_ret
 	*nested_exc = false;
 
 	if ((exc_return & EXC_RETURN_INDICATOR_PREFIX) !=
-			(uint32_t)EXC_RETURN_INDICATOR_PREFIX) {
+			EXC_RETURN_INDICATOR_PREFIX) {
 		/* Invalid EXC_RETURN value. This is a fatal error. */
 		return NULL;
 	}

--- a/arch/arm/core/aarch32/cortex_m/fault.c
+++ b/arch/arm/core/aarch32/cortex_m/fault.c
@@ -900,7 +900,7 @@ static inline z_arch_esf_t *get_esf(uint32_t msp, uint32_t psp, uint32_t exc_ret
 	*nested_exc = false;
 
 	if ((exc_return & EXC_RETURN_INDICATOR_PREFIX) !=
-			EXC_RETURN_INDICATOR_PREFIX) {
+			(uint32_t)EXC_RETURN_INDICATOR_PREFIX) {
 		/* Invalid EXC_RETURN value. This is a fatal error. */
 		return NULL;
 	}

--- a/arch/arm/core/aarch32/thread.c
+++ b/arch/arm/core/aarch32/thread.c
@@ -339,7 +339,7 @@ void configure_builtin_stack_guard(struct k_thread *thread)
 #if defined(CONFIG_MPU_STACK_GUARD) || defined(CONFIG_USERSPACE)
 
 #define IS_MPU_GUARD_VIOLATION(guard_start, guard_len, fault_addr, stack_ptr) \
-	((fault_addr != -EINVAL) ? \
+	(((int)fault_addr != -EINVAL) ? \
 	((fault_addr >= guard_start) && \
 	(fault_addr < (guard_start + guard_len)) && \
 	(stack_ptr < (guard_start + guard_len))) \

--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -113,7 +113,7 @@ void stm32_exti_enable(int line)
 {
 	int irqnum = 0;
 
-	if (line >= ARRAY_SIZE(exti_irq_table)) {
+	if (line >= (int)ARRAY_SIZE(exti_irq_table)) {
 		__ASSERT_NO_MSG(line);
 	}
 

--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -109,11 +109,11 @@ struct stm32_exti_data {
 	struct __exti_cb cb[ARRAY_SIZE(exti_irq_table)];
 };
 
-void stm32_exti_enable(int line)
+void stm32_exti_enable(unsigned int line)
 {
 	int irqnum = 0;
 
-	if (line >= (int)ARRAY_SIZE(exti_irq_table)) {
+	if (line >= ARRAY_SIZE(exti_irq_table)) {
 		__ASSERT_NO_MSG(line);
 	}
 
@@ -134,7 +134,7 @@ void stm32_exti_enable(int line)
 	irq_enable(irqnum);
 }
 
-void stm32_exti_disable(int line)
+void stm32_exti_disable(unsigned int line)
 {
 	z_stm32_hsem_lock(CFG_HW_EXTI_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -201,8 +201,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		delay =
 		 ((delay + CYC_PER_TICK - 1) / CYC_PER_TICK) * CYC_PER_TICK;
 		delay -= unannounced;
-		delay = MAX(delay, MIN_DELAY);
-		if (delay > MAX_CYCLES) {
+		delay = MAX(delay, (uint32_t)MIN_DELAY);
+		if (delay > (uint32_t)MAX_CYCLES) {
 			last_load = MAX_CYCLES;
 		} else {
 			last_load = delay;

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -15,7 +15,7 @@
 
 #define CYC_PER_TICK (sys_clock_hw_cycles_per_sec()	\
 		      / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-#define MAX_TICKS ((COUNTER_MAX / CYC_PER_TICK) - 1)
+#define MAX_TICKS ((k_ticks_t)((COUNTER_MAX / CYC_PER_TICK) - 1))
 #define MAX_CYCLES (MAX_TICKS * CYC_PER_TICK)
 
 /* Minimum cycles in the future to try to program.  Note that this is
@@ -27,7 +27,7 @@
  * masked.  Choosing a fraction of a tick is probably a good enough
  * default, with an absolute minimum of 1k cyc.
  */
-#define MIN_DELAY MAX(1024, (CYC_PER_TICK/16))
+#define MIN_DELAY MAX(1024U, ((k_ticks_t)CYC_PER_TICK/16U))
 
 #define TICKLESS (IS_ENABLED(CONFIG_TICKLESS_KERNEL))
 
@@ -201,8 +201,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		delay =
 		 ((delay + CYC_PER_TICK - 1) / CYC_PER_TICK) * CYC_PER_TICK;
 		delay -= unannounced;
-		delay = MAX(delay, (uint32_t)MIN_DELAY);
-		if (delay > (uint32_t)MAX_CYCLES) {
+		delay = MAX(delay, MIN_DELAY);
+		if (delay > MAX_CYCLES) {
 			last_load = MAX_CYCLES;
 		} else {
 			last_load = delay;

--- a/include/zephyr/drivers/interrupt_controller/exti_stm32.h
+++ b/include/zephyr/drivers/interrupt_controller/exti_stm32.h
@@ -28,14 +28,14 @@
  *
  * @param line EXTI# line
  */
-void stm32_exti_enable(int line);
+void stm32_exti_enable(unsigned int line);
 
 /**
  * @brief disable EXTI interrupt for specific line
  *
  * @param line EXTI# line
  */
-void stm32_exti_disable(int line);
+void stm32_exti_disable(unsigned int line);
 
 /**
  * @brief EXTI trigger flags

--- a/lib/os/bitarray.c
+++ b/lib/os/bitarray.c
@@ -67,7 +67,7 @@ static bool match_region(sys_bitarray_t *bitarray, size_t offset,
 			 struct bundle_data *bd,
 			 size_t *mismatch)
 {
-	int idx;
+	size_t idx;
 	uint32_t bundle;
 	uint32_t mismatch_bundle;
 	size_t mismatch_bundle_idx;
@@ -173,7 +173,7 @@ static void set_region(sys_bitarray_t *bitarray, size_t offset,
 		       size_t num_bits, bool to_set,
 		       struct bundle_data *bd)
 {
-	int idx;
+	size_t idx;
 	struct bundle_data bdata;
 
 	if (bd == NULL) {
@@ -414,16 +414,16 @@ int sys_bitarray_alloc(sys_bitarray_t *bitarray, size_t num_bits,
 	 * On RISC-V 64-bit, it complains about undefined reference to `ffs`.
 	 * So don't use this on RISCV64.
 	 */
-	for (ret = 0; ret < bitarray->num_bundles; ret++) {
-		if (~bitarray->bundles[ret] == 0U) {
+	for (uint32_t bundle = 0; bundle < bitarray->num_bundles; bundle++) {
+		if (~bitarray->bundles[bundle] == 0U) {
 			/* bundle is all 1s => all allocated, skip */
 			bit_idx += bundle_bitness(bitarray);
 			continue;
 		}
 
-		if (bitarray->bundles[ret] != 0U) {
+		if (bitarray->bundles[bundle] != 0U) {
 			/* Find the first free bit in bundle if not all free */
-			off_start = find_lsb_set(~bitarray->bundles[ret]) - 1;
+			off_start = find_lsb_set(~bitarray->bundles[bundle]) - 1;
 			bit_idx += off_start;
 		}
 

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1601,7 +1601,7 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
 		}
 		case 'c':
 			bps = buf;
-			buf[0] = CHAR_IS_SIGNED ? value->sint : value->uint;
+			buf[0] = CHAR_IS_SIGNED ? (char)value->sint : (char)value->uint;
 			bpe = buf + 1;
 			break;
 		case 'd':

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -212,7 +212,7 @@ static size_t get_package_len(void *packaged)
 	buf += ros_nbr;
 
 	/* Move beyond strings appended to the package. */
-	for (int i = 0; i < s_nbr; i++) {
+	for (unsigned int i = 0; i < s_nbr; i++) {
 		buf++;
 		buf += strlen((const char *)buf) + 1;
 	}
@@ -970,7 +970,7 @@ int cbprintf_package_convert(void *in_packaged,
 	if (cb == NULL) {
 		out_len = (int)in_len;
 		if (ro_cpy) {
-			for (int i = 0; i < ros_nbr; i++) {
+			for (unsigned int i = 0; i < ros_nbr; i++) {
 				const char *str = *(const char **)&buf32[*str_pos];
 				int len = append_string(cb, NULL, str, 0);
 
@@ -992,7 +992,7 @@ int cbprintf_package_convert(void *in_packaged,
 					 CBPRINTF_PACKAGE_CONVERT_RO_STR));
 
 		/* Handle RW strings. */
-		for (int i = 0; i < rws_nbr; i++) {
+		for (unsigned int i = 0; i < rws_nbr; i++) {
 			uint8_t arg_idx = *str_pos++;
 			uint8_t arg_pos = *str_pos++;
 			const char *str = *(const char **)&buf32[arg_pos];
@@ -1071,7 +1071,7 @@ calculate_string_length:
 	 * Note that there may be read-only strings there. Use address evaluation
 	 * to determine if strings is read-only.
 	 */
-	for (int i = 0; i < rws_nbr; i++) {
+	for (unsigned int i = 0; i < rws_nbr; i++) {
 		uint8_t arg_idx = *str_pos++;
 		uint8_t arg_pos = *str_pos++;
 		const char *str = *(const char **)&buf32[arg_pos];

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -96,7 +96,7 @@ static int _find_fd_entry(void)
 {
 	int fd;
 
-	for (fd = 0; fd < ARRAY_SIZE(fdtable); fd++) {
+	for (fd = 0; fd < (int)ARRAY_SIZE(fdtable); fd++) {
 		if (!atomic_get(&fdtable[fd].refcount)) {
 			return fd;
 		}
@@ -108,7 +108,7 @@ static int _find_fd_entry(void)
 
 static int _check_fd(int fd)
 {
-	if (fd < 0 || fd >= ARRAY_SIZE(fdtable)) {
+	if (fd < 0 || fd >= (int)ARRAY_SIZE(fdtable)) {
 		errno = EBADF;
 		return -1;
 	}

--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -285,7 +285,7 @@ static void cdc_acm_read_cb(uint8_t ep, int size, void *priv)
 	}
 
 	wrote = ring_buf_put(dev_data->rx_ringbuf, dev_data->rx_buf, size);
-	if (wrote < size) {
+	if ((int)wrote >= 0 && (int)wrote < size) {
 		LOG_ERR("Ring buffer full, drop %zd bytes", size - wrote);
 	}
 
@@ -517,7 +517,7 @@ static int cdc_acm_fifo_fill(const struct device *dev,
 	dev_data->tx_ready = false;
 
 	wrote = ring_buf_put(dev_data->tx_ringbuf, tx_data, len);
-	if (wrote < len) {
+	if ((int)wrote >= 0 && (int)wrote < len) {
 		LOG_WRN("Ring buffer full, drop %zd bytes", len - wrote);
 	}
 

--- a/subsys/usb/device/usb_transfer.c
+++ b/subsys/usb/device/usb_transfer.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
 #include <zephyr/kernel.h>
 #include <zephyr/usb/usb_device.h>
 #include <zephyr/logging/log.h>
@@ -50,7 +51,7 @@ static struct usb_transfer_data ut_data[CONFIG_USB_MAX_NUM_TRANSFERS];
 /* Transfer management */
 static struct usb_transfer_data *usb_ep_get_transfer(uint8_t ep)
 {
-	for (int i = 0; i < ARRAY_SIZE(ut_data); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(ut_data); i++) {
 		if (ut_data[i].ep == ep && ut_data[i].status != 0) {
 			return &ut_data[i];
 		}
@@ -198,7 +199,7 @@ int usb_transfer(uint8_t ep, uint8_t *data, size_t dlen, unsigned int flags,
 		 usb_transfer_callback cb, void *cb_data)
 {
 	struct usb_transfer_data *trans = NULL;
-	int i, key, ret = 0;
+	int key, ret = 0;
 
 	/* Parallel transfer to same endpoint is not supported. */
 	if (usb_transfer_is_busy(ep)) {
@@ -210,7 +211,7 @@ int usb_transfer(uint8_t ep, uint8_t *data, size_t dlen, unsigned int flags,
 
 	key = irq_lock();
 
-	for (i = 0; i < ARRAY_SIZE(ut_data); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(ut_data); i++) {
 		if (!k_sem_take(&ut_data[i].sem, K_NO_WAIT)) {
 			trans = &ut_data[i];
 			break;
@@ -284,7 +285,7 @@ done:
 
 void usb_cancel_transfers(void)
 {
-	for (int i = 0; i < ARRAY_SIZE(ut_data); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(ut_data); i++) {
 		struct usb_transfer_data *trans = &ut_data[i];
 		unsigned int key;
 
@@ -344,7 +345,7 @@ int usb_transfer_sync(uint8_t ep, uint8_t *data, size_t dlen, unsigned int flags
 /* Init transfer slots */
 int usb_transfer_init(void)
 {
-	for (int i = 0; i < ARRAY_SIZE(ut_data); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(ut_data); i++) {
 		k_work_init(&ut_data[i].work, usb_transfer_work);
 		k_sem_init(&ut_data[i].sem, 1, 1);
 	}


### PR DESCRIPTION
Fix warnings generated from `-Wextra -Wno-unused-parameter` compiler flags.

Related to issue #30914 