### PR TITLE
net: openthread: fix `otPlatRadioSetMacKey` when asserts are disabled

### DIFF
--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -1044,16 +1044,20 @@ void otPlatRadioSetMacKey(otInstance *aInstance, uint8_t aKeyIdMode, uint8_t aKe
 #if defined(CONFIG_OPENTHREAD_PLATFORM_KEYS_EXPORTABLE_ENABLE)
 	__ASSERT_NO_MSG(aKeyType == OT_KEY_TYPE_KEY_REF);
 	size_t keyLen;
+	otError error;
 
-	__ASSERT_NO_MSG(otPlatCryptoExportKey(aPrevKey->mKeyMaterial.mKeyRef,
-					      (uint8_t *)aPrevKey->mKeyMaterial.mKey.m8,
-					      OT_MAC_KEY_SIZE, &keyLen) == OT_ERROR_NONE);
-	__ASSERT_NO_MSG(otPlatCryptoExportKey(aCurrKey->mKeyMaterial.mKeyRef,
-					      (uint8_t *)aCurrKey->mKeyMaterial.mKey.m8,
-					      OT_MAC_KEY_SIZE, &keyLen) == OT_ERROR_NONE);
-	__ASSERT_NO_MSG(otPlatCryptoExportKey(aNextKey->mKeyMaterial.mKeyRef,
-					      (uint8_t *)aNextKey->mKeyMaterial.mKey.m8,
-					      OT_MAC_KEY_SIZE, &keyLen) == OT_ERROR_NONE);
+	error = otPlatCryptoExportKey(aPrevKey->mKeyMaterial.mKeyRef,
+				      (uint8_t *)aPrevKey->mKeyMaterial.mKey.m8, OT_MAC_KEY_SIZE,
+				      &keyLen);
+	__ASSERT_NO_MSG(error == OT_ERROR_NONE);
+	error = otPlatCryptoExportKey(aCurrKey->mKeyMaterial.mKeyRef,
+				      (uint8_t *)aCurrKey->mKeyMaterial.mKey.m8, OT_MAC_KEY_SIZE,
+				      &keyLen);
+	__ASSERT_NO_MSG(error == OT_ERROR_NONE);
+	error = otPlatCryptoExportKey(aNextKey->mKeyMaterial.mKeyRef,
+				      (uint8_t *)aNextKey->mKeyMaterial.mKey.m8, OT_MAC_KEY_SIZE,
+				      &keyLen);
+	__ASSERT_NO_MSG(error == OT_ERROR_NONE);
 #else
 	__ASSERT_NO_MSG(aKeyType == OT_KEY_TYPE_LITERAL_KEY);
 #endif


### PR DESCRIPTION
Ensure `otPlatRadioSetMacKey` is properly implemented when asserts are disabled.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>