### PR TITLE
shell: Fix log message queue size for all backends

### DIFF
--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -147,7 +147,7 @@ module = SHELL_BACKEND_RTT
 default-timeout = 100
 source "subsys/shell/Kconfig.template.shell_log_queue_timeout"
 
-default-size = 10
+default-size = 512
 source "subsys/shell/Kconfig.template.shell_log_queue_size"
 
 choice
@@ -243,7 +243,7 @@ module = SHELL_BACKEND_MQTT
 default-timeout = 100
 source "subsys/shell/Kconfig.template.shell_log_queue_timeout"
 
-default-size = 10
+default-size = 512
 source "subsys/shell/Kconfig.template.shell_log_queue_size"
 
 choice
@@ -339,7 +339,7 @@ module = SHELL_TELNET
 default-timeout = 100
 source "subsys/shell/Kconfig.template.shell_log_queue_timeout"
 
-default-size = 10
+default-size = 512
 source "subsys/shell/Kconfig.template.shell_log_queue_size"
 
 choice

--- a/subsys/shell/backends/shell_dummy.c
+++ b/subsys/shell/backends/shell_dummy.c
@@ -10,7 +10,7 @@
 #include <zephyr/init.h>
 
 SHELL_DUMMY_DEFINE(shell_transport_dummy);
-SHELL_DEFINE(shell_dummy, CONFIG_SHELL_PROMPT_DUMMY, &shell_transport_dummy, 1,
+SHELL_DEFINE(shell_dummy, CONFIG_SHELL_PROMPT_DUMMY, &shell_transport_dummy, 256,
 	     0, SHELL_FLAG_OLF_CRLF);
 
 static int init(const struct shell_transport *transport,


### PR DESCRIPTION
188d2dfcca7 introduced a change where log message queue again become configurable through Kconfig instead of being fixed in the code. However, it updated only the configuration of an UART backend. This commit updates other backends as well. Including dummy backend which has fixed in the code value.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>