### PR TITLE
Refactor and extend quarantine implementation in twister

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -902,14 +902,15 @@ using an external J-Link probe.  The "probe_id" keyword overrides the
 Quarantine
 ++++++++++
 
-Twister allows using user-defined yaml files defining the list of tests to be put
-under quarantine. Such tests will be skipped and marked accordingly in the output
-reports. This feature is especially useful when running larger test suits, where
-a failure of one test can affect the execution of other tests (e.g. putting the
-physical board in a corrupted state).
+Twister allows user to provide onfiguration files defining a list of tests or
+platforms to be put under quarantine. Such tests will be skipped and marked
+accordingly in the output reports. This feature is especially useful when
+running larger test suits, where a failure of one test can affect the execution
+of other tests (e.g. putting the physical board in a corrupted state).
 
 To use the quarantine feature one has to add the argument
 ``--quarantine-list <PATH_TO_QUARANTINE_YAML>`` to a twister call.
+Multiple quarantine files can be used.
 The current status of tests on the quarantine list can also be verified by adding
 ``--quarantine-verify`` to the above argument. This will make twister skip all tests
 which are not on the given list.
@@ -920,21 +921,32 @@ to put under quarantine. In addition, an optional entry "comment" can be used, w
 some more details can be given (e.g. link to a reported issue). These comments will also
 be added to the output reports.
 
+When quarantining a class of tests or many scenarios in a single testsuite or
+when dealing with multiple issues within a subsystem, it is possible to use
+regular expressions, for example, **kernel.*** would quarantine
+all kernel tests.
+
 An example of entries in a quarantine yaml::
 
     - scenarios:
         - sample.basic.helloworld
-      platforms:
-        - all
       comment: "Link to the issue: https://github.com/zephyrproject-rtos/zephyr/pull/33287"
 
     - scenarios:
         - kernel.common
-        - kernel.common.misra
+        - kernel.common.(misra|tls)
         - kernel.common.nano64
       platforms:
-        - qemu_cortex_m3
+        - .*_cortex_.*
         - native_posix
+
+To exclude a platform, use the following syntax::
+
+    - platforms:
+      - qemu_x86
+      comment: "broken qemu"
+
+Additionally you can quarantine entire architectures or a specific simulator for executing tests.
 
 Running in Tests in Random Order
 ********************************

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -475,6 +475,7 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
 
     parser.add_argument(
         "--quarantine-list",
+        action="append",
         metavar="FILENAME",
         help="Load list of test scenarios under quarantine. The entries in "
              "the file need to correspond to the test scenarios names as in "

--- a/scripts/pylib/twister/twisterlib/quarantine.py
+++ b/scripts/pylib/twister/twisterlib/quarantine.py
@@ -40,7 +40,7 @@ class QuarantineElement:
     platforms: list[str] = field(default_factory=list)
     architectures: list[str] = field(default_factory=list)
     simulations: list[str] = field(default_factory=list)
-    comment: str = 'under quarantine'
+    comment: str = 'NA'
 
     def __post_init__(self):
         # If there is no entry in filters then take all possible values.

--- a/scripts/pylib/twister/twisterlib/quarantine.py
+++ b/scripts/pylib/twister/twisterlib/quarantine.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+
+from pathlib import Path
+from yaml import safe_load
+from dataclasses import dataclass, field
+
+
+logger = logging.getLogger(__name__)
+
+
+class QuarantineException(Exception):
+    pass
+
+
+class Quarantine:
+    """Handle tests under quarantine."""
+
+    def __init__(self, quarantine_list=[]) -> None:
+        self.quarantine = QuarantineData()
+        for quarantine_file in quarantine_list:
+            self.quarantine.extend(QuarantineData.load_data_from_yaml(quarantine_file))
+
+    def get_matched_quarantine(self, testname, platform, architecture):
+        qelem = self.quarantine.get_matched_quarantine(testname, platform, architecture)
+        if qelem:
+            return qelem.comment
+        return None
+
+
+@dataclass
+class QuarantineElement:
+    scenarios: list[str] = field(default_factory=list)
+    platforms: list[str] = field(default_factory=list)
+    architectures: list[str] = field(default_factory=list)
+    comment: str = 'under quarantine'
+
+    def __post_init__(self):
+        if 'all' in self.scenarios:
+            self.scenarios = []
+        if 'all' in self.platforms:
+            self.platforms = []
+        if 'all' in self.architectures:
+            self.architectures = []
+        if not any([self.scenarios, self.platforms, self.architectures]):
+            raise QuarantineException("At least one of filters ('scenarios', 'platforms', "
+                                      "'architectures') must be specified")
+
+
+@dataclass
+class QuarantineData:
+    qlist: list[QuarantineElement] = field(default_factory=list)
+
+    def __post_init__(self):
+        qelements = []
+        for qelem in self.qlist:
+            qelements.append(QuarantineElement(**qelem))
+        self.qlist = qelements
+
+    @classmethod
+    def load_data_from_yaml(cls, filename: str | Path) -> QuarantineData:
+        """Load quarantine from yaml file."""
+        with open(filename, 'r', encoding='UTF-8') as yaml_fd:
+            qlist: list(dict) = safe_load(yaml_fd)
+        try:
+            return cls(qlist)
+
+        except Exception as e:
+            logger.error(f'When loading {filename} received error: {e}')
+            raise QuarantineException('Cannot load Quarantine data') from e
+
+    def extend(self, qdata: QuarantineData) -> list[QuarantineElement]:
+        self.qlist.extend(qdata.qlist)
+
+    def get_matched_quarantine(self, scenario: str, platform: str,
+                               architecture: str) -> QuarantineElement | None:
+        """Return quarantine element if test is matched to quarantine rules"""
+        for qelem in self.qlist:
+            matched: bool = False
+            if qelem.scenarios:
+                if scenario in qelem.scenarios:
+                    matched = True
+                else:
+                    matched = False
+                    continue
+            if qelem.platforms:
+                if platform in qelem.platforms:
+                    matched = True
+                else:
+                    matched = False
+                    continue
+            if qelem.architectures:
+                if architecture in qelem.architectures:
+                    matched = True
+                else:
+                    matched = False
+                    continue
+            if matched:
+                return qelem
+
+        return None

--- a/scripts/pylib/twister/twisterlib/quarantine.py
+++ b/scripts/pylib/twister/twisterlib/quarantine.py
@@ -80,6 +80,9 @@ class QuarantineData:
         with open(filename, 'r', encoding='UTF-8') as yaml_fd:
             qlist_raw_data: list[dict] = safe_load(yaml_fd)
         try:
+            if not qlist_raw_data:
+                # in case of loading empty quarantine file
+                return cls()
             return cls(qlist_raw_data)
 
         except Exception as e:

--- a/scripts/pylib/twister/twisterlib/quarantine.py
+++ b/scripts/pylib/twister/twisterlib/quarantine.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from pathlib import Path
 from yaml import safe_load
@@ -25,9 +26,10 @@ class Quarantine:
         for quarantine_file in quarantine_list:
             self.quarantine.extend(QuarantineData.load_data_from_yaml(quarantine_file))
 
-    def get_matched_quarantine(self, testname, platform, architecture):
-        qelem = self.quarantine.get_matched_quarantine(testname, platform, architecture)
+    def get_matched_quarantine(self, testname, platform, architecture, simulation):
+        qelem = self.quarantine.get_matched_quarantine(testname, platform, architecture, simulation)
         if qelem:
+            logger.debug('%s quarantined with reason: %s' % (testname, qelem.comment))
             return qelem.comment
         return None
 
@@ -37,18 +39,26 @@ class QuarantineElement:
     scenarios: list[str] = field(default_factory=list)
     platforms: list[str] = field(default_factory=list)
     architectures: list[str] = field(default_factory=list)
+    simulations: list[str] = field(default_factory=list)
     comment: str = 'under quarantine'
 
     def __post_init__(self):
+        # If there is no entry in filters then take all possible values.
+        # To keep backward compatibility, 'all' keyword might be still used.
         if 'all' in self.scenarios:
             self.scenarios = []
         if 'all' in self.platforms:
             self.platforms = []
         if 'all' in self.architectures:
             self.architectures = []
-        if not any([self.scenarios, self.platforms, self.architectures]):
-            raise QuarantineException("At least one of filters ('scenarios', 'platforms', "
-                                      "'architectures') must be specified")
+        if 'all' in self.simulations:
+            self.simulations = []
+        # However, at least one of the filters ('scenarios', platforms' ...)
+        # must be given (there is no sense to put all possible configuration
+        # into quarantine)
+        if not any([self.scenarios, self.platforms, self.architectures, self.simulations]):
+            raise QuarantineException("At least one of filters ('scenarios', 'platforms' ...) "
+                                      "must be specified")
 
 
 @dataclass
@@ -58,48 +68,56 @@ class QuarantineData:
     def __post_init__(self):
         qelements = []
         for qelem in self.qlist:
-            qelements.append(QuarantineElement(**qelem))
+            if isinstance(qelem, QuarantineElement):
+                qelements.append(qelem)
+            else:
+                qelements.append(QuarantineElement(**qelem))
         self.qlist = qelements
 
     @classmethod
     def load_data_from_yaml(cls, filename: str | Path) -> QuarantineData:
         """Load quarantine from yaml file."""
         with open(filename, 'r', encoding='UTF-8') as yaml_fd:
-            qlist: list(dict) = safe_load(yaml_fd)
+            qlist_raw_data: list[dict] = safe_load(yaml_fd)
         try:
-            return cls(qlist)
+            return cls(qlist_raw_data)
 
         except Exception as e:
             logger.error(f'When loading {filename} received error: {e}')
             raise QuarantineException('Cannot load Quarantine data') from e
 
-    def extend(self, qdata: QuarantineData) -> list[QuarantineElement]:
+    def extend(self, qdata: QuarantineData) -> None:
         self.qlist.extend(qdata.qlist)
 
-    def get_matched_quarantine(self, scenario: str, platform: str,
-                               architecture: str) -> QuarantineElement | None:
+    def get_matched_quarantine(self,
+                               scenario: str,
+                               platform: str,
+                               architecture: str,
+                               simulation: str) -> QuarantineElement | None:
         """Return quarantine element if test is matched to quarantine rules"""
         for qelem in self.qlist:
             matched: bool = False
-            if qelem.scenarios:
-                if scenario in qelem.scenarios:
-                    matched = True
-                else:
-                    matched = False
-                    continue
-            if qelem.platforms:
-                if platform in qelem.platforms:
-                    matched = True
-                else:
-                    matched = False
-                    continue
-            if qelem.architectures:
-                if architecture in qelem.architectures:
-                    matched = True
-                else:
-                    matched = False
-                    continue
+            if (qelem.scenarios
+                    and (matched := _is_element_matched(scenario, qelem.scenarios)) is False):
+                continue
+            if (qelem.platforms
+                    and (matched := _is_element_matched(platform, qelem.platforms)) is False):
+                continue
+            if (qelem.architectures
+                    and (matched := _is_element_matched(architecture, qelem.architectures)) is False):
+                continue
+            if (qelem.simulations
+                    and (matched := _is_element_matched(simulation, qelem.simulations)) is False):
+                continue
+
             if matched:
                 return qelem
-
         return None
+
+
+def _is_element_matched(element: str, list_of_elements: list) -> bool:
+    """Return True if given element is matching to any of elements from the list"""
+    for pattern in list_of_elements:
+        if re.fullmatch(pattern, element):
+            return True
+    return False

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -753,7 +753,7 @@ class TestPlan:
                         instance.testsuite.id, plat.name, plat.arch, plat.simulation
                     )
                     if matched_quarantine and not self.options.quarantine_verify:
-                        instance.add_filter(matched_quarantine, Filters.QUARENTINE)
+                        instance.add_filter("Quarantine: " + matched_quarantine, Filters.QUARENTINE)
                     if not matched_quarantine and self.options.quarantine_verify:
                         instance.add_filter("Not under quarantine", Filters.QUARENTINE)
 

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -747,7 +747,7 @@ class TestPlan:
                 # handle quarantined tests
                 if self.quarantine:
                     matched_quarantine = self.quarantine.get_matched_quarantine(
-                        instance.testsuite.id, plat.name, plat.arch
+                        instance.testsuite.id, plat.name, plat.arch, plat.simulation
                     )
                     if matched_quarantine and not self.options.quarantine_verify:
                         instance.add_filter(matched_quarantine, Filters.QUARENTINE)

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -134,6 +134,9 @@ class TestPlan:
             logger.error("No quarantine list given to be verified")
             raise TwisterRuntimeError("No quarantine list given to be verified")
         if ql:
+            for quarantine_file in ql:
+                # validate quarantine yaml file against the provided schema
+                scl.yaml_load_verify(quarantine_file, self.quarantine_schema)
             self.quarantine = Quarantine(ql)
 
     def load(self):

--- a/scripts/schemas/twister/quarantine-schema.yaml
+++ b/scripts/schemas/twister/quarantine-schema.yaml
@@ -31,7 +31,13 @@ sequence:
         type: seq
         sequence:
           - type: str
-          - unique: true
+          - unique: True
+      "simulations":
+        required: false
+        type: seq
+        sequence:
+          - type: str
+          - unique: True
       "comment":
         type: str
         required: false

--- a/scripts/schemas/twister/quarantine-schema.yaml
+++ b/scripts/schemas/twister/quarantine-schema.yaml
@@ -25,19 +25,19 @@ sequence:
         type: seq
         sequence:
           - type: str
-          - unique: True
+          - unique: true
       "architectures":
         required: false
         type: seq
         sequence:
           - type: str
-          - unique: True
+          - unique: true
       "simulations":
         required: false
         type: seq
         sequence:
           - type: str
-          - unique: True
+          - unique: true
       "comment":
         type: str
         required: false

--- a/scripts/schemas/twister/quarantine-schema.yaml
+++ b/scripts/schemas/twister/quarantine-schema.yaml
@@ -16,12 +16,18 @@ sequence:
     mapping:
       "scenarios":
         type: seq
-        required: true
+        required: false
         sequence:
           - type: str
           - unique: true
       "platforms":
-        required: true
+        required: false
+        type: seq
+        sequence:
+          - type: str
+          - unique: True
+      "architectures":
+        required: false
         type: seq
         sequence:
           - type: str

--- a/scripts/tests/twister/test_data/quarantines/basic.yaml
+++ b/scripts/tests/twister/test_data/quarantines/basic.yaml
@@ -1,0 +1,6 @@
+- scenarios:
+  - test_a.check_1
+  platforms:
+  - demo_board_1
+  - demo_board_3
+  comment: "a1 on board_1 and board_3"

--- a/scripts/tests/twister/test_data/quarantines/empty.yaml
+++ b/scripts/tests/twister/test_data/quarantines/empty.yaml
@@ -1,0 +1,1 @@
+# empty quarantine file

--- a/scripts/tests/twister/test_data/quarantines/platform.yaml
+++ b/scripts/tests/twister/test_data/quarantines/platform.yaml
@@ -1,0 +1,4 @@
+
+- platforms:
+  - demo_board_3
+  comment: "all on board_3"

--- a/scripts/tests/twister/test_data/quarantines/platform.yaml
+++ b/scripts/tests/twister/test_data/quarantines/platform.yaml
@@ -1,4 +1,3 @@
-
 - platforms:
   - demo_board_3
   comment: "all on board_3"

--- a/scripts/tests/twister/test_data/quarantines/with_regexp.yaml
+++ b/scripts/tests/twister/test_data/quarantines/with_regexp.yaml
@@ -1,0 +1,10 @@
+
+- scenarios:
+  - test_(a|c).check_2
+  architectures:
+  - x86.*
+  comment: "a2 and c2 on x86"
+
+- scenarios:
+  - test_d.*
+  comment: "all test_d"

--- a/scripts/tests/twister/test_data/quarantines/with_regexp.yaml
+++ b/scripts/tests/twister/test_data/quarantines/with_regexp.yaml
@@ -1,4 +1,3 @@
-
 - scenarios:
   - test_(a|c).check_2
   architectures:

--- a/scripts/tests/twister/test_testplan_class.py
+++ b/scripts/tests/twister/test_testplan_class.py
@@ -17,6 +17,7 @@ from twisterlib.testplan import TestPlan
 from twisterlib.testinstance import TestInstance
 from twisterlib.testsuite import TestSuite
 from twisterlib.platform import Platform
+from twisterlib.quarantine import Quarantine
 
 
 def test_testplan_add_testsuites(class_testplan):
@@ -256,3 +257,81 @@ def test_add_instances(test_data, class_env, all_testsuites_dict, platforms_list
 		   [platform.name + '/' + s for s in list(all_testsuites_dict.keys())]
     assert all(isinstance(n, TestInstance) for n in list(plan.instances.values()))
     assert list(plan.instances.values()) == instance_list
+
+
+QUARANTINE_BASIC = {
+    'demo_board_1/zephyr/scripts/tests/twister/test_data/testsuites/tests/test_a/test_a.check_1' : 'a1 on board_1 and board_3',
+    'demo_board_3/zephyr/scripts/tests/twister/test_data/testsuites/tests/test_a/test_a.check_1' : 'a1 on board_1 and board_3'
+}
+
+QUARANTINE_WITH_REGEXP = {
+    'demo_board_2/zephyr/scripts/tests/twister/test_data/testsuites/tests/test_a/test_a.check_2' : 'a2 and c2 on x86',
+    'demo_board_1/zephyr/scripts/tests/twister/test_data/testsuites/tests/test_d/test_d.check_1' : 'all test_d',
+    'demo_board_3/zephyr/scripts/tests/twister/test_data/testsuites/tests/test_d/test_d.check_1' : 'all test_d',
+    'demo_board_2/zephyr/scripts/tests/twister/test_data/testsuites/tests/test_d/test_d.check_1' : 'all test_d',
+    'demo_board_2/zephyr/scripts/tests/twister/test_data/testsuites/tests/test_c/test_c.check_2' : 'a2 and c2 on x86'
+}
+
+QUARANTINE_PLATFORM = {
+    'demo_board_3/zephyr/scripts/tests/twister/test_data/testsuites/tests/test_a/test_a.check_1' : 'all on board_3',
+    'demo_board_3/zephyr/scripts/tests/twister/test_data/testsuites/tests/test_a/test_a.check_2' : 'all on board_3',
+    'demo_board_3/zephyr/scripts/tests/twister/test_data/testsuites/tests/test_d/test_d.check_1' : 'all on board_3',
+    'demo_board_3/zephyr/scripts/tests/twister/test_data/testsuites/tests/test_b/test_b.check_1' : 'all on board_3',
+    'demo_board_3/zephyr/scripts/tests/twister/test_data/testsuites/tests/test_b/test_b.check_2' : 'all on board_3',
+    'demo_board_3/zephyr/scripts/tests/twister/test_data/testsuites/tests/test_c/test_c.check_1' : 'all on board_3',
+    'demo_board_3/zephyr/scripts/tests/twister/test_data/testsuites/tests/test_c/test_c.check_2' : 'all on board_3'
+}
+
+QUARANTINE_MULTIFILES = {
+    **QUARANTINE_BASIC,
+    **QUARANTINE_WITH_REGEXP
+}
+
+@pytest.mark.parametrize(
+    ("quarantine_files, quarantine_verify, expected_val"),
+    [
+        (['basic.yaml'], False, QUARANTINE_BASIC),
+        (['with_regexp.yaml'], False, QUARANTINE_WITH_REGEXP),
+        (['with_regexp.yaml'], True, QUARANTINE_WITH_REGEXP),
+        (['platform.yaml'], False, QUARANTINE_PLATFORM),
+        (['basic.yaml', 'with_regexp.yaml'], False, QUARANTINE_MULTIFILES),
+        (['empty.yaml'], False, {})
+    ],
+    ids=[
+        'basic',
+        'with_regexp',
+        'quarantine_verify',
+        'platform',
+        'multifiles',
+        'empty'
+    ])
+def test_quarantine(class_testplan, platforms_list, test_data,
+                    quarantine_files, quarantine_verify, expected_val):
+    """ Testing quarantine feature in Twister
+    """
+    class_testplan.options.all = True
+    class_testplan.platforms = platforms_list
+    class_testplan.platform_names = [p.name for p in platforms_list]
+    class_testplan.TESTSUITE_FILENAME = 'test_data.yaml'
+    class_testplan.add_testsuites()
+
+    quarantine_list = [
+        os.path.join(test_data, 'quarantines', quarantine_file) for quarantine_file in quarantine_files
+    ]
+    class_testplan.quarantine = Quarantine(quarantine_list)
+    class_testplan.options.quarantine_verify = quarantine_verify
+    class_testplan.apply_filters()
+
+    for testname, instance in class_testplan.instances.items():
+        if quarantine_verify:
+            if testname in expected_val:
+                assert not instance.status
+            else:
+                assert instance.status == 'filtered'
+                assert instance.reason == "Not under quarantine"
+        else:
+            if testname in expected_val:
+                assert instance.status == 'filtered'
+                assert instance.reason == expected_val[testname]
+            else:
+                assert not instance.status

--- a/scripts/tests/twister/test_testplan_class.py
+++ b/scripts/tests/twister/test_testplan_class.py
@@ -332,6 +332,6 @@ def test_quarantine(class_testplan, platforms_list, test_data,
         else:
             if testname in expected_val:
                 assert instance.status == 'filtered'
-                assert instance.reason == expected_val[testname]
+                assert instance.reason == "Quarantine: " + expected_val[testname]
             else:
                 assert not instance.status


### PR DESCRIPTION
Implementation ported from TwisterV2.
- quarantine handled by separate module
- multiple yaml allowed from args: --quarantine-list
  example: `scripts/twister -T tests/kernel/common -p native_posix --quarantine-list test_quarantine1.yml --quarantine-list test_quarantine2.yml`
- scenarios, platforms, architectures keywords in quarantine yaml are optional, if not given - means take them all.
  Means, to filter all scenarios for platforms `qemu_cortex_m3` and `native_posix`, one can use
```
- platforms:
  - qemu_cortex_m3
  - native_posix
 comment: "reason"
```
  or
```
- scenarios:
  - all
 platforms:
  - qemu_cortex_m3
  - native_posix
 comment: "reason"
```
- `architecture` keyword also added like in solution proposed in PR #52179

Signed-off-by: Grzegorz Chwierut <grzegorz.chwierut@nordicsemi.no>