### PR TITLE
Add PLL2 clock support for STM32H7

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -87,6 +87,13 @@
 			status = "disabled";
 		};
 
+		pll2: pll@1 {
+			#clock-cells = <0>;
+			compatible = "st,stm32h7-pll-clock";
+			reg = <1>;
+			status = "disabled";
+		};
+
 		pll3: pll@2 {
 			#clock-cells = <0>;
 			compatible = "st,stm32h7-pll-clock";

--- a/dts/bindings/clock/st,stm32h7-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32h7-pll-clock.yaml
@@ -39,7 +39,7 @@ properties:
       description: |
           Division factor for PLLx
           input clock
-          Valid range: 0 - 63
+          Valid range: 1 - 63
 
     mul-n:
       type: int

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -126,7 +126,8 @@
 #define STM32_PLL_R_DIVISOR	DT_PROP_OR(DT_NODELABEL(pll), div_r, 1)
 #endif
 
-#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll2), st_stm32u5_pll_clock, okay)
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll2), st_stm32u5_pll_clock, okay) || \
+	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll2), st_stm32h7_pll_clock, okay)
 #define STM32_PLL2_ENABLED	1
 #define STM32_PLL2_M_DIVISOR	DT_PROP(DT_NODELABEL(pll2), div_m)
 #define STM32_PLL2_N_MULTIPLIER	DT_PROP(DT_NODELABEL(pll2), mul_n)

--- a/include/zephyr/dt-bindings/clock/stm32h7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h7_clock.h
@@ -14,10 +14,9 @@
 #define STM32_SRC_PLL1_P	0x001
 #define STM32_SRC_PLL1_Q	0x002
 #define STM32_SRC_PLL1_R	0x003
-/** PLL2 not yet supported */
-/* #define STM32_SRC_PLL2_P	0x004 */
-/* #define STM32_SRC_PLL2_Q	0x005 */
-/* #define STM32_SRC_PLL2_R	0x006 */
+#define STM32_SRC_PLL2_P	0x004
+#define STM32_SRC_PLL2_Q	0x005
+#define STM32_SRC_PLL2_R	0x006
 #define STM32_SRC_PLL3_P	0x007
 #define STM32_SRC_PLL3_Q	0x008
 #define STM32_SRC_PLL3_R	0x009

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/boards/core_init.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/boards/core_init.overlay
@@ -47,6 +47,16 @@
 	status = "disabled";
 };
 
+&pll2 {
+	/delete-property/ div-m;
+	/delete-property/ mul-n;
+	/delete-property/ div-p;
+	/delete-property/ div-q;
+	/delete-property/ div-r;
+	/delete-property/ clocks;
+	status = "disabled";
+};
+
 &pll3 {
 	/delete-property/ div-m;
 	/delete-property/ mul-n;

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/boards/spi1_pll2p_1.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/boards/spi1_pll2p_1.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Georgij Cernysiov
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after core_init.overlay file.
+ */
+
+&pll3 {
+	clocks = <&clk_hse>;
+	div-m = <1>;
+	mul-n = <24>;
+	div-p = <1>;
+	status = "okay";
+};
+
+&spi1 {
+	/delete-property/ clocks;
+	clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>,
+		 <&rcc STM32_SRC_PLL2_P SPI123_SEL(1)>;
+	status = "okay";
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/src/test_stm32_clock_configuration.c
@@ -66,6 +66,10 @@ ZTEST(stm32h7_devices_clocks, test_spi_clk_config)
 			zassert_equal(spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_PLL,
 					"Expected SPI src: PLL1 Q (0x%x). Actual: 0x%x",
 					RCC_SPI123CLKSOURCE_PLL, spi1_actual_domain_clk);
+		} else if (pclken[1].bus == STM32_SRC_PLL2_P) {
+			zassert_equal(spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_PLL2,
+					"Expected SPI src: PLL2 P (0x%x). Actual: 0x%x",
+					RCC_SPI123CLKSOURCE_PLL2, spi1_actual_domain_clk);
 		} else if (pclken[1].bus == STM32_SRC_PLL3_P) {
 			zassert_equal(spi1_actual_domain_clk, RCC_SPI123CLKSOURCE_PLL3,
 					"Expected SPI src: PLL3 P (0x%x). Actual: 0x%x",

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/testcase.yaml
@@ -6,6 +6,8 @@ tests:
     extra_args: DTC_OVERLAY_FILE="boards/core_init.overlay;boards/spi1_pllq_1_d1ppre_1.overlay"
   drivers.stm32_clock_configuration.h7_dev.spi1_pllq_2_d1ppre_4:
     extra_args: DTC_OVERLAY_FILE="boards/core_init.overlay;boards/spi1_pllq_2_d1ppre_4.overlay"
+  drivers.stm32_clock_configuration.h7_dev.spi1_pll2p_1:
+    extra_args: DTC_OVERLAY_FILE="boards/core_init.overlay;boards/spi1_pll2p_1.overlay"
   drivers.stm32_clock_configuration.h7_dev.spi1_pll3p_1_d1ppre_4:
     extra_args: DTC_OVERLAY_FILE="boards/core_init.overlay;boards/spi1_pll3p_1_d1ppre_4.overlay"
   drivers.stm32_clock_configuration.h7_dev.spi1_per_ck_d1ppre_1:


### PR DESCRIPTION
- Adds PLL2 clock support to STM32 H7 clock driver similarly to existing PLL3. 
  Allows usage of PLL2 P/Q/R for peripherals. Tested with SPI1,2,3 using PLL2P.
  Resolves #51785.
- Corrects H7 PLL `div-m` description in the bindings file. The value shall start from 1.



