### PR TITLE
mtl: pm: D3 power flow errata

### DIFF
--- a/soc/xtensa/intel_adsp/ace/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/ace/CMakeLists.txt
@@ -10,4 +10,5 @@ zephyr_library_sources(
   irq.c
   power_down.S
   power.c
+  boot.c
   )

--- a/soc/xtensa/intel_adsp/ace/boot.c
+++ b/soc/xtensa/intel_adsp/ace/boot.c
@@ -52,7 +52,7 @@ __imr void boot_d3_restore(void)
 	extern void lp_sram_init(void);
 	lp_sram_init();
 
-	extern FUNC_NORETURN void pm_state_imr_restore(void);
+	extern void pm_state_imr_restore(void);
 	pm_state_imr_restore();
 }
 #endif /* CONFIG_PM */

--- a/soc/xtensa/intel_adsp/ace/boot.c
+++ b/soc/xtensa/intel_adsp/ace/boot.c
@@ -1,0 +1,58 @@
+/* Copyright(c) 2021 Intel Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <soc.h>
+#include <zephyr/arch/xtensa/cache.h>
+#include <adsp_shim.h>
+#include <adsp_memory.h>
+#include <cpu_init.h>
+#include "manifest.h"
+
+#ifdef CONFIG_PM
+
+#define STRINGIFY_MACRO(x) Z_STRINGIFY(x)
+#define IMRSTACK STRINGIFY_MACRO(IMR_BOOT_LDR_MANIFEST_BASE)
+__asm__(".section .imr.boot_entry_d3_restore, \"x\"\n\t"
+	".align 4\n\t"
+	".global boot_entry_d3_restore\n\t"
+	"boot_entry_d3_restore:\n\t"
+	"  movi  a0, 0x4002f\n\t"
+	"  wsr   a0, PS\n\t"
+	"  movi  a0, 0\n\t"
+	"  wsr   a0, WINDOWBASE\n\t"
+	"  movi  a0, 1\n\t"
+	"  wsr   a0, WINDOWSTART\n\t"
+	"  rsync\n\t"
+	"  movi  a1, " IMRSTACK"\n\t"
+	"  call4 boot_d3_restore\n\t");
+
+
+__imr void boot_d3_restore(void)
+{
+
+	cpu_early_init();
+
+#ifdef CONFIG_ADSP_DISABLE_L2CACHE_AT_BOOT
+	ADSP_L2PCFG_REG = 0;
+#endif
+
+#ifdef RESET_MEMORY_HOLE
+	/* reset memory hole */
+	CAVS_SHIM.l2mecs = 0;
+#endif
+
+	extern void lp_sram_init(void);
+	lp_sram_init();
+
+	extern FUNC_NORETURN void pm_state_imr_restore(void);
+	pm_state_imr_restore();
+}
+#endif /* CONFIG_PM */

--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -89,7 +89,7 @@ struct core_state {
 	uint32_t bctl;
 };
 
-static struct core_state core_desc[CONFIG_MP_MAX_NUM_CPUS] = { 0 };
+static struct core_state core_desc[CONFIG_MP_MAX_NUM_CPUS] = {{0}};
 
 struct lpsram_header {
 	uint32_t alt_reset_vector;
@@ -156,7 +156,7 @@ void power_gate_exit(void)
 	_restore_core_context();
 }
 
-void ALWAYS_INLINE power_off_exit(void)
+static void ALWAYS_INLINE power_off_exit(void)
 {
 	__asm__(
 		"  movi  a0, 0\n\t"
@@ -183,7 +183,7 @@ __asm__(".align 4\n\t"
 	"  add sp, sp, a2\n\t"
 	"  call0 power_gate_exit\n\t");
 
-__imr FUNC_NORETURN void pm_state_imr_restore(void)
+__imr void pm_state_imr_restore(void)
 {
 	struct imr_layout *imr_layout = (struct imr_layout *)(IMR_LAYOUT_ADDRESS);
 	/* restore lpsram power and contents */
@@ -234,7 +234,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 			_save_core_context(cpu);
 
 			/* save LPSRAM - a simple copy */
-			memcpy(global_imr_ram_storage, LP_SRAM_BASE, LP_SRAM_SIZE);
+			memcpy(global_imr_ram_storage, (void *)LP_SRAM_BASE, LP_SRAM_SIZE);
 
 			/* save HPSRAM - a multi step procedure, executed by a TLB driver
 			 * the TLB driver will change memory mapping

--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -73,7 +73,7 @@ uint8_t *global_imr_ram_storage;
 /*8
  * @biref a d3 restore boot entry point
  */
-extern void rom_entry_d3_restore(void);
+extern void boot_entry_d3_restore(void);
 
 /* NOTE: This struct will grow with all values that have to be stored for
  * proper cpu restore after PG.
@@ -219,7 +219,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 
 			imr_layout->imr_state.header.adsp_imr_magic = ADSP_IMR_MAGIC_VALUE;
 			imr_layout->imr_state.header.imr_restore_vector =
-					(void *)rom_entry_d3_restore;
+					(void *)boot_entry_d3_restore;
 			imr_layout->imr_state.header.imr_ram_storage = global_imr_ram_storage;
 			z_xtensa_cache_flush(imr_layout, sizeof(*imr_layout));
 

--- a/soc/xtensa/intel_adsp/common/boot.c
+++ b/soc/xtensa/intel_adsp/common/boot.c
@@ -76,31 +76,6 @@ __asm__(".section .imr.z_boot_asm_entry, \"x\" \n\t"
 	"  movi  a1, " IMRSTACK    "\n\t"
 	"  call4 boot_core0   \n\t");
 
-
-#ifdef CONFIG_PM
-
-/* Entry point for restore from IMR flow */
-__asm__(".pushsection .boot_entry.text, \"ax\"\n\t"
-	".global rom_entry_d3_restore\n\t"
-	"rom_entry_d3_restore:\n\t"
-	"  j z_boot_entry_d3_restore\n\t"
-	".popsection\n\t");
-
-__asm__(".section .imr.z_boot_entry_d3_restore, \"x\"\n\t"
-	".align 4\n\t"
-	"z_boot_entry_d3_restore:\n\t"
-	"  movi  a0, 0x4002f\n\t"
-	"  wsr   a0, PS\n\t"
-	"  movi  a0, 0\n\t"
-	"  wsr   a0, WINDOWBASE\n\t"
-	"  movi  a0, 1\n\t"
-	"  wsr   a0, WINDOWSTART\n\t"
-	"  rsync\n\t"
-	"  movi  a1, " IMRSTACK"\n\t"
-	"  call4 boot_d3_restore\n\t");
-
-#endif /* CONFIG_PM */
-
 static __imr void parse_module(struct sof_man_fw_header *hdr,
 			       struct sof_man_module *mod)
 {
@@ -183,25 +158,3 @@ __imr void boot_core0(void)
 	extern FUNC_NORETURN void z_cstart(void);
 	z_cstart();
 }
-
-#ifdef CONFIG_PM
-__imr void boot_d3_restore(void)
-{
-
-	cpu_early_init();
-
-#ifdef CONFIG_ADSP_DISABLE_L2CACHE_AT_BOOT
-	ADSP_L2PCFG_REG = 0;
-#endif
-
-#ifdef RESET_MEMORY_HOLE
-	/* reset memory hole */
-	CAVS_SHIM.l2mecs = 0;
-#endif
-
-	lp_sram_init();
-
-	extern FUNC_NORETURN void pm_state_imr_restore(void);
-	pm_state_imr_restore();
-}
-#endif /* CONFIG_PM */


### PR DESCRIPTION
Building of some legacy SOF platforms with specific configs fail after https://github.com/zephyrproject-rtos/zephyr/pull/47840 is applied. This is a hotfix for this