### PR TITLE
settings: use CONTAINER_OF() to access backend structure

### DIFF
--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -150,7 +150,7 @@ static int settings_fcb_load_priv(struct settings_store *cs,
 				  void *cb_arg,
 				  bool filter_duplicates)
 {
-	struct settings_fcb *cf = (struct settings_fcb *)cs;
+	struct settings_fcb *cf = CONTAINER_OF(cs, struct settings_fcb, cf_store);
 	struct fcb_entry_ctx entry_ctx = {
 		{.fe_sector = NULL, .fe_elem_off = 0},
 		.fap = cf->cf_fcb.fap
@@ -326,7 +326,7 @@ static int write_handler(void *ctx, off_t off, char const *buf, size_t len)
 static int settings_fcb_save_priv(struct settings_store *cs, const char *name,
 				  const char *value, size_t val_len)
 {
-	struct settings_fcb *cf = (struct settings_fcb *)cs;
+	struct settings_fcb *cf = CONTAINER_OF(cs, struct settings_fcb, cf_store);
 	struct fcb_entry_ctx loc;
 	int len;
 	int rc = -EINVAL;
@@ -457,7 +457,7 @@ int settings_backend_init(void)
 
 static void *settings_fcb_storage_get(struct settings_store *cs)
 {
-	struct settings_fcb *cf = (struct settings_fcb *)cs;
+	struct settings_fcb *cf = CONTAINER_OF(cs, struct settings_fcb, cf_store);
 
 	return &cf->cf_fcb;
 }

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -112,7 +112,7 @@ static int read_entry_len(const struct line_entry_ctx *entry_ctx, off_t off)
 static int settings_file_load_priv(struct settings_store *cs, line_load_cb cb,
 				   void *cb_arg, bool filter_duplicates)
 {
-	struct settings_file *cf = (struct settings_file *)cs;
+	struct settings_file *cf = CONTAINER_OF(cs, struct settings_file, cf_store);
 	struct fs_file_t file;
 	int lines;
 	int rc;
@@ -365,7 +365,7 @@ end_rolback:
 static int settings_file_save_priv(struct settings_store *cs, const char *name,
 				   const char *value, size_t val_len)
 {
-	struct settings_file *cf = (struct settings_file *)cs;
+	struct settings_file *cf = CONTAINER_OF(cs, struct settings_file, cf_store);
 	struct line_entry_ctx entry_ctx;
 	struct fs_file_t file;
 	int rc2;
@@ -540,7 +540,7 @@ int settings_backend_init(void)
 
 static void *settings_fs_storage_get(struct settings_store *cs)
 {
-	struct settings_file *cf = (struct settings_file *)cs;
+	struct settings_file *cf = CONTAINER_OF(cs, struct settings_file, cf_store);
 
 	return (void *)cf->cf_name;
 }

--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -122,7 +122,7 @@ static int settings_nvs_load(struct settings_store *cs,
 			     const struct settings_load_arg *arg)
 {
 	int ret = 0;
-	struct settings_nvs *cf = (struct settings_nvs *)cs;
+	struct settings_nvs *cf = CONTAINER_OF(cs, struct settings_nvs, cf_store);
 	struct settings_nvs_read_fn_arg read_fn_arg;
 	char name[SETTINGS_MAX_NAME_LEN + SETTINGS_EXTRA_LEN + 1];
 	char buf;
@@ -189,7 +189,7 @@ static int settings_nvs_load(struct settings_store *cs,
 static int settings_nvs_save(struct settings_store *cs, const char *name,
 			     const char *value, size_t val_len)
 {
-	struct settings_nvs *cf = (struct settings_nvs *)cs;
+	struct settings_nvs *cf = CONTAINER_OF(cs, struct settings_nvs, cf_store);
 	char rdname[SETTINGS_MAX_NAME_LEN + SETTINGS_EXTRA_LEN + 1];
 	uint16_t name_id, write_name_id;
 	bool delete, write_name;
@@ -404,7 +404,7 @@ int settings_backend_init(void)
 
 static void *settings_nvs_storage_get(struct settings_store *cs)
 {
-	struct settings_nvs *cf = (struct settings_nvs *)cs;
+	struct settings_nvs *cf = CONTAINER_OF(cs, struct settings_nvs, cf_store);
 
 	return &cf->cf_nvs;
 }


### PR DESCRIPTION
Use CONTAINER_OF() macro to access outer backend-specific structure. This
removes the requirement to keep `struct settings_store` as the first item
in outer structure.