### PR TITLE
settings: file: do not create file when loading

### DIFF
--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -127,8 +127,12 @@ static int settings_file_load_priv(struct settings_store *cs, line_load_cb cb,
 
 	fs_file_t_init(&file);
 
-	rc = fs_open(&file, cf->cf_name, FS_O_CREATE | FS_O_RDWR);
+	rc = fs_open(&file, cf->cf_name, FS_O_READ);
 	if (rc != 0) {
+		if (rc == -ENOENT) {
+			return -ENOENT;
+		}
+
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
File backend can be read-only with the use of `settings_file_src()` API. It
makes no sense to create file when `settings_load()` is called and
registered file backend won't be used for saving files (because
`settings_file_dst()` was not used).

Do not create file during `settings_load()` if it does not exist yet. This
just requires to remove FS_O_CREATE flag in `fs_open()` invocation.

Open file with read-only access, which is now possible after removal of
`FS_O_CREATE` flag.