### PR TITLE
driver: can: add new filter to match CAN-FD frames

### DIFF
--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -173,7 +173,12 @@ static int can_loopback_add_rx_filter(const struct device *dev, can_rx_callback_
 
 	LOG_DBG("Setting filter ID: 0x%x, mask: 0x%x", filter->id, filter->mask);
 
+#ifdef CONFIG_CAN_FD_MODE
+	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA |
+							CAN_FILTER_RTR | CAN_FILTER_FDF)) != 0) {
+#else
 	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA | CAN_FILTER_RTR)) != 0) {
+#endif
 		LOG_ERR("unsupported CAN filter flags 0x%02x", filter->flags);
 		return -ENOTSUP;
 	}

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -178,8 +178,10 @@ struct can_mcan_data {
 	void *cb_arg_ext[NUM_EXT_FILTER_DATA];
 	can_state_change_callback_t state_change_cb;
 	void *state_change_cb_data;
+	uint32_t std_filt_fd_frame;
 	uint32_t std_filt_rtr;
 	uint32_t std_filt_rtr_mask;
+	uint16_t ext_filt_fd_frame;
 	uint16_t ext_filt_rtr;
 	uint16_t ext_filt_rtr_mask;
 	struct can_mcan_mm mm;

--- a/drivers/can/can_native_posix_linux.c
+++ b/drivers/can/can_native_posix_linux.c
@@ -199,7 +199,12 @@ static int can_npl_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
 	LOG_DBG("Setting filter ID: 0x%x, mask: 0x%x", filter->id,
 		filter->mask);
 
+#ifdef CONFIG_CAN_FD_MODE
+	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA |
+							CAN_FILTER_RTR | CAN_FILTER_FDF)) != 0) {
+#else
 	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA | CAN_FILTER_RTR)) != 0) {
+#endif
 		LOG_ERR("unsupported CAN filter flags 0x%02x", filter->flags);
 		return -ENOTSUP;
 	}

--- a/drivers/can/can_utils.h
+++ b/drivers/can/can_utils.h
@@ -33,6 +33,10 @@ static inline bool can_utils_filter_match(const struct can_frame *frame,
 		return false;
 	}
 
+	if (((frame->flags & CAN_FRAME_FDF) != 0) && (filter->flags & CAN_FILTER_FDF) == 0) {
+		return false;
+	}
+
 	if ((frame->id ^ filter->id) & filter->mask) {
 		return false;
 	}

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -196,6 +196,9 @@ struct can_frame {
 /** Filter matches data frames */
 #define CAN_FILTER_DATA BIT(2)
 
+/** Filter matches CAN-FD frames (FDF) */
+#define CAN_FILTER_FDF BIT(3)
+
 /** @} */
 
 /**
@@ -212,7 +215,7 @@ struct can_filter {
 	 */
 	uint32_t mask         : 29;
 	/** Flags. @see @ref CAN_FILTER_FLAGS. */
-	uint8_t flags         : 3;
+	uint8_t flags;
 };
 
 /**

--- a/include/zephyr/net/socketcan.h
+++ b/include/zephyr/net/socketcan.h
@@ -124,6 +124,8 @@ struct socketcan_filter {
 	socketcan_id_t can_id;
 	/** The mask applied to @a can_id for matching. */
 	socketcan_id_t can_mask;
+	/** Additional flags for FD frame filter. */
+	uint8_t flags;
 };
 
 /** @} */

--- a/include/zephyr/net/socketcan_utils.h
+++ b/include/zephyr/net/socketcan_utils.h
@@ -88,6 +88,7 @@ static inline void socketcan_to_can_filter(const struct socketcan_filter *sfilte
 	zfilter->flags |= (sfilter->can_id & BIT(31)) != 0 ? CAN_FILTER_IDE : 0;
 	zfilter->id = sfilter->can_id & BIT_MASK(29);
 	zfilter->mask = sfilter->can_mask & BIT_MASK(29);
+	zfilter->flags |= (sfilter->flags & CANFD_FDF) != 0 ? CAN_FILTER_FDF : 0;
 
 	if ((sfilter->can_mask & BIT(30)) == 0) {
 		zfilter->flags |= CAN_FILTER_DATA | CAN_FILTER_RTR;
@@ -119,6 +120,10 @@ static inline void socketcan_from_can_filter(const struct can_filter *zfilter,
 	if ((zfilter->flags & (CAN_FILTER_DATA | CAN_FILTER_RTR)) !=
 		(CAN_FILTER_DATA | CAN_FILTER_RTR)) {
 		sfilter->can_mask |= BIT(30);
+	}
+
+	if ((zfilter->flags & CAN_FILTER_FDF) != 0) {
+		sfilter->flags |= CANFD_FDF;
 	}
 }
 

--- a/tests/drivers/can/canfd/src/main.c
+++ b/tests/drivers/can/canfd/src/main.c
@@ -114,6 +114,24 @@ const struct can_filter test_std_filter_2 = {
 };
 
 /**
+ * @brief Standard (11-bit) CAN-FD ID filter 1.
+ */
+const struct can_filter test_std_filter_fd_1 = {
+	.flags = CAN_FILTER_DATA | CAN_FILTER_FDF,
+	.id = TEST_CAN_STD_ID_1,
+	.mask = CAN_STD_ID_MASK
+};
+
+/**
+ * @brief Standard (11-bit) CAN-FD ID filter 2.
+ */
+const struct can_filter test_std_filter_fd_2 = {
+	.flags = CAN_FILTER_DATA | CAN_FILTER_FDF,
+	.id = TEST_CAN_STD_ID_2,
+	.mask = CAN_STD_ID_MASK
+};
+
+/**
  * @brief Assert that two CAN frames are equal.
  *
  * @param frame1  First CAN frame.
@@ -177,7 +195,7 @@ static void rx_std_callback_fd_1(const struct device *dev, struct can_frame *fra
 
 	assert_frame_equal(frame, &test_std_frame_fd_1);
 	zassert_equal(dev, can_dev, "CAN device does not match");
-	zassert_equal_ptr(filter, &test_std_filter_1, "filter does not match");
+	zassert_equal_ptr(filter, &test_std_filter_fd_1, "filter does not match");
 
 	k_sem_give(&rx_callback_sem);
 }
@@ -189,7 +207,7 @@ static void rx_std_callback_fd_2(const struct device *dev, struct can_frame *fra
 
 	assert_frame_equal(frame, &test_std_frame_fd_2);
 	zassert_equal(dev, can_dev, "CAN device does not match");
-	zassert_equal_ptr(filter, &test_std_filter_2, "filter does not match");
+	zassert_equal_ptr(filter, &test_std_filter_fd_2, "filter does not match");
 
 	k_sem_give(&rx_callback_sem);
 }
@@ -363,7 +381,7 @@ ZTEST(canfd, test_send_receive_classic)
  */
 ZTEST(canfd, test_send_receive_fd)
 {
-	send_receive(&test_std_filter_1, &test_std_filter_2,
+	send_receive(&test_std_filter_fd_1, &test_std_filter_fd_2,
 		     &test_std_frame_fd_1, &test_std_frame_fd_2);
 }
 
@@ -372,7 +390,7 @@ ZTEST(canfd, test_send_receive_fd)
  */
 ZTEST(canfd, test_send_receive_mixed)
 {
-	send_receive(&test_std_filter_1, &test_std_filter_2,
+	send_receive(&test_std_filter_fd_1, &test_std_filter_2,
 		     &test_std_frame_fd_1, &test_std_frame_2);
 }
 


### PR DESCRIPTION
Add support FD frame filter to configure type frame for each Rx msg to receive corresponding frames (classic, FD frames). 

I have a PR https://github.com/zephyrproject-rtos/zephyr/pull/52450 which introduces support for NXP S32 CANEXCEL, it need to implement this.