### PR TITLE
ci: bluetooth-tests: Run with GNU parallel

### DIFF
--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -66,6 +66,12 @@ jobs:
           west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/zephyrproject)
           west forall -c 'git reset --hard HEAD'
 
+      - name: Install parallel
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y parallel
+          parallel --version
+
       - name: Run Bluetooth Tests with BSIM
         run: |
           export ZEPHYR_BASE=${PWD}

--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -17,10 +17,13 @@ concurrency:
 
 jobs:
   bluetooth-test:
-    runs-on: ubuntu-20.04
+    if: github.repository_owner == 'zephyrproject-rtos'
+    runs-on: zephyr-runner-linux-x64-4xlarge
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.24.6
       options: '--entrypoint /bin/bash'
+      volumes:
+        - /repo-cache/zephyrproject:/github/cache/zephyrproject
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.2
@@ -37,26 +40,31 @@ jobs:
           #        GitHub comes up with a fundamental fix for this problem.
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
-      - name: Update PATH for west
+      - name: Clone cached Zephyr repository
+        continue-on-error: true
         run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          git clone --shared /github/cache/zephyrproject/zephyr .
+          git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
 
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: west setup
+      - name: Environment Setup
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          git config --global user.email "you@example.com"
-          git config --global user.name "Your Name"
-          git remote -v
+          git config --global user.email "bot@zephyrproject.org"
+          git config --global user.name "Zephyr Bot"
+          rm -fr ".git/rebase-apply"
           git rebase origin/${BASE_REF}
+          git log  --pretty=oneline | head -n 10
           west init -l . || true
+          west config manifest.group-filter -- +ci
           west config --global update.narrow true
-          west update 2>&1 1> west.update.log || west update 2>&1 1> west.update2.log
+          west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/zephyrproject)
+          west forall -c 'git reset --hard HEAD'
 
       - name: Run Bluetooth Tests with BSIM
         run: |

--- a/tests/bluetooth/bsim_bt/bsim_test_multiple/tests_scripts/multiple.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_multiple/tests_scripts/multiple.sh
@@ -13,7 +13,7 @@ function Execute(){
  compile it?)\e[39m"
     exit 1
   fi
-  timeout 900 $@ & process_ids="$process_ids $!"
+  timeout 1800 $@ & process_ids="$process_ids $!"
 }
 
 : "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"

--- a/tests/bluetooth/bsim_bt/compile.sh
+++ b/tests/bluetooth/bsim_bt/compile.sh
@@ -20,47 +20,49 @@ mkdir -p ${WORK_DIR}
 
 source ${ZEPHYR_BASE}/tests/bluetooth/bsim_bt/compile.source
 
-app=tests/bluetooth/bsim_bt/bsim_test_bond_overwrite_allowed compile
-app=tests/bluetooth/bsim_bt/bsim_test_bond_overwrite_denied compile
-app=tests/bluetooth/bsim_bt/bsim_test_notify compile
-app=tests/bluetooth/bsim_bt/bsim_test_notify_multiple compile
-app=tests/bluetooth/bsim_bt/bsim_test_eatt_notif conf_file=prj.conf compile
-app=tests/bluetooth/bsim_bt/bsim_test_gatt_caching compile
-app=tests/bluetooth/bsim_bt/bsim_test_eatt conf_file=prj_collision.conf compile
-app=tests/bluetooth/bsim_bt/bsim_test_eatt conf_file=prj_multiple_conn.conf compile
-app=tests/bluetooth/bsim_bt/bsim_test_eatt conf_file=prj_autoconnect.conf compile
+app=tests/bluetooth/bsim_bt/bsim_test_bond_overwrite_allowed compile &
+app=tests/bluetooth/bsim_bt/bsim_test_bond_overwrite_denied compile &
+app=tests/bluetooth/bsim_bt/bsim_test_notify compile &
+app=tests/bluetooth/bsim_bt/bsim_test_notify_multiple compile &
+app=tests/bluetooth/bsim_bt/bsim_test_eatt_notif conf_file=prj.conf compile &
+app=tests/bluetooth/bsim_bt/bsim_test_gatt_caching compile &
+app=tests/bluetooth/bsim_bt/bsim_test_eatt conf_file=prj_collision.conf compile &
+app=tests/bluetooth/bsim_bt/bsim_test_eatt conf_file=prj_multiple_conn.conf compile &
+app=tests/bluetooth/bsim_bt/bsim_test_eatt conf_file=prj_autoconnect.conf compile &
 app=tests/bluetooth/bsim_bt/bsim_test_app conf_file=prj_split.conf \
-  compile
+  compile &
 app=tests/bluetooth/bsim_bt/bsim_test_app conf_file=prj_split_privacy.conf \
-  compile
+  compile &
 app=tests/bluetooth/bsim_bt/bsim_test_app conf_file=prj_split_low_lat.conf \
-  compile
-app=tests/bluetooth/bsim_bt/bsim_test_multiple compile
-app=tests/bluetooth/bsim_bt/bsim_test_advx compile
-app=tests/bluetooth/bsim_bt/bsim_test_adv_chain compile
-app=tests/bluetooth/bsim_bt/bsim_test_gatt compile
-app=tests/bluetooth/bsim_bt/bsim_test_gatt_write compile
-app=tests/bluetooth/bsim_bt/bsim_test_l2cap compile
-app=tests/bluetooth/bsim_bt/bsim_test_l2cap_userdata compile
-app=tests/bluetooth/bsim_bt/bsim_test_l2cap_stress compile
-app=tests/bluetooth/bsim_bt/bsim_test_iso compile
+  compile &
+app=tests/bluetooth/bsim_bt/bsim_test_multiple compile &
+app=tests/bluetooth/bsim_bt/bsim_test_advx compile &
+app=tests/bluetooth/bsim_bt/bsim_test_adv_chain compile &
+app=tests/bluetooth/bsim_bt/bsim_test_gatt compile &
+app=tests/bluetooth/bsim_bt/bsim_test_gatt_write compile &
+app=tests/bluetooth/bsim_bt/bsim_test_l2cap compile &
+app=tests/bluetooth/bsim_bt/bsim_test_l2cap_userdata compile &
+app=tests/bluetooth/bsim_bt/bsim_test_l2cap_stress compile &
+app=tests/bluetooth/bsim_bt/bsim_test_iso compile &
 app=tests/bluetooth/bsim_bt/bsim_test_iso conf_file=prj_vs_dp.conf \
-  compile
-app=tests/bluetooth/bsim_bt/bsim_test_audio compile
+  compile &
+app=tests/bluetooth/bsim_bt/bsim_test_audio compile &
 app=tests/bluetooth/bsim_bt/edtt_ble_test_app/hci_test_app \
-  conf_file=prj_dut_llcp.conf compile
+  conf_file=prj_dut_llcp.conf compile &
 app=tests/bluetooth/bsim_bt/edtt_ble_test_app/hci_test_app \
-  conf_file=prj_tst_llcp.conf compile
+  conf_file=prj_tst_llcp.conf compile &
 app=tests/bluetooth/bsim_bt/edtt_ble_test_app/hci_test_app \
-  conf_file=prj_dut.conf compile
+  conf_file=prj_dut.conf compile &
 app=tests/bluetooth/bsim_bt/edtt_ble_test_app/hci_test_app \
-  conf_file=prj_tst.conf compile
+  conf_file=prj_tst.conf compile &
 app=tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app \
-  conf_file=prj.conf compile
+  conf_file=prj.conf compile &
 app=tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app \
-  conf_file=prj_llcp.conf compile
-app=tests/bluetooth/bsim_bt/bsim_test_mesh compile
-app=tests/bluetooth/bsim_bt/bsim_test_mesh conf_file=prj_low_lat.conf compile
-app=tests/bluetooth/bsim_bt/bsim_test_mesh conf_file=prj_pst.conf compile
-app=tests/bluetooth/bsim_bt/bsim_test_mesh conf_file=prj_gatt.conf compile
-app=tests/bluetooth/bsim_bt/bsim_test_disable compile
+  conf_file=prj_llcp.conf compile &
+app=tests/bluetooth/bsim_bt/bsim_test_mesh compile &
+app=tests/bluetooth/bsim_bt/bsim_test_mesh conf_file=prj_low_lat.conf compile &
+app=tests/bluetooth/bsim_bt/bsim_test_mesh conf_file=prj_pst.conf compile &
+app=tests/bluetooth/bsim_bt/bsim_test_mesh conf_file=prj_gatt.conf compile &
+app=tests/bluetooth/bsim_bt/bsim_test_disable compile &
+
+wait


### PR DESCRIPTION
This series updates the bluetooth-tests workflow to use the zephyr-runner and run with GNU parallel to reduce the test execution time.

This reduces the Bluetooth BSIM test execution time from approx. 50 min. avg. to 20 min. avg.