### PR TITLE
fs/fatfs: Move FF_USE_LFN logic to Kconfig

### DIFF
--- a/modules/fatfs/zephyr_fatfs_config.h
+++ b/modules/fatfs/zephyr_fatfs_config.h
@@ -33,14 +33,10 @@
 #define FF_CODE_PAGE 437
 #endif /* defined(CONFIG_FS_FATFS_CODEPAGE) */
 
-#if defined(CONFIG_FS_FATFS_LFN)
+#if defined(CONFIG_FS_FATFS_FF_USE_LFN)
+#if CONFIG_FS_FATFS_FF_USE_LFN <= 3
 #undef FF_USE_LFN
-#if CONFIG_FS_FATFS_LFN_MODE_BSS
-#define	FF_USE_LFN	1
-#elif CONFIG_FS_FATFS_LFN_MODE_STACK
-#define	FF_USE_LFN	2
-#elif CONFIG_FS_FATFS_LFN_MODE_HEAP
-#define	FF_USE_LFN	3
+#define FF_USE_LFN CONFIG_FS_FATFS_FF_USE_LFN
 #else
 #error Invalid LFN buffer location
 #endif

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -99,6 +99,15 @@ config FS_FATFS_LFN_MODE_HEAP
 
 endchoice
 
+config FS_FATFS_FF_USE_LFN
+	int
+	default 1 if FS_FATFS_LFN_MODE_BSS
+	default 2 if FS_FATFS_LFN_MODE_STACK
+	default 3 if FS_FATFS_LFN_MODE_HEAP
+	help
+	  Translates FS_FATFS_LFN_MODE selection to FF_USE_LFN, defined in ffconf.h,
+	  inside ELM FAT module.
+
 config FS_FATFS_MAX_LFN
 	int "Max filename length"
 	range 12 255


### PR DESCRIPTION
Commit add hidden Kconfig option CONFIG_FS_FATFS_FF_USE_LFN that is passed to ELM FAT to define FF_USE_LFN configuration. The FF_USE_LFN still depends, indirectly, on choice CONFIG_FS_FATFS_LFN_MODE config options
CONFIG_FS_FATFS_LFN_MODE_BSS, FS_FATFS_LFN_MODE_STACK and FS_FATFS_LFN_MODE_HEAP, but the ~~lofic~~ logic has been moved out of zephyr_fatfs_config.h into Kconfig file.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

**2022-12-08**: Fixed typo in commit message.