### PR TITLE
ace: cavs: dts: Add d-cache and i-cache line size

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -17,6 +17,8 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <0>;
 			cpu-power-states = <&d0i3 &d3>;
+			i-cache-line-size = <64>;
+			d-cache-line-size = <64>;
 		};
 
 		cpu1: cpu@1 {

--- a/dts/xtensa/intel/intel_adsp_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs15.dtsi
@@ -16,6 +16,8 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx4";
 			reg = <0>;
+			i-cache-line-size = <64>;
+			d-cache-line-size = <64>;
 		};
 
 		cpu1: cpu@1 {

--- a/dts/xtensa/intel/intel_adsp_cavs18.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs18.dtsi
@@ -16,6 +16,8 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <0>;
+			i-cache-line-size = <64>;
+			d-cache-line-size = <64>;
 		};
 
 		cpu1: cpu@1 {

--- a/dts/xtensa/intel/intel_adsp_cavs20.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs20.dtsi
@@ -16,6 +16,8 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <0>;
+			i-cache-line-size = <64>;
+			d-cache-line-size = <64>;
 		};
 
 		cpu1: cpu@1 {

--- a/dts/xtensa/intel/intel_adsp_cavs20_jsl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs20_jsl.dtsi
@@ -16,6 +16,8 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <0>;
+			i-cache-line-size = <64>;
+			d-cache-line-size = <64>;
 		};
 
 		cpu1: cpu@1 {

--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -16,6 +16,8 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <0>;
+			i-cache-line-size = <64>;
+			d-cache-line-size = <64>;
 		};
 
 		cpu1: cpu@1 {

--- a/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
@@ -16,6 +16,8 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <0>;
+			i-cache-line-size = <64>;
+			d-cache-line-size = <64>;
 		};
 
 		cpu1: cpu@1 {


### PR DESCRIPTION
Added i-cache-line-size and d-cache-line-size values to device tree for cavs and ace platforms. These values are used by sys_cache_instr_line_size_get and sys_cache_data_line_size_get functions.