### PR TITLE
Bluetooth: Mesh: Limit number of Bluetooth connections used by mesh

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -212,6 +212,14 @@ config BT_MESH_PROXY_FILTER_SIZE
 	  enough so that proxy client can communicate with several devices through
 	  this proxy server node using the default accept list filter type.
 
+config BT_MESH_MAX_CONN
+	int "Maximum number of simultaneous connections used by the stack"
+	default BT_MAX_CONN
+	range 1 BT_MAX_CONN
+	help
+	  Maximum number of simultaneous Bluetooth connections that the Bluetooth
+	  mesh stack can use.
+
 endif # BT_CONN
 
 config BT_MESH_ACCESS_LAYER_MSG

--- a/subsys/bluetooth/mesh/gatt_cli.c
+++ b/subsys/bluetooth/mesh/gatt_cli.c
@@ -302,7 +302,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 		return;
 	}
 
-	if (bt_mesh_proxy_conn_count_get() == CONFIG_BT_MAX_CONN) {
+	if (!bt_mesh_proxy_has_avail_conn()) {
 		return;
 	}
 

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -100,7 +100,7 @@ static void gatt_connected(struct bt_conn *conn, uint8_t err)
 
 	bt_conn_get_info(conn, &info);
 	if (info.role != BT_CONN_ROLE_PERIPHERAL || !service_registered ||
-	    bt_mesh_is_provisioned() || info.id != BT_ID_DEFAULT) {
+	    bt_mesh_is_provisioned() || info.id != BT_ID_DEFAULT || cli)  {
 		return;
 	}
 
@@ -115,14 +115,12 @@ static void gatt_disconnected(struct bt_conn *conn, uint8_t reason)
 
 	bt_conn_get_info(conn, &info);
 	if (info.role != BT_CONN_ROLE_PERIPHERAL || !service_registered ||
-	    info.id != BT_ID_DEFAULT) {
+	    info.id != BT_ID_DEFAULT || !cli || cli->conn != conn) {
 		return;
 	}
 
-	if (cli) {
-		bt_mesh_proxy_role_cleanup(cli);
-		cli = NULL;
-	}
+	bt_mesh_proxy_role_cleanup(cli);
+	cli = NULL;
 
 	bt_mesh_pb_gatt_close(conn);
 

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -271,7 +271,7 @@ int bt_mesh_pb_gatt_srv_adv_start(void)
 	BT_DBG("");
 
 	if (!service_registered || bt_mesh_is_provisioned() ||
-	    bt_mesh_proxy_conn_count_get() == CONFIG_BT_MAX_CONN) {
+	    !bt_mesh_proxy_has_avail_conn()) {
 		return -ENOTSUP;
 	}
 

--- a/subsys/bluetooth/mesh/proxy_msg.c
+++ b/subsys/bluetooth/mesh/proxy_msg.c
@@ -277,7 +277,7 @@ void bt_mesh_proxy_role_cleanup(struct bt_mesh_proxy_role *role)
 	bt_mesh_adv_gatt_update();
 }
 
-int bt_mesh_proxy_conn_count_get(void)
+bool bt_mesh_proxy_has_avail_conn(void)
 {
-	return conn_count;
+	return conn_count < CONFIG_BT_MESH_MAX_CONN;
 }

--- a/subsys/bluetooth/mesh/proxy_msg.h
+++ b/subsys/bluetooth/mesh/proxy_msg.h
@@ -57,6 +57,6 @@ struct bt_mesh_proxy_role *bt_mesh_proxy_role_setup(struct bt_conn *conn,
 						    proxy_recv_cb_t recv);
 void bt_mesh_proxy_role_cleanup(struct bt_mesh_proxy_role *role);
 
-int bt_mesh_proxy_conn_count_get(void);
+bool bt_mesh_proxy_has_avail_conn(void);
 
 #endif /* ZEPHYR_SUBSYS_BLUETOOTH_MESH_PROXY_MSG_H_ */

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -556,7 +556,7 @@ static int gatt_proxy_advertise(struct bt_mesh_subnet *sub)
 
 	BT_DBG("");
 
-	if (bt_mesh_proxy_conn_count_get() == CONFIG_BT_MAX_CONN) {
+	if (!bt_mesh_proxy_has_avail_conn()) {
 		BT_DBG("Connectable advertising deferred (max connections)");
 		return -ENOMEM;
 	}
@@ -847,7 +847,7 @@ static void gatt_connected(struct bt_conn *conn, uint8_t err)
 					       proxy_msg_recv);
 
 	/* Try to re-enable advertising in case it's possible */
-	if (bt_mesh_proxy_conn_count_get() < CONFIG_BT_MAX_CONN) {
+	if (bt_mesh_proxy_has_avail_conn()) {
 		bt_mesh_adv_gatt_update();
 	}
 }


### PR DESCRIPTION
When a remote devices establishes a ble connection with the mesh device
with default identity and there are more available connection slots, the
mesh stack will try to restart connectable advertisements (either
pb-gatt or proxy depending on the provisioning state). This makes
difficult for an application to advertise own connectable advertisements
as the mesh stack will not let a chance the app to start advertising.

This change adds a Kconfig option that limits number of connection slots
that the mesh stack can use for own connectable advertisements.

Additional fix:
- Ensure that another established connection with the mesh device don't
mess up pb-gatt server state.