### PR TITLE
FAT FS driver update to version 0.15

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -342,6 +342,7 @@ Libraries / Subsystems
 
   * Added new API call `fs_mkfs`.
   * Added new sample `samples/subsys/fs/format`.
+  * FAT FS driver has been updated to version 0.15 w/patch1.
 
 * Management
 

--- a/modules/fatfs/zephyr_fatfs_config.h
+++ b/modules/fatfs/zephyr_fatfs_config.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#if FFCONF_DEF != 86631
+#if FFCONF_DEF != 80286
 #error "Configuration version mismatch"
 #endif
 

--- a/modules/fatfs/zfs_diskio.c
+++ b/modules/fatfs/zfs_diskio.c
@@ -41,7 +41,7 @@ DSTATUS disk_initialize(BYTE pdrv)
 }
 
 /* Read Sector(s) */
-DRESULT disk_read(BYTE pdrv, BYTE *buff, DWORD sector, UINT count)
+DRESULT disk_read(BYTE pdrv, BYTE *buff, LBA_t sector, UINT count)
 {
 	__ASSERT(pdrv < ARRAY_SIZE(pdrv_str), "pdrv out-of-range\n");
 
@@ -54,7 +54,7 @@ DRESULT disk_read(BYTE pdrv, BYTE *buff, DWORD sector, UINT count)
 }
 
 /* Write Sector(s) */
-DRESULT disk_write(BYTE pdrv, const BYTE *buff, DWORD sector, UINT count)
+DRESULT disk_write(BYTE pdrv, const BYTE *buff, LBA_t sector, UINT count)
 {
 	__ASSERT(pdrv < ARRAY_SIZE(pdrv_str), "pdrv out-of-range\n");
 

--- a/west.yml
+++ b/west.yml
@@ -42,7 +42,7 @@ manifest:
       groups:
         - tools
     - name: fatfs
-      revision: 38f303ad09fdd687ee066a938f65ad708dd5989d
+      revision: 89f53db0207cdcea5bd9bdd64acc3e1ed9a65b15
       path: modules/fs/fatfs
       groups:
         - fs


### PR DESCRIPTION
The PR brings three commits that:
 1) update manifest revision to bring version 0.15 of FAT FS driver;
 2) bring necessary changes to Zephyr code.
 3) release notes update.

