### PR TITLE
Bluetooth: audio: has: Fix HAS features dynamic presets value

### DIFF
--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -1128,7 +1128,10 @@ static int has_init(const struct device *dev)
 
 	/* Initialize the supported features characteristic value */
 	has.features = CONFIG_BT_HAS_HEARING_AID_TYPE & BT_HAS_FEAT_HEARING_AID_TYPE_MASK;
-	has.features |= BT_HAS_FEAT_DYNAMIC_PRESETS;
+
+	if (IS_ENABLED(CONFIG_BT_HAS_PRESET_SUPPORT)) {
+		has.features |= BT_HAS_FEAT_DYNAMIC_PRESETS;
+	}
 
 	if (IS_ENABLED(CONFIG_BT_HAS_HEARING_AID_BINAURAL)) {
 		if (IS_ENABLED(CONFIG_BT_HAS_PRESET_SYNC_SUPPORT)) {


### PR DESCRIPTION
If there is no support for presets, Dynamic Presets feature flag should not be set.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>