### PR TITLE
scripts: gen_relocate_app: Fix a typo in parse_input_string()

### DIFF
--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -446,7 +446,7 @@ def get_obj_filename(searchpath, filename):
 def parse_input_string(line):
     line = line.replace('\\ :', ':')
 
-    flag_sep = ':NOCOPY' if ':NOCOPY' in line else ':COPY:'
+    flag_sep = ':NOCOPY:' if ':NOCOPY' in line else ':COPY:'
     mem_region_phdr, copy_flag, file_name = line.partition(flag_sep)
     copy_flag = copy_flag.replace(':', '')
 


### PR DESCRIPTION
This is a follow-up to commit b1a3ce4016e7cdc46b165e13c7f98110542e5f27.

`parse_input_string()` needs to use `:NOCOPY:`, not `:NOCOPY`, when partitioning input lines, otherwise, when a line contains the NOCOPY flag, the file name returned by the function starts with `:` and the file cannot be then found by the script.
Such problem can be observed in the code_relocation_nocopy sample, which without this fix does not actually relocate code from ext_code.c.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>