### PR TITLE
sys: linear_range: initial API

### DIFF
--- a/include/zephyr/sys/linear_range.h
+++ b/include/zephyr/sys/linear_range.h
@@ -1,0 +1,303 @@
+/*
+ * Copyright (C) 2022, Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef INCLUDE_ZEPHYR_SYS_LINEAR_RANGE_H_
+#define INCLUDE_ZEPHYR_SYS_LINEAR_RANGE_H_
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <zephyr/sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup linear_range Linear Range
+ *
+ * The linear range API maps values in a linear range to a range index. A linear
+ * range can be fully defined by four parameters:
+ *
+ * - Minimum value
+ * - Step value
+ * - Minimum index value
+ * - Maximum index value
+ *
+ * For example, in a voltage regulator, supported voltages typically map to a
+ * register index value like this:
+ *
+ * - 1000uV: 0x00
+ * - 1250uV: 0x01
+ * - 1500uV: 0x02
+ * - ...
+ * - 3000uV: 0x08
+ *
+ * In this case, we have:
+ *
+ * - Minimum value: 1000uV
+ * - Step value: 250uV
+ * - Minimum index value: 0x00
+ * - Maximum index value: 0x08
+ *
+ * A linear range may also be constant, that is, step set to zero.
+ *
+ * It is often the case where the same device has discontinuous linear ranges.
+ * The API offers utility functions to deal with groups of linear ranges as
+ * well.
+ *
+ * Implementation uses fixed-width integers. Range is limited to [INT32_MIN,
+ * INT32_MAX], while number of indices is limited to UINT16_MAX.
+ *
+ * Original idea borrowed from Linux.
+ * @{
+ */
+
+/** @brief Linear range. */
+struct linear_range {
+	/** Minimum value. */
+	int32_t min;
+	/** Step value. */
+	uint32_t step;
+	/** Minimum index (must be <= maximum index). */
+	uint16_t min_idx;
+	/** Maximum index (must be >= minimum index). */
+	uint16_t max_idx;
+};
+
+/**
+ * @brief Initializer for @ref linear_range.
+ *
+ * @param _min Minimum value in range.
+ * @param _step Step value.
+ * @param _min_idx Minimum index.
+ * @param _max_idx Maximum index.
+ */
+#define LINEAR_RANGE_INIT(_min, _step, _min_idx, _max_idx)                     \
+	{                                                                      \
+		.min = (_min),                                                 \
+		.step = (_step),                                               \
+		.min_idx = (_min_idx),                                         \
+		.max_idx = (_max_idx),                                         \
+	}
+
+/**
+ * @brief Obtain the number of values representable in a linear range.
+ *
+ * @param[in] r Linear range instance.
+ *
+ * @return Number of ranges representable by @p r.
+ */
+static inline uint32_t linear_range_values_count(const struct linear_range *r)
+{
+	if (r->step == 0U) {
+		return 1U;
+	}
+
+	return r->max_idx - r->min_idx + 1U;
+}
+
+/**
+ * @brief Obtain the number of values representable by a group of linear ranges.
+ *
+ * @param[in] r Array of linear range instances.
+ * @param r_cnt Number of linear range instances.
+ *
+ * @return Number of ranges representable by the @p r group.
+ */
+static inline uint32_t linear_range_group_values_count(
+	const struct linear_range *r, size_t r_cnt)
+{
+	uint32_t values = 0U;
+
+	for (size_t i = 0U; i < r_cnt; i++) {
+		values += linear_range_values_count(&r[i]);
+	}
+
+	return values;
+}
+
+/**
+ * @brief Obtain the maximum value representable by a linear range.
+ *
+ * @param[in] r Linear range instance.
+ *
+ * @return Maximum value representable by @p r.
+ */
+static inline int32_t linear_range_get_max_value(const struct linear_range *r)
+{
+	return r->min + (int32_t)(r->step * (r->max_idx - r->min_idx));
+}
+
+/**
+ * @brief Obtain value given a linear range index.
+ *
+ * @param[in] r Linear range instance.
+ * @param idx Range index.
+ * @param[out] val Where value will be stored.
+ *
+ * @retval 0 If successful
+ * @retval -EINVAL If index is out of range.
+ */
+static inline int linear_range_get_value(const struct linear_range *r,
+					 uint16_t idx, int32_t *val)
+{
+	if ((idx < r->min_idx) || (idx > r->max_idx)) {
+		return -EINVAL;
+	}
+
+	*val = r->min + (int32_t)(r->step * (idx - r->min_idx));
+
+	return 0;
+}
+
+/**
+ * @brief Obtain value in a group given a linear range index.
+ *
+ * @param[in] r Array of linear range instances.
+ * @param r_cnt Number of linear range instances.
+ * @param idx Range index.
+ * @param[out] val Where value will be stored.
+ *
+ * @retval 0 If successful
+ * @retval -EINVAL If index is out of range.
+ */
+static inline int linear_range_group_get_value(const struct linear_range *r,
+					       size_t r_cnt, uint16_t idx,
+					       int32_t *val)
+{
+	int ret = -EINVAL;
+
+	for (size_t i = 0U; (ret != 0) && (i < r_cnt); i++) {
+		ret = linear_range_get_value(&r[i], idx, val);
+	}
+
+	return ret;
+}
+
+/**
+ * @brief Obtain index given a value.
+ *
+ * @param[in] r Linear range instance.
+ * @param val Value.
+ * @param[out] idx Where index will be stored.
+ *
+ * @retval 0 If a valid index is found within the linear range.
+ * @retval -EINVAL If value is out of range.
+ */
+static inline int linear_range_get_index(const struct linear_range *r,
+					 int32_t val, uint16_t *idx)
+{
+	if ((val < r->min) || (val > linear_range_get_max_value(r))) {
+		return -EINVAL;
+	}
+
+	if (r->step == 0U) {
+		*idx = r->max_idx;
+		return 0;
+	}
+
+	*idx = r->min_idx + ceiling_fraction((uint32_t)(val - r->min), r->step);
+
+	return 0;
+}
+
+/**
+ * @brief Obtain index in a group given a value.
+ *
+ * @param[in] r Linear range instances.
+ * @param r_cnt Number of linear range instances.
+ * @param val Value.
+ * @param[out] idx Where index will be stored.
+ *
+ * @retval 0 If a valid index is found.
+ * @retval -EINVAL If value is out of range, or if the given window of values is
+ * too narrow.
+ */
+static inline int linear_range_group_get_index(const struct linear_range *r,
+					       size_t r_cnt, int32_t val,
+					       uint16_t *idx)
+{
+	int ret = -EINVAL;
+
+	for (size_t i = 0U; (ret != 0) && (i < r_cnt); i++) {
+		ret = linear_range_get_index(&r[i], val, idx);
+	}
+
+	return ret;
+}
+
+/**
+ * @brief Obtain index given a window of values.
+ *
+ * @param[in] r Linear range instance.
+ * @param val_min Minimum window value.
+ * @param val_max Maximum window value.
+ * @param[out] idx Where index will be stored.
+ *
+ * @retval 0 If a valid index is found within window.
+ * @retval -EINVAL If value is out of range, or if the given window of values is
+ * too narrow.
+ */
+static inline int linear_range_get_win_index(const struct linear_range *r,
+					     int32_t val_min, int32_t val_max,
+					     uint16_t *idx)
+{
+	if ((val_min < r->min) || (val_max > linear_range_get_max_value(r))) {
+		return -EINVAL;
+	}
+
+	if (r->step == 0U) {
+		*idx = r->max_idx;
+		return 0;
+	}
+
+	*idx = r->min_idx + ceiling_fraction((uint32_t)(val_min - r->min),
+					     r->step);
+
+	if ((r->min + r->step * (*idx - r->min_idx)) > val_max) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Obtain index in a group given a value that must be within a window of
+ * values.
+ *
+ * @param[in] r Linear range instances.
+ * @param r_cnt Number of linear range instances.
+ * @param val_min Minimum window value.
+ * @param val_max Maximum window value.
+ * @param[out] idx Where index will be stored.
+ *
+ * @retval 0 If a valid index is found within window.
+ * @retval -EINVAL If value is out of range, or if the given window of values is
+ * too narrow.
+ */
+static inline int linear_range_group_get_win_index(const struct linear_range *r,
+						   size_t r_cnt,
+						   int32_t val_min,
+						   int32_t val_max,
+						   uint16_t *idx)
+{
+	int ret = -EINVAL;
+
+	for (size_t i = 0U; (ret != 0) && (i < r_cnt); i++) {
+		ret = linear_range_get_win_index(&r[i], val_min, val_max, idx);
+	}
+
+	return ret;
+}
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INCLUDE_ZEPHYR_SYS_LINEAR_RANGE_H_ */

--- a/tests/lib/linear_range/CMakeLists.txt
+++ b/tests/lib/linear_range/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(linear_range)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/linear_range/prj.conf
+++ b/tests/lib/linear_range/prj.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y

--- a/tests/lib/linear_range/src/main.c
+++ b/tests/lib/linear_range/src/main.c
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/sys/linear_range.h>
+
+/*
+ * +-----+-----+
+ * | Val | Idx |
+ * +-----+-----+
+ * | -10 | 0   |
+ * | -5  | 1   |
+ * +-----+-----+
+ * | 0   | 2   |
+ * | 1   | 3   |
+ * +-----+-----+
+ * | 100 | 4   |
+ * | 130 | 5   |
+ * | 160 | 6   |
+ * | 190 | 7   |
+ * | 220 | 8   |
+ * | 250 | 9   |
+ * | 290 | 10  |
+ * +-----+-----+
+ * | 400 | 11  |
+ * | 400 | 12  |
+ * +-----+-----+
+ */
+static const struct linear_range r[] = {
+	LINEAR_RANGE_INIT(-10, 5U,  0U,  1U),
+	LINEAR_RANGE_INIT(0,   1U,  2U,  3U),
+	LINEAR_RANGE_INIT(100, 30U, 4U,  10U),
+	LINEAR_RANGE_INIT(400, 0U,  11U, 12U),
+};
+
+static const size_t r_cnt = ARRAY_SIZE(r);
+
+ZTEST(linear_range, test_linear_range_init)
+{
+	zassert_equal(r[0].min, -10);
+	zassert_equal(r[0].step, 5U);
+	zassert_equal(r[0].min_idx, 0U);
+	zassert_equal(r[0].max_idx, 1U);
+}
+
+ZTEST(linear_range, test_linear_range_values_count)
+{
+	zassert_equal(linear_range_values_count(&r[0]), 2U);
+	zassert_equal(linear_range_values_count(&r[1]), 2U);
+	zassert_equal(linear_range_values_count(&r[2]), 7U);
+	zassert_equal(linear_range_values_count(&r[3]), 1U);
+
+	zassert_equal(linear_range_group_values_count(r, r_cnt), 12U);
+}
+
+ZTEST(linear_range, test_linear_range_get_max_value)
+{
+	zassert_equal(linear_range_get_max_value(&r[0]), -5);
+	zassert_equal(linear_range_get_max_value(&r[1]), 1);
+	zassert_equal(linear_range_get_max_value(&r[2]), 280);
+	zassert_equal(linear_range_get_max_value(&r[3]), 400);
+}
+
+ZTEST(linear_range, test_linear_range_get_value)
+{
+	int ret;
+	int32_t val;
+
+	ret = linear_range_get_value(&r[0], 0U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, -10);
+
+	ret = linear_range_get_value(&r[0], 1U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, -5);
+
+	ret = linear_range_get_value(&r[1], 2U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 0);
+
+	ret = linear_range_get_value(&r[1], 3U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 1);
+
+	ret = linear_range_get_value(&r[2], 4U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 100);
+
+	ret = linear_range_get_value(&r[2], 5U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 130);
+
+	ret = linear_range_get_value(&r[2], 6U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 160);
+
+	ret = linear_range_get_value(&r[2], 7U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 190);
+
+	ret = linear_range_get_value(&r[2], 8U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 220);
+
+	ret = linear_range_get_value(&r[2], 9U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 250);
+
+	ret = linear_range_get_value(&r[2], 10U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 280);
+
+	ret = linear_range_get_value(&r[3], 11U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 400);
+
+	ret = linear_range_get_value(&r[3], 12U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 400);
+
+	ret = linear_range_get_value(&r[1], 13U, &val);
+	zassert_equal(ret, -EINVAL);
+
+	ret = linear_range_group_get_value(r, r_cnt, 0U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, -10);
+
+	ret = linear_range_group_get_value(r, r_cnt, 1U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, -5);
+
+	ret = linear_range_group_get_value(r, r_cnt, 2U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 0);
+
+	ret = linear_range_group_get_value(r, r_cnt, 3U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 1);
+
+	ret = linear_range_group_get_value(r, r_cnt, 4U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 100);
+
+	ret = linear_range_group_get_value(r, r_cnt, 5U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 130);
+
+	ret = linear_range_group_get_value(r, r_cnt, 6U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 160);
+
+	ret = linear_range_group_get_value(r, r_cnt, 7U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 190);
+
+	ret = linear_range_group_get_value(r, r_cnt, 8U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 220);
+
+	ret = linear_range_group_get_value(r, r_cnt, 9U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 250);
+
+	ret = linear_range_group_get_value(r, r_cnt, 10U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 280);
+
+	ret = linear_range_group_get_value(r, r_cnt, 11U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 400);
+
+	ret = linear_range_group_get_value(r, r_cnt, 12U, &val);
+	zassert_equal(ret, 0);
+	zassert_equal(val, 400);
+}
+
+ZTEST(linear_range, test_linear_range_get_index)
+{
+	int ret;
+	uint16_t idx;
+
+	/* negative */
+	ret = linear_range_get_index(&r[0], -10, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 0U);
+
+	ret = linear_range_get_index(&r[0], -7, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 1U);
+
+	/* out of range (< min, > max) */
+	ret = linear_range_get_index(&r[1], -1, &idx);
+	zassert_equal(ret, -EINVAL);
+
+	ret = linear_range_get_index(&r[1], 2, &idx);
+	zassert_equal(ret, -EINVAL);
+
+	/* range limits */
+	ret = linear_range_get_index(&r[2], 100, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 4U);
+
+	ret = linear_range_get_index(&r[2], 280, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 10U);
+
+	/* rounding: 120->130 (5) */
+	ret = linear_range_get_index(&r[2], 120, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 5U);
+
+	/* always maximum index in constant ranges */
+	ret = linear_range_get_index(&r[3], 400, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 12U);
+
+	/* group */
+	ret = linear_range_group_get_index(r, r_cnt, -20, &idx);
+	zassert_equal(ret, -EINVAL);
+
+	ret = linear_range_group_get_index(r, r_cnt, 50, &idx);
+	zassert_equal(ret, -EINVAL);
+
+	ret = linear_range_group_get_index(r, r_cnt, -6, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 1U);
+
+	ret = linear_range_group_get_index(r, r_cnt, 0, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 2U);
+
+	ret = linear_range_group_get_index(r, r_cnt, 200, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 8U);
+
+	ret = linear_range_group_get_index(r, r_cnt, 400, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 12U);
+}
+
+ZTEST(linear_range, test_linear_range_get_win_index)
+{
+	int ret;
+	uint16_t idx;
+
+	/* negative */
+	ret = linear_range_get_win_index(&r[0], -10, -6, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 0U);
+
+	ret = linear_range_get_win_index(&r[0], -7, -5, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 1U);
+
+	/* out of range (< min, > max) */
+	ret = linear_range_get_win_index(&r[1], -1, 0, &idx);
+	zassert_equal(ret, -EINVAL);
+
+	ret = linear_range_get_win_index(&r[1], 2, 3, &idx);
+	zassert_equal(ret, -EINVAL);
+
+	/* min/max equal */
+	ret = linear_range_get_win_index(&r[2], 100, 100, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 4U);
+
+	/* always minimum index that satisfies >= min */
+	ret = linear_range_get_win_index(&r[2], 100, 180, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 4U);
+
+	/* rounding: 120->130, maximum < 130 */
+	ret = linear_range_get_win_index(&r[2], 120, 140, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 5U);
+
+	/* rounding: 120->130, maximum > 125 (range too narrow) */
+	ret = linear_range_get_win_index(&r[2], 120, 125, &idx);
+	zassert_equal(ret, -EINVAL);
+
+	ret = linear_range_group_get_win_index(r, r_cnt, 120, 125, &idx);
+	zassert_equal(ret, -EINVAL);
+
+	/* always maximum index in constant ranges */
+	ret = linear_range_get_win_index(&r[3], 400, 400, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 12U);
+
+	/* group */
+	ret = linear_range_group_get_win_index(r, r_cnt, -10, -8, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 0U);
+
+	ret = linear_range_group_get_win_index(r, r_cnt, 0, 1, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 2U);
+
+	ret = linear_range_group_get_win_index(r, r_cnt, 120, 140, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 5U);
+
+	ret = linear_range_group_get_win_index(r, r_cnt, 400, 400, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 12U);
+}
+
+ZTEST_SUITE(linear_range, NULL, NULL, NULL, NULL, NULL);

--- a/tests/lib/linear_range/testcase.yaml
+++ b/tests/lib/linear_range/testcase.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  libraries.linear_range:
+    integration_platforms:
+      - native_posix


### PR DESCRIPTION
This patch adds a new API to map values in a linear range to a range
index. This API is useful in the context of regulators, where it is
common that devices map regulator voltages to a set of indices with a
linear relationship.

The original idea is borrowed from Linux.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>