### PR TITLE
lib: posix: make sleep() and usleep() standards-compliant

### DIFF
--- a/lib/posix/sleep.c
+++ b/lib/posix/sleep.c
@@ -14,8 +14,12 @@
  */
 unsigned sleep(unsigned int seconds)
 {
-	k_sleep(K_SECONDS(seconds));
-	return 0;
+	int rem;
+
+	rem = k_sleep(K_SECONDS(seconds));
+	__ASSERT_NO_MSG(rem >= 0);
+
+	return rem / MSEC_PER_SEC;
 }
 /**
  * @brief Suspend execution for microsecond intervals.

--- a/lib/posix/sleep.c
+++ b/lib/posix/sleep.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
+
 #include <zephyr/kernel.h>
 #include <zephyr/posix/unistd.h>
 
@@ -28,10 +30,19 @@ unsigned sleep(unsigned int seconds)
  */
 int usleep(useconds_t useconds)
 {
-	if (useconds < USEC_PER_MSEC) {
-		k_busy_wait(useconds);
-	} else {
-		k_msleep(useconds / USEC_PER_MSEC);
+	int32_t rem;
+
+	if (useconds >= USEC_PER_SEC) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	rem = k_usleep(useconds);
+	__ASSERT_NO_MSG(rem >= 0);
+	if (rem > 0) {
+		/* sleep was interrupted by a call to k_wakeup() */
+		errno = EINTR;
+		return -1;
 	}
 
 	return 0;

--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -23,11 +23,9 @@ ZTEST(posix_apis, test_posix_clock)
 			NULL);
 	zassert_equal(errno, EINVAL);
 
-	clock_gettime(CLOCK_MONOTONIC, &ts);
-	/* 2 Sec Delay */
-	sleep(SLEEP_SECONDS);
-	usleep(SLEEP_SECONDS * USEC_PER_SEC);
-	clock_gettime(CLOCK_MONOTONIC, &te);
+	zassert_ok(clock_gettime(CLOCK_MONOTONIC, &ts));
+	zassert_ok(k_sleep(K_SECONDS(SLEEP_SECONDS)));
+	zassert_ok(clock_gettime(CLOCK_MONOTONIC, &te));
 
 	if (te.tv_nsec >= ts.tv_nsec) {
 		secs_elapsed = te.tv_sec - ts.tv_sec;
@@ -38,7 +36,7 @@ ZTEST(posix_apis, test_posix_clock)
 	}
 
 	/*TESTPOINT: Check if POSIX clock API test passes*/
-	zassert_equal(secs_elapsed, (2 * SLEEP_SECONDS),
+	zassert_equal(secs_elapsed, SLEEP_SECONDS,
 			"POSIX clock API test failed");
 
 	printk("POSIX clock APIs test done\n");

--- a/tests/posix/common/src/sleep.c
+++ b/tests/posix/common/src/sleep.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022, Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/posix/unistd.h>
+#include <zephyr/ztest.h>
+
+struct waker_work {
+	k_tid_t tid;
+	struct k_work_delayable dwork;
+};
+static struct waker_work ww;
+
+static void waker_func(struct k_work *work)
+{
+	struct waker_work *ww;
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+
+	ww = CONTAINER_OF(dwork, struct waker_work, dwork);
+	k_wakeup(ww->tid);
+}
+K_WORK_DELAYABLE_DEFINE(waker, waker_func);
+
+ZTEST(posix_apis, test_sleep)
+{
+	uint32_t then;
+	uint32_t now;
+	/* call sleep(10), wakeup after 1s, expect >= 8s left */
+	const uint32_t sleep_min_s = 1;
+	const uint32_t sleep_max_s = 10;
+	const uint32_t sleep_rem_s = 8;
+
+	/* sleeping for 0s should return 0 */
+	zassert_ok(sleep(0));
+
+	/* test that sleeping for 1s sleeps for at least 1s */
+	then = k_uptime_get();
+	zassert_equal(0, sleep(1));
+	now = k_uptime_get();
+	zassert_true((now - then) >= 1 * MSEC_PER_SEC);
+
+	/* test that sleeping for 2s sleeps for at least 2s */
+	then = k_uptime_get();
+	zassert_equal(0, sleep(2));
+	now = k_uptime_get();
+	zassert_true((now - then) >= 2 * MSEC_PER_SEC);
+
+	/* test that sleep reports the remainder */
+	ww.tid = k_current_get();
+	k_work_init_delayable(&ww.dwork, waker_func);
+	zassert_equal(1, k_work_schedule(&ww.dwork, K_SECONDS(sleep_min_s)));
+	zassert_true(sleep(sleep_max_s) >= sleep_rem_s);
+}
+
+ZTEST(posix_apis, test_usleep)
+{
+	uint32_t then;
+	uint32_t now;
+
+	/* test usleep works for small values */
+	/* Note: k_usleep(), an implementation detail, is a cancellation point */
+	zassert_equal(0, usleep(0));
+	zassert_equal(0, usleep(1));
+
+	/* sleep for the spec limit */
+	then = k_uptime_get();
+	zassert_equal(0, usleep(USEC_PER_SEC - 1));
+	now = k_uptime_get();
+	zassert_true(((now - then) * USEC_PER_MSEC) / (USEC_PER_SEC - 1) >= 1);
+
+	/* sleep for exactly the limit threshold */
+	zassert_equal(-1, usleep(USEC_PER_SEC));
+	zassert_equal(errno, EINVAL);
+
+	/* sleep for over the spec limit */
+	zassert_equal(-1, usleep((useconds_t)ULONG_MAX));
+	zassert_equal(errno, EINVAL);
+
+	/* test that sleep reports errno = EINTR when woken up */
+	ww.tid = k_current_get();
+	k_work_init_delayable(&ww.dwork, waker_func);
+	zassert_equal(1, k_work_schedule(&ww.dwork, K_USEC(USEC_PER_SEC / 2)));
+	zassert_equal(-1, usleep(USEC_PER_SEC - 1));
+	zassert_equal(EINTR, errno);
+}


### PR DESCRIPTION
4 commits:
* lib: posix: `sleep()` should report unslept time in seconds
* lib: posix: update `usleep()` to follow the POSIX spec
* tests: posix: add tests for `sleep()` and `usleep()`
* tests: posix: clock: do not use usleep in a broken way

See individual commit messages for details.

Fixes #51776
Fixes #52517
Fixes #52518