### PR TITLE
drivers: counter: add st,stm32-counter to stm32h7

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -528,6 +528,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers3: timers@40000400 {
@@ -544,6 +549,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -562,6 +572,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers5: timers@40000c00 {
@@ -579,6 +594,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers6: timers@40001000 {
@@ -590,6 +610,11 @@
 			interrupt-names = "global";
 			st,prescaler = <0>;
 			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers7: timers@40001400 {
@@ -601,6 +626,11 @@
 			interrupt-names = "global";
 			st,prescaler = <0>;
 			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers8: timers@40010400 {
@@ -635,6 +665,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers13: timers@40001c00 {
@@ -651,6 +686,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -669,6 +709,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers15: timers@40014000 {
@@ -685,6 +730,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -703,6 +753,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers17: timers@40014800 {
@@ -719,6 +774,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/tests/drivers/counter/counter_basic_api/boards/stm32h747i_disco_m7.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/stm32h747i_disco_m7.overlay
@@ -1,0 +1,87 @@
+&timers2 {
+	st,prescaler = <239>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers3 {
+	st,prescaler = <239>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers4 {
+	st,prescaler = <239>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers5 {
+	st,prescaler = <239>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers6 {
+	st,prescaler = <239>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers7 {
+	st,prescaler = <239>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers12 {
+	st,prescaler = <239>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers13 {
+	st,prescaler = <239>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers14 {
+	st,prescaler = <239>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers15 {
+	st,prescaler = <239>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <239>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers17 {
+	st,prescaler = <239>;
+	counter {
+		status = "okay";
+	};
+};
+
+&rtc {
+	status = "disabled";
+};


### PR DESCRIPTION
The STM32H7 was missing definitions in it's devicetree include for the stm32-counter

Signed-off-by: Ryan McClelland <ryanmcclelland@meta.com>