### PR TITLE
drivers: dma: gpdma: reduce logging verbosity

### DIFF
--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -719,7 +719,7 @@ static int dw_dma_avail_data_size(uint32_t base,
 		if (delta) {
 			size = chan_data->ptr_data.buffer_bytes;
 		} else {
-			LOG_INF("%s size is 0!", __func__);
+			LOG_DBG("%s size is 0!", __func__);
 		}
 	}
 
@@ -751,7 +751,7 @@ static int dw_dma_free_data_size(uint32_t base,
 		if (delta) {
 			size = chan_data->ptr_data.buffer_bytes;
 		} else {
-			LOG_INF("%s size is 0!", __func__);
+			LOG_DBG("%s size is 0!", __func__);
 		}
 	}
 


### PR DESCRIPTION
Reduce logging verbosity in status call from INF to DBG as the function can be called any given time i.e. eveything is fine even if the read and write pointers don't differ.

Signed-off-by: Jaska Uimonen <jaska.uimonen@linux.intel.com>