### PR TITLE
Bluetooth: tests: shell: Fix build error

### DIFF
--- a/subsys/bluetooth/shell/CMakeLists.txt
+++ b/subsys/bluetooth/shell/CMakeLists.txt
@@ -74,7 +74,7 @@ zephyr_library_sources_ifdef(
   has.c
   )
 zephyr_library_sources_ifdef(
-  CONFIG_BT_CAP_ACCEPTOR
+  CONFIG_BT_CAP_ACCEPTOR_SET_MEMBER
   cap_acceptor.c
   )
 zephyr_library_sources_ifdef(

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -258,7 +258,6 @@ tests:
     build_only: true
     platform_allow: native_posix
     extra_configs:
-      - CONFIG_BT_CAP_ACCEPTOR=n
       - CONFIG_BT_CAP_ACCEPTOR_SET_MEMBER=n
   bluetooth.audio_shell.no_cap_initiator:
     extra_args: CONF_FILE="audio.conf"


### PR DESCRIPTION
This fixes build error that happened if CONFIG_BT_CAP_ACCEPTOR_SET_MEMBER was not set. This fixes the build test case as well.