### PR TITLE
Add CONFIG_FS_FATFS_MIN_SS  Kconfig option for FAT FS

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -1386,6 +1386,8 @@ Libraries / Subsystems
   * Added cash used to reduce the NVS data lookup time, see
     :kconfig:option:`CONFIG_NVS_LOOKUP_CACHE` option.
   * Changing mkfs options to create FAT32 on larger storage when FAT16 fails.
+  * Added :kconfig:option:`CONFIG_FS_FATFS_MIN_SS` that allows to set
+    minimal expected sector size to be supported.
 
 * Management
 

--- a/modules/fatfs/zephyr_fatfs_config.h
+++ b/modules/fatfs/zephyr_fatfs_config.h
@@ -51,6 +51,11 @@
 #define	FF_MAX_LFN	CONFIG_FS_FATFS_MAX_LFN
 #endif /* defined(CONFIG_FS_FATFS_MAX_LFN) */
 
+#if defined(CONFIG_FS_FATFS_MIN_SS)
+#undef FF_MIN_SS
+#define FF_MIN_SS	CONFIG_FS_FATFS_MIN_SS
+#endif /* defined(CONFIG_FS_FATFS_MIN_SS) */
+
 #if defined(CONFIG_FS_FATFS_MAX_SS)
 #undef FF_MAX_SS
 #define FF_MAX_SS		CONFIG_FS_FATFS_MAX_SS

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -142,6 +142,20 @@ config FS_FATFS_MAX_SS
 	range 512 4096
 	default 512
 
+config FS_FATFS_MIN_SS
+	int "Minimum expected sector size"
+	range 512 FS_FATFS_MAX_SS
+	default 512
+	help
+	  Specifies minimum sector size the FAT FS driver is expected to
+	  support. Set this to FS_FATFS_MAX_FS when you have single
+	  device with FAT FS or all connected devices use the same
+	  sector size, to have slight reduction in code in FAT FS driver.
+	  The reduction comes from the fact that FAT FS does not have to
+	  query every connected device for sector size.
+	  This option affects FF_MAX_SS defined in ffconf.h, inside
+	  ELM FAT module
+
 config FS_FATFS_WINDOW_ALIGNMENT
 	int "Memory alignment for the member \"win\" in FATFS"
 	default 1


### PR DESCRIPTION
Option adds ability to set lower range of supported sector sizes.
This option, together with `CONFIG_FS_FATFS_MAX_SS` decides whether one sector size is used by all devices or different sector sizes are used. The former case allows to reduce code size as there is no need to query device for sector size before operations,
the later case allows to use devices with different sector size, at cost of increased code size.

Two commits:
 1) The change to Kconfig and FAT FS module configuration header;
 2) Release notes

Size test for `CONFIG_FS_FATFS_MIN_SS == CONFIG_FS_FATFS_MAX_SS == 512`
```
west build -d ttt -b nrf52840dk_nrf52840 samples/subsys/fs/fat_fs/ -DCONFIG_FS_FATFS_MIN_SS=512 -DCONFIG_FS_FATFS_MAX_SS=512
...
Memory region         Used Size  Region Size  %age Used
           FLASH:       42728 B         1 MB      4.07%
             RAM:       10000 B       256 KB      3.81%
        IDT_LIST:          0 GB         2 KB      0.00%
```
and for `CONFIG_FS_FATFS_MIN_SS == 512` and ~~`CONFIG_FS_FATFS_MAX_SS == 4095`~~ `CONFIG_FS_FATFS_MAX_SS == 4096`

```
west build -d ttt -b nrf52840dk_nrf52840 samples/subsys/fs/fat_fs/ -DCONFIG_FS_FATFS_MIN_SS=512 -DCONFIG_FS_FATFS_MAX_SS=4096
...

Memory region         Used Size  Region Size  %age Used
           FLASH:       43064 B         1 MB      4.11%
             RAM:       13584 B       256 KB      5.18%
        IDT_LIST:          0 GB         2 KB      0.00%
```


