### PR TITLE
tests: use ignore_fault field instead of tags

### DIFF
--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -27,6 +27,8 @@ class TwisterConfigParser:
                        "arch_exclude": {"type": "set"},
                        "extra_sections": {"type": "list", "default": []},
                        "integration_platforms": {"type": "list", "default": []},
+                       "ignore_faults": {"type": "bool", "default": False },
+                       "ignore_qemu_crash": {"type": "bool", "default": False },
                        "testcases": {"type": "list", "default": []},
                        "platform_type": {"type": "list", "default": []},
                        "platform_exclude": {"type": "set"},

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -658,7 +658,7 @@ class QEMUHandler(Handler):
 
         self.pid_fn = os.path.join(instance.build_dir, "qemu.pid")
 
-        if "ignore_qemu_crash" in instance.testsuite.tags:
+        if instance.testsuite.ignore_qemu_crash:
             self.ignore_qemu_crash = True
             self.ignore_unexpected_eof = True
         else:

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -59,7 +59,7 @@ class Harness:
         config = instance.testsuite.harness_config
         self.id = instance.testsuite.id
         self.run_id = instance.run_id
-        if "ignore_faults" in instance.testsuite.tags:
+        if instance.testsuite.ignore_faults:
             self.fail_on_fault = False
 
         if config:

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -43,6 +43,12 @@ mapping:
         required: false
         sequence:
           - type: str
+      "ignore_faults":
+        type: bool
+        required: false
+      "ignore_qemu_crash":
+        type: bool
+        required: false
       "testcases":
         type: seq
         required: false
@@ -199,6 +205,12 @@ mapping:
             required: false
             sequence:
               - type: str
+          "ignore_faults":
+            type: bool
+            required: false
+          "ignore_qemu_crash":
+            type: bool
+            required: false
           "harness":
             type: str
             required: false

--- a/tests/arch/arm/arm_interrupt/testcase.yaml
+++ b/tests/arch/arm/arm_interrupt/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
-  tags: arm fpu interrupt ignore_faults
+  tags: arm fpu interrupt
+  ignore_faults: true
   arch_allow: arm
 tests:
   arch.interrupt.arm:

--- a/tests/arch/x86/static_idt/testcase.yaml
+++ b/tests/arch/x86/static_idt/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   arch.x86.interrupt:
+    ignore_faults: True
     arch_allow: x86
     filter: not CONFIG_X86_64
-    tags: ignore_faults interrupt idt
+    tags: interrupt idt

--- a/tests/drivers/coredump/coredump_api/testcase.yaml
+++ b/tests/drivers/coredump/coredump_api/testcase.yaml
@@ -1,9 +1,12 @@
 # Copyright Meta Platforms, Inc. and its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 
+common:
+  tags: coredump
+  ignore_faults: True
+  ignore_qemu_crash: True
 tests:
   drivers.coredump.api.qemu_riscv32:
-    tags: ignore_faults ignore_qemu_crash
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     platform_allow: qemu_riscv32
     harness: console
@@ -27,7 +30,6 @@ tests:
         - "E: #CD:babababa"
         - "E: #CD:END#"
   drivers.coredump.api:
-    tags: ignore_faults ignore_qemu_crash
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     platform_exclude: qemu_riscv32
     harness: console

--- a/tests/kernel/condvar/condvar_api/testcase.yaml
+++ b/tests/kernel/condvar/condvar_api/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.condvar:
-    tags: kernel userspace condition_variables ignore_faults
+    ignore_faults: True
+    tags: kernel userspace condition_variables

--- a/tests/kernel/events/sys_event/testcase.yaml
+++ b/tests/kernel/events/sys_event/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   kernel.events.usage:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: kernel userspace ignore_faults
+    tags: kernel userspace
+    ignore_faults: True

--- a/tests/kernel/fatal/exception/testcase.yaml
+++ b/tests/kernel/fatal/exception/testcase.yaml
@@ -1,26 +1,28 @@
+common:
+  ignore_faults: True
 tests:
   kernel.common.stack_protection:
     extra_args: CONF_FILE=prj.conf
     platform_exclude: twr_ke18f
     filter: CONFIG_ARCH_HAS_STACK_PROTECTION
-    tags: kernel ignore_faults userspace
+    tags: kernel userspace
   kernel.common.stack_protection_no_userspace:
     extra_args: CONF_FILE=protection_no_userspace.conf
     filter: CONFIG_ARCH_HAS_STACK_PROTECTION
     arch_allow: arm
-    tags: kernel ignore_faults memory_protection
+    tags: kernel memory_protection
   kernel.common.stack_protection_arm_fpu_sharing:
     extra_args: CONF_FILE=prj_arm_fpu_sharing.conf
     platform_exclude: twr_ke18f
     filter: CONFIG_ARCH_HAS_STACK_PROTECTION and CONFIG_ARMV7_M_ARMV8_M_FP
-    tags: fpu kernel ignore_faults userspace
+    tags: fpu kernel userspace
   kernel.common.stack_protection_armv8m_mpu_stack_guard:
     extra_args: CONF_FILE=prj_armv8m_mpu_stack_guard.conf
     filter: CONFIG_ARM_MPU and CONFIG_ARMV8_M_MAINLINE
     arch_allow: arm
-    tags: kernel ignore_faults userspace
+    tags: kernel userspace
   kernel.common.stack_sentinel:
     extra_args: CONF_FILE=sentinel.conf
     # FIXME: See issue #39948
     platform_exclude: qemu_cortex_a9
-    tags: kernel ignore_faults
+    tags: kernel

--- a/tests/kernel/fatal/no-multithreading/testcase.yaml
+++ b/tests/kernel/fatal/no-multithreading/testcase.yaml
@@ -1,7 +1,8 @@
 common:
   platform_allow: qemu_cortex_m3 qemu_arc_em qemu_arc_hs qemu_arc_hs6x nsim_em nsim_em7d_v22
     nsim_hs nsim_hs_mpuv6 nsim_hs5x nsim_hs6x
-  tags: kernel ignore_faults
+  tags: kernel scheduler
+  ignore_faults: True
 tests:
   kernel.no-mt.cpu_exception:
     extra_args: EXTRA_CPPFLAGS=-DVIA_TWISTER=0

--- a/tests/kernel/mem_protect/demand_paging/testcase.yaml
+++ b/tests/kernel/mem_protect/demand_paging/testcase.yaml
@@ -1,9 +1,11 @@
+common:
+  ignore_faults: True
 tests:
   kernel.demand_paging:
-    tags: kernel mmu demand_paging ignore_faults
+    tags: kernel mmu demand_paging
     filter: CONFIG_DEMAND_PAGING
   kernel.demand_paging.timing_funcs:
-    tags: kernel mmu demand_paging ignore_faults
+    tags: kernel mmu demand_paging
     platform_allow: qemu_x86_tiny
     filter: CONFIG_DEMAND_PAGING
     extra_configs:

--- a/tests/kernel/mem_protect/mem_map/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_map/testcase.yaml
@@ -1,22 +1,21 @@
+common:
+  ignore_faults: true
+  tags: kernel mmu
 tests:
   kernel.memory_protection.mem_map:
-    tags: kernel mmu ignore_faults
     filter: CONFIG_MMU and not CONFIG_X86_64
     extra_sections: _TRANSPLANTED_FUNC
     extra_args: CONFIG_PICOLIBC_HEAP_SIZE=0
     platform_exclude: qemu_x86_64
   kernel.memory_protection.mem_map.x86_64:
-    tags: kernel mmu ignore_faults
     filter: CONFIG_MMU and CONFIG_X86_64 and not CONFIG_COVERAGE
     extra_sections: _TRANSPLANTED_FUNC
   kernel.memory_protection.mem_map.x86_64.coverage:
-    tags: kernel mmu ignore_faults
     filter: CONFIG_MMU and CONFIG_X86_64 and CONFIG_COVERAGE
     extra_sections: _TRANSPLANTED_FUNC
     extra_args: EXTRA_CFLAGS=-DSKIP_EXECUTE_TESTS
     platform_allow: qemu_x86_64
   kernel.memory_protection.mem_map.x86_64.coverage.exec:
-    tags: kernel mmu ignore_faults
     filter: CONFIG_MMU and CONFIG_X86_64 and CONFIG_COVERAGE
     extra_sections: _TRANSPLANTED_FUNC
     extra_args: CONF_FILE=prj_x86_64_coverage_exec.conf

--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -1,3 +1,6 @@
+common:
+  ignore_faults: true
+  tags: kernel security userspace
 tests:
   kernel.memory_protection:
     filter: CONFIG_ARCH_HAS_USERSPACE
@@ -7,15 +10,12 @@ tests:
     # gets propagated to new Zephyr-SDK.
     platform_exclude: twr_ke18f qemu_arc_hs qemu_arc_em
     extra_args: CONFIG_TEST_HW_STACK_PROTECTION=n
-    tags: kernel security userspace ignore_faults
   kernel.memory_protection.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     arch_allow: arc
     extra_args: CONFIG_MPU_GAP_FILLING=y
-    tags: kernel security userspace ignore_faults
   kernel.memory_protection.gap_filling.arm:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     arch_allow: arm
     platform_allow: efr32_radio_brd4180a mps2_an521 nrf9160dk_nrf9160
     extra_args: CONFIG_MPU_GAP_FILLING=y
-    tags: kernel security userspace ignore_faults

--- a/tests/kernel/mem_protect/protection/testcase.yaml
+++ b/tests/kernel/mem_protect/protection/testcase.yaml
@@ -2,4 +2,5 @@ tests:
   kernel.memory_protection.protection:
     platform_exclude: twr_ke18f
     filter: CONFIG_SRAM_REGION_PERMISSIONS
-    tags: kernel security ignore_faults
+    tags: kernel security
+    ignore_faults: true

--- a/tests/kernel/mem_protect/stackprot/testcase.yaml
+++ b/tests/kernel/mem_protect/stackprot/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   kernel.memory_protection.stackprot:
     arch_exclude: nios2 xtensa posix sparc
-    tags: kernel ignore_faults userspace
+    tags: kernel userspace
+    ignore_faults: true

--- a/tests/kernel/mem_protect/syscalls/testcase.yaml
+++ b/tests/kernel/mem_protect/syscalls/testcase.yaml
@@ -1,7 +1,8 @@
 tests:
   kernel.memory_protection.syscalls:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: kernel security userspace ignore_faults
+    tags: kernel security userspace
+    ignore_faults: true
     # FIXME: This test may fail for qemu_arc_em on certain host systems.
     #        See foss-for-synopsys-dwc-arc-processors/qemu#66.
     platform_exclude: qemu_arc_em

--- a/tests/kernel/mem_protect/userspace/testcase.yaml
+++ b/tests/kernel/mem_protect/userspace/testcase.yaml
@@ -1,18 +1,18 @@
+common:
+  ignore_faults: true
+  tags: kernel security userspace
 tests:
   kernel.memory_protection.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_TEST_HW_STACK_PROTECTION=n
       - CONFIG_PICOLIBC_HEAP_SIZE=0
-    tags: kernel security userspace ignore_faults
   kernel.memory_protection.userspace.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     arch_allow: arc
     extra_args: CONFIG_MPU_GAP_FILLING=y
-    tags: kernel security userspace ignore_faults
   kernel.memory_protection.userspace.gap_filling.arm:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     arch_allow: arm
     platform_allow: efr32_radio_brd4180a mps2_an521 nrf9160dk_nrf9160
     extra_args: CONFIG_MPU_GAP_FILLING=y
-    tags: kernel security userspace ignore_faults

--- a/tests/kernel/mutex/mutex_error_case/testcase.yaml
+++ b/tests/kernel/mutex/mutex_error_case/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   kernel.mutex_error_case:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: kernel userspace ignore_faults
+    tags: kernel userspace
+    ignore_faults: true

--- a/tests/kernel/pipe/pipe/testcase.yaml
+++ b/tests/kernel/pipe/pipe/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.pipe:
-      tags: kernel userspace ignore_faults
+      tags: kernel userspace
+      ignore_faults: true

--- a/tests/kernel/poll/testcase.yaml
+++ b/tests/kernel/poll/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   kernel.poll:
-    tags: kernel userspace ignore_faults
+    ignore_faults: true
+    tags: kernel userspace
     # FIXME: qemu_arc_hs6x is excluded due to a run-time failure, see #49492
     platform_exclude: nrf52dk_nrf52810 qemu_arc_hs6x

--- a/tests/kernel/queue/testcase.yaml
+++ b/tests/kernel/queue/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.queue:
-    tags: kernel userspace ignore_faults
+    tags: kernel userspace
+    ignore_faults: true

--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -1,7 +1,8 @@
 common:
   timeout: 180
   min_ram: 34
-  tags: kernel threads sched userspace ignore_faults
+  tags: kernel threads scheduler userspace
+  ignore_faults: true
 tests:
   kernel.scheduler:
     filter: not CONFIG_SCHED_MULTIQ

--- a/tests/kernel/semaphore/semaphore/testcase.yaml
+++ b/tests/kernel/semaphore/semaphore/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.semaphore:
-    tags: kernel userspace ignore_faults
+    tags: kernel userspace
+    ignore_faults: true

--- a/tests/kernel/semaphore/sys_sem/testcase.yaml
+++ b/tests/kernel/semaphore/sys_sem/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   kernel.semaphore.usage:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: kernel userspace ignore_faults
+    tags: kernel userspace
+    ignore_faults: true

--- a/tests/kernel/smp/testcase.yaml
+++ b/tests/kernel/smp/testcase.yaml
@@ -1,10 +1,12 @@
 tests:
   kernel.multiprocessing.smp:
-    tags: kernel smp ignore_faults
+    tags: kernel smp
+    ignore_faults: true
     filter: (CONFIG_MP_MAX_NUM_CPUS > 1)
   kernel.multiprocessing.smp.linker_generator:
     platform_allow: qemu_x86_64
     extra_configs:
       - CONFIG_CMAKE_LINKER_GENERATOR=y
-    tags: ignore_faults linker_generator
+    tags: linker_generator
+    ignore_faults: true
     filter: (CONFIG_MP_MAX_NUM_CPUS > 1)

--- a/tests/kernel/stack/stack/testcase.yaml
+++ b/tests/kernel/stack/stack/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.stack.usage:
-    tags: kernel userspace ignore_faults
+    tags: kernel userspace
+    ignore_faults: true

--- a/tests/kernel/threads/dynamic_thread/testcase.yaml
+++ b/tests/kernel/threads/dynamic_thread/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   kernel.threads.dynamic:
-    tags: kernel threads userspace ignore_faults
+    tags: kernel threads userspace
+    ignore_faults: true
     filter: CONFIG_ARCH_HAS_USERSPACE

--- a/tests/kernel/threads/thread_apis/testcase.yaml
+++ b/tests/kernel/threads/thread_apis/testcase.yaml
@@ -1,9 +1,10 @@
+common:
+  ignore_faults: true
+  tags: kernel threads userspace
 tests:
   kernel.threads.apis:
-    tags: kernel threads userspace ignore_faults
     min_flash: 34
   kernel.threads.apis.pinonly:
-    tags: kernel threads userspace ignore_faults
     min_flash: 34
     filter: CONFIG_SMP
     extra_configs:

--- a/tests/kernel/threads/thread_error_case/testcase.yaml
+++ b/tests/kernel/threads/thread_error_case/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   kernel.threads.error.case:
-    tags: kernel threads userspace ignore_faults
+    tags: kernel threads userspace
     filter: CONFIG_USERSPACE
+    ignore_faults: true

--- a/tests/kernel/threads/thread_stack/testcase.yaml
+++ b/tests/kernel/threads/thread_stack/testcase.yaml
@@ -1,10 +1,12 @@
 tests:
   kernel.threads.thread_stack:
-    tags: kernel security userspace ignore_faults
+    tags: kernel security userspace
+    ignore_faults: true
     min_ram: 16
   kernel.threads.armv8m_mpu_stack_guard:
     min_ram: 16
     extra_args: CONF_FILE=prj_armv8m_mpu_stack_guard.conf
     filter: CONFIG_ARM_MPU and CONFIG_ARMV8_M_MAINLINE
     arch_allow: arm
-    tags: kernel security userspace ignore_faults
+    tags: kernel security userspace
+    ignore_faults: true

--- a/tests/kernel/timer/timer_error_case/testcase.yaml
+++ b/tests/kernel/timer/timer_error_case/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   kernel.timer.error_case:
-    tags: kernel timer userspace ignore_faults
+    tags: kernel timer userspace
+    ignore_faults: true

--- a/tests/lib/c_lib/testcase.yaml
+++ b/tests/lib/c_lib/testcase.yaml
@@ -3,10 +3,11 @@ common:
   platform_exclude: native_posix native_posix_64 nrf52_bsim
 tests:
   libraries.libc:
-    tags: ignore_faults
+    ignore_faults: true
   libraries.picolibc:
     filter: CONFIG_PICOLIBC_SUPPORTED
-    tags: picolibc ignore_faults
+    tags: picolibc
+    ignore_faults: true
     extra_configs:
       - CONFIG_PICOLIBC=y
   libraries.libc.minimal.strerror_table:

--- a/tests/lib/sprintf/testcase.yaml
+++ b/tests/lib/sprintf/testcase.yaml
@@ -5,7 +5,8 @@ tests:
     integration_platforms:
     - qemu_x86
     platform_exclude: native_posix native_posix_64 nrf52_bsim
-    tags: libc ignore_faults
+    tags: libc
+    ignore_faults: true
     testcases:
     - sprintf_integer
     - sprintf_double
@@ -28,7 +29,8 @@ tests:
     - EOF
   libraries.picolibc.sprintf:
     extra_args: CONF_FILE=prj_picolibc.conf
-    tags: libc ignore_faults picolibc
+    tags: libc picolibc
+    ignore_faults: true
     filter: CONFIG_PICOLIBC_SUPPORTED
   libraries.picolibc.sprintf_new:
     extra_args: CONF_FILE=prj_picolibc_new.conf

--- a/tests/subsys/debug/coredump/testcase.yaml
+++ b/tests/subsys/debug/coredump/testcase.yaml
@@ -1,6 +1,8 @@
 tests:
   coredump.logging_backend:
-    tags: ignore_faults ignore_qemu_crash
+    tags: coredump
+    ignore_faults: true
+    ignore_qemu_crash: true
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     platform_exclude: acrn_ehl_crb
     harness: console

--- a/tests/subsys/debug/coredump_backends/testcase.yaml
+++ b/tests/subsys/debug/coredump_backends/testcase.yaml
@@ -1,6 +1,9 @@
+common:
+  tags: coredump
+  ignore_faults: true
+  ignore_qemu_crash: true
 tests:
   coredump.backends.logging:
-    tags: ignore_faults ignore_qemu_crash
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     platform_exclude: acrn_ehl_crb
     harness: console
@@ -11,12 +14,10 @@ tests:
         - "E: #CD:5([aA])45([0-9a-fA-F]+)"
         - "E: #CD:END#"
   coredump.backends.flash:
-    tags: ignore_faults ignore_qemu_crash
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     extra_args: CONF_FILE=prj_flash_partition.conf
     platform_allow: qemu_x86
   coredump.backends.other:
-    tags: ignore_faults ignore_qemu_crash
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     extra_args: CONF_FILE=prj_backend_other.conf
     platform_exclude: acrn_ehl_crb

--- a/tests/ztest/error_hook/testcase.yaml
+++ b/tests/ztest/error_hook/testcase.yaml
@@ -1,7 +1,8 @@
 tests:
   testing.ztest.error_hook:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    tags: test_framework userspace ignore_faults
+    tags: test_framework userspace
+    ignore_faults: true
     testcases:
     - catch_assert_fail
     - catch_fatal_error
@@ -10,7 +11,8 @@ tests:
 
   testing.ztest.error_hook.no_userspace:
     extra_args: CONF_FILE=prj_no_userspace.conf
-    tags: test_framework ignore_faults
+    tags: test_framework
+    ignore_faults: true
     testcases:
     - catch_fatal_error
     - catch_assert_fail


### PR DESCRIPTION
Use dedicated field in the yaml file instead of mixing this testing
feature with tags.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
