### PR TITLE
lorawan: enforce larger system work queue stack size via Kconfig

### DIFF
--- a/subsys/lorawan/Kconfig
+++ b/subsys/lorawan/Kconfig
@@ -6,6 +6,7 @@
 menuconfig LORAWAN
 	bool "LoRaWAN support [EXPERIMENTAL]"
 	depends on LORA
+	depends on SYSTEM_WORKQUEUE_STACK_SIZE >= 2048
 	select REQUIRES_FULL_LIBC
 	select HAS_SEMTECH_LORAMAC
 	select HAS_SEMTECH_SOFT_SE


### PR DESCRIPTION
The LoRaWAN subsystem uses the system work queue internally and needs more than the default stack size of 1024 bytes. This is considered in the sample application, but may be forgotten by out of tree users.

Enforcing it via Kconfig prevents users from accidentally getting hard-to-debug stack overflows.