### PR TITLE
boards: olimex_lora_stm32wl_devkit: enable MPU and HW stack protection

### DIFF
--- a/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit_defconfig
+++ b/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit_defconfig
@@ -14,11 +14,11 @@ CONFIG_CLOCK_CONTROL=y
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
 
-# PRELIMINARY: Don't enable MPU to prevent random MPU faults in Zephyr LoRa driver
-#CONFIG_ARM_MPU=y
+# Enable MPU
+CONFIG_ARM_MPU=y
 
-# PRELIMINARY: Don't enable HW stack protection (only available with MPU)
-#CONFIG_HW_STACK_PROTECTION=y
+# Enable HW stack protection
+CONFIG_HW_STACK_PROTECTION=y
 
 # enable pin controller
 CONFIG_PINCTRL=y


### PR DESCRIPTION
The random MPU faults experienced before were actually caused by a too small system work queue stack for LoRaWAN in a custom application.

PR #52550 adds a compile-time check to avoid such issues in the future.