### PR TITLE
kernel: events: add function to clear events

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2123,7 +2123,7 @@ __syscall void k_event_post(struct k_event *event, uint32_t events);
  * events tracked by the event object.
  *
  * @param event Address of the event object
- * @param events Set of events to post to @a event
+ * @param events Set of events to set in @a event
  */
 __syscall void k_event_set(struct k_event *event, uint32_t events);
 
@@ -2136,7 +2136,7 @@ __syscall void k_event_set(struct k_event *event, uint32_t events);
  * allows specific event bits to be set and cleared as determined by the mask.
  *
  * @param event Address of the event object
- * @param events Set of events to post to @a event
+ * @param events Set of events to set/clear in @a event
  * @param events_mask Mask to be applied to @a events
  */
 __syscall void k_event_set_masked(struct k_event *event, uint32_t events,
@@ -2167,7 +2167,7 @@ __syscall uint32_t k_event_wait(struct k_event *event, uint32_t events,
 				bool reset, k_timeout_t timeout);
 
 /**
- * @brief Wait for any of the specified events
+ * @brief Wait for all of the specified events
  *
  * This routine waits on event object @a event until all of the specified
  * events have been delivered to the event object, or the maximum wait time

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2143,6 +2143,16 @@ __syscall void k_event_set_masked(struct k_event *event, uint32_t events,
 				  uint32_t events_mask);
 
 /**
+ * @brief Clear the events in an event object
+ *
+ * This routine clears (resets) the specified events stored in an event object.
+ *
+ * @param event Address of the event object
+ * @param events Set of events to clear in @a event
+ */
+__syscall void k_event_clear(struct k_event *event, uint32_t events);
+
+/**
  * @brief Wait for any of the specified events
  *
  * This routine waits on event object @a event until any of the specified

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -188,6 +188,20 @@ void z_vrfy_k_event_set_masked(struct k_event *event, uint32_t events,
 #include <syscalls/k_event_set_masked_mrsh.c>
 #endif
 
+void z_impl_k_event_clear(struct k_event *event, uint32_t events)
+{
+	k_event_post_internal(event, 0, events);
+}
+
+#ifdef CONFIG_USERSPACE
+void z_vrfy_k_event_clear(struct k_event *event, uint32_t events)
+{
+	Z_OOPS(Z_SYSCALL_OBJ(event, K_OBJ_EVENT));
+	z_impl_k_event_clear(event, events);
+}
+#include <syscalls/k_event_clear_mrsh.c>
+#endif
+
 static uint32_t k_event_wait_internal(struct k_event *event, uint32_t events,
 				      unsigned int options, k_timeout_t timeout)
 {

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -125,8 +125,6 @@ static void k_event_post_internal(struct k_event *event, uint32_t events,
 			thread->next_event_link = head;
 			head = thread;
 		}
-
-
 	}
 
 	if (head != NULL) {


### PR DESCRIPTION
Shortcut making it easier to clear events than with `k_event_set_masked`.

Also fixing some small docs issues.