### PR TITLE
intel_adsp: ace: dmic power domain

### DIFF
--- a/drivers/dai/intel/dmic/Kconfig.dmic
+++ b/drivers/dai/intel/dmic/Kconfig.dmic
@@ -7,6 +7,7 @@ config DAI_INTEL_DMIC
 	bool "Intel digital PDM microphone driver support for DAI interface"
 	default y
 	depends on DT_HAS_INTEL_DAI_DMIC_ENABLED
+	depends on PM_DEVICE_RUNTIME
 	help
 	  Enable Intel digital PDM microphone driver for DAI interface
 

--- a/drivers/power_domain/power_domain_intel_adsp.c
+++ b/drivers/power_domain/power_domain_intel_adsp.c
@@ -7,25 +7,26 @@
 #include <zephyr/kernel.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
+#include <adsp_shim.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(power_domain_intel_adsp, LOG_LEVEL_INF);
 
-struct pg_registers {
+struct pg_bits {
 	uint32_t SPA_bit;
 	uint32_t CPA_bit;
 };
 
-static int pd_intel_adsp_set_power_enable(struct pg_registers *reg, bool power_enable)
+static int pd_intel_adsp_set_power_enable(struct pg_bits *bits, bool power_enable)
 {
-	uint32_t SPA_bit_mask = BIT(reg->SPA_bit);
+	uint16_t SPA_bit_mask = BIT(bits->SPA_bit);
 
 	if (power_enable) {
-		sys_write32(sys_read32(ACE_DfPMCCU->dfpwrctl) | SPA_bit_mask,
-					ACE_DfPMCCU->dfpwrctl);
+		sys_write16(sys_read16((mem_addr_t)&ACE_DfPMCCU.dfpwrctl) | SPA_bit_mask,
+			    (mem_addr_t)&ACE_DfPMCCU.dfpwrctl);
 	} else {
-		sys_write32(sys_read32(ACE_DfPMCCU->dfpwrctl) & ~(SPA_bit_mask),
-					ACE_DfPMCCU->dfpwrctl);
+		sys_write16(sys_read16((mem_addr_t)&ACE_DfPMCCU.dfpwrctl) & ~(SPA_bit_mask),
+			    (mem_addr_t)&ACE_DfPMCCU.dfpwrctl);
 	}
 
 	return 0;
@@ -33,16 +34,16 @@ static int pd_intel_adsp_set_power_enable(struct pg_registers *reg, bool power_e
 
 static int pd_intel_adsp_pm_action(const struct device *dev, enum pm_device_action action)
 {
-	struct pg_registers *reg_data = (struct pg_registers *)dev->data;
+	struct pg_bits *reg_bits = (struct pg_bits *)dev->data;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
 		pm_device_children_action_run(dev, PM_DEVICE_ACTION_TURN_ON, NULL);
-		pd_intel_adsp_set_power_enable(reg_data, true);
+		pd_intel_adsp_set_power_enable(reg_bits, true);
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
 		pm_device_children_action_run(dev, PM_DEVICE_ACTION_TURN_OFF, NULL);
-		pd_intel_adsp_set_power_enable(reg_data, false);
+		pd_intel_adsp_set_power_enable(reg_bits, false);
 		break;
 	case PM_DEVICE_ACTION_TURN_ON:
 		break;
@@ -57,14 +58,13 @@ static int pd_intel_adsp_pm_action(const struct device *dev, enum pm_device_acti
 static int pd_intel_adsp_init(const struct device *dev)
 {
 	pm_device_init_suspended(dev);
-	pm_device_runtime_enable(dev);
-	return 0;
+	return pm_device_runtime_enable(dev);
 }
 
 #define DT_DRV_COMPAT intel_adsp_power_domain
 
 #define POWER_DOMAIN_DEVICE(id)							\
-	static struct pg_registers pd_pg_reg##id = {				\
+	static struct pg_bits pd_pg_reg##id = {					\
 		.SPA_bit = DT_INST_PROP(id, bit_position),			\
 		.CPA_bit = DT_INST_PROP(id, bit_position),			\
 	};									\

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -118,6 +118,7 @@
 			fifo = <0x0008>;
 			interrupts = <0x08 0 0>;
 			interrupt-parent = <&ace_intc>;
+			power-domain = <&hub_ulp_domain>;
 		};
 
 		dmic1: dmic1@10000 {
@@ -127,6 +128,7 @@
 			fifo = <0x0108>;
 			interrupts = <0x09 0 0>;
 			interrupt-parent = <&ace_intc>;
+			power-domain = <&hub_ulp_domain>;
 		};
 
 		/*

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -291,7 +291,7 @@
 				compatible = "intel,adsp-power-domain";
 				bit-position = <15>;
 			};
-			hub_hp_domain: hub_hpp_domain {
+			hub_hp_domain: hub_hp_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <6>;
 			};

--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_power.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_power.h
@@ -3,13 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <adsp_shim.h>
+
 #ifndef ZEPHYR_SOC_INTEL_ADSP_POWER_H_
 #define ZEPHYR_SOC_INTEL_ADSP_POWER_H_
 
 /* Value used as delay when waiting for hw register state change. */
 #define HW_STATE_CHECK_DELAY 256
 
-
+/* Power Control register - controls the power domain operations. */
 struct ace_pwrctl {
 	uint16_t wpdsphpxpg : 3;
 	uint16_t rsvd3      : 1;
@@ -24,13 +26,9 @@ struct ace_pwrctl {
 	uint16_t phubulppg  : 1;
 };
 
-/* Power control */
-#define PWRCTL_REG 0x71b90
+#define ACE_PWRCTL ((volatile struct ace_pwrctl *) &ACE_DfPMCCU.dfpwrctl)
 
-#define ACE_PWRCTL ((volatile struct ace_pwrctl *)PWRCTL_REG)
-
-#define PWRSTS_REG 0x71b92
-
+/* Power Status register - reports the power domain status. */
 struct ace_pwrsts {
 	uint16_t dsphpxpgs : 4;
 	uint16_t hstpgs    : 1;
@@ -43,6 +41,6 @@ struct ace_pwrsts {
 	uint16_t hubulppgs : 1;
 };
 
-#define ACE_PWRSTS ((volatile struct ace_pwrsts *)PWRSTS_REG)
+#define ACE_PWRSTS ((volatile struct ace_pwrsts *) &ACE_DfPMCCU.dfpwrsts)
 
 #endif /* ZEPHYR_SOC_INTEL_ADSP_POWER_H_ */


### PR DESCRIPTION
Combining the Intel DMIC with proper power domain to prevent it power gaitin during d0i0/d0i3 transition.

* intel adsp power domain update,
* initial implementation for dmic runtime pm.