### PR TITLE
drivers: spi: fix 16 bit spi dma transfers for the STM32 driver

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -206,14 +206,14 @@ static int spi_dma_move_buffers(const struct device *dev, size_t len)
 	int ret;
 	size_t dma_segment_len;
 
-	dma_segment_len = len / data->dma_rx.dma_cfg.dest_data_size;
+	dma_segment_len = len * data->dma_rx.dma_cfg.dest_data_size;
 	ret = spi_stm32_dma_rx_load(dev, data->ctx.rx_buf, dma_segment_len);
 
 	if (ret != 0) {
 		return ret;
 	}
 
-	dma_segment_len = len / data->dma_tx.dma_cfg.source_data_size;
+	dma_segment_len = len * data->dma_tx.dma_cfg.source_data_size;
 	ret = spi_stm32_dma_tx_load(dev, data->ctx.tx_buf, dma_segment_len);
 
 	return ret;


### PR DESCRIPTION
Calculates the correct dma segment length for STM32 16 bit spi dma transfers. Fixes zephyrproject-rtos#52563

Signed-off-by: Rami Saad <rami.saad@morgansolar.com>