### PR TITLE
ARC: MWDT add TLS support

### DIFF
--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -121,7 +121,8 @@ static inline void arch_setup_callee_saved_regs(struct k_thread *thread,
 
 	ARG_UNUSED(regs);
 
-#ifdef CONFIG_THREAD_LOCAL_STORAGE
+/* GCC uses tls pointer cached in register, MWDT just call for _mwget_tls */
+#if defined(CONFIG_THREAD_LOCAL_STORAGE) && !defined(__CCAC__)
 #ifdef CONFIG_ISA_ARCV2
 #if __ARC_TLS_REGNO__ <= 0
 #error Compiler not configured for thread local storage

--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -150,7 +150,13 @@ set_property(TARGET compiler-cpp PROPERTY no_rtti "-fno-rtti")
 set_compiler_property(PROPERTY freestanding -Hnocrt)
 
 # Flag to enable debugging
-set_compiler_property(PROPERTY debug -g)
+if(CONFIG_THREAD_LOCAL_STORAGE)
+  # FIXME: Temporary workaround for ARC MWDT toolchain issue - LLDAC linker produce errors on
+  # debugging information (if -g option specified) of thread-local variables.
+  set_compiler_property(PROPERTY debug)
+else()
+  set_compiler_property(PROPERTY debug -g)
+endif()
 
 # compile common globals like normal definitions
 set_compiler_property(PROPERTY no_common -fno-common)

--- a/cmake/toolchain/arcmwdt/Kconfig
+++ b/cmake/toolchain/arcmwdt/Kconfig
@@ -1,0 +1,6 @@
+# Copyright (c) 2022 Synopsys
+# SPDX-License-Identifier: Apache-2.0
+
+config TOOLCHAIN_ARCMWDT_SUPPORTS_THREAD_LOCAL_STORAGE
+	def_bool y
+	select TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE

--- a/include/zephyr/arch/arc/v2/linker.ld
+++ b/include/zephyr/arch/arc/v2/linker.ld
@@ -92,10 +92,24 @@ SECTIONS {
 	__rodata_region_start = .;
 
 #include <zephyr/linker/common-rom.ld>
-#include <zephyr/linker/thread-local-storage.ld>
 #ifdef __MWDT_LINKER_CMD__
+	SECTION_DATA_PROLOGUE(tdata,,)
+	{
+		*(.tls .tls.*);
+	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+	#ifdef CONFIG_XIP
+		/* The "primary copy" of tls should be only in flash on XIP systems */
+		PROVIDE(_arcmwdt_tls_start = LOADADDR(tdata));
+	#else
+		PROVIDE(_arcmwdt_tls_start = ADDR(tdata));
+	#endif
+
+	PROVIDE(_arcmwdt_tls_size = SIZEOF(tdata));
+
 /* TODO: add mwdt specific ROM C++ sections */
 #else
+#include <zephyr/linker/thread-local-storage.ld>
 #include <zephyr/linker/cplusplus-rom.ld>
 #endif /* __MWDT_LINKER_CMD__ */
 

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -641,6 +641,10 @@ flagged.
         "STD_CPP",  # Referenced in CMake comment
         "TAGOIO_HTTP_POST_LOG_LEVEL",  # Used as in samples/net/cloud/tagoio
         "TEST1",
+        "TOOLCHAIN_ARCMWDT_SUPPORTS_THREAD_LOCAL_STORAGE", # The symbol is defined in the toolchain
+                                                    # Kconfig which is sourced based on Zephyr
+                                                    # toolchain variant and therefore not visible
+                                                    # to compliance.
         "TYPE_BOOLEAN",
         "USB_CONSOLE",
         "USE_STDC_",

--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -6,7 +6,10 @@ tests:
   kernel.common:
     build_on_all: true
   kernel.common.tls:
-    filter: CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
+    # ARCMWDT can't handle THREAD_LOCAL_STORAGE with USERSPACE, see #52570 for details
+    filter: >
+      CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
+      and not (CONFIG_TOOLCHAIN_ARCMWDT_SUPPORTS_THREAD_LOCAL_STORAGE and CONFIG_USERSPACE)
     extra_configs:
       - CONFIG_THREAD_LOCAL_STORAGE=y
   kernel.common.misra:

--- a/tests/kernel/threads/tls/testcase.yaml
+++ b/tests/kernel/threads/tls/testcase.yaml
@@ -5,5 +5,7 @@ tests:
   kernel.threads.tls.userspace:
     tags: kernel threads userspace
     filter: CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_ARCH_HAS_USERSPACE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
+    # ARCMWDT can't handle THREAD_LOCAL_STORAGE with USERSPACE, see #52570 for details
+    toolchain_exclude: arcmwdt
     extra_configs:
       - CONFIG_TEST_USERSPACE=y


### PR DESCRIPTION
Add thread local storage support for ARC MWDT toolchain.

Note: as a temporary workaround we disable debug information if TLS is enabled due to ARC MWDT toolchain issue  - the LLDAC linker produce errors on debugging information (if -g option specified) of thread-local variables. Unfortunately that doesn't allow us to build Zephyr with TLS and USERSPACE enabled simultaneously as `gen_kobject_list.py` relies on debug information.