### PR TITLE
drivers: serial: uart_xmc4xxx: Fix write to fifo with more than one byte

### DIFF
--- a/drivers/serial/uart_xmc4xxx.c
+++ b/drivers/serial/uart_xmc4xxx.c
@@ -138,7 +138,7 @@ static int uart_xmc4xxx_fifo_fill(const struct device *dev, const uint8_t *tx_da
 	for (i = 0; i < len; i++) {
 		bool fifo_full;
 
-		XMC_UART_CH_Transmit(config->uart, tx_data[0]);
+		XMC_UART_CH_Transmit(config->uart, tx_data[i]);
 		if (config->fifo_tx_size == 0) {
 			return 1;
 		}


### PR DESCRIPTION
Currently only the first byte was written when pushing more than one byte into the fifo.

Signed-off-by: Andriy Gelman <andriy.gelman@gmail.com>