### PR TITLE
ARC: ARCv2: GCC: restore default TLS behavior for all SDKs

### DIFF
--- a/arch/arc/CMakeLists.txt
+++ b/arch/arc/CMakeLists.txt
@@ -12,11 +12,16 @@ zephyr_cc_option(-fno-delete-null-pointer-checks)
 
 zephyr_cc_option_ifdef(CONFIG_ARC_USE_UNALIGNED_MEM_ACCESS -munaligned-access)
 
-if(CONFIG_ISA_ARCV2)
-  # Instruct compiler to use register R26 as thread pointer
-  # for thread local storage.
-  # For ARCv3 the register is fixed to r30, so we don't need to specify it
-  zephyr_cc_option_ifdef(CONFIG_THREAD_LOCAL_STORAGE -mtp-regno=26)
+if(NOT COMPILER STREQUAL arcmwdt)
+  if(CONFIG_THREAD_LOCAL_STORAGE)
+    # Instruct compiler to use proper register as cached thread pointer for thread local storage.
+    # For ARCv2 the default register is usually not specified - so we need to specify it
+    # For ARCv3 the register is fixed to r30, so we don't need to specify it
+    zephyr_compile_options_ifdef(CONFIG_ISA_ARCV2 -mtp-regno=26)
+  else()
+    # If thread local storage isn't used - we can safely schedule thread pointer register
+    zephyr_compile_options_ifdef(CONFIG_ISA_ARCV2 -mtp-regno=none)
+  endif()
 endif()
 
 add_subdirectory(core)


### PR DESCRIPTION
In 0.15.2 SDK we specify r26 as default register for TLS cached pointer, so it isn't used by compiler even if TLS support isn't enabled. Restore the previous behavior - so if we don't use TLS in Zephyr the register isn't stay reserved.