### PR TITLE
arch/arm/core: fixup typo

### DIFF
--- a/arch/arm/core/aarch32/thread.c
+++ b/arch/arm/core/aarch32/thread.c
@@ -620,7 +620,7 @@ FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(
 	__set_PSPLIM(0);
 #endif
 
-	/* Store all required input in registers, to be accesible
+	/* Store all required input in registers, to be accessible
 	 * after stack pointer change. The function is not going
 	 * to return, so callee-saved registers do not need to be
 	 * stacked.


### PR DESCRIPTION
Fixup trivial typo.