### PR TITLE
[v3.1] Miscellaneous CI updates for v3.1-branch

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: Backport
     steps:
       - name: Backport

--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   backport:
     name: Backport Issue Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check out source code

--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/bluetooth-tests-publish.yaml
+++ b/.github/workflows/bluetooth-tests-publish.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   bluetooth-test-results:
     name: "Publish Bluetooth Test Results"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event.workflow_run.conclusion != 'skipped'
 
     steps:

--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
   bluetooth-test-build:

--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -13,14 +13,14 @@ on:
 
 jobs:
   bluetooth-test-prep:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
         with:
           access_token: ${{ github.token }}
   bluetooth-test-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: bluetooth-test-prep
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.23.3

--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bluetooth-test-results
           path: |
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload Event Details
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: event
           path: |

--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -43,7 +43,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -11,17 +11,13 @@ on:
       - "soc/posix/**"
       - "arch/posix/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  bluetooth-test-prep:
+  bluetooth-test:
     runs-on: ubuntu-20.04
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-  bluetooth-test-build:
-    runs-on: ubuntu-20.04
-    needs: bluetooth-test-prep
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/bug_snapshot.yaml
+++ b/.github/workflows/bug_snapshot.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
   clang-build:

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -4,7 +4,7 @@ on: pull_request_target
 
 jobs:
   clang-build-prep:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -39,7 +39,7 @@ jobs:
           # hotfix, until we have a better way to deal with existing data
           rm -rf zephyr zephyr-testing
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload Unit Test Results
         if: always() && steps.twister.outputs.report_needed != 0
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Unit Test Results (Subset ${{ matrix.platform }})
           path: twister-out/twister.xml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload Unit Test Results in HTML
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: HTML Unit Test Results
           if-no-files-found: ignore

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Clone cached Zephyr repository
         continue-on-error: true
         run: |
-          git clone /github/cache/zephyrproject/zephyr .
+          git clone --shared /github/cache/zephyrproject/zephyr .
           git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
 
       - name: Checkout

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -8,12 +8,12 @@ concurrency:
 
 jobs:
   clang-build:
-    runs-on: zephyr_runner
+    runs-on: zephyr-runner-linux-x64-4xlarge
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
       options: '--entrypoint /bin/bash'
       volumes:
-        - /home/runners/zephyrproject:/github/cache/zephyrproject
+        - /repo-cache/zephyrproject:/github/cache/zephyrproject
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -2,17 +2,13 @@ name: Build with Clang/LLVM
 
 on: pull_request_target
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  clang-build-prep:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
   clang-build:
     runs-on: zephyr_runner
-    needs: clang-build-prep
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -38,6 +38,13 @@ jobs:
         run: |
           # hotfix, until we have a better way to deal with existing data
           rm -rf zephyr zephyr-testing
+
+      - name: Clone cached Zephyr repository
+        continue-on-error: true
+        run: |
+          git clone /github/cache/zephyrproject/zephyr .
+          git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -34,11 +34,6 @@ jobs:
           #        GitHub comes up with a fundamental fix for this problem.
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
-      - name: Cleanup
-        run: |
-          # hotfix, until we have a better way to deal with existing data
-          rm -rf zephyr zephyr-testing
-
       - name: Clone cached Zephyr repository
         continue-on-error: true
         run: |

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -76,7 +76,7 @@ jobs:
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
           string(REPLACE "/" "_" repo ${{github.repository}})
           string(REPLACE "-" "_" repo2 ${repo})
-          message("::set-output name=repo::${repo2}")
+          file(APPEND $ENV{GITHUB_OUTPUT} "repo=${repo2}\n")
       - name: use cache
         id: cache-ccache
         uses: nashif/action-s3-cache@master
@@ -104,12 +104,12 @@ jobs:
 
           # We can limit scope to just what has changed
           if [ -s testplan.json ]; then
-            echo "::set-output name=report_needed::1";
+            echo "report_needed=1" >> $GITHUB_OUTPUT
             # Full twister but with options based on changes
             ./scripts/twister --force-color --inline-logs -M -N -v --load-tests testplan.json --retry-failed 2
           else
             # if nothing is run, skip reporting step
-            echo "::set-output name=report_needed::0";
+            echo "report_needed=0" >> $GITHUB_OUTPUT
           fi
 
       - name: ccache stats post

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Clone cached Zephyr repository
         continue-on-error: true
         run: |
-          git clone /github/cache/zephyrproject/zephyr .
+          git clone --shared /github/cache/zephyrproject/zephyr .
           git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
 
       - name: checkout

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -35,7 +35,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Download Artifacts

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload Coverage Results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Coverage Data (Subset ${{ matrix.platform }})
           path: coverage/reports/${{ matrix.platform }}.info

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -4,19 +4,13 @@ on:
   schedule:
     - cron: '25 */3 * * 1-5'
 
-jobs:
-  codecov-prep:
-    runs-on: ubuntu-latest
-    if: github.repository == 'zephyrproject-rtos/zephyr'
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
+jobs:
   codecov:
     runs-on: zephyr_runner
-    needs: codecov-prep
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   codecov:
-    runs-on: zephyr_runner
+    runs-on: zephyr-runner-linux-x64-4xlarge
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |
           string(REPLACE "/" "_" repo ${{github.repository}})
           string(REPLACE "-" "_" repo2 ${repo})
-          message("::set-output name=repo::${repo2}")
+          file(APPEND $ENV{GITHUB_OUTPUT} "repo=${repo2}\n")
 
       - name: use cache
         id: cache-ccache
@@ -146,8 +146,8 @@ jobs:
               set(MERGELIST "${MERGELIST} -a ${f}")
             endif()
           endforeach()
-          message("::set-output name=mergefiles::${MERGELIST}")
-          message("::set-output name=covfiles::${FILELIST}")
+          file(APPEND $ENV{GITHUB_OUTPUT} "mergefiles=${MERGELIST}\n")
+          file(APPEND $ENV{GITHUB_OUTPUT} "covfiles=${FILELIST}\n")
 
       - name: Merge coverage files
         run: |

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -14,6 +14,8 @@ jobs:
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
       options: '--entrypoint /bin/bash'
+      volumes:
+        - /repo-cache/zephyrproject:/github/cache/zephyrproject
     strategy:
       fail-fast: false
       matrix:
@@ -33,6 +35,12 @@ jobs:
       - name: Update PATH for west
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Clone cached Zephyr repository
+        continue-on-error: true
+        run: |
+          git clone /github/cache/zephyrproject/zephyr .
+          git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
 
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   compliance_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Run coding guidelines checks on patch series (PR)
     steps:
     - name: Checkout the code

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -14,7 +14,7 @@ jobs:
         fetch-depth: 0
 
     - name: cache-pip
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-doc-pip

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -8,7 +8,7 @@ jobs:
     name: Run coding guidelines checks on patch series (PR)
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -72,7 +72,7 @@ jobs:
         ./scripts/ci/check_compliance.py -m Devicetree -m Gitlint -m Identity -m Nits -m pylint -m checkpatch -m Kconfig -c origin/${BASE_REF}..
 
     - name: upload-results
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v3
       continue-on-error: True
       with:
         name: compliance.xml

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   maintainer_check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Check MAINTAINERS file
     steps:
     - name: Checkout the code
@@ -20,7 +20,7 @@ jobs:
         python3 ./scripts/get_maintainer.py path CMakeLists.txt
 
   check_compliance:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Run compliance checks on patch series (PR)
     steps:
     - name: Update PATH for west

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -8,7 +8,7 @@ jobs:
     name: Check MAINTAINERS file
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -28,7 +28,7 @@ jobs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Checkout the code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -34,7 +34,7 @@ jobs:
         fetch-depth: 0
 
     - name: cache-pip
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-doc-pip

--- a/.github/workflows/daily_test_version.yml
+++ b/.github/workflows/daily_test_version.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   get_version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
 
     steps:

--- a/.github/workflows/daily_test_version.yml
+++ b/.github/workflows/daily_test_version.yml
@@ -28,7 +28,7 @@ jobs:
         pip3 install gitpython
 
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -21,11 +21,11 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-11, windows-2022]
         exclude:
-          - os: macos-latest
+          - os: macos-11
             python-version: 3.6
-          - os: windows-latest
+          - os: windows-2022
             python-version: 3.6
     steps:
     - name: checkout

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -29,7 +29,7 @@ jobs:
             python-version: 3.6
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -36,7 +36,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux
       if: startsWith(runner.os, 'Linux')
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}
@@ -44,7 +44,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}
     - name: cache-pip-mac
       if: startsWith(runner.os, 'macOS')
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/Library/Caches/pip
         # Trailing '-' was just to get a different cache name
@@ -53,7 +53,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
     - name: cache-pip-win
       if: startsWith(runner.os, 'Windows')
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -31,7 +31,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -6,10 +6,16 @@ name: Devicetree script tests
 
 on:
   push:
+    branches:
+    - main
+    - v*-branch
     paths:
     - 'scripts/dts/**'
     - '.github/workflows/devicetree_checks.yml'
   pull_request:
+    branches:
+    - main
+    - v*-branch
     paths:
     - 'scripts/dts/**'
     - '.github/workflows/devicetree_checks.yml'

--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -8,7 +8,7 @@ jobs:
   do-not-merge:
     if: ${{ contains(github.event.*.labels.*.name, 'DNM') }}
     name: Prevent Merging
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check for label
         run: |

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: install-pkgs
       run: |
@@ -125,7 +125,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: install-pkgs
       run: |

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -92,7 +92,7 @@ jobs:
         tar cfJ html-output.tar.xz --directory=doc/_build html
 
     - name: upload-build
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v3
       with:
         name: html-output
         path: html-output.tar.xz
@@ -160,7 +160,7 @@ jobs:
         DOC_TAG=${DOC_TAG} SPHINXOPTS="-q -j auto" LATEXMKOPTS="-quiet -halt-on-error" make -C doc pdf
 
     - name: upload-build
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v3
       with:
         name: pdf-output
         path: doc/_build/latex/zephyr.pdf

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -35,8 +35,9 @@ env:
 jobs:
   doc-build-html:
     name: "Documentation Build (HTML)"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
+
     concurrency:
       group: doc-build-html-${{ github.ref }}
       cancel-in-progress: true
@@ -115,7 +116,7 @@ jobs:
 
   doc-build-pdf:
     name: "Documentation Build (PDF)"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: texlive/texlive:latest
     timeout-minutes: 30
     concurrency:

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -55,7 +55,7 @@ jobs:
         echo "${PWD}/doxygen-${DOXYGEN_VERSION}/bin" >> $GITHUB_PATH
 
     - name: cache-pip
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-${{ hashFiles('scripts/requirements-doc.txt') }}
@@ -133,7 +133,7 @@ jobs:
         apt-get install -y python3-pip ninja-build doxygen graphviz librsvg2-bin
 
     - name: cache-pip
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-${{ hashFiles('scripts/requirements-doc.txt') }}

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -108,7 +108,7 @@ jobs:
         echo "Documentation will be available shortly at: ${DOC_URL}" >> $GITHUB_STEP_SUMMARY
 
     - name: upload-pr-number
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: github.event_name == 'pull_request'
       with:
         name: pr_num

--- a/.github/workflows/doc-publish-pr.yml
+++ b/.github/workflows/doc-publish-pr.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   doc-publish:
     name: Publish Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: |
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   doc-publish:
     name: Publish Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: |
       github.event.workflow_run.event != 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-errno:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
     env:

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -24,7 +24,7 @@ jobs:
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run errno.py
         run: |

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
   footprint-tracking:

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   footprint-tracking-cancel:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
     steps:
       - name: Cancel Previous Runs
@@ -23,7 +23,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
   footprint-tracking:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-tracking-cancel
     container:

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -47,7 +47,7 @@ jobs:
           sudo pip3 install -U setuptools wheel pip gitpython
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -13,19 +13,14 @@ on:
       # same commit
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  footprint-tracking-cancel:
-    runs-on: ubuntu-20.04
-    if: github.repository == 'zephyrproject-rtos/zephyr'
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
   footprint-tracking:
     runs-on: ubuntu-20.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
-    needs: footprint-tracking-cancel
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   footprint-cancel:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
     steps:
       - name: Cancel Previous Runs
@@ -12,7 +12,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
   footprint-delta:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-cancel
     container:

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
   footprint-delta:
@@ -26,7 +26,7 @@ jobs:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -2,19 +2,14 @@ name: Footprint Delta
 
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  footprint-cancel:
-    runs-on: ubuntu-20.04
-    if: github.repository == 'zephyrproject-rtos/zephyr'
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
   footprint-delta:
     runs-on: ubuntu-20.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
-    needs: footprint-cancel
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
       options: '--entrypoint /bin/bash'
@@ -25,11 +20,6 @@ jobs:
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Apply container owner mismatch workaround
         run: |
           # FIXME: The owner UID of the GITHUB_WORKSPACE directory may not

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -33,7 +33,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/issue_count.yml
+++ b/.github/workflows/issue_count.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - name: Download configuration file
       run: |
-        wget -q https://raw.githubusercontent.com/$GITHUB_REPOSITORY/master/.github/workflows/issues-report-config.json
+        wget -q https://raw.githubusercontent.com/$GITHUB_REPOSITORY/main/.github/workflows/issues-report-config.json
 
     - name: install-packages
       run: |

--- a/.github/workflows/issue_count.yml
+++ b/.github/workflows/issue_count.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   track-issues:
     name: "Collect Issue Stats"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
 
     steps:

--- a/.github/workflows/issue_count.yml
+++ b/.github/workflows/issue_count.yml
@@ -35,7 +35,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: upload-stats
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v3
       continue-on-error: True
       with:
         name: ${{ env.OUTPUT_FILE_NAME }}

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         directory-to-scan: 'scan/'
     - name: Artifact Upload
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: scancode
         path: ./artifacts

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   scancode_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Scan code for licenses
     steps:
     - name: Checkout the code

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   contribs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Manifest
     steps:
       - name: Checkout the code

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -10,7 +10,7 @@ jobs:
     name: Manifest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: zephyrproject/zephyr
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           args: spdx -o zephyr-${{ steps.get_version.outputs.VERSION }}.spdx
 
       - name: upload-results
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3
         continue-on-error: True
         with:
           name: zephyr-${{ steps.get_version.outputs.VERSION }}.spdx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,8 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+        run: |
+          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v1

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   stale:
     name: Find Stale issues and PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
     steps:
     - uses: actions/stale@v3

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -13,19 +13,13 @@ on:
     # Run at 00:00 on Wednesday and Saturday
     - cron: '0 0 * * 3,6'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  twister-build-cleanup:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-
   twister-build-prep:
-
     runs-on: zephyr_runner
-    needs: twister-build-cleanup
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -19,12 +19,12 @@ concurrency:
 
 jobs:
   twister-build-prep:
-    runs-on: zephyr_runner
+    runs-on: zephyr-runner-linux-x64-4xlarge
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
       options: '--entrypoint /bin/bash'
       volumes:
-        - /home/runners/zephyrproject:/github/cache/zephyrproject
+        - /repo-cache/zephyrproject:/github/cache/zephyrproject
     outputs:
       subset: ${{ steps.output-services.outputs.subset }}
       size: ${{ steps.output-services.outputs.size }}
@@ -112,14 +112,14 @@ jobs:
           echo "fullrun=${TWISTER_FULL}" >> $GITHUB_OUTPUT
 
   twister-build:
-    runs-on: zephyr_runner
+    runs-on: zephyr-runner-linux-x64-4xlarge
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
       options: '--entrypoint /bin/bash'
       volumes:
-        - /home/runners/zephyrproject:/github/cache/zephyrproject
+        - /repo-cache/zephyrproject:/github/cache/zephyrproject
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -52,6 +52,13 @@ jobs:
           # hotfix, until we have a better way to deal with existing data
           rm -rf zephyr zephyr-testing
 
+      - name: Clone cached Zephyr repository
+        if: github.event_name == 'pull_request_target'
+        continue-on-error: true
+        run: |
+          git clone /github/cache/zephyrproject/zephyr .
+          git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+
       - name: Checkout
         if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v3
@@ -146,6 +153,12 @@ jobs:
         run: |
           # hotfix, until we have a better way to deal with existing data
           rm -rf zephyr zephyr-testing
+
+      - name: Clone cached Zephyr repository
+        continue-on-error: true
+        run: |
+          git clone /github/cache/zephyrproject/zephyr .
+          git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   twister-build-cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
@@ -270,7 +270,7 @@ jobs:
   twister-test-results:
     name: "Publish Unit Tests Results"
     needs: twister-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
       # the build-and-test job might be skipped, we don't need to run this job then
     if: success() || failure()
 

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -107,9 +107,9 @@ jobs:
           else
             size=0
           fi
-          echo "::set-output name=subset::${subset}";
-          echo "::set-output name=size::${size}";
-          echo "::set-output name=fullrun::${TWISTER_FULL}";
+          echo "subset=${subset}" >> $GITHUB_OUTPUT
+          echo "size=${size}" >> $GITHUB_OUTPUT
+          echo "fullrun=${TWISTER_FULL}" >> $GITHUB_OUTPUT
 
   twister-build:
     runs-on: zephyr_runner
@@ -187,7 +187,7 @@ jobs:
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
           string(REPLACE "/" "_" repo ${{github.repository}})
           string(REPLACE "-" "_" repo2 ${repo})
-          message("::set-output name=repo::${repo2}")
+          file(APPEND $ENV{GITHUB_OUTPUT} "repo=${repo2}\n")
 
       - name: use cache
         id: cache-ccache

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -253,7 +253,7 @@ jobs:
 
       - name: Upload Unit Test Results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Unit Test Results (Subset ${{ matrix.subset }})
           if-no-files-found: ignore
@@ -282,7 +282,7 @@ jobs:
 
       - name: Upload Unit Test Results in HTML
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: HTML Unit Test Results
           if-no-files-found: ignore

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -51,7 +51,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         continue-on-error: true
         run: |
-          git clone /github/cache/zephyrproject/zephyr .
+          git clone --shared /github/cache/zephyrproject/zephyr .
           git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
 
       - name: Checkout
@@ -147,7 +147,7 @@ jobs:
       - name: Clone cached Zephyr repository
         continue-on-error: true
         run: |
-          git clone /github/cache/zephyrproject/zephyr .
+          git clone --shared /github/cache/zephyrproject/zephyr .
           git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
 
       - name: Checkout

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Checkout
         if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -148,7 +148,7 @@ jobs:
           rm -rf zephyr zephyr-testing
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -47,11 +47,6 @@ jobs:
           #        GitHub comes up with a fundamental fix for this problem.
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
-      - name: Cleanup
-        run: |
-          # hotfix, until we have a better way to deal with existing data
-          rm -rf zephyr zephyr-testing
-
       - name: Clone cached Zephyr repository
         if: github.event_name == 'pull_request_target'
         continue-on-error: true
@@ -148,11 +143,6 @@ jobs:
           #        Actions runner is implemented. Remove this workaround when
           #        GitHub comes up with a fundamental fix for this problem.
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
-
-      - name: Cleanup
-        run: |
-          # hotfix, until we have a better way to deal with existing data
-          rm -rf zephyr zephyr-testing
 
       - name: Clone cached Zephyr repository
         continue-on-error: true

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -5,12 +5,18 @@ name: Twister TestSuite
 
 on:
   push:
+    branches:
+    - main
+    - v*-branch
     paths:
     - 'scripts/pylib/twister/**'
     - 'scripts/twister'
     - 'scripts/tests/twister/**'
     - '.github/workflows/twister_tests.yml'
   pull_request:
+    branches:
+    - main
+    - v*-branch
     paths:
     - 'scripts/pylib/twister/**'
     - 'scripts/twister'

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -27,7 +27,7 @@ jobs:
         os: [ubuntu-20.04]
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -34,7 +34,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux
       if: startsWith(runner.os, 'Linux')
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -29,7 +29,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -22,11 +22,11 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-11, windows-2022]
         exclude:
-          - os: macos-latest
+          - os: macos-11
             python-version: 3.6
-          - os: windows-latest
+          - os: windows-2022
             python-version: 3.6
     steps:
     - name: checkout

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -37,7 +37,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux
       if: startsWith(runner.os, 'Linux')
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}
@@ -45,7 +45,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}
     - name: cache-pip-mac
       if: startsWith(runner.os, 'macOS')
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/Library/Caches/pip
         # Trailing '-' was just to get a different cache name
@@ -54,7 +54,7 @@ jobs:
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
     - name: cache-pip-win
       if: startsWith(runner.os, 'Windows')
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -32,7 +32,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: cache-pip-linux

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -30,7 +30,7 @@ jobs:
             python-version: 3.6
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -5,11 +5,17 @@ name: Zephyr West Command Tests
 
 on:
   push:
+    branches:
+    - main
+    - v*-branch
     paths:
     - 'scripts/west-commands.yml'
     - 'scripts/west_commands/**'
     - '.github/workflows/west_cmds.yml'
   pull_request:
+    branches:
+    - main
+    - v*-branch
     paths:
     - 'scripts/west-commands.yml'
     - 'scripts/west_commands/**'

--- a/scripts/dts/python-devicetree/tox.ini
+++ b/scripts/dts/python-devicetree/tox.ini
@@ -5,7 +5,7 @@ envlist=py3
 deps =
     setuptools-scm
     pytest
-    types-PyYAML
+    types-PyYAML==6.0.7
     mypy
 setenv =
     TOXTEMPDIR={envtmpdir}


### PR DESCRIPTION
This series implements (mostly backports) the following changes for the v3.1-branch:

* Designate a specific runner image version instead of using the `latest` to prevent the upcoming changes to the `latest` tag.
* Use `concurrency` to cancel previous runs instead of using the hacky `styfle/cancel-workflow-action`, which can cancel the CI runs on other branches such as `main`.
* Fix deprecated `set-output` command usages.
* Update deprecated Node 12-based actions.
* Use new Kubernetes-based zephyr-runner since the old zephyr_runner is going to be shut down soon.