### PR TITLE
STM32 L5 - Enable RTC counter

### DIFF
--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_ns.dts
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_ns.dts
@@ -28,6 +28,13 @@
 	};
 };
 
+&rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>,
+		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
+
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_ns.yaml
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_ns.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - counter
   - gpio
   - i2c
   - lptim

--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -13,7 +13,7 @@ menuconfig COUNTER_RTC_STM32
 	select USE_STM32_LL_EXTI
 	help
 	  Build RTC driver for STM32 SoCs.
-	  Tested on STM32 F0, F2, F3, F4, L1, L4, F7, G0, G4, H7 series
+	  Tested on STM32 F0, F2, F3, F4, F7, G0, G4, H7, L1, L4, L5, U5 series
 
 if COUNTER_RTC_STM32
 

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -49,6 +49,7 @@ LOG_MODULE_REGISTER(counter_rtc_stm32, CONFIG_COUNTER_LOG_LEVEL);
 	|| defined(CONFIG_SOC_SERIES_STM32G4X) \
 	|| defined(CONFIG_SOC_SERIES_STM32L0X) \
 	|| defined(CONFIG_SOC_SERIES_STM32L1X) \
+	|| defined(CONFIG_SOC_SERIES_STM32L5X) \
 	|| defined(CONFIG_SOC_SERIES_STM32H7X) \
 	|| defined(CONFIG_SOC_SERIES_STM32WLX)
 #define RTC_EXTI_LINE	LL_EXTI_LINE_17
@@ -370,7 +371,7 @@ void rtc_stm32_isr(const struct device *dev)
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CONFIG_CPU_CORTEX_M4)
 	LL_C2_EXTI_ClearFlag_0_31(RTC_EXTI_LINE);
-#elif defined(CONFIG_SOC_SERIES_STM32G0X)
+#elif defined(CONFIG_SOC_SERIES_STM32G0X) || defined(CONFIG_SOC_SERIES_STM32L5X)
 	LL_EXTI_ClearRisingFlag_0_31(RTC_EXTI_LINE);
 #elif defined(CONFIG_SOC_SERIES_STM32U5X)
 	/* in STM32U5 family RTC is not connected to EXTI */

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -397,6 +397,15 @@
 			status = "disabled";
 		};
 
+		rtc: rtc@40002800 {
+			compatible = "st,stm32-rtc";
+			reg = <0x40002800 0x400>;
+			interrupts = <2 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>;
+			prescaler = <32768>;
+			status = "disabled";
+		};
+
 		timers1: timers@40012c00 {
 			compatible = "st,stm32-timers";
 			reg = <0x40012c00 0x400>;

--- a/samples/drivers/counter/alarm/CMakeLists.txt
+++ b/samples/drivers/counter/alarm/CMakeLists.txt
@@ -6,3 +6,9 @@ project(counter)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+
+if(CONFIG_BUILD_WITH_TFM)
+  target_include_directories(app PRIVATE
+    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
+  )
+endif()

--- a/samples/drivers/counter/alarm/boards/stm32l562e_dk_ns.conf
+++ b/samples/drivers/counter/alarm/boards/stm32l562e_dk_ns.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 O.S.Systems
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_BUILD_WITH_TFM=y
+CONFIG_TFM_PROFILE_TYPE_MEDIUM=y


### PR DESCRIPTION
This add:
* RTC node on STM32L5 dts
* support to STM32L5 counter driver
* DTS configurations for stm32l562e_dk_ns board
* support to build samples/drivers/counter/alarm with TFM

Tested on stm32l562e_dk board:

```
[INF] Beginning TF-M provisioning
[WRN] TFM_DUMMY_PROVISIONING is not suitable for production! This device is NOT SECURE
[Sec Thread] Secure image initializing!
Booting TF-M v1.6.0+8cffe127
Creating an empty ITS flash layout.
Creating an empty PS flash layout.
*** Booting Zephyr OS build zephyr-v3.2.0-2019-g7ac69dc4ca95 ***
Counter alarm sample

Set alarm in 2 sec (2 ticks)
!!! Alarm !!!
Now: 3
Set alarm in 4 sec (4 ticks)
!!! Alarm !!!
Now: 8
Set alarm in 8 sec (8 ticks)
!!! Alarm !!!
Now: 17
Set alarm in 16 sec (16 ticks)
!!! Alarm !!!
Now: 34
Set alarm in 32 sec (32 ticks)
!!! Alarm !!!
Now: 67
Set alarm in 64 sec (64 ticks)
!!! Alarm !!!
Now: 132
Set alarm in 128 sec (128 ticks)
!!! Alarm !!!
Now: 261
Set alarm in 256 sec (256 ticks)
!!! Alarm !!!
Now: 518
Set alarm in 512 sec (512 ticks)
!!! Alarm !!!
Now: 1031
Set alarm in 1024 sec (1024 ticks)
```