### PR TITLE
Add support for NXP S32 Watchdog driver

### DIFF
--- a/boards/arm/s32z270dc2_r52/doc/index.rst
+++ b/boards/arm/s32z270dc2_r52/doc/index.rst
@@ -43,6 +43,8 @@ The boards support the following hardware features:
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
+| SWT       | on-chip    | watchdog                            |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not currently supported by the port.
 
@@ -104,6 +106,12 @@ Serial Port
 The SoC has 12 LINFlexD instances that can be used in UART mode. Instance 0
 (defined as ``uart0`` in devicetree) is configured for the console and the
 remaining are disabled and not configured.
+
+Watchdog
+========
+
+Currently Watchdog only supports interrupt triggering, but does not support
+reset function because currently the board does not support running on flash.
 
 Programming and Debugging
 *************************

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
@@ -68,3 +68,24 @@
 &stm3 {
 	clock-frequency = <133333333>;
 };
+
+&swt0 {
+	clock-frequency = <48000000>;
+	status = "okay";
+};
+
+&swt1 {
+	clock-frequency = <48000000>;
+};
+
+&swt2 {
+	clock-frequency = <48000000>;
+};
+
+&swt3 {
+	clock-frequency = <48000000>;
+};
+
+&swt4 {
+	clock-frequency = <48000000>;
+};

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.yaml
@@ -11,3 +11,4 @@ toolchain:
 supported:
   - uart
   - gpio
+  - watchdog

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.yaml
@@ -11,3 +11,4 @@ toolchain:
 supported:
   - uart
   - gpio
+  - watchdog

--- a/drivers/watchdog/CMakeLists.txt
+++ b/drivers/watchdog/CMakeLists.txt
@@ -27,5 +27,6 @@ zephyr_library_sources_ifdef(CONFIG_WDT_SAM0 wdt_sam0.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_SIFIVE wdt_sifive.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_XEC wdt_mchp_xec.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_COUNTER wdt_counter.c)
+zephyr_library_sources_ifdef(CONFIG_WDT_NXP_S32 wdt_nxp_s32.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE wdt_handlers.c)

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -90,4 +90,6 @@ source "drivers/watchdog/Kconfig.gd32"
 
 source "drivers/watchdog/Kconfig.npm6001"
 
+source "drivers/watchdog/Kconfig.nxp_s32"
+
 endif

--- a/drivers/watchdog/Kconfig.nxp_s32
+++ b/drivers/watchdog/Kconfig.nxp_s32
@@ -1,0 +1,10 @@
+# Copyright 2022 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config WDT_NXP_S32
+	bool "NXP S32 SWT driver"
+	default y
+	depends on DT_HAS_NXP_S32_SWT_ENABLED
+	select NOCACHE_MEMORY
+	help
+	  Enable the Software Watchdog Timer (SWT) driver.

--- a/drivers/watchdog/wdt_nxp_s32.c
+++ b/drivers/watchdog/wdt_nxp_s32.c
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/watchdog.h>
+#include <zephyr/irq.h>
+#include <Swt_Ip.h>
+#include <Swt_Ip_Irq.h>
+
+#define LOG_LEVEL CONFIG_WDT_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(swt_nxp_s32);
+
+#define PARAM_UNUSED	0
+
+struct swt_nxp_s32_config {
+	uint32_t clock_freq;
+	uint8_t instance;
+};
+
+struct swt_nxp_s32_data {
+	Swt_Ip_ConfigType swt_config;
+	wdt_callback_t callback;
+	bool timeout_valid;
+};
+
+static int swt_nxp_s32_setup(const struct device *dev, uint8_t options)
+{
+	const struct swt_nxp_s32_config *config = dev->config;
+	struct swt_nxp_s32_data *data = dev->data;
+	Swt_Ip_StatusType status;
+
+	if (!data->timeout_valid) {
+		LOG_ERR("No valid timeouts installed");
+		return -EINVAL;
+	}
+
+	data->swt_config.bEnRunInStopMode =
+		(options & WDT_OPT_PAUSE_IN_SLEEP) == 0U;
+
+	data->swt_config.bEnRunInDebugMode =
+		(options & WDT_OPT_PAUSE_HALTED_BY_DBG) == 0U;
+
+	status = Swt_Ip_Init(config->instance, &data->swt_config);
+
+	if (status != SWT_IP_STATUS_SUCCESS) {
+		LOG_ERR("Setting up watchdog failed");
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int swt_nxp_s32_disable(const struct device *dev)
+{
+	const struct swt_nxp_s32_config *config = dev->config;
+	struct swt_nxp_s32_data *data = dev->data;
+	Swt_Ip_StatusType status;
+
+	status = Swt_Ip_Deinit(config->instance);
+
+	if (status != SWT_IP_STATUS_SUCCESS) {
+		LOG_ERR("Disabling watchdog failed");
+		return -EIO;
+	}
+
+	data->timeout_valid = false;
+
+	return 0;
+}
+
+static int swt_nxp_s32_install_timeout(const struct device *dev,
+				       const struct wdt_timeout_cfg *cfg)
+{
+	const struct swt_nxp_s32_config *config = dev->config;
+	struct swt_nxp_s32_data *data = dev->data;
+
+	if (data->timeout_valid) {
+		LOG_ERR("No more timeouts can be installed");
+		return -ENOMEM;
+	}
+
+	data->swt_config.u32TimeoutValue = config->clock_freq / 1000U * cfg->window.max;
+
+	if (cfg->window.min) {
+		data->swt_config.bEnWindow = true;
+		data->swt_config.u32WindowValue =
+			config->clock_freq / 1000U * (cfg->window.max - cfg->window.min);
+	} else {
+		data->swt_config.bEnWindow = false;
+		data->swt_config.u32WindowValue = 0;
+	}
+
+	if ((data->swt_config.u32TimeoutValue < SWT_MIN_VALUE_TIMEOUT_U32) ||
+	    (data->swt_config.u32TimeoutValue < data->swt_config.u32WindowValue)) {
+		LOG_ERR("Invalid timeout");
+		return -EINVAL;
+	}
+
+	data->swt_config.bEnInterrupt = cfg->callback != NULL;
+	data->callback = cfg->callback;
+	data->timeout_valid = true;
+	LOG_DBG("Installed timeout (timeoutValue = %d)",
+		data->swt_config.u32TimeoutValue);
+
+	return 0;
+}
+
+static int swt_nxp_s32_feed(const struct device *dev, int channel_id)
+{
+	ARG_UNUSED(channel_id);
+	const struct swt_nxp_s32_config *config = dev->config;
+
+	Swt_Ip_Service(config->instance);
+	LOG_DBG("Fed the watchdog");
+
+	return 0;
+}
+
+static const struct wdt_driver_api swt_nxp_s32_driver_api = {
+	.setup = swt_nxp_s32_setup,
+	.disable = swt_nxp_s32_disable,
+	.install_timeout = swt_nxp_s32_install_timeout,
+	.feed = swt_nxp_s32_feed,
+};
+
+#define SWT_NODE(n)		DT_NODELABEL(swt##n)
+#define RTU0_SWT_OFFSET_IDX	2
+#define RTU1_SWT_OFFSET_IDX	7
+#define RTU_SWT(n)								\
+	COND_CODE_1(CONFIG_NXP_S32_RTU_INDEX, (RTU1_SWT_OFFSET_IDX + n),	\
+		    (RTU0_SWT_OFFSET_IDX + n))
+
+#define SWT_NXP_S32_CALLBACK(n)							\
+	void swt_nxp_s32_##n##_callback(void)					\
+	{									\
+		const struct device *dev = DEVICE_DT_GET(SWT_NODE(n));		\
+		struct swt_nxp_s32_data *data = dev->data;			\
+										\
+		if (data->callback) {						\
+			data->callback(dev, PARAM_UNUSED);			\
+		}								\
+	}
+
+#define SWT_NXP_S32_DEVICE_INIT(n)						\
+	SWT_NXP_S32_CALLBACK(n)							\
+	static struct swt_nxp_s32_data swt_nxp_s32_data_##n = {			\
+		.swt_config = {							\
+			.u8MapEnBitmask = SWT_IP_ALL_MAP_DISABLE |		\
+				SWT_IP_MAP0_ENABLE | SWT_IP_MAP1_ENABLE |	\
+				SWT_IP_MAP2_ENABLE | SWT_IP_MAP3_ENABLE |	\
+				SWT_IP_MAP4_ENABLE | SWT_IP_MAP5_ENABLE |	\
+				SWT_IP_MAP6_ENABLE | SWT_IP_MAP7_ENABLE,	\
+			.bEnResetOnInvalidAccess = TRUE,			\
+			.eServiceMode = FALSE,					\
+			.u16InitialKey = 0,					\
+			.lockConfig = SWT_IP_UNLOCK,				\
+			.pfSwtCallback = &swt_nxp_s32_##n##_callback,		\
+		},								\
+	};									\
+	static const struct swt_nxp_s32_config swt_nxp_s32_config_##n = {	\
+		.clock_freq = DT_PROP(SWT_NODE(n), clock_frequency),		\
+		.instance = (uint8_t)(RTU_SWT(n)),				\
+	};									\
+										\
+	static int swt_nxp_s32_##n##_init(const struct device *dev)		\
+	{									\
+		IRQ_CONNECT(DT_IRQN(SWT_NODE(n)),				\
+			    DT_IRQ(SWT_NODE(n), priority),			\
+			    Swt_Ip_IrqHandler,					\
+			    (uint8_t)(RTU_SWT(n)),				\
+			    DT_IRQ(SWT_NODE(n), flags));			\
+		irq_enable(DT_IRQN(SWT_NODE(n)));				\
+										\
+		return 0;							\
+	}									\
+										\
+	DEVICE_DT_DEFINE(SWT_NODE(n),						\
+			 swt_nxp_s32_##n##_init,				\
+			 NULL,							\
+			 &swt_nxp_s32_data_##n,					\
+			 &swt_nxp_s32_config_##n,				\
+			 POST_KERNEL,						\
+			 CONFIG_KERNEL_INIT_PRIORITY_DEVICE,			\
+			 &swt_nxp_s32_driver_api);
+
+
+#if DT_NODE_HAS_STATUS(SWT_NODE(0), okay)
+SWT_NXP_S32_DEVICE_INIT(0)
+#endif
+
+#if DT_NODE_HAS_STATUS(SWT_NODE(1), okay)
+SWT_NXP_S32_DEVICE_INIT(1)
+#endif
+
+#if DT_NODE_HAS_STATUS(SWT_NODE(2), okay)
+SWT_NXP_S32_DEVICE_INIT(2)
+#endif
+
+#if DT_NODE_HAS_STATUS(SWT_NODE(3), okay)
+SWT_NXP_S32_DEVICE_INIT(3)
+#endif
+
+#if DT_NODE_HAS_STATUS(SWT_NODE(4), okay)
+SWT_NXP_S32_DEVICE_INIT(4)
+#endif

--- a/dts/arm/nxp/nxp_s32z27x_rtu0_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_rtu0_r52.dtsi
@@ -43,6 +43,40 @@
 			interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			status = "disabled";
 		};
-	};
 
+		swt0: watchdog@76000000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x76000000 0x10000>;
+			interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		swt1: watchdog@76010000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x76010000 0x10000>;
+			interrupts = <GIC_SPI 9 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		swt2: watchdog@76220000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x76220000 0x10000>;
+			interrupts = <GIC_SPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		swt3: watchdog@76230000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x76230000 0x10000>;
+			interrupts = <GIC_SPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		swt4: watchdog@76140000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x76140000 0x10000>;
+			interrupts = <GIC_SPI 12 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+	};
 };

--- a/dts/arm/nxp/nxp_s32z27x_rtu1_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_rtu1_r52.dtsi
@@ -43,6 +43,40 @@
 			interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			status = "disabled";
 		};
-	};
 
+		swt0: watchdog@76800000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x76800000 0x10000>;
+			interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		swt1: watchdog@76810000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x76810000 0x10000>;
+			interrupts = <GIC_SPI 9 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		swt2: watchdog@76a20000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x76a20000 0x10000>;
+			interrupts = <GIC_SPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		swt3: watchdog@76a30000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x76a30000 0x10000>;
+			interrupts = <GIC_SPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+
+		swt4: watchdog@76940000 {
+			compatible = "nxp,s32-swt";
+			reg = <0x76940000 0x10000>;
+			interrupts = <GIC_SPI 12 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			status = "disabled";
+		};
+	};
 };

--- a/dts/bindings/watchdog/nxp,s32-swt.yaml
+++ b/dts/bindings/watchdog/nxp,s32-swt.yaml
@@ -1,0 +1,20 @@
+# Copyright 2022 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: Software Watchdog Timer (SWT)
+
+compatible: "nxp,s32-swt"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  clock-frequency:
+    type: int
+    required: true
+    description: Software Watchdog Timer module clock frequency, in Hz.

--- a/tests/drivers/watchdog/wdt_basic_reset_none/CMakeLists.txt
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright 2022 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(wdt_basic_reset_none)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/watchdog/wdt_basic_reset_none/prj.conf
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/prj.conf
@@ -1,0 +1,6 @@
+# Copyright 2022 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y
+CONFIG_WATCHDOG=y

--- a/tests/drivers/watchdog/wdt_basic_reset_none/src/main.c
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/src/main.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/drivers/watchdog.h>
+
+
+/*
+ * To use this test, either the devicetree's /aliases must have a
+ * 'watchdog0' property, or one of the following watchdog compatibles
+ * must have an enabled node.
+ */
+#if DT_NODE_HAS_STATUS(DT_ALIAS(watchdog0), okay)
+#define WDT_NODE DT_ALIAS(watchdog0)
+#elif DT_HAS_COMPAT_STATUS_OKAY(nxp_s32_swt)
+#define WDT_NODE DT_INST(0, nxp_s32_swt)
+#endif
+
+#define WDT_FEED_TRIES		2
+#define WDT_MAX_WINDOW		1000
+#define WDT_TIMEOUT		K_MSEC(1100)
+#define SLEEP_TIME		K_MSEC(500)
+#define WDT_TEST_CB_TEST_VALUE	0xCB
+
+static struct wdt_timeout_cfg m_cfg_wdt0;
+static volatile int wdt_interrupted_flag;
+static volatile int wdt_feed_flag;
+
+
+static void wdt_callback(const struct device *dev, int channel_id)
+{
+	wdt_interrupted_flag += WDT_TEST_CB_TEST_VALUE;
+	zassert_equal(WDT_FEED_TRIES, wdt_feed_flag,
+			"%d: Invalid number of feeding (expected: %d)",
+			wdt_feed_flag, WDT_FEED_TRIES);
+}
+
+static int test_wdt_callback_reset_none(void)
+{
+	int err;
+	const struct device *const wdt = DEVICE_DT_GET(WDT_NODE);
+
+	if (!device_is_ready(wdt)) {
+		TC_PRINT("WDT device is not ready\n");
+		return TC_FAIL;
+	}
+
+	m_cfg_wdt0.window.min = 0U;
+	m_cfg_wdt0.window.max = WDT_MAX_WINDOW;
+	m_cfg_wdt0.flags = WDT_FLAG_RESET_NONE;
+	m_cfg_wdt0.callback = wdt_callback;
+
+	err = wdt_install_timeout(wdt, &m_cfg_wdt0);
+	if (err != 0) {
+		TC_PRINT("Watchdog install error\n");
+		return TC_FAIL;
+	}
+
+	err = wdt_setup(wdt, WDT_OPT_PAUSE_HALTED_BY_DBG);
+	if (err != 0) {
+		TC_PRINT("Watchdog setup error\n");
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Feeding watchdog %d times\n", WDT_FEED_TRIES);
+	wdt_feed_flag = 0;
+	wdt_interrupted_flag = 0;
+	for (int i = 0; i < WDT_FEED_TRIES; ++i) {
+		TC_PRINT("Feeding %d\n", i+1);
+		wdt_feed(wdt, 0);
+		wdt_feed_flag++;
+		k_sleep(SLEEP_TIME);
+	}
+
+	k_timeout_t timeout = WDT_TIMEOUT;
+	uint64_t start_time = k_uptime_ticks();
+
+	while (wdt_interrupted_flag == 0) {
+		if (k_uptime_ticks() - start_time >= timeout.ticks) {
+			break;
+		}
+	}
+
+	zassert_equal(wdt_interrupted_flag, WDT_TEST_CB_TEST_VALUE,
+			"wdt callback failed");
+
+	err = wdt_disable(wdt);
+	if (err != 0) {
+		TC_PRINT("Disable watchdog error\n");
+		return TC_FAIL;
+	}
+
+	return TC_PASS;
+}
+
+static int test_wdt_bad_window_max(void)
+{
+	int err;
+	const struct device *const wdt = DEVICE_DT_GET(WDT_NODE);
+
+	if (!device_is_ready(wdt)) {
+		TC_PRINT("WDT device is not ready\n");
+		return TC_FAIL;
+	}
+
+	m_cfg_wdt0.callback = NULL;
+	m_cfg_wdt0.flags = WDT_FLAG_RESET_NONE;
+	m_cfg_wdt0.window.max = 0U;
+	m_cfg_wdt0.window.min = 0U;
+	err = wdt_install_timeout(wdt, &m_cfg_wdt0);
+	if (err == -EINVAL) {
+		return TC_PASS;
+	}
+
+	return TC_FAIL;
+}
+
+
+ZTEST(wdt_basic_reset_none, test_wdt_callback_reset_none)
+{
+	zassert_true(test_wdt_callback_reset_none() == TC_PASS);
+}
+
+ZTEST(wdt_basic_reset_none, test_wdt_bad_window_max)
+{
+	zassert_true(test_wdt_bad_window_max() == TC_PASS);
+}
+
+ZTEST_SUITE(wdt_basic_reset_none, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml
@@ -1,0 +1,8 @@
+# Copyright 2022 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  drivers.watchdog.reset_none:
+    platform_allow: s32z270dc2_rtu0_r52 s32z270dc2_rtu1_r52
+    tags: drivers watchdog
+    depends_on: watchdog

--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: e31187c0046473fe76578712964238b9c1cf3c0b
+      revision: 0594f3042da3ddc0f7e590142b0ff3e5935257ca
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This PR introduces support for NXP S32 RTU.SWT (WATCHDOG) driver and enable its usage for `s32z270dc2_r52` boards.

The initial version only supports interrupt triggering when timeout expires and does not support the reset function because currently, the board does not support running on flash.

Cherry-picked 924715be84b02117603df8304bcc51e1684f9c6b commit from NXP S32 System Timer Module Pull Request (https://github.com/zephyrproject-rtos/zephyr/pull/51451) to get the RTU index for the purpose of getting the correct instance of the Watchdog interrupts.

A simple test case to test watchdog interrupt can be triggered when the timeout expires is also added for this board.