### PR TITLE
[v2.7-branch] net: Synchronise user data size with mcumgr

### DIFF
--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -15,7 +15,9 @@ if NET_BUF
 
 config NET_BUF_USER_DATA_SIZE
 	int "Size of user_data available in every network buffer"
-	default 8 if ((BT || NET_TCP2) && 64BIT) || BT_ISO
+	default 24 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV6
+	default 8 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV4
+	default 8 if ((BT || NET_TCP2) && 64BIT) || BT_ISO || MCUMGR_SMP_BT
 	default 4
 	range 4 65535 if BT || NET_TCP2
 	range 0 65535


### PR DESCRIPTION
Fixes an issue with 2 user data sizes being out of sync causing CI failures.

Fixes #52591