### PR TITLE
driver: gpio: npcx: correct the usage of npcx voltage flags

### DIFF
--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -128,11 +128,13 @@ static int gpio_npcx_config(const struct device *dev,
 
 	/* Does this IO pad support low-voltage input (1.8V) detection? */
 	if (lvol->ctrl != NPCX_DT_LVOL_CTRL_NONE) {
+		gpio_flags_t volt = flags & NPCX_GPIO_VOLTAGE_MASK;
+
 		/*
 		 * If this IO pad is configured for low-voltage input detection,
 		 * the related drive type must select to open-drain also.
 		 */
-		if ((flags & NPCX_GPIO_VOLTAGE_1P8) != 0) {
+		if (volt == NPCX_GPIO_VOLTAGE_1P8) {
 			flags |= GPIO_OPEN_DRAIN;
 			npcx_lvol_set_detect_level(lvol->ctrl, lvol->bit, true);
 		} else {

--- a/include/zephyr/dt-bindings/gpio/nuvoton-npcx-gpio.h
+++ b/include/zephyr/dt-bindings/gpio/nuvoton-npcx-gpio.h
@@ -20,8 +20,10 @@
 #define NPCX_GPIO_VOLTAGE_MASK	(1U << NPCX_GPIO_VOLTAGE_POS)
 /** @endcond */
 
+/** Set pin at the default voltage level (3.3V) */
+#define NPCX_GPIO_VOLTAGE_DEFAULT	(0U << NPCX_GPIO_VOLTAGE_POS)
 /** Set pin voltage level at 1.8 V */
-#define NPCX_GPIO_VOLTAGE_1P8	(0U << NPCX_GPIO_VOLTAGE_POS)
+#define NPCX_GPIO_VOLTAGE_1P8		(1U << NPCX_GPIO_VOLTAGE_POS)
 
 /** @} */
 


### PR DESCRIPTION
In npcx ec series, two detection levels, 3.3V (default) and 1.8V are supported during gpio configuration. But the current implementation always selects default detection level whether NPCX_GPIO_VOLTAGE_1P8 is set. This PR is a fix for this issue.

The regression has been introduced in b1552001bf0b544b3210b6586ec15167cdbf7bc0

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>