### PR TITLE
soc: stm32u5: Replace IMGTOOL_ARGS with ROM_START_OFFSET

### DIFF
--- a/soc/arm/st_stm32/stm32u5/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32u5/Kconfig.defconfig.series
@@ -10,7 +10,7 @@ source "soc/arm/st_stm32/stm32u5/Kconfig.defconfig.stm32u5*"
 config SOC_SERIES
 	default "stm32u5"
 
-config MCUBOOT_EXTRA_IMGTOOL_ARGS
-	default "--header-size 1024" if BOOTLOADER_MCUBOOT
+config ROM_START_OFFSET
+	default 0x400 if BOOTLOADER_MCUBOOT
 
 endif # SOC_SERIES_STM32U5X


### PR DESCRIPTION
EXTRA_IMGTOOL_ARGS option is intended for the user. It is used to set additional options by the user.
Setting it here will cause the user to accidentally overwrite it if they try to use it as intended, which is unintuitive. Also if user intentionally sets ROM_START_OFFSET, this option will try to overwrite user choice during sign.

Replace hardcoded config option MCUBOOT_EXTRA_IMGTOOL_ARGS with proper config ROM_START_OFFSET.