### PR TITLE
Do not return early on fs-close error

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -187,7 +187,6 @@ int fs_close(struct fs_file_t *zfp)
 	rc = zfp->mp->fs->close(zfp);
 	if (rc < 0) {
 		LOG_ERR("file close error (%d)", rc);
-		return rc;
 	}
 
 	zfp->mp = NULL;


### PR DESCRIPTION
Returning early, on fs_close error does not set zfp->mp pointer to NULL, which causes a crash the next time, fs_close function is called.