### PR TITLE
ARC: arcmwdt: fix & rework inclusion of C/C++ headers

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -117,9 +117,8 @@ set_compiler_property(PROPERTY cstd -std=)
 
 if (NOT CONFIG_ARCMWDT_LIBC)
   set_compiler_property(PROPERTY nostdinc -Hno_default_include -Hnoarcexlib)
+  set_compiler_property(APPEND PROPERTY nostdinc_include ${NOSTDINC})
 endif()
-
-set_compiler_property(APPEND PROPERTY nostdinc_include ${NOSTDINC})
 
 # C++ std options
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp98 "-std=c++98")
@@ -187,3 +186,10 @@ set_compiler_property(PROPERTY no_position_independent
 
 # Required ASM flags when using mwdt
 set_property(TARGET asm PROPERTY required "-Hasmcpp")
+
+if(CONFIG_ARCMWDT_LIBC)
+  # We rely on the default C/C++ include locations which are provided by MWDT if we do build with
+  # MW C / C++ libraries. However, for that case we still need to explicitly set header directory
+  # to ASM builds (which may use 'stdbool.h').
+  set_property(TARGET asm APPEND PROPERTY required "-I${NOSTDINC}")
+endif()

--- a/cmake/compiler/arcmwdt/target.cmake
+++ b/cmake/compiler/arcmwdt/target.cmake
@@ -22,23 +22,11 @@ list(APPEND CMAKE_REQUIRED_FLAGS
   )
 string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 
-set(NOSTDINC "")
+set(NOSTDINC ${TOOLCHAIN_HOME}/arc/inc)
 
-list(APPEND NOSTDINC ${TOOLCHAIN_HOME}/arc/inc)
-
-if(CONFIG_ARCMWDT_LIBC AND CONFIG_LIB_CPLUSPLUS)
-  list(APPEND NOSTDINC ${TOOLCHAIN_HOME}/arc/lib/src/c++/inc)
-endif()
-
-# For CMake to be able to test if a compiler flag is supported by the
-# toolchain we need to give CMake the necessary flags to compile and
-# link a dummy C file.
-#
-# CMake checks compiler flags with check_c_compiler_flag() (Which we
-# wrap with target_cc_option() in extensions.cmake)
-foreach(isystem_include_dir ${NOSTDINC})
-  list(APPEND isystem_include_flags -isystem "\"${isystem_include_dir}\"")
-endforeach()
+# For CMake to be able to test if a compiler flag is supported by the toolchain
+# (check_c_compiler_flag function which we wrap with target_cc_option in extensions.cmake)
+# we rely on default MWDT header locations and don't manually specify headers directories.
 
 # common compile options, no copyright msg, little-endian, no small data,
 # no MWDT stack checking


### PR DESCRIPTION
Currently we try to manually specify C/C++ headers locations with -isystem flag which lead to issues with "include_next" directive which is used in C/C++ headers. As advised by MWDT R&D team let's rely on the default C/C++ include locations which are provided by MWDT if we do build with MW C / C++ libraries. For that case we still need to manually specify header directory to ASM builds which bay use 'stdbool.h'

In case of building with minimal libc (provided by Zephyr) we rely on minimal libc headers and manually specify toolchain's C header directory (as minimal libc still uses some toolchain's C headers.