### PR TITLE
Bluetooth: Add legacy warning to `Kconfig.template.log_config_bt`

### DIFF
--- a/subsys/bluetooth/common/Kconfig.template.log_config_bt
+++ b/subsys/bluetooth/common/Kconfig.template.log_config_bt
@@ -1,6 +1,19 @@
 # Copyright (c) 2022 Nordic Semicoductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+# Usage:
+# This template provides backwards compatibility for legacy kconfig symbols.
+# Do not add new uses of it.
+#
+# The following arguments are mandatory:
+# 	- module:
+#		Name of the new log level kconfig.
+#		Example: "BT_HCI_CORE"
+# 	- legacy-debug-sym:
+#		An existing "legacy" kconfig bool. If that bool is selected,
+#		the new kconfig is forced to max verbosity.
+#		Example: "BT_DEBUG_HCI_CORE"
+
 parent-module = BT
 
 choice "$(module)_LOG_LEVEL_CHOICE"


### PR DESCRIPTION
Add legacy warning to `Kconfig.template.log_config_bt`