### PR TITLE
lib: os: add CRC shell command for integrity verification

### DIFF
--- a/include/zephyr/sys/crc.h
+++ b/include/zephyr/sys/crc.h
@@ -4,6 +4,7 @@
  * Copyright (c) 2017 Nordic Semiconductor ASA
  * Copyright (c) 2015 Runtime Inc
  * Copyright (c) 2018 Google LLC.
+ * Copyright (c) 2022 Meta
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,6 +18,8 @@
 #include <zephyr/types.h>
 #include <stdbool.h>
 #include <stddef.h>
+
+#include <zephyr/sys/__assert.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,6 +39,23 @@ extern "C" {
  * @ingroup checksum
  * @{
  */
+
+/**
+ * @brief CRC algorithm enumeration
+ *
+ * These values should be used with the @ref crc dispatch function.
+ */
+enum crc_type {
+	CRC7_BE,     /**< Use @ref crc7_be */
+	CRC8,	     /**< Use @ref crc8 */
+	CRC8_CCITT,  /**< Use @ref crc8_ccitt */
+	CRC16,	     /**< Use @ref crc16 */
+	CRC16_ANSI,  /**< Use @ref crc16_ansi */
+	CRC16_CCITT, /**< Use @ref crc16_ccitt */
+	CRC16_ITU_T, /**< Use @ref crc16_itu_t */
+	CRC32_C,     /**< Use @ref crc32_c */
+	CRC32_IEEE,  /**< Use @ref crc32_ieee */
+};
 
 /**
  * @brief Generic function for computing a CRC-16 without input or output
@@ -256,6 +276,63 @@ uint8_t crc8_ccitt(uint8_t initial_value, const void *buf, size_t len);
  * @return The computed CRC7 value
  */
 uint8_t crc7_be(uint8_t seed, const uint8_t *src, size_t len);
+
+/**
+ * @brief Compute a CRC checksum, in a generic way.
+ *
+ * This is a dispatch function that calls the individual CRC routine
+ * determined by @p type.
+ *
+ * For 7, 8, and 16-bit CRCs, the relevant @p seed and @p poly values should
+ * be passed in via the least-significant byte(s).
+ *
+ * Similarly, for 7, 8, and 16-bit CRCs, the relevant result is stored in the
+ * least-significant byte(s) of the returned value.
+ *
+ * @param type CRC algorithm to use.
+ * @param src Input bytes for the computation
+ * @param len Length of the input in bytes
+ * @param seed Value to seed the CRC with
+ * @param poly The polynomial to use omitting the leading coefficient
+ * @param reflect Should we use reflected/reversed values or not
+ * @param first Whether this is the first packet in the stream.
+ * @param last Whether this is the last packet in the stream.
+ * @return uint32_t the computed CRC value
+ */
+static inline uint32_t crc_by_type(enum crc_type type, const uint8_t *src, size_t len,
+				   uint32_t seed, uint32_t poly, bool reflect, bool first,
+				   bool last)
+{
+	switch (type) {
+	case CRC7_BE:
+		return crc7_be(seed, src, len);
+	case CRC8:
+		return crc8(src, len, poly, seed, reflect);
+	case CRC8_CCITT:
+		return crc8_ccitt(seed, src, len);
+	case CRC16:
+		if (reflect) {
+			return crc16_reflect(poly, seed, src, len);
+		} else {
+			return crc16(poly, seed, src, len);
+		}
+	case CRC16_ANSI:
+		return crc16_ansi(src, len);
+	case CRC16_CCITT:
+		return crc16_ccitt(seed, src, len);
+	case CRC16_ITU_T:
+		return crc16_itu_t(seed, src, len);
+	case CRC32_C:
+		return crc32_c(seed, src, len, first, last);
+	case CRC32_IEEE:
+		return crc32_ieee_update(seed, src, len);
+	default:
+		break;
+	}
+
+	__ASSERT_NO_MSG(false);
+	return -1;
+}
 
 /**
  * @}

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -27,6 +27,7 @@ zephyr_sources_ifdef(CONFIG_CRC
   crc8_sw.c
   crc7_sw.c
   )
+zephyr_sources_ifdef(CONFIG_CRC_SHELL crc_shell.c)
 
 zephyr_sources_ifdef(CONFIG_CBPRINTF_COMPLETE cbprintf_complete.c)
 zephyr_sources_ifdef(CONFIG_CBPRINTF_NANO cbprintf_nano.c)

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -32,6 +32,15 @@ config CRC
 	help
 	  Enable use of CRC.
 
+if CRC
+config CRC_SHELL
+	bool "CRC Shell"
+	depends on SHELL
+	select GETOPT
+	help
+	  Enable CRC checking for memory regions from the shell.
+endif # CRC
+
 config PRINTK_SYNC
 	bool "Serialize printk() calls"
 	default y if SMP && MP_NUM_CPUS > 1 && !(EFI_CONSOLE && LOG)

--- a/lib/os/crc_shell.c
+++ b/lib/os/crc_shell.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2022 Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <getopt.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/sys/crc.h>
+
+static const char *const crc_types[] = {
+	[CRC7_BE] = "7_be",
+	[CRC8] = "8",
+	[CRC8_CCITT] "8_ccitt",
+	[CRC16] = "16",
+	[CRC16_ANSI] = "16_ansi",
+	[CRC16_CCITT] = "16_ccitt",
+	[CRC16_ITU_T] = "16_itu_t",
+	[CRC32_C] = "32_c",
+	[CRC32_IEEE] = "32_ieee",
+};
+
+static int string_to_crc_type(const char *s)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(crc_types); ++i) {
+		if (strcmp(s, crc_types[i]) == 0) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+static void usage(const struct shell *sh)
+{
+	size_t i;
+
+	shell_print(sh, "crc [options..] <address> <size>");
+	shell_print(sh, "options:");
+	shell_print(sh, "-f         This is the first packet");
+	shell_print(sh, "-l         This is the last packet");
+	shell_print(sh, "-p <poly>  Use polynomial 'poly'");
+	shell_print(sh, "-r         Reflect");
+	shell_print(sh, "-s <seed>  Use 'seed' as the initial value");
+	shell_print(sh, "-t <type>  Compute the CRC described by 'type'");
+	shell_print(sh, "Note: some options are only useful for certain CRCs");
+	shell_print(sh, "CRC Types:");
+	for (i = 0; i < ARRAY_SIZE(crc_types); ++i) {
+		shell_print(sh, "%s", crc_types[i]);
+	}
+}
+
+static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
+{
+	int rv;
+	size_t size = -1;
+	bool last = false;
+	uint32_t poly = 0;
+	bool first = false;
+	uint32_t seed = 0;
+	bool reflect = false;
+	void *addr = (void *)-1;
+	enum crc_type type = CRC32_IEEE;
+
+	optind = 1;
+	optreset = 1;
+
+	while ((rv = getopt(argc, argv, "fhlp:rs:t:")) != -1) {
+		switch (rv) {
+		case 'f':
+			first = true;
+			break;
+		case 'h':
+			usage(sh);
+			return 0;
+		case 'l':
+			last = true;
+			break;
+		case 'p':
+			poly = (size_t)strtoul(optarg, NULL, 16);
+			if (poly == 0 && errno == EINVAL) {
+				shell_error(sh, "invalid seed '%s'", optarg);
+				return -EINVAL;
+			}
+			break;
+		case 'r':
+			reflect = true;
+			break;
+		case 's':
+			seed = (size_t)strtoul(optarg, NULL, 16);
+			if (seed == 0 && errno == EINVAL) {
+				shell_error(sh, "invalid seed '%s'", optarg);
+				return -EINVAL;
+			}
+			break;
+		case 't':
+			type = string_to_crc_type(optarg);
+			if (type == -1) {
+				shell_error(sh, "invalid type '%s'", optarg);
+				return -EINVAL;
+			}
+			break;
+		case '?':
+		default:
+			usage(sh);
+			return -EINVAL;
+		}
+	}
+
+	if (optind + 2 > argc) {
+		shell_error(sh, "'address' and 'size' arguments are mandatory");
+		usage(sh);
+		return -EINVAL;
+	}
+
+	addr = (void *)strtoul(argv[optind], NULL, 16);
+	if (addr == 0 && errno == EINVAL) {
+		shell_error(sh, "invalid address '%s'", argv[optind]);
+		return -EINVAL;
+	}
+
+	size = (size_t)strtoul(argv[optind + 1], NULL, 0);
+	if (size == 0 && errno == EINVAL) {
+		shell_error(sh, "invalid size '%s'", argv[optind + 1]);
+		return -EINVAL;
+	}
+
+	shell_print(sh, "0x%x", crc_by_type(type, addr, size, seed, poly, reflect, first, last));
+
+	return 0;
+}
+
+SHELL_CMD_ARG_REGISTER(crc, NULL, NULL, cmd_crc, 0, 12);


### PR DESCRIPTION
Several Zephyr shell commands are used for transferring data over a possibly unreliable connection such as a UART into either memory or flash. For example, `flash load` and `devmem load`.

Make the CRC functions available so that they can be used to verify the integrity of data transferred over possibly unreliable connections.

Signed-off-by: Chris Friedt <cfriedt@meta.com>