### PR TITLE
drivers: gpio: fix gpio-reserved-ranges handling in MCUX iGPIO driver

### DIFF
--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -56,8 +56,8 @@ static int mcux_igpio_configure(const struct device *dev,
 
 	/* Some SOCs have non-contiguous gpio pin layouts, account for this */
 	for (i = 0; i < config->gap_count; i++) {
-		if (cfg_idx >= config->pin_gaps[i].start) {
-			if (cfg_idx < (config->pin_gaps[i].start +
+		if (pin >= config->pin_gaps[i].start) {
+			if (pin < (config->pin_gaps[i].start +
 				config->pin_gaps[i].len)) {
 				/* Pin is not connected to a mux */
 				return -ENOTSUP;


### PR DESCRIPTION
Fix handling of gpio-reserved-ranges within MCUX iGPIO driver, to ensure that the configuration IDX will be correctly calculated for pins where multiple reserved ranges are present on the GPIO controller

Fixes #52506

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>