### PR TITLE
drivers: wifi: eswifi: Guard net_ctx state change

### DIFF
--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -222,6 +222,10 @@ int __eswifi_off_start_client(struct eswifi_dev *eswifi,
 		return -EIO;
 	}
 
+#if !defined(CONFIG_NET_SOCKETS_OFFLOAD)
+	net_context_set_state(socket->context, NET_CONTEXT_CONNECTED);
+#endif
+
 	return 0;
 }
 


### PR DESCRIPTION
Previously, a call to set the net_context state was added here to
accommodate a new KConfig scenario that permitted disabling offload
sockets. This code path is used by both local and offloaded sockets.
While it is necessary to update the state of the net_context for a
locally managed socket, setting the net_context for an offloaded socket
is an error, as the net_context is invalid (in fact, it points to a
hard-coded dummy socket), as observed in #52346 and #38544.

A prior commit (a9ac0a88) attempting to remedy the offload socket
scenario removed this line, which resulted in problems for the local
socket scenario. The socket never got updated to the connected state,
and thus was unusable.

Adding this guard allows the eswifi socket to set the socket net_context
only if the socket is NOT offloaded.

Signed-off-by: Brian Dunlay <brian@nubix.io>.

Tested this manually by fetching data over sockets with the B_L4S5I_IOT01A board with an eswifi module using the default configuration (offload sockets) as well as the explicit CONFIG_NET_SOCKETS_OFFLOAD=n configuration.