### PR TITLE
twister: fix simulation conditional

### DIFF
--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -140,7 +140,7 @@ class TestInstance:
 
         options = env.options
         handler = Handler(self, "")
-        if self.platform.simulation:
+        if self.platform.simulation != "na":
             if self.platform.simulation == "qemu":
                 handler = QEMUHandler(self, "qemu")
                 handler.args.append(f"QEMU_PIPE={handler.get_fifo()}")


### PR DESCRIPTION
non-simulation platforms set key to 'na', we need to check for that
instead of just checking for existance of key.

Fixes #52595

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
