### PR TITLE
unittest: add support for coverage

### DIFF
--- a/cmake/modules/unittest.cmake
+++ b/cmake/modules/unittest.cmake
@@ -93,7 +93,7 @@ target_link_libraries(testbinary PRIVATE
   ${EXTRA_LDFLAGS_AS_LIST}
   )
 
-if(COVERAGE)
+if(CONFIG_COVERAGE)
   target_compile_options(test_interface INTERFACE $<TARGET_PROPERTY:compiler,coverage>)
 
   target_link_libraries(testbinary PRIVATE $<TARGET_PROPERTY:linker,coverage>)

--- a/subsys/testsuite/boards/unit_testing/unit_testing/Kconfig.board
+++ b/subsys/testsuite/boards/unit_testing/unit_testing/Kconfig.board
@@ -4,5 +4,7 @@
 
 config BOARD_UNIT_TESTING
 	bool "Unit testing board"
+	select HAS_COVERAGE_SUPPORT
+	select NATIVE_APPLICATION
 	help
 	  Board for unit testing


### PR DESCRIPTION
Some missing features for getting coverage data for unit tests:
- Setting the unit_testing board to have coverage support and native application.
- Fixing the CONFIG_COVERAGE check

Signed-off-by: Yuval Peress <peress@google.com>