### PR TITLE
tests/samples: use integration_plaforms in more tests/samples

### DIFF
--- a/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25.yaml
+++ b/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25.yaml
@@ -7,6 +7,7 @@ toolchain:
   - zephyr
 supported:
   - dma
+  - dai
 testing:
   ignore_tags:
      - net

--- a/samples/application_development/code_relocation_nocopy/sample.yaml
+++ b/samples/application_development/code_relocation_nocopy/sample.yaml
@@ -4,6 +4,8 @@ sample:
 tests:
   sample.application_development.code_relocation_nocopy:
     platform_allow: qemu_cortex_m3 nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - qemu_cortex_m3
     tags: linker
     harness: console
     harness_config:

--- a/samples/application_development/out_of_tree_board/sample.yaml
+++ b/samples/application_development/out_of_tree_board/sample.yaml
@@ -5,6 +5,8 @@ tests:
   sample.app_dev.out_of_tree:
     tags: out_of_tree
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
+    integration_platforms:
+      - nrf52840dk_nrf52840
     harness: console
     harness_config:
       type: one_line

--- a/samples/application_development/sysbuild/with_mcuboot/sample.yaml
+++ b/samples/application_development/sysbuild/with_mcuboot/sample.yaml
@@ -1,16 +1,18 @@
 sample:
-    description: Sample with MCUboot built through sysbuild
-    name: with mcuboot
+  description: Sample with MCUboot built through sysbuild
+  name: with mcuboot
 tests:
   sample.application_development.sysbuild.with_mcuboot:
     sysbuild: True
     # Platform allowed is used as twister using sysbuild still lacks proper
     # filtering support, see discussion in #49552.
     platform_allow: reel_board nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: mcuboot
     harness: console
     harness_config:
       type: multi_line
       regex:
-      - "Address of sample(.*)"
-      - "Hello sysbuild with mcuboot!(.*)"
+        - "Address of sample(.*)"
+        - "Hello sysbuild with mcuboot!(.*)"

--- a/samples/basic/minimal/sample.yaml
+++ b/samples/basic/minimal/sample.yaml
@@ -3,44 +3,37 @@ sample:
   name: minimal
 common:
   tags: footprint
+  build_only: true
 tests:
   sample.minimal.mt.arm:
-    build_only: true
     extra_args: CONF_FILE='common.conf;mt.conf;arm.conf'
     platform_allow: reel_board frdm_k64f mps2_an385 nrf51dk_nrf51422 nucleo_f429zi disco_l475_iot1
+    integration_platforms:
+      - frdm_k64f
   sample.minimal.mt-no-preempt.arm:
-    build_only: true
     extra_args: CONF_FILE='common.conf;mt.conf;no-preempt.conf;arm.conf'
     platform_allow: reel_board frdm_k64f mps2_an385 nrf51dk_nrf51422 nucleo_f429zi disco_l475_iot1
   sample.minimal.mt-no-preempt-no-timers.arm:
-    build_only: true
     extra_args: CONF_FILE='common.conf;mt.conf;no-preempt.conf;no-timers.conf;arm.conf'
     platform_allow: reel_board frdm_k64f mps2_an385 nrf51dk_nrf51422 nucleo_f429zi disco_l475_iot1
   sample.minimal.no-mt.arm:
-    build_only: true
     extra_args: CONF_FILE='common.conf;no-mt.conf;arm.conf'
     platform_allow: reel_board frdm_k64f mps2_an385 nrf51dk_nrf51422 nucleo_f429zi disco_l475_iot1
   sample.minimal.no-mt-no-timers.arm:
-    build_only: true
     extra_args: CONF_FILE='common.conf;no-mt.conf;no-timers.conf;arm.conf'
     platform_allow: reel_board frdm_k64f mps2_an385 nrf51dk_nrf51422 nucleo_f429zi disco_l475_iot1
   sample.minimal.mt.x86:
-    build_only: true
     extra_args: CONF_FILE='common.conf;mt.conf;x86.conf'
     platform_allow: qemu_x86
   sample.minimal.mt-no-preempt.x86:
-    build_only: true
     extra_args: CONF_FILE='common.conf;mt.conf;no-preempt.conf;x86.conf'
     platform_allow: qemu_x86
   sample.minimal.mt-no-preempt-no-timers.x86:
-    build_only: true
     extra_args: CONF_FILE='common.conf;mt.conf;no-preempt.conf;no-timers.conf;x86.conf'
     platform_allow: qemu_x86
   sample.minimal.no-mt.x86:
-    build_only: true
     extra_args: CONF_FILE='common.conf;no-mt.conf;x86.conf'
     platform_allow: qemu_x86
   sample.minimal.no-mt-no-timers.x86:
-    build_only: true
     extra_args: CONF_FILE='common.conf;no-mt.conf;no-timers.conf;x86.conf'
     platform_allow: qemu_x86

--- a/samples/bluetooth/beacon/sample.yaml
+++ b/samples/bluetooth/beacon/sample.yaml
@@ -5,3 +5,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52dk_nrf52832
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/broadcast_audio_sink/sample.yaml
+++ b/samples/bluetooth/broadcast_audio_sink/sample.yaml
@@ -6,3 +6,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52_bsim
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/broadcast_audio_source/sample.yaml
+++ b/samples/bluetooth/broadcast_audio_source/sample.yaml
@@ -5,4 +5,6 @@ tests:
   sample.bluetooth.broadcast_audio_source:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52_bsim
+    integration_platforms:
+      - qemu_x86
     tags: bluetooth

--- a/samples/bluetooth/broadcaster/sample.yaml
+++ b/samples/bluetooth/broadcaster/sample.yaml
@@ -5,3 +5,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf51dk_nrf51422 nrf52dk_nrf52832
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/broadcaster_multiple/sample.yaml
+++ b/samples/bluetooth/broadcaster_multiple/sample.yaml
@@ -5,3 +5,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf51dk_nrf51422 nrf52_bsim nrf52dk_nrf52832
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/central/sample.yaml
+++ b/samples/bluetooth/central/sample.yaml
@@ -5,3 +5,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/central_gatt_write/sample.yaml
+++ b/samples/bluetooth/central_gatt_write/sample.yaml
@@ -4,4 +4,6 @@ tests:
   sample.bluetooth.central_gatt_write:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52_bsim
+    integration_platforms:
+      - qemu_cortex_m3
     tags: bluetooth

--- a/samples/bluetooth/central_ht/sample.yaml
+++ b/samples/bluetooth/central_ht/sample.yaml
@@ -5,3 +5,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf51dk_nrf51422 nrf52dk_nrf52832
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/central_iso/sample.yaml
+++ b/samples/bluetooth/central_iso/sample.yaml
@@ -5,4 +5,6 @@ tests:
   sample.bluetooth.central_iso:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
+    integration_platforms:
+      - qemu_cortex_m3
     tags: bluetooth

--- a/samples/bluetooth/central_multilink/sample.yaml
+++ b/samples/bluetooth/central_multilink/sample.yaml
@@ -4,4 +4,6 @@ tests:
   sample.bluetooth.central.multilink:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52840dk_nrf52840
+    integration_platforms:
+      - qemu_cortex_m3
     tags: bluetooth

--- a/samples/bluetooth/central_otc/sample.yaml
+++ b/samples/bluetooth/central_otc/sample.yaml
@@ -5,3 +5,5 @@ tests:
     harness: bluetooth
     platform_allow: nrf21540dk_nrf52840 nrf52840dk_nrf52840 nrf52833dk_nrf52833
     tags: bluetooth
+    integration_platforms:
+      - nrf21540dk_nrf52840

--- a/samples/bluetooth/central_past/sample.yaml
+++ b/samples/bluetooth/central_past/sample.yaml
@@ -4,4 +4,6 @@ tests:
   sample.bluetooth.central_past:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52_bsim
+    integration_platforms:
+      - qemu_cortex_m3
     tags: bluetooth

--- a/samples/bluetooth/direct_adv/sample.yaml
+++ b/samples/bluetooth/direct_adv/sample.yaml
@@ -4,4 +4,6 @@ tests:
   sample.bluetooth.direct_adv:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
+    integration_platforms:
+      - qemu_cortex_m3
     tags: bluetooth

--- a/samples/bluetooth/eddystone/sample.yaml
+++ b/samples/bluetooth/eddystone/sample.yaml
@@ -5,3 +5,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/handsfree/sample.yaml
+++ b/samples/bluetooth/handsfree/sample.yaml
@@ -5,3 +5,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/hci_pwr_ctrl/sample.yaml
+++ b/samples/bluetooth/hci_pwr_ctrl/sample.yaml
@@ -5,3 +5,5 @@ tests:
     harness: bluetooth
     platform_allow: bbc_microbit nrf51dk_nrf51422 nrf52dk_nrf52832 qemu_cortex_m3 qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/ibeacon/sample.yaml
+++ b/samples/bluetooth/ibeacon/sample.yaml
@@ -6,3 +6,5 @@ tests:
     harness: bluetooth
     platform_allow: bbc_microbit qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_x86

--- a/samples/bluetooth/ipsp/sample.yaml
+++ b/samples/bluetooth/ipsp/sample.yaml
@@ -6,8 +6,12 @@ tests:
     harness: bluetooth
     platform_allow: qemu_x86 qemu_cortex_m3
     tags: bluetooth net
+    integration_platforms:
+      - qemu_x86
   sample.bluetooth.ipsp.zep1656:
     harness: bluetooth
     extra_args: CONF_FILE="prj_zep1656.conf"
     platform_allow: qemu_x86 qemu_cortex_m3
     tags: bluetooth net
+    integration_platforms:
+      - qemu_x86

--- a/samples/bluetooth/iso_broadcast/sample.yaml
+++ b/samples/bluetooth/iso_broadcast/sample.yaml
@@ -4,4 +4,6 @@ tests:
   sample.bluetooth.iso_broadcast:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52_bsim nrf52dk_nrf52832
+    integration_platforms:
+      - qemu_cortex_m3
     tags: bluetooth

--- a/samples/bluetooth/iso_broadcast_benchmark/sample.yaml
+++ b/samples/bluetooth/iso_broadcast_benchmark/sample.yaml
@@ -5,4 +5,6 @@ tests:
   sample.bluetooth.iso_broadcast_benchmark:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: bluetooth

--- a/samples/bluetooth/iso_receive/sample.yaml
+++ b/samples/bluetooth/iso_receive/sample.yaml
@@ -4,4 +4,6 @@ tests:
   sample.bluetooth.iso_receive:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52_bsim nrf52dk_nrf52832
+    integration_platforms:
+      - qemu_cortex_m3
     tags: bluetooth

--- a/samples/bluetooth/mesh/sample.yaml
+++ b/samples/bluetooth/mesh/sample.yaml
@@ -4,4 +4,6 @@ tests:
   sample.bluetooth.mesh:
     harness: bluetooth
     platform_allow: bbc_microbit nrf51_blenano qemu_x86
+    integration_platforms:
+      - qemu_x86
     tags: bluetooth

--- a/samples/bluetooth/mesh_demo/sample.yaml
+++ b/samples/bluetooth/mesh_demo/sample.yaml
@@ -4,4 +4,6 @@ tests:
   sample.bluetooth.mesh_demo:
     harness: bluetooth
     platform_allow: bbc_microbit nrf51_blenano qemu_x86
+    integration_platforms:
+      - qemu_x86
     tags: bluetooth

--- a/samples/bluetooth/mesh_provisioner/sample.yaml
+++ b/samples/bluetooth/mesh_provisioner/sample.yaml
@@ -4,4 +4,6 @@ tests:
   sample.bluetooth.mesh_provisioner:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf51dk_nrf51422 nrf52dk_nrf52832
+    integration_platforms:
+      - qemu_cortex_m3
     tags: bluetooth

--- a/samples/bluetooth/observer/sample.yaml
+++ b/samples/bluetooth/observer/sample.yaml
@@ -4,9 +4,13 @@ tests:
   sample.bluetooth.observer:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52840dk_nrf52840
+    integration_platforms:
+      - qemu_cortex_m3
     tags: bluetooth
   sample.bluetooth.observer.extended:
     harness: bluetooth
     extra_args: CONF_FILE="prj_extended.conf"
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52840dk_nrf52840
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/periodic_adv/sample.yaml
+++ b/samples/bluetooth/periodic_adv/sample.yaml
@@ -5,3 +5,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52_bsim nrf52dk_nrf52832
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/periodic_sync/sample.yaml
+++ b/samples/bluetooth/periodic_sync/sample.yaml
@@ -5,3 +5,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52_bsim nrf52dk_nrf52832
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/peripheral/sample.yaml
+++ b/samples/bluetooth/peripheral/sample.yaml
@@ -5,9 +5,13 @@ tests:
   sample.bluetooth.peripheral:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nucleo_wb55rg
+    integration_platforms:
+      - qemu_cortex_m3
     tags: bluetooth
   sample.bluetooth.peripheral.x_nucleo_idb05a1_shield:
     harness: bluetooth
     platform_allow: nucleo_l4r5zi
     depends_on: arduino_spi arduino_gpio
     extra_args: SHIELD=x_nucleo_idb05a1
+    integration_platforms:
+      - nucleo_l4r5zi

--- a/samples/bluetooth/peripheral_csc/sample.yaml
+++ b/samples/bluetooth/peripheral_csc/sample.yaml
@@ -6,3 +6,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/peripheral_dis/sample.yaml
+++ b/samples/bluetooth/peripheral_dis/sample.yaml
@@ -6,3 +6,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/peripheral_esp/sample.yaml
+++ b/samples/bluetooth/peripheral_esp/sample.yaml
@@ -6,3 +6,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/peripheral_gatt_write/sample.yaml
+++ b/samples/bluetooth/peripheral_gatt_write/sample.yaml
@@ -5,3 +5,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52_bsim
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/peripheral_hids/sample.yaml
+++ b/samples/bluetooth/peripheral_hids/sample.yaml
@@ -6,3 +6,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/peripheral_hr/sample.yaml
+++ b/samples/bluetooth/peripheral_hr/sample.yaml
@@ -5,6 +5,8 @@ tests:
   sample.bluetooth.peripheral_hr:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
+    integration_platforms:
+      - qemu_cortex_m3
     tags: bluetooth
   sample.bluetooth.peripheral_hr_rv32m1_vega_ri5cy:
     platform_allow: rv32m1_vega_ri5cy

--- a/samples/bluetooth/peripheral_ht/sample.yaml
+++ b/samples/bluetooth/peripheral_ht/sample.yaml
@@ -6,8 +6,12 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf51dk_nrf51422 nrf52dk_nrf52832
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3
   sample.bluetooth.peripheral_ht.frdm_kw41z_shield:
     harness: bluetooth
     platform_allow: mimxrt1020_evk mimxrt1050_evk mimxrt1060_evk frdm_k64f
     tags: bluetooth
     extra_args: SHIELD=frdm_kw41z
+    integration_platforms:
+      - mimxrt1020_evk

--- a/samples/bluetooth/peripheral_identity/sample.yaml
+++ b/samples/bluetooth/peripheral_identity/sample.yaml
@@ -6,3 +6,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52840dk_nrf52840
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/peripheral_iso/sample.yaml
+++ b/samples/bluetooth/peripheral_iso/sample.yaml
@@ -6,3 +6,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/peripheral_ots/sample.yaml
+++ b/samples/bluetooth/peripheral_ots/sample.yaml
@@ -6,3 +6,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/peripheral_past/sample.yaml
+++ b/samples/bluetooth/peripheral_past/sample.yaml
@@ -5,3 +5,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86 nrf52_bsim
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/peripheral_sc_only/sample.yaml
+++ b/samples/bluetooth/peripheral_sc_only/sample.yaml
@@ -6,3 +6,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/scan_adv/sample.yaml
+++ b/samples/bluetooth/scan_adv/sample.yaml
@@ -6,3 +6,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/unicast_audio_client/sample.yaml
+++ b/samples/bluetooth/unicast_audio_client/sample.yaml
@@ -6,3 +6,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/unicast_audio_server/sample.yaml
+++ b/samples/bluetooth/unicast_audio_server/sample.yaml
@@ -6,3 +6,5 @@ tests:
     harness: bluetooth
     platform_allow: qemu_cortex_m3 qemu_x86
     tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/boards/arc_secure_services/sample.yaml
+++ b/samples/boards/arc_secure_services/sample.yaml
@@ -7,6 +7,8 @@ tests:
     # Requires multiple kernels in an AMP config. See README.rst
     build_only: true
     platform_allow: nsim_sem em_starterkit_em7d
+    integration_platforms:
+      - nsim_sem
     tags: secure
     harness: console
     harness_config:

--- a/samples/boards/mimxrt1060_evk/system_off/sample.yaml
+++ b/samples/boards/mimxrt1060_evk/system_off/sample.yaml
@@ -6,3 +6,5 @@ tests:
   sample.boards.mimxrt1060_evk.system_off:
     build_only: true
     platform_allow: mimxrt1060_evk mimxrt1060_evkb
+    integration_platforms:
+      - mimxrt1060_evk

--- a/samples/boards/nrf/battery/sample.yaml
+++ b/samples/boards/nrf/battery/sample.yaml
@@ -5,3 +5,5 @@ tests:
     build_only: true
     platform_allow: particle_xenon thingy52_nrf52832
     tags: battery
+    integration_platforms:
+      - particle_xenon

--- a/samples/boards/nrf/clock_skew/sample.yaml
+++ b/samples/boards/nrf/clock_skew/sample.yaml
@@ -5,3 +5,5 @@ tests:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
     tags: power
+    integration_platforms:
+      - nrf52840dk_nrf52840

--- a/samples/boards/nrf/nrfx/sample.yaml
+++ b/samples/boards/nrf/nrfx/sample.yaml
@@ -3,6 +3,8 @@ sample:
 tests:
   sample.boards.nrf.nrfx:
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: board
     harness: console
     harness_config:

--- a/samples/boards/nrf/system_off/sample.yaml
+++ b/samples/boards/nrf/system_off/sample.yaml
@@ -2,6 +2,8 @@ sample:
   name: Low Power State Sample for nRF5x
 common:
   tags: power
+  integration_platforms:
+    - nrf52840dk_nrf52840
 tests:
   sample.boards.nrf.system_off:
     build_only: true

--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -7,6 +7,8 @@ tests:
     platform_allow: nucleo_f746zg nrf51dk_nrf51422 nrf52dk_nrf52832
                         nrf52840dk_nrf52840 nrf9160dk_nrf9160 atsamd20_xpro
                         bl5340_dvk_cpuapp
+    integration_platforms:
+      - nucleo_f746zg
     harness_config:
         type: multi_line
         ordered: true

--- a/samples/drivers/counter/maxim_ds3231/sample.yaml
+++ b/samples/drivers/counter/maxim_ds3231/sample.yaml
@@ -6,3 +6,5 @@ tests:
   sample.basic.maxim_ds3231:
     build_only: true
     platform_allow: efr32mg_sltb004a frdm_k64f nrf51dk_nrf51422 nucleo_l476rg particle_xenon
+    integration_platforms:
+      - efr32mg_sltb004a

--- a/samples/drivers/ipm/ipm_imx/sample.yaml
+++ b/samples/drivers/ipm/ipm_imx/sample.yaml
@@ -1,10 +1,12 @@
 sample:
-    description: the sample reads the received data from the Messaging Unit
-        using the IPM and transmits it back unchanged
-    name: i.MX IPM sample
+  description: the sample reads the received data from the Messaging Unit
+    using the IPM and transmits it back unchanged
+  name: i.MX IPM sample
 tests:
-    sample.ipm.ipm_imx:
-        build_only: true
-        filter: CONFIG_SOC_FAMILY_IMX
-        platform_allow: udoo_neo_full_m4 colibri_imx7d_m4 warp7_m4
-        tags: samples ipm
+  sample.ipm.ipm_imx:
+    build_only: true
+    filter: CONFIG_SOC_FAMILY_IMX
+    platform_allow: udoo_neo_full_m4 colibri_imx7d_m4 warp7_m4
+    integration_platforms:
+      - udoo_neo_full_m4
+    tags: samples ipm

--- a/samples/drivers/ipm/ipm_mcux/remote/sample.yaml
+++ b/samples/drivers/ipm/ipm_mcux/remote/sample.yaml
@@ -1,9 +1,11 @@
 sample:
-    description: Sample app that sends messages between the two cores on
-        the lpcxpresso54114 using a mailbox.
-    name: IPM MCUX Mailbox Sample
+  description: Sample app that sends messages between the two cores on
+    the lpcxpresso54114 using a mailbox.
+  name: IPM MCUX Mailbox Sample
 tests:
-    sample.ipm.ipm_mcux.remote:
-        platform_allow: lpcxpresso54114_m0 lpcxpresso55s69_cpu1
-        tags: ipm
-        harness: remote
+  sample.ipm.ipm_mcux.remote:
+    platform_allow: lpcxpresso54114_m0 lpcxpresso55s69_cpu1
+    integration_platforms:
+      - lpcxpresso54114_m0
+    tags: ipm
+    harness: remote

--- a/samples/drivers/ipm/ipm_mcux/sample.yaml
+++ b/samples/drivers/ipm/ipm_mcux/sample.yaml
@@ -1,16 +1,18 @@
 sample:
-    description: Sample app that sends messages between the two cores on
-        the lpcxpresso54114 using a mailbox.
-    name: IPM MCUX Mailbox Sample
+  description: Sample app that sends messages between the two cores on
+    the lpcxpresso54114 using a mailbox.
+  name: IPM MCUX Mailbox Sample
 tests:
-    sample.ipm.ipm_mcux:
-        platform_allow: lpcxpresso54114_m4 lpcxpresso55s69_cpu0
-        tags: ipm
-        harness: console
-        sysbuild: True
-        harness_config:
-          type: multi_line
-          regex:
-            - "Hello World from MASTER! (.*)"
-            - "Received: 1"
-            - "Received: 20"
+  sample.ipm.ipm_mcux:
+    platform_allow: lpcxpresso54114_m4 lpcxpresso55s69_cpu0
+    integration_platforms:
+      - lpcxpresso54114_m4
+    tags: ipm
+    harness: console
+    sysbuild: True
+    harness_config:
+      type: multi_line
+      regex:
+        - "Hello World from MASTER! (.*)"
+        - "Received: 1"
+        - "Received: 20"

--- a/samples/drivers/ipm/ipm_mhu_dual_core/sample.yaml
+++ b/samples/drivers/ipm/ipm_mhu_dual_core/sample.yaml
@@ -6,3 +6,5 @@ tests:
   sample.ipm.ipm_mhu_dual_core:
     tags: ipm
     platform_allow: v2m_musca_b1 v2m_musca_b1_ns
+    integration_platforms:
+      - v2m_musca_b1

--- a/samples/drivers/led_lp3943/sample.yaml
+++ b/samples/drivers/led_lp3943/sample.yaml
@@ -4,4 +4,6 @@ sample:
 tests:
   sample.drivers.led.lp3943:
     platform_allow: 96b_neonkey 96b_argonkey
+    integration_platforms:
+      - 96b_argonkey
     tags: LED

--- a/samples/drivers/soc_flash_nrf/sample.yaml
+++ b/samples/drivers/soc_flash_nrf/sample.yaml
@@ -3,6 +3,8 @@ sample:
 tests:
   sample.drivers.flash.soc_flash_nrf:
     platform_allow: nrf52dk_nrf52832 nrf9160dk_nrf9160 nrf9160dk_nrf9160_ns
+    integration_platforms:
+      - nrf52dk_nrf52832
     tags: flash nrf52 nrf9160
     harness: console
     harness_config:

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -21,6 +21,8 @@ tests:
     platform_allow: b_u585i_iot02a nucleo_f091rc nucleo_f103rb nucleo_f207zg nucleo_f429zi
         nucleo_f746zg nucleo_g071rb nucleo_g474re nucleo_l073rz nucleo_l152re
         nucleo_wb55rg nucleo_wl55jc stm32f3_disco stm32l562e_dk disco_l475_iot1
+    integration_platforms:
+      - nucleo_f103rb
   sample.drivers.watchdog.stm32h7_wwdg:
     extra_args: DTC_OVERLAY_FILE=boards/stm32h7_wwdg.overlay
     filter: dt_compat_enabled("st,stm32-window-watchdog")
@@ -31,15 +33,21 @@ tests:
     platform_allow: b_u585i_iot02a nucleo_f091rc nucleo_f103rb nucleo_f207zg nucleo_f429zi
         nucleo_f746zg nucleo_g071rb nucleo_g474re nucleo_h743zi nucleo_l073rz nucleo_l152re
         nucleo_wb55rg nucleo_wl55jc stm32f3_disco stm32l562e_dk disco_l475_iot1
+    integration_platforms:
+      - nucleo_f103rb
   sample.drivers.watchdog.gd32_fwdgt:
     filter: dt_has_compat("gd,gd32-fwdgt")
     extra_args: DTC_OVERLAY_FILE=boards/gd32_fwdgt.overlay
     platform_allow: gd32e103v_eval gd32e507v_start gd32f350r_eval gd32f403z_eval
         gd32f450i_eval gd32f450z_eval gd32f470i_eval gd32vf103c_starter gd32vf103v_eval
         longan_nano
+    integration_platforms:
+      - gd32e103v_eval
   sample.drivers.watchdog.gd32_wwdgt:
     filter: dt_has_compat("gd,gd32-wwdgt")
     extra_args: DTC_OVERLAY_FILE=boards/gd32_wwdgt.overlay
     platform_allow: gd32e103v_eval gd32e507v_start gd32f350r_eval gd32f403z_eval
         gd32f450i_eval gd32f450z_eval gd32f470i_eval gd32vf103c_starter gd32vf103v_eval
         longan_nano
+    integration_platforms:
+      - gd32e103v_eval

--- a/samples/modules/tflite-micro/hello_world/sample.yaml
+++ b/samples/modules/tflite-micro/hello_world/sample.yaml
@@ -15,6 +15,8 @@ common:
 tests:
   sample.tensorflow.helloworld:
     platform_allow: qemu_x86 qemu_x86_64
+    integration_platforms:
+      - qemu_x86
     tags: tensorflow
   sample.tensorflow.helloworld.cmsis_nn:
     tags: tensorflow

--- a/samples/net/cloud/google_iot_mqtt/sample.yaml
+++ b/samples/net/cloud/google_iot_mqtt/sample.yaml
@@ -10,3 +10,5 @@ tests:
   sample.net.cloud.google_iot_mqtt:
     depends_on: netif
     platform_allow: frdm_k64f qemu_x86
+    integration_platforms:
+      - qemu_x86

--- a/samples/net/cloud/mqtt_azure/sample.yaml
+++ b/samples/net/cloud/mqtt_azure/sample.yaml
@@ -7,4 +7,6 @@ tests:
   sample.net.cloud.mqtt_azure:
     harness: net
     platform_allow: sam_e70_xplained frdm_k64f qemu_x86
+    integration_platforms:
+      - qemu_x86
     tags: net mqtt cloud

--- a/samples/net/cloud/tagoio_http_post/sample.yaml
+++ b/samples/net/cloud/tagoio_http_post/sample.yaml
@@ -8,12 +8,16 @@ sample:
 tests:
   sample.net.cloud.tagoio_http_post:
     platform_allow: frdm_k64f nucleo_f767zi
+    integration_platforms:
+      - frdm_k64f
   sample.net.cloud.tagoio_http_post.wifi:
     extra_args: OVERLAY_CONFIG="overlay-wifi.conf"
     platform_allow: disco_l475_iot1
   sample.net.cloud.tagoio_http_post.wifi.esp:
     extra_args: SHIELD=esp_8266_arduino OVERLAY_CONFIG="overlay-wifi.conf"
     platform_allow: frdm_k64f nucleo_f767zi
+    integration_platforms:
+      - frdm_k64f
   sample.net.cloud.tagoio_http_post.modem:
     extra_args: OVERLAY_CONFIG="overlay-modem.conf"
     platform_allow: sam4e_xpro

--- a/samples/net/eth_native_posix/sample.yaml
+++ b/samples/net/eth_native_posix/sample.yaml
@@ -7,3 +7,5 @@ sample:
 tests:
   sample.net.eth_native_posix:
     platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix

--- a/samples/net/gptp/sample.yaml
+++ b/samples/net/gptp/sample.yaml
@@ -8,3 +8,5 @@ tests:
   sample.net.gptp:
     platform_allow: frdm_k64f sam_e70_xplained native_posix native_posix_64 nucleo_f767zi nucleo_h743zi nucleo_h745zi_q_m7
     depends_on: netif
+    integration_platforms:
+      - frdm_k64f

--- a/samples/net/ipv4_autoconf/sample.yaml
+++ b/samples/net/ipv4_autoconf/sample.yaml
@@ -2,6 +2,8 @@ common:
   harness: net
   tags: net ipv4_autoconf
   platform_allow: qemu_x86 native_posix native_posix_64
+  integration_platforms:
+    - native_posix
 sample:
   description: Test IPv4 autoconf functionality
   name: IPv4 autoconf sample app

--- a/samples/net/lldp/sample.yaml
+++ b/samples/net/lldp/sample.yaml
@@ -7,4 +7,6 @@ sample:
 tests:
   sample.net.lldp:
     platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix
     depends_on: netif

--- a/samples/net/lwm2m_client/sample.yaml
+++ b/samples/net/lwm2m_client/sample.yaml
@@ -6,11 +6,15 @@ tests:
     harness: net
     depends_on: netif
     platform_allow: qemu_x86 frdm_k64f pinnacle_100_dvk mg100
+    integration_platforms:
+      - qemu_x86
     tags: net lwm2m
   sample.net.lwm2m_client.all_objects:
     harness: net
     depends_on: netif
     platform_allow: qemu_x86
+    integration_platforms:
+      - qemu_x86
     tags: net lwm2m
     extra_configs:
       - CONFIG_LWM2M_CONN_MON_OBJ_SUPPORT=y
@@ -27,20 +31,28 @@ tests:
     depends_on: netif
     extra_args: OVERLAY_CONFIG=overlay-dtls.conf
     platform_allow: qemu_x86 frdm_k64f pinnacle_100_dvk mg100
+    integration_platforms:
+      - qemu_x86
     tags: net lwm2m
   sample.net.lwm2m_client.bt:
     harness: net
     extra_args: OVERLAY_CONFIG=overlay-bt.conf
     platform_allow: nrf52840dk_nrf52840 disco_l475_iot1
     tags: net lwm2m
+    integration_platforms:
+      - disco_l475_iot1
   sample.net.lwm2m_client.queue_mode:
     harness: net
     depends_on: netif
     extra_args: OVERLAY_CONFIG=overlay-queue.conf
     platform_allow: qemu_x86
+    integration_platforms:
+      - qemu_x86
     tags: net lwm2m
   sample.net.lwm2m_client.wnc_m14a2a:
     harness: net
     extra_args: SHIELD=wnc_m14a2a
     platform_allow: frdm_k64f nrf52840dk_nrf52840
+    integration_platforms:
+      - frdm_k64f
     tags: net lwm2m

--- a/samples/net/mdns_responder/sample.yaml
+++ b/samples/net/mdns_responder/sample.yaml
@@ -4,4 +4,6 @@ tests:
   sample.net.mdns_responder:
     harness: net
     platform_allow: qemu_x86 qemu_cortex_m3
+    integration_platforms:
+      - qemu_x86
     tags: net mdns

--- a/samples/net/mqtt_publisher/sample.yaml
+++ b/samples/net/mqtt_publisher/sample.yaml
@@ -7,8 +7,12 @@ common:
 tests:
   sample.net.mqtt_publisher:
     platform_allow: frdm_k64f qemu_x86 pinnacle_100_dvk mg100
+    integration_platforms:
+      - qemu_x86
   sample.net.mqtt_publisher.userspace:
     platform_allow: frdm_k64f qemu_x86
+    integration_platforms:
+      - qemu_x86
     extra_args: CONFIG_USERSPACE=y
   sample.net.mqtt_publisher.bt:
     platform_allow: 96b_nitrogen

--- a/samples/net/mqtt_sn_publisher/sample.yaml
+++ b/samples/net/mqtt_sn_publisher/sample.yaml
@@ -7,3 +7,5 @@ common:
 tests:
   sample.net.mqtt_publisher.sn:
     platform_allow: frdm_k64f qemu_x86 pinnacle_100_dvk mg100
+    integration_platforms:
+      - qemu_x86

--- a/samples/net/openthread/coprocessor/sample.yaml
+++ b/samples/net/openthread/coprocessor/sample.yaml
@@ -1,6 +1,6 @@
 common:
   harness: net
-  tags: net
+  tags: net openthread
   depends_on: netif
   min_flash: 140
 sample:
@@ -10,15 +10,19 @@ tests:
   sample.net.openthread.coprocessor:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 tlsr9518adk80d
-    tags: ci_build
+    integration_platforms:
+      - nrf52840dk_nrf52840
   sample.net.openthread.coprocessor.usb:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: ci_build
     extra_args: OVERLAY_CONFIG=overlay-usb-nrf-br.conf
                 DTC_OVERLAY_FILE="usb.overlay"
   sample.openthread.coprocessor.rcp:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 tlsr9518adk80d
-    tags: ci_build
+    integration_platforms:
+      - nrf52840dk_nrf52840
     extra_args: OVERLAY_CONFIG=overlay-rcp.conf

--- a/samples/net/sockets/echo_client/sample.yaml
+++ b/samples/net/sockets/echo_client/sample.yaml
@@ -11,6 +11,8 @@ tests:
   sample.net.sockets.echo_client:
     platform_allow: qemu_x86 frdm_k64f sam_e70_xplained
       qemu_cortex_m3 frdm_kw41z
+    integration_platforms:
+      - qemu_x86
   sample.net.sockets.echo_client.802154:
     extra_args: OVERLAY_CONFIG="overlay-qemu_802154.conf"
     platform_allow: qemu_x86
@@ -23,12 +25,18 @@ tests:
   sample.net.sockets.echo_client.802154.rf2xx.xpro:
     extra_args: SHIELD=atmel_rf2xx_xpro OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: sam4e_xpro sam_v71_xult
+    integration_platforms:
+      - sam_v71_xult
   sample.net.sockets.echo_client.802154.rf2xx.legacy:
     extra_args: SHIELD=atmel_rf2xx_legacy OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: sam4e_xpro sam_v71_xult
+    integration_platforms:
+      - sam_v71_xult
   sample.net.sockets.echo_client.802154.rf2xx.arduino:
     extra_args: SHIELD=atmel_rf2xx_arduino OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: sam_v71_xult frdm_k64f nucleo_f767zi
+    integration_platforms:
+      - sam_v71_xult
   sample.net.sockets.echo_client.802154.rf2xx.mikrobus:
     extra_args: SHIELD=atmel_rf2xx_mikrobus OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: lpcxpresso55s69_ns
@@ -66,3 +74,5 @@ tests:
   sample.net.sockets.echo_client.userspace:
     extra_args: CONFIG_USERSPACE=y OVERLAY_CONFIG="overlay-e1000.conf"
     platform_allow: qemu_x86 qemu_x86_64
+    integration_platforms:
+      - qemu_x86

--- a/samples/net/sockets/echo_server/sample.yaml
+++ b/samples/net/sockets/echo_server/sample.yaml
@@ -11,9 +11,13 @@ tests:
   sample.net.sockets.echo_server:
     platform_allow: qemu_x86 qemu_x86_64 sam_e70_xplained frdm_k64f
       qemu_cortex_m3 frdm_kw41z
+    integration_platforms:
+      - qemu_x86
   sample.net.sockets.echo_server.802154:
     extra_args: OVERLAY_CONFIG="overlay-qemu_802154.conf"
     platform_allow: qemu_x86
+    integration_platforms:
+      - qemu_x86
   sample.net.sockets.echo_server.802154.rf2xx:
     extra_args: OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: atsamr21_xpro
@@ -23,12 +27,18 @@ tests:
   sample.net.sockets.echo_server.802154.rf2xx.xpro:
     extra_args: SHIELD=atmel_rf2xx_xpro OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: sam4e_xpro sam_v71_xult
+    integration_platforms:
+      - sam_v71_xult
   sample.net.sockets.echo_server.802154.rf2xx.legacy:
     extra_args: SHIELD=atmel_rf2xx_legacy OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: sam4e_xpro sam_v71_xult
+    integration_platforms:
+      - sam_v71_xult
   sample.net.sockets.echo_server.802154.rf2xx.arduino:
     extra_args: SHIELD=atmel_rf2xx_arduino OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: sam_v71_xult frdm_k64f nucleo_f767zi
+    integration_platforms:
+      - sam_v71_xult
   sample.net.sockets.echo_server.802154.rf2xx.mikrobus:
     extra_args: SHIELD=atmel_rf2xx_mikrobus OVERLAY_CONFIG="overlay-802154.conf"
     platform_allow: lpcxpresso55s69_ns
@@ -90,3 +100,5 @@ tests:
   sample.net.sockets.echo_server.userspace:
     extra_args: CONFIG_USERSPACE=y OVERLAY_CONFIG="overlay-e1000.conf"
     platform_allow: qemu_x86 qemu_x86_64
+    integration_platforms:
+      - qemu_x86

--- a/samples/net/sockets/packet/sample.yaml
+++ b/samples/net/sockets/packet/sample.yaml
@@ -5,4 +5,6 @@ tests:
   sample.net.sockets.packet:
     harness: net
     platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix
     tags: net sockets packet-socket

--- a/samples/net/sockets/txtime/sample.yaml
+++ b/samples/net/sockets/txtime/sample.yaml
@@ -3,6 +3,8 @@ common:
   depends_on: netif
   # We can only run this in platforms that support PTP clock and TXTIME
   platform_allow: native_posix native_posix_64 qemu_x86 qemu_x86_64
+  integration_platforms:
+    - native_posix
 sample:
   description: Socket SO_TXTIME sample
   name: txtime-socket

--- a/samples/net/wifi/sample.yaml
+++ b/samples/net/wifi/sample.yaml
@@ -7,6 +7,8 @@ sample:
 tests:
   sample.net.wifi:
     platform_allow: cc3220sf_launchxl disco_l475_iot1 reel_board
+    integration_platforms:
+      - cc3220sf_launchxl
   sample.net.wifi.mikroe_wifi_bt_click:
     extra_args: SHIELD=mikroe_wifi_bt_click_mikrobus
     platform_allow: lpcxpresso55s69_cpu0
@@ -16,9 +18,15 @@ tests:
   sample.net.wifi.esp_8266_arduino:
     extra_args: SHIELD=esp_8266_arduino
     platform_allow: frdm_k64f disco_l475_iot1
+    integration_platforms:
+      - frdm_k64f
   sample.net.wifi.inventek_eswifi_arduino_uart:
     extra_args: SHIELD=inventek_eswifi_arduino_uart
     platform_allow: frdm_k64f nucleo_f767zi
+    integration_platforms:
+      - frdm_k64f
   sample.net.wifi.inventek_eswifi_arduino_spi:
     extra_args: SHIELD=inventek_eswifi_arduino_spi
     platform_allow: frdm_k64f nucleo_f767zi
+    integration_platforms:
+      - frdm_k64f

--- a/samples/sensor/sht3xd/sample.yaml
+++ b/samples/sensor/sht3xd/sample.yaml
@@ -6,15 +6,14 @@
 
 sample:
   name: SHT3XD Sensor Sample
+common:
+  platform_allow: efr32mg_sltb004a frdm_k64f nrf51_ble400
+    nrf52840dk_nrf52840 nucleo_l476rg
+  integration_platforms:
+    - nrf52840dk_nrf52840
+  tags: sensors
+  build_only: true
 tests:
-  sample.sensor.sht3xd:
-    build_only: true
-    platform_allow: efr32mg_sltb004a frdm_k64f nrf51_ble400
-      nrf52840dk_nrf52840 nucleo_l476rg
-    tags: sensors
+  sample.sensor.sht3xd: {}
   sample.sensor.sht3xd.trigger:
-    build_only: true
     extra_args: CONF_FILE="trigger.conf"
-    platform_allow: efr32mg_sltb004a frdm_k64f nrf51_ble400
-      nrf52840dk_nrf52840 nucleo_l476rg
-    tags: sensors

--- a/samples/sensor/stm32_vbat_sensor/sample.yaml
+++ b/samples/sensor/stm32_vbat_sensor/sample.yaml
@@ -6,6 +6,8 @@ tests:
     depends_on: adc
     tags: sensors
     platform_allow: nucleo_g071rb nucleo_wb55rg
+    integration_platforms:
+      - nucleo_g071rb
     timeout: 10
     harness: console
     harness_config:

--- a/samples/subsys/edac/sample.yaml
+++ b/samples/subsys/edac/sample.yaml
@@ -2,14 +2,16 @@ sample:
   description: EDAC shell sample application
   name: edac shell
 common:
-    tags: edac
-    harness: console
-    harness_config:
-      type: one_line
-      regex:
-        - "EDAC shell application initialized"
+  tags: edac
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "EDAC shell application initialized"
 
 tests:
   sample.subsys.edac:
     platform_allow: ehl_crb
+    integration_platforms:
+      - ehl_crb
     tags: edac

--- a/samples/subsys/fs/littlefs/sample.yaml
+++ b/samples/subsys/fs/littlefs/sample.yaml
@@ -7,3 +7,5 @@ tests:
       mimxrt685_evk_cm33 mimxrt1060_evk mimxrt1064_evk qemu_x86 native_posix
       mimxrt1160_evk_cm7
     tags: filesystem
+    integration_platforms:
+      - nrf52840dk_nrf52840

--- a/samples/subsys/ipc/openamp/remote/sample.yaml
+++ b/samples/subsys/ipc/openamp/remote/sample.yaml
@@ -1,9 +1,11 @@
 sample:
-    description: This app provides an example of how to integrate OpenAMP
-        with Zephyr.
-    name: OpenAMP example integration (remote)
+  description: This app provides an example of how to integrate OpenAMP
+    with Zephyr.
+  name: OpenAMP example integration (remote)
 tests:
-    sample.ipc.openamp.remote:
-        platform_allow: lpcxpresso54114_m0 lpcxpresso55s69_cpu1
-        tags: ipm
-        harness: remote
+  sample.ipc.openamp.remote:
+    platform_allow: lpcxpresso54114_m0 lpcxpresso55s69_cpu1
+    integration_platforms:
+      - lpcxpresso54114_m0
+    tags: ipm
+    harness: remote

--- a/samples/subsys/ipc/openamp_rsc_table/sample.yaml
+++ b/samples/subsys/ipc/openamp_rsc_table/sample.yaml
@@ -1,9 +1,11 @@
 sample:
-    description: This app provides an example of how to integrate OpenAMP
-        with Zephyr in cluding a esource table.
-    name: OpenAMP with resource table example integration
+  description: This app provides an example of how to integrate OpenAMP
+    with Zephyr in cluding a esource table.
+  name: OpenAMP with resource table example integration
 tests:
-    sample.subsys.ipc.openamp_rs_table:
-        build_only: true
-        platform_allow: stm32mp157c_dk2
-        tags: ipm
+  sample.subsys.ipc.openamp_rs_table:
+    build_only: true
+    platform_allow: stm32mp157c_dk2
+    integration_platforms:
+      - stm32mp157c_dk2
+    tags: ipm

--- a/samples/subsys/ipc/rpmsg_service/remote/sample.yaml
+++ b/samples/subsys/ipc/rpmsg_service/remote/sample.yaml
@@ -1,10 +1,12 @@
 sample:
-    description: This app provides an example of how to integrate
-        RPMsg Service with Zephyr.
-    name: RPMsg Service example integration (remote)
+  description: This app provides an example of how to integrate
+    RPMsg Service with Zephyr.
+  name: RPMsg Service example integration (remote)
 common:
-    harness: remote
+  harness: remote
 tests:
-    sample.ipc.rpmsg_service.remote:
-        platform_allow: mps2_an521_remote v2m_musca_b1_ns
-        tags: ipm
+  sample.ipc.rpmsg_service.remote:
+    platform_allow: mps2_an521_remote v2m_musca_b1_ns
+    integration_platforms:
+      - v2m_musca_b1_ns
+    tags: ipm

--- a/samples/subsys/ipc/rpmsg_service/sample.yaml
+++ b/samples/subsys/ipc/rpmsg_service/sample.yaml
@@ -1,15 +1,17 @@
 sample:
-    description: This app provides an example of how to integrate
-        RPMsg Service with Zephyr.
-    name: RPMsg Service example integration
+  description: This app provides an example of how to integrate
+    RPMsg Service with Zephyr.
+  name: RPMsg Service example integration
 tests:
-    sample.ipc.rpmsg_service:
-        platform_allow: mps2_an521 v2m_musca_b1
-        tags: ipm
-        harness: console
-        harness_config:
-          type: multi_line
-          regex:
-            - "Master core received a message: 1"
-            - "Master core received a message: 99"
-            - "RPMsg Service demo ended."
+  sample.ipc.rpmsg_service:
+    platform_allow: mps2_an521 v2m_musca_b1
+    integration_platforms:
+      - mps2_an521
+    tags: ipm
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "Master core received a message: 1"
+        - "Master core received a message: 99"
+        - "RPMsg Service demo ended."

--- a/samples/subsys/mgmt/hawkbit/sample.yaml
+++ b/samples/subsys/mgmt/hawkbit/sample.yaml
@@ -10,3 +10,5 @@ tests:
     depends_on: netif
     build_only: true
     platform_allow: frdm_k64f
+    integration_platforms:
+      - frdm_k64f

--- a/samples/subsys/mgmt/updatehub/sample.yaml
+++ b/samples/subsys/mgmt/updatehub/sample.yaml
@@ -7,6 +7,8 @@ common:
   depends_on: netif
   build_only: true
   platform_allow: frdm_k64f
+  integration_platforms:
+    - frdm_k64f
 tests:
   sample.net.updatehub:
     extra_configs:

--- a/samples/subsys/modbus/rtu_client/sample.yaml
+++ b/samples/subsys/modbus/rtu_client/sample.yaml
@@ -4,5 +4,7 @@ tests:
   sample.modbus.rtu_client:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 frdm_k64f
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: uart modbus
     depends_on: gpio arduino_serial

--- a/samples/subsys/modbus/rtu_server/sample.yaml
+++ b/samples/subsys/modbus/rtu_server/sample.yaml
@@ -4,6 +4,8 @@ tests:
   sample.modbus.rtu_server:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 frdm_k64f
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: uart modbus
     filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
             dt_enabled_alias_with_parent_compat("led1", "gpio-leds") and
@@ -12,6 +14,8 @@ tests:
   sample.modbus.rtu_server.cdc_acm:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 frdm_k64f
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: usb modbus
     filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
             dt_enabled_alias_with_parent_compat("led1", "gpio-leds") and

--- a/samples/subsys/modbus/tcp_server/sample.yaml
+++ b/samples/subsys/modbus/tcp_server/sample.yaml
@@ -4,6 +4,8 @@ tests:
   sample.modbus.tcp_server:
     build_only: true
     platform_allow: frdm_k64f
+    integration_platforms:
+      - frdm_k64f
     tags: modbus
     filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
             dt_enabled_alias_with_parent_compat("led1", "gpio-leds") and

--- a/samples/subsys/pm/device_pm/sample.yaml
+++ b/samples/subsys/pm/device_pm/sample.yaml
@@ -3,6 +3,8 @@ sample:
 tests:
   sample.power.ospm.dev_idle_pm:
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: power
     harness: console
     harness_config:

--- a/samples/subsys/pm/latency/sample.yaml
+++ b/samples/subsys/pm/latency/sample.yaml
@@ -3,6 +3,8 @@ sample:
 tests:
   sample.pm.latency:
     platform_allow: native_posix
+    integration_platforms:
+      - native_posix
     tags: pm
     harness: console
     harness_config:

--- a/samples/subsys/settings/sample.yaml
+++ b/samples/subsys/settings/sample.yaml
@@ -6,6 +6,8 @@ tests:
     tags: settings
     timeout: 10
     platform_allow: qemu_x86 native_posix native_posix_64
+    integration_platforms:
+      - native_posix
     harness: console
     harness_config:
       type: multi_line

--- a/samples/subsys/shell/fs/sample.yaml
+++ b/samples/subsys/shell/fs/sample.yaml
@@ -6,9 +6,13 @@ tests:
     tags: shell filesystem
     harness: keyboard
     platform_allow: reel_board mimxrt1060_evk
+    integration_platforms:
+      - reel_board
 
   sample.filesystem.shell.flash_load:
     tags: shell filesystem flash_load
     harness: keyboard
     platform_allow: nrf52dk_nrf52832
     extra_args: CONF_FILE=prj_flash_load.conf
+    integration_platforms:
+      - nrf52dk_nrf52832

--- a/samples/subsys/testsuite/integration/testcase.yaml
+++ b/samples/subsys/testsuite/integration/testcase.yaml
@@ -3,4 +3,6 @@ tests:
   sample.testing.ztest:
     build_only: true
     platform_allow: native_posix
+    integration_platforms:
+      - native_posix
     tags: testing

--- a/samples/subsys/testsuite/pytest/testcase.yaml
+++ b/samples/subsys/testsuite/pytest/testcase.yaml
@@ -5,3 +5,5 @@ tests:
     harness_config:
       pytest_args: [ "--custom-pytest-arg", "foo" ]
     tags: testing pytest
+    integration_platforms:
+      - native_posix

--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -11,12 +11,16 @@ tests:
     extra_args: CONF_FILE="prj_user.conf"
   sample.tracing.format.sysview:
     platform_allow: nrf52840dk_nrf52840 mimxrt1050_evk mimxrt1064_evk
+    integration_platforms:
+      - nrf52840dk_nrf52840
     extra_args: CONF_FILE="prj_sysview.conf"
   sample.tracing.osawareness.openocd:
     arch_exclude: posix xtensa
     platform_exclude: qemu_x86_64
   sample.tracing.transport.uart:
     platform_allow: qemu_x86 qemu_x86_64
+    integration_platforms:
+      - qemu_x86
     extra_args: CONF_FILE="prj_uart.conf"
     filter: dt_chosen_enabled("zephyr,tracing-uart")
   sample.tracing.transport.usb:
@@ -25,6 +29,8 @@ tests:
     extra_args: CONF_FILE="prj_usb.conf"
   sample.tracing.transport.uart.ctf:
     platform_allow: qemu_x86 qemu_x86_64
+    integration_platforms:
+      - qemu_x86
     extra_args: CONF_FILE="prj_uart_ctf.conf"
     filter: dt_chosen_enabled("zephyr,tracing-uart")
   sample.tracing.transport.usb.ctf:

--- a/samples/subsys/usb/cdc_acm/sample.yaml
+++ b/samples/subsys/usb/cdc_acm/sample.yaml
@@ -25,3 +25,5 @@ tests:
     tags: usb
     platform_allow: native_posix native_posix_64
     build_only: true
+    integration_platforms:
+      - native_posix

--- a/samples/subsys/usb/hid-cdc/sample.yaml
+++ b/samples/subsys/usb/hid-cdc/sample.yaml
@@ -4,5 +4,7 @@ tests:
   sample.usb.hid-cdc:
     depends_on: usb_device
     platform_allow: nrf52840dk_nrf52840 nrf52840dongle_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
     harness: button
     tags: usb

--- a/samples/subsys/usb/hid/sample.yaml
+++ b/samples/subsys/usb/hid/sample.yaml
@@ -28,3 +28,5 @@ tests:
     tags: usb
     platform_allow: native_posix native_posix_64
     build_only: true
+    integration_platforms:
+      - native_posix

--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -37,6 +37,8 @@ tests:
     depends_on: usb_device
     filter: dt_compat_enabled("nordic,qspi-nor")
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp adafruit_feather_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
     extra_configs:
         - CONFIG_LOG_DEFAULT_LEVEL=3
         - CONFIG_APP_MSC_STORAGE_FLASH_FATFS=y
@@ -72,6 +74,8 @@ tests:
     depends_on: usb_device
     filter: dt_compat_enabled("nordic,qspi-nor")
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp adafruit_feather_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
     extra_configs:
         - CONFIG_LOG_DEFAULT_LEVEL=3
         - CONFIG_APP_MSC_STORAGE_FLASH_LITTLEFS=y

--- a/samples/subsys/usb_c/sink/sample.yaml
+++ b/samples/subsys/usb_c/sink/sample.yaml
@@ -5,6 +5,8 @@ tests:
     depends_on: tcpc
     tags: usbc
     platform_allow: b_g474e_dpow1
+    integration_platforms:
+      - b_g474e_dpow1
     harness: console
     harness_config:
       type: one_line

--- a/samples/subsys/video/capture/sample.yaml
+++ b/samples/subsys/video/capture/sample.yaml
@@ -6,3 +6,5 @@ tests:
     tags: video
     platform_allow: mimxrt1064_evk mm_swiftio
     depends_on: video
+    integration_platforms:
+      - mimxrt1064_evk

--- a/samples/subsys/video/tcpserversink/sample.yaml
+++ b/samples/subsys/video/tcpserversink/sample.yaml
@@ -6,3 +6,5 @@ tests:
     tags: video net socket
     platform_allow: mimxrt1064_evk
     depends_on: video netif
+    integration_platforms:
+      - mimxrt1064_evk

--- a/samples/subsys/zbus/remote_mock/sample.yaml
+++ b/samples/subsys/zbus/remote_mock/sample.yaml
@@ -5,3 +5,5 @@ tests:
     build_only: true
     tags: zbus
     platform_allow: native_posix hifive1_revb
+    integration_platforms:
+      - native_posix

--- a/samples/tfm_integration/psa_crypto/sample.yaml
+++ b/samples/tfm_integration/psa_crypto/sample.yaml
@@ -1,25 +1,27 @@
 sample:
-    description: This app provides an example of using PSA crypto APIs
-        to generate device certificate signing request in Zephyr
-        using IPC mode.
-    name: PSA crypto example
+  description: This app provides an example of using PSA crypto APIs
+    to generate device certificate signing request in Zephyr
+    using IPC mode.
+  name: PSA crypto example
 tests:
-    sample.psa_crypto:
-        tags: introduction tfm crypto csr
-        platform_allow: mps2_an521_ns mps3_an547_ns v2m_musca_s1_ns
-          nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
-          stm32l562e_dk_ns bl5340_dvk_cpuapp_ns
-        harness: console
-        harness_config:
-          type: multi_line
-          regex:
-            - "System IAT size is: (.*)"
-            - "Requesting IAT with (.*) byte challenge."
-            - "IAT data received: (.*)"
-            - "Retrieving public key for key #1"
-            - "Signature verified"
-            - "Destroyed persistent key #1"
-            - "Generating 256 bytes of random data."
-            - "Create device Certificate Signing Request completed"
-            - "BEGIN CERTIFICATE REQUEST"
-            - "END CERTIFICATE REQUEST"
+  sample.psa_crypto:
+    tags: introduction tfm crypto csr
+    platform_allow: mps2_an521_ns mps3_an547_ns v2m_musca_s1_ns
+      nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
+      stm32l562e_dk_ns bl5340_dvk_cpuapp_ns
+    integration_platforms:
+      - mps2_an521_ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "System IAT size is: (.*)"
+        - "Requesting IAT with (.*) byte challenge."
+        - "IAT data received: (.*)"
+        - "Retrieving public key for key #1"
+        - "Signature verified"
+        - "Destroyed persistent key #1"
+        - "Generating 256 bytes of random data."
+        - "Create device Certificate Signing Request completed"
+        - "BEGIN CERTIFICATE REQUEST"
+        - "END CERTIFICATE REQUEST"

--- a/samples/tfm_integration/psa_firmware/sample.yaml
+++ b/samples/tfm_integration/psa_firmware/sample.yaml
@@ -3,29 +3,33 @@ sample:
         to update to a new firmware using TF-M and MCUBoot.
     name: TF-M PSA firmware update example
 tests:
-    sample.update-success:
-        tags: introduction tfm
-        platform_allow: mps3_an547_ns
-        harness: console
-        timeout: 300
-        extra_configs:
-          - CONFIG_APP_FIRMWARE_UPDATE_IMAGE_VERSION="0.0.2+0"
-        harness_config:
-          type: multi_line
-          regex:
-            - "Active NS image version: 0.0.1-0"
-            - "Wrote Header; Installing Image"
-            - "Hello World from UserSpace!"
-    sample.fail-rollback:
-        tags: introduction tfm
-        platform_allow: mps3_an547_ns
-        harness: console
-        timeout: 300
-        extra_configs:
-          - CONFIG_APP_FIRMWARE_UPDATE_IMAGE_VERSION="0.0.0+0"
-        harness_config:
-          type: multi_line
-          regex:
-            - "Active NS image version: 0.0.1-0"
-            - "Wrote Header; Installing Image"
-            - "Active NS image version: 0.0.1-0"
+  sample.update-success:
+    tags: introduction tfm
+    platform_allow: mps3_an547_ns
+    integration_platforms:
+      - mps3_an547_ns
+    harness: console
+    timeout: 300
+    extra_configs:
+      - CONFIG_APP_FIRMWARE_UPDATE_IMAGE_VERSION="0.0.2+0"
+    harness_config:
+      type: multi_line
+      regex:
+        - "Active NS image version: 0.0.1-0"
+        - "Wrote Header; Installing Image"
+        - "Hello World from UserSpace!"
+  sample.fail-rollback:
+    tags: introduction tfm
+    platform_allow: mps3_an547_ns
+    integration_platforms:
+    - mps3_an547_ns
+    harness: console
+    timeout: 300
+    extra_configs:
+      - CONFIG_APP_FIRMWARE_UPDATE_IMAGE_VERSION="0.0.0+0"
+    harness_config:
+      type: multi_line
+      regex:
+        - "Active NS image version: 0.0.1-0"
+        - "Wrote Header; Installing Image"
+        - "Active NS image version: 0.0.1-0"

--- a/samples/tfm_integration/psa_protected_storage/sample.yaml
+++ b/samples/tfm_integration/psa_protected_storage/sample.yaml
@@ -5,6 +5,8 @@ common:
   tags: psa
   platform_allow: mps2_an521_ns v2m_musca_s1_ns
                     nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns bl5340_dvk_cpuapp_ns
+  integration_platforms:
+    - mps2_an521_ns
   harness: console
   harness_config:
     type: multi_line

--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -8,6 +8,8 @@ tests:
         platform_allow: mps2_an521_ns mps3_an547_ns
           nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns nucleo_l552ze_q_ns
           stm32l562e_dk_ns v2m_musca_s1_ns v2m_musca_b1_ns bl5340_dvk_cpuapp_ns
+        integration_platforms:
+          - mps2_an521_ns
         harness: console
         harness_config:
           type: multi_line

--- a/samples/tfm_integration/tfm_psa_test/sample.yaml
+++ b/samples/tfm_integration/tfm_psa_test/sample.yaml
@@ -3,6 +3,8 @@ common:
     platform_allow: mps2_an521_ns
                     nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
                     v2m_musca_s1_ns
+    integration_platforms:
+      - mps2_an521_ns
     harness: console
     harness_config:
       type: multi_line

--- a/samples/tfm_integration/tfm_regression_test/sample.yaml
+++ b/samples/tfm_integration/tfm_regression_test/sample.yaml
@@ -2,6 +2,9 @@ common:
     tags: tfm
     platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
                     v2m_musca_s1_ns
+
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp_ns
     harness: console
     harness_config:
       type: multi_line

--- a/samples/tfm_integration/tfm_secure_partition/sample.yaml
+++ b/samples/tfm_integration/tfm_secure_partition/sample.yaml
@@ -1,17 +1,19 @@
 common:
-    tags: tfm
-    platform_allow: mps2_an521_ns v2m_musca_s1_ns
-                    nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
-    harness: console
-    harness_config:
-      type: multi_line
-      regex:
-        - "Digest: be45cb2605bf36bebde684841a28f0fd43c69850a3dce5fedba69928ee3a8991"
-        - "Digest: 1452c8f04245d355722fdbfb03c69bcfd380b7dff911a3e425013397251f6a4e"
-        - "Digest: d3b4349010abb691b9584b6fd6b41ec54596ef7b98d853fb4f5bfa690f50f222"
-        - "Digest: 5afbcfede855ca834ff5b4e8a44a32206a51381f3cf52f5001a3241f017ac41a"
-        - "Digest: 983318380c325099da63de2e7ca57c1630693b28b4754e08817533295dbfcfbb"
-        - "No valid secret for key, received expected error code"
+  tags: tfm
+  platform_allow: mps2_an521_ns v2m_musca_s1_ns
+                  nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
+  integration_platforms:
+    - mps2_an521_ns
+  harness: console
+  harness_config:
+    type: multi_line
+    regex:
+      - "Digest: be45cb2605bf36bebde684841a28f0fd43c69850a3dce5fedba69928ee3a8991"
+      - "Digest: 1452c8f04245d355722fdbfb03c69bcfd380b7dff911a3e425013397251f6a4e"
+      - "Digest: d3b4349010abb691b9584b6fd6b41ec54596ef7b98d853fb4f5bfa690f50f222"
+      - "Digest: 5afbcfede855ca834ff5b4e8a44a32206a51381f3cf52f5001a3241f017ac41a"
+      - "Digest: 983318380c325099da63de2e7ca57c1630693b28b4754e08817533295dbfcfbb"
+      - "No valid secret for key, received expected error code"
 sample:
   name: "TFM Secure Partition Sample"
 

--- a/tests/application_development/code_relocation/testcase.yaml
+++ b/tests/application_development/code_relocation/testcase.yaml
@@ -17,6 +17,8 @@ tests:
     arch_allow: arm
     extra_sections: _SRAM2_RODATA_SECTION_NAME _SRAM_TEXT_SECTION_NAME _SRAM_RODATA_SECTION_NAME _SRAM_DATA_SECTION_NAME _CUSTOM_SECTION_NAME2
     platform_allow: qemu_cortex_m3 mps2_an385 sam_e70_xplained
+    integration_platforms:
+      - qemu_cortex_m3
   tests.application_development.code_relocation.riscv:
     extra_args: CONF_FILE="prj_riscv.conf"
     platform_allow: qemu_riscv32 qemu_riscv64

--- a/tests/arch/arm/arm_no_multithreading/testcase.yaml
+++ b/tests/arch/arm/arm_no_multithreading/testcase.yaml
@@ -7,3 +7,5 @@ tests:
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     platform_allow: qemu_cortex_m0 qemu_cortex_m3 mps2_an385 mps2_an521
       mps3_an547 nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf51dk_nrf51422
+    integration_platforms:
+      - qemu_cortex_m0

--- a/tests/bluetooth/addr/testcase.yaml
+++ b/tests/bluetooth/addr/testcase.yaml
@@ -2,3 +2,5 @@ tests:
   bluetooth.addr:
     platform_allow: native_posix native_posix_64 qemu_x86 qemu_cortex_m3
     tags: bluetooth addr
+    integration_platforms:
+      - native_posix

--- a/tests/bluetooth/adv/testcase.yaml
+++ b/tests/bluetooth/adv/testcase.yaml
@@ -4,3 +4,5 @@ tests:
     tags: bluetooth
     slow: true
     timeout: 360
+    integration_platforms:
+      - nrf51dk_nrf51422

--- a/tests/bluetooth/at/testcase.yaml
+++ b/tests/bluetooth/at/testcase.yaml
@@ -4,3 +4,5 @@ tests:
     min_ram: 16
     platform_allow: qemu_x86 qemu_cortex_m3
     tags: bluetooth
+    integration_platforms:
+      - qemu_x86

--- a/tests/bluetooth/bluetooth/testcase.yaml
+++ b/tests/bluetooth/bluetooth/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bluetooth.general:
     platform_allow: qemu_x86 qemu_cortex_m3 native_posix native_posix_64
+    integration_platforms:
+      - qemu_x86
     tags: bluetooth

--- a/tests/bluetooth/bt_crypto/testcase.yaml
+++ b/tests/bluetooth/bt_crypto/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bluetooth.bt_crypto:
     platform_allow: native_posix native_posix_64 qemu_x86 qemu_cortex_m3
+    integration_platforms:
+      - native_posix
     tags: bluetooth

--- a/tests/bluetooth/gatt/testcase.yaml
+++ b/tests/bluetooth/gatt/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bluetooth.gatt:
     platform_allow: native_posix native_posix_64 qemu_x86 qemu_cortex_m3
+    integration_platforms:
+      - native_posix
     tags: bluetooth gatt

--- a/tests/bluetooth/hci_prop_evt/testcase.yaml
+++ b/tests/bluetooth/hci_prop_evt/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bluetooth.hci_prop_evt:
     platform_allow: qemu_x86 qemu_cortex_m3 native_posix native_posix_64
+    integration_platforms:
+      - native_posix
     tags: bluetooth hci prop event

--- a/tests/bluetooth/host_long_adv_recv/testcase.yaml
+++ b/tests/bluetooth/host_long_adv_recv/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bluetooth.host_long_adv_recv:
     platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix
     tags: bluetooth host

--- a/tests/bluetooth/l2cap/testcase.yaml
+++ b/tests/bluetooth/l2cap/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bluetooth.l2cap:
     platform_allow: native_posix native_posix_64 qemu_x86 qemu_cortex_m3
+    integration_platforms:
+      - native_posix
     tags: bluetooth l2cap

--- a/tests/bluetooth/mesh/testcase.yaml
+++ b/tests/bluetooth/mesh/testcase.yaml
@@ -2,26 +2,36 @@ tests:
   bluetooth.mesh.main:
     build_only: true
     platform_allow: qemu_x86 nrf51dk_nrf51422 nrf52840dk_nrf52840
+    integration_platforms:
+      - qemu_x86
     tags: bluetooth mesh
   bluetooth.mesh.dbg:
     build_only: true
     extra_args: CONF_FILE=dbg.conf
     platform_allow: qemu_x86 nrf51dk_nrf51422 nrf52840dk_nrf52840
+    integration_platforms:
+      - qemu_x86
     tags: bluetooth mesh
   bluetooth.mesh.friend:
     build_only: true
     extra_args: CONF_FILE=friend.conf
     platform_allow: qemu_x86 nrf51dk_nrf51422 nrf52840dk_nrf52840
+    integration_platforms:
+      - qemu_x86
     tags: bluetooth mesh
   bluetooth.mesh.gatt:
     build_only: true
     extra_args: CONF_FILE=gatt.conf
     platform_allow: qemu_x86 nrf51dk_nrf51422 nrf52840dk_nrf52840
+    integration_platforms:
+      - qemu_x86
     tags: bluetooth mesh
   bluetooth.mesh.lpn:
     build_only: true
     extra_args: CONF_FILE=lpn.conf
     platform_allow: qemu_x86 nrf51dk_nrf51422 nrf52840dk_nrf52840
+    integration_platforms:
+      - qemu_x86
     tags: bluetooth mesh
   bluetooth.mesh.main.microbit:
     build_only: true
@@ -32,19 +42,27 @@ tests:
     build_only: true
     extra_args: CONF_FILE=pb_gatt.conf
     platform_allow: qemu_x86 nrf51dk_nrf51422 nrf52840dk_nrf52840
+    integration_platforms:
+      - qemu_x86
     tags: bluetooth mesh
   bluetooth.mesh.proxy:
     build_only: true
     extra_args: CONF_FILE=proxy.conf
     platform_allow: qemu_x86 nrf51dk_nrf51422 nrf52840dk_nrf52840
+    integration_platforms:
+      - qemu_x86
     tags: bluetooth mesh
   bluetooth.mesh.ext_adv:
     build_only: true
     extra_args: CONF_FILE=ext_adv.conf
     platform_allow: qemu_x86 nrf51dk_nrf51422 nrf52840dk_nrf52840
+    integration_platforms:
+      - qemu_x86
     tags: bluetooth mesh
   bluetooth.mesh.multi_ext_adv:
     build_only: true
     extra_args: CONF_FILE=multi_ext_adv.conf
     platform_allow: qemu_x86 nrf51dk_nrf51422 nrf52840dk_nrf52840
+    integration_platforms:
+      - qemu_x86
     tags: bluetooth mesh

--- a/tests/bluetooth/mesh_shell/testcase.yaml
+++ b/tests/bluetooth/mesh_shell/testcase.yaml
@@ -4,6 +4,8 @@ common:
 tests:
   bluetooth.mesh.mesh_shell:
     platform_allow: qemu_x86 nrf51dk_nrf51422
+    integration_platforms:
+      - qemu_x86
     platform_exclude: nrf52dk_nrf52810
   bluetooth.mesh.mesh_shell.legacy_adv:
     platform_allow: qemu_cortex_m3

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -3,6 +3,8 @@ tests:
     extra_configs:
       - CONFIG_NATIVE_UART_0_ON_STDINOUT=y
     platform_allow: qemu_cortex_m3 qemu_x86 native_posix native_posix_64 nrf52840dk_nrf52840
+    integration_platforms:
+      - qemu_x86
     platform_exclude: nrf52dk_nrf52810
     tags: bluetooth
     harness: keyboard
@@ -12,6 +14,8 @@ tests:
                 DTC_OVERLAY_FILE="usb.overlay"
     depends_on: usb_device
     platform_allow: native_posix native_posix_64 nrf52840dk_nrf52840
+    integration_platforms:
+      - native_posix
     platform_exclude: nrf52dk_nrf52810
     tags: bluetooth
     harness: keyboard
@@ -21,6 +25,8 @@ tests:
       - CONFIG_NATIVE_UART_0_ON_STDINOUT=y
     extra_args: CONF_FILE="prj_br.conf"
     platform_allow: qemu_cortex_m3 qemu_x86 native_posix native_posix_64
+    integration_platforms:
+      - native_posix
     platform_exclude: nrf52dk_nrf52810
     tags: bluetooth
     harness: keyboard

--- a/tests/bluetooth/uuid/testcase.yaml
+++ b/tests/bluetooth/uuid/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bluetooth.uuid:
     platform_allow: native_posix native_posix_64 qemu_x86 qemu_cortex_m3
+    integration_platforms:
+      - native_posix
     tags: bluetooth uuid

--- a/tests/boards/intel_adsp/cache/testcase.yaml
+++ b/tests/boards/intel_adsp/cache/testcase.yaml
@@ -3,3 +3,5 @@ common:
 tests:
   boards.intel_adsp.cache:
     platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs25
+    integration_platforms:
+      - intel_adsp_cavs25

--- a/tests/boards/intel_adsp/hda/testcase.yaml
+++ b/tests/boards/intel_adsp/hda/testcase.yaml
@@ -1,7 +1,11 @@
+common:
+  platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20 intel_adsp_cavs25
+  integration_platforms:
+    - intel_adsp_cavs25
 tests:
   boards.intel_adsp.hda:
-    platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20 intel_adsp_cavs25
+    tags: hda dma
   boards.intel_adsp.hda.1cpu:
-    platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20 intel_adsp_cavs25
+    tags: hda dma
     extra_configs:
       - CONFIG_MP_MAX_NUM_CPUS=1

--- a/tests/boards/intel_adsp/hda_log/testcase.yaml
+++ b/tests/boards/intel_adsp/hda_log/testcase.yaml
@@ -1,21 +1,21 @@
 common:
-    harness: console
-    harness_config:
-      type: multi_line
-      regex:
-        - "TEST:([0-9]){6,7}"
-        - "Timeout flush working if shown"
+  harness: console
+  platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20 intel_adsp_cavs25
+  integration_platforms:
+    - intel_adsp_cavs25
+  harness_config:
+    type: multi_line
+    regex:
+      - "TEST:([0-9]){6,7}"
+      - "Timeout flush working if shown"
 tests:
   boards.intel_adsp.hda_log:
-    platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20 intel_adsp_cavs25
     timeout: 120
   boards.intel_adsp.hda_log.printk:
-    platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20 intel_adsp_cavs25
     timeout: 120
     extra_configs:
       - CONFIG_LOG_PRINTK=y
   boards.intel_adsp.hda_log.1cpu:
-    platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20 intel_adsp_cavs25
     timeout: 120
     extra_configs:
       - CONFIG_MP_MAX_NUM_CPUS=1

--- a/tests/boards/intel_adsp/smoke/testcase.yaml
+++ b/tests/boards/intel_adsp/smoke/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   boards.intel_adsp.smoke:
     platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20 intel_adsp_cavs25
+    integration_platforms:
+      - intel_adsp_cavs25

--- a/tests/boards/intel_adsp/ssp/testcase.yaml
+++ b/tests/boards/intel_adsp/ssp/testcase.yaml
@@ -1,6 +1,8 @@
 common:
-  tags: boards
+  tags: dai dma
 tests:
   boards.intel_adsp.ssp:
     depends_on: dai dma
     platform_allow: intel_adsp_cavs25 intel_adsp_cavs15
+    integration_platforms:
+      - intel_adsp_cavs25

--- a/tests/boards/native_posix/cpu_wait/testcase.yaml
+++ b/tests/boards/native_posix/cpu_wait/testcase.yaml
@@ -2,3 +2,5 @@
 tests:
   boards.native_posix.cpu_wait:
     platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix

--- a/tests/boards/native_posix/rtc/testcase.yaml
+++ b/tests/boards/native_posix/rtc/testcase.yaml
@@ -2,6 +2,8 @@
 tests:
   boards.native_posix.rtc:
     platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix
     build_only: true
 #Note: this test depends too much on not having a high host load to pass.
 #      Therefore it should not be run in automated regression

--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -13,3 +13,5 @@ tests:
   boot.mcuboot:
     tags: mcuboot
     platform_allow: frdm_k64f mimxrt1060_evk
+    integration_platforms:
+      - frdm_k64f

--- a/tests/drivers/adc/adc_dma/testcase.yaml
+++ b/tests/drivers/adc/adc_dma/testcase.yaml
@@ -4,3 +4,5 @@ tests:
   drivers.adc-dma:
     depends_on: adc dma
     platform_allow: frdm_k82f frdm_k64f
+    integration_platforms:
+      - frdm_k82f

--- a/tests/drivers/clock_control/adsp_clock/testcase.yaml
+++ b/tests/drivers/clock_control/adsp_clock/testcase.yaml
@@ -2,3 +2,5 @@ tests:
   drivers.clock.adsp_clock_control:
     tags: drivers clock
     platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20 intel_adsp_cavs25
+    integration_platforms:
+      - intel_adsp_cavs25

--- a/tests/drivers/clock_control/clock_control_api/testcase.yaml
+++ b/tests/drivers/clock_control/clock_control_api/testcase.yaml
@@ -3,7 +3,11 @@ tests:
     tags: drivers cloc
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf9160dk_nrf9160
+    integration_platforms:
+      - nrf51dk_nrf51422
   drivers.clock.clock_control_nrf5_lfclk_rc:
     tags: drivers clock
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf51dk_nrf51422
     extra_args: CONF_FILE="nrf_lfclk_rc.conf"

--- a/tests/drivers/clock_control/nrf_clock_calibration/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_clock_calibration/testcase.yaml
@@ -2,3 +2,5 @@ tests:
   drivers.clock.nrf5_clock_calibration:
     tags: drivers clock
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf51dk_nrf51422

--- a/tests/drivers/clock_control/nrf_lf_clock_start/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_lf_clock_start/testcase.yaml
@@ -1,5 +1,7 @@
 common:
   tags: drivers clock
+  integration_platforms:
+    - nrf51dk_nrf51422
 tests:
   drivers.clock.nrf_lf_clock_start_xtal_stable:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
@@ -8,6 +10,8 @@ tests:
     extra_configs:
       - CONFIG_SYSTEM_CLOCK_WAIT_FOR_STABILITY=y
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL=y
+    integration_platforms:
+      - nrf51dk_nrf51422
 
   drivers.clock.nrf_lf_clock_start_xtal_available:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
@@ -16,11 +20,15 @@ tests:
     extra_configs:
       - CONFIG_SYSTEM_CLOCK_WAIT_FOR_AVAILABILITY=y
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL=y
+    integration_platforms:
+      - nrf51dk_nrf51422
 
   drivers.clock.nrf_lf_clock_start_xtal_no_wait:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
                         nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf51dk_nrf51422
     extra_configs:
       - CONFIG_SYSTEM_CLOCK_NO_WAIT=y
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL=y
@@ -28,6 +36,8 @@ tests:
   drivers.clock.nrf_lf_clock_start_rc_stable:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf51dk_nrf51422
     extra_configs:
       - CONFIG_SYSTEM_CLOCK_WAIT_FOR_STABILITY=y
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
@@ -35,6 +45,8 @@ tests:
   drivers.clock.nrf_lf_clock_start_rc_available:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf51dk_nrf51422
     extra_configs:
       - CONFIG_SYSTEM_CLOCK_WAIT_FOR_AVAILABILITY=y
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
@@ -42,6 +54,8 @@ tests:
   drivers.clock.nrf_lf_clock_start_rc_no_wait:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf51dk_nrf51422
     extra_configs:
       - CONFIG_SYSTEM_CLOCK_NO_WAIT=y
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
@@ -49,6 +63,8 @@ tests:
   drivers.clock.nrf_lf_clock_start_synth_stable:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf51dk_nrf51422
     extra_configs:
       - CONFIG_SYSTEM_CLOCK_WAIT_FOR_STABILITY=y
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_SYNTH=y
@@ -56,6 +72,8 @@ tests:
   drivers.clock.nrf_lf_clock_start_synth_available:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf51dk_nrf51422
     extra_configs:
       - CONFIG_SYSTEM_CLOCK_WAIT_FOR_AVAILABILITY=y
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_SYNTH=y
@@ -63,6 +81,8 @@ tests:
   drivers.clock.nrf_lf_clock_start_synth_no_wait:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf51dk_nrf51422
     extra_configs:
       - CONFIG_SYSTEM_CLOCK_NO_WAIT=y
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_SYNTH=y

--- a/tests/drivers/clock_control/nrf_onoff_and_bt/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_onoff_and_bt/testcase.yaml
@@ -2,3 +2,5 @@ tests:
   drivers.clock.nrf_onoff_and_bt:
     tags: drivers clock
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf51dk_nrf51422

--- a/tests/drivers/clock_control/onoff/testcase.yaml
+++ b/tests/drivers/clock_control/onoff/testcase.yaml
@@ -3,3 +3,5 @@ tests:
     tags: drivers clock
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf9160dk_nrf9160
+    integration_platforms:
+      - nrf51dk_nrf51422

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/testcase.yaml
@@ -5,128 +5,203 @@
 # - add the sloder bridge
 # - add the fixture in map file
 common:
-    timeout: 5
+  timeout: 5
+  tags: clock-control
 tests:
   drivers.stm32_clock_configuration.common_core.l4_l5.sysclksrc_pll_48_msi_4:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/clear_msi.overlay;boards/pll_48_msi_4.overlay"
     platform_allow: disco_l475_iot1 nucleo_l4r5zi stm32l562e_dk
+    integration_platforms:
+      - disco_l475_iot1
   drivers.stm32_clock_configuration.common_core.l4_l5.sysclksrc_pll_64_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/clear_msi.overlay;boards/pll_64_hsi_16.overlay"
     platform_allow: disco_l475_iot1 nucleo_l4r5zi stm32l562e_dk
+    integration_platforms:
+      - disco_l475_iot1
   drivers.stm32_clock_configuration.common_core.sysclksrc_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/clear_msi.overlay;boards/hsi_16.overlay"
     platform_allow: disco_l475_iot1 nucleo_l4r5zi stm32l562e_dk nucleo_wb55rg nucleo_wl55jc
+    integration_platforms:
+      - disco_l475_iot1
   drivers.stm32_clock_configuration.common_core.sysclksrc_msi_48:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/clear_msi.overlay;boards/msi_range11.overlay"
     platform_allow: disco_l475_iot1 nucleo_l4r5zi stm32l562e_dk nucleo_wl55jc nucleo_wb55rg
+    integration_platforms:
+      - disco_l475_iot1
   drivers.stm32_clock_configuration.common_core.l4_l5.sysclksrc_hse_8.fixup:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/clear_msi.overlay;boards/hse_8.overlay"
     platform_allow: disco_l475_iot1 nucleo_l4r5zi stm32l562e_dk
     harness: ztest
     harness_config:
       fixture: mco_sb_closed
+    integration_platforms:
+      - disco_l475_iot1
   drivers.stm32_clock_configuration.common_core.l4_l5.sysclksrc_pll_64_hse_8.fixup:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/clear_msi.overlay;boards/pll_64_hse_8.overlay"
     platform_allow: disco_l475_iot1 nucleo_l4r5zi stm32l562e_dk
     harness: ztest
     harness_config:
       fixture: mco_sb_closed
+    integration_platforms:
+      - disco_l475_iot1
   drivers.stm32_clock_configuration.common_core.g0.sysclksrc_pll_64_hse_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_64_hse_8.overlay"
     platform_allow: nucleo_g071rb
     harness: ztest
     harness_config:
       fixture: mco_sb_closed
+    integration_platforms:
+      - nucleo_g071rb
   drivers.stm32_clock_configuration.common_core.g0.sysclksrc_hsi_g0_16_div_2:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_g0_16_div_2.overlay"
     platform_allow: nucleo_g071rb
+    integration_platforms:
+      - nucleo_g071rb
   drivers.stm32_clock_configuration.common_core.g0.sysclksrc_hsi_g0_16_div_4:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_g0_16_div_4.overlay"
     platform_allow: nucleo_g071rb
+    integration_platforms:
+      - nucleo_g071rb
   drivers.stm32_clock_configuration.common_core.g4.sysclksrc_pll_64_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_64_hsi_16.overlay"
     platform_allow: nucleo_g474re
+    integration_platforms:
+      - nucleo_g474re
   drivers.stm32_clock_configuration.common_core.g0.sysclksrc_pll_g0_64_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_g0_64_hsi_16.overlay"
     platform_allow: nucleo_g071rb
+    integration_platforms:
+      - nucleo_g071rb
   drivers.stm32_clock_configuration.common_core.g4.sysclksrc_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_16.overlay"
     platform_allow: nucleo_g474re
+    integration_platforms:
+      - nucleo_g474re
   drivers.stm32_clock_configuration.common_core.g0.sysclksrc_hsi_g0_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_g0_16.overlay"
     platform_allow: nucleo_g071rb
+    integration_platforms:
+      - nucleo_g071rb
   drivers.stm32_clock_configuration.common_core.g4.sysclksrc_hse_24:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hse_24.overlay"
     platform_allow: nucleo_g474re
   drivers.stm32_clock_configuration.common_core.l0_l1.sysclksrc_hse_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/clear_msi.overlay;boards/hse_8.overlay"
     platform_allow: nucleo_l152re nucleo_l073rz
+    integration_platforms:
+      - nucleo_l152re
   drivers.stm32_clock_configuration.common_core.l0_l1.sysclksrc_pll_32_hse_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_32_hse_8.overlay"
     platform_allow: nucleo_l152re nucleo_l073rz
+    integration_platforms:
+      - nucleo_l152re
   drivers.stm32_clock_configuration.common_core.l0_l1.sysclksrc_pll_32_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_32_hsi_16.overlay"
     platform_allow: nucleo_l152re nucleo_l073rz
+    integration_platforms:
+      - nucleo_l152re
   drivers.stm32_clock_configuration.common_core.l0_l1.sysclksrc_msi_range6:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/msi_range6.overlay"
     platform_allow: nucleo_l152re nucleo_l073rz
+    integration_platforms:
+      - nucleo_l152re
   drivers.stm32_clock_configuration.common_core.wl.sysclksrc_pll_48_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_48_hsi_16.overlay"
     platform_allow: nucleo_wl55jc
+    integration_platforms:
+      - nucleo_wl55jc
   drivers.stm32_clock_configuration.common_core.wl.sysclksrc_pll_48_hse_32:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/wl_pll_48_hse_32.overlay"
     platform_allow: nucleo_wl55jc
+    integration_platforms:
+      - nucleo_wl55jc
   drivers.stm32_clock_configuration.common_core.wl.sysclksrc_hse_32:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/wl_32_hse.overlay"
     platform_allow: nucleo_wl55jc
+    integration_platforms:
+      - nucleo_wl55jc
   drivers.stm32_clock_configuration.common_core.wb.sysclksrc_hse_32:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hse_32.overlay"
     platform_allow: nucleo_wb55rg
+    integration_platforms:
+      - nucleo_wb55rg
   drivers.stm32_clock_configuration.common_core.wb.sysclksrc_pll_48_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/wb_pll_48_hsi_16.overlay"
     platform_allow: nucleo_wb55rg
+    integration_platforms:
+      - nucleo_wb55rg
   drivers.stm32_clock_configuration.common_core.wb.sysclksrc_pll_64_hse_32:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/wb_pll_64_hse_32.overlay"
     platform_allow: nucleo_wb55rg
+    integration_platforms:
+      - nucleo_wb55rg
   drivers.stm32_clock_configuration.common_core.wb.sysclksrc_pll_48_msi_4:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/wb_pll_48_msi_4.overlay"
     platform_allow: nucleo_wb55rg
+    integration_platforms:
+      - nucleo_wb55rg
   drivers.stm32_clock_configuration.common_core.f0_f3.sysclksrc_hsi_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/hsi_8.overlay"
     platform_allow: nucleo_f091rc stm32f3_disco
+    integration_platforms:
+      - nucleo_f091rc
   drivers.stm32_clock_configuration.common_core.f0_f3.sysclksrc_hse_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/hse_8_bypass.overlay"
     platform_allow: nucleo_f091rc stm32f3_disco
+    integration_platforms:
+      - nucleo_f091rc
   drivers.stm32_clock_configuration.common_core.f0_f3.sysclksrc_pll_32_hsi_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/f0_f3_pll_32_hsi_8.overlay"
     platform_allow: nucleo_f091rc stm32f3_disco
+    integration_platforms:
+      - nucleo_f091rc
   drivers.stm32_clock_configuration.common_core.f0_f3.sysclksrc_pll_32_hse_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/f0_f3_pll_32_hse_8.overlay"
     platform_allow: nucleo_f091rc stm32f3_disco
+    integration_platforms:
+      - nucleo_f091rc
   drivers.stm32_clock_configuration.common_core.f1.sysclksrc_hsi_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/hsi_8.overlay"
     platform_allow: nucleo_f103rb
+    integration_platforms:
+      - nucleo_f103rb
   drivers.stm32_clock_configuration.common_core.f1.sysclksrc_hse_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/hse_8.overlay"
     platform_allow: nucleo_f103rb
+    integration_platforms:
+      - nucleo_f103rb
   drivers.stm32_clock_configuration.common_core.f1.sysclksrc_pll_64_hsi_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/f1_pll_64_hsi_8.overlay"
     platform_allow: nucleo_f103rb
+    integration_platforms:
+      - nucleo_f103rb
   drivers.stm32_clock_configuration.common_core.f1.sysclksrc_pll_64_hse_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_f0_f1_f3_clocks.overlay;boards/f1_pll_64_hse_8.overlay"
     platform_allow: nucleo_f103rb
+    integration_platforms:
+      - nucleo_f103rb
   drivers.stm32_clock_configuration.common_core.f2_f4_f7.sysclksrc_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_f2_f4_f7_clocks.overlay;boards/hsi_16.overlay"
     platform_allow: nucleo_f207zg nucleo_f429zi nucleo_f446re nucleo_f746zg
+    integration_platforms:
+      - nucleo_f207zg
   drivers.stm32_clock_configuration.common_core.f2_f4_f7.sysclksrc_hse_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_f2_f4_f7_clocks.overlay;boards/hse_8.overlay"
     platform_allow: nucleo_f207zg nucleo_f429zi nucleo_f446re nucleo_f746zg
+    integration_platforms:
+      - nucleo_f207zg
   drivers.stm32_clock_configuration.common_core.f2_f4_f7.sysclksrc_pll_64_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_f2_f4_f7_clocks.overlay;boards/f2_f4_f7_pll_64_hsi_16.overlay"
     platform_allow: nucleo_f207zg nucleo_f429zi nucleo_f446re nucleo_f746zg
+    integration_platforms:
+      - nucleo_f207zg
   drivers.stm32_clock_configuration.common_core.f2_f4_f7.sysclksrc_pll_64_hse_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_f2_f4_f7_clocks.overlay;boards/f2_f4_f7_pll_64_hse_8.overlay"
     platform_allow: nucleo_f207zg nucleo_f429zi nucleo_f446re nucleo_f746zg
+    integration_platforms:
+      - nucleo_f207zg
   drivers.stm32_clock_configuration.common_core.f2_f4_f7.sysclksrc_pll_100_hsi_16_ahb2:
     extra_args: DTC_OVERLAY_FILE="boards/clear_f2_f4_f7_clocks.overlay;boards/f2_f4_f7_pll_100_hsi_16_ahb_2.overlay"
     platform_allow: nucleo_f207zg nucleo_f429zi nucleo_f446re nucleo_f746zg
+    integration_platforms:
+      - nucleo_f207zg

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_core/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_core/testcase.yaml
@@ -1,24 +1,40 @@
 common:
-    timeout: 5
+  timeout: 5
+  tags: clock_control
+
 tests:
   drivers.stm32_clock_configuration.h7_core.sysclksrc_pll_hse_96:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_hse_96.overlay"
     platform_allow: nucleo_h743zi
+    integration_platforms:
+      - nucleo_h743zi
   drivers.stm32_clock_configuration.h7_core.sysclksrc_pll_hsi_96:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_hsi_96.overlay"
     platform_allow: nucleo_h743zi
+    integration_platforms:
+      - nucleo_h743zi
   drivers.stm32_clock_configuration.h7_core.sysclksrc_hsi_64:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_64.overlay"
     platform_allow: nucleo_h743zi
+    integration_platforms:
+      - nucleo_h743zi
   drivers.stm32_clock_configuration.h7_core.sysclksrc_csi_4:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/csi_4.overlay"
     platform_allow: nucleo_h743zi
+    integration_platforms:
+      - nucleo_h743zi
   drivers.stm32_clock_configuration.h7_core.sysclksrc_hse_8:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hse_8.overlay"
     platform_allow: nucleo_h743zi
+    integration_platforms:
+      - nucleo_h743zi
   drivers.stm32_clock_configuration.h7_core.sysclksrc_pll_csi_96:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_csi_96.overlay"
     platform_allow: nucleo_h743zi
+    integration_platforms:
+      - nucleo_h743zi
   drivers.stm32_clock_configuration.h7_core.sysclksrc_pll_hse_550:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_hse_550.overlay"
     platform_allow: nucleo_h723zg stm32h735g_disco
+    integration_platforms:
+      - nucleo_h723zg

--- a/tests/drivers/dac/dac_loopback/testcase.yaml
+++ b/tests/drivers/dac/dac_loopback/testcase.yaml
@@ -10,3 +10,5 @@ tests:
       frdm_k22f frdm_k64f nucleo_f207zg nucleo_l073rz nucleo_l152re twr_ke18f
       bl652_dvk bl653_dvk bl654_dvk bl5340_dvk_cpuapp stm32f3_disco stm32l562e_dk
       nucleo_l552ze_q nucleo_f429zi nucleo_f746zg nucleo_g071rb nucleo_wl55jc
+    integration_platforms:
+      - nucleo_f207zg

--- a/tests/drivers/dma/chan_link_transfer/testcase.yaml
+++ b/tests/drivers/dma/chan_link_transfer/testcase.yaml
@@ -4,3 +4,5 @@ tests:
     depends_on: dma
     tags: drivers dma
     platform_allow: frdm_k64f mimxrt1060_evk mimxrt1064_evk mimxrt1160_evk_cm7 mimxrt1170_evk_cm7
+    integration_platforms:
+      - frdm_k64f

--- a/tests/drivers/dma/scatter_gather/testcase.yaml
+++ b/tests/drivers/dma/scatter_gather/testcase.yaml
@@ -5,3 +5,5 @@ tests:
     platform_allow: intel_adsp_cavs25 intel_adsp_cavs20 intel_adsp_cavs18 intel_adsp_cavs15
      frdm_k64f mimxrt1060_evk
     filter: dt_alias_exists("dma0")
+    integration_platforms:
+      - intel_adsp_cavs25

--- a/tests/drivers/flash/testcase.yaml
+++ b/tests/drivers/flash/testcase.yaml
@@ -1,13 +1,13 @@
+common:
+  tags: drivers flash
 tests:
   drivers.flash.nrf_qspi_nor:
     platform_allow: nrf52840dk_nrf52840
-    tags: flash nrf52 nrf_qspi_fash
     extra_args: OVERLAY_CONFIG=boards/nrf52840_flash_qspi.conf
     integration_platforms:
       - nrf52840dk_nrf52840
   drivers.flash.nrf_qspi_nor.size_in_bytes:
     platform_allow: nrf52840dk_nrf52840
-    tags: flash nrf52 nrf_qspi_fash
     extra_args:
       OVERLAY_CONFIG=boards/nrf52840_flash_qspi.conf
       DTC_OVERLAY_FILE=boards/nrf52840_size_in_bytes.overlay
@@ -15,7 +15,6 @@ tests:
       - nrf52840dk_nrf52840
   drivers.flash.nrf_qspi_nor_4B_addr:
     platform_allow: nrf52840dk_nrf52840
-    tags: flash nrf52 nrf_qspi_fash
     extra_args: OVERLAY_CONFIG=boards/nrf52840_flash_qspi.conf
                 DTC_OVERLAY_FILE=boards/nrf52840dk_mx25l51245g.overlay
     harness_config:
@@ -24,12 +23,10 @@ tests:
       - nrf52840dk_nrf52840
   drivers.flash.soc_flash_nrf:
     platform_allow: nrf52840dk_nrf52840
-    tags: nrf52 soc_flash_nrf
     extra_args: OVERLAY_CONFIG=boards/nrf52840_flash_soc.conf
     integration_platforms:
       - nrf52840dk_nrf52840
   drivers.flash.default:
-    tags: drivers flash
     filter: ((CONFIG_FLASH_HAS_DRIVER_ENABLED and
         not CONFIG_TRUSTED_EXECUTION_NONSECURE) and
         dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions"))
@@ -37,33 +34,18 @@ tests:
         dt_label_with_parent_compat_enabled("image_1_nonsecure", "fixed-partitions"))
   drivers.flash.mcux:
     platform_allow: mimxrt1060_evk it8xxx2_evb mimxrt685_evk_cm33 mimxrt595_evk_cm33
-    tags: mcux
     integration_platforms:
       - mimxrt1060_evk
   drivers.flash.stm32:
+    platform_allow: nucleo_f103rb nucleo_f207zg stm32f3_disco nucleo_f429zi stm32f746g_disco nucleo_g0b1re nucleo_g474re
+                    nucleo_h743zi nucleo_l152re disco_l475_iot1 nucleo_wb55rg nucleo_wl55jc stm32l562e_dk stm32l562e_dk_ns
     integration_platforms:
-      - nucleo_f091rc
       - nucleo_f103rb
-      - nucleo_f207zg
-      - stm32f3_disco
-      - nucleo_f429zi
-      - stm32f746g_disco
-      - nucleo_g0b1re
-      - nucleo_g474re
-      - nucleo_h743zi
-      - nucleo_l152re
-      - disco_l475_iot1
-      - nucleo_wb55rg
-      - nucleo_wl55jc
-      - stm32l562e_dk
-      - stm32l562e_dk_ns
     filter: (dt_compat_enabled("st,stm32-flash-controller") or
              dt_compat_enabled("st,stm32h7-flash-controller")) and
        dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
-    tags: drivers flash
   drivers.flash.mx25r_high_perf:
     platform_allow: nrf52840dk_nrf52840
-    tags: flash nrf52 mx25r_hp
     extra_args:
       OVERLAY_CONFIG=boards/nrf52840dk_flash_spi.conf
       DTC_OVERLAY_FILE=boards/nrf52840dk_mx25r_high_perf.overlay

--- a/tests/drivers/flash_simulator/testcase.yaml
+++ b/tests/drivers/flash_simulator/testcase.yaml
@@ -3,12 +3,20 @@ common:
 tests:
   drivers.flash.flash_simulator:
     platform_allow: qemu_x86 native_posix native_posix_64
+    integration_platforms:
+      - qemu_x86
   drivers.flash.flash_simulator.qemu_erase_value_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/qemu_x86_ev_0x00.overlay
     platform_allow: qemu_x86
+    integration_platforms:
+      - qemu_x86
   drivers.flash.flash_simulator.posix_erase_value_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/native_posix_ev_0x00.overlay
     platform_allow: native_posix
+    integration_platforms:
+      - native_posix
   drivers.flash.flash_simulator.posix_64_erase_value_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/native_posix_64_ev_0x00.overlay
     platform_allow: native_posix_64
+    integration_platforms:
+      - native_posix_64

--- a/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
+++ b/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
@@ -3,9 +3,6 @@ tests:
   drivers.sbs_gauge_new_api:
     tags: test_framework
     filter: dt_compat_enabled("sbs,sbs-gauge-new-api")
-    platform_allow:
-      native_posix
-      qemu_cortex_a9
-      nucleo_f070rb
+    platform_allow: native_posix qemu_cortex_a9 nucleo_f070rb
     integration_platforms:
       - nucleo_f070rb

--- a/tests/drivers/i2c/i2c_target_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_target_api/testcase.yaml
@@ -8,5 +8,7 @@ common:
 tests:
   drivers.i2c.target_api.dual_role:
     platform_allow: nucleo_f091rc stm32f072b_disco nucleo_g071rb rpi_pico
+    integration_platforms:
+      - nucleo_f091rc
     extra_configs:
       - CONFIG_APP_DUAL_ROLE_I2C=y

--- a/tests/drivers/pinctrl/api/testcase.yaml
+++ b/tests/drivers/pinctrl/api/testcase.yaml
@@ -5,7 +5,11 @@ tests:
   drivers.pinctrl.api:
     tags: drivers pinctrl
     platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix
   drivers.pinctrl.api_reg:
     tags: drivers pinctrl
     platform_allow: native_posix native_posix_64
     extra_args: CONF_FILE="prj.conf;reg.conf"
+    integration_platforms:
+      - native_posix

--- a/tests/drivers/sensor/sbs_gauge/testcase.yaml
+++ b/tests/drivers/sensor/sbs_gauge/testcase.yaml
@@ -9,6 +9,6 @@ tests:
   drivers.sbs_gauge.emulated:
     tags: test_framework
     filter: dt_compat_enabled("sbs,sbs-gauge")
-    platform_allow:
-      native_posix
-      qemu_cortex_a9
+    platform_allow: native_posix qemu_cortex_a9
+    integration_platforms:
+      - native_posix

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -1,34 +1,26 @@
 common:
   depends_on: spi
-  tags: drivers spi
+  tags: drivers spi dma
   filter: dt_compat_enabled("test-spi-loopback-slow") and dt_compat_enabled("test-spi-loopback-fast")
+  harness: ztest
+  harness_config:
+    fixture: spi_loopback
 tests:
-  drivers.spi.loopback:
-    harness: ztest
-    harness_config:
-      fixture: spi_loopback
+  drivers.spi.loopback: {}
   drivers.spi.loopback.internal:
     filter: CONFIG_SPI_LOOPBACK_MODE_LOOP
   drivers.mcux_dspi_dma.loopback:
-    tags: dma
-    harness: ztest
     extra_args: OVERLAY_CONFIG="overlay-mcux-dspi-dma.conf" DTC_OVERLAY_FILE="overlay-mcux-dspi-dma.overlay"
-    harness_config:
-      fixture: spi_loopback
     platform_allow: frdm_k64f
   drivers.sam_spi_dma.loopback:
-    tags: dma
-    harness: ztest
     extra_args: OVERLAY_CONFIG="overlay-sam-spi-dma.conf" DTC_OVERLAY_FILE="overlay-sam-spi-dma.overlay"
-    harness_config:
-      fixture: spi_loopback
     platform_allow: sam_e70_xplained sam_v71_xult tdk_robokit1
+    integration_platforms:
+      - sam_e70_xplained
   drivers.stm32_spi_dma.loopback:
-    tags: dma
-    harness: ztest
-    harness_config:
-      fixture: spi_loopback
     extra_args: OVERLAY_CONFIG="overlay-stm32-spi-dma.conf"
     filter: CONFIG_SOC_FAMILY_STM32
     platform_allow: nucleo_g474re nucleo_f207zg nucleo_f429zi nucleo_f746zg nucleo_wb55rg
         nucleo_wl55jc nucleo_h743zi
+    integration_platforms:
+      - nucleo_g474re

--- a/tests/drivers/timer/nrf_rtc_timer/testcase.yaml
+++ b/tests/drivers/timer/nrf_rtc_timer/testcase.yaml
@@ -2,9 +2,13 @@ tests:
   drivers.timer.nrf_rtc_timer:
     tags: drivers timer
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf52dk_nrf52832
     extra_configs:
       - CONFIG_ZERO_LATENCY_IRQS=y
 
   drivers.timer.nrf_rtc_timer_no_zli:
     tags: drivers timer
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52_bsim
+    integration_platforms:
+      - nrf52dk_nrf52832

--- a/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
+++ b/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
@@ -1,25 +1,25 @@
 common:
   tags: drivers uart
   harness: ztest
+  platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
+  integration_platforms:
+    - nrf52840dk_nrf52840
   harness_config:
     fixture: gpio_loopback
 tests:
   drivers.uart.uart_mix_poll:
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
       - CONFIG_UART_ASYNC_API=n
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
 
   drivers.uart.uart_mix_poll_fifo:
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
 
   drivers.uart.uart_mix_poll_async_api:
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_ASYNC_API=y
       - CONFIG_UART_0_INTERRUPT_DRIVEN=n
@@ -30,7 +30,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
 
   drivers.uart.uart_mix_poll_async_api_const:
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_args: TEST_CONST_BUFFER=1
     extra_configs:
       - CONFIG_UART_ASYNC_API=y
@@ -43,7 +42,6 @@ tests:
       - CONFIG_UART_ASYNC_TX_CACHE_SIZE=2
 
   drivers.uart.uart_mix_poll_async_api_low_power:
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_ASYNC_API=y
       - CONFIG_UART_0_INTERRUPT_DRIVEN=n
@@ -55,21 +53,18 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
 
   drivers.uart.uart_mix_poll_with_ppi:
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
       - CONFIG_UART_ASYNC_API=n
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
 
   drivers.uart.uart_mix_poll_fifo_with_ppi:
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
 
   drivers.uart.uart_mix_poll_async_api_with_ppi:
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_ASYNC_API=y
       - CONFIG_UART_0_INTERRUPT_DRIVEN=n
@@ -80,7 +75,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
 
   drivers.uart.uart_mix_poll_async_api_with_ppi_low_power:
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     extra_configs:
       - CONFIG_UART_ASYNC_API=y
       - CONFIG_UART_0_INTERRUPT_DRIVEN=n

--- a/tests/drivers/uart/uart_pm/testcase.yaml
+++ b/tests/drivers/uart/uart_pm/testcase.yaml
@@ -1,18 +1,17 @@
 common:
   tags: drivers uart
   harness: ztest
+  platform_allow: nrf52840dk_nrf52840
   harness_config:
     fixture: gpio_loopback
 tests:
   drivers.uart.pm:
-    platform_allow: nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
       - CONFIG_UART_ASYNC_API=n
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
 
   drivers.uart.pm.no_rxpin:
-    platform_allow: nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
       - CONFIG_UART_ASYNC_API=n
@@ -20,14 +19,12 @@ tests:
     extra_args: DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840.overlay;nrf_rx_disable.overlay"
 
   drivers.uart.pm.enhanced_poll:
-    platform_allow: nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
       - CONFIG_UART_ASYNC_API=n
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
 
   drivers.uart.pm.int_driven:
-    platform_allow: nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_INTERRUPT_DRIVEN=y
@@ -35,7 +32,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
 
   drivers.uart.pm.int_driven.enhanced_poll:
-    platform_allow: nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
       - CONFIG_UART_0_INTERRUPT_DRIVEN=y
@@ -43,7 +39,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=y
 
   drivers.uart.pm.async:
-    platform_allow: nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
       - CONFIG_UART_ASYNC_API=y
@@ -54,7 +49,6 @@ tests:
       - CONFIG_UART_0_ENHANCED_POLL_OUT=n
 
   drivers.uart.pm.async.enhanced_poll:
-    platform_allow: nrf52840dk_nrf52840
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=n
       - CONFIG_UART_ASYNC_API=y

--- a/tests/drivers/w1/w1_api/testcase.yaml
+++ b/tests/drivers/w1/w1_api/testcase.yaml
@@ -1,23 +1,23 @@
 common:
   tags: drivers w1 userspace
   harness: ztest
+  platform_allow: nucleo_g0b1re nrf52840dk_nrf52840
+  integration_platforms:
+    - nrf52840dk_nrf52840
 
 tests:
   drivers.w1.w1-serial:
     depends_on: arduino_serial
     extra_args: DTC_OVERLAY_FILE=w1_serial.overlay
-    platform_allow: nucleo_g0b1re nrf52840dk_nrf52840
     harness_config:
       fixture: w1_serial_idle
   drivers.w1.ds2484:
     depends_on: arduino_i2c
     extra_args: DTC_OVERLAY_FILE=ds2484.overlay
-    platform_allow: nucleo_g0b1re nrf52840dk_nrf52840
     harness_config:
       fixture: w1_ds2484_idle
   drivers.w1.ds2485:
     depends_on: arduino_i2c
     extra_args: DTC_OVERLAY_FILE=ds2485.overlay
-    platform_allow: nucleo_g0b1re nrf52840dk_nrf52840
     harness_config:
       fixture: w1_ds2485_idle

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -16,6 +16,8 @@ tests:
         nucleo_f429zi nucleo_f746zg nucleo_g071rb nucleo_g474re nucleo_l073rz
         nucleo_l152re nucleo_l4r5zi stm32l562e_dk nucleo_wb55rg nucleo_wl55jc
         b_u585i_iot02a nucleo_u575zi_q
+    integration_platforms:
+      - nucleo_f091rc
   drivers.watchdog.stm32wwdg_h7:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
     extra_args: DTC_OVERLAY_FILE="boards/stm32_wwdg_h7.overlay"
@@ -27,6 +29,8 @@ tests:
         nucleo_f429zi nucleo_f746zg nucleo_g071rb nucleo_g474re nucleo_l073rz
         nucleo_l152re nucleo_l4r5zi stm32l562e_dk nucleo_wb55rg nucleo_wl55jc
         b_u585i_iot02a nucleo_u575zi_q nucleo_h753zi nucleo_h743zi
+    integration_platforms:
+      - nucleo_f091rc
   drivers.watchdog.mec15xxevb_assy6853:
     build_only: true
     platform_allow: mec15xxevb_assy6853
@@ -40,9 +44,13 @@ tests:
     platform_allow: gd32e103v_eval gd32e507v_start gd32f350r_eval gd32f403z_eval
         gd32f450i_eval gd32f450z_eval gd32f470i_eval gd32vf103c_starter gd32vf103v_eval
         longan_nano
+    integration_platforms:
+      - gd32e103v_eval
   drivers.watchdog.gd32wwdgt:
     filter: dt_compat_enabled("gd,gd32-wwdgt")
     extra_args: DTC_OVERLAY_FILE="boards/gd32_wwdgt.overlay"
     platform_allow: gd32e103v_eval gd32e507v_start gd32f350r_eval gd32f403z_eval
         gd32f450i_eval gd32f450z_eval gd32f470i_eval gd32vf103c_starter
         gd32vf103v_eval longan_nano
+    integration_platforms:
+      - gd32e103v_eval

--- a/tests/kernel/fatal/no-multithreading/testcase.yaml
+++ b/tests/kernel/fatal/no-multithreading/testcase.yaml
@@ -1,6 +1,9 @@
 common:
   platform_allow: qemu_cortex_m3 qemu_arc_em qemu_arc_hs qemu_arc_hs6x nsim_em nsim_em7d_v22
     nsim_hs nsim_hs_mpuv6 nsim_hs5x nsim_hs6x
+  integration_platforms:
+    - qemu_cortex_m3
+    - nsim_em
   tags: kernel scheduler
   ignore_faults: True
 tests:

--- a/tests/kernel/fpu_sharing/float_disable/testcase.yaml
+++ b/tests/kernel/fpu_sharing/float_disable/testcase.yaml
@@ -1,31 +1,31 @@
+common:
+  tags: fpu kernel userspace
 tests:
   kernel.fpu_sharing.float_disable.arm:
     arch_allow: arm
     filter: CONFIG_ARMV7_M_ARMV8_M_FP or CONFIG_ARMV7_R_FP
     extra_configs:
       - CONFIG_DYNAMIC_INTERRUPTS=y
-    tags: fpu kernel userspace
   kernel.fpu_sharing.float_disable.riscv32:
     filter: CONFIG_CPU_HAS_FPU
     arch_allow: riscv32
-    tags: fpu kernel userspace
   kernel.fpu_sharing.float_disable.riscv64:
     filter: CONFIG_CPU_HAS_FPU
     arch_allow: riscv64
-    tags: fpu kernel userspace
   kernel.fpu_sharing.float_disable.sparc:
     filter: CONFIG_CPU_HAS_FPU
     arch_allow: sparc
-    tags: kernel userspace
   kernel.fpu_sharing.float_disable.x86.fpu:
     extra_args: CONF_FILE=prj_x86.conf
     extra_configs:
       - CONFIG_X86_SSE_FP_MATH=n
     platform_allow: qemu_x86 qemu_x86_lakemont ehl_crb acrn_ehl_crb
-    tags: fpu kernel userspace
+    integration_platforms:
+      - qemu_x86
   kernel.fpu_sharing.float_disable.x86.sse:
     extra_args: CONF_FILE=prj_x86.conf
     extra_configs:
       - CONFIG_X86_SSE_FP_MATH=y
     platform_allow: qemu_x86 qemu_x86_lakemont ehl_crb acrn_ehl_crb
-    tags: fpu kernel userspace
+    integration_platforms:
+      - qemu_x86

--- a/tests/kernel/fpu_sharing/generic/testcase.yaml
+++ b/tests/kernel/fpu_sharing/generic/testcase.yaml
@@ -45,6 +45,8 @@ tests:
     extra_configs:
       - CONFIG_X86_SSE_FP_MATH=n
     platform_allow: qemu_x86 qemu_x86_lakemont
+    integration_platforms:
+      - qemu_x86
     slow: true
     tags: fpu kernel
     timeout: 600

--- a/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
+++ b/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
@@ -7,6 +7,8 @@ tests:
     tags: kernel memory_heap
     platform_allow: qemu_cortex_m3 qemu_cortex_m0 nsim_em nsim_em7d_v22 nsim_hs
       nsim_hs_mpuv6 nsim_hs5x nsim_hs6x qemu_arc_em qemu_arc_hs qemu_arc_hs6x
+    integration_platforms:
+      - qemu_cortex_m3
     extra_configs:
       - CONFIG_MULTITHREADING=n
   kernel.memory_heap.linker_generator:

--- a/tests/kernel/mem_heap/shared_multi_heap/testcase.yaml
+++ b/tests/kernel/mem_heap/shared_multi_heap/testcase.yaml
@@ -4,5 +4,7 @@
 tests:
   kernel.shared_multi_heap:
     platform_allow: qemu_cortex_a53 mps2_an521
+    integration_platforms:
+      - qemu_cortex_a53
     tags: kernel multi_heap
     harness: ztest

--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -18,4 +18,6 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     arch_allow: arm
     platform_allow: efr32_radio_brd4180a mps2_an521 nrf9160dk_nrf9160
+    integration_platforms:
+      - mps2_an521
     extra_args: CONFIG_MPU_GAP_FILLING=y

--- a/tests/kernel/mem_protect/userspace/testcase.yaml
+++ b/tests/kernel/mem_protect/userspace/testcase.yaml
@@ -15,4 +15,6 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     arch_allow: arm
     platform_allow: efr32_radio_brd4180a mps2_an521 nrf9160dk_nrf9160
+    integration_platforms:
+      - mps2_an521
     extra_args: CONFIG_MPU_GAP_FILLING=y

--- a/tests/kernel/mem_slab/mslab_api/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_api/testcase.yaml
@@ -5,6 +5,9 @@ tests:
     tags: kernel memory_slabs
     platform_allow: qemu_cortex_m3 qemu_cortex_m0 nsim_em nsim_em7d_v22 nsim_hs
       nsim_hs_mpuv6 nsim_hs5x nsim_hs6x qemu_arc_em qemu_arc_hs qemu_arc_hs6x
+    integration_platforms:
+      - qemu_cortex_m3
+      - qemu_arc_hs
     extra_configs:
       - CONFIG_MULTITHREADING=n
   kernel.memory_slabs.api.linker_generator:

--- a/tests/kernel/smp_boot_delay/testcase.yaml
+++ b/tests/kernel/smp_boot_delay/testcase.yaml
@@ -2,3 +2,5 @@ tests:
   kernel.multiprocessing.smp_boot_delay:
     tags: kernel smp
     platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20 intel_adsp_cavs25
+    integration_platforms:
+      - intel_adsp_cavs25

--- a/tests/kernel/threads/no-multithreading/testcase.yaml
+++ b/tests/kernel/threads/no-multithreading/testcase.yaml
@@ -6,3 +6,5 @@ tests:
       nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf51dk_nrf51422 nsim_em
       nsim_em7d_v22 nsim_hs nsim_hs_mpuv6 nsim_hs5x nsim_hs6x qemu_arc_em
       qemu_arc_hs qemu_arc_hs6x
+    integration_platforms:
+      - qemu_cortex_m0

--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -7,10 +7,15 @@ tests:
     platform_exclude: litex_vexriscv rv32m1_vega_zero_riscy rv32m1_vega_ri5cy
       nrf5340dk_nrf5340_cpunet
     tags: kernel timer userspace
+    integration_platforms:
+      - litex_vexriscv
   kernel.timer.no_multitheading:
     tags: kernel timer
     platform_allow: qemu_cortex_m3 nsim_em nsim_em7d_v22 nsim_hs nsim_hs_mpuv6
       nsim_hs5x nsim_hs6x qemu_arc_em qemu_arc_hs qemu_arc_hs6x
+    integration_platforms:
+      - qemu_cortex_m3
+      - nsim_em
     extra_configs:
       - CONFIG_MULTITHREADING=n
       - CONFIG_TEST_USERSPACE=n

--- a/tests/lib/devicetree/api/testcase.yaml
+++ b/tests/lib/devicetree/api/testcase.yaml
@@ -4,3 +4,5 @@ tests:
     # We only need this to run on one platform so use native_posix as it
     # will mostly likely be the fastest.
     platform_allow: native_posix qemu_x86 qemu_x86_64 qemu_cortex_m3
+    integration_platforms:
+      - native_posix

--- a/tests/net/ieee802154/6lo_fragment/testcase.yaml
+++ b/tests/net/ieee802154/6lo_fragment/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   net.ieee802154.fragment:
     platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix
     tags: net ieee802154 fragment
     min_ram: 48

--- a/tests/net/ieee802154/custom_l2/testcase.yaml
+++ b/tests/net/ieee802154/custom_l2/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   net.ieee802154.custom_l2:
     platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix
     tags: net ieee802154 l2
     min_ram: 16

--- a/tests/net/ieee802154/l2/testcase.yaml
+++ b/tests/net/ieee802154/l2/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   net.ieee802154.l2:
     platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix
     tags: net ieee802154 l2
     min_ram: 16

--- a/tests/net/pm/testcase.yaml
+++ b/tests/net/pm/testcase.yaml
@@ -2,6 +2,8 @@ common:
   # There is nothing hw specific to be tested here
   # so let's limit the test to a few platforms.
   platform_allow: qemu_x86 qemu_leon3 qemu_riscv32 qemu_riscv64
+  integration_platforms:
+    - qemu_x86
   depends_on: netif
 tests:
   net.pm:

--- a/tests/net/ptp/clock/testcase.yaml
+++ b/tests/net/ptp/clock/testcase.yaml
@@ -2,6 +2,8 @@ common:
   depends_on: netif
   # We can only run this in platforms that support PTP clock
   platform_allow: frdm_k64f sam_e70_xplained native_posix
+  integration_platforms:
+    - native_posix
 tests:
   net.ptp.clock:
     min_ram: 32

--- a/tests/net/socket/tls_ext/testcase.yaml
+++ b/tests/net/socket/tls_ext/testcase.yaml
@@ -2,5 +2,6 @@ common:
   tags: net socket tls
 tests:
   net.socket.tls.ext:
-    min_ram: 65536
-    platform_allow: qemu_cortex_m3 qemu_x86
+    platform_allow: qemu_x86
+    integration_platforms:
+      - qemu_x86

--- a/tests/net/traffic_class/testcase.yaml
+++ b/tests/net/traffic_class/testcase.yaml
@@ -1,5 +1,7 @@
 common:
   platform_allow: native_posix native_posix_64
+  integration_platforms:
+    - native_posix_64
   tags: net traffic_class
 tests:
   net.traffic_class.1:

--- a/tests/subsys/dfu/img_util/testcase.yaml
+++ b/tests/subsys/dfu/img_util/testcase.yaml
@@ -2,7 +2,11 @@ tests:
   dfu.image_util:
     platform_allow: nrf52840dk_nrf52840 native_posix native_posix_64
     tags: dfu_image_util
+    integration_platforms:
+      - nrf52840dk_nrf52840
   dfu.image_util.progressive:
     extra_args: OVERLAY_CONFIG=progressively_overlay.conf
     platform_allow:  nrf52840dk_nrf52840 native_posix native_posix_64
     tags: dfu_image_util
+    integration_platforms:
+      - nrf52840dk_nrf52840

--- a/tests/subsys/dfu/mcuboot/testcase.yaml
+++ b/tests/subsys/dfu/mcuboot/testcase.yaml
@@ -2,3 +2,5 @@ tests:
   dfu.mcuboot:
     platform_allow: nrf52840dk_nrf52840 native_posix native_posix_64
     tags: dfu_mcuboot
+    integration_platforms:
+      - nrf52840dk_nrf52840

--- a/tests/subsys/dfu/mcuboot_multi/testcase.yaml
+++ b/tests/subsys/dfu/mcuboot_multi/testcase.yaml
@@ -2,3 +2,5 @@ tests:
   dfu.mcuboot.multiimage:
     platform_allow: nrf52840dk_nrf52840 native_posix native_posix_64
     tags: dfu_mcuboot
+    integration_platforms:
+      - nrf52840dk_nrf52840

--- a/tests/subsys/fs/fat_fs_dual_drive/testcase.yaml
+++ b/tests/subsys/fs/fat_fs_dual_drive/testcase.yaml
@@ -2,3 +2,5 @@ tests:
   filesystem.fat.dual_drive:
     platform_allow: qemu_x86 native_posix qemu_leon3 qemu_riscv32 qemu_riscv64
     tags: filesystem
+    integration_platforms:
+      - native_posix

--- a/tests/subsys/fs/fcb/testcase.yaml
+++ b/tests/subsys/fs/fcb/testcase.yaml
@@ -3,6 +3,8 @@ tests:
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
         native_posix native_posix_64
     tags: flash_circural_buffer
+    integration_platforms:
+      - nrf52840dk_nrf52840
   filesystem.native_posix.fcb_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/native_posix_ev_0x00.overlay
     platform_allow: native_posix

--- a/tests/subsys/fs/littlefs/testcase.yaml
+++ b/tests/subsys/fs/littlefs/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   tags: filesystem
   platform_allow: nrf52840dk_nrf52840 native_posix native_posix_64 mimxrt1060_evk
+  integration_platforms:
+    - nrf52840dk_nrf52840
   modules:
     - littlefs
 tests:

--- a/tests/subsys/fs/multi-fs/testcase.yaml
+++ b/tests/subsys/fs/multi-fs/testcase.yaml
@@ -6,6 +6,10 @@ common:
 tests:
   filesystem.multifs:
     platform_allow: native_posix qemu_x86
+    integration_platforms:
+      - native_posix
   filesystem.fs_shell:
     extra_args: CONF_FILE="prj_fs_shell.conf"
     platform_allow: native_posix qemu_x86
+    integration_platforms:
+      - native_posix

--- a/tests/subsys/logging/log_backend_fs/testcase.yaml
+++ b/tests/subsys/logging/log_backend_fs/testcase.yaml
@@ -5,12 +5,20 @@ common:
 tests:
   logging.log_backend_fs.automounted:
     platform_allow: native_posix native_posix_64 nrf52840dk_nrf52840
+    integration_platforms:
+      - native_posix
   logging.log_backend_fs.manualmounted.native_posix:
     platform_allow: native_posix
     extra_args: DTC_OVERLAY_FILE="./boards/native_posix.overlay;./boards/automount.overlay"
+    integration_platforms:
+      - native_posix
   logging.log_backend_fs.manualmounted.native_posix_64:
     platform_allow: native_posix_64
     extra_args: DTC_OVERLAY_FILE="./boards/native_posix_64.overlay;./boards/automount.overlay"
+    integration_platforms:
+      - native_posix_64
   logging.log_backend_fs.manualmounted.nrf5840dk:
     platform_allow: nrf52840dk_nrf52840
     extra_args: DTC_OVERLAY_FILE="./boards/nrf52840dk_nrf52840.overlay;./boards/automount.overlay"
+    integration_platforms:
+      - nrf52840dk_nrf52840

--- a/tests/subsys/openthread/testcase.yaml
+++ b/tests/subsys/openthread/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   openthread.radio:
     platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix
     tags: ot_radio

--- a/tests/subsys/pm/policy_api/testcase.yaml
+++ b/tests/subsys/pm/policy_api/testcase.yaml
@@ -4,6 +4,8 @@
 common:
   tags: pm
   platform_allow: native_posix native_posix_64
+  integration_platforms:
+    - native_posix
 tests:
   pm.policy.api.app:
     extra_configs:

--- a/tests/subsys/pm/power_mgmt_soc/testcase.yaml
+++ b/tests/subsys/pm/power_mgmt_soc/testcase.yaml
@@ -3,3 +3,5 @@ tests:
     platform_allow: cc26x2r1_launchxl cc1352r1_launchxl mec15xxevb_assy6853 mec1501modular_assy6885
        nucleo_wb55rg nucleo_l476rg twr_ke18f
     tags: pm
+    integration_platforms:
+      - mec15xxevb_assy6853

--- a/tests/subsys/settings/fcb/testcase.yaml
+++ b/tests/subsys/settings/fcb/testcase.yaml
@@ -1,10 +1,14 @@
 tests:
   system.settings.fcb.raw:
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: settings_fcb
     extra_configs:
     - CONFIG_ARM_MPU=n
     - CONFIG_STDOUT_CONSOLE=y
   system.settings.fcb.raw_native_posix:
     platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix
     tags: settings_fcb

--- a/tests/subsys/settings/fcb_init/testcase.yaml
+++ b/tests/subsys/settings/fcb_init/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   system.settings.fcb:
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: settings_intialization_fcb

--- a/tests/subsys/settings/functional/fcb/testcase.yaml
+++ b/tests/subsys/settings/functional/fcb/testcase.yaml
@@ -1,8 +1,12 @@
 tests:
   system.settings.functional.fcb:
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 native_posix native_posix_64
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: settings_fcb
   system.settings.functional.fcb.chosen:
     extra_args: DTC_OVERLAY_FILE=./chosen.overlay
     platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix
     tags: settings_fcb

--- a/tests/subsys/settings/functional/file/testcase.yaml
+++ b/tests/subsys/settings/functional/file/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   system.settings.file:
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 native_posix native_posix_64
+    integration_platforms:
+      - native_posix
     tags: settings_file

--- a/tests/subsys/settings/functional/nvs/testcase.yaml
+++ b/tests/subsys/settings/functional/nvs/testcase.yaml
@@ -9,4 +9,6 @@ tests:
   system.settings.functional.nvs.dk:
     extra_args: OVERLAY_CONFIG=mpu.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: settings_nvs

--- a/tests/subsys/storage/flash_map/testcase.yaml
+++ b/tests/subsys/storage/flash_map/testcase.yaml
@@ -2,12 +2,18 @@ tests:
   storage.flash_map:
     platform_allow: nrf51dk_nrf51422 qemu_x86 native_posix native_posix_64
     tags: flash_map
+    integration_platforms:
+      - native_posix
   storage.flash_map.mpu:
     extra_args: OVERLAY_CONFIG=overlay-mpu.conf
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 frdm_k64f hexiwear_k64
                         twr_ke18f
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: flash_map
   storage.flash_map.mbedtls:
     extra_args: OVERLAY_CONFIG=overlay-mbedtls.conf
     platform_allow: nrf51dk_nrf51422 qemu_x86 native_posix native_posix_64
     tags: flash_map
+    integration_platforms:
+      - native_posix

--- a/tests/subsys/usb/os_desc/testcase.yaml
+++ b/tests/subsys/usb/os_desc/testcase.yaml
@@ -2,3 +2,5 @@ tests:
   usb.osdesc:
     platform_allow: native_posix native_posix_64 frdm_k64f
     tags: usb osdesc
+    integration_platforms:
+      - native_posix


### PR DESCRIPTION
integration_platforms help us control what get built/executed in CI and
for each PR submitted. They do not filter out platforms, instead they
just minimize the amount of builds/testing for a particular
tests/sample.
Tests still run on all supported platforms when not in integration mode.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
