### PR TITLE
sys: linear_range: fix index calculation when spanning across groups

### DIFF
--- a/include/zephyr/sys/linear_range.h
+++ b/include/zephyr/sys/linear_range.h
@@ -288,7 +288,11 @@ static inline int linear_range_group_get_win_index(const struct linear_range *r,
 	int ret = -EINVAL;
 
 	for (size_t i = 0U; (ret != 0) && (i < r_cnt); i++) {
-		ret = linear_range_get_win_index(&r[i], val_min, val_max, idx);
+		int32_t r_val_max = linear_range_get_max_value(&r[i]);
+
+		ret = linear_range_get_win_index(
+			&r[i], val_min, MAX(val_min, MIN(r_val_max, val_max)),
+			idx);
 	}
 
 	return ret;

--- a/tests/lib/linear_range/src/main.c
+++ b/tests/lib/linear_range/src/main.c
@@ -301,6 +301,10 @@ ZTEST(linear_range, test_linear_range_get_win_index)
 	zassert_equal(ret, 0);
 	zassert_equal(idx, 5U);
 
+	ret = linear_range_group_get_win_index(r, r_cnt, 140, 400, &idx);
+	zassert_equal(ret, 0);
+	zassert_equal(idx, 6U);
+
 	ret = linear_range_group_get_win_index(r, r_cnt, 400, 400, &idx);
 	zassert_equal(ret, 0);
 	zassert_equal(idx, 12U);


### PR DESCRIPTION
When dealing with groups, the specified window in
linear_range_group_get_win_index can span across multiple groups. In the current implementation, if maximum value was not in the same sub-window as the minimum value the function would return -EINVAL. This patch fixes the problem and updates test cases to cover such scenario.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>