### PR TITLE
spi: fix cbprintf warnings for pointer formatting

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -312,7 +312,7 @@ void spi_context_buffers_setup(struct spi_context *ctx,
 		" tx buf/len %p/%zu, rx buf/len %p/%zu",
 		ctx->current_tx, ctx->tx_count,
 		ctx->current_rx, ctx->rx_count,
-		ctx->tx_buf, ctx->tx_len, ctx->rx_buf, ctx->rx_len);
+		(void *) ctx->tx_buf, ctx->tx_len, (void *) ctx->rx_buf, ctx->rx_len);
 }
 
 static ALWAYS_INLINE
@@ -340,7 +340,7 @@ void spi_context_update_tx(struct spi_context *ctx, uint8_t dfs, uint32_t len)
 		ctx->tx_buf += dfs * len;
 	}
 
-	LOG_DBG("tx buf/len %p/%zu", ctx->tx_buf, ctx->tx_len);
+	LOG_DBG("tx buf/len %p/%zu", (void *) ctx->tx_buf, ctx->tx_len);
 }
 
 static ALWAYS_INLINE
@@ -387,7 +387,7 @@ void spi_context_update_rx(struct spi_context *ctx, uint8_t dfs, uint32_t len)
 		ctx->rx_buf += dfs * len;
 	}
 
-	LOG_DBG("rx buf/len %p/%zu", ctx->rx_buf, ctx->rx_len);
+	LOG_DBG("rx buf/len %p/%zu", (void *) ctx->rx_buf, ctx->rx_len);
 }
 
 static ALWAYS_INLINE


### PR DESCRIPTION
Cbprintf warns about printing char* as %p, this fixes that by casting to void* where required.

```console
[00:00:00.551,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: current_tx %p (%zu), current_rx %p (%zu), tx buf/len %p/%zu, rx buf/len %p/%zu" argument:5
[00:00:00.041,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: tx buf/len %p/%zu" argument:1
[00:00:00.042,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: rx buf/len %p/%zu" argument:1
[00:00:00.041,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: current_tx %p (%zu), current_rx %p (%zu), tx buf/len %p/%zu, rx buf/len %p/%zu" argument:7
```
