### PR TITLE
driver: wifi: esp32: linker changes to free up iram

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -219,7 +219,6 @@ config ESP32_WIFI_SW_COEXIST_ENABLE
 
 config ESP32_WIFI_IRAM_OPT
 	bool "WiFi IRAM speed optimization"
-	default y
 	help
 	  Select this option to place frequently called Wi-Fi library functions in IRAM.
 	  When this option is disabled, more than 10Kbytes of IRAM memory will be saved
@@ -227,7 +226,6 @@ config ESP32_WIFI_IRAM_OPT
 
 config ESP32_WIFI_RX_IRAM_OPT
 	bool "WiFi RX IRAM speed optimization"
-	default y
 	help
 	  Select this option to place frequently called Wi-Fi library RX functions in IRAM.
 	  When this option is disabled, more than 17Kbytes of IRAM memory will be saved

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -6,6 +6,8 @@
 
 #define DT_DRV_COMPAT espressif_esp32_wifi
 
+#define _POSIX_C_SOURCE 200809
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(esp32_wifi, CONFIG_WIFI_LOG_LEVEL);
 

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -39,10 +39,12 @@
 #define IROM_SEG_ORG 0x400D0020
 #define IROM_SEG_LEN 0x330000-0x20
 #define IROM_SEG_ALIGN 0x4
+#define IRAM_SEG_LEN 0x20000
 #else
 #define IROM_SEG_ORG 0x400D0000
 #define IROM_SEG_LEN 0x330000
 #define IROM_SEG_ALIGN 0x10000
+#define IRAM_SEG_LEN 0x13000
 #endif
 
 MEMORY
@@ -54,7 +56,7 @@ MEMORY
   #ifdef CONFIG_ESP32_NETWORK_CORE
   iram0_0_seg(RX): org = 0x40080000, len = 0x08000
   #else
-  iram0_0_seg(RX): org = 0x40080000, len = 0x20000
+  iram0_0_seg(RX): org = 0x40080000, len = IRAM_SEG_LEN
   #endif
 
   irom0_0_seg(RX): org = IROM_SEG_ORG, len = IROM_SEG_LEN
@@ -343,10 +345,6 @@ SECTIONS
     *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
     *libesp32.a:panic.*(.literal .text .literal.* .text.*)
     *librtc.a:(.literal .text .literal.* .text.*)
-    *libsubsys__net__l2__ethernet.a:(.literal .text .literal.* .text.*)
-    *libsubsys__net__lib__config.a:(.literal .text .literal.* .text.*)
-    *libsubsys__net__ip.a:(.literal .text .literal.* .text.*)
-    *libsubsys__net.a:(.literal .text .literal.* .text.*)
     *libarch__xtensa__core.a:(.literal .text .literal.* .text.*)
     *libkernel.a:(.literal .text .literal.* .text.*)
     *libsoc.a:rtc_*.*(.literal .text .literal.* .text.*)


### PR DESCRIPTION
This PR adds some linker changes to increase IRAM area.
This also fixes IRAM length when MCUBoot is enabled.
Fix build warnings when newlibc is enabled.  

Fixes #52242