### PR TITLE
Bluetooth: Host: l2cap: disconnect when PDU > MPS

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2487,6 +2487,12 @@ static void l2cap_chan_le_recv(struct bt_l2cap_le_chan *chan,
 		return;
 	}
 
+	if (buf->len > chan->rx.mps) {
+		LOG_WRN("PDU size > MPS (%u > %u)", buf->len, chan->rx.mps);
+		bt_l2cap_chan_disconnect(&chan->chan);
+		return;
+	}
+
 	/* Check if segments already exist */
 	if (chan->_sdu) {
 		l2cap_chan_le_recv_seg(chan, buf);


### PR DESCRIPTION
The Bluetooth spec states that a K-frame exceeding the device's MPS should trigger a disconnection of the channel.

Fixes two PTS tests that verify this behavior:
L2CAP/LE/CFC/BV-27-C
L2CAP/ECFC/BV-34-C

The current behavior is a silent truncation, which is not very nice for the user, even if the spec would allow it.

Fixes #52228 
Fixes #51174