### PR TITLE
scripts: compliance: check for merge commits

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -43,6 +43,18 @@ jobs:
         west init -l . || true
         west update 2>&1 1> west.update.log || west update 2>&1 1> west.update2.log
 
+    - name: Run Compliance Tests (no rebase)
+      continue-on-error: true
+      id: compliance-norebase
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        PR_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        export ZEPHYR_BASE=$PWD
+        git log --pretty=oneline origin/${BASE_REF}..${PR_SHA}
+        ./scripts/ci/check_compliance.py --annotate -m MergeCommits \
+        -c origin/${BASE_REF}..${PR_SHA}
+
     - name: Run Compliance Tests
       continue-on-error: true
       id: compliance

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1059,6 +1059,21 @@ class BinaryFiles(ComplianceTest):
                 self.failure(f"Binary file not allowed: {fname}")
 
 
+class MergeCommits(ComplianceTest):
+    """
+    Check that the range does not contain any merge commits.
+    """
+    name = "MergeCommits"
+    doc = "No merge commits allowed."
+    path_hint = "<git-top>"
+
+    def run(self):
+        for commits in git("log", "--format=%h %p", COMMIT_RANGE).splitlines():
+            commit, *parents = commits.split(" ")
+            if len(parents) > 1:
+                self.failure(f"Merge commits not allowed: {commit} <- {*parents,}")
+
+
 def init_logs(cli_arg):
     # Initializes logging
 


### PR DESCRIPTION
Add a compliance check that fails if the PR contains merge commits.

```
$ ./scripts/ci/check_compliance.py --annotate -m MergeCommits -c origin/main..
Running MergeCommits     tests in /usr/local/google/home/fabiobaltieri/zephyrproject/zephyr ...

Complete results in compliance.xml
$ git merge origin/main
...
$ ./scripts/ci/check_compliance.py --annotate -m MergeCommits -c origin/main..
Running MergeCommits     tests in /usr/local/google/home/fabiobaltieri/zephyrproject/zephyr ...
1 checks failed
ERROR   : Test MergeCommits failed: 
Merge commits not allowed: f7ad71f40c <- ('e721f60484', '5c773ae45e')

Complete results in compliance.xml
$ 
```