### PR TITLE
Bluetooth: Add Kconfig template for log inheriting

### DIFF
--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -326,10 +326,8 @@ int bt_tbs_set_uri_scheme_list(uint8_t bearer_index, const char **uri_list,
  */
 void bt_tbs_register_cb(struct bt_tbs_cb *cbs);
 
-#if defined(CONFIG_BT_TBS_LOG_LEVEL_DBG)
 /** @brief Prints all calls of all services to the debug log */
 void bt_tbs_dbg_print_calls(void);
-#endif /* defined(CONFIG_BT_TBS_LOG_LEVEL_DBG) */
 
 struct bt_tbs_client_call_state {
 	uint8_t index;

--- a/subsys/bluetooth/common/Kconfig.template.log_config_bt
+++ b/subsys/bluetooth/common/Kconfig.template.log_config_bt
@@ -14,17 +14,9 @@
 #		the new kconfig is forced to max verbosity.
 #		Example: "BT_DEBUG_HCI_CORE"
 
-parent-module = BT
-
-choice "$(module)_LOG_LEVEL_CHOICE"
-	default $(module)_LOG_LEVEL_INHERIT if y
-
-config $(module)_LOG_LEVEL_INHERIT
-	bool "Inherit $(parent-module)_LOG_LEVEL"
-endchoice
-
 config $(module)_LOG_LEVEL
 	default 4 if $(legacy-debug-sym)
-	default $(parent-module)_LOG_LEVEL if $(module)_LOG_LEVEL_INHERIT
 
-source "subsys/logging/Kconfig.template.log_config"
+module := $(module)
+parent-module := BT
+source "subsys/logging/Kconfig.template.log_config_inherit"

--- a/subsys/logging/Kconfig.template.log_config_inherit
+++ b/subsys/logging/Kconfig.template.log_config_inherit
@@ -1,0 +1,27 @@
+# Copyright (c) 2022 Nordic Semicoductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Usage:
+# This template allow module to use the parent module log level by default.
+#
+# The following arguments are mandatory:
+# 	- module:
+#		Name of the new log module.
+#		Example: "BT_HCI_CORE"
+#	- parent-module:
+#		Name of the module that will be inherited by the new module.
+#		Example: "BT"
+
+choice "$(module)_LOG_LEVEL_CHOICE"
+	default $(module)_LOG_LEVEL_INHERIT if y
+
+config $(module)_LOG_LEVEL_INHERIT
+	bool "Inherit $(parent-module)_LOG_LEVEL"
+
+endchoice
+
+config $(module)_LOG_LEVEL
+	default $(parent-module)_LOG_LEVEL if $(module)_LOG_LEVEL_INHERIT
+
+module := $(module)
+source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
Add a new Kconfig template that allow log modules to inherit their log level from their parent module.
For example, the logs used in the Bluetooth audio like `BT_AUDIO_STREAM_LOG_LEVEL` can inherit their level from `BT_AUDIO_LOG_LEVEL`.

Update the Bluetooth specific Kconfig legacy log template to use the new template.

Also, remove unnecessary conditionnal definition of `bt_tbs_dbg_print_calls` in `subsys/bluetooth/audio/tbs.h`.