### PR TITLE
drivers: spi_mcux_lpspi: fix baudrate change when switching devices

### DIFF
--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -226,6 +226,15 @@ static int spi_mcux_configure(const struct device *dev,
 		return -EINVAL;
 	}
 
+	/* Setting the baud rate in LPSPI_MasterInit requires module to be disabled */
+	LPSPI_Enable(base, false);
+	while ((base->CR & LPSPI_CR_MEN_MASK) != 0U) {
+		/* Wait until LPSPI is disabled. Datasheet:
+		 * After writing 0, MEN (Module Enable) remains set until the LPSPI has completed
+		 * the current transfer and is idle.
+		 */
+	}
+
 	LPSPI_MasterInit(base, &master_config, clock_freq);
 
 	LPSPI_MasterTransferCreateHandle(base, &data->handle,


### PR DESCRIPTION
When configuring an LPSPI module for a new device with different baud rate, the module needs to be disabled for the baud rate change to take effect. This adds the necessary call to LPSPI_Enable before initializing the module.

Fixes #51177
Fixes #52628

