### PR TITLE
github: workflows: compliance: Ensure no merge commits

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -37,6 +37,9 @@ jobs:
         git config --global user.email "you@example.com"
         git config --global user.name "Your Name"
         git remote -v
+        # Ensure there's no merge commits in the PR
+        [[ "$(git rev-list --merges --count origin/${BASE_REF}..)" == "0" ]] || \
+        (echo "::error ::Merge commits not allowed, rebase instead";false)
         git rebase origin/${BASE_REF}
         # debug
         git log  --pretty=oneline | head -n 10


### PR DESCRIPTION
Add a simple one-liner that checks for "0" in the count of commits with
two or more parents. If a merge commit is present the output will be "1"
or higher, failing the job.


Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>

This is what it looks like:

![image](https://user-images.githubusercontent.com/12450381/204567049-cb968e2f-0fd7-43e5-8683-d3b41d671e9b.png)

![image](https://user-images.githubusercontent.com/12450381/204566986-1068eda8-fda7-443f-95a3-9537d4cada8b.png)
