### PR TITLE
twister: ignore unit tests/EFI images with --show-footprint

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -854,7 +854,7 @@ class ProjectBuilder(FilterBuilder):
     @staticmethod
     def calc_size(instance: TestInstance, from_buildlog: bool):
         if instance.status not in ["error", "failed", "skipped"]:
-            if not instance.platform.type in ["native", "qemu"]:
+            if not instance.platform.type in ["native", "qemu", "unit"]:
                 generate_warning = bool(instance.platform.type == "mcu")
                 size_calc = instance.calculate_sizes(from_buildlog=from_buildlog, generate_warning=generate_warning)
                 instance.metrics["used_ram"] = size_calc.get_used_ram()

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -254,6 +254,8 @@ class TestInstance:
         fns = glob.glob(os.path.join(self.build_dir, "zephyr", "*.elf"))
         fns.extend(glob.glob(os.path.join(self.build_dir, "zephyr", "*.exe")))
         fns = [x for x in fns if '_pre' not in x]
+        # EFI elf files
+        fns = [x for x in fns if 'zefi' not in x]
         if len(fns) != 1:
             raise BuildError("Missing/multiple output ELF binary")
         return fns[0]

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -246,9 +246,9 @@ class TestInstance:
         elf_filepath = self.get_elf_file()
         buildlog_filepath = self.get_buildlog_file() if from_buildlog else ''
         return SizeCalculator(elf_filename=elf_filepath,
-        extra_sections=self.testsuite.extra_sections,
-        buildlog_filepath=buildlog_filepath,
-        generate_warning=generate_warning)
+                            extra_sections=self.testsuite.extra_sections,
+                            buildlog_filepath=buildlog_filepath,
+                            generate_warning=generate_warning)
 
     def get_elf_file(self) -> str:
         fns = glob.glob(os.path.join(self.build_dir, "zephyr", "*.elf"))


### PR DESCRIPTION
Ignore unit tests and EFI binaries when calculating footprints with
--show-footprint, or we will get a build error.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
