### PR TITLE
dts: arm: st: h7: stm32h723: add CAN2 and CAN3

### DIFF
--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -79,6 +79,40 @@
 			#size-cells = <0>;
 			status = "disabled";
 		};
+
+		can {
+			can2: can@4000A400 {
+				compatible = "st,stm32h7-fdcan";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				reg = <0x4000A400 0x400>, <0x4000ac00 0x350>;
+				reg-names = "m_can", "message_ram";
+				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
+				interrupts = <20 0>, <22 0>, <63 0>;
+				interrupt-names = "LINE_0", "LINE_1", "CALIB";
+				sjw = <1>;
+				sample-point = <875>;
+				sjw-data = <1>;
+				sample-point-data = <875>;
+				status = "disabled";
+			};
+
+			can3: can@4000D400 {
+				compatible = "st,stm32h7-fdcan";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				reg = <0x4000D400 0x400>, <0x4000ac00 0x350>;
+				reg-names = "m_can", "message_ram";
+				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
+				interrupts = <159 0>, <160 0>, <63 0>;
+				interrupt-names = "LINE_0", "LINE_1", "CALIB";
+				sjw = <1>;
+				sample-point = <875>;
+				sjw-data = <1>;
+				sample-point-data = <875>;
+				status = "disabled";
+			};
+		};
 	};
 
 	/* D1 domain, AXI SRAM (128KB with shared ITCM 192KB as `TCM_AXI_SHARED` is `000`) */


### PR DESCRIPTION
I have test and it is working with CAN API on nucleo_h723zg board

Signed-off-by: Manojkumar Subramaniam <manoj@electrolance.com>