### PR TITLE
drivers: hwinfo: Implement hwinfo_get_device_id for ESP32-C3

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -118,7 +118,7 @@ config HWINFO_SAM0
 config HWINFO_ESP32
 	bool "ESP32 device ID"
 	default y
-	depends on SOC_ESP32
+	depends on SOC_ESP32 || SOC_ESP32C3
 	help
 	  Enable ESP32 hwinfo driver.
 

--- a/drivers/hwinfo/hwinfo_esp32.c
+++ b/drivers/hwinfo/hwinfo_esp32.c
@@ -12,8 +12,13 @@
 
 ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
+#ifdef CONFIG_SOC_ESP32C3
+	uint32_t rdata1 = sys_read32(EFUSE_RD_MAC_SPI_SYS_0_REG);
+	uint32_t rdata2 = sys_read32(EFUSE_RD_MAC_SPI_SYS_1_REG);
+#else
 	uint32_t rdata1 = sys_read32(EFUSE_BLK0_RDATA1_REG);
 	uint32_t rdata2 = sys_read32(EFUSE_BLK0_RDATA2_REG);
+#endif
 	uint8_t id[6];
 
 	/* The first word provides the lower 32 bits of the MAC


### PR DESCRIPTION
ESP32-C3 uses different fuse addresses for storing the MAC addr, but the the format is the same. Tested to return the same value as the function from esp-idf.