### PR TITLE
shell: devmem: add devmem dump subcommand

### DIFF
--- a/include/zephyr/posix/unistd.h
+++ b/include/zephyr/posix/unistd.h
@@ -43,6 +43,12 @@ static inline int gethostname(char *buf, size_t len)
 
 #endif /* CONFIG_POSIX_API */
 
+#ifdef CONFIG_GETOPT
+int getopt(int argc, char *const argv[], const char *optstring);
+extern char *optarg;
+extern int opterr, optind, optopt;
+#endif
+
 unsigned sleep(unsigned int seconds);
 int usleep(useconds_t useconds);
 

--- a/lib/os/crc_shell.c
+++ b/lib/os/crc_shell.c
@@ -5,10 +5,14 @@
  */
 
 #include <errno.h>
-#include <getopt.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#ifdef CONFIG_ARCH_POSIX
+#include <unistd.h>
+#else
+#include <zephyr/posix/unistd.h>
+#endif
 
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
@@ -71,7 +75,6 @@ static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
 	enum crc_type type = CRC32_IEEE;
 
 	optind = 1;
-	optreset = 1;
 
 	while ((rv = getopt(argc, argv, "fhlp:rs:t:")) != -1) {
 		switch (rv) {

--- a/lib/posix/getopt/getopt.c
+++ b/lib/posix/getopt/getopt.c
@@ -30,6 +30,11 @@
  */
 
 #include <string.h>
+#ifdef CONFIG_ARCH_POSIX
+#include <unistd.h>
+#else
+#include <zephyr/posix/unistd.h>
+#endif
 #include "getopt.h"
 #include "getopt_common.h"
 

--- a/lib/posix/getopt/getopt.h
+++ b/lib/posix/getopt/getopt.h
@@ -28,11 +28,7 @@ struct getopt_state {
 #endif
 };
 
-extern int opterr;	/* if error message should be printed */
-extern int optind;	/* index into parent argv vector */
-extern int optopt;	/* character checked for validity */
 extern int optreset;	/* reset getopt */
-extern char *optarg;	/* argument associated with option */
 
 #define no_argument        0
 #define required_argument  1
@@ -57,27 +53,6 @@ void getopt_init(void);
 
 /* Function returns getopt_state structure for the current thread. */
 struct getopt_state *getopt_state_get(void);
-
-/**
- * @brief Parses the command-line arguments.
- *
- * It is based on FreeBSD implementation.
- *
- * @param[in] argc	Arguments count.
- * @param[in] argv	Arguments.
- * @param[in] options	String containing the legitimate option characters.
- *
- * @return		If an option was successfully found, function returns
- *			the option character.
- * @return		If options have been detected that is not in @p options
- *			function will return '?'.
- *			If function encounters an option with a missing
- *			argument, then the return value depends on the first
- *			character in optstring: if it is ':', then ':' is
- *			returned; otherwise '?' is returned.
- * @return -1		If all options have been parsed.
- */
-int getopt(int nargc, char *const nargv[], const char *ostr);
 
 /**
  * @brief Parses the command-line arguments.

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -13,6 +13,12 @@
 #include <zephyr/usb/usb_device.h>
 #include <ctype.h>
 
+#ifdef CONFIG_ARCH_POSIX
+#include <unistd.h>
+#else
+#include <zephyr/posix/unistd.h>
+#endif
+
 LOG_MODULE_REGISTER(app);
 
 extern void foo(void);

--- a/subsys/shell/modules/Kconfig
+++ b/subsys/shell/modules/Kconfig
@@ -42,5 +42,6 @@ config DATE_SHELL
 config DEVMEM_SHELL
 	bool "Devmem shell"
 	default y if !SHELL_MINIMAL
+	select GETOPT
 	help
 	  This shell command provides read/write access to physical memory.

--- a/subsys/shell/modules/devmem_service.c
+++ b/subsys/shell/modules/devmem_service.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020 Intel Corporation
  * Copyright (c) 2021 Antmicro <www.antmicro.com>
+ * Copyright (c) 2022 Meta
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +10,11 @@
 #include <zephyr/device.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/byteorder.h>
+#ifdef CONFIG_ARCH_POSIX
+#include <unistd.h>
+#else
+#include <zephyr/posix/unistd.h>
+#endif
 
 static inline bool is_ascii(uint8_t data)
 {
@@ -25,6 +31,122 @@ static bool littleendian;
 
 #define CHAR_CAN 0x18
 #define CHAR_DC1 0x11
+
+#ifndef BITS_PER_BYTE
+#define BITS_PER_BYTE 8
+#endif
+
+static int memory_dump(const struct shell *sh, mem_addr_t phys_addr, size_t size, uint8_t width)
+{
+	uint32_t value;
+	size_t data_offset;
+	mm_reg_t addr;
+	const size_t vsize = width / BITS_PER_BYTE;
+	uint8_t data[SHELL_HEXDUMP_BYTES_IN_LINE];
+
+#if defined(CONFIG_MMU) || defined(CONFIG_PCIE)
+	device_map((mm_reg_t *)&addr, phys_addr, size, K_MEM_CACHE_NONE);
+
+	shell_print(sh, "Mapped 0x%lx to 0x%lx\n", phys_addr, addr);
+#else
+	addr = phys_addr;
+#endif /* defined(CONFIG_MMU) || defined(CONFIG_PCIE) */
+
+	for (; size > 0;
+	     addr += SHELL_HEXDUMP_BYTES_IN_LINE, size -= MIN(size, SHELL_HEXDUMP_BYTES_IN_LINE)) {
+		for (data_offset = 0;
+		     size >= vsize && data_offset + vsize <= SHELL_HEXDUMP_BYTES_IN_LINE;
+		     data_offset += vsize) {
+			switch (width) {
+			case 8:
+				value = sys_read8(addr + data_offset);
+				data[data_offset] = value;
+				break;
+			case 16:
+				value = sys_read16(addr + data_offset);
+				if (IS_ENABLED(CONFIG_BIG_ENDIAN)) {
+					value = __bswap_16(value);
+				}
+
+				data[data_offset] = (uint8_t)value;
+				value >>= 8;
+				data[data_offset + 1] = (uint8_t)value;
+				break;
+			case 32:
+				value = sys_read32(addr + data_offset);
+				if (IS_ENABLED(CONFIG_BIG_ENDIAN)) {
+					value = __bswap_32(value);
+				}
+
+				data[data_offset] = (uint8_t)value;
+				value >>= 8;
+				data[data_offset + 1] = (uint8_t)value;
+				value >>= 8;
+				data[data_offset + 2] = (uint8_t)value;
+				value >>= 8;
+				data[data_offset + 3] = (uint8_t)value;
+				break;
+			default:
+				shell_fprintf(sh, SHELL_NORMAL, "Incorrect data width\n");
+				return -EINVAL;
+			}
+		}
+
+		shell_hexdump_line(sh, addr, data, MIN(size, SHELL_HEXDUMP_BYTES_IN_LINE));
+	}
+
+	return 0;
+}
+
+static int cmd_dump(const struct shell *sh, size_t argc, char **argv)
+{
+	int rv;
+	size_t size = -1;
+	size_t width = 32;
+	mem_addr_t addr = -1;
+
+	optind = 1;
+	while ((rv = getopt(argc, argv, "a:s:w:")) != -1) {
+		switch (rv) {
+		case 'a':
+			addr = (mem_addr_t)strtoul(optarg, NULL, 16);
+			if (addr == 0 && errno == EINVAL) {
+				shell_error(sh, "invalid addr '%s'", optarg);
+				return -EINVAL;
+			}
+			break;
+		case 's':
+			size = (size_t)strtoul(optarg, NULL, 0);
+			if (size == 0 && errno == EINVAL) {
+				shell_error(sh, "invalid size '%s'", optarg);
+				return -EINVAL;
+			}
+			break;
+		case 'w':
+			width = (size_t)strtoul(optarg, NULL, 0);
+			if (width == 0 && errno == EINVAL) {
+				shell_error(sh, "invalid width '%s'", optarg);
+				return -EINVAL;
+			}
+			break;
+		case '?':
+		default:
+			return -EINVAL;
+		}
+	}
+
+	if (addr == -1) {
+		shell_error(sh, "'-a <address>' is mandatory");
+		return -EINVAL;
+	}
+
+	if (size == -1) {
+		shell_error(sh, "'-s <size>' is mandatory");
+		return -EINVAL;
+	}
+
+	return memory_dump(sh, addr, size, width);
+}
 
 static int set_bypass(const struct shell *sh, shell_bypass_cb_t bypass)
 {
@@ -229,6 +351,10 @@ static int cmd_devmem(const struct shell *sh, size_t argc, char **argv)
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_devmem,
+			       SHELL_CMD_ARG(dump, NULL,
+					     "Usage:\n"
+					     "devmem dump -a <address> -s <size> [-w <width>]\n",
+					     cmd_dump, 4, 6),
 			       SHELL_CMD_ARG(load, NULL,
 					     "Usage:\n"
 					     "devmem load [options] [address]\n"


### PR DESCRIPTION
2 commits:
* move `getopt()` declaration to `<zephyr/posix/unistd.h>`
* shell: devmem: add devmem dump subcommand

This allows the caller to dump a region of memory rather than dumping one byte (word, etc) at a time. Additionally, it respects alignment requirements so it works for e.g. 32-bit register accesses.

E.g.
```
uart:~$ devmem dump -a 0x0 -s 42 -w 8
00000000: 18 35 00 20 ed 9a 00 00  f1 89 00 00 85 9a 00 00 |.5. .... ........|
00000010: 85 9a 00 00 85 9a 00 00  85 9a 00 00 00 00 00 00 |........ ........|
00000020: 00 00 00 00 00 00 00 00  00 00                   |........ ..      |
```
