### PR TITLE
ITE: soc: it81xx2: Add new variant of it81xx2cx related configuration

### DIFF
--- a/dts/riscv/ite/it81202cx.dtsi
+++ b/dts/riscv/ite/it81202cx.dtsi
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 ITE Corporation. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+
+/ {
+	soc {
+		sram0: memory@80100000 {
+			compatible = "mmio-sram";
+			reg = <0x80100000 DT_SIZE_K(128)>;
+		};
+	};
+};
+

--- a/dts/riscv/ite/it81302cx.dtsi
+++ b/dts/riscv/ite/it81302cx.dtsi
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 ITE Corporation. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+
+/ {
+	soc {
+		sram0: memory@80100000 {
+			compatible = "mmio-sram";
+			reg = <0x80100000 DT_SIZE_K(128)>;
+		};
+	};
+};
+

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.it81202cx
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.it81202cx
@@ -1,0 +1,12 @@
+# Copyright (c) 2022 ITE Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_IT81202_CX
+
+config SOC
+	default "it81202cx"
+
+config SOC_IT8XXX2_GPIO_GROUP_K_L_DEFAULT_PULL_DOWN
+	default y
+
+endif

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.it81302cx
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.it81302cx
@@ -1,0 +1,12 @@
+# Copyright (c) 2022 ITE Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_IT81302_CX
+
+config SOC
+	default "it81302cx"
+
+config SOC_IT8XXX2_GPIO_GROUP_K_L_DEFAULT_PULL_DOWN
+	default n
+
+endif

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
@@ -14,7 +14,7 @@ config SOC_IT8XXX2
 	select RISCV_ISA_EXT_ZIFENCEI
 	# Workaround mul instruction bug, see:
 	# https://www.ite.com.tw/uploads/product_download/it81202-bx-chip-errata.pdf
-	#select RISCV_ISA_EXT_M
+	select RISCV_ISA_EXT_M if !(SOC_IT81302_BX || SOC_IT81202_BX)
 	select RISCV_ISA_EXT_A
 	select RISCV_ISA_EXT_C
 
@@ -31,6 +31,12 @@ config SOC_IT81302_BX
 
 config SOC_IT81202_BX
 	bool "IT81202 BX version"
+
+config SOC_IT81302_CX
+	bool "IT81302 CX version"
+
+config SOC_IT81202_CX
+	bool "IT81202 CX version"
 
 endchoice
 

--- a/soc/riscv/riscv-ite/it8xxx2/ilm.c
+++ b/soc/riscv/riscv-ite/it8xxx2/ilm.c
@@ -185,8 +185,13 @@ static const struct ilm_config ilm_config = {
 		SCAR_REG(14),
 		SCAR_REG(15),
 	}};
+#if defined(CONFIG_SOC_IT81202_CX) || defined(CONFIG_SOC_IT81302_CX)
+BUILD_ASSERT(ARRAY_SIZE(ilm_config.scar_regs) * ILM_BLOCK_SIZE == KB(60),
+	     "Maximum number of SCAR registers defined for 60k RAM size");
+#else
 BUILD_ASSERT(ARRAY_SIZE(ilm_config.scar_regs) * ILM_BLOCK_SIZE == KB(RAM_SIZE),
 	     "Wrong number of SCAR registers defined for RAM size");
+#endif
 BUILD_ASSERT(ARRAY_SIZE(ilm_config.scar_regs) <= DT_REG_SIZE_BY_IDX(ILM_NODE, 0) * 8,
 	     "Size of ILM control register block is too small for number of SCARs");
 


### PR DESCRIPTION
Add new variant configuration of it81202cx and it81302cx. This cx variant of it81xx2 changes are as follows:
1. SRAM size will increase from 60k to 128k.
2. Configurable ILM size is still 60k.
3. Support M extension of RISC-V.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>