### PR TITLE
ITE drivers/pwm/it8xxx2: don't gate pwm clock when set cycle

### DIFF
--- a/drivers/pwm/pwm_ite_it8xxx2.c
+++ b/drivers/pwm/pwm_ite_it8xxx2.c
@@ -99,9 +99,6 @@ static int pwm_it8xxx2_set_cycles(const struct device *dev,
 	uint32_t actual_freq = 0xffffffff, target_freq, deviation, cxcprs, ctr;
 	uint64_t pwm_clk_src;
 
-	/* PWM channel clock source gating before configuring */
-	pwm_enable(dev, 0);
-
 	/* Select PWM inverted polarity (ex. active-low pulse) */
 	if (flags & PWM_POLARITY_INVERTED) {
 		*reg_pwmpol |= BIT(ch);


### PR DESCRIPTION
When pwm_it8xxx2_set_cycles() is called, we disable the pwm clock at the beginning and enable it at the end, so there is a more than 1ms pwm low pulse when every time changing the cycle. The low pulse would let some fans go to idle mode, so we don't gate the pwm clock.

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>