### PR TITLE
scripts: west_commands: runners: remove deprecated options

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -485,10 +485,7 @@ class DeviceHandler(Handler):
                 board_id = hardware.probe_id or hardware.id
                 product = hardware.product
                 if board_id is not None:
-                    if runner == "pyocd":
-                        command_extra_args.append("--board-id")
-                        command_extra_args.append(board_id)
-                    elif runner == "nrfjprog":
+                    if runner in ("pyocd", "nrfjprog"):
                         command_extra_args.append("--dev-id")
                         command_extra_args.append(board_id)
                     elif runner == "openocd" and product == "STM32 STLink":

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -5,7 +5,6 @@
 '''Runner for debugging with J-Link.'''
 
 import argparse
-from functools import partial
 import logging
 import os
 from pathlib import Path
@@ -14,7 +13,7 @@ import subprocess
 import sys
 import tempfile
 
-from runners.core import ZephyrBinaryRunner, RunnerCaps, depr_action
+from runners.core import ZephyrBinaryRunner, RunnerCaps
 
 try:
     import pylink
@@ -93,10 +92,6 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         # Optional:
         parser.add_argument('--loader', required=False, dest='loader',
                             help='specifies a loader type')
-        parser.add_argument('--id', required=False, dest='dev_id',
-                            action=partial(depr_action,
-                                           replacement='-i/--dev-id'),
-                            help='Deprecated: use -i/--dev-id instead')
         parser.add_argument('--iface', default='swd',
                             help='interface to use, default is swd')
         parser.add_argument('--speed', default='auto',

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -5,7 +5,6 @@
 
 '''Runner for flashing with nrfjprog.'''
 
-from functools import partial
 import os
 from pathlib import Path
 import shlex
@@ -13,7 +12,7 @@ import subprocess
 import sys
 from re import fullmatch, escape
 
-from runners.core import ZephyrBinaryRunner, RunnerCaps, depr_action
+from runners.core import ZephyrBinaryRunner, RunnerCaps
 
 try:
     from intelhex import IntelHex
@@ -70,10 +69,6 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--softreset', required=False,
                             action='store_true',
                             help='use reset instead of pinreset')
-        parser.add_argument('--snr', required=False, dest='dev_id',
-                            action=partial(depr_action,
-                                           replacement='-i/--dev-id'),
-                            help='Deprecated: use -i/--dev-id instead')
         parser.add_argument('--force', required=False,
                             action='store_true',
                             help='Flash even if the result cannot be guaranteed.')

--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -4,12 +4,10 @@
 
 '''Runner for pyOCD .'''
 
-from functools import partial
 import os
 from os import path
 
-from runners.core import ZephyrBinaryRunner, RunnerCaps, \
-    BuildConfiguration, depr_action
+from runners.core import ZephyrBinaryRunner, RunnerCaps, BuildConfiguration
 
 DEFAULT_PYOCD_GDB_PORT = 3333
 DEFAULT_PYOCD_TELNET_PORT = 4444
@@ -109,10 +107,6 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
                                 DEFAULT_PYOCD_TELNET_PORT))
         parser.add_argument('--tui', default=False, action='store_true',
                             help='if given, GDB uses -tui')
-        parser.add_argument('--board-id', dest='dev_id',
-                            action=partial(depr_action,
-                                           replacement='-i/--dev-id'),
-                            help='Deprecated: use -i/--dev-id instead')
 
     @classmethod
     def tool_opt_help(cls) -> str:

--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -473,7 +473,7 @@ def test_nrfjprog_create(check_call, get_snr, require, test_case,
     if test_case.softreset:
         args.append('--softreset')
     if test_case.snr:
-        args.extend(['--snr', TEST_OVR_SNR])
+        args.extend(['--dev-id', TEST_OVR_SNR])
     if test_case.erase:
         args.append('--erase')
     if test_case.recover:


### PR DESCRIPTION
The --snr (nrfjprog) --id (jlink) and --board-id (pyocd) options were
deprecated a long time ago in favor of --dev-id. It is time to remove
them.

Ref. https://github.com/zephyrproject-rtos/zephyr/commit/5ee719ee9d61dd10e646b3a68a72115304735d9b

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>