### PR TITLE
checkpatch: Remove ext/ from excludes

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -29,4 +29,3 @@
 --ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
 --ignore ENOSYS
 --ignore IS_ENABLED_CONFIG
---exclude ext


### PR DESCRIPTION
The ext/ folder does not exist anymore, remove it from the checkpatch config file.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>