### PR TITLE
Two minor missing fixups re. Peripheral CIS Create 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -154,6 +154,9 @@ static void llcp_rp_cc_tx_rsp(struct ll_conn *conn, struct proc_ctx *ctx)
 
 	pdu = (struct pdu_data *)tx->pdu;
 
+	ctx->data.cis_create.conn_event_count = MAX(ctx->data.cis_create.conn_event_count,
+						    cc_event_counter(conn) + 2);
+
 	llcp_pdu_encode_cis_rsp(ctx, pdu);
 	ctx->tx_opcode = pdu->llctrl.opcode;
 
@@ -368,6 +371,7 @@ static void rp_cc_state_wait_rx_cis_ind(struct ll_conn *conn, struct proc_ctx *c
 
 	switch (evt) {
 	case RP_CC_EVT_CIS_IND:
+		llcp_pdu_decode_cis_ind(ctx, pdu);
 		if (!ull_peripheral_iso_setup(&pdu->llctrl.cis_ind, ctx->data.cis_create.cig_id,
 					 ctx->data.cis_create.cis_handle)) {
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -432,8 +432,19 @@ static void rp_cc_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint
 				void *param)
 {
 	uint16_t start_event_count;
+	struct ll_conn_iso_group *cig;
 
+	cig = ll_conn_iso_group_get_by_id(ctx->data.cis_create.cig_id);
 	start_event_count = ctx->data.cis_create.conn_event_count;
+	LL_ASSERT(cig);
+
+	if (!cig->started) {
+		/* Start ISO peripheral one event before the requested instant
+		 * for first CIS. This is done to be able to accept small CIS
+		 * offsets.
+		 */
+		start_event_count--;
+	}
 
 	if (is_instant_reached_or_passed(start_event_count,
 					 cc_event_counter(conn))) {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -716,6 +716,7 @@ void llcp_rp_cc_reject(struct ll_conn *conn, struct proc_ctx *ctx);
 
 void llcp_pdu_decode_cis_req(struct proc_ctx *ctx, struct pdu_data *pdu);
 void llcp_pdu_encode_cis_rsp(struct proc_ctx *ctx, struct pdu_data *pdu);
+void llcp_pdu_decode_cis_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
 void llcp_pdu_encode_cis_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
 void llcp_pdu_decode_cis_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
 void llcp_pdu_encode_cis_req(struct proc_ctx *ctx, struct pdu_data *pdu);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -828,6 +828,15 @@ void llcp_pdu_decode_cis_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 	*/
 }
 
+void llcp_pdu_decode_cis_ind(struct proc_ctx *ctx, struct pdu_data *pdu)
+{
+	ctx->data.cis_create.conn_event_count =
+		sys_le16_to_cpu(pdu->llctrl.cis_ind.conn_event_count);
+	/* The remainder of the cis ind is decoded by ull_peripheral_iso_setup, so
+	 * no need to do it here too
+	 */
+}
+
 void llcp_pdu_encode_cis_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
 {
 	struct pdu_data_llctrl_cis_rsp *p;


### PR DESCRIPTION
Some differences between down stream and up stream code bases have been identified. Minor changes made locally that did not find their way up.
1. In case of start of first CIS in a CIG, we should initiate the ISO peripheral sooner to allow for small CIS offset
2. In case a CIS_IND reaches the Peripheral procedure late, the peripheral will suggest a postponement of 'instant' to allow for time to set up