### PR TITLE
MAINTAINERS: update collaborator list

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1985,11 +1985,10 @@ Espressif Platforms:
   status: maintained
   maintainers:
     - sylvioalves
-    - glaubermaroto
-    - uLipe
   collaborators:
     - LucasTambor
     - marekmatej
+    - uLipe
   files:
     - drivers/*/*esp32*.c
     - boards/xtensa/esp32*/


### PR DESCRIPTION
glaubermaroto is no longer working on Zephyr.
uLipe isn't maintaining the support.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>