### PR TITLE
Misc. ISO CIS Peripheral Fixes and Improvements

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1650,6 +1650,9 @@ void ll_rx_mem_release(void **node_rx)
 				conn->lll.link_tx_free = link;
 
 				ll_conn_release(conn);
+			} else if (IS_CIS_HANDLE(rx_free->handle)) {
+				ll_rx_link_quota_inc();
+				ll_rx_release(rx_free);
 			}
 		}
 		break;

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -789,15 +789,15 @@ void ll_reset(void)
 	LL_ASSERT(!err);
 #endif /* CONFIG_BT_OBSERVER */
 
-#if defined(CONFIG_BT_CTLR_ISO)
-	err = ull_iso_reset();
-	LL_ASSERT(!err);
-#endif /* CONFIG_BT_CTLR_ISO */
-
 #if defined(CONFIG_BT_CTLR_CONN_ISO)
 	err = ull_conn_iso_reset();
 	LL_ASSERT(!err);
 #endif /* CONFIG_BT_CTLR_CONN_ISO */
+
+#if defined(CONFIG_BT_CTLR_ISO)
+	err = ull_iso_reset();
+	LL_ASSERT(!err);
+#endif /* CONFIG_BT_CTLR_ISO */
 
 #if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO)
 	err = ull_peripheral_iso_reset();

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -624,12 +624,13 @@ uint8_t ll_terminate_ind_send(uint16_t handle, uint8_t reason)
 	if (IS_CIS_HANDLE(handle)) {
 #if !defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
 		cis = ll_iso_stream_connected_get(handle);
+		/* Disallow if CIS is not connected */
 		if (!cis) {
-			return BT_HCI_ERR_UNKNOWN_CONN_ID;
+			return BT_HCI_ERR_CMD_DISALLOWED;
 		}
 
 		conn = ll_connected_get(cis->lll.acl_handle);
-		/* Is conn still connected? */
+		/* Disallow if ACL has disconnected */
 		if (!conn) {
 			return BT_HCI_ERR_CMD_DISALLOWED;
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -542,6 +542,7 @@ static int init_reset(void)
 		cis = ll_conn_iso_stream_get(handle);
 		cis->cis_id = 0;
 		cis->group  = NULL;
+		cis->lll.link_tx_free = NULL;
 	}
 
 	conn_accept_timeout = CONN_ACCEPT_TIMEOUT_DEFAULT;
@@ -961,6 +962,11 @@ static void cis_tx_lll_flush(void *param)
 		link = memq_dequeue(lll->memq_tx.tail, &lll->memq_tx.head,
 				    (void **)&tx);
 	}
+
+	LL_ASSERT(!lll->link_tx_free);
+	link = memq_deinit(&lll->memq_tx.head, &lll->memq_tx.tail);
+	LL_ASSERT(link);
+	lll->link_tx_free = link;
 
 	/* Resume CIS teardown in ULL_HIGH context */
 	mfys[cig->lll.handle].param = &cig->lll;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -159,8 +159,10 @@ struct ll_conn_iso_stream *ll_iso_stream_connected_get(uint16_t handle)
 	}
 
 	cis = ll_conn_iso_stream_get(handle);
-	if ((cis->group == NULL) || (cis->lll.handle != handle)) {
-		/* CIS does not belong to a group or has inconsistent handle */
+	if ((cis->group == NULL) || (cis->lll.handle != handle) || !cis->established) {
+		/* CIS does not belong to a group, has inconsistent handle or is
+		 * not yet established.
+		 */
 		return NULL;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -259,10 +259,6 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 #endif /* CONFIG_BT_CTLR_SYNC_ISO */
 
 #if defined(CONFIG_BT_CTLR_SYNC_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
-#if defined(CONFIG_BT_CTLR_CONN_ISO)
-	isoal_source_handle_t source_handle;
-	uint8_t max_octets;
-#endif /* CONFIG_BT_CTLR_CONN_ISO */
 	isoal_sink_handle_t sink_handle;
 	uint32_t stream_sync_delay;
 	uint32_t group_sync_delay;
@@ -275,11 +271,10 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 	uint8_t role;
 
 #if defined(CONFIG_BT_CTLR_CONN_ISO)
-	struct ll_iso_datapath *dp_in = NULL;
-	struct ll_iso_datapath *dp_out = NULL;
-
 	struct ll_conn_iso_stream *cis = NULL;
 	struct ll_conn_iso_group *cig = NULL;
+	isoal_source_handle_t source_handle;
+	uint8_t max_octets;
 
 	if (IS_CIS_HANDLE(handle)) {
 		struct ll_conn *conn;
@@ -310,8 +305,6 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 		}
 
 		cig = cis->group;
-		dp_in = cis->hdr.datapath_in;
-		dp_out = cis->hdr.datapath_out;
 	}
 
 	/* If the Host attempts to set a data path with a Connection Handle
@@ -322,8 +315,8 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 		return BT_HCI_ERR_UNKNOWN_CONN_ID;
 	}
 
-	if ((path_dir == BT_HCI_DATAPATH_DIR_HOST_TO_CTLR  && dp_in) ||
-	    (path_dir == BT_HCI_DATAPATH_DIR_CTLR_TO_HOST && dp_out)) {
+	if ((path_dir == BT_HCI_DATAPATH_DIR_HOST_TO_CTLR && cis->hdr.datapath_in) ||
+	    (path_dir == BT_HCI_DATAPATH_DIR_CTLR_TO_HOST && cis->hdr.datapath_out)) {
 		/* Data path has been set up, can only do setup once */
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -197,11 +197,13 @@ uint8_t ll_read_iso_tx_sync(uint16_t handle, uint16_t *seq,
 }
 
 /* Must be implemented by vendor */
-__weak bool ll_data_path_sink_create(struct ll_iso_datapath *datapath,
+__weak bool ll_data_path_sink_create(uint16_t handle,
+				     struct ll_iso_datapath *datapath,
 				     isoal_sink_sdu_alloc_cb *sdu_alloc,
 				     isoal_sink_sdu_emit_cb *sdu_emit,
 				     isoal_sink_sdu_write_cb *sdu_write)
 {
+	ARG_UNUSED(handle);
 	ARG_UNUSED(datapath);
 
 	*sdu_alloc = NULL;
@@ -406,7 +408,8 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 			isoal_sink_sdu_write_cb sdu_write;
 
 			/* Request vendor sink callbacks for path */
-			if (ll_data_path_sink_create(dp, &sdu_alloc, &sdu_emit, &sdu_write)) {
+			if (ll_data_path_sink_create(handle, dp, &sdu_alloc, &sdu_emit,
+						     &sdu_write)) {
 				err = isoal_sink_create(handle, role, framed,
 							burst_number, flush_timeout,
 							sdu_interval, iso_interval,
@@ -506,7 +509,7 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 		isoal_sink_sdu_write_cb sdu_write;
 
 		/* Request vendor sink callbacks for path */
-		if (ll_data_path_sink_create(dp, &sdu_alloc, &sdu_emit, &sdu_write)) {
+		if (ll_data_path_sink_create(handle, dp, &sdu_alloc, &sdu_emit, &sdu_write)) {
 			err = isoal_sink_create(handle, role, framed,
 						burst_number, flush_timeout,
 						sdu_interval, iso_interval,
@@ -1538,6 +1541,11 @@ void ll_iso_rx_mem_release(void **node_rx)
 	RXFIFO_ALLOC(iso_rx, UINT8_MAX);
 }
 #endif /* CONFIG_BT_CTLR_SYNC_ISO) || CONFIG_BT_CTLR_CONN_ISO */
+
+struct ll_iso_datapath *ull_iso_datapath_alloc(void)
+{
+	return mem_acquire(&datapath_free);
+}
 
 void ull_iso_datapath_release(struct ll_iso_datapath *dp)
 {

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -742,7 +742,12 @@ static isoal_status_t ll_iso_test_sdu_emit(const struct isoal_sink             *
 			break;
 		}
 
-		if (framed) {
+		/* In framed mode, we may start incrementing the SDU counter when rx_sdu_counter
+		 * becomes non zero (initial state), or in case of zero-based counting, if zero
+		 * is actually the first valid SDU counter received.
+		 */
+		if (framed && (cis->hdr.test_mode.rx_sdu_counter ||
+			       (sdu_frag->sdu.status == ISOAL_SDU_STATUS_VALID))) {
 			cis->hdr.test_mode.rx_sdu_counter++;
 		}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso_internal.h
@@ -6,6 +6,7 @@
 
 int ull_iso_init(void);
 int ull_iso_reset(void);
+struct ll_iso_datapath *ull_iso_datapath_alloc(void);
 void ull_iso_datapath_release(struct ll_iso_datapath *dp);
 void ll_iso_rx_put(memq_link_t *link, void *rx);
 void *ll_iso_rx_get(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -1118,6 +1118,15 @@ static void rp_comm_tx(struct ll_conn *conn, struct proc_ctx *ctx)
 		ctx->rx_opcode = PDU_DATA_LLCTRL_TYPE_UNUSED;
 		break;
 #endif /* CONFIG_BT_CTLR_SCA_UPDATE */
+#if !defined(CONFIG_BT_CTLR_CENTRAL_ISO) || !defined(CONFIG_BT_CTLR_PERIPHERAL_ISO)
+	case PROC_CIS_TERMINATE:
+		/* Only possible response to LL_CIS_TERMINATE is if a central or peripheral
+		 * does not have ISO support. Then reject with error 'unsupported feature'.
+		 */
+		llcp_pdu_encode_reject_ext_ind(pdu, PDU_DATA_LLCTRL_TYPE_CIS_TERMINATE_IND,
+					       BT_HCI_ERR_UNSUPP_FEATURE_PARAM_VAL);
+		break;
+#endif /* !CONFIG_BT_CTLR_CENTRAL_ISO || !CONFIG_BT_CTLR_PERIPHERAL_ISO */
 	default:
 		/* Unknown procedure */
 		LL_ASSERT(0);
@@ -1275,10 +1284,17 @@ static void rp_comm_send_rsp(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 		break;
 #if defined(CONFIG_BT_CTLR_CENTRAL_ISO) || defined(CONFIG_BT_CTLR_PERIPHERAL_ISO)
 	case PROC_CIS_TERMINATE:
-		/* No response */
+		/* Make sure role is configured for ISO, otherwise reject */
+		if ((!IS_ENABLED(CONFIG_BT_CTLR_CENTRAL_ISO) &&
+			conn->lll.role == BT_HCI_ROLE_CENTRAL) ||
+		    (!IS_ENABLED(CONFIG_BT_CTLR_PERIPHERAL_ISO) &&
+			conn->lll.role == BT_HCI_ROLE_PERIPHERAL)) {
+			rp_comm_tx(conn, ctx);
+			/* Fall through */
+		}
+
 		llcp_rr_complete(conn);
 		ctx->state = RP_COMMON_STATE_IDLE;
-
 		break;
 #endif /* CONFIG_BT_CTLR_CENTRAL_ISO || CONFIG_BT_CTLR_PERIPHERAL_ISO */
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)

--- a/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
@@ -129,11 +129,12 @@ static isoal_status_t test_sink_sdu_write(void *dbuf,
 }
 
 
-bool ll_data_path_sink_create(struct ll_iso_datapath *datapath,
+bool ll_data_path_sink_create(uint16_t handle, struct ll_iso_datapath *datapath,
 			      isoal_sink_sdu_alloc_cb *sdu_alloc,
 			      isoal_sink_sdu_emit_cb *sdu_emit,
 			      isoal_sink_sdu_write_cb *sdu_write)
 {
+	ARG_UNUSED(handle);
 	ARG_UNUSED(datapath);
 
 	*sdu_alloc = test_sink_sdu_alloc;


### PR DESCRIPTION
**Bluetooth: controller: Fix LL_CIS_TERMINATE RX node leak**
Reusing NODE_RX_TYPE_TERMINATE for CIS requires special deallocation
handling to prevent memory leak.

**Bluetooth: controller: Fix error in ISO reset sequence**
To avoid races, ull_conn_iso_reset must be performed before higher level
ull_iso_reset.

**Bluetooth: controller: Reject CIS_REQ with invalid PHY**
Send LL_REJECT_EXT_IND if a LL_CIS_REQ was recevied with invalid PHY
specification.
Fixes EBQ tests:
  /LL/CIS/PER/BI-02-C
  /LL/CIS/PER/BI-03-C
  /LL/CIS/PER/BI-05-C
  /LL/CIS/PER/BI-06-C

**Bluetooth: controller: Fix CIS restart state de-initialization**
When a CIS is terminated, the associated link pool must be de-
initialized to be ready for next creation of the corresponding
instance in memory.

**Bluetooth: controller: Don't consider CIS connected before established**
Make sure ll_iso_stream_connected_get returns NULL until CIS is
established. Always return DISALLOWED when trying to disconnect a CIS
which is not connected.
 
**Bluetooth: controller: Fix ISO Test Mode SDU counting for framed**
For framed case, the internal RX SDU counter would increment regardless
of whether the first valid SDU was received or not. According to spec,
SDU counter synchronization is done from first valid SDU.
 
**Bluetooth: controller: Minor ISO refactoring due to compiler issue**
Function ll_setup_iso_path has a construction which causes proprietary
compiler to generate incorrect code. As a workaround, local data path
pointer variables are eliminated.

**Bluetooth: controller: Add handle to ll_data_path_sink_create**
For making handle available in vendor sink creation, add ISO handle
to function prototype.
Expose datapath allocation via new ull_iso_datapath_alloc function.

**Bluetooth: controller: Reject CIS_TERMINATE when unsupported for role**
If a central or peripheral is not configured for ISO connected streams,
reject a remote LL_CIS_TERMINATE_IND procedure, responding with an
unsupported feature error (BT_HCI_ERR_UNSUPP_FEATURE).

This fixes EBQ test /LL/PAC/CEN/BV-01-C.

Signed-off-by: Morten Priess <mtpr@oticon.com>