### PR TITLE
cmake: implement build infrastructure for supporting SCA tools.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,12 +301,6 @@ if(CONFIG_COMPILER_COLOR_DIAGNOSTICS)
 zephyr_compile_options($<TARGET_PROPERTY:compiler,diagnostic>)
 endif()
 
-if("${SPARSE}" STREQUAL "y")
-  list(APPEND TOOLCHAIN_C_FLAGS -D__CHECKER__)
-  # Avoid compiler "attribute directive ignored" warnings
-  list(APPEND TOOLCHAIN_C_FLAGS -Wno-attributes)
-endif()
-
 zephyr_compile_options(
   ${TOOLCHAIN_C_FLAGS}
 )

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -5,39 +5,8 @@ set_ifndef(C++ g++)
 # Configures CMake for using GCC, this script is re-used by several
 # GCC-based toolchains
 
-if("${SPARSE}" STREQUAL "y")
-  # No search PATHS because we need more than cgcc in the default PATH
-  find_program(CMAKE_C_COMPILER cgcc REQUIRED)
-  message(STATUS "Found sparse: ${CMAKE_C_COMPILER}")
-
-  find_program(SPARSE_REAL_COMPILER ${CROSS_COMPILE}${CC} PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH REQUIRED)
-
-  # We know what REAL_CC _must_ be, so why do we ask the user to define it?  Because CMake
-  # cannot set (evil) build time env variables at configure time:
-  # https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#how-can-i-get-or-set-environment-variables
-  # As of Sep. 2022, sparse/cgcc has unfortunately no --real-cc option as it should.
-  #
-  # In theory we could define REAL_CC ourselves here and fix the configure-time
-  # --print-file-name below (and maybe others). Then ask the user to define REAL_CC later
-  # at _build_ time. But in practice who would define environment variables at build time
-  # _only_?  So best to fail early and clearly here.
-  if ("$ENV{REAL_CC}" STREQUAL "")
-    message(FATAL_ERROR
-      "The only way to override its 'cc' default when cross-compiling with sparse is "
-      "unfortunately an environment variable. So you _must_ set REAL_CC at both configuration "
-      "time and build time to: ${SPARSE_REAL_COMPILER}")
-  else() # check ENV{REAL_CC}
-    file(REAL_PATH "${SPARSE_REAL_COMPILER}" real_compiler_rp)
-    file(REAL_PATH "$ENV{REAL_CC}" env_real_cc_rp)
-    cmake_path(COMPARE "${real_compiler_rp}" EQUAL "${env_real_cc_rp}" expected_env_REAL_CC)
-    if(NOT expected_env_REAL_CC)
-      message(FATAL_ERROR
-        "Unexpected environment variable REAL_CC: $ENV{REAL_CC}, must be: ${SPARSE_REAL_COMPILER}")
-    endif()
-  endif()
-else() # SPARSE
-  find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC} PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-endif()
+find_package(Deprecated COMPONENTS SPARSE)
+find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}${CC} PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
 if(${CMAKE_C_COMPILER} STREQUAL CMAKE_C_COMPILER-NOTFOUND)
   message(FATAL_ERROR "C compiler ${CROSS_COMPILE}${CC} not found - Please check your toolchain installation")

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -66,12 +66,6 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     zephyr_get_include_directories_for_lang(C current_includes)
     get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 
-    if("${SPARSE}" STREQUAL "y")
-      set(ld_command ${SPARSE_REAL_COMPILER})
-    else()
-      set(ld_command ${CMAKE_C_COMPILER})
-    endif()
-
     add_custom_command(
       OUTPUT ${linker_script_gen}
       DEPENDS
@@ -80,7 +74,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
       ${extra_dependencies}
       # NB: 'linker_script_dep' will use a keyword that ends 'DEPENDS'
       ${linker_script_dep}
-      COMMAND ${ld_command}
+      COMMAND ${CMAKE_C_COMPILER}
       -x assembler-with-cpp
       ${NOSYSDEF_CFLAG}
       -MD -MF ${linker_script_gen}.dep -MT ${linker_script_gen}

--- a/cmake/modules/FindDeprecated.cmake
+++ b/cmake/modules/FindDeprecated.cmake
@@ -78,6 +78,18 @@ if("XTOOLS" IN_LIST Deprecated_FIND_COMPONENTS)
                       "Please set ZEPHYR_TOOLCHAIN_VARIANT to 'zephyr'")
 endif()
 
+if("SPARSE" IN_LIST Deprecated_FIND_COMPONENTS)
+  list(REMOVE_ITEM Deprecated_FIND_COMPONENTS SPARSE)
+  # This code was deprecated after Zephyr v3.2.0
+  if(SPARSE)
+    message(DEPRECATION
+        "Setting SPARSE=${SPARSE} is deprecated. "
+        "Please set ZEPHYR_SCA_VARIANT to 'sparse'"
+    )
+    set_ifndef(ZEPHYR_SCA_VARIANT sparse)
+  endif()
+endif()
+
 if("SOURCES" IN_LIST Deprecated_FIND_COMPONENTS)
   list(REMOVE_ITEM Deprecated_FIND_COMPONENTS SOURCES)
   if(SOURCES)

--- a/cmake/modules/FindScaTools.cmake
+++ b/cmake/modules/FindScaTools.cmake
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2022, Nordic Semiconductor ASA
+
+# 'SCA_ROOT' is a prioritized list of directories where SCA tools may
+# be found. It always includes ${ZEPHYR_BASE} at the lowest priority.
+list(APPEND SCA_ROOT ${ZEPHYR_BASE})
+
+zephyr_get(ZEPHYR_SCA_VARIANT)
+
+if(ScaTools_FIND_REQUIRED AND NOT DEFINED ZEPHYR_SCA_VARIANT)
+  message(FATAL_ERROR "ScaTools required but 'ZEPHYR_SCA_VARIANT' is not set. "
+                      "Please set 'ZEPHYR_SCA_VARIANT' to desired tool."
+  )
+endif()
+
+if(NOT DEFINED ZEPHYR_SCA_VARIANT)
+  return()
+endif()
+
+foreach(root ${SCA_ROOT})
+  if(EXISTS ${root}/cmake/sca/${ZEPHYR_SCA_VARIANT}/sca.cmake)
+    include(${root}/cmake/sca/${ZEPHYR_SCA_VARIANT}/sca.cmake)
+    return()
+  endif()
+endforeach()
+
+message(FATAL_ERROR "ZEPHYR_SCA_VARIANT set to '${ZEPHYR_SCA_VARIANT}' but no "
+                    "implementation for '${ZEPHYR_SCA_VARIANT}' found. "
+                    "SCA_ROOTs searched: ${SCA_ROOT}"
+)

--- a/cmake/modules/kernel.cmake
+++ b/cmake/modules/kernel.cmake
@@ -23,6 +23,7 @@
 include_guard(GLOBAL)
 
 find_package(TargetTools)
+find_package(ScaTools)
 
 # As this module is not intended for direct loading, but should be loaded through
 # find_package(Zephyr) then it won't be loading any Zephyr CMake modules by itself.

--- a/cmake/modules/root.cmake
+++ b/cmake/modules/root.cmake
@@ -33,6 +33,9 @@ zephyr_file(APPLICATION_ROOT SOC_ROOT)
 # Convert paths to absolute, relative from APPLICATION_SOURCE_DIR
 zephyr_file(APPLICATION_ROOT ARCH_ROOT)
 
+# Convert paths to absolute, relative from APPLICATION_SOURCE_DIR
+zephyr_file(APPLICATION_ROOT SCA_ROOT)
+
 if(unittest IN_LIST Zephyr_FIND_COMPONENTS)
   # Zephyr used in unittest mode, use dedicated unittest root.
   set(BOARD_ROOT ${ZEPHYR_BASE}/subsys/testsuite)

--- a/cmake/sca/sparse/sca.cmake
+++ b/cmake/sca/sparse/sca.cmake
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2022, Nordic Semiconductor ASA
+
+find_program(SPARSE_COMPILER cgcc REQUIRED)
+message(STATUS "Found sparse: ${SPARSE_COMPILER}")
+
+# Create sparse.cmake which will be called as compiler launcher.
+# sparse.cmake will ensure that REAL_CC is set correctly in environment before
+# cgcc is called, thereby ensuring correct behavior of sparse without a need
+# for REAL_CC to be set in environment.
+configure_file(${CMAKE_CURRENT_LIST_DIR}/sparse.template ${CMAKE_BINARY_DIR}/sparse.cmake @ONLY)
+
+set(launch_environment ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/sparse.cmake --)
+set(CMAKE_C_COMPILER_LAUNCHER ${launch_environment} CACHE INTERNAL "")
+
+list(APPEND TOOLCHAIN_C_FLAGS -D__CHECKER__)
+# Avoid compiler "attribute directive ignored" warnings
+list(APPEND TOOLCHAIN_C_FLAGS -Wno-attributes)

--- a/cmake/sca/sparse/sparse.template
+++ b/cmake/sca/sparse/sparse.template
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2022, Nordic Semiconductor ASA
+
+# Everything before `--` are arguments for cmake invocation, those must be ignored.
+# First argument after `--` is the real compiler, but that is defined in REAL_CC
+# as environment variable for cgcc, hence that must also be ignored, thus first
+# argument to be passed to sparse is 2nd argument after `--`.
+foreach(i RANGE ${CMAKE_ARGC})
+  if("${CMAKE_ARGV${i}}" STREQUAL "--")
+    math(EXPR end_of_options "${i} + 2")
+    break()
+  endif()
+endforeach()
+
+foreach(i RANGE ${end_of_options} ${CMAKE_ARGC})
+  list(APPEND ARGS ${CMAKE_ARGV${i}})
+endforeach()
+execute_process(COMMAND @CMAKE_COMMAND@ -E env REAL_CC=@CMAKE_C_COMPILER@ @SPARSE_COMPILER@ ${ARGS})

--- a/doc/develop/index.rst
+++ b/doc/develop/index.rst
@@ -17,5 +17,6 @@ Developing with Zephyr
    modules.rst
    west/index
    test/index
+   sca/index
    toolchains/index
    tools/index

--- a/doc/develop/modules.rst
+++ b/doc/develop/modules.rst
@@ -724,6 +724,10 @@ Build settings supported in the :file:`module.yml` file are:
   :file:`<arch_root>/arch` folder.
 - ``module_ext_root``: Contains :file:`CMakeLists.txt` and :file:`Kconfig` files
   for Zephyr modules, see also :ref:`modules_module_ext_root`.
+- ``sca_root``: Contains additional :ref:`SCA <sca>` tool implementations
+  available to the build system. Each tool must be located in
+  :file:`<sca_root>/sca/<tool>` folder. The folder must contain a
+  :file:`sca.cmake`.
 
 Example of a :file:`module.yaml` file containing additional roots, and the
 corresponding file system layout.

--- a/doc/develop/sca/index.rst
+++ b/doc/develop/sca/index.rst
@@ -1,0 +1,64 @@
+.. _sca:
+
+Static Code Analysis (SCA)
+##########################
+
+Support for static code analysis tools in Zephyr is possible through CMake.
+
+The build setting :makevar:`ZEPHYR_SCA_VARIANT` can be used to specify the SCA
+tool to use. :envvar:`ZEPHYR_SCA_VARIANT` is also supported as
+:ref:`environment variable <env_vars>`.
+
+Use ``-DZEPHYR_SCA_VARIANT=<tool>``, for example ``-DZEPHYR_SCA_VARIANT=sparse``
+to enable the static analysis tool ``sparse``.
+
+.. _sca_infrastructure:
+
+SCA Tool infrastructure
+***********************
+
+Support for an SCA tool is implemented in a file:`sca.cmake` file.
+The file:`sca.cmake` must be placed under file:`<SCA_ROOT>/cmake/sca/<tool>/sca.cmake`.
+Zephyr itself is always added as an :makevar:`SCA_ROOT` but the build system offers the
+possibility to add additional folders to the :makevar:`SCA_ROOT` setting.
+
+You can provide support for out of tree SCA tools by creating the following
+structure:
+
+.. code-block:: none
+
+   <sca_root>/                 # Custom SCA root
+   └── cmake/
+       └── sca/
+           └── <tool>/         # Name of SCA tool, this is the value given to ZEPHYR_SCA_VARIANT
+               └── sca.cmake   # CMake code that confgures the tool to be used with Zephyr
+
+To add ``foo`` under ``/path/to/my_tools/cmake/sca`` create the following structure:
+
+.. code-block:: none
+
+   /path/to/my_tools
+            └── cmake/
+                └── sca/
+                    └── foo/
+                        └── sca.cmake
+
+To use ``foo`` as SCA tool you must then specify ``-DZEPHYR_SCA_VARIANT=foo``.
+
+Remember to add ``/path/to/my_tools`` to :makevar:`SCA_ROOT`.
+
+:makevar:`SCA_TOOL` can be set as a regular CMake setting using
+``-DSCA_ROOT=<sca_root>``, or added by a Zephyr module in its :file:`module.yml`
+file, see :ref:`Zephyr Modules - Build settings <modules_build_settings>`
+
+.. _sca_native_tools:
+
+Native SCA Tool support
+***********************
+
+The following is a list of SCA tools natively supported by Zephyr build system.
+
+.. toctree::
+   :maxdepth: 1
+
+   sparse

--- a/doc/develop/sca/sparse.rst
+++ b/doc/develop/sca/sparse.rst
@@ -19,8 +19,8 @@ Running with sparse
 *******************
 
 To run a sparse verification build :ref:`west build <west-building>` should be
-called with a ``-DSPARSE=y`` parameter, e.g.
+called with a ``-DZEPHYR_SCA_VARIANT=sparse`` parameter, e.g.
 
 .. code-block:: shell
 
-    west build -d hello -b intel_adsp_cavs25 zephyr/samples/hello_world -- -DSPARSE=y
+    west build -d hello -b intel_adsp_cavs25 zephyr/samples/hello_world -- -DZEPHYR_SCA_VARIANT=sparse

--- a/doc/develop/test/index.rst
+++ b/doc/develop/test/index.rst
@@ -9,5 +9,4 @@ Testing
    ztest
    twister
    coverage
-   sparse
    ztest_deprecated

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -81,6 +81,9 @@ mapping:
           module_ext_root:
             required: false
             type: str
+          sca_root:
+            required: false
+            type: str
   tests:
     required: false
     type: seq
@@ -219,7 +222,7 @@ def process_settings(module, meta):
     out_text = ""
 
     if build_settings is not None:
-        for root in ['board', 'dts', 'soc', 'arch', 'module_ext']:
+        for root in ['board', 'dts', 'soc', 'arch', 'module_ext', 'sca']:
             setting = build_settings.get(root+'_root', None)
             if setting is not None:
                 root_path = PurePath(module) / setting


### PR DESCRIPTION
Static code analyser (SCA) tools are important in software development.

CMake offers built-in support for some tools, such as cppcheck and
clang-tidy.

Other tools, such as sparse, are not directly supported.

This commit provides a uniform way for users to specify a supported
SCA using `ZEPHYR_SCA_VARIANT=<tool>` which is consistent with how
toolchains are specified.
ZEPHYR_SCA_VARIANT can be set using `-D` or in environment.

Support for an SCA tool is done in `cmake/sca/<tool>/sca.cmake`.
SCA_ROOT can be used to specify additional search paths when looking up
implementation for a tool. SCA_ROOT can also be specified in
`zephyr/module.yml` as setting. This makes it possible to provide SCA
tool implementation as part of a Zephyr module.

As a show-case, sparse support has been reworked into the new framework and old way of enabling sparse has been deprecated.

This PR is out-come of the Zephyr Architecture meeting, 2022-11-30.

--------

Pending work:
- [x] Create documentation and update existing Zephyr module docs to describe `sca_root` in module.yml.
- [x] Update Sparse doc: https://docs.zephyrproject.org/latest/develop/test/sparse.html
- [x] Decide if `SCA` is the proper name, or we want to use a different name for this functionality