### PR TITLE
logging: allow disabling auto-start of UART backend

### DIFF
--- a/samples/net/syslog_net/src/main.c
+++ b/samples/net/syslog_net/src/main.c
@@ -36,10 +36,7 @@ void main(void)
 		const struct log_backend *backend = log_backend_net_get();
 
 		if (!log_backend_is_active(backend)) {
-			if (backend->api->init != NULL) {
-				backend->api->init(backend);
-			}
-
+			log_backend_init(backend);
 			log_backend_enable(backend, backend->cb->ctx, CONFIG_LOG_MAX_LEVEL);
 		}
 	}

--- a/samples/net/syslog_net/src/main.c
+++ b/samples/net/syslog_net/src/main.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(net_syslog, LOG_LEVEL_DBG);
 #include <zephyr/kernel.h>
 
 #include <zephyr/logging/log_backend.h>
+#include <zephyr/logging/log_ctrl.h>
 
 #include <stdlib.h>
 
@@ -39,7 +40,7 @@ void main(void)
 				backend->api->init(backend);
 			}
 
-			log_backend_activate(backend, NULL);
+			log_backend_enable(backend, backend->cb->ctx, CONFIG_LOG_MAX_LEVEL);
 		}
 	}
 

--- a/subsys/logging/backends/Kconfig.uart
+++ b/subsys/logging/backends/Kconfig.uart
@@ -24,6 +24,14 @@ config LOG_BACKEND_UART_BUFFER_SIZE
 	  Sets the number of bytes which can be buffered in RAM before log_output_flush
 	  is automatically called on the backend.
 
+config LOG_BACKEND_UART_AUTOSTART
+	bool "Automatically start UART backend"
+	default y
+	help
+	  When enabled automatically start the UART logging backend on
+	  application start. When disabled, the application needs to start
+	  the backend manually using log_backend_enable().
+
 backend = UART
 backend-str = uart
 source "subsys/logging/Kconfig.template.log_format_config"

--- a/subsys/logging/backends/log_backend_uart.c
+++ b/subsys/logging/backends/log_backend_uart.c
@@ -12,6 +12,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
+#include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/__assert.h>
 LOG_MODULE_REGISTER(log_uart);
 
@@ -161,4 +162,5 @@ const struct log_backend_api log_backend_uart_api = {
 	.format_set = format_set,
 };
 
-LOG_BACKEND_DEFINE(log_backend_uart, log_backend_uart_api, true);
+LOG_BACKEND_DEFINE(log_backend_uart, log_backend_uart_api,
+		IS_ENABLED(CONFIG_LOG_BACKEND_UART_AUTOSTART));


### PR DESCRIPTION
This allows putting the UART backend on a serial device that has to be quiet unless logging is explicitly enabled at runtime.

Also fixes the sample showing how to initialize a backend that wasn't auto-started.