### PR TITLE
i2c: add `i2c_is_ready_dt` function

### DIFF
--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -396,6 +396,20 @@ struct i2c_target_config {
 	const struct i2c_target_callbacks *callbacks;
 };
 
+/**
+ * @brief Validate that I2C bus is ready.
+ *
+ * @param spec I2C specification from devicetree
+ *
+ * @retval true if the I2C bus is ready for use.
+ * @retval false if the I2C bus is not ready for use.
+ */
+static inline bool i2c_is_ready_dt(const struct i2c_dt_spec *spec)
+{
+	/* Validate bus is ready */
+	return device_is_ready(spec->bus);
+}
+
 #if defined(CONFIG_I2C_STATS) || defined(__DOXYGEN__)
 
 #include <zephyr/stats/stats.h>


### PR DESCRIPTION
Add `i2c_is_ready_dt` function that validates I2C spec bus is ready and it allows the user to pass `i2c_dt_spec` directly.

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>