### PR TITLE
[Backport v2.7-branch] lib: posix: make sleep() and usleep() standards-compliant

### DIFF
--- a/lib/posix/sleep.c
+++ b/lib/posix/sleep.c
@@ -14,8 +14,12 @@
  */
 unsigned sleep(unsigned int seconds)
 {
-	k_sleep(K_SECONDS(seconds));
-	return 0;
+	int rem;
+
+	rem = k_sleep(K_SECONDS(seconds));
+	__ASSERT_NO_MSG(rem >= 0);
+
+	return rem / MSEC_PER_SEC;
 }
 /**
  * @brief Suspend execution for microsecond intervals.

--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -23,11 +23,9 @@ void test_posix_clock(void)
 			NULL);
 	zassert_equal(errno, EINVAL, NULL);
 
-	clock_gettime(CLOCK_MONOTONIC, &ts);
-	/* 2 Sec Delay */
-	sleep(SLEEP_SECONDS);
-	usleep(SLEEP_SECONDS * USEC_PER_SEC);
-	clock_gettime(CLOCK_MONOTONIC, &te);
+	zassert_ok(clock_gettime(CLOCK_MONOTONIC, &ts));
+	zassert_ok(k_sleep(K_SECONDS(SLEEP_SECONDS)));
+	zassert_ok(clock_gettime(CLOCK_MONOTONIC, &te));
 
 	if (te.tv_nsec >= ts.tv_nsec) {
 		secs_elapsed = te.tv_sec - ts.tv_sec;
@@ -38,7 +36,7 @@ void test_posix_clock(void)
 	}
 
 	/*TESTPOINT: Check if POSIX clock API test passes*/
-	zassert_equal(secs_elapsed, (2 * SLEEP_SECONDS),
+	zassert_equal(secs_elapsed, SLEEP_SECONDS,
 			"POSIX clock API test failed");
 
 	printk("POSIX clock APIs test done\n");

--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -23,9 +23,9 @@ void test_posix_clock(void)
 			NULL);
 	zassert_equal(errno, EINVAL, NULL);
 
-	zassert_ok(clock_gettime(CLOCK_MONOTONIC, &ts));
-	zassert_ok(k_sleep(K_SECONDS(SLEEP_SECONDS)));
-	zassert_ok(clock_gettime(CLOCK_MONOTONIC, &te));
+	zassert_ok(clock_gettime(CLOCK_MONOTONIC, &ts), NULL);
+	zassert_ok(k_sleep(K_SECONDS(SLEEP_SECONDS)), NULL);
+	zassert_ok(clock_gettime(CLOCK_MONOTONIC, &te), NULL);
 
 	if (te.tv_nsec >= ts.tv_nsec) {
 		secs_elapsed = te.tv_sec - ts.tv_sec;

--- a/tests/posix/common/src/main.c
+++ b/tests/posix/common/src/main.c
@@ -37,6 +37,8 @@ extern void test_nanosleep_0_500000000(void);
 extern void test_nanosleep_1_0(void);
 extern void test_nanosleep_1_1(void);
 extern void test_nanosleep_1_1001(void);
+extern void test_sleep(void);
+extern void test_usleep(void);
 
 void test_main(void)
 {
@@ -69,7 +71,9 @@ void test_main(void)
 			ztest_unit_test(test_nanosleep_1_0),
 			ztest_unit_test(test_nanosleep_1_1),
 			ztest_unit_test(test_nanosleep_1_1001),
-			ztest_unit_test(test_posix_pthread_create_negative)
+			ztest_unit_test(test_posix_pthread_create_negative),
+			ztest_unit_test(test_sleep),
+			ztest_unit_test(test_usleep)
 			);
 	ztest_run_test_suite(posix_apis);
 }

--- a/tests/posix/common/src/sleep.c
+++ b/tests/posix/common/src/sleep.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022, Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <posix/unistd.h>
+#include <ztest.h>
+
+struct waker_work {
+	k_tid_t tid;
+	struct k_work_delayable dwork;
+};
+static struct waker_work ww;
+
+static void waker_func(struct k_work *work)
+{
+	struct waker_work *ww;
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+
+	ww = CONTAINER_OF(dwork, struct waker_work, dwork);
+	k_wakeup(ww->tid);
+}
+K_WORK_DELAYABLE_DEFINE(waker, waker_func);
+
+void test_sleep(void)
+{
+	uint32_t then;
+	uint32_t now;
+	/* call sleep(10), wakeup after 1s, expect >= 8s left */
+	const uint32_t sleep_min_s = 1;
+	const uint32_t sleep_max_s = 10;
+	const uint32_t sleep_rem_s = 8;
+
+	/* sleeping for 0s should return 0 */
+	zassert_ok(sleep(0), NULL);
+
+	/* test that sleeping for 1s sleeps for at least 1s */
+	then = k_uptime_get();
+	zassert_equal(0, sleep(1), NULL);
+	now = k_uptime_get();
+	zassert_true((now - then) >= 1 * MSEC_PER_SEC, NULL);
+
+	/* test that sleeping for 2s sleeps for at least 2s */
+	then = k_uptime_get();
+	zassert_equal(0, sleep(2), NULL);
+	now = k_uptime_get();
+	zassert_true((now - then) >= 2 * MSEC_PER_SEC, NULL);
+
+	/* test that sleep reports the remainder */
+	ww.tid = k_current_get();
+	k_work_init_delayable(&ww.dwork, waker_func);
+	zassert_equal(1, k_work_schedule(&ww.dwork, K_SECONDS(sleep_min_s)), NULL);
+	zassert_true(sleep(sleep_max_s) >= sleep_rem_s, NULL);
+}
+
+void test_usleep(void)
+{
+	uint32_t then;
+	uint32_t now;
+
+	/* test usleep works for small values */
+	/* Note: k_usleep(), an implementation detail, is a cancellation point */
+	zassert_equal(0, usleep(0), NULL);
+	zassert_equal(0, usleep(1), NULL);
+
+	/* sleep for the spec limit */
+	then = k_uptime_get();
+	zassert_equal(0, usleep(USEC_PER_SEC - 1), NULL);
+	now = k_uptime_get();
+	zassert_true(((now - then) * USEC_PER_MSEC) / (USEC_PER_SEC - 1) >= 1, NULL);
+
+	/* sleep for exactly the limit threshold */
+	zassert_equal(-1, usleep(USEC_PER_SEC), NULL);
+	zassert_equal(errno, EINVAL, NULL);
+
+	/* sleep for over the spec limit */
+	zassert_equal(-1, usleep((useconds_t)ULONG_MAX), NULL);
+	zassert_equal(errno, EINVAL, NULL);
+
+	/* test that sleep reports errno = EINTR when woken up */
+	ww.tid = k_current_get();
+	k_work_init_delayable(&ww.dwork, waker_func);
+	zassert_equal(1, k_work_schedule(&ww.dwork, K_USEC(USEC_PER_SEC / 2)), NULL);
+	zassert_equal(-1, usleep(USEC_PER_SEC - 1), NULL);
+	zassert_equal(EINTR, errno, NULL);
+}


### PR DESCRIPTION
This is a (manual) backport of #52519

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/51776
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/52517
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/52518

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/52542