### PR TITLE
samples: drivers: adc: fixup ADC sample support for LPADC

### DIFF
--- a/samples/drivers/adc/boards/lpcxpresso55s69_cpu0.overlay
+++ b/samples/drivers/adc/boards/lpcxpresso55s69_cpu0.overlay
@@ -17,10 +17,18 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
+	/*
+	 * To use this sample:
+	 * - Connect VREFN_TARGET to GND, and VREFP_TARGET to 3v3
+	 *   (Resistors J8 and J9, should be populated by default)
+	 * - Connect LPADC0 CH0 signal to voltage between 0~3.3V (P19 pin 4)
+	 */
+
 	channel@0 {
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};

--- a/samples/drivers/adc/boards/mimxrt1160_evk_cm7.overlay
+++ b/samples/drivers/adc/boards/mimxrt1160_evk_cm7.overlay
@@ -17,10 +17,16 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
+	/*
+	 * To use this sample:
+	 * - Connect LPADC0 CH0 signal to voltage between 0~1.8V (J9 pin 10)
+	 */
+
 	channel@0 {
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <1800>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};

--- a/samples/drivers/adc/boards/mimxrt1170_evk_cm7.overlay
+++ b/samples/drivers/adc/boards/mimxrt1170_evk_cm7.overlay
@@ -17,10 +17,16 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
+	/*
+	 * To use this sample:
+	 * - Connect LPADC0 CH0 signal to voltage between 0~1.8V (J9 pin 10)
+	 */
+
 	channel@0 {
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <1800>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};

--- a/samples/drivers/adc/boards/mimxrt685_evk_cm33.overlay
+++ b/samples/drivers/adc/boards/mimxrt685_evk_cm33.overlay
@@ -17,10 +17,17 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
+	/*
+	 * To use this sample:
+	 * - Connect VREF_L to GND, and VREF_H to 1.8V (connect JP9 and JP10).
+	 * - Connect LPADC0 CH0 signal to voltage between 0~1.8V (J30 pin 1)
+	 */
+
 	channel@0 {
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <1800>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};


### PR DESCRIPTION
Fixup ADC sample support for boards with LPADC present. This ADC only supports an external reference voltage, which is a board-specific value. Add reference voltage values for all supported boards.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>