### PR TITLE
tests: kernel: do not set excluded  as integration platform

### DIFF
--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -7,8 +7,6 @@ tests:
     platform_exclude: litex_vexriscv rv32m1_vega_zero_riscy rv32m1_vega_ri5cy
       nrf5340dk_nrf5340_cpunet
     tags: kernel timer userspace
-    integration_platforms:
-      - litex_vexriscv
   kernel.timer.no_multitheading:
     tags: kernel timer
     platform_allow: qemu_cortex_m3 nsim_em nsim_em7d_v22 nsim_hs nsim_hs_mpuv6


### PR DESCRIPTION
excluded platforms shall not be set as integration platforms.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
