### PR TITLE
twister: Allow passing additional args to native_posix test binary

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -626,6 +626,9 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         help="Get information about memory footprint from generated build.log. "
              "Requires using --show-footprint option.")
 
+    parser.add_argument("extra_test_args", nargs=argparse.REMAINDER,
+        help="Additional args following a '--' are passed to the test binary")
+
     options = parser.parse_args(args)
 
     # Very early error handling
@@ -679,6 +682,29 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
             sc = SizeCalculator(fn, [])
             sc.size_report()
         sys.exit(1)
+
+    if len(options.extra_test_args) > 0:
+        # extra_test_args is a list of CLI args that Twister did not recognize
+        # and are intended to be passed through to the ztest executable. This
+        # list should begin with a "--". If not, there is some extra
+        # unrecognized arg(s) that shouldn't be there. Tell the user there is a
+        # syntax error.
+        if options.extra_test_args[0] != "--":
+            try:
+                double_dash = options.extra_test_args.index("--")
+            except ValueError:
+                double_dash = len(options.extra_test_args)
+            unrecognized = " ".join(options.extra_test_args[0:double_dash])
+
+            logger.error("Unrecognized arguments found: '%s'. Use -- to "
+                         "delineate extra arguments for test binary or pass "
+                         "-h for help.",
+                         unrecognized)
+
+            sys.exit(1)
+
+        # Strip off the initial "--" following validation.
+        options.extra_test_args = options.extra_test_args[1:]
 
     return options
 

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -166,6 +166,7 @@ class BinaryHandler(Handler):
 
         self.call_west_flash = False
         self.seed = None
+        self.extra_test_args = None
         self.line = b""
 
     def try_kill_process_by_pid(self):
@@ -246,7 +247,9 @@ class BinaryHandler(Handler):
 
         # Only valid for native_posix
         if self.seed is not None:
-            command = command + ["--seed="+str(self.seed)]
+            command.append(f"--seed={self.seed}")
+        if self.extra_test_args is not None:
+            command.extend(self.extra_test_args)
 
         logger.debug("Spawning process: " +
                      " ".join(shlex.quote(word) for word in command) + os.linesep +

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -837,6 +837,9 @@ class ProjectBuilder(FilterBuilder):
                     self.defconfig['CONFIG_FAKE_ENTROPY_NATIVE_POSIX'] == 'y'):
                     instance.handler.seed = self.options.seed
 
+            if self.options.extra_test_args and instance.platform.arch == "posix":
+                instance.handler.extra_test_args = self.options.extra_test_args
+
             instance.handler.handle()
 
         sys.stdout.flush()


### PR DESCRIPTION
This commit expands Twister's CLI so that arguments passed after a double dash (`--`) get forwarded to the ztest test executable when run. When built for native_posix, ztest provides a useful CLI that allows filtering individual suites and tests, adjusting timing settings, and controlling the shuffling seed. Currently there is no easy way to use these (with the exception of `--seed`) without needing to dig out the resulting `zephyr.exe` binary from the build dir and invoke it manually.

 ### Examples

Run a specific ztest suite only (useful when writing tests and you don't want to run a long testcase in its entirety)

```
$ scripts/twister \
  -p native_posix \
  -s zephyr/tests/lib/cmsis_dsp/basicmath/libraries.cmsis_dsp.basicmath \
  -- -test=basic_math_q7::*
```

Unrecognized arguments that precede the double dash will result in an error message:

```
$ scripts/twister \
  -p native_posix \
  --foobar 123 \
  -- -test=basic_math_q7::*

...
Unrecognized arguments found: '--foobar 123'. Use -- to delineate extra
arguments for test binary or pass -h for help.
```

Signed-off-by: Tristan Honscheid <honscheid@google.com>