### PR TITLE
boards: arm: b_l4s5i_iot01a and stm32h7b3i_dk: fix OSPI flash size

### DIFF
--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -248,7 +248,7 @@ zephyr_udc0: &usbotg_fs {
 		compatible = "st,stm32-ospi-nor";
 		reg = <0>;
 		ospi-max-frequency = <DT_FREQ_M(26)>; /* for Voltage Range 2 */
-		size = <DT_SIZE_M(8)>; /* 64 Megabits = 8 Megabytes */
+		size = <DT_SIZE_M(64)>; /* 64 Megabits */
 		spi-bus-width = <OSPI_QUAD_MODE>;
 		data-rate = <OSPI_STR_TRANSFER>;
 		writeoc="PP_1_4_4";

--- a/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -240,7 +240,7 @@
 		compatible = "st,stm32-ospi-nor";
 		reg = <0>;
 		ospi-max-frequency = <DT_FREQ_M(50)>;
-		size = <DT_SIZE_M(64)>;
+		size = <DT_SIZE_M(512)>; /* 512 Megabits */
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_DTR_TRANSFER>;
 		status = "okay";


### PR DESCRIPTION
The OSPI flash driver expects size in bits. This PR uses bits instead of bytes for the size.

Fixes #52691.