### PR TITLE
boards: qemu_x86: Do not build "raw" binary for qemu

### DIFF
--- a/boards/x86/qemu_x86/Kconfig.defconfig
+++ b/boards/x86/qemu_x86/Kconfig.defconfig
@@ -7,12 +7,12 @@ config EEPROM_INIT_PRIORITY
 	default 60
 	depends on EEPROM
 
+config BUILD_OUTPUT_BIN
+	default n
+
 endif # BOARD_QEMU_X86 || BOARD_QEMU_X86_64 || BOARD_QEMU_X86_LAKEMONT || BOARD_QEMU_X86_TINY
 
 if BOARD_QEMU_X86
-
-config BUILD_OUTPUT_BIN
-	default n
 
 config BOARD
 	default "qemu_x86"
@@ -53,9 +53,6 @@ endif # BOARD_QEMU_X86_64
 
 if BOARD_QEMU_X86_LAKEMONT
 
-config BUILD_OUTPUT_BIN
-	default n
-
 config BOARD
 	default "qemu_x86_lakemont"
 
@@ -82,9 +79,6 @@ config UART_NS16550_ACCESS_IOPORT
 endif # BOARD_QEMU_X86_LAKEMONT
 
 if BOARD_QEMU_X86_TINY
-
-config BUILD_OUTPUT_BIN
-	default n
 
 config BOARD
 	default "qemu_x86_tiny"


### PR DESCRIPTION
Do not build "raw" binary for qemu boards. It was already disabled for all qemu boards except for qemu_x86_64. This also prevents exposing bug with llvm when building "raw" binary using unsupported options in objcopy.