### PR TITLE
stm32U5 dma driver adding a resume API function 

### DIFF
--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -582,10 +582,7 @@ static int dma_stm32_suspend(const struct device *dev, uint32_t id)
 		k_msleep(1); /* A delay is needed (1ms is valid) */
 	} while (LL_DMA_IsActiveFlag_SUSP(dma, dma_stm32_id_to_stream(id)) != 1);
 
-	/* Reset the FIFO register and internal state */
-	LL_DMA_ResetChannel(dma, dma_stm32_id_to_stream(id));
-	/* The Channel is disabled and its suspend Flag is also reset */
-
+	/* Do not Reset the channel to allow resuming later */
 	return 0;
 }
 

--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -586,6 +586,24 @@ static int dma_stm32_suspend(const struct device *dev, uint32_t id)
 	return 0;
 }
 
+static int dma_stm32_resume(const struct device *dev, uint32_t id)
+{
+	const struct dma_stm32_config *config = dev->config;
+	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
+
+	/* Give channel from index 0 */
+	id = id - STM32_DMA_STREAM_OFFSET;
+
+	if (id >= config->max_streams) {
+		return -EINVAL;
+	}
+
+	/* Resume the channel : it's enough after suspend */
+	LL_DMA_ResumeChannel(dma, dma_stm32_id_to_stream(id));
+
+	return 0;
+}
+
 static int dma_stm32_stop(const struct device *dev, uint32_t id)
 {
 	const struct dma_stm32_config *config = dev->config;
@@ -662,6 +680,7 @@ static const struct dma_driver_api dma_funcs = {
 	.stop		 = dma_stm32_stop,
 	.get_status	 = dma_stm32_get_status,
 	.suspend	 = dma_stm32_suspend,
+	.resume		 = dma_stm32_resume,
 };
 
 #define DMA_STM32_OFFSET_INIT(index)


### PR DESCRIPTION
This PR adds the .resume API function for the dma driver of the stm32U5 serie

It completes the list of dma_driver_api 

When the suspend function is supported but not the resume function, the tests/drivers/dma/dma_loopback test fails

```
START - test_dma_m2m_loop_suspend_resume                                        
DMA memory to memory transfer started                                           
Preparing DMA Controller                                                        
this platform do not support the dma channel                                    
Starting the transfer on channel 2 and waiting for 1 second                     
suspended after 0 transfers occurred                                            
resuming after 0 transfers occurred                                             
Resumed transfers                                                               
ERROR: resume failed, channel 2, result -88                                     
    Assertion failed at WEST_TOPDIR/zephyr/tests/drivers/dma/loop_transfer/src/e
                                                                                
 FAIL - test_dma_m2m_loop_suspend_resume in 0.296 seconds                       
===================================================================
```             
The [DMA API](https://docs.zephyrproject.org/latest/hardware/peripherals/dma.html#api-reference)
does not mention that suspend/resume are required together

Signed-off-by: Francois Ramu <francois.ramu@st.com>