### PR TITLE
twister: support test plans and test configuration

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -340,11 +340,16 @@ build_only: <True|False> (default False)
     test shall not be used to verify the functionality of the dritver.
 
 build_on_all: <True|False> (default False)
-    If true, attempt to build test on all available platforms.
+    If true, attempt to build test on all available platforms. This is mostly
+    used in CI for increased coverage. Do not use this flag in new tests.
 
 depends_on: <list of features>
     A board or platform can announce what features it supports, this option
     will enable the test only those platforms that provide this feature.
+
+levels: <list of levels"
+    Test levels this test should be part of. If a level is present, this
+    test will be selectable using the command line option ``--level <level name>``
 
 min_ram: <integer>
     minimum amount of RAM in KB needed for this test to build and run. This is
@@ -984,6 +989,91 @@ To exclude a platform, use the following syntax::
       comment: "broken qemu"
 
 Additionally you can quarantine entire architectures or a specific simulator for executing tests.
+
+Test Configuration
+******************
+
+A test configuration can be used to customize various apects of twister
+and the default enabled options and features. This allows tweaking the filtering
+capabilities depending on the environment and makes it possible to adapt and
+improve coverage when targeting different sets of platforms.
+
+The test configuration also adds support for test levels and the ability to
+assign a specific test to one or more levels. Using command line options of
+twister it is then possible to select a level and just execute the tests
+included in this level.
+
+Additionally, the test configuration allows  defining level
+dependencies and additional inclusion of tests into a specific level if
+the test itself does not have this information already.
+
+In the configuration file you can include complete components using
+regular expressions and you can specify which test level to import from
+the same file, making management of levels easier.
+
+To help with testing outside of upstream CI infrastructure, additional
+options are available in the configuration file, which can be hosted
+locally. As of now, those options are available:
+
+- Ability to ignore default platforms as defined in board definitions
+  (Those are mostly emulation platforms used to run tests in upstream
+  CI)
+- Option to specify your own list of default platforms overriding what
+  upstream defines.
+- Ability to override `build_onl_all` options used in some testscases.
+  This will treat tests or sample as any other just build for default
+  platforms you specify in the configuation file or on the command line.
+- Ignore some logic in twister to expand platform coverage in cases where
+  default platforms are not in scope.
+
+
+Platform Configuration
+======================
+
+The following options control platform filtering in twister:
+
+- `override_default_platforms`: override default key a platform sets in board
+  configuration and instead use the list of platforms provided in the
+  configuration file as the list of default platforms. This option is set to
+  False by default.
+- `increased_platform_scope`: This option is set to True by default, when
+  disabled, twister will not increase platform coverage automatically and will
+  only build and run tests on the specified platforms.
+- `default_platforms`: A list of additional default platforms to add. This list
+  can either be used to replace the existing default platforms or can extend it
+  depending on the value of `override_default_platforms`.
+
+And example platforms configuration::
+
+	platforms:
+	  override_default_platforms: true
+	  increased_platform_scope: false
+	  default_platforms:
+	    - qemu_x86
+
+
+Test Level Configuration
+========================
+
+The test configuration allows defining test levels, level dependencies and
+additional inclusion of tests into a specific test level if the test itself
+does not have this information already.
+
+In the configuration file you can include complete components using
+regular expressions and you can specify which test level to import from
+the same file, making management of levels simple.
+
+And example test level configuration::
+
+	levels:
+	  - name: my-test-level
+	    description: >
+	      my custom test level
+	    adds:
+	      - kernel.threads.*
+	      - kernel.timer.behavior
+	      - arch.interrupt
+	      - boards.*
 
 Running in Tests in Random Order
 ********************************

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -65,6 +65,7 @@ class TwisterConfigParser:
                        "toolchain_exclude": {"type": "set"},
                        "toolchain_allow": {"type": "set"},
                        "filter": {"type": "str"},
+                       "levels": {"type": "list", "default": []},
                        "harness": {"type": "str", "default": "test"},
                        "harness_config": {"type": "map", "default": {}},
                        "seed": {"type": "int", "default": 0},

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -268,6 +268,13 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
                              "Default to html. "
                              "Valid options are html, xml, csv, txt, coveralls, sonarqube.")
 
+    parser.add_argument("--test-config", action="store", default=os.path.join(ZEPHYR_BASE, "tests", "test_config.yaml"),
+        help="Path to file with plans and test configurations.")
+
+    parser.add_argument("--level", action="store",
+        help="Test level to be used. By default, no levels are used for filtering"
+             "and do the selection based on existing filters.")
+
     parser.add_argument(
         "-D", "--all-deltas", action="store_true",
         help="Show all footprint deltas, positive or negative. Implies "
@@ -743,6 +750,8 @@ class TwisterEnv:
             self.outdir = None
 
         self.hwm = None
+
+        self.test_config = options.test_config
 
     def discover(self):
         self.check_zephyr_version()

--- a/scripts/schemas/twister/test-config-schema.yaml
+++ b/scripts/schemas/twister/test-config-schema.yaml
@@ -1,0 +1,44 @@
+#
+# Schema to validate a YAML file describing a Zephyr test configuration.
+#
+
+type: map
+mapping:
+  "platforms":
+    type: map
+    required: false
+    mapping:
+      "override_default_platforms":
+        type: bool
+        required: false
+      "increased_platform_scope":
+        type: bool
+        required: false
+      "default_platforms":
+        type: seq
+        required: false
+        sequence:
+          - type: str
+  "levels":
+    type: seq
+    required: false
+    sequence:
+      - type: map
+        required: false
+        mapping:
+          "name":
+            type: str
+            required: true
+          "description":
+            type: str
+            required: false
+          "adds":
+            type: seq
+            required: false
+            sequence:
+              - type: str
+          "inherits":
+            type: seq
+            required: false
+            sequence:
+              - type: str

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -64,6 +64,12 @@ mapping:
       "ignore_qemu_crash":
         type: bool
         required: false
+      "levels":
+        type: seq
+        required: false
+        sequence:
+          - type: str
+            enum: ["smoke", "unit", "integration", "acceptance", "system", "regression"]
       "testcases":
         type: seq
         required: false
@@ -237,6 +243,12 @@ mapping:
           "filter":
             type: str
             required: false
+          "levels":
+            type: seq
+            required: false
+            sequence:
+              - type: str
+                enum: ["smoke", "unit", "integration", "acceptance", "system", "regression"]
           "integration_platforms":
             type: seq
             required: false

--- a/scripts/tests/twister/conftest.py
+++ b/scripts/tests/twister/conftest.py
@@ -38,8 +38,9 @@ def tesenv_obj(test_data, testsuites_dir, tmpdir_factory):
     parser = add_parse_arguments()
     options = parse_arguments(parser, [])
     env = TwisterEnv(options)
-    env.board_roots = [test_data +"board_config/1_level/2_level/"]
-    env.test_roots = [testsuites_dir + '/tests', testsuites_dir + '/samples']
+    env.board_roots = [os.path.join(test_data, "board_config", "1_level", "2_level")]
+    env.test_roots = [os.path.join(testsuites_dir, 'tests', testsuites_dir, 'samples')]
+    env.test_config = os.path.join(test_data, "test_config.yaml")
     env.outdir = tmpdir_factory.mktemp("sanity_out_demo")
     return env
 
@@ -52,6 +53,7 @@ def testplan_obj(test_data, class_env, testsuites_dir, tmpdir_factory):
     env.test_roots = [testsuites_dir + '/tests', testsuites_dir + '/samples']
     env.outdir = tmpdir_factory.mktemp("sanity_out_demo")
     plan = TestPlan(env)
+    plan.parse_configuration(config_file=env.test_config)
     return plan
 
 @pytest.fixture(name='all_testsuites_dict')
@@ -67,8 +69,9 @@ def testsuites_dict(class_testplan):
 def all_platforms_list(test_data, class_testplan):
     """ Pytest fixture to call add_configurations function of
 	Testsuite class and return the Platforms list"""
-    class_testplan.env.board_roots = [os.path.abspath(test_data + "board_config")]
+    class_testplan.env.board_roots = [os.path.abspath(os.path.join(test_data, "board_config"))]
     plan = TestPlan(class_testplan.env)
+    plan.parse_configuration(config_file=class_testplan.env.test_config)
     plan.add_configurations()
     return plan.platforms
 

--- a/scripts/tests/twister/test_data/test_config.yaml
+++ b/scripts/tests/twister/test_data/test_config.yaml
@@ -1,0 +1,19 @@
+platforms:
+  override_default_platforms: false
+  increased_platform_scope: true
+levels:
+  - name: smoke
+    description: >
+      A plan to be used verifying basic zephyr features on hardware.
+    adds:
+      - kernel.threads.*
+      - kernel.timer.behavior
+      - arch.interrupt
+      - boards.*
+  - name: acceptance
+    description: >
+      More coverage
+    adds:
+      - kernel.*
+      - arch.interrupt
+      - boards.*

--- a/scripts/tests/twister/test_testplan_class.py
+++ b/scripts/tests/twister/test_testplan_class.py
@@ -54,6 +54,7 @@ def test_add_configurations(test_data, class_env, board_root_dir):
     """
     class_env.board_roots = [os.path.abspath(test_data + board_root_dir)]
     plan = TestPlan(class_env)
+    plan.parse_configuration(config_file=class_env.test_config)
     if board_root_dir == "board_config":
         plan.add_configurations()
         assert sorted(plan.default_platforms) == sorted(['demo_board_1', 'demo_board_3'])
@@ -62,9 +63,9 @@ def test_add_configurations(test_data, class_env, board_root_dir):
         assert sorted(plan.default_platforms) != sorted(['demo_board_1'])
 
 
-def test_get_all_testsuites(class_env, all_testsuites_dict):
+def test_get_all_testsuites(class_testplan, all_testsuites_dict):
     """ Testing get_all_testsuites function of TestPlan class in Twister """
-    plan = TestPlan(class_env)
+    plan = class_testplan
     plan.testsuites = all_testsuites_dict
     expected_tests = ['sample_test.app', 'test_a.check_1.1a',
                       'test_a.check_1.1c',
@@ -79,9 +80,9 @@ def test_get_all_testsuites(class_env, all_testsuites_dict):
                       'test_d.check_1.unit_1b', 'test_config.main']
     assert sorted(plan.get_all_tests()) == sorted(expected_tests)
 
-def test_get_platforms(class_env, platforms_list):
+def test_get_platforms(class_testplan, platforms_list):
     """ Testing get_platforms function of TestPlan class in Twister """
-    plan = TestPlan(class_env)
+    plan = class_testplan
     plan.platforms = platforms_list
     platform = plan.get_platform("demo_board_1")
     assert isinstance(platform, Platform)
@@ -106,13 +107,13 @@ TESTDATA_PART1 = [
 
 @pytest.mark.parametrize("tc_attribute, tc_value, plat_attribute, plat_value, expected_discards",
                          TESTDATA_PART1)
-def test_apply_filters_part1(class_env, all_testsuites_dict, platforms_list,
+def test_apply_filters_part1(class_testplan, all_testsuites_dict, platforms_list,
                              tc_attribute, tc_value, plat_attribute, plat_value, expected_discards):
     """ Testing apply_filters function of TestPlan class in Twister
     Part 1: Response of apply_filters function have
             appropriate values according to the filters
     """
-    plan = TestPlan(class_env)
+    plan = class_testplan
     if tc_attribute is None and plat_attribute is None:
         plan.apply_filters()
 

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -1,0 +1,19 @@
+platforms:
+  override_default_platforms: false
+  increased_platform_scope: true
+levels:
+  - name: smoke
+    description: >
+      A plan to be used verifying basic zephyr features on hardware.
+    adds:
+      - kernel.threads.*
+      - kernel.timer.behavior
+      - arch.interrupt
+      - boards.*
+  - name: acceptance
+    description: >
+      More coverage
+    adds:
+      - kernel.*
+      - arch.interrupt
+      - boards.*


### PR DESCRIPTION
Add support test plans and the ability to assign a specific test to one
or more plans. Use command line options of twister it is then possible
to select a plan and just execute the tests included in this plan.

Additionally, a test configuration is now available to define plan
dependencies and additional inclusion of tests into a specific plan if
the test itself does not have this information already.

In the configuration file you can include complete components using
regular expressions and you can specific which test plan to import from
the same file, making management of plans easier.

To help with testing outside of upstream CI infrastructure, additional
options are available in the configuration file, which can be hosted
locally. As of now, those options are available:

- Ability to ignore default platforms as defined in board definitions
  (Those are mostly emulation platforms used to run tests in upstream
  CI)
- Option to specify your own list of default platforms overriding what
  upstream defines.
- Ability to override build_onl_all options used in some testscases.
  This will treat tests or sample as any other just build for default
  platforms you specify in the configuation file or on the command line.




commits:
- twister: add support for plans and test configuration
- tests: add smoke tests
- tests: mem_map: remove scnearios used for coverage
- tests: mem_protect: cleanup yaml and reenable qemu_arc
