### PR TITLE
checkpatch: update --exclude docs

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -97,7 +97,7 @@ Options:
   --list-types               list the possible message types
   --types TYPE(,TYPE2...)    show only these comma separated message types
   --ignore TYPE(,TYPE2...)   ignore various comma separated message types
-  --exclude DIR(,DIR22...)   exclude directories
+  --exclude DIR (--exclude DIR2...)   exclude directories
   --show-types               show the specific message type in the output
   --max-line-length=n        set the maximum line length, (default $max_line_length)
                              if exceeded, warn on patches


### PR DESCRIPTION
The current docs are incorrect as comma separated paths are not working. Providing a separate --exclude argement per path does however work.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>