### PR TITLE
Bluetooth: controller: use RX node piggy-back for NTF when possible

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1133,10 +1133,11 @@ int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx)
 		ARG_UNUSED(link);
 		ARG_UNUSED(pdu_rx);
 
-		ull_cp_rx(conn, *rx);
-
 		/* Mark buffer for release */
 		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
+
+		ull_cp_rx(conn, *rx);
+
 		return 0;
 #endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -293,7 +293,7 @@ static struct proc_ctx *create_procedure(enum llcp_proc proc, struct llcp_mem_po
 	ctx->collision = 0U;
 	ctx->done = 0U;
 	ctx->rx_greedy = 0U;
-	ctx->tx_ack = NULL;
+	ctx->node_ref.tx_ack = NULL;
 
 	/* Clear procedure data */
 	memset((void *)&ctx->data, 0, sizeof(ctx->data));
@@ -1613,13 +1613,13 @@ void ull_cp_tx_ack(struct ll_conn *conn, struct node_tx *tx)
 	struct proc_ctx *ctx;
 
 	ctx = llcp_lr_peek(conn);
-	if (ctx && ctx->tx_ack == tx) {
+	if (ctx && ctx->node_ref.tx_ack == tx) {
 		/* TX ack re. local request */
 		llcp_lr_tx_ack(conn, ctx, tx);
 	}
 
 	ctx = llcp_rr_peek(conn);
-	if (ctx && ctx->tx_ack == tx) {
+	if (ctx && ctx->node_ref.tx_ack == tx) {
 		/* TX ack re. remote response */
 		llcp_rr_tx_ack(conn, ctx, tx);
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -196,9 +196,7 @@ static void rp_cc_ntf_create(struct ll_conn *conn, struct proc_ctx *ctx)
 	struct node_rx_pdu *ntf;
 	struct node_rx_conn_iso_req *pdu;
 
-	/* Allocate ntf node */
-	ntf = llcp_ntf_alloc();
-	LL_ASSERT(ntf);
+	ntf = ctx->node_ref.rx;
 
 	ntf->hdr.type = NODE_RX_TYPE_CIS_REQUEST;
 	ntf->hdr.handle = conn->lll.handle;
@@ -209,9 +207,6 @@ static void rp_cc_ntf_create(struct ll_conn *conn, struct proc_ctx *ctx)
 	pdu->cis_handle = ctx->data.cis_create.cis_handle;
 
 	ctx->data.cis_create.host_request_to = 0U;
-
-	/* Enqueue notification towards LL */
-	ll_rx_put_sched(ntf->hdr.link, ntf);
 }
 
 static void rp_cc_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
@@ -56,7 +56,6 @@ enum {
 	LP_ENC_STATE_WAIT_RX_START_ENC_REQ,
 	LP_ENC_STATE_WAIT_TX_START_ENC_RSP,
 	LP_ENC_STATE_WAIT_RX_START_ENC_RSP,
-	LP_ENC_STATE_WAIT_NTF,
 	/* Pause Procedure */
 	LP_ENC_STATE_ENCRYPTED,
 	LP_ENC_STATE_WAIT_TX_PAUSE_ENC_REQ,
@@ -101,7 +100,6 @@ enum {
 	RP_ENC_STATE_WAIT_TX_START_ENC_REQ,
 	RP_ENC_STATE_WAIT_TX_REJECT_IND,
 	RP_ENC_STATE_WAIT_RX_START_ENC_RSP,
-	RP_ENC_STATE_WAIT_NTF,
 	RP_ENC_STATE_WAIT_TX_START_ENC_RSP,
 	/* Pause Procedure */
 	RP_ENC_STATE_ENCRYPTED,
@@ -222,8 +220,8 @@ static void lp_enc_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	struct node_rx_pdu *ntf;
 	struct pdu_data *pdu;
 
-	/* Allocate ntf node */
-	ntf = llcp_ntf_alloc();
+	/* Piggy-back on RX node */
+	ntf = ctx->node_ref.rx;
 	LL_ASSERT(ntf);
 
 	ntf->hdr.type = NODE_RX_TYPE_DC_PDU;
@@ -245,20 +243,13 @@ static void lp_enc_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	} else {
 		llcp_pdu_encode_reject_ind(pdu, ctx->data.enc.error);
 	}
-
-	/* Enqueue notification towards LL */
-	ll_rx_put_sched(ntf->hdr.link, ntf);
 }
 
 static void lp_enc_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
-	if (!llcp_ntf_alloc_is_available()) {
-		ctx->state = LP_ENC_STATE_WAIT_NTF;
-	} else {
-		lp_enc_ntf(conn, ctx);
-		llcp_lr_complete(conn);
-		ctx->state = LP_ENC_STATE_UNENCRYPTED;
-	}
+	lp_enc_ntf(conn, ctx);
+	llcp_lr_complete(conn);
+	ctx->state = LP_ENC_STATE_UNENCRYPTED;
 }
 
 static void lp_enc_store_m(struct ll_conn *conn, struct proc_ctx *ctx, struct pdu_data *pdu)
@@ -516,18 +507,6 @@ static void lp_enc_st_wait_rx_start_enc_rsp(struct ll_conn *conn, struct proc_ct
 	}
 }
 
-static void lp_enc_st_wait_ntf(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
-{
-	switch (evt) {
-	case LP_ENC_EVT_RUN:
-		lp_enc_complete(conn, ctx, evt, param);
-		break;
-	default:
-		/* Ignore other evts */
-		break;
-	}
-}
-
 static void lp_enc_state_encrypted(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				   void *param)
 {
@@ -608,9 +587,6 @@ static void lp_enc_execute_fsm(struct ll_conn *conn, struct proc_ctx *ctx, uint8
 		break;
 	case LP_ENC_STATE_WAIT_RX_START_ENC_RSP:
 		lp_enc_st_wait_rx_start_enc_rsp(conn, ctx, evt, param);
-		break;
-	case LP_ENC_STATE_WAIT_NTF:
-		lp_enc_st_wait_ntf(conn, ctx, evt, param);
 		break;
 	/* Pause Procedure */
 	case LP_ENC_STATE_ENCRYPTED:
@@ -772,8 +748,8 @@ static void rp_enc_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	struct node_rx_pdu *ntf;
 	struct pdu_data *pdu;
 
-	/* Allocate ntf node */
-	ntf = llcp_ntf_alloc();
+	/* Piggy-back on RX node */
+	ntf = ctx->node_ref.rx;
 	LL_ASSERT(ntf);
 
 	ntf->hdr.type = NODE_RX_TYPE_DC_PDU;
@@ -791,9 +767,6 @@ static void rp_enc_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 		/* Should never happen */
 		LL_ASSERT(0);
 	}
-
-	/* Enqueue notification towards LL */
-	ll_rx_put_sched(ntf->hdr.link, ntf);
 }
 
 static void rp_enc_send_start_enc_rsp(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
@@ -801,12 +774,8 @@ static void rp_enc_send_start_enc_rsp(struct ll_conn *conn, struct proc_ctx *ctx
 
 static void rp_enc_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
-	if (!llcp_ntf_alloc_is_available()) {
-		ctx->state = RP_ENC_STATE_WAIT_NTF;
-	} else {
-		rp_enc_ntf(conn, ctx);
-		rp_enc_send_start_enc_rsp(conn, ctx, evt, param);
-	}
+	rp_enc_ntf(conn, ctx);
+	rp_enc_send_start_enc_rsp(conn, ctx, evt, param);
 }
 
 static void rp_enc_send_ltk_ntf(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
@@ -1055,19 +1024,6 @@ static void rp_enc_state_wait_rx_start_enc_rsp(struct ll_conn *conn, struct proc
 	}
 }
 
-static void rp_enc_state_wait_ntf(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
-				  void *param)
-{
-	switch (evt) {
-	case RP_ENC_EVT_RUN:
-		rp_enc_complete(conn, ctx, evt, param);
-		break;
-	default:
-		/* Ignore other evts */
-		break;
-	}
-}
-
 static void rp_enc_state_wait_tx_start_enc_rsp(struct ll_conn *conn, struct proc_ctx *ctx,
 					       uint8_t evt, void *param)
 {
@@ -1173,9 +1129,6 @@ static void rp_enc_execute_fsm(struct ll_conn *conn, struct proc_ctx *ctx, uint8
 		break;
 	case RP_ENC_STATE_WAIT_RX_START_ENC_RSP:
 		rp_enc_state_wait_rx_start_enc_rsp(conn, ctx, evt, param);
-		break;
-	case RP_ENC_STATE_WAIT_NTF:
-		rp_enc_state_wait_ntf(conn, ctx, evt, param);
 		break;
 	case RP_ENC_STATE_WAIT_TX_START_ENC_RSP:
 		rp_enc_state_wait_tx_start_enc_rsp(conn, ctx, evt, param);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -156,9 +156,12 @@ struct proc_ctx {
 	enum llcp_wait_reason wait_reason;
 #endif /* LLCP_TX_CTRL_BUF_QUEUE_ENABLE */
 
-	/* TX node awaiting ack */
-	struct node_tx *tx_ack;
-
+	union {
+		/* TX node awaiting ack */
+		struct node_tx *tx_ack;
+		/* current RX node */
+		struct node_rx_pdu *rx;
+	} node_ref;
 	/*
 	 * This flag is set to 1 when we are finished with the control
 	 * procedure and it is safe to release the context ctx

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -199,6 +199,9 @@ void llcp_lr_prt_stop(struct ll_conn *conn)
 
 void llcp_lr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
 {
+	/* Store RX node */
+	ctx->node_ref.rx = rx;
+
 	switch (ctx->proc) {
 #if defined(CONFIG_BT_CTLR_LE_PING)
 	case PROC_LE_PING:

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -395,7 +395,7 @@ static void lp_pu_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 	}
 
 	/* Always 'request' the ACK signal */
-	ctx->tx_ack = tx;
+	ctx->node_ref.tx_ack = tx;
 	ctx->tx_opcode = pdu->llctrl.opcode;
 
 	/* Enqueue LL Control PDU towards LLL */
@@ -921,7 +921,7 @@ static void rp_pu_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 		LL_ASSERT(0);
 	}
 
-	ctx->tx_ack = tx;
+	ctx->node_ref.tx_ack = tx;
 	ctx->tx_opcode = pdu->llctrl.opcode;
 
 	/* Enqueue LL Control PDU towards LLL */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -213,6 +213,9 @@ void llcp_rr_prt_stop(struct ll_conn *conn)
 
 void llcp_rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
 {
+	/* Store RX node */
+	ctx->node_ref.rx = rx;
+
 	switch (ctx->proc) {
 	case PROC_UNKNOWN:
 		/* Do nothing */


### PR DESCRIPTION
Does in fact not fix #45323

However it implements RX node piggy-backing (ie no delay) for notifications where this is possible.  

This change was tested in EBQ qualifying no regressions