### PR TITLE
Add SBS manufactuer access support to fuel gauge API - includes adding write to API

### DIFF
--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -69,6 +69,10 @@ static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_pr
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AVG_TIME2FULL, &val);
 		prop->value.runtime_to_empty = val;
 		break;
+	case FUEL_GAUGE_SBS_MFR_ACCESS:
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_MANUFACTURER_ACCESS, &val);
+		prop->value.sbs_mfr_access_word = val;
+		break;
 	case FUEL_GAUGE_STATE_OF_CHARGE:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ASOC, &val);
 		prop->value.state_of_charge = val;

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -35,6 +35,16 @@ static int sbs_cmd_reg_read(const struct device *dev, uint8_t reg_addr, uint16_t
 	return 0;
 }
 
+static int sbs_cmd_reg_write(const struct device *dev, uint8_t reg_addr, uint16_t val)
+{
+	const struct sbs_gauge_config *config = dev->config;
+	uint8_t buf[2];
+
+	sys_put_le16(val, buf);
+
+	return i2c_burst_write_dt(&config->i2c, reg_addr, buf, sizeof(buf));
+}
+
 static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_property *prop)
 {
 	int rc = 0;
@@ -94,6 +104,27 @@ static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_pr
 	return rc;
 }
 
+static int sbs_gauge_set_prop(const struct device *dev, struct fuel_gauge_set_property *prop)
+{
+	int rc = 0;
+	uint16_t val = 0;
+
+	switch (prop->property_type) {
+
+	case FUEL_GAUGE_SBS_MFR_ACCESS:
+		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_MANUFACTURER_ACCESS,
+				       prop->value.sbs_mfr_access_word);
+		prop->value.sbs_mfr_access_word = val;
+		break;
+	default:
+		rc = -ENOTSUP;
+	}
+
+	prop->status = rc;
+
+	return rc;
+}
+
 static int sbs_gauge_get_props(const struct device *dev, struct fuel_gauge_get_property *props,
 			       size_t len)
 {
@@ -101,6 +132,22 @@ static int sbs_gauge_get_props(const struct device *dev, struct fuel_gauge_get_p
 
 	for (int i = 0; i < len; i++) {
 		int ret = sbs_gauge_get_prop(dev, props + i);
+
+		err_count += ret ? 1 : 0;
+	}
+
+	err_count = (err_count == len) ? -1 : err_count;
+
+	return err_count;
+}
+
+static int sbs_gauge_set_props(const struct device *dev, struct fuel_gauge_set_property *props,
+			       size_t len)
+{
+	int err_count = 0;
+
+	for (int i = 0; i < len; i++) {
+		int ret = sbs_gauge_set_prop(dev, props + i);
 
 		err_count += ret ? 1 : 0;
 	}
@@ -131,6 +178,7 @@ static int sbs_gauge_init(const struct device *dev)
 
 static const struct battery_driver_api sbs_gauge_driver_api = {
 	.get_property = &sbs_gauge_get_props,
+	.set_property = &sbs_gauge_set_props,
 };
 
 /* FIXME: fix init priority */

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -55,8 +55,10 @@ extern "C" {
 #define FUEL_GAUGE_RUNTIME_TO_EMPTY	FUEL_GAUGE_REMAINING_CAPACITY + 1
 /** Remaining time in minutes until battery reaches full charge */
 #define FUEL_GAUGE_RUNTIME_TO_FULL	FUEL_GAUGE_RUNTIME_TO_EMPTY + 1
+/** Retrieve word from SBS1.1 ManufactuerAccess */
+#define FUEL_GAUGE_SBS_MFR_ACCESS	FUEL_GAUGE_RUNTIME_TO_FULL + 1
 /** Absolute state of charge (percent, 0-100) - expressed as % of design capacity */
-#define FUEL_GAUGE_STATE_OF_CHARGE	FUEL_GAUGE_RUNTIME_TO_FULL + 1
+#define FUEL_GAUGE_STATE_OF_CHARGE	FUEL_GAUGE_SBS_MFR_ACCESS + 1
 /** Temperature in 0.1 K */
 #define FUEL_GAUGE_TEMPERATURE		FUEL_GAUGE_STATE_OF_CHARGE + 1
 /** Battery voltage (uV) */
@@ -105,6 +107,8 @@ struct fuel_gauge_get_property {
 		uint32_t runtime_to_empty;
 		/** FUEL_GAUGE_RUNTIME_TO_FULL */
 		uint32_t runtime_to_full;
+		/** FUEL_GAUGE_SBS_MFR_ACCESS */
+		uint16_t sbs_mfr_access_word;
 		/** FUEL_GAUGE_STATE_OF_CHARGE */
 		uint8_t state_of_charge;
 		/** FUEL_GAUGE_TEMPERATURE */

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -118,6 +118,25 @@ struct fuel_gauge_get_property {
 	} value;
 };
 
+struct fuel_gauge_set_property {
+	/** Battery fuel gauge property to set */
+	uint16_t property_type;
+
+	/** Negative error status set by callee e.g. -ENOTSUP for an unsupported property */
+	int status;
+
+	/** Property field for setting */
+	union {
+		/* Fields have the format: */
+		/* FUEL_GAUGE_PROPERTY_FIELD */
+		/* type property_field; */
+
+		/* Writable Dynamic Battery Info */
+		/** FUEL_GAUGE_SBS_MFR_ACCESS */
+		uint16_t sbs_mfr_access_word;
+	} value;
+};
+
 /**
  * @brief Fetch a battery fuel-gauge property
  *
@@ -133,10 +152,26 @@ struct fuel_gauge_get_property {
 typedef int (*fuel_gauge_get_property_t)(const struct device *dev,
 					 struct fuel_gauge_get_property *props, size_t props_len);
 
+/**
+ * @brief Set a battery fuel-gauge property
+ *
+ * @param dev Pointer to the battery fuel-gauge device
+ * @param props pointer to array of fuel_gauge_set_property struct where the property struct
+ * field is set by the caller to determine what property is written to the fuel gauge device from
+ * the fuel_gauge_get_property struct's value field.
+ * @param props_len number of properties in props array
+ *
+ * @return return=0 if successful, return < 0 if setting all properties failed, return > 0 if some
+ * properties failed where return=number of failing properties.
+ */
+typedef int (*fuel_gauge_set_property_t)(const struct device *dev,
+					 struct fuel_gauge_set_property *props, size_t props_len);
+
 /* Caching is entirely on the onus of the client */
 
 __subsystem struct battery_driver_api {
 	fuel_gauge_get_property_t get_property;
+	fuel_gauge_set_property_t set_property;
 };
 
 /**

--- a/subsys/emul/i2c/emul_sbs_gauge.c
+++ b/subsys/emul/i2c/emul_sbs_gauge.c
@@ -53,6 +53,7 @@ static int emul_sbs_gauge_reg_read(const struct emul *target, int reg, int *val)
 	ARG_UNUSED(target);
 
 	switch (reg) {
+	case SBS_GAUGE_CMD_MANUFACTURER_ACCESS:
 	case SBS_GAUGE_CMD_VOLTAGE:
 	case SBS_GAUGE_CMD_AVG_CURRENT:
 	case SBS_GAUGE_CMD_TEMP:

--- a/subsys/emul/i2c/emul_sbs_gauge.c
+++ b/subsys/emul/i2c/emul_sbs_gauge.c
@@ -25,7 +25,7 @@ LOG_MODULE_REGISTER(sbs_sbs_gauge);
 
 /** Run-time data used by the emulator */
 struct sbs_gauge_emul_data {
-	/* Stub */
+	uint16_t mfr_acc;
 };
 
 /** Static configuration for the emulator */
@@ -36,10 +36,13 @@ struct sbs_gauge_emul_cfg {
 
 static int emul_sbs_gauge_reg_write(const struct emul *target, int reg, int val)
 {
-	ARG_UNUSED(target);
+	struct sbs_gauge_emul_data *data = target->data;
 
 	LOG_INF("write %x = %x", reg, val);
 	switch (reg) {
+	case SBS_GAUGE_CMD_MANUFACTURER_ACCESS:
+		data->mfr_acc = val;
+		break;
 	default:
 		LOG_INF("Unknown write %x", reg);
 		return -EIO;
@@ -50,10 +53,12 @@ static int emul_sbs_gauge_reg_write(const struct emul *target, int reg, int val)
 
 static int emul_sbs_gauge_reg_read(const struct emul *target, int reg, int *val)
 {
-	ARG_UNUSED(target);
+	struct sbs_gauge_emul_data *data = target->data;
 
 	switch (reg) {
 	case SBS_GAUGE_CMD_MANUFACTURER_ACCESS:
+		*val = data->mfr_acc;
+		break;
 	case SBS_GAUGE_CMD_VOLTAGE:
 	case SBS_GAUGE_CMD_AVG_CURRENT:
 	case SBS_GAUGE_CMD_TEMP:

--- a/subsys/emul/i2c/emul_sbs_gauge.c
+++ b/subsys/emul/i2c/emul_sbs_gauge.c
@@ -115,17 +115,22 @@ static int sbs_gauge_emul_transfer_i2c(const struct emul *target, struct i2c_msg
 					/* Return before writing bad value to message buffer */
 					return rc;
 				}
-				msgs->buf[0] = val;
+
+				/* SBS uses SMBus, which sends data in little-endian format. */
+				sys_put_le16(val, msgs->buf);
 				break;
 			default:
 				LOG_ERR("Unexpected msg1 length %d", msgs->len);
 				return -EIO;
 			}
 		} else {
-			if (msgs->len != 1) {
+			/* We write a word (2 bytes by the SBS spec) */
+			if (msgs->len != 2) {
 				LOG_ERR("Unexpected msg1 length %d", msgs->len);
 			}
-			rc = emul_sbs_gauge_reg_write(target, reg, msgs->buf[0]);
+			uint16_t *value = (uint16_t *)msgs->buf;
+
+			rc = emul_sbs_gauge_reg_write(target, reg, *value);
 		}
 		break;
 	default:

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -123,6 +123,9 @@ ZTEST_F(sbs_gauge_new_api, test_get_props__returns_ok)
 		{
 			.property_type = FUEL_GAUGE_CYCLE_COUNT,
 		},
+		{
+			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
+		},
 	};
 
 	int ret = fixture->api->get_property(fixture->dev, props, ARRAY_SIZE(props));

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -88,6 +88,79 @@ ZTEST_F(sbs_gauge_new_api, test_get_some_props_failed_returns_failed_prop_count)
 	zassert_equal(ret, 2);
 }
 
+ZTEST_F(sbs_gauge_new_api, test_set_all_props_failed_returns_negative)
+{
+	struct fuel_gauge_set_property props[] = {
+		{
+			/* Invalid property */
+			.property_type = FUEL_GAUGE_PROP_MAX,
+		},
+	};
+
+	int ret = fixture->api->set_property(fixture->dev, props, ARRAY_SIZE(props));
+
+	zassert_equal(props[0].status, -ENOTSUP, "Setting bad property %d has a good status.",
+		      props[0].property_type);
+
+	zassert_true(ret < 0);
+}
+
+ZTEST_F(sbs_gauge_new_api, test_set_some_props_failed_returns_failed_prop_count)
+{
+	struct fuel_gauge_set_property props[] = {
+		{
+			/* First invalid property */
+			.property_type = FUEL_GAUGE_PROP_MAX,
+		},
+		{
+			/* Second invalid property */
+			.property_type = FUEL_GAUGE_PROP_MAX,
+		},
+		{
+			/* Valid property */
+			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
+			/* Set Manufacturer's Access to arbitrary word */
+			.value.sbs_mfr_access_word = 1,
+		},
+
+	};
+
+	int ret = fixture->api->set_property(fixture->dev, props, ARRAY_SIZE(props));
+
+	zassert_equal(props[0].status, -ENOTSUP, "Setting bad property %d has a good status.",
+		      props[0].property_type);
+
+	zassert_equal(props[1].status, -ENOTSUP, "Setting bad property %d has a good status.",
+		      props[1].property_type);
+
+	zassert_ok(props[2].status, "Property %d setting %d has a bad status.", 2,
+		   props[2].property_type);
+
+	zassert_equal(ret, 2);
+}
+
+ZTEST_F(sbs_gauge_new_api, test_set_prop_can_be_get)
+{
+	uint16_t word = BIT(15) | BIT(0);
+	struct fuel_gauge_set_property set_prop = {
+		/* Valid property */
+		.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
+		/* Set Manufacturer's Access to 16 bit word*/
+		.value.sbs_mfr_access_word = word,
+	};
+
+	zassert_ok(fixture->api->set_property(fixture->dev, &set_prop, 1));
+	zassert_ok(set_prop.status);
+
+	struct fuel_gauge_get_property get_prop = {
+		.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
+	};
+
+	zassert_ok(fixture->api->get_property(fixture->dev, &get_prop, 1));
+	zassert_ok(get_prop.status);
+	zassert_equal(get_prop.value.sbs_mfr_access_word, word);
+}
+
 ZTEST_F(sbs_gauge_new_api, test_get_props__returns_ok)
 {
 	/* Validate what props are supported by the driver */
@@ -132,6 +205,26 @@ ZTEST_F(sbs_gauge_new_api, test_get_props__returns_ok)
 
 	for (int i = 0; i < ARRAY_SIZE(props); i++) {
 		zassert_ok(props[i].status, "Property %d getting %d has a bad status.", i,
+			   props[i].property_type);
+	}
+
+	zassert_ok(ret);
+}
+
+ZTEST_F(sbs_gauge_new_api, test_set_props__returns_ok)
+{
+	/* Validate what props are supported by the driver */
+
+	struct fuel_gauge_set_property props[] = {
+		{
+			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
+		},
+	};
+
+	int ret = fixture->api->set_property(fixture->dev, props, ARRAY_SIZE(props));
+
+	for (int i = 0; i < ARRAY_SIZE(props); i++) {
+		zassert_ok(props[i].status, "Property %d writing %d has a bad status.", i,
 			   props[i].property_type);
 	}
 


### PR DESCRIPTION
This is part of the ongoing fuel gauge effort described in
https://github.com/zephyrproject-rtos/zephyr/issues/44847

In this PR:

* Add `set_property` to fuel gauge API
* Add read/write SBS specific mfr access to fuel gauge API
* Implement/test mfr access read/writing in SBS Gauge driver


The `set_property` added to the API is intended to mirror the `get_property`
API.

Adding a `set_property` in no way implies we're finished with the `get_property`
or adding support for more SBS spec properties to the SBS Gauge Driver
itself. Current strategy is to prototype this API by maintaining a breadth of
the kind of features it supports with the SBS Gauge driver as an example.