### PR TITLE
fuel_gauge: Fix sbs_gauge err to conform to API

### DIFF
--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -93,13 +93,17 @@ static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_pr
 static int sbs_gauge_get_props(const struct device *dev, struct fuel_gauge_get_property *props,
 			       size_t len)
 {
-	int ret = 0;
+	int err_count = 0;
 
 	for (int i = 0; i < len; i++) {
-		ret |= sbs_gauge_get_prop(dev, props + i);
+		int ret = sbs_gauge_get_prop(dev, props + i);
+
+		err_count += ret ? 1 : 0;
 	}
 
-	return ret;
+	err_count = (err_count == len) ? -1 : err_count;
+
+	return err_count;
 }
 
 /**


### PR DESCRIPTION
The SBS fuel gauge driver did not return a count of the number of properties that failed.

Fix this and add a test that verifies the sbs_gauge returns the number of failing properties as well as a test that verifies a negative return code if all properties failed.

Signed-off-by: Aaron Massey <aaronmassey@google.com>