### PR TITLE
ace: gpdma: add power domain

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -430,6 +430,7 @@
 			dma-buf-size-alignment = <4>;
 			dma-copy-alignment = <4>;
 			status = "okay";
+			power-domain = <&hub_ulp_domain>;
 		};
 
 		lpgpdma1: dma@7d000 {
@@ -442,6 +443,7 @@
 			dma-buf-size-alignment = <4>;
 			dma-copy-alignment = <4>;
 			status = "okay";
+			power-domain = <&io0_domain>;
 		};
 
 		sha: adsp-sha@17df00 {


### PR DESCRIPTION
Device power management aspect of this pull request will be developed later. Right now focusing only on power domains and dynamic power gating (PG). To guarantee correct operation during PG we need to prevent PG on certain power domains.

This patch results with PG prevent for  IO_0 domain, under which is GPDMA.