### PR TITLE
MAINTAINERS.yml: Update x86 platform & arch maintainers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1828,9 +1828,9 @@ SiLabs Platforms:
 Intel Platforms (X86):
   status: maintained
   maintainers:
-    - enjiamai
-  collaborators:
     - jhedberg
+  collaborators:
+    - tbursztyka
     - aasthagr
     - laurenmurphyx64
     - MaureenHelm
@@ -2783,6 +2783,7 @@ x86 arch:
   maintainers:
     - jhedberg
   collaborators:
+    - tbursztyka
     - andyross
     - nashif
     - dcpleung


### PR DESCRIPTION
Replace Enjia with Johan for x86 platform maintenance, and add Tomasz as collaborator for x86 platforms & arch.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>