### PR TITLE
logging: minimal: Change imply to select for printk

### DIFF
--- a/subsys/logging/Kconfig.mode
+++ b/subsys/logging/Kconfig.mode
@@ -27,7 +27,7 @@ config LOG_MODE_IMMEDIATE
 
 config LOG_MODE_MINIMAL
 	bool "Minimal-footprint"
-	imply PRINTK
+	select PRINTK
 	help
 	  Enable minimal logging implementation. This has very little footprint
 	  overhead on top of the printk() implementation for standard


### PR DESCRIPTION
This changes the minimal logging Kconfig to select printk rather than imply it, this is because if someone turns printk off, minimal footprint logging does not work, therefore it needs to be a requirement.

Fixes #52721