### PR TITLE
ci: twister: fixed path for tag based filtering

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -59,7 +59,7 @@ kernel:
 
 posix:
     files:
-        - lib/posix
+        - lib/posix/
 
 # cbprintf:
 #    files:

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -256,7 +256,7 @@ class Filters:
             self.tag_options.extend(["-e", tag ])
 
         if exclude_tags:
-            logging.info(f'Potential tag based filters...')
+            logging.info(f'Potential tag based filters: {exclude_tags}')
 
     def find_excludes(self, skip=[]):
         with open("scripts/ci/twister_ignore.txt", "r") as twister_ignore:


### PR DESCRIPTION
path for posix was not being matched correctly due to a missing /. So
some posix tests were excluded and not excercised.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
