### PR TITLE
settings: misc cleanups

### DIFF
--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -10,27 +10,24 @@ menuconfig SETTINGS
 	  and it can do so atomically for all involved modules.
 
 if SETTINGS
+
 module = SETTINGS
 module-str = settings
 source "subsys/logging/Kconfig.template.log_config"
-endif
 
 config SETTINGS_RUNTIME
 	bool "runtime storage back-end"
-	depends on SETTINGS
 	help
 	  Enables runtime storage back-end.
 
 config SETTINGS_DYNAMIC_HANDLERS
 	bool "dynamic settings handlers"
-	depends on SETTINGS
 	default y
 	help
 	  Enables the use of dynamic settings handlers
 
 # Hidden option to enable encoding length into settings entry
 config SETTINGS_ENCODE_LEN
-	depends on SETTINGS
 	bool
 
 choice SETTINGS_BACKEND
@@ -39,7 +36,6 @@ choice SETTINGS_BACKEND
 	default SETTINGS_FCB if FCB
 	default SETTINGS_FILE if FILE_SYSTEM
 	default SETTINGS_NONE
-	depends on SETTINGS
 	help
 	  Storage back-end to be used by the settings subsystem.
 
@@ -103,7 +99,7 @@ endchoice
 config SETTINGS_FCB_NUM_AREAS
 	int "Number of flash areas used by the settings subsystem"
 	default 8
-	depends on SETTINGS && SETTINGS_FCB
+	depends on SETTINGS_FCB
 	help
 	  Number of areas to allocate in the settings FCB. A smaller number is
 	  used if the flash hardware cannot support this value.
@@ -111,56 +107,56 @@ config SETTINGS_FCB_NUM_AREAS
 config SETTINGS_FCB_MAGIC
 	hex "FCB magic for the settings subsystem"
 	default 0xc0ffeeee
-	depends on SETTINGS && SETTINGS_FCB
+	depends on SETTINGS_FCB
 	help
 	  Magic 32-bit word for to identify valid settings area
 
 config SETTINGS_FILE_DIR
 	string "Serialization directory"
 	default "/settings"
-	depends on SETTINGS && SETTINGS_FILE
+	depends on SETTINGS_FILE
 	help
 	  Directory where the settings data is stored
 
 config SETTINGS_FILE_PATH
 	string "Default settings file"
 	default "/settings/run"
-	depends on SETTINGS && SETTINGS_FILE
+	depends on SETTINGS_FILE
 	help
 	  Full path to the default settings file.
 
 config SETTINGS_FILE_MAX_LINES
 	int "Compression threshold"
 	default 32
-	depends on SETTINGS && SETTINGS_FILE
+	depends on SETTINGS_FILE
 	help
 	  Limit how many items stored in a file before compressing
 
 config SETTINGS_FS_DIR
 	string "Serialization directory (DEPRECATED)"
 	default "/settings"
-	depends on SETTINGS && SETTINGS_FS
+	depends on SETTINGS_FS
 	help
 	  This is deprecated. Use SETTINGS_FILE_DIR instead.
 
 config SETTINGS_FS_FILE
 	string "Default settings file (DEPRECATED)"
 	default "/settings/run"
-	depends on SETTINGS && SETTINGS_FS
+	depends on SETTINGS_FS
 	help
 	  This is deprecated. Use SETTINGS_FILE_PATH instead.
 
 config SETTINGS_FS_MAX_LINES
 	int "Compression threshold (DEPRECATED)"
 	default 32
-	depends on SETTINGS && SETTINGS_FS
+	depends on SETTINGS_FS
 	help
 	  This is deprecated. Use SETTINGS_FILE_MAX_LINES instead.
 
 config SETTINGS_NVS_SECTOR_SIZE_MULT
 	int "Sector size of the NVS settings area"
 	default 1
-	depends on SETTINGS && SETTINGS_NVS
+	depends on SETTINGS_NVS
 	help
 	  The sector size to use for the NVS settings area as a multiple of
 	  FLASH_ERASE_BLOCK_SIZE.
@@ -168,15 +164,17 @@ config SETTINGS_NVS_SECTOR_SIZE_MULT
 config SETTINGS_NVS_SECTOR_COUNT
 	int "Sector count of the NVS settings area"
 	default 8
-	depends on SETTINGS && SETTINGS_NVS
+	depends on SETTINGS_NVS
 	help
 	  Number of sectors used for the NVS settings area
 
 config SETTINGS_SHELL
 	bool "Settings shell"
-	depends on SETTINGS && SHELL
+	depends on SHELL
 	help
 	  Enable shell commands for listing and reading the settings. Note that
 	  reading the settings requires quite a big stack buffer, so the stack
 	  size of the shell thread may need to be increased to accommodate this
 	  feature.
+
+endif # SETTINGS

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -388,7 +388,7 @@ static int settings_fcb_save(struct settings_store *cs, const char *name,
 	if (cdca.is_dup == 1) {
 		return 0;
 	}
-	return settings_fcb_save_priv(cs, name, (char *)value, val_len);
+	return settings_fcb_save_priv(cs, name, value, val_len);
 }
 
 void settings_mount_fcb_backend(struct settings_fcb *cf)

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -444,7 +444,7 @@ static int settings_file_save(struct settings_store *cs, const char *name,
 	if (cdca.is_dup == 1) {
 		return 0;
 	}
-	return settings_file_save_priv(cs, name, (char *)value, val_len);
+	return settings_file_save_priv(cs, name, value, val_len);
 }
 
 static int read_handler(void *ctx, off_t off, char *buf, size_t *len)

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -128,7 +128,7 @@ int settings_next_line_ctx(struct line_entry_ctx *entry_ctx)
 	uint16_t readout;
 	int rc;
 
-	entry_ctx->seek += entry_ctx->len; /* to begin of nex line */
+	entry_ctx->seek += entry_ctx->len; /* to begin of next line */
 
 	entry_ctx->len = 0; /* ask read handler to ignore len */
 
@@ -165,7 +165,7 @@ int settings_line_len_calc(const char *name, size_t val_len)
 /**
  * Read RAW settings line entry data until a char from the storage.
  *
- * @param seek offset form the line beginning.
+ * @param seek offset from the line beginning.
  * @param[out] out buffer for name
  * @param[in] len_req size of <p>out</p> buffer
  * @param[out] len_read length of read name

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -21,8 +21,6 @@ struct settings_io_cb_s {
 	uint8_t rwbs;
 } static settings_io_cb;
 
-#define MAX_ENC_BLOCK_SIZE 4
-
 int settings_line_write(const char *name, const char *value, size_t val_len,
 			off_t w_loc, void *cb_arg)
 {

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -149,14 +149,8 @@ int settings_next_line_ctx(struct line_entry_ctx *entry_ctx)
 
 int settings_line_len_calc(const char *name, size_t val_len)
 {
-	int len;
-
-	/* <evalue> */
-	len = val_len;
-	/* <name>=<enc(value)> */
-	len += strlen(name) + 1;
-
-	return len;
+	/* <name>=<value> */
+	return strlen(name) + 1 + val_len;
 }
 
 


### PR DESCRIPTION
Put all Kconfig entries under single `if + endif` block. This removes the need
for `depends on SETTINGS` for each option.

Fix some typos in comments.

Remove unused macro.

Drop unnecessary drop of `const` identifier for File and FCB backends.