### PR TITLE
drivers: usb: usb_dc_nrfx: add usbd worker thread name. 

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1918,6 +1918,7 @@ static int usb_init(const struct device *arg)
 			   K_KERNEL_STACK_SIZEOF(usbd_work_queue_stack),
 			   CONFIG_SYSTEM_WORKQUEUE_PRIORITY, NULL);
 
+	k_thread_name_set(&usbd_work_queue.thread, "usbd_workq");
 	k_work_init(&ctx->usb_work, usbd_work_handler);
 
 	return 0;


### PR DESCRIPTION
Note: there remains other drivers using worker threads that do not explicitly name them. May create a different issue to capture that work since this issue pertains to the usb_dc_nrfx specifically.

Signed-off-by: Mark Watson <markus.c.watson@gmail.com>

Fixes: #43330