### PR TITLE
net: buf: Simplify fragment handling

### DIFF
--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -885,15 +885,6 @@ static inline void net_buf_simple_restore(struct net_buf_simple *buf,
 }
 
 /**
- * Flag indicating that the buffer has associated fragments. Only used
- * internally by the buffer handling code while the buffer is inside a
- * FIFO, meaning this never needs to be explicitly set or unset by the
- * net_buf API user. As long as the buffer is outside of a FIFO, i.e.
- * in practice always for the user for this API, the buf->frags pointer
- * should be used instead.
- */
-#define NET_BUF_FRAGS        BIT(0)
-/**
  * Flag indicating that the buffer's associated data pointer, points to
  * externally allocated memory. Therefore once ref goes down to zero, the
  * pointed data will not need to be deallocated. This never needs to be
@@ -902,7 +893,7 @@ static inline void net_buf_simple_restore(struct net_buf_simple *buf,
  * Reference count mechanism however will behave the same way, and ref
  * count going to 0 will free the net_buf but no the data pointer in it.
  */
-#define NET_BUF_EXTERNAL_DATA  BIT(1)
+#define NET_BUF_EXTERNAL_DATA  BIT(0)
 
 /**
  * @brief Network buffer representation.
@@ -912,13 +903,11 @@ static inline void net_buf_simple_restore(struct net_buf_simple *buf,
  * using the net_buf_alloc() API.
  */
 struct net_buf {
-	union {
-		/** Allow placing the buffer into sys_slist_t */
-		sys_snode_t node;
+	/** Allow placing the buffer into sys_slist_t */
+	sys_snode_t node;
 
-		/** Fragments associated with this buffer. */
-		struct net_buf *frags;
-	};
+	/** Fragments associated with this buffer. */
+	struct net_buf *frags;
 
 	/** Reference count. */
 	uint8_t ref;

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -124,11 +124,20 @@ static void purge_buffers(sys_slist_t *list)
 
 		buf = (void *)sys_slist_get_not_empty(list);
 
-		buf->frags = NULL;
-		buf->flags &= ~NET_BUF_FRAGS;
-
 		net_buf_unref(buf);
 	}
+}
+
+static void purge_seg_buffers(struct net_buf *buf)
+{
+	/* Fragments head has always 2 references: one when allocated, one when becomes
+	 * fragments head.
+	 */
+	net_buf_unref(buf);
+
+	do {
+		buf = net_buf_frag_del(NULL, buf);
+	} while (buf != NULL);
 }
 
 /* Intentionally start a little bit late into the ReceiveWindow when
@@ -166,8 +175,10 @@ static void friend_clear(struct bt_mesh_friend *frnd)
 	for (i = 0; i < ARRAY_SIZE(frnd->seg); i++) {
 		struct bt_mesh_friend_seg *seg = &frnd->seg[i];
 
-		purge_buffers(&seg->queue);
-		seg->seg_count = 0U;
+		if (seg->buf) {
+			purge_seg_buffers(seg->buf);
+			seg->seg_count = 0U;
+		}
 	}
 
 	STRUCT_SECTION_FOREACH(bt_mesh_friend_cb, cb) {
@@ -1054,7 +1065,7 @@ init_friend:
 
 static bool is_seg(struct bt_mesh_friend_seg *seg, uint16_t src, uint16_t seq_zero)
 {
-	struct net_buf *buf = (void *)sys_slist_peek_head(&seg->queue);
+	struct net_buf *buf = seg->buf;
 	struct net_buf_simple_state state;
 	uint16_t buf_seq_zero;
 	uint16_t buf_src;
@@ -1087,7 +1098,7 @@ static struct bt_mesh_friend_seg *get_seg(struct bt_mesh_friend *frnd,
 			return seg;
 		}
 
-		if (!unassigned && !sys_slist_peek_head(&seg->queue)) {
+		if (!unassigned && !seg->buf) {
 			unassigned = seg;
 		}
 	}
@@ -1122,16 +1133,13 @@ static void enqueue_friend_pdu(struct bt_mesh_friend *frnd,
 		return;
 	}
 
-	net_buf_slist_put(&seg->queue, buf);
+	seg->buf = net_buf_frag_add(seg->buf, buf);
 
 	if (type == BT_MESH_FRIEND_PDU_COMPLETE) {
-		sys_slist_merge_slist(&frnd->queue, &seg->queue);
+		net_buf_slist_put(&frnd->queue, seg->buf);
 
 		frnd->queue_size += seg->seg_count;
 		seg->seg_count = 0U;
-	} else {
-		/* Mark the buffer as having more to come after it */
-		buf->flags |= NET_BUF_FRAGS;
 	}
 }
 
@@ -1248,6 +1256,15 @@ static void friend_timeout(struct k_work *work)
 		return;
 	}
 
+	/* Put next segment to the friend queue. */
+	if (frnd->last != net_buf_frag_last(frnd->last)) {
+		struct net_buf *next;
+
+		next = net_buf_frag_del(NULL, frnd->last);
+		net_buf_frag_add(NULL, next);
+		sys_slist_prepend(&frnd->queue, &next->node);
+	}
+
 	md = (uint8_t)(sys_slist_peek_head(&frnd->queue) != NULL);
 
 	update_overwrite(frnd->last, md);
@@ -1255,10 +1272,6 @@ static void friend_timeout(struct k_work *work)
 	if (encrypt_friend_pdu(frnd, frnd->last, false)) {
 		return;
 	}
-
-	/* Clear the flag we use for segment tracking */
-	frnd->last->flags &= ~NET_BUF_FRAGS;
-	frnd->last->frags = NULL;
 
 	LOG_DBG("Sending buf %p from Friend Queue of LPN 0x%04x", frnd->last, frnd->lpn);
 	frnd->queue_size--;
@@ -1333,16 +1346,11 @@ int bt_mesh_friend_init(void)
 
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.frnd); i++) {
 		struct bt_mesh_friend *frnd = &bt_mesh.frnd[i];
-		int j;
 
 		sys_slist_init(&frnd->queue);
 
 		k_work_init_delayable(&frnd->timer, friend_timeout);
 		k_work_init_delayable(&frnd->clear.timer, clear_timeout);
-
-		for (j = 0; j < ARRAY_SIZE(frnd->seg); j++) {
-			sys_slist_init(&frnd->seg[j].queue);
-		}
 	}
 
 	return 0;
@@ -1636,11 +1644,16 @@ static bool friend_queue_prepare_space(struct bt_mesh_friend *frnd, uint16_t add
 		frnd->queue_size--;
 		avail_space++;
 
-		pending_segments = (buf->flags & NET_BUF_FRAGS);
+		if (buf != net_buf_frag_last(buf)) {
+			struct net_buf *next;
 
-		/* Make sure old slist entry state doesn't remain */
-		buf->frags = NULL;
-		buf->flags &= ~NET_BUF_FRAGS;
+			next = net_buf_frag_del(NULL, buf);
+
+			net_buf_frag_add(NULL, next);
+			sys_slist_prepend(&frnd->queue, &next->node);
+
+			pending_segments = true;
+		}
 
 		net_buf_unref(buf);
 	}
@@ -1761,7 +1774,7 @@ void bt_mesh_friend_clear_incomplete(struct bt_mesh_subnet *sub, uint16_t src,
 
 			LOG_WRN("Clearing incomplete segments for 0x%04x", src);
 
-			purge_buffers(&seg->queue);
+			purge_seg_buffers(seg->buf);
 			seg->seg_count = 0U;
 			break;
 		}

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -67,7 +67,10 @@ struct bt_mesh_friend {
 	struct k_work_delayable timer;
 
 	struct bt_mesh_friend_seg {
-		sys_slist_t queue;
+		/* First received segment of a segmented message. Rest
+		 * segments are added as net_buf fragments.
+		 */
+		struct net_buf *buf;
 
 		/* The target number of segments, i.e. not necessarily
 		 * the current number of segments, in the queue. This is


### PR DESCRIPTION
This patch reworks how fragments are handled in the net_buf infrastructure.

In particular, it removes the union around the node and frags members in the main net_buf structure. This is done so that both can be used at the same time, at a cost of 4 bytes per net_buf instance. This implies that the layout of net_buf instances changes whenever being inserted into a queue (fifo or lifo) or a linked list (slist).

Until now, this is what happened when enqueueing a net_buf with frags in a queue or linked list:

1.1 Before enqueueing:
```
  +--------+      +--------+      +--------+
  |#1  node|\     |#2  node|\     |#3  node|\
  |        | \    |        | \    |        | \
  | frags  |------| frags  |------| frags  |------NULL
  +--------+      +--------+      +--------+
```
net_buf #1 has 2 fragments, net_bufs #2 and #3. Both the node and frags pointers (they are the same, since they are unioned) point to the next fragment.

1.2 After enqueueing:
```
  +--------+      +--------+      +--------+      +--------+      +--------+
  |q/slist |------|#1  node|------|#2  node|------|#3  node|------|q/slist |
  |node    |      | *flag  | /    | *flag  | /    |        | /    |node    |
  |        |      | frags  |/     | frags  |/     | frags  |/     |        |
  +--------+      +--------+      +--------+      +--------+      +--------+
```
When enqueing a net_buf (in this case #1) that contains fragments, the current net_buf implementation actually enqueues all the fragments (in this case #2 and #3) as actual queue/slist items, since node and frags are one and the same in memory. This makes the enqueuing operation expensive and it makes it impossible to atomically dequeue. The `*flag` notation here means that the `flags` member has been set to `NET_BUF_FRAGS` in order to be able to reconstruct the frags pointers when dequeuing.

After this patch, the layout changes considerably:

2.1 Before enqueueing:
```
  +--------+       +--------+       +--------+
  |#1  node|--NULL |#2  node|--NULL |#3  node|--NULL
  |        |       |        |       |        |
  | frags  |-------| frags  |-------| frags  |------NULL
  +--------+       +--------+       +--------+
```
This is very similar to 1.1, except that now node and frags are different pointers, so node is just set to NULL.

2.2 After enqueueing:
```
  +--------+       +--------+       +--------+
  |q/slist |-------|#1  node|-------|q/slist |
  |node    |       |        |       |node    |
  |        |       | frags  |       |        |
  +--------+       +--------+       +--------+
                       |            +--------+       +--------+
                       |            |#2  node|--NULL |#3  node|--NULL
                       |            |        |       |        |
                       +------------| frags  |-------| frags  |------NULL
                                    +--------+       +--------+
```
When enqueuing net_buf #1, now we only enqueue that very item, instead of enqueing the frags as well, since now node and frags are separate pointers. This simplifies the operation and makes it atomic.

Resolves #52718.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>