### PR TITLE
newlib: do not attempt to overallocate heap

### DIFF
--- a/include/zephyr/sys/mem_manage.h
+++ b/include/zephyr/sys/mem_manage.h
@@ -291,6 +291,13 @@ void z_phys_unmap(uint8_t *virt, size_t size);
 size_t k_mem_free_get(void);
 
 /**
+ * Return the amount of free virtual memory available
+ *
+ * @return Free virtual RAM, in bytes
+ */
+int k_virt_free_range_max_get(void);
+
+/**
  * Map anonymous memory into Zephyr's address space
  *
  * This function effectively increases the data space available to Zephyr.

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -932,6 +932,28 @@ void z_mem_manage_boot_finish(void)
 #endif
 }
 
+int k_virt_free_range_max_get(void)
+{
+	int bit_val;
+	int free_pages = 0;
+	int free_pages_max = 0;
+	k_spinlock_key_t key = k_spin_lock(&z_mm_lock);
+
+	for (size_t i = 0; i < virt_region_bitmap.num_bits; ++i) {
+		sys_bitarray_test_bit(&virt_region_bitmap, i, &bit_val);
+		if (!bit_val) {
+			++free_pages;
+			continue;
+		}
+		free_pages_max = free_pages > free_pages_max ? free_pages : free_pages_max;
+		free_pages = 0;
+	}
+	k_spin_unlock(&z_mm_lock, key);
+	free_pages_max = free_pages > free_pages_max ? free_pages : free_pages_max;
+
+	return free_pages_max * CONFIG_MMU_PAGE_SIZE;
+}
+
 #ifdef CONFIG_DEMAND_PAGING
 
 #ifdef CONFIG_DEMAND_PAGING_STATS

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -104,8 +104,13 @@ static int malloc_prepare(const struct device *unused)
 
 #ifdef USE_MALLOC_PREPARE
 #ifdef CONFIG_MMU
+	/* Need extra for the guard pages (before and after) which we
+	 * won't map.
+	 */
+	size_t max_alloc = k_mem_free_get() - CONFIG_MMU_PAGE_SIZE * 2;
+
 	max_heap_size = MIN(CONFIG_NEWLIB_LIBC_MAX_MAPPED_REGION_SIZE,
-			    k_mem_free_get());
+			    max_alloc);
 
 	if (max_heap_size != 0) {
 		heap_base = k_mem_map(max_heap_size, K_MEM_PERM_RW);

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -104,10 +104,12 @@ static int malloc_prepare(const struct device *unused)
 
 #ifdef USE_MALLOC_PREPARE
 #ifdef CONFIG_MMU
+	/* To map the heap, we need both virtual and physical memory.  */
+	int mem_free = MIN(k_mem_free_get(), k_virt_free_range_max_get());
 	/* Need extra for the guard pages (before and after) which we
 	 * won't map.
 	 */
-	size_t max_alloc = k_mem_free_get() - CONFIG_MMU_PAGE_SIZE * 2;
+	size_t max_alloc = mem_free - CONFIG_MMU_PAGE_SIZE * 2;
 
 	max_heap_size = MIN(CONFIG_NEWLIB_LIBC_MAX_MAPPED_REGION_SIZE,
 			    max_alloc);


### PR DESCRIPTION
In malloc_prepare, in the case where the configured Newlib max heap size is greater than the physically available memory, we allocate as much as possible. Because k_mem_free_get returns all the available page frames but k_mem_map reserves two guard pages (one at the start, one at the end), to avoid a failure in k_mem_map that results in no heap being allocated, subtract the size of those two guard pages.

Signed-off-by: Théophile Ranquet <theophile.ranquet@gmail.com>