### PR TITLE
posix: getopt: move declarations to unistd.h

### DIFF
--- a/include/zephyr/posix/unistd.h
+++ b/include/zephyr/posix/unistd.h
@@ -43,6 +43,12 @@ static inline int gethostname(char *buf, size_t len)
 
 #endif /* CONFIG_POSIX_API */
 
+#ifdef CONFIG_GETOPT
+int getopt(int argc, char *const argv[], const char *optstring);
+extern char *optarg;
+extern int opterr, optind, optopt;
+#endif
+
 unsigned sleep(unsigned int seconds);
 int usleep(useconds_t useconds);
 

--- a/lib/os/crc_shell.c
+++ b/lib/os/crc_shell.c
@@ -5,10 +5,14 @@
  */
 
 #include <errno.h>
-#include <getopt.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#ifdef CONFIG_ARCH_POSIX
+#include <unistd.h>
+#else
+#include <zephyr/posix/unistd.h>
+#endif
 
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
@@ -71,7 +75,6 @@ static int cmd_crc(const struct shell *sh, size_t argc, char **argv)
 	enum crc_type type = CRC32_IEEE;
 
 	optind = 1;
-	optreset = 1;
 
 	while ((rv = getopt(argc, argv, "fhlp:rs:t:")) != -1) {
 		switch (rv) {

--- a/lib/posix/getopt/getopt.c
+++ b/lib/posix/getopt/getopt.c
@@ -30,6 +30,11 @@
  */
 
 #include <string.h>
+#ifdef CONFIG_ARCH_POSIX
+#include <unistd.h>
+#else
+#include <zephyr/posix/unistd.h>
+#endif
 #include "getopt.h"
 #include "getopt_common.h"
 

--- a/lib/posix/getopt/getopt.h
+++ b/lib/posix/getopt/getopt.h
@@ -28,11 +28,7 @@ struct getopt_state {
 #endif
 };
 
-extern int opterr;	/* if error message should be printed */
-extern int optind;	/* index into parent argv vector */
-extern int optopt;	/* character checked for validity */
 extern int optreset;	/* reset getopt */
-extern char *optarg;	/* argument associated with option */
 
 #define no_argument        0
 #define required_argument  1
@@ -57,27 +53,6 @@ void getopt_init(void);
 
 /* Function returns getopt_state structure for the current thread. */
 struct getopt_state *getopt_state_get(void);
-
-/**
- * @brief Parses the command-line arguments.
- *
- * It is based on FreeBSD implementation.
- *
- * @param[in] argc	Arguments count.
- * @param[in] argv	Arguments.
- * @param[in] options	String containing the legitimate option characters.
- *
- * @return		If an option was successfully found, function returns
- *			the option character.
- * @return		If options have been detected that is not in @p options
- *			function will return '?'.
- *			If function encounters an option with a missing
- *			argument, then the return value depends on the first
- *			character in optstring: if it is ':', then ':' is
- *			returned; otherwise '?' is returned.
- * @return -1		If all options have been parsed.
- */
-int getopt(int nargc, char *const nargv[], const char *ostr);
 
 /**
  * @brief Parses the command-line arguments.

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -13,6 +13,12 @@
 #include <zephyr/usb/usb_device.h>
 #include <ctype.h>
 
+#ifdef CONFIG_ARCH_POSIX
+#include <unistd.h>
+#else
+#include <zephyr/posix/unistd.h>
+#endif
+
 LOG_MODULE_REGISTER(app);
 
 extern void foo(void);

--- a/tests/posix/getopt/src/main.c
+++ b/tests/posix/getopt/src/main.c
@@ -12,6 +12,11 @@
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 #include <string.h>
+#ifdef CONFIG_ARCH_POSIX
+#include <unistd.h>
+#else
+#include <zephyr/posix/unistd.h>
+#endif
 #include <getopt.h>
 
 ZTEST_SUITE(getopt_test_suite, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Declarations for `getopt()` should be in `<unistd.h>` according to the spec. The extended versions `getopt_long()` and `getopt_long_only()` are declared in `<getopt.h>`.

Fixes #52749