### PR TITLE
dts: xtensa: intel: update cavs25_tgph to match cavs25

### DIFF
--- a/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
@@ -39,6 +39,36 @@
 		reg = <0xbe800000 DT_SIZE_K(64)>;
 	};
 
+	sysclk: system-clock {
+		compatible = "fixed-clock";
+		clock-frequency = <38400000>;
+		#clock-cells = <0>;
+	};
+
+	audioclk: audio-clock {
+		compatible = "fixed-clock";
+		clock-frequency = <24576000>;
+		#clock-cells = <0>;
+	};
+
+	pllclk: pll-clock {
+		compatible = "fixed-clock";
+		clock-frequency = <96000000>;
+		#clock-cells = <0>;
+	};
+
+	clkctl: clkctl {
+		compatible = "intel,adsp-shim-clkctl";
+		adsp-clkctl-clk-wovcro = <0>;
+		adsp-clkctl-clk-lpro = <1>;
+		adsp-clkctl-clk-hpro = <2>;
+		adsp-clkctl-freq-enc = <0x1a 0x20000002 0x80000002>;
+		adsp-clkctl-freq-mask = <0x10 0x20000000 0x80000000>;
+		adsp-clkctl-freq-default = <2>;
+		adsp-clkctl-freq-lowest = <0>;
+		wovcro-supported;
+	};
+
 	soc {
 		shim: shim@71f00 {
 			compatible = "intel,adsp-shim";
@@ -51,6 +81,7 @@
 			offset = <0x4000>;
 			memory = <&sram0>;
 			initialize;
+			read-only;
 		};
 		mem_window1: mem_window@71a08 {
 			compatible = "intel,adsp-mem-window";
@@ -68,6 +99,7 @@
 			compatible = "intel,adsp-mem-window";
 			reg = <0x71a18 0x8>;
 			memory = <&sram0>;
+			read-only;
 		};
 
 		timer: timer {
@@ -75,9 +107,21 @@
 			syscon = <&shim>;
 		};
 
+		sspbase: ssp_base@71c00 {
+			compatible = "intel,cavs-sspbase";
+			reg = <0x71c00 0x100>;
+		};
+
 		l2lm: l2lm@71d00 {
 			compatible = "intel,cavs-l2lm";
 			reg = <0x71d00 0x20>;
+		};
+
+		adsp_host_ipc: cavs_host_ipc@71e00 {
+			compatible = "intel,adsp-host-ipc";
+			reg = <0x71e00 0x30>;
+			interrupts = <7 0 0>;
+			interrupt-parent = <&cavs_intc0>;
 		};
 
 		core_intc: core_intc@0 {
@@ -134,6 +178,221 @@
 			compatible = "intel,adsp-tlb";
 			reg = <0x3000 0x1000>;
 			paddr-size = <11>;
+		};
+
+		dmic0: dmic0@10000 {
+			compatible = "intel,dai-dmic";
+			reg = <0x10000 0x8000>;
+			shim = <0x71E80>;
+			fifo = <0x0008>;
+			interrupts = <0x08 0 0>;
+			interrupt-parent = <&cavs_intc3>;
+		};
+
+		dmic1: dmic1@10000 {
+			compatible = "intel,dai-dmic";
+			reg = <0x10000 0x8000>;
+			shim = <0x71E80>;
+			fifo = <0x0108>;
+			interrupts = <0x09 0 0>;
+			interrupt-parent = <&cavs_intc3>;
+		};
+
+		/*
+		 * FIXME this is modeling individual alh channels/instances
+		 * with node labels, which has problems. A better representation
+		 * is discussed here:
+		 *
+		 * https://github.com/zephyrproject-rtos/zephyr/pull/50287#discussion_r974591009
+		 */
+		alh0: alh0@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+
+			status = "okay";
+		};
+
+		alh1: alh1@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+
+			status = "okay";
+		};
+
+		ssp0: ssp@77000 {
+			compatible = "intel,ssp-dai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x00077000 0x200
+			       0x00078C00 0x008>;
+			interrupts = <0x01 0 0>;
+			interrupt-parent = <&cavs_intc3>;
+			dmas = <&lpgpdma0 2
+				&lpgpdma0 3>;
+			dma-names = "tx", "rx";
+
+			status = "okay";
+		};
+
+		ssp1: ssp@77200 {
+			compatible = "intel,ssp-dai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x00077200 0x200
+			       0x00078C00 0x008>;
+			interrupts = <0x01 0 0>;
+			interrupt-parent = <&cavs_intc3>;
+			dmas = <&lpgpdma0 4
+				&lpgpdma0 5>;
+			dma-names = "tx", "rx";
+
+			status = "okay";
+		};
+
+		ssp2: ssp@77400 {
+			compatible = "intel,ssp-dai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x00077400 0x200
+			       0x00078C00 0x008>;
+			interrupts = <0x02 0 0>;
+			interrupt-parent = <&cavs_intc3>;
+			dmas = <&lpgpdma0 6
+				&lpgpdma0 7>;
+			dma-names = "tx", "rx";
+
+			status = "okay";
+		};
+
+		ssp3: ssp@77600 {
+			compatible = "intel,ssp-dai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x00077600 0x200
+			       0x00078C00 0x008>;
+			interrupts = <0x03 0 0>;
+			interrupt-parent = <&cavs_intc3>;
+			dmas = <&lpgpdma0 8
+				&lpgpdma0 9>;
+			dma-names = "tx", "rx";
+
+			status = "okay";
+		};
+
+		ssp4: ssp@77800 {
+			compatible = "intel,ssp-dai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x00077800 0x200
+			       0x00078C00 0x008>;
+			interrupts = <0x03 0 0>;
+			interrupt-parent = <&cavs_intc3>;
+			dmas = <&lpgpdma0 10
+				&lpgpdma0 11>;
+			dma-names = "tx", "rx";
+
+			status = "okay";
+		};
+
+		ssp5: ssp@77a00 {
+			compatible = "intel,ssp-dai";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x00077A00 0x200
+			       0x00078C00 0x008>;
+			interrupts = <0x03 0 0>;
+			interrupt-parent = <&cavs_intc3>;
+			dmas = <&lpgpdma0 12
+				&lpgpdma0 13>;
+			dma-names = "tx", "rx";
+
+			status = "okay";
+		};
+	};
+
+	hdas {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		hda0: hda@0 {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <0>;
+		};
+		hda1: hda@1 {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <1>;
+		};
+		hda2: hda@2 {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <2>;
+		};
+		hda3: hda@3 {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <3>;
+		};
+		hda4: hda@4 {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <4>;
+		};
+		hda5: hda@5 {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <5>;
+		};
+		hda6: hda@6 {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <6>;
+		};
+		hda7: hda@7 {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <7>;
+		};
+		hda8: hda@8 {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <8>;
+		};
+		hda9: hda@9 {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <9>;
+		};
+		hda10: hda@a {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <0x0a>;
+		};
+		hda11: hda@b {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <0x0b>;
+		};
+		hda12: hda@c {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <0x0c>;
+		};
+		hda13: hda@d {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <0x0d>;
+		};
+		hda14: hda@e {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <0x0e>;
+		};
+		hda15: hda@f {
+			compatible = "intel,hda-dai";
+			status = "okay";
+			reg = <0x0f>;
 		};
 	};
 };


### PR DESCRIPTION
Add definitions for DMAs, Digital Audio Interfaces (DAIs) and the necessary clocks to enable full use of audio peripherals in the intel_adsp_cavs25_tgph boards.

Link: https://github.com/thesofproject/sof/issues/6710
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>