### PR TITLE
spi: deprecate `spi_is_ready` function in favor of `spi_is_ready_dt`

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -124,6 +124,8 @@ Deprecated in this release
 * PCIe APIs :c:func:`pcie_probe` and :c:func:`pcie_bdf_lookup` have been
   deprecated in favor of a centralized scan of available PCIe devices.
 
+* SPI DT :c:func:`spi_is_ready` function has been deprecated in favor of :c:func:`spi_is_ready_dt`.
+
 Stable API changes in this release
 ==================================
 

--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -940,7 +940,7 @@ static int lmp90xxx_init(const struct device *dev)
 	/* Force INST1 + UAB on first access */
 	data->ura = LMP90XXX_INVALID_URA;
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/adc/adc_mcp320x.c
+++ b/drivers/adc/adc_mcp320x.c
@@ -274,7 +274,7 @@ static int mcp320x_init(const struct device *dev)
 
 	k_sem_init(&data->sem, 0, 1);
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("SPI bus is not ready");
 		return -ENODEV;
 	}

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -521,7 +521,7 @@ static int bt_spi_init(const struct device *unused)
 {
 	ARG_UNUSED(unused);
 
-	if (!spi_is_ready(&bus)) {
+	if (!spi_is_ready_dt(&bus)) {
 		LOG_ERR("SPI device not ready");
 		return -ENODEV;
 	}

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -953,7 +953,7 @@ static int mcp2515_init(const struct device *dev)
 		}
 	}
 
-	if (!spi_is_ready(&dev_cfg->bus)) {
+	if (!spi_is_ready_dt(&dev_cfg->bus)) {
 		LOG_ERR("SPI bus %s not ready", dev_cfg->bus.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/dac/dac_dacx0508.c
+++ b/drivers/dac/dac_dacx0508.c
@@ -330,7 +330,7 @@ static int dacx0508_init(const struct device *dev)
 	struct dacx0508_data *data = dev->data;
 	int ret;
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -351,7 +351,7 @@ static int ili9xxx_init(const struct device *dev)
 
 	int r;
 
-	if (!spi_is_ready(&config->spi)) {
+	if (!spi_is_ready_dt(&config->spi)) {
 		LOG_ERR("SPI device is not ready");
 		return -ENODEV;
 	}

--- a/drivers/display/display_max7219.c
+++ b/drivers/display/display_max7219.c
@@ -314,7 +314,7 @@ static int max7219_init(const struct device *dev)
 	struct max7219_data *dev_data = dev->data;
 	int ret;
 
-	if (!spi_is_ready(&dev_config->spi)) {
+	if (!spi_is_ready_dt(&dev_config->spi)) {
 		LOG_ERR("SPI device not ready");
 		return -ENODEV;
 	}

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -439,7 +439,7 @@ static int st7735r_init(const struct device *dev)
 	const struct st7735r_config *config = dev->config;
 	int ret;
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -347,7 +347,7 @@ static int st7789v_init(const struct device *dev)
 {
 	const struct st7789v_config *config = dev->config;
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("SPI device not ready");
 		return -ENODEV;
 	}

--- a/drivers/display/ls0xx.c
+++ b/drivers/display/ls0xx.c
@@ -264,7 +264,7 @@ static int ls0xx_init(const struct device *dev)
 {
 	const struct ls0xx_config *config = dev->config;
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -93,7 +93,7 @@ static inline bool ssd1306_bus_ready(const struct device *dev)
 		return false;
 	}
 
-	return spi_is_ready(&config->bus);
+	return spi_is_ready_dt(&config->bus);
 }
 
 static inline int ssd1306_write_bus(const struct device *dev,

--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -844,7 +844,7 @@ static int ssd16xx_init(const struct device *dev)
 
 	LOG_DBG("");
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/display/uc81xx.c
+++ b/drivers/display/uc81xx.c
@@ -618,7 +618,7 @@ static int uc81xx_init(const struct device *dev)
 
 	LOG_DBG("");
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -353,7 +353,7 @@ static bool eeprom_at25_bus_is_ready(const struct device *dev)
 {
 	const struct eeprom_at2x_config *config = dev->config;
 
-	return spi_is_ready(&config->bus.spi);
+	return spi_is_ready_dt(&config->bus.spi);
 }
 
 static int eeprom_at25_rdsr(const struct device *dev, uint8_t *status)

--- a/drivers/ethernet/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa_ksz8xxx.c
@@ -675,7 +675,7 @@ int dsa_hw_init(struct ksz8xxx_data *pdev)
 #endif
 
 #if defined(CONFIG_DSA_SPI)
-	if (!spi_is_ready(&pdev->spi)) {
+	if (!spi_is_ready_dt(&pdev->spi)) {
 		LOG_ERR("SPI bus %s is not ready",
 			pdev->spi.bus->name);
 		return -ENODEV;

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -782,7 +782,7 @@ static int eth_enc28j60_init(const struct device *dev)
 	struct eth_enc28j60_runtime *context = dev->data;
 
 	/* SPI config */
-	if (!spi_is_ready(&config->spi)) {
+	if (!spi_is_ready_dt(&config->spi)) {
 		LOG_ERR("SPI master port %s not ready", config->spi.bus->name);
 		return -EINVAL;
 	}

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -656,7 +656,7 @@ static int enc424j600_init(const struct device *dev)
 	context->dev = dev;
 
 	/* SPI config */
-	if (!spi_is_ready(&config->spi)) {
+	if (!spi_is_ready_dt(&config->spi)) {
 		LOG_ERR("SPI master port %s not ready", config->spi.bus->name);
 		return -EINVAL;
 	}

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -473,7 +473,7 @@ static int w5500_init(const struct device *dev)
 	const struct w5500_config *config = dev->config;
 	struct w5500_runtime *ctx = dev->data;
 
-	if (!spi_is_ready(&config->spi)) {
+	if (!spi_is_ready_dt(&config->spi)) {
 		LOG_ERR("SPI master port %s not ready", config->spi.bus->name);
 		return -EINVAL;
 	}

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -542,7 +542,7 @@ static int spi_flash_at45_init(const struct device *dev)
 	const struct spi_flash_at45_config *dev_config = dev->config;
 	int err;
 
-	if (!spi_is_ready(&dev_config->bus)) {
+	if (!spi_is_ready_dt(&dev_config->bus)) {
 		LOG_ERR("SPI bus %s not ready", dev_config->bus.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1139,7 +1139,7 @@ static int spi_nor_configure(const struct device *dev)
 	int rc;
 
 	/* Validate bus and CS is ready */
-	if (!spi_is_ready(&cfg->spi)) {
+	if (!spi_is_ready_dt(&cfg->spi)) {
 		return -ENODEV;
 	}
 

--- a/drivers/gpio/gpio_mcp23s17.c
+++ b/drivers/gpio/gpio_mcp23s17.c
@@ -359,7 +359,7 @@ static int mcp23s17_init(const struct device *dev)
 	const struct mcp23s17_config *config = dev->config;
 	struct mcp23s17_drv_data *drv_data = dev->data;
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/gpio/gpio_mcp23sxx.c
+++ b/drivers/gpio/gpio_mcp23sxx.c
@@ -105,7 +105,7 @@ static int mcp23sxx_bus_is_ready(const struct device *dev)
 {
 	const struct mcp23xxx_config *config = dev->config;
 
-	if (!spi_is_ready(&config->bus.spi)) {
+	if (!spi_is_ready_dt(&config->bus.spi)) {
 		LOG_ERR("SPI bus %s not ready", config->bus.spi.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/gpio/gpio_sn74hc595.c
+++ b/drivers/gpio/gpio_sn74hc595.c
@@ -165,7 +165,7 @@ static int gpio_sn74hc595_init(const struct device *dev)
 	const struct gpio_sn74hc595_config *config = dev->config;
 	struct gpio_sn74hc595_drv_data *drv_data = dev->data;
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -744,7 +744,7 @@ static int cc1200_init(const struct device *dev)
 	}
 	gpio_pin_configure_dt(&config->interrupt, GPIO_INPUT);
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("SPI bus %s is not ready", config->bus.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -989,7 +989,7 @@ static int cc2520_init(const struct device *dev)
 		return -EIO;
 	}
 
-	if (!spi_is_ready(&cfg->bus)) {
+	if (!spi_is_ready_dt(&cfg->bus)) {
 		LOG_ERR("SPI bus %s not ready", cfg->bus.bus->name);
 		return -EIO;
 	}

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -1494,7 +1494,7 @@ static int dw1000_init(const struct device *dev)
 	memcpy(&ctx->spi_cfg_slow, &hi_cfg->bus.config, sizeof(ctx->spi_cfg_slow));
 	ctx->spi_cfg_slow.frequency = DWT_SPI_SLOW_FREQ;
 
-	if (!spi_is_ready(&hi_cfg->bus)) {
+	if (!spi_is_ready_dt(&hi_cfg->bus)) {
 		LOG_ERR("SPI device not ready");
 		return -ENODEV;
 	}

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1381,7 +1381,7 @@ static int mcr20a_init(const struct device *dev)
 		return -EIO;
 	}
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("Configuring SPI failed");
 		return -EIO;
 	}

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -964,7 +964,7 @@ static inline int configure_spi(const struct device *dev)
 {
 	const struct rf2xx_config *conf = dev->config;
 
-	if (!spi_is_ready(&conf->spi)) {
+	if (!spi_is_ready_dt(&conf->spi)) {
 		LOG_ERR("SPI bus %s is not ready",
 			conf->spi.bus->name);
 		return -ENODEV;

--- a/drivers/led_strip/apa102.c
+++ b/drivers/led_strip/apa102.c
@@ -84,7 +84,7 @@ static int apa102_init(const struct device *dev)
 {
 	const struct apa102_config *config = dev->config;
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		return -ENODEV;
 	}
 

--- a/drivers/led_strip/lpd880x.c
+++ b/drivers/led_strip/lpd880x.c
@@ -129,7 +129,7 @@ static int lpd880x_strip_init(const struct device *dev)
 {
 	const struct lpd880x_config *config = dev->config;
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("SPI device %s not ready", config->bus.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/led_strip/tlc5971.c
+++ b/drivers/led_strip/tlc5971.c
@@ -292,7 +292,7 @@ static int tlc5971_init(const struct device *dev)
 	const struct tlc5971_config *cfg = dev->config;
 	struct tlc5971_data *data = dev->data;
 
-	if (!spi_is_ready(&cfg->bus)) {
+	if (!spi_is_ready_dt(&cfg->bus)) {
 		LOG_ERR("%s: SPI device %s not ready", dev->name, cfg->bus.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/led_strip/ws2812_spi.c
+++ b/drivers/led_strip/ws2812_spi.c
@@ -167,7 +167,7 @@ static int ws2812_spi_init(const struct device *dev)
 	const struct ws2812_spi_cfg *cfg = dev_cfg(dev);
 	uint8_t i;
 
-	if (!spi_is_ready(&cfg->bus)) {
+	if (!spi_is_ready_dt(&cfg->bus)) {
 		LOG_ERR("SPI device %s not ready", cfg->bus.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/lora/sx126x.c
+++ b/drivers/lora/sx126x.c
@@ -449,7 +449,7 @@ static int sx126x_lora_init(const struct device *dev)
 		return ret;
 	}
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("SPI device not ready");
 		return -ENODEV;
 	}

--- a/drivers/lora/sx127x.c
+++ b/drivers/lora/sx127x.c
@@ -582,7 +582,7 @@ static int sx127x_lora_init(const struct device *dev)
 	int ret;
 	uint8_t regval;
 
-	if (!spi_is_ready(&dev_config.bus)) {
+	if (!spi_is_ready_dt(&dev_config.bus)) {
 		LOG_ERR("SPI device not ready");
 		return -ENODEV;
 	}

--- a/drivers/misc/ft8xx/ft8xx_drv.c
+++ b/drivers/misc/ft8xx/ft8xx_drv.c
@@ -55,7 +55,7 @@ int ft8xx_drv_init(void)
 {
 	int ret;
 
-	if (!spi_is_ready(&spi)) {
+	if (!spi_is_ready_dt(&spi)) {
 		LOG_ERR("SPI bus %s not ready", spi.bus->name);
 		return -ENODEV;
 	}

--- a/drivers/sensor/adxl345/adxl345.c
+++ b/drivers/sensor/adxl345/adxl345.c
@@ -39,7 +39,7 @@ static int adxl345_reg_access_i2c(const struct device *dev, uint8_t cmd, uint8_t
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 static bool adxl345_bus_is_ready_spi(const union adxl345_bus *bus)
 {
-	return spi_is_ready(&bus->spi);
+	return spi_is_ready_dt(&bus->spi);
 }
 
 static int adxl345_reg_access_spi(const struct device *dev, uint8_t cmd, uint8_t reg_addr,

--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -708,7 +708,7 @@ static int adxl362_init(const struct device *dev)
 	uint8_t value;
 	int err;
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_DBG("spi device not ready: %s", config->bus.bus->name);
 		return -EINVAL;
 	}

--- a/drivers/sensor/adxl372/adxl372_spi.c
+++ b/drivers/sensor/adxl372/adxl372_spi.c
@@ -109,7 +109,7 @@ int adxl372_spi_init(const struct device *dev)
 
 	data->hw_tf = &adxl372_spi_transfer_fn;
 
-	if (!spi_is_ready(&config->spi)) {
+	if (!spi_is_ready_dt(&config->spi)) {
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bme280/bme280_spi.c
+++ b/drivers/sensor/bme280/bme280_spi.c
@@ -19,7 +19,7 @@ LOG_MODULE_DECLARE(BME280, CONFIG_SENSOR_LOG_LEVEL);
 
 static int bme280_bus_check_spi(const union bme280_bus *bus)
 {
-	return spi_is_ready(&bus->spi) ? 0 : -ENODEV;
+	return spi_is_ready_dt(&bus->spi) ? 0 : -ENODEV;
 }
 
 static int bme280_reg_read_spi(const union bme280_bus *bus,

--- a/drivers/sensor/bme680/bme680_spi.c
+++ b/drivers/sensor/bme680/bme680_spi.c
@@ -20,7 +20,7 @@ LOG_MODULE_DECLARE(bme680, CONFIG_SENSOR_LOG_LEVEL);
 
 static int bme680_bus_check_spi(const union bme680_bus *bus)
 {
-	return spi_is_ready(&bus->spi) ? 0 : -ENODEV;
+	return spi_is_ready_dt(&bus->spi) ? 0 : -ENODEV;
 }
 
 static inline int bme680_set_mem_page(const struct device *dev, uint8_t addr)

--- a/drivers/sensor/bmi160/bmi160.c
+++ b/drivers/sensor/bmi160/bmi160.c
@@ -60,7 +60,7 @@ bool bmi160_bus_ready_spi(const struct device *dev)
 {
 	const struct bmi160_cfg *cfg = dev->config;
 
-	return spi_is_ready(&cfg->bus.spi);
+	return spi_is_ready_dt(&cfg->bus.spi);
 }
 
 int bmi160_read_spi(const struct device *dev,

--- a/drivers/sensor/bmi270/bmi270_spi.c
+++ b/drivers/sensor/bmi270/bmi270_spi.c
@@ -16,7 +16,7 @@ LOG_MODULE_DECLARE(bmi270, CONFIG_SENSOR_LOG_LEVEL);
 
 static int bmi270_bus_check_spi(const union bmi270_bus *bus)
 {
-	return spi_is_ready(&bus->spi) ? 0 : -ENODEV;
+	return spi_is_ready_dt(&bus->spi) ? 0 : -ENODEV;
 }
 
 static int bmi270_reg_read_spi(const union bmi270_bus *bus,

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -605,7 +605,7 @@ static int bmp388_init(const struct device *dev)
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 	/* Verify the SPI bus */
 	if (is_spi) {
-		if (!spi_is_ready(&cfg->spi)) {
+		if (!spi_is_ready_dt(&cfg->spi)) {
 			LOG_ERR("SPI bus is not ready");
 			return -ENODEV;
 		}

--- a/drivers/sensor/i3g4250d/i3g4250d_spi.c
+++ b/drivers/sensor/i3g4250d/i3g4250d_spi.c
@@ -92,7 +92,7 @@ int i3g4250d_spi_init(const struct device *dev)
 	struct i3g4250d_data *i3g4250d = dev->data;
 	const struct i3g4250d_device_config *cfg = dev->config;
 
-	if (!spi_is_ready(&cfg->spi)) {
+	if (!spi_is_ready_dt(&cfg->spi)) {
 		LOG_ERR("spi not ready");
 		return -ENODEV;
 	}

--- a/drivers/sensor/icm42605/icm42605.c
+++ b/drivers/sensor/icm42605/icm42605.c
@@ -392,7 +392,7 @@ static int icm42605_init(const struct device *dev)
 	struct icm42605_data *drv_data = dev->data;
 	const struct icm42605_config *cfg = dev->config;
 
-	if (!spi_is_ready(&cfg->spi)) {
+	if (!spi_is_ready_dt(&cfg->spi)) {
 		LOG_ERR("SPI bus is not ready");
 		return -ENODEV;
 	}

--- a/drivers/sensor/icm42670/icm42670.c
+++ b/drivers/sensor/icm42670/icm42670.c
@@ -621,7 +621,7 @@ static int icm42670_init(const struct device *dev)
 	struct icm42670_data *data = dev->data;
 	const struct icm42670_config *cfg = dev->config;
 
-	if (!spi_is_ready(&cfg->spi)) {
+	if (!spi_is_ready_dt(&cfg->spi)) {
 		LOG_ERR("SPI bus is not ready");
 		return -ENODEV;
 	}

--- a/drivers/sensor/iis2dh/iis2dh_spi.c
+++ b/drivers/sensor/iis2dh/iis2dh_spi.c
@@ -92,7 +92,7 @@ int iis2dh_spi_init(const struct device *dev)
 	struct iis2dh_data *data = dev->data;
 	const struct iis2dh_device_config *config = dev->config;
 
-	if (!spi_is_ready(&config->spi)) {
+	if (!spi_is_ready_dt(&config->spi)) {
 		LOG_ERR("Bus device is not ready");
 		return -ENODEV;
 	}

--- a/drivers/sensor/iis2mdc/iis2mdc_spi.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_spi.c
@@ -95,7 +95,7 @@ int iis2mdc_spi_init(const struct device *dev)
 	struct iis2mdc_data *data = dev->data;
 	const struct iis2mdc_dev_config *const cfg = dev->config;
 
-	if (!spi_is_ready(&cfg->spi)) {
+	if (!spi_is_ready_dt(&cfg->spi)) {
 		LOG_ERR("SPI bus is not ready");
 		return -ENODEV;
 	}

--- a/drivers/sensor/iis3dhhc/iis3dhhc.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.c
@@ -194,7 +194,7 @@ static int iis3dhhc_init(const struct device *dev)
 {
 	const struct iis3dhhc_config * const config = dev->config;
 
-	if (!spi_is_ready(&config->spi)) {
+	if (!spi_is_ready_dt(&config->spi)) {
 		LOG_ERR("SPI bus is not ready");
 		return -ENODEV;
 	}

--- a/drivers/sensor/iis3dhhc/iis3dhhc_spi.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_spi.c
@@ -91,7 +91,7 @@ int iis3dhhc_spi_init(const struct device *dev)
 	struct iis3dhhc_data *data = dev->data;
 	const struct iis3dhhc_config *config = dev->config;
 
-	if (!spi_is_ready(&config->spi)) {
+	if (!spi_is_ready_dt(&config->spi)) {
 		LOG_ERR("SPI bus is not ready");
 		return -ENODEV;
 	};

--- a/drivers/sensor/ism330dhcx/ism330dhcx_spi.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_spi.c
@@ -97,7 +97,7 @@ int ism330dhcx_spi_init(const struct device *dev)
 	struct ism330dhcx_data *data = dev->data;
 	const struct ism330dhcx_config *cfg = dev->config;
 
-	if (!spi_is_ready(&cfg->spi)) {
+	if (!spi_is_ready_dt(&cfg->spi)) {
 		LOG_ERR("SPI bus is not ready");
 		return -ENODEV;
 	};

--- a/drivers/sensor/lis2dh/lis2dh_spi.c
+++ b/drivers/sensor/lis2dh/lis2dh_spi.c
@@ -155,7 +155,7 @@ int lis2dh_spi_init(const struct device *dev)
 
 	data->hw_tf = &lis2dh_spi_transfer_fn;
 
-	if (!spi_is_ready(&cfg->bus_cfg.spi)) {
+	if (!spi_is_ready_dt(&cfg->bus_cfg.spi)) {
 		LOG_ERR("SPI bus is not ready");
 		return -ENODEV;
 	}

--- a/drivers/sensor/lsm6dsl/lsm6dsl_spi.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_spi.c
@@ -135,7 +135,7 @@ int lsm6dsl_spi_init(const struct device *dev)
 
 	data->hw_tf = &lsm6dsl_spi_transfer_fn;
 
-	if (!spi_is_ready(&cfg->bus_cfg.spi)) {
+	if (!spi_is_ready_dt(&cfg->bus_cfg.spi)) {
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/max6675/max6675.c
+++ b/drivers/sensor/max6675/max6675.c
@@ -91,7 +91,7 @@ static int max6675_init(const struct device *dev)
 {
 	const struct max6675_config *config = dev->config;
 
-	if (!spi_is_ready(&config->spi)) {
+	if (!spi_is_ready_dt(&config->spi)) {
 		LOG_ERR("SPI bus is not ready");
 		return -ENODEV;
 	}

--- a/drivers/sensor/ms5607/ms5607_spi.c
+++ b/drivers/sensor/ms5607/ms5607_spi.c
@@ -140,7 +140,7 @@ static int ms5607_spi_read_adc(const struct ms5607_config *config, uint32_t *val
 
 static int ms5607_spi_check(const struct ms5607_config *config)
 {
-	if (!spi_is_ready(&config->bus_cfg.spi)) {
+	if (!spi_is_ready_dt(&config->bus_cfg.spi)) {
 		LOG_DBG("SPI bus not ready");
 		return -ENODEV;
 	}

--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -242,7 +242,7 @@ int eswifi_spi_init(struct eswifi_dev *eswifi)
 	gpio_pin_configure_dt(&cfg->dr, GPIO_INPUT);
 
 	/* SPI BUS */
-	if (!spi_is_ready(&cfg->bus)) {
+	if (!spi_is_ready_dt(&cfg->bus)) {
 		LOG_ERR("SPI bus is not ready");
 		return -ENODEV;
 	};

--- a/drivers/wifi/winc1500/wifi_winc1500_nm_bus_wrapper.c
+++ b/drivers/wifi/winc1500/wifi_winc1500_nm_bus_wrapper.c
@@ -109,7 +109,7 @@ int8_t nm_bus_init(void *pvinit)
 	/* Not implemented */
 #elif defined CONF_WINC_USE_SPI
 	/* setup SPI device */
-	if (!spi_is_ready(&winc1500_config.spi)) {
+	if (!spi_is_ready_dt(&winc1500_config.spi)) {
 		LOG_ERR("spi device binding");
 		return -ENODEV;
 	}

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -392,6 +392,7 @@ struct spi_dt_spec {
  * Important: multiple fields are automatically constructed by this macro
  * which must be checked before use. @ref spi_is_ready performs the required
  * @ref device_is_ready checks.
+ * @deprecated Use @ref spi_is_ready_dt instead.
  *
  * This macro is not available in C++.
  *
@@ -508,6 +509,7 @@ __subsystem struct spi_driver_api {
  * @retval true if the SPI bus is ready for use.
  * @retval false if the SPI bus is not ready for use.
  */
+__deprecated
 static inline bool spi_is_ready(const struct spi_dt_spec *spec)
 {
 	/* Validate bus is ready */

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -523,6 +523,27 @@ static inline bool spi_is_ready(const struct spi_dt_spec *spec)
 }
 
 /**
+ * @brief Validate that SPI bus (and CS gpio if defined) is ready.
+ *
+ * @param spec SPI specification from devicetree
+ *
+ * @retval true if the SPI bus is ready for use.
+ * @retval false if the SPI bus (or the CS gpio defined) is not ready for use.
+ */
+static inline bool spi_is_ready_dt(const struct spi_dt_spec *spec)
+{
+	/* Validate bus is ready */
+	if (!device_is_ready(spec->bus)) {
+		return false;
+	}
+	/* Validate CS gpio port is ready, if it is used */
+	if (spec->config.cs &&
+	    !device_is_ready(spec->config.cs->gpio.port)) {
+		return false;
+	}
+	return true;
+}
+/**
  * @brief Read/write the specified amount of data from the SPI driver.
  *
  * @note This function is synchronous.

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -543,7 +543,7 @@ ZTEST(spi_loopback, test_spi_loopback)
 					  &async_evt, &caller, NULL,
 					  K_PRIO_COOP(7), 0, K_NO_WAIT);
 #endif
-	zassert_true(spi_is_ready(&spi_slow), "Slow spi lookback device is not ready");
+	zassert_true(spi_is_ready_dt(&spi_slow), "Slow spi lookback device is not ready");
 
 	LOG_INF("SPI test slow config");
 
@@ -560,7 +560,7 @@ ZTEST(spi_loopback, test_spi_loopback)
 		goto end;
 	}
 
-	zassert_true(spi_is_ready(&spi_fast), "Fast spi lookback device is not ready");
+	zassert_true(spi_is_ready_dt(&spi_fast), "Fast spi lookback device is not ready");
 
 	LOG_INF("SPI test fast config");
 


### PR DESCRIPTION
Add a new `spi_is_ready_dt` function to validate SPI `spi_dt_spec` member object instead of the old `spi_is_ready` which is being deprecated. Replace the usage of the old function in the tree with the new one and add a note in the release notes about deprecation.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>