### PR TITLE
stm32h7: add usb hs ulpi support

### DIFF
--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -43,6 +43,11 @@
 		};
 	};
 
+	otghs_ulpi_phy: otghs_ulpis_phy {
+		compatible = "usb-ulpi-phy";
+		#phy-cells = <0>;
+	};
+
 	aliases {
 		led0 = &green_led_1;
 		led1 = &orange_led_2;
@@ -167,6 +172,27 @@
 			st,sdram-timing = <2 6 4 6 2 2 2>;
 		};
 	};
+};
+
+zephyr_udc0: &usbotg_hs {
+	pinctrl-0 = <&usb_otg_hs_ulpi_ck_pa5
+			&usb_otg_hs_ulpi_d0_pa3
+			&usb_otg_hs_ulpi_d1_pb0
+			&usb_otg_hs_ulpi_d2_pb1
+			&usb_otg_hs_ulpi_d3_pb10
+			&usb_otg_hs_ulpi_d4_pb11
+			&usb_otg_hs_ulpi_d5_pb12
+			&usb_otg_hs_ulpi_d6_pb13
+			&usb_otg_hs_ulpi_d7_pb5
+			&usb_otg_hs_ulpi_stp_pc0
+			&usb_otg_hs_ulpi_dir_pi11
+			&usb_otg_hs_ulpi_nxt_ph4>;
+	pinctrl-names = "default";
+	maximum-speed = "high-speed";
+	/* Include the USB1ULPIEN clock enable bit */
+	clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x06000000>;
+	phys = <&otghs_ulpi_phy>;
+	status = "okay";
 };
 
 &sdmmc1 {

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.yaml
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.yaml
@@ -15,3 +15,5 @@ supported:
   - spi
   - netif:eth
   - memc
+  - usb_cdc
+  - usb_device

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -40,6 +40,9 @@ config USB_DC_RPI_PICO
 	help
 	  Enable USB support on the RP2 family of processors.
 
+DT_STM32_USBHS := $(dt_nodelabel_path,usbotg_hs)
+DT_STM32_USBHS_SPEED := $(dt_node_str_prop_equals,$(DT_STM32_USBHS),maximum-speed,high-speed)
+
 config USB_DC_STM32
 	bool "USB device controller driver for STM32 devices"
 	default y
@@ -49,6 +52,7 @@ config USB_DC_STM32
 	select USE_STM32_LL_USB
 	select USE_STM32_HAL_PCD
 	select USE_STM32_HAL_PCD_EX
+	select USB_DC_HAS_HS_SUPPORT if "$(DT_STM32_USBHS_SPEED)"
 	help
 	  Enable STM32 family USB device controller shim driver.
 

--- a/dts/arm/st/h7/stm32h745.dtsi
+++ b/dts/arm/st/h7/stm32h745.dtsi
@@ -39,6 +39,19 @@
 			status = "disabled";
 		};
 
+		usbotg_hs: usb@40040000 {
+			compatible = "st,stm32-otghs";
+			reg = <0x40040000 0x40000>;
+			interrupts = <74 0>, <75 0>, <76 0>, <77 0>;
+			interrupt-names = "ep1_out", "ep1_in", "wkup", "otghs";
+			num-bidir-endpoints = <9>;
+			ram-size = <4096>;
+			maximum-speed = "full-speed";
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x02000000>;
+			phys = <&otghs_fs_phy>;
+			status = "disabled";
+		};
+
 		usbotg_fs: usb@40080000 {
 			compatible = "st,stm32-otgfs";
 			reg = <0x40080000 0x40000>;

--- a/dts/bindings/phy/usb-ulpi-phy.yaml
+++ b/dts/bindings/phy/usb-ulpi-phy.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2022 Meta Platforms
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    This binding is to be used by all the usb transceivers which are an external
+    ULPI phy
+
+compatible: "usb-ulpi-phy"
+
+include: phy-controller.yaml
+
+properties:
+    "#phy-cells":
+      const: 0
+
+    reset-gpios:
+      type: phandle-array
+      required: false
+      description: |
+        GPIO connected to the ulpi RESET pin.

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 15993325e3aa961fbf5ffc17583ab1d4fed1e0bc
+      revision: e1c54e99a40da705c156ae3464a14720e7d668c8
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Add support for the STM32H7 USB OTG HS and support for the ULPI PHY. Add the ulpi definition example with the STM32H747-Disco Board.

Signed-off-by: Ryan McClelland <ryanmcclelland@meta.com>