### PR TITLE
tests: settings: remove passing -DTEST_${TEST} from cmake

### DIFF
--- a/tests/subsys/settings/file_littlefs/CMakeLists.txt
+++ b/tests/subsys/settings/file_littlefs/CMakeLists.txt
@@ -6,9 +6,3 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(littlefs_raw)
 
 add_subdirectory(./src littlefs_test_bindir)
-
-if(TEST)
-	target_compile_definitions(app PRIVATE
-		-DTEST_${TEST}
-		)
-endif()

--- a/tests/subsys/settings/functional/fcb/CMakeLists.txt
+++ b/tests/subsys/settings/functional/fcb/CMakeLists.txt
@@ -8,9 +8,3 @@ project(functional_fcb)
 target_sources(app PRIVATE settings_test_fcb.c)
 
 add_subdirectory(../src func_test_bindir)
-
-if(TEST)
-	target_compile_definitions(app PRIVATE
-		-DTEST_${TEST}
-		)
-endif()

--- a/tests/subsys/settings/functional/file/CMakeLists.txt
+++ b/tests/subsys/settings/functional/file/CMakeLists.txt
@@ -11,9 +11,3 @@ zephyr_include_directories(
 	${ZEPHYR_BASE}/subsys/settings/include
 	${ZEPHYR_BASE}/subsys/settings/src
 	)
-
-if(TEST)
-	target_compile_definitions(app PRIVATE
-		-DTEST_${TEST}
-		)
-endif()

--- a/tests/subsys/settings/functional/nvs/CMakeLists.txt
+++ b/tests/subsys/settings/functional/nvs/CMakeLists.txt
@@ -8,9 +8,3 @@ project(functional_nvs)
 target_sources(app PRIVATE settings_test_nvs.c)
 
 add_subdirectory(../src func_test_bindir)
-
-if(TEST)
-	target_compile_definitions(app PRIVATE
-		-DTEST_${TEST}
-		)
-endif()

--- a/tests/subsys/settings/nvs/CMakeLists.txt
+++ b/tests/subsys/settings/nvs/CMakeLists.txt
@@ -5,9 +5,3 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test_settings_nvs_raw)
 
 add_subdirectory(./src nvs_test_bindir)
-
-if(TEST)
-	target_compile_definitions(app PRIVATE
-		-DTEST_${TEST}
-		)
-endif()


### PR DESCRIPTION
This feature is not used in most tests, as there is no logic in C code that
utilizes `#ifdef TEST_x` statement.

The only test that does that is `tests/subsys/settings/fcb/` where `#ifdef
TEST_LONG` is used, so leave that test case untouched.