### PR TITLE
spsc_pbuf: Fix cache wb in spsc_pbuf_free

### DIFF
--- a/lib/os/spsc_pbuf.c
+++ b/lib/os/spsc_pbuf.c
@@ -346,7 +346,7 @@ void spsc_pbuf_free(struct spsc_pbuf *pb, uint16_t len)
 
 	*rd_idx_loc = rd_idx;
 	__sync_synchronize();
-	cache_wb(&rd_idx_loc, sizeof(*rd_idx_loc), flags);
+	cache_wb(rd_idx_loc, sizeof(*rd_idx_loc), flags);
 }
 
 int spsc_pbuf_read(struct spsc_pbuf *pb, char *buf, uint16_t len)


### PR DESCRIPTION
This commit properly writes back cached read pointer in spsc buffer when freeing the memory.

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>