### PR TITLE
samples: jesd216: fix integration platforms

### DIFF
--- a/samples/drivers/jesd216/sample.yaml
+++ b/samples/drivers/jesd216/sample.yaml
@@ -19,4 +19,4 @@ tests:
       OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_spi.conf
     platform_allow: nrf52840dk_nrf52840
     integration_platforms:
-      - nrf52840dongle_nrf52840
+      - nrf52840dk_nrf52840


### PR DESCRIPTION
Fix integration platforms to match what is allowed (platform_allow).

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
