### PR TITLE
samples: subsys: shell: shell_module: Add support for mec15xxevb_assy6853 board

### DIFF
--- a/samples/subsys/shell/shell_module/boards/mec15xxevb_assy6853.overlay
+++ b/samples/subsys/shell/shell_module/boards/mec15xxevb_assy6853.overlay
@@ -1,0 +1,6 @@
+/ {
+    chosen {
+        zephyr,console = &uart2;
+        zephyr,shell-uart = &uart2;
+    };
+};

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -429,6 +429,8 @@ SHELL_CMD_REGISTER(section_cmd, &sub_section_cmd,
 
 void main(void)
 {
+	volatile uint64_t	loop_count=0;
+
 	if (IS_ENABLED(CONFIG_SHELL_START_OBSCURED)) {
 		login_init();
 	}
@@ -447,4 +449,11 @@ void main(void)
 		k_sleep(K_MSEC(100));
 	}
 #endif
+
+	// prevent system from going into deep sleep by doing some dummy work
+	while(1)
+	{
+		loop_count++;
+		k_sleep(K_MSEC(1));
+	}
 }


### PR DESCRIPTION
The shell didn't work on the "mec15xxevb_assy6853" board.

I identified two problems:

- The board goes to a deep sleep state after a short moment. In this mode the UARTs are powered down and do no longer work.
- The "shell_module" sample requires the shell UART to be enabled/defined, which was not the case for the "mec15xxevb_assy6853" board.

With these fixes the "shell_module" sample is working well on my "mec15xxevb_assy6853" board.