### PR TITLE
tests: settings: file: remove declarations of ZTEST() routines

### DIFF
--- a/tests/subsys/settings/file/include/settings_test_file.h
+++ b/tests/subsys/settings/file/include/settings_test_file.h
@@ -44,20 +44,6 @@ int settings_test_file_strstr(const char *fname, char const *string,
 			      size_t str_len);
 
 
-void test_config_empty_lookups(void);
-void test_config_insert(void);
-void test_config_getset_unknown(void);
-void test_config_getset_int(void);
-void test_config_getset_int64(void);
-void test_config_commit(void);
-
-void test_config_empty_file(void);
-void test_config_small_file(void);
-void test_config_multiple_in_file(void);
-void test_config_save_in_file(void);
-void test_config_save_one_file(void);
-void test_config_compress_file(void);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Remove declarations of ZTEST() routines in header file, because there is
simply no value in having it.