### PR TITLE
settings: file: Fix flash area erase offset

### DIFF
--- a/tests/subsys/settings/file_littlefs/src/settings_setup_littlefs.c
+++ b/tests/subsys/settings/file_littlefs/src/settings_setup_littlefs.c
@@ -29,7 +29,7 @@ void *config_setup_littlefs(void)
 	rc = flash_area_open(LITTLEFS_PARTITION_ID, &fap);
 	zassume_true(rc == 0, "opening flash area for erase [%d]\n", rc);
 
-	rc = flash_area_erase(fap, fap->fa_off, fap->fa_size);
+	rc = flash_area_erase(fap, 0, fap->fa_size);
 	zassume_true(rc == 0, "erasing flash area [%d]\n", rc);
 
 	rc = fs_mount(&littlefs_mnt);


### PR DESCRIPTION
Incorrect erase start offset has been given.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>