### PR TITLE
samples: shields: npm6001_ek: fix build

### DIFF
--- a/samples/shields/npm6001_ek/src/main.c
+++ b/samples/shields/npm6001_ek/src/main.c
@@ -9,6 +9,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/dt-bindings/gpio/nordic-npm6001-gpio.h>
+#include <zephyr/posix/unistd.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/printk.h>
 


### PR DESCRIPTION
Commit ff3aaa6ef30bf08f2a7490b3608f10b64c1821c3 moved some getopt declarations to unistd.h. Update sample to include the header, so that we can access optarg.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>