### PR TITLE
arch: arm64: timer: Add missing inclusion of limits.h

### DIFF
--- a/include/zephyr/arch/arm64/timer.h
+++ b/include/zephyr/arch/arm64/timer.h
@@ -9,6 +9,8 @@
 
 #ifndef _ASMLANGUAGE
 
+#include <limits.h>
+
 #include <zephyr/drivers/timer/arm_arch_timer.h>
 #include <zephyr/types.h>
 


### PR DESCRIPTION
This header file makes use of INT_MAX, which is defined in limits.h. Include the header to make sure it can be used.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>