### PR TITLE
drivers: gpio: stm32: allow using pin get with PM

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -409,10 +409,23 @@ static int gpio_stm32_enable_int(int port, int pin)
 
 static int gpio_stm32_port_get_raw(const struct device *dev, uint32_t *value)
 {
+	int ret;
 	const struct gpio_stm32_config *cfg = dev->config;
 	GPIO_TypeDef *gpio = (GPIO_TypeDef *)cfg->base;
 
+	/* Enable device clock before read */
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
 	*value = LL_GPIO_ReadInputPort(gpio);
+
+	/* Release device clock after read */
+	ret = pm_device_runtime_put(dev);
+	if (ret < 0) {
+		return ret;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
The PM in gpio_stm32.c disables clock with:
```
	/* Release clock only if configuration doesn't require bank writes */
	if ((flags & GPIO_OUTPUT) == 0) {
		err = pm_device_runtime_put(dev);
		if (err < 0) {
			return err;
		}
	}
```
so if I enable `CONFIG_PM_DEVICE_RUNTIME` the clock is actually disabled after configuration, rendering impossible to get pin state with `gpio_pin_get` if the pin is configured with `GPIO_INPUT`. Interrupt on that pin still works.
It is easy reproducible using `samples/basic/button`, by adding to the configuration following pins:
```
CONFIG_PM=y
CONFIG_PM_DEVICE=y
CONFIG_PM_DEVICE_RUNTIME=y
```
If no others peripherals uses the same pin bank, which is true on e.g. `nucleo_f411re`, where I have tested it, `pin_get` stops working, no surprise.
I do not know why the issue lived that long, probably because if you enable more pins on the same bank, and other pins are OUTPUTs, clock stays enabled and everything works fine.
This patch fixes this single behaviour, but it might be worth to review PM in this driver further.