### PR TITLE
drivers: regulator: pca9420: fix boot-on support

### DIFF
--- a/drivers/regulator/regulator_pca9420.c
+++ b/drivers/regulator/regulator_pca9420.c
@@ -496,7 +496,7 @@ static int regulator_pca9420_init(const struct device *dev)
 	}
 
 	if (config->boot_on) {
-		rc = regulator_pca9420_enable(dev);
+		rc = regulator_enable(dev);
 	}
 
 	return rc;


### PR DESCRIPTION
Fix boot-on support for PCA9420. Since the regulator API now tracks refcnt via a common data structure, the standard "regulator_enable()" API must be used from within the driver when enabling the regulator at boot, to ensure that the refcnt for regulators enabled at boot is correct.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>