### PR TITLE
modules: lvgl: Enable for CPU_CORTEX_M0/M0PLUS

### DIFF
--- a/modules/Kconfig.lvgl
+++ b/modules/Kconfig.lvgl
@@ -3,7 +3,6 @@
 
 config LVGL
 	bool "LittlevGL GUI library"
-	depends on !CPU_CORTEX_M0 && !CPU_CORTEX_M0PLUS
 	help
 	  This option enables the LittlevGL GUI library.
 


### PR DESCRIPTION
Cortex M0 support was previously disabled due to a compiler bug. SDK 15.1 includes GCC 12.1 which solves this issue.

Fixes: #52788

Signed-off-by: Jon Escombe <jone@dresco.co.uk>