### PR TITLE
Bluetooth: controller: proper handling of invalid pdu in CIS create

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -588,8 +588,12 @@ void llcp_rp_cc_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		rp_cc_execute_fsm(conn, ctx, RP_CC_EVT_REJECT, pdu);
 		break;
 	default:
-		/* Unknown opcode */
-		LL_ASSERT(0);
+		/* Invalid behaviour */
+		/* Invalid PDU received so terminate connection */
+		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+		llcp_rr_complete(conn);
+		ctx->state = RP_CC_STATE_IDLE;
+		break;
 	}
 }
 
@@ -698,8 +702,12 @@ void llcp_lp_cc_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		lp_cc_execute_fsm(conn, ctx, LP_CC_EVT_REJECT, pdu);
 		break;
 	default:
-		/* Unknown opcode */
-		LL_ASSERT(0);
+		/* Invalid behaviour */
+		/* Invalid PDU received so terminate connection */
+		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+		llcp_lr_complete(conn);
+		ctx->state = LP_CC_STATE_IDLE;
+		break;
 	}
 }
 


### PR DESCRIPTION
Do not assert on invalid PDU in CIS create procedure. Instead terminate with reason BT_HCI_ERR_LMP_PDU_NOT_ALLOWED

Signed-off-by: Erik Brockhoff <erbr@oticon.com>