### PR TITLE
CIS LLCP Fixes and Improvements

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -72,6 +72,7 @@
 #include "lll_conn_iso.h"
 #include "ull_conn_iso_types.h"
 #include "ull_central_iso_internal.h"
+#include "ull_llcp.h"
 
 #include "ull_conn_iso_internal.h"
 #include "ull_peripheral_iso_internal.h"
@@ -2780,6 +2781,25 @@ static inline int rx_demux_rx(memq_link_t *link, struct node_rx_hdr *rx)
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 #endif /* CONFIG_BT_OBSERVER */
+
+#if !defined(CONFIG_BT_LL_SW_LLCP_LEGACY) && \
+	defined(CONFIG_BT_CTLR_PERIPHERAL_ISO)
+	case NODE_RX_TYPE_CIS_ESTABLISHED:
+	{
+		struct ll_conn *conn;
+
+		(void)memq_dequeue(memq_ull_rx.tail, &memq_ull_rx.head, NULL);
+
+		conn = ll_conn_get(rx->handle);
+		if (ull_cp_cc_awaiting_established(conn)) {
+			ull_cp_cc_established(conn, BT_HCI_ERR_SUCCESS);
+		}
+
+		rx->type = NODE_RX_TYPE_RELEASE;
+		ll_rx_put_sched(link, rx);
+	}
+	break;
+#endif /* !CONFIG_BT_LL_SW_LLCP_LEGACY && CONFIG_BT_CTLR_PERIPHERAL_ISO */
 
 #if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX) || defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX) || \
 	defined(CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -7984,12 +7984,25 @@ uint16_t ull_conn_event_counter(struct ll_conn *conn)
 	struct lll_conn *lll;
 	uint16_t event_counter;
 
-	uint16_t lazy = conn->llcp.prep.lazy;
-
 	lll = &conn->lll;
 
-	/* Calculate current event counter */
-	event_counter = lll->event_counter + lll->latency_prepare + lazy;
+	/* Calculate current event counter. If refcount is non-zero, we have called
+	 * prepare and the LLL implementation has calculated and incremented the event
+	 * counter (RX path). In this case we need to subtract one from the current
+	 * event counter.
+	 * Otherwise we are in the TX path, and we calculate the current event counter
+	 * similar to LLL by taking the expected event counter value plus accumulated
+	 * latency.
+	 */
+	if (ull_ref_get(&conn->ull)) {
+		/* We are in post-prepare (RX path). Event counter is already
+		 * calculated and incremented by 1 for next event.
+		 */
+		event_counter = lll->event_counter - 1;
+	} else {
+		event_counter = lll->event_counter + lll->latency_prepare +
+				conn->llcp.prep.lazy;
+	}
 
 	return event_counter;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -314,7 +314,10 @@ void ull_conn_iso_done(struct node_rx_event_done *done)
 
 		if (cis->lll.handle != LLL_HANDLE_INVALID) {
 			/* CIS was setup and is now expected to be going */
-			if (!(done->extra.trx_performed_mask &
+			if (done->extra.mic_state == LLL_CONN_MIC_FAIL) {
+				/* MIC failure - stop CIS and defer cleanup to after teardown. */
+				ull_conn_iso_cis_stop(cis, NULL, BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL);
+			} else if (!(done->extra.trx_performed_mask &
 			      (1U << LL_CIS_IDX_FROM_HANDLE(cis->lll.handle)))) {
 				/* We did NOT have successful transaction on established CIS,
 				 * or CIS was not yet established, so handle timeout

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -1230,6 +1230,7 @@ void ull_cp_cte_req_set_disable(struct ll_conn *conn)
 	conn->llcp.cte_req.req_interval = 0U;
 }
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_REQ */
+
 #if defined(CONFIG_BT_PERIPHERAL) && defined(CONFIG_BT_CTLR_PERIPHERAL_ISO)
 bool ull_cp_cc_awaiting_reply(struct ll_conn *conn)
 {
@@ -1276,7 +1277,50 @@ void ull_cp_cc_reject(struct ll_conn *conn, uint8_t error_code)
 		llcp_rp_cc_reject(conn, ctx);
 	}
 }
-#endif /* defined(CONFIG_BT_PERIPHERAL) && defined(CONFIG_BT_CTLR_PERIPHERAL_ISO) */
+#endif /* CONFIG_BT_PERIPHERAL && CONFIG_BT_CTLR_PERIPHERAL_ISO */
+
+#if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO) || defined(CONFIG_BT_CTLR_CENTRAL_ISO)
+bool ull_cp_cc_awaiting_established(struct ll_conn *conn)
+{
+	struct proc_ctx *ctx;
+
+#if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO)
+	ctx = llcp_rr_peek(conn);
+	if (ctx && ctx->proc == PROC_CIS_CREATE) {
+		return llcp_rp_cc_awaiting_established(ctx);
+	}
+#endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO */
+
+#if defined(CONFIG_BT_CTLR_CENTRAL_ISO)
+	ctx = llcp_lr_peek(conn);
+	if (ctx && ctx->proc == PROC_CIS_CREATE) {
+		return llcp_lp_cc_awaiting_established(ctx);
+	}
+#endif /* CONFIG_BT_CTLR_CENTRAL_ISO */
+	return false;
+}
+
+void ull_cp_cc_established(struct ll_conn *conn, uint8_t error_code)
+{
+	struct proc_ctx *ctx;
+
+#if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO)
+	ctx = llcp_rr_peek(conn);
+	if (ctx && ctx->proc == PROC_CIS_CREATE) {
+		ctx->data.cis_create.error = error_code;
+		llcp_rp_cc_established(conn, ctx);
+	}
+#endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO */
+
+#if defined(CONFIG_BT_CTLR_CENTRAL_ISO)
+	ctx = llcp_lr_peek(conn);
+	if (ctx && ctx->proc == PROC_CIS_CREATE) {
+		ctx->data.cis_create.error = error_code;
+		llcp_lp_cc_established(conn, ctx);
+	}
+#endif /* CONFIG_BT_CTLR_CENTRAL_ISO */
+}
+#endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO || CONFIG_BT_CTLR_CENTRAL_ISO */
 
 #if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_CTLR_CENTRAL_ISO)
 bool ull_lp_cc_is_active(struct ll_conn *conn)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -192,6 +192,11 @@ uint8_t ull_cp_cis_create(struct ll_conn *conn, struct ll_conn_iso_stream *cis);
 bool ull_cp_cc_awaiting_reply(struct ll_conn *conn);
 
 /**
+ * @brief Is ongoing create cis procedure expecting an established event?
+ */
+bool ull_cp_cc_awaiting_established(struct ll_conn *conn);
+
+/**
  * @brief Get handle of ongoing create cis procedure.
  * @return 0xFFFF if none
  */
@@ -203,7 +208,7 @@ uint16_t ull_cp_cc_ongoing_handle(struct ll_conn *conn);
 void ull_cp_cc_accept(struct ll_conn *conn);
 
 /**
- * @brief Rejset the remote device’s request to create cis.
+ * @brief Reject the remote device’s request to create cis.
  */
 void ull_cp_cc_reject(struct ll_conn *conn, uint8_t error_code);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -127,6 +127,9 @@ enum {
 	/* Reject response received */
 	RP_CC_EVT_REJECT,
 
+	/* Established */
+	RP_CC_EVT_CIS_ESTABLISHED,
+
 	/* Unknown response received */
 	RP_CC_EVT_UNKNOWN,
 };
@@ -433,7 +436,6 @@ static void rp_cc_state_wait_ntf_cis_create(struct ll_conn *conn, struct proc_ct
 	}
 }
 
-
 static void rp_cc_state_wait_ntf(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				 void *param)
 {
@@ -535,6 +537,10 @@ static void rp_cc_state_wait_cis_established(struct ll_conn *conn, struct proc_c
 			rp_cc_complete(conn, ctx, evt, param);
 		}
 		break;
+	case RP_CC_EVT_CIS_ESTABLISHED:
+		/* CIS was established, so let's go ahead and complete procedure */
+		rp_cc_complete(conn, ctx, evt, param);
+		break;
 	default:
 		/* Ignore other evts */
 		break;
@@ -623,6 +629,11 @@ bool llcp_rp_cc_awaiting_reply(struct proc_ctx *ctx)
 	return (ctx->state == RP_CC_STATE_WAIT_REPLY);
 }
 
+bool llcp_rp_cc_awaiting_established(struct proc_ctx *ctx)
+{
+	return (ctx->state == RP_CC_STATE_WAIT_CIS_ESTABLISHED);
+}
+
 void llcp_rp_cc_accept(struct ll_conn *conn, struct proc_ctx *ctx)
 {
 	rp_cc_execute_fsm(conn, ctx, RP_CC_EVT_CIS_REQ_ACCEPT, NULL);
@@ -641,6 +652,11 @@ void llcp_rp_cc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
 bool llcp_rp_cc_awaiting_instant(struct proc_ctx *ctx)
 {
 	return (ctx->state == RP_CC_STATE_WAIT_INSTANT);
+}
+
+void llcp_rp_cc_established(struct ll_conn *conn, struct proc_ctx *ctx)
+{
+	rp_cc_execute_fsm(conn, ctx, RP_CC_EVT_CIS_ESTABLISHED, NULL);
 }
 #endif /* CONFIG_BT_PERIPHERAL */
 
@@ -668,6 +684,9 @@ enum {
 
 	/* Reject response received */
 	LP_CC_EVT_REJECT,
+
+	/* CIS established */
+	LP_CC_EVT_ESTABLISHED,
 
 	/* Unknown response received */
 	LP_CC_EVT_UNKNOWN,
@@ -898,6 +917,10 @@ static void lp_cc_st_wait_established(struct ll_conn *conn, struct proc_ctx *ctx
 			lp_cc_complete(conn, ctx, evt, param);
 		}
 		break;
+	case LP_CC_EVT_ESTABLISHED:
+		/* CIS was established, so let's go ahead and complete procedure */
+		lp_cc_complete(conn, ctx, evt, param);
+		break;
 	default:
 		/* Ignore other evts */
 		break;
@@ -955,5 +978,15 @@ void llcp_lp_cc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
 bool llcp_lp_cc_is_active(struct proc_ctx *ctx)
 {
 	return ctx->state != LP_CC_STATE_IDLE;
+}
+
+bool llcp_lp_cc_awaiting_established(struct proc_ctx *ctx)
+{
+	return (ctx->state == LP_CC_STATE_WAIT_ESTABLISHED);
+}
+
+void llcp_lp_cc_established(struct ll_conn *conn, struct proc_ctx *ctx)
+{
+	lp_cc_execute_fsm(conn, ctx, LP_CC_EVT_ESTABLISHED, NULL);
 }
 #endif /* CONFIG_BT_CTLR_CENTRAL_ISO */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -89,22 +89,6 @@ static void cc_ntf_established(struct ll_conn *conn, struct proc_ctx *ctx)
 }
 
 #if defined(CONFIG_BT_PERIPHERAL)
-static uint16_t cc_event_counter(struct ll_conn *conn)
-{
-	struct lll_conn *lll;
-	uint16_t event_counter;
-
-	uint16_t lazy = conn->llcp.prep.lazy;
-
-	/**/
-	lll = &conn->lll;
-
-	/* Calculate current event counter */
-	event_counter = lll->event_counter + lll->latency_prepare + lazy;
-
-	return event_counter;
-}
-
 /* LLCP Remote Procedure FSM states */
 enum {
 	/* Establish Procedure */
@@ -147,6 +131,9 @@ enum {
 	RP_CC_EVT_UNKNOWN,
 };
 
+static void rp_cc_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
+				void *param);
+
 /*
  * LLCP Remote Procedure FSM
  */
@@ -162,8 +149,13 @@ static void llcp_rp_cc_tx_rsp(struct ll_conn *conn, struct proc_ctx *ctx)
 
 	pdu = (struct pdu_data *)tx->pdu;
 
+	/* Postpone if instant is in this or next connection event. This would handle obsolete value
+	 * due to retransmission, as well as incorrect behavior by central.
+	 * We need at least 2 connection events to get ready. First for receiving the indication,
+	 * the second for setting up the CIS.
+	 */
 	ctx->data.cis_create.conn_event_count = MAX(ctx->data.cis_create.conn_event_count,
-						    cc_event_counter(conn) + 2);
+						    ull_conn_event_counter(conn) + 2);
 
 	llcp_pdu_encode_cis_rsp(ctx, pdu);
 	ctx->tx_opcode = pdu->llctrl.opcode;
@@ -380,19 +372,13 @@ static void rp_cc_state_wait_rx_cis_ind(struct ll_conn *conn, struct proc_ctx *c
 	case RP_CC_EVT_CIS_IND:
 		llcp_pdu_decode_cis_ind(ctx, pdu);
 		if (!ull_peripheral_iso_setup(&pdu->llctrl.cis_ind, ctx->data.cis_create.cig_id,
-					 ctx->data.cis_create.cis_handle)) {
+					      ctx->data.cis_create.cis_handle)) {
 
 			/* CIS has been setup, go wait for 'instant' before starting */
 			ctx->state = RP_CC_STATE_WAIT_INSTANT;
 
-			/* Fixme - Implement CIS Supervision timeout
-			 * Spec:
-			 * When establishing a CIS, the Peripheral shall start the CIS supervision
-			 * timer at the start of the next CIS event after receiving the LL_CIS_IND.
-			 * If the CIS supervision timer reaches 6 * ISO_Interval before the CIS is
-			 * established, the CIS shall be considered lost.
-			 */
-
+			/* Check if this connection event is where we need to start the CIS */
+			rp_cc_check_instant(conn, ctx, evt, param);
 			break;
 		}
 		/* If we get to here the CIG_ID referred in req/acquire has become void/invalid */
@@ -454,7 +440,7 @@ static void rp_cc_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint
 	}
 
 	if (is_instant_reached_or_passed(start_event_count,
-					 cc_event_counter(conn))) {
+					 ull_conn_event_counter(conn))) {
 		/* Start CIS */
 		ull_conn_iso_start(conn, conn->llcp.prep.ticks_at_expire,
 				   ctx->data.cis_create.cis_handle);
@@ -624,6 +610,11 @@ void llcp_rp_cc_reject(struct ll_conn *conn, struct proc_ctx *ctx)
 void llcp_rp_cc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
 {
 	rp_cc_execute_fsm(conn, ctx, RP_CC_EVT_RUN, param);
+}
+
+bool llcp_rp_cc_awaiting_instant(struct proc_ctx *ctx)
+{
+	return (ctx->state == RP_CC_STATE_WAIT_INSTANT);
 }
 #endif /* CONFIG_BT_PERIPHERAL */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
@@ -204,6 +204,10 @@ void llcp_lp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
 	lp_chmu_execute_fsm(conn, ctx, LP_CHMU_EVT_RUN, param);
 }
 
+bool llcp_lp_chmu_awaiting_instant(struct proc_ctx *ctx)
+{
+	return (ctx->state == LP_CHMU_STATE_WAIT_INSTANT);
+}
 #endif /* CONFIG_BT_CENTRAL */
 
 #if defined(CONFIG_BT_PERIPHERAL)
@@ -319,5 +323,10 @@ void llcp_rp_chmu_init_proc(struct proc_ctx *ctx)
 void llcp_rp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
 {
 	rp_chmu_execute_fsm(conn, ctx, RP_CHMU_EVT_RUN, param);
+}
+
+bool llcp_rp_chmu_awaiting_instant(struct proc_ctx *ctx)
+{
+	return (ctx->state == RP_CHMU_STATE_WAIT_INSTANT);
 }
 #endif /* CONFIG_BT_PERIPHERAL */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -1225,6 +1225,16 @@ void llcp_rp_cu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
 	rp_cu_execute_fsm(conn, ctx, RP_CU_EVT_RUN, param);
 }
 
+bool llcp_rp_cu_awaiting_instant(struct proc_ctx *ctx)
+{
+	return (ctx->state == RP_CU_STATE_WAIT_INSTANT);
+}
+
+bool llcp_lp_cu_awaiting_instant(struct proc_ctx *ctx)
+{
+	return (ctx->state == LP_CU_STATE_WAIT_INSTANT);
+}
+
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 void llcp_rp_conn_param_req_reply(struct ll_conn *conn, struct proc_ctx *ctx)
 {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -258,6 +258,7 @@ struct proc_ctx {
 			uint8_t  cig_id;
 			uint8_t  cis_id;
 			uint16_t conn_event_count;
+			uint16_t iso_interval;
 			uint32_t cis_offset_min;
 			uint32_t cis_offset_max;
 #if defined(CONFIG_BT_PERIPHERAL)
@@ -281,7 +282,6 @@ struct proc_ctx {
 			uint8_t  c_bn;
 			uint8_t  c_ft;
 			uint8_t  p_ft;
-			uint16_t iso_interval;
 			uint8_t  aa[4];
 #endif /* defined(CONFIG_BT_CENTRAL) */
 		} cis_create;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -711,14 +711,18 @@ void llcp_lp_cc_init_proc(struct proc_ctx *ctx);
 void llcp_lp_cc_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
 void llcp_lp_cc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 bool llcp_lp_cc_is_active(struct proc_ctx *ctx);
+bool llcp_lp_cc_awaiting_established(struct proc_ctx *ctx);
+void llcp_lp_cc_established(struct ll_conn *conn, struct proc_ctx *ctx);
 
 void llcp_rp_cc_init_proc(struct proc_ctx *ctx);
 void llcp_rp_cc_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
 void llcp_rp_cc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 bool llcp_rp_cc_awaiting_reply(struct proc_ctx *ctx);
+bool llcp_rp_cc_awaiting_established(struct proc_ctx *ctx);
 void llcp_rp_cc_accept(struct ll_conn *conn, struct proc_ctx *ctx);
 void llcp_rp_cc_reject(struct ll_conn *conn, struct proc_ctx *ctx);
 bool llcp_rp_cc_awaiting_instant(struct proc_ctx *ctx);
+void llcp_rp_cc_established(struct ll_conn *conn, struct proc_ctx *ctx);
 
 void llcp_pdu_decode_cis_req(struct proc_ctx *ctx, struct pdu_data *pdu);
 void llcp_pdu_encode_cis_rsp(struct proc_ctx *ctx, struct pdu_data *pdu);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -458,6 +458,7 @@ void llcp_lp_pu_init_proc(struct proc_ctx *ctx);
 void llcp_lp_pu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 void llcp_lp_pu_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 void llcp_lp_pu_tx_ntf(struct ll_conn *conn, struct proc_ctx *ctx);
+bool llcp_lp_pu_awaiting_instant(struct proc_ctx *ctx);
 #endif /* CONFIG_BT_CTLR_PHY */
 
 /*
@@ -466,6 +467,7 @@ void llcp_lp_pu_tx_ntf(struct ll_conn *conn, struct proc_ctx *ctx);
 void llcp_lp_cu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
 void llcp_lp_cu_init_proc(struct proc_ctx *ctx);
 void llcp_lp_cu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
+bool llcp_lp_cu_awaiting_instant(struct proc_ctx *ctx);
 
 /*
  * LLCP Local Channel Map Update
@@ -473,6 +475,7 @@ void llcp_lp_cu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 void llcp_lp_chmu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
 void llcp_lp_chmu_init_proc(struct proc_ctx *ctx);
 void llcp_lp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
+bool llcp_lp_chmu_awaiting_instant(struct proc_ctx *ctx);
 
 #if defined(CONFIG_BT_CTLR_PHY)
 /*
@@ -483,6 +486,7 @@ void llcp_rp_pu_init_proc(struct proc_ctx *ctx);
 void llcp_rp_pu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 void llcp_rp_pu_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 void llcp_rp_pu_tx_ntf(struct ll_conn *conn, struct proc_ctx *ctx);
+bool llcp_rp_pu_awaiting_instant(struct proc_ctx *ctx);
 #endif /* CONFIG_BT_CTLR_PHY */
 
 /*
@@ -495,6 +499,7 @@ void llcp_rp_conn_param_req_reply(struct ll_conn *conn, struct proc_ctx *ctx);
 void llcp_rp_conn_param_req_neg_reply(struct ll_conn *conn, struct proc_ctx *ctx);
 bool llcp_rp_conn_param_req_apm_awaiting_reply(struct proc_ctx *ctx);
 void llcp_rp_conn_param_req_apm_reply(struct ll_conn *conn, struct proc_ctx *ctx);
+bool llcp_rp_cu_awaiting_instant(struct proc_ctx *ctx);
 
 /*
  * Terminate Helper
@@ -659,6 +664,7 @@ void llcp_pdu_decode_chan_map_update_ind(struct proc_ctx *ctx, struct pdu_data *
 void llcp_rp_chmu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
 void llcp_rp_chmu_init_proc(struct proc_ctx *ctx);
 void llcp_rp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
+bool llcp_rp_chmu_awaiting_instant(struct proc_ctx *ctx);
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 /*
@@ -712,6 +718,7 @@ void llcp_rp_cc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 bool llcp_rp_cc_awaiting_reply(struct proc_ctx *ctx);
 void llcp_rp_cc_accept(struct ll_conn *conn, struct proc_ctx *ctx);
 void llcp_rp_cc_reject(struct ll_conn *conn, struct proc_ctx *ctx);
+bool llcp_rp_cc_awaiting_instant(struct proc_ctx *ctx);
 
 void llcp_pdu_decode_cis_req(struct proc_ctx *ctx, struct pdu_data *pdu);
 void llcp_pdu_encode_cis_rsp(struct proc_ctx *ctx, struct pdu_data *pdu);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -775,6 +775,7 @@ void llcp_pdu_decode_cis_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 	ctx->data.cis_create.cis_offset_max = sys_get_le24(pdu->llctrl.cis_req.cis_offset_max);
 	ctx->data.cis_create.conn_event_count =
 		sys_le16_to_cpu(pdu->llctrl.cis_req.conn_event_count);
+	ctx->data.cis_create.iso_interval = sys_le16_to_cpu(pdu->llctrl.cis_req.iso_interval);
 	/* The remainder of the req is decoded by ull_peripheral_iso_acquire, so
 	 *  no need to do it here too
 	ctx->data.cis_create.c_phy	= pdu->llctrl.cis_req.c_phy;
@@ -792,7 +793,6 @@ void llcp_pdu_decode_cis_req(struct proc_ctx *ctx, struct pdu_data *pdu)
 	ctx->data.cis_create.c_bn	= pdu->llctrl.cis_req.c_bn;
 	ctx->data.cis_create.c_ft	= pdu->llctrl.cis_req.c_ft;
 	ctx->data.cis_create.p_ft	= pdu->llctrl.cis_req.p_ft;
-	ctx->data.cis_create.iso_interval = sys_le16_to_cpu(pdu->llctrl.cis_req.iso_interval);
 	*/
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -892,6 +892,12 @@ void llcp_lp_pu_tx_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 {
 	lp_pu_execute_fsm(conn, ctx, LP_PU_EVT_NTF, NULL);
 }
+
+bool llcp_lp_pu_awaiting_instant(struct proc_ctx *ctx)
+{
+	return (ctx->state == LP_PU_STATE_WAIT_INSTANT);
+}
+
 /*
  * LLCP Remote Procedure PHY Update FSM
  */
@@ -1317,4 +1323,9 @@ void llcp_rp_pu_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
 void llcp_rp_pu_tx_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 {
 	rp_pu_execute_fsm(conn, ctx, RP_PU_EVT_NTF, NULL);
+}
+
+bool llcp_rp_pu_awaiting_instant(struct proc_ctx *ctx)
+{
+	return (ctx->state == RP_PU_STATE_WAIT_INSTANT);
 }

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_conn_iso.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_conn_iso.c
@@ -52,6 +52,11 @@ struct ll_conn_iso_stream *ll_conn_iso_stream_get(uint16_t handle)
 	return &cis;
 }
 
+struct ll_conn_iso_stream *ll_iso_stream_connected_get(uint16_t handle)
+{
+	return &cis;
+}
+
 struct ll_conn_iso_group *ll_conn_iso_group_get_by_id(uint8_t id)
 {
 	return &cig;


### PR DESCRIPTION
**Bluetooth: controller: Reduce ISO peripheral CIS establishement delay**
New LLCP will process the CIS establishement in the TX path, meaning it
will only process once every ACL connection interval.
If ACL connection interval is significantly longer than the ISO
interval, CIS packets corresponding to the ACL connection interval will
be lost. This may cause latency in audio rendition.

By processing the CIS establishment in the RX path, notification will be
sent immediately, and audio path is enabled fast to reduce latency.

When a CIS fails to establish, the controller shall complete the
procedure by sending a CIS_ESTABLISHED event containing the error.

**Bluetooth: controller: Fix missing CIS disconnect on MIC failure**
Disconnect CIS immediately if event done extra status indicates MIC
failure. Return reason BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL.

Fixes EBQ test /LL/CIS/PER/BV-27-C.

**Bluetooth: controller: Implement CIS offset equivalent calculation**
When the 'instant' of a CIS is postponed by increasing the conn_event of
the CIS_RSP compared to CIS_REQ, the CIS offset shall be calculated as
an equivalent window offset by an integer number of ISO intervals.
This is obtained by increasing the CIS_Offset_Min and CIS_Offset_Max by
the modulus of the connection interval delay time.

**Bluetooth: controller: Start CIG immediately if instant is next event**
To be able to timely start the first CIS/CIG, if the requested instant
is the next connection event, call ull_peripheral_iso_start directly
from rp_cc_state_wait_rx_cis_ind instead of waiting for next time
through the state machine.

To enable ULL/LLL to prevent adding latency when LLCP is waiting for
instant, local- and remote procedures with instant now expose a function
for checking this state.

Fixed event_counter function to prevent one-off in RX path. Unified to
use single function ull_conn_event_counter.

Fixed LLCP unit tests and added new mock function.

Signed-off-by: Morten Priess <mtpr@oticon.com>