### PR TITLE
fs: fat: document path transformation

### DIFF
--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -64,6 +64,17 @@ static int translate_error(int error)
 	return -EIO;
 }
 
+/* Converts a zephyr path like /SD:/foo into a path digestible by FATFS by stripping the
+ * leading slash, i.e. SD:/foo.
+ */
+static const char *translate_path(const char *path)
+{
+	/* this is guaranteed by the fs subsystem */
+	__ASSERT_NO_MSG(path[0] == '/');
+
+	return &path[1];
+}
+
 static uint8_t translate_flags(fs_mode_t flags)
 {
 	uint8_t fat_mode = 0;
@@ -97,7 +108,7 @@ static int fatfs_open(struct fs_file_t *zfp, const char *file_name,
 
 	fs_mode = translate_flags(mode);
 
-	res = f_open(zfp->filep, &file_name[1], fs_mode);
+	res = f_open(zfp->filep, translate_path(file_name), fs_mode);
 
 	if (res != FR_OK) {
 		k_mem_slab_free(&fatfs_filep_pool, &ptr);
@@ -125,7 +136,7 @@ static int fatfs_unlink(struct fs_mount_t *mountp, const char *path)
 	int res = -ENOTSUP;
 
 #if !defined(CONFIG_FS_FATFS_READ_ONLY)
-	res = f_unlink(&path[1]);
+	res = f_unlink(translate_path(path));
 
 	res = translate_error(res);
 #endif
@@ -142,14 +153,14 @@ static int fatfs_rename(struct fs_mount_t *mountp, const char *from,
 	FILINFO fno;
 
 	/* Check if 'to' path exists; remove it if it does */
-	res = f_stat(&to[1], &fno);
+	res = f_stat(translate_path(to), &fno);
 	if (FR_OK == res) {
-		res = f_unlink(&to[1]);
+		res = f_unlink(translate_path(to));
 		if (FR_OK != res)
 			return translate_error(res);
 	}
 
-	res = f_rename(&from[1], &to[1]);
+	res = f_rename(translate_path(from), translate_path(to));
 	res = translate_error(res);
 #endif
 
@@ -301,7 +312,7 @@ static int fatfs_mkdir(struct fs_mount_t *mountp, const char *path)
 	int res = -ENOTSUP;
 
 #if !defined(CONFIG_FS_FATFS_READ_ONLY)
-	res = f_mkdir(&path[1]);
+	res = f_mkdir(translate_path(path));
 	res = translate_error(res);
 #endif
 
@@ -320,7 +331,7 @@ static int fatfs_opendir(struct fs_dir_t *zdp, const char *path)
 		return -ENOMEM;
 	}
 
-	res = f_opendir(zdp->dirp, &path[1]);
+	res = f_opendir(zdp->dirp, translate_path(path));
 
 	if (res != FR_OK) {
 		k_mem_slab_free(&fatfs_dirp_pool, &ptr);
@@ -366,7 +377,7 @@ static int fatfs_stat(struct fs_mount_t *mountp,
 	FRESULT res;
 	FILINFO fno;
 
-	res = f_stat(&path[1], &fno);
+	res = f_stat(translate_path(path), &fno);
 	if (res == FR_OK) {
 		entry->type = ((fno.fattrib & AM_DIR) ?
 			       FS_DIR_ENTRY_DIR : FS_DIR_ENTRY_FILE);
@@ -385,7 +396,7 @@ static int fatfs_statvfs(struct fs_mount_t *mountp,
 	FATFS *fs;
 	DWORD f_bfree = 0;
 
-	res = f_getfree(&mountp->mnt_point[1], &f_bfree, &fs);
+	res = f_getfree(translate_path(mountp->mnt_point), &f_bfree, &fs);
 	if (res != FR_OK) {
 		return -EIO;
 	}
@@ -414,7 +425,7 @@ static int fatfs_mount(struct fs_mount_t *mountp)
 {
 	FRESULT res;
 
-	res = f_mount((FATFS *)mountp->fs_data, &mountp->mnt_point[1], 1);
+	res = f_mount((FATFS *)mountp->fs_data, translate_path(mountp->mnt_point), 1);
 
 #if defined(CONFIG_FS_FATFS_MOUNT_MKFS)
 	if (res == FR_NO_FILESYSTEM &&
@@ -433,10 +444,10 @@ static int fatfs_mount(struct fs_mount_t *mountp)
 			.au_size = 0		/* Auto calculate cluster size */
 		};
 
-		res = f_mkfs(&mountp->mnt_point[1], &mkfs_opt, work, sizeof(work));
+		res = f_mkfs(translate_path(mountp->mnt_point), &mkfs_opt, work, sizeof(work));
 		if (res == FR_OK) {
 			res = f_mount((FATFS *)mountp->fs_data,
-					&mountp->mnt_point[1], 1);
+					translate_path(mountp->mnt_point), 1);
 		}
 	}
 #endif /* CONFIG_FS_FATFS_MOUNT_MKFS */
@@ -453,7 +464,7 @@ static int fatfs_unmount(struct fs_mount_t *mountp)
 {
 	FRESULT res;
 
-	res = f_mount(NULL, &mountp->mnt_point[1], 0);
+	res = f_mount(NULL, translate_path(mountp->mnt_point), 0);
 
 	return translate_error(res);
 }


### PR DESCRIPTION
The FAT driver converts zephyr paths like `/SD:/foo` into ELM-FATFS paths like `SD:/foo`. Document this behaviour by extracting it into a separate function (and adding a sanity check).