### PR TITLE
samples: blinky_pwm: Add nucleo_l476rg support

### DIFF
--- a/samples/basic/blinky_pwm/boards/nucleo_l476rg.overlay
+++ b/samples/basic/blinky_pwm/boards/nucleo_l476rg.overlay
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2022 STMicroelectronics
+ */
+
+
+/ {
+	pwmleds: pwmleds {
+		compatible = "pwm-leds";
+		status = "okay";
+
+		green_pwm_led: green_pwm_led {
+			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+
+    aliases {
+        pwm-led0 = &green_pwm_led;
+    };
+
+};
+
+&pwm2 {
+	status = "okay";
+};


### PR DESCRIPTION
Enable use of nucleo_l476rg on this sample using a dedicated overlay.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>