### PR TITLE
Switch zcbor_map_decode_bulk from ZCBOR_MAP_DECODE_KEY_VAL to ZCBOR_MAP_DECODE_KEY_DECODER

### DIFF
--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
@@ -175,8 +175,8 @@ static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 	size_t decoded;
 
 	struct zcbor_map_decode_key_val fs_download_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(off, zcbor_uint64_decode, &off),
-		ZCBOR_MAP_DECODE_KEY_VAL(name, zcbor_tstr_decode, &name),
+		ZCBOR_MAP_DECODE_KEY_DECODER("off", zcbor_uint64_decode, &off),
+		ZCBOR_MAP_DECODE_KEY_DECODER("name", zcbor_tstr_decode, &name),
 	};
 
 #if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
@@ -313,10 +313,10 @@ static int fs_mgmt_file_upload(struct smp_streamer *ctxt)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val fs_upload_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(off, zcbor_uint64_decode, &off),
-		ZCBOR_MAP_DECODE_KEY_VAL(name, zcbor_tstr_decode, &name),
-		ZCBOR_MAP_DECODE_KEY_VAL(data, zcbor_bstr_decode, &file_data),
-		ZCBOR_MAP_DECODE_KEY_VAL(len, zcbor_uint64_decode, &len),
+		ZCBOR_MAP_DECODE_KEY_DECODER("off", zcbor_uint64_decode, &off),
+		ZCBOR_MAP_DECODE_KEY_DECODER("name", zcbor_tstr_decode, &name),
+		ZCBOR_MAP_DECODE_KEY_DECODER("data", zcbor_bstr_decode, &file_data),
+		ZCBOR_MAP_DECODE_KEY_DECODER("len", zcbor_uint64_decode, &len),
 	};
 
 #if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
@@ -408,7 +408,7 @@ static int fs_mgmt_file_status(struct smp_streamer *ctxt)
 	size_t decoded;
 
 	struct zcbor_map_decode_key_val fs_status_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(name, zcbor_tstr_decode, &name),
+		ZCBOR_MAP_DECODE_KEY_DECODER("name", zcbor_tstr_decode, &name),
 	};
 
 	ok = zcbor_map_decode_bulk(zsd, fs_status_decode,
@@ -467,10 +467,10 @@ static int fs_mgmt_file_hash_checksum(struct smp_streamer *ctxt)
 	const struct fs_mgmt_hash_checksum_group *group = NULL;
 
 	struct zcbor_map_decode_key_val fs_hash_checksum_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(type, zcbor_tstr_decode, &type),
-		ZCBOR_MAP_DECODE_KEY_VAL(name, zcbor_tstr_decode, &name),
-		ZCBOR_MAP_DECODE_KEY_VAL(off, zcbor_uint64_decode, &off),
-		ZCBOR_MAP_DECODE_KEY_VAL(len, zcbor_uint64_decode, &len),
+		ZCBOR_MAP_DECODE_KEY_DECODER("type", zcbor_tstr_decode, &type),
+		ZCBOR_MAP_DECODE_KEY_DECODER("name", zcbor_tstr_decode, &name),
+		ZCBOR_MAP_DECODE_KEY_DECODER("off", zcbor_uint64_decode, &off),
+		ZCBOR_MAP_DECODE_KEY_DECODER("len", zcbor_uint64_decode, &len),
 	};
 
 	ok = zcbor_map_decode_bulk(zsd, fs_hash_checksum_decode,

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -269,7 +269,7 @@ img_mgmt_erase(struct smp_streamer *ctxt)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val image_erase_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(slot, zcbor_uint32_decode, &slot),
+		ZCBOR_MAP_DECODE_KEY_DECODER("slot", zcbor_uint32_decode, &slot),
 	};
 
 	ok = zcbor_map_decode_bulk(zsd, image_erase_decode,
@@ -376,12 +376,12 @@ img_mgmt_upload(struct smp_streamer *ctxt)
 	bool reset = false;
 
 	struct zcbor_map_decode_key_val image_upload_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(image, zcbor_uint32_decode, &req.image),
-		ZCBOR_MAP_DECODE_KEY_VAL(data, zcbor_bstr_decode, &req.img_data),
-		ZCBOR_MAP_DECODE_KEY_VAL(len, zcbor_size_decode, &req.size),
-		ZCBOR_MAP_DECODE_KEY_VAL(off, zcbor_size_decode, &req.off),
-		ZCBOR_MAP_DECODE_KEY_VAL(sha, zcbor_bstr_decode, &req.data_sha),
-		ZCBOR_MAP_DECODE_KEY_VAL(upgrade, zcbor_bool_decode, &req.upgrade)
+		ZCBOR_MAP_DECODE_KEY_DECODER("image", zcbor_uint32_decode, &req.image),
+		ZCBOR_MAP_DECODE_KEY_DECODER("data", zcbor_bstr_decode, &req.img_data),
+		ZCBOR_MAP_DECODE_KEY_DECODER("len", zcbor_size_decode, &req.size),
+		ZCBOR_MAP_DECODE_KEY_DECODER("off", zcbor_size_decode, &req.off),
+		ZCBOR_MAP_DECODE_KEY_DECODER("sha", zcbor_bstr_decode, &req.data_sha),
+		ZCBOR_MAP_DECODE_KEY_DECODER("upgrade", zcbor_bool_decode, &req.upgrade)
 	};
 
 #if defined(CONFIG_MCUMGR_SMP_COMMAND_STATUS_HOOKS)

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -281,8 +281,8 @@ img_mgmt_state_write(struct smp_streamer *ctxt)
 	struct zcbor_string zhash = { 0 };
 
 	struct zcbor_map_decode_key_val image_list_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(hash, zcbor_bstr_decode, &zhash),
-		ZCBOR_MAP_DECODE_KEY_VAL(confirm, zcbor_bool_decode, &confirm)
+		ZCBOR_MAP_DECODE_KEY_DECODER("hash", zcbor_bstr_decode, &zhash),
+		ZCBOR_MAP_DECODE_KEY_DECODER("confirm", zcbor_bool_decode, &confirm)
 	};
 
 	zcbor_state_t *zsd = ctxt->reader->zs;

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -363,7 +363,7 @@ static int os_mgmt_info(struct smp_streamer *ctxt)
 	uint16_t valid_formats = 0;
 
 	struct zcbor_map_decode_key_val fs_info_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(format, zcbor_tstr_decode, &format),
+		ZCBOR_MAP_DECODE_KEY_DECODER("format", zcbor_tstr_decode, &format),
 	};
 
 #ifdef CONFIG_MCUMGR_GRP_OS_INFO_CUSTOM_HOOKS

--- a/subsys/mgmt/mcumgr/util/include/mgmt/mcumgr/util/zcbor_bulk.h
+++ b/subsys/mgmt/mcumgr/util/include/mgmt/mcumgr/util/zcbor_bulk.h
@@ -21,7 +21,32 @@ struct zcbor_map_decode_key_val {
 	bool found;
 };
 
+/** @brief Define single key-decoder mapping
+ *
+ * The macro creates a single zcbor_map_decode_key_val type object.
+ *
+ * @param k	key is "" enclosed string representing key;
+ * @param dec	decoder function; this should be zcbor_decoder_t
+ *		type function from zcbor or a user provided implementation
+ *		compatible with the type.
+ * @param vp	non-NULL pointer for result of decoding; should correspond
+ *		to type served by decoder function for the mapping.
+ */
+#define ZCBOR_MAP_DECODE_KEY_DECODER(k, dec, vp)		\
+	{							\
+		{						\
+			.value = k,				\
+			.len = sizeof(k) - 1,			\
+		},						\
+		.decoder = (zcbor_decoder_t *)dec,		\
+		.value_ptr = vp,				\
+	}
+
 /** @brief Define single key-value decode mapping
+ *
+ * ZCBOR_MAP_DECODE_KEY_DECODER should be used instead of this macro as,
+ * this macro does not allow keys with whitespaces embeeded, which CBOR
+ * does allow.
  *
  * The macro creates a single zcbor_map_decode_key_val type object.
  *
@@ -34,28 +59,19 @@ struct zcbor_map_decode_key_val {
  *		to type served by decoder function for the mapping.
  */
 #define ZCBOR_MAP_DECODE_KEY_VAL(k, dec, vp)			\
-	{							\
-		{						\
-			.value = STRINGIFY(k),			\
-			.len = sizeof(STRINGIFY(k)) - 1,	\
-		},						\
-		.decoder = (zcbor_decoder_t *)dec,		\
-		.value_ptr = vp,				\
-	}
-
+	ZCBOR_MAP_DECODE_KEY_DECODER(STRINGIFY(k), dec, vp)
 
 /** @brief Decodes single level map according to a provided key-decode map.
  *
  * The function takes @p map of key to decoder array defined as:
  *
  *	struct zcbor_map_decode_key_val map[] = {
- *		ZCBOR_MAP_DECODE_KEY_VAL(key0, decode_fun0, val_ptr0),
- *		ZCBOR_MAP_DECODE_KEY_VAL(key1, decode_fun1, val_ptr1),
+ *		ZCBOR_MAP_DECODE_KEY_DECODER("key0", decode_fun0, val_ptr0),
+ *		ZCBOR_MAP_DECODE_KEY_DECODER("key1", decode_fun1, val_ptr1),
  *		...
  *	};
  *
- * where key? is string representing key without "", for example when key
- * is "abcd" , then the abcd should be provided; the decode_fun? is
+ * where "key?" is string representing key; the decode_fun? is
  * zcbor_decoder_t compatible function, either from zcbor or defined by
  * user; val_ptr? are pointers to variables where decoder function for
  * a given key will place a decoded value - they have to agree in type

--- a/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/build_date.c
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/build_date.c
@@ -88,7 +88,7 @@ ZTEST(os_mgmt_info_build_date, test_info_build_date_1_build_date)
 	int32_t received_time_seconds;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -164,7 +164,7 @@ ZTEST(os_mgmt_info_build_date, test_info_build_date_2_all)
 	int32_t received_time_seconds;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));

--- a/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/limited.c
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/limited.c
@@ -48,7 +48,7 @@ ZTEST(os_mgmt_info_limited, test_info_1_kernel_name)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -110,11 +110,11 @@ ZTEST(os_mgmt_info_limited, test_info_2_all)
 	int32_t rc;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	struct zcbor_map_decode_key_val error_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(rc, zcbor_int32_decode, &rc),
+		ZCBOR_MAP_DECODE_KEY_DECODER("rc", zcbor_int32_decode, &rc),
 	};
 
 	memset(buffer, 0, sizeof(buffer));

--- a/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/os_mgmt_info/src/main.c
@@ -302,7 +302,7 @@ ZTEST(os_mgmt_info, test_info_2_kernel_name)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -363,7 +363,7 @@ ZTEST(os_mgmt_info, test_info_3_node_name)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -424,7 +424,7 @@ ZTEST(os_mgmt_info, test_info_4_kernel_release)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -486,7 +486,7 @@ ZTEST(os_mgmt_info, test_info_5_kernel_version)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -548,7 +548,7 @@ ZTEST(os_mgmt_info, test_info_6_machine)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -609,7 +609,7 @@ ZTEST(os_mgmt_info, test_info_7_processor)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -670,7 +670,7 @@ ZTEST(os_mgmt_info, test_info_8_platform)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -742,7 +742,7 @@ ZTEST(os_mgmt_info, test_info_9_os)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -803,7 +803,7 @@ ZTEST(os_mgmt_info, test_info_10_all)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -876,7 +876,7 @@ ZTEST(os_mgmt_info, test_info_11_multi_1)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -941,7 +941,7 @@ ZTEST(os_mgmt_info, test_info_12_multi_2)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -1009,11 +1009,11 @@ ZTEST(os_mgmt_info, test_info_13_invalid_1)
 	int32_t rc;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	struct zcbor_map_decode_key_val error_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(rc, zcbor_int32_decode, &rc),
+		ZCBOR_MAP_DECODE_KEY_DECODER("rc", zcbor_int32_decode, &rc),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -1080,11 +1080,11 @@ ZTEST(os_mgmt_info, test_info_14_invalid_2)
 	int32_t rc;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	struct zcbor_map_decode_key_val error_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(rc, zcbor_int32_decode, &rc),
+		ZCBOR_MAP_DECODE_KEY_DECODER("rc", zcbor_int32_decode, &rc),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -1163,7 +1163,7 @@ ZTEST(os_mgmt_info_custom_os, test_info_os_custom)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -1224,7 +1224,7 @@ ZTEST(os_mgmt_info_custom_os_disabled, test_info_os_custom_disabled)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -1299,7 +1299,7 @@ ZTEST(os_mgmt_info_custom_cmd, test_info_cmd_custom)
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -1361,11 +1361,11 @@ ZTEST(os_mgmt_info_custom_cmd_disabled, test_info_cmd_custom_disabled)
 	int32_t rc;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	struct zcbor_map_decode_key_val error_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(rc, zcbor_int32_decode, &rc),
+		ZCBOR_MAP_DECODE_KEY_DECODER("rc", zcbor_int32_decode, &rc),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -1430,11 +1430,11 @@ ZTEST(os_mgmt_info_custom_cmd_disabled_verify, test_info_cmd_custom_disabled)
 	int32_t rc;
 
 	struct zcbor_map_decode_key_val output_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(output, zcbor_tstr_decode, &output),
+		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 	};
 
 	struct zcbor_map_decode_key_val error_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(rc, zcbor_int32_decode, &rc),
+		ZCBOR_MAP_DECODE_KEY_DECODER("rc", zcbor_int32_decode, &rc),
 	};
 
 	memset(buffer, 0, sizeof(buffer));

--- a/tests/subsys/mgmt/mcumgr/zcbor_bulk/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/zcbor_bulk/src/main.c
@@ -13,6 +13,28 @@
 
 #define zcbor_true_put(zse) zcbor_bool_put(zse, true)
 
+ZTEST(zcbor_bulk, test_ZCBOR_MAP_DECODE_KEY_DECODER)
+{
+	struct zcbor_string world;
+	struct zcbor_map_decode_key_val map_one[] = {
+		ZCBOR_MAP_DECODE_KEY_DECODER("hello", zcbor_tstr_decode, &world),
+	};
+	/* ZCBOR_MAP_DECODE_KEY_DECODER should not be used but is still provided */
+	struct zcbor_map_decode_key_val map_two[] = {
+		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_tstr_decode, &world),
+	};
+
+	zassert_ok(strcmp(map_one[0].key.value, "hello"));
+	zassert_equal(map_one[0].key.len, sizeof("hello") - 1);
+	zassert_equal((void *)map_one[0].decoder, (void *)&zcbor_tstr_decode);
+	zassert_equal((void *)map_one[0].value_ptr, (void *)&world);
+	/* Both maps should be the same */
+	zassert_ok(strcmp(map_one[0].key.value, map_two[0].key.value));
+	zassert_equal(map_one[0].key.len, map_two[0].key.len);
+	zassert_equal(map_one[0].decoder, map_two[0].decoder);
+	zassert_equal(map_one[0].value_ptr, map_two[0].value_ptr);
+}
+
 ZTEST(zcbor_bulk, test_correct)
 {
 	uint8_t buffer[512];
@@ -23,9 +45,9 @@ ZTEST(zcbor_bulk, test_correct)
 	size_t decoded = 0;
 	bool ok;
 	struct zcbor_map_decode_key_val dm[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_tstr_decode, &world),
-		ZCBOR_MAP_DECODE_KEY_VAL(one, zcbor_uint32_decode, &one),
-		ZCBOR_MAP_DECODE_KEY_VAL(bool_val, zcbor_bool_decode, &bool_val)
+		ZCBOR_MAP_DECODE_KEY_DECODER("hello", zcbor_tstr_decode, &world),
+		ZCBOR_MAP_DECODE_KEY_DECODER("one", zcbor_uint32_decode, &one),
+		ZCBOR_MAP_DECODE_KEY_DECODER("bool val", zcbor_bool_decode, &bool_val)
 	};
 
 	zcbor_new_encode_state(zsd, 2, buffer, ARRAY_SIZE(buffer), 0);
@@ -34,7 +56,7 @@ ZTEST(zcbor_bulk, test_correct)
 	ok = zcbor_map_start_encode(zsd, 10) &&
 	     zcbor_tstr_put_lit(zsd, "hello") && zcbor_tstr_put_lit(zsd, "world")	&&
 	     zcbor_tstr_put_lit(zsd, "one") && zcbor_uint32_put(zsd, 1)			&&
-	     zcbor_tstr_put_lit(zsd, "bool_val") && zcbor_true_put(zsd)			&&
+	     zcbor_tstr_put_lit(zsd, "bool val") && zcbor_true_put(zsd)			&&
 	     zcbor_map_end_encode(zsd, 10);
 
 	zassert_true(ok, "Expected to be successful in encoding test pattern");
@@ -51,7 +73,7 @@ ZTEST(zcbor_bulk, test_correct)
 		sizeof("world") - 1);
 	zassert_equal(0, memcmp(world.value, "world", world.len),
 		"Expected \"world\", got %.*s", world.len, world.value);
-	zassert_true(bool_val, "Expected bool_val == true");
+	zassert_true(bool_val, "Expected bool val == true");
 }
 
 ZTEST(zcbor_bulk, test_correct_out_of_order)
@@ -64,16 +86,16 @@ ZTEST(zcbor_bulk, test_correct_out_of_order)
 	size_t decoded = 0;
 	bool ok;
 	struct zcbor_map_decode_key_val dm[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_tstr_decode, &world),
-		ZCBOR_MAP_DECODE_KEY_VAL(one, zcbor_uint32_decode, &one),
-		ZCBOR_MAP_DECODE_KEY_VAL(bool_val, zcbor_bool_decode, &bool_val)
+		ZCBOR_MAP_DECODE_KEY_DECODER("hello", zcbor_tstr_decode, &world),
+		ZCBOR_MAP_DECODE_KEY_DECODER("one", zcbor_uint32_decode, &one),
+		ZCBOR_MAP_DECODE_KEY_DECODER("bool val", zcbor_bool_decode, &bool_val)
 	};
 
 	zcbor_new_encode_state(zsd, 2, buffer, ARRAY_SIZE(buffer), 0);
 
 	/* { "hello":"world", "one":1, "bool_val":true } */
 	ok = zcbor_map_start_encode(zsd, 10) &&
-	     zcbor_tstr_put_lit(zsd, "bool_val") && zcbor_true_put(zsd)			&&
+	     zcbor_tstr_put_lit(zsd, "bool val") && zcbor_true_put(zsd)			&&
 	     zcbor_tstr_put_lit(zsd, "one") && zcbor_uint32_put(zsd, 1)			&&
 	     zcbor_tstr_put_lit(zsd, "hello") && zcbor_tstr_put_lit(zsd, "world")	&&
 	     zcbor_map_end_encode(zsd, 10);
@@ -92,7 +114,7 @@ ZTEST(zcbor_bulk, test_correct_out_of_order)
 		sizeof("world") - 1);
 	zassert_equal(0, memcmp(world.value, "world", world.len),
 		"Expected \"world\", got %.*s", world.len, world.value);
-	zassert_true(bool_val, "Expected bool_val == true");
+	zassert_true(bool_val, "Expected bool val == true");
 }
 
 ZTEST(zcbor_bulk, test_not_map)
@@ -105,9 +127,9 @@ ZTEST(zcbor_bulk, test_not_map)
 	size_t decoded = 1111;
 	bool ok;
 	struct zcbor_map_decode_key_val dm[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_tstr_decode, &world),
-		ZCBOR_MAP_DECODE_KEY_VAL(one, zcbor_uint32_decode, &one),
-		ZCBOR_MAP_DECODE_KEY_VAL(bool_val, zcbor_bool_decode, &bool_val)
+		ZCBOR_MAP_DECODE_KEY_DECODER("hello", zcbor_tstr_decode, &world),
+		ZCBOR_MAP_DECODE_KEY_DECODER("one", zcbor_uint32_decode, &one),
+		ZCBOR_MAP_DECODE_KEY_DECODER("bool val", zcbor_bool_decode, &bool_val)
 	};
 
 	zcbor_new_encode_state(zsd, 2, buffer, ARRAY_SIZE(buffer), 0);
@@ -138,9 +160,9 @@ ZTEST(zcbor_bulk, test_bad_type)
 	bool ok;
 	struct zcbor_map_decode_key_val dm[] = {
 		/* First entry has bad decoder given instead of tstr */
-		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_uint32_decode, &world),
-		ZCBOR_MAP_DECODE_KEY_VAL(one, zcbor_uint32_decode, &one),
-		ZCBOR_MAP_DECODE_KEY_VAL(bool_val, zcbor_bool_decode, &bool_val)
+		ZCBOR_MAP_DECODE_KEY_DECODER("hello", zcbor_uint32_decode, &world),
+		ZCBOR_MAP_DECODE_KEY_DECODER("one", zcbor_uint32_decode, &one),
+		ZCBOR_MAP_DECODE_KEY_DECODER("bool val", zcbor_bool_decode, &bool_val)
 	};
 
 	zcbor_new_encode_state(zsd, 2, buffer, ARRAY_SIZE(buffer), 0);
@@ -149,7 +171,7 @@ ZTEST(zcbor_bulk, test_bad_type)
 	ok = zcbor_map_start_encode(zsd, 10) &&
 	     zcbor_tstr_put_lit(zsd, "hello") && zcbor_tstr_put_lit(zsd, "world")	&&
 	     zcbor_tstr_put_lit(zsd, "one") && zcbor_uint32_put(zsd, 1)			&&
-	     zcbor_tstr_put_lit(zsd, "bool_val") && zcbor_true_put(zsd)			&&
+	     zcbor_tstr_put_lit(zsd, "bool val") && zcbor_true_put(zsd)			&&
 	     zcbor_map_end_encode(zsd, 10);
 
 	zassert_true(ok, "Expected to be successful in encoding test pattern");
@@ -162,7 +184,7 @@ ZTEST(zcbor_bulk, test_bad_type)
 	zassert_equal(decoded, 0, "Expected 0 got %d", decoded);
 	zassert_equal(one, 0, "Expected 0");
 	zassert_equal(0, world.len, "Expected to be unmodified");
-	zassert_false(bool_val, "Expected bool_val == false");
+	zassert_false(bool_val, "Expected bool val == false");
 }
 
 ZTEST(zcbor_bulk, test_bad_type_2)
@@ -175,10 +197,10 @@ ZTEST(zcbor_bulk, test_bad_type_2)
 	size_t decoded = 0;
 	bool ok;
 	struct zcbor_map_decode_key_val dm[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_tstr_decode, &world),
-		ZCBOR_MAP_DECODE_KEY_VAL(one, zcbor_uint32_decode, &one),
+		ZCBOR_MAP_DECODE_KEY_DECODER("hello", zcbor_tstr_decode, &world),
+		ZCBOR_MAP_DECODE_KEY_DECODER("one", zcbor_uint32_decode, &one),
 		/* This is bad decoder for type bool */
-		ZCBOR_MAP_DECODE_KEY_VAL(bool_val, zcbor_tstr_decode, &bool_val)
+		ZCBOR_MAP_DECODE_KEY_DECODER("bool val", zcbor_tstr_decode, &bool_val)
 	};
 
 	zcbor_new_encode_state(zsd, 2, buffer, ARRAY_SIZE(buffer), 0);
@@ -187,7 +209,7 @@ ZTEST(zcbor_bulk, test_bad_type_2)
 	ok = zcbor_map_start_encode(zsd, 10) &&
 	     zcbor_tstr_put_lit(zsd, "hello") && zcbor_tstr_put_lit(zsd, "world")	&&
 	     zcbor_tstr_put_lit(zsd, "one") && zcbor_uint32_put(zsd, 1)			&&
-	     zcbor_tstr_put_lit(zsd, "bool_val") && zcbor_true_put(zsd)			&&
+	     zcbor_tstr_put_lit(zsd, "bool val") && zcbor_true_put(zsd)			&&
 	     zcbor_map_end_encode(zsd, 10);
 
 	zcbor_new_decode_state(zsd, 4, buffer, ARRAY_SIZE(buffer), 1);
@@ -202,7 +224,7 @@ ZTEST(zcbor_bulk, test_bad_type_2)
 		sizeof("world") - 1);
 	zassert_equal(0, memcmp(world.value, "world", world.len),
 		"Expected \"world\", got %.*s", world.len, world.value);
-	zassert_false(bool_val, "Expected bool_val unmodified");
+	zassert_false(bool_val, "Expected bool val unmodified");
 }
 
 ZTEST(zcbor_bulk, test_bad_type_encoded)
@@ -215,9 +237,9 @@ ZTEST(zcbor_bulk, test_bad_type_encoded)
 	size_t decoded = 0;
 	bool ok;
 	struct zcbor_map_decode_key_val dm[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_tstr_decode, &world),
-		ZCBOR_MAP_DECODE_KEY_VAL(one, zcbor_uint32_decode, &one),
-		ZCBOR_MAP_DECODE_KEY_VAL(bool_val, zcbor_bool_decode, &bool_val)
+		ZCBOR_MAP_DECODE_KEY_DECODER("hello", zcbor_tstr_decode, &world),
+		ZCBOR_MAP_DECODE_KEY_DECODER("one", zcbor_uint32_decode, &one),
+		ZCBOR_MAP_DECODE_KEY_DECODER("bool val", zcbor_bool_decode, &bool_val)
 	};
 
 	zcbor_new_encode_state(zsd, 2, buffer, ARRAY_SIZE(buffer), 0);
@@ -226,7 +248,7 @@ ZTEST(zcbor_bulk, test_bad_type_encoded)
 	ok = zcbor_map_start_encode(zsd, 10) &&
 	     zcbor_tstr_put_lit(zsd, "hello") && zcbor_uint32_put(zsd, 10)		&&
 	     zcbor_tstr_put_lit(zsd, "one") && zcbor_uint32_put(zsd, 1)			&&
-	     zcbor_tstr_put_lit(zsd, "bool_val") && zcbor_true_put(zsd)			&&
+	     zcbor_tstr_put_lit(zsd, "bool val") && zcbor_true_put(zsd)			&&
 	     zcbor_map_end_encode(zsd, 10);
 
 	zassert_true(ok, "Expected to be successful in encoding test pattern");
@@ -239,7 +261,7 @@ ZTEST(zcbor_bulk, test_bad_type_encoded)
 	zassert_equal(decoded, 0, "Expected 0 got %d", decoded);
 	zassert_equal(one, 0, "Expected 0");
 	zassert_equal(0, world.len, "Expected to be unmodified");
-	zassert_false(bool_val, "Expected bool_val == false");
+	zassert_false(bool_val, "Expected bool val == false");
 }
 
 ZTEST(zcbor_bulk, test_duplicate)
@@ -253,9 +275,9 @@ ZTEST(zcbor_bulk, test_duplicate)
 	size_t decoded = 0;
 	bool ok;
 	struct zcbor_map_decode_key_val dm[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_tstr_decode, &world),
-		ZCBOR_MAP_DECODE_KEY_VAL(one, zcbor_uint32_decode, &one),
-		ZCBOR_MAP_DECODE_KEY_VAL(bool_val, zcbor_bool_decode, &bool_val)
+		ZCBOR_MAP_DECODE_KEY_DECODER("hello", zcbor_tstr_decode, &world),
+		ZCBOR_MAP_DECODE_KEY_DECODER("one", zcbor_uint32_decode, &one),
+		ZCBOR_MAP_DECODE_KEY_DECODER("bool val", zcbor_bool_decode, &bool_val)
 	};
 
 	zcbor_new_encode_state(zsd, 2, buffer, ARRAY_SIZE(buffer), 0);
@@ -278,7 +300,7 @@ ZTEST(zcbor_bulk, test_duplicate)
 		sizeof("world") - 1);
 	zassert_equal(0, memcmp(world.value, "world", world.len),
 		"Expected \"world\", got %.*s", world.len, world.value);
-	zassert_false(bool_val, "Expected bool_val unmodified");
+	zassert_false(bool_val, "Expected bool val unmodified");
 }
 
 ZTEST_SUITE(zcbor_bulk, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
New macro allows spaces in string keys inside CBOR map encoding.