### PR TITLE
tests: Test tag cleanup

### DIFF
--- a/samples/application_development/external_lib/sample.yaml
+++ b/samples/application_development/external_lib/sample.yaml
@@ -4,7 +4,6 @@ tests:
   sample.app_dev.external_lib:
     integration_platforms:
       - native_posix
-    platform_exclude: intel_adsp_cavs15
     tags: external
     harness: console
     harness_config:

--- a/samples/drivers/audio/dmic/sample.yaml
+++ b/samples/drivers/audio/dmic/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: DMIC sample
 tests:
   sample.drivers.audio.dmic:
-    tags: DMIC
+    tags: dmic
     filter: dt_nodelabel_enabled("dmic_dev")
     integration_platforms:
       - nrf52840dk_nrf52840

--- a/samples/drivers/i2s/echo/sample.yaml
+++ b/samples/drivers/i2s/echo/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: I2S echo sample
 tests:
   sample.drivers.i2s.echo:
-    tags: I2S
+    tags: i2s
     filter: dt_nodelabel_enabled("i2s_rxtx") or
             (dt_nodelabel_enabled("i2s_rx") and dt_nodelabel_enabled("i2s_tx"))
     integration_platforms:

--- a/samples/modules/chre/sample.yaml
+++ b/samples/modules/chre/sample.yaml
@@ -4,7 +4,7 @@ sample:
   name: chre
 tests:
   sample.modules.chre:
-    tags: introduction
+    tags: introduction chre
     platform_exclude: qemu_leon3
     modules:
       - chre

--- a/tests/drivers/console/testcase.yaml
+++ b/tests/drivers/console/testcase.yaml
@@ -8,10 +8,10 @@ common:
 
 tests:
   drivers.console.uart:
-    tags: drivers console
+    tags: drivers console uart
     filter: CONFIG_UART_CONSOLE
   drivers.console.semihost:
-    tags: drivers console
+    tags: drivers console semihost
     arch_allow: arm arm64 riscv32 riscv64
     platform_type:
       - qemu

--- a/tests/drivers/uart/uart_basic_api/testcase.yaml
+++ b/tests/drivers/uart/uart_basic_api/testcase.yaml
@@ -1,13 +1,13 @@
 tests:
   drivers.uart.basic_api:
-    tags: drivers
+    tags: drivers uart
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
     integration_platforms:
       - mps2_an385
   drivers.uart.basic_api.poll:
     extra_args: CONF_FILE=prj_poll.conf
-    tags: drivers
+    tags: drivers uart
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
     integration_platforms:
@@ -15,7 +15,7 @@ tests:
   drivers.uart.basic_api.shell:
     extra_args: CONF_FILE=prj_shell.conf
     min_flash: 64
-    tags: drivers
+    tags: drivers uart
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
     integration_platforms:


### PR DESCRIPTION
Several test tags were inconsistently upper cased, some tests were missing appropriate tags that could be used to identify and exclude certain tests. This PR fixes several issues found while determining tags to ignore for intel platforms. While the ignore_tags updates were decided to not be the approach to use, the tag fixes are still useful.