### PR TITLE
soc: arm: microchip: mec172x: Correct PECI base address

### DIFF
--- a/soc/arm/microchip_mec/mec172x/device_power.c
+++ b/soc/arm/microchip_mec/mec172x/device_power.c
@@ -19,7 +19,7 @@
 #define ECS_XEC_REG_BASE						\
 	((struct ecs_regs *)(DT_REG_ADDR(DT_NODELABEL(ecs))))
 #define PECI_XEC_REG_BASE						\
-	((struct peci_regs *)(DT_REG_ADDR(DT_NODELABEL(pcr))))
+	((struct peci_regs *)(DT_REG_ADDR(DT_NODELABEL(peci0))))
 #define PCR_XEC_REG_BASE						\
 	((struct pcr_regs *)(DT_REG_ADDR(DT_NODELABEL(pcr))))
 #define TFDP_0_XEC_REG_BASE						\


### PR DESCRIPTION
Use correct device tree entry for PECI

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>