### PR TITLE
gitlint: Add "commit" to violation messages

### DIFF
--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -32,7 +32,7 @@ class BodyMinLineCount(CommitRule):
         line_count = len(filtered)
         min_line_count = self.options['min-line-count'].value
         if line_count < min_line_count:
-            message = "Body has no content, should at least have {} line.".format(min_line_count)
+            message = "Commit body has no content, should at least have {} line(s).".format(min_line_count)
             return [RuleViolation(self.id, message, line_nr=1)]
 
 class BodyMaxLineCount(CommitRule):
@@ -49,7 +49,7 @@ class BodyMaxLineCount(CommitRule):
         line_count = len(commit.message.body)
         max_line_count = self.options['max-line-count'].value
         if line_count > max_line_count:
-            message = "Body contains too many lines ({0} > {1})".format(line_count, max_line_count)
+            message = "Commit body contains too many lines ({0} > {1})".format(line_count, max_line_count)
             return [RuleViolation(self.id, message, line_nr=1)]
 
 class SignedOffBy(CommitRule):
@@ -72,14 +72,14 @@ class SignedOffBy(CommitRule):
                     return [RuleViolation(self.id, "Signed-off-by: must have a full name", line_nr=1)]
                 else:
                     return
-        return [RuleViolation(self.id, "Body does not contain a 'Signed-off-by:' line", line_nr=1)]
+        return [RuleViolation(self.id, "Commit body does not contain a 'Signed-off-by:' line", line_nr=1)]
 
 class TitleMaxLengthRevert(LineRule):
     name = "title-max-length-no-revert"
     id = "UC5"
     target = CommitMessageTitle
     options_spec = [IntOption('line-length', 72, "Max line length")]
-    violation_message = "Title exceeds max length ({0}>{1})"
+    violation_message = "Commit title exceeds max length ({0}>{1})"
 
     def validate(self, line, _commit):
         max_length = self.options['line-length'].value
@@ -95,7 +95,7 @@ class TitleStartsWithSubsystem(LineRule):
     def validate(self, title, _commit):
         regex = self.options['regex'].value
         pattern = re.compile(regex, re.UNICODE)
-        violation_message = "Title does not follow [subsystem]: [subject] (and should not start with literal subsys:)"
+        violation_message = "Commit title does not follow [subsystem]: [subject] (and should not start with literal subsys:)"
         if not pattern.search(title):
             return [RuleViolation(self.id, violation_message, title)]
 
@@ -104,7 +104,7 @@ class MaxLineLengthExceptions(LineRule):
     id = "UC4"
     target = CommitMessageBody
     options_spec = [IntOption('line-length', 80, "Max line length")]
-    violation_message = "Line exceeds max length ({0}>{1})"
+    violation_message = "Commit body line exceeds max length ({0}>{1})"
 
     def validate(self, line, _commit):
         max_length = self.options['line-length'].value
@@ -128,5 +128,5 @@ class BodyContainsBlockedTags(LineRule):
         flags = re.IGNORECASE
         for tag in self.tags:
             if re.search(rf"^\s*{tag}:", line, flags=flags):
-                return [RuleViolation(self.id, f"Body contains a blocked tag: {tag}")]
+                return [RuleViolation(self.id, f"Commit body contains a blocked tag: {tag}")]
         return


### PR DESCRIPTION
This PR clarifies the violation messages emitted by gitlint when checking the commit message. For example:

 * Before: `43: UC4 Line exceeds max length (N>75): "..."`
 * After: `43: UC4 Commit line exceeds max length (N>75): "..."`

This makes it easier to identify the source of the error since there is currently no additional context besides the error code UC*. I recently pushed a commit that had some sample code as part of the commit body that exceeded the lenght limit, and thought the error was referring to one of my source files based on the line it showed. (feel free to laugh at me, but let's make it better for the next person)

Signed-off-by: Tristan Honscheid <honscheid@google.com>