### PR TITLE
Bluetooth: Controller: Fix dynamic tx power for Broadcast ISO

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -229,7 +229,7 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	radio_reset();
 
 #if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
-	radio_tx_power_set(lll->tx_pwr_lvl);
+	radio_tx_power_set(lll->adv->tx_pwr_lvl);
 #else
 	radio_tx_power_set(RADIO_TXP_DEFAULT);
 #endif

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -257,12 +257,6 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 	/* Start setting up of Radio h/w */
 	radio_reset();
 
-#if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
-	radio_tx_power_set(lll->tx_pwr_lvl);
-#else
-	radio_tx_power_set(RADIO_TXP_DEFAULT);
-#endif
-
 	phy = lll->phy;
 	radio_phy_set(phy, PHY_FLAGS_S8);
 	radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT, lll->max_pdu,


### PR DESCRIPTION
Fix compilation error for ISO Broadcaster with dynamix Tx power support, and remove setting tx power for ISO Synchronized Receiver.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>