### PR TITLE
Bluetooth: Controller: Remove duplicate code in nRF5 radio HAL

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1242,24 +1242,7 @@ uint32_t radio_tmr_start_now(uint8_t trx)
 {
 	uint32_t start_us;
 
-	hal_radio_enable_on_tick_ppi_config_and_enable(trx);
-
-#if !defined(CONFIG_BT_CTLR_TIFS_HW)
-#if defined(CONFIG_SOC_SERIES_NRF53X)
-	/* NOTE: Timer clear DPPI configuration is needed only for nRF53
-	 *       because of calls to radio_disable() and
-	 *       radio_switch_complete_and_disable() inside a radio event call
-	 *       hal_radio_sw_switch_disable(), which in the case of nRF53
-	 *       cancels the task subscription.
-	 */
-	/* FIXME: hal_sw_switch_timer_clear_ppi_config() sets both task and
-	 *        event. Consider a new interface to only set the task, or
-	 *        change the design to not clear task subscription inside a
-	 *        radio event but when the radio event is done.
-	 */
-	hal_sw_switch_timer_clear_ppi_config();
-#endif /* CONFIG_SOC_SERIES_NRF53X */
-#endif /* !CONFIG_BT_CTLR_TIFS_HW */
+	/* PPI/DPPI configuration will be done in radio_tmr_start_us() */
 
 	/* Capture the current time */
 	nrf_timer_task_trigger(EVENT_TIMER, NRF_TIMER_TASK_CAPTURE1);

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
@@ -24,10 +24,8 @@
  */
 #define NRF_RADIO_SHORTS_PDU_END_DISABLE RADIO_SHORTS_END_DISABLE_Msk
 
-#if defined(CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE)
 /* Delay of EVENTS_PHYEND event on receive PDU without CTE inclded when CTEINLINE is enabled */
 #define RADIO_EVENTS_PHYEND_DELAY_US 16
-#endif /* CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE */
 
 /* Delay of CCM TASKS_CRYPT start in number of bits for Radio Bit counter */
 #define CCM_TASKS_CRYPT_DELAY_BITS 3
@@ -36,6 +34,7 @@
 #define HAL_EVENT_TIMER_SAMPLE_CC_OFFSET 3
 #define HAL_EVENT_TIMER_SAMPLE_TASK NRF_TIMER_TASK_CAPTURE3
 
+/* Define to reset PPI registration */
 #define NRF_PPI_NONE 0
 
 #if defined(CONFIG_SOC_SERIES_BSIM_NRFXX)


### PR DESCRIPTION
Remove duplicate PPI/DPPI configuration in
radio_tmr_start_now() which reuses radio_tmr_start_us().

And other minor refactor to remove unnecessary conditional compilation of a define.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>