### PR TITLE
net: zperf: fix incorrect statistics of zperf

### DIFF
--- a/subsys/net/lib/zperf/zperf_session.c
+++ b/subsys/net/lib/zperf/zperf_session.c
@@ -129,7 +129,7 @@ void zperf_reset_session_stats(struct session *session)
 
 	session->counter = 0U;
 	session->start_time = 0U;
-	session->next_id = 0U;
+	session->next_id = 1U;
 	session->length = 0U;
 	session->outorder = 0U;
 	session->error = 0U;

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -195,10 +195,10 @@ static void udp_received(const struct shell *sh, int sock,
 				      session->counter);
 			shell_fprintf(sh, SHELL_NORMAL,
 				      " nb packets lost:\t%u\n",
-				      session->outorder);
+				      session->error);
 			shell_fprintf(sh, SHELL_NORMAL,
 				      " nb packets outorder:\t%u\n",
-				      session->error);
+				      session->outorder);
 
 			shell_fprintf(sh, SHELL_NORMAL,
 				      " jitter:\t\t\t");


### PR DESCRIPTION
The sequence id from iperf starts with 1. The commit changes the initial value of "next_id" in zperf from 0 to 1. In addition, the error output of "error" and "out of order" packets is corrected.

Signed-off-by: Yanqin Wei <Yanqin.Wei@arm.com>