### PR TITLE
tests: settings: remove dead code

### DIFF
--- a/tests/subsys/settings/fcb/src/settings_test_compress_deleted.c
+++ b/tests/subsys/settings/fcb/src/settings_test_compress_deleted.c
@@ -6,7 +6,6 @@
 
 #include "settings_test.h"
 #include "settings/settings_fcb.h"
-#include <zephyr/sys/printk.h>
 
 #define NAME_DELETABLE "4/deletable"
 

--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -359,9 +359,6 @@ void *settings_config_fcb_setup(void)
 	return NULL;
 }
 
-void test_config_insert2(void);
-void test_config_insert3(void);
-
 ZTEST(settings_config_fcb, test_config_insert_handler2)
 {
 	test_config_insert2();

--- a/tests/subsys/settings/file/include/settings_test_file.h
+++ b/tests/subsys/settings/file/include/settings_test_file.h
@@ -28,8 +28,6 @@ extern int test_set_called;
 extern int test_commit_called;
 extern int test_export_block;
 
-extern int c2_var_count;
-
 extern struct settings_handler c_test_handlers[];
 
 void ctest_clear_call_state(void);

--- a/tests/subsys/settings/file/src/settings_test_file.c
+++ b/tests/subsys/settings/file/src/settings_test_file.c
@@ -19,8 +19,6 @@ int test_set_called;
 int test_commit_called;
 int test_export_block;
 
-int c2_var_count = 1;
-
 int c1_handle_get(const char *name, char *val, int val_len_max);
 int c1_handle_set(const char *name, size_t len, settings_read_cb read_cb,
 		  void *cb_arg);

--- a/tests/subsys/settings/nvs/src/settings_test.h
+++ b/tests/subsys/settings/nvs/src/settings_test.h
@@ -17,10 +17,6 @@
 extern "C" {
 #endif
 
-#define SETTINGS_TEST_NVS_VAL_STR_CNT   64
-#define SETTINGS_TEST_NVS_FLASH_CNT   4
-
-
 extern uint8_t val8;
 extern uint8_t val8_un;
 extern uint32_t val32;
@@ -30,9 +26,6 @@ extern int test_get_called;
 extern int test_set_called;
 extern int test_commit_called;
 extern int test_export_block;
-
-extern char val_string[SETTINGS_TEST_NVS_VAL_STR_CNT][SETTINGS_MAX_VAL_LEN];
-extern char test_ref_value[SETTINGS_TEST_NVS_VAL_STR_CNT][SETTINGS_MAX_VAL_LEN];
 
 extern struct settings_handler c_test_handlers[];
 

--- a/tests/subsys/settings/nvs/src/settings_test_nvs.c
+++ b/tests/subsys/settings/nvs/src/settings_test_nvs.c
@@ -19,25 +19,11 @@ int test_set_called;
 int test_commit_called;
 int test_export_block;
 
-int c2_var_count = 1;
-
 int c1_handle_get(const char *name, char *val, int val_len_max);
 int c1_handle_set(const char *name, size_t len, settings_read_cb read_cb,
 		  void *cb_arg);
 int c1_handle_commit(void);
 int c1_handle_export(int (*cb)(const char *name,
-			       const void *value, size_t val_len));
-
-int c2_handle_get(const char *name, char *val, int val_len_max);
-int c2_handle_set(const char *name, size_t len, settings_read_cb read_cb,
-		  void *cb_arg);
-int c2_handle_export(int (*cb)(const char *name,
-			       const void *value, size_t val_len));
-
-int c3_handle_get(const char *name, char *val, int val_len_max);
-int c3_handle_set(const char *name, size_t len, settings_read_cb read_cb,
-		  void *cb_arg);
-int c3_handle_export(int (*cb)(const char *name,
 			       const void *value, size_t val_len));
 
 struct settings_handler c_test_handlers[] = {
@@ -48,24 +34,7 @@ struct settings_handler c_test_handlers[] = {
 		.h_commit = c1_handle_commit,
 		.h_export = c1_handle_export
 	},
-	{
-		.name = "2nd",
-		.h_get = c2_handle_get,
-		.h_set = c2_handle_set,
-		.h_commit = NULL,
-		.h_export = c2_handle_export
-	},
-	{
-		.name = "3",
-		.h_get = c3_handle_get,
-		.h_set = c3_handle_set,
-		.h_commit = NULL,
-		.h_export = c3_handle_export
-	}
 };
-
-char val_string[SETTINGS_TEST_NVS_VAL_STR_CNT][SETTINGS_MAX_VAL_LEN];
-char test_ref_value[SETTINGS_TEST_NVS_VAL_STR_CNT][SETTINGS_MAX_VAL_LEN];
 
 int c1_handle_get(const char *name, char *val, int val_len_max)
 {
@@ -158,136 +127,6 @@ void config_wipe_srcs(void)
 {
 	sys_slist_init(&settings_load_srcs);
 	settings_save_dst = NULL;
-}
-
-char *c2_var_find(char *name)
-{
-	int idx = 0;
-	int len;
-	char *eptr;
-
-	len = strlen(name);
-	zassert_true(len > 6, "string type expected");
-	zassert_true(!strncmp(name, "string", 6), "string type expected");
-
-	idx = strtoul(&name[6], &eptr, 10);
-	zassert_true(*eptr == '\0', "EOF");
-	zassert_true(idx < c2_var_count,
-		     "var index greather than any exporter");
-
-	return val_string[idx];
-}
-
-int c2_handle_get(const char *name, char *val, int val_len_max)
-{
-	int len;
-	char *valptr;
-	const char *next;
-	char argv[32];
-
-	len = settings_name_next(name, &next);
-	if (len && !next) {
-		strncpy(argv, name, len);
-		argv[len] = '\0';
-		valptr = c2_var_find(argv);
-		if (!valptr) {
-			return -ENOENT;
-		}
-
-		len = strlen(val_string[0]);
-		if (len > val_len_max) {
-			len = val_len_max;
-		}
-
-		len = MIN(strlen(valptr), len);
-		memcpy(val, valptr, len);
-		return len;
-	}
-
-	return -ENOENT;
-}
-
-int c2_handle_set(const char *name, size_t len, settings_read_cb read_cb,
-		  void *cb_arg)
-{
-	char *valptr;
-	const char *next;
-	char argv[32];
-
-	int rc;
-
-	len = settings_name_next(name, &next);
-	if (len && !next) {
-		strncpy(argv, name, len);
-		argv[len] = '\0';
-		valptr = c2_var_find(argv);
-		if (!valptr) {
-			return -ENOENT;
-		}
-
-		rc = read_cb(cb_arg, valptr, sizeof(val_string[0]));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
-		if (rc == 0) {
-			(void)memset(valptr, 0, sizeof(val_string[0]));
-		}
-
-		return 0;
-	}
-
-	return -ENOENT;
-}
-
-int c2_handle_export(int (*cb)(const char *name,
-			       const void *value, size_t val_len))
-{
-	int i;
-	char name[32];
-
-	for (i = 0; i < c2_var_count; i++) {
-		snprintf(name, sizeof(name), "2nd/string%d", i);
-		(void)cb(name, val_string[i], strlen(val_string[i]));
-	}
-
-	return 0;
-}
-
-int c3_handle_get(const char *name, char *val, int val_len_max)
-{
-	const char *next;
-
-	if (settings_name_steq(name, "v", &next) && !next) {
-		val_len_max = MIN(val_len_max, sizeof(val32));
-		memcpy(val, &val32, MIN(val_len_max, sizeof(val32)));
-		return val_len_max;
-	}
-	return -EINVAL;
-}
-
-int c3_handle_set(const char *name, size_t len, settings_read_cb read_cb,
-		  void *cb_arg)
-{
-	int rc;
-	size_t val_len;
-	const char *next;
-
-	if (settings_name_steq(name, "v", &next) && !next) {
-		val_len = len;
-		zassert_true(val_len == 4, "bad set-value size");
-
-		rc = read_cb(cb_arg, &val32, sizeof(val32));
-		zassert_true(rc >= 0, "SETTINGS_VALUE_SET callback");
-		return 0;
-	}
-
-	return -ENOENT;
-}
-
-int c3_handle_export(int (*cb)(const char *name,
-			       const void *value, size_t val_len))
-{
-	(void)cb("3/v", &val32, sizeof(val32));
-
-	return 0;
 }
 
 ZTEST_SUITE(settings_config, NULL, settings_config_setup, NULL, NULL,


### PR DESCRIPTION
Remove:
 * some local (duplicated from header) C function prototypes
 * unused includes
 * unused (never registered and tested) settings handlers for NVS backend
 * unused global variables