### PR TITLE
ITE soc/it8xxx2/linker: add sections for hw sha256 calculation

### DIFF
--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
@@ -105,4 +105,12 @@ config SOC_IT8XXX2_EXCEPTIONS_IN_RAM
 	  Flash. This can significantly improve performance when under I-cache
 	  pressure.
 
+config SOC_IT8XXX2_SHA256_HW_ACCELERATE
+	bool "HW SHA256 calculation"
+	help
+	  IT8XXX2 HW support sha256 calculation, and its calculation is faster than FW.
+	  We place SHA256 message, hash and key data (total 512bytes) in RAM.
+	  If we enable this config, because HW limits, the sha256 data must place in
+	  first 4KB of RAM.
+
 endif # SOC_IT8XXX2

--- a/soc/riscv/riscv-ite/it8xxx2/linker.ld
+++ b/soc/riscv/riscv-ite/it8xxx2/linker.ld
@@ -65,6 +65,10 @@
 	#define MPU_ALIGN(region_size) . = ALIGN(4)
 #endif
 
+#ifdef CONFIG_SOC_IT8XXX2_SHA256_HW_ACCELERATE
+#define SHA256_BLOCK_SIZE 0x200
+#endif
+
 MEMORY
 {
 #ifdef CONFIG_XIP
@@ -147,6 +151,12 @@ SECTIONS
 		. = ALIGN(0x1000);
 		/* Mapping base address must be 4k-aligned */
 		__ilm_flash_start = .;
+#ifdef CONFIG_SOC_IT8XXX2_SHA256_HW_ACCELERATE
+		/* Pad to match allocation of block in RAM,
+		 * maintaining code alignment against ILM */
+		__sha256_pad_block_start = .;
+		. = . + SHA256_BLOCK_SIZE;
+#endif
 		/* Specially-tagged functions in SoC sources */
 		KEEP(*(.__ram_code))
 		*(.__ram_code.*)
@@ -226,6 +236,21 @@ SECTIONS
     SECTION_PROLOGUE(ilm_ram,(NOLOAD),ALIGN(0x1000))
 	{
 		__ilm_ram_start = .;
+
+#ifdef CONFIG_SOC_IT8XXX2_SHA256_HW_ACCELERATE
+		__sha256_ram_block_start = .;
+		KEEP(*(.__sha256_ram_block))
+		__sha256_ram_block_size = \
+			ABSOLUTE(. - __sha256_ram_block_start);
+		__sha256_ram_block_end = .;
+		ASSERT((__sha256_ram_block_size == SHA256_BLOCK_SIZE), \
+			"We need 512bytes for HW sha256 module");
+		ASSERT((__sha256_ram_block_end < (RAM_BASE + 0x1000)), \
+			"512bytes must in SRAM first 4kbytes");
+		ASSERT(((ABSOLUTE(__sha256_ram_block_start) & 0xfff) == \
+			(ABSOLUTE(__sha256_pad_block_start) & 0xfff)), \
+			"sha256 ram block needs the same offset with sha256 rom block");
+#endif
 		. += __ilm_flash_end - __ilm_flash_start;
 		__ilm_ram_end = .;
 	} GROUP_LINK_IN(RAMABLE_REGION)


### PR DESCRIPTION
IT8XXX2 HW support sha256 calculation, and its calculation is faster than FW. We place SHA256 message, hash and key data (total 512bytes) in RAM. If we enable this config, because HW limits, the sha256 data must place in first 4KB of RAM. We add sections for hw sha256 calculation in linker.

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>
Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>