### PR TITLE
STM32H723/733, STM32H725/735 and STM32H730 add USB OTG HS

### DIFF
--- a/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
@@ -164,6 +164,12 @@
 	pinctrl-names = "default";
 };
 
+zephyr_udc0: &usbotg_hs {
+	pinctrl-0 = <&usb_otg_hs_dm_pa11 &usb_otg_hs_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &rng {
 	status = "okay";
 };

--- a/boards/arm/nucleo_h723zg/nucleo_h723zg.yaml
+++ b/boards/arm/nucleo_h723zg/nucleo_h723zg.yaml
@@ -20,3 +20,4 @@ supported:
   - spi
   - netif:eth
   - backup_sram
+  - usb_device

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -50,8 +50,7 @@ config USB_DC_STM32
 	select USE_STM32_HAL_PCD
 	select USE_STM32_HAL_PCD_EX
 	help
-	  Enable USB support on the STM32 F0, F1, F2, F3, F4, F7, L0, L4, G4, U5 family of
-	  processors.
+	  Enable STM32 family USB device controller shim driver.
 
 config USB_DC_SAM0
 	bool "SAM0 series USB Device Controller driver"

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -47,6 +47,19 @@
 			health-test-config = <0xaa74>;
 		};
 
+		usbotg_hs: usb@40040000 {
+			compatible = "st,stm32-otghs";
+			reg = <0x40040000 0x40000>;
+			interrupts = <77 0>, <74 0>, <75 0>;
+			interrupt-names = "otghs", "ep1_out", "ep1_in";
+			num-bidir-endpoints = <9>;
+			ram-size = <DT_SIZE_K(4)>;
+			maximum-speed = "full-speed";
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x02000000>;
+			phys = <&otghs_fs_phy>;
+			status = "disabled";
+		};
+
 		ltdc: display-controller@50001000 {
 			compatible = "st,stm32-ltdc";
 			reg = <0x50001000 0x200>;
@@ -154,6 +167,11 @@
 		compatible = "zephyr,memory-region", "arm,itcm";
 		reg = <0x00000000 DT_SIZE_K(64)>;
 		zephyr,memory-region = "ITCM";
+	};
+
+	otghs_fs_phy: otghs_fs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
 	};
 
 	die_temp: dietemp {


### PR DESCRIPTION
* Adds USB OTG HS and internal FS PHY.
* Simplifies STM32 USB Kconfig help message.
  The USB_DC_STM32 help message started to miss some STM32 MCU families (_i.e., H7_).
  Overtime, the message will get bigger if we continue to list family names.
  Removed family names to simplify the message and avoid periodic modifications.
* Enables it on `nucleo_h723zg` and adds `usb_device` to the board support