### PR TITLE
Bluetooth: Mesh: Multiple friendship fixes

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/core.rst
+++ b/doc/connectivity/bluetooth/api/mesh/core.rst
@@ -21,6 +21,12 @@ the LPN API allows the application to trigger the polling at any time through
 interval, poll event timing and Friend requirements is controlled through the
 :kconfig:option:`CONFIG_BT_MESH_LOW_POWER` option and related configuration options.
 
+When using the LPN feature with logging, it is strongly recommended to only use
+the :kconfig:option:`CONFIG_LOG_MODE_DEFERRED` option. Log modes other than the
+deferred may cause unintended delays during processing of log messages. This in
+turns will affect scheduling of the receive delay and receive window. The same
+limitation applies for the :kconfig:option:`CONFIG_BT_MESH_FRIEND` option.
+
 Replay Protection List
 **********************
 

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -765,13 +765,16 @@ config BT_MESH_LPN_MIN_QUEUE_SIZE
 
 config BT_MESH_LPN_RECV_DELAY
 	int "Receive delay requested by the local node"
+	range 50 255 if BT_MESH_ADV_LEGACY
 	range 10 255
 	default 100
 	help
 	  The ReceiveDelay is the time between the Low Power node
 	  sending a request and listening for a response. This delay
 	  allows the Friend node time to prepare the response. The value
-	  is in units of milliseconds.
+	  is in units of milliseconds. When BT_MESH_ADV_LEGACY is used,
+	  the minimal value for the delay can not be less than 50ms due
+	  to a limitation in the legacy advertiser implementation.
 
 config BT_MESH_LPN_POLL_TIMEOUT
 	int "The value of the PollTimeout timer"

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -26,6 +26,17 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mesh_friend);
 
+/**
+ * Log modes other than the deferred may cause unintended delays during processing of log messages.
+ * This in turns will affect scheduling of the receive delay and receive window.
+ */
+#if !defined(CONFIG_TEST) && !defined(CONFIG_ARCH_POSIX) && \
+	defined(CONFIG_LOG) && !defined(CONFIG_LOG_MODE_DEFERRED) && \
+	(LOG_LEVEL >= LOG_LEVEL_INF)
+#warning Frienship feature may work unstable when non-deferred log mode is selected. Use the \
+	 CONFIG_LOG_MODE_DEFERRED Kconfig option when Friend feature is enabled.
+#endif
+
 /* We reserve one extra buffer for each friendship, since we need to be able
  * to resend the last sent PDU, which sits separately outside of the queue.
  */

--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -27,6 +27,17 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mesh_lpn);
 
+/**
+ * Log modes other than the deferred may cause unintended delays during processing of log messages.
+ * This in turns will affect scheduling of the receive delay and receive window.
+ */
+#if !defined(CONFIG_TEST) && !defined(CONFIG_ARCH_POSIX) && \
+	defined(CONFIG_LOG) && !defined(CONFIG_LOG_MODE_DEFERRED) && \
+	(LOG_LEVEL >= LOG_LEVEL_INF)
+#warning Frienship feature may work unstable when non-deferred log mode is selected. Use the \
+	 CONFIG_LOG_MODE_DEFERRED Kconfig option when Low Power node feature is enabled.
+#endif
+
 #if defined(CONFIG_BT_MESH_LPN_AUTO)
 #define LPN_AUTO_TIMEOUT (CONFIG_BT_MESH_LPN_AUTO_TIMEOUT * MSEC_PER_SEC)
 #else

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -152,6 +152,9 @@ struct bt_mesh_lpn {
 	/* Duration reported for last advertising packet */
 	uint16_t adv_duration;
 
+	/* Advertising start time. */
+	uint32_t adv_start_time;
+
 	/* Next LPN related action timer */
 	struct k_work_delayable timer;
 


### PR DESCRIPTION
This PR addresses the following issues:
- Calling friendship callbacks before scheduling timers or queueing friendship messages may break friendship communication;
- Incorrect adv duration calculation resulting in longer receive delay and receive window;
- Using incorrect logging mode that may affect the friendship communication;

For details, see commits messages.