### PR TITLE
boards: arm: nucleo l4r5zi enables HSI48 clock for USB

### DIFF
--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -74,6 +74,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &pll {
 	div-m = <4>;
 	mul-n = <40>;


### PR DESCRIPTION
Enables the HSI48 clock on the nucleo_l4r5zi platform.

Avoid warning during compilation due to HSI48 not enabled.
```
#warning USB device requires HSI48 clock to be enabled using device tree [-Wcpp]
  212 | #warning USB device requires HSI48 clock to be enabled using device tree
```

Fix CI error on the nucleo_l4r5zi             zephyr/samples/net/sockets/big_http_download/sample.net.sockets.big_http_download.posix FAILED Build failure (build)

Signed-off-by: Francois Ramu <francois.ramu@st.com>