### PR TITLE
Revert "drivers: gpio: STM32U5 independant IO supply"

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -711,11 +711,7 @@ static int gpio_stm32_init(const struct device *dev)
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 	/* Port G[15:2] requires external power supply */
 	/* Cf: L4/L5 RM, Chapter "Independent I/O supply rail" */
-#if defined(CONFIG_SOC_SERIES_STM32U5X)
-	LL_PWR_EnableVDDIO2();
-#else
 	LL_PWR_EnableVddIO2();
-#endif
 	z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
 #endif
 	/* enable port clock (if runtime PM is not enabled) */


### PR DESCRIPTION
Reverts zephyrproject-rtos/zephyr#51706
Unnecessary, It was already patched in hal: https://github.com/zephyrproject-rtos/hal_stm32/pull/147