### PR TITLE
tests: re-enable tests which were disabled due to ARC QEMU issues

### DIFF
--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -4,11 +4,7 @@ common:
 tests:
   kernel.memory_protection:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    # FIXME: This test fails on qemu_arc_{em|hs} consistently, due to bug in quem_arc,
-    # details: https://github.com/foss-for-synopsys-dwc-arc-processors/qemu/issues/14.
-    # To get clean results we need to disable this test until the bug is fixed and fix
-    # gets propagated to new Zephyr-SDK.
-    platform_exclude: twr_ke18f qemu_arc_hs qemu_arc_em
+    platform_exclude: twr_ke18f
     extra_args: CONFIG_TEST_HW_STACK_PROTECTION=n
   kernel.memory_protection.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS

--- a/tests/kernel/mem_protect/syscalls/testcase.yaml
+++ b/tests/kernel/mem_protect/syscalls/testcase.yaml
@@ -3,7 +3,4 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     tags: kernel security userspace
     ignore_faults: true
-    # FIXME: This test may fail for qemu_arc_em on certain host systems.
-    #        See foss-for-synopsys-dwc-arc-processors/qemu#66.
-    platform_exclude: qemu_arc_em
     timeout: 180


### PR DESCRIPTION
Re-enable several mem_protect tests for qemu_arc_* platforms which were disabled due to issues in ARC QEMU (which are fixed and fixes were propagated to Zephyr SDK)

The related QEMU issues are:
https://github.com/foss-for-synopsys-dwc-arc-processors/qemu/issues/14
https://github.com/foss-for-synopsys-dwc-arc-processors/qemu/issues/67 (in the code comment it was mentioned with 66 number which is incorrect)