### PR TITLE
drivers: gpio: Add more flags for GPIO's in devicetree

### DIFF
--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -246,7 +246,7 @@ typedef uint8_t gpio_pin_t;
  * The lower 8 bits are used for standard flags. The upper 8 bits are reserved
  * for SoC specific flags.
  */
-typedef uint16_t gpio_dt_flags_t;
+typedef uint32_t gpio_dt_flags_t;
 
 /**
  * @brief Provides a type to hold GPIO configuration flags.

--- a/include/zephyr/dt-bindings/gpio/gpio.h
+++ b/include/zephyr/dt-bindings/gpio/gpio.h
@@ -79,7 +79,170 @@
 /* Note: Bits 15 downto 8 are reserved for SoC specific flags. */
 
 /**
- * @}
+ * @name GPIO input/output configuration flags
+ * @{
  */
+
+/** Enables pin as input. */
+#define GPIO_INPUT              (1U << 16)
+
+/** Enables pin as output, no change to the output state. */
+#define GPIO_OUTPUT             (1U << 17)
+
+/** Disables pin for both input and output. */
+#define GPIO_DISCONNECTED	0
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Initializes output to a low state. */
+#define GPIO_OUTPUT_INIT_LOW    (1U << 18)
+
+/* Initializes output to a high state. */
+#define GPIO_OUTPUT_INIT_HIGH   (1U << 19)
+
+/* Initializes output based on logic level */
+#define GPIO_OUTPUT_INIT_LOGICAL (1U << 20)
+
+/** @endcond */
+
+/** Configures GPIO pin as output and initializes it to a low state. */
+#define GPIO_OUTPUT_LOW         (GPIO_OUTPUT | GPIO_OUTPUT_INIT_LOW)
+/** Configures GPIO pin as output and initializes it to a high state. */
+#define GPIO_OUTPUT_HIGH        (GPIO_OUTPUT | GPIO_OUTPUT_INIT_HIGH)
+/** Configures GPIO pin as output and initializes it to a logic 0. */
+#define GPIO_OUTPUT_INACTIVE    (GPIO_OUTPUT |			\
+				 GPIO_OUTPUT_INIT_LOW |		\
+				 GPIO_OUTPUT_INIT_LOGICAL)
+/** Configures GPIO pin as output and initializes it to a logic 1. */
+#define GPIO_OUTPUT_ACTIVE      (GPIO_OUTPUT |			\
+				 GPIO_OUTPUT_INIT_HIGH |	\
+				 GPIO_OUTPUT_INIT_LOGICAL)
+
+/** @} */
+
+/**
+ * @name GPIO interrupt configuration flags
+ * The `GPIO_INT_*` flags are used to specify how input GPIO pins will trigger
+ * interrupts. The interrupts can be sensitive to pin physical or logical level.
+ * Interrupts sensitive to pin logical level take into account GPIO_ACTIVE_LOW
+ * flag. If a pin was configured as Active Low, physical level low will be
+ * considered as logical level 1 (an active state), physical level high will
+ * be considered as logical level 0 (an inactive state).
+ * @{
+ */
+
+/** Disables GPIO pin interrupt. */
+#define GPIO_INT_DISABLE               (1U << 21)
+
+/** @cond INTERNAL_HIDDEN */
+
+/* Enables GPIO pin interrupt. */
+#define GPIO_INT_ENABLE                (1U << 22)
+
+/* GPIO interrupt is sensitive to logical levels.
+ *
+ * This is a component flag that should be combined with other
+ * `GPIO_INT_*` flags to produce a meaningful configuration.
+ */
+#define GPIO_INT_LEVELS_LOGICAL        (1U << 23)
+
+/* GPIO interrupt is edge sensitive.
+ *
+ * Note: by default interrupts are level sensitive.
+ *
+ * This is a component flag that should be combined with other
+ * `GPIO_INT_*` flags to produce a meaningful configuration.
+ */
+#define GPIO_INT_EDGE                  (1U << 24)
+
+/* Trigger detection when input state is (or transitions to) physical low or
+ * logical 0 level.
+ *
+ * This is a component flag that should be combined with other
+ * `GPIO_INT_*` flags to produce a meaningful configuration.
+ */
+#define GPIO_INT_LOW_0                 (1U << 25)
+
+/* Trigger detection on input state is (or transitions to) physical high or
+ * logical 1 level.
+ *
+ * This is a component flag that should be combined with other
+ * `GPIO_INT_*` flags to produce a meaningful configuration.
+ */
+#define GPIO_INT_HIGH_1                (1U << 26)
+
+#define GPIO_INT_MASK                  (GPIO_INT_DISABLE | \
+					GPIO_INT_ENABLE | \
+					GPIO_INT_LEVELS_LOGICAL | \
+					GPIO_INT_EDGE | \
+					GPIO_INT_LOW_0 | \
+					GPIO_INT_HIGH_1)
+
+/** @endcond */
+
+/** Configures GPIO interrupt to be triggered on pin rising edge and enables it.
+ */
+#define GPIO_INT_EDGE_RISING           (GPIO_INT_ENABLE | \
+					GPIO_INT_EDGE | \
+					GPIO_INT_HIGH_1)
+
+/** Configures GPIO interrupt to be triggered on pin falling edge and enables
+ * it.
+ */
+#define GPIO_INT_EDGE_FALLING          (GPIO_INT_ENABLE | \
+					GPIO_INT_EDGE | \
+					GPIO_INT_LOW_0)
+
+/** Configures GPIO interrupt to be triggered on pin rising or falling edge and
+ * enables it.
+ */
+#define GPIO_INT_EDGE_BOTH             (GPIO_INT_ENABLE | \
+					GPIO_INT_EDGE | \
+					GPIO_INT_LOW_0 | \
+					GPIO_INT_HIGH_1)
+
+/** Configures GPIO interrupt to be triggered on pin physical level low and
+ * enables it.
+ */
+#define GPIO_INT_LEVEL_LOW             (GPIO_INT_ENABLE | \
+					GPIO_INT_LOW_0)
+
+/** Configures GPIO interrupt to be triggered on pin physical level high and
+ * enables it.
+ */
+#define GPIO_INT_LEVEL_HIGH            (GPIO_INT_ENABLE | \
+					GPIO_INT_HIGH_1)
+
+/** Configures GPIO interrupt to be triggered on pin state change to logical
+ * level 0 and enables it.
+ */
+#define GPIO_INT_EDGE_TO_INACTIVE      (GPIO_INT_ENABLE | \
+					GPIO_INT_LEVELS_LOGICAL | \
+					GPIO_INT_EDGE | \
+					GPIO_INT_LOW_0)
+
+/** Configures GPIO interrupt to be triggered on pin state change to logical
+ * level 1 and enables it.
+ */
+#define GPIO_INT_EDGE_TO_ACTIVE        (GPIO_INT_ENABLE | \
+					GPIO_INT_LEVELS_LOGICAL | \
+					GPIO_INT_EDGE | \
+					GPIO_INT_HIGH_1)
+
+/** Configures GPIO interrupt to be triggered on pin logical level 0 and enables
+ * it.
+ */
+#define GPIO_INT_LEVEL_INACTIVE        (GPIO_INT_ENABLE | \
+					GPIO_INT_LEVELS_LOGICAL | \
+					GPIO_INT_LOW_0)
+
+/** Configures GPIO interrupt to be triggered on pin logical level 1 and enables
+ * it.
+ */
+#define GPIO_INT_LEVEL_ACTIVE          (GPIO_INT_ENABLE | \
+					GPIO_INT_LEVELS_LOGICAL | \
+					GPIO_INT_HIGH_1)
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_GPIO_H_ */


### PR DESCRIPTION
Currently only a subset of possible GPIO Flags is available inside the devicetree. Add the remaining to ones from drivers/gpio.h into the gpio devicetree header so that people can configure GPIO's inside the devicetree.

Signed-off-by: Maximilian Brune <brune.max@aol.de>