### PR TITLE
sysbuild: shared cache variable instead of local scope variable

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -183,7 +183,7 @@ function(ExternalZephyrProject_Add)
       # Required CMake variable to be passed, like CMAKE_BUILD_TYPE must be
       # passed using `-D` on command invocation.
       get_property(var_type CACHE ${var_name} PROPERTY TYPE)
-      set(cache_entry "${var_name}:${var_type}=${${var_name}}")
+      set(cache_entry "${var_name}:${var_type}=$CACHE{${var_name}}")
       string(REPLACE ";" "\;" cache_entry "${cache_entry}")
       list(APPEND sysbuild_cache_strings "${cache_entry}\n")
     endif()


### PR DESCRIPTION
Fixes: #52353 

If a CMake variable is available in both local scope and as CMake cache variable, then the use of `${<var>}` fetches the local scoped variable. If only the cache variable is set, then things works as expected.

Ensure that the cached variable is always the variable being shared to images by using `$CACHE{<var>}` instead.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>