### PR TITLE
manifest: MCUboot upgrader

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -181,7 +181,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: cfec947e0f8be686d02c73104a3b1ad0b5dcf1e6
+      revision: ef863820efe62cda092c51ad8a0836d663684583
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
MCUboot was synchronized to
https://github.com/mcu-tools/mcuboot/commit/ad1fb3dde2

doc: actualize zephyr-rtos port README
Kconfig: prefer swap move if scratch_partition not enabled Kconfig: Explicitly select CONFIG_CRC for CONFIG_MCUBOOT_SERIAL

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>