### PR TITLE
Improve artifact management of twister

### DIFF
--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.yaml
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.yaml
@@ -19,3 +19,9 @@ supported:
   - adc
   - pwm
   - counter
+testing:
+  binaries:
+    - spi_image.bin
+  ignore_tags:
+    - bluetooth
+    - net

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -184,6 +184,11 @@ Artificially long but functional example:
         help="Generate artifacts for testing, do not attempt to run the"
               "code on targets.")
 
+    parser.add_argument(
+        "--package-artifacts",
+        help="Package artifacts needed for flashing in a file to be used with --test-only"
+        )
+
     test_or_build.add_argument(
         "--test-only", action="store_true",
         help="""Only run device tests with current artifacts, do not build

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -442,7 +442,6 @@ class DeviceHandler(Handler):
 
         hardware = self.device_is_available(self.instance)
         while not hardware:
-            logger.debug("Waiting for device {} to become available".format(self.instance.platform.name))
             time.sleep(1)
             hardware = self.device_is_available(self.instance)
 

--- a/scripts/pylib/twister/twisterlib/package.py
+++ b/scripts/pylib/twister/twisterlib/package.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# vim: set syntax=python ts=4 :
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import tarfile
+import json
+import os
+
+class Artifacts:
+
+    def __init__(self, env):
+        self.options = env.options
+
+    def make_tarfile(self, output_filename, source_dirs):
+        root = os.path.basename(self.options.outdir)
+        with tarfile.open(output_filename, "w:bz2") as tar:
+            tar.add("twister-out", recursive=False)
+            for d in source_dirs:
+                f = os.path.relpath(d, self.options.outdir)
+                tar.add(d, arcname=os.path.join(root, f))
+
+    def package(self):
+        dirs = []
+        with open(os.path.join(self.options.outdir, "twister.json"), "r") as json_test_plan:
+            jtp = json.load(json_test_plan)
+            for t in jtp['testsuites']:
+                if t['status'] != "filtered":
+                    dirs.append(os.path.join(self.options.outdir, t['platform'], t['name']))
+
+        dirs.extend(
+            [
+                os.path.join(self.options.outdir, "twister.json"),
+                os.path.join(self.options.outdir, "testplan.json")
+                ]
+            )
+        self.make_tarfile(self.options.package_artifacts, dirs)

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -58,6 +58,7 @@ class Platform:
         self.ignore_tags = testing.get("ignore_tags", [])
         self.only_tags = testing.get("only_tags", [])
         self.default = testing.get("default", False)
+        self.binaries = testing.get("binaries", [])
         # if no flash size is specified by the board, take a default of 512K
         self.flash = data.get("flash", 512)
         self.supported = set()

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -673,11 +673,17 @@ class ProjectBuilder(FilterBuilder):
             'CMakeCache.txt',
             os.path.join('zephyr', 'runners.yaml'),
         ]
-        keep = [
-            os.path.join('zephyr', 'zephyr.hex'),
-            os.path.join('zephyr', 'zephyr.bin'),
-            os.path.join('zephyr', 'zephyr.elf'),
-            ]
+        platform = self.instance.platform
+        if platform.binaries:
+            keep = []
+            for binary in platform.binaries:
+                keep.append(os.path.join('zephyr', binary ))
+        else:
+            keep = [
+                os.path.join('zephyr', 'zephyr.hex'),
+                os.path.join('zephyr', 'zephyr.bin'),
+                os.path.join('zephyr', 'zephyr.elf'),
+                ]
 
         keep += sanitizelist
 

--- a/scripts/schemas/twister/platform-schema.yaml
+++ b/scripts/schemas/twister/platform-schema.yaml
@@ -55,11 +55,14 @@ mapping:
         required: false
       "default":
         type: bool
+      "binaries":
+        type: seq
+        seq:
+          - type: str
       "only_tags":
         type: seq
         seq:
-          -
-            type: str
+          - type: str
       "ignore_tags":
         type: seq
         seq:

--- a/scripts/twister
+++ b/scripts/twister
@@ -201,6 +201,7 @@ from twisterlib.reports import Reporting
 from twisterlib.hardwaremap import HardwareMap
 from twisterlib.coverage import run_coverage
 from twisterlib.runner import TwisterRunner
+from twisterlib.package import Artifacts
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
@@ -397,6 +398,10 @@ def main():
                        options.no_update,
                        options.platform_reports
                        )
+
+    if options.package_artifacts:
+        artifacts = Artifacts(env)
+        artifacts.package()
 
     logger.info("Run completed")
     if runner.results.failed or runner.results.error or (tplan.warnings and options.warnings_as_errors):


### PR DESCRIPTION

- Add support for optimizing and packaging build artifacts to be used with --test-only. For example, this will only package runnable tests and remove all artifacts of filtered tests, remove any non-relevant files that will not be used for --test-only
- Add support for specifying what binaries boards expect and use for flashing. Right now we whitelist binaries in a generic way and might be including binaries that will not be used for flashing. In the board yaml file we could specify which binaries are needed and reduce the size of generated artifacts
- remove noisy debug message when waiting for devices

Fixes #52855

- twister: support custom test binaries
- twister: improve handling of artifacts with --prep-artifacts-for-testing
- twister: package artifacts for testing
- twister: do not log on waiting for devices
