### PR TITLE
rpi_pico: Add support for ROM math functions

### DIFF
--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -2,6 +2,10 @@
 
 include(ExternalProject)
 
+function(pico_wrap_function FUNCNAME)
+  target_link_options(app INTERFACE "LINKER:--wrap=${FUNCNAME}")
+endfunction()
+
 if(CONFIG_HAS_RPI_PICO)
   zephyr_library()
 
@@ -113,4 +117,87 @@ if(CONFIG_HAS_RPI_PICO)
     COMPILE_FLAGS $<TARGET_PROPERTY:compiler,warning_no_pointer_arithmetic>
   )
 
+  if(CONFIG_PICOSDK_USE_ROM_MATH)
+    zephyr_library_sources(
+      # Hardware divider for improved performance
+      ${rp2_common_dir}/hardware_divider/divider.S
+
+      # Float ABI
+      ${rp2_common_dir}/pico_float/float_init_rom.c
+      ${rp2_common_dir}/pico_float/float_aeabi.S
+      ${rp2_common_dir}/pico_float/float_v1_rom_shim.S
+
+      # Double ABI
+      ${rp2_common_dir}/pico_double/double_init_rom.c
+      ${rp2_common_dir}/pico_double/double_aeabi.S
+      ${rp2_common_dir}/pico_double/double_v1_rom_shim.S
+
+      # Int64 ABI
+      ${rp2_common_dir}/pico_int64_ops/pico_int64_ops_aeabi.S
+    )
+
+    zephyr_include_directories(
+      ${rp2_common_dir}/pico_float/include
+      ${rp2_common_dir}/pico_double/include
+      ${rp2_common_dir}/pico_int64_ops/include
+      ${rp2_common_dir}/hardware_divider/include
+    )
+
+    # The Pico implementations for the ABI functions have a
+    # __wrap_ prefix. To make the compiler call these functions,
+    # we need to tell the linker that they are wrapped. For example,
+    # calling the linker with "--wrap=__aeabi_fadd" will replace all
+    # calls to __aeabi_fadd with calls to __wrap___aeabi_fadd. This
+    # will call a wrapper that finds the implementation in ROM, and
+    # call it.
+    pico_wrap_function(__aeabi_fadd)
+    pico_wrap_function(__aeabi_fdiv)
+    pico_wrap_function(__aeabi_fmul)
+    pico_wrap_function(__aeabi_frsub)
+    pico_wrap_function(__aeabi_fsub)
+    pico_wrap_function(__aeabi_cfcmpeq)
+    pico_wrap_function(__aeabi_cfrcmple)
+    pico_wrap_function(__aeabi_cfcmple)
+    pico_wrap_function(__aeabi_fcmpeq)
+    pico_wrap_function(__aeabi_fcmplt)
+    pico_wrap_function(__aeabi_fcmple)
+    pico_wrap_function(__aeabi_fcmpge)
+    pico_wrap_function(__aeabi_fcmpgt)
+    pico_wrap_function(__aeabi_fcmpun)
+    pico_wrap_function(__aeabi_i2f)
+    pico_wrap_function(__aeabi_l2f)
+    pico_wrap_function(__aeabi_ui2f)
+    pico_wrap_function(__aeabi_ul2f)
+    pico_wrap_function(__aeabi_f2iz)
+    pico_wrap_function(__aeabi_f2lz)
+    pico_wrap_function(__aeabi_f2uiz)
+    pico_wrap_function(__aeabi_f2ulz)
+    pico_wrap_function(__aeabi_f2d)
+
+    pico_wrap_function(__aeabi_dadd)
+    pico_wrap_function(__aeabi_ddiv)
+    pico_wrap_function(__aeabi_dmul)
+    pico_wrap_function(__aeabi_drsub)
+    pico_wrap_function(__aeabi_dsub)
+    pico_wrap_function(__aeabi_cdcmpeq)
+    pico_wrap_function(__aeabi_cdrcmple)
+    pico_wrap_function(__aeabi_cdcmple)
+    pico_wrap_function(__aeabi_dcmpeq)
+    pico_wrap_function(__aeabi_dcmplt)
+    pico_wrap_function(__aeabi_dcmple)
+    pico_wrap_function(__aeabi_dcmpge)
+    pico_wrap_function(__aeabi_dcmpgt)
+    pico_wrap_function(__aeabi_dcmpun)
+    pico_wrap_function(__aeabi_i2d)
+    pico_wrap_function(__aeabi_l2d)
+    pico_wrap_function(__aeabi_ui2d)
+    pico_wrap_function(__aeabi_ul2d)
+    pico_wrap_function(__aeabi_d2iz)
+    pico_wrap_function(__aeabi_d2lz)
+    pico_wrap_function(__aeabi_d2uiz)
+    pico_wrap_function(__aeabi_d2ulz)
+    pico_wrap_function(__aeabi_d2f)
+
+    pico_wrap_function(__aeabi_lmul)
+  endif()
 endif()

--- a/modules/hal_rpi_pico/Kconfig
+++ b/modules/hal_rpi_pico/Kconfig
@@ -28,3 +28,12 @@ config PICOSDK_USE_ADC
 	bool
 	help
 	  Use the ADC driver from pico-sdk
+
+config PICOSDK_USE_ROM_MATH
+	bool "Use ROM math"
+	default y
+	help
+	  Use math ABI functions from ROM. The Pico comes with ABI functions
+	  (e.g. __aeabi_fadd) pre-programmed to the ROM. These implementations
+	  can be used instead of the default software implementations.
+	  Enabling this is beneficial for binary size and performance.

--- a/soc/arm/rpi_pico/rp2/soc.c
+++ b/soc/arm/rpi_pico/rp2/soc.c
@@ -13,9 +13,12 @@
  * for the Raspberry Pi RP2040 family processor.
  */
 
+#include <stdio.h>
+
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/fatal.h>
 
 #include <hardware/regs/resets.h>
 #include <hardware/clocks.h>
@@ -59,6 +62,20 @@ static int rp2040_init(const struct device *arg)
 	irq_unlock(key);
 
 	return 0;
+}
+
+/*
+ * Some pico-sdk drivers call panic on fatal error.
+ * This alternative implementation of panic handles the panic
+ * through Zephyr.
+ */
+void __attribute__((noreturn)) panic(const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	vprintf(fmt, args);
+	k_fatal_halt(K_ERR_CPU_EXCEPTION);
 }
 
 SYS_INIT(rp2040_init, PRE_KERNEL_1, 0);

--- a/soc/arm/rpi_pico/rp2/soc.c
+++ b/soc/arm/rpi_pico/rp2/soc.c
@@ -33,6 +33,21 @@ extern void z_arm_nmi_init(void);
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
+#ifdef CONFIG_PICOSDK_USE_ROM_MATH
+void __aeabi_float_init(void);
+void __aeabi_double_init(void);
+
+static int rp2040_rom_math_init(const struct device *arg)
+{
+	ARG_UNUSED(arg);
+
+	__aeabi_float_init();
+	__aeabi_double_init();
+
+	return 0;
+}
+#endif /* CONFIG_PICOSDK_USE_ROM_MATH */
+
 static int rp2040_init(const struct device *arg)
 {
 	uint32_t key;
@@ -79,3 +94,7 @@ void __attribute__((noreturn)) panic(const char *fmt, ...)
 }
 
 SYS_INIT(rp2040_init, PRE_KERNEL_1, 0);
+
+#ifdef CONFIG_PICOSDK_USE_ROM_MATH
+SYS_INIT(rp2040_rom_math_init, PRE_KERNEL_1, 1);
+#endif /* CONFIG_PICOSDK_USE_ROM_MATH */


### PR DESCRIPTION
The RP2040's BOOTROM contains ABI functions for working with floating
point numbers and large integers. When using the implementations that
are already in the ROM, there is no need to link these to the user's
binary, thus reducing the binary size.
Moreover, these implementations take advantage of a hardware divider,
thus improving the performance of float division.

**Proof of it working**
Compiling the following app (with no optimizations):
```
void main(void)
{
	float a = 3.0f;
	float b = 4.0f;
	double c = 5.0f;
	double d = 6.0f;

	printk("a + b = %f\n", a + b);
	printk("c + d = %f\n", c + d);
}
```

Yields the following call:
```
f004 fc80       bl      10004dac <__wrap___aeabi_fadd>
```

Which is implemented as:
```
10004dac <__wrap___aeabi_fadd>:
10004dac:       2300            movs    r3, #0
10004dae:       469c            mov     ip, r3
10004db0:       4b0e            ldr     r3, [pc, #56]   ; (10004dec <__wrap___aeabi_fmul+0xa>)
10004db2:       681b            ldr     r3, [r3, #0]
10004db4:       4718            bx      r3
```
R3 is loaded with a pointer to a lookup table that points to the implementation in ROM. It then loads the address of __aeabi_fadd in ROM, and jumps.