### PR TITLE
mgmt: mcumgr: Replace non-zephyr cmake functions with zephyr versions

### DIFF
--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/CMakeLists.txt
@@ -8,27 +8,16 @@
 
 # File System management group public API is exposed by MCUmgr API
 # interface, when File System management is enabled.
-add_library(mgmt_mcumgr_grp_fs src/fs_mgmt.c)
-
-target_sources_ifdef(CONFIG_FS_MGMT_CHECKSUM_HASH
-	mgmt_mcumgr_grp_fs PRIVATE src/fs_mgmt_hash_checksum.c
-)
-target_sources_ifdef(CONFIG_FS_MGMT_CHECKSUM_IEEE_CRC32
-	mgmt_mcumgr_grp_fs PRIVATE src/fs_mgmt_hash_checksum_crc32.c
-)
-target_sources_ifdef(CONFIG_FS_MGMT_HASH_SHA256
-	mgmt_mcumgr_grp_fs PRIVATE src/fs_mgmt_hash_checksum_sha256.c)
+zephyr_library(mgmt_mcumgr_grp_fs)
+zephyr_library_sources(src/fs_mgmt.c)
+zephyr_library_sources_ifdef(CONFIG_FS_MGMT_CHECKSUM_HASH src/fs_mgmt_hash_checksum.c)
+zephyr_library_sources_ifdef(CONFIG_FS_MGMT_CHECKSUM_IEEE_CRC32 src/fs_mgmt_hash_checksum_crc32.c)
+zephyr_library_sources_ifdef(CONFIG_FS_MGMT_HASH_SHA256 src/fs_mgmt_hash_checksum_sha256.c)
 
 if (CONFIG_FS_MGMT_CHECKSUM_HASH AND CONFIG_FS_MGMT_HASH_SHA256)
   if (NOT CONFIG_TINYCRYPT)
-    target_link_libraries(mgmt_mcumgr_grp_fs PRIVATE mbedTLS)
+    zephyr_library_link_libraries(mbedTLS)
   endif()
 endif()
 
-target_include_directories(mgmt_mcumgr_grp_fs PUBLIC include)
-
-target_link_libraries(mgmt_mcumgr_grp_fs PRIVATE
-  zephyr_interface mgmt_mcumgr_mgmt mgmt_mcumgr_util
-)
-
-target_link_libraries(mgmt_mcumgr INTERFACE mgmt_mcumgr_grp_fs)
+zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/CMakeLists.txt
@@ -7,7 +7,8 @@
 
 # Image management group public API is exported by MCUmgr interface API,
 # when Image Management is enabled.
-add_library(mgmt_mcumgr_grp_img
+zephyr_library(mgmt_mcumgr_grp_img)
+zephyr_library_sources(
   src/zephyr_img_mgmt.c
   src/zephyr_img_mgmt_log.c
   src/img_mgmt_state.c
@@ -15,15 +16,8 @@ add_library(mgmt_mcumgr_grp_img
   src/img_mgmt.c
 )
 
-target_include_directories(mgmt_mcumgr_grp_img PUBLIC include)
-
-# Allow fs group interface to be included out of MCUmgr subsystem scope
-target_link_libraries(mgmt_mcumgr_grp_img PRIVATE
-  zephyr_interface mgmt_mcumgr_mgmt mgmt_mcumgr_util
-)
+zephyr_library_include_directories(include)
 
 if(CONFIG_MCUBOOT_IMG_MANAGER)
-  target_link_libraries(mgmt_mcumgr_grp_img PRIVATE MCUBOOT_BOOTUTIL)
+  zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
 endif()
-
-target_link_libraries(mgmt_mcumgr INTERFACE mgmt_mcumgr_grp_img)

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/CMakeLists.txt
@@ -7,19 +7,10 @@
 
 # OS Management group public API is exposed through zephyr_interface,
 # when OS Management is enabled.
-add_library(mgmt_mcumgr_grp_os src/os_mgmt.c)
+zephyr_library(mgmt_mcumgr_grp_os)
+zephyr_library_sources(src/os_mgmt.c)
 
-target_include_directories(mgmt_mcumgr_grp_os PUBLIC include)
-
-target_link_libraries(mgmt_mcumgr_grp_os PRIVATE
-  zephyr_interface mgmt_mcumgr_mgmt mgmt_mcumgr_util
-)
-
-if (CONFIG_REBOOT)
-  target_link_libraries(mgmt_mcumgr_grp_os PRIVATE kernel)
-endif()
-
-target_link_libraries(mgmt_mcumgr INTERFACE mgmt_mcumgr_grp_os)
+zephyr_library_include_directories(include)
 
 if(DEFINED CONFIG_MCUMGR_GRP_OS_INFO_BUILD_DATE_TIME)
   set(MCUMGR_GRP_OS_INFO_BUILD_DATE_TIME_DIR ${PROJECT_BINARY_DIR}/os_mgmt_auto)

--- a/subsys/mgmt/mcumgr/grp/shell_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/shell_mgmt/CMakeLists.txt
@@ -7,12 +7,7 @@
 
 # Shell Management group public API is exposed by MCUmgr API
 # interface, when Shell Management is enabled.
-add_library(mgmt_mcumgr_grp_shell src/shell_mgmt.c)
+zephyr_library(mgmt_mcumgr_grp_shell)
+zephyr_library_sources(src/shell_mgmt.c)
 
-target_include_directories(mgmt_mcumgr_grp_shell PUBLIC include)
-
-target_link_libraries(mgmt_mcumgr_grp_shell PRIVATE
-  zephyr_interface mgmt_mcumgr_mgmt mgmt_mcumgr_util
-)
-
-target_link_libraries(mgmt_mcumgr INTERFACE mgmt_mcumgr_grp_shell)
+zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/grp/stat_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/stat_mgmt/CMakeLists.txt
@@ -7,12 +7,7 @@
 
 # Statistics management group public API is exposed by MCUmgr API
 # interface, when Statistics management is enabled.
-add_library(mgmt_mcumgr_grp_stat src/stat_mgmt.c)
+zephyr_library(mgmt_mcumgr_grp_stat)
+zephyr_library_sources(src/stat_mgmt.c)
 
-target_include_directories(mgmt_mcumgr_grp_stat PUBLIC include)
-
-target_link_libraries(mgmt_mcumgr_grp_stat PRIVATE
-  zephyr_interface mgmt_mcumgr_mgmt mgmt_mcumgr_util
-)
-
-target_link_libraries(mgmt_mcumgr INTERFACE mgmt_mcumgr_grp_stat)
+zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/grp/zephyr_basic/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/zephyr_basic/CMakeLists.txt
@@ -4,15 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-add_library(mgmt_mcumgr_grp_zephyr)
-
-target_sources_ifdef(CONFIG_MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE
-  mgmt_mcumgr_grp_zephyr PRIVATE
-  src/basic_mgmt.c
-)
-
-target_link_libraries(mgmt_mcumgr_grp_zephyr PRIVATE
-  zephyr_interface mgmt_mcumgr_mgmt mgmt_mcumgr_util
-)
-
-target_link_libraries(mgmt_mcumgr INTERFACE mgmt_mcumgr_grp_zephyr)
+zephyr_library(mgmt_mcumgr_grp_zephyr)
+zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE src/basic_mgmt.c)

--- a/subsys/mgmt/mcumgr/mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/mgmt/CMakeLists.txt
@@ -5,9 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Provides MCUmgr services, group registration, event handling etc.
-add_library(mgmt_mcumgr_mgmt src/mgmt.c)
+zephyr_library(mgmt_mcumgr_mgmt)
+zephyr_library_sources(src/mgmt.c)
 
-target_include_directories(mgmt_mcumgr_mgmt PUBLIC include)
-
-target_link_libraries(mgmt_mcumgr_mgmt PRIVATE zephyr_interface)
-target_link_libraries(mgmt_mcumgr INTERFACE mgmt_mcumgr_mgmt)
+zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/smp/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/smp/CMakeLists.txt
@@ -5,8 +5,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Protocol API is only exposed to MCUmgr internals.
-add_library(mgmt_mcumgr_protocol src/smp.c)
-
-target_link_libraries(mgmt_mcumgr_protocol PRIVATE
-  mgmt_mcumgr mgmt_mcumgr_util mgmt_mcumgr_transport zephyr_interface
-)
+zephyr_library(mgmt_mcumgr_protocol)
+zephyr_library_sources(src/smp.c)

--- a/subsys/mgmt/mcumgr/transport/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/transport/CMakeLists.txt
@@ -7,37 +7,30 @@
 
 # mgmt_mcumgr_transport covers interface API, allowing to implement transports.
 # It is exposed with mgmt_mcumgr interface.
-add_library(mgmt_mcumgr_transport STATIC src/smp.c)
+zephyr_library(mgmt_mcumgr_transport)
+zephyr_library_sources(src/smp.c)
 
-target_sources_ifdef(CONFIG_MCUMGR_SMP_REASSEMBLY mgmt_mcumgr_transport PRIVATE
+zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_REASSEMBLY
   src/smp_reassembly.c
 )
-target_sources_ifdef(CONFIG_MCUMGR_SMP_BT mgmt_mcumgr_transport PRIVATE
+zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_BT
   src/smp_bt.c
 )
-target_sources_ifdef(CONFIG_MCUMGR_SMP_SHELL mgmt_mcumgr_transport PRIVATE
+zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_SHELL
   src/smp_shell.c
 )
-target_sources_ifdef(CONFIG_MCUMGR_SMP_UART mgmt_mcumgr_transport PRIVATE
+zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_UART
   src/smp_uart.c
 )
-target_sources_ifdef(CONFIG_MCUMGR_SMP_UDP mgmt_mcumgr_transport PRIVATE
+zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_UDP
   src/smp_udp.c
 )
-target_sources_ifdef(CONFIG_MCUMGR_SMP_DUMMY mgmt_mcumgr_transport PRIVATE
+zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_DUMMY
   src/smp_dummy.c
 )
 
 if (CONFIG_MCUMGR_SMP_SHELL OR CONFIG_MCUMGR_SMP_UART)
-  target_sources(mgmt_mcumgr_transport PRIVATE src/serial_util.c)
+  zephyr_library_sources(src/serial_util.c)
 endif()
 
-target_include_directories(mgmt_mcumgr_transport PUBLIC include)
-
-target_link_libraries(mgmt_mcumgr_transport PRIVATE
-  mgmt_mcumgr_mgmt mgmt_mcumgr_util mgmt_mcumgr_protocol
-)
-
-target_link_libraries(mgmt_mcumgr_transport PRIVATE zephyr_interface kernel)
-
-target_link_libraries(mgmt_mcumgr INTERFACE mgmt_mcumgr_transport)
+zephyr_include_directories(include)

--- a/subsys/mgmt/mcumgr/util/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/util/CMakeLists.txt
@@ -8,8 +8,7 @@
 # MCUmgr utilities, for use within the library.
 # API interface for utilities is exposed by mgmt_mcumgr_util,
 # and should not be exposed outside of mgmt_mcumgr.
-add_library(mgmt_mcumgr_util src/zcbor_bulk.c)
+zephyr_library(mgmt_mcumgr_util)
+zephyr_library_sources(src/zcbor_bulk.c)
 
 zephyr_include_directories(include)
-
-target_link_libraries(mgmt_mcumgr_util PRIVATE zephyr_interface)


### PR DESCRIPTION
    This fixes an issue whilst investigating using iterable sections,
    which cannot be used when the non-zephyr prefixed functions are
    used. It also resolves a possible critical bug intoduced with the
    MCUmgr rework whereby functions or elements seem to have silently
    dropped.

Fixes #53164