### PR TITLE
usb: device: update logger module registration

### DIFF
--- a/subsys/usb/device/bos.c
+++ b/subsys/usb/device/bos.c
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_bos);
+LOG_MODULE_REGISTER(usb_bos, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
 

--- a/subsys/usb/device/class/bluetooth.c
+++ b/subsys/usb/device/class/bluetooth.c
@@ -21,9 +21,8 @@
 #include <zephyr/drivers/bluetooth/hci_driver.h>
 #include <zephyr/sys/atomic.h>
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_bluetooth);
+LOG_MODULE_REGISTER(usb_bluetooth, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 #define USB_RF_SUBCLASS			0x01
 #define USB_BLUETOOTH_PROTOCOL		0x01

--- a/subsys/usb/device/class/bt_h4.c
+++ b/subsys/usb/device/class/bt_h4.c
@@ -18,9 +18,8 @@
 #include <zephyr/bluetooth/hci_raw.h>
 #include <zephyr/bluetooth/l2cap.h>
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_bt_h4);
+LOG_MODULE_REGISTER(usb_bt_h4, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 static K_FIFO_DEFINE(rx_queue);
 static K_FIFO_DEFINE(tx_queue);

--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -55,9 +55,8 @@
 
 /* definitions */
 
-#define LOG_LEVEL CONFIG_USB_CDC_ACM_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_cdc_acm);
+LOG_MODULE_REGISTER(usb_cdc_acm, CONFIG_USB_CDC_ACM_LOG_LEVEL);
 
 /* 115200bps, no parity, 1 stop bit, 8bit char */
 #define CDC_ACM_DEFAULT_BAUDRATE {sys_cpu_to_le32(115200), 0, 0, 8}

--- a/subsys/usb/device/class/dfu/usb_dfu.c
+++ b/subsys/usb/device/class/dfu/usb_dfu.c
@@ -53,9 +53,8 @@
 #include <usb_descriptor.h>
 #include <usb_work_q.h>
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_dfu);
+LOG_MODULE_REGISTER(usb_dfu, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 #define SLOT0_PARTITION			slot0_partition
 #define SLOT1_PARTITION			slot1_partition

--- a/subsys/usb/device/class/hid/core.c
+++ b/subsys/usb/device/class/hid/core.c
@@ -7,9 +7,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_LEVEL CONFIG_USB_HID_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_hid);
+LOG_MODULE_REGISTER(usb_hid, CONFIG_USB_HID_LOG_LEVEL);
 
 #include <zephyr/sys/byteorder.h>
 #include <usb_device.h>

--- a/subsys/usb/device/class/loopback.c
+++ b/subsys/usb/device/class/loopback.c
@@ -12,9 +12,8 @@
 #include <zephyr/usb/usb_device.h>
 #include <usb_descriptor.h>
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_loopback);
+LOG_MODULE_REGISTER(usb_loopback, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 #define LOOPBACK_OUT_EP_ADDR		0x01
 #define LOOPBACK_IN_EP_ADDR		0x81

--- a/subsys/usb/device/class/msc.c
+++ b/subsys/usb/device/class/msc.c
@@ -43,9 +43,8 @@
 #include <zephyr/usb/usb_device.h>
 #include <usb_descriptor.h>
 
-#define LOG_LEVEL CONFIG_USB_MASS_STORAGE_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_msc);
+LOG_MODULE_REGISTER(usb_msc, CONFIG_USB_MASS_STORAGE_LOG_LEVEL);
 
 /* max USB packet size */
 #define MAX_PACKET	CONFIG_MASS_STORAGE_BULK_EP_MPS

--- a/subsys/usb/device/class/netusb/function_ecm.c
+++ b/subsys/usb/device/class/netusb/function_ecm.c
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_NETWORK_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_ecm);
+LOG_MODULE_REGISTER(usb_ecm, CONFIG_USB_DEVICE_NETWORK_LOG_LEVEL);
 
 /* Enable verbose debug printing extra hexdumps */
 #define VERBOSE_DEBUG	0

--- a/subsys/usb/device/class/netusb/function_eem.c
+++ b/subsys/usb/device/class/netusb/function_eem.c
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_NETWORK_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_eem);
+LOG_MODULE_REGISTER(usb_eem, CONFIG_USB_DEVICE_NETWORK_LOG_LEVEL);
 
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/ethernet.h>

--- a/subsys/usb/device/class/netusb/function_rndis.c
+++ b/subsys/usb/device/class/netusb/function_rndis.c
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_NETWORK_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_rndis);
+LOG_MODULE_REGISTER(usb_rndis, CONFIG_USB_DEVICE_NETWORK_LOG_LEVEL);
 
 /* Enable verbose debug printing extra hexdumps */
 #define VERBOSE_DEBUG		0

--- a/subsys/usb/device/class/netusb/netusb.c
+++ b/subsys/usb/device/class/netusb/netusb.c
@@ -6,9 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_NETWORK_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_net);
+LOG_MODULE_REGISTER(usb_net, CONFIG_USB_DEVICE_NETWORK_LOG_LEVEL);
 
 #include <zephyr/init.h>
 

--- a/subsys/usb/device/os_desc.c
+++ b/subsys/usb/device/os_desc.c
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_os_desc);
+LOG_MODULE_REGISTER(usb_os_desc, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
 

--- a/subsys/usb/device/usb_descriptor.c
+++ b/subsys/usb/device/usb_descriptor.c
@@ -14,9 +14,8 @@
 #include "usb_descriptor.h"
 #include <zephyr/drivers/hwinfo.h>
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_descriptor);
+LOG_MODULE_REGISTER(usb_descriptor, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 /*
  * The last index of the initializer_string without null character is:

--- a/subsys/usb/device/usb_device.c
+++ b/subsys/usb/device/usb_device.c
@@ -68,9 +68,8 @@
 #include <usb_descriptor.h>
 #include <zephyr/usb/class/usb_audio.h>
 
-#define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(usb_device);
+LOG_MODULE_REGISTER(usb_device, CONFIG_USB_DEVICE_LOG_LEVEL);
 
 #include <zephyr/usb/bos.h>
 #include <os_desc.h>


### PR DESCRIPTION
Change to preferred module registration mode.

Using the old way, setting `LOG_LEVEL` to 0 prints the log anyway.
`LOG_MODULE_REGISTER` with two parameters works as expected.

Signed-off-by: Witold Lukasik <witold.lukasik@nordicsemi.no>