### PR TITLE
tests: drivers: udc: fix uninitialized variable and thread

### DIFF
--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -614,7 +614,11 @@ int udc_ep_dequeue(const struct device *dev, const uint8_t ep)
 		udc_debug_ep_enqueue(dev, cfg);
 	}
 
-	ret = api->ep_dequeue(dev, cfg);
+	if (k_fifo_is_empty(&cfg->fifo)) {
+		ret = 0;
+	} else  {
+		ret = api->ep_dequeue(dev, cfg);
+	}
 
 ep_dequeue_error:
 	api->unlock(dev);

--- a/tests/drivers/udc/src/main.c
+++ b/tests/drivers/udc/src/main.c
@@ -338,7 +338,7 @@ static void test_udc_ep_api(const struct device *dev,
 		zassert_ok(err, "Failed to dequeue endpoint");
 
 		err = k_sem_take(&ep_queue_sem, K_MSEC(100));
-		zassert_ok(err, "Timeout to dequeue endpoint %d", err);
+		zassert_ok(err, "Timeout to dequeue endpoint %x %d", last_used_ep, err);
 	}
 }
 
@@ -354,7 +354,7 @@ static void test_udc_ep_mps(uint8_t type)
 		.bInterval = 0,
 	};
 	const struct device *dev;
-	uint16_t supported;
+	uint16_t supported = 0;
 	int err;
 
 	dev = DEVICE_DT_GET(DT_NODELABEL(zephyr_udc0));
@@ -401,7 +401,7 @@ static void test_udc_ep_mps(uint8_t type)
 	zassert_ok(err, "Failed to shoot-down UDC driver");
 }
 
-ZTEST(udc_driver_test, test_udc_device_get)
+static void *test_udc_device_get(void)
 {
 	struct udc_device_caps caps;
 	const struct device *dev;
@@ -419,6 +419,8 @@ ZTEST(udc_driver_test, test_udc_device_get)
 			K_PRIO_COOP(9), 0, K_NO_WAIT);
 
 	k_thread_name_set(&test_udc_thread_data, "test-udc");
+
+	return (void *)dev;
 }
 
 static struct usb_ep_descriptor ed_ctrl_out = {
@@ -594,4 +596,4 @@ ZTEST(udc_driver_test, test_udc_ep_iso)
 	test_udc_ep_mps(USB_EP_TYPE_ISO);
 }
 
-ZTEST_SUITE(udc_driver_test, NULL, NULL, NULL, NULL, NULL);
+ZTEST_SUITE(udc_driver_test, NULL, test_udc_device_get, NULL, NULL, NULL);


### PR DESCRIPTION
tests: drivers: udc: fix uninitialized variable and thread
Variable to get MPS supported by the controller was used
uninitialized. This caused the test to fail depending on
the memory state.

test_udc_device_get has to be called only once, at the very
beginning. This was overlooked during migration to new test API.

---

drivers: udc_nrf: dequeue instantly when endpoint is not busy

In the case that IN endpoint is not busy there will be
no notification from the HAL driver.

Fixes: #52817 
