### PR TITLE
drivers: dma: Simplify stm32_dma_check_fifo_mburst() function

### DIFF
--- a/drivers/dma/dma_stm32_v1.c
+++ b/drivers/dma/dma_stm32_v1.c
@@ -402,7 +402,6 @@ uint32_t stm32_dma_get_pburst(struct dma_config *config, bool source_periph)
  * compatible. If they are not compatible, refer to the 'FIFO'
  * section in the 'DMA' chapter in the Reference Manual for more
  * information.
- * break is emitted since every path of the code has 'return'.
  * This function does not have the obligation of checking the parameters.
  */
 bool stm32_dma_check_fifo_mburst(LL_DMA_InitTypeDef *DMAx)
@@ -420,44 +419,39 @@ bool stm32_dma_check_fifo_mburst(LL_DMA_InitTypeDef *DMAx)
 			if (fifo_level == LL_DMA_FIFOTHRESHOLD_1_2 ||
 			    fifo_level == LL_DMA_FIFOTHRESHOLD_FULL) {
 				return true;
-			} else {
-				return false;
 			}
+			break;
 		case LL_DMA_MBURST_INC16:
 			if (fifo_level == LL_DMA_FIFOTHRESHOLD_FULL) {
 				return true;
-			} else {
-				return false;
 			}
+			break;
 		}
+		break;
 	case LL_DMA_MDATAALIGN_HALFWORD:
 		switch (mburst) {
 		case LL_DMA_MBURST_INC4:
 			if (fifo_level == LL_DMA_FIFOTHRESHOLD_1_2 ||
 			    fifo_level == LL_DMA_FIFOTHRESHOLD_FULL) {
 				return true;
-			} else {
-				return false;
 			}
+			break;
 		case LL_DMA_MBURST_INC8:
 			if (fifo_level == LL_DMA_FIFOTHRESHOLD_FULL) {
 				return true;
-			} else {
-				return false;
 			}
-		case LL_DMA_MBURST_INC16:
-			return false;
+			break;
 		}
+		break;
 	case LL_DMA_MDATAALIGN_WORD:
 		if (mburst == LL_DMA_MBURST_INC4 &&
 		    fifo_level == LL_DMA_FIFOTHRESHOLD_FULL) {
 			return true;
-		} else {
-			return false;
 		}
-	default:
-		return false;
 	}
+
+	/* Other combinations are forbidden. */
+	return false;
 }
 
 uint32_t stm32_dma_get_fifo_threshold(uint16_t fifo_mode_control)


### PR DESCRIPTION
This function is responsible for checking if combination of msize, mburst and FIFO level is allowed. Possible combinations can be found in ST documentation, eg. Table 36. FIFO threshold configurations, RM0402 9.3.13 FIFO chapter.

Previously there was no 'break' or '__fallthrough' in msize switch which caused compilation errors. Since we are confirming that combination is correct, 'break' statements should be used.

Besides of introducing missing 'break' statements, this patch moves 'return false' from switch to the end of the function. This makes code shorter and easier to understand, because we have only correct combinations.

Best regards,
Patryk