### PR TITLE
x86: mmu: Remove unnecessary instruction

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1917,7 +1917,6 @@ int arch_mem_domain_thread_add(struct k_thread *thread)
 	 * z_x86_current_stack_perms()
 	 */
 	if (is_migration) {
-		old_ptables = z_mem_virt_addr(thread->arch.ptables);
 		set_stack_perms(thread, domain->arch.ptables);
 	}
 


### PR DESCRIPTION
old_ptables is assigned when migrating a thread
for a nother domain but it is not used. Just
remove it.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>