### PR TITLE
Increase the main stack size for ARM v8A/R AArch32 when TEST

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -156,8 +156,7 @@ config SCHED_CPU_MASK_PIN_ONLY
 config MAIN_STACK_SIZE
 	int "Size of stack for initialization and main thread"
 	default 2048 if COVERAGE_GCOV
-	default 1024 if TEST_ARM_CORTEX_M
-	default 512 if ZTEST && !(RISCV || X86)
+	default 512 if ZTEST && !(RISCV || X86 || ARM)
 	default 1024
 	help
 	  When the initialization is complete, the thread executing it then


### PR DESCRIPTION
Fix #52918 by increasing the CONFIG_MAIN_STACK_SIZE to 1024 for ARM v8A/R AArch32.
512B of the main stack size is not enough for `qemu_cortex_r5`.
I doubt 512 will fail for most aarch32 platforms in the near future, so increase it.