### PR TITLE
logging: Fix case when LOG_LEVEL is 0

### DIFF
--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -84,6 +84,8 @@ extern "C" {
 #define Z_LOG_EVAL1(_eval_level, _iftrue, _iffalse) \
 	__COND_CODE(_LOG_ZZZZ##_eval_level, _iftrue, _iffalse)
 
+#define _LOG_ZZZZ0  _LOG_YYYY,
+#define _LOG_ZZZZ0U _LOG_YYYY,
 #define _LOG_ZZZZ1  _LOG_YYYY,
 #define _LOG_ZZZZ1U _LOG_YYYY,
 #define _LOG_ZZZZ2  _LOG_YYYY,


### PR DESCRIPTION
Setting LOG_LEVEL to 0 was not covered. It resulted in the logging misbehavior when module logging level was set using LOG_LEVEL define method and it was set to 0. Instead of filtering all levels it was applying the default filtering.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>

Fixes: #52925 