### PR TITLE
drivers: i2c_nrfx_twi[m]: Make transfer timeout value configurable

### DIFF
--- a/drivers/i2c/Kconfig.nrfx
+++ b/drivers/i2c/Kconfig.nrfx
@@ -12,6 +12,14 @@ menuconfig I2C_NRFX
 
 if I2C_NRFX
 
+config I2C_NRFX_TRANSFER_TIMEOUT
+	int "Transfer timeout [ms]"
+	default 500
+	help
+	  Timeout in milliseconds used for each I2C transfer.
+	  0 means that the driver should use the K_FOREVER value,
+	  i.e. it should wait as long as necessary.
+
 config I2C_0_NRF_TWI
 	def_bool HAS_HW_NRF_TWI0
 	select NRFX_TWI0

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -16,7 +16,11 @@
 #include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_nrfx_twi, CONFIG_I2C_LOG_LEVEL);
 
-#define I2C_TRANSFER_TIMEOUT_MSEC		K_MSEC(500)
+#if CONFIG_I2C_NRFX_TRANSFER_TIMEOUT
+#define I2C_TRANSFER_TIMEOUT_MSEC K_MSEC(CONFIG_I2C_NRFX_TRANSFER_TIMEOUT)
+#else
+#define I2C_TRANSFER_TIMEOUT_MSEC K_FOREVER
+#endif
 
 struct i2c_nrfx_twi_data {
 	struct k_sem transfer_sync;

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -18,7 +18,11 @@
 #include <zephyr/irq.h>
 LOG_MODULE_REGISTER(i2c_nrfx_twim, CONFIG_I2C_LOG_LEVEL);
 
-#define I2C_TRANSFER_TIMEOUT_MSEC		K_MSEC(500)
+#if CONFIG_I2C_NRFX_TRANSFER_TIMEOUT
+#define I2C_TRANSFER_TIMEOUT_MSEC K_MSEC(CONFIG_I2C_NRFX_TRANSFER_TIMEOUT)
+#else
+#define I2C_TRANSFER_TIMEOUT_MSEC K_FOREVER
+#endif
 
 struct i2c_nrfx_twim_data {
 	struct k_sem transfer_sync;


### PR DESCRIPTION
Add a Kconfig option allowing users to configure the transfer timeout value, as the default 500 ms may not be sufficient in specific cases.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>