### PR TITLE
net: l2: bluetooth: Fix IPSP interface startup at boot

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -857,7 +857,7 @@ static inline int net_if_set_link_addr_unlocked(struct net_if *iface,
 						uint8_t *addr, uint8_t len,
 						enum net_link_type type)
 {
-	if (net_if_flag_is_set(iface, NET_IF_UP)) {
+	if (net_if_flag_is_set(iface, NET_IF_RUNNING)) {
 		return -EPERM;
 	}
 

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -136,13 +136,7 @@ static int net_bt_send(struct net_if *iface, struct net_pkt *pkt)
 
 static int net_bt_enable(struct net_if *iface, bool state)
 {
-	struct bt_if_conn *conn = net_bt_get_conn(iface);
-
 	NET_DBG("iface %p %s", iface, state ? "up" : "down");
-
-	if (state && conn->ipsp_chan.state != BT_L2CAP_CONNECTED) {
-		return -ENETDOWN;
-	}
 
 	return 0;
 }

--- a/subsys/net/l2/ieee802154/ieee802154_mgmt.c
+++ b/subsys/net/l2/ieee802154/ieee802154_mgmt.c
@@ -203,11 +203,11 @@ static inline void update_net_if_link_addr(struct net_if *iface, struct ieee8021
 {
 	bool was_if_up;
 
-	was_if_up = net_if_flag_test_and_clear(iface, NET_IF_UP);
+	was_if_up = net_if_flag_test_and_clear(iface, NET_IF_RUNNING);
 	net_if_set_link_addr(iface, ctx->linkaddr.addr, ctx->linkaddr.len, ctx->linkaddr.type);
 
 	if (was_if_up) {
-		net_if_flag_set(iface, NET_IF_UP);
+		net_if_flag_set(iface, NET_IF_RUNNING);
 	}
 }
 


### PR DESCRIPTION
Bluetooth IPSP interface failed to be brought up at boot due to some invalid checks (overlooked in https://github.com/zephyrproject-rtos/zephyr/pull/51240). This PR fixes it.