### PR TITLE
cmake: fix the wrong arg name when calling check_zephyr_package()

### DIFF
--- a/share/zephyr-package/cmake/ZephyrConfig.cmake
+++ b/share/zephyr-package/cmake/ZephyrConfig.cmake
@@ -137,7 +137,7 @@ if(NOT IS_INCLUDED)
     # common path with the current sample.
     # and if so, we will return here, and let CMake call into the other registered package for real
     # version checking.
-    check_zephyr_package(CURRENT_WORKSPACE_DIR ${CURRENT_WORKSPACE_DIR})
+    check_zephyr_package(WORKSPACE_DIR ${CURRENT_WORKSPACE_DIR})
 
     if(ZEPHYR_PREFER)
       check_zephyr_package(SEARCH_PARENTS CANDIDATES_PREFERENCE_LIST ${ZEPHYR_PREFER})

--- a/share/zephyr-package/cmake/ZephyrConfigVersion.cmake
+++ b/share/zephyr-package/cmake/ZephyrConfigVersion.cmake
@@ -115,7 +115,7 @@ if(NOT IS_INCLUDED)
     # Project is a Zephyr workspace app.
     # This means this Zephyr is likely the correct one, but there could be an alternative installed along-side
     # Thus, check if there is an even better candidate.
-    check_zephyr_package(CURRENT_WORKSPACE_DIR ${CURRENT_WORKSPACE_DIR} VERSION_CHECK)
+    check_zephyr_package(WORKSPACE_DIR ${CURRENT_WORKSPACE_DIR} VERSION_CHECK)
 
     # We are the best candidate, so let's check our own version.
     check_zephyr_version()


### PR DESCRIPTION
check_zephyr_package() accepts an one-value arg named "WORKSPACE_DIR". 
But it is called with "CURRENT_WORKSPACE_DIR".

Signed-off-by: Ming Shao <smrtos@163.com>