### PR TITLE
intel_adsp: Add signed image target to cmake

### DIFF
--- a/scripts/west_commands/runners/intel_adsp.py
+++ b/scripts/west_commands/runners/intel_adsp.py
@@ -95,31 +95,12 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
     def do_run(self, command, **kwargs):
         self.logger.info('Starting Intel ADSP runner')
 
-        # Always re-sign because here we cannot know whether `west
-        # flash` was invoked with `--skip-rebuild` or not and we have no
-        # way to tell whether there was any code change either.
-        #
-        # Signing does not belong here; it should be invoked either from
-        # some CMakeLists.txt file or an optional hook in some generic
-        # `west flash` code but right now it's in neither so we have to
-        # do this.
-        self.sign(**kwargs)
-
         if re.search("intel_adsp_cavs", self.platform):
             self.require(self.cavstool)
             self.flash(**kwargs)
         else:
             self.logger.error("No suitable platform for running")
             sys.exit(1)
-
-    def sign(self, **kwargs):
-        path_opt = ['-p', f'{self.rimage_tool}'] if self.rimage_tool else []
-        sign_cmd = (
-            ['west', 'sign', '-d', f'{self.cfg.build_dir}', '-t', 'rimage']
-            + path_opt + ['-D', f'{self.config_dir}', '--', '-k', f'{self.key}']
-        )
-        self.logger.info(" ".join(sign_cmd))
-        self.check_call(sign_cmd)
 
     def flash(self, **kwargs):
         # Generate a hash string for appending to the sending ri file

--- a/soc/xtensa/intel_adsp/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/CMakeLists.txt
@@ -3,6 +3,87 @@
 # Copyright (c) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+
+find_program(RIMAGE NAMES rimage)
+
+if (DEFINED RIMAGE)
+message(STATUS "Found rimage ${RIMAGE}")
+else()
+message(STATUS "No rimage found")
+endif()
+
+# The path to where toml configurations are by default
+# will be the rimage config directory in the sof module
+# but may be overridden with an environment variable if
+# needed.
+if (DEFINED ENV{RIMAGE_CONF_PATH}
+    AND EXISTS "$ENV{RIMAGE_CONF_PATH}")
+set(RIMAGE_CONF_PATH "$ENV{RIMAGE_CONF_PATH}")
+else()
+# TODO this *will* change once rimage is a west only module
+set(RIMAGE_CONF_PATH "${ZEPHYR_SOF_MODULE_DIR}/rimage/config")
+endif()
+
+# The path to where signing keys are by default will be the sof module but may
+# be overridden with an environment variable if needed.
+if (DEFINED ENV{RIMAGE_KEY_PATH}
+    AND EXISTS "$ENV{RIMAGE_KEY_PATH}")
+set(RIMAGE_KEY_PATH "$ENV{RIMAGE_KEY_PATH}")
+else()
+set(RIMAGE_KEY_PATH "${ZEPHYR_SOF_MODULE_DIR}/keys")
+endif()
+
+# A direct env var RIMAGE_KEY_FILE may be given, otherwise
+# the board may define the RIMAGE_SIGN_KEY name along with an env
+# var to define the path to where key files are stored.
+if (DEFINED ENV{RIMAGE_KEY_FILE}
+    AND EXISTS "$ENV{RIMAGE_KEY_FILE}")
+set(RIMAGE_KEY_FILE ENV{RIMAGE_KEY_FILE})
+message(STATUS "Using rimage key file from ENV{RIMAGE_KEY_FILE} ${RIMAGE_KEY_FILE}")
+elseif(DEFINED RIMAGE_KEY_PATH
+    AND DEFINED RIMAGE_SIGN_KEY
+    AND EXISTS "${RIMAGE_KEY_PATH}/${RIMAGE_SIGN_KEY}")
+set(RIMAGE_KEY_FILE "${RIMAGE_KEY_PATH}/${RIMAGE_SIGN_KEY}")
+message(STATUS "Using rimage key file from RIMAGE_KEY_PATH/RIMAGE_SIGN_KEY ${RIMAGE_KEY_FILE}")
+elseif(DEFINED RIMAGE_SIGN_KEY)
+set(RIMAGE_KEY_FILE "")
+message(STATUS "No rimage key file defined, RIMAGE_SIGN_KEY ${RIMAGE_SIGN_KEY}, RIMAGE_KEY_PATH $ENV{RIMAGE_KEY_PATH}, RIMAGE_KEY_FILE $ENV{RIMAGE_KEY_FILE}")
+endif()
+
+# A direct env var RIMAGE_CONF_FILE may be given, otherwise
+# the board may define the RIMAGE_TARGET name along with an env
+# var to define the path to where config files are stored.
+if (DEFINED ENV{RIMAGE_CONF_FILE}
+    AND EXISTS "$ENV{RIMAGE_CONF_FILE}")
+set(RIMAGE_CONF_FILE ENV{RIMAGE_CONF_FILE})
+message(STATUS "Using rimage conf file from ENV{RIMAGE_CONF_FILE} ${RIMAGE_CONF_FILE}")
+elseif (DEFINED RIMAGE_CONF_PATH
+    AND DEFINED RIMAGE_TARGET
+    AND EXISTS "${RIMAGE_CONF_PATH}/${RIMAGE_TARGET}.toml")
+set(RIMAGE_CONF_FILE "${RIMAGE_CONF_PATH}/${RIMAGE_TARGET}.toml")
+message(STATUS "Using rimage conf file from RIMAGE_CONF_PATH/RIMAGE_TARGET.toml ${RIMAGE_CONF_FILE}")
+else()
+message(STATUS "No rimage config file defined, RIMAGE_TARGET ${RIMAGE_TARGET}, RIMAGE_CONF_PATH $ENV{RIMAGE_CONF_PATH}, RIMAGE_CONF_FILE $ENV{RIMAGE_CONF_FILE}")
+endif()
+
+# If rimage is in the path, and a valid key and conf file path are
+# defined, then add an rimage target (signed image target)
+if(DEFINED RIMAGE
+    AND DEFINED RIMAGE_KEY_FILE
+    AND DEFINED RIMAGE_CONF_FILE)
+message(STATUS "Intel ADSP adding signed image target with rimage")
+add_custom_target(rimage_target ALL
+  DEPENDS ${CMAKE_BINARY_DIR}/zephyr/boot.mod ${CMAKE_BINARY_DIR}/zephyr/main.mod
+  COMMAND ${RIMAGE}
+  	-k ${RIMAGE_KEY_FILE}
+    -c ${RIMAGE_CONF_FILE}
+    -o ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
+    ${CMAKE_BINARY_DIR}/zephyr/boot.mod
+    ${CMAKE_BINARY_DIR}/zephyr/main.mod)
+else()
+message(STATUS "Missing rimage or an appropriate environment variable for finding conf and key files, rimage will not be run")
+endif()
+
 add_subdirectory(common)
 if(CONFIG_SOC_SERIES_INTEL_ACE)
 	add_subdirectory(ace)

--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -98,6 +98,8 @@ add_custom_target(
       --set-section-flags .fw_metadata=noload,readonly
       ${CMAKE_BINARY_DIR}/zephyr/main.mod
       ${CMAKE_BINARY_DIR}/zephyr/main.mod 2>${NULL_FILE}
+
+	BYPRODUCTS ${CMAKE_BINARY_DIR}/zephyr/boot.mod ${CMAKE_BINARY_DIR}/zephyr/main.mod
 )
 
 if(CONFIG_BUILD_OUTPUT_STRIPPED)

--- a/soc/xtensa/intel_adsp/tools/cavstwist.sh
+++ b/soc/xtensa/intel_adsp/tools/cavstwist.sh
@@ -104,10 +104,10 @@ if [ "$DO_SIGN" = "1" ]; then
 	sleep 0.1
     done
 
-    ELF=$BLDDIR/zephyr/zephyr.elf.mod
-    BOOT=$BLDDIR/zephyr/bootloader.elf.mod
-    (cd $BLDDIR;
-     west sign --tool-data=$CAVS_RIMAGE/config -t rimage -- -k $CAVS_KEY)
+    if [ ! -f "$BLDDIR/zephyr/zephyr.ri" ]; then
+        (cd $BLDDIR; west sign --tool-data=$CAVS_RIMAGE/config -t rimage -- -k $CAVS_KEY)
+    fi
+
     cp $BLDDIR/zephyr/zephyr.ri $IMAGE
 fi
 


### PR DESCRIPTION
When running intel_adsp boards through twister I noticed rimage execution was being serialized in the flash stage rather than done in parallel in the build stage. This is quite time consuming.

Adds a custom signed image target to the common builds of all intel adsp targets given rimage is found. By default it uses the sof module to source rimage keys and conf files defined by the intel platforms. The paths to the conf files and key files may be changed using env vars. The actual file used for the key or conf may also be changed using env vars overriding even the name of the file set by the platform. This enables, for example, trying out newer rimage builds or different confs/keys without hacking up cmake files. The default should work for most builds and requires no configuration.

If the signed image is in the build directory, when running twister using cavstwist signing is skipped saving nearly 30% of the test run time for me. Test time went from 36min to 24min on my machine.

The west runner no longer signs the image and expects instead a signed image to exist.

Given rimage is in the PATH somewhere...

west build -b intel_adsp_cavs25 -p always samples/hello_world

now generates a zephyr.ri signed image with the correct key and conf

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>