### PR TITLE
boards: arm: Introduce dragonclaw board

### DIFF
--- a/boards/arm/google_dragonclaw/Kconfig.board
+++ b/boards/arm/google_dragonclaw/Kconfig.board
@@ -1,0 +1,6 @@
+# Copyright (c) 2022 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_GOOGLE_DRAGONCLAW
+	bool "Google Dragonclaw Development Board"
+	depends on SOC_STM32F412CX

--- a/boards/arm/google_dragonclaw/Kconfig.defconfig
+++ b/boards/arm/google_dragonclaw/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2022 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_GOOGLE_DRAGONCLAW
+
+config BOARD
+	default "google_dragonclaw"
+
+endif # BOARD_GOOGLE_DRAGONCLAW

--- a/boards/arm/google_dragonclaw/board.cmake
+++ b/boards/arm/google_dragonclaw/board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(jlink "--device=STM32F412CG" "--speed=4000")
+
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/google_dragonclaw/doc/index.rst
+++ b/boards/arm/google_dragonclaw/doc/index.rst
@@ -1,0 +1,50 @@
+.. _google_dragonclaw_board:
+
+Google Dragonclaw Development Board
+###################################
+
+Overview
+********
+
+Dragonclaw is a board created by Google for fingerprint-related functionality
+development. See the `Dragonclaw Schematics`_ for board schematics, layout and
+BOM.
+
+Board has connectors for fingerprint sensors. Console is exposed over μServo
+connector. MCU can be flashed using μServo or SWD.
+
+Hardware
+********
+
+- STM32F412CGU6 UFQFPN48 package
+
+Peripherial Mapping
+===================
+
+- USART_1 TX/RX : PA9/PA10
+- USART_2 TX/RX : PA2/PA3
+- SPI_1 CS/CLK/MISO/MOSI : PA4/PA5/PA6/PA7
+- SPI_2 CS/CLK/MISO/MOSI : PB12/PB13/PB14/PB15
+
+Programming and Debugging
+*************************
+
+Build application as usual for the ``dragonclaw`` board, and flash
+using μServo or an external J-Link connected to J4. If μServo is used, please
+follow the `Chromium EC Flashing Documentation`_.
+
+Debugging
+=========
+
+Use SWD with a J-Link or ST-Link. Remember that SW2 must be set to CORESIGHT.
+
+References
+**********
+
+.. target-notes::
+
+.. _Dragonclaw Schematics:
+   https://chromium.googlesource.com/chromiumos/platform/ec/+/HEAD/docs/schematics/dragonclaw
+
+.. _Chromium EC Flashing Documentation:
+   https://chromium.googlesource.com/chromiumos/platform/ec#Flashing-via-the-servo-debug-board

--- a/boards/arm/google_dragonclaw/google_dragonclaw.dts
+++ b/boards/arm/google_dragonclaw/google_dragonclaw.dts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2022 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <st/f4/stm32f412Xg.dtsi>
+#include <st/f4/stm32f412z(e-g)tx-pinctrl.dtsi>
+
+/ {
+	model = "Google Dragonclaw development board";
+	compatible = "google,dragonclaw-fpmcu";
+
+	chosen {
+		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,flash-controller = &flash;
+	};
+};
+
+&clk_hsi {
+	/* HSI clock frequency is 16MHz */
+	status = "okay";
+};
+
+&clk_lsi {
+	/* LSI clock frequency is 32768kHz */
+	status = "okay";
+};
+
+&pll {
+	div-m = <8>;
+	mul-n = <192>; /* 16MHz * 192/8 = 384MHz VCO clock */
+	div-p = <4>; /* 96MHz PLL general clock output */
+	div-q = <8>; /* 48MHz PLL output for USB, SDIO, RNG */
+	clocks = <&clk_hsi>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>; /* Select PLL as SYSCLK source (96MHz) */
+	ahb-prescaler = <1>; /* SYSCLK not divided */
+	clock-frequency = <DT_FREQ_M(96)>; /* AHB frequency */
+	apb1-prescaler = <2>; /* AHB clock divided by 2 */
+	apb2-prescaler = <2>; /* AHB clock divided by 2 */
+};
+
+/* USART1: AP UART (Host Commands and MKBP) */
+&usart1 {
+	pinctrl-0 = <&usart1_tx_pa9 &usart1_rx_pa10>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+/* USART2: Servo UART (console) */
+&usart2 {
+	pinctrl-0 = <&usart2_tx_pa2 &usart2_rx_pa3>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+/* SPI1: communication with the AP */
+&spi1 {
+	pinctrl-0 = <&spi1_nss_pa4 &spi1_sck_pa5
+		     &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+/* SPI2: communication with the fingerprint sensor */
+&spi2 {
+	pinctrl-0 = <&spi2_nss_pb12 &spi2_sck_pb13
+		     &spi2_miso_pb14 &spi2_mosi_pb15>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&rtc {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
+		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
+	status = "okay";
+
+	backup_regs {
+		status = "okay";
+	};
+};
+
+/*
+ * The board uses STM32F412CG in UFQFPN48 package in which gpio[c-h] is not
+ * exposed, so disable it.
+ */
+&gpioc {status = "disabled";};
+&gpiod {status = "disabled";};
+&gpioe {status = "disabled";};
+&gpiof {status = "disabled";};
+&gpiog {status = "disabled";};
+&gpioh {status = "disabled";};

--- a/boards/arm/google_dragonclaw/google_dragonclaw.yaml
+++ b/boards/arm/google_dragonclaw/google_dragonclaw.yaml
@@ -1,0 +1,10 @@
+identifier: google_dragonclaw
+name: Google Dragonclaw Development Board
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+ram: 256
+flash: 1024

--- a/boards/arm/google_dragonclaw/google_dragonclaw_defconfig
+++ b/boards/arm/google_dragonclaw/google_dragonclaw_defconfig
@@ -1,0 +1,27 @@
+# Copyright (c) 2022 Google Inc
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_SERIES_STM32F4X=y
+CONFIG_SOC_STM32F412CX=y
+CONFIG_BOARD_GOOGLE_DRAGONCLAW=y
+
+# Serial Drivers
+CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# Console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# GPIO Controller
+CONFIG_GPIO=y
+
+# Clock Controller
+CONFIG_CLOCK_CONTROL=y
+
+# Pin Controller
+CONFIG_PINCTRL=y
+
+# Enable MPU and HW stack protection
+CONFIG_ARM_MPU=y
+CONFIG_HW_STACK_PROTECTION=y


### PR DESCRIPTION
Dragonclaw is a board created by Google for fingerprint-related functionality development. Board schematics, layout and BOM is available at:
https://chromium.googlesource.com/chromiumos/platform/ec/+/HEAD/docs/schematics/dragonclaw

Best regards,
Patryk