### PR TITLE
boards: arm: mec172xevb: add cpu-power-states property

### DIFF
--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
@@ -66,6 +66,7 @@
 &cpu0 {
 	clock-frequency = <96000000>;
 	status = "okay";
+	cpu-power-states = <&idle &suspend_to_ram>;
 };
 
 /* Initialize ECIA. Does not initialize child devices */


### PR DESCRIPTION
Add cpu-power-states property in cpu0 node to describe the two supported power states idle and suspend_to_ram

Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>