### PR TITLE
Promote is_bit_mask() function to common utils

### DIFF
--- a/drivers/counter/counter_gd32_timer.c
+++ b/drivers/counter/counter_gd32_timer.c
@@ -172,17 +172,11 @@ static uint32_t counter_gd32_timer_get_top_value(const struct device *dev)
 	return get_autoreload_value(dev);
 }
 
-/* Return true if value equals 2^n - 1 */
-static inline bool is_bit_mask(uint32_t val)
-{
-	return !(val & (val + 1));
-}
-
 static uint32_t ticks_add(uint32_t val1, uint32_t val2, uint32_t top)
 {
 	uint32_t to_top;
 
-	if (likely(is_bit_mask(top))) {
+	if (likely(IS_BIT_MASK(top))) {
 		return (val1 + val2) & top;
 	}
 
@@ -193,7 +187,7 @@ static uint32_t ticks_add(uint32_t val1, uint32_t val2, uint32_t top)
 
 static uint32_t ticks_sub(uint32_t val, uint32_t old, uint32_t top)
 {
-	if (likely(is_bit_mask(top))) {
+	if (likely(IS_BIT_MASK(top))) {
 		return (val - old) & top;
 	}
 

--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -150,17 +150,11 @@ static int counter_stm32_get_value(const struct device *dev, uint32_t *ticks)
 	return 0;
 }
 
-/* Return true if value equals 2^n - 1 */
-static inline bool counter_stm32_is_bit_mask(uint32_t val)
-{
-	return !(val & (val + 1U));
-}
-
 static uint32_t counter_stm32_ticks_add(uint32_t val1, uint32_t val2, uint32_t top)
 {
 	uint32_t to_top;
 
-	if (likely(counter_stm32_is_bit_mask(top))) {
+	if (likely(IS_BIT_MASK(top))) {
 		return (val1 + val2) & top;
 	}
 
@@ -171,7 +165,7 @@ static uint32_t counter_stm32_ticks_add(uint32_t val1, uint32_t val2, uint32_t t
 
 static uint32_t counter_stm32_ticks_sub(uint32_t val, uint32_t old, uint32_t top)
 {
-	if (likely(counter_stm32_is_bit_mask(top))) {
+	if (likely(IS_BIT_MASK(top))) {
 		return (val - old) & top;
 	}
 

--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -102,12 +102,6 @@ static int get_value(const struct device *dev, uint32_t *ticks)
 	return 0;
 }
 
-/* Return true if value equals 2^n - 1 */
-static inline bool is_bit_mask(uint32_t val)
-{
-	return !(val & (val + 1));
-}
-
 /* Function calculates distance between to values assuming that one first
  * argument is in front and that values wrap.
  */
@@ -116,7 +110,7 @@ static uint32_t ticks_sub(const struct device *dev, uint32_t val,
 {
 	if (IS_FIXED_TOP(dev)) {
 		return (val - old) & COUNTER_MAX_TOP_VALUE;
-	} else if (likely(is_bit_mask(top))) {
+	} else if (likely(IS_BIT_MASK(top))) {
 		return (val - old) & top;
 	}
 
@@ -146,7 +140,7 @@ static uint32_t ticks_add(const struct device *dev, uint32_t val1,
 		ARG_UNUSED(top);
 		return sum & COUNTER_MAX_TOP_VALUE;
 	}
-	if (likely(is_bit_mask(top))) {
+	if (likely(IS_BIT_MASK(top))) {
 		sum = sum & top;
 	} else {
 		sum = sum > top ? sum - (top + 1) : sum;

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -93,17 +93,11 @@ static int get_value(const struct device *dev, uint32_t *ticks)
 	return 0;
 }
 
-/* Return true if value equals 2^n - 1 */
-static inline bool is_bit_mask(uint32_t val)
-{
-	return !(val & (val + 1));
-}
-
 static uint32_t ticks_add(uint32_t val1, uint32_t val2, uint32_t top)
 {
 	uint32_t to_top;
 
-	if (likely(is_bit_mask(top))) {
+	if (likely(IS_BIT_MASK(top))) {
 		return (val1 + val2) & top;
 	}
 
@@ -114,7 +108,7 @@ static uint32_t ticks_add(uint32_t val1, uint32_t val2, uint32_t top)
 
 static uint32_t ticks_sub(uint32_t val, uint32_t old, uint32_t top)
 {
-	if (likely(is_bit_mask(top))) {
+	if (likely(IS_BIT_MASK(top))) {
 		return (val - old) & top;
 	}
 

--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -74,6 +74,23 @@ extern "C" {
 #define BIT64_MASK(n) (BIT64(n) - 1ULL)
 
 /**
+ * @brief Check if bits are set continuously from the specified bit
+ *
+ * The macro is not dependent on the bit-width.
+ *
+ * @param m Check whether the bits are set continuously or not.
+ * @param s Specify the lowest bit for that is continuously set bits.
+ */
+#define IS_SHIFTED_BIT_MASK(m, s) (!(((m) >> (s)) & (((m) >> (s)) + 1U)))
+
+/**
+ * @brief Check if bits are set continuously from the LSB.
+ *
+ * @param m Check whether the bits are set continuously from LSB.
+ */
+#define IS_BIT_MASK(m) IS_SHIFTED_BIT_MASK(m, 0)
+
+/**
  * @brief Check for macro definition in compiler-visible expressions
  *
  * This trick was pioneered in Linux as the config_enabled() macro. It

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -126,6 +126,26 @@ ZTEST(util_cxx, test_ARRAY_INDEX_FLOOR)
 	run_ARRAY_INDEX_FLOOR();
 }
 
+ZTEST(util_cxx, test_BIT_MASK)
+{
+	run_BIT_MASK();
+}
+
+ZTEST(util_cxx, test_BIT_MASK64)
+{
+	run_BIT_MASK64();
+}
+
+ZTEST(util_cxx, test_IS_BIT_MASK)
+{
+	run_IS_BIT_MASK();
+}
+
+ZTEST(util_cxx, test_IS_SHIFTED_BIT_MASK)
+{
+	run_IS_SHIFTED_BIT_MASK();
+}
+
 ZTEST_SUITE(util_cxx, NULL, NULL, NULL, NULL, NULL);
 
 #if __cplusplus
@@ -243,5 +263,26 @@ ZTEST(util_cc, test_ARRAY_INDEX_FLOOR)
 {
 	run_ARRAY_INDEX_FLOOR();
 }
+
+ZTEST(util_cc, test_BIT_MASK)
+{
+	run_BIT_MASK();
+}
+
+ZTEST(util_cc, test_BIT_MASK64)
+{
+	run_BIT_MASK64();
+}
+
+ZTEST(util_cc, test_IS_BIT_MASK)
+{
+	run_IS_BIT_MASK();
+}
+
+ZTEST(util_cc, test_IS_SHIFTED_BIT_MASK)
+{
+	run_IS_SHIFTED_BIT_MASK();
+}
+
 
 ZTEST_SUITE(util_cc, NULL, NULL, NULL, NULL, NULL);

--- a/tests/unit/util/test.inc
+++ b/tests/unit/util/test.inc
@@ -526,3 +526,85 @@ void run_ARRAY_INDEX_FLOOR(void)
 
 	zassert_equal(array[ARRAY_INDEX_FLOOR(array, &alias[1])], 0);
 }
+
+void run_BIT_MASK(void)
+{
+	uint32_t bitmask0 = BIT_MASK(0);
+	uint32_t bitmask1 = BIT_MASK(1);
+	uint32_t bitmask2 = BIT_MASK(2);
+	uint32_t bitmask31 = BIT_MASK(31);
+
+	zassert_equal(0x00000000UL, bitmask0);
+	zassert_equal(0x00000001UL, bitmask1);
+	zassert_equal(0x00000003UL, bitmask2);
+	zassert_equal(0x7ffffffFUL, bitmask31);
+}
+
+void run_BIT_MASK64(void)
+{
+	uint64_t bitmask0 = BIT64_MASK(0);
+	uint64_t bitmask1 = BIT64_MASK(1);
+	uint64_t bitmask2 = BIT64_MASK(2);
+	uint64_t bitmask63 = BIT64_MASK(63);
+
+	zassert_equal(0x0000000000000000ULL, bitmask0);
+	zassert_equal(0x0000000000000001ULL, bitmask1);
+	zassert_equal(0x0000000000000003ULL, bitmask2);
+	zassert_equal(0x7fffffffffffffffULL, bitmask63);
+}
+
+void run_IS_BIT_MASK(void)
+{
+	uint32_t zero32 = 0UL;
+	uint64_t zero64 = 0ULL;
+	uint32_t bitmask1 = 0x00000001UL;
+	uint32_t bitmask2 = 0x00000003UL;
+	uint32_t bitmask31 = 0x7fffffffUL;
+	uint32_t bitmask32 = 0xffffffffUL;
+	uint64_t bitmask63 = 0x7fffffffffffffffULL;
+	uint64_t bitmask64 = 0xffffffffffffffffULL;
+
+	uint32_t not_bitmask32 = 0xfffffffeUL;
+	uint64_t not_bitmask64 = 0xfffffffffffffffeULL;
+
+	zassert_true(IS_BIT_MASK(zero32));
+	zassert_true(IS_BIT_MASK(zero64));
+	zassert_true(IS_BIT_MASK(bitmask1));
+	zassert_true(IS_BIT_MASK(bitmask2));
+	zassert_true(IS_BIT_MASK(bitmask31));
+	zassert_true(IS_BIT_MASK(bitmask32));
+	zassert_true(IS_BIT_MASK(bitmask63));
+	zassert_true(IS_BIT_MASK(bitmask64));
+	zassert_false(IS_BIT_MASK(not_bitmask32));
+	zassert_false(IS_BIT_MASK(not_bitmask64));
+
+	zassert_true(IS_BIT_MASK(0));
+	zassert_true(IS_BIT_MASK(0x00000001UL));
+	zassert_true(IS_BIT_MASK(0x00000003UL));
+	zassert_true(IS_BIT_MASK(0x7fffffffUL));
+	zassert_true(IS_BIT_MASK(0xffffffffUL));
+	zassert_true(IS_BIT_MASK(0x7fffffffffffffffUL));
+	zassert_true(IS_BIT_MASK(0xffffffffffffffffUL));
+	zassert_false(IS_BIT_MASK(0xfffffffeUL));
+	zassert_false(IS_BIT_MASK(0xfffffffffffffffeULL));
+	zassert_false(IS_BIT_MASK(0x00000002UL));
+	zassert_false(IS_BIT_MASK(0x8000000000000000ULL));
+}
+
+void run_IS_SHIFTED_BIT_MASK(void)
+{
+	uint32_t bitmask32_shift1 = 0xfffffffeUL;
+	uint32_t bitmask32_shift31 = 0x80000000UL;
+	uint64_t bitmask64_shift1 =  0xfffffffffffffffeULL;
+	uint64_t bitmask64_shift63 = 0x8000000000000000ULL;
+
+	zassert_true(IS_SHIFTED_BIT_MASK(bitmask32_shift1, 1));
+	zassert_true(IS_SHIFTED_BIT_MASK(bitmask32_shift31, 31));
+	zassert_true(IS_SHIFTED_BIT_MASK(bitmask64_shift1, 1));
+	zassert_true(IS_SHIFTED_BIT_MASK(bitmask64_shift63, 63));
+
+	zassert_true(IS_SHIFTED_BIT_MASK(0xfffffffeUL, 1));
+	zassert_true(IS_SHIFTED_BIT_MASK(0xfffffffffffffffeULL, 1));
+	zassert_true(IS_SHIFTED_BIT_MASK(0x80000000UL, 31));
+	zassert_true(IS_SHIFTED_BIT_MASK(0x8000000000000000ULL, 63));
+}


### PR DESCRIPTION
From the discussion #51955 (comment),
is_bit_mask() function can use commonly in whole system.

Move it to sys/util.h.