### PR TITLE
net: l2: ethernet: ethernet support for AF_PACKET/SOCK_RAW/IPPROTO_RAW

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -667,6 +667,21 @@ static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 			net_pkt_lladdr_src(pkt)->len =
 						sizeof(struct net_eth_addr);
 			ptype = dst_addr->sll_protocol;
+		} else if (context && net_context_get_type(context) == SOCK_RAW &&
+			   net_context_get_proto(context) == IPPROTO_RAW) {
+			char type = (NET_IPV6_HDR(pkt)->vtc & 0xf0);
+
+			switch (type) {
+			case 0x60:
+				ptype = htons(NET_ETH_PTYPE_IPV6);
+				break;
+			case 0x40:
+				ptype = htons(NET_ETH_PTYPE_IP);
+				break;
+			default:
+				ret = -ENOTSUP;
+				goto error;
+			}
 		} else {
 			goto send;
 		}


### PR DESCRIPTION
Ethernet support for AF_PACKET/SOCK_RAW/IPPROTO_RAW: setting protocol type for raw packets to be sent.

Signed-off-by: Jani Hirsimäki <jani.hirsimaki@nordicsemi.no>