### PR TITLE
cmake: fix a typo in zephyr_linker_arg_val_list() macro

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -4120,7 +4120,7 @@ endfunction()
 # BAZ: <undefined>
 # QUX: option set
 #
-# will create a list as: "FOO;bar;QUX:TRUE" which can then be parsed as argument
+# will create a list as: "FOO;bar;QUX;TRUE" which can then be parsed as argument
 # list later.
 macro(zephyr_linker_arg_val_list list arguments)
   foreach(arg ${arguments})


### PR DESCRIPTION
The CMake list delimiter is ";" rather than ":".

Signed-off-by: Ming Shao <smrtos@163.com>