### PR TITLE
dts: riscv: gd32vf103: Correct wrong clock configuration for `dma1`

### DIFF
--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -401,7 +401,7 @@
 			reg = <0x40020400 0x400>;
 			interrupts = <75 0>, <76 0>, <77 0>, <78 0>,
 				     <79 0>;
-			clocks = <&cctl GD32_CLOCK_DMA0>;
+			clocks = <&cctl GD32_CLOCK_DMA1>;
 			dma-channels = <5>;
 			#dma-cells = <1>;
 			status = "disabled";


### PR DESCRIPTION
The `dma1` node had used GD32_CLOCK_DMA0.
Correct it to GD32_CLOCK_DMA1.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@gmail.com>