### PR TITLE
boards: nucleo_g0b1re: enables HSI48 clock for USB

### DIFF
--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -68,6 +68,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &pll {
 	div-m = <1>;
 	mul-n = <8>;


### PR DESCRIPTION
Enables the HSI48 clock on the nucleo_g0b1re platform. Fix warning when building USB related samples.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>