### PR TITLE
include: drivers: adc: Refactor the ADC_CHANNEL_CFG_DT() macro

### DIFF
--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -217,11 +217,9 @@ struct adc_channel_cfg {
 	.acquisition_time = DT_PROP(node_id, zephyr_acquisition_time), \
 	.channel_id       = DT_REG_ADDR(node_id), \
 IF_ENABLED(CONFIG_ADC_CONFIGURABLE_INPUTS, \
-	(COND_CODE_1(DT_NODE_HAS_PROP(node_id, zephyr_input_negative), \
-		(.differential   = true, \
-		 .input_positive = DT_PROP(node_id, zephyr_input_positive), \
-		 .input_negative = DT_PROP(node_id, zephyr_input_negative),), \
-		(.input_positive = DT_PROP(node_id, zephyr_input_positive),)))) \
+	(.differential    = DT_NODE_HAS_PROP(node_id, zephyr_input_negative), \
+	 .input_positive  = DT_PROP_OR(node_id, zephyr_input_positive, 0), \
+	 .input_negative  = DT_PROP_OR(node_id, zephyr_input_negative, 0),)) \
 }
 
 /**


### PR DESCRIPTION
Add a default value (0) used for the `input_positive` field of the `adc_channel_cfg` structure when there is no `input-positive` property specified in the DT node for a given channel.
This solves a problem that occurs when an ADC driver that requires analog inputs to be specified (so it selects ADC_CONFIGURABLE_INPUTS) is used together with an ADC driver that does not use the corresponding fields of the `adc_channel_cfg` structure. With the previous form of the macro, the DT nodes with channel configuration for the latter driver would need to specify the `input-positive` property, though its value would be ignored, otherwise a build error would occur.

Fixes #52914.