### PR TITLE
openamp: Add new Kconfig option to enable dcache

### DIFF
--- a/lib/open-amp/CMakeLists.txt
+++ b/lib/open-amp/CMakeLists.txt
@@ -6,3 +6,7 @@
 
 zephyr_include_directories_ifdef(CONFIG_OPENAMP_RSC_TABLE .)
 zephyr_sources_ifdef(CONFIG_OPENAMP_RSC_TABLE resource_table.c)
+
+zephyr_compile_definitions_ifdef(CONFIG_OPENAMP_WITH_DCACHE
+				 WITH_DCACHE_VRINGS
+				 WITH_DCACHE_BUFFERS)

--- a/lib/open-amp/Kconfig
+++ b/lib/open-amp/Kconfig
@@ -18,3 +18,10 @@ config OPENAMP_RSC_TABLE_NUM_RPMSG_BUFF
 	help
 	  This option specifies the number of buffer used in a Vring for
 	  interprocessor communication
+
+config OPENAMP_WITH_DCACHE
+	bool "Build OpenAMP with vrings cache operations enabled"
+	default y
+	depends on CACHE_MANAGEMENT
+	help
+	  Build OpenAMP with vrings cache operations enabled.


### PR DESCRIPTION
Currently OpenAMP is unconditionally compiled with the options to use the vrings cache operations disabled.

Add a new CONFIG_OPENAMP_WITH_DCACHE Kconfig option to enable the support for d-cache operations in OpenAMP when needed.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>