### PR TITLE
scripts: compliance: Fix misdetection of Kconfig choices as undefined

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -397,9 +397,12 @@ class KconfigCheck(ComplianceTest):
         grep_stdout = git("grep", "-I", "-h", "--perl-regexp", regex, "--",
                           ":samples", ":tests", cwd=ZEPHYR_BASE)
 
+        # Generate combined list of configs and choices from the main Kconfig tree.
+        kconf_syms = kconf.unique_defined_syms + kconf.unique_choices
+
         # Symbols from the main Kconfig tree + grepped definitions from samples
         # and tests
-        return set([sym.name for sym in kconf.unique_defined_syms]
+        return set([sym.name for sym in kconf_syms]
                    + re.findall(regex, grep_stdout, re.MULTILINE))
 
 


### PR DESCRIPTION
This commit updates the KconfigCheck to add the Kconfig symbols from both "config" and "choice" symbol lists to the defined symbol list, as opposed to the "config" list only, in order to prevent any references to the choice symbols outside the Kconfig files (e.g. in documentation) from being reported as undefined.

Signed-off-by: Stephanos Ioannidis <stephanos.ioannidis@nordicsemi.no>

---

A practical use of this is referencing a Kconfig choice as `:kconfig:option:'CONFIG_NAMED_CHOICE'` in the documentation, which currently results in a compliance check failure without this patch.