### PR TITLE
boards: ARC: nsim: sync compiler options for GCC & MWDT

### DIFF
--- a/soc/arc/snps_nsim/CMakeLists.txt
+++ b/soc/arc/snps_nsim/CMakeLists.txt
@@ -31,8 +31,9 @@ else()
 			       -Xsec_timer0 -Xstack_check -Xsec_modes -Xdmac)
 
   zephyr_compile_options_ifdef(CONFIG_SOC_NSIM_HS -arcv2hs -core2 -Xatomic
-			       -Xunaligned -Xcode_density -Xswap -Xbitscan
-			       -Xmpy_option=qmpyh -Xshift_assist -Xbarrel_shifter
+			       -Xll64 -Xdiv_rem=radix4 -Xunaligned -Xcode_density
+			       -Xswap -Xbitscan -Xmpy_option=qmpyh -Xshift_assist
+			       -Xbarrel_shifter -Xfpud_div -Xfpu_mac -Xrtc
 			       -Xtimer0 -Xtimer1)
 
   zephyr_ld_option_ifdef(CONFIG_SOC_NSIM_HS -Hlib=hs38_full)
@@ -46,8 +47,9 @@ else()
   zephyr_ld_option_ifdef(CONFIG_SOC_NSIM_HS_SMP -Hlib=hs38_full)
 
   zephyr_compile_options_ifdef(CONFIG_SOC_NSIM_HS_MPUV6 -arcv2hs -core2 -Xatomic
-			       -Xunaligned -Xcode_density -Xswap -Xbitscan
-			       -Xmpy_option=qmpyh -Xshift_assist -Xbarrel_shifter
+			       -Xll64 -Xdiv_rem=radix4 -Xunaligned -Xcode_density
+			       -Xswap -Xbitscan -Xmpy_option=qmpyh -Xshift_assist
+			       -Xbarrel_shifter -Xfpud_div -Xfpu_mac -Xrtc
 			       -Xtimer0 -Xtimer1)
 
   zephyr_ld_option_ifdef(CONFIG_SOC_NSIM_HS_MPUV6 -Hlib=hs38_full)


### PR DESCRIPTION
Sync MWDT compiler options to GCC ones for ARCv2 nsim hs3x boards (for `nsim_hs` and `nsim_hs_mpuv6`)

