### PR TITLE
posix: clock: fix seconds calculation

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -379,3 +379,15 @@ uint64_t sys_clock_timeout_end_calc(k_timeout_t timeout)
 		return sys_clock_tick_get() + MAX(1, dt);
 	}
 }
+
+#ifdef CONFIG_ZTEST
+void z_impl_sys_clock_tick_set(uint64_t tick)
+{
+	curr_tick = tick;
+}
+
+void z_vrfy_sys_clock_tick_set(uint64_t tick)
+{
+	z_impl_sys_clock_tick_set(tick);
+}
+#endif

--- a/lib/posix/clock.c
+++ b/lib/posix/clock.c
@@ -48,8 +48,8 @@ int z_impl_clock_gettime(clockid_t clock_id, struct timespec *ts)
 	}
 
 	uint64_t ticks = k_uptime_ticks();
-	uint64_t elapsed_secs = k_ticks_to_ms_floor64(ticks) / MSEC_PER_SEC;
-	uint64_t nremainder = ticks - k_ms_to_ticks_floor64(MSEC_PER_SEC * elapsed_secs);
+	uint64_t elapsed_secs = ticks / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+	uint64_t nremainder = ticks - elapsed_secs * CONFIG_SYS_CLOCK_TICKS_PER_SEC;
 
 	ts->tv_sec = (time_t) elapsed_secs;
 	/* For ns 32 bit conversion can be used since its smaller than 1sec. */

--- a/subsys/testsuite/ztest/include/zephyr/ztest_test.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test.h
@@ -21,6 +21,8 @@ extern "C" {
 __syscall void z_test_1cpu_start(void);
 __syscall void z_test_1cpu_stop(void);
 
+__syscall void sys_clock_tick_set(uint64_t tick);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -122,3 +122,67 @@ ZTEST(posix_apis, test_posix_realtime)
 	zassert_true(rts.tv_nsec >= tv.tv_usec * NSEC_PER_USEC,
 			"gettimeofday didn't provide correct result");
 }
+
+static inline bool ts_gt(const struct timespec *a, const struct timespec *b)
+{
+	__ASSERT_NO_MSG(a->tv_nsec < NSEC_PER_SEC);
+	__ASSERT_NO_MSG(a->tv_nsec >= 0);
+	__ASSERT_NO_MSG(b->tv_nsec < NSEC_PER_SEC);
+	__ASSERT_NO_MSG(b->tv_nsec >= 0);
+
+	if (a->tv_sec > b->tv_sec) {
+		return true;
+	}
+
+	if (a->tv_sec < b->tv_sec) {
+		return false;
+	}
+
+	if (a->tv_nsec > b->tv_nsec) {
+		return true;
+	}
+
+	return false;
+}
+
+static inline void ts_print(const char *label, const struct timespec *ts)
+{
+	printk("%s: {%" PRIu64 ", %" PRIu64 "}\n", label, (uint64_t)ts->tv_sec,
+	       (uint64_t)ts->tv_nsec);
+}
+
+ZTEST(posix_apis, test_clock_gettime_rollover)
+{
+	uint64_t t;
+	struct timespec ts[3];
+	const uint64_t rollover_s = UINT64_MAX / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+
+	printk("CONFIG_SYS_CLOCK_TICKS_PER_SEC: %u\n", CONFIG_SYS_CLOCK_TICKS_PER_SEC);
+	printk("rollover_s: %" PRIu64 "\n", rollover_s);
+
+	t = UINT64_MAX - 1;
+	/* align to tick boundary */
+	k_sleep(K_TICKS(1));
+	sys_clock_tick_set(t);
+	zassert_ok(clock_gettime(CLOCK_MONOTONIC, &ts[0]));
+	ts_print("t-1", &ts[0]);
+	zassert_equal(rollover_s, ts[0].tv_sec);
+
+	t = UINT64_MAX;
+	/* align to tick boundary */
+	k_sleep(K_TICKS(1));
+	sys_clock_tick_set(t);
+	zassert_ok(clock_gettime(CLOCK_MONOTONIC, &ts[1]));
+	ts_print("t+0", &ts[1]);
+	zassert_equal(rollover_s, ts[1].tv_sec);
+	zassert_true(ts_gt(&ts[1], &ts[0]));
+
+	t = UINT64_MAX + 1;
+	/* align to tick boundary */
+	k_sleep(K_TICKS(1));
+	sys_clock_tick_set(t);
+	zassert_ok(clock_gettime(CLOCK_MONOTONIC, &ts[2]));
+	ts_print("t+1", &ts[2]);
+	zassert_equal(0, ts[2].tv_sec);
+	zassert_true(ts_gt(&ts[1], &ts[2]));
+}


### PR DESCRIPTION
The previous method used to calculate seconds in `clock_gettime()` seemed to have an inaccuracy that grew with time, causing the seconds to be off by an order of magnitude when ticks would roll over.

Edit: technically, this is likely a bug in `z_tmcvt()`.

Fixes #52975