### PR TITLE
drivers: gpio: stm32: Keep port clock in input configuration

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -550,8 +550,8 @@ static int gpio_stm32_config(const struct device *dev,
 
 	gpio_stm32_configure_raw(dev, pin, pincfg, 0);
 
-	/* Release clock only if configuration doesn't require bank writes */
-	if ((flags & GPIO_OUTPUT) == 0) {
+	/* Release clock only if pin is disconnected */
+	if (((flags & GPIO_OUTPUT) == 0) && ((flags & GPIO_INPUT) == 0)) {
 		err = pm_device_runtime_put(dev);
 		if (err < 0) {
 			return err;


### PR DESCRIPTION
When pin is configured in input mode, clock is also required.

Data on the I/O pin is sampled in the input data register on bus clock cycles, so clock is for this operation as well.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>