### PR TITLE
ipc: static_vrings: Zero config struct

### DIFF
--- a/subsys/ipc/ipc_service/lib/ipc_rpmsg.c
+++ b/subsys/ipc/ipc_service/lib/ipc_rpmsg.c
@@ -88,7 +88,7 @@ int ipc_rpmsg_init(struct ipc_rpmsg_instance *instance,
 	}
 
 	if (role == RPMSG_HOST) {
-		struct rpmsg_virtio_config config;
+		struct rpmsg_virtio_config config = { 0 };
 
 		config.h2r_buf_size = (uint32_t) buffer_size;
 		config.r2h_buf_size = (uint32_t) buffer_size;


### PR DESCRIPTION
Initialize the config struct to zero before passing down to OpenAMP.

Fixes: #52962

Signed-off-by: Carlo Caione <ccaione@baylibre.com>