### PR TITLE
Fix and add cache documentation

### DIFF
--- a/doc/hardware/cache/index.rst
+++ b/doc/hardware/cache/index.rst
@@ -1,0 +1,59 @@
+.. _cache-guide:
+
+Cache Interface
+###############
+
+This is a high-level guide to cache interface and Kconfig options related to
+cache controllers. See :ref:`cache_api` for API reference material.
+
+Zephyr has different Kconfig options to control how the cache controller is
+implemented and controlled.
+
+* :kconfig:option:`CONFIG_CPU_HAS_DCACHE` /
+  :kconfig:option:`CONFIG_CPU_HAS_ICACHE`: these hidden options should be
+  selected at SoC / platform level when the CPU actually supports a data or
+  instruction cache. The cache controller can be in the core or can be an
+  external cache controller for which a driver is provided.
+
+  These options have the goal to document an available feature and should be
+  set whether we plan to support and use the caches in Zephyr or not.
+
+* :kconfig:option:`CONFIG_DCACHE` / :kconfig:option:`CONFIG_ICACHE`: these
+  options must be selected when support for data or instruction cache is
+  present and working in zephyr.
+
+  All the code paths related to cache control must be conditionally enabled
+  depending on these symbols. When the symbol is set the cache is considered
+  enabled and used.
+
+  These symbols say nothing about the actual API interface exposed to the user.
+  For example a platform using the data cache can enable the
+  :kconfig:option:`CONFIG_DCACHE` symbol and use some HAL exported function in
+  some platform-specific code to enable and manage the d-cache.
+
+* :kconfig:option:`CONFIG_CACHE_MANAGEMENT`: this option must be selected when
+  the cache operations are exposed to the user through a standard API (see
+  :ref:`cache_api`).
+
+  When this option is enabled we assume that all the cache functions are
+  implemented in the architectural code or in an external cache controller
+  driver.
+
+* :kconfig:option:`CONFIG_ARCH_CACHE`/:kconfig:option:`CONFIG_EXTERNAL_CACHE`:
+  mutually exclusive options for :kconfig:option:`CACHE_TYPE` used to define
+  whether the cache operations are implemented at arch level or using an
+  external cache controller with a provided driver.
+
+  * :kconfig:option:`CONFIG_ARCH_CACHE`: the cache API is implemented by the
+    arch code
+
+  * :kconfig:option:`CONFIG_EXTERNAL_CACHE`: the cache API is implemented by a
+    driver that supports the external cache controller. In this case the driver
+    must be located as usual in the :file:`drivers/cache/` directory
+
+.. _cache_api:
+
+Cache API
+*********
+
+.. doxygengroup:: cache_interface

--- a/doc/hardware/index.rst
+++ b/doc/hardware/index.rst
@@ -7,6 +7,7 @@ Hardware Support
    :maxdepth: 1
 
    arch/index.rst
+   cache/index.rst
    emulator/index.rst
    peripherals/index.rst
    pinctrl/index.rst

--- a/include/zephyr/cache.h
+++ b/include/zephyr/cache.h
@@ -113,6 +113,21 @@ extern size_t cache_instr_line_size_get(void);
 #endif /* CONFIG_ICACHE */
 #endif /* CONFIG_EXTERNAL_CACHE */
 
+
+/**
+ * @defgroup cache_interface Cache Interface
+ * @{
+ */
+
+/**
+ * @cond INTERNAL_HIDDEN
+ *
+ */
+
+#define _CPU DT_PATH(cpus, cpu_0)
+
+/** @endcond */
+
 /**
  * @brief Enable the d-cache
  *
@@ -408,8 +423,6 @@ static inline int sys_cache_instr_flush_and_invd_range(void *addr, size_t size)
 	return -ENOTSUP;
 }
 
-#define CPU DT_PATH(cpus, cpu_0)
-
 /**
  *
  * @brief Get the the d-cache line size.
@@ -418,8 +431,8 @@ static inline int sys_cache_instr_flush_and_invd_range(void *addr, size_t size)
  *
  * The cache line size is calculated (in order of priority):
  *
- * - At run-time when CONFIG_DCACHE_LINE_SIZE_DETECT is set.
- * - At compile time using the value set in CONFIG_DCACHE_LINE_SIZE.
+ * - At run-time when @kconfig{CONFIG_DCACHE_LINE_SIZE_DETECT} is set.
+ * - At compile time using the value set in @kconfig{CONFIG_DCACHE_LINE_SIZE}.
  * - At compile time using the `d-cache-line-size` CPU0 property of the DT.
  * - 0 otherwise
  *
@@ -433,7 +446,7 @@ static inline size_t sys_cache_data_line_size_get(void)
 #elif (CONFIG_DCACHE_LINE_SIZE != 0)
 	return CONFIG_DCACHE_LINE_SIZE;
 #else
-	return DT_PROP_OR(CPU, d_cache_line_size, 0);
+	return DT_PROP_OR(_CPU, d_cache_line_size, 0);
 #endif
 }
 
@@ -445,8 +458,8 @@ static inline size_t sys_cache_data_line_size_get(void)
  *
  * The cache line size is calculated (in order of priority):
  *
- * - At run-time when CONFIG_ICACHE_LINE_SIZE_DETECT is set.
- * - At compile time using the value set in CONFIG_ICACHE_LINE_SIZE.
+ * - At run-time when @kconfig{CONFIG_ICACHE_LINE_SIZE_DETECT} is set.
+ * - At compile time using the value set in @kconfig{CONFIG_ICACHE_LINE_SIZE}.
  * - At compile time using the `i-cache-line-size` CPU0 property of the DT.
  * - 0 otherwise
  *
@@ -460,7 +473,7 @@ static inline size_t sys_cache_instr_line_size_get(void)
 #elif (CONFIG_ICACHE_LINE_SIZE != 0)
 	return CONFIG_ICACHE_LINE_SIZE;
 #else
-	return DT_PROP_OR(CPU, i_cache_line_size, 0);
+	return DT_PROP_OR(_CPU, i_cache_line_size, 0);
 #endif
 }
 
@@ -475,5 +488,9 @@ static inline void sys_cache_flush(void *addr, size_t size)
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_CACHE_H_ */

--- a/include/zephyr/drivers/cache.h
+++ b/include/zephyr/drivers/cache.h
@@ -14,7 +14,7 @@
 
 /**
  * @brief External Cache Controller Interface
- * @defgroup cache_interface External Cache Controller Interface
+ * @defgroup cache_external_interface External Cache Controller Interface
  * @ingroup io_interfaces
  * @{
  */


### PR DESCRIPTION
Add a cache documentation in the zephyr doc to disambiguate the several Kconfig options.