### PR TITLE
log_core: Add Kconfig symbol for init priority

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -12,6 +12,11 @@ config LOG
 
 if LOG
 
+config LOG_CORE_INIT_PRIORITY
+	int "Log Core Initialization Priority"
+	range 0 99
+	default 0
+
 rsource "Kconfig.mode"
 
 rsource "Kconfig.filtering"

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -907,4 +907,4 @@ static int enable_logger(const struct device *arg)
 	return 0;
 }
 
-SYS_INIT(enable_logger, POST_KERNEL, 0);
+SYS_INIT(enable_logger, POST_KERNEL, CONFIG_LOG_CORE_INIT_PRIORITY);


### PR DESCRIPTION
Users may want to do some configuration after the kernel is up, but before initializing the log_core. Making the log_core's init priority configurable makes that possible.

Signed-off-by: Ian Oliver <io@amperecomputing.com>