### PR TITLE
drivers: gpio: narrow single ended mode assertion

### DIFF
--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -696,9 +696,8 @@ static inline int z_impl_gpio_pin_configure(const struct device *port,
 		 (GPIO_PULL_UP | GPIO_PULL_DOWN),
 		 "Pull Up and Pull Down should not be enabled simultaneously");
 
-	__ASSERT((flags & GPIO_OUTPUT) != 0 || (flags & GPIO_SINGLE_ENDED) == 0,
-		 "Output needs to be enabled for 'Open Drain', 'Open Source' "
-		 "mode to be supported");
+	__ASSERT(!((flags & GPIO_INPUT) && !(flags && GPIO_OUTPUT) && (flags & GPIO_SINGLE_ENDED)),
+		 "Input cannot be enabled for 'Open Drain', 'Open Source' modes without Output");
 
 	__ASSERT_NO_MSG((flags & GPIO_SINGLE_ENDED) != 0 ||
 			(flags & GPIO_LINE_OPEN_DRAIN) == 0);


### PR DESCRIPTION
Instead of checking that output mode is enabled when single ended configuration is requested, instead check that input mode is not requested without output mode. This enables a pin to be configured as `GPIO_DISCONNECTED | GPIO_SINGLE_ENDED` without triggering the assertion.

Without this change `gpio_pin_configure_dt(&gpio_spec, GPIO_DISCONNECTED);` can trigger assertions depending on the pin flags.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>