### PR TITLE
drivers: gicv3: add zephyr kernel header file

### DIFF
--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sw_isr_table.h>


### PR DESCRIPTION
zephyr kernel header file should be included otherwise gcc will report the warning: `implicit declaration of function 'k_aligned_alloc'` and the return value of the `k_aligned_alloc` will be treated as an int type, which will cause an error on the 64 bits platform.