### PR TITLE
tests: ARC: MWDT: allow cpp.libcxx.arcmwdtlib for all arc targets

### DIFF
--- a/tests/subsys/cpp/libcxx/testcase.yaml
+++ b/tests/subsys/cpp/libcxx/testcase.yaml
@@ -23,7 +23,6 @@ tests:
       - mps2_an385
   cpp.libcxx.arcmwdtlib:
     toolchain_allow: arcmwdt
-    platform_allow: nsim_hs nsim_em
     min_flash: 54
     tags: cpp
     extra_configs:


### PR DESCRIPTION
Allow `cpp.libcxx.arcmwdtlib` for all arc targets in case of ARC MWDT toolchain.