### PR TITLE
ci: doc-build: Disable PDF documentation build for pull requests

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -117,7 +117,7 @@ jobs:
     name: "Documentation Build (PDF)"
     runs-on: ubuntu-20.04
     container: texlive/texlive:latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     concurrency:
       group: doc-build-pdf-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -115,6 +115,7 @@ jobs:
 
   doc-build-pdf:
     name: "Documentation Build (PDF)"
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-20.04
     container: texlive/texlive:latest
     timeout-minutes: 60


### PR DESCRIPTION
* ci: doc-build: Disable PDF documentation build for pull requests 
* ci: doc-build: Increase PDF documentation build timeout 

```
This commit disables the PDF documentation build for pull request CI
runs because the HTML documentation build already validates the
documentation changes and the PDF build takes significantly longer than
the HTML build.
```