### PR TITLE
Fix smp img upload request specification of field 'sha'

### DIFF
--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -257,7 +257,7 @@ CBOR data of request:
             (str,opt)"image"    : (uint)
             (str,opt)"len"      : (uint)
             (str)"off"          : (uint)
-            (str,opt)"sha"      : (str)
+            (str,opt)"sha"      : (byte str)
             (str,opt)"data"     : (byte str)
             (str,opt)"upgrade"  : (bool)
         }


### PR DESCRIPTION
While implementing a SMP client i had an issue with the commande Image Upload request that gave me back Error 3 which signify that the command is invalid. The documentation specify that the field "sha" has to be of type (str). Which in the rest of documentation mean in reality type `text string` . But this is wrong this field has to be type `byte string` or (byte str) as it is called in documentation.
 
 Proof of the field is `bstr` and not `tstr` can be found [here](https://github.com/zephyrproject-rtos/zephyr/blob/72db5c09c04a81fbf4e9536cfe357c11fe3e2c97/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c#L383)