### PR TITLE
mcuboot: doc: Define MCUBOOT_EXTRA_IMGTOOL_ARGS more clearly

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -822,12 +822,12 @@ config MCUBOOT_ENCRYPTION_KEY_FILE
 	  If left empty, you must encrypt the Zephyr binaries manually.
 
 config MCUBOOT_EXTRA_IMGTOOL_ARGS
-	string "Extra arguments to pass to imgtool"
+	string "Extra arguments to pass to imgtool when signing"
 	default ""
 	help
-	  If CONFIG_MCUBOOT_SIGNATURE_KEY_FILE is a non-empty string,
-	  you can use this option to pass extra options to imgtool.
-	  For example, you could set this to "--version 1.2".
+	  When signing (CONFIG_MCUBOOT_SIGNATURE_KEY_FILE is a non-empty
+	  string) you can use this option to pass extra options to
+	  imgtool.  For example, you could set this to "--version 1.2".
 
 config MCUBOOT_GENERATE_UNSIGNED_IMAGE
 	bool "Generate unsigned binary image bootable with MCUboot"


### PR DESCRIPTION
imgtool could be used for many things, but
CONFIG_MCUBOOT_EXTRA_IMGTOOL_ARGS, despite it's generic name, is only applied when signing. Make it even more clear in the prompt and help text that it's limited to signing.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>