### PR TITLE
tests: spin lock timeout test spin time

### DIFF
--- a/tests/kernel/spinlock/src/spinlock_error_case.c
+++ b/tests/kernel/spinlock/src/spinlock_error_case.c
@@ -173,8 +173,11 @@ ZTEST(spinlock, test_spinlock_lock_time_limit)
 
 	key = k_spin_lock(&timeout_lock);
 
-	/* spin here for at least 2x the cycle limit */
-	for (volatile int i = 0; i < CONFIG_SPIN_LOCK_TIME_LIMIT*2; i++) {
+	/* spin here a while, the spin lock limit is in terms of system clock
+	 * not core clock. So a multiplier is needed here to ensure things
+	 * go well past the time limit.
+	 */
+	for (volatile int i = 0; i < CONFIG_SPIN_LOCK_TIME_LIMIT*10; i++) {
 	}
 
 	set_assert_valid(true, false);


### PR DESCRIPTION
The spin loop to ensure time goes past the timeout is done in terms of the core clock, while the spin lock is timed on the system clock.

This difference is exasperated on systems where the core clock is much faster than the system clock and the test failed. Add a significant multiplier so the test works even when the system clock is much slower.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>