### PR TITLE
drivers: xec_qmspi: add missing default y to SPI_XEC_QMSPI_FULL_DUPLEX

### DIFF
--- a/drivers/spi/Kconfig.xec_qmspi
+++ b/drivers/spi/Kconfig.xec_qmspi
@@ -20,6 +20,7 @@ config SPI_XEC_QMSPI_LDMA
 
 config SPI_XEC_QMSPI_FULL_DUPLEX
 	bool "Microchip XEC MEC17xx QMSPI Full Duplex driver"
+	default y
 	depends on DT_HAS_MICROCHIP_XEC_QMSPI_FULL_DUPLEX_ENABLED
 	help
 	  Enable support for Microchip MEC17xx QMSPI full duplex driver


### PR DESCRIPTION
Add missing "default y" to the Kconfig option so that it gets selected automatically when a matching devicetree node is enabled.