### PR TITLE
tests: Conditionally compile MKFS Fat FS test

### DIFF
--- a/tests/subsys/fs/fat_fs_api/CMakeLists.txt
+++ b/tests/subsys/fs/fat_fs_api/CMakeLists.txt
@@ -5,7 +5,5 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fat_fs_api)
 
 FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE
-  ${app_sources}
-  ../common/test_fs_open_flags.c
-  ../common/test_fs_mkfs.c)
+target_sources(app PRIVATE ${app_sources} ../common/test_fs_open_flags.c)
+target_sources_ifdef(CONFIG_FLASH app PRIVATE ../common/test_fs_mkfs.c)


### PR DESCRIPTION
This is a hotfix to work around build issues due to this FS test using the flash API innappropriately.