### PR TITLE
nrf52_bsim: Add option to delay CPU and test initialization

### DIFF
--- a/boards/posix/nrf52_bsim/argparse.c
+++ b/boards/posix/nrf52_bsim/argparse.c
@@ -58,6 +58,11 @@ static void cmd_nosim_found(char *argv, int offset)
 	hwll_set_nosim(true);
 }
 
+static void cmd_no_delay_init_found(char *argv, int offset)
+{
+	arg.delay_init = false;
+}
+
 static void save_test_arg(struct NRF_bsim_args_t *args, char *argv)
 {
 	if (args->test_case_argc >= MAXPARAMS_TESTCASES) {
@@ -110,6 +115,16 @@ void nrfbsim_register_args(void)
 		"nosim", "", 'b',
 		(void *)&nosim, cmd_nosim_found,
 		"(debug feature) Do not connect to the phy"},
+		{ false, false, true,
+		"delay_init", "", 'b',
+		(void *)&arg.delay_init, NULL,
+		"If start_offset is used, postpone initialization and startup "
+		"until start_offset is reached (by default not set)"
+		},
+		{ false, false, true,
+		"no_delay_init", "", 'b',
+		NULL, cmd_no_delay_init_found,
+		"Clear delay_init. Note that by default delay_init is not set"},
 		BS_DUMP_FILES_ARGS,
 		{false, false, false,
 		"testid", "testid", 's',

--- a/boards/posix/nrf52_bsim/argparse.h
+++ b/boards/posix/nrf52_bsim/argparse.h
@@ -21,6 +21,7 @@ struct NRF_bsim_args_t {
 	BS_BASIC_DEVICE_OPTIONS_FIELDS
 	char *test_case_argv[MAXPARAMS_TESTCASES];
 	int test_case_argc;
+	bool delay_init;
 	nrf_hw_sub_args_t nrf_hw;
 };
 

--- a/boards/posix/nrf52_bsim/bstests.h
+++ b/boards/posix/nrf52_bsim/bstests.h
@@ -22,9 +22,17 @@ extern "C" {
 /*
  * Will be called with the command line arguments for the testcase.
  * This is BEFORE any SW has run, and before the HW has been initialized
+ * This is also before a possible initialization delay.
+ * Note that this function can be used for test pre-initialization steps
+ * like opening the back-channels. But you should not interact yet with the
+ * test ticker or other HW models.
  */
 typedef void (*bst_test_args_t)(int, char**);
-/* It will be called (in the HW models thread) before the CPU is booted */
+/* It will be called (in the HW models thread) before the CPU is booted,
+ * after the HW models have been initialized. Note that a possible delayed
+ * initialization may delay the execution of this function vs other devices
+ * tests pre-initialization
+ */
 typedef void (*bst_test_pre_init_t)(void);
 /*
  * It will be called (in the HW models thread) when the CPU goes to sleep

--- a/boards/posix/nrf52_bsim/main.c
+++ b/boards/posix/nrf52_bsim/main.c
@@ -95,6 +95,13 @@ int main(int argc, char *argv[])
 	/* We pass to a possible testcase its command line arguments */
 	bst_pass_args(args->test_case_argc, args->test_case_argv);
 
+	if ((args->nrf_hw.start_offset > 0) && (args->delay_init)) {
+		/* Delay the next steps until the simulation time has
+		 * reached start_offset
+		 */
+		hwll_wait_for_phy_simu_time(args->nrf_hw.start_offset);
+	}
+
 	nrf_hw_initialize(&args->nrf_hw);
 
 	run_native_tasks(_NATIVE_PRE_BOOT_3_LEVEL);

--- a/west.yml
+++ b/west.yml
@@ -197,7 +197,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 65bc5305d432c08e24a3f343006d1e7deaff4908
+      revision: 85ecf8e3bda805fa1405db5048d77e2980c976f0
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: aedcc262f93bbb1b0c2f58026911575729b7465c


### PR DESCRIPTION
In some simulated test cases, it can be useful
to delay the boot of the CPU and the test initialization
for a while. Namely by the offset of the device
relative to other simulated devices.

We add the option to select so from command line.
By default the option is disabled so this change is
backwards compatible.

&

Expand the descriptions of some bs_tests hooks