### PR TITLE
MAINTAINERS: add an entry for google_* boards

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1249,6 +1249,14 @@ Formatted Output:
   labels:
     - "area: Formatting Output"
 
+Google Platforms:
+  status: maintained
+  maintainers:
+    - fabiobaltieri
+    - keith-zephyr
+  files:
+    - boards/*/google_*/
+
 IPC:
   status: maintained
   maintainers:


### PR DESCRIPTION
Adding an entry to avoid having these boards as orphaned:

```
$ ./scripts/get_maintainer.py path boards/arm/google_dragonclaw/
Orphaned paths (not in any area):
boards/arm/google_dragonclaw/
```

-- 8< --

There's now two google_* boards in the repository and it looks like we are going to keep a common prefix for these.

Add an explicit maintainer entry for these with Keith and I as maintainers so that PRs against these will get reviewers and assignees.