### PR TITLE
soc: arm: nxp: switch imxrt boards to use systick timer

### DIFF
--- a/boards/arm/mimxrt1010_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1010_evk/CMakeLists.txt
@@ -25,3 +25,9 @@ if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
     zephyr_library_include_directories(${RT1010_BOARD_DIR}/xip)
   endif()
 endif()
+
+if(CONFIG_MCUX_GPT_TIMER)
+  message(WARNING "You appear to be using the GPT hardware timer. "
+    "This timer will enable lower power modes, but at the cost of reduced "
+    "hardware timer resolution")
+endif()

--- a/boards/arm/mimxrt1010_evk/doc/index.rst
+++ b/boards/arm/mimxrt1010_evk/doc/index.rst
@@ -6,7 +6,7 @@ NXP MIMXRT1010-EVK
 Overview
 ********
 
-The i.MX RT1010 offers a new entry-point into the i.MX RT crossover processor
+The i.MX RT1010 offer a new entry-point into the i.MX RT crossover processor
 series by providing the lowest-cost LQFP package option, combined with the
 high performance and ease-of-use known throughout the entire i.MX RT series.
 This device is fully supported by NXP’s MCUXpresso Software and Tools.
@@ -127,8 +127,13 @@ The MIMXRT1010 SoC has five pairs of pinmux/gpio controllers.
 System Clock
 ============
 
-The MIMXRT1010 SoC is configured to use the 32 KHz low frequency oscillator on
-the board as a source for the GPT timer to generate a system clock.
+The MIMXRT1010 SoC is configured to use SysTick as the system clock source,
+running at 500MHz.
+
+When power management is enabled, the 32 KHz low frequency
+oscillator on the board will be used as a source for the GPT timer to
+generate a system clock. This clock enables lower power states, at the
+cost of reduced resolution
 
 Serial Port
 ===========

--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -104,9 +104,14 @@ zephyr_udc0: &usb1 {
 	status = "okay";
 };
 
-/* Enable GPT for use as a hardware timer. This disables Cortex Systick.
- * to use systick, change this node from "gpt_hw_timer" to "systick"
+/* GPT and Systick are enabled. If power management is enabled, the GPT
+ * timer will be used instead of systick, as allows the core clock to
+ * be gated.
  */
 &gpt_hw_timer {
+	status = "okay";
+};
+
+&systick {
 	status = "okay";
 };

--- a/boards/arm/mimxrt1015_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1015_evk/CMakeLists.txt
@@ -24,3 +24,9 @@ if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
     zephyr_library_include_directories(${RT1015_BOARD_DIR}/xip)
   endif()
 endif()
+
+if(CONFIG_MCUX_GPT_TIMER)
+  message(WARNING "You appear to be using the GPT hardware timer. "
+    "This timer will enable lower power modes, but at the cost of reduced "
+    "hardware timer resolution")
+endif()

--- a/boards/arm/mimxrt1015_evk/doc/index.rst
+++ b/boards/arm/mimxrt1015_evk/doc/index.rst
@@ -131,8 +131,13 @@ The MIMXRT1015 SoC has five pairs of pinmux/gpio controllers.
 System Clock
 ============
 
-The MIMXRT1015 SoC is configured to use the 32 KHz low frequency oscillator on
-the board as a source for the GPT timer to generate a system clock.
+The MIMXRT1015 SoC is configured to use SysTick as the system clock source,
+running at 500MHz.
+
+When power management is enabled, the 32 KHz low frequency
+oscillator on the board will be used as a source for the GPT timer to
+generate a system clock. This clock enables lower power states, at the
+cost of reduced resolution
 
 Serial Port
 ===========

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -131,9 +131,14 @@ zephyr_udc0: &usb1 {
 	pinctrl-names = "default";
 };
 
-/* Enable GPT for use as a hardware timer. This disables Cortex Systick.
- * to use systick, change this node from "gpt_hw_timer" to "systick"
+/* GPT and Systick are enabled. If power management is enabled, the GPT
+ * timer will be used instead of systick, as allows the core clock to
+ * be gated.
  */
 &gpt_hw_timer {
+	status = "okay";
+};
+
+&systick {
 	status = "okay";
 };

--- a/boards/arm/mimxrt1020_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1020_evk/CMakeLists.txt
@@ -31,3 +31,9 @@ if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
     zephyr_library_sources(${RT1020_BOARD_DIR}/dcd.c)
   endif()
 endif()
+
+if(CONFIG_MCUX_GPT_TIMER)
+  message(WARNING "You appear to be using the GPT hardware timer. "
+    "This timer will enable lower power modes, but at the cost of reduced "
+    "hardware timer resolution")
+endif()

--- a/boards/arm/mimxrt1020_evk/doc/index.rst
+++ b/boards/arm/mimxrt1020_evk/doc/index.rst
@@ -183,8 +183,14 @@ The MIMXRT1020 SoC has five pairs of pinmux/gpio controllers.
 System Clock
 ============
 
-The MIMXRT1020 SoC is configured to use the 32 KHz low frequency oscillator on
-the board as a source for the GPT timer to generate a system clock.
+The MIMXRT1020 SoC is configured to use SysTick as the system clock source,
+running at 500MHz.
+
+When power management is enabled, the 32 KHz low frequency
+oscillator on the board will be used as a source for the GPT timer to
+generate a system clock. This clock enables lower power states, at the
+cost of reduced resolution
+
 
 Serial Port
 ===========

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -207,9 +207,14 @@ zephyr_udc0: &usb1 {
 	status = "okay";
 };
 
-/* Enable GPT for use as a hardware timer. This disables Cortex Systick.
- * to use systick, change this node from "gpt_hw_timer" to "systick"
+/* GPT and Systick are enabled. If power management is enabled, the GPT
+ * timer will be used instead of systick, as allows the core clock to
+ * be gated.
  */
 &gpt_hw_timer {
+	status = "okay";
+};
+
+&systick {
 	status = "okay";
 };

--- a/boards/arm/mimxrt1024_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1024_evk/CMakeLists.txt
@@ -31,3 +31,9 @@ if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
     zephyr_library_sources(${RT1024_BOARD_DIR}/dcd.c)
   endif()
 endif()
+
+if(CONFIG_MCUX_GPT_TIMER)
+  message(WARNING "You appear to be using the GPT hardware timer. "
+    "This timer will enable lower power modes, but at the cost of reduced "
+    "hardware timer resolution")
+endif()

--- a/boards/arm/mimxrt1024_evk/doc/index.rst
+++ b/boards/arm/mimxrt1024_evk/doc/index.rst
@@ -172,8 +172,13 @@ The MIMXRT1024 SoC has five pairs of pinmux/gpio controllers.
 System Clock
 ============
 
-The MIMXRT1024 SoC is configured to use the 32 KHz low frequency oscillator on
-the board as a source for the GPT timer to generate a system clock.
+The MIMXRT1024 SoC is configured to use SysTick as the system clock source,
+running at 500MHz.
+
+When power management is enabled, the 32 KHz low frequency
+oscillator on the board will be used as a source for the GPT timer to
+generate a system clock. This clock enables lower power states, at the
+cost of reduced resolution
 
 Serial Port
 ===========

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -165,10 +165,15 @@
 	pinctrl-names = "default";
 };
 
-/* Enable GPT for use as a hardware timer. This disables Cortex Systick.
- * to use systick, change this node from "gpt_hw_timer" to "systick"
+/* GPT and Systick are enabled. If power management is enabled, the GPT
+ * timer will be used instead of systick, as allows the core clock to
+ * be gated.
  */
 &gpt_hw_timer {
+	status = "okay";
+};
+
+&systick {
 	status = "okay";
 };
 

--- a/boards/arm/mimxrt1050_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1050_evk/CMakeLists.txt
@@ -42,3 +42,9 @@ if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
     zephyr_library_sources(${RT1050_BOARD_DIR}/dcd.c)
   endif()
 endif()
+
+if(CONFIG_MCUX_GPT_TIMER)
+  message(WARNING "You appear to be using the GPT hardware timer. "
+    "This timer will enable lower power modes, but at the cost of reduced "
+    "hardware timer resolution")
+endif()

--- a/boards/arm/mimxrt1050_evk/doc/index.rst
+++ b/boards/arm/mimxrt1050_evk/doc/index.rst
@@ -268,8 +268,13 @@ The MIMXRT1050 SoC has five pairs of pinmux/gpio controllers.
 System Clock
 ============
 
-The MIMXRT1050 SoC is configured to use the 32 KHz low frequency oscillator on
-the board as a source for the GPT timer to generate a system clock.
+The MIMXRT1050 SoC is configured to use SysTick as the system clock source,
+running at 600MHz.
+
+When power management is enabled, the 32 KHz low frequency
+oscillator on the board will be used as a source for the GPT timer to
+generate a system clock. This clock enables lower power states, at the
+cost of reduced resolution
 
 Serial Port
 ===========

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -282,9 +282,14 @@ zephyr_udc0: &usb1 {
 	status = "okay";
 };
 
-/* Enable GPT for use as a hardware timer. This disables Cortex Systick.
- * to use systick, change this node from "gpt_hw_timer" to "systick"
+/* GPT and Systick are enabled. If power management is enabled, the GPT
+ * timer will be used instead of systick, as allows the core clock to
+ * be gated.
  */
 &gpt_hw_timer {
+	status = "okay";
+};
+
+&systick {
 	status = "okay";
 };

--- a/boards/arm/mimxrt1060_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1060_evk/CMakeLists.txt
@@ -51,3 +51,9 @@ if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
     zephyr_library_sources(${RT1060_BOARD_DIR}/dcd.c)
   endif()
 endif()
+
+if(CONFIG_MCUX_GPT_TIMER)
+  message(WARNING "You appear to be using the GPT hardware timer. "
+    "This timer will enable lower power modes, but at the cost of reduced "
+    "hardware timer resolution")
+endif()

--- a/boards/arm/mimxrt1060_evk/doc/index.rst
+++ b/boards/arm/mimxrt1060_evk/doc/index.rst
@@ -284,8 +284,14 @@ The MIMXRT1060 SoC has five pairs of pinmux/gpio controllers.
 System Clock
 ============
 
-The MIMXRT1060 SoC is configured to use the 32 KHz low frequency oscillator on
-the board as a source for the GPT timer to generate a system clock.
+The MIMXRT1060 SoC is configured to use SysTick as the system clock source,
+running at 600MHz.
+
+When power management is enabled, the 32 KHz low frequency
+oscillator on the board will be used as a source for the GPT timer to
+generate a system clock. This clock enables lower power states, at the
+cost of reduced resolution
+
 
 Serial Port
 ===========

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -276,10 +276,15 @@ zephyr_udc0: &usb1 {
 	pinctrl-names = "default";
 };
 
-/* Enable GPT for use as a hardware timer. This disables Cortex Systick.
- * to use systick, change this node from "gpt_hw_timer" to "systick"
+/* GPT and Systick are enabled. If power management is enabled, the GPT
+ * timer will be used instead of systick, as allows the core clock to
+ * be gated.
  */
 &gpt_hw_timer {
+	status = "okay";
+};
+
+&systick {
 	status = "okay";
 };
 

--- a/boards/arm/mimxrt1064_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1064_evk/CMakeLists.txt
@@ -36,3 +36,9 @@ if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
     zephyr_library_sources(${RT1064_BOARD_DIR}/dcd.c)
   endif()
 endif()
+
+if(CONFIG_MCUX_GPT_TIMER)
+  message(WARNING "You appear to be using the GPT hardware timer. "
+    "This timer will enable lower power modes, but at the cost of reduced "
+    "hardware timer resolution")
+endif()

--- a/boards/arm/mimxrt1064_evk/doc/index.rst
+++ b/boards/arm/mimxrt1064_evk/doc/index.rst
@@ -284,8 +284,13 @@ The MIMXRT1064 SoC has four pairs of pinmux/gpio controllers.
 System Clock
 ============
 
-The MIMXRT1064 SoC is configured to use the 32 KHz low frequency oscillator on
-the board as a source for the GPT timer to generate a system clock.
+The MIMXRT1064 SoC is configured to use SysTick as the system clock source,
+running at 600MHz.
+
+When power management is enabled, the 32 KHz low frequency
+oscillator on the board will be used as a source for the GPT timer to
+generate a system clock. This clock enables lower power states, at the
+cost of reduced resolution
 
 Serial Port
 ===========

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -337,10 +337,15 @@ zephyr_udc0: &usb1 {
 	pinctrl-names = "default";
 };
 
-/* Enable GPT for use as a hardware timer. This disables Cortex Systick.
- * to use systick, change this node from "gpt_hw_timer" to "systick"
+/* GPT and Systick are enabled. If power management is enabled, the GPT
+ * timer will be used instead of systick, as allows the core clock to
+ * be gated.
  */
 &gpt_hw_timer {
+	status = "okay";
+};
+
+&systick {
 	status = "okay";
 };
 

--- a/boards/arm/mimxrt1160_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1160_evk/CMakeLists.txt
@@ -31,3 +31,9 @@ if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
     zephyr_library_sources(${RT1160_BOARD_DIR}/dcd.c)
   endif()
 endif()
+
+if(CONFIG_MCUX_GPT_TIMER)
+  message(WARNING "You appear to be using the GPT hardware timer. "
+    "This timer will enable lower power modes, but at the cost of reduced "
+    "hardware timer resolution")
+endif()

--- a/boards/arm/mimxrt1160_evk/doc/index.rst
+++ b/boards/arm/mimxrt1160_evk/doc/index.rst
@@ -204,8 +204,14 @@ used as shared memory
 System Clock
 ============
 
-The MIMXRT1160 SoC is configured to use the 32 KHz low frequency oscillator on
-the board as a source for the GPT timer to generate a system clock.
+The MIMXRT1160 SoC is configured to use SysTick as the system clock source,
+running at 600MHz. When targeting the M4 core, SysTick will also be used,
+running at 240MHz
+
+When power management is enabled, the 32 KHz low frequency
+oscillator on the board will be used as a source for the GPT timer to
+generate a system clock. This clock enables lower power states, at the
+cost of reduced resolution
 
 Serial Port
 ===========

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm4.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm4.dts
@@ -47,10 +47,15 @@
 	status = "okay";
 };
 
-/* Enable GPT for use as a hardware timer. This disables Cortex Systick.
- * to use systick, change this node from "gpt_hw_timer" to "systick"
+/* GPT and Systick are enabled. If power management is enabled, the GPT
+ * timer will be used instead of systick, as allows the core clock to
+ * be gated.
  */
 &gpt_hw_timer {
+	status = "okay";
+};
+
+&systick {
 	status = "okay";
 };
 

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
@@ -60,10 +60,15 @@
 	status = "okay";
 };
 
-/* Enable GPT for use as a hardware timer. This disables Cortex Systick.
- * to use systick, change this node from "gpt_hw_timer" to "systick"
+/* GPT and Systick are enabled. If power management is enabled, the GPT
+ * timer will be used instead of systick, as allows the core clock to
+ * be gated.
  */
 &gpt_hw_timer {
+	status = "okay";
+};
+
+&systick {
 	status = "okay";
 };
 

--- a/boards/arm/mimxrt1170_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt1170_evk/CMakeLists.txt
@@ -31,3 +31,9 @@ if(CONFIG_NXP_IMX_RT_BOOT_HEADER)
     zephyr_library_sources(${RT1170_BOARD_DIR}/dcd.c)
   endif()
 endif()
+
+if(CONFIG_MCUX_GPT_TIMER)
+  message(WARNING "You appear to be using the GPT hardware timer. "
+    "This timer will enable lower power modes, but at the cost of reduced "
+    "hardware timer resolution")
+endif()

--- a/boards/arm/mimxrt1170_evk/doc/index.rst
+++ b/boards/arm/mimxrt1170_evk/doc/index.rst
@@ -243,8 +243,14 @@ used as shared memory
 System Clock
 ============
 
-The MIMXRT1170 SoC is configured to use the 32 KHz low frequency oscillator on
-the board as a source for the GPT timer to generate a system clock.
+The MIMXRT1170 SoC is configured to use SysTick as the system clock source,
+running at 996MHz. When targeting the M4 core, SysTick will also be used,
+running at 400MHz
+
+When power management is enabled, the 32 KHz low frequency
+oscillator on the board will be used as a source for the GPT timer to
+generate a system clock. This clock enables lower power states, at the
+cost of reduced resolution
 
 Serial Port
 ===========

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm4.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm4.dts
@@ -47,10 +47,15 @@
 	status = "okay";
 };
 
-/* Enable GPT for use as a hardware timer. This disables Cortex Systick.
- * to use systick, change this node from "gpt_hw_timer" to "systick"
+/* GPT and Systick are enabled. If power management is enabled, the GPT
+ * timer will be used instead of systick, as allows the core clock to
+ * be gated.
  */
 &gpt_hw_timer {
+	status = "okay";
+};
+
+&systick {
 	status = "okay";
 };
 

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
@@ -135,10 +135,15 @@
 	status = "okay";
 };
 
-/* Enable GPT for use as a hardware timer. This disables Cortex Systick.
- * to use systick, change this node from "gpt_hw_timer" to "systick"
+/* GPT and Systick are enabled. If power management is enabled, the GPT
+ * timer will be used instead of systick, as allows the core clock to
+ * be gated.
  */
 &gpt_hw_timer {
+	status = "okay";
+};
+
+&systick {
 	status = "okay";
 };
 

--- a/drivers/timer/Kconfig.mcux_gpt
+++ b/drivers/timer/Kconfig.mcux_gpt
@@ -4,6 +4,7 @@
 config MCUX_GPT_TIMER
 	bool "MCUX GPT Event timer"
 	default y
+	depends on PM
 	depends on DT_HAS_NXP_GPT_HW_TIMER_ENABLED
 	select TICKLESS_CAPABLE
 	help

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1166_cm4
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1166_cm4
@@ -14,4 +14,7 @@ config NUM_IRQS
 config GPIO
 	default y
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 240000000 if CORTEX_M_SYSTICK
+
 endif # SOC_MIMXRT1166_CM4

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1166_cm7
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.mimxrt1166_cm7
@@ -14,4 +14,7 @@ config NUM_IRQS
 config GPIO
 	default y
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 600000000 if CORTEX_M_SYSTICK
+
 endif # SOC_MIMXRT1166_CM7

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -47,6 +47,10 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,$(DT_SYSCLK_PATH),clock-frequency) if SOC_SERIES_IMX_RT10XX && CORTEX_M_SYSTICK
 	default 32768 if MCUX_GPT_TIMER
 
+# Disable systick if using MCUX_GPT_TIMER, as they will conflict
+config CORTEX_M_SYSTICK
+	default n if MCUX_GPT_TIMER
+
 config PM_MCUX_GPC
 	default y if HAS_MCUX_GPC
 	depends on SOC_SERIES_IMX_RT11XX && PM


### PR DESCRIPTION
Switch all imxrt boards to use the systick timer by default, and only
enable the GPT timer when using low power modes. This is desirable
because the systick has a higher resolution, but the GPT can run
while the core clock is gated, making it useful for low power modes.

This PR was tested using `samples/hello_world`, and `tests/subsys/pm/power_mgmt_soc`.
Test report for this PR:  [test_report.csv](https://github.com/zephyrproject-rtos/zephyr/files/10222468/test_report.csv)
