### PR TITLE
logging: prevent of NULL pointer comparison

### DIFF
--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -359,8 +359,9 @@ void z_log_runtime_filters_init(void)
 int log_source_id_get(const char *name)
 {
 	for (int i = 0; i < log_src_cnt_get(Z_LOG_LOCAL_DOMAIN_ID); i++) {
-		if (strcmp(log_source_name_get(Z_LOG_LOCAL_DOMAIN_ID, i),
-			   name) == 0) {
+		const char *sname = log_source_name_get(Z_LOG_LOCAL_DOMAIN_ID, i);
+
+		if ((sname != NULL) && (strcmp(sname, name) == 0)) {
 			return i;
 		}
 	}

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -194,7 +194,7 @@ static void __attribute__((unused)) get_YMD_from_seconds(uint64_t seconds,
 		output_date->year++;
 	}
 	/* compute the proper month */
-	for (i = 0; i < sizeof(days_in_month); i++) {
+	for (i = 0; i < ARRAY_SIZE(days_in_month); i++) {
 		tmp = ((i == 1) && is_leap_year(output_date->year)) ?
 					(days_in_month[i] + 1) * SECONDS_IN_DAY :
 					days_in_month[i] * SECONDS_IN_DAY;


### PR DESCRIPTION
Static analysis tool detect NULL pointer dereference in logging management. Add extra condition to prevent it in strcmp.

Signed-off-by: PawelX Dobrowolski <pawelx.dobrowolski@intel.com>