### PR TITLE
Add .hpp extension to migrate_includes.py

### DIFF
--- a/scripts/utils/migrate_includes.py
+++ b/scripts/utils/migrate_includes.py
@@ -23,7 +23,7 @@ import sys
 
 ZEPHYR_BASE = Path(__file__).parents[2]
 
-EXTENSIONS = ("c", "cpp", "h", "dts", "dtsi", "rst", "S", "overlay", "ld")
+EXTENSIONS = ("c", "cpp", "h", "hpp", "dts", "dtsi", "rst", "S", "overlay", "ld")
 
 
 def update_includes(project, dry_run):


### PR DESCRIPTION
Using migrate_include.py on modules which uses the c++ header extension `.hpp` is currently not a supported suffix.
Added `hpp` as an extension to allow for c++ header files to be recognised by migrate_include.py

Looking at https://github.com/zephyrproject-rtos/zephyr/issues/44196 it seems that the extension convention `hpp` is being accepted.