### PR TITLE
sample: Bluetooth: Add PA interval check in iso broadcast benchmark

### DIFF
--- a/samples/bluetooth/iso_broadcast_benchmark/src/receiver.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/receiver.c
@@ -94,6 +94,11 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 		return;
 	}
 
+	if (info->interval == 0U) {
+		/* Not broadcast periodic advertising - Ignore */
+		return;
+	}
+
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	LOG_INF("Found broadcaster with address %s (RSSI %i)",


### PR DESCRIPTION
Verify that the peridic advertising interval is non-0 to ensure that the remote device is actually advertising with peridic advertising enabled.

This fixes an issue where per_interval_ms would be set to 0, causing bt_le_per_adv_sync_create to fail to invalid values.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>