### PR TITLE
settings: do not panic on backend initialization errors

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -432,6 +432,11 @@ Libraries / Subsystems
 
   * The ``lwm2m_senml_cbor_*`` files have been regenerated using zcbor 0.6.0.
 
+* Settings
+
+  * Replaced all :c:func:`k_panic` invocations within settings backend
+    initialization with returning / propagating error codes.
+
 HALs
 ****
 

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -415,39 +415,35 @@ int settings_backend_init(void)
 
 	rc = flash_area_get_sectors(settings_fcb_get_flash_area(), &cnt,
 				    settings_fcb_area);
-	if (rc == -ENODEV) {
+	if (rc != 0 && rc != -ENOMEM) {
 		return rc;
-	} else if (rc != 0 && rc != -ENOMEM) {
-		k_panic();
 	}
 
 	config_init_settings_fcb.cf_fcb.f_sector_cnt = cnt;
 
 	rc = settings_fcb_src(&config_init_settings_fcb);
-
 	if (rc != 0) {
 		rc = flash_area_open(settings_fcb_get_flash_area(), &fap);
-
-		if (rc == 0) {
-			rc = flash_area_erase(fap, 0, fap->fa_size);
-			flash_area_close(fap);
+		if (rc != 0) {
+			return rc;
 		}
+
+		rc = flash_area_erase(fap, 0, fap->fa_size);
+		flash_area_close(fap);
 
 		if (rc != 0) {
-			k_panic();
-		} else {
-			rc = settings_fcb_src(&config_init_settings_fcb);
+			return rc;
 		}
-	}
 
-	if (rc != 0) {
-		k_panic();
+		rc = settings_fcb_src(&config_init_settings_fcb);
+		if (rc != 0) {
+			return rc;
+		}
 	}
 
 	rc = settings_fcb_dst(&config_init_settings_fcb);
-
 	if (rc != 0) {
-		k_panic();
+		return rc;
 	}
 
 	settings_mount_fcb_backend(&config_init_settings_fcb);

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -531,12 +531,12 @@ int settings_backend_init(void)
 
 	rc = settings_file_src(&config_init_settings_file);
 	if (rc) {
-		k_panic();
+		return rc;
 	}
 
 	rc = settings_file_dst(&config_init_settings_file);
 	if (rc) {
-		k_panic();
+		return rc;
 	}
 
 	settings_mount_file_backend(&config_init_settings_file);

--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -33,7 +33,7 @@ int settings_subsys_init(void)
 
 	settings_init();
 
-	err = settings_backend_init(); /* func rises kernel panic once error */
+	err = settings_backend_init();
 
 	if (!err) {
 		settings_subsys_initialized = true;

--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -359,10 +359,8 @@ int settings_backend_init(void)
 
 	rc = flash_area_get_sectors(SETTINGS_PARTITION, &sector_cnt,
 				    &hw_flash_sector);
-	if (rc == -ENODEV) {
+	if (rc != 0 && rc != -ENOMEM) {
 		return rc;
-	} else if (rc != 0 && rc != -ENOMEM) {
-		k_panic();
 	}
 
 	nvs_sector_size = CONFIG_SETTINGS_NVS_SECTOR_SIZE_MULT *


### PR DESCRIPTION
There is little reason to panic on settings backend initialization error.
Such behavior was introduced with initial settings subsystem support, which
was adapted from MyNewt. This is not the usual way how Zephyr handles
errors, so it is time to change that.

There is already handling of some errors by simply returning / propagating
them to caller. Rework all the paths that resulted in k_panic() to also
return error codes.