### PR TITLE
ace: hda: add power domain

### DIFF
--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -236,7 +236,7 @@ int intel_adsp_hda_dma_start(const struct device *dev, uint32_t channel)
 		intel_adsp_hda_link_commit(cfg->base, cfg->regblock_size, channel, size);
 	}
 
-	return 0;
+	return pm_device_runtime_get(dev);
 }
 
 int intel_adsp_hda_dma_stop(const struct device *dev, uint32_t channel)
@@ -247,7 +247,7 @@ int intel_adsp_hda_dma_stop(const struct device *dev, uint32_t channel)
 
 	intel_adsp_hda_disable(cfg->base, cfg->regblock_size, channel);
 
-	return 0;
+	return pm_device_runtime_put(dev);
 }
 
 int intel_adsp_hda_dma_init(const struct device *dev)
@@ -263,7 +263,8 @@ int intel_adsp_hda_dma_init(const struct device *dev)
 	data->ctx.atomic = data->channels_atomic;
 	data->ctx.magic = DMA_MAGIC;
 
-	return 0;
+	pm_device_init_suspended(dev);
+	return pm_device_runtime_enable(dev);
 }
 
 int intel_adsp_hda_dma_get_attribute(const struct device *dev, uint32_t type, uint32_t *value)
@@ -289,3 +290,20 @@ int intel_adsp_hda_dma_get_attribute(const struct device *dev, uint32_t type, ui
 
 	return 0;
 }
+
+#ifdef CONFIG_PM_DEVICE
+int intel_adsp_hda_dma_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+	case PM_DEVICE_ACTION_RESUME:
+	case PM_DEVICE_ACTION_TURN_ON:
+	case PM_DEVICE_ACTION_TURN_OFF:
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif

--- a/drivers/dma/dma_intel_adsp_hda.h
+++ b/drivers/dma/dma_intel_adsp_hda.h
@@ -10,6 +10,8 @@
 #define INTEL_ADSP_HDA_MAX_CHANNELS DT_PROP(DT_NODELABEL(hda_host_out), dma_channels)
 
 #include <zephyr/drivers/dma.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
 
 struct intel_adsp_hda_dma_data {
 	struct dma_context ctx;
@@ -59,5 +61,9 @@ int intel_adsp_hda_dma_stop(const struct device *dev, uint32_t channel);
 int intel_adsp_hda_dma_init(const struct device *dev);
 
 int intel_adsp_hda_dma_get_attribute(const struct device *dev, uint32_t type, uint32_t *value);
+
+#ifdef CONFIG_PM_DEVICE
+int intel_adsp_hda_dma_pm_action(const struct device *dev, enum pm_device_action action);
+#endif
 
 #endif /* ZEPHYR_DRIVERS_DMA_INTEL_ADSP_HDA_COMMON_H_ */

--- a/drivers/dma/dma_intel_adsp_hda_host_in.c
+++ b/drivers/dma/dma_intel_adsp_hda_host_in.c
@@ -29,7 +29,10 @@ static const struct dma_driver_api intel_adsp_hda_dma_host_in_api = {
 												   \
 	static struct intel_adsp_hda_dma_data intel_adsp_hda_dma##inst##_data = {};                \
 												   \
-	DEVICE_DT_INST_DEFINE(inst, &intel_adsp_hda_dma_init, NULL,                                \
+	PM_DEVICE_DT_INST_DEFINE(inst, intel_adsp_hda_dma_pm_action);				   \
+												   \
+	DEVICE_DT_INST_DEFINE(inst, &intel_adsp_hda_dma_init,					   \
+			      PM_DEVICE_DT_INST_GET(inst),					   \
 			      &intel_adsp_hda_dma##inst##_data,                                    \
 			      &intel_adsp_hda_dma##inst##_config, POST_KERNEL,                     \
 			      CONFIG_DMA_INIT_PRIORITY,                                            \

--- a/drivers/dma/dma_intel_adsp_hda_host_out.c
+++ b/drivers/dma/dma_intel_adsp_hda_host_out.c
@@ -33,7 +33,10 @@ static const struct dma_driver_api intel_adsp_hda_dma_host_out_api = {
 												   \
 	static struct intel_adsp_hda_dma_data intel_adsp_hda_dma##inst##_data = {};                \
 												   \
-	DEVICE_DT_INST_DEFINE(inst, &intel_adsp_hda_dma_init, NULL,                                \
+	PM_DEVICE_DT_INST_DEFINE(inst, intel_adsp_hda_dma_pm_action);				   \
+												   \
+	DEVICE_DT_INST_DEFINE(inst, &intel_adsp_hda_dma_init,					   \
+			      PM_DEVICE_DT_INST_GET(inst),					   \
 			      &intel_adsp_hda_dma##inst##_data,                                    \
 			      &intel_adsp_hda_dma##inst##_config, POST_KERNEL,                     \
 			      CONFIG_DMA_INIT_PRIORITY,                                            \

--- a/drivers/dma/dma_intel_adsp_hda_link_in.c
+++ b/drivers/dma/dma_intel_adsp_hda_link_in.c
@@ -34,7 +34,10 @@ static const struct dma_driver_api intel_adsp_hda_dma_link_in_api = {
 												   \
 	static struct intel_adsp_hda_dma_data intel_adsp_hda_dma##inst##_data = {};                \
 												   \
-	DEVICE_DT_INST_DEFINE(inst, &intel_adsp_hda_dma_init, NULL,				   \
+	PM_DEVICE_DT_INST_DEFINE(inst, intel_adsp_hda_dma_pm_action);				   \
+												   \
+	DEVICE_DT_INST_DEFINE(inst, &intel_adsp_hda_dma_init,					   \
+			      PM_DEVICE_DT_INST_GET(inst),					   \
 			      &intel_adsp_hda_dma##inst##_data,                                    \
 			      &intel_adsp_hda_dma##inst##_config, POST_KERNEL,                     \
 			      CONFIG_DMA_INIT_PRIORITY,                                            \

--- a/drivers/dma/dma_intel_adsp_hda_link_out.c
+++ b/drivers/dma/dma_intel_adsp_hda_link_out.c
@@ -34,7 +34,10 @@ static const struct dma_driver_api intel_adsp_hda_dma_link_out_api = {
 												   \
 	static struct intel_adsp_hda_dma_data intel_adsp_hda_dma##inst##_data = {};                \
 												   \
-	DEVICE_DT_INST_DEFINE(inst, &intel_adsp_hda_dma_init, NULL,				   \
+	PM_DEVICE_DT_INST_DEFINE(inst, intel_adsp_hda_dma_pm_action);				   \
+												   \
+	DEVICE_DT_INST_DEFINE(inst, &intel_adsp_hda_dma_init,					   \
+			      PM_DEVICE_DT_INST_GET(inst),					   \
 			      &intel_adsp_hda_dma##inst##_data,					   \
 			      &intel_adsp_hda_dma##inst##_config, POST_KERNEL,			   \
 			      CONFIG_DMA_INIT_PRIORITY,                                            \

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -361,6 +361,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <32>;
+			power-domain = <&hst_domain>;
 			status = "okay";
 		};
 
@@ -372,6 +373,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <32>;
+			power-domain = <&hst_domain>;
 			status = "okay";
 		};
 
@@ -383,6 +385,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <32>;
+			power-domain = <&hst_domain>;
 			status = "okay";
 		};
 
@@ -394,6 +397,7 @@
 			dma-buf-addr-alignment = <128>;
 			dma-buf-size-alignment = <32>;
 			dma-copy-alignment = <32>;
+			power-domain = <&hst_domain>;
 			status = "okay";
 		};
 


### PR DESCRIPTION
I'm making the same changes for GP DMA https://github.com/zephyrproject-rtos/zephyr/pull/52734

This patch results with PG prevent for HST domain, under which is Intel HD Audio controllers.

Empty PM action handler is enough for purpose of domain usage tracking. This part of code will be fill out later to handle device suspend.