### PR TITLE
drivers: flash: clear stm32 status register errors

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -83,6 +83,9 @@ static int flash_stm32_check_status(const struct device *dev)
 		LOG_DBG("Status: 0x%08lx",
 			FLASH_STM32_REGS(dev)->FLASH_STM32_SR &
 							FLASH_STM32_SR_ERRORS);
+		/* Clear errors to unblock usage of the flash */
+		FLASH_STM32_REGS(dev)->FLASH_STM32_SR = FLASH_STM32_REGS(dev)->FLASH_STM32_SR &
+							FLASH_STM32_SR_ERRORS;
 		return -EIO;
 	}
 


### PR DESCRIPTION
In case of errors in the status register and to unblock Flash, it is advised to clear the errors.
