### PR TITLE
drivers: timer: lptim timer clock on stm32u5 has a prescaler

### DIFF
--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -408,6 +408,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000800>;
 			interrupts = <67 1>;
 			interrupt-names = "wakeup";
+			st,static-prescaler;
 			status = "disabled";
 		};
 

--- a/dts/bindings/timer/st,stm32-lptim.yaml
+++ b/dts/bindings/timer/st,stm32-lptim.yaml
@@ -12,3 +12,12 @@ include:
       - resets
       - st,prescaler
       - st,countermode
+
+properties:
+  st,static-prescaler:
+    type: boolean
+    description: |
+        Clock x2 factor at the input of the LPTIM,
+        depending on the serie.
+        For example, stm32U5x have a x2-factor for LPTIM1,3,4.
+        To be adapted once the value is selectable.


### PR DESCRIPTION
The stm32U5 devices shows a x2 factor on the LPTIM1,3,4 clock source but it acts as a prescaler.
The max lptim counter (timebase) is counting 4 sec The LPTIM count unit is double.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/53012

Signed-off-by: Francois Ramu <francois.ramu@st.com>