### PR TITLE
intel_adsp: dai: Add support for ALH streams 2 and 3

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -137,6 +137,9 @@
 		 * is discussed here:
 		 *
 		 * https://github.com/zephyrproject-rtos/zephyr/pull/50287#discussion_r974591009
+		 *
+		 * The hardware actually supports 16 ALH streams/FIFOs. Below description does
+		 * not fully represent hardware capabilities and is expected to be modified.
 		 */
 		alh0: alh0@24400 {
 			compatible = "intel,alh-dai";
@@ -145,6 +148,18 @@
 		};
 
 		alh1: alh1@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		alh2: alh2@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		alh3: alh3@24400 {
 			compatible = "intel,alh-dai";
 			reg = <0x00024400 0x00024600>;
 			status = "okay";


### PR DESCRIPTION
Adds two additional alh2 and alh3 "devices" to already defined alh0 and alh1. This (seems) is a temporarily solution as the hardware actually supports 16 streams and future update to device tree is required.

Signed-off-by: Serhiy Katsyuba <serhiy.katsyuba@intel.com>