### PR TITLE
Usbc boards

### DIFF
--- a/boards/arm/stm32g081b_eval/stm32g081b_eval.dts
+++ b/boards/arm/stm32g081b_eval/stm32g081b_eval.dts
@@ -132,6 +132,37 @@
 	};
 };
 
+&ucpd1 {
+	status = "okay";
+
+	/*
+	 * UCPD is fed directly from HSI which is @ 16MHz. The ucpd_clk goes to
+	 * a prescaler who's output feeds the 'half-bit' divider which is used
+	 * to generate clock for delay counters and BMC Rx/Tx blocks. The rx is
+	 * designed to work in freq ranges of 6 <--> 18 MHz, however recommended
+	 * range is 9 <--> 18 MHz.
+	 *
+	 *          +-------+ @ 16 MHz +-------+   @ ~600 kHz   +-----------+
+	 * HSI ---->| /psc  |--------->| /hbit |--------------->| trans_cnt |
+	 *          +-------+          +-------+   |            +-----------+
+	 *                                         |            +-----------+
+	 *                                         +----------->| ifrgap_cnt|
+	 *                                                      +-----------+
+	 * Requirements:
+	 *   1. hbit_clk ~= 600 kHz: 16 MHz / 600 kHz = 26.67
+	 *   2. tTransitionWindow - 12 to 20 uSec
+	 *   3. tInterframGap - uSec
+	 *
+	 * hbit_clk = HSI_clk / 27 = 592.6 kHz = 1.687 uSec period
+	 * tTransitionWindow = 1.687 uS * 8 = 13.5 uS
+	 * tInterFrameGap = 1.687 uS * 17 = 28.68 uS
+	 */
+	psc-ucpdclk = <1>;
+	hbitclkdiv = <27>;
+	pinctrl-0 = <&ucpd1_cc1_pa8 &ucpd1_cc2_pb15>;
+	pinctrl-names = "default";
+};
+
 &ucpd2 {
 	status = "okay";
 

--- a/boards/arm/stm32g081b_eval/stm32g081b_eval.dts
+++ b/boards/arm/stm32g081b_eval/stm32g081b_eval.dts
@@ -106,7 +106,7 @@
 };
 
 &adc1 {
-	pinctrl-0 = <&adc1_in3_pa3>;
+	pinctrl-0 = <&adc1_in3_pa3 &adc1_in9_pb1>;
 	pinctrl-names = "default";
 	status = "okay";
 
@@ -115,6 +115,15 @@
 
 	channel@3 {
 		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+
+	channel@9 {
+		reg = <9>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;

--- a/boards/arm/stm32g081b_eval/stm32g081b_eval.dts
+++ b/boards/arm/stm32g081b_eval/stm32g081b_eval.dts
@@ -105,6 +105,21 @@
 	status = "okay";
 };
 
+&tim15_ch1_pc1 {
+	slew-rate = "very-high-speed";
+	bias-pull-up;
+	drive-open-drain;
+};
+
+&timers15 {
+	status = "okay";
+	pwm15: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim15_ch1_pc1>;
+		pinctrl-names = "default";
+	};
+};
+
 &adc1 {
 	pinctrl-0 = <&adc1_in3_pa3 &adc1_in9_pb1>;
 	pinctrl-names = "default";


### PR DESCRIPTION
Add stm32g081b peripherals to devicetree that are needed for a USB-C Source device 