### PR TITLE
Audio iso unicast client fix

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1514,7 +1514,7 @@ static int ase_stream_qos(struct bt_audio_stream *stream,
 			return -ENOMEM;
 		}
 
-		if (bt_audio_iso_get_ep(iso, ep->dir) != NULL) {
+		if (bt_audio_iso_get_ep(false, iso, ep->dir) != NULL) {
 			LOG_ERR("iso %p already in use in dir %u",
 			       &iso->chan, ep->dir);
 			bt_audio_iso_unref(iso);

--- a/subsys/bluetooth/audio/audio_iso.h
+++ b/subsys/bluetooth/audio/audio_iso.h
@@ -40,5 +40,6 @@ struct bt_audio_iso *bt_audio_iso_find(bt_audio_iso_func_t func,
 void bt_audio_iso_init(struct bt_audio_iso *iso, struct bt_iso_chan_ops *ops);
 void bt_audio_iso_bind_ep(struct bt_audio_iso *iso, struct bt_audio_ep *ep);
 void bt_audio_iso_unbind_ep(struct bt_audio_iso *iso, struct bt_audio_ep *ep);
-struct bt_audio_ep *bt_audio_iso_get_ep(struct bt_audio_iso *iso,
+struct bt_audio_ep *bt_audio_iso_get_ep(bool unicast_client,
+					struct bt_audio_iso *iso,
 					enum bt_audio_dir dir);

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -131,3 +131,4 @@ static inline const char *bt_audio_ep_state_str(uint8_t state)
 
 bool bt_audio_ep_is_broadcast_snk(const struct bt_audio_ep *ep);
 bool bt_audio_ep_is_broadcast_src(const struct bt_audio_ep *ep);
+bool bt_audio_ep_is_unicast_client(const struct bt_audio_ep *ep);

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -738,7 +738,7 @@ static struct bt_audio_iso *get_new_iso(struct bt_audio_unicast_group *group,
 			continue;
 		}
 
-		if (bt_audio_iso_get_ep(stream->ep->iso, dir) == NULL) {
+		if (bt_audio_iso_get_ep(true, stream->ep->iso, dir) == NULL) {
 			return bt_audio_iso_ref(stream->ep->iso);
 		}
 	}

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -235,6 +235,23 @@ static struct bt_iso_chan_ops unicast_client_iso_ops = {
 	.disconnected	= unicast_client_iso_disconnected,
 };
 
+bool bt_audio_ep_is_unicast_client(const struct bt_audio_ep *ep)
+{
+	for (size_t i = 0U; i < ARRAY_SIZE(snks); i++) {
+		if (PART_OF_ARRAY(snks[i], ep)) {
+			return true;
+		}
+	}
+
+	for (size_t i = 0U; i < ARRAY_SIZE(srcs); i++) {
+		if (PART_OF_ARRAY(srcs[i], ep)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 static void unicast_client_ep_init(struct bt_audio_ep *ep, uint16_t handle,
 				   uint8_t dir)
 {

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -1479,11 +1479,18 @@ int bt_unicast_client_ep_send(struct bt_conn *conn, struct bt_audio_ep *ep,
 
 static void unicast_client_reset(struct bt_audio_ep *ep)
 {
+	struct bt_unicast_client_ep *client_ep = CONTAINER_OF(ep, struct bt_unicast_client_ep, ep);
+
 	LOG_DBG("ep %p", ep);
 
 	bt_audio_stream_reset(ep->stream);
 
 	(void)memset(ep, 0, sizeof(*ep));
+
+	client_ep->cp_handle = 0U;
+	client_ep->handle = 0U;
+	(void)memset(&client_ep->discover, 0, sizeof(client_ep->discover));
+	/* Need to keep the subscribe params intact for the callback */
 }
 
 static void unicast_client_ep_reset(struct bt_conn *conn)

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -207,8 +207,7 @@ static int hci_le_setup_iso_data_path(const struct bt_conn *iso, uint8_t dir,
 		 dir == BT_HCI_DATAPATH_DIR_CTLR_TO_HOST,
 		 "invalid ISO data path dir: %u", dir);
 
-	if ((path->cc == NULL && path->cc_len != 0) ||
-	    (path->cc != NULL && path->cc_len == 0)) {
+	if ((path->cc == NULL && path->cc_len != 0)) {
 		LOG_DBG("Invalid ISO data path CC: %p %u", path->cc, path->cc_len);
 
 		return -EINVAL;


### PR DESCRIPTION
Fixes a few issues that was introduced by the audio_iso refactor work, which unfortunately broke the BAP unicast client completely. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/52464