### PR TITLE
drivers: pwm: pwm_mcux: Reload mode option

### DIFF
--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -25,6 +25,7 @@ struct pwm_mcux_config {
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
 	pwm_clock_prescale_t prescale;
+	pwm_register_reload_t reload;
 	pwm_mode_t mode;
 	bool run_wait;
 	bool run_debug;
@@ -80,7 +81,7 @@ static int mcux_pwm_set_cycles(const struct device *dev, uint32_t channel,
 
 		data->period_cycles[channel] = period_cycles;
 
-		LOG_DBG("SETUP dutycycle to %u\n", duty_cycle);
+		LOG_DBG("SETUP dutycycle to %u", duty_cycle);
 
 		if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				&clock_freq)) {
@@ -153,9 +154,12 @@ static int pwm_mcux_init(const struct device *dev)
 		return err;
 	}
 
+	LOG_DBG("Set prescaler %d, reload mode %d",
+			1 << config->prescale, config->reload);
+
 	PWM_GetDefaultConfig(&pwm_config);
 	pwm_config.prescale = config->prescale;
-	pwm_config.reloadLogic = kPWM_ReloadPwmFullCycle;
+	pwm_config.reloadLogic = config->reload;
 	pwm_config.clockSource = kPWM_BusClock;
 	pwm_config.enableDebugMode = config->run_debug;
 	pwm_config.enableWait = config->run_wait;
@@ -193,6 +197,8 @@ static const struct pwm_driver_api pwm_mcux_driver_api = {
 		.index = DT_INST_PROP(n, index),			  \
 		.mode = kPWM_EdgeAligned,				  \
 		.prescale = _CONCAT(kPWM_Prescale_Divide_, DT_INST_PROP(n, nxp_prescaler)),\
+		.reload = DT_ENUM_IDX_OR(DT_DRV_INST(n), nxp_reload,\
+				kPWM_ReloadPwmFullCycle),\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
 		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
 		.run_wait = DT_INST_PROP(n, run_in_wait),		  \

--- a/dts/bindings/pwm/nxp,imx-pwm.yaml
+++ b/dts/bindings/pwm/nxp,imx-pwm.yaml
@@ -33,6 +33,20 @@ properties:
     description: |
       Clock prescaler at the input of the PWM.
 
+  nxp,reload:
+    type: string
+    enum:
+      - "immediate"
+      - "half-cycle"
+      - "full-cycle"
+      - "half-and-full-cycle"
+    description: |
+      Select how to load the buffered-registers with new values:
+      "immediate" - buffered-registers get loaded with new values as soon as LDOK bit is set;
+      "half-cycle" - registers loaded on a PWM half cycle;
+      "full-cycle" - registers loaded on a PWM full cycle;
+      "half-and-full-cycle" - registers loaded on a PWM half & full cycle.
+
   "#pwm-cells":
     const: 2
 


### PR DESCRIPTION
DTS property `nxp,reload` selects how to load the buffered-registers with new values.

I have testing this changes in the local patch for 2.7.3 at last six months. I use my proprietary board with array of leds and array of contactors (contactors need pwm for reduce consumption). This changes are need for channels are independent. Otherwise a change of channel A is overwritten when software change channel B immediately.
Also i tested this PR using `zephyr/samples/basic/blinky_pwm` on board `mimxrt1064_evk`.