### PR TITLE
LPC55XXX Update Clock Init

### DIFF
--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -27,6 +27,12 @@
 			};
 		};
 	};
+
+	sysclk: system-clock {
+		compatible = "fixed-clock";
+		clock-frequency = <96000000>;
+		#clock-cells = <0>;
+	};
 };
 
 &sram {
@@ -68,6 +74,8 @@
 	syscon: syscon@0 {
 		compatible = "nxp,lpc-syscon";
 		reg = <0x0 0x4000>;
+		clocks = <&sysclk>;
+		clock-names = "sysclk";
 		#clock-cells = <1>;
 	};
 

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -28,6 +28,11 @@
 			};
 		};
 	};
+	sysclk: system-clock {
+		compatible = "fixed-clock";
+		clock-frequency = <150000000>;
+		#clock-cells = <0>;
+	};
 };
 
 &sram {
@@ -71,6 +76,8 @@
 	syscon: syscon@0 {
 		compatible = "nxp,lpc-syscon";
 		reg = <0x0 0x4000>;
+		clocks = <&sysclk>;
+		clock-names = "sysclk";
 		#clock-cells = <1>;
 	};
 

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -79,6 +79,16 @@
 		clocks = <&sysclk>;
 		clock-names = "sysclk";
 		#clock-cells = <1>;
+
+		pll1 {
+			compatible = "pll-config";
+			pll-ctrl-seli = <53>;
+			pll-ctrl-selp = <31>;
+			pll-ndec-ndiv = <8>;
+			pll-pdec-pdiv = <1>;
+			pll-mdec-mdiv = <150>;
+			pll-rate = <150000000>;
+		};
 	};
 
 	iap: flash-controller@34000 {

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -87,6 +87,16 @@
 		clocks = <&sysclk>;
 		clock-names = "sysclk";
 		#clock-cells = <1>;
+
+		pll1 {
+			compatible = "pll-config";
+			pll-ctrl-seli = <53>;
+			pll-ctrl-selp = <31>;
+			pll-ndec-ndiv = <8>;
+			pll-pdec-pdiv = <1>;
+			pll-mdec-mdiv = <150>;
+			pll-rate = <150000000>;
+		};
 	};
 
 	iap: flash-controller@34000 {

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -36,6 +36,12 @@
 			};
 		};
 	};
+
+	sysclk: system-clock {
+		compatible = "fixed-clock";
+		clock-frequency = <150000000>;
+		#clock-cells = <0>;
+	};
 };
 
 &sram {
@@ -78,6 +84,8 @@
 	syscon: syscon@0 {
 		compatible = "nxp,lpc-syscon";
 		reg = <0x0 0x1000>;
+		clocks = <&sysclk>;
+		clock-names = "sysclk";
 		#clock-cells = <1>;
 	};
 

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -84,6 +84,16 @@
 		clocks = <&sysclk>;
 		clock-names = "sysclk";
 		#clock-cells = <1>;
+
+		pll1 {
+			compatible = "pll-config";
+			pll-ctrl-seli = <53>;
+			pll-ctrl-selp = <31>;
+			pll-ndec-ndiv = <8>;
+			pll-pdec-pdiv = <1>;
+			pll-mdec-mdiv = <150>;
+			pll-rate = <150000000>;
+		};
 	};
 
 	iap: flash-controller@34000 {

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -32,6 +32,12 @@
 			};
 		};
 	};
+
+	sysclk: system-clock {
+		compatible = "fixed-clock";
+		clock-frequency = <150000000>;
+		#clock-cells = <0>;
+	};
 };
 
 &sram {
@@ -75,6 +81,8 @@
 	syscon: syscon@0 {
 		compatible = "nxp,lpc-syscon";
 		reg = <0x0 0x1000>;
+		clocks = <&sysclk>;
+		clock-names = "sysclk";
 		#clock-cells = <1>;
 	};
 

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -40,6 +40,11 @@
 			reg = <1>;
 		};
 	};
+	sysclk: system-clock {
+		compatible = "fixed-clock";
+		clock-frequency = <150000000>;
+		#clock-cells = <0>;
+	};
 };
 
 &sram {
@@ -98,7 +103,29 @@
 	syscon: syscon@0 {
 		compatible = "nxp,lpc-syscon";
 		reg = <0x0 0x1000>;
+		clocks = <&sysclk>;
+		clock-names = "sysclk";
 		#clock-cells = <1>;
+
+		pll0 {
+			compatible = "pll-config";
+			pll-ctrl-seli = <2>;
+			pll-ctrl-selp = <31>;
+			pll-ndec-ndiv = <125>;
+			pll-pdec-pdiv = <8>;
+			pll-sscg1-mdiv = <3072>;
+			pll-rate = <24576000>;
+		};
+
+		pll1 {
+			compatible = "pll-config";
+			pll-ctrl-seli = <53>;
+			pll-ctrl-selp = <31>;
+			pll-ndec-ndiv = <8>;
+			pll-pdec-pdiv = <1>;
+			pll-mdec-mdiv = <150>;
+			pll-rate = <150000000>;
+		};
 	};
 
 	iap: flash-controller@34000 {

--- a/dts/bindings/clock/pll-config.yaml
+++ b/dts/bindings/clock/pll-config.yaml
@@ -1,0 +1,42 @@
+# Copyright NXP 2022
+# SPDX-License-Identifier: Apache-2.0
+
+description: Generic fixed-rate clock provider
+
+compatible: "pll-config"
+
+properties:
+    pll-ctrl-seli:
+      type: int
+      description: Bandwidth select I value
+      required: true
+
+    pll-ctrl-selp:
+      type: int
+      description: Bandwidth select P value
+      required: true
+
+    pll-ndec-ndiv:
+      type: int
+      description: PLL 550m Pre Divider
+      required: true
+
+    pll-pdec-pdiv:
+      type: int
+      description: PPL 550m Post Divider
+      required: true
+
+    pll-sscg1-mdiv:
+      type: int
+      description: PLL0 Spread Spectrum Control
+      required: false
+
+    pll-mdec-mdiv:
+      type: int
+      description: PLL1 Feddback ratio
+      required: false
+
+    pll-rate:
+      type: int
+      description: PLL clock frequency (Hz)
+      required: true


### PR DESCRIPTION
Updated the Clock Init function in the SOC
of the LPC55XXX to reflect the NXP MCUXpresso SDK,
added the initialization of dual PLL usage. 
By default, the PLL usage is one for the main
clock on higher frequency SOCs and another
PLL for I2S
