### PR TITLE
Bluetooth: Audio: Fix issue with non-bonded devices in has.c

### DIFF
--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -200,7 +200,8 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 
 	LOG_DBG("conn %p level %d err %d", (void *)conn, level, err);
 
-	if (err != BT_SECURITY_ERR_SUCCESS) {
+	if (err != BT_SECURITY_ERR_SUCCESS ||
+	    !bt_addr_le_is_bonded(conn->id, &conn->le.dst)) {
 		return;
 	}
 


### PR DESCRIPTION
The HAS implementation of the security_changed callback expected all devices to have bonded, and thus always added them to the ntf_bonded implementation.

This adds a check to whether the device is actually bonded.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>