### PR TITLE
Bluetooth: Audio: Fix logging of object ID in mcc.c

### DIFF
--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -2305,7 +2305,7 @@ int bt_mcc_set_current_track_obj_id(struct bt_conn *conn, uint64_t obj_id)
 	}
 
 	CHECKIF(obj_id < BT_OTS_OBJ_ID_MIN || obj_id > BT_OTS_OBJ_ID_MAX) {
-		LOG_DBG("Object ID 0x%016x invalid", obj_id);
+		LOG_DBG("Object ID 0x%016llx invalid", obj_id);
 		return -EINVAL;
 	}
 
@@ -2390,7 +2390,7 @@ int bt_mcc_set_next_track_obj_id(struct bt_conn *conn, uint64_t obj_id)
 	}
 
 	CHECKIF(obj_id < BT_OTS_OBJ_ID_MIN || obj_id > BT_OTS_OBJ_ID_MAX) {
-		LOG_DBG("Object ID 0x%016x invalid", obj_id);
+		LOG_DBG("Object ID 0x%016llx invalid", obj_id);
 		return -EINVAL;
 	}
 
@@ -2513,7 +2513,7 @@ int bt_mcc_set_current_group_obj_id(struct bt_conn *conn, uint64_t obj_id)
 	}
 
 	CHECKIF(obj_id < BT_OTS_OBJ_ID_MIN || obj_id > BT_OTS_OBJ_ID_MAX) {
-		LOG_DBG("Object ID 0x%016x invalid", obj_id);
+		LOG_DBG("Object ID 0x%016llx invalid", obj_id);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
mcc.c used 0x%016x, but for some platforms we need to be more explicit and use 0x%016llx to avoid compile warnings.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>