### PR TITLE
Bluetooth: Host: Fix issue with setting 0/NULL data for PA

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1810,7 +1810,7 @@ int bt_le_per_adv_set_data(const struct bt_le_ext_adv *adv,
 		return -EINVAL;
 	}
 
-	if (!ad_len || !ad) {
+	if (ad_len != 0 && ad == NULL) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
bt_le_per_adv_set_data would not accept the ad to be NULL or the ad_len to be 0, making it impossible to set no data (which effectively clears existing data).

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>