### PR TITLE
Bluetooth: Host: Add length values to malformed adv data warning

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4047,7 +4047,8 @@ void bt_data_parse(struct net_buf_simple *ad,
 		}
 
 		if (len > ad->len) {
-			LOG_WRN("malformed advertising data");
+			LOG_WRN("malformed advertising data %u / %u",
+				len, ad->len);
 			return;
 		}
 


### PR DESCRIPTION
Add the advertised length, and the actual length, in the log statement so it is more clear what the issue is.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>