### PR TITLE
Bluetooth: Audio: Shell: Add missing metadata type

### DIFF
--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -734,6 +734,7 @@ static int handle_metadata_update(const char *meta_str,
 		(void)memcpy(meta[i].value,
 			     default_preset->preset.codec.meta[i].data.data,
 			     default_preset->preset.codec.meta[i].data.data_len);
+		meta[i].data.type = default_preset->preset.codec.meta[i].data.type;
 		meta[i].data.data_len = default_preset->preset.codec.meta[i].data.data_len;
 		meta[i].data.data = meta[i].value;
 	}


### PR DESCRIPTION
In handle_metadata_update the metadata type was never copied, causing it to always be 0.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>