### PR TITLE
doc: application development: fix DT overlay section

### DIFF
--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -517,7 +517,7 @@ worth going through, especially if you planning to add new configuration
 options.
 
 Experimental features
-*********************
+~~~~~~~~~~~~~~~~~~~~~
 
 Zephyr is a project under constant development and thus there are features that
 are still in early stages of their development cycle. Such features will be


### PR DESCRIPTION
Commit f17630ba7501cabb40a4d57a4892a1a5bd0603ff ("doc: application: added description of WARN_EXPERIMENTAL setting") introduced a new section in the Kconfig settings bit about experimental features.

This broke the structure of the document, however, because it used the wrong kind of section underline, resulting in a hierarchy that looks like this:

```
   Application Configuration
   └── Kconfig Configuration
   Experimental Features
   └── Devicetree Overlays
```

when it should have looked like this:

```
   Application Configuration
   ├── Kconfig Configuration
   |   └── Experimental Features
   └── Devicetree Overlays
```

This falsely make it look like DT overlays are an experimental feature!

Fix it.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>