### PR TITLE
Bluetooth: Controller: legacy conn param req caching and max central data PDU spacing

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -459,6 +459,20 @@ config BT_CTLR_CENTRAL_SPACING
 	  (active clock jitter) + 17040 (PDU rx) = (radio event overheads +
 	  34234) microseconds.
 
+config BT_CTLR_CENTRAL_RESERVE_MAX
+	bool "Use maximum data PDU size time reservation for Central"
+	depends on BT_CENTRAL
+	default y
+	help
+	  Use the maximum data PDU size time reservation considering the Data
+	  length could be updated from default 27 bytes to maximum support size.
+	  If maximum time reservation is disabled then time reservation
+	  corresponding to the default data length at the time of the
+	  start/enable of Central role is used.
+
+	  Note, currently this value is only used to space multiple central
+	  connections and not for actual ticker time reservations.
+
 config BT_CTLR_SLOT_RESERVATION_UPDATE
 	bool "Update event length reservation after PHY or DLE update"
 	depends on !BT_LL_SW_LLCP_LEGACY && (BT_CTLR_DATA_LENGTH || BT_CTLR_PHY)

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1121,6 +1121,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn->llcp_req = conn->llcp_ack = conn->llcp_type = 0;
 		conn->llcp_rx = NULL;
 		conn->llcp_cu.req = conn->llcp_cu.ack = 0;
+		conn->llcp_cu.pause_tx = 0U;
 		conn->llcp_feature.req = conn->llcp_feature.ack = 0;
 		conn->llcp_feature.features_conn = ll_feat_get();
 		conn->llcp_feature.features_peer = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1149,10 +1149,11 @@ uint8_t ll_adv_enable(uint8_t enable)
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
-		conn->llcp_conn_param.req = 0;
-		conn->llcp_conn_param.ack = 0;
-		conn->llcp_conn_param.disabled = 0;
-		conn->periph.ticks_to_offset = 0;
+		conn->llcp_conn_param.req = 0U;
+		conn->llcp_conn_param.ack = 0U;
+		conn->llcp_conn_param.disabled = 0U;
+		conn->llcp_conn_param.cache.timeout = 0U;
+		conn->periph.ticks_to_offset = 0U;
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -314,6 +314,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn->llcp_req = conn->llcp_ack = conn->llcp_type = 0U;
 	conn->llcp_rx = NULL;
 	conn->llcp_cu.req = conn->llcp_cu.ack = 0;
+	conn->llcp_cu.pause_tx = 0U;
 	conn->llcp_feature.req = conn->llcp_feature.ack = 0;
 	conn->llcp_feature.features_conn = ll_feat_get();
 	conn->llcp_feature.features_peer = 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -343,6 +343,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 	conn->llcp_conn_param.req = 0U;
 	conn->llcp_conn_param.ack = 0U;
+	conn->llcp_conn_param.cache.timeout = 0U;
 	conn->llcp_conn_param.disabled = 0U;
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -139,6 +139,7 @@ static inline bool ctrl_is_unexpected(struct ll_conn *conn, uint8_t opcode);
 static inline void event_conn_param_prep(struct ll_conn *conn,
 					 uint16_t event_counter,
 					 uint32_t ticks_at_expire);
+static void cpr_cache_initiate_or_complete(struct ll_conn *conn);
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 
 #if defined(CONFIG_BT_CTLR_LE_PING)
@@ -451,7 +452,21 @@ uint8_t ll_conn_update(uint16_t handle, uint8_t cmd, uint8_t status, uint16_t in
 		} else {
 			if (conn->llcp_conn_param.req !=
 			    conn->llcp_conn_param.ack) {
-				return BT_HCI_ERR_CMD_DISALLOWED;
+				if (!conn->llcp_conn_param.remote ||
+				    conn->llcp_conn_param.cache.timeout) {
+					return BT_HCI_ERR_CMD_DISALLOWED;
+				}
+
+				conn->llcp_conn_param.cache.interval_min =
+					interval_min;
+				conn->llcp_conn_param.cache.interval_max =
+					interval_max;
+				conn->llcp_conn_param.cache.latency =
+					latency;
+				conn->llcp_conn_param.cache.timeout =
+					timeout;
+
+				return BT_HCI_ERR_SUCCESS;
 			}
 
 			conn->llcp_conn_param.status = 0U;
@@ -461,6 +476,7 @@ uint8_t ll_conn_update(uint16_t handle, uint8_t cmd, uint8_t status, uint16_t in
 			conn->llcp_conn_param.timeout = timeout;
 			conn->llcp_conn_param.state = cmd;
 			conn->llcp_conn_param.cmd = 1U;
+			conn->llcp_conn_param.remote = 0U;
 			conn->llcp_conn_param.req++;
 
 			if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
@@ -3272,7 +3288,9 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 			/* procedure request acked */
 			conn->llcp_ack = conn->llcp_req;
 			conn->llcp_cu.ack = conn->llcp_cu.req;
-			conn->llcp_conn_param.ack = conn->llcp_conn_param.req;
+
+			/* Check and initiate new CPR from cache, if any */
+			cpr_cache_initiate_or_complete(conn);
 
 			/* Reset CPR mutex */
 			cpr_active_reset();
@@ -3396,7 +3414,8 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 		if ((conn->llcp_conn_param.req != conn->llcp_conn_param.ack) &&
 		    (conn->llcp_conn_param.state == LLCP_CPR_STATE_UPD)) {
-			conn->llcp_conn_param.ack = conn->llcp_conn_param.req;
+			/* Check and initiate new CPR from cache, if any */
+			cpr_cache_initiate_or_complete(conn);
 
 			/* Stop procedure timeout */
 			conn->procedure_expire = 0U;
@@ -4182,8 +4201,8 @@ static inline void event_conn_param_rsp(struct ll_conn *conn)
 
 		ctrl_tx_enqueue(conn, tx);
 
-		/* procedure request acked */
-		conn->llcp_conn_param.ack = conn->llcp_conn_param.req;
+		/* Check and initiate new CPR from cache, if any */
+		cpr_cache_initiate_or_complete(conn);
 
 		/* Reset CPR mutex */
 		cpr_active_reset();
@@ -5117,7 +5136,8 @@ static uint8_t conn_upd_recv(struct ll_conn *conn, memq_link_t *link,
 	if ((conn->llcp_conn_param.req != conn->llcp_conn_param.ack) &&
 	    ((conn->llcp_conn_param.state == LLCP_CPR_STATE_RSP_WAIT) ||
 	     (conn->llcp_conn_param.state == LLCP_CPR_STATE_UPD_WAIT))) {
-		conn->llcp_conn_param.ack = conn->llcp_conn_param.req;
+		/* Check and initiate new CPR from cache, if any */
+		cpr_cache_initiate_or_complete(conn);
 	}
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 
@@ -5661,8 +5681,8 @@ static inline int reject_ind_conn_upd_recv(struct ll_conn *conn,
 		/* Reset CPR mutex */
 		cpr_active_reset();
 
-		/* Procedure complete */
-		conn->llcp_conn_param.ack = conn->llcp_conn_param.req;
+		/* Check and initiate new CPR from cache, if any */
+		cpr_cache_initiate_or_complete(conn);
 
 		/* Stop procedure timeout */
 		conn->procedure_expire = 0U;
@@ -5691,6 +5711,30 @@ static inline int reject_ind_conn_upd_recv(struct ll_conn *conn,
 
 	return 0;
 }
+
+static void cpr_cache_initiate_or_complete(struct ll_conn *conn)
+{
+	if (conn->llcp_conn_param.cache.timeout) {
+		conn->llcp_conn_param.status = 0U;
+		conn->llcp_conn_param.interval_min =
+			conn->llcp_conn_param.cache.interval_min;
+		conn->llcp_conn_param.interval_max =
+			conn->llcp_conn_param.cache.interval_max;
+		conn->llcp_conn_param.latency =
+			conn->llcp_conn_param.cache.latency;
+		conn->llcp_conn_param.timeout =
+			conn->llcp_conn_param.cache.timeout;
+		conn->llcp_conn_param.state = LLCP_CPR_STATE_REQ;
+		conn->llcp_conn_param.cmd = 1U;
+		conn->llcp_conn_param.remote = 0U;
+
+		/* Invalidate cache */
+		conn->llcp_conn_param.cache.timeout = 0U;
+	} else {
+		conn->llcp_conn_param.ack = conn->llcp_conn_param.req;
+	}
+}
+
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
@@ -7343,6 +7387,8 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 						NODE_RX_TYPE_RELEASE;
 				}
 
+				conn->llcp_conn_param.remote = 1U;
+
 				conn->llcp_conn_param.ack--;
 
 				/* Set CPR mutex */
@@ -7423,6 +7469,8 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 				/* Mark for buffer for release */
 				(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 			}
+
+			conn->llcp_conn_param.remote = 1U;
 
 			conn->llcp_conn_param.ack--;
 
@@ -7593,8 +7641,8 @@ static inline int ctrl_rx(memq_link_t *link, struct node_rx_pdu **rx,
 			/* Reset CPR mutex */
 			cpr_active_reset();
 
-			/* Procedure complete */
-			conn->llcp_conn_param.ack = conn->llcp_conn_param.req;
+			/* Check and initiate new CPR from cache, if any */
+			cpr_cache_initiate_or_complete(conn);
 
 			/* skip event generation if not cmd initiated */
 			if (!conn->llcp_conn_param.cmd) {

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -243,12 +243,19 @@ struct ll_conn {
 			LLCP_CPR_STATE_OFFS_RDY,
 		} state:4 __packed;
 		uint8_t  cmd:1;
+		uint8_t  remote:1;
 		uint8_t  disabled:1;
 		uint8_t  status;
 		uint16_t interval_min;
 		uint16_t interval_max;
 		uint16_t latency;
 		uint16_t timeout;
+		struct {
+			uint16_t interval_min;
+			uint16_t interval_max;
+			uint16_t latency;
+			uint16_t timeout;
+		} cache;
 		uint8_t  preferred_periodicity;
 		uint16_t reference_conn_event_count;
 		uint16_t offset0;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -169,6 +169,7 @@ struct ll_conn {
 			LLCP_CUI_STATE_REJECT,
 		} state:3 __packed;
 		uint8_t  cmd:1;
+		uint8_t  pause_tx:1;
 		uint16_t interval;
 		uint16_t latency;
 		uint16_t timeout;

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
-
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/bluetooth/hci.h>
 
 #include "hal/ccm.h"
 #include "hal/radio.h"
@@ -44,7 +43,7 @@
 #include "ull_adv_internal.h"
 #include "ull_conn_internal.h"
 
-#include <zephyr/bluetooth/hci.h>
+#include "ll_feat.h"
 
 #include "hal/debug.h"
 
@@ -875,8 +874,46 @@ static struct ull_hdr *ull_hdr_get_cb(uint8_t ticker_id, uint32_t *ticks_slot)
 
 		conn = ll_conn_get(ticker_id - TICKER_ID_CONN_BASE);
 		if (conn && !conn->lll.role) {
+			uint32_t ticks_slot_conn;
+
+			if (IS_ENABLED(CONFIG_BT_CTLR_CENTRAL_RESERVE_MAX)) {
+				uint32_t ready_delay_us;
+				uint16_t max_tx_time;
+				uint16_t max_rx_time;
+				uint32_t time_us;
+
+#if defined(CONFIG_BT_CTLR_PHY)
+				ready_delay_us =
+					lll_radio_tx_ready_delay_get(conn->lll.phy_tx,
+								     conn->lll.phy_flags);
+#else
+				ready_delay_us =
+					lll_radio_tx_ready_delay_get(0U, 0U);
+#endif
+
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
+				max_tx_time = PDU_DC_MAX_US(LL_LENGTH_OCTETS_TX_MAX,
+							    PHY_CODED);
+				max_rx_time = PDU_DC_MAX_US(LL_LENGTH_OCTETS_RX_MAX,
+							    PHY_CODED);
+#else /* !CONFIG_BT_CTLR_PHY_CODED */
+				max_tx_time = PDU_DC_MAX_US(LL_LENGTH_OCTETS_TX_MAX,
+							    PHY_1M);
+				max_rx_time = PDU_DC_MAX_US(LL_LENGTH_OCTETS_RX_MAX,
+							    PHY_1M);
+#endif /* !CONFIG_BT_CTLR_PHY_CODED */
+
+				time_us = EVENT_OVERHEAD_START_US +
+					  ready_delay_us +  max_rx_time +
+					  EVENT_IFS_US + max_tx_time;
+				ticks_slot_conn =
+					HAL_TICKER_US_TO_TICKS(time_us);
+			} else {
+				ticks_slot_conn = conn->ull.ticks_slot;
+			}
+
 			*ticks_slot =
-				MAX(conn->ull.ticks_slot,
+				MAX(ticks_slot_conn,
 				    HAL_TICKER_US_TO_TICKS(
 					    CONFIG_BT_CTLR_CENTRAL_SPACING));
 

--- a/tests/bluetooth/bsim_bt/bsim_test_multiple/prj.conf
+++ b/tests/bluetooth/bsim_bt/bsim_test_multiple/prj.conf
@@ -45,3 +45,7 @@ CONFIG_BT_CTLR_RX_BUFFERS=6
 # (Event Overhead + Radio Ready Delay + Rx window + 1064 + 154 + 1064)
 CONFIG_BT_CTLR_ADVANCED_FEATURES=y
 CONFIG_BT_CTLR_CENTRAL_SPACING=3750
+
+# Do not use max data PDU size time reservation for connection events spacing
+# instead use lesser value as supplied in CONFIG_BT_CTLR_CENTRAL_SPACING
+CONFIG_BT_CTLR_CENTRAL_RESERVE_MAX=n

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/ll.set1.test_list
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/ll.set1.test_list
@@ -35,7 +35,7 @@ LL/CON/CEN/BV-21-C
 LL/CON/CEN/BV-23-C
 LL/CON/CEN/BV-24-C
 LL/CON/CEN/BV-25-C
-LL/CON/CEN/BV-26-C
+#LL/CON/CEN/BV-26-C # This test case is not valid, and will fail with CPR cache
 LL/CON/CEN/BV-27-C
 LL/CON/CEN/BV-29-C
 LL/CON/CEN/BV-30-C


### PR DESCRIPTION
Fix legacy control procedure implementation to avoid
connection update procedure with reason instant passed
(0x28).

Connection Update Indication PDU is enqueued after data
enqueue to LLL context is paused and the enqueue resumes
when already enqueued data PDUs are all acknowledged.

Fix connection parameter request  procedure to be cacheable
if a remote control procedure is in progress.

Use the maximum data PDU size time reservation space
considering the Data length could be updated from default
27 bytes to maximum support size.

If maximum time reservation is disabled then time space
reservation corresponding to the default data length at the
time of the start/enable of Central role is used.

Note, currently this value is only used to space multiple central
connections and not for actual ticker time reservations.

Relates to https://github.com/zephyrproject-rtos/zephyr/issues/53007

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>