### PR TITLE
net: shell: Make it possible to abort ping command

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1690,6 +1690,10 @@ void shell_set_bypass(const struct shell *sh, shell_bypass_cb_t bypass)
 	__ASSERT_NO_MSG(sh);
 
 	sh->ctx->bypass = bypass;
+
+	if (bypass == NULL) {
+		cmd_buffer_clear(sh);
+	}
 }
 
 bool shell_ready(const struct shell *sh)


### PR DESCRIPTION
Rewrite the ping command, so that instead of blocking shell thread, it works on top of system workqueue. This allows to use `shell_set_bypass()` functionality to capture input, and implement `CTRL-C` handling to abort the ping command.

@nordic-krch @jakub-uC Please review the change in the shell module itself - during the implementation I've faced an issue, that when bypass mode is left from a thread other than shell thread (i. e. not from the registered callback), the internal command buffer contained leftovers from processing the previous command, causing undefined behavior on the next input.

Fixes #49844