### PR TITLE
tfm: Add TF-M interface include headers always

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/CMakeLists.txt
+++ b/boards/arm/nrf5340dk_nrf5340/CMakeLists.txt
@@ -6,10 +6,4 @@ if ((CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP OR CONFIG_BOARD_NRF5340DK_NRF5340_CPU
 zephyr_library()
 zephyr_library_sources(nrf5340_cpunet_reset.c)
 
-if (CONFIG_BUILD_WITH_TFM)
-  zephyr_library_include_directories(
-    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-  )
-endif()
-
 endif()

--- a/drivers/entropy/CMakeLists.txt
+++ b/drivers/entropy/CMakeLists.txt
@@ -22,9 +22,3 @@ zephyr_library_sources_ifdef(CONFIG_ENTROPY_NEORV32_TRNG       entropy_neorv32_t
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_BT_HCI             entropy_bt_hci.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_GECKO_SE           entropy_gecko_se.c)
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_PSA_CRYPTO_RNG     entropy_psa_crypto.c)
-
-if (CONFIG_BUILD_WITH_TFM)
-  target_include_directories(${ZEPHYR_CURRENT_LIBRARY} PRIVATE
-    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-  )
-endif()

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -408,9 +408,6 @@ if (CONFIG_BUILD_WITH_TFM)
 
   zephyr_include_directories(
     ${TFM_GENERATED_INCLUDES}
-    )
-
-  target_include_directories(tfm_api PRIVATE
     ${TFM_BINARY_DIR}/install/interface/include
     )
 

--- a/samples/drivers/counter/alarm/CMakeLists.txt
+++ b/samples/drivers/counter/alarm/CMakeLists.txt
@@ -6,9 +6,3 @@ project(counter)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
-
-if(CONFIG_BUILD_WITH_TFM)
-  target_include_directories(app PRIVATE
-    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-  )
-endif()

--- a/samples/subsys/usb/mass/CMakeLists.txt
+++ b/samples/subsys/usb/mass/CMakeLists.txt
@@ -12,9 +12,3 @@ endif()
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
-
-if(CONFIG_BUILD_WITH_TFM)
-  target_include_directories(app PRIVATE
-    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-  )
-endif()

--- a/samples/tfm_integration/psa_crypto/CMakeLists.txt
+++ b/samples/tfm_integration/psa_crypto/CMakeLists.txt
@@ -15,10 +15,6 @@ target_sources(app PRIVATE src/util_app_cfg.c)
 target_sources(app PRIVATE src/util_app_log.c)
 target_sources(app PRIVATE src/util_sformat.c)
 
-target_include_directories(app PRIVATE
-  $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-)
-
 # In TF-M, default value of CRYPTO_ENGINE_BUF_SIZE is 0x2080. It causes
 # insufficient memory failure while verifying signature. Increase it to 0x2400.
 set_property(TARGET zephyr_property_target

--- a/samples/tfm_integration/psa_firmware/CMakeLists.txt
+++ b/samples/tfm_integration/psa_firmware/CMakeLists.txt
@@ -99,7 +99,3 @@ add_custom_command(
 # Source files in this sample
 # Node (6) in the above graphic
 target_sources(app PRIVATE src/main.c ${UPDATE_OBJ} ${UPDATE_HEADER_OBJ})
-
-target_include_directories(app PRIVATE
-  $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-)

--- a/samples/tfm_integration/psa_protected_storage/CMakeLists.txt
+++ b/samples/tfm_integration/psa_protected_storage/CMakeLists.txt
@@ -11,7 +11,3 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(protected_storage)
 
 target_sources(app PRIVATE src/main.c)
-
-target_include_directories(app PRIVATE
-  $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-)

--- a/samples/tfm_integration/tfm_ipc/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_ipc/CMakeLists.txt
@@ -7,7 +7,3 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tfm_ipc)
 
 target_sources(app PRIVATE src/main.c)
-
-target_include_directories(app PRIVATE
-  $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-)

--- a/samples/tfm_integration/tfm_psa_test/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_psa_test/CMakeLists.txt
@@ -11,7 +11,3 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tfm_psa_storage_test)
 
 target_sources(app PRIVATE src/main.c)
-
-target_include_directories(app PRIVATE
-  $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-)

--- a/samples/tfm_integration/tfm_secure_partition/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_secure_partition/CMakeLists.txt
@@ -27,10 +27,6 @@ target_sources(app PRIVATE
   src/dummy_partition.c
 )
 
-target_include_directories(app PRIVATE
-  $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-)
-
 target_compile_definitions(app
     PRIVATE TFM_PARTITION_DUMMY_PARTITION
 )

--- a/soc/arm/nordic_nrf/common/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/common/CMakeLists.txt
@@ -6,7 +6,4 @@ zephyr_include_directories(.)
 
 if (CONFIG_TFM_PARTITION_PLATFORM)
   zephyr_sources(soc_secure.c)
-  zephyr_library_include_directories(
-    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-  )
 endif()

--- a/tests/arch/arm/arm_thread_swap_tz/CMakeLists.txt
+++ b/tests/arch/arm/arm_thread_swap_tz/CMakeLists.txt
@@ -11,9 +11,3 @@ project(NONE)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
-
-if (CONFIG_BUILD_WITH_TFM)
-  target_include_directories(app PRIVATE
-    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
-  )
-endif()


### PR DESCRIPTION
Add the TF-M interface include headers to the zephyr includes when building with TF-M.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>