### PR TITLE
samples: net: sockets: net_mgmt: Update flash requirement for twister

### DIFF
--- a/samples/net/sockets/net_mgmt/sample.yaml
+++ b/samples/net/sockets/net_mgmt/sample.yaml
@@ -1,6 +1,7 @@
 common:
   harness: net
   depends_on: netif
+  min_flash: 210
   tags: net socket mgmt
 sample:
   description: Test network management socket


### PR DESCRIPTION
The net_mgmt sample enables a lot of features, resulting in pretty large image sizes for various platforms (~200k). At the same time, the sample.yaml for the sample did not specify minimum flash requirement for the sample, causing flash overflows during build in certain cases. This commit fixes this by setting a reasonable flash requirement for the sample.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>