### PR TITLE
Change mentions of "LittleVGL" to "LVGL"

### DIFF
--- a/modules/Kconfig.lvgl
+++ b/modules/Kconfig.lvgl
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config LVGL
-	bool "LittlevGL GUI library"
+	bool "LVGL GUI library"
 	help
-	  This option enables the LittlevGL GUI library.
+	  This option enables the LVGL GUI library.
 
 if LVGL
 

--- a/samples/subsys/display/lvgl/README.rst
+++ b/samples/subsys/display/lvgl/README.rst
@@ -1,7 +1,7 @@
 .. _lvgl-sample:
 
-LittlevGL Basic Sample
-######################
+LVGL Basic Sample
+#################
 
 Overview
 ********
@@ -67,6 +67,6 @@ References
 
 .. target-notes::
 
-.. _LittlevGL Web Page: https://littlevgl.com/
+.. _LVGL Web Page: https://lvgl.io/
 .. _SDL2: https://www.libsdl.org
 .. _RK043FN02H-CT: https://www.nxp.com/products/processors-and-microcontrollers/arm-based-processors-and-mcus/i.mx-applications-processors/i.mx-rt-series/4.3-lcd-panel:RK043FN02H-CT


### PR DESCRIPTION
The project was renamed to LVGL with release 7.0.0, from 2020-05-18.