### PR TITLE
kernel: resolve static analysis false positives

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -258,8 +258,11 @@ void sys_clock_announce(int32_t ticks)
 
 	announce_remaining = ticks;
 
-	while (first() != NULL && first()->dticks <= announce_remaining) {
-		struct _timeout *t = first();
+	struct _timeout *t = first();
+
+	for (t = first();
+	     (t != NULL) && (t->dticks <= announce_remaining);
+	     t = first()) {
 		int dt = t->dticks;
 
 		curr_tick += dt;
@@ -272,8 +275,8 @@ void sys_clock_announce(int32_t ticks)
 		announce_remaining -= dt;
 	}
 
-	if (first() != NULL) {
-		first()->dticks -= announce_remaining;
+	if (t != NULL) {
+		t->dticks -= announce_remaining;
 	}
 
 	curr_tick += announce_remaining;


### PR DESCRIPTION
At least one static analysis tool is flagging a potential NULL derefence in sys_clock_announce()'s tick processing loop where the routine 'first()' is concerned. In practice, this does not occur as ...

  1. The code in question is protected by a spinlock.
  2. 'first()' does not change the contents of anything.

The code has consequently been tweaked to prevent similar such false positives in the future.

Signed-off-by: Peter Mitsis <peter.mitsis@intel.com>