### PR TITLE
stm32wb: ble: hci: Configure rf device clocks using device tree 

### DIFF
--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -405,17 +405,6 @@ static void start_ble_rf(void)
 
 	/* Select wakeup source of BLE RF */
 	LL_RCC_SetRFWKPClockSource(LL_RCC_RFWKP_CLKSOURCE_LSE);
-
-	/* Switch OFF LSI */
-	LL_RCC_LSI2_Disable();
-#else
-	LL_RCC_LSI2_Enable();
-	while (!LL_RCC_LSI2_IsReady()) {
-	}
-
-	/* Select wakeup source of BLE RF */
-	LL_RCC_SetRFWKPClockSource(LL_RCC_RFWKP_CLKSOURCE_LSI);
-	LL_RCC_SetRTCClockSource(LL_RCC_RTC_CLKSOURCE_LSI);
 #endif
 
 	/* HSI48 clock and CLK48 clock source are enabled using the device tree */

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -405,7 +405,6 @@ static void start_ble_rf(void)
 
 	/* Select wakeup source of BLE RF */
 	LL_RCC_SetRFWKPClockSource(LL_RCC_RFWKP_CLKSOURCE_LSE);
-	LL_RCC_SetRTCClockSource(LL_RCC_RTC_CLKSOURCE_LSE);
 
 	/* Switch OFF LSI */
 	LL_RCC_LSI2_Disable();

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -387,25 +387,8 @@ static int bt_ipm_send(struct net_buf *buf)
 
 static void start_ble_rf(void)
 {
-	if ((LL_RCC_IsActiveFlag_PINRST()) && (!LL_RCC_IsActiveFlag_SFTRST())) {
-		/* Simulate power off reset */
-		LL_PWR_EnableBkUpAccess();
-		LL_PWR_EnableBkUpAccess();
-		LL_RCC_ForceBackupDomainReset();
-		LL_RCC_ReleaseBackupDomainReset();
-	}
-
-#if STM32_LSE_ENABLED
-	/* Configure driving capability */
-	LL_RCC_LSE_SetDriveCapability(STM32_LSE_DRIVING << RCC_BDCR_LSEDRV_Pos);
-	/* Select LSE clock */
-	LL_RCC_LSE_Enable();
-	while (!LL_RCC_LSE_IsReady()) {
-	}
-
 	/* Select wakeup source of BLE RF */
 	LL_RCC_SetRFWKPClockSource(LL_RCC_RFWKP_CLKSOURCE_LSE);
-#endif
 
 	/* HSI48 clock and CLK48 clock source are enabled using the device tree */
 #if !STM32_HSI48_ENABLED

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -467,6 +467,12 @@
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;
 	};
+
+	ble_rf: ble_rf {
+		compatible = "st,stm32wb-rf";
+		clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00100000>,
+				<&rcc STM32_SRC_LSE RFWKP_SEL(1)>;
+	};
 };
 
 &nvic {

--- a/dts/bindings/bluetooth/st,stm32wb-ble-rf.yaml
+++ b/dts/bindings/bluetooth/st,stm32wb-ble-rf.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    STM32WB Radio device
+
+compatible: "st,stm32wb-rf"
+
+include: base.yaml
+
+properties:
+    clocks:
+      required: true

--- a/include/zephyr/dt-bindings/clock/stm32wb_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wb_clock.h
@@ -26,14 +26,15 @@
 #define STM32_SRC_LSE		0x003
 #define STM32_SRC_LSI		0x004
 #define STM32_SRC_MSI		0x005
+#define STM32_SRC_HSE		0x006
 /** System clock */
-#define STM32_SRC_SYSCLK	0x006
+#define STM32_SRC_SYSCLK	0x007
 /** Bus clock */
-#define STM32_SRC_PCLK		0x007
+#define STM32_SRC_PCLK		0x008
 /** PLL clock outputs */
-#define STM32_SRC_PLL_P		0x008
-#define STM32_SRC_PLL_Q		0x009
-#define STM32_SRC_PLL_R		0x00a
+#define STM32_SRC_PLL_P		0x009
+#define STM32_SRC_PLL_Q		0x00a
+#define STM32_SRC_PLL_R		0x00b
 /* TODO: PLLSAI clocks */
 
 #define STM32_CLOCK_REG_MASK    0xFFU
@@ -70,6 +71,9 @@
 /** @brief RCC_BDCR register offset */
 #define BDCR_REG		0x90
 
+/** @brief RCC_CSR register offset */
+#define CSR_REG		0x94
+
 /** @brief Device domain clocks selection helpers */
 /** CCIPR devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CCIPR_REG)
@@ -84,5 +88,7 @@
 #define RNG_SEL(val)		STM32_CLOCK(val, 3, 30, CCIPR_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+/** CSR devices */
+#define RFWKP_SEL(val)		STM32_CLOCK(val, 3, 14, CSR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WB_CLOCK_H_ */


### PR DESCRIPTION
Add a dt node to describe rf device in stm32wb.
Use it to provide RF clock configuration.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/31959