### PR TITLE
twister: Platform key for test suites

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -147,6 +147,8 @@ name:
   The actual name of the board as it appears in marketing material.
 type:
   Type of the board or configuration, currently we support 2 types: mcu, qemu
+simulation:
+  Simulator used to simulate the platform, e.g. qemu.
 arch:
   Architecture of the board
 toolchain:

--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -375,6 +375,25 @@ harness: <string>
     Usually pertains to external dependency domains but can be anything such as
     console, sensor, net, keyboard, Bluetooth or pytest.
 
+platform_key: <list of platform attributes>
+    Often a test needs to only be built and run once to qualify as passing.
+    Imagine a library of code that depends on the platform architecture where
+    passing the test on a single platform for each arch is enough to qualify the
+    tests and code as passing. The platform_key attribute enables doing just
+    that.
+
+    For example to key on (arch, simulation) to ensure a test is run once
+    per arch and simulation (as would be most common)::
+
+      platform_key:
+        - arch
+        - simulation
+
+    Adding platform (board) attributes to include things such as soc name,
+    soc family, and perhaps sets of IP blocks implementing each peripheral
+    interface would enable other interesting uses. For example, this could enable
+    building and running SPI tests once for eacn unique IP block.
+
 harness_config: <harness configuration options>
     Extra harness configuration options to be used to select a board and/or
     for handling generic Console with regex matching. Config can announce

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -33,6 +33,7 @@ class TwisterConfigParser:
                        "platform_type": {"type": "list", "default": []},
                        "platform_exclude": {"type": "set"},
                        "platform_allow": {"type": "set"},
+                       "platform_key": {"type": "list", "default": []},
                        "toolchain_exclude": {"type": "set"},
                        "toolchain_allow": {"type": "set"},
                        "filter": {"type": "str"},

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -356,6 +356,9 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         help="Upon test failure, print relevant log data to stdout "
              "instead of just a path to it.")
 
+    parser.add_argument("--ignore-platform-key", action="store_true",
+                        help="Do not filter based on platform key")
+
     parser.add_argument(
         "-j", "--jobs", type=int,
         help="Number of jobs for building, defaults to number of CPU threads, "

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -115,6 +115,12 @@ mapping:
         required: false
         sequence:
           - type: str
+      "platform_key":
+        required: false
+        type: seq
+        matching: "all"
+        sequence:
+          - type: str
       "tags":
         type: str
         required: false
@@ -270,6 +276,12 @@ mapping:
           "platform_type":
             type: seq
             required: false
+            sequence:
+              - type: str
+          "platform_key":
+            required: false
+            type: seq
+            matching: "all"
             sequence:
               - type: str
           "tags":

--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -3,6 +3,9 @@ common:
     - qemu
     - native
   tags: log_api logging
+  platform_key:
+    - arch
+    - simulation
   integration_platforms:
     - native_posix
 tests:

--- a/tests/subsys/rtio/rtio_api/testcase.yaml
+++ b/tests/subsys/rtio/rtio_api/testcase.yaml
@@ -1,3 +1,7 @@
+common:
+  platform_key:
+    - arch
+    - simulation
 tests:
   subsys.rtio.api:
     filter: not CONFIG_ARCH_HAS_USERSPACE


### PR DESCRIPTION
Adds an option to inform twister a testsuite should only be built and
run for platforms with unique sets of attributes. This enables
for example keying on unique (arch, simulation) platforms to run the test
suite on.

The most common usage may be test suites configured to run once per 
(arch, simulation) pair as being enough. Additional information about
platforms may enable running a test once per hardware IP block or once 
per soc family or soc avoiding duplicated effort in building and running \
tests when once suffices.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>
