### PR TITLE
drivers: hwinfo: stm32: Deal with iwdgX and wwdgX instances

### DIFF
--- a/drivers/hwinfo/hwinfo_stm32.c
+++ b/drivers/hwinfo/hwinfo_stm32.c
@@ -51,8 +51,28 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 		flags |= RESET_WATCHDOG;
 	}
 #endif
+#if defined(RCC_RSR_IWDG1RSTF)
+	if (LL_RCC_IsActiveFlag_IWDG1RST()) {
+		flags |= RESET_WATCHDOG;
+	}
+#endif
+#if defined(RCC_RSR_IWDG2RSTF)
+	if (LL_RCC_IsActiveFlag_IWDG2RST()) {
+		flags |= RESET_WATCHDOG;
+	}
+#endif
 #if defined(RCC_FLAG_WWDGRST)
 	if (LL_RCC_IsActiveFlag_WWDGRST()) {
+		flags |= RESET_WATCHDOG;
+	}
+#endif
+#if defined(RCC_RSR_WWDG1RSTF)
+	if (LL_RCC_IsActiveFlag_WWDG1RST()) {
+		flags |= RESET_WATCHDOG;
+	}
+#endif
+#if defined(RCC_RSR_WWDG2RSTF)
+	if (LL_RCC_IsActiveFlag_WWDG2RST()) {
 		flags |= RESET_WATCHDOG;
 	}
 #endif


### PR DESCRIPTION
On some STM32 series (H7, MP1), iwdg and wwdg have multiple instances. Due to current driver implementation, these wdg instances were not checked in the function.

Fixes #53002

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>