### PR TITLE
Bluetooth: Optimize calls to bt_data_parse to get names a few places

### DIFF
--- a/samples/bluetooth/iso_broadcast_benchmark/src/receiver.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/receiver.c
@@ -86,16 +86,16 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 		return;
 	}
 
+	if (info->interval == 0U) {
+		/* Not broadcast periodic advertising - Ignore */
+		return;
+	}
+
 	(void)memset(name, 0, sizeof(name));
 
 	bt_data_parse(buf, data_cb, name);
 
 	if (strncmp(DEVICE_NAME, name, strlen(DEVICE_NAME))) {
-		return;
-	}
-
-	if (info->interval == 0U) {
-		/* Not broadcast periodic advertising - Ignore */
 		return;
 	}
 

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -194,21 +194,21 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 	char le_addr[BT_ADDR_LE_STR_LEN];
 	char name[NAME_LEN];
 
-	(void)memset(name, 0, sizeof(name));
-
-	bt_data_parse(buf, data_cb, name);
-
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
-
-	if (scan_filter.name_set && !is_substring(scan_filter.name, name)) {
+	if (scan_filter.rssi_set && (scan_filter.rssi > info->rssi)) {
 		return;
 	}
+
+	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	if (scan_filter.addr_set && !is_substring(scan_filter.addr, le_addr)) {
 		return;
 	}
 
-	if (scan_filter.rssi_set && (scan_filter.rssi > info->rssi)) {
+	(void)memset(name, 0, sizeof(name));
+
+	bt_data_parse(buf, data_cb, name);
+
+	if (scan_filter.name_set && !is_substring(scan_filter.name, name)) {
 		return;
 	}
 


### PR DESCRIPTION
Since parsing all the advertising data to find the name is a costly operation, it is usually placed last. 