### PR TITLE
Bluetooth: Audio: Remove unicast_group_valid_qos

### DIFF
--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -727,18 +727,6 @@ int bt_audio_stream_connect(struct bt_audio_stream *stream)
 	}
 }
 
-static bool unicast_group_valid_qos(const struct bt_codec_qos *group_qos,
-				    const struct bt_codec_qos *stream_qos)
-{
-	if (group_qos->framing != stream_qos->framing ||
-	    group_qos->interval != stream_qos->interval ||
-	    group_qos->latency != stream_qos->latency) {
-		return false;
-	}
-
-	return true;
-}
-
 static struct bt_audio_iso *get_new_iso(struct bt_audio_unicast_group *group,
 					struct bt_conn *acl,
 					enum bt_audio_dir dir)
@@ -1018,10 +1006,6 @@ int bt_audio_unicast_group_create(struct bt_audio_unicast_group_param *param,
 
 		if (group_qos == NULL) {
 			group_qos = stream_param->qos;
-		} else if (!unicast_group_valid_qos(group_qos,
-						    stream_param->qos)) {
-			LOG_DBG("Stream[%zu] QoS incompatible with group QoS", i);
-			return -EINVAL;
 		}
 
 		CHECKIF(!bt_audio_valid_qos(stream_param->qos)) {
@@ -1107,9 +1091,6 @@ int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_gr
 
 		if (group_qos == NULL) {
 			group_qos = params[i].qos;
-		} else if (!unicast_group_valid_qos(group_qos, params[i].qos)) {
-			LOG_DBG("Stream[%zu] QoS incompatible with group QoS", i);
-			return -EINVAL;
 		}
 	}
 


### PR DESCRIPTION
The function checked several value, but the BAP spec does not specify that these cannot be different from stream to stream in the CIG. The function thus did nothing but needlessly restrict the upper layers.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>