### PR TITLE
drivers: usb_dc_stm32: implement usb_dc_wakeup_request

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -53,6 +53,7 @@ config USB_DC_STM32
 	select USE_STM32_HAL_PCD
 	select USE_STM32_HAL_PCD_EX
 	select USB_DC_HAS_HS_SUPPORT if "$(DT_STM32_USBHS_SPEED)"
+	imply USB_DEVICE_REMOTE_WAKEUP
 	help
 	  Enable STM32 family USB device controller shim driver.
 

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -1038,6 +1038,26 @@ int usb_dc_ep_mps(const uint8_t ep)
 	return ep_state->ep_mps;
 }
 
+int usb_dc_wakeup_request(void)
+{
+	HAL_StatusTypeDef status;
+
+	status = HAL_PCD_ActivateRemoteWakeup(&usb_dc_stm32_state.pcd);
+	if (status != HAL_OK) {
+		return -EAGAIN;
+	}
+
+	/* Must be active from 1ms to 15ms as per reference manual. */
+	k_sleep(K_MSEC(2));
+
+	status = HAL_PCD_DeActivateRemoteWakeup(&usb_dc_stm32_state.pcd);
+	if (status != HAL_OK) {
+		return -EAGAIN;
+	}
+
+	return 0;
+}
+
 int usb_dc_detach(void)
 {
 	HAL_StatusTypeDef status;


### PR DESCRIPTION
Hi, this implements remote wakeup support on STM32 and enables the option by default (same as for USB_NRFX). Tested using the `samples/subsys/usb/hid-mouse` on a `nucleo_h745zi_q_m7`.

-- 8< --

Implement usb_dc_wakeup_request for STM32 USB DC and default to enable remote wakeup functionality when the drivers is selected.

This allows the device to wake the host up by calling usb_wakeup_request().