### PR TITLE
fix: Swan DeviceTree Inheritence

### DIFF
--- a/boards/arm/swan_r5/swan_r5.dts
+++ b/boards/arm/swan_r5/swan_r5.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 #include <st/l4/stm32l4r5Xi.dtsi>
-#include <st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi>
+#include <st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi>
 #include "feather_connector.dtsi"
 
 / {


### PR DESCRIPTION
The Swan was originally cloned from the Nucleo-L4R5ZI.

The Nucleo is a sister board, but not identical
and some artifacts from cloning are incorrect.

Signed-off-by: Zachary J. Fields <zachary_fields@yahoo.com>