### PR TITLE
cmake: set PYTHONPATH consistently

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -130,7 +130,7 @@ endif()
 
 zephyr_get(WEST_DIR)
 if(WEST_DIR)
-  set(WEST "PYTHONPATH=${WEST_DIR}/src" "${PYTHON_EXECUTABLE};${WEST_DIR}/src/west/app/main.py;--zephyr-base=${ZEPHYR_BASE} ")
+  set(WEST "PYTHONPATH=${WEST_DIR}/src${SEP}$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE};${WEST_DIR}/src/west/app/main.py;--zephyr-base=${ZEPHYR_BASE} ")
 endif()
 
 # Generate the flash, debug, debugserver, attach targets within the build

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -449,7 +449,7 @@ if (CONFIG_BUILD_WITH_TFM)
       # Add the MCUBoot script to the path so that if there is a version of imgtool in there then
       # it gets used over the system imgtool. Used so that imgtool from upstream
       # mcuboot is preferred over system imgtool
-      ${CMAKE_COMMAND} -E env PYTHONPATH=${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts
+      ${CMAKE_COMMAND} -E env PYTHONPATH=${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts${SEP}$ENV{PYTHONPATH}
       ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/wrapper/wrapper.py
       --layout ${PREPROCESSED_FILE_${SUFFIX}}
       -k ${CONFIG_TFM_KEY_FILE_${SUFFIX}}

--- a/samples/tfm_integration/psa_firmware/CMakeLists.txt
+++ b/samples/tfm_integration/psa_firmware/CMakeLists.txt
@@ -51,7 +51,7 @@ set(TFM_MCUBOOT_DIR "${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/bl2/ext/mcuboot")
 add_custom_command(
   DEPENDS ${CONFIG_APP_FIRMWARE_UPDATE_IMAGE}
   OUTPUT ${UPDATE_SIGNED_HEX}
-  COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts
+  COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts${SEP}$ENV{PYTHONPATH}
     ${PYTHON_EXECUTABLE}
     ${TFM_MCUBOOT_DIR}/scripts/wrapper/wrapper.py
     --layout "${CMAKE_BINARY_DIR}/tfm/bl2/ext/mcuboot/CMakeFiles/signing_layout_ns.dir/signing_layout_ns.o"


### PR DESCRIPTION
When setting PYTHONPATH explicitly we need to keep the user settings so custom build environment works.

This commit fixes following error for me:

,----
| Traceback (most recent call last):
|   File ".../modules/tee/tf-m/trusted-firmware-m/bl2/ext/mcuboot/scripts/wrapper/wrapper.py", line 13, in <module>
|     import click
| ModuleNotFoundError: No module named 'click'
`----

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>