### PR TITLE
stm32: ethernet: mac address: Deprecate Kconfig symbols and generate iud based address by default

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -129,6 +129,11 @@ Deprecated in this release
 
   NOTE: Only functions are marked as ``__deprecated``, type definitions are not.
 
+* STM32 Ethernet Mac address Kconfig related symbols (:kconfig:option:`CONFIG_ETH_STM32_HAL_RANDOM_MAC`,
+  :kconfig:option:`CONFIG_ETH_STM32_HAL_MAC4`, ...) have been deprecated in favor
+  of the use of zephyr generic device tree ``local-mac-address`` and ``zephyr,random-mac-address``
+  properties.
+
 * STM32 RTC source clock should now be configured using devicetree.
   Related Kconfig :kconfig:option:`CONFIG_COUNTER_RTC_STM32_CLOCK_LSI` and
   :kconfig:option:`CONFIG_COUNTER_RTC_STM32_CLOCK_LSE` options are now
@@ -297,6 +302,11 @@ Drivers and Sensors
 
 * Ethernet
 
+  * STM32: Default Mac address configuration is now uid based. Optionally, user can
+    configure it to be random or provide its own address using device tree.
+
+* Flash
+
   * Flash: Moved CONFIG_FLASH_FLEXSPI_XIP into the SOC level due to the flexspi clock initialization occurring in the SOC level.
 
   * NRF: Added CONFIG_SOC_FLASH_NRF_TIMEOUT_MULTIPLIER to allow tweaking the timeout of flash operations.
@@ -392,6 +402,8 @@ Devicetree
     * STM32 SoCs:
 
       * :dtcompatible: `st,stm32-lse-clock`: new ``lse-bypass`` property
+      * :dtcompatible: `st,stm32-ethernet`: now allows ``local-mac-address`` and
+         ``zephyr,random-mac-address`` properties.
 
 Libraries / Subsystems
 **********************

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -50,50 +50,57 @@ config ETH_STM32_HAL_PHY_ADDRESS
 
 choice
 	prompt "Mac address definition method"
+	optional
 	help
 	  The driver supports 2 methods to define 3 last bytes of MAC address
 	  1. Statically defined by user
 	  2. Generated dynamically at each boot
-	  By default random method is used.
+
+	  Note: Configuring this methods using Kconfig is now deprecated in favor
+	  of device tree based configuration.
 
 config ETH_STM32_HAL_RANDOM_MAC
-	bool "Random MAC address"
+	bool "Random MAC address (DEPRECATED)"
 	depends on ENTROPY_GENERATOR
+	select DEPRECATED
 	help
 	  Generate a random MAC address dynamically.
+	  Deprecated in favor of device tree property "zephyr,random-mac-address"
 
 config ETH_STM32_HAL_USER_STATIC_MAC
-	bool "User defined MAC address"
+	bool "User defined MAC address (DEPRECATED)"
+	select DEPRECATED
 	help
 	  3 last bytes of MAC address are defined by user thanks to
 	  ETH_STM32_HAL_MAC3, ETH_STM32_HAL_MAC4 and ETH_STM32_HAL_MAC5.
+	  Deprecated in favor of device tree property "local-mac-address"
 
 endchoice
 
-if !ETH_STM32_HAL_RANDOM_MAC
+if ETH_STM32_HAL_USER_STATIC_MAC
 
 config ETH_STM32_HAL_MAC3
-	hex "MAC Address Byte 3"
+	hex "MAC Address Byte 3 (DEPRECATED)"
 	default 0
 	range 0 0xff
 	help
 	  This is the byte 3 of the MAC address.
 
 config ETH_STM32_HAL_MAC4
-	hex "MAC Address Byte 4"
+	hex "MAC Address Byte 4 (DEPRECATED)"
 	default 0
 	range 0 0xff
 	help
 	  This is the byte 4 of the MAC address.
 
 config ETH_STM32_HAL_MAC5
-	hex "MAC Address Byte 5"
+	hex "MAC Address Byte 5 (DEPRECATED)"
 	default 0
 	range 0 0xff
 	help
 	  This is the byte 5 of the MAC address.
 
-endif # !ETH_STM32_HAL_RANDOM_MAC
+endif # ETH_STM32_HAL_USER_STATIC_MAC
 
 config ETH_STM32_HAL_MII
 	bool "Use MII interface"

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -48,12 +48,27 @@ config ETH_STM32_HAL_PHY_ADDRESS
 	help
 	  The phy address to use.
 
+choice
+	prompt "Mac address definition method"
+	help
+	  The driver supports 2 methods to define 3 last bytes of MAC address
+	  1. Statically defined by user
+	  2. Generated dynamically at each boot
+	  By default random method is used.
+
 config ETH_STM32_HAL_RANDOM_MAC
 	bool "Random MAC address"
 	depends on ENTROPY_GENERATOR
-	default y
 	help
 	  Generate a random MAC address dynamically.
+
+config ETH_STM32_HAL_USER_STATIC_MAC
+	bool "User defined MAC address"
+	help
+	  3 last bytes of MAC address are defined by user thanks to
+	  ETH_STM32_HAL_MAC3, ETH_STM32_HAL_MAC4 and ETH_STM32_HAL_MAC5.
+
+endchoice
 
 if !ETH_STM32_HAL_RANDOM_MAC
 

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -10,6 +10,7 @@ menuconfig ETH_STM32_HAL
 	depends on DT_HAS_ST_STM32_ETHERNET_ENABLED
 	select USE_STM32_HAL_ETH
 	select NOCACHE_MEMORY if SOC_SERIES_STM32H7X && CPU_CORTEX_M7
+	select HWINFO
 	help
 	  Enable STM32 HAL based Ethernet driver. It is available for
 	  all Ethernet enabled variants of the F2, F4, F7 and H7 series.

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -30,6 +30,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
 #include <zephyr/net/lldp.h>
+#include <zephyr/drivers/hwinfo.h>
 
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
 #include <zephyr/drivers/ptp_clock.h>
@@ -1032,6 +1033,9 @@ static void generate_mac(uint8_t *mac_addr)
 	mac_addr[3] = CONFIG_ETH_STM32_HAL_MAC3;
 	mac_addr[4] = CONFIG_ETH_STM32_HAL_MAC4;
 	mac_addr[5] = CONFIG_ETH_STM32_HAL_MAC5;
+#else
+	/* Nothing defined by the user, use device id */
+	hwinfo_get_device_id(&mac_addr[3], 3);
 #endif /* NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(0))) */
 #endif
 }

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -38,6 +38,10 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "eth.h"
 #include "eth_stm32_hal_priv.h"
 
+#if defined(CONFIG_ETH_STM32_HAL_RANDOM_MAC) || DT_INST_PROP(0, zephyr_random_mac_address)
+#define ETH_STM32_RANDOM_MAC
+#endif
+
 #if defined(CONFIG_ETH_STM32_HAL_USE_DTCM_FOR_DMA_BUFFER) && \
 	    !DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)
 #error DTCM for DMA buffer is activated but zephyr,dtcm is not present in dts
@@ -1012,15 +1016,23 @@ void HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth_handle)
 
 static void generate_mac(uint8_t *mac_addr)
 {
-#if defined(CONFIG_ETH_STM32_HAL_RANDOM_MAC)
+#if defined(ETH_STM32_RANDOM_MAC)
+	/* Either CONFIG_ETH_STM32_HAL_RANDOM_MAC or device tree property */
+	/* "zephyr,random-mac-address" is set, generate a random mac address */
 	gen_random_mac(mac_addr, ST_OUI_B0, ST_OUI_B1, ST_OUI_B2);
-#else
+#else /* Use user defined mac address */
 	mac_addr[0] = ST_OUI_B0;
 	mac_addr[1] = ST_OUI_B1;
 	mac_addr[2] = ST_OUI_B2;
+#if NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(0))
+	mac_addr[3] = NODE_MAC_ADDR_OCTET(DT_DRV_INST(0), 3);
+	mac_addr[4] = NODE_MAC_ADDR_OCTET(DT_DRV_INST(0), 4);
+	mac_addr[5] = NODE_MAC_ADDR_OCTET(DT_DRV_INST(0), 5);
+#elif defined(CONFIG_ETH_STM32_HAL_USER_STATIC_MAC)
 	mac_addr[3] = CONFIG_ETH_STM32_HAL_MAC3;
 	mac_addr[4] = CONFIG_ETH_STM32_HAL_MAC4;
 	mac_addr[5] = CONFIG_ETH_STM32_HAL_MAC5;
+#endif /* NODE_HAS_VALID_MAC_ADDR(DT_DRV_INST(0))) */
 #endif
 }
 

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1010,12 +1010,19 @@ void HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth_handle)
 	k_sem_give(&dev_data->rx_int_sem);
 }
 
-#if defined(CONFIG_ETH_STM32_HAL_RANDOM_MAC)
 static void generate_mac(uint8_t *mac_addr)
 {
+#if defined(CONFIG_ETH_STM32_HAL_RANDOM_MAC)
 	gen_random_mac(mac_addr, ST_OUI_B0, ST_OUI_B1, ST_OUI_B2);
-}
+#else
+	mac_addr[0] = ST_OUI_B0;
+	mac_addr[1] = ST_OUI_B1;
+	mac_addr[2] = ST_OUI_B2;
+	mac_addr[3] = CONFIG_ETH_STM32_HAL_MAC3;
+	mac_addr[4] = CONFIG_ETH_STM32_HAL_MAC4;
+	mac_addr[5] = CONFIG_ETH_STM32_HAL_MAC5;
 #endif
+}
 
 static int eth_initialize(const struct device *dev)
 {
@@ -1066,9 +1073,8 @@ static int eth_initialize(const struct device *dev)
 
 	heth = &dev_data->heth;
 
-#if defined(CONFIG_ETH_STM32_HAL_RANDOM_MAC)
 	generate_mac(dev_data->mac_addr);
-#endif
+
 	heth->Init.MACAddr = dev_data->mac_addr;
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_ETH_STM32_HAL_API_V2)
@@ -1368,16 +1374,6 @@ static struct eth_stm32_hal_dev_data eth0_data = {
 			.MediaInterface = ETH_MEDIA_INTERFACE_RMII,
 #endif
 		},
-	},
-	.mac_addr = {
-		ST_OUI_B0,
-		ST_OUI_B1,
-		ST_OUI_B2,
-#if !defined(CONFIG_ETH_STM32_HAL_RANDOM_MAC)
-		CONFIG_ETH_STM32_HAL_MAC3,
-		CONFIG_ETH_STM32_HAL_MAC4,
-		CONFIG_ETH_STM32_HAL_MAC5
-#endif
 	},
 };
 


### PR DESCRIPTION
First, deprecate Kconfig based mac address configuration in profit of existing available device tree properties:
- local-mac-address
- zephyr,random-mac-address

Then, in case user doesn't select any of above options, generate a mac address using device's unique id.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/50947