### PR TITLE
Remove fa_device_id field from flash_area structure.

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -438,6 +438,13 @@ HALs
 MCUboot
 *******
 
+Storage
+*******
+
+* Flash Map API drops ``fa_device_id`` from :c:struct:`flash_area`, as it
+  is no longer needed by MCUboot, and has not been populated for a long
+  time now.
+
 Trusted Firmware-M
 ******************
 

--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -56,8 +56,6 @@ extern "C" {
 struct flash_area {
 	/** ID number */
 	uint8_t fa_id;
-	/** Provided for compatibility with MCUboot */
-	uint8_t fa_device_id;
 	uint16_t pad16;
 	/** Start offset from the beginning of the flash device */
 	off_t fa_off;

--- a/subsys/storage/flash_map/flash_map_shell.c
+++ b/subsys/storage/flash_map/flash_map_shell.c
@@ -24,17 +24,17 @@ static void fa_cb(const struct flash_area *fa, void *user_data)
 {
 	struct shell *shell = user_data;
 
-	shell_print(shell, "%-4d %-8d %-20s  0x%-10x 0x%-12x",
-		    fa->fa_id, fa->fa_device_id, fa->fa_dev->name,
+	shell_print(shell, "%2d   0x%0*"PRIxPTR"   %-26s  0x%-10x 0x%-12x",
+		    (int)fa->fa_id, sizeof(uintptr_t) * 2, (uintptr_t)fa->fa_dev, fa->fa_dev->name,
 		    (uint32_t) fa->fa_off, fa->fa_size);
 }
 
 static int cmd_flash_map_list(const struct shell *shell, size_t argc,
 			      char **argv)
 {
-	shell_print(shell, "ID | Device | Device Name"
-		    "       |   Offset   |   Size");
-	shell_print(shell, "-------------------------"
+	shell_print(shell, "ID | Device     | Device Name               "
+		    "|   Offset   |   Size");
+	shell_print(shell, "-----------------------------------------"
 		    "------------------------------");
 	flash_area_foreach(fa_cb, (struct shell *)shell);
 	return 0;


### PR DESCRIPTION
Three commits:
 1) Switch flash_map shell to use `fa_dev` pointer to identify device rather than `fa_device_id`.
 2) Remove`fa_device_id` from `struct flash_area`.
 3) Release notes update.

The `fa_device_id` has not been populated for some time now, and it is no longer needed by MCUboot, as it does not directly access `flash_area` structures anymore and `flash_area_get_device_id` gives the ID.