### PR TITLE
Bluetooth: Mesh: Add extra flag to control seg msg in frnd queue

### DIFF
--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -135,20 +135,11 @@ static void purge_buffers(sys_slist_t *list)
 
 		buf = (void *)sys_slist_get_not_empty(list);
 
+		buf->frags = NULL;
+		buf->flags &= ~NET_BUF_FRAGS;
+
 		net_buf_unref(buf);
 	}
-}
-
-static void purge_seg_buffers(struct net_buf *buf)
-{
-	/* Fragments head has always 2 references: one when allocated, one when becomes
-	 * fragments head.
-	 */
-	net_buf_unref(buf);
-
-	do {
-		buf = net_buf_frag_del(NULL, buf);
-	} while (buf != NULL);
 }
 
 /* Intentionally start a little bit late into the ReceiveWindow when
@@ -186,10 +177,8 @@ static void friend_clear(struct bt_mesh_friend *frnd)
 	for (i = 0; i < ARRAY_SIZE(frnd->seg); i++) {
 		struct bt_mesh_friend_seg *seg = &frnd->seg[i];
 
-		if (seg->buf) {
-			purge_seg_buffers(seg->buf);
-			seg->seg_count = 0U;
-		}
+		purge_buffers(&seg->queue);
+		seg->seg_count = 0U;
 	}
 
 	STRUCT_SECTION_FOREACH(bt_mesh_friend_cb, cb) {
@@ -1076,7 +1065,7 @@ init_friend:
 
 static bool is_seg(struct bt_mesh_friend_seg *seg, uint16_t src, uint16_t seq_zero)
 {
-	struct net_buf *buf = seg->buf;
+	struct net_buf *buf = (void *)sys_slist_peek_head(&seg->queue);
 	struct net_buf_simple_state state;
 	uint16_t buf_seq_zero;
 	uint16_t buf_src;
@@ -1109,7 +1098,7 @@ static struct bt_mesh_friend_seg *get_seg(struct bt_mesh_friend *frnd,
 			return seg;
 		}
 
-		if (!unassigned && !seg->buf) {
+		if (!unassigned && !sys_slist_peek_head(&seg->queue)) {
 			unassigned = seg;
 		}
 	}
@@ -1144,13 +1133,16 @@ static void enqueue_friend_pdu(struct bt_mesh_friend *frnd,
 		return;
 	}
 
-	seg->buf = net_buf_frag_add(seg->buf, buf);
+	net_buf_slist_put(&seg->queue, buf);
 
 	if (type == BT_MESH_FRIEND_PDU_COMPLETE) {
-		net_buf_slist_put(&frnd->queue, seg->buf);
+		sys_slist_merge_slist(&frnd->queue, &seg->queue);
 
 		frnd->queue_size += seg->seg_count;
 		seg->seg_count = 0U;
+	} else {
+		/* Mark the buffer as having more to come after it */
+		buf->flags |= NET_BUF_FRAGS;
 	}
 }
 
@@ -1267,15 +1259,6 @@ static void friend_timeout(struct k_work *work)
 		return;
 	}
 
-	/* Put next segment to the friend queue. */
-	if (frnd->last != net_buf_frag_last(frnd->last)) {
-		struct net_buf *next;
-
-		next = net_buf_frag_del(NULL, frnd->last);
-		net_buf_frag_add(NULL, next);
-		sys_slist_prepend(&frnd->queue, &next->node);
-	}
-
 	md = (uint8_t)(sys_slist_peek_head(&frnd->queue) != NULL);
 
 	update_overwrite(frnd->last, md);
@@ -1283,6 +1266,10 @@ static void friend_timeout(struct k_work *work)
 	if (encrypt_friend_pdu(frnd, frnd->last, false)) {
 		return;
 	}
+
+	/* Clear the flag we use for segment tracking */
+	frnd->last->flags &= ~NET_BUF_FRAGS;
+	frnd->last->frags = NULL;
 
 	LOG_DBG("Sending buf %p from Friend Queue of LPN 0x%04x", frnd->last, frnd->lpn);
 	frnd->queue_size--;
@@ -1357,11 +1344,16 @@ int bt_mesh_friend_init(void)
 
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.frnd); i++) {
 		struct bt_mesh_friend *frnd = &bt_mesh.frnd[i];
+		int j;
 
 		sys_slist_init(&frnd->queue);
 
 		k_work_init_delayable(&frnd->timer, friend_timeout);
 		k_work_init_delayable(&frnd->clear.timer, clear_timeout);
+
+		for (j = 0; j < ARRAY_SIZE(frnd->seg); j++) {
+			sys_slist_init(&frnd->seg[j].queue);
+		}
 	}
 
 	return 0;
@@ -1655,16 +1647,11 @@ static bool friend_queue_prepare_space(struct bt_mesh_friend *frnd, uint16_t add
 		frnd->queue_size--;
 		avail_space++;
 
-		if (buf != net_buf_frag_last(buf)) {
-			struct net_buf *next;
+		pending_segments = (buf->flags & NET_BUF_FRAGS);
 
-			next = net_buf_frag_del(NULL, buf);
-
-			net_buf_frag_add(NULL, next);
-			sys_slist_prepend(&frnd->queue, &next->node);
-
-			pending_segments = true;
-		}
+		/* Make sure old slist entry state doesn't remain */
+		buf->frags = NULL;
+		buf->flags &= ~NET_BUF_FRAGS;
 
 		net_buf_unref(buf);
 	}
@@ -1785,7 +1772,7 @@ void bt_mesh_friend_clear_incomplete(struct bt_mesh_subnet *sub, uint16_t src,
 
 			LOG_WRN("Clearing incomplete segments for 0x%04x", src);
 
-			purge_seg_buffers(seg->buf);
+			purge_buffers(&seg->queue);
 			seg->seg_count = 0U;
 			break;
 		}

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -67,10 +67,7 @@ struct bt_mesh_friend {
 	struct k_work_delayable timer;
 
 	struct bt_mesh_friend_seg {
-		/* First received segment of a segmented message. Rest
-		 * segments are added as net_buf fragments.
-		 */
-		struct net_buf *buf;
+		sys_slist_t queue;
 
 		/* The target number of segments, i.e. not necessarily
 		 * the current number of segments, in the queue. This is

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.h
@@ -43,13 +43,24 @@
 		bs_trace_info_time(1, "%s PASSED\n", __func__);                \
 	} while (0)
 
-#define ASSERT_OK(cond, ...)                                                   \
+#define ASSERT_OK(cond)                                                        \
 	do {                                                                   \
 		int _err = (cond);                                             \
 		if (_err) {                                                    \
 			bst_result = Failed;                                   \
 			bs_trace_error_time_line(                              \
 				#cond " failed with error %d\n", _err);        \
+		}                                                              \
+	} while (0)
+
+#define ASSERT_OK_MSG(cond, fmt, ...)                                          \
+	do {                                                                   \
+		int _err = (cond);                                             \
+		if (_err) {                                                    \
+			bst_result = Failed;                                   \
+			bs_trace_error_time_line(                              \
+				#cond " failed with error %d\n" fmt, _err,     \
+				##__VA_ARGS__);                                \
 		}                                                              \
 	} while (0)
 

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_access.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_access.c
@@ -471,9 +471,9 @@ static void test_sub_capacity_ext_model(void)
 	 * in the extension linked list.
 	 */
 	for (i = 0; i < 5 * CONFIG_BT_MESH_MODEL_GROUP_COUNT; i++) {
-		ASSERT_OK(bt_mesh_cfg_cli_mod_sub_add(0, UNICAST_ADDR2, UNICAST_ADDR2,
-			GROUP_ADDR + i, TEST_MODEL_ID_2, &status),
-			"Can't deliver subscription on address %#4x", GROUP_ADDR + i);
+		ASSERT_OK_MSG(bt_mesh_cfg_cli_mod_sub_add(0, UNICAST_ADDR2, UNICAST_ADDR2,
+							  GROUP_ADDR + i, TEST_MODEL_ID_2, &status),
+			      "Can't deliver subscription on address %#4x", GROUP_ADDR + i);
 
 		ASSERT_EQUAL(STATUS_SUCCESS, status);
 	}
@@ -482,9 +482,9 @@ static void test_sub_capacity_ext_model(void)
 			TEST_MODEL_ID_3, TEST_MODEL_ID_4, TEST_MODEL_ID_5};
 
 	for (int j = 0; j < ARRAY_SIZE(model_ids); j++) {
-		ASSERT_OK(bt_mesh_cfg_cli_mod_sub_add(0, UNICAST_ADDR2, UNICAST_ADDR2,
-			GROUP_ADDR + i, model_ids[j], &status),
-			"Can't deliver subscription on address %#4x", GROUP_ADDR + i);
+		ASSERT_OK_MSG(bt_mesh_cfg_cli_mod_sub_add(0, UNICAST_ADDR2, UNICAST_ADDR2,
+							  GROUP_ADDR + i, model_ids[j], &status),
+			      "Can't deliver subscription on address %#4x", GROUP_ADDR + i);
 
 		ASSERT_EQUAL(STATUS_INSUFF_RESOURCES, status);
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_advertiser.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_advertiser.c
@@ -68,14 +68,14 @@ static void test_rx_init(void)
 
 static void bt_init(void)
 {
-	ASSERT_OK(bt_enable(NULL), "Bluetooth init failed");
+	ASSERT_OK_MSG(bt_enable(NULL), "Bluetooth init failed");
 	LOG_INF("Bluetooth initialized");
 }
 
 static void adv_init(void)
 {
 	bt_mesh_adv_init();
-	ASSERT_OK(bt_mesh_adv_enable(), "Mesh adv init failed");
+	ASSERT_OK_MSG(bt_mesh_adv_enable(), "Mesh adv init failed");
 }
 
 static void allocate_all_array(struct net_buf **buf, size_t num_buf, uint8_t xmit)
@@ -306,7 +306,7 @@ static void send_order_start_cb(uint16_t duration, int err, void *user_data)
 {
 	struct net_buf *buf = (struct net_buf *)user_data;
 
-	ASSERT_OK(err, "Failed adv start cb err (%d)", err);
+	ASSERT_OK_MSG(err, "Failed adv start cb err (%d)", err);
 	ASSERT_EQUAL(2, buf->len);
 
 	uint8_t current = buf->data[0];
@@ -322,7 +322,7 @@ static void send_order_end_cb(int err, void *user_data)
 {
 	struct net_buf *buf = (struct net_buf *)user_data;
 
-	ASSERT_OK(err, "Failed adv start cb err (%d)", err);
+	ASSERT_OK_MSG(err, "Failed adv start cb err (%d)", err);
 	ASSERT_TRUE(!buf->data, "Data not cleared!");
 	seq_checker++;
 	LOG_INF("tx end: seq(%d)", seq_checker);
@@ -372,7 +372,7 @@ static void receive_order(int expect_adv)
 	previous_checker = 0xff;
 	for (int i = 0; i < expect_adv; i++) {
 		err = k_sem_take(&observer_sem, K_SECONDS(10));
-		ASSERT_OK(err, "Didn't receive adv in time");
+		ASSERT_OK_MSG(err, "Didn't receive adv in time");
 	}
 
 	err = bt_le_scan_stop();
@@ -438,7 +438,7 @@ static void test_tx_cb_single(void)
 	net_buf_unref(buf);
 
 	err = k_sem_take(&observer_sem, K_SECONDS(1));
-	ASSERT_OK(err, "Didn't call end tx cb.");
+	ASSERT_OK_MSG(err, "Didn't call end tx cb.");
 
 	PASS();
 }
@@ -476,7 +476,7 @@ static void test_tx_cb_multi(void)
 	net_buf_unref(buf[0]);
 
 	err = k_sem_take(&observer_sem, K_SECONDS(1));
-	ASSERT_OK(err, "Didn't call the end tx cb that reallocates buffer one more time.");
+	ASSERT_OK_MSG(err, "Didn't call the end tx cb that reallocates buffer one more time.");
 
 	/* Start multi advs to check that all buffers are sent and cbs are triggered. */
 	send_cb.start = seq_start_cb;
@@ -490,7 +490,7 @@ static void test_tx_cb_multi(void)
 	}
 
 	err = k_sem_take(&observer_sem, K_SECONDS(10));
-	ASSERT_OK(err, "Didn't call the last end tx cb.");
+	ASSERT_OK_MSG(err, "Didn't call the last end tx cb.");
 
 	PASS();
 }
@@ -506,7 +506,7 @@ static void test_tx_proxy_mixin(void)
 	/* Initialize mesh stack and enable pb gatt bearer to emit beacons. */
 	bt_mesh_device_setup(&prov, &comp);
 	err = bt_mesh_prov_enable(BT_MESH_PROV_GATT);
-	ASSERT_OK(err, "Failed to enable GATT provisioner");
+	ASSERT_OK_MSG(err, "Failed to enable GATT provisioner");
 
 	/* Let the tester to measure an interval between advertisements.
 	 * The node should advertise pb gatt service with 100 msec interval.
@@ -588,8 +588,8 @@ static void test_tx_send_order(void)
 	send_adv_array(&buf[0], ARRAY_SIZE(buf), false);
 
 	/* Wait for no message receive window to end. */
-	ASSERT_OK(k_sem_take(&observer_sem, K_SECONDS(10)),
-		  "Didn't call the last end tx cb.");
+	ASSERT_OK_MSG(k_sem_take(&observer_sem, K_SECONDS(10)),
+		      "Didn't call the last end tx cb.");
 
 	/* Verify buffer allocation/deallocation after sending */
 	allocate_all_array(buf, ARRAY_SIZE(buf), xmit);
@@ -618,8 +618,8 @@ static void test_tx_reverse_order(void)
 	send_adv_array(&buf[CONFIG_BT_MESH_ADV_BUF_COUNT - 1], ARRAY_SIZE(buf), true);
 
 	/* Wait for no message receive window to end. */
-	ASSERT_OK(k_sem_take(&observer_sem, K_SECONDS(10)),
-		  "Didn't call the last end tx cb.");
+	ASSERT_OK_MSG(k_sem_take(&observer_sem, K_SECONDS(10)),
+		      "Didn't call the last end tx cb.");
 
 	PASS();
 }
@@ -653,8 +653,8 @@ static void test_tx_random_order(void)
 	send_adv_buf(buf[1], 1, 2);
 
 	/* Wait for no message receive window to end. */
-	ASSERT_OK(k_sem_take(&observer_sem, K_SECONDS(10)),
-		  "Didn't call the last end tx cb.");
+	ASSERT_OK_MSG(k_sem_take(&observer_sem, K_SECONDS(10)),
+		      "Didn't call the last end tx cb.");
 
 	PASS();
 }

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_friendship.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_friendship.c
@@ -153,14 +153,14 @@ BT_MESH_LPN_CB_DEFINE(lpn) = {
 static void friend_wait_for_polls(int polls)
 {
 	/* Let LPN poll to get the sent message */
-	ASSERT_OK(evt_wait(FRIEND_POLLED, K_SECONDS(30)), "LPN never polled");
+	ASSERT_OK_MSG(evt_wait(FRIEND_POLLED, K_SECONDS(30)), "LPN never polled");
 
 	while (--polls) {
 		/* Wait for LPN to poll until the "no more data" message.
 		 * At this point, the message has been delivered.
 		 */
-		ASSERT_OK(evt_wait(FRIEND_POLLED, K_SECONDS(2)),
-			  "LPN missing %d polls", polls);
+		ASSERT_OK_MSG(evt_wait(FRIEND_POLLED, K_SECONDS(2)),
+			      "LPN missing %d polls", polls);
 	}
 
 	if (evt_wait(FRIEND_POLLED, K_SECONDS(2)) != -EAGAIN) {
@@ -179,8 +179,8 @@ static void test_friend_est(void)
 
 	bt_mesh_friend_set(BT_MESH_FEATURE_ENABLED);
 
-	ASSERT_OK(evt_wait(FRIEND_ESTABLISHED, K_SECONDS(5)),
-		  "Friendship not established");
+	ASSERT_OK_MSG(evt_wait(FRIEND_ESTABLISHED, K_SECONDS(5)),
+		      "Friendship not established");
 
 	PASS();
 }
@@ -202,8 +202,8 @@ static void test_friend_est_multi(void)
 	bt_mesh_friend_set(BT_MESH_FEATURE_ENABLED);
 
 	for (int i = 0; i < CONFIG_BT_MESH_FRIEND_LPN_COUNT; i++) {
-		ASSERT_OK(evt_wait(FRIEND_ESTABLISHED, K_SECONDS(5)),
-			  "Friendship %d not established", i);
+		ASSERT_OK_MSG(evt_wait(FRIEND_ESTABLISHED, K_SECONDS(5)),
+			      "Friendship %d not established", i);
 	}
 
 	/* Wait for all friends to do at least one poll without terminating */
@@ -226,8 +226,8 @@ static void test_friend_msg(void)
 
 	bt_mesh_friend_set(BT_MESH_FEATURE_ENABLED);
 
-	ASSERT_OK(evt_wait(FRIEND_ESTABLISHED, K_SECONDS(5)),
-		  "Friendship not established");
+	ASSERT_OK_MSG(evt_wait(FRIEND_ESTABLISHED, K_SECONDS(5)),
+		      "Friendship not established");
 	/* LPN polls on establishment. Clear the poll state */
 	evt_clear(FRIEND_POLLED);
 
@@ -235,15 +235,15 @@ static void test_friend_msg(void)
 
 	/* Send unsegmented message from friend to LPN: */
 	LOG_INF("Sending unsegmented message");
-	ASSERT_OK(bt_mesh_test_send(friend_lpn_addr, 5, 0, K_SECONDS(1)),
-		  "Unseg send failed");
+	ASSERT_OK_MSG(bt_mesh_test_send(friend_lpn_addr, 5, 0, K_SECONDS(1)),
+		      "Unseg send failed");
 
 	/* Wait for LPN to poll for message and the "no more messages" msg */
 	friend_wait_for_polls(2);
 
 	/* Send segmented message */
-	ASSERT_OK(bt_mesh_test_send(friend_lpn_addr, 13, 0, K_SECONDS(1)),
-		  "Unseg send failed");
+	ASSERT_OK_MSG(bt_mesh_test_send(friend_lpn_addr, 13, 0, K_SECONDS(1)),
+		      "Unseg send failed");
 
 	/* Two segments require 2 polls plus the "no more messages" msg */
 	friend_wait_for_polls(3);
@@ -255,22 +255,22 @@ static void test_friend_msg(void)
 	 * transport and network parts of the second packet.
 	 * Ensures coverage for the regression reported in #32033.
 	 */
-	ASSERT_OK(bt_mesh_test_send(friend_lpn_addr, BT_MESH_SDU_UNSEG_MAX, 0, K_SECONDS(1)),
-		  "Unseg send failed");
-	ASSERT_OK(bt_mesh_test_send(friend_lpn_addr, BT_MESH_SDU_UNSEG_MAX, 0, K_SECONDS(1)),
-		  "Unseg send failed");
+	ASSERT_OK_MSG(bt_mesh_test_send(friend_lpn_addr, BT_MESH_SDU_UNSEG_MAX, 0, K_SECONDS(1)),
+		      "Unseg send failed");
+	ASSERT_OK_MSG(bt_mesh_test_send(friend_lpn_addr, BT_MESH_SDU_UNSEG_MAX, 0, K_SECONDS(1)),
+		      "Unseg send failed");
 
 	/* Two messages require 2 polls plus the "no more messages" msg */
 	friend_wait_for_polls(3);
 
-	ASSERT_OK(bt_mesh_test_recv(5, cfg->addr, K_SECONDS(10)),
-		  "Receive from LPN failed");
+	ASSERT_OK_MSG(bt_mesh_test_recv(5, cfg->addr, K_SECONDS(10)),
+		      "Receive from LPN failed");
 
 	/* Receive a segmented message from the LPN. LPN should poll for the ack
 	 * after sending the segments.
 	 */
-	ASSERT_OK(bt_mesh_test_recv(15, cfg->addr, K_SECONDS(10)),
-		  "Receive from LPN failed");
+	ASSERT_OK_MSG(bt_mesh_test_recv(15, cfg->addr, K_SECONDS(10)),
+		      "Receive from LPN failed");
 	friend_wait_for_polls(2);
 
 	PASS();
@@ -287,8 +287,8 @@ static void test_friend_overflow(void)
 
 	bt_mesh_friend_set(BT_MESH_FEATURE_ENABLED);
 
-	ASSERT_OK(evt_wait(FRIEND_ESTABLISHED, K_SECONDS(5)),
-		  "Friendship not established");
+	ASSERT_OK_MSG(evt_wait(FRIEND_ESTABLISHED, K_SECONDS(5)),
+		      "Friendship not established");
 	evt_clear(FRIEND_POLLED);
 
 	k_sleep(K_SECONDS(3));
@@ -305,8 +305,8 @@ static void test_friend_overflow(void)
 	 */
 	bt_mesh_test_send(friend_lpn_addr, 5, 0, K_NO_WAIT);
 
-	ASSERT_OK(evt_wait(FRIEND_POLLED, K_SECONDS(35)),
-		  "Friend never polled");
+	ASSERT_OK_MSG(evt_wait(FRIEND_POLLED, K_SECONDS(35)),
+		      "Friend never polled");
 
 	/* LPN verifies that no more messages are in Friend Queue. */
 	k_sleep(K_SECONDS(10));
@@ -322,8 +322,8 @@ static void test_friend_overflow(void)
 	/* This message should preempt the segmented one. */
 	bt_mesh_test_send(friend_lpn_addr, 5, 0, K_NO_WAIT);
 
-	ASSERT_OK(evt_wait(FRIEND_POLLED, K_SECONDS(35)),
-		  "Friend never polled");
+	ASSERT_OK_MSG(evt_wait(FRIEND_POLLED, K_SECONDS(35)),
+		      "Friend never polled");
 
 	/* LPN verifies that there are no more messages in the Friend Queue. */
 	k_sleep(K_SECONDS(10));
@@ -346,8 +346,8 @@ static void test_friend_overflow(void)
 	/* This message should fit in Friend Queue as well. */
 	bt_mesh_test_send(friend_lpn_addr, 5, 0, K_NO_WAIT);
 
-	ASSERT_OK(evt_wait(FRIEND_POLLED, K_SECONDS(35)),
-		  "Friend never polled");
+	ASSERT_OK_MSG(evt_wait(FRIEND_POLLED, K_SECONDS(35)),
+		      "Friend never polled");
 
 	if (atomic_test_bit(state, FRIEND_TERMINATED)) {
 		FAIL("Friendship terminated unexpectedly");
@@ -368,8 +368,8 @@ static void test_friend_group(void)
 
 	bt_mesh_friend_set(BT_MESH_FEATURE_ENABLED);
 
-	ASSERT_OK(evt_wait(FRIEND_ESTABLISHED, K_SECONDS(5)),
-		  "Friendship not established");
+	ASSERT_OK_MSG(evt_wait(FRIEND_ESTABLISHED, K_SECONDS(5)),
+		      "Friendship not established");
 	evt_clear(FRIEND_POLLED);
 
 	ASSERT_OK(bt_mesh_va_add(test_va_uuid, &virtual_addr));
@@ -382,11 +382,11 @@ static void test_friend_group(void)
 	evt_clear(FRIEND_POLLED);
 
 	/* Send a group message to the LPN */
-	ASSERT_OK(bt_mesh_test_send(GROUP_ADDR, 5, 0, K_SECONDS(1)),
-		  "Failed to send to LPN");
+	ASSERT_OK_MSG(bt_mesh_test_send(GROUP_ADDR, 5, 0, K_SECONDS(1)),
+		      "Failed to send to LPN");
 	/* Send a virtual message to the LPN */
-	ASSERT_OK(bt_mesh_test_send(virtual_addr, 5, 0, K_SECONDS(1)),
-		  "Failed to send to LPN");
+	ASSERT_OK_MSG(bt_mesh_test_send(virtual_addr, 5, 0, K_SECONDS(1)),
+		      "Failed to send to LPN");
 
 	/* Wait for the LPN to poll for each message, then for adding the
 	 * group address:
@@ -396,8 +396,8 @@ static void test_friend_group(void)
 	/* Send a group message to an address the LPN added after the friendship
 	 * was established.
 	 */
-	ASSERT_OK(bt_mesh_test_send(GROUP_ADDR + 1, 5, 0, K_SECONDS(1)),
-		  "Failed to send to LPN");
+	ASSERT_OK_MSG(bt_mesh_test_send(GROUP_ADDR + 1, 5, 0, K_SECONDS(1)),
+		      "Failed to send to LPN");
 
 	evt_wait(FRIEND_POLLED, K_SECONDS(10));
 
@@ -442,8 +442,8 @@ static void test_lpn_est(void)
 
 	bt_mesh_lpn_set(true);
 
-	ASSERT_OK(evt_wait(LPN_ESTABLISHED, K_SECONDS(5)),
-		  "LPN not established");
+	ASSERT_OK_MSG(evt_wait(LPN_ESTABLISHED, K_SECONDS(5)),
+		      "LPN not established");
 	if (!evt_wait(LPN_TERMINATED,
 		      K_MSEC(POLL_TIMEOUT_MS + 5 * MSEC_PER_SEC))) {
 		FAIL("Friendship terminated unexpectedly");
@@ -463,8 +463,7 @@ static void test_lpn_msg_frnd(void)
 
 	bt_mesh_lpn_set(true);
 
-	ASSERT_OK(evt_wait(LPN_ESTABLISHED, K_SECONDS(5)),
-		  "LPN not established");
+	ASSERT_OK_MSG(evt_wait(LPN_ESTABLISHED, K_SECONDS(5)), "LPN not established");
 	/* LPN polls on establishment. Clear the poll state */
 	evt_clear(LPN_POLLED);
 
@@ -472,43 +471,41 @@ static void test_lpn_msg_frnd(void)
 	k_sleep(K_SECONDS(3));
 
 	/* Receive unsegmented message */
-	ASSERT_OK(bt_mesh_lpn_poll(), "Poll failed");
-	ASSERT_OK(bt_mesh_test_recv(5, cfg->addr, K_SECONDS(1)),
-		  "Failed to receive message");
+	ASSERT_OK_MSG(bt_mesh_lpn_poll(), "Poll failed");
+	ASSERT_OK_MSG(bt_mesh_test_recv(5, cfg->addr, K_SECONDS(1)), "Failed to receive message");
 
 	/* Give friend time to prepare the message */
 	k_sleep(K_SECONDS(3));
 
 	/* Receive segmented message */
-	ASSERT_OK(bt_mesh_lpn_poll(), "Poll failed");
-	ASSERT_OK(bt_mesh_test_recv(13, cfg->addr, K_SECONDS(2)),
-		  "Failed to receive message");
+	ASSERT_OK_MSG(bt_mesh_lpn_poll(), "Poll failed");
+	ASSERT_OK_MSG(bt_mesh_test_recv(13, cfg->addr, K_SECONDS(2)), "Failed to receive message");
 
 	/* Give friend time to prepare the messages */
 	k_sleep(K_SECONDS(3));
 
 	/* Receive two unsegmented messages */
-	ASSERT_OK(bt_mesh_lpn_poll(), "Poll failed");
-	ASSERT_OK(bt_mesh_test_recv(BT_MESH_SDU_UNSEG_MAX, cfg->addr, K_SECONDS(2)),
-		  "Failed to receive message");
-	ASSERT_OK(bt_mesh_test_recv(BT_MESH_SDU_UNSEG_MAX, cfg->addr, K_SECONDS(2)),
-		  "Failed to receive message");
+	ASSERT_OK_MSG(bt_mesh_lpn_poll(), "Poll failed");
+	ASSERT_OK_MSG(bt_mesh_test_recv(BT_MESH_SDU_UNSEG_MAX, cfg->addr, K_SECONDS(2)),
+		      "Failed to receive message");
+	ASSERT_OK_MSG(bt_mesh_test_recv(BT_MESH_SDU_UNSEG_MAX, cfg->addr, K_SECONDS(2)),
+		      "Failed to receive message");
 
 	k_sleep(K_SECONDS(3));
 
 	/* Send an unsegmented message to the friend.
 	 * Should not be affected by the LPN mode at all.
 	 */
-	ASSERT_OK(bt_mesh_test_send(friend_cfg.addr, 5, 0, K_MSEC(500)),
-		  "Send to friend failed");
+	ASSERT_OK_MSG(bt_mesh_test_send(friend_cfg.addr, 5, 0, K_MSEC(500)),
+		      "Send to friend failed");
 
 	k_sleep(K_SECONDS(5));
 
 	/* Send a segmented message to the friend. Should trigger a poll for the
 	 * ack.
 	 */
-	ASSERT_OK(bt_mesh_test_send(friend_cfg.addr, 15, 0, K_SECONDS(5)),
-		  "Send to friend failed");
+	ASSERT_OK_MSG(bt_mesh_test_send(friend_cfg.addr, 15, 0, K_SECONDS(5)),
+		      "Send to friend failed");
 
 	PASS();
 }
@@ -525,16 +522,15 @@ static void test_lpn_msg_mesh(void)
 
 	bt_mesh_lpn_set(true);
 
-	ASSERT_OK(evt_wait(LPN_ESTABLISHED, K_SECONDS(2)),
-		  "LPN not established");
+	ASSERT_OK_MSG(evt_wait(LPN_ESTABLISHED, K_SECONDS(2)), "LPN not established");
 	/* LPN polls on establishment. Clear the poll state */
 	evt_clear(LPN_POLLED);
 
 	/* Send an unsegmented message to a third mesh node.
 	 * Should not be affected by the LPN mode at all.
 	 */
-	ASSERT_OK(bt_mesh_test_send(other_cfg.addr, 5, 0, K_MSEC(500)),
-		  "Send to mesh failed");
+	ASSERT_OK_MSG(bt_mesh_test_send(other_cfg.addr, 5, 0, K_MSEC(500)),
+		     "Send to mesh failed");
 
 	/* Receive an unsegmented message back */
 	k_sleep(K_SECONDS(1));
@@ -546,8 +542,8 @@ static void test_lpn_msg_mesh(void)
 	/* Send a segmented message to the mesh node.
 	 * Should trigger a poll for the ack.
 	 */
-	ASSERT_OK(bt_mesh_test_send(other_cfg.addr, 15, 0, K_SECONDS(5)),
-		  "Send to other failed");
+	ASSERT_OK_MSG(bt_mesh_test_send(other_cfg.addr, 15, 0, K_SECONDS(5)),
+		      "Send to other failed");
 
 	/* Receive a segmented message back */
 	k_sleep(K_SECONDS(1));
@@ -577,12 +573,12 @@ static void test_lpn_re_est(void)
 
 	for (int i = 0; i < 4; i++) {
 		bt_mesh_lpn_set(true);
-		ASSERT_OK(evt_wait(LPN_ESTABLISHED, K_SECONDS(2)),
-			"LPN not established");
+		ASSERT_OK_MSG(evt_wait(LPN_ESTABLISHED, K_SECONDS(2)),
+			      "LPN not established");
 
 		bt_mesh_lpn_set(false);
-		ASSERT_OK(evt_wait(LPN_TERMINATED, K_SECONDS(5)),
-			"LPN never terminated friendship");
+		ASSERT_OK_MSG(evt_wait(LPN_TERMINATED, K_SECONDS(5)),
+			      "LPN never terminated friendship");
 
 		k_sleep(K_SECONDS(2));
 	}
@@ -598,12 +594,11 @@ static void test_lpn_poll(void)
 	bt_mesh_test_setup();
 
 	bt_mesh_lpn_set(true);
-	ASSERT_OK(evt_wait(LPN_ESTABLISHED, K_SECONDS(5)),
-		  "LPN not established");
+	ASSERT_OK_MSG(evt_wait(LPN_ESTABLISHED, K_SECONDS(5)), "LPN not established");
 	evt_clear(LPN_POLLED);
 
-	ASSERT_OK(evt_wait(LPN_POLLED, K_MSEC(POLL_TIMEOUT_MS)),
-		  "LPN failed to poll before the timeout");
+	ASSERT_OK_MSG(evt_wait(LPN_POLLED, K_MSEC(POLL_TIMEOUT_MS)),
+		      "LPN failed to poll before the timeout");
 
 	k_sleep(K_SECONDS(10));
 	if (atomic_test_bit(state, LPN_TERMINATED)) {
@@ -625,18 +620,17 @@ static void test_lpn_overflow(void)
 	bt_mesh_test_setup();
 
 	bt_mesh_lpn_set(true);
-	ASSERT_OK(evt_wait(LPN_ESTABLISHED, K_SECONDS(5)),
-		  "LPN not established");
+	ASSERT_OK_MSG(evt_wait(LPN_ESTABLISHED, K_SECONDS(5)), "LPN not established");
 	evt_clear(LPN_POLLED);
 
 	k_sleep(K_SECONDS(5));
-	ASSERT_OK(bt_mesh_lpn_poll(), "Poll failed");
+	ASSERT_OK_MSG(bt_mesh_lpn_poll(), "Poll failed");
 
 	LOG_INF("Testing overflow with only unsegmented messages...");
 
 	for (int i = 0; i < CONFIG_BT_MESH_FRIEND_QUEUE_SIZE; i++) {
-		ASSERT_OK(bt_mesh_test_recv_msg(&msg, K_SECONDS(2)),
-			  "Receive %d failed", i);
+		ASSERT_OK_MSG(bt_mesh_test_recv_msg(&msg, K_SECONDS(2)),
+			      "Receive %d failed", i);
 
 		if (msg.len != 5) {
 			FAIL("Message %d: Invalid length %d", i, msg.len);
@@ -664,21 +658,21 @@ static void test_lpn_overflow(void)
 
 	LOG_INF("Testing overflow with unsegmented message preempting segmented one...");
 
-	ASSERT_OK(bt_mesh_lpn_poll(), "Poll failed");
+	ASSERT_OK_MSG(bt_mesh_lpn_poll(), "Poll failed");
 
 	/* Last seq from the previous step. */
 	exp_seq = CONFIG_BT_MESH_FRIEND_QUEUE_SIZE + 1;
 
 	exp_seq += 2; /* Skipping the first message in Friend Queue. */
-	ASSERT_OK(bt_mesh_test_recv_msg(&msg, K_SECONDS(2)),
-		  "Receive first unseg msg failed");
+	ASSERT_OK_MSG(bt_mesh_test_recv_msg(&msg, K_SECONDS(2)),
+		      "Receive first unseg msg failed");
 	ASSERT_EQUAL(5, msg.len);
 	ASSERT_EQUAL(cfg->addr, msg.ctx.recv_dst);
 	ASSERT_EQUAL(exp_seq, msg.seq);
 
 	exp_seq++;
-	ASSERT_OK(bt_mesh_test_recv_msg(&msg, K_SECONDS(2)),
-		  "Receive the second unseg msg failed");
+	ASSERT_OK_MSG(bt_mesh_test_recv_msg(&msg, K_SECONDS(2)),
+		      "Receive the second unseg msg failed");
 	ASSERT_EQUAL(5, msg.len);
 	ASSERT_EQUAL(cfg->addr, msg.ctx.recv_dst);
 	ASSERT_EQUAL(exp_seq, msg.seq);
@@ -692,25 +686,25 @@ static void test_lpn_overflow(void)
 
 	LOG_INF("Testing overflow with segmented message preempting another segmented...");
 
-	ASSERT_OK(bt_mesh_lpn_poll(), "Poll failed");
+	ASSERT_OK_MSG(bt_mesh_lpn_poll(), "Poll failed");
 
 	exp_seq += 2; /* Skipping the first message in Friend Queue. */
-	ASSERT_OK(bt_mesh_test_recv_msg(&msg, K_SECONDS(2)),
-		  "Receive the first unseg msg failed");
+	ASSERT_OK_MSG(bt_mesh_test_recv_msg(&msg, K_SECONDS(2)),
+		      "Receive the first unseg msg failed");
 	ASSERT_EQUAL(5, msg.len);
 	ASSERT_EQUAL(cfg->addr, msg.ctx.recv_dst);
 	ASSERT_EQUAL(exp_seq, msg.seq);
 
 	exp_seq++;
-	ASSERT_OK(bt_mesh_test_recv_msg(&msg, K_SECONDS(20)),
-		  "Receive the seg msg failed");
+	ASSERT_OK_MSG(bt_mesh_test_recv_msg(&msg, K_SECONDS(20)),
+		      "Receive the seg msg failed");
 	ASSERT_EQUAL(BT_MESH_SDU_UNSEG_MAX * (CONFIG_BT_MESH_FRIEND_QUEUE_SIZE - 2),
 		     msg.len);
 	ASSERT_EQUAL(cfg->addr, msg.ctx.recv_dst);
 	ASSERT_EQUAL(exp_seq, msg.seq);
 
-	ASSERT_OK(bt_mesh_test_recv_msg(&msg, K_SECONDS(2)),
-		  "Receive the second unseg msg failed");
+	ASSERT_OK_MSG(bt_mesh_test_recv_msg(&msg, K_SECONDS(2)),
+		      "Receive the second unseg msg failed");
 	ASSERT_EQUAL(5, msg.len);
 	ASSERT_EQUAL(cfg->addr, msg.ctx.recv_dst);
 
@@ -751,8 +745,7 @@ static void test_lpn_group(void)
 	}
 
 	bt_mesh_lpn_set(true);
-	ASSERT_OK(evt_wait(LPN_ESTABLISHED, K_SECONDS(5)),
-		  "LPN not established");
+	ASSERT_OK_MSG(evt_wait(LPN_ESTABLISHED, K_SECONDS(5)), "LPN not established");
 	evt_clear(LPN_POLLED);
 
 	/* Send a message to the other mesh device to indicate that the
@@ -763,7 +756,7 @@ static void test_lpn_group(void)
 	ASSERT_OK(bt_mesh_test_send(other_cfg.addr, 5, 0, K_SECONDS(1)));
 
 	k_sleep(K_SECONDS(5));
-	ASSERT_OK(bt_mesh_lpn_poll(), "Poll failed");
+	ASSERT_OK_MSG(bt_mesh_lpn_poll(), "Poll failed");
 
 	/* From other device */
 	ASSERT_OK(bt_mesh_test_recv_msg(&msg, K_SECONDS(1)));
@@ -779,7 +772,7 @@ static void test_lpn_group(void)
 	}
 
 	k_sleep(K_SECONDS(5));
-	ASSERT_OK(bt_mesh_lpn_poll(), "Poll failed");
+	ASSERT_OK_MSG(bt_mesh_lpn_poll(), "Poll failed");
 
 	/* From friend */
 	ASSERT_OK(bt_mesh_test_recv_msg(&msg, K_SECONDS(1)));
@@ -809,7 +802,7 @@ static void test_lpn_group(void)
 	}
 
 	k_sleep(K_SECONDS(5));
-	ASSERT_OK(bt_mesh_lpn_poll(), "Poll failed");
+	ASSERT_OK_MSG(bt_mesh_lpn_poll(), "Poll failed");
 
 	/* From friend on second group address */
 	ASSERT_OK(bt_mesh_test_recv_msg(&msg, K_SECONDS(1)));
@@ -850,8 +843,8 @@ static void test_lpn_loopback(void)
 	}
 
 	bt_mesh_lpn_set(true);
-	ASSERT_OK(evt_wait(LPN_ESTABLISHED, K_SECONDS(5)),
-		  "LPN not established");
+	ASSERT_OK_MSG(evt_wait(LPN_ESTABLISHED, K_SECONDS(5)),
+		      "LPN not established");
 	evt_clear(LPN_POLLED);
 
 	k_sleep(K_SECONDS(1));
@@ -864,7 +857,7 @@ static void test_lpn_loopback(void)
 	ASSERT_OK(bt_mesh_test_send_async(GROUP_ADDR, 5, 0, NULL, NULL));
 	ASSERT_OK(bt_mesh_test_recv(5, GROUP_ADDR, K_SECONDS(1)));
 
-	ASSERT_OK(bt_mesh_lpn_poll(), "Poll failed");
+	ASSERT_OK_MSG(bt_mesh_lpn_poll(), "Poll failed");
 	err = bt_mesh_test_recv_msg(&msg, K_SECONDS(2));
 	if (err != -ETIMEDOUT) {
 		FAIL("Unexpected receive status: %d", err);
@@ -877,7 +870,7 @@ static void test_lpn_loopback(void)
 	k_sleep(K_SECONDS(2));
 
 	/* Poll the friend and make sure we don't receive any messages: */
-	ASSERT_OK(bt_mesh_lpn_poll(), "Poll failed");
+	ASSERT_OK_MSG(bt_mesh_lpn_poll(), "Poll failed");
 	err = bt_mesh_test_recv_msg(&msg, K_SECONDS(5));
 	if (err != -ETIMEDOUT) {
 		FAIL("Unexpected receive status: %d", err);
@@ -896,28 +889,28 @@ static void test_other_msg(void)
 	bt_mesh_test_setup();
 
 	/* Receive an unsegmented message from the LPN. */
-	ASSERT_OK(bt_mesh_test_recv(5, cfg->addr, K_SECONDS(4)),
-		  "Failed to receive from LPN");
+	ASSERT_OK_MSG(bt_mesh_test_recv(5, cfg->addr, K_SECONDS(4)),
+		      "Failed to receive from LPN");
 
 	/* Send an unsegmented message to the LPN */
-	ASSERT_OK(bt_mesh_test_send(LPN_ADDR_START, 5, 0, K_SECONDS(1)),
-		  "Failed to send to LPN");
+	ASSERT_OK_MSG(bt_mesh_test_send(LPN_ADDR_START, 5, 0, K_SECONDS(1)),
+		      "Failed to send to LPN");
 
 	/* Receive a segmented message from the LPN. */
-	ASSERT_OK(bt_mesh_test_recv(15, cfg->addr, K_SECONDS(10)),
-		  "Failed to receive from LPN");
+	ASSERT_OK_MSG(bt_mesh_test_recv(15, cfg->addr, K_SECONDS(10)),
+		      "Failed to receive from LPN");
 
 	/* Send a segmented message to the friend. Should trigger a poll for the
 	 * ack.
 	 */
-	ASSERT_OK(bt_mesh_test_send(LPN_ADDR_START, 15, 0, K_SECONDS(10)),
-		  "Send to LPN failed");
+	ASSERT_OK_MSG(bt_mesh_test_send(LPN_ADDR_START, 15, 0, K_SECONDS(10)),
+		      "Send to LPN failed");
 
 	/* Receive an unsegmented message from the LPN, originally sent with
 	 * friend credentials.
 	 */
-	ASSERT_OK(bt_mesh_test_recv(1, cfg->addr, K_SECONDS(10)),
-		  "Failed to receive from LPN");
+	ASSERT_OK_MSG(bt_mesh_test_recv(1, cfg->addr, K_SECONDS(10)),
+		      "Failed to receive from LPN");
 
 	PASS();
 }
@@ -937,11 +930,11 @@ static void test_other_group(void)
 	ASSERT_OK(bt_mesh_test_recv(5, cfg->addr, K_SECONDS(1)));
 
 	/* Send a group message to the LPN */
-	ASSERT_OK(bt_mesh_test_send(GROUP_ADDR, 5, 0, K_SECONDS(1)),
-		  "Failed to send to LPN");
+	ASSERT_OK_MSG(bt_mesh_test_send(GROUP_ADDR, 5, 0, K_SECONDS(1)),
+		      "Failed to send to LPN");
 	/* Send a virtual message to the LPN */
-	ASSERT_OK(bt_mesh_test_send(virtual_addr, 5, 0, K_SECONDS(1)),
-		  "Failed to send to LPN");
+	ASSERT_OK_MSG(bt_mesh_test_send(virtual_addr, 5, 0, K_SECONDS(1)),
+		      "Failed to send to LPN");
 
 	PASS();
 }
@@ -974,7 +967,7 @@ static void test_lpn_term_cb_check(void)
 	bt_mesh_test_setup();
 
 	bt_mesh_lpn_set(true);
-	ASSERT_OK(evt_wait(LPN_POLLED, K_MSEC(1000)), "Friend never polled");
+	ASSERT_OK_MSG(evt_wait(LPN_POLLED, K_MSEC(1000)), "Friend never polled");
 	bt_mesh_lpn_set(false);
 
 	if (!evt_wait(LPN_TERMINATED, K_SECONDS(30))) {

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_scanner.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_scanner.c
@@ -186,7 +186,7 @@ static void test_rx_invalid_packet(void)
 
 	/* Verify that test data is received correct. */
 	err = bt_mesh_test_recv(10, cfg->addr, K_SECONDS(10));
-	ASSERT_OK(err, "Failed receiving with valid ad_type");
+	ASSERT_OK_MSG(err, "Failed receiving with valid ad_type");
 
 	PASS();
 }

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_transport.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_transport.c
@@ -98,7 +98,7 @@ static void test_tx_unicast(void)
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		err = bt_mesh_test_send(rx_cfg.addr, test_vector[i].len,
 					test_vector[i].flags, K_SECONDS(10));
-		ASSERT_OK(err, "Failed sending vector %d", i);
+		ASSERT_OK_MSG(err, "Failed sending vector %d", i);
 	}
 
 	PASS();
@@ -115,7 +115,7 @@ static void test_tx_group(void)
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		err = bt_mesh_test_send(GROUP_ADDR, test_vector[i].len,
 					test_vector[i].flags, K_SECONDS(20));
-		ASSERT_OK(err, "Failed sending vector %d", i);
+		ASSERT_OK_MSG(err, "Failed sending vector %d", i);
 	}
 
 	PASS();
@@ -131,12 +131,12 @@ static void test_tx_va(void)
 	bt_mesh_test_setup();
 
 	err = bt_mesh_va_add(test_va_uuid, &virtual_addr);
-	ASSERT_OK(err, "Virtual addr add failed (err %d)", err);
+	ASSERT_OK_MSG(err, "Virtual addr add failed (err %d)", err);
 
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		err = bt_mesh_test_send(virtual_addr, test_vector[i].len,
 					test_vector[i].flags, K_SECONDS(20));
-		ASSERT_OK(err, "Failed sending vector %d", i);
+		ASSERT_OK_MSG(err, "Failed sending vector %d", i);
 	}
 
 	PASS();
@@ -155,7 +155,7 @@ static void test_tx_loopback(void)
 		err = bt_mesh_test_send(cfg->addr, test_vector[i].len,
 					test_vector[i].flags,
 					K_SECONDS(20));
-		ASSERT_OK(err, "Failed sending vector %d", i);
+		ASSERT_OK_MSG(err, "Failed sending vector %d", i);
 
 		if (test_stats.received != i + 1) {
 			FAIL("Didn't receive message %d", i);
@@ -177,26 +177,26 @@ static void test_tx_unknown_app(void)
 
 	bt_mesh_test_setup();
 
-	ASSERT_OK(bt_mesh_cfg_cli_app_key_add(0, cfg->addr, 0, 1, app_key, &status),
-		  "Failed adding additional appkey");
+	ASSERT_OK_MSG(bt_mesh_cfg_cli_app_key_add(0, cfg->addr, 0, 1, app_key, &status),
+		      "Failed adding additional appkey");
 	if (status) {
 		FAIL("App key add status: 0x%02x", status);
 	}
 
-	ASSERT_OK(bt_mesh_cfg_cli_mod_app_bind(0, cfg->addr, cfg->addr, 1,
-					   TEST_MOD_ID, &status),
-		  "Failed binding additional appkey");
+	ASSERT_OK_MSG(bt_mesh_cfg_cli_mod_app_bind(0, cfg->addr, cfg->addr, 1,
+						   TEST_MOD_ID, &status),
+		      "Failed binding additional appkey");
 	if (status) {
 		FAIL("App key add status: 0x%02x", status);
 	}
 
 	test_send_ctx.app_idx = 1;
 
-	ASSERT_OK(bt_mesh_test_send(rx_cfg.addr, 5, 0, K_SECONDS(1)),
-		  "Failed sending unsegmented");
+	ASSERT_OK_MSG(bt_mesh_test_send(rx_cfg.addr, 5, 0, K_SECONDS(1)),
+		      "Failed sending unsegmented");
 
-	ASSERT_OK(bt_mesh_test_send(rx_cfg.addr, 25, 0, K_SECONDS(1)),
-		  "Failed sending segmented");
+	ASSERT_OK_MSG(bt_mesh_test_send(rx_cfg.addr, 25, 0, K_SECONDS(1)),
+		      "Failed sending segmented");
 
 	PASS();
 }
@@ -216,7 +216,7 @@ static void test_tx_loopback_group(void)
 
 	err = bt_mesh_cfg_cli_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR,
 				      TEST_MOD_ID, &status);
-	ASSERT_OK(err || status, "Mod sub add failed (err %d, status %u)",
+	ASSERT_OK_MSG(err || status, "Mod sub add failed (err %d, status %u)",
 		  err, status);
 
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
@@ -224,12 +224,12 @@ static void test_tx_loopback_group(void)
 					test_vector[i].flags,
 					K_SECONDS(20));
 
-		ASSERT_OK(err, "Failed sending vector %d", i);
+		ASSERT_OK_MSG(err, "Failed sending vector %d", i);
 
 		k_sleep(K_SECONDS(1));
-		ASSERT_OK(bt_mesh_test_recv(test_vector[i].len, GROUP_ADDR,
-					    K_SECONDS(1)),
-			  "Failed receiving loopback %d", i);
+		ASSERT_OK_MSG(bt_mesh_test_recv(test_vector[i].len, GROUP_ADDR,
+						K_SECONDS(1)),
+			      "Failed receiving loopback %d", i);
 
 		if (test_stats.received != i + 1) {
 			FAIL("Didn't receive message %d", i);
@@ -369,7 +369,7 @@ static void test_rx_unicast(void)
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		err = bt_mesh_test_recv(test_vector[i].len, cfg->addr,
 					K_SECONDS(10));
-		ASSERT_OK(err, "Failed receiving vector %d", i);
+		ASSERT_OK_MSG(err, "Failed receiving vector %d", i);
 	}
 
 	PASS();
@@ -386,13 +386,12 @@ static void test_rx_group(void)
 
 	err = bt_mesh_cfg_cli_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR,
 				      TEST_MOD_ID, &status);
-	ASSERT_OK(err || status, "Mod sub add failed (err %d, status %u)",
-		  err, status);
+	ASSERT_OK_MSG(err || status, "Mod sub add failed (err %d, status %u)", err, status);
 
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		err = bt_mesh_test_recv(test_vector[i].len, GROUP_ADDR,
 					K_SECONDS(20));
-		ASSERT_OK(err, "Failed receiving vector %d", i);
+		ASSERT_OK_MSG(err, "Failed receiving vector %d", i);
 	}
 
 	PASS();
@@ -410,13 +409,12 @@ static void test_rx_va(void)
 
 	err = bt_mesh_cfg_cli_mod_sub_va_add(0, cfg->addr, cfg->addr, test_va_uuid,
 					 TEST_MOD_ID, &virtual_addr, &status);
-	ASSERT_OK(err || status, "Sub add failed (err %d, status %u)", err,
-		  status);
+	ASSERT_OK_MSG(err || status, "Sub add failed (err %d, status %u)", err, status);
 
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
 		err = bt_mesh_test_recv(test_vector[i].len, virtual_addr,
 					K_SECONDS(20));
-		ASSERT_OK(err, "Failed receiving vector %d", i);
+		ASSERT_OK_MSG(err, "Failed receiving vector %d", i);
 	}
 
 	PASS();
@@ -445,9 +443,9 @@ static void test_rx_seg_block(void)
 {
 	bt_mesh_test_setup();
 
-	ASSERT_OK(bt_mesh_test_recv(20, cfg->addr, K_SECONDS(2)), "RX fail");
-	ASSERT_OK(bt_mesh_test_recv(20, cfg->addr, K_SECONDS(2)), "RX fail");
-	ASSERT_OK(bt_mesh_test_recv(20, cfg->addr, K_SECONDS(2)), "RX fail");
+	ASSERT_OK_MSG(bt_mesh_test_recv(20, cfg->addr, K_SECONDS(2)), "RX fail");
+	ASSERT_OK_MSG(bt_mesh_test_recv(20, cfg->addr, K_SECONDS(2)), "RX fail");
+	ASSERT_OK_MSG(bt_mesh_test_recv(20, cfg->addr, K_SECONDS(2)), "RX fail");
 
 	PASS();
 }
@@ -464,15 +462,14 @@ static void test_rx_seg_concurrent(void)
 	/* Subscribe to group addr */
 	err = bt_mesh_cfg_cli_mod_sub_add(0, cfg->addr, cfg->addr, GROUP_ADDR,
 				      TEST_MOD_ID, &status);
-	ASSERT_OK(err || status, "Mod sub add failed (err %d, status %u)",
-		  err, status);
+	ASSERT_OK_MSG(err || status, "Mod sub add failed (err %d, status %u)", err, status);
 
 	/* Receive both messages from the sender.
 	 * Note: The receive order is technically irrelevant, but the test_recv
 	 * function fails if the order is wrong.
 	 */
-	ASSERT_OK(bt_mesh_test_recv(20, cfg->addr, K_SECONDS(2)), "RX fail");
-	ASSERT_OK(bt_mesh_test_recv(20, GROUP_ADDR, K_SECONDS(2)), "RX fail");
+	ASSERT_OK_MSG(bt_mesh_test_recv(20, cfg->addr, K_SECONDS(2)), "RX fail");
+	ASSERT_OK_MSG(bt_mesh_test_recv(20, GROUP_ADDR, K_SECONDS(2)), "RX fail");
 
 	PASS();
 }
@@ -483,8 +480,8 @@ static void test_rx_seg_ivu(void)
 {
 	bt_mesh_test_setup();
 
-	ASSERT_OK(bt_mesh_test_recv(255, cfg->addr, K_SECONDS(5)), "RX fail");
-	ASSERT_OK(bt_mesh_test_recv(255, cfg->addr, K_SECONDS(5)), "RX fail");
+	ASSERT_OK_MSG(bt_mesh_test_recv(255, cfg->addr, K_SECONDS(5)), "RX fail");
+	ASSERT_OK_MSG(bt_mesh_test_recv(255, cfg->addr, K_SECONDS(5)), "RX fail");
 
 	PASS();
 }


### PR DESCRIPTION
This PR fixes issue introduced in
https://github.com/zephyrproject-rtos/zephyr/commit/5d059117fd279ee0eec4fb1c4d0244a37937013c.

Use extra flag stored in user data of net_buf to control segmented
messages in Friend Queue. The initial idea with using fragments didn't
work.

This fixes the following PTS tests:
- MESH/NODE/FRND/FN/BV-08-C
- MESH/NODE/FRND/FN/BV-19-C
- MESH/NODE/CFG/HBS/BV-05-C