### PR TITLE
boards: degu_evk: disable CDC ACM logging

### DIFF
--- a/boards/arm/degu_evk/Kconfig.defconfig
+++ b/boards/arm/degu_evk/Kconfig.defconfig
@@ -21,4 +21,16 @@ config UART_LINE_CTRL
 
 endif # USB_DEVICE_STACK
 
+if LOG
+
+# Logger cannot use itself to log
+config USB_CDC_ACM_LOG_LEVEL
+	default 0
+
+# Set USB log level to error only
+config USB_DEVICE_LOG_LEVEL
+	default 1
+
+endif # LOG
+
 endif # BOARD_DEGU_EVK


### PR DESCRIPTION
Board degu_evk uses CDC ACM UART as default backend for logging. Disable logging module in CDC ACM to prevent recursive logging loop.

Fixes: #53147