### PR TITLE
Bluetooth: Audio: Shell: Add CAP Acceptor Set Member AD data

### DIFF
--- a/subsys/bluetooth/audio/shell/CMakeLists.txt
+++ b/subsys/bluetooth/audio/shell/CMakeLists.txt
@@ -52,7 +52,7 @@ zephyr_library_sources_ifdef(
   has.c
   )
 zephyr_library_sources_ifdef(
-  CONFIG_BT_CAP_ACCEPTOR_SET_MEMBER
+  CONFIG_BT_CAP_ACCEPTOR
   cap_acceptor.c
   )
 zephyr_library_sources_ifdef(

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -21,5 +21,6 @@ ssize_t audio_ad_data_add(struct bt_data *data, const size_t data_size, const bo
 			  const bool connectable);
 ssize_t audio_pa_data_add(struct bt_data *data_array, const size_t data_array_size);
 ssize_t csis_ad_data_add(struct bt_data *data, const size_t data_size, const bool discoverable);
+size_t cap_acceptor_ad_data_add(struct bt_data data[], size_t data_size, bool discoverable);
 
 #endif /* __AUDIO_H */

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -26,6 +26,7 @@
 #include <zephyr/bluetooth/audio/pacs.h>
 
 #include "shell/bt.h"
+#include "audio.h"
 
 #define LOCATION BT_AUDIO_LOCATION_FRONT_LEFT
 #define CONTEXT BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL | BT_AUDIO_CONTEXT_TYPE_MEDIA
@@ -2603,16 +2604,7 @@ static ssize_t connectable_ad_data_add(struct bt_data *data_array,
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CAP_ACCEPTOR)) {
-		static const uint8_t ad_cap_announcement[3] = {
-			BT_UUID_16_ENCODE(BT_UUID_CAS_VAL),
-			BT_AUDIO_UNICAST_ANNOUNCEMENT_TARGETED,
-		};
-
-		__ASSERT(data_array_size > ad_len, "No space for AD_CAP_ANNOUNCEMENT");
-		data_array[ad_len].type = BT_DATA_SVC_DATA16;
-		data_array[ad_len].data_len = ARRAY_SIZE(ad_cap_announcement);
-		data_array[ad_len].data = &ad_cap_announcement[0];
-		ad_len++;
+		ad_len += cap_acceptor_ad_data_add(data_array, data_array_size - ad_len, true);
 	}
 
 	if (ARRAY_SIZE(ad_ext_uuid16) > 0) {


### PR DESCRIPTION
Add automatic adding of the CAP Acceptor Set Member AD data.
    
This also moves the CAP Acceptor service data into the
cap_acceptor.c shell implementation.

depends on https://github.com/zephyrproject-rtos/zephyr/pull/53090