### PR TITLE
usb: device: hid: correct bcdHID to v1.11 spec

### DIFF
--- a/include/zephyr/usb/class/hid.h
+++ b/include/zephyr/usb/class/hid.h
@@ -33,6 +33,9 @@ extern "C" {
  * @{
  */
 
+/** HID Specification release v1.11 */
+#define USB_HID_VERSION			0x0111
+
 /** USB HID Class HID descriptor type */
 #define USB_DESC_HID			0x21
 /** USB HID Class Report descriptor type */

--- a/subsys/usb/device/class/hid/core.c
+++ b/subsys/usb/device/class/hid/core.c
@@ -82,7 +82,7 @@ struct usb_hid_config {
 	{								\
 		.bLength = sizeof(struct usb_hid_descriptor),		\
 		.bDescriptorType = USB_DESC_HID,			\
-		.bcdHID = sys_cpu_to_le16(USB_SRN_1_1),			\
+		.bcdHID = sys_cpu_to_le16(USB_HID_VERSION),		\
 		.bCountryCode = 0,					\
 		.bNumDescriptors = 1,					\
 		.subdesc[0] = {						\


### PR DESCRIPTION
bcdHID is intended for the spec version of USB HID. It was pointing to the v1.1 bcdUSB define which happens to be the same value for the v1.10 hid spec version. This corrects it to use the v1.11 HID spec.

Signed-off-by: Ryan McClelland <ryanmcclelland@meta.com>