### PR TITLE
drivers: usb_c: Properly detect a disconnect while operating as a Source

### DIFF
--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -172,7 +172,7 @@ static inline int tcpc_is_cc_rp(enum tc_cc_voltage_state cc)
 static inline int tcpc_is_cc_open(enum tc_cc_voltage_state cc1,
 				  enum tc_cc_voltage_state cc2)
 {
-	return cc1 == TC_CC_VOLT_OPEN && cc2 == TC_CC_VOLT_OPEN;
+	return (cc1 < TC_CC_VOLT_RD) && (cc2 < TC_CC_VOLT_RD);
 }
 
 /**


### PR DESCRIPTION
While operating as a Source, a disconnect can be missed if using an E-Marker cable that presents an Ra. This change detects a disconnect as follows, while operating as a Source:

(CC1 - OPEN) (CC2 - OPEN)  ----> Nothing attached
(CC1 - OPEN) (CC2 - Ra) ---------> Powered cable without Sink attached
(CC1 - Ra) (CC2 - OPEN) ---------> Powered cable without Sink attached

Signed-off-by: Sam Hurst <sbh1187@gmail.com>