### PR TITLE
boards: riscv: hifive1: Add GPIO-controlled LEDs

### DIFF
--- a/boards/riscv/hifive1/hifive1.dts
+++ b/boards/riscv/hifive1/hifive1.dts
@@ -10,10 +10,14 @@
 / {
 	model = "SiFive HiFive 1";
 	compatible = "sifive,hifive1";
+
 	aliases {
-		pwm-led0 = &led0;
-		pwm-led1 = &led1;
-		pwm-led2 = &led2;
+		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
+		pwm-led0 = &pwmled0;
+		pwm-led1 = &pwmled1;
+		pwm-led2 = &pwmled2;
 		watchdog0 = &wdog0;
 	};
 
@@ -25,16 +29,32 @@
 	};
 
 	leds {
-		compatible = "pwm-leds";
+		compatible = "gpio-leds";
 		led0: led_0 {
-			pwms = <&pwm1 1 PWM_MSEC(20)>;
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
 			label = "Green LED";
 		};
 		led1: led_1 {
-			pwms = <&pwm1 2 PWM_MSEC(20)>;
+			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 			label = "Blue LED";
 		};
 		led2: led_2 {
+			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
+			label = "Red LED";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwmled0: pwmled_0 {
+			pwms = <&pwm1 1 PWM_MSEC(20)>;
+			label = "Green LED";
+		};
+		pwmled1: pwmled_1 {
+			pwms = <&pwm1 2 PWM_MSEC(20)>;
+			label = "Blue LED";
+		};
+		pwmled2: pwmled_2 {
 			pwms = <&pwm1 3 PWM_MSEC(20)>;
 			label = "Red LED";
 		};


### PR DESCRIPTION
Add GPIO-controlled LEDs and alias them as led0, led1, led2. Rename the PWM controlled LEDs to pwmled0, pwmled2, pwmled2.

Add empty prj.conf to `samples/shields/x_nucleo_53l0a1` to fix CI failure.


Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@gmail.com>