### PR TITLE
boards: riscv: hifive1: add arduino_header configuration

### DIFF
--- a/boards/riscv/hifive1/hifive1-pinctrl.dtsi
+++ b/boards/riscv/hifive1/hifive1-pinctrl.dtsi
@@ -76,4 +76,12 @@
 	pwm2_3_default: pwm2_3_default {
 		pinmux = <13 SIFIVE_PINMUX_IOF1>;
 	};
+
+	/* I2C0 */
+	i2c0_0_default: i2c0_0_default {
+		pinmux = <12 SIFIVE_PINMUX_IOF0>;
+	};
+	i2c0_1_default: i2c0_1_default {
+		pinmux = <13 SIFIVE_PINMUX_IOF0>;
+	};
 };

--- a/boards/riscv/hifive1/hifive1.dts
+++ b/boards/riscv/hifive1/hifive1.dts
@@ -4,6 +4,7 @@
 /dts-v1/;
 
 #include <sifive/riscv32-fe310.dtsi>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include "hifive1-pinctrl.dtsi"
 
 / {
@@ -37,6 +38,35 @@
 			pwms = <&pwm1 3 PWM_MSEC(20)>;
 			label = "Red LED";
 		};
+	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = /* A0 not connected */
+			   <1 0 &gpio0 9 0>,	/* A1, also CS2 */
+			   <2 0 &gpio0 10 0>,	/* A2, also WF_INT */
+			   <3 0 &gpio0 11 0>,	/* A3 */
+			   <4 0 &gpio0 12 0>,	/* A4 */
+			   <5 0 &gpio0 13 0>,	/* A5 */
+			   <6 0 &gpio0 16 0>,	/* D0, also TX */
+			   <7 0 &gpio0 17 0>,	/* D1, also RX */
+			   <8 0 &gpio0 18 0>,	/* D2 */
+			   <9 0 &gpio0 19 0>,	/* D3 */
+			   <10 0 &gpio0 20 0>,	/* D4 */
+			   <11 0 &gpio0 21 0>,	/* D5 */
+			   <12 0 &gpio0 22 0>,	/* D6 */
+			   <13 0 &gpio0 23 0>,	/* D7 */
+			   <14 0 &gpio0 0 0>,	/* D8 */
+			   <15 0 &gpio0 1 0>,	/* D9 */
+			   <16 0 &gpio0 2 0>,	/* D10 */
+			   <17 0 &gpio0 3 0>,	/* D11, also MOSI */
+			   <18 0 &gpio0 4 0>,	/* D12, also MISO */
+			   <19 0 &gpio0 5 0>,	/* D13, also SCK */
+			   <20 0 &gpio0 12 0>,	/* D14, also SDA */
+			   <21 0 &gpio0 13 0>;	/* D15, also SCL */
 	};
 };
 
@@ -88,5 +118,12 @@
 &pwm2 {
 	status = "okay";
 	pinctrl-0 = <&pwm2_1_default &pwm2_2_default &pwm2_3_default>;
+	pinctrl-names = "default";
+};
+
+arduino_i2c: &i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+	pinctrl-0 = <&i2c0_0_default &i2c0_1_default>;
 	pinctrl-names = "default";
 };

--- a/boards/riscv/hifive1/hifive1.yaml
+++ b/boards/riscv/hifive1/hifive1.yaml
@@ -11,6 +11,8 @@ supported:
   - pwm
   - gpio
   - spi
+  - arduino_gpio
+  - arduino_i2c
 testing:
   ignore_tags:
     - net


### PR DESCRIPTION
Add arduino_header and arduino_i2c configuration.
Also add pinctrl definitions.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>