### PR TITLE
drivers: gpio: sifive: Reset iof_en and iof_sel on init

### DIFF
--- a/drivers/gpio/gpio_sifive.c
+++ b/drivers/gpio/gpio_sifive.c
@@ -360,6 +360,8 @@ static int gpio_sifive_init(const struct device *dev)
 	gpio->fall_ie = 0U;
 	gpio->high_ie = 0U;
 	gpio->low_ie  = 0U;
+	gpio->iof_en  = 0U;
+	gpio->iof_sel = 0U;
 	gpio->invert  = 0U;
 
 	/* Setup IRQ handler for each gpio pin */


### PR DESCRIPTION
If the bootloader changes iof_en/iof_sel settings before zephyr launching, GPIO does not behave correctly.
These values should be 0 initially, Initialize to 0 at GPIO initialize.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>