### PR TITLE
Bluetooth: Host: Fix access of uninitialized bt_dev.le.acl_pkts

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -138,6 +138,7 @@ struct k_sem *bt_conn_get_pkts(struct bt_conn *conn)
 		return &bt_dev.br.pkts;
 	}
 #endif /* CONFIG_BT_BREDR */
+
 #if defined(CONFIG_BT_ISO)
 	/* Use ISO pkts semaphore if LE Read Buffer Size command returned
 	 * dedicated ISO buffers.
@@ -150,11 +151,14 @@ struct k_sem *bt_conn_get_pkts(struct bt_conn *conn)
 		return NULL;
 	}
 #endif /* CONFIG_BT_ISO */
+
 #if defined(CONFIG_BT_CONN)
-	return &bt_dev.le.acl_pkts;
-#else
-	return NULL;
+	if (bt_dev.le.acl_mtu) {
+		return &bt_dev.le.acl_pkts;
+	}
 #endif /* CONFIG_BT_CONN */
+
+	return NULL;
 }
 
 static inline const char *state2str(bt_conn_state_t state)
@@ -774,7 +778,16 @@ static int conn_prepare_events(struct bt_conn *conn,
 
 	LOG_DBG("Adding conn %p to poll list", conn);
 
-	bool buffers_available = k_sem_count_get(bt_conn_get_pkts(conn)) > 0;
+	/* ISO Synchronized Receiver only builds do not transmit and hence
+	 * may not have any tx buffers allocated in a Controller.
+	 */
+	struct k_sem *conn_pkts = bt_conn_get_pkts(conn);
+
+	if (!conn_pkts) {
+		return -ENOTCONN;
+	}
+
+	bool buffers_available = k_sem_count_get(conn_pkts) > 0;
 	bool packets_waiting = !k_fifo_is_empty(&conn->tx_queue);
 
 	if (packets_waiting && !buffers_available) {
@@ -785,7 +798,7 @@ static int conn_prepare_events(struct bt_conn *conn,
 		k_poll_event_init(&events[0],
 				  K_POLL_TYPE_SEM_AVAILABLE,
 				  K_POLL_MODE_NOTIFY_ONLY,
-				  bt_conn_get_pkts(conn));
+				  conn_pkts);
 	} else {
 		/* Wait until there is more data to send. */
 		LOG_DBG("wait on host fifo");


### PR DESCRIPTION
ISO Synchronized Receiver only builds do not transmit and
hence may not have any tx buffers allocated in a
Controller, leaving bt_dev.le.acl_pkts semaphore
uninitialized or bt_conn_get_pkts() returning NULL.
Do not use the semaphore if no Tx buffers allocated in a
Controller.

Regression in commit ef19c64f1b77 ("Bluetooth: host: poll on CTLR buffers instead of host TX queue").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>