### PR TITLE
cmake: armfvp: allow for extra arguments

### DIFF
--- a/boards/arm/fvp_baser_aemv8r_aarch32/doc/index.rst
+++ b/boards/arm/fvp_baser_aemv8r_aarch32/doc/index.rst
@@ -63,6 +63,19 @@ UART0.
 Programming and Debugging
 *************************
 
+Environment
+===========
+
+First, set the ``ARMFVP_BIN_PATH`` environment variable before building.
+Optionally, set ``ARMFVP_EXTRA_FLAGS`` to pass additional arguments to the FVP.
+
+.. code-block:: bash
+
+   export ARMFVP_BIN_PATH=/path/to/fvp/directory
+
+Programming
+===========
+
 Use this configuration to build basic Zephyr applications and kernel tests in the
 Arm FVP emulated environment, for example, with the :ref:`synchronization_sample`:
 
@@ -72,14 +85,8 @@ Arm FVP emulated environment, for example, with the :ref:`synchronization_sample
    :board: fvp_baser_aemv8r_aarch32
    :goals: build
 
-This will build an image with the synchronization sample app. To run with FVP,
-first set environment variable ``ARMFVP_BIN_PATH`` before using it. Then you
-can run it with ``west build -t run``.
-
-.. code-block:: bash
-
-   export ARMFVP_BIN_PATH=/path/to/fvp/directory
-   west build -t run
+This will build an image with the synchronization sample app.
+Then you can run it with ``west build -t run``.
 
 Debugging
 =========

--- a/boards/arm64/fvp_base_revc_2xaemv8a/doc/index.rst
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/doc/index.rst
@@ -56,6 +56,19 @@ Known Problems or Limitations
 Programming and Debugging
 *************************
 
+Environment
+===========
+
+First, set the ``ARMFVP_BIN_PATH`` environment variable before building.
+Optionally, set ``ARMFVP_EXTRA_FLAGS`` to pass additional arguments to the FVP.
+
+.. code-block:: bash
+
+   export ARMFVP_BIN_PATH=/path/to/fvp/directory
+
+Programming
+===========
+
 Use this configuration to build basic Zephyr applications and kernel tests in the
 ARM FVP emulated environment, for example, with the :ref:`synchronization_sample`:
 
@@ -66,10 +79,7 @@ ARM FVP emulated environment, for example, with the :ref:`synchronization_sample
    :goals: build
 
 This will build an image with the synchronization sample app.
-
-To run with FVP, ARMFVP_BIN_PATH must be set before running:
-
-e.g. export ARMFVP_BIN_PATH=<path/to/fvp/dir>
+Then you can run it with ``west build -t run``.
 
 Running Zephyr at EL1NS
 ***********************

--- a/boards/arm64/fvp_baser_aemv8r/doc/index.rst
+++ b/boards/arm64/fvp_baser_aemv8r/doc/index.rst
@@ -70,6 +70,19 @@ UART0.
 Programming and Debugging
 *************************
 
+Environment
+===========
+
+First, set the ``ARMFVP_BIN_PATH`` environment variable before building.
+Optionally, set ``ARMFVP_EXTRA_FLAGS`` to pass additional arguments to the FVP.
+
+.. code-block:: bash
+
+   export ARMFVP_BIN_PATH=/path/to/fvp/directory
+
+Programming
+===========
+
 Use this configuration to build basic Zephyr applications and kernel tests in the
 Arm FVP emulated environment, for example, with the :ref:`synchronization_sample`:
 
@@ -79,14 +92,8 @@ Arm FVP emulated environment, for example, with the :ref:`synchronization_sample
    :board: fvp_baser_aemv8r
    :goals: build
 
-This will build an image with the synchronization sample app. To run with FVP,
-first set environment variable ``ARMFVP_BIN_PATH`` before using it. Then you
-can run it with ``west build -t run``.
-
-.. code-block:: bash
-
-   export ARMFVP_BIN_PATH=/path/to/fvp/directory
-   west build -t run
+This will build an image with the synchronization sample app.
+Then you can run it with ``west build -t run``.
 
 Debugging
 =========

--- a/cmake/emu/armfvp.cmake
+++ b/cmake/emu/armfvp.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Arm Limited (or its affiliates). All rights reserved.
+# Copyright (c) 2021-2022 Arm Limited (or its affiliates). All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set(armfvp_bin_path $ENV{ARMFVP_BIN_PATH})
@@ -39,7 +39,7 @@ elseif(CONFIG_ARMV8_A_NS)
     if ((NOT DEFINED ARMFVP_${filetype}_FILE) AND (EXISTS "$ENV{ARMFVP_${filetype}_FILE}"))
       set(ARMFVP_${filetype}_FILE "$ENV{ARMFVP_${filetype}_FILE}" CACHE FILEPATH
         "ARM FVP ${filetype} File specified in environment"
-	)
+        )
     endif()
 
     if(NOT EXISTS "${ARMFVP_${filetype}_FILE}")
@@ -60,10 +60,16 @@ else()
     )
 endif()
 
+# Use flags passed in from the environment
+set(env_fvp $ENV{ARMFVP_EXTRA_FLAGS})
+separate_arguments(env_fvp)
+list(APPEND ARMFVP_EXTRA_FLAGS ${env_fvp})
+
 add_custom_target(run_armfvp
   COMMAND
   ${ARMFVP}
   ${ARMFVP_FLAGS}
+  ${ARMFVP_EXTRA_FLAGS}
   DEPENDS ${logical_target_for_zephyr_elf}
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   COMMENT "${ARMFVP_BIN_NAME}: ${armfvp_version}"


### PR DESCRIPTION
It is not currently possible to pass extra arguments when launching an FVP target.

This change is taking example on the qemu cmake file.

Signed-off-by: Ambroise Vincent <ambroise.vincent@arm.com>