### PR TITLE
settings: remove duplicated function prototypes

### DIFF
--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -26,7 +26,6 @@ LOG_MODULE_DECLARE(settings, CONFIG_SETTINGS_LOG_LEVEL);
 #define SETTINGS_FCB_VERS		1
 
 int settings_backend_init(void);
-void settings_mount_fcb_backend(struct settings_fcb *cf);
 
 static int settings_fcb_load(struct settings_store *cs,
 			     const struct settings_load_arg *arg);

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -27,7 +27,6 @@ LOG_MODULE_DECLARE(settings, CONFIG_SETTINGS_LOG_LEVEL);
 
 int settings_backend_init(void);
 void settings_mount_fcb_backend(struct settings_fcb *cf);
-static void *settings_fcb_storage_get(struct settings_store *cs);
 
 static int settings_fcb_load(struct settings_store *cs,
 			     const struct settings_load_arg *arg);

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -28,7 +28,6 @@ LOG_MODULE_DECLARE(settings, CONFIG_SETTINGS_LOG_LEVEL);
 #endif
 
 int settings_backend_init(void);
-void settings_mount_file_backend(struct settings_file *cf);
 
 static int settings_file_load(struct settings_store *cs,
 			      const struct settings_load_arg *arg);


### PR DESCRIPTION
Remove:
* second `settings_fcb_storage_get()` prototype
* local `settings_mount_fcb_backend()` (there is already prototype in header)
* local `settings_mount_file_backend()` (there is already prototype in header)