### PR TITLE
dts: stm32: f302: reset property missing from tim4 node

### DIFF
--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -78,6 +78,7 @@
 			compatible = "st,stm32-timers";
 			reg = <0x40000800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000004>;
+			resets = <&rctl STM32_RESET(APB1, 2U)>;
 			interrupts = <30 0>;
 			interrupt-names = "global";
 			st,prescaler = <0>;


### PR DESCRIPTION
reset is now a mandatory property in timer nodes

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>