### PR TITLE
drivers: ethernet: stm32f7: Enable use of HAL V2 API

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -18,7 +18,7 @@ if ETH_STM32_HAL
 
 config ETH_STM32_HAL_API_V2
 	bool "Use new HAL driver"
-	depends on SOC_SERIES_STM32H7X || SOC_SERIES_STM32F4X
+	depends on SOC_SERIES_STM32H7X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
 	help
 	  Use the new HAL driver instead of the legacy one.
 

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 6679ef7c30178191638f023f81f054cd053f5eb9
+      revision: 83cf59e4309e5f1758a76c0513c437e0fbcee40b
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Point to the modified version of hal_stm32 which allow to use ETH HAL V2 on stm32F7.
Update zephyr driver to allow it.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>