### PR TITLE
Bluetooth: Host: Add logging of pairing req/rsp

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1060,7 +1060,10 @@ static uint8_t smp_br_pairing_req(struct bt_smp_br *smp, struct net_buf *buf)
 	struct net_buf *rsp_buf;
 	uint8_t max_key_size;
 
-	LOG_DBG("");
+	LOG_DBG("req: io_capability 0x%02X, oob_flag 0x%02X, auth_req 0x%02X, "
+		"max_key_size 0x%02X, init_key_dist 0x%02X, resp_key_dist 0x%02X",
+		req->io_capability, req->oob_flag, req->auth_req,
+		req->max_key_size, req->init_key_dist, req->resp_key_dist);
 
 	/*
 	 * If a Pairing Request is received over the BR/EDR transport when
@@ -1109,6 +1112,11 @@ static uint8_t smp_br_pairing_req(struct bt_smp_br *smp, struct net_buf *buf)
 	smp->local_dist = rsp->resp_key_dist;
 	smp->remote_dist = rsp->init_key_dist;
 
+	LOG_DBG("rsp: io_capability 0x%02X, oob_flag 0x%02X, auth_req 0x%02X, "
+		"max_key_size 0x%02X, init_key_dist 0x%02X, resp_key_dist 0x%02X",
+		rsp->io_capability, rsp->oob_flag, rsp->auth_req,
+		rsp->max_key_size, rsp->init_key_dist, rsp->resp_key_dist);
+
 	smp_br_send(smp, rsp_buf, NULL);
 
 	atomic_set_bit(smp->flags, SMP_FLAG_PAIRING);
@@ -1144,7 +1152,10 @@ static uint8_t smp_br_pairing_rsp(struct bt_smp_br *smp, struct net_buf *buf)
 	struct bt_conn *conn = smp->chan.chan.conn;
 	uint8_t max_key_size;
 
-	LOG_DBG("");
+	LOG_DBG("rsp: io_capability 0x%02X, oob_flag 0x%02X, auth_req 0x%02X, "
+		"max_key_size 0x%02X, init_key_dist 0x%02X, resp_key_dist 0x%02X",
+		rsp->io_capability, rsp->oob_flag, rsp->auth_req,
+		rsp->max_key_size, rsp->init_key_dist, rsp->resp_key_dist);
 
 	max_key_size = bt_conn_enc_key_size(conn);
 	if (!max_key_size) {
@@ -2791,7 +2802,10 @@ static uint8_t smp_pairing_req(struct bt_smp *smp, struct net_buf *buf)
 	struct bt_smp_pairing *rsp;
 	uint8_t err;
 
-	LOG_DBG("");
+	LOG_DBG("req: io_capability 0x%02X, oob_flag 0x%02X, auth_req 0x%02X, "
+		"max_key_size 0x%02X, init_key_dist 0x%02X, resp_key_dist 0x%02X",
+		req->io_capability, req->oob_flag, req->auth_req,
+		req->max_key_size, req->init_key_dist, req->resp_key_dist);
 
 	if ((req->max_key_size > BT_SMP_MAX_ENC_KEY_SIZE) ||
 	    (req->max_key_size < BT_SMP_MIN_ENC_KEY_SIZE)) {
@@ -2903,6 +2917,12 @@ static uint8_t smp_pairing_req(struct bt_smp *smp, struct net_buf *buf)
 	}
 
 	atomic_set_bit(smp->allowed_cmds, BT_SMP_CMD_PUBLIC_KEY);
+
+	LOG_DBG("rsp: io_capability 0x%02X, oob_flag 0x%02X, auth_req 0x%02X, "
+		"max_key_size 0x%02X, init_key_dist 0x%02X, resp_key_dist 0x%02X",
+		rsp->io_capability, rsp->oob_flag, rsp->auth_req,
+		rsp->max_key_size, rsp->init_key_dist, rsp->resp_key_dist);
+
 	return send_pairing_rsp(smp);
 }
 #else
@@ -3010,6 +3030,11 @@ static int smp_send_pairing_req(struct bt_conn *conn)
 	smp->preq[0] = BT_SMP_CMD_PAIRING_REQ;
 	memcpy(smp->preq + 1, req, sizeof(*req));
 
+	LOG_DBG("req: io_capability 0x%02X, oob_flag 0x%02X, auth_req 0x%02X, "
+		"max_key_size 0x%02X, init_key_dist 0x%02X, resp_key_dist 0x%02X",
+		req->io_capability, req->oob_flag, req->auth_req,
+		req->max_key_size, req->init_key_dist, req->resp_key_dist);
+
 	smp_send(smp, req_buf, NULL, NULL);
 
 	atomic_set_bit(smp->allowed_cmds, BT_SMP_CMD_PAIRING_RSP);
@@ -3027,7 +3052,10 @@ static uint8_t smp_pairing_rsp(struct bt_smp *smp, struct net_buf *buf)
 	struct bt_smp_pairing *req = (struct bt_smp_pairing *)&smp->preq[1];
 	uint8_t err;
 
-	LOG_DBG("");
+	LOG_DBG("rsp: io_capability 0x%02X, oob_flag 0x%02X, auth_req 0x%02X, "
+		"max_key_size 0x%02X, init_key_dist 0x%02X, resp_key_dist 0x%02X",
+		rsp->io_capability, rsp->oob_flag, rsp->auth_req,
+		rsp->max_key_size, rsp->init_key_dist, rsp->resp_key_dist);
 
 	if ((rsp->max_key_size > BT_SMP_MAX_ENC_KEY_SIZE) ||
 	    (rsp->max_key_size < BT_SMP_MIN_ENC_KEY_SIZE)) {


### PR DESCRIPTION
Add logging of the fields in the sent and received pairing requests and responses. This makes it easier to debug why a pairing would be e.g. rejected, or simply to get more insight in the resulting pairing.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>