### PR TITLE
boards: arm: bl654_usb: Fix USB CDC enablement with MCUboot

### DIFF
--- a/boards/arm/bl654_usb/Kconfig.defconfig
+++ b/boards/arm/bl654_usb/Kconfig.defconfig
@@ -37,7 +37,7 @@ config UART_CONSOLE
 	default CONSOLE
 
 config USB_DEVICE_INITIALIZE_AT_BOOT
-	default y
+	default y if !MCUBOOT
 
 config SHELL_BACKEND_SERIAL_CHECK_DTR
 	default SHELL


### PR DESCRIPTION
Prevents USB being initialised at boot if target is MCUboot, this allows for building MCUboot with serial recovery without preventing it from working.