### PR TITLE
Give uart_irq_callback_user_data_set a return value

### DIFF
--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -1160,10 +1160,14 @@ static inline int z_impl_uart_irq_update(const struct device *dev)
  * @param dev UART device instance.
  * @param cb Pointer to the callback function.
  * @param user_data Data to pass to callback function.
+ *
+ * @retval 0 On success.
+ * @retval -ENOSYS If this function is not implemented.
+ * @retval -ENOTSUP If API is not enabled.
  */
-static inline void uart_irq_callback_user_data_set(const struct device *dev,
-						   uart_irq_callback_user_data_t cb,
-						   void *user_data)
+static inline int uart_irq_callback_user_data_set(const struct device *dev,
+						  uart_irq_callback_user_data_t cb,
+						  void *user_data)
 {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	const struct uart_driver_api *api =
@@ -1171,11 +1175,15 @@ static inline void uart_irq_callback_user_data_set(const struct device *dev,
 
 	if ((api != NULL) && (api->irq_callback_set != NULL)) {
 		api->irq_callback_set(dev, cb, user_data);
+		return 0;
+	} else {
+		return -ENOSYS;
 	}
 #else
 	ARG_UNUSED(dev);
 	ARG_UNUSED(cb);
 	ARG_UNUSED(user_data);
+	return -ENOTSUP;
 #endif
 }
 
@@ -1187,11 +1195,15 @@ static inline void uart_irq_callback_user_data_set(const struct device *dev,
  *
  * @param dev UART device instance.
  * @param cb Pointer to the callback function.
+ *
+ * @retval 0 On success.
+ * @retval -ENOSYS If this function is not implemented.
+ * @retval -ENOTSUP If API is not enabled.
  */
-static inline void uart_irq_callback_set(const struct device *dev,
+static inline int uart_irq_callback_set(const struct device *dev,
 					 uart_irq_callback_user_data_t cb)
 {
-	uart_irq_callback_user_data_set(dev, cb, NULL);
+	return uart_irq_callback_user_data_set(dev, cb, NULL);
 }
 
 /**

--- a/samples/drivers/uart/echo_bot/src/main.c
+++ b/samples/drivers/uart/echo_bot/src/main.c
@@ -78,7 +78,18 @@ void main(void)
 	}
 
 	/* configure interrupt and callback to receive data */
-	uart_irq_callback_user_data_set(uart_dev, serial_cb, NULL);
+	int ret = uart_irq_callback_user_data_set(uart_dev, serial_cb, NULL);
+
+	if (ret < 0) {
+		if (ret == -ENOTSUP) {
+			printk("Interrupt-driven UART API support not enabled\n");
+		} else if (ret == -ENOSYS) {
+			printk("UART device does not support interrupt-driven API\n");
+		} else {
+			printk("Error setting UART callback: %d\n", ret);
+		}
+		return;
+	}
 	uart_irq_rx_enable(uart_dev);
 
 	print_uart("Hello! I'm your echo bot.\r\n");


### PR DESCRIPTION
Allows detecting support for interrupt-drive API.  There isn't a good way otherwise.  Async UART API has a return value for the callback set function.