### PR TITLE
logging: backend_uart: Reword buffer size Kconfig text

### DIFF
--- a/subsys/logging/backends/Kconfig.uart
+++ b/subsys/logging/backends/Kconfig.uart
@@ -17,12 +17,16 @@ config LOG_BACKEND_UART_ASYNC
 	depends on !LOG_BACKEND_UART_OUTPUT_DICTIONARY_HEX
 
 config LOG_BACKEND_UART_BUFFER_SIZE
-	int "Number of bytes to buffer in RAM before flushing"
+	int "Maximum number of bytes to buffer in RAM before flushing"
 	default 32 if LOG_BACKEND_UART_ASYNC
 	default 1
 	help
-	  Sets the number of bytes which can be buffered in RAM before log_output_flush
-	  is automatically called on the backend.
+	  In deferred logging mode, sets the maximum number of bytes which can be buffered in
+	  RAM before log_output_flush is automatically called on the UART backend.  The buffer
+	  will also be flushed after each log message.
+
+	  In immediate logging mode, processed log messages are not buffered and are always
+	  output one byte at a time.
 
 config LOG_BACKEND_UART_AUTOSTART
 	bool "Automatically start UART backend"


### PR DESCRIPTION
As written, the title and description of the Kconfig option seem to specify the logging sub-system will not flush until the buffer is full. Someone reading this would expect that shorter log message will not be flushed until the specified number of bytes accumulate.

This is not the case.  Each log message is flushed when finished.  The size is only the maximum bytes of a single formatted message's contents that will be accumated before the backend flushes.

What's more, it only applies in deferred mode.  In immediate mode there is no buffering, not just of multiple log messages but also of the message contents as they are formatted.