### PR TITLE
include: dt-bindings: pinctrl_stm32: Fix output level definitions

### DIFF
--- a/include/zephyr/dt-bindings/pinctrl/stm32-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/stm32-pinctrl.h
@@ -74,7 +74,7 @@
  *    GPIO Output type    [ 6 ]
  *    GPIO Speed          [ 7 : 8 ]
  *    GPIO PUPD config    [ 9 : 10 ]
- *    GPIO Output data     [ 11 ]
+ *    GPIO Output data    [ 11: 12 ]
  *
  */
 
@@ -108,9 +108,9 @@
 #define STM32_PUPDR_SHIFT		9
 
 /* GPIO plain output value */
-#define STM32_ODR_0			(0x0 << STM32_ODR_SHIFT)
-#define STM32_ODR_1			(0x1 << STM32_ODR_SHIFT)
-#define STM32_ODR_MASK			0x1
-#define STM32_ODR_SHIFT			11
+#define STM32_ODR_0			(0x1 << STM32_ODR_SHIFT)
+#define STM32_ODR_1			(0x2 << STM32_ODR_SHIFT)
+#define STM32_ODR_MASK			0x3
+#define STM32_ODR_SHIFT			12
 
 #endif	/* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_STM32_PINCTRL_H_ */

--- a/soc/arm/st_stm32/common/pinctrl_soc.h
+++ b/soc/arm/st_stm32/common/pinctrl_soc.h
@@ -51,8 +51,8 @@ typedef struct pinctrl_soc_pin {
 #define STM32_PULL_DOWN   0x2
 #define STM32_PUSH_PULL   0x0
 #define STM32_OPEN_DRAIN  0x1
-#define STM32_OUTPUT_LOW  0x0
-#define STM32_OUTPUT_HIGH 0x1
+#define STM32_OUTPUT_LOW  0x1
+#define STM32_OUTPUT_HIGH 0x2
 
 #ifdef CONFIG_SOC_SERIES_STM32F1X
 /**


### PR DESCRIPTION
Using 0/1 to define output level high/low leads to an issue when evaluating pin description using pinctrl which consider 3 cases -output-high
-output-low
-nothing > input

This breaks in function pinctrl_configure_pins() which performs the following:
	uint32_t gpio_out = pins[i].pincfg &
				(STM32_ODR_MASK << STM32_ODR_SHIFT);
	if (gpio_out != 0) {
		pin_cgf = pins[i].pincfg | STM32_MODER_OUTPUT_MODE;
	} else {
		pin_cgf = pins[i].pincfg | STM32_MODER_INPUT_MODE;
	}

2 values are not sufficient to encode the 3 cases to consider. Fix this by defining output level on 2 bits.

This doesn't break anything because this specific value is never set directly into register, but instead we're calling dedicated set/clear functions.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>