### PR TITLE
mgmt/mcumgr: Remove inclusion of mgmt.h from smp/smp.h

### DIFF
--- a/include/zephyr/mgmt/mcumgr/smp/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp/smp.h
@@ -27,7 +27,6 @@
 
 #include <zephyr/net/buf.h>
 #include <zephyr/mgmt/mcumgr/transport/smp.h>
-#include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>
 
 #include <zcbor_common.h>
 


### PR DESCRIPTION
Unneded header.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>