### PR TITLE
drivers: flash: flash page layout returns error if pages_size null

### DIFF
--- a/drivers/flash/flash_stm32l5x.c
+++ b/drivers/flash/flash_stm32l5x.c
@@ -360,10 +360,9 @@ void flash_stm32_page_layout(const struct device *dev,
 	static struct flash_pages_layout stm32_flash_layout[3];
 
 	*layout = stm32_flash_layout;
-	*layout_size = ARRAY_SIZE(stm32_flash_layout);
 
 	if (stm32_flash_layout[0].pages_count != 0) {
-		/* Short circuit calculation logic if already performed */
+		/* Short circuit calculation logic if already performed (size is known) */
 		return;
 	}
 
@@ -386,6 +385,8 @@ void flash_stm32_page_layout(const struct device *dev,
 		/* Bank2 */
 		stm32_flash_layout[2].pages_count = PAGES_PER_BANK;
 		stm32_flash_layout[2].pages_size = FLASH_PAGE_SIZE;
+
+		*layout_size = ARRAY_SIZE(stm32_flash_layout);
 	} else {
 		/*
 		 * For stm32l562xx & stm32l552xx with 512 flash or stm32u58x
@@ -404,6 +405,11 @@ void flash_stm32_page_layout(const struct device *dev,
 			stm32_flash_layout[0].pages_size = FLASH_PAGE_SIZE_128_BITS;
 #endif /* CONFIG_SOC_SERIES_STM32L5X */
 		}
-	}
 
+		/*
+		 * In this case the stm32_flash_layout table has one single element
+		 * when read by the flash_get_page_info()
+		 */
+		*layout_size = 1;
+	}
 }


### PR DESCRIPTION
Return the error code if the layout->pages_size is null instead of going to a "divide by zero" fault
This can occur when CONFIG_FLASH_PAGE_LAYOUT is set and read out of range.

Run samples/drivers/flash_shell on a stm32u575 nucleo board  and read flash out of range :
```
flash read 0x2a0000 0x100
Read ERROR!
[00:00:13.919,000] <err> flash_stm32: Read range invalid. Offset: 2752512, len: 16

```

With the page layout **CONFIG_FLASH_PAGE_LAYOUT=y**
```
flash read 0x2a0000 0x100
[00:00:20.887,000] <err> os: ***** USAGE FAULT *****
[00:00:20.887,000] <err> os:   Division by zero
[00:00:20.887,000] <err> os: r0/a1:  0x200010f4  r1/a2:  0x00200000  r2/a3:  0x00000100
[00:00:20.887,000] <err> os: r3/a4:  0x000a0000 r12/ip:  0x00000100 r14/lr:  0x0800c021
[00:00:20.887,000] <err> os:  xpsr:  0x21000000
[00:00:20.887,000] <err> os: Faulting instruction address (r15/pc): 0x0800c060
[00:00:20.887,000] <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
[00:00:20.887,000] <err> os: Current thread: 0x20000700 (shell_uart)
[00:00:20.950,000] <err> os: Halting system

```

This change avoid the Usage Fault 

Signed-off-by: Francois Ramu <francois.ramu@st.com>