### PR TITLE
drivers/i2c: stm32: Use dts for i2c clock source

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -29,7 +29,8 @@ struct i2c_stm32_config {
 #ifdef CONFIG_I2C_STM32_INTERRUPT
 	irq_config_func_t irq_config_func;
 #endif
-	struct stm32_pclken pclken;
+	const struct stm32_pclken *pclken;
+	size_t pclk_len;
 	I2C_TypeDef *i2c;
 	uint32_t bitrate;
 	const struct pinctrl_dev_config *pcfg;

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -179,7 +179,8 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>,
+				 <&rcc STM32_SRC_SYSCLK I2C1_SEL(1)>;
 			interrupts = <23 0>;
 			interrupt-names = "combined";
 			status = "disabled";

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -213,7 +213,8 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>,
+				 <&rcc STM32_SRC_SYSCLK I2C1_SEL(1)>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -19,7 +19,8 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00400000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00400000>,
+				 <&rcc STM32_SRC_SYSCLK I2C2_SEL(1)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -31,7 +32,8 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007800 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x40000000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x40000000>,
+				 <&rcc STM32_SRC_SYSCLK I2C3_SEL(1)>;
 			interrupts = <72 0>, <73 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -6,7 +6,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <zephyr/dt-bindings/clock/stm32f4_clock.h>
+#include <zephyr/dt-bindings/clock/stm32f7_clock.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>

--- a/include/zephyr/dt-bindings/clock/stm32f7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f7_clock.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F7_CLOCK_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F7_CLOCK_H_
+
+/** Domain clocks */
+
+/** Bus clocks */
+#define STM32_CLOCK_BUS_AHB1    0x030
+#define STM32_CLOCK_BUS_AHB2    0x034
+#define STM32_CLOCK_BUS_AHB3    0x038
+#define STM32_CLOCK_BUS_APB1    0x040
+#define STM32_CLOCK_BUS_APB2    0x044
+#define STM32_CLOCK_BUS_APB3    0x0A8
+
+#define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
+#define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB3
+
+/** Domain clocks */
+/* RM0386, 0390, 0402, 0430 § Dedicated Clock configuration register (RCC_DCKCFGRx) */
+
+/** PLL clock outputs */
+#define STM32_SRC_PLL_P	0x001
+#define STM32_SRC_PLL_Q	0x002
+#define STM32_SRC_PLL_R	0x003
+/** Fixed clocks */
+#define STM32_SRC_LSE	0x004
+#define STM32_SRC_LSI	0x005
+#define STM32_SRC_HSI	0x008
+/** System clock */
+#define STM32_SRC_SYSCLK 0x006
+/** Peripheral bus clock */
+#define STM32_SRC_PCLK	0x007
+
+/**
+ * @brief STM32 clock configuration bit field.
+ *
+ * - reg   (1/2/3)         [ 0 : 7 ]
+ * - shift (0..31)         [ 8 : 12 ]
+ * - mask  (0x1, 0x3, 0x7) [ 13 : 15 ]
+ * - val   (0..7)          [ 16 : 18 ]
+ *
+ * @param reg RCC_CFGRx register offset
+ * @param shift Position within RCC_CFGRx.
+ * @param mask Mask for the RCC_CFGRx field.
+ * @param val Clock value (0, 1, ... 7).
+ */
+
+#define STM32_CLOCK_REG_MASK    0xFFU
+#define STM32_CLOCK_REG_SHIFT   0U
+#define STM32_CLOCK_SHIFT_MASK  0x1FU
+#define STM32_CLOCK_SHIFT_SHIFT 8U
+#define STM32_CLOCK_MASK_MASK   0x7U
+#define STM32_CLOCK_MASK_SHIFT  13U
+#define STM32_CLOCK_VAL_MASK    0x7U
+#define STM32_CLOCK_VAL_SHIFT   16U
+
+#define STM32_CLOCK(val, mask, shift, reg)					\
+	((((reg) & STM32_CLOCK_REG_MASK) << STM32_CLOCK_REG_SHIFT) |		\
+	 (((shift) & STM32_CLOCK_SHIFT_MASK) << STM32_CLOCK_SHIFT_SHIFT) |	\
+	 (((mask) & STM32_CLOCK_MASK_MASK) << STM32_CLOCK_MASK_SHIFT) |		\
+	 (((val) & STM32_CLOCK_VAL_MASK) << STM32_CLOCK_VAL_SHIFT))
+
+/** @brief RCC_BDCR register offset */
+#define BDCR_REG		0x70
+
+/** @brief Device domain clocks selection helpers */
+/** BDCR devices */
+#define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+
+/** @brief RCC_DKCFGR register offset */
+#define DKCFGR1_REG		0x54
+#define DKCFGR2_REG		0x58
+
+/** @brief Dedicated clocks configuration register selection helpers */
+/** DKCFGR2 devices */
+#define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, DKCFGR2_REG)
+#define USART2_SEL(val)		STM32_CLOCK(val, 3, 2, DKCFGR2_REG)
+#define USART3_SEL(val)		STM32_CLOCK(val, 3, 4, DKCFGR2_REG)
+#define USART4_SEL(val)		STM32_CLOCK(val, 1, 6, DKCFGR2_REG)
+#define USART5_SEL(val)		STM32_CLOCK(val, 3, 8, DKCFGR2_REG)
+#define USART6_SEL(val)		STM32_CLOCK(val, 3, 10, DKCFGR2_REG)
+#define USART7_SEL(val)		STM32_CLOCK(val, 3, 12, DKCFGR2_REG)
+#define USART8_SEL(val)		STM32_CLOCK(val, 3, 14, DKCFGR2_REG)
+#define I2C1_SEL(val)		STM32_CLOCK(val, 3, 16, DKCFGR2_REG)
+#define I2C2_SEL(val)		STM32_CLOCK(val, 3, 18, DKCFGR2_REG)
+#define I2C3_SEL(val)		STM32_CLOCK(val, 3, 20, DKCFGR2_REG)
+#define LPTIM1_SEL(val)		STM32_CLOCK(val, 3, 24, DKCFGR2_REG)
+#define CK48M_SEL(val)		STM32_CLOCK(val, 1, 27, DKCFGR2_REG)
+#define SDMMC1_SEL(val)		STM32_CLOCK(val, 1, 28, DKCFGR2_REG)
+#define SDMMC2_SEL(val)		STM32_CLOCK(val, 1, 29, DKCFGR2_REG)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F7_CLOCK_H_ */


### PR DESCRIPTION
This PR adds support of the I2C clock source for STM32 in the dts file.

Fixes #52675