### PR TITLE
include: dt-bindings: pinctrl_stm32: Fix for pinctrl GPIO-out pin confguration

### DIFF
--- a/drivers/pinctrl/pinctrl_stm32.c
+++ b/drivers/pinctrl/pinctrl_stm32.c
@@ -236,13 +236,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 		} else if (STM32_DT_PINMUX_FUNC(mux) == STM32_ANALOG) {
 			pin_cgf = STM32_MODER_ANALOG_MODE;
 		} else if (STM32_DT_PINMUX_FUNC(mux) == STM32_GPIO) {
-			uint32_t gpio_out = pins[i].pincfg &
-						(STM32_ODR_MASK << STM32_ODR_SHIFT);
-			if (gpio_out != 0) {
-				pin_cgf = pins[i].pincfg | STM32_MODER_OUTPUT_MODE;
-			} else {
-				pin_cgf = pins[i].pincfg | STM32_MODER_INPUT_MODE;
-			}
+			pin_cgf = pins[i].pincfg;
 		} else {
 			/* Not supported */
 			__ASSERT_NO_MSG(STM32_DT_PINMUX_FUNC(mux));

--- a/soc/arm/st_stm32/common/pinctrl_soc.h
+++ b/soc/arm/st_stm32/common/pinctrl_soc.h
@@ -53,6 +53,7 @@ typedef struct pinctrl_soc_pin {
 #define STM32_OPEN_DRAIN  0x1
 #define STM32_OUTPUT_LOW  0x0
 #define STM32_OUTPUT_HIGH 0x1
+#define STM32_GPIO_OUTPUT 0x1
 
 #ifdef CONFIG_SOC_SERIES_STM32F1X
 /**
@@ -83,6 +84,8 @@ typedef struct pinctrl_soc_pin {
 	 ((STM32_OPEN_DRAIN * DT_PROP(node_id, drive_open_drain)) << STM32_OTYPER_SHIFT) | \
 	 ((STM32_OUTPUT_LOW * DT_PROP(node_id, output_low)) << STM32_ODR_SHIFT) | \
 	 ((STM32_OUTPUT_HIGH * DT_PROP(node_id, output_high)) << STM32_ODR_SHIFT) | \
+	 ((STM32_GPIO_OUTPUT * DT_PROP(node_id, output_low)) << STM32_MODER_SHIFT) | \
+	 ((STM32_GPIO_OUTPUT * DT_PROP(node_id, output_high)) << STM32_MODER_SHIFT) | \
 	 (DT_ENUM_IDX(node_id, slew_rate) << STM32_OSPEEDR_SHIFT))
 #endif /* CONFIG_SOC_SERIES_STM32F1X */
 


### PR DESCRIPTION
Added information about pin mode into Z_PINCTRL_STM32_PINCFG_INIT. _pinctrl_configure_pins()_ does not need to figure out GPIO pin direction now. 
