### PR TITLE
boards: make names in platform YAML files unique

### DIFF
--- a/boards/arm/arduino_portenta_h7/arduino_portenta_h7_m4.yaml
+++ b/boards/arm/arduino_portenta_h7/arduino_portenta_h7_m4.yaml
@@ -1,5 +1,5 @@
 identifier: arduino_portenta_h7_m4
-name: Arduino Portenta H7
+name: Arduino Portenta H7 (M4)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/arduino_portenta_h7/arduino_portenta_h7_m7.yaml
+++ b/boards/arm/arduino_portenta_h7/arduino_portenta_h7_m7.yaml
@@ -1,5 +1,5 @@
 identifier: arduino_portenta_h7_m7
-name: Arduino Portenta H7
+name: Arduino Portenta H7 (M7)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/blackpill_f401cc/blackpill_f401cc.yaml
+++ b/boards/arm/blackpill_f401cc/blackpill_f401cc.yaml
@@ -1,5 +1,5 @@
 identifier: blackpill_f401cc
-name: WeAct Studio Black Pill V3.0
+name: WeAct Studio Black Pill V3.0 (F401CC)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/blackpill_f401ce/blackpill_f401ce.yaml
+++ b/boards/arm/blackpill_f401ce/blackpill_f401ce.yaml
@@ -1,5 +1,5 @@
 identifier: blackpill_f401ce
-name: WeAct Studio Black Pill V3.0
+name: WeAct Studio Black Pill V3.0 (F401CE)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0.yaml
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m0.yaml
@@ -6,7 +6,7 @@
 #
 
 identifier: cy8ckit_062_ble_m0
-name: Cypress PSoC6 BLE Pioneer Kit
+name: Cypress PSoC6 BLE Pioneer Kit (M0)
 type: mcu
 arch: arm
 ram: 288

--- a/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m4.yaml
+++ b/boards/arm/cy8ckit_062_ble/cy8ckit_062_ble_m4.yaml
@@ -6,7 +6,7 @@
 #
 
 identifier: cy8ckit_062_ble_m4
-name: Cypress PSoC6 BLE Pioneer Kit
+name: Cypress PSoC6 BLE Pioneer Kit (M4)
 type: mcu
 arch: arm
 ram: 288

--- a/boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m0.yaml
+++ b/boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m0.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: cy8ckit_062_wifi_bt_m0
-name: Cypress PSoC6 WiFi-BT Pioneer Kit
+name: Cypress PSoC6 WiFi-BT Pioneer Kit (M0)
 type: mcu
 arch: arm
 ram: 288

--- a/boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m4.yaml
+++ b/boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m4.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: cy8ckit_062_wifi_bt_m4
-name: Cypress PSoC6 WiFi-BT Pioneer Kit
+name: Cypress PSoC6 WiFi-BT Pioneer Kit (M4)
 type: mcu
 arch: arm
 ram: 288

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.yaml
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: lpcxpresso55s69_cpu0
-name: NXP LPCXpresso55S69
+name: NXP LPCXpresso55S69 (CPU0)
 type: mcu
 arch: arm
 ram: 64

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.yaml
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: lpcxpresso55s69_cpu1
-name: NXP LPCXpresso55S69
+name: NXP LPCXpresso55S69 (CPU1)
 type: mcu
 arch: arm
 ram: 64

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_ns.yaml
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_ns.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: lpcxpresso55s69_ns
-name: NXP LPCXpresso55S69
+name: NXP LPCXpresso55S69 (Non-Secure)
 type: mcu
 arch: arm
 ram: 136

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m4.yaml
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m4.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_h745zi_q_m4
-name: ST Nucleo H745ZI-Q
+name: ST Nucleo H745ZI-Q (M4)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.yaml
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_h745zi_q_m7
-name: ST Nucleo H745ZI-Q
+name: ST Nucleo H745ZI-Q (M7)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32_min_dev/stm32_min_dev_black.yaml
+++ b/boards/arm/stm32_min_dev/stm32_min_dev_black.yaml
@@ -1,5 +1,5 @@
 identifier: stm32_min_dev_black
-name: STM32 Minimum Development Board
+name: STM32 Minimum Development Board (Black)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32_min_dev/stm32_min_dev_blue.yaml
+++ b/boards/arm/stm32_min_dev/stm32_min_dev_blue.yaml
@@ -1,5 +1,5 @@
 identifier: stm32_min_dev_blue
-name: STM32 Minimum Development Board
+name: STM32 Minimum Development Board (Blue)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m4.yaml
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m4.yaml
@@ -1,5 +1,5 @@
 identifier: stm32h747i_disco_m4
-name: ST STM32H747I Discovery
+name: ST STM32H747I Discovery (M4)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.yaml
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.yaml
@@ -1,5 +1,5 @@
 identifier: stm32h747i_disco_m7
-name: ST STM32H747I Discovery
+name: ST STM32H747I Discovery (M7)
 type: mcu
 arch: arm
 toolchain:

--- a/boards/riscv/rv32m1_vega/rv32m1_vega_ri5cy.yaml
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega_ri5cy.yaml
@@ -1,5 +1,5 @@
 identifier: rv32m1_vega_ri5cy
-name: RV32M1-VEGA
+name: RV32M1-VEGA (RI5CY)
 type: mcu
 arch: riscv32
 toolchain:

--- a/boards/riscv/rv32m1_vega/rv32m1_vega_zero_riscy.yaml
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega_zero_riscy.yaml
@@ -1,5 +1,5 @@
 identifier: rv32m1_vega_zero_riscy
-name: RV32M1-VEGA
+name: RV32M1-VEGA (ZERO-RISCY)
 type: mcu
 arch: riscv32
 toolchain:

--- a/boards/xtensa/esp32s2_franzininho/esp32s2_franzininho.yaml
+++ b/boards/xtensa/esp32s2_franzininho/esp32s2_franzininho.yaml
@@ -1,5 +1,5 @@
 identifier: esp32s2_franzininho
-name: ESP32-S2
+name: ESP32-S2 Franzininho
 type: mcu
 arch: xtensa
 toolchain:

--- a/boards/xtensa/esp32s2_saola/esp32s2_saola.yaml
+++ b/boards/xtensa/esp32s2_saola/esp32s2_saola.yaml
@@ -1,5 +1,5 @@
 identifier: esp32s2_saola
-name: ESP32-S2
+name: ESP32-S2 Saola
 type: mcu
 arch: xtensa
 toolchain:


### PR DESCRIPTION
Some platforms have duplicate platform names. These duplicate names are:
- Arduino Portenta H7
- WeAct Studio Black Pill V3.0
- Cypress PSoC6 BLE Pioneer Kit
- Cypress PSoC6 WiFi-BT Pioneer Kit
- NXP LPCXpresso55S69
- ST Nucleo H745ZI-Q
- STM32 Minimum Development Board
- ST STM32H747I Discovery
- RV32M1-VEGA
- ESP32-S2

Since Zephyr already keeps platform data in a nice and structured format, the `name` which is most likely to be used as a platform's display name by external tools/sites (e.g. [Renodepedia](https://zephyr-dashboard.renode.io/renodepedia/)), we might as well make them unique.