### PR TITLE
manifest: MCUboot upgrade

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -182,7 +182,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: ef863820efe62cda092c51ad8a0836d663684583
+      revision: dd59d907639b81f3c0556ebf6e9249f85482b407
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
MCUboot was synchronized to
https://github.com/mcu-tools/mcuboot/commit/d165e9b

ci: fih: update TF-M version to 1.7.0 and adjust test suite docs: fix FIH example command in design.md
boot: Update Nordic's license identifier tag
espressif: add downgrade prevention feature
boot: zephyr: boards: nrf52840dk: Fix overlay