### PR TITLE
manifest: hal_nxp: Replace PR with SHA

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -93,8 +93,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      # revision: 0ee50e0796d66307c8a99e9178140e7432b1eaba
-      revision: refs/pull/213/head
+      revision: e31187c0046473fe76578712964238b9c1cf3c0b
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
The previous PR had been merged mistakenly, and it contained a reference to a PR. Point to a SHA instead now that
https://github.com/zephyrproject-rtos/hal_nxp/pull/213 has been merged.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>