### PR TITLE
clang-format: Enable InsertBraces option

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -77,6 +77,7 @@ IncludeCategories:
     Priority: 3
 IndentCaseLabels: false
 IndentWidth: 8
+InsertBraces: true
 # SpaceBeforeParens: ControlStatementsExceptControlMacros # clang-format >= 13.0
 SortIncludes: false
 UseTab: Always

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -10,7 +10,7 @@ gitlint
 junit2html
 
 # helper for developers - code formatter
-clang-format>=1.13x
+clang-format>=15.0.0
 
 # Script used to build firmware images for NXP LPC MCUs.
 lpc_checksum


### PR DESCRIPTION
Zephyr's coding guidelines require braces on every code block body. Enable InsertBraces option so clang-format automatically adds these braces.

Signed-off-by: Keith Short <keithshort@google.com>