### PR TITLE
dma: hda: dma channel status check

### DIFF
--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -231,6 +231,11 @@ int intel_adsp_hda_dma_start(const struct device *dev, uint32_t channel)
 
 	__ASSERT(channel < cfg->dma_channels, "Channel does not exist");
 
+	/* checking if channel has been already enabled */
+	if (*DGCS(cfg->base, cfg->regblock_size, channel) & DGCS_GEN) {
+		return -EINVAL;
+	}
+
 	intel_adsp_hda_enable(cfg->base, cfg->regblock_size, channel);
 	if (cfg->direction == MEMORY_TO_PERIPHERAL) {
 		size = intel_adsp_hda_get_buffer_size(cfg->base, cfg->regblock_size, channel);
@@ -245,6 +250,11 @@ int intel_adsp_hda_dma_stop(const struct device *dev, uint32_t channel)
 	const struct intel_adsp_hda_dma_cfg *const cfg = dev->config;
 
 	__ASSERT(channel < cfg->dma_channels, "Channel does not exist");
+
+	/* checking if channel has been already disabled */
+	if ((*DGCS(cfg->base, cfg->regblock_size, channel) & DGCS_GEN) == 0) {
+		return -EINVAL;
+	}
 
 	intel_adsp_hda_disable(cfg->base, cfg->regblock_size, channel);
 

--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -202,6 +202,7 @@ int intel_adsp_hda_dma_status(const struct device *dev, uint32_t channel,
 	stat->read_position = *DGBRP(cfg->base, cfg->regblock_size, channel);
 	stat->pending_length = used;
 	stat->free = unused;
+	stat->enabled = *DGCS(cfg->base, cfg->regblock_size, channel) & DGCS_GEN;
 
 	return 0;
 }

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -219,6 +219,7 @@ struct dma_config {
  * DMA runtime status structure
  *
  * busy 			- is current DMA transfer busy or idle
+ * enabled			- is current DMA enabled
  * dir				- DMA transfer direction
  * pending_length 		- data length pending to be transferred in bytes
  * 					or platform dependent.
@@ -229,6 +230,7 @@ struct dma_config {
  */
 struct dma_status {
 	bool busy;
+	bool enabled;
 	enum dma_channel_direction dir;
 	uint32_t pending_length;
 	uint32_t free;


### PR DESCRIPTION
To avoid enabling power gaiting on HST power domain by mistake we need to be shore that DMA stop function is called only once per channel. PM device context is counting usage for entire HDA controller. 

For example, in scenario with usage of two DMA channels, disabling twice the same channel will result with removing PG prevent on entire power domain, despite that the second channel will be still in use.