### PR TITLE
scripts: dts: gen_driver_kconfig_dts: Use SafeLoader

### DIFF
--- a/scripts/dts/gen_driver_kconfig_dts.py
+++ b/scripts/dts/gen_driver_kconfig_dts.py
@@ -12,9 +12,9 @@ import re
 import yaml
 try:
     # Use the C LibYAML parser if available, rather than the Python parser.
-    from yaml import CLoader as Loader
+    from yaml import CSafeLoader as SafeLoader
 except ImportError:
-    from yaml import Loader     # type: ignore
+    from yaml import SafeLoader     # type: ignore
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'python-devicetree',
                                 'src'))
@@ -75,7 +75,7 @@ def main():
             try:
                 # Parsed PyYAML output (Python lists/dictionaries/strings/etc.,
                 # representing the file)
-                raw = yaml.load(contents, Loader=Loader)
+                raw = yaml.load(contents, Loader=SafeLoader)
             except yaml.YAMLError as e:
                 print(f"WARNING: '{binding_path}' appears in binding "
                       f"directories but isn't valid YAML: {e}")


### PR DESCRIPTION
Using SafeLoader is preferrable where possible.

Signed-off-by: Moritz Fischer <moritzf@google.com>