### PR TITLE
net: lwm2m: add callback for send confirmation

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -2087,35 +2087,71 @@ void lwm2m_rd_client_update(void);
  */
 char *lwm2m_path_log_buf(char *buf, struct lwm2m_obj_path *path);
 
+/**
+ * @brief LwM2M send status
+ *
+ * LwM2M send status are generated back to the lwm2m_send_cb_t function in
+ * lwm2m_send_cb()
+ */
+enum lwm2m_send_status {
+	LWM2M_SEND_STATUS_SUCCESS,
+	LWM2M_SEND_STATUS_FAILURE,
+	LWM2M_SEND_STATUS_TIMEOUT,
+};
+
+/**
+ * @typedef lwm2m_send_cb_t
+ * @brief Callback returning send status
+ */
+typedef void (*lwm2m_send_cb_t)(enum lwm2m_send_status status);
+
 /** 
  * @brief LwM2M SEND operation to given path list
  *
- * @deprecated Use lwm2m_send() instead.
+ * @deprecated Use lwm2m_send_cb() instead.
  *
  * @param ctx LwM2M context
  * @param path_list LwM2M Path string list
  * @param path_list_size Length of path list. Max size is CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE
  * @param confirmation_request True request confirmation for operation.
- * 
+ *
  * @return 0 for success or negative in case of error.
  *
  */
+__deprecated
 int lwm2m_engine_send(struct lwm2m_ctx *ctx, char const *path_list[], uint8_t path_list_size,
 		      bool confirmation_request);
 
 /** 
  * @brief LwM2M SEND operation to given path list
  *
+ * @deprecated Use lwm2m_send_cb() instead.
+ *
  * @param ctx LwM2M context
  * @param path_list LwM2M path struct list
  * @param path_list_size Length of path list. Max size is CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE
  * @param confirmation_request True request confirmation for operation.
- * 
+ *
  * @return 0 for success or negative in case of error.
  *
  */
+__deprecated
 int lwm2m_send(struct lwm2m_ctx *ctx, const struct lwm2m_obj_path path_list[],
 	       uint8_t path_list_size, bool confirmation_request);
+
+/** 
+ * @brief LwM2M SEND operation to given path list asynchronously with confirmation callback
+ *
+ * @param ctx LwM2M context
+ * @param path_list LwM2M path struct list
+ * @param path_list_size Length of path list. Max size is CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE
+ * @param reply_cb Callback triggered with confirmation state or NULL if not used
+ *
+ * @return 0 for success or negative in case of error.
+ *
+ */
+int lwm2m_send_cb(struct lwm2m_ctx *ctx, const struct lwm2m_obj_path path_list[],
+			  uint8_t path_list_size, lwm2m_send_cb_t reply_cb);
 
 /** 
  * @brief Returns LwM2M client context

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -500,6 +500,7 @@ struct lwm2m_message {
 	uint8_t *token;
 	coap_reply_t reply_cb;
 	lwm2m_message_timeout_cb_t message_timeout_cb;
+	lwm2m_send_cb_t send_status_cb;
 	uint16_t mid;
 	uint8_t type;
 	uint8_t code;

--- a/subsys/net/lib/lwm2m/lwm2m_shell.c
+++ b/subsys/net/lib/lwm2m/lwm2m_shell.c
@@ -23,7 +23,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #define LWM2M_HELP_CMD "LwM2M commands"
 #define LWM2M_HELP_SEND "LwM2M SEND operation\nsend [OPTION]... [PATH]...\n" \
-	"-n\t Send as non-confirmable\n" \
 	"Root-level operation is unsupported"
 #define LWM2M_HELP_EXEC "Execute a resource\nexec PATH\n"
 #define LWM2M_HELP_READ "Read value from LwM2M resource\nread PATH [OPTIONS]\n" \
@@ -61,8 +60,6 @@ static int cmd_send(const struct shell *sh, size_t argc, char **argv)
 	int ret = 0;
 	struct lwm2m_ctx *ctx = lwm2m_rd_client_ctx();
 	int path_cnt = argc - 1;
-	bool confirmable = true;
-	int ignore_cnt = 1; /* Subcmd + arguments preceding the path list */
 	struct lwm2m_obj_path lwm2m_path_list[CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE];
 
 	if (!ctx) {
@@ -71,18 +68,6 @@ static int cmd_send(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	if (argc < 2) {
-		shell_error(sh, "no arguments or path(s)\n");
-		shell_help(sh);
-		return -EINVAL;
-	}
-
-	if (strcmp(argv[1], "-n") == 0) {
-		confirmable = false;
-		path_cnt--;
-		ignore_cnt++;
-	}
-
-	if ((argc - ignore_cnt) == 0) {
 		shell_error(sh, "no path(s)\n");
 		shell_help(sh);
 		return -EINVAL;
@@ -92,18 +77,19 @@ static int cmd_send(const struct shell *sh, size_t argc, char **argv)
 		return -E2BIG;
 	}
 
-	for (int i = ignore_cnt; i < path_cnt; i++) {
+	for (int i = 0; i < path_cnt; i++) {
+		const char *p = argv[1 + i];
 		/* translate path -> path_obj */
-		ret = lwm2m_string_to_path(argv[i], &lwm2m_path_list[i], '/');
+		ret = lwm2m_string_to_path(p, &lwm2m_path_list[i], '/');
 		if (ret < 0) {
 			return ret;
 		}
 	}
 
-	ret = lwm2m_send(ctx, lwm2m_path_list, path_cnt, confirmable);
+	ret = lwm2m_send_cb(ctx, lwm2m_path_list, path_cnt, NULL);
 
 	if (ret < 0) {
-		shell_error(sh, "can't do send operation, request failed\n");
+		shell_error(sh, "can't do send operation, request failed (%d)\n", ret);
 		return -ENOEXEC;
 	}
 	return 0;


### PR DESCRIPTION
Make send result deprecated as confirmation result shall always be asked. Add user callback to get confirmation result. See #52328

Signed-off-by: romain pelletant <romainp@kickmaker.net>