### PR TITLE
userspace: Add --no-relax build option

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -292,6 +292,23 @@ config LINKER_LAST_SECTION_ID_PATTERN
 	  be used.
 	  The size of the pattern must not exceed 4 bytes.
 
+config LINKER_USE_NO_RELAX
+	bool
+	help
+	  Hidden symbol to allow features to force the use of no relax.
+
+config LINKER_USE_RELAX
+	bool "Linker optimization of call addressing"
+	depends on !LINKER_USE_NO_RELAX
+	default y
+	help
+	  This option performs global optimizations that become possible when the linker resolves
+	  addressing in the program, such as relaxing address modes and synthesizing new
+	  instructions in the output object file. For ld and lld, this enables `--relax`.
+	  On platforms where this is not supported, `--relax' is accepted, but ignored.
+	  Disabling it can reduce performance, as the linker is no longer able to substiture long /
+	  in-effective jump calls to shorter / more effective instructions.
+
 endmenu # "Linker Sections"
 
 endmenu

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -274,6 +274,7 @@ config USERSPACE
 	depends on RUNTIME_ERROR_CHECKS
 	depends on SRAM_REGION_PERMISSIONS
 	select THREAD_STACK_INFO
+	select LINKER_USE_NO_RELAX
 	help
 	  When enabled, threads may be created or dropped down to user mode,
 	  which has significantly restricted permissions and must interact

--- a/cmake/linker/ld/target_base.cmake
+++ b/cmake/linker/ld/target_base.cmake
@@ -28,4 +28,10 @@ macro(toolchain_ld_base)
     ${LINKERFLAGPREFIX},--sort-section=alignment
   )
 
+  if (NOT CONFIG_LINKER_USE_RELAX)
+    zephyr_ld_options(
+      ${LINKERFLAGPREFIX},--no-relax
+    )
+  endif()
+
 endmacro()

--- a/cmake/linker/lld/target_base.cmake
+++ b/cmake/linker/lld/target_base.cmake
@@ -26,4 +26,10 @@ macro(toolchain_ld_base)
     ${LINKERFLAGPREFIX},--sort-section=alignment
   )
 
+  if (NOT CONFIG_LINKER_USE_RELAX)
+    zephyr_ld_options(
+      ${LINKERFLAGPREFIX},--no-relax
+    )
+  endif()
+
 endmacro()


### PR DESCRIPTION
In some architectures the linker performs global optimization relaxing address modes and changing instructions in the output object file. This is a problem when userspace is enabled since it assumes that addresses won't changes after certain build stage. In no supported architectures this option is ignored.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>