### PR TITLE
tests: drivers: regulator: support PCA9420 in voltage levels test

### DIFF
--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -232,19 +232,19 @@ i2s1: &flexcomm3 {
 		reg = <0x61>;
 		nxp,enable-modesel-pins;
 
-		BUCK1 {
+		buck1: BUCK1 {
 			regulator-boot-on;
 		};
 
-		BUCK2 {
+		buck2: BUCK2 {
 			regulator-boot-on;
 		};
 
-		LDO1 {
+		ldo1: LDO1 {
 			regulator-boot-on;
 		};
 
-		LDO2 {
+		ldo2: LDO2 {
 			regulator-boot-on;
 		};
 

--- a/tests/drivers/regulator/voltage/boards/mimxrt685_evk_cm33.overlay
+++ b/tests/drivers/regulator/voltage/boards/mimxrt685_evk_cm33.overlay
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/* RT685 ADC only supports up to 1.8V,
+ * so limit regulator voltage to this range.
+ * Only test regulators we can safely change voltage to in RUN mode
+ */
+ &ldo1 {
+	regulator-max-microvolt = <1800000>;
+ };
+
+ &ldo2 {
+	regulator-max-microvolt = <1800000>;
+ };
+
+/* Override LPADC0 pinctrl settings */
+&pinmux_lpadc0 {
+	group0 {
+		pinmux = <ADC0_CH0_PIO0_5>,
+			<ADC0_CH2_PIO0_19>;
+		slew-rate = "normal";
+		drive-strength = "normal";
+		nxp,analog-mode;
+	};
+};
+
+/ {
+	/* Note: make the following connections to run test on an RT685:
+	 * J30.1-> TP15
+	 * J30.3-> TP17
+	 */
+	resources: resources {
+		compatible = "test-regulator-voltage";
+		/* Note: LDO2 voltage range needs to be tested first
+		 * to pass this test. It seems that when LDO2 is at the
+		 * default voltage of 3.3V, LDO1 will not always deliver
+		 * a voltage within given tolerance
+		 */
+		regulators = <&ldo2 &ldo1>;
+		io-channels = <&lpadc0 0>, <&lpadc0 2>;
+		tolerance-microvolt = <35000>, <35000>;
+		set-read-delay-ms = <20>;
+		adc-avg-count = <10>;
+	};
+};
+
+&lpadc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <1800>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <1800>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <1800>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/tests/drivers/regulator/voltage/src/main.c
+++ b/tests/drivers/regulator/voltage/src/main.c
@@ -61,6 +61,11 @@ ZTEST(regulator_voltage, test_output_voltage)
 			int32_t val_mv = 0;
 
 			(void)regulator_list_voltage(regs[i], j, &volt_uv);
+			/* Check if voltage is outside user constraints */
+			if (!regulator_is_supported_voltage(regs[i],
+				volt_uv, volt_uv)) {
+				continue;
+			}
 
 			ret = regulator_set_voltage(regs[i], volt_uv, volt_uv);
 			zassert_equal(ret, 0);

--- a/tests/drivers/regulator/voltage/testcase.yaml
+++ b/tests/drivers/regulator/voltage/testcase.yaml
@@ -11,3 +11,5 @@ tests:
     extra_args: DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840_npm6001.overlay SHIELD=npm6001_ek
     harness_config:
       fixture: npm6001_ek_to_adc
+  drivers.regulator.voltage.mimxrt685_evk_cm33:
+    platform_allow: mimxrt685_evk_cm33


### PR DESCRIPTION
Add support for the PCA9420 present on the RT685 EVK to the regulator voltage levels test. Only LDO1 and LDO2 are enabled, as these are the only regulators that can be reconfigured without the SOC voltage dropping too low.

~Depends on #53224 (earlier commits in this PR are from there and will be dropped)~