### PR TITLE
linker: kobject: Handle literal section

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1290,6 +1290,7 @@ if(CONFIG_USERSPACE)
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${KOBJECT_HASH_OUTPUT_OBJ_RENAMED}
     COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
             $<TARGET_PROPERTY:bintools,elfconvert_flag>
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_section_rename>.literal=.kobject_data.literal
             $<TARGET_PROPERTY:bintools,elfconvert_flag_section_rename>.data=.kobject_data.data
             $<TARGET_PROPERTY:bintools,elfconvert_flag_section_rename>.sdata=.kobject_data.sdata
             $<TARGET_PROPERTY:bintools,elfconvert_flag_section_rename>.text=.kobject_data.text

--- a/include/zephyr/linker/kobject-text.ld
+++ b/include/zephyr/linker/kobject-text.ld
@@ -9,6 +9,7 @@
 	 * is moving backwards if the reserved room isn't large enough.
 	 */
 	_kobject_text_area_start = .;
+	*(".kobject_data.literal*")
 	*(".kobject_data.text*")
 	_kobject_text_area_end = .;
 	_kobject_text_area_used = _kobject_text_area_end - _kobject_text_area_start;


### PR DESCRIPTION
Add kobject_data prefix to kobject literals and group it close to text area to avoid changing .text addresses in the final linkage.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>