### PR TITLE
drivers: entropy: Add Gecko trng driver for EFR32BG22

### DIFF
--- a/boards/arm/efr32bg_sltb010a/efr32bg_sltb010a.dts
+++ b/boards/arm/efr32bg_sltb010a/efr32bg_sltb010a.dts
@@ -115,3 +115,7 @@
 &stimer0 {
 	status = "okay";
 };
+
+&trng {
+	status = "okay";
+};

--- a/drivers/entropy/Kconfig.gecko
+++ b/drivers/entropy/Kconfig.gecko
@@ -9,6 +9,7 @@ config ENTROPY_GECKO_TRNG
 	default y
 	depends on DT_HAS_SILABS_GECKO_TRNG_ENABLED
 	select ENTROPY_HAS_DRIVER
+	select CRYPTO_ACC_GECKO_TRNG if SOC_SERIES_EFR32BG22
 	help
 	  This option enables the true random number generator
 	  driver based on the TRNG.

--- a/dts/arm/silabs/efr32bg22.dtsi
+++ b/dts/arm/silabs/efr32bg22.dtsi
@@ -13,6 +13,7 @@
 / {
 	chosen {
 		zephyr,flash-controller = &msc;
+		zephyr,entropy = &trng;
 	};
 
 	power-states {
@@ -67,6 +68,13 @@
 			interrupts = <15 0>, <16 0>;
 			interrupt-names = "rx", "tx";
 			status = "disabled";
+		};
+
+		trng: trng@4c021000 {
+			compatible = "silabs,gecko-trng";
+			reg = <0x4C021000 0x1000>;
+			status = "disabled";
+			interrupts = <0x1 0x0>;
 		};
 
 		i2c0: i2c@5a010000 {

--- a/soc/arm/silabs_exx32/Kconfig
+++ b/soc/arm/silabs_exx32/Kconfig
@@ -134,6 +134,12 @@ choice SOC_GECKO_EMU_DCDC_MODE
 		bool "Bypass"
 endchoice
 
+config CRYPTO_ACC_GECKO_TRNG
+	bool
+	help
+	  Enable Entropy driver based on the CRYPTO_ACC module for Silicon Labs
+	  Gecko chips.
+
 config SOC_GECKO_DEV_INIT
 	bool
 	help


### PR DESCRIPTION
This PR enables entropy driver on EFR32BG22 SoC.