### PR TITLE
drivers: i2c: Enable Gecko i2c driver for efr32bg_sltb010a

### DIFF
--- a/boards/arm/efr32bg_sltb010a/doc/index.rst
+++ b/boards/arm/efr32bg_sltb010a/doc/index.rst
@@ -72,6 +72,8 @@ The efr32bg_sltb010a board configuration supports the following hardware feature
 +-----------+------------+-------------------------------------+
 | TRNG      | on-chip    | true random number generator        |
 +-----------+------------+-------------------------------------+
+| I2C(M/S)  | on-chip    | i2c                                 |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 ``boards/arm/efr32bg_sltb010a/efr32bg_sltb010a_defconfig``.

--- a/boards/arm/efr32bg_sltb010a/efr32bg_sltb010a.dts
+++ b/boards/arm/efr32bg_sltb010a/efr32bg_sltb010a.dts
@@ -119,3 +119,9 @@
 &trng {
 	status = "okay";
 };
+
+&i2c0 {
+	location-sda = <GECKO_LOCATION(3) GECKO_PORT_D GECKO_PIN(2)>;
+	location-scl = <GECKO_LOCATION(3) GECKO_PORT_D GECKO_PIN(3)>;
+	status = "okay";
+};

--- a/boards/arm/efr32bg_sltb010a/efr32bg_sltb010a.yaml
+++ b/boards/arm/efr32bg_sltb010a/efr32bg_sltb010a.yaml
@@ -12,6 +12,7 @@ supported:
   - counter
   - gpio
   - uart
+  - i2c
 testing:
   ignore_tags:
     - net

--- a/dts/arm/silabs/efr32bg22.dtsi
+++ b/dts/arm/silabs/efr32bg22.dtsi
@@ -81,6 +81,8 @@
 			compatible = "silabs,gecko-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x5a010000 0x3044>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			interrupts = <27 0>;
 			status = "disabled";
 		};
@@ -89,6 +91,8 @@
 			compatible = "silabs,gecko-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x50068000 0x3044>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			interrupts = <28 0>;
 			status = "disabled";
 		};

--- a/soc/arm/silabs_exx32/efr32bg22/Kconfig.defconfig.efr32bg22
+++ b/soc/arm/silabs_exx32/efr32bg22/Kconfig.defconfig.efr32bg22
@@ -6,9 +6,6 @@
 config GPIO_GECKO
 	default y
 
-config I2C_GECKO
-	default n
-
 config SOC_FLASH_GECKO
 	default n
 

--- a/soc/arm/silabs_exx32/efr32bg22/soc.h
+++ b/soc/arm/silabs_exx32/efr32bg22/soc.h
@@ -16,6 +16,7 @@
 #ifndef _ASMLANGUAGE
 
 #include <em_common.h>
+#include "../common/soc_gpio.h"
 
 #endif /* !_ASMLANGUAGE */
 


### PR DESCRIPTION
This PR enables the Gecko i2c driver on the efr32bg_sltb010a board.