### PR TITLE
drivers: watchdog: Enable Gecko wdt driver efr32bg_sltb010a

### DIFF
--- a/boards/arm/efr32bg_sltb010a/efr32bg_sltb010a.dts
+++ b/boards/arm/efr32bg_sltb010a/efr32bg_sltb010a.dts
@@ -18,6 +18,7 @@
 		sw0 = &button0;
 		spi-flash0 = &mx25r80;
 		spi0 = &usart0;
+		watchdog0 = &wdog0;
 	};
 
 	chosen {
@@ -87,6 +88,10 @@
 	status = "okay";
 	pinctrl-0 = <&usart1_default>;
 	pinctrl-names = "default";
+};
+
+&wdog0 {
+	status = "okay";
 };
 
 &flash0 {

--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -254,10 +254,10 @@ static int wdt_gecko_init(const struct device *dev)
 	/* Enable ULFRCO (1KHz) oscillator */
 	CMU_OscillatorEnable(cmuOsc_ULFRCO, true, false);
 
-#if !defined(_SILICON_LABS_32B_SERIES_2)
 	/* Ensure LE modules are clocked */
 	CMU_ClockEnable(config->clock, true);
-#else
+
+#if defined(_SILICON_LABS_32B_SERIES_2)
 	CMU_ClockSelectSet(config->clock, cmuSelect_ULFRCO);
 #endif
 

--- a/dts/arm/silabs/efr32bg22.dtsi
+++ b/dts/arm/silabs/efr32bg22.dtsi
@@ -162,6 +162,15 @@
 			};
 
 		};
+
+		wdog0: wdog@4a018000 {
+			compatible = "silabs,gecko-wdog";
+			reg = <0x4A018000 0x3028>;
+			peripheral-id = <0>;
+			interrupts = <43 0>;
+			status = "disabled";
+		};
+
 	};
 };
 


### PR DESCRIPTION
This commit enables the Gecko Watchdog Timer driver on the efr32bg_sltb010 board.