### PR TITLE
doc: services: device_mgmt: smp_groups: Correct smp img upload request

### DIFF
--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -257,7 +257,7 @@ CBOR data of request:
             (str,opt)"image"    : (uint)
             (str,opt)"len"      : (uint)
             (str)"off"          : (uint)
-            (str,opt)"sha"      : (str)
+            (str,opt)"sha"      : (byte str)
             (str,opt)"data"     : (byte str)
             (str,opt)"upgrade"  : (bool)
         }


### PR DESCRIPTION
The specification of que CBOR request 'image upload request' field 'sha' was decalred as type (str) but is (byte str).
Just replaced the field type after verified with code here: /subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c#L383

Signed-off-by: Thisora <mathis.raemy@gmail.com>