### PR TITLE
twister: fix hardware map updates

### DIFF
--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -320,10 +320,16 @@ class HardwareMap:
 
                     for _detected in self.detected:
                         for h in hwm:
-                            if _detected.id == h['id'] and _detected.product == h['product'] and not _detected.match:
+                            if all([
+                                _detected.id == h['id'],
+                                _detected.product == h['product'],
+                                _detected.match is False,
+                                h['connected'] is False
+                            ]):
                                 h['connected'] = True
                                 h['serial'] = _detected.serial
                                 _detected.match = True
+                                break
 
                 new_duts = list(filter(lambda d: not d.match, self.detected))
                 new = []


### PR DESCRIPTION
When re-generating hardware map for DKs with more than 1 serial port (more entries in the hardware map), then we keep info only about the last entry. For boards like nrf5340 it works, because the last serial port is used, but for nrf52840 with two ports, the first one is important, so after re-generating the hardware map it does not work.
The solution is to keep all entries after re-generating the hardware map.

Signed-off-by: Grzegorz Chwierut <grzegorz.chwierut@nordicsemi.no>