### PR TITLE
soc: arm: efr32bg22: Add support for Gecko SPI

### DIFF
--- a/boards/arm/efr32bg_sltb010a/doc/index.rst
+++ b/boards/arm/efr32bg_sltb010a/doc/index.rst
@@ -62,6 +62,8 @@ The efr32bg_sltb010a board configuration supports the following hardware feature
 +-----------+------------+-------------------------------------+
 | COUNTER   | on-chip    | stimer                              |
 +-----------+------------+-------------------------------------+
+| SPI(M/S)  | on-chip    | spi                                 |
++-----------+------------+-------------------------------------+
 | FLASH     | on-chip    | flash memory                        |
 +-----------+------------+-------------------------------------+
 | GPIO      | on-chip    | gpio                                |

--- a/boards/arm/efr32bg_sltb010a/efr32bg_sltb010a.dts
+++ b/boards/arm/efr32bg_sltb010a/efr32bg_sltb010a.dts
@@ -48,6 +48,12 @@
 		gpios = <&gpioa GECKO_PIN(5) GPIO_ACTIVE_LOW>;
 	};
 
+	spi_enable: peripheral-enable {
+		compatible = "regulator-fixed";
+		regulator-name = "spi-enable-ctrl";
+		enable-gpios = <&gpiob GECKO_PIN(4) GPIO_ACTIVE_HIGH>;
+	};
+
 };
 
 &cpu0 {

--- a/boards/arm/efr32bg_sltb010a/efr32bg_sltb010a.dts
+++ b/boards/arm/efr32bg_sltb010a/efr32bg_sltb010a.dts
@@ -16,6 +16,8 @@
 	aliases {
 		led0 = &led0;
 		sw0 = &button0;
+		spi-flash0 = &mx25r80;
+		spi0 = &usart0;
 	};
 
 	chosen {
@@ -50,6 +52,28 @@
 
 &cpu0 {
 	clock-frequency = <76800000>;
+};
+
+&usart0 {
+	status = "okay";
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
+
+	cs-gpios = <&gpioc 3 GPIO_ACTIVE_LOW>;
+
+	mx25r80: mx25r8035f@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		size = <0x800000>;
+		jedec-id = [c2 28 14];
+		sfdp-bfp = [
+			 e5 20 f1 ff  ff ff 7f 00  44 eb 08 6b  08 3b 04 bb
+			 ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			 10 d8 00 ff  23 72 f5 00  82 ed 04 b7  44 83 38 44
+			 30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
+	};
 };
 
 &usart1 {
@@ -109,6 +133,10 @@
 };
 
 &gpiob {
+	status = "okay";
+};
+
+&gpioc {
 	status = "okay";
 };
 

--- a/boards/arm/efr32bg_sltb010a/efr32bg_sltb010a.yaml
+++ b/boards/arm/efr32bg_sltb010a/efr32bg_sltb010a.yaml
@@ -13,6 +13,7 @@ supported:
   - gpio
   - uart
   - i2c
+  - spi
 testing:
   ignore_tags:
     - net

--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -95,11 +95,6 @@ static int spi_config(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	if (config->operation & (SPI_MODE_CPOL | SPI_MODE_CPHA)) {
-		LOG_ERR("Only supports CPOL=CPHA=0");
-		return -ENOTSUP;
-	}
-
 	if (config->operation & SPI_OP_MODE_SLAVE) {
 		LOG_ERR("Slave mode not supported");
 		return -ENOTSUP;
@@ -110,6 +105,20 @@ static int spi_config(const struct device *dev,
 		gecko_config->base->CTRL |= USART_CTRL_LOOPBK;
 	} else {
 		gecko_config->base->CTRL &= ~USART_CTRL_LOOPBK;
+	}
+
+	/* Set CPOL */
+	if (config->operation & SPI_MODE_CPOL) {
+		gecko_config->base->CTRL |= USART_CTRL_CLKPOL;
+	} else {
+		gecko_config->base->CTRL &= ~USART_CTRL_CLKPOL;
+	}
+
+	/* Set CPHA */
+	if (config->operation & SPI_MODE_CPHA) {
+		gecko_config->base->CTRL |= USART_CTRL_CLKPHA;
+	} else {
+		gecko_config->base->CTRL &= ~USART_CTRL_CLKPHA;
 	}
 
 	/* Set word size */

--- a/dts/arm/silabs/efr32bg22-pinctrl.dtsi
+++ b/dts/arm/silabs/efr32bg22-pinctrl.dtsi
@@ -7,17 +7,16 @@
 #include <dt-bindings/pinctrl/gecko-pinctrl.h>
 
 &pinctrl {
-	/* configuration for uart0 device, default state */
+	/* configuration for usart0 device, operating as SPI */
 	usart0_default: usart0_default {
 		group1 {
-			/* configure PE.11 as UART_RX and PE.10 as UART_TX */
-			psels = <GECKO_PSEL(UART_TX, E, 10)>,
-				<GECKO_PSEL(UART_RX, E, 11)>,
-				<GECKO_LOC(UART, 0)>;
+			psels = <GECKO_PSEL(SPI_SCK, C, 2)>,
+				<GECKO_PSEL(SPI_MOSI, C, 0)>,
+				<GECKO_PSEL(SPI_MISO, C, 1)>;
 		};
 	};
 
-	/* configuration for uart1 device, default state */
+	/* configuration for usart1 device, default state - operating as UART */
 	usart1_default: usart1_default {
 		group1 {
 			/* configure PA.6 as UART_RX and PA.5 as UART_TX */

--- a/dts/arm/silabs/efr32bg22.dtsi
+++ b/dts/arm/silabs/efr32bg22.dtsi
@@ -55,10 +55,15 @@
 		};
 
 		usart0: usart@5005c000 {
-			compatible = "silabs,gecko-usart";
+			compatible = "silabs,gecko-spi-usart";
 			reg = <0x5005C000 0x400>;
 			interrupts = <13 0>, <14 0>;
 			interrupt-names = "rx", "tx";
+			status = "disabled";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
 			status = "disabled";
 		};
 

--- a/dts/bindings/spi/silabs,gecko-spi-usart.yaml
+++ b/dts/bindings/spi/silabs,gecko-spi-usart.yaml
@@ -2,7 +2,7 @@ description: GECKO USART SPI
 
 compatible: "silabs,gecko-spi-usart"
 
-include: spi-controller.yaml
+include: [spi-controller.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
@@ -21,15 +21,12 @@ properties:
 
   location-rx:
     type: array
-    required: true
     description: RX pin configuration defined as <location port pin>
 
   location-tx:
     type: array
-    required: true
     description: TX pin configuration defined as <location port pin>
 
   location-clk:
     type: array
-    required: true
     description: CLK pin configuration defined as <location port pin>

--- a/dts/bindings/spi/silabs,gecko-spi-usart.yaml
+++ b/dts/bindings/spi/silabs,gecko-spi-usart.yaml
@@ -13,7 +13,6 @@ properties:
 
   peripheral-id:
     type: int
-    required: true
     description: peripheral ID
 
   # Note: Not all SoC series support setting individual pin location. If this

--- a/include/zephyr/dt-bindings/pinctrl/gecko-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/gecko-pinctrl.h
@@ -61,6 +61,11 @@
 /** UART LOCATION */
 #define GECKO_FUN_UART_LOC 4U
 
+#define GECKO_FUN_SPI_MISO 5U
+#define GECKO_FUN_SPI_MOSI 6U
+#define GECKO_FUN_SPI_CSN  7U
+#define GECKO_FUN_SPI_SCK  8U
+
 /** @} */
 
 /**

--- a/soc/arm/silabs_exx32/efr32bg22/Kconfig.defconfig.efr32bg22
+++ b/soc/arm/silabs_exx32/efr32bg22/Kconfig.defconfig.efr32bg22
@@ -8,6 +8,3 @@ config GPIO_GECKO
 
 config SOC_FLASH_GECKO
 	default n
-
-config SPI_GECKO
-	default n


### PR DESCRIPTION
This PR adds support for the Gecko SPI and adds an SPI transaction sample in `samples/drivers/spi_efr32bg22/src/spi.c`.