### PR TITLE
Refactor sys clock disable

### DIFF
--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -5,6 +5,8 @@
 # Copyright (c) 2019 Intel Corp.
 # SPDX-License-Identifier: Apache-2.0
 
+if SYS_CLOCK_EXISTS
+
 menu "Timer Drivers"
 
 config TIMER_HAS_64BIT_CYCLE_COUNTER
@@ -90,3 +92,5 @@ source "drivers/timer/Kconfig.xlnx_psttc"
 source "drivers/timer/Kconfig.xtensa"
 
 endmenu
+
+endif # SYS_CLOCK_EXISTS

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -109,19 +109,14 @@ extern void sys_clock_announce(int32_t ticks);
  */
 extern uint32_t sys_clock_elapsed(void);
 
-#if defined(CONFIG_SYS_CLOCK_EXISTS) && \
-	defined(CONFIG_SYSTEM_TIMER_HAS_DISABLE_SUPPORT) || \
-	defined(__DOXYGEN__)
 /**
  * @brief Disable system timer.
  *
- * This function is a no-op if the system timer does not have the capability
- * of being disabled.
+ * @note Not all system timer drivers has the capability of being disabled.
+ * The config @kconfig{CONFIG_SYSTEM_TIMER_HAS_DISABLE_SUPPORT} can be used to
+ * check if the system timer has the capability of being disabled.
  */
 extern void sys_clock_disable(void);
-#else
-static inline void sys_clock_disable(void) {}
-#endif /* CONFIG_SYSTEM_TIMER_HAS_DISABLE_SUPPORT */
 
 /**
  * @}

--- a/lib/os/reboot.c
+++ b/lib/os/reboot.c
@@ -26,7 +26,9 @@ FUNC_NORETURN void sys_reboot(int type)
 #endif /* CONFIG_ICACHE */
 #endif /* CONFIG_ARCH_CACHE */
 
-	sys_clock_disable();
+	if (IS_ENABLED(CONFIG_SYSTEM_TIMER_HAS_DISABLE_SUPPORT)) {
+		sys_clock_disable();
+	}
 
 	sys_arch_reboot(type);
 

--- a/west.yml
+++ b/west.yml
@@ -181,7 +181,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: dd59d907639b81f3c0556ebf6e9249f85482b407
+      revision: 750678e33819b95756203e5db1ba827baee35708
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Add dependency on SYS_CLOCK_EXISTS to all timer configurations.
This would avoid a situation where a possible timer configuration would
be wrongfully selected but SYS_CLOCK_EXISTS is disabled.

This simplifies code that wants to check for system clock capabilities
don't have to check if the system clock exists in addition.

Refactor sys_clock_disable not implemented behavior.
Instead of calling an empty inline header function check if the feature
is enabled before calling function.
