### PR TITLE
usb: stm32f1: Move PLL prescaler configuration to clock_control driver

### DIFF
--- a/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
+++ b/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
@@ -58,6 +58,7 @@
 	ahb-prescaler = <1>;
 	apb1-prescaler = <2>;
 	apb2-prescaler = <1>;
+	/* usbpre not set: USB clock = 72 / 1.5: 48MHz */
 };
 
 &usart1 {

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -73,6 +73,7 @@
 	ahb-prescaler = <1>;
 	apb1-prescaler = <2>;
 	apb2-prescaler = <1>;
+	/* usbpre not set: USB clock = 72 / 1.5: 48MHz */
 };
 
 uext_i2c: &i2c2 {};

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
@@ -50,6 +50,7 @@
 	ahb-prescaler = <1>;
 	apb1-prescaler = <2>;
 	apb2-prescaler = <1>;
+	/* usbpre not set: USB clock = 72 / 1.5: 48MHz */
 };
 
 &usart1 {

--- a/boards/arm/stm32f103_mini/stm32f103_mini.dts
+++ b/boards/arm/stm32f103_mini/stm32f103_mini.dts
@@ -54,6 +54,7 @@
 	ahb-prescaler = <1>;
 	apb1-prescaler = <2>;
 	apb2-prescaler = <1>;
+	/* usbpre not set: USB clock = 72 / 1.5: 48MHz */
 };
 
 &usart1 {

--- a/boards/arm/waveshare_open103z/waveshare_open103z.dts
+++ b/boards/arm/waveshare_open103z/waveshare_open103z.dts
@@ -95,6 +95,7 @@
 	ahb-prescaler = <1>;
 	apb1-prescaler = <2>;
 	apb2-prescaler = <1>;
+	/* usbpre not set: USB clock = 72 / 1.5: 48MHz */
 };
 
 &usart1 {

--- a/drivers/clock_control/clock_stm32f1.c
+++ b/drivers/clock_control/clock_stm32f1.c
@@ -15,6 +15,12 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include "clock_stm32_ll_common.h"
 
+#if defined(RCC_CFGR_USBPRE)
+#define STM32_USB_PRE_ENABLED	RCC_CFGR_USBPRE
+#elif defined(RCC_CFGR_OTGFSPRE)
+#define STM32_USB_PRE_ENABLED	RCC_CFGR_OTGFSPRE
+#endif
+
 #if defined(STM32_PLL_ENABLED)
 
 /*
@@ -93,6 +99,12 @@ void config_pll_sysclock(void)
 	}
 
 	LL_RCC_PLL_ConfigDomain_SYS(pll_source, pll_mul);
+
+#ifdef STM32_USB_PRE_ENABLED
+	/* Prescaler is enabled: PLL clock is not divided */
+	LL_RCC_SetUSBClockSource(IS_ENABLED(STM32_PLL_USBPRE) ?
+				 STM32_USB_PRE_ENABLED : 0);
+#endif
 }
 
 #endif /* defined(STM32_PLL_ENABLED) */

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -281,53 +281,14 @@ static int usb_dc_stm32_clock_enable(void)
 	}
 #endif /* STM32_MSI_PLL_MODE && !STM32_SYSCLK_SRC_MSI */
 
-#elif defined(RCC_CFGR_OTGFSPRE)
-	/* On STM32F105 and STM32F107 parts the USB OTGFSCLK is derived from
-	 * PLL1, and must result in a 48 MHz clock... the options to achieve
-	 * this are as below, controlled by the RCC_CFGR_OTGFSPRE bit.
-	 *   - PLLCLK * 2 / 2     i.e: PLLCLK == 48 MHz
-	 *   - PLLCLK * 2 / 3     i.e: PLLCLK == 72 MHz
-	 *
-	 * this requires that the system is running from PLLCLK
-	 */
-	if (LL_RCC_GetSysClkSource() == LL_RCC_SYS_CLKSOURCE_STATUS_PLL) {
-		switch (sys_clock_hw_cycles_per_sec()) {
-		case MHZ(48):
-			LL_RCC_SetUSBClockSource(LL_RCC_USB_CLKSOURCE_PLL_DIV_2);
-			break;
-		case MHZ(72):
-			LL_RCC_SetUSBClockSource(LL_RCC_USB_CLKSOURCE_PLL_DIV_3);
-			break;
-		default:
-			LOG_ERR("Unable to set USB clock source (incompatible PLLCLK rate)");
-			return -EIO;
-		}
-	} else {
-		LOG_ERR("Unable to set USB clock source (not using PLL1)");
-		return -EIO;
-	}
-#elif defined(RCC_CFGR_USBPRE)
-	/* on other STM32F1 family SOCs, we have a simple /1 or /1.5 divider on
-	 * the back of the RCC.  Similar strategy to the above, but we use the
-	 * correct flags
-	 */
-	if (LL_RCC_GetSysClkSource() == LL_RCC_SYS_CLKSOURCE_STATUS_PLL) {
-		switch (sys_clock_hw_cycles_per_sec()) {
-		case MHZ(48):
-			LL_RCC_SetUSBClockSource(LL_RCC_USB_CLKSOURCE_PLL);
-			break;
-		case MHZ(72):
-			LL_RCC_SetUSBClockSource(LL_RCC_USB_CLKSOURCE_PLL_DIV_1_5);
-			break;
-		default:
-			LOG_ERR("Unable to set USB clock source (incompatible PLLCLK rate)");
-			return -EIO;
-		}
-	} else {
-		LOG_ERR("Unable to set USB clock source (not using PLL1)");
-		return -EIO;
-	}
-#endif /* RCC_HSI48_SUPPORT / LL_RCC_USB_CLKSOURCE_NONE / RCC_CFGR_OTGFSPRE / RCC_CFGR_USBPRE */
+#elif defined(RCC_CFGR_OTGFSPRE) || defined(RCC_CFGR_USBPRE)
+
+#if (MHZ(48) == CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) && !defined(STM32_PLL_USBPRE)
+	/* PLL output clock is set to 48MHz, it should not be divided */
+#warning USBPRE/OTGFSPRE should be set in rcc node
+#endif
+
+#endif /* RCC_HSI48_SUPPORT / LL_RCC_USB_CLKSOURCE_NONE */
 
 	if (!device_is_ready(clk)) {
 		LOG_ERR("clock control device not ready");

--- a/dts/bindings/clock/st,stm32f0-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f0-pll-clock.yaml
@@ -30,6 +30,7 @@ include:
   - name: st,stm32f105-pll-clock.yaml
     property-blocklist:
       - mul
+      - otgfspre
 
 properties:
     mul:

--- a/dts/bindings/clock/st,stm32f1-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f1-pll-clock.yaml
@@ -7,11 +7,9 @@ description: |
   Takes one of 'clk_hse', 'clk_hse / 2' (when 'xtpre' is set) or 'clk_hsi / 2'
   as input clock.
 
-  Up to 2 output clocks could be supported and for each output clock, the
-  frequency can be computed with the following formula:
+  Output clock frequency can be computed with the following formula:
 
     f(PLLCLK) = f(input clk) x PLLMUL  --> SYSCLK (System Clock)
-    f(USBCLK) = f(PLLCLK) / USBPRE     --> USB
 
   The PLL output frequency must not exceed 72 MHz.
 
@@ -40,6 +38,8 @@ properties:
           Otpional HSE divider for PLL entry
 
     usbpre:
-      type: int
+      type: boolean
       description: |
-          Otpional HSE divider for PLL entry
+          Otpional PLL output divisor to generate a 48MHz USB clock.
+          When set, PLL clock is not divided.
+          Otherwise, PLL output clock is divided by 1.5.

--- a/dts/bindings/clock/st,stm32f105-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f105-pll-clock.yaml
@@ -8,11 +8,9 @@ description: |
   When clk_hsi is used a fixed prescaler is applied. When input clock is hse or
   pll2, configurable prescaler is used.
 
-  Up to 2 output clocks could be supported and for each output clock, the
-  frequency can be computed with the following formula:
+  Output clock frequency can be computed with the following formula:
 
-    f(PLLCLK) = f(PLLIN) x PLLMUL       --> SYSCLK (System Clock)
-    f(USBCLK) = f(PLLCLK) * 2 / USBPRE  --> USB
+    f(PLLCLK) = f(PLLIN) x PLLMUL         --> SYSCLK (System Clock)
 
     with, depending on the case:
             f(PLLIN) = f(input_clk) / 2       if input_clk = clk_hsi
@@ -53,3 +51,10 @@ properties:
       description: |
           Configurable prescaler
           Valid range: 1 - 16
+
+    otgfspre:
+      type: boolean
+      description: |
+          Otpional PLL output divisor to generate a 48MHz USB clock.
+          When set, PLL output clock is not divided.
+          Otherwise, PLL output clock is divided by 1.5.

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -156,12 +156,14 @@
 #define STM32_PLL_ENABLED	1
 #define STM32_PLL_XTPRE		DT_PROP(DT_NODELABEL(pll), xtpre)
 #define STM32_PLL_MULTIPLIER	DT_PROP(DT_NODELABEL(pll), mul)
+#define STM32_PLL_USBPRE	DT_PROP(DT_NODELABEL(pll), usbpre)
 #elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32f0_pll_clock, okay) || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32f100_pll_clock, okay) || \
 	DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32f105_pll_clock, okay)
 #define STM32_PLL_ENABLED	1
 #define STM32_PLL_MULTIPLIER	DT_PROP(DT_NODELABEL(pll), mul)
 #define STM32_PLL_PREDIV	DT_PROP(DT_NODELABEL(pll), prediv)
+#define STM32_PLL_USBPRE	DT_PROP(DT_NODELABEL(pll), otgfspre)
 #elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pll), st_stm32l0_pll_clock, okay)
 #define STM32_PLL_ENABLED	1
 #define STM32_PLL_DIVISOR	DT_PROP(DT_NODELABEL(pll), div)


### PR DESCRIPTION
USB clock configuration should be moved to clock_control driver.

In case of STM32F1, the configuration consists in setting a prescaler on the PLL clock output path, to achieve a 48MHz clock on USB depending on PLL output value (72 or 48MHz).
Since this is a pure PLL configuration set is as a rcc node property.

Note that this has an impact on the existing behavior since configuration was done automatically.
Now, it is up to the user to provide the right configuration, similarly to other components.

In tree impacted boards configuration has been checked.
A warning has been added for out of tree boards for a transition period.