### PR TITLE
drivers: gic: support for GIC-600 power

### DIFF
--- a/drivers/interrupt_controller/Kconfig.gic
+++ b/drivers/interrupt_controller/Kconfig.gic
@@ -61,4 +61,11 @@ config GIC_V3_ITS
 	  Support for the optional Interrupt Translation Service used to translate
 	  hardware interrupt from PCIe MSI messages for example.
 
+config GIC_V3_600
+	bool "GIC-600 variant of GIC v3"
+	depends on GIC_V3
+	help
+	  Support for features present on GIC-600 but not on other GIC v3 such
+	  as GIC-500, eg. PWRR Power Register.
+
 endif # CPU_CORTEX

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -274,6 +274,7 @@ void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff,
  */
 static void gicv3_rdist_enable(mem_addr_t rdist)
 {
+#if defined(CONFIG_GIC_V3_600)
 	uint32_t pwrr = sys_read32(rdist + GICR_PWRR);
 
 	pwrr |= GICR_PWRR_RDAG;
@@ -282,6 +283,7 @@ static void gicv3_rdist_enable(mem_addr_t rdist)
 	do {
 		pwrr = sys_read32(rdist + GICR_PWRR);
 	} while (pwrr & GICR_PWRR_RDGPO);
+#endif
 
 	if (!(sys_read32(rdist + GICR_WAKER) & BIT(GICR_WAKER_CA))) {
 		return;

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -274,6 +274,15 @@ void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff,
  */
 static void gicv3_rdist_enable(mem_addr_t rdist)
 {
+	uint32_t pwrr = sys_read32(rdist + GICR_PWRR);
+
+	pwrr |= GICR_PWRR_RDAG;
+	pwrr &= ~GICR_PWRR_RDPD;
+	sys_write32(pwrr, rdist + GICR_PWRR);
+	do {
+		pwrr = sys_read32(rdist + GICR_PWRR);
+	} while (pwrr & GICR_PWRR_RDGPO);
+
 	if (!(sys_read32(rdist + GICR_WAKER) & BIT(GICR_WAKER_CA))) {
 		return;
 	}

--- a/drivers/interrupt_controller/intc_gicv3_priv.h
+++ b/drivers/interrupt_controller/intc_gicv3_priv.h
@@ -41,6 +41,7 @@
 #define GICR_TYPER			0x0008
 #define GICR_STATUSR			0x0010
 #define GICR_WAKER			0x0014
+#define GICR_PWRR			0x0024
 #define GICR_PROPBASER			0x0070
 #define GICR_PENDBASER			0x0078
 
@@ -76,6 +77,14 @@
 /* GICR_WAKER */
 #define GICR_WAKER_PS			1
 #define GICR_WAKER_CA			2
+
+/* GICR_PWRR */
+#define GICR_PWRR_RDPD                          BIT(0)
+#define GICR_PWRR_RDAG                          BIT(1)
+#define GICR_PWRR_RDGPD                         BIT(2)
+#define GICR_PWRR_RDGPO                         BIT(3)
+#define GICR_PWRR_RDGO                          BIT(8)
+#define GICR_PWRR_RDG                           BIT(16)
 
 /* GICR_PROPBASER */
 #define GITR_PROPBASER_ID_BITS_MASK		0x1fUL


### PR DESCRIPTION
This register controls the powerup sequence of the Redistributors. Software must write to this register during the powerup sequence.

Signed-off-by: Théophile Ranquet <theophile.ranquet@gmail.com>

As documented by ARM at:
    https://developer.arm.com/documentation/100336/0002/programmers-model/redistributor-registers-for-control-and-physical-lpis-summary/power-register--gicr-pwrr