### PR TITLE
arm: ld: place .bss at the end

### DIFF
--- a/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -266,32 +266,6 @@ SECTIONS
     _app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
 #endif  /* CONFIG_USERSPACE */
 
-    SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD), BSS_ALIGN)
-    {
-        /*
-         * For performance, BSS section is assumed to be 4 byte aligned and
-         * a multiple of 4 bytes
-         */
-        . = ALIGN(4);
-        __bss_start = .;
-        __kernel_ram_start = .;
-
-        *(.bss)
-        *(".bss.*")
-        *(COMMON)
-        *(".kernel_bss.*")
-
-#ifdef CONFIG_CODE_DATA_RELOCATION
-#include <linker_sram_bss_relocate.ld>
-#endif
-
-        /*
-         * As memory is cleared in words only, it is simpler to ensure the BSS
-         * section ends on a 4 byte boundary. This wastes a maximum of 3 bytes.
-         */
-        __bss_end = ALIGN(4);
-    } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
-
 #include <zephyr/linker/common-noinit.ld>
 
     SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
@@ -329,6 +303,31 @@ SECTIONS
 
     __data_region_end = .;
 
+    SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD), BSS_ALIGN)
+    {
+        /*
+         * For performance, BSS section is assumed to be 4 byte aligned and
+         * a multiple of 4 bytes
+         */
+        . = ALIGN(4);
+        __bss_start = .;
+        __kernel_ram_start = .;
+
+        *(.bss)
+        *(".bss.*")
+        *(COMMON)
+        *(".kernel_bss.*")
+
+#ifdef CONFIG_CODE_DATA_RELOCATION
+#include <linker_sram_bss_relocate.ld>
+#endif
+
+        /*
+         * As memory is cleared in words only, it is simpler to ensure the BSS
+         * section ends on a 4 byte boundary. This wastes a maximum of 3 bytes.
+         */
+        __bss_end = ALIGN(4);
+    } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
     /* Define linker symbols */
 


### PR DESCRIPTION
This is to avoid the binary padding caused by placing sections after the .bss noload gap, which causes the binary to be unnecessarily large. By placing the noload .bss at the end, we do not have to include it in the binary.

Signed-off-by: Théophile Ranquet <theophile.ranquet@gmail.com>