### PR TITLE
modules: hal_nordic: nrf_802154: RNG xor-shift algorithm

### DIFF
--- a/modules/hal_nordic/nrf_802154/radio/platform/nrf_802154_random_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/radio/platform/nrf_802154_random_zephyr.c
@@ -12,10 +12,9 @@ static uint32_t state;
 
 static uint32_t next(void)
 {
-	uint32_t num = state;
-
-	state = 1664525 * num + 1013904223;
-	return num;
+	state ^= (state<<13);
+	state ^= (state>>17);
+	return state ^= (state<<5);
 }
 
 void nrf_802154_random_init(void)


### PR DESCRIPTION
The LCG method used earlier in the random number generator was problematic, as the lowest bits repeated periodically (for example, the generated number always resulted in an odd-even-odd-even-.. sequence, or the last three bits formed an cycle of the length 8). This is because the LCG was done module 2^32. Any LCG using a power of 2 as the modulus will cause the same issue. The used RNG method was changed to Marsaglia's xor shift-algorithm, which does not have this issue.