### PR TITLE
drivers: clock_control: stm32: Use zephyr functions for bit operations

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -11,6 +11,7 @@
 #include <stm32_ll_rcc.h>
 #include <stm32_ll_system.h>
 #include <stm32_ll_utils.h>
+#include <zephyr/arch/cpu.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/__assert.h>
@@ -184,8 +185,6 @@ static inline int stm32_clock_control_on(const struct device *dev,
 					 clock_control_subsys_t sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
-	volatile uint32_t *reg;
-	uint32_t reg_val;
 
 	ARG_UNUSED(dev);
 
@@ -194,10 +193,8 @@ static inline int stm32_clock_control_on(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	reg = (uint32_t *)(DT_REG_ADDR(DT_NODELABEL(rcc)) + pclken->bus);
-	reg_val = *reg;
-	reg_val |= pclken->enr;
-	*reg = reg_val;
+	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + pclken->bus,
+		     pclken->enr);
 
 	return 0;
 }
@@ -206,8 +203,6 @@ static inline int stm32_clock_control_off(const struct device *dev,
 					  clock_control_subsys_t sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
-	volatile uint32_t *reg;
-	uint32_t reg_val;
 
 	ARG_UNUSED(dev);
 
@@ -216,10 +211,8 @@ static inline int stm32_clock_control_off(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	reg = (uint32_t *)(DT_REG_ADDR(DT_NODELABEL(rcc)) + pclken->bus);
-	reg_val = *reg;
-	reg_val &= ~pclken->enr;
-	*reg = reg_val;
+	sys_clear_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + pclken->bus,
+		       pclken->enr);
 
 	return 0;
 }
@@ -231,8 +224,6 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 #if defined(STM32_SRC_SYSCLK)
 	/* At least one alt src clock available */
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
-	volatile uint32_t *reg;
-	uint32_t reg_val, dt_val;
 	int err;
 
 	ARG_UNUSED(dev);
@@ -244,13 +235,8 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 		return err;
 	}
 
-	dt_val = STM32_CLOCK_VAL_GET(pclken->enr) <<
-					STM32_CLOCK_SHIFT_GET(pclken->enr);
-	reg = (uint32_t *)(DT_REG_ADDR(DT_NODELABEL(rcc)) +
-					STM32_CLOCK_REG_GET(pclken->enr));
-	reg_val = *reg;
-	reg_val |= dt_val;
-	*reg = reg_val;
+	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_CLOCK_REG_GET(pclken->enr),
+		     STM32_CLOCK_VAL_GET(pclken->enr) << STM32_CLOCK_SHIFT_GET(pclken->enr));
 
 	return 0;
 #else

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -12,6 +12,7 @@
 #include <stm32_ll_pwr.h>
 #include <stm32_ll_rcc.h>
 #include <stm32_ll_utils.h>
+#include <zephyr/arch/cpu.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
@@ -356,8 +357,6 @@ static inline int stm32_clock_control_on(const struct device *dev,
 					 clock_control_subsys_t sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
-	volatile uint32_t *reg;
-	uint32_t reg_val;
 
 	ARG_UNUSED(dev);
 
@@ -368,10 +367,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 
-	reg = (uint32_t *)(STM32H7_BUS_CLK_REG + pclken->bus);
-	reg_val = *reg;
-	reg_val |= pclken->enr;
-	*reg = reg_val;
+	sys_set_bits(STM32H7_BUS_CLK_REG + pclken->bus, pclken->enr);
 
 	z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
 
@@ -382,8 +378,6 @@ static inline int stm32_clock_control_off(const struct device *dev,
 					  clock_control_subsys_t sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
-	volatile uint32_t *reg;
-	uint32_t reg_val;
 
 	ARG_UNUSED(dev);
 
@@ -394,10 +388,7 @@ static inline int stm32_clock_control_off(const struct device *dev,
 
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 
-	reg = (uint32_t *)(STM32H7_BUS_CLK_REG + pclken->bus);
-	reg_val = *reg;
-	reg_val &= ~pclken->enr;
-	*reg = reg_val;
+	sys_clear_bits(STM32H7_BUS_CLK_REG + pclken->bus, pclken->enr);
 
 	z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
 
@@ -409,8 +400,6 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 						void *data)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
-	volatile uint32_t *reg;
-	uint32_t reg_val, dt_val;
 	int err;
 
 	ARG_UNUSED(dev);
@@ -424,14 +413,8 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 
-	dt_val = STM32_CLOCK_VAL_GET(pclken->enr) <<
-					STM32_CLOCK_SHIFT_GET(pclken->enr);
-	reg = (uint32_t *)(DT_REG_ADDR(DT_NODELABEL(rcc)) +
-					STM32_CLOCK_REG_GET(pclken->enr));
-	reg_val = *reg;
-	reg_val &= ~dt_val;
-	reg_val |= dt_val;
-	*reg = reg_val;
+	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_CLOCK_REG_GET(pclken->enr),
+		     STM32_CLOCK_VAL_GET(pclken->enr) << STM32_CLOCK_SHIFT_GET(pclken->enr));
 
 	z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
 


### PR DESCRIPTION
Use builtin functions for bit operations to increase readability.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>