### PR TITLE
tests: clock_control: stm32h7: pll2: Fix test configuration

### DIFF
--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/boards/spi1_pll2p_1.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/boards/spi1_pll2p_1.overlay
@@ -9,7 +9,7 @@
  * It is assumed that it is applied after core_init.overlay file.
  */
 
-&pll3 {
+&pll2 {
 	clocks = <&clk_hse>;
 	div-m = <1>;
 	mul-n = <24>;


### PR DESCRIPTION
In test spi1_pll2p_1, pll2 should be enabled instead of pll3.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>