### PR TITLE
sensor: esp32c3: fix coretemp DTS register address

### DIFF
--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -224,7 +224,7 @@
 			status = "disabled";
 		};
 
-		coretemp: coretemp@0x60040058 {
+		coretemp: coretemp@60040058 {
 			compatible = "espressif,esp32-temp";
 			friendly-name = "coretemp";
 			reg = <0x60040058 0x4>;


### PR DESCRIPTION
Remove 0x prefix to avoid build warning.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>