### PR TITLE
cmake: log ${CMAKE_VERSION}

### DIFF
--- a/cmake/modules/zephyr_default.cmake
+++ b/cmake/modules/zephyr_default.cmake
@@ -19,6 +19,11 @@ cmake_minimum_required(VERSION 3.20.0)
 
 message(STATUS "Application: ${APPLICATION_SOURCE_DIR}")
 
+# Different CMake versions can have very subtle differences, for
+# instance CMake 3.21 links object files in a different order compared
+# to CMake 3.20; this produces different binaries.
+message(STATUS "CMake version: ${CMAKE_VERSION}")
+
 find_package(ZephyrBuildConfiguration
   QUIET NO_POLICY_SCOPE
   NAMES ZephyrBuild


### PR DESCRIPTION
Different CMake versions can have very subtle differences, for instance CMake 3.21 links object files in a different order compared to CMake 3.20; this produces different binaries.

CMAKE_VERSION is required information to track binary differences between two build systems.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>