### PR TITLE
net: lib: LwM2M rd client fix

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1115,6 +1115,13 @@ static int sm_do_deregister(void)
 	struct lwm2m_message *msg;
 	int ret;
 
+	if (lwm2m_engine_connection_resume(client.ctx)) {
+		lwm2m_engine_context_close(client.ctx);
+		/* Connection failed, enter directly to deregistered state */
+		set_sm_state(ENGINE_DEREGISTERED);
+		return 0;
+	}
+
 	msg = rd_get_message();
 	if (!msg) {
 		LOG_ERR("Unable to get a lwm2m message!");


### PR DESCRIPTION
Fix LwM2M rd client stop call hang when Queue client is at RX_ON_IDLE_STATE. Added miossing connection resume for de-register functionality.

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>