### PR TITLE
drivers: i2c: Use DT_INST for stm32 i2c driver

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -30,6 +30,14 @@ LOG_MODULE_REGISTER(i2c_ll_stm32);
 #define DT_DRV_COMPAT st_stm32_i2c_v1
 #endif
 
+/* This symbol takes the value 1 if one of the device instances */
+/* is configured in dts with a domain clock */
+#if STM32_DT_INST_DEV_DOMAIN_CLOCK_SUPPORT
+#define STM32_I2C_DOMAIN_CLOCK_SUPPORT 1
+#else
+#define STM32_I2C_DOMAIN_CLOCK_SUPPORT 0
+#endif
+
 int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
@@ -241,7 +249,7 @@ static int i2c_stm32_init(const struct device *dev)
 		return -EIO;
 	}
 
-	if (cfg->pclk_len > 1) {
+	if (IS_ENABLED(STM32_I2C_DOMAIN_CLOCK_SUPPORT) && (cfg->pclk_len > 1)) {
 		/* Enable I2C clock source */
 		ret = clock_control_configure(clk,
 					(clock_control_subsys_t *) &cfg->pclken[1],

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -180,6 +180,9 @@
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>,
+				 /* I2C1 clock source should always be defined,
+				  * even for the default value
+				  */
 				 <&rcc STM32_SRC_SYSCLK I2C1_SEL(1)>;
 			interrupts = <23 0>;
 			interrupt-names = "combined";

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -214,6 +214,9 @@
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>,
+				 /* I2C clock source should always be defined,
+				  * even for the default value
+				  */
 				 <&rcc STM32_SRC_SYSCLK I2C1_SEL(1)>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "event", "error";

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -20,6 +20,9 @@
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00400000>,
+				 /* I2C clock source should always be defined,
+				  * even for the default value
+				  */
 				 <&rcc STM32_SRC_SYSCLK I2C2_SEL(1)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
@@ -33,6 +36,9 @@
 			#size-cells = <0>;
 			reg = <0x40007800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x40000000>,
+				 /* I2C clock source should always be defined,
+				  * even for the default value
+				  */
 				 <&rcc STM32_SRC_SYSCLK I2C3_SEL(1)>;
 			interrupts = <72 0>, <73 0>;
 			interrupt-names = "event", "error";

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -19,7 +19,11 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00400000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00400000>,
+				 /* I2C clock source should always be defined,
+				  * even for the default value
+				  */
+				 <&rcc STM32_SRC_SYSCLK I2C2_SEL(1)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -24,7 +24,11 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00400000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00400000>,
+				 /* I2C clock source should always be defined,
+				  * even for the default value
+				  */
+				 <&rcc STM32_SRC_SYSCLK I2C2_SEL(1)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";


### PR DESCRIPTION
Now that I2C source clock is configured in the dts file, we can migrate the driver to use DT_INST macros.
Once it's done, we can condition the code related to the domain source clock to its effective declaration in dts, and fix the value assigned to the I2C clock.
