### PR TITLE
clang-format: enable SpaceBeforeParens option

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -78,7 +78,7 @@ IncludeCategories:
 IndentCaseLabels: false
 IndentWidth: 8
 InsertBraces: true
-# SpaceBeforeParens: ControlStatementsExceptControlMacros # clang-format >= 13.0
+SpaceBeforeParens: ControlStatementsExceptControlMacros
 SortIncludes: false
 UseTab: Always
 WhitespaceSensitiveMacros:


### PR DESCRIPTION
The option required clang-format >= 13, we now require >= 15, so it can be enabled.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>