### PR TITLE
espi: it8xxx2: make sure h2ram offset is configured correctly

### DIFF
--- a/drivers/espi/espi_it8xxx2.c
+++ b/drivers/espi/espi_it8xxx2.c
@@ -196,6 +196,7 @@ static const struct ec2i_t pmc2_settings[] = {
  * Linker script of h2ram.ld will make the pool 4K aligned.
  */
 #define IT8XXX2_ESPI_H2RAM_POOL_SIZE_MAX 0x1000
+#define IT8XXX2_ESPI_H2RAM_OFFSET_MASK   GENMASK(3, 0)
 
 #if defined(CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION)
 #define H2RAM_ACPI_SHM_MAX ((CONFIG_ESPI_IT8XXX2_ACPI_SHM_H2RAM_SIZE) + \
@@ -249,7 +250,9 @@ static void smfi_it8xxx2_init(const struct device *dev)
 	/* Set the host to RAM cycle address offset */
 	h2ram_offset = ((uint32_t)h2ram_pool & 0xffff) /
 				IT8XXX2_ESPI_H2RAM_POOL_SIZE_MAX;
-	gctrl->GCTRL_H2ROFSR |= h2ram_offset;
+	gctrl->GCTRL_H2ROFSR =
+		(gctrl->GCTRL_H2ROFSR & ~IT8XXX2_ESPI_H2RAM_OFFSET_MASK) |
+		h2ram_offset;
 
 #ifdef CONFIG_ESPI_PERIPHERAL_EC_HOST_CMD
 	memset(&h2ram_pool[CONFIG_ESPI_PERIPHERAL_HOST_CMD_PARAM_PORT_NUM], 0,


### PR DESCRIPTION
This change for addressing the below symptoms.
Two FW images have different h2ram offset settings.
Jumping to each other will cause offset setting errors.

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>