### PR TITLE
logging: fix error handling in link_filters_init

### DIFF
--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -137,6 +137,7 @@ static int link_filters_init(const struct log_link *link)
 	if (link->ctrl_blk->filters == NULL) {
 		LOG_ERR("Failed to allocate buffer for runtime filtering.");
 		__ASSERT(0, "Failed to allocate buffer.");
+		return -ENOMEM;
 	}
 
 	memset(link->ctrl_blk->filters, 0, sizeof(uint32_t) * total_cnt);


### PR DESCRIPTION
If k_malloc() of filters fails in log_mgmt.c:link_filters_init(), return an error and do not rely on the __ASSERT(0).

If __ASSERT_ON==0 in the build, assert will not trigger and code will proceed to execute

  memset(NULL, 0, sizeof(uint32_t) * total_cnt);

Avoid this by returning -ENOMEM on error.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>