### PR TITLE
mgmt: mcumgr: img_mgmt: Fix mismatched slot missing variable

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -588,6 +588,8 @@ img_mgmt_upload_inspect(const struct img_mgmt_upload_req *req,
 
 #if defined(CONFIG_IMG_MGMT_REJECT_DIRECT_XIP_MISMATCHED_SLOT)
 		if (hdr->ih_flags & IMAGE_F_ROM_FIXED_ADDR) {
+			const struct flash_area *fa;
+
 			rc = flash_area_open(action->area_id, &fa);
 			if (rc) {
 				IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action,


### PR DESCRIPTION
Fixes an issue with a missing variable when
CONFIG_IMG_MGMT_REJECT_DIRECT_XIP_MISMATCHED_SLOT is enabled.

Fixes #53293