### PR TITLE
json: Increase max number of descriptor elements from 30 to 62

### DIFF
--- a/include/zephyr/data/json.h
+++ b/include/zephyr/data/json.h
@@ -577,14 +577,14 @@ typedef int (*json_append_bytes_t)(const char *bytes, size_t len,
  * @param len Length of JSON-encoded value
  * @param descr Pointer to the descriptor array
  * @param descr_len Number of elements in the descriptor array. Must be less
- * than 31 due to implementation detail reasons (if more fields are
+ * than 63 due to implementation detail reasons (if more fields are
  * necessary, use two descriptors)
  * @param val Pointer to the struct to hold the decoded values
  *
  * @return < 0 if error, bitmap of decoded fields on success (bit 0
  * is set if first field in the descriptor has been properly decoded, etc).
  */
-int json_obj_parse(char *json, size_t len,
+int64_t json_obj_parse(char *json, size_t len,
 	const struct json_obj_descr *descr, size_t descr_len,
 	void *val);
 

--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -438,18 +438,18 @@ static bool equivalent_types(enum json_tokens type1, enum json_tokens type2)
 	return type1 == type2;
 }
 
-static int obj_parse(struct json_obj *obj,
-		     const struct json_obj_descr *descr, size_t descr_len,
-		     void *val);
+static int64_t obj_parse(struct json_obj *obj,
+			 const struct json_obj_descr *descr, size_t descr_len,
+			 void *val);
 static int arr_parse(struct json_obj *obj,
 		     const struct json_obj_descr *elem_descr,
 		     size_t max_elements, void *field, void *val);
 
 static int arr_data_parse(struct json_obj *obj, struct json_obj_token *val);
 
-static int decode_value(struct json_obj *obj,
-			const struct json_obj_descr *descr,
-			struct json_token *value, void *field, void *val)
+static int64_t decode_value(struct json_obj *obj,
+			    const struct json_obj_descr *descr,
+			    struct json_token *value, void *field, void *val)
 {
 
 	if (!equivalent_types(value->type, descr->type)) {
@@ -620,11 +620,11 @@ static int arr_data_parse(struct json_obj *obj, struct json_obj_token *val)
 	return -EINVAL;
 }
 
-static int obj_parse(struct json_obj *obj, const struct json_obj_descr *descr,
-		     size_t descr_len, void *val)
+static int64_t obj_parse(struct json_obj *obj, const struct json_obj_descr *descr,
+			 size_t descr_len, void *val)
 {
 	struct json_obj_key_value kv;
-	int32_t decoded_fields = 0;
+	int64_t decoded_fields = 0;
 	size_t i;
 	int ret;
 
@@ -637,7 +637,7 @@ static int obj_parse(struct json_obj *obj, const struct json_obj_descr *descr,
 			void *decode_field = (char *)val + descr[i].offset;
 
 			/* Field has been decoded already, skip */
-			if (decoded_fields & (1 << i)) {
+			if (decoded_fields & ((int64_t)1 << i)) {
 				continue;
 			}
 
@@ -658,7 +658,7 @@ static int obj_parse(struct json_obj *obj, const struct json_obj_descr *descr,
 				return ret;
 			}
 
-			decoded_fields |= 1<<i;
+			decoded_fields |= (int64_t)1<<i;
 			break;
 		}
 	}
@@ -666,12 +666,12 @@ static int obj_parse(struct json_obj *obj, const struct json_obj_descr *descr,
 	return -EINVAL;
 }
 
-int json_obj_parse(char *payload, size_t len,
-		   const struct json_obj_descr *descr, size_t descr_len,
-		   void *val)
+int64_t json_obj_parse(char *payload, size_t len,
+		       const struct json_obj_descr *descr, size_t descr_len,
+		       void *val)
 {
 	struct json_obj obj;
-	int ret;
+	int64_t ret;
 
 	__ASSERT_NO_MSG(descr_len < (sizeof(ret) * CHAR_BIT - 1));
 

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -662,4 +662,112 @@ ZTEST(lib_json_test, test_json_encode_bounds_check)
 	zassert_equal(ret, -ENOMEM, "Bounds check failed");
 }
 
+ZTEST(lib_json_test, test_large_descriptor)
+{
+	struct large_struct {
+		int int0;
+		int int1;
+		int int2;
+		int int3;
+		int int4;
+		int int5;
+		int int6;
+		int int7;
+		int int8;
+		int int9;
+		int int10;
+		int int11;
+		int int12;
+		int int13;
+		int int14;
+		int int15;
+		int int16;
+		int int17;
+		int int18;
+		int int19;
+		int int20;
+		int int21;
+		int int22;
+		int int23;
+		int int24;
+		int int25;
+		int int26;
+		int int27;
+		int int28;
+		int int29;
+		int int30;
+		int int31;
+		int int32;
+		int int33;
+		int int34;
+		int int35;
+		int int36;
+		int int37;
+		int int38;
+		int int39;
+	};
+
+	static const struct json_obj_descr large_descr[] = {
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int0, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int1, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int2, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int3, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int4, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int5, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int6, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int7, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int8, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int9, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int10, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int11, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int12, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int13, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int14, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int15, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int16, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int17, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int18, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int19, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int20, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int21, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int22, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int23, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int24, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int25, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int26, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int27, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int28, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int29, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int30, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int31, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int32, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int33, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int34, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int35, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int36, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int37, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int38, JSON_TOK_NUMBER),
+		JSON_OBJ_DESCR_PRIM(struct large_struct, int39, JSON_TOK_NUMBER),
+	};
+	char encoded[] = "{"
+		"\"int1\": 1,"
+		"\"int21\": 21,"
+		"\"int31\": 31,"
+		"\"int39\": 39"
+		"}";
+
+	struct large_struct ls;
+
+	int64_t ret = json_obj_parse(encoded, sizeof(encoded) - 1, large_descr,
+				     ARRAY_SIZE(large_descr), &ls);
+
+	zassert_false(ret < 0, "json_obj_parse returned error %d", ret);
+	zassert_false(ret & ((int64_t)1 << 2), "Field int2 erroneously decoded");
+	zassert_false(ret & ((int64_t)1 << 35), "Field int35 erroneously decoded");
+	zassert_true(ret & ((int64_t)1 << 1), "Field int1 not decoded");
+	zassert_true(ret & ((int64_t)1 << 21), "Field int21 not decoded");
+	zassert_true(ret & ((int64_t)1 << 31), "Field int31 not decoded");
+	zassert_true(ret & ((int64_t)1 << 39), "Field int39 not decoded");
+}
+
 ZTEST_SUITE(lib_json_test, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
The limiting factor is the output bitmask that says which elements have been filled in by the parser. This patch changes the bitmask type from int to int64_t.

Signed-off-by: Björn Stenberg <bjorn@haxx.se>

## Rationale for this change

Parsing JSON messages is a common need in IoT connectivity. Sometimes these message grow larger than 30 fields. This can technically already be handled by calling `json_obj_parse()` several times for the same message using different descriptor structs, but this is a somewhat cumbersome solution that requires structural changes to the calling code. Raising the element limit leaves the calling logic as simple as for smaller messages.

`int64_t` is already used in a number of Zephyr APIs such as bluetooth, time, networking and drivers.

The 64-bit int is only used to store the result, not as part of the parsing work. Thus the change doesn't impact parser performance.

## Points for discussion

I prioritised making the diff small and therefore left out some optional changes that I'd like input on if they are wanted or not:

1. I only changed the return type of `json_obj_parse()` and not any other JSON API call. One can argue this makes the API inconsistent, but there's also an argument that `int` is the norm and should be used unless there is a reason to deviate from it.
1. I did not change the return type declaration in the old testcases that call `json_obj_parse()` with small descriptors. This causes a truncation of the return value from int64_t to int. Since these testcases all use small structs the return value always fits in the int used and hence the code works as intended. But one can reasonably argue it's wrong and inconsistent to keep using the old return type in the old test functions.