### PR TITLE
toolchain: Move extra warning options to toolchain abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,13 @@ endif()
 zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,no_strict_aliasing>>)
 zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,no_strict_aliasing>>)
 
+# Extra warnings options for twister run
+if (CONFIG_COMPILER_WARNINGS_AS_ERRORS)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,warnings_as_errors>>)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:asm,warnings_as_errors>>)
+  zephyr_link_libraries($<TARGET_PROPERTY:linker,warnings_as_errors>)
+endif()
+
 # @Intent: Set compiler flags to enable buffer overflow checks in libc functions
 # @details:
 #  Kconfig.zephyr "Detect buffer overflows in libc calls" is a kconfig choice,

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -360,8 +360,12 @@ config NO_OPTIMIZATIONS
 	help
 	  Compiler optimizations will be set to -O0 independently of other
 	  options.
-
 endchoice
+
+config COMPILER_WARNINGS_AS_ERRORS
+	bool "Treat warnings as errors"
+	help
+	  Turn on "warning as error" toolchain flags
 
 config COMPILER_COLOR_DIAGNOSTICS
 	bool "Colored diagnostics"

--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -134,6 +134,10 @@ set_property(TARGET compiler-cpp PROPERTY dialect_cpp2b "")
 # Flag for disabling strict aliasing rule in C and C++
 set_compiler_property(PROPERTY no_strict_aliasing -fno-strict-aliasing)
 
+# Flags for set extra warnigs (ARCMWDT asm can't recognize --fatal-warnings. Skip it)
+set_property(TARGET compiler PROPERTY warnings_as_errors -Werror)
+set_property(TARGET asm PROPERTY warnings_as_errors -Werror)
+
 # Disable exceptions flag in C++
 set_property(TARGET compiler-cpp PROPERTY no_exceptions "-fno-exceptions")
 

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -68,6 +68,10 @@ set_property(TARGET compiler-cpp PROPERTY dialect_cpp2b)
 # Flag for disabling strict aliasing rule in C and C++
 set_compiler_property(PROPERTY no_strict_aliasing)
 
+# Extra warnings options for twister run
+set_property(TARGET compiler PROPERTY warnings_as_errors)
+set_property(TARGET asm PROPERTY warnings_as_errors)
+
 # Flag for disabling exceptions in C++
 set_property(TARGET compiler-cpp PROPERTY no_exceptions)
 

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -133,6 +133,10 @@ set_property(TARGET compiler-cpp PROPERTY dialect_cpp2b "-std=c++2b"
 # Flag for disabling strict aliasing rule in C and C++
 set_compiler_property(PROPERTY no_strict_aliasing -fno-strict-aliasing)
 
+# Extra warning options
+set_property(TARGET compiler PROPERTY warnings_as_errors -Werror)
+set_property(TARGET asm PROPERTY warnings_as_errors -Werror -Wa,--fatal-warnings)
+
 # Disable exceptions flag in C++
 set_property(TARGET compiler-cpp PROPERTY no_exceptions "-fno-exceptions")
 

--- a/cmake/linker/arcmwdt/linker_flags.cmake
+++ b/cmake/linker/arcmwdt/linker_flags.cmake
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Extra warnings options for twister run
+set_property(TARGET linker PROPERTY warnings_as_errors -Wl,--fatal-warnings)

--- a/cmake/linker/ld/clang/linker_flags.cmake
+++ b/cmake/linker/ld/clang/linker_flags.cmake
@@ -2,3 +2,6 @@
 if (NOT CONFIG_COVERAGE_GCOV)
   set_property(TARGET linker PROPERTY coverage --coverage)
 endif()
+
+# Extra warnings options for twister run
+set_property(TARGET linker PROPERTY ld_extra_warning_options -Wl,--fatal-warnings)

--- a/cmake/linker/ld/gcc/linker_flags.cmake
+++ b/cmake/linker/ld/gcc/linker_flags.cmake
@@ -12,3 +12,6 @@ check_set_linker_property(TARGET linker APPEND PROPERTY gprof -pg)
 # GCC 11 by default emits DWARF version 5 which cannot be parsed by
 # pyelftools. Can be removed once pyelftools supports v5.
 add_link_options(-gdwarf-4)
+
+# Extra warnings options for twister run
+set_property(TARGET linker PROPERTY warnings_as_errors -Wl,--fatal-warnings)

--- a/cmake/linker/linker_flags_template.cmake
+++ b/cmake/linker/linker_flags_template.cmake
@@ -9,3 +9,6 @@ set_property(TARGET linker PROPERTY coverage)
 # If memory reporting is a post build command, please use
 # cmake/bintools/bintools.cmake instead.
 check_set_linker_property(TARGET linker PROPERTY memusage)
+
+# Extra warnings options for twister run
+set_property(TARGET linker PROPERTY warnings_as_errors)

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -277,21 +277,17 @@ class CMake:
     def run_cmake(self, args=""):
 
         if not self.options.disable_warnings_as_errors:
-            ldflags = "-Wl,--fatal-warnings"
-            cflags = "-Werror"
-            aflags = "-Werror -Wa,--fatal-warnings"
+            warnings_as_errors = 'y'
             gen_defines_args = "--edtlib-Werror"
         else:
-            ldflags = cflags = aflags = ""
+            warnings_as_errors = 'n'
             gen_defines_args = ""
 
         logger.debug("Running cmake on %s for %s" % (self.source_dir, self.platform.name))
         cmake_args = [
             f'-B{self.build_dir}',
             f'-DTC_RUNID={self.instance.run_id}',
-            f'-DEXTRA_CFLAGS={cflags}',
-            f'-DEXTRA_AFLAGS={aflags}',
-            f'-DEXTRA_LDFLAGS={ldflags}',
+            f'-DCONFIG_COMPILER_WARNINGS_AS_ERRORS={warnings_as_errors}',
             f'-DEXTRA_GEN_DEFINES_ARGS={gen_defines_args}',
             f'-G{self.env.generator}'
         ]


### PR DESCRIPTION
Move extra warning option from generic twister script into compiler-dependent config files.
ARCMWDT compiler doesn't support extra warning options ex. "-Wl,--fatal-warnings". To avoid build fails flag
"disable_warnings_as_errors" should be passed to twister. This allows all warning messages and make atomatic test useles.

Signed-off-by: Nikolay Agishev <agishev@synopsys.com>