### PR TITLE
drivers: memc: don't relocate MEMC functions unless CONFIG_FLASH=y

### DIFF
--- a/drivers/memc/CMakeLists.txt
+++ b/drivers/memc/CMakeLists.txt
@@ -12,6 +12,6 @@ zephyr_library_sources_ifdef(CONFIG_MEMC_MCUX_FLEXSPI_HYPERRAM memc_mcux_flexspi
 
 zephyr_library_sources_ifdef(CONFIG_MEMC_SAM_SMC memc_sam_smc.c)
 
-if(CONFIG_FLASH_MCUX_FLEXSPI_XIP)
+if((DEFINED CONFIG_FLASH_MCUX_FLEXSPI_XIP) AND (DEFINED CONFIG_FLASH))
   zephyr_code_relocate(memc_mcux_flexspi.c ${CONFIG_FLASH_MCUX_FLEXSPI_XIP_MEM}_TEXT)
 endif()

--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 0594f3042da3ddc0f7e590142b0ff3e5935257ca
+      revision: d33133de8863aac13bf826c02786fc9310380746
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Only relocate memc driver when CONFIG_FLASH=y.
CONFIG_FLASH_MCUX_FLEXSPI_XIP previously was dependent on CONFIG_FLASH, but the scope of this Kconfig has changed.

Due to this, the memc driver now must have two checks, as it should not relocated when the driver is being used for a memory controller that does not expose the flash driver interface.

Since the NXP HAL also relocates the underlying FlexSPI driver using a similar check, it is updated in this commit as well.


This PR was verified using `samples/driver/flash_shell` on the following boards: 
- RT595
- RT1060
- RT1050

In all cases, page read, page write, and page erase were tested

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>