### PR TITLE
Fixes for lsm6dso IMU sensor

### DIFF
--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -715,6 +715,16 @@ static int lsm6dso_init_chip(const struct device *dev)
 	uint8_t chip_id, master_on;
 	uint8_t odr, fs;
 
+	/* All registers except 0x01 are different between banks, including the WHO_AM_I
+	 * register and the register used for a SW reset.  If the lsm6dso wasn't on the user
+	 * bank when it reset, then both the chip id check and the sw reset will fail unless we
+	 * set the bank now.
+	 */
+	if (lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK) < 0) {
+		LOG_DBG("Failed to set user bank");
+		return -EIO;
+	}
+
 	if (lsm6dso_device_id_get(ctx, &chip_id) < 0) {
 		LOG_DBG("Failed reading chip id");
 		return -EIO;

--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -823,6 +823,11 @@ static int lsm6dso_init(const struct device *dev)
 	LOG_INF("Initialize device %s", dev->name);
 	data->dev = dev;
 
+	if (lsm6dso_init_chip(dev) < 0) {
+		LOG_DBG("failed to initialize chip");
+		return -EIO;
+	}
+
 #ifdef CONFIG_LSM6DSO_TRIGGER
 	if (cfg->trig_enabled) {
 		if (lsm6dso_init_interrupt(dev) < 0) {
@@ -831,11 +836,6 @@ static int lsm6dso_init(const struct device *dev)
 		}
 	}
 #endif
-
-	if (lsm6dso_init_chip(dev) < 0) {
-		LOG_DBG("failed to initialize chip");
-		return -EIO;
-	}
 
 #ifdef CONFIG_LSM6DSO_SENSORHUB
 	data->shub_inited = true;

--- a/drivers/sensor/lsm6dso/lsm6dso_shub.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_shub.c
@@ -441,11 +441,11 @@ static int lsm6dso_shub_wait_completed(stmdev_ctx_t *ctx)
 
 static inline void lsm6dso_shub_embedded_en(stmdev_ctx_t *ctx, bool on)
 {
-	if (on) {
-		(void) lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
-	} else {
-		(void) lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-	}
+	lsm6dso_func_cfg_access_t reg = {
+		.reg_access = on ? LSM6DSO_SENSOR_HUB_BANK : LSM6DSO_USER_BANK
+	};
+
+	lsm6dso_write_reg(ctx, LSM6DSO_FUNC_CFG_ACCESS, (uint8_t *)&reg, 1);
 
 	k_busy_wait(150);
 }

--- a/drivers/sensor/lsm6dso/lsm6dso_shub.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_shub.c
@@ -54,6 +54,13 @@ static int lsm6dso_shub_read_slave_reg(const struct device *dev,
 				       uint8_t *value, uint16_t len);
 static void lsm6dso_shub_enable(const struct device *dev, uint8_t enable);
 
+
+/* ST HAL skips this register, only supports it via the slower lsm6dso_sh_status_get() */
+static int32_t lsm6dso_sh_status_mainpage_get(stmdev_ctx_t *ctx, lsm6dso_status_master_t *val)
+{
+	return lsm6dso_read_reg(ctx, LSM6DSO_STATUS_MASTER_MAINPAGE, (uint8_t *)val, 1);
+}
+
 /*
  * LIS2MDL magn device specific part
  */
@@ -415,14 +422,21 @@ static struct lsm6dso_shub_slist {
 #endif /* CONFIG_LSM6DSO_EXT_LPS22HH */
 };
 
-static inline void lsm6dso_shub_wait_completed(stmdev_ctx_t *ctx)
+static int lsm6dso_shub_wait_completed(stmdev_ctx_t *ctx)
 {
 	lsm6dso_status_master_t status;
+	int tries = 200; /* Should be max ~160 ms, from 2 cycles at slowest ODR 12.5 Hz */
 
 	do {
+		if (!--tries) {
+			LOG_DBG("shub: Timeout waiting for operation to complete");
+			return -ETIMEDOUT;
+		}
 		k_msleep(1);
-		lsm6dso_sh_status_get(ctx, &status);
+		lsm6dso_sh_status_mainpage_get(ctx, &status);
 	} while (status.sens_hub_endop == 0);
+
+	return 1;
 }
 
 static inline void lsm6dso_shub_embedded_en(stmdev_ctx_t *ctx, bool on)
@@ -486,7 +500,12 @@ static void lsm6dso_shub_enable(const struct device *dev, uint8_t enable)
 		}
 	}
 
-	lsm6dso_shub_embedded_en(ctx, true);
+	if (enable) {
+		lsm6dso_status_master_t status;
+
+		/* Clear any pending status flags */
+		lsm6dso_sh_status_mainpage_get(ctx, &status);
+	}
 
 	if (lsm6dso_sh_master_set(ctx, enable) < 0) {
 		LOG_DBG("shub: failed to set master on");
@@ -494,7 +513,10 @@ static void lsm6dso_shub_enable(const struct device *dev, uint8_t enable)
 		return;
 	}
 
-	lsm6dso_shub_embedded_en(ctx, false);
+	if (!enable) {
+		/* Necessary per AN5192 §7.2.1 */
+		k_busy_wait(300);
+	}
 }
 
 /* must be called with master on */
@@ -537,7 +559,7 @@ static int lsm6dso_shub_read_slave_reg(const struct device *dev,
 		return -EIO;
 	}
 
-	/* turn SH on */
+	/* turn SH on, wait for shub i2c read to finish */
 	lsm6dso_shub_enable(dev, 1);
 	lsm6dso_shub_wait_completed(ctx);
 
@@ -590,7 +612,7 @@ static int lsm6dso_shub_write_slave_reg(const struct device *dev,
 			return -EIO;
 		}
 
-		/* turn SH on */
+		/* turn SH on, wait for shub i2c write to finish */
 		lsm6dso_shub_enable(dev, 1);
 		lsm6dso_shub_wait_completed(ctx);
 
@@ -658,17 +680,9 @@ static int lsm6dso_shub_set_data_channel(const struct device *dev)
 		return -EIO;
 	}
 
-	lsm6dso_write_once_t wo = LSM6DSO_ONLY_FIRST_CYCLE;
 
-	if (lsm6dso_sh_write_mode_set(ctx, wo) < 0) {
-		LOG_DBG("shub: error setting write once");
-		return -EIO;
-	}
-
-
-	/* turn SH on */
+	/* turn SH on, no need to wait for 1st shub i2c read, if any, to complete */
 	lsm6dso_shub_enable(dev, 1);
-	lsm6dso_shub_wait_completed(ctx);
 
 	return 0;
 }
@@ -750,11 +764,20 @@ int lsm6dso_shub_config(const struct device *dev, enum sensor_channel chan,
 int lsm6dso_shub_init(const struct device *dev)
 {
 	struct lsm6dso_data *data = dev->data;
+	const struct lsm6dso_config *cfg = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	uint8_t i, n = 0, regn;
 	uint8_t chip_id;
 	struct lsm6dso_shub_slist *sp;
 
 	LOG_INF("shub: start sensorhub for %s", dev->name);
+
+	/* This must be set or lsm6dso_shub_write_slave_reg() will repeatedly write the same reg */
+	if (lsm6dso_sh_write_mode_set(ctx, LSM6DSO_ONLY_FIRST_CYCLE) < 0) {
+		LOG_DBG("shub: error setting write once");
+		return -EIO;
+	}
+
 	for (n = 0; n < ARRAY_SIZE(lsm6dso_shub_slist); n++) {
 		if (data->num_ext_dev >= LSM6DSO_SHUB_MAX_NUM_SLVS) {
 			break;

--- a/drivers/sensor/lsm6dso/lsm6dso_shub.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_shub.c
@@ -446,8 +446,6 @@ static inline void lsm6dso_shub_embedded_en(stmdev_ctx_t *ctx, bool on)
 	};
 
 	lsm6dso_write_reg(ctx, LSM6DSO_FUNC_CFG_ACCESS, (uint8_t *)&reg, 1);
-
-	k_busy_wait(150);
 }
 
 static int lsm6dso_shub_read_embedded_regs(stmdev_ctx_t *ctx,

--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -268,6 +268,7 @@ int lsm6dso_init_interrupt(const struct device *dev)
 			(k_thread_entry_t)lsm6dso_thread, lsm6dso,
 			NULL, NULL, K_PRIO_COOP(CONFIG_LSM6DSO_THREAD_PRIORITY),
 			0, K_NO_WAIT);
+	k_thread_name_set(&lsm6dso->thread, "lsm6dso");
 #elif defined(CONFIG_LSM6DSO_TRIGGER_GLOBAL_THREAD)
 	lsm6dso->work.handler = lsm6dso_work_cb;
 #endif /* CONFIG_LSM6DSO_TRIGGER_OWN_THREAD */


### PR DESCRIPTION
A number of fixes, for some critical bugs, and improvements for this driver.  See individual commit messages for detailed descriptions.

* More efficient data reads allow for a higher data rate.
* Reset during read or other sensor hub activity may cause lsm6dso to enter state unrecoverable without a power cycle fixed.
* Sporadic failure for sensors attached to sensor hub to initialize properly fixed.
* Enabling the sensor hub when no sensors are attached results in lsm6dso init time that is tens of seconds to minutes long fixed.