### PR TITLE
samples: basic: use `gpio_is_ready_dt` function

### DIFF
--- a/samples/basic/blinky/src/main.c
+++ b/samples/basic/blinky/src/main.c
@@ -23,7 +23,7 @@ void main(void)
 {
 	int ret;
 
-	if (!device_is_ready(led.port)) {
+	if (!gpio_is_ready_dt(&led)) {
 		return;
 	}
 

--- a/samples/basic/button/src/main.c
+++ b/samples/basic/button/src/main.c
@@ -42,7 +42,7 @@ void main(void)
 {
 	int ret;
 
-	if (!device_is_ready(button.port)) {
+	if (!gpio_is_ready_dt(&button)) {
 		printk("Error: button device %s is not ready\n",
 		       button.port->name);
 		return;


### PR DESCRIPTION
Switch to using the dedicated `gpio_is_ready_dt` function instead of the raw `device_is_ready`.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>