### PR TITLE
dma: hda: enable xrun handling

### DIFF
--- a/soc/xtensa/intel_adsp/common/include/intel_adsp_hda.h
+++ b/soc/xtensa/intel_adsp/common/include/intel_adsp_hda.h
@@ -346,4 +346,28 @@ static inline bool intel_adsp_hda_wp_rp_eq(uint32_t base, uint32_t regblock_size
 	return *DGBWP(base, regblock_size, sid) == *DGBRP(base, regblock_size, sid);
 }
 
+static inline bool intel_adsp_hda_is_buffer_overrun(uint32_t base, uint32_t regblock_size,
+						    uint32_t sid)
+{
+	return (*DGCS(base, regblock_size, sid) & DGCS_BOR) == DGCS_BOR ? 1 : 0;
+}
+
+static inline bool intel_adsp_hda_is_buffer_underrun(uint32_t base, uint32_t regblock_size,
+						     uint32_t sid)
+{
+	return (*DGCS(base, regblock_size, sid) & DGCS_BUR) == DGCS_BUR ? 1 : 0;
+}
+
+static inline void intel_adsp_hda_overrun_clear(uint32_t base, uint32_t regblock_size,
+						uint32_t sid)
+{
+	*DGCS(base, regblock_size, sid) |= DGCS_BOR;
+}
+
+static inline void intel_adsp_hda_underrun_clear(uint32_t base, uint32_t regblock_size,
+						 uint32_t sid)
+{
+	*DGCS(base, regblock_size, sid) |= DGCS_BUR;
+}
+
 #endif /* ZEPHYR_INCLUDE_INTEL_ADSP_HDA_H */


### PR DESCRIPTION
This is proposition of enabling link under/overruns handling and reporting such events in dma status. 

Signed-off-by: Piotr Makaruk <piotr.makaruk@intel.com>