### PR TITLE
C++ compat fix for LE Audio

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -336,12 +336,12 @@ enum bt_audio_dir {
 #define BT_CODEC_QOS(_interval, _framing, _phy, _sdu, _rtn, _latency, \
 		     _pd) \
 	{ \
-		.interval = _interval, \
-		.framing = _framing, \
 		.phy = _phy, \
-		.sdu = _sdu, \
+		.framing = _framing, \
 		.rtn = _rtn, \
+		.sdu = _sdu, \
 		.latency = _latency, \
+		.interval = _interval, \
 		.pd = _pd, \
 	}
 


### PR DESCRIPTION
Designator order fix for compiling under C++.