### PR TITLE
net: zperf: Make shell dependency optional

### DIFF
--- a/samples/net/zperf/sample.yaml
+++ b/samples/net/zperf/sample.yaml
@@ -10,6 +10,10 @@ sample:
 tests:
   sample.net.zperf:
     platform_allow: qemu_x86
+  sample.net.zperf_no_shell:
+    extra_configs:
+      - CONFIG_NET_SHELL=n
+    platform_allow: qemu_x86
   sample.net.zperf.netusb_ecm:
     extra_args: OVERLAY_CONFIG="overlay-netusb.conf"
     tags: usb net zperf

--- a/subsys/net/lib/zperf/CMakeLists.txt
+++ b/subsys/net/lib/zperf/CMakeLists.txt
@@ -5,11 +5,14 @@ zephyr_library_named(zperf)
 zephyr_library_sources(
   zperf_common.c
   zperf_session.c
-  zperf_shell.c
   zperf_udp_receiver.c
   zperf_udp_uploader.c
   zperf_tcp_receiver.c
   zperf_tcp_uploader.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_NET_SHELL
+  zperf_shell.c
 )
 
 zephyr_library_include_directories(

--- a/subsys/net/lib/zperf/Kconfig
+++ b/subsys/net/lib/zperf/Kconfig
@@ -3,7 +3,6 @@
 
 menuconfig NET_ZPERF
 	bool "zperf shell utility"
-	depends on SHELL
 	select NET_CONTEXT_RCVTIMEO if NET_NATIVE_UDP
 	help
 	  This option enables zperf shell utility, which allows to generate

--- a/subsys/net/lib/zperf/zperf_internal.h
+++ b/subsys/net/lib/zperf/zperf_internal.h
@@ -39,6 +39,12 @@
 
 #define PACKET_SIZE_MAX CONFIG_NET_ZPERF_MAX_PACKET_SIZE
 
+#define MY_SRC_PORT 50000
+#define DEF_PORT 5001
+#define DEF_PORT_STR STRINGIFY(DEF_PORT)
+
+#define ZPERF_VERSION "1.1"
+
 struct zperf_udp_datagram {
 	int32_t id;
 	uint32_t tv_sec;


### PR DESCRIPTION
Now that we a proper API, shell is just optional, so, make the dependency optional by refactoring the code.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>