### PR TITLE
libc: Add remaining picolibc-supported targets

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -18,9 +18,11 @@ config SUPPORT_MINIMAL_LIBC
 # Picolibc with C++ support in Zephyr SDK is handled by Zephyr SDK's own Kconfig.
 config PICOLIBC_SUPPORTED
 	bool
-	depends on ARC || ARM || ARM64 || MIPS || RISCV
+	depends on !NATIVE_APPLICATION
 	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "arcmwdt"
 	depends on !(CPP && "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr")
+	# picolibc text is outside .pinned.text on this board. #54148
+	depends on !BOARD_QEMU_X86_TINY
 	default y
 	help
 	  Selected when the target has support for picolibc.


### PR DESCRIPTION
Picolibc now supports all of the Zephyr SDK target architectures for C, except for qemu_x86_tiny which needs fixes to get the libc partition linked into the right spot.

Signed-off-by: Keith Packard <keithp@keithp.com>