### PR TITLE
python-devicetree: bump version to 0.0.2

### DIFF
--- a/scripts/dts/python-devicetree/setup.py
+++ b/scripts/dts/python-devicetree/setup.py
@@ -12,7 +12,7 @@ This is just a placeholder for moving Zephyr's devicetree libraries
 to PyPI.
 '''
 
-version = '0.0.1'
+version = '0.0.2'
 
 setuptools.setup(
     # TBD, just use these for now.

--- a/scripts/dts/python-devicetree/tox.ini
+++ b/scripts/dts/python-devicetree/tox.ini
@@ -5,7 +5,7 @@ envlist=py3
 deps =
     setuptools-scm
     pytest
-    types-PyYAML==6.0.7
+    types-PyYAML
     mypy
 setenv =
     TOXTEMPDIR={envtmpdir}


### PR DESCRIPTION
Today I've been a bit confused by the python-devicetree version at PyPI: 0.0.2, while `zephyr/scripts/dts/python-devicetree/setup.py` still sets the version to 0.0.1.

*Diffing* the repositories at `zephyr-rtos/zephyr/scripts/dts/python-devicetree` and `zephyr-rtos/python-devicetree` shows that (besides the different versions set in `setup.py`):
- the `doc` directory exists only in `zephyr-rtos/python-devicetree`
- the mirrored `tox.ini` file in `zephyr-rtos/python-devicetree` does not pin `types-PyYAML` to version 6.0.7, which the *main* one does to work-around a few mypy errors (Zephyr CI)

This PR:
- assuming the original issue has been resolved, unpins the `types-PyYAML` version (tested with `types-PyYAML` 6.0.12.2)
- now that repositories are identical, bump python-devicetree here to 0.0.2, avoiding confusion regarding which repository is the up-to-date version (and what the differences are)

IMHO, syncing these versions when appropriate may unfortunately remain a *good idea* as long as versioned python-devicetree packages are also distributed through PyPI (independently from Zephyr).  
  
Thanks.

--
chris