### PR TITLE
arch: riscv: add ARCH_HAS_SINGLE_THREAD_SUPPORT

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -242,6 +242,7 @@ endif #RISCV_PMP
 
 config PMP_STACK_GUARD
 	def_bool y
+	depends on MULTITHREADING
 	depends on HW_STACK_PROTECTION
 
 config PMP_STACK_GUARD_MIN_SIZE
@@ -279,6 +280,9 @@ config ARCH_IRQ_VECTOR_TABLE_ALIGN
 
 config GEN_IRQ_VECTOR_TABLE
 	select RISCV_MTVEC_VECTORED_MODE if SOC_FAMILY_RISCV_PRIVILEGE
+
+config ARCH_HAS_SINGLE_THREAD_SUPPORT
+	default y if !SMP
 
 rsource "Kconfig.isa"
 rsource "Kconfig.core"

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -557,6 +557,7 @@ irq_done:
 
 check_reschedule:
 
+#ifdef CONFIG_MULTITHREADING
 	/* Get pointer to current thread on this CPU */
 	lr a1, ___cpu_t_current_OFFSET(s0)
 
@@ -572,6 +573,9 @@ check_reschedule:
 	lr a1, 0(sp)
 	addi sp, sp, 16
 	beqz a0, no_reschedule
+#else
+	j no_reschedule
+#endif /* CONFIG_MULTITHREADING */
 
 reschedule:
 

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -46,7 +46,7 @@ void z_riscv_secondary_cpu_init(int hartid)
 #ifdef CONFIG_SMP
 	_kernel.cpus[cpu_num].arch.online = true;
 #endif
-#ifdef CONFIG_THREAD_LOCAL_STORAGE
+#if defined(CONFIG_MULTITHREADING) && defined(CONFIG_THREAD_LOCAL_STORAGE)
 	__asm__("mv tp, %0" : : "r" (z_idle_threads[cpu_num].tls));
 #endif
 #if defined(CONFIG_RISCV_SOC_INTERRUPT_INIT)

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -99,6 +99,15 @@ void z_riscv_flush_local_fpu(void);
 void z_riscv_flush_fpu_ipi(unsigned int cpu);
 #endif
 
+#ifndef CONFIG_MULTITHREADING
+extern FUNC_NORETURN void z_riscv_switch_to_main_no_multithreading(
+	k_thread_entry_t main_func, void *p1, void *p2, void *p3);
+
+#define ARCH_SWITCH_TO_MAIN_NO_MULTITHREADING \
+	z_riscv_switch_to_main_no_multithreading
+
+#endif /* !CONFIG_MULTITHREADING */
+
 #endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/tests/kernel/fatal/no-multithreading/testcase.yaml
+++ b/tests/kernel/fatal/no-multithreading/testcase.yaml
@@ -4,6 +4,9 @@ common:
     - qemu_arc_em
     - qemu_arc_hs
     - qemu_arc_hs6x
+    - qemu_riscv32
+    - qemu_riscv32e
+    - qemu_riscv64
     - nsim_em
     - nsim_em7d_v22
     - nsim_hs

--- a/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
+++ b/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
@@ -21,6 +21,9 @@ tests:
       - qemu_arc_em
       - qemu_arc_hs
       - qemu_arc_hs6x
+      - qemu_riscv32
+      - qemu_riscv32e
+      - qemu_riscv64
     integration_platforms:
       - qemu_cortex_m3
     extra_configs:

--- a/tests/kernel/mem_slab/mslab_api/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_api/testcase.yaml
@@ -19,6 +19,9 @@ tests:
       - qemu_arc_em
       - qemu_arc_hs
       - qemu_arc_hs6x
+      - qemu_riscv32
+      - qemu_riscv32e
+      - qemu_riscv64
     integration_platforms:
       - qemu_cortex_m3
       - qemu_arc_hs

--- a/tests/kernel/threads/no-multithreading/testcase.yaml
+++ b/tests/kernel/threads/no-multithreading/testcase.yaml
@@ -19,5 +19,8 @@ tests:
       - qemu_arc_em
       - qemu_arc_hs
       - qemu_arc_hs6x
+      - qemu_riscv32
+      - qemu_riscv32e
+      - qemu_riscv64
     integration_platforms:
       - qemu_cortex_m0


### PR DESCRIPTION
Enable single-threading support for the riscv architecture.

Add `z_riscv_switch_to_main_no_multithreading` function for
supporting single-threading.

The single-threading does not work with enabling `PMP_STACK_GUARD`.
It is because single-threading does not use context-switching.
But the privileged mode transition that PMP depends on implicitly
presupposes using context-switching. It is a contradiction.
Thus, disable `PMP_STACK_GUARD` when `MULTITHREADING` is enabled.

--- 

Add qemu_riscv* targets to the tests that list below. 
These set CONFIG_MULTITHREADING=n.

- tests/kernel/fatal/no-multithreading
- tests/kernel/mem_heap/mheap_api_concept
- tests/kernel/mem_slab/mslab_api
- tests/kernel/threads/no-multithreading

note: tests/kernel/timer/timer_api/ test failed. It seems caused by driver. This PR does't enable it.

