### PR TITLE
MAINTAINERS: fix missing ":"

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -973,18 +973,18 @@ Release Notes:
   labels:
     - "area: Neural Networks"
 
-"Drivers: Regulators"
+"Drivers: Regulators":
   status: maintained
   maintainers:
     - gmarull
   collaborators:
     - danieldegrasse
   files:
-    - drivers/regulator
-    - include/zephyr/drivers/regulator
+    - drivers/regulator/
+    - include/zephyr/drivers/regulator/
     - include/zephyr/drivers/regulator.h
-    - include/zephyr/dt-bindings/regulator
-    - tests/drivers/regulator
+    - include/zephyr/dt-bindings/regulator/
+    - tests/drivers/regulator/
   labels:
     - "area: Regulators"
 


### PR DESCRIPTION
Add a missing ":" for "Drivers: Regulators", currently causing PR assigner failure:

```
yaml.scanner.ScannerError: while scanning a simple key
  in "MAINTAINERS.yml", line 976, column 1
could not find expected ':'
  in "MAINTAINERS.yml", line 977, column 3
```