### PR TITLE
ITE: drivers/i2c: Don't spam NACK error messages

### DIFF
--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -140,14 +140,14 @@ static int i2c_parsing_return_value(const struct device *dev)
 		LOG_ERR("I2C ch%d Address:0x%X Transaction time out.",
 			config->port, data->addr_16bit);
 	} else {
-		LOG_ERR("I2C ch%d Address:0x%X Host error bits message:",
+		LOG_DBG("I2C ch%d Address:0x%X Host error bits message:",
 			config->port, data->addr_16bit);
 		/* Host error bits message*/
 		if (data->err & HOSTA_TMOE) {
 			LOG_ERR("Time-out error: hardware time-out error.");
 		}
 		if (data->err & HOSTA_NACK) {
-			LOG_ERR("NACK error: device does not response ACK.");
+			LOG_DBG("NACK error: device does not response ACK.");
 		}
 		if (data->err & HOSTA_FAIL) {
 			LOG_ERR("Fail: a processing transmission is killed.");


### PR DESCRIPTION
Printing of NACK messages should be set to LOG_DBG to avoid spamming. When we scan whether there is a target device through I2C, if we use LOG_ERR, it will frequently print out NACK messages. So it is set to LOG_DBG in the case of NACK.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>