### PR TITLE
net: lwm2m: Refactor lwm2m message handling

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -432,13 +432,8 @@ int lwm2m_information_interface_send(struct lwm2m_message *msg)
 		return 0;
 	}
 #endif
-	sys_slist_append(&msg->ctx->pending_sends, &msg->node);
 
-	if (IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUPPORT) &&
-	    IS_ENABLED(CONFIG_LWM2M_QUEUE_MODE_ENABLED)) {
-		engine_update_tx_time();
-	}
-	return 0;
+	return lwm2m_send_message_async(msg);
 }
 
 int lwm2m_send_empty_ack(struct lwm2m_ctx *client_ctx, uint16_t mid)

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -441,36 +441,6 @@ int lwm2m_information_interface_send(struct lwm2m_message *msg)
 	return 0;
 }
 
-int lwm2m_send_message(struct lwm2m_message *msg)
-{
-	int rc;
-
-	if (!msg || !msg->ctx) {
-		LOG_ERR("LwM2M message is invalid.");
-		return -EINVAL;
-	}
-
-	if (msg->type == COAP_TYPE_CON) {
-		coap_pending_cycle(msg->pending);
-	}
-
-	rc = zsock_send(msg->ctx->sock_fd, msg->cpkt.data, msg->cpkt.offset, 0);
-
-	if (rc < 0) {
-		LOG_ERR("Failed to send packet, err %d", errno);
-		if (msg->type != COAP_TYPE_CON) {
-			lwm2m_reset_message(msg, true);
-		}
-
-		return -errno;
-	}
-
-	if (msg->type != COAP_TYPE_CON) {
-		lwm2m_reset_message(msg, true);
-	}
-
-	return 0;
-}
 int lwm2m_send_empty_ack(struct lwm2m_ctx *client_ctx, uint16_t mid)
 {
 	struct lwm2m_message *msg;

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.h
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.h
@@ -42,7 +42,6 @@ struct lwm2m_message *find_msg(struct coap_pending *pending, struct coap_reply *
 void lwm2m_reset_message(struct lwm2m_message *msg, bool release);
 void lm2m_message_clear_allocations(struct lwm2m_message *msg);
 int lwm2m_init_message(struct lwm2m_message *msg);
-int lwm2m_send_message(struct lwm2m_message *msg);
 int lwm2m_send_message_async(struct lwm2m_message *msg);
 
 int handle_request(struct coap_packet *request, struct lwm2m_message *msg);


### PR DESCRIPTION

- Refactor function lwm2m_information_interface_send()
- Remove function lwm2m_send_message() from public API and combine the code with socket_send_message()
