### PR TITLE
tests: drivers: regulator: fixed: Standarize names of the fixture

### DIFF
--- a/tests/drivers/regulator/fixed/testcase.yaml
+++ b/tests/drivers/regulator/fixed/testcase.yaml
@@ -3,7 +3,8 @@ tests:
     tags: drivers regulator
     harness: ztest
     harness_config:
-      fixture: regulator_gpio_loopback
+      fixture: gpio_loopback
+    depends_on: gpio
     platform_allow: nrf52840dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840


### PR DESCRIPTION
Unify the name of the used fixture and add GPIO for the boards requirements.

Signed-off-by: Katarzyna Giądła <katarzyna.giadla@nordicsemi.no>