### PR TITLE
Lwm2m time series fix and shell command

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -2947,9 +2947,7 @@ static bool init_next_pending_timeseries_data(struct lwm2m_cache_read_info *cach
 					  sys_slist_t *lwm2m_path_list,
 					  sys_slist_t *lwm2m_path_free_list)
 {
-	struct lwm2m_obj_path temp;
 	uint32_t bytes_available = 0;
-	int ret;
 
 	/* Check do we have still pending data to send */
 	for (int i = 0; i < cache_temp->entry_size; i++) {
@@ -2958,12 +2956,9 @@ static bool init_next_pending_timeseries_data(struct lwm2m_cache_read_info *cach
 			continue;
 		}
 
-		ret = lwm2m_string_to_path(cache_temp->read_info[i].cache_data->path, &temp, '/');
-		if (ret < 0) {
-			return false;
-		}
 		/* Add to linked list */
-		if (lwm2m_engine_add_path_to_list(lwm2m_path_list, lwm2m_path_free_list, &temp)) {
+		if (lwm2m_engine_add_path_to_list(lwm2m_path_list, lwm2m_path_free_list,
+						  &cache_temp->read_info[i].cache_data->path)) {
 			return false;
 		}
 

--- a/subsys/net/lib/lwm2m/lwm2m_observation.c
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.c
@@ -1468,18 +1468,6 @@ void lwm2m_engine_free_list(sys_slist_t *path_list, sys_slist_t *free_list)
 	}
 }
 
-static bool lwm2m_path_object_compare(struct lwm2m_obj_path *path,
-				      struct lwm2m_obj_path *compare_path)
-{
-	if (path->level != compare_path->level || path->obj_id != compare_path->obj_id ||
-	    path->obj_inst_id != compare_path->obj_inst_id ||
-	    path->res_id != compare_path->res_id ||
-	    path->res_inst_id != compare_path->res_inst_id) {
-		return false;
-	}
-	return true;
-}
-
 void lwm2m_engine_path_list_init(sys_slist_t *lwm2m_path_list, sys_slist_t *lwm2m_free_list,
 				 struct lwm2m_obj_path_list path_object_buf[],
 				 uint8_t path_object_size)
@@ -1519,7 +1507,7 @@ int lwm2m_engine_add_path_to_list(sys_slist_t *lwm2m_path_list, sys_slist_t *lwm
 		/* Keep list Ordered by Object ID/ Object instance/ resource ID */
 		SYS_SLIST_FOR_EACH_CONTAINER(lwm2m_path_list, entry, node) {
 			if (entry->path.level == LWM2M_PATH_LEVEL_NONE ||
-			    lwm2m_path_object_compare(&entry->path, &new_entry->path)) {
+			    lwm2m_obj_path_equal(&entry->path, &new_entry->path)) {
 				/* Already Root request at list or current path is at list */
 				sys_slist_append(lwm2m_free_list, &new_entry->node);
 				return 0;

--- a/subsys/net/lib/lwm2m/lwm2m_registry.h
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.h
@@ -207,7 +207,7 @@ struct lwm2m_time_series_resource {
 	/* object list */
 	sys_snode_t node;
 	/* Resource Path url */
-	const char *path;
+	struct lwm2m_obj_path path;
 	/* Ring buffer */
 	struct ring_buf rb;
 };
@@ -232,7 +232,6 @@ struct lwm2m_cache_read_info {
 
 int lwm2m_engine_data_cache_init(void);
 struct lwm2m_time_series_resource *lwm2m_cache_entry_get_by_object(struct lwm2m_obj_path *obj_path);
-struct lwm2m_time_series_resource *lwm2m_cache_entry_get_by_string(char const *resource_path);
 bool lwm2m_cache_write(struct lwm2m_time_series_resource *cache_entry,
 		       struct lwm2m_time_series_elem *buf);
 bool lwm2m_cache_read(struct lwm2m_time_series_resource *cache_entry,

--- a/subsys/net/lib/lwm2m/lwm2m_util.c
+++ b/subsys/net/lib/lwm2m/lwm2m_util.c
@@ -551,3 +551,30 @@ int lwm2m_string_to_path(const char *pathstr, struct lwm2m_obj_path *path,
 
 	return 0;
 }
+
+bool lwm2m_obj_path_equal(struct lwm2m_obj_path *a, struct lwm2m_obj_path *b)
+{
+	uint8_t level = a->level;
+
+	if (a->level != b->level) {
+		return false;
+	}
+
+	if (level >= LWM2M_PATH_LEVEL_OBJECT && (a->obj_id != b->obj_id)) {
+		return false;
+	}
+
+	if (level >= LWM2M_PATH_LEVEL_OBJECT_INST && (a->obj_inst_id != b->obj_inst_id)) {
+		return false;
+	}
+
+	if (level >= LWM2M_PATH_LEVEL_RESOURCE && (a->res_id != b->res_id)) {
+		return false;
+	}
+
+	if (level >= LWM2M_PATH_LEVEL_RESOURCE_INST && (a->res_inst_id != b->res_inst_id)) {
+		return false;
+	}
+
+	return true;
+}

--- a/subsys/net/lib/lwm2m/lwm2m_util.h
+++ b/subsys/net/lib/lwm2m/lwm2m_util.h
@@ -33,4 +33,5 @@ int lwm2m_path_to_string(char *buf, size_t buf_size, struct lwm2m_obj_path *inpu
 
 int lwm2m_string_to_path(const char *pathstr, struct lwm2m_obj_path *path, char delim);
 
+bool lwm2m_obj_path_equal(struct lwm2m_obj_path *a, struct lwm2m_obj_path *b);
 #endif /* LWM2M_UTIL_H_ */


### PR DESCRIPTION
Fixed problem for matching path url with or without '/'
by change time series data structure to use struct lwm2m_obj_path.
Cherry-picked commit from PR
https://github.com/zephyrproject-rtos/zephyr/pull/53272 top of my commits.