### PR TITLE
scripts: compliance: add a check for MAINTAINERS.yml format

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -20,6 +20,9 @@ import shlex
 from junitparser import TestCase, TestSuite, JUnitXml, Skipped, Error, Failure
 import magic
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from get_maintainer import Maintainers, MaintainersError
+
 logger = None
 
 def git(*args, cwd=None):
@@ -965,6 +968,27 @@ class ImageSize(ComplianceTest):
             if size > limit:
                 self.failure(f"Image file too large: {file} reduce size to "
                              f"less than {limit >> 10}kB")
+
+
+class MaintainersFormat(ComplianceTest):
+    """
+    Check that MAINTAINERS file parses correctly.
+    """
+    name = "MaintainersFormat"
+    doc = "Check that MAINTAINERS file parses correctly."
+    path_hint = "<git-top>"
+
+    def run(self):
+        MAINTAINERS_FILES = ["MAINTAINERS.yml", "MAINTAINERS.yaml"]
+
+        for file in get_files(filter="d"):
+            if file not in MAINTAINERS_FILES:
+                continue
+
+            try:
+                Maintainers(file)
+            except MaintainersError as ex:
+                self.failure(f"Error parsing {file}: {ex}")
 
 
 def init_logs(cli_arg):


### PR DESCRIPTION
Hi! Seems like nothing checks for the maintainers file format automatically besides `set_assignees.py` scripts, and the run on the PR itself does not seem to be patching in the changed version (?!), so if an error is introduced is going to break PR assignment on new PRs. Adding a simple compliance check to make sure that the file loads.

-- 8< --

Add a compliance check that tries to load MAINTAINERS.yml with get_maintainer.Maintainers() if it's been modified by the CL, and fail compliance if it fails to be parsed.

Example output:

```
ERROR   : Test MaintainersFormat failed:
Error parsing MAINTAINERS.yml: MAINTAINERS.yml: YAML error: while
scanning a simple key
  in "MAINTAINERS.yml", line 976, column 1
could not find expected ':'
  in "MAINTAINERS.yml", line 977, column 3
```

```
ERROR   : Test MaintainersFormat failed:
Error parsing MAINTAINERS.yml: MAINTAINERS.yml: glob pattern
'drivers/regulator' in 'files' in area 'Drivers: Regulators' matches a
directory, but has no trailing '/'
```