### PR TITLE
change initialization order of CSI and cameras

### DIFF
--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk-pinctrl.dtsi
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk-pinctrl.dtsi
@@ -24,7 +24,7 @@
 	/* conflicts with lpuart3 and flexcan1 */
 	pinmux_csi: pinmux_csi {
 		group0 {
-			pinmux = <&iomuxc_gpio_ad_b0_04_gpio1_io04>;
+			pinmux = <&iomuxc_gpio_ad_b1_02_gpio1_io18>;
 			drive-strength = "r0-6";
 			bias-pull-down;
 			bias-pull-down-value = "100k";

--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -15,7 +15,7 @@ if VIDEO
 
 config VIDEO_INIT_PRIORITY
 	int "Video initialization priority"
-	default 90
+	default 60
 	help
 	  System initialization priority for video drivers.
 

--- a/drivers/video/mt9m114.c
+++ b/drivers/video/mt9m114.c
@@ -409,6 +409,6 @@ static int mt9m114_init_0(const struct device *dev)
 
 DEVICE_DT_INST_DEFINE(0, &mt9m114_init_0, NULL,
 		    &mt9m114_data_0, &mt9m114_cfg_0,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,
 		    &mt9m114_driver_api);
 #endif

--- a/drivers/video/ov7725.c
+++ b/drivers/video/ov7725.c
@@ -645,5 +645,5 @@ static int ov7725_init_0(const struct device *dev)
 
 DEVICE_DT_INST_DEFINE(0, &ov7725_init_0, NULL,
 		    &ov7725_data_0, &ov7725_cfg_0,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,
 		    &ov7725_driver_api);

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -369,8 +369,10 @@ static int video_mcux_csi_init(const struct device *dev)
 
 	CSI_GetDefaultConfig(&data->csi_config);
 
-	/* check if there is any sensor device (video ctrl device) */
-	if (!device_is_ready(config->sensor_dev)) {
+	/* check if there is any sensor device (video ctrl device)
+	 * the device is not yet initialized so we only check if it exists
+	 */
+	if (config->sensor_dev == NULL) {
 		return -ENODEV;
 	}
 
@@ -440,9 +442,14 @@ static int video_mcux_csi_init_0(const struct device *dev)
 	return video_mcux_csi_init(dev);
 }
 
+/* CONFIG_KERNEL_INIT_PRIORITY_DEVICE is used to make sure the
+ * CSI peripheral is initialized before the camera, which is
+ * necessary since the clock to the camera is provided by the
+ * CSI peripheral.
+ */
 DEVICE_DT_INST_DEFINE(0, &video_mcux_csi_init_0,
 		    NULL, &video_mcux_csi_data_0,
 		    &video_mcux_csi_config_0,
-		    POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,
+		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		    &video_mcux_csi_driver_api);
 #endif


### PR DESCRIPTION
`video_mcux_csi_init`, which setups the CSI pins (i.e: calls pinctrl_apply_state) was called after `mt9m114_init` which tries to do i2c communication with the camera to read the chip id. But since one of the CSI pins is the camera master clock, doing things in this order won't work. This PR inverts the order in which the devices are initialized.

also, somewhat related, correct the PWDN pin for pinmux_csi