### PR TITLE
boards: nrf: Add GPIO support for Nordic-supported boards

### DIFF
--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.yaml
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.yaml
@@ -12,3 +12,4 @@ supported:
   - counter
   - pwm
   - netif:openthread
+  - gpio

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.yaml
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.yaml
@@ -18,3 +18,4 @@ supported:
   - watchdog
   - counter
   - netif:openthread
+  - gpio

--- a/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.yaml
+++ b/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.yaml
@@ -8,5 +8,6 @@ toolchain:
   - xtools
 supported:
   - counter
+  - gpio
 ram: 24
 flash: 192

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.yaml
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.yaml
@@ -8,5 +8,6 @@ toolchain:
   - xtools
 supported:
   - counter
+  - gpio
 ram: 24
 flash: 192

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp.yaml
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp.yaml
@@ -17,3 +17,4 @@ supported:
   - usb_cdc
   - usb_device
   - netif:openthread
+  - gpio

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp_ns.yaml
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpuapp_ns.yaml
@@ -15,3 +15,4 @@ supported:
   - usb_cdc
   - usb_device
   - netif:openthread
+  - gpio

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.yaml
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.yaml
@@ -10,3 +10,4 @@ ram: 64
 flash: 256
 supported:
   - watchdog
+  - gpio

--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.yaml
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.yaml
@@ -10,3 +10,4 @@ toolchain:
 supported:
   - ble
   - netif:openthread
+  - gpio

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_ns.yaml
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_ns.yaml
@@ -17,3 +17,4 @@ supported:
   - pwm
   - watchdog
   - netif:modem
+  - gpio


### PR DESCRIPTION
Add information about GPIO support for Nordic-supported boards.

Signed-off-by: Katarzyna Giądła <katarzyna.giadla@nordicsemi.no>