### PR TITLE
cache: kconfig: Reorder and fix entries

### DIFF
--- a/drivers/cache/Kconfig
+++ b/drivers/cache/Kconfig
@@ -3,18 +3,21 @@
 
 menuconfig CACHE
 	bool "External cache controllers drivers"
+	default y if CACHE_MANAGEMENT
 	help
 	  Enable support for external cache controllers drivers
 
 if CACHE
 
+config CACHE_HAS_DRIVER
+	bool
+
 module = CACHE
 module-str = cache
 source "subsys/logging/Kconfig.template.log_config"
 
-config CACHE_HAS_DRIVER
-	bool
-
-endif # CACHE
+comment "Device Drivers"
 
 source "drivers/cache/Kconfig.aspeed"
+
+endif # CACHE


### PR DESCRIPTION
The general Kconfig is at the moment a bit messy. Reorder and fix it.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>