### PR TITLE
lora: sx12xx_common: fix clearing buffer before jumping to user handler

### DIFF
--- a/drivers/lora/sx12xx_common.c
+++ b/drivers/lora/sx12xx_common.c
@@ -103,10 +103,10 @@ static void sx12xx_ev_rx_done(uint8_t *payload, uint16_t size, int16_t rssi,
 
 	/* Receiving in asynchronous mode */
 	if (dev_data.async_rx_cb) {
-		/* Start receiving again */
-		Radio.Rx(0);
 		/* Run the callback */
 		dev_data.async_rx_cb(dev_data.dev, payload, size, rssi, snr);
+		/* Start receiving again */
+		Radio.Rx(0);
 		/* Don't run the synchronous code */
 		return;
 	}


### PR DESCRIPTION
Inside the Radio.RX(0) command, the payload buffer with the received data is cleared and size became 0 and so it must happen after jump no user handler.

It happens because of Radio.Rx(0) jump to 
https://github.com/zephyrproject-rtos/loramac-node/blob/12019623bbad9eb54fe51066847a7cbd4b4eac57/src/radio/sx1276/sx1276.c#L898
and the payload buffer is cleared here
https://github.com/zephyrproject-rtos/loramac-node/blob/12019623bbad9eb54fe51066847a7cbd4b4eac57/src/radio/sx1276/sx1276.c#L1033
