### PR TITLE
drivers: dai: intel: dmic: don't use assert for error handling

### DIFF
--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -743,7 +743,9 @@ static const struct dai_config *dai_dmic_get_config(const struct device *dev, en
 {
 	struct dai_intel_dmic *dmic = (struct dai_intel_dmic *)dev->data;
 
-	__ASSERT_NO_MSG(dir == DAI_DIR_RX);
+	if (dir != DAI_DIR_RX)
+		return NULL;
+
 	return &dmic->dai_config_params;
 }
 


### PR DESCRIPTION
The dai.h interface does not prohibit calling dai_config_get() with different direction values. The dmic driver should handle invalid direction value explicitly and not rely on an assert.

Link: https://github.com/thesofproject/sof/issues/6896
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>