### PR TITLE
intel_adsp: ace: power: fix build error with asserts enabled

### DIFF
--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -224,8 +224,10 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		soc_cpus_active[cpu] = false;
 		z_xtensa_cache_flush_inv_all();
 		if (cpu == 0) {
+#ifdef CONFIG_ADSP_IMR_CONTEXT_SAVE
 			/* save storage and restore information to imr */
 			__ASSERT_NO_MSG(global_imr_ram_storage != NULL);
+#endif
 			struct imr_layout *imr_layout = (struct imr_layout *)(IMR_LAYOUT_ADDRESS);
 
 			imr_layout->imr_state.header.adsp_imr_magic = ADSP_IMR_MAGIC_VALUE;


### PR DESCRIPTION
If defined(CONFIG_ASSERT) and !defined(CONFIG_ADSP_IMR_CONTEXT_SAVE), build will fail as symbol "global_imr_ram_storage" is not defined.

Link: https://github.com/thesofproject/sof/issues/6896
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>