### PR TITLE
native: sync providers of native_posix to native_posix_64

### DIFF
--- a/boards/posix/native_posix/native_posix_64.yaml
+++ b/boards/posix/native_posix/native_posix_64.yaml
@@ -1,6 +1,7 @@
 identifier: native_posix_64
 name: Native 64-bit POSIX port
 type: native
+simulation: native
 arch: posix
 ram: 65536
 flash: 65536
@@ -14,4 +15,8 @@ supported:
   - netif:eth
   - usb_device
   - adc
+  - i2c
+  - spi
   - gpio
+testing:
+  default: true

--- a/tests/subsys/logging/log_msg/src/main.c
+++ b/tests/subsys/logging/log_msg/src/main.c
@@ -568,7 +568,7 @@ ZTEST(log_msg, test_saturate)
 	Z_LOG_MSG2_CREATE3(0, mode, 0, 0, (void *)1, 2, NULL, 0, "test");
 	z_log_msg_runtime_create(0, (void *)1, 2, NULL, 0, 0, "test");
 
-	zassert_equal(z_log_dropped_read_and_clear(), 3, "No dropped messages.");
+	zassert_equal(z_log_dropped_read_and_clear(), 3, "Wrong number of dropped messages.");
 
 	for (int i = 0; i < exp_capacity; i++) {
 		msg = z_log_msg_claim(NULL);


### PR DESCRIPTION
This syncs the board definition with native_posix so the supported
features are the same.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
