### PR TITLE
scripts: compliance: add support for YAMLLint

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         pip3 install setuptools
         pip3 install wheel
-        pip3 install python-magic lxml junitparser gitlint pylint pykwalify
+        pip3 install python-magic lxml junitparser gitlint pylint pykwalify yamllint
         pip3 install west
 
     - name: west setup

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+extends: default
+
+rules:
+  line-length:
+    max: 100
+  comments:
+    min-spaces-from-content: 1
+  indentation:
+    spaces: 2
+    indent-sequences: consistent
+  document-start:
+    present: false
+  truthy:
+    check-keys: false

--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -6,3 +6,4 @@ python-magic-bin; sys_platform == "win32"
 lxml
 junitparser>=2
 pylint
+yamllint


### PR DESCRIPTION
Hi! Here's a proposal to integrate yamllint to our compliance tests. This is using YAMLLint (https://yamllint.readthedocs.io/en/stable/index.html), which is also used in Linux (https://lxr.missinglinkelectronics.com/linux/Documentation/devicetree/bindings/Makefile).

Linux config: https://lxr.missinglinkelectronics.com/linux/Documentation/devicetree/bindings/.yamllint
Rules documentation: https://yamllint.readthedocs.io/en/stable/rules.html

Current rules: (updated)
```
{'braces': {'forbid': False,
            'level': 'error',
            'max-spaces-inside': 0,
            'max-spaces-inside-empty': -1,
            'min-spaces-inside': 0,
            'min-spaces-inside-empty': -1},
 'brackets': {'forbid': False,
              'level': 'error',
              'max-spaces-inside': 0,
              'max-spaces-inside-empty': -1,
              'min-spaces-inside': 0,
              'min-spaces-inside-empty': -1},
 'colons': {'level': 'error', 'max-spaces-after': 1, 'max-spaces-before': 0},
 'commas': {'level': 'error',
            'max-spaces-after': 1,
            'max-spaces-before': 0,
            'min-spaces-after': 1},
 'comments': {'ignore-shebangs': True,
              'level': 'warning',
              'min-spaces-from-content': 1,
              'require-starting-space': True},
 'comments-indentation': {'level': 'warning'},
 'document-end': False,
 'document-start': {'level': 'warning', 'present': False},
 'empty-lines': {'level': 'error', 'max': 2, 'max-end': 0, 'max-start': 0},
 'empty-values': False,
 'float-values': False,
 'hyphens': {'level': 'error', 'max-spaces-after': 1},
 'indentation': {'check-multi-line-strings': False,
                 'indent-sequences': 'consistent',
                 'level': 'error',
                 'spaces': 2},
 'key-duplicates': {'level': 'error'},
 'key-ordering': False,
 'line-length': {'allow-non-breakable-inline-mappings': False,
                 'allow-non-breakable-words': True,
                 'level': 'error',
                 'max': 100},
 'new-line-at-end-of-file': {'level': 'error'},
 'new-lines': {'level': 'error', 'type': 'unix'},
 'octal-values': False,
 'quoted-strings': False,
 'trailing-spaces': {'level': 'error'},
 'truthy': {'allowed-values': ['true', 'false'],
            'check-keys': False,
            'level': 'warning'}}
```

...and I added some tweaks for the github workflow files to avoid breaking long command lines and to allow on/off booleans.

Now this is finding a lot of lint warnings in our current files:

```
$ yamllint -f parsable -c .yamllint $( find -regex '.*\.y[a]*ml' )  | sed -r 's/^.*\((.*)\)$/\1/' | sort | uniq -c
     22 brackets
     16 colons
      1 commas
    178 comments
     31 comments-indentation
      1 empty-lines
     47 hyphens
   1763 indentation
     14 key-duplicates
    192 line-length
     48 truthy
```

Full list: https://gist.github.com/fabiobaltieri/c5b72fe03b2e0ca57b3a5df922666549

The ones I checked look reasonable to me, and would have to be addressed before submitting this PR otherwise they'd block unrelated patches (case in point, I had to fix a True -> true for this one). I'll work on those on separate PRs if we decide to go ahead with this, will likely tweak few rules in the process I imagine.

One cool thing of this beside the file format consistency is that it catches duplicate keys (the `14 key-duplicates` above), which are hard to spot otherwise.

Prerequisite PRs:

- [x] Fix most errors https://github.com/zephyrproject-rtos/zephyr/pull/53449
- [x] Fix duplicate keys (https://github.com/zephyrproject-rtos/zephyr/pull/53462)
- [x] Fix indentations (https://github.com/zephyrproject-rtos/zephyr/pull/53481)