### PR TITLE
boards: st: Fix external storage to be used with LittleFS

### DIFF
--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -166,8 +166,7 @@
 			   #size-cells = <1>;
 
 			   partition@0 {
-			       label = "nor";
-			       reg = <0x00000000 DT_SIZE_M(4)>;
+			       reg = <0x00000000 DT_SIZE_M(64)>;
 			   };
 		};
 	};

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -163,7 +163,6 @@
 		data-rate = <OSPI_DTR_TRANSFER>;
 		four-byte-opcodes;
 		status = "okay";
-
 		sfdp-bfp = [
 			53 46 44 50 06 01 02 ff
 			00 06 01 10 30 00 00 ff
@@ -190,15 +189,15 @@
 			00 00 00 00 00 00 00 00
 			00 00 00 00 00 00 00 00
 			7f ef ff ff 21 5c dc ff
-	];
+		];
+
 		partitions {
 			   compatible = "fixed-partitions";
 			   #address-cells = <1>;
 			   #size-cells = <1>;
 
 			   partition@0 {
-			       label = "nor";
-			       reg = <0x00000000 DT_SIZE_M(4)>;
+			       reg = <0x00000000 DT_SIZE_M(64)>;
 			   };
 		};
 	};

--- a/samples/subsys/fs/littlefs/boards/b_u585i_iot02a.conf
+++ b/samples/subsys/fs/littlefs/boards/b_u585i_iot02a.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2023 OS Systems
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_FS_LITTLEFS_FC_HEAP_SIZE=8192

--- a/samples/subsys/fs/littlefs/boards/b_u585i_iot02a.overlay
+++ b/samples/subsys/fs/littlefs/boards/b_u585i_iot02a.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 OS Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ / {
+	fstab {
+		compatible = "zephyr,fstab";
+		lfs1: lfs1 {
+			compatible = "zephyr,fstab,littlefs";
+			read-size = <256>;
+			prog-size = <256>;
+			cache-size = <4096>;
+			lookahead-size = <256>;
+			block-cycles = <512>;
+			partition = <&lfs1_partition>;
+			mount-point = "/lfs1";
+			automount;
+		};
+	};
+};
+
+&mx25lm51245 {
+	partitions {
+		/delete-node/ partition;
+
+		/* Use the whole flash for the filesystem. */
+		lfs1_partition: partition@0 {
+			reg = <0x00000000 DT_SIZE_M(64)>;
+		};
+	};
+};

--- a/samples/subsys/fs/littlefs/boards/stm32l562e_dk.conf
+++ b/samples/subsys/fs/littlefs/boards/stm32l562e_dk.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2023 OS Systems
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_FS_LITTLEFS_FC_HEAP_SIZE=8192

--- a/samples/subsys/fs/littlefs/boards/stm32l562e_dk.overlay
+++ b/samples/subsys/fs/littlefs/boards/stm32l562e_dk.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 OS Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ / {
+	fstab {
+		compatible = "zephyr,fstab";
+		lfs1: lfs1 {
+			compatible = "zephyr,fstab,littlefs";
+			read-size = <256>;
+			prog-size = <256>;
+			cache-size = <4096>;
+			lookahead-size = <256>;
+			block-cycles = <512>;
+			partition = <&lfs1_partition>;
+			mount-point = "/lfs1";
+			automount;
+		};
+	};
+};
+
+&mx25lm51245 {
+	partitions {
+		/delete-node/ partition;
+
+		/* Use the whole flash for the filesystem. */
+		lfs1_partition: partition@0 {
+			reg = <0x00000000 DT_SIZE_M(64)>;
+		};
+	};
+};


### PR DESCRIPTION
This harmonize and fix external NOR configs for stm32l562e_dk and b_u585i_iot02a boards. It add a fstab to allow use with LittleFS.

CC: @otavio