### PR TITLE
mgmt: updatehub: Rework check integrity

### DIFF
--- a/subsys/mgmt/updatehub/CMakeLists.txt
+++ b/subsys/mgmt/updatehub/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 O.S.Systems
+# Copyright (c) 2018-2023 O.S.Systems
 #
 # SPDX -License-Identifier: Apache-2.0
 #
@@ -10,6 +10,7 @@ zephyr_library_sources_ifdef(CONFIG_UPDATEHUB updatehub.c)
 zephyr_library_sources_ifdef(CONFIG_UPDATEHUB updatehub_device.c)
 zephyr_library_sources_ifdef(CONFIG_UPDATEHUB updatehub_firmware.c)
 zephyr_library_sources_ifdef(CONFIG_UPDATEHUB updatehub_timer.c)
+zephyr_library_sources_ifdef(CONFIG_UPDATEHUB updatehub_integrity.c)
 zephyr_library_sources_ifdef(CONFIG_UPDATEHUB_SHELL shell.c)
 
 zephyr_include_directories(

--- a/subsys/mgmt/updatehub/Kconfig
+++ b/subsys/mgmt/updatehub/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 O.S.Systems
+# Copyright (c) 2018-2023 O.S.Systems
 # SPDX -License-Identifier: Apache-2.0
 
 menuconfig UPDATEHUB
@@ -17,8 +17,6 @@ menuconfig UPDATEHUB
 	select COAP
 	select DNS_RESOLVER
 	select JSON_LIBRARY
-	select TINYCRYPT
-	select TINYCRYPT_SHA256
 	select HWINFO
 	help
 	  UpdateHub is an enterprise-grade solution which makes simple to
@@ -147,6 +145,10 @@ config UPDATEHUB_DOWNLOAD_STORAGE_SHA256_VERIFICATION
 
 	  It is advised to leave this option enabled.
 
+endchoice
+
+choice FLASH_AREA_CHECK_INTEGRITY_BACKEND
+	default FLASH_AREA_CHECK_INTEGRITY_MBEDTLS
 endchoice
 
 module = UPDATEHUB

--- a/subsys/mgmt/updatehub/updatehub_integrity.c
+++ b/subsys/mgmt/updatehub/updatehub_integrity.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2023 O.S.Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(updatehub, CONFIG_UPDATEHUB_LOG_LEVEL);
+
+#include "updatehub_integrity.h"
+
+int updatehub_integrity_init(struct updatehub_crypto_context *ctx)
+{
+	int ret;
+
+	if (ctx == NULL) {
+		LOG_DBG("Invalid integrity context");
+		return -EINVAL;
+	}
+
+	memset(ctx, 0, sizeof(struct updatehub_crypto_context));
+
+#if defined(CONFIG_FLASH_AREA_CHECK_INTEGRITY_MBEDTLS)
+	ctx->md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+	if (ctx->md_info == NULL) {
+		LOG_DBG("Message Digest not found or not enabled");
+		return -ENOENT;
+	}
+
+	mbedtls_md_init(&ctx->md_ctx);
+	ret = mbedtls_md_setup(&ctx->md_ctx, ctx->md_info, 0);
+	if (ret == MBEDTLS_ERR_MD_BAD_INPUT_DATA) {
+		LOG_DBG("Bad Message Digest selected");
+		return -EFAULT;
+	}
+	if (ret == MBEDTLS_ERR_MD_ALLOC_FAILED) {
+		LOG_DBG("Failed to allocate memory");
+		return -ENOMEM;
+	}
+
+	ret = mbedtls_md_starts(&ctx->md_ctx);
+	if (ret == MBEDTLS_ERR_MD_BAD_INPUT_DATA) {
+		LOG_DBG("Bad Message Digest selected");
+		return -EFAULT;
+	}
+#elif defined(CONFIG_FLASH_AREA_CHECK_INTEGRITY_TC)
+	ret = tc_sha256_init(&ctx->sha256sum);
+	if (ret != TC_CRYPTO_SUCCESS) {
+		LOG_DBG("Invalid integrity context");
+		return -EFAULT;
+	}
+#endif
+
+	return 0;
+}
+
+int updatehub_integrity_update(struct updatehub_crypto_context *ctx,
+			       const uint8_t *buffer, const uint32_t len)
+{
+	int ret;
+
+	if (ctx == NULL || buffer == NULL) {
+		return -EINVAL;
+	}
+
+	/* bypass */
+	if (len == 0) {
+		return 0;
+	}
+
+#if defined(CONFIG_FLASH_AREA_CHECK_INTEGRITY_MBEDTLS)
+	ret = mbedtls_md_update(&ctx->md_ctx, buffer, len);
+	if (ret == MBEDTLS_ERR_MD_BAD_INPUT_DATA) {
+		LOG_DBG("Bad Message Digest selected");
+		return -EFAULT;
+	}
+#elif defined(CONFIG_FLASH_AREA_CHECK_INTEGRITY_TC)
+	ret = tc_sha256_update(&ctx->sha256sum, buffer, len);
+	if (ret != TC_CRYPTO_SUCCESS) {
+		LOG_DBG("Invalid integrity context or invalid buffer");
+		return -EFAULT;
+	}
+#endif
+
+	return 0;
+}
+
+int updatehub_integrity_finish(struct updatehub_crypto_context *ctx,
+			       uint8_t *hash, const uint32_t size)
+{
+	int ret;
+
+	if (ctx == NULL || hash == NULL) {
+		return -EINVAL;
+	}
+
+#if defined(CONFIG_FLASH_AREA_CHECK_INTEGRITY_MBEDTLS)
+	if (size < mbedtls_md_get_size(ctx->md_info)) {
+		LOG_DBG("HASH input buffer is to small to store the message digest");
+		return -EINVAL;
+	}
+
+	ret = mbedtls_md_finish(&ctx->md_ctx, hash);
+	if (ret == MBEDTLS_ERR_MD_BAD_INPUT_DATA) {
+		LOG_DBG("Bad Message Digest selected");
+		return -EFAULT;
+	}
+
+	mbedtls_md_free(&ctx->md_ctx);
+#elif defined(CONFIG_FLASH_AREA_CHECK_INTEGRITY_TC)
+	ret = tc_sha256_final(hash, &ctx->sha256sum);
+	if (ret != TC_CRYPTO_SUCCESS) {
+		LOG_DBG("Invalid integrity context or invalid hash pointer");
+		return -EFAULT;
+	}
+#endif
+
+	return 0;
+}

--- a/subsys/mgmt/updatehub/updatehub_integrity.h
+++ b/subsys/mgmt/updatehub/updatehub_integrity.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 O.S.Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __UPDATEHUB_INTEGRITY_H__
+#define __UPDATEHUB_INTEGRITY_H__
+
+#if defined(CONFIG_FLASH_AREA_CHECK_INTEGRITY_MBEDTLS)
+#include <mbedtls/md.h>
+#elif defined(CONFIG_FLASH_AREA_CHECK_INTEGRITY_TC)
+#include <tinycrypt/sha256.h>
+#include <tinycrypt/constants.h>
+#else
+#error "Integrity check method not defined"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SHA256_BIN_DIGEST_SIZE	(32)
+#define SHA256_HEX_DIGEST_SIZE	((SHA256_BIN_DIGEST_SIZE * 2) + 1)
+
+struct updatehub_crypto_context {
+#if defined(CONFIG_FLASH_AREA_CHECK_INTEGRITY_MBEDTLS)
+	mbedtls_md_context_t md_ctx;
+	const mbedtls_md_info_t *md_info;
+#elif defined(CONFIG_FLASH_AREA_CHECK_INTEGRITY_TC)
+	struct tc_sha256_state_struct sha256sum;
+#endif
+};
+
+int updatehub_integrity_init(struct updatehub_crypto_context *ctx);
+int updatehub_integrity_update(struct updatehub_crypto_context *ctx,
+			       const uint8_t *buffer, const uint32_t len);
+int updatehub_integrity_finish(struct updatehub_crypto_context *ctx,
+			       uint8_t *hash, const uint32_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __UPDATEHUB_INTEGRITY_H__ */

--- a/subsys/storage/flash_map/Kconfig
+++ b/subsys/storage/flash_map/Kconfig
@@ -35,7 +35,7 @@ config FLASH_AREA_CHECK_INTEGRITY
 	  integrity using SHA-256 verification algorithm.
 
 if FLASH_AREA_CHECK_INTEGRITY
-choice
+choice FLASH_AREA_CHECK_INTEGRITY_BACKEND
 	prompt "Crypto backend for the flash check functions"
 	default FLASH_AREA_CHECK_INTEGRITY_TC
 


### PR DESCRIPTION
The TinyCrypt is the current library used by UpdateHub to perform SHA-256 integrity check. This refactor code and add support to
mbedTLS library. It changes default library to mbedTLS to use hardware accelerator when available.

CC: @otavio