### PR TITLE
Option to log I2C transactions

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -29,6 +29,12 @@ config I2C_STATS
 	help
 	  Enable I2C Stats.
 
+config I2C_DUMP_MESSAGES
+	bool "Log all I2C transactions"
+	depends on LOG
+	help
+	  Dump every I2C transaction to the system log as debug level log messages.
+
 config I2C_CALLBACK
 	bool "I2C asynchronous callback API"
 	help

--- a/drivers/i2c/i2c_common.c
+++ b/drivers/i2c/i2c_common.c
@@ -34,12 +34,19 @@ void i2c_dump_msgs_rw(const char *name, const struct i2c_msg *msgs,
 		const bool is_read = msg->flags & I2C_MSG_READ;
 		const bool dump_data = dump_read || !is_read;
 
-		LOG_DBG("   %c %s%s len=%02x: ", is_read ? 'R' : 'W',
-			msg->flags & I2C_MSG_RESTART ? "Sr " : "",
-			msg->flags & I2C_MSG_STOP ? "P" : "",
-			msg->len);
-		if (dump_data) {
-			LOG_HEXDUMP_DBG(msg->buf, msg->len, "contents:");
+		if (msg->len == 1 && dump_data) {
+			LOG_DBG("   %c %s%s len=01: %02x", is_read ? 'R' : 'W',
+				msg->flags & I2C_MSG_RESTART ? "Sr " : "",
+				msg->flags & I2C_MSG_STOP ? "P" : "",
+				msg->buf[0]);
+		} else {
+			LOG_DBG("   %c %s%s len=%02x: ", is_read ? 'R' : 'W',
+				msg->flags & I2C_MSG_RESTART ? "Sr " : "",
+				msg->flags & I2C_MSG_STOP ? "P" : "",
+				msg->len);
+			if (dump_data) {
+				LOG_HEXDUMP_DBG(msg->buf, msg->len, "contents:");
+			}
 		}
 	}
 }

--- a/drivers/i2c/i2c_common.c
+++ b/drivers/i2c/i2c_common.c
@@ -25,19 +25,20 @@ void z_i2c_transfer_signal_cb(const struct device *dev,
 }
 #endif
 
-void i2c_dump_msgs(const char *name, const struct i2c_msg *msgs,
-		   uint8_t num_msgs, uint16_t addr)
+void i2c_dump_msgs_rw(const char *name, const struct i2c_msg *msgs,
+		      uint8_t num_msgs, uint16_t addr, bool dump_read)
 {
 	LOG_DBG("I2C msg: %s, addr=%x", name, addr);
 	for (unsigned int i = 0; i < num_msgs; i++) {
 		const struct i2c_msg *msg = &msgs[i];
+		const bool is_read = msg->flags & I2C_MSG_READ;
+		const bool dump_data = dump_read || !is_read;
 
-		LOG_DBG("   %c %s%s len=%02x: ",
-			msg->flags & I2C_MSG_READ ? 'R' : 'W',
+		LOG_DBG("   %c %s%s len=%02x: ", is_read ? 'R' : 'W',
 			msg->flags & I2C_MSG_RESTART ? "Sr " : "",
 			msg->flags & I2C_MSG_STOP ? "P" : "",
 			msg->len);
-		if (!(msg->flags & I2C_MSG_READ)) {
+		if (dump_data) {
 			LOG_HEXDUMP_DBG(msg->buf, msg->len, "contents:");
 		}
 	}

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -1429,7 +1429,8 @@ static inline int i2c_reg_update_byte_dt(const struct i2c_dt_spec *spec,
  * @brief Dump out an I2C message
  *
  * Dumps out a list of I2C messages. For any that are writes (W), the data is
- * displayed in hex.
+ * displayed in hex. Setting dump_read will dump the data for read messages too,
+ * which only makes sense when called after the messages have been processed.
  *
  * It looks something like this (with name "testing"):
  *
@@ -1448,9 +1449,30 @@ static inline int i2c_reg_update_byte_dt(const struct i2c_dt_spec *spec,
  * @param msgs Array of messages to dump.
  * @param num_msgs Number of messages to dump.
  * @param addr Address of the I2C target device.
+ * @param dump_read Dump data from I2C reads, otherwise only writes have data dumped.
  */
-void i2c_dump_msgs(const char *name, const struct i2c_msg *msgs,
-		   uint8_t num_msgs, uint16_t addr);
+void i2c_dump_msgs_rw(const char *name, const struct i2c_msg *msgs,
+		      uint8_t num_msgs, uint16_t addr, bool dump_read);
+
+/**
+ * @brief Dump out an I2C message, before it is executed.
+ *
+ * This is equivalent to:
+ *
+ *     i2c_dump_msgs_rw(name, msgs, num_msgs, addr, false);
+ *
+ * The read messages' data isn't dumped.
+ *
+ * @param name Name of this dump, displayed at the top.
+ * @param msgs Array of messages to dump.
+ * @param num_msgs Number of messages to dump.
+ * @param addr Address of the I2C target device.
+ */
+static inline void i2c_dump_msgs(const char *name, const struct i2c_msg *msgs,
+				 uint8_t num_msgs, uint16_t addr)
+{
+	i2c_dump_msgs_rw(name, msgs, num_msgs, addr, false);
+}
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -1436,13 +1436,13 @@ static inline int i2c_reg_update_byte_dt(const struct i2c_dt_spec *spec,
  *
  * @code
  * D: I2C msg: testing, addr=56
- * D:    W len=01:
- * D: contents:
- * D: 06                      |.
+ * D:    W len=01: 06
  * D:    W len=0e:
  * D: contents:
  * D: 00 01 02 03 04 05 06 07 |........
  * D: 08 09 0a 0b 0c 0d       |......
+ * D:    W len=01: 0f
+ * D:    R len=01: 6c
  * @endcode
  *
  * @param name Name of this dump, displayed at the top.

--- a/subsys/emul/emul_bmi160.c
+++ b/subsys/emul/emul_bmi160.c
@@ -241,7 +241,7 @@ static int bmi160_emul_transfer_i2c(const struct emul *target, struct i2c_msg *m
 
 	__ASSERT_NO_MSG(msgs && num_msgs);
 
-	i2c_dump_msgs("emul", msgs, num_msgs, addr);
+	i2c_dump_msgs_rw("emul", msgs, num_msgs, addr, false);
 	switch (num_msgs) {
 	case 2:
 		if (msgs->flags & I2C_MSG_READ) {

--- a/subsys/emul/i2c/emul_atmel_at24.c
+++ b/subsys/emul/i2c/emul_atmel_at24.c
@@ -81,7 +81,7 @@ static int at24_emul_transfer(const struct emul *target, struct i2c_msg *msgs,
 		return -EIO;
 	}
 
-	i2c_dump_msgs("emul", msgs, num_msgs, addr);
+	i2c_dump_msgs_rw("emul", msgs, num_msgs, addr, false);
 	switch (num_msgs) {
 	case 1:
 		if (msgs->flags & I2C_MSG_READ) {

--- a/subsys/emul/i2c/emul_sbs_gauge.c
+++ b/subsys/emul/i2c/emul_sbs_gauge.c
@@ -91,7 +91,7 @@ static int sbs_gauge_emul_transfer_i2c(const struct emul *target, struct i2c_msg
 
 	__ASSERT_NO_MSG(msgs && num_msgs);
 
-	i2c_dump_msgs("emul", msgs, num_msgs, addr);
+	i2c_dump_msgs_rw("emul", msgs, num_msgs, addr, false);
 	switch (num_msgs) {
 	case 2:
 		if (msgs->flags & I2C_MSG_READ) {


### PR DESCRIPTION
This adds a configuration option to log all I2C messages.  This can be very useful for debugging problems with I2C drivers and devices.  The code to do the logging was already there.  This just adds the option to turn on a call that logs everything.

Linux had an option like this for many years until the dynamic tracing system replaced it a few years ago.

This also changes the format of the debug logs slightly so they are easier to read and don't take as many lines.