### PR TITLE
test: spi: update fast test frequecny for em_starterkit

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/em_starterkit.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/em_starterkit.overlay
@@ -13,6 +13,6 @@
 	fast@0 {
 		compatible = "test-spi-loopback-fast";
 		reg = <0>;
-		spi-max-frequency = <16000000>;
+		spi-max-frequency = <2500000>;
 	};
 };


### PR DESCRIPTION
Async test failed in fast test due to too fast spi frequency.
Now it is lowered to 2500000Hz.

Signed-off-by: Siyuan Cheng <siyuanc@synopsys.com>