### PR TITLE
samples: drivers: uart: Read until FIFO empty in echo_bot

### DIFF
--- a/samples/drivers/uart/echo_bot/src/main.c
+++ b/samples/drivers/uart/echo_bot/src/main.c
@@ -36,10 +36,12 @@ void serial_cb(const struct device *dev, void *user_data)
 		return;
 	}
 
-	while (uart_irq_rx_ready(uart_dev)) {
+	if (!uart_irq_rx_ready(uart_dev)) {
+		return;
+	}
 
-		uart_fifo_read(uart_dev, &c, 1);
-
+	/* read until FIFO empty */
+	while (uart_fifo_read(uart_dev, &c, 1) == 1) {
 		if ((c == '\n' || c == '\r') && rx_buf_pos > 0) {
 			/* terminate string */
 			rx_buf[rx_buf_pos] = '\0';


### PR DESCRIPTION
The RX ready condition is unspecified with regard to being level or edge triggered, so all available data should then be read once the RX ready condition is detected. This change brings the sample into agreement with the documentation and tests.

Signed-off-by: Brett Witherspoon <brett@witherspoon.engineering>