### PR TITLE
net: lib: sockets: support IPv6-only use case with AF_UNSPEC

### DIFF
--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -201,6 +201,11 @@ int z_impl_z_zsock_getaddrinfo_internal(const char *host, const char *service,
 	ai_state.dns_id = 0;
 	k_sem_init(&ai_state.sem, 0, K_SEM_MAX_LIMIT);
 
+	/* In case IPv4 is not supported, force to check only for IPv6 */
+	if (family == AF_UNSPEC && !IS_ENABLED(CONFIG_NET_IPV4)) {
+		family = AF_INET6;
+	}
+
 	/* If the family is AF_UNSPEC, then we query IPv4 address first */
 	ret = exec_query(host, family, &ai_state);
 	if (ret == 0) {


### PR DESCRIPTION
Setting `hints.ai_family` to `AF_UNSPEC` was causing `net_getaddrinfo_addr_str()` and in turn `getaddrinfo()` to resolve the literal SNTP SERVER first into IPv4 and then (if supported) IPv6 addresses. This was causing useless waste of time and memory in case IPv4 was not supported. In addition, in case IPv4 addresses were not supported, other system components (eg. SNTP) could fail due to the DNS returning IP addresses with unsupported family type (ie. IPv4).
Now, if address family is not explicitly set to `AF_INET` (ie. IPv4), then no attempt is made to resolve SNTP server address into an IPv4 address, in case the system does not support IPv4.

Signed-off-by: Marco Argiolas <marco.argiolas@ftpsolutions.com.au>