### PR TITLE
net: lib: sntp: add support for unspecified IP-family type

### DIFF
--- a/subsys/net/lib/sntp/sntp_simple.c
+++ b/subsys/net/lib/sntp/sntp_simple.c
@@ -17,7 +17,7 @@ int sntp_simple(const char *server, uint32_t timeout, struct sntp_time *time)
 	uint64_t deadline;
 	uint32_t iter_timeout;
 
-	hints.ai_family = AF_INET;
+	hints.ai_family = AF_UNSPEC;
 	hints.ai_socktype = SOCK_DGRAM;
 	hints.ai_protocol = 0;
 	/* 123 is the standard SNTP port per RFC4330 */

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -201,6 +201,11 @@ int z_impl_z_zsock_getaddrinfo_internal(const char *host, const char *service,
 	ai_state.dns_id = 0;
 	k_sem_init(&ai_state.sem, 0, K_SEM_MAX_LIMIT);
 
+	/* In case IPv4 is not supported, force to check only for IPv6 */
+	if (family == AF_UNSPEC && !IS_ENABLED(CONFIG_NET_IPV4)) {
+		family = AF_INET6;
+	}
+
 	/* If the family is AF_UNSPEC, then we query IPv4 address first */
 	ret = exec_query(host, family, &ai_state);
 	if (ret == 0) {


### PR DESCRIPTION
`sntp_simple()` was forcing to resolve SNTP-server's URL into IPv4 addresses. This was not allowing `sntp_init()` to succeed in case the system did not support IPv4 addresses (returning EPFNOSUPPORT, ie. Protoco Family error).
Now by default SNTP has unspecified family type and it relies on `net_getaddrinfo_addr_str()` to be able to resolve literal server URLs into the supported IP family type.
    
Signed-off-by: Marco Argiolas <marco.argiolas@ftpsolutions.com.au>