### PR TITLE
maintainers: change lvgl status to "odd fixes"

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2557,8 +2557,8 @@ West:
     - manifest-loramac-node
 
 "West project: lvgl":
-  status: maintained
-  maintainers:
+  status: odd fixes
+  collaborators:
     - brgl
   files:
     - modules/Kconfig.lvgl


### PR DESCRIPTION
Due to an unexpected change in employment status and going back to full-time linux kernel development and maintenance, I'm no longer able to spend much time on Zephyr. :(

Change my maintainership status to "odd fixes" for lvgl. I would also be willing to pass the torch on to anyone interested.