### PR TITLE
drivers: can: mcan: Fix flag overflow for some MCUs

### DIFF
--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -180,8 +180,8 @@ struct can_mcan_data {
 	void *state_change_cb_data;
 	uint32_t std_filt_rtr;
 	uint32_t std_filt_rtr_mask;
-	uint8_t ext_filt_rtr;
-	uint8_t ext_filt_rtr_mask;
+	uint16_t ext_filt_rtr;
+	uint16_t ext_filt_rtr_mask;
 	struct can_mcan_mm mm;
 	bool started;
 	void *custom;


### PR DESCRIPTION
The number of extended filters can be up to 15 for MCUs like the NXP LPC55Sxx series, so the flags don't fit into uint8_t.

Fixes #53417