### PR TITLE
tests: drivers: regulator: fixed: add nrf5340dk/nrf9160dk overlays

### DIFF
--- a/tests/drivers/regulator/fixed/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/regulator/fixed/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "test_common.dtsi"
+
+/ {
+	regulator {
+		/* Arduino D11 */
+		enable-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+	};
+	resources {
+		/* Arduino D13 */
+		check-gpios = <&gpio0 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+	};
+};

--- a/tests/drivers/regulator/fixed/boards/nrf9160dk_nrf9160.overlay
+++ b/tests/drivers/regulator/fixed/boards/nrf9160dk_nrf9160.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "test_common.dtsi"
+
+/ {
+	regulator {
+		/* Arduino D0 */
+		enable-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+	};
+	resources {
+		/* Arduino D1 */
+		check-gpios = <&gpio0 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+	};
+};
+
+&uart1 {
+	/* Default-enabled Arduino UART steals the pins we want. */
+	status = "disabled";
+};

--- a/tests/drivers/regulator/fixed/testcase.yaml
+++ b/tests/drivers/regulator/fixed/testcase.yaml
@@ -5,6 +5,8 @@ tests:
     harness_config:
       fixture: gpio_loopback
     depends_on: gpio
-    platform_allow: nrf52840dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160
     integration_platforms:
       - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf9160dk_nrf9160


### PR DESCRIPTION
Allow to run the test on nRF5340DK and nRF9160DK boards.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>

cc: @katgiadla