### PR TITLE
toolchain: gcc: rename popcount to avoid conflict with C++20

### DIFF
--- a/drivers/dai/intel/alh/alh.c
+++ b/drivers/dai/intel/alh/alh.c
@@ -50,7 +50,7 @@ static int dai_alh_set_config_blob(struct dai_intel_alh *dp, const struct dai_co
 
 		if (IPC4_ALH_DAI_INDEX(alh_id) == dp->index) {
 			alh->params.stream_id = alh_id;
-			alh->params.channels = popcount(alh_cfg->mapping[i].channel_mask);
+			alh->params.channels = POPCOUNT(alh_cfg->mapping[i].channel_mask);
 			break;
 		}
 	}

--- a/drivers/dai/intel/dmic/dmic_nhlt.c
+++ b/drivers/dai/intel/dmic/dmic_nhlt.c
@@ -253,7 +253,7 @@ int dai_dmic_set_config_nhlt(struct dai_intel_dmic *dmic, const void *bespoke_cf
 
 	/* Channel_ctlr_mask bits indicate the FIFOs enabled*/
 	channel_ctrl_mask = ((struct nhlt_dmic_channel_ctrl_mask *)p)->channel_ctrl_mask;
-	num_fifos = popcount(channel_ctrl_mask); /* Count set bits */
+	num_fifos = POPCOUNT(channel_ctrl_mask); /* Count set bits */
 	p += sizeof(struct nhlt_dmic_channel_ctrl_mask);
 	LOG_DBG("dmic_set_config_nhlt(): channel_ctrl_mask = %d", channel_ctrl_mask);
 
@@ -336,7 +336,7 @@ int dai_dmic_set_config_nhlt(struct dai_intel_dmic *dmic, const void *bespoke_cf
 
 	/* Get PDMx registers */
 	pdm_ctrl_mask = ((struct nhlt_pdm_ctrl_mask *)p)->pdm_ctrl_mask;
-	num_pdm = popcount(pdm_ctrl_mask); /* Count set bits */
+	num_pdm = POPCOUNT(pdm_ctrl_mask); /* Count set bits */
 	p += sizeof(struct nhlt_pdm_ctrl_mask);
 	LOG_DBG("dmic_set_config_nhlt(): pdm_ctrl_mask = %d", pdm_ctrl_mask);
 	if (num_pdm < 1 || num_pdm > CONFIG_DAI_DMIC_HW_CONTROLLERS) {

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -1348,8 +1348,8 @@ static int dai_ssp_set_config_tplg(struct dai_intel_ssp *dp, const struct dai_co
 		 */
 		sspsp |= SSPSP_SFRMP(!inverted_frame);
 
-		active_tx_slots = popcount(ssp->params.tx_slots);
-		active_rx_slots = popcount(ssp->params.rx_slots);
+		active_tx_slots = POPCOUNT(ssp->params.tx_slots);
+		active_rx_slots = POPCOUNT(ssp->params.rx_slots);
 
 		/*
 		 * handle TDM mode, TDM mode has padding at the end of
@@ -1837,9 +1837,9 @@ static const struct dai_config *dai_ssp_config_get(const struct device *dev, enu
 	params->rate = ssp->params.fsync_rate;
 
 	if (dir == DAI_DIR_PLAYBACK) {
-		params->channels = popcount(ssp->params.tx_slots);
+		params->channels = POPCOUNT(ssp->params.tx_slots);
 	} else {
-		params->channels = popcount(ssp->params.rx_slots);
+		params->channels = POPCOUNT(ssp->params.rx_slots);
 	}
 
 	params->word_size = ssp->params.sample_valid_bits;

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -250,7 +250,7 @@ do {                                                                    \
 
 #define likely(x)   (__builtin_expect((bool)!!(x), true) != 0L)
 #define unlikely(x) (__builtin_expect((bool)!!(x), false) != 0L)
-#define popcount(x) __builtin_popcount(x)
+#define POPCOUNT(x) __builtin_popcount(x)
 
 #ifndef __no_optimization
 #define __no_optimization __attribute__((optimize("-O0")))

--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -748,10 +748,10 @@ static inline int group_popcount(atomic_t *target)
 	int i, count = 0;
 
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.lpn.added); i++) {
-		count += popcount(atomic_get(&target[i]));
+		count += POPCOUNT(atomic_get(&target[i]));
 	}
 #else
-	return popcount(atomic_get(target));
+	return POPCOUNT(atomic_get(target));
 #endif
 }
 

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1002,7 +1002,7 @@ static inline int32_t ack_timeout(struct seg_rx *rx)
 	     (ttl * (int32_t)CONFIG_BT_MESH_SEG_ACK_PER_HOP_TIMEOUT);
 
 	/* Add timeout for evenry not yet received segment. */
-	to += ((rx->seg_n + 1) - popcount(rx->block)) *
+	to += ((rx->seg_n + 1) - POPCOUNT(rx->block)) *
 		(int32_t)CONFIG_BT_MESH_SEG_ACK_PER_SEGMENT_TIMEOUT;
 
 	/* Make sure we don't send more frequently than the duration for

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -878,7 +878,7 @@ ZTEST(userspace, test_object_recycle)
 		     "object wasn't marked as initialized");
 
 	for (int i = 0; i < CONFIG_MAX_THREAD_BYTES; i++) {
-		perms_count += popcount(ko->perms[i]);
+		perms_count += POPCOUNT(ko->perms[i]);
 	}
 
 	zassert_true(perms_count == 1, "invalid number of thread permissions");


### PR DESCRIPTION
The macro conflicts with the C++20 feature std::popcount

fixes https://github.com/zephyrproject-rtos/zephyr/issues/53421

Signed-off-by: Hein Wessels <heinwessels93@gmail.com>