### PR TITLE
tests: logging: log_msg: Fix test after mpsc_pbuf changes

### DIFF
--- a/tests/subsys/logging/log_msg/src/main.c
+++ b/tests/subsys/logging/log_msg/src/main.c
@@ -549,7 +549,7 @@ ZTEST(log_msg, test_saturate)
 	uint32_t exp_len =
 		ROUND_UP(offsetof(struct log_msg, data) + 2 * sizeof(void *),
 			 Z_LOG_MSG2_ALIGNMENT);
-	uint32_t exp_capacity = (CONFIG_LOG_BUFFER_SIZE - 1) / exp_len;
+	uint32_t exp_capacity = CONFIG_LOG_BUFFER_SIZE / exp_len;
 	int mode;
 	union log_msg_generic *msg;
 
@@ -574,9 +574,11 @@ ZTEST(log_msg, test_saturate)
 		msg = z_log_msg_claim(NULL);
 		zassert_equal(log_msg_get_timestamp(&msg->log), i,
 				"Unexpected timestamp used for message id");
+		z_log_msg_free(msg);
 	}
 
 	msg = z_log_msg_claim(NULL);
+
 	zassert_equal(msg, NULL, "Expected no pending messages");
 }
 


### PR DESCRIPTION
Test started to fail after updated in mpsc_pbuf. It was failing for two reasons:
- Expected capacity was not updated after change in mpsc_pbuf which now has full capacity (does not use extra byte for empty vs full distinction).
- Messages were claimed without freeing. It was faulty even before the update since mpsc_pbuf is single consumer so only one message can be claimed at a time. However, test was passing before unexpectedly.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>