### PR TITLE
rpi_pico: Fix DTC warnings

### DIFF
--- a/boards/arm/rpi_pico/rpi_pico.dts
+++ b/boards/arm/rpi_pico/rpi_pico.dts
@@ -18,7 +18,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,flash-controller = &flash_controller;
+		zephyr,flash-controller = &ssi;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,code-partition = &code_partition;

--- a/drivers/flash/flash_rpi_pico.c
+++ b/drivers/flash/flash_rpi_pico.c
@@ -27,10 +27,11 @@ LOG_MODULE_REGISTER(flash_rpi_pico, CONFIG_FLASH_LOG_LEVEL);
 #define DT_DRV_COMPAT raspberrypi_pico_flash_controller
 
 #define PAGE_SIZE 256
-#define SECTOR_SIZE DT_PROP(DT_CHILD(DT_NODELABEL(flash_controller), flash_0), erase_block_size)
+#define SECTOR_SIZE DT_PROP(DT_CHOSEN(zephyr_flash), erase_block_size)
 #define ERASE_VALUE 0xff
 #define FLASH_SIZE KB(CONFIG_FLASH_SIZE)
-#define FLASH_BASE DT_REG_ADDR(DT_NODELABEL(flash_controller))
+#define FLASH_BASE CONFIG_FLASH_BASE_ADDRESS
+#define SSI_BASE_ADDRESS DT_REG_ADDR(DT_CHOSEN(zephyr_flash_controller))
 
 static const struct flash_parameters flash_rpi_parameters = {
 	.write_block_size = 1,
@@ -56,7 +57,7 @@ enum outover {
 	OUTOVER_HIGH
 };
 
-static ssi_hw_t *const ssi = (ssi_hw_t *)XIP_SSI_BASE;
+static ssi_hw_t *const ssi = (ssi_hw_t *)SSI_BASE_ADDRESS;
 static uint32_t boot2_copyout[BOOT2_SIZE_WORDS];
 static bool boot2_copyout_valid;
 

--- a/dts/arm/rpi_pico/rp2040.dtsi
+++ b/dts/arm/rpi_pico/rp2040.dtsi
@@ -33,15 +33,14 @@
 			reg = <0x20000000 DT_SIZE_K(264)>;
 		};
 
-		flash_controller: flash-controller@10000000 {
+		ssi: flash-controller@18000000 {
 			compatible = "raspberrypi,pico-flash-controller";
-			reg = <0x10000000 DT_SIZE_K(4)>;
-			interrupts = <15 0>;
+			reg = <0x18000000 0xfc>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			flash0: flash@0 {
+			flash0: flash@10000000 {
 				compatible = "soc-nv-flash";
 				write-block-size = <1>;
 				erase-block-size = <DT_SIZE_K(4)>;

--- a/dts/arm/rpi_pico/rp2040.dtsi
+++ b/dts/arm/rpi_pico/rp2040.dtsi
@@ -68,12 +68,6 @@
 			#reset-cells = <1>;
 		};
 
-		pinctrl: pin-controller@40014000 {
-			compatible = "raspberrypi,pico-pinctrl";
-			reg = <0x40014000 DT_SIZE_K(4)>;
-			status = "okay";
-		};
-
 		gpio0: gpio@40014000 {
 			compatible = "raspberrypi,pico-gpio";
 			reg = <0x40014000 DT_SIZE_K(4)>;
@@ -187,6 +181,10 @@
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
+	};
+
+	pinctrl: pin-controller {
+		compatible = "raspberrypi,pico-pinctrl";
 	};
 };
 


### PR DESCRIPTION
This PR fixes two DTC warnings that have been present for some time:
```
Warning (unique_unit_address_if_enabled): /soc/pin-controller@40014000: duplicate unit-address (also used in node /soc/gpio@40014000)
```
and:
```
unit address and first address in 'reg' (0x10000000) don't match for /soc/flash-controller@10000000/flash@0
```
The first was caused by the pinctrl and gpio bank sharing the same unit address. The RP2040 doesn't have an actual pin control unit, so it does not need a unit address.
The second was caused by a conflict of the unit address of the flash as defined by the SoC and the board. There wasn't a clear distinction between the flash controller and the flash itself. This was fixed for the SoC, board and driver.