### PR TITLE
net: ip: net_context: AF_PACKET/SOCK_RAW/IPPROTO_RAW: set pkt family

### DIFF
--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -747,21 +747,7 @@ static int ppp_send(const struct device *dev, struct net_pkt *pkt)
 			protocol = htons(PPP_IP);
 		} else if (net_pkt_family(pkt) == AF_INET6) {
 			protocol = htons(PPP_IPV6);
-		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
-			   net_pkt_family(pkt) == AF_PACKET) {
-			char type = (NET_IPV6_HDR(pkt)->vtc & 0xf0);
-
-			switch (type) {
-			case 0x60:
-				protocol = htons(PPP_IPV6);
-				break;
-			case 0x40:
-				protocol = htons(PPP_IP);
-				break;
-			default:
-				return -EPROTONOSUPPORT;
-			}
-		} else {
+		}  else {
 			return -EPROTONOSUPPORT;
 		}
 	}

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1763,6 +1763,21 @@ static int context_sendto(struct net_context *context,
 		net_pkt_cursor_init(pkt);
 
 		if (net_context_get_proto(context) == IPPROTO_RAW) {
+			char type = (NET_IPV6_HDR(pkt)->vtc & 0xf0);
+
+			/* Set the family to pkt if detected */
+			switch (type) {
+			case 0x60:
+				net_pkt_set_family(pkt, AF_INET6);
+				break;
+			case 0x40:
+				net_pkt_set_family(pkt, AF_INET);
+				break;
+			default:
+				/* Not IP traffic, let it go forward as it is */
+				break;
+			}
+
 			/* Pass to L2: */
 			ret = net_send_data(pkt);
 		} else {

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -667,21 +667,6 @@ static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 			net_pkt_lladdr_src(pkt)->len =
 						sizeof(struct net_eth_addr);
 			ptype = dst_addr->sll_protocol;
-		} else if (context && net_context_get_type(context) == SOCK_RAW &&
-			   net_context_get_proto(context) == IPPROTO_RAW) {
-			char type = (NET_IPV6_HDR(pkt)->vtc & 0xf0);
-
-			switch (type) {
-			case 0x60:
-				ptype = htons(NET_ETH_PTYPE_IPV6);
-				break;
-			case 0x40:
-				ptype = htons(NET_ETH_PTYPE_IP);
-				break;
-			default:
-				ret = -ENOTSUP;
-				goto error;
-			}
 		} else {
 			goto send;
 		}


### PR DESCRIPTION
Setting a detected packet family (ipv4 or ipv6) in net_context level instead in lower layers for AF_PACKET/SOCK_RAW/IPPROTO_RAW type sockets when sending data.