### PR TITLE
Add API for flash write protection and readout protection functionality

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -116,6 +116,12 @@ Stable API changes in this release
 New APIs in this release
 ========================
 
+* Introduced :c:func:`flash_ex_op` function. This allows to perform extra
+  operations on flash devices, defined by Zephyr Flash API or by vendor specific
+  header files. Support for extra operations is enabled by
+  :kconfig:option:`CONFIG_FLASH_EX_OP_ENABLED` which depends on
+  :kconfig:option:`CONFIG_FLASH_HAS_EX_OP` selected by driver.
+
 Kernel
 ******
 
@@ -249,6 +255,14 @@ Drivers and Sensors
 * Ethernet
 
 * Flash
+
+  * Introduced new flash API call :c:func:`flash_ex_op` which calls
+    :c:func:`ec_op` callback provided by a flash driver. This allows to perform
+    extra operations on flash devices, defined by Zephyr Flash API or by vendor
+    specific header files. :kconfig:option:`CONFIG_FLASH_HAS_EX_OP` should be
+    selected by the driver to indicate that extra operations are supported.
+    To enable extra operations user should select
+    :kconfig:option:`CONFIG_FLASH_EX_OP_ENABLED`.
 
 * FPGA
 

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -11,6 +11,12 @@ config FLASH_HAS_DRIVER_ENABLED
 	help
 	  This option is enabled when any flash driver is enabled.
 
+config FLASH_HAS_EX_OP
+	bool
+	help
+	  This option is selected by drivers that support flash extended
+	  operations.
+
 config FLASH_HAS_PAGE_LAYOUT
 	bool
 	help
@@ -77,6 +83,14 @@ config FLASH_PAGE_LAYOUT
 	default y
 	help
 	  Enables API for retrieving the layout of flash memory pages.
+
+config FLASH_EX_OP_ENABLED
+	bool "API for extended flash operations"
+	depends on FLASH_HAS_EX_OP
+	default n
+	help
+	  Enables flash extended operations API. It can be used to perform
+	  non-standard operations e.g. manipulating flash protection.
 
 config FLASH_INIT_PRIORITY
 	int "Flash init priority"

--- a/drivers/flash/flash_handlers.c
+++ b/drivers/flash/flash_handlers.c
@@ -98,3 +98,22 @@ static inline int z_vrfy_flash_read_jedec_id(const struct device *dev,
 #include <syscalls/flash_sfdp_jedec_id.c>
 
 #endif /* CONFIG_FLASH_JESD216_API */
+
+#ifdef CONFIG_FLASH_EX_OP_ENABLED
+
+static inline int z_vrfy_flash_ex_op(const struct device *dev, uint16_t code,
+				     const uintptr_t in, void *out)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_FLASH(dev, ex_op));
+
+	/*
+	 * If the code is a vendor code, then ex_op function have to perform
+	 * verification. Zephyr codes should be verified here, but currently
+	 * there are no Zephyr extended codes yet.
+	 */
+
+	return z_impl_flash_ex_op(dev, code, in, out);
+}
+#include <syscalls/flash_ex_op_mrsh.c>
+
+#endif /* CONFIG_FLASH_EX_OP_ENABLED */


### PR DESCRIPTION
This PR extends flash API to expose flash write protection (persistent across reboots) and readout protection (temporary or permanent) functionality.

The flash API was extended by functions responsible for checking and changing WP and RDP state. Enabling RDP permanently is guarded by FLASH_ALLOW_PERMANENT_READOUT_PROTECTION option. Disabling RDP (which triggers mass erase) is guarded by FLASH_ALLOW_DISABLING_READOUT_PROTECTION.

Best regards,
Patryk
