### PR TITLE
sysbuild/west: runners: Add optional configuration for setting flashing configuration

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/flash_runner.yml
+++ b/boards/arm/nrf5340dk_nrf5340/flash_runner.yml
@@ -13,3 +13,14 @@ board_single_commands:
       nrf5340dk_nrf5340_cpuapp,
       nrf5340dk_nrf5340_cpuapp_ns,
     ]
+# Prevent resetting the cores whilst flashing multiple images until all images
+# for each core have been flashed, this allows security bits to be set during
+# programming without them interfering with additional flashing processes.
+board_delay_reset:
+  - [
+      nrf5340dk_nrf5340_cpuapp,
+      nrf5340dk_nrf5340_cpuapp_ns,
+    ]
+  - [
+      nrf5340dk_nrf5340_cpunet,
+    ]

--- a/boards/arm/nrf5340dk_nrf5340/flash_runner.yml
+++ b/boards/arm/nrf5340dk_nrf5340/flash_runner.yml
@@ -1,0 +1,9 @@
+# Recovery is only needed once per core.
+board_single_commands:
+  - --recover: [
+      nrf5340dk_nrf5340_cpunet,
+    ]
+  - --recover: [
+      nrf5340dk_nrf5340_cpuapp,
+      nrf5340dk_nrf5340_cpuapp_ns,
+    ]

--- a/boards/arm/nrf5340dk_nrf5340/flash_runner.yml
+++ b/boards/arm/nrf5340dk_nrf5340/flash_runner.yml
@@ -1,3 +1,9 @@
+# Flash network CPU before other cores as a --recover operation on the network
+# core will erase both cores.
+board_flash_priority:
+  - nrf5340dk_nrf5340_cpunet
+  - nrf5340dk_nrf5340_cpuapp
+  - nrf5340dk_nrf5340_cpuapp_ns
 # Recovery is only needed once per core.
 board_single_commands:
   - --recover: [

--- a/boards/arm/nrf9160dk_nrf9160/flash_runner.yml
+++ b/boards/arm/nrf9160dk_nrf9160/flash_runner.yml
@@ -4,3 +4,11 @@ board_single_commands:
       nrf9160dk_nrf9160,
       nrf9160dk_nrf9160_ns,
     ]
+# Prevent resetting the cores whilst flashing multiple images until all images
+# for each core have been flashed, this allows security bits to be set during
+# programming without them interfering with additional flashing processes.
+board_delay_reset:
+  - [
+      nrf9160dk_nrf9160,
+      nrf9160dk_nrf9160_ns,
+    ]

--- a/boards/arm/nrf9160dk_nrf9160/flash_runner.yml
+++ b/boards/arm/nrf9160dk_nrf9160/flash_runner.yml
@@ -1,0 +1,6 @@
+# Recovery is only needed once per core.
+board_single_commands:
+  - --recover: [
+      nrf9160dk_nrf9160,
+      nrf9160dk_nrf9160_ns,
+    ]

--- a/boards/arm/thingy53_nrf5340/flash_runner.yml
+++ b/boards/arm/thingy53_nrf5340/flash_runner.yml
@@ -1,3 +1,9 @@
+# Flash network CPU before other cores as a --recover operation on the network
+# core will erase both cores.
+board_flash_priority:
+  - thingy53_nrf5340_cpunet
+  - thingy53_nrf5340_cpuapp
+  - thingy53_nrf5340_cpuapp_ns
 # Recovery is only needed once per core.
 board_single_commands:
   - --recover: [

--- a/boards/arm/thingy53_nrf5340/flash_runner.yml
+++ b/boards/arm/thingy53_nrf5340/flash_runner.yml
@@ -1,0 +1,9 @@
+# Recovery is only needed once per core.
+board_single_commands:
+  - --recover: [
+      thingy53_nrf5340_cpunet,
+    ]
+  - --recover: [
+      thingy53_nrf5340_cpuapp,
+      thingy53_nrf5340_cpuapp_ns,
+    ]

--- a/boards/arm/thingy53_nrf5340/flash_runner.yml
+++ b/boards/arm/thingy53_nrf5340/flash_runner.yml
@@ -13,3 +13,14 @@ board_single_commands:
       thingy53_nrf5340_cpuapp,
       thingy53_nrf5340_cpuapp_ns,
     ]
+# Prevent resetting the cores whilst flashing multiple images until all images
+# for each core have been flashed, this allows security bits to be set during
+# programming without them interfering with additional flashing processes.
+board_delay_reset:
+  - [
+      thingy53_nrf5340_cpuapp,
+      thingy53_nrf5340_cpuapp_ns,
+    ]
+  - [
+      thingy53_nrf5340_cpunet,
+    ]

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -257,12 +257,41 @@ Boards & SoC Support
     Note that MCUboot and MCUboot image updates from pre-Zephyr 3.3 might be
     incompatible with Zephyr 3.3 onwards and vice versa.
 
+  * When using sysbuild with the following boards with ``west flash``, reset
+    of the board will only be performed once all images for a core have been
+    programmed, fixing an issue whereby later images might fail to be
+    programmed to a board:
+    ``nrf5340dk_nrf5340``
+    ``thingy53_nrf5340``
+    ``nrf9160dk_nrf9160``
+
+  * When using sysbuild with the following boards with ``west flash``, the
+    ``--recover`` argument will only recover the devices once per core instead
+    of once per image flashed, fixing an issue whereby the board could be
+    unbootable:
+    ``nrf5340dk_nrf5340``
+    ``thingy53_nrf5340``
+    ``nrf9160dk_nrf9160``
+
+  * When using sysbuild with the following boards with ``west flash``, the
+    images are now flashed in order of network core (if present),
+    application secure core, application non-secure core:
+    ``nrf5340dk_nrf5340``
+    ``thingy53_nrf5340``
+    ``nrf9160dk_nrf9160``
+
 * Made these changes in other boards:
 
 * Added support for these following shields:
 
 Build system and infrastructure
 *******************************
+
+* Added optional board configuration for boards using sysbuild to flash
+  multiple images to a single or many cores that allows setting the order of
+  which boards get flashed, limiting commands to be ran once per set of boards
+  and preventing reset of a set of boards until all images for those boards
+  have been flashed.
 
 Drivers and Sensors
 *******************

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2018 Open Source Foundries Limited.
+# Copyright (c) 2023 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -147,6 +148,15 @@ def do_run_common(command, user_args, user_runner_args, domains=None):
     # This is the main routine for all the "west flash", "west debug",
     # etc. commands.
 
+    # Holds a dictionary of single-use commands, this is useful for sysbuild
+    # images whereby there are multiple images per board with flash commands
+    # that can interfere with other images if they run one per time an image
+    # is flashed.
+    used_cmds = []
+
+    # Holds a list of processed board names for flash running information.
+    processed_boards = {}
+
     if user_args.context:
         dump_context(command, user_args, user_runner_args)
         return
@@ -165,15 +175,56 @@ def do_run_common(command, user_args, user_runner_args, domains=None):
             # Get the user specified domains.
             domains = load_domains(build_dir).get_domains(user_args.domain)
 
-    if len(domains) > 1 and len(user_runner_args) > 0:
-        log.wrn("Specifying runner options for multiple domains is experimental.\n"
-                "If problems are experienced, please specify a single domain "
-                "using '--domain <domain>'")
+    if len(domains) > 1:
+        if len(user_runner_args) > 0:
+            log.wrn("Specifying runner options for multiple domains is experimental.\n"
+                    "If problems are experienced, please specify a single domain "
+                    "using '--domain <domain>'")
+
+        # Process all domains to load board names and populate flash runner
+        # parameters.
+        for d in domains:
+            if d.build_dir is None:
+                build_dir = get_build_dir(user_args)
+            else:
+                build_dir = d.build_dir
+
+            cache = load_cmake_cache(build_dir, user_args)
+            board = cache['CACHED_BOARD']
+
+            # Load board flash runner configuration (if it exists) and store
+            # single-use commands in a dictionary so that they get executed
+            # once per unique board name.
+            try:
+                processed_boards[cache['BOARD_DIR']]
+            except KeyError:
+                board_runner_test_file = Path(cache['BOARD_DIR']) / 'flash_runner.yml'
+
+                try:
+                    with open(board_runner_test_file, 'r') as f:
+                        board_runner_test_yaml = yaml.safe_load(f.read())
+                    processed_boards[cache['BOARD_DIR']] = True
+
+                    # Board single commands.
+                    if len(user_runner_args) > 0:
+                        try:
+                            for c in board_runner_test_yaml['board_single_commands']:
+                                used_cmds.append(len(used_cmds))
+                                used_cmds[len(used_cmds)-1] = c
+                                used_cmds[len(used_cmds)-1]['Ran'] = False
+
+                        except KeyError:
+                            pass
+
+                except FileNotFoundError:
+                    pass
 
     for d in domains:
-        do_run_common_image(command, user_args, user_runner_args, d.build_dir)
+        do_run_common_image(command, user_args, user_runner_args, d.build_dir,
+                            used_cmds)
 
-def do_run_common_image(command, user_args, user_runner_args, build_dir=None):
+def do_run_common_image(command, user_args, user_runner_args, build_dir=None,
+                        used_cmds=None):
     command_name = command.name
     if build_dir is None:
         build_dir = get_build_dir(user_args)
@@ -200,6 +251,28 @@ def do_run_common_image(command, user_args, user_runner_args, build_dir=None):
     # If the user passed -- to force the parent argument parser to stop
     # parsing, it will show up here, and needs to be filtered out.
     runner_args = [arg for arg in user_runner_args if arg != '--']
+
+    # Check if there are any commands that should only be ran once per board
+    # and if so, remove them for all but the first iteration of the flash
+    # runner per unique board name.
+    try:
+        if len(used_cmds) > 0 and len(runner_args) > 0:
+            for a in runner_args:
+                i = 0
+                while i < len(used_cmds):
+                    try:
+                        if used_cmds[i][a] and type(used_cmds[i][a].index(board)):
+                            if used_cmds[i]['Ran'] is False:
+                                used_cmds[i]['Ran'] = True
+                            else:
+                                runner_args.pop(runner_args.index(a))
+                    except ValueError:
+                        pass
+
+                    i = i + 1
+
+    except KeyError:
+        pass
 
     # Arguments in this order to allow specific to override general:
     #

--- a/scripts/west_commands/runners/esp32.py
+++ b/scripts/west_commands/runners/esp32.py
@@ -16,13 +16,17 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for espidf.'''
 
     def __init__(self, cfg, device, boot_address, part_table_address,
-                 app_address, erase=False, baud=921600, flash_size='detect',
+                 app_address, erase=False, reset=True, baud=921600, flash_size='detect',
                  flash_freq='40m', flash_mode='dio', espidf='espidf',
                  bootloader_bin=None, partition_table_bin=None):
         super().__init__(cfg)
         self.elf = cfg.elf_file
         self.app_bin = cfg.bin_file
         self.erase = bool(erase)
+        if reset is None:
+            self.reset = True
+        else:
+            self.reset = bool(reset)
         self.device = device
         self.boot_address = boot_address
         self.part_table_address = part_table_address
@@ -41,7 +45,7 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash'}, erase=True)
+        return RunnerCaps(commands={'flash'}, erase=True, reset=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -86,9 +90,10 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
             cfg, args.esp_device, boot_address=args.esp_boot_address,
             part_table_address=args.esp_partition_table_address,
             app_address=args.esp_app_address, erase=args.erase,
-            baud=args.esp_baud_rate, flash_size=args.esp_flash_size,
-            flash_freq=args.esp_flash_freq, flash_mode=args.esp_flash_mode,
-            espidf=espidf, bootloader_bin=args.esp_flash_bootloader,
+            reset=args.reset, baud=args.esp_baud_rate,
+            flash_size=args.esp_flash_size, flash_freq=args.esp_flash_freq,
+            flash_mode=args.esp_flash_mode, espidf=espidf,
+            bootloader_bin=args.esp_flash_bootloader,
             partition_table_bin=args.esp_flash_partition_table)
 
     def do_run(self, command, **kwargs):
@@ -105,7 +110,8 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
             cmd_flash.extend(['--port', self.device])
         cmd_flash.extend(['--baud', self.baud])
         cmd_flash.extend(['--before', 'default_reset'])
-        cmd_flash.extend(['--after', 'hard_reset', 'write_flash', '-u'])
+        if self.reset is True:
+            cmd_flash.extend(['--after', 'hard_reset', 'write_flash', '-u'])
         cmd_flash.extend(['--flash_mode', self.flash_mode])
         cmd_flash.extend(['--flash_freq', self.flash_freq])
         cmd_flash.extend(['--flash_size', self.flash_size])

--- a/scripts/west_commands/runners/intel_cyclonev.py
+++ b/scripts/west_commands/runners/intel_cyclonev.py
@@ -100,7 +100,7 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'attach'},
-                          dev_id=False, flash_addr=False, erase=False)
+                          dev_id=False, flash_addr=False, erase=False, reset=False)
 
     @classmethod
     def do_add_parser(cls, parser):

--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -77,7 +77,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach'},
-                          dev_id=True, flash_addr=True, erase=True,
+                          dev_id=True, flash_addr=True, erase=True, reset=False,
                           tool_opt=True)
 
     @classmethod

--- a/scripts/west_commands/runners/spi_burn.py
+++ b/scripts/west_commands/runners/spi_burn.py
@@ -29,7 +29,7 @@ class SpiBurnBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash', 'debug'}, erase=True, flash_addr=True)
+        return RunnerCaps(commands={'flash', 'debug'}, erase=True, reset=False, flash_addr=True)
 
     @classmethod
     def do_add_parser(cls, parser):

--- a/scripts/west_commands/runners/stm32flash.py
+++ b/scripts/west_commands/runners/stm32flash.py
@@ -72,9 +72,6 @@ class Stm32flashBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--serial-mode', default='8e1', required=False,
                             help='serial port mode, default \'8e1\'')
 
-        parser.add_argument('--reset', default=False, required=False, action='store_true',
-                            help='reset device at exit, default False')
-
         parser.add_argument('--verify', default=False, required=False, action='store_true',
                             help='verify writes, default False')
 

--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2018 Foundries.io
-# Copyright (c) 2020 Nordic Semiconductor ASA
+# Copyright (c) 2020-2023 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -64,111 +64,121 @@ class TC(typing.NamedTuple):    # 'TestCase'
     # --sectorerase if False (or --sectoranduicrerase on nRF52)
     erase: bool
 
+    # --reset if True, --no-reset if False
+    reset: bool
 
 EXPECTED_RESULTS = {
 
     # -------------------------------------------------------------------------
     # NRF51
     #
-    #  family   CP    recov  soft   snr    erase
-    TC('NRF51', None, False, False, False, False):
+    #  family   CP    recov  soft   snr    erase  reset
+    TC('NRF51', None, False, False, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51', None, False, False, False, True):
+    TC('NRF51', None, False, False, False, True, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51', None, False, False, True, False):
+    TC('NRF51', None, False, False, True, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF51', None, False, True, False, False):
+    TC('NRF51', None, False, True, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51', None, True, False, False, False):
+    TC('NRF51', None, True, False, False, False, True):
     (['nrfjprog', '--recover', '-f', 'NRF51', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51', None, True, True, True, True):
+    TC('NRF51', None, True, True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF51', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF51',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF51', '--snr', TEST_OVR_SNR]),
 
+    TC('NRF51', None, False, False, False, False, False):
+    (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
+      '--snr', TEST_DEF_SNR]),
+
     # -------------------------------------------------------------------------
     # NRF52
     #
-    #  family   CP    recov  soft   snr    erase
-    TC('NRF52', None, False, False, False, False):
+    #  family   CP    recov  soft   snr    erase  reset
+    TC('NRF52', None, False, False, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52', None, False, False, False, True):
+    TC('NRF52', None, False, False, False, True, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF52',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52', None, False, False, True, False):
+    TC('NRF52', None, False, False, True, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF52', None, False, True, False, False):
+    TC('NRF52', None, False, True, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52', None, True, False, False, False):
+    TC('NRF52', None, True, False, False, False, True):
     (['nrfjprog', '--recover', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52', None, True, True, True, True):
+    TC('NRF52', None, True, True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF52', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF52',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF52', '--snr', TEST_OVR_SNR]),
 
+    TC('NRF52', None, False, False, False, False, False):
+    (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
+      '--verify', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
+
     # -------------------------------------------------------------------------
     # NRF53 APP only
     #
-    #  family   CP     recov  soft   snr    erase
+    #  family   CP     recov  soft   snr    erase  reset
 
-    TC('NRF53', 'APP', False, False, False, False):
+    TC('NRF53', 'APP', False, False, False, False, True):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_APPLICATION'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'APP', False, False, False, True):
+    TC('NRF53', 'APP', False, False, False, True, True):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--chiperase',
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_APPLICATION'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'APP', False, False, True, False):
+    TC('NRF53', 'APP', False, False, True, False, True):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR, '--coprocessor', 'CP_APPLICATION'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF53', 'APP', False, True, False, False):
+    TC('NRF53', 'APP', False, True, False, False, True):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_APPLICATION'],
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'APP', True, False, False, False):
+    TC('NRF53', 'APP', True, False, False, False, True):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_DEF_SNR],
@@ -176,7 +186,7 @@ EXPECTED_RESULTS = {
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_APPLICATION'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'APP', True, True, True, True):
+    TC('NRF53', 'APP', True, True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR],
@@ -184,32 +194,36 @@ EXPECTED_RESULTS = {
       '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR, '--coprocessor', 'CP_APPLICATION'],
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
+    TC('NRF53', 'APP', False, False, False, False, False):
+    (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
+      '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_APPLICATION']),
+
     # -------------------------------------------------------------------------
     # NRF53 NET only
     #
-    #  family   CP     recov  soft   snr    erase
+    #  family   CP     recov  soft   snr    erase  reset
 
-    TC('NRF53', 'NET', False, False, False, False):
+    TC('NRF53', 'NET', False, False, False, False, True):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_NETWORK'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'NET', False, False, False, True):
+    TC('NRF53', 'NET', False, False, False, True, True):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--chiperase',
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_NETWORK'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'NET', False, False, True, False):
+    TC('NRF53', 'NET', False, False, True, False, True):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR, '--coprocessor', 'CP_NETWORK'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF53', 'NET', False, True, False, False):
+    TC('NRF53', 'NET', False, True, False, False, True):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_NETWORK'],
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'NET', True, False, False, False):
+    TC('NRF53', 'NET', True, False, False, False, True):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_DEF_SNR],
@@ -217,7 +231,7 @@ EXPECTED_RESULTS = {
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_NETWORK'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'NET', True, True, True, True):
+    TC('NRF53', 'NET', True, True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR],
@@ -225,12 +239,16 @@ EXPECTED_RESULTS = {
       '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR, '--coprocessor', 'CP_NETWORK'],
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
+    TC('NRF53', 'NET', False, False, False, False, False):
+    (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
+      '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_NETWORK']),
+
     # -------------------------------------------------------------------------
     # NRF53 APP+NET
     #
-    #  family   CP     recov  soft   snr    erase
+    #  family    CP        recov  soft   snr    erase  reset
 
-    TC('NRF53', 'APP+NET', False, False, False, False):
+    TC('NRF53', 'APP+NET', False, False, False, False, True):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
@@ -244,7 +262,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION'],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53', 'APP+NET', False, False, False, True):
+    TC('NRF53', 'APP+NET', False, False, False, True, True):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
@@ -258,7 +276,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION'],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53', 'APP+NET', False, False, True, False):
+    TC('NRF53', 'APP+NET', False, False, True, False, True):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
@@ -272,7 +290,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION'],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_OVR_SNR])),
 
-    TC('NRF53', 'APP+NET', False, True, False, False):
+    TC('NRF53', 'APP+NET', False, True, False, False, True):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
@@ -286,7 +304,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION'],
          ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53', 'APP+NET', True, False, False, False):
+    TC('NRF53', 'APP+NET', True, False, False, False, True):
     (lambda tmpdir, infile: \
         (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
           '--snr', TEST_DEF_SNR],
@@ -303,7 +321,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION'],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53', 'APP+NET', True, True, True, True):
+    TC('NRF53', 'APP+NET', True, True, True, True, True):
     (lambda tmpdir, infile: \
         (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
           '--snr', TEST_OVR_SNR],
@@ -320,41 +338,58 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION'],
          ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR])),
 
+    TC('NRF53', 'APP+NET', False, False, False, False, False):
+    (lambda tmpdir, infile: \
+        (['nrfjprog',
+          '--program',
+          os.fspath(tmpdir / 'GENERATED_CP_NETWORK_' + Path(infile).name),
+          '--sectorerase', '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR,
+          '--coprocessor', 'CP_NETWORK'],
+         ['nrfjprog',
+          '--program',
+          os.fspath(tmpdir / 'GENERATED_CP_APPLICATION_' + Path(infile).name),
+          '--sectorerase', '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR,
+          '--coprocessor', 'CP_APPLICATION'])),
+
     # -------------------------------------------------------------------------
     # NRF91
     #
-    #  family   CP    recov  soft   snr    erase
-    TC('NRF91', None, False, False, False, False):
+    #  family   CP    recov  soft   snr    erase  reset
+    TC('NRF91', None, False, False, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91', None, False, False, False, True):
+    TC('NRF91', None, False, False, False, True, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91', None, False, False, True, False):
+    TC('NRF91', None, False, False, True, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF91', None, False, True, False, False):
+    TC('NRF91', None, False, True, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91', None, True, False, False, False):
+    TC('NRF91', None, True, False, False, False, True):
     (['nrfjprog', '--recover', '-f', 'NRF91', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91', None, True, True, True, True):
+    TC('NRF91', None, True, True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF91', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF91',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF91', '--snr', TEST_OVR_SNR]),
+
+    TC('NRF91', None, False, False, False, False, False):
+    (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
+      '--snr', TEST_DEF_SNR]),
 }
 
 #
@@ -389,8 +424,9 @@ def id_fn(test_case):
     sn = 'default snr' if test_case.snr else 'override snr'
     e = 'chip erase' if test_case.erase else 'sector[anduicr] erase'
     r = 'recover' if test_case.recover else 'no recover'
+    rst = 'reset' if test_case.reset else 'no reset'
 
-    return f'{test_case.family}{cp}, {s}, {sn}, {e}, {r}'
+    return f'{test_case.family}{cp}, {s}, {sn}, {e}, {r}, {rst}'
 
 def fix_up_runner_config(test_case, runner_config, tmpdir):
     # Helper that adjusts the common runner_config fixture for our
@@ -442,6 +478,7 @@ def test_nrfjprog_init(check_call, get_snr, require, test_case,
                                   test_case.softreset,
                                   snr,
                                   erase=test_case.erase,
+                                  reset=test_case.reset,
                                   recover=test_case.recover)
 
     with patch('os.path.isfile', side_effect=os_path_isfile_patch):
@@ -452,7 +489,10 @@ def test_nrfjprog_init(check_call, get_snr, require, test_case,
         assert (check_call.call_args_list ==
                 [call(x) for x in expected(tmpdir, runner_config.hex_file)])
     else:
-        assert check_call.call_args_list == [call(x) for x in expected]
+        if test_case.reset:
+            assert check_call.call_args_list == [call(x) for x in expected]
+        else:
+            assert check_call.call_args_list == [call(expected)]
 
     if snr is None:
         get_snr.assert_called_once_with('*')
@@ -476,6 +516,10 @@ def test_nrfjprog_create(check_call, get_snr, require, test_case,
         args.extend(['--dev-id', TEST_OVR_SNR])
     if test_case.erase:
         args.append('--erase')
+    if test_case.reset:
+        args.append('--reset')
+    else:
+        args.append('--no-reset')
     if test_case.recover:
         args.append('--recover')
 
@@ -491,7 +535,10 @@ def test_nrfjprog_create(check_call, get_snr, require, test_case,
         assert (check_call.call_args_list ==
                 [call(x) for x in expected(tmpdir, runner_config.hex_file)])
     else:
-        assert check_call.call_args_list == [call(x) for x in expected]
+        if test_case.reset:
+            assert check_call.call_args_list == [call(x) for x in expected]
+        else:
+            assert check_call.call_args_list == [call(expected)]
 
     if not test_case.snr:
         get_snr.assert_called_once_with('*')

--- a/scripts/west_commands/tests/test_stm32cubeprogrammer.py
+++ b/scripts/west_commands/tests/test_stm32cubeprogrammer.py
@@ -384,7 +384,7 @@ def test_stm32cubeprogrammer_create(
     if tc["frequency"]:
         args.extend(["--frequency", tc["frequency"]])
     if tc["reset_mode"]:
-        args.extend(["--reset", tc["reset_mode"]])
+        args.extend(["--reset-mode", tc["reset_mode"]])
     if tc["conn_modifiers"]:
         args.extend(["--conn-modifiers", tc["conn_modifiers"]])
     if tc["cli"]:


### PR DESCRIPTION
This set of commits adds optional configuration option to boards when flashing sysbuild-enabled images to allow for:

- Setting board priorities, which boards should be flashed before others
- Preventing reset after flashing each image and resetting only once all images have been flashed
- Preventing commands specified on the command line to `west flash` running for each image flash stage

These features are opt-in and disabled by default, configurations are added for nrf5340dk_nrf5340, thingy53_nrf5340 and nrf9160dk_nrf9160 boards which addresses some possible issues with flashing multiple images on these boards. The main issues that this resolves are:

- Security being enabled by an image, if one of the images enables security on the micro e.g. mcuboot, then without this, later images would fail to flash
- Running "west flash --recover" recovering the flash each time an image is flash, wrongly erasing the flash contents from the previous image flash invocations
- nRF5340 recovery for the network core recovering both application and network cores, whilst recovery for the application core only impacting the application core

Also fixes #53487 by fixing the wrong argument name used by the stm32cubeprogrammer west flash test script