### PR TITLE
drivers: can: add RX overrun counter statistic

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -772,6 +772,7 @@ static FLEXCAN_CALLBACK(mcux_flexcan_transfer_callback)
 		mcux_flexcan_transfer_tx_idle(data->dev, mb);
 		break;
 	case kStatus_FLEXCAN_RxOverflow:
+		CAN_STATS_RX_OVERRUN_INC(data->dev);
 		__fallthrough;
 	case kStatus_Fail:
 		/* If reading an RX MB failed mark it as idle to be reprocessed. */

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -731,8 +731,6 @@ static inline void mcux_flexcan_transfer_rx_idle(const struct device *dev,
 		function(dev, &frame, arg);
 
 		/* Setup RX message buffer to receive next message */
-		FLEXCAN_SetRxMbConfig(config->base, mb,
-				      &data->rx_cbs[alloc].mb_config, true);
 		xfer.frame = &data->rx_cbs[alloc].frame;
 		xfer.mbIdx = mb;
 		status = FLEXCAN_TransferReceiveNonBlocking(config->base,
@@ -774,6 +772,9 @@ static FLEXCAN_CALLBACK(mcux_flexcan_transfer_callback)
 		mcux_flexcan_transfer_tx_idle(data->dev, mb);
 		break;
 	case kStatus_FLEXCAN_RxOverflow:
+		__fallthrough;
+	case kStatus_Fail:
+		/* If reading an RX MB failed mark it as idle to be reprocessed. */
 		__fallthrough;
 	case kStatus_FLEXCAN_RxIdle:
 		mcux_flexcan_transfer_rx_idle(data->dev, mb);

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -346,6 +346,7 @@ static void can_rcar_error(const struct device *dev)
 	}
 	if (eifr & RCAR_CAN_EIFR_ORIF) {
 		LOG_DBG("Receive overrun error interrupt\n");
+		CAN_STATS_RX_OVERRUN_INC(dev);
 		sys_write8((uint8_t)~RCAR_CAN_EIFR_ORIF,
 			   config->reg_addr + RCAR_CAN_EIFR);
 	}

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -127,6 +127,7 @@ static inline void can_stm32_rx_isr_handler(const struct device *dev)
 
 	if (can->RF0R & CAN_RF0R_FOVR0) {
 		LOG_ERR("RX FIFO Overflow");
+		CAN_STATS_RX_OVERRUN_INC(dev);
 	}
 }
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -461,6 +461,7 @@ STATS_SECT_ENTRY32(stuff_error)
 STATS_SECT_ENTRY32(crc_error)
 STATS_SECT_ENTRY32(form_error)
 STATS_SECT_ENTRY32(ack_error)
+STATS_SECT_ENTRY32(rx_overrun)
 STATS_SECT_END;
 
 STATS_NAME_START(can)
@@ -470,6 +471,7 @@ STATS_NAME(can, stuff_error)
 STATS_NAME(can, crc_error)
 STATS_NAME(can, form_error)
 STATS_NAME(can, ack_error)
+STATS_NAME(can, rx_overrun)
 STATS_NAME_END(can);
 
 /** @endcond */
@@ -559,6 +561,18 @@ struct can_device_state {
 #define CAN_STATS_ACK_ERROR_INC(dev_)			\
 	STATS_INC(Z_CAN_GET_STATS(dev_), ack_error)
 
+/**
+ * @brief Increment the RX overrun counter for a CAN device
+ *
+ * The RX overrun counter is incremented when the CAN controller receives a CAN
+ * frame matching an installed filter but lacks the capacity to store it (either
+ * due to an already full RX mailbox or a full RX FIFO).
+ *
+ * @param dev_ Pointer to the device structure for the driver instance.
+ */
+#define CAN_STATS_RX_OVERRUN_INC(dev_)			\
+	STATS_INC(Z_CAN_GET_STATS(dev_), rx_overrun)
+
 /** @cond INTERNAL_HIDDEN */
 
 /**
@@ -579,7 +593,7 @@ struct can_device_state {
 	{								\
 		struct can_device_state *state =			\
 			CONTAINER_OF(dev->state, struct can_device_state, devstate); \
-		stats_init(&state->stats.s_hdr, STATS_SIZE_32, 6,	\
+		stats_init(&state->stats.s_hdr, STATS_SIZE_32, 7,	\
 			   STATS_NAME_INIT_PARMS(can));			\
 		stats_register(dev->name, &(state->stats.s_hdr));	\
 		return init_fn(dev);					\
@@ -626,6 +640,7 @@ struct can_device_state {
 #define CAN_STATS_CRC_ERROR_INC(dev_)
 #define CAN_STATS_FORM_ERROR_INC(dev_)
 #define CAN_STATS_ACK_ERROR_INC(dev_)
+#define CAN_STATS_RX_OVERRUN_INC(dev_)
 
 #define CAN_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
 			     prio, api, ...)				\


### PR DESCRIPTION
The RX overrun counter is incremented when the CAN controller receives a CAN frame matching an installed filter but lacks the capacity to store it (either due to an already full RX mailbox or a full RX FIFO).

Implementing support for this new statistic required a few changes/fixes to the NXP FlexCAN driver, which are included here as well. The fixes could be split to a separate PR, but they are only really needed for correctly counting the RX overruns.