### PR TITLE
doc: develop: api: overview: mark the CAN controller driver API stable

### DIFF
--- a/doc/develop/api/overview.rst
+++ b/doc/develop/api/overview.rst
@@ -42,7 +42,7 @@ between major releases are available in the :ref:`zephyr_release_notes`.
      - 1.10
 
    * - :ref:`can_api`
-     - Unstable
+     - Stable
      - 1.14
 
    * - :ref:`counter_api`


### PR DESCRIPTION
Mark the CAN controller driver API as stable.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/36724

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>