### PR TITLE
tests: drivers: uart: Add GPIO dependency to tests

### DIFF
--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -10,12 +10,14 @@ tests:
     harness: ztest
     harness_config:
       fixture: gpio_loopback
+    depends_on: gpio
   drivers.uart.async_api.nrf_uart:
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC
     harness: ztest
     platform_allow: nrf52840dk_nrf52840
     harness_config:
       fixture: gpio_loopback
+    depends_on: gpio
     extra_args: DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840.overlay;boards/nrf_uart.overlay"
   drivers.uart.async_api.rtt:
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_HAS_SEGGER_RTT and not CONFIG_UART_MCUX_LPUART

--- a/tests/drivers/uart/uart_pm/testcase.yaml
+++ b/tests/drivers/uart/uart_pm/testcase.yaml
@@ -4,6 +4,7 @@ common:
   platform_allow: nrf52840dk_nrf52840
   harness_config:
     fixture: gpio_loopback
+  depends_on: gpio
 tests:
   drivers.uart.pm:
     extra_configs:


### PR DESCRIPTION
Add gpio dependency to the tests, which require fixture `gpio_loopback`.

Signed-off-by: Katarzyna Giądła <katarzyna.giadla@nordicsemi.no>