### PR TITLE
twister: bugfix: Make elf scan more precise.

### DIFF
--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -253,9 +253,9 @@ class TestInstance:
     def get_elf_file(self) -> str:
         fns = glob.glob(os.path.join(self.build_dir, "zephyr", "*.elf"))
         fns.extend(glob.glob(os.path.join(self.build_dir, "zephyr", "*.exe")))
-        fns = [x for x in fns if '_pre' not in x]
+        fns = [x for x in fns if '_pre' not in os.path.split(x)[-1]]
         # EFI elf files
-        fns = [x for x in fns if 'zefi' not in x]
+        fns = [x for x in fns if 'zefi' not in os.path.split(x)[-1]]
         if len(fns) != 1:
             raise BuildError("Missing/multiple output ELF binary")
         return fns[0]


### PR DESCRIPTION
When scanning for available elfs, twister discards ones with `_pre` in their name, to not include prebuilds like 'zephyr_pre0.elf`. However, the scan looks at the whole test name. If _pre is in the name (e.g. _precision) it would be wrongly discarded ending with twister reporting error that no elfs were found. This commit makes the discard to look only at the last part of the name (i.e. not including test name but only a lowest level, where zephyr.elf etc are located.)

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>