### PR TITLE
yamllint: key-duplicates fixes

### DIFF
--- a/dts/bindings/pinctrl/atmel,sam0-pinctrl.yaml
+++ b/dts/bindings/pinctrl/atmel,sam0-pinctrl.yaml
@@ -78,10 +78,6 @@ compatible: "atmel,sam0-pinctrl"
 include: base.yaml
 
 properties:
-    reg:
-      required: true
-
-properties:
     "#address-cells":
       required: true
       const: 1

--- a/dts/bindings/spi/st,stm32-spi-subghz.yaml
+++ b/dts/bindings/spi/st,stm32-spi-subghz.yaml
@@ -6,8 +6,6 @@ description: STM32 SUBGHZ SPI controller
 compatible: "st,stm32-spi-subghz"
 
 include:
-
-include:
   - name: st,stm32-spi-common.yaml
     property-blocklist:
       - pinctrl-0

--- a/samples/sensor/esp32_temp_sensor/sample.yaml
+++ b/samples/sensor/esp32_temp_sensor/sample.yaml
@@ -3,8 +3,7 @@ sample:
   name: esp32_temp_sensor
 tests:
   sample.sensor.esp32_temp_sensor:
-    tags: sensors
-    tags: tests
+    tags: sensors tests
     filter: dt_compat_enabled("espressif,esp32-temp")
     harness: console
     harness_config:

--- a/samples/sensor/stm32_temp_sensor/sample.yaml
+++ b/samples/sensor/stm32_temp_sensor/sample.yaml
@@ -4,8 +4,7 @@ sample:
 tests:
   sample.sensor.stm32_temp_sensor:
     depends_on: adc
-    tags: sensors
-    tags: tests
+    tags: sensors tests
     filter: dt_compat_enabled("st,stm32-temp-cal") or dt_compat_enabled("st,stm32-temp")
     harness: console
     harness_config:

--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -31,7 +31,7 @@ tests:
     platform_allow: nrf52840dk_nrf52840 pinnacle_100_dvk mg100
     integration_platforms:
       - nrf52840dk_nrf52840
-  sample.mcumgr.smp_svr.serial:
+  sample.mcumgr.smp_svr.serial-console:
     extra_args: OVERLAY_CONFIG="overlay-serial-console.conf"
     platform_allow: nrf52840dk_nrf52840 pinnacle_100_dvk mg100
     integration_platforms:

--- a/tests/drivers/build_all/pwm/testcase.yaml
+++ b/tests/drivers/build_all/pwm/testcase.yaml
@@ -19,7 +19,7 @@ tests:
     tags: pwm_mcux_pwt
     extra_configs:
       - CONFIG_PWM_CAPTURE=y
-  drivers.pwm.mcux.ftm.build:
+  drivers.pwm.mcux.tpm.build:
     platform_allow: frdm_kw41z
     tags: pwm_mcux_tpm
   drivers.pwm.mcux.build:

--- a/tests/lib/cbprintf_package/testcase.yaml
+++ b/tests/lib/cbprintf_package/testcase.yaml
@@ -125,8 +125,7 @@ tests:
       - CONFIG_PICOLIBC=y
 
   libraries.cbprintf_package_fp.picolibc:
-    filter: CONFIG_CPU_HAS_FPU
-    filter: CONFIG_PICOLIBC_SUPPORTED
+    filter: CONFIG_CPU_HAS_FPU and CONFIG_PICOLIBC_SUPPORTED
     tags: picolibc
     extra_configs:
       - CONFIG_CBPRINTF_FP_SUPPORT=y
@@ -153,8 +152,7 @@ tests:
       - CONFIG_PICOLIBC=y
 
   libraries.cbprintf_package_fp_cpp.picolibc:
-    filter: CONFIG_CPU_HAS_FPU
-    filter: CONFIG_PICOLIBC_SUPPORTED
+    filter: CONFIG_CPU_HAS_FPU and CONFIG_PICOLIBC_SUPPORTED
     tags: picolibc
     extra_configs:
       - CONFIG_CPLUSPLUS=y

--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -54,15 +54,6 @@ tests:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_OVERRIDE_LEVEL=4
 
-  logging.log_api_deferred_override_level_rt_filtering:
-    # Testing on selected platforms as it enables all logs in the application
-    # and it cannot be handled on many platforms.
-    platform_allow: qemu_cortex_m3 qemu_cortex_a9 native_posix
-    extra_configs:
-      - CONFIG_LOG_MODE_DEFERRED=y
-      - CONFIG_LOG_RUNTIME_FILTERING=y
-      - CONFIG_LOG_OVERRIDE_LEVEL=4
-
   logging.log_api_immediate:
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y


### PR DESCRIPTION
Fix few yamllint duplicate keys warnings, these are probably going to enable some extra tests.