### PR TITLE
gen_defines.py HACK: add new DT_REG_ADDR_U() _unsigned_ integer

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -57,6 +57,11 @@
 	sram0: memory@a0020000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
+
+/* Without DT_REG_ADDR_U(), sparse warning: 'decimal constant 2684485632
+   is between LONG_MAX and ULONG_MAX. For C99 that means long long, C90
+   compilers are very likely to produce unsigned long (and a warning)
+   here' */
 		reg = <0xa0020000 DT_SIZE_K(2816)>;
 	};
 

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2061,6 +2061,8 @@
  */
 #define DT_REG_ADDR_BY_IDX(node_id, idx) \
 	DT_CAT4(node_id, _REG_IDX_, idx, _VAL_ADDRESS)
+#define DT_REG_ADDR_BY_IDX_U(node_id, idx) \
+	DT_CAT4(node_id, _REG_IDX_, idx, _VAL_ADDRESS_U)
 
 /**
  * @brief Get the size of the register block at index @p idx
@@ -2084,6 +2086,7 @@
  * @return node's register block address
  */
 #define DT_REG_ADDR(node_id) DT_REG_ADDR_BY_IDX(node_id, 0)
+#define DT_REG_ADDR_U(node_id) DT_REG_ADDR_BY_IDX_U(node_id, 0)
 
 /**
  * @brief Get a node's (only) register block size

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -420,6 +420,11 @@ def write_regs(node):
             idx_macro = f"{path_id}_REG_IDX_{i}_VAL_ADDRESS"
             idx_vals.append((idx_macro,
                              f"{reg.addr} /* {hex(reg.addr)} */"))
+            # unsigned HACK / demo; NOT A FIX.
+            # linker scripts don't like the 'u' suffix at all
+            idx_vals.append((idx_macro + "_U",
+                             f"{reg.addr}u /* {hex(reg.addr)} */"))
+
             if reg.name:
                 name_macro = f"{path_id}_REG_NAME_{reg.name}_VAL_ADDRESS"
                 name_vals.append((name_macro, f"DT_{idx_macro}"))


### PR DESCRIPTION
[ Please consider this hack as a bug report. In my experience, an ugly
  hack that makes a problem "go away" provides more information in much fewer
  lines than a long and detailed issue, "code speaks louder than words" ]

Switching `sof/src/platform/meteorlake/include/platform/lib/memory.h` to this new DT_REG_ADDR_U() unsigned macro silences about 1200 warnings like these:

```
/zep_workspace/sof/zephyr/../src/platform/intel/ace/include/ace/lib/mailbox.h:83:57:
warning: decimal constant 2684485632 is between LONG_MAX and
ULONG_MAX. For C99 that means long long, C90 compilers are very likely
to produce unsigned long (and a warning) here
/zep_workspace/sof/zephyr/../src/platform/intel/ace/include/ace/lib/mailbox.h:87:72:
warning: decimal constant 2684485632 is between LONG_MAX and
ULONG_MAX. For C99 that means long long, C90 compilers are very likely
to produce unsigned long (and a warning) here
```

Example of warnings:
 https://github.com/thesofproject/sof/actions/runs/3831594561/jobs/6520904053

About 1200 warnings because this is located in a .h file included almost everywhere.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>