### PR TITLE
pm: pm_device_runtime_enable/disable should return 0 when PM is disabled

### DIFF
--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -148,13 +148,13 @@ bool pm_device_runtime_is_enabled(const struct device *dev);
 static inline int pm_device_runtime_enable(const struct device *dev)
 {
 	ARG_UNUSED(dev);
-	return -ENOSYS;
+	return 0;
 }
 
 static inline int pm_device_runtime_disable(const struct device *dev)
 {
 	ARG_UNUSED(dev);
-	return -ENOSYS;
+	return 0;
 }
 
 static inline int pm_device_runtime_get(const struct device *dev)


### PR DESCRIPTION
When PM is disabled, it does not make sense to return ENOSYS,
pm_device_runtime_enable/disable should be treated as noop functions.
When PM is disabled, those functions are not supposed to be implemented.


Signed-off-by: Anas Nashif <anas.nashif@intel.com>
