### PR TITLE
dts: flash: em_starterkit: Add spi flash support

### DIFF
--- a/boards/arc/em_starterkit/doc/index.rst
+++ b/boards/arc/em_starterkit/doc/index.rst
@@ -114,6 +114,9 @@ be found on which architectures:
 The board has 3 (debounced and interrupting) buttons for use with GPIO, 4 dip
 switches, 9 LEDs, SDCard on SPI, and a 16MB SPI-Flash memory.
 
+The SPI-FLASH driver is supported with sample, which can be found in
+``samples/drivers/spi_flash``.
+
 The SPI-Flash also holds 3 (or 4) separate FPGA CPU bit files, selectable via
 dip switch.
 

--- a/boards/arc/em_starterkit/em_starterkit.dts
+++ b/boards/arc/em_starterkit/em_starterkit.dts
@@ -19,6 +19,7 @@
 		uart-0 = &uart0;
 		uart-1 = &uart1;
 		uart-2 = &uart2;
+		spi-flash0 = &w25q128bv;
 	};
 
 	chosen {

--- a/boards/arc/em_starterkit/em_starterkit_em11d.dts
+++ b/boards/arc/em_starterkit/em_starterkit_em11d.dts
@@ -19,6 +19,7 @@
 		uart-0 = &uart0;
 		uart-1 = &uart1;
 		uart-2 = &uart2;
+		spi-flash0 = &w25q128bv;
 	};
 
 	chosen {

--- a/boards/arc/em_starterkit/em_starterkit_em7d.dts
+++ b/boards/arc/em_starterkit/em_starterkit_em7d.dts
@@ -19,6 +19,7 @@
 		uart-0 = &uart0;
 		uart-1 = &uart1;
 		uart-2 = &uart2;
+		spi-flash0 = &w25q128bv;
 	};
 
 	chosen {

--- a/boards/arc/em_starterkit/em_starterkit_r23.dtsi
+++ b/boards/arc/em_starterkit/em_starterkit_r23.dtsi
@@ -52,6 +52,14 @@
 					   <&creg_gpio 3 GPIO_ACTIVE_HIGH>,
 					   <&creg_gpio 4 GPIO_ACTIVE_HIGH>,
 					   <&creg_gpio 5 GPIO_ACTIVE_HIGH>;
+			w25q128bv: w25q128bv@0 {
+				compatible ="jedec,spi-nor";
+				size = <0x8000000>;
+				reg = <0>;
+				spi-max-frequency = <20000000>;
+				status = "okay";
+				jedec-id = [ef 40 18];
+			};
 		};
 
 		spi@f0007000 {


### PR DESCRIPTION
Add spi flash support for em_starterkit.

This PR is based on #53249 

Signed-off-by: Siyuan Cheng <siyuanc@synopsys.com>