### PR TITLE
sample: driver: spi_flash: Add em_starterkit support

### DIFF
--- a/samples/drivers/spi_flash/boards/em_starterkit.conf
+++ b/samples/drivers/spi_flash/boards/em_starterkit.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2023 Synopsys.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SPI_NOR=y

--- a/samples/drivers/spi_flash/boards/em_starterkit.overlay
+++ b/samples/drivers/spi_flash/boards/em_starterkit.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2023 Synopsys.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi0 {
+	cs-gpios = <&creg_gpio 5 GPIO_ACTIVE_HIGH>;
+};


### PR DESCRIPTION
Add em_starterkit support in spi_flash driver sample.

em_starterkit spi_flash dts suuport: #53472 

Signed-off-by: Siyuan Cheng <siyuanc@synopsys.com>