### PR TITLE
drivers: regulator: shell: fix isdigit() usage

### DIFF
--- a/drivers/regulator/regulator_shell.c
+++ b/drivers/regulator/regulator_shell.c
@@ -35,7 +35,7 @@ static int strtomicro(char *inp, char units, int32_t *val)
 	} else if ((len > 2) && (inp[len - 2] == 'm')) {
 		mult = 1000;
 		end = len - 3;
-	} else if (isdigit(inp[len - 2]) > 0) {
+	} else if (isdigit((unsigned char)inp[len - 2]) > 0) {
 		mult = 1000000;
 		end = len - 2;
 	} else {
@@ -55,7 +55,7 @@ static int strtomicro(char *inp, char units, int32_t *val)
 	/* numeric part */
 	*val = 0;
 	for (size_t i = start; i <= end; i++) {
-		if (isdigit(inp[i]) > 0) {
+		if (isdigit((unsigned char)inp[i]) > 0) {
 			*val = *val * 10 / decdiv +
 			       (int32_t)(inp[i] - '0') * mult / decdiv;
 		} else if (inp[i] == '.') {


### PR DESCRIPTION
ISO/IEC 9899:1999 (C Standard), §7.4 Character handling <ctype.h>:

In all cases the argument is an int, the value of which shall be representable as an unsigned char or shall equal the value of the macro EOF. If the argument has any other value, the behavior is undefined.

So add a cast to unsigned char to make sure we do not trigger UB.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>