### PR TITLE
Bluetooth: Fix deadlock on meta data context allocation

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -158,6 +158,14 @@ K_FIFO_DEFINE(free_att_tx_meta_data);
 
 static struct bt_att_tx_meta_data *tx_meta_data_alloc(k_timeout_t timeout)
 {
+	/* The meta data always get freed in the system workqueue,
+	 * so if we're in the same workqueue but there are no immediate
+	 * contexts available, there's no chance we'll get one by waiting.
+	 */
+	if (k_current_get() == &k_sys_work_q.thread) {
+		return k_fifo_get(&free_att_tx_meta_data, K_NO_WAIT);
+	}
+
 	return k_fifo_get(&free_att_tx_meta_data, timeout);
 }
 


### PR DESCRIPTION
This fixes deadlock that happened waiting for meta data in system
workqueue.
The meta data always get freed in the system workqueue,
so if we're in the same workqueue but there are no immediate
contexts available, there's no chance we'll get one by waiting.

Fixes: #53455
Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>