### PR TITLE
manifest: Update TF-M to use upstream patch for MBedTLS build warnings

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -234,7 +234,7 @@ manifest:
       groups:
         - debug
     - name: trusted-firmware-m
-      revision: 887798f6e67203e6a77059a86edf41bb136a3c0b
+      revision: 13abde213930ffdf600cf8f01113da8a5fdd9d9c
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Update TF-M version which remove the downstream patch and replaces it with the upstream TF-M patch for masking MBedTLS build warning of unused const variable.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>