### PR TITLE
stm32 DMA driver has macro to help channel configuration

### DIFF
--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32f0_1_3_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <freq.h>

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32f0_1_3_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <freq.h>

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32f2_4_7_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <freq.h>

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32f0_1_3_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <freq.h>

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32f2_4_7_reset.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32f2_4_7_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/reset/stm32g0_reset.h>

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32g4_l4_5_reset.h>
 #include <freq.h>
 

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32h7_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32l0_reset.h>
 #include <freq.h>
 

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32l1_reset.h>
 #include <freq.h>
 

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32g4_l4_5_reset.h>
 #include <freq.h>
 

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32g4_l4_5_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32mp1_reset.h>
 #include <zephyr/dt-bindings/display/stm32_ltdc.h>
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
 #include <zephyr/dt-bindings/reset/stm32u5_reset.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32wb_l_reset.h>
 #include <freq.h>
 

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32wb_l_reset.h>
 #include <freq.h>
 

--- a/include/zephyr/dt-bindings/dma/stm32_dma.h
+++ b/include/zephyr/dt-bindings/dma/stm32_dma.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_STM32_DMA_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_STM32_DMA_H_
+
+/**
+ * @name custom DMA flags for channel configuration
+ * @{
+ */
+/** DMA  cyclic mode config on bit 5*/
+#define STM32_DMA_CH_CFG_MODE(val)		((val & 0x1) << 5)
+#define STM32_DMA_MODE_NORMAL			STM32_DMA_CH_CFG_MODE(0)
+#define STM32_DMA_MODE_CYCLIC			STM32_DMA_CH_CFG_MODE(1)
+
+/** DMA  transfer direction config on bits 6-7 */
+#define STM32_DMA_CH_CFG_DIRECTION(val)		((val & 0x3) << 6)
+#define STM32_DMA_MEMORY_TO_MEMORY		STM32_DMA_CH_CFG_DIRECTION(0)
+#define STM32_DMA_MEMORY_TO_PERIPH		STM32_DMA_CH_CFG_DIRECTION(1)
+#define STM32_DMA_PERIPH_TO_MEMORY		STM32_DMA_CH_CFG_DIRECTION(2)
+#define STM32_DMA_PERIPH_TO_PERIPH		STM32_DMA_CH_CFG_DIRECTION(3)
+
+/** DMA  Peripheral increment Address config on bit 9 */
+#define STM32_DMA_CH_CFG_PERIPH_ADDR_INC(val)	((val & 0x1) << 9)
+#define STM32_DMA_PERIPH_NO_INC			STM32_DMA_CH_CFG_PERIPH_ADDR_INC(0)
+#define STM32_DMA_PERIPH_INC			STM32_DMA_CH_CFG_PERIPH_ADDR_INC(1)
+
+/** DMA  Memory increment Address config on bit 10 */
+#define STM32_DMA_CH_CFG_MEM_ADDR_INC(val)	((val & 0x1) << 10)
+#define STM32_DMA_MEM_NO_INC			STM32_DMA_CH_CFG_MEM_ADDR_INC(0)
+#define STM32_DMA_MEM_INC			STM32_DMA_CH_CFG_MEM_ADDR_INC(1)
+
+/** DMA  Peripheral data size config on bits 11, 12 */
+#define STM32_DMA_CH_CFG_PERIPH_WIDTH(val)	((val & 0x3) << 11)
+#define STM32_DMA_PERIPH_8BITS			STM32_DMA_CH_CFG_PERIPH_WIDTH(0)
+#define STM32_DMA_PERIPH_16BITS			STM32_DMA_CH_CFG_PERIPH_WIDTH(1)
+#define STM32_DMA_PERIPH_32BITS			STM32_DMA_CH_CFG_PERIPH_WIDTH(2)
+
+/** DMA  Memory data size config on bits 13, 14 */
+#define STM32_DMA_CH_CFG_MEM_WIDTH(val)		((val & 0x3) << 13)
+#define STM32_DMA_MEM_8BITS			STM32_DMA_CH_CFG_MEM_WIDTH(0)
+#define STM32_DMA_MEM_16BITS			STM32_DMA_CH_CFG_MEM_WIDTH(1)
+#define STM32_DMA_MEM_32BITS			STM32_DMA_CH_CFG_MEM_WIDTH(2)
+
+/** DMA  Peripheral increment offset config on bit 15 */
+#define STM32_DMA_CH_CFG_PERIPH_INC_FIXED(val)	((val & 0x1) << 15)
+
+/** DMA  Priority config  on bits 16, 17*/
+#define STM32_DMA_CH_CFG_PRIORITY(val)		((val & 0x3) << 16)
+#define STM32_DMA_PRIORITY_LOW			STM32_DMA_CH_CFG_PRIORITY(0)
+#define STM32_DMA_PRIORITY_MEDIUM		STM32_DMA_CH_CFG_PRIORITY(1)
+#define STM32_DMA_PRIORITY_HIGH			STM32_DMA_CH_CFG_PRIORITY(2)
+#define STM32_DMA_PRIORITY_VERY_HIGH		STM32_DMA_CH_CFG_PRIORITY(3)
+
+/** DMA  FIFO threshold feature */
+#define STM32_DMA_FIFO_1_4			0U
+#define STM32_DMA_FIFO_HALF			1U
+#define STM32_DMA_FIFO_3_4			2U
+#define STM32_DMA_FIFO_FULL			3U
+
+/* DMA  usual combination for peripheral transfer */
+#define STM32_DMA_PERIPH_TX	(STM32_DMA_MEMORY_TO_PERIPH | STM32_DMA_MEM_INC)
+#define STM32_DMA_PERIPH_RX	(STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_MEM_INC)
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_STM32_DMA_H_ */

--- a/samples/drivers/led_ws2812/boards/nucleo_f070rb.overlay
+++ b/samples/drivers/led_ws2812/boards/nucleo_f070rb.overlay
@@ -9,7 +9,8 @@
 #include "../f070rb-bindings.h"
 
 &spi1 { /* MOSI on PA7 */
-	dmas = <&dma1 3 0x20440>, <&dma1 2 0x20480>;
+	dmas = <&dma1 3 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+		<&dma1 2 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 
 	led_strip: b1414@0 {

--- a/tests/drivers/spi/spi_loopback/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/b_u585i_iot02a.overlay
@@ -9,8 +9,8 @@
 };
 
 &spi1 {
-	dmas = <&gpdma1 0 7 0x440
-		&gpdma1 1 6 0x480>;
+	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX
+		&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_g0b1re.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_g0b1re.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 2 17 0x20440
-		&dmamux1 1 16 0x20480>;
+	dmas = <&dmamux1 2 17 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dmamux1 1 16 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_g431rb.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_g431rb.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 0 11 0x20440
-		&dmamux1 1 10 0x20480>;
+	dmas = <&dmamux1 0 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dmamux1 1 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_g474re.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_g474re.overlay
@@ -14,8 +14,8 @@
 };
 
 &spi1 {
-	dmas = <&dmamux1 0 11 0x20440
-		&dmamux1 8 10 0x20480>;
+	dmas = <&dmamux1 0 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dmamux1 8 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h743zi.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 0 38 0x20440
-		&dmamux1 1 37 0x20480>;
+	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_l152re.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_l152re.overlay
@@ -8,8 +8,8 @@
 	pinctrl-0 = <&spi1_nss_pa4 &spi1_sck_pa5
 		     &spi1_miso_pa6 &spi1_mosi_pa7>;
 	pinctrl-names = "default";
-	dmas = <&dma1 3 0x20440
-		&dma1 2 0x20480>;
+	dmas = <&dma1 3 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dma1 2 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	status = "okay";
 	slow@0 {

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_l476rg.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dma1 3 1 0x20440
-		&dma1 2 1 0x20480>;
+	dmas = <&dma1 3 1 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dma1 2 1 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_l4r5zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_l4r5zi.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 0 11 0x20440
-		&dmamux1 7 10 0x20480>;
+	dmas = <&dmamux1 0 11 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dmamux1 7 10 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_l552ze_q.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_l552ze_q.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 0 12 0x440
-		&dmamux1 7 11 0x480>;
+	dmas = <&dmamux1 0 12 STM32_DMA_PERIPH_TX
+		&dmamux1 7 11 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_u575zi_q.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_u575zi_q.overlay
@@ -9,8 +9,8 @@
 };
 
 &spi1 {
-	dmas = <&gpdma1 0 7 0x440
-		&gpdma1 1 6 0x480>;
+	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX
+		&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wb55rg.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 11 7 0x20440
-		&dmamux1 1 6 0x20480>;
+	dmas = <&dmamux1 11 7 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dmamux1 1 6 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wl55jc.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 11 8 0x20440
-		&dmamux1 1 7 0x20480>;
+	dmas = <&dmamux1 11 8 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dmamux1 1 7 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32l562e_dk.overlay
@@ -5,8 +5,8 @@
  */
 
 &spi1 {
-	dmas = <&dmamux1 0 12 0x440
-		&dmamux1 7 11 0x480>;
+	dmas = <&dmamux1 0 12 STM32_DMA_PERIPH_TX
+		&dmamux1 7 11 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/uart/uart_async_api/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/b_u585i_iot02a.overlay
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 &usart3 {
-	dmas = <&gpdma1 0 29 0x440
-		&gpdma1 1 28 0x480>;
+	dmas = <&gpdma1 0 29 STM32_DMA_PERIPH_TX
+		&gpdma1 1 28 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };

--- a/tests/drivers/uart/uart_async_api/boards/disco_l475_iot1.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/disco_l475_iot1.overlay
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 &uart4 {
-	dmas = <&dma2 3 2 0x20440>,
-		<&dma2 5 2 0x20480>;
+	dmas = <&dma2 3 2 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+		<&dma2 5 2 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_f103rb.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_f103rb.overlay
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 &usart1 {
-	dmas = <&dma1 4 0x440>,
-	       <&dma1 5 0x480>;
+	dmas = <&dma1 4 STM32_DMA_PERIPH_TX>,
+	       <&dma1 5 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_g071rb.overlay
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 &usart1 {
-	dmas = <&dmamux1 5 51 0x440>,
-	       <&dmamux1 4 50 0x480>;
+	dmas = <&dmamux1 5 51 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 4 50 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_g474re.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_g474re.overlay
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 &usart1 {
-	dmas = <&dmamux1 2 25 0x440>,
-	       <&dmamux1 1 24 0x480>;
+	dmas = <&dmamux1 2 25 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 1 24 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_h723zg.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_h723zg.overlay
@@ -3,8 +3,8 @@
  */
 
 &usart2 {
-	dmas = <&dmamux1 2 44 0x440>,
-		<&dmamux1 3 43 0x480>;
+	dmas = <&dmamux1 2 44 STM32_DMA_PERIPH_TX>,
+		<&dmamux1 3 43 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_h743zi.overlay
@@ -3,8 +3,8 @@
  */
 
 &usart2 {
-	dmas = <&dmamux1 2 44 0x440>,
-		<&dmamux1 3 43 0x480>;
+	dmas = <&dmamux1 2 44 STM32_DMA_PERIPH_TX>,
+		<&dmamux1 3 43 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	pinctrl-0 = <&usart2_tx_pd5 &usart2_rx_pd6>;
 	pinctrl-names = "default";

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_l152re.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_l152re.overlay
@@ -4,8 +4,8 @@
 	pinctrl-0 = <&usart3_tx_pb10 &usart3_rx_pb11>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
-	dmas = <&dma1 2 0x20440>,
-		<&dma1 3 0x20480>;
+	dmas = <&dma1 2 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+		<&dma1 3 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	status = "okay";
 };

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_l4r5zi.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_l4r5zi.overlay
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 &usart3 {
-	dmas = <&dmamux1 5 29 0x440>,
-		<&dmamux1 4 28 0x480>;
+	dmas = <&dmamux1 5 29 STM32_DMA_PERIPH_TX>,
+		<&dmamux1 4 28 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_l552ze_q.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_l552ze_q.overlay
@@ -5,8 +5,8 @@
  */
 
 &usart3 {
-	dmas = <&dmamux1 5 30 0x440>,
-		<&dmamux1 4 29 0x480>;
+	dmas = <&dmamux1 5 30 STM32_DMA_PERIPH_TX>,
+		<&dmamux1 4 29 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_l552ze_q_ns.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_l552ze_q_ns.overlay
@@ -5,8 +5,8 @@
  */
 
 &usart3 {
-	dmas = <&dmamux1 5 30 0x440>,
-		<&dmamux1 4 29 0x480>;
+	dmas = <&dmamux1 5 30 STM32_DMA_PERIPH_TX>,
+		<&dmamux1 4 29 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_u575zi_q.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_u575zi_q.overlay
@@ -5,7 +5,7 @@
  */
 
 &usart2 {
-	dmas = <&gpdma1 0 27 0x440
-		&gpdma1 1 26 0x480>;
+	dmas = <&gpdma1 0 27 STM32_DMA_PERIPH_TX
+		&gpdma1 1 26 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_wb55rg.overlay
@@ -6,8 +6,8 @@
 
 &lpuart1 {
 	/delete-property/ hw-flow-control;
-	dmas = <&dmamux1 0 17 0x20440
-		&dmamux1 1 16 0x20480>;
+	dmas = <&dmamux1 0 17 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dmamux1 1 16 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_wl55jc.overlay
@@ -5,8 +5,8 @@
  */
 
 &usart1 {
-	dmas = <&dmamux1 11 18 0x20440
-		&dmamux1 1 17 0x20480>;
+	dmas = <&dmamux1 11 18 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dmamux1 1 17 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 	pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pb7>;
 	pinctrl-names = "default";

--- a/tests/drivers/uart/uart_async_api/boards/stm32f3_disco.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/stm32f3_disco.overlay
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 &usart2 {
-	dmas = <&dma1 7 0x440>,
-		<&dma1 6 0x480>;
+	dmas = <&dma1 7 STM32_DMA_PERIPH_TX>,
+		<&dma1 6 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };

--- a/tests/drivers/uart/uart_async_api/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/stm32l562e_dk.overlay
@@ -5,8 +5,8 @@
  */
 
 &usart3 {
-	dmas = <&dmamux1 5 30 0x440>,
-		<&dmamux1 4 29 0x480>;
+	dmas = <&dmamux1 5 30 STM32_DMA_PERIPH_TX>,
+		<&dmamux1 4 29 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };
 

--- a/tests/drivers/uart/uart_async_api/boards/stm32l562e_dk_ns.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/stm32l562e_dk_ns.overlay
@@ -5,8 +5,8 @@
  */
 
 &usart3 {
-	dmas = <&dmamux1 5 30 0x440>,
-		<&dmamux1 4 29 0x480>;
+	dmas = <&dmamux1 5 30 STM32_DMA_PERIPH_TX>,
+		<&dmamux1 4 29 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 };
 


### PR DESCRIPTION
This PR adds a include/zephyr/dt-bindings/dma/stm32_dma.h header file with all the bit fields for the
stm32 DMA channel configuration.
Makes the dma channel config more readable
from `<&dma2 7 5 0x440 0x03>`
to `<&dma2 7 5 DMA_STM32_PERIPH_TX_DEFAULT DMA_STM32_FIFO_FULL>`

User can choose a combination of ORed values to write the bitfield, like : 
DMA_STM32_PERIPH_TX_DEFAULT | DMA_STM32_PERIPH_NO_INC | DMA_STM32_MEM_INC | DMA_STM32_PERIPH_8BITS | DMA_STM32_MEM_8BITS | DMA_STM32_PRIORITY_LOW

The DMA_STM32_PERIPH_TX_DEFAULT DMA_STM32_PERIPH_RX_DEFAULT are also created with that basic default configuration.

Signed-off-by: Francois Ramu <francois.ramu@st.com>