### PR TITLE
Deprecate STM32 RTC Kconfig symbols

### DIFF
--- a/boards/arm/b_l072z_lrwan1/Kconfig.defconfig
+++ b/boards/arm/b_l072z_lrwan1/Kconfig.defconfig
@@ -8,9 +8,4 @@ if BOARD_B_L072Z_LRWAN1
 config BOARD
 	default "b_l072z_lrwan1"
 
-choice COUNTER_RTC_STM32_CLOCK_SRC
-	default COUNTER_RTC_STM32_CLOCK_LSE
-	depends on COUNTER
-endchoice # COUNTER_RTC_STM32_CLOCK_SRC
-
 endif # BOARD_B_L072Z_LRWAN1

--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -71,7 +71,7 @@
 	cpu-power-states = <&stop>;
 };
 
-&clk_lsi {
+&clk_lse {
 	status = "okay";
 };
 
@@ -158,7 +158,7 @@ arduino_i2c: &i2c1 {};
 
 &rtc {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>,
-		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
+		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
 	status = "okay";
 };
 

--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -19,17 +19,22 @@ if COUNTER_RTC_STM32
 
 choice COUNTER_RTC_STM32_CLOCK_SRC
 	bool "RTC clock source"
+	optional
 	depends on COUNTER_RTC_STM32
 
 config COUNTER_RTC_STM32_CLOCK_LSI
 	bool "LSI"
+	select DEPRECATED
 	help
 	  Use LSI as RTC clock
+	  Deprecated in favor of device tree secondary domain clock
 
 config COUNTER_RTC_STM32_CLOCK_LSE
 	bool "LSE"
+	select DEPRECATED
 	help
 	  Use LSE as RTC clock
+	  Deprecated in favor of device tree secondary domain clock
 
 endchoice #COUNTER_RTC_STM32_CLOCK_SRC
 

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -451,15 +451,15 @@ static int rtc_stm32_init(const struct device *dev)
 static struct rtc_stm32_data rtc_data;
 
 #if DT_INST_NUM_CLOCKS(0) == 1
-#warning Kconfig COUNTER_RTC_STM32_CLOCK_LS* are deprecated. Please define clock source in dtsi file
+#warning STM32 RTC needs a kernel source clock. Please define it in dts file
 static const struct stm32_pclken rtc_clk[] = {
 	STM32_CLOCK_INFO(0, DT_DRV_INST(0)),
-	/* Use Kconfig to configure source clocks fields */
+	/* Use Kconfig to configure source clocks fields (Deprecated) */
 	/* Fortunately, values are consistent across enabled series */
-#ifdef COUNTER_RTC_STM32_CLOCK_LSI
-	{.bus = STM32_SRC_LSI, .enr = RTC_SEL(2)}
-#else
+#ifdef CONFIG_COUNTER_RTC_STM32_CLOCK_LSE
 	{.bus = STM32_SRC_LSE, .enr = RTC_SEL(1)}
+#else
+	{.bus = STM32_SRC_LSI, .enr = RTC_SEL(2)}
 #endif
 };
 #else


### PR DESCRIPTION
Following comments on #53138, adds DEPRECATED to Kconfig symbols that are no longer in use after PR #50104.