### PR TITLE
treewide: Disable automatic argparse argument shortening

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -611,7 +611,7 @@ execute_process(
   ${ZEPHYR_BASE}/scripts/build/subfolder_list.py
   --directory        ${ZEPHYR_BASE}/include      # Walk this directory
   --out-file         ${syscalls_subdirs_txt}     # Write file with discovered folder
-  --trigger          ${syscalls_subdirs_trigger} # Trigger file that is used for json generation
+  --trigger-file     ${syscalls_subdirs_trigger} # Trigger file that is used for json generation
   ${syscalls_links}                              # If defined, create symlinks for dependencies
 )
 file(STRINGS ${syscalls_subdirs_txt} PARSE_SYSCALLS_PATHS_DEPENDS ENCODING UTF-8)
@@ -644,7 +644,7 @@ else()
     ${ZEPHYR_BASE}/scripts/build/subfolder_list.py
     --directory        ${ZEPHYR_BASE}/include      # Walk this directory
     --out-file         ${syscalls_subdirs_txt}     # Write file with discovered folder
-    --trigger          ${syscalls_subdirs_trigger} # Trigger file that is used for json generation
+    --trigger-file     ${syscalls_subdirs_trigger} # Trigger file that is used for json generation
     ${syscalls_links}                              # If defined, create symlinks for dependencies
     DEPENDS ${PARSE_SYSCALLS_PATHS_DEPENDS}
   )
@@ -740,7 +740,7 @@ add_custom_command(OUTPUT include/generated/syscall_dispatch.c ${syscall_list_h}
   )
 
 # This is passed into all calls to the gen_kobject_list.py script.
-set(gen_kobject_list_include_args --include ${struct_tags_json})
+set(gen_kobject_list_include_args --include-subsystem-list ${struct_tags_json})
 
 set(DRV_VALIDATION ${PROJECT_BINARY_DIR}/include/generated/driver-validation.h)
 add_custom_command(

--- a/arch/x86/gen_gdt.py
+++ b/arch/x86/gen_gdt.py
@@ -158,7 +158,7 @@ def parse_args():
     global args
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument("-k", "--kernel", required=True,
                         help="Zephyr kernel image")

--- a/arch/x86/gen_idt.py
+++ b/arch/x86/gen_idt.py
@@ -251,7 +251,7 @@ def parse_args():
     global args
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument("-m", "--vector-map", required=True,
                         help="Output file mapping IRQ lines to IDT vectors")

--- a/arch/x86/gen_mmu.py
+++ b/arch/x86/gen_mmu.py
@@ -599,7 +599,7 @@ def parse_args():
 
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument("-k", "--kernel", required=True,
                         help="path to prebuilt kernel ELF binary")

--- a/arch/x86/zefi/zefi.py
+++ b/arch/x86/zefi/zefi.py
@@ -142,7 +142,7 @@ def build_elf(elf_file, include_dirs):
 def parse_args():
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument("-c", "--compiler", required=True, help="Compiler to be used")
     parser.add_argument("-o", "--objcopy", required=True, help="objcopy to be used")

--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -172,7 +172,7 @@ def main():
 def parse_args():
     # Parse command line arguments from sys.argv.
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument('-v', '--verbose', default=0, action='count',
                         help='increase verbosity; may be given multiple times')
     parser.add_argument('--vendor-prefixes', required=True,

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -91,6 +91,17 @@ Changes in this release
   * :kconfig:option:`CONFIG_NETWORKING`
   * :kconfig:option:`CONFIG_NET_UDP`
 
+* Python's argparse argument parser usage in Zephyr scripts has been updated
+  to disable abbreviations, any future python scripts or python code updates
+  must also disable allowing abbreviations by using ``allow_abbrev=False``
+  when setting up ``ArgumentParser()``.
+
+  This may cause out-of-tree scripts or commands to fail if they have relied
+  upon their behaviour previously, these will need to be updated in order for
+  building to work. As an example, if a script argument had ``--reset-type``
+  and an out-of-tree script used this by passing ``--reset`` then it will need
+  to be updated to use the full argument name, ``--reset-type``.
+
 Removed APIs in this release
 ============================
 

--- a/samples/modules/tflite-micro/magic_wand/train/train.py
+++ b/samples/modules/tflite-micro/magic_wand/train/train.py
@@ -176,7 +176,7 @@ def train_net(
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("--model", "-m")
     parser.add_argument("--person", "-p")
     args = parser.parse_args()

--- a/samples/net/cloud/google_iot_mqtt/src/private_info/create_keys.py
+++ b/samples/net/cloud/google_iot_mqtt/src/private_info/create_keys.py
@@ -12,7 +12,7 @@ def parse_args():
     global args
 
     parser = argparse.ArgumentParser(description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument(
         "-d", "--device", required=True,

--- a/samples/subsys/zbus/remote_mock/remote_mock.py
+++ b/samples/subsys/zbus/remote_mock/remote_mock.py
@@ -14,7 +14,7 @@ j = """
 ]"""
 
 channels = json.loads(j)
-parser = argparse.ArgumentParser(description='Read zbus events via serial.')
+parser = argparse.ArgumentParser(description='Read zbus events via serial.', allow_abbrev=False)
 parser.add_argument("port", type=str, help='The tty or COM port to be used')
 
 args = parser.parse_args()

--- a/samples/subsys/zbus/uart_bridge/decoder.py
+++ b/samples/subsys/zbus/uart_bridge/decoder.py
@@ -14,7 +14,7 @@ j = """
 ]
 """
 
-parser = argparse.ArgumentParser(description='Read zbus events via serial.')
+parser = argparse.ArgumentParser(description='Read zbus events via serial.', allow_abbrev=False)
 parser.add_argument("port", type=str, help='The tty or COM port to be used')
 
 args = parser.parse_args()

--- a/samples/tfm_integration/psa_firmware/split-header.py
+++ b/samples/tfm_integration/psa_firmware/split-header.py
@@ -20,7 +20,7 @@ def dump_header(infile, image, header):
     inhex.tobinfile(header, start=start, end=end-1)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument('input')
     parser.add_argument('image')
     parser.add_argument('header')

--- a/scripts/build/file2hex.py
+++ b/scripts/build/file2hex.py
@@ -23,7 +23,7 @@ def parse_args():
 
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument("-f", "--file", required=True, help="Input file")
     parser.add_argument("-g", "--gzip", action="store_true",

--- a/scripts/build/gen_app_partitions.py
+++ b/scripts/build/gen_app_partitions.py
@@ -232,7 +232,7 @@ def parse_args():
     global args
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
     parser.add_argument("-d", "--directory", required=False, default=None,
                         help="Root build directory")
     parser.add_argument("-e", "--elf", required=False, default=None,

--- a/scripts/build/gen_cfb_font_header.py
+++ b/scripts/build/gen_cfb_font_header.py
@@ -194,7 +194,7 @@ def parse_args():
     global args
     parser = argparse.ArgumentParser(
         description="Character Frame Buffer (CFB) font header file generator",
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument(
         "-z", "--zephyr-base",

--- a/scripts/build/gen_handles.py
+++ b/scripts/build/gen_handles.py
@@ -43,7 +43,7 @@ def parse_args():
 
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument("-k", "--kernel", required=True,
                         help="Input zephyr ELF binary")

--- a/scripts/build/gen_image_info.py
+++ b/scripts/build/gen_image_info.py
@@ -66,7 +66,7 @@ def main():
     parser = argparse.ArgumentParser(description='''
     Process ELF file and extract image information.
     Create header file with extracted image information which can be included
-    in other build systems.''')
+    in other build systems.''', allow_abbrev=False)
 
     parser.add_argument('--header-file', required=True,
                         help="""Header file to write with image data.""")

--- a/scripts/build/gen_isr_tables.py
+++ b/scripts/build/gen_isr_tables.py
@@ -105,7 +105,7 @@ def parse_args():
     global args
 
     parser = argparse.ArgumentParser(description=__doc__,
-            formatter_class=argparse.RawDescriptionHelpFormatter)
+            formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument("-e", "--big-endian", action="store_true",
             help="Target encodes data in big-endian format (little endian is "

--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -981,7 +981,7 @@ def parse_args():
 
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument("-k", "--kernel", required=False,
                         help="Input zephyr ELF binary")

--- a/scripts/build/gen_kobject_placeholders.py
+++ b/scripts/build/gen_kobject_placeholders.py
@@ -108,7 +108,7 @@ def parse_args():
 
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument("--object", required=True,
                         help="Points to kobject_prebuilt_hash.c.obj")

--- a/scripts/build/gen_offset_header.py
+++ b/scripts/build/gen_offset_header.py
@@ -62,7 +62,7 @@ def gen_offset_header(input_name, input_file, output_file):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument(
         "-i",

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -407,7 +407,7 @@ def parse_args():
     global args
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
     parser.add_argument("-d", "--directory", required=True,
                         help="obj file's directory")
     parser.add_argument("-i", "--input_rel_dict", required=True,

--- a/scripts/build/gen_strerror_table.py
+++ b/scripts/build/gen_strerror_table.py
@@ -79,7 +79,7 @@ def gen_strerror_table(input, output):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument(
         '-i',
         '--input',

--- a/scripts/build/gen_syscalls.py
+++ b/scripts/build/gen_syscalls.py
@@ -387,7 +387,7 @@ def parse_args():
     global args
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument("-i", "--json-file", required=True,
                         help="Read syscall information from json file")

--- a/scripts/build/mergehex.py
+++ b/scripts/build/mergehex.py
@@ -35,7 +35,7 @@ def merge_hex_files(output, input_hex_files, overlap):
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Merge hex files.",
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
     parser.add_argument("-o", "--output", required=False, default="merged.hex",
                         type=argparse.FileType('w', encoding='UTF-8'),
                         help="Output file name.")

--- a/scripts/build/parse_syscalls.py
+++ b/scripts/build/parse_syscalls.py
@@ -110,7 +110,7 @@ def parse_args():
     global args
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument("-i", "--include", required=True, action='append',
                         help='''include directories recursively scanned

--- a/scripts/build/process_gperf.py
+++ b/scripts/build/process_gperf.py
@@ -134,7 +134,8 @@ def parse_args():
 
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False)
 
     parser.add_argument("-i", "--input", required=True,
                         help="Input C file from gperf")

--- a/scripts/build/subfolder_list.py
+++ b/scripts/build/subfolder_list.py
@@ -18,7 +18,8 @@ def parse_args():
     """Parse command line arguments and options"""
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False)
 
     parser.add_argument('-d', '--directory', required=True,
                         help='Directory to walk for sub-directory discovery')

--- a/scripts/build/uf2conv.py
+++ b/scripts/build/uf2conv.py
@@ -247,7 +247,8 @@ def main():
     def error(msg):
         print(msg)
         sys.exit(1)
-    parser = argparse.ArgumentParser(description='Convert to UF2 or flash directly.')
+    parser = argparse.ArgumentParser(description='Convert to UF2 or flash directly.',
+                                     allow_abbrev=False)
     parser.add_argument('input', metavar='INPUT', type=str, nargs='?',
                         help='input file (HEX, BIN or UF2)')
     parser.add_argument('-b' , '--base', dest='base', type=str,

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -327,7 +327,7 @@ class KconfigCheck(ComplianceTest):
                                                "gen_driver_kconfig_dts.py")
         binding_path = os.path.join(ZEPHYR_BASE, "dts", "bindings")
         cmd = [sys.executable, zephyr_drv_kconfig_path,
-               '--kconfig-out', kconfig_dts_file, '--bindings', binding_path]
+               '--kconfig-out', kconfig_dts_file, '--bindings-dirs', binding_path]
         try:
             subprocess.run(cmd, check=True, stdout=subprocess.PIPE,
                            stderr=subprocess.STDOUT)
@@ -1077,7 +1077,7 @@ def parse_args():
 
     default_range = 'HEAD~1..HEAD'
     parser = argparse.ArgumentParser(
-        description="Check for coding style and documentation warnings.")
+        description="Check for coding style and documentation warnings.", allow_abbrev=False)
     parser.add_argument('-c', '--commits', default=default_range,
                         help=f'''Commit range in the form: a..[b], default is
                         {default_range}''')

--- a/scripts/ci/guideline_check.py
+++ b/scripts/ci/guideline_check.py
@@ -38,7 +38,7 @@ def parse_coccinelle(contents: str, violations: dict):
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Check if change requires full twister")
+        description="Check if change requires full twister", allow_abbrev=False)
     parser.add_argument('-c', '--commits', default=None,
                         help="Commit range in the form: a..b")
     parser.add_argument("-o", "--output", required=False,

--- a/scripts/ci/pylintrc
+++ b/scripts/ci/pylintrc
@@ -247,6 +247,8 @@ enable=
     deprecated-str-translate-call,
     deprecated-itertools-function,
     deprecated-types-field,
+    # Custom Zephyr check scripts
+    zephyr-arg-parse,
 
 [SIMILARITIES]
 

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -293,7 +293,8 @@ class Filters:
 
 def parse_args():
     parser = argparse.ArgumentParser(
-                description="Generate twister argument files based on modified file")
+                description="Generate twister argument files based on modified file",
+                allow_abbrev=False)
     parser.add_argument('-c', '--commits', default=None,
             help="Commit range in the form: a..b")
     parser.add_argument('-m', '--modified-files', default=None,

--- a/scripts/ci/upload_test_results.py
+++ b/scripts/ci/upload_test_results.py
@@ -46,7 +46,7 @@ def main():
 
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument('-u', '--user', help='username')
     parser.add_argument('-p', '--password', help='password')
     parser.add_argument('-i', '--index', help='index to push to.', required=True)

--- a/scripts/ci/version_mgr.py
+++ b/scripts/ci/version_mgr.py
@@ -25,7 +25,7 @@ VERSIONS_FILE = "versions.json"
 
 def parse_args():
     parser = argparse.ArgumentParser(
-                description="Manage versions to be tested.")
+                description="Manage versions to be tested.", allow_abbrev=False)
     parser.add_argument('-l', '--list', action="store_true",
                         help="List all published versions")
     parser.add_argument('-u', '--update',

--- a/scripts/coredump/coredump_gdbserver.py
+++ b/scripts/coredump/coredump_gdbserver.py
@@ -22,7 +22,7 @@ GDBSERVER_HOST = ""
 
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
 
     parser.add_argument("elffile", help="Zephyr ELF binary")
     parser.add_argument("logfile", help="Coredump binary log file")

--- a/scripts/coredump/coredump_serial_log_parser.py
+++ b/scripts/coredump/coredump_serial_log_parser.py
@@ -17,7 +17,7 @@ COREDUMP_ERROR_STR = COREDUMP_PREFIX_STR + "ERROR CANNOT DUMP#"
 
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
 
     parser.add_argument("infile", help="Serial Log File")
     parser.add_argument("outfile",

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -185,7 +185,7 @@ def node_z_path_id(node):
 def parse_args():
     # Returns parsed command-line arguments
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("--dts", required=True, help="DTS file")
     parser.add_argument("--dtc-flags",
                         help="'dtc' devicetree compiler flags, some of which "

--- a/scripts/dts/gen_driver_kconfig_dts.py
+++ b/scripts/dts/gen_driver_kconfig_dts.py
@@ -36,7 +36,7 @@ def binding_paths(bindings_dirs):
 def parse_args():
     # Returns parsed command-line arguments
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("--kconfig-out", required=True,
                         help="path to write the Kconfig file")
     parser.add_argument("--bindings-dirs", nargs='+', required=True,

--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -52,7 +52,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'python-devicetree',
 def parse_args():
     # Returns parsed command-line arguments
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("--cmake-out", required=True,
                         help="path to write the CMake property file")
     parser.add_argument("--edt-pickle", required=True,

--- a/scripts/dump_bugs_pickle.py
+++ b/scripts/dump_bugs_pickle.py
@@ -15,7 +15,7 @@ from github.Issue import Issue
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument('pickle_file', metavar='PICKLE-FILE', type=Path,
                         help='pickle file containing list of issues')

--- a/scripts/footprint/compare_footprint
+++ b/scripts/footprint/compare_footprint
@@ -70,7 +70,8 @@ def init_logs():
 def parse_args():
     parser = argparse.ArgumentParser(
                 description="Compare footprint apps RAM and ROM sizes. Note: "
-                "To run it you need to set up the same environment as twister.")
+                "To run it you need to set up the same environment as twister.",
+                allow_abbrev=False)
     parser.add_argument('-b', '--base-commit', default=None,
                         help="Commit ID to use as base for footprint "
                                     "compare. Default is parent current commit."

--- a/scripts/footprint/fpdiff.py
+++ b/scripts/footprint/fpdiff.py
@@ -27,7 +27,7 @@ importer = DictImporter()
 
 def parse_args():
     parser = argparse.ArgumentParser(
-                description="Compare footprint sizes of two builds.")
+                description="Compare footprint sizes of two builds.", allow_abbrev=False)
     parser.add_argument("file1", help="First file")
     parser.add_argument("file2", help="Second file")
 

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -705,7 +705,7 @@ def parse_args():
     """
     global args
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
 
     parser.add_argument("-k", "--kernel", required=True,
                         help="Zephyr ELF binary")

--- a/scripts/footprint/track.py
+++ b/scripts/footprint/track.py
@@ -12,7 +12,8 @@ import argparse
 
 def parse_args():
     parser = argparse.ArgumentParser(
-                description="Generate footprint data based on a predefined plan.")
+                description="Generate footprint data based on a predefined plan.",
+                allow_abbrev=False)
     parser.add_argument("-p", "--plan", help="Path of test plan", required=True)
 
     return parser.parse_args()

--- a/scripts/footprint/upload_data.py
+++ b/scripts/footprint/upload_data.py
@@ -51,7 +51,7 @@ def parse_args():
     global args
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument("-d", "--data", help="Data Directory")
     parser.add_argument("-y", "--dryrun", action="store_true", help="Dry run, do not upload to database")

--- a/scripts/gen_gcov_files.py
+++ b/scripts/gen_gcov_files.py
@@ -65,7 +65,7 @@ def parse_args():
     global args
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
     parser.add_argument("-i", "--input", required=True,
                         help="Input dump data")
     parser.add_argument("-v", "--verbose", action="count", default=0,

--- a/scripts/generate_usb_vif/generate_vif.py
+++ b/scripts/generate_usb_vif/generate_vif.py
@@ -248,7 +248,7 @@ def parse_and_add_node_to_xml(xml_ele, node):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("--edt-pickle", required=True,
                         help="path to read the pickled edtlib.EDT object from")
     parser.add_argument("--compatible", required=True,

--- a/scripts/get_maintainer.py
+++ b/scripts/get_maintainer.py
@@ -54,7 +54,7 @@ def _parse_args():
 
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description=__doc__)
+        description=__doc__, allow_abbrev=False)
 
     parser.add_argument(
         "-m", "--maintainers",

--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -250,7 +250,7 @@ def write_kconfig_filenames(kconf, kconfig_list_path):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
 
     parser.add_argument("--handwritten-input-configs",
                         action="store_true",

--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -6202,14 +6202,14 @@ def standard_kconfig(description=None):
     Exits with sys.exit() (which raises SystemExit) on errors.
 
     description (default: None):
-      The 'description' passed to argparse.ArgumentParser().
+      The 'description' passed to argparse.ArgumentParser(allow_abbrev=False).
       argparse.RawDescriptionHelpFormatter is used, so formatting is preserved.
     """
     import argparse
 
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description=description)
+        description=description, allow_abbrev=False)
 
     parser.add_argument(
         "kconfig",

--- a/scripts/kconfig/lint.py
+++ b/scripts/kconfig/lint.py
@@ -56,7 +56,7 @@ def parse_args():
 
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
-        description=__doc__)
+        description=__doc__, allow_abbrev=False)
 
     parser.add_argument(
         "-n", "--check-always-n",

--- a/scripts/list_boards.py
+++ b/scripts/list_boards.py
@@ -88,7 +88,7 @@ def find_arch2board_set_in(root, arches):
     return ret
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     add_args(parser)
     return parser.parse_args()
 

--- a/scripts/logging/dictionary/database_gen.py
+++ b/scripts/logging/dictionary/database_gen.py
@@ -74,7 +74,7 @@ ACCEPTABLE_ESCAPE_CHARS = [
 
 def parse_args():
     """Parse command line arguments"""
-    argparser = argparse.ArgumentParser()
+    argparser = argparse.ArgumentParser(allow_abbrev=False)
 
     argparser.add_argument("elffile", help="Zephyr ELF binary")
     argparser.add_argument("--build", help="Build ID")

--- a/scripts/logging/dictionary/log_parser.py
+++ b/scripts/logging/dictionary/log_parser.py
@@ -28,7 +28,7 @@ LOG_HEX_SEP = "##ZLOGV1##"
 
 def parse_args():
     """Parse command line arguments"""
-    argparser = argparse.ArgumentParser()
+    argparser = argparse.ArgumentParser(allow_abbrev=False)
 
     argparser.add_argument("dbfile", help="Dictionary Logging Database file")
     argparser.add_argument("logfile", help="Log Data file")

--- a/scripts/make_bugs_pickle.py
+++ b/scripts/make_bugs_pickle.py
@@ -35,7 +35,7 @@ For more information, see:
     https://pygithub.readthedocs.io/en/latest/github_objects/Issue.html
   - pickle: https://docs.python.org/3/library/pickle.html
 ''',
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
     parser.add_argument('out_file', metavar='OUTFILE', type=Path, nargs='?',
                         help='''file to write pickle data to (default:
                         stdout)''')

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -52,7 +52,8 @@ def add_parse_arguments(parser = None):
     if parser is None:
         parser = argparse.ArgumentParser(
             description=__doc__,
-            formatter_class=argparse.RawDescriptionHelpFormatter)
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            allow_abbrev=False)
     parser.fromfile_prefix_chars = "+"
 
     case_select = parser.add_argument_group("Test case selection",

--- a/scripts/pylint/checkers/argparse-checker.py
+++ b/scripts/pylint/checkers/argparse-checker.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pylint.checkers import BaseChecker
+
+import astroid
+from astroid import nodes
+
+class ZephyrArgParseChecker(BaseChecker):
+    """Class implementing function checker for Zephyr."""
+
+    # The name defines a custom section of the config for this checker.
+    name = "zephyr-arg-parse"
+
+    # Register messages emitted by the checker.
+    msgs = {
+        "E9901": (
+            "Argument parser with abbreviations is disallowed",
+            "argument-parser-with-abbreviations",
+            "An ArgumentParser object must set `allow_abbrev=false` to disable "
+            "abbreviations and prevent issues with these being used by projects"
+            " and/or scripts."
+        )
+    }
+
+    # Function that looks at evert function call for ArgumentParser invocation
+    def visit_call(self, node: nodes.Call) -> None:
+        if isinstance(node.func, astroid.nodes.node_classes.Attribute) and \
+           node.func.attrname == "ArgumentParser":
+            abbrev_disabled = False
+
+            # Check that allow_abbrev is set and that the value is False
+            for keyword in node.keywords:
+                if keyword.arg == "allow_abbrev":
+                    if not isinstance(keyword.value, astroid.nodes.node_classes.Const):
+                        continue
+                    if keyword.value.pytype() != "builtins.bool":
+                        continue
+                    if keyword.value.value is False:
+                        abbrev_disabled = True
+
+            if abbrev_disabled is False:
+                self.add_message(
+                    "argument-parser-with-abbreviations", node=node
+                )
+
+        return ()
+
+# This is called from pylint, hence PyLinter not being declared in this file
+# pylint: disable=undefined-variable
+def register(linter: PyLinter) -> None:
+    linter.register_checker(ZephyrArgParseChecker(linter))

--- a/scripts/release/bug_bash.py
+++ b/scripts/release/bug_bash.py
@@ -22,7 +22,7 @@ from github import Github
 
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument('-a', '--all', dest='all',
                         help='Show all bugs squashed', action='store_true')
     parser.add_argument('-t', '--token', dest='tokenfile',

--- a/scripts/release/list_backports.py
+++ b/scripts/release/list_backports.py
@@ -56,7 +56,7 @@ def valid_date_type(arg_date_str):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument('-t', '--token', dest='tokenfile',
                         help='File containing GitHub token (alternatively, use GITHUB_TOKEN env variable)', metavar='FILE')
     parser.add_argument('-b', '--base', dest='base',

--- a/scripts/release/list_issues.py
+++ b/scripts/release/list_issues.py
@@ -119,7 +119,7 @@ def parse_args():
 
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument("-o", "--org", default="zephyrproject-rtos",
                         help="Github organisation")

--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -24,7 +24,7 @@ def parse_args():
     global args
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
 
     parser.add_argument("-M", "--maintainer-file", required=False, default="MAINTAINERS.yml",
                         help="Maintainer file to be used.")

--- a/scripts/support/quartus-flash.py
+++ b/scripts/support/quartus-flash.py
@@ -118,7 +118,7 @@ def flash_kernel(device_id, input_sof, kernel_hex):
     pof_file.close()
 
 def main():
-    parser = argparse.ArgumentParser(description="Flash zephyr onto Altera boards")
+    parser = argparse.ArgumentParser(description="Flash zephyr onto Altera boards", allow_abbrev=False)
     parser.add_argument("-s", "--sof",
             help=".sof file with Nios II CPU configuration")
     parser.add_argument("-k", "--kernel",

--- a/scripts/tracing/parse_ctf.py
+++ b/scripts/tracing/parse_ctf.py
@@ -31,7 +31,7 @@ except ImportError:
 def parse_args():
     parser = argparse.ArgumentParser(
             description=__doc__,
-            formatter_class=argparse.RawDescriptionHelpFormatter)
+            formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
     parser.add_argument("-t", "--trace",
             required=True,
             help="tracing data (directory with metadata and trace file)")

--- a/scripts/tracing/trace_capture_uart.py
+++ b/scripts/tracing/trace_capture_uart.py
@@ -15,7 +15,7 @@ def parse_args():
     global args
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
     parser.add_argument("-d", "--serial_port", required=True,
                         help="serial port")
     parser.add_argument("-b", "--serial_baudrate", required=True,

--- a/scripts/tracing/trace_capture_usb.py
+++ b/scripts/tracing/trace_capture_usb.py
@@ -16,7 +16,7 @@ def parse_args():
     global args
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
     parser.add_argument("-v", "--vendor_id", required=True,
                         help="usb device vendor id")
     parser.add_argument("-p", "--product_id", required=True,

--- a/scripts/utils/migrate_includes.py
+++ b/scripts/utils/migrate_includes.py
@@ -75,7 +75,7 @@ def update_includes(project, dry_run):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument(
         "-p", "--project", type=Path, required=True, help="Zephyr-based project path"
     )

--- a/scripts/utils/migrate_mcumgr_kconfigs.py
+++ b/scripts/utils/migrate_mcumgr_kconfigs.py
@@ -148,7 +148,7 @@ def process_tree(project):
                 process_file(p)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument(
         "-r", "--root", type=Path, required=True, help="Zephyr-based project path"
     )

--- a/scripts/utils/pinctrl_nrf_migrate.py
+++ b/scripts/utils/pinctrl_nrf_migrate.py
@@ -665,7 +665,7 @@ def main(input_file: Path, no_backup: bool, skip_nrf_check: bool, header: str) -
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser("pinctrl migration utility for nRF")
+    parser = argparse.ArgumentParser("pinctrl migration utility for nRF", allow_abbrev=False)
     parser.add_argument(
         "-i", "--input", type=Path, required=True, help="Board DTS file"
     )

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -224,7 +224,7 @@ def do_run_common_image(command, user_args, user_runner_args, build_dir=None):
     #   arguments
     # - create a RunnerConfig using 'user_args' and the result
     #   of parsing 'final_argv'
-    parser = argparse.ArgumentParser(prog=runner_name)
+    parser = argparse.ArgumentParser(prog=runner_name, allow_abbrev=False)
     add_parser_common(command, parser=parser)
     runner_cls.add_parser(parser)
     args, unknown = parser.parse_known_args(args=final_argv)
@@ -504,7 +504,7 @@ def dump_runner_option_help(cls, indent=''):
     # Print help text for class-specific command line options for the
     # given runner class.
 
-    dummy_parser = argparse.ArgumentParser(prog='', add_help=False)
+    dummy_parser = argparse.ArgumentParser(prog='', add_help=False, allow_abbrev=False)
     cls.add_parser(dummy_parser)
     formatter = dummy_parser._get_formatter()
     for group in dummy_parser._action_groups:

--- a/scripts/west_commands/tests/test_blackmagicprobe.py
+++ b/scripts/west_commands/tests/test_blackmagicprobe.py
@@ -71,7 +71,7 @@ def test_blackmagicprobe_init(cc, req, command, runner_config):
 def test_blackmagicprobe_create(cc, req, command, runner_config):
     '''Test commands using a runner created from command line parameters.'''
     args = ['--gdb-serial', TEST_GDB_SERIAL]
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     BlackMagicProbeRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
     runner = BlackMagicProbeRunner.create(runner_config, arg_namespace)
@@ -84,7 +84,7 @@ def test_blackmagicprobe_create(cc, req, command, runner_config):
 def test_blackmagicprobe_connect_rst(cc, req, command, runner_config):
     '''Test that commands list the correct connect_rst value when enabled.'''
     args = ['--gdb-serial', TEST_GDB_SERIAL, '--connect-rst']
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     BlackMagicProbeRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
     runner = BlackMagicProbeRunner.create(runner_config, arg_namespace)

--- a/scripts/west_commands/tests/test_bossac.py
+++ b/scripts/west_commands/tests/test_bossac.py
@@ -209,7 +209,7 @@ def test_bossac_create(cc, req, get_cod_par, sup, runner_config, tmpdir):
 	no --offset
     """
     args = ['--bossac-port', str(TEST_BOSSAC_PORT)]
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     BossacBinaryRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
     runner_config = adjust_runner_config(runner_config, tmpdir, DOTCONFIG_STD)
@@ -247,7 +247,7 @@ def test_bossac_create_with_speed(cc, req, get_cod_par, sup, runner_config, tmpd
     """
     args = ['--bossac-port', str(TEST_BOSSAC_PORT),
             '--speed', str(TEST_BOSSAC_SPEED)]
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     BossacBinaryRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
     runner_config = adjust_runner_config(runner_config, tmpdir, DOTCONFIG_STD)
@@ -287,7 +287,7 @@ def test_bossac_create_with_flash_address(cc, req, get_cod_par, sup,
         '--bossac-port',
         str(TEST_BOSSAC_PORT),
     ]
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     BossacBinaryRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
     runner_config = adjust_runner_config(runner_config, tmpdir,

--- a/scripts/west_commands/tests/test_canopen_program.py
+++ b/scripts/west_commands/tests/test_canopen_program.py
@@ -69,7 +69,7 @@ def test_canopen_program_create(cpd, test_case, runner_config):
     mock.wait_for_flash_status_ok.return_value = 0
     mock.swid.return_value = 0
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     CANopenBinaryRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
     runner = CANopenBinaryRunner.create(runner_config, arg_namespace)

--- a/scripts/west_commands/tests/test_dediprog.py
+++ b/scripts/west_commands/tests/test_dediprog.py
@@ -69,7 +69,7 @@ def test_dediprog_create(cc, req, tc, runner_config):
     args = ['--spi-image', spi_image, '--retries', '0']
     if vcc:
         args.extend(['--vcc', vcc])
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     DediProgBinaryRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
     runner = DediProgBinaryRunner.create(runner_config, arg_namespace)

--- a/scripts/west_commands/tests/test_dfu_util.py
+++ b/scripts/west_commands/tests/test_dfu_util.py
@@ -128,7 +128,7 @@ def test_dfu_util_create(cc, req, gfa, find_device, tc, runner_config, tmpdir):
         f.write('\n')
     runner_config = runner_config._replace(build_dir=os.fspath(tmpdir))
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     DfuUtilBinaryRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
     runner = DfuUtilBinaryRunner.create(runner_config, arg_namespace)

--- a/scripts/west_commands/tests/test_gd32isp.py
+++ b/scripts/west_commands/tests/test_gd32isp.py
@@ -62,7 +62,7 @@ def test_gd32isp_create(cc, req, runner_config):
             '--speed', TEST_GD32ISP_SPEED,
             '--addr', TEST_GD32ISP_ADDR,
             '--isp', TEST_GD32ISP_CLI_T]
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     Gd32ispBinaryRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
     runner = Gd32ispBinaryRunner.create(runner_config, arg_namespace)

--- a/scripts/west_commands/tests/test_mdb.py
+++ b/scripts/west_commands/tests/test_mdb.py
@@ -21,7 +21,7 @@ TEST_BOARD_NSIM_ARGS = '@' + path.join(RC_BOARD_DIR, 'support', TEST_NSIM_ARGS)
 # mdb-nsim
 TEST_NSIM_FLASH_CASES = [
     {
-        'i': ['--cores=1', '--nsim=' + TEST_NSIM_ARGS],
+        'i': ['--cores=1', '--nsim_args=' + TEST_NSIM_ARGS],
         'o': [TEST_DRIVER_CMD, '-nooptions', '-nogoifmain',
            '-toggle=include_local_symbols=1',
            '-nsim', TEST_BOARD_NSIM_ARGS,
@@ -30,7 +30,7 @@ TEST_NSIM_FLASH_CASES = [
 
 TEST_NSIM_DEBUG_CASES = [
     {
-        'i': ['--cores=1', '--nsim=' + TEST_NSIM_ARGS],
+        'i': ['--cores=1', '--nsim_args=' + TEST_NSIM_ARGS],
         'o': [TEST_DRIVER_CMD, '-nooptions', '-nogoifmain',
            '-toggle=include_local_symbols=1',
            '-nsim', TEST_BOARD_NSIM_ARGS,
@@ -38,7 +38,7 @@ TEST_NSIM_DEBUG_CASES = [
           ]
     }]
 
-TEST_NSIM_MULTICORE_CASES = [['--cores=2', '--nsim=' + TEST_NSIM_ARGS]]
+TEST_NSIM_MULTICORE_CASES = [['--cores=2', '--nsim_args=' + TEST_NSIM_ARGS]]
 TEST_NSIM_CORE1 = [TEST_DRIVER_CMD, '-pset=1', '-psetname=core0', '',
               '-nooptions', '-nogoifmain', '-toggle=include_local_symbols=1',
               '-nsim', TEST_BOARD_NSIM_ARGS, RC_KERNEL_ELF]
@@ -121,7 +121,7 @@ def mdb(runner_config, tmpdir, mdb_runner):
         if isinstance(args, dict):
             return mdb_runner(runner_config, TEST_TARGET, **args)
         elif isinstance(args, list):
-            parser = argparse.ArgumentParser()
+            parser = argparse.ArgumentParser(allow_abbrev=False)
             mdb_runner.add_parser(parser)
             arg_namespace = parser.parse_args(args)
             return mdb_runner.create(runner_config, arg_namespace)

--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -479,7 +479,7 @@ def test_nrfjprog_create(check_call, get_snr, require, test_case,
     if test_case.recover:
         args.append('--recover')
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     NrfJprogBinaryRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
     runner = NrfJprogBinaryRunner.create(runner_config, arg_namespace)

--- a/scripts/west_commands/tests/test_pyocd.py
+++ b/scripts/west_commands/tests/test_pyocd.py
@@ -141,7 +141,7 @@ def pyocd(runner_config, tmpdir):
         if isinstance(args, dict):
             return PyOcdBinaryRunner(runner_config, TEST_TARGET, **args)
         elif isinstance(args, list):
-            parser = argparse.ArgumentParser()
+            parser = argparse.ArgumentParser(allow_abbrev=False)
             PyOcdBinaryRunner.add_parser(parser)
             arg_namespace = parser.parse_args(args)
             return PyOcdBinaryRunner.create(runner_config, arg_namespace)

--- a/scripts/west_commands/tests/test_stm32cubeprogrammer.py
+++ b/scripts/west_commands/tests/test_stm32cubeprogrammer.py
@@ -384,7 +384,7 @@ def test_stm32cubeprogrammer_create(
     if tc["frequency"]:
         args.extend(["--frequency", tc["frequency"]])
     if tc["reset_mode"]:
-        args.extend(["--reset", tc["reset_mode"]])
+        args.extend(["--reset-mode", tc["reset_mode"]])
     if tc["conn_modifiers"]:
         args.extend(["--conn-modifiers", tc["conn_modifiers"]])
     if tc["cli"]:
@@ -396,7 +396,7 @@ def test_stm32cubeprogrammer_create(
     if tc["tool_opt"]:
         args.extend(["--tool-opt", " " + tc["tool_opt"][0]])
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     STM32CubeProgrammerBinaryRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
 

--- a/scripts/west_commands/tests/test_stm32flash.py
+++ b/scripts/west_commands/tests/test_stm32flash.py
@@ -102,7 +102,7 @@ def test_stm32flash_create(cc, req, action, runner_config):
     else:
         args = ['--action', action, '--baud-rate', TEST_BAUD, '--start-addr', TEST_ADDR]
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     Stm32flashBinaryRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)
     runner = Stm32flashBinaryRunner.create(runner_config, arg_namespace)

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -539,7 +539,7 @@ def parse_modules(zephyr_base, manifest=None, west_projs=None, modules=None,
 def main():
     parser = argparse.ArgumentParser(description='''
     Process a list of projects and create Kconfig / CMake include files for
-    projects which are also a Zephyr module''')
+    projects which are also a Zephyr module''', allow_abbrev=False)
 
     parser.add_argument('--kconfig-out',
                         help="""File to write with resulting KConfig import

--- a/soc/arm/microchip_mec/common/spigen/mec_spi_gen.py
+++ b/soc/arm/microchip_mec/common/spigen/mec_spi_gen.py
@@ -237,7 +237,7 @@ def build_header(chip, spi_config, hdr_spi_loc, pld_spi_loc, pld_entry_addr, pld
     return bytes(hdr)
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     # Use a lambda to handle base 10 or base 16 (hex) input
     parser.add_argument("-c",
                         type=str,

--- a/soc/arm/nuvoton_npcx/common/ecst/ecst_args.py
+++ b/soc/arm/nuvoton_npcx/common/ecst/ecst_args.py
@@ -180,7 +180,7 @@ def _create_parser(arg_list):
     else parses the given string
     """
 
-    parser = argparse.ArgumentParser(conflict_handler='resolve')
+    parser = argparse.ArgumentParser(conflict_handler='resolve', allow_abbrev=False)
     parser.add_argument("-i", nargs='?', dest="input")
     parser.add_argument("-o", nargs='?', dest="output")
     parser.add_argument("-chip", dest="chip")

--- a/soc/xtensa/intel_adsp/tools/cavstool.py
+++ b/soc/xtensa/intel_adsp/tools/cavstool.py
@@ -683,7 +683,7 @@ async def main():
                 ipc_command(dsp.HIPCTDR & ~0x80000000, dsp.HIPCTDD)
 
 
-ap = argparse.ArgumentParser(description="DSP loader/logger tool")
+ap = argparse.ArgumentParser(description="DSP loader/logger tool", allow_abbrev=False)
 ap.add_argument("-q", "--quiet", action="store_true",
                 help="No loader output, just DSP logging")
 ap.add_argument("-v", "--verbose", action="store_true",

--- a/soc/xtensa/intel_adsp/tools/cavstool_client.py
+++ b/soc/xtensa/intel_adsp/tools/cavstool_client.py
@@ -123,7 +123,7 @@ def main():
         client = cavstool_client(HOST, PORT, args)
         client.send_cmd(CMD_DOWNLOAD)
 
-ap = argparse.ArgumentParser(description="DSP loader/logger client tool")
+ap = argparse.ArgumentParser(description="DSP loader/logger client tool", allow_abbrev=False)
 ap.add_argument("-q", "--quiet", action="store_true",
                 help="No loader output, just DSP logging")
 ap.add_argument("-l", "--log-only", action="store_true",

--- a/soc/xtensa/intel_adsp/tools/remote-fw-service.py
+++ b/soc/xtensa/intel_adsp/tools/remote-fw-service.py
@@ -260,7 +260,7 @@ class board_config():
         return self.params
 
 
-ap = argparse.ArgumentParser(description="RemoteHW service tool")
+ap = argparse.ArgumentParser(description="RemoteHW service tool", allow_abbrev=False)
 ap.add_argument("-q", "--quiet", action="store_true",
                 help="No loader output, just DSP logging")
 ap.add_argument("-v", "--verbose", action="store_true",

--- a/tests/net/socket/udp/generate-c-string.py
+++ b/tests/net/socket/udp/generate-c-string.py
@@ -11,7 +11,7 @@ from math import ceil
 CHUNK = "This is a fragment of generated C string. "
 
 
-parser = ArgumentParser(description="Generate C string of arbitrary size")
+parser = ArgumentParser(description="Generate C string of arbitrary size", allow_abbrev=False)
 parser.add_argument("-s", "--size", help="Size of string (without NULL termination)",
                     required=True, type=int)
 parser.add_argument("filepath", help="Output filepath")


### PR DESCRIPTION
Disables allowing the python argparse library from automatically shortening command line arguments, this prevents issues whereby a new command is added and code that wrongly uses the shortened command of an existing argument which is the same as the new command being added will silently change script behaviour.

Fixes #53495

- [X] Scripts updated
- [X] Script invocations updated
- [x] Release notes added
- [X] RFC treewide change email sent
- [X] Architecture working group discussed
- [X] pylint check added to ensure additional python code isn't added that uses argparse without this
- [x] Have pylint check run in CI