### PR TITLE
twister: cmake: Add prefiltration based on cmake package helper script

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -531,6 +531,12 @@ filter: <expression>
               *<env>: any environment variable available
             }
 
+    Twister will first evaluate the expression to find if a "limited" cmake call, i.e. using package_helper cmake script,
+    can be done. Existence of "dt_*" entries indicates devicetree is needed.
+    Existence of "CONFIG*" entries indicates kconfig is needed.
+    If there are no other types of entries in the expression a filtration can be done wihout creating a complete build system.
+    If there are entries of other types a full cmake is required.
+
     The grammar for the expression language is as follows:
 
     expression ::= expression "and" expression


### PR DESCRIPTION
Twister allows filtering based on kconfigs and dts, however the filtration is a part of the cmake stage, i.e. the stage has to pass first and then twister checks if required properties are available. This causes problems, when the full cmake stage is unable to pass. If so, other filtration methods had to be used, e.g. platform_allow. The commit modifies the twister workflow:
if a test defines filters based on kconfig/dts first a cmake package helper script is used to extract dt and kconfigs and if the conditions are fulfilled  it proceeds to a regular cmake stage. If not, test is skipped.

Co-authored-by: Daniel DeGrasse <daniel.degrasse@nxp.com>
Signed-off-by: Maciej Perkowski Maciej.Perkowski@nordicsemi.no