### PR TITLE
Enforce `-` as word separator in devicetree property names

### DIFF
--- a/boards/arc/em_starterkit/em_starterkit_r23.dtsi
+++ b/boards/arc/em_starterkit/em_starterkit_r23.dtsi
@@ -34,9 +34,9 @@
 			compatible = "snps,creg-gpio";
 			reg = <0xf0000014 0x4>;
 			ngpios = <6>;
-			bit_per_gpio = <1>;
-			off_val = <0>;
-			on_val = <1>;
+			bit-per-gpio = <1>;
+			off-val = <0>;
+			on-val = <1>;
 
 			gpio-controller;
 			#gpio-cells = <2>;

--- a/boards/arm/efm32gg_slwstk6121a/efm32gg_slwstk6121a.dts
+++ b/boards/arm/efm32gg_slwstk6121a/efm32gg_slwstk6121a.dts
@@ -120,19 +120,19 @@
 
 	/* PHY management pins */
 	location-mdio        = <GECKO_LOCATION(3)>;
-	location-phy_mdc     = <GECKO_LOCATION(3) GECKO_PORT_A GECKO_PIN(6)>;
-	location-phy_mdio    = <GECKO_LOCATION(3) GECKO_PORT_A GECKO_PIN(15)>;
+	location-phy-mdc     = <GECKO_LOCATION(3) GECKO_PORT_A GECKO_PIN(6)>;
+	location-phy-mdio    = <GECKO_LOCATION(3) GECKO_PORT_A GECKO_PIN(15)>;
 
 	/* RMII interface pins */
 	location-rmii        = <GECKO_LOCATION(0)>;
-	location-rmii_refclk = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(3)>;
-	location-rmii_crs_dv = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(4)>;
-	location-rmii_txd0   = <GECKO_LOCATION(0) GECKO_PORT_E GECKO_PIN(15)>;
-	location-rmii_txd1   = <GECKO_LOCATION(0) GECKO_PORT_E GECKO_PIN(14)>;
-	location-rmii_tx_en  = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(0)>;
-	location-rmii_rxd0   = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(2)>;
-	location-rmii_rxd1   = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(1)>;
-	location-rmii_rx_er  = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(5)>;
+	location-rmii-refclk = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(3)>;
+	location-rmii-crs-dv = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(4)>;
+	location-rmii-txd0   = <GECKO_LOCATION(0) GECKO_PORT_E GECKO_PIN(15)>;
+	location-rmii-txd1   = <GECKO_LOCATION(0) GECKO_PORT_E GECKO_PIN(14)>;
+	location-rmii-tx-en  = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(0)>;
+	location-rmii-rxd0   = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(2)>;
+	location-rmii-rxd1   = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(1)>;
+	location-rmii-rx-er  = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(5)>;
 
 	status = "okay";
 };

--- a/boards/arm/efm32gg_stk3701a/efm32gg_stk3701a.dts
+++ b/boards/arm/efm32gg_stk3701a/efm32gg_stk3701a.dts
@@ -140,19 +140,19 @@
 
 	/* PHY management pins */
 	location-mdio        = <GECKO_LOCATION(1)>;
-	location-phy_mdc     = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(14)>;
-	location-phy_mdio    = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(13)>;
+	location-phy-mdc     = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(14)>;
+	location-phy-mdio    = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(13)>;
 
 	/* RMII interface pins */
 	location-rmii        = <GECKO_LOCATION(1)>;
-	location-rmii_refclk = <GECKO_LOCATION(5) GECKO_PORT_D GECKO_PIN(10)>;
-	location-rmii_crs_dv = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(11)>;
-	location-rmii_txd0   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(7)>;
-	location-rmii_txd1   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(6)>;
-	location-rmii_tx_en  = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(8)>;
-	location-rmii_rxd0   = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(9)>;
-	location-rmii_rxd1   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(9)>;
-	location-rmii_rx_er  = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(12)>;
+	location-rmii-refclk = <GECKO_LOCATION(5) GECKO_PORT_D GECKO_PIN(10)>;
+	location-rmii-crs-dv = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(11)>;
+	location-rmii-txd0   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(7)>;
+	location-rmii-txd1   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(6)>;
+	location-rmii-tx-en  = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(8)>;
+	location-rmii-rxd0   = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(9)>;
+	location-rmii-rxd1   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(9)>;
+	location-rmii-rx-er  = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(12)>;
 
 	status = "okay";
 };

--- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
+++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
@@ -70,7 +70,7 @@
 
 &i2c_smb_0 {
 	status = "okay";
-	port_sel = <0>;
+	port-sel = <0>;
 	sda-gpios = <&gpio_000_036 3 0>;
 	scl-gpios = <&gpio_000_036 4 0>;
 	pinctrl-0 = < &i2c00_scl_gpio004 &i2c00_sda_gpio003 >;
@@ -79,7 +79,7 @@
 
 &i2c_smb_1 {
 	status = "okay";
-	port_sel = <1>;
+	port-sel = <1>;
 	sda-gpios = <&gpio_100_136 24 0>;
 	scl-gpios = <&gpio_100_136 25 0>;
 	pinctrl-0 = < &i2c01_scl_gpio131 &i2c01_sda_gpio130 >;
@@ -88,9 +88,9 @@
 
 &espi0 {
 	status = "okay";
-	io_girq = <19>;
-	vw_girqs = <24 25>;
-	pc_girq = <15>;
+	io-girq = <19>;
+	vw-girqs = <24 25>;
+	pc-girq = <15>;
 	pinctrl-0 = < &espi_reset_n_gpio061 &espi_cs_n_gpio066
 		  &espi_alert_n_gpio063 &espi_clk_gpio065
 		  &espi_io0_gpio070 &espi_io1_gpio071

--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -98,7 +98,7 @@
 
 &i2c_smb_0 {
 	status = "okay";
-	port_sel = <0>;
+	port-sel = <0>;
 	sda-gpios = <&gpio_000_036 3 0>;
 	scl-gpios = <&gpio_000_036 4 0>;
 	pinctrl-0 = < &i2c00_scl_gpio004 &i2c00_sda_gpio003 >;
@@ -107,7 +107,7 @@
 
 &i2c_smb_1 {
 	status = "okay";
-	port_sel = <1>;
+	port-sel = <1>;
 	sda-gpios = <&gpio_100_136 24 0>;
 	scl-gpios = <&gpio_100_136 25 0>;
 	pinctrl-0 = < &i2c01_scl_gpio131 &i2c01_sda_gpio130 >;
@@ -132,7 +132,7 @@
 
 &i2c_smb_2 {
 	status = "okay";
-	port_sel = <7>;
+	port-sel = <7>;
 	sda-gpios = <&gpio_000_036 10 0>;
 	scl-gpios = <&gpio_000_036 11 0>;
 	pinctrl-0 = < &i2c07_scl_gpio013 &i2c07_sda_gpio012 >;
@@ -141,9 +141,9 @@
 
 &espi0 {
 	status = "okay";
-	io_girq = <19>;
-	vw_girqs = <24 25>;
-	pc_girq = <15>;
+	io-girq = <19>;
+	vw-girqs = <24 25>;
+	pc-girq = <15>;
 	pinctrl-0 = < &espi_reset_n_gpio061 &espi_cs_n_gpio066
 		  &espi_alert_n_gpio063 &espi_clk_gpio065
 		  &espi_io0_gpio070 &espi_io1_gpio071
@@ -211,8 +211,8 @@
 
 &spi0 {
 	status = "okay";
-	port_sel = <0>;
-	chip_select = <0>;
+	port-sel = <0>;
+	chip-select = <0>;
 	lines = <1>;
 	pinctrl-0 = < &shd_cs0_n_gpio055
 		      &shd_clk_gpio056

--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
@@ -138,7 +138,7 @@
 /* I2C */
 &i2c_smb_0 {
 	status = "okay";
-	port_sel = <0>;
+	port-sel = <0>;
 
 	pinctrl-0 = < &i2c00_scl_gpio004 &i2c00_sda_gpio003 >;
 	pinctrl-names = "default";
@@ -156,7 +156,7 @@
 
 &i2c_smb_1 {
 	status = "okay";
-	port_sel = <1>;
+	port-sel = <1>;
 	pinctrl-0 = <&i2c01_scl_gpio131 &i2c01_sda_gpio130>;
 	pinctrl-names = "default";
 
@@ -189,7 +189,7 @@
 
 &i2c_smb_2 {
 	status = "okay";
-	port_sel = <7>;
+	port-sel = <7>;
 	pinctrl-0 = <&i2c07_scl_gpio013 &i2c07_sda_gpio012>;
 	pinctrl-names = "default";
 };

--- a/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
+++ b/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
@@ -134,7 +134,7 @@
 /* I2C */
 &i2c_smb_0 {
 	status = "okay";
-	port_sel = <0>;
+	port-sel = <0>;
 
 	pinctrl-0 = < &i2c00_scl_gpio004 &i2c00_sda_gpio003 >;
 	pinctrl-names = "default";
@@ -168,7 +168,7 @@
 
 &i2c_smb_1 {
 	status = "okay";
-	port_sel = <1>;
+	port-sel = <1>;
 	pinctrl-0 = <&i2c01_scl_gpio131 &i2c01_sda_gpio130>;
 	pinctrl-names = "default";
 };
@@ -185,7 +185,7 @@
 
 &i2c_smb_2 {
 	status = "okay";
-	port_sel = <7>;
+	port-sel = <7>;
 	pinctrl-0 = <&i2c07_scl_gpio013 &i2c07_sda_gpio012>;
 	pinctrl-names = "default";
 };
@@ -204,8 +204,8 @@
 	status = "okay";
 	clock-frequency = <4000000>;
 	lines = <4>;
-	chip_select = <0>;
-	port_sel = <0>; /* Shared SPI */
+	chip-select = <0>;
+	port-sel = <0>; /* Shared SPI */
 
 	pinctrl-0 = < &shd_cs0_n_gpio055
 		      &shd_clk_gpio056

--- a/boards/shields/ftdi_vm800c/ftdi_vm800c.overlay
+++ b/boards/shields/ftdi_vm800c/ftdi_vm800c.overlay
@@ -19,7 +19,7 @@
 		irq-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;
 
 		pclk = <5>;
-		pclk_pol = <1>;
+		pclk-pol = <1>;
 		cspread = <1>;
 		swizzle = <0>;
 		vsize = <272>;

--- a/boards/shields/ssd1306/ssd1306_128x64_spi.overlay
+++ b/boards/shields/ssd1306/ssd1306_128x64_spi.overlay
@@ -26,7 +26,7 @@
 		segment-remap;
 		com-invdir;
 		prechargep = <0x22>;
-		data_cmd-gpios = <&arduino_header 15 0>;
+		data-cmd-gpios = <&arduino_header 15 0>;
 		/* reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>; */
 	};
 };

--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -8,7 +8,6 @@ devicetree bindings.
 
 import argparse
 from collections import defaultdict
-import glob
 import io
 import logging
 import os
@@ -202,7 +201,8 @@ def setup_logging(verbose):
 def load_relevant_bindings(dts_roots):
     # Load just the bindings we care about from dts_roots.
 
-    bindings = load_bindings(dts_roots)
+    bindings = edtlib.bindings_from_dirs(f'{root}/dts/bindings' for root in
+                                         dts_roots)
     num_total = len(bindings)
 
     # Remove bindings from the 'vnd' vendor, which is not a real vendor,
@@ -215,18 +215,6 @@ def load_relevant_bindings(dts_roots):
                 len(bindings), num_total - len(bindings), dts_roots)
 
     return bindings
-
-def load_bindings(dts_roots):
-    # Get a list of edtlib.Binding objects from searching 'dts_roots'.
-
-    binding_files = []
-    for dts_root in dts_roots:
-        binding_files.extend(glob.glob(f'{dts_root}/dts/bindings/**/*.yml',
-                                       recursive=True))
-        binding_files.extend(glob.glob(f'{dts_root}/dts/bindings/**/*.yaml',
-                                       recursive=True))
-
-    return edtlib.bindings_from_paths(binding_files, ignore_errors=True)
 
 def load_base_binding():
     # Make a Binding object for base.yaml.

--- a/dts/arc/synopsys/arc_hsdk.dtsi
+++ b/dts/arc/synopsys/arc_hsdk.dtsi
@@ -135,9 +135,9 @@
 			compatible = "snps,creg-gpio";
 			reg = <0xf00014b0 0x4>;
 			ngpios = <12>;
-			bit_per_gpio = <2>;
-			off_val = <0>;
-			on_val = <2>;
+			bit-per-gpio = <2>;
+			off-val = <0>;
+			on-val = <2>;
 
 			gpio-controller;
 			#gpio-cells = <2>;

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -478,7 +478,7 @@
 			rxdma = <11>;
 			txdma = <10>;
 			lines = <1>;
-			chip_select = <0>;
+			chip-select = <0>;
 			dcsckon = <6>;
 			dckcsoff = <4>;
 			dldh = <6>;

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -829,7 +829,7 @@
 			dma-channels = <32>;
 			dma-requests = <128>;
 			nxp,mem2mem;
-			nxp,a_on;
+			nxp,a-on;
 			reg = <0x400E8000 0x4000>,
 				<0x400EC000 0x4000>;
 			interrupts = <0 0>, <1 0>, <2 0>, <3 0>,

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -935,7 +935,7 @@
 			dma-channels = <32>;
 			dma-requests = <208>;
 			nxp,mem2mem;
-			nxp,a_on;
+			nxp,a-on;
 			reg = <0x40070000 0x4000>,
 				<0x40074000 0x4000>;
 			clocks = <&ccm IMX_CCM_EDMA_CLK 0x7C 0x000000C0>;
@@ -953,7 +953,7 @@
 			dma-channels = <32>;
 			dma-requests = <208>;
 			nxp,mem2mem;
-			nxp,a_on;
+			nxp,a-on;
 			reg = <0x40c14000 0x4000>,
 				<0x40c18000 0x4000>;
 			clocks = <&ccm IMX_CCM_EDMA_LPSR_CLK 0x7C 0x000000C0>;

--- a/dts/bindings/counter/nxp,imx-tmr.yaml
+++ b/dts/bindings/counter/nxp,imx-tmr.yaml
@@ -33,7 +33,7 @@ properties:
       - "kQTMR_SecSrcTrigPriCnt"
       - "kQTMR_CascadeCount"
 
-  primary_source:
+  primary-source:
     type: string
     required: true
     description: Primary source of the timer, see qtmr_primary_count_source_t enumerator type
@@ -56,7 +56,7 @@ properties:
       - "kQTMR_ClockDivide_64"
       - "kQTMR_ClockDivide_128"
 
-  secondary_source:
+  secondary-source:
     type: string
     description: Secondary source of the timer, see qtmr_input_source_t enumerator type
       of the MCUXpresso SDK
@@ -66,11 +66,11 @@ properties:
       - "kQTMR_Counter2InputPin"
       - "kQTMR_Counter3InputPin"
 
-  filter_count:
+  filter-count:
     type: int
     description: Fault filter count (0-255).
 
-  filter_period:
+  filter-period:
     type: int
     description: Fault filter period (0-255).
 

--- a/dts/bindings/dac/microchip,mcp4728.yaml
+++ b/dts/bindings/dac/microchip,mcp4728.yaml
@@ -8,7 +8,7 @@ properties:
   "#io-channel-cells":
     const: 1
 
-  voltage_reference:
+  voltage-reference:
     type: array
     required: true
     description: |
@@ -17,7 +17,7 @@ properties:
       1 - Internal voltage reference (2.048V)
       Note: array entries correspond to the successive channels
 
-  power_down_mode:
+  power-down-mode:
     type: array
     required: true
     description: |

--- a/dts/bindings/display/ftdi,ft800.yaml
+++ b/dts/bindings/display/ftdi,ft800.yaml
@@ -20,7 +20,7 @@ properties:
       typical main clock was 48MHz and this value is 5, the PCLK
       will be 9.6 MHz. Must be positive value to enable the screen
 
-  pclk_pol:
+  pclk-pol:
     type: int
     required: true
     description: |

--- a/dts/bindings/display/solomon,ssd1306fb-spi.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb-spi.yaml
@@ -8,7 +8,7 @@ compatible: "solomon,ssd1306fb"
 include: ["solomon,ssd1306fb-common.yaml", "spi-device.yaml"]
 
 properties:
-  data_cmd-gpios:
+  data-cmd-gpios:
     type: phandle-array
     required: true
     description: D/C# pin.

--- a/dts/bindings/dma/nxp,mcux-edma.yaml
+++ b/dts/bindings/dma/nxp,mcux-edma.yaml
@@ -24,7 +24,7 @@ properties:
     type: boolean
     description: If the DMA controller supports memory to memory transfer
 
-  nxp,a_on:
+  nxp,a-on:
     type: boolean
     description: If the DMA controller supports always on
 

--- a/dts/bindings/espi/microchip,xec-espi-saf.yaml
+++ b/dts/bindings/espi/microchip,xec-espi-saf.yaml
@@ -13,26 +13,26 @@ properties:
     description: mmio register space
     required: true
 
-  io_girq:
+  io-girq:
     type: int
     description: soc group irq index for eSPI I/O
 
-  poll_timeout:
+  poll-timeout:
     type: int
     description: poll flash busy timeout in 32KHz periods
 
-  poll_interval:
+  poll-interval:
     type: int
     description: interval between flash busy poll in 20 ns units
 
-  consec_rd_timeout:
+  consec-rd-timeout:
     type: int
     description: timeout after last read to resume supended operations in 20 ns units
 
-  sus_chk_delay:
+  sus-chk-delay:
     type: int
     description: hold off poll after suspend in 20 ns units
 
-  sus_rsm_interval:
+  sus-rsm-interval:
     type: int
     description: force suspended erase or program to resume in 32KHz periods

--- a/dts/bindings/espi/microchip,xec-espi.yaml
+++ b/dts/bindings/espi/microchip,xec-espi.yaml
@@ -12,17 +12,17 @@ properties:
     description: mmio register space
     required: true
 
-  io_girq:
+  io-girq:
     type: int
     description: soc group irq index for eSPI I/O
     required: true
 
-  vw_girqs:
+  vw-girqs:
     type: array
     description: soc group irq indexes for eSPI virtual wires channel
     required: true
 
-  pc_girq:
+  pc-girq:
     type: int
     description: soc group irq index for eSPI peripheral channel
     required: true

--- a/dts/bindings/ethernet/silabs,gecko-ethernet.yaml
+++ b/dts/bindings/ethernet/silabs,gecko-ethernet.yaml
@@ -36,66 +36,66 @@ properties:
     description: location of MDC and MDIO pins, configuration defined as <location>
 
   # PHY management pins
-  location-phy_mdc:
+  location-phy-mdc:
     type: array
     required: true
     description: PHY MDC individual pin configuration defined as <location port pin>
 
-  location-phy_mdio:
+  location-phy-mdio:
     type: array
     required: true
     description: PHY MDIO individual pin configuration defined as <location port pin>
 
   # RMII interface pins
-  location-rmii_refclk:
+  location-rmii-refclk:
     type: array
     required: true
     description: Reference clock individual pin configuration defined as <location port pin>
 
-  location-rmii_crs_dv:
+  location-rmii-crs-dv:
     type: array
     required: true
     description: Receive data valid individual pin configuration defined as <location port pin>
 
-  location-rmii_txd0:
+  location-rmii-txd0:
     type: array
     required: true
     description: Transmit data 0 individual pin configuration defined as <location port pin>
 
-  location-rmii_txd1:
+  location-rmii-txd1:
     type: array
     required: true
     description: Transmit data 1 individual pin configuration defined as <location port pin>
 
-  location-rmii_tx_en:
+  location-rmii-tx-en:
     type: array
     required: true
     description: Transmit enable individual pin configuration defined as <location port pin>
 
-  location-rmii_rxd0:
+  location-rmii-rxd0:
     type: array
     required: true
     description: Receive data 0 individual pin configuration defined as <location port pin>
 
-  location-rmii_rxd1:
+  location-rmii-rxd1:
     type: array
     required: true
     description: Receive data 1 individual pin configuration defined as <location port pin>
 
-  location-rmii_rx_er:
+  location-rmii-rx-er:
     type: array
     required: true
     description: Receive error individual pin configuration defined as <location port pin>
 
   # PHY control pins
-  location-phy_pwr_enable:
+  location-phy-pwr-enable:
     type: array
     description: PHY power enable individual pin configuration defined as <port pin>
 
-  location-phy_reset:
+  location-phy-reset:
     type: array
     description: PHY reset individual pin configuration defined as <port pin>
 
-  location-phy_interrupt:
+  location-phy-interrupt:
     type: array
     description: PHY interrupt individual pin configuration defined as <port pin>

--- a/dts/bindings/gpio/nuvoton,nct38xx-gpio-port.yaml
+++ b/dts/bindings/gpio/nuvoton,nct38xx-gpio-port.yaml
@@ -11,7 +11,7 @@ properties:
   reg:
     required: true
 
-  pin_mask:
+  pin-mask:
     type: int
     required: true
     description: |
@@ -21,7 +21,7 @@ properties:
       NCT3808: <0xdc>
       others: <0xff>
 
-  pinmux_mask:
+  pinmux-mask:
     type: int
     description: |
       NCT38XX series port 0 has Pin Multiplexing functionality. However, not

--- a/dts/bindings/gpio/snps,creg-gpio.yaml
+++ b/dts/bindings/gpio/snps,creg-gpio.yaml
@@ -11,15 +11,15 @@ properties:
   reg:
     required: true
 
-  bit_per_gpio:
+  bit-per-gpio:
     type: int
     required: true
 
-  off_val:
+  off-val:
     type: int
     required: true
 
-  on_val:
+  on-val:
     type: int
     required: true
 

--- a/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
@@ -11,7 +11,7 @@ properties:
   reg:
     required: true
 
-  port_sel:
+  port-sel:
     type: int
     description: soc block mapping to pin
     required: true

--- a/dts/bindings/i2c/microchip,xec-i2c.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c.yaml
@@ -11,7 +11,7 @@ properties:
   reg:
     required: true
 
-  port_sel:
+  port-sel:
     type: int
     description: soc block mapping to pin
     required: true

--- a/dts/bindings/i2s/litex,i2s.yaml
+++ b/dts/bindings/i2s/litex,i2s.yaml
@@ -13,6 +13,6 @@ properties:
   reg:
     required: true
 
-  fifo_depth:
+  fifo-depth:
     type: int
     required: true

--- a/dts/bindings/led/ti,lp503x.yaml
+++ b/dts/bindings/led/ti,lp503x.yaml
@@ -8,11 +8,11 @@ compatible: "ti,lp503x"
 include: ["i2c-device.yaml", "led-controller.yaml"]
 
 properties:
-  max_curr_opt:
+  max-curr-opt:
     type: boolean
     description: |
       If enabled the maximum current output is set to 35 mA (25.5 mA else).
-  log_scale_en:
+  log-scale-en:
     type: boolean
     description: |
       If enabled a logarithmic dimming scale curve is used for LED brightness

--- a/dts/bindings/sdhc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/sdhc/nxp,imx-usdhc.yaml
@@ -29,7 +29,7 @@ properties:
     description: |
       Number of words used as write watermark level in FIFO queue for USDHC
 
-  max_current_330:
+  max-current-330:
     type: int
     default: 0
     description: |

--- a/dts/bindings/spi/microchip,xec-qmspi.yaml
+++ b/dts/bindings/spi/microchip,xec-qmspi.yaml
@@ -11,7 +11,7 @@ properties:
   reg:
     required: true
 
-  port_sel:
+  port-sel:
     type: int
     required: true
     description: SPI Port 0 or 1.
@@ -37,7 +37,7 @@ properties:
     required: true
     description: QMSPI lines 1, 2, or 4
 
-  chip_select:
+  chip-select:
     type: int
     required: true
     description: Use QMSPI CS0# or CS1#

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -228,7 +228,7 @@
 				"rx_stat",
 				"rx_conf",
 				"fifo";
-			fifo_depth = <256>;
+			fifo-depth = <256>;
 			status = "disabled";
 		};
 		i2s_tx: i2s_tx@e000b000 {
@@ -251,7 +251,7 @@
 				"tx_stat",
 				"tx_conf",
 				"fifo";
-			fifo_depth = <256>;
+			fifo-depth = <256>;
 			status = "disabled";
 		};
 		clock-outputs {

--- a/samples/boards/nrf/dynamic_pinctrl/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/boards/nrf/dynamic_pinctrl/boards/nrf52840dk_nrf52840.overlay
@@ -5,8 +5,8 @@
 
 / {
 	zephyr,user {
-		uart0_alt_default = <&uart0_alt_default>;
-		uart0_alt_sleep = <&uart0_alt_sleep>;
+		uart0-alt-default = <&uart0_alt_default>;
+		uart0-alt-sleep = <&uart0_alt_sleep>;
 	};
 };
 

--- a/samples/drivers/espi/boards/mec1501modular_assy6885.overlay
+++ b/samples/drivers/espi/boards/mec1501modular_assy6885.overlay
@@ -16,8 +16,8 @@
 
 &spi0 {
 	status = "okay";
-	port_sel = <0>;
-	chip_select = <0>;
+	port-sel = <0>;
+	chip-select = <0>;
 	lines = <4>;
 	pinctrl-0 = < &shd_cs0_n_gpio055
 		      &shd_clk_gpio056

--- a/samples/drivers/espi/boards/mec15xxevb_assy6853.overlay
+++ b/samples/drivers/espi/boards/mec15xxevb_assy6853.overlay
@@ -20,7 +20,7 @@
 
 &spi0 {
 	status = "okay";
-	port_sel = <0>;
-	chip_select = <0>;
+	port-sel = <0>;
+	chip-select = <0>;
 	lines = <4>;
 };

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -227,7 +227,7 @@ class CheckPatch(ComplianceTest):
                            stdin=diff.stdout,
                            stdout=subprocess.PIPE,
                            stderr=subprocess.STDOUT,
-                           shell=True, cwd=GIT_TOP)
+                           shell=True)
 
         except subprocess.CalledProcessError as ex:
             output = ex.output.decode("utf-8")
@@ -738,7 +738,7 @@ class Nits(ComplianceTest):
     def check_kconfig_header(self, fname):
         # Checks for a spammy copy-pasted header format
 
-        with open(os.path.join(GIT_TOP, fname), encoding="utf-8") as f:
+        with open(fname, encoding="utf-8") as f:
             contents = f.read()
 
         # 'Kconfig - yada yada' has a copy-pasted redundant filename at the
@@ -764,7 +764,7 @@ failure.
         # Checks for 'source "$(ZEPHYR_BASE)/Kconfig[.zephyr]"', which can be
         # be simplified to 'source "Kconfig[.zephyr]"'
 
-        with open(os.path.join(GIT_TOP, fname), encoding="utf-8") as f:
+        with open(fname, encoding="utf-8") as f:
             # Look for e.g. rsource as well, for completeness
             match = re.search(
                 r'^\s*(?:o|r|or)?source\s*"\$\(?ZEPHYR_BASE\)?/(Kconfig(?:\.zephyr)?)"',
@@ -779,7 +779,7 @@ and all 'source's are relative to it.""".format(match.group(1), fname))
     def check_redundant_document_separator(self, fname):
         # Looks for redundant '...' document separators in bindings
 
-        with open(os.path.join(GIT_TOP, fname), encoding="utf-8") as f:
+        with open(fname, encoding="utf-8") as f:
             if re.search(r"^\.\.\.", f.read(), re.MULTILINE):
                 self.failure(f"""\
 Redundant '...' document separator in {fname}. Binding YAML files are never
@@ -788,7 +788,7 @@ concatenated together, so no document separators are needed.""")
     def check_source_file(self, fname):
         # Generic nits related to various source files
 
-        with open(os.path.join(GIT_TOP, fname), encoding="utf-8") as f:
+        with open(fname, encoding="utf-8") as f:
             contents = f.read()
 
         if not contents.endswith("\n"):
@@ -819,7 +819,7 @@ class GitLint(ComplianceTest):
                            check=True,
                            stdout=subprocess.PIPE,
                            stderr=subprocess.STDOUT,
-                           shell=True, cwd=GIT_TOP)
+                           shell=True)
 
         except subprocess.CalledProcessError as ex:
             self.failure(ex.output.decode("utf-8"))
@@ -843,9 +843,9 @@ class PyLint(ComplianceTest):
         files = get_files(filter="d")
 
         # Filter out everything but Python files. Keep filenames
-        # relative (to GIT_TOP) to stay farther from any command line
+        # relative (to <git-top>) to stay farther from any command line
         # limit.
-        py_files = filter_py(GIT_TOP, files)
+        py_files = filter_py(str(Path.cwd()), files)
         if not py_files:
             return
 
@@ -855,8 +855,7 @@ class PyLint(ComplianceTest):
             subprocess.run(pylintcmd,
                            check=True,
                            stdout=subprocess.PIPE,
-                           stderr=subprocess.STDOUT,
-                           cwd=GIT_TOP)
+                           stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as ex:
             output = ex.output.decode("utf-8")
             regex = r'^\s*(\S+):(\d+):(\d+):\s*([A-Z]\d{4}):\s*(.*)$'

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -25,7 +25,14 @@ import magic
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from get_maintainer import Maintainers, MaintainersError
 
+HERE = Path(__file__).parent
+
 logger = None
+
+# This ends up using the current repository if ZEPHYR_BASE is unset.
+ZEPHYR_BASE = (os.environ.get('ZEPHYR_BASE') or
+               str((HERE / '..' / '..').resolve()))
+os.environ['ZEPHYR_BASE'] = ZEPHYR_BASE
 
 def git(*args, cwd=None):
     # Helper for running a Git command. Returns the rstrip()ed stdout output.

--- a/scripts/ci/check_compliance_ok_properties.yaml
+++ b/scripts/ci/check_compliance_ok_properties.yaml
@@ -1,0 +1,9 @@
+# This file is a YAML list of property names that are OK to contain
+# underscores because they are from upstream Linux or some other
+# authoritative source.
+#
+# Otherwise, the preferred word separator in DT property names is '-',
+# not '_'.
+
+- mmc-hs200-1_8v
+- mmc-hs400-1_8v

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -272,40 +272,6 @@ class EDT:
         except Exception as e:
             raise EDTError(e)
 
-    def _init_graph(self):
-        # Constructs a graph of dependencies between Node instances,
-        # which is usable for computing a partial order over the dependencies.
-        # The algorithm supports detecting dependency loops.
-        #
-        # Actually computing the SCC order is lazily deferred to the
-        # first time the scc_order property is read.
-
-        self._graph = Graph()
-
-        for node in self.nodes:
-            # A Node always depends on its parent.
-            for child in node.children.values():
-                self._graph.add_edge(child, node)
-
-            # A Node depends on any Nodes present in 'phandle',
-            # 'phandles', or 'phandle-array' property values.
-            for prop in node.props.values():
-                if prop.type == 'phandle':
-                    self._graph.add_edge(node, prop.val)
-                elif prop.type == 'phandles':
-                    for phandle_node in prop.val:
-                        self._graph.add_edge(node, phandle_node)
-                elif prop.type == 'phandle-array':
-                    for cd in prop.val:
-                        if cd is None:
-                            continue
-                        self._graph.add_edge(node, cd.controller)
-
-            # A Node depends on whatever supports the interrupts it
-            # generates.
-            for intr in node.interrupts:
-                self._graph.add_edge(node, intr.controller)
-
     def _init_compat2binding(self):
         # Creates self._compat2binding, a dictionary that maps
         # (<compatible>, <bus>) tuples (both strings) to Binding objects.
@@ -449,6 +415,40 @@ class EDT:
                     _LOG.warning("unit address and first address in 'reg' "
                                  f"(0x{node.regs[0].addr:x}) don't match for "
                                  f"{node.path}")
+
+    def _init_graph(self):
+        # Constructs a graph of dependencies between Node instances,
+        # which is usable for computing a partial order over the dependencies.
+        # The algorithm supports detecting dependency loops.
+        #
+        # Actually computing the SCC order is lazily deferred to the
+        # first time the scc_order property is read.
+
+        self._graph = Graph()
+
+        for node in self.nodes:
+            # A Node always depends on its parent.
+            for child in node.children.values():
+                self._graph.add_edge(child, node)
+
+            # A Node depends on any Nodes present in 'phandle',
+            # 'phandles', or 'phandle-array' property values.
+            for prop in node.props.values():
+                if prop.type == 'phandle':
+                    self._graph.add_edge(node, prop.val)
+                elif prop.type == 'phandles':
+                    for phandle_node in prop.val:
+                        self._graph.add_edge(node, phandle_node)
+                elif prop.type == 'phandle-array':
+                    for cd in prop.val:
+                        if cd is None:
+                            continue
+                        self._graph.add_edge(node, cd.controller)
+
+            # A Node depends on whatever supports the interrupts it
+            # generates.
+            for intr in node.interrupts:
+                self._graph.add_edge(node, intr.controller)
 
     def _init_luts(self):
         # Initialize node lookup tables (LUTs).

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -490,11 +490,7 @@ class EDT:
                     # compatibles it wants. Other nodes get checked.
                     elif node.path != '/' and \
                        vendor not in _VENDOR_PREFIX_ALLOWED:
-                        if self._werror:
-                            handler_fn = _err
-                        else:
-                            handler_fn = _LOG.warning
-                        handler_fn(
+                        self._warning(
                             f"node '{node.path}' compatible '{compat}' "
                             f"has unknown vendor prefix '{vendor}'")
 
@@ -542,6 +538,11 @@ class EDT:
                 # This is also just for future-proofing.
                 assert isinstance(compat, str)
 
+    def _warning(self, msg):
+        if self._werror:
+            _err(msg)
+        else:
+            _LOG.warning(msg)
 
 class Node:
     """

--- a/tests/boards/mec15xxevb_assy6853/qspi/boards/mec15xxevb_assy6853.overlay
+++ b/tests/boards/mec15xxevb_assy6853/qspi/boards/mec15xxevb_assy6853.overlay
@@ -6,7 +6,7 @@
 
 &spi0 {
         status = "okay";
-        port_sel = <0>;
-        chip_select = <0>;
+        port-sel = <0>;
+        chip-select = <0>;
         lines = <4>;
 };

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -105,8 +105,8 @@
 					gpio-controller;
 					#gpio-cells = <2>;
 					ngpios = <8>;
-					pin_mask = <0xff>;
-					pinmux_mask = <0xf7>;
+					pin-mask = <0xff>;
+					pinmux-mask = <0xf7>;
 				};
 
 				gpio@1 {
@@ -115,7 +115,7 @@
 					gpio-controller;
 					#gpio-cells = <2>;
 					ngpios = <8>;
-					pin_mask = <0xff>;
+					pin-mask = <0xff>;
 				};
 			};
 
@@ -131,8 +131,8 @@
 					gpio-controller;
 					#gpio-cells = <2>;
 					ngpios = <8>;
-					pin_mask = <0xdc>;
-					pinmux_mask = <0xff>;
+					pin-mask = <0xdc>;
+					pinmux-mask = <0xff>;
 				};
 			};
 
@@ -148,8 +148,8 @@
 					gpio-controller;
 					#gpio-cells = <2>;
 					ngpios = <8>;
-					pin_mask = <0xdc>;
-					pinmux_mask = <0xff>;
+					pin-mask = <0xdc>;
+					pinmux-mask = <0xff>;
 				};
 			};
 

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1060_evk.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1060_evk.overlay
@@ -1,5 +1,5 @@
 &qtmr1_timer0 {
 	status = "okay";
-	primary_source = "kQTMR_ClockDivide_128";
+	primary-source = "kQTMR_ClockDivide_128";
 	mode = "kQTMR_PriSrcRiseEdge";
 };

--- a/tests/drivers/pinctrl/api/app.overlay
+++ b/tests/drivers/pinctrl/api/app.overlay
@@ -70,8 +70,8 @@
 	};
 
 	zephyr,user {
-		test_device0_alt_default = <&test_device0_alt_default>;
-		test_device0_alt_sleep = <&test_device0_alt_sleep>;
+		test-device0-alt-default = <&test_device0_alt_default>;
+		test-device0-alt-sleep = <&test_device0_alt_sleep>;
 	};
 
 	test_device0: test_device@0 {


### PR DESCRIPTION
Fixes: #53506

This tree-wide change cleans up existing property names which use `_` instead of `-`, and adds a CI check to avoid new ones from creeping in. This requires a little bit of prep work to add a helper function to edtlib to make the check easier to write.

I found a few issues in check_compliance.py while I was adding this that I took the time to fix while I was here.