### PR TITLE
dma: Start/stop behavioral contract

### DIFF
--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -417,6 +417,13 @@ out:
 	return ret;
 }
 
+bool dw_dma_is_enabled(const struct device *dev, uint32_t channel)
+{
+	const struct dw_dma_dev_cfg *const dev_cfg = dev->config;
+
+	return dw_read(dev_cfg->base, DW_DMA_CHAN_EN) & DW_CHAN_MASK(channel);
+}
+
 int dw_dma_start(const struct device *dev, uint32_t channel)
 {
 	const struct dw_dma_dev_cfg *const dev_cfg = dev->config;
@@ -426,6 +433,10 @@ int dw_dma_start(const struct device *dev, uint32_t channel)
 	/* validate channel */
 	if (channel >= DW_MAX_CHAN) {
 		ret = -EINVAL;
+		goto out;
+	}
+
+	if (dw_dma_is_enabled(dev, channel)) {
 		goto out;
 	}
 
@@ -510,6 +521,10 @@ int dw_dma_stop(const struct device *dev, uint32_t channel)
 
 	if (channel >= DW_MAX_CHAN) {
 		ret = -EINVAL;
+		goto out;
+	}
+
+	if (!dw_dma_is_enabled(dev, channel)) {
 		goto out;
 	}
 

--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -230,6 +230,10 @@ int intel_adsp_hda_dma_start(const struct device *dev, uint32_t channel)
 
 	__ASSERT(channel < cfg->dma_channels, "Channel does not exist");
 
+	if (intel_adsp_hda_is_enabled(cfg->base, cfg->regblock_size, channel)) {
+		return 0;
+	}
+
 	intel_adsp_hda_enable(cfg->base, cfg->regblock_size, channel);
 	if (cfg->direction == MEMORY_TO_PERIPHERAL) {
 		size = intel_adsp_hda_get_buffer_size(cfg->base, cfg->regblock_size, channel);
@@ -244,6 +248,10 @@ int intel_adsp_hda_dma_stop(const struct device *dev, uint32_t channel)
 	const struct intel_adsp_hda_dma_cfg *const cfg = dev->config;
 
 	__ASSERT(channel < cfg->dma_channels, "Channel does not exist");
+
+	if (!intel_adsp_hda_is_enabled(cfg->base, cfg->regblock_size, channel)) {
+		return 0;
+	}
 
 	intel_adsp_hda_disable(cfg->base, cfg->regblock_size, channel);
 

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -375,6 +375,9 @@ static inline int dma_reload(const struct device *dev, uint32_t channel,
  * Implementations must check the validity of the channel ID passed in and
  * return -EINVAL if it is invalid.
  *
+ * Start is allowed on channels that have already been started and must report
+ * success.
+ *
  * @param dev     Pointer to the device structure for the driver instance.
  * @param channel Numeric identification of the channel where the transfer will
  *                be processed
@@ -397,6 +400,9 @@ static inline int z_impl_dma_start(const struct device *dev, uint32_t channel)
  *
  * Implementations must check the validity of the channel ID passed in and
  * return -EINVAL if it is invalid.
+ *
+ * Stop is allowed on channels that have already been stopped and must report
+ * success.
  *
  * @param dev     Pointer to the device structure for the driver instance.
  * @param channel Numeric identification of the channel where the transfer was

--- a/soc/xtensa/intel_adsp/common/include/intel_adsp_hda.h
+++ b/soc/xtensa/intel_adsp/common/include/intel_adsp_hda.h
@@ -225,6 +225,20 @@ static inline void intel_adsp_hda_disable(uint32_t base, uint32_t regblock_size,
 	*DGCS(base, regblock_size, sid) &= ~(DGCS_GEN | DGCS_FIFORDY);
 }
 
+
+/**
+ * @brief Check if stream is enabled
+ *
+ * @param base Base address of the IP register block
+ * @param regblock_size Register block size
+ * @param sid Stream ID
+ */
+static inline bool intel_adsp_hda_is_enabled(uint32_t base, uint32_t regblock_size, uint32_t sid)
+{
+	return *DGCS(base, regblock_size, sid) & (DGCS_GEN | DGCS_FIFORDY);
+}
+
+
 /**
  * @brief Determine the number of unused bytes in the buffer
  *

--- a/soc/xtensa/intel_adsp/common/include/intel_adsp_hda.h
+++ b/soc/xtensa/intel_adsp/common/include/intel_adsp_hda.h
@@ -118,7 +118,7 @@
 /**
  * @brief Initialize an HDA stream for use with the firmware
  *
- * @param hda Stream set to work with
+ * @param base Base address of the IP register block
  * @param sid Stream ID
  */
 static inline void intel_adsp_hda_init(uint32_t base, uint32_t regblock_size, uint32_t sid)
@@ -136,7 +136,7 @@ static inline void intel_adsp_hda_init(uint32_t base, uint32_t regblock_size, ui
  * that is required. It must be set *after* the host has configured its own buffers.
  *
  *
- * @param hda Stream set to work with
+ * @param base Base address of the IP register block
  * @param regblock_size Register block size
  * @param sid Stream ID
  * @param buf Buffer address to use for the shared FIFO. Must be in L2 and 128 byte aligned.
@@ -187,7 +187,7 @@ static inline int intel_adsp_hda_set_buffer(uint32_t base,
 /**
  * @brief Get the buffer size
  *
- * @param hda Stream set to work with
+ * @param base Base address of the IP register block
  * @param regblock_size Register block size
  * @param sid Stream ID
  *
@@ -197,14 +197,13 @@ static inline uint32_t intel_adsp_hda_get_buffer_size(uint32_t base,
 					    uint32_t regblock_size,
 					    uint32_t sid)
 {
-
 	return *DGBS(base, regblock_size, sid);
 }
 
 /**
  * @brief Enable the stream
  *
- * @param hda HDA stream set
+ * @param base Base address of the IP register block
  * @param regblock_size Register block size
  * @param sid Stream ID
  */
@@ -216,7 +215,7 @@ static inline void intel_adsp_hda_enable(uint32_t base, uint32_t regblock_size, 
 /**
  * @brief Disable stream
  *
- * @param hda HDA stream set
+ * @param base Base address of the IP register block
  * @param regblock_size Register block size
  * @param sid Stream ID
  */

--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -339,6 +339,108 @@ static int test_loop_suspend_resume(void)
 }
 
 
+static int test_loop_repeated_start_stop(void)
+{
+	const struct device *dma;
+	static int chan_id;
+
+	test_case_id = 0;
+	TC_PRINT("DMA memory to memory transfer started\n");
+	TC_PRINT("Preparing DMA Controller\n");
+
+#if CONFIG_NOCACHE_MEMORY
+	memset(tx_data, 0, sizeof(tx_data));
+	memcpy(tx_data, TX_DATA, sizeof(TX_DATA));
+#endif
+
+	memset(rx_data, 0, sizeof(rx_data));
+
+	dma = DEVICE_DT_GET(DT_NODELABEL(test_dma));
+	if (!device_is_ready(dma)) {
+		TC_PRINT("dma controller device is not ready\n");
+		return TC_FAIL;
+	}
+
+	dma_cfg.channel_direction = MEMORY_TO_MEMORY;
+	dma_cfg.source_data_size = 1U;
+	dma_cfg.dest_data_size = 1U;
+	dma_cfg.source_burst_length = 1U;
+	dma_cfg.dest_burst_length = 1U;
+#ifdef CONFIG_DMAMUX_STM32
+	dma_cfg.user_data = (void *)dma;
+#else
+	dma_cfg.user_data = NULL;
+#endif /* CONFIG_DMAMUX_STM32 */
+	dma_cfg.dma_callback = dma_user_callback;
+	dma_cfg.block_count = 1U;
+	dma_cfg.head_block = &dma_block_cfg;
+
+#ifdef CONFIG_DMA_MCUX_TEST_SLOT_START
+	dma_cfg.dma_slot = CONFIG_DMA_MCUX_TEST_SLOT_START;
+#endif
+
+	chan_id = dma_request_channel(dma, NULL);
+	if (chan_id < 0) {
+		TC_PRINT("this platform do not support the dma channel\n");
+		chan_id = CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR;
+	}
+	transfer_count = 0;
+	done = 0;
+	TC_PRINT("Starting the transfer on channel %d and waiting for 1 second\n", chan_id);
+	dma_block_cfg.block_size = strlen(tx_data);
+	dma_block_cfg.source_address = (uint32_t)tx_data;
+	dma_block_cfg.dest_address = (uint32_t)rx_data[transfer_count];
+
+	if (dma_config(dma, chan_id, &dma_cfg)) {
+		TC_PRINT("ERROR: transfer config (%d)\n", chan_id);
+		return TC_FAIL;
+	}
+
+	if (dma_stop(dma, chan_id)) {
+		TC_PRINT("ERROR: transfer stop on stopped channel (%d)\n", chan_id);
+		return TC_FAIL;
+	}
+
+	if (dma_start(dma, chan_id)) {
+		TC_PRINT("ERROR: transfer start (%d)\n", chan_id);
+		return TC_FAIL;
+	}
+
+	k_sleep(K_MSEC(SLEEPTIME));
+
+	if (transfer_count < TRANSFER_LOOPS) {
+		transfer_count = TRANSFER_LOOPS;
+		TC_PRINT("ERROR: unfinished transfer\n");
+		if (dma_stop(dma, chan_id)) {
+			TC_PRINT("ERROR: transfer stop\n");
+		}
+		return TC_FAIL;
+	}
+
+	TC_PRINT("Each RX buffer should contain the full TX buffer string.\n");
+
+	for (int i = 0; i < TRANSFER_LOOPS; i++) {
+		TC_PRINT("RX data Loop %d: %s\n", i, rx_data[i]);
+		if (strncmp(tx_data, rx_data[i], sizeof(rx_data[i])) != 0) {
+			return TC_FAIL;
+		}
+	}
+
+	TC_PRINT("Finished: DMA\n");
+
+	if (dma_stop(dma, chan_id)) {
+		TC_PRINT("ERROR: transfer stop (%d)\n", chan_id);
+		return TC_FAIL;
+	}
+
+	if (dma_stop(dma, chan_id)) {
+		TC_PRINT("ERROR: repeated transfer stop (%d)\n", chan_id);
+		return TC_FAIL;
+	}
+
+	return TC_PASS;
+}
+
 /* export test cases */
 ZTEST(dma_m2m_loop, test_dma_m2m_loop)
 {
@@ -349,4 +451,10 @@ ZTEST(dma_m2m_loop, test_dma_m2m_loop)
 ZTEST(dma_m2m_loop, test_dma_m2m_loop_suspend_resume)
 {
 	zassert_true((test_loop_suspend_resume() == TC_PASS));
+}
+
+/* export test cases */
+ZTEST(dma_m2m_loop, test_dma_m2m_loop_repeated_start_stop)
+{
+	zassert_true((test_loop_repeated_start_stop() == TC_PASS));
 }


### PR DESCRIPTION
Further specifies the behavioral contract for start/stop to be callable regardless of the channel status.