### PR TITLE
drivers: clock_control: esp32: fix cpu_freq divisor typo.

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -476,7 +476,7 @@ static const struct clock_control_driver_api clock_control_esp32_api = {
 
 static const struct esp32_clock_config esp32_clock_config0 = {
 	.clk_src_sel = ESP32_CLOCK_SOURCE,
-	.cpu_freq = DT_PROP(DT_INST(0, DT_CPU_COMPAT), clock_frequency) / 10000000,
+	.cpu_freq = DT_PROP(DT_INST(0, DT_CPU_COMPAT), clock_frequency) / 1000000,
 	.xtal_freq_sel = DT_INST_PROP(0, xtal_freq),
 	.xtal_div = ESP32_CLOCK_XTAL_DIV
 };


### PR DESCRIPTION
Current divisor is 10,000,000 (should be 1,000,000).

For example, ESP32_CLK_CPU_240M / 10000000 == 24 MHz (incorrect).

Signed-off-by: Chris Wilson <christopher.david.wilson@gmail.com>