### PR TITLE
dts: can: add can support for stm32f412 and stm32f413

### DIFF
--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -183,5 +183,29 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000002>;
 			status = "disabled";
 		};
+
+		can1: can@40006400 {
+			compatible = "st,stm32-can";
+			reg = <0x40006400 0x400>;
+			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
+			interrupt-names = "TX", "RX0", "RX1", "SCE";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
+			status = "disabled";
+			sjw = <1>;
+			sample-point = <875>;
+		};
+
+		can2: can@40006800 {
+			compatible = "st,stm32-can";
+			reg = <0x40006800 0x400>;
+			interrupts = <63 0>, <64 0>, <65 0>, <66 0>;
+			interrupt-names = "TX", "RX0", "RX1", "SCE";
+			/* also enabling clock for can1 (master instance) */
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x06000000>;
+			master-can-reg = <0x40006400>;
+			status = "disabled";
+			sjw = <1>;
+			sample-point = <875>;
+		};
 	};
 };

--- a/dts/arm/st/f4/stm32f413.dtsi
+++ b/dts/arm/st/f4/stm32f413.dtsi
@@ -69,5 +69,16 @@
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
+
+		can3: can@40006c00 {
+			compatible = "st,stm32-can";
+			reg = <0x40006c00 0x400>;
+			interrupts = <74 0>, <75 0>, <76 0>, <77 0>;
+			interrupt-names = "TX", "RX0", "RX1", "SCE";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x08000000>;
+			status = "disabled";
+			sjw = <1>;
+			sample-point = <875>;
+		};
 	};
 };


### PR DESCRIPTION
STMF412 and STM32F413 did not support CAN bus in Zephyr yet. This adds the device tree entries to be able to use all 2, resp. 3 CAN controllers.

Signed-off-by: Tom Stirnkorb <tom@stirnkorb.me>