### PR TITLE
boards: stm32: fix --reset argument for stm32cubeprogrammer runner

### DIFF
--- a/boards/arm/b_g474e_dpow1/board.cmake
+++ b/boards/arm/b_g474e_dpow1/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 

--- a/boards/arm/b_u585i_iot02a/board.cmake
+++ b/boards/arm/b_u585i_iot02a/board.cmake
@@ -12,8 +12,8 @@ if(CONFIG_BUILD_WITH_TFM)
   endif()
 endif()
 
-board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset=hw")
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 board_runner_args(openocd "--tcl-port=6666")
 board_runner_args(openocd --cmd-pre-init "gdb_report_data_abort enable")

--- a/boards/arm/lora_e5_dev_board/board.cmake
+++ b/boards/arm/lora_e5_dev_board/board.cmake
@@ -4,7 +4,7 @@ board_runner_args(pyocd "--target=stm32wle5jcix")
 board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
 board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 board_runner_args(jlink "--device=STM32WLE5JC" "--speed=4000" "--reset-after-load")
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(blackmagicprobe "--gdb-serial=/dev/ttyBmpGdb" "--connect-srst")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nucleo_g071rb/board.cmake
+++ b/boards/arm/nucleo_g071rb/board.cmake
@@ -3,7 +3,7 @@ board_runner_args(pyocd "--target=stm32g071rbtx")
 board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
 board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 board_runner_args(jlink "--device=STM32G071RB" "--speed=4000")
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nucleo_g0b1re/board.cmake
+++ b/boards/arm/nucleo_g0b1re/board.cmake
@@ -5,7 +5,7 @@ board_runner_args(pyocd "--target=stm32g071rbtx")
 board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
 board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 board_runner_args(jlink "--device=STM32G0B1RE" "--speed=4000")
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_h723zg/board.cmake
+++ b/boards/arm/nucleo_h723zg/board.cmake
@@ -2,7 +2,7 @@
 
 board_runner_args(jlink "--device=STM32H723ZG" "--speed=4000")
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_h743zi/board.cmake
+++ b/boards/arm/nucleo_h743zi/board.cmake
@@ -3,7 +3,7 @@
 board_runner_args(openocd --cmd-post-verify "reset halt")
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 board_runner_args(jlink "--device=STM32H743ZI" "--speed=4000")
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_h753zi/board.cmake
+++ b/boards/arm/nucleo_h753zi/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=STM32H753ZI" "--speed=4000")
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_h7a3zi_q/board.cmake
+++ b/boards/arm/nucleo_h7a3zi_q/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=STM32H7A3ZI" "--speed=4000")
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_l073rz/board.cmake
+++ b/boards/arm/nucleo_l073rz/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=STM32L073RZ" "--speed=4000")
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_u575zi_q/board.cmake
+++ b/boards/arm/nucleo_u575zi_q/board.cmake
@@ -1,5 +1,5 @@
-board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset=hw")
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 board_runner_args(openocd "--tcl-port=6666")
 board_runner_args(openocd --cmd-pre-init "gdb_report_data_abort enable")

--- a/boards/arm/nucleo_wb55rg/board.cmake
+++ b/boards/arm/nucleo_wb55rg/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 board_runner_args(pyocd "--target=stm32wb55rgvx")
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nucleo_wl55jc/board.cmake
+++ b/boards/arm/nucleo_wl55jc/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)

--- a/boards/arm/stm32f3_disco/board.cmake
+++ b/boards/arm/stm32f3_disco/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=STM32F303VC" "--speed=4000")
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32g0316_disco/board.cmake
+++ b/boards/arm/stm32g0316_disco/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 board_runner_args(pyocd "--target=stm32g031j6mx")
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(jlink "--device=STM32G031J6" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/stm32g071b_disco/board.cmake
+++ b/boards/arm/stm32g071b_disco/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 

--- a/boards/arm/stm32g081b_eval/board.cmake
+++ b/boards/arm/stm32g081b_eval/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 

--- a/boards/arm/stm32l562e_dk/board.cmake
+++ b/boards/arm/stm32l562e_dk/board.cmake
@@ -14,7 +14,7 @@ endif()
 
 
 board_runner_args(pyocd "--target=stm32l562qeixq")
-board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)


### PR DESCRIPTION
stm32cubeprogrammer runner takes a --reset-mode argument to specify the type of reset used in the flashing process.
Though, argparse default configuration in python allows shortened command arguments and it happened that --reset was used on most boards instead of --reset-mode.
This argparse configuration is being changed in order to prevent shortened command  args (see #53495). As a consequence all board configs using --reset should be updated to use the full length version.

In prevision of https://github.com/zephyrproject-rtos/zephyr/pull/53498

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>