### PR TITLE
usb: device: Do not cancel transfers on suspend

### DIFF
--- a/subsys/usb/device/class/bluetooth.c
+++ b/subsys/usb/device/class/bluetooth.c
@@ -340,11 +340,6 @@ static void bluetooth_status_cb(struct usb_cfg_data *cfg,
 		tmp = atomic_clear(&suspended);
 		if (tmp) {
 			LOG_DBG("Device resumed from suspend");
-			if (configured) {
-				/* Start reading */
-				acl_read_cb(bluetooth_ep_data[HCI_OUT_EP_IDX].ep_addr,
-					    0, NULL);
-			}
 		} else {
 			LOG_DBG("Spurious resume event");
 		}

--- a/subsys/usb/device/class/bt_h4.c
+++ b/subsys/usb/device/class/bt_h4.c
@@ -179,11 +179,6 @@ static void bt_h4_status_cb(struct usb_cfg_data *cfg,
 		if (suspended) {
 			LOG_DBG("from suspend");
 			suspended = false;
-			if (configured) {
-				/* Start reading */
-				bt_h4_read(bt_h4_ep_data[BT_H4_OUT_EP_IDX].ep_addr,
-					   0, NULL);
-			}
 		} else {
 			LOG_DBG("Spurious resume event");
 		}

--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -392,10 +392,6 @@ static void cdc_acm_do_cb(struct cdc_acm_dev_data_t *dev_data,
 		if (dev_data->suspended) {
 			LOG_INF("from suspend");
 			dev_data->suspended = false;
-			if (dev_data->configured) {
-				cdc_acm_read_cb(cfg->endpoint[ACM_OUT_EP_IDX].ep_addr,
-					0, dev_data);
-			}
 		} else {
 			LOG_DBG("Spurious resume event");
 		}
@@ -555,7 +551,7 @@ static int cdc_acm_fifo_read(const struct device *dev, uint8_t *rx_data,
 		if (ring_buf_space_get(dev_data->rx_ringbuf) >= CDC_ACM_BUFFER_SIZE) {
 			struct usb_cfg_data *cfg = (void *)dev->config;
 
-			if (dev_data->configured && !dev_data->suspended) {
+			if (dev_data->configured) {
 				cdc_acm_read_cb(cfg->endpoint[ACM_OUT_EP_IDX].ep_addr, 0, dev_data);
 			}
 			dev_data->rx_paused = false;

--- a/subsys/usb/device/usb_device.c
+++ b/subsys/usb/device/usb_device.c
@@ -1246,13 +1246,11 @@ static void forward_status_cb(enum usb_dc_status_code status, const uint8_t *par
 		usb_reset_alt_setting();
 	}
 
-	if (status == USB_DC_DISCONNECTED || status == USB_DC_SUSPEND || status == USB_DC_RESET) {
+	if (status == USB_DC_DISCONNECTED || status == USB_DC_RESET) {
 		if (usb_dev.configured) {
 			usb_cancel_transfers();
-			if (status == USB_DC_DISCONNECTED || status == USB_DC_RESET) {
-				foreach_ep(disable_interface_ep);
-				usb_dev.configured = false;
-			}
+			foreach_ep(disable_interface_ep);
+			usb_dev.configured = false;
 		}
 	}
 

--- a/west.yml
+++ b/west.yml
@@ -83,7 +83,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: fe0be3c3546e136a67264084c0e3edfd7354645a
+      revision: 3f7ae2320b6d348898c7b11e956a6e792d0b3724
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Cancelling transfers on suspend contradicts Universal Serial Bus Specification Revision 2.0, 9.1.1.6 Suspended:
  * When suspended, the USB device maintains any internal status, including its address and configuration.

The internal status definitely includes any pending USB transfers. If there is a class that wants to cancel transfer on suspend, then the cancel should be initiated by the class, not the device stack itself.

Update hal_nordic to a version that does not abort all endpoints at suspend. It seems that aborting endpoints on suspend in nrfx driver was the actual reason why transfers were canceled on suspend.

Remove transfer retriggering on resume from CDC ACM and Bluetooth class implementations because transfers are no longer cancelled on suspend. Other classes do not have any suspend related workarounds implemented.

Signed-off-by: Tomasz Moń <tomasz.mon@nordicsemi.no>

Fixes: #53451