### PR TITLE
Bluetooth: Audio: Add bt_audio_dir_str to improve logging of dir

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -340,9 +340,9 @@ static void ascs_ep_get_status_config(struct bt_audio_ep *ep,
 	cfg->codec.cid = sys_cpu_to_le16(ep->codec.cid);
 	cfg->codec.vid = sys_cpu_to_le16(ep->codec.vid);
 
-	LOG_DBG("dir 0x%02x unframed_supported 0x%02x phy 0x%02x rtn %u "
+	LOG_DBG("dir %s unframed_supported 0x%02x phy 0x%02x rtn %u "
 	       "latency %u pd_min %u pd_max %u codec 0x%02x",
-	       ep->dir, pref->unframed_supported, pref->phy,
+	       bt_audio_dir_str(ep->dir), pref->unframed_supported, pref->phy,
 	       pref->rtn, pref->latency, pref->pd_min, pref->pd_max,
 	       ep->stream->codec->id);
 
@@ -367,9 +367,9 @@ static void ascs_ep_get_status_qos(struct bt_audio_ep *ep,
 	qos->latency = sys_cpu_to_le16(ep->stream->qos->latency);
 	sys_put_le24(ep->stream->qos->pd, qos->pd);
 
-	LOG_DBG("dir 0x%02x codec 0x%02x interval %u framing 0x%02x phy 0x%02x "
+	LOG_DBG("dir %s codec 0x%02x interval %u framing 0x%02x phy 0x%02x "
 	       "rtn %u latency %u pd %u",
-	       ep->dir, ep->stream->codec->id,
+	       bt_audio_dir_str(ep->dir), ep->stream->codec->id,
 	       ep->stream->qos->interval, ep->stream->qos->framing,
 	       ep->stream->qos->phy, ep->stream->qos->rtn,
 	       ep->stream->qos->latency, ep->stream->qos->pd);
@@ -388,7 +388,8 @@ static void ascs_ep_get_status_enable(struct bt_audio_ep *ep,
 	ascs_codec_data_add(buf, "meta", ep->codec.meta_count, ep->codec.meta);
 	enable->metadata_len = buf->len - enable->metadata_len;
 
-	LOG_DBG("dir 0x%02x cig 0x%02x cis 0x%02x", ep->dir, ep->cig_id, ep->cis_id);
+	LOG_DBG("dir %s cig 0x%02x cis 0x%02x",
+		bt_audio_dir_str(ep->dir), ep->cig_id, ep->cis_id);
 }
 
 static int ascs_ep_get_status_idle(uint8_t ase_id, struct net_buf_simple *buf)
@@ -1218,14 +1219,14 @@ static int ascs_ep_set_codec(struct bt_audio_ep *ep, uint8_t id, uint16_t cid,
 		return -EINVAL;
 	}
 
-	LOG_DBG("ep %p dir %u codec id 0x%02x cid 0x%04x vid 0x%04x len %u", ep, ep->dir, id, cid,
-		vid, len);
+	LOG_DBG("ep %p dir %s codec id 0x%02x cid 0x%04x vid 0x%04x len %u",
+		ep, bt_audio_dir_str(ep->dir), id, cid, vid, len);
 
 	bt_pacs_cap_foreach(ep->dir, codec_lookup_id, &lookup_data);
 
 	if (lookup_data.codec == NULL) {
-		LOG_DBG("Codec with id %u for dir %u is not supported by our capabilities",
-			id, ep->dir);
+		LOG_DBG("Codec with id %u for dir %s is not supported by our capabilities",
+			id, bt_audio_dir_str(ep->dir));
 
 		return -ENOENT;
 	}
@@ -1515,8 +1516,8 @@ static int ase_stream_qos(struct bt_audio_stream *stream,
 		}
 
 		if (bt_audio_iso_get_ep(false, iso, ep->dir) != NULL) {
-			LOG_ERR("iso %p already in use in dir %u",
-			       &iso->chan, ep->dir);
+			LOG_ERR("iso %p already in use in dir %s",
+			       &iso->chan, bt_audio_dir_str(ep->dir));
 			bt_audio_iso_unref(iso);
 			return -EALREADY;
 		}

--- a/subsys/bluetooth/audio/audio_internal.h
+++ b/subsys/bluetooth/audio/audio_internal.h
@@ -58,3 +58,15 @@ ssize_t bt_audio_ccc_cfg_write(struct bt_conn *conn, const struct bt_gatt_attr *
 	BT_GATT_CCC_MANAGED(((struct _bt_gatt_ccc[])					\
 		{BT_GATT_CCC_INITIALIZER(_changed, bt_audio_ccc_cfg_write, NULL)}),	\
 		(BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT))
+
+static inline const char *bt_audio_dir_str(enum bt_audio_dir dir)
+{
+	switch (dir) {
+	case BT_AUDIO_DIR_SINK:
+		return "sink";
+	case BT_AUDIO_DIR_SOURCE:
+		return "source";
+	}
+
+	return "Unknown";
+}

--- a/subsys/bluetooth/audio/audio_iso.c
+++ b/subsys/bluetooth/audio/audio_iso.c
@@ -7,6 +7,7 @@
  */
 
 #include "audio_iso.h"
+#include "audio_internal.h"
 #include "endpoint.h"
 
 #include <zephyr/logging/log.h>
@@ -151,7 +152,7 @@ void bt_audio_iso_bind_ep(struct bt_audio_iso *iso, struct bt_audio_ep *ep)
 	__ASSERT(ep->dir == BT_AUDIO_DIR_SINK || ep->dir == BT_AUDIO_DIR_SOURCE,
 		 "invalid dir: %u", ep->dir);
 
-	LOG_DBG("iso %p ep %p dir %u", iso, ep, ep->dir);
+	LOG_DBG("iso %p ep %p dir %s", iso, ep, bt_audio_dir_str(ep->dir));
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_UNICAST_CLIENT) &&
 	    bt_audio_ep_is_unicast_client(ep)) {
@@ -189,7 +190,7 @@ void bt_audio_iso_unbind_ep(struct bt_audio_iso *iso, struct bt_audio_ep *ep)
 	__ASSERT(ep->dir == BT_AUDIO_DIR_SINK || ep->dir == BT_AUDIO_DIR_SOURCE,
 		 "Invalid dir: %u", ep->dir);
 
-	LOG_DBG("iso %p ep %p dir %u", iso, ep, ep->dir);
+	LOG_DBG("iso %p ep %p dir %s", iso, ep, bt_audio_dir_str(ep->dir));
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_UNICAST_CLIENT) &&
 	    bt_audio_ep_is_unicast_client(ep)) {
@@ -226,7 +227,7 @@ struct bt_audio_ep *bt_audio_iso_get_ep(bool unicast_client,
 	__ASSERT(dir == BT_AUDIO_DIR_SINK || dir == BT_AUDIO_DIR_SOURCE,
 		 "invalid dir: %u", dir);
 
-	LOG_DBG("iso %p dir %u", iso, dir);
+	LOG_DBG("iso %p dir %s", iso, bt_audio_dir_str(dir));
 
 	/* TODO FIX FOR CLIENT */
 	if (IS_ENABLED(CONFIG_BT_AUDIO_UNICAST_CLIENT) && unicast_client) {
@@ -257,8 +258,8 @@ void bt_audio_iso_bind_stream(struct bt_audio_iso *audio_iso,
 		 "stream %p bound with audio_iso %p already",
 		 stream, stream->audio_iso);
 
-	LOG_DBG("audio_iso %p stream %p dir %u",
-		audio_iso, stream, stream->dir);
+	LOG_DBG("audio_iso %p stream %p dir %s",
+		audio_iso, stream, bt_audio_dir_str(stream->dir));
 
 	/* For the unicast client, the direction and tx/rx is reversed */
 	if (stream->dir == BT_AUDIO_DIR_SOURCE) {
@@ -286,8 +287,8 @@ void bt_audio_iso_unbind_stream(struct bt_audio_iso *audio_iso,
 		 "stream %p not bound with an audio_iso",
 		 stream);
 
-	LOG_DBG("audio_iso %p stream %p dir %u",
-		audio_iso, stream, stream->dir);
+	LOG_DBG("audio_iso %p stream %p dir %s",
+		audio_iso, stream, bt_audio_dir_str(stream->dir));
 
 	/* For the unicast client, the direction and tx/rx is reversed */
 	if (stream->dir == BT_AUDIO_DIR_SOURCE) {
@@ -311,7 +312,7 @@ struct bt_audio_stream *bt_audio_iso_get_stream(struct bt_audio_iso *iso,
 	__ASSERT(dir == BT_AUDIO_DIR_SINK || dir == BT_AUDIO_DIR_SOURCE,
 		 "invalid dir: %u", dir);
 
-	LOG_DBG("iso %p dir %u", iso, dir);
+	LOG_DBG("iso %p dir %s", iso, bt_audio_dir_str(dir));
 
 	/* For the unicast client, the direction and tx/rx is reversed */
 	if (dir == BT_AUDIO_DIR_SOURCE) {

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -662,8 +662,8 @@ int bt_pacs_cap_register(enum bt_audio_dir dir, struct bt_pacs_cap *cap)
 		return -EINVAL;
 	}
 
-	LOG_DBG("cap %p dir 0x%02x codec 0x%02x codec cid 0x%04x "
-	       "codec vid 0x%04x", cap, dir, cap->codec->id,
+	LOG_DBG("cap %p dir %s codec 0x%02x codec cid 0x%04x "
+	       "codec vid 0x%04x", cap, bt_audio_dir_str(dir), cap->codec->id,
 	       cap->codec->cid, cap->codec->vid);
 
 	sys_slist_append(&pac->list, &cap->_node);
@@ -687,7 +687,7 @@ int bt_pacs_cap_unregister(enum bt_audio_dir dir, struct bt_pacs_cap *cap)
 		return -EINVAL;
 	}
 
-	LOG_DBG("cap %p dir 0x%02x", cap, dir);
+	LOG_DBG("cap %p dir %s", cap, bt_audio_dir_str(dir));
 
 	if (!sys_slist_find_and_remove(&pac->list, &cap->_node)) {
 		return -ENOENT;

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -22,6 +22,7 @@
 #include "../host/iso_internal.h"
 
 #include "audio_iso.h"
+#include "audio_internal.h"
 #include "endpoint.h"
 #include "unicast_client_internal.h"
 #include "unicast_server.h"
@@ -872,7 +873,8 @@ static int unicast_group_add_stream(struct bt_audio_unicast_group *group,
 	__ASSERT_NO_MSG(stream->ep == NULL ||
 			(stream->ep != NULL && stream->ep->iso == NULL));
 
-	LOG_DBG("group %p stream %p dir %u", group, stream, dir);
+	LOG_DBG("group %p stream %p dir %s",
+		group, stream, bt_audio_dir_str(dir));
 
 	iso = get_new_iso(group, stream->conn, dir);
 	if (iso == NULL) {


### PR DESCRIPTION
The direction of a stream/endpoint/parameter has just been logged as a unsigned integer. This commits adds a
value -> string internal function that would log
BT_AUDIO_DIR_SINK as "sink" and BT_AUDIO_DIR_SOURCE as "source".

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>