### PR TITLE
tests: libc: Fix "unused" type of warnings

### DIFF
--- a/tests/lib/c_lib/src/test_strerror.c
+++ b/tests/lib/c_lib/src/test_strerror.c
@@ -18,15 +18,12 @@ ZTEST(test_c_lib, test_strerror)
 	if (IS_ENABLED(CONFIG_MINIMAL_LIBC_DISABLE_STRING_ERROR_TABLE)) {
 		expected = "";
 		actual = strerror(EINVAL);
-
-		zassert_equal(0, strcmp("", strerror(EINVAL)), "");
 	} else {
 		expected = "Invalid argument";
 		actual = strerror(EINVAL);
-
-		zassert_equal(0, strcmp(expected, actual),
-			      "mismatch: exp: %s act: %s", expected, actual);
 	}
+	zassert_equal(0, strcmp(expected, actual),
+		      "mismatch: exp: %s act: %s", expected, actual);
 
 	/* do not change errno on success */
 	zassert_equal(4242, errno, "");


### PR DESCRIPTION
Follow example several lines below and fix warnings from static tools.