### PR TITLE
net: ipv4: Fix packet leak with IPv4 autoconf

### DIFF
--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -281,7 +281,10 @@ static inline struct net_pkt *arp_prepare(struct net_if *iface,
 	 * request and we want to send it again.
 	 */
 	if (entry) {
-		k_fifo_put(&entry->pending_queue, net_pkt_ref(pending));
+		if (!net_pkt_ipv4_auto(pkt)) {
+			k_fifo_put(&entry->pending_queue, net_pkt_ref(pending));
+		}
+
 		entry->iface = net_pkt_iface(pkt);
 
 		net_ipaddr_copy(&entry->ip, next_addr);
@@ -385,7 +388,8 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
 			 * in the pending list and if so, resend the request, otherwise just
 			 * append the packet to the request fifo list.
 			 */
-			if (k_queue_unique_append(&entry->pending_queue._queue,
+			if (!net_pkt_ipv4_auto(pkt) &&
+			    k_queue_unique_append(&entry->pending_queue._queue,
 						  net_pkt_ref(pkt))) {
 				k_mutex_unlock(&arp_mutex);
 				return NULL;


### PR DESCRIPTION
The IPv4 autoconfiguration feature relies on the fact, that autoconf ARP packets are always prepared by the ARP module. After recent ARP refactoring though that could no longer be the case due to packet queueing mechanism. This could lead to net pkt leaks in the autoconf module.

Fix this by skipping the pending packet queue for autoconf packets. Since for autoconf ARP requests there's no really a pending packet to queue, it can be safely avoided. This results in the ARP request being always sent for the autoconf case, preventing the packet leak.

Fixes #53458

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>