### PR TITLE
usb: remove USB_TRANS_NO_ZLP for hci_usb OUT transfers, do not block cdc_acm sample thread for one second

### DIFF
--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -200,8 +200,8 @@ void main(void)
 		LOG_WRN("Failed to set DSR, ret code %d", ret);
 	}
 
-	/* Wait 1 sec for the host to do all settings */
-	k_busy_wait(1000000);
+	/* Wait 100ms for the host to do all settings */
+	k_msleep(100);
 
 	ret = uart_line_ctrl_get(dev, UART_LINE_CTRL_BAUD_RATE, &baudrate);
 	if (ret) {

--- a/subsys/usb/device/class/bluetooth.c
+++ b/subsys/usb/device/class/bluetooth.c
@@ -296,7 +296,7 @@ static void acl_read_cb(uint8_t ep, int size, void *priv)
 
 restart_out_transfer:
 	usb_transfer(bluetooth_ep_data[HCI_OUT_EP_IDX].ep_addr, ep_out_buf,
-		     sizeof(ep_out_buf), USB_TRANS_READ | USB_TRANS_NO_ZLP,
+		     sizeof(ep_out_buf), USB_TRANS_READ,
 		     acl_read_cb, NULL);
 }
 


### PR DESCRIPTION
Two small cleanups.
Remove USB_TRANS_NO_ZLP for hci_usb OUT transfers.
Do not block cdc_acm sample main thread for one second after DTR set.