### PR TITLE
tests: logging: log_api: Fix test_log_arguments case

### DIFF
--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -445,7 +445,6 @@ ZTEST(test_log_api, test_log_overflow)
 
 ZTEST(test_log_api, test_log_arguments)
 {
-	return;
 	log_timestamp_t exp_timestamp = TIMESTAMP_INIT_VAL;
 
 	log_setup(false);
@@ -476,21 +475,26 @@ ZTEST(test_log_api, test_log_arguments)
 
 	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10");
 	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11");
-	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12");
 
 	LOG_INF("test %d %d %d %d %d %d %d %d %d %d",
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 	LOG_INF("test %d %d %d %d %d %d %d %d %d %d %d",
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-	LOG_INF("test %d %d %d %d %d %d %d %d %d %d %d %d",
-		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
 
 	process_and_validate(false, false);
 
+	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12");
 	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12 13");
-	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12 13 14");
+
+	LOG_INF("test %d %d %d %d %d %d %d %d %d %d %d %d",
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+
 	LOG_INF("test %d %d %d %d %d %d %d %d %d %d %d %d %d",
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
+
+	process_and_validate(false, false);
+
+	MOCK_LOG_FRONT_BACKEND_RECORD("test 1 2 3 4 5 6 7 8 9 10 11 12 13 14");
 	LOG_INF("test %d %d %d %d %d %d %d %d %d %d %d %d %d %d",
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
 


### PR DESCRIPTION
Test had by accident an early return and after removal case was failing in certain configurations. It was failing because set of long messages was not fitting into the logging buffer used in the test. Fixed the test by adding more frequent processing between the messages.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>