### PR TITLE
Revert "usb: device: Do not call callback when transfer is cancelled"

### DIFF
--- a/subsys/usb/device/usb_transfer.c
+++ b/subsys/usb/device/usb_transfer.c
@@ -151,9 +151,7 @@ done:
 		k_sem_give(&trans->sem);
 
 		/* Transfer completion callback */
-		if (trans->status != -ECANCELED) {
-			cb(ep, tsize, priv);
-		}
+		cb(ep, tsize, priv);
 	}
 }
 


### PR DESCRIPTION
This reverts commit f206170c655c433f25691728a22d675e15ad6d78.

Signed-off-by: Nickolas Lapp <nickolaslapp@gmail.com>

This change to not call the user callback in the case that the transfer was cancelled seems to have been a workaround for usb reconnect working in https://github.com/zephyrproject-rtos/zephyr/pull/16193

This change, however, makes it so that the user callback is not called to notify a usb-transfer subscriber that their transfer was cancelled. This can lead to resource leaks on the buffer that was passed to the transfer call, unless the user explicitly monitors for conditions (suspend/detach) which would cancel the transfer and cleans up resources in those cases.

This commit should land after: https://github.com/zephyrproject-rtos/zephyr/pull/53518 which should fix the underlying bug that made this necessary in the first place.

CC: @desowin 