### PR TITLE
net: wifi: Add support for regulatory domain configuration

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -12,6 +12,8 @@
 #ifndef ZEPHYR_INCLUDE_NET_WIFI_H_
 #define ZEPHYR_INCLUDE_NET_WIFI_H_
 
+#define WIFI_COUNTRY_CODE_LEN 2
+
 /* Not having support for legacy types is deliberate to enforce
  * higher security.
  */

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -40,6 +40,7 @@ enum net_request_wifi_cmd {
 	NET_REQUEST_WIFI_CMD_PS_MODE,
 	NET_REQUEST_WIFI_CMD_TWT,
 	NET_REQUEST_WIFI_CMD_PS_CONFIG,
+	NET_REQUEST_WIFI_CMD_REG_DOMAIN,
 };
 
 #define NET_REQUEST_WIFI_SCAN					\
@@ -91,6 +92,10 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_TWT);
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_PS_CONFIG)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_CONFIG);
+#define NET_REQUEST_WIFI_REG_DOMAIN				\
+	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_REG_DOMAIN)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_REG_DOMAIN);
 
 enum net_event_wifi_cmd {
 	NET_EVENT_WIFI_CMD_SCAN_RESULT = 1,
@@ -231,6 +236,19 @@ struct wifi_ps_config {
 	char num_twt_flows;
 };
 
+/* Generic get/set operation for any command*/
+enum wifi_mgmt_op {
+	WIFI_MGMT_GET = 0,
+	WIFI_MGMT_SET = 1,
+};
+
+struct wifi_reg_domain {
+	enum wifi_mgmt_op oper;
+	/* Ignore all other regulatory hints */
+	bool force;
+	uint8_t country_code[WIFI_COUNTRY_CODE_LEN];
+};
+
 #include <zephyr/net/net_if.h>
 
 typedef void (*scan_result_cb_t)(struct net_if *iface, int status,
@@ -268,6 +286,7 @@ struct net_wifi_mgmt_offload {
 	int (*set_power_save_mode)(const struct device *dev, struct wifi_ps_mode_params *params);
 	int (*set_twt)(const struct device *dev, struct wifi_twt_params *params);
 	int (*get_power_save_config)(const struct device *dev, struct wifi_ps_config *config);
+	int (*reg_domain)(const struct device *dev, struct wifi_reg_domain *reg_domain);
 };
 
 /* Make sure that the network interface API is properly setup inside

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -293,3 +293,24 @@ void wifi_mgmt_raise_twt_event(struct net_if *iface, struct wifi_twt_params *twt
 					iface, twt_params,
 					sizeof(struct wifi_twt_params));
 }
+
+static int wifi_reg_domain(uint32_t mgmt_request, struct net_if *iface,
+			   void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api =
+			(struct net_wifi_mgmt_offload *) dev->api;
+	struct wifi_reg_domain *reg_domain = data;
+
+	if (off_api == NULL || off_api->reg_domain == NULL) {
+		return -ENOTSUP;
+	}
+
+	if (!data || len != sizeof(*reg_domain)) {
+		return -EINVAL;
+	}
+
+	return off_api->reg_domain(dev, reg_domain);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_REG_DOMAIN, wifi_reg_domain);

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -168,7 +168,6 @@ NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_AP_DISABLE, wifi_ap_disable);
 static int wifi_iface_status(uint32_t mgmt_request, struct net_if *iface,
 			  void *data, size_t len)
 {
-	int ret;
 	const struct device *dev = net_if_get_device(iface);
 	struct net_wifi_mgmt_offload *off_api =
 		(struct net_wifi_mgmt_offload *) dev->api;
@@ -182,13 +181,7 @@ static int wifi_iface_status(uint32_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	ret = off_api->iface_status(dev, status);
-
-	if (ret) {
-		return ret;
-	}
-
-	return 0;
+	return off_api->iface_status(dev, status);
 }
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_IFACE_STATUS, wifi_iface_status);
 
@@ -204,7 +197,6 @@ void wifi_mgmt_raise_iface_status_event(struct net_if *iface,
 static int wifi_iface_stats(uint32_t mgmt_request, struct net_if *iface,
 			  void *data, size_t len)
 {
-	int ret;
 	const struct device *dev = net_if_get_device(iface);
 	struct net_wifi_mgmt_offload *off_api =
 		(struct net_wifi_mgmt_offload *) dev->api;
@@ -218,13 +210,7 @@ static int wifi_iface_stats(uint32_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	ret = off_api->get_stats(dev, stats);
-
-	if (ret) {
-		return ret;
-	}
-
-	return 0;
+	return off_api->get_stats(dev, stats);
 }
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_STATS_GET_WIFI, wifi_iface_stats);
 #endif /* CONFIG_NET_STATISTICS_WIFI */


### PR DESCRIPTION
Wi-Fi bands are regulated by a governing body depending on operating country, add support for the user to provide a country of operation as a hint to the Wi-Fi chipset.

Ideally if the chipset supports this is all handled internally, in that case "get" is useful but for testing and other usecases add a "set" as well, similar to "iw reg set" or "country_code=" configuration in hostapd/wpa_supplicant in Linux world.

This add a new offload API operation "reg_domain" that can be used to either get or set the regulatory information.

The validation is left to the underlying chipset, shell only does basic validation in case of set, the standard database used is [1].

[1] - https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git/tree/db.txt

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>