### PR TITLE
kernel: mark z_cstart to not have stack protector

### DIFF
--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -625,5 +625,16 @@ do {                                                                    \
 #define __noasan /**/
 #endif
 
+/**
+ * @brief Function attribute to disable stack protector.
+ *
+ * @note Only supported for GCC >= 11.0.0 or Clang >= 7.
+ */
+#if (TOOLCHAIN_GCC_VERSION >= 110000) || (TOOLCHAIN_CLANG_VERSION >= 70000)
+#define FUNC_NO_STACK_PROTECTOR __attribute__((no_stack_protector))
+#else
+#define FUNC_NO_STACK_PROTECTOR
+#endif
+
 #endif /* !_LINKER */
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_GCC_H_ */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -498,6 +498,7 @@ sys_rand_fallback:
  * @return Does not return
  */
 __boot_func
+FUNC_NO_STACK_PROTECTOR
 FUNC_NORETURN void z_cstart(void)
 {
 	/* gcov hook needed to get the coverage report.*/


### PR DESCRIPTION
Most of the time, z_cstart() is running on an arbitrary region of memory as stack, where the necessary stack setup has not been performed. This prevents stack protection to work correctly, as the stack canary has not been populated. So mark z_cstart() to have no stack protection at all inside the function to avoid raising exception during boot.