### PR TITLE
Application development documentation improvements

### DIFF
--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -191,25 +191,26 @@ following example, ``app`` is a Zephyr freestanding application:
             └── main.c
 
 Example workspace application
-******************************
+*****************************
 
-A reference :ref:`workspace application <zephyr-workspace-app>` contained in its
-own Git repository can be found in the `Example Application`_ repository.
-It can be used as a reference on how to structure out-of-tree, Zephyr-based workspace applications
-using the :ref:`T2 star topology <west-t2>`. It also demonstrates the out-of-tree
-use of features commonly used in applications such as:
+The `example-application`_ Git repository contains a reference :ref:`workspace
+application <zephyr-workspace-app>`. It can be used as a reference when
+creating your own application.
 
-- Custom boards
-- Custom devicetree bindings
-- Custom drivers
-- Continuous Integration (CI) setup
-- An example west :ref:`extension <west-extensions>` command
+The example-application repository demonstrates how to use several
+commonly-used features, such as:
+
+- Custom :ref:`board ports <board_porting_guide>`
+- Custom :ref:`devicetree bindings <dt-bindings>`
+- Custom :ref:`device drivers <device_model_api>`
+- Continuous Integration (CI) setup, including using :ref:`twister <twister_script>`
+- A custom west :ref:`extension command <west-extensions>`
 
 Creating an Application
 ***********************
 
 Follow these steps to create a new application directory. (Refer to
-the `Example Application`_ repository for a reference standalone application in its own Git repository
+the `example-application`_ repository for a reference standalone application in its own Git repository
 or to :ref:`samples-and-demos` for existing applications provided as part of
 Zephyr.)
 
@@ -1435,4 +1436,4 @@ CONFIG_DEBUG_THREAD_INFO=y in your application.
 .. _CMake list: https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#lists
 .. _add_subdirectory(): https://cmake.org/cmake/help/latest/command/add_subdirectory.html
 .. _using Chocolatey: https://chocolatey.org/packages/RapidEE
-.. _Example Application: https://github.com/zephyrproject-rtos/example-application
+.. _example-application: https://github.com/zephyrproject-rtos/example-application

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -190,12 +190,15 @@ following example, ``app`` is a Zephyr freestanding application:
         └── src/
             └── main.c
 
-Example workspace application
-*****************************
+Creating an Application
+***********************
+
+example-application
+===================
 
 The `example-application`_ Git repository contains a reference :ref:`workspace
-application <zephyr-workspace-app>`. It can be used as a reference when
-creating your own application.
+application <zephyr-workspace-app>`. It is recommended to use it as a reference
+when creating your own application as described in the following sections.
 
 The example-application repository demonstrates how to use several
 commonly-used features, such as:
@@ -206,20 +209,90 @@ commonly-used features, such as:
 - Continuous Integration (CI) setup, including using :ref:`twister <twister_script>`
 - A custom west :ref:`extension command <west-extensions>`
 
-Creating an Application
-***********************
+Basic example-application Usage
+===============================
 
-Follow these steps to create a new application directory. (Refer to
-the `example-application`_ repository for a reference standalone application in its own Git repository
-or to :ref:`samples-and-demos` for existing applications provided as part of
-Zephyr.)
+The easiest way to get started with the example-application repository within
+an existing Zephyr workspace is to follow these steps:
 
-#. Create an application directory on your workstation computer, outside of the
-   Zephyr base directory.  Usually you'll want to create it somewhere under
-   your user's home directory.
+.. code-block:: console
 
-   For example, in a Unix shell or Windows ``cmd.exe`` prompt, navigate to
-   where you want to create your application, then enter:
+   cd <home>/zephyrproject
+   git clone https://github.com/zephyrproject-rtos/example-application my-app
+
+The directory name :file:`my-app` above is arbitrary: change it as needed. You
+can now go into this directory and adapt its contents to suit your needs. Since
+you are using an existing Zephyr workspace, you can use ``west build`` or any
+other west commands to build, flash, and debug.
+
+Advanced example-application Usage
+==================================
+
+You can also use the example-application repository as a starting point for
+building your own customized Zephyr-based software distribution. This lets you
+do things like:
+
+- remove Zephyr modules you don't need
+- add additional custom repositories of your own
+- override repositories provided by Zephyr with your own versions
+- share the results with others and collaborate further
+
+The example-application repository contains a :file:`west.yml` file and is
+therefore also a west :ref:`manifest repository <west-workspace>`. Use this to
+create a new, customized workspace by following these steps:
+
+.. code-block:: console
+
+   cd <home>
+   mkdir my-workspace
+   cd my-workspace
+   git clone https://github.com/zephyrproject-rtos/example-application my-manifest-repo
+   west init -l my-manifest-repo
+
+This will create a new workspace with the :ref:`T2 topology <west-t2>`, with
+:file:`my-manifest-repo` as the manifest repository. The :file:`my-workspace`
+and :file:`my-manifest-repo` names are arbitrary: change them as needed.
+
+Next, customize the manifest repository. The initial contents of this
+repository will match the example-application's contents when you clone it. You
+can then edit :file:`my-manifest-repo/west.yml` to your liking, changing the
+set of repositories in it as you wish. See :ref:`west-manifest-import` for many
+examples of how to add or remove different repositories from your workspace as
+needed. Make any other changes you need to other files.
+
+When you are satisfied, you can run:
+
+.. code-block::
+
+   west update
+
+and your workspace will be ready for use.
+
+If you push the resulting :file:`my-manifest-repo` repository somewhere else,
+you can share your work with others. For example, let's say you push the
+repository to ``https://git.example.com/my-manifest-repo``. Other people can
+then set up a matching workspace by running:
+
+.. code-block::
+
+   west init -m https://git.example.com/my-manifest-repo my-workspace
+   cd my-workspace
+   west update
+
+From now on, you can collaborate on the shared software by pushing changes to
+the repositories you are using and updating :file:`my-manifest-repo/west.yml`
+as needed to add and remove repositories, or change their contents.
+
+Creating an Application by Hand
+===============================
+
+You can follow these steps to create a basic application directory from
+scratch. However, using the `example-application`_ repository or one of
+Zephyr's :ref:`samples-and-demos` as a starting point is likely to be easier.
+
+#. Create an application directory.
+
+   For example, in a Unix shell or Windows ``cmd.exe`` prompt:
 
    .. code-block:: console
 
@@ -229,10 +302,12 @@ Zephyr.)
 
       Building Zephyr or creating an application in a directory with spaces
       anywhere on the path is not supported. So the Windows path
-      :file:`C:\\Users\\YourName\\app` will work, but :file:`C:\\Users\\Your
-      Name\\app` will not.
+      :file:`C:\\Users\\YourName\\app` will work, but
+      :file:`C:\\Users\\Your Name\\app` will not.
 
-#. It's recommended to place all application source code in a subdirectory
+#. Create your source code files.
+
+   It's recommended to place all application source code in a subdirectory
    named :file:`src`.  This makes it easier to distinguish between project
    files and sources.
 
@@ -258,35 +333,37 @@ Zephyr.)
 
       target_sources(app PRIVATE src/main.c)
 
-   ``cmake_minimum_required()`` is required to be in your
-   :file:`CMakeLists.txt` by CMake. It is also invoked by the Zephyr
-   package. The most recent of the two versions will be enforced by CMake.
+   Notes:
 
-   ``find_package(Zephyr)`` pulls in the Zephyr build system, which creates a
-   CMake target named ``app`` (see :ref:`cmake_pkg`). Adding sources to this
-   target is how you include them in the build. The Zephyr package will define
-   ``Zephyr-Kernel`` as a CMake project and enable support for the ``C``,
-   ``CXX``, ``ASM`` languages.
+   - The ``cmake_minimum_required()`` call is required by CMake. It is also
+     invoked by the Zephyr package on the next line. CMake will error out if
+     its version is older than either the version in your
+     :file:`CMakeLists.txt` or the version number in the Zephyr package.
 
-   ``project(my_zephyr_app)`` is required for defining your application
-   project.  This must be called after ``find_package(Zephyr)`` to avoid
-   interference with Zephyr's ``project(Zephyr-Kernel)``.
+   - ``find_package(Zephyr)`` pulls in the Zephyr build system, which creates a
+     CMake target named ``app`` (see :ref:`cmake_pkg`). Adding sources to this
+     target is how you include them in the build. The Zephyr package will
+     define ``Zephyr-Kernel`` as a CMake project and enable support for the
+     ``C``, ``CXX``, ``ASM`` languages.
 
-   ``target_sources(app PRIVATE src/main.c)`` is to add your source file to the
-   ``app`` target. This must come after ``find_package(Zephyr)`` which defines
-   the target.
+   - ``project(my_zephyr_app)`` defines your application's CMake
+     project.  This must be called after ``find_package(Zephyr)`` to avoid
+     interference with Zephyr's ``project(Zephyr-Kernel)``.
 
-#. Set Kconfig configuration options. See :ref:`application-kconfig`.
+   - ``target_sources(app PRIVATE src/main.c)`` is to add your source file to
+     the ``app`` target. This must come after ``find_package(Zephyr)`` which
+     defines the target. You can add as many files as you want with
+     ``target_sources()``.
 
-#. Configure any devicetree overlays needed by your application.
-   See :ref:`set-devicetree-overlays`.
+#. Create at least one Kconfig fragment for your application (usually named
+   :file:`prj.conf`) and set Kconfig option values needed by your application
+   there. See :ref:`application-kconfig`.
 
-.. note::
+#. Configure any devicetree overlays needed by your application, usually in a
+   file named :file:`app.overlay`. See :ref:`set-devicetree-overlays`.
 
-   ``include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)``
-   is still supported for backward compatibility with older applications.
-   Including ``boilerplate.cmake`` directly in the sample still requires using
-   :ref:`zephyr-env` before building the application.
+#. Set up any other files you may need, such as :ref:`twister <twister_script>`
+   configuration files, continuous integration files, documentation, etc.
 
 .. _important-build-vars:
 

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -24,23 +24,26 @@ Overview
 Zephyr's build system is based on `CMake`_.
 
 The build system is application-centric, and requires Zephyr-based applications
-to initiate building the kernel source tree. The application build controls
+to initiate building the Zephyr source code. The application build controls
 the configuration and build process of both the application and Zephyr itself,
 compiling them into a single binary.
 
-Zephyr's base directory hosts Zephyr's own source code, its kernel
-configuration options, and its build definitions.
+The main zephyr repository contains Zephyr's source code, configuration files,
+and build system. You also likely have installed various :ref:`modules`
+alongside the zephyr repository, which provide third party source code
+integration.
 
-The files in the **application directory** link Zephyr with the
+The files in the **application directory** link Zephyr and any modules with the
 application. This directory contains all application-specific files, such as
-configuration options and source code.
+application-specific configuration files and source code.
 
-An application in its simplest form has the following contents:
+Here are the files in a simple Zephyr application:
 
 .. code-block:: none
 
    <app>
    ├── CMakeLists.txt
+   ├── app.overlay
    ├── prj.conf
    └── src
        └── main.c
@@ -50,25 +53,40 @@ These contents are:
 * **CMakeLists.txt**: This file tells the build system where to find the other
   application files, and links the application directory with Zephyr's CMake
   build system. This link provides features supported by Zephyr's build system,
-  such as board-specific kernel configuration files, the ability to run and
+  such as board-specific configuration files, the ability to run and
   debug compiled binaries on real or emulated hardware, and more.
 
-* **Kernel configuration files**: An application typically provides a
-  Kconfig configuration file (usually called :file:`prj.conf`) that specifies
-  application-specific values for one or more kernel configuration options.
-  These application settings are merged with board-specific settings to produce
-  a kernel configuration.
+* **app.overlay**: This is a devicetree overlay file that specifies
+  application-specific changes which should be applied to the base devicetree
+  for any board you build for. The purpose of devicetree overlays is
+  usually to configure something about the hardware used by the application.
+
+  The build system looks for :file:`app.overlay` by default, but you can add
+  more devicetree overlays, and other default files are also searched for.
+
+  See :ref:`devicetree` for more information about devicetree.
+
+* **prj.conf**: This is a Kconfig fragment that specifies application-specific
+  values for one or more Kconfig options. These application settings are merged
+  with other settings to produce the final configuration. The purpose of
+  Kconfig fragments is usually to configure the software features used by
+  the application.
+
+  The build system looks for :file:`prj.conf` by default, but you can add more
+  Kconfig fragments, and other default files are also searched for.
 
   See :ref:`application-kconfig` below for more information.
 
-* **Application source code files**: An application typically provides one
-  or more application-specific files, written in C or assembly language. These
-  files are usually located in a sub-directory called :file:`src`.
+* **main.c**: A source code file. Applications typically contain source files
+  written in C, C++, or assembly language. The Zephyr convention is to place
+  them in a subdirectory of :file:`<app>` named :file:`src`.
 
-Once an application has been defined, you can use CMake to create project files
-for building it from a directory where you want to host these files. This is
-known as the **build directory**. Application build artifacts are always
-generated in a build directory; Zephyr does not support "in-tree" builds.
+Once an application has been defined, you will use CMake to generate a **build
+directory**, which contains the files you need to build the application and
+Zephyr, then link them together into a final binary you can run on your board.
+The easiest way to do this is with :ref:`west build <west-building>`, but you
+can use CMake directly also. Application build artifacts are always generated
+in a separate build directory: Zephyr does not support "in-tree" builds.
 
 The following sections describe how to create, build, and run Zephyr
 applications, followed by more detailed reference material.

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -5,12 +5,18 @@ Application Development
 
 .. note::
 
-   In this document, we'll assume your **application directory** is
-   :file:`<home>/app`, and that its **build directory** is
-   :file:`<home>/app/build`.
-   (These terms are defined in the following Overview.)
-   On Linux/macOS, <home> is equivalent to ``~``, whereas on Windows it's
-   ``%userprofile%``.
+   In this document, we'll assume:
+
+   - your **application directory**, :file:`<app>`, is something like :file:`<home>/zephyrproject/app`
+   - its **build directory** is :file:`<app>/build`
+
+   These terms are defined below. On Linux/macOS, <home> is equivalent to
+   ``~``. On Windows, it's ``%userprofile%``.
+
+   Keeping your application inside the workspace (:file:`<home>/zephyrproject`)
+   makes it easier to use ``west build`` and other commands with it. (You can
+   put your application anywhere as long as :ref:`ZEPHYR_BASE
+   <important-build-vars>` is set appropriately, though.)
 
 Overview
 ********
@@ -33,7 +39,7 @@ An application in its simplest form has the following contents:
 
 .. code-block:: none
 
-   <home>/app
+   <app>
    ├── CMakeLists.txt
    ├── prj.conf
    └── src
@@ -645,14 +651,7 @@ Using CMake directly:
 Basics
 ======
 
-.. note::
-
-   In the below example, ``west`` is used outside of a west workspace. For this
-   to work, you must set the ``ZEPHYR_BASE`` environment variable to the path
-   of your zephyr git repository, using one of the methods on the
-   :ref:`Environment Variables <env_vars>` page.
-
-#. Navigate to the application directory :file:`<home>/app`.
+#. Navigate to the application directory :file:`<app>`.
 #. Enter the following commands to build the application's :file:`zephyr.elf`
    image for the board specified in the command-line parameters:
 
@@ -691,7 +690,7 @@ When using the Ninja generator a build directory looks like this:
 
 .. code-block:: none
 
-   <home>/app/build
+   <app>/build
    ├── build.ninja
    ├── CMakeCache.txt
    ├── CMakeFiles
@@ -751,7 +750,7 @@ the build system to rebuild the entire application from scratch with the
 following procedure:
 
 #. Open a terminal console on your host computer, and navigate to the
-   build directory :file:`<home>/app/build`.
+   build directory :file:`<app>/build`.
 
 #. Enter one of the following commands, depending on whether you want to use
    ``west`` or ``cmake`` directly to delete the application's generated
@@ -844,7 +843,7 @@ hardware:
    this via USB.
 
 #. Run one of these console commands from the build directory,
-   :file:`<home>/app/build`, to flash the compiled Zephyr image and run it on
+   :file:`<app>/build`, to flash the compiled Zephyr image and run it on
    your board:
 
    .. code-block:: console
@@ -894,7 +893,7 @@ hardware. Follow these instructions to run an application via QEMU:
    - ``qemu_cortex_m3`` to emulate running on an ARM Cortex M3-based board
 
 #. Run one of these console commands from the build directory,
-   :file:`<home>/app/build`, to run the Zephyr binary in QEMU:
+   :file:`<app>/build`, to run the Zephyr binary in QEMU:
 
    .. code-block:: console
 

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -96,25 +96,36 @@ applications, followed by more detailed reference material.
 Application types
 *****************
 
-Based on where the source code of the application is located we can distinguish
-between three basic application types.
+We distinguish three basic types of Zephyr application based on where
+:file:`<app>` is located:
 
-* Zephyr repository application
-* Zephyr workspace application
-* Zephyr freestanding application
+.. table::
 
-You can find out more about how the build system supports all the application
-types described in this section in the :ref:`cmake_pkg` section.
+   +------------------------------+--------------------------------+
+   | Application type             | :file:`<app>` location         |
+   +------------------------------+--------------------------------+
+   | :ref:`repository             | zephyr repository              |
+   | <zephyr-repo-app>`           |                                |
+   +------------------------------+--------------------------------+
+   | :ref:`workspace              | west workspace where Zephyr is |
+   | <zephyr-workspace-app>`      | installed                      |
+   +------------------------------+--------------------------------+
+   | :ref:`freestanding           | other locations                |
+   | <zephyr-freestanding-app>`   |                                |
+   +------------------------------+--------------------------------+
+
+We'll discuss these more below. To learn how the build system supports each
+type, see :ref:`cmake_pkg`.
 
 .. _zephyr-repo-app:
 
 Zephyr repository application
 =============================
 
-An application located within the ``zephyr`` folder in a Zephyr :ref:`west
-workspace <west-workspaces>` is referred to as a Zephyr repository application.
-In the following example, the :ref:`hello_world sample <hello_world>` is a
-Zephyr repository application:
+An application located within the ``zephyr`` source code repository in a Zephyr
+:ref:`west workspace <west-workspaces>` is referred to as a Zephyr repository
+application. In the following example, the :ref:`hello_world sample
+<hello_world>` is a Zephyr repository application:
 
 .. code-block:: none
 
@@ -137,9 +148,8 @@ Zephyr workspace application
 ============================
 
 An application located within a :ref:`workspace <west-workspaces>`, but outside
-the Zephyr repository (and thus folder) itself, is referred to as a Zephyr
-workspace application.  In the following example, ``app`` is a Zephyr workspace
-application:
+the zephyr repository itself, is referred to as a Zephyr workspace application.
+In the following example, ``app`` is a Zephyr workspace application:
 
 .. code-block:: none
 


### PR DESCRIPTION
The goal of this pull request is to clean up and modernize some aspects of the application development guide that have been around since before several now-relatively-standard things were introduced:

- now that we've been using west for over 3.5 years, and it's easiest to `west build` workspace applications, let's go ahead and recommend that as the default to save people confusion
- similarly, now that we have had  https://github.com/zephyrproject-rtos/example-application for almost 1 year, and lots of people are successfully using it, let's go ahead and make it the recommended starting out point for first-timers
- other cleanups, additional cross references, etc

Nothing in here changes any functionality or removes documentation for any existing way of doing things. The point is instead to change the emphasis of the page onto best current practice in terms of what's easiest for users.