### PR TITLE
cmake: Fix typo by replacing zephyr_library_add_sources

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -436,7 +436,7 @@ endmacro()
 # ZEPHYR_MODULE/drivers/entropy/CMakeLists.txt
 # with content:
 # zephyr_library_amend()
-# zephyr_library_add_sources(...)
+# zephyr_library_sources(...)
 #
 # It is also possible to use generator expression when amending to Zephyr
 # libraries.


### PR DESCRIPTION
There is no function called zephyr_library_add_sources().  This must be zephyr_library_sources().

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>