### PR TITLE
samples: canbus: isotp: add missing isotp tag

### DIFF
--- a/samples/subsys/canbus/isotp/sample.yaml
+++ b/samples/subsys/canbus/isotp/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: ISO-TP lib sample
 tests:
   sample.subsys.canbus.isotp:
-    tags: can
+    tags: can isotp
     depends_on: can
     filter: dt_chosen_enabled("zephyr,canbus")
     harness: console


### PR DESCRIPTION
Add missing "isotp" tag to the CAN bus ISO-TP sample.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>