### PR TITLE
mgmt: mcumgr: grp: fs_mgmt: Improve upload and download performance

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -391,6 +391,17 @@ Libraries / Subsystems
     set with
     :kconfig:option:`CONFIG_MCUMGR_TRANSPORT_SHELL_INPUT_TIMEOUT_TIME`.
 
+  * MCUmgr fs_mgmt upload and download now caches the file handle to improve
+    throughput when transferring data, the file is no longer opened and closed
+    for each part of a transfer. In addition, new functionality has been added
+    that will allow closing file handles of uploaded/downloaded files if they
+    are idle for a period of time, the timeout is set with
+    :kconfig:option:`MCUMGR_GRP_FS_FILE_AUTOMATIC_IDLE_CLOSE_TIME`. There is a
+    new command that can be used to close open file handles which can be used
+    after a file upload is complete to ensure that the file handle is closed
+    correctly, allowing other transports or other parts of the application
+    code to use it.
+
 HALs
 ****
 

--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -375,7 +375,7 @@ where:
     +-----------------------+-----------------------------------------------------+
 
 The "off" field is only included in responses to successfully processed requests;
-if "rc" is negative the "off' may not appear.
+if "rc" is negative then "off" may not appear.
 
 Image erase
 ***********

--- a/doc/services/device_mgmt/smp_groups/smp_group_8.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_8.rst
@@ -43,11 +43,12 @@ requests or even be removed.
 
 .. note::
     By default, all file upload requests are unconditionally allowed. However,
-    if the Kconfig option :kconfig:option:`FS_MGMT_FILE_ACCESS_HOOK` is enabled,
-    then an application can register a callback handler for ``fs_mgmt_on_evt_cb``
-    by calling ``fs_mgmt_register_evt_cb()`` with the handler supplied. This can
-    be used to allow or decline access to reading from or writing to a
-    particular file, or for rewriting the path supplied by the client.
+    if the Kconfig option :kconfig:option:`CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK`
+    is enabled, then an application can register a callback handler for
+    ``fs_mgmt_on_evt_cb`` by calling ``fs_mgmt_register_evt_cb()`` with the
+    handler supplied. This can be used to allow or decline access to reading
+    from or writing to a particular file, or for rewriting the path supplied by
+    the client.
 
 File download request
 =====================
@@ -161,11 +162,12 @@ change between requests or even be removed.
 
 .. note::
     By default, all file upload requests are unconditionally allowed. However,
-    if the Kconfig option :kconfig:option:`FS_MGMT_FILE_ACCESS_HOOK` is enabled,
-    then an application can register a callback handler for ``fs_mgmt_on_evt_cb``
-    by calling ``fs_mgmt_register_evt_cb()`` with the handler supplied. This can
-    be used to allow or decline access to reading from or writing to a
-    particular file, or for rewriting the path supplied by the client.
+    if the Kconfig option :kconfig:option:`CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK`
+    is enabled, then an application can register a callback handler for
+    ``fs_mgmt_on_evt_cb`` by calling ``fs_mgmt_register_evt_cb()`` with the
+    handler supplied. This can be used to allow or decline access to reading
+    from or writing to a particular file, or for rewriting the path supplied by
+    the client.
 
 File upload request
 ===================

--- a/doc/services/device_mgmt/smp_groups/smp_group_8.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_8.rst
@@ -22,22 +22,24 @@ File management group defines following commands:
     +-------------------+-----------------------------------------------+
     | ``3``             | Supported file hash/checksum types            |
     +-------------------+-----------------------------------------------+
+    | ``4``             | File close                                    |
+    +-------------------+-----------------------------------------------+
 
 File download
 *************
 
 Command allows to download contents of an existing file from specified path
-of a target device. The command is stateless and mcumgr does not hold file
-in open state after response to the command is issued, instead a client
-application is supposed to keep track of data it has already downloaded,
-and issue subsequent requests, with modified offset, to gather entire file.
+of a target device. Client applications must keep track of data they have
+already downloaded and where their position in the file is (MCUmgr will cache
+these also), and issue subsequent requests, with modified offset, to gather
+the entire file.
 Request does not carry size of requested chunk, the size is specified
 by application itself.
-Mcumgr server side re-opens a file for each subsequent request, and current
-specification does not provide means to identify subsequent requests as
-belonging to specified download session. This means that the file is not
-locked in any way or exclusively owned by mcumgr, for the time of download
-session, and may change between requests or even be removed.
+Note that file handles will remain open for consecutive requests (as long as
+an idle timeout has not been reached and another transport does not make use
+of uploading/downloading files using fs_mgmt), but files are not exclusively
+owned by MCUmgr, for the time of download session, and may change between
+requests or even be removed.
 
 .. note::
     By default, all file upload requests are unconditionally allowed. However,
@@ -142,11 +144,14 @@ existing file or create a new one if it does not exist at specified path.
 The protocol supports stateless upload where each requests carries different chunk
 of a file and it is client side responsibility to track progress of upload.
 
-Mcumgr server side re-opens a file for each subsequent request, and current
-specification does not provide means to identify subsequent requests as
-belonging to specified upload session. This means that the file is not
-locked in any way or exclusively owned by mcumgr, for the time of upload
-session, and may change between requests or even be removed.
+Note that file handles will remain open for consecutive requests (as long as
+an idle timeout has not been reached, but files are not exclusively owned by
+MCUmgr, for the time of download session, and may change between requests or
+even be removed. Note that file handles will remain open for consecutive
+requests (as long as an idle timeout has not been reached and another transport
+does not make use of uploading/downloading files using fs_mgmt), but files are
+not exclusively owned by MCUmgr, for the time of download session, and may
+change between requests or even be removed.
 
 .. note::
     Weirdly, the current Zephyr implementation is half-stateless as is able to hold
@@ -334,6 +339,10 @@ Command allows to generate a hash/checksum of an existing file at a specified
 path on a target device. Note that kernel heap memory is required for buffers to
 be allocated for this to function, and large stack memory buffers are required
 for generation of the output hash/checksum.
+Requires :kconfig:option:`CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH` to be enabled for
+the base functionality, supported hash/checksum are opt-in with
+:kconfig:option:`CONFIG_MCUMGR_GRP_FS_CHECKSUM_IEEE_CRC32` or
+:kconfig:option:`CONFIG_MCUMGR_GRP_FS_HASH_SHA256`.
 
 File hash/checksum request
 ==========================
@@ -531,3 +540,58 @@ where:
     +-----------------------+---------------------------------------------------+
 
 In case when "rc" is not 0, success, the other fields will not appear.
+
+File close
+**********
+
+Command allows closing any open file handles held by fs_mgmt upload/download
+requests that might have stalled or be incomplete.
+
+File close request
+==================
+
+File close request header:
+
+.. table::
+    :align: center
+
+    +--------+--------------+----------------+
+    | ``OP`` | ``Group ID`` | ``Command ID`` |
+    +========+==============+================+
+    | ``2``  | ``8``        |  ``4``         |
+    +--------+--------------+----------------+
+
+The command sends empty CBOR map as data.
+
+File close response
+===================
+
+File close response header:
+
+.. table::
+    :align: center
+
+    +--------+--------------+----------------+
+    | ``OP`` | ``Group ID`` | ``Command ID`` |
+    +========+==============+================+
+    | ``3``  | ``8``        |  ``4``         |
+    +--------+--------------+----------------+
+
+The command sends an empty CBOR map as data if successful.
+In case of error the CBOR data takes the form:
+
+.. code-block:: none
+
+    {
+        (str)"rc"           : (int)
+    }
+
+where:
+
+.. table::
+    :align: center
+
+    +-----------------------+---------------------------------------------------+
+    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    |                       | only appears if non-zero (error condition).       |
+    +-----------------------+---------------------------------------------------+

--- a/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h
@@ -20,6 +20,7 @@ extern "C" {
 #define FS_MGMT_ID_STAT				1
 #define FS_MGMT_ID_HASH_CHECKSUM		2
 #define FS_MGMT_ID_SUPPORTED_HASH_CHECKSUM	3
+#define FS_MGMT_ID_OPENED_FILE			4
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/Kconfig
@@ -1,5 +1,5 @@
 # Copyright Runtime.io 2018. All rights reserved.
-# Copyright Nordic Semiconductor ASA 2020-2022. All rights reserved.
+# Copyright Nordic Semiconductor ASA 2020-2023. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # The Kconfig file is dedicated to File System management group of
@@ -160,6 +160,26 @@ config MCUMGR_GRP_FS_FILE_ACCESS_HOOK
 	  re-writing or changing of supplied file paths.
 	  Note that this will be called multiple times for each file read and
 	  write due to mcumgr's method of stateless operation.
+
+config MCUMGR_GRP_FS_FILE_SEMAPHORE_TAKE_TIME
+	int "File handle semaphore take time (ms)"
+	default 100
+	help
+	  Maximum time (in ms) to acquire the file handle semaphore when a file
+	  upload/download command is used. If unable to acquire the semaphore,
+	  then MGMT_ERR_EBUSY will be returned.
+
+	  Can specify 0 to not wait for the lock and return instantly if it
+	  cannot be acquired.
+
+config MCUMGR_GRP_FS_FILE_AUTOMATIC_IDLE_CLOSE_TIME
+	int "Automatic file handle close time (ms)"
+	default 4000
+	range 1 99999999
+	help
+	  Time (in ms) for a file upload/download to be declared aborted and
+	  file handle cleaned up. Each access to the file will reset the idle
+	  time to 0.
 
 module = MCUMGR_GRP_FS
 module-str = mcumgr_grp_fs

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
  * Copyright (c) 2022 Laird Connectivity
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,6 +18,7 @@
 #include <assert.h>
 #include <limits.h>
 #include <string.h>
+#include <stdio.h>
 
 #include <zcbor_common.h>
 #include <zcbor_decode.h>
@@ -62,15 +63,49 @@ LOG_MODULE_REGISTER(mcumgr_fs_grp, CONFIG_MCUMGR_GRP_FS_LOG_LEVEL);
 
 #define HASH_CHECKSUM_SUPPORTED_COLUMNS_MAX 4
 
-static struct {
-	/** Whether an upload is currently in progress. */
-	bool uploading;
+#if CONFIG_MCUMGR_GRP_FS_FILE_SEMAPHORE_TAKE_TIME == 0
+#define FILE_SEMAPHORE_MAX_TAKE_TIME K_NO_WAIT
+#else
+#define FILE_SEMAPHORE_MAX_TAKE_TIME K_MSEC(CONFIG_MCUMGR_GRP_FS_FILE_SEMAPHORE_TAKE_TIME)
+#endif
 
-	/** Expected offset of next upload request. */
+#define FILE_SEMAPHORE_MAX_TAKE_TIME_WORK_HANDLER K_MSEC(500)
+#define FILE_CLOSE_IDLE_TIME K_MSEC(CONFIG_MCUMGR_GRP_FS_FILE_AUTOMATIC_IDLE_CLOSE_TIME)
+
+enum {
+	STATE_NO_UPLOAD_OR_DOWNLOAD = 0,
+	STATE_UPLOAD,
+	STATE_DOWNLOAD,
+};
+
+static struct {
+	/** Whether an upload or download is currently in progress. */
+	uint8_t state;
+
+	/** Expected offset of next upload/download request. */
 	size_t off;
 
-	/** Total length of file currently being uploaded. */
+	/**
+	 * Total length of file currently being uploaded/downloaded. Note that for file
+	 * uploads, it is possible for this to be lost in which case it is not known when
+	 * the file can be closed, and the automatic close will need to close the file.
+	 */
 	size_t len;
+
+	/** Path of file being accessed. */
+	char path[CONFIG_MCUMGR_GRP_FS_PATH_LEN + 1];
+
+	/** File handle. */
+	struct fs_file_t file;
+
+	/** Semaphore lock. */
+	struct k_sem lock_sem;
+
+	/** Which transport owns the lock on the on-going file transfer. */
+	void *transport;
+
+	/** Delayed workqueue used to close the file after a period of inactivity. */
+	struct k_work_delayable file_close_work;
 } fs_mgmt_ctxt;
 
 static const struct mgmt_handler fs_mgmt_handlers[];
@@ -82,6 +117,32 @@ struct fs_mgmt_hash_checksum_iterator_info {
 	bool ok;
 };
 #endif
+
+/* Clean up open file state */
+static void fs_mgmt_cleanup(void)
+{
+	if (fs_mgmt_ctxt.state != STATE_NO_UPLOAD_OR_DOWNLOAD) {
+		fs_mgmt_ctxt.state = STATE_NO_UPLOAD_OR_DOWNLOAD;
+		fs_mgmt_ctxt.off = 0;
+		fs_mgmt_ctxt.len = 0;
+		memset(fs_mgmt_ctxt.path, 0, sizeof(fs_mgmt_ctxt.path));
+		fs_close(&fs_mgmt_ctxt.file);
+		fs_mgmt_ctxt.transport = NULL;
+	}
+}
+
+static void file_close_work_handler(struct k_work *work)
+{
+	if (k_sem_take(&fs_mgmt_ctxt.lock_sem, FILE_SEMAPHORE_MAX_TAKE_TIME_WORK_HANDLER)) {
+		/* Re-schedule to retry */
+		k_work_reschedule(&fs_mgmt_ctxt.file_close_work, FILE_CLOSE_IDLE_TIME);
+		return;
+	}
+
+	fs_mgmt_cleanup();
+
+	k_sem_give(&fs_mgmt_ctxt.lock_sem);
+}
 
 static int fs_mgmt_filelen(const char *path, size_t *out_len)
 {
@@ -123,39 +184,18 @@ static bool fs_mgmt_file_rsp(zcbor_state_t *zse, int rc, uint64_t off)
 		     zcbor_uint64_put(zse, off);
 }
 
-static int fs_mgmt_read(const char *path, size_t offset, size_t len,
-			void *out_data, size_t *out_len)
+/**
+ * Cleans up open file handle and state when upload is finished.
+ */
+static void fs_mgmt_upload_download_finish_check(void)
 {
-	struct fs_file_t file;
-	ssize_t bytes_read;
-	int rc;
-
-	fs_file_t_init(&file);
-	rc = fs_open(&file, path, FS_O_READ);
-	if (rc != 0) {
-		return MGMT_ERR_ENOENT;
+	if (fs_mgmt_ctxt.len > 0 && fs_mgmt_ctxt.off >= fs_mgmt_ctxt.len) {
+		/* File upload/download has finished, clean up */
+		k_work_cancel_delayable(&fs_mgmt_ctxt.file_close_work);
+		fs_mgmt_cleanup();
+	} else {
+		k_work_reschedule(&fs_mgmt_ctxt.file_close_work, FILE_CLOSE_IDLE_TIME);
 	}
-
-	rc = fs_seek(&file, offset, FS_SEEK_SET);
-	if (rc != 0) {
-		goto done;
-	}
-
-	bytes_read = fs_read(&file, out_data, len);
-	if (bytes_read < 0) {
-		goto done;
-	}
-
-	*out_len = bytes_read;
-
-done:
-	fs_close(&file);
-
-	if (rc < 0) {
-		return MGMT_ERR_EUNKNOWN;
-	}
-
-	return 0;
 }
 
 /**
@@ -167,7 +207,6 @@ static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 	char path[CONFIG_MCUMGR_GRP_FS_PATH_LEN + 1];
 	uint64_t off = ULLONG_MAX;
 	size_t bytes_read = 0;
-	size_t file_len;
 	int rc;
 	zcbor_state_t *zse = ctxt->writer->zs;
 	zcbor_state_t *zsd = ctxt->reader->zs;
@@ -207,93 +246,84 @@ static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 	}
 #endif
 
+	if (k_sem_take(&fs_mgmt_ctxt.lock_sem, FILE_SEMAPHORE_MAX_TAKE_TIME)) {
+		return MGMT_ERR_EBUSY;
+	}
+
+	/* Check if this download is already in progress */
+	if (ctxt->smpt != fs_mgmt_ctxt.transport ||
+	    fs_mgmt_ctxt.state != STATE_DOWNLOAD ||
+	    strcmp(path, fs_mgmt_ctxt.path)) {
+		fs_mgmt_cleanup();
+	}
+
+	/* Open new file */
+	if (fs_mgmt_ctxt.state == STATE_NO_UPLOAD_OR_DOWNLOAD) {
+		rc = fs_mgmt_filelen(path, &fs_mgmt_ctxt.len);
+
+		if (rc != 0) {
+			k_sem_give(&fs_mgmt_ctxt.lock_sem);
+			return rc;
+		}
+
+		fs_mgmt_ctxt.off = 0;
+		fs_file_t_init(&fs_mgmt_ctxt.file);
+		rc = fs_open(&fs_mgmt_ctxt.file, path, FS_O_READ);
+
+		if (rc != 0) {
+			rc = MGMT_ERR_ENOENT;
+			goto end;
+		}
+
+		strcpy(fs_mgmt_ctxt.path, path);
+		fs_mgmt_ctxt.state = STATE_DOWNLOAD;
+		fs_mgmt_ctxt.transport = ctxt->smpt;
+	}
+
+	/* Seek to desired offset */
+	if (off != fs_mgmt_ctxt.off) {
+		rc = fs_seek(&fs_mgmt_ctxt.file, off, FS_SEEK_SET);
+
+		if (rc != 0) {
+			rc = MGMT_ERR_EUNKNOWN;
+			fs_mgmt_cleanup();
+			goto end;
+		}
+
+		fs_mgmt_ctxt.off = off;
+	}
+
 	/* Only the response to the first download request contains the total file
 	 * length.
 	 */
-	if (off == 0) {
-		rc = fs_mgmt_filelen(path, &file_len);
-		if (rc != 0) {
-			return rc;
-		}
-	}
 
 	/* Read the requested chunk from the file. */
-	rc = fs_mgmt_read(path, off, MCUMGR_GRP_FS_DL_CHUNK_SIZE, file_data, &bytes_read);
-	if (rc != 0) {
-		return rc;
+	bytes_read = fs_read(&fs_mgmt_ctxt.file, file_data, MCUMGR_GRP_FS_DL_CHUNK_SIZE);
+
+	if (bytes_read < 0) {
+		rc = MGMT_ERR_EUNKNOWN;
+		fs_mgmt_cleanup();
+		goto end;
 	}
+
+	/* Increment offset */
+	fs_mgmt_ctxt.off += bytes_read;
 
 	/* Encode the response. */
 	ok = fs_mgmt_file_rsp(zse, MGMT_ERR_EOK, off)				&&
 	     zcbor_tstr_put_lit(zse, "data")					&&
 	     zcbor_bstr_encode_ptr(zse, file_data, bytes_read)			&&
 	     ((off != 0)							||
-		(zcbor_tstr_put_lit(zse, "len") && zcbor_uint64_put(zse, file_len)));
+		(zcbor_tstr_put_lit(zse, "len") && zcbor_uint64_put(zse, fs_mgmt_ctxt.len)));
 
-	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
-}
+	fs_mgmt_upload_download_finish_check();
 
-static int fs_mgmt_write(const char *path, size_t offset,
-			 const void *data, size_t len)
-{
-	struct fs_file_t file;
-	int rc;
-	size_t file_size = 0;
+	rc = (ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE);
 
-	if (offset == 0) {
-		rc = fs_mgmt_filelen(path, &file_size);
-	}
+end:
+	k_sem_give(&fs_mgmt_ctxt.lock_sem);
 
-	fs_file_t_init(&file);
-	rc = fs_open(&file, path, FS_O_CREATE | FS_O_WRITE);
-	if (rc != 0) {
-		return MGMT_ERR_EUNKNOWN;
-	}
-
-	if (offset == 0 && file_size > 0) {
-		/* Offset is 0 and existing file exists with data, attempt to truncate the file
-		 * size to 0
-		 */
-		rc = fs_truncate(&file, 0);
-
-		if (rc == -ENOTSUP) {
-			/* Truncation not supported by filesystem, therefore close file, delete
-			 * it then re-open it
-			 */
-			fs_close(&file);
-
-			rc = fs_unlink(path);
-			if (rc < 0 && rc != -ENOENT) {
-				return rc;
-			}
-
-			rc = fs_open(&file, path, FS_O_CREATE | FS_O_WRITE);
-		}
-
-		if (rc < 0) {
-			/* Failed to truncate file */
-			return MGMT_ERR_EUNKNOWN;
-		}
-	} else if (offset > 0) {
-		rc = fs_seek(&file, offset, FS_SEEK_SET);
-		if (rc != 0) {
-			goto done;
-		}
-	}
-
-	rc = fs_write(&file, data, len);
-	if (rc < 0) {
-		goto done;
-	}
-
-done:
-	fs_close(&file);
-
-	if (rc < 0) {
-		return MGMT_ERR_EUNKNOWN;
-	}
-
-	return 0;
+	return rc;
 }
 
 /**
@@ -304,7 +334,6 @@ static int fs_mgmt_file_upload(struct smp_streamer *ctxt)
 	char file_name[CONFIG_MCUMGR_GRP_FS_PATH_LEN + 1];
 	unsigned long long len = ULLONG_MAX;
 	unsigned long long off = ULLONG_MAX;
-	size_t new_off;
 	bool ok;
 	int rc;
 	zcbor_state_t *zse = ctxt->writer->zs;
@@ -312,6 +341,7 @@ static int fs_mgmt_file_upload(struct smp_streamer *ctxt)
 	struct zcbor_string name = { 0 };
 	struct zcbor_string file_data = { 0 };
 	size_t decoded = 0;
+	ssize_t existing_file_size = 0;
 
 	struct zcbor_map_decode_key_val fs_upload_decode[] = {
 		ZCBOR_MAP_DECODE_KEY_DECODER("off", zcbor_uint64_decode, &off),
@@ -353,44 +383,152 @@ static int fs_mgmt_file_upload(struct smp_streamer *ctxt)
 		if (len == ULLONG_MAX) {
 			return MGMT_ERR_EINVAL;
 		}
+	}
 
-		fs_mgmt_ctxt.uploading = true;
+	if (k_sem_take(&fs_mgmt_ctxt.lock_sem, FILE_SEMAPHORE_MAX_TAKE_TIME)) {
+		return MGMT_ERR_EBUSY;
+	}
+
+	/* Check if this upload is already in progress */
+	if (ctxt->smpt != fs_mgmt_ctxt.transport ||
+	    fs_mgmt_ctxt.state != STATE_UPLOAD ||
+	    strcmp(file_name, fs_mgmt_ctxt.path)) {
+		fs_mgmt_cleanup();
+	}
+
+	/* Open new file */
+	if (fs_mgmt_ctxt.state == STATE_NO_UPLOAD_OR_DOWNLOAD) {
 		fs_mgmt_ctxt.off = 0;
-		fs_mgmt_ctxt.len = len;
-	} else {
-		if (!fs_mgmt_ctxt.uploading) {
-			return MGMT_ERR_EINVAL;
+		fs_file_t_init(&fs_mgmt_ctxt.file);
+		rc = fs_open(&fs_mgmt_ctxt.file, file_name, FS_O_CREATE | FS_O_WRITE);
+
+		if (rc != 0) {
+			rc = MGMT_ERR_ENOENT;
+			goto end;
 		}
 
-		if (off != fs_mgmt_ctxt.off) {
-			/* Invalid offset.  Drop the data and send the expected offset. */
-			return fs_mgmt_file_rsp(zse, MGMT_ERR_EINVAL, fs_mgmt_ctxt.off);
+		strcpy(fs_mgmt_ctxt.path, file_name);
+		fs_mgmt_ctxt.state = STATE_UPLOAD;
+		fs_mgmt_ctxt.transport = ctxt->smpt;
+	}
+
+	if (off == 0) {
+		/* Store the uploaded file size from the first packet, this will allow
+		 * closing the file when the full upload has finished, however the file
+		 * will remain opened if the upload state is lost. It will, however,
+		 * still be closed automatically after a timeout.
+		 */
+		fs_mgmt_ctxt.len = len;
+		rc = fs_mgmt_filelen(file_name, &existing_file_size);
+
+		if (rc != 0) {
+			rc = MGMT_ERR_EUNKNOWN;
+			fs_mgmt_cleanup();
+			goto end;
+		}
+	} else if (fs_mgmt_ctxt.off == 0) {
+		rc = fs_mgmt_filelen(file_name, &fs_mgmt_ctxt.off);
+
+		if (rc != 0) {
+			rc = MGMT_ERR_EUNKNOWN;
+			fs_mgmt_cleanup();
+			goto end;
 		}
 	}
 
-	new_off = fs_mgmt_ctxt.off + file_data.len;
-	if (new_off > fs_mgmt_ctxt.len) {
-		/* Data exceeds image length. */
-		return MGMT_ERR_EINVAL;
+	/* Verify that the data offset matches the expected offset (i.e. current size of file) */
+	if (off > 0 && off != fs_mgmt_ctxt.off) {
+		/* Offset mismatch, send file length, client needs to handle this */
+		ok = zcbor_tstr_put_lit(zse, "rc")		&&
+		     zcbor_int32_put(zse, MGMT_ERR_EUNKNOWN)	&&
+		     zcbor_tstr_put_lit(zse, "len")		&&
+		     zcbor_uint64_put(zse, fs_mgmt_ctxt.off);
+
+		rc = (ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE);
+
+		/* Because the client would most likely decide to abort and transfer and start
+		 * again, clean everything up and release the file handle so it can be used
+		 * elsewhere (if needed).
+		 */
+		fs_mgmt_cleanup();
+		goto end;
 	}
 
 	if (file_data.len > 0) {
 		/* Write the data chunk to the file. */
-		rc = fs_mgmt_write(file_name, off, file_data.value, file_data.len);
-		if (rc != 0) {
-			return rc;
-		}
-		fs_mgmt_ctxt.off = new_off;
-	}
+		if (off == 0 && existing_file_size != 0) {
+			/* Offset is 0 and existing file exists with data, attempt to truncate
+			 * the file size to 0
+			 */
+			rc = fs_seek(&fs_mgmt_ctxt.file, 0, FS_SEEK_SET);
 
-	if (fs_mgmt_ctxt.off == fs_mgmt_ctxt.len) {
-		/* Upload complete. */
-		fs_mgmt_ctxt.uploading = false;
+			if (rc != 0) {
+				rc = MGMT_ERR_EUNKNOWN;
+				fs_mgmt_cleanup();
+				goto end;
+			}
+
+			rc = fs_truncate(&fs_mgmt_ctxt.file, 0);
+
+			if (rc == -ENOTSUP) {
+				/* Truncation not supported by filesystem, therefore close file,
+				 * delete it then re-open it
+				 */
+				fs_close(&fs_mgmt_ctxt.file);
+
+				rc = fs_unlink(file_name);
+				if (rc < 0 && rc != -ENOENT) {
+					rc = MGMT_ERR_EUNKNOWN;
+					fs_mgmt_cleanup();
+					goto end;
+				}
+
+				rc = fs_open(&fs_mgmt_ctxt.file, file_name, FS_O_CREATE |
+					     FS_O_WRITE);
+			}
+
+			if (rc < 0) {
+				/* Failed to truncate file */
+				rc = MGMT_ERR_EUNKNOWN;
+				fs_mgmt_cleanup();
+				goto end;
+			}
+		} else if (fs_tell(&fs_mgmt_ctxt.file) != off) {
+			/* The offset has been validated to be file size previously, seek to
+			 * the end of the file to write the new data.
+			 */
+			rc = fs_seek(&fs_mgmt_ctxt.file, 0, FS_SEEK_END);
+
+			if (rc < 0) {
+				/* Failed to seek in file */
+				rc = MGMT_ERR_EUNKNOWN;
+				fs_mgmt_cleanup();
+				goto end;
+			}
+		}
+
+		rc = fs_write(&fs_mgmt_ctxt.file, file_data.value, file_data.len);
+
+		if (rc < 0) {
+			rc = MGMT_ERR_EUNKNOWN;
+			fs_mgmt_cleanup();
+			goto end;
+		}
+
+		fs_mgmt_ctxt.off += file_data.len;
 	}
 
 	/* Send the response. */
-	return fs_mgmt_file_rsp(zse, MGMT_ERR_EOK, fs_mgmt_ctxt.off) ?
-			MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
+	ok = fs_mgmt_file_rsp(zse, MGMT_ERR_EOK, fs_mgmt_ctxt.off);
+
+	fs_mgmt_upload_download_finish_check();
+
+	rc = (ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE);
+
+end:
+	k_sem_give(&fs_mgmt_ctxt.lock_sem);
+
+	return rc;
 }
 
 #if defined(CONFIG_MCUMGR_GRP_FS_FILE_STATUS)
@@ -640,6 +778,22 @@ fs_mgmt_supported_hash_checksum(struct smp_streamer *ctxt)
 #endif
 #endif
 
+/**
+ * Command handler: fs opened file (write)
+ */
+static int fs_mgmt_close_opened_file(struct smp_streamer *ctxt)
+{
+	if (k_sem_take(&fs_mgmt_ctxt.lock_sem, FILE_SEMAPHORE_MAX_TAKE_TIME)) {
+		return MGMT_ERR_EBUSY;
+	}
+
+	fs_mgmt_cleanup();
+
+	k_sem_give(&fs_mgmt_ctxt.lock_sem);
+
+	return MGMT_ERR_EOK;
+}
+
 static const struct mgmt_handler fs_mgmt_handlers[] = {
 	[FS_MGMT_ID_FILE] = {
 		.mh_read = fs_mgmt_file_download,
@@ -663,6 +817,10 @@ static const struct mgmt_handler fs_mgmt_handlers[] = {
 	},
 #endif
 #endif
+	[FS_MGMT_ID_OPENED_FILE] = {
+		.mh_read = NULL,
+		.mh_write = fs_mgmt_close_opened_file,
+	},
 };
 
 #define FS_MGMT_HANDLER_CNT ARRAY_SIZE(fs_mgmt_handlers)
@@ -675,6 +833,11 @@ static struct mgmt_group fs_mgmt_group = {
 
 static void fs_mgmt_register_group(void)
 {
+	/* Initialise state variables */
+	fs_mgmt_ctxt.state = STATE_NO_UPLOAD_OR_DOWNLOAD;
+	k_sem_init(&fs_mgmt_ctxt.lock_sem, 1, 1);
+	k_work_init_delayable(&fs_mgmt_ctxt.file_close_work, file_close_work_handler);
+
 	mgmt_register_group(&fs_mgmt_group);
 
 #if defined(CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH)


### PR DESCRIPTION
This vastly increases the performance of file transfers using the fs_mgmt group over MCUmgr by allowing the file handle to remain open between commands instead of having to open, feek, read/write then close the file handle for each invocation.

Fixes #52075

- [X] Upload code improvement
- [X] Download code improvement
- [x] Add fs_mgmt command to close open files (i.e. clean up)
- [x] Possibly add timer for automatic clean up if an upload/download is started but abandoned part way through
- [x] Code clean up
- [x] Kconfig to control new feature to truncate file to new size upon creation (early warning of insufficient flash to upload) **should be disabled by default:** allocating e.g. 2MB on a QSPI flash is very slow, apparently
- [ ] ~~Possibly add option to revert back to old method (check flash/RAM usage)~~
- [ ] ~~Possibly add array of fs_mgmt states, one for upload and one for download, to allow for con-current upload and download by different transports (as with this patch, if using fs_mgmt on 2 interfaces at the same time, the old issue of having to open, seed, read/write, close is present whilst flipping between states)~~ will leave for another PR if this is going to be implemented
- [x] Documentation update (if needed)
- [x] Release notes update