### PR TITLE
correct the stm32 OSPI and QSPI  Device SIZE written to periph register

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -1934,7 +1934,8 @@ static int flash_stm32_ospi_init(const struct device *dev)
 	/* Initialize OSPI HAL structure completely */
 	dev_data->hospi.Init.FifoThreshold = 4;
 	dev_data->hospi.Init.ClockPrescaler = prescaler;
-	dev_data->hospi.Init.DeviceSize = find_lsb_set(dev_cfg->flash_size);
+	/* Give a bit position from 0 to 31 to the HAL init for the DCR1 reg */
+	dev_data->hospi.Init.DeviceSize = find_lsb_set(dev_cfg->flash_size) - 1;
 	dev_data->hospi.Init.DualQuad = HAL_OSPI_DUALQUAD_DISABLE;
 	dev_data->hospi.Init.ChipSelectHighTime = 2;
 	dev_data->hospi.Init.FreeRunningClock = HAL_OSPI_FREERUNCLK_DISABLE;

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -1189,7 +1189,8 @@ static int flash_stm32_qspi_init(const struct device *dev)
 	__ASSERT_NO_MSG(prescaler <= STM32_QSPI_CLOCK_PRESCALER_MAX);
 	/* Initialize QSPI HAL */
 	dev_data->hqspi.Init.ClockPrescaler = prescaler;
-	dev_data->hqspi.Init.FlashSize = find_lsb_set(dev_cfg->flash_size);
+	/* Give a bit position from 0 to 31 to the HAL init minus 1 for the DCR1 reg */
+	dev_data->hqspi.Init.FlashSize = find_lsb_set(dev_cfg->flash_size) - 2;
 
 	HAL_QSPI_Init(&dev_data->hqspi);
 


### PR DESCRIPTION
During the initialization of the OSPI or QSPI of the Stm32 device, 
the peripheral device configuration register (DCR) is writing   :

- for OCTOSPI : 
DEVSIZE[4:0]: Device size 
This bitfield defines the size of the external device using the following formula:
Number of bytes in device = 2^[DEVSIZE+1] .
DEVSIZE + 1 is effectively the number of address bits required to address the external
device.
- for QUADSPI : 
 FSIZE[4:0]: Flash memory size
This bitfield defines the size of the external device using the following formula:
Number of bytes in device = 2^[FSIZE+1] .
FSIZE + 1 is effectively the number of address bits required to address the external
device.

1) The OSPI_HandleTypeDef or QSPI_HandleTypeDef  structure has a Init.MemorySize to hold the bit POSITION_VAL of the device size. When using the find_lsb_set function Bits are numbered starting at 1 from the least significant bit.
Consequently, when the 64MBytes NOR flash is configured, bit 26 is set from[0:31] and 
POSITION_VAL(0x4000000) = 26 _but_ `find_lsb_set(0x4000000) = 27`

2) Because the stm32Cube  HAL_OSPI_Init and HAL_QSPI_Init APIs are specified differently and access their  DCR Device Configuration register : 

- for OCTOSPI :  writes DEVSIZE to the  DCR with  `((hospi->Init.DeviceSize - 1U) << OCTOSPI_DCR1_DEVSIZE_Pos)`
--> hospi->Init.DeviceSize = find_lsb_set() - 1

- for QUADSPI :   writes FSIZE to the  DCR with `((hqspi->Init.FlashSize << QUADSPI_DCR_FSIZE_Pos)`
--> hospi->Init.FlashSize = find_lsb_set() - 2


With that adjustment, when the NOR flash is 64MBytes, DCR[20:16] bitfield is **25**, and retrieving the correct "Number of bytes in Flash memory "= 2^[25+1] = 0x4000000


Signed-off-by: Francois Ramu <francois.ramu@st.com>