### PR TITLE
mgmt: mcumgr: Select console if using UART transport

### DIFF
--- a/subsys/mgmt/mcumgr/transport/Kconfig.uart
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.uart
@@ -11,6 +11,7 @@
 
 menuconfig MCUMGR_TRANSPORT_UART
 	bool "UART mcumgr SMP transport"
+	select CONSOLE
 	select UART_MCUMGR
 	select BASE64
 	help


### PR DESCRIPTION
This prevents a configuration error by selecting the console if the UART MCUmgr transport is used, which is actually a dependency for this transport.