### PR TITLE
tests: drivers: counter: counter_basic_api: src: Fix STM32 RTC device

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -85,6 +85,8 @@ static const struct device *const devices[] = {
 #endif
 #ifdef CONFIG_COUNTER_GECKO_RTCC
 	DEVS_FOR_DT_COMPAT(silabs_gecko_rtcc)
+#endif
+#ifdef CONFIG_COUNTER_RTC_STM32
 	DEVS_FOR_DT_COMPAT(st_stm32_rtc)
 #endif
 #ifdef CONFIG_COUNTER_GECKO_STIMER


### PR DESCRIPTION
Commit fd65800 introduced a regression for the counter_basic_api test for STM32 by using a Silabs Gecko Kconfig to enable the STM32 RTC. This commit uses the proper STM32 Kconfig for the RTC instead.

Signed-off-by: Guillaume Gautier <guillaume.gautier-ext@st.com>