### PR TITLE
Fix Zbus Benchmark Sample is smashing the stack and is too fast

### DIFF
--- a/samples/subsys/zbus/benchmark/sample.yaml
+++ b/samples/subsys/zbus/benchmark/sample.yaml
@@ -12,8 +12,8 @@ tests:
       regex:
         - "I: Benchmark 1 to 8: Dynamic memory, ASYNC transmission and message size 256"
         - "I: Bytes sent = 262144, received = 262144"
-        - "I: Average data rate: (.*)B/s"
-        - "I: Duration: (.*)ms"
+        - "I: Average data rate: (\\d+).(\\d+)MB/s"
+        - "I: Duration: (\\d+).(\\d+)us"
         - "@(.*)"
     extra_configs:
       - CONFIG_BM_ONE_TO=8
@@ -33,8 +33,8 @@ tests:
       regex:
         - "I: Benchmark 1 to 8: Dynamic memory, SYNC transmission and message size 256"
         - "I: Bytes sent = 262144, received = 262144"
-        - "I: Average data rate: (.*)B/s"
-        - "I: Duration: (.*)ms"
+        - "I: Average data rate: (\\d+).(\\d+)MB/s"
+        - "I: Duration: (\\d+).(\\d+)us"
         - "@(.*)"
     extra_configs:
       - CONFIG_BM_ONE_TO=8

--- a/samples/subsys/zbus/benchmark/sample.yaml
+++ b/samples/subsys/zbus/benchmark/sample.yaml
@@ -19,9 +19,6 @@ tests:
       - CONFIG_BM_ONE_TO=8
       - CONFIG_BM_MESSAGE_SIZE=256
       - CONFIG_BM_ASYNC=y
-    platform_exclude: qemu_x86 qemu_x86_64 qemu_riscv32_smp native_posix native_posix_64
-      qemu_riscv32_smp qemu_cortex_a53_smp qemu_riscv64_smp qemu_leon3 qemu_xtensa qemu_cortex_a53
-      qemu_riscv32 qemu_malta qemu_malta_be qemu_arc_hs6x qemu_riscv64 m2gl025_miv hifive_unleashed
   sample.zbus.benchmark_sync:
     tags: zbus
     min_ram: 16
@@ -40,6 +37,3 @@ tests:
       - CONFIG_BM_ONE_TO=8
       - CONFIG_BM_MESSAGE_SIZE=256
       - CONFIG_BM_ASYNC=n
-    platform_exclude: qemu_x86 qemu_x86_64 qemu_riscv32_smp native_posix native_posix_64
-      qemu_riscv32_smp qemu_cortex_a53_smp qemu_riscv64_smp qemu_leon3 qemu_xtensa qemu_cortex_a53
-      qemu_riscv32 m2gl025_miv m2gl025_miv

--- a/samples/subsys/zbus/benchmark/src/benchmark.c
+++ b/samples/subsys/zbus/benchmark/src/benchmark.c
@@ -13,6 +13,9 @@
 #include <zephyr/zbus/zbus.h>
 LOG_MODULE_DECLARE(zbus, CONFIG_ZBUS_LOG_LEVEL);
 
+#define CONSUMER_STACK_SIZE (CONFIG_IDLE_STACK_SIZE + CONFIG_BM_MESSAGE_SIZE)
+#define PRODUCER_STACK_SIZE (CONFIG_MAIN_STACK_SIZE + CONFIG_BM_MESSAGE_SIZE)
+
 ZBUS_CHAN_DEFINE(bm_channel,		   /* Name */
 		 struct external_data_msg, /* Message type */
 
@@ -91,8 +94,7 @@ ZBUS_SUBSCRIBER_DEFINE(s16, 4);
 		}                                                                                  \
 	}                                                                                          \
                                                                                                    \
-	K_THREAD_DEFINE(name##_id, CONFIG_BM_MESSAGE_SIZE + 196, name##_task, NULL, NULL, NULL, 3, \
-			0, 0);
+	K_THREAD_DEFINE(name##_id, CONSUMER_STACK_SIZE, name##_task, NULL, NULL, NULL, 3, 0, 0);
 
 S_TASK(s1)
 #if (CONFIG_BM_ONE_TO >= 2LLU)
@@ -213,4 +215,4 @@ static void producer_thread(void)
 	printk("\n@%u\n", duration);
 }
 
-K_THREAD_DEFINE(producer_thread_id, 1024, producer_thread, NULL, NULL, NULL, 5, 0, 0);
+K_THREAD_DEFINE(producer_thread_id, PRODUCER_STACK_SIZE, producer_thread, NULL, NULL, NULL, 5, 0, 0);


### PR DESCRIPTION
ZBus subscriber threads were smashing their threads. Upped their stack with something safe by utilising `IDLE_STACK_SIZE` for subscribers and `MAIN_STACK_SIZE` for producer.

Benchmark also finishes way too fast for most if not all targets. Used cycles instead of uptime as originally suggested by @rodrigopex and used nanosecond conversions to get around the `duration==0` check.

Native posix still returns `start` and `end` times as `0` though, so with further commits utilised `native_rtc` with `RTC_CLOCK_PSEUDOHOSTREALTIME` to get as much resolution as possible.