### PR TITLE
debug: tracing: Add Segger RTT linker section options

### DIFF
--- a/drivers/console/rtt_console.c
+++ b/drivers/console/rtt_console.c
@@ -41,9 +41,7 @@ static int rtt_console_out(int character)
 	int max_cnt = CONFIG_RTT_TX_RETRY_CNT;
 
 	do {
-		SEGGER_RTT_LOCK();
-		cnt = SEGGER_RTT_WriteNoLock(0, &c, 1);
-		SEGGER_RTT_UNLOCK();
+		cnt = SEGGER_RTT_Write(0, &c, 1);
 
 		/* There are two possible reasons for not writing any data to
 		 * RTT:

--- a/modules/segger/CMakeLists.txt
+++ b/modules/segger/CMakeLists.txt
@@ -10,6 +10,8 @@ if(CONFIG_USE_SEGGER_RTT)
     SEGGER_RTT_zephyr.c
   )
   zephyr_library_sources_ifdef(CONFIG_SEGGER_SYSTEMVIEW ${SEGGER_DIR}/SEGGER/SEGGER_SYSVIEW.c)
+  # Using sort key AAA to ensure that we are placed at start of RAM
+  zephyr_linker_sources_ifdef(CONFIG_SEGGER_RTT_SECTION_CUSTOM RAM_SECTIONS SORT_KEY aaa segger_rtt.ld)
 endif()
 
 if(CONFIG_SEGGER_DEBUGMON)

--- a/modules/segger/Kconfig
+++ b/modules/segger/Kconfig
@@ -103,4 +103,23 @@ config SEGGER_RTT_SECTION_CUSTOM_NAME
 
 endif
 
+choice SEGGER_RTT_INIT_MODE
+	prompt "RTT Initialization mode"
+	help
+		RTT inizialization function can avoid re-init of Cntrol Block
+		if another program (e.g. bootloader) has already initialized it.
+	default SEGGER_RTT_INIT_MODE_STRONG_CHECK if SEGGER_RTT_SECTION_CUSTOM
+	default SEGGER_RTT_INIT_MODE_STRONG_CHECK
+
+config SEGGER_RTT_INIT_MODE_ALWAYS
+	bool "RTT Initialization done without conditions"
+
+config SEGGER_RTT_INIT_MODE_STRONG_CHECK
+	bool "RTT Initialization done if full check on Control Block ID fails"
+
+config SEGGER_RTT_INIT_MODE_WEAK_CHECK
+	bool "RTT Initialization done if partial check on Control Block ID fails"
+
+endchoice
+
 endif

--- a/modules/segger/Kconfig
+++ b/modules/segger/Kconfig
@@ -72,6 +72,7 @@ config SEGGER_RTT_MEMCPY_USE_BYTELOOP
 
 choice SEGGER_RTT_SECTION
 	prompt "Choose RTT data linker section"
+	default SEGGER_RTT_SECTION_CUSTOM
 
 config SEGGER_RTT_SECTION_NONE
 	bool "Place RTT data in the default linker section"
@@ -82,6 +83,24 @@ config SEGGER_RTT_SECTION_DTCM
 config SEGGER_RTT_SECTION_CCM
 	bool "Place RTT data in the CCM linker section"
 
+if CPU_CORTEX_M
+
+config SEGGER_RTT_SECTION_CUSTOM
+	bool "Place RTT data in custom linker section at RAM start"
+
+config SEGGER_RTT_SECTION_CUSTOM_DTS_REGION
+	bool "Place RTT data in custom linker section defined by a memory region in DTS"
+
+endif
+
 endchoice
+
+if SEGGER_RTT_SECTION_CUSTOM || SEGGER_RTT_SECTION_CUSTOM_DTS_REGION
+
+config SEGGER_RTT_SECTION_CUSTOM_NAME
+	string "Name of RTT data custom linker section"
+	default ".rtt_buff_data"
+
+endif
 
 endif

--- a/modules/segger/segger_rtt.ld
+++ b/modules/segger/segger_rtt.ld
@@ -1,0 +1,7 @@
+SECTION_DATA_PROLOGUE(_RTT_SECTION_NAME,(NOLOAD),)
+{
+__rtt_buff_data_start = .;
+*(CONFIG_SEGGER_RTT_SECTION_CUSTOM_NAME)
+__rtt_buff_data_end = ALIGN(4);
+} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+__rtt_buff_data_size = __rtt_buff_data_end - __rtt_buff_data_start;


### PR DESCRIPTION
Allows optionally placing Segger RTT data either in a specific
linker section that is located at RAM start, or in a specific linker
section defined by a memory region in DTS, as third and fourth
alternative to the DTCM section or the default data section.
This is useful to share the fixed address for different programs,
typically bootloader and application, and have seamless logging.

Signed-off-by: Giancarlo Stasi <giancarlo.stasi.co@gmail.com>

fixes #53544