### PR TITLE
x86: Assorted fixes

### DIFF
--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -33,15 +33,6 @@ FUNC_NORETURN void arch_system_halt(unsigned int reason)
 }
 #endif
 
-static inline uintptr_t esf_get_sp(const z_arch_esf_t *esf)
-{
-#ifdef CONFIG_X86_64
-	return esf->rsp;
-#else
-	return esf->esp;
-#endif
-}
-
 static inline uintptr_t esf_get_code(const z_arch_esf_t *esf)
 {
 #ifdef CONFIG_X86_64
@@ -52,6 +43,16 @@ static inline uintptr_t esf_get_code(const z_arch_esf_t *esf)
 }
 
 #ifdef CONFIG_THREAD_STACK_INFO
+
+static inline uintptr_t esf_get_sp(const z_arch_esf_t *esf)
+{
+#ifdef CONFIG_X86_64
+	return esf->rsp;
+#else
+	return esf->esp;
+#endif
+}
+
 __pinned_func
 bool z_x86_check_stack_bounds(uintptr_t addr, size_t size, uint16_t cs)
 {

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -33,15 +33,6 @@ FUNC_NORETURN void arch_system_halt(unsigned int reason)
 }
 #endif
 
-static inline uintptr_t esf_get_code(const z_arch_esf_t *esf)
-{
-#ifdef CONFIG_X86_64
-	return esf->code;
-#else
-	return esf->errorCode;
-#endif
-}
-
 #ifdef CONFIG_THREAD_STACK_INFO
 
 static inline uintptr_t esf_get_sp(const z_arch_esf_t *esf)
@@ -96,6 +87,16 @@ bool z_x86_check_stack_bounds(uintptr_t addr, size_t size, uint16_t cs)
 #endif
 
 #ifdef CONFIG_EXCEPTION_DEBUG
+
+static inline uintptr_t esf_get_code(const z_arch_esf_t *esf)
+{
+#ifdef CONFIG_X86_64
+	return esf->code;
+#else
+	return esf->errorCode;
+#endif
+}
+
 #if defined(CONFIG_X86_EXCEPTION_STACK_TRACE)
 struct stack_frame {
 	uintptr_t next;

--- a/arch/x86/core/ia32/irq_manage.c
+++ b/arch/x86/core/ia32/irq_manage.c
@@ -18,7 +18,6 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/kernel_structs.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys/printk.h>
 #include <zephyr/irq.h>
 #include <zephyr/tracing/tracing.h>
 #include <kswap.h>

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -153,18 +153,6 @@ static inline void hpet_gconf_set(uint32_t val)
 }
 
 /**
- * @brief Write to General Interrupt Status Register
- *
- * This is used to acknowledge and clear interrupt bits.
- *
- * @param val Value to be written to the register
- */
-static inline void hpet_int_sts_set(uint32_t val)
-{
-	sys_write32(val, INTR_STATUS_REG);
-}
-
-/**
  * @brief Return the value of the Timer Configuration Register
  *
  * This reads and returns the value of the Timer Configuration
@@ -258,6 +246,20 @@ static __pinned_bss unsigned int cyc_per_tick;
 #endif /* CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME */
 
 #define HPET_MAX_TICKS ((int32_t)0x7fffffff)
+
+#ifdef HPET_INT_LEVEL_TRIGGER
+/**
+ * @brief Write to General Interrupt Status Register
+ *
+ * This is used to acknowledge and clear interrupt bits.
+ *
+ * @param val Value to be written to the register
+ */
+static inline void hpet_int_sts_set(uint32_t val)
+{
+	sys_write32(val, INTR_STATUS_REG);
+}
+#endif
 
 __isr
 static void hpet_isr(const void *arg)

--- a/kernel/banner.c
+++ b/kernel/banner.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/sys/util.h>
 #include <zephyr/init.h>
 #include <zephyr/device.h>
 #include <version.h>

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -178,6 +178,7 @@ static ALWAYS_INLINE struct k_thread *_priq_dumb_mask_best(sys_dlist_t *pq)
 }
 #endif
 
+#if defined(CONFIG_SCHED_DUMB) || defined(CONFIG_WAITQ_DUMB)
 static ALWAYS_INLINE void z_priq_dumb_add(sys_dlist_t *pq,
 					  struct k_thread *thread)
 {
@@ -195,6 +196,7 @@ static ALWAYS_INLINE void z_priq_dumb_add(sys_dlist_t *pq,
 
 	sys_dlist_append(pq, &thread->base.qnode_dlist);
 }
+#endif
 
 static ALWAYS_INLINE void *thread_runq(struct k_thread *thread)
 {

--- a/subsys/tracing/tracing_none.c
+++ b/subsys/tracing/tracing_none.c
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/init.h>
-#include <string.h>
-#include <zephyr/kernel.h>
 
 void sys_trace_isr_enter(void) {}
 


### PR DESCRIPTION
- Remove unnecessary headers
- Move functions to inside ifdef guards to avoid deadcode