### PR TITLE
samples/modules/chre: Support picolibc %p for NULL pointers

### DIFF
--- a/samples/modules/chre/sample.yaml
+++ b/samples/modules/chre/sample.yaml
@@ -18,7 +18,7 @@ tests:
         - "D: Instance ID 1 assigned to app ID 0x0000000000000001.*"
         - "EchoApp::nanoappStart\\(\\)"
         - "EchoApp::nanoappHandleEvent\\(sender_instance_id=0, event_type=1,
-          event_data@\\(nil\\)\\)"
+          event_data@(\\(nil\\))|0\\)"
         - "Event \\(1\\) complete!"
         - "EchoApp::nanoappEnd\\(\\)"
         - "I: Exiting EventLoop.*"


### PR DESCRIPTION
glibc and newlib print "(nil)" for NULL pointers while picolibc just prints "0". Allow either by replacing the exact "(nil)" match with ".*" instead

Note that both C and POSIX specs place no specific requirements on how pointer values are represented, so this is not a question of standards compliance.

Signed-off-by: Keith Packard <keithp@keithp.com>