### PR TITLE
samples/philosophers: Make output atomic with picolibc

### DIFF
--- a/samples/subsys/portability/cmsis_rtos_v1/philosophers/sample.yaml
+++ b/samples/subsys/portability/cmsis_rtos_v1/philosophers/sample.yaml
@@ -13,9 +13,10 @@ common:
     ordered: false
     regex:
       - ".*STARVING.*"
+      - ".*HOLDING.*"
+      - ".*EATING.*"
       - ".*DROPPED ONE FORK.*"
       - ".*THINKING.*"
-      - ".*EATING.*"
 tests:
   sample.portability.cmsis_rtos_v1.philosopher:
     tags: cmsis_rtos

--- a/samples/subsys/portability/cmsis_rtos_v1/philosophers/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v1/philosophers/src/main.c
@@ -100,19 +100,24 @@ static void print_phil_state(int id, const char *fmt, int32_t delay)
 	int prio = osThreadGetPriority(osThreadGetId());
 
 	set_phil_state_pos(id);
+#define STATE_LEN 80
+	char state[STATE_LEN];
+	int p = 0;
 
-	printk("Philosopher %d [%s:%s%d] ",
-	       id, prio < 0 ? "C" : "P",
-	       prio < 0 ? "" : " ",
-	       prio);
+	p += snprintk(state + p, STATE_LEN - p, "Philosopher %d [%s:%s%d] ",
+		     id, prio < 0 ? "C" : "P",
+		     prio < 0 ? "" : " ",
+		     prio);
 
 	if (delay) {
-		printk(fmt, delay < 1000 ? " " : "", delay);
+		p += snprintk(state + p, STATE_LEN - p, fmt,
+			      delay < 1000 ? " " : "", delay);
 	} else {
-		printk(fmt, "");
+		p += snprintk(state + p, STATE_LEN - p, fmt, "");
 	}
 
-	printk("\n");
+	p += snprintk(state + p, STATE_LEN - p, "\n");
+	printk("%s", state);
 }
 
 static int32_t get_random_delay(int id, int period_in_ms)


### PR DESCRIPTION
Picolibc doesn't have any output buffering for printk, so the various
pieces of the status line would get interleaved between threads. Build the
whole line in memory using snprintk and then print it in a single printk
call.

This series also has a patch in the test configuration to match the 
'HOLDING' status as well as place the EATING status in the right sequence.
    
Signed-off-by: Keith Packard <keithp@keithp.com>