### PR TITLE
usb_c: Add protocol error flag

### DIFF
--- a/subsys/usb/usb_c/usbc_pe_common.c
+++ b/subsys/usb/usb_c/usbc_pe_common.c
@@ -230,7 +230,7 @@ void pe_report_error(const struct device *dev, const enum pe_error e,
 	 */
 	if (pe_get_state(dev) == PE_SEND_SOFT_RESET ||
 	    pe_get_state(dev) == PE_SOFT_RESET) {
-		pe_set_state(dev, PE_SNK_HARD_RESET);
+		atomic_set_bit(pe->flags, PE_FLAGS_PROTOCOL_ERROR);
 		return;
 	}
 

--- a/subsys/usb/usb_c/usbc_pe_common_internal.h
+++ b/subsys/usb/usb_c/usbc_pe_common_internal.h
@@ -106,6 +106,10 @@ enum pe_flags {
 	 * Data Role Swap
 	 */
 	PE_FLAGS_WAIT_DATA_ROLE_SWAP = 12,
+	/**
+	 * This flag is set when a protocol error occurs.
+	 */
+	PE_FLAGS_PROTOCOL_ERROR = 13,
 
 	/** Number of PE Flags */
 	PE_FLAGS_COUNT

--- a/subsys/usb/usb_c/usbc_pe_snk_states.c
+++ b/subsys/usb/usb_c/usbc_pe_snk_states.c
@@ -289,12 +289,11 @@ void pe_snk_select_capability_run(void *obj)
 				}
 
 				pe_set_state(dev, PE_SNK_READY);
-			}
-			/*
-			 * No previous explicit contract, so transition
-			 * to PE_SNK_Wait_For_Capabilities
-			 */
-			else {
+			} else {
+				/*
+				 * No previous explicit contract, so transition
+				 * to PE_SNK_Wait_For_Capabilities
+				 */
 				pe_set_state(dev, PE_SNK_WAIT_FOR_CAPABILITIES);
 			}
 		} else {
@@ -426,9 +425,8 @@ void pe_snk_ready_run(void *obj)
 		if (header.extended) {
 			extended_message_not_supported(dev);
 			return;
-		}
-		/* Data Messages */
-		else if (header.number_of_data_objects > 0) {
+		} else if (header.number_of_data_objects > 0) {
+			/* Data Messages */
 			switch (header.message_type) {
 			case PD_DATA_SOURCE_CAP:
 				pe_set_state(dev, PE_SNK_EVALUATE_CAPABILITY);
@@ -437,9 +435,8 @@ void pe_snk_ready_run(void *obj)
 				pe_set_state(dev, PE_SEND_NOT_SUPPORTED);
 			}
 			return;
-		}
-		/* Control Messages */
-		else {
+		} else {
+			/* Control Messages */
 			switch (header.message_type) {
 			case PD_CTRL_GOOD_CRC:
 				/* Do nothing */
@@ -632,25 +629,23 @@ void pe_snk_get_source_cap_run(void *obj)
 	if (atomic_test_and_clear_bit(pe->flags, PE_FLAGS_TX_COMPLETE)) {
 		/* The Policy Engine Shall then start the SenderResponseTimer. */
 		usbc_timer_start(&pe->pd_t_sender_response);
-	}
-	/*
-	 * The Policy Engine Shall transition to the PE_SNK_Evaluate_Capability
-	 * State when:
-	 *	1: In SPR Mode and SPR Source Capabilities were requested and
-	 *	   a Source_Capabilities Message is received
-	 */
-	else if (atomic_test_and_clear_bit(pe->flags, PE_FLAGS_MSG_RECEIVED)) {
+	} else if (atomic_test_and_clear_bit(pe->flags, PE_FLAGS_MSG_RECEIVED)) {
+		/*
+		 * The Policy Engine Shall transition to the PE_SNK_Evaluate_Capability
+		 * State when:
+		 *	1: In SPR Mode and SPR Source Capabilities were requested and
+		 *	   a Source_Capabilities Message is received
+		 */
 		header = prl_rx->emsg.header;
 
 		if (received_control_message(dev, header, PD_DATA_SOURCE_CAP)) {
 			pe_set_state(dev, PE_SNK_EVALUATE_CAPABILITY);
 		}
-	}
-	/*
-	 * The Policy Engine Shall transition to the PE_SNK_Ready state when:
-	 *	1: The SenderResponseTimer times out.
-	 */
-	else if (usbc_timer_expired(&pe->pd_t_sender_response)) {
+	} else if (usbc_timer_expired(&pe->pd_t_sender_response)) {
+		/*
+		 * The Policy Engine Shall transition to the PE_SNK_Ready state when:
+		 *	1: The SenderResponseTimer times out.
+		 */
 		pe_set_state(dev, PE_SNK_READY);
 		/* Inform the DPM of the sender response timeout */
 		policy_notify(dev, SENDER_RESPONSE_TIMEOUT);
@@ -710,26 +705,24 @@ void pe_send_soft_reset_run(void *obj)
 	} else if (atomic_test_and_clear_bit(pe->flags, PE_FLAGS_TX_COMPLETE)) {
 		/* Start SenderResponse timer */
 		usbc_timer_start(&pe->pd_t_sender_response);
-	}
-	/*
-	 * The Policy Engine Shall transition to the PE_SNK_Wait_for_Capabilities
-	 * state when:
-	 *	1: An Accept Message has been received on SOP
-	 */
-	else if (atomic_test_and_clear_bit(pe->flags, PE_FLAGS_MSG_RECEIVED)) {
+	} else if (atomic_test_and_clear_bit(pe->flags, PE_FLAGS_MSG_RECEIVED)) {
+		/*
+		 * The Policy Engine Shall transition to the PE_SNK_Wait_for_Capabilities
+		 * state when:
+		 *	1: An Accept Message has been received on SOP
+		 */
 		header = prl_rx->emsg.header;
 
 		if (received_control_message(dev, header, PD_CTRL_ACCEPT)) {
 			pe_set_state(dev, PE_SNK_WAIT_FOR_CAPABILITIES);
 		}
-	}
-	/*
-	 * The Policy Engine Shall transition to the PE_SNK_Hard_Reset state when:
-	 *	1: A SenderResponseTimer timeout occurs
-	 *	2: Or the Protocol Layer indicates that a transmission error has occurred
-	 */
-	else if (usbc_timer_expired(&pe->pd_t_sender_response) ||
-		 atomic_test_and_clear_bit(pe->flags, PE_FLAGS_PROTOCOL_ERROR)) {
+	} else if (usbc_timer_expired(&pe->pd_t_sender_response) ||
+			atomic_test_and_clear_bit(pe->flags, PE_FLAGS_PROTOCOL_ERROR)) {
+		/*
+		 * The Policy Engine Shall transition to the PE_SNK_Hard_Reset state when:
+		 *	1: A SenderResponseTimer timeout occurs
+		 *	2: Or the Protocol Layer indicates that a transmission error has occurred
+		 */
 		pe_set_state(dev, PE_SNK_HARD_RESET);
 	}
 }
@@ -775,22 +768,20 @@ void pe_soft_reset_run(void *obj)
 	if (atomic_test_and_clear_bit(pe->flags, PE_FLAGS_SEND_SOFT_RESET)) {
 		/* Send Accept message */
 		pe_send_ctrl_msg(dev, PD_PACKET_SOP, PD_CTRL_ACCEPT);
-	}
-	/*
-	 * The Policy Engine Shall transition to the PE_SNK_Wait_for_Capabilities
-	 * state when:
-	 *	1: The Accept Message has been sent on SOP.
-	 */
-	else if (atomic_test_and_clear_bit(pe->flags, PE_FLAGS_TX_COMPLETE)) {
+	} else if (atomic_test_and_clear_bit(pe->flags, PE_FLAGS_TX_COMPLETE)) {
+		/*
+		 * The Policy Engine Shall transition to the PE_SNK_Wait_for_Capabilities
+		 * state when:
+		 *	1: The Accept Message has been sent on SOP.
+		 */
 		pe_set_state(dev, PE_SNK_WAIT_FOR_CAPABILITIES);
-	}
-	/*
-	 * The Policy Engine Shall transition to the PE_SNK_Hard_Reset
-	 * state when:
-	 *	1: The Protocol Layer indicates that a transmission error
-	 *	   has occurred.
-	 */
-	else if (atomic_test_and_clear_bit(pe->flags, PE_FLAGS_PROTOCOL_ERROR)) {
+	} else if (atomic_test_and_clear_bit(pe->flags, PE_FLAGS_PROTOCOL_ERROR)) {
+		/*
+		 * The Policy Engine Shall transition to the PE_SNK_Hard_Reset
+		 * state when:
+		 *	1: The Protocol Layer indicates that a transmission error
+		 *	   has occurred.
+		 */
 		pe_set_state(dev, PE_SNK_HARD_RESET);
 	}
 }

--- a/subsys/usb/usb_c/usbc_prl.c
+++ b/subsys/usb/usb_c/usbc_prl.c
@@ -620,11 +620,9 @@ static void prl_tx_wait_for_message_request_run(void *obj)
 		 */
 		if ((prl_tx->msg_type == PD_CTRL_SOFT_RESET) && (prl_tx->emsg.len == 0)) {
 			prl_tx_set_state(dev, PRL_TX_LAYER_RESET_FOR_TRANSMIT);
-		}
-		/*
-		 * Message pending (except Soft Reset)
-		 */
-		else {
+		} else {
+			/* Message pending (except Soft Reset) */
+
 			/* NOTE: PRL_TX_Construct_Message State embedded here */
 			prl_tx_construct_message(dev);
 			prl_tx_set_state(dev, PRL_TX_WAIT_FOR_PHY_RESPONSE);
@@ -796,13 +794,13 @@ static void prl_tx_snk_pending_run(void *obj)
 	 */
 	if ((prl_tx->msg_type == PD_CTRL_SOFT_RESET) && (prl_tx->emsg.len == 0)) {
 		prl_tx_set_state(dev, PRL_TX_LAYER_RESET_FOR_TRANSMIT);
-	}
-	/*
-	 * The Protocol Layer Shall transition to the PRL_Tx_Construct_Message
-	 * state when Rp is set to SinkTxOk and a Soft_Reset Message is not
-	 * pending.
-	 */
-	else if (cc1 == TC_CC_VOLT_RP_3A0 || cc2 == TC_CC_VOLT_RP_3A0) {
+	} else if (cc1 == TC_CC_VOLT_RP_3A0 || cc2 == TC_CC_VOLT_RP_3A0) {
+		/*
+		 * The Protocol Layer Shall transition to the PRL_Tx_Construct_Message
+		 * state when Rp is set to SinkTxOk and a Soft_Reset Message is not
+		 * pending.
+		 */
+
 		/*
 		 * Message pending (except Soft Reset) &
 		 * Rp = SinkTxOk
@@ -932,12 +930,12 @@ static void prl_hr_reset_layer_entry(void *obj)
 		 */
 		prl_hr_send_msg_to_phy(dev);
 		prl_hr_set_state(dev, PRL_HR_WAIT_FOR_PHY_HARD_RESET_COMPLETE);
-	}
-	/*
-	 * Protocol Layer reset complete &
-	 * Hard Reset was initiated by Port Partner
-	 */
-	else {
+	} else {
+		/*
+		 * Protocol Layer reset complete &
+		 * Hard Reset was initiated by Port Partner
+		 */
+
 		/* Inform Policy Engine of the Hard Reset */
 		pe_got_hard_reset(dev);
 		prl_hr_set_state(dev, PRL_HR_WAIT_FOR_PE_HARD_RESET_COMPLETE);


### PR DESCRIPTION
Use a flag to report a protocol error to the states. This keeps state specific actions in the state. Currently, those state specific actions are handled in the pe_report_error function.

Signed-off-by: Sam Hurst <sbh1187@gmail.com>