### PR TITLE
sys: next highest power-of-two (nhpot) utilities

### DIFF
--- a/include/zephyr/sys/nhpot.h
+++ b/include/zephyr/sys/nhpot.h
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2022 Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Next-Highest Power-of-Two Utilities
+ *
+ * Macros and static inline functions for dealing with next-highest power-of-two (NHPOT)
+ * calculatinos.
+ */
+
+#ifndef ZEPHYR_INCLUDE_SYS_NHPOT_H_
+#define ZEPHYR_INCLUDE_SYS_NHPOT_H_
+
+#include <stdint.h>
+
+#include <zephyr/sys/util_macro.h>
+
+#if defined(__cplusplus) && __cplusplus >= 201402L
+#define NHPOT_CONSTEXPR constexpr
+#else
+#define NHPOT_CONSTEXPR
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @ingroup sys-util
+ * @{
+ */
+
+/**
+ * @brief Get the next highest 32-bit power of two for @p val
+ *
+ * This macro rounds-up @p val to the next-highest power of two, as opposed to @ref ROUND_UP which
+ * rounds up a certain value to the next multiple of some alignment.
+ *
+ * For example,
+ * ```
+ * NHPOT(0) => 1
+ * NHPOT(1) => 1
+ * NHPOT(2) => 2
+ * NHPOT(3) => 4
+ * NHPOT(4) => 4
+ * NHPOT(5) => 8
+ * ...
+ * NHPOT(4294967295UL) => 0
+ * ```
+ *
+ * @note This macro should only be used for compile-time constant expressions. The runtime
+ * equivalent of this is @ref nhpot.
+ *
+ * @param val the value for which to calculate the next highest power of two
+ *
+ * @retval the next highest power of two for @p val
+ * @retval zero, if the next higher power of two for @p val would saturate 32-bits
+ *
+ * @see See @ref NHPOT64 for the 64-bit variant.
+ *
+ */
+/* clang-format off */
+#define NHPOT(val) \
+	((val) <= BIT(0) ? BIT(0) : ((val) <= BIT(1) ? BIT(1) : ((val) <= BIT(2) ? BIT(2) : \
+	((val) <= BIT(3) ? BIT(3) : ((val) <= BIT(4) ? BIT(4) : ((val) <= BIT(5) ? BIT(5) : \
+	((val) <= BIT(6) ? BIT(6) : ((val) <= BIT(7) ? BIT(7) : ((val) <= BIT(8) ? BIT(8) : \
+	((val) <= BIT(9) ? BIT(9) : ((val) <= BIT(10) ? BIT(10) : ((val) <= BIT(11) ? BIT(11) : \
+	((val) <= BIT(12) ? BIT(12) : ((val) <= BIT(13) ? BIT(13) : ((val) <= BIT(14) ? BIT(14) : \
+	((val) <= BIT(15) ? BIT(15) : ((val) <= BIT(16) ? BIT(16) : ((val) <= BIT(17) ? BIT(17) : \
+	((val) <= BIT(18) ? BIT(18) : ((val) <= BIT(19) ? BIT(19) : ((val) <= BIT(20) ? BIT(20) : \
+	((val) <= BIT(21) ? BIT(21) : ((val) <= BIT(22) ? BIT(22) : ((val) <= BIT(23) ? BIT(23) : \
+	((val) <= BIT(24) ? BIT(24) : ((val) <= BIT(25) ? BIT(25) : ((val) <= BIT(26) ? BIT(26) : \
+	((val) <= BIT(27) ? BIT(27) : ((val) <= BIT(28) ? BIT(28) : ((val) <= BIT(29) ? BIT(29) : \
+	((val) <= BIT(30) ? BIT(30) : ((val) <= BIT(31) ? BIT(31) : \
+	0))))))))))))))))))))))))))))))))
+/* clang-format on */
+
+/**
+ * @brief Get the next highest 64-bit power of two for @p val
+ *
+ * This macro rounds-up @p val to the next-highest power of two, as opposed to @ref ROUND_UP which
+ * rounds up a certain value to the next multiple of some alignment.
+ *
+ * For example,
+ * ```
+ * NHPOT64(0) => 1
+ * NHPOT64(1) => 1
+ * NHPOT64(2) => 2
+ * NHPOT64(3) => 4
+ * NHPOT64(4) => 4
+ * NHPOT64(5) => 8
+ * ...
+ * NHPOT(0xffffffffffffffffULL) => 0
+ * ```
+ *
+ * @note This macro should only be used for compile-time constant expressions. The runtime
+ * equivalent of this is @ref nhpot64.
+ *
+ * @param val the value for which to calculate the next highest power of two
+ *
+ * @retval the next highest power of two for @p val
+ * @retval zero, if the next higher power of two for @p val would saturate 64-bits
+ *
+ * @see See @ref NHPOT for the 32-bit variant.
+ */
+/* clang-format off */
+#define NHPOT64(val) \
+	((NHPOT(val) != 0) ? NHPOT(val) : \
+	((val) <= BIT64(32) ? BIT64(32) : ((val) <= BIT64(33) ? BIT64(33) : \
+	((val) <= BIT64(34) ? BIT64(34) : ((val) <= BIT64(35) ? BIT64(35) : \
+	((val) <= BIT64(36) ? BIT64(36) : ((val) <= BIT64(37) ? BIT64(37) : \
+	((val) <= BIT64(38) ? BIT64(38) : ((val) <= BIT64(39) ? BIT64(39) : \
+	((val) <= BIT64(40) ? BIT64(40) : ((val) <= BIT64(41) ? BIT64(41) : \
+	((val) <= BIT64(42) ? BIT64(42) : ((val) <= BIT64(43) ? BIT64(43) : \
+	((val) <= BIT64(44) ? BIT64(44) : ((val) <= BIT64(45) ? BIT64(45) : \
+	((val) <= BIT64(46) ? BIT64(46) : ((val) <= BIT64(47) ? BIT64(47) : \
+	((val) <= BIT64(48) ? BIT64(48) : ((val) <= BIT64(49) ? BIT64(49) : \
+	((val) <= BIT64(50) ? BIT64(50) : ((val) <= BIT64(51) ? BIT64(51) : \
+	((val) <= BIT64(52) ? BIT64(52) : ((val) <= BIT64(53) ? BIT64(53) : \
+	((val) <= BIT64(54) ? BIT64(54) : ((val) <= BIT64(55) ? BIT64(55) : \
+	((val) <= BIT64(56) ? BIT64(56) : ((val) <= BIT64(57) ? BIT64(57) : \
+	((val) <= BIT64(58) ? BIT64(58) : ((val) <= BIT64(59) ? BIT64(59) : \
+	((val) <= BIT64(60) ? BIT64(60) : ((val) <= BIT64(61) ? BIT64(61) : \
+	((val) <= BIT64(62) ? BIT64(62) : ((val) <= BIT64(63) ? BIT64(63) : 0 \
+	)))))))))))))))))))))))))))))))))
+/* clang-format on */
+
+/**
+ * @brief Get the next highest 32-bit power of two for @p val
+ *
+ * This macro rounds-up @p val to the next-highest power of two, as opposed to @ref ROUND_UP which
+ * rounds up a certain value to the next multiple of some alignment.
+ *
+ * @note This function should be used with runtime C or C++ expressions and compile-time
+ * constant C++ expressions.
+ *
+ * @param val the value for which to calculate the next highest power of two
+ *
+ * @retval the next highest power of two for @p val
+ * @retval zero, if the next higher power of two for @p val would saturate 32-bits
+ *
+ * @see See @ref NHPOT for a compile-time constant C macro
+ * @see See @ref nhpot64 for the 64-bit variant of this function
+ */
+static NHPOT_CONSTEXPR inline uint32_t nhpot(uint32_t val)
+{
+	uint32_t val2 = val;
+
+	val2--;
+	val2 |= val2 >> 1;
+	val2 |= val2 >> 2;
+	val2 |= val2 >> 4;
+	val2 |= val2 >> 8;
+	val2 |= val2 >> 16;
+	val2++;
+
+	return (val == 0) * 1 + (val != 0) * val2;
+}
+
+/**
+ * @brief Get the next highest 64-bit power of two for @p val
+ *
+ * This macro rounds-up @p val to the next-highest power of two, as opposed to @ref ROUND_UP which
+ * rounds up a certain value to the next multiple of some alignment.
+ *
+ * @note This function should be used with runtime C or C++ expressions and compile-time
+ * constant C++ expressions.
+ *
+ * @param val the value for which to calculate the next highest power of two
+ *
+ * @retval the next highest power of two for @p val
+ * @retval zero, if the next higher power of two for @p val would saturate 64-bits
+ *
+ * @see See @ref NHPOT64 for a compile-time constant C macro
+ * @see See @ref nhpot for the 32-bit variant of this function
+ */
+static NHPOT_CONSTEXPR inline uint64_t nhpot64(uint64_t val)
+{
+	uint64_t val2 = val;
+
+	val2--;
+	val2 |= val2 >> 1;
+	val2 |= val2 >> 2;
+	val2 |= val2 >> 4;
+	val2 |= val2 >> 8;
+	val2 |= val2 >> 16;
+	val2 |= val2 >> 32;
+	val2++;
+
+	return (val == 0) * 1ULL + (val != 0) * val2;
+}
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_SYS_NHPOT_H_ */

--- a/tests/unit/nhpot/CMakeLists.txt
+++ b/tests/unit/nhpot/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright 2023 Meta
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(nhpot_test)
+
+FILE(GLOB app_sources *.c *.cpp)
+target_sources(testbinary PRIVATE ${app_sources})

--- a/tests/unit/nhpot/main.c
+++ b/tests/unit/nhpot/main.c
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2023 Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+ZTEST_SUITE(nhpot, NULL, NULL, NULL, NULL, NULL);

--- a/tests/unit/nhpot/nhpot.c
+++ b/tests/unit/nhpot/nhpot.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <limits.h>
+
+#include <zephyr/sys/nhpot.h>
+#include <zephyr/ztest.h>
+
+static const uint32_t val = NHPOT(42);
+
+ZTEST(nhpot, test_NHPOT)
+{
+	zassert_equal(1, NHPOT(0));
+	zassert_equal(1, NHPOT(1));
+	zassert_equal(2, NHPOT(2));
+	zassert_equal(4, NHPOT(3));
+	zassert_equal(4, NHPOT(4));
+	zassert_equal(8, NHPOT(5));
+	zassert_equal(2147483648UL, NHPOT(2147483648UL));
+	zassert_equal(0, NHPOT(2147483649UL));
+	zassert_equal(0, NHPOT(4294967295UL));
+
+	zassert_equal(64, val);
+}
+
+static const uint64_t val64 = NHPOT64(42 + BIT64(32));
+
+ZTEST(nhpot, test_NHPOT64)
+{
+	zassert_equal(1, NHPOT64(0));
+	zassert_equal(1, NHPOT64(1));
+	zassert_equal(2, NHPOT64(2));
+	zassert_equal(4, NHPOT64(3));
+	zassert_equal(4, NHPOT64(4));
+	zassert_equal(8, NHPOT64(5));
+	zassert_equal(2147483648UL, NHPOT64(2147483648UL));
+	zassert_equal(4294967296ULL, NHPOT64(2147483649UL));
+	zassert_equal(4294967296ULL, NHPOT64(4294967295UL));
+	zassert_equal(9223372036854775808ULL, NHPOT64(9223372036854775807ULL));
+	zassert_equal(9223372036854775808ULL, NHPOT64(9223372036854775808ULL));
+	zassert_equal(0, NHPOT64(9223372036854775809ULL));
+	zassert_equal(0, NHPOT64(18446744073709551615ULL));
+
+	zassert_equal(BIT64(33), val64);
+}
+
+ZTEST(nhpot, test_nhpot)
+{
+	zassert_equal(1, nhpot(0));
+	zassert_equal(1, nhpot(1));
+	zassert_equal(2, nhpot(2));
+	zassert_equal(4, nhpot(3));
+	zassert_equal(4, nhpot(4));
+	zassert_equal(8, nhpot(5));
+	zassert_equal(2147483648UL, nhpot(2147483648UL));
+	zassert_equal(0, nhpot((UINT32_MAX >> 1) + 2));
+	zassert_equal(0, nhpot(UINT32_MAX));
+}
+
+ZTEST(nhpot, test_nhpot64)
+{
+	zassert_equal(1, nhpot64(0));
+	zassert_equal(1, nhpot64(1));
+	zassert_equal(2, nhpot64(2));
+	zassert_equal(4, nhpot64(3));
+	zassert_equal(4, nhpot64(4));
+	zassert_equal(8, nhpot64(5));
+	zassert_equal(2147483648UL, nhpot64(2147483648UL));
+	zassert_equal(4294967296ULL, nhpot64(2147483649UL));
+	zassert_equal(4294967296ULL, nhpot64(4294967295UL));
+	zassert_equal(9223372036854775808ULL, nhpot64(9223372036854775807ULL));
+	zassert_equal(9223372036854775808ULL, nhpot64(9223372036854775808ULL));
+	zassert_equal(0, nhpot64((UINT64_MAX >> 1) + 2));
+	zassert_equal(0, nhpot64(UINT64_MAX));
+}

--- a/tests/unit/nhpot/nhpotxx.cpp
+++ b/tests/unit/nhpot/nhpotxx.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/nhpot.h>
+#include <zephyr/ztest.h>
+
+static constexpr uint32_t val = nhpot(42);
+
+ZTEST(nhpot, test_constexpr_nhpot)
+{
+	zassert_equal(64, val);
+}
+
+static constexpr uint64_t val64 = nhpot64(42 + BIT64(32));
+
+ZTEST(nhpot, test_constexpr_nhpot64)
+{
+	zassert_equal(BIT64(33), val64);
+}

--- a/tests/unit/nhpot/prj.conf
+++ b/tests/unit/nhpot/prj.conf
@@ -1,0 +1,5 @@
+# Copyright 2023 Meta
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y

--- a/tests/unit/nhpot/testcase.yaml
+++ b/tests/unit/nhpot/testcase.yaml
@@ -1,0 +1,7 @@
+# Copyright 2023 Meta
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  utilities.nhpot:
+    tags: nhpot
+    type: unit


### PR DESCRIPTION
There are scenarios at both compile time and runtime where it is useful to know the next highest power of two.

Provide both macros and static inline functions for to fill those respective gaps as well as 64-bit variants. Additionally, the static inline function is `constexpr` to facilitate compile-time C++ optimizations.

Each of the API calls behave the same in that the return the next highest power of two.

E.g.
```
NHPOT(0) => 1
NHPOT(1) => 1
NHPOT(2) => 2
NHPOT(3) => 4
NHPOT(4) => 4
NHPOT(5) => 8
..
NHPOT64(BIT64(63)) => BIT64(63)
NHPOT64(BIT64(63)+1) => 0
```