### PR TITLE
drivers: lora: fix busy after sx12xx_lora_test_cw

### DIFF
--- a/drivers/lora/sx12xx_common.c
+++ b/drivers/lora/sx12xx_common.c
@@ -163,6 +163,12 @@ static void sx12xx_ev_tx_done(void)
 	}
 }
 
+static void sx12xx_ev_tx_timed_out(void)
+{
+	/* Just release the modem */
+	modem_release(&dev_data);
+}
+
 int sx12xx_lora_send(const struct device *dev, uint8_t *data,
 		     uint32_t data_len)
 {
@@ -351,6 +357,8 @@ int sx12xx_init(const struct device *dev)
 	dev_data.dev = dev;
 	dev_data.events.TxDone = sx12xx_ev_tx_done;
 	dev_data.events.RxDone = sx12xx_ev_rx_done;
+	/* TX timeout event raises at the end of the test CW transmission */
+	dev_data.events.TxTimeout = sx12xx_ev_tx_timed_out;
 	Radio.Init(&dev_data.events);
 
 	/*


### PR DESCRIPTION
This fixes an issue whereby the LoRa modem has been staying in `STATE_BUSY` after `sx12xx_lora_test_cw()` call because `Radio.SetTxContinuousWave()` doesn't configure the PHY to raise **'TX done'** event. It runs `TxTimeoutTimer` instead, so we have to handle **'TX timeout'** event to correctly release the modem.

Tested on custom board with STM32L4 and SX1276.

Signed-off-by: Petr Sharshavin sharshavin@mail.ru