### PR TITLE
drivers: lora: shell: fix invalid range in config bw param

### DIFF
--- a/drivers/lora/shell.c
+++ b/drivers/lora/shell.c
@@ -161,7 +161,7 @@ static int lora_conf_set(const struct shell *sh, const char *param,
 		modem_config.tx_power = lval;
 	} else if (!strcmp("bw", param)) {
 		if (parse_long_range(&lval, sh, value,
-				     "bw", 0, INT8_MAX) < 0) {
+				     "bw", 0, INT16_MAX) < 0) {
 			return -EINVAL;
 		}
 		switch (lval) {


### PR DESCRIPTION
The **'bw'** parameter in 'lora config' command has a range of 0 to `INT8_MAX`. However possible values of 'bw' (125, 250, 500) don't fit this range. In this PR the range has been extended to 0 to `INT16_MAX`.

Tested on custom board with STM32L4 and SX1276.

Signed-off-by: Petr Sharshavin sharshavin@mail.ru