### PR TITLE
subsys/zbus: benchmark test runs "too fast" with picolibc

### DIFF
--- a/samples/subsys/zbus/benchmark/src/benchmark.c
+++ b/samples/subsys/zbus/benchmark/src/benchmark.c
@@ -199,10 +199,9 @@ static void producer_thread(void)
 	}
 	uint32_t duration = (k_uptime_get_32() - start);
 
-	if (duration == 0) {
-		LOG_ERR("Something wrong. Duration is zero!\n");
-		k_oops();
-	}
+	if (duration == 0)
+		duration = 1;
+
 	uint64_t i = (BYTES_TO_BE_SENT * 1000) / duration;
 	uint64_t f = ((BYTES_TO_BE_SENT * 100000) / duration) % 100;
 


### PR DESCRIPTION
When using picolibc, this benchmark completes faster than the timer tick interval on several qemu instances. Instead of failing the test, pretend it finished in 1 millisecond.

Signed-off-by: Keith Packard <keithp@keithp.com>