### PR TITLE
drivers: flash: bug fix inline function was not inlined

### DIFF
--- a/drivers/flash/flash_rpi_pico.c
+++ b/drivers/flash/flash_rpi_pico.c
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
+#include <zephyr/toolchain.h>
 
 #include <hardware/flash.h>
 #include <hardware/regs/io_qspi.h>
@@ -136,7 +137,7 @@ void __no_inline_not_in_flash_func(flash_put_get_wrapper)(uint8_t cmd, const uin
 	flash_put_get(tx, rx, count, 1);
 }
 
-static inline void flash_put_cmd_addr(uint8_t cmd, uint32_t addr)
+static ALWAYS_INLINE void flash_put_cmd_addr(uint8_t cmd, uint32_t addr)
 {
 	flash_cs_force(OUTOVER_LOW);
 	addr |= cmd << 24;


### PR DESCRIPTION
During flash operation, you have to disable XiP which force function to be located in RAM. On top of that, the function `flash_put_cmd_addr` is time critical so we need to declare as inline. For some reason, sometimes the function was not really inline. Changed it to ALWAYS_INLINE fixed the bug.

Signed-off-by: Mathis Raemy <mathis.raemy@gmail.com>