### PR TITLE
Revert "test: log_output: Exclude qemu_arc_hs5x"

### DIFF
--- a/tests/subsys/logging/log_output/testcase.yaml
+++ b/tests/subsys/logging/log_output/testcase.yaml
@@ -9,7 +9,7 @@ tests:
     extra_configs:
       - CONFIG_LOG_TIMESTAMP_64BIT=n
   logging.log_output_ts64:
-    platform_exclude: intel_adsp_cavs15 qemu_arc_hs5x
+    platform_exclude: intel_adsp_cavs15
     tags: log_output logging
     extra_configs:
       - CONFIG_LOG_TIMESTAMP_64BIT=y


### PR DESCRIPTION
This reverts commit dfbfb3ff67f1caaaf86a72335ff751260d416fc5.

Fixes #50940.