### PR TITLE
drivers: flash: bug fix stm32 ospi flash erase

### DIFF
--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -26,25 +26,18 @@
 #endif
 #define SPI_FLASH_SECTOR_SIZE        4096
 
-void main(void)
+#if defined CONFIG_FLASH_STM32_OSPI
+#define SPI_FLASH_MULTI_SECTOR_TEST
+#endif
+
+void single_sector_test(const struct device *flash_dev)
 {
 	const uint8_t expected[] = { 0x55, 0xaa, 0x66, 0x99 };
 	const size_t len = sizeof(expected);
 	uint8_t buf[sizeof(expected)];
-	const struct device *flash_dev;
 	int rc;
 
-	flash_dev = DEVICE_DT_GET(DT_ALIAS(spi_flash0));
-
-	if (!device_is_ready(flash_dev)) {
-		printk("%s: device not ready.\n", flash_dev->name);
-		return;
-	}
-
-	printf("\n%s SPI flash testing\n", flash_dev->name);
-	printf("==========================\n");
-
-
+	printf("\nPerform test on single sector");
 	/* Write protection needs to be disabled before each write or
 	 * erase, since the flash component turns on write protection
 	 * automatically after completion of write and erase
@@ -95,4 +88,107 @@ void main(void)
 			++wp;
 		}
 	}
+}
+
+#if defined SPI_FLASH_MULTI_SECTOR_TEST
+void multi_sector_test(const struct device *flash_dev)
+{
+	const uint8_t expected[] = { 0x55, 0xaa, 0x66, 0x99 };
+	const size_t len = sizeof(expected);
+	uint8_t buf[sizeof(expected)];
+	int rc;
+
+	printf("\nPerform test on multiple consequtive sectors");
+
+	/* Write protection needs to be disabled before each write or
+	 * erase, since the flash component turns on write protection
+	 * automatically after completion of write and erase
+	 * operations.
+	 */
+	printf("\nTest 1: Flash erase\n");
+
+	/* Full flash erase if SPI_FLASH_TEST_REGION_OFFSET = 0 and
+	 * SPI_FLASH_SECTOR_SIZE = flash size
+	 * Erase 2 sectors for check for erase of consequtive sectors
+	 */
+	rc = flash_erase(flash_dev, SPI_FLASH_TEST_REGION_OFFSET, SPI_FLASH_SECTOR_SIZE * 2);
+	if (rc != 0) {
+		printf("Flash erase failed! %d\n", rc);
+	} else {
+		/* Read the content and check for erased */
+		memset(buf, 0, len);
+		size_t offs = SPI_FLASH_TEST_REGION_OFFSET;
+
+		while (offs < SPI_FLASH_TEST_REGION_OFFSET + 2 * SPI_FLASH_SECTOR_SIZE) {
+			rc = flash_read(flash_dev, offs, buf, len);
+			if (rc != 0) {
+				printf("Flash read failed! %d\n", rc);
+				return;
+			}
+			if (buf[0] != 0xff) {
+				printf("Flash erase failed at offset 0x%x got 0x%x\n",
+				offs, buf[0]);
+				return;
+			}
+			offs += SPI_FLASH_SECTOR_SIZE;
+		}
+		printf("Flash erase succeeded!\n");
+	}
+
+	printf("\nTest 2: Flash write\n");
+
+	size_t offs = SPI_FLASH_TEST_REGION_OFFSET;
+
+	while (offs < SPI_FLASH_TEST_REGION_OFFSET + 2 * SPI_FLASH_SECTOR_SIZE) {
+		printf("Attempting to write %zu bytes at offset 0x%x\n", len, offs);
+		rc = flash_write(flash_dev, offs, expected, len);
+		if (rc != 0) {
+			printf("Flash write failed! %d\n", rc);
+			return;
+		}
+
+		memset(buf, 0, len);
+		rc = flash_read(flash_dev, offs, buf, len);
+		if (rc != 0) {
+			printf("Flash read failed! %d\n", rc);
+			return;
+		}
+
+		if (memcmp(expected, buf, len) == 0) {
+			printf("Data read matches data written. Good!!\n");
+		} else {
+			const uint8_t *wp = expected;
+			const uint8_t *rp = buf;
+			const uint8_t *rpe = rp + len;
+
+			printf("Data read does not match data written!!\n");
+			while (rp < rpe) {
+				printf("%08x wrote %02x read %02x %s\n",
+					(uint32_t)(offs + (rp - buf)),
+					*wp, *rp, (*rp == *wp) ? "match" : "MISMATCH");
+				++rp;
+				++wp;
+			}
+		}
+		offs += SPI_FLASH_SECTOR_SIZE;
+	}
+}
+#endif
+
+void main(void)
+{
+	const struct device *flash_dev = DEVICE_DT_GET(DT_ALIAS(spi_flash0));
+
+	if (!device_is_ready(flash_dev)) {
+		printk("%s: device not ready.\n", flash_dev->name);
+		return;
+	}
+
+	printf("\n%s SPI flash testing\n", flash_dev->name);
+	printf("==========================\n");
+
+	single_sector_test(flash_dev);
+#if defined SPI_FLASH_MULTI_SECTOR_TEST
+	multi_sector_test(flash_dev);
+#endif
 }


### PR DESCRIPTION
This commit fixes a bug in the STM32 ospi flash driver when attempting to erase an area that spans more than one erase sector. Without this fix, only the first sector is actually erased, the rest silently fails the erase.
Issue is that the write enable latch command is only sent for the first erase command.

samples/drivers/spi_flash is updated to check for this condition.

Tested with: west build -b b_u585i_iot02a samples/drivers/spi_flash

Signed-off-by: Brian Juel Folkmann <bju@trackunit.com>