### PR TITLE
drivers: regulator: npm6001: add support for enable/disable

### DIFF
--- a/drivers/regulator/regulator_common.c
+++ b/drivers/regulator/regulator_common.c
@@ -13,7 +13,7 @@ void regulator_common_data_init(const struct device *dev)
 	data->refcnt = 0;
 }
 
-int regulator_common_init_enable(const struct device *dev)
+int regulator_common_init(const struct device *dev, bool is_enabled)
 {
 	const struct regulator_driver_api *api = dev->api;
 	const struct regulator_common_config *config = dev->config;
@@ -27,7 +27,9 @@ int regulator_common_init_enable(const struct device *dev)
 		}
 	}
 
-	if ((config->flags & REGULATOR_INIT_ENABLED) != 0U) {
+	if (is_enabled) {
+		data->refcnt++;
+	} else if ((config->flags & REGULATOR_INIT_ENABLED) != 0U) {
 		ret = api->enable(dev);
 		if (ret < 0) {
 			return ret;

--- a/drivers/regulator/regulator_fake.c
+++ b/drivers/regulator/regulator_fake.c
@@ -60,7 +60,7 @@ static int regulator_fake_init(const struct device *dev)
 {
 	regulator_common_data_init(dev);
 
-	return regulator_common_init_enable(dev);
+	return regulator_common_init(dev, false);
 }
 
 /* parent regulator */

--- a/drivers/regulator/regulator_fixed.c
+++ b/drivers/regulator/regulator_fixed.c
@@ -72,7 +72,7 @@ static int regulator_fixed_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = regulator_common_init_enable(dev);
+	ret = regulator_common_init(dev, false);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/regulator/regulator_npm6001.c
+++ b/drivers/regulator/regulator_npm6001.c
@@ -49,6 +49,7 @@ enum npm6001_sources {
 #define NPM6001_BUCK3CONFPWMMODE     0x4DU
 #define NPM6001_BUCKMODEPADCONF	     0x4EU
 #define NPM6001_PADDRIVESTRENGTH     0x53U
+#define NPM6001_OVERRIDEPWRUPBUCK    0xABU
 
 /* nPM6001 LDO0VOUT values */
 #define NPM6001_LDO0VOUT_SET1V8	 0x06U
@@ -75,6 +76,12 @@ enum npm6001_sources {
 #define NPM6001_PADDRIVESTRENGTH_READY_HIGH BIT(2)
 #define NPM6001_PADDRIVESTRENGTH_NINT_HIGH  BIT(3)
 #define NPM6001_PADDRIVESTRENGTH_SDA_HIGH   BIT(5)
+
+/* nPM6001 OVERRIDEPWRUPBUCK fields */
+#define NPM6001_OVERRIDEPWRUPBUCK_BUCK1DISABLE_MSK 0x22U
+#define NPM6001_OVERRIDEPWRUPBUCK_BUCK2DISABLE_MSK 0x44U
+#define NPM6001_OVERRIDEPWRUPBUCK_BUCK1DISABLE     BIT(1)
+#define NPM6001_OVERRIDEPWRUPBUCK_BUCK2DISABLE     BIT(2)
 
 struct regulator_npm6001_pconfig {
 	struct i2c_dt_spec i2c;
@@ -488,47 +495,58 @@ static int regulator_npm6001_enable(const struct device *dev)
 {
 	const struct regulator_npm6001_config *config = dev->config;
 	const struct regulator_npm6001_pconfig *pconfig = config->p->config;
-	uint8_t start_reg;
 
 	switch (config->source) {
+	case NPM6001_SOURCE_BUCK1:
+		return i2c_reg_update_byte_dt(
+			&pconfig->i2c, NPM6001_OVERRIDEPWRUPBUCK,
+			NPM6001_OVERRIDEPWRUPBUCK_BUCK1DISABLE_MSK, 0U);
+	case NPM6001_SOURCE_BUCK2:
+		return i2c_reg_update_byte_dt(
+			&pconfig->i2c, NPM6001_OVERRIDEPWRUPBUCK,
+			NPM6001_OVERRIDEPWRUPBUCK_BUCK2DISABLE_MSK, 0U);
 	case NPM6001_SOURCE_BUCK3:
-		start_reg = NPM6001_TASKS_START_BUCK3;
-		break;
+		return i2c_reg_write_byte_dt(&pconfig->i2c,
+					     NPM6001_TASKS_START_BUCK3, 1U);
 	case NPM6001_SOURCE_LDO0:
-		start_reg = NPM6001_TASKS_START_LDO0;
-		break;
+		return i2c_reg_write_byte_dt(&pconfig->i2c,
+					     NPM6001_TASKS_START_LDO0, 1U);
 	case NPM6001_SOURCE_LDO1:
-		start_reg = NPM6001_TASKS_START_LDO1;
-		break;
+		return i2c_reg_write_byte_dt(&pconfig->i2c,
+					     NPM6001_TASKS_START_LDO1, 1U);
 	default:
 		return 0;
 	}
-
-	/* TASKS_START_(BUCK3|LDO0|LDO1) */
-	return i2c_reg_write_byte_dt(&pconfig->i2c, start_reg, 1U);
 }
 
 static int regulator_npm6001_disable(const struct device *dev)
 {
 	const struct regulator_npm6001_config *config = dev->config;
 	const struct regulator_npm6001_pconfig *pconfig = config->p->config;
-	uint8_t stop_reg;
 
 	switch (config->source) {
+	case NPM6001_SOURCE_BUCK1:
+		return i2c_reg_update_byte_dt(
+			&pconfig->i2c, NPM6001_OVERRIDEPWRUPBUCK,
+			NPM6001_OVERRIDEPWRUPBUCK_BUCK1DISABLE_MSK,
+			NPM6001_OVERRIDEPWRUPBUCK_BUCK1DISABLE);
+	case NPM6001_SOURCE_BUCK2:
+		return i2c_reg_update_byte_dt(
+			&pconfig->i2c, NPM6001_OVERRIDEPWRUPBUCK,
+			NPM6001_OVERRIDEPWRUPBUCK_BUCK2DISABLE_MSK,
+			NPM6001_OVERRIDEPWRUPBUCK_BUCK2DISABLE);
 	case NPM6001_SOURCE_BUCK3:
-		stop_reg = NPM6001_TASKS_STOP_BUCK3;
-		break;
+		return i2c_reg_write_byte_dt(&pconfig->i2c,
+					     NPM6001_TASKS_STOP_BUCK3, 1U);
 	case NPM6001_SOURCE_LDO0:
-		stop_reg = NPM6001_TASKS_STOP_LDO0;
-		break;
+		return i2c_reg_write_byte_dt(&pconfig->i2c,
+					     NPM6001_TASKS_STOP_LDO0, 1U);
 	case NPM6001_SOURCE_LDO1:
-		stop_reg = NPM6001_TASKS_STOP_LDO1;
-		break;
+		return i2c_reg_write_byte_dt(&pconfig->i2c,
+					     NPM6001_TASKS_STOP_LDO1, 1U);
 	default:
 		return 0;
 	}
-
-	return i2c_reg_write_byte_dt(&pconfig->i2c, stop_reg, 1U);
 }
 
 static int regulator_npm6001_get_error_flags(const struct device *dev,
@@ -597,13 +615,19 @@ static int regulator_npm6001_get_error_flags(const struct device *dev,
 static int regulator_npm6001_init(const struct device *dev)
 {
 	const struct regulator_npm6001_config *config = dev->config;
+	bool is_enabled;
 
 	regulator_common_data_init(dev);
 
 	if (!device_is_ready(config->p)) {
 		return -ENODEV;
 	}
-	return regulator_common_init(dev, false);
+
+	/* BUCK1/2 are ON by default */
+	is_enabled = (config->source == NPM6001_SOURCE_BUCK1) ||
+		     (config->source == NPM6001_SOURCE_BUCK2);
+
+	return regulator_common_init(dev, is_enabled);
 }
 
 static int regulator_npm6001_common_init(const struct device *dev)

--- a/drivers/regulator/regulator_npm6001.c
+++ b/drivers/regulator/regulator_npm6001.c
@@ -603,8 +603,7 @@ static int regulator_npm6001_init(const struct device *dev)
 	if (!device_is_ready(config->p)) {
 		return -ENODEV;
 	}
-
-	return regulator_common_init_enable(dev);
+	return regulator_common_init(dev, false);
 }
 
 static int regulator_npm6001_common_init(const struct device *dev)

--- a/drivers/regulator/regulator_pca9420.c
+++ b/drivers/regulator/regulator_pca9420.c
@@ -343,7 +343,7 @@ static int regulator_pca9420_init(const struct device *dev)
 		}
 	}
 
-	return regulator_common_init_enable(dev);
+	return regulator_common_init(dev, false);
 }
 
 int regulator_pca9420_dvs_state_set(const struct device *dev,

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -194,18 +194,22 @@ struct regulator_common_data {
 void regulator_common_data_init(const struct device *dev);
 
 /**
- * @brief Common function to enable regulator at init time.
+ * @brief Common function to initialize the regulator at init time.
  *
  * This function can be called after drivers initialize the regulator. It
  * will automatically enable the regulator if it is set to `regulator-boot-on`
- * or `regulator-always-on` and increase its usage count.
+ * or `regulator-always-on` and increase its usage count. It will also configure
+ * the regulator mode if `regulator-initial-mode` is set. Regulators that are
+ * enabled by default in hardware, must set @p is_enabled to `true`.
  *
  * @param dev Regulator device instance
+ * @param is_enabled Indicate if the regulator is enabled by default in
+ * hardware.
  *
  * @retval 0 If enabled successfully.
  * @retval -errno Negative errno in case of failure.
  */
-int regulator_common_init_enable(const struct device *dev);
+int regulator_common_init(const struct device *dev, bool is_enabled);
 
 /** @endcond */
 


### PR DESCRIPTION
```
Some regulators are enabled by default, add a new driver helper to
specify this condition. Such helper sets the reference count to 1 so
that regulator_disable() and regulator_is_enabled() work as expected
without a first call to regulator_enable().
```

```
BUCK1/2 are defined as "always on" regulators, however, there is a
special override register that allows to turn them on/off.
```