### PR TITLE
drivers: flash: stm32: Use consistent log priorities

### DIFF
--- a/drivers/flash/flash_stm32f1x.c
+++ b/drivers/flash/flash_stm32f1x.c
@@ -140,7 +140,7 @@ static int write_value(const struct device *dev, off_t offset,
 
 	/* Check if this half word is erased */
 	if (*flash != FLASH_ERASED_VALUE) {
-		LOG_DBG("Flash location not erased");
+		LOG_ERR("Flash location not erased");
 		return -EIO;
 	}
 


### PR DESCRIPTION
Any error erasing the flash might want to log
the event with "ERROR" priority.

Signed-off-by: Marco Peter <marco.peter@joylab.ch>