### PR TITLE
MAINTAINERS: Remove inactive collaboratos for Bluetooth Audio

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -243,11 +243,9 @@ Bluetooth Audio:
   maintainers:
     - Thalley
   collaborators:
-    - Vudentz
     - jhedberg
     - Casper-Bonde-Bose
     - MariuszSkamra
-    - rymanluk
     - sjanc
     - szymon-czapracki
     - asbjornsabo


### PR DESCRIPTION
Remove Vudentz and rymanluk as they are not actively collaborating anymore.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>