### PR TITLE
bindings: fuel-gauge: drop redundant compatible

### DIFF
--- a/dts/bindings/fuel-gauge/fuel-gauge.yaml
+++ b/dts/bindings/fuel-gauge/fuel-gauge.yaml
@@ -8,5 +8,3 @@ include: base.yaml
 
 description: |
    Battery fuel-gauge parameters and info
-
-compatible: "fuel-gauge.yaml"


### PR DESCRIPTION
Drop compatible from fuel-gauge.yaml, it's not needed since this binding is not meant to be used directly, and is also incorrect as it includes the "yaml" suffix.