### PR TITLE
adsp: boot: power: Fixed used register name

### DIFF
--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_boot.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_boot.h
@@ -6,14 +6,31 @@
 #ifndef ZEPHYR_SOC_INTEL_ADSP_BOOT_H_
 #define ZEPHYR_SOC_INTEL_ADSP_BOOT_H_
 
-/* Boot / recovery capability function registers */
+#define DSPCS_REG					0x178d00
 
-struct dfdspbrcp {
+struct dspcs {
+	/*
+	 * DSPCSx
+	 * DSP Core Shim
+	 *
+	 * These registers are added by Intel outside of the Tensilica Core for general operation
+	 * control, such as reset, stall, power gating, clock gating etc.
+	 * Note: These registers are accessible through the host space or DSP space depending on
+	 * ownership, as governed by SAI and RS.
+	 */
 	struct {
 		uint32_t cap;
 		uint32_t ctl;
 	} capctl[3];
 	uint32_t unused0[10];
+
+	/*
+	 * DSPBRx
+	 * DSP Boot / Recovery
+	 *
+	 * These registers are added by Intel outside of the Tensilica Core for boot / recovery
+	 * control, such as boot path, watch dog timer etc.
+	 */
 	struct {
 		uint32_t brcap;
 		uint32_t wdtcs;
@@ -26,26 +43,23 @@ struct dfdspbrcp {
 	} bootctl[3];
 };
 
-/* These registers are added by Intel outside of the Tensilica Core
- * for boot / recovery control, such as boot path, watch dog timer etc.
- */
-#define DFDSPBRCP_REG				0x178d00
 
-#define DFDSPBRCP_CTL_SPA			BIT(0)
-#define DFDSPBRCP_CTL_CPA			BIT(8)
-#define DFDSPBRCP_BCTL_BYPROM		BIT(0)
-#define DFDSPBRCP_BCTL_WAITIPCG		BIT(16)
-#define DFDSPBRCP_BCTL_WAITIPPG		BIT(17)
+#define DSPCS_CTL_SPA					BIT(0)
+#define DSPCS_CTL_CPA					BIT(8)
 
-#define DFDSPBRCP_BATTR_LPSCTL_RESTORE_BOOT		BIT(12)
-#define DFDSPBRCP_BATTR_LPSCTL_HP_CLOCK_BOOT	BIT(13)
-#define DFDSPBRCP_BATTR_LPSCTL_LP_CLOCK_BOOT	BIT(14)
-#define DFDSPBRCP_BATTR_LPSCTL_L1_MIN_WAY		BIT(15)
-#define DFDSPBRCP_BATTR_LPSCTL_BATTR_SLAVE_CORE	BIT(16)
+#define DSPBR_BCTL_BYPROM				BIT(0)
+#define DSPBR_BCTL_WAITIPCG				BIT(16)
+#define DSPBR_BCTL_WAITIPPG				BIT(17)
 
-#define DFDSPBRCP_WDT_RESUME		BIT(8)
-#define DFDSPBRCP_WDT_RESTART_COMMAND	0x76
+#define DSPBR_BATTR_LPSCTL_RESTORE_BOOT			BIT(12)
+#define DSPBR_BATTR_LPSCTL_HP_CLOCK_BOOT		BIT(13)
+#define DSPBR_BATTR_LPSCTL_LP_CLOCK_BOOT		BIT(14)
+#define DSPBR_BATTR_LPSCTL_L1_MIN_WAY			BIT(15)
+#define DSPBR_BATTR_LPSCTL_BATTR_SLAVE_CORE		BIT(16)
 
-#define DFDSPBRCP (*(volatile struct dfdspbrcp *)DFDSPBRCP_REG)
+#define DSPBR_WDT_RESUME				BIT(8)
+#define DSPBR_WDT_RESTART_COMMAND			0x76
+
+#define DSPCS (*(volatile struct dspcs *)DSPCS_REG)
 
 #endif /* ZEPHYR_SOC_INTEL_ADSP_BOOT_H_ */

--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -93,13 +93,13 @@ void soc_start_core(int cpu_num)
 		}
 
 		/* Tell the ACE ROM that it should use secondary core flow */
-		DFDSPBRCP.bootctl[cpu_num].battr |= DFDSPBRCP_BATTR_LPSCTL_BATTR_SLAVE_CORE;
+		DSPCS.bootctl[cpu_num].battr |= DSPBR_BATTR_LPSCTL_BATTR_SLAVE_CORE;
 	}
 
-	DFDSPBRCP.capctl[cpu_num].ctl |= DFDSPBRCP_CTL_SPA;
+	DSPCS.capctl[cpu_num].ctl |= DSPCS_CTL_SPA;
 
 	/* Waiting for power up */
-	while (((DFDSPBRCP.capctl[cpu_num].ctl & DFDSPBRCP_CTL_CPA) != DFDSPBRCP_CTL_CPA) &&
+	while (((DSPCS.capctl[cpu_num].ctl & DSPCS_CTL_CPA) != DSPCS_CTL_CPA) &&
 	       (retry > 0)) {
 		k_busy_wait(HW_STATE_CHECK_DELAY);
 		retry--;
@@ -116,11 +116,11 @@ void soc_mp_startup(uint32_t cpu)
 	z_xtensa_irq_enable(ACE_INTC_IRQ);
 
 	/* Prevent idle from powering us off */
-	DFDSPBRCP.bootctl[cpu].bctl |=
-		DFDSPBRCP_BCTL_WAITIPCG | DFDSPBRCP_BCTL_WAITIPPG;
+	DSPCS.bootctl[cpu].bctl |=
+		DSPBR_BCTL_WAITIPCG | DSPBR_BCTL_WAITIPPG;
 	/* checking if WDT was stopped during D3 transition */
-	if (DFDSPBRCP.bootctl[cpu].wdtcs & DFDSPBRCP_WDT_RESUME) {
-		DFDSPBRCP.bootctl[cpu].wdtcs = DFDSPBRCP_WDT_RESUME;
+	if (DSPCS.bootctl[cpu].wdtcs & DSPBR_WDT_RESUME) {
+		DSPCS.bootctl[cpu].wdtcs = DSPBR_WDT_RESUME;
 		/* TODO: delete this IF when FW starts using imr restore vector */
 	}
 }
@@ -156,10 +156,10 @@ int soc_adsp_halt_cpu(int id)
 		return -EINVAL;
 	}
 
-	DFDSPBRCP.capctl[id].ctl &= ~DFDSPBRCP_CTL_SPA;
+	DSPCS.capctl[id].ctl &= ~DSPCS_CTL_SPA;
 
 	/* Waiting for power off */
-	while (((DFDSPBRCP.capctl[id].ctl & DFDSPBRCP_CTL_CPA) == DFDSPBRCP_CTL_CPA) &&
+	while (((DSPCS.capctl[id].ctl & DSPCS_CTL_CPA) == DSPCS_CTL_CPA) &&
 	       (retry > 0)) {
 		k_busy_wait(HW_STATE_CHECK_DELAY);
 		retry--;

--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -25,7 +25,7 @@
 __imr void power_init(void)
 {
 	/* Disable idle power gating */
-	DFDSPBRCP.bootctl[0].bctl |= DFDSPBRCP_BCTL_WAITIPCG | DFDSPBRCP_BCTL_WAITIPPG;
+	DSPCS.bootctl[0].bctl |= DSPBR_BCTL_WAITIPCG | DSPBR_BCTL_WAITIPPG;
 }
 
 #ifdef CONFIG_PM
@@ -218,9 +218,9 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		/* save interrupt state and turn off all interrupts */
 		core_desc[cpu].intenable = XTENSA_RSR("INTENABLE");
 		z_xt_ints_off(0xffffffff);
-		core_desc[cpu].bctl = DFDSPBRCP.bootctl[cpu].bctl;
-		DFDSPBRCP.bootctl[cpu].wdtcs = DFDSPBRCP_WDT_RESTART_COMMAND;
-		DFDSPBRCP.bootctl[cpu].bctl &= ~DFDSPBRCP_BCTL_WAITIPCG;
+		core_desc[cpu].bctl = DSPCS.bootctl[cpu].bctl;
+		DSPCS.bootctl[cpu].wdtcs = DSPBR_WDT_RESTART_COMMAND;
+		DSPCS.bootctl[cpu].bctl &= ~DSPBR_BCTL_WAITIPCG;
 		soc_cpus_active[cpu] = false;
 		z_xtensa_cache_flush_inv_all();
 		if (cpu == 0) {
@@ -280,14 +280,14 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 	} else if (state == PM_STATE_RUNTIME_IDLE) {
 		core_desc[cpu].intenable = XTENSA_RSR("INTENABLE");
 		z_xt_ints_off(0xffffffff);
-		DFDSPBRCP.bootctl[cpu].bctl &= ~DFDSPBRCP_BCTL_WAITIPPG;
-		DFDSPBRCP.bootctl[cpu].bctl &= ~DFDSPBRCP_BCTL_WAITIPCG;
+		DSPCS.bootctl[cpu].bctl &= ~DSPBR_BCTL_WAITIPPG;
+		DSPCS.bootctl[cpu].bctl &= ~DSPBR_BCTL_WAITIPCG;
 		ACE_PWRCTL->wpdsphpxpg &= ~BIT(cpu);
 		if (cpu == 0) {
-			uint32_t battr = DFDSPBRCP.bootctl[cpu].battr & (~LPSCTL_BATTR_MASK);
+			uint32_t battr = DSPCS.bootctl[cpu].battr & (~LPSCTL_BATTR_MASK);
 
-			battr |= (DFDSPBRCP_BATTR_LPSCTL_RESTORE_BOOT & LPSCTL_BATTR_MASK);
-			DFDSPBRCP.bootctl[cpu].battr = battr;
+			battr |= (DSPBR_BATTR_LPSCTL_RESTORE_BOOT & LPSCTL_BATTR_MASK);
+			DSPCS.bootctl[cpu].battr = battr;
 		}
 		power_gate_entry(cpu);
 	} else {
@@ -306,10 +306,10 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 #ifdef CONFIG_ADSP_IMR_CONTEXT_SAVE
 			struct imr_layout *imr_layout = (struct imr_layout *)(IMR_LAYOUT_ADDRESS);
 
-			DFDSPBRCP.bootctl[cpu].wdtcs = DFDSPBRCP_WDT_RESUME;
+			DSPCS.bootctl[cpu].wdtcs = DSPBR_WDT_RESUME;
 			/* restore clock gating state */
-			DFDSPBRCP.bootctl[cpu].bctl |=
-					(core_desc[0].bctl & DFDSPBRCP_BCTL_WAITIPCG);
+			DSPCS.bootctl[cpu].bctl |=
+					(core_desc[0].bctl & DSPBR_BCTL_WAITIPCG);
 			soc_cpus_active[cpu] = true;
 
 			/* clean storage and restore information */
@@ -341,10 +341,10 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 			k_busy_wait(HW_STATE_CHECK_DELAY);
 		}
 
-		DFDSPBRCP.bootctl[cpu].bctl |=
-			DFDSPBRCP_BCTL_WAITIPCG | DFDSPBRCP_BCTL_WAITIPPG;
+		DSPCS.bootctl[cpu].bctl |=
+			DSPBR_BCTL_WAITIPCG | DSPBR_BCTL_WAITIPPG;
 		if (cpu == 0) {
-			DFDSPBRCP.bootctl[cpu].battr &= (~LPSCTL_BATTR_MASK);
+			DSPCS.bootctl[cpu].battr &= (~LPSCTL_BATTR_MASK);
 		}
 
 		soc_cpus_active[cpu] = true;


### PR DESCRIPTION
The code used the name DFDSPBRCP referring to the DSP Boot / Recovery Capability Pointer register from DSP Subsystem Capability / Status Registers range. The address used, however, pointed to DSP Core Shim (DSPCS) registers block. Changed define names to not be misleading.
