### PR TITLE
Bluetooth: host: clear ATT_CONNECTED flag on detach

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -216,6 +216,7 @@ static int chan_send(struct bt_att_chan *chan, struct net_buf *buf)
 	LOG_DBG("code 0x%02x", hdr->code);
 
 	if (!atomic_test_bit(chan->flags, ATT_CONNECTED)) {
+		LOG_ERR("ATT channel not connected");
 		return -EINVAL;
 	}
 
@@ -2863,8 +2864,10 @@ static struct bt_att *att_get(struct bt_conn *conn)
 	}
 
 	att_chan = ATT_CHAN(chan);
-	__ASSERT(atomic_test_bit(att_chan->flags, ATT_CONNECTED),
-		 "ATT channel not connected");
+	if (!atomic_test_bit(att_chan->flags, ATT_CONNECTED)) {
+		LOG_ERR("ATT channel not connected");
+		return NULL;
+	}
 
 	return att_chan->att;
 }
@@ -2957,6 +2960,7 @@ static void att_chan_detach(struct bt_att_chan *chan)
 	}
 
 	chan->att = NULL;
+	atomic_clear_bit(chan->flags, ATT_CONNECTED);
 }
 
 static void att_timeout(struct k_work *work)


### PR DESCRIPTION
Clear the `ATT_CONNECTED` flag when a channel is detached (could be after an ATT timeout).

Also convert the assert checking it in `chan send` to an `if` test, since the channel could be disconnected from a different thread than the one triggering `chan_send`.

Fixes #53247.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>