### PR TITLE
drivers: ethernet: fix error UDP server on STM32

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -926,28 +926,10 @@ void HAL_ETH_TxCpltCallback(ETH_HandleTypeDef *heth_handle)
 #if defined(CONFIG_ETH_STM32_HAL_API_V2)
 void HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth)
 {
-	__ASSERT_NO_MSG(heth != NULL);
-
-	const uint32_t error_code = HAL_ETH_GetError(heth);
-
-	switch (error_code) {
-	case HAL_ETH_ERROR_DMA:
-		LOG_ERR("%s errorcode:%x dmaerror:%x",
-			__func__,
-			error_code,
-			HAL_ETH_GetDMAError(heth));
-		break;
-	case HAL_ETH_ERROR_MAC:
-		LOG_ERR("%s errorcode:%x macerror:%x",
-			__func__,
-			error_code,
-			HAL_ETH_GetMACError(heth));
-		break;
-	default:
-		LOG_ERR("%s errorcode:%x",
-			__func__,
-			error_code);
-	}
+	/* Do nothing */
+	/* Do not log errors. If errors are reported du to high traffic,
+	 * logging errors will only increase traffic issues
+	 */
 }
 #elif defined(CONFIG_SOC_SERIES_STM32H7X)
 /* DMA and MAC errors callback only appear in H7 series */


### PR DESCRIPTION
On UDP server with ETH_STM32_HAL_API_V2 avoid log error message from HAL_ETH_ERROR_DMA irq

Signed-off-by: Marc Desvaux <marc.desvaux-ext@st.com>