### PR TITLE
sysbuild: Fix missing ram/rom report and footprint targets

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Nordic Semiconductor
+# Copyright (c) 2021-2023 Nordic Semiconductor
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -251,6 +251,9 @@ function(ExternalZephyrProject_Add)
       menuconfig
       hardenconfig
       guiconfig
+      ram_report
+      rom_report
+      footprint
       ${EXTRA_KCONFIG_TARGETS}
       )
 


### PR DESCRIPTION
Fixes 3 missing targets for images: ram_report, rom_report and footprint, which should be visible for all images in a build.

Fixes #53607