### PR TITLE
scripts: kconfig: Add functions for array/chosen props

### DIFF
--- a/doc/build/kconfig/preprocessor-functions.rst
+++ b/doc/build/kconfig/preprocessor-functions.rst
@@ -51,6 +51,7 @@ while the ``*_hex`` version returns a hexadecimal value starting with ``0x``.
    $(dt_chosen_enabled,<property in /chosen>)
    $(dt_node_bool_prop,<node path>,<prop>)
    $(dt_nodelabel_bool_prop,<node label>,<prop>)
+   $(dt_chosen_bool_prop, <property in /chosen>, <prop>)
    $(dt_node_has_prop,<node path>,<prop>)
    $(dt_nodelabel_has_prop,<node label>,<prop>)
    $(dt_node_int_prop_int,<node path>,<prop>[,<unit>])
@@ -60,6 +61,7 @@ while the ``*_hex`` version returns a hexadecimal value starting with ``0x``.
    $(dt_node_has_compat,<node path>,<compatible string>)
    $(dt_nodelabel_path,<node label>)
    $(dt_node_parent,<node path>)
+   $(dt_nodelabel_array_prop_has_val, <node label>, <prop>, <value>)
    $(shields_list_contains,<shield name>)
 
 

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -425,6 +425,17 @@ def dt_nodelabel_bool_prop(kconf, _, label, prop):
 
     return _dt_node_bool_prop_generic(edt.label2node.get, label, prop)
 
+def dt_chosen_bool_prop(kconf, _, chosen, prop):
+    """
+    This function takes a /chosen node property named 'chosen', and
+    looks for the chosen node. If that node exists and has a boolean
+    property 'prop', it returns "y". Otherwise, it returns "n".
+    """
+    if doc_mode or edt is None:
+        return "n"
+
+    return _dt_node_bool_prop_generic(edt.chosen_node, chosen, prop)
+
 def _dt_node_has_prop_generic(node_search_function, search_arg, prop):
     """
     This function takes the 'node_search_function' and uses it to search for
@@ -645,6 +656,25 @@ def dt_nodelabel_enabled_with_compat(kconf, _, label, compat):
     return "n"
 
 
+def dt_nodelabel_array_prop_has_val(kconf, _, label, prop, val):
+    """
+    This function looks for a node with node label 'label'.
+    If the node exists, it checks if the node node has a property
+    'prop' with type "array". If so, and the property contains
+    an element equal to the integer 'val', it returns "y".
+    Otherwise, it returns "n".
+    """
+    if doc_mode or edt is None:
+        return "n"
+
+    node = edt.label2node.get(label)
+
+    if not node or (prop not in node.props) or (node.props[prop].type != "array"):
+        return "n"
+    else:
+        return "y" if int(val, base=0) in node.props[prop].val else "n"
+
+
 def dt_nodelabel_path(kconf, _, label):
     """
     This function takes a node label (not a label property) and
@@ -723,6 +753,7 @@ functions = {
         "dt_node_reg_size_hex": (dt_node_reg, 1, 3),
         "dt_node_bool_prop": (dt_node_bool_prop, 2, 2),
         "dt_nodelabel_bool_prop": (dt_nodelabel_bool_prop, 2, 2),
+        "dt_chosen_bool_prop": (dt_chosen_bool_prop, 2, 2),
         "dt_node_has_prop": (dt_node_has_prop, 2, 2),
         "dt_nodelabel_has_prop": (dt_nodelabel_has_prop, 2, 2),
         "dt_node_int_prop_int": (dt_node_int_prop, 2, 3),
@@ -734,5 +765,6 @@ functions = {
         "dt_node_has_compat": (dt_node_has_compat, 2, 2),
         "dt_nodelabel_path": (dt_nodelabel_path, 1, 1),
         "dt_node_parent": (dt_node_parent, 1, 1),
+        "dt_nodelabel_array_prop_has_val": (dt_nodelabel_array_prop_has_val, 3, 3),
         "shields_list_contains": (shields_list_contains, 1, 1),
 }


### PR DESCRIPTION
Expands kconfigfunctions to include checks for value existence in an array property by nodelabel, or a chosen's boolean prop value.

Signed-off-by: Stephen Stauts <stephen.stauts@nordicsemi.no>