### PR TITLE
tests: drivers: i2s: Align nRF pinctrl with other gpio_loopback users

### DIFF
--- a/tests/drivers/i2s/i2s_api/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/i2s/i2s_api/boards/nrf52840dk_nrf52840.overlay
@@ -1,10 +1,10 @@
 &pinctrl {
 	i2s0_default_alt: i2s0_default_alt {
 		group1 {
-			psels = <NRF_PSEL(I2S_SCK_M, 1, 4)>,
-				<NRF_PSEL(I2S_LRCK_M, 1, 3)>,
-				<NRF_PSEL(I2S_SDOUT, 1, 2)>,
-				<NRF_PSEL(I2S_SDIN, 1, 1)>;
+			psels = <NRF_PSEL(I2S_SCK_M, 1, 5)>,
+				<NRF_PSEL(I2S_LRCK_M, 1, 6)>,
+				<NRF_PSEL(I2S_SDOUT, 1, 1)>,
+				<NRF_PSEL(I2S_SDIN, 1, 2)>;
 		};
 	};
 };

--- a/tests/drivers/i2s/i2s_api/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/i2s/i2s_api/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,10 +1,10 @@
 &pinctrl {
 	i2s0_default_alt: i2s0_default_alt {
 		group1 {
-			psels = <NRF_PSEL(I2S_SCK_M, 1, 5)>,
-				<NRF_PSEL(I2S_LRCK_M, 1, 4)>,
-				<NRF_PSEL(I2S_SDOUT, 1, 1)>,
-				<NRF_PSEL(I2S_SDIN, 1, 0)>;
+			psels = <NRF_PSEL(I2S_SCK_M, 1, 6)>,
+				<NRF_PSEL(I2S_LRCK_M, 1, 7)>,
+				<NRF_PSEL(I2S_SDOUT, 0, 4)>,
+				<NRF_PSEL(I2S_SDIN, 0, 5)>;
 		};
 	};
 };

--- a/tests/drivers/i2s/i2s_api/testcase.yaml
+++ b/tests/drivers/i2s/i2s_api/testcase.yaml
@@ -4,7 +4,7 @@ tests:
     tags: drivers userspace
     filter: not CONFIG_I2S_TEST_USE_GPIO_LOOPBACK
   drivers.i2s.gpio_loopback:
-    depends_on: i2s
+    depends_on: i2s gpio
     tags: drivers userspace
     filter: CONFIG_I2S_TEST_USE_GPIO_LOOPBACK
     harness: ztest

--- a/tests/drivers/i2s/i2s_speed/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/nrf52840dk_nrf52840.overlay
@@ -9,10 +9,10 @@
 &pinctrl {
 	i2s0_default_alt: i2s0_default_alt {
 		group1 {
-			psels = <NRF_PSEL(I2S_SCK_M, 1, 4)>,
-				<NRF_PSEL(I2S_LRCK_M, 1, 3)>,
-				<NRF_PSEL(I2S_SDOUT, 1, 2)>,
-				<NRF_PSEL(I2S_SDIN, 1, 1)>;
+			psels = <NRF_PSEL(I2S_SCK_M, 1, 5)>,
+				<NRF_PSEL(I2S_LRCK_M, 1, 6)>,
+				<NRF_PSEL(I2S_SDOUT, 1, 1)>,
+				<NRF_PSEL(I2S_SDIN, 1, 2)>;
 		};
 	};
 };

--- a/tests/drivers/i2s/i2s_speed/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -9,10 +9,10 @@
 &pinctrl {
 	i2s0_default_alt: i2s0_default_alt {
 		group1 {
-			psels = <NRF_PSEL(I2S_SCK_M, 1, 5)>,
-				<NRF_PSEL(I2S_LRCK_M, 1, 4)>,
-				<NRF_PSEL(I2S_SDOUT, 1, 1)>,
-				<NRF_PSEL(I2S_SDIN, 1, 0)>;
+			psels = <NRF_PSEL(I2S_SCK_M, 1, 6)>,
+				<NRF_PSEL(I2S_LRCK_M, 1, 7)>,
+				<NRF_PSEL(I2S_SDOUT, 0, 4)>,
+				<NRF_PSEL(I2S_SDIN, 0, 5)>;
 		};
 	};
 };

--- a/tests/drivers/i2s/i2s_speed/testcase.yaml
+++ b/tests/drivers/i2s/i2s_speed/testcase.yaml
@@ -4,7 +4,7 @@ tests:
     tags: drivers i2s
     filter: not CONFIG_I2S_TEST_USE_GPIO_LOOPBACK
   drivers.i2s.speed.gpio_loopback:
-    depends_on: i2s
+    depends_on: i2s gpio
     tags: drivers i2s
     filter: CONFIG_I2S_TEST_USE_GPIO_LOOPBACK
     harness: ztest


### PR DESCRIPTION
For nRF boards and lines that need to be connected with an external
loopback (SDOUT and SDIN), use the same pins as in other tests that
use the gpio_loopback fixture (like uart_async_api or regulator/fixed)
so that a common wiring can be used for all those cases.

Relates to #53307.