### PR TITLE
subsys/settings/fcb: removed unused var

### DIFF
--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -329,13 +329,11 @@ static int settings_fcb_save_priv(struct settings_store *cs, const char *name,
 	int len;
 	int rc = -EINVAL;
 	int i;
-	uint8_t wbs;
 
 	if (!name) {
 		return -EINVAL;
 	}
 
-	wbs = cf->cf_fcb.f_align;
 	len = settings_line_len_calc(name, val_len);
 
 	for (i = 0; i < cf->cf_fcb.f_sector_cnt; i++) {


### PR DESCRIPTION
Removed the `wbs` var since it isn't used, came across this while reading the source code.