### PR TITLE
Fuel Gauge API uses syscalls for kernel device driver access

### DIFF
--- a/drivers/fuel_gauge/CMakeLists.txt
+++ b/drivers/fuel_gauge/CMakeLists.txt
@@ -1,3 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory_ifdef(CONFIG_SBS_GAUGE_NEW_API		sbs_gauge)
+
+zephyr_library_sources_ifdef(CONFIG_USERSPACE fuel_gauge_syscall_handlers.c)

--- a/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
+++ b/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/syscall_handler.h>
+#include <zephyr/drivers/fuel_gauge.h>
+
+static inline int z_vrfy_fuel_gauge_get_prop(const struct device *dev,
+					     struct fuel_gauge_get_property *props,
+					     size_t props_len)
+{
+	struct fuel_gauge_get_property k_props[props_len];
+
+	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, get_property));
+
+	Z_OOPS(z_user_from_copy(k_props, props,
+				props_len * sizeof(struct fuel_gauge_get_property)));
+
+	int ret = z_impl_fuel_gauge_get_prop(dev, k_props, props_len);
+
+	Z_OOPS(z_user_to_copy(props, k_props, props_len * sizeof(struct fuel_gauge_get_property)));
+
+	return ret;
+}
+
+#include <syscalls/fuel_gauge_get_prop_mrsh.c>
+
+static inline int z_vrfy_fuel_gauge_set_prop(const struct device *dev,
+					     struct fuel_gauge_set_property *props,
+					     size_t props_len)
+{
+	struct fuel_gauge_set_property k_props[props_len];
+
+	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, set_property));
+
+	Z_OOPS(z_user_from_copy(k_props, props,
+				props_len * sizeof(struct fuel_gauge_set_property)));
+
+	int ret = z_impl_fuel_gauge_set_prop(dev, k_props, props_len);
+
+	Z_OOPS(z_user_to_copy(props, k_props, props_len * sizeof(struct fuel_gauge_set_property)));
+
+	return ret;
+}
+
+#include <syscalls/fuel_gauge_set_prop_mrsh.c>

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -201,7 +201,7 @@ static int sbs_gauge_init(const struct device *dev)
 	return 0;
 }
 
-static const struct battery_driver_api sbs_gauge_driver_api = {
+static const struct fuel_gauge_driver_api sbs_gauge_driver_api = {
 	.get_property = &sbs_gauge_get_props,
 	.set_property = &sbs_gauge_set_props,
 };

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -193,7 +193,7 @@ typedef int (*fuel_gauge_set_property_t)(const struct device *dev,
 
 /* Caching is entirely on the onus of the client */
 
-__subsystem struct battery_driver_api {
+__subsystem struct fuel_gauge_driver_api {
 	fuel_gauge_get_property_t get_property;
 	fuel_gauge_set_property_t set_property;
 };

--- a/tests/drivers/fuel_gauge/sbs_gauge/boards/qemu_arc_hs.conf
+++ b/tests/drivers/fuel_gauge/sbs_gauge/boards/qemu_arc_hs.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_EMUL=y
+CONFIG_EMUL_SBS_GAUGE=y
+CONFIG_I2C=y
+CONFIG_I2C_EMUL=y

--- a/tests/drivers/fuel_gauge/sbs_gauge/boards/qemu_arc_hs.overlay
+++ b/tests/drivers/fuel_gauge/sbs_gauge/boards/qemu_arc_hs.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/i2c/i2c.h>
+
+/ {
+	/* qemu_cortex_a9 board isn't configured with an I2C node */
+	fake_i2c_bus: i2c@100 {
+		status = "okay";
+		compatible = "zephyr,i2c-emul-controller";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x100 4>;
+	};
+};
+
+&fake_i2c_bus {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	compatible = "zephyr,i2c-emul-controller";
+	smartbattery0: smartbattery@b {
+		compatible = "sbs,sbs-gauge-new-api";
+		reg = <0x0B>;
+		status = "okay";
+	};
+};

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -15,7 +15,7 @@
 
 struct sbs_gauge_new_api_fixture {
 	const struct device *dev;
-	const struct battery_driver_api *api;
+	const struct fuel_gauge_driver_api *api;
 };
 
 static void *sbs_gauge_new_api_setup(void)
@@ -23,7 +23,7 @@ static void *sbs_gauge_new_api_setup(void)
 
 	static struct sbs_gauge_new_api_fixture fixture;
 	const struct device *dev = DEVICE_DT_GET_ANY(sbs_sbs_gauge_new_api);
-	const struct battery_driver_api *api = dev->api;
+	const struct fuel_gauge_driver_api *api = dev->api;
 
 	fixture.dev = dev;
 	fixture.api = api;

--- a/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
+++ b/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
@@ -3,6 +3,6 @@ tests:
   drivers.sbs_gauge_new_api:
     tags: test_framework
     filter: dt_compat_enabled("sbs,sbs-gauge-new-api")
-    platform_allow: native_posix qemu_cortex_a9 nucleo_f070rb
+    platform_allow: native_posix qemu_cortex_a9 nucleo_f070rb qemu_arc_hs
     integration_platforms:
       - nucleo_f070rb

--- a/tests/drivers/sensor/sbs_gauge/boards/qemu_arc_hs.conf
+++ b/tests/drivers/sensor/sbs_gauge/boards/qemu_arc_hs.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_EMUL=y
+CONFIG_EMUL_SBS_GAUGE=y
+CONFIG_I2C=y
+CONFIG_I2C_EMUL=y

--- a/tests/drivers/sensor/sbs_gauge/boards/qemu_arc_hs.overlay
+++ b/tests/drivers/sensor/sbs_gauge/boards/qemu_arc_hs.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/i2c/i2c.h>
+
+/ {
+	/* qemu_cortex_a9 board isn't configured with an I2C node */
+	fake_i2c_bus: i2c@100 {
+		status = "okay";
+		compatible = "zephyr,i2c-emul-controller";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x100 4>;
+	};
+};
+
+&fake_i2c_bus {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	compatible = "zephyr,i2c-emul-controller";
+	smartbattery0: smartbattery@b {
+		compatible = "sbs,sbs-gauge";
+		reg = <0x0B>;
+		status = "okay";
+	};
+};

--- a/tests/drivers/sensor/sbs_gauge/testcase.yaml
+++ b/tests/drivers/sensor/sbs_gauge/testcase.yaml
@@ -9,6 +9,6 @@ tests:
   drivers.sbs_gauge.emulated:
     tags: test_framework
     filter: dt_compat_enabled("sbs,sbs-gauge")
-    platform_allow: native_posix qemu_cortex_a9
+    platform_allow: native_posix qemu_cortex_a9 qemu_arc_hs
     integration_platforms:
       - native_posix


### PR DESCRIPTION
Part of https://github.com/zephyrproject-rtos/zephyr/issues/44847 efforts.

This API gave non-syscall access to device drivers. This PR includes a simple renaming the API to be more specific and also adds syscalls.

If requested, I am more than happy to split this up as two separate PRs, one for each commit to keep PRs small.