### PR TITLE
ec_host_cmd: add missing name to choice in Kconfig

### DIFF
--- a/drivers/ec_host_cmd_periph/Kconfig
+++ b/drivers/ec_host_cmd_periph/Kconfig
@@ -17,7 +17,7 @@ module = EC_HC
 module-str = ec-host-commands
 source "subsys/logging/Kconfig.template.log_config"
 
-choice
+choice EC_HOST_CMD_PERIPH_TYPE
 	prompt "Host commands peripheral"
 
 config EC_HOST_CMD_SIMULATOR


### PR DESCRIPTION
It is recommended that choices in Kconfig have names so this commit adds missing one for the type of
host commands peripheral.

Signed-off-by: Michał Barnaś <mb@semihalf.com>