### PR TITLE
kernel: Fix pipe ISR instability issues (#52812)

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -363,6 +363,26 @@ static inline bool z_sched_wake_all(_wait_q_t *wait_q, int swap_retval,
 int z_sched_wait(struct k_spinlock *lock, k_spinlock_key_t key,
 		 _wait_q_t *wait_q, k_timeout_t timeout, void **data);
 
+/**
+ * @brief Walks the wait queue invoking the callback on each waiting thread
+ *
+ * This function walks the wait queue invoking the callback function on each
+ * waiting thread while holding sched_spinlock. This can be useful for routines
+ * that need to operate on multiple waiting threads.
+ *
+ * CAUTION! As a wait queue is of indeterminant length, the scheduler will be
+ * locked for an indeterminant amount of time. This may impact system
+ * performance. As such, care must be taken when using both this function and
+ * the specified callback.
+ *
+ * @param wait_q Identifies the wait queue to walk
+ * @param func   Callback to invoke on each waiting thread
+ * @param data   Custom data passed to the callback
+ *
+ * @retval non-zero if walk is terminated by the callback; otherwise 0
+ */
+int z_sched_waitq_walk(_wait_q_t *wait_q,
+		       int (*func)(struct k_thread *, void *), void *data);
 
 /** @brief Halt thread cycle usage accounting.
  *

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -349,9 +349,10 @@ static size_t pipe_write(struct k_pipe *pipe, sys_dlist_t *src_list,
 			}
 		} else if (dest->bytes_to_xfer == 0U) {
 
-			/* A thread's read request has been satisfied. */
+			/* The thread's read request has been satisfied. */
 
-			(void) z_sched_wake(&pipe->wait_q.readers, 0, NULL);
+			z_unpend_thread(dest->thread);
+			z_ready_thread(dest->thread);
 
 			*reschedule = true;
 		}
@@ -586,7 +587,8 @@ static int pipe_get_internal(k_spinlock_key_t key, struct k_pipe *pipe,
 
 			/* The thread's write request has been satisfied. */
 
-			(void) z_sched_wake(&pipe->wait_q.writers, 0, NULL);
+			z_unpend_thread(src_desc->thread);
+			z_ready_thread(src_desc->thread);
 
 			reschedule_needed = true;
 		}

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1913,3 +1913,28 @@ int z_sched_wait(struct k_spinlock *lock, k_spinlock_key_t key,
 	}
 	return ret;
 }
+
+int z_sched_waitq_walk(_wait_q_t  *wait_q,
+		       int (*func)(struct k_thread *, void *), void *data)
+{
+	struct k_thread *thread;
+	int  status = 0;
+
+	LOCKED(&sched_spinlock) {
+		_WAIT_Q_FOR_EACH(wait_q, thread) {
+
+			/*
+			 * Invoke the callback function on each waiting thread
+			 * for as long as there are both waiting threads AND
+			 * it returns 0.
+			 */
+
+			status = func(thread, data);
+			if (status != 0) {
+				break;
+			}
+		}
+	}
+
+	return status;
+}

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -788,7 +788,9 @@ static inline void unpend_thread_no_timeout(struct k_thread *thread)
 ALWAYS_INLINE void z_unpend_thread_no_timeout(struct k_thread *thread)
 {
 	LOCKED(&sched_spinlock) {
-		unpend_thread_no_timeout(thread);
+		if (thread->base.pended_on != NULL) {
+			unpend_thread_no_timeout(thread);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #52812 (well, most of it)

This series of commits is an attempt to fix the pipe instability issues raised in issue #52812 (the second and third issues). The issues that I have been able identify related to those boil down to improperly protecting the wait queue from within the pipe routines.

When the working list of pended threads (to read from or write to) is generated, sched_spinlock must be taken to protect the wait queue. Otherwise, an in-opportune timeout can lead to problems.

As there is a gap in time between when that list is generated and when data is copied to/from the previously identified waiting thread, that thread can time out. There are two things that need to be done to avoid problems stemming from this.
    1. Waking the thread must be done safely. That is, it must be explicitly specified and a run-time check to determine if it is still pended must be done before unpending it.
    2. A barrier must be inserted after the thread has been safely unpended so that it spins waiting for the pipe lock, which it can get after the put/get operation that was supposed to wake it finishes. I specify "supposed to" because it could have technically timed out while data was being copied, but since it made it to the "working list" before timing out, I am arguing that it is not really a timeout, but a special processing case.

This set of commits does not address the first of the three issues identified in #52812.