### PR TITLE
mgmt: updatehub: Add support to storage abstraction

### DIFF
--- a/samples/subsys/mgmt/updatehub/src/main.c
+++ b/samples/subsys/mgmt/updatehub/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 O.S.Systems
+ * Copyright (c) 2018-2023 O.S.Systems
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,7 +10,6 @@
 #include <zephyr/net/net_event.h>
 #include <zephyr/net/net_conn_mgr.h>
 #include <zephyr/net/wifi_mgmt.h>
-#include <zephyr/dfu/mcuboot.h>
 
 #if defined(CONFIG_UPDATEHUB_DTLS)
 #include <zephyr/net/tls_credentials.h>
@@ -45,7 +44,7 @@ void start_updatehub(void)
 		switch (updatehub_update()) {
 		case UPDATEHUB_OK:
 			ret = 0;
-			sys_reboot(SYS_REBOOT_WARM);
+			updatehub_reboot();
 			break;
 
 		default:
@@ -110,7 +109,7 @@ void main(void)
 
 	/* The image of application needed be confirmed */
 	LOG_INF("Confirming the boot image");
-	ret = boot_write_img_confirmed();
+	ret = updatehub_confirm();
 	if (ret < 0) {
 		LOG_ERR("Error to confirm the image");
 	}

--- a/subsys/mgmt/updatehub/CMakeLists.txt
+++ b/subsys/mgmt/updatehub/CMakeLists.txt
@@ -11,6 +11,7 @@ zephyr_library_sources_ifdef(CONFIG_UPDATEHUB updatehub_device.c)
 zephyr_library_sources_ifdef(CONFIG_UPDATEHUB updatehub_firmware.c)
 zephyr_library_sources_ifdef(CONFIG_UPDATEHUB updatehub_timer.c)
 zephyr_library_sources_ifdef(CONFIG_UPDATEHUB updatehub_integrity.c)
+zephyr_library_sources_ifdef(CONFIG_UPDATEHUB updatehub_storage.c)
 zephyr_library_sources_ifdef(CONFIG_UPDATEHUB_SHELL shell.c)
 
 zephyr_include_directories(

--- a/subsys/mgmt/updatehub/include/updatehub.h
+++ b/subsys/mgmt/updatehub/include/updatehub.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 O.S.Systems
+ * Copyright (c) 2018-2023 O.S.Systems
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -68,6 +68,23 @@ enum updatehub_response updatehub_probe(void);
  * @return UPDATEHUB_FLASH_INIT_ERROR fail to initialize the flash.
  */
 enum updatehub_response updatehub_update(void);
+
+/**
+ * @brief Confirm that image is running as expected.
+ *
+ * @details Must be used before the UpdateHub probe. It should be one of first
+ * actions after reboot.
+ *
+ * @return Return 0 if success otherwise a negative @errorno value.
+ */
+int updatehub_confirm(void);
+
+/**
+ * @brief Request system to reboot.
+ *
+ * @return Return 0 if success otherwise a negative @errorno value.
+ */
+int updatehub_reboot(void);
 
 /**
  * @}

--- a/subsys/mgmt/updatehub/shell.c
+++ b/subsys/mgmt/updatehub/shell.c
@@ -5,12 +5,11 @@
  */
 
 #include <zephyr/shell/shell.h>
-#include <zephyr/drivers/flash.h>
-#include <zephyr/dfu/mcuboot.h>
-#include <zephyr/dfu/flash_img.h>
+
 #include "include/updatehub.h"
 #include "updatehub_firmware.h"
 #include "updatehub_device.h"
+#include "updatehub_storage.h"
 
 #if defined(CONFIG_UPDATEHUB_CE)
 #define UPDATEHUB_SERVER CONFIG_UPDATEHUB_SERVER
@@ -59,7 +58,7 @@ static int cmd_info(const struct shell *shell, size_t argc, char **argv)
 	char *firmware_version = k_malloc(FIRMWARE_IMG_VER_STRLEN_MAX);
 
 	updatehub_get_device_identity(device_id, DEVICE_ID_HEX_MAX_SIZE);
-	updatehub_get_firmware_version(FIXED_PARTITION_ID(slot0_partition),
+	updatehub_get_firmware_version(UPDATEHUB_SLOT_PARTITION_0,
 				       firmware_version,
 				       FIRMWARE_IMG_VER_STRLEN_MAX);
 

--- a/subsys/mgmt/updatehub/shell.c
+++ b/subsys/mgmt/updatehub/shell.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 O.S.Systems
+ * Copyright (c) 2018-2023 O.S.Systems
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -56,10 +56,12 @@ static int cmd_info(const struct shell *shell, size_t argc, char **argv)
 	ARG_UNUSED(argv);
 
 	char *device_id = k_malloc(DEVICE_ID_HEX_MAX_SIZE);
-	char *firmware_version = k_malloc(BOOT_IMG_VER_STRLEN_MAX);
+	char *firmware_version = k_malloc(FIRMWARE_IMG_VER_STRLEN_MAX);
 
 	updatehub_get_device_identity(device_id, DEVICE_ID_HEX_MAX_SIZE);
-	updatehub_get_firmware_version(firmware_version, BOOT_IMG_VER_STRLEN_MAX);
+	updatehub_get_firmware_version(FIXED_PARTITION_ID(slot0_partition),
+				       firmware_version,
+				       FIRMWARE_IMG_VER_STRLEN_MAX);
 
 	shell_fprintf(shell, SHELL_NORMAL, "Unique device id: %s\n",
 		      device_id);

--- a/subsys/mgmt/updatehub/updatehub.c
+++ b/subsys/mgmt/updatehub/updatehub.c
@@ -620,7 +620,7 @@ static int report(enum updatehub_state state)
 	int ret = -1;
 	const char *exec = state_name(state);
 	char *device_id = k_malloc(DEVICE_ID_HEX_MAX_SIZE);
-	char *firmware_version = k_malloc(BOOT_IMG_VER_STRLEN_MAX);
+	char *firmware_version = k_malloc(FIRMWARE_IMG_VER_STRLEN_MAX);
 
 	if (device_id == NULL || firmware_version == NULL) {
 		LOG_ERR("Could not alloc device_id or firmware_version memory");
@@ -631,7 +631,9 @@ static int report(enum updatehub_state state)
 		goto error;
 	}
 
-	if (!updatehub_get_firmware_version(firmware_version, BOOT_IMG_VER_STRLEN_MAX)) {
+	if (!updatehub_get_firmware_version(FIXED_PARTITION_ID(slot0_partition),
+					    firmware_version,
+					    FIRMWARE_IMG_VER_STRLEN_MAX)) {
 		goto error;
 	}
 
@@ -769,7 +771,7 @@ enum updatehub_response updatehub_probe(void)
 	char *metadata = k_malloc(MAX_DOWNLOAD_DATA);
 	char *metadata_copy = k_malloc(MAX_DOWNLOAD_DATA);
 	char *device_id = k_malloc(DEVICE_ID_HEX_MAX_SIZE);
-	char *firmware_version = k_malloc(BOOT_IMG_VER_STRLEN_MAX);
+	char *firmware_version = k_malloc(FIRMWARE_IMG_VER_STRLEN_MAX);
 
 	size_t sha256size;
 
@@ -786,7 +788,9 @@ enum updatehub_response updatehub_probe(void)
 		goto error;
 	}
 
-	if (!updatehub_get_firmware_version(firmware_version, BOOT_IMG_VER_STRLEN_MAX)) {
+	if (!updatehub_get_firmware_version(FIXED_PARTITION_ID(slot0_partition),
+					    firmware_version,
+					    FIRMWARE_IMG_VER_STRLEN_MAX)) {
 		ctx.code_status = UPDATEHUB_METADATA_ERROR;
 		goto error;
 	}

--- a/subsys/mgmt/updatehub/updatehub.c
+++ b/subsys/mgmt/updatehub/updatehub.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(updatehub, CONFIG_UPDATEHUB_LOG_LEVEL);
 #include <zephyr/drivers/flash.h>
 #include <zephyr/sys/reboot.h>
 #include <zephyr/data/json.h>
+#include <zephyr/dfu/mcuboot.h>
 #include <zephyr/storage/flash_map.h>
 
 #include "include/updatehub.h"
@@ -762,6 +763,18 @@ static void probe_cb(char *metadata, size_t metadata_size)
 	LOG_INF("Probe metadata received");
 }
 
+int updatehub_confirm(void)
+{
+	return boot_write_img_confirmed();
+}
+
+int updatehub_reboot(void)
+{
+	sys_reboot(SYS_REBOOT_WARM);
+
+	return 0;
+}
+
 enum updatehub_response updatehub_probe(void)
 {
 	struct probe request;
@@ -985,14 +998,14 @@ static void autohandler(struct k_work *work)
 			"confirmed image.");
 
 		LOG_PANIC();
-		sys_reboot(SYS_REBOOT_WARM);
+		updatehub_reboot();
 		break;
 
 	case UPDATEHUB_HAS_UPDATE:
 		switch (updatehub_update()) {
 		case UPDATEHUB_OK:
 			LOG_PANIC();
-			sys_reboot(SYS_REBOOT_WARM);
+			updatehub_reboot();
 			break;
 
 		default:

--- a/subsys/mgmt/updatehub/updatehub_device.c
+++ b/subsys/mgmt/updatehub/updatehub_device.c
@@ -1,11 +1,14 @@
 /*
- * Copyright (c) 2018-2020 O.S.Systems
+ * Copyright (c) 2018-2023 O.S.Systems
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "updatehub_device.h"
 
 #include <string.h>
+
+#include <zephyr/drivers/hwinfo.h>
+
+#include "updatehub_device.h"
 
 bool updatehub_get_device_identity(char *id, int id_max_len)
 {

--- a/subsys/mgmt/updatehub/updatehub_device.h
+++ b/subsys/mgmt/updatehub/updatehub_device.h
@@ -7,9 +7,6 @@
 #ifndef __UPDATEHUB_DEVICE_H__
 #define __UPDATEHUB_DEVICE_H__
 
-#include <zephyr/kernel.h>
-#include <zephyr/drivers/hwinfo.h>
-
 #define DEVICE_ID_BIN_MAX_SIZE	64
 #define DEVICE_ID_HEX_MAX_SIZE	((DEVICE_ID_BIN_MAX_SIZE * 2) + 1)
 

--- a/subsys/mgmt/updatehub/updatehub_firmware.h
+++ b/subsys/mgmt/updatehub/updatehub_firmware.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 O.S.Systems
+ * Copyright (c) 2018-2023 O.S.Systems
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,10 +7,10 @@
 #ifndef __UPDATEHUB_FIRMWARE_H__
 #define __UPDATEHUB_FIRMWARE_H__
 
-#include <zephyr/drivers/flash.h>
-#include <zephyr/dfu/mcuboot.h>
-#include <zephyr/dfu/flash_img.h>
+/* 255.255.65535\0 */
+#define FIRMWARE_IMG_VER_STRLEN_MAX 14
 
-bool updatehub_get_firmware_version(char *version, int version_len);
+bool updatehub_get_firmware_version(const uint32_t partition_id,
+				    char *version, int version_len);
 
 #endif /* __UPDATEHUB_FIRMWARE_H__ */

--- a/subsys/mgmt/updatehub/updatehub_storage.c
+++ b/subsys/mgmt/updatehub/updatehub_storage.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023 O.S.Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(updatehub, CONFIG_UPDATEHUB_LOG_LEVEL);
+
+#include <zephyr/dfu/mcuboot.h>
+
+#include "updatehub_storage.h"
+
+int updatehub_storage_is_partition_good(struct updatehub_storage_context *ctx)
+{
+	bool ret;
+
+	if (ctx == NULL) {
+		return -EINVAL;
+	}
+
+	ret = boot_is_img_confirmed() == 0;
+
+	return ret ? 0 : -EIO;
+}
+
+int updatehub_storage_init(struct updatehub_storage_context *ctx,
+			   const uint32_t partition_id)
+{
+	if (ctx == NULL) {
+		return -EINVAL;
+	}
+
+	if (boot_erase_img_bank(partition_id)) {
+		return -EIO;
+	}
+
+	return flash_img_init(&ctx->flash_ctx);
+}
+
+int updatehub_storage_write(struct updatehub_storage_context *ctx,
+			    const uint8_t *data, const size_t size,
+			    const bool flush)
+{
+	if (ctx == NULL || (size > 0 && data == NULL)) {
+		return -EINVAL;
+	}
+
+	LOG_DBG("Flash: Address: 0x%08x, Size: %d, Flush: %s",
+		ctx->flash_ctx.stream.bytes_written, size,
+		flush ? "True" : "False");
+
+	return flash_img_buffered_write(&ctx->flash_ctx, data, size, flush);
+}
+
+int updatehub_storage_check(struct updatehub_storage_context *ctx,
+			    const uint32_t partition_id,
+			    const uint8_t *hash, const size_t size)
+{
+	if (ctx == NULL || hash == NULL || size == 0) {
+		return -EINVAL;
+	}
+
+	const struct flash_img_check fic = { .match = hash, .clen = size };
+
+	return flash_img_check(&ctx->flash_ctx, &fic, partition_id);
+}
+
+int updatehub_storage_mark_partition_to_upgrade(struct updatehub_storage_context *ctx,
+						const uint32_t partition_id)
+{
+	if (ctx == NULL) {
+		return -EINVAL;
+	}
+
+	return boot_request_upgrade_multi(partition_id, BOOT_UPGRADE_TEST);
+}
+
+int updatehub_storage_mark_partition_as_confirmed(const uint32_t partition_id)
+{
+	return boot_write_img_confirmed();
+}

--- a/subsys/mgmt/updatehub/updatehub_storage.h
+++ b/subsys/mgmt/updatehub/updatehub_storage.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 O.S.Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __UPDATEHUB_STORAGE_H__
+#define __UPDATEHUB_STORAGE_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/dfu/flash_img.h>
+#include <zephyr/storage/flash_map.h>
+#define UPDATEHUB_SLOT_PARTITION_0 FIXED_PARTITION_ID(slot0_partition)
+#define UPDATEHUB_SLOT_PARTITION_1 FIXED_PARTITION_ID(slot1_partition)
+
+struct updatehub_storage_context {
+	struct flash_img_context flash_ctx;
+};
+
+int updatehub_storage_is_partition_good(struct updatehub_storage_context *ctx);
+int updatehub_storage_init(struct updatehub_storage_context *ctx,
+			   const uint32_t partition_id);
+int updatehub_storage_write(struct updatehub_storage_context *ctx,
+			    const uint8_t *data, const size_t size,
+			    const bool flush);
+int updatehub_storage_check(struct updatehub_storage_context *ctx,
+			    const uint32_t partition_id,
+			    const uint8_t *hash, const size_t size);
+int updatehub_storage_mark_partition_to_upgrade(struct updatehub_storage_context *ctx,
+						const uint32_t partition_id);
+int updatehub_storage_mark_partition_as_confirmed(const uint32_t partition_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __UPDATEHUB_STORAGE_H__ */


### PR DESCRIPTION
The UpdateHub public API requires that application have directly access to both systems and mcuboot functions. This clean-up such issues by exposing two new public functions. It clean-up a few internals and add a storage abstraction to make updatehub core generic.

CC: @otavio