### PR TITLE
Suppress advertising timeout warning when successful

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1768,7 +1768,9 @@ static void adv_timeout(struct k_work *work)
 #else
 	err = bt_le_adv_stop();
 #endif
-	LOG_WRN("Failed to stop advertising: %d", err);
+	if (err) {
+		LOG_WRN("Failed to stop advertising: %d", err);
+	}
 }
 
 #if defined(CONFIG_BT_PER_ADV)


### PR DESCRIPTION
Issue the following log only when there is an actual failure (`err` is non-zero).

```
BT_WARN("Failed to stop advertising: %d", err);
```

Fixes [#53643](https://github.com/zephyrproject-rtos/zephyr/issues/53643).