### PR TITLE
ITE dts/riscv/ite: separate dtsi node to it81xx2 from it8xxx2

### DIFF
--- a/dts/riscv/ite/it81xx2.dtsi
+++ b/dts/riscv/ite/it81xx2.dtsi
@@ -503,6 +503,22 @@
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
+
+		intc: interrupt-controller@f03f00 {
+			compatible = "ite,it8xxx2-intc";
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
+			interrupt-controller;
+			reg = <0x00f03f00 0x0100>;
+		};
+
+		twd0: watchdog@f01f00 {
+			compatible = "ite,it8xxx2-watchdog";
+			reg = <0x00f01f00 0x0062>;
+			interrupts = <IT8XXX2_IRQ_TIMER1 IRQ_TYPE_EDGE_RISING   /* Warning timer */
+				      IT8XXX2_IRQ_TIMER2 IRQ_TYPE_EDGE_RISING>; /* One shot timer */
+			interrupt-parent = <&intc>;
+		};
 	};
 };
 

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -101,13 +101,6 @@
 			       0xf010ce 3>;	/* SCAR23 */
 		};
 
-		intc: interrupt-controller@f03f00 {
-			compatible = "ite,it8xxx2-intc";
-			#address-cells = <0>;
-			#interrupt-cells = <2>;
-			interrupt-controller;
-			reg = <0x00f03f00 0x0100>;
-		};
 		uart1: uart@f02700 {
 			compatible = "ns16550";
 			reg = <0x00f02700 0x0020>;
@@ -145,14 +138,6 @@
 			port-num = <2>;
 			gpios = <&gpioh 1 0>;
 			uart-dev = <&uart2>;
-		};
-
-		twd0: watchdog@f01f00 {
-			compatible = "ite,it8xxx2-watchdog";
-			reg = <0x00f01f00 0x0062>;
-			interrupts = <IT8XXX2_IRQ_TIMER1 IRQ_TYPE_EDGE_RISING   /* Warning timer */
-				      IT8XXX2_IRQ_TIMER2 IRQ_TYPE_EDGE_RISING>; /* One shot timer */
-			interrupt-parent = <&intc>;
 		};
 
 		timer: timer@f01f10 {


### PR DESCRIPTION
The interrupt and watchdog registers of the it82xx2 will be remapped, so these device nodes should be separated to it81xx2 from it8xxx2. it8xxx2 dtsi are common settings for it81xx2 and it82xx2.

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>