### PR TITLE
clock_control: stm32: F4 domain clock + fixed domain clock

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -242,6 +242,11 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 		return err;
 	}
 
+	if (pclken->enr == NO_SEL) {
+		/* Domain clock is fixed. Nothing to set. Exit */
+		return 0;
+	}
+
 	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_CLOCK_REG_GET(pclken->enr),
 		     STM32_CLOCK_VAL_GET(pclken->enr) << STM32_CLOCK_SHIFT_GET(pclken->enr));
 

--- a/dts/arm/st/f4/stm32f410.dtsi
+++ b/dts/arm/st/f4/stm32f410.dtsi
@@ -7,6 +7,10 @@
 #include <st/f4/stm32f4.dtsi>
 
 / {
+	chosen {
+		zephyr,entropy = &rng;
+	};
+
 	soc {
 		spi2: spi@40003800 {
 			compatible = "st,stm32-spi";
@@ -91,6 +95,13 @@
 			#io-channel-cells = <1>;
 		};
 
+		rng: rng@40080000 {
+			compatible = "st,stm32-rng";
+			reg = <0x40080000 0x400>;
+			interrupts = <80 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x80000000>;
+			status = "disabled";
+		};
 	};
 
 	die_temp: dietemp {

--- a/dts/arm/st/f4/stm32f410.dtsi
+++ b/dts/arm/st/f4/stm32f410.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/clock/stm32f410_clock.h>
 #include <st/f4/stm32f4.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/f4/stm32f411.dtsi>
+#include <st/f4/stm32f410.dtsi>
 
+/delete-node/ &dac1;
 / {
 	chosen {
 		zephyr,entropy = &rng;
@@ -41,20 +42,27 @@
 			status = "disabled";
 		};
 
-		timers6: timers@40001000 {
-			compatible = "st,stm32-timers";
-			reg = <0x40001000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000010>;
-			resets = <&rctl STM32_RESET(APB1, 4U)>;
-			interrupts = <54 0>;
-			interrupt-names = "global";
-			st,prescaler = <0>;
+		spi4: spi@40013400 {
+			compatible = "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40013400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00002000>;
+			interrupts = <84 5>;
 			status = "disabled";
+		};
 
-			counter {
-				compatible = "st,stm32-counter";
-				status = "disabled";
-			};
+		i2s4: i2s@40013400 {
+			compatible = "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40013400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00002000>;
+			interrupts = <84 5>;
+			dmas = <&dma2 1 4 0x400 0x3
+				&dma2 0 4 0x400 0x3>;
+			dma-names = "tx", "rx";
+			status = "disabled";
 		};
 
 		timers7: timers@40001400 {

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -7,11 +7,9 @@
 #include <st/f4/stm32f410.dtsi>
 
 /delete-node/ &dac1;
-/ {
-	chosen {
-		zephyr,entropy = &rng;
-	};
+/delete-node/ &rng;
 
+/ {
 	soc {
 		pinctrl: pin-controller@40020000 {
 			reg = <0x40020000 0x1c00>;

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -58,8 +58,8 @@
 			status = "disabled";
 		};
 
-		/* spi5 is present on all STM32F429XX SoCs except
-		 * STM32F429vX SoCs. Delete node in stm32f429vX.dtsi.
+		/* spi5 is present on all STM32F427XX and derivates SoCs except
+		 * some vX variants. Delete node in vX.dtsi.
 		 */
 		 spi5: spi@40015000 {
 			compatible = "st,stm32-spi";
@@ -71,8 +71,8 @@
 			status = "disabled";
 		};
 
-		/* spi6 is present on all STM32F429XX SoCs except
-		 * STM32F429vX SoCs. Delete node in stm32f429vX.dtsi.
+		/* spi6 is present on all STM32F427XX and derivates SoCs except
+		 * some vX variants. Delete node in vX.dtsi.
 		 */
 		spi6: spi@40015400 {
 			compatible = "st,stm32-spi";

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/f4/stm32f407.dtsi>
+#include <zephyr/dt-bindings/clock/stm32f427_clock.h>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>
 
 / {

--- a/dts/arm/st/f4/stm32f437.dtsi
+++ b/dts/arm/st/f4/stm32f437.dtsi
@@ -4,97 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/f4/stm32f407.dtsi>
-#include <zephyr/dt-bindings/clock/stm32f427_clock.h>
+#include <st/f4/stm32f427.dtsi>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>
 
 / {
 	soc {
-		pinctrl: pin-controller@40020000 {
-			reg = <0x40020000 0x2C00>;
-
-			gpioj: gpio@40022400 {
-				compatible = "st,stm32-gpio";
-				gpio-controller;
-				#gpio-cells = <2>;
-				reg = <0x40022400 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000200>;
-			};
-
-			gpiok: gpio@40022800 {
-				compatible = "st,stm32-gpio";
-				gpio-controller;
-				#gpio-cells = <2>;
-				reg = <0x40022800 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000400>;
-			};
-		};
-
-		uart7: serial@40007800 {
-			compatible = "st,stm32-uart";
-			reg = <0x40007800 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x40000000>;
-			resets = <&rctl STM32_RESET(APB1, 30U)>;
-			interrupts = <82 0>;
-			status = "disabled";
-		};
-
-		uart8: serial@40007c00 {
-			compatible = "st,stm32-uart";
-			reg = <0x40007c00 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>;
-			resets = <&rctl STM32_RESET(APB1, 31U)>;
-			interrupts = <83 0>;
-			status = "disabled";
-		};
-
-		spi4: spi@40013400 {
-			compatible = "st,stm32-spi";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40013400 0x400>;
-			interrupts = <84 5>;
-			status = "disabled";
-		};
-
-		/* spi5 is present on all STM32F437XX SoCs except
-		 * STM32F437vX SoCs. Delete node in stm32f437vX.dtsi.
-		 */
-		 spi5: spi@40015000 {
-			compatible = "st,stm32-spi";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015000 0x400>;
-			interrupts = <85 5>;
-			status = "disabled";
-		};
-
-		/* spi6 is present on all STM32F437XX SoCs except
-		 * STM32F437vX SoCs. Delete node in stm32f437vX.dtsi.
-		 */
-		spi6: spi@40015400 {
-			compatible = "st,stm32-spi";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015400 0x400>;
-			interrupts = <86 5>;
-			status = "disabled";
-		};
-
-		fmc: memory-controller@a0000000 {
-			compatible = "st,stm32-fmc";
-			reg = <0xa0000000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000001>;
-			status = "disabled";
-
-			sdram: sdram {
-				compatible = "st,stm32-fmc-sdram";
-				#address-cells = <1>;
-				#size-cells = <0>;
-				status = "disabled";
-			};
-		};
-
 		cryp: cryp@50060000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
@@ -102,9 +16,5 @@
 			interrupts = <79 0>;
 			status = "disabled";
 		};
-	};
-
-	die_temp: dietemp {
-		io-channels = <&adc1 18>;
 	};
 };

--- a/dts/arm/st/f4/stm32f437.dtsi
+++ b/dts/arm/st/f4/stm32f437.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/f4/stm32f407.dtsi>
+#include <zephyr/dt-bindings/clock/stm32f427_clock.h>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>
 
 / {

--- a/dts/arm/st/f4/stm32f437vX.dtsi
+++ b/dts/arm/st/f4/stm32f437vX.dtsi
@@ -6,6 +6,11 @@
 
 #include <st/f4/stm32f437.dtsi>
 
+/* spi5 and spi6 are present on all STM32F437XX SoCs except
+ * STM32F437vX SoCs, so they are defined in stm32f429.dtsi and deleted
+ * here.
+ */
+
 /delete-node/ &spi5;
 
 /delete-node/ &spi6;

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/f4/stm32f401.dtsi>
+#include <zephyr/dt-bindings/clock/stm32f410_clock.h>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>
 
 / {

--- a/include/zephyr/dt-bindings/clock/stm32f0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f0_clock.h
@@ -73,5 +73,7 @@
 #define USART3_SEL(val)		STM32_CLOCK(val, 3, 18, CFGR3_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+/** Dummy: Add a specificier when no selection is possible */
+#define NO_SEL			0xFF
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f1_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f1_clock.h
@@ -59,5 +59,7 @@
 /** @brief Device domain clocks selection helpers */
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+/** Dummy: Add a specificier when no selection is possible */
+#define NO_SEL			0xFF
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F1_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f3_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f3_clock.h
@@ -83,5 +83,7 @@
 #define TIM3_4_SEL(val)		STM32_CLOCK(val, 1, 25, CFGR3_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+/** Dummy: Add a specificier when no selection is possible */
+#define NO_SEL			0xFF
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F3_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f410_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f410_clock.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F410_CLOCK_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F410_CLOCK_H_
+
+/** @brief RCC_DCKCFGR register offset */
+#define DCKCFGR_REG		0x8C
+#define DCKCFGR2_REG		0x94
+
+/** @brief Device domain clocks selection helpers */
+/** DCKCFGR devices */
+#define CKDFSDM2A_SEL(val)	STM32_CLOCK(val, 1, 14, DCKCFGR_REG)
+#define CKDFSDM1A_SEL(val)	STM32_CLOCK(val, 1, 15, DCKCFGR_REG)
+#define SAI1A_SEL(val)		STM32_CLOCK(val, 2, 20, DCKCFGR_REG)
+#define SAI1B_SEL(val)		STM32_CLOCK(val, 2, 22, DCKCFGR_REG)
+#define I2S1_SEL(val)		STM32_CLOCK(val, 2, 25, DCKCFGR_REG)
+#define I2S2_SEL(val)		STM32_CLOCK(val, 2, 27, DCKCFGR_REG)
+#define CKDFSDM_SEL(val)	STM32_CLOCK(val, 1, 31, DCKCFGR_REG)
+
+/** DCKCFGR2 devices */
+#define I2CFMP1_SEL(val)	STM32_CLOCK(val, 1, 22, DCKCFGR2_REG)
+#define CK48M_SEL(val)		STM32_CLOCK(val, 1, 27, DCKCFGR2_REG)
+#define SDIO_SEL(val)		STM32_CLOCK(val, 1, 28, DCKCFGR2_REG)
+#define LPTIM1_SEL(val)		STM32_CLOCK(val, 1, 30, DCKCFGR2_REG)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F410_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f427_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f427_clock.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F427_CLOCK_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F427_CLOCK_H_
+
+/** @brief RCC_DCKCFGR register offset */
+#define DCKCFGR_REG		0x8C
+
+/** @brief Device domain clocks selection helpers */
+/** DCKCFGR devices */
+#define CKDFSDM2A_SEL(val)	STM32_CLOCK(val, 1, 14, DCKCFGR_REG)
+#define CKDFSDM1A_SEL(val)	STM32_CLOCK(val, 1, 15, DCKCFGR_REG)
+#define SAI1A_SEL(val)		STM32_CLOCK(val, 2, 20, DCKCFGR_REG)
+#define SAI1B_SEL(val)		STM32_CLOCK(val, 2, 22, DCKCFGR_REG)
+#define CLK48M_SEL(val)		STM32_CLOCK(val, 1, 27, DCKCFGR_REG)
+#define SDMMC_SEL(val)		STM32_CLOCK(val, 1, 28, DCKCFGR_REG)
+#define DSI_SEL(val)		STM32_CLOCK(val, 1, 29, DCKCFGR_REG)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F427_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f4_clock.h
@@ -68,4 +68,7 @@
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
 
+/** Dummy: Add a specificier when no selection is possible */
+#define NO_SEL			0xFF
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f7_clock.h
@@ -92,5 +92,7 @@
 #define CK48M_SEL(val)		STM32_CLOCK(val, 1, 27, DKCFGR2_REG)
 #define SDMMC1_SEL(val)		STM32_CLOCK(val, 1, 28, DKCFGR2_REG)
 #define SDMMC2_SEL(val)		STM32_CLOCK(val, 1, 29, DKCFGR2_REG)
+/** Dummy: Add a specificier when no selection is possible */
+#define NO_SEL			0xFF
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F7_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32g0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_clock.h
@@ -92,7 +92,7 @@
 #define USB_SEL(val)		STM32_CLOCK(val, 3, 12, CCIPR2_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
-
-
+/** Dummy: Add a specificier when no selection is possible */
+#define NO_SEL			0xFF
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32g4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g4_clock.h
@@ -95,5 +95,7 @@
 #define QSPI_SEL(val)		STM32_CLOCK(val, 3, 20, CCIPR2_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+/** Dummy: Add a specificier when no selection is possible */
+#define NO_SEL			0xFF
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l0_clock.h
@@ -74,5 +74,7 @@
 #define HSI48_SEL(val)		STM32_CLOCK(val, 1, 26, CCIPR_REG)
 /** CSR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 16, CSR_REG)
+/** Dummy: Add a specificier when no selection is possible */
+#define NO_SEL			0xFF
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l1_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l1_clock.h
@@ -57,4 +57,7 @@
 
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 16, CSR_REG)
 
+/** Dummy: Add a specificier when no selection is possible */
+#define NO_SEL			0xFF
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L1_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l4_clock.h
@@ -101,5 +101,7 @@
 #define OSPI_SEL(val)		STM32_CLOCK(val, 3, 20, CCIPR2_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+/** Dummy: Add a specificier when no selection is possible */
+#define NO_SEL			0xFF
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wb_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wb_clock.h
@@ -90,5 +90,7 @@
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
 /** CSR devices */
 #define RFWKP_SEL(val)		STM32_CLOCK(val, 3, 14, CSR_REG)
+/** Dummy: Add a specificier when no selection is possible */
+#define NO_SEL			0xFF
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WB_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wl_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wl_clock.h
@@ -85,5 +85,7 @@
 #define RNG_SEL(val)		STM32_CLOCK(val, 3, 30, CCIPR_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+/** Dummy: Add a specificier when no selection is possible */
+#define NO_SEL			0xFF
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WL_CLOCK_H_ */


### PR DESCRIPTION
This PR contains 2 changes required for https://github.com/zephyrproject-rtos/zephyr/pull/53258

1- Provide DCKCFGR description on F4 series
2- Add ability to describe in dts fixed domain clocks 