### PR TITLE
samples: mgmt: mcumgr: Fix fs overlay

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/overlay-fs.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/overlay-fs.conf
@@ -1,4 +1,5 @@
 # Enable the LittleFS file system.
+CONFIG_FLASH_MAP=y
 CONFIG_FILE_SYSTEM=y
 CONFIG_FILE_SYSTEM_LITTLEFS=y
 


### PR DESCRIPTION
Fixes the filesystem overlay by enabling flash map, which is needed for lfs.

Fixes #53652