### PR TITLE
arch/x86: Fix compilation error

### DIFF
--- a/arch/x86/core/cache.c
+++ b/arch/x86/core/cache.c
@@ -19,22 +19,20 @@
 #include <stdbool.h>
 
 /**
- * @brief Flush cache lines to main memory
- *
  * No alignment is required for either <virt> or <size>, but since
  * sys_cache_flush() iterates on the cache lines, a cache line alignment for
  * both is optimal.
  *
  * The cache line size is specified via the d-cache-line-size DTS property.
  */
-static void arch_dcache_flush(void *start_addr, size_t size)
+int arch_dcache_flush_range(void *start_addr, size_t size)
 {
 	size_t line_size = sys_cache_data_line_size_get();
 	uintptr_t start = (uintptr_t)start_addr;
 	uintptr_t end = start + size;
 
 	if (line_size == 0U) {
-		return;
+		return -ENOTSUP;
 	}
 
 	end = ROUND_UP(end, line_size);
@@ -49,14 +47,5 @@ static void arch_dcache_flush(void *start_addr, size_t size)
 #else
 	__asm__ volatile("lock; addl $0,-4(%%esp);\n\t":::"memory", "cc");
 #endif
-}
-
-int arch_dcache_range(void *addr, size_t size, int op)
-{
-	if (op & K_CACHE_WB) {
-		arch_dcache_flush(addr, size);
-		return 0;
-	}
-
-	return -ENOTSUP;
+	return 0;
 }


### PR DESCRIPTION
arch_dcache_range() function does not exist anymore, nor K_CACHE_WB macro. Removing it entirely.

arch_dcache_flush_range() signature changed, so relevantly applying these.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>