### PR TITLE
Revert "soc: intel_adsp/ace: fix CPU halting"

### DIFF
--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -152,7 +152,7 @@ int soc_adsp_halt_cpu(int id)
 		return -EINVAL;
 	}
 
-	CHECKIF(!soc_cpus_active[id]) {
+	CHECKIF(soc_cpus_active[id]) {
 		return -EINVAL;
 	}
 
@@ -169,9 +169,6 @@ int soc_adsp_halt_cpu(int id)
 		__ASSERT(false, "%s secondary core has not powered down", __func__);
 		return -EINVAL;
 	}
-
-	/* Stop sending IPIs to this core */
-	soc_cpus_active[id] = false;
 
 	return 0;
 }


### PR DESCRIPTION
This reverts commit 81908cd36747da5a3c4c649e79decf4facbd6a4e.

This commit introduced a regression in SOF. Value of soc_cpus_active is set by the core X it self in functions pm_state_set and pm_state_exit_post_ops. soc_adsp_halt_cpu can by called only by the primary core.

This check was to prevent a situation when we cut power to a core that is still active:

```c
CHECKIF(soc_cpus_active[id]) {
    return -EINVAL;
}
```

By changing the condition we have prevented primary core from disabling secondary cores when they are entering D3 state.

Usage in SOF can be find here: https://github.com/thesofproject/sof/blob/90c14e56cbffe6c41ebfba739da34229472c0a8d/src/lib-zephyr/cpu.c#LL194-L200C55