### PR TITLE
drivers: can: fake: fix header guards

### DIFF
--- a/include/zephyr/drivers/can/can_fake.h
+++ b/include/zephyr/drivers/can/can_fake.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_TESTS_DRIVERS_CAN_SHELL_FAKE_CAN_H_
-#define ZEPHYR_TESTS_DRIVERS_CAN_SHELL_FAKE_CAN_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CAN_CAN_FAKE_H_
+#define ZEPHYR_INCLUDE_DRIVERS_CAN_CAN_FAKE_H_
 
 #include <zephyr/drivers/can.h>
 #include <zephyr/fff.h>
@@ -49,4 +49,4 @@ DECLARE_FAKE_VALUE_FUNC(int, fake_can_get_max_filters, const struct device *, bo
 }
 #endif
 
-#endif /* ZEPHYR_TESTS_DRIVERS_CAN_SHELL_FAKE_CAN_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_CAN_CAN_FAKE_H_ */


### PR DESCRIPTION
Change the fake CAN driver headers guards to match the updated file location.

Fixes: f30a5969d0302745b9afeb3c3c7946b434dbdbb5

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>