### PR TITLE
tests/net/socket: fix compiler warnings

### DIFF
--- a/tests/net/socket/af_packet_ipproto_raw/src/main.c
+++ b/tests/net/socket/af_packet_ipproto_raw/src/main.c
@@ -35,7 +35,7 @@ static int fake_dev_send(const struct device *dev, struct net_pkt *pkt)
 	ARG_UNUSED(pkt);
 
 	/* Loopback the data back to stack: */
-	NET_DBG("Dummy device: Loopbacking data (%d bytes) to iface %d\n", net_pkt_get_len(pkt),
+	NET_DBG("Dummy device: Loopbacking data (%zd bytes) to iface %d\n", net_pkt_get_len(pkt),
 	    net_if_get_by_iface(net_pkt_iface(pkt)));
 
 	recv_pkt = net_pkt_clone(pkt, K_NO_WAIT);

--- a/tests/net/socket/misc/src/main.c
+++ b/tests/net/socket/misc/src/main.c
@@ -96,7 +96,7 @@ static int dummy_send(const struct device *dev, struct net_pkt *pkt)
 	ARG_UNUSED(dev);
 	ARG_UNUSED(pkt);
 
-	NET_DBG("Sending data (%d bytes) to iface %d\n",
+	NET_DBG("Sending data (%zd bytes) to iface %d\n",
 		net_pkt_get_len(pkt), net_if_get_by_iface(net_pkt_iface(pkt)));
 
 	current_dev = dev;


### PR DESCRIPTION
Get rid of:

warning: format '%d' expects argument of type 'int', but argument 3
has type 'size_' {aka 'long unsigned int'} [-Wformat=]
