### PR TITLE
dts: arm: st: Fix type in clock assignment of timer15

### DIFF
--- a/dts/arm/st/g0/stm32g070.dtsi
+++ b/dts/arm/st/g0/stm32g070.dtsi
@@ -30,7 +30,7 @@
 		timers15: timers@40014000 {
 			compatible = "st,stm32-timers";
 			reg = <0x40014000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00010000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00010000>;
 			resets = <&rctl STM32_RESET(APB1H, 16U)>;
 			interrupts = <20 0>;
 			interrupt-names = "global";


### PR DESCRIPTION
STM32Gxxx controllers only have a single APB bus.