### PR TITLE
lib: os: Fix note on fdtable.c

### DIFF
--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -14,7 +14,7 @@
  */
 
 #include <errno.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/fdtable.h>
 #include <zephyr/sys/speculation.h>


### PR DESCRIPTION
After `fcntl.h` moved to posix, there have a compiler note on `lib/os/fdtables.c`.
As suggested in `fcntl.h`, instead with `zephyr/posix/fcntl.h` .