### PR TITLE
manifest: update NXP HAL

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 0fd458a33ffc06913efafd808c8e91b122bd2175
+      revision: b74522c2e452b170922f639bf5720461e533fb7e
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update NXP HAL to latest revision. Commit
3e4406d98272dd53d623e4df8cc96ee040120312 within the NXP HAL broke builds for some NXP platforms, so this manifest update will allow Zephyr to skip that broken SHA.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>