### PR TITLE
net: lwm2m: fix max path length bugs for senml cbor usecase

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -1398,7 +1398,7 @@ void lwm2m_rd_client_update(void);
 /**
  * @brief LwM2M path maximum length
  */
-#define LWM2M_MAX_PATH_STR_LEN sizeof("65535/65535/65535/65535")
+#define LWM2M_MAX_PATH_STR_SIZE sizeof("65535/65535/65535/65535")
 
 /**
  * @brief Helper function to print path objects' contents to log

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -1398,7 +1398,7 @@ void lwm2m_rd_client_update(void);
 /**
  * @brief LwM2M path maximum length
  */
-#define LWM2M_MAX_PATH_STR_SIZE sizeof("65535/65535/65535/65535")
+#define LWM2M_MAX_PATH_STR_SIZE sizeof("/65535/65535/65535/65535")
 
 /**
  * @brief Helper function to print path objects' contents to log

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -283,7 +283,7 @@ static void rd_client_event(struct lwm2m_ctx *client,
 static void observe_cb(enum lwm2m_observe_event event,
 		       struct lwm2m_obj_path *path, void *user_data)
 {
-	char buf[LWM2M_MAX_PATH_STR_LEN];
+	char buf[LWM2M_MAX_PATH_STR_SIZE];
 
 	switch (event) {
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -97,7 +97,7 @@ uint8_t lwm2m_firmware_get_update_state(void)
 void lwm2m_firmware_set_update_state_inst(uint16_t obj_inst_id, uint8_t state)
 {
 	bool error = false;
-	char path[LWM2M_MAX_PATH_STR_LEN];
+	char path[LWM2M_MAX_PATH_STR_SIZE];
 
 	snprintk(path, sizeof(path), "%" PRIu16 "/%" PRIu16 "/%" PRIu16,
 		LWM2M_OBJECT_FIRMWARE_ID, obj_inst_id, FIRMWARE_UPDATE_RESULT_ID);
@@ -164,7 +164,7 @@ void lwm2m_firmware_set_update_result_inst(uint16_t obj_inst_id, uint8_t result)
 {
 	uint8_t state;
 	bool error = false;
-	char path[LWM2M_MAX_PATH_STR_LEN];
+	char path[LWM2M_MAX_PATH_STR_SIZE];
 
 	/* Check LWM2M SPEC appendix E.6.1 */
 	switch (result) {

--- a/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
@@ -205,7 +205,7 @@ static void *callback_read_not_defined(uint16_t obj_inst_id, uint16_t res_id, ui
 static void set_sw_update_state(struct lwm2m_swmgmt_data *instance, uint8_t state)
 {
 	int ret;
-	char obj_path[LWM2M_MAX_PATH_STR_LEN];
+	char obj_path[LWM2M_MAX_PATH_STR_SIZE];
 
 	(void)snprintk(obj_path, sizeof(obj_path), "%d/%d/%d", LWM2M_OBJECT_SOFTWARE_MANAGEMENT_ID,
 		       instance->obj_inst_id, SWMGMT_UPDATE_STATE_ID);
@@ -218,7 +218,7 @@ static void set_sw_update_state(struct lwm2m_swmgmt_data *instance, uint8_t stat
 static void set_sw_update_result(struct lwm2m_swmgmt_data *instance, uint8_t result)
 {
 	int ret;
-	char obj_path[LWM2M_MAX_PATH_STR_LEN];
+	char obj_path[LWM2M_MAX_PATH_STR_SIZE];
 
 	(void)snprintk(obj_path, sizeof(obj_path), "%d/%d/%d", LWM2M_OBJECT_SOFTWARE_MANAGEMENT_ID,
 		       instance->obj_inst_id, SWMGMT_UPDATE_RESULT_ID);
@@ -231,7 +231,7 @@ static void set_sw_update_result(struct lwm2m_swmgmt_data *instance, uint8_t res
 static void set_sw_update_act_state(struct lwm2m_swmgmt_data *instance, bool state)
 {
 	int ret;
-	char obj_path[LWM2M_MAX_PATH_STR_LEN];
+	char obj_path[LWM2M_MAX_PATH_STR_SIZE];
 
 	(void)snprintk(obj_path, sizeof(obj_path), "%d/%d/%d", LWM2M_OBJECT_SOFTWARE_MANAGEMENT_ID,
 		       instance->obj_inst_id, SWMGMT_ACTIVATION_UPD_STATE_ID);

--- a/subsys/net/lib/lwm2m/lwm2m_observation.c
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.c
@@ -459,7 +459,7 @@ static void engine_observe_node_init(struct observe_node *obs, const uint8_t *to
 static void remove_observer_path_from_list(struct lwm2m_ctx *ctx, struct observe_node *obs,
 					   struct lwm2m_obj_path_list *o_p, sys_snode_t *prev_node)
 {
-	char buf[LWM2M_MAX_PATH_STR_LEN];
+	char buf[LWM2M_MAX_PATH_STR_SIZE];
 
 	LOG_DBG("Removing observer %p for path %s", obs, lwm2m_path_log_buf(buf, &o_p->path));
 	if (ctx->observe_cb) {
@@ -799,7 +799,7 @@ char *lwm2m_path_log_buf(char *buf, struct lwm2m_obj_path *path)
 #if defined(CONFIG_LWM2M_CANCEL_OBSERVE_BY_PATH)
 static int engine_remove_observer_by_path(struct lwm2m_ctx *ctx, struct lwm2m_obj_path *path)
 {
-	char buf[LWM2M_MAX_PATH_STR_LEN];
+	char buf[LWM2M_MAX_PATH_STR_SIZE];
 	struct observe_node *obs;
 	struct lwm2m_obj_path_list obs_path_list_buf;
 	sys_slist_t lwm2m_path_list;

--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
@@ -33,13 +33,15 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "lwm2m_senml_cbor_types.h"
 #include "lwm2m_util.h"
 
+#define SENML_MAX_NAME_SIZE sizeof("/65535/65535/")
+
 struct cbor_out_fmt_data {
 	/* Data */
 	struct lwm2m_senml input;
 
-	/* Storage for basenames and names ~ sizeof("/65535/999/") */
+	/* Storage for basenames and names ~ sizeof("/65535/65535/") */
 	struct {
-		char names[CONFIG_LWM2M_RW_SENML_CBOR_RECORDS][sizeof("/65535/999/")];
+		char names[CONFIG_LWM2M_RW_SENML_CBOR_RECORDS][SENML_MAX_NAME_SIZE];
 		size_t name_sz; /* Name buff size */
 		uint8_t name_cnt;
 	};
@@ -93,7 +95,7 @@ static void setup_out_fmt_data(struct lwm2m_message *msg)
 
 	(void)memset(fd, 0, sizeof(*fd));
 	engine_set_out_user_data(&msg->out, fd);
-	fd->name_sz = sizeof("/65535/999/");
+	fd->name_sz = SENML_MAX_NAME_SIZE;
 	fd->basetime = 0;
 	fd->objlnk_sz = sizeof("65535:65535");
 }
@@ -160,7 +162,7 @@ static int put_basename(struct lwm2m_output_context *out, struct lwm2m_obj_path 
 	record->_record_bn._record_bn.len = len;
 	record->_record_bn_present = 1;
 
-	if ((len < sizeof("0/0") - 1) || (len >= sizeof("65535/999"))) {
+	if ((len < sizeof("/0/0") - 1) || (len >= SENML_MAX_NAME_SIZE)) {
 		__ASSERT_NO_MSG(false);
 		return -EINVAL;
 	}
@@ -307,7 +309,7 @@ static int put_begin_ri(struct lwm2m_output_context *out, struct lwm2m_obj_path 
 	}
 
 	/* Forms name from resource id and resource instance id */
-	int len = snprintk(name, sizeof("65535/999"),
+	int len = snprintk(name, SENML_MAX_NAME_SIZE,
 			   "%" PRIu16 "/%" PRIu16 "",
 			   path->res_id, path->res_inst_id);
 
@@ -709,7 +711,7 @@ static int do_write_op_item(struct lwm2m_message *msg, struct record *rec)
 	uint8_t created = 0U;
 	struct cbor_in_fmt_data *fd;
 	/* Composite op - name with basename */
-	char name[sizeof("65535/999")] = { 0 }; /* Null terminated name */
+	char name[SENML_MAX_NAME_SIZE] = { 0 }; /* Null terminated name */
 	int len = 0;
 	char fqn[MAX_RESOURCE_LEN + 1] = {0};
 


### PR DESCRIPTION
Some fixes for the edge cases / bugs we have run into so far. It appears that there might be some other edge cases still there. Related to #53676