### PR TITLE
drivers: sensor: Add sensor reporters to sensor info

### DIFF
--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -221,11 +221,20 @@ static int cmd_get_sensor_info(const struct shell *sh, size_t argc,
 	STRUCT_SECTION_FOREACH(sensor_info, sensor) {
 		shell_print(sh,
 			    "device name: %s, vendor: %s, model: %s, "
-			    "friendly name: %s",
+			    "friendly name: %s, num reporters: %zu",
 			    sensor->dev->name,
 			    sensor->vendor ? sensor->vendor : null_str,
 			    sensor->model ? sensor->model : null_str,
-			    sensor->friendly_name ? sensor->friendly_name : null_str);
+			    sensor->friendly_name ? sensor->friendly_name : null_str,
+			    sensor->num_reporters);
+		for (int i = 0; i < sensor->num_reporters; i++) {
+			shell_print(sh,
+				    "\treporter: %d, name: %s, interval: %d, sensitivity: %d",
+				    i,
+				    sensor->reporters[i].info->dev->name,
+				    sensor->reporters[i].interval,
+				    sensor->reporters[i].sensitivity);
+		}
 	}
 	return 0;
 #else

--- a/dts/bindings/sensor/sensor-device.yaml
+++ b/dts/bindings/sensor/sensor-device.yaml
@@ -17,3 +17,18 @@ properties:
       This property is defined in the Generic Sensor Property Usages of the HID
       Usage Tables specification
       (https://usb.org/sites/default/files/hut1_3_0.pdf, section 22.5).
+
+  reporters:
+    type: phandle-array
+    description: |
+      Sensor input reporter specifiers, used by virtual sensors to synthesize
+      sensor channels from one or more other sensors. For example, a lid angle
+      sensor synthesized from a lid accelerometer and a base accelerometer.
+
+  reporter-names:
+    type: string-array
+    description: Provided names of sensor input reporter specifiers
+
+reporter-cells:
+  - interval
+  - sensitivity

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -762,31 +762,20 @@ struct sensor_info {
 	const char *friendly_name;
 };
 
-#define SENSOR_INFO_INITIALIZER(_dev, _vendor, _model, _friendly_name)	\
-	{								\
-		.dev = _dev,						\
-		.vendor = _vendor,					\
-		.model = _model,					\
-		.friendly_name = _friendly_name,			\
-	}
-
-#define SENSOR_INFO_DEFINE(name, ...)					\
-	static const STRUCT_SECTION_ITERABLE(sensor_info, name) =	\
-		SENSOR_INFO_INITIALIZER(__VA_ARGS__)
-
-#define SENSOR_INFO_DT_NAME(node_id)					\
+#define SENSOR_INFO_DT_NAME(node_id)							\
 	_CONCAT(__sensor_info, DEVICE_DT_NAME_GET(node_id))
 
-#define SENSOR_INFO_DT_DEFINE(node_id)					\
-	SENSOR_INFO_DEFINE(SENSOR_INFO_DT_NAME(node_id),		\
-			   DEVICE_DT_GET(node_id),			\
-			   DT_NODE_VENDOR_OR(node_id, NULL),		\
-			   DT_NODE_MODEL_OR(node_id, NULL),		\
-			   DT_PROP_OR(node_id, friendly_name, NULL))	\
+#define SENSOR_INFO_DT_DEFINE(node_id)							\
+	static const STRUCT_SECTION_ITERABLE(sensor_info,				\
+			SENSOR_INFO_DT_NAME(node_id)) = {				\
+		.dev = DEVICE_DT_GET(node_id),						\
+		.vendor = DT_NODE_VENDOR_OR(node_id, NULL),				\
+		.model = DT_NODE_MODEL_OR(node_id, NULL),				\
+		.friendly_name = DT_PROP_OR(node_id, friendly_name, NULL),		\
+	};
 
 #else
 
-#define SENSOR_INFO_DEFINE(name, ...)
 #define SENSOR_INFO_DT_DEFINE(node_id)
 
 #endif /* CONFIG_SENSOR_INFO */

--- a/samples/sensor/sensor_shell/CMakeLists.txt
+++ b/samples/sensor/sensor_shell/CMakeLists.txt
@@ -5,5 +5,5 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sensor_shell)
 
-FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
+target_sources(app PRIVATE src/main.c)
+target_sources_ifdef(CONFIG_APP_SENSOR_VIRTUAL app PRIVATE src/sensor_virtual.c)

--- a/samples/sensor/sensor_shell/Kconfig
+++ b/samples/sensor/sensor_shell/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Sensor shell sample application"
+
+menu "Application configuration"
+
+config APP_SENSOR_VIRTUAL
+	bool "Virtual sensor driver"
+	default y
+	depends on DT_HAS_SENSOR_VIRTUAL_ENABLED
+
+endmenu
+
+source "Kconfig.zephyr"

--- a/samples/sensor/sensor_shell/boards/native_posix.conf
+++ b/samples/sensor/sensor_shell/boards/native_posix.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_EMUL=y
+CONFIG_EMUL_BMI160=y
+CONFIG_BMI160_TRIGGER_NONE=y

--- a/samples/sensor/sensor_shell/boards/native_posix.overlay
+++ b/samples/sensor/sensor_shell/boards/native_posix.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	virtual-sensors {
+		hinge-angle {
+			compatible = "sensor-virtual";
+			friendly-name = "Hinge Angle";
+			reporters = <&lid_accel 10 0>, <&base_accel 5 0>;
+			reporter-names = "lid-accel", "base-accel";
+			status = "okay";
+		};
+
+		motion-detect {
+			compatible = "sensor-virtual";
+			friendly-name = "Motion Detect";
+			reporters = <&base_accel 20 0>;
+			status = "okay";
+		};
+	};
+};
+
+&i2c0 {
+	base_accel: bmi160@1 {
+		compatible = "bosch,bmi160";
+		reg = <0x1>;
+		friendly-name = "Base Accelerometer";
+		#reporter-cells = <2>;
+	};
+
+	lid_accel: bmi160@2 {
+		compatible = "bosch,bmi160";
+		reg = <0x2>;
+		friendly-name = "Lid Accelerometer";
+		#reporter-cells = <2>;
+	};
+};

--- a/samples/sensor/sensor_shell/dts/bindings/sensor-virtual.yaml
+++ b/samples/sensor/sensor_shell/dts/bindings/sensor-virtual.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Virtual Sensor
+
+compatible: "sensor-virtual"
+
+include: sensor-device.yaml

--- a/samples/sensor/sensor_shell/sample.yaml
+++ b/samples/sensor/sensor_shell/sample.yaml
@@ -4,6 +4,7 @@ tests:
   sample.sensor.shell:
     integration_platforms:
       - frdm_k64f
+      - native_posix
     filter: ( CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT )
     tags: shell
     harness: keyboard

--- a/samples/sensor/sensor_shell/src/sensor_virtual.c
+++ b/samples/sensor/sensor_shell/src/sensor_virtual.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT sensor_virtual
+
+#include <zephyr/drivers/sensor.h>
+
+struct sensor_virtual_config {
+};
+
+struct sensor_virtual_data {
+};
+
+static int sensor_virtual_sample_fetch(const struct device *dev,
+		enum sensor_channel chan)
+{
+	return -ENOTSUP;
+}
+
+static int sensor_virtual_channel_get(const struct device *dev,
+		enum sensor_channel chan, struct sensor_value *val)
+{
+	return -ENOTSUP;
+}
+
+static const struct sensor_driver_api sensor_virtual_driver_api = {
+	.sample_fetch = sensor_virtual_sample_fetch,
+	.channel_get = sensor_virtual_channel_get,
+};
+
+static int sensor_virtual_init(const struct device *dev)
+{
+	return 0;
+}
+
+#define SENSOR_VIRTUAL_INIT(n)						\
+	static const struct sensor_virtual_config			\
+		sensor_virtual_config_##n;				\
+									\
+	static struct sensor_virtual_data sensor_virtual_data_##n;	\
+									\
+	SENSOR_DEVICE_DT_INST_DEFINE(n,					\
+				     sensor_virtual_init,		\
+				     NULL,				\
+				     &sensor_virtual_data_##n,		\
+				     &sensor_virtual_config_##n,	\
+				     POST_KERNEL,			\
+				     CONFIG_SENSOR_INIT_PRIORITY,	\
+				     &sensor_virtual_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(SENSOR_VIRTUAL_INIT)


### PR DESCRIPTION
Adds support for sensors to specify an array of other sensors they
depend upon in the devicetree and instantiate an array of references in
the sensor info data structure.

This will be used by virtual sensors that synthesize sensor channels
from one or more other sensors, such as a virtual lid angle sensor
synthesized from a lid accelerometer and a base accelerometer.

The size of the sensor reporters array in the sensor info data structure
is exactly the number of reporters specified in the devicetree for each
node, and can vary from node to node. This enables an efficient use of
data memory compared to an alternative implementation that defines a
constant array size for all nodes. Also note that the sensor reporters
array is constant and instantiated in ROM, without any RAM overhead.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>

```
$ west build -b native_posix -p auto -t run samples/sensor/sensor_shell
```

```console
uart:~$ sensor info
device name: bmi160@1, vendor: Bosch Sensortec GmbH, model: bmi160, friendly name: Base Accelerometer, num reporters: 0
device name: bmi160@2, vendor: Bosch Sensortec GmbH, model: bmi160, friendly name: Lid Accelerometer, num reporters: 0
device name: hinge-angle, vendor: (null), model: (null), friendly name: Hinge Angle, num reporters: 2
        reporter: 0, name: bmi160@2, interval: 10, sensitivity: 0
        reporter: 1, name: bmi160@1, interval: 5, sensitivity: 0
device name: motion-detect, vendor: (null), model: (null), friendly name: Motion Detect, num reporters: 1
        reporter: 0, name: bmi160@1, interval: 20, sensitivity: 0
```

cc: @huhebo 