### PR TITLE
tests: obj_validation: Call setup function

### DIFF
--- a/tests/kernel/mem_protect/obj_validation/src/main.c
+++ b/tests/kernel/mem_protect/obj_validation/src/main.c
@@ -190,4 +190,4 @@ void *object_validation_setup(void)
 	return NULL;
 }
 
-ZTEST_SUITE(object_validation, NULL, NULL, NULL, NULL, NULL);
+ZTEST_SUITE(object_validation, NULL, object_validation_setup, NULL, NULL, NULL);


### PR DESCRIPTION
The setup function for object validation test was defined but no called.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>