### PR TITLE
ace: linker: Fix CPP ctors section

### DIFF
--- a/soc/xtensa/intel_adsp/ace/ace-link.ld
+++ b/soc/xtensa/intel_adsp/ace/ace-link.ld
@@ -266,9 +266,11 @@ SECTIONS {
     *(.gnu.version_r)
     KEEP (*(.eh_frame))
     KEEP (*crtbegin.o(.ctors))
+#ifndef CONFIG_CPP_STATIC_INIT_GNU
     KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
     KEEP (*(SORT(.ctors.*)))
     KEEP (*(.ctors))
+#endif
     KEEP (*crtbegin.o(.dtors))
     KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
     KEEP (*(SORT(.dtors.*)))


### PR DESCRIPTION
CPP static ctors are properly place in common-rom-cpp.ld.

Change the linker script to keep these sections onlye if CONFIG_CPP_STATIC_INIT_GNU is not defined.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>