### PR TITLE
samples: posix: gettimeofday: include time.h

### DIFF
--- a/samples/posix/gettimeofday/src/main.c
+++ b/samples/posix/gettimeofday/src/main.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 
 int main(void)


### PR DESCRIPTION
Due to some previous time-related header issues, we included `<sys/time.h>` without including `<time.h>`. The latter is necessary for `time()` (specified by both ISO C and POSIX).

Fixes #53673