### PR TITLE
modules: mbedtls: Bump to 3.2.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -176,7 +176,7 @@ manifest:
       revision: 8e303c264fc21c2116dc612658003a22e933124d
       path: modules/lib/lz4
     - name: mbedtls
-      revision: 7fed49c9b9f983ad6416986661ef637459723bcb
+      revision: pull/40/head
       path: modules/crypto/mbedtls
       groups:
         - crypto


### PR DESCRIPTION
Bump mbedTLS to 3.2.1

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>