### PR TITLE
MAINTAINERS: mem_protect tests are part of userspace

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1324,6 +1324,8 @@ Kernel:
     - tests/kernel/
     - include/zephyr/sys_clock.h
     - samples/kernel/
+  files-exclude:
+    - tests/kernel/mem_protect/
   labels:
     - "area: Kernel"
 


### PR DESCRIPTION
This directory is both in kernel and userspace areas, exclude it from
kernel area.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
