### PR TITLE
drivers: ethernet: PTP clock CONFIGURATED

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1887,6 +1887,11 @@ static int ptp_stm32_init(const struct device *port)
 	}
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
 
+#if defined(CONFIG_ETH_STM32_HAL_API_V2)
+	/* Set PTP Configuration done */
+	heth->IsPtpConfigured = HAL_ETH_PTP_CONFIGURATED;
+#endif
+
 	return 0;
 }
 

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 83cf59e4309e5f1758a76c0513c437e0fbcee40b
+      revision: b916f9a01c665194fbbdd6a67a0f37b4e0a7e78c
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Set PTP Configuration done on ETH_STM32_HAL_API_V2

Signed-off-by: Marc Desvaux <marc.desvaux-ext@st.com>