### PR TITLE
boards: ronoth_lodev: Enable HSI48 clock

### DIFF
--- a/boards/arm/ronoth_lodev/ronoth_lodev.dts
+++ b/boards/arm/ronoth_lodev/ronoth_lodev.dts
@@ -111,6 +111,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hsi {
 	status = "okay";
 };


### PR DESCRIPTION
Since the commit 2ed292e1be918ea48a7014884e036ae0e0cf9912, the HSI48 clock must be explicitly enabled in the devicetree when a peripheral that depends on the HSI48 clock is enabled.

This commit enables the HSI48 clock for the `ronoth_lodev` board because it enables the RNG, which requires the it.

Signed-off-by: Stephanos Ioannidis <stephanos.ioannidis@nordicsemi.no>

---

This is a hotfix for the following bug introduced by the PR https://github.com/zephyrproject-rtos/zephyr/pull/50643:

```
[110/169] Building C object zephyr/drivers/entropy/CMakeFiles/drivers__entropy.dir/entropy_stm32.c.obj
FAILED: zephyr/drivers/entropy/CMakeFiles/drivers__entropy.dir/entropy_stm32.c.obj 
ccache /opt/toolchains/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc -DHSE_VALUE=8000000 -DKERNEL -DSTM32L073xx -DTC_RUNID=e4a1755d982af9fe10fadbe419aa4418 -DUSE_FULL_LL_DRIVER -DUSE_HAL_DRIVER -D__PROGRAM_START -D__ZEPHYR_SUPERVISOR__ -D__ZEPHYR__=1 -I../../../../../../../include -Izephyr/include/generated -I../../../../../../../soc/arm/st_stm32/stm32l0 -I../../../../../../../drivers -I../../../../../../../soc/arm/st_stm32/common -I../../../../../../../subsys/testsuite/include -I../../../../../../../subsys/testsuite/ztest/include -I/__w/zephyr/modules/hal/cmsis/CMSIS/Core/Include -I/__w/zephyr/modules/hal/stm32/stm32cube/stm32l0xx/soc -I/__w/zephyr/modules/hal/stm32/stm32cube/stm32l0xx/drivers/include -I/__w/zephyr/modules/hal/stm32/stm32cube/stm32l0xx/drivers/include/Legacy -I/__w/zephyr/modules/hal/stm32/stm32cube/common_ll/include -isystem ../../../../../../../lib/libc/minimal/include -isystem /opt/toolchains/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.1.0/include -isystem /opt/toolchains/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.1.0/include-fixed -fno-strict-aliasing -Os -imacros /__w/zephyr/zephyr/twister-out/ronoth_lodev/zephyr/tests/ztest/base/testing.ztest.base.verbose_0/zephyr/include/generated/autoconf.h -ffreestanding -fno-common -g -gdwarf-4 -fdiagnostics-color=always -mcpu=cortex-m0plus -mthumb -mabi=aapcs -mfp16-format=ieee --sysroot=/opt/toolchains/zephyr-sdk-0.15.2/arm-zephyr-eabi/arm-zephyr-eabi -imacros /__w/zephyr/zephyr/include/zephyr/toolchain/zephyr_stdint.h -Wall -Wformat -Wformat-security -Wno-format-zero-length -Wno-main -Wno-pointer-sign -Wpointer-arith -Wexpansion-to-defined -Wno-unused-but-set-variable -Werror=implicit-int -fno-pic -fno-pie -Werror -fno-asynchronous-unwind-tables -fno-reorder-functions --param=min-pagesize=0 -fno-defer-pop -fmacro-prefix-map=/__w/zephyr/zephyr/tests/ztest/base=CMAKE_SOURCE_DIR -fmacro-prefix-map=/__w/zephyr/zephyr=ZEPHYR_BASE -fmacro-prefix-map=/__w/zephyr=WEST_TOPDIR -ffunction-sections -fdata-sections -std=c99 -nostdinc -MD -MT zephyr/drivers/entropy/CMakeFiles/drivers__entropy.dir/entropy_stm32.c.obj -MF zephyr/drivers/entropy/CMakeFiles/drivers__entropy.dir/entropy_stm32.c.obj.d -o zephyr/drivers/entropy/CMakeFiles/drivers__entropy.dir/entropy_stm32.c.obj -c /__w/zephyr/zephyr/drivers/entropy/entropy_stm32.c
/__w/zephyr/zephyr/drivers/entropy/entropy_stm32.c: In function 'entropy_stm32_rng_init':
/__w/zephyr/zephyr/drivers/entropy/entropy_stm32.c:608:2: error: #warning RNG requires HSI48 clock to be enabled using device tree [-Werror=cpp]
  608 | #warning RNG requires HSI48 clock to be enabled using device tree
      |  ^~~~~~~
cc1: all warnings being treated as errors
```