### PR TITLE
fixed missing compat for spi2

### DIFF
--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -31,7 +31,7 @@
 		};
 
 		spi2: spi@40003800 {
-			compatible = "st,stm32-spi";
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;


### PR DESCRIPTION
Fixing issue #53654 , that is, SPI2 not working on STM32L412 due to missing parameter in corresponding dtsi file.