### PR TITLE
drivers: dai: modify dai_config_get API func

### DIFF
--- a/drivers/dai/intel/alh/alh.c
+++ b/drivers/dai/intel/alh/alh.c
@@ -89,17 +89,24 @@ static void alh_release_ownership(void)
 }
 
 
-static const struct dai_config *dai_alh_config_get(const struct device *dev, enum dai_dir dir)
+static int dai_alh_config_get(const struct device *dev, struct dai_config *cfg,
+			      enum dai_dir dir)
 {
 	struct dai_config *params = (struct dai_config *)dev->config;
 	struct dai_intel_alh *dp = (struct dai_intel_alh *)dev->data;
 	struct dai_intel_alh_pdata *alh = dai_get_drvdata(dp);
 
+	if (!cfg) {
+		return -EINVAL;
+	}
+
 	params->rate = alh->params.rate;
 	params->channels = alh->params.channels;
 	params->word_size = ALH_WORD_SIZE_DEFAULT;
 
-	return params;
+	*cfg = *params;
+
+	return 0;
 }
 
 static int dai_alh_config_set(const struct device *dev, const struct dai_config *cfg,

--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -739,14 +739,21 @@ static int dai_dmic_trigger(const struct device *dev, enum dai_dir dir,
 	return 0;
 }
 
-static const struct dai_config *dai_dmic_get_config(const struct device *dev, enum dai_dir dir)
+static int dai_dmic_get_config(const struct device *dev, struct dai_config *cfg, enum dai_dir dir)
 {
 	struct dai_intel_dmic *dmic = (struct dai_intel_dmic *)dev->data;
 
-	if (dir != DAI_DIR_RX)
-		return NULL;
+	if (dir != DAI_DIR_RX) {
+		return -EINVAL;
+	}
 
-	return &dmic->dai_config_params;
+	if (!cfg) {
+		return -EINVAL;
+	}
+
+	*cfg = dmic->dai_config_params;
+
+	return 0;
 }
 
 static int dai_dmic_set_config(const struct device *dev,

--- a/drivers/dai/intel/hda/hda.c
+++ b/drivers/dai/intel/hda/hda.c
@@ -40,18 +40,24 @@ static int dai_hda_set_config_tplg(struct dai_intel_hda *dp, const void *spec_co
 	return 0;
 }
 
-static const struct dai_config *dai_hda_config_get(const struct device *dev, enum dai_dir dir)
+static int dai_hda_config_get(const struct device *dev, struct dai_config *cfg, enum dai_dir dir)
 {
 	struct dai_config *params = (struct dai_config *)dev->config;
 	struct dai_intel_hda *dp = (struct dai_intel_hda *)dev->data;
 	struct dai_intel_hda_pdata *hda = dai_get_drvdata(dp);
+
+	if (!cfg) {
+		return -EINVAL;
+	}
 
 	params->rate = hda->params.rate;
 	params->channels = hda->params.channels;
 
 	params->word_size = DAI_INTEL_HDA_DEFAULT_WORD_SIZE;
 
-	return params;
+	*cfg = *params;
+
+	return 0;
 }
 
 static int dai_hda_config_set(const struct device *dev, const struct dai_config *cfg,

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -1825,14 +1825,20 @@ static int dai_ssp_trigger(const struct device *dev, enum dai_dir dir,
 	return 0;
 }
 
-static const struct dai_config *dai_ssp_config_get(const struct device *dev, enum dai_dir dir)
+static int dai_ssp_config_get(const struct device *dev, struct dai_config *cfg, enum dai_dir dir)
 {
 	struct dai_config *params = (struct dai_config *)dev->config;
 	struct dai_intel_ssp *dp = (struct dai_intel_ssp *)dev->data;
 	struct dai_intel_ssp_pdata *ssp = dai_get_drvdata(dp);
 
-	if (!ssp)
-		return params;
+	if (!cfg) {
+		return -EINVAL;
+	}
+
+	if (!ssp) {
+		*cfg = *params;
+		return 0;
+	}
 
 	params->rate = ssp->params.fsync_rate;
 
@@ -1844,7 +1850,9 @@ static const struct dai_config *dai_ssp_config_get(const struct device *dev, enu
 
 	params->word_size = ssp->params.sample_valid_bits;
 
-	return params;
+	*cfg = *params;
+
+	return 0;
 }
 
 static int dai_ssp_config_set(const struct device *dev, const struct dai_config *cfg,

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -238,8 +238,8 @@ __subsystem struct dai_driver_api {
 	int (*remove)(const struct device *dev);
 	int (*config_set)(const struct device *dev, const struct dai_config *cfg,
 			  const void *bespoke_cfg);
-	const struct dai_config *(*config_get)(const struct device *dev,
-					       enum dai_dir dir);
+	int (*config_get)(const struct device *dev, struct dai_config *cfg,
+			  enum dai_dir dir);
 
 	const struct dai_properties *(*get_properties)(const struct device *dev,
 						       enum dai_dir dir,
@@ -328,16 +328,17 @@ static inline int dai_config_set(const struct device *dev,
  * @brief Fetch configuration information of a DAI driver
  *
  * @param dev Pointer to the device structure for the driver instance
+ * @param cfg Pointer to the config structure to be filled by the instance
  * @param dir Stream direction: RX or TX as defined by DAI_DIR_*
- * @retval Pointer to the structure containing configuration parameters,
- *         or NULL if un-configured
+ * @retval 0 if success, negative if invalid parameters or dai un-configured
  */
-static inline const struct dai_config *dai_config_get(const struct device *dev,
-						      enum dai_dir dir)
+static inline int dai_config_get(const struct device *dev,
+				 struct dai_config *cfg,
+				 enum dai_dir dir)
 {
 	const struct dai_driver_api *api = (const struct dai_driver_api *)dev->api;
 
-	return api->config_get(dev, dir);
+	return api->config_get(dev, cfg, dir);
 }
 
 /**


### PR DESCRIPTION
Modify dai_config_get function to have the config struct as argument. This was not a showstopper but a request in the API review.

In the same patch modify all Intel dai drivers using the API to preserve bisect/compile.

Signed-off-by: Jaska Uimonen <jaska.uimonen@linux.intel.com>