### PR TITLE
scripts: dts: Skip empty yaml files

### DIFF
--- a/scripts/dts/gen_driver_kconfig_dts.py
+++ b/scripts/dts/gen_driver_kconfig_dts.py
@@ -80,7 +80,7 @@ def main():
                 print(f"WARNING: '{binding_path}' appears in binding "
                       f"directories but isn't valid YAML: {e}")
                 continue
-        if 'compatible' not in raw:
+        if raw is None or 'compatible' not in raw:
             continue
 
         compat_list.append(raw['compatible'])


### PR DESCRIPTION
Leaving an empty yaml file in any DTS_ROOT included directories will currently crash the script `dts/gen_driver_kconfig_dts.py`. Added a check to skip any empty files, like it is already skipping unparsable files and files without a `compatible` field.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/54683