### PR TITLE
net: ethernet: Check return value for start/stop

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -729,6 +729,7 @@ error:
 
 static inline int ethernet_enable(struct net_if *iface, bool state)
 {
+	int ret = 0;
 	const struct ethernet_api *eth =
 		net_if_get_device(iface)->api;
 
@@ -740,15 +741,15 @@ static inline int ethernet_enable(struct net_if *iface, bool state)
 		net_arp_clear_cache(iface);
 
 		if (eth->stop) {
-			eth->stop(net_if_get_device(iface));
+			ret = eth->stop(net_if_get_device(iface));
 		}
 	} else {
 		if (eth->start) {
-			eth->start(net_if_get_device(iface));
+			ret = eth->start(net_if_get_device(iface));
 		}
 	}
 
-	return 0;
+	return ret;
 }
 
 enum net_l2_flags ethernet_flags(struct net_if *iface)


### PR DESCRIPTION
The L2 networking layer checks for return value from enable, but Ethernet is not checking and always returns 0, so, relay the return value from the Ethernet driver to networking stack.

This fixes the issue of interface start failing but interface still being up.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>