### PR TITLE
net: ipv4: Added mechanism to add 224.0.0.1 address to a multicast filter

### DIFF
--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -34,6 +34,7 @@ config NET_IF_UNICAST_IPV4_ADDR_COUNT
 
 config NET_IF_MCAST_IPV4_ADDR_COUNT
 	int "Max number of multicast IPv4 addresses per network interface"
+	default 2 if NET_IPV4_IGMP
 	default 1
 
 config NET_ICMPV4_ACCEPT_BROADCAST

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4159,6 +4159,21 @@ exit:
 	}
 }
 
+static void init_igmp(struct net_if *iface)
+{
+#if defined(CONFIG_NET_IPV4_IGMP)
+	/* Ensure IPv4 is enabled for this interface */
+	if (iface->config.ip.ipv4 == NULL) {
+		return;
+	}
+
+	net_ipv4_igmp_init(iface);
+#else
+	ARG_UNUSED(iface);
+	return;
+#endif
+}
+
 int net_if_up(struct net_if *iface)
 {
 	int status = 0;
@@ -4186,6 +4201,8 @@ int net_if_up(struct net_if *iface)
 	if (status < 0) {
 		goto out;
 	}
+
+	init_igmp(iface);
 
 done:
 	net_if_flag_set(iface, NET_IF_UP);

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -174,6 +174,15 @@ extern uint16_t net_calc_chksum_ipv4(struct net_pkt *pkt);
 #endif /* CONFIG_NET_IPV4 */
 
 #if defined(CONFIG_NET_IPV4_IGMP)
+/**
+ * @brief Initialise the IGMP module for a given interface
+ *
+ * @param iface		Interface to init IGMP
+ */
+void net_ipv4_igmp_init(struct net_if *iface);
+#endif /* CONFIG_NET_IPV4_IGMP */
+
+#if defined(CONFIG_NET_IPV4_IGMP)
 uint16_t net_calc_chksum_igmp(uint8_t *data, size_t len);
 enum net_verdict net_ipv4_igmp_input(struct net_pkt *pkt,
 				     struct net_ipv4_hdr *ip_hdr);


### PR DESCRIPTION
The purpose of the change was to have the Zephyr network stack internally add the IGMP all systems 224.0.0.1 multicast address to a multicast membership list so that multicast hash filter implementations can add this address to the hash filter.

Fixes #53548

Signed-off-by: Chamira Perera <chamira.perera@audinate.com>