### PR TITLE
boards: stm32l412: fifo compatibility to spi2

### DIFF
--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -31,7 +31,7 @@
 		};
 
 		spi2: spi@40003800 {
-			compatible = "st,stm32-spi";
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;


### PR DESCRIPTION
In file stm32l412.dtsi, spi2 was missing fifo compatibility, this way failing to initialise fifo threshold correctly when spi data width is configured.

Signed-off-by: Mirko Bottarelli <mirko.bottarelli@gmail.com>