### PR TITLE
drivers: dma: stm32 dma driver support repeated start/stop

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -573,6 +573,11 @@ DMA_STM32_EXPORT_API int dma_stm32_start(const struct device *dev, uint32_t id)
 		return -EINVAL;
 	}
 
+	/* Repeated start : return now if channel is already started */
+	if (stm32_dma_is_enabled_stream(dma, id)) {
+		return 0;
+	}
+
 	/* When starting the dma, the stream is busy before enabling */
 	stream = &config->streams[id];
 	stream->busy = true;
@@ -594,6 +599,11 @@ DMA_STM32_EXPORT_API int dma_stm32_stop(const struct device *dev, uint32_t id)
 
 	if (id >= config->max_streams) {
 		return -EINVAL;
+	}
+
+	/* Repeated stop : return now if channel is already stopped */
+	if (!stm32_dma_is_enabled_stream(dma, id)) {
+		return 0;
 	}
 
 #if !defined(CONFIG_DMAMUX_STM32) \

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -81,6 +81,7 @@ void stm32_dma_clear_stream_irq(DMA_TypeDef *dma, uint32_t id);
 bool stm32_dma_is_irq_happened(DMA_TypeDef *dma, uint32_t id);
 bool stm32_dma_is_unexpected_irq_happened(DMA_TypeDef *dma, uint32_t id);
 void stm32_dma_enable_stream(DMA_TypeDef *dma, uint32_t id);
+bool stm32_dma_is_enabled_stream(DMA_TypeDef *dma, uint32_t id);
 int stm32_dma_disable_stream(DMA_TypeDef *dma, uint32_t id);
 
 #if !defined(CONFIG_DMAMUX_STM32)

--- a/drivers/dma/dma_stm32_v1.c
+++ b/drivers/dma/dma_stm32_v1.c
@@ -320,6 +320,14 @@ void stm32_dma_enable_stream(DMA_TypeDef *dma, uint32_t id)
 	LL_DMA_EnableStream(dma, dma_stm32_id_to_stream(id));
 }
 
+bool stm32_dma_is_enabled_stream(DMA_TypeDef *dma, uint32_t id)
+{
+	if (LL_DMA_IsEnabledStream(dma, dma_stm32_id_to_stream(id)) == 1) {
+		return true;
+	}
+	return false;
+}
+
 int stm32_dma_disable_stream(DMA_TypeDef *dma, uint32_t id)
 {
 	LL_DMA_DisableStream(dma, dma_stm32_id_to_stream(id));

--- a/drivers/dma/dma_stm32_v2.c
+++ b/drivers/dma/dma_stm32_v2.c
@@ -291,6 +291,14 @@ void stm32_dma_enable_stream(DMA_TypeDef *dma, uint32_t id)
 	LL_DMA_EnableChannel(dma, dma_stm32_id_to_stream(id));
 }
 
+bool stm32_dma_is_enabled_stream(DMA_TypeDef *dma, uint32_t id)
+{
+	if (LL_DMA_IsEnabledChannel(dma, dma_stm32_id_to_stream(id)) == 1) {
+		return true;
+	}
+	return false;
+}
+
 int stm32_dma_disable_stream(DMA_TypeDef *dma, uint32_t id)
 {
 	LL_DMA_DisableChannel(dma, dma_stm32_id_to_stream(id));


### PR DESCRIPTION
To support the repeated start/stop, the stm32 dma driver is returning 0 if the channel is already started/stopped.
This is not done at the dmamux level if any.

This is required by the https://github.com/zephyrproject-rtos/zephyr/pull/53504
Then running the test_loop_repeated_start_stop testcase of the tests/drivers/dma/loop_transfer : 
` - PASS - [dma_m2m_loop.test_dma_m2m_loop_repeated_start_stop] duration = 0.605s
`

Signed-off-by: Francois Ramu <francois.ramu@st.com>