### PR TITLE
Bluetooth: has: Fix HAS features value

### DIFF
--- a/include/zephyr/bluetooth/audio/has.h
+++ b/include/zephyr/bluetooth/audio/has.h
@@ -72,10 +72,20 @@ struct bt_has_register_param {
 	/** Hearing Aid Type value */
 	enum bt_has_hearing_aid_type type;
 
-	/** Preset Synchronization Support. Only applicable for binaural hearing aids. */
+	/**
+	 * @brief Preset Synchronization Support.
+	 *
+	 * Only applicable if @p type is @ref BT_HAS_HEARING_AID_TYPE_BINAURAL
+	 * and @kconfig{CONFIG_BT_HAS_PRESET_COUNT} is non-zero.
+	 */
 	bool preset_sync_support;
 
-	/** Independent Presets. Only applicable for binaural hearing aids. */
+	/**
+	 * @brief Independent Presets.
+	 *
+	 * Only applicable if @p type is @ref BT_HAS_HEARING_AID_TYPE_BINAURAL
+	 * and @kconfig{CONFIG_BT_HAS_PRESET_COUNT} is non-zero.
+	 */
 	bool independent_presets;
 };
 

--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -1142,24 +1142,26 @@ int bt_has_register(const struct bt_has_register_param *param)
 
 	if (IS_ENABLED(CONFIG_BT_HAS_PRESET_SUPPORT)) {
 		has.features |= BT_HAS_FEAT_DYNAMIC_PRESETS;
-	}
 
-	if (param->preset_sync_support) {
-		if (param->type != BT_HAS_HEARING_AID_TYPE_BINAURAL) {
-			LOG_DBG("Preset sync support only available for binaural hearing aid type");
-			return -EINVAL;
+		if (param->preset_sync_support) {
+			if (param->type != BT_HAS_HEARING_AID_TYPE_BINAURAL) {
+				LOG_DBG("Preset sync support only available "
+					"for binaural hearing aid type");
+				return -EINVAL;
+			}
+
+			has.features |= BT_HAS_FEAT_PRESET_SYNC_SUPP;
 		}
 
-		has.features |= BT_HAS_FEAT_PRESET_SYNC_SUPP;
-	}
+		if (param->independent_presets) {
+			if (param->type != BT_HAS_HEARING_AID_TYPE_BINAURAL) {
+				LOG_DBG("Independent presets only available "
+					"for binaural hearing aid type");
+				return -EINVAL;
+			}
 
-	if (param->independent_presets) {
-		if (param->type != BT_HAS_HEARING_AID_TYPE_BINAURAL) {
-			LOG_DBG("Independent presets only available for binaural hearing aid type");
-			return -EINVAL;
+			has.features |= BT_HAS_FEAT_INDEPENDENT_PRESETS;
 		}
-
-		has.features |= BT_HAS_FEAT_INDEPENDENT_PRESETS;
 	}
 
 	if (IS_ENABLED(CONFIG_BT_HAS_PRESET_NAME_DYNAMIC)) {


### PR DESCRIPTION
The bt_has_register_param's preset_sync_support and independent_presets make sense only if CONFIG_BT_HAS_PRESET_COUNT is non-zero meaning the CONFIG_BT_HAS_PRESET_SUPPORT is enabled.
Otherwise, those parameters shall be skipped.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>