### PR TITLE
tests: use namespacing in extra_configs and drop duplicated scenarios

### DIFF
--- a/tests/benchmarks/app_kernel/testcase.yaml
+++ b/tests/benchmarks/app_kernel/testcase.yaml
@@ -5,21 +5,13 @@ tests:
   benchmark.kernel.application:
     arch_allow: x86 arm riscv32 riscv64
     min_flash: 34
-    min_ram: 32
-  benchmark.kernel.application.fp.arm:
-    extra_args: CONF_FILE=prj_fp.conf
-    arch_allow: arm
-    filter: CONFIG_ARMV7_M_ARMV8_M_FP
-    min_flash: 34
-    min_ram: 32
-    slow: true
-  benchmark.kernel.application.fp.x86.fpu:
+  benchmark.kernel.application.fp:
     extra_args: CONF_FILE=prj_fp.conf
     extra_configs:
-      - CONFIG_X86_SSE=y
-      - CONFIG_X86_SSE_FP_MATH=n
-    arch_allow: x86
-    filter: CONFIG_CPU_HAS_FPU
+      - arch:x86:CONFIG_X86_SSE=y
+      - arch:x86:CONFIG_X86_SSE_FP_MATH=n
+    arch_allow: x86 arm
+    filter: CONFIG_CPU_HAS_FPU or CONFIG_ARMV7_M_ARMV8_M_FP
     min_flash: 34
     min_ram: 32
     slow: true

--- a/tests/crypto/mbedtls/testcase.yaml
+++ b/tests/crypto/mbedtls/testcase.yaml
@@ -5,11 +5,7 @@ common:
   timeout: 400
 tests:
   crypto.mbedtls:
-    arch_exclude: riscv64
     platform_exclude: m2gl025_miv
     extra_configs:
       - CONFIG_PICOLIBC_HEAP_SIZE=0
-  crypto.mbedtls.riscv64:
-    arch_allow: riscv64
-    extra_configs:
-      - CONFIG_ZTEST_STACK_SIZE=8192
+      - arch:riscv64:CONFIG_ZTEST_STACK_SIZE=8192

--- a/tests/kernel/fpu_sharing/float_disable/testcase.yaml
+++ b/tests/kernel/fpu_sharing/float_disable/testcase.yaml
@@ -1,20 +1,11 @@
 common:
   tags: fpu kernel userspace
 tests:
-  kernel.fpu_sharing.float_disable.arm:
-    arch_allow: arm
-    filter: CONFIG_ARMV7_M_ARMV8_M_FP or CONFIG_ARMV7_R_FP
+  kernel.fpu_sharing.float_disable:
+    arch_allow: arm riscv32 riscv64 sparc
+    filter: CONFIG_ARMV7_M_ARMV8_M_FP or CONFIG_ARMV7_R_FP or CONFIG_CPU_HAS_FPU
     extra_configs:
-      - CONFIG_DYNAMIC_INTERRUPTS=y
-  kernel.fpu_sharing.float_disable.riscv32:
-    filter: CONFIG_CPU_HAS_FPU
-    arch_allow: riscv32
-  kernel.fpu_sharing.float_disable.riscv64:
-    filter: CONFIG_CPU_HAS_FPU
-    arch_allow: riscv64
-  kernel.fpu_sharing.float_disable.sparc:
-    filter: CONFIG_CPU_HAS_FPU
-    arch_allow: sparc
+      - arch:arm:CONFIG_DYNAMIC_INTERRUPTS=y
   kernel.fpu_sharing.float_disable.x86.fpu:
     extra_args: CONF_FILE=prj_x86.conf
     extra_configs:


### PR DESCRIPTION
Use namespacing with extra_configs in some tests and remove duplicated
scenarios the were made arch or platform specifc.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
