### PR TITLE
west: flash: sysbuild: Add single user commands per board and waiting for board reset

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/flash_runner.yml
+++ b/boards/arm/nrf5340dk_nrf5340/flash_runner.yml
@@ -14,3 +14,15 @@ board_single_commands:
     nrf5340dk_nrf5340_cpuapp,
     nrf5340dk_nrf5340_cpuapp_ns,
   ]
+
+# Prevent resetting the cores whilst flashing multiple images until all images
+# for each core have been flashed, this allows security bits to be set during
+# programming without them interfering with additional flashing processes.
+board_delay_reset:
+  - [
+    nrf5340dk_nrf5340_cpuapp,
+    nrf5340dk_nrf5340_cpuapp_ns,
+  ]
+  - [
+    nrf5340dk_nrf5340_cpunet,
+  ]

--- a/boards/arm/nrf5340dk_nrf5340/flash_runner.yml
+++ b/boards/arm/nrf5340dk_nrf5340/flash_runner.yml
@@ -1,0 +1,16 @@
+# Recovery/erase is only needed once per core.
+board_single_commands:
+  - --recover: [
+    nrf5340dk_nrf5340_cpunet,
+  ]
+  - --recover: [
+    nrf5340dk_nrf5340_cpuapp,
+    nrf5340dk_nrf5340_cpuapp_ns,
+  ]
+  - --erase: [
+    nrf5340dk_nrf5340_cpunet,
+  ]
+  - --erase: [
+    nrf5340dk_nrf5340_cpuapp,
+    nrf5340dk_nrf5340_cpuapp_ns,
+  ]

--- a/boards/arm/nrf9160dk_nrf9160/flash_runner.yml
+++ b/boards/arm/nrf9160dk_nrf9160/flash_runner.yml
@@ -8,3 +8,12 @@ board_single_commands:
     nrf9160dk_nrf9160,
     nrf9160dk_nrf9160_ns,
   ]
+
+# Prevent resetting the cores whilst flashing multiple images until all images
+# for each core have been flashed, this allows security bits to be set during
+# programming without them interfering with additional flashing processes.
+board_delay_reset:
+  - [
+    nrf9160dk_nrf9160,
+    nrf9160dk_nrf9160_ns,
+  ]

--- a/boards/arm/nrf9160dk_nrf9160/flash_runner.yml
+++ b/boards/arm/nrf9160dk_nrf9160/flash_runner.yml
@@ -1,0 +1,10 @@
+# Recovery/erase is only needed once per core.
+board_single_commands:
+  - --recover: [
+    nrf9160dk_nrf9160,
+    nrf9160dk_nrf9160_ns,
+  ]
+  - --erase: [
+    nrf9160dk_nrf9160,
+    nrf9160dk_nrf9160_ns,
+  ]

--- a/boards/arm/thingy53_nrf5340/flash_runner.yml
+++ b/boards/arm/thingy53_nrf5340/flash_runner.yml
@@ -14,3 +14,15 @@ board_single_commands:
     thingy53_nrf5340_cpuapp,
     thingy53_nrf5340_cpuapp_ns,
   ]
+
+# Prevent resetting the cores whilst flashing multiple images until all images
+# for each core have been flashed, this allows security bits to be set during
+# programming without them interfering with additional flashing processes.
+board_delay_reset:
+  - [
+    thingy53_nrf5340_cpuapp,
+    thingy53_nrf5340_cpuapp_ns,
+  ]
+  - [
+    thingy53_nrf5340_cpunet,
+  ]

--- a/boards/arm/thingy53_nrf5340/flash_runner.yml
+++ b/boards/arm/thingy53_nrf5340/flash_runner.yml
@@ -1,0 +1,16 @@
+# Recovery/erase is only needed once per core.
+board_single_commands:
+  - --recover: [
+    thingy53_nrf5340_cpunet,
+  ]
+  - --recover: [
+    thingy53_nrf5340_cpuapp,
+    thingy53_nrf5340_cpuapp_ns,
+  ]
+  - --erase: [
+    thingy53_nrf5340_cpunet,
+  ]
+  - --erase: [
+    thingy53_nrf5340_cpuapp,
+    thingy53_nrf5340_cpuapp_ns,
+  ]

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -257,6 +257,22 @@ Boards & SoC Support
     Note that MCUboot and MCUboot image updates from pre-Zephyr 3.3 might be
     incompatible with Zephyr 3.3 onwards and vice versa.
 
+  * When using sysbuild with the following boards with ``west flash``, reset
+    of the board will only be performed once all images for a core have been
+    programmed, fixing an issue whereby later images might fail to be
+    programmed to a board:
+    ``nrf5340dk_nrf5340``
+    ``thingy53_nrf5340``
+    ``nrf9160dk_nrf9160``
+
+  * When using sysbuild with the following boards with ``west flash``, the
+    ``--recover`` and ``--erase`` arguments will only recover/erase the
+    devices once per core instead of once per image flashed, fixing an issue
+    whereby the board could be unbootable:
+    ``nrf5340dk_nrf5340``
+    ``thingy53_nrf5340``
+    ``nrf9160dk_nrf9160``
+
 * Made these changes in other boards:
 
 * Added support for these following shields:

--- a/scripts/west_commands/runners/esp32.py
+++ b/scripts/west_commands/runners/esp32.py
@@ -16,13 +16,17 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end for espidf.'''
 
     def __init__(self, cfg, device, boot_address, part_table_address,
-                 app_address, erase=False, baud=921600, flash_size='detect',
+                 app_address, erase=False, reset=True, baud=921600, flash_size='detect',
                  flash_freq='40m', flash_mode='dio', espidf='espidf',
                  bootloader_bin=None, partition_table_bin=None):
         super().__init__(cfg)
         self.elf = cfg.elf_file
         self.app_bin = cfg.bin_file
         self.erase = bool(erase)
+        if reset is None:
+            self.reset = True
+        else:
+            self.reset = bool(reset)
         self.device = device
         self.boot_address = boot_address
         self.part_table_address = part_table_address
@@ -41,7 +45,7 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash'}, erase=True)
+        return RunnerCaps(commands={'flash'}, erase=True, reset=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -86,9 +90,10 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
             cfg, args.esp_device, boot_address=args.esp_boot_address,
             part_table_address=args.esp_partition_table_address,
             app_address=args.esp_app_address, erase=args.erase,
-            baud=args.esp_baud_rate, flash_size=args.esp_flash_size,
-            flash_freq=args.esp_flash_freq, flash_mode=args.esp_flash_mode,
-            espidf=espidf, bootloader_bin=args.esp_flash_bootloader,
+            reset=args.reset, baud=args.esp_baud_rate,
+            flash_size=args.esp_flash_size, flash_freq=args.esp_flash_freq,
+            flash_mode=args.esp_flash_mode, espidf=espidf,
+            bootloader_bin=args.esp_flash_bootloader,
             partition_table_bin=args.esp_flash_partition_table)
 
     def do_run(self, command, **kwargs):
@@ -105,7 +110,8 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
             cmd_flash.extend(['--port', self.device])
         cmd_flash.extend(['--baud', self.baud])
         cmd_flash.extend(['--before', 'default_reset'])
-        cmd_flash.extend(['--after', 'hard_reset', 'write_flash', '-u'])
+        if self.reset is True:
+            cmd_flash.extend(['--after', 'hard_reset', 'write_flash', '-u'])
         cmd_flash.extend(['--flash_mode', self.flash_mode])
         cmd_flash.extend(['--flash_freq', self.flash_freq])
         cmd_flash.extend(['--flash_size', self.flash_size])

--- a/scripts/west_commands/runners/intel_cyclonev.py
+++ b/scripts/west_commands/runners/intel_cyclonev.py
@@ -100,7 +100,7 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'attach'},
-                          dev_id=False, flash_addr=False, erase=False)
+                          dev_id=False, flash_addr=False, erase=False, reset=False)
 
     @classmethod
     def do_add_parser(cls, parser):

--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -77,7 +77,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach'},
-                          dev_id=True, flash_addr=True, erase=True,
+                          dev_id=True, flash_addr=True, erase=True, reset=False,
                           tool_opt=True)
 
     @classmethod

--- a/scripts/west_commands/runners/spi_burn.py
+++ b/scripts/west_commands/runners/spi_burn.py
@@ -29,7 +29,7 @@ class SpiBurnBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash', 'debug'}, erase=True, flash_addr=True)
+        return RunnerCaps(commands={'flash', 'debug'}, erase=True, reset=False, flash_addr=True)
 
     @classmethod
     def do_add_parser(cls, parser):

--- a/scripts/west_commands/runners/stm32flash.py
+++ b/scripts/west_commands/runners/stm32flash.py
@@ -72,9 +72,6 @@ class Stm32flashBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--serial-mode', default='8e1', required=False,
                             help='serial port mode, default \'8e1\'')
 
-        parser.add_argument('--reset', default=False, required=False, action='store_true',
-                            help='reset device at exit, default False')
-
         parser.add_argument('--verify', default=False, required=False, action='store_true',
                             help='verify writes, default False')
 

--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2018 Foundries.io
-# Copyright (c) 2020 Nordic Semiconductor ASA
+# Copyright (c) 2020-2023 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -64,111 +64,121 @@ class TC(typing.NamedTuple):    # 'TestCase'
     # --sectorerase if False (or --sectoranduicrerase on nRF52)
     erase: bool
 
+    # --reset if True, --no-reset if False
+    reset: bool
 
 EXPECTED_RESULTS = {
 
     # -------------------------------------------------------------------------
     # NRF51
     #
-    #  family   CP    recov  soft   snr    erase
-    TC('NRF51', None, False, False, False, False):
+    #  family   CP    recov  soft   snr    erase  reset
+    TC('NRF51', None, False, False, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51', None, False, False, False, True):
+    TC('NRF51', None, False, False, False, True, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51', None, False, False, True, False):
+    TC('NRF51', None, False, False, True, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF51', None, False, True, False, False):
+    TC('NRF51', None, False, True, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51', None, True, False, False, False):
+    TC('NRF51', None, True, False, False, False, True):
     (['nrfjprog', '--recover', '-f', 'NRF51', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51', None, True, True, True, True):
+    TC('NRF51', None, True, True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF51', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF51',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF51', '--snr', TEST_OVR_SNR]),
 
+    TC('NRF51', None, False, False, False, False, False):
+    (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
+      '--snr', TEST_DEF_SNR]),
+
     # -------------------------------------------------------------------------
     # NRF52
     #
-    #  family   CP    recov  soft   snr    erase
-    TC('NRF52', None, False, False, False, False):
+    #  family   CP    recov  soft   snr    erase  reset
+    TC('NRF52', None, False, False, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52', None, False, False, False, True):
+    TC('NRF52', None, False, False, False, True, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF52',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52', None, False, False, True, False):
+    TC('NRF52', None, False, False, True, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF52', None, False, True, False, False):
+    TC('NRF52', None, False, True, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52', None, True, False, False, False):
+    TC('NRF52', None, True, False, False, False, True):
     (['nrfjprog', '--recover', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52', None, True, True, True, True):
+    TC('NRF52', None, True, True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF52', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF52',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF52', '--snr', TEST_OVR_SNR]),
 
+    TC('NRF52', None, False, False, False, False, False):
+    (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
+      '--verify', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
+
     # -------------------------------------------------------------------------
     # NRF53 APP only
     #
-    #  family   CP     recov  soft   snr    erase
+    #  family   CP     recov  soft   snr    erase  reset
 
-    TC('NRF53', 'APP', False, False, False, False):
+    TC('NRF53', 'APP', False, False, False, False, True):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_APPLICATION'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'APP', False, False, False, True):
+    TC('NRF53', 'APP', False, False, False, True, True):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--chiperase',
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_APPLICATION'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'APP', False, False, True, False):
+    TC('NRF53', 'APP', False, False, True, False, True):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR, '--coprocessor', 'CP_APPLICATION'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF53', 'APP', False, True, False, False):
+    TC('NRF53', 'APP', False, True, False, False, True):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_APPLICATION'],
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'APP', True, False, False, False):
+    TC('NRF53', 'APP', True, False, False, False, True):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_DEF_SNR],
@@ -176,7 +186,7 @@ EXPECTED_RESULTS = {
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_APPLICATION'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'APP', True, True, True, True):
+    TC('NRF53', 'APP', True, True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR],
@@ -184,32 +194,36 @@ EXPECTED_RESULTS = {
       '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR, '--coprocessor', 'CP_APPLICATION'],
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
+    TC('NRF53', 'APP', False, False, False, False, False):
+    (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
+      '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_APPLICATION']),
+
     # -------------------------------------------------------------------------
     # NRF53 NET only
     #
-    #  family   CP     recov  soft   snr    erase
+    #  family   CP     recov  soft   snr    erase  reset
 
-    TC('NRF53', 'NET', False, False, False, False):
+    TC('NRF53', 'NET', False, False, False, False, True):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_NETWORK'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'NET', False, False, False, True):
+    TC('NRF53', 'NET', False, False, False, True, True):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--chiperase',
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_NETWORK'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'NET', False, False, True, False):
+    TC('NRF53', 'NET', False, False, True, False, True):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR, '--coprocessor', 'CP_NETWORK'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF53', 'NET', False, True, False, False):
+    TC('NRF53', 'NET', False, True, False, False, True):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_NETWORK'],
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'NET', True, False, False, False):
+    TC('NRF53', 'NET', True, False, False, False, True):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_DEF_SNR],
@@ -217,7 +231,7 @@ EXPECTED_RESULTS = {
       '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_NETWORK'],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'NET', True, True, True, True):
+    TC('NRF53', 'NET', True, True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR],
@@ -225,12 +239,16 @@ EXPECTED_RESULTS = {
       '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR, '--coprocessor', 'CP_NETWORK'],
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
+    TC('NRF53', 'NET', False, False, False, False, False):
+    (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
+      '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_NETWORK']),
+
     # -------------------------------------------------------------------------
     # NRF53 APP+NET
     #
-    #  family   CP     recov  soft   snr    erase
+    #  family    CP        recov  soft   snr    erase  reset
 
-    TC('NRF53', 'APP+NET', False, False, False, False):
+    TC('NRF53', 'APP+NET', False, False, False, False, True):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
@@ -244,7 +262,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION'],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53', 'APP+NET', False, False, False, True):
+    TC('NRF53', 'APP+NET', False, False, False, True, True):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
@@ -258,7 +276,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION'],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53', 'APP+NET', False, False, True, False):
+    TC('NRF53', 'APP+NET', False, False, True, False, True):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
@@ -272,7 +290,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION'],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_OVR_SNR])),
 
-    TC('NRF53', 'APP+NET', False, True, False, False):
+    TC('NRF53', 'APP+NET', False, True, False, False, True):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
@@ -286,7 +304,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION'],
          ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53', 'APP+NET', True, False, False, False):
+    TC('NRF53', 'APP+NET', True, False, False, False, True):
     (lambda tmpdir, infile: \
         (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
           '--snr', TEST_DEF_SNR],
@@ -303,7 +321,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION'],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53', 'APP+NET', True, True, True, True):
+    TC('NRF53', 'APP+NET', True, True, True, True, True):
     (lambda tmpdir, infile: \
         (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
           '--snr', TEST_OVR_SNR],
@@ -320,41 +338,58 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION'],
          ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR])),
 
+    TC('NRF53', 'APP+NET', False, False, False, False, False):
+    (lambda tmpdir, infile: \
+        (['nrfjprog',
+          '--program',
+          os.fspath(tmpdir / 'GENERATED_CP_NETWORK_' + Path(infile).name),
+          '--sectorerase', '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR,
+          '--coprocessor', 'CP_NETWORK'],
+         ['nrfjprog',
+          '--program',
+          os.fspath(tmpdir / 'GENERATED_CP_APPLICATION_' + Path(infile).name),
+          '--sectorerase', '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR,
+          '--coprocessor', 'CP_APPLICATION'])),
+
     # -------------------------------------------------------------------------
     # NRF91
     #
-    #  family   CP    recov  soft   snr    erase
-    TC('NRF91', None, False, False, False, False):
+    #  family   CP    recov  soft   snr    erase  reset
+    TC('NRF91', None, False, False, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91', None, False, False, False, True):
+    TC('NRF91', None, False, False, False, True, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91', None, False, False, True, False):
+    TC('NRF91', None, False, False, True, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF91', None, False, True, False, False):
+    TC('NRF91', None, False, True, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91', None, True, False, False, False):
+    TC('NRF91', None, True, False, False, False, True):
     (['nrfjprog', '--recover', '-f', 'NRF91', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91', None, True, True, True, True):
+    TC('NRF91', None, True, True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF91', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF91',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF91', '--snr', TEST_OVR_SNR]),
+
+    TC('NRF91', None, False, False, False, False, False):
+    (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
+      '--snr', TEST_DEF_SNR]),
 }
 
 #
@@ -389,8 +424,9 @@ def id_fn(test_case):
     sn = 'default snr' if test_case.snr else 'override snr'
     e = 'chip erase' if test_case.erase else 'sector[anduicr] erase'
     r = 'recover' if test_case.recover else 'no recover'
+    rst = 'reset' if test_case.reset else 'no reset'
 
-    return f'{test_case.family}{cp}, {s}, {sn}, {e}, {r}'
+    return f'{test_case.family}{cp}, {s}, {sn}, {e}, {r}, {rst}'
 
 def fix_up_runner_config(test_case, runner_config, tmpdir):
     # Helper that adjusts the common runner_config fixture for our
@@ -442,6 +478,7 @@ def test_nrfjprog_init(check_call, get_snr, require, test_case,
                                   test_case.softreset,
                                   snr,
                                   erase=test_case.erase,
+                                  reset=test_case.reset,
                                   recover=test_case.recover)
 
     with patch('os.path.isfile', side_effect=os_path_isfile_patch):
@@ -452,7 +489,10 @@ def test_nrfjprog_init(check_call, get_snr, require, test_case,
         assert (check_call.call_args_list ==
                 [call(x) for x in expected(tmpdir, runner_config.hex_file)])
     else:
-        assert check_call.call_args_list == [call(x) for x in expected]
+        if test_case.reset:
+            assert check_call.call_args_list == [call(x) for x in expected]
+        else:
+            assert check_call.call_args_list == [call(expected)]
 
     if snr is None:
         get_snr.assert_called_once_with('*')
@@ -476,6 +516,10 @@ def test_nrfjprog_create(check_call, get_snr, require, test_case,
         args.extend(['--dev-id', TEST_OVR_SNR])
     if test_case.erase:
         args.append('--erase')
+    if test_case.reset:
+        args.append('--reset')
+    else:
+        args.append('--no-reset')
     if test_case.recover:
         args.append('--recover')
 
@@ -491,7 +535,10 @@ def test_nrfjprog_create(check_call, get_snr, require, test_case,
         assert (check_call.call_args_list ==
                 [call(x) for x in expected(tmpdir, runner_config.hex_file)])
     else:
-        assert check_call.call_args_list == [call(x) for x in expected]
+        if test_case.reset:
+            assert check_call.call_args_list == [call(x) for x in expected]
+        else:
+            assert check_call.call_args_list == [call(expected)]
 
     if not test_case.snr:
         get_snr.assert_called_once_with('*')

--- a/scripts/west_commands/tests/test_stm32cubeprogrammer.py
+++ b/scripts/west_commands/tests/test_stm32cubeprogrammer.py
@@ -384,7 +384,7 @@ def test_stm32cubeprogrammer_create(
     if tc["frequency"]:
         args.extend(["--frequency", tc["frequency"]])
     if tc["reset_mode"]:
-        args.extend(["--reset", tc["reset_mode"]])
+        args.extend(["--reset-mode", tc["reset_mode"]])
     if tc["conn_modifiers"]:
         args.extend(["--conn-modifiers", tc["conn_modifiers"]])
     if tc["cli"]:


### PR DESCRIPTION
This takes just the single command per set of boards and single reset per set of board features for flash runners from https://github.com/zephyrproject-rtos/zephyr/pull/53443 without the board priority part.

Includes:

    west: runners: Add single-use commands per board flash
    
    This adds supports for flashing images with sysbuild where there
    are multiple images per board to prevent using the same command per
    image flash which might cause issues if they are not ran just once
    per flash per unique board name. This can be enabled per-board by
    creating a `flash_runner.yml` file in the board directory with a
    list named `board_single_commands`, e.g. to prevent the --recover
    command being used multiple times when flashing a board, the file
    contents would be similar to:
    
    board_single_commands:
      - --recover: [
        nrf9160dk_nrf9160,
        nrf9160dk_nrf9160_ns,
      ]

and

    west: runners: Add option to allow/prevent board reset

    This adds supports for specifying if boards should be reset or not
    after an image has been flashed, this is most useful for sysbuild
    where multiple images are flashed and having one boot before all
    are flashed causes the debug interface to be disabled or faults,
    preventing correct operation of the firmware. Existing reset
    priority of runners that supported it has been maintained.
    
    This can be enabled per-board by creating a `flash_runner.yml` file
    in the board directory with a list named `board_delay_reset`, e.g.
    to delay an nRF5340 board from resetting whilst network core images
    are being flashed, or whilst application core images (secure and
    non-secure combined) are being flashed, the file contents would be
    similar to:
    
    board_delay_reset:
      - [
        nrf5340dk_nrf5340_cpuapp,
        nrf5340dk_nrf5340_cpuapp_ns,
      ]
      - [
        nrf5340dk_nrf5340_cpunet,
      ]
    
    Also fixes #53487 by using the correct argument for the
    stm32cubeprogrammer tests of "--reset-mode" instead of "--reset".

and changes to nrf5340dk_nrf5340, thingy53_nrf5340 and nrf9160dk_nrf9160 boards. Includes command updates for west flash test scripts.

- [X] Code updates
- [X] Board updates
- [ ] Documentation
- [X] Release notes
- [ ] Decide if the resetting once per board should be opt-out instead of opt-in
- [ ] Update code to make reset once per board opt-out if needed
- [ ] Update release notes as above

Fixes #50421
Fixes #55631