### PR TITLE
boards: nrf52840dk_nrf52840: Do not enable arduino_serial by default

### DIFF
--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -167,7 +167,6 @@
 };
 
 arduino_serial: &uart1 {
-	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&uart1_default>;
 	pinctrl-1 = <&uart1_sleep>;

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -144,7 +144,6 @@
 };
 
 arduino_serial: &uart1 {
-	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&uart1_default>;
 	pinctrl-1 = <&uart1_sleep>;

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -156,7 +156,6 @@
 };
 
 arduino_serial: &uart1 {
-	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&uart1_default>;
 	pinctrl-1 = <&uart1_sleep>;

--- a/samples/drivers/w1/scanner/ds2484.overlay
+++ b/samples/drivers/w1/scanner/ds2484.overlay
@@ -1,4 +1,6 @@
 &arduino_i2c {
+	status = "okay";
+
 	w1: w1@18 {
 		compatible = "maxim,ds2484";
 		reg = <0x18>;

--- a/samples/drivers/w1/scanner/ds2485.overlay
+++ b/samples/drivers/w1/scanner/ds2485.overlay
@@ -1,4 +1,6 @@
 &arduino_i2c {
+	status = "okay";
+
 	w1: w1@40 {
 		compatible = "maxim,ds2485";
 		reg = <0x40>;

--- a/samples/drivers/w1/scanner/w1_serial.overlay
+++ b/samples/drivers/w1/scanner/w1_serial.overlay
@@ -1,4 +1,6 @@
 &arduino_serial {
+	status = "okay";
+
 	w1: w1 {
 		compatible = "zephyr,w1-serial";
 	};

--- a/samples/net/openthread/coprocessor/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/net/openthread/coprocessor/boards/nrf52833dk_nrf52833.overlay
@@ -10,3 +10,7 @@
 		zephyr,console = &uart1;
 	};
 };
+
+&uart1 {
+	status = "okay";
+};

--- a/samples/net/openthread/coprocessor/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/net/openthread/coprocessor/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,ot-uart = &uart0;
+		zephyr,console = &uart1;
+	};
+};
+
+&uart1 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf52840dk_nrf52840.overlay
@@ -11,7 +11,3 @@
 		in-gpios = <&gpio1 2 0>;  /* Arduino D1 */
 	};
 };
-
-&uart1 {
-	status = "disabled";
-};

--- a/tests/drivers/i2s/i2s_api/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/i2s/i2s_api/boards/nrf52840dk_nrf52840.overlay
@@ -9,10 +9,6 @@
 	};
 };
 
-&uart1 {
-	status = "disabled";
-};
-
 &i2s0 {
 	status = "okay";
 	pinctrl-0 = <&i2s0_default_alt>;

--- a/tests/drivers/i2s/i2s_speed/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/nrf52840dk_nrf52840.overlay
@@ -17,10 +17,6 @@
 	};
 };
 
-&uart1 {
-	status = "disabled";
-};
-
 &i2s0 {
 	status = "okay";
 	pinctrl-0 = <&i2s0_default_alt>;

--- a/tests/drivers/regulator/fixed/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/regulator/fixed/boards/nrf52840dk_nrf52840.overlay
@@ -15,8 +15,3 @@
 		check-gpios = <&gpio1 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 	};
 };
-
-&uart1 {
-	/* Default-enabled Arduino UART steals the pins we want. */
-	status = "disabled";
-};

--- a/tests/drivers/w1/w1_api/ds2484.overlay
+++ b/tests/drivers/w1/w1_api/ds2484.overlay
@@ -5,6 +5,8 @@
  */
 
 &arduino_i2c {
+	status = "okay";
+
 	w1_0: w1@18 {
 		compatible = "maxim,ds2484";
 		reg = <0x18>;

--- a/tests/drivers/w1/w1_api/ds2485.overlay
+++ b/tests/drivers/w1/w1_api/ds2485.overlay
@@ -1,4 +1,6 @@
 &arduino_i2c {
+	status = "okay";
+
 	w1_0: w1@40 {
 		compatible = "maxim,ds2485";
 		reg = <0x40>;

--- a/tests/drivers/w1/w1_api/w1_serial.overlay
+++ b/tests/drivers/w1/w1_api/w1_serial.overlay
@@ -5,6 +5,8 @@
  */
 
 &arduino_serial {
+	status = "okay";
+
 	w1_0: w1 {
 		compatible = "zephyr,w1-serial";
 	};


### PR DESCRIPTION
This is a follow-up to commit 25d7a09aa5e3b1826c1571872204852815df3ad0.

The arduino_serial/uart1 node should not be enabled by default because even if an application does not use it, the default CONFIG_SERIAL=y setting causes that it is anyway initialized, so the UARTE peripheral acquires its assigned pins (and they cannot be used in other way) and its enabled receiver causes increased current consumption (by ~500 uA) when the CPU is sleeping. This affects e.g. the boards/nrf/system_off sample.
Applications that actually need to use this UART or shields that use the arduino_serial node should enable the node explicitly.

Keep this node disabled by default for the nrf52840dk_nrf52840 board and also for boards whose definitions are mostly copies of the above: nrf52833dk_nrf52833 and nrf21540dk_nrf52840.

Update also accordingly a few overlay files in tests/ that were disabling this node because of the pins it undesirably acquired.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>