### PR TITLE
Updated clock init for the LPC55XXX Series

### DIFF
--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.soc
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.soc
@@ -1,6 +1,6 @@
 # LPC LPC55XXX Series
 
-# Copyright (c) 2019, NXP
+# Copyright 2019, 2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 choice
@@ -119,6 +119,14 @@ config SOC_PART_NUMBER_LPC55XXX
 
 config INIT_PLL0
 	bool "Initialize PLL0"
+
+config INIT_PLL1
+	bool "Initialize PLL1"
+	default "y"
+	depends on !SOC_LPC55S06
+	help
+	  In the LPC55XXX Family, this is currently being used to set the
+	  core clock value at it's highest frequency which clocks at 150MHz.
 
 config SECOND_CORE_MCUX
 	bool "LPC55xxx's second core"


### PR DESCRIPTION
Currently the LPC Family has mixed clock frequency values in the SOC derived from either the LPC55S06, LPC55S36 or LPC55S69, this PR aims to decouple this problem while updating the clock_init code with accordance to the SDK. 

Updated the clock init to reflect the NXP's MCUXpresso SDK also
updated the clock frequencies to reflect the
respective soc clock values, this file originally
contained unexpected clock values, updated comments to reflect changes and got rid of doxygen style
comments

Signed-off-by: Emilio Benavente <emilio.benavente@nxp.com>