### PR TITLE
build: Add property for longcalls flag

### DIFF
--- a/arch/xtensa/core/CMakeLists.txt
+++ b/arch/xtensa/core/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_cc_option(-mlongcalls)
-
+zephyr_compile_options($<TARGET_PROPERTY:compiler,long_calls>)
 zephyr_library()
 
 zephyr_library_sources(

--- a/arch/xtensa/core/startup/CMakeLists.txt
+++ b/arch/xtensa/core/startup/CMakeLists.txt
@@ -3,10 +3,10 @@
 if(CONFIG_XTENSA_RESET_VECTOR)
   zephyr_library()
 
+  zephyr_compile_options($<TARGET_PROPERTY:compiler,long_calls>)
   zephyr_library_cc_option(
     -c
     -mtext-section-literals
-    -mlongcalls
     )
 
   zephyr_library_sources(

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -108,3 +108,7 @@ set_compiler_property(PROPERTY warning_error_coding_guideline
                       -Wconversion
                       -Woverride-init
 )
+
+# Compiler flag to instruct the assembler to translate direct calls to
+# indirect calls unless it can determine that the target of a direct call.
+set_compiler_property(PROPERTY long_calls "-mlong-calls")

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -115,3 +115,7 @@ set_compiler_property(PROPERTY warning_no_pointer_arithmetic)
 
 # Compiler flags for disabling position independent code / executable
 set_compiler_property(PROPERTY no_position_independent)
+
+# Compiler flag to instruct the assembler to translate direct calls to
+# indirect calls unless it can determine that the target of a direct call.
+set_compiler_property(PROPERTY long_calls)

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -200,3 +200,7 @@ set_compiler_property(PROPERTY no_position_independent
                       -fno-pic
                       -fno-pie
 )
+
+# Compiler flag to instruct the assembler to translate direct calls to
+# indirect calls unless it can determine that the target of a direct call.
+set_compiler_property(PROPERTY long_calls "-mlongcalls")

--- a/cmake/compiler/xcc-clang/compiler_flags.cmake
+++ b/cmake/compiler/xcc-clang/compiler_flags.cmake
@@ -15,3 +15,9 @@ endif()
 
 # Clang version used by Xtensa does not support -fno-pic and -fno-pie
 set_compiler_property(PROPERTY no_position_independent "")
+
+# Compiler flag to instruct the assembler to translate direct calls to
+# indirect calls unless it can determine that the target of a direct call.
+#
+# xcc-clang is odd and uses mlongcalls flag
+set_compiler_property(PROPERTY long_calls "-mlongcalls")


### PR DESCRIPTION
-mlongcalls flag has different syntax on clang.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>