### PR TITLE
samples/soc_flash_nrf: Use filter to pick platforms witn nRF chip

### DIFF
--- a/samples/drivers/soc_flash_nrf/sample.yaml
+++ b/samples/drivers/soc_flash_nrf/sample.yaml
@@ -1,10 +1,14 @@
 sample:
-  name: SoC Flash on NRF52
+  name: SoC Flash on nRF52 and nRF91
 tests:
   sample.drivers.flash.soc_flash_nrf:
-    platform_allow: nrf52dk_nrf52832 nrf9160dk_nrf9160 nrf9160dk_nrf9160_ns
+    # Below will allow any platforms that have specified nRF SoC
+    # and will not restrict selection to Nordic DK boards.
+    filter: (dt_compat_enabled("nordic,nrf52-flash-controller") or
+             dt_compat_enabled("nordic,nrf91-flash-controller"))
     integration_platforms:
       - nrf52dk_nrf52832
+    extra_args: DTC_OVERLAY_FILE="test_partitions.overlay"
     tags: flash nrf52 nrf9160
     harness: console
     harness_config:

--- a/samples/drivers/soc_flash_nrf/src/main.c
+++ b/samples/drivers/soc_flash_nrf/src/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016 Linaro Limited
  *               2016 Intel Corporation.
+ * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,11 +14,7 @@
 #include <stdio.h>
 
 
-#ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
-#define TEST_PARTITION	slot1_ns_partition
-#else
-#define TEST_PARTITION	slot1_partition
-#endif
+#define TEST_PARTITION	storage_partition
 
 #define TEST_PARTITION_OFFSET	FIXED_PARTITION_OFFSET(TEST_PARTITION)
 #define TEST_PARTITION_DEVICE	FIXED_PARTITION_DEVICE(TEST_PARTITION)

--- a/samples/drivers/soc_flash_nrf/test_partitions.overlay
+++ b/samples/drivers/soc_flash_nrf/test_partitions.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &slot1_partition;
+/delete-node/ &scratch_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		storage_partition: partition@f8000 {
+			label = "storage";
+			reg = < 0xf8000 0x8000 >;
+		};
+	};
+};


### PR DESCRIPTION
Instead of platform allow filter is now used to pick platforms
depending on enabled Nordic compatible flash controller.
test_partitios.overlay file has been added that provides
test partition definition (storage_partition) for all platforms
selected for sample, by overriding default platform DTS entries
for fixed-partitions.
Test has been altered to only use the storage_partition.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

**2023-01-16** Replaced original platform_allow with filter.
**2023-01-17** Filter now selects nrf soc platforms, but I have decided to simplify partition selection and provide overlay uniform for all selected platforms.