### PR TITLE
tests: kernel: fatal: Catch EPSR reason code

### DIFF
--- a/tests/kernel/fatal/no-multithreading/src/main.c
+++ b/tests/kernel/fatal/no-multithreading/src/main.c
@@ -29,7 +29,11 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 
 static void entry_cpu_exception(void)
 {
+#if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	expected_reason = K_ERR_ARM_USAGE_ILLEGAL_EPSR;
+#else
 	expected_reason = K_ERR_CPU_EXCEPTION;
+#endif
 
 	TC_PRINT("cpu exception\n");
 #if defined(CONFIG_X86)


### PR DESCRIPTION
Adds a check for `K_ERR_ARM_USAGE_ILLEGAL_EPSR` as the reason code when running this test for `CONFIG_ARMV7_M_ARMV8_M_MAINLINE`.

Fixes an issue mentionned in https://github.com/zephyrproject-rtos/zephyr/pull/53551#pullrequestreview-1245704456