### PR TITLE
stm32: adc: Simplify code with dt bindings addition (DNM)

### DIFF
--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/stm32wb_adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/reset/stm32wb_l_reset.h>
 #include <freq.h>
@@ -369,6 +370,8 @@
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+			st,resolutions = <STM32_ADC_RES_12 STM32_ADC_RES_10
+					  STM32_ADC_RES_8 STM32_ADC_RES_6>;
 		};
 
 		iwdg: watchdog@40003000 {

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -44,5 +44,11 @@ properties:
     type: boolean
     description: Indicates if the ADC has a dedicated internal vbat monitoring channel.
 
+  st,resolutions:
+    type: array
+    description: |
+      Resolutions supoprted by the ADC instance. Maximum supported resolution is expected
+      to be the first array element.
+
 io-channel-cells:
   - input

--- a/include/zephyr/dt-bindings/adc/stm32_adc.h
+++ b/include/zephyr/dt-bindings/adc/stm32_adc.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Linaro Ltd.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADC_STM32_ADC_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ADC_STM32_ADC_H_
+
+#define STM32_ADC_RES_RES_MASK    0x15U
+#define STM32_ADC_RES_RES_SHIFT   0U
+#define STM32_ADC_RES_VAL_MASK    0x7U
+#define STM32_ADC_RES_VAL_SHIFT   4U
+#define STM32_ADC_RES_OFF_MASK    0x31U
+#define STM32_ADC_RES_OFF_SHIFT   6U
+
+/**
+ * @brief STM32 ADC resolutions bit field.
+ *
+ * - res      (0..14)         [ 0 : 3 ]
+ * - val      (0x0..0x3)      [ 4 : 5 ]
+ * - offset   (0..31)         [ 6 : 10 ]
+ *
+ * @param res Supported resolutions [6,8,10,12,14, ..]
+ * @param val Value of the supported resolution in ADC register
+ * @param offset Offset of the RES bits in ADC register
+ */
+#define STM32_ADC_RES(res, val, offset)						\
+	((((res) & STM32_ADC_RES_RES_MASK) << STM32_ADC_RES_RES_SHIFT) |	\
+	 (((val) & STM32_ADC_RES_VAL_MASK) << STM32_ADC_RES_VAL_SHIFT) |	\
+	 (((offset) & STM32_ADC_RES_OFF_MASK) << STM32_ADC_RES_OFF_SHIFT))
+
+/**
+ * @brief Resolution vamue from ADC resolutions bit field.
+ *
+ * @param res_val ADC resolution bit field value.
+ */
+#define STM32_ADC_RES_RES(res_val)						\
+	(((res_val) >> STM32_ADC_RES_RES_SHIFT) & STM32_ADC_RES_RES_MASK)
+
+/**
+ * @brief Get resolution value in ADC register space
+ *
+ * @param res_val ADC resolution bit field value.
+ */
+#define STM32_ADC_RES_VAL(res_val)						\
+	(((res_val) >> STM32_ADC_RES_VAL_SHIFT) & STM32_ADC_RES_VAL_MASK)	\
+	<< (((res_val) >> STM32_ADC_RES_OFF_SHIFT) & STM32_ADC_RES_OFF_MASK)
+
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_STM32_ADC_H_ */

--- a/include/zephyr/dt-bindings/adc/stm32wb_adc.h
+++ b/include/zephyr/dt-bindings/adc/stm32wb_adc.h
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Linaro Ltd.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADC_STM32WB_ADC_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ADC_STM32WB_ADC_H_
+
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
+
+#define STM32_ADC_RES_12	STM32_ADC_RES(12, 0, 3)
+#define STM32_ADC_RES_10	STM32_ADC_RES(10, 1, 3)
+#define STM32_ADC_RES_8		STM32_ADC_RES(8, 2, 3)
+#define STM32_ADC_RES_6		STM32_ADC_RES(6, 3, 3)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_STM32WB_ADC_H_ */


### PR DESCRIPTION
Encode more information in device tree to simplify driver implementation.

This is only POC for now:
- Need to extend to other series
- Some other data could help to reduce driver complexity