### PR TITLE
Lwm2m string api deprecation

### DIFF
--- a/doc/connectivity/networking/api/lwm2m.rst
+++ b/doc/connectivity/networking/api/lwm2m.rst
@@ -331,29 +331,29 @@ to connect as well as set the ``Manufacturer`` and ``Reboot`` resources in the
 	 * Server URL of default Security object = 0/0/0
 	 * Use leshan.eclipse.org server IP (5.39.83.206) for connection
 	 */
-	lwm2m_engine_set_string("0/0/0", "coap://5.39.83.206");
+	lwm2m_set_string(&LWM2M_OBJ(0, 0, 0), "coap://5.39.83.206");
 
 	/*
 	 * Security Mode of default Security object = 0/0/2
 	 * 3 = NoSec mode (no security beware!)
 	 */
-	lwm2m_engine_set_u8("0/0/2", 3);
+	lwm2m_set_u8(&LWM2M_OBJ(0, 0, 2), 3);
 
 	#define CLIENT_MANUFACTURER "Zephyr Manufacturer"
 
 	/*
 	 * Manufacturer resource of Device object = 3/0/0
-	 * We use lwm2m_engine_set_res_data() function to set a pointer to the
+	 * We use lwm2m_set_res_data() function to set a pointer to the
 	 * CLIENT_MANUFACTURER string.
 	 * Note the LWM2M_RES_DATA_FLAG_RO flag which stops the engine from
 	 * trying to assign a new value to the buffer.
 	 */
-	lwm2m_engine_set_res_data("3/0/0", CLIENT_MANUFACTURER,
-				  sizeof(CLIENT_MANUFACTURER),
-				  LWM2M_RES_DATA_FLAG_RO);
+	lwm2m_set_res_data(&LWM2M_OBJ(3, 0, 0), CLIENT_MANUFACTURER,
+			   sizeof(CLIENT_MANUFACTURER),
+			   LWM2M_RES_DATA_FLAG_RO);
 
 	/* Reboot resource of Device object = 3/0/4 */
-	lwm2m_engine_register_exec_callback("3/0/4", device_reboot_cb);
+	lwm2m_register_exec_callback(&LWM2M_OBJ(3, 0, 4), device_reboot_cb);
 
 Lastly, we start the LwM2M RD client (which in turn starts the LwM2M engine).
 The second parameter of :c:func:`lwm2m_rd_client_start` is the client
@@ -391,13 +391,13 @@ resource.  Lastly, set the client identity and PSK resources.
 .. code-block:: c
 
 	/* Use coaps:// for server URL protocol */
-	lwm2m_engine_set_string("0/0/0", "coaps://5.39.83.206");
+	lwm2m_set_string(&LWM2M_OBJ(0, 0, 0), "coaps://5.39.83.206");
 	/* 0 = Pre-Shared Key mode */
-	lwm2m_engine_set_u8("0/0/2", 0);
+	lwm2m_set_u8(&LWM2M_OBJ(0, 0, 2), 0);
 	/* Set the client identity */
-	lwm2m_engine_set_string("0/0/3", (char *)client_identity);
+	lwm2m_set_string(&LWM2M_OBJ(0, 0, 3), (char *)client_identity);
 	/* Set the client pre-shared key (PSK) */
-	lwm2m_engine_set_opaque("0/0/5", (void *)client_psk, sizeof(client_psk));
+	lwm2m_set_opaque(&LWM2M_OBJ(0, 0, 5), (void *)client_psk, sizeof(client_psk));
 
 Before calling :c:func:`lwm2m_rd_client_start` assign the tls_tag # where the
 LwM2M library should store the DTLS information prior to connection (normally a
@@ -413,16 +413,16 @@ For a more detailed LwM2M client sample see: :ref:`lwm2m-client-sample`.
 
 Multi-thread usage
 ******************
-Writing a value to a resource can be done using functions like lwm2m_engine_set_u8. When writing
+Writing a value to a resource can be done using functions like lwm2m_set_u8. When writing
 to multiple resources, the function lwm2m_registry_lock will ensure that the
 client halts until all writing operations are finished:
 
 .. code-block:: c
 
   lwm2m_registry_lock();
-  lwm2m_engine_set_u32("1/0/1", 60);
-  lwm2m_engine_set_u8("5/0/3", 0);
-  lwm2m_engine_set_float("3303/0/5700", &value);
+  lwm2m_set_u32(&LWM2M_OBJ(1, 0, 1), 60);
+  lwm2m_set_u8(&LWM2M_OBJ(5, 0, 3), 0);
+  lwm2m_set_f64(&LWM2M_OBJ(3303, 0, 5700), value);
   lwm2m_registry_unlock();
 
 This is especially useful if the server is composite-observing the resources being
@@ -478,9 +478,9 @@ Read and Write operations
 Full content of data cache is written into a payload when any READ, SEND or NOTIFY operation
 internally reads the content of a given resource. This has a side effect that any read callbacks
 registered for a that resource are ignored when cache is enabled.
-Data is written into a cache when any of the ``lwm2m_engine_set_*`` functions are called. To filter
+Data is written into a cache when any of the ``lwm2m_set_*`` functions are called. To filter
 the data entering the cache, application may register a validation callback using
-:c:func:`lwm2m_engine_register_validate_callback`.
+:c:func:`lwm2m_register_validate_callback`.
 
 Limitations
 ===========

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -199,6 +199,9 @@ Deprecated in this release
 
 * SPI DT :c:func:`spi_is_ready` function has been deprecated in favor of :c:func:`spi_is_ready_dt`.
 
+* LwM2M APIs using string references as LwM2M paths has been deprecated in favor of functions
+  using :c:struct:`lwm2m_path_obj` instead.
+
 Stable API changes in this release
 ==================================
 

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -2089,6 +2089,8 @@ char *lwm2m_path_log_buf(char *buf, struct lwm2m_obj_path *path);
 /** 
  * @brief LwM2M SEND operation to given path list
  *
+ * @deprecated Use lwm2m_send() instead.
+ *
  * @param ctx LwM2M context
  * @param path_list LwM2M Path string list
  * @param path_list_size Length of path list. Max size is CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE
@@ -2099,6 +2101,20 @@ char *lwm2m_path_log_buf(char *buf, struct lwm2m_obj_path *path);
  */
 int lwm2m_engine_send(struct lwm2m_ctx *ctx, char const *path_list[], uint8_t path_list_size,
 		      bool confirmation_request);
+
+/** 
+ * @brief LwM2M SEND operation to given path list
+ *
+ * @param ctx LwM2M context
+ * @param path_list LwM2M path struct list
+ * @param path_list_size Length of path list. Max size is CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE
+ * @param confirmation_request True request confirmation for operation.
+ * 
+ * @return 0 for success or negative in case of error.
+ *
+ */
+int lwm2m_send(struct lwm2m_ctx *ctx, const struct lwm2m_obj_path path_list[],
+	       uint8_t path_list_size, bool confirmation_request);
 
 /** 
  * @brief Returns LwM2M client context

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -610,6 +610,8 @@ struct lwm2m_objlnk {
 /**
  * @brief Change an observer's pmin value.
  *
+ * @deprecated Use lwm2m_update_observer_min_period() instead.
+ *
  * LwM2M clients use this function to modify the pmin attribute
  * for an observation being made.
  * Example to update the pmin of a temperature sensor value being observed:
@@ -621,11 +623,31 @@ struct lwm2m_objlnk {
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_update_observer_min_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
 					    uint32_t period_s);
 
 /**
+ * @brief Change an observer's pmin value.
+ *
+ * LwM2M clients use this function to modify the pmin attribute
+ * for an observation being made.
+ * Example to update the pmin of a temperature sensor value being observed:
+ * lwm2m_update_observer_min_period(client_ctx, &LWM2M_OBJ(3303, 0, 5700), 5);
+ *
+ * @param[in] client_ctx LwM2M context
+ * @param[in] path LwM2M path as a struct
+ * @param[in] period_s Value of pmin to be given (in seconds).
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_update_observer_min_period(struct lwm2m_ctx *client_ctx,
+				     const struct lwm2m_obj_path *path, uint32_t period_s);
+
+/**
  * @brief Change an observer's pmax value.
+ *
+ * @deprecated Use lwm2m_update_observer_max_period() instead.
  *
  * LwM2M clients use this function to modify the pmax attribute
  * for an observation being made.
@@ -638,8 +660,26 @@ int lwm2m_engine_update_observer_min_period(struct lwm2m_ctx *client_ctx, const 
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_update_observer_max_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
 					    uint32_t period_s);
+
+/**
+ * @brief Change an observer's pmax value.
+ *
+ * LwM2M clients use this function to modify the pmax attribute
+ * for an observation being made.
+ * Example to update the pmax of a temperature sensor value being observed:
+ * lwm2m__update_observer_max_period(client_ctx, &LWM2M_OBJ(3303, 0, 5700), 5);
+ *
+ * @param[in] client_ctx LwM2M context
+ * @param[in] path LwM2M path as a struct
+ * @param[in] period_s Value of pmax to be given (in seconds).
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_update_observer_max_period(struct lwm2m_ctx *client_ctx,
+				     const struct lwm2m_obj_path *path, uint32_t period_s);
 
 /**
  * @brief Create an LwM2M object instance.
@@ -1664,6 +1704,8 @@ int lwm2m_update_device_service_period(uint32_t period_ms);
 /**
  * @brief Check whether a path is observed
  *
+ * @deprecated Use lwm2m_path_is_observed() instead.
+ *
  * @param[in] pathstr LwM2M path string to check, e.g. "3/0/1"
  *
  * @return true when there exists an observation of the same level
@@ -1672,7 +1714,21 @@ int lwm2m_update_device_service_period(uint32_t period_ms);
  *         E.g. true if path refers to a resource and the parent object has an
  *         observation, false for the inverse.
  */
+__deprecated
 bool lwm2m_engine_path_is_observed(const char *pathstr);
+
+/**
+ * @brief Check whether a path is observed
+ *
+ * @param[in] path LwM2M path as a struct to check
+ *
+ * @return true when there exists an observation of the same level
+ *         or lower as the given path, false if it doesn't or path is not a
+ *         valid LwM2M-path.
+ *         E.g. true if path refers to a resource and the parent object has an
+ *         observation, false for the inverse.
+ */
+bool lwm2m_path_is_observed(const struct lwm2m_obj_path *path);
 
 /**
  * @brief Stop the LwM2M engine

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -2127,18 +2127,37 @@ struct lwm2m_ctx *lwm2m_rd_client_ctx(void);
 /** 
  * @brief Enable data cache for a resource.
  *
+ * @deprecated Use lwm2m_enable_cache instead
+ *
  * Application may enable caching of resource data by allocating buffer for LwM2M engine to use.
  * Buffer must be size of struct @ref lwm2m_time_series_elem times cache_len
  *
  * @param resource_path LwM2M resourcepath string "obj/obj-inst/res(/res-inst)"
  * @param data_cache Pointer to Data cache array
  * @param cache_len number of cached entries
- * 
+ *
  * @return 0 for success or negative in case of error.
  *
  */
+__deprecated
 int lwm2m_engine_enable_cache(char const *resource_path, struct lwm2m_time_series_elem *data_cache,
 			      size_t cache_len);
+
+/** 
+ * @brief Enable data cache for a resource.
+ *
+ * Application may enable caching of resource data by allocating buffer for LwM2M engine to use.
+ * Buffer must be size of struct @ref lwm2m_time_series_elem times cache_len
+ *
+ * @param path LwM2M path to resource as a struct
+ * @param data_cache Pointer to Data cache array
+ * @param cache_len number of cached entries
+ *
+ * @return 0 for success or negative in case of error.
+ *
+ */
+int lwm2m_enable_cache(struct lwm2m_obj_path *path, struct lwm2m_time_series_elem *data_cache,
+		       size_t cache_len);
 
 #endif	/* ZEPHYR_INCLUDE_NET_LWM2M_H_ */
 /**@}  */

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -644,6 +644,8 @@ int lwm2m_engine_update_observer_max_period(struct lwm2m_ctx *client_ctx, const 
 /**
  * @brief Create an LwM2M object instance.
  *
+ * @deprecated Use lwm2m_create_obj_inst() instead.
+ *
  * LwM2M clients use this function to create non-default LwM2M objects:
  * Example to create first temperature sensor object:
  * lwm2m_engine_create_obj_inst("3303/0");
@@ -652,10 +654,26 @@ int lwm2m_engine_update_observer_max_period(struct lwm2m_ctx *client_ctx, const 
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_create_obj_inst(const char *pathstr);
 
 /**
+ * @brief Create an LwM2M object instance.
+ *
+ * LwM2M clients use this function to create non-default LwM2M objects:
+ * Example to create first temperature sensor object:
+ * lwm2m_create_obj_inst(&LWM2M_OBJ(3303, 0));
+ *
+ * @param[in] path LwM2M path as a struct
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_create_object_inst(const struct lwm2m_obj_path *path);
+
+/**
  * @brief Delete an LwM2M object instance.
+ *
+ * @deprecated Use lwm2m_delete_obj_inst() instead.
  *
  * LwM2M clients use this function to delete LwM2M objects.
  *
@@ -663,7 +681,19 @@ int lwm2m_engine_create_obj_inst(const char *pathstr);
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_delete_obj_inst(const char *pathstr);
+
+/**
+ * @brief Delete an LwM2M object instance.
+ *
+ * LwM2M clients use this function to delete LwM2M objects.
+ *
+ * @param[in] path LwM2M path as a struct
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_delete_object_inst(const struct lwm2m_obj_path *path);
 
 /**
  * @brief Locks the registry for this thread.
@@ -1553,6 +1583,8 @@ int lwm2m_engine_get_res_data(const char *pathstr, void **data_ptr, uint16_t *da
 /**
  * @brief Create a resource instance
  *
+ * @deprecated Use lwm2m_create_res_inst() instead.
+ *
  * LwM2M clients use this function to create multi-resource instances:
  * Example to create 0 instance of device available power sources:
  * lwm2m_engine_create_res_inst("3/0/6/0");
@@ -1561,10 +1593,26 @@ int lwm2m_engine_get_res_data(const char *pathstr, void **data_ptr, uint16_t *da
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_create_res_inst(const char *pathstr);
 
 /**
+ * @brief Create a resource instance
+ *
+ * LwM2M clients use this function to create multi-resource instances:
+ * Example to create 0 instance of device available power sources:
+ * lwm2m_create_res_inst(&LWM2M_OBJ(3, 0, 6, 0));
+ *
+ * @param[in] path LwM2M path as a struct
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_create_res_inst(const struct lwm2m_obj_path *path);
+
+/**
  * @brief Delete a resource instance
+ *
+ * @deprecated Use lwm2m_delete_res_inst() instead.
  *
  * Use this function to remove an existing resource instance
  *
@@ -1572,7 +1620,19 @@ int lwm2m_engine_create_res_inst(const char *pathstr);
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_delete_res_inst(const char *pathstr);
+
+/**
+ * @brief Delete a resource instance
+ *
+ * Use this function to remove an existing resource instance
+ *
+ * @param[in] path LwM2M path as a struct
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_delete_res_inst(const struct lwm2m_obj_path *path);
 
 /**
  * @brief Update the period of a given service.

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -1667,6 +1667,8 @@ int lwm2m_register_delete_callback(uint16_t obj_id,
 /**
  * @brief Set data buffer for a resource
  *
+ * @deprecated Use lwm2m_set_res_buf() instead.
+ *
  * Use this function to set the data buffer and flags for the specified LwM2M
  * resource.
  *
@@ -1678,6 +1680,7 @@ int lwm2m_register_delete_callback(uint16_t obj_id,
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_res_buf(const char *pathstr, void *buffer_ptr, uint16_t buffer_len,
 			     uint16_t data_len, uint8_t data_flags);
 
@@ -1687,7 +1690,24 @@ int lwm2m_engine_set_res_buf(const char *pathstr, void *buffer_ptr, uint16_t buf
  * Use this function to set the data buffer and flags for the specified LwM2M
  * resource.
  *
- * @deprecated Use lwm2m_engine_set_res_buf() instead, so you can define buffer size and data size
+ * @param[in] path LwM2M path as a struct
+ * @param[in] buffer_ptr Data buffer pointer
+ * @param[in] buffer_len Length of buffer
+ * @param[in] data_len Length of existing data in the buffer
+ * @param[in] data_flags Data buffer flags (such as read-only, etc)
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_res_buf(const struct lwm2m_obj_path *path, void *buffer_ptr, uint16_t buffer_len,
+		      uint16_t data_len, uint8_t data_flags);
+
+/**
+ * @brief Set data buffer for a resource
+ *
+ * Use this function to set the data buffer and flags for the specified LwM2M
+ * resource.
+ *
+ * @deprecated Use lwm2m_set_res_buf() instead, so you can define buffer size and data size
  *             separately.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
@@ -1704,6 +1724,8 @@ int lwm2m_engine_set_res_data(const char *pathstr, void *data_ptr, uint16_t data
 /**
  * @brief Update data size for a resource
  *
+ * @deprecated Use lwm2m_set_res_data_len() instead.
+ *
  * Use this function to set the new size of data in the buffer if you write
  * to a buffer received by lwm2m_engine_get_res_buf().
  *
@@ -1711,10 +1733,25 @@ int lwm2m_engine_set_res_data(const char *pathstr, void *data_ptr, uint16_t data
  * @param[in] data_len Length of data
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_res_data_len(const char *pathstr, uint16_t data_len);
 
 /**
+ * @brief Update data size for a resource
+ *
+ * Use this function to set the new size of data in the buffer if you write
+ * to a buffer received by lwm2m_engine_get_res_buf().
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] data_len Length of data
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_res_data_len(const struct lwm2m_obj_path *path, uint16_t data_len);
+
+/**
  * @brief Get data buffer for a resource
+ *
+ * @deprecated Use lwm2m_get_res_buf() instead.
  *
  * Use this function to get the data buffer information for the specified LwM2M
  * resource.
@@ -1732,6 +1769,7 @@ int lwm2m_engine_set_res_data_len(const char *pathstr, uint16_t data_len);
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_res_buf(const char *pathstr, void **buffer_ptr, uint16_t *buffer_len,
 			     uint16_t *data_len, uint8_t *data_flags);
 
@@ -1741,7 +1779,29 @@ int lwm2m_engine_get_res_buf(const char *pathstr, void **buffer_ptr, uint16_t *b
  * Use this function to get the data buffer information for the specified LwM2M
  * resource.
  *
- * @deprecated Use lwm2m_engine_get_res_buf() as it can tell you the size of the buffer as well.
+ * If you directly write into the buffer, you must use lwm2m_set_res_data_len()
+ * function to update the new size of the written data.
+ *
+ * All parameters, except for the pathstr, can be NULL if you don't want to read those values.
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] buffer_ptr Data buffer pointer
+ * @param[out] buffer_len Length of buffer
+ * @param[out] data_len Length of existing data in the buffer
+ * @param[out] data_flags Data buffer flags (such as read-only, etc)
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_res_buf(const struct lwm2m_obj_path *path, void **buffer_ptr, uint16_t *buffer_len,
+		      uint16_t *data_len, uint8_t *data_flags);
+
+/**
+ * @brief Get data buffer for a resource
+ *
+ * Use this function to get the data buffer information for the specified LwM2M
+ * resource.
+ *
+ * @deprecated Use lwm2m_get_res_buf() as it can tell you the size of the buffer as well.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] data_ptr Data buffer pointer

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -1403,6 +1403,8 @@ int lwm2m_get_time(const struct lwm2m_obj_path *path, time_t *buf);
 /**
  * @brief Set resource (instance) read callback
  *
+ * @deprecated Use lwm2m_register_read_callback() instead.
+ *
  * LwM2M clients can use this to set the callback function for resource reads when data
  * handling in the LwM2M engine needs to be bypassed.
  * For example reading back opaque binary data from external storage.
@@ -1418,11 +1420,34 @@ int lwm2m_get_time(const struct lwm2m_obj_path *path, time_t *buf);
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_register_read_callback(const char *pathstr,
 					lwm2m_engine_get_data_cb_t cb);
 
 /**
+ * @brief Set resource (instance) read callback
+ *
+ * LwM2M clients can use this to set the callback function for resource reads when data
+ * handling in the LwM2M engine needs to be bypassed.
+ * For example reading back opaque binary data from external storage.
+ *
+ * This callback should not generally be used for any data that might be observed as
+ * engine does not have any knowledge of data changes.
+ *
+ * When separate buffer for data should be used, use lwm2m_engine_set_res_buf() instead
+ * to set the storage.
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] cb Read resource callback
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_register_read_callback(const struct lwm2m_obj_path *path, lwm2m_engine_get_data_cb_t cb);
+
+/**
  * @brief Set resource (instance) pre-write callback
+ *
+ * @deprecated Use lwm2m_register_pre_write_callback() instead.
  *
  * This callback is triggered before setting the value of a resource.  It
  * can pass a special data buffer to the engine so that the actual resource
@@ -1433,11 +1458,29 @@ int lwm2m_engine_register_read_callback(const char *pathstr,
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_register_pre_write_callback(const char *pathstr,
 					     lwm2m_engine_get_data_cb_t cb);
 
 /**
+ * @brief Set resource (instance) pre-write callback
+ *
+ * This callback is triggered before setting the value of a resource.  It
+ * can pass a special data buffer to the engine so that the actual resource
+ * value can be calculated later, etc.
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] cb Pre-write resource callback
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_register_pre_write_callback(const struct lwm2m_obj_path *path,
+				      lwm2m_engine_get_data_cb_t cb);
+
+/**
  * @brief Set resource (instance) validation callback
+ *
+ * @deprecated Use lwm2m_register_validate_callback() instead.
  *
  * This callback is triggered before setting the value of a resource to the
  * resource data buffer.
@@ -1456,11 +1499,37 @@ int lwm2m_engine_register_pre_write_callback(const char *pathstr,
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_register_validate_callback(const char *pathstr,
 					    lwm2m_engine_set_data_cb_t cb);
 
 /**
+ * @brief Set resource (instance) validation callback
+ *
+ * This callback is triggered before setting the value of a resource to the
+ * resource data buffer.
+ *
+ * The callback allows an LwM2M client or object to validate the data before
+ * writing and notify an error if the data should be discarded for any reason
+ * (by returning a negative error code).
+ *
+ * @note All resources that have a validation callback registered are initially
+ *       decoded into a temporary validation buffer. Make sure that
+ *       ``CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE`` is large enough to
+ *       store each of the validated resources (individually).
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] cb Validate resource data callback
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_register_validate_callback(const struct lwm2m_obj_path *path,
+				     lwm2m_engine_set_data_cb_t cb);
+
+/**
  * @brief Set resource (instance) post-write callback
+ *
+ * @deprecated Use lwm2m_register_post_write_callback() instead.
  *
  * This callback is triggered after setting the value of a resource to the
  * resource data buffer.
@@ -1473,11 +1542,31 @@ int lwm2m_engine_register_validate_callback(const char *pathstr,
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_register_post_write_callback(const char *pathstr,
 					      lwm2m_engine_set_data_cb_t cb);
 
 /**
+ * @brief Set resource (instance) post-write callback
+ *
+ * This callback is triggered after setting the value of a resource to the
+ * resource data buffer.
+ *
+ * It allows an LwM2M client or object to post-process the value of a resource
+ * or trigger other related resource calculations.
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] cb Post-write resource callback
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_register_post_write_callback(const struct lwm2m_obj_path *path,
+				       lwm2m_engine_set_data_cb_t cb);
+
+/**
  * @brief Set resource execute event callback
+ *
+ * @deprecated Use lwm2m_register_exec_callback() instead.
  *
  * This event is triggered when the execute method of a resource is enabled.
  *
@@ -1486,8 +1575,37 @@ int lwm2m_engine_register_post_write_callback(const char *pathstr,
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_register_exec_callback(const char *pathstr,
 					lwm2m_engine_execute_cb_t cb);
+
+/**
+ * @brief Set resource execute event callback
+ *
+ * This event is triggered when the execute method of a resource is enabled.
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] cb Execute resource callback
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_register_exec_callback(const struct lwm2m_obj_path *path, lwm2m_engine_execute_cb_t cb);
+
+/**
+ * @brief Set object instance create event callback
+ *
+ * @deprecated Use lwm2m_register_create_callback instead.
+ *
+ * This event is triggered when an object instance is created.
+ *
+ * @param[in] obj_id LwM2M object id
+ * @param[in] cb Create object instance callback
+ *
+ * @return 0 for success or negative in case of error.
+ */
+__deprecated
+int lwm2m_engine_register_create_callback(uint16_t obj_id,
+					  lwm2m_engine_user_cb_t cb);
 
 /**
  * @brief Set object instance create event callback
@@ -1499,7 +1617,23 @@ int lwm2m_engine_register_exec_callback(const char *pathstr,
  *
  * @return 0 for success or negative in case of error.
  */
-int lwm2m_engine_register_create_callback(uint16_t obj_id,
+int lwm2m_register_create_callback(uint16_t obj_id,
+				   lwm2m_engine_user_cb_t cb);
+
+/**
+ * @brief Set object instance delete event callback
+ *
+ * @deprecated Use lwm2m_register_delete_callback instead
+ *
+ * This event is triggered when an object instance is deleted.
+ *
+ * @param[in] obj_id LwM2M object id
+ * @param[in] cb Delete object instance callback
+ *
+ * @return 0 for success or negative in case of error.
+ */
+__deprecated
+int lwm2m_engine_register_delete_callback(uint16_t obj_id,
 					  lwm2m_engine_user_cb_t cb);
 
 /**
@@ -1512,7 +1646,7 @@ int lwm2m_engine_register_create_callback(uint16_t obj_id,
  *
  * @return 0 for success or negative in case of error.
  */
-int lwm2m_engine_register_delete_callback(uint16_t obj_id,
+int lwm2m_register_delete_callback(uint16_t obj_id,
 					  lwm2m_engine_user_cb_t cb);
 
 /**

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -683,146 +683,331 @@ void lwm2m_registry_unlock(void);
 /**
  * @brief Set resource (instance) value (opaque buffer)
  *
+ * @deprecated Use lwm2m_set_opaque() instead.
+ *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] data_ptr Data buffer
  * @param[in] data_len Length of buffer
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_opaque(const char *pathstr, const char *data_ptr, uint16_t data_len);
 
 /**
+ * @brief Set resource (instance) value (opaque buffer)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] data_ptr Data buffer
+ * @param[in] data_len Length of buffer
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_opaque(const struct lwm2m_obj_path *path, const char *data_ptr, uint16_t data_len);
+
+/**
  * @brief Set resource (instance) value (string)
+ *
+ * @deprecated Use lwm2m_set_string() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] data_ptr NULL terminated char buffer
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_string(const char *pathstr, const char *data_ptr);
 
 /**
+ * @brief Set resource (instance) value (string)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] data_ptr NULL terminated char buffer
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_string(const struct lwm2m_obj_path *path, const char *data_ptr);
+
+/**
  * @brief Set resource (instance) value (u8)
+ *
+ * @deprecated Use lwm2m_set_u8() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] value u8 value
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_u8(const char *pathstr, uint8_t value);
 
 /**
+ * @brief Set resource (instance) value (u8)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] value u8 value
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_u8(const struct lwm2m_obj_path *path, uint8_t value);
+
+/**
  * @brief Set resource (instance) value (u16)
+ *
+ * @deprecated Use lwm2m_set_u16() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] value u16 value
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_u16(const char *pathstr, uint16_t value);
 
 /**
+ * @brief Set resource (instance) value (u16)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] value u16 value
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_u16(const struct lwm2m_obj_path *path, uint16_t value);
+
+/**
  * @brief Set resource (instance) value (u32)
+ *
+ * @deprecated Use lwm2m_set_u32() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] value u32 value
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_u32(const char *pathstr, uint32_t value);
 
 /**
+ * @brief Set resource (instance) value (u32)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] value u32 value
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_u32(const struct lwm2m_obj_path *path, uint32_t value);
+
+/**
  * @brief Set resource (instance) value (u64)
+ *
+ * @deprecated Use lwm2m_set_u64() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] value u64 value
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_u64(const char *pathstr, uint64_t value);
 
 /**
+ * @brief Set resource (instance) value (u64)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] value u64 value
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_u64(const struct lwm2m_obj_path *path, uint64_t value);
+
+/**
  * @brief Set resource (instance) value (s8)
+ *
+ * @deprecated Use lwm2m_set_s8() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] value s8 value
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_s8(const char *pathstr, int8_t value);
 
 /**
+ * @brief Set resource (instance) value (s8)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] value s8 value
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_s8(const struct lwm2m_obj_path *path, int8_t value);
+
+/**
  * @brief Set resource (instance) value (s16)
+ *
+ * @deprecated Use lwm2m_set_s16() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] value s16 value
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_s16(const char *pathstr, int16_t value);
 
 /**
+ * @brief Set resource (instance) value (s16)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] value s16 value
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_s16(const struct lwm2m_obj_path *path, int16_t value);
+
+/**
  * @brief Set resource (instance) value (s32)
+ *
+ * @deprecated Use lwm2m_set_s32() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] value s32 value
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_s32(const char *pathstr, int32_t value);
 
 /**
+ * @brief Set resource (instance) value (s32)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] value s32 value
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_s32(const struct lwm2m_obj_path *path, int32_t value);
+
+/**
  * @brief Set resource (instance) value (s64)
+ *
+ * @deprecated Use lwm2m_set_s64() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] value s64 value
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_s64(const char *pathstr, int64_t value);
 
 /**
+ * @brief Set resource (instance) value (s64)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] value s64 value
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_s64(const struct lwm2m_obj_path *path, int64_t value);
+
+/**
  * @brief Set resource (instance) value (bool)
+ *
+ * @deprecated Use lwm2m_set_bool() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] value bool value
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_bool(const char *pathstr, bool value);
 
 /**
+ * @brief Set resource (instance) value (bool)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] value bool value
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_bool(const struct lwm2m_obj_path *path, bool value);
+
+/**
  * @brief Set resource (instance) value (double)
+ *
+ * @deprecated Use lwm2m_set_f64() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] value double value
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_float(const char *pathstr, const double *value);
 
 /**
+ * @brief Set resource (instance) value (double)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] value double value
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_f64(const struct lwm2m_obj_path *path, const double value);
+
+/**
  * @brief Set resource (instance) value (ObjLnk)
+ *
+ * @deprecated Use lwm2m_set_objlnk() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] value pointer to the lwm2m_objlnk structure
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_objlnk(const char *pathstr, const struct lwm2m_objlnk *value);
 
 /**
+ * @brief Set resource (instance) value (ObjLnk)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] value pointer to the lwm2m_objlnk structure
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_objlnk(const struct lwm2m_obj_path *path, const struct lwm2m_objlnk *value);
+
+/**
  * @brief Set resource (instance) value (Time)
+ *
+ * @deprecated Use lwm2m_set_time() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] value Epoch timestamp
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_time(const char *pathstr, time_t value);
 
 /**
+ * @brief Set resource (instance) value (Time)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[in] value Epoch timestamp
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_set_time(const struct lwm2m_obj_path *path, time_t value);
+
+/**
  * @brief Get resource (instance) value (opaque buffer)
+ *
+ * @deprecated Use lwm2m_get_opaque() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] buf Data buffer to copy data into
@@ -830,10 +1015,24 @@ int lwm2m_engine_set_time(const char *pathstr, time_t value);
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_opaque(const char *pathstr, void *buf, uint16_t buflen);
 
 /**
+ * @brief Get resource (instance) value (opaque buffer)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] buf Data buffer to copy data into
+ * @param[in] buflen Length of buffer
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_opaque(const struct lwm2m_obj_path *path, void *buf, uint16_t buflen);
+
+/**
  * @brief Get resource (instance) value (string)
+ *
+ * @deprecated Use lwm2m_get_string() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] str String buffer to copy data into
@@ -841,128 +1040,295 @@ int lwm2m_engine_get_opaque(const char *pathstr, void *buf, uint16_t buflen);
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_string(const char *pathstr, void *str, uint16_t strlen);
 
 /**
+ * @brief Get resource (instance) value (string)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] str String buffer to copy data into
+ * @param[in] strlen Length of buffer
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_string(const struct lwm2m_obj_path *path, void *str, uint16_t strlen);
+
+/**
  * @brief Get resource (instance) value (u8)
+ *
+ * @deprecated Use lwm2m_get_u8() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] value u8 buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_u8(const char *pathstr, uint8_t *value);
 
 /**
+ * @brief Get resource (instance) value (u8)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] value u8 buffer to copy data into
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_u8(const struct lwm2m_obj_path *path, uint8_t *value);
+
+/**
  * @brief Get resource (instance) value (u16)
+ *
+ * @deprecated Use lwm2m_get_u16() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] value u16 buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_u16(const char *pathstr, uint16_t *value);
 
 /**
+ * @brief Get resource (instance) value (u16)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] value u16 buffer to copy data into
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_u16(const struct lwm2m_obj_path *path, uint16_t *value);
+
+/**
  * @brief Get resource (instance) value (u32)
+ *
+ * @deprecated Use lwm2m_get_u32() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] value u32 buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_u32(const char *pathstr, uint32_t *value);
 
 /**
+ * @brief Get resource (instance) value (u32)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] value u32 buffer to copy data into
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_u32(const struct lwm2m_obj_path *path, uint32_t *value);
+
+/**
  * @brief Get resource (instance) value (u64)
+ *
+ * @deprecated Use lwm2m_get_u64() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] value u64 buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_u64(const char *pathstr, uint64_t *value);
 
 /**
+ * @brief Get resource (instance) value (u64)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] value u64 buffer to copy data into
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_u64(const struct lwm2m_obj_path *path, uint64_t *value);
+
+/**
  * @brief Get resource (instance) value (s8)
+ *
+ * @deprecated Use lwm2m_get_s8() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] value s8 buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_s8(const char *pathstr, int8_t *value);
 
 /**
+ * @brief Get resource (instance) value (s8)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] value s8 buffer to copy data into
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_s8(const struct lwm2m_obj_path *path, int8_t *value);
+
+/**
  * @brief Get resource (instance) value (s16)
+ *
+ * @deprecated Use lwm2m_get_s16() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] value s16 buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_s16(const char *pathstr, int16_t *value);
 
 /**
+ * @brief Get resource (instance) value (s16)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] value s16 buffer to copy data into
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_s16(const struct lwm2m_obj_path *path, int16_t *value);
+
+/**
  * @brief Get resource (instance) value (s32)
+ *
+ * @deprecated Use lwm2m_get_s32() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] value s32 buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_s32(const char *pathstr, int32_t *value);
 
 /**
+ * @brief Get resource (instance) value (s32)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] value s32 buffer to copy data into
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_s32(const struct lwm2m_obj_path *path, int32_t *value);
+
+/**
  * @brief Get resource (instance) value (s64)
+ *
+ * @deprecated Use lwm2m_get_s64() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] value s64 buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_s64(const char *pathstr, int64_t *value);
 
 /**
+ * @brief Get resource (instance) value (s64)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] value s64 buffer to copy data into
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_s64(const struct lwm2m_obj_path *path, int64_t *value);
+
+/**
  * @brief Get resource (instance) value (bool)
+ *
+ * @deprecated Use lwm2m_get_bool() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] value bool buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_bool(const char *pathstr, bool *value);
 
 /**
+ * @brief Get resource (instance) value (bool)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] value bool buffer to copy data into
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_bool(const struct lwm2m_obj_path *path, bool *value);
+
+/**
  * @brief Get resource (instance) value (double)
+ *
+ * @deprecated Use lwm2m_get_f64() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] buf double buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_float(const char *pathstr, double *buf);
 
 /**
+ * @brief Get resource (instance) value (double)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] value double buffer to copy data into
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_f64(const struct lwm2m_obj_path *path, double *value);
+
+/**
  * @brief Get resource (instance) value (ObjLnk)
+ *
+ * @deprecated Use lwm2m_get_objlnk() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] buf lwm2m_objlnk buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_objlnk(const char *pathstr, struct lwm2m_objlnk *buf);
 
 /**
+ * @brief Get resource (instance) value (ObjLnk)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] buf lwm2m_objlnk buffer to copy data into
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_objlnk(const struct lwm2m_obj_path *path, struct lwm2m_objlnk *buf);
+
+/**
  * @brief Get resource (instance) value (Time)
+ *
+ * @deprecated Use lwm2m_get_time() instead.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] buf time_t pointer to copy data
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_get_time(const char *pathstr, time_t *buf);
 
+/**
+ * @brief Get resource (instance) value (Time)
+ *
+ * @param[in] path LwM2M path as a struct
+ * @param[out] buf time_t pointer to copy data
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_time(const struct lwm2m_obj_path *path, time_t *buf);
 
 /**
  * @brief Set resource (instance) read callback

--- a/samples/net/lwm2m_client/src/firmware_update.c
+++ b/samples/net/lwm2m_client/src/firmware_update.c
@@ -26,8 +26,8 @@ static int firmware_update_cb(uint16_t obj_inst_id,
 	/* If success, set the update result as RESULT_SUCCESS.
 	 * In reality, it should be set at function lwm2m_setup()
 	 */
-	lwm2m_engine_set_u8("5/0/3", STATE_IDLE);
-	lwm2m_engine_set_u8("5/0/5", RESULT_SUCCESS);
+	lwm2m_set_u8(&LWM2M_OBJ(5, 0, 3), STATE_IDLE);
+	lwm2m_set_u8(&LWM2M_OBJ(5, 0, 5), RESULT_SUCCESS);
 	return 0;
 }
 
@@ -51,12 +51,12 @@ static int firmware_block_received_cb(uint16_t obj_inst_id,
 void init_firmware_update(void)
 {
 	/* setup data buffer for block-wise transfer */
-	lwm2m_engine_register_pre_write_callback("5/0/0", firmware_get_buf);
+	lwm2m_register_pre_write_callback(&LWM2M_OBJ(5, 0, 0), firmware_get_buf);
 	lwm2m_firmware_set_write_cb(firmware_block_received_cb);
 
 	if (IS_ENABLED(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT)) {
-		lwm2m_engine_create_res_inst("5/0/8/0");
-		lwm2m_engine_set_res_buf("5/0/8/0", &supported_protocol[0],
+		lwm2m_create_res_inst(&LWM2M_OBJ(5, 0, 8, 0));
+		lwm2m_set_res_buf(&LWM2M_OBJ(5, 0, 8, 0), &supported_protocol[0],
 					 sizeof(supported_protocol[0]),
 					 sizeof(supported_protocol[0]), 0);
 

--- a/samples/net/lwm2m_client/src/led.c
+++ b/samples/net/lwm2m_client/src/led.c
@@ -43,7 +43,7 @@ static int led_on_off_cb(uint16_t obj_inst_id, uint16_t res_id, uint16_t res_ins
 
 		led_state = led_val;
 		/* TODO: Move to be set by an internal post write function */
-		lwm2m_engine_set_s32("3311/0/5852", 0);
+		lwm2m_set_s32(&LWM2M_OBJ(3311, 0, 5852), 0);
 	}
 
 	return ret;
@@ -62,10 +62,10 @@ int init_led_device(void)
 		return ret;
 	}
 
-	lwm2m_engine_create_obj_inst("3311/0");
-	lwm2m_engine_register_post_write_callback("3311/0/5850", led_on_off_cb);
-	lwm2m_engine_set_res_buf("3311/0/5750", LIGHT_NAME, sizeof(LIGHT_NAME), sizeof(LIGHT_NAME),
-				 LWM2M_RES_DATA_FLAG_RO);
+	lwm2m_create_object_inst(&LWM2M_OBJ(3311, 0));
+	lwm2m_register_post_write_callback(&LWM2M_OBJ(3311, 0, 5850), led_on_off_cb);
+	lwm2m_set_res_buf(&LWM2M_OBJ(3311, 0, 5750), LIGHT_NAME, sizeof(LIGHT_NAME),
+			  sizeof(LIGHT_NAME), LWM2M_RES_DATA_FLAG_RO);
 
 	return 0;
 }

--- a/samples/net/lwm2m_client/src/temperature.c
+++ b/samples/net/lwm2m_client/src/temperature.c
@@ -45,7 +45,7 @@ static void temp_work_cb(struct k_work *work)
 		v = 20.0 + (double)sys_rand32_get() / UINT32_MAX * 5.0;
 	}
 
-	lwm2m_engine_set_float("3303/0/5700", &v);
+	lwm2m_set_f64(&LWM2M_OBJ(3303, 0, 5700), v);
 
 out:
 	k_work_schedule(&temp_work, PERIOD);
@@ -53,7 +53,7 @@ out:
 
 void init_temp_sensor(void)
 {
-	if (lwm2m_engine_create_obj_inst("3303/0") == 0) {
+	if (lwm2m_create_object_inst(&LWM2M_OBJ(3303, 0)) == 0) {
 		k_work_init_delayable(&temp_work, temp_work_cb);
 		k_work_schedule(&temp_work, K_NO_WAIT);
 	}

--- a/samples/net/lwm2m_client/src/timer.c
+++ b/samples/net/lwm2m_client/src/timer.c
@@ -49,9 +49,9 @@ static int timer_digital_state_cb(uint16_t obj_inst_id, uint16_t res_id, uint16_
 
 void init_timer_object(void)
 {
-	lwm2m_engine_create_obj_inst("3340/0");
-	lwm2m_engine_register_validate_callback("3340/0/5850", timer_on_off_validate_cb);
-	lwm2m_engine_register_post_write_callback("3340/0/5543", timer_digital_state_cb);
-	lwm2m_engine_set_res_buf("3340/0/5750", TIMER_NAME, sizeof(TIMER_NAME), sizeof(TIMER_NAME),
-				 LWM2M_RES_DATA_FLAG_RO);
+	lwm2m_create_object_inst(&LWM2M_OBJ(3340, 0));
+	lwm2m_register_validate_callback(&LWM2M_OBJ(3340, 0, 5850), timer_on_off_validate_cb);
+	lwm2m_register_post_write_callback(&LWM2M_OBJ(3340, 0, 5543), timer_digital_state_cb);
+	lwm2m_set_res_buf(&LWM2M_OBJ(3340, 0, 5750), TIMER_NAME, sizeof(TIMER_NAME),
+			  sizeof(TIMER_NAME), LWM2M_RES_DATA_FLAG_RO);
 }

--- a/subsys/net/lib/lwm2m/ipso_buzzer.c
+++ b/subsys/net/lib/lwm2m/ipso_buzzer.c
@@ -100,7 +100,8 @@ static int get_buzzer_index(uint16_t obj_inst_id)
 static int start_buzzer(struct ipso_buzzer_data *buzzer)
 {
 	uint32_t temp = 0U;
-	char path[MAX_RESOURCE_LEN];
+	struct lwm2m_obj_path path = LWM2M_OBJ(IPSO_OBJECT_BUZZER_ID, buzzer->obj_inst_id,
+					       DIGITAL_INPUT_STATE_RID);
 
 	/* make sure buzzer is currently not active */
 	if (buzzer->active) {
@@ -116,9 +117,7 @@ static int start_buzzer(struct ipso_buzzer_data *buzzer)
 	/* TODO: check delay_duration > 0 */
 
 	buzzer->trigger_offset = k_uptime_get();
-	snprintk(path, MAX_RESOURCE_LEN, "%d/%u/%d", IPSO_OBJECT_BUZZER_ID,
-		 buzzer->obj_inst_id, DIGITAL_INPUT_STATE_RID);
-	lwm2m_engine_set_bool(path, true);
+	lwm2m_set_bool(&path, true);
 
 	temp = (uint32_t)(buzzer->delay_duration * MSEC_PER_SEC);
 	k_work_reschedule(&buzzer->buzzer_work, K_MSEC(temp));
@@ -128,16 +127,15 @@ static int start_buzzer(struct ipso_buzzer_data *buzzer)
 
 static int stop_buzzer(struct ipso_buzzer_data *buzzer, bool cancel)
 {
-	char path[MAX_RESOURCE_LEN];
+	struct lwm2m_obj_path path = LWM2M_OBJ(IPSO_OBJECT_BUZZER_ID, buzzer->obj_inst_id,
+					       DIGITAL_INPUT_STATE_RID);
 
 	/* make sure buzzer is currently active */
 	if (!buzzer->active) {
 		return -EINVAL;
 	}
 
-	snprintk(path, MAX_RESOURCE_LEN, "%d/%u/%d", IPSO_OBJECT_BUZZER_ID,
-		 buzzer->obj_inst_id, DIGITAL_INPUT_STATE_RID);
-	lwm2m_engine_set_bool(path, false);
+	lwm2m_set_bool(&path, false);
 
 	if (cancel) {
 		k_work_cancel_delayable(&buzzer->buzzer_work);

--- a/subsys/net/lib/lwm2m/ipso_push_button.c
+++ b/subsys/net/lib/lwm2m/ipso_push_button.c
@@ -88,7 +88,6 @@ static int state_post_write_cb(uint16_t obj_inst_id,
 			       bool last_block, size_t total_size)
 {
 	int i;
-	char path[MAX_RESOURCE_LEN];
 
 	i = get_button_index(obj_inst_id);
 	if (i < 0) {
@@ -98,17 +97,16 @@ static int state_post_write_cb(uint16_t obj_inst_id,
 	if (button_data[i].state && !button_data[i].last_state) {
 		/* off to on transition, increment the counter */
 		int64_t counter = button_data[i].counter + 1;
+		struct lwm2m_obj_path path = LWM2M_OBJ(IPSO_OBJECT_PUSH_BUTTON_ID, obj_inst_id,
+						       DIGITAL_INPUT_COUNTER_RID);
 
 		if (counter < 0) {
 			counter = 0;
 		}
 
-		snprintk(path, sizeof(path), "%u/%u/%u",
-			 IPSO_OBJECT_PUSH_BUTTON_ID, obj_inst_id,
-			 DIGITAL_INPUT_COUNTER_RID);
-
-		if (lwm2m_engine_set_s64(path, counter) < 0) {
-			LOG_ERR("Failed to increment counter resource %s", path);
+		if (lwm2m_set_s64(&path, counter) < 0) {
+			LOG_ERR("Failed to increment counter resource %d/%d/%d", path.obj_id,
+				path.obj_inst_id, path.res_id);
 		}
 	}
 

--- a/subsys/net/lib/lwm2m/ipso_timer.c
+++ b/subsys/net/lib/lwm2m/ipso_timer.c
@@ -104,7 +104,8 @@ static int get_timer_index(uint16_t obj_inst_id)
 static int start_timer(struct ipso_timer_data *timer)
 {
 	uint32_t temp = 0U;
-	char path[MAX_RESOURCE_LEN];
+	struct lwm2m_obj_path path = LWM2M_OBJ(IPSO_OBJECT_TIMER_ID, timer->obj_inst_id,
+					       DIGITAL_STATE_RID);
 
 	/* make sure timer is enabled and not already active */
 	if (timer->timer_mode == TIMER_MODE_OFF || timer->active ||
@@ -123,9 +124,7 @@ static int start_timer(struct ipso_timer_data *timer)
 	timer->trigger_offset = k_uptime_get();
 	timer->trigger_counter += 1U;
 
-	snprintk(path, MAX_RESOURCE_LEN, "%d/%u/%d", IPSO_OBJECT_TIMER_ID,
-		 timer->obj_inst_id, DIGITAL_STATE_RID);
-	lwm2m_engine_set_bool(path, true);
+	lwm2m_set_bool(&path, true);
 
 	temp = timer->delay_duration * MSEC_PER_SEC;
 	k_work_reschedule(&timer->timer_work, K_MSEC(temp));
@@ -135,7 +134,8 @@ static int start_timer(struct ipso_timer_data *timer)
 
 static int stop_timer(struct ipso_timer_data *timer, bool cancel)
 {
-	char path[MAX_RESOURCE_LEN];
+	struct lwm2m_obj_path path = LWM2M_OBJ(IPSO_OBJECT_TIMER_ID, timer->obj_inst_id,
+					       DIGITAL_STATE_RID);
 
 	/* make sure timer is active */
 	if (!timer->active) {
@@ -143,9 +143,7 @@ static int stop_timer(struct ipso_timer_data *timer, bool cancel)
 	}
 
 	timer->cumulative_time_ms += k_uptime_get() - timer->trigger_offset;
-	snprintk(path, MAX_RESOURCE_LEN, "%d/%u/%d", IPSO_OBJECT_TIMER_ID,
-		 timer->obj_inst_id, DIGITAL_STATE_RID);
-	lwm2m_engine_set_bool(path, false);
+	lwm2m_set_bool(&path, false);
 
 	if (cancel) {
 		k_work_cancel_delayable(&timer->timer_work);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -317,14 +317,12 @@ int lwm2m_engine_validate_write_access(struct lwm2m_message *msg,
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
 static bool bootstrap_delete_allowed(int obj_id, int obj_inst_id)
 {
-	char pathstr[MAX_RESOURCE_LEN];
 	bool bootstrap_server;
 	int ret;
 
 	if (obj_id == LWM2M_OBJECT_SECURITY_ID) {
-		snprintk(pathstr, sizeof(pathstr), "%d/%d/1", LWM2M_OBJECT_SECURITY_ID,
-			 obj_inst_id);
-		ret = lwm2m_engine_get_bool(pathstr, &bootstrap_server);
+		ret = lwm2m_get_bool(&LWM2M_OBJ(LWM2M_OBJECT_SECURITY_ID, obj_inst_id, 1),
+					    &bootstrap_server);
 		if (ret < 0) {
 			return false;
 		}
@@ -787,16 +785,15 @@ static int load_tls_credential(struct lwm2m_ctx *client_ctx, uint16_t res_id,
 	void *cred = NULL;
 	uint16_t cred_len;
 	uint8_t cred_flags;
-	char pathstr[MAX_RESOURCE_LEN];
 
 	/* ignore error value */
 	tls_credential_delete(client_ctx->tls_tag, type);
 
-	snprintk(pathstr, sizeof(pathstr), "0/%d/%u", client_ctx->sec_obj_inst, res_id);
-
-	ret = lwm2m_engine_get_res_buf(pathstr, &cred, NULL, &cred_len, &cred_flags);
+	ret = lwm2m_get_res_buf(&LWM2M_OBJ(0, client_ctx->sec_obj_inst, res_id), &cred, NULL,
+				&cred_len, &cred_flags);
 	if (ret < 0) {
-		LOG_ERR("Unable to get resource data for '%s'", pathstr);
+		LOG_ERR("Unable to get resource data for %d/%d/%d", 0,  client_ctx->sec_obj_inst,
+			res_id);
 		return ret;
 	}
 
@@ -957,15 +954,14 @@ int lwm2m_engine_stop(struct lwm2m_ctx *client_ctx)
 
 int lwm2m_engine_start(struct lwm2m_ctx *client_ctx)
 {
-	char pathstr[MAX_RESOURCE_LEN];
 	char *url;
 	uint16_t url_len;
 	uint8_t url_data_flags;
 	int ret = 0U;
 
 	/* get the server URL */
-	snprintk(pathstr, sizeof(pathstr), "0/%d/0", client_ctx->sec_obj_inst);
-	ret = lwm2m_engine_get_res_buf(pathstr, (void **)&url, NULL, &url_len, &url_data_flags);
+	ret = lwm2m_get_res_buf(&LWM2M_OBJ(0, client_ctx->sec_obj_inst, 0), (void **)&url, NULL,
+				&url_len, &url_data_flags);
 	if (ret < 0) {
 		return ret;
 	}

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -803,7 +803,7 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst, struct lwm2m_eng
 				*(uint32_t *)write_buf = (uint32_t)temp_time;
 				len = sizeof(uint32_t);
 			} else {
-				LOG_ERR("Time resource buf len not supported %d", write_buf_len);
+				LOG_ERR("Time resource buf len not supported %zu", write_buf_len);
 				ret = -EINVAL;
 			}
 
@@ -988,7 +988,7 @@ static int lwm2m_read_resource_data(struct lwm2m_message *msg, void *data_ptr, s
 			ret = engine_put_time(&msg->out, &msg->path,
 					      (time_t) *((uint32_t *)data_ptr));
 		} else {
-			LOG_ERR("Resource time length not supported %d", data_len);
+			LOG_ERR("Resource time length not supported %zu", data_len);
 			ret = -EINVAL;
 		}
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -97,25 +97,23 @@ uint8_t lwm2m_firmware_get_update_state(void)
 void lwm2m_firmware_set_update_state_inst(uint16_t obj_inst_id, uint8_t state)
 {
 	bool error = false;
-	char path[LWM2M_MAX_PATH_STR_SIZE];
-
-	snprintk(path, sizeof(path), "%" PRIu16 "/%" PRIu16 "/%" PRIu16,
-		LWM2M_OBJECT_FIRMWARE_ID, obj_inst_id, FIRMWARE_UPDATE_RESULT_ID);
+	struct lwm2m_obj_path path = LWM2M_OBJ(LWM2M_OBJECT_FIRMWARE_ID, obj_inst_id,
+					       FIRMWARE_UPDATE_RESULT_ID);
 
 	/* Check LWM2M SPEC appendix E.6.1 */
 	switch (state) {
 	case STATE_DOWNLOADING:
 		if (update_state[obj_inst_id] == STATE_IDLE) {
-			lwm2m_engine_set_u8(path, RESULT_DEFAULT);
+			lwm2m_set_u8(&path, RESULT_DEFAULT);
 		} else {
 			error = true;
 		}
 		break;
 	case STATE_DOWNLOADED:
 		if (update_state[obj_inst_id] == STATE_DOWNLOADING) {
-			lwm2m_engine_set_u8(path, RESULT_DEFAULT);
+			lwm2m_set_u8(&path, RESULT_DEFAULT);
 		} else if (update_state[obj_inst_id] == STATE_UPDATING) {
-			lwm2m_engine_set_u8(path, RESULT_UPDATE_FAILED);
+			lwm2m_set_u8(&path, RESULT_UPDATE_FAILED);
 		} else {
 			error = true;
 		}
@@ -137,10 +135,9 @@ void lwm2m_firmware_set_update_state_inst(uint16_t obj_inst_id, uint8_t state)
 			update_state[obj_inst_id], state);
 	}
 
-	snprintk(path, sizeof(path), "%" PRIu16 "/%" PRIu16 "/%" PRIu16,
-		 LWM2M_OBJECT_FIRMWARE_ID, obj_inst_id, FIRMWARE_STATE_ID);
+	path.res_id = FIRMWARE_STATE_ID;
 
-	lwm2m_engine_set_u8(path, state);
+	lwm2m_set_u8(&path, state);
 
 	LOG_DBG("Update state = %d", state);
 }
@@ -164,7 +161,8 @@ void lwm2m_firmware_set_update_result_inst(uint16_t obj_inst_id, uint8_t result)
 {
 	uint8_t state;
 	bool error = false;
-	char path[LWM2M_MAX_PATH_STR_SIZE];
+	struct lwm2m_obj_path path = LWM2M_OBJ(LWM2M_OBJECT_FIRMWARE_ID, obj_inst_id,
+					       FIRMWARE_UPDATE_RESULT_ID);
 
 	/* Check LWM2M SPEC appendix E.6.1 */
 	switch (result) {
@@ -220,10 +218,7 @@ void lwm2m_firmware_set_update_result_inst(uint16_t obj_inst_id, uint8_t result)
 			result, state);
 	}
 
-	snprintk(path, sizeof(path), "%" PRIu16 "/%" PRIu16 "/%" PRIu16,
-		 LWM2M_OBJECT_FIRMWARE_ID, obj_inst_id, FIRMWARE_UPDATE_RESULT_ID);
-
-	lwm2m_engine_set_u8(path, result);
+	lwm2m_set_u8(&path, result);
 
 	LOG_DBG("Update result = %d", result);
 }

--- a/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
@@ -205,11 +205,11 @@ static void *callback_read_not_defined(uint16_t obj_inst_id, uint16_t res_id, ui
 static void set_sw_update_state(struct lwm2m_swmgmt_data *instance, uint8_t state)
 {
 	int ret;
-	char obj_path[LWM2M_MAX_PATH_STR_SIZE];
+	struct lwm2m_obj_path obj_path = LWM2M_OBJ(LWM2M_OBJECT_SOFTWARE_MANAGEMENT_ID,
+						   instance->obj_inst_id,
+						   SWMGMT_UPDATE_STATE_ID);
 
-	(void)snprintk(obj_path, sizeof(obj_path), "%d/%d/%d", LWM2M_OBJECT_SOFTWARE_MANAGEMENT_ID,
-		       instance->obj_inst_id, SWMGMT_UPDATE_STATE_ID);
-	ret = lwm2m_engine_set_u8(obj_path, state);
+	ret = lwm2m_set_u8(obj_path, state);
 	if (ret != 0) {
 		LOG_ERR("Could not set state");
 	}
@@ -218,11 +218,11 @@ static void set_sw_update_state(struct lwm2m_swmgmt_data *instance, uint8_t stat
 static void set_sw_update_result(struct lwm2m_swmgmt_data *instance, uint8_t result)
 {
 	int ret;
-	char obj_path[LWM2M_MAX_PATH_STR_SIZE];
+	struct lwm2m_obj_path obj_path = LWM2M_OBJ(LWM2M_OBJECT_SOFTWARE_MANAGEMENT_ID,
+						   instance->obj_inst_id,
+						   SWMGMT_UPDATE_RESULT_ID);
 
-	(void)snprintk(obj_path, sizeof(obj_path), "%d/%d/%d", LWM2M_OBJECT_SOFTWARE_MANAGEMENT_ID,
-		       instance->obj_inst_id, SWMGMT_UPDATE_RESULT_ID);
-	ret = lwm2m_engine_set_u8(obj_path, result);
+	ret = lwm2m_set_u8(&obj_path, result);
 	if (ret != 0) {
 		LOG_ERR("Could not set result");
 	}
@@ -231,11 +231,11 @@ static void set_sw_update_result(struct lwm2m_swmgmt_data *instance, uint8_t res
 static void set_sw_update_act_state(struct lwm2m_swmgmt_data *instance, bool state)
 {
 	int ret;
-	char obj_path[LWM2M_MAX_PATH_STR_SIZE];
+	struct lwm2m_obj_path obj_path = LWM2M_OBJ(LWM2M_OBJECT_SOFTWARE_MANAGEMENT_ID,
+						   instance->obj_inst_id,
+						   SWMGMT_ACTIVATION_UPD_STATE_ID);
 
-	(void)snprintk(obj_path, sizeof(obj_path), "%d/%d/%d", LWM2M_OBJECT_SOFTWARE_MANAGEMENT_ID,
-		       instance->obj_inst_id, SWMGMT_ACTIVATION_UPD_STATE_ID);
-	ret = lwm2m_engine_set_bool(obj_path, state);
+	ret = lwm2m_set_bool(&obj_path, state);
 	if (ret != 0) {
 		LOG_ERR("Could not set activation state");
 	}

--- a/subsys/net/lib/lwm2m/lwm2m_observation.c
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.c
@@ -1501,7 +1501,7 @@ void lwm2m_engine_path_list_init(sys_slist_t *lwm2m_path_list, sys_slist_t *lwm2
 }
 
 int lwm2m_engine_add_path_to_list(sys_slist_t *lwm2m_path_list, sys_slist_t *lwm2m_free_list,
-				  struct lwm2m_obj_path *path)
+				  const struct lwm2m_obj_path *path)
 {
 	struct lwm2m_obj_path_list *prev = NULL;
 	struct lwm2m_obj_path_list *entry;

--- a/subsys/net/lib/lwm2m/lwm2m_observation.c
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.c
@@ -199,7 +199,7 @@ int lwm2m_notify_observer(uint16_t obj_id, uint16_t obj_inst_id, uint16_t res_id
 	return lwm2m_notify_observer_path(&path);
 }
 
-static int engine_observe_get_attributes(struct lwm2m_obj_path *path,
+static int engine_observe_get_attributes(const struct lwm2m_obj_path *path,
 					 struct notification_attrs *attrs, uint16_t srv_obj_inst)
 {
 	struct lwm2m_engine_obj *obj;
@@ -905,7 +905,7 @@ const char *lwm2m_engine_get_attr_name(const struct lwm2m_attr *attr)
 }
 
 static int lwm2m_engine_observer_timestamp_update(sys_slist_t *observer,
-						  struct lwm2m_obj_path *path,
+						  const struct lwm2m_obj_path *path,
 						  uint16_t srv_obj_inst)
 {
 	struct observe_node *obs;
@@ -947,7 +947,7 @@ static int lwm2m_engine_observer_timestamp_update(sys_slist_t *observer,
 
 /* input / output selection */
 
-int lwm2m_get_path_reference_ptr(struct lwm2m_engine_obj *obj, struct lwm2m_obj_path *path,
+int lwm2m_get_path_reference_ptr(struct lwm2m_engine_obj *obj, const struct lwm2m_obj_path *path,
 				 void **ref)
 {
 	struct lwm2m_engine_obj_inst *obj_inst;
@@ -997,22 +997,16 @@ int lwm2m_get_path_reference_ptr(struct lwm2m_engine_obj *obj, struct lwm2m_obj_
 	return 0;
 }
 
-int lwm2m_engine_update_observer_min_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
-					    uint32_t period_s)
+int lwm2m_update_observer_min_period(struct lwm2m_ctx *client_ctx,
+				     const struct lwm2m_obj_path *path, uint32_t period_s)
 {
 	int ret;
-	struct lwm2m_obj_path path;
 	struct notification_attrs nattrs = {0};
 	struct notification_attrs attrs = {0};
 	void *ref;
 
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
 	/* Read Reference pointer to attribute */
-	ret = lwm2m_get_path_reference_ptr(NULL, &path, &ref);
+	ret = lwm2m_get_path_reference_ptr(NULL, path, &ref);
 	if (ret < 0) {
 		return ret;
 	}
@@ -1028,7 +1022,7 @@ int lwm2m_engine_update_observer_min_period(struct lwm2m_ctx *client_ctx, const 
 	}
 
 	/* Read Pmin & Pmax values for path */
-	ret = engine_observe_get_attributes(&path, &attrs, client_ctx->srv_obj_inst);
+	ret = engine_observe_get_attributes(path, &attrs, client_ctx->srv_obj_inst);
 	if (ret < 0) {
 		return ret;
 	}
@@ -1041,22 +1035,30 @@ int lwm2m_engine_update_observer_min_period(struct lwm2m_ctx *client_ctx, const 
 	return lwm2m_update_or_allocate_attribute(ref, LWM2M_ATTR_PMIN, &period_s);
 }
 
-int lwm2m_engine_update_observer_max_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
+int lwm2m_engine_update_observer_min_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
 					    uint32_t period_s)
 {
 	int ret;
 	struct lwm2m_obj_path path;
-	void *ref;
-	struct notification_attrs nattrs = {0};
-	struct notification_attrs attrs = {0};
 
 	ret = lwm2m_string_to_path(pathstr, &path, '/');
 	if (ret < 0) {
 		return ret;
 	}
 
+	return lwm2m_update_observer_min_period(client_ctx, &path, period_s);
+}
+
+int lwm2m_update_observer_max_period(struct lwm2m_ctx *client_ctx,
+				     const struct lwm2m_obj_path *path, uint32_t period_s)
+{
+	int ret;
+	void *ref;
+	struct notification_attrs nattrs = {0};
+	struct notification_attrs attrs = {0};
+
 	/* Read Reference pointer to attribute */
-	ret = lwm2m_get_path_reference_ptr(NULL, &path, &ref);
+	ret = lwm2m_get_path_reference_ptr(NULL, path, &ref);
 	if (ret < 0) {
 		return ret;
 	}
@@ -1072,7 +1074,7 @@ int lwm2m_engine_update_observer_max_period(struct lwm2m_ctx *client_ctx, const 
 	}
 
 	/* Read Pmin & Pmax values for path */
-	ret = engine_observe_get_attributes(&path, &attrs, client_ctx->srv_obj_inst);
+	ret = engine_observe_get_attributes(path, &attrs, client_ctx->srv_obj_inst);
 	if (ret < 0) {
 		return ret;
 	}
@@ -1089,8 +1091,22 @@ int lwm2m_engine_update_observer_max_period(struct lwm2m_ctx *client_ctx, const 
 	}
 
 	/* Update Observer timestamp */
-	return lwm2m_engine_observer_timestamp_update(&client_ctx->observer, &path,
+	return lwm2m_engine_observer_timestamp_update(&client_ctx->observer, path,
 						      client_ctx->srv_obj_inst);
+}
+
+int lwm2m_engine_update_observer_max_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
+					    uint32_t period_s)
+{
+	int ret;
+	struct lwm2m_obj_path path;
+
+	ret = lwm2m_string_to_path(pathstr, &path, '/');
+	if (ret < 0) {
+		return ret;
+	}
+
+	return lwm2m_update_observer_max_period(client_ctx, &path, period_s);
 }
 
 struct lwm2m_attr *lwm2m_engine_get_next_attr(const void *ref, struct lwm2m_attr *prev)
@@ -1348,28 +1364,34 @@ int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj, struct lwm2m_message 
 	return 0;
 }
 
+bool lwm2m_path_is_observed(const struct lwm2m_obj_path *path)
+{
+	int i;
+	struct observe_node *obs;
+	struct lwm2m_ctx **sock_ctx = lwm2m_sock_ctx();
+
+	for (i = 0; i < lwm2m_sock_nfds(); ++i) {
+		SYS_SLIST_FOR_EACH_CONTAINER(&sock_ctx[i]->observer, obs, node) {
+
+			if (lwm2m_notify_observer_list(&obs->path_list, path)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 bool lwm2m_engine_path_is_observed(const char *pathstr)
 {
-	struct observe_node *obs;
-	struct lwm2m_obj_path path;
 	int ret;
-	int i;
-	struct lwm2m_ctx **sock_ctx = lwm2m_sock_ctx();
+	struct lwm2m_obj_path path;
 
 	ret = lwm2m_string_to_path(pathstr, &path, '/');
 	if (ret < 0) {
 		return false;
 	}
 
-	for (i = 0; i < lwm2m_sock_nfds(); ++i) {
-		SYS_SLIST_FOR_EACH_CONTAINER(&sock_ctx[i]->observer, obs, node) {
-
-			if (lwm2m_notify_observer_list(&obs->path_list, &path)) {
-				return true;
-			}
-		}
-	}
-	return false;
+	return lwm2m_path_is_observed(&path);
 }
 
 int lwm2m_engine_observation_handler(struct lwm2m_message *msg, int observe, uint16_t accept,

--- a/subsys/net/lib/lwm2m/lwm2m_observation.c
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.c
@@ -143,7 +143,8 @@ void clear_attrs(void *ref)
 	}
 }
 
-static bool lwm2m_observer_path_compare(struct lwm2m_obj_path *o_p, struct lwm2m_obj_path *p)
+static bool lwm2m_observer_path_compare(const struct lwm2m_obj_path *o_p,
+					const struct lwm2m_obj_path *p)
 {
 	/* check obj id matched or not */
 	if (p->obj_id != o_p->obj_id) {
@@ -173,7 +174,7 @@ static bool lwm2m_observer_path_compare(struct lwm2m_obj_path *o_p, struct lwm2m
 	return true;
 }
 
-static bool lwm2m_notify_observer_list(sys_slist_t *path_list, struct lwm2m_obj_path *path)
+static bool lwm2m_notify_observer_list(sys_slist_t *path_list, const struct lwm2m_obj_path *path)
 {
 	struct lwm2m_obj_path_list *o_p;
 
@@ -334,7 +335,7 @@ int engine_observe_attribute_list_get(sys_slist_t *path_list, struct notificatio
 	return 0;
 }
 
-int lwm2m_notify_observer_path(struct lwm2m_obj_path *path)
+int lwm2m_notify_observer_path(const struct lwm2m_obj_path *path)
 {
 	struct observe_node *obs;
 	struct notification_attrs nattrs = {0};

--- a/subsys/net/lib/lwm2m/lwm2m_observation.h
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.h
@@ -8,7 +8,7 @@
 #include "lwm2m_object.h"
 
 int lwm2m_notify_observer(uint16_t obj_id, uint16_t obj_inst_id, uint16_t res_id);
-int lwm2m_notify_observer_path(struct lwm2m_obj_path *path);
+int lwm2m_notify_observer_path(const struct lwm2m_obj_path *path);
 
 #define MAX_TOKEN_LEN 8
 

--- a/subsys/net/lib/lwm2m/lwm2m_observation.h
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.h
@@ -70,7 +70,7 @@ void lwm2m_engine_path_list_init(sys_slist_t *lwm2m_path_list, sys_slist_t *lwm2
  * @return 0 on success or a negative error code
  */
 int lwm2m_engine_add_path_to_list(sys_slist_t *lwm2m_path_list, sys_slist_t *lwm2m_free_list,
-				  struct lwm2m_obj_path *path);
+				  const struct lwm2m_obj_path *path);
 
 int lwm2m_get_path_reference_ptr(struct lwm2m_engine_obj *obj, const struct lwm2m_obj_path *path,
 				 void **ref);

--- a/subsys/net/lib/lwm2m/lwm2m_observation.h
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.h
@@ -72,7 +72,7 @@ void lwm2m_engine_path_list_init(sys_slist_t *lwm2m_path_list, sys_slist_t *lwm2
 int lwm2m_engine_add_path_to_list(sys_slist_t *lwm2m_path_list, sys_slist_t *lwm2m_free_list,
 				  struct lwm2m_obj_path *path);
 
-int lwm2m_get_path_reference_ptr(struct lwm2m_engine_obj *obj, struct lwm2m_obj_path *path,
+int lwm2m_get_path_reference_ptr(struct lwm2m_engine_obj *obj, const struct lwm2m_obj_path *path,
 				 void **ref);
 
 /**

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -571,12 +571,10 @@ static void do_deregister_timeout_cb(struct lwm2m_message *msg)
 
 static bool sm_bootstrap_verify(bool bootstrap_server, int sec_obj_inst)
 {
-	char pathstr[MAX_RESOURCE_LEN];
 	bool bootstrap;
 	int ret;
 
-	snprintk(pathstr, sizeof(pathstr), "0/%d/1", sec_obj_inst);
-	ret = lwm2m_engine_get_bool(pathstr, &bootstrap);
+	ret = lwm2m_get_bool(&LWM2M_OBJ(0, sec_obj_inst, 1), &bootstrap);
 	if (ret < 0) {
 		LOG_WRN("Failed to check bootstrap, err %d", ret);
 		return false;
@@ -591,11 +589,9 @@ static bool sm_bootstrap_verify(bool bootstrap_server, int sec_obj_inst)
 
 static bool sm_update_lifetime(int srv_obj_inst, uint32_t *lifetime)
 {
-	char pathstr[MAX_RESOURCE_LEN];
 	uint32_t new_lifetime;
 
-	snprintk(pathstr, sizeof(pathstr), "1/%d/1", srv_obj_inst);
-	if (lwm2m_engine_get_u32(pathstr, &new_lifetime) < 0) {
+	if (lwm2m_get_u32(&LWM2M_OBJ(1, srv_obj_inst, 1), &new_lifetime) < 0) {
 		new_lifetime = CONFIG_LWM2M_ENGINE_DEFAULT_LIFETIME;
 		LOG_INF("Using default lifetime: %u", new_lifetime);
 	}
@@ -611,12 +607,10 @@ static bool sm_update_lifetime(int srv_obj_inst, uint32_t *lifetime)
 static int sm_select_server_inst(int sec_obj_inst, int *srv_obj_inst,
 				 uint32_t *lifetime)
 {
-	char pathstr[MAX_RESOURCE_LEN];
 	uint16_t server_id;
 	int ret, obj_inst_id;
 
-	snprintk(pathstr, sizeof(pathstr), "0/%d/10", sec_obj_inst);
-	ret = lwm2m_engine_get_u16(pathstr, &server_id);
+	ret = lwm2m_get_u16(&LWM2M_OBJ(0, sec_obj_inst, 10), &server_id);
 	if (ret < 0) {
 		LOG_WRN("Failed to obtain Short Server ID, err %d", ret);
 		return -EINVAL;

--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -1411,6 +1411,16 @@ int lwm2m_engine_get_time(const char *pathstr, time_t *buf)
 	return lwm2m_get_time(&path, buf);
 }
 
+int lwm2m_get_resource(const struct lwm2m_obj_path *path, struct lwm2m_engine_res **res)
+{
+	if (path->level < LWM2M_PATH_LEVEL_RESOURCE) {
+		LOG_ERR("path must have 3 parts");
+		return -EINVAL;
+	}
+
+	return path_to_objs(path, NULL, NULL, res, NULL);
+}
+
 int lwm2m_engine_get_resource(const char *pathstr, struct lwm2m_engine_res **res)
 {
 	int ret;
@@ -1421,12 +1431,7 @@ int lwm2m_engine_get_resource(const char *pathstr, struct lwm2m_engine_res **res
 		return ret;
 	}
 
-	if (path.level < LWM2M_PATH_LEVEL_RESOURCE) {
-		LOG_ERR("path must have 3 parts");
-		return -EINVAL;
-	}
-
-	return path_to_objs(&path, NULL, NULL, res, NULL);
+	return lwm2m_get_resource(&path, res);
 }
 
 size_t lwm2m_engine_get_opaque_more(struct lwm2m_input_context *in, uint8_t *buf, size_t buflen,
@@ -1628,12 +1633,12 @@ int lwm2m_engine_delete_res_inst(const char *pathstr)
 }
 /* Register callbacks */
 
-int lwm2m_engine_register_read_callback(const char *pathstr, lwm2m_engine_get_data_cb_t cb)
+int lwm2m_register_read_callback(const struct lwm2m_obj_path *path, lwm2m_engine_get_data_cb_t cb)
 {
 	int ret;
 	struct lwm2m_engine_res *res = NULL;
 
-	ret = lwm2m_engine_get_resource(pathstr, &res);
+	ret = lwm2m_get_resource(path, &res);
 	if (ret < 0) {
 		return ret;
 	}
@@ -1642,12 +1647,26 @@ int lwm2m_engine_register_read_callback(const char *pathstr, lwm2m_engine_get_da
 	return 0;
 }
 
-int lwm2m_engine_register_pre_write_callback(const char *pathstr, lwm2m_engine_get_data_cb_t cb)
+int lwm2m_engine_register_read_callback(const char *pathstr, lwm2m_engine_get_data_cb_t cb)
+{
+	int ret;
+	struct lwm2m_obj_path path;
+
+	ret = lwm2m_string_to_path(pathstr, &path, '/');
+	if (ret < 0) {
+		return ret;
+	}
+
+	return lwm2m_register_read_callback(&path, cb);
+}
+
+int lwm2m_register_pre_write_callback(const struct lwm2m_obj_path *path,
+				      lwm2m_engine_get_data_cb_t cb)
 {
 	int ret;
 	struct lwm2m_engine_res *res = NULL;
 
-	ret = lwm2m_engine_get_resource(pathstr, &res);
+	ret = lwm2m_get_resource(path, &res);
 	if (ret < 0) {
 		return ret;
 	}
@@ -1656,19 +1675,56 @@ int lwm2m_engine_register_pre_write_callback(const char *pathstr, lwm2m_engine_g
 	return 0;
 }
 
-int lwm2m_engine_register_validate_callback(const char *pathstr, lwm2m_engine_set_data_cb_t cb)
+int lwm2m_engine_register_pre_write_callback(const char *pathstr, lwm2m_engine_get_data_cb_t cb)
+{
+	int ret;
+	struct lwm2m_obj_path path;
+
+	ret = lwm2m_string_to_path(pathstr, &path, '/');
+	if (ret < 0) {
+		return ret;
+	}
+
+	return lwm2m_register_pre_write_callback(&path, cb);
+}
+
+int lwm2m_register_validate_callback(const struct lwm2m_obj_path *path,
+				     lwm2m_engine_set_data_cb_t cb)
 {
 #if CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE > 0
 	int ret;
 	struct lwm2m_engine_res *res = NULL;
 
-	ret = lwm2m_engine_get_resource(pathstr, &res);
+	ret = lwm2m_get_resource(path, &res);
 	if (ret < 0) {
 		return ret;
 	}
 
 	res->validate_cb = cb;
 	return 0;
+#else
+	ARG_UNUSED(path);
+	ARG_UNUSED(cb);
+
+	LOG_ERR("Validation disabled. Set "
+		"CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE > 0 to "
+		"enable validation support.");
+	return -ENOTSUP;
+#endif /* CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE > 0 */
+}
+
+int lwm2m_engine_register_validate_callback(const char *pathstr, lwm2m_engine_set_data_cb_t cb)
+{
+#if CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE > 0
+	int ret;
+	struct lwm2m_obj_path path;
+
+	ret = lwm2m_string_to_path(pathstr, &path, '/');
+	if (ret < 0) {
+		return ret;
+	}
+
+	return lwm2m_register_validate_callback(&path, cb);
 #else
 	ARG_UNUSED(pathstr);
 	ARG_UNUSED(cb);
@@ -1680,12 +1736,13 @@ int lwm2m_engine_register_validate_callback(const char *pathstr, lwm2m_engine_se
 #endif /* CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE > 0 */
 }
 
-int lwm2m_engine_register_post_write_callback(const char *pathstr, lwm2m_engine_set_data_cb_t cb)
+int lwm2m_register_post_write_callback(const struct lwm2m_obj_path *path,
+				       lwm2m_engine_set_data_cb_t cb)
 {
 	int ret;
 	struct lwm2m_engine_res *res = NULL;
 
-	ret = lwm2m_engine_get_resource(pathstr, &res);
+	ret = lwm2m_get_resource(path, &res);
 	if (ret < 0) {
 		return ret;
 	}
@@ -1694,12 +1751,25 @@ int lwm2m_engine_register_post_write_callback(const char *pathstr, lwm2m_engine_
 	return 0;
 }
 
-int lwm2m_engine_register_exec_callback(const char *pathstr, lwm2m_engine_execute_cb_t cb)
+int lwm2m_engine_register_post_write_callback(const char *pathstr, lwm2m_engine_set_data_cb_t cb)
+{
+	int ret;
+	struct lwm2m_obj_path path;
+
+	ret = lwm2m_string_to_path(pathstr, &path, '/');
+	if (ret < 0) {
+		return ret;
+	}
+
+	return lwm2m_register_post_write_callback(&path, cb);
+}
+
+int lwm2m_register_exec_callback(const struct lwm2m_obj_path *path, lwm2m_engine_execute_cb_t cb)
 {
 	int ret;
 	struct lwm2m_engine_res *res = NULL;
 
-	ret = lwm2m_engine_get_resource(pathstr, &res);
+	ret = lwm2m_get_resource(path, &res);
 	if (ret < 0) {
 		return ret;
 	}
@@ -1708,7 +1778,20 @@ int lwm2m_engine_register_exec_callback(const char *pathstr, lwm2m_engine_execut
 	return 0;
 }
 
-int lwm2m_engine_register_create_callback(uint16_t obj_id, lwm2m_engine_user_cb_t cb)
+int lwm2m_engine_register_exec_callback(const char *pathstr, lwm2m_engine_execute_cb_t cb)
+{
+	int ret;
+	struct lwm2m_obj_path path;
+
+	ret = lwm2m_string_to_path(pathstr, &path, '/');
+	if (ret < 0) {
+		return ret;
+	}
+
+	return lwm2m_register_exec_callback(&path, cb);
+}
+
+int lwm2m_register_create_callback(uint16_t obj_id, lwm2m_engine_user_cb_t cb)
 {
 	struct lwm2m_engine_obj *obj = NULL;
 
@@ -1722,7 +1805,12 @@ int lwm2m_engine_register_create_callback(uint16_t obj_id, lwm2m_engine_user_cb_
 	return 0;
 }
 
-int lwm2m_engine_register_delete_callback(uint16_t obj_id, lwm2m_engine_user_cb_t cb)
+int lwm2m_engine_register_create_callback(uint16_t obj_id, lwm2m_engine_user_cb_t cb)
+{
+	return lwm2m_register_create_callback(obj_id, cb);
+}
+
+int lwm2m_register_delete_callback(uint16_t obj_id, lwm2m_engine_user_cb_t cb)
 {
 	struct lwm2m_engine_obj *obj = NULL;
 
@@ -1734,6 +1822,11 @@ int lwm2m_engine_register_delete_callback(uint16_t obj_id, lwm2m_engine_user_cb_
 
 	obj->user_delete_cb = cb;
 	return 0;
+}
+
+int lwm2m_engine_register_delete_callback(uint16_t obj_id, lwm2m_engine_user_cb_t cb)
+{
+	return lwm2m_register_delete_callback(obj_id, cb);
 }
 /* Generic data handlers */
 

--- a/subsys/net/lib/lwm2m/lwm2m_registry.h
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.h
@@ -71,11 +71,22 @@ int lwm2m_engine_get_create_res_inst(struct lwm2m_obj_path *path, struct lwm2m_e
 /**
  * @brief Gets the resource specified by @p pathstr.
  *
+ * @deprecated Use lwm2m_get_resource() instead.
+ *
  * @param[in] pathstr Path to resource (i.e 100/100/100/x, the fourth component is optional)
  * @param[out] res Engine resource buffer pointer.
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_engine_get_resource(const char *pathstr, struct lwm2m_engine_res **res);
+
+/**
+ * @brief Gets the resource specified by @p path.
+ *
+ * @param[in] path Path to resource (i.e 100/100/100/x, the fourth component is optional)
+ * @param[out] res Engine resource buffer pointer.
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_get_resource(const struct lwm2m_obj_path *path, struct lwm2m_engine_res **res);
 
 /**
  * @brief Returns pointer to the object in the registry specified by @p path.

--- a/subsys/net/lib/lwm2m/lwm2m_rw_link_format.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_link_format.c
@@ -265,13 +265,7 @@ static int put_corelink_ssid(struct lwm2m_output_context *out,
 	case LWM2M_OBJECT_SECURITY_ID: {
 		bool bootstrap_inst;
 
-		ret = snprintk(buf, buflen, "0/%d/1",
-			       path->obj_inst_id);
-		if (ret < 0 || ret >= buflen) {
-			return -ENOMEM;
-		}
-
-		ret = lwm2m_engine_get_bool(buf, &bootstrap_inst);
+		ret = lwm2m_get_bool(&LWM2M_OBJ(0, path->obj_inst_id, 1), &bootstrap_inst);
 		if (ret < 0) {
 			return ret;
 		}
@@ -283,13 +277,11 @@ static int put_corelink_ssid(struct lwm2m_output_context *out,
 			return 0;
 		}
 
-		ret = snprintk(buf, buflen, "0/%d/10",
-				path->obj_inst_id);
 		if (ret < 0 || ret >= buflen) {
 			return -ENOMEM;
 		}
 
-		ret = lwm2m_engine_get_u16(buf, &server_id);
+		ret = lwm2m_get_u16(&LWM2M_OBJ(0, path->obj_inst_id, 10), &server_id);
 		if (ret < 0) {
 			return ret;
 		}
@@ -298,12 +290,7 @@ static int put_corelink_ssid(struct lwm2m_output_context *out,
 	}
 
 	case LWM2M_OBJECT_SERVER_ID:
-		ret = snprintk(buf, buflen, "1/%d/0", path->obj_inst_id);
-		if (ret < 0 || ret >= buflen) {
-			return -ENOMEM;
-		}
-
-		ret = lwm2m_engine_get_u16(buf, &server_id);
+		ret = lwm2m_get_u16(&LWM2M_OBJ(1, path->obj_inst_id, 0), &server_id);
 		if (ret < 0) {
 			return ret;
 		}

--- a/subsys/net/lib/lwm2m/lwm2m_shell.c
+++ b/subsys/net/lib/lwm2m/lwm2m_shell.c
@@ -166,6 +166,12 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	const char *dtype = "-s"; /* default */
 	const char *pathstr = argv[1];
 	int ret = 0;
+	struct lwm2m_obj_path path;
+
+	ret = lwm2m_string_to_path(pathstr, &path, '/');
+	if (ret < 0) {
+		return ret;
+	}
 
 	if (argc > 2) { /* read + path + options(data type) */
 		dtype = argv[2];
@@ -174,8 +180,8 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 		const char *buff;
 		uint16_t buff_len = 0;
 
-		ret = lwm2m_engine_get_res_buf(pathstr, (void **)&buff,
-					       &buff_len, NULL, NULL);
+		ret = lwm2m_get_res_buf(&path, (void **)&buff,
+					&buff_len, NULL, NULL);
 		if (ret != 0) {
 			goto out;
 		}
@@ -183,7 +189,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	} else if (strcmp(dtype, "-s8") == 0) {
 		int8_t temp = 0;
 
-		ret = lwm2m_engine_get_s8(pathstr, &temp);
+		ret = lwm2m_get_s8(&path, &temp);
 		if (ret != 0) {
 			goto out;
 		}
@@ -191,7 +197,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	} else if (strcmp(dtype, "-s16") == 0) {
 		int16_t temp = 0;
 
-		ret = lwm2m_engine_get_s16(pathstr, &temp);
+		ret = lwm2m_get_s16(&path, &temp);
 		if (ret != 0) {
 			goto out;
 		}
@@ -199,7 +205,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	} else if (strcmp(dtype, "-s32") == 0) {
 		int32_t temp = 0;
 
-		ret = lwm2m_engine_get_s32(pathstr, &temp);
+		ret = lwm2m_get_s32(&path, &temp);
 		if (ret != 0) {
 			goto out;
 		}
@@ -207,7 +213,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	} else if (strcmp(dtype, "-s64") == 0) {
 		int64_t temp = 0;
 
-		ret = lwm2m_engine_get_s64(pathstr, &temp);
+		ret = lwm2m_get_s64(&path, &temp);
 		if (ret != 0) {
 			goto out;
 		}
@@ -215,7 +221,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	} else if (strcmp(dtype, "-u8") == 0) {
 		uint8_t temp = 0;
 
-		ret = lwm2m_engine_get_u8(pathstr, &temp);
+		ret = lwm2m_get_u8(&path, &temp);
 		if (ret != 0) {
 			goto out;
 		}
@@ -223,7 +229,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	} else if (strcmp(dtype, "-u16") == 0) {
 		uint16_t temp = 0;
 
-		ret = lwm2m_engine_get_u16(pathstr, &temp);
+		ret = lwm2m_get_u16(&path, &temp);
 		if (ret != 0) {
 			goto out;
 		}
@@ -231,7 +237,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	} else if (strcmp(dtype, "-u32") == 0) {
 		uint32_t temp = 0;
 
-		ret = lwm2m_engine_get_u32(pathstr, &temp);
+		ret = lwm2m_get_u32(&path, &temp);
 		if (ret != 0) {
 			goto out;
 		}
@@ -239,7 +245,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	} else if (strcmp(dtype, "-u64") == 0) {
 		uint64_t temp = 0;
 
-		ret = lwm2m_engine_get_u64(pathstr, &temp);
+		ret = lwm2m_get_u64(&path, &temp);
 		if (ret != 0) {
 			goto out;
 		}
@@ -247,7 +253,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	} else if (strcmp(dtype, "-f") == 0) {
 		double temp = 0;
 
-		ret = lwm2m_engine_get_float(pathstr, &temp);
+		ret = lwm2m_get_f64(&path, &temp);
 		if (ret != 0) {
 			goto out;
 		}
@@ -255,7 +261,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	} else if (strcmp(dtype, "-b") == 0) {
 		bool temp;
 
-		ret = lwm2m_engine_get_bool(pathstr, &temp);
+		ret = lwm2m_get_bool(&path, &temp);
 		if (ret != 0) {
 			goto out;
 		}
@@ -263,7 +269,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	} else if (strcmp(dtype, "-t") == 0) {
 		time_t temp;
 
-		ret = lwm2m_engine_get_time(pathstr, &temp);
+		ret = lwm2m_get_time(&path, &temp);
 		if (ret != 0) {
 			goto out;
 		}
@@ -298,6 +304,12 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 	const char *pathstr = argv[1];
 	const char *dtype;
 	char *value;
+	struct lwm2m_obj_path path;
+
+	ret = lwm2m_string_to_path(pathstr, &path, '/');
+	if (ret < 0) {
+		return ret;
+	}
 
 	if (argc == 4) { /* write path options value */
 		dtype = argv[2];
@@ -308,45 +320,35 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	if (strcmp(dtype, "-s") == 0) {
-		ret = lwm2m_engine_set_string(pathstr, value);
+		ret = lwm2m_set_string(&path, value);
 	} else if (strcmp(dtype, "-f") == 0) {
 		double new = 0;
 
 		lwm2m_atof(value, &new); /* Convert string -> float */
-		ret = lwm2m_engine_set_float(pathstr, &new);
+		ret = lwm2m_set_f64(&path, new);
 	} else { /* All the types using stdlib funcs*/
 		char *e;
 
 		if (strcmp(dtype, "-s8") == 0) {
-			ret = lwm2m_engine_set_s8(pathstr,
-						  strtol(value, &e, 10));
+			ret = lwm2m_set_s8(&path, strtol(value, &e, 10));
 		} else if (strcmp(dtype, "-s16") == 0) {
-			ret = lwm2m_engine_set_s16(pathstr,
-						   strtol(value, &e, 10));
+			ret = lwm2m_set_s16(&path, strtol(value, &e, 10));
 		} else if (strcmp(dtype, "-s32") == 0) {
-			ret = lwm2m_engine_set_s32(pathstr,
-						   strtol(value, &e, 10));
+			ret = lwm2m_set_s32(&path, strtol(value, &e, 10));
 		} else if (strcmp(dtype, "-s64") == 0) {
-			ret = lwm2m_engine_set_s64(pathstr,
-						   strtoll(value, &e, 10));
+			ret = lwm2m_set_s64(&path, strtoll(value, &e, 10));
 		} else if (strcmp(dtype, "-u8") == 0) {
-			ret = lwm2m_engine_set_u8(pathstr,
-						  strtoul(value, &e, 10));
+			ret = lwm2m_set_u8(&path, strtoul(value, &e, 10));
 		} else if (strcmp(dtype, "-u16") == 0) {
-			ret = lwm2m_engine_set_u16(pathstr,
-						   strtoul(value, &e, 10));
+			ret = lwm2m_set_u16(&path, strtoul(value, &e, 10));
 		} else if (strcmp(dtype, "-u32") == 0) {
-			ret = lwm2m_engine_set_u32(pathstr,
-						   strtoul(value, &e, 10));
+			ret = lwm2m_set_u32(&path, strtoul(value, &e, 10));
 		} else if (strcmp(dtype, "-u64") == 0) {
-			ret = lwm2m_engine_set_u64(pathstr,
-						   strtoull(value, &e, 10));
+			ret = lwm2m_set_u64(&path, strtoull(value, &e, 10));
 		} else if (strcmp(dtype, "-b") == 0) {
-			ret = lwm2m_engine_set_bool(pathstr,
-						    strtoul(value, &e, 10));
+			ret = lwm2m_set_bool(&path, strtoul(value, &e, 10));
 		} else if (strcmp(dtype, "-t") == 0) {
-			ret = lwm2m_engine_set_time(pathstr,
-						    strtoll(value, &e, 10));
+			ret = lwm2m_set_time(&path, strtoll(value, &e, 10));
 		} else {
 			shell_error(sh, "can't recognize data type %s\n",
 				    dtype);
@@ -501,7 +503,6 @@ static int cmd_cache(const struct shell *sh, size_t argc, char **argv)
 #if (CONFIG_HEAP_MEM_POOL_SIZE > 0)
 	int rc;
 	int elems;
-	char *path;
 	struct lwm2m_time_series_elem *cache;
 	struct lwm2m_obj_path obj_path;
 
@@ -526,8 +527,6 @@ static int cmd_cache(const struct shell *sh, size_t argc, char **argv)
 		return -ENOEXEC;
 	}
 
-	path = argv[1];
-
 	elems = atoi(argv[2]);
 	if (elems < 1) {
 		shell_error(sh, "Size must be 1 or more (given %d)\n", elems);
@@ -540,10 +539,11 @@ static int cmd_cache(const struct shell *sh, size_t argc, char **argv)
 		return -ENOEXEC;
 	}
 
-	rc = lwm2m_engine_enable_cache(path, cache, elems);
+	rc = lwm2m_enable_cache(&obj_path, cache, elems);
 	if (rc) {
-		shell_error(sh, "lwm2m_engine_enable_cache(%s, %p, %d) returned %d\n", path, cache,
-			    elems, rc);
+		shell_error(sh, "lwm2m_enable_cache(%u/%u/%u/%u, %p, %d) returned %d\n",
+			    obj_path.obj_id, obj_path.obj_inst_id, obj_path.res_id,
+			    obj_path.res_inst_id, cache, elems, rc);
 		k_free(cache);
 		return -ENOEXEC;
 	}

--- a/tests/net/lib/lwm2m/content_link_format/src/main.c
+++ b/tests/net/lib/lwm2m/content_link_format/src/main.c
@@ -377,8 +377,8 @@ static void *obj_attr_init(void)
 {
 	test_obj_init();
 	test_attr_init();
-	lwm2m_engine_set_u16("0/0/10", TEST_SSID);
-	lwm2m_engine_set_u16("1/0/0", TEST_SSID);
+	lwm2m_set_u16(&LWM2M_OBJ(0, 0, 10), TEST_SSID);
+	lwm2m_set_u16(&LWM2M_OBJ(1, 0, 0), TEST_SSID);
 	return NULL;
 }
 


### PR DESCRIPTION
### Description
LwM2M engine has used string based references for LwM2M paths in many places. Some API's use the `lwm2m_obj_path` -struct for paths. This PR deprecates the old API's and creates new functions which will take the `lwm2m_obj_path` as path parameter instead of a `const char*`.

The new API functions drop the `engine` part away from the function names. I.e. `lwm2m_engine_get_string` -> `lwm2m_get_string`. The old functions can still be used, but they will call the new API after the `const char*` path conversion to `lwm2m_obj_path` has been made.

### Usage
Old function usage:
`lwm2m_engine_create_res_inst("3/0/6/0");`
New function usage:
`lwm2m_engine_create_res_inst(&LWM2M_OBJ(3, 0, 6, 0));`

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/53209
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/53676