### PR TITLE
 boards: arm: nrf5340dk_nrf5340: i2c pincontrol needs bias-pull-up flag

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
@@ -8,6 +8,7 @@
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
 				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet-pinctrl.dtsi
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet-pinctrl.dtsi
@@ -30,6 +30,7 @@
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
 				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			bias-pull-up;
 		};
 	};
 

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -173,7 +173,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 				 */
 				drive = NRF_DRIVE_S0D1;
 			}
-#if !defined(NRF5340_XXAA)
+#endif /* !defined(NRF5340_XXAA) */
 			dir = NRF_GPIO_PIN_DIR_INPUT;
 			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
@@ -183,7 +183,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			if (drive == NRF_DRIVE_S0S1) {
 				drive = NRF_DRIVE_S0D1;
 			}
-#if !defined(NRF5340_XXAA)
+#endif /* !defined(NRF5340_XXAA) */
 			dir = NRF_GPIO_PIN_DIR_INPUT;
 			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -163,6 +163,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 #if defined(NRF_PSEL_TWIM)
 		case NRF_FUN_TWIM_SCL:
 			NRF_PSEL_TWIM(reg, SCL) = pin;
+#if !defined(NRF5340_XXAA)
 			if (drive == NRF_DRIVE_S0S1) {
 				/* Override the default drive setting with one
 				 * suitable for TWI/TWIM peripherals (S0D1).
@@ -172,14 +173,17 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 				 */
 				drive = NRF_DRIVE_S0D1;
 			}
+#if !defined(NRF5340_XXAA)
 			dir = NRF_GPIO_PIN_DIR_INPUT;
 			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 		case NRF_FUN_TWIM_SDA:
 			NRF_PSEL_TWIM(reg, SDA) = pin;
+#if !defined(NRF5340_XXAA)
 			if (drive == NRF_DRIVE_S0S1) {
 				drive = NRF_DRIVE_S0D1;
 			}
+#if !defined(NRF5340_XXAA)
 			dir = NRF_GPIO_PIN_DIR_INPUT;
 			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -163,7 +163,6 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 #if defined(NRF_PSEL_TWIM)
 		case NRF_FUN_TWIM_SCL:
 			NRF_PSEL_TWIM(reg, SCL) = pin;
-#if !defined(NRF5340_XXAA)
 			if (drive == NRF_DRIVE_S0S1) {
 				/* Override the default drive setting with one
 				 * suitable for TWI/TWIM peripherals (S0D1).
@@ -173,17 +172,14 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 				 */
 				drive = NRF_DRIVE_S0D1;
 			}
-#endif /* !defined(NRF5340_XXAA) */
 			dir = NRF_GPIO_PIN_DIR_INPUT;
 			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 		case NRF_FUN_TWIM_SDA:
 			NRF_PSEL_TWIM(reg, SDA) = pin;
-#if !defined(NRF5340_XXAA)
 			if (drive == NRF_DRIVE_S0S1) {
 				drive = NRF_DRIVE_S0D1;
 			}
-#endif /* !defined(NRF5340_XXAA) */
 			dir = NRF_GPIO_PIN_DIR_INPUT;
 			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;


### PR DESCRIPTION
 drivers: pinctrl_nrf: Extempt nrf53xx from overwriting drive mode for TWIM

Previously a patch merged to overwrite drive modes for TWIM pins for nrf ICs. But the patch is not working for nrf53. The patch was made 6 months ago here:
https://github.com/zephyrproject-rtos/zephyr/pull/47145

This patch extempt the nrf53 from overwriting the drive mode for TWIM pins. The TWIM pins work with default status S0S1.

Signed-off-by: Masoud Shiroei <masoud.shiroei@assaabloy.com>