### PR TITLE
scripts: runners: bossac: Enable BOSSAC to run on Windows (native)

### DIFF
--- a/boards/arm/arduino_nano_33_ble/doc/index.rst
+++ b/boards/arm/arduino_nano_33_ble/doc/index.rst
@@ -103,6 +103,13 @@ For example
 
     west flash --bossac=$HOME/.arduino15/packages/arduino/tools/bossac/1.9.1-arduino2/bossac
 
+On Windows you need to use the :file:`bossac.exe` from the `Arduino IDE`_
+You will also need to specify the COM port using the --bossac-port argument:
+
+.. code-block:: bash
+
+    west flash --bossac=%USERPROFILE%\AppData\Local\Arduino15\packages\arduino\tools\bossac\1.9.1-arduino2\bossac.exe --bossac-port="COMx"
+
 Flashing
 ========
 
@@ -221,3 +228,6 @@ References
 
 .. _TRACE32 as GDB Front-End:
     https://www2.lauterbach.com/pdf/frontend_gdb.pdf
+
+.. _Arduino IDE:
+	https://www.arduino.cc/en/Main/Software

--- a/doc/develop/flash_debug/host-tools.rst
+++ b/doc/develop/flash_debug/host-tools.rst
@@ -184,6 +184,22 @@ As a quick reference, see these three board documentation pages:
 
 .. _jlink-debug-host-tools:
 
+Enabling BOSSAC on Windows Native [Experimental]
+------------------------------------------------
+Zephyr SDK´s bossac is only currenty support on Linux and macOS. Windows support
+can be achieved by using the bossac version from `BOSSA oficial releases`_.
+After installing using default options, the :file:`bossac.exe` must be added to
+Windows PATH. A specific bossac executable can be used by passing the
+``--bossac`` option, as follows:
+
+.. code-block:: console
+
+    west flash -r bossac --bossac="C:\Program Files (x86)\BOSSA\bossac.exe" --bossac-port="COMx"
+
+.. note::
+
+   WSL is not currently supported.
+
 J-Link Debug Host Tools
 ***********************
 
@@ -336,3 +352,6 @@ To enable Zephyr RTOS awareness follow the steps described in
 
 .. _Lauterbach TRACE32 Zephyr OS Awareness Manual:
 	https://www2.lauterbach.com/pdf/rtos_zephyr.pdf
+
+.. _BOSSA oficial releases:
+	https://github.com/shumatech/BOSSA/releases

--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -5,6 +5,7 @@
 
 '''bossac-specific runner (flash only) for Atmel SAM microcontrollers.'''
 
+import os
 import pathlib
 import pickle
 import platform
@@ -251,9 +252,12 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
                 'could not import edtlib; something may be wrong with the '
                 'python environment')
 
-        if platform.system() == 'Windows':
-            msg = 'CAUTION: BOSSAC runner not support on Windows!'
-            raise RuntimeError(msg)
+        if platform.system() == 'Linux':
+            if 'microsoft' in platform.uname().release.lower() or \
+                os.getenv('WSL_DISTRO_NAME') is not None or \
+                    os.getenv('WSL_INTEROP') is not None:
+                msg = 'CAUTION: BOSSAC runner not supported on WSL!'
+                raise RuntimeError(msg)
         elif platform.system() == 'Darwin' and self.port is None:
             self.port = self.get_darwin_user_port_choice()
 


### PR DESCRIPTION
Fixes #37538 by correctly detecting WSL and blocking bossac from running on that platform, but allowing it to run on Windows native.

This is a new PR superseding the original one (https://github.com/zephyrproject-rtos/zephyr/pull/37584). Unfortunately the original fork was removed.

I implemented all the requests from @nandojve in the original PR.

Signed-off-by: João Dullius <joaodullius@bpmrep.com.br>