### PR TITLE
pm: MEC172x: enable device power mgmt in soc layer

### DIFF
--- a/soc/arm/microchip_mec/mec172x/CMakeLists.txt
+++ b/soc/arm/microchip_mec/mec172x/CMakeLists.txt
@@ -10,10 +10,7 @@ zephyr_sources(
   )
 
 if(CONFIG_PM)
-  zephyr_library_sources(power.c)
-  if(NOT CONFIG_PM_DEVICE)
-    zephyr_library_sources(device_power.c)
-  endif()
+  zephyr_library_sources(power.c device_power.c)
 endif()
 
 if(CONFIG_SOC_HAS_TIMING_FUNCTIONS AND NOT CONFIG_BOARD_HAS_TIMING_FUNCTIONS)

--- a/soc/arm/microchip_mec/mec172x/device_power.h
+++ b/soc/arm/microchip_mec/mec172x/device_power.h
@@ -19,11 +19,6 @@
  */
 /* #define DEEP_SLEEP_UART_SAVE_RESTORE */
 
-/* Enable SoC control over peripherals only when drivers do not support
- * power management
- */
-#ifndef CONFIG_PM_DEVICE
-
 /* Comment out to use JTAG without interruptions.
  * Beware this blocks PLL going off, hence should be enabled
  * for power consumption measurements
@@ -83,8 +78,6 @@ struct ds_dev_info {
 	uint8_t tfdp_en;
 	uint8_t comp_en;
 };
-
-#endif /* CONFIG_PM_DEVICE */
 
 void soc_deep_sleep_periph_save(void);
 void soc_deep_sleep_periph_restore(void);

--- a/soc/arm/microchip_mec/mec172x/power.c
+++ b/soc/arm/microchip_mec/mec172x/power.c
@@ -12,9 +12,7 @@
 #include <soc.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
-#ifndef CONFIG_PM_DEVICE
 #include "device_power.h"
-#endif
 
 #include "soc_power_debug.h"
 
@@ -61,11 +59,9 @@ static void z_power_soc_deep_sleep(void)
 	__disable_irq();
 	basepri = __get_BASEPRI();
 
-#ifndef CONFIG_PM_DEVICE
 	soc_deep_sleep_periph_save();
 	soc_deep_sleep_wake_en();
 	soc_deep_sleep_non_wake_en();
-#endif
 
 	/*
 	 * Enable deep sleep mode in CM4 and MEC172x.
@@ -109,11 +105,9 @@ static void z_power_soc_deep_sleep(void)
 
 	__set_BASEPRI(basepri);
 
-#ifndef CONFIG_PM_DEVICE
 	soc_deep_sleep_non_wake_dis();
 	soc_deep_sleep_wake_dis();
 	soc_deep_sleep_periph_restore();
-#endif
 
 	PM_DP_EXIT();
 }


### PR DESCRIPTION
Update MEC172x SoC PM code to enter deep sleep when CONFIG_PM_DEVICE is enabled

Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>