### PR TITLE
subsys: fb: cfb: support drawing to any coordinates 

### DIFF
--- a/include/zephyr/display/cfb.h
+++ b/include/zephyr/display/cfb.h
@@ -90,6 +90,20 @@ struct cfb_font {
 int cfb_print(const struct device *dev, const char *const str, uint16_t x, uint16_t y);
 
 /**
+ * @brief Print a string into the framebuffer.
+ * For compare to cfb_print, cfb_draw_text accept non tile-aligned coords
+ * and not line wrapping.
+ *
+ * @param dev Pointer to device structure for driver instance
+ * @param str String to print
+ * @param x Position in X direction of the beginning of the string
+ * @param y Position in Y direction of the beginning of the string
+ *
+ * @return 0 on success, negative value otherwise
+ */
+int cfb_draw_text(const struct device *dev, const char *const str, int16_t x, int16_t y);
+
+/**
  * @brief Clear framebuffer.
  *
  * @param dev Pointer to device structure for driver instance

--- a/include/zephyr/display/cfb.h
+++ b/include/zephyr/display/cfb.h
@@ -87,7 +87,7 @@ struct cfb_font {
  *
  * @return 0 on success, negative value otherwise
  */
-int cfb_print(const struct device *dev, char *str, uint16_t x, uint16_t y);
+int cfb_print(const struct device *dev, const char *const str, uint16_t x, uint16_t y);
 
 /**
  * @brief Clear framebuffer.

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -128,7 +128,7 @@ static uint8_t draw_char_vtmono(const struct char_framebuffer *fb,
 	return fptr->width;
 }
 
-int cfb_print(const struct device *dev, char *str, uint16_t x, uint16_t y)
+int cfb_print(const struct device *dev, const char *const str, uint16_t x, uint16_t y)
 {
 	const struct char_framebuffer *fb = &char_fb;
 	const struct cfb_font *fptr;

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -240,6 +240,7 @@ int cfb_framebuffer_finalize(const struct device *dev)
 	const struct display_driver_api *api = dev->api;
 	const struct char_framebuffer *fb = &char_fb;
 	struct display_buffer_descriptor desc;
+	int err;
 
 	if (!fb || !fb->buf) {
 		return -ENODEV;
@@ -252,6 +253,9 @@ int cfb_framebuffer_finalize(const struct device *dev)
 
 	if (!(fb->pixel_format & PIXEL_FORMAT_MONO10) != !(fb->inverted)) {
 		cfb_invert(fb);
+		err = api->write(dev, 0, 0, &desc, fb->buf);
+		cfb_invert(fb);
+		return err;
 	}
 
 	return api->write(dev, 0, 0, &desc, fb->buf);

--- a/subsys/fb/cfb_shell.c
+++ b/subsys/fb/cfb_shell.c
@@ -119,6 +119,29 @@ static int cmd_print(const struct shell *shell, size_t argc, char *argv[])
 	return err;
 }
 
+static int cmd_draw_text(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+	int x, y;
+
+	if (!dev) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
+	x = strtol(argv[1], NULL, 10);
+	y = strtol(argv[2], NULL, 10);
+	err = cfb_draw_text(dev, argv[3], x, y);
+	if (err) {
+		shell_error(sh, "Failed text drawing to Framebuffer error=%d", err);
+		return err;
+	}
+
+	err = cfb_framebuffer_finalize(dev);
+
+	return err;
+}
+
 static int cmd_scroll_vert(const struct shell *shell, size_t argc, char *argv[])
 {
 	int err = 0;
@@ -488,6 +511,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_cmd_scroll,
 	SHELL_SUBCMD_SET_END
 );
 
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_cmd_draw,
+	SHELL_CMD_ARG(text, NULL, HELP_PRINT, cmd_draw_text, 4, 0),
+	SHELL_SUBCMD_SET_END
+);
+
 SHELL_STATIC_SUBCMD_SET_CREATE(cfb_cmds,
 	SHELL_CMD_ARG(init, NULL, HELP_NONE, cmd_init, 1, 0),
 	SHELL_CMD_ARG(get_device, NULL, HELP_NONE, cmd_get_device, 1, 0),
@@ -500,6 +528,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(cfb_cmds,
 	SHELL_CMD_ARG(print, NULL, HELP_PRINT, cmd_print, 4, 0),
 	SHELL_CMD(scroll, &sub_cmd_scroll, "scroll a text in vertical or "
 		  "horizontal direction", NULL),
+	SHELL_CMD(draw, &sub_cmd_draw, "drawing text", NULL),
 	SHELL_CMD_ARG(clear, NULL, HELP_NONE, cmd_clear, 1, 0),
 	SHELL_SUBCMD_SET_END
 );


### PR DESCRIPTION
This PR intends to use cfb like as a graphics oriented devices. It will be fundamental for implements simple graphics rendering.

# API improvement:

- Allow printing and inverting at any coordinates.

  Currently, the CFB API can only draw at tile bounds coordinates (where the y coordinate is a multiple of 8).
  Implements dot-by-dot font rendering to make cfb_print() able to draw text even at a coordinate that is not on tile boundaries.
  For API consistency, change cfb_invert_area() able to invert even at a coordinate not on tile boundaries.

- Add `cfb_draw_text()` API

  Added `cfb_draw_text()` that does not wrap when specifying the position in dots, as it may be inconvenient if there is wrapping

# Shell Improvements:

- Add command `draw text`

  Add command to run the new API `cfb_draw_text()`.
  This command is similar to `print`.
  The position specify with (x,y) not column-row and doesn't clear buffer is differences.

- Add support for running cfb_invert_area().
  
  Extend the invert command to run cfb_invert_area when given four arguments.
  Make a change to invert the screen immediately in case of run invert without arguments.