### PR TITLE
pwm: Add PWM support for nRF5340 Audio DK RGB LED

### DIFF
--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common-pinctrl.dtsi
@@ -66,6 +66,23 @@
 		};
 	};
 
+	pwm0_default: pwm0_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 7)>,
+				<NRF_PSEL(PWM_OUT1, 0, 25)>,
+				<NRF_PSEL(PWM_OUT2, 0, 26)>;
+		};
+	};
+
+	pwm0_sleep: pwm0_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 7)>,
+				<NRF_PSEL(PWM_OUT1, 0, 25)>,
+				<NRF_PSEL(PWM_OUT2, 0, 26)>;
+			low-power-enable;
+		};
+	};
+
 	spi4_default: spi4_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 8)>,

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -29,6 +29,28 @@
 		compatible = "nordic,npm1100";
 		nordic,iset-gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>;
 	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		rgb1_red_pwm_led: pwm_led_0 {
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+		rgb1_green_pwm_led: pwm_led_1 {
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+		rgb1_blue_pwm_led: pwm_led_2 {
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	aliases {
+		pwm-led0 = &rgb1_red_pwm_led;
+		pwm-led1 = &rgb1_green_pwm_led;
+		pwm-led2 = &rgb1_blue_pwm_led;
+		red-pwm-led = &rgb1_red_pwm_led;
+		green-pwm-led = &rgb1_green_pwm_led;
+		blue-pwm-led = &rgb1_blue_pwm_led;
+	};
 };
 
 &adc {
@@ -140,6 +162,9 @@
 
 &pwm0 {
 	status = "okay";
+	pinctrl-0 = <&pwm0_default>;
+	pinctrl-1 = <&pwm0_sleep>;
+	pinctrl-names = "default", "sleep";
 };
 
 &timer0 {


### PR DESCRIPTION
Adding PWM support for the center RGB LED to allow for fancy disco lights, suitable for an audio development kit.

Signed-off-by: Lars Knudsen <larsgk@gmail.com>