### PR TITLE
boards: arm: rpi_pico: Remove `i2c1` node

### DIFF
--- a/boards/arm/rpi_pico/rpi_pico-pinctrl.dtsi
+++ b/boards/arm/rpi_pico/rpi_pico-pinctrl.dtsi
@@ -24,14 +24,6 @@
 		};
 	};
 
-	i2c1_default: i2c1_default {
-		group1 {
-			pinmux = <I2C1_SDA_P14>, <I2C1_SCL_P15>;
-			input-enable;
-			input-schmitt-enable;
-		};
-	};
-
 	spi0_default: spi0_default {
 		group1 {
 			pinmux = <SPI0_CSN_P17>, <SPI0_SCK_P18>, <SPI0_TX_P19>;

--- a/boards/arm/rpi_pico/rpi_pico.dts
+++ b/boards/arm/rpi_pico/rpi_pico.dts
@@ -99,13 +99,6 @@
 	pinctrl-names = "default";
 };
 
-&i2c1 {
-	clock-frequency = <I2C_BITRATE_STANDARD>;
-	status = "okay";
-	pinctrl-0 = <&i2c1_default>;
-	pinctrl-names = "default";
-};
-
 &spi0 {
 	clock-frequency = <DT_FREQ_M(8)>;
 	status = "okay";

--- a/tests/drivers/i2c/i2c_target_api/boards/rpi_pico.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/rpi_pico.overlay
@@ -4,6 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&pinctrl {
+	i2c1_default: i2c1_default {
+		group1 {
+			pinmux = <I2C1_SDA_P14>, <I2C1_SCL_P15>;
+			input-enable;
+			input-schmitt-enable;
+		};
+	};
+};
+
 &i2c0 {
 	eeprom0: eeprom@54 {
 		compatible = "atmel,at24";
@@ -16,6 +26,10 @@
 };
 
 &i2c1 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
+	pinctrl-0 = <&i2c1_default>;
+	pinctrl-names = "default";
 	eeprom1: eeprom@56 {
 		compatible = "atmel,at24";
 		reg = <0x56>;


### PR DESCRIPTION
Zephyr's default settings usually enable the only minimum of peripherals, and rpi_pico already has `i2c0` enabled.
Remove the `i2c1` node configuration.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>