### PR TITLE
drivers: i2s: Improve precision in PLLI2S VCO calculation

### DIFF
--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -130,7 +130,7 @@ static int i2s_stm32_set_clock(const struct device *dev,
 {
 	const struct i2s_stm32_cfg *cfg = dev->config;
 	uint32_t pll_src = LL_RCC_PLL_GetMainSource();
-	int freq_in;
+	float freq_in;
 	uint8_t i2s_div, i2s_odd;
 
 	freq_in = (pll_src == LL_RCC_PLLSOURCE_HSI) ?
@@ -157,12 +157,9 @@ static int i2s_stm32_set_clock(const struct device *dev,
 	LOG_DBG("PLLI2S is locked");
 
 	/* Adjust freq_in according to PLLM, PLLN, PLLR */
-	float freq_tmp;
-
-	freq_tmp = freq_in / CONFIG_I2S_STM32_PLLI2S_PLLM;
-	freq_tmp *= CONFIG_I2S_STM32_PLLI2S_PLLN;
-	freq_tmp /= CONFIG_I2S_STM32_PLLI2S_PLLR;
-	freq_in = (int) freq_tmp;
+	freq_in /= CONFIG_I2S_STM32_PLLI2S_PLLM;
+	freq_in *= CONFIG_I2S_STM32_PLLI2S_PLLN;
+	freq_in /= CONFIG_I2S_STM32_PLLI2S_PLLR;
 #endif /* CONFIG_I2S_STM32_USE_PLLI2S_ENABLE */
 
 	/* Select clock source */
@@ -174,7 +171,7 @@ static int i2s_stm32_set_clock(const struct device *dev,
 	 * following formula:
 	 *   (i2s_div * 2) + i2s_odd
 	 */
-	i2s_div = div_round_closest(freq_in, bit_clk_freq);
+	i2s_div = div_round_closest((uint32_t) freq_in, bit_clk_freq);
 	i2s_odd = (i2s_div & 0x1) ? 1 : 0;
 	i2s_div >>= 1;
 


### PR DESCRIPTION
Minor rework to perform the PLLI2S VCO computations in floating point as per the original seemingly intent.

Signed-off-by: Raul Pando <raul.pando@bytegrity.co.uk>

Fixes: [#53808](https://github.com/zephyrproject-rtos/zephyr/issues/53808)