### PR TITLE
soc: rpi_pico: Add restart to bootloader support.

### DIFF
--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -75,6 +75,7 @@ if(CONFIG_HAS_RPI_PICO)
     ${rp2040_dir}/hardware_structs/include
     ${common_dir}/pico_base/include
     ${rp2_common_dir}/pico_platform/include
+    ${rp2_common_dir}/pico_bootrom/include
     ${CMAKE_CURRENT_LIST_DIR}
   )
 

--- a/soc/arm/rpi_pico/rp2/soc.c
+++ b/soc/arm/rpi_pico/rp2/soc.c
@@ -15,11 +15,14 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr/logging/log.h>
 
 #include <hardware/regs/resets.h>
 #include <hardware/clocks.h>
 #include <hardware/resets.h>
+
+#include <pico/bootrom.h>
 
 #ifdef CONFIG_RUNTIME_NMI
 extern void z_arm_nmi_init(void);
@@ -29,6 +32,17 @@ extern void z_arm_nmi_init(void);
 #endif
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
+
+/* Overrides the weak ARM implementation:
+   Set general purpose retention register and reboot */
+void sys_arch_reboot(int type)
+{
+	if (type != 0) {
+		reset_usb_boot(0,0);
+	} else {
+		NVIC_SystemReset();
+	}
+}
 
 static int rp2040_init(const struct device *arg)
 {


### PR DESCRIPTION
Reboot to the bootloader if non-zero restart type.

Signed-off-by: Peter Johanson <peter@peterjohanson.com>

See https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/pico_bootrom/include/pico/bootrom.h#L161 for the API used to reboot into the bootloader in ROM.