### PR TITLE
dts: arm: nordic: Set RNG node for Nordic devices

### DIFF
--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -29,7 +29,7 @@
 	};
 
 	chosen {
-		zephyr,entropy = &rng_hci;
+		zephyr,entropy = &psa_rng;
 		zephyr,flash-controller = &flash_controller;
 	};
 
@@ -53,6 +53,11 @@
 	/* Default IPC description */
 	ipc {
 		#include "nrf5340_cpuapp_ipc.dtsi"
+	};
+
+	psa_rng: psa-rng {
+		compatible = "zephyr,psa-crypto-rng";
+		status = "okay";
 	};
 };
 

--- a/dts/arm/nordic/nrf9160ns.dtsi
+++ b/dts/arm/nordic/nrf9160ns.dtsi
@@ -28,6 +28,7 @@
 	};
 
 	chosen {
+		zephyr,entropy = &psa_rng;
 		zephyr,flash-controller = &flash_controller;
 	};
 
@@ -52,6 +53,11 @@
 			interrupts = <49 5>;
 			status = "disabled";
 		};
+	};
+
+	psa_rng: psa-rng {
+		compatible = "zephyr,psa-crypto-rng";
+		status = "okay";
 	};
 };
 


### PR DESCRIPTION
This sets the RNG node that will be used by the Nordic devices which support TF-M (nRF5340/nRF9160) to use the defined scheme with psa_generate_random.

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>