### PR TITLE
dts: bindings: pwm custom macro for STM32 vendor

### DIFF
--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -53,7 +53,7 @@
 
 		red_pwm_led: red_pwm_led {
 			pwms = <&pwm1 2 PWM_MSEC(20) (PWM_POLARITY_NORMAL |
-						      PWM_STM32_COMPLEMENTARY)>;
+						      STM32_PWM_COMPLEMENTARY)>;
 		};
 	};
 

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -271,7 +271,7 @@ static int pwm_stm32_set_cycles(const struct device *dev, uint32_t channel,
 	/* in LL_TIM_CC_DisableChannel and LL_TIM_CC_IsEnabledChannel,
 	 * the channel param could be the complementary one
 	 */
-	if ((flags & PWM_STM32_COMPLEMENTARY_MASK) == PWM_STM32_COMPLEMENTARY) {
+	if ((flags & STM32_PWM_COMPLEMENTARY_MASK) == STM32_PWM_COMPLEMENTARY) {
 		if (channel > ARRAY_SIZE(ch2ll_n)) {
 			/* setting a flag on a channel that has not this capability */
 			LOG_ERR("Channel %d has NO complementary output", channel);
@@ -310,8 +310,8 @@ static int pwm_stm32_set_cycles(const struct device *dev, uint32_t channel,
 		oc_init.OCMode = LL_TIM_OCMODE_PWM1;
 
 #if defined(LL_TIM_CHANNEL_CH1N)
-		/* the flags holds the PWM_STM32_COMPLEMENTARY information */
-		if ((flags & PWM_STM32_COMPLEMENTARY_MASK) == PWM_STM32_COMPLEMENTARY) {
+		/* the flags holds the STM32_PWM_COMPLEMENTARY information */
+		if ((flags & STM32_PWM_COMPLEMENTARY_MASK) == STM32_PWM_COMPLEMENTARY) {
 			oc_init.OCNState = LL_TIM_OCSTATE_ENABLE;
 			oc_init.OCNPolarity = get_polarity(flags);
 		} else {

--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -18,8 +18,8 @@ properties:
       - channel of the timer used for PWM
       - period to set in ns
       - flags : combination of standard flags like PWM_POLARITY_NORMAL
-        or specific flags like PWM_STM32_COMPLEMENTARY. As an example for channel2:
-         <&pwm1 2 100 (PWM_POLARITY_NORMAL | PWM_STM32_COMPLEMENTARY)>;
+        or specific flags like STM32_PWM_COMPLEMENTARY. As an example for channel2:
+         <&pwm1 2 100 (PWM_POLARITY_NORMAL | STM32_PWM_COMPLEMENTARY)>;
 
 pwm-cells:
   - channel

--- a/include/zephyr/dt-bindings/pwm/stm32_pwm.h
+++ b/include/zephyr/dt-bindings/pwm/stm32_pwm.h
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PWM_STM32_H_
-#define ZEPHYR_INCLUDE_DT_BINDINGS_PWM_STM32_H_
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_STM32_PWM_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_STM32_PWM_H_
 
 /**
  * @name custom PWM complementary flags for output pins
@@ -16,10 +16,14 @@
  * @{
  */
 /** PWM complementary output pin is enabled */
+#define STM32_PWM_COMPLEMENTARY	(1U << 8)
+/**
+ * @deprecated Use the PWM complementary `STM32_PWM_COMPLEMENTARY` flag instead.
+ */
 #define PWM_STM32_COMPLEMENTARY	(1U << 8)
 
 /** @cond INTERNAL_HIDDEN */
-#define PWM_STM32_COMPLEMENTARY_MASK	0x100
+#define STM32_PWM_COMPLEMENTARY_MASK	0x100
 /** @endcond */
 /** @} */
 


### PR DESCRIPTION
Change the name of the custom macro defined for the stm32 devices to fit the VND_PWM_xxx model
This is **STM32_PWM_COMPLEMENTARY**

Signed-off-by: Francois Ramu <francois.ramu@st.com>