### PR TITLE
boards: arm: nrf5340dk_nrf5340: Fix missing pull ups on i2c

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
@@ -8,6 +8,7 @@
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
 				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet-pinctrl.dtsi
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet-pinctrl.dtsi
@@ -30,6 +30,7 @@
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
 				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			bias-pull-up;
 		};
 	};
 


### PR DESCRIPTION
Fixes an issue whereby the I2C lines are not pulled up with internal resistors.

Fixes #53782