### PR TITLE
Samples: Bluetooth: hci_rpmsg add missing platform_allow

### DIFF
--- a/samples/bluetooth/hci_rpmsg/sample.yaml
+++ b/samples/bluetooth/hci_rpmsg/sample.yaml
@@ -5,7 +5,7 @@ sample:
 tests:
   sample.bluetooth.hci_rpmsg:
     harness: bluetooth
-    platform_allow: nrf5340dk_nrf5340_cpunet
+    platform_allow: nrf5340dk_nrf5340_cpunet nrf5340_audio_dk_nrf5340_cpunet
     tags: bluetooth
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet
@@ -13,7 +13,7 @@ tests:
   sample.bluetooth.hci_rpmsg.iso_broadcast.bt_ll_sw_split:
     harness: bluetooth
     extra_args: CONF_FILE="nrf5340_cpunet_iso_broadcast-bt_ll_sw_split.conf"
-    platform_allow: nrf5340dk_nrf5340_cpunet
+    platform_allow: nrf5340dk_nrf5340_cpunet nrf5340_audio_dk_nrf5340_cpunet
     tags: bluetooth
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet
@@ -21,7 +21,7 @@ tests:
   sample.bluetooth.hci_rpmsg.iso_receive.bt_ll_sw_split:
     harness: bluetooth
     extra_args: CONF_FILE="nrf5340_cpunet_iso_receive-bt_ll_sw_split.conf"
-    platform_allow: nrf5340dk_nrf5340_cpunet
+    platform_allow: nrf5340dk_nrf5340_cpunet nrf5340_audio_dk_nrf5340_cpunet
     tags: bluetooth
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet


### PR DESCRIPTION
Add nrf5340_audio_dk_nrf5340_cpunet to the platform_allow as having it only in integration_platforms causes issues with the CI system.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>