### PR TITLE
net: ppp: Fix PPP connection with host

### DIFF
--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -210,7 +210,7 @@ static void lcp_finished(struct ppp_fsm *fsm)
 	/* take the remainder down */
 	ppp_mgmt_raise_carrier_off_event(ctx->iface);
 
-	net_if_down(ctx->iface);
+	ppp_if_carrier_down(ctx->iface);
 }
 
 #if defined(CONFIG_NET_L2_PPP_OPTION_MRU)

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -212,3 +212,5 @@ static inline bool ppp_my_option_is_acked(struct ppp_fsm *fsm,
 {
 	return ppp_my_option_flags(fsm, code) & PPP_MY_OPTION_ACKED;
 }
+
+void ppp_if_carrier_down(struct net_if *iface);

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(net_l2_ppp, CONFIG_NET_L2_PPP_LOG_LEVEL);
 #include <zephyr/net/ppp.h>
 
 #include "net_private.h"
+#include "ipv4_autoconf_internal.h"
 
 #include "ppp_stats.h"
 #include "ppp_internal.h"
@@ -259,6 +260,14 @@ static enum net_l2_flags ppp_flags(struct net_if *iface)
 
 NET_L2_INIT(PPP_L2, ppp_recv, ppp_send, ppp_enable, ppp_flags);
 
+/* A workaround for PPP L2 not yet supporting net_if_carrier_on/off(). */
+void ppp_if_carrier_down(struct net_if *iface)
+{
+	net_if_flag_clear(iface, NET_IF_UP);
+	net_mgmt_event_notify(NET_EVENT_IF_DOWN, iface);
+	net_ipv4_autoconf_reset(iface);
+}
+
 static void carrier_on_off(struct k_work *work)
 {
 	struct ppp_context *ctx = CONTAINER_OF(work, struct ppp_context,
@@ -291,7 +300,7 @@ static void carrier_on_off(struct k_work *work)
 			ppp_change_phase(ctx, PPP_DEAD);
 
 			ppp_mgmt_raise_carrier_off_event(ctx->iface);
-			net_if_down(ctx->iface);
+			ppp_if_carrier_down(ctx->iface);
 		}
 	}
 }


### PR DESCRIPTION
A follow up to commit 1d7a077e11 - apparently the PPP interface should not be brought entirely down internally, as this can break further communication with the host. Because of that, reintroduce functionality that used to be covered by net_if_carrier_down() (which basically skips the L2 enable(false) call), but limited to PPP scope only.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>