### PR TITLE
samples: Remove point 6 of Samples Guidelines

### DIFF
--- a/samples/sample_definition_and_criteria.rst
+++ b/samples/sample_definition_and_criteria.rst
@@ -92,11 +92,6 @@ Sample Criteria
     * Building & Running instructions
     * Sample output, if applicable.
 
-6. A sample should be a reference, not a tutorial.
-++++++++++++++++++++++++++++++++++++++++++++++++++
-  * Should have minimal comments, when applicable.
-  * Should concisely demonstrate HOW to solve a problem, not WHY.
-
 
 As a starting point, this sample is a good example to refer to
 :zephyr_file:`samples/kernel/condition_variables/condvar`.


### PR DESCRIPTION
Point 6 of Samples Guidelines stated that samples should be references and not tutorials. The problem is that there is currently no tutorials in Zephyr.

~~The proposal here, is to use samples has tutorials. The references could be left to the tests.~~

After further discussion, samples should not be used as tutorials but as examples.
Even with that said, the point 6 of the Samples Guidelines should be removed because it go against the point 5 and the general idea of an example.
Point 5 say that the Readme of samples should be « [...] clearly explaining the purpose of the sample [...] » when, point 6 say that the sample should not explain the « WHY ».

Samples, if they are demonstrating somehow complex concepts should be able to explain those concepts, if the authors of those samples feel it can be useful.