### PR TITLE
manifest: Update FAT FS revision to fix STRINGIZE redefinition

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -42,7 +42,7 @@ manifest:
       groups:
         - tools
     - name: fatfs
-      revision: 89f53db0207cdcea5bd9bdd64acc3e1ed9a65b15
+      revision: 427159bf95ea49b7680facffaa29ad506b42709b
       path: modules/fs/fatfs
       groups:
         - fs


### PR DESCRIPTION
The commit bring FAT FS driver update with ffconf.h that removes STRINGIZE redefinition.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>