### PR TITLE
testsuite: coverage: fix -Wcast-align warning

### DIFF
--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <errno.h>
+#include <string.h>
 #include "coverage.h"
 
 K_HEAP_DEFINE(gcov_heap, CONFIG_COVERAGE_GCOV_HEAP_SIZE);
@@ -38,12 +39,9 @@ void __gcov_exit(void)
  * buff_write_u64 - Store 64 bit data on a buffer and return the size
  */
 
-#define MASK_32BIT (0xffffffffUL)
 static inline void buff_write_u64(void *buffer, size_t *off, uint64_t v)
 {
-	*((uint32_t *)((uint8_t *)buffer + *off) + 0) = (uint32_t)(v & MASK_32BIT);
-	*((uint32_t *)((uint8_t *)buffer + *off) + 1) = (uint32_t)((v >> 32) &
-							  MASK_32BIT);
+	memcpy((uint8_t *)buffer + *off, (uint8_t *)&v, sizeof(v));
 	*off = *off + sizeof(uint64_t);
 }
 
@@ -52,7 +50,7 @@ static inline void buff_write_u64(void *buffer, size_t *off, uint64_t v)
  */
 static inline void buff_write_u32(void *buffer, size_t *off, uint32_t v)
 {
-	*((uint32_t *)((uint8_t *)buffer + *off)) = v;
+	memcpy((uint8_t *)buffer + *off, (uint8_t *)&v, sizeof(v));
 	*off = *off + sizeof(uint32_t);
 }
 


### PR DESCRIPTION
While porting the `coverage.c` file [from RIOT to Zephyr](https://github.com/RIOT-OS/RIOT/pull/17000) (which employs different compiler flags) I noticed the following `-Wcast-align` GCC warnings on arm:

	coverage.c: In function 'buff_write_u64':
	coverage.c: error: cast increases required alignment of target type [-Werror=cast-align]
	   64 |         *((uint32_t *)((uint8_t *)buffer + *off) + 0) = (uint32_t)(v & MASK_32BIT);
	      |           ^
	coverage.c: error: cast increases required alignment of target type [-Werror=cast-align]
	   65 |         *((uint32_t *)((uint8_t *)buffer + *off) + 1) = (uint32_t)((v >> 32) &
	      |           ^
	coverage.c: In function 'buff_write_u32':
	coverage.c: error: cast increases required alignment of target type [-Werror=cast-align]
	   75 |         *((uint32_t *)((uint8_t *)buffer + *off)) = v;
	      |           ^

I think, as is, the current implementation may perform unaligned memory accesses which may not be supported on certain platforms. To workaround that, I have rewritten the code for RIOT using byte-wise writes using `memcpy`. Proposing a backport of this change as I figured it might be useful for Zephyr as well. If you are not interested in this change feel free to close this PR.