### PR TITLE
cmake: FindZephyr-sdk: Find newest SDK version

### DIFF
--- a/cmake/modules/FindZephyr-sdk.cmake
+++ b/cmake/modules/FindZephyr-sdk.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (c) 2022, Nordic Semiconductor ASA
+# Copyright (c) 2022-2023, Nordic Semiconductor ASA
 
 # FindZephyr-sdk module for supporting module search mode of Zephyr SDK.
 #
@@ -60,19 +60,65 @@ if(("zephyr" STREQUAL ${ZEPHYR_TOOLCHAIN_VARIANT}) OR
       set(ZEPHYR_TOOLCHAIN_VARIANT ${ZEPHYR_CURRENT_TOOLCHAIN_VARIANT})
     endif()
   else()
-    find_package(Zephyr-sdk ${Zephyr-sdk_FIND_VERSION} REQUIRED QUIET CONFIG PATHS
-                 /usr
-                 /usr/local
-                 /opt
-                 $ENV{HOME}
-                 $ENV{HOME}/.local
-                 $ENV{HOME}/.local/opt
-                 $ENV{HOME}/bin)
+    # Paths that are used to find installed Zephyr SDK versions
+    SET(zephyr_sdk_search_paths
+        /usr
+        /usr/local
+        /opt
+        $ENV{HOME}
+        $ENV{HOME}/.local
+        $ENV{HOME}/.local/opt
+        $ENV{HOME}/bin)
+
+    # Search for Zephyr SDK version 0.0.0 which does not exist, this is needed to
+    # return a list of compatible versions and find the best suited version that
+    # is available.
+    find_package(Zephyr-sdk 0.0.0 EXACT QUIET CONFIG PATHS ${zephyr_sdk_search_paths})
+
+    # Remove duplicate entries and sort naturally in descending order.
+    set(zephyr_sdk_found_versions ${Zephyr-sdk_CONSIDERED_VERSIONS})
+    set(zephyr_sdk_found_configs ${Zephyr-sdk_CONSIDERED_CONFIGS})
+
+    list(REMOVE_DUPLICATES Zephyr-sdk_CONSIDERED_VERSIONS)
+    list(SORT Zephyr-sdk_CONSIDERED_VERSIONS COMPARE NATURAL ORDER DESCENDING)
+
+    # Loop over each found Zepher SDK version until one is found that is compatible.
+    foreach(zephyr_sdk_candidate ${Zephyr-sdk_CONSIDERED_VERSIONS})
+      if("${zephyr_sdk_candidate}" VERSION_GREATER_EQUAL "${Zephyr-sdk_FIND_VERSION}")
+        # Find the path for the current version being checked and get the directory
+        # of the Zephyr SDK so it can be checked.
+        list(FIND zephyr_sdk_found_versions ${zephyr_sdk_candidate} zephyr_sdk_current_index)
+        list(GET zephyr_sdk_found_configs ${zephyr_sdk_current_index} zephyr_sdk_current_check_path)
+        get_filename_component(zephyr_sdk_current_check_path ${zephyr_sdk_current_check_path} DIRECTORY)
+
+        # Then see if this version is compatible.
+        find_package(Zephyr-sdk ${Zephyr-sdk_FIND_VERSION} QUIET CONFIG PATHS ${zephyr_sdk_current_check_path} NO_DEFAULT_PATH)
+
+        if (${Zephyr-sdk_FOUND})
+          # A compatible version of the Zephyr SDK has been found which is the highest
+          # supported version, exit.
+          break()
+        endif()
+      endif()
+    endforeach()
+
+    if (NOT ${Zephyr-sdk_FOUND})
+      # This means no compatible Zephyr SDK versions were found, set the version
+      # back to the minimum version so that it is displayed in the error text.
+      find_package(Zephyr-sdk ${Zephyr-sdk_FIND_VERSION} REQUIRED CONFIG PATHS ${zephyr_sdk_search_paths})
+    endif()
   endif()
 
   SET(CMAKE_FIND_PACKAGE_SORT_DIRECTION ${CMAKE_FIND_PACKAGE_SORT_DIRECTION_CURRENT})
   SET(CMAKE_FIND_PACKAGE_SORT_ORDER ${CMAKE_FIND_PACKAGE_SORT_ORDER_CURRENT})
 endif()
+
+# Clean up temp variables
+set(zephyr_sdk_search_paths)
+set(zephyr_sdk_found_versions)
+set(zephyr_sdk_found_configs)
+set(zephyr_sdk_current_index)
+set(zephyr_sdk_current_check_path)
 
 if(DEFINED ZEPHYR_SDK_INSTALL_DIR)
   # Cache the Zephyr SDK install dir.

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -115,6 +115,9 @@ Boards & SoC Support
 Build system and infrastructure
 *******************************
 
+* Fixed an issue whereby whereby older versions of the Zephyr SDK toolchain
+  were used instead of the latest compatible version.
+
 Drivers and Sensors
 *******************
 


### PR DESCRIPTION
This improves the version checking for the zephyr SDK by searching for newer versions that the version that was detected. This works around the issue whereby the versions are contained in files with MD5 hashes which might be in any order.

Fixes #52234