### PR TITLE
LE Audio: PACS Context fix

### DIFF
--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -599,6 +599,37 @@ static int set_location(void)
 	return 0;
 }
 
+static int set_supported_contexts(void)
+{
+	int err;
+
+	if (IS_ENABLED(CONFIG_BT_PAC_SNK)) {
+		err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK,
+						     AVAILABLE_SINK_CONTEXT);
+		if (err != 0) {
+			printk("Failed to set sink supported contexts (err %d)\n",
+			       err);
+
+			return err;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_BT_PAC_SRC)) {
+		err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SOURCE,
+						     AVAILABLE_SOURCE_CONTEXT);
+		if (err != 0) {
+			printk("Failed to set source supported contexts (err %d)\n",
+			       err);
+
+			return err;
+		}
+	}
+
+	printk("Supported contexts successfully set\n");
+
+	return 0;
+}
+
 static int set_available_contexts(void)
 {
 	int err;
@@ -648,6 +679,11 @@ void main(void)
 	}
 
 	err = set_location();
+	if (err != 0) {
+		return;
+	}
+
+	err = set_supported_contexts();
 	if (err != 0) {
 		return;
 	}

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -57,7 +57,7 @@ struct pacs {
 
 #if defined(CONTIG_BT_PAC_SNK)
 static uint16_t snk_available_contexts;
-static uint16_t snk_supported_contexts;
+static uint16_t snk_supported_contexts = BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED;
 #else
 static uint16_t snk_available_contexts = BT_AUDIO_CONTEXT_TYPE_PROHIBITED;
 static uint16_t snk_supported_contexts = BT_AUDIO_CONTEXT_TYPE_PROHIBITED;
@@ -65,7 +65,7 @@ static uint16_t snk_supported_contexts = BT_AUDIO_CONTEXT_TYPE_PROHIBITED;
 
 #if defined(CONFIG_BT_PAC_SRC)
 static uint16_t src_available_contexts;
-static uint16_t src_supported_contexts;
+static uint16_t src_supported_contexts = BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED;
 #else
 static uint16_t src_available_contexts = BT_AUDIO_CONTEXT_TYPE_PROHIBITED;
 static uint16_t src_supported_contexts = BT_AUDIO_CONTEXT_TYPE_PROHIBITED;

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -434,7 +434,7 @@ static inline int set_src_available_contexts(uint16_t contexts)
 static inline int set_src_supported_contexts(uint16_t contexts)
 {
 	return set_supported_contexts(contexts, &src_supported_contexts,
-				      &snk_supported_contexts);
+				      &src_available_contexts);
 }
 #else
 static inline int set_src_available_contexts(uint16_t contexts)


### PR DESCRIPTION
Fixes 2 issues in PACS and missing call to bt_pacs_set_supported_contexts in the unicast server sample. 