### PR TITLE
stm32: reset SDMMC peripheral during init

### DIFF
--- a/drivers/disk/Kconfig.sdmmc
+++ b/drivers/disk/Kconfig.sdmmc
@@ -57,6 +57,7 @@ config SDMMC_STM32
 	select USE_STM32_LL_SDMMC
 	select USE_STM32_HAL_DMA if (SOC_SERIES_STM32L4X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32F4X)
 	select DMA if ($(DT_STM32_SDMMC_HAS_DMA) && SOC_SERIES_STM32F4X)
+	select RESET
 	help
 	  File system on sdmmc accessed through stm32 sdmmc.
 

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -530,6 +530,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000800>;
+			resets = <&rctl STM32_RESET(APB2, 11U)>;
 			interrupts = <49 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -726,6 +726,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000800>;
+			resets = <&rctl STM32_RESET(APB2, 11U)>;
 			interrupts = <49 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f7/stm32f723.dtsi
+++ b/dts/arm/st/f7/stm32f723.dtsi
@@ -42,6 +42,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40011c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;
+			resets = <&rctl STM32_RESET(APB2, 7U)>;
 			interrupts = <103 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f7/stm32f767.dtsi
+++ b/dts/arm/st/f7/stm32f767.dtsi
@@ -83,6 +83,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40011c00 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;
+			resets = <&rctl STM32_RESET(APB2, 7U)>;
 			interrupts = <103 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -817,6 +817,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x52007000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00010000>;
+			resets = <&rctl STM32_RESET(AHB3, 16U)>;
 			interrupts = <49 0>;
 			status = "disabled";
 		};
@@ -825,6 +826,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x48022400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000100>;
+			resets = <&rctl STM32_RESET(AHB2, 8U)>;
 			interrupts = <124 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -238,6 +238,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000400>;
+			resets = <&rctl STM32_RESET(APB2, 10U)>;
 			interrupts = <49 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -316,6 +316,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x50062400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x400000>;
+			resets = <&rctl STM32_RESET(AHB2, 22U)>;
 			interrupts = <49 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -361,6 +361,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x420c8000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00400000>;
+			resets = <&rctl STM32_RESET(AHB2, 22U)>;
 			interrupts = <78 0>;
 			status = "disabled";
 		};

--- a/dts/bindings/mmc/st,stm32-sdmmc.yaml
+++ b/dts/bindings/mmc/st,stm32-sdmmc.yaml
@@ -2,13 +2,16 @@ description: stm32 sdmmc disk access
 
 compatible: "st,stm32-sdmmc"
 
-include: [mmc.yaml, pinctrl-device.yaml]
+include: [mmc.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   clocks:
     required: true
 
   reg:
+    required: true
+
+  resets:
     required: true
 
   pinctrl-0:


### PR DESCRIPTION
This is important for applications which are chain-loaded by a broken bootloader which doesn't reset the peripheral before handing over control. See also #51756.