### PR TITLE
tests: drivers: flash: Fix filter using non-existent partition

### DIFF
--- a/tests/drivers/flash/testcase.yaml
+++ b/tests/drivers/flash/testcase.yaml
@@ -31,7 +31,7 @@ tests:
         not CONFIG_TRUSTED_EXECUTION_NONSECURE) and
         dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions"))
         or (CONFIG_FLASH_HAS_DRIVER_ENABLED and CONFIG_TRUSTED_EXECUTION_NONSECURE and
-        dt_label_with_parent_compat_enabled("image_1_nonsecure", "fixed-partitions"))
+        dt_label_with_parent_compat_enabled("slot1_ns_partition", "fixed-partitions"))
   drivers.flash.mcux:
     platform_allow: mimxrt1060_evk it8xxx2_evb mimxrt685_evk_cm33 mimxrt595_evk_cm33
     integration_platforms:


### PR DESCRIPTION
Filtering used image_1_nonsecure as DTS node label, while correct one is slot1_ns_partition.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>