### PR TITLE
adsp: ace: ipc: boot: power: watchdog: A set of changes required by the watchdog

### DIFF
--- a/soc/xtensa/intel_adsp/ace/_soc_inthandlers.h
+++ b/soc/xtensa/intel_adsp/ace/_soc_inthandlers.h
@@ -117,17 +117,12 @@ handle_irq:
 
 static inline int _xtensa_handle_one_int5(unsigned int mask)
 {
-	int irq;
-
-	if (mask & BIT(8)) {
-		mask = BIT(8);
-		irq = 8;
-		goto handle_irq;
-	}
+	/* It is a Non-maskable interrupt handler.
+	 * The non-maskable interrupt have no corresponding bit in INTERRUPT and INTENABLE registers
+	 * so mask parameter is always 0.
+	 */
+	_sw_isr_table[8].isr(_sw_isr_table[8].arg);
 	return 0;
-handle_irq:
-	_sw_isr_table[irq].isr(_sw_isr_table[irq].arg);
-	return mask;
 }
 
 static inline int _xtensa_handle_one_int0(unsigned int mask)

--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_boot.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_boot.h
@@ -57,9 +57,6 @@ struct dspcs {
 #define DSPBR_BATTR_LPSCTL_L1_MIN_WAY			BIT(15)
 #define DSPBR_BATTR_LPSCTL_BATTR_SLAVE_CORE		BIT(16)
 
-#define DSPBR_WDT_RESUME				BIT(8)
-#define DSPBR_WDT_RESTART_COMMAND			0x76
-
 #define DSPCS (*(volatile struct dspcs *)DSPCS_REG)
 
 #endif /* ZEPHYR_SOC_INTEL_ADSP_BOOT_H_ */

--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -129,11 +129,6 @@ void soc_mp_startup(uint32_t cpu)
 	/* Prevent idle from powering us off */
 	DSPCS.bootctl[cpu].bctl |=
 		DSPBR_BCTL_WAITIPCG | DSPBR_BCTL_WAITIPPG;
-	/* checking if WDT was stopped during D3 transition */
-	if (DSPCS.bootctl[cpu].wdtcs & DSPBR_WDT_RESUME) {
-		DSPCS.bootctl[cpu].wdtcs = DSPBR_WDT_RESUME;
-		/* TODO: delete this IF when FW starts using imr restore vector */
-	}
 }
 
 void arch_sched_ipi(void)

--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -221,7 +221,6 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		core_desc[cpu].intenable = XTENSA_RSR("INTENABLE");
 		z_xt_ints_off(0xffffffff);
 		core_desc[cpu].bctl = DSPCS.bootctl[cpu].bctl;
-		DSPCS.bootctl[cpu].wdtcs = DSPBR_WDT_RESTART_COMMAND;
 		DSPCS.bootctl[cpu].bctl &= ~DSPBR_BCTL_WAITIPCG;
 		soc_cpus_active[cpu] = false;
 		z_xtensa_cache_flush_inv_all();
@@ -309,7 +308,6 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	uint32_t cpu = arch_proc_id();
 
 	if (state == PM_STATE_SOFT_OFF) {
-		DSPCS.bootctl[cpu].wdtcs = DSPBR_WDT_RESUME;
 		/* restore clock gating state */
 		DSPCS.bootctl[cpu].bctl |=
 			(core_desc[0].bctl & DSPBR_BCTL_WAITIPCG);

--- a/soc/xtensa/intel_adsp/common/include/intel_adsp_ipc.h
+++ b/soc/xtensa/intel_adsp/common/include/intel_adsp_ipc.h
@@ -161,4 +161,17 @@ bool intel_adsp_ipc_send_message(const struct device *dev,
 bool intel_adsp_ipc_send_message_sync(const struct device *dev,
 	uint32_t data, uint32_t ext_data, k_timeout_t timeout);
 
+
+/** @brief Send an emergency IPC message.
+ *
+ * Sends a message to the other side of an IPC link. The data and ext_data parameters are passed
+ * using the IDR/IDD registers. Waits in a loop until it is possible to send a message.
+ *
+ * @param dev IPC device.
+ * @param data 30 bits value to transmit with the message (IDR register).
+ * @param ext_data Extended value to transmit with the message (IDD register).
+ */
+void intel_adsp_ipc_send_message_emergency(const struct device *dev, uint32_t data,
+					   uint32_t ext_data);
+
 #endif /* ZEPHYR_INCLUDE_INTEL_ADSP_IPC_H */


### PR DESCRIPTION
Fixed non-maskable interrupt handling:
The non-maskable interrupt have no corresponding bit in INTERRUPT and INTENABLE registers so its occurrence cannot be confirmed. Removed the code that checked if the interrupt flag is set.

Added emergency ipc message send function"
Added intel_adsp_ipc_send_message_emergency function that allows to send an ipc message notifying about emergency event, such as watchdog timeout.

Separated a watchdog state from core power:
The watchdog is controlled by ll-scheduler and should not be resumed when a core is bringing up. Watchdog pause control code was removed.