### PR TITLE
cpp: Fix toolchain C++ standard library linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,7 +339,7 @@ if(NOT CONFIG_NATIVE_APPLICATION)
   toolchain_ld_baremetal()
 endif()
 
-if(NOT CONFIG_MINIMAL_LIBCPP)
+if(CONFIG_CPP AND NOT CONFIG_MINIMAL_LIBCPP)
   # @Intent: Set linker specific flags for C++
   toolchain_ld_cpp()
 endif()


### PR DESCRIPTION
The build system currently links the toolchain-provided C++ standard library even when the C++ support (`CONFIG_CPP`) is not enabled.

This commit updates the build system to link the toolchain-provided C++ standard library when the C++ support is enabled and a C++ library implementation other than the Zephyr minimal C++ library is selected.

Signed-off-by: Stephanos Ioannidis <stephanos.ioannidis@nordicsemi.no>