### PR TITLE
Various updates to the blackmagicprobe runner

### DIFF
--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -69,7 +69,7 @@ jobs:
     - name: install pytest
       run: |
         pip3 install wheel
-        pip3 install pytest west pyelftools canopen progress mypy intelhex psutil ply
+        pip3 install pytest west pyelftools canopen progress mypy intelhex psutil ply pyserial
     - name: run pytest-win
       if: runner.os == 'Windows'
       run: |

--- a/boards/arm/adafruit_feather_nrf52840/board.cmake
+++ b/boards/arm/adafruit_feather_nrf52840/board.cmake
@@ -2,7 +2,6 @@
 
 board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
-board_runner_args(blackmagicprobe "--gdb-serial=/dev/ttyBmpGdb")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)

--- a/boards/arm/lora_e5_dev_board/board.cmake
+++ b/boards/arm/lora_e5_dev_board/board.cmake
@@ -5,7 +5,7 @@ board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
 board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 board_runner_args(jlink "--device=STM32WLE5JC" "--speed=4000" "--reset-after-load")
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
-board_runner_args(blackmagicprobe "--gdb-serial=/dev/ttyBmpGdb" "--connect-rst")
+board_runner_args(blackmagicprobe "--connect-rst")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/lora_e5_dev_board/board.cmake
+++ b/boards/arm/lora_e5_dev_board/board.cmake
@@ -5,7 +5,7 @@ board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
 board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 board_runner_args(jlink "--device=STM32WLE5JC" "--speed=4000" "--reset-after-load")
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
-board_runner_args(blackmagicprobe "--gdb-serial=/dev/ttyBmpGdb" "--connect-srst")
+board_runner_args(blackmagicprobe "--gdb-serial=/dev/ttyBmpGdb" "--connect-rst")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/rpi_pico/board.cmake
+++ b/boards/arm/rpi_pico/board.cmake
@@ -27,8 +27,6 @@ board_runner_args(openocd --cmd-pre-init "set_adapter_speed_if_not_set 2000")
 
 board_runner_args(jlink "--device=RP2040_M0_0")
 
-board_runner_args(blackmagicprobe "--gdb-serial=/dev/ttyBmpGdb")
-
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)

--- a/scripts/west_commands/tests/test_blackmagicprobe.py
+++ b/scripts/west_commands/tests/test_blackmagicprobe.py
@@ -5,11 +5,14 @@
 
 import argparse
 from unittest.mock import patch, call
+import os
 
 import pytest
 
+from runners import blackmagicprobe
 from runners.blackmagicprobe import BlackMagicProbeRunner
 from conftest import RC_KERNEL_ELF, RC_GDB
+import serial.tools.list_ports
 
 TEST_GDB_SERIAL = 'test-gdb-serial'
 
@@ -88,3 +91,111 @@ def test_blackmagicprobe_connect_rst(cc, req, command, runner_config):
     runner.run(command)
     expected = EXPECTED_CONNECT_SRST_COMMAND[command]
     assert expected in cc.call_args_list[0][0][0]
+
+@pytest.mark.parametrize('arg, env, expected', [
+    # Argument has priority
+    ('/dev/XXX', None, '/dev/XXX'),
+    ('/dev/XXX', '/dev/YYYY', '/dev/XXX'),
+
+    # Then BMP_GDB_SERIAL env variable
+    (None, '/dev/XXX', '/dev/XXX'),
+    ])
+def test_blackmagicprobe_gdb_serial_generic(arg, env, expected):
+    if env:
+        os.environ['BMP_GDB_SERIAL'] = env
+    else:
+        if 'BMP_GDB_SERIAL' in os.environ:
+            os.environ.pop('BMP_GDB_SERIAL')
+
+    ret = blackmagicprobe.blackmagicprobe_gdb_serial(arg)
+    assert expected == ret
+
+@pytest.mark.parametrize('known_path, comports, globs, expected', [
+    (True, False, ['/dev/ttyACM0', '/dev/ttyACM1'],
+     blackmagicprobe.DEFAULT_LINUX_BMP_PATH),
+    (False, True, [], '/dev/ttyACM3'),
+    (False, False,  ['/dev/ttyACM0', '/dev/ttyACM1'], '/dev/ttyACM0'),
+    (False, False, ['/dev/ttyACM1', '/dev/ttyACM0'], '/dev/ttyACM0'),
+    ])
+@patch('serial.tools.list_ports.comports')
+@patch('os.path.exists')
+@patch('glob.glob')
+def test_blackmagicprobe_gdb_serial_linux(gg, ope, stlpc, known_path, comports,
+                                          globs, expected):
+    gg.return_value = globs
+    ope.return_value = known_path
+    if comports:
+        fake_comport1 = serial.tools.list_ports_common.ListPortInfo(
+                '/dev/ttyACM1')
+        fake_comport1.interface = 'something'
+        fake_comport2 = serial.tools.list_ports_common.ListPortInfo(
+                '/dev/ttyACM2')
+        fake_comport2.interface = None
+        fake_comport3 = serial.tools.list_ports_common.ListPortInfo(
+                '/dev/ttyACM3')
+        fake_comport3.interface = blackmagicprobe.BMP_GDB_INTERFACE
+        stlpc.return_value = [fake_comport1, fake_comport2, fake_comport3]
+    else:
+        stlpc.return_value = []
+
+    ret = blackmagicprobe.blackmagicprobe_gdb_serial_linux()
+    assert expected == ret
+
+@pytest.mark.parametrize('comports, globs, expected', [
+    (True, [], '/dev/cu.usbmodem3'),
+    (False, ['/dev/cu.usbmodemAABBCC0', '/dev/cu.usbmodemAABBCC1'],
+     '/dev/cu.usbmodemAABBCC0'),
+    (False, ['/dev/cu.usbmodemAABBCC1', '/dev/cu.usbmodemAABBCC0'],
+     '/dev/cu.usbmodemAABBCC0'),
+    ])
+@patch('serial.tools.list_ports.comports')
+@patch('glob.glob')
+def test_blackmagicprobe_gdb_serial_darwin(gg, stlpc, comports, globs, expected):
+    gg.return_value = globs
+    if comports:
+        fake_comport1 = serial.tools.list_ports_common.ListPortInfo(
+                '/dev/cu.usbmodem1')
+        fake_comport1.description = 'unrelated'
+        fake_comport2 = serial.tools.list_ports_common.ListPortInfo(
+                '/dev/cu.usbmodem2')
+        fake_comport2.description = None
+        fake_comport3 = serial.tools.list_ports_common.ListPortInfo(
+                '/dev/cu.usbmodem3')
+        fake_comport3.description = f'{blackmagicprobe.BMP_GDB_PRODUCT} v1234'
+        fake_comport4 = serial.tools.list_ports_common.ListPortInfo(
+                '/dev/cu.usbmodem4')
+        fake_comport4.description = f'{blackmagicprobe.BMP_GDB_PRODUCT} v1234'
+        stlpc.return_value = [fake_comport1, fake_comport2,
+                              fake_comport4, fake_comport3]
+    else:
+        stlpc.return_value = []
+
+    ret = blackmagicprobe.blackmagicprobe_gdb_serial_darwin()
+    assert expected == ret
+
+@pytest.mark.parametrize('comports, expected', [
+    (True, 'COM4'),
+    (False, 'COM1'),
+    ])
+@patch('serial.tools.list_ports.comports')
+def test_blackmagicprobe_gdb_serial_win32(stlpc, comports, expected):
+    if comports:
+        fake_comport1 = serial.tools.list_ports_common.ListPortInfo('COM2')
+        fake_comport1.vid = 123
+        fake_comport1.pid = 456
+        fake_comport2 = serial.tools.list_ports_common.ListPortInfo('COM3')
+        fake_comport2.vid = None
+        fake_comport2.pid = None
+        fake_comport3 = serial.tools.list_ports_common.ListPortInfo('COM4')
+        fake_comport3.vid = blackmagicprobe.BMP_GDB_VID
+        fake_comport3.pid = blackmagicprobe.BMP_GDB_PID
+        fake_comport4 = serial.tools.list_ports_common.ListPortInfo('COM5')
+        fake_comport4.vid = blackmagicprobe.BMP_GDB_VID
+        fake_comport4.pid = blackmagicprobe.BMP_GDB_PID
+        stlpc.return_value = [fake_comport1, fake_comport2,
+                              fake_comport4, fake_comport3]
+    else:
+        stlpc.return_value = []
+
+    ret = blackmagicprobe.blackmagicprobe_gdb_serial_win32()
+    assert expected == ret

--- a/scripts/west_commands/tests/test_blackmagicprobe.py
+++ b/scripts/west_commands/tests/test_blackmagicprobe.py
@@ -45,9 +45,9 @@ EXPECTED_COMMANDS = {
 }
 
 EXPECTED_CONNECT_SRST_COMMAND = {
-        'attach': 'monitor connect_srst disable',
-        'debug': 'monitor connect_srst enable',
-        'flash': 'monitor connect_srst enable',
+        'attach': 'monitor connect_rst disable',
+        'debug': 'monitor connect_rst enable',
+        'flash': 'monitor connect_rst enable',
 }
 
 def require_patch(program):
@@ -78,9 +78,9 @@ def test_blackmagicprobe_create(cc, req, command, runner_config):
 @pytest.mark.parametrize('command', EXPECTED_CONNECT_SRST_COMMAND)
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 @patch('runners.core.ZephyrBinaryRunner.check_call')
-def test_blackmagicprobe_connect_srst(cc, req, command, runner_config):
-    '''Test that commands list the correct connect_srst value when enabled.'''
-    args = ['--gdb-serial', TEST_GDB_SERIAL, '--connect-srst']
+def test_blackmagicprobe_connect_rst(cc, req, command, runner_config):
+    '''Test that commands list the correct connect_rst value when enabled.'''
+    args = ['--gdb-serial', TEST_GDB_SERIAL, '--connect-rst']
     parser = argparse.ArgumentParser()
     BlackMagicProbeRunner.add_parser(parser)
     arg_namespace = parser.parse_args(args)


### PR DESCRIPTION
Hi, ~~quick one~~ for the BMP runner to catch up with https://github.com/blackmagic-debug/blackmagic/pull/1056/commits/240099dde9fae2be6f50a0913f065736500d0727, they changed the command, updating the runner to send both the old and new ones, and take both version of the flags.

EDIT: added two patches to also improve the serial port guessing.

--

Recently the blackmagicprobe command for "connect under reset" has been updated from "connect_srst" to "connect_rst". Update the flag name in the west blackmagicprobe binding, keep the old one as well for compatibility with out of tree boards, and send both the old and new commands to GDB so that it works with both the old and new firmware. GDB is going to get a "command not supported by this target" for one of the two and proceed with the other one.