### PR TITLE
MAINTAINERS: Add kruithofa to Bluetooth Audio

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -250,6 +250,7 @@ Bluetooth Audio:
     - szymon-czapracki
     - asbjornsabo
     - fredrikdanebjer
+    - kruithofa
   files:
     - subsys/bluetooth/audio/
     - include/zephyr/bluetooth/audio/


### PR DESCRIPTION
kruithofa will start collaborating on Bluetooth Audio.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>