### PR TITLE
intel_adsp: dai: Add support for ALH up to 16 nodes

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -171,6 +171,78 @@
 			status = "okay";
 		};
 
+		alh4: alh4@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		alh5: alh5@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		alh6: alh6@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		alh7: alh7@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		alh8: alh8@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		alh9: alh9@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		alh10: alh10@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		alh11: alh11@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		alh12: alh12@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		alh13: alh13@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		alh14: alh14@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
+		alh15: alh15@24400 {
+			compatible = "intel,alh-dai";
+			reg = <0x00024400 0x00024600>;
+			status = "okay";
+		};
+
 		ssp0: ssp@28000 {
 			compatible = "intel,ssp-dai";
 			#address-cells = <1>;

--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -292,14 +292,96 @@
 		alh0: alh0@71000 {
 			compatible = "intel,alh-dai";
 			reg = <0x00071000 0x00071200>;
-
 			status = "okay";
 		};
 
 		alh1: alh1@71000 {
 			compatible = "intel,alh-dai";
 			reg = <0x00071000 0x00071200>;
+			status = "okay";
+		};
 
+		alh2: alh2@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+			status = "okay";
+		};
+
+		alh3: alh3@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+			status = "okay";
+		};
+
+		alh4: alh4@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+			status = "okay";
+		};
+
+		alh5: alh5@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+			status = "okay";
+		};
+
+		alh6: alh6@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+			status = "okay";
+		};
+
+		alh7: alh7@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+			status = "okay";
+		};
+
+		alh8: alh8@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+			status = "okay";
+		};
+
+		alh9: alh9@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+			status = "okay";
+		};
+
+		alh10: alh10@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+			status = "okay";
+		};
+
+		alh11: alh11@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+			status = "okay";
+		};
+
+		alh12: alh12@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+			status = "okay";
+		};
+
+		alh13: alh13@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+			status = "okay";
+		};
+
+		alh14: alh14@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
+			status = "okay";
+		};
+
+		alh15: alh15@71000 {
+			compatible = "intel,alh-dai";
+			reg = <0x00071000 0x00071200>;
 			status = "okay";
 		};
 


### PR DESCRIPTION
ALH dts definitions need to have 16 nodes, thus add them to supported platforms (cavs25 and ace15).

Signed-off-by: Jaska Uimonen <jaska.uimonen@linux.intel.com>