### PR TITLE
drivers: flash: fix hyperflash write

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_hyperflash.c
+++ b/drivers/flash/flash_mcux_flexspi_hyperflash.c
@@ -427,6 +427,9 @@ static int flash_flexspi_hyperflash_write(const struct device *dev, off_t offset
 		key = irq_lock();
 	}
 
+	(void)memc_flexspi_update_clock(data->controller, &data->config,
+					data->port, MEMC_FLEXSPI_CLOCK_42M);
+
 	while (len) {
 		/* Writing between two page sizes crashes the platform so we
 		 * have to write the part that fits in the first page and then
@@ -465,6 +468,9 @@ static int flash_flexspi_hyperflash_write(const struct device *dev, off_t offset
 		offset += i;
 		len -= i;
 	}
+
+	(void)memc_flexspi_update_clock(data->controller, &data->config,
+					data->port, MEMC_FLEXSPI_CLOCK_166M);
 
 	if (memc_flexspi_is_running_xip(data->controller)) {
 		/* ==== EXIT CRITICAL SECTION ==== */

--- a/drivers/flash/flash_mcux_flexspi_hyperflash.c
+++ b/drivers/flash/flash_mcux_flexspi_hyperflash.c
@@ -595,7 +595,8 @@ static int flash_flexspi_hyperflash_init(const struct device *dev)
 
 	memc_flexspi_wait_bus_idle(data->controller);
 
-	if (memc_flexspi_set_device_config(data->controller, &data->config,
+	if (!memc_flexspi_is_running_xip(data->controller) &&
+	    memc_flexspi_set_device_config(data->controller, &data->config,
 				data->port)) {
 		LOG_ERR("Could not set device configuration");
 		return -EINVAL;

--- a/drivers/memc/memc_mcux_flexspi.c
+++ b/drivers/memc/memc_mcux_flexspi.c
@@ -10,6 +10,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/pm/device.h>
+#include <soc.h>
 
 #include "memc_mcux_flexspi.h"
 
@@ -75,6 +76,34 @@ int memc_flexspi_update_lut(const struct device *dev, uint32_t index,
 	FLEXSPI_UpdateLUT(data->base, index, cmd, count);
 
 	return 0;
+}
+
+int memc_flexspi_update_clock(const struct device *dev,
+		flexspi_device_config_t *device_config,
+		flexspi_port_t port, enum memc_flexspi_clock_t clock)
+{
+#if CONFIG_SOC_SERIES_IMX_RT10XX
+	struct memc_flexspi_data *data = dev->data;
+
+	memc_flexspi_wait_bus_idle(dev);
+
+	FLEXSPI_Enable(data->base, false);
+
+	flexspi_clock_set_div(clock == MEMC_FLEXSPI_CLOCK_166M ? 0 : 3);
+
+	FLEXSPI_Enable(data->base, true);
+
+	memc_flexspi_reset(dev);
+
+	device_config->flexspiRootClk = flexspi_clock_get_freq();
+	FLEXSPI_UpdateDllValue(data->base, device_config, port);
+
+	memc_flexspi_reset(dev);
+
+	return 0;
+#else
+	return -ENOTSUP;
+#endif
 }
 
 int memc_flexspi_set_device_config(const struct device *dev,

--- a/drivers/memc/memc_mcux_flexspi.h
+++ b/drivers/memc/memc_mcux_flexspi.h
@@ -8,12 +8,23 @@
 #include <sys/types.h>
 #include <fsl_flexspi.h>
 
+enum memc_flexspi_clock_t {
+	/* Flexspi clock 332M, DDR mode, internal clock 166M. */
+	MEMC_FLEXSPI_CLOCK_166M,
+	/* Flexspi clock 83M, DDR mode, internal clock 42M. */
+	MEMC_FLEXSPI_CLOCK_42M,
+};
+
 void memc_flexspi_wait_bus_idle(const struct device *dev);
 
 bool memc_flexspi_is_running_xip(const struct device *dev);
 
 int memc_flexspi_update_lut(const struct device *dev, uint32_t index,
 		const uint32_t *cmd, uint32_t count);
+
+int memc_flexspi_update_clock(const struct device *dev,
+		flexspi_device_config_t *device_config,
+		flexspi_port_t port, enum memc_flexspi_clock_t clock);
 
 int memc_flexspi_set_device_config(const struct device *dev,
 		const flexspi_device_config_t *device_config,

--- a/soc/arm/nxp_imx/rt/CMakeLists.txt
+++ b/soc/arm/nxp_imx/rt/CMakeLists.txt
@@ -29,6 +29,11 @@ if(CONFIG_PM)
   zephyr_sources_ifdef(CONFIG_SOC_SERIES_IMX_RT11XX power_rt11xx.c)
 endif()
 
+if (CONFIG_FLASH_MCUX_FLEXSPI_XIP AND CONFIG_SOC_SERIES_IMX_RT10XX AND CONFIG_MEMC)
+  zephyr_sources(flexspi_rt10xx.c)
+  zephyr_code_relocate(FILES flexspi_rt10xx.c LOCATION ITCM_TEXT)
+endif ()
+
 if (CONFIG_PM AND CONFIG_SOC_SERIES_IMX_RT10XX)
   zephyr_sources(power_rt10xx.c)
   zephyr_code_relocate(FILES power_rt10xx.c LOCATION ITCM_TEXT)

--- a/soc/arm/nxp_imx/rt/flexspi_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/flexspi_rt10xx.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <fsl_clock.h>
+#include <soc.h>
+
+/* reimplementation of non-inline CLOCK_GetFreq(kCLOCK_Usb1PllPfd0Clk) */
+static uint32_t clock_get_usb1_pll_pfd0_clk(void)
+{
+	uint32_t freq;
+
+	if (!CLOCK_IsPllEnabled(CCM_ANALOG, kCLOCK_PllUsb1)) {
+		return 0;
+	}
+
+	freq = CLOCK_GetPllBypassRefClk(CCM_ANALOG, kCLOCK_PllUsb1);
+
+	if (CLOCK_IsPllBypassed(CCM_ANALOG, kCLOCK_PllUsb1)) {
+		return freq;
+	}
+
+	freq *= ((CCM_ANALOG->PLL_USB1 & CCM_ANALOG_PLL_USB1_DIV_SELECT_MASK) != 0) ? 22 : 20;
+
+	/* get current USB1 PLL PFD output frequency */
+	freq /= (CCM_ANALOG->PFD_480 & CCM_ANALOG_PFD_480_PFD0_FRAC_MASK) >>
+		CCM_ANALOG_PFD_480_PFD0_FRAC_SHIFT;
+	freq *= 18;
+
+	return freq;
+}
+
+void flexspi_clock_set_div(uint32_t value)
+{
+	CLOCK_DisableClock(kCLOCK_FlexSpi);
+
+	CLOCK_SetDiv(kCLOCK_FlexspiDiv, value);
+
+	CLOCK_EnableClock(kCLOCK_FlexSpi);
+}
+
+uint32_t flexspi_clock_get_freq(void)
+{
+	uint32_t divider;
+	uint32_t frequency;
+
+	divider = CLOCK_GetDiv(kCLOCK_FlexspiDiv);
+
+	frequency = clock_get_usb1_pll_pfd0_clk() / (divider + 1);
+
+	return frequency;
+}

--- a/soc/arm/nxp_imx/rt/soc.h
+++ b/soc/arm/nxp_imx/rt/soc.h
@@ -45,6 +45,9 @@ void imxrt_pre_init_display_interface(void);
 void imxrt_post_init_display_interface(void);
 #endif
 
+void flexspi_clock_set_div(uint32_t value);
+uint32_t flexspi_clock_get_freq(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR fixes hyperflash write issues.
It implements the functionality from mcux-sdk-examples on board evkbimxrt1050:

- [flexspi_hyper_flash_ops.c](https://github.com/nxp-mcuxpresso/mcux-sdk-examples/blob/main/evkbimxrt1050/driver_examples/flexspi/hyper_flash/polling_transfer/flexspi_hyper_flash_ops.c) contains the clock logic.
- [flexspi_hyper_flash_polling_transfer.c](https://github.com/nxp-mcuxpresso/mcux-sdk-examples/blob/main/evkbimxrt1050/driver_examples/flexspi/hyper_flash/polling_transfer/flexspi_hyper_flash_polling_transfer.c) contains the flash_flexspi_hyperflash_lut array.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/53855