### PR TITLE
Bluetooth: Mesh: Fix issues with rescheduling points

### DIFF
--- a/subsys/bluetooth/mesh/app_keys.c
+++ b/subsys/bluetooth/mesh/app_keys.c
@@ -665,12 +665,12 @@ void bt_mesh_app_key_pending_store(void)
 			continue;
 		}
 
+		update->valid = 0U;
+
 		if (update->clear) {
 			clear_app_key(update->key_idx);
 		} else {
 			store_app_key(update->key_idx);
 		}
-
-		update->valid = 0U;
 	}
 }

--- a/subsys/bluetooth/mesh/cdb.c
+++ b/subsys/bluetooth/mesh/cdb.c
@@ -1023,27 +1023,29 @@ static void store_cdb_pending_nodes(void)
 
 	for (i = 0; i < ARRAY_SIZE(cdb_node_updates); ++i) {
 		struct node_update *update = &cdb_node_updates[i];
+		uint16_t addr;
 
 		if (update->addr == BT_MESH_ADDR_UNASSIGNED) {
 			continue;
 		}
 
-		LOG_DBG("addr: 0x%04x, clear: %d", update->addr, update->clear);
+		addr = update->addr;
+		update->addr = BT_MESH_ADDR_UNASSIGNED;
+
+		LOG_DBG("addr: 0x%04x, clear: %d", addr, update->clear);
 
 		if (update->clear) {
-			clear_cdb_node(update->addr);
+			clear_cdb_node(addr);
 		} else {
 			struct bt_mesh_cdb_node *node;
 
-			node = bt_mesh_cdb_node_get(update->addr);
+			node = bt_mesh_cdb_node_get(addr);
 			if (node) {
 				store_cdb_node(node);
 			} else {
-				LOG_WRN("Node 0x%04x not found", update->addr);
+				LOG_WRN("Node 0x%04x not found", addr);
 			}
 		}
-
-		update->addr = BT_MESH_ADDR_UNASSIGNED;
 	}
 }
 
@@ -1057,6 +1059,8 @@ static void store_cdb_pending_keys(void)
 		if (!update->valid) {
 			continue;
 		}
+
+		update->valid = 0U;
 
 		if (update->clear) {
 			if (update->app_key) {
@@ -1085,8 +1089,6 @@ static void store_cdb_pending_keys(void)
 				}
 			}
 		}
-
-		update->valid = 0U;
 	}
 }
 

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -189,6 +189,8 @@ void bt_mesh_reset(void)
 	memset(bt_mesh.flags, 0, sizeof(bt_mesh.flags));
 	atomic_set_bit(bt_mesh.flags, BT_MESH_INIT);
 
+	bt_mesh_scan_disable();
+
 	/* If this fails, the work handler will return early on the next
 	 * execution, as the device is not provisioned. If the device is
 	 * reprovisioned, the timer is always restarted.
@@ -231,7 +233,6 @@ void bt_mesh_reset(void)
 
 	(void)memset(bt_mesh.dev_key, 0, sizeof(bt_mesh.dev_key));
 
-	bt_mesh_scan_disable();
 	bt_mesh_beacon_disable();
 
 	bt_mesh_comp_unprovision();

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -831,12 +831,12 @@ void bt_mesh_subnet_pending_store(void)
 			continue;
 		}
 
+		update->valid = 0U;
+
 		if (update->clear) {
 			clear_net_key(update->key_idx);
 		} else {
 			store_subnet(update->key_idx);
 		}
-
-		update->valid = 0U;
 	}
 }


### PR DESCRIPTION
This PR fixes issues that could happen due to rescheduling points that can allow to enter a mesh code twice from different cooperative threads. Explanations are provided in the commit messages.