### PR TITLE
samples: net: zperf: convert duration to 64 bit precision

### DIFF
--- a/include/zephyr/net/zperf.h
+++ b/include/zephyr/net/zperf.h
@@ -49,9 +49,9 @@ struct zperf_results {
 	uint32_t nb_packets_lost;
 	uint32_t nb_packets_outorder;
 	uint32_t total_len;
-	uint32_t time_in_us;
+	uint64_t time_in_us;
 	uint32_t jitter_in_us;
-	uint32_t client_time_in_us;
+	uint64_t client_time_in_us;
 	uint32_t packet_size;
 	uint32_t nb_packets_errors;
 };

--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -81,7 +81,7 @@ const char *KBPS_UNIT[] = { "Mbps", "Kbps" };
 const uint32_t K[] = { 1024 * 1024, 1024, 0 };
 const char *K_UNIT[] = { "M", "K", "" };
 
-static void print_number(const struct shell *sh, uint32_t value,
+static void print_number(const struct shell *sh, uint64_t value,
 			 const uint32_t *divisor_arr, const char **units)
 {
 	const char **unit;
@@ -102,7 +102,7 @@ static void print_number(const struct shell *sh, uint32_t value,
 		shell_fprintf(sh, SHELL_NORMAL, "%u.%s%u %s", radix,
 			      (dec < 10) ? "0" : "", dec, *unit);
 	} else {
-		shell_fprintf(sh, SHELL_NORMAL, "%u %s", value, *unit);
+		shell_fprintf(sh, SHELL_NORMAL, "%llu %s", value, *unit);
 	}
 }
 

--- a/subsys/net/lib/zperf/zperf_tcp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_tcp_receiver.c
@@ -89,7 +89,7 @@ static void tcp_received(int sock, size_t datalen)
 			session->state = STATE_COMPLETED;
 
 			results.total_len = session->length;
-			results.time_in_us = k_ticks_to_us_ceil32(
+			results.time_in_us = k_ticks_to_us_ceil64(
 						time - session->start_time);
 
 			if (tcp_session_cb != NULL) {

--- a/subsys/net/lib/zperf/zperf_tcp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_tcp_uploader.c
@@ -88,7 +88,7 @@ static int tcp_upload(int sock,
 	/* Add result coming from the client */
 	results->nb_packets_sent = nb_packets;
 	results->client_time_in_us =
-				k_ticks_to_us_ceil32(end_time - start_time);
+				k_ticks_to_us_ceil64(end_time - start_time);
 	results->packet_size = packet_size;
 	results->nb_packets_errors = nb_errors;
 

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -149,9 +149,9 @@ static void udp_received(int sock, const struct sockaddr *addr, uint8_t *data,
 	case STATE_ONGOING:
 		if (id < 0) { /* Negative id means session end. */
 			struct zperf_results results = { 0 };
-			uint32_t duration;
+			uint64_t duration;
 
-			duration = k_ticks_to_us_ceil32(time -
+			duration = k_ticks_to_us_ceil64(time -
 							session->start_time);
 
 			/* Update state machine */

--- a/subsys/net/lib/zperf/zperf_udp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_udp_uploader.c
@@ -263,7 +263,7 @@ static int udp_upload(int sock, int port,
 	/* Add result coming from the client */
 	results->nb_packets_sent = nb_packets;
 	results->client_time_in_us =
-				k_ticks_to_us_ceil32(end_time - start_time);
+				k_ticks_to_us_ceil64(end_time - start_time);
 	results->packet_size = packet_size;
 
 	return 0;


### PR DESCRIPTION
 With the current duration variable type (uint32_t) the baud rate
 calculation will be incorrect after 70 minutes (the highest value
 of uint32_t). Convert the duration variable type to 64 bit precision
 so that baud rate calculation is correct after a long duration.
