### PR TITLE
Use dts to simplify and refactor code of STM32 ADC driver

### DIFF
--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32c0_reset.h>
 #include <freq.h>
 
@@ -281,6 +282,10 @@
 			#io-channel-cells = <1>;
 			temp-channel = <9>;
 			vref-channel = <10>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 	};
 

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32f0_1_3_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <freq.h>
@@ -312,6 +313,10 @@
 			#io-channel-cells = <1>;
 			temp-channel = <16>;
 			vref-channel = <17>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/adc/stm32f1_adc.h>
 #include <zephyr/dt-bindings/reset/stm32f0_1_3_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <freq.h>
@@ -325,6 +326,7 @@
 			#io-channel-cells = <1>;
 			temp-channel = <16>;
 			vref-channel = <17>;
+			resolutions = <STM32F1_ADC_RES(12)>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/adc/stm32f4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32f2_4_7_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <freq.h>
@@ -367,6 +368,10 @@
 			#io-channel-cells = <1>;
 			temp-channel = <16>;
 			vref-channel = <17>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/f3/stm32f3.dtsi>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 
 / {
 	soc {
@@ -108,6 +109,10 @@
 			#io-channel-cells = <1>;
 			temp-channel = <16>;
 			vref-channel = <18>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 	};
 };

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/f3/stm32f3.dtsi>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 
 / {
 	soc {
@@ -147,6 +148,10 @@
 			#io-channel-cells = <1>;
 			temp-channel = <16>;
 			vref-channel = <18>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 	};
 };

--- a/dts/arm/st/f3/stm32f334.dtsi
+++ b/dts/arm/st/f3/stm32f334.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/f3/stm32f3.dtsi>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 
 / {
 	soc {
@@ -32,6 +33,10 @@
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		rtc@40002800 {

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/f3/stm32f3.dtsi>
+#include <zephyr/dt-bindings/adc/stm32f1_adc.h>
 
 / {
 	soc {
@@ -180,6 +181,7 @@
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32F1_ADC_RES(12)>;
 		};
 
 		rtc@40002800 {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -14,6 +14,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/adc/stm32f4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32f2_4_7_reset.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
@@ -514,6 +515,10 @@
 			#io-channel-cells = <1>;
 			temp-channel = <18>;
 			vref-channel = <17>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/adc/stm32f4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32f2_4_7_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>
@@ -675,6 +676,10 @@
 			#io-channel-cells = <1>;
 			temp-channel = <18>;
 			vref-channel = <17>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		adc2: adc@40012100 {
@@ -684,6 +689,10 @@
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		adc3: adc@40012200 {
@@ -693,6 +702,10 @@
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -15,6 +15,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/reset/stm32g0_reset.h>
 #include <freq.h>
@@ -372,6 +373,10 @@
 			temp-channel = <12>;
 			vref-channel = <13>;
 			vbat-channel = <14>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -14,6 +14,7 @@
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32g4_l4_5_reset.h>
 #include <freq.h>
 
@@ -108,6 +109,10 @@
 			#io-channel-cells = <1>;
 			temp-channel = <16>;
 			vref-channel = <18>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		adc2: adc@50000100 {
@@ -117,6 +122,10 @@
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		dac1: dac@50000800 {

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/reset/stm32h5_reset.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <freq.h>
 
 / {
@@ -263,6 +264,10 @@
 			#io-channel-cells = <1>;
 			temp-channel = <16>;
 			vref-channel = <17>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		rtc: rtc@44007800 {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/adc/stm32h7_adc.h>
 #include <zephyr/dt-bindings/reset/stm32h7_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>
@@ -794,6 +795,13 @@
 			status = "disabled";
 		};
 
+		/*
+		 * For devices STM32H742, H743, H750 & H753, revision Y only,
+		 * resolution 14 and 12 shall be replaced, respectively, by
+		 * STM32_ADC_RES(14, 0x01) and STM32_ADC_RES(12, 0x02)
+		 * for all ADCs
+		 * See RM0433 for more details
+		 */
 		adc1: adc@40022000 {
 			compatible = "st,stm32-adc";
 			reg = <0x40022000 0x400>;
@@ -801,6 +809,11 @@
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(16, 0x00)
+				       STM32_ADC_RES(14, 0x05)
+				       STM32_ADC_RES(12, 0x06)
+				       STM32_ADC_RES(10, 0x03)
+				       STM32_ADC_RES(8, 0x07)>;
 		};
 
 		adc2: adc@40022100 {
@@ -810,6 +823,11 @@
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(16, 0x00)
+				       STM32_ADC_RES(14, 0x05)
+				       STM32_ADC_RES(12, 0x06)
+				       STM32_ADC_RES(10, 0x03)
+				       STM32_ADC_RES(8, 0x07)>;
 		};
 
 		/* dual mode: adc1 and adc2 coupled */
@@ -820,6 +838,11 @@
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(16, 0x00)
+				       STM32_ADC_RES(14, 0x05)
+				       STM32_ADC_RES(12, 0x06)
+				       STM32_ADC_RES(10, 0x03)
+				       STM32_ADC_RES(8, 0x07)>;
 		};
 
 		adc3: adc@58026000 {
@@ -829,6 +852,11 @@
 			interrupts = <127 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(16, 0x00)
+				       STM32_ADC_RES(14, 0x05)
+				       STM32_ADC_RES(12, 0x06)
+				       STM32_ADC_RES(10, 0x03)
+				       STM32_ADC_RES(8, 0x07)>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -40,9 +40,17 @@
 			status = "disabled";
 		};
 
+		/*
+		 * ADC3 on STM32H723, 725, 730, 733 & 735 is a 12-bit resolution
+		 * ADC, so we redefine the resolution for these devices.
+		 */
 		adc3: adc@58026000 {
 			temp-channel = <17>;
 			vref-channel = <18>;
+			resolutions = <STM32H72X_ADC3_RES(12, 0x00)
+				       STM32H72X_ADC3_RES(10, 0x01)
+				       STM32H72X_ADC3_RES(8, 0x02)
+				       STM32H72X_ADC3_RES(6, 0x03)>;
 		};
 
 		dmamux1: dmamux@40020800 {

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32l0_reset.h>
 #include <freq.h>
 
@@ -289,6 +290,10 @@
 			status = "disabled";
 			#io-channel-cells = <1>;
 			vref-channel = <17>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/adc/stm32f4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32l1_reset.h>
 #include <freq.h>
 
@@ -217,6 +218,10 @@
 			#io-channel-cells = <1>;
 			temp-channel = <16>;
 			vref-channel = <17>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -14,6 +14,7 @@
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32g4_l4_5_reset.h>
 #include <freq.h>
 
@@ -390,6 +391,10 @@
 			#io-channel-cells = <1>;
 			temp-channel = <17>;
 			vref-channel = <0>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		adc2: adc@50040100 {
@@ -399,6 +404,10 @@
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32g4_l4_5_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
@@ -624,6 +625,10 @@
 			#io-channel-cells = <1>;
 			temp-channel = <17>;
 			vref-channel = <0>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		adc2: adc@42028100 {
@@ -633,6 +638,10 @@
 			interrupts = <37 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		usb: usb@4000d400 {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -16,6 +16,7 @@
 #include <zephyr/dt-bindings/reset/stm32u5_reset.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-nor-psram.h>
+#include <zephyr/dt-bindings/adc/stm32u5_adc.h>
 #include <freq.h>
 
 / {
@@ -626,6 +627,10 @@
 			temp-channel = <19>;
 			vref-channel = <0>;
 			vbat-channel = <18>;
+			resolutions = <STM32_ADC_RES(14, 0x00)
+				       STM32_ADC_RES(12, 0x01)
+				       STM32_ADC_RES(10, 0x02)
+				       STM32_ADC_RES(8, 0x03)>;
 		};
 
 		adc4: adc@46021000 {
@@ -638,6 +643,10 @@
 			temp-channel = <13>;
 			vref-channel = <0>;
 			vbat-channel = <14>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		can {

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32wb_l_reset.h>
 #include <freq.h>
 
@@ -396,6 +397,10 @@
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		iwdg: watchdog@40003000 {

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32wb_l_reset.h>
 #include <freq.h>
 
@@ -332,6 +333,10 @@
 			#io-channel-cells = <1>;
 			temp-channel = <12>;
 			vref-channel = <13>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -44,5 +44,19 @@ properties:
     type: int
     description: Indicates the ADC channel of the internal vbat monitoring.
 
+  resolutions:
+    type: array
+    required: true
+    description: |
+      List of the resolutions supported by the ADC instance. They should be
+      values created with STM32_ADC_RES macro or similar. Their order is not
+      important. For example for STM32F4:
+        <STM32_ADC_RES(12, 0x00) STM32_ADC_RES(10, 0x01)
+         STM32_ADC_RES(8, 0x02)  STM32_ADC_RES(6, 0x03)>
+      The two parameters are the resolution (for example 10 bits) and the
+      corresponding register value (0x01 for a 10-bit resolution).
+      By design, these macros also contains all register information (address,
+      field offset and field mask) necessary to properly set the resolution.
+
 io-channel-cells:
   - input

--- a/include/zephyr/dt-bindings/adc/stm32_adc.h
+++ b/include/zephyr/dt-bindings/adc/stm32_adc.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 STMicrelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_STM32_ADC_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_STM32_ADC_H_
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+#define STM32_ADC_REG_MASK		BIT_MASK(8)
+#define STM32_ADC_REG_SHIFT		0U
+#define STM32_ADC_SHIFT_MASK		BIT_MASK(5)
+#define STM32_ADC_SHIFT_SHIFT		8U
+#define STM32_ADC_MASK_MASK		BIT_MASK(3)
+#define STM32_ADC_MASK_SHIFT		13U
+#define STM32_ADC_REG_VAL_MASK		BIT_MASK(3)
+#define STM32_ADC_REG_VAL_SHIFT		16U
+#define STM32_ADC_REAL_VAL_MASK		BIT_MASK(13)
+#define STM32_ADC_REAL_VAL_SHIFT	19U
+
+/**
+ * @brief STM32 ADC configuration bit field.
+ *
+ * - reg      (0..0xFF)       [ 0 : 7 ]
+ * - shift    (0..31)         [ 8 : 12 ]
+ * - mask     (0x1, 0x3, 0x7) [ 13 : 15 ]
+ * - reg_val  (0..7)          [ 16 : 18 ]
+ * - real_val (0..8191)       [ 19 : 31 ]
+ *
+ * @param reg ADC_x register offset
+ * @param shift Position within ADC_x.
+ * @param mask Mask for the ADC_x field.
+ * @param reg_val Register value (0, 1, ... 7).
+ * @param real_val Real corresponding value (0, 1, ... 8191).
+ */
+#define STM32_ADC(real_val, reg_val, mask, shift, reg)				\
+	((((reg) & STM32_ADC_REG_MASK) << STM32_ADC_REG_SHIFT) |		\
+	 (((shift) & STM32_ADC_SHIFT_MASK) << STM32_ADC_SHIFT_SHIFT) |		\
+	 (((mask) & STM32_ADC_MASK_MASK) << STM32_ADC_MASK_SHIFT) |		\
+	 (((reg_val) & STM32_ADC_REG_VAL_MASK) << STM32_ADC_REG_VAL_SHIFT) |	\
+	 (((real_val) & STM32_ADC_REAL_VAL_MASK) << STM32_ADC_REAL_VAL_SHIFT))
+
+#define STM32_ADC_GET_REAL_VAL(val)	\
+	(((val) >> STM32_ADC_REAL_VAL_SHIFT) & STM32_ADC_REAL_VAL_MASK)
+
+#define STM32_ADC_GET_REG_VAL(val)	\
+	(((val) >> STM32_ADC_REG_VAL_SHIFT) & STM32_ADC_REG_VAL_MASK)
+
+#define STM32_ADC_GET_MASK(val)		\
+	(((val) >> STM32_ADC_MASK_SHIFT) & STM32_ADC_MASK_MASK)
+
+#define STM32_ADC_GET_SHIFT(val)	\
+	(((val) >> STM32_ADC_SHIFT_SHIFT) & STM32_ADC_SHIFT_MASK)
+
+#define STM32_ADC_GET_REG(val)		\
+	(((val) >> STM32_ADC_REG_SHIFT) & STM32_ADC_REG_MASK)
+
+/*
+ * Macro used to store resolution info. STM32_ADC_RES_* macros are defined in
+ * respective stm32xx_adc.h files
+ */
+#define STM32_ADC_RES(resolution, reg_val)	\
+	STM32_ADC(resolution, reg_val, STM32_ADC_RES_MASK, STM32_ADC_RES_SHIFT, \
+		  STM32_ADC_RES_REG)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_STM32_ADC_H_ */

--- a/include/zephyr/dt-bindings/adc/stm32f1_adc.h
+++ b/include/zephyr/dt-bindings/adc/stm32f1_adc.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 STMicrelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_STM32F1_ADC_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_STM32F1_ADC_H_
+
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
+
+/*
+ * For STM32 F1 and similar, the only available resolution is 12-bit
+ * and there is no register to set it.
+ * We still need the macro to get the value of the resolution but the driver
+ * does not set the resolution in any register by checking that the register
+ * address is configured as 0xFF
+ */
+#define STM32_ADC_RES_REG	0xFF
+#define STM32_ADC_RES_SHIFT	0
+#define STM32_ADC_RES_MASK	0x00
+#define STM32_ADC_RES_REG_VAL	0x00
+
+#define STM32F1_ADC_RES(resolution)	\
+	STM32_ADC_RES(resolution, STM32_ADC_RES_REG_VAL)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_STM32F1_ADC_H_ */

--- a/include/zephyr/dt-bindings/adc/stm32f4_adc.h
+++ b/include/zephyr/dt-bindings/adc/stm32f4_adc.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023 STMicrelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_STM32F4_ADC_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_STM32F4_ADC_H_
+
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
+
+/* STM32 ADC resolution register for F4 and similar */
+#define STM32_ADC_RES_REG	0x04
+#define STM32_ADC_RES_SHIFT	24
+#define STM32_ADC_RES_MASK	BIT_MASK(2)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_STM32F4_ADC_H_ */

--- a/include/zephyr/dt-bindings/adc/stm32h7_adc.h
+++ b/include/zephyr/dt-bindings/adc/stm32h7_adc.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 STMicrelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_STM32H7_ADC_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_STM32H7_ADC_H_
+
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
+
+/* STM32 ADC resolution register for H7 and similar */
+#define STM32_ADC_RES_REG	0x0C
+#define STM32_ADC_RES_SHIFT	2
+#define STM32_ADC_RES_MASK	BIT_MASK(3)
+
+/*
+ * For STM32H72x & H73x, ADC3 is different and has a 12 to 6-bit resolution.
+ * The offset and the width of the resolution field need to be redefined.
+ */
+#define STM32H72X_ADC3_RES_SHIFT	3
+#define STM32H72X_ADC3_RES_MASK		0x03
+
+#define STM32H72X_ADC3_RES(resolution, reg_val)	\
+	STM32_ADC(resolution, reg_val, STM32H72X_ADC3_RES_MASK, \
+		  STM32H72X_ADC3_RES_SHIFT, STM32_ADC_RES_REG)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_STM32H7_ADC_H_ */

--- a/include/zephyr/dt-bindings/adc/stm32l4_adc.h
+++ b/include/zephyr/dt-bindings/adc/stm32l4_adc.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023 STMicrelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_STM32L4_ADC_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_STM32L4_ADC_H_
+
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
+
+/* STM32 ADC resolution register for L4 and similar */
+#define STM32_ADC_RES_REG	0x0C
+#define STM32_ADC_RES_SHIFT	3
+#define STM32_ADC_RES_MASK	BIT_MASK(2)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_STM32L4_ADC_H_ */

--- a/include/zephyr/dt-bindings/adc/stm32u5_adc.h
+++ b/include/zephyr/dt-bindings/adc/stm32u5_adc.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023 STMicrelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_STM32U5_ADC_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_STM32U5_ADC_H_
+
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
+
+/* STM32 ADC resolution register for U5 and similar */
+#define STM32_ADC_RES_REG	0x0C
+#define STM32_ADC_RES_SHIFT	2
+#define STM32_ADC_RES_MASK	BIT_MASK(2)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_STM32U5_ADC_H_ */


### PR DESCRIPTION
This PR is an attempt at simplifying the STM32 ADC driver and reduce code clutter.
The idea is to move as much info as possible to the dts to reduce the need of specific code in the driver.
This PR moves the ADC resolution to the dts for all series.