### PR TITLE
soc: mec15xx: program the 32khz clock

### DIFF
--- a/soc/arm/microchip_mec/mec1501/soc.c
+++ b/soc/arm/microchip_mec/mec1501/soc.c
@@ -12,6 +12,62 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
+
+/* MEC devices IDs with special PLL handling */
+#define MCHP_GCFG_DID_DEV_ID_MEC150x    0x0020U
+#define MCHP_TRIM_ENABLE_INT_OSCILLATOR 0x06U
+
+/*
+ * Select 32KHz clock source used for PLL reference.
+ * Options are:
+ * Internal 32KHz silicon oscillator.
+ * External parallel resonant crystal between XTAL1 and XTAL2 pins.
+ * External single ended crystal connected to XTAL2 pin.
+ * External 32KHz square wave from Host chipset/board on 32KHZ_IN pin.
+ * NOTES:
+ *   FW Program new value to VBAT CLK32 Enable register.
+ *   HW if new value != current value
+ *   HW endif
+ *   FW spin until PCR PLL lock is set.
+ *   32K stable and PLL locked.
+ *   PLL POR or clock source change can take up to 3ms to lock.
+ *   32KHZ_IN pin must be configured for 32KHZ_IN function.
+ *   Crystals vary and may take longer time to stabilize this will
+ *   affect PLL lock time.
+ *   Crystal do not like to be power cycled. If using a crystal
+ *   the board should supply a battery backed (VBAT) power rail.
+ *   The VBAT clock control register selecting 32KHz source is
+ *   connected to the VBAT power rail. If using a battery one can
+ *   check the VBAT Power Fail and Reset Status register for a VBAT POR.
+ */
+static void clk32_change(uint8_t new_clk32)
+{
+	/* Program new value. */
+	VBATR_REGS->CLK32_EN = new_clk32 & MCHP_VBATR_CLKEN_MASK;
+
+	/* Wait for PLL lock. HW state machine is configuring PLL. */
+	while ((PCR_REGS->OSC_ID & MCHP_PCR_OSC_ID_PLL_LOCK) == 0)
+		;
+}
+
+static int soc_clk32_init(void)
+{
+	uint8_t new_clk32 = MCHP_VBATR_USE_SIL_OSC;
+
+	/* Use internal 32KHz +/-2% silicon oscillator
+	 * if required performed OTP value override
+	 */
+	if (MCHP_DEVICE_ID() == MCHP_GCFG_DID_DEV_ID_MEC150x) {
+		if (MCHP_REVISION_ID() == MCHP_GCFG_REV_B0) {
+			VBATR_REGS->CKK32_TRIM = MCHP_TRIM_ENABLE_INT_OSCILLATOR;
+		}
+	}
+
+	clk32_change(new_clk32);
+
+	return 0;
+}
+
 /*
  * Initialize MEC1501 EC Interrupt Aggregator (ECIA) and external NVIC
  * inputs.
@@ -79,6 +135,17 @@ static int soc_init(const struct device *dev)
 
 	isave = __get_PRIMASK();
 	__disable_irq();
+
+	soc_clk32_init();
+
+	/*
+	 * On HW reset PCR Processor Clock Divider = 4 for 48/4 = 12 MHz.
+	 * Set clock divider = 1 for maximum speed.
+	 * NOTE1: This clock divider affects all Cortex-M4 core clocks.
+	 * If you change it you must reprogram SYSTICK to maintain the
+	 * same absolute time interval.
+	 */
+	PCR_REGS->PROC_CLK_CTRL = CONFIG_SOC_MEC1501_PROC_CLK_DIV;
 
 	soc_ecia_init();
 


### PR DESCRIPTION
Program the soc layer to use internal 32KHz silicon oscillator. This will help to lock the PLL for proper uart debug messages before the clock control driver gets a chance to program the 32Khz clock.

Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>