### PR TITLE
Fix typo: "CMSI" -> "CMSIS"

### DIFF
--- a/samples/subsys/portability/cmsis_rtos_v1/philosophers/README.rst
+++ b/samples/subsys/portability/cmsis_rtos_v1/philosophers/README.rst
@@ -1,7 +1,7 @@
 .. _cmsis_rtos_v1-sample:
 
-Dining Philosophers (CMSI RTOS V1 APIs)
-#######################################
+Dining Philosophers (CMSIS RTOS V1 APIs)
+########################################
 
 Overview
 ********

--- a/samples/subsys/portability/cmsis_rtos_v1/timer_synchronization/README.rst
+++ b/samples/subsys/portability/cmsis_rtos_v1/timer_synchronization/README.rst
@@ -1,7 +1,7 @@
 .. _cmsis_rtos_v1-sync_sample:
 
-Synchronization using CMSI RTOS V1 APIs
-#######################################
+Synchronization using CMSIS RTOS V1 APIs
+########################################
 
 Overview
 ********

--- a/samples/subsys/portability/cmsis_rtos_v2/philosophers/README.rst
+++ b/samples/subsys/portability/cmsis_rtos_v2/philosophers/README.rst
@@ -1,7 +1,7 @@
 .. _cmsis_rtos_v2-sample:
 
-Dining Philosophers (CMSI RTOS V2 APIs)
-#######################################
+Dining Philosophers (CMSIS RTOS V2 APIs)
+########################################
 
 Overview
 ********

--- a/samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/README.rst
+++ b/samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/README.rst
@@ -1,7 +1,7 @@
 .. _cmsis_rtos_v2-sync_sample:
 
-Synchronization using CMSI RTOS V2 APIs
-#######################################
+Synchronization using CMSIS RTOS V2 APIs
+########################################
 
 Overview
 ********


### PR DESCRIPTION
Signed-off-by: David Reiss <dreiss@meta.com>