### PR TITLE
arm: aarch32: cortex_a_r: disable interrupts before context switching

### DIFF
--- a/arch/arm/core/aarch32/cortex_a_r/exc_exit.S
+++ b/arch/arm/core/aarch32/cortex_a_r/exc_exit.S
@@ -129,6 +129,11 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_int_exit)
 	bl z_check_stack_sentinel
 #endif /* CONFIG_STACK_SENTINEL */
 
+	/* Disable nested interrupts while exiting, this should happens
+	 * before context switch also, to ensure interrupts are disabled.
+	 */
+	cpsid i
+
 #ifdef CONFIG_PREEMPT_ENABLED
 	/* Do not context switch if exiting a nested interrupt */
 	ldr r3, =_kernel
@@ -142,9 +147,6 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_int_exit)
 	blne z_arm_pendsv
 __EXIT_INT:
 #endif /* CONFIG_PREEMPT_ENABLED */
-
-	/* Disable nested interrupts while exiting */
-	cpsid i
 
 	/* Decrement interrupt nesting count */
 	ldr r2, =_kernel


### PR DESCRIPTION
…tching

Ultil now Cortex A/R aarch32 implementation for context switching expects that interrupts was disabled. This is true if a context switching happens at thread context.

But if a context switching happens at last action during interrupt context, this assumption is not true because the interrupts are still enabled (to allow nesting interrupts).

Disable interrupts at the last interrupt action to ensure the interrupts are always disabled before context switching is processed

Signed-off-by: Dat Nguyen Duy <dat.nguyenduy@nxp.com>