### PR TITLE
Revert "driver: uart: npcx: add missing tx/rx interrupt enabled checks"

### DIFF
--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -194,17 +194,9 @@ static void uart_npcx_irq_tx_disable(const struct device *dev)
 	inst->UFTCTL &= ~(BIT(NPCX_UFTCTL_TEMPTY_EN));
 }
 
-static bool uart_npcx_irq_tx_is_enabled(const struct device *dev)
-{
-	const struct uart_npcx_config *const config = dev->config;
-	struct uart_reg *const inst = config->inst;
-
-	return IS_BIT_SET(inst->UFTCTL, NPCX_UFTCTL_TEMPTY_EN);
-}
-
 static int uart_npcx_irq_tx_ready(const struct device *dev)
 {
-	return uart_npcx_tx_fifo_ready(dev) && uart_npcx_irq_tx_is_enabled(dev);
+	return uart_npcx_tx_fifo_ready(dev);
 }
 
 static int uart_npcx_irq_tx_complete(const struct device *dev)
@@ -232,14 +224,6 @@ static void uart_npcx_irq_rx_disable(const struct device *dev)
 	inst->UFRCTL &= ~(BIT(NPCX_UFRCTL_RNEMPTY_EN));
 }
 
-static bool uart_npcx_irq_rx_is_enabled(const struct device *dev)
-{
-	const struct uart_npcx_config *const config = dev->config;
-	struct uart_reg *const inst = config->inst;
-
-	return IS_BIT_SET(inst->UFRCTL, NPCX_UFRCTL_RNEMPTY_EN);
-}
-
 static int uart_npcx_irq_rx_ready(const struct device *dev)
 {
 	return uart_npcx_rx_fifo_available(dev);
@@ -263,8 +247,7 @@ static void uart_npcx_irq_err_disable(const struct device *dev)
 
 static int uart_npcx_irq_is_pending(const struct device *dev)
 {
-	return uart_npcx_irq_tx_ready(dev) ||
-		(uart_npcx_irq_rx_ready(dev) && uart_npcx_irq_rx_is_enabled(dev));
+	return (uart_npcx_irq_tx_ready(dev) || uart_npcx_irq_rx_ready(dev));
 }
 
 static int uart_npcx_irq_update(const struct device *dev)


### PR DESCRIPTION
This reverts commit 271b306.

In rare conditions, this commit causes the uart shell mechanism to corrupt on Cros ec system. Revert this commit on upstream repo first to avoid blocking the development. Will dig out why this symptom occurs later.

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>