### PR TITLE
Bluetooth: Host: Re-subscribe only after encrypt change

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1781,6 +1781,16 @@ enum {
 	 */
 	BT_GATT_SUBSCRIBE_FLAG_WRITE_PENDING,
 
+	/** @brief Sent flag
+	 *
+	 *  If set, indicates that a subscription request (CCC write) has
+	 *  already been sent in the active connection.
+	 *
+	 *  Used to avoid sending subscription requests multiple times when the
+	 *  @kconfig{CONFIG_BT_GATT_AUTO_RESUBSCRIBE} quirk is enabled.
+	 */
+	BT_GATT_SUBSCRIBE_FLAG_SENT,
+
 	BT_GATT_SUBSCRIBE_NUM_FLAGS
 };
 

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1778,6 +1778,8 @@ enum {
 	 *
 	 *  If set, indicates write operation is pending waiting remote end to
 	 *  respond.
+	 *
+	 *  @note Internal use only.
 	 */
 	BT_GATT_SUBSCRIBE_FLAG_WRITE_PENDING,
 
@@ -1788,6 +1790,8 @@ enum {
 	 *
 	 *  Used to avoid sending subscription requests multiple times when the
 	 *  @kconfig{CONFIG_BT_GATT_AUTO_RESUBSCRIBE} quirk is enabled.
+	 *
+	 *  @note Internal use only.
 	 */
 	BT_GATT_SUBSCRIBE_FLAG_SENT,
 

--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -62,6 +62,19 @@ config BT_EATT_AUTO_CONNECT
 
 endif # BT_EATT
 
+config BT_GATT_AUTO_RESUBSCRIBE
+	bool "Automatic re-subscription to characteristics"
+	default y
+	imply BT_GATT_AUTO_SEC_REQ
+	depends on BT_GATT_CLIENT
+	help
+	  Quirk: upon re-establishing a bonded connection, assumes the remote
+	  forgot the CCC values and sets them again. If this behavior is not
+	  desired for a particular subscription, set the
+	  `BT_GATT_SUBSCRIBE_FLAG_NO_RESUB` flag.
+	  This also means that upon a reconnection, the application will get an
+	  unprompted call to its `subscribe` callback.
+
 config BT_GATT_AUTO_SEC_REQ
 	bool "Automatic security re-establishment request as a peripheral"
 	default y


### PR DESCRIPTION
Wait until encrypt change to trigger the re-subscription quirk. Otherwise it could fail with insufficient security.

Also gate it behind a kconfig to make apparent its dependencies:

If `add_subscriptions()` is executed in the first place, that means that the device was bonded and thus that it has to encrypt the link eventually.

`BT_GATT_AUTO_SEC_REQ` should take care of that.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>
Co-authored-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemi.no>

Fixes #52195 (partially)