### PR TITLE
drivers: audio: dmic_nrfx_pdm: Fix a race condition in the driver

### DIFF
--- a/drivers/audio/dmic_nrfx_pdm.c
+++ b/drivers/audio/dmic_nrfx_pdm.c
@@ -95,8 +95,8 @@ static void event_handler(const struct device *dev, const nrfx_pdm_evt_t *evt)
 	}
 
 	if (stop) {
-		nrfx_pdm_stop();
 		drv_data->stopping = true;
+		nrfx_pdm_stop();
 	}
 }
 
@@ -461,8 +461,8 @@ static int dmic_nrfx_pdm_trigger(const struct device *dev,
 	case DMIC_TRIGGER_PAUSE:
 	case DMIC_TRIGGER_STOP:
 		if (drv_data->active) {
-			nrfx_pdm_stop();
 			drv_data->stopping = true;
+			nrfx_pdm_stop();
 		}
 		break;
 


### PR DESCRIPTION
When the PAUSE or STOP command was triggered, the driver was first requesting the PDM peripheral to stop by calling nrfx_pdm_stop() and then it was setting a flag that was in turn checked in an interrupt that was generated when the PDM actually stopped (what happens a moment after the stop request is made). But that setting of the flag could get preempted and the interrupt handler could get executed first causing the stopping to be not handled properly and leaving the driver falsely considering the peripheral as still active.
This commit reverses the order of these two operations to avoid the described race condition.
Same sequence is corrected also in event_handler(), but this is done only for consistency (it is in the interrupt handler itself so there is no race possible in this case).

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>