### PR TITLE
dts: riscv: mpfs_icicle devicetree cpu updates

### DIFF
--- a/dts/riscv/mpfs-icicle.dtsi
+++ b/dts/riscv/mpfs-icicle.dtsi
@@ -16,7 +16,7 @@
 		#size-cells = <0>;
 		cpu@0 {
 			clock-frequency = <0>;
-			compatible = "microsemi,miv", "riscv";
+			compatible = "riscv";
 			device_type = "cpu";
 			reg = < 0x0 >;
 			riscv,isa = "rv64imac";
@@ -30,7 +30,7 @@
 
 		cpu@1 {
 			clock-frequency = <0>;
-			compatible = "microsemi,miv", "riscv";
+			compatible = "riscv";
 			device_type = "cpu";
 			reg = < 0x1 >;
 			riscv,isa = "rv64imafdc";
@@ -44,7 +44,7 @@
 
 		cpu@2 {
 			clock-frequency = <0>;
-			compatible = "microsemi,miv", "riscv";
+			compatible = "riscv";
 			device_type = "cpu";
 			reg = < 0x2 >;
 			riscv,isa = "rv64imafdc";
@@ -58,7 +58,7 @@
 
 		cpu@3 {
 			clock-frequency = <0>;
-			compatible = "microsemi,miv", "riscv";
+			compatible = "riscv";
 			device_type = "cpu";
 			reg = < 0x3 >;
 			riscv,isa = "rv64imafdc";
@@ -72,7 +72,7 @@
 
 		cpu@4 {
 			clock-frequency = <0>;
-			compatible = "microsemi,miv", "riscv";
+			compatible = "riscv";
 			device_type = "cpu";
 			reg = < 0x4 >;
 			riscv,isa = "rv64imafdc";

--- a/dts/riscv/mpfs-icicle.dtsi
+++ b/dts/riscv/mpfs-icicle.dtsi
@@ -41,6 +41,48 @@
 				interrupt-controller;
 			};
 		};
+
+		cpu@2 {
+			clock-frequency = <0>;
+			compatible = "microsemi,miv", "riscv";
+			device_type = "cpu";
+			reg = < 0x2 >;
+			riscv,isa = "rv64imafdc";
+			hlic2: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+
+		cpu@3 {
+			clock-frequency = <0>;
+			compatible = "microsemi,miv", "riscv";
+			device_type = "cpu";
+			reg = < 0x3 >;
+			riscv,isa = "rv64imafdc";
+			hlic3: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+
+		cpu@4 {
+			clock-frequency = <0>;
+			compatible = "microsemi,miv", "riscv";
+			device_type = "cpu";
+			reg = < 0x4 >;
+			riscv,isa = "rv64imafdc";
+			hlic4: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
 	};
 
 	soc {
@@ -62,8 +104,13 @@
 		clint: clint@2000000 {
 			compatible = "sifive,clint0";
 			interrupts-extended = <&hlic0 3 &hlic0 7
-					       &hlic1 3 &hlic1 7>;
-			interrupt-names = "soft0", "timer0", "soft1", "timer1";
+					       &hlic1 3 &hlic1 7
+					       &hlic2 3 &hlic2 7
+						   &hlic3 3 &hlic3 7
+						   &hlic4 3 &hlic4 7>;
+			interrupt-names = "soft0", "timer0", "soft1", "timer1",
+							"soft2", "timer2", "soft3", "timer3",
+							"soft4", "timer4";
 			reg = <0x2000000 0x10000>;
 		};
 


### PR DESCRIPTION
Add the full complement of cpus available on the mpfs_icicle platform and
remove the old microsemi vendor compatible which is not correct for this platform.