### PR TITLE
drivers: i2c: eeprom_target: switch to dedicated driver compatible

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -142,6 +142,8 @@ Drivers and Sensors
 
 * EEPROM
 
+  * Switched from :dtcompatible:`atmel,at24` to dedicated :dtcompatible:`zephyr,i2c-target-eeprom` for I2C EEPROM target driver.
+
 * Entropy
 
 * ESPI

--- a/drivers/i2c/target/eeprom_target.c
+++ b/drivers/i2c/target/eeprom_target.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT atmel_at24
+#define DT_DRV_COMPAT zephyr_i2c_target_eeprom
 
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>

--- a/dts/bindings/mtd/zephyr,i2c-target-eeprom.yaml
+++ b/dts/bindings/mtd/zephyr,i2c-target-eeprom.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+description: Zephyr I2C target EEPROM
+
+compatible: "zephyr,i2c-target-eeprom"
+
+include: ["eeprom-base.yaml", i2c-device.yaml]

--- a/tests/drivers/i2c/i2c_target_api/boards/mec1501modular_assy6885.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mec1501modular_assy6885.overlay
@@ -6,23 +6,17 @@
 
 &i2c_smb_0 {
 	eeprom0: eeprom@54 {
-		compatible = "atmel,at24";
+		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
 		size = <1024>;
-		pagesize = <16>;
-		address-width = <8>;
-		timeout = <5>;
 	};
 };
 
 
 &i2c_smb_1 {
 	eeprom1: eeprom@56 {
-		compatible = "atmel,at24";
+		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <1024>;
-		pagesize = <16>;
-		address-width = <8>;
-		timeout = <5>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/mimxrt1060_evk.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mimxrt1060_evk.overlay
@@ -23,12 +23,9 @@
 &lpi2c1 {
 	status = "okay";
 	eeprom0: eeprom@54 {
-		compatible = "atmel,at24";
+		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
 		size = <1024>;
-		pagesize = <16>;
-		address-width = <8>;
-		timeout = <5>;
 	};
 };
 
@@ -37,11 +34,8 @@
 	pinctrl-0 = <&pinmux_lpi2c3>;
 	pinctrl-names = "default";
 	eeprom1: eeprom@56 {
-		compatible = "atmel,at24";
+		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <1024>;
-		pagesize = <16>;
-		address-width = <8>;
-		timeout = <5>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.overlay
@@ -2,23 +2,17 @@
 
 &i2c1 {
 	eeprom0: eeprom@54 {
-		compatible = "atmel,at24";
+		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
 		size = <1024>;
-		pagesize = <16>;
-		address-width = <8>;
-		timeout = <5>;
 	};
 };
 
 
 &i2c2 {
 	eeprom1: eeprom@56 {
-		compatible = "atmel,at24";
+		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <1024>;
-		pagesize = <16>;
-		address-width = <8>;
-		timeout = <5>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_g071rb.overlay
@@ -15,22 +15,16 @@
 
 &i2c1 {
 	eeprom0: eeprom@54 {
-		compatible = "atmel,at24";
+		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
 		size = <1024>;
-		pagesize = <16>;
-		address-width = <8>;
-		timeout = <5>;
 	};
 };
 
 &i2c2 {
 	eeprom1: eeprom@56 {
-		compatible = "atmel,at24";
+		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <1024>;
-		pagesize = <16>;
-		address-width = <8>;
-		timeout = <5>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l476rg.overlay
@@ -15,22 +15,16 @@
 
 &i2c1 {
 	eeprom0: eeprom@54 {
-		compatible = "atmel,at24";
+		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
 		size = <1024>;
-		pagesize = <16>;
-		address-width = <8>;
-		timeout = <5>;
 	};
 };
 
 &i2c3 {
 	eeprom1: eeprom@56 {
-		compatible = "atmel,at24";
+		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <1024>;
-		pagesize = <16>;
-		address-width = <8>;
-		timeout = <5>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/rpi_pico.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/rpi_pico.overlay
@@ -16,12 +16,9 @@
 
 &i2c0 {
 	eeprom0: eeprom@54 {
-		compatible = "atmel,at24";
+		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
 		size = <1024>;
-		pagesize = <16>;
-		address-width = <8>;
-		timeout = <5>;
 	};
 };
 
@@ -31,11 +28,8 @@
 	pinctrl-0 = <&i2c1_default>;
 	pinctrl-names = "default";
 	eeprom1: eeprom@56 {
-		compatible = "atmel,at24";
+		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <1024>;
-		pagesize = <16>;
-		address-width = <8>;
-		timeout = <5>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
@@ -2,23 +2,17 @@
 
 &i2c1 {
 	eeprom0: eeprom@54 {
-		compatible = "atmel,at24";
+		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
 		size = <1024>;
-		pagesize = <16>;
-		address-width = <8>;
-		timeout = <5>;
 	};
 };
 
 
 &i2c2 {
 	eeprom1: eeprom@56 {
-		compatible = "atmel,at24";
+		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <1024>;
-		pagesize = <16>;
-		address-width = <8>;
-		timeout = <5>;
 	};
 };


### PR DESCRIPTION
Create and use a new `zephyr,i2c-target-eeprom` compatible within I2C  eeprom target driver that allows to use that driver along with real atmel at24 EEPROM simultaneously.

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>