### PR TITLE
disk/sdmmc: stm32: Move clock configuration to device tree

### DIFF
--- a/drivers/disk/Kconfig.sdmmc
+++ b/drivers/disk/Kconfig.sdmmc
@@ -72,6 +72,15 @@ config SDMMC_STM32_HWFC
 	  Enable SDMMC Hardware Flow Control to avoid FIFO underrun (TX mode) and
 	  overrun (RX mode) errors.
 
+config SDMMC_STM32_CLOCK_CHECK
+	bool "Runtime SDMMC 48MHz clock check"
+	depends on SDMMC_STM32
+	default y
+	help
+	  Enable SDMMC clock 48MHz configuration runtime check.
+	  In specific cases, this check might provide wrong verdict and should
+	  be disabled.
+
 module = SDMMC
 module-str = sdmmc
 source "subsys/logging/Kconfig.template.log_config"

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -529,7 +529,8 @@
 		sdmmc1: sdmmc@40012c00 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012c00 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000800>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000800>,
+				 <&rcc STM32_SRC_PLL_Q NO_SEL>;
 			resets = <&rctl STM32_RESET(APB2, 11U)>;
 			interrupts = <49 0>;
 			status = "disabled";

--- a/dts/arm/st/f4/stm32f410Xb.dtsi
+++ b/dts/arm/st/f4/stm32f410Xb.dtsi
@@ -7,6 +7,8 @@
 #include <mem.h>
 #include <st/f4/stm32f410.dtsi>
 
+/delete-node/ &sdmmc1;
+
 / {
 	sram0: memory@20000000 {
 		reg = <0x20000000 DT_SIZE_K(32)>;

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -180,6 +180,11 @@
 			num-bidir-endpoints = <6>;
 		};
 
+		sdmmc1: sdmmc@40012c00 {
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000800>,
+				 <&rcc STM32_SRC_SYSCLK SDIO_SEL(1)>;
+		};
+
 		quadspi: quadspi@a0001000 {
 			compatible = "st,stm32-qspi";
 			#address-cells = <0x1>;

--- a/dts/arm/st/f4/stm32f469.dtsi
+++ b/dts/arm/st/f4/stm32f469.dtsi
@@ -8,6 +8,11 @@
 
 / {
 	soc {
+		sdmmc1: sdmmc@40012c00 {
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000800>,
+				 <&rcc STM32_SRC_SYSCLK SDMMC_SEL(1)>;
+		};
+
 		usbotg_fs: usb@50000000 {
 			num-bidir-endpoints = <6>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000080>,

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -718,7 +718,8 @@
 			compatible = "st,stm32-rng";
 			reg = <0x50060800 0x400>;
 			interrupts = <80 0>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000040>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000040>,
+				 <&rcc STM32_SRC_PLL_Q CK48M_SEL(0)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -725,7 +725,8 @@
 		sdmmc1: sdmmc@40012c00 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012c00 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000800>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000800>,
+				 <&rcc STM32_SRC_PLL_Q SDMMC1_SEL(0)>;
 			resets = <&rctl STM32_RESET(APB2, 11U)>;
 			interrupts = <49 0>;
 			status = "disabled";

--- a/dts/arm/st/f7/stm32f723.dtsi
+++ b/dts/arm/st/f7/stm32f723.dtsi
@@ -41,7 +41,8 @@
 		sdmmc2: sdmmc@40011c00 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40011c00 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>,
+				 <&rcc STM32_SRC_PLL_Q SDMMC2_SEL(0)>;
 			resets = <&rctl STM32_RESET(APB2, 7U)>;
 			interrupts = <103 0>;
 			status = "disabled";

--- a/dts/arm/st/f7/stm32f767.dtsi
+++ b/dts/arm/st/f7/stm32f767.dtsi
@@ -82,7 +82,8 @@
 		sdmmc2: sdmmc@40011c00 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40011c00 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>,
+				 <&rcc STM32_SRC_PLL_Q SDMMC2_SEL(0)>;
 			resets = <&rctl STM32_RESET(APB2, 7U)>;
 			interrupts = <103 0>;
 			status = "disabled";

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -816,7 +816,8 @@
 		sdmmc1: sdmmc@52007000 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x52007000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00010000>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00010000>,
+				 <&rcc STM32_SRC_HSI48 SDMMC_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB3, 16U)>;
 			interrupts = <49 0>;
 			status = "disabled";
@@ -825,7 +826,8 @@
 		sdmmc2: sdmmc@48022400 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x48022400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000100>,
+				 <&rcc STM32_SRC_HSI48 SDMMC_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB2, 8U)>;
 			interrupts = <124 0>;
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l431.dtsi
+++ b/dts/arm/st/l4/stm32l431.dtsi
@@ -8,6 +8,14 @@
 
 / {
 	soc {
+		clocks {
+			clk_hsi48: clk-hsi48 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(48)>;
+				status = "disabled";
+			};
+		};
 
 		pinctrl: pin-controller@48000000 {
 
@@ -111,7 +119,8 @@
 		sdmmc1: sdmmc@40012800 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012800 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000400>,
+				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			interrupts = <49 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -237,7 +237,8 @@
 		sdmmc1: sdmmc@40012800 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012800 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000400>,
+				 <&rcc STM32_SRC_MSI CLK48_SEL(3)>;
 			resets = <&rctl STM32_RESET(APB2, 10U)>;
 			interrupts = <49 0>;
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -320,7 +320,8 @@
 		sdmmc1: sdmmc@50062400 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x50062400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x400000>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x400000>,
+				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB2, 22U)>;
 			interrupts = <49 0>;
 			status = "disabled";

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -360,7 +360,8 @@
 		sdmmc1: sdmmc@420c8000 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x420c8000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00400000>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00400000>,
+				 <&rcc STM32_SRC_HSI48 SDMMC_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB2, 22U)>;
 			interrupts = <78 0>;
 			status = "disabled";


### PR DESCRIPTION
Similarly to https://github.com/zephyrproject-rtos/zephyr/pull/53258 and https://github.com/zephyrproject-rtos/zephyr/pull/53719 update SDMMC driver to get clock configuration from device tree.

Noticeable changes:

STM32L4 are now using MSI or HSI48 instead of PLLSAI as SDMMC CLK
A runtime check is implemented to check SDMMC clock config correctness