### PR TITLE
drivers: uart_mux: Fix documentation of uart_mux_recv()

### DIFF
--- a/drivers/console/uart_mux_internal.h
+++ b/drivers/console/uart_mux_internal.h
@@ -26,15 +26,15 @@ int uart_mux_send(const struct device *uart, const uint8_t *buf, size_t size);
  * @brief Receive unmuxed data.
  *
  * @param mux UART mux device structure.
- * @param uart Real UART device structure.
- * @param dlci_address DLCI id for the virtual muxing channel
- * @param timeout Amount of time to wait for the channel creation.
+ * @param dlci DLCI id for the muxing channel that should receive the data.
+ * @param data Received data (already unmuxed)
+ * @param len Length of the received data
  *
  * @retval >=0 No errors, number of bytes received
  * @retval <0 Error
  */
 int uart_mux_recv(const struct device *mux, struct gsm_dlci *dlci,
-			    uint8_t *data, size_t len);
+		  uint8_t *data, size_t len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The uart_mux_recv() documentation was wrong, the function parameters were incorrectly documented.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>