### PR TITLE
drivers: usb: Enable High speed Kconfig for NXP controllers

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -152,11 +152,13 @@ choice USB_MCUX_CONTROLLER_TYPE
 config USB_DC_NXP_EHCI
 	bool "MXRT EHCI USB Device Controller"
 	select NOCACHE_MEMORY if HAS_MCUX_CACHE
+	select USB_DC_HAS_HS_SUPPORT
 	help
 	  Kinetis and RT EHCI USB Device Controller Driver.
 
 config USB_DC_NXP_LPCIP3511
 	bool "LPC USB Device Controller"
+	select USB_DC_HAS_HS_SUPPORT
 	help
 	  LPC USB Device Controller Driver.
 


### PR DESCRIPTION
Enable the USB_DC_HAS_HS_SUPPORT Kconfig for NXP controllers that support High speed.

Fixes #53697
