### PR TITLE
xtensa: stop execution under simulator for double exception

### DIFF
--- a/arch/xtensa/core/xtensa-asm2-util.S
+++ b/arch/xtensa/core/xtensa-asm2-util.S
@@ -7,6 +7,10 @@
 #include <offsets.h>
 #include <zsr.h>
 
+#if defined(CONFIG_SIMULATOR_XTENSA) || defined(XT_SIMULATOR)
+#include <xtensa/simcall.h>
+#endif
+
 /*
  * xtensa_spill_reg_windows
  *
@@ -365,7 +369,17 @@ _KernelExceptionVector:
 .pushsection .DoubleExceptionVector.text, "ax"
 .global _DoubleExceptionVector
 _DoubleExceptionVector:
-#if XCHAL_HAVE_DEBUG
+#if defined(CONFIG_SIMULATOR_XTENSA) || defined(XT_SIMULATOR)
+1:
+/* Tell simulator to stop executing here, instead of trying to do
+ * an infinite loop (see below). Greatly help with using tracing in
+ * simulator so that traces will not have infinite iterations of
+ * jumps.
+ */
+	movi a3, 1
+	movi a2, SYS_exit
+	simcall
+#elif XCHAL_HAVE_DEBUG
 /* Signals an unhandled double exception */
 1:	break	1, 4
 #else


### PR DESCRIPTION
If running under Xtensa simulator, it is good to tell simulator to stop execution once we reach double exception, as the current double exception handler is simply an endless loop. If we turn on tracing in the simulator, the output file would contain an infinite iteration of this endless loop, and the simulator needs to be stopped manually before the file size goes out of control. So we need to tell the simulator to stop once we reach this point instead of doing an endless loop.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>