### PR TITLE
samples/boards/intel_adsp: Make sample work with twister

### DIFF
--- a/samples/boards/intel_adsp/code_relocation/README.rst
+++ b/samples/boards/intel_adsp/code_relocation/README.rst
@@ -16,7 +16,7 @@ linker script to ensure that.
 Building and Running
 ********************
 
-This application can be built and executed on QEMU as follows:
+This application can be built and executed as follows:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world

--- a/samples/boards/intel_adsp/code_relocation/sample.yaml
+++ b/samples/boards/intel_adsp/code_relocation/sample.yaml
@@ -1,3 +1,7 @@
 sample:
   description: Code relocation sample for Intel ADSP Cavs.
   name: cavs_code_reloc
+tests:
+  sample.intel_adsp.code_relocation:
+    platform_allow: intel_adsp_cavs18 intel_adsp_cavs25
+    tags: linker


### PR DESCRIPTION
sample.yaml was missing a tests section, making it unable to run with twister. This patch adds the section.

While at that, fix an issue in the sample README.rst.

Fixes #53656.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>