### PR TITLE
net: ipv4: Using a different API to ensure that IPv4 is enabled

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4162,8 +4162,8 @@ exit:
 static void init_igmp(struct net_if *iface)
 {
 #if defined(CONFIG_NET_IPV4_IGMP)
-	/* Ensure IPv4 is enabled for this interface */
-	if (iface->config.ip.ipv4 == NULL) {
+	/* Ensure IPv4 is enabled for this interface. */
+	if (net_if_config_ipv4_get(iface, NULL)) {
 		return;
 	}
 


### PR DESCRIPTION
When init_igmp is called the ipv4 pointer was not initialised. Therefore, a different API needs to be used to ensure that IPv4 is enabled when calling init_igmp.

Fixes #53913

Signed-off-by: Chamira Perera <chamira.perera@audinate.com>