### PR TITLE
Add support for get/set attributes in sensor shell

### DIFF
--- a/drivers/sensor/icm42688/icm42688.h
+++ b/drivers/sensor/icm42688/icm42688.h
@@ -42,6 +42,37 @@ enum icm42688_accel_fs {
 	ICM42688_ACCEL_FS_2G,
 };
 
+static inline enum icm42688_accel_fs icm42688_accel_fs_to_reg(uint8_t g)
+{
+	if (g >= 16) {
+		return ICM42688_ACCEL_FS_16G;
+	} else if (g >= 8) {
+		return ICM42688_ACCEL_FS_8G;
+	} else if (g >= 4) {
+		return ICM42688_ACCEL_FS_4G;
+	} else {
+		return ICM42688_ACCEL_FS_2G;
+	}
+}
+
+static inline void icm42688_accel_reg_to_fs(enum icm42688_accel_fs fs, struct sensor_value *out)
+{
+	switch (fs) {
+	case ICM42688_ACCEL_FS_16G:
+		sensor_g_to_ms2(16, out);
+		return;
+	case ICM42688_ACCEL_FS_8G:
+		sensor_g_to_ms2(8, out);
+		return;
+	case ICM42688_ACCEL_FS_4G:
+		sensor_g_to_ms2(4, out);
+		return;
+	case ICM42688_ACCEL_FS_2G:
+		sensor_g_to_ms2(2, out);
+		return;
+	}
+}
+
 /**
  * @brief Gyroscope scale options
  */
@@ -55,6 +86,57 @@ enum icm42688_gyro_fs {
 	ICM42688_GYRO_FS_31_25,
 	ICM42688_GYRO_FS_15_625,
 };
+
+static inline enum icm42688_gyro_fs icm42688_gyro_fs_to_reg(uint16_t dps)
+{
+	if (dps >= 2000) {
+		return ICM42688_GYRO_FS_2000;
+	} else if (dps >= 1000) {
+		return ICM42688_GYRO_FS_1000;
+	} else if (dps >= 500) {
+		return ICM42688_GYRO_FS_500;
+	} else if (dps >= 250) {
+		return ICM42688_GYRO_FS_250;
+	} else if (dps >= 125) {
+		return ICM42688_GYRO_FS_125;
+	} else if (dps >= 62) {
+		return ICM42688_GYRO_FS_62_5;
+	} else if (dps >= 31) {
+		return ICM42688_GYRO_FS_31_25;
+	} else {
+		return ICM42688_GYRO_FS_15_625;
+	}
+}
+
+static inline void icm42688_gyro_reg_to_fs(enum icm42688_gyro_fs fs, struct sensor_value *out)
+{
+	switch (fs) {
+	case ICM42688_GYRO_FS_2000:
+		sensor_degrees_to_rad(2000, out);
+		return;
+	case ICM42688_GYRO_FS_1000:
+		sensor_degrees_to_rad(1000, out);
+		return;
+	case ICM42688_GYRO_FS_500:
+		sensor_degrees_to_rad(500, out);
+		return;
+	case ICM42688_GYRO_FS_250:
+		sensor_degrees_to_rad(250, out);
+		return;
+	case ICM42688_GYRO_FS_125:
+		sensor_degrees_to_rad(125, out);
+		return;
+	case ICM42688_GYRO_FS_62_5:
+		sensor_10udegrees_to_rad(6250000, out);
+		return;
+	case ICM42688_GYRO_FS_31_25:
+		sensor_10udegrees_to_rad(3125000, out);
+		return;
+	case ICM42688_GYRO_FS_15_625:
+		sensor_10udegrees_to_rad(1562500, out);
+		return;
+	}
+}
 
 /**
  * @brief Accelerometer data rate options
@@ -77,6 +159,107 @@ enum icm42688_accel_odr {
 	ICM42688_ACCEL_ODR_500,
 };
 
+static inline enum icm42688_accel_odr icm42688_accel_hz_to_reg(uint16_t hz)
+{
+	if (hz >= 32000) {
+		return ICM42688_ACCEL_ODR_32000;
+	} else if (hz >= 16000) {
+		return ICM42688_ACCEL_ODR_16000;
+	} else if (hz >= 8000) {
+		return ICM42688_ACCEL_ODR_8000;
+	} else if (hz >= 4000) {
+		return ICM42688_ACCEL_ODR_4000;
+	} else if (hz >= 2000) {
+		return ICM42688_ACCEL_ODR_2000;
+	} else if (hz >= 1000) {
+		return ICM42688_ACCEL_ODR_1000;
+	} else if (hz >= 500) {
+		return ICM42688_ACCEL_ODR_500;
+	} else if (hz >= 200) {
+		return ICM42688_ACCEL_ODR_200;
+	} else if (hz >= 100) {
+		return ICM42688_ACCEL_ODR_100;
+	} else if (hz >= 50) {
+		return ICM42688_ACCEL_ODR_50;
+	} else if (hz >= 25) {
+		return ICM42688_ACCEL_ODR_25;
+	} else if (hz >= 12) {
+		return ICM42688_ACCEL_ODR_12_5;
+	} else if (hz >= 6) {
+		return ICM42688_ACCEL_ODR_6_25;
+	} else if (hz >= 3) {
+		return ICM42688_ACCEL_ODR_3_125;
+	} else {
+		return ICM42688_ACCEL_ODR_1_5625;
+	}
+}
+
+static inline void icm42688_accel_reg_to_hz(enum icm42688_accel_odr odr, struct sensor_value *out)
+{
+	switch (odr) {
+	case ICM42688_ACCEL_ODR_32000:
+		out->val1 = 32000;
+		out->val2 = 0;
+		return;
+	case ICM42688_ACCEL_ODR_16000:
+		out->val1 = 1600;
+		out->val2 = 0;
+		return;
+	case ICM42688_ACCEL_ODR_8000:
+		out->val1 = 8000;
+		out->val2 = 0;
+		return;
+	case ICM42688_ACCEL_ODR_4000:
+		out->val1 = 4000;
+		out->val2 = 0;
+		return;
+	case ICM42688_ACCEL_ODR_2000:
+		out->val1 = 2000;
+		out->val2 = 0;
+		return;
+	case ICM42688_ACCEL_ODR_1000:
+		out->val1 = 1000;
+		out->val2 = 0;
+		return;
+	case ICM42688_ACCEL_ODR_500:
+		out->val1 = 500;
+		out->val2 = 0;
+		return;
+	case ICM42688_ACCEL_ODR_200:
+		out->val1 = 200;
+		out->val2 = 0;
+		return;
+	case ICM42688_ACCEL_ODR_100:
+		out->val1 = 100;
+		out->val2 = 0;
+		return;
+	case ICM42688_ACCEL_ODR_50:
+		out->val1 = 50;
+		out->val2 = 0;
+		return;
+	case ICM42688_ACCEL_ODR_25:
+		out->val1 = 25;
+		out->val2 = 0;
+		return;
+	case ICM42688_ACCEL_ODR_12_5:
+		out->val1 = 12;
+		out->val2 = 500000;
+		return;
+	case ICM42688_ACCEL_ODR_6_25:
+		out->val1 = 6;
+		out->val2 = 250000;
+		return;
+	case ICM42688_ACCEL_ODR_3_125:
+		out->val1 = 3;
+		out->val2 = 125000;
+		return;
+	case ICM42688_ACCEL_ODR_1_5625:
+		out->val1 = 1;
+		out->val2 = 562500;
+		return;
+	}
+}
+
 /**
  * @brief Gyroscope data rate options
  */
@@ -94,6 +277,89 @@ enum icm42688_gyro_odr {
 	ICM42688_GYRO_ODR_12_5,
 	ICM42688_GYRO_ODR_500 = 0xF
 };
+
+static inline enum icm42688_gyro_odr icm42688_gyro_odr_to_reg(uint16_t hz)
+{
+	if (hz >= 32000) {
+		return ICM42688_GYRO_ODR_32000;
+	} else if (hz >= 16000) {
+		return ICM42688_GYRO_ODR_16000;
+	} else if (hz >= 8000) {
+		return ICM42688_GYRO_ODR_8000;
+	} else if (hz >= 4000) {
+		return ICM42688_GYRO_ODR_4000;
+	} else if (hz >= 2000) {
+		return ICM42688_GYRO_ODR_2000;
+	} else if (hz >= 1000) {
+		return ICM42688_GYRO_ODR_1000;
+	} else if (hz >= 500) {
+		return ICM42688_GYRO_ODR_500;
+	} else if (hz >= 200) {
+		return ICM42688_GYRO_ODR_200;
+	} else if (hz >= 100) {
+		return ICM42688_GYRO_ODR_100;
+	} else if (hz >= 50) {
+		return ICM42688_GYRO_ODR_50;
+	} else if (hz >= 25) {
+		return ICM42688_GYRO_ODR_25;
+	} else {
+		return ICM42688_GYRO_ODR_12_5;
+	}
+}
+
+static inline void icm42688_gyro_reg_to_odr(enum icm42688_gyro_odr odr, struct sensor_value *out)
+{
+	switch (odr) {
+	case ICM42688_GYRO_ODR_32000:
+		out->val1 = 32000;
+		out->val2 = 0;
+		return;
+	case ICM42688_GYRO_ODR_16000:
+		out->val1 = 16000;
+		out->val2 = 0;
+		return;
+	case ICM42688_GYRO_ODR_8000:
+		out->val1 = 8000;
+		out->val2 = 0;
+		return;
+	case ICM42688_GYRO_ODR_4000:
+		out->val1 = 4000;
+		out->val2 = 0;
+		return;
+	case ICM42688_GYRO_ODR_2000:
+		out->val1 = 2000;
+		out->val2 = 0;
+		return;
+	case ICM42688_GYRO_ODR_1000:
+		out->val1 = 1000;
+		out->val2 = 0;
+		return;
+	case ICM42688_GYRO_ODR_500:
+		out->val1 = 500;
+		out->val2 = 0;
+		return;
+	case ICM42688_GYRO_ODR_200:
+		out->val1 = 200;
+		out->val2 = 0;
+		return;
+	case ICM42688_GYRO_ODR_100:
+		out->val1 = 100;
+		out->val2 = 0;
+		return;
+	case ICM42688_GYRO_ODR_50:
+		out->val1 = 50;
+		out->val2 = 0;
+		return;
+	case ICM42688_GYRO_ODR_25:
+		out->val1 = 25;
+		out->val2 = 0;
+		return;
+	case ICM42688_GYRO_ODR_12_5:
+		out->val1 = 12;
+		out->val2 = 500000;
+		return;
+	}
+}
 
 /**
  * @brief All sensor configuration options

--- a/drivers/sensor/icm42688/icm42688_common.c
+++ b/drivers/sensor/icm42688/icm42688_common.c
@@ -103,6 +103,9 @@ int icm42688_configure(const struct device *dev, struct icm42688_cfg *cfg)
 		LOG_ERR("Error writing PWR_MGMT0");
 		return -EINVAL;
 	}
+	dev_data->cfg.gyro_mode = cfg->gyro_mode;
+	dev_data->cfg.accel_mode = cfg->accel_mode;
+	dev_data->cfg.temp_dis = cfg->temp_dis;
 
 	/* Need to wait at least 200us before updating more registers
 	 * see datasheet 14.36
@@ -117,6 +120,8 @@ int icm42688_configure(const struct device *dev, struct icm42688_cfg *cfg)
 		LOG_ERR("Error writing ACCEL_CONFIG0");
 		return -EINVAL;
 	}
+	dev_data->cfg.accel_odr = cfg->accel_odr;
+	dev_data->cfg.accel_fs = cfg->accel_fs;
 
 	res = icm42688_spi_single_write(&dev_cfg->spi, REG_GYRO_CONFIG0,
 					FIELD_PREP(MASK_GYRO_ODR, cfg->gyro_odr) |
@@ -126,6 +131,8 @@ int icm42688_configure(const struct device *dev, struct icm42688_cfg *cfg)
 		LOG_ERR("Error writing GYRO_CONFIG0");
 		return -EINVAL;
 	}
+	dev_data->cfg.gyro_odr = cfg->gyro_odr;
+	dev_data->cfg.gyro_fs = cfg->gyro_fs;
 
 	/*
 	 * Accelerometer sensor need at least 10ms startup time
@@ -151,6 +158,7 @@ int icm42688_configure(const struct device *dev, struct icm42688_cfg *cfg)
 			LOG_ERR("Error writing FIFO_CONFIG3");
 			return -EINVAL;
 		}
+		dev_data->cfg.fifo_wm = cfg->fifo_wm;
 
 		/* TODO we have two interrupt lines, either can be used for watermark, choose 1 for
 		 *   now...
@@ -176,10 +184,12 @@ int icm42688_configure(const struct device *dev, struct icm42688_cfg *cfg)
 			LOG_ERR("Error writing FIFO_CONFIG1");
 			return -EINVAL;
 		}
+		dev_data->cfg.fifo_hires = cfg->fifo_hires;
 
 		/* Begin streaming */
 		res = icm42688_spi_single_write(&dev_cfg->spi, REG_FIFO_CONFIG,
 						FIELD_PREP(MASK_FIFO_MODE, BIT_FIFO_MODE_STREAM));
+		dev_data->cfg.fifo_en = true;
 	}
 
 	return res;

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -16,6 +16,15 @@
 	"when no channels are provided. Syntax:\n"                                                 \
 	"<device_name> <channel name 0> .. <channel name N>"
 
+#define SENSOR_ATTR_GET_HELP                                                                       \
+	"Get the sensor's channel attribute. Syntax:\n"                                            \
+	"<device_name> [<channel_name 0> <attribute_name 0> .. "                                   \
+	"<channel_name N> <attribute_name N>]"
+
+#define SENSOR_ATTR_SET_HELP                                                                       \
+	"Set the sensor's channel attribute.\n"                                                    \
+	"<device_name> <channel_name> <attribute_name> <value>"
+
 #define SENSOR_INFO_HELP "Get sensor info, such as vendor and model name, for all sensors."
 
 const char *sensor_channel_name[SENSOR_CHAN_ALL] = {
@@ -78,29 +87,105 @@ const char *sensor_channel_name[SENSOR_CHAN_ALL] = {
 	[SENSOR_CHAN_GAUGE_DESIRED_CHARGING_CURRENT] = "gauge_desired_charging_current",
 };
 
-static int handle_channel_by_name(const struct shell *shell, const struct device *dev,
-				  const char *channel_name)
+static const char *sensor_attribute_name[SENSOR_ATTR_COMMON_COUNT] = {
+	[SENSOR_ATTR_SAMPLING_FREQUENCY] = "sampling_frequency",
+	[SENSOR_ATTR_LOWER_THRESH] = "lower_thresh",
+	[SENSOR_ATTR_UPPER_THRESH] = "upper_thresh",
+	[SENSOR_ATTR_SLOPE_TH] = "slope_th",
+	[SENSOR_ATTR_SLOPE_DUR] = "slope_dur",
+	[SENSOR_ATTR_HYSTERESIS] = "hysteresis",
+	[SENSOR_ATTR_OVERSAMPLING] = "oversampling",
+	[SENSOR_ATTR_FULL_SCALE] = "full_scale",
+	[SENSOR_ATTR_OFFSET] = "offset",
+	[SENSOR_ATTR_CALIB_TARGET] = "calib_target",
+	[SENSOR_ATTR_CONFIGURATION] = "configuration",
+	[SENSOR_ATTR_CALIBRATION] = "calibration",
+	[SENSOR_ATTR_FEATURE_MASK] = "feature_mask",
+	[SENSOR_ATTR_ALERT] = "alert",
+	[SENSOR_ATTR_FF_DUR] = "ff_dur",
+};
+
+enum dynamic_command_context {
+	NONE,
+	CTX_GET,
+	CTX_ATTR_GET_SET,
+};
+
+static enum dynamic_command_context current_cmd_ctx = NONE;
+
+static int parse_named_int(const char *name, const char *heystack[], size_t count)
 {
-	struct sensor_value value[3];
 	char *endptr;
-	int err;
 	int i;
 
 	/* Attempt to parse channel name as a number first */
-	i = strtoul(channel_name, &endptr, 0);
+	i = strtoul(name, &endptr, 0);
 
+	if (*endptr == '\0') {
+		return i;
+	}
+
+	/* Channel name is not a number, look it up */
+	for (i = 0; i < count; i++) {
+		if (strcmp(name, heystack[i]) == 0) {
+			return i;
+		}
+	}
+
+	return -ENOTSUP;
+}
+
+static int parse_sensor_value(const char *val_str, struct sensor_value *out)
+{
+	const bool is_negative = val_str[0] == '-';
+	const char *decimal_pos = strchr(val_str, '.');
+	long value;
+	char *endptr;
+
+	/* Parse int portion */
+	value = strtol(val_str, &endptr, 0);
+
+	if (*endptr != '\0' && *endptr != '.') {
+		return -EINVAL;
+	}
+	if (value > INT32_MAX || value < INT32_MIN) {
+		return -EINVAL;
+	}
+	out->val1 = (int32_t)value;
+
+	if (decimal_pos == NULL) {
+		return 0;
+	}
+
+	/* Parse the decimal portion */
+	value = strtoul(decimal_pos + 1, &endptr, 0);
 	if (*endptr != '\0') {
-		/* Channel name is not a number, look it up */
-		for (i = 0; i < ARRAY_SIZE(sensor_channel_name); i++) {
-			if (strcmp(channel_name, sensor_channel_name[i]) == 0) {
-				break;
-			}
-		}
+		return -EINVAL;
+	}
+	while (value < 100000) {
+		value *= 10;
+	}
+	if (value > INT32_C(999999)) {
+		return -EINVAL;
+	}
+	out->val2 = (int32_t)value;
+	if (is_negative) {
+		out->val2 *= -1;
+	}
+	return 0;
+}
 
-		if (i == ARRAY_SIZE(sensor_channel_name)) {
-			shell_error(shell, "Channel not supported (%s)", channel_name);
-			return -ENOTSUP;
-		}
+static int handle_channel_by_name(const struct shell *shell_ptr, const struct device *dev,
+				  const char *channel_name)
+{
+	struct sensor_value value[3];
+	int err;
+	const int i =
+		parse_named_int(channel_name, sensor_channel_name, ARRAY_SIZE(sensor_channel_name));
+
+	if (i < 0) {
+		shell_error(shell_ptr, "Channel not supported (%s)", channel_name);
+		return i;
 	}
 
 	err = sensor_channel_get(dev, i, value);
@@ -109,15 +194,15 @@ static int handle_channel_by_name(const struct shell *shell, const struct device
 	}
 
 	if (i >= ARRAY_SIZE(sensor_channel_name)) {
-		shell_print(shell, "channel idx=%d value = %10.6f", i,
+		shell_print(shell_ptr, "channel idx=%d value = %10.6f", i,
 			    sensor_value_to_double(&value[0]));
 	} else if (i != SENSOR_CHAN_ACCEL_XYZ && i != SENSOR_CHAN_GYRO_XYZ &&
 		   i != SENSOR_CHAN_MAGN_XYZ) {
-		shell_print(shell, "channel idx=%d %s = %10.6f", i, sensor_channel_name[i],
+		shell_print(shell_ptr, "channel idx=%d %s = %10.6f", i, sensor_channel_name[i],
 			    sensor_value_to_double(&value[0]));
 	} else {
 		/* clang-format off */
-		shell_print(shell,
+		shell_print(shell_ptr,
 			"channel idx=%d %s x = %10.6f y = %10.6f z = %10.6f",
 			i, sensor_channel_name[i],
 			sensor_value_to_double(&value[0]),
@@ -128,6 +213,7 @@ static int handle_channel_by_name(const struct shell *shell, const struct device
 
 	return 0;
 }
+
 static int cmd_get_sensor(const struct shell *shell, size_t argc, char *argv[])
 {
 	const struct device *dev;
@@ -163,9 +249,139 @@ static int cmd_get_sensor(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_sensor_attr_set(const struct shell *shell_ptr, size_t argc, char *argv[])
+{
+	const struct device *dev;
+	int rc;
+
+	dev = device_get_binding(argv[1]);
+	if (dev == NULL) {
+		shell_error(shell_ptr, "Device unknown (%s)", argv[1]);
+		return -ENODEV;
+	}
+
+	for (size_t i = 2; i < argc; i += 3) {
+		int channel = parse_named_int(argv[i], sensor_channel_name,
+					      ARRAY_SIZE(sensor_channel_name));
+		int attr = parse_named_int(argv[i + 1], sensor_attribute_name,
+					   ARRAY_SIZE(sensor_attribute_name));
+		struct sensor_value value = {0};
+
+		if (channel < 0) {
+			shell_error(shell_ptr, "Channel '%s' unknown", argv[i]);
+			return -EINVAL;
+		}
+		if (attr < 0) {
+			shell_error(shell_ptr, "Attribute '%s' unknown", argv[i + 1]);
+			return -EINVAL;
+		}
+		if (parse_sensor_value(argv[i + 2], &value)) {
+			shell_error(shell_ptr, "Sensor value '%s' invalid", argv[i + 2]);
+			return -EINVAL;
+		}
+
+		rc = sensor_attr_set(dev, channel, attr, &value);
+		if (rc) {
+			shell_error(shell_ptr, "Failed to set channel(%s) attribute(%s): %d",
+				    sensor_channel_name[channel], sensor_attribute_name[attr], rc);
+			continue;
+		}
+		shell_info(shell_ptr, "%s channel=%s, attr=%s set to value=%s", dev->name,
+			   sensor_channel_name[channel], sensor_attribute_name[attr], argv[i + 2]);
+	}
+	return 0;
+}
+
+static void cmd_sensor_attr_get_handler(const struct shell *shell_ptr, const struct device *dev,
+					const char *channel_name, const char *attr_name,
+					bool print_missing_attribute)
+{
+	int channel =
+		parse_named_int(channel_name, sensor_channel_name, ARRAY_SIZE(sensor_channel_name));
+	int attr = parse_named_int(attr_name, sensor_attribute_name,
+				   ARRAY_SIZE(sensor_attribute_name));
+	struct sensor_value value = {0};
+	int rc;
+
+	if (channel < 0) {
+		shell_error(shell_ptr, "Channel '%s' unknown", channel_name);
+		return;
+	}
+	if (attr < 0) {
+		shell_error(shell_ptr, "Attribute '%s' unknown", attr_name);
+		return;
+	}
+
+	rc = sensor_attr_get(dev, channel, attr, &value);
+
+	if (rc != 0) {
+		if (rc == -EINVAL && !print_missing_attribute) {
+			return;
+		}
+		shell_error(shell_ptr, "Failed to get channel(%s) attribute(%s): %d",
+			    sensor_channel_name[channel], sensor_attribute_name[attr], rc);
+		return;
+	}
+
+	shell_info(shell_ptr, "%s(channel=%s, attr=%s) value=%.6f", dev->name,
+		   sensor_channel_name[channel], sensor_attribute_name[attr],
+		   sensor_value_to_double(&value));
+}
+
+static int cmd_sensor_attr_get(const struct shell *shell_ptr, size_t argc, char *argv[])
+{
+	const struct device *dev;
+
+	dev = device_get_binding(argv[1]);
+	if (dev == NULL) {
+		shell_error(shell_ptr, "Device unknown (%s)", argv[1]);
+		return -ENODEV;
+	}
+
+	if (argc > 2) {
+		for (size_t i = 2; i < argc; i += 2) {
+			cmd_sensor_attr_get_handler(shell_ptr, dev, argv[i], argv[i + 1],
+						    /*print_missing_attribute=*/true);
+		}
+	} else {
+		for (size_t channel_idx = 0; channel_idx < ARRAY_SIZE(sensor_channel_name);
+		     ++channel_idx) {
+			for (size_t attr_idx = 0; attr_idx < ARRAY_SIZE(sensor_attribute_name);
+			     ++attr_idx) {
+				cmd_sensor_attr_get_handler(shell_ptr, dev,
+							    sensor_channel_name[channel_idx],
+							    sensor_attribute_name[attr_idx],
+							    /*print_missing_attribute=*/false);
+			}
+		}
+	}
+	return 0;
+}
+
 static void channel_name_get(size_t idx, struct shell_static_entry *entry);
 
 SHELL_DYNAMIC_CMD_CREATE(dsub_channel_name, channel_name_get);
+
+static void attribute_name_get(size_t idx, struct shell_static_entry *entry)
+{
+	int cnt = 0;
+
+	entry->syntax = NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = &dsub_channel_name;
+
+	for (int i = 0; i < SENSOR_ATTR_COMMON_COUNT; i++) {
+		if (sensor_attribute_name[i] != NULL) {
+			if (cnt == idx) {
+				entry->syntax = sensor_attribute_name[i];
+				break;
+			}
+			cnt++;
+		}
+	}
+}
+SHELL_DYNAMIC_CMD_CREATE(dsub_attribute_name, attribute_name_get);
 
 static void channel_name_get(size_t idx, struct shell_static_entry *entry)
 {
@@ -174,7 +390,13 @@ static void channel_name_get(size_t idx, struct shell_static_entry *entry)
 	entry->syntax = NULL;
 	entry->handler = NULL;
 	entry->help = NULL;
-	entry->subcmd = &dsub_channel_name;
+	if (current_cmd_ctx == CTX_GET) {
+		entry->subcmd = &dsub_channel_name;
+	} else if (current_cmd_ctx == CTX_ATTR_GET_SET) {
+		entry->subcmd = &dsub_attribute_name;
+	} else {
+		entry->subcmd = NULL;
+	}
 
 	for (int i = 0; i < SENSOR_CHAN_ALL; i++) {
 		if (sensor_channel_name[i] != NULL) {
@@ -195,11 +417,24 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
 	const struct device *dev = shell_device_lookup(idx, NULL);
 
+	current_cmd_ctx = CTX_GET;
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;
 	entry->help = NULL;
 	entry->subcmd = &dsub_channel_name;
 }
+
+static void device_name_get_for_attr(size_t idx, struct shell_static_entry *entry)
+{
+	const struct device *dev = shell_device_lookup(idx, NULL);
+
+	current_cmd_ctx = CTX_ATTR_GET_SET;
+	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = &dsub_channel_name;
+}
+SHELL_DYNAMIC_CMD_CREATE(dsub_device_name_for_attr, device_name_get_for_attr);
 
 static int cmd_get_sensor_info(const struct shell *sh, size_t argc, char **argv)
 {
@@ -228,6 +463,10 @@ static int cmd_get_sensor_info(const struct shell *sh, size_t argc, char **argv)
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_sensor,
 	SHELL_CMD_ARG(get, &dsub_device_name, SENSOR_GET_HELP, cmd_get_sensor,
 			2, 255),
+	SHELL_CMD_ARG(attr_set, &dsub_device_name_for_attr, SENSOR_ATTR_SET_HELP,
+			cmd_sensor_attr_set, 2, 255),
+	SHELL_CMD_ARG(attr_get, &dsub_device_name_for_attr, SENSOR_ATTR_GET_HELP,
+			cmd_sensor_attr_get, 2, 255),
 	SHELL_COND_CMD(CONFIG_SENSOR_INFO, info, NULL, SENSOR_INFO_HELP,
 			cmd_get_sensor_info),
 	SHELL_SUBCMD_SET_END

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -11,78 +11,75 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
 
-#define SENSOR_GET_HELP \
-	"Get sensor data. Channel names are optional. All channels are read " \
-	"when no channels are provided. Syntax:\n" \
+#define SENSOR_GET_HELP                                                                            \
+	"Get sensor data. Channel names are optional. All channels are read "                      \
+	"when no channels are provided. Syntax:\n"                                                 \
 	"<device_name> <channel name 0> .. <channel name N>"
 
-#define SENSOR_INFO_HELP \
-	"Get sensor info, such as vendor and model name, for all sensors."
+#define SENSOR_INFO_HELP "Get sensor info, such as vendor and model name, for all sensors."
 
 const char *sensor_channel_name[SENSOR_CHAN_ALL] = {
-	[SENSOR_CHAN_ACCEL_X] =		"accel_x",
-	[SENSOR_CHAN_ACCEL_Y] =		"accel_y",
-	[SENSOR_CHAN_ACCEL_Z] =		"accel_z",
-	[SENSOR_CHAN_ACCEL_XYZ] =	"accel_xyz",
-	[SENSOR_CHAN_GYRO_X] =		"gyro_x",
-	[SENSOR_CHAN_GYRO_Y] =		"gyro_y",
-	[SENSOR_CHAN_GYRO_Z] =		"gyro_z",
-	[SENSOR_CHAN_GYRO_XYZ] =	"gyro_xyz",
-	[SENSOR_CHAN_MAGN_X] =		"magn_x",
-	[SENSOR_CHAN_MAGN_Y] =		"magn_y",
-	[SENSOR_CHAN_MAGN_Z] =		"magn_z",
-	[SENSOR_CHAN_MAGN_XYZ] =	"magn_xyz",
-	[SENSOR_CHAN_DIE_TEMP] =	"die_temp",
-	[SENSOR_CHAN_AMBIENT_TEMP] =	"ambient_temp",
-	[SENSOR_CHAN_PRESS] =		"press",
-	[SENSOR_CHAN_PROX] =		"prox",
-	[SENSOR_CHAN_HUMIDITY] =	"humidity",
-	[SENSOR_CHAN_LIGHT] =		"light",
-	[SENSOR_CHAN_IR] =		"ir",
-	[SENSOR_CHAN_RED] =		"red",
-	[SENSOR_CHAN_GREEN] =		"green",
-	[SENSOR_CHAN_BLUE] =		"blue",
-	[SENSOR_CHAN_ALTITUDE] =	"altitude",
-	[SENSOR_CHAN_PM_1_0] =		"pm_1_0",
-	[SENSOR_CHAN_PM_2_5] =		"pm_2_5",
-	[SENSOR_CHAN_PM_10] =		"pm_10",
-	[SENSOR_CHAN_DISTANCE] =	"distance",
-	[SENSOR_CHAN_CO2] =		"co2",
-	[SENSOR_CHAN_VOC] =		"voc",
-	[SENSOR_CHAN_GAS_RES] =		"gas_resistance",
-	[SENSOR_CHAN_VOLTAGE] =		"voltage",
-	[SENSOR_CHAN_CURRENT] =		"current",
-	[SENSOR_CHAN_POWER] =		"power",
-	[SENSOR_CHAN_RESISTANCE] =	"resistance",
-	[SENSOR_CHAN_ROTATION] =	"rotation",
-	[SENSOR_CHAN_POS_DX] =		"pos_dx",
-	[SENSOR_CHAN_POS_DY] =		"pos_dy",
-	[SENSOR_CHAN_POS_DZ] =		"pos_dz",
-	[SENSOR_CHAN_RPM] = 		"rpm",
-	[SENSOR_CHAN_GAUGE_VOLTAGE] =	"gauge_voltage",
+	[SENSOR_CHAN_ACCEL_X] = "accel_x",
+	[SENSOR_CHAN_ACCEL_Y] = "accel_y",
+	[SENSOR_CHAN_ACCEL_Z] = "accel_z",
+	[SENSOR_CHAN_ACCEL_XYZ] = "accel_xyz",
+	[SENSOR_CHAN_GYRO_X] = "gyro_x",
+	[SENSOR_CHAN_GYRO_Y] = "gyro_y",
+	[SENSOR_CHAN_GYRO_Z] = "gyro_z",
+	[SENSOR_CHAN_GYRO_XYZ] = "gyro_xyz",
+	[SENSOR_CHAN_MAGN_X] = "magn_x",
+	[SENSOR_CHAN_MAGN_Y] = "magn_y",
+	[SENSOR_CHAN_MAGN_Z] = "magn_z",
+	[SENSOR_CHAN_MAGN_XYZ] = "magn_xyz",
+	[SENSOR_CHAN_DIE_TEMP] = "die_temp",
+	[SENSOR_CHAN_AMBIENT_TEMP] = "ambient_temp",
+	[SENSOR_CHAN_PRESS] = "press",
+	[SENSOR_CHAN_PROX] = "prox",
+	[SENSOR_CHAN_HUMIDITY] = "humidity",
+	[SENSOR_CHAN_LIGHT] = "light",
+	[SENSOR_CHAN_IR] = "ir",
+	[SENSOR_CHAN_RED] = "red",
+	[SENSOR_CHAN_GREEN] = "green",
+	[SENSOR_CHAN_BLUE] = "blue",
+	[SENSOR_CHAN_ALTITUDE] = "altitude",
+	[SENSOR_CHAN_PM_1_0] = "pm_1_0",
+	[SENSOR_CHAN_PM_2_5] = "pm_2_5",
+	[SENSOR_CHAN_PM_10] = "pm_10",
+	[SENSOR_CHAN_DISTANCE] = "distance",
+	[SENSOR_CHAN_CO2] = "co2",
+	[SENSOR_CHAN_VOC] = "voc",
+	[SENSOR_CHAN_GAS_RES] = "gas_resistance",
+	[SENSOR_CHAN_VOLTAGE] = "voltage",
+	[SENSOR_CHAN_CURRENT] = "current",
+	[SENSOR_CHAN_POWER] = "power",
+	[SENSOR_CHAN_RESISTANCE] = "resistance",
+	[SENSOR_CHAN_ROTATION] = "rotation",
+	[SENSOR_CHAN_POS_DX] = "pos_dx",
+	[SENSOR_CHAN_POS_DY] = "pos_dy",
+	[SENSOR_CHAN_POS_DZ] = "pos_dz",
+	[SENSOR_CHAN_RPM] = "rpm",
+	[SENSOR_CHAN_GAUGE_VOLTAGE] = "gauge_voltage",
 	[SENSOR_CHAN_GAUGE_AVG_CURRENT] = "gauge_avg_current",
 	[SENSOR_CHAN_GAUGE_STDBY_CURRENT] = "gauge_stdby_current",
 	[SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT] = "gauge_max_load_current",
-	[SENSOR_CHAN_GAUGE_TEMP] =	"gauge_temp",
-	[SENSOR_CHAN_GAUGE_STATE_OF_CHARGE] =	"gauge_state_of_charge",
-	[SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY] =	"gauge_full_cap",
+	[SENSOR_CHAN_GAUGE_TEMP] = "gauge_temp",
+	[SENSOR_CHAN_GAUGE_STATE_OF_CHARGE] = "gauge_state_of_charge",
+	[SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY] = "gauge_full_cap",
 	[SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY] = "gauge_remaining_cap",
-	[SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY] =	"gauge_nominal_cap",
+	[SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY] = "gauge_nominal_cap",
 	[SENSOR_CHAN_GAUGE_FULL_AVAIL_CAPACITY] = "gauge_full_avail_cap",
-	[SENSOR_CHAN_GAUGE_AVG_POWER] =		"gauge_avg_power",
-	[SENSOR_CHAN_GAUGE_STATE_OF_HEALTH] =	"gauge_state_of_health",
-	[SENSOR_CHAN_GAUGE_TIME_TO_EMPTY] =	"gauge_time_to_empty",
-	[SENSOR_CHAN_GAUGE_TIME_TO_FULL] =	"gauge_time_to_full",
-	[SENSOR_CHAN_GAUGE_CYCLE_COUNT] =	"gauge_cycle_count",
-	[SENSOR_CHAN_GAUGE_DESIGN_VOLTAGE] =	"gauge_design_voltage",
-	[SENSOR_CHAN_GAUGE_DESIRED_VOLTAGE] =	"gauge_desired_voltage",
-	[SENSOR_CHAN_GAUGE_DESIRED_CHARGING_CURRENT] =
-		 "gauge_desired_charging_current",
+	[SENSOR_CHAN_GAUGE_AVG_POWER] = "gauge_avg_power",
+	[SENSOR_CHAN_GAUGE_STATE_OF_HEALTH] = "gauge_state_of_health",
+	[SENSOR_CHAN_GAUGE_TIME_TO_EMPTY] = "gauge_time_to_empty",
+	[SENSOR_CHAN_GAUGE_TIME_TO_FULL] = "gauge_time_to_full",
+	[SENSOR_CHAN_GAUGE_CYCLE_COUNT] = "gauge_cycle_count",
+	[SENSOR_CHAN_GAUGE_DESIGN_VOLTAGE] = "gauge_design_voltage",
+	[SENSOR_CHAN_GAUGE_DESIRED_VOLTAGE] = "gauge_desired_voltage",
+	[SENSOR_CHAN_GAUGE_DESIRED_CHARGING_CURRENT] = "gauge_desired_charging_current",
 };
 
-static int handle_channel_by_name(const struct shell *shell,
-					const struct device *dev,
-					const char *channel_name)
+static int handle_channel_by_name(const struct shell *shell, const struct device *dev,
+				  const char *channel_name)
 {
 	struct sensor_value value[3];
 	char *endptr;
@@ -101,8 +98,7 @@ static int handle_channel_by_name(const struct shell *shell,
 		}
 
 		if (i == ARRAY_SIZE(sensor_channel_name)) {
-			shell_error(shell, "Channel not supported (%s)",
-				    channel_name);
+			shell_error(shell, "Channel not supported (%s)", channel_name);
 			return -ENOTSUP;
 		}
 	}
@@ -115,20 +111,19 @@ static int handle_channel_by_name(const struct shell *shell,
 	if (i >= ARRAY_SIZE(sensor_channel_name)) {
 		shell_print(shell, "channel idx=%d value = %10.6f", i,
 			    sensor_value_to_double(&value[0]));
-	} else if (i != SENSOR_CHAN_ACCEL_XYZ &&
-		i != SENSOR_CHAN_GYRO_XYZ &&
-		i != SENSOR_CHAN_MAGN_XYZ) {
-		shell_print(shell,
-			"channel idx=%d %s = %10.6f", i,
-			sensor_channel_name[i],
-			sensor_value_to_double(&value[0]));
+	} else if (i != SENSOR_CHAN_ACCEL_XYZ && i != SENSOR_CHAN_GYRO_XYZ &&
+		   i != SENSOR_CHAN_MAGN_XYZ) {
+		shell_print(shell, "channel idx=%d %s = %10.6f", i, sensor_channel_name[i],
+			    sensor_value_to_double(&value[0]));
 	} else {
+		/* clang-format off */
 		shell_print(shell,
 			"channel idx=%d %s x = %10.6f y = %10.6f z = %10.6f",
 			i, sensor_channel_name[i],
 			sensor_value_to_double(&value[0]),
 			sensor_value_to_double(&value[1]),
 			sensor_value_to_double(&value[2]));
+		/* clang-format on */
 	}
 
 	return 0;
@@ -153,16 +148,14 @@ static int cmd_get_sensor(const struct shell *shell, size_t argc, char *argv[])
 		/* read all channels */
 		for (int i = 0; i < ARRAY_SIZE(sensor_channel_name); i++) {
 			if (sensor_channel_name[i]) {
-				handle_channel_by_name(shell, dev,
-							sensor_channel_name[i]);
+				handle_channel_by_name(shell, dev, sensor_channel_name[i]);
 			}
 		}
 	} else {
 		for (int i = 2; i < argc; i++) {
 			err = handle_channel_by_name(shell, dev, argv[i]);
 			if (err < 0) {
-				shell_error(shell,
-					"Failed to read channel (%s)", argv[i]);
+				shell_error(shell, "Failed to read channel (%s)", argv[i]);
 			}
 		}
 	}
@@ -180,7 +173,7 @@ static void channel_name_get(size_t idx, struct shell_static_entry *entry)
 
 	entry->syntax = NULL;
 	entry->handler = NULL;
-	entry->help  = NULL;
+	entry->help = NULL;
 	entry->subcmd = &dsub_channel_name;
 
 	for (int i = 0; i < SENSOR_CHAN_ALL; i++) {
@@ -204,13 +197,11 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;
-	entry->help  = NULL;
+	entry->help = NULL;
 	entry->subcmd = &dsub_channel_name;
 }
 
-
-static int cmd_get_sensor_info(const struct shell *sh, size_t argc,
-		char **argv)
+static int cmd_get_sensor_info(const struct shell *sh, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
@@ -218,12 +209,12 @@ static int cmd_get_sensor_info(const struct shell *sh, size_t argc,
 #ifdef CONFIG_SENSOR_INFO
 	const char *null_str = "(null)";
 
-	STRUCT_SECTION_FOREACH(sensor_info, sensor) {
+	STRUCT_SECTION_FOREACH(sensor_info, sensor)
+	{
 		shell_print(sh,
 			    "device name: %s, vendor: %s, model: %s, "
 			    "friendly name: %s",
-			    sensor->dev->name,
-			    sensor->vendor ? sensor->vendor : null_str,
+			    sensor->dev->name, sensor->vendor ? sensor->vendor : null_str,
 			    sensor->model ? sensor->model : null_str,
 			    sensor->friendly_name ? sensor->friendly_name : null_str);
 	}
@@ -233,6 +224,7 @@ static int cmd_get_sensor_info(const struct shell *sh, size_t argc,
 #endif
 }
 
+/* clang-format off */
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_sensor,
 	SHELL_CMD_ARG(get, &dsub_device_name, SENSOR_GET_HELP, cmd_get_sensor,
 			2, 255),
@@ -240,5 +232,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_sensor,
 			cmd_get_sensor_info),
 	SHELL_SUBCMD_SET_END
 	);
+/* clang-format on */
 
 SHELL_CMD_REGISTER(sensor, &sub_sensor, "Sensor commands", NULL);


### PR DESCRIPTION
1. Implement sensor shell commands `attr_get` and `attr_set` which allow us to get/set sensor attributes.
2. Implement the attribute get/set for the ICM42688

Verified by running shell commands, here's a sample output:
```
uart:~$ sensor attr_get icm42688p@0 accel_xyz full_scale

icm42688p@0(channel=accel_xyz, attr=full_scale) value=19.613300

uart:~$ sensor get icm42688p@0 accel_xyz

channel idx=3 accel_xyz x =   1.302445 y =   0.585382 z =   9.776722

uart:~$ sensor attr_get icm42688p@0 accel_xyz full_scale

icm42688p@0(channel=accel_xyz, attr=full_scale) value=19.613300

uart:~$ sensor attr_set icm42688p@0 accel_xyz full_scale 40

icm42688p@0 channel=accel_xyz, attr=full_scale set to value=40

uart:~$ sensor attr_get icm42688p@0 accel_xyz full_scale

icm42688p@0(channel=accel_xyz, attr=full_scale) value=39.226600

uart:~$ sensor get icm42688p@0 accel_xyz

channel idx=3 accel_xyz x =   1.296460 y =   0.598550 z =   9.678560
```