### PR TITLE
tools: Fix clang-format for IntelliJ IDEs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -66,6 +66,8 @@ ForEachMacros:
   - 'Z_GENLIST_FOR_EACH_NODE_SAFE'
 # Disabled for now, see bug https://github.com/zephyrproject-rtos/zephyr/issues/48520
 #IncludeBlocks: Regroup
+BraceWrapping:
+  AfterControlStatement: Always
 IncludeCategories:
   - Regex: '^".*\.h"$'
     Priority: 0
@@ -77,7 +79,8 @@ IncludeCategories:
     Priority: 3
 IndentCaseLabels: false
 IndentWidth: 8
-InsertBraces: true
+# Disabled for now, see bug https://github.com/zephyrproject-rtos/zephyr/issues/53917
+#InsertBraces: true
 SpaceBeforeParens: ControlStatementsExceptControlMacros
 SortIncludes: Never
 UseTab: Always


### PR DESCRIPTION
IntelliJ IDEs do not yet support `InsertBraces` which makes it near impossible to work with.

Fixes #53917