### PR TITLE
tools: Fix clang-format values

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,7 @@
 ---
 BasedOnStyle: LLVM
 AlignConsecutiveMacros: AcrossComments
-AllowShortBlocksOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
@@ -79,7 +79,7 @@ IndentCaseLabels: false
 IndentWidth: 8
 InsertBraces: true
 SpaceBeforeParens: ControlStatementsExceptControlMacros
-SortIncludes: false
+SortIncludes: Never
 UseTab: Always
 WhitespaceSensitiveMacros:
   - STRINGIFY


### PR DESCRIPTION
According to the clang-format documentation some values in our .clang-format are incorrect. See:

- https://clang.llvm.org/docs/ClangFormatStyleOptions.html#allowshortblocksonasingleline
- https://clang.llvm.org/docs/ClangFormatStyleOptions.html#sortincludes