### PR TITLE
samples: watchdog: board s32z270dc2_r52 only build and not running

### DIFF
--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,5 +16,9 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+	};
+
+	aliases {
+		watchdog0 = &swt0;
 	};
 };

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,5 +16,9 @@
 		zephyr,sram = &sram1;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
+	};
+
+	aliases {
+		watchdog0 = &swt0;
 	};
 };

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -15,6 +15,7 @@ common:
 tests:
   sample.drivers.watchdog:
     filter: not (CONFIG_SOC_FAMILY_STM32 or CONFIG_SOC_FAMILY_GD32 or SOC_SERIES_GD32VF103)
+    platform_exclude: s32z270dc2_rtu0_r52 s32z270dc2_rtu1_r52
   sample.drivers.watchdog.stm32_wwdg:
     extra_args: DTC_OVERLAY_FILE=boards/stm32_wwdg.overlay
     filter: dt_compat_enabled("st,stm32-window-watchdog")
@@ -51,3 +52,6 @@ tests:
         longan_nano
     integration_platforms:
       - gd32e103v_eval
+  sample.drivers.watchdog.s32z270dc2_r52:
+    build_only: true
+    platform_allow: s32z270dc2_rtu0_r52 s32z270dc2_rtu1_r52

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -8,7 +8,7 @@ tests:
        or dt_compat_enabled("st,stm32-watchdog") or CONFIG_SOC_FAMILY_LPC or
        CONFIG_SOC_SERIES_IMX_RT6XX or CONFIG_SOC_SERIES_IMX_RT5XX or
        CONFIG_SOC_FAMILY_GD32 or SOC_SERIES_GD32VF103)
-    platform_exclude: mec15xxevb_assy6853
+    platform_exclude: mec15xxevb_assy6853 s32z270dc2_rtu0_r52 s32z270dc2_rtu1_r52
   drivers.watchdog.stm32wwdg:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
     extra_args: DTC_OVERLAY_FILE="boards/stm32_wwdg.overlay"
@@ -54,3 +54,6 @@ tests:
         gd32vf103v_eval longan_nano
     integration_platforms:
       - gd32e103v_eval
+  drivers.watchdog.s32z270dc2_r52:
+    build_only: true
+    platform_allow: s32z270dc2_rtu0_r52 s32z270dc2_rtu1_r52


### PR DESCRIPTION
 Currently, the s32z270dc2_r52 board only supports running on RAM,
 so samples or tests watchdogs that perform SoC reset will not produce
 results. Set the build only for these samples and tests until the
 reset SoC function is supported.

Signed-off-by: Quang Bui Trong <quang.buitrong@nxp.com>