### PR TITLE
net: wifi_shell: Display correct power save status

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -445,7 +445,7 @@ static int cmd_wifi_ps(const struct shell *sh, size_t argc, char *argv[])
 		}
 
 		shell_fprintf(sh, SHELL_NORMAL, "PS status: %s\n",
-				wifi_ps_mode2str[config.enabled]);
+				wifi_ps2str[config.enabled]);
 		if (config.enabled) {
 			shell_fprintf(sh, SHELL_NORMAL, "PS mode: %s\n",
 					wifi_ps_mode2str[config.mode]);


### PR DESCRIPTION
Display power save status correctly.

Signed-off-by: Ajay Parida <ajay.parida@nordicsemi.no>