### PR TITLE
dma: dw: Align error code for xrun reporting

### DIFF
--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -786,7 +786,7 @@ int dw_dma_get_status(const struct device *dev, uint32_t channel,
 #if CONFIG_DMA_DW_HW_LLI
 	if (!(dw_read(dev_cfg->base, DW_DMA_CHAN_EN) & DW_CHAN(channel))) {
 		LOG_ERR("xrun detected");
-		return -ENODATA;
+		return -EPIPE;
 	}
 #endif
 	return 0;


### PR DESCRIPTION
The hda driver uses -EPIPE to signal xrun, as proposed in the alsa lib https://www.alsa-project.org/alsa-doc/alsa-lib/pcm.html. This commit changes the xrun error code in dw dma driver from -ENODATA to -EPIPE to make it consistent across drivers.

Reference PRs:
https://github.com/zephyrproject-rtos/zephyr/pull/53327
https://github.com/thesofproject/sof/pull/6965