### PR TITLE
net: iface: Add NULL pointer check in net_if_ipv6_set_reachable_time

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1504,6 +1504,10 @@ uint32_t net_if_ipv6_calc_reachable_time(struct net_if_ipv6 *ipv6);
 static inline void net_if_ipv6_set_reachable_time(struct net_if_ipv6 *ipv6)
 {
 #if defined(CONFIG_NET_NATIVE_IPV6)
+	if (ipv6 == NULL) {
+		return;
+	}
+
 	ipv6->reachable_time = net_if_ipv6_calc_reachable_time(ipv6);
 #endif
 }


### PR DESCRIPTION
In case the IPv6 context pointer was not set on an interface (for instance due to IPv6 context shortage), processing the RA message could lead to a crash (i. e. NULL pointer dereference). Protect against this by adding NULL pointer check, similarly to other functions in this area.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>