### PR TITLE
sampes/smp_svr: Bring back UART shell when using BT transport

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/overlay-bt.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/overlay-bt.conf
@@ -13,6 +13,8 @@ CONFIG_MCUMGR_TRANSPORT_BT_AUTHEN=n
 CONFIG_MCUMGR_TRANSPORT_BT_CONN_PARAM_CONTROL=y
 
 # Enable the Shell mcumgr transport.
+CONFIG_SHELL=y
+CONFIG_SHELL_BACKEND_SERIAL=y
 CONFIG_MCUMGR_TRANSPORT_SHELL=y
 
 # Enable the mcumgr Packet Reassembly feature over Bluetooth and its configuration dependencies.


### PR DESCRIPTION
Adding configuration options to bring old behaviour where UART shell have been available when overlay-bt.conf has been used for building sample.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>