### PR TITLE
ci: doc-build: change Doxygen download URL

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y ninja-build graphviz
-        wget --no-verbose https://downloads.sourceforge.net/project/doxygen/rel-${DOXYGEN_VERSION}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
+        wget --no-verbose "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz"
         tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
         echo "${PWD}/doxygen-${DOXYGEN_VERSION}/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
It looks like versions >= 1.9.2 have disappeared from the Sourceforge website. Since they use GH releases since 1.9.6, the version we use, let's just update download URL.

Ref. https://github.com/doxygen/doxygen/issues/9801

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>