### PR TITLE
Bluetooth: audio: Remove cleanup on PA sync loss

### DIFF
--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -316,7 +316,6 @@ static void pa_term(struct bt_le_per_adv_sync *sync,
 	}
 
 	LOG_DBG("PA sync with broadcast source with ID 0x%06X lost", sink->broadcast_id);
-	broadcast_sink_cleanup(sink);
 	SYS_SLIST_FOR_EACH_CONTAINER(&sink_cbs, listener, _node) {
 		if (listener->pa_sync_lost != NULL) {
 			listener->pa_sync_lost(sink);


### PR DESCRIPTION
This removes broadcast_sink_cleanup() function call from PA sync termination callback. The reason is that the stream might be active while the PA is terminated. The sink once synced to BIG, does not need to keep PA sync.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>