### PR TITLE
twister: Better messages for keyed test exclusions

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -734,16 +734,18 @@ class TestPlan:
                     key = [getattr(plat, key_field) for key_field in key_fields]
                     has_all_fields = True
                     for key_field in key_fields:
-                        if key_field is None:
+                        if key_field is None or key_field == 'na':
                             has_all_fields = False
                     if has_all_fields:
-                        key.append(ts.name)
-                        key = tuple(key)
-                        keyed_test = keyed_tests.get(key)
+                        test_key = copy.deepcopy(key)
+                        test_key.append(ts.name)
+                        test_key = tuple(test_key)
+                        keyed_test = keyed_tests.get(test_key)
                         if keyed_test is not None:
-                            instance.add_filter(f"Excluded test already covered by platform_key {key} given fields {key_fields}", Filters.TESTSUITE)
+                            plat_key = {key_field: getattr(keyed_test['plat'], key_field) for key_field in key_fields}
+                            instance.add_filter(f"Excluded test already covered for key {tuple(key)} by platform {keyed_test['plat'].name} having key {plat_key}", Filters.TESTSUITE)
                         else:
-                            keyed_tests[key] = {'plat': plat, 'ts': ts}
+                            keyed_tests[test_key] = {'plat': plat, 'ts': ts}
                     else:
                         instance.add_filter(f"Excluded platform missing key fields demanded by test {key_fields}", Filters.PLATFORM)
 


### PR DESCRIPTION
Improves the message for tests being excluded using the platform key, describes the key already found and the platform being used to run the test in its place.

Messaging now looks like...

```
DEBUG   - qemu_cortex_m0            zephyr/tests/subsys/rtio/rtio_api/subsys.rtio.api  SKIPPED: Excluded test already covered for key ('arm', 'qemu') by platform mps2_an385 having key {'arch': 'arm', 'simulation': 'qemu'}
DEBUG   - mps3_an547_ns             zephyr/tests/subsys/rtio/rtio_api/subsys.rtio.api  SKIPPED: Excluded test already covered for key ('arm', 'qemu') by platform mps2_an385 having key {'arch': 'arm', 'simulation': 'qemu'}
```

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>