### PR TITLE
doc: mgmt: img_mgmt: Correct "hash" type in image status response

### DIFF
--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -113,7 +113,7 @@ CBOR data of successful response:
                 (str,opt)"image"        : (int)
                 (str)"slot"             : (int)
                 (str)"version"          : (str)
-                (str)"hash"             ; (str)
+                (str)"hash"             : (byte str)
                 (str,opt)"bootable"     : (bool)
                 (str,opt)"pending"      : (bool)
                 (str,opt)"confirmed"    : (bool)


### PR DESCRIPTION
Fix incorrect value type.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

For context, encoding is here:
https://github.com/zephyrproject-rtos/zephyr/blob/b7c2b3fc3ad2f6db72fff39aec149c54ed090c03/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c#L246-L249
and it is binary type not text.