### PR TITLE
Bluetooth: ISO advanced qos

### DIFF
--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -109,6 +109,16 @@ extern "C" {
 #define BT_ISO_BIS_INDEX_MIN        0x01
 /** Highest BIS index */
 #define BT_ISO_BIS_INDEX_MAX        0x1F
+/** Minimum Immediate Repetition Count */
+#define BT_ISO_IRC_MIN              0x01U
+/** Maximum Immediate Repetition Count */
+#define BT_ISO_IRC_MAX              0x0FU
+/** Minimum pre-transmission offset */
+#define BT_ISO_PTO_MIN              0x00U
+/** Maximum pre-transmission offset */
+#define BT_ISO_PTO_MAX              0x0FU
+
+
 /** Omit time stamp when sending to controller
  *
  * Using this value will enqueue the ISO SDU in a FIFO manner, instead of
@@ -416,6 +426,8 @@ struct bt_iso_big_create_param {
 	/** @brief Channel Latency in ms.
 	 *
 	 *  Value range BT_ISO_LATENCY_MIN - BT_ISO_LATENCY_MAX.
+	 *
+	 *  This value is ignored if any advanced ISO parameters are set.
 	 */
 	uint16_t latency;
 
@@ -448,6 +460,34 @@ struct bt_iso_big_create_param {
 	 *    [42 72 6F 61 64 63 61 73 74 20 43 6F 64 65 00 00]
 	 */
 	uint8_t bcode[BT_ISO_BROADCAST_CODE_SIZE];
+
+#if defined(CONFIG_BT_ISO_ADVANCED)
+	/** @brief Immediate Repetition Count
+	 *
+	 *  The number of times the scheduled payloads are transmitted in a
+	 *  given event.
+	 *
+	 *  Value range from @ref BT_ISO_MIN_IRC to @ref BT_ISO_MAX_IRC.
+	 */
+	uint8_t irc;
+
+	/** @brief Pre-transmission offset
+	 *
+	 *  Offset used for pre-transmissions.
+	 *
+	 *  Value range from @ref BT_ISO_MIN_PTO to @ref BT_ISO_MAX_PTO.
+	 */
+	uint8_t pto;
+
+	/** @brief ISO interval
+	 *
+	 *  Time between consecutive BIS anchor points.
+	 *
+	 *  Value range from @ref BT_ISO_ISO_INTERVAL_MIN to
+	 *  @ref BT_ISO_ISO_INTERVAL_MAX.
+	 */
+	uint16_t iso_interval;
+#endif /* CONFIG_BT_ISO_ADVANCED */
 };
 
 struct bt_iso_big_sync_param {

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -49,6 +49,10 @@ extern "C" {
 #define BT_ISO_SDU_INTERVAL_MIN     0x0000FFU
 /** Maximum interval value in microseconds */
 #define BT_ISO_SDU_INTERVAL_MAX     0x0FFFFFU
+/** Minimum ISO interval (N * 1.25 ms) */
+#define BT_ISO_ISO_INTERVAL_MIN     0x0004U
+/** Maximum ISO interval (N * 1.25 ms) */
+#define BT_ISO_ISO_INTERVAL_MAX     0x0C80U
 /** Minimum latency value in milliseconds */
 #define BT_ISO_LATENCY_MIN          0x0005
 /** Maximum latency value in milliseconds */
@@ -63,8 +67,28 @@ extern "C" {
 #define BT_ISO_FRAMING_FRAMED       0x01
 /** Maximum number of isochronous channels in a single group */
 #define BT_ISO_MAX_GROUP_ISO_COUNT  0x1F
+/** Minimum SDU size */
+#define BT_ISO_MIN_SDU              0x0001
 /** Maximum SDU size */
 #define BT_ISO_MAX_SDU              0x0FFF
+/** Minimum PDU size */
+#define BT_ISO_CONNECTED_PDU_MIN    0x0000U
+/** Minimum PDU size */
+#define BT_ISO_BROADCAST_PDU_MIN    0x0001U
+/** Maximum PDU size */
+#define BT_ISO_PDU_MAX              0x00FBU
+/** Minimum burst number */
+#define BT_ISO_BN_MIN               0x01U
+/** Maximum burst number */
+#define BT_ISO_BN_MAX               0x0FU
+/** Minimum flush timeout */
+#define BT_ISO_FT_MIN               0x01U
+/** Maximum flush timeout */
+#define BT_ISO_FT_MAX               0xFFU
+/** Minimum number of subevents */
+#define BT_ISO_NSE_MIN              0x01U
+/** Maximum number of subevents */
+#define BT_ISO_NSE_MAX              0x1FU
 /** Minimum BIG sync timeout value (N * 10 ms) */
 #define BT_ISO_SYNC_TIMEOUT_MIN     0x000A
 /** Maximum BIG sync timeout value (N * 10 ms) */
@@ -148,7 +172,10 @@ struct bt_iso_chan_io_qos {
 	 *  Setting BT_GAP_LE_PHY_NONE is invalid.
 	 */
 	uint8_t				phy;
-	/** Channel Retransmission Number. */
+	/** @brief Channel Retransmission Number.
+	 *
+	 * This value is ignored if any advanced ISO parameters are set.
+	 */
 	uint8_t				rtn;
 	/** @brief Channel data path reference
 	 *
@@ -156,6 +183,27 @@ struct bt_iso_chan_io_qos {
 	 *  to BT_ISO_DATA_PATH_HCI).
 	 */
 	struct bt_iso_chan_path		*path;
+
+#if defined(CONFIG_BT_ISO_ADVANCED)
+	/** @brief Maximum PDU size
+	 *
+	 *  Maximum size, in octets, of the payload from link layer to link
+	 *  layer.
+	 *
+	 *  Value range @ref BT_ISO_CONNECTED_PDU_MIN to @ref BT_ISO_PDU_MAX for
+	 *  connected ISO.
+	 *
+	 *  Value range @ref BT_ISO_BROADCAST_PDU_MIN to @ref BT_ISO_PDU_MAX for
+	 *  broadcast ISO.
+	 */
+	uint16_t max_pdu;
+
+	/** @brief Burst number
+	 *
+	 *  Value range @ref BT_ISO_BN_MIN to @ref BT_ISO_BN_MAX.
+	 */
+	uint8_t burst_number;
+#endif /* CONFIG_BT_ISO_ADVANCED */
 };
 
 /** @brief ISO Channel QoS structure. */
@@ -176,6 +224,16 @@ struct bt_iso_chan_qos {
 	 *  isochronous transmitter.
 	 */
 	struct bt_iso_chan_io_qos	*tx;
+
+#if defined(CONFIG_BT_ISO_ADVANCED)
+	/** @brief Number of subevents
+	 *
+	 *  Maximum number of subevents in each CIS or BIS event.
+	 *
+	 *  Value range @ref BT_ISO_NSE_MIN to @ref BT_ISO_NSE_MAX.
+	 */
+	uint8_t num_subevents;
+#endif /* CONFIG_BT_ISO_ADVANCED */
 };
 
 /** @brief ISO Channel Data Path structure. */
@@ -269,6 +327,8 @@ struct bt_iso_cig_param {
 	/** @brief Channel Latency in ms.
 	 *
 	 *  Value range BT_ISO_LATENCY_MIN - BT_ISO_LATENCY_MAX.
+	 *
+	 *  This value is ignored if any advanced ISO parameters are set.
 	 */
 	uint16_t latency;
 
@@ -293,6 +353,36 @@ struct bt_iso_cig_param {
 	 * BT_ISO_FRAMING_FRAMED for framed.
 	 */
 	uint8_t framing;
+
+#if defined(CONFIG_BT_ISO_ADVANCED)
+	/** @brief Central to Peripheral flush timeout
+	 *
+	 *  The flush timeout in multiples of ISO_Interval for each payload sent
+	 *  from the Central to Peripheral.
+	 *
+	 *  Value range from @ref BT_ISO_FT_MIN to @ref BT_ISO_FT_MAX
+	 */
+	uint8_t c_to_p_ft;
+
+	/** @brief Peripheral to Central flush timeout
+	 *
+	 *  The flush timeout in multiples of ISO_Interval for each payload sent
+	 *  from the Peripheral to Central.
+	 *
+	 *  Value range from @ref BT_ISO_FT_MIN to @ref BT_ISO_FT_MAX.
+	 */
+	uint8_t p_to_c_ft;
+
+	/** @brief ISO interval
+	 *
+	 *  Time between consecutive CIS anchor points.
+	 *
+	 *  Value range from @ref BT_ISO_ISO_INTERVAL_MIN to
+	 *  @ref BT_ISO_ISO_INTERVAL_MAX.
+	 */
+	uint16_t iso_interval;
+#endif /* CONFIG_BT_ISO_ADVANCED */
+
 };
 
 struct bt_iso_connect_param {

--- a/subsys/bluetooth/Kconfig.iso
+++ b/subsys/bluetooth/Kconfig.iso
@@ -114,6 +114,14 @@ config BT_ISO_RX_MTU
 	help
 	  Maximum MTU for Isochronous channels RX buffers.
 
+config BT_ISO_ADVANCED
+	bool "Advanced ISO parameters"
+	help
+	  Enabling advanced ISO parameters will allow the use of the ISO test
+	  parameters for creating a CIG or a BIG. These test parameters were
+	  intended for testing, but can be used to allow the host to set more
+	  settings that are otherwise usually controlled by the controller.
+
 if BT_ISO_UNICAST
 
 config BT_ISO_MAX_CIG

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -2561,25 +2561,113 @@ static int hci_le_create_big(struct bt_le_ext_adv *padv, struct bt_iso_big *big,
 	return err;
 }
 
-int bt_iso_big_create(struct bt_le_ext_adv *padv, struct bt_iso_big_create_param *param,
-		      struct bt_iso_big **out_big)
+#if defined(CONFIG_BT_ISO_ADVANCED)
+static int hci_le_create_big_test(const struct bt_le_ext_adv *padv,
+				  struct bt_iso_big *big,
+				  const struct bt_iso_big_create_param *param)
 {
+	struct bt_hci_cp_le_create_big_test *req;
+	struct bt_hci_cmd_state_set state;
+	const struct bt_iso_chan_qos *qos;
+	struct bt_iso_chan *bis;
+	struct net_buf *buf;
 	int err;
-	struct bt_iso_big *big;
 
-	if (!atomic_test_bit(padv->flags, BT_PER_ADV_PARAMS_SET)) {
-		LOG_DBG("PA params not set; invalid adv object");
-		return -EINVAL;
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CREATE_BIG_TEST, sizeof(*req));
+
+	if (!buf) {
+		return -ENOBUFS;
 	}
 
+	bis = SYS_SLIST_PEEK_HEAD_CONTAINER(&big->bis_channels, bis, node);
+	__ASSERT(bis != NULL, "bis was NULL");
+
+	/* All BIS will share the same QOS */
+	qos = bis->qos;
+
+	req = net_buf_add(buf, sizeof(*req));
+	req->big_handle = big->handle;
+	req->adv_handle = padv->handle;
+	req->num_bis = big->num_bis;
+	sys_put_le24(param->interval, req->sdu_interval);
+	req->iso_interval = sys_cpu_to_le16(param->iso_interval);
+	req->nse = qos->num_subevents;
+	req->max_sdu = sys_cpu_to_le16(qos->tx->sdu);
+	req->max_pdu = sys_cpu_to_le16(qos->tx->max_pdu);
+	req->phy = qos->tx->phy;
+	req->packing = param->packing;
+	req->framing = param->framing;
+	req->bn = qos->tx->burst_number;
+	req->irc = param->irc;
+	req->pto = param->pto;
+	req->encryption = param->encryption;
+	if (req->encryption) {
+		memcpy(req->bcode, param->bcode, sizeof(req->bcode));
+	} else {
+		memset(req->bcode, 0, sizeof(req->bcode));
+	}
+
+	LOG_DBG("BIG handle %u, adv handle %u, num_bis %u, SDU interval %u, "
+		"ISO interval %u, NSE %u, SDU %u, PDU %u, PHY %u, packing %u, "
+		"framing %u, BN %u, IRC %u, PTO %u, encryption %u",
+		req->big_handle, req->adv_handle, req->num_bis, param->interval,
+		param->iso_interval, req->nse, req->max_sdu, req->max_pdu,
+		req->phy, req->packing, req->framing, req->bn, req->irc,
+		req->pto, req->encryption);
+
+	bt_hci_cmd_state_set_init(buf, &state, big->flags, BT_BIG_PENDING, true);
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_CREATE_BIG_TEST, buf, NULL);
+	if (err) {
+		return err;
+	}
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&big->bis_channels, bis, node) {
+		bt_iso_chan_set_state(bis, BT_ISO_STATE_CONNECTING);
+	}
+
+	return err;
+}
+
+static bool is_advanced_big_param(const struct bt_iso_big_create_param *param)
+{
+	if (param->irc != 0U ||
+	    param->iso_interval != 0U) {
+		return true;
+	}
+
+	/* Check if any of the CIS contain any test-param-only values */
+	for (uint8_t i = 0U; i < param->num_bis; i++) {
+		const struct bt_iso_chan *bis = param->bis_channels[i];
+		const struct bt_iso_chan_qos *qos = bis->qos;
+
+		if (qos->num_subevents > 0U) {
+			return true;
+		}
+
+		__ASSERT(qos->tx != NULL, "TX cannot be NULL for broadcaster");
+
+		if (qos->tx->max_pdu > 0U || qos->tx->burst_number > 0U) {
+			return true;
+		}
+	}
+
+	return false;
+}
+#endif /* CONFIG_BT_ISO_ADVANCED */
+
+static bool valid_big_param(const struct bt_iso_big_create_param *param,
+			    bool advanced)
+{
 	CHECKIF(!param->bis_channels) {
 		LOG_DBG("NULL BIS channels");
-		return -EINVAL;
+
+		return false;
 	}
 
 	CHECKIF(!param->num_bis) {
 		LOG_DBG("Invalid number of BIS %u", param->num_bis);
-		return -EINVAL;
+
+		return false;
 	}
 
 	for (uint8_t i = 0; i < param->num_bis; i++) {
@@ -2587,54 +2675,116 @@ int bt_iso_big_create(struct bt_le_ext_adv *padv, struct bt_iso_big_create_param
 
 		CHECKIF(bis == NULL) {
 			LOG_DBG("bis_channels[%u]: NULL channel", i);
-			return -EINVAL;
+
+			return false;
 		}
 
 		if (bis->iso) {
 			LOG_DBG("bis_channels[%u]: already allocated", i);
-			return -EALREADY;
+
+			return false;
 		}
 
 		CHECKIF(bis->qos == NULL) {
 			LOG_DBG("bis_channels[%u]: qos is NULL", i);
-			return -EINVAL;
+
+			return false;
 		}
 
 		CHECKIF(bis->qos->tx == NULL ||
-			!valid_chan_io_qos(bis->qos->tx, true, true, false)) {
+			!valid_chan_io_qos(bis->qos->tx, true, true,
+					   advanced)) {
 			LOG_DBG("bis_channels[%u]: Invalid QOS", i);
-			return -EINVAL;
+
+			return false;
 		}
 	}
 
 	CHECKIF(param->framing != BT_ISO_FRAMING_UNFRAMED &&
 		param->framing != BT_ISO_FRAMING_FRAMED) {
 		LOG_DBG("Invalid framing parameter: %u", param->framing);
-		return -EINVAL;
+
+		return false;
 	}
 
 	CHECKIF(param->packing != BT_ISO_PACKING_SEQUENTIAL &&
 		param->packing != BT_ISO_PACKING_INTERLEAVED) {
 		LOG_DBG("Invalid packing parameter: %u", param->packing);
-		return -EINVAL;
+
+		return false;
 	}
 
 	CHECKIF(param->num_bis > BT_ISO_MAX_GROUP_ISO_COUNT ||
 		param->num_bis > CONFIG_BT_ISO_MAX_CHAN) {
 		LOG_DBG("num_bis (%u) shall be lower than: %u", param->num_bis,
 			MAX(CONFIG_BT_ISO_MAX_CHAN, BT_ISO_MAX_GROUP_ISO_COUNT));
-		return -EINVAL;
+
+		return false;
 	}
 
-	CHECKIF(param->interval < BT_ISO_SDU_INTERVAL_MIN ||
-		param->interval > BT_ISO_SDU_INTERVAL_MAX) {
+	CHECKIF(!IN_RANGE(param->interval,
+			  BT_ISO_SDU_INTERVAL_MIN,
+			  BT_ISO_SDU_INTERVAL_MAX)) {
 		LOG_DBG("Invalid interval: %u", param->interval);
+
+		return false;
+	}
+
+	CHECKIF(!advanced &&
+		!IN_RANGE(param->latency,
+			  BT_ISO_LATENCY_MIN,
+			  BT_ISO_LATENCY_MAX)) {
+		LOG_DBG("Invalid latency: %u", param->latency);
+
+		return false;
+	}
+
+#if defined(CONFIG_BT_ISO_ADVANCED)
+	if (advanced) {
+		CHECKIF(!IN_RANGE(param->irc, BT_ISO_IRC_MIN, BT_ISO_IRC_MAX)) {
+			LOG_DBG("Invalid IRC %u", param->irc);
+
+			return false;
+		}
+
+		CHECKIF(!IN_RANGE(param->pto, BT_ISO_PTO_MIN, BT_ISO_PTO_MAX)) {
+			LOG_DBG("Invalid PTO %u", param->pto);
+
+			return false;
+		}
+
+		CHECKIF(!IN_RANGE(param->iso_interval,
+				BT_ISO_ISO_INTERVAL_MIN,
+				BT_ISO_ISO_INTERVAL_MAX)) {
+			LOG_DBG("Invalid ISO interval %u", param->iso_interval);
+
+			return false;
+		}
+	}
+#endif /* CONFIG_BT_ISO_ADVANCED */
+
+	return true;
+}
+
+int bt_iso_big_create(struct bt_le_ext_adv *padv, struct bt_iso_big_create_param *param,
+		      struct bt_iso_big **out_big)
+{
+	int err;
+	struct bt_iso_big *big;
+	bool advanced = false;
+
+	if (!atomic_test_bit(padv->flags, BT_PER_ADV_PARAMS_SET)) {
+		LOG_DBG("PA params not set; invalid adv object");
 		return -EINVAL;
 	}
 
-	CHECKIF(param->latency < BT_ISO_LATENCY_MIN ||
-		param->latency > BT_ISO_LATENCY_MAX) {
-		LOG_DBG("Invalid latency: %u", param->latency);
+#if defined(CONFIG_BT_ISO_ADVANCED)
+	advanced = is_advanced_big_param(param);
+#endif /* CONFIG_BT_ISO_ADVANCED */
+
+	if (!valid_big_param(param, advanced)) {
+		LOG_DBG("Invalid BIG parameters");
+
 		return -EINVAL;
 	}
 
@@ -2652,7 +2802,14 @@ int bt_iso_big_create(struct bt_le_ext_adv *padv, struct bt_iso_big_create_param
 	}
 	big->num_bis = param->num_bis;
 
-	err = hci_le_create_big(padv, big, param);
+	if (!advanced) {
+		err = hci_le_create_big(padv, big, param);
+#if defined(CONFIG_BT_ISO_ADVANCED)
+	} else {
+		err = hci_le_create_big_test(padv, big, param);
+#endif /* CONFIG_BT_ISO_ADVANCED */
+	}
+
 	if (err) {
 		LOG_DBG("Could not create BIG %d", err);
 		cleanup_big(big);

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -830,6 +830,14 @@ static bool valid_chan_io_qos(const struct bt_iso_chan_io_qos *io_qos,
 		return false;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_ISO_BROADCASTER) &&
+	    is_broadcast &&
+	    io_qos->rtn > BT_ISO_BROADCAST_RTN_MAX) {
+		LOG_DBG("Invalid RTN %u", io_qos->phy);
+
+		return false;
+	}
+
 #if defined(CONFIG_BT_ISO_ADVANCED)
 	if (advanced) {
 		if (IS_ENABLED(CONFIG_BT_ISO_BROADCASTER) && is_broadcast) {

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -813,20 +813,54 @@ int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf,
 
 #if defined(CONFIG_BT_ISO_CENTRAL) || defined(CONFIG_BT_ISO_BROADCASTER)
 static bool valid_chan_io_qos(const struct bt_iso_chan_io_qos *io_qos,
-			      bool is_tx)
+			      bool is_tx, bool is_broadcast, bool advanced)
 {
 	const size_t max_mtu = (is_tx ? CONFIG_BT_ISO_TX_MTU : CONFIG_BT_ISO_RX_MTU);
 	const size_t max_sdu = MIN(max_mtu, BT_ISO_MAX_SDU);
 
 	if (io_qos->sdu > max_sdu) {
-		LOG_DBG("sdu (%u) shall be smaller than %zu", io_qos->sdu, max_sdu);
+		LOG_DBG("sdu (%u) shall be smaller or equal to %zu", io_qos->sdu, max_sdu);
+
 		return false;
 	}
 
-	if (io_qos->phy > BT_GAP_LE_PHY_CODED) {
-		LOG_DBG("Invalid phy %u", io_qos->phy);
+	if (!IN_RANGE(io_qos->phy, BT_GAP_LE_PHY_1M, BT_GAP_LE_PHY_CODED)) {
+		LOG_DBG("Invalid PHY %u", io_qos->phy);
+
 		return false;
 	}
+
+#if defined(CONFIG_BT_ISO_ADVANCED)
+	if (advanced) {
+		if (IS_ENABLED(CONFIG_BT_ISO_BROADCASTER) && is_broadcast) {
+			if (!IN_RANGE(io_qos->max_pdu,
+				      BT_ISO_BROADCAST_PDU_MIN,
+				      BT_ISO_PDU_MAX)) {
+				LOG_DBG("Invalid PDU %u", io_qos->max_pdu);
+
+				return false;
+			}
+		} else if (IS_ENABLED(CONFIG_BT_ISO_CENTRAL)) {
+			if (!IN_RANGE(io_qos->max_pdu,
+				      BT_ISO_CONNECTED_PDU_MIN,
+				      BT_ISO_PDU_MAX)) {
+				LOG_DBG("Invalid PDU %u", io_qos->max_pdu);
+
+				return false;
+			}
+		}
+
+		if (!IN_RANGE(io_qos->burst_number,
+			      BT_ISO_BN_MIN,
+			      BT_ISO_BN_MAX)) {
+			LOG_DBG("Invalid BN %u", io_qos->burst_number);
+
+			return false;
+		}
+	}
+#else
+	ARG_UNUSED(advanced);
+#endif /* CONFIG_BT_ISO_ADVANCED */
 
 	return true;
 }
@@ -1391,10 +1425,19 @@ static void bt_iso_remove_data_path(struct bt_conn *iso)
 	}
 }
 
-static bool valid_chan_qos(const struct bt_iso_chan_qos *qos)
+static bool valid_chan_qos(const struct bt_iso_chan_qos *qos, bool advanced)
 {
+#if defined(CONFIG_BT_ISO_ADVANCED)
+	if (advanced &&
+	    !IN_RANGE(qos->num_subevents, BT_ISO_NSE_MIN, BT_ISO_NSE_MAX)) {
+		LOG_DBG("Invalid NSE: %u", qos->num_subevents);
+
+		return false;
+	}
+#endif /* CONFIG_BT_ISO_ADVANCED */
+
 	if (qos->rx != NULL) {
-		if (!valid_chan_io_qos(qos->rx, false)) {
+		if (!valid_chan_io_qos(qos->rx, false, false, advanced)) {
 			LOG_DBG("Invalid rx qos");
 			return false;
 		}
@@ -1404,7 +1447,7 @@ static bool valid_chan_qos(const struct bt_iso_chan_qos *qos)
 	}
 
 	if (qos->tx != NULL) {
-		if (!valid_chan_io_qos(qos->tx, true)) {
+		if (!valid_chan_io_qos(qos->tx, true, false, advanced)) {
 			LOG_DBG("Invalid tx qos");
 			return false;
 		}
@@ -1518,6 +1561,138 @@ static struct net_buf *hci_le_set_cig_params(const struct bt_iso_cig *cig,
 	return rsp;
 }
 
+#if defined(CONFIG_BT_ISO_ADVANCED)
+static struct net_buf *hci_le_set_cig_test_params(const struct bt_iso_cig *cig,
+						  const struct bt_iso_cig_param *param)
+{
+	struct bt_hci_cp_le_set_cig_params_test *req;
+	struct bt_hci_cis_params_test *cis_param;
+	struct net_buf *buf;
+	struct net_buf *rsp;
+	int err;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CIG_PARAMS_TEST,
+				sizeof(*req) + sizeof(*cis_param) * param->num_cis);
+	if (!buf) {
+		return NULL;
+	}
+
+	req = net_buf_add(buf, sizeof(*req));
+
+	memset(req, 0, sizeof(*req));
+
+	req->cig_id = cig->id;
+	sys_put_le24(param->interval, req->c_interval);
+	sys_put_le24(param->interval, req->p_interval);
+
+	req->c_ft = param->c_to_p_ft;
+	req->p_ft = param->p_to_c_ft;
+	req->iso_interval = sys_cpu_to_le16(param->iso_interval);
+	req->sca = param->sca;
+	req->packing = param->packing;
+	req->framing = param->framing;
+	req->num_cis = param->num_cis;
+
+	LOG_DBG("id %u, SDU interval %u, c_ft %u, p_ft %u, iso_interval %u, "
+		"sca %u, packing %u, framing %u, num_cis %u",
+		cig->id, param->interval, param->c_to_p_ft, param->p_to_c_ft,
+		param->iso_interval, param->sca, param->packing,
+		param->framing, param->num_cis);
+
+	/* Program the cis parameters */
+	for (uint8_t i = 0U; i < param->num_cis; i++) {
+		const struct bt_iso_chan *cis = param->cis_channels[i];
+		const struct bt_iso_chan_qos *qos = cis->qos;
+
+		cis_param = net_buf_add(buf, sizeof(*cis_param));
+
+		memset(cis_param, 0, sizeof(*cis_param));
+
+		cis_param->cis_id = cis->iso->iso.cis_id;
+		cis_param->nse = qos->num_subevents;
+
+		if (!qos->tx && !qos->rx) {
+			LOG_ERR("Both TX and RX QoS are disabled");
+			net_buf_unref(buf);
+			return NULL;
+		}
+
+		if (!qos->tx) {
+			/* Use RX PHY if TX is not set (disabled)
+			 * to avoid setting invalid values
+			 */
+			cis_param->c_phy = qos->rx->phy;
+		} else {
+			cis_param->c_sdu = sys_cpu_to_le16(qos->tx->sdu);
+			cis_param->c_pdu = sys_cpu_to_le16(qos->tx->max_pdu);
+			cis_param->c_phy = qos->tx->phy;
+			cis_param->c_bn = qos->tx->burst_number;
+		}
+
+		if (!qos->rx) {
+			/* Use TX PHY if RX is not set (disabled)
+			 * to avoid setting invalid values
+			 */
+			cis_param->p_phy = qos->tx->phy;
+		} else {
+			cis_param->p_sdu = sys_cpu_to_le16(qos->rx->sdu);
+			cis_param->p_pdu = sys_cpu_to_le16(qos->rx->max_pdu);
+			cis_param->p_phy = qos->rx->phy;
+			cis_param->p_bn = qos->rx->burst_number;
+		}
+
+		LOG_DBG("[%d]: id %u, nse %u c_sdu %u, p_sdu %u, c_pdu %u, "
+			"p_pdu %u, c_phy %u, p_phy %u, c_bn %u, p_bn %u",
+			i, cis_param->cis_id, cis_param->nse, cis_param->c_sdu,
+			cis_param->p_sdu, cis_param->c_pdu, cis_param->p_pdu,
+			cis_param->c_phy, cis_param->p_phy, cis_param->c_bn,
+			cis_param->p_bn);
+	}
+
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_CIG_PARAMS_TEST, buf, &rsp);
+	if (err) {
+		return NULL;
+	}
+
+	return rsp;
+}
+
+static bool is_advanced_cig_param(const struct bt_iso_cig_param *param)
+{
+	if (param->c_to_p_ft != 0U ||
+	    param->p_to_c_ft != 0U ||
+	    param->iso_interval != 0U) {
+		return true;
+	}
+
+	/* Check if any of the CIS contain any test-param-only values */
+	for (uint8_t i = 0U; i < param->num_cis; i++) {
+		const struct bt_iso_chan *cis = param->cis_channels[i];
+		const struct bt_iso_chan_qos *qos = cis->qos;
+
+		if (qos->num_subevents > 0U) {
+			return true;
+		}
+
+		if (qos->tx != NULL) {
+			if (qos->tx->max_pdu > 0U ||
+			    qos->tx->burst_number > 0U) {
+				return true;
+			}
+		}
+
+		if (qos->rx != NULL) {
+			if (qos->rx->max_pdu > 0U ||
+			    qos->rx->burst_number > 0U) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+#endif /* CONFIG_BT_ISO_ADVANCED */
+
 static struct bt_iso_cig *get_cig(const struct bt_iso_chan *iso_chan)
 {
 	if (iso_chan->iso == NULL) {
@@ -1599,7 +1774,7 @@ static void cleanup_cig(struct bt_iso_cig *cig)
 	memset(cig, 0, sizeof(*cig));
 }
 
-static bool valid_cig_param(const struct bt_iso_cig_param *param)
+static bool valid_cig_param(const struct bt_iso_cig_param *param, bool advanced)
 {
 	if (param == NULL) {
 		return false;
@@ -1618,7 +1793,7 @@ static bool valid_cig_param(const struct bt_iso_cig_param *param)
 			return false;
 		}
 
-		if (!valid_chan_qos(cis->qos)) {
+		if (!valid_chan_qos(cis->qos, advanced)) {
 			LOG_DBG("cis_channels[%d]: Invalid QOS", i);
 			return false;
 		}
@@ -1656,11 +1831,38 @@ static bool valid_cig_param(const struct bt_iso_cig_param *param)
 		return false;
 	}
 
-	if (param->latency < BT_ISO_LATENCY_MIN ||
-	    param->latency > BT_ISO_LATENCY_MAX) {
+	if (!advanced &&
+	    (param->latency < BT_ISO_LATENCY_MIN ||
+	     param->latency > BT_ISO_LATENCY_MAX)) {
 		LOG_DBG("Invalid latency: %u", param->latency);
 		return false;
 	}
+
+#if defined(CONFIG_BT_ISO_ADVANCED)
+	if (advanced) {
+		if (!IN_RANGE(param->c_to_p_ft, BT_ISO_FT_MIN, BT_ISO_FT_MAX)) {
+			LOG_DBG("Invalid Central to Peripheral FT %u",
+				param->c_to_p_ft);
+
+			return false;
+		}
+
+		if (!IN_RANGE(param->p_to_c_ft, BT_ISO_FT_MIN, BT_ISO_FT_MAX)) {
+			LOG_DBG("Invalid Peripheral to Central FT %u",
+				param->p_to_c_ft);
+
+			return false;
+		}
+
+		if (!IN_RANGE(param->iso_interval,
+			      BT_ISO_ISO_INTERVAL_MIN,
+			      BT_ISO_ISO_INTERVAL_MAX)) {
+			LOG_DBG("Invalid ISO interval %u", param->iso_interval);
+
+			return false;
+		}
+	}
+#endif /* CONFIG_BT_ISO_ADVANCED */
 
 	return true;
 }
@@ -1673,6 +1875,7 @@ int bt_iso_cig_create(const struct bt_iso_cig_param *param,
 	struct bt_iso_cig *cig;
 	struct bt_hci_rp_le_set_cig_params *cig_rsp;
 	struct bt_iso_chan *cis;
+	bool advanced = false;
 	int i;
 
 	CHECKIF(out_cig == NULL) {
@@ -1698,7 +1901,11 @@ int bt_iso_cig_create(const struct bt_iso_cig_param *param,
 		return -EINVAL;
 	}
 
-	CHECKIF(!valid_cig_param(param)) {
+#if defined(CONFIG_BT_ISO_ADVANCED)
+	advanced = is_advanced_cig_param(param);
+#endif /* CONFIG_BT_ISO_ADVANCED */
+
+	CHECKIF(!valid_cig_param(param, advanced)) {
 		LOG_DBG("Invalid CIG params");
 		return -EINVAL;
 	}
@@ -1716,7 +1923,14 @@ int bt_iso_cig_create(const struct bt_iso_cig_param *param,
 		return err;
 	}
 
-	rsp = hci_le_set_cig_params(cig, param);
+	if (!advanced) {
+		rsp = hci_le_set_cig_params(cig, param);
+#if defined(CONFIG_BT_ISO_ADVANCED)
+	} else {
+		rsp = hci_le_set_cig_test_params(cig, param);
+#endif /* CONFIG_BT_ISO_ADVANCED */
+	}
+
 	if (rsp == NULL) {
 		LOG_WRN("Unexpected response to hci_le_set_cig_params");
 		err = -EIO;
@@ -1777,6 +1991,7 @@ int bt_iso_cig_reconfigure(struct bt_iso_cig *cig,
 	struct bt_hci_rp_le_set_cig_params *cig_rsp;
 	uint8_t existing_num_cis;
 	struct bt_iso_chan *cis;
+	bool advanced = false;
 	struct net_buf *rsp;
 	int err;
 	int i;
@@ -1791,7 +2006,11 @@ int bt_iso_cig_reconfigure(struct bt_iso_cig *cig,
 		return -EINVAL;
 	}
 
-	CHECKIF(!valid_cig_param(param)) {
+#if defined(CONFIG_BT_ISO_ADVANCED)
+	advanced = is_advanced_cig_param(param);
+#endif /* CONFIG_BT_ISO_ADVANCED */
+
+	CHECKIF(!valid_cig_param(param, advanced)) {
 		LOG_DBG("Invalid CIG params");
 		return -EINVAL;
 	}
@@ -1817,7 +2036,14 @@ int bt_iso_cig_reconfigure(struct bt_iso_cig *cig,
 		return err;
 	}
 
-	rsp = hci_le_set_cig_params(cig, param);
+	if (!advanced) {
+		rsp = hci_le_set_cig_params(cig, param);
+#if defined(CONFIG_BT_ISO_ADVANCED)
+	} else {
+		rsp = hci_le_set_cig_test_params(cig, param);
+#endif /* CONFIG_BT_ISO_ADVANCED */
+	}
+
 	if (rsp == NULL) {
 		LOG_WRN("Unexpected response to hci_le_set_cig_params");
 		err = -EIO;
@@ -2367,7 +2593,7 @@ int bt_iso_big_create(struct bt_le_ext_adv *padv, struct bt_iso_big_create_param
 		}
 
 		CHECKIF(bis->qos->tx == NULL ||
-			!valid_chan_io_qos(bis->qos->tx, true)) {
+			!valid_chan_io_qos(bis->qos->tx, true, true, false)) {
 			LOG_DBG("bis_channels[%u]: Invalid QOS", i);
 			return -EINVAL;
 		}

--- a/tests/bsim/bluetooth/ll/bis/src/main.c
+++ b/tests/bsim/bluetooth/ll/bis/src/main.c
@@ -147,23 +147,12 @@ bool ll_data_path_sink_create(uint16_t handle, struct ll_iso_datapath *datapath,
 }
 #endif /* CONFIG_BT_CTLR_ISO_VENDOR_DATA_PATH */
 
-static void test_iso_main(void)
+static void setup_ext_adv(struct bt_le_ext_adv **adv)
 {
-	struct bt_le_ext_adv *adv;
 	int err;
 
-	printk("\n*ISO broadcast test*\n");
-
-	printk("Bluetooth initializing...");
-	err = bt_enable(NULL);
-	if (err) {
-		FAIL("Could not init BT: %d\n", err);
-		return;
-	}
-	printk("success.\n");
-
 	printk("Create advertising set...");
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, &adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, adv);
 	if (err) {
 		FAIL("Failed to create advertising set (err %d)\n", err);
 		return;
@@ -171,7 +160,7 @@ static void test_iso_main(void)
 	printk("success.\n");
 
 	printk("Setting Periodic Advertising parameters...");
-	err = bt_le_per_adv_set_param(adv, BT_LE_PER_ADV_DEFAULT);
+	err = bt_le_per_adv_set_param(*adv, BT_LE_PER_ADV_DEFAULT);
 	if (err) {
 		FAIL("Failed to set periodic advertising parameters (err %d)\n",
 		     err);
@@ -180,7 +169,7 @@ static void test_iso_main(void)
 	printk("success.\n");
 
 	printk("Enable Periodic Advertising...");
-	err = bt_le_per_adv_start(adv);
+	err = bt_le_per_adv_start(*adv);
 	if (err) {
 		FAIL("Failed to enable periodic advertising (err %d)\n", err);
 		return;
@@ -188,29 +177,60 @@ static void test_iso_main(void)
 	printk("success.\n");
 
 	printk("Start extended advertising...");
-	err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
+	err = bt_le_ext_adv_start(*adv, BT_LE_EXT_ADV_START_DEFAULT);
 	if (err) {
 		printk("Failed to start extended advertising (err %d)\n", err);
 		return;
 	}
 	printk("success.\n");
+}
 
+static void teardown_ext_adv(struct bt_le_ext_adv *adv)
+{
+	int err;
+
+	printk("Stop Periodic Advertising...");
+	err = bt_le_per_adv_stop(adv);
+	if (err) {
+		FAIL("Failed to stop periodic advertising (err %d)\n", err);
+		return;
+	}
+	printk("success.\n");
+
+	printk("Stop Extended Advertising...");
+	err = bt_le_ext_adv_stop(adv);
+	if (err) {
+		FAIL("Failed to stop extended advertising (err %d)\n", err);
+		return;
+	}
+	printk("success.\n");
+
+	printk("Deleting Extended Advertising...");
+	err = bt_le_ext_adv_delete(adv);
+	if (err) {
+		FAIL("Failed to delete extended advertising (err %d)\n", err);
+		return;
+	}
+	printk("success.\n");
+}
 
 #if TEST_LL_INTERFACE
-	printk("Creating BIG...");
+static void create_ll_big(uint8_t big_handle, struct bt_le_ext_adv *adv)
+{
 	uint16_t max_sdu = CONFIG_BT_CTLR_ADV_ISO_PDU_LEN_MAX;
 	uint8_t bcode[BT_ISO_BROADCAST_CODE_SIZE] = { 0 };
 	uint32_t sdu_interval = 10000; /* us */
 	uint16_t max_latency = 10; /* ms */
 	uint8_t encryption = 0;
-	uint8_t big_handle = 0;
 	uint8_t bis_count = 1; /* TODO: Add support for multiple BIS per BIG */
 	uint8_t phy = BIT(1);
 	uint8_t packing = 0;
 	uint8_t framing = 0;
 	uint8_t adv_handle;
 	uint8_t rtn = 0;
+	int err;
 
+	printk("Creating LL BIG...");
 	/* Assume that index == handle */
 	adv_handle = bt_le_ext_adv_get_index(adv);
 
@@ -222,12 +242,28 @@ static void test_iso_main(void)
 		return;
 	}
 	printk("success.\n");
-#endif
+}
+
+static void terminate_ll_big(uint8_t big_handle)
+{
+	int err;
+
+	printk("Terminating LL BIG...");
+	err = ll_big_terminate(big_handle, BT_HCI_ERR_LOCALHOST_TERM_CONN);
+	if (err) {
+		FAIL("Could not terminate BIG: %d\n", err);
+		return;
+	}
+	printk("success.\n");
+}
+#endif /* TEST_LL_INTERFACE */
+
+static void create_big(struct bt_le_ext_adv *adv, struct bt_iso_big **big)
+{
+	struct bt_iso_big_create_param big_create_param;
+	int err;
 
 	printk("Creating BIG...\n");
-	struct bt_iso_big_create_param big_create_param;
-	struct bt_iso_big *big;
-
 	big_create_param.bis_channels = bis_channels;
 	big_create_param.num_bis = BIS_ISO_CHAN_COUNT;
 	big_create_param.encryption = false;
@@ -240,7 +276,7 @@ static void test_iso_main(void)
 	iso_tx_qos.phy = BT_GAP_LE_PHY_2M;
 	bis_iso_qos.tx = &iso_tx_qos;
 	bis_iso_qos.rx = NULL;
-	err = bt_iso_big_create(adv, &big_create_param, &big);
+	err = bt_iso_big_create(adv, &big_create_param, big);
 	if (err) {
 		FAIL("Could not create BIG: %d\n", err);
 		return;
@@ -252,10 +288,27 @@ static void test_iso_main(void)
 		k_sleep(K_MSEC(100));
 	}
 	printk("ISO connected\n");
+}
 
+static void terminate_big(struct bt_iso_big *big)
+{
+	int err;
+
+	printk("Terminating BIG...\n");
+	err = bt_iso_big_terminate(big);
+	if (err) {
+		FAIL("Could not terminate BIG: %d\n", err);
+		return;
+	}
+	printk("success.\n");
+}
+
+static void send_iso_data(void)
+{
 	uint32_t iso_send_count = 0;
 	uint8_t iso_data[sizeof(iso_send_count)] = { 0 };
 	struct net_buf *buf;
+	int err;
 
 	buf = net_buf_alloc(&bis_tx_pool, K_FOREVER);
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
@@ -268,6 +321,35 @@ static void test_iso_main(void)
 		return;
 	}
 	printk("Sending value %u\n", iso_send_count);
+}
+
+static void test_iso_main(void)
+{
+	struct bt_le_ext_adv *adv;
+	struct bt_iso_big *big;
+	int err;
+
+	printk("\n*ISO broadcast test*\n");
+
+	printk("Bluetooth initializing...");
+	err = bt_enable(NULL);
+	if (err) {
+		FAIL("Could not init BT: %d\n", err);
+		return;
+	}
+	printk("success.\n");
+
+	setup_ext_adv(&adv);
+
+#if TEST_LL_INTERFACE
+	uint8_t big_handle = 0;
+
+	create_ll_big(big_handle, adv);
+#endif
+
+	create_big(adv, &big);
+
+	send_iso_data();
 
 	k_sleep(K_MSEC(5000));
 
@@ -303,33 +385,16 @@ static void test_iso_main(void)
 	k_sleep(K_MSEC(5000));
 
 #if TEST_LL_INTERFACE
-	printk("Terminating BIG...");
-	err = ll_big_terminate(big_handle, BT_HCI_ERR_LOCALHOST_TERM_CONN);
-	if (err) {
-		FAIL("Could not terminate BIG: %d\n", err);
-		return;
-	}
-	printk("success.\n");
+	terminate_ll_big(big_handle);
 #endif
 
-	printk("Terminating BIG...\n");
-	err = bt_iso_big_terminate(big);
-	if (err) {
-		FAIL("Could not terminate BIG: %d\n", err);
-		return;
-	}
-	printk("success.\n");
+	terminate_big(big);
+	big = NULL;
 
 	k_sleep(K_MSEC(10000));
 
-	printk("Stop Periodic Advertising...");
-	err = bt_le_per_adv_stop(adv);
-	if (err) {
-		FAIL("Failed to stop periodic advertising (err %d)\n", err);
-		return;
-	}
-	printk("success.\n");
-
+	teardown_ext_adv(adv);
+	adv = NULL;
 
 	PASS("ISO tests Passed\n");
 


### PR DESCRIPTION
Adds support for setting advanced ISO settings for CIGs and BIGs. This also adds support for the new settings in the benchmark samples. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/50949