### PR TITLE
modules/cmsis: Change libc requirement to allow picolibc

### DIFF
--- a/modules/Kconfig.cmsis
+++ b/modules/Kconfig.cmsis
@@ -22,7 +22,7 @@ endif
 
 menuconfig CMSIS_DSP
 	bool "CMSIS-DSP Library Support"
-	depends on NEWLIB_LIBC || ARCH_POSIX
+	select REQUIRES_FULL_LIBC if !ARCH_POSIX
 
 if CMSIS_DSP
 source "modules/Kconfig.cmsis_dsp"


### PR DESCRIPTION
Change from depending on newlib to requiring a full libc, this allows use with picolibc or any other C library providing a complete implementation.

Signed-off-by: Keith Packard <keithp@keithp.com>