### PR TITLE
runners: restore obsolete synonyms for -i/--dev-id

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -94,6 +94,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         # Optional:
         parser.add_argument('--loader', required=False, dest='loader',
                             help='specifies a loader type')
+        parser.add_argument('--id', required=False, dest='dev_id',
+                            help='obsolete synonym for -i/--dev-id')
         parser.add_argument('--iface', default='swd',
                             help='interface to use, default is swd')
         parser.add_argument('--speed', default='auto',

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -69,6 +69,8 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--softreset', required=False,
                             action='store_true',
                             help='use reset instead of pinreset')
+        parser.add_argument('--snr', required=False, dest='dev_id',
+                            help='obsolete synonym for -i/--dev-id')
         parser.add_argument('--force', required=False,
                             action='store_true',
                             help='Flash even if the result cannot be guaranteed.')

--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -107,6 +107,8 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
                                 DEFAULT_PYOCD_TELNET_PORT))
         parser.add_argument('--tui', default=False, action='store_true',
                             help='if given, GDB uses -tui')
+        parser.add_argument('--board-id', dest='dev_id',
+                            help='obsolete synonym for -i/--dev-id')
 
     @classmethod
     def tool_opt_help(cls) -> str:


### PR DESCRIPTION
This is a partial revert of commit 2cee5ff5191e2f75995c8c91edec6ed8dcb22a8a
("scripts: west_commands: runners: remove deprecated options").

I remarked at the time that the removal of the older way of writing things from the runners themselves seemed gratuitous since they are easy to continue to support indefinitely and people may have been used to the old way of doing things. It didn't seem worth the fight to push for a revert at the time, though.

Since then I've run into real problems that their removal has caused in the wild and I am convinced that this part of that patch was wrong.

Restore the original, undeprecated forms of these options, but make it clear in the command line help that they're just obsolete alternative spellings at this point.

Fixes: #54384