### PR TITLE
samples: spi_bitbang: Use gpio_loopback pins for MOSI and MISO

### DIFF
--- a/samples/drivers/spi_bitbang/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/spi_bitbang/boards/nrf52840dk_nrf52840.overlay
@@ -11,8 +11,8 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		clk-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
-		mosi-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
-		miso-gpios = <&gpio1 6 0>;
+		mosi-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+		miso-gpios = <&gpio1 2 0>;
 		cs-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 	};
 };


### PR DESCRIPTION
Align pins that are required to be shorted for this sample on nRF52840 DK with those used in e.g. uart driver tests.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>