### PR TITLE
drivers: spi_context: Use total transfer length in timeout calculation

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -129,6 +129,9 @@ static inline void spi_context_release(struct spi_context *ctx, int status)
 #endif /* CONFIG_SPI_ASYNC */
 }
 
+static inline size_t spi_context_total_tx_len(struct spi_context *ctx);
+static inline size_t spi_context_total_rx_len(struct spi_context *ctx);
+
 static inline int spi_context_wait_for_completion(struct spi_context *ctx)
 {
 	int status = 0;
@@ -141,9 +144,11 @@ static inline int spi_context_wait_for_completion(struct spi_context *ctx)
 	if (IS_ENABLED(CONFIG_SPI_SLAVE) && spi_context_is_slave(ctx)) {
 		timeout = K_FOREVER;
 	} else {
+		uint32_t tx_len = spi_context_total_tx_len(ctx);
+		uint32_t rx_len = spi_context_total_rx_len(ctx);
 		uint32_t timeout_ms;
 
-		timeout_ms = MAX(ctx->tx_len, ctx->rx_len) * 8 * 1000 /
+		timeout_ms = MAX(tx_len, rx_len) * 8 * 1000 /
 			     ctx->config->frequency;
 		timeout_ms += CONFIG_SPI_COMPLETION_TIMEOUT_TOLERANCE;
 

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -135,41 +135,41 @@ static inline size_t spi_context_total_rx_len(struct spi_context *ctx);
 static inline int spi_context_wait_for_completion(struct spi_context *ctx)
 {
 	int status = 0;
-	k_timeout_t timeout;
-
-	/* Do not use any timeout in the slave mode, as in this case it is not
-	 * known when the transfer will actually start and what the frequency
-	 * will be.
-	 */
-	if (IS_ENABLED(CONFIG_SPI_SLAVE) && spi_context_is_slave(ctx)) {
-		timeout = K_FOREVER;
-	} else {
-		uint32_t tx_len = spi_context_total_tx_len(ctx);
-		uint32_t rx_len = spi_context_total_rx_len(ctx);
-		uint32_t timeout_ms;
-
-		timeout_ms = MAX(tx_len, rx_len) * 8 * 1000 /
-			     ctx->config->frequency;
-		timeout_ms += CONFIG_SPI_COMPLETION_TIMEOUT_TOLERANCE;
-
-		timeout = K_MSEC(timeout_ms);
-	}
+	bool wait;
 
 #ifdef CONFIG_SPI_ASYNC
-	if (!ctx->asynchronous) {
+	wait = !ctx->asynchronous;
+#else
+	wait = true;
+#endif
+
+	if (wait) {
+		k_timeout_t timeout;
+
+		/* Do not use any timeout in the slave mode, as in this case
+		 * it is not known when the transfer will actually start and
+		 * what the frequency will be.
+		 */
+		if (IS_ENABLED(CONFIG_SPI_SLAVE) && spi_context_is_slave(ctx)) {
+			timeout = K_FOREVER;
+		} else {
+			uint32_t tx_len = spi_context_total_tx_len(ctx);
+			uint32_t rx_len = spi_context_total_rx_len(ctx);
+			uint32_t timeout_ms;
+
+			timeout_ms = MAX(tx_len, rx_len) * 8 * 1000 /
+				     ctx->config->frequency;
+			timeout_ms += CONFIG_SPI_COMPLETION_TIMEOUT_TOLERANCE;
+
+			timeout = K_MSEC(timeout_ms);
+		}
+
 		if (k_sem_take(&ctx->sync, timeout)) {
 			LOG_ERR("Timeout waiting for transfer complete");
 			return -ETIMEDOUT;
 		}
 		status = ctx->sync_status;
 	}
-#else
-	if (k_sem_take(&ctx->sync, timeout)) {
-		LOG_ERR("Timeout waiting for transfer complete");
-		return -ETIMEDOUT;
-	}
-	status = ctx->sync_status;
-#endif /* CONFIG_SPI_ASYNC */
 
 #ifdef CONFIG_SPI_SLAVE
 	if (spi_context_is_slave(ctx) && !status) {


### PR DESCRIPTION
When estimating the time that a given SPI transfer will take, whole buffer sets for TX and RX need to be taken into account, not only their first parts. Correct `spi_context_wait_for_completion()` accordingly. On the occasion, refactor also the code of this function to make it a bit easier to read.