### PR TITLE
dts: arm: stm32u5: Add aes node

### DIFF
--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -191,6 +191,10 @@
 	};
 };
 
+&aes {
+	status = "okay";
+};
+
 &rng {
 	status = "okay";
 };

--- a/boards/arm/b_u585i_iot02a/doc/index.rst
+++ b/boards/arm/b_u585i_iot02a/doc/index.rst
@@ -191,6 +191,8 @@ The Zephyr b_u585i_iot02a board configuration supports the following hardware fe
 | PWM       | on-chip    | pwm                                 |
 | die-temp  | on-chip    | die temperature sensor              |
 +-----------+------------+-------------------------------------+
+| AES       | on-chip    | crypto                              |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -556,6 +556,14 @@
 			status = "disabled";
 		};
 
+		aes: aes@420c0000 {
+			compatible = "st,stm32-aes";
+			reg = <0x420c0000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			interrupts = <93 0>;
+			status = "disabled";
+		};
+
 		rng: rng@420c0800 {
 			compatible = "st,stm32-rng";
 			reg = <0x420c0800 0x400>;


### PR DESCRIPTION
Add hw crypto support in stm32u5 dtsi.

Signed-off-by: Wojciech Slenska <wsl@trackunit.com>