### PR TITLE
drivers: usb: Fix NXP driver for CDC test cases

### DIFF
--- a/drivers/usb/device/usb_dc_mcux.c
+++ b/drivers/usb/device/usb_dc_mcux.c
@@ -560,7 +560,7 @@ int usb_dc_ep_read_wait(uint8_t ep, uint8_t *data, uint32_t max_data_len,
 	uint32_t data_len;
 	uint8_t *bufp = NULL;
 
-	while (dev_state.eps[ep_abs_idx].ep_occupied) {
+	if (dev_state.eps[ep_abs_idx].ep_occupied) {
 		LOG_ERR("Endpoint is occupied by the controller");
 		return -EBUSY;
 	}


### PR DESCRIPTION
The cdc_acm tests were failing. Remove a length check in the write function as this is handled by the HAL driver. Remove unused type member and improve the error checking.

Fixes #53636 , #52625