### PR TITLE
west: hal_rpi_pico: Update Pico-SDK to v1.5.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -115,7 +115,7 @@ manifest:
         - hal
     - name: hal_rpi_pico
       path: modules/hal/rpi_pico
-      revision: a094c060e0c2d43c7f9d8f5c06cc0665117e0c18
+      revision: b7801e4db6a62ea2d37bbef7880c3d056530c9bf
       groups:
         - hal
     - name: hal_silabs


### PR DESCRIPTION
Update Pico-SDK to v1.5.0 release.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>