### PR TITLE
drivers: ieee802154: rf2xx: Fix hang on 0x2c isr_status

### DIFF
--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -326,7 +326,8 @@ static void rf2xx_thread_main(void *arg)
 				rf2xx_iface_sram_read(ctx->dev, 0,
 						      &ctx->rx_phr, 1);
 			}
-		} else if (isr_status & (1 << RF2XX_TRX_END)) {
+		}
+		if (isr_status & (1 << RF2XX_TRX_END)) {
 			rf2xx_process_trx_end(ctx->dev);
 		}
 	}


### PR DESCRIPTION
When transceiver is overload on reception a frame can be stored on internal buffer. When frame is complete receibed a new interrupt will signal receive thread and isr_status can assume the value 0x2c.

The current implementation process one flag at time and it hangs when status is 0x2c. This can be reproduced using two nodes where one perform a regular TX broadcast. The another one should be wait for frames. The cause the problem the RX node should run on debug mode. The system should be started normally and wait for frames. The problems can be checked pressing CTRL+C which will cause system to stop. However, the transceiver still can receive one frame. After a few TX user can continue application and a isr_status of 0x2c will be visible if CONFIG_IEEE802154_DRIVER_LOG_DEBUG is enabled.

This fixes the current issue by processing all RF2XX_TRX_END events.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>