### PR TITLE
riscv: smarter FPU context switching

### DIFF
--- a/arch/riscv/core/CMakeLists.txt
+++ b/arch/riscv/core/CMakeLists.txt
@@ -18,6 +18,7 @@ if ((CONFIG_MP_MAX_NUM_CPUS GREATER 1) OR (CONFIG_SMP))
   zephyr_library_sources(smp.c)
 endif ()
 
+zephyr_library_sources_ifdef(CONFIG_FPU_SHARING fpu.c fpu.S)
 zephyr_library_sources_ifdef(CONFIG_DEBUG_COREDUMP coredump.c)
 zephyr_library_sources_ifdef(CONFIG_IRQ_OFFLOAD irq_offload.c)
 zephyr_library_sources_ifdef(CONFIG_RISCV_PMP pmp.c pmp.S)

--- a/arch/riscv/core/fpu.S
+++ b/arch/riscv/core/fpu.S
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023 BayLibre SAS
+ * Written by: Nicolas Pitre
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <offsets.h>
+
+#ifdef CONFIG_CPU_HAS_FPU_DOUBLE_PRECISION
+#define LOAD	fld
+#define STORE	fsd
+#else
+#define LOAD	flw
+#define STORE	fsw
+#endif
+
+#define DO_FP_REGS(op, ptr) \
+	op fa0,  __z_riscv_fp_context_t_fa0_OFFSET (ptr); \
+	op fa1,  __z_riscv_fp_context_t_fa1_OFFSET (ptr); \
+	op fa2,  __z_riscv_fp_context_t_fa2_OFFSET (ptr); \
+	op fa3,  __z_riscv_fp_context_t_fa3_OFFSET (ptr); \
+	op fa4,  __z_riscv_fp_context_t_fa4_OFFSET (ptr); \
+	op fa5,  __z_riscv_fp_context_t_fa5_OFFSET (ptr); \
+	op fa6,  __z_riscv_fp_context_t_fa6_OFFSET (ptr); \
+	op fa7,  __z_riscv_fp_context_t_fa7_OFFSET (ptr); \
+	op fs0,  __z_riscv_fp_context_t_fs0_OFFSET (ptr); \
+	op fs1,  __z_riscv_fp_context_t_fs1_OFFSET (ptr); \
+	op fs2,  __z_riscv_fp_context_t_fs2_OFFSET (ptr); \
+	op fs3,  __z_riscv_fp_context_t_fs3_OFFSET (ptr); \
+	op fs4,  __z_riscv_fp_context_t_fs4_OFFSET (ptr); \
+	op fs5,  __z_riscv_fp_context_t_fs5_OFFSET (ptr); \
+	op fs6,  __z_riscv_fp_context_t_fs6_OFFSET (ptr); \
+	op fs7,  __z_riscv_fp_context_t_fs7_OFFSET (ptr); \
+	op fs8,  __z_riscv_fp_context_t_fs8_OFFSET (ptr); \
+	op fs9,  __z_riscv_fp_context_t_fs9_OFFSET (ptr); \
+	op fs10, __z_riscv_fp_context_t_fs10_OFFSET(ptr); \
+	op fs11, __z_riscv_fp_context_t_fs11_OFFSET(ptr); \
+	op ft0,  __z_riscv_fp_context_t_ft0_OFFSET (ptr); \
+	op ft1,  __z_riscv_fp_context_t_ft1_OFFSET (ptr); \
+	op ft2,  __z_riscv_fp_context_t_ft2_OFFSET (ptr); \
+	op ft3,  __z_riscv_fp_context_t_ft3_OFFSET (ptr); \
+	op ft4,  __z_riscv_fp_context_t_ft4_OFFSET (ptr); \
+	op ft5,  __z_riscv_fp_context_t_ft5_OFFSET (ptr); \
+	op ft6,  __z_riscv_fp_context_t_ft6_OFFSET (ptr); \
+	op ft7,  __z_riscv_fp_context_t_ft7_OFFSET (ptr); \
+	op ft8,  __z_riscv_fp_context_t_ft8_OFFSET (ptr); \
+	op ft9,  __z_riscv_fp_context_t_ft9_OFFSET (ptr); \
+	op ft10, __z_riscv_fp_context_t_ft10_OFFSET(ptr); \
+	op ft11, __z_riscv_fp_context_t_ft11_OFFSET(ptr)
+
+GTEXT(z_riscv_fpu_save)
+SECTION_FUNC(TEXT, z_riscv_fpu_save)
+
+	frcsr t0
+	DO_FP_REGS(STORE, a0)
+	sw t0, __z_riscv_fp_context_t_fcsr_OFFSET(a0)
+	ret
+
+GTEXT(z_riscv_fpu_restore)
+SECTION_FUNC(TEXT, z_riscv_fpu_restore)
+
+	DO_FP_REGS(LOAD, a0)
+	lw t0, __z_riscv_fp_context_t_fcsr_OFFSET(a0)
+	fscsr t0
+	ret
+

--- a/arch/riscv/core/fpu.c
+++ b/arch/riscv/core/fpu.c
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2023 BayLibre SAS
+ * Written by: Nicolas Pitre
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
+#include <kernel_arch_interface.h>
+#include <zephyr/sys/atomic.h>
+
+/* to be found in fpu.S */
+extern void z_riscv_fpu_save(struct z_riscv_fp_context *saved_fp_context);
+extern void z_riscv_fpu_restore(struct z_riscv_fp_context *saved_fp_context);
+
+#define FPU_DEBUG 0
+
+#if FPU_DEBUG
+
+/*
+ * Debug traces have to be produced without printk() or any other functions
+ * using a va_list as va_start() may copy the FPU registers that could be
+ * used to pass float arguments, and that would trigger an FPU access trap.
+ * Note: Apparently gcc doesn't use float regs with variadic functions on
+ * RISC-V even if -mabi is used with f or d so this precaution might be
+ * unnecessary. But better be safe than sorry especially for debugging code.
+ */
+
+#include <string.h>
+
+static void DBG(char *msg, struct k_thread *th)
+{
+	char buf[80], *p;
+	unsigned int v;
+
+	strcpy(buf, "CPU# exc# ");
+	buf[3] = '0' + _current_cpu->id;
+	buf[8] = '0' + _current->arch.exception_depth;
+	strcat(buf, _current->name);
+	strcat(buf, ": ");
+	strcat(buf, msg);
+	strcat(buf, " ");
+	strcat(buf, th->name);
+
+	v = *(unsigned char *)&th->arch.saved_fp_context;
+	p = buf + strlen(buf);
+	*p++ = ' ';
+	*p++ = ((v >> 4) < 10) ? ((v >> 4) + '0') : ((v >> 4) - 10 + 'a');
+	*p++ = ((v & 15) < 10) ? ((v & 15) + '0') : ((v & 15) - 10 + 'a');
+	*p++ = '\n';
+	*p = 0;
+
+	k_str_out(buf, p - buf);
+}
+
+#else
+
+static inline void DBG(char *msg, struct k_thread *t) { }
+
+#endif /* FPU_DEBUG */
+
+static void z_riscv_fpu_disable(void)
+{
+	unsigned long status = csr_read(mstatus);
+
+	__ASSERT((status & MSTATUS_IEN) == 0, "must be called with IRQs disabled");
+
+	if ((status & MSTATUS_FS) != 0) {
+		csr_clear(mstatus, MSTATUS_FS);
+
+		/* remember its clean/dirty state */
+		_current_cpu->arch.fpu_state = (status & MSTATUS_FS);
+	}
+}
+
+/*
+ * Flush FPU content and clear ownership. If the saved FPU state is "clean"
+ * then we know the in-memory copy is up to date and skip the FPU content
+ * transfer. The saved FPU state is updated upon disabling FPU access so
+ * we require that this be called only when the FPU is disabled.
+ *
+ * This is called locally and also from flush_fpu_ipi_handler().
+ */
+void z_riscv_flush_local_fpu(void)
+{
+	__ASSERT((csr_read(mstatus) & MSTATUS_IEN) == 0,
+		 "must be called with IRQs disabled");
+	__ASSERT((csr_read(mstatus) & MSTATUS_FS) == 0,
+		 "must be called with FPU access disabled");
+
+	struct k_thread *owner = atomic_ptr_get(&_current_cpu->arch.fpu_owner);
+
+	if (owner != NULL) {
+		bool dirty = (_current_cpu->arch.fpu_state == MSTATUS_FS_DIRTY);
+
+		if (dirty) {
+			/* turn on FPU access */
+			csr_set(mstatus, MSTATUS_FS_CLEAN);
+			/* save current owner's content */
+			z_riscv_fpu_save(&owner->arch.saved_fp_context);
+		}
+
+		/* disable FPU access */
+		csr_clear(mstatus, MSTATUS_FS);
+
+		/* release ownership */
+		atomic_ptr_clear(&_current_cpu->arch.fpu_owner);
+		DBG("disable", owner);
+	}
+}
+
+#ifdef CONFIG_SMP
+static void flush_owned_fpu(struct k_thread *thread)
+{
+	__ASSERT((csr_read(mstatus) & MSTATUS_IEN) == 0,
+		 "must be called with IRQs disabled");
+
+	int i;
+	atomic_ptr_val_t owner;
+
+	/* search all CPUs for the owner we want */
+	unsigned int num_cpus = arch_num_cpus();
+
+	for (i = 0; i < num_cpus; i++) {
+		owner = atomic_ptr_get(&_kernel.cpus[i].arch.fpu_owner);
+		if (owner != thread) {
+			continue;
+		}
+		/* we found it live on CPU i */
+		if (i == _current_cpu->id) {
+			z_riscv_fpu_disable();
+			z_riscv_flush_local_fpu();
+			break;
+		}
+		/* the FPU context is live on another CPU */
+		z_riscv_flush_fpu_ipi(i);
+
+		/*
+		 * Wait for it only if this is about the thread
+		 * currently running on this CPU. Otherwise the
+		 * other CPU running some other thread could regain
+		 * ownership the moment it is removed from it and
+		 * we would be stuck here.
+		 *
+		 * Also, if this is for the thread running on this
+		 * CPU, then we preemptively flush any live context
+		 * on this CPU as well since we're likely to
+		 * replace it, and this avoids a deadlock where
+		 * two CPUs want to pull each other's FPU context.
+		 */
+		if (thread == _current) {
+			z_riscv_fpu_disable();
+			z_riscv_flush_local_fpu();
+			do {
+				arch_nop();
+				owner = atomic_ptr_get(&_kernel.cpus[i].arch.fpu_owner);
+			} while (owner == thread);
+		}
+		break;
+	}
+}
+#endif
+
+void z_riscv_fpu_enter_exc(void)
+{
+	/* always deny FPU access whenever an exception is entered */
+	z_riscv_fpu_disable();
+}
+
+/*
+ * Process the FPU trap.
+ *
+ * This usually means that FP regs belong to another thread. Save them
+ * to that thread's save area and restore the current thread's content.
+ *
+ * We also get here when FP regs are used while in exception as FP access
+ * is always disabled by default in that case. If so we save the FPU content
+ * to the owning thread and simply enable FPU access. Exceptions should be
+ * short and don't have persistent register contexts when they're done so
+ * there is nothing to save/restore for that context... as long as we
+ * don't get interrupted that is. To ensure that we mask interrupts to
+ * the triggering exception context.
+ *
+ * Note that the exception depth count was not incremented before this call
+ * as no further exceptions are expected before returning to normal mode.
+ */
+void z_riscv_fpu_trap(z_arch_esf_t *esf)
+{
+	__ASSERT((esf->mstatus & MSTATUS_FS) == 0 &&
+		 (csr_read(mstatus) & MSTATUS_FS) == 0,
+		 "called despite FPU being accessible");
+
+	/* save current owner's content  if any */
+	z_riscv_flush_local_fpu();
+
+	if (_current->arch.exception_depth > 0) {
+		/*
+		 * We were already in exception when the FPU access trapped.
+		 * We give it access and prevent any further IRQ recursion
+		 * by disabling IRQs as we wouldn't be able to preserve the
+		 * interrupted exception's FPU context.
+		 */
+		esf->mstatus &= ~MSTATUS_IEN;
+
+		/* make it accessible to the returning context */
+		esf->mstatus |= MSTATUS_FS_INIT;
+
+		return;
+	}
+
+#ifdef CONFIG_SMP
+	/*
+	 * Make sure the FPU context we need isn't live on another CPU.
+	 * The current CPU's FPU context is NULL at this point.
+	 */
+	flush_owned_fpu(_current);
+#endif
+
+	/* become new owner */
+	atomic_ptr_set(&_current_cpu->arch.fpu_owner, _current);
+
+	/* make it accessible and clean to the returning context */
+	esf->mstatus |= MSTATUS_FS_CLEAN;
+
+	/* restore our content */
+	csr_set(mstatus, MSTATUS_FS_INIT);
+	z_riscv_fpu_restore(&_current->arch.saved_fp_context);
+	DBG("restore", _current);
+}
+
+/*
+ * Perform lazy FPU context switching by simply granting or denying
+ * access to FP regs based on FPU ownership before leaving the last
+ * exception level in case of exceptions, or during a thread context
+ * switch with the exception level of the new thread being 0.
+ * If current thread doesn't own the FP regs then it will trap on its
+ * first access and then the actual FPU context switching will occur.
+ */
+static bool fpu_access_allowed(unsigned int exc_update_level)
+{
+	__ASSERT((csr_read(mstatus) & MSTATUS_IEN) == 0,
+		 "must be called with IRQs disabled");
+
+	if (_current->arch.exception_depth == exc_update_level) {
+		/* We're about to execute non-exception code */
+		return (_current_cpu->arch.fpu_owner == _current);
+	}
+	/*
+	 * Any new exception level should always trap on FPU
+	 * access as we want to make sure IRQs are disabled before
+	 * granting it access (see z_riscv_fpu_trap() documentation).
+	 */
+	return false;
+}
+
+/*
+ * This is called on every exception exit except for z_riscv_fpu_trap().
+ * In that case the exception level of interest is 1 (soon to be 0).
+ */
+void z_riscv_fpu_exit_exc(z_arch_esf_t *esf)
+{
+	if (fpu_access_allowed(1)) {
+		esf->mstatus |= _current_cpu->arch.fpu_state;
+	} else {
+		esf->mstatus &= ~MSTATUS_FS;
+	}
+}
+
+/*
+ * This is called from z_riscv_context_switch(). FPU access may be granted
+ * only if exception level is 0. If we switch to a thread that is still in
+ * some exception context then FPU access would be re-evaluated at exception
+ * exit time via z_riscv_fpu_exit_exc().
+ */
+void z_riscv_fpu_thread_context_switch(void)
+{
+	if (fpu_access_allowed(0)) {
+		csr_clear(mstatus, MSTATUS_FS);
+		csr_set(mstatus, _current_cpu->arch.fpu_state);
+	} else {
+		z_riscv_fpu_disable();
+	}
+}
+
+int arch_float_disable(struct k_thread *thread)
+{
+	if (thread != NULL) {
+		unsigned int key = arch_irq_lock();
+
+#ifdef CONFIG_SMP
+		flush_owned_fpu(thread);
+#else
+		if (thread == _current_cpu->arch.fpu_owner) {
+			z_riscv_fpu_disable();
+			z_riscv_flush_local_fpu();
+		}
+#endif
+
+		arch_irq_unlock(key);
+	}
+
+	return 0;
+}
+
+int arch_float_enable(struct k_thread *thread, unsigned int options)
+{
+	/* floats always gets enabled automatically at the moment */
+	return 0;
+}

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -21,30 +21,7 @@
 #include <soc_isr_stacking.h>
 #endif
 
-/* Convenience macros for loading/storing register states. */
-
-#define DO_FP_CALLER_SAVED(op, reg) \
-	op ft0, __z_arch_esf_t_ft0_OFFSET(reg)	 ;\
-	op ft1, __z_arch_esf_t_ft1_OFFSET(reg)	 ;\
-	op ft2, __z_arch_esf_t_ft2_OFFSET(reg)	 ;\
-	op ft3, __z_arch_esf_t_ft3_OFFSET(reg)	 ;\
-	op ft4, __z_arch_esf_t_ft4_OFFSET(reg)	 ;\
-	op ft5, __z_arch_esf_t_ft5_OFFSET(reg)	 ;\
-	op ft6, __z_arch_esf_t_ft6_OFFSET(reg)	 ;\
-	op ft7, __z_arch_esf_t_ft7_OFFSET(reg)	 ;\
-	op ft8, __z_arch_esf_t_ft8_OFFSET(reg)	 ;\
-	op ft9, __z_arch_esf_t_ft9_OFFSET(reg)	 ;\
-	op ft10, __z_arch_esf_t_ft10_OFFSET(reg) ;\
-	op ft11, __z_arch_esf_t_ft11_OFFSET(reg) ;\
-	op fa0, __z_arch_esf_t_fa0_OFFSET(reg)	 ;\
-	op fa1, __z_arch_esf_t_fa1_OFFSET(reg)	 ;\
-	op fa2, __z_arch_esf_t_fa2_OFFSET(reg)	 ;\
-	op fa3, __z_arch_esf_t_fa3_OFFSET(reg)	 ;\
-	op fa4, __z_arch_esf_t_fa4_OFFSET(reg)	 ;\
-	op fa5, __z_arch_esf_t_fa5_OFFSET(reg)	 ;\
-	op fa6, __z_arch_esf_t_fa6_OFFSET(reg)	 ;\
-	op fa7, __z_arch_esf_t_fa7_OFFSET(reg)	 ;
-
+/* Convenience macro for loading/storing register states. */
 #define DO_CALLER_SAVED(op) \
 	RV_E(	op t0, __z_arch_esf_t_t0_OFFSET(sp)	);\
 	RV_E(	op t1, __z_arch_esf_t_t1_OFFSET(sp)	);\
@@ -186,14 +163,67 @@ SECTION_FUNC(exception.entry, _isr_wrapper)
 	csrr t2, mstatus
 	sr t2, __z_arch_esf_t_mstatus_OFFSET(sp)
 
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-	/* Assess whether floating-point registers need to be saved. */
-	li t1, MSTATUS_FS_INIT
-	and t0, t2, t1
-	beqz t0, skip_store_fp_caller_saved
-	DO_FP_CALLER_SAVED(fsr, sp)
-skip_store_fp_caller_saved:
-#endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
+#if defined(CONFIG_FPU_SHARING)
+	/* determine if this is an Illegal Instruction exception */
+	csrr t0, mcause
+	li t1, 2		/* 2 = illegal instruction */
+	bne t0, t1, no_fp
+	/* determine if FPU access was disabled */
+	csrr t0, mstatus
+	li t1, MSTATUS_FS
+	and t0, t0, t1
+	bnez t0, no_fp
+	/* determine if we trapped on an FP instruction. */
+	csrr t2, mtval		/* get faulting instruction */
+	andi t0, t2, 0x7f	/* keep only the opcode bits */
+	xori t1, t0, 0b1010011	/* OP-FP */
+	beqz t1, is_fp
+	ori  t0, t0, 0b0100000
+	xori t1, t0, 0b0100111	/* LOAD-FP / STORE-FP */
+#if !defined(CONFIG_RISCV_ISA_EXT_C)
+	bnez t1, no_fp
+#else
+	beqz t1, is_fp
+	/* remaining non RVC (0b11) and RVC with 0b01 are not FP instructions */
+	andi t1, t0, 1
+	bnez t1, no_fp
+	/*
+	 * 001...........00 = C.FLD    RV32/64  (RV128 = C.LQ)
+	 * 001...........10 = C.FLDSP  RV32/64  (RV128 = C.LQSP)
+	 * 011...........00 = C.FLW    RV32     (RV64/128 = C.LD)
+	 * 011...........10 = C.FLWSPP RV32     (RV64/128 = C.LDSP)
+	 * 101...........00 = C.FSD    RV32/64  (RV128 = C.SQ)
+	 * 101...........10 = C.FSDSP  RV32/64  (RV128 = C.SQSP)
+	 * 111...........00 = C.FSW    RV32     (RV64/128 = C.SD)
+	 * 111...........10 = C.FSWSP  RV32     (RV64/128 = C.SDSP)
+	 *
+	 * so must be .01............. on RV64 and ..1............. on RV32.
+	 */
+	srli t0, t2, 8
+#if defined(CONFIG_64BIT)
+	andi t1, t0, 0b01100000
+	xori t1, t1, 0b00100000
+	bnez t1, no_fp
+#else
+	andi t1, t0, 0b00100000
+	beqz t1, no_fp
+#endif
+#endif /* CONFIG_RISCV_ISA_EXT_C */
+
+is_fp:	/* Process the FP trap and quickly return from exception */
+	la ra, fp_trap_exit
+	mv a0, sp
+	tail z_riscv_fpu_trap
+
+no_fp:	/* increment _current->arch.exception_depth */
+	lr t0, ___cpu_t_current_OFFSET(s0)
+	lb t1, _thread_offset_to_exception_depth(t0)
+	add t1, t1, 1
+	sb t1, _thread_offset_to_exception_depth(t0)
+
+	/* configure the FPU for exception mode */
+	call z_riscv_fpu_enter_exc
+#endif
 
 #ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE
 	/* Handle context saving at SOC level. */
@@ -528,10 +558,8 @@ reschedule:
 
 z_riscv_thread_start:
 might_have_rescheduled:
-#ifdef CONFIG_SMP
-	/* reload s0 with &_current_cpu as it might have changed */
+	/* reload s0 with &_current_cpu as it might have changed or be unset */
 	get_current_cpu s0
-#endif
 
 no_reschedule:
 
@@ -541,32 +569,24 @@ no_reschedule:
 	jal ra, __soc_restore_context
 #endif /* CONFIG_RISCV_SOC_CONTEXT_SAVE */
 
-	/* Restore MEPC register */
+#if defined(CONFIG_FPU_SHARING)
+	/* FPU handling upon exception mode exit */
+	mv a0, sp
+	call z_riscv_fpu_exit_exc
+
+	/* decrement _current->arch.exception_depth */
+	lr t0, ___cpu_t_current_OFFSET(s0)
+	lb t1, _thread_offset_to_exception_depth(t0)
+	add t1, t1, -1
+	sb t1, _thread_offset_to_exception_depth(t0)
+fp_trap_exit:
+#endif
+
+	/* Restore MEPC and MSTATUS registers */
 	lr t0, __z_arch_esf_t_mepc_OFFSET(sp)
-	csrw mepc, t0
-
-	/* Restore MSTATUS register */
 	lr t2, __z_arch_esf_t_mstatus_OFFSET(sp)
-	csrrw t0, mstatus, t2
-
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-	/*
-	 * Determine if we need to restore FP regs based on the previous
-	 * (before the csr above) mstatus value available in t0.
-	 */
-	li t1, MSTATUS_FS_INIT
-	and t0, t0, t1
-	beqz t0, no_fp
-
-	/* make sure FP is enabled in the restored mstatus */
-	csrs mstatus, t1
-	DO_FP_CALLER_SAVED(flr, sp)
-	j 1f
-
-no_fp:	/* make sure this is reflected in the restored mstatus */
-	csrc mstatus, t1
-1:
-#endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
+	csrw mepc, t0
+	csrw mstatus, t2
 
 #ifdef CONFIG_USERSPACE
 	/*

--- a/arch/riscv/core/offsets/offsets.c
+++ b/arch/riscv/core/offsets/offsets.c
@@ -43,21 +43,48 @@ GEN_OFFSET_SYM(_callee_saved_t, s10);
 GEN_OFFSET_SYM(_callee_saved_t, s11);
 #endif /* !CONFIG_RISCV_ISA_RV32E */
 
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-GEN_OFFSET_SYM(_callee_saved_t, fcsr);
-GEN_OFFSET_SYM(_callee_saved_t, fs0);
-GEN_OFFSET_SYM(_callee_saved_t, fs1);
-GEN_OFFSET_SYM(_callee_saved_t, fs2);
-GEN_OFFSET_SYM(_callee_saved_t, fs3);
-GEN_OFFSET_SYM(_callee_saved_t, fs4);
-GEN_OFFSET_SYM(_callee_saved_t, fs5);
-GEN_OFFSET_SYM(_callee_saved_t, fs6);
-GEN_OFFSET_SYM(_callee_saved_t, fs7);
-GEN_OFFSET_SYM(_callee_saved_t, fs8);
-GEN_OFFSET_SYM(_callee_saved_t, fs9);
-GEN_OFFSET_SYM(_callee_saved_t, fs10);
-GEN_OFFSET_SYM(_callee_saved_t, fs11);
-#endif
+#if defined(CONFIG_FPU_SHARING)
+
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fa0);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fa1);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fa2);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fa3);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fa4);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fa5);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fa6);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fa7);
+
+GEN_OFFSET_SYM(z_riscv_fp_context_t, ft0);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, ft1);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, ft2);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, ft3);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, ft4);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, ft5);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, ft6);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, ft7);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, ft8);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, ft9);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, ft10);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, ft11);
+
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fs0);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fs1);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fs2);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fs3);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fs4);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fs5);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fs6);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fs7);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fs8);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fs9);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fs10);
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fs11);
+
+GEN_OFFSET_SYM(z_riscv_fp_context_t, fcsr);
+
+GEN_OFFSET_SYM(_thread_arch_t, exception_depth);
+
+#endif /* CONFIG_FPU_SHARING */
 
 /* esf member offsets */
 GEN_OFFSET_SYM(z_arch_esf_t, ra);
@@ -87,29 +114,6 @@ GEN_OFFSET_SYM(z_arch_esf_t, s0);
 
 #ifdef CONFIG_USERSPACE
 GEN_OFFSET_SYM(z_arch_esf_t, sp);
-#endif
-
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-GEN_OFFSET_SYM(z_arch_esf_t, ft0);
-GEN_OFFSET_SYM(z_arch_esf_t, ft1);
-GEN_OFFSET_SYM(z_arch_esf_t, ft2);
-GEN_OFFSET_SYM(z_arch_esf_t, ft3);
-GEN_OFFSET_SYM(z_arch_esf_t, ft4);
-GEN_OFFSET_SYM(z_arch_esf_t, ft5);
-GEN_OFFSET_SYM(z_arch_esf_t, ft6);
-GEN_OFFSET_SYM(z_arch_esf_t, ft7);
-GEN_OFFSET_SYM(z_arch_esf_t, ft8);
-GEN_OFFSET_SYM(z_arch_esf_t, ft9);
-GEN_OFFSET_SYM(z_arch_esf_t, ft10);
-GEN_OFFSET_SYM(z_arch_esf_t, ft11);
-GEN_OFFSET_SYM(z_arch_esf_t, fa0);
-GEN_OFFSET_SYM(z_arch_esf_t, fa1);
-GEN_OFFSET_SYM(z_arch_esf_t, fa2);
-GEN_OFFSET_SYM(z_arch_esf_t, fa3);
-GEN_OFFSET_SYM(z_arch_esf_t, fa4);
-GEN_OFFSET_SYM(z_arch_esf_t, fa5);
-GEN_OFFSET_SYM(z_arch_esf_t, fa6);
-GEN_OFFSET_SYM(z_arch_esf_t, fa7);
 #endif
 
 #if defined(CONFIG_RISCV_SOC_CONTEXT_SAVE)

--- a/arch/riscv/core/switch.S
+++ b/arch/riscv/core/switch.S
@@ -29,41 +29,16 @@
 	RV_I(	op s10, _thread_offset_to_s10(reg)	);\
 	RV_I(	op s11, _thread_offset_to_s11(reg)	)
 
-#define DO_FP_CALLEE_SAVED(op, reg) \
-	op fs0, _thread_offset_to_fs0(reg)	;\
-	op fs1, _thread_offset_to_fs1(reg)	;\
-	op fs2, _thread_offset_to_fs2(reg)	;\
-	op fs3, _thread_offset_to_fs3(reg)	;\
-	op fs4, _thread_offset_to_fs4(reg)	;\
-	op fs5, _thread_offset_to_fs5(reg)	;\
-	op fs6, _thread_offset_to_fs6(reg)	;\
-	op fs7, _thread_offset_to_fs7(reg)	;\
-	op fs8, _thread_offset_to_fs8(reg)	;\
-	op fs9, _thread_offset_to_fs9(reg)	;\
-	op fs10, _thread_offset_to_fs10(reg)	;\
-	op fs11, _thread_offset_to_fs11(reg)
-
 GTEXT(z_riscv_switch)
 GTEXT(z_thread_mark_switched_in)
 GTEXT(z_riscv_configure_stack_guard)
+GTEXT(z_riscv_fpu_thread_context_switch)
 
 /* void z_riscv_switch(k_thread_t *switch_to, k_thread_t *switch_from) */
 SECTION_FUNC(TEXT, z_riscv_switch)
 
 	/* Save the old thread's callee-saved registers */
 	DO_CALLEE_SAVED(sr, a1)
-
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-	/* Assess whether floating-point registers need to be saved. */
-	lb t0, _thread_offset_to_user_options(a1)
-	andi t0, t0, K_FP_REGS
-	beqz t0, skip_store_fp_callee_saved
-
-	frcsr t0
-	sw t0, _thread_offset_to_fcsr(a1)
-	DO_FP_CALLEE_SAVED(fsr, a1)
-skip_store_fp_callee_saved:
-#endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
 	/* Save the old thread's stack pointer */
 	sr sp, _thread_offset_to_sp(a1)
@@ -79,11 +54,15 @@ skip_store_fp_callee_saved:
 	lr tp, _thread_offset_to_tls(a0)
 #endif
 
+#if defined(CONFIG_FPU_SHARING)
+	 /* Preserve a0 across following call. s0 is not yet restored. */
+	mv s0, a0
+	call z_riscv_fpu_thread_context_switch
+	mv a0, s0
+#endif
+
 #if defined(CONFIG_PMP_STACK_GUARD)
-	/*
-	 * Stack guard has priority over user space for PMP usage.
-	 * Preserve a0 across following call. s0 is not yet restored.
-	 */
+	/* Stack guard has priority over user space for PMP usage. */
 	mv s0, a0
 	call z_riscv_pmp_stackguard_enable
 	mv a0, s0
@@ -110,28 +89,6 @@ not_user_task:
 
 	/* Restore the new thread's callee-saved registers */
 	DO_CALLEE_SAVED(lr, a0)
-
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-	/* Determine if we need to restore floating-point registers. */
-	lb t0, _thread_offset_to_user_options(a0)
-	li t1, MSTATUS_FS_INIT
-	andi t0, t0, K_FP_REGS
-	beqz t0, no_fp
-
-	/* Enable floating point access */
-	csrs mstatus, t1
-
-	/* Restore FP regs */
-	lw t1, _thread_offset_to_fcsr(a0)
-	fscsr t1
-	DO_FP_CALLEE_SAVED(flr, a0)
-	j 1f
-
-no_fp:
-	/* Disable floating point access */
-	csrc mstatus, t1
-1:
-#endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
 	/* Return to arch_switch() or _irq_wrapper() */
 	ret

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -65,12 +65,9 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	 */
 	stack_init->mstatus = MSTATUS_DEF_RESTORE;
 
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-	/* Shared FP mode: enable FPU of threads with K_FP_REGS. */
-	if ((thread->base.user_options & K_FP_REGS) != 0) {
-		stack_init->mstatus |= MSTATUS_FS_INIT;
-	}
-	thread->callee_saved.fcsr = 0;
+#if defined(CONFIG_FPU_SHARING)
+	/* thread birth happens through the exception return path */
+	thread->arch.exception_depth = 1;
 #elif defined(CONFIG_FPU)
 	/* Unshared FP mode: enable FPU of each thread. */
 	stack_init->mstatus |= MSTATUS_FS_INIT;
@@ -117,72 +114,6 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	/* our switch handle is the thread pointer itself */
 	thread->switch_handle = thread;
 }
-
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-int arch_float_disable(struct k_thread *thread)
-{
-	unsigned int key;
-
-	if (thread != _current) {
-		return -EINVAL;
-	}
-
-	if (arch_is_in_isr()) {
-		return -EINVAL;
-	}
-
-	/* Ensure a preemptive context switch does not occur */
-	key = irq_lock();
-
-	/* Disable all floating point capabilities for the thread */
-	thread->base.user_options &= ~K_FP_REGS;
-
-	/* Clear the FS bits to disable the FPU. */
-	__asm__ volatile (
-		"mv t0, %0\n"
-		"csrrc x0, mstatus, t0\n"
-		:
-		: "r" (MSTATUS_FS_MASK)
-		);
-
-	irq_unlock(key);
-
-	return 0;
-}
-
-
-int arch_float_enable(struct k_thread *thread, unsigned int options)
-{
-	unsigned int key;
-
-	if (thread != _current) {
-		return -EINVAL;
-	}
-
-	if (arch_is_in_isr()) {
-		return -EINVAL;
-	}
-
-	/* Ensure a preemptive context switch does not occur */
-	key = irq_lock();
-
-	/* Enable all floating point capabilities for the thread. */
-	thread->base.user_options |= K_FP_REGS;
-
-	/* Set the FS bits to Initial and clear the fcsr to enable the FPU. */
-	__asm__ volatile (
-		"mv t0, %0\n"
-		"csrrs x0, mstatus, t0\n"
-		"fscsr x0, x0\n"
-		:
-		: "r" (MSTATUS_FS_INIT)
-		);
-
-	irq_unlock(key);
-
-	return 0;
-}
-#endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
 #ifdef CONFIG_USERSPACE
 

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -80,6 +80,11 @@ extern FUNC_NORETURN void z_riscv_userspace_enter(k_thread_entry_t user_entry,
 int z_irq_do_offload(void);
 #endif
 
+#ifdef CONFIG_FPU_SHARING
+void z_riscv_flush_local_fpu(void);
+void z_riscv_flush_fpu_ipi(unsigned int cpu);
+#endif
+
 #endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/arch/riscv/include/offsets_short_arch.h
+++ b/arch/riscv/include/offsets_short_arch.h
@@ -57,48 +57,12 @@
 #define _thread_offset_to_swap_return_value \
 	(___thread_t_arch_OFFSET + ___thread_arch_t_swap_return_value_OFFSET)
 
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
+#if defined(CONFIG_FPU_SHARING)
 
-#define _thread_offset_to_fcsr \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_fcsr_OFFSET)
+#define _thread_offset_to_exception_depth \
+	(___thread_t_arch_OFFSET + ___thread_arch_t_exception_depth_OFFSET)
 
-#define _thread_offset_to_fs0 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_fs0_OFFSET)
-
-#define _thread_offset_to_fs1 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_fs1_OFFSET)
-
-#define _thread_offset_to_fs2 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_fs2_OFFSET)
-
-#define _thread_offset_to_fs3 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_fs3_OFFSET)
-
-#define _thread_offset_to_fs4 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_fs4_OFFSET)
-
-#define _thread_offset_to_fs5 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_fs5_OFFSET)
-
-#define _thread_offset_to_fs6 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_fs6_OFFSET)
-
-#define _thread_offset_to_fs7 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_fs7_OFFSET)
-
-#define _thread_offset_to_fs8 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_fs8_OFFSET)
-
-#define _thread_offset_to_fs9 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_fs9_OFFSET)
-
-#define _thread_offset_to_fs10 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_fs10_OFFSET)
-
-#define _thread_offset_to_fs11 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_fs11_OFFSET)
-
-#endif /* defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING) */
+#endif
 
 #ifdef CONFIG_USERSPACE
 

--- a/include/zephyr/arch/riscv/arch.h
+++ b/include/zephyr/arch/riscv/arch.h
@@ -149,9 +149,11 @@
 #define MSTATUS_IEN     (1UL << 3)
 #define MSTATUS_MPP_M   (3UL << 11)
 #define MSTATUS_MPIE_EN (1UL << 7)
-#define MSTATUS_FS_INIT (1UL << 13)
-#define MSTATUS_FS_MASK ((1UL << 13) | (1UL << 14))
 
+#define MSTATUS_FS_OFF   (0UL << 13)
+#define MSTATUS_FS_INIT  (1UL << 13)
+#define MSTATUS_FS_CLEAN (2UL << 13)
+#define MSTATUS_FS_DIRTY (3UL << 13)
 
 /* This comes from openisa_rv32m1, but doesn't seem to hurt on other
  * platforms:

--- a/include/zephyr/arch/riscv/exp.h
+++ b/include/zephyr/arch/riscv/exp.h
@@ -45,14 +45,6 @@ struct soc_esf {
 };
 #endif
 
-#if !defined(RV_FP_TYPE) && defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-#ifdef CONFIG_CPU_HAS_FPU_DOUBLE_PRECISION
-#define RV_FP_TYPE uint64_t
-#else
-#define RV_FP_TYPE uint32_t
-#endif
-#endif
-
 #if defined(CONFIG_RISCV_SOC_HAS_ISR_STACKING)
 	SOC_ISR_STACKING_ESF_DECLARE;
 #else
@@ -87,29 +79,6 @@ struct __esf {
 
 #ifdef CONFIG_USERSPACE
 	unsigned long sp;		/* preserved (user or kernel) stack pointer */
-#endif
-
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-	RV_FP_TYPE ft0;		/* Caller-saved temporary floating register */
-	RV_FP_TYPE ft1;		/* Caller-saved temporary floating register */
-	RV_FP_TYPE ft2;		/* Caller-saved temporary floating register */
-	RV_FP_TYPE ft3;		/* Caller-saved temporary floating register */
-	RV_FP_TYPE ft4;		/* Caller-saved temporary floating register */
-	RV_FP_TYPE ft5;		/* Caller-saved temporary floating register */
-	RV_FP_TYPE ft6;		/* Caller-saved temporary floating register */
-	RV_FP_TYPE ft7;		/* Caller-saved temporary floating register */
-	RV_FP_TYPE ft8;		/* Caller-saved temporary floating register */
-	RV_FP_TYPE ft9;		/* Caller-saved temporary floating register */
-	RV_FP_TYPE ft10;	/* Caller-saved temporary floating register */
-	RV_FP_TYPE ft11;	/* Caller-saved temporary floating register */
-	RV_FP_TYPE fa0;		/* function argument/return value */
-	RV_FP_TYPE fa1;		/* function argument/return value */
-	RV_FP_TYPE fa2;		/* function argument */
-	RV_FP_TYPE fa3;		/* function argument */
-	RV_FP_TYPE fa4;		/* function argument */
-	RV_FP_TYPE fa5;		/* function argument */
-	RV_FP_TYPE fa6;		/* function argument */
-	RV_FP_TYPE fa7;		/* function argument */
 #endif
 
 #ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE

--- a/include/zephyr/arch/riscv/structs.h
+++ b/include/zephyr/arch/riscv/structs.h
@@ -18,6 +18,10 @@ struct _cpu_arch {
 	unsigned long hartid;
 	bool online;
 #endif
+#ifdef CONFIG_FPU_SHARING
+	atomic_ptr_val_t fpu_owner;
+	uint32_t fpu_state;
+#endif
 };
 
 #endif /* ZEPHYR_INCLUDE_RISCV_STRUCTS_H_ */

--- a/include/zephyr/arch/riscv/thread.h
+++ b/include/zephyr/arch/riscv/thread.h
@@ -68,6 +68,7 @@ typedef struct z_riscv_fp_context z_riscv_fp_context_t;
 struct _thread_arch {
 #ifdef CONFIG_FPU_SHARING
 	struct z_riscv_fp_context saved_fp_context;
+	bool fpu_recently_used;
 	uint8_t exception_depth;
 #endif
 #ifdef CONFIG_USERSPACE

--- a/include/zephyr/arch/riscv/thread.h
+++ b/include/zephyr/arch/riscv/thread.h
@@ -22,14 +22,6 @@
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
 
-#if !defined(RV_FP_TYPE) && defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-#ifdef CONFIG_CPU_HAS_FPU_DOUBLE_PRECISION
-#define RV_FP_TYPE uint64_t
-#else
-#define RV_FP_TYPE uint32_t
-#endif
-#endif
-
 /*
  * The following structure defines the list of registers that need to be
  * saved/restored when a context switch occurs.
@@ -52,28 +44,32 @@ struct _callee_saved {
 	unsigned long s10;	/* saved register */
 	unsigned long s11;	/* saved register */
 #endif
-
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-	uint32_t fcsr;		/* Control and status register */
-	RV_FP_TYPE fs0;		/* saved floating-point register */
-	RV_FP_TYPE fs1;		/* saved floating-point register */
-	RV_FP_TYPE fs2;		/* saved floating-point register */
-	RV_FP_TYPE fs3;		/* saved floating-point register */
-	RV_FP_TYPE fs4;		/* saved floating-point register */
-	RV_FP_TYPE fs5;		/* saved floating-point register */
-	RV_FP_TYPE fs6;		/* saved floating-point register */
-	RV_FP_TYPE fs7;		/* saved floating-point register */
-	RV_FP_TYPE fs8;		/* saved floating-point register */
-	RV_FP_TYPE fs9;		/* saved floating-point register */
-	RV_FP_TYPE fs10;	/* saved floating-point register */
-	RV_FP_TYPE fs11;	/* saved floating-point register */
-#endif
 };
 typedef struct _callee_saved _callee_saved_t;
+
+#if !defined(RV_FP_TYPE)
+#ifdef CONFIG_CPU_HAS_FPU_DOUBLE_PRECISION
+#define RV_FP_TYPE uint64_t
+#else
+#define RV_FP_TYPE uint32_t
+#endif
+#endif
+
+struct z_riscv_fp_context {
+	RV_FP_TYPE fa0, fa1, fa2, fa3, fa4, fa5, fa6, fa7;
+	RV_FP_TYPE ft0, ft1, ft2, ft3, ft4, ft5, ft6, ft7, ft8, ft9, ft10, ft11;
+	RV_FP_TYPE fs0, fs1, fs2, fs3, fs4, fs5, fs6, fs7, fs8, fs9, fs10, fs11;
+	uint32_t fcsr;
+};
+typedef struct z_riscv_fp_context z_riscv_fp_context_t;
 
 #define PMP_M_MODE_SLOTS 8	/* 8 is plenty enough for m-mode */
 
 struct _thread_arch {
+#ifdef CONFIG_FPU_SHARING
+	struct z_riscv_fp_context saved_fp_context;
+	uint8_t exception_depth;
+#endif
 #ifdef CONFIG_USERSPACE
 	unsigned long priv_stack_start;
 	unsigned long u_mode_pmpaddr_regs[CONFIG_PMP_SLOTS];

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -107,15 +107,14 @@ static void cpu_hold(void *arg1, void *arg2, void *arg3)
 
 	k_sem_give(&cpuhold_sem);
 
-#if defined(CONFIG_ARM64) && defined(CONFIG_FPU_SHARING)
+#if (defined(CONFIG_ARM64) || defined(CONFIG_RISCV)) && defined(CONFIG_FPU_SHARING)
 	/*
 	 * We'll be spinning with IRQs disabled. The flush-your-FPU request
 	 * IPI will never be serviced during that time. Therefore we flush
 	 * the FPU preemptively here to prevent any other CPU waiting after
 	 * this CPU forever and deadlock the system.
 	 */
-	extern void z_arm64_flush_local_fpu(void);
-	z_arm64_flush_local_fpu();
+	k_float_disable(_current_cpu->arch.fpu_owner);
 #endif
 
 	while (cpuhold_active) {

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -132,15 +132,14 @@ static void cpu_hold(void *arg1, void *arg2, void *arg3)
 
 	k_sem_give(&cpuhold_sem);
 
-#if defined(CONFIG_ARM64) && defined(CONFIG_FPU_SHARING)
+#if (defined(CONFIG_ARM64) || defined(CONFIG_RISCV)) && defined(CONFIG_FPU_SHARING)
 	/*
 	 * We'll be spinning with IRQs disabled. The flush-your-FPU request
 	 * IPI will never be serviced during that time. Therefore we flush
 	 * the FPU preemptively here to prevent any other CPU waiting after
 	 * this CPU forever and deadlock the system.
 	 */
-	extern void z_arm64_flush_local_fpu(void);
-	z_arm64_flush_local_fpu();
+	k_float_disable(_current_cpu->arch.fpu_owner);
 #endif
 
 	while (cpuhold_active) {

--- a/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
+++ b/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
@@ -14,7 +14,7 @@
  */
 #define PRIORITY  K_PRIO_COOP(0)
 
-#if defined(CONFIG_ARM) || defined(CONFIG_RISCV) || defined(CONFIG_SPARC)
+#if defined(CONFIG_ARM) || defined(CONFIG_SPARC)
 #define K_FP_OPTS K_FP_REGS
 #elif defined(CONFIG_X86)
 #define K_FP_OPTS (K_FP_REGS | K_SSE_REGS)
@@ -32,8 +32,7 @@ static void usr_fp_thread_entry_1(void)
 	k_yield();
 }
 
-#if defined(CONFIG_ARM) || defined(CONFIG_RISCV) || \
-	(defined(CONFIG_X86) && defined(CONFIG_LAZY_FPU_SHARING))
+#if defined(CONFIG_ARM) || (defined(CONFIG_X86) && defined(CONFIG_LAZY_FPU_SHARING))
 #define K_FLOAT_DISABLE_SYSCALL_RETVAL 0
 #else
 #define K_FLOAT_DISABLE_SYSCALL_RETVAL -ENOTSUP
@@ -78,7 +77,7 @@ ZTEST(k_float_disable, test_k_float_disable_common)
 		"usr_fp_thread FP options not set (0x%0x)",
 		usr_fp_thread.base.user_options);
 
-#if defined(CONFIG_ARM) || defined(CONFIG_RISCV)
+#if defined(CONFIG_ARM)
 	/* Verify FP mode can only be disabled for current thread */
 	zassert_true((k_float_disable(&usr_fp_thread) == -EINVAL),
 		"k_float_disable() successful on thread other than current!");
@@ -130,8 +129,7 @@ ZTEST(k_float_disable, test_k_float_disable_syscall)
 	/* Yield will swap-in usr_fp_thread */
 	k_yield();
 
-#if defined(CONFIG_ARM) || defined(CONFIG_RISCV) || \
-	(defined(CONFIG_X86) && defined(CONFIG_LAZY_FPU_SHARING))
+#if defined(CONFIG_ARM) || (defined(CONFIG_X86) && defined(CONFIG_LAZY_FPU_SHARING))
 
 	/* Verify K_FP_OPTS are now cleared by the user thread itself */
 	zassert_true(

--- a/tests/kernel/fpu_sharing/float_disable/testcase.yaml
+++ b/tests/kernel/fpu_sharing/float_disable/testcase.yaml
@@ -2,7 +2,7 @@ common:
   tags: fpu kernel userspace
 tests:
   kernel.fpu_sharing.float_disable:
-    arch_allow: arm riscv32 riscv64 sparc
+    arch_allow: arm sparc
     filter: CONFIG_ARMV7_M_ARMV8_M_FP or CONFIG_ARMV7_R_FP or CONFIG_CPU_HAS_FPU
     extra_configs:
       - arch:arm:CONFIG_DYNAMIC_INTERRUPTS=y


### PR DESCRIPTION
Instead of saving/restoring FPU content on every exception and task
switch, this replaces FPU sharing support with a "lazy" (on-demand)
context switching algorithm similar to the one used on ARM64.

Every thread starts with FPU access disabled. On the first access the
FPU trap is invoked to:

- flush the FPU content to the previous thread's memory storage;

- restore the current thread's FPU content from memory.

When a thread loads its data in the FPU, it becomes the FPU owner.

FPU content is preserved across task switching, however FPU access is
either allowed if the new thread is the FPU owner, or denied otherwise.
A thread may claim FPU ownership only through the FPU trap. This way,
threads that don't use the FPU won't force an FPU context switch.
If only one running thread uses the FPU, there will be no FPU context
switching to do at all.

