### PR TITLE
logging/console: uart: runtime power management

### DIFF
--- a/subsys/logging/backends/log_backend_uart.c
+++ b/subsys/logging/backends/log_backend_uart.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 LOG_MODULE_REGISTER(log_uart);
 
@@ -153,6 +154,26 @@ static void log_backend_uart_init(struct log_backend const *const backend)
 
 static void panic(struct log_backend const *const backend)
 {
+	/* Ensure that the UART device is in active mode */
+#if defined(CONFIG_PM_DEVICE_RUNTIME)
+	if (pm_device_runtime_is_enabled(uart_dev)) {
+		if (k_is_in_isr()) {
+			/* pm_device_runtime_get cannot be used from ISRs */
+			pm_device_action_run(uart_dev, PM_DEVICE_ACTION_RESUME);
+		} else {
+			pm_device_runtime_get(uart_dev);
+		}
+	}
+#elif defined(CONFIG_PM_DEVICE)
+	enum pm_device_state pm_state;
+	int rc;
+
+	rc = pm_device_state_get(uart_dev, &pm_state);
+	if ((rc == 0) && (pm_state == PM_DEVICE_STATE_SUSPENDED)) {
+		pm_device_action_run(uart_dev, PM_DEVICE_ACTION_RESUME);
+	}
+#endif /* CONFIG_PM_DEVICE */
+
 	in_panic = true;
 	log_backend_std_panic(&log_output_uart);
 }


### PR DESCRIPTION
Handle runtime power management for the UART backends of the logging and console APIs.
This lets the logging and console backends continue to operate normally after power management is enabled on the UART backend.