### PR TITLE
z_thread_mark_switched_*: use z_current_get() instead of k_current_get()

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1011,7 +1011,7 @@ void z_thread_mark_switched_in(void)
 #ifdef CONFIG_THREAD_RUNTIME_STATS
 	struct k_thread *thread;
 
-	thread = k_current_get();
+	thread = z_current_get();
 #ifdef CONFIG_THREAD_RUNTIME_STATS_USE_TIMING_FUNCTIONS
 	thread->rt_stats.last_switched_in = timing_counter_get();
 #else
@@ -1033,7 +1033,7 @@ void z_thread_mark_switched_out(void)
 	uint64_t diff;
 	struct k_thread *thread;
 
-	thread = k_current_get();
+	thread = z_current_get();
 
 	if (unlikely(thread->rt_stats.last_switched_in == 0)) {
 		/* Has not run before */


### PR DESCRIPTION
`k_current_get()` may rely on TLS which might not yet be initialized
when those tracing functions are called, resulting in a crash.

This is different from the main branch as in that case the implementation
was completely revamped and neither `k_current_get()` nor `z_current_get()`
are used anymore. This is a much simpler fix than a backport of that
code, similar to the implication in commit commit f07df42d49c0 ("kernel:
make k_current_get() work without syscall").

Fixes #53983
