### PR TITLE
build: userspace: No merge globals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,6 +388,10 @@ include(cmake/extra_flags.cmake)
 
 zephyr_cc_option(-fno-asynchronous-unwind-tables)
 
+if(CONFIG_USERSPACE)
+  zephyr_compile_options($<TARGET_PROPERTY:compiler,no_global_merge>)
+endif()
+
 if(CONFIG_THREAD_LOCAL_STORAGE)
 # Only support local exec TLS model at this point.
 zephyr_cc_option(-ftls-model=local-exec)

--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -185,6 +185,8 @@ set_property(TARGET compiler-cpp PROPERTY no_threadsafe_statics "-fno-threadsafe
 # but it has PIE disabled by default - so no extra flags are required here.
 set_compiler_property(PROPERTY no_position_independent "")
 
+set_compiler_property(PROPERTY no_global_merge "")
+
 #################################
 # This section covers asm flags #
 #################################

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -108,3 +108,5 @@ set_compiler_property(PROPERTY warning_error_coding_guideline
                       -Wconversion
                       -Woverride-init
 )
+
+set_compiler_property(PROPERTY no_global_merge "-mno-global-merge")

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -115,3 +115,8 @@ set_compiler_property(PROPERTY warning_no_pointer_arithmetic)
 
 # Compiler flags for disabling position independent code / executable
 set_compiler_property(PROPERTY no_position_independent)
+
+# Compiler flag to avoid combine more than one global variable into a single aggregate.
+# gen_kobject_list.py is does not understand it and end up identifying objects as if
+# they had the same address.
+set_compiler_property(PROPERTY no_global_merge)

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -201,3 +201,5 @@ set_compiler_property(PROPERTY no_position_independent
                       -fno-pic
                       -fno-pie
 )
+
+set_compiler_property(PROPERTY no_global_merge "")


### PR DESCRIPTION
Add a compiler option to not merge globals. gen_kobject_list.py is not capable of distinguish addresses of merged objects. The script itself does not look wrong. The dward specification says that the attribute DW_AT_location with opcode DW_OP_addr encodes a machine address and whose size is the size of an address on the target machine but for merged objects the address is longer, not clear why.

Disable global merge when userspace is enabled to avoid this problem.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>