### PR TITLE
[DNM] tests: samples: watchdog: fix compilation issue with s32z270dc2_r52

### DIFF
--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
@@ -12,6 +12,10 @@
 	model = "NXP X-S32Z270-DC (DC2) on RTU0 Cortex-R52 cores";
 	compatible = "nxp,s32z270";
 
+	aliases {
+		/* watchdog0 = &swt0; */
+	};
+
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
@@ -12,6 +12,10 @@
 	model = "NXP X-S32Z270-DC (DC2) on RTU1 Cortex-R52 cores";
 	compatible = "nxp,s32z270";
 
+	aliases {
+		/* watchdog0 = &swt0; */
+	};
+
 	chosen {
 		zephyr,sram = &sram1;
 		zephyr,console = &uart0;

--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -14,6 +14,8 @@
 
 #define WDT_FEED_TRIES 5
 
+/* twister, please re-test this! */
+
 /*
  * To use this sample the devicetree's /aliases must have a 'watchdog0' property.
  */


### PR DESCRIPTION
The board was missing the `watchdog0` alias required for this sample compilation test.

Probably introduced by e63d1389a9 .

TODO: will uncomment the fix later, for now we'll see the tests fail using the CI to demonstrate the issue (also see #49223).