### PR TITLE
nvs: use CRC8 if cache size is 256

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -25,7 +25,7 @@ static inline size_t nvs_lookup_cache_pos(uint16_t id)
 {
 	size_t pos;
 
-#if CONFIG_NVS_LOOKUP_CACHE_SIZE <= UINT8_MAX
+#if CONFIG_NVS_LOOKUP_CACHE_SIZE <= (UINT8_MAX + 1)
 	/*
 	 * CRC8-CCITT is used for ATE checksums and it also acts well as a hash
 	 * function, so it can be a good choice from the code size perspective.


### PR DESCRIPTION
When cache size is 256, we can use CRC8

Signed-off-by: Julien D'Ascenzio <julien.dascenzio@paratronic.fr>