### PR TITLE
soc: nordic_nrf: Kconfig: Add missing NFCT_PINS_AS_GPIOS dependency

### DIFF
--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -48,7 +48,8 @@ config NRF_ACL_FLASH_REGION_SIZE
 
 config NFCT_PINS_AS_GPIOS
 	bool "NFCT pins as GPIOs"
-	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_NFCT))
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_NFCT)) && \
+		   !TRUSTED_EXECUTION_NONSECURE
 	help
 	  Two pins are usually reserved for NFC in SoCs that implement the
 	  NFCT peripheral. This option switches them to normal GPIO mode.
@@ -56,6 +57,9 @@ config NFCT_PINS_AS_GPIOS
 	  system startup. Disabling this option will not switch back these
 	  pins to NFCT mode. Doing this requires UICR erase prior to
 	  flashing device using the image which has this option disabled.
+
+	  This option involves writing to UICR, hence it is not available for
+	  non-secure code.
 
 	  NFC pins in nRF52 series: P0.09 and P0.10
 	  NFC pins in nRF5340: P0.02 and P0.03


### PR DESCRIPTION
This option involves writing to UICR, so it cannot be used in non-secure images. Add a corresponding dependency.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>