### PR TITLE
usb: device_next: Do not leak memory on set address

### DIFF
--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -811,6 +811,8 @@ int usbd_handle_ctrl_xfer(struct usbd_contex *const uds_ctx,
 	}
 
 	if (bi->status && bi->ep == USB_CONTROL_EP_IN) {
+		net_buf_unref(buf);
+
 		if (ch9_get_ctrl_type(uds_ctx) == CTRL_AWAIT_STATUS_STAGE) {
 			LOG_INF("s-(out)-status finished");
 			if (unlikely(uds_ctx->ch9_data.new_address)) {
@@ -819,8 +821,6 @@ int usbd_handle_ctrl_xfer(struct usbd_contex *const uds_ctx,
 		} else {
 			LOG_WRN("Awaited s-(out)-status not finished");
 		}
-
-		net_buf_unref(buf);
 
 		return ret;
 	}


### PR DESCRIPTION
USB stack did leak memory on every SET ADDRESS request. UDC control allocator could cope with up to 13 leaked allocations. Therefore, issuing bus reset 13 times in a row (in addition to automatic reset after connecting the USB cable) was enough to exhaust memory and thus drive USB stack inoperable.

Signed-off-by: Tomasz Moń <tomasz.mon@nordicsemi.no>