### PR TITLE
mgmt: mcumgr: transport: smp_bt: Fix wrongly enabling Bluetooth

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -60,15 +60,10 @@ Changes in this release
 
 * MCUmgr Bluetooth and UDP transports no longer need to be registered by the
   application code, these will now automatically be registered at bootup (this
-  feature can be disabled or tweaked by adjusting:
-  :kconfig:option:`CONFIG_MCUMGR_TRANSPORT_BT_AUTOMATIC_INIT`,
-  :kconfig:option:`CONFIG_MCUMGR_TRANSPORT_BT_AUTOMATIC_INIT_WAIT`, and
-  :kconfig:option:`CONFIG_MCUMGR_TRANSPORT_UDP_AUTOMATIC_INIT`. If applications
-  register transports then those registrations should be removed to prevent
-  registering the same transport multiple times. If the Bluetooth stack needs
-  to be setup/initialised by another module or the application itself, then
-  :kconfig:option:`CONFIG_MCUMGR_TRANSPORT_BT_AUTOMATIC_INIT` should be
-  disabled and the application should call :c:func:`smp_bt_start` at startup.
+  feature can be disabled for the UDP transport by setting
+  :kconfig:option:`CONFIG_MCUMGR_TRANSPORT_UDP_AUTOMATIC_INIT`). If
+  applications register transports then those registrations should be removed
+  to prevent registering the same transport multiple times.
 
 * MCUmgr transport Kconfigs have changed from ``select`` to ``depends on``
   which means that for applications using the Bluetooth transport,

--- a/include/zephyr/mgmt/mcumgr/transport/smp_bt.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp_bt.h
@@ -34,14 +34,6 @@ int smp_bt_register(void);
 int smp_bt_unregister(void);
 
 /**
- * @brief	Sets up the Bluetooth SMP (MCUmgr) transport. This should be called if the Kconfig
- *		option ``CONFIG_MCUMGR_TRANSPORT_BT_AUTOMATIC_INIT`` is not enabled, this will
- *		register the transport and add it to the Bluetooth registered services so that
- *		clients can access registered MCUmgr commands.
- */
-void smp_bt_start(void);
-
-/**
  * @brief	Transmits an SMP command/response over the specified Bluetooth connection as a
  *		notification.
  *

--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c
@@ -58,9 +58,23 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected,
 };
 
+static void bt_ready(int err)
+{
+	if (err != 0) {
+		LOG_ERR("Bluetooth failed to initialise: %d", err);
+	} else {
+		k_work_submit(&advertise_work);
+	}
+}
+
 void start_smp_bluetooth_adverts(void)
 {
-	k_work_init(&advertise_work, advertise);
+	int rc;
 
-	k_work_submit(&advertise_work);
+	k_work_init(&advertise_work, advertise);
+	rc = bt_enable(bt_ready);
+
+	if (rc != 0) {
+		LOG_ERR("Bluetooth enable failed: %d", rc);
+	}
 }

--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
@@ -66,6 +66,7 @@ void main(void)
 		LOG_ERR("Error mounting littlefs [%d]", rc);
 	}
 #endif
+
 #ifdef CONFIG_MCUMGR_TRANSPORT_BT
 	start_smp_bluetooth_adverts();
 #endif

--- a/subsys/mgmt/mcumgr/transport/Kconfig.bluetooth
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.bluetooth
@@ -93,24 +93,4 @@ config MCUMGR_TRANSPORT_BT_CONN_PARAM_CONTROL_RETRY_TIME
 
 endif # MCUMGR_TRASNPORT_BT_CONN_PARAM_CONTROL
 
-config MCUMGR_TRANSPORT_BT_AUTOMATIC_INIT
-	bool "Bluetooth SMP stack enable autostart/setup"
-	default y
-	help
-	  If this option is enabled, then the Bluetooth stack will be enabled
-	  when the Bluetooth SMP (MCUmgr) transport initialises. If another
-	  system or the application does this, then this option should be
-	  disabled. Note that Bluetooth will need to be enabled prior to the
-	  Bluetooth SMP (MCUmgr) transport being initialised (by calling
-	  ``smp_bt_start()``) if this option is disabled.
-
-config MCUMGR_TRANSPORT_BT_AUTOMATIC_INIT_WAIT
-	bool "Bluetooth SMP wait for autostart/setup completion"
-	default y
-	depends on MCUMGR_TRANSPORT_BT_AUTOMATIC_INIT
-	help
-	  If this option is enabled, then the setup handler will wait for the
-	  Bluetooth stack to become ready from the ``bt_enable()`` call,
-	  otherwise will return instantly without waiting.
-
 endif # MCUMGR_TRANSPORT_BT


### PR DESCRIPTION
    Bluetooth does not need to be enabled to register services,
    therefore the newly introduced automatic bluetooth SMP transport
    registration system can be simplified by returning enabling of
    bluetooth back to the application.

Fixes #54002