### PR TITLE
fb: cfb: add API to set font kerning

### DIFF
--- a/include/zephyr/display/cfb.h
+++ b/include/zephyr/display/cfb.h
@@ -154,6 +154,16 @@ int cfb_get_display_parameter(const struct device *dev,
 int cfb_framebuffer_set_font(const struct device *dev, uint8_t idx);
 
 /**
+ * @brief Set font kerning (spacing between individual letters).
+ *
+ * @param dev Pointer to device structure for driver instance
+ * @param kerning Font kerning
+ *
+ * @return 0 on success, negative value otherwise
+ */
+int cfb_set_kerning(const struct device *dev, int8_t kerning);
+
+/**
  * @brief Get font size.
  *
  * @param dev Pointer to device structure for driver instance

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -316,6 +316,13 @@ int cfb_get_font_size(const struct device *dev, uint8_t idx, uint8_t *width,
 	return 0;
 }
 
+int cfb_set_kerning(const struct device *dev, int8_t kerning)
+{
+	char_fb.kerning = kerning;
+
+	return 0;
+}
+
 int cfb_get_numof_fonts(const struct device *dev)
 {
 	const struct char_framebuffer *fb = &char_fb;
@@ -343,7 +350,6 @@ int cfb_framebuffer_init(const struct device *dev)
 	fb->pixel_format = cfg.current_pixel_format;
 	fb->screen_info = cfg.screen_info;
 	fb->buf = NULL;
-	fb->font_idx = 0U;
 	fb->kerning = 0;
 	fb->inverted = false;
 

--- a/subsys/fb/cfb_shell.c
+++ b/subsys/fb/cfb_shell.c
@@ -235,6 +235,33 @@ static int cmd_set_font(const struct shell *shell, size_t argc, char *argv[])
 	return err;
 }
 
+static int cmd_set_kerning(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+	char *ep = NULL;
+	long kerning;
+
+	if (!dev) {
+		shell_error(sh, HELP_INIT);
+		return -ENODEV;
+	}
+
+	errno = 0;
+	kerning = strtol(argv[1], &ep, 10);
+	if (errno || ep == argv[1]) {
+		shell_error(sh, HELP_INIT);
+		return -EINVAL;
+	}
+
+	err = cfb_set_kerning(dev, kerning);
+	if (err) {
+		shell_error(sh, "Failed to set kerning err=%d", err);
+		return err;
+	}
+
+	return err;
+}
+
 static int cmd_invert(const struct shell *shell, size_t argc, char *argv[])
 {
 	int err;
@@ -453,6 +480,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(cfb_cmds,
 		  "<all, height, width, ppt, rows, cols>", NULL),
 	SHELL_CMD_ARG(get_fonts, NULL, HELP_NONE, cmd_get_fonts, 1, 0),
 	SHELL_CMD_ARG(set_font, NULL, "<idx>", cmd_set_font, 2, 0),
+	SHELL_CMD_ARG(set_kerning, NULL, "<kerning>", cmd_set_kerning, 2, 0),
 	SHELL_CMD_ARG(invert, NULL, HELP_NONE, cmd_invert, 1, 0),
 	SHELL_CMD_ARG(print, NULL, HELP_PRINT, cmd_print, 4, 0),
 	SHELL_CMD(scroll, &sub_cmd_scroll, "scroll a text in vertical or "


### PR DESCRIPTION
Font kerning was used but it was not possible to change it. Also, font_idx was set to zero twice in init.

Signed-off-by: Simon Frank <simon.frank@lohmega.com>