### PR TITLE
tests: mem_blocks: Remove suspicious break statement

### DIFF
--- a/tests/lib/mem_blocks/src/main.c
+++ b/tests/lib/mem_blocks/src/main.c
@@ -427,12 +427,9 @@ ZTEST(lib_mem_block, test_mem_block_alloc_free_contiguous)
 
 	/* all blocks should be taken */
 	for (i = 0; i < NUM_BLOCKS; i++) {
-		ret = sys_bitarray_test_bit(mem_block_01.bitmap,
-					    i, &val);
+		ret = sys_bitarray_test_bit(mem_block_01.bitmap, i, &val);
 		zassert_equal(val, 1,
 		     "sys_mem_blocks_alloc_contiguous failed, bit %i should be set", i);
-		break;
-
 	}
 
 	/* free first 3 memory blocks, use a pointer provided by previous case */


### PR DESCRIPTION
Fixes dead code warnings form static tools.