### PR TITLE
samples: drivers: led_pwm on stm32 boards

### DIFF
--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -63,9 +63,25 @@
 		};
 	};
 
+	pwmleds: pwmleds {
+		compatible = "pwm-leds";
+		status = "disabled";
+
+		green_pwm_1: green_led_1 {
+			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "green LD1";
+		};
+		green_pwm_2: green_led_2 {
+			pwms = <&pwm15 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "green LD2";
+		};
+	};
+
 	aliases {
 		led0 = &green_led_2;
 		led1 = &green_led_1;
+		pwm-led0 = &green_pwm_1;
+		pwm-led1 = &green_pwm_2;
 		sw0 = &user_button;
 		eswifi0 = &wifi0;
 		watchdog0 = &iwdg;
@@ -244,11 +260,23 @@
 };
 
 &timers2 {
+	st,prescaler = <10000>;
 	status = "okay";
 
 	pwm2: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa15>;
+		pinctrl-names = "default";
+	};
+};
+
+&timers15 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm15: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim15_ch1_pb14>; /* CN1 D10 */
 		pinctrl-names = "default";
 	};
 };

--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -32,6 +32,21 @@
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
 		};
 	};
+
+	pwmleds: pwmleds {
+		compatible = "pwm-leds";
+		status = "disabled";
+
+		pwm_led_1: green_led_1 {
+			pwms = <&pwm3 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "green led";
+		};
+
+		pwm_led_2: blue_led_1 {
+			pwms = <&pwm4 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "blue led";
+		};
+	};
 };
 
 &clk_hsi48 {
@@ -118,6 +133,28 @@
 	pinctrl-0 = <&adc4_in18_pb0>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&timers3 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm3: pwm {
+	pinctrl-0 = <&tim3_ch2_pc7>;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};
+
+&timers4 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm4: pwm {
+		pinctrl-0 = <&tim4_ch2_pb7>;
+		pinctrl-names = "default";
+		status = "okay";
+	};
 };
 
 &iwdg {

--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q.dts
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q.dts
@@ -25,6 +25,8 @@
 	aliases {
 		led0 = &blue_led_1;
 		sw0 = &user_button;
+		pwm-led0 = &pwm_led_1;
+		pwm-led1 = &pwm_led_2;
 		watchdog0 = &iwdg;
 	};
 };

--- a/samples/drivers/led_pwm/boards/disco_l475_iot1.overlay
+++ b/samples/drivers/led_pwm/boards/disco_l475_iot1.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/* do not define the leds on the pa5 and pb14 but pwmleds */
+	leds {
+		status = "disabled";
+	};
+};
+
+&pwmleds {
+	/* NOTE: enable here because it is disabled by default */
+	status = "okay";
+};
+
+&timers2 {
+	pwm2: pwm {
+		/* Change the pin used for PWM2 channel 1 */
+		/delete-property/ pinctrl-0;
+		pinctrl-0 = <&tim2_ch1_pa5>;
+	};
+};

--- a/samples/drivers/led_pwm/boards/nucleo_f091rc.overlay
+++ b/samples/drivers/led_pwm/boards/nucleo_f091rc.overlay
@@ -4,6 +4,13 @@
  * Copyright (c) 2022 STMicroelectronics
  */
 
+/ {
+	/* do not define the led on the pa5 but a pwmleds */
+	leds {
+		status = "disabled";
+	};
+};
+
 &pwmleds {
 	/* NOTE: enable here because it is disabled by default */
 	status = "okay";

--- a/samples/drivers/led_pwm/boards/nucleo_l073rz.overlay
+++ b/samples/drivers/led_pwm/boards/nucleo_l073rz.overlay
@@ -4,6 +4,13 @@
  * Copyright (c) 2022 STMicroelectronics
  */
 
+/ {
+	/* do not define the led on the pa5 but a pwmleds */
+	leds {
+		status = "disabled";
+	};
+};
+
 &pwmleds {
 	/* NOTE: enable here because it is disabled by default */
 	status = "okay";

--- a/samples/drivers/led_pwm/boards/nucleo_u575zi_q.overlay
+++ b/samples/drivers/led_pwm/boards/nucleo_u575zi_q.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/* do not define the leds on the pc7 and pb7 but pwmleds */
+	leds {
+		status = "disabled";
+	};
+};
+
+&pwmleds {
+	/* NOTE: enable here because it is disabled by default */
+	status = "okay";
+};


### PR DESCRIPTION
Configure with overlay files for the stm32 boards 
- disco_l475_iot1  : green led LD2  and green led LD2
- nucleo_u575zi_q : green led LD2  and blue led LD2
- nucleo_f091rc : green led LD2 
- nucleo_l073rz  : green led LD2 

to pass the samples/drivers/led_pwm

The led(s) used for pwm on the timer channel output should not already be defined as a leds node in the board dts
That's the reason for the overlay removes that `&leds` node (the alias is kept).

Fixes https://github.com/zephyrproject-rtos/zephyr/discussions/53925

Signed-off-by: Francois Ramu <francois.ramu@st.com>