### PR TITLE
bluetooth:host: added a mode param to PAST parameters

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -20,6 +20,10 @@ API Changes
 Changes in this release
 =======================
 
+* Bluetooth: Add extra options to bt_le_per_adv_sync_transfer_subscribe to
+  allow disabling sync reports, and enable sync report filtering. these two
+  options are mutually exclusive.
+
 * Bluetooth: :kconfig:option:`CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER`
   and :kconfig:option:`CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER` have been
   added to enable the PAST implementation rather than

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1569,6 +1569,22 @@ enum {
 
 	/** Only sync to packets with constant tone extension */
 	BT_LE_PER_ADV_SYNC_TRANSFER_OPT_SYNC_ONLY_CTE = BIT(3),
+
+	/**
+	 * @brief Sync to received PAST packets but don't generate sync reports
+	 *
+	 * This option must not be set at the same time as
+	 * @ref BT_LE_PER_ADV_SYNC_TRANSFER_OPT_FILTER_DUPLICATES.
+	 */
+	BT_LE_PER_ADV_SYNC_TRANSFER_OPT_REPORTING_INITIALLY_DISABLED = BIT(4),
+
+	/**
+	 * @brief Sync to received PAST packets and generate sync reports with duplicate filtering
+	 *
+	 * This option must not be set at the same time as
+	 * @ref BT_LE_PER_ADV_SYNC_TRANSFER_OPT_REPORTING_INITIALLY_DISABLED.
+	 */
+	BT_LE_PER_ADV_SYNC_TRANSFER_OPT_FILTER_DUPLICATES = BIT(5),
 };
 
 struct bt_le_per_adv_sync_transfer_param {

--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -1766,9 +1766,10 @@ struct bt_hci_rp_le_per_adv_set_info_transfer {
 	uint16_t conn_handle;
 } __packed;
 
-#define BT_HCI_LE_PAST_MODE_NO_SYNC              0x00
-#define BT_HCI_LE_PAST_MODE_NO_REPORTS           0x01
-#define BT_HCI_LE_PAST_MODE_SYNC                 0x02
+#define BT_HCI_LE_PAST_MODE_NO_SYNC                0x00
+#define BT_HCI_LE_PAST_MODE_NO_REPORTS             0x01
+#define BT_HCI_LE_PAST_MODE_SYNC                   0x02
+#define BT_HCI_LE_PAST_MODE_SYNC_FILTER_DUPLICATES 0x03
 
 #define BT_HCI_LE_PAST_CTE_TYPE_NO_AOA           BIT(0)
 #define BT_HCI_LE_PAST_CTE_TYPE_NO_AOD_1US       BIT(1)


### PR DESCRIPTION
We now have a parameter for the mode to specify if we sync or not, whether to generate sync reports, and whether those reports should be duplicate filtered. also adds to the validation for this mode param.

Signed-off-by: Raphael Treccani-Chinelli <raphael.treccani@nordicsemi.no>