### PR TITLE
tests: Add newlib filter for some testcases that dont have it

### DIFF
--- a/samples/modules/tflite-micro/hello_world/sample.yaml
+++ b/samples/modules/tflite-micro/hello_world/sample.yaml
@@ -18,6 +18,7 @@ tests:
     integration_platforms:
       - qemu_x86
     tags: tensorflow
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
   sample.tensorflow.helloworld.cmsis_nn:
     tags: tensorflow
     platform_allow: mps3_an547

--- a/tests/net/lib/lwm2m/content_json/testcase.yaml
+++ b/tests/net/lib/lwm2m/content_json/testcase.yaml
@@ -2,4 +2,5 @@ common:
   depends_on: netif
 tests:
   net.lwm2m.content_json:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     tags: lwm2m net

--- a/tests/net/lib/lwm2m/content_link_format/testcase.yaml
+++ b/tests/net/lib/lwm2m/content_link_format/testcase.yaml
@@ -2,4 +2,5 @@ common:
   depends_on: netif
 tests:
   net.lwm2m.content_link_format:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     tags: lwm2m net

--- a/tests/net/lib/lwm2m/content_oma_tlv/testcase.yaml
+++ b/tests/net/lib/lwm2m/content_oma_tlv/testcase.yaml
@@ -2,4 +2,5 @@ common:
   depends_on: netif
 tests:
   net.lwm2m.content_oma_tlv:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     tags: lwm2m net

--- a/tests/net/lib/lwm2m/content_plain_text/testcase.yaml
+++ b/tests/net/lib/lwm2m/content_plain_text/testcase.yaml
@@ -2,4 +2,5 @@ common:
   depends_on: netif
 tests:
   net.lwm2m.content_plain_text:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     tags: lwm2m net


### PR DESCRIPTION
Not all toolchains support newlib so tests that require newlib need to have a filter to we don't try and build those tests on those testcases.  Some newer tests are missing:

	filter: TOOLCHAIN_HAS_NEWLIB == 1

so add that to testcases that needed.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>