### PR TITLE
samples: bt: hids: add a non authenticated mode to the sample

### DIFF
--- a/samples/bluetooth/hci_uart/sample.yaml
+++ b/samples/bluetooth/hci_uart/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: TBD
-  name: TBD
+  name: Bluetooth HCI UART
+  description: Allows Zephyr to provide Bluetooth connectivity via UART
 tests:
   sample.bluetooth.hci_uart.arm:
     harness: bluetooth

--- a/samples/bluetooth/ipsp/sample.yaml
+++ b/samples/bluetooth/ipsp/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: TBD
-  name: TBD
+  name: Bluetooth IPSP Sample
+  description: IPSP (Internet Protocol Support Profile) Node role sample
 tests:
   sample.bluetooth.ipsp:
     harness: bluetooth

--- a/samples/bluetooth/peripheral/sample.yaml
+++ b/samples/bluetooth/peripheral/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: TBD
-  name: TBD
+  name: Bluetooth Peripheral
+  description: Demonstrates the BLE Peripheral role
 tests:
   sample.bluetooth.peripheral:
     harness: bluetooth

--- a/samples/bluetooth/peripheral_csc/sample.yaml
+++ b/samples/bluetooth/peripheral_csc/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: TBD
-  name: TBD
+  name: Bluetooth Peripheral CSC
+  description: Demonstrates the CSC (Cycling Speed and Cadence) GATT Service
 tests:
   sample.bluetooth.peripheral_csc:
     harness: bluetooth

--- a/samples/bluetooth/peripheral_dis/sample.yaml
+++ b/samples/bluetooth/peripheral_dis/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: TBD
-  name: TBD
+  name: Bluetooth Peripheral DIS
+  description: Demonstrates the DIS (Device Information) GATT Service
 tests:
   sample.bluetooth.peripheral_dis:
     harness: bluetooth

--- a/samples/bluetooth/peripheral_esp/sample.yaml
+++ b/samples/bluetooth/peripheral_esp/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: TBD
-  name: TBD
+  name: Bluetooth Peripheral ESP
+  description: Demonstrates the ESP (Environmental Sensing Profile) GATT Service
 tests:
   sample.bluetooth.peripheral_esp:
     harness: bluetooth

--- a/samples/bluetooth/peripheral_hids/Kconfig
+++ b/samples/bluetooth/peripheral_hids/Kconfig
@@ -1,0 +1,13 @@
+# Copyright 2023 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Bluetooth: Peripheral HIDs"
+
+config SAMPLE_BT_USE_AUTHENTICATION
+	bool "Enable passkey authentication"
+	default y
+	help
+	  Enable the passkey authentication callback and register the GATT
+	  read and and write attributes as authentication required.
+
+source "Kconfig.zephyr"

--- a/samples/bluetooth/peripheral_hids/README.rst
+++ b/samples/bluetooth/peripheral_hids/README.rst
@@ -10,6 +10,11 @@ Similar to the :ref:`Peripheral <ble_peripheral>` sample, except that this
 application specifically exposes the HID GATT Service. The report map used is
 for a generic mouse.
 
+In the default configuration the sample uses passkey authentication (displays a
+code on the peripheral and requires that to be entered on the host during
+pairing) and requires an authenticated link to access the GATT characteristics.
+To disable authentication and just use encrypted channels instead, build the
+sample with `CONFIG_SAMPLE_BT_USE_AUTHENTICATION=n`.
 
 Requirements
 ************

--- a/samples/bluetooth/peripheral_hids/sample.yaml
+++ b/samples/bluetooth/peripheral_hids/sample.yaml
@@ -8,3 +8,11 @@ tests:
     tags: bluetooth
     integration_platforms:
       - qemu_cortex_m3
+  sample.bluetooth.peripheral_hids.no_authentication:
+    harness: bluetooth
+    extra_configs:
+      - CONFIG_SAMPLE_BT_USE_AUTHENTICATION=n
+    platform_allow: qemu_cortex_m3 qemu_x86
+    tags: bluetooth
+    integration_platforms:
+      - qemu_cortex_m3

--- a/samples/bluetooth/peripheral_hids/sample.yaml
+++ b/samples/bluetooth/peripheral_hids/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: TBD
-  name: TBD
+  name: Bluetooth Peripheral HIDs
+  description: Bluetooth Low Energy HID-over-GATT service sample
 tests:
   sample.bluetooth.peripheral_hids:
     harness: bluetooth

--- a/samples/bluetooth/peripheral_hids/src/hog.c
+++ b/samples/bluetooth/peripheral_hids/src/hog.c
@@ -141,6 +141,16 @@ static ssize_t write_ctrl_point(struct bt_conn *conn,
 	return len;
 }
 
+#if CONFIG_SAMPLE_BT_USE_AUTHENTICATION
+/* Require encryption using authenticated link-key. */
+#define SAMPLE_BT_PERM_READ BT_GATT_PERM_READ_AUTHEN
+#define SAMPLE_BT_PERM_WRITE BT_GATT_PERM_WRITE_AUTHEN
+#else
+/* Require encryption. */
+#define SAMPLE_BT_PERM_READ BT_GATT_PERM_READ_ENCRYPT
+#define SAMPLE_BT_PERM_WRITE BT_GATT_PERM_WRITE_ENCRYPT
+#endif
+
 /* HID Service Declaration */
 BT_GATT_SERVICE_DEFINE(hog_svc,
 	BT_GATT_PRIMARY_SERVICE(BT_UUID_HIDS),
@@ -150,10 +160,10 @@ BT_GATT_SERVICE_DEFINE(hog_svc,
 			       BT_GATT_PERM_READ, read_report_map, NULL, NULL),
 	BT_GATT_CHARACTERISTIC(BT_UUID_HIDS_REPORT,
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
-			       BT_GATT_PERM_READ_AUTHEN,
+			       SAMPLE_BT_PERM_READ,
 			       read_input_report, NULL, NULL),
 	BT_GATT_CCC(input_ccc_changed,
-		    BT_GATT_PERM_READ_AUTHEN | BT_GATT_PERM_WRITE_AUTHEN),
+		    SAMPLE_BT_PERM_READ | SAMPLE_BT_PERM_WRITE),
 	BT_GATT_DESCRIPTOR(BT_UUID_HIDS_REPORT_REF, BT_GATT_PERM_READ,
 			   read_report, NULL, &input),
 	BT_GATT_CHARACTERISTIC(BT_UUID_HIDS_CTRL_POINT,

--- a/samples/bluetooth/peripheral_hids/src/main.c
+++ b/samples/bluetooth/peripheral_hids/src/main.c
@@ -137,7 +137,10 @@ void main(void)
 		return;
 	}
 
-	bt_conn_auth_cb_register(&auth_cb_display);
+	if (IS_ENABLED(CONFIG_SAMPLE_BT_USE_AUTHENTICATION)) {
+		bt_conn_auth_cb_register(&auth_cb_display);
+		printk("Bluetooth authentication callbacks registered.\n");
+	}
 
 	hog_button_loop();
 }

--- a/samples/bluetooth/peripheral_hr/sample.yaml
+++ b/samples/bluetooth/peripheral_hr/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: TBD
-  name: TBD
+  name: Bluetooth Peripheral HR
+  description: Demonstrates the HR (Heart Rate) GATT Service
 tests:
   sample.bluetooth.peripheral_hr:
     harness: bluetooth

--- a/samples/bluetooth/peripheral_ht/sample.yaml
+++ b/samples/bluetooth/peripheral_ht/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: TBD
-  name: TBD
+  name: Bluetooth Peripheral HT
+  description: Demonstrates the HT (Health Thermometer) GATT Service
 tests:
   sample.bluetooth.peripheral_ht:
     harness: bluetooth

--- a/samples/bluetooth/peripheral_identity/sample.yaml
+++ b/samples/bluetooth/peripheral_identity/sample.yaml
@@ -1,6 +1,7 @@
 sample:
-  description: TBD
-  name: TBD
+  description: Bluetooth Peripheral Identity
+  name: Demonstrates use of multiple identity and the ability to be connected
+    to from multiple central devices
 tests:
   sample.bluetooth.peripheral_identity:
     harness: bluetooth

--- a/samples/bluetooth/peripheral_ots/sample.yaml
+++ b/samples/bluetooth/peripheral_ots/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: TBD
-  name: TBD
+  name: Bluetooth Peripheral OTS
+  description: Demonstrates the OTS (Object Transfer) GATT Service
 tests:
   sample.bluetooth.peripheral_ots:
     harness: bluetooth

--- a/samples/bluetooth/peripheral_sc_only/sample.yaml
+++ b/samples/bluetooth/peripheral_sc_only/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: TBD
-  name: TBD
+  name: Bluetooth Peripheral SC-only
+  description: Demonstrates Secure Connections Only mode
 tests:
   sample.bluetooth.peripheral_sc_only:
     harness: bluetooth

--- a/samples/bluetooth/scan_adv/sample.yaml
+++ b/samples/bluetooth/scan_adv/sample.yaml
@@ -1,6 +1,7 @@
 sample:
-  description: TBD
-  name: TBD
+  name: Bluetooth Scan & Advertise
+  description: Demonstrates combined BLE Broadcaster & Observer role
+    functionality
 tests:
   sample.bluetooth.scan_adv:
     harness: bluetooth

--- a/samples/bluetooth/st_ble_sensor/sample.yaml
+++ b/samples/bluetooth/st_ble_sensor/sample.yaml
@@ -1,6 +1,7 @@
 sample:
-  description: TBD
-  name: TBD
+  name: Bluetooth ST BLE Sensor Demo
+  description: Demonstrates BLE peripheral by exposing vendor-specific GATT
+    services
 tests:
   sample.bluetooth.st_ble_sensor:
     harness: bluetooth


### PR DESCRIPTION
Hi, adding an sample option for the HID over GATT sample to make it work out of the box without the passkey. Just turning the passkey callback off results in host loop in a connected-disconnected cycle and not giving much information about why, this should make it obvious that the two have to be changed together.

Also noticed that many BLE samples had no name/description set, fixed that too.