### PR TITLE
Fix echo_bot sample on RISC-V virt QEMU machine

### DIFF
--- a/samples/drivers/uart/echo_bot/src/main.c
+++ b/samples/drivers/uart/echo_bot/src/main.c
@@ -32,13 +32,9 @@ void serial_cb(const struct device *dev, void *user_data)
 {
 	uint8_t c;
 
-	if (!uart_irq_update(uart_dev)) {
-		return;
-	}
+	while (uart_irq_update(dev) && uart_irq_rx_ready(dev)) {
 
-	while (uart_irq_rx_ready(uart_dev)) {
-
-		uart_fifo_read(uart_dev, &c, 1);
+		uart_fifo_read(dev, &c, 1);
 
 		if ((c == '\n' || c == '\r') && rx_buf_pos > 0) {
 			/* terminate string */


### PR DESCRIPTION
This machine uses an ns16550 UART, and the Zephyr driver for this device caches status register state in the uart_irq_update call, so uart_irq_rx_ready can never change its return value without an intervening call to uart_irq_update.  Change the echo_bot sample to a pattern I found in the PPP driver, which fixes the sample on qemu_riscv32.

I'm not 100% sure that this is the right solution.  The docs say "Before calling [uart_irq_rx_ready] in the interrupt handler, uart_irq_update() must be called once per the handler invocation".  But following those instructions causes this sample to hang in QEMU.