### PR TITLE
RP2040: fix USB stability issue related to control transfers.

### DIFF
--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -9,6 +9,7 @@
 #include <hardware/regs/usb.h>
 #include <hardware/structs/usb.h>
 #include <hardware/resets.h>
+#include <pico/platform.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/usb/usb_device.h>
@@ -54,8 +55,10 @@ struct udc_rpi_state {
 	usb_dc_status_callback status_cb;
 	struct udc_rpi_ep_state out_ep_state[USB_NUM_BIDIR_ENDPOINTS];
 	struct udc_rpi_ep_state in_ep_state[USB_NUM_BIDIR_ENDPOINTS];
+	bool abort_control_writes;
 	bool setup_available;
 	bool should_set_address;
+	uint16_t control_out_ep_rcvd;
 	uint8_t addr;
 };
 
@@ -91,6 +94,10 @@ static int udc_rpi_start_xfer(uint8_t ep, const void *data, size_t len)
 	struct udc_rpi_ep_state *ep_state = udc_rpi_get_ep_state(ep);
 	uint32_t val = len | USB_BUF_CTRL_AVAIL;
 
+	if (*ep_state->buf_ctl & USB_BUF_CTRL_AVAIL) {
+		LOG_WRN("ep 0x%02x was already armed", ep);
+	}
+
 	if (USB_EP_DIR_IS_IN(ep)) {
 		if (len > DATA_BUFFER_SIZE) {
 			return -ENOMEM;
@@ -113,11 +120,78 @@ static int udc_rpi_start_xfer(uint8_t ep, const void *data, size_t len)
 	return 0;
 }
 
+/*
+ * This function converts a zephyr endpoint address into a
+ * bit mask that can be used with registers:
+ *  - BUFF_STATUS
+ *  - BUFF_CPU_SHOULD_HANDLE
+ *  - EP_ABOR
+ *  - EP_ABORT_DONE
+ *  - EP_STATUS_STALL_NAK
+ */
+static inline uint32_t udc_rpi_endpoint_mask(const uint8_t ep)
+{
+	const int bit_index = (USB_EP_GET_IDX(ep) << 1) | !!USB_EP_DIR_IS_OUT(ep);
+
+	return BIT(bit_index);
+}
+
+static void udc_rpi_cancel_endpoint(const uint8_t ep)
+{
+	struct udc_rpi_ep_state *const ep_state = udc_rpi_get_ep_state(ep);
+
+	if (*ep_state->buf_ctl & USB_BUF_CTRL_AVAIL) {
+		const uint32_t mask = udc_rpi_endpoint_mask(ep);
+		bool abort_handshake_supported = rp2040_chip_version() >= 2;
+
+		if (abort_handshake_supported) {
+			hw_set_alias(usb_hw)->abort = mask;
+			while ((usb_hw->abort_done & mask) != mask) {
+			}
+		}
+
+		*ep_state->buf_ctl &= ~USB_BUF_CTRL_AVAIL;
+
+		if (abort_handshake_supported) {
+			hw_clear_alias(usb_hw)->abort = mask;
+		}
+
+		if (USB_EP_DIR_IS_IN(ep)) {
+			k_sem_give(&ep_state->write_sem);
+		}
+	}
+}
+
 static void udc_rpi_handle_setup(void)
 {
+	const struct udc_rpi_ep_state *const ep_state = udc_rpi_get_ep_state(USB_CONTROL_EP_OUT);
 	struct cb_msg msg;
 
-	state.setup_available = true;
+	/* Normally all control transfers should complete before a new setup
+	 * transaction is sent, however in some rare cases from the perspective
+	 * of the device, a new setup transaction could arrive prematurely, in
+	 * which case the previous control transfer should be aborted, and for
+	 * this reason we're canceling both control IN and control OUT
+	 * endpoints. See section 5.5.5 of the Universal Serial Bus
+	 * Specification, version 2.0.
+	 */
+
+	udc_rpi_cancel_endpoint(USB_CONTROL_EP_IN);
+
+	if (*ep_state->buf_ctl & USB_BUF_CTRL_AVAIL) {
+		udc_rpi_cancel_endpoint(USB_CONTROL_EP_OUT);
+
+		/* This warning could be triggered by the rare event described
+		 * above, but it could also be a sign of a software bug, that
+		 * can expose us to race conditions when the system is slowed
+		 * down, because it becomes impossible to determine in what
+		 * order did setup/data transactions arrive.
+		 */
+
+		LOG_WRN("EP0_OUT was armed while setup stage arrived.");
+	}
+
+	state.abort_control_writes = true;
 
 	/* Set DATA1 PID for the next (data or status) stage */
 	udc_rpi_get_ep_state(USB_CONTROL_EP_IN)->next_pid = 1;
@@ -179,15 +253,23 @@ static void udc_rpi_isr(const void *arg)
 	uint32_t handled = 0;
 	struct cb_msg msg;
 
+	if (status & USB_INTS_BUFF_STATUS_BITS) {
+		/* Note: we should check buffer interrupts before setup interrupts.
+		 * this may seem a little counter-intuitive, because setup irqs
+		 * sound more urgent, however in case we see an EP0_OUT buffer irq
+		 * at the same time as a setup irq, then we know the buffer irq
+		 * belongs to the previous control transfer, so we want to handle
+		 * that first.
+		 */
+
+		handled |= USB_INTS_BUFF_STATUS_BITS;
+		udc_rpi_handle_buff_status();
+	}
+
 	if (status & USB_INTS_SETUP_REQ_BITS) {
 		handled |= USB_INTS_SETUP_REQ_BITS;
 		hw_clear_alias(usb_hw)->sie_status = USB_SIE_STATUS_SETUP_REC_BITS;
 		udc_rpi_handle_setup();
-	}
-
-	if (status & USB_INTS_BUFF_STATUS_BITS) {
-		handled |= USB_INTS_BUFF_STATUS_BITS;
-		udc_rpi_handle_buff_status();
 	}
 
 	if (status & USB_INTS_DEV_CONN_DIS_BITS) {
@@ -439,6 +521,10 @@ int usb_dc_ep_set_stall(const uint8_t ep)
 	}
 
 	*ep_state->buf_ctl = USB_BUF_CTRL_STALL;
+	if (ep == USB_CONTROL_EP_IN) {
+		/* Un-arm EP0_OUT endpoint, to make sure next setup packet starts clean */
+		udc_rpi_cancel_endpoint(USB_CONTROL_EP_OUT);
+	}
 
 	ep_state->halted = 1U;
 
@@ -558,6 +644,20 @@ int usb_dc_ep_write(const uint8_t ep, const uint8_t *const data,
 		return -EINVAL;
 	}
 
+	if (ep == USB_CONTROL_EP_IN && state.abort_control_writes) {
+		/* If abort_control_writes is high, it means the setup packet has not
+		 * yet been consumed by the thread, which means that this write
+		 * is part of a previous control transfer, which now must be
+		 * aborted.
+		 */
+
+		if (ret_bytes != NULL) {
+			*ret_bytes = len;
+		}
+
+		return 0;
+	}
+
 	if (ep == USB_CONTROL_EP_IN && len > USB_MAX_CTRL_MPS) {
 		len = USB_MAX_CTRL_MPS;
 	} else if (len > ep_state->mps) {
@@ -615,8 +715,12 @@ int usb_dc_ep_read_wait(uint8_t ep, uint8_t *data,
 		return -EINVAL;
 	}
 
-	if (state.setup_available) {
+	if (ep == USB_CONTROL_EP_OUT && state.setup_available) {
 		read_count = sizeof(struct usb_setup_packet);
+		if (read_count != max_data_len) {
+			LOG_WRN("Attempting to read setup packet with the wrong length"
+				" (expected: %d, read: %d)", read_count, max_data_len);
+		}
 	} else {
 		read_count = udc_rpi_get_ep_buffer_len(ep) - ep_state->read_offset;
 	}
@@ -627,7 +731,7 @@ int usb_dc_ep_read_wait(uint8_t ep, uint8_t *data,
 	if (data) {
 		read_count = MIN(read_count, max_data_len);
 
-		if (state.setup_available) {
+		if (ep == USB_CONTROL_EP_OUT && state.setup_available) {
 			memcpy(data, (const void *)&usb_dpram->setup_packet, read_count);
 		} else {
 			memcpy(data, ep_state->buf + ep_state->read_offset, read_count);
@@ -645,26 +749,79 @@ int usb_dc_ep_read_wait(uint8_t ep, uint8_t *data,
 	return 0;
 }
 
-int usb_dc_ep_read_continue(uint8_t ep)
+static int usb_dc_control_ep_read_continue(const struct udc_rpi_ep_state *const ep_state,
+					   bool *const arm_out_endpoint)
 {
-	struct udc_rpi_ep_state *ep_state = udc_rpi_get_ep_state(ep);
-	size_t bytes_received;
+	const struct usb_setup_packet *const setup = (const void *)&usb_dpram->setup_packet;
+
+	if (state.setup_available) {
+		LOG_DBG("EP0 setup (wLength=%d, is_to_device=%d)",
+			setup->wLength, usb_reqtype_is_to_device(setup));
+		if (setup->wLength != 0U) {
+			/* In the case of a control transfer, we want to prime the OUT endpoint
+			 * exactly once, to either:
+			 * 1) in the to_device case, to receive the data (only if wLength is not 0)
+			 * 2) in the to_host case, to receive a 0-length status stage transfer
+			 *    (only valid if wLength is not 0)
+			 * Note that when wLength = 0, the status stage transfer is always an IN
+			 * type so we don't need to consider that case.
+			 */
+			*arm_out_endpoint = true;
+			state.control_out_ep_rcvd = 0;
+		}
+
+		state.setup_available = false;
+	} else {
+		const size_t len = udc_rpi_get_ep_buffer_len(USB_CONTROL_EP_OUT);
+
+		LOG_DBG("Control OUT received %u offset: %u",
+			len, ep_state->read_offset);
+		if (usb_reqtype_is_to_device(setup)) {
+			if (state.control_out_ep_rcvd + ep_state->read_offset < setup->wLength) {
+				/* If no more data in the buffer, but we're still waiting
+				 * for more, start a new read transaction.
+				 */
+				if (len == ep_state->read_offset) {
+					state.control_out_ep_rcvd += ep_state->read_offset;
+					*arm_out_endpoint = true;
+				}
+			}
+		}
+	}
+	return 0;
+}
+
+int usb_dc_ep_read_continue(const uint8_t ep)
+{
+	const struct udc_rpi_ep_state *const ep_state = udc_rpi_get_ep_state(ep);
+	bool arm_out_endpoint = false;
 
 	if (!ep_state || !USB_EP_DIR_IS_OUT(ep)) {
 		LOG_ERR("Not valid endpoint: %02x", ep);
 		return -EINVAL;
 	}
+	if (ep == USB_CONTROL_EP_OUT) {
+		int ret = usb_dc_control_ep_read_continue(ep_state, &arm_out_endpoint);
 
-	bytes_received = state.setup_available ?
-			 sizeof(struct usb_setup_packet) :
-			 udc_rpi_get_ep_buffer_len(ep);
+		if (ret != 0) {
+			return ret;
+		}
+	} else {
+		const size_t len = udc_rpi_get_ep_buffer_len(ep);
 
-	state.setup_available = false;
+		LOG_DBG("Endpoint 0x%02x received %u offset: %u",
+			ep, len, ep_state->read_offset);
+		/* If no more data in the buffer, start a new read transaction. */
+		if (len == ep_state->read_offset) {
+			arm_out_endpoint = true;
+		}
+	}
 
-	/* If no more data in the buffer, start a new read transaction. */
-	LOG_DBG("received %d offset: %d", bytes_received, ep_state->read_offset);
-	if (bytes_received == ep_state->read_offset) {
+	if (arm_out_endpoint) {
+		LOG_DBG("Arming endpoint 0x%02x", ep);
 		return usb_dc_ep_start_read(ep, DATA_BUFFER_SIZE);
+	} else {
+		LOG_DBG("Not arming endpoint 0x%02x", ep);
 	}
 
 	return 0;
@@ -749,6 +906,11 @@ static void udc_rpi_thread_main(void *arg1, void *unused1, void *unused2)
 
 		if (msg.ep_event) {
 			struct udc_rpi_ep_state *ep_state = udc_rpi_get_ep_state(msg.ep);
+
+			if (msg.type == USB_DC_EP_SETUP) {
+				state.abort_control_writes = false;
+				state.setup_available = true;
+			}
 
 			if (ep_state->cb) {
 				ep_state->cb(msg.ep, msg.type);


### PR DESCRIPTION
Description of the bad behaviour before this change:

The arming of the control EP0_OUT endpoint was not kept under control. It could happen that the EP0_OUT endpoint was left armed, after the completion of a complete control transfer.

It is clear that the intention was to NOT keep EP0_OUT constantly armed while idle, because usb_dc_ep_enable() doesn't arm it, and the intention was for when usb_dc_ep_read() is called to collect the Setup-Stage 8-byte data, that is when EP0_OUT is armed, and before this call is performed, the host will keep getting NAKs for the Data-Stage of the to_device control transfer.

This happens correctly on the first to_device control transfer with wLength > 0. However, because usb_dc_ep_read_continue() indiscriminately re-arms all OUT endpoints, in the case of to_device control transfers with wLength > 0, on the Data-Stage, the endpoint is also re-armed, which is wrong, because then the endpoint will be left armed after the control transfer is over.

In this case when a new to_device control transfer starts, the Data-Stage will be accepted on the first try. This would still have worked without a failure if the Setup-Stage would have been processed immediately, but because we process everything in a work queue at a later time, when the Setup-Stage associated 8-byte data buffer is read both the Setup-Stage and Data-Stage have arrived. At the end of handling the Setup-Stage we try to re-arm the EP0_OUT, which already contains data, thereby corrupting the received length portion of the buf_ctl register. (Obviously other fields are changed too, but the length field is the one that first causes chaos, cause it's written to the maximum, which is 64.) The above mentioned Data-Stage already has a message in its workqueue for it to be processed, but it is picked up only after the length field has been corrupted. Because of this usb_dc_ep_read() thinks there is more data in the buffer than there really is, and everything becomes de-synchronized, with later reads accessing uninitialized parts of the buffer.

This sounds like a fundamental failure, that should make it impossible to operate USB, however the reason this behaviour doesn't make it impossible to enumerate the device is that this only affects to_device control transfers with wLength > 0, and during enumeration there are not many of those happening.
When enumerating a HID keyboard, there is only _one_ of those happening, and it is the initial setting of the lock light led status. And that first one succeeds because it's the first one. (However, later lock light setting control transfers can cause problems, which is how this problem was encountered.)

The solution in this commit is to keep better control over when EP0_OUT is armed. This forces the Data-Stage to arrive later (the host will keep re-trying), and that way the corruption of the buffer control register is avoided.

Summary of the changes:
- Rework the logic around deciding wether to re-arm the out endpoint after a read.
For non-0 endpoint the previous behaviour is kept, however for EP0 it is only re-
armed if more OUT transactions are expected for that SETUP transfer (be it data-
stage or status-stage)
- Force un-arm the EP0_OUT endpoint in case a stall condition is observed.
- When a setup transfer is received check if EP0_OUT is already armed. If armed
then log a warning message, and force-disarm it.
- When a setup req interrupt fires, don't immediately force the next
       read to get it, instead, it will be read only after a setup message
       is extracted from the message queue.
- When a setup packet is received abort any unfinished previous control
       transfers:
        - cancel any data buffers given to the EP0_IN endpoint
        - drop any new ep0_in writes that are attempted before this newest
          setup packet's associated message is extracted from the message
          queue.
- In the ISR, check buffer interrupts before setup req interrupts.
       This is to make sure that the final 0-length status message from the
       previous setup packet is consumed before the new setup packet.
       (this is the only case now when both interrupts could be seen as
       having fired by the time the interrupt handler routine executes.
