### PR TITLE
RP2040: Cleanup incorrect comment and condition from the USB driver.

### DIFF
--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -349,8 +349,7 @@ int usb_dc_ep_start_read(uint8_t ep, size_t len)
 
 	LOG_DBG("ep 0x%02x len %d", ep, len);
 
-	/* we flush USB_CONTROL_EP_IN by doing a 0 length receive on it */
-	if (!USB_EP_DIR_IS_OUT(ep) && (ep != USB_CONTROL_EP_IN || len)) {
+	if (!USB_EP_DIR_IS_OUT(ep)) {
 		LOG_ERR("invalid ep 0x%02x", ep);
 		return -EINVAL;
 	}


### PR DESCRIPTION
I believe this comment and condition may have found its way into the rp2040 driver from other drivers where it makes more sense. For example for the stm32 driver performing a read on the EP0_IN endpoint turns it silently into a read on the EP0_OUT endpoint. As far as I can tell, this really was only used to consume 0-length Status-Stages of to_host control transfer in the other drivers.

Note that usb_dc_ep_start_read() is never called in an IN endpoint in the rp2040 driver, and furthermore, even if it would have been called like that, the current implementation would not do the silent change into actually performing a read on the EP0_OUT endpoint instead, so the condition and comment is just wrong.

Note that 0-length Status-Stage of to_host control transfers is currently consumed in this driver by usb_dc_ep_read_continue().
