### PR TITLE
Add Renode script overlays support

### DIFF
--- a/cmake/emu/renode.cmake
+++ b/cmake/emu/renode.cmake
@@ -11,11 +11,18 @@ set(RENODE_FLAGS
   --pid-file renode.pid
   )
 
+# Check if there is any Renode script overlay defined for the target board
+set(resc_overlay_file ${APPLICATION_SOURCE_DIR}/boards/${BOARD}.resc)
+if(EXISTS ${resc_overlay_file})
+  set(RENODE_OVERLAY include "@${resc_overlay_file}\;")
+  message(STATUS "Found Renode script overlay: ${resc_overlay_file}")
+endif()
+
 add_custom_target(run_renode
   COMMAND
   ${RENODE}
   ${RENODE_FLAGS}
-  -e '$$bin=@${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}\; include @${RENODE_SCRIPT}\; s'
+  -e '$$bin=@${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}\; include @${RENODE_SCRIPT}\; ${RENODE_OVERLAY} s'
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   DEPENDS ${logical_target_for_zephyr_elf}
   USES_TERMINAL

--- a/tests/kernel/context/boards/hifive_unleashed.resc
+++ b/tests/kernel/context/boards/hifive_unleashed.resc
@@ -1,0 +1,1 @@
+emulation SetGlobalQuantum "0.00001"

--- a/tests/kernel/sched/schedule_api/boards/hifive_unleashed.resc
+++ b/tests/kernel/sched/schedule_api/boards/hifive_unleashed.resc
@@ -1,0 +1,1 @@
+emulation SetGlobalQuantum "0.00001"

--- a/tests/kernel/usage/thread_runtime_stats/boards/hifive_unleashed.resc
+++ b/tests/kernel/usage/thread_runtime_stats/boards/hifive_unleashed.resc
@@ -1,0 +1,1 @@
+emulation SetGlobalQuantum "0.000001"


### PR DESCRIPTION
This PR:
* adds Renode script overlay support allowing to tune simulation parameters for selected samples/tests
* adds an overlay fine tuning selected kernel tests targeting the HiFive Unleashed platform - those tests require higher fidelity of the virtual time flow which is achievable on multi-core platforms in Renode by reducing the quantum