### PR TITLE
drivers: watchdog: stm32 iwdt enable and update during setup

### DIFF
--- a/drivers/watchdog/wdt_iwdg_stm32.h
+++ b/drivers/watchdog/wdt_iwdg_stm32.h
@@ -24,6 +24,8 @@
 struct iwdg_stm32_data {
 	/* IWDG peripheral instance. */
 	IWDG_TypeDef *Instance;
+	uint32_t prescaler;
+	uint32_t reload;
 };
 
 #define IWDG_STM32_DATA(dev)					\


### PR DESCRIPTION
To follow the IWDG configuration sequence, the timeout install is just preparing the reload and prescaler parameters. Then during the iwdg setup the watchdog is enabled and configured.
As specified by the refMan (of the stm32u575) : 
```
Enable the IWDG by writing 0x0000 CCCC in the IWDG key register (IWDG_KR).
2 . Enable register access by writing 0x0000 5555 in the IWDG key register (IWDG_KR).
3. Write the prescaler by programming the IWDG prescaler register (IWDG_PR).
4. Write the IWDG reload register (IWDG_RLR).
5. If needed, enable the early wakeup interrupt, and program the early wakeup
comparator, by writing the proper values into the IWDG early wakeup interrupt register
(IWDG_EWCR).
6. Wait for the registers to be updated (IWDG_SR = 0x0000 0000).
7. Refresh the counter with RL[11:0] value, and write-protect registers by writing
0x0000 AAAA into IWDG key register (IWDG_KR).

```

The iwdg_stm32_install_timeout() function is just calculating the config parameter prescaler and reload.
The IWDG enable and configuration is done by the iwdg_stm32_setup function.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/53935

Signed-off-by: Francois Ramu <francois.ramu@st.com>