### PR TITLE
net: socket: asynchronous connect

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -948,6 +948,11 @@ int net_context_connect(struct net_context *context,
 
 	k_mutex_lock(&context->lock, K_FOREVER);
 
+	if (net_context_get_state(context) == NET_CONTEXT_CONNECTING) {
+		ret = -EALREADY;
+		goto unlock;
+	}
+
 	if (!net_context_is_used(context)) {
 		ret = -EBADF;
 		goto unlock;

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -414,6 +414,15 @@ static inline int net_tcp_get_option(struct net_context *context,
  */
 struct k_sem *net_tcp_tx_sem_get(struct net_context *context);
 
+/**
+ * @brief Obtain a semaphore indicating if connection is connected.
+ *
+ * @param context Network context
+ *
+ * @return semaphore indicating if connection is connected
+ */
+struct k_sem *net_tcp_conn_sem_get(struct net_context *context);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -234,6 +234,7 @@ struct tcp { /* TCP connection */
 		net_tcp_accept_cb_t accept_cb;
 		struct tcp *accepted_conn;
 	};
+	net_context_connect_cb_t connect_cb;
 	struct k_mutex lock;
 	struct k_sem connect_sem; /* semaphore for blocking connect */
 	struct k_sem tx_sem; /* Semaphore indicating if transfers are blocked . */

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -481,9 +481,21 @@ static inline int z_vrfy_zsock_bind(int sock, const struct sockaddr *addr,
 #include <syscalls/zsock_bind_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
+static void zsock_connected_cb(struct net_context *ctx, int status, void *user_data)
+{
+	if (status < 0) {
+		ctx->user_data = INT_TO_POINTER(-status);
+		sock_set_error(ctx);
+	} else if (status == 0) {
+		(void)net_context_recv(ctx, zsock_received_cb, K_NO_WAIT, ctx->user_data);
+	}
+}
+
 int zsock_connect_ctx(struct net_context *ctx, const struct sockaddr *addr,
 		      socklen_t addrlen)
 {
+	k_timeout_t timeout;
+
 #if defined(CONFIG_SOCKS)
 	if (net_context_is_proxy_enabled(ctx)) {
 		SET_ERRNO(net_socks5_connect(ctx, addr, addrlen));
@@ -492,11 +504,26 @@ int zsock_connect_ctx(struct net_context *ctx, const struct sockaddr *addr,
 		return 0;
 	}
 #endif
-	SET_ERRNO(net_context_connect(ctx, addr, addrlen, NULL,
-			      K_MSEC(CONFIG_NET_SOCKETS_CONNECT_TIMEOUT),
-			      NULL));
-	SET_ERRNO(net_context_recv(ctx, zsock_received_cb, K_NO_WAIT,
-				   ctx->user_data));
+	if (net_context_get_state(ctx) == NET_CONTEXT_CONNECTED) {
+		return 0;
+	} else if (net_context_get_state(ctx) == NET_CONTEXT_CONNECTING) {
+		if (sock_is_error(ctx)) {
+			SET_ERRNO(-POINTER_TO_INT(ctx->user_data));
+		} else {
+			SET_ERRNO(-EALREADY);
+		}
+	} else if (sock_is_nonblock(ctx)) {
+		timeout = K_NO_WAIT;
+		SET_ERRNO(net_context_connect(ctx, addr, addrlen,
+					      zsock_connected_cb, timeout,
+					      ctx->user_data));
+	} else {
+		timeout = K_MSEC(CONFIG_NET_SOCKETS_CONNECT_TIMEOUT);
+		SET_ERRNO(net_context_connect(ctx, addr, addrlen, NULL,
+					      timeout, NULL));
+		SET_ERRNO(net_context_recv(ctx, zsock_received_cb, K_NO_WAIT,
+					   ctx->user_data));
+	}
 
 	return 0;
 }
@@ -1498,7 +1525,12 @@ static int zsock_poll_prepare_ctx(struct net_context *ctx,
 				return -ENOMEM;
 			}
 
-			(*pev)->obj = net_tcp_tx_sem_get(ctx);
+			if (net_context_get_state(ctx) == NET_CONTEXT_CONNECTING) {
+				(*pev)->obj = net_tcp_conn_sem_get(ctx);
+			} else {
+				(*pev)->obj = net_tcp_tx_sem_get(ctx);
+			}
+
 			(*pev)->type = K_POLL_TYPE_SEM_AVAILABLE;
 			(*pev)->mode = K_POLL_MODE_NOTIFY_ONLY;
 			(*pev)->state = K_POLL_STATE_NOT_READY;
@@ -1535,7 +1567,8 @@ static int zsock_poll_update_ctx(struct net_context *ctx,
 		if (IS_ENABLED(CONFIG_NET_NATIVE_TCP) &&
 		    net_context_get_type(ctx) == SOCK_STREAM) {
 			if ((*pev)->state != K_POLL_STATE_NOT_READY &&
-			    !sock_is_eof(ctx)) {
+			    !sock_is_eof(ctx) &&
+			    (net_context_get_state(ctx) == NET_CONTEXT_CONNECTED)) {
 				pfd->revents |= ZSOCK_POLLOUT;
 			}
 			(*pev)++;

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1794,10 +1794,25 @@ int ztls_connect_ctx(struct tls_context *ctx, const struct sockaddr *addr,
 		     socklen_t addrlen)
 {
 	int ret;
+	int sock_flags;
+
+	sock_flags = zsock_fcntl(ctx->sock, F_GETFL, 0);
+	if (sock_flags < 0) {
+		return -EIO;
+	}
+
+	if (sock_flags & O_NONBLOCK) {
+		(void)zsock_fcntl(ctx->sock, F_SETFL,
+				  sock_flags & ~O_NONBLOCK);
+	}
 
 	ret = zsock_connect(ctx->sock, addr, addrlen);
 	if (ret < 0) {
 		return ret;
+	}
+
+	if (sock_flags & O_NONBLOCK) {
+		(void)zsock_fcntl(ctx->sock, F_SETFL, sock_flags);
 	}
 
 	if (ctx->type == SOCK_STREAM) {


### PR DESCRIPTION
Added a feature of socket connect
being asynchronous. If socket is set
to nonblock with O_NONBLOCK flag,
then connect() is non-blocking aswell.
App can normally poll the socket to
test when the connection is established.

Signed-off-by: Daniel Nejezchleb <dnejezchleb@hwg.cz>