### PR TITLE
tests: bsim_bt compile: Provide more info during errors

### DIFF
--- a/tests/bluetooth/bsim_bt/compile.source
+++ b/tests/bluetooth/bsim_bt/compile.source
@@ -1,6 +1,12 @@
 # Copyright 2018 Oticon A/S
 # SPDX-License-Identifier: Apache-2.0
 
+function print_error_info(){
+  echo -e "\033[0;31mFailure building ${app} ${conf_file} for ${BOARD}\033[0m\n\
+  You can rebuild it with\n\
+  ${cmake_cmd[@]} && ninja ${ninja_args}"
+}
+
 function compile(){
   : "${app:?app must be defined}"
 
@@ -27,19 +33,22 @@ function compile(){
 
   local ret=0
 
+  local cmake_cmd=(cmake -GNinja -DBOARD_ROOT=${BOARD_ROOT} -DBOARD=${BOARD} \
+            -DCONF_FILE=${conf_file} -DOVERLAY_CONFIG=${conf_overlay} \
+            ${modules_arg} \
+            ${cmake_args} -DCMAKE_C_FLAGS=\"${cc_flags}\" ${app_root}/${app})
+
   # Set INCR_BUILD when calling to only do an incremental build
   if [ ! -v INCR_BUILD ] || [ ! -d "${this_dir}" ]; then
       [ -d "${this_dir}" ] && rm ${this_dir} -rf
       mkdir -p ${this_dir} && cd ${this_dir}
-      cmake -GNinja -DBOARD_ROOT=${BOARD_ROOT} -DBOARD=${BOARD} \
-            -DCONF_FILE=${conf_file} -DOVERLAY_CONFIG=${conf_overlay} \
-            ${modules_arg} \
-            ${cmake_args} -DCMAKE_C_FLAGS="${cc_flags}" ${app_root}/${app} \
-            &> cmake.out || { ret="$?"; cat cmake.out && return $ret; }
+      ${cmake_cmd[@]} &> cmake.out || \
+      { ret="$?"; print_error_info ; cat cmake.out && return $ret; }
   else
       cd ${this_dir}
   fi
-  ninja ${ninja_args} &> ninja.out || { ret="$?"; cat ninja.out && return $ret; }
+  ninja ${ninja_args} &> ninja.out || \
+  { ret="$?"; print_error_info ; cat ninja.out && return $ret; }
   cp ${this_dir}/zephyr/zephyr.exe ${exe_name}
 
   nm ${exe_name} | grep -v " [U|w] " | sort | cut -d" " -f1,3 > ${map_file_name}


### PR DESCRIPTION
As we are now compiling in parallel all apps, build errors are not anymore next to the compile line, so let's tell developers for which app we are printing the build output to ease debugging.

Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>