### PR TITLE
lib: os: reboot: include zephyr/cache.h

### DIFF
--- a/lib/os/reboot.c
+++ b/lib/os/reboot.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/cache.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys/reboot.h>
 #include <zephyr/kernel.h>


### PR DESCRIPTION
Include <zephyr/cache.h> in order to use the Zephyr cache APIs.

Fixes: b94ab6e9f1987e85f31594a3b10d998bfab4513c

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>