### PR TITLE
github: bug template: Propose users to create discussion topic

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,6 +9,8 @@ assignees: ''
 
 **Describe the bug**
 A clear and concise description of what the bug is.
+(Note that [Github Discussions](https://github.com/zephyrproject-rtos/zephyr/discussions) are available to first verify that the issue
+is a genuine Zephyr bug and not a consequence of Zephyr services misuse.)
 
 Please also mention any information which could help others to understand
 the problem you're facing:


### PR DESCRIPTION
In order to minimize the number of users creating bugs that are actually an issue in their application, remind the existence and purpose of github Dicussions.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>