### PR TITLE
Bluetooth: Audio: Add comment for bt_audio_stream.audio_iso

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1356,8 +1356,14 @@ struct bt_audio_stream {
 	/** Audio stream operations */
 	struct bt_audio_stream_ops *ops;
 
-	/** Audio ISO reference */
+#if defined(CONFIG_BT_AUDIO_UNICAST_CLIENT)
+	/** @brief Audio ISO reference
+	 *
+	 *  This is only used for Unicast Client streams,
+	 *  and is handled internally.
+	 */
 	struct bt_audio_iso *audio_iso;
+#endif /* CONFIG_BT_AUDIO_UNICAST_CLIENT */
 
 	union {
 		void *group;


### PR DESCRIPTION
The bt_audio_stream.audio_iso is something we only use for the unicast client, and will only be set by the unicast client operatiosn.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>