### PR TITLE
samples: net: lwm2m_client: Drop QEMU M3 from integration

### DIFF
--- a/samples/net/lwm2m_client/sample.yaml
+++ b/samples/net/lwm2m_client/sample.yaml
@@ -8,8 +8,6 @@ tests:
     platform_allow: qemu_cortex_m3 qemu_x86 native_posix frdm_k64f pinnacle_100_dvk mg100
     integration_platforms:
       - qemu_x86
-      - qemu_cortex_m3
-      - native_posix
     tags: net lwm2m
   sample.net.lwm2m_client.all_objects:
     harness: net
@@ -17,8 +15,6 @@ tests:
     platform_allow: qemu_cortex_m3 qemu_x86 native_posix
     integration_platforms:
       - qemu_x86
-      - qemu_cortex_m3
-      - native_posix
     tags: net lwm2m
     extra_configs:
       - CONFIG_LWM2M_CONN_MON_OBJ_SUPPORT=y
@@ -37,8 +33,6 @@ tests:
     platform_allow: qemu_cortex_m3 qemu_x86 native_posix frdm_k64f pinnacle_100_dvk mg100
     integration_platforms:
       - qemu_x86
-      - qemu_cortex_m3
-      - native_posix
     tags: net lwm2m
   sample.net.lwm2m_client.bt:
     harness: net
@@ -54,8 +48,6 @@ tests:
     platform_allow: qemu_cortex_m3 qemu_x86 native_posix
     integration_platforms:
       - qemu_x86
-      - qemu_cortex_m3
-      - native_posix
     tags: net lwm2m
   sample.net.lwm2m_client.wnc_m14a2a:
     harness: net


### PR DESCRIPTION
QEMU M3 cannot be used in integration platform that requires net
