### PR TITLE
scripts: compliance: pass argv explicitly to parse_args

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1073,7 +1073,7 @@ def resolve_path_hint(hint):
         return hint
 
 
-def parse_args():
+def parse_args(argv):
 
     default_range = 'HEAD~1..HEAD'
     parser = argparse.ArgumentParser(
@@ -1101,7 +1101,7 @@ def parse_args():
     parser.add_argument('--annotate', action="store_true",
                         help="Print GitHub Actions-compatible annotations.")
 
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 def _main(args):
     # The "real" main(), which is wrapped to catch exceptions and report them
@@ -1221,8 +1221,8 @@ def _main(args):
     return n_fails
 
 
-def main():
-    args = parse_args()
+def main(argv=None):
+    args = parse_args(argv)
 
     try:
         # pylint: disable=unused-import
@@ -1260,4 +1260,4 @@ def err(msg):
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])


### PR DESCRIPTION
Change the check_compliance main invocation to pass an explicit argv list from main to parse_args(). This does not change anything for direct invocation, but allows wrapping the compliance script and using it as a library while controlling its behavior by passing the intended flags to main().