### PR TITLE
ARC: irq: idu: mask IRQ before trigger type setup

### DIFF
--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -40,6 +40,9 @@ static void arc_shared_intc_init(void)
 		 * TODO: don't use z_arc_connect_idu* functions to avoid
 		 * locking/unlocking every time.
 		 */
+
+		/* Disable (mask) line */
+		z_arc_connect_idu_set_mask(i, 0x1);
 		z_arc_connect_idu_set_mode(i, ARC_CONNECT_INTRPT_TRIGGER_LEVEL,
 					   ARC_CONNECT_DISTRI_MODE_ROUND_ROBIN);
 
@@ -48,9 +51,6 @@ static void arc_shared_intc_init(void)
 		 * secondary cores may be not initialized yet.
 		 */
 		z_arc_connect_idu_set_dest(i, BIT(ARC_MP_PRIMARY_CPU_ID));
-
-		/* Disable (mask) line */
-		z_arc_connect_idu_set_mask(i, 0x1);
 	}
 
 	z_arc_connect_idu_enable();


### PR DESCRIPTION
Currently we setup IRQ trigger type (pulse or level) in IDU before we Mask (disable) IRQ line.

The IDU is disabled at this moment, however we still may accidentally generate interrupt by trigger setup.

To avoid that let's mask (disable) IRQ before trigger type setup.