### PR TITLE
llvm: define __INT*_C() and __UINT*_C()

### DIFF
--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -27,5 +27,84 @@
 
 #include <zephyr/toolchain/gcc.h>
 
+#ifndef __INT8_C
+#define __INT8_C(x)	x
+#endif
+
+#ifndef INT8_C
+#define INT8_C(x)	__INT8_C(x)
+#endif
+
+#ifndef __UINT8_C
+#define __UINT8_C(x)	x ## U
+#endif
+
+#ifndef UINT8_C
+#define UINT8_C(x)	__UINT8_C(x)
+#endif
+
+#ifndef __INT16_C
+#define __INT16_C(x)	x
+#endif
+
+#ifndef INT16_C
+#define INT16_C(x)	__INT16_C(x)
+#endif
+
+#ifndef __UINT16_C
+#define __UINT16_C(x)	x ## U
+#endif
+
+#ifndef UINT16_C
+#define UINT16_C(x)	__UINT16_C(x)
+#endif
+
+#ifndef __INT32_C
+#define __INT32_C(x)	x
+#endif
+
+#ifndef INT32_C
+#define INT32_C(x)	__INT32_C(x)
+#endif
+
+#ifndef __UINT32_C
+#define __UINT32_C(x)	x ## U
+#endif
+
+#ifndef UINT32_C
+#define UINT32_C(x)	__UINT32_C(x)
+#endif
+
+#ifndef __INT64_C
+#define __INT64_C(x)	x
+#endif
+
+#ifndef INT64_C
+#define INT64_C(x)	__INT64_C(x)
+#endif
+
+#ifndef __UINT64_C
+#define __UINT64_C(x)	x ## ULL
+#endif
+
+#ifndef UINT64_C
+#define UINT64_C(x)	__UINT64_C(x)
+#endif
+
+#ifndef __INTMAX_C
+#define __INTMAX_C(x)	x
+#endif
+
+#ifndef INTMAX_C
+#define INTMAX_C(x)	__INTMAX_C(x)
+#endif
+
+#ifndef __UINTMAX_C
+#define __UINTMAX_C(x)	x ## ULL
+#endif
+
+#ifndef UINTMAX_C
+#define UINTMAX_C(x)	__UINTMAX_C(x)
+#endif
 
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_LLVM_H_ */


### PR DESCRIPTION
llvm based toolchains need the same fix as exists for xcc that was introduced with commit:

commit 5ef8db8ac989e683fb1b51572b00074780f82f0a
Author: Daniel Leung <daniel.leung@intel.com>
Date:   Wed Feb 3 14:23:51 2021 -0800

    xcc: define __INT*_C() and __UINT*_C()

Since llvm based toolchains don't define these macros either.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>