### PR TITLE
toolchain: oneApi: Fix support and update for 2023.0.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,7 +407,8 @@ zephyr_compile_options(${COMPILER_OPT_AS_LIST})
 
 # TODO: Include arch compiler options at this point.
 
-if(NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
+if(NOT CMAKE_C_COMPILER_ID STREQUAL "Clang" AND
+   NOT CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
   # GCC assumed
   zephyr_cc_option(-fno-reorder-functions)
 

--- a/cmake/bintools/oneApi/target.cmake
+++ b/cmake/bintools/oneApi/target.cmake
@@ -1,12 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(DEFINED TOOLCHAIN_HOME)
-  set(find_program_clang_args PATHS ${TOOLCHAIN_HOME} ${ONEAPI_PYTHON_PATH} NO_DEFAULT_PATH)
+  set(find_program_clang_args PATHS ${TOOLCHAIN_HOME} ${ONEAPI_LLVM_BIN_PATH} NO_DEFAULT_PATH)
   set(find_program_binutils_args PATHS ${TOOLCHAIN_HOME} )
 endif()
 
+find_package(oneApi 2023.0.0 REQUIRED)
+
 find_program(CMAKE_AR      llvm-ar      ${find_program_clang_args}   )
-find_program(CMAKE_NM      llvm-nm      ${find_program_clang_args}   )
+if(ONEAPI_VERSION VERSION_LESS_EQUAL "2023.0.0")
+  find_program(CMAKE_NM      nm           ${find_program_binutils_args}   )
+else()
+  find_program(CMAKE_NM      llvm-nm      ${find_program_clang_args}   )
+endif()
 # In OneApi installation directory on Windows, there is no llvm-objdump
 # binary, so would better use objdump from system environment both
 # on Linux and Windows.

--- a/cmake/modules/FindoneApi.cmake
+++ b/cmake/modules/FindoneApi.cmake
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# FindoneApi module for locating oneAPI compiler, icx.
+#
+# The module defines the following variables:
+#
+# 'oneApi_FOUND', 'ONEAPI_FOUND'
+# True if the oneApi toolchain/compiler, icx, was found.
+#
+# 'ONEAPI_VERSION'
+# The version of the oneAPI toolchain.
+
+if(CMAKE_C_COMPILER)
+  # Parse the 'clang --version' output to find the installed version.
+  execute_process(COMMAND ${CMAKE_C_COMPILER} --version OUTPUT_VARIABLE ONEAPI_VERSION)
+  string(REGEX REPLACE "[^0-9]*([0-9.]+) .*" "\\1" ONEAPI_VERSION ${ONEAPI_VERSION})
+endif()
+
+find_package_handle_standard_args(oneApi
+				  REQUIRED_VARS CMAKE_C_COMPILER
+				  VERSION_VAR ONEAPI_VERSION
+)

--- a/cmake/toolchain/oneApi/generic.cmake
+++ b/cmake/toolchain/oneApi/generic.cmake
@@ -10,7 +10,7 @@ endif()
 string(TOLOWER ${CMAKE_HOST_SYSTEM_NAME} system)
 if(ONEAPI_TOOLCHAIN_PATH)
   set(TOOLCHAIN_HOME ${ONEAPI_TOOLCHAIN_PATH}/compiler/latest/${system}/bin/)
-  set(ONEAPI_PYTHON_PATH ${ONEAPI_TOOLCHAIN_PATH}/intelpython/latest/bin)
+  set(ONEAPI_LLVM_BIN_PATH ${ONEAPI_TOOLCHAIN_PATH}/compiler/latest/${system}/bin-llvm)
 endif()
 
 set(ONEAPI_TOOLCHAIN_PATH ${ONEAPI_TOOLCHAIN_PATH} CACHE PATH "oneApi install directory")
@@ -42,5 +42,7 @@ elseif(system STREQUAL "windows")
   add_compile_options(--target=${triple})
   add_link_options(--target=${triple})
 endif()
+
+set(TOOLCHAIN_HAS_NEWLIB OFF CACHE BOOL "True if toolchain supports newlib")
 
 message(STATUS "Found toolchain: host (clang/ld)")


### PR DESCRIPTION
The oneApi support has bit rotten since it was first introduced.  Update the support to function with the latest 2023.0.0 release and add a check to only support that version or newer for now.  Versions before 2021.2.0 have linker script failures.

Various fixes made:
* In the 2023.0.0 release, various binaries are in a llvm-bin path so add support to search in that path.  This replaces the python search path that much older versions needed.
* newlib isn't supported with oneApi so set TOOLCHAIN_HAS_NEWLIB to OFF to match that.
* 2023.0.0 doesn't back llvm-nm, so use binutils version.  This is expected to be fixed in 2023.1.0 release so add a check to handle either case.
* Update compiler flag check based on clang to also support CMAKE_C_COMPILER_ID of "IntelLLVM" as that is how the oneApi toolchain reports itself.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>