### PR TITLE
samples/subsys/zbus/benchmark: fix counter synchronization issue

### DIFF
--- a/samples/subsys/zbus/benchmark/src/benchmark.c
+++ b/samples/subsys/zbus/benchmark/src/benchmark.c
@@ -10,6 +10,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/sys/atomic.h>
 #include <zephyr/zbus/zbus.h>
 
 #if defined(CONFIG_ARCH_POSIX)
@@ -52,7 +53,7 @@ ZBUS_CHAN_DEFINE(bm_channel,		   /* Name */
 );
 
 #define BYTES_TO_BE_SENT (256LLU * 1024LLU)
-static uint64_t count;
+static atomic_t count;
 
 #if (CONFIG_BM_ASYNC == 1)
 ZBUS_SUBSCRIBER_DEFINE(s1, 4);
@@ -98,7 +99,7 @@ ZBUS_SUBSCRIBER_DEFINE(s16, 4);
                                                                                                    \
 			zbus_chan_finish(chan);                                                    \
                                                                                                    \
-			count += CONFIG_BM_MESSAGE_SIZE;                                           \
+			atomic_add(&count, CONFIG_BM_MESSAGE_SIZE);                                \
 		}                                                                                  \
 	}                                                                                          \
                                                                                                    \
@@ -219,7 +220,7 @@ static void producer_thread(void)
 	uint64_t i = ((BYTES_TO_BE_SENT * NSEC_PER_SEC) / MB(1)) / duration;
 	uint64_t f = ((BYTES_TO_BE_SENT * NSEC_PER_SEC * 100) / MB(1) / duration) % 100;
 
-	LOG_INF("Bytes sent = %lld, received = %llu", BYTES_TO_BE_SENT, count);
+	LOG_INF("Bytes sent = %lld, received = %lu", BYTES_TO_BE_SENT, atomic_get(&count));
 	LOG_INF("Average data rate: %llu.%lluMB/s", i, f);
 	LOG_INF("Duration: %u.%uus", duration / NSEC_PER_USEC, duration % NSEC_PER_USEC);
 


### PR DESCRIPTION
Current implementation has obvious synchronization issue with global counter variable which is updated (RMW) in multiple threads without any locking.

Replace regular variable by atomic type. As the maximum possible value is much less than INT32_MAX it's OK to replace the original uint64_t by (32-bit) atomic_t.

We've bumped into this by testing on HSDK4xD board (SMP, 4 cores)