### PR TITLE
drivers: ethernet: stm32: Enabling stats for the driver.

### DIFF
--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -53,6 +53,9 @@ struct eth_stm32_hal_dev_data {
 	float clk_ratio;
 	float clk_ratio_adj;
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+	struct net_stats_eth stats;
+#endif
 };
 
 #endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_STM32_HAL_PRIV_H_ */


### PR DESCRIPTION
The change enables the ethernet driver to save statistics in a structure in the ethernet driver API structure. In addition, the change also attempts to update error statistics based on errors reported in the STM32 ethernet HAL API.

Fixes #53995

Signed-off-by: Chamira Perera <chamira.perera@audinate.com>