### PR TITLE
drivers/disk: sdmmc stm32: Enable SDMMC Internal DMA on STM32L4plus mcu

### DIFF
--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -322,7 +322,7 @@ static int stm32_sdmmc_access_read(struct disk_info *disk, uint8_t *data_buf,
 
 	k_sem_take(&priv->thread_lock, K_FOREVER);
 
-#if STM32_SDMMC_USE_DMA
+#if STM32_SDMMC_USE_DMA || IS_ENABLED(DT_PROP(DT_DRV_INST(0), idma))
 	err = HAL_SD_ReadBlocks_DMA(&priv->hsd, data_buf, start_sector,
 				num_sector);
 #else
@@ -361,7 +361,7 @@ static int stm32_sdmmc_access_write(struct disk_info *disk,
 
 	k_sem_take(&priv->thread_lock, K_FOREVER);
 
-#if STM32_SDMMC_USE_DMA
+#if STM32_SDMMC_USE_DMA || IS_ENABLED(DT_PROP(DT_DRV_INST(0), idma))
 	err = HAL_SD_WriteBlocks_DMA(&priv->hsd, (uint8_t *)data_buf, start_sector,
 				 num_sector);
 #else

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -324,6 +324,7 @@
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB2, 22U)>;
 			interrupts = <49 0>;
+			idma;
 			status = "disabled";
 		};
 

--- a/dts/bindings/mmc/st,stm32-sdmmc.yaml
+++ b/dts/bindings/mmc/st,stm32-sdmmc.yaml
@@ -39,6 +39,13 @@ properties:
       - 4
       - 8
 
+  idma:
+    type: boolean
+    description: |
+      SDMMC device has an internal DMA. Internal DMA doesn't require any additional
+      configuration using "dmas" property.
+      Delete this property to use interrupt driven mode.
+
   dmas:
     description: |
       Optional DMA channel specifier. If DMA should be used, specifier should


### PR DESCRIPTION
STM32L4plus mcu has SDMMC internal DMA which works without any configuration and it's handled by SDMMC HAL driver. This commit adds option to enable it and use it.

Signed-off-by: Petr Hlineny <development@hlineny.cz>