### PR TITLE
Bluetooth: Audio: Call stream released on ACL disconnect

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -941,6 +941,18 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 			 * state, where the ase finally will be deallocated
 			 */
 			ase_release(ase);
+
+			if (stream != NULL) {
+				const struct bt_audio_stream_ops *ops;
+
+				/* Notify upper layer */
+				ops = stream->ops;
+				if (ops != NULL && ops->released != NULL) {
+					ops->released(stream);
+				} else {
+					LOG_WRN("No callback for released set");
+				}
+			}
 		}
 
 		if (stream != NULL && stream->conn != NULL) {


### PR DESCRIPTION
If the ACL disconnects, then the unicast server cannot send a notification to the client about the endpoint and stream being released. We now call the released callback if the stream's endpoint was not idle before the disconnection.

Similarly the unicast server (ASCS) did also not call the released callback if the ACL disconnection causes a endpoint release.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/52366