### PR TITLE
Bluetooth: Host: If available use resp_addr to connect

### DIFF
--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -57,7 +57,13 @@ enum {
 struct bt_conn_le {
 	bt_addr_le_t dst;
 
+	/** Initiator address. aka "InitA". This is the on-air address of the
+	  * Central, as in the CONN_IND LL-PDU.
+	  */
 	bt_addr_le_t init_addr;
+	/** Responder address. aka "AdvA". This is the on-air address of the
+	  * Peripheral, as in the CONN_IND LL-PDU.
+	  */
 	bt_addr_le_t resp_addr;
 
 	uint16_t interval;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -583,12 +583,12 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 	} else {
 		const bt_addr_le_t *peer_addr = &conn->le.dst;
 
-#if defined(CONFIG_BT_SMP)
-		if (bt_dev.le.rl_entries > bt_dev.le.rl_size) {
-			/* Host resolving is used, use the RPA directly. */
+		/* Prefer actual advertiser address (found by Host RPA resolver). */
+		if (!bt_addr_le_eq(&conn->le.resp_addr, BT_ADDR_LE_ANY)) {
 			peer_addr = &conn->le.resp_addr;
+			LOG_DBG("Using resp_addr %s", bt_addr_le_str(peer_addr));
 		}
-#endif
+
 		bt_addr_le_copy(&cp->peer_addr, peer_addr);
 		cp->filter_policy = BT_HCI_LE_CREATE_CONN_FP_NO_FILTER;
 	}
@@ -656,12 +656,12 @@ static int bt_le_create_conn_legacy(const struct bt_conn *conn)
 	} else {
 		const bt_addr_le_t *peer_addr = &conn->le.dst;
 
-#if defined(CONFIG_BT_SMP)
-		if (bt_dev.le.rl_entries > bt_dev.le.rl_size) {
-			/* Host resolving is used, use the RPA directly. */
+		/* Prefer actual advertiser address (found by Host RPA resolver). */
+		if (!bt_addr_le_eq(&conn->le.resp_addr, BT_ADDR_LE_ANY)) {
 			peer_addr = &conn->le.resp_addr;
+			LOG_DBG("Using resp_addr %s", bt_addr_le_str(peer_addr));
 		}
-#endif
+
 		bt_addr_le_copy(&cp->peer_addr, peer_addr);
 		cp->filter_policy = BT_HCI_LE_CREATE_CONN_FP_NO_FILTER;
 	}


### PR DESCRIPTION
The responder address is the controller will actually connect to. If we have it, we should always pass that to the controller.

This change avoids the need to keep this code in sync with the condition that selects the Host RPA resolver. It just works.

This change is picked from the now reverted commit https://github.com/zephyrproject-rtos/zephyr/commit/5824ac90ecd8dd06d9ea117d345dbc6b069e5840.

This PR also documents `init_addr` and `resp_addr`.

Signed-off-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemi.no>