### PR TITLE
drivers: flash: stm32_qspi: handle 4-byte addressing only chips

### DIFF
--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -982,6 +982,10 @@ static int spi_nor_process_bfp(const struct device *dev,
 			}
 		}
 	}
+	if (addr_mode == JESD216_SFDP_BFP_DW1_ADDRBYTES_VAL_4B) {
+		data->flag_access_32bit = true;
+		LOG_INF("Flash - address mode: 4B");
+	}
 
 	/*
 	 * Only check if the 1-4-4 (i.e. 4READ) or 1-1-4 (QREAD)


### PR DESCRIPTION
Driver already supports switching to 4-byte addressing if the chip supports both (3- and 4-byte) addressing modes. This modification correctly initializes the driver if the chip supports 4-byte addressing only. Tested with a MX25L25745G chip.