### PR TITLE
dts: stm32: add UART5 for STM32G4

### DIFF
--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -65,5 +65,14 @@
 			#io-channel-cells = <1>;
 			has-vref-channel;
 		};
+
+		uart5: serial@40005000 {
+			compatible = "st,stm32-uart";
+			reg = <0x40005000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00100000>;
+			resets = <&rctl STM32_RESET(APB1L, 20U)>;
+			interrupts = <53 0>;
+			status = "disabled";
+		};
 	};
 };


### PR DESCRIPTION
According to the reference manual, all STM32G4 variants except STM32G431/STM32G441 have the UART5 peripheral.