### PR TITLE
soc: posix: inf_clock: add C++ support to NATIVE_TASK

### DIFF
--- a/soc/posix/inf_clock/soc.h
+++ b/soc/posix/inf_clock/soc.h
@@ -43,7 +43,7 @@ void posix_soc_clean_up(void);
  * any Zephyr thread are running.
  */
 #define NATIVE_TASK(fn, level, prio)	\
-	static const void (*_CONCAT(__native_task_, fn)) __used	__noasan \
+	static void (* const _CONCAT(__native_task_, fn))() __used __noasan \
 	__attribute__((__section__(".native_" #level STRINGIFY(prio) "_task")))\
 	= fn
 

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/common/edtt_driver.h
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/common/edtt_driver.h
@@ -23,7 +23,7 @@ extern "C" {
  * Generic EDTT interface
  */
 bool edtt_start(void);
-bool edtt_stop(void);
+void edtt_stop(void);
 int edtt_read(uint8_t *ptr, size_t size, int flags);
 int edtt_write(uint8_t *ptr, size_t size, int flags);
 

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/common/edtt_driver_bsim.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/common/edtt_driver_bsim.c
@@ -62,17 +62,16 @@ bool edtt_start(void)
 	return true;
 }
 
-bool edtt_stop(void)
+void edtt_stop(void)
 {
 	if (edtt_mode_enabled == false) {
 		/* otherwise we don't try to open the EDTT interface */
-		return true;
+		return;
 	}
 
 	bs_trace_raw(9, "EDTTT: %s called\n", __func__);
 	edttd_clean_up();
 	edtt_mode_enabled = false;
-	return true;
 }
 
 #if defined(NATIVE_TASK)


### PR DESCRIPTION
Explicitly define function pointer as the correct type `(void*)()` and not `(void*)`. In C this cast is done implicitly, but C++ does not allow it.

A minimal recreation for reference:
- C: https://godbolt.org/z/cjvnoWxc5
- C++: https://godbolt.org/z/v63Mvqh6s

Signed-off-by: Hein Wessels <heinwessels93@gmail.com>