### PR TITLE
Bluetooth: Audio: Unicast stream start fix

### DIFF
--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -44,7 +44,7 @@ struct bt_bap_ep {
 	struct bt_codec_qos_pref qos_pref;
 	struct bt_bap_iso *iso;
 
-	/* Used by the unicast server */
+	/* Used by the unicast server and client */
 	bool receiver_ready;
 
 	/* TODO: Create a union to reduce memory usage */


### PR DESCRIPTION
The unicast client would attempt to send the
receiver start ready opcode to the server for
source ASEs before the CIS was connected, which
is a spec violation.
    
The code has been refactored to set a boolean,
and then send the receiver start ready opcode on
CIS connection instead.
    
Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/53552
depends on https://github.com/zephyrproject-rtos/zephyr/pull/51030