### PR TITLE
ci: Add qemu_x86 to clang build platforms

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["native_posix"]
+        platform: ["native_posix", "qemu_x86"]
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.2
       LLVM_TOOLCHAIN_PATH: /usr/lib/llvm-15


### PR DESCRIPTION
Add qemu_x86 so we can additional coverage on clang outside of just native posix.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>