### PR TITLE
riscv: properly clear pending IPI flags

### DIFF
--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -92,7 +92,7 @@ static void ipi_handler(const void *unused)
 
 	MSIP(csr_read(mhartid)) = 0;
 
-	atomic_val_t pending_ipi = atomic_get(&cpu_pending_ipi[_current_cpu->id]);
+	atomic_val_t pending_ipi = atomic_clear(&cpu_pending_ipi[_current_cpu->id]);
 
 	if (pending_ipi & IPI_SCHED) {
 		z_sched_ipi();


### PR DESCRIPTION
Commit 4f9b547ebd0a ("riscv: smp: prepare for more than one IPI type")
didn't clear pending IPI flags.

Noticed by @akabaev.

