### PR TITLE
arch: simplified exception codes

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -501,6 +501,18 @@ config EXTRA_EXCEPTION_INFO
 	  register state, when a fault occurs. This information can be useful
 	  to collect for post-mortem analysis and debug of issues.
 
+config SIMPLIFIED_EXCEPTION_CODES
+	bool "Convert arch specific exception codes to K_ERR_CPU_EXCEPTION"
+	default y if ZTEST
+	help
+	  The same piece of faulty code (NULL dereference, etc) can result in
+	  a multitude of potential exception codes at the CPU level, depending
+	  upon whether addresses exist, an MPU is configured, the particular
+	  implementation of the CPU or any number of other reasons. Enabling
+	  this option collapses all the architecture specific exception codes
+	  down to the generic K_ERR_CPU_EXCEPTION, which makes testing code
+	  much more portable.
+
 endmenu # Interrupt configuration
 
 config INIT_ARCH_HW_AT_BOOT

--- a/arch/arm/core/aarch32/cortex_a_r/fault.c
+++ b/arch/arm/core/aarch32/cortex_a_r/fault.c
@@ -194,8 +194,12 @@ bool z_arm_fault_undef_instruction(z_arch_esf_t *esf)
 	/* Print fault information */
 	LOG_ERR("***** UNDEFINED INSTRUCTION ABORT *****");
 
+	uint32_t reason = IS_ENABLED(CONFIG_SIMPLIFIED_EXCEPTION_CODES) ?
+			  K_ERR_CPU_EXCEPTION :
+			  K_ERR_ARM_UNDEFINED_INSTRUCTION;
+
 	/* Invoke kernel fatal exception handler */
-	z_arm_fatal_error(K_ERR_ARM_UNDEFINED_INSTRUCTION, esf);
+	z_arm_fatal_error(reason, esf);
 
 	/* All undefined instructions are treated as fatal for now */
 	return true;
@@ -221,6 +225,11 @@ bool z_arm_fault_prefetch(z_arch_esf_t *esf)
 	LOG_ERR("***** PREFETCH ABORT *****");
 	if (FAULT_DUMP_VERBOSE) {
 		reason = dump_fault(fs, ifar);
+	}
+
+	/* Simplify exception codes if requested */
+	if (IS_ENABLED(CONFIG_SIMPLIFIED_EXCEPTION_CODES) && (reason >= K_ERR_ARCH_START)) {
+		reason = K_ERR_CPU_EXCEPTION;
 	}
 
 	/* Invoke kernel fatal exception handler */
@@ -288,6 +297,11 @@ bool z_arm_fault_data(z_arch_esf_t *esf)
 	LOG_ERR("***** DATA ABORT *****");
 	if (FAULT_DUMP_VERBOSE) {
 		reason = dump_fault(fs, dfar);
+	}
+
+	/* Simplify exception codes if requested */
+	if (IS_ENABLED(CONFIG_SIMPLIFIED_EXCEPTION_CODES) && (reason >= K_ERR_ARCH_START)) {
+		reason = K_ERR_CPU_EXCEPTION;
 	}
 
 	/* Invoke kernel fatal exception handler */

--- a/arch/arm/core/aarch32/cortex_m/fault.c
+++ b/arch/arm/core/aarch32/cortex_m/fault.c
@@ -1124,6 +1124,10 @@ void z_arm_fault(uint32_t msp, uint32_t psp, uint32_t exc_return,
 		esf_copy.basic.xpsr &= ~(IPSR_ISR_Msk);
 	}
 
+	if (IS_ENABLED(CONFIG_SIMPLIFIED_EXCEPTION_CODES) && (reason >= K_ERR_ARCH_START)) {
+		reason = K_ERR_CPU_EXCEPTION;
+	}
+
 	z_arm_fatal_error(reason, &esf_copy);
 }
 

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -166,13 +166,7 @@ ZTEST(arm_interrupt, test_arm_esf_collection)
 	expected_msp = __get_MSP();
 
 	run_esf_validation = 1;
-#if defined(CONFIG_CPU_AARCH32_CORTEX_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A)
-	expected_reason = K_ERR_ARM_UNDEFINED_INSTRUCTION;
-#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	expected_reason = K_ERR_ARM_USAGE_UNDEFINED_INSTRUCTION;
-#else
 	expected_reason = K_ERR_CPU_EXCEPTION;
-#endif
 
 	/* Run test thread and main thread at same priority to guarantee the
 	 * crashy thread we create below runs to completion before we get
@@ -474,7 +468,7 @@ ZTEST(arm_interrupt, test_arm_null_pointer_exception)
 
 	struct test_struct *test_struct_null_pointer = 0x0;
 
-	expected_reason = K_ERR_ARM_MEM_DATA_ACCESS;
+	expected_reason = K_ERR_CPU_EXCEPTION;
 
 	printk("Reading a null pointer value: 0x%0x\n",
 		test_struct_null_pointer->val[1]);

--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -45,7 +45,6 @@ static struct k_thread alt_thread;
 volatile int rv;
 
 static ZTEST_DMEM volatile int expected_reason = -1;
-static ZTEST_DMEM volatile int alternate_reason = -1;
 
 void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 {
@@ -61,34 +60,18 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		k_fatal_halt(reason);
 	}
 
-	if ((reason != expected_reason) && (reason != alternate_reason)) {
-		if (alternate_reason != -1) {
-			printk("Wrong crash type got %d expected %d or %d\n", reason,
-				expected_reason, alternate_reason);
-		} else {
-			printk("Wrong crash type got %d expected %d\n", reason,
-				expected_reason);
-		}
+	if (reason != expected_reason) {
+		printk("Wrong crash type got %d expected %d\n", reason,
+		       expected_reason);
 		k_fatal_halt(reason);
 	}
 
 	expected_reason = -1;
-	alternate_reason = -1;
 }
 
 void entry_cpu_exception(void *p1, void *p2, void *p3)
 {
-#if defined(CONFIG_CPU_AARCH32_CORTEX_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A)
-	expected_reason = K_ERR_ARM_UNDEFINED_INSTRUCTION;
-#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	/* The generated exception depends on whether address 0 is valid and it is executed.
-	 * It is not feasible to generically check that here, so accept either faulting reason.
-	 */
-	expected_reason = K_ERR_ARM_USAGE_ILLEGAL_EPSR;
-	alternate_reason = K_ERR_ARM_MEM_INSTRUCTION_ACCESS;
-#else
 	expected_reason = K_ERR_CPU_EXCEPTION;
-#endif
 
 #if defined(CONFIG_X86)
 	__asm__ volatile ("ud2");
@@ -113,11 +96,7 @@ void entry_cpu_exception(void *p1, void *p2, void *p3)
 
 void entry_cpu_exception_extend(void *p1, void *p2, void *p3)
 {
-#if defined(CONFIG_CPU_AARCH32_CORTEX_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A)
-	expected_reason = K_ERR_ARM_DEBUG_EVENT;
-#else
 	expected_reason = K_ERR_CPU_EXCEPTION;
-#endif
 
 #if defined(CONFIG_ARM64)
 	__asm__ volatile ("svc 0");

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -27,14 +27,6 @@
 extern void arm_core_mpu_disable(void);
 #endif
 
-#if defined(CONFIG_CPU_AARCH32_CORTEX_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A)
-#define PERMISSION_EXCEPTION K_ERR_ARM_PERMISSION_FAULT
-#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-#define PERMISSION_EXCEPTION K_ERR_ARM_MEM_DATA_ACCESS
-#else
-#define PERMISSION_EXCEPTION K_ERR_CPU_EXCEPTION
-#endif
-
 #define INFO(fmt, ...) printk(fmt, ##__VA_ARGS__)
 #define PIPE_LEN 1
 #define BYTES_TO_READ_WRITE 1
@@ -159,11 +151,7 @@ ZTEST_USER(userspace, test_write_control)
 #else
 	uint32_t val;
 
-#if defined(CONFIG_CPU_AARCH32_CORTEX_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A)
-	set_fault(K_ERR_ARM_UNDEFINED_INSTRUCTION);
-#else
 	set_fault(K_ERR_CPU_EXCEPTION);
-#endif
 
 	val = __get_SCTLR();
 	val |= SCTLR_DZ_Msk;
@@ -230,13 +218,7 @@ ZTEST_USER(userspace, test_disable_mmu_mpu)
 
 #elif defined(CONFIG_ARM)
 #ifndef CONFIG_TRUSTED_EXECUTION_NONSECURE
-#if defined(CONFIG_CPU_AARCH32_CORTEX_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A)
-	set_fault(K_ERR_ARM_UNDEFINED_INSTRUCTION);
-#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	set_fault(K_ERR_ARM_BUS_PRECISE_DATA_BUS);
-#else
 	set_fault(K_ERR_CPU_EXCEPTION);
-#endif
 
 	arm_core_mpu_disable();
 #else
@@ -276,7 +258,7 @@ ZTEST_USER(userspace, test_read_kernram)
 	/* Try to read from kernel RAM. */
 	void *p;
 
-	set_fault(PERMISSION_EXCEPTION);
+	set_fault(K_ERR_CPU_EXCEPTION);
 
 	p = _current->init_data;
 	printk("%p\n", p);
@@ -291,7 +273,7 @@ ZTEST_USER(userspace, test_read_kernram)
 ZTEST_USER(userspace, test_write_kernram)
 {
 	/* Try to write to kernel RAM. */
-	set_fault(PERMISSION_EXCEPTION);
+	set_fault(K_ERR_CPU_EXCEPTION);
 
 	_current->init_data = NULL;
 	zassert_unreachable("Write to kernel RAM did not fault");
@@ -326,7 +308,7 @@ ZTEST_USER(userspace, test_write_kernro)
 	zassert_true(in_rodata,
 		     "_k_neg_eagain is not in rodata");
 
-	set_fault(PERMISSION_EXCEPTION);
+	set_fault(K_ERR_CPU_EXCEPTION);
 
 	_k_neg_eagain = -EINVAL;
 	zassert_unreachable("Write to kernel RO did not fault");
@@ -340,7 +322,7 @@ ZTEST_USER(userspace, test_write_kernro)
 ZTEST_USER(userspace, test_write_kerntext)
 {
 	/* Try to write to kernel text. */
-	set_fault(PERMISSION_EXCEPTION);
+	set_fault(K_ERR_CPU_EXCEPTION);
 
 	memset(&z_is_thread_essential, 0, 4);
 	zassert_unreachable("Write to kernel text did not fault");
@@ -355,7 +337,7 @@ static int kernel_data;
  */
 ZTEST_USER(userspace, test_read_kernel_data)
 {
-	set_fault(PERMISSION_EXCEPTION);
+	set_fault(K_ERR_CPU_EXCEPTION);
 
 	printk("%d\n", kernel_data);
 	zassert_unreachable("Read from data did not fault");
@@ -368,7 +350,7 @@ ZTEST_USER(userspace, test_read_kernel_data)
  */
 ZTEST_USER(userspace, test_write_kernel_data)
 {
-	set_fault(PERMISSION_EXCEPTION);
+	set_fault(K_ERR_CPU_EXCEPTION);
 
 	kernel_data = 1;
 	zassert_unreachable("Write to  data did not fault");
@@ -401,7 +383,7 @@ ZTEST_USER(userspace, test_read_priv_stack)
 #else
 #error "Not implemented for this architecture"
 #endif
-	set_fault(PERMISSION_EXCEPTION);
+	set_fault(K_ERR_CPU_EXCEPTION);
 
 	printk("%c\n", *priv_stack_ptr);
 	zassert_unreachable("Read from privileged stack did not fault");
@@ -425,7 +407,7 @@ ZTEST_USER(userspace, test_write_priv_stack)
 #else
 #error "Not implemented for this architecture"
 #endif
-	set_fault(PERMISSION_EXCEPTION);
+	set_fault(K_ERR_CPU_EXCEPTION);
 
 	*priv_stack_ptr = 42;
 	zassert_unreachable("Write to privileged stack did not fault");
@@ -490,7 +472,7 @@ static void uthread_read_body(void *p1, void *p2, void *p3)
 {
 	unsigned int *vptr = p1;
 
-	set_fault(PERMISSION_EXCEPTION);
+	set_fault(K_ERR_CPU_EXCEPTION);
 	printk("%u\n", *vptr);
 	zassert_unreachable("Read from other thread stack did not fault");
 }
@@ -499,7 +481,7 @@ static void uthread_write_body(void *p1, void *p2, void *p3)
 {
 	unsigned int *vptr = p1;
 
-	set_fault(PERMISSION_EXCEPTION);
+	set_fault(K_ERR_CPU_EXCEPTION);
 	*vptr = 2U;
 	zassert_unreachable("Write to other thread stack did not fault");
 }
@@ -709,7 +691,7 @@ ZTEST(userspace_domain, test_1st_init_and_access_other_memdomain)
 	 * contains default_bool. This should fault when we try to write it.
 	 */
 	k_mem_domain_add_thread(&alternate_domain, k_current_get());
-	set_fault(PERMISSION_EXCEPTION);
+	set_fault(K_ERR_CPU_EXCEPTION);
 	spawn_user(&default_bool);
 }
 
@@ -760,7 +742,7 @@ ZTEST(userspace_domain, test_domain_remove_part_drop_to_user)
 	/* We added alt_part to the default domain in the previous test,
 	 * remove it, and then try to access again.
 	 */
-	set_fault(PERMISSION_EXCEPTION);
+	set_fault(K_ERR_CPU_EXCEPTION);
 
 	zassert_equal(
 		k_mem_domain_remove_partition(&k_mem_domain_default, &alt_part),
@@ -810,7 +792,7 @@ ZTEST(userspace_domain_ctx, test_domain_remove_part_context_switch)
 	/* We added alt_part to the default domain in the previous test,
 	 * remove it, and then try to access again.
 	 */
-	set_fault(PERMISSION_EXCEPTION);
+	set_fault(K_ERR_CPU_EXCEPTION);
 
 	zassert_equal(
 		k_mem_domain_remove_partition(&k_mem_domain_default, &alt_part),


### PR DESCRIPTION
Alternate solution to #54053 that keeps the high resolution architecture specific codes for general applications but collapses them down to `K_ERR_CPU_EXCEPTION` for testing purposes.

Fixes #54053.