### PR TITLE
Bluetooth: Controller: Fix missing node rx release on legacy CPR reject

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -3302,6 +3302,19 @@ static inline int event_conn_upd_prep(struct ll_conn *conn, uint16_t lazy,
 					     llctrl.conn_update_ind.win_offset);
 			tx = CONTAINER_OF(pdu_ctrl_tx, struct node_tx, pdu);
 			ctrl_tx_enqueue(conn, tx);
+
+			/* Acquire the reserved Rx node */
+			rx = conn->llcp_rx;
+			LL_ASSERT(rx && rx->hdr.link);
+			conn->llcp_rx = rx->hdr.link->mem;
+
+			/* Mark for buffer for release */
+			rx->hdr.type = NODE_RX_TYPE_RELEASE;
+
+			/* enqueue rx node towards Thread */
+			ll_rx_put(rx->hdr.link, rx);
+			ll_rx_sched();
+
 			return -ECANCELED;
 #endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 


### PR DESCRIPTION
Legacy Control Procedure fix. Fix missing release of the node rx allocation that was reserved at the start of the LE Connection Parameter Request procedure and the procedure ends with reject indication transmitted to the initiating peer.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>