### PR TITLE
MAINTAINERS: Use my dedicated work GitHub account

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2159,7 +2159,7 @@ USB:
   maintainers:
     - jfischer-no
   collaborators:
-    - desowin
+    - tmon-nordic
   files:
     - drivers/usb/
     - dts/bindings/usb/


### PR DESCRIPTION
While GitHub encourages using single account for both personal and work purposes (even recommends merging multiple accounts into one), there are some serious downsides when doing so.

The biggest disadvantage of using one account is the inability to select which email address the "Rebase and merge" action will use. GitHub, at least as of today, always uses primary email address for "Rebase and merge" action.

Another issue is selecting email for notification based on organization. Custom email routing can only be configured if you are organization member (or at least outside collaborator). While this works reasonably fine for zephyrproject-rtos organization, I cannot route e.g. mcu-tools organization emails to my work email.

To avoid the issues I have decided to use dedicated GitHub account for my Nordic Semiconductor related work activities: tmon-nordic

Signed-off-by: Tomasz Moń <tomasz.mon@nordicsemi.no>