### PR TITLE
flash shell and fs shell: Add read/erase/write test commands

### DIFF
--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -51,6 +51,26 @@ config FLASH_SHELL
 	  Enable the flash shell with flash related commands such as test,
 	  write, read and erase.
 
+if FLASH_SHELL
+
+config FLASH_SHELL_TEST_COMMANDS
+	bool "Flash read/write/erase test commands"
+	select CBPRINTF_FP_SUPPORT
+	help
+	  Enable additional flash shell commands for performing
+	  read/write/erase tests with speed output.
+
+config FLASH_SHELL_BUFFER_SIZE
+	hex "Flash shell buffer size"
+	default 0x4000 if FLASH_SHELL_TEST_COMMANDS
+	default 0x1000
+	range 0x400 0x1000000
+	help
+	  Size of the buffer used for flash commands, will determine the
+	  maximum size that can be used with a read/write test.
+
+endif # FLASH_SHELL
+
 config FLASH_PAGE_LAYOUT
 	bool "API for retrieving the layout of pages"
 	depends on FLASH_HAS_PAGE_LAYOUT

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -51,6 +51,27 @@ config FILE_SYSTEM_SHELL
 	  This shell provides basic browsing of the contents of the
 	  file system.
 
+if FILE_SYSTEM_SHELL
+
+config FILE_SYSTEM_SHELL_TEST_COMMANDS
+	bool "File system shell read/write/erase test commands"
+	select CBPRINTF_FP_SUPPORT
+	help
+	  Enable additional file system shell commands for performing
+	  read/write/erase tests with speed output.
+
+config FILE_SYSTEM_SHELL_BUFFER_SIZE
+	hex "File system shell buffer size"
+	depends on FILE_SYSTEM_SHELL_TEST_COMMANDS
+	default 0x100
+	range 0x20 0x1000000
+	help
+	  Size of the buffer used for file system commands, will determine the
+	  maximum size that can be used with a read/write test. Note that this
+	  is is used on the stack.
+
+endif # FILE_SYSTEM_SHELL
+
 config FILE_SYSTEM_MKFS
 	bool "Allow to format file system"
 	help


### PR DESCRIPTION
    Adds commands which can be used for timing flash device tasks and
    outputting a rough speed.

    Adds an optional shell command for testing the speed of the flash
    device and file system, which outputs a rough speed.

Fixes #54098