### PR TITLE
lwm2m: More rd client tests

### DIFF
--- a/tests/net/lib/lwm2m/lwm2m_rd_client/src/main.c
+++ b/tests/net/lib/lwm2m/lwm2m_rd_client/src/main.c
@@ -526,3 +526,70 @@ ZTEST(lwm2m_rd_client, test_socket_error)
 	zassert_true(check_lwm2m_rd_client_event(LWM2M_RD_CLIENT_EVENT_REG_UPDATE_COMPLETE, 3),
 		     NULL);
 }
+
+ZTEST(lwm2m_rd_client, test_start_stop_ignore_engine_fault)
+{
+	struct lwm2m_ctx ctx;
+
+	(void)memset(&ctx, 0x0, sizeof(ctx));
+
+	test_prepare_pending_message_cb(&message_reply_cb_default);
+
+	lwm2m_engine_add_service_fake.custom_fake = lwm2m_engine_add_service_fake_default;
+	lwm2m_rd_client_init();
+	test_lwm2m_engine_start_service();
+	wait_for_service(1);
+
+	lwm2m_engine_context_init_fake.custom_fake = lwm2m_engine_context_init_fake1;
+	lwm2m_get_bool_fake.custom_fake = lwm2m_get_bool_fake_default;
+	lwm2m_sprint_ip_addr_fake.custom_fake = lwm2m_sprint_ip_addr_fake_default;
+	lwm2m_init_message_fake.custom_fake = lwm2m_init_message_fake_default;
+	coap_header_get_code_fake.custom_fake = coap_header_get_code_fake_created;
+	coap_find_options_fake.custom_fake = coap_find_options_do_registration_reply_cb_ok;
+	zassert_true(lwm2m_rd_client_start(&ctx, "Test", 0, lwm2m_event_cb, lwm2m_observe_cb) == 0,
+		     NULL);
+	zassert_true(check_lwm2m_rd_client_event(LWM2M_RD_CLIENT_EVENT_REGISTRATION_COMPLETE, 0),
+		     NULL);
+
+	coap_header_get_code_fake.custom_fake = coap_header_get_code_fake_deleted;
+	zassert_true(lwm2m_rd_client_stop(&ctx, lwm2m_event_cb, true) == 0, NULL);
+	zassert_true(check_lwm2m_rd_client_event(LWM2M_RD_CLIENT_EVENT_DISCONNECT, 1), NULL);
+
+	test_throw_network_error_from_engine(EIO);
+	wait_for_service(10);
+	zassert_equal(show_lwm2m_event_fake.call_count, 2,
+		      "Should not enter any other state and throw an event");
+}
+
+ZTEST(lwm2m_rd_client, test_start_suspend_ignore_engine_fault)
+{
+	struct lwm2m_ctx ctx;
+
+	(void)memset(&ctx, 0x0, sizeof(ctx));
+
+	test_prepare_pending_message_cb(&message_reply_cb_default);
+
+	lwm2m_engine_add_service_fake.custom_fake = lwm2m_engine_add_service_fake_default;
+	lwm2m_rd_client_init();
+	test_lwm2m_engine_start_service();
+	wait_for_service(1);
+
+	lwm2m_engine_context_init_fake.custom_fake = lwm2m_engine_context_init_fake1;
+	lwm2m_get_bool_fake.custom_fake = lwm2m_get_bool_fake_default;
+	lwm2m_sprint_ip_addr_fake.custom_fake = lwm2m_sprint_ip_addr_fake_default;
+	lwm2m_init_message_fake.custom_fake = lwm2m_init_message_fake_default;
+	coap_header_get_code_fake.custom_fake = coap_header_get_code_fake_created;
+	coap_find_options_fake.custom_fake = coap_find_options_do_registration_reply_cb_ok;
+	zassert_true(lwm2m_rd_client_start(&ctx, "Test", 0, lwm2m_event_cb, lwm2m_observe_cb) == 0,
+		     NULL);
+	zassert_true(check_lwm2m_rd_client_event(LWM2M_RD_CLIENT_EVENT_REGISTRATION_COMPLETE, 0),
+		     NULL);
+
+	coap_header_get_code_fake.custom_fake = coap_header_get_code_fake_deleted;
+	zassert_true(lwm2m_rd_client_pause() == 0, NULL);
+	zassert_true(check_lwm2m_rd_client_event(LWM2M_RD_CLIENT_EVENT_ENGINE_SUSPENDED, 1), NULL);
+	test_throw_network_error_from_engine(EIO);
+	wait_for_service(10);
+	zassert_equal(show_lwm2m_event_fake.call_count, 2,
+		      "Should not enter any other state and throw an event");
+}

--- a/tests/net/lib/lwm2m/lwm2m_rd_client/src/stubs.c
+++ b/tests/net/lib/lwm2m/lwm2m_rd_client/src/stubs.c
@@ -64,12 +64,26 @@ int lwm2m_get_bool_fake_default(const struct lwm2m_obj_path *path, bool *value)
 
 /* subsys/net/lib/lwm2m/lwm2m_engine.h */
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_socket_start, struct lwm2m_ctx *);
+int lwm2m_socket_start_fake_fail(struct lwm2m_ctx *client_ctx)
+{
+	return -1;
+}
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_socket_close, struct lwm2m_ctx *);
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_close_socket, struct lwm2m_ctx *);
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_security_inst_id_to_index, uint16_t);
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_engine_connection_resume, struct lwm2m_ctx *);
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_push_queued_buffers, struct lwm2m_ctx *);
 DEFINE_FAKE_VOID_FUNC(lwm2m_engine_context_init, struct lwm2m_ctx *);
+struct lwm2m_ctx *client_ctx_fake;
+void lwm2m_engine_context_init_fake1(struct lwm2m_ctx *client_ctx)
+{
+	client_ctx_fake = client_ctx;
+}
+void test_throw_network_error_from_engine(int err)
+{
+	client_ctx_fake->fault_cb(err);
+}
+
 DEFINE_FAKE_VOID_FUNC(lwm2m_engine_context_close, struct lwm2m_ctx *);
 DEFINE_FAKE_VALUE_FUNC(char *, lwm2m_sprint_ip_addr, const struct sockaddr *);
 char *lwm2m_sprint_ip_addr_fake_default(const struct sockaddr *addr)

--- a/tests/net/lib/lwm2m/lwm2m_rd_client/src/stubs.h
+++ b/tests/net/lib/lwm2m/lwm2m_rd_client/src/stubs.h
@@ -49,12 +49,15 @@ int lwm2m_get_bool_fake_default(const struct lwm2m_obj_path *path, bool *value);
 
 /* subsys/net/lib/lwm2m/lwm2m_engine.h */
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_socket_start, struct lwm2m_ctx *);
+int lwm2m_socket_start_fake_fail(struct lwm2m_ctx *client_ctx);
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_socket_close, struct lwm2m_ctx *);
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_close_socket, struct lwm2m_ctx *);
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_security_inst_id_to_index, uint16_t);
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_engine_connection_resume, struct lwm2m_ctx *);
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_push_queued_buffers, struct lwm2m_ctx *);
 DECLARE_FAKE_VOID_FUNC(lwm2m_engine_context_init, struct lwm2m_ctx *);
+void lwm2m_engine_context_init_fake1(struct lwm2m_ctx *client_ctx);
+void test_throw_network_error_from_engine(int err);
 DECLARE_FAKE_VOID_FUNC(lwm2m_engine_context_close, struct lwm2m_ctx *);
 DECLARE_FAKE_VALUE_FUNC(char *, lwm2m_sprint_ip_addr, const struct sockaddr *);
 char *lwm2m_sprint_ip_addr_fake_default(const struct sockaddr *addr);


### PR DESCRIPTION
This PR is repeated to https://github.com/zephyrproject-rtos/zephyr/pull/53476

This tests fails due to a bug in RDClient. I have opened an issue for that

[If the rdclient is suspended or deregistered any network errors caused
by lwm2m_engine and forwarded by socket_fault handler should not change
the rd client state.](https://github.com/zephyrproject-rtos/zephyr/issues/54136)