### PR TITLE
samples: canbus: isotp: add missing call to can_start()

### DIFF
--- a/samples/subsys/canbus/isotp/src/main.c
+++ b/samples/subsys/canbus/isotp/src/main.c
@@ -154,6 +154,12 @@ void main(void)
 		return;
 	}
 
+	ret = can_start(can_dev);
+	if (ret != 0) {
+		printk("CAN: Failed to start device [%d]\n", ret);
+		return;
+	}
+
 	tid = k_thread_create(&rx_8_0_thread_data, rx_8_0_thread_stack,
 			      K_THREAD_STACK_SIZEOF(rx_8_0_thread_stack),
 			      rx_8_0_thread, NULL, NULL, NULL,


### PR DESCRIPTION
Add missing call to can_start().

Fixes: #54078

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>