### PR TITLE
net: websockets: Fix websocket close procedure

### DIFF
--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -419,6 +419,12 @@ static int websocket_interal_disconnect(struct websocket_context *ctx)
 
 	NET_DBG("[%p] Disconnecting", ctx);
 
+	ret = websocket_send_msg(ctx->sock, NULL, 0, WEBSOCKET_OPCODE_CLOSE,
+				 true, true, SYS_FOREVER_MS);
+	if (ret < 0) {
+		NET_ERR("[%p] Failed to send close message (err %d).", ctx, ret);
+	}
+
 	ret = close(ctx->real_sock);
 
 	websocket_context_unref(ctx);

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -505,6 +505,10 @@ static int websocket_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 		return websocket_poll_offload(fds, nfds, timeout);
 	}
 
+	case ZFD_IOCTL_SET_LOCK:
+		/* Ignore, don't want to overwrite underlying socket lock. */
+		return 0;
+
 	default: {
 		const struct fd_op_vtable *vtable;
 		void *core_obj;


### PR DESCRIPTION
The websocket implementation did not comply with the RFC 6455 when it
comes to connection close. The websocket should send in such case Close
control frame, and wait for the reply, before closing the underlying TCP
connection. This commit fixes this behaviour.

Additionally, fix a small mutext-related bug with websockets.

Fixes #53942