### PR TITLE
drivers: mm: Add module to track page usage within specific memory banks

### DIFF
--- a/drivers/mm/CMakeLists.txt
+++ b/drivers/mm/CMakeLists.txt
@@ -3,7 +3,7 @@
 zephyr_library()
 
 zephyr_include_directories(${ZEPHYR_BASE}/drivers)
-zephyr_library_sources(mm_drv_common.c)
+zephyr_library_sources(mm_drv_common.c mm_drv_bank.c)
 
 zephyr_library_sources_ifdef(
 	CONFIG_MM_DRV_INTEL_ADSP_TLB

--- a/drivers/mm/mm_drv_bank.c
+++ b/drivers/mm/mm_drv_bank.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Module for tracking page use within memory banks
+ *
+ * The memory management drivers may use the routines within this module
+ * to track page use within their memory banks. This information in turn
+ * could be leveraged by them to determine when to power them on or off to
+ * better conserve energy.
+ */
+
+#include <zephyr/kernel.h>
+
+#include <zephyr/drivers/mm/mm_drv_bank.h>
+#include <zephyr/sys/mem_stats.h>
+
+void sys_mm_drv_bank_init(struct mem_drv_bank *bank, uint32_t bank_pages)
+{
+	bank->unmapped_pages = bank_pages;
+	bank->mapped_pages = 0;
+	bank->max_mapped_pages = 0;
+}
+
+uint32_t sys_mm_drv_bank_page_mapped(struct mem_drv_bank *bank)
+{
+	bank->unmapped_pages--;
+	bank->mapped_pages++;
+	if (bank->mapped_pages > bank->max_mapped_pages) {
+		bank->max_mapped_pages = bank->mapped_pages;
+	}
+	return bank->mapped_pages;
+}
+
+uint32_t sys_mm_drv_bank_page_unmapped(struct mem_drv_bank *bank)
+{
+	bank->unmapped_pages++;
+	bank->mapped_pages--;
+
+	return bank->unmapped_pages;
+}
+
+void sys_mm_drv_bank_stats_get(struct mem_drv_bank *bank,
+			       struct sys_memory_stats *stats)
+{
+	stats->free_bytes          = bank->unmapped_pages *
+				     CONFIG_MM_DRV_PAGE_SIZE;
+	stats->allocated_bytes     = bank->mapped_pages *
+				     CONFIG_MM_DRV_PAGE_SIZE;
+	stats->max_allocated_bytes = bank->max_mapped_pages *
+				     CONFIG_MM_DRV_PAGE_SIZE;
+}
+
+void sys_mm_drv_bank_stats_reset_max(struct mem_drv_bank *bank)
+{
+	bank->max_mapped_pages = bank->mapped_pages;
+}

--- a/include/zephyr/drivers/mm/mm_drv_bank.h
+++ b/include/zephyr/drivers/mm/mm_drv_bank.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Memory Banks Driver APIs
+ *
+ * This contains generic APIs to be used by a system-wide memory management
+ * driver to track page usage within memory banks. It is incumbent upon the
+ * caller to ensure that proper locking is used to protect the data when
+ * using these APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_KERNEL_H
+#define ZEPHYR_INCLUDE_KERNEL_H
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/mem_stats.h>
+#include <stdint.h>
+
+struct mem_drv_bank {
+	uint32_t  unmapped_pages;
+	uint32_t  mapped_pages;
+	uint32_t  max_mapped_pages;
+};
+
+/**
+ * @brief Initialize a memory bank's data structure
+ *
+ * The driver may wish to track various information about the memory banks
+ * that it uses. This routine will initialize a generic structure containing
+ * that information.
+ *
+ * @param bank Pointer to the memory bank structure used for tracking
+ * @param bank_pages Number of pages in the memory bank
+ */
+void sys_mm_drv_bank_init(struct mem_drv_bank *bank, uint32_t bank_pages);
+
+/**
+ * @brief Track the mapping of a page in the specified memory bank
+ *
+ * This function is used to update the number of mapped pages within the
+ * specified memory bank.
+ *
+ * @param bank Pointer to the memory bank's data structure
+ *
+ * @return The number of pages mapped within the memory bank
+ */
+uint32_t sys_mm_drv_bank_page_mapped(struct mem_drv_bank *bank);
+
+/**
+ * @brief Track the unmapping of a page in the specified memory bank
+ *
+ * This function is used to update the number of unmapped pages within the
+ * specified memory bank.
+ *
+ * @param bank Pointer to the memory bank's data structure
+ *
+ * @return The number of unmapped pages within the memory bank
+ */
+uint32_t sys_mm_drv_bank_page_unmapped(struct mem_drv_bank *bank);
+
+/**
+ * @brief Reset the max number of pages mapped in the bank
+ *
+ * This routine is used to reset the maximum number of pages mapped in
+ * the specified memory bank to the current number of pages mapped in
+ * that memory bank.
+ *
+ * @param bank Pointer to the memory bank's data structure
+ */
+void sys_mm_drv_bank_stats_reset_max(struct mem_drv_bank *bank);
+
+/**
+ * @brief Retrieve the memory usage stats for the specified memory bank
+ *
+ * This routine extracts the system memory stats from the memory bank.
+ *
+ * @param bank Pointer to the memory bank's data structure
+ * @param stats Pointer to memory into which to copy the system memory stats
+ */
+void sys_mm_drv_bank_stats_get(struct mem_drv_bank *bank,
+			       struct sys_memory_stats *stats);
+
+#endif /* ZEPHYR_INCLUDE_KERNEL_H */


### PR DESCRIPTION
This set of commits does two things.

1. It adds a module to track page usage with specific memory banks used by a memory management (MM) driver. This can subsequently allow a MM driver to power up or power down individual memory banks.
2. It updates the mm_drv_intel_adsp_mtl_tlb MM driver to make use of this generic module instead of relying upon a custom implementation.