### PR TITLE
drivers: timer: get mtime cmp reg by reading mhartid

### DIFF
--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -67,7 +67,7 @@ const int32_t z_sys_timer_irq_for_test = TIMER_IRQN;
 
 static uint64_t get_hart_mtimecmp(void)
 {
-	return MTIMECMP_REG + (_current_cpu->id * 8);
+	return MTIMECMP_REG + (arch_proc_id() * 8);
 }
 
 static void set_mtimecmp(uint64_t time)


### PR DESCRIPTION
It is not guaranteed that a multi-core RISC-V hart numbering scheme will match Zephyr's sequential cpu numbering scheme. Read the hartid and use that value in calculation to get mtime_cmp reg, instead of the current_cpu id.

Signed-off-by: Conor Paxton <conor.paxton@microchip.com>