### PR TITLE
net: sockets: Fix TLS_HOSTNAME option length inconsistency

### DIFF
--- a/doc/connectivity/networking/api/sockets.rst
+++ b/doc/connectivity/networking/api/sockets.rst
@@ -128,7 +128,7 @@ CA certificate and hostname can be set:
 
    char host[] = "google.com";
 
-   ret = setsockopt(sock, SOL_TLS, TLS_HOSTNAME, host, sizeof(host) - 1);
+   ret = setsockopt(sock, SOL_TLS, TLS_HOSTNAME, host, sizeof(host));
 
 Once configured, socket can be used just like a regular TCP socket.
 

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
@@ -72,7 +72,7 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 	if (tls_config->hostname) {
 		ret = zsock_setsockopt(client->transport.tls.sock, SOL_TLS,
 				       TLS_HOSTNAME, tls_config->hostname,
-				       strlen(tls_config->hostname));
+				       strlen(tls_config->hostname) + 1);
 		if (ret < 0) {
 			goto error;
 		}


### PR DESCRIPTION
The TLS_HOSTNAME socket option expects a NULL terminated string and doesn't really care about the optlen provided. However, as the option expects that the string is NULL terminated, the optlen value should take NULL character into account, for consistency across the codebase.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>