### PR TITLE
boards: arm: mimxrtxxx: fixup MCUBoot support

### DIFF
--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -353,13 +353,7 @@ zephyr_udc0: &usbhs {
 		status = "okay";
 		jedec-id = [c2 81 3a];
 		erase-block-size = <4096>;
-		/*
-		 * Note- ECC will be disabled with a
-		 * write block size of 1 byte. To enable ECC, ensure
-		 * writes are in multiples of 16 bytes. This reduced
-		 * block size is required for MCUBoot support.
-		 */
-		write-block-size = <1>;
+		write-block-size = <16>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -368,23 +362,19 @@ zephyr_udc0: &usbhs {
 
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(64)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			slot0_partition: partition@10000 {
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00010000 DT_SIZE_M(24)>;
+				reg = <0x00020000 DT_SIZE_K(3076)>;
 			};
-			slot1_partition: partition@1810000 {
+			slot1_partition: partition@321000 {
 				label = "image-1";
-				reg = <0x01810000 DT_SIZE_M(24)>;
+				reg = <0x00321000 DT_SIZE_K(3072)>;
 			};
-			scratch_partition: partition@3010000 {
-				label = "image-scratch";
-				reg = <0x03010000 DT_SIZE_K(8128)>;
-			};
-			storage_partition: partition@3f00000 {
+			storage_partition: partition@621000 {
 				label = "storage";
-				reg = <0x03f00000 DT_SIZE_M(1)>;
+				reg = <0x00621000 DT_SIZE_M(57)>;
 			};
 		};
 	};

--- a/boards/arm/mimxrt685_evk/init.c
+++ b/boards/arm/mimxrt685_evk/init.c
@@ -43,6 +43,19 @@ static int mimxrt685_evk_init(const struct device *dev)
 #endif
 
 #endif
+
+#ifdef CONFIG_REBOOT
+	/*
+	 * The sys_reboot API calls NVIC_SystemReset. On the RT685, the warm
+	 * reset will not complete correctly unless the ROM toggles the
+	 * flash reset pin. We can control this behavior using the OTP shadow
+	 * register for OPT word BOOT_CFG1
+	 *
+	 * Set FLEXSPI_RESET_PIN_ENABLE=1, FLEXSPI_RESET_PIN= PIO2_12
+	 */
+	 OCOTP->OTP_SHADOW[97] = 0x314000;
+#endif /* CONFIG_REBOOT */
+
 	return 0;
 }
 

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -265,13 +265,7 @@ i2s1: &flexcomm3 {
 		status = "okay";
 		jedec-id = [c2 81 3a];
 		erase-block-size = <4096>;
-		/*
-		 * Note- ECC will be disabled with a
-		 * write block size of 1 byte. To enable ECC, ensure
-		 * writes are in multiples of 16 bytes. This reduced
-		 * block size is required for MCUBoot support.
-		 */
-		write-block-size = <1>;
+		write-block-size = <16>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -280,23 +274,19 @@ i2s1: &flexcomm3 {
 
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(64)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			slot0_partition: partition@10000 {
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00010000 DT_SIZE_M(24)>;
+				reg = <0x00020000 DT_SIZE_K(3076)>;
 			};
-			slot1_partition: partition@1810000 {
+			slot1_partition: partition@321000 {
 				label = "image-1";
-				reg = <0x01810000 DT_SIZE_M(24)>;
+				reg = <0x00321000 DT_SIZE_K(3072)>;
 			};
-			scratch_partition: partition@3010000 {
-				label = "image-scratch";
-				reg = <0x03010000 DT_SIZE_K(8128)>;
-			};
-			storage_partition: partition@3f00000 {
+			storage_partition: partition@621000 {
 				label = "storage";
-				reg = <0x03f00000 DT_SIZE_M(1)>;
+				reg = <0x00621000 DT_SIZE_M(57)>;
 			};
 		};
 	};

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -88,9 +88,10 @@ const clock_frg_clk_config_t g_frg12Config_clock_init = {
 
 /* System clock frequency. */
 extern uint32_t SystemCoreClock;
+/* Main stack pointer */
+extern char z_main_stack[];
 
 #ifdef CONFIG_NXP_IMX_RT5XX_BOOT_HEADER
-extern char z_main_stack[];
 extern char _flash_used[];
 
 extern void z_arm_reset(void);
@@ -198,6 +199,21 @@ static void usb_device_clock_init(void)
 
 void z_arm_platform_init(void)
 {
+#ifndef CONFIG_NXP_IMX_RT5XX_BOOT_HEADER
+	/*
+	 * If boot did not proceed using a boot header, we should not assume
+	 * the core is in reset state. Disable the MPU and correctly
+	 * set the stack pointer, since we are about to push to
+	 * the stack when we call SystemInit
+	 */
+	 /* Clear stack limit registers */
+	 __set_MSPLIM(0);
+	 __set_PSPLIM(0);
+	/* Disable MPU */
+	 MPU->CTRL &= ~MPU_CTRL_ENABLE_Msk;
+	 /* Set stack pointer */
+	 __set_MSP((uint32_t)(z_main_stack + CONFIG_MAIN_STACK_SIZE));
+#endif /* !CONFIG_NXP_IMX_RT5XX_BOOT_HEADER */
 	/* This is provided by the SDK */
 	SystemInit();
 }


### PR DESCRIPTION
Both the RT6xx and RT5xx previously were using a non-optimal write alignment size to support MCUboot. Now that MCUboot supports 16 byte aligned writes, fix up the flash partition definitions and write alignments. Flash partition sizes are reduced due to excessively long upgrade times when using the entire flash region.

Additionally, the following extra patches are present in this PR:
- clean up the ARM core on reset for the RT5xx. This is required when booting from a bootloader, as the MPU has not been disabled when SystemInit is called, and the stack utilization will trigger a fault.
- set OTP shadow register to enable warm resets on RT6xx. While not required for MCUboot support, this fix enables the `sys_reboot` API to function, which simplifies testing of MCUBoot.