### PR TITLE
Bluetooth: Audio: Add presentation delay value macros

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -32,6 +32,10 @@ extern "C" {
 #endif
 
 #define BT_AUDIO_BROADCAST_ID_SIZE               3 /* octets */
+/** Indicates that the server have no preference for the presentation delay */
+#define BT_AUDIO_PD_PREF_NONE                    0x000000U
+/** Maximum presentation delay in microseconds */
+#define BT_AUDIO_PD_MAX                          0xFFFFFFU
 
 /** @brief Audio Context Type for Generic Audio
  *
@@ -452,7 +456,11 @@ struct bt_codec_qos {
 
 	/** QoS Frame Interval */
 	uint32_t interval;
-	/** QoS Presentation Delay */
+
+	/** @brief QoS Presentation Delay in microseconds
+	 *
+	 *  Value range 0 to @ref BT_AUDIO_PD_MAX.
+	 */
 	uint32_t pd;
 };
 
@@ -499,10 +507,13 @@ struct bt_codec_qos_pref {
 	/** Preferred Transport Latency */
 	uint16_t latency;
 
-	/** @brief Minimum Presentation Delay
+	/** @brief Minimum Presentation Delay in microseconds
 	 *
 	 *  Unlike the other fields, this is not a preference but a minimum
 	 *  requirement.
+	 *
+	 *  Value range 0 to @ref BT_AUDIO_PD_MAX, or @ref BT_AUDIO_PD_PREF_NONE
+	 *  to indicate no preference.
 	 */
 	uint32_t pd_min;
 
@@ -510,13 +521,22 @@ struct bt_codec_qos_pref {
 	 *
 	 *  Unlike the other fields, this is not a preference but a maximum
 	 *  requirement.
+	 *
+	 *  Value range 0 to @ref BT_AUDIO_PD_MAX, or @ref BT_AUDIO_PD_PREF_NONE
+	 *  to indicate no preference.
 	 */
 	uint32_t pd_max;
 
-	/** @brief Preferred minimum Presentation Delay */
+	/** @brief Preferred minimum Presentation Delay
+	 *
+	 *  Value range 0 to @ref BT_AUDIO_PD_MAX.
+	 */
 	uint32_t pref_pd_min;
 
-	/** @brief Preferred maximum Presentation Delay	*/
+	/** @brief Preferred maximum Presentation Delay
+	 *
+	 *  Value range 0 to @ref BT_AUDIO_PD_MAX.
+	 */
 	uint32_t pref_pd_max;
 };
 


### PR DESCRIPTION
Add BT_AUDIO_PD_MAX and BT_AUDIO_PD_PREF_NONE to
better define the value range (and unit) of the
presentation delay.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>