### PR TITLE
drivers: ieee802154_nrf5: Fix warning in ISR prototype

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -723,7 +723,7 @@ static int nrf5_stop(const struct device *dev)
 }
 
 #if !IS_ENABLED(CONFIG_IEEE802154_NRF5_EXT_IRQ_MGMT)
-static void nrf5_radio_irq(void *arg)
+static void nrf5_radio_irq(const void *arg)
 {
 	ARG_UNUSED(arg);
 


### PR DESCRIPTION
The ISR prototype was changed some time ago
(6df8b3995e05d6348f8de9601379475a5455fedd)
to (const void*) => fix the prototype used when
CONFIG_IEEE802154_NRF5_EXT_IRQ_MGMT is not set
to avoid a compile warning.

Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>