### PR TITLE
drivers: timer: added MTIMER_DIVIDER register initialization

### DIFF
--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -62,6 +62,15 @@
 #define MTIMECMP_REG	DT_INST_REG_ADDR(0)
 #define MTIME_REG	(DT_INST_REG_ADDR(0) + 8)
 #define TIMER_IRQN	DT_INST_IRQN(0)
+/* scr,machine-timer*/
+#elif DT_HAS_COMPAT_STATUS_OKAY(scr_machine_timer)
+#define DT_DRV_COMPAT scr_machine_timer
+#define MTIMER_HAS_DIVIDER
+
+#define MTIMEDIV_REG	(DT_INST_REG_ADDR(0) + 4)
+#define MTIME_REG	(DT_INST_REG_ADDR(0) + 8)
+#define MTIMECMP_REG	(DT_INST_REG_ADDR(0) + 16)
+#define TIMER_IRQN	DT_INST_IRQN(0)
 #endif
 
 #define CYC_PER_TICK (uint32_t)(sys_clock_hw_cycles_per_sec() \
@@ -100,6 +109,14 @@ static void set_mtimecmp(uint64_t time)
 	r[1] = 0xffffffff;
 	r[0] = (uint32_t)time;
 	r[1] = (uint32_t)(time >> 32);
+#endif
+}
+
+static void set_divider(void)
+{
+#ifdef MTIMER_HAS_DIVIDER
+	*(volatile uint32_t *)MTIMEDIV_REG =
+		CONFIG_RISCV_MACHINE_TIMER_SYSTEM_CLOCK_DIVIDER;
 #endif
 }
 
@@ -206,6 +223,8 @@ uint64_t sys_clock_cycle_get_64(void)
 static int sys_clock_driver_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
+
+	set_divider();
 
 	IRQ_CONNECT(TIMER_IRQN, 0, timer_isr, NULL, 0);
 	last_ticks = mtime() / CYC_PER_TICK;


### PR DESCRIPTION
Syntacore RISC-V platforms have dedicated MTIMER_DIVIDER register which
should be configured during the Timer initialization.

The configuration of dedicated MTIMER_DIVIDER register could now
be performed during initialization if its address is provided.

Signed-off-by: Alexander Razinkov <alexander.razinkov@syntacore.com>