### PR TITLE
west build --test-item improvement, twister synopsis

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -414,6 +414,30 @@ class Reporting:
             logger.warning("Deltas based on metrics from last %s" %
                            ("release" if not last_metrics else "run"))
 
+    def synopsis(self):
+        cnt = 0
+        instance = None
+        for instance in self.instances.values():
+            if instance.status not in ["passed", "filtered", "skipped"]:
+                cnt = cnt + 1
+                if cnt == 1:
+                    logger.info("-+" * 40)
+                    logger.info("The following issues were found (showing the top 10 items):")
+
+                logger.info(f"{cnt}) {instance.testsuite.name} on {instance.platform.name} {instance.status} ({instance.reason})")
+            if cnt == 10:
+                break
+
+        if cnt:
+            logger.info("")
+            logger.info("To rerun the tests, call twister using the following commandline:")
+            logger.info("./scripts/twister -p <PLATFORM> -s <TEST PATH>, for example:")
+            logger.info("")
+            logger.info(f"./scripts/twister -p {instance.platform.name} -s {instance.testsuite.name}")
+            logger.info(f"or with west:")
+            logger.info(f"west build -b {instance.platform.name} -T {instance.testsuite.name}")
+            logger.info("-+" * 40)
+
     def summary(self, results, unrecognized_sections, duration):
         failed = 0
         run = 0

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -223,6 +223,8 @@ def main(options):
         options.platform_reports,
     )
 
+    report.synopsis()
+
     if options.package_artifacts:
         artifacts = Artifacts(env)
         artifacts.package()

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -156,7 +156,12 @@ class Build(Forceable):
         self._parse_remainder(remainder)
         # Parse testcase.yaml or sample.yaml files for additional options.
         if self.args.test_item:
-            if not self._parse_test_item():
+            # we get path + testitem
+            item = os.path.basename(self.args.test_item)
+            test_path = os.path.dirname(self.args.test_item)
+            if test_path:
+                self.args.source_dir = test_path
+            if not self._parse_test_item(item):
                 log.die("No test metadata found")
         if source_dir:
             if self.args.source_dir:
@@ -246,7 +251,7 @@ class Build(Forceable):
         except IndexError:
             return
 
-    def _parse_test_item(self):
+    def _parse_test_item(self, test_item):
         found_test_metadata = False
         for yp in ['sample.yaml', 'testcase.yaml']:
             yf = os.path.join(self.args.source_dir, yp)
@@ -261,9 +266,9 @@ class Build(Forceable):
             tests = y.get('tests')
             if not tests:
                 log.die(f"No tests found in {yf}")
-            item = tests.get(self.args.test_item)
+            item = tests.get(test_item)
             if not item:
-                log.die(f"Test item {self.args.test_item} not found in {yf}")
+                log.die(f"Test item {test_item} not found in {yf}")
 
             for data in ['extra_args', 'extra_configs']:
                 extra = item.get(data)


### PR DESCRIPTION
Provide brief summary about failed tests at the end and instructions on how to reporduce them using twister or west.

- west: build: handler errors in west build with --test-item
- west: build: allow --test-item to accept twister style instance names
- twister: print synopsis at the end and instruction for reproducing

Fixes #52614
