### PR TITLE
LE Audio shell strtoX fixes

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -32,6 +32,8 @@ extern "C" {
 #endif
 
 #define BT_AUDIO_BROADCAST_ID_SIZE               3 /* octets */
+/** Maximum broadcast ID value */
+#define BT_AUDIO_BROADCAST_ID_MAX                0xFFFFFFU
 /** Indicates that the server have no preference for the presentation delay */
 #define BT_AUDIO_PD_PREF_NONE                    0x000000U
 /** Maximum presentation delay in microseconds */

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -32,6 +32,10 @@ extern "C" {
 #endif
 
 #define BT_AUDIO_BROADCAST_ID_SIZE               3 /* octets */
+/** Indicates that the server have no preference for the presentation delay */
+#define BT_AUDIO_PD_PREF_NONE                    0x000000U
+/** Maximum presentation delay in microseconds */
+#define BT_AUDIO_PD_MAX                          0xFFFFFFU
 
 /** @brief Audio Context Type for Generic Audio
  *
@@ -452,7 +456,11 @@ struct bt_codec_qos {
 
 	/** QoS Frame Interval */
 	uint32_t interval;
-	/** QoS Presentation Delay */
+
+	/** @brief QoS Presentation Delay in microseconds
+	 *
+	 *  Value range 0 to @ref BT_AUDIO_PD_MAX.
+	 */
 	uint32_t pd;
 };
 
@@ -499,10 +507,13 @@ struct bt_codec_qos_pref {
 	/** Preferred Transport Latency */
 	uint16_t latency;
 
-	/** @brief Minimum Presentation Delay
+	/** @brief Minimum Presentation Delay in microseconds
 	 *
 	 *  Unlike the other fields, this is not a preference but a minimum
 	 *  requirement.
+	 *
+	 *  Value range 0 to @ref BT_AUDIO_PD_MAX, or @ref BT_AUDIO_PD_PREF_NONE
+	 *  to indicate no preference.
 	 */
 	uint32_t pd_min;
 
@@ -510,13 +521,22 @@ struct bt_codec_qos_pref {
 	 *
 	 *  Unlike the other fields, this is not a preference but a maximum
 	 *  requirement.
+	 *
+	 *  Value range 0 to @ref BT_AUDIO_PD_MAX, or @ref BT_AUDIO_PD_PREF_NONE
+	 *  to indicate no preference.
 	 */
 	uint32_t pd_max;
 
-	/** @brief Preferred minimum Presentation Delay */
+	/** @brief Preferred minimum Presentation Delay
+	 *
+	 *  Value range 0 to @ref BT_AUDIO_PD_MAX.
+	 */
 	uint32_t pref_pd_min;
 
-	/** @brief Preferred maximum Presentation Delay	*/
+	/** @brief Preferred maximum Presentation Delay
+	 *
+	 *  Value range 0 to @ref BT_AUDIO_PD_MAX.
+	 */
 	uint32_t pref_pd_max;
 };
 

--- a/subsys/bluetooth/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/shell/bap_scan_delegator.c
@@ -67,36 +67,62 @@ static int cmd_bap_scan_delegator_init(const struct shell *sh, size_t argc,
 static int cmd_bap_scan_delegator_synced(const struct shell *sh, size_t argc,
 					 char **argv)
 {
-	int result;
-	long src_id;
-	long pa_sync_state;
-	long bis_synced;
-	long encrypted;
 	uint32_t bis_syncs[CONFIG_BT_BAP_SCAN_DELEGATOR_MAX_SUBGROUPS];
+	unsigned long pa_sync_state;
+	unsigned long bis_synced;
+	unsigned long src_id;
+	bool encrypted;
+	int result = 0;
 
-	src_id = strtol(argv[1], NULL, 0);
-	if (src_id < 0 || src_id > UINT8_MAX) {
-		shell_error(sh, "adv_sid shall be 0x00-0xff");
+	src_id = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse src_id: %d", result);
+
 		return -ENOEXEC;
 	}
 
-	pa_sync_state = strtol(argv[2], NULL, 0);
-	if (pa_sync_state < 0 ||
-	    pa_sync_state > BT_BAP_PA_STATE_NO_PAST) {
+	if (src_id > UINT8_MAX) {
+		shell_error(sh, "Invalid src_id: %lu", src_id);
+
+		return -ENOEXEC;
+	}
+
+	pa_sync_state = shell_strtoul(argv[2], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse pa_sync_state: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (pa_sync_state > BT_BAP_PA_STATE_NO_PAST) {
 		shell_error(sh, "Invalid pa_sync_state %ld", pa_sync_state);
+
 		return -ENOEXEC;
 	}
 
-	bis_synced = strtol(argv[3], NULL, 0);
-	if (bis_synced < 0 || bis_synced > UINT32_MAX) {
-		shell_error(sh, "Invalid bis_synced %ld", bis_synced);
+	bis_synced = shell_strtoul(argv[3], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse bis_synced: %d", result);
+
 		return -ENOEXEC;
 	}
-	for (int i = 0; i < ARRAY_SIZE(bis_syncs); i++) {
+
+	if (bis_synced > UINT32_MAX) {
+		shell_error(sh, "Invalid bis_synced %ld", bis_synced);
+
+		return -ENOEXEC;
+	}
+
+	for (size_t i = 0U; i < ARRAY_SIZE(bis_syncs); i++) {
 		bis_syncs[i] = bis_synced;
 	}
 
-	encrypted = strtol(argv[4], NULL, 0);
+	encrypted = shell_strtobool(argv[4], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse encrypted: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	result = bt_bap_scan_delegator_set_sync_state(src_id, pa_sync_state,
 						      bis_syncs, encrypted);

--- a/subsys/bluetooth/shell/cap_acceptor.c
+++ b/subsys/bluetooth/shell/cap_acceptor.c
@@ -60,7 +60,6 @@ static struct bt_csip_set_member_cb csip_set_member_cbs = {
 static int cmd_cap_acceptor_init(const struct shell *sh, size_t argc,
 				 char **argv)
 {
-	int err;
 	struct bt_csip_set_member_register_param param = {
 		.set_size = 2,
 		.rank = 1,
@@ -70,20 +69,71 @@ static int cmd_cap_acceptor_init(const struct shell *sh, size_t argc,
 			      0x22, 0xfd, 0xa1, 0x21, 0x09, 0x7d, 0x7d, 0x45 },
 		.cb = &csip_set_member_cbs
 	};
+	int err = 0;
 
 	for (size_t argn = 1; argn < argc; argn++) {
 		const char *arg = argv[argn];
 
 		if (strcmp(arg, "size") == 0) {
-			param.set_size = strtol(argv[++argn], NULL, 10);
+			unsigned long set_size;
+
+			argn++;
+			if (argn == argc) {
+				shell_help(sh);
+				return SHELL_CMD_HELP_PRINTED;
+			}
+
+			set_size = shell_strtoul(argv[argn], 0, &err);
+			if (err != 0) {
+				shell_error(sh, "Could not parse set_size: %d",
+					    err);
+
+				return -ENOEXEC;
+			}
+
+			if (set_size > UINT8_MAX) {
+				shell_error(sh, "Invalid set_size: %lu",
+					    set_size);
+
+				return -ENOEXEC;
+			}
+
+			param.set_size = set_size;
 		} else if (strcmp(arg, "rank") == 0) {
-			param.rank = strtol(argv[++argn], NULL, 10);
+			unsigned long rank;
+
+			argn++;
+			if (argn == argc) {
+				shell_help(sh);
+				return SHELL_CMD_HELP_PRINTED;
+			}
+
+			rank = shell_strtoul(argv[argn], 0, &err);
+			if (err != 0) {
+				shell_error(sh, "Could not parse rank: %d",
+					    err);
+
+				return -ENOEXEC;
+			}
+
+			if (rank > UINT8_MAX) {
+				shell_error(sh, "Invalid rank: %lu", rank);
+
+				return -ENOEXEC;
+			}
+
+			param.rank = rank;
 		} else if (strcmp(arg, "not-lockable") == 0) {
 			param.lockable = false;
 		} else if (strcmp(arg, "sirk") == 0) {
 			size_t len;
 
 			argn++;
+			if (argn == argc) {
+				shell_help(sh);
+				return SHELL_CMD_HELP_PRINTED;
+			}
+
 			len = hex2bin(argv[argn], strlen(argv[argn]),
 				      param.set_sirk, sizeof(param.set_sirk));
 			if (len == 0) {

--- a/subsys/bluetooth/shell/csip_set_coordinator.c
+++ b/subsys/bluetooth/shell/csip_set_coordinator.c
@@ -233,9 +233,9 @@ static void discover_members_timer_handler(struct k_work *work)
 static int cmd_csip_set_coordinator_discover(const struct shell *sh,
 					     size_t argc, char *argv[])
 {
+	unsigned long member_index = 0U;
 	char addr[BT_ADDR_LE_STR_LEN];
 	static bool initialized;
-	long member_index = 0;
 	struct bt_conn *conn;
 	int err;
 
@@ -247,11 +247,18 @@ static int cmd_csip_set_coordinator_discover(const struct shell *sh,
 	}
 
 	if (argc > 1) {
-		member_index = strtol(argv[1], NULL, 0);
+		member_index = shell_strtoul(argv[1], 0, &err);
+		if (err != 0) {
+			shell_error(sh, "Could not parse member_index: %d",
+				    err);
 
-		if (member_index < 0 || member_index > ARRAY_SIZE(conns)) {
-			shell_error(sh, "Invalid member_index %ld",
+			return -ENOEXEC;
+		}
+
+		if (member_index > ARRAY_SIZE(conns)) {
+			shell_error(sh, "Invalid member_index: %lu",
 				    member_index);
+
 			return -ENOEXEC;
 		}
 	}
@@ -376,15 +383,22 @@ static int cmd_csip_set_coordinator_ordered_access(const struct shell *sh,
 						   size_t argc, char *argv[])
 {
 	int err;
-	long member_count = (long)ARRAY_SIZE(set_members);
+	unsigned long member_count = (unsigned long)ARRAY_SIZE(set_members);
 	const struct bt_csip_set_coordinator_set_member *members[ARRAY_SIZE(set_members)];
 
 	if (argc > 1) {
-		member_count = strtol(argv[1], NULL, 0);
+		member_count = shell_strtoul(argv[1], 0, &err);
+		if (err != 0) {
+			shell_error(sh, "Could not parse member_count: %d",
+				    err);
 
-		if (member_count < 0 || member_count > ARRAY_SIZE(members)) {
-			shell_error(sh, "Invalid member count %ld",
+			return -ENOEXEC;
+		}
+
+		if (member_count > ARRAY_SIZE(members)) {
+			shell_error(sh, "Invalid member_count: %lu",
 				    member_count);
+
 			return -ENOEXEC;
 		}
 	}
@@ -408,7 +422,7 @@ static int cmd_csip_set_coordinator_lock(const struct shell *sh, size_t argc,
 					 char *argv[])
 {
 	int err;
-	long member_index = 0;
+	unsigned long member_index = 0;
 	const struct bt_csip_set_coordinator_set_member *lock_member[1];
 
 	if (cur_inst == NULL) {
@@ -417,12 +431,18 @@ static int cmd_csip_set_coordinator_lock(const struct shell *sh, size_t argc,
 	}
 
 	if (argc > 1) {
-		member_index = strtol(argv[1], NULL, 0);
+		member_index = shell_strtoul(argv[1], 0, &err);
+		if (err != 0) {
+			shell_error(sh, "Could not parse member_index: %d",
+				    err);
 
-		if (member_index < 0 ||
-		    member_index > ARRAY_SIZE(set_members)) {
-			shell_error(sh, "Invalid member_index %ld",
+			return -ENOEXEC;
+		}
+
+		if (member_index > ARRAY_SIZE(set_members)) {
+			shell_error(sh, "Invalid member_index: %lu",
 				    member_index);
+
 			return -ENOEXEC;
 		}
 	}
@@ -441,7 +461,7 @@ static int cmd_csip_set_coordinator_release(const struct shell *sh, size_t argc,
 					    char *argv[])
 {
 	int err;
-	long member_index = 0;
+	unsigned long member_index = 0;
 	const struct bt_csip_set_coordinator_set_member *lock_member[1];
 
 	if (cur_inst == NULL) {
@@ -450,12 +470,18 @@ static int cmd_csip_set_coordinator_release(const struct shell *sh, size_t argc,
 	}
 
 	if (argc > 1) {
-		member_index = strtol(argv[1], NULL, 0);
+		member_index = shell_strtoul(argv[1], 0, &err);
+		if (err != 0) {
+			shell_error(sh, "Could not parse member_index: %d",
+				    err);
 
-		if (member_index < 0 ||
-		    member_index > ARRAY_SIZE(set_members)) {
-			shell_error(sh, "Invalid member_index %ld",
+			return -ENOEXEC;
+		}
+
+		if (member_index > ARRAY_SIZE(set_members)) {
+			shell_error(sh, "Invalid member_index: %lu",
 				    member_index);
+
 			return -ENOEXEC;
 		}
 	}

--- a/subsys/bluetooth/shell/csip_set_member.c
+++ b/subsys/bluetooth/shell/csip_set_member.c
@@ -76,17 +76,66 @@ static int cm_csip_set_member_register(const struct shell *sh, size_t argc, char
 
 	for (size_t argn = 1; argn < argc; argn++) {
 		const char *arg = argv[argn];
-
 		if (strcmp(arg, "size") == 0) {
-			param.set_size = strtol(argv[++argn], NULL, 10);
+			unsigned long set_size;
+
+			argn++;
+			if (argn == argc) {
+				shell_help(sh);
+				return SHELL_CMD_HELP_PRINTED;
+			}
+
+			set_size = shell_strtoul(argv[argn], 0, &err);
+			if (err != 0) {
+				shell_error(sh, "Could not parse set_size: %d",
+					    err);
+
+				return -ENOEXEC;
+			}
+
+			if (set_size > UINT8_MAX) {
+				shell_error(sh, "Invalid set_size: %lu",
+					    set_size);
+
+				return -ENOEXEC;
+			}
+
+			param.set_size = set_size;
 		} else if (strcmp(arg, "rank") == 0) {
-			param.rank = strtol(argv[++argn], NULL, 10);
+			unsigned long rank;
+
+			argn++;
+			if (argn == argc) {
+				shell_help(sh);
+				return SHELL_CMD_HELP_PRINTED;
+			}
+
+			rank = shell_strtoul(argv[argn], 0, &err);
+			if (err != 0) {
+				shell_error(sh, "Could not parse rank: %d",
+					    err);
+
+				return -ENOEXEC;
+			}
+
+			if (rank > UINT8_MAX) {
+				shell_error(sh, "Invalid rank: %lu", rank);
+
+				return -ENOEXEC;
+			}
+
+			param.rank = rank;
 		} else if (strcmp(arg, "not-lockable") == 0) {
 			param.lockable = false;
 		} else if (strcmp(arg, "sirk") == 0) {
 			size_t len;
 
 			argn++;
+			if (argn == argc) {
+				shell_help(sh);
+				return SHELL_CMD_HELP_PRINTED;
+			}
+
 			len = hex2bin(argv[argn], strlen(argv[argn]),
 				      param.set_sirk, sizeof(param.set_sirk));
 			if (len == 0) {

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -160,58 +160,174 @@ static int cmd_cig_create(const struct shell *sh, size_t argc, char *argv[])
 		}
 	}
 
+	err = 0;
 	if (argc > 2) {
-		param.interval = strtol(argv[2], NULL, 0);
+		unsigned long interval;
+
+		interval = shell_strtoul(argv[2], 0, &err);
+		if (err != 0) {
+			shell_error(sh, "Could not parse interval: %d", err);
+
+			return -ENOEXEC;
+		}
+
+		if (!IN_RANGE(interval,
+			      BT_ISO_SDU_INTERVAL_MIN,
+			      BT_ISO_SDU_INTERVAL_MAX)) {
+			shell_error(sh, "Invalid interval %lu", interval);
+
+			return -ENOEXEC;
+		}
+
+		param.interval = interval;
 	} else {
 		param.interval = 10000;
 	}
 	cis_sdu_interval_us = param.interval;
 
 	if (argc > 3) {
-		param.packing = strtol(argv[3], NULL, 0);
+		unsigned long packing;
+
+		packing = shell_strtoul(argv[3], 0, &err);
+		if (err != 0) {
+			shell_error(sh, "Could not parse packing: %d", err);
+
+			return -ENOEXEC;
+		}
+
+		if (!IN_RANGE(packing,
+			      BT_ISO_PACKING_SEQUENTIAL,
+			      BT_ISO_PACKING_INTERLEAVED)) {
+			shell_error(sh, "Invalid packing %lu", packing);
+
+			return -ENOEXEC;
+		}
+
+		param.packing = packing;
 	} else {
 		param.packing = 0;
 	}
 
 	if (argc > 4) {
-		param.framing = strtol(argv[4], NULL, 0);
+		unsigned long framing;
+
+		framing = shell_strtoul(argv[4], 0, &err);
+		if (err != 0) {
+			shell_error(sh, "Could not parse framing: %d", err);
+
+			return -ENOEXEC;
+		}
+
+		if (!IN_RANGE(framing,
+			      BT_ISO_FRAMING_UNFRAMED,
+			      BT_ISO_FRAMING_FRAMED)) {
+			shell_error(sh, "Invalid framing %lu", framing);
+
+			return -ENOEXEC;
+		}
+
+		param.framing = framing;
 	} else {
 		param.framing = 0;
 	}
 
 	if (argc > 5) {
-		param.latency = strtol(argv[5], NULL, 0);
+		unsigned long latency;
+
+		latency = shell_strtoul(argv[5], 0, &err);
+		if (err != 0) {
+			shell_error(sh, "Could not parse latency: %d", err);
+
+			return -ENOEXEC;
+		}
+
+		if (!IN_RANGE(latency,
+			      BT_ISO_LATENCY_MIN,
+			      BT_ISO_LATENCY_MAX)) {
+			shell_error(sh, "Invalid latency %lu", latency);
+
+			return -ENOEXEC;
+		}
+
+		param.latency = latency;
 	} else {
 		param.latency = 10;
 	}
 
 	if (argc > 6) {
+		unsigned long sdu;
+
+		sdu = shell_strtoul(argv[6], 0, &err);
+		if (err != 0) {
+			shell_error(sh, "Could not parse sdu: %d", err);
+
+			return -ENOEXEC;
+		}
+
+		if (sdu > BT_ISO_MAX_SDU) {
+			shell_error(sh, "Invalid sdu %lu", sdu);
+
+			return -ENOEXEC;
+		}
+
 		if (chans[0]->qos->tx) {
-			chans[0]->qos->tx->sdu = strtol(argv[6], NULL, 0);
+			chans[0]->qos->tx->sdu = sdu;
 		}
 
 		if (chans[0]->qos->rx) {
-			chans[0]->qos->rx->sdu = strtol(argv[6], NULL, 0);
+			chans[0]->qos->rx->sdu = sdu;
 		}
 	}
 
 	if (argc > 7) {
+		unsigned long phy;
+
+		phy = shell_strtoul(argv[7], 0, &err);
+		if (err != 0) {
+			shell_error(sh, "Could not parse phy: %d", err);
+
+			return -ENOEXEC;
+		}
+
+		if (phy != BT_GAP_LE_PHY_1M &&
+		    phy != BT_GAP_LE_PHY_2M &&
+		    phy != BT_GAP_LE_PHY_CODED) {
+			shell_error(sh, "Invalid phy %lu", phy);
+
+			return -ENOEXEC;
+		}
+
 		if (chans[0]->qos->tx) {
-			chans[0]->qos->tx->phy = strtol(argv[7], NULL, 0);
+			chans[0]->qos->tx->phy = phy;
 		}
 
 		if (chans[0]->qos->rx) {
-			chans[0]->qos->rx->phy = strtol(argv[7], NULL, 0);
+			chans[0]->qos->rx->phy = phy;
 		}
 	}
 
 	if (argc > 8) {
+		unsigned long rtn;
+
+		rtn = shell_strtoul(argv[8], 0, &err);
+		if (err != 0) {
+			shell_error(sh, "Could not parse rtn: %d", err);
+
+			return -ENOEXEC;
+		}
+
+		if (rtn > BT_ISO_CONNECTED_RTN_MAX) {
+			shell_error(sh, "Invalid rtn %lu", rtn);
+
+			return -ENOEXEC;
+		}
+
 		if (chans[0]->qos->tx) {
-			chans[0]->qos->tx->rtn = strtol(argv[8], NULL, 0);
+			chans[0]->qos->tx->rtn = rtn;
 		}
 
 		if (chans[0]->qos->rx) {
-			chans[0]->qos->rx->rtn = strtol(argv[8], NULL, 0);
+			chans[0]->qos->rx->rtn = rtn;
 		}
 	}
 
@@ -361,11 +477,18 @@ static int cmd_send(const struct shell *sh, size_t argc, char *argv[])
 	static uint8_t buf_data[CONFIG_BT_ISO_TX_MTU] = {
 		[0 ... (CONFIG_BT_ISO_TX_MTU - 1)] = 0xff
 	};
-	int ret, len, count = 1;
+	unsigned long count = 1;
 	struct net_buf *buf;
+	int ret = 0;
+	int len;
 
 	if (argc > 1) {
-		count = strtoul(argv[1], NULL, 10);
+		count = shell_strtoul(argv[1], 0, &ret);
+		if (ret != 0) {
+			shell_error(sh, "Could not parse count: %d", ret);
+
+			return -ENOEXEC;
+		}
 	}
 
 	if (!iso_chan.iso) {
@@ -465,11 +588,18 @@ static int cmd_broadcast(const struct shell *sh, size_t argc, char *argv[])
 	static uint8_t buf_data[CONFIG_BT_ISO_TX_MTU] = {
 		[0 ... (CONFIG_BT_ISO_TX_MTU - 1)] = 0xff
 	};
-	int ret, len, count = 1;
+	unsigned long count = 1;
 	struct net_buf *buf;
+	int ret = 0;
+	int len;
 
 	if (argc > 1) {
-		count = strtoul(argv[1], NULL, 10);
+		count = shell_strtoul(argv[1], 0, &ret);
+		if (ret != 0) {
+			shell_error(sh, "Could not parse count: %d", ret);
+
+			return -ENOEXEC;
+		}
 	}
 
 	if (!bis_iso_chan.iso) {
@@ -591,9 +721,23 @@ static int cmd_big_sync(const struct shell *sh, size_t argc, char *argv[])
 	/* TODO: Add support to select which PA sync to BIG sync to */
 	struct bt_le_per_adv_sync *pa_sync = per_adv_syncs[0];
 	struct bt_iso_big_sync_param param;
+	unsigned long bis_bitfield;
 
 	if (!pa_sync) {
 		shell_error(sh, "No PA sync selected");
+		return -ENOEXEC;
+	}
+
+	bis_bitfield = shell_strtoul(argv[1], 0, &err);
+	if (err != 0) {
+		shell_error(sh, "Could not parse bis_bitfield: %d", err);
+
+		return -ENOEXEC;
+	}
+
+	if (bis_bitfield > BIT_MASK(BT_ISO_BIS_INDEX_MAX)) {
+		shell_error(sh, "Invalid bis_bitfield: %lu", bis_bitfield);
+
 		return -ENOEXEC;
 	}
 
@@ -602,17 +746,13 @@ static int cmd_big_sync(const struct shell *sh, size_t argc, char *argv[])
 	param.bis_channels = bis_channels;
 	param.num_bis = BIS_ISO_CHAN_COUNT;
 	param.encryption = false;
-	param.bis_bitfield = strtoul(argv[1], NULL, 16);
+	param.bis_bitfield = bis_bitfield;
 	param.mse = 0;
 	param.sync_timeout = 0xFF;
 
-	for (int i = 2; i < argc; i++) {
+	for (size_t i = 2U; i < argc; i++) {
 		if (!strcmp(argv[i], "mse")) {
-			param.mse = strtoul(argv[i], NULL, 16);
-		} else if (!strcmp(argv[i], "timeout")) {
-			param.sync_timeout = strtoul(argv[i], NULL, 16);
-		} else if (!strcmp(argv[i], "enc")) {
-			uint8_t bcode_len;
+			unsigned long mse;
 
 			i++;
 			if (i == argc) {
@@ -620,13 +760,69 @@ static int cmd_big_sync(const struct shell *sh, size_t argc, char *argv[])
 				return SHELL_CMD_HELP_PRINTED;
 			}
 
+			mse = shell_strtoul(argv[i], 0, &err);
+			if (err != 0) {
+				shell_error(sh, "Could not parse mse: %d", err);
+
+				return -ENOEXEC;
+			}
+
+			if (!IN_RANGE(mse,
+				      BT_ISO_SYNC_MSE_MIN,
+				      BT_ISO_SYNC_MSE_MAX)) {
+				shell_error(sh, "Invalid mse %lu", mse);
+
+				return -ENOEXEC;
+			}
+
+			param.mse = mse;
+		} else if (!strcmp(argv[i], "timeout")) {
+			unsigned long sync_timeout;
+
+			i++;
+			if (i == argc) {
+				shell_help(sh);
+				return SHELL_CMD_HELP_PRINTED;
+			}
+
+			sync_timeout = shell_strtoul(argv[i], 0, &err);
+			if (err != 0) {
+				shell_error(sh,
+					    "Could not parse sync_timeout: %d",
+					    err);
+
+				return -ENOEXEC;
+			}
+
+			if (!IN_RANGE(sync_timeout,
+				      BT_ISO_SYNC_MSE_MIN,
+				      BT_ISO_SYNC_MSE_MAX)) {
+				shell_error(sh, "Invalid sync_timeout %lu",
+					    sync_timeout);
+
+				return -ENOEXEC;
+			}
+
+			param.sync_timeout = sync_timeout;
+		} else if (!strcmp(argv[i], "enc")) {
+			size_t bcode_len;
+
+			i++;
+			if (i == argc) {
+				shell_help(sh);
+				return SHELL_CMD_HELP_PRINTED;
+			}
+
+			memset(param.bcode, 0, sizeof(param.bcode));
 			bcode_len = hex2bin(argv[i], strlen(argv[i]), param.bcode,
 					    sizeof(param.bcode));
 
-			if (!bcode_len || bcode_len != sizeof(param.bcode)) {
-				shell_error(sh, "Invalid Broadcast Code Length");
+			if (bcode_len == 0) {
+				shell_error(sh, "Invalid Broadcast Code");
+
 				return -ENOEXEC;
 			}
+
 			param.encryption = true;
 		} else {
 			shell_help(sh);

--- a/subsys/bluetooth/shell/mcc.c
+++ b/subsys/bluetooth/shell/mcc.c
@@ -624,14 +624,15 @@ static int cmd_mcc_init(const struct shell *sh, size_t argc, char **argv)
 static int cmd_mcc_discover_mcs(const struct shell *sh, size_t argc,
 				char **argv)
 {
-	int result;
-	int subscribe = 1;
+	bool subscribe = true;
+	int result = 0;
 
 	if (argc > 1) {
-		subscribe = strtol(argv[1], NULL, 0);
+		subscribe = shell_strtobool(argv[1], 0, &result);
+		if (result != 0) {
+			shell_error(sh, "Could not parse subscribe: %d",
+				    result);
 
-		if (subscribe < 0 || subscribe > 1) {
-			shell_error(sh, "Invalid parameter");
 			return -ENOEXEC;
 		}
 	}
@@ -720,10 +721,21 @@ static int cmd_mcc_read_track_position(const struct shell *sh, size_t argc,
 static int cmd_mcc_set_track_position(const struct shell *sh, size_t argc,
 				      char *argv[])
 {
-	int result;
-	int32_t pos = strtol(argv[1], NULL, 0);
+	int result = 0;
+	long pos;
 
-	/* Todo: Check input "pos" for validity, or for errors in conversion? */
+	pos = shell_strtol(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse pos: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (!IN_RANGE(pos, INT32_MIN, INT32_MAX)) {
+		shell_error(sh, "Invalid pos: %ld", pos);
+
+		return -ENOEXEC;
+	}
 
 	result = bt_mcc_set_track_position(default_conn, pos);
 	if (result) {
@@ -749,8 +761,21 @@ static int cmd_mcc_read_playback_speed(const struct shell *sh, size_t argc,
 static int cmd_mcc_set_playback_speed(const struct shell *sh, size_t argc,
 				      char *argv[])
 {
-	int result;
-	int8_t speed = strtol(argv[1], NULL, 0);
+	int result = 0;
+	long speed;
+
+	speed = shell_strtol(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse speed: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (!IN_RANGE(speed, INT8_MIN, INT8_MAX)) {
+		shell_error(sh, "Invalid speed: %ld", speed);
+
+		return -ENOEXEC;
+	}
 
 	result = bt_mcc_set_playback_speed(default_conn, speed);
 	if (result) {
@@ -801,10 +826,21 @@ static int cmd_mcc_read_current_track_obj_id(const struct shell *sh,
 static int cmd_mcc_set_current_track_obj_id(const struct shell *sh, size_t argc,
 					    char *argv[])
 {
-	int result;
-	uint64_t id = strtoul(argv[1], NULL, 0);
+	unsigned long id;
+	int result = 0;
 
-	id = id & 0x0000FFFFFFFFFFFFUL; /* 48 bits only */
+	id = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse id: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (!IN_RANGE(id, BT_OTS_OBJ_ID_MIN, BT_OTS_OBJ_ID_MAX)) {
+		shell_error(sh, "Invalid id: %lu", id);
+
+		return -ENOEXEC;
+	}
 
 	result = bt_mcc_set_current_track_obj_id(default_conn, id);
 	if (result) {
@@ -828,10 +864,21 @@ static int cmd_mcc_read_next_track_obj_id(const struct shell *sh, size_t argc,
 static int cmd_mcc_set_next_track_obj_id(const struct shell *sh, size_t argc,
 					 char *argv[])
 {
-	int result;
-	uint64_t id = strtoul(argv[1], NULL, 0);
+	unsigned long id;
+	int result = 0;
 
-	id = id & 0x0000FFFFFFFFFFFFUL; /* 48 bits only */
+	id = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse id: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (!IN_RANGE(id, BT_OTS_OBJ_ID_MIN, BT_OTS_OBJ_ID_MAX)) {
+		shell_error(sh, "Invalid id: %lu", id);
+
+		return -ENOEXEC;
+	}
 
 	result = bt_mcc_set_next_track_obj_id(default_conn, id);
 	if (result) {
@@ -867,10 +914,21 @@ static int cmd_mcc_read_current_group_obj_id(const struct shell *sh,
 static int cmd_mcc_set_current_group_obj_id(const struct shell *sh, size_t argc,
 					    char *argv[])
 {
-	int result;
-	uint64_t id = strtoul(argv[1], NULL, 0);
+	unsigned long id;
+	int result = 0;
 
-	id = id & 0x0000FFFFFFFFFFFFUL; /* 48 bits only */
+	id = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse id: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (!IN_RANGE(id, BT_OTS_OBJ_ID_MIN, BT_OTS_OBJ_ID_MAX)) {
+		shell_error(sh, "Invalid id: %lu", id);
+
+		return -ENOEXEC;
+	}
 
 	result = bt_mcc_set_current_group_obj_id(default_conn, id);
 	if (result) {
@@ -895,8 +953,21 @@ static int cmd_mcc_read_playing_order(const struct shell *sh, size_t argc,
 static int cmd_mcc_set_playing_order(const struct shell *sh, size_t argc,
 				     char *argv[])
 {
-	int result;
-	uint8_t order = strtol(argv[1], NULL, 0);
+	unsigned long order;
+	int result = 0;
+
+	order = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse order: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (order > UINT8_MAX) {
+		shell_error(sh, "Invalid order: %lu", order);
+
+		return -ENOEXEC;
+	}
 
 	result = bt_mcc_set_playing_order(default_conn, order);
 	if (result) {
@@ -1395,15 +1466,18 @@ static int cmd_mcc_send_search_ioptest(const struct shell *sh, size_t argc,
 {
 	/* Implementation follows Media control service testspec 0.9.0r13 */
 	/* Testcase MCS/SR/SCP/BV-01-C [Search Control Point], rounds 1 - 9 */
-
-	int result;
-	uint8_t testround;
 	struct mpl_sci sci_1 = {0};
 	struct mpl_sci sci_2 = {0};
 	struct mpl_search search;
+	unsigned long testround;
+	int result = 0;
 
+	testround = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse testround: %d", result);
 
-	testround = strtol(argv[1], NULL, 0);
+		return -ENOEXEC;
+	}
 
 	switch (testround) {
 	case 1:
@@ -1606,13 +1680,19 @@ static int cmd_mcc_otc_read_metadata(const struct shell *sh, size_t argc,
 
 static int cmd_mcc_otc_select(const struct shell *sh, size_t argc, char *argv[])
 {
-	int result;
-	uint64_t id;
+	unsigned long id;
+	int result = 0;
 
-	if (argc > 1) {
-		id = strtol(argv[1], NULL, 0);
-	} else {
-		shell_error(sh, "Invalid parameter, requires the Object ID");
+	id = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse id: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (!IN_RANGE(id, BT_OTS_OBJ_ID_MIN, BT_OTS_OBJ_ID_MAX)) {
+		shell_error(sh, "Invalid id: %lu", id);
+
 		return -ENOEXEC;
 	}
 

--- a/subsys/bluetooth/shell/media_controller.c
+++ b/subsys/bluetooth/shell/media_controller.c
@@ -566,11 +566,23 @@ static int cmd_media_read_track_position(const struct shell *sh, size_t argc, ch
 static int cmd_media_set_track_position(const struct shell *sh, size_t argc,
 			       char *argv[])
 {
-	/* Todo: Check input "pos" for validity, or for errors in conversion? */
-	int32_t position = strtol(argv[1], NULL, 0);
+	long position;
+	int err = 0;
 
-	int err = media_proxy_ctrl_set_track_position(current_player, position);
+	position = shell_strtol(argv[1], 0, &err);
+	if (err != 0) {
+		shell_error(sh, "Could not parse position: %d", err);
 
+		return -ENOEXEC;
+	}
+
+	if (!IN_RANGE(position, INT32_MIN, INT32_MAX)) {
+		shell_error(sh, "Invalid position: %ld", position);
+
+		return -ENOEXEC;
+	}
+
+	err = media_proxy_ctrl_set_track_position(current_player, position);
 	if (err) {
 		shell_error(ctx_shell, "Track position set failed (%d)", err);
 	}
@@ -592,9 +604,23 @@ static int cmd_media_read_playback_speed(const struct shell *sh, size_t argc, ch
 
 static int cmd_media_set_playback_speed(const struct shell *sh, size_t argc, char *argv[])
 {
-	int8_t speed = strtol(argv[1], NULL, 0);
-	int err = media_proxy_ctrl_set_playback_speed(current_player, speed);
+	long speed;
+	int err = 0;
 
+	speed = shell_strtol(argv[1], 0, &err);
+	if (err != 0) {
+		shell_error(sh, "Could not parse speed: %d", err);
+
+		return -ENOEXEC;
+	}
+
+	if (!IN_RANGE(speed, INT8_MIN, INT8_MAX)) {
+		shell_error(sh, "Invalid speed: %ld", speed);
+
+		return -ENOEXEC;
+	}
+
+	err = media_proxy_ctrl_set_playback_speed(current_player, speed);
 	if (err) {
 		shell_error(ctx_shell, "Playback speed set failed (%d)", err);
 	}
@@ -686,10 +712,23 @@ static int cmd_media_read_playing_order(const struct shell *sh, size_t argc, cha
 
 static int cmd_media_set_playing_order(const struct shell *sh, size_t argc, char *argv[])
 {
-	uint8_t order = strtol(argv[1], NULL, 0);
+	unsigned long order;
+	int err = 0;
 
-	int err = media_proxy_ctrl_set_playing_order(current_player, order);
+	order = shell_strtoul(argv[1], 0, &err);
+	if (err != 0) {
+		shell_error(sh, "Could not parse order: %d", err);
 
+		return -ENOEXEC;
+	}
+
+	if (order > UINT8_MAX) {
+		shell_error(sh, "Invalid order: %ld", order);
+
+		return -ENOEXEC;
+	}
+
+	err = media_proxy_ctrl_set_playing_order(current_player, order);
 	if (err) {
 		shell_error(ctx_shell, "Playing order set failed (%d)", err);
 	}

--- a/subsys/bluetooth/shell/micp_mic_ctlr.c
+++ b/subsys/bluetooth/shell/micp_mic_ctlr.c
@@ -299,12 +299,20 @@ static int cmd_micp_mic_ctlr_unmute(const struct shell *sh, size_t argc,
 static int cmd_micp_mic_ctlr_aics_input_state_get(const struct shell *sh,
 						size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -323,12 +331,20 @@ static int cmd_micp_mic_ctlr_aics_input_state_get(const struct shell *sh,
 static int cmd_micp_mic_ctlr_aics_gain_setting_get(const struct shell *sh,
 						 size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -347,12 +363,20 @@ static int cmd_micp_mic_ctlr_aics_gain_setting_get(const struct shell *sh,
 static int cmd_micp_mic_ctlr_aics_input_type_get(const struct shell *sh,
 					       size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -371,12 +395,20 @@ static int cmd_micp_mic_ctlr_aics_input_type_get(const struct shell *sh,
 static int cmd_micp_mic_ctlr_aics_input_status_get(const struct shell *sh,
 						 size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -395,17 +427,21 @@ static int cmd_micp_mic_ctlr_aics_input_status_get(const struct shell *sh,
 static int cmd_micp_mic_ctlr_aics_input_unmute(const struct shell *sh,
 					     size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
-		return -ENOEXEC;
-	}
 
-	if (mic_ctlr == NULL) {
-		return -ENOENT;
+		return -ENOEXEC;
 	}
 
 	result = bt_aics_unmute(micp_included.aics[index]);
@@ -419,12 +455,20 @@ static int cmd_micp_mic_ctlr_aics_input_unmute(const struct shell *sh,
 static int cmd_micp_mic_ctlr_aics_input_mute(const struct shell *sh,
 					   size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -443,12 +487,20 @@ static int cmd_micp_mic_ctlr_aics_input_mute(const struct shell *sh,
 static int cmd_micp_mic_ctlr_aics_manual_input_gain_set(const struct shell *sh,
 						      size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -468,12 +520,20 @@ static int cmd_micp_mic_ctlr_aics_automatic_input_gain_set(const struct shell *s
 							 size_t argc,
 							 char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -492,19 +552,35 @@ static int cmd_micp_mic_ctlr_aics_automatic_input_gain_set(const struct shell *s
 static int cmd_micp_mic_ctlr_aics_gain_set(const struct shell *sh, size_t argc,
 					 char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
-	int gain = strtol(argv[2], NULL, 0);
+	unsigned long index;
+	int result = 0;
+	long gain;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
+		return -ENOEXEC;
+	}
+
+	gain = shell_strtol(argv[2], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse gain: %d", result);
+
 		return -ENOEXEC;
 	}
 
 	if (gain > INT8_MAX || gain < INT8_MIN) {
-		shell_error(sh, "Offset shall be %d-%d, was %d",
+		shell_error(sh, "Gain shall be %d-%d, was %d",
 			    INT8_MIN, INT8_MAX, gain);
+
 		return -ENOEXEC;
 	}
 
@@ -523,12 +599,20 @@ static int cmd_micp_mic_ctlr_aics_gain_set(const struct shell *sh, size_t argc,
 static int cmd_micp_mic_ctlr_aics_input_description_get(const struct shell *sh,
 						      size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -547,13 +631,20 @@ static int cmd_micp_mic_ctlr_aics_input_description_get(const struct shell *sh,
 static int cmd_micp_mic_ctlr_aics_input_description_set(const struct shell *sh,
 						      size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
-	char *description = argv[2];
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -561,8 +652,7 @@ static int cmd_micp_mic_ctlr_aics_input_description_set(const struct shell *sh,
 		return -ENOENT;
 	}
 
-	result = bt_aics_description_set(micp_included.aics[index],
-					      description);
+	result = bt_aics_description_set(micp_included.aics[index], argv[2]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}

--- a/subsys/bluetooth/shell/micp_mic_dev.c
+++ b/subsys/bluetooth/shell/micp_mic_dev.c
@@ -201,12 +201,20 @@ static int cmd_micp_mic_dev_mute_disable(const struct shell *sh, size_t argc,
 static int cmd_micp_mic_dev_aics_deactivate(const struct shell *sh, size_t argc,
 					    char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -221,12 +229,20 @@ static int cmd_micp_mic_dev_aics_deactivate(const struct shell *sh, size_t argc,
 static int cmd_micp_mic_dev_aics_activate(const struct shell *sh, size_t argc,
 					  char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -241,12 +257,20 @@ static int cmd_micp_mic_dev_aics_activate(const struct shell *sh, size_t argc,
 static int cmd_micp_mic_dev_aics_input_state_get(const struct shell *sh,
 						 size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -261,12 +285,20 @@ static int cmd_micp_mic_dev_aics_input_state_get(const struct shell *sh,
 static int cmd_micp_mic_dev_aics_gain_setting_get(const struct shell *sh,
 						  size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -281,12 +313,20 @@ static int cmd_micp_mic_dev_aics_gain_setting_get(const struct shell *sh,
 static int cmd_micp_mic_dev_aics_input_type_get(const struct shell *sh,
 						size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -301,12 +341,20 @@ static int cmd_micp_mic_dev_aics_input_type_get(const struct shell *sh,
 static int cmd_micp_mic_dev_aics_input_status_get(const struct shell *sh,
 						  size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -321,12 +369,20 @@ static int cmd_micp_mic_dev_aics_input_status_get(const struct shell *sh,
 static int cmd_micp_mic_dev_aics_input_unmute(const struct shell *sh,
 					      size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -341,12 +397,20 @@ static int cmd_micp_mic_dev_aics_input_unmute(const struct shell *sh,
 static int cmd_micp_mic_dev_aics_input_mute(const struct shell *sh, size_t argc,
 					    char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -361,12 +425,20 @@ static int cmd_micp_mic_dev_aics_input_mute(const struct shell *sh, size_t argc,
 static int cmd_micp_mic_dev_aics_manual_input_gain_set(const struct shell *sh,
 						       size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -382,12 +454,20 @@ static int cmd_micp_mic_dev_aics_automatic_input_gain_set(const struct shell *sh
 							  size_t argc,
 							  char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -402,19 +482,42 @@ static int cmd_micp_mic_dev_aics_automatic_input_gain_set(const struct shell *sh
 static int cmd_micp_mic_dev_aics_gain_set(const struct shell *sh, size_t argc,
 					  char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
-	int gain = strtol(argv[2], NULL, 0);
+	unsigned long index;
+	int result = 0;
+	long gain;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
-	if (gain > INT8_MAX || gain < INT8_MIN) {
-		shell_error(sh, "Offset shall be %d-%d, was %d",
+	if (index >= micp_included.aics_cnt) {
+		shell_error(sh, "Index shall be less than %u, was %u",
+			    micp_included.aics_cnt, index);
+
+		return -ENOEXEC;
+	}
+
+	gain = shell_strtol(argv[2], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse gain: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (!IN_RANGE(gain, INT8_MIN, INT8_MAX)) {
+		shell_error(sh, "Gain shall be %d-%d, was %d",
 			    INT8_MIN, INT8_MAX, gain);
+
 		return -ENOEXEC;
 	}
 
@@ -429,12 +532,20 @@ static int cmd_micp_mic_dev_aics_gain_set(const struct shell *sh, size_t argc,
 static int cmd_micp_mic_dev_aics_input_description_get(const struct shell *sh,
 						       size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -449,18 +560,24 @@ static int cmd_micp_mic_dev_aics_input_description_get(const struct shell *sh,
 static int cmd_micp_mic_dev_aics_input_description_set(const struct shell *sh,
 						       size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
-	char *description = argv[2];
+	unsigned long index;
+	int result = 0;
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
+
+		return -ENOEXEC;
+	}
 
 	if (index >= micp_included.aics_cnt) {
 		shell_error(sh, "Index shall be less than %u, was %u",
 			    micp_included.aics_cnt, index);
+
 		return -ENOEXEC;
 	}
 
-	result = bt_aics_description_set(micp_included.aics[index],
-					      description);
+	result = bt_aics_description_set(micp_included.aics[index], argv[2]);
 	if (result != 0) {
 		shell_error(sh, "Fail: %d", result);
 	}

--- a/subsys/bluetooth/shell/mpl.c
+++ b/subsys/bluetooth/shell/mpl.c
@@ -29,7 +29,21 @@ LOG_MODULE_REGISTER(bt_mpl_shell, CONFIG_BT_MPL_LOG_LEVEL);
 int cmd_mpl_test_set_media_state(const struct shell *sh, size_t argc,
 				 char *argv[])
 {
-	uint8_t state = strtol(argv[1], NULL, 0);
+	unsigned long state;
+	int err = 0;
+
+	state = shell_strtoul(argv[1], 0, &err);
+	if (err != 0) {
+		shell_error(sh, "Could not parse state: %d", err);
+
+		return -ENOEXEC;
+	}
+
+	if (state > UINT8_MAX) {
+		shell_error(sh, "Invalid state %lu", state);
+
+		return -ENOEXEC;
+	}
 
 	mpl_test_media_state_set(state);
 

--- a/subsys/bluetooth/shell/tbs.c
+++ b/subsys/bluetooth/shell/tbs.c
@@ -62,12 +62,19 @@ static int cmd_tbs_init(void)
 
 static int cmd_tbs_accept(const struct shell *sh, size_t argc, char *argv[])
 {
-	long call_index;
-	int result;
+	unsigned long call_index;
+	int result = 0;
 
-	call_index = strtol(argv[1], NULL, 0);
-	if (call_index <= 0 || call_index > UINT8_MAX) {
-		shell_error(sh, "Invalid call_index: %ld", call_index);
+	call_index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse call_index: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (call_index > UINT8_MAX) {
+		shell_error(sh, "Invalid call_index: %lu", call_index);
+
 		return -ENOEXEC;
 	}
 
@@ -85,12 +92,19 @@ static int cmd_tbs_accept(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_tbs_terminate(const struct shell *sh, size_t argc,
 			     char *argv[])
 {
-	long call_index;
-	int result;
+	unsigned long call_index;
+	int result = 0;
 
-	call_index = strtol(argv[1], NULL, 0);
-	if (call_index <= 0 || call_index > UINT8_MAX) {
-		shell_error(sh, "Invalid call_index: %ld", call_index);
+	call_index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse call_index: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (call_index > UINT8_MAX) {
+		shell_error(sh, "Invalid call_index: %lu", call_index);
+
 		return -ENOEXEC;
 	}
 
@@ -107,12 +121,19 @@ static int cmd_tbs_terminate(const struct shell *sh, size_t argc,
 
 static int cmd_tbs_hold(const struct shell *sh, size_t argc, char *argv[])
 {
-	long call_index;
-	int result;
+	unsigned long call_index;
+	int result = 0;
 
-	call_index = strtol(argv[1], NULL, 0);
-	if (call_index <= 0 || call_index > UINT8_MAX) {
-		shell_error(sh, "Invalid call_index: %ld", call_index);
+	call_index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse call_index: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (call_index > UINT8_MAX) {
+		shell_error(sh, "Invalid call_index: %lu", call_index);
+
 		return -ENOEXEC;
 	}
 
@@ -130,12 +151,19 @@ static int cmd_tbs_hold(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_tbs_retrieve(const struct shell *sh, size_t argc,
 			    char *argv[])
 {
-	long call_index;
-	int result;
+	unsigned long call_index;
+	int result = 0;
 
-	call_index = strtol(argv[1], NULL, 0);
-	if (call_index <= 0 || call_index > UINT8_MAX) {
-		shell_error(sh, "Invalid call_index: %ld", call_index);
+	call_index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse call_index: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (call_index > UINT8_MAX) {
+		shell_error(sh, "Invalid call_index: %lu", call_index);
+
 		return -ENOEXEC;
 	}
 
@@ -152,21 +180,27 @@ static int cmd_tbs_retrieve(const struct shell *sh, size_t argc,
 
 static int cmd_tbs_originate(const struct shell *sh, size_t argc, char *argv[])
 {
-	long service_index;
-	int result;
+	unsigned long service_index;
 	uint8_t call_index;
+	int result = 0;
 
 	if (argc > 2) {
-		service_index = strtol(argv[1], NULL, 0);
-		if (service_index < 0 ||
-		    service_index >= CONFIG_BT_TBS_BEARER_COUNT) {
-			shell_error(sh, "Invalid service index: %ld",
+		service_index = shell_strtoul(argv[1], 0, &result);
+		if (result != 0) {
+			shell_error(sh, "Could not parse service_index: %d",
+				    result);
+
+			return -ENOEXEC;
+		}
+
+		if (service_index > CONFIG_BT_TBS_BEARER_COUNT) {
+			shell_error(sh, "Invalid service_index: %lu",
 				    service_index);
 
 			return -ENOEXEC;
 		}
 	} else {
-		service_index = 0;
+		service_index = 0U;
 	}
 
 	result = bt_tbs_originate((uint8_t)service_index, argv[argc - 1],
@@ -183,14 +217,21 @@ static int cmd_tbs_originate(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_tbs_join(const struct shell *sh, size_t argc, char *argv[])
 {
 	uint8_t call_indexes[CONFIG_BT_TBS_MAX_CALLS];
-	int result;
-	long call_index;
+	unsigned long call_index;
+	int result = 0;
 
-	for (int i = 1; i < argc; i++) {
-		call_index = strtol(argv[i], NULL, 0);
+	for (size_t i = 1; i < argc; i++) {
+		call_index = shell_strtoul(argv[i], 0, &result);
+		if (result != 0) {
+			shell_error(sh, "Could not parse call_index: %d",
+				    result);
 
-		if (call_index < 0 || call_index > UINT8_MAX) {
-			shell_error(sh, "Invalid call index %ld", call_index);
+			return -ENOEXEC;
+		}
+
+		if (call_index > UINT8_MAX) {
+			shell_error(sh, "Invalid call_index: %lu", call_index);
+
 			return -ENOEXEC;
 		}
 
@@ -209,12 +250,19 @@ static int cmd_tbs_join(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_tbs_answer(const struct shell *sh, size_t argc, char *argv[])
 {
-	long call_index;
-	int result;
+	unsigned long call_index;
+	int result = 0;
 
-	call_index = strtol(argv[1], NULL, 0);
-	if (call_index <= 0 || call_index > UINT8_MAX) {
-		shell_error(sh, "Invalid call_index: %ld", call_index);
+	call_index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse call_index: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (call_index > UINT8_MAX) {
+		shell_error(sh, "Invalid call_index: %lu", call_index);
+
 		return -ENOEXEC;
 	}
 
@@ -232,12 +280,19 @@ static int cmd_tbs_answer(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_tbs_remote_hold(const struct shell *sh, size_t argc,
 			       char *argv[])
 {
-	long call_index;
-	int result;
+	unsigned long call_index;
+	int result = 0;
 
-	call_index = strtol(argv[1], NULL, 0);
-	if (call_index <= 0 || call_index > UINT8_MAX) {
-		shell_error(sh, "Invalid call_index: %ld", call_index);
+	call_index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse call_index: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (call_index > UINT8_MAX) {
+		shell_error(sh, "Invalid call_index: %lu", call_index);
+
 		return -ENOEXEC;
 	}
 
@@ -255,12 +310,19 @@ static int cmd_tbs_remote_hold(const struct shell *sh, size_t argc,
 static int cmd_tbs_remote_retrieve(const struct shell *sh, size_t argc,
 				   char *argv[])
 {
-	long call_index;
-	int result;
+	unsigned long call_index;
+	int result = 0;
 
-	call_index = strtol(argv[1], NULL, 0);
-	if (call_index <= 0 || call_index > UINT8_MAX) {
-		shell_error(sh, "Invalid call_index: %ld", call_index);
+	call_index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse call_index: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (call_index > UINT8_MAX) {
+		shell_error(sh, "Invalid call_index: %lu", call_index);
+
 		return -ENOEXEC;
 	}
 
@@ -278,12 +340,19 @@ static int cmd_tbs_remote_retrieve(const struct shell *sh, size_t argc,
 static int cmd_tbs_remote_terminate(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
-	long call_index;
-	int result;
+	unsigned long call_index;
+	int result = 0;
 
-	call_index = strtol(argv[1], NULL, 0);
-	if (call_index <= 0 || call_index > UINT8_MAX) {
-		shell_error(sh, "Invalid call_index: %ld", call_index);
+	call_index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse call_index: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (call_index > UINT8_MAX) {
+		shell_error(sh, "Invalid call_index: %lu", call_index);
+
 		return -ENOEXEC;
 	}
 
@@ -300,20 +369,31 @@ static int cmd_tbs_remote_terminate(const struct shell *sh, size_t argc,
 
 static int cmd_tbs_incoming(const struct shell *sh, size_t argc, char *argv[])
 {
-	long service_index;
-	int result;
+	unsigned long service_index;
+	int result = 0;
 
 	if (argc > 4) {
-		service_index = strtol(argv[1], NULL, 0);
-		if (service_index < 0 ||
-		    service_index >= CONFIG_BT_TBS_BEARER_COUNT) {
-			shell_error(sh, "Invalid service index: %ld",
-				    service_index);
+		if (strcmp(argv[1], "gtbs") == 0) {
+			service_index = BT_TBS_GTBS_INDEX;
+		} else {
+			service_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Could not parse service_index: %d",
+					    result);
 
-			return -ENOEXEC;
+				return -ENOEXEC;
+			}
+
+			if (service_index > CONFIG_BT_TBS_BEARER_COUNT) {
+				shell_error(sh, "Invalid service_index: %lu",
+					    service_index);
+
+				return -ENOEXEC;
+			}
 		}
 	} else {
-		service_index = 0;
+		service_index = 0U;
 	}
 
 	result = bt_tbs_remote_incoming((uint8_t)service_index,
@@ -332,23 +412,31 @@ static int cmd_tbs_incoming(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_tbs_set_bearer_provider_name(const struct shell *sh, size_t argc,
 					    char *argv[])
 {
-	long service_index;
-	int result;
+	unsigned long service_index;
+	int result = 0;
 
 	if (argc > 2) {
-		if (!strcmp(argv[1], "gtbs")) {
+		if (strcmp(argv[1], "gtbs") == 0) {
 			service_index = BT_TBS_GTBS_INDEX;
 		} else {
-			service_index = strtol(argv[1], NULL, 0);
-			if (service_index < 0 ||
-			    service_index >= CONFIG_BT_TBS_BEARER_COUNT) {
-				shell_error(sh, "Invalid service index: %ld",
+			service_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Could not parse service_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (service_index > CONFIG_BT_TBS_BEARER_COUNT) {
+				shell_error(sh, "Invalid service_index: %lu",
 					    service_index);
+
 				return -ENOEXEC;
 			}
 		}
 	} else {
-		service_index = 0;
+		service_index = 0U;
 	}
 
 	result = bt_tbs_set_bearer_provider_name((uint8_t)service_index,
@@ -363,29 +451,43 @@ static int cmd_tbs_set_bearer_provider_name(const struct shell *sh, size_t argc,
 static int cmd_tbs_set_bearer_technology(const struct shell *sh, size_t argc,
 					 char *argv[])
 {
-	long technology;
-	long service_index;
-	int result;
+	unsigned long service_index;
+	unsigned long technology;
+	int result = 0;
 
 	if (argc > 2) {
-		if (!strcmp(argv[1], "gtbs")) {
+		if (strcmp(argv[1], "gtbs") == 0) {
 			service_index = BT_TBS_GTBS_INDEX;
 		} else {
-			service_index = strtol(argv[1], NULL, 0);
-			if (service_index < 0 ||
-			    service_index >= CONFIG_BT_TBS_BEARER_COUNT) {
-				shell_error(sh, "Invalid service index: %ld",
+			service_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Could not parse service_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (service_index > CONFIG_BT_TBS_BEARER_COUNT) {
+				shell_error(sh, "Invalid service_index: %lu",
 					    service_index);
+
 				return -ENOEXEC;
 			}
 		}
 	} else {
-		service_index = 0;
+		service_index = 0U;
 	}
 
-	technology = strtol(argv[argc - 1], NULL, 0);
-	if (technology < 0 || technology > UINT8_MAX) {
-		shell_error(sh, "Invalid technology value: %ld", technology);
+	technology = shell_strtoul(argv[argc - 1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse technology: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (technology > UINT8_MAX) {
+		shell_error(sh, "Invalid technology: %lu", technology);
 
 		return -ENOEXEC;
 	}
@@ -402,30 +504,43 @@ static int cmd_tbs_set_bearer_technology(const struct shell *sh, size_t argc,
 static int cmd_tbs_set_bearer_signal_strength(const struct shell *sh,
 					      size_t argc, char *argv[])
 {
-	long signal_strength;
-	long service_index;
-	int result;
+	unsigned long signal_strength;
+	unsigned long service_index;
+	int result = 0;
 
 	if (argc > 2) {
-		if (!strcmp(argv[1], "gtbs")) {
+		if (strcmp(argv[1], "gtbs") == 0) {
 			service_index = BT_TBS_GTBS_INDEX;
 		} else {
-			service_index = strtol(argv[1], NULL, 0);
-			if (service_index < 0 ||
-			service_index >= CONFIG_BT_TBS_BEARER_COUNT) {
-				shell_error(sh, "Invalid service index: %ld",
+			service_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Could not parse service_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (service_index > CONFIG_BT_TBS_BEARER_COUNT) {
+				shell_error(sh, "Invalid service_index: %lu",
 					    service_index);
 
 				return -ENOEXEC;
 			}
 		}
 	} else {
-		service_index = 0;
+		service_index = 0U;
 	}
 
-	signal_strength = strtol(argv[argc - 1], NULL, 0);
-	if (signal_strength < 0 || signal_strength > UINT8_MAX) {
-		shell_error(sh, "Invalid signal strength: %ld",
+	signal_strength = shell_strtoul(argv[argc - 1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse signal_strength: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (signal_strength > UINT8_MAX) {
+		shell_error(sh, "Invalid signal_strength: %lu",
 			    signal_strength);
 
 		return -ENOEXEC;
@@ -443,31 +558,43 @@ static int cmd_tbs_set_bearer_signal_strength(const struct shell *sh,
 static int cmd_tbs_set_status_flags(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
-	long status_flags;
-	long service_index;
-	int result;
+	unsigned long service_index;
+	unsigned long status_flags;
+	int result = 0;
 
 	if (argc > 2) {
-		if (!strcmp(argv[1], "gtbs")) {
+		if (strcmp(argv[1], "gtbs") == 0) {
 			service_index = BT_TBS_GTBS_INDEX;
 		} else {
-			service_index = strtol(argv[1], NULL, 0);
-			if (service_index < 0 ||
-			    service_index >= CONFIG_BT_TBS_BEARER_COUNT) {
-				shell_error(sh, "Invalid service index: %ld",
+			service_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Could not parse service_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (service_index > CONFIG_BT_TBS_BEARER_COUNT) {
+				shell_error(sh, "Invalid service_index: %lu",
 					    service_index);
 
 				return -ENOEXEC;
 			}
 		}
 	} else {
-		service_index = 0;
+		service_index = 0U;
 	}
 
-	status_flags = strtol(argv[argc - 1], NULL, 0);
-	if (status_flags < 0 || status_flags > 3) {
-		shell_error(sh, "Invalid status flags value: %ld",
-			    status_flags);
+	status_flags = shell_strtoul(argv[argc - 1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse status_flags: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (status_flags > UINT8_MAX) {
+		shell_error(sh, "Invalid status_flags: %lu", status_flags);
 
 		return -ENOEXEC;
 	}
@@ -484,14 +611,31 @@ static int cmd_tbs_set_status_flags(const struct shell *sh, size_t argc,
 static int cmd_tbs_set_uri_scheme_list(const struct shell *sh, size_t argc,
 				       char *argv[])
 {
-	long service_index;
-	int result;
+	unsigned long service_index;
+	int result = 0;
 
-	service_index = strtol(argv[1], NULL, 0);
-	if (service_index < 0 || service_index >= CONFIG_BT_TBS_BEARER_COUNT) {
-		shell_error(sh, "Invalid service index: %ld", service_index);
+	if (argc > 2) {
+		if (strcmp(argv[1], "gtbs") == 0) {
+			service_index = BT_TBS_GTBS_INDEX;
+		} else {
+			service_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Could not parse service_index: %d",
+					    result);
 
-		return -ENOEXEC;
+				return -ENOEXEC;
+			}
+
+			if (service_index > CONFIG_BT_TBS_BEARER_COUNT) {
+				shell_error(sh, "Invalid service_index: %lu",
+					    service_index);
+
+				return -ENOEXEC;
+			}
+		}
+	} else {
+		service_index = 0U;
 	}
 
 	result = bt_tbs_set_uri_scheme_list((uint8_t)service_index,

--- a/subsys/bluetooth/shell/tbs_client.c
+++ b/subsys/bluetooth/shell/tbs_client.c
@@ -27,13 +27,15 @@
 static int cmd_tbs_client_discover(const struct shell *sh, size_t argc,
 				   char *argv[])
 {
-	int result;
-	int subscribe = 1;
+	bool subscribe = true;
+	int result = 0;
 
 	if (argc > 1) {
-		subscribe = strtol(argv[1], NULL, 0);
-		if (subscribe < 0 || subscribe > 1) {
-			shell_error(sh, "Invalid parameter");
+		subscribe = shell_strtobool(argv[1], 0, &result);
+		if (result != 0) {
+			shell_error(sh, "Could not parse subscribe: %d",
+				    result);
+
 			return -ENOEXEC;
 		}
 	}
@@ -51,17 +53,30 @@ static int cmd_tbs_client_set_signal_strength_interval(const struct shell *sh,
 						       size_t argc,
 						       char *argv[])
 {
-	int result;
-	int interval;
-	int inst_index;
+	unsigned long inst_index;
+	unsigned long interval;
+	int result = 0;
 
+	/* TODO: The handling of index/GTBS index is done in almost every
+	 * function - Should add a helper function to reduce duplicated code
+	 */
 	if (argc > 2) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -69,9 +84,16 @@ static int cmd_tbs_client_set_signal_strength_interval(const struct shell *sh,
 		inst_index = 0;
 	}
 
-	interval = strtol(argv[argc - 1], NULL, 0);
-	if (interval < 0 || interval > UINT8_MAX) {
-		shell_error(sh, "Invalid interval");
+	interval = shell_strtoul(argv[argc - 1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse interval: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (interval > UINT8_MAX) {
+		shell_error(sh, "Invalid interval: %lu", interval);
+
 		return -ENOEXEC;
 	}
 
@@ -90,17 +112,27 @@ static int cmd_tbs_client_set_signal_strength_interval(const struct shell *sh,
 static int cmd_tbs_client_hold(const struct shell *sh, size_t argc,
 			       char *argv[])
 {
-	int result;
-	int inst_index;
-	int call_index;
+	unsigned long inst_index;
+	unsigned long call_index;
+	int result = 0;
 
 	if (argc > 2) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -108,9 +140,16 @@ static int cmd_tbs_client_hold(const struct shell *sh, size_t argc,
 		inst_index = 0;
 	}
 
-	call_index = strtol(argv[argc - 1], NULL, 0);
-	if (call_index < 0 || call_index > UINT8_MAX) {
-		shell_error(sh, "Invalid parameter");
+	call_index = shell_strtoul(argv[argc - 1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse call_index: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (call_index > UINT8_MAX) {
+		shell_error(sh, "Invalid call_index: %lu", call_index);
+
 		return -ENOEXEC;
 	}
 
@@ -127,17 +166,27 @@ static int cmd_tbs_client_hold(const struct shell *sh, size_t argc,
 static int cmd_tbs_client_retrieve(const struct shell *sh, size_t argc,
 				   char *argv[])
 {
-	int result;
-	int inst_index;
-	int call_index;
+	unsigned long inst_index;
+	unsigned long call_index;
+	int result = 0;
 
 	if (argc > 2) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -145,9 +194,16 @@ static int cmd_tbs_client_retrieve(const struct shell *sh, size_t argc,
 		inst_index = 0;
 	}
 
-	call_index = strtol(argv[argc - 1], NULL, 0);
-	if (call_index < 0 || call_index > UINT8_MAX) {
-		shell_error(sh, "Invalid parameter");
+	call_index = shell_strtoul(argv[argc - 1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse call_index: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (call_index > UINT8_MAX) {
+		shell_error(sh, "Invalid call_index: %lu", call_index);
+
 		return -ENOEXEC;
 	}
 
@@ -165,17 +221,27 @@ static int cmd_tbs_client_retrieve(const struct shell *sh, size_t argc,
 static int cmd_tbs_client_accept(const struct shell *sh, size_t argc,
 				 char *argv[])
 {
-	int result;
-	int inst_index;
-	int call_index;
+	unsigned long inst_index;
+	unsigned long call_index;
+	int result = 0;
 
 	if (argc > 2) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -183,9 +249,16 @@ static int cmd_tbs_client_accept(const struct shell *sh, size_t argc,
 		inst_index = 0;
 	}
 
-	call_index = strtol(argv[argc - 1], NULL, 0);
-	if (call_index < 0 || call_index > UINT8_MAX) {
-		shell_error(sh, "Invalid parameter");
+	call_index = shell_strtoul(argv[argc - 1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse call_index: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (call_index > UINT8_MAX) {
+		shell_error(sh, "Invalid call_index: %lu", call_index);
+
 		return -ENOEXEC;
 	}
 
@@ -204,26 +277,45 @@ static int cmd_tbs_client_accept(const struct shell *sh, size_t argc,
 static int cmd_tbs_client_join(const struct shell *sh, size_t argc,
 			       char *argv[])
 {
-	int result;
+
 	uint8_t call_indexes[CONFIG_BT_TBS_CLIENT_MAX_CALLS];
-	int call_index;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (strcmp(argv[1], "gtbs") == 0) {
 		inst_index = BT_TBS_GTBS_INDEX;
 	} else {
-		inst_index = strtol(argv[1], NULL, 0);
-		if (inst_index < 0 || inst_index > UINT8_MAX) {
-			shell_error(sh, "Invalid index");
+		inst_index = shell_strtoul(argv[1], 0, &result);
+		if (result != 0) {
+			shell_error(sh,
+					"Failed to parse inst_index: %d",
+					result);
+
+			return -ENOEXEC;
+		}
+
+		if (inst_index > UINT8_MAX) {
+			shell_error(sh, "Invalid index: %lu",
+					inst_index);
+
 			return -ENOEXEC;
 		}
 	}
 
-	for (int i = 2; i < argc; i++) {
-		call_index = (int)strtol(argv[i], NULL, 0);
-		if ((call_index < 0) || (call_index > UINT8_MAX)) {
-			shell_error(sh, "Invalid parameter %s [%d]", argv[i],
-				    call_index);
+	for (size_t i = 2U; i < argc; i++) {
+		unsigned long call_index;
+
+		call_index = shell_strtoul(argv[i], 0, &result);
+		if (result != 0) {
+			shell_error(sh, "Failed to parse call_index: %d",
+				    result);
+
+			return -ENOEXEC;
+		}
+
+		if (call_index > UINT8_MAX) {
+			shell_error(sh, "Invalid call_index: %lu", call_index);
+
 			return -ENOEXEC;
 		}
 
@@ -244,17 +336,27 @@ static int cmd_tbs_client_join(const struct shell *sh, size_t argc,
 static int cmd_tbs_client_terminate(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
-	int result;
-	int inst_index;
-	int call_index;
+	unsigned long inst_index;
+	unsigned long call_index;
+	int result = 0;
 
 	if (argc > 2) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -262,9 +364,16 @@ static int cmd_tbs_client_terminate(const struct shell *sh, size_t argc,
 		inst_index = 0;
 	}
 
-	call_index = strtol(argv[argc - 1], NULL, 0);
-	if (call_index < 0 || call_index > UINT8_MAX) {
-		shell_error(sh, "Invalid parameter");
+	call_index = shell_strtoul(argv[argc - 1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse call_index: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (call_index > UINT8_MAX) {
+		shell_error(sh, "Invalid call_index: %lu", call_index);
+
 		return -ENOEXEC;
 	}
 
@@ -282,16 +391,26 @@ static int cmd_tbs_client_terminate(const struct shell *sh, size_t argc,
 static int cmd_tbs_client_originate(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 2) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -313,16 +432,26 @@ static int cmd_tbs_client_originate(const struct shell *sh, size_t argc,
 static int cmd_tbs_client_read_bearer_provider_name(const struct shell *sh,
 						    size_t argc, char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -344,16 +473,26 @@ static int cmd_tbs_client_read_bearer_provider_name(const struct shell *sh,
 static int cmd_tbs_client_read_bearer_uci(const struct shell *sh, size_t argc,
 					  char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -374,16 +513,26 @@ static int cmd_tbs_client_read_bearer_uci(const struct shell *sh, size_t argc,
 static int cmd_tbs_client_read_technology(const struct shell *sh, size_t argc,
 					  char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -404,16 +553,26 @@ static int cmd_tbs_client_read_technology(const struct shell *sh, size_t argc,
 static int cmd_tbs_client_read_uri_list(const struct shell *sh, size_t argc,
 					char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -434,16 +593,26 @@ static int cmd_tbs_client_read_uri_list(const struct shell *sh, size_t argc,
 static int cmd_tbs_client_read_signal_strength(const struct shell *sh,
 					       size_t argc, char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -464,16 +633,26 @@ static int cmd_tbs_client_read_signal_strength(const struct shell *sh,
 static int cmd_tbs_client_read_signal_interval(const struct shell *sh,
 					       size_t argc, char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -494,16 +673,26 @@ static int cmd_tbs_client_read_signal_interval(const struct shell *sh,
 static int cmd_tbs_client_read_current_calls(const struct shell *sh,
 					     size_t argc, char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -524,16 +713,26 @@ static int cmd_tbs_client_read_current_calls(const struct shell *sh,
 static int cmd_tbs_client_read_ccid(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -554,16 +753,26 @@ static int cmd_tbs_client_read_ccid(const struct shell *sh, size_t argc,
 static int cmd_tbs_client_read_uri(const struct shell *sh, size_t argc,
 				   char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -584,16 +793,26 @@ static int cmd_tbs_client_read_uri(const struct shell *sh, size_t argc,
 static int cmd_tbs_client_read_status_flags(const struct shell *sh, size_t argc,
 					    char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -613,16 +832,26 @@ static int cmd_tbs_client_read_status_flags(const struct shell *sh, size_t argc,
 static int cmd_tbs_client_read_call_state(const struct shell *sh, size_t argc,
 					  char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -642,16 +871,26 @@ static int cmd_tbs_client_read_call_state(const struct shell *sh, size_t argc,
 static int cmd_tbs_client_read_remote_uri(const struct shell *sh, size_t argc,
 					  char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -672,16 +911,26 @@ static int cmd_tbs_client_read_remote_uri(const struct shell *sh, size_t argc,
 static int cmd_tbs_client_read_friendly_name(const struct shell *sh,
 					     size_t argc, char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}
@@ -702,16 +951,26 @@ static int cmd_tbs_client_read_friendly_name(const struct shell *sh,
 static int cmd_tbs_client_read_optional_opcodes(const struct shell *sh,
 						size_t argc, char *argv[])
 {
-	int result;
-	int inst_index;
+	unsigned long inst_index;
+	int result = 0;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "gtbs") == 0) {
 			inst_index = BT_TBS_GTBS_INDEX;
 		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
+			inst_index = shell_strtoul(argv[1], 0, &result);
+			if (result != 0) {
+				shell_error(sh,
+					    "Failed to parse inst_index: %d",
+					    result);
+
+				return -ENOEXEC;
+			}
+
+			if (inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index: %lu",
+					    inst_index);
+
 				return -ENOEXEC;
 			}
 		}

--- a/subsys/bluetooth/shell/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/shell/vcp_vol_ctlr.c
@@ -464,16 +464,24 @@ static int cmd_vcp_vol_ctlr_volume_set(const struct shell *sh, size_t argc,
 				     char **argv)
 
 {
-	int result;
-	int volume = strtol(argv[1], NULL, 0);
+	unsigned long volume;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
+	volume = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse volume: %d", result);
+
+		return -ENOEXEC;
+	}
+
 	if (volume > UINT8_MAX) {
-		shell_error(sh, "Volume shall be 0-255, was %d", volume);
+		shell_error(sh, "Volume shall be 0-255, was %lu", volume);
+
 		return -ENOEXEC;
 	}
 
@@ -525,17 +533,25 @@ static int cmd_vcp_vol_ctlr_mute(const struct shell *sh, size_t argc,
 static int cmd_vcp_vol_ctlr_vocs_state_get(const struct shell *sh, size_t argc,
 					 char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
+		return -ENOEXEC;
+	}
+
 	if (index >= vcp_included.vocs_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    vcp_included.vocs_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -550,17 +566,25 @@ static int cmd_vcp_vol_ctlr_vocs_state_get(const struct shell *sh, size_t argc,
 static int cmd_vcp_vol_ctlr_vocs_location_get(const struct shell *sh,
 					    size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
+		return -ENOEXEC;
+	}
+
 	if (index >= vcp_included.vocs_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    vcp_included.vocs_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -575,30 +599,43 @@ static int cmd_vcp_vol_ctlr_vocs_location_get(const struct shell *sh,
 static int cmd_vcp_vol_ctlr_vocs_location_set(const struct shell *sh,
 					    size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
-	int location = strtol(argv[2], NULL, 0);
+	unsigned long location;
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
+		return -ENOEXEC;
+	}
+
 	if (index >= vcp_included.vocs_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    vcp_included.vocs_cnt, index);
+
 		return -ENOEXEC;
 	}
 
-	if (location > UINT32_MAX || location < 0) {
-		shell_error(sh, "Invalid location (%u-%u), was %u",
-			    0, UINT32_MAX, location);
+	location = shell_strtoul(argv[2], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse location: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (location > UINT32_MAX) {
+		shell_error(sh, "Invalid location %lu", location);
 		return -ENOEXEC;
 
 	}
 
-	result = bt_vocs_location_set(vcp_included.vocs[index],
-					  location);
+	result = bt_vocs_location_set(vcp_included.vocs[index], location);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -609,23 +646,38 @@ static int cmd_vcp_vol_ctlr_vocs_location_set(const struct shell *sh,
 static int cmd_vcp_vol_ctlr_vocs_offset_set(const struct shell *sh,
 					  size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
-	int offset = strtol(argv[2], NULL, 0);
+	unsigned long index;
+	int result = 0;
+	long offset;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (index >= vcp_included.vocs_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcp_included.vocs_cnt, index);
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
 		return -ENOEXEC;
 	}
 
-	if (offset > BT_VOCS_MAX_OFFSET || offset < BT_VOCS_MIN_OFFSET) {
-		shell_error(sh, "Offset shall be %d-%d, was %d",
+	if (index >= vcp_included.vocs_cnt) {
+		shell_error(sh, "Index shall be less than %u, was %lu",
+			    vcp_included.vocs_cnt, index);
+
+		return -ENOEXEC;
+	}
+
+	offset = shell_strtol(argv[2], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse offset: %d", result);
+
+		return -ENOEXEC;
+	}
+
+	if (!IN_RANGE(offset, BT_VOCS_MIN_OFFSET, BT_VOCS_MAX_OFFSET)) {
+		shell_error(sh, "Offset shall be %d-%d, was %ld",
 			    BT_VOCS_MIN_OFFSET, BT_VOCS_MAX_OFFSET, offset);
 		return -ENOEXEC;
 	}
@@ -642,17 +694,25 @@ static int cmd_vcp_vol_ctlr_vocs_offset_set(const struct shell *sh,
 static int cmd_vcp_vol_ctlr_vocs_output_description_get(const struct shell *sh,
 						      size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
+		return -ENOEXEC;
+	}
+
 	if (index >= vcp_included.vocs_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    vcp_included.vocs_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -667,23 +727,29 @@ static int cmd_vcp_vol_ctlr_vocs_output_description_get(const struct shell *sh,
 static int cmd_vcp_vol_ctlr_vocs_output_description_set(const struct shell *sh,
 						      size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
-	char *description = argv[2];
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (index >= vcp_included.vocs_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcp_included.vocs_cnt, index);
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
 		return -ENOEXEC;
 	}
 
-	result = bt_vocs_description_set(vcp_included.vocs[index],
-					     description);
+	if (index >= vcp_included.vocs_cnt) {
+		shell_error(sh, "Index shall be less than %u, was %lu",
+			    vcp_included.vocs_cnt, index);
+
+		return -ENOEXEC;
+	}
+
+	result = bt_vocs_description_set(vcp_included.vocs[index], argv[2]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -694,17 +760,25 @@ static int cmd_vcp_vol_ctlr_vocs_output_description_set(const struct shell *sh,
 static int cmd_vcp_vol_ctlr_aics_input_state_get(const struct shell *sh,
 					       size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
+		return -ENOEXEC;
+	}
+
 	if (index >= vcp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcp_included.aics_cnt, index);
+		shell_error(sh, "Index shall be less than %u, was %lu",
+			    vcp_included.vocs_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -719,17 +793,25 @@ static int cmd_vcp_vol_ctlr_aics_input_state_get(const struct shell *sh,
 static int cmd_vcp_vol_ctlr_aics_gain_setting_get(const struct shell *sh,
 						size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
+		return -ENOEXEC;
+	}
+
 	if (index >= vcp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcp_included.aics_cnt, index);
+		shell_error(sh, "Index shall be less than %u, was %lu",
+			    vcp_included.vocs_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -744,17 +826,25 @@ static int cmd_vcp_vol_ctlr_aics_gain_setting_get(const struct shell *sh,
 static int cmd_vcp_vol_ctlr_aics_input_type_get(const struct shell *sh,
 					      size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
+		return -ENOEXEC;
+	}
+
 	if (index >= vcp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcp_included.aics_cnt, index);
+		shell_error(sh, "Index shall be less than %u, was %lu",
+			    vcp_included.vocs_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -769,17 +859,25 @@ static int cmd_vcp_vol_ctlr_aics_input_type_get(const struct shell *sh,
 static int cmd_vcp_vol_ctlr_aics_input_status_get(const struct shell *sh,
 						size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
+		return -ENOEXEC;
+	}
+
 	if (index >= vcp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcp_included.aics_cnt, index);
+		shell_error(sh, "Index shall be less than %u, was %lu",
+			    vcp_included.vocs_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -794,17 +892,25 @@ static int cmd_vcp_vol_ctlr_aics_input_status_get(const struct shell *sh,
 static int cmd_vcp_vol_ctlr_aics_input_unmute(const struct shell *sh,
 					    size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
+		return -ENOEXEC;
+	}
+
 	if (index >= vcp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcp_included.aics_cnt, index);
+		shell_error(sh, "Index shall be less than %u, was %lu",
+			    vcp_included.vocs_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -819,17 +925,25 @@ static int cmd_vcp_vol_ctlr_aics_input_unmute(const struct shell *sh,
 static int cmd_vcp_vol_ctlr_aics_input_mute(const struct shell *sh,
 					  size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
+		return -ENOEXEC;
+	}
+
 	if (index >= vcp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcp_included.aics_cnt, index);
+		shell_error(sh, "Index shall be less than %u, was %lu",
+			    vcp_included.vocs_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -844,17 +958,25 @@ static int cmd_vcp_vol_ctlr_aics_input_mute(const struct shell *sh,
 static int cmd_vcp_vol_ctlr_aics_manual_input_gain_set(const struct shell *sh,
 						     size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
+		return -ENOEXEC;
+	}
+
 	if (index >= vcp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcp_included.aics_cnt, index);
+		shell_error(sh, "Index shall be less than %u, was %lu",
+			    vcp_included.vocs_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -869,17 +991,25 @@ static int cmd_vcp_vol_ctlr_aics_manual_input_gain_set(const struct shell *sh,
 static int cmd_vcp_vol_ctlr_aics_auto_input_gain_set(const struct shell *sh,
 						   size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
+		return -ENOEXEC;
+	}
+
 	if (index >= vcp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcp_included.aics_cnt, index);
+		shell_error(sh, "Index shall be less than %u, was %lu",
+			    vcp_included.vocs_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -894,12 +1024,18 @@ static int cmd_vcp_vol_ctlr_aics_auto_input_gain_set(const struct shell *sh,
 static int cmd_vcp_vol_ctlr_aics_gain_set(const struct shell *sh, size_t argc,
 					char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
-	int gain = strtol(argv[2], NULL, 0);
+	unsigned long index;
+	int result = 0;
+	long gain;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
+		return -ENOEXEC;
+	}
+
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse index: %d", result);
 		return -ENOEXEC;
 	}
 
@@ -909,8 +1045,14 @@ static int cmd_vcp_vol_ctlr_aics_gain_set(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	if (gain > INT8_MAX || gain < INT8_MIN) {
-		shell_error(sh, "Offset shall be %d-%d, was %d",
+	gain = shell_strtol(argv[2], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Could not parse gain: %d", result);
+		return -ENOEXEC;
+	}
+
+	if (!IN_RANGE(gain, INT8_MIN, INT8_MAX)) {
+		shell_error(sh, "Gain shall be %d-%d, was %d",
 			    INT8_MIN, INT8_MAX, gain);
 		return -ENOEXEC;
 	}
@@ -926,17 +1068,25 @@ static int cmd_vcp_vol_ctlr_aics_gain_set(const struct shell *sh, size_t argc,
 static int cmd_vcp_vol_ctlr_aics_input_description_get(const struct shell *sh,
 						     size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
+		return -ENOEXEC;
+	}
+
 	if (index >= vcp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcp_included.aics_cnt, index);
+		shell_error(sh, "Index shall be less than %u, was %lu",
+			    vcp_included.vocs_cnt, index);
+
 		return -ENOEXEC;
 	}
 
@@ -951,23 +1101,29 @@ static int cmd_vcp_vol_ctlr_aics_input_description_get(const struct shell *sh,
 static int cmd_vcp_vol_ctlr_aics_input_description_set(const struct shell *sh,
 						     size_t argc, char **argv)
 {
-	int result;
-	int index = strtol(argv[1], NULL, 0);
-	char *description = argv[2];
+	unsigned long index;
+	int result = 0;
 
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
 	}
 
-	if (index >= vcp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
-			    vcp_included.aics_cnt, index);
+	index = shell_strtoul(argv[1], 0, &result);
+	if (result != 0) {
+		shell_error(sh, "Failed to parse index: %d", result);
+
 		return -ENOEXEC;
 	}
 
-	result = bt_aics_description_set(vcp_included.aics[index],
-					     description);
+	if (index >= vcp_included.aics_cnt) {
+		shell_error(sh, "Index shall be less than %u, was %lu",
+			    vcp_included.vocs_cnt, index);
+
+		return -ENOEXEC;
+	}
+
+	result = bt_aics_description_set(vcp_included.aics[index], argv[2]);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}

--- a/subsys/bluetooth/shell/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/shell/vcp_vol_ctlr.c
@@ -590,9 +590,9 @@ static int cmd_vcp_vol_ctlr_vocs_location_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (location > UINT16_MAX || location < 0) {
+	if (location > UINT32_MAX || location < 0) {
 		shell_error(sh, "Invalid location (%u-%u), was %u",
-			    0, UINT16_MAX, location);
+			    0, UINT32_MAX, location);
 		return -ENOEXEC;
 
 	}

--- a/subsys/bluetooth/shell/vcp_vol_rend.c
+++ b/subsys/bluetooth/shell/vcp_vol_rend.c
@@ -438,9 +438,9 @@ static int cmd_vcp_vol_rend_vocs_location_set(const struct shell *sh,
 			    CONFIG_BT_VCP_VOL_REND_VOCS_INSTANCE_COUNT, index);
 		return -ENOEXEC;
 	}
-	if (location > UINT16_MAX || location < 0) {
+	if (location > UINT32_MAX || location < 0) {
 		shell_error(sh, "Invalid location (%u-%u), was %u",
-			    0, UINT16_MAX, location);
+			    0, UINT32_MAX, location);
 		return -ENOEXEC;
 
 	}


### PR DESCRIPTION
Ensures that all `strtoX` calls are handled correctly, and moves to use the `shell_strtoX` functions 

Fixes most of the bugs reported in https://github.com/zephyrproject-rtos/zephyr/issues/54101

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54101