### PR TITLE
cmake: emu: qemu: introduce `CONFIG_QEMU_GDBSERVER_LISTEN_DEV` so that gdbserver listeners other than `-s`  can be set

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -99,6 +99,18 @@ config QEMU_UEFI_BOOT
 	  This option indicates that QEMU will use UEFI bootable method
 	  to boot up.
 
+config QEMU_GDBSERVER_LISTEN_DEV
+	string "QEMU gdbserver listen device"
+	default "tcp::1234"
+	depends on QEMU_TARGET
+	help
+	  This options is passed onto QEMU as a parameter to `-gdb` option.
+	  The default value is equivalent to `-s` which is a shorthand for
+	  `-gdb tcp::1234`. An empty value omits the `-gdb` parameter altogether.
+	  This allows the injection of `-gdb` parameter from other sources such
+	  as the `QEMU_EXTRA_FLAGS` environment variable. Refer to application
+	  development doc and/or QEMU invocation doc for more info.
+
 # There might not be any board options, hence the optional source
 osource "$(BOARD_DIR)/Kconfig"
 endmenu

--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -364,7 +364,11 @@ set(env_qemu $ENV{QEMU_EXTRA_FLAGS})
 separate_arguments(env_qemu)
 list(APPEND QEMU_EXTRA_FLAGS ${env_qemu})
 
-list(APPEND MORE_FLAGS_FOR_debugserver_qemu -s -S)
+list(APPEND MORE_FLAGS_FOR_debugserver_qemu -S)
+
+if(NOT CONFIG_QEMU_GDBSERVER_LISTEN_DEV STREQUAL "")
+  list(APPEND MORE_FLAGS_FOR_debugserver_qemu -gdb "${CONFIG_QEMU_GDBSERVER_LISTEN_DEV}")
+endif()
 
 # Architectures can define QEMU_KERNEL_FILE to use a specific output
 # file to pass to qemu (and a "qemu_kernel_target" target to generate

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -1082,12 +1082,28 @@ The options used above have the following meaning:
 To debug with QEMU and to start a GDB server and wait for a remote connect, run
 either of the following inside the build directory of an application:
 
-.. code-block:: bash
+.. code-block:: console
 
    ninja debugserver
 
+or invoke west from your project root:
+
+.. code-block:: console
+
+   west build -t debugserver_qemu
+
 The build system will start a QEMU instance with the CPU halted at startup
 and with a GDB server instance listening at the TCP port 1234.
+
+The listening device (tcp port number or a character device) can be configured
+via the Kconfig option :kconfig:option:`CONFIG_QEMU_GDBSERVER_LISTEN_DEV`. It's
+possible to setup unix sockets as well as tcp listen ports. Unix sockets
+however, require gdb version 9.0 or newer.
+
+If the option is unset, then QEMU invocation will lack a ``-s`` or a ``-gdb``
+parameter, which allows users to utilize :envvar:`QEMU_EXTRA_FLAGS` shell
+environment variable to pass in their own listen device configuration from
+their own shell environments.
 
 Using a local GDB configuration :file:`.gdbinit` can help initialize your GDB
 instance on every run.


### PR DESCRIPTION
First, we introduce a new string option to pass into QEMU invocation so that gdbserver listeners other than `-s` (tcp::1234) can be set while setting its default to `"tcp::1234"` for backwards compatibility.

Then we remove the enforced `-s` and set `-gdb` but only if above-mentioned Kconfig is NOT an empty string.
This allows users to utilize `QEMU_EXTRA_FLAGS` from shell environment. 
Otherwise, trying to inject a `-gdb` flag from shell causes a fatal clash that occurs between `-s` and `-gdb` during QEMU invocation.

Signed-off-by: Alp Sayin <alpsayin@gmail.com>