### PR TITLE
boards: arm: lpcxpresso55s36: add pyocd support

### DIFF
--- a/boards/arm/lpcxpresso55s36/board.cmake
+++ b/boards/arm/lpcxpresso55s36/board.cmake
@@ -5,5 +5,7 @@
 #
 
 board_runner_args(jlink "--device=LPC55S36" "--reset-after-load")
+board_runner_args(pyocd "--target=lpc55s36")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Add support for flashing the NXP LPCXpresso55S36 Development Board via pyOCD.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>