### PR TITLE
twister: make job server default only on Linux

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -22,7 +22,11 @@ from colorama import Fore
 from domains import Domains
 from twisterlib.cmakecache import CMakeCache
 from twisterlib.environment import canonical_zephyr_base
-from twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer, JobClient
+
+# Job server only works on Linux for now.
+if sys.platform == 'linux':
+    from twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer, JobClient
+
 from twisterlib.log_helper import log_command
 from twisterlib.testinstance import TestInstance
 
@@ -230,7 +234,11 @@ class CMake:
         if self.cwd:
             kwargs['cwd'] = self.cwd
 
-        p = self.jobserver.popen(cmd, **kwargs)
+        if sys.platform == 'linux':
+            p = self.jobserver.popen(cmd, **kwargs)
+        else:
+            p = subprocess.Popen(cmd, **kwargs)
+
         out, _ = p.communicate()
 
         results = {}
@@ -331,7 +339,10 @@ class CMake:
         if self.cwd:
             kwargs['cwd'] = self.cwd
 
-        p = self.jobserver.popen(cmd, **kwargs)
+        if sys.platform == 'linux':
+            p = self.jobserver.popen(cmd, **kwargs)
+        else:
+            p = subprocess.Popen(cmd, **kwargs)
         out, _ = p.communicate()
 
         if p.returncode == 0:
@@ -456,7 +467,7 @@ class FilterBuilder(CMake):
 class ProjectBuilder(FilterBuilder):
 
     def __init__(self, instance, env, jobserver, **kwargs):
-        super().__init__(instance.testsuite, instance.platform, instance.testsuite.source_dir, instance.build_dir, jobserver)
+        super().__init__(instance.testsuite, instance.platform, instance.testsuite.source_dir, instance.build_dir, jobserver=None)
 
         self.log = "build.log"
         self.instance = instance
@@ -915,16 +926,19 @@ class TwisterRunner:
             self.jobs = multiprocessing.cpu_count() * 2
         else:
             self.jobs = multiprocessing.cpu_count()
-        if os.name == "posix":
-            self.jobserver = GNUMakeJobClient.from_environ(jobs=self.options.jobs)
-            if not self.jobserver:
-                self.jobserver = GNUMakeJobServer(self.jobs)
-            elif self.jobserver.jobs:
-                self.jobs = self.jobserver.jobs
-        # TODO: Implement this on windows also
-        else:
-            self.jobserver = JobClient()
-        logger.info("JOBS: %d", self.jobs)
+
+        if sys.platform == "linux":
+            if os.name == 'posix':
+                self.jobserver = GNUMakeJobClient.from_environ(jobs=self.options.jobs)
+                if not self.jobserver:
+                    self.jobserver = GNUMakeJobServer(self.jobs)
+                elif self.jobserver.jobs:
+                    self.jobs = self.jobserver.jobs
+            # TODO: Implement this on windows/mac also
+            else:
+                self.jobserver = JobClient()
+
+            logger.info("JOBS: %d", self.jobs)
 
         self.update_counting_before_pipeline()
 
@@ -1018,7 +1032,21 @@ class TwisterRunner:
                     pipeline.put({"op": "cmake", "test": instance})
 
     def pipeline_mgr(self, pipeline, done_queue, lock, results):
-        with self.jobserver.get_job():
+        if sys.platform == 'linux':
+            with self.jobserver.get_job():
+                while True:
+                    try:
+                        task = pipeline.get_nowait()
+                    except queue.Empty:
+                        break
+                    else:
+                        instance = task['test']
+                        pb = ProjectBuilder(instance, self.env, self.jobserver)
+                        pb.duts = self.duts
+                        pb.process(pipeline, done_queue, task, lock, results)
+
+                return True
+        else:
             while True:
                 try:
                     task = pipeline.get_nowait()
@@ -1029,7 +1057,6 @@ class TwisterRunner:
                     pb = ProjectBuilder(instance, self.env, self.jobserver)
                     pb.duts = self.duts
                     pb.process(pipeline, done_queue, task, lock, results)
-
             return True
 
     def execute(self, pipeline, done):


### PR DESCRIPTION
Job server only works on Linux, revert to original behaviour when
running on Windows or MacOS.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
