### PR TITLE
net: context: Separate user data pointer from FIFO reserved space

### DIFF
--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -199,10 +199,11 @@ struct net_conn_handle;
  * anyway. This saves 12 bytes / context in IPv6.
  */
 __net_socket struct net_context {
-	/** User data.
-	 *
-	 *  First member of the structure to let users either have user data
-	 *  associated with a context, or put contexts into a FIFO.
+	/** First member of the structure to allow to put contexts into a FIFO.
+	 */
+	void *fifo_reserved;
+
+	/** User data associated with a context.
 	 */
 	void *user_data;
 


### PR DESCRIPTION
Using the same memory as a user data pointer and FIFO reserved space could lead to a crash in certain circumstances, those two use cases were not completely separate.

The crash could happen for example, if an incoming TCP connection was abruptly closed just after being established. As TCP uses the user data to notify error condition to the upper layer, the user data pointer could've been used while the newly allocated context could still be waiting on the accept queue. This damaged the data area used by the FIFO and eventually could lead to a crash.

Fixes #54140

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>