### PR TITLE
net: lib: Fix build warning for sockets_tls

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -6,7 +6,7 @@
  */
 
 #include <stdbool.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);


### PR DESCRIPTION
Fixes issue where a build warning would be emmited for sockets_tls.c due to usage of the deprecated fcntl.h header file.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>