### PR TITLE
tracing: scripts: Fix spelling

### DIFF
--- a/scripts/tracing/parse_ctf.py
+++ b/scripts/tracing/parse_ctf.py
@@ -26,7 +26,7 @@ import argparse
 try:
     import bt2
 except ImportError:
-    sys.exit("Missing dependency: You need to install python bindings of babletrace.")
+    sys.exit("Missing dependency: You need to install python bindings of babeltrace.")
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -111,7 +111,7 @@ def main():
                     tin = th.get('in', None)
                     tout = th.get('out', None)
                     if tout is not None and tin is not None:
-                        diff = (tout - tin)
+                        diff = tout - tin
                         th['runtime'] = diff
                 elif event.name in ['thread_switched_in']:
                     th['in'] = ns_from_origin


### PR DESCRIPTION
Fix the spelling of Babeltrace library in the warning message displayed when such a library can not be imported.

Signed-off-by: Gustavo Romero <gustavo.romero@linaro.org>