### PR TITLE
pm: adc: MEC172x adc device PM support

### DIFF
--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
@@ -102,7 +102,9 @@
 	status = "okay";
 	pinctrl-0 = <&adc00_gpio200 &adc03_gpio203
 		     &adc04_gpio204 &adc05_gpio205>;
-	pinctrl-names = "default";
+	pinctrl-1 = <&adc00_gpio200_sleep &adc03_gpio203_sleep
+		     &adc04_gpio204_sleep &adc05_gpio205_sleep>;
+	pinctrl-names = "default", "sleep";
 };
 
 &espi0 {

--- a/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi
+++ b/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi
@@ -1073,3 +1073,24 @@
 	};
 
 };
+
+/* Add Sleep Pin Control */
+&pinctrl {
+	adc00_gpio200_sleep: adc00_gpio200_sleep {
+		pinmux = < MCHP_XEC_PINMUX(0200, MCHP_AF1) >;
+		low-power-enable;
+	};
+	adc03_gpio203_sleep: adc03_gpio203_sleep {
+		pinmux = < MCHP_XEC_PINMUX(0203, MCHP_AF1) >;
+		low-power-enable;
+	};
+	adc04_gpio204_sleep: adc04_gpio204_sleep {
+		pinmux = < MCHP_XEC_PINMUX(0204, MCHP_AF1) >;
+		low-power-enable;
+	};
+	adc05_gpio205_sleep: adc05_gpio205_sleep {
+		pinmux = < MCHP_XEC_PINMUX(0205, MCHP_AF1) >;
+		low-power-enable;
+	};
+
+};


### PR DESCRIPTION
Update MEC172x adc driver to support device PM. Implement pm resume and suspend actions to put adc pins in proper state for suspend and resume. Notify kernel of busy when adc sampling is in progress.