### PR TITLE
dts: Add _STRING_UNQUOTED string and string-array

### DIFF
--- a/dts/bindings/test/vnd,string-array-unquoted.yaml
+++ b/dts/bindings/test/vnd,string-array-unquoted.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2023 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test string array unquoted property container
+
+compatible: "vnd,string-array-unquoted"
+
+properties:
+  val:
+    type: string-array
+    required: true

--- a/dts/bindings/test/vnd,string-unquoted.yaml
+++ b/dts/bindings/test/vnd,string-unquoted.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2023 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test string unquoted property container
+
+compatible: "vnd,string-unquoted"
+
+properties:
+  val:
+    type: string

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -645,6 +645,7 @@ def write_vanilla_props(node):
             macro2val[macro] = val
 
         if prop.spec.type == 'string':
+            macro2val[macro + "_STRING_UNQUOTED"] = prop.val
             macro2val[macro + "_STRING_TOKEN"] = prop.val_as_token
             macro2val[macro + "_STRING_UPPER_TOKEN"] = prop.val_as_token.upper()
 
@@ -672,6 +673,7 @@ def write_vanilla_props(node):
                 if isinstance(subval, str):
                     macro2val[macro + f"_IDX_{i}"] = quote_str(subval)
                     subval_as_token = edtlib.str_as_token(subval)
+                    macro2val[macro + f"_IDX_{i}_STRING_UNQUOTED"] = subval
                     macro2val[macro + f"_IDX_{i}_STRING_TOKEN"] = subval_as_token
                     macro2val[macro + f"_IDX_{i}_STRING_UPPER_TOKEN"] = subval_as_token.upper()
                 else:

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -566,5 +566,35 @@
 			      "token_second_idx_two",
 			      "token_second_idx_three";
 		};
+
+		test_str_unquoted_f0: string-unquoted-f0 {
+			compatible = "vnd,string-unquoted";
+			val = "0.1234";
+		};
+
+		test_str_unquoted_f1: string-unquoted-f1 {
+			compatible = "vnd,string-unquoted";
+			val = "0.9e-3";
+		};
+
+		test_str_unquoted_t: string-unquoted-t {
+			compatible = "vnd,string-unquoted";
+			val = "XA XPLUS XB";
+		};
+
+		test_stra_unquoted_f0: string-array-unquoted-f0 {
+			compatible = "vnd,string-array-unquoted";
+			val = "1.0e2", "2.0e2", "3.0e2", "4.0e2";
+		};
+
+		test_stra_unquoted_f1: string-array-unquoted-f1 {
+			compatible = "vnd,string-array-unquoted";
+			val = "0.01", "0.1", "1.0", "10.0";
+		};
+
+		test_stra_unquoted_t: string-array-unquoted-t {
+			compatible = "vnd,string-array-unquoted";
+			val = "XA XPLUS XB", "XC XPLUS XD", "XA XMINUS XB", "XC XMINUS XD";
+		};
 	};
 };

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2710,6 +2710,160 @@ ZTEST(devicetree_api, test_string_idx_token)
 }
 
 #undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_string_unquoted
+ZTEST(devicetree_api, test_string_unquoted)
+{
+#define XA 12.0
+#define XB 34.0
+#define XPLUS +
+	const double f0_expected = 0.1234;
+	const double f1_expected = 0.9e-3;
+	const double delta = 0.1e-4;
+
+	/* Test DT_STRING_UNQUOTED */
+	zassert_within(DT_STRING_UNQUOTED(DT_NODELABEL(test_str_unquoted_f0), val),
+		       f0_expected, delta, "");
+	zassert_within(DT_STRING_UNQUOTED(DT_NODELABEL(test_str_unquoted_f1), val),
+		       f1_expected, delta, "");
+	zassert_within(DT_STRING_UNQUOTED(DT_NODELABEL(test_str_unquoted_t), val),
+		       XA XPLUS XB, delta, "");
+	/* Test DT_STRING_UNQUOTED_OR */
+	zassert_within(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_f0), val, (0.0)),
+		       f0_expected, delta, "");
+	zassert_within(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_f1), val, (0.0)),
+		       f1_expected, delta, "");
+	zassert_within(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_t), val, (0.0)),
+		       XA XPLUS XB, delta, "");
+	zassert_within(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_f0), nak, (0.0)),
+		       0.0, delta, "");
+	zassert_within(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_f1), nak, (0.0)),
+		       0.0, delta, "");
+	zassert_within(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_t), nak, (0.0)),
+		       0.0, delta, "");
+	/* Test DT_INST_STRING_UNQUOTED */
+#define STRING_UNQUOTED_VAR(node_id) _CONCAT(var_, node_id)
+#define STRING_UNQUOTED_TEST_INST_EXPANSION(inst) \
+	double STRING_UNQUOTED_VAR(DT_DRV_INST(inst)) = DT_INST_STRING_UNQUOTED(inst, val);
+	DT_INST_FOREACH_STATUS_OKAY(STRING_UNQUOTED_TEST_INST_EXPANSION);
+
+	zassert_within(STRING_UNQUOTED_VAR(DT_NODELABEL(test_str_unquoted_f0)),
+		       f0_expected, delta, "");
+	zassert_within(STRING_UNQUOTED_VAR(DT_NODELABEL(test_str_unquoted_f1)),
+		       f1_expected, delta, "");
+	zassert_within(STRING_UNQUOTED_VAR(DT_NODELABEL(test_str_unquoted_t)), XA XPLUS XB,
+		       delta, "");
+
+	/* Test DT_INST_STRING_UNQUOTED_OR */
+#define STRING_UNQUOTED_OR_VAR(node_id) _CONCAT(var_or_, node_id)
+#define STRING_UNQUOTED_OR_TEST_INST_EXPANSION(inst)       \
+	double STRING_UNQUOTED_OR_VAR(DT_DRV_INST(inst))[2] = { \
+		DT_INST_STRING_UNQUOTED_OR(inst, val, (1.0e10)),   \
+		DT_INST_STRING_UNQUOTED_OR(inst, dummy, (1.0e10))  \
+	};
+	DT_INST_FOREACH_STATUS_OKAY(STRING_UNQUOTED_OR_TEST_INST_EXPANSION);
+
+	zassert_within(STRING_UNQUOTED_OR_VAR(DT_NODELABEL(test_str_unquoted_f0))[0],
+		       f0_expected, delta, "");
+	zassert_within(STRING_UNQUOTED_OR_VAR(DT_NODELABEL(test_str_unquoted_f1))[0],
+		       f1_expected, delta, "");
+	zassert_within(STRING_UNQUOTED_OR_VAR(DT_NODELABEL(test_str_unquoted_t))[0],
+		       XA XPLUS XB, delta, "");
+	zassert_within(STRING_UNQUOTED_OR_VAR(DT_NODELABEL(test_str_unquoted_f0))[1],
+		       1.0e10, delta, "");
+	zassert_within(STRING_UNQUOTED_OR_VAR(DT_NODELABEL(test_str_unquoted_f1))[1],
+		       1.0e10, delta, "");
+	zassert_within(STRING_UNQUOTED_OR_VAR(DT_NODELABEL(test_str_unquoted_t))[1],
+		       1.0e10, delta, "");
+#undef XA
+#undef XB
+#undef XPLUS
+}
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_string_array_unquoted
+ZTEST(devicetree_api, test_string_idx_unquoted)
+{
+#define XA 12.0
+#define XB 34.0
+#define XC 56.0
+#define XD 78.0
+#define XPLUS +
+#define XMINUS -
+	const double delta = 0.1e-4;
+
+	/* DT_STRING_UNQUOTED_BY_IDX */
+	zassert_within(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_f0), val, 0),
+		       1.0e2, delta, "");
+	zassert_within(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_f0), val, 1),
+		       2.0e2, delta, "");
+	zassert_within(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_f0), val, 2),
+		       3.0e2, delta, "");
+	zassert_within(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_f0), val, 3),
+		       4.0e2, delta, "");
+
+	zassert_within(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_f1), val, 0),
+		       0.01, delta, "");
+	zassert_within(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_f1), val, 1),
+		       0.1,  delta, "");
+	zassert_within(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_f1), val, 2),
+		       1.0,  delta, "");
+	zassert_within(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_f1), val, 3),
+		       10.0, delta, "");
+
+	zassert_within(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_t), val, 0),
+		       XA XPLUS XB, delta, "");
+	zassert_within(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_t), val, 1),
+		       XC XPLUS XD,  delta, "");
+	zassert_within(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_t), val, 2),
+		       XA XMINUS XB,  delta, "");
+	zassert_within(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_t), val, 3),
+		       XC XMINUS XD, delta, "");
+
+#define STRING_UNQUOTED_BY_IDX_VAR(node_id) _CONCAT(var_, node_id)
+#define STRING_UNQUOTED_BY_IDX_TEST_INST_EXPANSION(inst)       \
+	double STRING_UNQUOTED_BY_IDX_VAR(DT_DRV_INST(inst))[] = { \
+		DT_INST_STRING_UNQUOTED_BY_IDX(inst, val, 0),          \
+		DT_INST_STRING_UNQUOTED_BY_IDX(inst, val, 1),          \
+		DT_INST_STRING_UNQUOTED_BY_IDX(inst, val, 2),          \
+		DT_INST_STRING_UNQUOTED_BY_IDX(inst, val, 3),          \
+	};
+	DT_INST_FOREACH_STATUS_OKAY(STRING_UNQUOTED_BY_IDX_TEST_INST_EXPANSION);
+
+	zassert_within(STRING_UNQUOTED_BY_IDX_VAR(DT_NODELABEL(test_stra_unquoted_f0))[0],
+		       1.0e2, delta, "");
+	zassert_within(STRING_UNQUOTED_BY_IDX_VAR(DT_NODELABEL(test_stra_unquoted_f0))[1],
+		       2.0e2, delta, "");
+	zassert_within(STRING_UNQUOTED_BY_IDX_VAR(DT_NODELABEL(test_stra_unquoted_f0))[2],
+		       3.0e2, delta, "");
+	zassert_within(STRING_UNQUOTED_BY_IDX_VAR(DT_NODELABEL(test_stra_unquoted_f0))[3],
+		       4.0e2, delta, "");
+
+	zassert_within(STRING_UNQUOTED_BY_IDX_VAR(DT_NODELABEL(test_stra_unquoted_f1))[0],
+		       0.01, delta, "");
+	zassert_within(STRING_UNQUOTED_BY_IDX_VAR(DT_NODELABEL(test_stra_unquoted_f1))[1],
+		       0.1,  delta, "");
+	zassert_within(STRING_UNQUOTED_BY_IDX_VAR(DT_NODELABEL(test_stra_unquoted_f1))[2],
+		       1.0,  delta, "");
+	zassert_within(STRING_UNQUOTED_BY_IDX_VAR(DT_NODELABEL(test_stra_unquoted_f1))[3],
+		       10.0, delta, "");
+
+	zassert_within(STRING_UNQUOTED_BY_IDX_VAR(DT_NODELABEL(test_stra_unquoted_t))[0],
+		       XA XPLUS XB, delta, "");
+	zassert_within(STRING_UNQUOTED_BY_IDX_VAR(DT_NODELABEL(test_stra_unquoted_t))[1],
+		       XC XPLUS XD,  delta, "");
+	zassert_within(STRING_UNQUOTED_BY_IDX_VAR(DT_NODELABEL(test_stra_unquoted_t))[2],
+		       XA XMINUS XB,  delta, "");
+	zassert_within(STRING_UNQUOTED_BY_IDX_VAR(DT_NODELABEL(test_stra_unquoted_t))[3],
+		       XC XMINUS XD, delta, "");
+#undef XA
+#undef XB
+#undef XC
+#undef XD
+#undef XPLUS
+#undef XMINUS
+}
+
+#undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_adc_temp_sensor
 ZTEST(devicetree_api, test_reset)
 {


### PR DESCRIPTION
This commit adds access to the string values without a quotes.

Why we need this?
Its main purpose is to allow the optimal usage of floating points in dts. I am using privately to describe some RC components and also PT100 coefficients. In any big system we may just use a string and then transform it to float by one of string conversion functions. In embedded system it would be a waste of resources.

I can imagine also the usage of this functionality to put some equations that may be then processed by c compiler directly, like:

```
transform-function = "sin(x) + 12.0";
```

The usage of this "unquoted" strings gives really many possibilities, probably exceeding the two samples described here.

The tests operates on the basic idea here - to use it to provide floating point number to the code.