### PR TITLE
lib/libc: Enable picolibc on qemu_x86_tiny

### DIFF
--- a/boards/x86/qemu_x86/Kconfig.defconfig
+++ b/boards/x86/qemu_x86/Kconfig.defconfig
@@ -112,6 +112,6 @@ config X86_EXTRA_PAGE_TABLE_PAGES
 
 config DEMAND_PAGING_PAGE_FRAMES_RESERVE
 	# Need to accommodate the heap for newlib in libc-hook.c
-	default 6 if NEWLIB_LIBC || PICOLIBC
+	default 6 if NEWLIB_LIBC || (PICOLIBC && PICOLIBC_HEAP_SIZE > 0)
 
 endif # BOARD_QEMU_X86_TINY

--- a/boards/x86/qemu_x86/qemu_x86_tiny.ld
+++ b/boards/x86/qemu_x86/qemu_x86_tiny.ld
@@ -393,10 +393,10 @@ SECTIONS
 		*(.text.*.constprop)
 		*(.text.*.constprop.*)
 
-#ifdef CONFIG_NEWLIB_LIBC
+#if defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_PICOLIBC)
 		*libc.a:(.text)
 		*libc.a:(.text.*)
-#endif /* CONFIG_NEWLIB_LIBC */
+#endif
 
 #ifdef CONFIG_COVERAGE
 		*(.text._sub_I_00100_0)
@@ -437,10 +437,10 @@ SECTIONS
 		*(.rodata.str*.*)
 		*(.rodata.*.str*.*)
 
-#ifdef CONFIG_NEWLIB_LIBC
+#if defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_PICOLIBC)
 		*libc.a:(.rodata)
 		*libc.a:(.rodata.*)
-#endif /* CONFIG_NEWLIB_LIBC */
+#endif
 
 #include <snippets-rodata.ld>
 #include <snippets-pinned-rodata.ld>

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -22,7 +22,6 @@ config PICOLIBC_SUPPORTED
 	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "arcmwdt"
 	depends on !(CPP && "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr")
 	# picolibc text is outside .pinned.text on this board. #54148
-	depends on !BOARD_QEMU_X86_TINY
 	default y
 	help
 	  Selected when the target has support for picolibc.

--- a/tests/arch/x86/pagetables/src/main.c
+++ b/tests/arch/x86/pagetables/src/main.c
@@ -111,6 +111,11 @@ ZTEST(x86_pagetables, test_ram_perms)
 		} else if (IN_REGION(__gcov_bss, pos)) {
 			expected = MMU_P | MMU_RW | MMU_US | MMU_XD;
 #endif
+#if defined(CONFIG_LINKER_USE_PINNED_SECTION) && \
+	!defined(CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)
+		} else if (IN_REGION(_app_smem_pinned, pos)) {
+			expected = MMU_P | MMU_RW | MMU_US | MMU_XD;
+#endif
 #if !defined(CONFIG_X86_KPTI) && !defined(CONFIG_X86_COMMON_PAGE_TABLE) && \
 				  defined(CONFIG_USERSPACE)
 		} else if (IN_REGION(_app_smem, pos)) {

--- a/tests/kernel/mem_protect/demand_paging/testcase.yaml
+++ b/tests/kernel/mem_protect/demand_paging/testcase.yaml
@@ -4,9 +4,12 @@ tests:
   kernel.demand_paging:
     tags: kernel mmu demand_paging
     filter: CONFIG_DEMAND_PAGING
+    extra_configs:
+      - CONFIG_PICOLIBC_HEAP_SIZE=0
   kernel.demand_paging.timing_funcs:
     tags: kernel mmu demand_paging
     platform_allow: qemu_x86_tiny
     filter: CONFIG_DEMAND_PAGING
     extra_configs:
       - CONFIG_DEMAND_PAGING_STATS_USING_TIMING_FUNCTIONS=y
+      - CONFIG_PICOLIBC_HEAP_SIZE=0

--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -5,7 +5,7 @@ tests:
   kernel.memory_protection:
     filter: CONFIG_ARCH_HAS_USERSPACE
     platform_exclude: twr_ke18f
-    extra_args: CONFIG_TEST_HW_STACK_PROTECTION=n
+    extra_args: CONFIG_TEST_HW_STACK_PROTECTION=n CONFIG_MINIMAL_LIBC=y
   kernel.memory_protection.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS
     arch_allow: arc


### PR DESCRIPTION
This series resolves the small number of failures when running the test suite using picolibc by default. All of them are pretty straightforward except for the change to the `kernel.memory_protection` test -- that test generates double fault errors on this board during nearly every run, even with the minimal C library, although in that case the error usually occurs after the test completes, during the cleanup code. I spent some quality time digging into it and it looks like whatever memory protection changes are made cause troubles when faulting in text pages for the main thread. I'm afraid I gave up attempting to find the actual problem and just switched to forcing that test to use the minimal C library.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54148