### PR TITLE
arch: Double privileged stack space with emulation

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -288,6 +288,7 @@ config USERSPACE
 
 config PRIVILEGED_STACK_SIZE
 	int "Size of privileged stack"
+	default 2048 if EMUL
 	default 1024
 	depends on ARCH_HAS_USERSPACE
 	help


### PR DESCRIPTION
Additional privileged stack space is used by peripheral emulators when userspace is enabled. This is largely due to additional function calls and data structures allocated on the stack. This can potentially lead to stack overflow if the privileged stack size isn't high enough, causing an exception.

Increase the privileged stack space when userspace and peripheral emulation are enabled.

Signed-off-by: Aaron Massey <aaronmassey@google.com>