### PR TITLE
WIP: add new west sign configuration file

### DIFF
--- a/boards/common/intel_adsp.board.cmake
+++ b/boards/common/intel_adsp.board.cmake
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# TODO: remove, moved to sign.py
 board_runner_args(intel_adsp "--default-key=${RIMAGE_SIGN_KEY}")
 
 board_finalize_runner_args(intel_adsp)

--- a/boards/xtensa/intel_adsp_cavs15/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs15/board.cmake
@@ -7,7 +7,7 @@ endif()
 
 board_set_flasher_ifnset(intel_adsp)
 
-set(RIMAGE_SIGN_KEY otc_private_key.pem)
+set(RIMAGE_SIGN_KEY "otc_private_key.pem" CACHE STRING "default rimage key")
 
 board_set_rimage_target(apl)
 

--- a/boards/xtensa/intel_adsp_cavs18/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs18/board.cmake
@@ -7,7 +7,7 @@ endif()
 
 board_set_flasher_ifnset(intel_adsp)
 
-set(RIMAGE_SIGN_KEY otc_private_key.pem)
+set(RIMAGE_SIGN_KEY "otc_private_key.pem" CACHE STRING "default rimage key")
 
 board_set_rimage_target(cnl)
 

--- a/boards/xtensa/intel_adsp_cavs20/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs20/board.cmake
@@ -7,7 +7,7 @@ endif()
 
 board_set_flasher_ifnset(intel_adsp)
 
-set(RIMAGE_SIGN_KEY otc_private_key.pem)
+set(RIMAGE_SIGN_KEY "otc_private_key.pem" CACHE STRING "default rimage key")
 
 if(CONFIG_BOARD_INTEL_ADSP_CAVS20)
 board_set_rimage_target(icl)

--- a/boards/xtensa/intel_adsp_cavs25/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs25/board.cmake
@@ -7,7 +7,7 @@ endif()
 
 board_set_flasher_ifnset(intel_adsp)
 
-set(RIMAGE_SIGN_KEY otc_private_key_3k.pem)
+set(RIMAGE_SIGN_KEY "otc_private_key_3k.pem" CACHE STRING "default rimage key")
 
 if(CONFIG_BOARD_INTEL_ADSP_CAVS25)
 board_set_rimage_target(tgl)

--- a/scripts/west_commands/runners/intel_adsp.py
+++ b/scripts/west_commands/runners/intel_adsp.py
@@ -14,6 +14,8 @@ from runners.core import ZephyrBinaryRunner, RunnerCaps
 from zephyr_ext_common import ZEPHYR_BASE
 
 DEFAULT_CAVSTOOL='soc/xtensa/intel_adsp/tools/cavstool_client.py'
+
+# This is being moved to `west sign` where it belongs
 DEFAULT_SOF_MOD_DIR=os.path.join(ZEPHYR_BASE, '../modules/audio/sof')
 DEFAULT_RIMAGE_TOOL=shutil.which('rimage')
 DEFAULT_CONFIG_DIR=os.path.join(DEFAULT_SOF_MOD_DIR, 'rimage/config')
@@ -113,6 +115,8 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
             sys.exit(1)
 
     def sign(self, **kwargs):
+        return # this is being moved to build time and
+               # soc/xtensa/intel_adsp/common/CMakeLists.txt
         path_opt = ['-p', f'{self.rimage_tool}'] if self.rimage_tool else []
         sign_cmd = (
             ['west', 'sign', '-d', f'{self.cfg.build_dir}', '-t', 'rimage']

--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -56,6 +56,8 @@ endif()
 add_custom_target(
   gen_modules ALL
   DEPENDS ${ZEPHYR_FINAL_EXECUTABLE}
+  BYPRODUCTS ${CMAKE_BINARY_DIR}/zephyr/main.mod
+  ${CMAKE_BINARY_DIR}/zephyr/boot.mod
 
   # The .fw_metadata section may not be present (xcc's older linker
   # will remove it if empty).  Extract it here (which will create an
@@ -99,6 +101,20 @@ add_custom_target(
       ${CMAKE_BINARY_DIR}/zephyr/main.mod
       ${CMAKE_BINARY_DIR}/zephyr/main.mod 2>${NULL_FILE}
 )
+
+# west sign
+
+# TODO: align with zephyr/cmake/mcuboot.cmake, maybe share some code?
+
+if(ZEPHYR_WEST_SIGN_CONFIG)
+  set(sign_config_opt "-c;${ZEPHYR_WEST_SIGN_CONFIG}")
+endif()
+
+add_custom_target(rimage_target ALL
+  DEPENDS ${CMAKE_BINARY_DIR}/zephyr/boot.mod ${CMAKE_BINARY_DIR}/zephyr/main.mod ${ZEPHYR_WEST_SIGN_CONFIG}
+  COMMAND west sign ${sign_config_opt} --tool rimage --build-dir ${CMAKE_BINARY_DIR}
+  )
+
 
 if(CONFIG_BUILD_OUTPUT_STRIPPED)
 add_custom_command(


### PR DESCRIPTION
Proof of concept that "works for me"

Start by looking at the `sign.rst` doc update than explains the rationale.

Like #52942, this moves rimage earlier to `west build` time instead of `west flash`.

Unlike #52942, this moves the rimage configuration logic not to CMake but to `west sign` configuration instead.

Should fix thesofproject/sof/issues/6917

Signed-off-by: Marc Herbert <marc.herbert@intel.com>