### PR TITLE
drivers: usb_dc_rpi_pico: correctly toggle between data1/data0 on to_device control transfers

### DIFF
--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -102,10 +102,6 @@ static int udc_rpi_start_xfer(uint8_t ep, const void *data, size_t len)
 		}
 	} else {
 		ep_state->read_offset = 0;
-
-		if (USB_EP_GET_IDX(ep) == 0) {
-			ep_state->next_pid = 1;
-		}
 	}
 
 	LOG_DBG("xfer ep %d len %d pid: %d", ep, len, ep_state->next_pid);
@@ -125,6 +121,7 @@ static void udc_rpi_handle_setup(void)
 
 	/* Set DATA1 PID for the next (data or status) stage */
 	udc_rpi_get_ep_state(USB_CONTROL_EP_IN)->next_pid = 1;
+	udc_rpi_get_ep_state(USB_CONTROL_EP_OUT)->next_pid = 1;
 
 	msg.ep = USB_CONTROL_EP_OUT;
 	msg.type = USB_DC_EP_SETUP;


### PR DESCRIPTION
drivers: usb_dc_rpi_pico: correctly toggle between data1/data0 on to_device control transfers

The data stage of Control transfers that are sent from Host to Device, can be made out of multiple OUT transactions, if the amount of data to be transmitted is larger than the endpoint size. When this happens, the DATA pid should be toggling. The USB Device driver of the pico must correctly prime the EP0_OUT buffer with the correct data PID, otherwise the hardware will reject the received transaction.

Before this change the driver used to always prime EP0_OUT with a DATA1 pid. After this change the driver only uses DATA1 pid after a setup transaction, and then toggles the pid for each transaction.

Partially fixes https://github.com/zephyrproject-rtos/zephyr/issues/52705