### PR TITLE
usb: add const to usb_reqtype_is_to_host/device function calls

### DIFF
--- a/include/zephyr/usb/usb_ch9.h
+++ b/include/zephyr/usb/usb_ch9.h
@@ -76,7 +76,7 @@ struct usb_setup_packet {
  * @param setup Pointer to USB Setup packet
  * @return true If transfer direction is to host
  */
-static inline bool usb_reqtype_is_to_host(struct usb_setup_packet *setup)
+static inline bool usb_reqtype_is_to_host(const struct usb_setup_packet *setup)
 {
 	return setup->RequestType.direction == USB_REQTYPE_DIR_TO_HOST;
 }
@@ -87,7 +87,7 @@ static inline bool usb_reqtype_is_to_host(struct usb_setup_packet *setup)
  * @param setup Pointer to USB Setup packet
  * @return true If transfer direction is to device
  */
-static inline bool usb_reqtype_is_to_device(struct usb_setup_packet *setup)
+static inline bool usb_reqtype_is_to_device(const struct usb_setup_packet *setup)
 {
 	return setup->RequestType.direction == USB_REQTYPE_DIR_TO_DEVICE;
 }


### PR DESCRIPTION
This makes it possible to call them on const structures without getting a compiler warning.
