### PR TITLE
drivers: usb_dc_rpi_pico: avoid infinite unhandled irq retriggers

### DIFF
--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -235,6 +235,30 @@ static void udc_rpi_isr(const void *arg)
 		handled |= USB_INTS_ERROR_DATA_SEQ_BITS;
 	}
 
+	if (status & USB_INTS_ERROR_RX_TIMEOUT_BITS) {
+		LOG_WRN("rx timeout");
+		hw_clear_alias(usb_hw)->sie_status = USB_SIE_STATUS_RX_TIMEOUT_BITS;
+		handled |= USB_INTS_ERROR_RX_TIMEOUT_BITS;
+	}
+
+	if (status & USB_INTS_ERROR_RX_OVERFLOW_BITS) {
+		LOG_WRN("rx overflow");
+		hw_clear_alias(usb_hw)->sie_status = USB_SIE_STATUS_RX_OVERFLOW_BITS;
+		handled |= USB_INTS_ERROR_RX_OVERFLOW_BITS;
+	}
+
+	if (status & USB_INTS_ERROR_BIT_STUFF_BITS) {
+		LOG_WRN("bit stuff error");
+		hw_clear_alias(usb_hw)->sie_status = USB_SIE_STATUS_BIT_STUFF_ERROR_BITS;
+		handled |= USB_INTS_ERROR_BIT_STUFF_BITS;
+	}
+
+	if (status & USB_INTS_ERROR_CRC_BITS) {
+		LOG_ERR("crc error");
+		hw_clear_alias(usb_hw)->sie_status = USB_SIE_STATUS_CRC_ERROR_BITS;
+		handled |= USB_INTS_ERROR_CRC_BITS;
+	}
+
 	if (status ^ handled) {
 		LOG_ERR("unhandled IRQ: 0x%x", (uint)(status ^ handled));
 	}


### PR DESCRIPTION
This driver enables a number of interrupts it does not attempt to handle. This results in "unhandled IRQ: 0x...." messages being printed, and the interrupt handler retriggers immediately again, and this happens again and again forver, because nothing ends up clearing the interrupt.

This change implements very limited handling of these interrupts. A custom warning is logged, and the interrupt is cleared.

This change does not imply that doing this is sufficient. More changes may need to be implemented to more gracefully re-start transactions or re-arm some endpoints, but this is one step in the right direction, and at least the OS doesn't freeze up.

Fixes: #54462