### PR TITLE
[osdp_fixes 3/5] More CP and PD state management cleanups

### DIFF
--- a/subsys/mgmt/osdp/src/osdp.c
+++ b/subsys/mgmt/osdp/src/osdp.c
@@ -32,8 +32,8 @@ struct osdp_device {
 	int rx_event_data;
 	struct k_fifo rx_event_fifo;
 #endif
-	uint8_t rx_fbuf[CONFIG_OSDP_UART_BUFFER_LENGTH];
-	uint8_t tx_fbuf[CONFIG_OSDP_UART_BUFFER_LENGTH];
+	uint8_t rx_fbuf[OSDP_PACKET_BUF_SIZE];
+	uint8_t tx_fbuf[OSDP_PACKET_BUF_SIZE];
 	struct uart_config dev_config;
 	const struct device *dev;
 	int wait_for_mark;

--- a/subsys/mgmt/osdp/src/osdp_common.h
+++ b/subsys/mgmt/osdp/src/osdp_common.h
@@ -11,6 +11,7 @@
 #include <zephyr/sys/__assert.h>
 
 #define OSDP_RESP_TOUT_MS              (200)
+#define OSDP_PD_SC_TIMEOUT_MS          (800)
 
 #define OSDP_QUEUE_SLAB_SIZE \
 	(sizeof(union osdp_ephemeral_data) * CONFIG_OSDP_PD_COMMAND_QUEUE_SIZE)

--- a/subsys/mgmt/osdp/src/osdp_common.h
+++ b/subsys/mgmt/osdp/src/osdp_common.h
@@ -502,7 +502,8 @@ int osdp_phy_packet_finalize(struct osdp_pd *p, uint8_t *buf,
 			       int len, int max_len);
 int osdp_phy_check_packet(struct osdp_pd *pd, uint8_t *buf, int len,
 			  int *one_pkt_len);
-int osdp_phy_decode_packet(struct osdp_pd *p, uint8_t *buf, int len);
+int osdp_phy_decode_packet(struct osdp_pd *p, uint8_t *buf, int len,
+			   uint8_t **pkt_start);
 void osdp_phy_state_reset(struct osdp_pd *pd);
 int osdp_phy_packet_get_data_offset(struct osdp_pd *p, const uint8_t *buf);
 uint8_t *osdp_phy_packet_get_smb(struct osdp_pd *p, const uint8_t *buf);

--- a/subsys/mgmt/osdp/src/osdp_common.h
+++ b/subsys/mgmt/osdp/src/osdp_common.h
@@ -11,7 +11,10 @@
 #include <zephyr/sys/__assert.h>
 
 #define OSDP_RESP_TOUT_MS              (200)
+#define OSDP_ONLINE_RETRY_WAIT_MAX_MS  (300 * 1000)
+#define OSDP_PACKET_BUF_SIZE           CONFIG_OSDP_UART_BUFFER_LENGTH
 #define OSDP_PD_SC_TIMEOUT_MS          (800)
+#define OSDP_ONLINE_RETRY_WAIT_MAX_MS  (300 * 1000)
 
 #define OSDP_QUEUE_SLAB_SIZE \
 	(sizeof(union osdp_ephemeral_data) * CONFIG_OSDP_PD_COMMAND_QUEUE_SIZE)
@@ -182,8 +185,6 @@ enum osdp_cp_phy_state_e {
 	OSDP_CP_PHY_STATE_REPLY_WAIT,
 	OSDP_CP_PHY_STATE_WAIT,
 	OSDP_CP_PHY_STATE_ERR,
-	OSDP_CP_PHY_STATE_ERR_WAIT,
-	OSDP_CP_PHY_STATE_CLEANUP,
 };
 
 enum osdp_cp_state_e {
@@ -456,10 +457,11 @@ struct osdp_pd {
 #else
 	enum osdp_cp_state_e state;
 	enum osdp_cp_phy_state_e phy_state;
+	uint32_t wait_ms;
 	int64_t phy_tstamp;
 #endif
 	int64_t tstamp;
-	uint8_t rx_buf[CONFIG_OSDP_UART_BUFFER_LENGTH];
+	uint8_t rx_buf[OSDP_PACKET_BUF_SIZE];
 	int rx_buf_len;
 
 	int cmd_id;

--- a/subsys/mgmt/osdp/src/osdp_cp.c
+++ b/subsys/mgmt/osdp/src/osdp_cp.c
@@ -623,6 +623,18 @@ static void cp_flush_command_queue(struct osdp_pd *pd)
 	}
 }
 
+static inline void cp_set_state(struct osdp_pd *pd, enum osdp_cp_state_e state)
+{
+	pd->state = state;
+	CLEAR_FLAG(pd, PD_FLAG_AWAIT_RESP);
+}
+
+static inline void cp_set_online(struct osdp_pd *pd)
+{
+	cp_set_state(pd, OSDP_CP_STATE_ONLINE);
+	pd->tstamp = 0;
+}
+
 static inline void cp_set_offline(struct osdp_pd *pd)
 {
 	sc_deactivate(pd);
@@ -634,12 +646,6 @@ static inline void cp_reset_state(struct osdp_pd *pd)
 {
 	pd->state = OSDP_CP_STATE_INIT;
 	osdp_phy_state_reset(pd);
-}
-
-static inline void cp_set_state(struct osdp_pd *pd, enum osdp_cp_state_e state)
-{
-	pd->state = state;
-	CLEAR_FLAG(pd, PD_FLAG_AWAIT_RESP);
 }
 
 #ifdef CONFIG_OSDP_SC_ENABLED
@@ -819,7 +825,7 @@ static int state_update(struct osdp_pd *pd)
 			break;
 		}
 #endif /* CONFIG_OSDP_SC_ENABLED */
-		cp_set_state(pd, OSDP_CP_STATE_ONLINE);
+		cp_set_online(pd);
 		break;
 #ifdef CONFIG_OSDP_SC_ENABLED
 	case OSDP_CP_STATE_SC_INIT:
@@ -834,7 +840,7 @@ static int state_update(struct osdp_pd *pd)
 			if (ISSET_FLAG(pd, PD_FLAG_SC_SCBKD_DONE)) {
 				LOG_INF("SC Failed. Online without SC");
 				pd->sc_tstamp = osdp_millis_now();
-				cp_set_state(pd, OSDP_CP_STATE_ONLINE);
+				cp_set_online(pd);
 				break;
 			}
 			SET_FLAG(pd, PD_FLAG_SC_USE_SCBKD);
@@ -847,7 +853,7 @@ static int state_update(struct osdp_pd *pd)
 		if (pd->reply_id != REPLY_CCRYPT) {
 			LOG_ERR("CHLNG failed. Online without SC");
 			pd->sc_tstamp = osdp_millis_now();
-			cp_set_state(pd, OSDP_CP_STATE_ONLINE);
+			cp_set_online(pd);
 			break;
 		}
 		cp_set_state(pd, OSDP_CP_STATE_SC_SCRYPT);
@@ -859,7 +865,7 @@ static int state_update(struct osdp_pd *pd)
 		if (pd->reply_id != REPLY_RMAC_I) {
 			LOG_ERR("SCRYPT failed. Online without SC");
 			pd->sc_tstamp = osdp_millis_now();
-			cp_set_state(pd, OSDP_CP_STATE_ONLINE);
+			cp_set_online(pd);
 			break;
 		}
 		if (ISSET_FLAG(pd, PD_FLAG_SC_USE_SCBKD)) {
@@ -869,7 +875,7 @@ static int state_update(struct osdp_pd *pd)
 		}
 		LOG_INF("SC Active");
 		pd->sc_tstamp = osdp_millis_now();
-		cp_set_state(pd, OSDP_CP_STATE_ONLINE);
+		cp_set_online(pd);
 		break;
 	case OSDP_CP_STATE_SET_SCBK:
 		if (cp_cmd_dispatcher(pd, CMD_KEYSET) != 0) {
@@ -877,7 +883,7 @@ static int state_update(struct osdp_pd *pd)
 		}
 		if (pd->reply_id == REPLY_NAK) {
 			LOG_WRN("Failed to set SCBK; continue with SCBK-D");
-			cp_set_state(pd, OSDP_CP_STATE_ONLINE);
+			cp_set_online(pd);
 			break;
 		}
 		LOG_INF("SCBK set; restarting SC to verify new SCBK");

--- a/subsys/mgmt/osdp/src/osdp_cp.c
+++ b/subsys/mgmt/osdp/src/osdp_cp.c
@@ -123,7 +123,7 @@ static inline void assert_buf_len(int need, int have)
 static int cp_build_command(struct osdp_pd *pd, uint8_t *buf, int max_len)
 {
 	struct osdp_cmd *cmd = NULL;
-	int ret = -1, len = 0;
+	int len = 0;
 	int data_off = osdp_phy_packet_get_data_offset(pd, buf);
 #ifdef CONFIG_OSDP_SC_ENABLED
 	uint8_t *smb = osdp_phy_packet_get_smb(pd, buf);
@@ -139,45 +139,37 @@ static int cp_build_command(struct osdp_pd *pd, uint8_t *buf, int max_len)
 	case CMD_POLL:
 		assert_buf_len(CMD_POLL_LEN, max_len);
 		buf[len++] = pd->cmd_id;
-		ret = 0;
 		break;
 	case CMD_LSTAT:
 		assert_buf_len(CMD_LSTAT_LEN, max_len);
 		buf[len++] = pd->cmd_id;
-		ret = 0;
 		break;
 	case CMD_ISTAT:
 		assert_buf_len(CMD_ISTAT_LEN, max_len);
 		buf[len++] = pd->cmd_id;
-		ret = 0;
 		break;
 	case CMD_OSTAT:
 		assert_buf_len(CMD_OSTAT_LEN, max_len);
 		buf[len++] = pd->cmd_id;
-		ret = 0;
 		break;
 	case CMD_RSTAT:
 		assert_buf_len(CMD_RSTAT_LEN, max_len);
 		buf[len++] = pd->cmd_id;
-		ret = 0;
 		break;
 	case CMD_ID:
 		assert_buf_len(CMD_ID_LEN, max_len);
 		buf[len++] = pd->cmd_id;
 		buf[len++] = 0x00;
-		ret = 0;
 		break;
 	case CMD_CAP:
 		assert_buf_len(CMD_CAP_LEN, max_len);
 		buf[len++] = pd->cmd_id;
 		buf[len++] = 0x00;
-		ret = 0;
 		break;
 	case CMD_DIAG:
 		assert_buf_len(CMD_DIAG_LEN, max_len);
 		buf[len++] = pd->cmd_id;
 		buf[len++] = 0x00;
-		ret = 0;
 		break;
 	case CMD_OUT:
 		assert_buf_len(CMD_OUT_LEN, max_len);
@@ -187,7 +179,6 @@ static int cp_build_command(struct osdp_pd *pd, uint8_t *buf, int max_len)
 		buf[len++] = cmd->output.control_code;
 		buf[len++] = BYTE_0(cmd->output.timer_count);
 		buf[len++] = BYTE_1(cmd->output.timer_count);
-		ret = 0;
 		break;
 	case CMD_LED:
 		assert_buf_len(CMD_LED_LEN, max_len);
@@ -209,7 +200,6 @@ static int cp_build_command(struct osdp_pd *pd, uint8_t *buf, int max_len)
 		buf[len++] = cmd->led.permanent.off_count;
 		buf[len++] = cmd->led.permanent.on_color;
 		buf[len++] = cmd->led.permanent.off_color;
-		ret = 0;
 		break;
 	case CMD_BUZ:
 		assert_buf_len(CMD_BUZ_LEN, max_len);
@@ -220,7 +210,6 @@ static int cp_build_command(struct osdp_pd *pd, uint8_t *buf, int max_len)
 		buf[len++] = cmd->buzzer.on_count;
 		buf[len++] = cmd->buzzer.off_count;
 		buf[len++] = cmd->buzzer.rep_count;
-		ret = 0;
 		break;
 	case CMD_TEXT:
 		cmd = (struct osdp_cmd *)pd->ephemeral_data;
@@ -234,7 +223,6 @@ static int cp_build_command(struct osdp_pd *pd, uint8_t *buf, int max_len)
 		buf[len++] = cmd->text.length;
 		memcpy(buf + len, cmd->text.data, cmd->text.length);
 		len += cmd->text.length;
-		ret = 0;
 		break;
 	case CMD_COMSET:
 		assert_buf_len(CMD_COMSET_LEN, max_len);
@@ -245,7 +233,6 @@ static int cp_build_command(struct osdp_pd *pd, uint8_t *buf, int max_len)
 		buf[len++] = BYTE_1(cmd->comset.baud_rate);
 		buf[len++] = BYTE_2(cmd->comset.baud_rate);
 		buf[len++] = BYTE_3(cmd->comset.baud_rate);
-		ret = 0;
 		break;
 #ifdef CONFIG_OSDP_SC_ENABLED
 	case CMD_KEYSET:
@@ -259,12 +246,12 @@ static int cp_build_command(struct osdp_pd *pd, uint8_t *buf, int max_len)
 		buf[len++] = 16; /* key length in bytes */
 		osdp_compute_scbk(pd, buf + len);
 		len += 16;
-		ret = 0;
 		break;
 	case CMD_CHLNG:
 		assert_buf_len(CMD_CHLNG_LEN, max_len);
 		if (smb == NULL) {
-			break;
+			LOG_ERR("Invalid secure message block!");
+			return -1;
 		}
 		osdp_fill_random(pd->sc.cp_random, 8);
 		smb[0] = 3;       /* length */
@@ -273,12 +260,12 @@ static int cp_build_command(struct osdp_pd *pd, uint8_t *buf, int max_len)
 		buf[len++] = pd->cmd_id;
 		memcpy(buf + len, pd->sc.cp_random, 8);
 		len += 8;
-		ret = 0;
 		break;
 	case CMD_SCRYPT:
 		assert_buf_len(CMD_SCRYPT_LEN, max_len);
 		if (smb == NULL) {
-			break;
+			LOG_ERR("Invalid secure message block!");
+			return -1;
 		}
 		osdp_compute_cp_cryptogram(pd);
 		smb[0] = 3;       /* length */
@@ -287,7 +274,6 @@ static int cp_build_command(struct osdp_pd *pd, uint8_t *buf, int max_len)
 		buf[len++] = pd->cmd_id;
 		memcpy(buf + len, pd->sc.cp_cryptogram, 16);
 		len += 16;
-		ret = 0;
 		break;
 #endif /* CONFIG_OSDP_SC_ENABLED */
 	default:
@@ -306,10 +292,6 @@ static int cp_build_command(struct osdp_pd *pd, uint8_t *buf, int max_len)
 		smb[1] = (len > 1) ? SCS_17 : SCS_15;
 	}
 #endif /* CONFIG_OSDP_SC_ENABLED */
-	if (ret < 0) {
-		LOG_ERR("Unable to build CMD(%02x)", pd->cmd_id);
-		return OSDP_CP_ERR_GENERIC;
-	}
 
 	return len;
 }

--- a/subsys/mgmt/osdp/src/osdp_pd.c
+++ b/subsys/mgmt/osdp/src/osdp_pd.c
@@ -850,7 +850,7 @@ static int pd_receve_packet(struct osdp_pd *pd)
 
 	pd->reply_id = 0;    /* reset past reply ID so phy can send NAK */
 	pd->ephemeral_data[0] = 0; /* reset past NAK reason */
-	ret = osdp_phy_decode_packet(pd, pd->rx_buf, pd->rx_buf_len);
+	ret = osdp_phy_decode_packet(pd, pd->rx_buf, pd->rx_buf_len, &buf);
 	if (ret == OSDP_ERR_PKT_FMT) {
 		if (pd->reply_id != 0) {
 			pd->reply_id = REPLY_NAK;

--- a/subsys/mgmt/osdp/src/osdp_pd.c
+++ b/subsys/mgmt/osdp/src/osdp_pd.c
@@ -569,11 +569,10 @@ static inline void assert_buf_len(int need, int have)
 static int pd_build_reply(struct osdp_pd *pd, uint8_t *buf, int max_len)
 {
 	int ret = OSDP_PD_ERR_GENERIC;
-	int i, data_off, len = 0;
+	int i, len = 0;
 	struct osdp_cmd *cmd;
 	struct osdp_event *event;
-
-	data_off = osdp_phy_packet_get_data_offset(pd, buf);
+	int data_off = osdp_phy_packet_get_data_offset(pd, buf);
 #ifdef CONFIG_OSDP_SC_ENABLED
 	uint8_t *smb = osdp_phy_packet_get_smb(pd, buf);
 #endif

--- a/subsys/mgmt/osdp/src/osdp_phy.c
+++ b/subsys/mgmt/osdp/src/osdp_phy.c
@@ -388,7 +388,8 @@ int osdp_phy_check_packet(struct osdp_pd *pd, uint8_t *buf, int len,
 	return OSDP_ERR_PKT_NONE;
 }
 
-int osdp_phy_decode_packet(struct osdp_pd *pd, uint8_t *buf, int len)
+int osdp_phy_decode_packet(struct osdp_pd *pd, uint8_t *buf, int len,
+			   uint8_t **pkt_start)
 {
 	uint8_t *data;
 	int mac_offset;
@@ -493,7 +494,7 @@ int osdp_phy_decode_packet(struct osdp_pd *pd, uint8_t *buf, int len)
 	}
 #endif /* CONFIG_OSDP_SC_ENABLED */
 
-	memmove(buf, data, len);
+	*pkt_start = data;
 	return len;
 }
 

--- a/subsys/mgmt/osdp/src/osdp_phy.c
+++ b/subsys/mgmt/osdp/src/osdp_phy.c
@@ -256,11 +256,11 @@ out_of_space_error:
 	return OSDP_ERR_PKT_FMT;
 }
 
-int osdp_phy_decode_packet(struct osdp_pd *pd, uint8_t *buf, int len)
+int osdp_phy_check_packet(struct osdp_pd *pd, uint8_t *buf, int len,
+			  int *one_pkt_len)
 {
-	uint8_t *data;
 	uint16_t comp, cur;
-	int pkt_len, pd_addr, mac_offset;
+	int pd_addr, pkt_len;
 	struct osdp_packet_header *pkt;
 
 	/* wait till we have the header */
@@ -296,75 +296,115 @@ int osdp_phy_decode_packet(struct osdp_pd *pd, uint8_t *buf, int len)
 		return OSDP_ERR_PKT_WAIT;
 	}
 
+	if (pkt_len > CONFIG_OSDP_UART_BUFFER_LENGTH ||
+	    (unsigned long)pkt_len < sizeof(struct osdp_packet_header)) {
+		pd->reply_id = REPLY_NAK;
+		pd->ephemeral_data[0] = OSDP_PD_NAK_CMD_LEN;
+		return OSDP_ERR_PKT_NACK;
+	}
+
+	*one_pkt_len = pkt_len + (packet_has_mark(pd) ? 1 : 0);
+
+	/* validate CRC/checksum */
+	if (pkt->control & PKT_CONTROL_CRC) {
+		pkt_len -= 2; /* consume CRC */
+		cur = (buf[pkt_len + 1] << 8) | buf[pkt_len];
+		comp = osdp_compute_crc16(buf, pkt_len);
+		if (comp != cur) {
+			LOG_ERR("Invalid crc 0x%04x/0x%04x", comp, cur);
+			pd->reply_id = REPLY_NAK;
+			pd->ephemeral_data[0] = OSDP_PD_NAK_MSG_CHK;
+			return OSDP_ERR_PKT_NACK;
+		}
+	} else {
+		pkt_len -= 1; /* consume checksum */
+		cur = buf[pkt_len];
+		comp = osdp_compute_checksum(buf, pkt_len);
+		if (comp != cur) {
+			LOG_ERR("Invalid checksum %02x/%02x", comp, cur);
+			pd->reply_id = REPLY_NAK;
+			pd->ephemeral_data[0] = OSDP_PD_NAK_MSG_CHK;
+			return OSDP_ERR_PKT_NACK;
+		}
+	}
+
 	/* validate PD address */
 	pd_addr = pkt->pd_address & 0x7F;
 	if (pd_addr != pd->address && pd_addr != 0x7F) {
 		/* not addressed to us and was not broadcasted */
 		if (is_cp_mode(pd)) {
 			LOG_ERR("Invalid pd address %d", pd_addr);
-			return OSDP_ERR_PKT_FMT;
+			return OSDP_ERR_PKT_CHECK;
 		}
-		LOG_DBG("cmd for PD[%d] discarded", pd_addr);
 		return OSDP_ERR_PKT_SKIP;
 	}
 
 	/* validate sequence number */
-	cur = pkt->control & PKT_CONTROL_SQN;
-	if (is_pd_mode(pd) && cur == 0) {
-		/**
-		 * CP is trying to restart communication by sending a 0. The
-		 * current PD implementation does not hold any state between
-		 * commands so we can just set seq_number to -1 (so it gets
-		 * incremented to 0 with a call to phy_get_seq_number()) and
-		 * invalidate any established secure channels.
-		 */
-		pd->seq_number = -1;
-		CLEAR_FLAG(pd, PD_FLAG_SC_ACTIVE);
-	}
-	if (is_pd_mode(pd) && cur == pd->seq_number) {
-		/**
-		 * TODO: PD must resend the last response if CP send the same
-		 * sequence number again.
-		 */
-		LOG_ERR("seq-repeat/reply-resend feature not supported!");
-		pd->reply_id = REPLY_NAK;
-		pd->ephemeral_data[0] = OSDP_PD_NAK_SEQ_NUM;
-		return OSDP_ERR_PKT_FMT;
-	}
-	comp = osdp_phy_get_seq_number(pd, is_pd_mode(pd));
-	if (comp != cur && !ISSET_FLAG(pd, PD_FLAG_SKIP_SEQ_CHECK)) {
-		LOG_ERR("packet seq mismatch %d/%d", comp, cur);
-		pd->reply_id = REPLY_NAK;
-		pd->ephemeral_data[0] = OSDP_PD_NAK_SEQ_NUM;
-		return OSDP_ERR_PKT_FMT;
-	}
-	len -= sizeof(struct osdp_packet_header); /* consume header */
-
-	/* validate CRC/checksum */
-	if (pkt->control & PKT_CONTROL_CRC) {
-		cur = (buf[pkt_len] << 8) | buf[pkt_len - 1];
-		comp = osdp_compute_crc16(buf + 1, pkt_len - 2);
-		if (comp != cur) {
-			LOG_ERR("invalid crc 0x%04x/0x%04x", comp, cur);
-			pd->reply_id = REPLY_NAK;
-			pd->ephemeral_data[0] = OSDP_PD_NAK_MSG_CHK;
-			return OSDP_ERR_PKT_FMT;
+	comp = pkt->control & PKT_CONTROL_SQN;
+	if (is_pd_mode(pd)) {
+		if (comp == 0) {
+			/**
+			 * CP is trying to restart communication by sending a 0.
+			 * The current PD implementation does not hold any state
+			 * between commands so we can just set seq_number to -1
+			 * (so it gets incremented to 0 with a call to
+			 * phy_get_seq_number()) and invalidate any established
+			 * secure channels.
+			 */
+			pd->seq_number = -1;
+			sc_deactivate(pd);
 		}
-		mac_offset = pkt_len - 4 - 2;
-		len -= 2; /* consume CRC */
+		if (comp == pd->seq_number) {
+			/**
+			 * TODO: PD must resend the last response if CP send the
+			 * same sequence number again.
+			 */
+			LOG_ERR("seq-repeat/reply-resend not supported!");
+			pd->reply_id = REPLY_NAK;
+			pd->ephemeral_data[0] = OSDP_PD_NAK_SEQ_NUM;
+			return OSDP_ERR_PKT_NACK;
+		}
 	} else {
-		comp = osdp_compute_checksum(buf + 1, pkt_len - 1);
-		if (comp != buf[len - 1]) {
-			LOG_ERR("invalid checksum %02x/%02x", comp, cur);
-			pd->reply_id = REPLY_NAK;
-			pd->ephemeral_data[0] = OSDP_PD_NAK_MSG_CHK;
-			return OSDP_ERR_PKT_FMT;
+		if (comp == 0) {
+			/**
+			 * Check for receiving a busy reply from the PD which would
+			 * have a sequence number of 0, come in an unsecured packet
+			 * of minimum length, and have the reply ID REPLY_BUSY.
+			 */
+			if ((pkt_len == 6) && (pkt->data[0] == REPLY_BUSY)) {
+				pd->seq_number -= 1;
+				return OSDP_ERR_PKT_BUSY;
+			}
 		}
-		mac_offset = pkt_len - 4 - 1;
-		len -= 1; /* consume checksum */
+	}
+	cur = osdp_phy_get_seq_number(pd, is_pd_mode(pd));
+	if (cur != comp && !ISSET_FLAG(pd, PD_FLAG_SKIP_SEQ_CHECK)) {
+		LOG_ERR("packet seq mismatch %d/%d", cur, comp);
+		pd->reply_id = REPLY_NAK;
+		pd->ephemeral_data[0] = OSDP_PD_NAK_SEQ_NUM;
+		return OSDP_ERR_PKT_NACK;
 	}
 
+	return OSDP_ERR_PKT_NONE;
+}
+
+int osdp_phy_decode_packet(struct osdp_pd *pd, uint8_t *buf, int len)
+{
+	uint8_t *data;
+	int mac_offset;
+	struct osdp_packet_header *pkt;
+
+	if (packet_has_mark(pd)) {
+		/* Consume mark byte */
+		buf += 1;
+		len -= 1;
+	}
+
+	pkt = (struct osdp_packet_header *)buf;
+	len -= pkt->control & PKT_CONTROL_CRC ? 2 : 1;
+	mac_offset = len - 4;
 	data = pkt->data;
+	len -= sizeof(struct osdp_packet_header);
 
 #ifdef CONFIG_OSDP_SC_ENABLED
 	uint8_t *mac;
@@ -375,19 +415,19 @@ int osdp_phy_decode_packet(struct osdp_pd *pd, uint8_t *buf, int len)
 			LOG_ERR("PD is not SC capable");
 			pd->reply_id = REPLY_NAK;
 			pd->ephemeral_data[0] = OSDP_PD_NAK_SC_UNSUP;
-			return OSDP_ERR_PKT_FMT;
+			return OSDP_ERR_PKT_NACK;
 		}
 		if (pkt->data[1] < SCS_11 || pkt->data[1] > SCS_18) {
 			LOG_ERR("Invalid SB Type");
 			pd->reply_id = REPLY_NAK;
 			pd->ephemeral_data[0] = OSDP_PD_NAK_SC_COND;
-			return OSDP_ERR_PKT_FMT;
+			return OSDP_ERR_PKT_NACK;
 		}
 		if (!sc_is_active(pd) && pkt->data[1] > SCS_14) {
 			LOG_ERR("Received invalid secure message!");
 			pd->reply_id = REPLY_NAK;
 			pd->ephemeral_data[0] = OSDP_PD_NAK_SC_COND;
-			return OSDP_ERR_PKT_FMT;
+			return OSDP_ERR_PKT_NACK;
 		}
 		if (pkt->data[1] == SCS_11 || pkt->data[1] == SCS_13) {
 			/**
@@ -409,7 +449,7 @@ int osdp_phy_decode_packet(struct osdp_pd *pd, uint8_t *buf, int len)
 			LOG_ERR("Received plain-text message in SC");
 			pd->reply_id = REPLY_NAK;
 			pd->ephemeral_data[0] = OSDP_PD_NAK_SC_COND;
-			return OSDP_ERR_PKT_FMT;
+			return OSDP_ERR_PKT_NACK;
 		}
 	}
 
@@ -421,9 +461,10 @@ int osdp_phy_decode_packet(struct osdp_pd *pd, uint8_t *buf, int len)
 		mac = is_cmd ? pd->sc.c_mac : pd->sc.r_mac;
 		if (memcmp(buf + mac_offset, mac, 4) != 0) {
 			LOG_ERR("Invalid MAC; discarding SC");
+			sc_deactivate(pd);
 			pd->reply_id = REPLY_NAK;
 			pd->ephemeral_data[0] = OSDP_PD_NAK_SC_COND;
-			return OSDP_ERR_PKT_FMT;
+			return OSDP_ERR_PKT_NACK;
 		}
 		len -= 4; /* consume MAC */
 
@@ -442,9 +483,10 @@ int osdp_phy_decode_packet(struct osdp_pd *pd, uint8_t *buf, int len)
 			len = osdp_decrypt_data(pd, is_cmd, data + 1, len - 1);
 			if (len <= 0) {
 				LOG_ERR("Failed at decrypt; discarding SC");
+				sc_deactivate(pd);
 				pd->reply_id = REPLY_NAK;
 				pd->ephemeral_data[0] = OSDP_PD_NAK_SC_COND;
-				return OSDP_ERR_PKT_FMT;
+				return OSDP_ERR_PKT_NACK;
 			}
 			len += 1; /* put back cmd/reply ID */
 		}

--- a/subsys/mgmt/osdp/src/osdp_phy.c
+++ b/subsys/mgmt/osdp/src/osdp_phy.c
@@ -296,7 +296,7 @@ int osdp_phy_check_packet(struct osdp_pd *pd, uint8_t *buf, int len,
 		return OSDP_ERR_PKT_WAIT;
 	}
 
-	if (pkt_len > CONFIG_OSDP_UART_BUFFER_LENGTH ||
+	if (pkt_len > OSDP_PACKET_BUF_SIZE ||
 	    (unsigned long)pkt_len < sizeof(struct osdp_packet_header)) {
 		pd->reply_id = REPLY_NAK;
 		pd->ephemeral_data[0] = OSDP_PD_NAK_CMD_LEN;

--- a/subsys/mgmt/osdp/src/osdp_sc.c
+++ b/subsys/mgmt/osdp/src/osdp_sc.c
@@ -189,7 +189,7 @@ int osdp_compute_mac(struct osdp_pd *pd, int is_cmd,
 		     const uint8_t *data, int len)
 {
 	int pad_len;
-	uint8_t buf[CONFIG_OSDP_UART_BUFFER_LENGTH] = { 0 };
+	uint8_t buf[OSDP_PACKET_BUF_SIZE] = { 0 };
 	uint8_t iv[16];
 
 	memcpy(buf, data, len);


### PR DESCRIPTION
This PR brings in various updates such as bug fixes, enhancements and cleanups to subsys/mgmt/osdp in peripheral device and control panel mode. These changes have been tested with a st-nucleo-g474re board with secure channel enabled.

This PR is a split version of https://github.com/zephyrproject-rtos/zephyr/pull/46449 to improve review-ability (changes remain the same).