### PR TITLE
usb: add usb device support for lpc55s28 platform

### DIFF
--- a/boards/arm/lpcxpresso55s28/lpcxpresso55s28.dts
+++ b/boards/arm/lpcxpresso55s28/lpcxpresso55s28.dts
@@ -118,3 +118,7 @@
 		};
 	};
 };
+
+zephyr_udc0: &usbhs {
+	status = "okay";
+};

--- a/boards/arm/lpcxpresso55s28/lpcxpresso55s28.yaml
+++ b/boards/arm/lpcxpresso55s28/lpcxpresso55s28.yaml
@@ -21,4 +21,5 @@ supported:
   - gpio
   - i2c
   - spi
+  - usb_device
   - watchdog

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -69,6 +69,12 @@
 		reg = <0x20040000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "SRAM4";
 	};
+
+	usb_sram: memory@40100000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x40100000  DT_SIZE_K(16)>;
+		zephyr,memory-region = "USB_SRAM";
+	};
 };
 
 &peripheral {
@@ -266,6 +272,15 @@
 		offset-value-a = <10>;
 		offset-value-b = <10>;
 		#io-channel-cells = <1>;
+	};
+
+	usbhs: usbhs@144000 {
+		compatible = "nxp,mcux-usbd";
+		reg = <0x94000 0x1000>;
+		interrupts = <47 1>;
+		num-bidir-endpoints = <6>;
+		usb-controller-index = "LpcIp3511Hs0";
+		status = "disabled";
 	};
 };
 

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -312,7 +312,7 @@
 		compatible = "nxp,mcux-usbd";
 		reg = <0x94000 0x1000>;
 		interrupts = <47 1>;
-		num-bidir-endpoints = <5>;
+		num-bidir-endpoints = <6>;
 		usb-controller-index = "LpcIp3511Hs0";
 		status = "disabled";
 	};

--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S28
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S28
@@ -12,4 +12,8 @@ config PINMUX_MCUX_LPC
 	default y
 	depends on PINMUX
 
+choice USB_MCUX_CONTROLLER_TYPE
+	default USB_DC_NXP_LPCIP3511
+endchoice
+
 endif # SOC_LPC55S28


### PR DESCRIPTION
enable it for LPC55S28

all USB supported tests/samples PASS

for samples:
scripts/twister -p lpcxpresso55s28  --device-testing --hardware-map ~/map.yml  -T samples/subsys/usb/ ...
INFO    - 7 of 25 test configurations passed (100.00%), 0 failed, 18 skipped with 0 warnings in 73.49 seconds
...

for tests
scripts/twister -p lpcxpresso55s28  --device-testing --hardware-map ~/map.yml  -T tests/subsys/usb/ ...
INFO    - 3 of 4 test configurations passed (100.00%), 0 failed, 1 skipped with 0 warnings in 36.39 seconds
...

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>