### PR TITLE
Bluetooth: Controller: Fix ISO Data sn nesn on flush

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -812,6 +812,18 @@ static void isr_done(void *param)
 	/* Get reference to CIS LLL context */
 	cis_lll = param;
 
+	/* Adjust sn when flushing Tx */
+	/* FIXME: When Flush Timeout is implemented */
+	if (bn_tx <= cis_lll->tx.bn) {
+		cis_lll->sn += cis_lll->tx.bn + 1U - bn_tx;
+	}
+
+	/* Adjust nesn when flushing Rx */
+	/* FIXME: When Flush Timeout is implemented */
+	if (bn_rx <= cis_lll->rx.bn) {
+		cis_lll->nesn += cis_lll->rx.bn + 1U - bn_rx;
+	}
+
 	/* Generate ISO Data Invalid Status */
 	bn = bn_rx;
 	while (bn <= cis_lll->rx.bn) {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -531,6 +531,16 @@ static void isr_rx(void *param)
 	/* FIXME: Consider Flush Timeout when resetting current burst number */
 	if (!has_tx) {
 		has_tx = 1U;
+
+		/* Adjust sn when flushing Tx. Stop at sn != nesn, hence
+		 * (bn < cis_lll->tx.bn).
+		 */
+		/* FIXME: When Flush Timeout is implemented */
+		if (bn_tx < cis_lll->tx.bn) {
+			cis_lll->sn += cis_lll->tx.bn - bn_tx;
+		}
+
+		/* Start transmitting new burst */
 		bn_tx = 1U;
 	}
 
@@ -971,6 +981,12 @@ static void isr_done(void *param)
 
 	/* Get reference to CIS LLL context */
 	cis_lll = param;
+
+	/* Adjust nesn when flushing Rx */
+	/* FIXME: When Flush Timeout is implemented */
+	if (bn_rx <= cis_lll->rx.bn) {
+		cis_lll->nesn += cis_lll->rx.bn + 1U - bn_rx;
+	}
 
 	/* Generate ISO Data Invalid Status */
 	bn = bn_rx;


### PR DESCRIPTION
Fix sn and nesn values of ISO data when starting a new burst. When central retransmitted but did not get an ack, it did not update the sn correctly causing the peripheral to drop the next ISO data PDU.

Fixes #54342

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>