### PR TITLE
Bluetooth: Controller: Fix Central from overlapping BIG events

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -276,6 +276,9 @@ void ull_adv_sync_offset_get(struct ll_adv_set *adv);
 int ull_adv_iso_init(void);
 int ull_adv_iso_reset(void);
 
+/* Return ll_adv_iso_set context (unconditional) */
+struct ll_adv_iso_set *ull_adv_iso_get(uint8_t handle);
+
 /* helper function to initial channel map update indications */
 uint8_t ull_adv_iso_chm_update(void);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -623,6 +623,11 @@ int ull_adv_iso_reset(void)
 	return 0;
 }
 
+struct ll_adv_iso_set *ull_adv_iso_get(uint8_t handle)
+{
+	return adv_iso_get(handle);
+}
+
 uint8_t ull_adv_iso_chm_update(void)
 {
 	uint8_t handle;

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -813,6 +813,11 @@ static bool ticker_match_op_cb(uint8_t ticker_id, uint32_t ticks_slot,
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
 	       IN_RANGE(ticker_id, TICKER_ID_ADV_SYNC_BASE,
 			TICKER_ID_ADV_SYNC_LAST) ||
+
+#if defined(CONFIG_BT_CTLR_ADV_ISO)
+	       IN_RANGE(ticker_id, TICKER_ID_ADV_ISO_BASE,
+			TICKER_ID_ADV_ISO_LAST) ||
+#endif /* CONFIG_BT_CTLR_ADV_ISO */
 #endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
 #endif /* CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_BROADCASTER */
 
@@ -866,6 +871,20 @@ static struct ull_hdr *ull_hdr_get_cb(uint8_t ticker_id, uint32_t *ticks_slot)
 
 			return &sync->ull;
 		}
+
+#if defined(CONFIG_BT_CTLR_ADV_ISO)
+	} else if (IN_RANGE(ticker_id, TICKER_ID_ADV_ISO_BASE,
+			    TICKER_ID_ADV_ISO_LAST)) {
+		struct ll_adv_iso_set *adv_iso;
+
+		adv_iso = ull_adv_iso_get(ticker_id - TICKER_ID_ADV_ISO_BASE);
+		if (adv_iso) {
+			*ticks_slot = adv_iso->ull.ticks_slot;
+
+			return &adv_iso->ull;
+		}
+
+#endif /* CONFIG_BT_CTLR_ADV_ISO */
 #endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
 #endif /* CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_BROADCASTER */
 


### PR DESCRIPTION
Fix advanced scheduling to consider active BIG events when establishing new Central connections. This will schedule AUX_ADV_IND, AUX_SYNC_IND and Central connections of similar interval to be non-overlapping.

Fixes #54344.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>