### PR TITLE
uart: microchip: fix build error with PM_DEVICE=n

### DIFF
--- a/drivers/serial/uart_mchp_xec.c
+++ b/drivers/serial/uart_mchp_xec.c
@@ -915,7 +915,7 @@ static void uart_xec_irq_callback_set(const struct device *dev,
 static void uart_xec_isr(const struct device *dev)
 {
 	struct uart_xec_dev_data * const dev_data = dev->data;
-#ifdef CONFIG_UART_CONSOLE_INPUT_EXPIRED
+#if defined(CONFIG_PM_DEVICE) && defined(CONFIG_UART_CONSOLE_INPUT_EXPIRED)
 	const struct uart_xec_device_config * const dev_cfg = dev->config;
 	struct uart_regs *regs = dev_cfg->regs;
 	int rx_ready = 0;


### PR DESCRIPTION
Hi, quick hotfix for the xec uart driver, this is failing in our CI, odd combination of config options but worth fixing anyway since it triggers a build error.

Tested with `west build -p -b mec172xevb_assy6906 samples/hello_world -DCONFIG_PM=y -DCONFIG_PM_DEVICE=n -DCONFIG_UART_CONSOLE_INPUT_EXPIRED=y -DCONFIG_UART_INTERRUPT_DRIVEN=y`

---

Fix a build error when the driver is built with:

CONFIG_PM=y
CONFIG_PM_DEVICE=n
CONFIG_UART_INTERRUPT_DRIVEN=y
CONFIG_UART_CONSOLE_INPUT_EXPIRED=y

due to uart_xec_pm_policy_state_lock_get() and rx_refresh_timeout_work() declared under different configuration options.

Fixes: 343d1919f1 "uart: microchip: add low power & wake support"