### PR TITLE
Bluetooth: Trivial fixes: NULL dereference and wrong parameter check

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1466,12 +1466,12 @@ static int ase_stream_qos(struct bt_audio_stream *stream,
 {
 	struct bt_audio_ep *ep;
 
-	LOG_DBG("stream %p ep %p qos %p", stream, stream->ep, qos);
-
 	if (stream == NULL || stream->ep == NULL || qos == NULL) {
 		LOG_DBG("Invalid input stream, ep or qos pointers");
 		return -EINVAL;
 	}
+
+	LOG_DBG("stream %p ep %p qos %p", stream, stream->ep, qos);
 
 	ep = stream->ep;
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -2033,7 +2033,7 @@ int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count)
 {
 	int err;
 
-	CHECKIF(param == NULL || count == 0) {
+	CHECKIF(param == NULL) {
 		LOG_DBG("param is NULL");
 		return -EINVAL;
 	}


### PR DESCRIPTION
Fix NULL de-reference and wrong parameter check