### PR TITLE
ARC: boards: allign cross-compile toolchain suport on ARC board

### DIFF
--- a/boards/arc/em_starterkit/em_starterkit.yaml
+++ b/boards/arc/em_starterkit/em_starterkit.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - xtools
 supported:
   - i2c

--- a/boards/arc/em_starterkit/em_starterkit_em11d.yaml
+++ b/boards/arc/em_starterkit/em_starterkit_em11d.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - xtools
 supported:
   - i2c

--- a/boards/arc/em_starterkit/em_starterkit_em7d.yaml
+++ b/boards/arc/em_starterkit/em_starterkit_em7d.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - xtools
 supported:
   - i2c

--- a/boards/arc/em_starterkit/em_starterkit_em7d_v22.yaml
+++ b/boards/arc/em_starterkit/em_starterkit_em7d_v22.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - xtools
 supported:
   - i2c

--- a/boards/arc/emsdp/emsdp.yaml
+++ b/boards/arc/emsdp/emsdp.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - xtools
 ram: 128
 testing:

--- a/boards/arc/emsdp/emsdp_em4.yaml
+++ b/boards/arc/emsdp/emsdp_em4.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - xtools
 ram: 128
 testing:

--- a/boards/arc/emsdp/emsdp_em5d.yaml
+++ b/boards/arc/emsdp/emsdp_em5d.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - xtools
 ram: 128
 testing:

--- a/boards/arc/emsdp/emsdp_em6.yaml
+++ b/boards/arc/emsdp/emsdp_em6.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - xtools
 ram: 128
 testing:

--- a/boards/arc/emsdp/emsdp_em7d.yaml
+++ b/boards/arc/emsdp/emsdp_em7d.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - xtools
 ram: 128
 testing:

--- a/boards/arc/emsdp/emsdp_em7d_esp.yaml
+++ b/boards/arc/emsdp/emsdp_em7d_esp.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - xtools
 ram: 128
 testing:

--- a/boards/arc/emsdp/emsdp_em9d.yaml
+++ b/boards/arc/emsdp/emsdp_em9d.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - xtools
 ram: 128
 testing:

--- a/boards/arc/hsdk/hsdk.yaml
+++ b/boards/arc/hsdk/hsdk.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - xtools
   - arcmwdt
 testing:

--- a/boards/arc/hsdk/hsdk_2cores.yaml
+++ b/boards/arc/hsdk/hsdk_2cores.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - xtools
   - arcmwdt
 testing:

--- a/boards/arc/iotdk/iotdk.yaml
+++ b/boards/arc/iotdk/iotdk.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - xtools
 ram: 128
 testing:

--- a/boards/arc/nsim/nsim_em.yaml
+++ b/boards/arc/nsim/nsim_em.yaml
@@ -6,6 +6,7 @@ simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - arcmwdt
 testing:
   ignore_tags:

--- a/boards/arc/nsim/nsim_em11d.yaml
+++ b/boards/arc/nsim/nsim_em11d.yaml
@@ -5,6 +5,7 @@ simulation: nsim
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - arcmwdt
 testing:
   ignore_tags:

--- a/boards/arc/nsim/nsim_em7d_v22.yaml
+++ b/boards/arc/nsim/nsim_em7d_v22.yaml
@@ -6,6 +6,7 @@ simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
 testing:
   ignore_tags:
     - net

--- a/boards/arc/nsim/nsim_hs.yaml
+++ b/boards/arc/nsim/nsim_hs.yaml
@@ -6,6 +6,7 @@ simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - arcmwdt
 testing:
   ignore_tags:

--- a/boards/arc/nsim/nsim_hs_flash_xip.yaml
+++ b/boards/arc/nsim/nsim_hs_flash_xip.yaml
@@ -6,6 +6,7 @@ simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - arcmwdt
 testing:
   ignore_tags:

--- a/boards/arc/nsim/nsim_hs_mpuv6.yaml
+++ b/boards/arc/nsim/nsim_hs_mpuv6.yaml
@@ -6,6 +6,7 @@ simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - arcmwdt
 testing:
   default: true

--- a/boards/arc/nsim/nsim_hs_smp.yaml
+++ b/boards/arc/nsim/nsim_hs_smp.yaml
@@ -6,6 +6,7 @@ simulation_exec: mdb
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - arcmwdt
 testing:
   timeout_multiplier: 1.5

--- a/boards/arc/nsim/nsim_hs_sram.yaml
+++ b/boards/arc/nsim/nsim_hs_sram.yaml
@@ -6,6 +6,7 @@ simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
   - arcmwdt
 testing:
   ignore_tags:

--- a/boards/arc/nsim/nsim_sem.yaml
+++ b/boards/arc/nsim/nsim_sem.yaml
@@ -6,6 +6,7 @@ simulation: nsim
 simulation_exec: nsimdrv
 toolchain:
   - zephyr
+  - cross-compile
   - arcmwdt
 testing:
   default: true

--- a/boards/arc/nsim/nsim_sem_mpu_stack_guard.yaml
+++ b/boards/arc/nsim/nsim_sem_mpu_stack_guard.yaml
@@ -6,6 +6,7 @@ simulation: nsim
 simulation_exec: nsimdrv
 toolchain:
   - zephyr
+  - cross-compile
   - arcmwdt
 testing:
   ignore_tags:

--- a/boards/arc/qemu_arc/qemu_arc_em.yaml
+++ b/boards/arc/qemu_arc/qemu_arc_em.yaml
@@ -5,6 +5,7 @@ simulation: qemu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
 testing:
   default: true
   ignore_tags:

--- a/boards/arc/qemu_arc/qemu_arc_hs.yaml
+++ b/boards/arc/qemu_arc/qemu_arc_hs.yaml
@@ -5,6 +5,7 @@ simulation: qemu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
 testing:
   default: true
   ignore_tags:

--- a/boards/arc/qemu_arc/qemu_arc_hs_xip.yaml
+++ b/boards/arc/qemu_arc/qemu_arc_hs_xip.yaml
@@ -5,6 +5,7 @@ simulation: qemu
 arch: arc
 toolchain:
   - zephyr
+  - cross-compile
 testing:
   default: true
   ignore_tags:


### PR DESCRIPTION
Allow cross-compile toolchain for all ARC target which support zephyr toolchain. Replace old outdated 'xtools' (which initially was used for cross compile toolchains) with 'cross-compile'.

This aligns the behavior between ARC targets - as some of them were supporting zephyr toolchain but weren't supporting cross-compile toolchain (which wasn't actually true).