### PR TITLE
Add the pyocd as a runner for stm32F303 and stm32f334 nucleo boards

### DIFF
--- a/boards/arm/nucleo_f303k8/board.cmake
+++ b/boards/arm/nucleo_f303k8/board.cmake
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=STM32F303K8" "--speed=4000")
+board_runner_args(pyocd "--target=stm32f303k8tx")
+board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
+board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_f334r8/board.cmake
+++ b/boards/arm/nucleo_f334r8/board.cmake
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=STM32F334R8" "--speed=4000")
+board_runner_args(pyocd "--target=stm32f334r8tx")
+board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
+board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/soc/arm/st_stm32/stm32f3/soc.c
+++ b/soc/arm/st_stm32/stm32f3/soc.c
@@ -11,6 +11,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <stm32_ll_system.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr/arch/arm/aarch32/nmi.h>
@@ -42,6 +43,9 @@ static int stm32f3_init(const struct device *arg)
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 8 MHz from HSI */
 	SystemCoreClock = 8000000;
+
+	/* Allow reflashing the board */
+	LL_DBGMCU_EnableDBGSleepMode();
 
 	return 0;
 }


### PR DESCRIPTION
Add the pyocd as a runner for the nucleo_f303k8 and nucleo_f334r8 boards for flashing and debugging.

If the stm32f303k8tx/ stm32f334r8tx  is not in the list of targets for pyocd :
`$ pyocd list --targets`
then add the pack for pyocd
`$ pyocd pack install stm32f303`  `$ pyocd pack install stm32f334`  

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54117

Nucleo_f334r8 and nucleo_f303k8 report the same error with openocd : unable to write the flash after erasing

Signed-off-by: Francois Ramu <francois.ramu@st.com>