### PR TITLE
riscv: Do not remove ESF when SOC_ISR_SW_UNSTACKING

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -633,7 +633,6 @@ fp_trap_exit:
 #else
 	/* Restore caller-saved registers from thread stack */
 	DO_CALLER_SAVED(lr)
-#endif /* CONFIG_RISCV_SOC_HAS_ISR_STACKING */
 
 #ifdef CONFIG_USERSPACE
 	/* retrieve saved stack pointer */
@@ -642,5 +641,7 @@ fp_trap_exit:
 	/* remove esf from the stack */
 	addi sp, sp, __z_arch_esf_t_SIZEOF
 #endif
+
+#endif /* CONFIG_RISCV_SOC_HAS_ISR_STACKING */
 
 	mret


### PR DESCRIPTION
When CONFIG_SOC_ISR_SW_UNSTACKING is defined, it's up to the custom soc code to remove the ESF, because the software-managed part of the ESF is depending on the hardware. Fix this in the ISR code.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>