### PR TITLE
samples: canbus: isotp: add option for running in loopback mode

### DIFF
--- a/samples/subsys/canbus/isotp/Kconfig
+++ b/samples/subsys/canbus/isotp/Kconfig
@@ -1,0 +1,13 @@
+# Private config options to the ISO-TP sample
+
+# Copyright (c) 2023 Vestas Wind Systems A/S
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "ISO-TP sample"
+
+config SAMPLE_LOOPBACK_MODE
+	bool "Use CAN loopback mode"
+	help
+	  Set the CAN controller to loopback mode. This allows testing without a second board.
+
+source "Kconfig.zephyr"

--- a/samples/subsys/canbus/isotp/sample.yaml
+++ b/samples/subsys/canbus/isotp/sample.yaml
@@ -1,13 +1,14 @@
 sample:
-  name: ISO-TP lib sample
+  name: ISO-TP sample
 tests:
   sample.subsys.canbus.isotp:
     tags: can isotp
     depends_on: can
-    filter: dt_chosen_enabled("zephyr,canbus")
+    filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")
+    extra_configs:
+      - CONFIG_SAMPLE_LOOPBACK_MODE=y
     harness: console
     harness_config:
       type: one_line
       regex:
-        - "(.*)Got 248 bytes in total"
-      fixture: fixture_can_two_boards
+        - "(.*)Got 247 bytes in total"

--- a/samples/subsys/canbus/isotp/src/main.c
+++ b/samples/subsys/canbus/isotp/src/main.c
@@ -154,6 +154,14 @@ void main(void)
 		return;
 	}
 
+#ifdef CONFIG_SAMPLE_LOOPBACK_MODE
+	ret = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
+	if (ret != 0) {
+		printk("CAN: Failed to set loopback mode [%d]", ret);
+		return;
+	}
+#endif /* CONFIG_SAMPLE_LOOPBACK_MODE */
+
 	ret = can_start(can_dev);
 	if (ret != 0) {
 		printk("CAN: Failed to start device [%d]\n", ret);


### PR DESCRIPTION
Add Kconfig option for running the CAN ISO-TP sample in loopback mode. This removes the need for a fixture when running the sample via twister.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>