### PR TITLE
drivers: ieee802154_rf2xx: Correct bit mask

### DIFF
--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -267,7 +267,7 @@ static void rf2xx_process_tx_frame(const struct device *dev)
 	struct rf2xx_context *ctx = dev->data;
 
 	ctx->trx_trac = (rf2xx_iface_reg_read(dev, RF2XX_TRX_STATE_REG) >>
-			 RF2XX_TRAC_STATUS) & 7;
+			 RF2XX_TRAC_STATUS) & RF2XX_TRAC_BIT_MASK;
 	k_sem_give(&ctx->trx_tx_sync);
 	rf2xx_trx_set_rx_state(dev);
 }

--- a/drivers/ieee802154/ieee802154_rf2xx_regs.h
+++ b/drivers/ieee802154/ieee802154_rf2xx_regs.h
@@ -295,6 +295,6 @@
 
 /* RX_STATUS */
 #define RF2XX_RX_TRAC_STATUS                4
-#define RF2XX_RX_TRAC_BIT_MASK              0x03
+#define RF2XX_RX_TRAC_BIT_MASK              0x07
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_RF2XX_REGS_H_ */

--- a/drivers/ieee802154/ieee802154_rf2xx_regs.h
+++ b/drivers/ieee802154/ieee802154_rf2xx_regs.h
@@ -100,6 +100,7 @@
 /* TRX_STATE */
 #define RF2XX_TRAC_STATUS                   5
 #define RF2XX_TRX_CMD                       0
+#define RF2XX_TRAC_BIT_MASK                 7
 
 /* TRX_CTRL_0 */
 #define RF2XX_TOM_EN                        7
@@ -295,6 +296,6 @@
 
 /* RX_STATUS */
 #define RF2XX_RX_TRAC_STATUS                4
-#define RF2XX_RX_TRAC_BIT_MASK              0x07
+#define RF2XX_RX_TRAC_BIT_MASK              RF2XX_TRAC_BIT_MASK
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_RF2XX_REGS_H_ */


### PR DESCRIPTION
Correct bit mask for RF2XX_RX_TRAC_BIT_MASK. Current mask produce dead code warnings when comparing to value:

RF2XX_TRX_PHY_STATE_TRAC_INVALID = 0x07