### PR TITLE
tests: canbus: isotp: conformance: skip stmin test on low tick Hz

### DIFF
--- a/tests/subsys/canbus/isotp/conformance/src/main.c
+++ b/tests/subsys/canbus/isotp/conformance/src/main.c
@@ -788,6 +788,11 @@ ZTEST(isotp_conformance, test_stmin)
 	struct can_frame raw_frame;
 	uint32_t start_time, time_diff;
 
+	if (CONFIG_SYS_CLOCK_TICKS_PER_SEC < 1000) {
+		/* This test requires millisecond tick resolution */
+		ztest_test_skip();
+	}
+
 	ff_frame.data[0] = FF_PCI_BYTE_1(DATA_SIZE_FF + DATA_SIZE_CF * 4);
 	ff_frame.data[1] = FF_PCI_BYTE_2(DATA_SIZE_FF + DATA_SIZE_CF * 4);
 	memcpy(&ff_frame.data[2], random_data, DATA_SIZE_FF);

--- a/tests/subsys/canbus/isotp/conformance/testcase.yaml
+++ b/tests/subsys/canbus/isotp/conformance/testcase.yaml
@@ -3,4 +3,3 @@ tests:
     tags: can isotp
     depends_on: can
     filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")
-    platform_exclude: native_posix native_posix_64


### PR DESCRIPTION
The CAN ISO-TP conformance test expects to receive a frame within STmin (5 msec) + upper tolerance (5msec) = 10msec. The expectation fails when `CONFIG_SYS_CLOCK_TICKS_PER_SEC` is too low.
    
Skip the STmin test case to allow the test suite to succeed on non-tickless and emulation platforms, where `CONFIG_SYS_CLOCK_TICKS_PER_SEC` defaults to `100`. Enable the tests for `native_posix` and `native_posix_64`.

Fixes: #54254

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>