### PR TITLE
riscv: Do not check mhartid on CONFIG_MP_MAX_NUM_CPUS == 1

### DIFF
--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -38,6 +38,9 @@ SECTION_FUNC(reset, __reset)
  * the C domain
  */
 SECTION_FUNC(TEXT, __initialize)
+#if (CONFIG_MP_MAX_NUM_CPUS == 1) && (CONFIG_RV_BOOT_HART == 0)
+	j boot_first_core
+#endif
 	csrr a0, mhartid
 	li t0, CONFIG_RV_BOOT_HART
 	beq a0, t0, boot_first_core


### PR DESCRIPTION
For CONFIG_MP_MAX_NUM_CPUS == 1 we assume that the mhartid is 0 so we can skip the check at reset.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>

Note: this is also done for out-of-spec RISCV cores where the `mhartid` is not set to `0` out of the factory.