### PR TITLE
Bluetooth: Audio: Shell: Fix issue with setting contexts

### DIFF
--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -1942,28 +1942,33 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 
 	if (IS_ENABLED(CONFIG_BT_PAC_SNK_LOC)) {
 		err = bt_pacs_set_location(BT_AUDIO_DIR_SINK, LOCATION);
-		__ASSERT(err == 0, "Failed to set sink location");
+		__ASSERT(err == 0, "Failed to set sink location: %d", err);
 
 		err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK,
 						     CONTEXT);
-		__ASSERT(err == 0, "Failed to set sink supported contexts");
+		__ASSERT(err == 0, "Failed to set sink supported contexts: %d",
+			 err);
 
 		err = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SINK,
 						     CONTEXT);
-		__ASSERT(err == 0, "Failed to set sink available contexts");
+		__ASSERT(err == 0, "Failed to set sink available contexts: %d",
+			 err);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_PAC_SRC_LOC)) {
 		err = bt_pacs_set_location(BT_AUDIO_DIR_SOURCE, LOCATION);
-		__ASSERT(err == 0, "Failed to set source location");
+		__ASSERT(err == 0, "Failed to set source location: %d", err);
 
-		err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SINK,
+		err = bt_pacs_set_supported_contexts(BT_AUDIO_DIR_SOURCE,
 						     CONTEXT);
-		__ASSERT(err == 0, "Failed to set sink supported contexts");
+		__ASSERT(err == 0, "Failed to set sink supported contexts: %d",
+			 err);
 
 		err = bt_pacs_set_available_contexts(BT_AUDIO_DIR_SOURCE,
 						     CONTEXT);
-		__ASSERT(err == 0, "Failed to set source available contexts");
+		__ASSERT(err == 0,
+			 "Failed to set source available contexts: %d",
+			 err);
 	}
 
 #if defined(CONFIG_BT_AUDIO_UNICAST)


### PR DESCRIPTION
There was a bug where BT_AUDIO_DIR_SINK should have been BT_AUDIO_DIR_SOURCE when setting supported contexts.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>