### PR TITLE
drivers: timer: mcux: lptmr: add dependency on CONFIG_PM

### DIFF
--- a/drivers/timer/Kconfig.mcux_lptmr
+++ b/drivers/timer/Kconfig.mcux_lptmr
@@ -8,6 +8,7 @@ config MCUX_LPTMR_TIMER
 	default y
 	depends on DT_HAS_NXP_KINETIS_LPTMR_ENABLED
 	depends on !COUNTER_MCUX_LPTMR
+	depends on PM
 	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
 	help
 	  This module implements a kernel device driver for the NXP MCUX Low


### PR DESCRIPTION
The introduction of cc2c05a90cd6b573c8702ae4c117c3e64efa42a9 caused CONFIG_MCUX_LPTMR_TIMER to always be enabled for boards where the NXP LPTMR is enabled in the board devicetree.

Using this low-power timer as system timer only makes sense when using power management. Otherwise, it just results in a lower tick resolution and non-tickless operation.

Add dependency on CONFIG_PM for CONFIG_MCUX_LPTMR_TIMER.

Fixes: #54258

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>