### PR TITLE
include: tracing: fix k_fifo peek defines

### DIFF
--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -1174,7 +1174,7 @@
  * @brief Trace FIFO Queue peek head entry
  * @param fifo FIFO object
  */
-#define sys_port_trace_k_fifo_peek_head_entry(fifo)
+#define sys_port_trace_k_fifo_peek_head_enter(fifo)
 
 /**
  * @brief Trace FIFO Queue peek head exit
@@ -1187,7 +1187,7 @@
  * @brief Trace FIFO Queue peek tail entry
  * @param fifo FIFO object
  */
-#define sys_port_trace_k_fifo_peek_tail_entry(fifo)
+#define sys_port_trace_k_fifo_peek_tail_enter(fifo)
 
 /**
  * @brief Trace FIFO Queue peek tail exit


### PR DESCRIPTION
Corrects `k_fifo_peek_head` and `k_fifo_peek_tail` defines to end with `enter` rather than `entry`.

Tracing macros expect `ENTER` defines to end with `enter`:
https://github.com/zephyrproject-rtos/zephyr/blob/48a6f160f285785d61101446930689c57468b332/include/zephyr/tracing/tracing_macros.h#L52-L53

They are being used in `k_fifo_peek_tail`
https://github.com/zephyrproject-rtos/zephyr/blob/48a6f160f285785d61101446930689c57468b332/include/zephyr/kernel.h#L2461-L2467
and `k_fifo_peek_head`:
https://github.com/zephyrproject-rtos/zephyr/blob/48a6f160f285785d61101446930689c57468b332/include/zephyr/kernel.h#L2442-L2448

Currently used `k_fifo_peek_head_entry` and `k_fifo_peek_tail_entry` lead to linked failure.