### PR TITLE
Bluetooth: Controller: Fix overlapping multiple BIG events

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -95,14 +95,14 @@ int ull_sched_adv_aux_sync_free_slot_get(uint8_t user_id,
 
 		} else if (IN_RANGE(ticker_id, TICKER_ID_ADV_AUX_BASE,
 				    TICKER_ID_ADV_AUX_LAST)) {
-			const struct ll_adv_aux_set *aux;
-
-			aux = (void *)ull_hdr_get_cb(ticker_id, &ticks_slot);
-
 			*ticks_anchor += ticks_to_expire;
 			*ticks_anchor += ticks_slot;
 
 			if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
+				const struct ll_adv_aux_set *aux;
+
+				aux = (void *)ull_hdr_get_cb(ticker_id,
+							     &ticks_slot);
 				*ticks_anchor +=
 					MAX(aux->ull.ticks_active_to_start,
 					    aux->ull.ticks_prepare_to_start);
@@ -113,20 +113,40 @@ int ull_sched_adv_aux_sync_free_slot_get(uint8_t user_id,
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC)
 		} else if (IN_RANGE(ticker_id, TICKER_ID_ADV_SYNC_BASE,
 				    TICKER_ID_ADV_SYNC_LAST)) {
-			const struct ll_adv_sync_set *sync;
-
-			sync = (void *)ull_hdr_get_cb(ticker_id, &ticks_slot);
-
 			*ticks_anchor += ticks_to_expire;
 			*ticks_anchor += ticks_slot;
 
 			if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
+				const struct ll_adv_sync_set *sync;
+
+				sync = (void *)ull_hdr_get_cb(ticker_id,
+							      &ticks_slot);
 				*ticks_anchor +=
 					MAX(sync->ull.ticks_active_to_start,
 					    sync->ull.ticks_prepare_to_start);
 			}
 
 			return 0;
+
+#if defined(CONFIG_BT_CTLR_ADV_ISO)
+		} else if (IN_RANGE(ticker_id, TICKER_ID_ADV_ISO_BASE,
+				    TICKER_ID_ADV_ISO_LAST)) {
+			*ticks_anchor += ticks_to_expire;
+			*ticks_anchor += ticks_slot;
+
+			if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
+				const struct ll_adv_iso_set *iso;
+
+				iso = (void *)ull_hdr_get_cb(ticker_id,
+							     &ticks_slot);
+				*ticks_anchor +=
+					MAX(iso->ull.ticks_active_to_start,
+					    iso->ull.ticks_prepare_to_start);
+			}
+
+			return 0;
+
+#endif /* CONFIG_BT_CTLR_ADV_ISO */
 #endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
 
 #if defined(CONFIG_BT_CONN)


### PR DESCRIPTION
Update advanced scheduling implementation to consider other active BIG events when scheduling new BIG instances.

Fixes #54393

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>