### PR TITLE
tests: sensor: fix reg address sequential

### DIFF
--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -642,7 +642,7 @@ test_i2c_icp10125: icp10125@63 {
 	pressure-measurement-mode = "normal";
 };
 
-test_i2c_as5600: as5600@54 {
+test_i2c_as5600: as5600@64 {
 	compatible = "ams,as5600";
-	reg = <0x54>;
+	reg = <0x64>;
 };


### PR DESCRIPTION
The address of the last added sensor did not fit into the
sequential reg address scheme.
Changed the address to fit into the convention.

Signed-off-by: Peter Fecher <p.fecher@phytec.de>