### PR TITLE
Bluetooth: Controller: Fix AUX_ADV_IND AUX_SYNC_IND radio utilization

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -282,6 +282,21 @@ config BT_CTLR_ADV_RESERVE_MAX
 	  corresponding to the Advertising Data present at the time of the
 	  start/enable of Advertising is used.
 
+config BT_CTLR_ADV_AUX_SYNC_OFFSET
+	int "Pre-defined offset between AUX_ADV_IND and AUX_SYNC_IND"
+	depends on BT_CTLR_ADV_PERIODIC
+	default 0
+	help
+	  Define an offset between AUX_ADV_IND and AUX_SYNC_IND when using
+	  Advertising Interval for the Extended Advertising and Periodic
+	  Advertising that are same or multiple of each other, respectively.
+	  Note, to get advertising intervals that are same or multiple,
+	  the Periodic Advertising Interval shall be 10 millisecond more than
+	  the Extended Advertising Interval; this is because the AUX_ADV_IND
+	  PDUs are scheduled as periodic events of Extended Advertising
+	  Interval plus 10 milliseconds (Advertising Random Delay) as the
+	  periodic interval.
+
 config BT_CTLR_ADV_DATA_BUF_MAX
 	int "Advertising Data Maximum Buffers"
 	depends on BT_BROADCASTER

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1493,6 +1493,8 @@ uint8_t ll_adv_enable(uint8_t enable)
 						 ticks_slot_overhead_aux;
 #endif
 
+#if !defined(CONFIG_BT_CTLR_ADV_AUX_SYNC_OFFSET) || \
+	(CONFIG_BT_CTLR_ADV_AUX_SYNC_OFFSET == 0)
 				/* Schedule periodic advertising PDU after
 				 * auxiliary PDUs.
 				 * Reduce the MAFS offset by the Event Overhead
@@ -1503,13 +1505,20 @@ uint8_t ll_adv_enable(uint8_t enable)
 				 * to accumulation of remainder to maintain
 				 * average ticker interval.
 				 */
-				uint32_t ticks_anchor_sync =
-					ticks_anchor_aux + ticks_slot_aux +
+				uint32_t ticks_anchor_sync = ticks_anchor_aux +
+					ticks_slot_aux +
 					HAL_TICKER_US_TO_TICKS(
 						MAX(EVENT_MAFS_US,
 						    EVENT_OVERHEAD_START_US) -
 						EVENT_OVERHEAD_START_US +
 						(EVENT_TICKER_RES_MARGIN_US << 1));
+
+#else /* CONFIG_BT_CTLR_ADV_AUX_SYNC_OFFSET */
+				uint32_t ticks_anchor_sync = ticks_anchor_aux +
+					HAL_TICKER_US_TO_TICKS(
+						CONFIG_BT_CTLR_ADV_AUX_SYNC_OFFSET);
+
+#endif /* CONFIG_BT_CTLR_ADV_AUX_SYNC_OFFSET */
 
 				ticks_slot_overhead = ull_adv_sync_evt_init(adv, sync, NULL);
 				ret = ull_adv_sync_start(adv, sync,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -907,11 +907,13 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 			 */
 			lll_aux = adv->lll.aux;
 			aux = HDR_LLL2ULL(lll_aux);
-			ticks_anchor_aux =
-				ticker_ticks_now_get() +
+			ticks_anchor_aux = ticker_ticks_now_get() +
 				HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 			ticks_slot_overhead_aux =
 				ull_adv_aux_evt_init(aux, &ticks_anchor_aux);
+
+#if !defined(CONFIG_BT_CTLR_ADV_AUX_SYNC_OFFSET) || \
+	(CONFIG_BT_CTLR_ADV_AUX_SYNC_OFFSET == 0)
 			ticks_anchor_sync = ticks_anchor_aux +
 				ticks_slot_overhead_aux + aux->ull.ticks_slot +
 				HAL_TICKER_US_TO_TICKS(
@@ -919,6 +921,13 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 					    EVENT_OVERHEAD_START_US) -
 					EVENT_OVERHEAD_START_US +
 					(EVENT_TICKER_RES_MARGIN_US << 1));
+
+#else /* CONFIG_BT_CTLR_ADV_AUX_SYNC_OFFSET */
+			ticks_anchor_sync = ticks_anchor_aux +
+				HAL_TICKER_US_TO_TICKS(
+					CONFIG_BT_CTLR_ADV_AUX_SYNC_OFFSET);
+
+#endif /* CONFIG_BT_CTLR_ADV_AUX_SYNC_OFFSET */
 		}
 
 		ret = ull_adv_sync_start(adv, sync, ticks_anchor_sync,

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -882,6 +882,17 @@ static struct ull_hdr *ull_hdr_get_cb(uint8_t ticker_id, uint32_t *ticks_slot)
 				*ticks_slot = HAL_TICKER_US_TO_TICKS(time_us);
 			} else {
 				*ticks_slot = aux->ull.ticks_slot;
+
+#if defined(CONFIG_BT_CTLR_ADV_AUX_SYNC_OFFSET) && \
+	(CONFIG_BT_CTLR_ADV_AUX_SYNC_OFFSET != 0)
+				struct ll_adv_sync_set *sync;
+
+				sync = HDR_LLL2ULL(aux->lll.adv->sync);
+				if (sync->ull.ticks_slot > *ticks_slot) {
+					*ticks_slot = sync->ull.ticks_slot;
+				}
+#endif /* CONFIG_BT_CTLR_ADV_AUX_SYNC_OFFSET */
+
 			}
 
 			return &aux->ull;


### PR DESCRIPTION
Fix AUX_ADV_IND AUX_SYNC_IND radio utilization by having a configurable offset.

Define an offset between AUX_ADV_IND and AUX_SYNC_IND when using Advertising Interval for the Extended Advertising and Periodic Advertising that are same or multiple of each other, respectively.

Note, to get advertising intervals that are same or multiple, the Periodic Advertising Interval shall be 10 millisecond more than the Extended Advertising Interval; this is because the AUX_ADV_IND PDUs are scheduled as periodic events of Extended Advertising Interval plus 10 milliseconds (Advertising Random Delay) as the periodic interval.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>