### PR TITLE
drivers: flash: shell: add verify step to cmd_test

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -209,6 +209,8 @@ static int cmd_test(const struct shell *shell, size_t argc, char *argv[])
 	uint32_t addr;
 	uint32_t size;
 
+	static uint8_t __aligned(4) check_arr[TEST_ARR_SIZE];
+
 	result = parse_helper(shell, &argc, &argv, &flash_dev, &addr);
 	if (result) {
 		return result;
@@ -241,15 +243,29 @@ static int cmd_test(const struct shell *shell, size_t argc, char *argv[])
 		result = flash_write(flash_dev, addr, test_arr, size);
 
 		if (result) {
-			shell_error(shell, "Write internal ERROR!");
+			shell_error(shell, "Write failed, code %d", result);
 			break;
 		}
 
 		shell_print(shell, "Write OK.");
+
+		result = flash_read(flash_dev, addr, check_arr, size);
+
+		if (result < 0) {
+			shell_print(shell, "Verification read failed, code: %d", result);
+			break;
+		}
+
+		if (memcmp(test_arr, check_arr, size) != 0) {
+			shell_error(shell, "Verification ERROR!");
+			break;
+		}
+
+		shell_print(shell, "Verified OK.");
 	}
 
 	if (result == 0) {
-		shell_print(shell, "Erase-Write test done.");
+		shell_print(shell, "Erase-Write-Verify test done.");
 	}
 
 	return result;

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -224,6 +224,10 @@ static int cmd_test(const struct shell *shell, size_t argc, char *argv[])
 		return -EINVAL;
 	}
 
+	if (repeat == 0) {
+		repeat = 1;
+	}
+
 	for (uint32_t i = 0; i < size; i++) {
 		test_arr[i] = (uint8_t)i;
 	}


### PR DESCRIPTION
Previously cmd_test could falsely give the indication that the flash driver functioning properly, because the written data isn't validated, and thus not truley tested.

This commit a verify step to ensure the data was written successfully.

Example output:
```
uart:~$ flash test flash-controller@52002000 100000 1000
Erase OK.
Write OK.
Verified OK.
Erase-Write-Verify test done.
```

```
uart:~$ flash test qspi-nor-flash@0 0 1000
Erase OK.
Write OK.
Verification ERROR!
Erase-Write-Verify test done.
```

Signed-off-by: Hein Wessels <heinwessels93@gmail.com>