### PR TITLE
net: pkt: Allow zero payload for non-IPv4/v6 frames

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -870,7 +870,7 @@ static struct net_buf *pkt_alloc_buffer(struct net_buf_pool *pool,
 	struct net_buf *first = NULL;
 	struct net_buf *current = NULL;
 
-	while (size) {
+	do {
 		struct net_buf *new;
 
 		new = net_buf_alloc_fixed(pool, timeout);
@@ -911,7 +911,7 @@ static struct net_buf *pkt_alloc_buffer(struct net_buf_pool *pool,
 			pool2str(pool), get_name(pool), get_frees(pool),
 			new, new->ref, caller, line);
 #endif
-	}
+	} while (size);
 
 	return first;
 error:

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -201,6 +201,35 @@ ZTEST(net_pkt_test_suite, test_net_pkt_allocate_with_buffer)
 	net_pkt_unref(pkt);
 	zassert_true(atomic_get(&pkt->atomic_ref) == 0,
 		     "Pkt not properly unreferenced");
+
+	/* d) - with a zero payload but AF_INET family
+	 */
+	pkt = net_pkt_alloc_with_buffer(eth_if, 0,
+					AF_INET, 0, K_NO_WAIT);
+	zassert_true(pkt != NULL, "Pkt not allocated");
+
+	/* Did we get the requested size? */
+	zassert_true(pkt_is_of_size(pkt, NET_IPV4H_LEN),
+		     "Pkt size is not right");
+
+	/* Freeing the packet */
+	net_pkt_unref(pkt);
+	zassert_true(atomic_get(&pkt->atomic_ref) == 0,
+		     "Pkt not properly unreferenced");
+
+	/* e) - with a zero payload but AF_PACKET family
+	 */
+	pkt = net_pkt_alloc_with_buffer(eth_if, 0,
+					AF_PACKET, 0, K_NO_WAIT);
+	zassert_true(pkt != NULL, "Pkt not allocated");
+
+	/* Did we get the requested size? */
+	zassert_true(pkt_is_of_size(pkt, 0), "Pkt size is not right");
+
+	/* Freeing the packet */
+	net_pkt_unref(pkt);
+	zassert_true(atomic_get(&pkt->atomic_ref) == 0,
+		     "Pkt not properly unreferenced");
 }
 
 /********************************\


### PR DESCRIPTION
For socket families that are niether INET/INET e.g., PACKET, we cannot estimate header length, so, if the payload is zero as well, networking stack drop the packet.

Instead, allow for zero header + payload packets and let L2 take care of handling them, for some L2's this is still a valid frame.

E..g, In case of Wi-Fi this is sent as 802.11 Header + LLC Header (no payload).

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>

@sachinthegreen @rlubos 