### PR TITLE
mtl: bugfix: tlb driver should allow remapping all unused pages, including one at UNUSED_L2_START_ALIGNED  address

### DIFF
--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -190,7 +190,7 @@ int sys_mm_drv_map_page(void *virt, uintptr_t phys, uint32_t flags)
 	}
 
 	/* Check bounds of virtual address space */
-	CHECKIF((va <= UNUSED_L2_START_ALIGNED) ||
+	CHECKIF((va < UNUSED_L2_START_ALIGNED) ||
 		(va >= (CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_SIZE))) {
 		ret = -EINVAL;
 		goto out;
@@ -336,7 +336,7 @@ int sys_mm_drv_unmap_page(void *virt)
 	uintptr_t va = POINTER_TO_UINT(z_soc_cached_ptr(virt));
 
 	/* Check bounds of virtual address space */
-	CHECKIF((va <= UNUSED_L2_START_ALIGNED) ||
+	CHECKIF((va < UNUSED_L2_START_ALIGNED) ||
 		(va >= (CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_SIZE))) {
 		ret = -EINVAL;
 		goto out;


### PR DESCRIPTION
UNUSED_L2_START_ALIGNED is a marker of first page not used by the linker. Starting from this page, the memory may be re-mapped. assertion <= is banning remapping of the first unused page changing to <

Defect reproduces when assertions are enabled

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54410