### PR TITLE
net/net_pkt: Fix is_ppp dependency issue

### DIFF
--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -1186,7 +1186,7 @@ static inline void net_pkt_set_lldp(struct net_pkt *pkt, bool is_lldp)
 }
 #endif /* CONFIG_NET_LLDP */
 
-#if defined(CONFIG_NET_PPP)
+#if defined(CONFIG_NET_L2_PPP)
 static inline bool net_pkt_is_ppp(struct net_pkt *pkt)
 {
 	return pkt->ppp_msg;
@@ -1197,7 +1197,7 @@ static inline void net_pkt_set_ppp(struct net_pkt *pkt,
 {
 	pkt->ppp_msg = is_ppp_msg;
 }
-#else /* CONFIG_NET_PPP */
+#else /* CONFIG_NET_L2_PPP */
 static inline bool net_pkt_is_ppp(struct net_pkt *pkt)
 {
 	ARG_UNUSED(pkt);
@@ -1211,7 +1211,7 @@ static inline void net_pkt_set_ppp(struct net_pkt *pkt,
 	ARG_UNUSED(pkt);
 	ARG_UNUSED(is_ppp_msg);
 }
-#endif /* CONFIG_NET_PPP */
+#endif /* CONFIG_NET_L2_PPP */
 
 #if defined(NET_PKT_HAS_CONTROL_BLOCK)
 static inline void *net_pkt_cb(struct net_pkt *pkt)


### PR DESCRIPTION
The functions `net_pkt_is_ppp()` and `net_pkt_set_ppp()` are used by both the l2 ppp subsystem (`NET_L2_PPP`) and the ppp uart based driver (`NET_PPP`), but the function is only included when NET_PPP is enabled.

the l2 ppp subsystem does not depend on the uart based PPP driver, the ppp uart driver does however depend on the l2 ppp subsystem. Including the two functions should therefore be dependent on if the l2 ppp subsystem is enabled using the symbol `CONFIG_NET_L2_PPP` instead of the symbol `CONFIG_NET_PPP`

The dependency issue was detected while creating a PPP interface which depends on the L2 PPP subsystem, which does not require the UART based PPP driver.

Signed-off-by: Bjarki Arge Andreasen <baa@trackunit.com>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54378