### PR TITLE
soc: arm: st_stm32: fix sram devicetree nodes

### DIFF
--- a/dts/arm/st/l4/stm32l471Xg.dtsi
+++ b/dts/arm/st/l4/stm32l471Xg.dtsi
@@ -9,7 +9,10 @@
 
 / {
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(128)>;
+		reg = <0x20000000 DT_SIZE_K(96)>;
+	};
+	sram1: memory@10000000 {
+		reg = <0x10000000 DT_SIZE_K(32)>;
 	};
 	soc {
 		flash-controller@40022000 {


### PR DESCRIPTION
This commit fixes the SRAM definition for the STM32L471xx. The original definition specified a single 128KB block of SRAM however there are two blocks at different memory addresses as in this commit.

Signed-off-by: Liam Clark liam.james.clark@gmail.com