### PR TITLE
tests: net: igmp: Set allowed platforms filter

### DIFF
--- a/tests/net/igmp/testcase.yaml
+++ b/tests/net/igmp/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   tags: net igmp
   depends_on: netif
+  platform_allow: qemu_x86
 tests:
   net.igmp:
     extra_configs:


### PR DESCRIPTION
The IGMP test cases are designed to use DUMMY L2 and not on real hardware. Add an "platform_allow" filter to only run on qemu platforms.

Fixes #54087

Signed-off-by: David Leach <david.leach@nxp.com>