### PR TITLE
boards: arm: frdm_k64f: Set TEST_EXTRA_STACK_SIZE

### DIFF
--- a/boards/arm/frdm_k64f/Kconfig.defconfig
+++ b/boards/arm/frdm_k64f/Kconfig.defconfig
@@ -20,6 +20,9 @@ config MCG_VDIV0
 config MCG_FCRDIV
 	default 1
 
+config TEST_EXTRA_STACK_SIZE
+	default 128
+
 if NETWORKING
 
 config NET_L2_ETHERNET


### PR DESCRIPTION
The RTIO API test case needs a little extra stack size when run on the frdm_k64f platform.

Fixes #54086

Signed-off-by: David Leach <david.leach@nxp.com>