### PR TITLE
board: nsim: enable FPU for nsim_sem and nsim_em7d_v22

### DIFF
--- a/boards/arc/nsim/support/nsim_em7d_v22.props
+++ b/boards/arc/nsim/support/nsim_em7d_v22.props
@@ -19,6 +19,7 @@
 	nsim_isa_dsp_complex_option=1
 	nsim_isa_dsp_divsqrt_option=1
 	nsim_isa_dsp_accshift_option=1
+	nsim_isa_fpuda_option=1
 	nsim_isa_enable_timer_0=1
 	nsim_isa_timer_0_int_level=1
 	nsim_isa_enable_timer_1=1

--- a/boards/arc/nsim/support/nsim_sem.props
+++ b/boards/arc/nsim/support/nsim_sem.props
@@ -19,6 +19,7 @@
 	nsim_isa_dsp_complex_option=1
 	nsim_isa_dsp_divsqrt_option=1
 	nsim_isa_dsp_accshift_option=1
+	nsim_isa_fpuda_option=1
 	nsim_isa_enable_timer_0=1
 	nsim_isa_timer_0_int_level=1
 	nsim_isa_enable_timer_1=1


### PR DESCRIPTION
In our internal test, we found nsim_sem and nsim_em7d_v22 failed in zdsp.basicmath and zdsp.basicmath.fpu tests and instruction error exception. After investigation, we found the exception happened on FPU instruction. To run FPU instructions on nsim simulator, the simulator should be configured to enable FPU. Now add FPU feature in nsim_sem and nsim_em7d_v22 props file.