### PR TITLE
Bluetooth: Controller: Fix missing DF related radio register reset

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -19,6 +19,7 @@
 
 #include "hal/ccm.h"
 #include "hal/radio.h"
+#include "hal/radio_df.h"
 #include "hal/ticker.h"
 
 #include "ll_sw/pdu_df.h"
@@ -215,6 +216,10 @@ void radio_reset(void)
 	 *       explicitly assigned by functions in this file.
 	 */
 	NRF_RADIO->PCNF1 = HAL_RADIO_RESET_VALUE_PCNF1;
+
+#if defined(CONFIG_BT_CTLR_DF) && !defined(CONFIG_ZTEST)
+	radio_df_reset();
+#endif /* CONFIG_BT_CTLR_DF && !CONFIG_ZTEST */
 
 	/* nRF SoC specific reset/initializations, if any */
 	hal_radio_reset();


### PR DESCRIPTION
Fix missing DF related Radio register reset on radio_reset().

Regression in commit 465a96181d7d ("Bluetooth: Controller: Explicitly set all bits of used radio registers") due to the removal of NRF_RADIO->POWER register use that was used to reset all Radio registers on every new Radio Event.

Fixes #54341

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>