### PR TITLE
soc: stm32: fix rtt on stm32u5 series by enabling GPDMA1 clock

### DIFF
--- a/soc/arm/st_stm32/common/soc_config.c
+++ b/soc/arm/st_stm32/common/soc_config.c
@@ -42,6 +42,8 @@ static int st_stm32_common_config(const struct device *dev)
 	 */
 #if defined(__HAL_RCC_DMA1_CLK_ENABLE)
 	__HAL_RCC_DMA1_CLK_ENABLE();
+#elif defined(__HAL_RCC_GPDMA1_CLK_ENABLE)
+	__HAL_RCC_GPDMA1_CLK_ENABLE();
 #endif /* __HAL_RCC_DMA1_CLK_ENABLE */
 
 	/* On some STM32 boards, for unclear reason,


### PR DESCRIPTION
On some STM32 MCUs SEGGER RTT is only working with realtime updates when DMA is clocked. 
The STM32U5 series uses a new DMA controller module called GPDMA.

Refs: #34324
Fixes: #54316 