### PR TITLE
[RFC] uart: stm32: DMA circular mode support from device tree

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -121,7 +121,10 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 		stream->dma_callback(dev, stream->user_data, callback_arg, 0);
 	} else if (stm32_dma_is_tc_irq_active(dma, id)) {
 #ifdef CONFIG_DMAMUX_STM32
-		stream->busy = false;
+		/* Circular buffer never stops receiving as long as peripheral is enabled */
+		if (!stream->cyclic && stream->direction == PERIPHERAL_TO_MEMORY) {
+			stream->busy = false;
+		}
 #endif
 		/* Let HAL DMA handle flags on its own */
 		if (!stream->hal_override) {
@@ -359,6 +362,7 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 	stream->user_data       = config->user_data;
 	stream->src_size	= config->source_data_size;
 	stream->dst_size	= config->dest_data_size;
+	stream->cyclic		= config->cyclic;
 
 	/* Check dest or source memory address, warn if 0 */
 	if ((config->head_block->source_address == 0)) {
@@ -430,7 +434,7 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 	LOG_DBG("Channel (%d) peripheral inc (%x).",
 				id, DMA_InitStruct.PeriphOrM2MSrcIncMode);
 
-	if (config->head_block->source_reload_en) {
+	if (config->head_block->source_reload_en || config->cyclic) {
 		DMA_InitStruct.Mode = LL_DMA_MODE_CIRCULAR;
 	} else {
 		DMA_InitStruct.Mode = LL_DMA_MODE_NORMAL;
@@ -492,7 +496,7 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 	LL_DMA_EnableIT_TC(dma, dma_stm32_id_to_stream(id));
 
 	/* Enable Half-Transfer irq if circular mode is enabled */
-	if (config->head_block->source_reload_en) {
+	if (config->head_block->source_reload_en || config->cyclic) {
 		LL_DMA_EnableIT_HT(dma, dma_stm32_id_to_stream(id));
 	}
 

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -27,6 +27,7 @@ struct dma_stm32_stream {
 	uint32_t dst_size;
 	void *user_data; /* holds the client data */
 	dma_callback_t dma_callback;
+	bool cyclic;
 };
 
 struct dma_stm32_data {

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -873,6 +873,27 @@ static inline void async_evt_rx_rdy(struct uart_stm32_data *data)
 {
 	LOG_DBG("rx_rdy: (%d %d)", data->dma_rx.offset, data->dma_rx.counter);
 
+	/* If the DMA buffer is cyclic, the offset index might be at a higher location
+	 * than the counter index (data wrapped-around to the beginning of the buffer).
+	 * The UART API expects a continuous chunk of memory, so it is needed to
+	 * report 2 separate events
+	 */
+	if (data->dma_rx.dma_cfg.cyclic && data->dma_rx.counter < data->dma_rx.offset) {
+		struct uart_event event = {
+			.type = UART_RX_RDY,
+			.data.rx.buf = data->dma_rx.buffer,
+			.data.rx.len = data->dma_rx.buffer_length - data->dma_rx.offset,
+			.data.rx.offset = data->dma_rx.offset
+		};
+
+		/* update the current pos for next chunk */
+		data->dma_rx.offset = 0;
+
+		if (event.data.rx.len > 0) {
+			async_user_callback(data, &event);
+		}
+	}
+
 	struct uart_event event = {
 		.type = UART_RX_RDY,
 		.data.rx.buf = data->dma_rx.buffer,
@@ -972,15 +993,16 @@ static void uart_stm32_dma_rx_flush(const struct device *dev)
 	struct dma_status stat;
 	struct uart_stm32_data *data = dev->data;
 
-	if (dma_get_status(data->dma_rx.dma_dev,
-				data->dma_rx.dma_channel, &stat) == 0) {
-		size_t rx_rcv_len = data->dma_rx.buffer_length -
-					stat.pending_length;
-		if (rx_rcv_len > data->dma_rx.offset) {
-			data->dma_rx.counter = rx_rcv_len;
+	size_t rx_rcv_len = 0;
 
-			async_evt_rx_rdy(data);
-		}
+	if (dma_get_status(data->dma_rx.dma_dev,
+				   data->dma_rx.dma_channel, &stat) == 0) {
+		rx_rcv_len = data->dma_rx.buffer_length -
+			     stat.pending_length;
+
+		data->dma_rx.counter = rx_rcv_len;
+
+		async_evt_rx_rdy(data);
 	}
 }
 
@@ -1224,10 +1246,7 @@ void uart_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 
 	(void)k_work_cancel_delayable(&data->dma_rx.timeout_work);
 
-	/* true since this functions occurs when buffer if full */
-	data->dma_rx.counter = data->dma_rx.buffer_length;
-
-	async_evt_rx_rdy(data);
+	uart_stm32_dma_rx_flush(data->uart_dev);
 
 	if (data->rx_next_buffer != NULL) {
 		async_evt_rx_buf_release(data);
@@ -1237,8 +1256,9 @@ void uart_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 		 * one.
 		 */
 		uart_stm32_dma_replace_buffer(uart_dev);
-	} else {
-		/* Buffer full without valid next buffer,
+	} else if (data->dma_rx.dma_cfg.cyclic == 0) {
+		/* Buffer full without valid next buffer
+		 * and not using cyclic rx buffer,
 		 * an UART_RX_DISABLED event must be generated,
 		 * but uart_stm32_async_rx_disable() cannot be
 		 * called in ISR context. So force the RX timeout
@@ -1359,7 +1379,9 @@ static int uart_stm32_async_rx_enable(const struct device *dev,
 
 	LL_USART_EnableIT_ERROR(config->usart);
 
-	/* Request next buffer */
+	/* Request next buffer,
+	 * likely not useful if cyclic mode is used
+	 */
 	async_evt_rx_buf_request(data);
 
 	LOG_DBG("async rx enabled");
@@ -1493,7 +1515,7 @@ static int uart_stm32_async_init(const struct device *dev)
 		data->dma_rx.blk_cfg.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 	}
 
-	/* RX disable circular buffer */
+	/* RX disable circular buffer by default */
 	data->dma_rx.blk_cfg.source_reload_en  = 0;
 	data->dma_rx.blk_cfg.dest_reload_en = 0;
 	data->dma_rx.blk_cfg.fifo_mode_control = data->dma_rx.fifo_threshold;
@@ -1818,7 +1840,9 @@ static int uart_stm32_pm_action(const struct device *dev,
 		.channel_direction = STM32_DMA_CONFIG_DIRECTION(	\
 					STM32_DMA_CHANNEL_CONFIG(index, dir)),\
 		.channel_priority = STM32_DMA_CONFIG_PRIORITY(		\
-				STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),                            \
+		.cyclic = STM32_DMA_CONFIG_CYCLIC(	\
+			STM32_DMA_CHANNEL_CONFIG(index, dir)),\
 		.source_data_size = STM32_DMA_CONFIG_##src_dev##_DATA_SIZE(\
 					STM32_DMA_CHANNEL_CONFIG(index, dir)),\
 		.dest_data_size = STM32_DMA_CONFIG_##dest_dev##_DATA_SIZE(\

--- a/dts/bindings/dma/st,stm32-dma-v1.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v1.yaml
@@ -16,6 +16,9 @@ description: |
     or a value beweeen <dma-generators>+1  ..  <dma-generators>+<dma-requests>
     3. channel-config: A 32bit mask specifying the DMA channel configuration
     which is device dependent:
+        -bit 5 : Cyclic mode
+               0x0: normal mode
+               0x1: circular mode
         -bit 6-7 : Direction  (see dma.h)
                0x0: MEM to MEM
                0x1: MEM to PERIPH

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -203,7 +203,7 @@ struct dma_config {
 	uint32_t  source_chaining_en :   1;
 	uint32_t  dest_chaining_en :     1;
 	uint32_t  linked_channel   :     7;
-	uint32_t  cyclic :				 1;
+	uint32_t  cyclic :		 1;
 	uint32_t  reserved :             3;
 	uint32_t  source_data_size :    16;
 	uint32_t  dest_data_size :      16;

--- a/include/zephyr/drivers/dma/dma_stm32.h
+++ b/include/zephyr/drivers/dma/dma_stm32.h
@@ -52,6 +52,8 @@
 		DT_INST_DMAS_CELL_BY_NAME(id, dir, channel_config)
 
 /* macros for channel-config */
+/* circular mode defined on bit 5 as true/false */
+#define STM32_DMA_CONFIG_CYCLIC(config)			((config >> 5) & 0x1)
 /* direction defined on bits 6-7 */
 /* 0 -> MEM_TO_MEM, 1 -> MEM_TO_PERIPH, 2 -> PERIPH_TO_MEM */
 #define STM32_DMA_CONFIG_DIRECTION(config)		((config >> 6) & 0x3)


### PR DESCRIPTION
This PR implements the usage of the DMA circular buffer for receiving UART data on STM32.
The configuration can be set in the device tree node by setting the `cyclic` bit.
With the `cyclic` bit, both half and full transfer interrupts are triggered, allowing the user to use the received data while some other bytes are being received in the background in the other half.
`UART_RX_BUF_RELEASED` and `UART_RX_BUF_REQUEST` are not used when circular mode is used.

Usage of circular buffer can still be enforced by DMA module users through [`source_reload_en`](https://github.com/zephyrproject-rtos/zephyr/blob/5d9c65fe7f817e67cce7649874f429db9b6abf3c/include/zephyr/drivers/dma.h#L132).

This PR is an alternative to #51795 which required DMA API modifications.
In order not to use the DMA interrupt source, the UART module calls `dma_get_status()` and split the RX buffer into two parts in case the data is wrapped around the end and beginning of the RX buffer.

The might lead to small inefficiencies when the DMA buffer is being filled by the time we call `dma_get_status()` when the write index goes back to the beginning, [more info here](https://github.com/zephyrproject-rtos/zephyr/issues/52417#issuecomment-1411820424). Even though this shouldn't decrease reliability.