### PR TITLE
drivers: gpio: esp32: fix reset interrupt status on new config

### DIFF
--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -394,6 +394,12 @@ static int gpio_esp32_pin_interrupt_configure(const struct device *port,
 	}
 
 	key = irq_lock();
+	if (cfg->gpio_port == 0) {
+		gpio_ll_clear_intr_status(cfg->gpio_base, BIT(pin));
+	} else {
+		gpio_ll_clear_intr_status_high(cfg->gpio_base, BIT(pin));
+	}
+
 	gpio_ll_set_intr_type(cfg->gpio_base, io_pin, intr_trig_mode);
 	gpio_ll_intr_enable_on_core(cfg->gpio_base, CPU_ID(), io_pin);
 	irq_unlock(key);


### PR DESCRIPTION
The interrupt status of the GPIO was not cleared when a new interrupt configuration was set. 
This prevents the driver from passing all the gpio tests.

Fixes #54833 

Signed-off-by: Lucas Tamborrino <lucas.tamborrino@espressif.com>