### PR TITLE
boards: nucleo_g474re: Add stm32cubeprogrammer runner

### DIFF
--- a/boards/arm/nucleo_g474re/board.cmake
+++ b/boards/arm/nucleo_g474re/board.cmake
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=stm32g474retx")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)


### PR DESCRIPTION
More reliable than openocd in CI on this board.

Fixes #54318

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>