### PR TITLE
intel_adsp: bbzero/bmemcpy with picolibc fix

### DIFF
--- a/soc/xtensa/intel_adsp/common/include/soc.h
+++ b/soc/xtensa/intel_adsp/common/include/soc.h
@@ -69,8 +69,8 @@ static ALWAYS_INLINE void z_idelay(int n)
 /* memcopy used by boot loader */
 static ALWAYS_INLINE void bmemcpy(void *dest, void *src, size_t bytes)
 {
-	uint32_t *d = (uint32_t *)dest;
-	uint32_t *s = (uint32_t *)src;
+	volatile uint32_t *d = (uint32_t *)dest;
+	volatile uint32_t *s = (uint32_t *)src;
 
 	z_xtensa_cache_inv(src, bytes);
 	for (size_t i = 0; i < (bytes >> 2); i++)
@@ -82,7 +82,7 @@ static ALWAYS_INLINE void bmemcpy(void *dest, void *src, size_t bytes)
 /* bzero used by bootloader */
 static ALWAYS_INLINE void bbzero(void *dest, size_t bytes)
 {
-	uint32_t *d = (uint32_t *)dest;
+	volatile uint32_t *d = (uint32_t *)dest;
 
 	for (size_t i = 0; i < (bytes >> 2); i++)
 		d[i] = 0;


### PR DESCRIPTION
When building with picolibc and gcc, the loops to do zeroing/copying get replaced by gcc with calls to memset/memcpy. This fails this early in the boot process and results in an illegal instruction exception.

Marking the variables being manipulated in the calls as volatile prevents the compiler from optimizing the loops (replacing them with memset/memcpy).

Fixes #54224 for me

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>