### PR TITLE
ARC: west runner: mdb: fix unusable console after flash or debug

### DIFF
--- a/scripts/west_commands/runners/mdb.py
+++ b/scripts/west_commands/runners/mdb.py
@@ -116,8 +116,7 @@ def mdb_do_run(mdb_runner, command):
     else:
         raise ValueError('unsupported cores {}'.format(mdb_runner.cores))
 
-    process = mdb_runner.popen_ignore_int(mdb_cmd, cwd=mdb_runner.build_dir)
-    record_cld_pid(mdb_runner, process)
+    mdb_runner.call(mdb_cmd, cwd=mdb_runner.build_dir)
 
 
 class MdbNsimBinaryRunner(ZephyrBinaryRunner):

--- a/scripts/west_commands/tests/test_mdb.py
+++ b/scripts/west_commands/tests/test_mdb.py
@@ -151,7 +151,7 @@ def require_patch(program):
 @pytest.mark.parametrize('test_case', TEST_NSIM_FLASH_CASES)
 @patch('runners.mdb.get_cld_pid', return_value=(False, -1))
 @patch('time.sleep', return_value=None)
-@patch('runners.mdb.MdbNsimBinaryRunner.popen_ignore_int')
+@patch('runners.mdb.MdbNsimBinaryRunner.call')
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 def test_flash_nsim(require, cc, t, gcp, test_case, mdb_nsim):
     mdb_nsim(test_case['i']).run('flash')
@@ -161,7 +161,7 @@ def test_flash_nsim(require, cc, t, gcp, test_case, mdb_nsim):
 @pytest.mark.parametrize('test_case', TEST_NSIM_DEBUG_CASES)
 @patch('runners.mdb.get_cld_pid', return_value=(False, -1))
 @patch('time.sleep', return_value=None)
-@patch('runners.mdb.MdbNsimBinaryRunner.popen_ignore_int')
+@patch('runners.mdb.MdbNsimBinaryRunner.call')
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 def test_debug_nsim(require, pii, t, gcp, test_case, mdb_nsim):
     mdb_nsim(test_case['i']).run('debug')
@@ -172,7 +172,7 @@ def test_debug_nsim(require, pii, t, gcp, test_case, mdb_nsim):
 @patch('runners.mdb.get_cld_pid', return_value=(False, -1))
 @patch('time.sleep', return_value=None)
 @patch('runners.mdb.MdbNsimBinaryRunner.check_call')
-@patch('runners.mdb.MdbNsimBinaryRunner.popen_ignore_int')
+@patch('runners.mdb.MdbNsimBinaryRunner.call')
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 def test_multicores_nsim(require, pii, cc, t, gcp, test_case, mdb_nsim):
     mdb_nsim(test_case).run('flash')
@@ -186,7 +186,7 @@ def test_multicores_nsim(require, pii, cc, t, gcp, test_case, mdb_nsim):
 @pytest.mark.parametrize('test_case', TEST_HW_FLASH_CASES)
 @patch('runners.mdb.get_cld_pid', return_value=(False, -1))
 @patch('time.sleep', return_value=None)
-@patch('runners.mdb.MdbHwBinaryRunner.popen_ignore_int')
+@patch('runners.mdb.MdbHwBinaryRunner.call')
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 def test_flash_hw(require, cc, t, gcp, test_case, mdb_hw):
     mdb_hw(test_case['i']).run('flash')
@@ -196,7 +196,7 @@ def test_flash_hw(require, cc, t, gcp, test_case, mdb_hw):
 @pytest.mark.parametrize('test_case', TEST_HW_DEBUG_CASES)
 @patch('runners.mdb.get_cld_pid', return_value=(False, -1))
 @patch('time.sleep', return_value=None)
-@patch('runners.mdb.MdbHwBinaryRunner.popen_ignore_int')
+@patch('runners.mdb.MdbHwBinaryRunner.call')
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 def test_debug_hw(require, pii, t, gcp, test_case, mdb_hw):
     mdb_hw(test_case['i']).run('debug')
@@ -207,7 +207,7 @@ def test_debug_hw(require, pii, t, gcp, test_case, mdb_hw):
 @patch('runners.mdb.get_cld_pid', return_value=(False, -1))
 @patch('time.sleep', return_value=None)
 @patch('runners.mdb.MdbHwBinaryRunner.check_call')
-@patch('runners.mdb.MdbHwBinaryRunner.popen_ignore_int')
+@patch('runners.mdb.MdbHwBinaryRunner.call')
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 def test_multicores_hw(require, pii, cc, t, gcp, test_case, mdb_hw):
     mdb_hw(test_case).run('flash')

--- a/scripts/west_commands/tests/test_mdb.py
+++ b/scripts/west_commands/tests/test_mdb.py
@@ -149,32 +149,26 @@ def require_patch(program):
 
 # mdb-nsim test cases
 @pytest.mark.parametrize('test_case', TEST_NSIM_FLASH_CASES)
-@patch('runners.mdb.get_cld_pid', return_value=(False, -1))
-@patch('time.sleep', return_value=None)
 @patch('runners.mdb.MdbNsimBinaryRunner.call')
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
-def test_flash_nsim(require, cc, t, gcp, test_case, mdb_nsim):
+def test_flash_nsim(require, cc, test_case, mdb_nsim):
     mdb_nsim(test_case['i']).run('flash')
     assert require.called
     cc.assert_called_once_with(test_case['o'], cwd=RC_BUILD_DIR)
 
 @pytest.mark.parametrize('test_case', TEST_NSIM_DEBUG_CASES)
-@patch('runners.mdb.get_cld_pid', return_value=(False, -1))
-@patch('time.sleep', return_value=None)
 @patch('runners.mdb.MdbNsimBinaryRunner.call')
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
-def test_debug_nsim(require, pii, t, gcp, test_case, mdb_nsim):
+def test_debug_nsim(require, pii, test_case, mdb_nsim):
     mdb_nsim(test_case['i']).run('debug')
     assert require.called
     pii.assert_called_once_with(test_case['o'], cwd=RC_BUILD_DIR)
 
 @pytest.mark.parametrize('test_case', TEST_NSIM_MULTICORE_CASES)
-@patch('runners.mdb.get_cld_pid', return_value=(False, -1))
-@patch('time.sleep', return_value=None)
 @patch('runners.mdb.MdbNsimBinaryRunner.check_call')
 @patch('runners.mdb.MdbNsimBinaryRunner.call')
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
-def test_multicores_nsim(require, pii, cc, t, gcp, test_case, mdb_nsim):
+def test_multicores_nsim(require, pii, cc, test_case, mdb_nsim):
     mdb_nsim(test_case).run('flash')
     assert require.called
     cc_calls = [call(TEST_NSIM_CORE1, cwd=RC_BUILD_DIR), call(TEST_NSIM_CORE2, cwd=RC_BUILD_DIR)]
@@ -184,32 +178,26 @@ def test_multicores_nsim(require, pii, cc, t, gcp, test_case, mdb_nsim):
 
 # mdb-hw test cases
 @pytest.mark.parametrize('test_case', TEST_HW_FLASH_CASES)
-@patch('runners.mdb.get_cld_pid', return_value=(False, -1))
-@patch('time.sleep', return_value=None)
 @patch('runners.mdb.MdbHwBinaryRunner.call')
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
-def test_flash_hw(require, cc, t, gcp, test_case, mdb_hw):
+def test_flash_hw(require, cc, test_case, mdb_hw):
     mdb_hw(test_case['i']).run('flash')
     assert require.called
     cc.assert_called_once_with(test_case['o'], cwd=RC_BUILD_DIR)
 
 @pytest.mark.parametrize('test_case', TEST_HW_DEBUG_CASES)
-@patch('runners.mdb.get_cld_pid', return_value=(False, -1))
-@patch('time.sleep', return_value=None)
 @patch('runners.mdb.MdbHwBinaryRunner.call')
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
-def test_debug_hw(require, pii, t, gcp, test_case, mdb_hw):
+def test_debug_hw(require, pii, test_case, mdb_hw):
     mdb_hw(test_case['i']).run('debug')
     assert require.called
     pii.assert_called_once_with(test_case['o'], cwd=RC_BUILD_DIR)
 
 @pytest.mark.parametrize('test_case', TEST_HW_MULTICORE_CASES)
-@patch('runners.mdb.get_cld_pid', return_value=(False, -1))
-@patch('time.sleep', return_value=None)
 @patch('runners.mdb.MdbHwBinaryRunner.check_call')
 @patch('runners.mdb.MdbHwBinaryRunner.call')
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
-def test_multicores_hw(require, pii, cc, t, gcp, test_case, mdb_hw):
+def test_multicores_hw(require, pii, cc, test_case, mdb_hw):
     mdb_hw(test_case).run('flash')
     assert require.called
     cc_calls = [call(TEST_HW_CORE1, cwd=RC_BUILD_DIR), call(TEST_HW_CORE2, cwd=RC_BUILD_DIR)]


### PR DESCRIPTION
Currently we try to start MDB (MetaWare Debugger) in background with ignored sigint no matter if we are planing to do debug session (via `west debug`) or just run something on HW or on nSIM (via `west flash`)
    
That cause really bad user experience as after we do `west debug` or `west flash` we can't terminate the debugger from the console. Moreover even if we terminate the debugger process from separate terminal the console stil would be broken so we need to do `stty sane` in it to make it usable again.

Fix all that by proper starting the debugger process.

While we at it we also remove dead code which looks for `cld` process pid - this functionality isn't use anymore by twister for a long time.

Fixes: #54321