### PR TITLE
MAINTAINERS: Add vaishnavachath as maintainer for TI Platforms

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -314,7 +314,7 @@
 /drivers/ieee802154/*b91*                 @andy-liu-telink
 /drivers/ieee802154/ieee802154_nrf5*      @jciupis
 /drivers/ieee802154/ieee802154_rf2xx*     @tbursztyka @nandojve
-/drivers/ieee802154/ieee802154_cc13xx*    @bwitherspoon @cfriedt
+/drivers/ieee802154/ieee802154_cc13xx*    @bwitherspoon @cfriedt @vaishnavachath
 /drivers/interrupt_controller/            @dcpleung @nashif
 /drivers/interrupt_controller/intc_gic.c  @stephanosio
 /drivers/interrupt_controller/*esp32*     @glaubermaroto

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2051,7 +2051,9 @@ ITE Platforms:
     - "platform: ITE"
 
 TI Platforms:
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - vaishnavachath
   collaborators:
     - vanti
     - cfriedt


### PR DESCRIPTION
Add myself as a maintainer for existing TI platforms which does not have a TI maintainer now, I am an employee with Texas Instruments Inc. in the Embedded Processors software department and has worked on the supported simple-link platforms in Zephyr for the last 2 years.