### PR TITLE
ARC: west runner: mdb: fix multiple argument handling issues

### DIFF
--- a/scripts/west_commands/runners/mdb.py
+++ b/scripts/west_commands/runners/mdb.py
@@ -41,7 +41,8 @@ def mdb_do_run(mdb_runner, command):
     # hardware target
     else:
         if mdb_runner.jtag == 'digilent':
-            mdb_target = ['-digilent', mdb_runner.dig_device]
+            mdb_target = ['-digilent']
+            if mdb_runner.dig_device: mdb_target += [mdb_runner.dig_device]
         else:
             # \todo: add support of other debuggers
             mdb_target = ['']
@@ -63,14 +64,11 @@ def mdb_do_run(mdb_runner, command):
     elif 1 < mdb_runner.cores <= 4:
         mdb_multifiles = '-multifiles='
         for i in range(mdb_runner.cores):
-            # note that: mdb requires -pset starting from 1, not 0 !!!
-            mdb_sub_cmd = ([commander] +
-                        ['-pset={}'.format(i + 1),
-                         '-psetname=core{}'.format(i),
-            # -prop=download=2 is used for SMP application debug, only the 1st
-            # core will download the shared image.
-                         ('-prop=download=2' if i > 0 else '')] +
-                         mdb_basic_options + mdb_target + [mdb_runner.elf_name])
+            mdb_sub_cmd = [commander] + ['-pset={}'.format(i + 1), '-psetname=core{}'.format(i)]
+            # -prop=download=2 is used for SMP application debug, only the 1st core
+            # will download the shared image.
+            if i > 0: mdb_sub_cmd += ['-prop=download=2']
+            mdb_sub_cmd += mdb_basic_options + mdb_target + [mdb_runner.elf_name]
             mdb_runner.check_call(mdb_sub_cmd, cwd=mdb_runner.build_dir)
             mdb_multifiles += ('core{}'.format(mdb_runner.cores-1-i) if i == 0 else ',core{}'.format(mdb_runner.cores-1-i))
 

--- a/scripts/west_commands/runners/mdb.py
+++ b/scripts/west_commands/runners/mdb.py
@@ -45,7 +45,7 @@ def mdb_do_run(mdb_runner, command):
             if mdb_runner.dig_device: mdb_target += [mdb_runner.dig_device]
         else:
             # \todo: add support of other debuggers
-            mdb_target = ['']
+            raise ValueError('unsupported jtag adapter {}'.format(mdb_runner.jtag))
 
     if command == 'flash':
         if simulation_run(mdb_runner):

--- a/scripts/west_commands/tests/test_mdb.py
+++ b/scripts/west_commands/tests/test_mdb.py
@@ -39,7 +39,7 @@ TEST_NSIM_DEBUG_CASES = [
     }]
 
 TEST_NSIM_MULTICORE_CASES = [['--cores=2', '--nsim_args=' + TEST_NSIM_ARGS]]
-TEST_NSIM_CORE1 = [TEST_DRIVER_CMD, '-pset=1', '-psetname=core0', '',
+TEST_NSIM_CORE1 = [TEST_DRIVER_CMD, '-pset=1', '-psetname=core0',
               '-nooptions', '-nogoifmain', '-toggle=include_local_symbols=1',
               '-nsim', TEST_BOARD_NSIM_ARGS, RC_KERNEL_ELF]
 TEST_NSIM_CORE2 = [TEST_DRIVER_CMD, '-pset=2', '-psetname=core1',
@@ -55,7 +55,7 @@ TEST_HW_FLASH_CASES = [
         'i': ['--jtag=digilent', '--cores=1'],
         'o': [TEST_DRIVER_CMD, '-nooptions', '-nogoifmain',
            '-toggle=include_local_symbols=1',
-           '-digilent', '',
+           '-digilent',
             '-run', '-cmd=-nowaitq run', '-cmd=quit', '-cl', RC_KERNEL_ELF]
     }, {
         'i': ['--jtag=digilent', '--cores=1', '--dig-device=test'],
@@ -66,8 +66,7 @@ TEST_HW_FLASH_CASES = [
     }, {
         'i': ['--jtag=test_debug', '--cores=1'],
         'o': [TEST_DRIVER_CMD, '-nooptions', '-nogoifmain',
-           '-toggle=include_local_symbols=1',
-           '',
+           '-toggle=include_local_symbols=1', '',
            '-run', '-cmd=-nowaitq run', '-cmd=quit', '-cl', RC_KERNEL_ELF]
     }]
 
@@ -76,7 +75,7 @@ TEST_HW_DEBUG_CASES = [
         'i': ['--jtag=digilent', '--cores=1'],
         'o': [TEST_DRIVER_CMD, '-nooptions', '-nogoifmain',
                '-toggle=include_local_symbols=1',
-               '-digilent', '',
+               '-digilent',
                '-OKN', RC_KERNEL_ELF]
     }, {
         'i': ['--jtag=digilent', '--cores=1', '--dig-device=test'],
@@ -87,19 +86,18 @@ TEST_HW_DEBUG_CASES = [
     }, {
         'i': ['--jtag=test_debug', '--cores=1'],
         'o': [TEST_DRIVER_CMD, '-nooptions', '-nogoifmain',
-               '-toggle=include_local_symbols=1',
-               '',
+               '-toggle=include_local_symbols=1', '',
                '-OKN', RC_KERNEL_ELF]
     }]
 
 TEST_HW_MULTICORE_CASES = [['--jtag=digilent', '--cores=2']]
-TEST_HW_CORE1 = [TEST_DRIVER_CMD, '-pset=1', '-psetname=core0', '',
+TEST_HW_CORE1 = [TEST_DRIVER_CMD, '-pset=1', '-psetname=core0',
               '-nooptions', '-nogoifmain', '-toggle=include_local_symbols=1',
-              '-digilent', '', RC_KERNEL_ELF]
+              '-digilent', RC_KERNEL_ELF]
 TEST_HW_CORE2 = [TEST_DRIVER_CMD, '-pset=2', '-psetname=core1',
               '-prop=download=2', '-nooptions', '-nogoifmain',
               '-toggle=include_local_symbols=1',
-              '-digilent', '', RC_KERNEL_ELF]
+              '-digilent', RC_KERNEL_ELF]
 TEST_HW_CORES_LAUNCH = [TEST_DRIVER_CMD, '-multifiles=core1,core0', '-run',
               '-cmd=-nowaitq run', '-cmd=quit', '-cl']
 


### PR DESCRIPTION
## Fix unexpected empty argument pass to MDB

Currently, in case of multi-core target or in case jtag adapter auto-select, we pass unexpected empty argument (empty quotes `''`) to MDB binary due to argument generation error. The example of such argument list is:
```
mdb -pset=1 -psetname=core0 '' -nooptions -nogoifmain -toggle=include_local_symbols=1 -nsim @/path/mdb_hs5x_smp.args /path/zephyr.elf
```

Such behavior looks really suspicious for anyone who check the commands produced by `west flash` or `west debug` for the `mdb-nsim` or `mdb-hw` west runners.

Fix that.

## Fix incorrect argument handling for jtag adapters

Currently we just pass in case of the unsupported jtag adapter is selected. Thar results in calling MDB with incorrect arguments combination. Fix that by rising ValueError as we do in case of other incorrect west arguments.

----

While I'm at it add few missing test-cases for mdb west runners.

----

Fixes: #54372
Fixes: #54374