### PR TITLE
cmake: linker: properly pass -no-pie to linker

### DIFF
--- a/cmake/linker/ld/target_base.cmake
+++ b/cmake/linker/ld/target_base.cmake
@@ -11,8 +11,11 @@ macro(toolchain_ld_base)
   # TOOLCHAIN_LD_FLAGS comes from compiler/gcc/target.cmake
   # LINKERFLAGPREFIX comes from linker/ld/target.cmake
   zephyr_ld_options(
-    -no-pie
     ${TOOLCHAIN_LD_FLAGS}
+  )
+
+  zephyr_ld_options(
+    ${LINKERFLAGPREFIX},-no-pie
   )
 
   zephyr_ld_options(

--- a/cmake/linker/lld/target_base.cmake
+++ b/cmake/linker/lld/target_base.cmake
@@ -11,8 +11,11 @@ macro(toolchain_ld_base)
   # TOOLCHAIN_LD_FLAGS comes from compiler/clang/target.cmake
   # LINKERFLAGPREFIX comes from linker/lld/target.cmake
   zephyr_ld_options(
-    -no-pie
     ${TOOLCHAIN_LD_FLAGS}
+  )
+
+  zephyr_ld_options(
+    ${LINKERFLAGPREFIX},--no-pie
   )
 
   zephyr_ld_options(


### PR DESCRIPTION
The option "-no-pie" is a linker option which should be passed to linker by adding linker prefix. Also, for LLD, it is with double hyphens: "--no-pie". This fixes an issue with using LLVM where it complains about unused command line argument.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>