### PR TITLE
boards: intel_adsp_ace15_mtpm board uses Xtensa toolchain xt-clang driver for twister

### DIFF
--- a/boards/xtensa/intel_adsp_ace15_mtpm/intel_adsp_ace15_mtpm.yaml
+++ b/boards/xtensa/intel_adsp_ace15_mtpm/intel_adsp_ace15_mtpm.yaml
@@ -5,6 +5,7 @@ arch: xtensa
 toolchain:
   - zephyr
   - xcc
+  - xt-clang
 supported:
   - dma
 testing:


### PR DESCRIPTION
Upgrading Xtensa toolchain for intel ACE1X boards.
Newer Xtensa toolchains support only xt-clang driver so we are forced to switch.
Release Xtensa toolchain version for Intel Meteorlake is RI-2022.10 that no longer provides obsolete xt-xcc driver.
Two commits:
1) Added new xcc-clang toolchain to intel_adsp_ace15_mtpm.yaml board file.
2) <s>Changed existing "-no-pie" flag to experimentally determined "-fno-pie" flag.
Some background - xt-clang --help or Xtensa documentation does not provide any information on "Position Independent Executable". However, on attempt to pass --no-pie flag to xt-clang driver, it responded with error message:
`clang: error: unsupported option '--no-pie'; did you mean '-fno-pie'? `
Indeed, flag '-fno-pie' is parsed by xt-clang driver and no warning message is issued.
Compiled firmware successfully with this flag so adding it here as experimentally determined.</s>

Waiting for dependencies to be merged:

- [x] https://github.com/zephyrproject-rtos/zephyr/pull/54836

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>