### PR TITLE
tests: kernel: cpu_exception: Make expected reason code generic.

### DIFF
--- a/tests/kernel/fatal/no-multithreading/src/main.c
+++ b/tests/kernel/fatal/no-multithreading/src/main.c
@@ -29,11 +29,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 
 static void entry_cpu_exception(void)
 {
-#if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-	expected_reason = K_ERR_ARM_USAGE_ILLEGAL_EPSR;
-#else
 	expected_reason = K_ERR_CPU_EXCEPTION;
-#endif
 
 	TC_PRINT("cpu exception\n");
 #if defined(CONFIG_X86)


### PR DESCRIPTION
Change expected reason code for cpu exception to be generic and in compliance with a3774fd51a716ffafeddfb017f9c25a046013132

Fixes #54335

Signed-off-by: Aastha Grover <aastha.grover@intel.com>