### PR TITLE
cmake: linker: rework no_global_merge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,8 @@ zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,
 # @Intent: Do not make position independent code / executable
 zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,no_position_independent>>)
 
+zephyr_ld_property_options(no_global_merge)
+
 # Allow the user to inject options when calling cmake, e.g.
 # 'cmake -DEXTRA_CFLAGS="-Werror -Wno-deprecated-declarations" ..'
 include(cmake/extra_flags.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,10 +382,6 @@ include(cmake/extra_flags.cmake)
 
 zephyr_cc_option(-fno-asynchronous-unwind-tables)
 
-if(CONFIG_USERSPACE)
-  zephyr_compile_options($<TARGET_PROPERTY:compiler,no_global_merge>)
-endif()
-
 if(CONFIG_THREAD_LOCAL_STORAGE)
 # Only support local exec TLS model at this point.
 zephyr_cc_option(-ftls-model=local-exec)

--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -185,8 +185,6 @@ set_property(TARGET compiler-cpp PROPERTY no_threadsafe_statics "-fno-threadsafe
 # but it has PIE disabled by default - so no extra flags are required here.
 set_compiler_property(PROPERTY no_position_independent "")
 
-set_compiler_property(PROPERTY no_global_merge "")
-
 #################################
 # This section covers asm flags #
 #################################

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -108,5 +108,3 @@ set_compiler_property(PROPERTY warning_error_coding_guideline
                       -Wconversion
                       -Woverride-init
 )
-
-set_compiler_property(PROPERTY no_global_merge "-mno-global-merge")

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -115,8 +115,3 @@ set_compiler_property(PROPERTY warning_no_pointer_arithmetic)
 
 # Compiler flags for disabling position independent code / executable
 set_compiler_property(PROPERTY no_position_independent)
-
-# Compiler flag to avoid combine more than one global variable into a single aggregate.
-# gen_kobject_list.py is does not understand it and end up identifying objects as if
-# they had the same address.
-set_compiler_property(PROPERTY no_global_merge)

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -201,5 +201,3 @@ set_compiler_property(PROPERTY no_position_independent
                       -fno-pic
                       -fno-pie
 )
-
-set_compiler_property(PROPERTY no_global_merge "")

--- a/cmake/linker/ld/clang/linker_flags.cmake
+++ b/cmake/linker/ld/clang/linker_flags.cmake
@@ -2,3 +2,7 @@
 if (NOT CONFIG_COVERAGE_GCOV)
   set_property(TARGET linker PROPERTY coverage --coverage)
 endif()
+
+if (CONFIG_USERSPACE)
+  check_set_linker_property(TARGET linker PROPERTY no_global_merge -mno-global-merge)
+endif()

--- a/cmake/linker/ld/linker_flags.cmake
+++ b/cmake/linker/ld/linker_flags.cmake
@@ -1,5 +1,7 @@
 check_set_linker_property(TARGET linker PROPERTY memusage "${LINKERFLAGPREFIX},--print-memory-usage")
 
+check_set_linker_property(TARGET linker PROPERTY no_global_merge "")
+
 # Some linker flags might not be purely ld specific, but a combination of
 # linker and compiler, such as:
 # --coverage for clang

--- a/cmake/linker/linker_flags_template.cmake
+++ b/cmake/linker/linker_flags_template.cmake
@@ -9,3 +9,12 @@ set_property(TARGET linker PROPERTY coverage)
 # If memory reporting is a post build command, please use
 # cmake/bintools/bintools.cmake instead.
 check_set_linker_property(TARGET linker PROPERTY memusage)
+
+# Linker flag to tell the linker not to merge globals.
+# When globals are merged, the address in ELF is a base address plus
+# an offset. However, when userspace is enabled, our handling of
+# kobject does not work with this (address + offset) when generating
+# the necessary kobject data. This step requires each kobject having
+# its own address. Hence the need to tell linker not to merge globals.
+# This is a LLVM/Clang only option.
+check_set_linker_property(TARGET linker PROPERTY no_global_merge)

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -125,6 +125,16 @@ function(zephyr_ld_options)
     target_ld_options(zephyr_interface INTERFACE ${ARGV})
 endfunction()
 
+# Get the value of a linker property and add it to LD options
+function(zephyr_ld_property_options)
+  foreach(arg ${ARGV})
+    get_target_property(LD_FLAG linker ${arg})
+    if(NOT ${LD_FLAG} STREQUAL LD_FLAG-NOTFOUND)
+      zephyr_ld_options(${LD_FLAG})
+    endif()
+  endforeach()
+endfunction()
+
 # Getter functions for extracting build information from
 # zephyr_interface. Returning lists, and strings is supported, as is
 # requesting specific categories of build information (defines,


### PR DESCRIPTION
The `-mno-global-merge` is actually a linker option. So if it is used for compiling C files, clang would complain about argument being unused during compilation. This reworks the flags to become a linker flag.