### PR TITLE
compiler/clang: Erase 'no_printf_return_value' prop for clang

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -7,6 +7,9 @@ include(${ZEPHYR_BASE}/cmake/compiler/gcc/compiler_flags.cmake)
 set_compiler_property(PROPERTY security_fortify_compile_time)
 set_compiler_property(PROPERTY security_fortify_run_time)
 
+# No printf-return-value optimizations in clang
+set_compiler_property(PROPERTY no_printf_return_value)
+
 # No property flag, this is used by the native_posix, clang has problems
 # compiling the native_posix with -fno-freestanding.
 check_set_compiler_property(PROPERTY hosted)


### PR DESCRIPTION
Clang does not have printf return value optimizations like GCC, so there's no flag to turn them off when building against a non-standard printf implementation (e.g., picolibc without float support).

Signed-off-by: Keith Packard <keithp@keithp.com>

Fixes #54336