### PR TITLE
Bluetooth: Controller: Rename lll_df_conf_cte_tx_disable()

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -291,7 +291,7 @@ static void isr_done(void *param)
 
 #if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
 	if (lll->cte_started) {
-		lll_df_conf_cte_tx_disable();
+		lll_df_cte_tx_disable();
 	}
 #endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
@@ -112,23 +112,18 @@ void lll_df_cte_tx_enable(struct lll_adv_sync *lll_sync, const struct pdu_adv *p
 			*cte_len_us = CTE_LEN_US(df_cfg->cte_length);
 		} else {
 			if (lll_sync->cte_started) {
-				lll_df_conf_cte_tx_disable();
+				lll_df_cte_tx_disable();
 				lll_sync->cte_started = 0U;
 			}
 			*cte_len_us = 0U;
 		}
 	} else {
 		if (lll_sync->cte_started) {
-			lll_df_conf_cte_tx_disable();
+			lll_df_cte_tx_disable();
 			lll_sync->cte_started = 0U;
 		}
 		*cte_len_us = 0U;
 	}
-}
-
-void lll_df_conf_cte_tx_disable(void)
-{
-	radio_df_reset();
 }
 #endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX */
 
@@ -397,5 +392,10 @@ void lll_df_cte_tx_configure(uint8_t cte_type, uint8_t cte_length, uint8_t num_a
 		radio_df_ant_switch_pattern_set(ant_ids, num_ant_ids);
 	}
 #endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_TX */
+}
+
+void lll_df_cte_tx_disable(void)
+{
+	radio_df_reset();
 }
 #endif /* CONFIG_BT_CTLR_DF_ADV_CTE_TX || CONFIG_BT_CTLR_DF_CONN_CTE_TX */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_internal.h
@@ -11,8 +11,6 @@ struct lll_sync;
 /* Enables CTE transmission according to provided configuration */
 void lll_df_cte_tx_enable(struct lll_adv_sync *lll_sync, const struct pdu_adv *pdu,
 			  uint32_t *cte_len_us);
-/* Disables CTE transmission */
-void lll_df_conf_cte_tx_disable(void);
 
 /* Allocate memory for new DF sync configuration. It will always return the same
  * pointer until buffer is swapped by lll_df_sync_cfg_latest_get operation.
@@ -68,6 +66,9 @@ int lll_df_iq_report_no_resources_prepare(struct lll_sync *sync);
 /* Configure CTE transmission */
 void lll_df_cte_tx_configure(uint8_t cte_type, uint8_t cte_length, uint8_t num_ant_ids,
 			     const uint8_t *ant_ids);
+
+/* Disables CTE transmission */
+void lll_df_cte_tx_disable(void);
 
 /* Enabled parsing of a PDU for CTEInfo */
 void lll_df_conf_cte_info_parsing_enable(void);


### PR DESCRIPTION
Rename lll_df_conf_cte_tx_disable() to lll_df_cte_tx_disable() so that it can be used as a common function between connection and connectionless implementations.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>