### PR TITLE
Fix STM32H7 Kernel crash with BCM4=0

### DIFF
--- a/soc/arm/st_stm32/common/stm32_hsem.h
+++ b/soc/arm/st_stm32/common/stm32_hsem.h
@@ -108,7 +108,7 @@
 /** Hardware Semaphore wait forever value */
 #define HSEM_LOCK_WAIT_FOREVER    0xFFFFFFFFU
 /** Hardware Semaphore default retry value */
-#define HSEM_LOCK_DEFAULT_RETRY       0xFFFFU
+#define HSEM_LOCK_DEFAULT_RETRY       0x100000U
 
 /**
  * @brief Lock Hardware Semaphore


### PR DESCRIPTION
When running the blinky example on STM32H747, with the BOOT_CM4 bit set to 0, the M4 core goes into panic.
Increasing the value of the hardware semaphore retry prevents this.

Fixes #54230 