### PR TITLE
Tests: bluetooth: Fix failing df unittests

### DIFF
--- a/tests/bluetooth/ctrl_user_ext/CMakeLists.txt
+++ b/tests/bluetooth/ctrl_user_ext/CMakeLists.txt
@@ -8,6 +8,19 @@ project(bluetooth_ctrl_user_ext)
 
 zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/bluetooth/controller/)
 
+if(CONFIG_SOC_COMPATIBLE_NRF)
+  zephyr_library_include_directories(
+    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
+    $ENV{ZEPHYR_BASE}/subsys/bluetooth/hci/nordic
+  )
+elseif(CONFIG_SOC_OPENISA_RV32M1_RISCV32)
+  zephyr_library_include_directories(
+    $ENV{ZEPHYR_BASE}/bluetooth/controller/ll_sw/openisa
+    $ENV{ZEPHYR_BASE}/bluetooth/hci/openisa
+  )
+endif()
+
+
 FILE(GLOB app_sources src/*.c)
 
 target_sources(app PRIVATE ${app_sources})

--- a/tests/bluetooth/ctrl_user_ext/src/hci_user_ext.c
+++ b/tests/bluetooth/ctrl_user_ext/src/hci_user_ext.c
@@ -11,6 +11,9 @@
 #include <zephyr/net/buf.h>
 
 #include "util/memq.h"
+
+#include "ll_sw/pdu_df.h"
+#include "lll/pdu_vendor.h"
 #include "ll_sw/pdu.h"
 #include "ll_sw/lll.h"
 #include "hci/hci_user_ext.h"

--- a/tests/bluetooth/df/common/src/bt_common.c
+++ b/tests/bluetooth/df/common/src/bt_common.c
@@ -9,7 +9,9 @@
 #include <zephyr/ztest.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
-
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 #include "bt_common.h"
 
 void *ut_bt_setup(void)

--- a/tests/bluetooth/df/common/src/bt_conn_common.c
+++ b/tests/bluetooth/df/common/src/bt_conn_common.c
@@ -15,6 +15,8 @@
 #include <hal/ccm.h>
 
 #include <zephyr/bluetooth/hci.h>
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
 #include <pdu.h>
 #include <lll.h>
 #include <lll/lll_df_types.h>

--- a/tests/bluetooth/df/connectionless_cte_chains/src/common.c
+++ b/tests/bluetooth/df/connectionless_cte_chains/src/common.c
@@ -22,6 +22,8 @@
 #include "lll/pdu_vendor.h"
 #include "pdu.h"
 
+#include "hal/ccm.h"
+
 #include "lll.h"
 #include "lll/lll_adv_types.h"
 #include "lll_adv.h"

--- a/tests/bluetooth/df/connectionless_cte_chains/src/test_add_cte_to_chain.c
+++ b/tests/bluetooth/df/connectionless_cte_chains/src/test_add_cte_to_chain.c
@@ -22,6 +22,8 @@
 #include "lll/pdu_vendor.h"
 #include "pdu.h"
 
+#include "hal/ccm.h"
+
 #include "lll.h"
 #include "lll/lll_adv_types.h"
 #include "lll_adv.h"

--- a/tests/bluetooth/df/connectionless_cte_chains/src/test_remove_cte_from_chain.c
+++ b/tests/bluetooth/df/connectionless_cte_chains/src/test_remove_cte_from_chain.c
@@ -22,6 +22,8 @@
 #include "lll/pdu_vendor.h"
 #include "pdu.h"
 
+#include "hal/ccm.h"
+
 #include "lll.h"
 #include "lll/lll_adv_types.h"
 #include "lll_adv.h"

--- a/tests/bluetooth/df/connectionless_cte_rx/src/common.c
+++ b/tests/bluetooth/df/connectionless_cte_rx/src/common.c
@@ -16,6 +16,8 @@
 #include <util/memq.h>
 #include <util/dbuf.h>
 
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
 #include <pdu.h>
 #include <lll.h>
 #include <lll_scan.h>

--- a/tests/bluetooth/df/connectionless_cte_tx/CMakeLists.txt
+++ b/tests/bluetooth/df/connectionless_cte_tx/CMakeLists.txt
@@ -14,3 +14,21 @@ SET(common_sources ${CMAKE_CURRENT_SOURCE_DIR}/../common/src/bt_common.c
 target_sources(app PRIVATE ${common_sources} ${app_sources})
 target_include_directories(app PRIVATE
 			   ${CMAKE_CURRENT_SOURCE_DIR}/../common/include)
+
+zephyr_library_include_directories(
+    $ENV{ZEPHYR_BASE}/subsys/bluetooth/
+    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/
+    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw
+)
+
+if(CONFIG_SOC_COMPATIBLE_NRF)
+  zephyr_library_include_directories(
+    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
+    $ENV{ZEPHYR_BASE}/subsys/bluetooth/hci/nordic
+  )
+elseif(CONFIG_SOC_OPENISA_RV32M1_RISCV32)
+  zephyr_library_include_directories(
+    $ENV{ZEPHYR_BASE}/bluetooth/controller/ll_sw/openisa
+    $ENV{ZEPHYR_BASE}/bluetooth/hci/openisa
+  )
+endif()


### PR DESCRIPTION
Due to recent refactoring following unittests are failing: tests/bluetooth/df/*
tests/bluetooth/ctrl_user_ext

This commit fixes these by adding the include files containing the missing type definitions

fixes #54351

issue #54348 was created  to avoid this situation from happening again

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>