### PR TITLE
Feature/stm32 usart wide data

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -645,25 +645,49 @@ static void uart_stm32_poll_out_visitor(const struct device *dev, void *out, pol
 	irq_unlock(key);
 }
 
-static void uart_stm32_poll_in_u8(const struct uart_stm32_config *config, void *in)
+static void poll_in_u8(const struct uart_stm32_config *config, void *in)
 {
 	*((unsigned char *)in) = (unsigned char)LL_USART_ReceiveData8(config->usart);
 }
 
-static void uart_stm32_poll_out_u8(const struct uart_stm32_config *config, void *out)
+static void poll_out_u8(const struct uart_stm32_config *config, void *out)
 {
 	LL_USART_TransmitData8(config->usart, *((uint8_t *)out));
 }
 
 static int uart_stm32_poll_in(const struct device *dev, unsigned char *c)
 {
-	return uart_stm32_poll_in_visitor(dev, (void *)c, uart_stm32_poll_in_u8);
+	return uart_stm32_poll_in_visitor(dev, (void *)c, poll_in_u8);
 }
 
 static void uart_stm32_poll_out(const struct device *dev, unsigned char c)
 {
-	uart_stm32_poll_out_visitor(dev, (void *)&c, uart_stm32_poll_out_u8);
+	uart_stm32_poll_out_visitor(dev, (void *)&c, poll_out_u8);
 }
+
+#ifdef CONFIG_UART_WIDE_DATA
+
+static void poll_out_u9(const struct uart_stm32_config *config, void *out)
+{
+	LL_USART_TransmitData9(config->usart, *((uint16_t *)out));
+}
+
+static void poll_in_u9(const struct uart_stm32_config *config, void *in)
+{
+	*((uint16_t *)in) = LL_USART_ReceiveData9(config->usart);
+}
+
+static int uart_stm32_poll_in_u16(const struct device *dev, uint16_t *in_u16)
+{
+	return uart_stm32_poll_in_visitor(dev, (void *)in_u16, poll_in_u9);
+}
+
+static void uart_stm32_poll_out_u16(const struct device *dev, uint16_t out_u16)
+{
+	uart_stm32_poll_out_visitor(dev, (void *)&out_u16, poll_out_u9);
+}
+
+#endif
 
 static int uart_stm32_err_check(const struct device *dev)
 {
@@ -827,6 +851,47 @@ static int uart_stm32_fifo_read(const struct device *dev, uint8_t *rx_data, cons
 	return uart_stm32_fifo_read_visitor(dev, (void *)rx_data, size,
 					    fifo_read_with_u8);
 }
+
+#ifdef CONFIG_UART_WIDE_DATA
+
+static void fifo_fill_with_u16(const struct uart_stm32_config *config,
+					  const void *tx_data, const uint8_t offset)
+{
+	const uint16_t *data = (const uint16_t *)tx_data;
+
+	/* Send a character (9bit) */
+	LL_USART_TransmitData9(config->usart, data[offset]);
+}
+
+static int uart_stm32_fifo_fill_u16(const struct device *dev, const uint16_t *tx_data, int size)
+{
+	if (uart_stm32_ll2cfg_databits(uart_stm32_get_databits(dev), uart_stm32_get_parity(dev)) !=
+	    UART_CFG_DATA_BITS_9) {
+		return -ENOTSUP;
+	}
+	return uart_stm32_fifo_fill_visitor(dev, (const void *)tx_data, size,
+					    fifo_fill_with_u16);
+}
+
+static void fifo_read_with_u16(const struct uart_stm32_config *config, void *rx_data,
+					  const uint8_t offset)
+{
+	uint16_t *data = (uint16_t *)rx_data;
+
+	data[offset] = LL_USART_ReceiveData9(config->usart);
+}
+
+static int uart_stm32_fifo_read_u16(const struct device *dev, uint16_t *rx_data, const int size)
+{
+	if (uart_stm32_ll2cfg_databits(uart_stm32_get_databits(dev), uart_stm32_get_parity(dev)) !=
+	    UART_CFG_DATA_BITS_9) {
+		return -ENOTSUP;
+	}
+	return uart_stm32_fifo_read_visitor(dev, (void *)rx_data, size,
+					    fifo_read_with_u16);
+}
+
+#endif
 
 static void uart_stm32_irq_tx_enable(const struct device *dev)
 {
@@ -1670,11 +1735,36 @@ static int uart_stm32_async_init(const struct device *dev)
 	return 0;
 }
 
+#ifdef CONFIG_UART_WIDE_DATA
+
+static int uart_stm32_async_tx_u16(const struct device *dev, const uint16_t *tx_data,
+				   size_t buf_size, int32_t timeout)
+{
+	return uart_stm32_async_tx(dev, (const uint8_t *)tx_data, buf_size * 2, timeout);
+}
+
+static int uart_stm32_async_rx_enable_u16(const struct device *dev, uint16_t *buf, size_t len,
+					  int32_t timeout)
+{
+	return uart_stm32_async_rx_enable(dev, (uint8_t *)buf, len * 2, timeout);
+}
+
+static int uart_stm32_async_rx_buf_rsp_u16(const struct device *dev, uint16_t *buf, size_t len)
+{
+	return uart_stm32_async_rx_buf_rsp(dev, (uint8_t *)buf, len * 2);
+}
+
+#endif
+
 #endif /* CONFIG_UART_ASYNC_API */
 
 static const struct uart_driver_api uart_stm32_driver_api = {
 	.poll_in = uart_stm32_poll_in,
 	.poll_out = uart_stm32_poll_out,
+#ifdef CONFIG_UART_WIDE_DATA
+	.poll_in_u16 = uart_stm32_poll_in_u16,
+	.poll_out_u16 = uart_stm32_poll_out_u16,
+#endif
 	.err_check = uart_stm32_err_check,
 #ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = uart_stm32_configure,
@@ -1683,6 +1773,10 @@ static const struct uart_driver_api uart_stm32_driver_api = {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = uart_stm32_fifo_fill,
 	.fifo_read = uart_stm32_fifo_read,
+#ifdef CONFIG_UART_WIDE_DATA
+	.fifo_fill_u16 = uart_stm32_fifo_fill_u16,
+	.fifo_read_u16 = uart_stm32_fifo_read_u16,
+#endif
 	.irq_tx_enable = uart_stm32_irq_tx_enable,
 	.irq_tx_disable = uart_stm32_irq_tx_disable,
 	.irq_tx_ready = uart_stm32_irq_tx_ready,
@@ -1695,7 +1789,7 @@ static const struct uart_driver_api uart_stm32_driver_api = {
 	.irq_is_pending = uart_stm32_irq_is_pending,
 	.irq_update = uart_stm32_irq_update,
 	.irq_callback_set = uart_stm32_irq_callback_set,
-#endif	/* CONFIG_UART_INTERRUPT_DRIVEN */
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 #ifdef CONFIG_UART_ASYNC_API
 	.callback_set = uart_stm32_async_callback_set,
 	.tx = uart_stm32_async_tx,
@@ -1703,7 +1797,12 @@ static const struct uart_driver_api uart_stm32_driver_api = {
 	.rx_enable = uart_stm32_async_rx_enable,
 	.rx_disable = uart_stm32_async_rx_disable,
 	.rx_buf_rsp = uart_stm32_async_rx_buf_rsp,
-#endif  /* CONFIG_UART_ASYNC_API */
+#ifdef CONFIG_UART_WIDE_DATA
+	.tx_u16 = uart_stm32_async_tx_u16,
+	.rx_enable_u16 = uart_stm32_async_rx_enable_u16,
+	.rx_buf_rsp_u16 = uart_stm32_async_rx_buf_rsp_u16,
+#endif
+#endif /* CONFIG_UART_ASYNC_API */
 };
 
 /**

--- a/tests/drivers/uart/uart_async_api/CMakeLists.txt
+++ b/tests/drivers/uart/uart_async_api/CMakeLists.txt
@@ -8,3 +8,4 @@ project(uart_high_level_api)
 target_sources(app PRIVATE
     src/test_uart_async.c
     )
+target_sources_ifdef(CONFIG_UART_WIDE_DATA app PRIVATE src/test_uart_wide.c)

--- a/tests/drivers/uart/uart_async_api/src/test_uart_wide.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_wide.c
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (c) 2023 Jeroen van Dooren
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "test_uart.h"
+
+K_SEM_DEFINE(tx_wide_done, 0, 1);
+K_SEM_DEFINE(tx_wide_aborted, 0, 1);
+K_SEM_DEFINE(rx_wide_rdy, 0, 1);
+K_SEM_DEFINE(rx_wide_buf_released, 0, 1);
+K_SEM_DEFINE(rx_wide_disabled, 0, 1);
+
+static ZTEST_BMEM const struct device *const uart_dev =
+	DEVICE_DT_GET(UART_NODE);
+
+static void init_test(void)
+{
+	__ASSERT_NO_MSG(device_is_ready(uart_dev));
+	uart_rx_disable(uart_dev);
+	uart_tx_abort(uart_dev);
+	k_sem_reset(&tx_wide_done);
+	k_sem_reset(&tx_wide_aborted);
+	k_sem_reset(&rx_wide_rdy);
+	k_sem_reset(&rx_wide_buf_released);
+	k_sem_reset(&rx_wide_disabled);
+}
+
+#ifdef CONFIG_USERSPACE
+static void set_permissions(void)
+{
+	k_thread_access_grant(k_current_get(), &tx_wide_done, &tx_wide_aborted,
+			      &rx_wide_rdy, &rx_wide_buf_released, &rx_wide_disabled,
+			      uart_dev);
+}
+#endif
+
+static void uart_async_test_init(void)
+{
+	init_test();
+
+#ifdef CONFIG_USERSPACE
+	set_permissions();
+#endif
+}
+
+static void test_single_read_callback(const struct device *dev,
+			       struct uart_event *evt, void *user_data)
+{
+	ARG_UNUSED(dev);
+
+	switch (evt->type) {
+	case UART_TX_DONE:
+		k_sem_give(&tx_wide_done);
+		break;
+	case UART_TX_ABORTED:
+		(*(uint32_t *)user_data)++;
+		break;
+	case UART_RX_RDY:
+		k_sem_give(&rx_wide_rdy);
+		break;
+	case UART_RX_BUF_RELEASED:
+		k_sem_give(&rx_wide_buf_released);
+		break;
+	case UART_RX_DISABLED:
+		k_sem_give(&rx_wide_disabled);
+		break;
+	default:
+		break;
+	}
+}
+
+ZTEST_BMEM volatile uint32_t tx_wide_aborted_count;
+
+static void *single_read_setup_wide(void)
+{
+	uart_async_test_init();
+
+	uart_callback_set(uart_dev,
+			  test_single_read_callback,
+			  (void *) &tx_wide_aborted_count);
+
+	return NULL;
+}
+
+ZTEST_USER(uart_async_single_read_wide, test_single_read_wide)
+{
+	uint16_t rx_buf[10] = {0};
+
+	/* Check also if sending from read only memory (e.g. flash) works. */
+	static const uint16_t tx_buf[5] = {0x74, 0x65, 0x73, 0x74, 0x0D};
+
+	zassert_not_equal(memcmp(tx_buf, rx_buf, 5), 0,
+			  "Initial buffer check failed");
+
+	uart_rx_enable_u16(uart_dev, rx_buf, 10, 50 * USEC_PER_MSEC);
+	zassert_equal(k_sem_take(&rx_wide_rdy, K_MSEC(100)), -EAGAIN,
+		      "RX_RDY not expected at this point");
+
+	uart_tx_u16(uart_dev, tx_buf, sizeof(tx_buf)/sizeof(uint16_t), 100 * USEC_PER_MSEC);
+	zassert_equal(k_sem_take(&tx_wide_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	zassert_equal(k_sem_take(&rx_wide_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
+	zassert_equal(k_sem_take(&rx_wide_rdy, K_MSEC(100)), -EAGAIN,
+		      "Extra RX_RDY received");
+
+	zassert_equal(memcmp(tx_buf, rx_buf, 5), 0, "Buffers not equal");
+	zassert_not_equal(memcmp(tx_buf, rx_buf+5, 5), 0, "Buffers not equal");
+
+	uart_tx_u16(uart_dev, tx_buf, sizeof(tx_buf)/sizeof(uint16_t), 100 * USEC_PER_MSEC);
+	zassert_equal(k_sem_take(&tx_wide_done, K_MSEC(100)), 0, "TX_DONE timeout");
+	zassert_equal(k_sem_take(&rx_wide_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
+	zassert_equal(k_sem_take(&rx_wide_buf_released, K_MSEC(100)),
+		      0,
+		      "RX_BUF_RELEASED timeout");
+	zassert_equal(k_sem_take(&rx_wide_disabled, K_MSEC(1000)), 0,
+		      "RX_DISABLED timeout");
+	zassert_equal(k_sem_take(&rx_wide_rdy, K_MSEC(100)), -EAGAIN,
+		      "Extra RX_RDY received");
+
+	zassert_equal(memcmp(tx_buf, rx_buf+5, 5), 0, "Buffers not equal");
+	zassert_equal(tx_wide_aborted_count, 0, "TX aborted triggered");
+}
+
+ZTEST_SUITE(uart_async_single_read_wide, NULL, single_read_setup_wide,
+		NULL, NULL, NULL);

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -31,6 +31,18 @@ tests:
     harness_config:
       fixture: gpio_loopback
     depends_on: gpio
+  drivers.uart.wide:
+    filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC and not CONFIG_UART_MCUX_LPUART
+    harness: ztest
+    harness_config:
+      fixture: gpio_loopback
+    depends_on: gpio
+    extra_configs:
+      - CONFIG_UART_WIDE_DATA=y
+    arch_allow: arm
+    platform_allow: nucleo_h743zi
+    integration_platforms:
+      - nucleo_h743zi
   drivers.uart.async_api.nrf_uart:
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC
     harness: ztest

--- a/tests/drivers/uart/uart_basic_api/CMakeLists.txt
+++ b/tests/drivers/uart/uart_basic_api/CMakeLists.txt
@@ -11,3 +11,4 @@ target_sources(app PRIVATE
     )
 target_sources_ifdef(CONFIG_UART_INTERRUPT_DRIVEN app PRIVATE src/test_uart_fifo.c)
 target_sources_ifdef(CONFIG_UART_INTERRUPT_DRIVEN app PRIVATE src/test_uart_pending.c)
+target_sources_ifdef(CONFIG_UART_WIDE_DATA app PRIVATE src/test_uart_config_wide.c)

--- a/tests/drivers/uart/uart_basic_api/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/uart/uart_basic_api/boards/nucleo_h743zi.overlay
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart2 {
+	pinctrl-0 = <&usart2_tx_pd5 &usart2_rx_pd6>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_basic_api/src/test_uart.h
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart.h
@@ -23,11 +23,16 @@ void test_uart_configure(void);
 void test_uart_config_get(void);
 void test_uart_poll_out(void);
 void test_uart_poll_in(void);
+#if CONFIG_UART_WIDE_DATA
+void test_uart_configure_wide(void);
+void test_uart_config_get_wide(void);
+#endif
 #if CONFIG_UART_INTERRUPT_DRIVEN
 void test_uart_fifo_fill(void);
 void test_uart_fifo_read(void);
 void test_uart_pending(void);
 #endif
+
 #endif
 
 #endif /* __TEST_UART_H__ */

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_config.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_config.c
@@ -25,7 +25,6 @@
  */
 
 #include "test_uart.h"
-struct uart_config uart_cfg_check;
 const struct uart_config uart_cfg = {
 		.baudrate = 115200,
 		.parity = UART_CFG_PARITY_NONE,
@@ -58,6 +57,7 @@ static int test_configure(void)
 /* test UART configure get (retrieve configuration) */
 static int test_config_get(void)
 {
+	struct uart_config uart_cfg_check;
 	const struct device *const uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	if (!device_is_ready(uart_dev)) {

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_config_wide.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_config_wide.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2023 Jeroen van Dooren
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * @addtogroup t_uart_basic
+ * @{
+ * @defgroup t_uart_config test_uart_config_wide
+ * @brief TestPurpose: verify UART configure API settings for wide data support
+ * @details
+ * - Test Steps
+ *   - Configure: test_uart_configure_wide( )
+ *   - Configure Get: test_uart_config_get_wide( )
+ * - Expected Results
+ *   -# When test UART CONFIG Configure, the value of configurations actually
+ *      set will be equal to the original configuration values (from device
+ *      tree or run-time configuration to modify those loaded initially from
+ *      device tree)
+ *   -# When test UART CONFIG Configure Get, the app will get/retrieve the
+ *      value of configurations stored at location and to be passed to UART
+ *      CONFIG Configure
+ * @}
+ */
+
+#include "test_uart.h"
+const struct uart_config uart_cfg_wide = {
+		.baudrate = 115200,
+		.parity = UART_CFG_PARITY_NONE,
+		.stop_bits = UART_CFG_STOP_BITS_1,
+		.data_bits = UART_CFG_DATA_BITS_9,
+		.flow_ctrl = UART_CFG_FLOW_CTRL_NONE
+	};
+
+static int test_configure_wide(void)
+{
+	const struct device *const uart_dev = DEVICE_DT_GET(DT_NODELABEL(dut));
+
+	if (!device_is_ready(uart_dev)) {
+		TC_PRINT("UART device not ready\n");
+		return TC_FAIL;
+	}
+
+	/* Verify configure() - set device configuration using data in cfg */
+	int ret = uart_configure(uart_dev, &uart_cfg_wide);
+
+	if (ret == -ENOSYS) {
+		return TC_SKIP;
+	}
+
+	/* 0 if successful, - error code otherwise */
+	return (ret == 0) ? TC_PASS : TC_FAIL;
+
+}
+
+/* test UART configure get (retrieve configuration) */
+static int test_config_get_wide(void)
+{
+	struct uart_config uart_cfg_check;
+	const struct device *const uart_dev = DEVICE_DT_GET(DT_NODELABEL(dut));
+
+	if (!device_is_ready(uart_dev)) {
+		TC_PRINT("UART device not ready\n");
+		return TC_FAIL;
+	}
+
+	TC_PRINT("This is a configure_get_wide test.\n");
+
+	/* Verify configure() - set device configuration using data in cfg */
+	/* 0 if successful, - error code otherwise */
+	int ret = uart_configure(uart_dev, &uart_cfg_wide);
+
+	if (ret == -ENOSYS) {
+		return TC_SKIP;
+	}
+
+	zassert_true(ret == 0, "set config error");
+
+	/* Verify config_get() - get device configuration, put in cfg */
+	/* 0 if successful, - error code otherwise */
+	/* so get the configurations from the device and check */
+	ret = uart_config_get(uart_dev, &uart_cfg_check);
+	zassert_true(ret == 0, "get config error");
+
+	/* Confirm the values from device are the values put in cfg*/
+	if (memcmp(&uart_cfg_wide, &uart_cfg_check, sizeof(uart_cfg_wide)) != 0) {
+		return TC_FAIL;
+	} else {
+		return TC_PASS;
+	}
+}
+
+#if CONFIG_SHELL
+void test_uart_configure_wide(void)
+#else
+ZTEST(uart_basic_api, test_uart_configure_wide)
+#endif
+{
+	int ret = test_configure_wide();
+
+	zassert_true((ret == TC_PASS) || (ret == TC_SKIP));
+}
+
+#if CONFIG_SHELL
+void test_uart_config_get_wide(void)
+#else
+ZTEST(uart_basic_api, test_uart_config_get_wide)
+#endif
+{
+	int ret = test_config_get_wide();
+
+	zassert_true((ret == TC_PASS) || (ret == TC_SKIP));
+}

--- a/tests/drivers/uart/uart_basic_api/testcase.yaml
+++ b/tests/drivers/uart/uart_basic_api/testcase.yaml
@@ -7,6 +7,16 @@ tests:
     harness: keyboard
     integration_platforms:
       - mps2_an385
+  drivers.uart.basic_api.wide:
+    extra_configs:
+      - CONFIG_UART_WIDE_DATA=y
+    tags: drivers uart
+    filter: CONFIG_UART_CONSOLE
+    arch_allow: arm
+    platform_allow: nucleo_h743zi
+    integration_platforms:
+      - nucleo_h743zi
+    extra_args: DTC_OVERLAY_FILE="boards/nucleo_h743zi.overlay"
   drivers.uart.basic_api.poll:
     extra_args: CONF_FILE=prj_poll.conf
     tags:


### PR DESCRIPTION
drivers: serial: stm32: add wide data support

Add wide data support to STM32 into
- interrupt driven code
- async code
- polling code
- DTS init code

Adds 9 bit datawidth support to serial driver.
Validated interrupt driven code on an STM32H743.

Signed-off-by: Jeroen van Dooren <jeroen.van.dooren@nobleo.nl>