### PR TITLE
ci: do not hardcode es server in script

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -268,6 +268,7 @@ jobs:
     name: "Publish Unit Tests Results"
     env:
       ELASTICSEARCH_KEY: ${{ secrets.ELASTICSEARCH_KEY }}
+      ELASTICSEARCH_SERVER: "https://elasticsearch.zephyrproject.io:443"
     needs: twister-build
     runs-on: ubuntu-20.04
     # the build-and-test job might be skipped, we don't need to run this job then

--- a/scripts/ci/upload_test_results_es.py
+++ b/scripts/ci/upload_test_results_es.py
@@ -14,8 +14,6 @@ import os
 import json
 import argparse
 
-host = "https://elasticsearch.zephyrproject.io:443"
-
 def gendata(f, index):
     with open(f, "r") as j:
         data = json.load(j)
@@ -63,7 +61,7 @@ def main():
         sys.exit(0)
 
     es = Elasticsearch(
-        [host],
+        [os.environ['ELASTICSEARCH_SERVER']],
         api_key=os.environ['ELASTICSEARCH_KEY'],
         verify_certs=False
         )


### PR DESCRIPTION
Use environment variable instead of hardcoding server in script. This
will allow reuse.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
