### PR TITLE
MAINTAINERS: Change CI maintainer order

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2829,9 +2829,9 @@ x86 arch:
 Continuous Integration:
   status: maintained
   maintainers:
+    - stephanosio
     - nashif
     - galak
-    - stephanosio
   files:
     - .github/
     - scripts/ci/


### PR DESCRIPTION
This commit places @stephanosio, the current CI maintainer, at the top of the maintainer list for the "Continuous Integration" area such that all CI-related PRs get assigned to @stephanosio.