### PR TITLE
ARM: nxp_imx: rt1064: use PODF values from rt1060

### DIFF
--- a/dts/arm/nxp/nxp_rt1064.dtsi
+++ b/dts/arm/nxp/nxp_rt1064.dtsi
@@ -7,16 +7,6 @@
 
 #include <nxp/nxp_rt1060.dtsi>
 
-&ccm {
-	arm-podf {
-		clock-div = <2>;
-	};
-
-	ipg-podf {
-		clock-div = <4>;
-	};
-};
-
 &flexspi2 {
 	status = "okay";
 	reg = <0x402a4000 0x4000>, <0x70000000 DT_SIZE_M(4)>;


### PR DESCRIPTION
rt1064 already includes dtsi file for rt1060, including values for ARM and
IPG PODFs. Drop explicit assignment of those PODF values in order to reduce
duplicated code.