### PR TITLE
doc: communication: update stale info

### DIFF
--- a/doc/project/communication.rst
+++ b/doc/project/communication.rst
@@ -1,16 +1,18 @@
 .. _communication-and-collaboration:
 
 Communication and Collaboration
-################################
+###############################
+
+The `Zephyr Discord Server <https://chat.zephyrproject.org>`_ is the primary
+chat forum used by Zephyr developers, contributors, and users.
 
 The `Zephyr project mailing lists
-<https://lists.zephyrproject.org/g/main/subgroups>`_ are used as the
-primary communication tool by project members, contributors, and the
-community. The mailing list is open for topics related to the project
-and should be used for collaboration among team members working on the
-same feature or subsystem or for discussing project direction and daily
-development of the code base. In general, bug reports and issues should
-be entered and tracked in the bug tracking system (`GitHub Issues
-<https://github.com/zephyrproject-rtos/zephyr/issues>`_) and not
-broadcasted to the mailing list, the same applies to code reviews. Code
-should be submitted to GitHub using the appropriate tools.
+<https://lists.zephyrproject.org/g/main/subgroups>`_ are used as an additional
+communication tool by project members, contributors, and the community. There
+are specialized mailing lists for specific interests. Several lists are public
+and open. Mailing lists are always available for use in situations where
+Discord is unavailable or an unsuitable forum.
+
+In general, bug reports and other issues should be reported as `GitHub Issues
+<https://github.com/zephyrproject-rtos/zephyr/issues>`_ and not broadcasted to
+the mailing list. The same applies to code reviews.


### PR DESCRIPTION
At this point I think it's clear that discord is more important than email as a discussion forum for the project, so clarify that on the communication and collaboration page.

Email is still important, though (e.g. Discord is currently not available in China) -- and we are not deprecating it at all.

