### PR TITLE
[v2.7] SMP scheduling fixes for v2.7

### DIFF
--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -162,6 +162,11 @@ struct z_kernel {
 #if defined(CONFIG_THREAD_MONITOR)
 	struct k_thread *threads; /* singly linked list of ALL threads */
 #endif
+
+#if defined(CONFIG_SMP) && defined(CONFIG_SCHED_IPI_SUPPORTED)
+	/* Need to signal an IPI at the next scheduling point */
+	bool pending_ipi;
+#endif
 };
 
 typedef struct z_kernel _kernel_t;

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -576,6 +576,9 @@ static void triggered_work_expiration_handler(struct _timeout *timeout)
 	k_work_submit_to_queue(twork->workq, &twork->work);
 }
 
+extern int z_work_submit_to_queue(struct k_work_q *queue,
+			 struct k_work *work);
+
 static int signal_triggered_work(struct k_poll_event *event, uint32_t status)
 {
 	struct z_poller *poller = event->poller;
@@ -587,7 +590,7 @@ static int signal_triggered_work(struct k_poll_event *event, uint32_t status)
 
 		z_abort_timeout(&twork->timeout);
 		twork->poll_result = 0;
-		k_work_submit_to_queue(work_q, &twork->work);
+		z_work_submit_to_queue(work_q, &twork->work);
 	}
 
 	return 0;

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -481,6 +481,13 @@ static bool thread_active_elsewhere(struct k_thread *thread)
 	return false;
 }
 
+static void flag_ipi(void)
+{
+#if defined(CONFIG_SMP) &&  defined(CONFIG_SCHED_IPI_SUPPORTED)
+		arch_sched_ipi();
+#endif
+}
+
 static void ready_thread(struct k_thread *thread)
 {
 #ifdef CONFIG_KERNEL_COHERENCE
@@ -495,9 +502,7 @@ static void ready_thread(struct k_thread *thread)
 
 		queue_thread(&_kernel.ready_q.runq, thread);
 		update_cache(0);
-#if defined(CONFIG_SMP) &&  defined(CONFIG_SCHED_IPI_SUPPORTED)
-		arch_sched_ipi();
-#endif
+		flag_ipi();
 	}
 }
 
@@ -799,9 +804,7 @@ void z_thread_priority_set(struct k_thread *thread, int prio)
 {
 	bool need_sched = z_set_prio(thread, prio);
 
-#if defined(CONFIG_SMP) && defined(CONFIG_SCHED_IPI_SUPPORTED)
-	arch_sched_ipi();
-#endif
+	flag_ipi();
 
 	if (need_sched && _current->base.sched_locked == 0U) {
 		z_reschedule_unlocked();
@@ -1346,9 +1349,7 @@ void z_impl_k_wakeup(k_tid_t thread)
 	z_mark_thread_as_not_suspended(thread);
 	z_ready_thread(thread);
 
-#if defined(CONFIG_SMP) && defined(CONFIG_SCHED_IPI_SUPPORTED)
-	arch_sched_ipi();
-#endif
+	flag_ipi();
 
 	if (!arch_is_in_isr()) {
 		z_reschedule_unlocked();

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -219,6 +219,25 @@ static ALWAYS_INLINE void dequeue_thread(void *pq,
 	}
 }
 
+static void signal_pending_ipi(void)
+{
+	/* Synchronization note: you might think we need to lock these
+	 * two steps, but an IPI is idempotent.  It's OK if we do it
+	 * twice.  All we require is that if a CPU sees the flag true,
+	 * it is guaranteed to send the IPI, and if a core sets
+	 * pending_ipi, the IPI will be sent the next time through
+	 * this code.
+	 */
+#if defined(CONFIG_SMP) && defined(CONFIG_SCHED_IPI_SUPPORTED)
+	if (CONFIG_MP_NUM_CPUS > 1) {
+		if (_kernel.pending_ipi) {
+			_kernel.pending_ipi = false;
+			arch_sched_ipi();
+		}
+	}
+#endif
+}
+
 #ifdef CONFIG_SMP
 /* Called out of z_swap() when CONFIG_SMP.  The current thread can
  * never live in the run queue until we are inexorably on the context
@@ -231,6 +250,7 @@ void z_requeue_current(struct k_thread *curr)
 	if (z_is_thread_queued(curr)) {
 		_priq_run_add(&_kernel.ready_q.runq, curr);
 	}
+	signal_pending_ipi();
 }
 #endif
 
@@ -483,8 +503,10 @@ static bool thread_active_elsewhere(struct k_thread *thread)
 
 static void flag_ipi(void)
 {
-#if defined(CONFIG_SMP) &&  defined(CONFIG_SCHED_IPI_SUPPORTED)
-		arch_sched_ipi();
+#if defined(CONFIG_SMP) && defined(CONFIG_SCHED_IPI_SUPPORTED)
+	if (CONFIG_MP_NUM_CPUS > 1) {
+		_kernel.pending_ipi = true;
+	}
 #endif
 }
 
@@ -844,6 +866,7 @@ void z_reschedule(struct k_spinlock *lock, k_spinlock_key_t key)
 		z_swap(lock, key);
 	} else {
 		k_spin_unlock(lock, key);
+		signal_pending_ipi();
 	}
 }
 
@@ -853,6 +876,7 @@ void z_reschedule_irqlock(uint32_t key)
 		z_swap_irqlock(key);
 	} else {
 		irq_unlock(key);
+		signal_pending_ipi();
 	}
 }
 
@@ -886,7 +910,16 @@ void k_sched_unlock(void)
 struct k_thread *z_swap_next_thread(void)
 {
 #ifdef CONFIG_SMP
-	return next_up();
+	struct k_thread *ret = next_up();
+
+	if (ret == _current) {
+		/* When not swapping, have to signal IPIs here.  In
+		 * the context switch case it must happen later, after
+		 * _current gets requeued.
+		 */
+		signal_pending_ipi();
+	}
+	return ret;
 #else
 	return _kernel.ready_q.cache;
 #endif
@@ -953,6 +986,7 @@ void *z_get_next_switch_handle(void *interrupted)
 			new_thread->switch_handle = NULL;
 		}
 	}
+	signal_pending_ipi();
 	return ret;
 #else
 	_current->switch_handle = interrupted;
@@ -1536,6 +1570,9 @@ void z_thread_abort(struct k_thread *thread)
 		/* It's running somewhere else, flag and poke */
 		thread->base.thread_state |= _THREAD_ABORTING;
 
+		/* We're going to spin, so need a true synchronous IPI
+		 * here, not deferred!
+		 */
 #ifdef CONFIG_SCHED_IPI_SUPPORTED
 		arch_sched_ipi();
 #endif

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -68,8 +68,14 @@ static int32_t next_timeout(void)
 {
 	struct _timeout *to = first();
 	int32_t ticks_elapsed = elapsed();
-	int32_t ret = to == NULL ? MAX_WAIT
-		: CLAMP(to->dticks - ticks_elapsed, 0, MAX_WAIT);
+	int32_t ret;
+
+	if ((to == NULL) ||
+	    ((int64_t)(to->dticks - ticks_elapsed) > (int64_t)INT_MAX)) {
+		ret = MAX_WAIT;
+	} else {
+		ret = MAX(0, to->dticks - ticks_elapsed);
+	}
 
 #ifdef CONFIG_TIMESLICING
 	if (_current_cpu->slice_ticks && _current_cpu->slice_ticks < ret) {

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -289,7 +289,7 @@ int64_t sys_clock_tick_get(void)
 	uint64_t t = 0U;
 
 	LOCKED(&timeout_lock) {
-		t = curr_tick + sys_clock_elapsed();
+		t = curr_tick + elapsed();
 	}
 	return t;
 }

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -250,7 +250,7 @@ void sys_clock_announce(int32_t ticks)
 	 * timeouts and confuse apps), just increment the tick count
 	 * and return.
 	 */
-	if (IS_ENABLED(CONFIG_SMP) && announce_remaining != 0) {
+	if (IS_ENABLED(CONFIG_SMP) && (announce_remaining != 0)) {
 		announce_remaining += ticks;
 		k_spin_unlock(&timeout_lock, key);
 		return;
@@ -263,13 +263,13 @@ void sys_clock_announce(int32_t ticks)
 		int dt = t->dticks;
 
 		curr_tick += dt;
-		announce_remaining -= dt;
 		t->dticks = 0;
 		remove_timeout(t);
 
 		k_spin_unlock(&timeout_lock, key);
 		t->fn(t);
 		key = k_spin_lock(&timeout_lock);
+		announce_remaining -= dt;
 	}
 
 	if (first() != NULL) {

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -368,13 +368,13 @@ int k_work_submit_to_queue(struct k_work_q *queue,
 
 	k_spin_unlock(&lock, key);
 
-	/* If we changed the queue contents (as indicated by a positive ret)
-	 * the queue thread may now be ready, but we missed the reschedule
-	 * point because the lock was held.  If this is being invoked by a
-	 * preemptible thread then yield.
+	/* submit_to_queue_locked() won't reschedule on its own
+	 * (really it should, otherwise this process will result in
+	 * spurious calls to z_swap() due to the race), so do it here
+	 * if the queue state changed.
 	 */
-	if ((ret > 0) && (k_is_preempt_thread() != 0)) {
-		k_yield();
+	if (ret > 0) {
+		z_reschedule_unlocked();
 	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work, submit_to_queue, queue, work, ret);

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -586,6 +586,7 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 		struct k_work *work = NULL;
 		k_work_handler_t handler = NULL;
 		k_spinlock_key_t key = k_spin_lock(&lock);
+		bool yield;
 
 		/* Check for and prepare any new work. */
 		node = sys_slist_get(&queue->pending);
@@ -644,34 +645,30 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 
 		k_spin_unlock(&lock, key);
 
-		if (work != NULL) {
-			bool yield;
+		__ASSERT_NO_MSG(handler != NULL);
+		handler(work);
 
-			__ASSERT_NO_MSG(handler != NULL);
-			handler(work);
+		/* Mark the work item as no longer running and deal
+		 * with any cancellation issued while it was running.
+		 * Clear the BUSY flag and optionally yield to prevent
+		 * starving other threads.
+		 */
+		key = k_spin_lock(&lock);
 
-			/* Mark the work item as no longer running and deal
-			 * with any cancellation issued while it was running.
-			 * Clear the BUSY flag and optionally yield to prevent
-			 * starving other threads.
-			 */
-			key = k_spin_lock(&lock);
+		flag_clear(&work->flags, K_WORK_RUNNING_BIT);
+		if (flag_test(&work->flags, K_WORK_CANCELING_BIT)) {
+			finalize_cancel_locked(work);
+		}
 
-			flag_clear(&work->flags, K_WORK_RUNNING_BIT);
-			if (flag_test(&work->flags, K_WORK_CANCELING_BIT)) {
-				finalize_cancel_locked(work);
-			}
+		flag_clear(&queue->flags, K_WORK_QUEUE_BUSY_BIT);
+		yield = !flag_test(&queue->flags, K_WORK_QUEUE_NO_YIELD_BIT);
+		k_spin_unlock(&lock, key);
 
-			flag_clear(&queue->flags, K_WORK_QUEUE_BUSY_BIT);
-			yield = !flag_test(&queue->flags, K_WORK_QUEUE_NO_YIELD_BIT);
-			k_spin_unlock(&lock, key);
-
-			/* Optionally yield to prevent the work queue from
-			 * starving other threads.
-			 */
-			if (yield) {
-				k_yield();
-			}
+		/* Optionally yield to prevent the work queue from
+		 * starving other threads.
+		 */
+		if (yield) {
+			k_yield();
 		}
 	}
 }


### PR DESCRIPTION
Those are commits cherry-picked from the main branch to fix SMP scheduling
problems that become much more prevalent on systems with more than 2 CPUs.
Without those fixes, CI would systematically fail on tests such as
tests/kernel/mutex/sys_mutex where tick advertisements get lost and
all CPUs eventually get stalled in their idle threads forever.

- kernel/sched: Refactor IPI signaling
- kernel/sched: Defer IPI sending to schedule points
- kernel: Fix timeout issue with SYSTEM_CLOCK_SLOPPY_IDLE
- kernel/timeout: Serialize handler callbacks on SMP
- kernel/timeout: Cleanup/speedup parallel announce logic
- kernel: fix race condition in sys_clock_announce()
- kernel: Fixes sys_clock_tick_get()

Fixes #54386