### PR TITLE
Add support for esp32c3 hardware half duplex RS485 mode

### DIFF
--- a/dts/bindings/serial/espressif,esp32-uart.yaml
+++ b/dts/bindings/serial/espressif,esp32-uart.yaml
@@ -13,3 +13,11 @@ properties:
 
   pinctrl-names:
     required: true
+
+  hw-rs485-hd-mode:
+    type: boolean
+    description: |
+      Enable the hardware RS485 half duplex mode.
+      Overrides hw-flow-control if both are set.
+      Using this mode, the pin assigned to DTR
+      is asserted during transmission.

--- a/west.yml
+++ b/west.yml
@@ -57,7 +57,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: d2564ca5c14439888f7c4351884a2cf4db517a33
+      revision: 8ee96508f329c7e59fcbf739f060cf12082dd805
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Hardware flow control mode UART_CFG_FLOW_CTRL_RS485 is enabled for the esp32 series. Option hw-rs485-hd-mode for the UART now enables DTR pin toggling during transmit. Also fixes bug where flow control modes weren't applied at boot.

Signed-off-by: Dean Sellers <dsellers@evos.com.au>
