### PR TITLE
ci: any arch/ changes should trigger kernel testing

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -56,6 +56,7 @@ cmsis_dsp:
 kernel:
   files:
     - kernel/
+    - arch/
 
 posix:
   files:


### PR DESCRIPTION
This should fix issue like #54337 where architecture code changes were
filtering out kernel tests, where those changes are being tested. Kernel
and arch code is tightly coupled and we need to run kernel tests.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
