### PR TITLE
modules/picolibc: Include picolibc with clang+cmake build fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -207,7 +207,7 @@ manifest:
       path: modules/lib/openthread
     - name: picolibc
       path: modules/lib/picolibc
-      revision: 98e59b70d6ef8eb18f7dccc3d39cecaa0658fa4f
+      revision: 2097f26ce7dee36922b22ce048c09cd073ebae3d
     - name: segger
       revision: e2ff2200556e8a8f962921444275c04971a2bb3d
       path: modules/debug/segger


### PR DESCRIPTION
Picolibc upstream has several fixes in the cmake build scripts that are useful when compiling with clang. Move the picolibc revision forward to include all of those changes.

See issue #54336 

Signed-off-by: Keith Packard <keithp@keithp.com>

Fixes #54336 