### PR TITLE
compilers/xcc: Disable -fno-printf-return-value property

### DIFF
--- a/cmake/compiler/xcc/compiler_flags.cmake
+++ b/cmake/compiler/xcc/compiler_flags.cmake
@@ -12,3 +12,6 @@ set_compiler_property(PROPERTY warning_error_misra_sane)
 
 # XCC does not support -fno-pic and -fno-pie
 set_compiler_property(PROPERTY no_position_independent "")
+
+# No printf-return-value optimizations in XCC
+set_compiler_property(PROPERTY no_printf_return_value)


### PR DESCRIPTION
XCC doesn't support the -fno-printf-return-value compiler option

This should fix the issue seen with clang in #54345 but with the xcc compiler.

Signed-off-by: Keith Packard <keithp@keithp.com>

Fixes #54345