### PR TITLE
modules/picolibc: Include clang+cmake and old GCC changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -207,7 +207,7 @@ manifest:
       path: modules/lib/openthread
     - name: picolibc
       path: modules/lib/picolibc
-      revision: 2097f26ce7dee36922b22ce048c09cd073ebae3d
+      revision: 0694a78fc08b3300c7db79602c46ba0a64428c8e
     - name: segger
       revision: e2ff2200556e8a8f962921444275c04971a2bb3d
       path: modules/debug/segger


### PR DESCRIPTION
This updates west.yml to pull a version of picolibc that includes both the patches in #54391 as well as a proposed fix that provides some compatibility with GCC versions before 4.5, such as the GCC based XCC compiler.

Signed-off-by: Keith Packard <keithp@keithp.com>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54336