### PR TITLE
kernel: Add dynamic interrupt priority API

### DIFF
--- a/arch/arc/core/arc_smp.c
+++ b/arch/arc/core/arc_smp.c
@@ -110,7 +110,7 @@ void z_arc_slave_start(int cpu_num)
 	arc_irq_offload_init_smp();
 
 	z_arc_connect_ici_clear();
-	z_irq_priority_set(DT_IRQN(DT_NODELABEL(ici)),
+	arch_irq_priority_set(DT_IRQN(DT_NODELABEL(ici)),
 			   DT_IRQ(DT_NODELABEL(ici), priority), 0);
 	irq_enable(DT_IRQN(DT_NODELABEL(ici)));
 #endif

--- a/arch/arc/core/irq_manage.c
+++ b/arch/arc/core/irq_manage.c
@@ -202,8 +202,6 @@ int arch_irq_is_enabled(unsigned int irq)
 #endif /* CONFIG_ARC_CONNECT */
 
 /**
- * @internal
- *
  * @brief Set an interrupt's priority
  *
  * Lower values take priority over higher values. Special case priorities are
@@ -213,7 +211,7 @@ int arch_irq_is_enabled(unsigned int irq)
  * depends on CONFIG_NUM_IRQ_PRIO_LEVELS.
  */
 
-void z_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+void arch_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
 	ARG_UNUSED(flags);
 
@@ -251,7 +249,7 @@ int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 			     const void *parameter, uint32_t flags)
 {
 	z_isr_install(irq, routine, parameter);
-	z_irq_priority_set(irq, priority, flags);
+	arch_irq_priority_set(irq, priority, flags);
 	return irq;
 }
 #endif /* CONFIG_DYNAMIC_INTERRUPTS */

--- a/arch/arm/core/aarch32/irq_manage.c
+++ b/arch/arm/core/aarch32/irq_manage.c
@@ -53,15 +53,13 @@ int arch_irq_is_enabled(unsigned int irq)
 }
 
 /**
- * @internal
- *
  * @brief Set an interrupt's priority
  *
  * The priority is verified if ASSERT_ON is enabled. The maximum number
  * of priority levels is a little complex, as there are some hardware
  * priority levels which are reserved.
  */
-void z_arm_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+void arch_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
 	/* The kernel may reserve some of the highest priority levels.
 	 * So we offset the requested priority level with the number
@@ -125,8 +123,6 @@ int arch_irq_is_enabled(unsigned int irq)
 }
 
 /**
- * @internal
- *
  * @brief Set an interrupt's priority
  *
  * The priority is verified if ASSERT_ON is enabled. The maximum number
@@ -134,7 +130,7 @@ int arch_irq_is_enabled(unsigned int irq)
  * priority levels which are reserved: three for various types of exceptions,
  * and possibly one additional to support zero latency interrupts.
  */
-void z_arm_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+void arch_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
 	arm_gic_irq_set_priority(irq, prio, flags);
 }
@@ -299,7 +295,7 @@ int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 			     const void *parameter, uint32_t flags)
 {
 	z_isr_install(irq, routine, parameter);
-	z_arm_irq_priority_set(irq, priority, flags);
+	arch_irq_priority_set(irq, priority, flags);
 	return irq;
 }
 #endif /* CONFIG_GEN_ISR_TABLES */

--- a/arch/arm64/core/irq_manage.c
+++ b/arch/arm64/core/irq_manage.c
@@ -47,7 +47,7 @@ int arch_irq_is_enabled(unsigned int irq)
 	return arm_gic_irq_is_enabled(irq);
 }
 
-void z_arm64_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+void arch_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
 	arm_gic_irq_set_priority(irq, prio, flags);
 }
@@ -59,7 +59,7 @@ int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 			     const void *parameter, uint32_t flags)
 {
 	z_isr_install(irq, routine, parameter);
-	z_arm64_irq_priority_set(irq, priority, flags);
+	arch_irq_priority_set(irq, priority, flags);
 	return irq;
 }
 #endif

--- a/arch/mips/core/irq_manage.c
+++ b/arch/mips/core/irq_manage.c
@@ -60,6 +60,11 @@ int arch_irq_is_enabled(unsigned int irq)
 	return read_c0_status() & (ST0_IP0 << irq);
 }
 
+void arch_irq_priority_set(unsigned int irq, unsigned int priority,
+							uint32_t flags)
+{
+}
+
 void z_mips_enter_irq(uint32_t ipending)
 {
 	_current_cpu->nested++;

--- a/arch/nios2/core/irq_manage.c
+++ b/arch/nios2/core/irq_manage.c
@@ -69,6 +69,11 @@ int arch_irq_is_enabled(unsigned int irq)
 	return ienable & BIT(irq);
 }
 
+void arch_irq_priority_set(unsigned int irq, unsigned int priority,
+							uint32_t flags)
+{
+}
+
 /**
  * @brief Interrupt demux function
  *

--- a/arch/posix/core/irq.c
+++ b/arch/posix/core/irq.c
@@ -31,6 +31,11 @@ int arch_irq_is_enabled(unsigned int irq)
 	return posix_irq_is_enabled(irq);
 }
 
+void arch_irq_priority_set(unsigned int irq, unsigned int priority, uint32_t flags)
+{
+	posix_irq_priority_set(irq, priority, flags);
+}
+
 #ifdef CONFIG_DYNAMIC_INTERRUPTS
 /**
  * Configure a dynamic interrupt.

--- a/arch/xtensa/core/irq_manage.c
+++ b/arch/xtensa/core/irq_manage.c
@@ -9,8 +9,6 @@
 #include <zephyr/sys/__assert.h>
 
 /**
- * @internal
- *
  * @brief Set an interrupt's priority
  *
  * The priority is verified if ASSERT_ON is enabled.
@@ -24,7 +22,7 @@
  * interrupts are locked system-wide, so care must be taken when using them.
  * ISR installed with priority 0 interrupts cannot make kernel calls.
  */
-void z_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+void arch_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
 	__ASSERT(prio < XCHAL_EXCM_LEVEL + 1,
 		 "invalid priority %d! values must be less than %d\n",

--- a/doc/kernel/services/interrupts.rst
+++ b/doc/kernel/services/interrupts.rst
@@ -274,6 +274,8 @@ Dynamic interrupts require the :kconfig:option:`CONFIG_DYNAMIC_INTERRUPTS` optio
 be enabled. Removing or re-configuring a dynamic interrupt is currently
 unsupported.
 
+The priority of an ISR can be changed at runtime by calling :c:func:`irq_priority_set`.
+
 Defining a 'direct' ISR
 =======================
 

--- a/drivers/interrupt_controller/intc_irqmp.c
+++ b/drivers/interrupt_controller/intc_irqmp.c
@@ -90,6 +90,11 @@ int arch_irq_is_enabled(unsigned int source)
 	return !!(*pimask & (1U << source));
 }
 
+void arch_irq_priority_set(unsigned int irq, unsigned int prio,
+							uint32_t flags)
+{
+}
+
 int z_sparc_int_get_source(int irl)
 {
 	volatile struct irqmp_regs *regs = get_irqmp_regs();

--- a/drivers/interrupt_controller/intc_swerv_pic.c
+++ b/drivers/interrupt_controller/intc_swerv_pic.c
@@ -236,4 +236,9 @@ int arch_irq_is_enabled(unsigned int irq)
 	return !!(mie & (1 << irq));
 }
 
+void arch_irq_priority_set(unsigned int irq, unsigned int prio,
+							uint32_t flags)
+{
+}
+
 SYS_INIT(swerv_pic_init, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY);

--- a/drivers/interrupt_controller/intc_system_apic.c
+++ b/drivers/interrupt_controller/intc_system_apic.c
@@ -96,3 +96,8 @@ void arch_irq_disable(unsigned int irq)
 		z_loapic_irq_disable(irq - z_loapic_irq_base());
 	}
 }
+
+void arch_irq_priority_set(unsigned int irq, unsigned int prio,
+							uint32_t flags)
+{
+}

--- a/drivers/interrupt_controller/intc_vexriscv_litex.c
+++ b/drivers/interrupt_controller/intc_vexriscv_litex.c
@@ -120,6 +120,11 @@ int arch_irq_is_enabled(unsigned int irq)
 	return vexriscv_litex_irq_getmask() & (1 << irq);
 }
 
+void arch_irq_priority_set(unsigned int irq, unsigned int prio,
+							uint32_t flags)
+{
+}
+
 static int vexriscv_litex_irq_init(void)
 {
 	__asm__ volatile ("csrrs x0, mie, %0"

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -399,7 +399,7 @@ void smp_timer_init(void)
 	timer0_count_register_set(0);
 	timer0_limit_register_set(0);
 
-	z_irq_priority_set(IRQ_TIMER0, CONFIG_ARCV2_TIMER_IRQ_PRIORITY, 0);
+	irq_priority_set(IRQ_TIMER0, CONFIG_ARCV2_TIMER_IRQ_PRIORITY, 0);
 	irq_enable(IRQ_TIMER0);
 }
 #endif

--- a/include/zephyr/arch/arc/v2/irq.h
+++ b/include/zephyr/arch/arc/v2/irq.h
@@ -37,7 +37,7 @@ extern void sys_trace_isr_enter(void);
 extern void sys_trace_isr_exit(void);
 #endif
 
-extern void z_irq_priority_set(unsigned int irq, unsigned int prio,
+extern void arch_irq_priority_set(unsigned int irq, unsigned int prio,
 			      uint32_t flags);
 
 /* Z_ISR_DECLARE will populate the .intList section with the interrupt's
@@ -51,7 +51,7 @@ extern void z_irq_priority_set(unsigned int irq, unsigned int prio,
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 { \
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
-	z_irq_priority_set(irq_p, priority_p, flags_p); \
+	arch_irq_priority_set(irq_p, priority_p, flags_p); \
 }
 
 /**
@@ -69,7 +69,7 @@ extern void z_irq_priority_set(unsigned int irq, unsigned int prio,
  * to 0 but next level 1.
  *
  * Note that for the above cases, if application still wants to use firq by
- * setting priority to 0. Application can call z_irq_priority_set again.
+ * setting priority to 0. Application can call arch_irq_priority_set again.
  * Then it's left to application to handle the details of firq
  *
  * See include/irq.h for details.
@@ -84,7 +84,7 @@ extern void z_irq_priority_set(unsigned int irq, unsigned int prio,
 	"irq priority cannot be set to 0 when CONFIG_ARC_FIRQ_STACK" \
 	"is not configured or CONFIG_ARC_FIRQ_STACK " \
 	"and CONFIG_ARC_STACK_CHECKING are configured together"); \
-	z_irq_priority_set(irq_p, priority_p, flags_p); \
+	arch_irq_priority_set(irq_p, priority_p, flags_p); \
 }
 
 

--- a/include/zephyr/arch/arm/aarch32/irq.h
+++ b/include/zephyr/arch/arm/aarch32/irq.h
@@ -39,9 +39,7 @@ GTEXT(z_soc_irq_eoi)
 extern void arch_irq_enable(unsigned int irq);
 extern void arch_irq_disable(unsigned int irq);
 extern int arch_irq_is_enabled(unsigned int irq);
-
-/* internal routine documented in C file, needed by IRQ_CONNECT() macro */
-extern void z_arm_irq_priority_set(unsigned int irq, unsigned int prio,
+extern void arch_irq_priority_set(unsigned int irq, unsigned int prio,
 				   uint32_t flags);
 
 #else
@@ -66,7 +64,7 @@ void z_soc_irq_eoi(unsigned int irq);
 #define arch_irq_disable(irq)		z_soc_irq_disable(irq)
 #define arch_irq_is_enabled(irq)	z_soc_irq_is_enabled(irq)
 
-#define z_arm_irq_priority_set(irq, prio, flags)	\
+#define arch_irq_priority_set(irq, prio, flags)	\
 	z_soc_irq_priority_set(irq, prio, flags)
 
 #endif /* !CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER */
@@ -127,7 +125,7 @@ extern void z_arm_interrupt_init(void);
 			"ZLI interrupt registered but feature is disabled"); \
 	_CHECK_PRIO(priority_p, flags_p) \
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
-	z_arm_irq_priority_set(irq_p, priority_p, flags_p); \
+	arch_irq_priority_set(irq_p, priority_p, flags_p); \
 }
 
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
@@ -136,7 +134,7 @@ extern void z_arm_interrupt_init(void);
 			"ZLI interrupt registered but feature is disabled"); \
 	_CHECK_PRIO(priority_p, flags_p) \
 	Z_ISR_DECLARE(irq_p, ISR_FLAG_DIRECT, isr_p, NULL); \
-	z_arm_irq_priority_set(irq_p, priority_p, flags_p); \
+	arch_irq_priority_set(irq_p, priority_p, flags_p); \
 }
 
 #ifdef CONFIG_PM

--- a/include/zephyr/arch/arm64/irq.h
+++ b/include/zephyr/arch/arm64/irq.h
@@ -38,9 +38,7 @@ GTEXT(z_soc_irq_eoi)
 extern void arch_irq_enable(unsigned int irq);
 extern void arch_irq_disable(unsigned int irq);
 extern int arch_irq_is_enabled(unsigned int irq);
-
-/* internal routine documented in C file, needed by IRQ_CONNECT() macro */
-extern void z_arm64_irq_priority_set(unsigned int irq, unsigned int prio,
+extern void arch_irq_priority_set(unsigned int irq, unsigned int prio,
 				     uint32_t flags);
 
 #else
@@ -65,7 +63,7 @@ void z_soc_irq_eoi(unsigned int irq);
 #define arch_irq_disable(irq)		z_soc_irq_disable(irq)
 #define arch_irq_is_enabled(irq)	z_soc_irq_is_enabled(irq)
 
-#define z_arm64_irq_priority_set(irq, prio, flags)	\
+#define arch_irq_priority_set(irq, prio, flags)	\
 	z_soc_irq_priority_set(irq, prio, flags)
 
 #endif /* !CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER */
@@ -85,13 +83,13 @@ extern void z_arm64_interrupt_init(void);
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 { \
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
-	z_arm64_irq_priority_set(irq_p, priority_p, flags_p); \
+	arch_irq_priority_set(irq_p, priority_p, flags_p); \
 }
 
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
 { \
 	Z_ISR_DECLARE(irq_p, ISR_FLAG_DIRECT, isr_p, NULL); \
-	z_arm64_irq_priority_set(irq_p, priority_p, flags_p); \
+	arch_irq_priority_set(irq_p, priority_p, flags_p); \
 }
 
 #endif /* _ASMLANGUAGE */

--- a/include/zephyr/arch/mips/arch.h
+++ b/include/zephyr/arch/mips/arch.h
@@ -39,6 +39,8 @@ extern "C" {
 void arch_irq_enable(unsigned int irq);
 void arch_irq_disable(unsigned int irq);
 int arch_irq_is_enabled(unsigned int irq);
+void arch_irq_priority_set(unsigned int irq, unsigned int priority,
+							uint32_t flags);
 void z_irq_spurious(const void *unused);
 
 /**

--- a/include/zephyr/arch/nios2/arch.h
+++ b/include/zephyr/arch/nios2/arch.h
@@ -98,6 +98,8 @@ static ALWAYS_INLINE bool arch_irq_unlocked(unsigned int key)
 
 void arch_irq_enable(unsigned int irq);
 void arch_irq_disable(unsigned int irq);
+void arch_irq_priority_set(unsigned int irq, unsigned int priority,
+							uint32_t flags);
 
 struct __esf {
 	uint32_t ra; /* return address r31 */

--- a/include/zephyr/arch/riscv/irq.h
+++ b/include/zephyr/arch/riscv/irq.h
@@ -28,20 +28,22 @@ extern "C" {
 extern void arch_irq_enable(unsigned int irq);
 extern void arch_irq_disable(unsigned int irq);
 extern int arch_irq_is_enabled(unsigned int irq);
-
-#if defined(CONFIG_RISCV_HAS_PLIC) || defined(CONFIG_RISCV_HAS_CLIC)
-extern void z_riscv_irq_priority_set(unsigned int irq,
+extern void arch_irq_priority_set(unsigned int irq,
 				     unsigned int prio,
 				     uint32_t flags);
-#else
-#define z_riscv_irq_priority_set(i, p, f) /* Nothing */
-#endif /* CONFIG_RISCV_HAS_PLIC || CONFIG_RISCV_HAS_CLIC */
 
+#if defined(CONFIG_RISCV_HAS_PLIC) || (CONFIG_RISCV_HAS_CLIC)
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 { \
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
-	z_riscv_irq_priority_set(irq_p, priority_p, flags_p); \
+	arch_irq_priority_set(irq_p, priority_p, flags_p); \
 }
+#else
+#define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
+{ \
+	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
+}
+#endif
 
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
 { \

--- a/include/zephyr/arch/x86/arch.h
+++ b/include/zephyr/arch/x86/arch.h
@@ -246,6 +246,9 @@ extern "C" {
 
 extern void arch_irq_enable(unsigned int irq);
 extern void arch_irq_disable(unsigned int irq);
+extern void arch_irq_priority_set(unsigned int irq,
+								unsigned int prio,
+								uint32_t flags);
 
 extern uint32_t sys_clock_cycle_get_32(void);
 

--- a/include/zephyr/arch/xtensa/arch.h
+++ b/include/zephyr/arch/xtensa/arch.h
@@ -52,9 +52,6 @@ extern void xtensa_arch_except(int reason_p);
 	CODE_UNREACHABLE; \
 } while (false)
 
-/* internal routine documented in C file, needed by IRQ_CONNECT() macro */
-extern void z_irq_priority_set(uint32_t irq, uint32_t prio, uint32_t flags);
-
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 { \
 	Z_ISR_DECLARE(irq_p, flags_p, isr_p, isr_param_p); \

--- a/include/zephyr/arch/xtensa/irq.h
+++ b/include/zephyr/arch/xtensa/irq.h
@@ -101,6 +101,8 @@ extern int z_soc_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 
 #endif
 
+void arch_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags);
+
 static ALWAYS_INLINE void z_xtensa_irq_enable(uint32_t irq)
 {
 	z_xt_ints_on(1 << irq);

--- a/include/zephyr/irq.h
+++ b/include/zephyr/irq.h
@@ -71,6 +71,22 @@ irq_connect_dynamic(unsigned int irq, unsigned int priority,
 }
 
 /**
+ * @brief Set an interrupt's priority.
+ *
+ * @note This operation is not supported by all architectures/targets.
+ * This routine will have no effect on unsupported targets.
+ *
+ * @param irq IRQ line number
+ * @param priority Interrupt priority
+ * @param flags Arch-specific IRQ configuration flags
+ */
+static inline void
+irq_priority_set(unsigned int irq, unsigned int priority, uint32_t flags)
+{
+	arch_irq_priority_set(irq, priority, flags);
+}
+
+/**
  * @brief Initialize a 'direct' interrupt handler.
  *
  * This routine initializes an interrupt handler for an IRQ. The IRQ must be

--- a/include/zephyr/sys/arch_interface.h
+++ b/include/zephyr/sys/arch_interface.h
@@ -324,6 +324,16 @@ int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 			     const void *parameter, uint32_t flags);
 
 /**
+ * Arch-specific hook to set an interrupt's priority
+ *
+ * @param irq IRQ line number
+ * @param priority Interrupt priority
+ * @param flags Arch-specific IRQ configuration flag
+ */
+void arch_irq_priority_set(unsigned int irq, unsigned int priority,
+			     uint32_t flags);
+
+/**
  * @def ARCH_IRQ_CONNECT(irq, pri, isr, arg, flags)
  *
  * @see IRQ_CONNECT()

--- a/soc/riscv/esp32c3/soc_irq.c
+++ b/soc/riscv/esp32c3/soc_irq.c
@@ -50,6 +50,10 @@ int arch_irq_is_enabled(unsigned int irq)
 	return res;
 }
 
+void arch_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+{
+}
+
 uint32_t soc_intr_get_next_source(void)
 {
 	uint32_t status;

--- a/soc/riscv/openisa_rv32m1/soc.c
+++ b/soc/riscv/openisa_rv32m1/soc.c
@@ -131,6 +131,10 @@ int arch_irq_is_enabled(unsigned int irq)
 	}
 }
 
+void arch_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+{
+}
+
 /*
  * SoC-level interrupt initialization. Clear any pending interrupts or
  * events, and find the INTMUX device if necessary.

--- a/soc/riscv/riscv-ite/common/soc_common_irq.c
+++ b/soc/riscv/riscv-ite/common/soc_common_irq.c
@@ -38,3 +38,7 @@ int arch_irq_is_enabled(unsigned int irq)
 		return 0;
 	}
 }
+
+void arch_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+{
+}

--- a/soc/riscv/riscv-privilege/common/soc_common_irq.c
+++ b/soc/riscv/riscv-privilege/common/soc_common_irq.c
@@ -31,7 +31,7 @@ int arch_irq_is_enabled(unsigned int irq)
 	return riscv_clic_irq_is_enabled(irq);
 }
 
-void z_riscv_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+void arch_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
 	riscv_clic_irq_priority_set(irq, prio, flags);
 }
@@ -99,7 +99,7 @@ int arch_irq_is_enabled(unsigned int irq)
 }
 
 #if defined(CONFIG_RISCV_HAS_PLIC)
-void z_riscv_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+void arch_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
 	unsigned int level = irq_get_level(irq);
 
@@ -107,6 +107,10 @@ void z_riscv_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flag
 		irq = irq_from_level_2(irq);
 		riscv_plic_set_priority(irq, prio);
 	}
+}
+#else /* !CONFIG_RISCV_HAS_PLIC && !CONFIG_RISCV_HAS_CLIC */
+void arch_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+{
 }
 #endif /* CONFIG_RISCV_HAS_PLIC */
 #endif /* CONFIG_RISCV_HAS_CLIC */

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -143,7 +143,7 @@ ZTEST(vector_table, test_arm_irq_vector_table)
 
 	for (int ii = 0; ii < 3; ii++) {
 		irq_enable(_ISR_OFFSET + ii);
-		z_arm_irq_priority_set(_ISR_OFFSET + ii, 0, 0);
+		arch_irq_priority_set(_ISR_OFFSET + ii, 0, 0);
 		k_sem_init(&sem[ii], 0, K_SEM_MAX_LIMIT);
 	}
 

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -139,7 +139,9 @@ ZTEST(interrupt_feature, test_nested_isr)
 
 	/* Connect and enable test IRQs */
 	arch_irq_connect_dynamic(irq_line_0, IRQ0_PRIO, isr0, NULL, 0);
-	arch_irq_connect_dynamic(irq_line_1, IRQ1_PRIO, isr1, NULL, 0);
+	arch_irq_connect_dynamic(irq_line_1, IRQ0_PRIO, isr1, NULL, 0);
+
+	irq_priority_set(irq_line_1, IRQ1_PRIO, 0);
 
 	irq_enable(irq_line_0);
 	irq_enable(irq_line_1);


### PR DESCRIPTION
This PR introduces a new API `irq_priority_set()`, which enables setting interrupt priority dynamically.

Existing internal architecture-specific IRQ priority setting functionality is now exposed through `arch_irq_priority_set()`, and architectures that do not support this have stubs to prevent build errors.

Testing of this API has been added to the existing nested_irq kernel interrupt test as it naturally can be very easily tested by that existing test.