### PR TITLE
tests: posix: headers: Add min_ram to fix compilation error on Twister

### DIFF
--- a/tests/posix/headers/testcase.yaml
+++ b/tests/posix/headers/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   arch_exclude: posix
   tags: posix net socket
+  min_ram: 32
 
 tests:
   portability.posix.headers.with_posix_api:


### PR DESCRIPTION
Compilation of the posix/headers test on nucleo_f103rb fails because "region 'RAM' overflowed by 136 bytes". Since this board has a ram size of 20k, we set the limit for this test at 21.

A similar problem for this same test is found on nucleo_l073rz whose RAM size is also 20k. 

Fixes #54397