### PR TITLE
drivers: serial: binding: add devicetree init support

### DIFF
--- a/dts/bindings/serial/infineon,cat1-uart.yaml
+++ b/dts/bindings/serial/infineon,cat1-uart.yaml
@@ -39,24 +39,3 @@ properties:
 
   pinctrl-names:
     required: true
-
-  stop-bits:
-    type: string
-    description: |
-      The number of stop bits, refer to uart_config_stop_bits
-    enum:
-      - "0.5"
-      - "1"
-      - "1.5"
-      - "2"
-
-  data-bits:
-    type: int
-    description: |
-      The number of data bits. Refer to enumeration uart_config_data_bits.
-    enum:
-      - 5
-      - 6
-      - 7
-      - 8
-      - 9

--- a/dts/bindings/serial/uart-controller.yaml
+++ b/dts/bindings/serial/uart-controller.yaml
@@ -23,3 +23,22 @@ properties:
       - "none"
       - "odd"
       - "even"
+  stop-bits:
+    type: string
+    description: |
+      Sets the number of stop bits.
+    enum:
+      - "0_5"
+      - "1"
+      - "1_5"
+      - "2"
+  data-bits:
+    type: int
+    description: |
+      Sets the number of data bits.
+    enum:
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9


### PR DESCRIPTION
Extend the binding to allow buildtime configuration of
- stopbits
- databits

Signed-off-by: Jeroen van Dooren <jeroen.van.dooren@nobleo.nl>