### PR TITLE
Disable cortex m4 core force-boot on STM32H7

### DIFF
--- a/soc/arm/st_stm32/stm32h7/Kconfig.soc
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.soc
@@ -73,3 +73,7 @@ config SOC_STM32H7B3XXQ
 	select CPU_HAS_FPU_DOUBLE_PRECISION
 
 endchoice
+
+config STM32H7_BOOT_M4_AT_INIT
+	bool "Boot M4 core during M7 init independent of option byte BCM4."
+	default y

--- a/soc/arm/st_stm32/stm32h7/soc_m7.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m7.c
@@ -37,7 +37,7 @@ static int stm32h7_m4_wakeup(const struct device *arg)
 		 * then Cortex-M7 takes HSEM so that CM4 can continue running.
 		 */
 		LL_HSEM_1StepLock(HSEM, CFG_HW_ENTRY_STOP_MODE_SEMID);
-	} else {
+	} else if (IS_ENABLED(CONFIG_STM32H7_BOOT_M4_AT_INIT)) {
 		/* CM4 is not started at boot, start it now */
 		LL_RCC_ForceCM4Boot();
 	}


### PR DESCRIPTION
As described in this [issue](https://github.com/zephyrproject-rtos/zephyr/issues/54230) Zephyr currently does not respect the `BCM4` option byte on STM32H7 microcontrollers.

This option byte should disable the boot of the m4 core but the Zephyr kernel on the m7 core force-boots the m4 core. The changes of this merge request disable this force-boot.