### PR TITLE
modules: trusted-firmware-m: Post upmerge fixes

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -31,7 +31,6 @@ set(TFM_CRYPTO_MODULES
 
 
 if (CONFIG_BUILD_WITH_TFM)
-  list(APPEND TFM_CMAKE_ARGS -DTFM_LIB_MODEL=OFF)
   # PSA API awareness for the Non-Secure application
   target_compile_definitions(app PRIVATE "TFM_PSA_API")
   if (CONFIG_TFM_SFN)

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -262,10 +262,13 @@ if (CONFIG_BUILD_WITH_TFM)
   endif()
 
   if(CONFIG_FPU AND CONFIG_FP_HARDABI)
-    list(APPEND TFM_CMAKE_ARGS -DCONFIG_TFM_FP=hard)
+    list(APPEND TFM_CMAKE_ARGS -DCONFIG_TFM_ENABLE_FP=ON)
+    # Note: This is not a cmake option in TF-M.
+    # This should be specified by the platform in preload.cmake
+    # This works as a workaround for the platforms that do not have this.
     list(APPEND TFM_CMAKE_ARGS -DCONFIG_TFM_FP_ARCH=${FPU_FOR_${GCC_M_CPU}})
   else()
-    list(APPEND TFM_CMAKE_ARGS -DCONFIG_TFM_FP=soft)
+    list(APPEND TFM_CMAKE_ARGS -DCONFIG_TFM_ENABLE_FP=OFF)
   endif()
 
   file(MAKE_DIRECTORY ${TFM_BINARY_DIR})

--- a/modules/trusted-firmware-m/Kconfig.tfm.partitions
+++ b/modules/trusted-firmware-m/Kconfig.tfm.partitions
@@ -56,7 +56,6 @@ config TFM_PARTITION_INITIAL_ATTESTATION
 config TFM_PARTITION_PLATFORM
 	bool "Secure partition 'Platform'"
 	default y
-	depends on !TFM_SFN # Currently using PSA Framework version 1.0
 	help
 	  Setting this option will cause '-DTFM_PARTITION_PLATFORM'
 	  to be passed to the TF-M build system. Look at 'config_default.cmake'


### PR DESCRIPTION
Fix setting of TF-M floating point options when floating point is
enabled in the application.
FP design in Armv8.0-M architecture requires consistent FP ABI types
between SPE and NSPE.

Remove setting of the TFM_LIB_MODEL option for IPC and SFN models.
This option is removed together with the library model.

The TF-M platform partition has now been ported to PSA firmware
framework 1.1 and can now be used together with the SFN model.

Fixes #54509 
