### PR TITLE
drivers: counter: align to NRF_TIMER hal

### DIFF
--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -13,7 +13,7 @@
 #include <zephyr/irq.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 
-#define TIMER_CLOCK 16000000
+#define TIMER_CLOCK(timer_instance) NRF_TIMER_BASE_FREQUENCY_GET(timer_instance)
 
 #define CC_TO_ID(cc_num) (cc_num - 2)
 
@@ -48,7 +48,7 @@ struct counter_nrfx_config {
 struct counter_timer_config {
 	nrf_timer_bit_width_t bit_width;
 	nrf_timer_mode_t mode;
-	nrf_timer_frequency_t freq;
+	uint32_t prescaler;
 };
 
 static int start(const struct device *dev)
@@ -240,7 +240,6 @@ static int set_top_value(const struct device *dev,
 	NRF_TIMER_Type *timer = nrfx_config->timer;
 	struct counter_nrfx_data *data = dev->data;
 	int err = 0;
-
 	for (int i = 0; i < counter_get_num_of_channels(dev); i++) {
 		/* Overflow can be changed only when all alarms are
 		 * disables.
@@ -286,7 +285,7 @@ static int init_timer(const struct device *dev,
 
 	nrf_timer_bit_width_set(reg, config->bit_width);
 	nrf_timer_mode_set(reg, config->mode);
-	nrf_timer_prescaler_set(reg, config->freq);
+	nrf_timer_prescaler_set(reg, config->prescaler);
 
 	nrf_timer_cc_set(reg, TOP_CH, counter_get_max_top_value(dev));
 
@@ -418,7 +417,7 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 	{								       \
 		TIMER_IRQ_CONNECT(idx);					       \
 		static const struct counter_timer_config config = {	       \
-			.freq = TIMER_PROP(idx, prescaler),		       \
+			.prescaler = TIMER_PROP(idx, prescaler),	       \
 			.mode = NRF_TIMER_MODE_TIMER,			       \
 			.bit_width = (TIMER##idx##_MAX_SIZE == 32) ?	       \
 					NRF_TIMER_BIT_WIDTH_32 :	       \
@@ -434,7 +433,7 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 		.info = {						       \
 			.max_top_value = (TIMER##idx##_MAX_SIZE == 32) ?       \
 					0xffffffff : 0x0000ffff,	       \
-			.freq = TIMER_CLOCK /				       \
+			.freq = TIMER_CLOCK(NRF_TIMER##idx) /		       \
 					(1 << TIMER_PROP(idx, prescaler)),     \
 			.flags = COUNTER_CONFIG_INFO_COUNT_UP,		       \
 			.channels = CC_TO_ID(TIMER##idx##_CC_NUM),	       \

--- a/dts/bindings/timer/nordic,nrf-timer.yaml
+++ b/dts/bindings/timer/nordic,nrf-timer.yaml
@@ -22,4 +22,4 @@ properties:
   prescaler:
     type: int
     required: true
-    description: Prescaler value determines frequency (16MHz/2^prescaler)
+    description: Prescaler value determines frequency (base_frequency/2^prescaler)


### PR DESCRIPTION
Align driver with changes introduced in the hal. `nrf_timer_frequency_set` was changed to `nrf_timer_prescaler_set`, update driver accordingly.