### PR TITLE
Bluetooth: Controller: EVENT_OVERHEAD_START_US for audio usecases

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
@@ -21,12 +21,20 @@
 /* Active connection in peripheral role with extended scanning on 1M and Coded
  * PHY, scheduling and receiving auxiliary PDUs.
  */
+#if defined(CONFIG_BT_CTLR_CONN_ISO)
+#define EVENT_OVERHEAD_START_US       579
+#else /* !CONFIG_BT_CTLR_CONN_ISO */
 #define EVENT_OVERHEAD_START_US       458
+#endif /* !CONFIG_BT_CTLR_CONN_ISO */
 #else /* !CONFIG_BT_CTLR_PHY_CODED */
 /* Active connection in peripheral role with extended scanning on 1M only,
  * scheduling and receiving auxiliary PDUs.
  */
+#if defined(CONFIG_BT_CTLR_CONN_ISO)
+#define EVENT_OVERHEAD_START_US       549
+#else /* !CONFIG_BT_CTLR_CONN_ISO */
 #define EVENT_OVERHEAD_START_US       428
+#endif /* !CONFIG_BT_CTLR_CONN_ISO */
 #endif /* !CONFIG_BT_CTLR_PHY_CODED */
 #else /* !CONFIG_BT_OBSERVER */
 /* Active connection in peripheral role with legacy scanning on 1M.


### PR DESCRIPTION
Tune the EVENT_OVERHEAD_START_US for audio usecases on nRF5340 SoC using the nrf5340_audio application provided in nRF Connect SDK.

The scenario involves one central ACL connections, one CIS connection, continuous scanning and establish the second ACL connection.

Manually run the samples for over 30 mins without any assertions and use the actual profiled value that would otherwise be printed on assertion.

Fixes #54407.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>