### PR TITLE
drivers/interrupt_controller: Move VT-D to new cache API

### DIFF
--- a/drivers/interrupt_controller/intc_intel_vtd.c
+++ b/drivers/interrupt_controller/intc_intel_vtd.c
@@ -86,8 +86,8 @@ static void vtd_flush_irte_from_cache(const struct device *dev,
 	struct vtd_ictl_data *data = dev->data;
 
 	if (!data->pwc) {
-		sys_cache_data_range(&data->irte[irte_idx],
-				     sizeof(union vtd_irte), K_CACHE_WB);
+		cache_data_flush_range(&data->irte[irte_idx],
+				       sizeof(union vtd_irte));
 	}
 }
 


### PR DESCRIPTION
Just a left-over from previous API.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>