### PR TITLE
LE Audio: Fix response code expected by ASCS/SR/SPE/BI-18-C

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -79,6 +79,11 @@ static int control_point_notify(struct bt_conn *conn, const void *data, uint16_t
 static int ascs_ep_get_status(struct bt_audio_ep *ep,
 			      struct net_buf_simple *buf);
 
+static bool is_valid_ase_id(uint8_t ase_id)
+{
+	return IN_RANGE(ase_id, 1, ASE_COUNT);
+}
+
 static void bt_ascs_ase_return_to_slab(struct bt_ascs_ase *ase)
 {
 	__ASSERT(ase && ase->ascs, "Non-existing ASE or ASCS");
@@ -1640,11 +1645,18 @@ static ssize_t ascs_qos(struct bt_ascs *ascs, struct net_buf_simple *buf)
 
 		LOG_DBG("ase 0x%02x", qos->ase);
 
-		ase = ase_find(ascs, qos->ase);
-		if (!ase) {
+		if (!is_valid_ase_id(qos->ase)) {
 			ascs_cp_rsp_add(qos->ase, BT_ASCS_QOS_OP,
 					BT_ASCS_RSP_INVALID_ASE, 0x00);
 			LOG_WRN("Unknown ase 0x%02x", qos->ase);
+			continue;
+		}
+
+		ase = ase_find(ascs, qos->ase);
+		if (!ase) {
+			LOG_DBG("Invalid operation for idle ASE");
+			ascs_cp_rsp_add(qos->ase, BT_ASCS_QOS_OP,
+					BT_ASCS_RSP_INVALID_ASE_STATE, 0x00);
 			continue;
 		}
 
@@ -1983,11 +1995,18 @@ static ssize_t ascs_enable(struct bt_ascs *ascs, struct net_buf_simple *buf)
 			return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 		}
 
-		ase = ase_find(ascs, meta->ase);
-		if (!ase) {
+		if (!is_valid_ase_id(meta->ase)) {
 			ascs_cp_rsp_add(meta->ase, BT_ASCS_ENABLE_OP,
 					BT_ASCS_RSP_INVALID_ASE, 0x00);
 			LOG_WRN("Unknown ase 0x%02x", meta->ase);
+			continue;
+		}
+
+		ase = ase_find(ascs, meta->ase);
+		if (!ase) {
+			LOG_DBG("Invalid operation for idle ASE");
+			ascs_cp_rsp_add(meta->ase, BT_ASCS_ENABLE_OP,
+					BT_ASCS_RSP_INVALID_ASE_STATE, 0x00);
 			continue;
 		}
 
@@ -2072,11 +2091,18 @@ static ssize_t ascs_start(struct bt_ascs *ascs, struct net_buf_simple *buf)
 
 		LOG_DBG("ase 0x%02x", id);
 
-		ase = ase_find(ascs, id);
-		if (!ase) {
+		if (!is_valid_ase_id(id)) {
 			ascs_cp_rsp_add(id, BT_ASCS_START_OP,
 					BT_ASCS_RSP_INVALID_ASE, 0x00);
 			LOG_WRN("Unknown ase 0x%02x", id);
+			continue;
+		}
+
+		ase = ase_find(ascs, id);
+		if (!ase) {
+			LOG_DBG("Invalid operation for idle ASE");
+			ascs_cp_rsp_add(id, BT_ASCS_START_OP,
+					BT_ASCS_RSP_INVALID_ASE_STATE, 0x00);
 			continue;
 		}
 
@@ -2115,11 +2141,18 @@ static ssize_t ascs_disable(struct bt_ascs *ascs, struct net_buf_simple *buf)
 
 		LOG_DBG("ase 0x%02x", id);
 
-		ase = ase_find(ascs, id);
-		if (!ase) {
+		if (!is_valid_ase_id(id)) {
 			ascs_cp_rsp_add(id, BT_ASCS_DISABLE_OP,
 					BT_ASCS_RSP_INVALID_ASE, 0x00);
 			LOG_WRN("Unknown ase 0x%02x", id);
+			continue;
+		}
+
+		ase = ase_find(ascs, id);
+		if (!ase) {
+			LOG_DBG("Invalid operation for idle ASE");
+			ascs_cp_rsp_add(id, BT_ASCS_DISABLE_OP,
+					BT_ASCS_RSP_INVALID_ASE_STATE, 0x00);
 			continue;
 		}
 
@@ -2223,11 +2256,18 @@ static ssize_t ascs_stop(struct bt_ascs *ascs, struct net_buf_simple *buf)
 
 		LOG_DBG("ase 0x%02x", id);
 
-		ase = ase_find(ascs, id);
-		if (!ase) {
+		if (!is_valid_ase_id(id)) {
 			ascs_cp_rsp_add(id, BT_ASCS_STOP_OP,
 					BT_ASCS_RSP_INVALID_ASE, 0x00);
 			LOG_WRN("Unknown ase 0x%02x", id);
+			continue;
+		}
+
+		ase = ase_find(ascs, id);
+		if (!ase) {
+			LOG_DBG("Invalid operation for idle ASE");
+			ascs_cp_rsp_add(id, BT_ASCS_STOP_OP,
+					BT_ASCS_RSP_INVALID_ASE_STATE, 0x00);
 			continue;
 		}
 
@@ -2272,11 +2312,18 @@ static ssize_t ascs_metadata(struct bt_ascs *ascs, struct net_buf_simple *buf)
 
 		LOG_DBG("ase 0x%02x meta->len %u", meta->ase, meta->len);
 
-		ase = ase_find(ascs, meta->ase);
-		if (!ase) {
+		if (!is_valid_ase_id(meta->ase)) {
 			ascs_cp_rsp_add(meta->ase, BT_ASCS_METADATA_OP,
 					BT_ASCS_RSP_INVALID_ASE, 0x00);
 			LOG_WRN("Unknown ase 0x%02x", meta->ase);
+			continue;
+		}
+
+		ase = ase_find(ascs, meta->ase);
+		if (!ase) {
+			LOG_DBG("Invalid operation for idle ASE");
+			ascs_cp_rsp_add(meta->ase, BT_ASCS_METADATA_OP,
+					BT_ASCS_RSP_INVALID_ASE_STATE, 0x00);
 			continue;
 		}
 
@@ -2315,11 +2362,18 @@ static ssize_t ascs_release(struct bt_ascs *ascs, struct net_buf_simple *buf)
 
 		LOG_DBG("ase 0x%02x", id);
 
+		if (!is_valid_ase_id(id)) {
+			ascs_cp_rsp_add(id, BT_ASCS_RELEASE_OP,
+					BT_ASCS_RSP_INVALID_ASE, 0x00);
+			LOG_WRN("Unknown ase 0x%02x", id);
+			continue;
+		}
+
 		ase = ase_find(ascs, id);
 		if (!ase) {
+			LOG_DBG("Invalid operation for idle ASE");
 			ascs_cp_rsp_add(id, BT_ASCS_RELEASE_OP,
-					BT_ASCS_RSP_INVALID_ASE, 0);
-			LOG_WRN("Unknown ase 0x%02x", id);
+					BT_ASCS_RSP_INVALID_ASE_STATE, 0x00);
 			continue;
 		}
 


### PR DESCRIPTION
When handling ASE Control operations requested by client, first verify that the requested ID is within the allowed range. If it does, lets assume that the NULL returned from ase_find() means the ASE state is set to idle.

This will fix ASE Notification Response code expected by the ASCS/SR/SPE/BI-18-C PTS test case.