### PR TITLE
drivers: serial: stm32 uart driver avoid LOG_ when going to sleep

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1792,10 +1792,14 @@ static int uart_stm32_pm_action(const struct device *dev,
 
 		/* Move pins to sleep state */
 		err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
-		if (err == -ENOENT) {
-			/* Warn but don't block PM suspend */
-			LOG_WRN("(LP)UART pinctrl sleep state not available ");
-		} else if (err < 0) {
+		if ((err < 0) && (err != -ENOENT)) {
+			/*
+			 * If returning -ENOENT, no pins where defined for sleep mode :
+			 * Do not output on console (might sleep already) when going to sleep,
+			 * "(LP)UART pinctrl sleep state not available"
+			 * and don't block PM suspend.
+			 * Else return the error.
+			 */
 			return err;
 		}
 		break;


### PR DESCRIPTION
When the LOG_WRN is used on stm32 uart driver it could block execution : when pin state for sleep mode is not defined by the DTS even if no error is raised, LOG_ msg is crashing when entering sleep mode.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54427

Signed-off-by: Francois Ramu <francois.ramu@st.com>