### PR TITLE
boards: arm: adafruit_kb2040: Fix missing flash controller

### DIFF
--- a/boards/arm/adafruit_kb2040/adafruit_kb2040.dts
+++ b/boards/arm/adafruit_kb2040/adafruit_kb2040.dts
@@ -16,6 +16,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,flash-controller = &ssi;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,code-partition = &code_partition;


### PR DESCRIPTION
Fixes an issue whereby the flash controller for this board was missing.

Fixes #54431

@petejohanson please check this is the correct flash controller for this board since I do not have it