### PR TITLE
boards: esp32: add default HEAP for all ESP32 boards

### DIFF
--- a/boards/riscv/esp32c3_devkitm/Kconfig.defconfig
+++ b/boards/riscv/esp32c3_devkitm/Kconfig.defconfig
@@ -7,13 +7,11 @@ config BOARD
 	default "esp32c3_devkitm"
 	depends on BOARD_ESP32C3_DEVKITM
 
-if BT
-
 config HEAP_MEM_POOL_SIZE
-	default 16384
+	default 98304 if WIFI
+	default 16384 if BT
+	default 4096
 
 choice BT_HCI_BUS_TYPE
-	default BT_ESP32
+	default BT_ESP32 if BT
 endchoice
-
-endif # BT

--- a/boards/riscv/icev_wireless/Kconfig.defconfig
+++ b/boards/riscv/icev_wireless/Kconfig.defconfig
@@ -5,13 +5,11 @@ config BOARD
 	default "icev_wireless"
 	depends on BOARD_ICEV_WIRELESS
 
-if BT
-
 config HEAP_MEM_POOL_SIZE
-	default 16384
+	default 98304 if WIFI
+	default 16384 if BT
+	default 4096
 
 choice BT_HCI_BUS_TYPE
-	default BT_ESP32
+	default BT_ESP32 if BT
 endchoice
-
-endif # BT

--- a/boards/riscv/xiao_esp32c3/Kconfig.defconfig
+++ b/boards/riscv/xiao_esp32c3/Kconfig.defconfig
@@ -10,10 +10,6 @@ config HEAP_MEM_POOL_SIZE
 	default 16384 if BT
 	default 4096
 
-if BT
-
 choice BT_HCI_BUS_TYPE
-	default BT_ESP32
+	default BT_ESP32 if BT
 endchoice
-
-endif # BT

--- a/boards/xtensa/esp32/Kconfig.defconfig
+++ b/boards/xtensa/esp32/Kconfig.defconfig
@@ -7,16 +7,14 @@ config BOARD
 	default "esp32"
 	depends on BOARD_ESP32
 
-if BT
-
-config HEAP_MEM_POOL_SIZE
-	default 16384
-
 config ENTROPY_GENERATOR
 	default y
 
-choice BT_HCI_BUS_TYPE
-	default BT_ESP32
-endchoice
+config HEAP_MEM_POOL_SIZE
+	default 98304 if WIFI
+	default 16384 if BT
+	default 4096
 
-endif # BT
+choice BT_HCI_BUS_TYPE
+	default BT_ESP32 if BT
+endchoice

--- a/boards/xtensa/esp32_ethernet_kit/Kconfig.defconfig
+++ b/boards/xtensa/esp32_ethernet_kit/Kconfig.defconfig
@@ -7,9 +7,6 @@ config BOARD
 	default "esp32_ethernet_kit"
 	depends on BOARD_ESP32_ETHERNET_KIT
 
-config ENTROPY_ESP32_RNG
-	default y if ENTROPY_GENERATOR
-
 config ESP_SPIRAM
 	default y
 
@@ -17,16 +14,14 @@ choice SPIRAM_TYPE
 	default SPIRAM_TYPE_ESPPSRAM64
 endchoice
 
-if BT
-
-config HEAP_MEM_POOL_SIZE
-	default 16384
-
 config ENTROPY_GENERATOR
 	default y
 
-choice BT_HCI_BUS_TYPE
-	default BT_ESP32
-endchoice
+config HEAP_MEM_POOL_SIZE
+	default 98304 if WIFI
+	default 16384 if BT
+	default 4096
 
-endif # BT
+choice BT_HCI_BUS_TYPE
+	default BT_ESP32 if BT
+endchoice

--- a/boards/xtensa/esp32_net/Kconfig.defconfig
+++ b/boards/xtensa/esp32_net/Kconfig.defconfig
@@ -7,19 +7,14 @@ config BOARD
 	default "esp32_net"
 	depends on BOARD_ESP32_NET
 
-config ENTROPY_ESP32_RNG
-	default y if ENTROPY_GENERATOR
-
-if BT
-
-config HEAP_MEM_POOL_SIZE
-	default 16384
-
 config ENTROPY_GENERATOR
 	default y
 
-choice BT_HCI_BUS_TYPE
-	default BT_ESP32
-endchoice
+config HEAP_MEM_POOL_SIZE
+	default 98304 if WIFI
+	default 16384 if BT
+	default 4096
 
-endif # BT
+choice BT_HCI_BUS_TYPE
+	default BT_ESP32 if BT
+endchoice

--- a/boards/xtensa/esp32s2_franzininho/Kconfig.defconfig
+++ b/boards/xtensa/esp32s2_franzininho/Kconfig.defconfig
@@ -9,3 +9,12 @@ config BOARD
 
 config ENTROPY_GENERATOR
 	default y
+
+config HEAP_MEM_POOL_SIZE
+	default 98304 if WIFI
+	default 16384 if BT
+	default 4096
+
+choice BT_HCI_BUS_TYPE
+	default BT_ESP32 if BT
+endchoice

--- a/boards/xtensa/esp32s2_saola/Kconfig.defconfig
+++ b/boards/xtensa/esp32s2_saola/Kconfig.defconfig
@@ -9,3 +9,12 @@ config BOARD
 
 config ENTROPY_GENERATOR
 	default y
+
+config HEAP_MEM_POOL_SIZE
+	default 98304 if WIFI
+	default 16384 if BT
+	default 4096
+
+choice BT_HCI_BUS_TYPE
+	default BT_ESP32 if BT
+endchoice

--- a/boards/xtensa/esp_wrover_kit/Kconfig.defconfig
+++ b/boards/xtensa/esp_wrover_kit/Kconfig.defconfig
@@ -7,19 +7,14 @@ config BOARD
 	default "esp_wrover_kit"
 	depends on BOARD_ESP_WROVER_KIT
 
-if BT
-
 config HEAP_MEM_POOL_SIZE
-	default 16384
-
-config ENTROPY_GENERATOR
-	default y
+	default 98304 if WIFI
+	default 16384 if BT
+	default 4096
 
 choice BT_HCI_BUS_TYPE
-	default BT_ESP32
+	default BT_ESP32 if BT
 endchoice
-
-endif # BT
 
 config DISK_DRIVER_SDMMC
 	default y

--- a/boards/xtensa/heltec_wifi_lora32_v2/Kconfig.defconfig
+++ b/boards/xtensa/heltec_wifi_lora32_v2/Kconfig.defconfig
@@ -6,3 +6,15 @@
 config BOARD
 	default "heltec_wifi_lora32"
 	depends on BOARD_HELTEC_WIFI_LORA32
+
+config ENTROPY_GENERATOR
+	default y
+
+config HEAP_MEM_POOL_SIZE
+	default 98304 if WIFI
+	default 16384 if BT
+	default 4096
+
+choice BT_HCI_BUS_TYPE
+	default BT_ESP32 if BT
+endchoice

--- a/boards/xtensa/m5stickc_plus/Kconfig.defconfig
+++ b/boards/xtensa/m5stickc_plus/Kconfig.defconfig
@@ -7,19 +7,14 @@ config BOARD
 	default "m5stickc_plus"
 	depends on BOARD_M5STICKC_PLUS
 
-config ENTROPY_ESP32_RNG
-	default y if ENTROPY_GENERATOR
-
-if BT
-
-config HEAP_MEM_POOL_SIZE
-	default 16384
-
 config ENTROPY_GENERATOR
 	default y
 
-choice BT_HCI_BUS_TYPE
-	default BT_ESP32
-endchoice
+config HEAP_MEM_POOL_SIZE
+	default 98304 if WIFI
+	default 16384 if BT
+	default 4096
 
-endif # BT
+choice BT_HCI_BUS_TYPE
+	default BT_ESP32 if BT
+endchoice

--- a/boards/xtensa/odroid_go/Kconfig.defconfig
+++ b/boards/xtensa/odroid_go/Kconfig.defconfig
@@ -13,16 +13,14 @@ config DISK_DRIVER_SDMMC
 config SPI
 	default y if DISK_DRIVER_SDMMC
 
-if BT
-
-config HEAP_MEM_POOL_SIZE
-	default 16384
-
 config ENTROPY_GENERATOR
 	default y
 
-choice BT_HCI_BUS_TYPE
-	default BT_ESP32
-endchoice
+config HEAP_MEM_POOL_SIZE
+	default 98304 if WIFI
+	default 16384 if BT
+	default 4096
 
-endif # BT
+choice BT_HCI_BUS_TYPE
+	default BT_ESP32 if BT
+endchoice

--- a/boards/xtensa/olimex_esp32_evb/Kconfig.defconfig
+++ b/boards/xtensa/olimex_esp32_evb/Kconfig.defconfig
@@ -8,4 +8,16 @@ if BOARD_OLIMEX_ESP32_EVB
 config BOARD
 	default "olimex_esp32_evb"
 
+config ENTROPY_GENERATOR
+	default y
+
+config HEAP_MEM_POOL_SIZE
+	default 98304 if WIFI
+	default 16384 if BT
+	default 4096
+
+choice BT_HCI_BUS_TYPE
+	default BT_ESP32 if BT
+endchoice
+
 endif # BOARD_OLIMEX_ESP32_EVB


### PR DESCRIPTION
In order to avoid missing k_malloc options, add default HEAP value for all boards.

Fixes #54428

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>