### PR TITLE
LE Audio: Fixes issues and race conditions when disconnecting CIS

### DIFF
--- a/subsys/bluetooth/audio/audio_iso.c
+++ b/subsys/bluetooth/audio/audio_iso.c
@@ -246,6 +246,15 @@ struct bt_audio_ep *bt_audio_iso_get_ep(bool unicast_client,
 	}
 }
 
+struct bt_audio_ep *bt_audio_iso_get_paired_ep(const struct bt_audio_ep *ep)
+{
+	if (ep->iso->rx.ep == ep) {
+		return ep->iso->tx.ep;
+	} else {
+		return ep->iso->rx.ep;
+	}
+}
+
 #if defined(CONFIG_BT_AUDIO_UNICAST_CLIENT)
 void bt_audio_iso_bind_stream(struct bt_audio_iso *audio_iso,
 			      struct bt_audio_stream *stream)

--- a/subsys/bluetooth/audio/audio_iso.h
+++ b/subsys/bluetooth/audio/audio_iso.h
@@ -44,6 +44,8 @@ void bt_audio_iso_unbind_ep(struct bt_audio_iso *iso, struct bt_audio_ep *ep);
 struct bt_audio_ep *bt_audio_iso_get_ep(bool unicast_client,
 					struct bt_audio_iso *iso,
 					enum bt_audio_dir dir);
+
+struct bt_audio_ep *bt_audio_iso_get_paired_ep(const struct bt_audio_ep *ep);
 /* Unicast client-only functions*/
 void bt_audio_iso_bind_stream(struct bt_audio_iso *audio_iso,
 			      struct bt_audio_stream *stream);

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -99,6 +99,46 @@ static int unicast_client_ep_set_codec(struct bt_audio_ep *ep, uint8_t id,
 
 static void unicast_client_ep_idle_state(struct bt_audio_ep *ep);
 
+/** Checks if the stream can terminate the CIS
+ *
+ * If the CIS is used for another stream, or if the CIS is not in the connected
+ * state it will return false.
+ */
+static bool unicast_client_can_disconnect_stream(const struct bt_audio_stream *stream)
+{
+	const struct bt_audio_ep *stream_ep;
+	enum bt_iso_state iso_state;
+
+	if (stream == NULL) {
+		return false;
+	}
+
+	stream_ep = stream->ep;
+
+	if (stream_ep ==  NULL || stream_ep->iso == NULL) {
+		return false;
+	}
+
+	iso_state = stream_ep->iso->chan.state;
+
+	if (iso_state == BT_ISO_STATE_CONNECTED ||
+	    iso_state == BT_ISO_STATE_CONNECTING) {
+		const struct bt_audio_ep *pair_ep;
+
+		pair_ep = bt_audio_iso_get_paired_ep(stream_ep);
+
+		/* If there are no paired endpoint, or the paired endpoint is
+		 * not in the streaming state, we can disconnect the CIS
+		 */
+		if (pair_ep == NULL ||
+		    pair_ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 static void unicast_client_ep_iso_recv(struct bt_iso_chan *chan,
 				       const struct bt_iso_recv_info *info,
 				       struct net_buf *buf)
@@ -404,20 +444,18 @@ static void unicast_client_ep_idle_state(struct bt_audio_ep *ep)
 	}
 
 	/* If CIS is connected, disconnect and wait for CIS disconnection */
-	if (ep->iso != NULL) {
-		if (ep->iso->chan.state == BT_ISO_STATE_CONNECTED ||
-		    ep->iso->chan.state == BT_ISO_STATE_CONNECTING) {
-			const int err = bt_audio_stream_disconnect(stream);
+	if (unicast_client_can_disconnect_stream(stream)) {
+		const int err = bt_audio_stream_disconnect(stream);
 
-			if (err != 0) {
-				LOG_ERR("Failed to disconnect stream: %d", err);
-			} else {
-				return;
-			}
-		} else if (ep->iso->chan.state == BT_ISO_STATE_DISCONNECTING) {
-			/* Wait */
+		if (err != 0) {
+			LOG_ERR("Failed to disconnect stream: %d", err);
+		} else {
 			return;
 		}
+	} else if (ep->iso != NULL &&
+		   ep->iso->chan.state == BT_ISO_STATE_DISCONNECTING) {
+		/* Wait */
+		return;
 	}
 
 	/* Notify upper layer */
@@ -586,9 +624,12 @@ static void unicast_client_ep_qos_state(struct bt_audio_ep *ep,
 	       stream->qos->pd);
 
 	/* Disconnect ISO if connected */
-	if (ep->iso->chan.state == BT_ISO_STATE_CONNECTED ||
-	    ep->iso->chan.state == BT_ISO_STATE_CONNECTING) {
-		bt_audio_stream_disconnect(stream);
+	if (unicast_client_can_disconnect_stream(stream)) {
+		const int err = bt_audio_stream_disconnect(stream);
+
+		if (err != 0) {
+			LOG_ERR("Failed to disconnect stream: %d", err);
+		}
 	} else {
 		/* We setup the data path here, as this is the earliest where
 		 * we have the ISO <-> EP coupling completed (due to setting
@@ -757,16 +798,18 @@ static void unicast_client_ep_releasing_state(struct bt_audio_ep *ep,
 
 	LOG_DBG("dir %s", bt_audio_dir_str(ep->dir));
 
-	if (ep->iso != NULL &&
-	    (ep->iso->chan.state == BT_ISO_STATE_CONNECTED ||
-	     ep->iso->chan.state == BT_ISO_STATE_CONNECTING)) {
+	if (unicast_client_can_disconnect_stream(stream)) {
 		/* The Unicast Client shall terminate any CIS established for
 		 * that ASE by following the Connected Isochronous Stream
 		 * Terminate procedure defined in Volume 3, Part C,
 		 * Section 9.3.15 in when the Unicast Client has determined
 		 * that the ASE is in the Releasing state.
 		 */
-		bt_audio_stream_disconnect(stream);
+		const int err = bt_audio_stream_disconnect(stream);
+
+		if (err != 0) {
+			LOG_ERR("Failed to disconnect stream: %d", err);
+		}
 	}
 }
 

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -97,6 +97,8 @@ static int unicast_client_ep_set_codec(struct bt_audio_ep *ep, uint8_t id,
 				       uint16_t cid, uint16_t vid,
 				       void *data, uint8_t len, struct bt_codec *codec);
 
+static void unicast_client_ep_idle_state(struct bt_audio_ep *ep);
+
 static void unicast_client_ep_iso_recv(struct bt_iso_chan *chan,
 				       const struct bt_iso_recv_info *info,
 				       struct net_buf *buf)
@@ -213,10 +215,18 @@ static void unicast_client_ep_iso_disconnected(struct bt_audio_ep *ep,
 
 	LOG_DBG("stream %p ep %p reason 0x%02x", stream, ep, reason);
 
-	if (stream->ops != NULL && stream->ops->stopped != NULL) {
-		stream->ops->stopped(stream);
+	/* If we were in the idle state when we started the ISO disconnection
+	 * then we need to call unicast_client_ep_idle_state again when
+	 * the ISO has finalized the disconnection
+	 */
+	if (ep->status.state == BT_AUDIO_EP_STATE_IDLE) {
+		unicast_client_ep_idle_state(ep);
 	} else {
-		LOG_WRN("No callback for stopped set");
+		if (stream->ops != NULL && stream->ops->stopped != NULL) {
+			stream->ops->stopped(stream);
+		} else {
+			LOG_WRN("No callback for stopped set");
+		}
 	}
 }
 
@@ -384,14 +394,30 @@ static struct bt_audio_ep *unicast_client_ep_get(struct bt_conn *conn,
 	return unicast_client_ep_new(conn, dir, handle);
 }
 
-static void unicast_client_ep_idle_state(struct bt_audio_ep *ep,
-					 struct net_buf_simple *buf)
+static void unicast_client_ep_idle_state(struct bt_audio_ep *ep)
 {
 	struct bt_audio_stream *stream = ep->stream;
 	const struct bt_audio_stream_ops *ops;
 
 	if (stream == NULL) {
 		return;
+	}
+
+	/* If CIS is connected, disconnect and wait for CIS disconnection */
+	if (ep->iso != NULL) {
+		if (ep->iso->chan.state == BT_ISO_STATE_CONNECTED ||
+		    ep->iso->chan.state == BT_ISO_STATE_CONNECTING) {
+			const int err = bt_audio_stream_disconnect(stream);
+
+			if (err != 0) {
+				LOG_ERR("Failed to disconnect stream: %d", err);
+			} else {
+				return;
+			}
+		} else if (ep->iso->chan.state == BT_ISO_STATE_DISCONNECTING) {
+			/* Wait */
+			return;
+		}
 	}
 
 	/* Notify upper layer */
@@ -771,7 +797,7 @@ static void unicast_client_ep_set_status(struct bt_audio_ep *ep,
 
 	switch (status->state) {
 	case BT_AUDIO_EP_STATE_IDLE:
-		unicast_client_ep_idle_state(ep, buf);
+		unicast_client_ep_idle_state(ep);
 		break;
 	case BT_AUDIO_EP_STATE_CODEC_CONFIGURED:
 		switch (old_state) {

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -730,12 +730,15 @@ static void unicast_client_ep_releasing_state(struct bt_audio_ep *ep,
 
 	LOG_DBG("dir %s", bt_audio_dir_str(ep->dir));
 
-	/* The Unicast Client shall terminate any CIS established for that ASE
-	 * by following the Connected Isochronous Stream Terminate procedure
-	 * defined in Volume 3, Part C, Section 9.3.15 in when the Unicast
-	 * Client has determined that the ASE is in the Releasing state.
-	 */
-	bt_audio_stream_disconnect(stream);
+	if (ep->iso != NULL && ep->iso->chan.state == BT_ISO_STATE_CONNECTED) {
+		/* The Unicast Client shall terminate any CIS established for
+		 * that ASE by following the Connected Isochronous Stream
+		 * Terminate procedure defined in Volume 3, Part C,
+		 * Section 9.3.15 in when the Unicast Client has determined
+		 * that the ASE is in the Releasing state.
+		 */
+		bt_audio_stream_disconnect(stream);
+	}
 }
 
 static void unicast_client_ep_set_status(struct bt_audio_ep *ep,

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -560,7 +560,8 @@ static void unicast_client_ep_qos_state(struct bt_audio_ep *ep,
 	       stream->qos->pd);
 
 	/* Disconnect ISO if connected */
-	if (ep->iso->chan.state == BT_ISO_STATE_CONNECTED) {
+	if (ep->iso->chan.state == BT_ISO_STATE_CONNECTED ||
+	    ep->iso->chan.state == BT_ISO_STATE_CONNECTING) {
 		bt_audio_stream_disconnect(stream);
 	} else {
 		/* We setup the data path here, as this is the earliest where
@@ -730,7 +731,9 @@ static void unicast_client_ep_releasing_state(struct bt_audio_ep *ep,
 
 	LOG_DBG("dir %s", bt_audio_dir_str(ep->dir));
 
-	if (ep->iso != NULL && ep->iso->chan.state == BT_ISO_STATE_CONNECTED) {
+	if (ep->iso != NULL &&
+	    (ep->iso->chan.state == BT_ISO_STATE_CONNECTED ||
+	     ep->iso->chan.state == BT_ISO_STATE_CONNECTING)) {
 		/* The Unicast Client shall terminate any CIS established for
 		 * that ASE by following the Connected Isochronous Stream
 		 * Terminate procedure defined in Volume 3, Part C,


### PR DESCRIPTION
Fixes multiple issues with disconnecting the CIS in the unicast client. 

This PR adds additional state checks and proper handling of disconnection of CIS when two endpoints are involved. 

Tested with https://github.com/zephyrproject-rtos/zephyr/pull/54441 which discovered the issue

fixes https://github.com/zephyrproject-rtos/zephyr/issues/54538
fixes https://github.com/zephyrproject-rtos/zephyr/issues/54539