### PR TITLE
tests: lwm2m_registry: Add newlib filter to testcase.yaml

### DIFF
--- a/tests/net/lib/lwm2m/lwm2m_registry/testcase.yaml
+++ b/tests/net/lib/lwm2m/lwm2m_registry/testcase.yaml
@@ -3,3 +3,4 @@ common:
 tests:
   subsys.net.lib.lwm2m.lwm2m_registry:
     tags: lwm2m net
+    filter: TOOLCHAIN_HAS_NEWLIB == 1


### PR DESCRIPTION
Not all toolchains support newlib so tests that require newlib need to have a filter to we don't try and build those tests on those testcases.  Add the following to testcase.yaml to handle the issue:

        filter: TOOLCHAIN_HAS_NEWLIB == 1

Fixes #54440

Signed-off-by: Kumar Gala <kumar.gala@intel.com>