### PR TITLE
kernel: Remove unused generated symbol offset macros

### DIFF
--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -57,10 +57,6 @@ GEN_OFFSET_SYM(_kernel_t, current_fp);
 GEN_ABSOLUTE_SYM(_STRUCT_KERNEL_SIZE, sizeof(struct z_kernel));
 
 GEN_OFFSET_SYM(_thread_base_t, user_options);
-GEN_OFFSET_SYM(_thread_base_t, thread_state);
-GEN_OFFSET_SYM(_thread_base_t, prio);
-GEN_OFFSET_SYM(_thread_base_t, sched_locked);
-GEN_OFFSET_SYM(_thread_base_t, preempt);
 
 GEN_OFFSET_SYM(_thread_t, base);
 GEN_OFFSET_SYM(_thread_t, callee_saved);
@@ -71,8 +67,6 @@ GEN_OFFSET_SYM(_thread_t, switch_handle);
 #endif
 
 #ifdef CONFIG_THREAD_STACK_INFO
-GEN_OFFSET_SYM(_thread_stack_info_t, start);
-
 GEN_OFFSET_SYM(_thread_t, stack_info);
 #endif
 

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -38,10 +38,6 @@ GEN_OFFSET_SYM(_kernel_t, cpus);
 GEN_OFFSET_SYM(_cpu_t, fp_ctx);
 #endif
 
-#if defined(CONFIG_THREAD_MONITOR)
-GEN_OFFSET_SYM(_kernel_t, threads);
-#endif
-
 #ifdef CONFIG_PM
 GEN_OFFSET_SYM(_kernel_t, idle);
 #endif
@@ -65,7 +61,6 @@ GEN_OFFSET_SYM(_thread_base_t, thread_state);
 GEN_OFFSET_SYM(_thread_base_t, prio);
 GEN_OFFSET_SYM(_thread_base_t, sched_locked);
 GEN_OFFSET_SYM(_thread_base_t, preempt);
-GEN_OFFSET_SYM(_thread_base_t, swap_data);
 
 GEN_OFFSET_SYM(_thread_t, base);
 GEN_OFFSET_SYM(_thread_t, callee_saved);
@@ -77,17 +72,8 @@ GEN_OFFSET_SYM(_thread_t, switch_handle);
 
 #ifdef CONFIG_THREAD_STACK_INFO
 GEN_OFFSET_SYM(_thread_stack_info_t, start);
-GEN_OFFSET_SYM(_thread_stack_info_t, size);
 
 GEN_OFFSET_SYM(_thread_t, stack_info);
-#endif
-
-#if defined(CONFIG_THREAD_MONITOR)
-GEN_OFFSET_SYM(_thread_t, next_thread);
-#endif
-
-#ifdef CONFIG_THREAD_CUSTOM_DATA
-GEN_OFFSET_SYM(_thread_t, custom_data);
 #endif
 
 #ifdef CONFIG_THREAD_LOCAL_STORAGE

--- a/kernel/include/offsets_short.h
+++ b/kernel/include/offsets_short.h
@@ -56,26 +56,9 @@
 
 /* base */
 
-#define _thread_offset_to_thread_state \
-	(___thread_t_base_OFFSET + ___thread_base_t_thread_state_OFFSET)
-
 #define _thread_offset_to_user_options \
 	(___thread_t_base_OFFSET + ___thread_base_t_user_options_OFFSET)
 
-#define _thread_offset_to_prio \
-	(___thread_t_base_OFFSET + ___thread_base_t_prio_OFFSET)
-
-#define _thread_offset_to_sched_locked \
-	(___thread_t_base_OFFSET + ___thread_base_t_sched_locked_OFFSET)
-
-#define _thread_offset_to_preempt \
-	(___thread_t_base_OFFSET + ___thread_base_t_preempt_OFFSET)
-
-#define _thread_offset_to_esf \
-	(___thread_t_arch_OFFSET + ___thread_arch_t_esf_OFFSET)
-
-#define _thread_offset_to_stack_start \
-	(___thread_t_stack_info_OFFSET + ___thread_stack_info_t_start_OFFSET)
 /* end - threads */
 
 #endif /* ZEPHYR_KERNEL_INCLUDE_OFFSETS_SHORT_H_ */


### PR DESCRIPTION
Some architecture specific parts of the Zephyr kernel need to know the offsets of various fields. Some of the offsets that are generated (at build time) via the GEN_OFFSET_SYM() macro are not referenced anywhere. This set of commits picks off some of the low-hanging fruit of unused macros in an effort to help clean up the code base.