### PR TITLE
drivers: adc: support side B channels in LPADC driver

### DIFF
--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69-pinctrl.dtsi
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69-pinctrl.dtsi
@@ -67,7 +67,8 @@
 	pinmux_lpadc0: pinmux_lpadc0 {
 		group0 {
 			pinmux = <ADC0_CH0_PIO0_23>,
-				<ADC0_CH1_PIO0_10>;
+				<ADC0_CH1_PIO0_10>,
+				<ADC0_CH8_PIO0_16>;
 			slew-rate = "standard";
 			nxp,analog-mode;
 		};

--- a/samples/drivers/adc/boards/lpcxpresso55s69_cpu0.overlay
+++ b/samples/drivers/adc/boards/lpcxpresso55s69_cpu0.overlay
@@ -9,7 +9,7 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc0 0>;
+		io-channels = <&adc0 0>, <&adc0 8>;
 	};
 };
 
@@ -21,11 +21,25 @@
 	 * To use this sample:
 	 * - Connect VREFN_TARGET to GND, and VREFP_TARGET to 3v3
 	 *   (Resistors J8 and J9, should be populated by default)
-	 * - Connect LPADC0 CH0 signal to voltage between 0~3.3V (P19 pin 4)
+	 * - Connect LPADC0 CH0A signal to voltage between 0~3.3V (P19 pin 4)
+	 * - Connect LPADC0 CH0B signal to voltage between 0~3.3V (P19 pin 2)
 	 */
 
 	channel@0 {
 		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	/*
+	 * Channel 8 corresponds to ADC CH0B.
+	 * Channel 9 corresponds to CH1B, etc
+	 */
+	channel@8 {
+		reg = <8>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,vref-mv = <3300>;

--- a/samples/drivers/adc/boards/mimxrt685_evk_cm33.overlay
+++ b/samples/drivers/adc/boards/mimxrt685_evk_cm33.overlay
@@ -9,7 +9,7 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&lpadc0 0>;
+		io-channels = <&lpadc0 0>, <&lpadc0 8>;
 	};
 };
 
@@ -20,11 +20,21 @@
 	/*
 	 * To use this sample:
 	 * - Connect VREF_L to GND, and VREF_H to 1.8V (connect JP9 and JP10).
-	 * - Connect LPADC0 CH0 signal to voltage between 0~1.8V (J30 pin 1)
+	 * - Connect LPADC0 CH0A signal to voltage between 0~1.8V (J30 pin 1)
+	 * - Connect LPADC0 CH0B signal to voltage between 0~1.8V (J30 pin 2)
 	 */
 
 	channel@0 {
 		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <1800>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@8 {
+		reg = <8>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,vref-mv = <1800>;


### PR DESCRIPTION
Add support for side B channels in MCUX LPADC driver. Given
that no instances of the IP block have more than 8 a side channels,
use channel numbers over 8 to indicate side B channel is desired.

Fixes #51076

This PR was tested on the RT685 and LPCXpresso55s69 EVKs, and is an alternative to #51134 based on @pdgendt's suggested change, since that PR appears to be stale