### PR TITLE
docs: kconfig: restore appearance of kconfig search

### DIFF
--- a/doc/_extensions/zephyr/kconfig/static/kconfig.css
+++ b/doc/_extensions/zephyr/kconfig/static/kconfig.css
@@ -15,13 +15,13 @@
 }
 
 #__kconfig-search .input-container input {
+    border-radius: 5px 0px 0px 5px;
     font-size: 18px;
     width: 90%;
     height: 100%;
     padding: 0.75rem;
     border: none;
     box-shadow: none !important;
-    background-color: white;
 }
 
 #__kconfig-search .input-container input:focus,
@@ -31,17 +31,19 @@
 
 #__kconfig-search .input-container button {
     font-size: 22px;
+    border-radius: 0px 5px 5px 0px;
     float: right;
     width: 10%;
     height: 100%;
     border: none;
-    background-color: white;
+    background-color: lightgrey;
 }
 
 #__kconfig-search select {
     border-radius: 5px;
     border: 1px solid rgba(149, 157, 165, 0.2);
     box-shadow: unset;
+    color: black;
 }
 
 #__kconfig-search .search-tools {


### PR DESCRIPTION
This PR restores the appearance of kconfig search, with rounded corners and black background. This should resolve visibility issues encountered on some browsers when running in dark mode

Fixes #53568

The output Kconfig search from this PR can be viewed here: https://builds.zephyrproject.io/zephyr/pr/54451/docs/kconfig.html

Some sample screenshots (collected on Firefox 109.0.1, running on Windows 10):


OS Light mode:

![image](https://user-images.githubusercontent.com/34665051/216753829-711c4370-2284-4a9a-8a51-039b34022b21.png)

OS Dark mode:

![image](https://user-images.githubusercontent.com/34665051/216753803-aa237348-471f-40c5-a660-4aa32350a8e8.png)

I've also verified this change on Chrome 109.0.5414.120, on Windows 10.

@gmarull, I'd appreciate your feedback here- it appears that the `background-color` property of the `input` element of `__kconfig-search` was the root cause of text not being visible, but I'm not sure why the `border-radius` set on the `div` wasn't propagating to the child `input` and `button` elements. I restored rounded edges using custom `border-radius` properties on the `input` and `button` elements, but I'm not sure how much I like this approach.