### PR TITLE
subsys: usb_transfer: fix race condition on completion of transfer

### DIFF
--- a/subsys/usb/device/usb_transfer.c
+++ b/subsys/usb/device/usb_transfer.c
@@ -333,6 +333,10 @@ int usb_transfer_sync(uint8_t ep, uint8_t *data, size_t dlen, unsigned int flags
 
 		trans = usb_ep_get_transfer(ep);
 		if (!trans || trans->status != -EBUSY) {
+			ret = k_sem_take(&pdata.sem, K_MSEC(USB_TRANSFER_SYNC_TIMEOUT));
+			if (ret == 0) {
+				break;
+			}
 			LOG_WRN("Sync transfer cancelled, ep 0x%02x", ep);
 			return -ECANCELED;
 		}


### PR DESCRIPTION
It is possible for the transfer to finish after the k_sem_take call has timed out, but before it's checked for still being busy. In this case an error is wrongly returned.

I have observed this happen in a system that was heavily slowed down by hundreds of IMMEDIATE uart log messages. I have confirmed that the break statemend added in this commit actually executes occasionally.