### PR TITLE
drivers: w1: Make 1-Wire Skip ROM cmd. optional

### DIFF
--- a/drivers/w1/Kconfig
+++ b/drivers/w1/Kconfig
@@ -52,4 +52,17 @@ config W1_NET
 	help
 	  Enable 1-wire network layer
 
+config W1_NET_FORCE_MULTIDROP_ADDRESSING
+	bool "Force 1-Wire multidrop addressing"
+	depends on W1_NET
+	help
+	  This option will ignore the number of 1-Wire
+	  slave devices defined in the DTS. Specifically,
+	  this option avoids the SKIP ROM command,
+	  which is otherwise used in case of a single
+	  1-Wire slave on the bus. In most cases, enabling
+	  this option is not needed, yet it is essential
+	  if multiple 1-Wire devices unspecified in the
+	  DTS are interfaced.
+
 endif # W1

--- a/drivers/w1/w1_net.c
+++ b/drivers/w1/w1_net.c
@@ -346,7 +346,7 @@ int w1_skip_rom(const struct device *dev, const struct w1_slave_config *config)
 
 static int reset_select(const struct device *dev, const struct w1_slave_config *config)
 {
-	if (w1_get_slave_count(dev) > 1) {
+	if (IS_ENABLED(CONFIG_W1_NET_FORCE_MULTIDROP_ADDRESSING) || w1_get_slave_count(dev) > 1) {
 		return match_rom(dev, config);
 	}
 


### PR DESCRIPTION
For systems with a true dynamic 1-Wire nature, the 1-Wire devices cannot be defined in the DeviceTree (the number of slaves in the system is not known during the build time).

In other words, there are no pre-defined 1-Wire devices on the bus in DeviceTree, and thus the slave_count variable is always zero.

That means the skip_rom functionality will always be called even if there are multiple devices connected to the bus.

This commit allows the user to override this original behavior and avoid the skip_rom call.

Also, this work preserves full backward compatibility.

Signed-off-by: Pavel Hübner <pavel.hubner@hardwario.com>