### PR TITLE
Bluetooth: Mesh: Remove meaningless condition

### DIFF
--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -277,10 +277,6 @@ static bool schedule_send(struct bt_mesh_ext_adv *adv)
 	uint64_t timestamp;
 	int64_t delta;
 
-	if (!adv) {
-		return false;
-	}
-
 	timestamp = adv->timestamp;
 
 	if (atomic_test_and_clear_bit(adv->flags, ADV_FLAG_PROXY)) {


### PR DESCRIPTION
Since `schedule_send` always have no-null params.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>