### PR TITLE
doc: release-notes 3.3: Add MCUmgr release notes

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -90,6 +90,10 @@ Changes in this release
   * :kconfig:option:`CONFIG_NETWORKING`
   * :kconfig:option:`CONFIG_NET_UDP`
 
+* MCUmgr fs_mgmt hash/checksum function, type and variable names have been
+  changed to be prefixed with ``fs_mgmt_`` to retain alignment with other
+  zephyr and MCUmgr APIs.
+
 * Python's argparse argument parser usage in Zephyr scripts has been updated
   to disable abbreviations, any future python scripts or python code updates
   must also disable allowing abbreviations by using ``allow_abbrev=False``
@@ -775,7 +779,7 @@ Libraries / Subsystems
     be restored by enabling
     :kconfig:option:`CONFIG_MCUMGR_SMP_LEGACY_RC_BEHAVIOUR`.
 
-  * MCUMGR now has log outputting on most errors from the included fs, img,
+  * MCUmgr now has log outputting on most errors from the included fs, img,
     os, shell, stat and zephyr_basic group commands. The level of logging can be
     controlled by adjusting: :kconfig:option:`CONFIG_MCUMGR_GRP_FS_LOG_LEVEL`,
     :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_LOG_LEVEL`,
@@ -783,6 +787,25 @@ Libraries / Subsystems
     :kconfig:option:`CONFIG_MCUMGR_GRP_SHELL_LOG_LEVEL`,
     :kconfig:option:`CONFIG_MCUMGR_GRP_STAT_LOG_LEVEL` and
     :kconfig:option:`CONFIG_MCUMGR_GRP_ZBASIC_LOG_LEVEL`.
+
+  * MCUmgr img_mgmt has a new field which is sent in the final packet (if
+    :kconfig:option:`CONFIG_IMG_ENABLE_IMAGE_CHECK` is enabled) named ``match``
+    which is a boolean and is true if the uploaded data matches the supplied
+    hash, or false otherwise.
+
+  * MCUmgr img_mgmt will now skip receiving data if the provided hash already
+    matches the hash of the data present (if
+    :kconfig:option:`CONFIG_IMG_ENABLE_IMAGE_CHECK` is enabled) and finish the
+    upload operation request instantly.
+
+  * MCUmgr img_mgmt structs are now packed, which fixes a fault issue on
+    processors that do not support unaligned memory access.
+
+  * If MCUmgr is used with the shell transport and ``printk()`` functionality
+    is used, there can be an issue whereby the ``printk()`` calls output during
+    a MCUmgr frame receive, this has been fixed by default in zephyr by routing
+    ``printk()`` calls to the logging system, For user applications,
+    :kconfig:option:`CONFIG_LOG_PRINTK` should be enabled to include this fix.
 
 * LwM2M
 

--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -332,7 +332,8 @@ CBOR data of successful response:
 .. code-block:: none
 
     {
-        (str,opt)"off"  : (uint)
+        (str,opt)"off"    : (uint)
+        (str,opt)"match"  : (bool)
     }
 
 In case of error the CBOR data takes the form:
@@ -349,16 +350,22 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | "off"                 | offset of last successfully written byte of update|
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
-    |                       | only appears if non-zero (error condition).       |
-    +-----------------------+---------------------------------------------------+
-    | "rsn"                 | Optional string that clarifies reason for an      |
-    |                       | error; specifically useful for error code ``1``,  |
-    |                       | unknown error                                     |
-    +-----------------------+---------------------------------------------------+
+    +-----------------------+-----------------------------------------------------+
+    | "off"                 | offset of last successfully written byte of update. |
+    +-----------------------+-----------------------------------------------------+
+    | "match"               | indicates if the uploaded data successfully matches |
+    |                       | the provided SHA256 hash or not, only sent in the   |
+    |                       | final packet if                                     |
+    |                       | :kconfig:option:`CONFIG_IMG_ENABLE_IMAGE_CHECK` is  |
+    |                       | enabled.                                            |
+    +-----------------------+-----------------------------------------------------+
+    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes` only        |
+    |                       | appears if non-zero (error condition).              |
+    +-----------------------+-----------------------------------------------------+
+    | "rsn"                 | Optional string that clarifies reason for an error; |
+    |                       | specifically useful for error code ``1``, unknown   |
+    |                       | error.                                              |
+    +-----------------------+-----------------------------------------------------+
 
 The "off" field is only included in responses to successfully processed requests;
 if "rc" is negative the "off' may not appear.


### PR DESCRIPTION
    doc: release-notes 3.3: Add MCUmgr release notes
    
    Adds changes to the relase notes for MCUmgr changes introduced in
    version 3.3.

and

    doc: mgmt: img_mgmt: Add note on optional match field response
    
    Adds a note on the new match field which will indicate if the
    uploaded data's SHA256 hash matches the provided hash.
