### PR TITLE
samples: subsys: task_wdt: skip for s32z270dc2

### DIFF
--- a/samples/subsys/task_wdt/sample.yaml
+++ b/samples/subsys/task_wdt/sample.yaml
@@ -18,3 +18,4 @@ tests:
     depends_on: watchdog
     integration_platforms:
       - nucleo_g474re
+    platform_exclude: s32z270dc2_rtu0_r52 s32z270dc2_rtu1_r52


### PR DESCRIPTION
This sample is being built and run by Twister for s32z270dc2_r52 boards because the watchdog driver is selected, but it shouldn't be run due to board's lack of support for system reset currently (test will fail with timeout). So skip it for these boards.

Fixes #54580 