### PR TITLE
Add ADC support for stm32h735g_disco

### DIFF
--- a/boards/arm/stm32h735g_disco/doc/index.rst
+++ b/boards/arm/stm32h735g_disco/doc/index.rst
@@ -63,6 +63,8 @@ The current Zephyr stm32h735g_disco board configuration supports the following h
 +-----------+------------+-------------------------------------+
 | FMC       | on-chip    | memc (SDRAM)                        |
 +-----------+------------+-------------------------------------+
+| ADC       | on-chip    | ADC Controller                      |
++-----------+------------+-------------------------------------+
 
 
 Other hardware features are not yet supported on Zephyr porting.

--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
@@ -106,6 +106,12 @@
 	status = "okay";
 };
 
+&adc1 {
+	pinctrl-0 = <&adc1_inp0_pa0_c>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &mac {
 	pinctrl-0 = <&eth_mdc_pc1
 		     &eth_rxd0_pc4

--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.yaml
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.yaml
@@ -13,3 +13,4 @@ supported:
   - gpio
   - netif:eth
   - memc
+  - adc

--- a/samples/drivers/adc/boards/stm32h735g_disco.overlay
+++ b/samples/drivers/adc/boards/stm32h735g_disco.overlay
@@ -1,0 +1,24 @@
+/* Copyright (c) 2021 STMicroelectronics
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+ / {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc1 0>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <16>;
+	};
+};

--- a/samples/drivers/adc/sample.yaml
+++ b/samples/drivers/adc/sample.yaml
@@ -4,8 +4,8 @@ tests:
   sample.drivers.adc:
     tags: ADC
     depends_on: adc
-    platform_allow: nucleo_l073rz disco_l475_iot1 cc3220sf_launchxl
-        cc3235sf_launchxl stm32l496g_disco nrf51dk_nrf51422 nrf52840dk_nrf52840
+    platform_allow: nucleo_l073rz disco_l475_iot1 cc3220sf_launchxl cc3235sf_launchxl
+        stm32l496g_disco stm32h735g_disco nrf51dk_nrf51422 nrf52840dk_nrf52840
         mec172xevb_assy6906 gd32f350r_eval gd32f450i_eval gd32vf103v_eval gd32f403z_eval
         esp32 esp32s2_saola esp32c3_devkitm gd32l233r_eval
     integration_platforms:

--- a/samples/drivers/adc/src/main.c
+++ b/samples/drivers/adc/src/main.c
@@ -32,7 +32,7 @@ static const struct adc_dt_spec adc_channels[] = {
 void main(void)
 {
 	int err;
-	int16_t buf;
+	uint16_t buf;
 	struct adc_sequence sequence = {
 		.buffer = &buf,
 		/* buffer size in bytes, not number of samples */
@@ -69,7 +69,7 @@ void main(void)
 				printk("Could not read (%d)\n", err);
 				continue;
 			} else {
-				printk("%"PRId16, buf);
+				printk("%"PRIu16, buf);
 			}
 
 			/* conversion to mV may not be supported, skip if not */

--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -239,6 +239,14 @@
 /* Some F3 series SOCs do not have channel 0 connected to an external GPIO. */
 #define ADC_1ST_CHANNEL_ID	1
 
+#elif defined(CONFIG_BOARD_STM32H735G_DISCO)
+#define ADC_DEVICE_NODE         DT_INST(0, st_stm32_adc)
+#define ADC_RESOLUTION		16
+#define ADC_GAIN		ADC_GAIN_1
+#define ADC_REFERENCE		ADC_REF_INTERNAL
+#define ADC_ACQUISITION_TIME	ADC_ACQ_TIME_DEFAULT
+#define ADC_1ST_CHANNEL_ID	0
+
 #elif defined(CONFIG_BOARD_NUCLEO_L476RG) || \
 	defined(CONFIG_BOARD_BLACKPILL_F411CE) || \
 	defined(CONFIG_BOARD_STM32F401_MINI) || \


### PR DESCRIPTION
Add ADC support for stm32h735g_disco in devicetree and to enable ADC sample to be built for this board. Please let me know if I've missed anything!

This PR also modifies the ADC sample to correctly display readings from 16-bit resolution ADC channels.