### PR TITLE
boards: arm: thingy53: Disable USB remote wakeup by default + fix setting default USB related log lvl

### DIFF
--- a/boards/arm/thingy53_nrf5340/Kconfig.defconfig
+++ b/boards/arm/thingy53_nrf5340/Kconfig.defconfig
@@ -114,12 +114,14 @@ config USB_DEVICE_REMOTE_WAKEUP
 if LOG
 
 # Logger cannot use itself to log
-config USB_CDC_ACM_LOG_LEVEL
-	default 0
+choice USB_CDC_ACM_LOG_LEVEL_CHOICE
+	default USB_CDC_ACM_LOG_LEVEL_OFF
+endchoice
 
 # Set USB log level to error only
-config USB_DEVICE_LOG_LEVEL
-	default 1
+choice USB_DEVICE_LOG_LEVEL_CHOICE
+	default USB_DEVICE_LOG_LEVEL_ERR
+endchoice
 
 # Wait 4000ms at startup for logging
 config LOG_PROCESS_THREAD_STARTUP_DELAY_MS

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp_defconfig
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp_defconfig
@@ -24,3 +24,9 @@ CONFIG_UART_CONSOLE=y
 CONFIG_SERIAL=y
 
 CONFIG_PINCTRL=y
+
+# Board Kconfig.defconfig enables USB CDC ACM and should disable USB remote
+# wakeup by default. It needs to be disabled here, because the USB nrfx
+# driver always overwrites option from Kconfig mentioned above with the
+# imply from CONFIG_USB_NRFX.
+CONFIG_USB_DEVICE_REMOTE_WAKEUP=n

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp_ns_defconfig
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp_ns_defconfig
@@ -27,3 +27,9 @@ CONFIG_UART_CONSOLE=y
 CONFIG_SERIAL=y
 
 CONFIG_PINCTRL=y
+
+# Board Kconfig.defconfig enables USB CDC ACM and should disable USB remote
+# wakeup by default. It needs to be disabled here, because the USB nrfx
+# driver always overwrites option from Kconfig mentioned above with the
+# imply from CONFIG_USB_NRFX.
+CONFIG_USB_DEVICE_REMOTE_WAKEUP=n


### PR DESCRIPTION
For Thingy:53 board, USB remote wakeup should be disabled by default. 
Current solution disabled it from Kconfig.defconfig, but was always overwritten by imply in CONFIG_USB_NRFX. 
This change disables it in board *_defconfig files.
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/54702

Previous method of setting default USB related log levels for Thingy53
led to generating inconsistent configuration, ex.
CONFIG_USB_CDC_ACM_LOG_LEVEL=0 and CONFIG_USB_CDC_ACM_LOG_LEVEL_INF=y
at the same time. This commit changes to proper implementation
which is overlaying choice's default.
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/54703

Signed-off-by: Mateusz Kapala <mateusz.kapala@nordicsemi.no>