### PR TITLE
Tests: Bluetooth: Tester: improve stability by Flow Control and UARTE

### DIFF
--- a/tests/bluetooth/tester/nrf52840dk_nrf52840.overlay
+++ b/tests/bluetooth/tester/nrf52840dk_nrf52840.overlay
@@ -7,7 +7,8 @@
 };
 
 &uart0 {
-	compatible = "nordic,nrf-uart";
+	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";
+	hw-flow-control;
 };


### PR DESCRIPTION
Some tests may be unstable because of missing data from BTP frames. Enabling Flow Control fixes the issue, but seems to work reliably only along with UARTE.

Signed-off-by: Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54532