### PR TITLE
net: config: Unify the init behaviour when timeout is enabled and not 

### DIFF
--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -578,6 +578,13 @@ static uint32_t dhcpv4_manage_timers(struct net_if *iface, int64_t now)
 		return timeleft;
 	}
 
+	if (!net_if_is_up(iface)) {
+		/* An interface is down, the registered event handler will
+		 * restart DHCP procedure when the interface is back up.
+		 */
+		return UINT32_MAX;
+	}
+
 	switch (iface->config.dhcpv4.state) {
 	case NET_DHCPV4_DISABLED:
 		break;

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -194,6 +194,10 @@ int net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr)
 		}
 	}
 
+	if (!net_if_is_up(iface)) {
+		return -ENETDOWN;
+	}
+
 	ret = mld_send_generic(iface, addr, NET_IPV6_MLDv2_MODE_IS_EXCLUDE);
 	if (ret < 0) {
 		return ret;

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -376,20 +376,17 @@ int net_config_init_by_iface(struct net_if *iface, const char *app_info,
 #if defined(CONFIG_NET_NATIVE)
 		net_mgmt_del_event_callback(&mgmt_iface_cb);
 #endif
-
-		/* Network interface did not come up. We will not try
-		 * to setup things in that case.
-		 */
-		if (timeout > 0 && count < 0) {
-			NET_ERR("Timeout while waiting network %s",
-				"interface");
-			return -ENETDOWN;
-		}
 	}
 
 	setup_ipv4(iface);
 	setup_dhcpv4(iface);
 	setup_ipv6(iface, flags);
+
+	/* Network interface did not come up. */
+	if (timeout > 0 && count < 0) {
+		NET_ERR("Timeout while waiting network %s", "interface");
+		return -ENETDOWN;
+	}
 
 	/* Loop here until we are ready to continue. As we might need
 	 * to wait multiple events, sleep smaller amounts of data.


### PR DESCRIPTION
Currently, if timeout is not configured for the network initialization in
the config module, the initialization function will configure IPv4/IPv6/
DHCPv4 regardless of the interface status. This is not the case when the
timeout is set, and the interface was not brought up during the timeout
period. This lead to ambiguity in terms of interface initialization.

This commits unifies the behaviour between these two cases. The
aforementioned initializations will always take place, regardless of the
interface status. The IPv4/IPv6 and DHCPv4 routines should be prepared
to deal with interfaces that are not brought up. The only difference
now, between timeout and no timeout scenario, is that the former will
report an error in case the timeout occurs wile waiting for the expected
events.

Fixes #54457