### PR TITLE
samples: ipc: Fix incorrect license

### DIFF
--- a/samples/subsys/ipc/ipc_service/icmsg/remote/CMakeLists.txt
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2022 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 
 cmake_minimum_required(VERSION 3.20.0)


### PR DESCRIPTION
Replace Nordic-5-Clause with Apache-2.0.

Signed-off-by: Emil Obalski <Emil.Obalski@nordicsemi.no>