### PR TITLE
samples: drivers: counter: alarm: STM32: do not save value between resets

### DIFF
--- a/samples/drivers/counter/alarm/Kconfig
+++ b/samples/drivers/counter/alarm/Kconfig
@@ -11,4 +11,8 @@ config COUNTER_SAM0_TC32
 	bool
 	default y if BOARD_ATSAMD20_XPRO
 
+config COUNTER_RTC_STM32_SAVE_VALUE_BETWEEN_RESETS
+	bool
+	default n if COUNTER_RTC_STM32
+
 source "Kconfig.zephyr"


### PR DESCRIPTION
As a verification, the samples/drivers/counter/alarm expects a regex on the console in the form "Now: [2|3]"

The problem is that the time value of the RTC is not reset to 0 on MCU reset, resulting in values generally far higher than expected and thus in a failed test, even though the alarm mechanism is properly working.

This PR adds a STM32 Kconfig to the sample to reinitialize the time value after a reset.

Fixes #54493