### PR TITLE
scripts: twister: west twister error codes match twister direct call

### DIFF
--- a/scripts/west_commands/twister_cmd.py
+++ b/scripts/west_commands/twister_cmd.py
@@ -57,7 +57,8 @@ class Twister(WestCommand):
         )
 
         options = self._parse_arguments(args=remainder, options=args)
-        main(options)
+        ret = main(options)
+        sys.exit(ret)
 
     def _parse_arguments(self, args, options):
         """Helper function for testing purposes"""


### PR DESCRIPTION
This commit fixes #54492. Return code 1 is returned when twister tests fail and twister is called directly. Return code is 0 in similar scenario but when twister is invoked using west. This PR unifies return codes. 

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>