### PR TITLE
doc: release-notes: add EEPROM release notes for v3.3.0

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -380,6 +380,8 @@ Drivers and Sensors
 
 * EEPROM
 
+  * Added fake EEPROM driver for testing purposes.
+
 * Entropy
 
 * ESPI


### PR DESCRIPTION
Add EEPROM related release notes for Zephyr v3.3.0.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>