### PR TITLE
Bluetooth: Audio: Remove deprecated requirement from audio API

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1332,10 +1332,6 @@ struct bt_audio_lc3_preset {
  *
  *  Audio Streams represents a stream configuration of a Remote Endpoint and
  *  a Local Capability.
- *
- *  @note Audio streams are unidirectional although its QoS can be configured
- *  to be bidirectional if stream are linked, in which case the QoS must be
- *  symmetric in both directions.
  */
 struct bt_audio_stream {
 	/** Stream direction */


### PR DESCRIPTION
Removed statement about the QoS having to be symmetrical for two streams using the same CIS, as that requirement was recently removed.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

The requirement was removed in https://github.com/zephyrproject-rtos/zephyr/pull/53119