### PR TITLE
west.yml: tf-m: Fix SAU configuration on U5

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -231,7 +231,7 @@ manifest:
       groups:
         - debug
     - name: trusted-firmware-m
-      revision: 5503c15bd4026e3ea4264a62d70395af34e16742
+      revision: 7426337b4293cdf20592c2861df7faf51d0ad6c9
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Fix SAU configuration on U5 to allow non secure application to use end of flash which is not used by secure.

Fixes #53231

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>