### PR TITLE
doc: release-notes/3.3: adds bits on PCIE, UART, IPM, and I3C

### DIFF
--- a/doc/hardware/peripherals/i3c.rst
+++ b/doc/hardware/peripherals/i3c.rst
@@ -358,5 +358,6 @@ API Reference
 .. doxygengroup:: i3c_interface
 .. doxygengroup:: i3c_ccc
 .. doxygengroup:: i3c_addresses
+.. doxygengroup:: i3c_target_device
 
 .. _I3C Specification: https://www.mipi.org/specifications/i3c-sensor-specification

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -885,6 +885,37 @@ Drivers and Sensors
   * Atmel SAM: UART/USART: Added support to configure driver at runtime
   * STM32: DMA now supported on STM32U5 series.
 
+  * uart_altera_jtag: added support for Nios-V UART.
+
+  * uart_esp32: added support asynchronous operation.
+
+  * uart_gecko: added support for pinctrl.
+
+  * uart_mchp_xec: now supports UART on MEC15xx SoC.
+
+  * uart_mcux_flexcomm: added support for runtime configuration.
+
+  * uart_mcux_lpuart: added support for RS-485.
+
+  * uart_numicro: uses pinctrl to configure UART pins.
+
+  * uart_pl011: added support for pinctrl.
+
+  * uart_rpi_pico: added support for runtime configuration.
+
+  * uart_xmc4xxx: added support for interrupt so it can now be interrupt driven.
+    Also added support for FIFO.
+
+  * New UART drivers are added:
+
+    * Cadence IP6528 UART.
+
+    * NXP S32 LINFlexD UART.
+
+    * OpenTitan UART.
+
+    * QuickLogic USBserialport_S3B.
+
 * SPI
 
   * Added dma support for GD32 driver.

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -767,6 +767,19 @@ Drivers and Sensors
 
 * PCIE
 
+  * Support for accessing I/O BARs, which was previously removed, is back.
+
+  * Added new API :c:func:`pcie_scan` to scan for devices.
+
+    * This interates through the the buses and devices which are expected to
+      exist. The old method was to try all possible combination of buses
+      and devices to determine if there is a device there.
+      :c:func:`pci_init` and :c:func:`pcie_bdf_lookup` have been updated to
+      use this new API.
+
+    * :c:func:`pcie_scan` also introduces a callback mechanism for when
+      a new device has been discovered.
+
 * PECI
 
 * Pin control

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -749,6 +749,14 @@ Drivers and Sensors
 
 * I3C
 
+  * Added a new target device API :c:func:`i3c_target_tx_write` to
+    explicit write to TX FIFO.
+
+  * GETMRL and GETMWL are both optional in :c:func:`i3c_device_basic_info_get` as
+    MRL and MWL are optional according to I3C specification.
+
+  * Added a new driver to support Cadence I3C controller.
+
 * IEEE 802.15.4
 
 * Interrupt Controller

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -765,6 +765,9 @@ Drivers and Sensors
 
 * IPM
 
+  * ipm_stm32_ipcc: fix an issue where interrupt mask is not cleaned correctly,
+    resulting in infinite TXF interrupts.
+
 * KSCAN
 
 * LED


### PR DESCRIPTION
This adds a few bits in the release notes for 3.3 on PCIE, UART, IPM and I3C.