### PR TITLE
bugfix: twister: Fix interaction between quarantine integration mode

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -802,7 +802,7 @@ class TestPlan:
         for filtered_instance in filtered_instances:
             # If integration mode is on all skips on integration_platforms are treated as errors.
             if self.options.integration and filtered_instance.platform.name in filtered_instance.testsuite.integration_platforms \
-                and "Quarantine" not in filtered_instance.reason:
+                and "quarantine" not in filtered_instance.reason.lower():
                 # Do not treat this as error if filter type is command line
                 filters = {t['type'] for t in filtered_instance.filters}
                 if Filters.CMD_LINE in filters or Filters.SKIP in filters:


### PR DESCRIPTION
Tests under quarantine are not treated as errors in the integration mode. However --quarantine-verify argument allowing to execute just test under quarantine and skipping others was not considered in relation to integration mode. Those skips are wrongly threated as errors. This commit fix this relation and makes thoses skips not turned to errors.

fixes: #54516

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>