### PR TITLE
tests: gpio_hogs: Fix the output low test

### DIFF
--- a/tests/drivers/gpio/gpio_hogs/src/main.c
+++ b/tests/drivers/gpio/gpio_hogs/src/main.c
@@ -98,7 +98,7 @@ ZTEST(gpio_hogs, test_gpio_hog_output_low_config)
 		expected |= GPIO_OUTPUT_INIT_HIGH;
 	}
 
-	assert_gpio_hog_config(&output_high_gpio, expected);
+	assert_gpio_hog_config(&output_low_gpio, expected);
 }
 
 ZTEST(gpio_hogs, test_gpio_hog_input_config)


### PR DESCRIPTION
The output low test was checking the wrong GPIO spec handle.

Fixes #54573

Signed-off-by: Keith Short <keithshort@google.com>