### PR TITLE
devicetree: Fix DT_FOREACH_PROP_ELEM_SEP example

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2594,7 +2594,7 @@
  * @code{.c}
  *     struct gpio_dt_spec specs[] = {
  *             DT_FOREACH_PROP_ELEM_SEP(DT_NODELABEL(n), my_gpios,
- *                                      GPIO_DT_SPEC_BY_IDX, (,))
+ *                                      GPIO_DT_SPEC_GET_BY_IDX, (,))
  *     };
  * @endcode
  *
@@ -2603,8 +2603,8 @@
  * @code{.c}
  *     struct gpio_dt_spec specs[] = {
  *     struct gpio_dt_spec specs[] = {
- *             GPIO_DT_SPEC_BY_IDX(DT_NODELABEL(n), my_gpios, 0),
- *             GPIO_DT_SPEC_BY_IDX(DT_NODELABEL(n), my_gpios, 1)
+ *             GPIO_DT_SPEC_GET_BY_IDX(DT_NODELABEL(n), my_gpios, 0),
+ *             GPIO_DT_SPEC_GET_BY_IDX(DT_NODELABEL(n), my_gpios, 1)
  *     };
  * @endcode
  *


### PR DESCRIPTION
Change the DT_FOREACH_PROP_ELEM_SEP example documented to use the correct macro GPIO_DT_SPEC_GET_BY_IDX() instead of GPIO_DT_SPEC_BY_IDX().

Signed-off-by: Keith Short <keithshort@google.com>