### PR TITLE
picolibc: picolibc still not fully supported with many toolchains variants

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -19,7 +19,7 @@ config SUPPORT_MINIMAL_LIBC
 config PICOLIBC_SUPPORTED
 	bool
 	depends on !NATIVE_APPLICATION
-	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "arcmwdt"
+	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr"
 	depends on !(CPP && "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr")
 	# picolibc text is outside .pinned.text on this board. #54148
 	default y


### PR DESCRIPTION
picolibc: picolibc support still not complete with many toolchains

Clang support still work in progress in zephyr. So for now enable only on gcc based toolchains.

We should enable this back for more toolchains once we have full clang support and are able to verify.

Fixes #54528

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
