### PR TITLE
compiler/clang: ignore main-return-type warning for clang

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -31,6 +31,7 @@ check_set_compiler_property(PROPERTY warning_base
                             -Wformat-security
                             -Wno-format-zero-length
                             -Wno-main
+                            -Wno-main-return-type
                             -Wno-unused-but-set-variable
                             -Wno-typedef-redefinition
                             -Wno-deprecated-non-prototype


### PR DESCRIPTION
Unlike gcc, clang splits out the flag controlling warnings about the return type of `main' from other warnings related to that function. Add the extra -Wno-main-return-type flag to mask these warnings when building Zephyr without -ffreestanding, as when using picolibc.

Signed-off-by: Keith Packard <keithp@keithp.com>

(Partially) fixes #54336