### PR TITLE
tests: Align zephyr,psa-crypto-rng node names with those used by SoCs

### DIFF
--- a/tests/crypto/rand32/entropy_psa_crypto.overlay
+++ b/tests/crypto/rand32/entropy_psa_crypto.overlay
@@ -6,10 +6,10 @@
 
 / {
 	chosen {
-		zephyr,entropy = &rng_psa;
+		zephyr,entropy = &psa_rng;
 	};
 
-	rng_psa: entropy_psa_crypto {
+	psa_rng: psa-rng {
 		compatible = "zephyr,psa-crypto-rng";
 		status = "okay";
 	};

--- a/tests/drivers/entropy/api/entropy_psa_crypto.overlay
+++ b/tests/drivers/entropy/api/entropy_psa_crypto.overlay
@@ -6,10 +6,10 @@
 
 / {
 	chosen {
-		zephyr,entropy = &rng_psa;
+		zephyr,entropy = &psa_rng;
 	};
 
-	rng_psa: entropy_psa_crypto {
+	psa_rng: psa-rng {
 		compatible = "zephyr,psa-crypto-rng";
 		status = "okay";
 	};


### PR DESCRIPTION
This is a follow-up to commit 9951971aeecc4f1ba434f4e5ee038b0cc3bb5b4a.

Align names of "zephyr,psa-crypto-rng" compatible nodes used in tests (crypto/rand32 and drivers/entropy/api) with those introduced by the above commit into SoC definitions (nRF5340/nRF9160). This way the test overlays will overwrite the already existing nodes instead of adding second instances of them, what leads to build failures at the linking stage as the related driver supports only single instance (and creates it for the first node found).

Fixes #54540.