### PR TITLE
dts: bindings: riscv: Add rv32emc variant

### DIFF
--- a/dts/bindings/riscv/riscv,cpus.yaml
+++ b/dts/bindings/riscv/riscv,cpus.yaml
@@ -18,6 +18,7 @@ properties:
     required: true
     type: string
     enum:
+      - rv32emc
       - rv32imac
       - rv32imafc
       - rv32imafcb


### PR DESCRIPTION
To the 'riscv,isa' property enum.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>