### PR TITLE
tests: bsim_bt: audio: Do not reuse sim_ids

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/broadcast_audio.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/broadcast_audio.sh
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SIMULATION_ID="broadcaster"
 VERBOSITY_LEVEL=2
 PROCESS_IDS=""; EXIT_CODE=0
 
@@ -26,6 +25,8 @@ cd ${BSIM_OUT_PATH}/bin
 
 printf "\n\n======== Broadcaster test =========\n\n"
 
+SIMULATION_ID="broadcaster"
+
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source -rs=23
 
@@ -42,6 +43,8 @@ for PROCESS_ID in $PROCESS_IDS; do
 done
 
 printf "\n\n======== Broadcaster sink disconnect test =========\n\n"
+
+SIMULATION_ID="broadcaster_sink_disconnect"
 
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source -rs=23

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/csip.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/csip.sh
@@ -6,7 +6,7 @@
 
 # Basic CSIP test. A set coordinator connects to multiple set members
 # lock thems, unlocks them and disconnects.
-SIMULATION_ID="csip"
+
 VERBOSITY_LEVEL=2
 PROCESS_IDS=""; EXIT_CODE=0
 
@@ -28,6 +28,9 @@ cd ${BSIM_OUT_PATH}/bin
 
 # NORMAL TEST
 printf "\n\n======== Running normal test ========\n\n"
+
+SIMULATION_ID="csip"
+
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator \
   -RealEncryption=1 -rs=1
@@ -55,6 +58,9 @@ done
 PROCESS_IDS="";
 
 # TEST WITH FORCE RELEASE
+
+SIMULATION_ID="csip_forced_release"
+
 printf "\n\n======== Running test with forced release of lock ========\n\n"
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator \
@@ -81,6 +87,9 @@ for PROCESS_ID in $PROCESS_IDS; do
 done
 
 # TEST WITH SIRK ENC
+
+SIMULATION_ID="csip_sirk_encrypted"
+
 printf "\n\n======== Running test with SIRK encrypted ========\n\n"
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_coordinator \


### PR DESCRIPTION
Even if the tests are not run in parallel
do not reuse sim_ids as that overwrites the result data preventing re-running in check mode, and inspecting the test results.

Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>