### PR TITLE
drivers: counter: Do not keep RTC value between resets on STM32

### DIFF
--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -40,8 +40,8 @@ endchoice #COUNTER_RTC_STM32_CLOCK_SRC
 
 config COUNTER_RTC_STM32_SAVE_VALUE_BETWEEN_RESETS
 	bool "Save rtc time value between resets"
-	default y
+	default n
 	help
-	  Do not reset the rtc time and date after each reset.
+	  Keep the counter value after each reset.
 
 endif # COUNTER_RTC_STM32


### PR DESCRIPTION
This commit changes the ability to keep the RTC value between resets, and turns it off by default.
Though this feature makes sense for an RTC counting the time and date, here it is used as a counter. As such the registers used for counting should be reset after each MCU reset.

Fixes #54493