### PR TITLE
twister: restore logic to determine which gcov we should use

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -237,6 +237,10 @@ class Gcovr(CoverageTool):
 
 
 def run_coverage(testplan, options):
+    for plat in options.coverage_platform:
+        _plat = testplan.get_platform(plat)
+        if _plat and (_plat.type in {"native", "unit"}):
+            use_system_gcov = True
     if not options.gcov_tool:
         zephyr_sdk_gcov_tool = os.path.join(
             os.environ.get("ZEPHYR_SDK_INSTALL_DIR", default=""),
@@ -253,10 +257,10 @@ def run_coverage(testplan, options):
             except OSError:
                 shutil.copy(llvm_cov, gcov_lnk)
             options.gcov_tool = gcov_lnk
+        elif use_system_gcov:
+            options.gcov_tool = "gcov"
         elif os.path.exists(zephyr_sdk_gcov_tool):
             options.gcov_tool = zephyr_sdk_gcov_tool
-        else:
-            options.gcov_tool = "gcov"
 
     logger.info("Generating coverage files...")
     coverage_tool = CoverageTool.factory(options.coverage_tool)


### PR DESCRIPTION
We do not want to use gcov from the SDK for native posix and unit tests,
instead we want the system gcov. Restore logic that determines that.

Fixes #54226

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
