### PR TITLE
doc: release-notes: Add 3.3.0 release notes for networking

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -524,10 +524,158 @@ Drivers and Sensors
 Networking
 **********
 
-IPv4 packet fragmentation support has been added, this allows large packets to
-be split up before sending or reassembled during receive for packets that are
-larger than the network device MTU. This is disabled by default but can be
-enabled with :kconfig:option:`CONFIG_NET_IPV4_FRAGMENT`.
+* CoAP:
+
+  * Implemented insertion of a CoAP option at arbitrary position.
+
+* Ethernet:
+
+  * Fixed AF_PACKET/SOCK_RAW/IPPROTO_RAW sockets on top of Ethernet L2.
+  * Added support for setting Ethernet MAC address with net shell.
+  * Added check for return values of the driver start/stop routines when
+    bringing Ethernet interface up.
+  * Added ``unknown_protocol`` statistic for packets with unrecognized protocol
+    field, instead of using ``error`` for this purpose.
+
+* HTTP:
+
+  * Reworked HTTP headers: moved methods to a separate header, added status
+    response codes header and grouped HTTP headers in a subdirectory.
+  * Used :c:func:`zsock_poll` for HTTP timeout instead of a delayed work.
+
+* ICMPv4:
+
+  * Added support to autogenerate Echo Request payload.
+
+* ICMPv6:
+
+  * Added support to autogenerate Echo Request payload.
+  * Fixed stats counting for ND packets.
+
+* IEEE802154:
+
+  * Improved short address support.
+  * Improved IEEE802154 context thread safety.
+  * Decoupled IEEE802154 parameters from :c:struct:`net_pkt` into
+    :c:struct:`net_pkt_cb_ieee802154`.
+  * Multiple other minor fixes/improvements.
+
+* IPv4:
+
+  * IPv4 packet fragmentation support has been added, this allows large packets
+    to be split up before sending or reassembled during receive for packets that
+    are larger than the network device MTU. This is disabled by default but can
+    be enabled with :kconfig:option:`CONFIG_NET_IPV4_FRAGMENT`.
+  * Added support for setting/reading DSCP/ECN fields.
+  * Fixed packet leak in IPv4 address auto-configuration procedure.
+  * Added support for configuring IPv4 addresses with ``net ipv4`` shell
+    command.
+  * Zephyr now adds IGMP all systems 224.0.0.1 address to all IPv4 network
+    interfaces by default.
+
+* IPv6:
+
+  * Made it possible to add route to router's link local address.
+  * Added support for setting/reading DSCP/ECN fields.
+  * Improved test coverage for IPv6 fragmentation.
+  * Added support for configuring IPv6 addresses with ``net ipv6`` shell
+    command.
+  * Added support for configuring IPv6 routes with ``net route`` shell
+    command.
+
+* LwM2M:
+
+  * Renamed ``LWM2M_RD_CLIENT_EVENT_REG_UPDATE_FAILURE`` to
+    :c:macro:`LWM2M_RD_CLIENT_EVENT_REG_TIMEOUT`. This event is now used in case
+    of registration timeout.
+  * Added new LwM2M APIs for historical data storage for LwM2M resource.
+  * Updated LwM2M APIs to use ``const`` pointers when possible.
+  * Added shell command to lock/unlock LwM2M registry.
+  * Added shell command to enable historical data cache for a resource.
+  * Switched to use ``zsock_*`` functions internally.
+  * Added uCIFI LPWAN (ID 3412) object implementation.
+  * Added BinaryAppDataContainer (ID 19) object implementation.
+  * Deprecated :kconfig:option:`CONFIG_LWM2M_RD_CLIENT_SUPPORT`, as it's now
+    considered as an integral part of the LwM2M library.
+  * Added support for SenML Object Link data type.
+  * Fixed a bug causing incorrect ordering of the observation paths.
+  * Deprecated string based LwM2M APIs. LwM2M APIs now use
+    :c:struct:`lwm2m_obj_path` to represent object/resource paths.
+  * Refactored ``lwm2m_client`` sample by splitting specific functionalities
+    into separate modules.
+  * Multiple other minor fixes within the LwM2M library.
+
+* Misc:
+
+  * Updated various networking test suites to use the new ztest API.
+  * Added redirect support for ``big_http_download`` sample and updated the
+    server URL for TLS variant.
+  * Fixed memory leak in ``net udp`` shell command.
+  * Fixed cloning of LL address for :c:struct:`net_pkt`.
+  * Added support for QoS and payload size setting in ``net ping`` shell
+    command.
+  * Added support for aborting ``net ping`` shell command.
+  * Introduced carrier and dormant management on network interfaces. Separated
+    interface administrative state from operational state.
+  * Improved DHCPv4 behavior with multiple DHCPv4 servers in the network.
+  * Fixed net_mgmt event size calculation.
+  * Added :kconfig:option:`CONFIG_NET_LOOPBACK_MTU` option to configure loopback
+    interface MTU.
+  * Reimplemented the IP/UDP/TCP checksum calculation to speed up the
+    processing.
+  * Removed :kconfig:option:`CONFIG_NET_CONFIG_SETTINGS` use from test cases to
+    improve test execution on real platforms.
+  * Added MQTT-SN library and sample.
+  * Fixed variable buffer length configuration
+    (:kconfig:option:`CONFIG_NET_BUF_VARIABLE_DATA_SIZE`).
+  * Fixed IGMPv2 membership report destination address.
+  * Added mutex protection for the connection list handling.
+  * Separated user data pointer from FIFO reserved space in
+    :c:struct:`net_context`.
+  * Added input validation for ``net pkt`` shell command.
+
+* OpenThread:
+
+  * Implemented PSA support for ECDSA API.
+  * Fixed :c:func:`otPlatRadioSetMacKey` when asserts are disabled.
+  * Depracated :c:func:`openthread_set_state_changed_cb` in favour of more
+    generic :c:func:`openthread_state_changed_cb_register`.
+  * Implemented diagnostic GPIO commands.
+
+* SNTP:
+
+  * Switched to use ``zsock_*`` functions internally.
+  * Fixed the library operation with IPv4 disabled.
+
+* Sockets:
+
+  * Fixed a possible memory leak on failed TLS socket creation.
+
+* TCP:
+
+  * Extended the default TCP out-of-order receive queue timeout to 2 seconds.
+  * Reimplemented TCP ref counting, to prevent situation, where TCP connection
+    context could be released prematurely.
+
+* Websockets:
+
+  * Reimplemented websocket receive routine to fix several issues.
+  * Implemented proper websocket close procedure.
+  * Fixed a bug where websocket would overwrite the mutex used by underlying TCP
+    socket.
+
+* Wi-Fi:
+
+  * Added support for power save configuration.
+  * Added support for regulatory domain configuration.
+  * Added support for power save timeout configuration.
+
+* zperf
+
+  * Added option to set QoS for zperf.
+  * Fixed out of order/lost packets statistics.
+  * Defined a public API for the library to allow throughput measurement without shell enabled.
+  * Added an option for asynchronous upload.
 
 USB
 ***


### PR DESCRIPTION
Add Zephyr 3.3.0 release notes for the networking area.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>