### PR TITLE
LE Audio: Map EALREADY error of ase_stream_qos()

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1593,7 +1593,7 @@ static void ase_qos(struct bt_ascs_ase *ase, const struct bt_ascs_qos *qos)
 			} else if (cqos->pd == 0) {
 				reason = BT_ASCS_REASON_PD;
 			}
-		} else if (err == -EADDRINUSE) {
+		} else if (err == -EALREADY) {
 			reason = BT_ASCS_REASON_CIS;
 			/* FIXME: Ugly workaround to send Response_Code
 			 *        0x09 = Invalid Configuration Parameter Value


### PR DESCRIPTION
In ASCS/SR/SPE/BI-15-C, ASCS/SR/SPE/BI-16-C test cases the PTS tries to configure two ASEs with the same CIS id. The expected response should be code 0x09 = Invalid Configuration Parameter Value and reason 0x0a = Invalid_ASE_CIS_Mapping. But the EALREADY error of returned from `ase_stream_qos()` in `ase_qos()` was not parsed, so the PTS receives an ASE Control Point notification with default code BT_ASCS_RSP_UNSPECIFIED (0x0e) and reason BT_ASCS_REASON_NONE (0x00).

This workaround fixes ASCS/SR/SPE/BI-15-C and ASCS/SR/SPE/BI-16-C PTS test cases.

Closes #54666 