### PR TITLE
boards: arm: stm32g431 nucleo has LPTIM1 peripheral clock config

### DIFF
--- a/boards/arm/nucleo_g431rb/Kconfig.defconfig
+++ b/boards/arm/nucleo_g431rb/Kconfig.defconfig
@@ -12,4 +12,8 @@ config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI
 
+# LPTIM clocked by LSE, force tick freq to 4096 for tick accuracy
+config SYS_CLOCK_TICKS_PER_SEC
+	default 4096 if STM32_LPTIM_TIMER
+
 endif # BOARD_NUCLEO_G431RB

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
@@ -56,6 +56,10 @@
 	status = "okay";
 };
 
+&clk_lse {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(24)>;
 	status = "okay";
@@ -129,6 +133,12 @@
 		pinctrl-0 = <&tim2_ch1_pa5>;
 		pinctrl-names = "default";
 	};
+};
+
+&lptim1 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>,
+		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
+	status = "okay";
 };
 
 &rtc {


### PR DESCRIPTION
Gives the LPTIM1 peripheral clock configuration for the instance of the stm32g431 nucleo board.
The LSE is enabled on the target board.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54558

Signed-off-by: Francois Ramu <francois.ramu@st.com>