### PR TITLE
os: bitarray.c: Address -Wextra warnings

### DIFF
--- a/lib/os/bitarray.c
+++ b/lib/os/bitarray.c
@@ -67,7 +67,7 @@ static bool match_region(sys_bitarray_t *bitarray, size_t offset,
 			 struct bundle_data *bd,
 			 size_t *mismatch)
 {
-	int idx;
+	size_t idx;
 	uint32_t bundle;
 	uint32_t mismatch_bundle;
 	size_t mismatch_bundle_idx;
@@ -173,7 +173,7 @@ static void set_region(sys_bitarray_t *bitarray, size_t offset,
 		       size_t num_bits, bool to_set,
 		       struct bundle_data *bd)
 {
-	int idx;
+	size_t idx;
 	struct bundle_data bdata;
 
 	if (bd == NULL) {
@@ -414,19 +414,20 @@ int sys_bitarray_alloc(sys_bitarray_t *bitarray, size_t num_bits,
 	 * On RISC-V 64-bit, it complains about undefined reference to `ffs`.
 	 * So don't use this on RISCV64.
 	 */
-	for (ret = 0; ret < bitarray->num_bundles; ret++) {
-		if (~bitarray->bundles[ret] == 0U) {
+	for (size_t idx = 0; idx < bitarray->num_bundles; idx++) {
+		if (~bitarray->bundles[idx] == 0U) {
 			/* bundle is all 1s => all allocated, skip */
 			bit_idx += bundle_bitness(bitarray);
 			continue;
 		}
 
-		if (bitarray->bundles[ret] != 0U) {
+		if (bitarray->bundles[idx] != 0U) {
 			/* Find the first free bit in bundle if not all free */
-			off_start = find_lsb_set(~bitarray->bundles[ret]) - 1;
+			off_start = find_lsb_set(~bitarray->bundles[idx]) - 1;
 			bit_idx += off_start;
 		}
 
+		ret = idx < INT_MAX ? (int)idx : INT_MAX;
 		break;
 	}
 


### PR DESCRIPTION
Changed incrementing `for` loop counters to `size_t` from `int` to eliminate warning, "warning: comparison of integer expressions of different signedness: 'uint32_t' {aka 'unsigned int'} and 'int' [-Wsign-compare]"

Signed-off-by: Zachary J. Fields <zachary_fields@yahoo.com>