### PR TITLE
tests: zbus: modify test identifiers to match component

### DIFF
--- a/tests/subsys/zbus/dyn_channel/testcase.yaml
+++ b/tests/subsys/zbus/dyn_channel/testcase.yaml
@@ -1,5 +1,4 @@
 tests:
-  dyn_channel.static_and_dynamic_channels:
-    build_only: false
+  message_bus.zbus.dyn_channel.static_and_dynamic_channels:
     platform_exclude: fvp_base_revc_2xaemv8a_smp_ns
     tags: zbus

--- a/tests/subsys/zbus/integration/testcase.yaml
+++ b/tests/subsys/zbus/integration/testcase.yaml
@@ -1,5 +1,4 @@
 tests:
-  integration.module_interaction_no_error:
-    build_only: false
+  message_bus.zbus.module_interaction_no_error:
     platform_exclude: qemu_cortex_a9 hifive_unleashed fvp_base_revc_2xaemv8a_smp_ns
     tags: zbus

--- a/tests/subsys/zbus/runtime_observers_registration/testcase.yaml
+++ b/tests/subsys/zbus/runtime_observers_registration/testcase.yaml
@@ -1,4 +1,3 @@
 tests:
-  runtime_obs_reg.add_and_remove_observers:
-    build_only: false
+  message_bus.zbus.runtime_obs_reg.add_and_remove_observers:
     tags: zbus

--- a/tests/subsys/zbus/unittests/testcase.yaml
+++ b/tests/subsys/zbus/unittests/testcase.yaml
@@ -1,5 +1,4 @@
 tests:
-  unittests.hard_and_readonly_channels:
-    build_only: false
+  message_bus.zbus.hard_and_readonly_channels:
     platform_exclude: fvp_base_revc_2xaemv8a_smp_ns
     tags: zbus

--- a/tests/subsys/zbus/user_data/testcase.yaml
+++ b/tests/subsys/zbus/user_data/testcase.yaml
@@ -1,5 +1,4 @@
 tests:
-  user_data.channel_user_data:
-    build_only: false
+  message_bus.zbus.user_data.channel_user_data:
     platform_exclude: fvp_base_revc_2xaemv8a_smp_ns
     tags: zbus


### PR DESCRIPTION
Use message_bus as component in all zbus tests for better organisation
and to be able to select them in test plans.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
