### PR TITLE
cmake: provide a useful error msg when native compiler is missing

### DIFF
--- a/cmake/compiler/clang/generic.cmake
+++ b/cmake/compiler/clang/generic.cmake
@@ -4,7 +4,7 @@ if(DEFINED TOOLCHAIN_HOME)
   set(find_program_clang_args PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 endif()
 
-find_program(CMAKE_C_COMPILER clang ${find_program_clang_args})
+find_program(CMAKE_C_COMPILER clang ${find_program_clang_args} REQUIRED)
 find_program(CMAKE_CXX_COMPILER clang++ ${find_program_clang_args})
 find_program(CMAKE_LLVM_COV llvm-cov ${find_program_clang_args})
 set(CMAKE_GCOV "${CMAKE_LLVM_COV} gcov")

--- a/cmake/compiler/host-gcc/generic.cmake
+++ b/cmake/compiler/host-gcc/generic.cmake
@@ -2,5 +2,5 @@
 
 # Configures CMake for using GCC
 
-find_program(CMAKE_C_COMPILER gcc)
+find_program(CMAKE_C_COMPILER gcc REQUIRED)
 find_program(CMAKE_GCOV gcov)


### PR DESCRIPTION
This avoids a cryptic DTC failure when trying to compile native_posix with a missing gcc or clang.

REQUIRED is available since CMake 3.18

Example with clang, cryptic error without this commit:

```
ZEPHYR_TOOLCHAIN_VARIANT=llvm west build            \
        -p -b native_posix samples/hello_world/
-- Found toolchain: host (clang/ld)    <= this is wrong
-- Found Dtc: /usr/bin/dtc (found suitable version "1.6.1", minimum ...
-- Found BOARD.dts: zephyr/boards/posix/native_posix/native_posix.dts
CMake Error at /zephyr/cmake/modules/dts.cmake:191 (message):
  command failed with return code: No such file or directory
Call Stack (most recent call first):
  zephyr/cmake/modules/zephyr_default.cmake:113 (include)
  zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:66 (include)
  zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:92 (include_boil...
  CMakeLists.txt:5 (find_package)
```

Well hidden behind the scenes, dts.cmake fails above because it invokes `CMAKE_C_COMPILER-NOTFOUND`

With this commit:

```
ZEPHYR_TOOLCHAIN_VARIANT=llvm west build            \
        -p -b native_posix samples/hello_world/
-- Found toolchain: host (clang/ld)    <= this is still wrong
CMake Error at zephyr/cmake/compiler/clang/generic.cmake:7 (find_program):
  Could not find CMAKE_C_COMPILER using the following names: clang
```

Signed-off-by: Marc Herbert <marc.herbert@intel.com>