### PR TITLE
Samples: Bluetooth: ignore -EALREADY when opening ipc instance

### DIFF
--- a/samples/bluetooth/hci_rpmsg/src/main.c
+++ b/samples/bluetooth/hci_rpmsg/src/main.c
@@ -377,7 +377,7 @@ void main(void)
 
 	/* Initialize IPC service instance and register endpoint. */
 	err = ipc_service_open_instance(hci_ipc_instance);
-	if (err) {
+	if (err < 0 && err != -EALREADY) {
 		LOG_ERR("IPC service instance initialization failed: %d\n", err);
 	}
 


### PR DESCRIPTION
This instance might be shared by other users that may have opened it earlier in the boot chain.

Fixes #54671 

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>