### PR TITLE
boards: posix: native_posix_64: Add sim: native

### DIFF
--- a/boards/posix/native_posix/native_posix_64.yaml
+++ b/boards/posix/native_posix/native_posix_64.yaml
@@ -1,6 +1,7 @@
 identifier: native_posix_64
 name: Native 64-bit POSIX port
 type: native
+simulation: native
 arch: posix
 ram: 65536
 flash: 65536


### PR DESCRIPTION
boards: posix: native_posix_64: Add sim: native

If one does not specify `simulation: native` in a `testcase.yaml` file,
then when trying to run tests with `native_posix_64` as the platform,
the `TestInstance.setup_handler` method in
`scripts/pylib/twister/twisterlib/testinstance.py` will not assign a handler and
one's tests will be marked as ran, but the test output will all be of the
form "... No status" since the test binary is built but not ran.

Fixes #54605

Signed-off-by: Pete Dietl <petedietl@gmail.com>
