### PR TITLE
board: enable FPU for nsim_sem_mpu and update mdb.args

### DIFF
--- a/boards/arc/nsim/support/mdb_em7d_v22.args
+++ b/boards/arc/nsim/support/mdb_em7d_v22.args
@@ -14,6 +14,11 @@
 	-Xdsp_complex
 	-Xdsp_divsqrt=radix2
 	-Xdsp_accshift=limited
+	-Xfpus_div
+	-Xfpu_mac
+	-Xfpuda
+	-Xfpus_mpy_slow
+	-Xfpus_div_slow
 	-Xtimer0
 	-Xtimer0_level=1
 	-Xtimer1

--- a/boards/arc/nsim/support/mdb_sem.args
+++ b/boards/arc/nsim/support/mdb_sem.args
@@ -14,6 +14,11 @@
 	-Xdsp_complex
 	-Xdsp_divsqrt=radix2
 	-Xdsp_accshift=limited
+	-Xfpus_div
+	-Xfpu_mac
+	-Xfpuda
+	-Xfpus_mpy_slow
+	-Xfpus_div_slow
 	-Xtimer0
 	-Xtimer0_level=1
 	-Xtimer1

--- a/boards/arc/nsim/support/nsim_em7d_v22.props
+++ b/boards/arc/nsim/support/nsim_em7d_v22.props
@@ -20,6 +20,10 @@
 	nsim_isa_dsp_divsqrt_option=1
 	nsim_isa_dsp_accshift_option=1
 	nsim_isa_fpuda_option=1
+	nsim_isa_fpus_div_option=1
+	nsim_isa_fpu_mac_option=1
+	nsim_isa_fpu_fast_mpy_option=0
+	nsim_isa_fpu_fast_div_option=0
 	nsim_isa_enable_timer_0=1
 	nsim_isa_timer_0_int_level=1
 	nsim_isa_enable_timer_1=1

--- a/boards/arc/nsim/support/nsim_sem.props
+++ b/boards/arc/nsim/support/nsim_sem.props
@@ -20,6 +20,10 @@
 	nsim_isa_dsp_divsqrt_option=1
 	nsim_isa_dsp_accshift_option=1
 	nsim_isa_fpuda_option=1
+	nsim_isa_fpus_div_option=1
+	nsim_isa_fpu_mac_option=1
+	nsim_isa_fpu_fast_mpy_option=0
+	nsim_isa_fpu_fast_div_option=0
 	nsim_isa_enable_timer_0=1
 	nsim_isa_timer_0_int_level=1
 	nsim_isa_enable_timer_1=1

--- a/boards/arc/nsim/support/nsim_sem_mpu_stack_guard.args
+++ b/boards/arc/nsim/support/nsim_sem_mpu_stack_guard.args
@@ -14,6 +14,11 @@
 	-Xdsp_complex
 	-Xdsp_divsqrt=radix2
 	-Xdsp_accshift=limited
+	-Xfpus_div
+	-Xfpu_mac
+	-Xfpuda
+	-Xfpus_mpy_slow
+	-Xfpus_div_slow
 	-Xtimer0
 	-Xtimer0_level=1
 	-Xtimer1

--- a/boards/arc/nsim/support/nsim_sem_mpu_stack_guard.props
+++ b/boards/arc/nsim/support/nsim_sem_mpu_stack_guard.props
@@ -19,6 +19,11 @@
 	nsim_isa_dsp_complex_option=1
 	nsim_isa_dsp_divsqrt_option=1
 	nsim_isa_dsp_accshift_option=1
+	nsim_isa_fpuda_option=1
+	nsim_isa_fpus_div_option=1
+	nsim_isa_fpu_mac_option=1
+	nsim_isa_fpu_fast_mpy_option=0
+	nsim_isa_fpu_fast_div_option=0
 	nsim_isa_enable_timer_0=1
 	nsim_isa_timer_0_int_level=1
 	nsim_isa_enable_timer_1=1


### PR DESCRIPTION
Enable FPU for nsim_sem_mpu_stack_guard to fix zdsp.basicmath.fpu failure due to lack of FPU option (#54469). Add FPU feature to its related mdb.args, also for nsim_sem and nsim_em7d_v22 boards.
