### PR TITLE
doc: add note for missing tf-m/ns target support

### DIFF
--- a/boards/arm/circuitdojo_feather_nrf9160/doc/index.rst
+++ b/boards/arm/circuitdojo_feather_nrf9160/doc/index.rst
@@ -94,9 +94,13 @@ Building an application
 =======================
 
 In most cases you'll want to use the ``ns`` target with any of the Zephyr
-or Nordic based examples. Some of the examples do not use secure mode,
-so they do not required the ``ns`` suffix. A great example of this is the
-`hello_world` below:
+or Nordic based examples.
+
+.. note::
+   Trusted Firmware-M (TF-M) and building the ``ns`` target is not supported for this board.
+
+Some of the examples do not use secure mode, so they do not require the
+``ns`` suffix. A great example of this is the `hello_world` below.
 
 Flashing
 ========

--- a/boards/arm/nrf5340_audio_dk_nrf5340/doc/index.rst
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/doc/index.rst
@@ -53,6 +53,8 @@ The nrf5340_audio_dk_nrf5340_cpuapp build target provides support for the applic
 core on the nRF5340 SoC. The nrf5340_audio_dk_nrf5340_cpunet build target provides
 support for the network core on the nRF5340 SoC.
 
+.. note::
+   Trusted Firmware-M (TF-M) and building the ``ns`` target is not supported for this board.
 
 The `Nordic Semiconductor Infocenter`_ contains the processor's information and
 the datasheet.

--- a/boards/arm/nrf9160_innblue21/doc/index.rst
+++ b/boards/arm/nrf9160_innblue21/doc/index.rst
@@ -104,6 +104,9 @@ have to set the IDAU (SPU) configuration to allow Non-Secure access to all
 CPU resources utilized by the Non-Secure application firmware. SPU
 configuration shall take place before jumping to the Non-Secure application.
 
+.. note::
+   Trusted Firmware-M (TF-M) and building the ``ns`` target is not supported for this board.
+
 Building a Secure only application
 ==================================
 

--- a/boards/arm/nrf9160_innblue22/doc/index.rst
+++ b/boards/arm/nrf9160_innblue22/doc/index.rst
@@ -104,6 +104,9 @@ have to set the IDAU (SPU) configuration to allow Non-Secure access to all
 CPU resources utilized by the Non-Secure application firmware. SPU
 configuration shall take place before jumping to the Non-Secure application.
 
+.. note::
+   Trusted Firmware-M (TF-M) and building the ``ns`` target is not supported for this board.
+
 Building a Secure only application
 ==================================
 

--- a/boards/arm/sparkfun_thing_plus_nrf9160/doc/index.rst
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/doc/index.rst
@@ -89,9 +89,13 @@ Building an application
 =======================
 
 In most cases you'll want to use the ``ns`` target with any of the Zephyr
-or Nordic based examples. Some of the examples do not use secure mode,
-so they do not required the ``ns`` suffix. A great example of this is the
-`hello_world` below:
+or Nordic based examples.
+
+.. note::
+   Trusted Firmware-M (TF-M) and building the ``ns`` target is not supported for this board.
+
+Some of the examples do not use secure mode, so they do not required the ``ns`` suffix.
+A great example of this is the `hello_world` below.
 
 Flashing
 ========

--- a/boards/arm/thingy53_nrf5340/doc/index.rst
+++ b/boards/arm/thingy53_nrf5340/doc/index.rst
@@ -22,6 +22,8 @@ The nrf5340dk_nrf5340_cpuapp build target provides support for the application
 core on the nRF5340 SoC. The nrf5340dk_nrf5340_cpunet build target provides
 support for the network core on the nRF5340 SoC.
 
+.. note::
+   Trusted Firmware-M (TF-M) and building the ``ns`` target is not supported for this board.
 
 The `Nordic Semiconductor Infocenter`_ contains the processor's information and
 the datasheet.


### PR DESCRIPTION
All nRF91 and nRF5340 boards (except the DKs)
should document a note stating that TF-M/_ns
is currently not supported.

Signed-off-by: Mia Koen <mia.koen@nordicsemi.no>