### PR TITLE
dts: arm: stm32h723 fix SRAM2 address

### DIFF
--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -158,8 +158,8 @@
 	};
 
 	/* D2 domain, AHB SRAM */
-	sram2: memory@30040000 {
-		reg = <0x30040000 DT_SIZE_K(16)>;
+	sram2: memory@30004000 {
+		reg = <0x30004000 DT_SIZE_K(16)>;
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "SRAM2";
 	};


### PR DESCRIPTION
 * there is a subtle difference to the stm32h74x
 * c.f. rm0468 (stm32h723/733 stm32h725/735 and stm32h730)
 * verified on stm32h735

Fixes #54597