### PR TITLE
stm32 board revision in the config to address nucleo without HSE

### DIFF
--- a/boards/arm/nucleo_f401re/doc/index.rst
+++ b/boards/arm/nucleo_f401re/doc/index.rst
@@ -127,7 +127,8 @@ System Clock
 
 Nucleo F401RE System Clock could be driven by internal or external oscillator,
 as well as main PLL clock. By default System clock is driven by PLL clock at 84MHz,
-driven by 8MHz high speed external clock.
+- driven by 8MHz high speed external clock (HSE) for board revision C02 and above
+- driven by 16MHz high speed internal clock (HSI) for board revision C01
 
 Serial Port
 ===========

--- a/boards/arm/nucleo_f401re/nucleo_f401re_C01.conf
+++ b/boards/arm/nucleo_f401re/nucleo_f401re_C01.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2023 STMicroelecronics
+# SPDX-License-Identifier: Apache-2.0

--- a/boards/arm/nucleo_f401re/nucleo_f401re_C01.overlay
+++ b/boards/arm/nucleo_f401re/nucleo_f401re_C01.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023, STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&clk_hse {
+	/* HSE not used on this board revision */
+	status = "disabled";
+};
+
+&clk_hsi {
+	/* use HSI */
+	status = "okay";
+};
+
+&pll {
+	/delete-property/ div-m;
+	div-m = <16>;
+	/delete-property/ clocks;
+	clocks = <&clk_hsi>;
+};

--- a/boards/arm/nucleo_f401re/nucleo_f401re_C01.yaml
+++ b/boards/arm/nucleo_f401re/nucleo_f401re_C01.yaml
@@ -1,0 +1,21 @@
+identifier: nucleo_f401re@C01
+name: ST Nucleo F401RE rev C-01
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+supported:
+  - arduino_gpio
+  - arduino_i2c
+  - arduino_spi
+  - pwm
+  - counter
+  - gpio
+  - i2c
+  - spi
+  - adc
+  - watchdog
+ram: 96
+flash: 512

--- a/boards/arm/nucleo_f401re/nucleo_f401re_C02.conf
+++ b/boards/arm/nucleo_f401re/nucleo_f401re_C02.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2023 STMicroelecronics
+# SPDX-License-Identifier: Apache-2.0

--- a/boards/arm/nucleo_f401re/revision.cmake
+++ b/boards/arm/nucleo_f401re/revision.cmake
@@ -1,0 +1,4 @@
+board_check_revision(
+        FORMAT ALPHANUM
+        DEFAULT_REVISION C02
+)

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -849,7 +849,9 @@ endfunction()
 # When `EXACT` is not specified, this function will set the Zephyr build system
 # variable `ACTIVE_BOARD_REVISION` with the selected revision.
 #
-# FORMAT <LETTER | NUMBER | MAJOR.MINOR.PATCH>: Specify the revision format.
+# FORMAT <ALPHANUM | LETTER | NUMBER | MAJOR.MINOR.PATCH>: Specify the revision format.
+#         ALPHANUM:           Revision format is a single letter from A - Z
+#                             followed by one or two integer number  ('C02')
 #         LETTER:             Revision format is a single letter from A - Z.
 #         NUMBER:             Revision format is a single integer number.
 #         MAJOR.MINOR.PATCH:  Revision format is three numbers, separated by `.`,
@@ -915,7 +917,9 @@ function(board_check_revision)
     endif()
   endif()
 
-  if(BOARD_REV_FORMAT STREQUAL LETTER)
+  if(BOARD_REV_FORMAT STREQUAL ALPHANUM)
+    set(revision_regex "([A-Z][0-9]+)")
+  elseif(BOARD_REV_FORMAT STREQUAL LETTER)
     set(revision_regex "([A-Z])")
   elseif(BOARD_REV_FORMAT STREQUAL NUMBER)
     set(revision_regex "([0-9]+)")
@@ -935,7 +939,7 @@ function(board_check_revision)
     endif()
   else()
     message(FATAL_ERROR "Invalid format specified for \
-    `board_check_revision(FORMAT <LETTER | NUMBER | MAJOR.MINOR.PATCH>)`")
+    `board_check_revision(FORMAT <ALPHANUM | LETTER | NUMBER | MAJOR.MINOR.PATCH>)`")
   endif()
 
   if(NOT (BOARD_REVISION MATCHES "^${revision_regex}$"))

--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -641,6 +641,30 @@ example will result in the following error message:
 
    Board revision `0.7.0` not found.  Please specify a valid board revision.
 
+Alphanum revision matching
+==========================
+
+Let's say instead that you need to support revisions ``A0``, ``C01``, and ``C02`` of
+the ``plank`` board. Create the following additional files in the board
+directory:
+
+.. code-block:: none
+
+   boards/<ARCH>/plank
+   ├── plank_A0.conf
+   ├── plank_A0.overlay
+   ├── plank_C01.conf
+   ├── plank_C01.overlay
+   ├── plank_C02.conf
+   ├── plank_C02.overlay
+   └── revision.cmake
+
+And add the following to :file:`revision.cmake`:
+
+.. code-block:: cmake
+
+   board_check_revision(FORMAT ALPHANUM)
+
 Letter revision matching
 ========================
 
@@ -694,7 +718,7 @@ board_check_revision() details
 
 .. code-block:: cmake
 
-   board_check_revision(FORMAT <LETTER | NUMBER | MAJOR.MINOR.PATCH>
+   board_check_revision(FORMAT <ALPHANUM | LETTER | NUMBER | ALPHANUM | MAJOR.MINOR.PATCH>
                         [EXACT]
                         [DEFAULT_REVISION <revision>]
                         [HIGHEST_REVISION <revision>]
@@ -703,6 +727,7 @@ board_check_revision() details
 
 This function supports the following arguments:
 
+* ``FORMAT ALPHANUM``: matches single letter followed by integer revisions
 * ``FORMAT LETTER``: matches single letter revisions from ``A`` to ``Z`` only
 * ``FORMAT NUMBER``: matches integer revisions
 * ``FORMAT MAJOR.MINOR.PATCH``: matches exactly three digits. The command line


### PR DESCRIPTION
Some old stm32 nucleo boards, like the MB1136  have no HSE : 8MHz crystal is not mounted and SolderBridge is not ON to get HSE from STlink with Bypass.

nucleo-64 boards MB1136 from rev C 02 have the 8MHz from the stlink (no X3 oscillator) mounted --> hse-bypass;
nucleo-64 boards MB1136 of rev C 01 have NO 8MHz X3 oscillator mounted and NO bypass from STlink : HSE cannot be used
This is a board revision C01 is created : with fixed clock source HSI but no HSE
Build for that board with
`$ west build -b nucleo_f401re@C01 samples/hello_world/`
To accept that format of board revision, modifying the cmake/modules/extensions.cmake is required to add a ALPHANUMerical format like "C01"

Not giving a BOARD_REV_HIGHEST_REVISION for this model.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/50440

Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)