### PR TITLE
tests: drivers: can: test timing on the nucleo_f746zg at lower freq

### DIFF
--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -74,16 +74,16 @@
 
 &pll {
 	div-m = <4>;
-	mul-n = <216>;
+	mul-n = <192>;
 	div-p = <2>;
-	div-q = <9>;
+	div-q = <8>;
 	clocks = <&clk_hse>;
 	status = "okay";
 };
 
 &rcc {
 	clocks = <&pll>;
-	clock-frequency = <DT_FREQ_M(216)>;
+	clock-frequency = <DT_FREQ_M(192)>;
 	ahb-prescaler = <1>;
 	apb1-prescaler = <4>;
 	apb2-prescaler = <2>;


### PR DESCRIPTION
Do not test when the CAN bus clock freq of the board (here nucleo_f746zg with CAN bus freq at 54MHz) is not giving a calutaion for a particular bitrate  (here 800000bps).
--> change the sysclock of the nucleo_f746zg to 192MHz which is the highest value to get a USB at 48MHz and a CAN bus freq (PCLK1) at 48MHz (compatible with testcase for various bitrate )

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54533

Signed-off-by: Francois Ramu <francois.ramu@st.com>