### PR TITLE
boards: arm: nrf9160dk_nrf52840: flow control pins crossed

### DIFF
--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840-pinctrl.dtsi
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840-pinctrl.dtsi
@@ -7,11 +7,11 @@
 	uart0_default: uart0_default {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 0, 5)>,
-				<NRF_PSEL(UART_RTS, 1, 8)>;
+				<NRF_PSEL(UART_RTS, 0, 7)>;
 		};
 		group2 {
 			psels = <NRF_PSEL(UART_RX, 0, 3)>,
-				<NRF_PSEL(UART_CTS, 0, 7)>;
+				<NRF_PSEL(UART_CTS, 1, 8)>;
 			bias-pull-up;
 		};
 	};
@@ -20,8 +20,8 @@
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 0, 5)>,
 				<NRF_PSEL(UART_RX, 0, 3)>,
-				<NRF_PSEL(UART_RTS, 1, 8)>,
-				<NRF_PSEL(UART_CTS, 0, 7)>;
+				<NRF_PSEL(UART_RTS, 0, 7)>,
+				<NRF_PSEL(UART_CTS, 1, 8)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
Devicetree pinout was written according to datasheet, but RX and TX were crossed because labels in the datasheet are written from debug interface point of view.
However, it seems that flow control pins were not crossed.

[Datasheet of nRF9160 DK](https://infocenter.nordicsemi.com/pdf/nRF9160_DK_HW_User_Guide_v1.1.0.pdf). 
Labels RX, TX, etc. are written on interface chip point of view, so all these pins should be crossed
![image](https://user-images.githubusercontent.com/3104794/217542605-ac18b5e8-2477-4246-83a6-b34b015c71a2.png)
