### PR TITLE
net: ipv4: Implement fallback to LL address 

### DIFF
--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -730,7 +730,7 @@ static inline bool net_ipv4_is_addr_mcast(const struct in_addr *addr)
  */
 static inline bool net_ipv4_is_ll_addr(const struct in_addr *addr)
 {
-	return (ntohl(UNALIGNED_GET(&addr->s_addr)) & 0xA9FE0000) == 0xA9FE0000;
+	return (ntohl(UNALIGNED_GET(&addr->s_addr)) & 0xFFFF0000) == 0xA9FE0000;
 }
 
 /**

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3265,6 +3265,14 @@ const struct in_addr *net_if_ipv4_select_src_addr(struct net_if *dst_iface,
 	if (!src) {
 		src = net_if_ipv4_get_global_addr(dst_iface,
 						  NET_ADDR_PREFERRED);
+
+		if (IS_ENABLED(CONFIG_NET_IPV4_AUTO) && !src) {
+			/* Try to use LL address if there's really no other
+			 * address available.
+			 */
+			src = net_if_ipv4_get_ll(dst_iface, NET_ADDR_PREFERRED);
+		}
+
 		if (!src) {
 			src = net_ipv4_unspecified_address();
 		}

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -337,6 +337,7 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
 				struct in_addr *request_ip,
 				struct in_addr *current_ip)
 {
+	bool is_ipv4_ll_used = false;
 	struct arp_entry *entry;
 	struct in_addr *addr;
 
@@ -344,10 +345,17 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
 		return NULL;
 	}
 
+	if (IS_ENABLED(CONFIG_NET_IPV4_AUTO)) {
+		is_ipv4_ll_used = net_ipv4_is_ll_addr((struct in_addr *)
+						&NET_IPV4_HDR(pkt)->src) ||
+				  net_ipv4_is_ll_addr((struct in_addr *)
+						&NET_IPV4_HDR(pkt)->dst);
+	}
+
 	/* Is the destination in the local network, if not route via
 	 * the gateway address.
 	 */
-	if (!current_ip &&
+	if (!current_ip && !is_ipv4_ll_used &&
 	    !net_if_ipv4_addr_mask_cmp(net_pkt_iface(pkt), request_ip)) {
 		struct net_if_ipv4 *ipv4 = net_pkt_iface(pkt)->config.ip.ipv4;
 


### PR DESCRIPTION
According to RFC3927, hosts with only IPv4 LL address should still be
able to send packets to destination w/o IPv4 LL address:

   A host with an IPv4 Link-Local address may send to a destination
   which does not have an IPv4 Link-Local address.  If the host is not
   multi-homed, the procedure is simple and unambiguous: Using ARP and
   forwarding directly to on-link destinations is the default route

This behaviour however was not possible with Zephyr, which only allowed
to use IPv4 LL source address for IPv4 LL destinations.

Fix this, by introducing a final fallback (only if IPv4 autoconf is
enabled), to select IPv4 LL address as a source address if no other
address is available.

Additionally, modify the ARP routine a bit if IPv4 LL address is in use.
There's no really point to forward the packet to gateway if IPv4 LL
address is used, as such addresses are not routable. Instead, try to
find the peer in local network in such case.

Fixes #53587