### PR TITLE
Fix uninitialized has param

### DIFF
--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common-pinctrl.dtsi
@@ -66,6 +66,23 @@
 		};
 	};
 
+	pwm0_default: pwm0_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 7)>,
+				<NRF_PSEL(PWM_OUT1, 0, 25)>,
+				<NRF_PSEL(PWM_OUT2, 0, 26)>;
+		};
+	};
+
+	pwm0_sleep: pwm0_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 7)>,
+				<NRF_PSEL(PWM_OUT1, 0, 25)>,
+				<NRF_PSEL(PWM_OUT2, 0, 26)>;
+			low-power-enable;
+		};
+	};
+
 	spi4_default: spi4_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 8)>,

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -29,6 +29,28 @@
 		compatible = "nordic,npm1100";
 		nordic,iset-gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>;
 	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		rgb1_red_pwm_led: pwm_led_0 {
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+		rgb1_green_pwm_led: pwm_led_1 {
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+		rgb1_blue_pwm_led: pwm_led_2 {
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	aliases {
+		pwm-led0 = &rgb1_red_pwm_led;
+		pwm-led1 = &rgb1_green_pwm_led;
+		pwm-led2 = &rgb1_blue_pwm_led;
+		red-pwm-led = &rgb1_red_pwm_led;
+		green-pwm-led = &rgb1_green_pwm_led;
+		blue-pwm-led = &rgb1_blue_pwm_led;
+	};
 };
 
 &adc {
@@ -140,6 +162,9 @@
 
 &pwm0 {
 	status = "okay";
+	pinctrl-0 = <&pwm0_default>;
+	pinctrl-1 = <&pwm0_sleep>;
+	pinctrl-names = "default", "sleep";
 };
 
 &timer0 {

--- a/samples/bluetooth/hap_ha/src/has_server.c
+++ b/samples/bluetooth/hap_ha/src/has_server.c
@@ -76,7 +76,9 @@ int has_server_preset_init(void)
 }
 
 static struct bt_has_register_param param = {
-	.type = BT_HAS_HEARING_AID_TYPE_MONAURAL
+	.type = BT_HAS_HEARING_AID_TYPE_MONAURAL,
+	.preset_sync_support = false,
+	.independent_presets = false
 };
 
 int has_server_init(void)

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/has_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/has_test.c
@@ -29,7 +29,7 @@ static const struct bt_has_preset_ops preset_ops = {
 
 static void test_main(void)
 {
-	struct bt_has_register_param has_param;
+	struct bt_has_register_param has_param = {0};
 	struct bt_has_preset_register_param preset_param;
 
 	int err;


### PR DESCRIPTION
Zero initialize has_param in BSIM test.
Also, specify all bt_has_register_param members in hap_ha sample

Fixes: #54401 