### PR TITLE
Bluetooth: has: Fix uninitialized bt_has_register_param

### DIFF
--- a/samples/bluetooth/hap_ha/src/has_server.c
+++ b/samples/bluetooth/hap_ha/src/has_server.c
@@ -76,7 +76,9 @@ int has_server_preset_init(void)
 }
 
 static struct bt_has_register_param param = {
-	.type = BT_HAS_HEARING_AID_TYPE_MONAURAL
+	.type = BT_HAS_HEARING_AID_TYPE_MONAURAL,
+	.preset_sync_support = false,
+	.independent_presets = false
 };
 
 int has_server_init(void)

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/has_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/has_test.c
@@ -29,7 +29,7 @@ static const struct bt_has_preset_ops preset_ops = {
 
 static void test_main(void)
 {
-	struct bt_has_register_param has_param;
+	struct bt_has_register_param has_param = {0};
 	struct bt_has_preset_register_param preset_param;
 
 	int err;


### PR DESCRIPTION
Zero initialize has_param in BSIM test.
Also, specify all bt_has_register_param members in hap_ha sample.

Fixes: #54401 

Signed-off-by: Lars Knudsen <larsgk@gmail.com>