### PR TITLE
drivers: serial: rp2040: fix rpi pico address mapping

### DIFF
--- a/drivers/serial/uart_rpi_pico.c
+++ b/drivers/serial/uart_rpi_pico.c
@@ -402,8 +402,8 @@ static const struct uart_driver_api uart_rpi_driver_api = {
 	}									\
 										\
 	static const struct uart_rpi_config uart##idx##_rpi_config = {		\
-		.uart_dev = uart##idx,						\
-		.uart_regs = (uart_hw_t *)uart##idx,				\
+		.uart_dev = (uart_inst_t *const)DT_INST_REG_ADDR(idx),		\
+		.uart_regs = (uart_hw_t *const)DT_INST_REG_ADDR(idx),		\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),			\
 		.reset = RESET_DT_SPEC_INST_GET(idx),				\
 		RPI_UART_IRQ_CONFIG_INIT(idx),					\


### PR DESCRIPTION
Address map used for config item `uart_dev` and `uart_regs` is currently derived using the rpi hal macros `uart0` and `uart1` which map to the same register address as given in the `reg` property of the devicetree.

However, the sdk macro is generated using `uart##idx` which zephyr does not necessarily map to uart0 or uart1. This is, for example, the case when disabling uart0 with the devicetree status "disabled" and enabling uart1 for which then the idx==0 and not 1 which therefore maps to the wrong controller address space.

This can simply be fixed by deriving the base address from `DT_INST_REG_ADDR(idx)` instead

Signed-off-by: Ramon Aerne <ramon.aerne@axelera.ai>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54685