### PR TITLE
Bluetooth: Controller: Fix assertion scheduling first BIG event and in window widening CIS event

### DIFF
--- a/samples/bluetooth/hci_rpmsg/src/main.c
+++ b/samples/bluetooth/hci_rpmsg/src/main.c
@@ -269,10 +269,10 @@ static void hci_rpmsg_send(struct net_buf *buf, bool is_fatal_err)
 #if defined(CONFIG_BT_CTLR_ASSERT_HANDLER)
 void bt_ctlr_assert_handle(char *file, uint32_t line)
 {
-#if defined(CONFIG_BT_HCI_VS_FATAL_ERROR)
 	/* Disable interrupts, this is unrecoverable */
 	(void)irq_lock();
 
+#if defined(CONFIG_BT_HCI_VS_FATAL_ERROR)
 	/* Generate an error event only when IPC service endpoint is already bound. */
 	if (ipc_ept_ready) {
 		/* Prepare vendor specific HCI debug event */
@@ -286,16 +286,18 @@ void bt_ctlr_assert_handle(char *file, uint32_t line)
 			LOG_ERR("Can't create Fatal Error HCI event: %s at %d", __FILE__, __LINE__);
 		}
 	} else {
-		LOG_ERR("IPC endpoint is not redy yet: %s at %d", __FILE__, __LINE__);
+		LOG_ERR("IPC endpoint is not ready yet: %s at %d", __FILE__, __LINE__);
 	}
 
 	LOG_ERR("Halting system");
 
+#else /* !CONFIG_BT_HCI_VS_FATAL_ERROR */
+	LOG_ERR("Controller assert in: %s at %d", file, line);
+
+#endif /* !CONFIG_BT_HCI_VS_FATAL_ERROR */
+
 	while (true) {
 	};
-#else
-	LOG_ERR("Controller assert in: %s at %d", file, line);
-#endif /* CONFIG_BT_HCI_VS_FATAL_ERROR */
 }
 #endif /* CONFIG_BT_CTLR_ASSERT_HANDLER */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
@@ -61,7 +61,7 @@ static inline void lll_adv_scan_rsp_enqueue(struct lll_adv *lll, uint8_t idx)
 	lll_adv_pdu_enqueue(&lll->scan_rsp, idx);
 }
 
-static inline struct pdu_adv *lll_adv_scan_rsp_peek(struct lll_adv *lll)
+static inline struct pdu_adv *lll_adv_scan_rsp_peek(const struct lll_adv *lll)
 {
 	return (void *)lll->scan_rsp.pdu[lll->scan_rsp.last];
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h
@@ -172,8 +172,8 @@ static inline void lll_adv_sync_data_enqueue(struct lll_adv_sync *lll,
 	lll_adv_pdu_enqueue(&lll->data, idx);
 }
 
-static inline struct pdu_adv *lll_adv_sync_data_peek(struct lll_adv_sync *lll,
-						     void **extra_data)
+static inline struct pdu_adv *
+lll_adv_sync_data_peek(const struct lll_adv_sync *lll, void **extra_data)
 {
 	uint8_t last = lll->data.last;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -117,7 +117,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 	uint32_t start_us;
 	uint8_t phy;
 
-	DEBUG_RADIO_START_A(1);
+	DEBUG_RADIO_START_M(1);
 
 	/* Reset global static variables */
 	trx_performed_bitmask = 0U;
@@ -332,7 +332,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 		LL_ASSERT(!ret);
 	}
 
-	DEBUG_RADIO_START_A(1);
+	DEBUG_RADIO_START_M(1);
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -930,7 +930,7 @@ static void isr_prepare_subevent(void *param)
 	}
 
 	start_us = radio_tmr_start_us(0U, subevent_us);
-	LL_ASSERT(start_us == (subevent_us + 1U));
+	LL_ASSERT(!trx_performed_bitmask || (start_us == (subevent_us + 1U)));
 
 	cig_lll = ull_conn_iso_lll_group_get_by_stream(cis_lll);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1511,7 +1511,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 						EVENT_OVERHEAD_START_US +
 						(EVENT_TICKER_RES_MARGIN_US << 1));
 
-				ticks_slot_overhead = ull_adv_sync_evt_init(adv, sync);
+				ticks_slot_overhead = ull_adv_sync_evt_init(adv, sync, NULL);
 				ret = ull_adv_sync_start(adv, sync,
 							 ticks_anchor_sync,
 							 ticks_slot_overhead);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1476,7 +1476,9 @@ uint8_t ll_adv_enable(uint8_t enable)
 			 * started.
 			 */
 			if (sync) {
+				uint32_t ticks_slot_overhead;
 				uint32_t ticks_slot_aux;
+
 #if defined(CONFIG_BT_CTLR_ADV_RESERVE_MAX)
 				uint32_t us_slot;
 
@@ -1509,8 +1511,10 @@ uint8_t ll_adv_enable(uint8_t enable)
 						EVENT_OVERHEAD_START_US +
 						(EVENT_TICKER_RES_MARGIN_US << 1));
 
+				ticks_slot_overhead = ull_adv_sync_evt_init(adv, sync);
 				ret = ull_adv_sync_start(adv, sync,
-							 ticks_anchor_sync);
+							 ticks_anchor_sync,
+							 ticks_slot_overhead);
 				if (ret) {
 					goto failure_cleanup;
 				}

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -52,8 +52,9 @@ static int init_reset(void);
 #if (CONFIG_BT_CTLR_ADV_AUX_SET > 0)
 static inline struct ll_adv_aux_set *aux_acquire(void);
 static inline void aux_release(struct ll_adv_aux_set *aux);
-static uint32_t aux_time_get(struct ll_adv_aux_set *aux, struct pdu_adv *pdu,
-			     struct pdu_adv *pdu_scan);
+static uint32_t aux_time_get(const struct ll_adv_aux_set *aux,
+			     const struct pdu_adv *pdu,
+			     uint8_t pdu_len, uint8_t pdu_scan_len);
 static uint8_t aux_time_update(struct ll_adv_aux_set *aux, struct pdu_adv *pdu,
 			       struct pdu_adv *pdu_scan);
 static void mfy_aux_offset_get(void *param);
@@ -2436,7 +2437,7 @@ uint32_t ull_adv_aux_evt_init(struct ll_adv_aux_set *aux,
 	pdu_scan = lll_adv_scan_rsp_peek(lll);
 
 	/* Calculate the PDU Tx Time and hence the radio event length */
-	time_us = aux_time_get(aux, pdu, pdu_scan);
+	time_us = aux_time_get(aux, pdu, pdu->len, pdu_scan->len);
 
 	/* TODO: active_to_start feature port */
 	aux->ull.ticks_active_to_start = 0;
@@ -2588,51 +2589,11 @@ struct ll_adv_aux_set *ull_adv_aux_get(uint8_t handle)
 uint32_t ull_adv_aux_time_get(const struct ll_adv_aux_set *aux, uint8_t pdu_len,
 			      uint8_t pdu_scan_len)
 {
-	const struct lll_adv_aux *lll_aux;
-	const struct lll_adv *lll;
 	const struct pdu_adv *pdu;
-	uint32_t time_us;
 
-	lll_aux = &aux->lll;
-	lll = lll_aux->adv;
+	pdu = lll_adv_aux_data_peek(&aux->lll);
 
-	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_RESERVE_MAX) &&
-	    (lll->phy_s == PHY_CODED)) {
-		pdu_len = PDU_AC_EXT_PAYLOAD_OVERHEAD;
-		pdu_scan_len = PDU_AC_EXT_PAYLOAD_OVERHEAD;
-	}
-
-	/* NOTE: 16-bit values are sufficient for minimum radio event time
-	 *       reservation, 32-bit are used here so that reservations for
-	 *       whole back-to-back chaining of PDUs can be accomodated where
-	 *       the required microseconds could overflow 16-bits, example,
-	 *       back-to-back chained Coded PHY PDUs.
-	 */
-	time_us = PDU_AC_US(pdu_len, lll->phy_s, lll->phy_flags) +
-		  EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;
-
-	pdu = lll_adv_aux_data_peek(lll_aux);
-	if ((pdu->adv_ext_ind.adv_mode & BT_HCI_LE_ADV_PROP_CONN) ==
-	    BT_HCI_LE_ADV_PROP_CONN) {
-		const uint16_t conn_req_us =
-			PDU_AC_MAX_US((INITA_SIZE + ADVA_SIZE + LLDATA_SIZE),
-				      lll->phy_s);
-		const uint16_t conn_rsp_us =
-			PDU_AC_US((PDU_AC_EXT_HEADER_SIZE_MIN + ADVA_SIZE +
-				   TARGETA_SIZE), lll->phy_s, lll->phy_flags);
-
-		time_us += EVENT_IFS_MAX_US * 2 + conn_req_us + conn_rsp_us;
-	} else if ((pdu->adv_ext_ind.adv_mode & BT_HCI_LE_ADV_PROP_SCAN) ==
-		   BT_HCI_LE_ADV_PROP_SCAN) {
-		const uint16_t scan_req_us  =
-			PDU_AC_MAX_US((SCANA_SIZE + ADVA_SIZE), lll->phy_s);
-		const uint16_t scan_rsp_us =
-			PDU_AC_US(pdu_scan_len, lll->phy_s, lll->phy_flags);
-
-		time_us += EVENT_IFS_MAX_US * 2 + scan_req_us + scan_rsp_us;
-	}
-
-	return time_us;
+	return aux_time_get(aux, pdu, pdu_len, pdu_scan_len);
 }
 
 void ull_adv_aux_offset_get(struct ll_adv_set *adv)
@@ -2877,12 +2838,22 @@ static inline void aux_release(struct ll_adv_aux_set *aux)
 	mem_release(aux, &adv_aux_free);
 }
 
-static uint32_t aux_time_get(struct ll_adv_aux_set *aux, struct pdu_adv *pdu,
-			     struct pdu_adv *pdu_scan)
+static uint32_t aux_time_get(const struct ll_adv_aux_set *aux,
+			     const struct pdu_adv *pdu,
+			     uint8_t pdu_len, uint8_t pdu_scan_len)
 {
-	struct lll_adv_aux *lll_aux;
-	struct lll_adv *lll;
+	const struct lll_adv_aux *lll_aux;
+	const struct lll_adv *lll;
 	uint32_t time_us;
+
+	lll_aux = &aux->lll;
+	lll = lll_aux->adv;
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_RESERVE_MAX) &&
+	    (lll->phy_s == PHY_CODED)) {
+		pdu_len = PDU_AC_EXT_PAYLOAD_OVERHEAD;
+		pdu_scan_len = PDU_AC_EXT_PAYLOAD_OVERHEAD;
+	}
 
 	/* NOTE: 16-bit values are sufficient for minimum radio event time
 	 *       reservation, 32-bit are used here so that reservations for
@@ -2890,9 +2861,7 @@ static uint32_t aux_time_get(struct ll_adv_aux_set *aux, struct pdu_adv *pdu,
 	 *       the required microseconds could overflow 16-bits, example,
 	 *       back-to-back chained Coded PHY PDUs.
 	 */
-	lll_aux = &aux->lll;
-	lll = lll_aux->adv;
-	time_us = PDU_AC_US(pdu->len, lll->phy_s, lll->phy_flags) +
+	time_us = PDU_AC_US(pdu_len, lll->phy_s, lll->phy_flags) +
 		  EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;
 
 	if ((pdu->adv_ext_ind.adv_mode & BT_HCI_LE_ADV_PROP_CONN) ==
@@ -2910,7 +2879,7 @@ static uint32_t aux_time_get(struct ll_adv_aux_set *aux, struct pdu_adv *pdu,
 		const uint16_t scan_req_us  =
 			PDU_AC_MAX_US((SCANA_SIZE + ADVA_SIZE), lll->phy_s);
 		const uint16_t scan_rsp_us =
-			PDU_AC_US(pdu_scan->len, lll->phy_s, lll->phy_flags);
+			PDU_AC_US(pdu_scan_len, lll->phy_s, lll->phy_flags);
 
 		time_us += EVENT_IFS_MAX_US * 2 + scan_req_us + scan_rsp_us;
 
@@ -2938,7 +2907,7 @@ static uint8_t aux_time_update(struct ll_adv_aux_set *aux, struct pdu_adv *pdu,
 	uint32_t time_us;
 	uint32_t ret;
 
-	time_us = aux_time_get(aux, pdu, pdu_scan);
+	time_us = aux_time_get(aux, pdu, pdu->len, pdu_scan->len);
 	time_ticks = HAL_TICKER_US_TO_TICKS(time_us);
 	if (aux->ull.ticks_slot > time_ticks) {
 		ticks_minus = aux->ull.ticks_slot - time_ticks;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -229,10 +229,15 @@ void ull_adv_sync_release(struct ll_adv_sync_set *sync);
 uint32_t ull_adv_sync_time_get(const struct ll_adv_sync_set *sync,
 			       uint8_t pdu_len);
 
+/* helper function to calculate ticks_slot and return slot overhead */
+uint32_t ull_adv_sync_evt_init(struct ll_adv_set *adv,
+			       struct ll_adv_sync_set *sync);
+
 /* helper function to start periodic advertising */
 uint32_t ull_adv_sync_start(struct ll_adv_set *adv,
 			    struct ll_adv_sync_set *sync,
-			    uint32_t ticks_anchor);
+			    uint32_t ticks_anchor,
+			    uint32_t ticks_slot_overhead);
 
 /* helper function to update periodic advertising event time reservation */
 uint8_t ull_adv_sync_time_update(struct ll_adv_sync_set *sync,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -231,7 +231,8 @@ uint32_t ull_adv_sync_time_get(const struct ll_adv_sync_set *sync,
 
 /* helper function to calculate ticks_slot and return slot overhead */
 uint32_t ull_adv_sync_evt_init(struct ll_adv_set *adv,
-			       struct ll_adv_sync_set *sync);
+			       struct ll_adv_sync_set *sync,
+			       struct pdu_adv *pdu);
 
 /* helper function to start periodic advertising */
 uint32_t ull_adv_sync_start(struct ll_adv_set *adv,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -939,6 +939,8 @@ static uint32_t adv_iso_start(struct ll_adv_iso_set *adv_iso,
 	ticks_slot = adv_iso->ull.ticks_slot + ticks_slot_overhead;
 
 	/* Find the slot after Periodic Advertisings events */
+	ticks_anchor = ticker_ticks_now_get() +
+		       HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 	err = ull_sched_adv_aux_sync_free_slot_get(TICKER_USER_ID_THREAD,
 						   ticks_slot, &ticks_anchor);
 	if (!err) {
@@ -947,9 +949,6 @@ static uint32_t adv_iso_start(struct ll_adv_iso_set *adv_iso,
 					    EVENT_OVERHEAD_START_US) -
 					EVENT_OVERHEAD_START_US +
 					(EVENT_TICKER_RES_MARGIN_US << 1));
-	} else {
-		ticks_anchor = ticker_ticks_now_get() +
-			       HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
 	}
 
 	/* setup to use ISO create prepare function for first radio event */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -51,8 +51,8 @@ static uint8_t adv_type_check(struct ll_adv_set *adv);
 static inline struct ll_adv_sync_set *sync_acquire(void);
 static inline void sync_release(struct ll_adv_sync_set *sync);
 static inline uint16_t sync_handle_get(struct ll_adv_sync_set *sync);
-static uint32_t ull_adv_sync_pdu_time_get(const struct ll_adv_sync_set *sync,
-					  const struct pdu_adv *pdu);
+static uint32_t sync_time_get(const struct ll_adv_sync_set *sync,
+			      const struct pdu_adv *pdu);
 static inline uint8_t sync_remove(struct ll_adv_sync_set *sync,
 				  struct ll_adv_set *adv, uint8_t enable);
 static uint8_t sync_chm_update(uint8_t handle);
@@ -1072,7 +1072,7 @@ uint32_t ull_adv_sync_start(struct ll_adv_set *adv,
 	lll_sync = &sync->lll;
 	ter_pdu = lll_adv_sync_data_peek(lll_sync, NULL);
 
-	time_us = ull_adv_sync_pdu_time_get(sync, ter_pdu);
+	time_us = sync_time_get(sync, ter_pdu);
 
 	/* TODO: active_to_start feature port */
 	sync->ull.ticks_active_to_start = 0U;
@@ -1118,7 +1118,7 @@ uint8_t ull_adv_sync_time_update(struct ll_adv_sync_set *sync,
 	uint32_t time_us;
 	uint32_t ret;
 
-	time_us = ull_adv_sync_pdu_time_get(sync, pdu);
+	time_us = sync_time_get(sync, pdu);
 	time_ticks = HAL_TICKER_US_TO_TICKS(time_us);
 	if (sync->ull.ticks_slot > time_ticks) {
 		ticks_minus = sync->ull.ticks_slot - time_ticks;
@@ -1888,8 +1888,8 @@ static inline uint16_t sync_handle_get(struct ll_adv_sync_set *sync)
 			     sizeof(struct ll_adv_sync_set));
 }
 
-static uint32_t ull_adv_sync_pdu_time_get(const struct ll_adv_sync_set *sync,
-					  const struct pdu_adv *pdu)
+static uint32_t sync_time_get(const struct ll_adv_sync_set *sync,
+			      const struct pdu_adv *pdu)
 {
 	uint8_t len;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -504,7 +504,7 @@ uint8_t ll_cis_create_check(uint16_t cis_handle, uint16_t acl_handle)
 
 		/* Verify handle validity and association */
 		cis = ll_conn_iso_stream_get(cis_handle);
-		if (cis->lll.handle == cis_handle && cis->lll.acl_handle == acl_handle) {
+		if (cis->lll.handle == cis_handle) {
 			return BT_HCI_ERR_SUCCESS;
 		}
 	}
@@ -521,6 +521,7 @@ void ll_cis_create(uint16_t cis_handle, uint16_t acl_handle)
 	/* Handles have been verified prior to calling this function */
 	conn = ll_connected_get(acl_handle);
 	cis = ll_conn_iso_stream_get(cis_handle);
+	cis->lll.acl_handle = acl_handle;
 
 	/* Create access address */
 	err = util_aa_le32(cis->lll.access_addr);
@@ -696,6 +697,13 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 	cis->offset = cis_offset;
 	cis->central.instant = instant;
 	cis->lll.event_count = -1;
+	cis->lll.next_subevent = 0U;
+	cis->lll.sn = 0U;
+	cis->lll.nesn = 0U;
+	cis->lll.cie = 0U;
+	cis->lll.flushed = 0U;
+	cis->lll.active = 0U;
+	cis->lll.datapath_ready_rx = 0U;
 	cis->lll.tx.payload_count = 0U;
 	cis->lll.rx.payload_count = 0U;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -259,13 +259,6 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 	cis->lll.acl_handle = acl->lll.handle;
 	cis->lll.sub_interval = sys_get_le24(req->sub_interval);
 	cis->lll.nse = req->nse;
-	cis->lll.next_subevent = 0;
-	cis->lll.sn = 0;
-	cis->lll.nesn = 0;
-	cis->lll.cie = 0;
-	cis->lll.flushed = 0;
-	cis->lll.active = 0;
-	cis->lll.datapath_ready_rx = 0;
 
 	cis->lll.rx.phy = req->c_phy;
 	cis->lll.rx.bn = req->c_bn;
@@ -316,6 +309,13 @@ uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 	cis->offset = sys_get_le24(ind->cis_offset);
 	memcpy(cis->lll.access_addr, ind->aa, sizeof(ind->aa));
 	cis->lll.event_count = -1;
+	cis->lll.next_subevent = 0U;
+	cis->lll.sn = 0U;
+	cis->lll.nesn = 0U;
+	cis->lll.cie = 0U;
+	cis->lll.flushed = 0U;
+	cis->lll.active = 0U;
+	cis->lll.datapath_ready_rx = 0U;
 	cis->lll.tx.payload_count = 0U;
 	cis->lll.rx.payload_count = 0U;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -101,8 +101,8 @@ int ull_sched_adv_aux_sync_free_slot_get(uint8_t user_id,
 			if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 				const struct ll_adv_aux_set *aux;
 
-				aux = (void *)ull_hdr_get_cb(ticker_id,
-							     &ticks_slot);
+				aux = ull_adv_aux_get(ticker_id -
+						      TICKER_ID_ADV_AUX_BASE);
 				*ticks_anchor +=
 					MAX(aux->ull.ticks_active_to_start,
 					    aux->ull.ticks_prepare_to_start);
@@ -119,8 +119,8 @@ int ull_sched_adv_aux_sync_free_slot_get(uint8_t user_id,
 			if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 				const struct ll_adv_sync_set *sync;
 
-				sync = (void *)ull_hdr_get_cb(ticker_id,
-							      &ticks_slot);
+				sync = ull_adv_sync_get(ticker_id -
+							TICKER_ID_ADV_SYNC_BASE);
 				*ticks_anchor +=
 					MAX(sync->ull.ticks_active_to_start,
 					    sync->ull.ticks_prepare_to_start);
@@ -137,8 +137,8 @@ int ull_sched_adv_aux_sync_free_slot_get(uint8_t user_id,
 			if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT)) {
 				const struct ll_adv_iso_set *iso;
 
-				iso = (void *)ull_hdr_get_cb(ticker_id,
-							     &ticks_slot);
+				iso = ull_adv_iso_get(ticker_id -
+						      TICKER_ID_ADV_ISO_BASE);
 				*ticks_anchor +=
 					MAX(iso->ull.ticks_active_to_start,
 					    iso->ull.ticks_prepare_to_start);


### PR DESCRIPTION
Fix assertion due to delayed prepare of first BIG event when
supporting encryption. Crypto calculation introduce extra
processing delay causing the scheduling of first BIG event
to be delayed. Detect such delay and skip to next ISO
interval.

Relax radio_tmr_start_us() delayed start assertion when
window widening in progress.

Fix Controller assertion handler to lock IRQs and spinlock
on assertions.

Fix uninitialized CIS LLL structure member variables,
uninitialised CIS acl_handle causes HCI command disallowed
for acl_handle's other than 0x0000.
Initialize other variables like sn, nesn etc. when create
CIS control procedure is performed.

Fixes #54642.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>