### PR TITLE
doc: releases: add disk release notes for 3.3

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -414,6 +414,12 @@ Drivers and Sensors
 
 * Disk
 
+  * STM32 SD host controller clocks are now configured via devicetree.
+  * Zephyr flash disks are now configured using the :dtcompatible:`zephyr,flash-disk`
+    devicetree binding
+  * Flash disks can be marked as read only by setting the ``read-only`` property
+    on the linked flash device partition.
+
 * Display
 
 * DMA


### PR DESCRIPTION
Add disk driver release notes for 3.3. The following changes are
included:

- STM32 SDHC now uses device tree to configure clock settings.
- Flash disks are now configured via zephyr,flash-disk binding
- Flash disks support read only operation if flash partition is
  read-only

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>