### PR TITLE
doc: release-notes/3.3: add release notes for SD host controller

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -538,6 +538,15 @@ Drivers and Sensors
 
 * SDHC
 
+  * i.MX RT USDHC:
+
+    - Support HS400 and HS200 mode. This mode is used with eMMC devices,
+      and will enable high speed operation for those cards.
+    - Support DMA operation on SOCs that do not support noncacheable memory,
+      such as the RT595. DMA will enable higher performance SD modes,
+      such as HS400 and SDR104, to reliably transfer data using the
+      SD host controller
+
 * Sensor
 
 * Serial


### PR DESCRIPTION
Add release notes for SD host controller drivers for 3.3. The following changes are highlighted:
- Added support for HS400 mode and HS200 mode in i.MX RT USDHC driver
- Added support for DMA operation on systems without NOCACHE memory to i.MX RT USDHC driver

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>