### PR TITLE
ci: Switch to CI image 0.24.10

### DIFF
--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository_owner == 'zephyrproject-rtos'
     runs-on: zephyr-runner-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.6
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.10
       options: '--entrypoint /bin/bash'
       volumes:
         - /repo-cache/zephyrproject:/github/cache/zephyrproject

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository_owner == 'zephyrproject-rtos'
     runs-on: zephyr-runner-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.6
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.10
       options: '--entrypoint /bin/bash'
       volumes:
         - /repo-cache/zephyrproject:/github/cache/zephyrproject

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     runs-on: zephyr-runner-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.6
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.10
       options: '--entrypoint /bin/bash'
       volumes:
         - /repo-cache/zephyrproject:/github/cache/zephyrproject

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -10,7 +10,7 @@ jobs:
   check-errno:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.6
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.10
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.2
 

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.6
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.10
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.6
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.10
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -22,7 +22,7 @@ jobs:
     if: github.repository_owner == 'zephyrproject-rtos'
     runs-on: zephyr-runner-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.6
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.10
       options: '--entrypoint /bin/bash'
       volumes:
         - /repo-cache/zephyrproject:/github/cache/zephyrproject
@@ -118,7 +118,7 @@ jobs:
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.24.6
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.10
       options: '--entrypoint /bin/bash'
       volumes:
         - /repo-cache/zephyrproject:/github/cache/zephyrproject


### PR DESCRIPTION
This commit updates the CI workflows to use the CI image 0.24.10, in order to pull in a more recent version of BabbleSim (v1.1.1) and an additional thrift-compiler dependency for the Apache Thrift module.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

---

Tested in https://github.com/zephyrproject-rtos/zephyr-testing/actions/runs/4125732751/jobs/7126862260