### PR TITLE
Switch return type of main from 'void' to 'int'

### DIFF
--- a/boards/arm/mps2_an521/empty_cpu0/src/main.c
+++ b/boards/arm/mps2_an521/empty_cpu0/src/main.c
@@ -8,11 +8,12 @@
 
 extern void wakeup_cpu1(void);
 
-void main(void)
+int main(void)
 {
 	/* Simply wake-up the remote core */
 	wakeup_cpu1();
 
 	while (1) {
 	}
+	return 0;
 }

--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -28,7 +28,6 @@ set_compiler_property(PROPERTY warning_base
                       -Wformat
                       -Wformat-security
                       -Wno-format-zero-length
-                      -Wno-main-return-type
                       -Wno-unaligned-pointer-conversion
                       -Wno-incompatible-pointer-types-discards-qualifiers
                       -Wno-typedef-redefinition

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -33,8 +33,6 @@ check_set_compiler_property(PROPERTY warning_base
                             -Wformat
                             -Wformat-security
                             -Wno-format-zero-length
-                            -Wno-main
-                            -Wno-main-return-type
                             -Wno-unused-but-set-variable
                             -Wno-typedef-redefinition
                             -Wno-deprecated-non-prototype

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -30,7 +30,6 @@ check_set_compiler_property(PROPERTY warning_base
     -Wall
     "SHELL:-Wformat -Wformat-security"
     "SHELL:-Wformat -Wno-format-zero-length"
-    -Wno-main
 )
 
 check_set_compiler_property(APPEND PROPERTY warning_base -Wno-pointer-sign)

--- a/doc/develop/languages/c/index.rst
+++ b/doc/develop/languages/c/index.rst
@@ -12,6 +12,11 @@ available as part of the C header files under the :file:`include` directory, so
 writing Zephyr applications in C gives the developers access to the most
 features.
 
+The ``main()`` function must have the return type of ``int`` as Zephyr
+applications run in a "hosted" environment as defined by the C
+standard. Applications must return zero (0) from main. All non-zero return
+values are reserved.
+
 .. _c_standards:
 
 Language Standards

--- a/doc/develop/languages/cpp/index.rst
+++ b/doc/develop/languages/cpp/index.rst
@@ -31,10 +31,9 @@ or a **cxx** suffix are compiled using the C++ compiler. For example,
 :file:`myCplusplusApp.cpp` is compiled using C++.
 
 The C++ standard requires the ``main()`` function to have the return type of
-``int`` while Zephyr uses ``void`` by default. If your ``main()`` is defined in
-a C++ source file, you must select :kconfig:option:`CONFIG_CPP_MAIN` in the
-application configuration file so that Zephyr uses ``int main(void)`` instead
-of ``void main(void)``.
+``int``. Your ``main()`` must be defined as ``int main(void)``. Zephyr ignores
+the return value from main, so applications should not return status
+information and should, instead, return zero.
 
 .. note::
     Do not use C++ for kernel, driver, or system initialization code.

--- a/doc/kernel/services/scheduling/index.rst
+++ b/doc/kernel/services/scheduling/index.rst
@@ -295,7 +295,7 @@ k_cpu_idle() unconditionally unmasks interrupts.
         k_sem_give(&my_sem);
     }
 
-    void main(void)
+    int main(void)
     {
         k_sem_init(&my_sem, 0, 1);
 
@@ -337,7 +337,7 @@ like in this example.
         k_sem_give(&my_sem);
     }
 
-    void main(void)
+    int main(void)
     {
         k_sem_init(&my_sem, 0, 1);
 
@@ -377,7 +377,7 @@ i.e. not doing any real work, like in this example below.
 
 .. code-block:: c
 
-    void main(void)
+    int main(void)
     {
         /* ... do some system/application initialization */
 

--- a/doc/kernel/services/synchronization/condvar.rst
+++ b/doc/kernel/services/synchronization/condvar.rst
@@ -77,7 +77,7 @@ The following code waits on the condition variable.
     K_MUTEX_DEFINE(mutex);
     K_CONDVAR_DEFINE(condvar)
 
-    void main(void)
+    int main(void)
     {
         k_mutex_lock(&mutex, K_FOREVER);
 

--- a/doc/kernel/services/threads/system_threads.rst
+++ b/doc/kernel/services/threads/system_threads.rst
@@ -62,7 +62,7 @@ The function used by a real application can be as complex as needed.
 
 .. code-block:: c
 
-    void main(void)
+    int main(void)
     {
         /* initialize a semaphore */
 	...

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -129,6 +129,17 @@ Changes in this release
   * Touchscreen drivers converted to use the input APIs can use the
     :dtcompatible:`zephyr,kscan-input` driver to maintain Kscan compatilibity.
 
+* The declaration of :c:func:`main` has been changed from ``void
+  main(void)`` to ``int main(void)``. The main function is required to
+  return the value zero. All other return values are reserved. This aligns
+  Zephyr with the C and C++ language specification requirements for
+  "hosted" environments, avoiding compiler warnings and errors. These
+  compiler messages are generated when applications are built in "hosted"
+  mode (which means without the ``-ffreestanding`` compiler flag). As the
+  ``-ffreestanding`` flag is currently enabled unless the application is
+  using picolibc, only applications using picolibc will be affected by this
+  change at this time.
+
 Removed APIs in this release
 ============================
 

--- a/doc/services/debugging/gdbstub.rst
+++ b/doc/services/debugging/gdbstub.rst
@@ -217,7 +217,7 @@ how GDB stub works.
 
          (gdb) list
          27
-         28     void main(void)
+         28     int main(void)
          29     {
          30             int ret;
          31

--- a/doc/services/device_mgmt/mcumgr_callbacks.rst
+++ b/doc/services/device_mgmt/mcumgr_callbacks.rst
@@ -54,7 +54,7 @@ application code as per:
         return MGMT_ERR_EOK;
     }
 
-    void main()
+    int main()
     {
         my_callback.callback = my_function;
         my_callback.event_id = MGMT_EVT_OP_CMD_DONE;
@@ -170,7 +170,7 @@ An example of selectively denying file access:
         return MGMT_ERR_EOK;
     }
 
-    void main()
+    int main()
     {
         my_callback.callback = my_function;
         my_callback.event_id = MGMT_EVT_OP_FS_MGMT_FILE_ACCESS;

--- a/doc/services/logging/index.rst
+++ b/doc/services/logging/index.rst
@@ -314,7 +314,7 @@ Following snippet shows how logging can be processed in simple forever loop.
 
    #include <zephyr/log_ctrl.h>
 
-   void main(void)
+   int main(void)
    {
    	LOG_INIT();
    	/* If multithreading is enabled provide thread id to the logging. */

--- a/doc/services/settings/index.rst
+++ b/doc/services/settings/index.rst
@@ -263,7 +263,7 @@ up from where it was before restart.
         .h_set = foo_settings_set
     };
 
-    void main(void)
+    int main(void)
     {
         settings_subsys_init();
         settings_register(&my_conf);

--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -271,7 +271,7 @@ and a function :c:func:`shell_execute_cmd`, as shown in this example:
 
 .. code-block:: c
 
-	void main(void)
+	int main(void)
 	{
 		/* Below code will execute "clear" command on a DUMMY backend */
 		shell_execute_cmd(NULL, "clear");
@@ -660,7 +660,7 @@ The following code shows a simple use case of this library:
 
 .. code-block:: c
 
-	void main(void)
+	int main(void)
 	{
 
 	}

--- a/doc/services/smf/index.rst
+++ b/doc/services/smf/index.rst
@@ -181,7 +181,7 @@ Code::
 		[S2] = SMF_CREATE_STATE(s2_entry, s2_run, NULL),
 	};
 
-	void main(void)
+	int main(void)
 	{
 		int32_t ret;
 
@@ -285,7 +285,7 @@ Code::
 		[S2] = SMF_CREATE_STATE(NULL, s2_run, NULL, NULL),
 	};
 
-	void main(void)
+	int main(void)
 	{
 		int32_t ret;
 
@@ -416,7 +416,7 @@ Code::
 		k_event_post(&s_obj.smf_event, EVENT_BTN_PRESS);
 	}
 
-	void main(void)
+	int main(void)
 	{
 		int ret;
 

--- a/doc/services/zbus/index.rst
+++ b/doc/services/zbus/index.rst
@@ -331,7 +331,7 @@ Zbus subsystem also implements :ref:`Iterable Sections <iterable_sections_api>` 
             ++count;
             return true;
     }
-    void main(void)
+    int main(void)
     {
             LOG_DBG("Channel list:");
             count = 0;

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -332,11 +332,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 	z_mem_manage_boot_finish();
 #endif /* CONFIG_MMU */
 
-#ifdef CONFIG_CPP_MAIN
 	extern int main(void);
-#else
-	extern void main(void);
-#endif
 
 	(void)main();
 

--- a/kernel/main_weak.c
+++ b/kernel/main_weak.c
@@ -21,16 +21,10 @@
 
 #include <kernel_internal.h>
 
-#ifdef CONFIG_CPP_MAIN
 int __weak main(void)
-#else
-void __weak main(void)
-#endif
 {
 	/* NOP default main() if the application does not provide one. */
 	arch_nop();
 
-#ifdef CONFIG_CPP_MAIN
 	return 0;
-#endif
 }

--- a/samples/application_development/code_relocation_nocopy/src/main.c
+++ b/samples/application_development/code_relocation_nocopy/src/main.c
@@ -42,7 +42,7 @@ void disable_mpu_rasr_xn(void)
 extern void function_in_ext_flash(void);
 extern void function_in_sram(void);
 
-void main(void)
+int main(void)
 {
 #ifdef CONFIG_ARM_MPU
 	disable_mpu_rasr_xn();
@@ -54,4 +54,5 @@ void main(void)
 	function_in_sram();
 
 	printk("Hello World! %s\n", CONFIG_BOARD);
+	return 0;
 }

--- a/samples/application_development/external_lib/src/main.c
+++ b/samples/application_development/external_lib/src/main.c
@@ -12,8 +12,9 @@
 
 #include <mylib.h>
 
-void main(void)
+int main(void)
 {
 	printf("Hello World!\n");
 	mylib_hello_world();
+	return 0;
 }

--- a/samples/application_development/out_of_tree_board/src/main.c
+++ b/samples/application_development/out_of_tree_board/src/main.c
@@ -7,7 +7,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 
-void main(void)
+int main(void)
 {
 	printk("Hello World! %s\n", CONFIG_ARCH);
+	return 0;
 }

--- a/samples/application_development/out_of_tree_driver/src/main.c
+++ b/samples/application_development/out_of_tree_driver/src/main.c
@@ -15,7 +15,7 @@ static void user_entry(void *p1, void *p2, void *p3)
 	hello_world_print(dev);
 }
 
-void main(void)
+int main(void)
 {
 	printk("Hello World from the app!\n");
 
@@ -27,4 +27,5 @@ void main(void)
 
 	k_object_access_grant(dev, k_current_get());
 	k_thread_user_mode_enter(user_entry, NULL, NULL, NULL);
+	return 0;
 }

--- a/samples/application_development/sysbuild/with_mcuboot/src/main.c
+++ b/samples/application_development/sysbuild/with_mcuboot/src/main.c
@@ -7,8 +7,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/linker/linker-defs.h>
 
-void main(void)
+int main(void)
 {
 	printk("Address of sample %p\n", (void *)__rom_region_start);
 	printk("Hello sysbuild with mcuboot! %s\n", CONFIG_BOARD);
+	return 0;
 }

--- a/samples/arch/mpu/mpu_test/src/main.c
+++ b/samples/arch/mpu/mpu_test/src/main.c
@@ -139,15 +139,16 @@ static int cmd_mtest(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 #if defined(CONFIG_SOC_FLASH_MCUX) || defined(CONFIG_SOC_FLASH_LPC) || \
 	defined(CONFIG_SOC_FLASH_STM32)
 	if (!device_is_ready(flash_dev)) {
 		printk("Flash device not ready\n");
-		return;
+		return 0;
 	}
 #endif
+	return 0;
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_mpu,

--- a/samples/arch/smp/pi/src/main.c
+++ b/samples/arch/smp/pi/src/main.c
@@ -77,7 +77,7 @@ void test_thread(void *arg1, void *arg2, void *arg3)
 	atomic_dec(counter);
 }
 
-void main(void)
+int main(void)
 {
 	uint32_t start_time, stop_time, cycles_spent, nanoseconds_spent;
 	int i;
@@ -112,4 +112,5 @@ void main(void)
 
 	printk("All %d threads executed by %d cores in %d msec\n", THREADS_NUM,
 	       CORES_NUM, nanoseconds_spent / 1000 / 1000);
+	return 0;
 }

--- a/samples/arch/smp/pktqueue/src/main.c
+++ b/samples/arch/smp/pktqueue/src/main.c
@@ -133,7 +133,7 @@ void queue_thread(void *arg1, void *arg2, void *arg3)
 	k_mutex_unlock(&fetch_queue_mtx);
 }
 
-void main(void)
+int main(void)
 {
 	uint32_t start_time, stop_time, cycles_spent, nanoseconds_spent;
 
@@ -201,4 +201,5 @@ void main(void)
 	}
 
 	k_sleep(K_MSEC(10));
+	return 0;
 }

--- a/samples/basic/blinky/src/main.c
+++ b/samples/basic/blinky/src/main.c
@@ -19,24 +19,25 @@
  */
 static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
 
-void main(void)
+int main(void)
 {
 	int ret;
 
 	if (!gpio_is_ready_dt(&led)) {
-		return;
+		return 0;
 	}
 
 	ret = gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
 	if (ret < 0) {
-		return;
+		return 0;
 	}
 
 	while (1) {
 		ret = gpio_pin_toggle_dt(&led);
 		if (ret < 0) {
-			return;
+			return 0;
 		}
 		k_msleep(SLEEP_TIME_MS);
 	}
+	return 0;
 }

--- a/samples/basic/blinky_pwm/src/main.c
+++ b/samples/basic/blinky_pwm/src/main.c
@@ -19,7 +19,7 @@ static const struct pwm_dt_spec pwm_led0 = PWM_DT_SPEC_GET(DT_ALIAS(pwm_led0));
 #define MIN_PERIOD PWM_SEC(1U) / 128U
 #define MAX_PERIOD PWM_SEC(1U)
 
-void main(void)
+int main(void)
 {
 	uint32_t max_period;
 	uint32_t period;
@@ -31,7 +31,7 @@ void main(void)
 	if (!device_is_ready(pwm_led0.dev)) {
 		printk("Error: PWM device %s is not ready\n",
 		       pwm_led0.dev->name);
-		return;
+		return 0;
 	}
 
 	/*
@@ -49,7 +49,7 @@ void main(void)
 			printk("Error: PWM device "
 			       "does not support a period at least %lu\n",
 			       4U * MIN_PERIOD);
-			return;
+			return 0;
 		}
 	}
 
@@ -61,7 +61,7 @@ void main(void)
 		ret = pwm_set_dt(&pwm_led0, period, period / 2U);
 		if (ret) {
 			printk("Error %d: failed to set pulse width\n", ret);
-			return;
+			return 0;
 		}
 
 		period = dir ? (period * 2U) : (period / 2U);
@@ -75,4 +75,5 @@ void main(void)
 
 		k_sleep(K_SECONDS(4U));
 	}
+	return 0;
 }

--- a/samples/basic/button/src/main.c
+++ b/samples/basic/button/src/main.c
@@ -38,21 +38,21 @@ void button_pressed(const struct device *dev, struct gpio_callback *cb,
 	printk("Button pressed at %" PRIu32 "\n", k_cycle_get_32());
 }
 
-void main(void)
+int main(void)
 {
 	int ret;
 
 	if (!gpio_is_ready_dt(&button)) {
 		printk("Error: button device %s is not ready\n",
 		       button.port->name);
-		return;
+		return 0;
 	}
 
 	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
 	if (ret != 0) {
 		printk("Error %d: failed to configure %s pin %d\n",
 		       ret, button.port->name, button.pin);
-		return;
+		return 0;
 	}
 
 	ret = gpio_pin_interrupt_configure_dt(&button,
@@ -60,7 +60,7 @@ void main(void)
 	if (ret != 0) {
 		printk("Error %d: failed to configure interrupt on %s pin %d\n",
 			ret, button.port->name, button.pin);
-		return;
+		return 0;
 	}
 
 	gpio_init_callback(&button_cb_data, button_pressed, BIT(button.pin));
@@ -95,4 +95,5 @@ void main(void)
 			k_msleep(SLEEP_TIME_MS);
 		}
 	}
+	return 0;
 }

--- a/samples/basic/custom_dts_binding/src/main.c
+++ b/samples/basic/custom_dts_binding/src/main.c
@@ -17,13 +17,13 @@
 static const struct gpio_dt_spec load_switch =
 	GPIO_DT_SPEC_GET_OR(DT_NODELABEL(load_switch), gpios, {0});
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	if (!gpio_is_ready_dt(&load_switch)) {
 		printf("The load switch pin GPIO port is not ready.\n");
-		return;
+		return 0;
 	}
 
 	printf("Initializing pin with inactive level.\n");
@@ -31,7 +31,7 @@ void main(void)
 	err = gpio_pin_configure_dt(&load_switch, GPIO_OUTPUT_INACTIVE);
 	if (err != 0) {
 		printf("Configuring GPIO pin failed: %d\n", err);
-		return;
+		return 0;
 	}
 
 	printf("Waiting one second.\n");
@@ -44,4 +44,5 @@ void main(void)
 	if (err != 0) {
 		printf("Setting GPIO pin level failed: %d\n", err);
 	}
+	return 0;
 }

--- a/samples/basic/fade_led/src/main.c
+++ b/samples/basic/fade_led/src/main.c
@@ -19,7 +19,7 @@ static const struct pwm_dt_spec pwm_led0 = PWM_DT_SPEC_GET(DT_ALIAS(pwm_led0));
 #define NUM_STEPS	50U
 #define SLEEP_MSEC	25U
 
-void main(void)
+int main(void)
 {
 	uint32_t pulse_width = 0U;
 	uint32_t step = pwm_led0.period / NUM_STEPS;
@@ -31,14 +31,14 @@ void main(void)
 	if (!device_is_ready(pwm_led0.dev)) {
 		printk("Error: PWM device %s is not ready\n",
 		       pwm_led0.dev->name);
-		return;
+		return 0;
 	}
 
 	while (1) {
 		ret = pwm_set_pulse_dt(&pwm_led0, pulse_width);
 		if (ret) {
 			printk("Error %d: failed to set pulse width\n", ret);
-			return;
+			return 0;
 		}
 
 		if (dir) {
@@ -58,4 +58,5 @@ void main(void)
 
 		k_sleep(K_MSEC(SLEEP_MSEC));
 	}
+	return 0;
 }

--- a/samples/basic/hash_map/src/main.c
+++ b/samples/basic/hash_map/src/main.c
@@ -26,7 +26,7 @@ struct _stats {
 
 static void print_stats(const struct _stats *stats);
 
-void main(void)
+int main(void)
 {
 	size_t i;
 	int ires;
@@ -89,9 +89,7 @@ out:
 
 	LOG_INF("success");
 
-	if (IS_ENABLED(CONFIG_ARCH_POSIX)) {
-		exit(0);
-	}
+	return 0;
 }
 
 static void print_stats(const struct _stats *stats)

--- a/samples/basic/minimal/src/main.c
+++ b/samples/basic/minimal/src/main.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/samples/basic/rgb_led/src/main.c
+++ b/samples/basic/rgb_led/src/main.c
@@ -22,7 +22,7 @@ static const struct pwm_dt_spec blue_pwm_led =
 
 #define STEP_SIZE PWM_USEC(2000)
 
-void main(void)
+int main(void)
 {
 	uint32_t pulse_red, pulse_green, pulse_blue; /* pulse widths */
 	int ret;
@@ -33,7 +33,7 @@ void main(void)
 	    !device_is_ready(green_pwm_led.dev) ||
 	    !device_is_ready(blue_pwm_led.dev)) {
 		printk("Error: one or more PWM devices not ready\n");
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -42,7 +42,7 @@ void main(void)
 			ret = pwm_set_pulse_dt(&red_pwm_led, pulse_red);
 			if (ret != 0) {
 				printk("Error %d: red write failed\n", ret);
-				return;
+				return 0;
 			}
 
 			for (pulse_green = 0U;
@@ -53,7 +53,7 @@ void main(void)
 				if (ret != 0) {
 					printk("Error %d: green write failed\n",
 					       ret);
-					return;
+					return 0;
 				}
 
 				for (pulse_blue = 0U;
@@ -65,11 +65,12 @@ void main(void)
 						printk("Error %d: "
 						       "blue write failed\n",
 						       ret);
-						return;
+						return 0;
 					}
 					k_sleep(K_SECONDS(1));
 				}
 			}
 		}
 	}
+	return 0;
 }

--- a/samples/basic/servo_motor/src/main.c
+++ b/samples/basic/servo_motor/src/main.c
@@ -24,7 +24,7 @@ enum direction {
 	UP,
 };
 
-void main(void)
+int main(void)
 {
 	uint32_t pulse_width = min_pulse;
 	enum direction dir = UP;
@@ -34,14 +34,14 @@ void main(void)
 
 	if (!device_is_ready(servo.dev)) {
 		printk("Error: PWM device %s is not ready\n", servo.dev->name);
-		return;
+		return 0;
 	}
 
 	while (1) {
 		ret = pwm_set_pulse_dt(&servo, pulse_width);
 		if (ret < 0) {
 			printk("Error %d: failed to set pulse width\n", ret);
-			return;
+			return 0;
 		}
 
 		if (dir == DOWN) {
@@ -62,4 +62,5 @@ void main(void)
 
 		k_sleep(K_SECONDS(1));
 	}
+	return 0;
 }

--- a/samples/basic/sys_heap/src/main.c
+++ b/samples/basic/sys_heap/src/main.c
@@ -14,7 +14,7 @@ static struct sys_heap heap;
 
 void print_sys_memory_stats(void);
 
-void main(void)
+int main(void)
 {
 	void *p;
 
@@ -31,6 +31,7 @@ void main(void)
 
 	sys_heap_free(&heap, p);
 	print_sys_memory_stats();
+	return 0;
 }
 
 void print_sys_memory_stats(void)

--- a/samples/bluetooth/beacon/src/main.c
+++ b/samples/bluetooth/beacon/src/main.c
@@ -74,7 +74,7 @@ static void bt_ready(int err)
 	printk("Beacon started, advertising as %s\n", addr_s);
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -85,4 +85,5 @@ void main(void)
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}
+	return 0;
 }

--- a/samples/bluetooth/broadcast_audio_sink/src/main.c
+++ b/samples/bluetooth/broadcast_audio_sink/src/main.c
@@ -580,14 +580,14 @@ static int stop_adv(void)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = init();
 	if (err) {
 		printk("Init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	for (size_t i = 0U; i < ARRAY_SIZE(streams_p); i++) {
@@ -646,7 +646,7 @@ void main(void)
 		if (err != 0 && err != -EALREADY) {
 			printk("Unable to start scan for broadcast sources: %d\n",
 			       err);
-			return;
+			return 0;
 		}
 
 		err = k_sem_take(&sem_broadcaster_found, SEM_TIMEOUT);
@@ -700,10 +700,11 @@ wait_for_pa_sync:
 						 streams_p, sink_broadcast_code);
 		if (err != 0) {
 			printk("Unable to sync to broadcast source: %d\n", err);
-			return;
+			return 0;
 		}
 
 		printk("Waiting for PA disconnected\n");
 		k_sem_take(&sem_pa_sync_lost, K_FOREVER);
 	}
+	return 0;
 }

--- a/samples/bluetooth/broadcast_audio_source/src/main.c
+++ b/samples/bluetooth/broadcast_audio_source/src/main.c
@@ -130,7 +130,7 @@ static int setup_broadcast_source(struct bt_bap_broadcast_source **source)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	struct bt_le_ext_adv *adv;
 	int err;
@@ -138,7 +138,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 	printk("Bluetooth initialized\n");
 
@@ -161,7 +161,7 @@ void main(void)
 		if (err != 0) {
 			printk("Unable to create extended advertising set: %d\n",
 			       err);
-			return;
+			return 0;
 		}
 
 		/* Set periodic advertising parameters */
@@ -169,20 +169,20 @@ void main(void)
 		if (err) {
 			printk("Failed to set periodic advertising parameters"
 			" (err %d)\n", err);
-			return;
+			return 0;
 		}
 
 		printk("Creating broadcast source\n");
 		err = setup_broadcast_source(&broadcast_source);
 		if (err != 0) {
 			printk("Unable to setup broadcast source: %d\n", err);
-			return;
+			return 0;
 		}
 
 		err = bt_bap_broadcast_source_get_id(broadcast_source, &broadcast_id);
 		if (err != 0) {
 			printk("Unable to get broadcast ID: %d\n", err);
-			return;
+			return 0;
 		}
 
 		/* Setup extended advertising data */
@@ -195,14 +195,14 @@ void main(void)
 		if (err != 0) {
 			printk("Failed to set extended advertising data: %d\n",
 			       err);
-			return;
+			return 0;
 		}
 
 		/* Setup periodic advertising data */
 		err = bt_bap_broadcast_source_get_base(broadcast_source, &base_buf);
 		if (err != 0) {
 			printk("Failed to get encoded BASE: %d\n", err);
-			return;
+			return 0;
 		}
 
 		per_ad.type = BT_DATA_SVC_DATA16;
@@ -212,7 +212,7 @@ void main(void)
 		if (err != 0) {
 			printk("Failed to set periodic advertising data: %d\n",
 			       err);
-			return;
+			return 0;
 		}
 
 		/* Start extended advertising */
@@ -220,7 +220,7 @@ void main(void)
 		if (err) {
 			printk("Failed to start extended advertising: %d\n",
 			       err);
-			return;
+			return 0;
 		}
 
 		/* Enable Periodic Advertising */
@@ -228,7 +228,7 @@ void main(void)
 		if (err) {
 			printk("Failed to enable periodic advertising: %d\n",
 			       err);
-			return;
+			return 0;
 		}
 
 		printk("Starting broadcast source\n");
@@ -236,7 +236,7 @@ void main(void)
 		err = bt_bap_broadcast_source_start(broadcast_source, adv);
 		if (err != 0) {
 			printk("Unable to start broadcast source: %d\n", err);
-			return;
+			return 0;
 		}
 
 		/* Wait for all to be started */
@@ -261,7 +261,7 @@ void main(void)
 		err = bt_bap_broadcast_source_stop(broadcast_source);
 		if (err != 0) {
 			printk("Unable to stop broadcast source: %d\n", err);
-			return;
+			return 0;
 		}
 
 		/* Wait for all to be stopped */
@@ -274,7 +274,7 @@ void main(void)
 		err = bt_bap_broadcast_source_delete(broadcast_source);
 		if (err != 0) {
 			printk("Unable to delete broadcast source: %d\n", err);
-			return;
+			return 0;
 		}
 		printk("Broadcast source deleted\n");
 		broadcast_source = NULL;
@@ -284,21 +284,22 @@ void main(void)
 		if (err) {
 			printk("Failed to stop periodic advertising (err %d)\n",
 			       err);
-			return;
+			return 0;
 		}
 
 		err = bt_le_ext_adv_stop(adv);
 		if (err) {
 			printk("Failed to stop extended advertising (err %d)\n",
 			       err);
-			return;
+			return 0;
 		}
 
 		err = bt_le_ext_adv_delete(adv);
 		if (err) {
 			printk("Failed to delete extended advertising (err %d)\n",
 			       err);
-			return;
+			return 0;
 		}
 	}
+	return 0;
 }

--- a/samples/bluetooth/broadcaster/src/main.c
+++ b/samples/bluetooth/broadcaster/src/main.c
@@ -20,7 +20,7 @@ static const struct bt_data ad[] = {
 	BT_DATA(BT_DATA_MANUFACTURER_DATA, mfg_data, 3),
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -30,7 +30,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Bluetooth initialized\n");
@@ -45,7 +45,7 @@ void main(void)
 				      NULL, 0);
 		if (err) {
 			printk("Advertising failed to start (err %d)\n", err);
-			return;
+			return 0;
 		}
 
 		k_msleep(1000);
@@ -53,10 +53,11 @@ void main(void)
 		err = bt_le_adv_stop();
 		if (err) {
 			printk("Advertising failed to stop (err %d)\n", err);
-			return;
+			return 0;
 		}
 
 		mfg_data[2]++;
 
 	} while (1);
+	return 0;
 }

--- a/samples/bluetooth/broadcaster_multiple/src/main.c
+++ b/samples/bluetooth/broadcaster_multiple/src/main.c
@@ -8,11 +8,12 @@
 
 int broadcaster_multiple(void);
 
-void main(void)
+int main(void)
 {
 	printk("Starting Multiple Broadcaster Demo\n");
 
 	(void)broadcaster_multiple();
 
 	printk("Exiting %s thread.\n", __func__);
+	return 0;
 }

--- a/samples/bluetooth/bthome_sensor_template/src/main.c
+++ b/samples/bluetooth/bthome_sensor_template/src/main.c
@@ -51,7 +51,7 @@ static void bt_ready(int err)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 	int temp = 0;
@@ -62,7 +62,7 @@ void main(void)
 	err = bt_enable(bt_ready);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	for (;;) {
@@ -78,4 +78,5 @@ void main(void)
 		}
 		k_sleep(K_MSEC(BT_GAP_ADV_SLOW_INT_MIN));
 	}
+	return 0;
 }

--- a/samples/bluetooth/central/src/main.c
+++ b/samples/bluetooth/central/src/main.c
@@ -121,17 +121,18 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected,
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Bluetooth initialized\n");
 
 	start_scan();
+	return 0;
 }

--- a/samples/bluetooth/central_gatt_write/src/main.c
+++ b/samples/bluetooth/central_gatt_write/src/main.c
@@ -8,7 +8,8 @@
 
 extern uint32_t central_gatt_write(uint32_t count);
 
-void main(void)
+int main(void)
 {
 	(void)central_gatt_write(0U);
+	return 0;
 }

--- a/samples/bluetooth/central_hr/src/main.c
+++ b/samples/bluetooth/central_hr/src/main.c
@@ -240,17 +240,18 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected,
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 	err = bt_enable(NULL);
 
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Bluetooth initialized\n");
 
 	start_scan();
+	return 0;
 }

--- a/samples/bluetooth/central_ht/src/main.c
+++ b/samples/bluetooth/central_ht/src/main.c
@@ -263,14 +263,14 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected,
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Bluetooth initialized\n");
@@ -279,8 +279,9 @@ void main(void)
 
 	if (err) {
 		printk("Scanning failed to start (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Scanning successfully started\n");
+	return 0;
 }

--- a/samples/bluetooth/central_iso/src/main.c
+++ b/samples/bluetooth/central_iso/src/main.c
@@ -218,7 +218,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected,
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 	struct bt_iso_chan *channels[1];
@@ -228,7 +228,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
@@ -257,10 +257,11 @@ void main(void)
 
 	if (err != 0) {
 		printk("Failed to create CIG (%d)\n", err);
-		return;
+		return 0;
 	}
 
 	start_scan();
 
 	k_work_init_delayable(&iso_send_work, iso_timer_timeout);
+	return 0;
 }

--- a/samples/bluetooth/central_multilink/src/main.c
+++ b/samples/bluetooth/central_multilink/src/main.c
@@ -10,7 +10,8 @@
 
 int init_central(uint8_t iterations);
 
-void main(void)
+int main(void)
 {
 	(void)init_central(CONFIG_SAMPLE_CONN_ITERATIONS);
+	return 0;
 }

--- a/samples/bluetooth/central_otc/src/main.c
+++ b/samples/bluetooth/central_otc/src/main.c
@@ -645,7 +645,7 @@ static void bt_otc_init(void)
 	bt_ots_client_register(&otc);
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -659,11 +659,12 @@ void main(void)
 
 	if (err != 0) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	bt_otc_init();
 	printk("Bluetooth OTS client sample running\n");
 
 	start_scan();
+	return 0;
 }

--- a/samples/bluetooth/central_past/src/main.c
+++ b/samples/bluetooth/central_past/src/main.c
@@ -228,7 +228,7 @@ static struct bt_le_per_adv_sync_cb sync_callbacks = {
 	.recv = recv_cb
 };
 
-void main(void)
+int main(void)
 {
 	struct bt_le_per_adv_sync_param sync_create_param;
 	struct bt_le_per_adv_sync *sync;
@@ -241,7 +241,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err != 0) {
 		printk("failed to enable BT (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Connection callbacks register\n");
@@ -257,7 +257,7 @@ void main(void)
 	err = bt_le_scan_start(BT_LE_SCAN_ACTIVE, NULL);
 	if (err != 0) {
 		printk("failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 	printk("success.\n");
 
@@ -266,7 +266,7 @@ void main(void)
 		err = k_sem_take(&sem_conn, K_FOREVER);
 		if (err != 0) {
 			printk("Could not take sem_conn (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("Connected.\n");
 
@@ -275,7 +275,7 @@ void main(void)
 		err = bt_le_scan_start(BT_LE_SCAN_ACTIVE, NULL);
 		if (err != 0) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("Scan started.\n");
 
@@ -283,7 +283,7 @@ void main(void)
 		err = k_sem_take(&sem_per_adv, K_FOREVER);
 		if (err != 0) {
 			printk("Could not take sem_per_adv (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("Found periodic advertising.\n");
 
@@ -297,7 +297,7 @@ void main(void)
 		err = bt_le_per_adv_sync_create(&sync_create_param, &sync);
 		if (err != 0) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("success.\n");
 
@@ -305,7 +305,7 @@ void main(void)
 		err = k_sem_take(&sem_per_sync, K_FOREVER);
 		if (err != 0) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("Periodic sync established.\n");
 
@@ -313,14 +313,14 @@ void main(void)
 		err = bt_le_per_adv_sync_transfer(sync, default_conn, 0);
 		if (err != 0) {
 			printk("Could not transfer sync (err %d)\n", err);
-			return;
+			return 0;
 		}
 
 		printk("Waiting for connection lost...\n");
 		err = k_sem_take(&sem_conn_lost, K_FOREVER);
 		if (err != 0) {
 			printk("Could not take sem_conn_lost (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("Connection lost.\n");
 	} while (true);

--- a/samples/bluetooth/direct_adv/src/main.c
+++ b/samples/bluetooth/direct_adv/src/main.c
@@ -149,14 +149,14 @@ static struct bt_conn_auth_info_cb bt_conn_auth_info = {
 	.pairing_complete = pairing_complete
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	bt_ready();
@@ -165,4 +165,5 @@ void main(void)
 	while (1) {
 		k_sleep(K_FOREVER);
 	}
+	return 0;
 }

--- a/samples/bluetooth/direction_finding_central/src/main.c
+++ b/samples/bluetooth/direction_finding_central/src/main.c
@@ -283,17 +283,18 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.cte_report_cb = cte_recv_cb,
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Bluetooth initialized\n");
 
 	start_scan();
+	return 0;
 }

--- a/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
@@ -364,7 +364,7 @@ static void scan_disable(void)
 	scan_enabled = false;
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -388,7 +388,7 @@ void main(void)
 		err = k_sem_take(&sem_per_adv, K_FOREVER);
 		if (err != 0) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("success. Found periodic advertising.\n");
 
@@ -410,7 +410,7 @@ void main(void)
 
 			err = delete_sync();
 			if (err != 0) {
-				return;
+				return 0;
 			}
 
 			continue;
@@ -427,8 +427,9 @@ void main(void)
 		err = k_sem_take(&sem_per_sync_lost, K_FOREVER);
 		if (err != 0) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("Periodic sync lost.\n");
 	} while (true);
+	return 0;
 }

--- a/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
@@ -72,7 +72,7 @@ static void adv_sent_cb(struct bt_le_ext_adv *adv,
 	       adv, info->num_sent);
 }
 
-void main(void)
+int main(void)
 {
 	char addr_s[BT_ADDR_LE_STR_LEN];
 	struct bt_le_oob oob_local;
@@ -85,7 +85,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 	printk("success\n");
 
@@ -93,7 +93,7 @@ void main(void)
 	err = bt_le_ext_adv_create(&param, &adv_callbacks, &adv_set);
 	if (err) {
 		printk("failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 	printk("success\n");
 
@@ -101,7 +101,7 @@ void main(void)
 	err = bt_df_set_adv_cte_tx_param(adv_set, &cte_params);
 	if (err) {
 		printk("failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 	printk("success\n");
 
@@ -109,7 +109,7 @@ void main(void)
 	err = bt_le_per_adv_set_param(adv_set, &per_adv_param);
 	if (err) {
 		printk("failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 	printk("success\n");
 
@@ -117,7 +117,7 @@ void main(void)
 	err = bt_df_adv_cte_tx_enable(adv_set);
 	if (err) {
 		printk("failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 	printk("success\n");
 
@@ -125,7 +125,7 @@ void main(void)
 	err = bt_le_per_adv_start(adv_set);
 	if (err) {
 		printk("failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 	printk("success\n");
 
@@ -133,7 +133,7 @@ void main(void)
 	err = bt_le_ext_adv_start(adv_set, &ext_adv_start_param);
 	if (err) {
 		printk("failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 	printk("success\n");
 
@@ -141,11 +141,12 @@ void main(void)
 	err = bt_le_ext_adv_oob_get_local(adv_set, &oob_local);
 	if (err) {
 		printk("failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 	printk("success\n");
 
 	bt_addr_le_to_str(&oob_local.addr, addr_s, sizeof(addr_s));
 
 	printk("Started extended advertising as %s\n", addr_s);
+	return 0;
 }

--- a/samples/bluetooth/direction_finding_peripheral/src/main.c
+++ b/samples/bluetooth/direction_finding_peripheral/src/main.c
@@ -108,15 +108,16 @@ static void bt_ready(void)
 	printk("Advertising successfully started\n");
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	bt_ready();
+	return 0;
 }

--- a/samples/bluetooth/eddystone/src/main.c
+++ b/samples/bluetooth/eddystone/src/main.c
@@ -681,7 +681,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected,
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -692,4 +692,5 @@ void main(void)
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}
+	return 0;
 }

--- a/samples/bluetooth/handsfree/src/main.c
+++ b/samples/bluetooth/handsfree/src/main.c
@@ -114,7 +114,7 @@ static void handsfree_enable(void)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -124,4 +124,5 @@ void main(void)
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}
+	return 0;
 }

--- a/samples/bluetooth/hap_ha/src/main.c
+++ b/samples/bluetooth/hap_ha/src/main.c
@@ -148,14 +148,14 @@ BT_IAS_CB_DEFINE(ias_callbacks) = {
 };
 #endif /* CONFIG_BT_IAS */
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(NULL);
 	if (err != 0) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Bluetooth initialized\n");
@@ -163,40 +163,40 @@ void main(void)
 	err = has_server_init();
 	if (err != 0) {
 		printk("HAS Server init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	err = bap_unicast_sr_init();
 	if (err != 0) {
 		printk("BAP Unicast Server init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	if (IS_ENABLED(CONFIG_HAP_HA_HEARING_AID_BINAURAL)) {
 		err = csip_set_member_init();
 		if (err != 0) {
 			printk("CSIP Set Member init failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 
 		err = csip_generate_rsi(csis_rsi_addata);
 		if (err != 0) {
 			printk("Failed to generate RSI (err %d)\n", err);
-			return;
+			return 0;
 		}
 	}
 
 	err = vcp_vol_renderer_init();
 	if (err != 0) {
 		printk("VCP Volume Renderer init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	if (IS_ENABLED(CONFIG_BT_ASCS_ASE_SRC)) {
 		err = micp_mic_dev_init();
 		if (err != 0) {
 			printk("MICP Microphone Device init failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 	}
 
@@ -204,7 +204,7 @@ void main(void)
 		err = ccp_call_ctrl_init();
 		if (err != 0) {
 			printk("MICP Microphone Device init failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 	}
 
@@ -234,4 +234,5 @@ void main(void)
 
 	k_work_init_delayable(&adv_work, adv_work_handler);
 	k_work_schedule(&adv_work, K_NO_WAIT);
+	return 0;
 }

--- a/samples/bluetooth/hci_pwr_ctrl/src/main.c
+++ b/samples/bluetooth/hci_pwr_ctrl/src/main.c
@@ -277,7 +277,7 @@ void modulate_tx_power(void *p1, void *p2, void *p3)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	int8_t txp_get = 0xFF;
 	int err;
@@ -312,4 +312,5 @@ void main(void)
 		hrs_notify();
 		k_sleep(K_SECONDS(2));
 	}
+	return 0;
 }

--- a/samples/bluetooth/hci_rpmsg/src/main.c
+++ b/samples/bluetooth/hci_rpmsg/src/main.c
@@ -355,7 +355,7 @@ static struct ipc_ept_cfg hci_ept_cfg = {
 	},
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 	const struct device *hci_ipc_instance =
@@ -396,4 +396,5 @@ void main(void)
 		buf = net_buf_get(&rx_queue, K_FOREVER);
 		hci_rpmsg_send(buf, HCI_REGULAR_MSG);
 	}
+	return 0;
 }

--- a/samples/bluetooth/hci_spi/src/main.c
+++ b/samples/bluetooth/hci_spi/src/main.c
@@ -280,7 +280,7 @@ static int hci_spi_init(void)
 
 SYS_INIT(hci_spi_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 
-void main(void)
+int main(void)
 {
 	static K_FIFO_DEFINE(rx_queue);
 	struct bt_hci_evt_hdr *evt_hdr;
@@ -293,7 +293,7 @@ void main(void)
 	err = bt_enable_raw(&rx_queue);
 	if (err) {
 		LOG_ERR("bt_enable_raw: %d; aborting", err);
-		return;
+		return 0;
 	}
 
 	/* Spawn the TX thread, which feeds cmds and data to the controller */
@@ -313,7 +313,7 @@ void main(void)
 	if (err) {
 		LOG_ERR("can't send initialization event; aborting");
 		k_thread_abort(tx_id);
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -323,4 +323,5 @@ void main(void)
 			LOG_ERR("Failed to send");
 		}
 	}
+	return 0;
 }

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -354,7 +354,7 @@ static int hci_uart_init(void)
 
 SYS_INIT(hci_uart_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 
-void main(void)
+int main(void)
 {
 	/* incoming events and data from the controller */
 	static K_FIFO_DEFINE(rx_queue);
@@ -409,4 +409,5 @@ void main(void)
 			LOG_ERR("Failed to send");
 		}
 	}
+	return 0;
 }

--- a/samples/bluetooth/hci_usb/src/main.c
+++ b/samples/bluetooth/hci_usb/src/main.c
@@ -71,7 +71,7 @@ static int enable_usb_device_next(void)
 }
 #endif /* CONFIG_USB_DEVICE_STACK_NEXT */
 
-void main(void)
+int main(void)
 {
 	int ret;
 
@@ -83,8 +83,9 @@ void main(void)
 
 	if (ret != 0) {
 		printk("Failed to enable USB");
-		return;
+		return 0;
 	}
 
 	printk("Bluetooth over USB sample\n");
+	return 0;
 }

--- a/samples/bluetooth/hci_usb_h4/src/main.c
+++ b/samples/bluetooth/hci_usb_h4/src/main.c
@@ -8,15 +8,16 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/usb/usb_device.h>
 
-void main(void)
+int main(void)
 {
 	int ret;
 
 	ret = usb_enable(NULL);
 	if (ret != 0) {
 		printk("Failed to enable USB");
-		return;
+		return 0;
 	}
 
 	printk("Bluetooth H:4 over USB sample\n");
+	return 0;
 }

--- a/samples/bluetooth/ibeacon/src/main.c
+++ b/samples/bluetooth/ibeacon/src/main.c
@@ -60,7 +60,7 @@ static void bt_ready(int err)
 	printk("iBeacon started\n");
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -71,4 +71,5 @@ void main(void)
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}
+	return 0;
 }

--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -308,11 +308,12 @@ static void listen(void)
 	net_context_put(tcp_recv6);
 }
 
-void main(void)
+int main(void)
 {
 	init_app();
 
 	k_thread_create(&thread_data, thread_stack, STACKSIZE,
 			(k_thread_entry_t)listen,
 			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+	return 0;
 }

--- a/samples/bluetooth/iso_broadcast/src/main.c
+++ b/samples/bluetooth/iso_broadcast/src/main.c
@@ -73,7 +73,7 @@ static struct bt_iso_big_create_param big_create_param = {
 	.framing = 0, /* 0 - unframed, 1 - framed */
 };
 
-void main(void)
+int main(void)
 {
 	uint32_t timeout_counter = INITIAL_TIMEOUT_COUNTER;
 	struct bt_le_ext_adv *adv;
@@ -89,14 +89,14 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	/* Create a non-connectable non-scannable advertising set */
 	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, &adv);
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	/* Set periodic advertising parameters */
@@ -104,28 +104,28 @@ void main(void)
 	if (err) {
 		printk("Failed to set periodic advertising parameters"
 		       " (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	/* Enable Periodic Advertising */
 	err = bt_le_per_adv_start(adv);
 	if (err) {
 		printk("Failed to enable periodic advertising (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	/* Start extended advertising */
 	err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
 	if (err) {
 		printk("Failed to start extended advertising (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	/* Create BIG */
 	err = bt_iso_big_create(adv, &big_create_param, &big);
 	if (err) {
 		printk("Failed to create BIG (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	for (uint8_t chan = 0U; chan < BIS_ISO_CHAN_COUNT; chan++) {
@@ -133,7 +133,7 @@ void main(void)
 		err = k_sem_take(&sem_big_cmplt, K_FOREVER);
 		if (err) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("BIG create complete chan %u.\n", chan);
 	}
@@ -151,7 +151,7 @@ void main(void)
 			if (!buf) {
 				printk("Data buffer allocate timeout on channel"
 				       " %u\n", chan);
-				return;
+				return 0;
 			}
 			net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 			sys_put_le32(iso_send_count, iso_data);
@@ -162,7 +162,7 @@ void main(void)
 				printk("Unable to broadcast data on channel %u"
 				       " : %d", chan, ret);
 				net_buf_unref(buf);
-				return;
+				return 0;
 			}
 
 		}
@@ -182,7 +182,7 @@ void main(void)
 			err = bt_iso_big_terminate(big);
 			if (err) {
 				printk("failed (err %d)\n", err);
-				return;
+				return 0;
 			}
 			printk("done.\n");
 
@@ -193,7 +193,7 @@ void main(void)
 				err = k_sem_take(&sem_big_term, K_FOREVER);
 				if (err) {
 					printk("failed (err %d)\n", err);
-					return;
+					return 0;
 				}
 				printk("BIG terminate complete chan %u.\n",
 				       chan);
@@ -203,7 +203,7 @@ void main(void)
 			err = bt_iso_big_create(adv, &big_create_param, &big);
 			if (err) {
 				printk("failed (err %d)\n", err);
-				return;
+				return 0;
 			}
 			printk("done.\n");
 
@@ -214,7 +214,7 @@ void main(void)
 				err = k_sem_take(&sem_big_cmplt, K_FOREVER);
 				if (err) {
 					printk("failed (err %d)\n", err);
-					return;
+					return 0;
 				}
 				printk("BIG create complete chan %u.\n", chan);
 			}

--- a/samples/bluetooth/iso_broadcast_benchmark/src/main.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/main.c
@@ -50,7 +50,7 @@ static enum benchmark_role device_role_select(void)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 	enum benchmark_role role;
@@ -60,13 +60,13 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err != 0) {
 		LOG_INF("Bluetooth init failed (err %d)", err);
-		return;
+		return 0;
 	}
 
 	err = console_init();
 	if (err != 0) {
 		LOG_INF("Console init failed (err %d)", err);
-		return;
+		return 0;
 	}
 
 	LOG_INF("Bluetooth initialized");
@@ -93,4 +93,5 @@ void main(void)
 	}
 
 	LOG_INF("Exiting");
+	return 0;
 }

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -1080,7 +1080,7 @@ static int run_peripheral(void)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -1089,7 +1089,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err != 0) {
 		LOG_ERR("Bluetooth init failed: %d", err);
-		return;
+		return 0;
 	}
 
 	bt_conn_cb_register(&conn_callbacks);
@@ -1098,7 +1098,7 @@ void main(void)
 	err = console_init();
 	if (err != 0) {
 		LOG_ERR("Console init failed: %d", err);
-		return;
+		return 0;
 	}
 
 	LOG_INF("Bluetooth initialized");
@@ -1147,4 +1147,5 @@ void main(void)
 	}
 
 	LOG_INF("Exiting");
+	return 0;
 }

--- a/samples/bluetooth/iso_receive/src/main.c
+++ b/samples/bluetooth/iso_receive/src/main.c
@@ -281,7 +281,7 @@ static struct bt_iso_big_sync_param big_sync_param = {
 	.sync_timeout = 100, /* in 10 ms units */
 };
 
-void main(void)
+int main(void)
 {
 	struct bt_le_per_adv_sync_param sync_create_param;
 	struct bt_le_per_adv_sync *sync;
@@ -298,14 +298,14 @@ void main(void)
 
 	if (!device_is_ready(led_gpio.port)) {
 		printk("LED gpio device not ready.\n");
-		return;
+		return 0;
 	}
 	printk("done.\n");
 
 	printk("Configure GPIO pin...");
 	err = gpio_pin_configure_dt(&led_gpio, GPIO_OUTPUT_ACTIVE);
 	if (err) {
-		return;
+		return 0;
 	}
 	printk("done.\n");
 
@@ -316,7 +316,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Scan callbacks register...");
@@ -334,7 +334,7 @@ void main(void)
 		err = bt_le_scan_start(BT_LE_SCAN_CUSTOM, NULL);
 		if (err) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("success.\n");
 
@@ -351,7 +351,7 @@ void main(void)
 		err = k_sem_take(&sem_per_adv, K_FOREVER);
 		if (err) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("Found periodic advertising.\n");
 
@@ -359,7 +359,7 @@ void main(void)
 		err = bt_le_scan_stop();
 		if (err) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("success.\n");
 
@@ -375,7 +375,7 @@ void main(void)
 		err = bt_le_per_adv_sync_create(&sync_create_param, &sync);
 		if (err) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("success.\n");
 
@@ -388,7 +388,7 @@ void main(void)
 			err = bt_le_per_adv_sync_delete(sync);
 			if (err) {
 				printk("failed (err %d)\n", err);
-				return;
+				return 0;
 			}
 			continue;
 		}
@@ -407,7 +407,7 @@ void main(void)
 			err = bt_le_per_adv_sync_delete(sync);
 			if (err) {
 				printk("failed (err %d)\n", err);
-				return;
+				return 0;
 			}
 			continue;
 		}
@@ -418,7 +418,7 @@ big_sync_create:
 		err = bt_iso_big_sync(sync, &big_sync_param, &big);
 		if (err) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("success.\n");
 
@@ -437,7 +437,7 @@ big_sync_create:
 			err = bt_iso_big_terminate(big);
 			if (err) {
 				printk("failed (err %d)\n", err);
-				return;
+				return 0;
 			}
 			printk("done.\n");
 
@@ -463,7 +463,7 @@ big_sync_create:
 			err = k_sem_take(&sem_big_sync_lost, K_FOREVER);
 			if (err) {
 				printk("failed (err %d)\n", err);
-				return;
+				return 0;
 			}
 			printk("BIG sync lost chan %u.\n", chan);
 		}

--- a/samples/bluetooth/mesh/src/main.c
+++ b/samples/bluetooth/mesh/src/main.c
@@ -399,7 +399,7 @@ static void bt_ready(int err)
 	printk("Mesh initialized\n");
 }
 
-void main(void)
+int main(void)
 {
 	static struct k_work button_work;
 	int err = -1;
@@ -420,7 +420,7 @@ void main(void)
 	err = board_init(&button_work);
 	if (err) {
 		printk("Board init failed (err: %d)\n", err);
-		return;
+		return 0;
 	}
 
 	k_work_init_delayable(&onoff.work, onoff_timeout);
@@ -430,4 +430,5 @@ void main(void)
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}
+	return 0;
 }

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -263,7 +263,7 @@ void board_play(const char *str)
 	k_sem_give(&tune_sem);
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -272,7 +272,7 @@ void main(void)
 	err = board_init(&addr);
 	if (err) {
 		printk("Board initialization failed\n");
-		return;
+		return 0;
 	}
 
 	printk("Unicast address: 0x%04x\n", addr);
@@ -281,7 +281,7 @@ void main(void)
 	err = bt_enable(bt_ready);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -289,4 +289,5 @@ void main(void)
 		board_play_tune(tune_str);
 	}
 
+	return 0;
 }

--- a/samples/bluetooth/mesh_provisioner/src/main.c
+++ b/samples/bluetooth/mesh_provisioner/src/main.c
@@ -328,7 +328,7 @@ static void button_init(void)
 }
 #endif
 
-void main(void)
+int main(void)
 {
 	char uuid_hex_str[32 + 1];
 	int err;
@@ -339,7 +339,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Bluetooth initialized\n");
@@ -388,4 +388,5 @@ void main(void)
 
 		printk("Added node 0x%04x\n", node_addr);
 	}
+	return 0;
 }

--- a/samples/bluetooth/mtu_update/central/src/main.c
+++ b/samples/bluetooth/mtu_update/central/src/main.c
@@ -12,7 +12,8 @@
 
 extern void run_central_sample(bt_gatt_notify_func_t cb);
 
-void main(void)
+int main(void)
 {
 	run_central_sample(NULL);
+	return 0;
 }

--- a/samples/bluetooth/mtu_update/peripheral/src/main.c
+++ b/samples/bluetooth/mtu_update/peripheral/src/main.c
@@ -11,7 +11,7 @@
 
 extern void run_peripheral_sample(uint8_t *notify_data, size_t notify_data_size, uint16_t seconds);
 
-void main(void)
+int main(void)
 {
 	uint8_t notify_data[100] = {};
 
@@ -19,4 +19,5 @@ void main(void)
 	notify_data[99] = 0x55;
 
 	run_peripheral_sample(notify_data, sizeof(notify_data), 0);
+	return 0;
 }

--- a/samples/bluetooth/observer/src/main.c
+++ b/samples/bluetooth/observer/src/main.c
@@ -9,7 +9,7 @@
 
 int observer_start(void);
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -19,10 +19,11 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	(void)observer_start();
 
 	printk("Exiting %s thread.\n", __func__);
+	return 0;
 }

--- a/samples/bluetooth/periodic_adv/src/main.c
+++ b/samples/bluetooth/periodic_adv/src/main.c
@@ -12,7 +12,7 @@ static const struct bt_data ad[] = {
 	BT_DATA(BT_DATA_MANUFACTURER_DATA, mfg_data, 3),
 };
 
-void main(void)
+int main(void)
 {
 	struct bt_le_ext_adv *adv;
 	int err;
@@ -23,14 +23,14 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	/* Create a non-connectable non-scannable advertising set */
 	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, NULL, &adv);
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	/* Set periodic advertising parameters */
@@ -38,14 +38,14 @@ void main(void)
 	if (err) {
 		printk("Failed to set periodic advertising parameters"
 		       " (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	/* Enable Periodic Advertising */
 	err = bt_le_per_adv_start(adv);
 	if (err) {
 		printk("Failed to enable periodic advertising (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	while (true) {
@@ -54,7 +54,7 @@ void main(void)
 		if (err) {
 			printk("Failed to start extended advertising "
 			       "(err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("done.\n");
 
@@ -67,7 +67,7 @@ void main(void)
 			err = bt_le_per_adv_set_data(adv, ad, ARRAY_SIZE(ad));
 			if (err) {
 				printk("Failed (err %d)\n", err);
-				return;
+				return 0;
 			}
 			printk("done.\n");
 		}
@@ -79,10 +79,11 @@ void main(void)
 		if (err) {
 			printk("Failed to stop extended advertising "
 			       "(err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("done.\n");
 
 		k_sleep(K_SECONDS(10));
 	}
+	return 0;
 }

--- a/samples/bluetooth/periodic_sync/src/main.c
+++ b/samples/bluetooth/periodic_sync/src/main.c
@@ -155,7 +155,7 @@ static struct bt_le_per_adv_sync_cb sync_callbacks = {
 	.recv = recv_cb
 };
 
-void main(void)
+int main(void)
 {
 	struct bt_le_per_adv_sync_param sync_create_param;
 	struct bt_le_per_adv_sync *sync;
@@ -167,7 +167,7 @@ void main(void)
 	printk("Checking LED device...");
 	if (!device_is_ready(led.port)) {
 		printk("failed.\n");
-		return;
+		return 0;
 	}
 	printk("done.\n");
 
@@ -175,7 +175,7 @@ void main(void)
 	err = gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
 	if (err) {
 		printk("failed.\n");
-		return;
+		return 0;
 	}
 	printk("done.\n");
 
@@ -186,7 +186,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Scan callbacks register...");
@@ -201,7 +201,7 @@ void main(void)
 	err = bt_le_scan_start(BT_LE_SCAN_ACTIVE, NULL);
 	if (err) {
 		printk("failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 	printk("success.\n");
 
@@ -220,7 +220,7 @@ void main(void)
 		err = k_sem_take(&sem_per_adv, K_FOREVER);
 		if (err) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("Found periodic advertising.\n");
 
@@ -233,7 +233,7 @@ void main(void)
 		err = bt_le_per_adv_sync_create(&sync_create_param, &sync);
 		if (err) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("success.\n");
 
@@ -246,7 +246,7 @@ void main(void)
 			err = bt_le_per_adv_sync_delete(sync);
 			if (err) {
 				printk("failed (err %d)\n", err);
-				return;
+				return 0;
 			}
 			continue;
 		}
@@ -265,7 +265,7 @@ void main(void)
 		err = k_sem_take(&sem_per_sync_lost, K_FOREVER);
 		if (err) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("Periodic sync lost.\n");
 	} while (true);

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -346,7 +346,7 @@ static void hrs_notify(void)
 	bt_hrs_notify(heartrate);
 }
 
-void main(void)
+int main(void)
 {
 	struct bt_gatt_attr *vnd_ind_attr;
 	char str[BT_UUID_STR_LEN];
@@ -355,7 +355,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	bt_ready();
@@ -400,4 +400,5 @@ void main(void)
 			}
 		}
 	}
+	return 0;
 }

--- a/samples/bluetooth/peripheral_accept_list/src/main.c
+++ b/samples/bluetooth/peripheral_accept_list/src/main.c
@@ -151,14 +151,14 @@ static struct bt_conn_auth_info_cb bt_conn_auth_info = {
 	.pairing_complete = pairing_complete
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	bt_ready();
@@ -167,4 +167,5 @@ void main(void)
 	while (1) {
 		k_sleep(K_FOREVER);
 	}
+	return 0;
 }

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -396,14 +396,14 @@ static void bas_notify(void)
 	bt_bas_set_battery_level(battery_level);
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	bt_ready();
@@ -419,4 +419,5 @@ void main(void)
 		/* Battery level simulation */
 		bas_notify();
 	}
+	return 0;
 }

--- a/samples/bluetooth/peripheral_dis/src/main.c
+++ b/samples/bluetooth/peripheral_dis/src/main.c
@@ -78,14 +78,14 @@ static int settings_runtime_load(void)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
@@ -99,8 +99,9 @@ void main(void)
 	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Advertising successfully started\n");
+	return 0;
 }

--- a/samples/bluetooth/peripheral_esp/src/main.c
+++ b/samples/bluetooth/peripheral_esp/src/main.c
@@ -417,14 +417,14 @@ static void bas_notify(void)
 	bt_bas_set_battery_level(battery_level);
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	bt_ready();
@@ -442,4 +442,5 @@ void main(void)
 		/* Battery level simulation */
 		bas_notify();
 	}
+	return 0;
 }

--- a/samples/bluetooth/peripheral_gatt_write/src/main.c
+++ b/samples/bluetooth/peripheral_gatt_write/src/main.c
@@ -8,7 +8,8 @@
 
 extern uint32_t peripheral_gatt_write(uint32_t count);
 
-void main(void)
+int main(void)
 {
 	(void)peripheral_gatt_write(0U);
+	return 0;
 }

--- a/samples/bluetooth/peripheral_hids/src/main.c
+++ b/samples/bluetooth/peripheral_hids/src/main.c
@@ -127,14 +127,14 @@ static struct bt_conn_auth_cb auth_cb_display = {
 	.cancel = auth_cancel,
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(bt_ready);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	if (IS_ENABLED(CONFIG_SAMPLE_BT_USE_AUTHENTICATION)) {
@@ -143,4 +143,5 @@ void main(void)
 	}
 
 	hog_button_loop();
+	return 0;
 }

--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -103,14 +103,14 @@ static void hrs_notify(void)
 	bt_hrs_notify(heartrate);
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	bt_ready();
@@ -129,4 +129,5 @@ void main(void)
 		/* Battery level simulation */
 		bas_notify();
 	}
+	return 0;
 }

--- a/samples/bluetooth/peripheral_ht/src/main.c
+++ b/samples/bluetooth/peripheral_ht/src/main.c
@@ -93,14 +93,14 @@ static void bas_notify(void)
 	bt_bas_set_battery_level(battery_level);
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	bt_ready();
@@ -119,4 +119,5 @@ void main(void)
 		/* Battery level simulation */
 		bas_notify();
 	}
+	return 0;
 }

--- a/samples/bluetooth/peripheral_identity/src/main.c
+++ b/samples/bluetooth/peripheral_identity/src/main.c
@@ -10,7 +10,8 @@
 
 int init_peripheral(uint8_t iterations);
 
-void main(void)
+int main(void)
 {
 	(void)init_peripheral(CONFIG_SAMPLE_CONN_ITERATIONS);
+	return 0;
 }

--- a/samples/bluetooth/peripheral_iso/src/main.c
+++ b/samples/bluetooth/peripheral_iso/src/main.c
@@ -148,14 +148,14 @@ static struct bt_iso_server iso_server = {
 	.accept = iso_accept,
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
@@ -167,14 +167,15 @@ void main(void)
 	err = bt_iso_server_register(&iso_server);
 	if (err) {
 		printk("Unable to register ISO server (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Advertising successfully started\n");
+	return 0;
 }

--- a/samples/bluetooth/peripheral_ots/src/main.c
+++ b/samples/bluetooth/peripheral_ots/src/main.c
@@ -314,7 +314,7 @@ static int ots_init(void)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -323,7 +323,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Bluetooth initialized\n");
@@ -331,15 +331,16 @@ void main(void)
 	err = ots_init();
 	if (err) {
 		printk("Failed to init OTS (err:%d)\n", err);
-		return;
+		return 0;
 	}
 
 	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad),
 			      sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Advertising successfully started\n");
+	return 0;
 }

--- a/samples/bluetooth/peripheral_past/src/main.c
+++ b/samples/bluetooth/peripheral_past/src/main.c
@@ -110,7 +110,7 @@ static struct bt_conn_cb conn_callbacks = {
 	.disconnected = disconnected,
 };
 
-void main(void)
+int main(void)
 {
 	struct bt_le_per_adv_sync_transfer_param past_param;
 	int err;
@@ -121,7 +121,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Connection callbacks register...");
@@ -139,13 +139,13 @@ void main(void)
 						    &past_param);
 	if (err) {
 		printk("PAST subscribe failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, NULL, 0, NULL, 0);
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	do {
@@ -153,7 +153,7 @@ void main(void)
 		err = k_sem_take(&sem_per_sync, K_FOREVER);
 		if (err) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("Periodic sync established.\n");
 
@@ -161,8 +161,9 @@ void main(void)
 		err = k_sem_take(&sem_per_sync_lost, K_FOREVER);
 		if (err) {
 			printk("failed (err %d)\n", err);
-			return;
+			return 0;
 		}
 		printk("Periodic sync lost.\n");
 	} while (true);
+	return 0;
 }

--- a/samples/bluetooth/peripheral_sc_only/src/main.c
+++ b/samples/bluetooth/peripheral_sc_only/src/main.c
@@ -125,14 +125,14 @@ static struct bt_conn_auth_info_cb auth_cb_info = {
 	.pairing_failed = pairing_failed,
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Bluetooth initialized\n");
@@ -144,8 +144,9 @@ void main(void)
 	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Advertising successfully started\n");
+	return 0;
 }

--- a/samples/bluetooth/scan_adv/src/main.c
+++ b/samples/bluetooth/scan_adv/src/main.c
@@ -26,7 +26,7 @@ static void scan_cb(const bt_addr_le_t *addr, int8_t rssi, uint8_t adv_type,
 	mfg_data[2]++;
 }
 
-void main(void)
+int main(void)
 {
 	struct bt_le_scan_param scan_param = {
 		.type       = BT_HCI_LE_SCAN_PASSIVE,
@@ -42,7 +42,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Bluetooth initialized\n");
@@ -50,7 +50,7 @@ void main(void)
 	err = bt_le_scan_start(&scan_param, scan_cb);
 	if (err) {
 		printk("Starting scanning failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	do {
@@ -61,7 +61,7 @@ void main(void)
 				      NULL, 0);
 		if (err) {
 			printk("Advertising failed to start (err %d)\n", err);
-			return;
+			return 0;
 		}
 
 		k_sleep(K_MSEC(400));
@@ -69,7 +69,8 @@ void main(void)
 		err = bt_le_adv_stop();
 		if (err) {
 			printk("Advertising failed to stop (err %d)\n", err);
-			return;
+			return 0;
 		}
 	} while (1);
+	return 0;
 }

--- a/samples/bluetooth/st_ble_sensor/src/main.c
+++ b/samples/bluetooth/st_ble_sensor/src/main.c
@@ -178,18 +178,18 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected,
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = button_init(button_callback);
 	if (err) {
-		return;
+		return 0;
 	}
 
 	err = led_init();
 	if (err) {
-		return;
+		return 0;
 	}
 
 	/* Initialize the Bluetooth Subsystem */
@@ -197,4 +197,5 @@ void main(void)
 	if (err) {
 		LOG_ERR("Bluetooth init failed (err %d)", err);
 	}
+	return 0;
 }

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -1033,21 +1033,21 @@ static void reset_data(void)
 	configured_source_stream_count = 0;
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	printk("Initializing\n");
 	err = init();
 	if (err != 0) {
-		return;
+		return 0;
 	}
 	printk("Initialized\n");
 
 	err = bt_bap_unicast_client_register_cb(&unicast_client_cbs);
 	if (err != 0) {
 		printk("Failed to register client callbacks: %d", err);
-		return;
+		return 0;
 	}
 
 	while (true) {
@@ -1056,60 +1056,60 @@ void main(void)
 		printk("Waiting for connection\n");
 		err = scan_and_connect();
 		if (err != 0) {
-			return;
+			return 0;
 		}
 		printk("Connected\n");
 
 		printk("Discovering sinks\n");
 		err = discover_sinks();
 		if (err != 0) {
-			return;
+			return 0;
 		}
 		printk("Sinks discovered\n");
 
 		printk("Discovering sources\n");
 		err = discover_sources();
 		if (err != 0) {
-			return;
+			return 0;
 		}
 		printk("Sources discovered\n");
 
 		printk("Configuring streams\n");
 		err = configure_streams();
 		if (err != 0) {
-			return;
+			return 0;
 		}
 
 		if (configured_stream_count == 0U) {
 			printk("No streams were configured\n");
-			return;
+			return 0;
 		}
 
 		printk("Creating unicast group\n");
 		err = create_group();
 		if (err != 0) {
-			return;
+			return 0;
 		}
 		printk("Unicast group created\n");
 
 		printk("Setting stream QoS\n");
 		err = set_stream_qos();
 		if (err != 0) {
-			return;
+			return 0;
 		}
 		printk("Stream QoS Set\n");
 
 		printk("Enabling streams\n");
 		err = enable_streams();
 		if (err != 0) {
-			return;
+			return 0;
 		}
 		printk("Streams enabled\n");
 
 		printk("Starting streams\n");
 		err = start_streams();
 		if (err != 0) {
-			return;
+			return 0;
 		}
 		printk("Streams started\n");
 
@@ -1120,13 +1120,13 @@ void main(void)
 		err = k_sem_take(&sem_disconnected, K_FOREVER);
 		if (err != 0) {
 			printk("failed to take sem_disconnected (err %d)\n", err);
-			return;
+			return 0;
 		}
 
 		printk("Deleting group\n");
 		err = delete_group();
 		if (err != 0) {
-			return;
+			return 0;
 		}
 		printk("Group deleted\n");
 	}

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -717,7 +717,7 @@ static int set_available_contexts(void)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	struct bt_le_ext_adv *adv;
 	int err;
@@ -725,7 +725,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err != 0) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Bluetooth initialized\n");
@@ -746,30 +746,30 @@ void main(void)
 
 	err = set_location();
 	if (err != 0) {
-		return;
+		return 0;
 	}
 
 	err = set_supported_contexts();
 	if (err != 0) {
-		return;
+		return 0;
 	}
 
 	err = set_available_contexts();
 	if (err != 0) {
-		return;
+		return 0;
 	}
 
 	/* Create a non-connectable non-scannable advertising set */
 	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, NULL, &adv);
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	err = bt_le_ext_adv_set_data(adv, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		printk("Failed to set advertising data (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	while (true) {
@@ -778,7 +778,7 @@ void main(void)
 		err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
 		if (err) {
 			printk("Failed to start advertising set (err %d)\n", err);
-			return;
+			return 0;
 		}
 
 		printk("Advertising successfully started\n");
@@ -788,7 +788,7 @@ void main(void)
 		err = k_sem_take(&sem_disconnected, K_FOREVER);
 		if (err != 0) {
 			printk("failed to take sem_disconnected (err %d)\n", err);
-			return;
+			return 0;
 		}
 
 		/* reset data */
@@ -796,4 +796,5 @@ void main(void)
 		k_work_cancel_delayable_sync(&audio_send_work, &sync);
 
 	}
+	return 0;
 }

--- a/samples/boards/96b_argonkey/microphone/src/main.c
+++ b/samples/boards/96b_argonkey/microphone/src/main.c
@@ -70,19 +70,19 @@ void signal_print_stopped(void)
 void *rx_block[NUM_MS];
 size_t rx_size = PCM_BLK_SIZE_MS;
 
-void main(void)
+int main(void)
 {
 	int i;
 	uint32_t ms;
 
 	if (!device_is_ready(led0.port)) {
 		printk("LED0 GPIO controller device is not ready\n");
-		return;
+		return 0;
 	}
 
 	if (!device_is_ready(led1.port)) {
 		printk("LED1 GPIO controller device is not ready\n");
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_LP3943
@@ -90,7 +90,7 @@ void main(void)
 
 	if (!device_is_ready(ledc)) {
 		printk("Device %s is not ready\n", ledc->name);
-		return;
+		return 0;
 	}
 
 	/* turn all leds on */
@@ -115,19 +115,19 @@ void main(void)
 
 	if (!device_is_ready(mic_dev)) {
 		printk("Device %s is not ready\n", mic_dev->name);
-		return;
+		return 0;
 	}
 
 	ret = dmic_configure(mic_dev, &cfg);
 	if (ret < 0) {
 		printk("microphone configuration error\n");
-		return;
+		return 0;
 	}
 
 	ret = dmic_trigger(mic_dev, DMIC_TRIGGER_START);
 	if (ret < 0) {
 		printk("microphone start trigger error\n");
-		return;
+		return 0;
 	}
 
 	signal_sampling_started();
@@ -137,7 +137,7 @@ void main(void)
 		ret = dmic_read(mic_dev, 0, &rx_block[ms], &rx_size, 2000);
 		if (ret < 0) {
 			printk("microphone audio read error\n");
-			return;
+			return 0;
 		}
 	}
 
@@ -146,7 +146,7 @@ void main(void)
 	ret = dmic_trigger(mic_dev, DMIC_TRIGGER_STOP);
 	if (ret < 0) {
 		printk("microphone stop trigger error\n");
-		return;
+		return 0;
 	}
 
 	/* print PCM stream */
@@ -180,4 +180,5 @@ void main(void)
 #endif
 
 	signal_print_stopped();
+	return 0;
 }

--- a/samples/boards/96b_argonkey/sensors/src/main.c
+++ b/samples/boards/96b_argonkey/sensors/src/main.c
@@ -107,7 +107,7 @@ static void lsm6dsl_trigger_handler(const struct device *dev,
 #define NUM_LEDS 12
 #define DELAY_TIME K_MSEC(50)
 
-void main(void)
+int main(void)
 {
 	int cnt = 0;
 	char out_str[64];
@@ -118,7 +118,7 @@ void main(void)
 #ifdef CONFIG_LP3943
 	if (!device_is_ready(ledc)) {
 		printk("%s: device not ready.\n", ledc->name);
-		return;
+		return 0;
 	}
 
 	/* turn all leds on */
@@ -136,13 +136,13 @@ void main(void)
 
 	if (!device_is_ready(led0_gpio.port)) {
 		printk("%s: device not ready.\n", led0_gpio.port->name);
-		return;
+		return 0;
 	}
 	gpio_pin_configure_dt(&led0_gpio, GPIO_OUTPUT_ACTIVE);
 
 	if (!device_is_ready(led1_gpio.port)) {
 		printk("%s: device not ready.\n", led1_gpio.port->name);
-		return;
+		return 0;
 	}
 	gpio_pin_configure_dt(&led1_gpio, GPIO_OUTPUT_INACTIVE);
 
@@ -159,7 +159,7 @@ void main(void)
 
 	if (!device_is_ready(baro_dev)) {
 		printk("%s: device not ready.\n", baro_dev->name);
-		return;
+		return 0;
 	}
 #endif
 
@@ -168,7 +168,7 @@ void main(void)
 
 	if (!device_is_ready(hum_dev)) {
 		printk("%s: device not ready.\n", hum_dev->name);
-		return;
+		return 0;
 	}
 #endif
 
@@ -177,7 +177,7 @@ void main(void)
 
 	if (!device_is_ready(accel_dev)) {
 		printk("%s: device not ready.\n", accel_dev->name);
-		return;
+		return 0;
 	}
 
 #if defined(CONFIG_LSM6DSL_ACCEL_ODR) && (CONFIG_LSM6DSL_ACCEL_ODR == 0)
@@ -190,7 +190,7 @@ void main(void)
 	if (sensor_attr_set(accel_dev, SENSOR_CHAN_ACCEL_XYZ,
 			    SENSOR_ATTR_SAMPLING_FREQUENCY, &a_odr_attr) < 0) {
 		printk("Cannot set sampling frequency for accelerometer.\n");
-		return;
+		return 0;
 	}
 #endif
 
@@ -203,7 +203,7 @@ void main(void)
 	if (sensor_attr_set(accel_dev, SENSOR_CHAN_ACCEL_XYZ,
 			    SENSOR_ATTR_FULL_SCALE, &a_fs_attr) < 0) {
 		printk("Cannot set fs for accelerometer.\n");
-		return;
+		return 0;
 	}
 #endif
 
@@ -217,7 +217,7 @@ void main(void)
 	if (sensor_attr_set(accel_dev, SENSOR_CHAN_GYRO_XYZ,
 			    SENSOR_ATTR_SAMPLING_FREQUENCY, &g_odr_attr) < 0) {
 		printk("Cannot set sampling frequency for gyro.\n");
-		return;
+		return 0;
 	}
 #endif
 
@@ -230,7 +230,7 @@ void main(void)
 	if (sensor_attr_set(accel_dev, SENSOR_CHAN_GYRO_XYZ,
 			    SENSOR_ATTR_FULL_SCALE, &g_fs_attr) < 0) {
 		printk("Cannot set fs for gyroscope.\n");
-		return;
+		return 0;
 	}
 #endif
 
@@ -241,7 +241,7 @@ void main(void)
 
 	if (!device_is_ready(tof_dev)) {
 		printk("%s: device not ready.\n", tof_dev->name);
-		return;
+		return 0;
 	}
 #endif
 
@@ -253,7 +253,7 @@ void main(void)
 	if (sensor_trigger_set(accel_dev, &trig,
 			       lsm6dsl_trigger_handler) != 0) {
 		printk("Could not set sensor type and channel\n");
-		return;
+		return 0;
 	}
 #endif
 

--- a/samples/boards/arc_secure_services/src/main.c
+++ b/samples/boards/arc_secure_services/src/main.c
@@ -39,7 +39,7 @@ K_THREAD_DEFINE(thread_a, STACKSIZE, threadA, NULL, NULL, NULL,
 		PRIORITY, 0, 0);
 
 
-void main(void)
+int main(void)
 {
 	/* necessary configuration before go to normal */
 	int32_t i = 0;
@@ -56,4 +56,5 @@ void main(void)
 				 __func__, i++);
 		k_msleep(SLEEPTIME);
 	}
+	return 0;
 }

--- a/samples/boards/bbc_microbit/display/src/main.c
+++ b/samples/boards/bbc_microbit/display/src/main.c
@@ -58,7 +58,7 @@ static const struct mb_image animation[] = {
 		 { 1, 1, 1, 1, 1 }),
 };
 
-void main(void)
+int main(void)
 {
 	struct mb_display *disp = mb_display_get();
 	int x, y;
@@ -104,4 +104,5 @@ void main(void)
 	/* Show some scrolling text ("Hello Zephyr!") */
 	mb_display_print(disp, MB_DISPLAY_MODE_DEFAULT | MB_DISPLAY_FLAG_LOOP,
 			 500, "Hello Zephyr!");
+	return 0;
 }

--- a/samples/boards/bbc_microbit/line_follower_robot/src/main.c
+++ b/samples/boards/bbc_microbit/line_follower_robot/src/main.c
@@ -95,17 +95,17 @@ static void line_follow(void)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	if (!device_is_ready(left_gpio.port) ||
 	    !device_is_ready(right_gpio.port)) {
 		printk("Left/Right GPIO controllers not ready.\n");
-		return;
+		return 0;
 	}
 
 	if (!device_is_ready(motorctl.bus)) {
 		printk("Motor controller I2C bus not ready.\n");
-		return;
+		return 0;
 	}
 
 	/* Setup gpio to read data from digital line sensors of the robot */
@@ -123,4 +123,5 @@ void main(void)
 	while (1) {
 		line_follow();
 	}
+	return 0;
 }

--- a/samples/boards/bbc_microbit/pong/src/main.c
+++ b/samples/boards/bbc_microbit/pong/src/main.c
@@ -513,7 +513,7 @@ static void configure_buttons(void)
 	gpio_add_callback(sw0_gpio.port, &button_cb_data);
 }
 
-void main(void)
+int main(void)
 {
 	struct mb_display *disp = mb_display_get();
 
@@ -523,7 +523,7 @@ void main(void)
 
 	if (!device_is_ready(pwm.dev)) {
 		printk("%s: device not ready.\n", pwm.dev->name);
-		return;
+		return 0;
 	}
 
 	ble_init();
@@ -551,4 +551,5 @@ void main(void)
 		mb_display_image(disp, MB_DISPLAY_MODE_SINGLE,
 				 SYS_FOREVER_MS, &img, 1);
 	}
+	return 0;
 }

--- a/samples/boards/bbc_microbit/sound/src/main.c
+++ b/samples/boards/bbc_microbit/sound/src/main.c
@@ -81,19 +81,19 @@ static void button_pressed(const struct device *dev, struct gpio_callback *cb,
 	k_work_submit(&beep_work);
 }
 
-void main(void)
+int main(void)
 {
 	static struct gpio_callback button_cb_data;
 
 	if (!device_is_ready(pwm.dev)) {
 		printk("%s: device not ready.\n", pwm.dev->name);
-		return;
+		return 0;
 	}
 
 	/* since sw0_gpio.port == sw1_gpio.port, we only need to check ready once */
 	if (!device_is_ready(sw0_gpio.port)) {
 		printk("%s: device not ready.\n", sw0_gpio.port->name);
-		return;
+		return 0;
 	}
 
 	period = pwm.period;
@@ -112,4 +112,5 @@ void main(void)
 	k_work_submit(&beep_work);
 
 	gpio_add_callback(sw0_gpio.port, &button_cb_data);
+	return 0;
 }

--- a/samples/boards/esp32/deep_sleep/src/main.c
+++ b/samples/boards/esp32/deep_sleep/src/main.c
@@ -25,7 +25,7 @@ static const struct gpio_dt_spec wakeup_button = GPIO_DT_SPEC_GET(DT_ALIAS(wakeu
 #endif
 #endif
 
-void main(void)
+int main(void)
 {
 	switch (esp_sleep_get_wakeup_cause()) {
 #ifdef CONFIG_EXAMPLE_EXT1_WAKEUP
@@ -87,7 +87,7 @@ void main(void)
 #ifdef CONFIG_EXAMPLE_GPIO_WAKEUP
 	if (!device_is_ready(wakeup_button.port)) {
 		printk("Error: wakeup button device %s is not ready\n", wakeup_button.port->name);
-		return;
+		return 0;
 	}
 
 	int ret = gpio_pin_configure_dt(&wakeup_button, GPIO_INPUT);
@@ -95,7 +95,7 @@ void main(void)
 	if (ret != 0) {
 		printk("Error %d: failed to configure %s pin %d\n",
 				ret, wakeup_button.port->name, wakeup_button.pin);
-		return;
+		return 0;
 	}
 
 	esp_deep_sleep_enable_gpio_wakeup(BIT(wakeup_button.pin), ESP_GPIO_WAKEUP_GPIO_HIGH);

--- a/samples/boards/esp32/ethernet/src/main.c
+++ b/samples/boards/esp32/ethernet/src/main.c
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
 	/* NET_CONFIG_SETTINGS will init DHCP
 	 * NET_SHELL is enabled to test ping, DNS etc
 	 */
+	return 0;
 }

--- a/samples/boards/esp32/flash_encryption/src/main.c
+++ b/samples/boards/esp32/flash_encryption/src/main.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(flash_encryption, CONFIG_LOG_DEFAULT_LEVEL);
 #error Flash encryption feature is only available for ESP32 SOC yet.
 #endif
 
-void main(void)
+int main(void)
 {
 	uint8_t buffer[32];
 	const struct device *flash_device;
@@ -29,7 +29,7 @@ void main(void)
 	flash_device = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 	if (!device_is_ready(flash_device)) {
 		printk("%s: device not ready.\n", flash_device->name);
-		return;
+		return 0;
 	}
 
 	for (int k = 0; k < 32; k++) {
@@ -52,4 +52,5 @@ void main(void)
 	memset(buffer, 0, sizeof(buffer));
 	flash_read(flash_device, address, &buffer, sizeof(buffer));
 	LOG_HEXDUMP_INF(buffer, sizeof(buffer), "FLASH DECRYPTED DATA");
+	return 0;
 }

--- a/samples/boards/esp32/light_sleep/src/main.c
+++ b/samples/boards/esp32/light_sleep/src/main.c
@@ -27,11 +27,11 @@
 static const struct gpio_dt_spec button =
 	GPIO_DT_SPEC_GET_OR(SW0_NODE, gpios, {0});
 
-void main(void)
+int main(void)
 {
 	if (!device_is_ready(button.port)) {
 		printk("Error: button device %s is not ready\n", button.port->name);
-		return;
+		return 0;
 	}
 
 	const int wakeup_level = (button.dt_flags & GPIO_ACTIVE_LOW) ? 0 : 1;
@@ -91,4 +91,5 @@ void main(void)
 				wakeup_reason, t_after_ms, (t_after_ms - t_before_ms));
 	}
 
+	return 0;
 }

--- a/samples/boards/esp32/spiram_test/src/main.c
+++ b/samples/boards/esp32/spiram_test/src/main.c
@@ -67,7 +67,7 @@ ret:
 	return err;
 }
 
-void main(void)
+int main(void)
 {
 	int err = test_heap_caps(10001);
 
@@ -83,4 +83,5 @@ void main(void)
 	} else {
 		printk("Internal mem test pass\n");
 	}
+	return 0;
 }

--- a/samples/boards/google_kukui/src/main.c
+++ b/samples/boards/google_kukui/src/main.c
@@ -7,7 +7,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 
-void main(void)
+int main(void)
 {
 	printk("Welcome to Google Kukui\n");
+	return 0;
 }

--- a/samples/boards/intel_adsp/code_relocation/src/main.c
+++ b/samples/boards/intel_adsp/code_relocation/src/main.c
@@ -8,9 +8,10 @@
 
 extern void reloc(void);
 
-void main(void)
+int main(void)
 {
 	printk("%s location: %p\n", __func__, main);
 	printk("Calling relocated code\n");
 	reloc();
+	return 0;
 }

--- a/samples/boards/litex/i2s/src/main.c
+++ b/samples/boards/litex/i2s/src/main.c
@@ -83,7 +83,7 @@ static void init(void)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	init();
 
@@ -112,4 +112,5 @@ void main(void)
 		i2s_write(host_i2s_tx_dev, tx_mem_block, size);
 		k_mem_slab_free(&i2s_rx_mem_slab, &rx_mem_block);
 	}
+	return 0;
 }

--- a/samples/boards/mec15xxevb_assy6853/power_management/src/main.c
+++ b/samples/boards/mec15xxevb_assy6853/power_management/src/main.c
@@ -11,7 +11,7 @@ LOG_MODULE_DECLARE(mec15_brd_test);
 
 #define MAX_CYCLES 5ul
 
-void main(void)
+int main(void)
 {
 	test_pwr_mgmt_singlethread(false, MAX_CYCLES);
 
@@ -20,4 +20,5 @@ void main(void)
 	test_pwr_mgmt_multithread(false, MAX_CYCLES);
 
 	test_pwr_mgmt_multithread(true, MAX_CYCLES);
+	return 0;
 }

--- a/samples/boards/mimxrt1060_evk/system_off/src/main.c
+++ b/samples/boards/mimxrt1060_evk/system_off/src/main.c
@@ -31,13 +31,13 @@
 static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET_OR(SW0_NODE, gpios, { 0 });
 static const struct device *const snvs_rtc_dev = DEVICE_DT_GET(SNVS_RTC_NODE);
 
-void main(void)
+int main(void)
 {
 	printk("\n%s system off demo\n", CONFIG_BOARD);
 
 	if (!device_is_ready(button.port)) {
 		printk("Error: button device %s is not ready\n", button.port->name);
-		return;
+		return 0;
 	}
 
 	/* Configure to generate PORT event (wakeup) on button press. */
@@ -47,14 +47,14 @@ void main(void)
 	if (ret != 0) {
 		printk("Error %d: failed to configure %s pin %d\n", ret, button.port->name,
 		       button.pin);
-		return;
+		return 0;
 	}
 
 	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_LEVEL_LOW);
 	if (ret != 0) {
 		printk("Error %d: failed to configure interrupt on %s pin %d\n", ret,
 		       button.port->name, button.pin);
-		return;
+		return 0;
 	}
 
 	printk("Busy-wait %u s\n", BUSY_WAIT_S);
@@ -78,7 +78,7 @@ void main(void)
 	ret = counter_set_channel_alarm(snvs_rtc_dev, SNVS_LP_RTC_ALARM_ID, &alarm_cfg);
 	if (ret != 0) {
 		printk("Could not rtc alarm.\n");
-		return;
+		return 0;
 	}
 	printk("RTC Alarm set for %llu seconds to wake from soft-off.\n",
 	       counter_ticks_to_us(snvs_rtc_dev, alarm_cfg.ticks) / (1000ULL * 1000ULL));
@@ -96,4 +96,5 @@ void main(void)
 	while (true) {
 		/* spin to avoid fall-off behavior */
 	}
+	return 0;
 }

--- a/samples/boards/mimxrt595_evk_cm33/system_off/src/main.c
+++ b/samples/boards/mimxrt595_evk_cm33/system_off/src/main.c
@@ -25,7 +25,7 @@
 
 static const struct device *const rtc_dev = DEVICE_DT_GET(RTC_NODE);
 
-void main(void)
+int main(void)
 {
 	int ret;
 
@@ -48,7 +48,7 @@ void main(void)
 	ret = counter_set_channel_alarm(rtc_dev, RTC_CHANNEL_ID, &alarm_cfg);
 	if (ret != 0) {
 		printk("Could not rtc alarm.\n");
-		return;
+		return 0;
 	}
 	printk("RTC Alarm set for %llu seconds to wake from soft-off.\n",
 	       counter_ticks_to_us(rtc_dev, alarm_cfg.ticks) / (1000ULL * 1000ULL));
@@ -65,4 +65,5 @@ void main(void)
 	while (true) {
 		/* spin to avoid fall-off behavior */
 	}
+	return 0;
 }

--- a/samples/boards/nrf/battery/src/main.c
+++ b/samples/boards/nrf/battery/src/main.c
@@ -52,13 +52,13 @@ static const char *now_str(void)
 	return buf;
 }
 
-void main(void)
+int main(void)
 {
 	int rc = battery_measure_enable(true);
 
 	if (rc != 0) {
 		printk("Failed initialize battery measurement: %d\n", rc);
-		return;
+		return 0;
 	}
 
 	while (true) {
@@ -79,4 +79,5 @@ void main(void)
 		k_busy_wait(5 * USEC_PER_SEC);
 	}
 	printk("Disable: %d\n", battery_measure_enable(false));
+	return 0;
 }

--- a/samples/boards/nrf/clock_skew/src/main.c
+++ b/samples/boards/nrf/clock_skew/src/main.c
@@ -194,7 +194,7 @@ static void sync_work_handler(struct k_work *work)
 			      K_SECONDS(UPDATE_INTERVAL_S));
 }
 
-void main(void)
+int main(void)
 {
 	uint32_t top;
 	int rc;
@@ -202,7 +202,7 @@ void main(void)
 	/* Grab the clock driver */
 	if (!device_is_ready(clock0)) {
 		printk("%s: device not ready.\n", clock0->name);
-		return;
+		return 0;
 	}
 
 	show_clocks("Power-up clocks");
@@ -215,7 +215,7 @@ void main(void)
 	/* Grab the timer. */
 	if (!device_is_ready(timer0)) {
 		printk("%s: device not ready.\n", timer0->name);
-		return;
+		return 0;
 	}
 
 	/* Apparently there's no API to configure a frequency at
@@ -225,14 +225,14 @@ void main(void)
 	if (sync_config.ref_Hz == 0) {
 		printk("Timer %s has no fixed frequency\n",
 			timer0->name);
-		return;
+		return 0;
 	}
 
 	top = counter_get_top_value(timer0);
 	if (top != UINT32_MAX) {
 		printk("Timer %s wraps at %u (0x%08x) not at 32 bits\n",
 		       timer0->name, top, top);
-		return;
+		return 0;
 	}
 
 	rc = counter_start(timer0);
@@ -253,4 +253,5 @@ void main(void)
 	rc = k_work_schedule(&sync_work, K_NO_WAIT);
 
 	printk("Started sync: %d\n", rc);
+	return 0;
 }

--- a/samples/boards/nrf/dynamic_pinctrl/src/main.c
+++ b/samples/boards/nrf/dynamic_pinctrl/src/main.c
@@ -6,7 +6,8 @@
 
 #include <zephyr/sys/printk.h>
 
-void main(void)
+int main(void)
 {
 	printk("Hello World!\n");
+	return 0;
 }

--- a/samples/boards/nrf/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf/mesh/onoff-app/src/main.c
@@ -573,7 +573,7 @@ static void bt_ready(int err)
 	printk("Mesh initialized\n");
 }
 
-void main(void)
+int main(void)
 {
 	int err, i;
 
@@ -595,7 +595,7 @@ void main(void)
 	for (i = 0; i < ARRAY_SIZE(sw_device); i++) {
 		if (!device_is_ready(sw_device[i].port)) {
 			printk("SW%d GPIO controller device is not ready\n", i);
-			return;
+			return 0;
 		}
 		gpio_pin_configure_dt(&sw_device[i], GPIO_INPUT);
 		gpio_pin_interrupt_configure_dt(&sw_device[i], GPIO_INT_EDGE_TO_ACTIVE);
@@ -607,7 +607,7 @@ void main(void)
 	for (i = 0; i < ARRAY_SIZE(onoff_state); i++) {
 		if (!device_is_ready(onoff_state[i].led_device.port)) {
 			printk("LED%d GPIO controller device is not ready\n", i);
-			return;
+			return 0;
 		}
 		gpio_pin_configure_dt(&onoff_state[i].led_device, GPIO_OUTPUT_INACTIVE);
 	}
@@ -617,4 +617,5 @@ void main(void)
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}
+	return 0;
 }

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -143,7 +143,7 @@ static void reset_counter_timer_handler(struct k_timer *dummy)
 
 K_TIMER_DEFINE(reset_counter_timer, reset_counter_timer_handler, NULL);
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -159,7 +159,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	bt_ready();
@@ -170,4 +170,5 @@ void main(void)
 
 	short_time_multireset_bt_mesh_unprovisioning();
 	k_timer_start(&reset_counter_timer, K_MSEC(7000), K_NO_WAIT);
+	return 0;
 }

--- a/samples/boards/nrf/nrf53_sync_rtc/net/src/main.c
+++ b/samples/boards/nrf/nrf53_sync_rtc/net/src/main.c
@@ -54,7 +54,7 @@ static int mbox_init(void)
 	return mbox_set_enabled(&channel, true);
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -63,4 +63,5 @@ void main(void)
 	if (err < 0) {
 		LOG_ERR("Failed to initialize sync RTC listener (err:%d)", err);
 	}
+	return 0;
 }

--- a/samples/boards/nrf/nrf53_sync_rtc/src/main.c
+++ b/samples/boards/nrf/nrf53_sync_rtc/src/main.c
@@ -30,8 +30,9 @@ static void timeout_handler(struct k_timer *timer)
 
 K_TIMER_DEFINE(timer, timeout_handler, NULL);
 
-void main(void)
+int main(void)
 {
 	LOG_INF("Synchronization using %s driver", IS_ENABLED(CONFIG_MBOX) ? "mbox" : "ipm");
 	k_timer_start(&timer, K_MSEC(50), K_MSEC(50));
+	return 0;
 }

--- a/samples/boards/nrf/nrf_led_matrix/src/main.c
+++ b/samples/boards/nrf/nrf_led_matrix/src/main.c
@@ -180,7 +180,7 @@ static void update_through_framebuffer(const struct device *dev)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	printk("nRF LED matrix sample on %s\n", CONFIG_BOARD);
 
@@ -189,13 +189,13 @@ void main(void)
 
 	if (!dev) {
 		printk("Display device not ready\n");
-		return;
+		return 0;
 	}
 
 	display_get_capabilities(dev, &caps);
 	if (!(caps.supported_pixel_formats & PIXEL_FORMAT_MONO01)) {
 		printk("Expected pixel format not supported\n");
-		return;
+		return 0;
 	}
 
 	ret = display_set_pixel_format(dev, PIXEL_FORMAT_MONO01);
@@ -262,4 +262,5 @@ void main(void)
 
 		k_sleep(K_MSEC(500));
 	}
+	return 0;
 }

--- a/samples/boards/nrf/nrfx/src/main.c
+++ b/samples/boards/nrf/nrfx/src/main.c
@@ -28,7 +28,7 @@ static void button_handler(nrfx_gpiote_pin_t pin,
 	LOG_INF("GPIO input event callback");
 }
 
-void main(void)
+int main(void)
 {
 	LOG_INF("nrfx_gpiote sample on %s", CONFIG_BOARD);
 
@@ -47,19 +47,19 @@ void main(void)
 	err = nrfx_gpiote_init(0);
 	if (err != NRFX_SUCCESS) {
 		LOG_ERR("nrfx_gpiote_init error: 0x%08X", err);
-		return;
+		return 0;
 	}
 
 	err = nrfx_gpiote_channel_alloc(&in_channel);
 	if (err != NRFX_SUCCESS) {
 		LOG_ERR("Failed to allocate in_channel, error: 0x%08X", err);
-		return;
+		return 0;
 	}
 
 	err = nrfx_gpiote_channel_alloc(&out_channel);
 	if (err != NRFX_SUCCESS) {
 		LOG_ERR("Failed to allocate out_channel, error: 0x%08X", err);
-		return;
+		return 0;
 	}
 
 	/* Initialize input pin to generate event on high to low transition
@@ -81,7 +81,7 @@ void main(void)
 					  &handler_config);
 	if (err != NRFX_SUCCESS) {
 		LOG_ERR("nrfx_gpiote_input_configure error: 0x%08X", err);
-		return;
+		return 0;
 	}
 
 	/* Initialize output pin. SET task will turn the LED on,
@@ -102,7 +102,7 @@ void main(void)
 					   &task_config);
 	if (err != NRFX_SUCCESS) {
 		LOG_ERR("nrfx_gpiote_output_configure error: 0x%08X", err);
-		return;
+		return 0;
 	}
 
 	nrfx_gpiote_trigger_enable(INPUT_PIN, true);
@@ -114,7 +114,7 @@ void main(void)
 	err = nrfx_gppi_channel_alloc(&ppi_channel);
 	if (err != NRFX_SUCCESS) {
 		LOG_ERR("nrfx_gppi_channel_alloc error: 0x%08X", err);
-		return;
+		return 0;
 	}
 
 	/* Configure endpoints of the channel so that the input pin event is
@@ -129,4 +129,5 @@ void main(void)
 	nrfx_gppi_channels_enable(BIT(ppi_channel));
 
 	LOG_INF("(D)PPI configured, leaving main()");
+	return 0;
 }

--- a/samples/boards/nrf/nrfx_prs/src/main.c
+++ b/samples/boards/nrf/nrfx_prs/src/main.c
@@ -330,7 +330,7 @@ static bool background_transfer(const struct device *spi_dev)
 	return true;
 }
 
-void main(void)
+int main(void)
 {
 	printk("nrfx PRS example on %s\n", CONFIG_BOARD);
 
@@ -341,7 +341,7 @@ void main(void)
 
 	if (!device_is_ready(spi_dev)) {
 		printk("%s is not ready\n", spi_dev->name);
-		return;
+		return 0;
 	}
 
 	/* Install a shared interrupt handler for peripherals used via
@@ -355,12 +355,12 @@ void main(void)
 		    nrfx_isr, nrfx_prs_box_2_irq_handler, 0);
 
 	if (!init_buttons()) {
-		return;
+		return 0;
 	}
 
 	/* Initially use the SPIM. */
 	if (!switch_to_spim()) {
-		return;
+		return 0;
 	}
 
 	for (;;) {
@@ -370,7 +370,7 @@ void main(void)
 		 */
 		if (k_sem_take(&button_pressed, K_MSEC(5000)) != 0) {
 			if (!background_transfer(spi_dev)) {
-				return;
+				return 0;
 			}
 		} else {
 			bool res;
@@ -393,7 +393,7 @@ void main(void)
 							rx_buffer,
 							sizeof(rx_buffer)));
 				if (!res) {
-					return;
+					return 0;
 				}
 
 				printk("Tx:");
@@ -407,10 +407,11 @@ void main(void)
 				       ? switch_to_uarte()
 				       : switch_to_spim());
 				if (!res) {
-					return;
+					return 0;
 				}
 				break;
 			}
 		}
 	}
+	return 0;
 }

--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -34,14 +34,14 @@ static int disable_ds_1(void)
 
 SYS_INIT(disable_ds_1, PRE_KERNEL_2, 0);
 
-void main(void)
+int main(void)
 {
 	int rc;
 	const struct device *const cons = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	if (!device_is_ready(cons)) {
 		printk("%s: device not ready.\n", cons->name);
-		return;
+		return 0;
 	}
 
 	printk("\n%s system off demo\n", CONFIG_BOARD);
@@ -107,4 +107,5 @@ void main(void)
 	while (true) {
 		/* spin to avoid fall-off behavior */
 	}
+	return 0;
 }

--- a/samples/boards/nxp_s32/netc/src/main.c
+++ b/samples/boards/nxp_s32/netc/src/main.c
@@ -91,7 +91,7 @@ static void wait_for_iface(struct net_if *iface)
 	net_mgmt_del_event_callback(&iface_up_cb);
 }
 
-void main(void)
+int main(void)
 {
 	struct net_if *iface;
 
@@ -116,4 +116,5 @@ void main(void)
 			    CONFIG_NET_SAMPLE_IFACE2_MY_IPV4_NETMASK);
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(nxp_s32_netc_vsi)*/
+	return 0;
 }

--- a/samples/boards/qomu/src/main.c
+++ b/samples/boards/qomu/src/main.c
@@ -14,7 +14,7 @@
 extern uint32_t axFPGABitStream[];
 extern uint32_t axFPGABitStream_length;
 
-void main(void)
+int main(void)
 {
 	const struct device *fpga = device_get_binding("fpga");
 
@@ -27,4 +27,5 @@ void main(void)
 	printk("####################\n");
 	printk("I am Zephyr on Qomu!\n");
 	printk("####################\n");
+	return 0;
 }

--- a/samples/boards/reel_board/mesh_badge/src/main.c
+++ b/samples/boards/reel_board/mesh_badge/src/main.c
@@ -191,14 +191,14 @@ static void bt_ready(int err)
 	printk("Board started\n");
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	err = board_init();
 	if (err) {
 		printk("board init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Starting Board Demo\n");
@@ -207,12 +207,13 @@ void main(void)
 	err = bt_enable(bt_ready);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	err = periphs_init();
 	if (err) {
 		printk("peripherals initialization failed (err %d)\n", err);
-		return;
+		return 0;
 	}
+	return 0;
 }

--- a/samples/boards/sensortile_box/src/main.c
+++ b/samples/boards/sensortile_box/src/main.c
@@ -247,7 +247,7 @@ static void iis3dhhc_config(const struct device *iis3dhhc)
 #endif
 }
 
-void main(void)
+int main(void)
 {
 	static const struct gpio_dt_spec led0_gpio = GPIO_DT_SPEC_GET(DT_ALIAS(led0), gpios);
 	static const struct gpio_dt_spec led1_gpio = GPIO_DT_SPEC_GET(DT_ALIAS(led1), gpios);
@@ -258,7 +258,7 @@ void main(void)
 
 	/* Application must enable USB by itself */
 	if (!device_is_ready(dev) || usb_enable(NULL)) {
-		return;
+		return 0;
 	}
 
 	/* Poll if the DTR flag was set, optional */
@@ -268,13 +268,13 @@ void main(void)
 
 	if (!device_is_ready(led0_gpio.port)) {
 		printk("%s: device not ready.\n", led0_gpio.port->name);
-		return;
+		return 0;
 	}
 	gpio_pin_configure_dt(&led0_gpio, GPIO_OUTPUT_ACTIVE);
 
 	if (!device_is_ready(led1_gpio.port)) {
 		printk("%s: device not ready.\n", led1_gpio.port->name);
-		return;
+		return 0;
 	}
 	gpio_pin_configure_dt(&led1_gpio, GPIO_OUTPUT_INACTIVE);
 
@@ -300,31 +300,31 @@ void main(void)
 
 	if (!device_is_ready(hts221)) {
 		printk("%s: device not ready.\n", hts221->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lis2dw12)) {
 		printk("%s: device not ready.\n", lis2dw12->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lps22hh)) {
 		printk("%s: device not ready.\n", lps22hh->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lsm6dso)) {
 		printk("%s: device not ready.\n", lsm6dso->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(stts751)) {
 		printk("%s: device not ready.\n", stts751->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(iis3dhhc)) {
 		printk("%s: device not ready.\n", iis3dhhc->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lis2mdl)) {
 		printk("%s: device not ready.\n", lis2mdl->name);
-		return;
+		return 0;
 	}
 
 	lis2dw12_config(lis2dw12);
@@ -345,48 +345,48 @@ void main(void)
 		/* handle HTS221 sensor */
 		if (sensor_sample_fetch(hts221) < 0) {
 			printf("HTS221 Sensor sample update error\n");
-			return;
+			return 0;
 		}
 
 #ifndef CONFIG_LIS2DW12_TRIGGER
 		/* handle LIS2DW12 sensor */
 		if (sensor_sample_fetch(lis2dw12) < 0) {
 			printf("LIS2DW12 Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 
 #ifndef CONFIG_LSM6DSO_TRIGGER
 		if (sensor_sample_fetch(lsm6dso) < 0) {
 			printf("LSM6DSO Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 
 #ifndef CONFIG_LPS22HH_TRIGGER
 		if (sensor_sample_fetch(lps22hh) < 0) {
 			printf("LPS22HH Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 
 #ifndef CONFIG_STTS751_TRIGGER
 		if (sensor_sample_fetch(stts751) < 0) {
 			printf("STTS751 Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 
 #ifndef CONFIG_IIS3DHHC_TRIGGER
 		if (sensor_sample_fetch(iis3dhhc) < 0) {
 			printf("IIS3DHHC Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 
 		if (sensor_sample_fetch(lis2mdl) < 0) {
 			printf("LIS2MDL Sensor sample update error\n");
-			return;
+			return 0;
 		}
 
 		sensor_channel_get(hts221, SENSOR_CHAN_HUMIDITY, &hts221_hum);

--- a/samples/boards/stm32/backup_sram/src/main.c
+++ b/samples/boards/stm32/backup_sram/src/main.c
@@ -15,7 +15,7 @@
 /** Value stored in backup SRAM. */
 __stm32_backup_sram_section uint32_t backup_value;
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(BACKUP_DEV_COMPAT);
 
@@ -33,4 +33,5 @@ void main(void)
 
 	printk("Next reported value should be: %d\n", backup_value);
 	printk("Keep VBAT power source and reset the board now!\n");
+	return 0;
 }

--- a/samples/boards/stm32/ccm/src/main.c
+++ b/samples/boards/stm32/ccm/src/main.c
@@ -112,7 +112,7 @@ void print_var_values(void)
 	printf("\n");
 }
 
-void main(void)
+int main(void)
 {
 	printf("\nCCM (Core Coupled Memory) usage example\n\n");
 
@@ -144,4 +144,5 @@ void main(void)
 	print_var_values();
 
 	printf("\nExample end\n");
+	return 0;
 }

--- a/samples/boards/stm32/h7_dual_core/src/main.c
+++ b/samples/boards/stm32/h7_dual_core/src/main.c
@@ -32,7 +32,7 @@ void new_message_callback(const struct device *dev, void *user_data,
 	ipm_data->led_is_on = !ipm_data->led_is_on;
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const ipm = DEVICE_DT_GET(DT_NODELABEL(mailbox));
 
@@ -40,12 +40,12 @@ void main(void)
 
 	if (!device_is_ready(ipm)) {
 		printk("ipm device not ready\n");
-		return;
+		return 0;
 	}
 
 	if (!device_is_ready(led0.port)) {
 		printk("led0 device not ready\n");
-		return;
+		return 0;
 	}
 
 	gpio_pin_configure_dt(&led0, GPIO_OUTPUT_INACTIVE);
@@ -61,4 +61,5 @@ void main(void)
 		ipm_send(ipm, 0, 0, NULL, 0);
 		k_msleep(SLEEP_TIME_MS);
 	}
+	return 0;
 }

--- a/samples/boards/stm32/power_mgmt/blinky/src/main.c
+++ b/samples/boards/stm32/power_mgmt/blinky/src/main.c
@@ -15,7 +15,7 @@
 static const struct gpio_dt_spec led =
 	GPIO_DT_SPEC_GET(DT_ALIAS(led0), gpios);
 
-void main(void)
+int main(void)
 {
 	bool led_is_on = true;
 
@@ -37,4 +37,5 @@ void main(void)
 		}
 		led_is_on = !led_is_on;
 	}
+	return 0;
 }

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/src/main.c
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/src/main.c
@@ -11,14 +11,14 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/__assert.h>
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev =
 		DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	if (!device_is_ready(dev)) {
 		printk("Console device not ready");
-		return;
+		return 0;
 	}
 
 #if CONFIG_PM_DEVICE
@@ -51,4 +51,5 @@ void main(void)
 	}
 #endif
 
+	return 0;
 }

--- a/samples/boards/stm32/power_mgmt/standby_shutdown/src/main.c
+++ b/samples/boards/stm32/power_mgmt/standby_shutdown/src/main.c
@@ -88,7 +88,7 @@ void thread_shutdown_standby_mode(void)
 K_THREAD_DEFINE(thread_shutdown_standby_mode_id, STACKSIZE, thread_shutdown_standby_mode,
 	NULL, NULL, NULL, PRIORITY, 0, 0);
 
-void main(void)
+int main(void)
 {
 	int ret;
 	uint32_t cause;
@@ -117,14 +117,14 @@ void main(void)
 	if (!gpio_is_ready_dt(&button)) {
 		printk("Error: button device %s is not ready\n",
 			button.port->name);
-		return;
+		return 0;
 	}
 
 	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
 	if (ret != 0) {
 		printk("Error %d: failed to configure %s pin %d\n",
 			ret, button.port->name, button.pin);
-		return;
+		return 0;
 	}
 
 	ret = gpio_pin_interrupt_configure_dt(&button,
@@ -132,7 +132,7 @@ void main(void)
 	if (ret != 0) {
 		printk("Error %d: failed to configure interrupt on %s pin %d\n",
 			ret, button.port->name, button.pin);
-		return;
+		return 0;
 	}
 
 	gpio_init_callback(&button_cb_data, button_pressed, BIT(button.pin));
@@ -152,4 +152,5 @@ void main(void)
 		led_is_on = !led_is_on;
 	}
 
+	return 0;
 }

--- a/samples/boards/stm32/power_mgmt/stm32wb_ble/src/main.c
+++ b/samples/boards/stm32/power_mgmt/stm32wb_ble/src/main.c
@@ -108,7 +108,7 @@ static void bt_ready(int err)
 	printk("Beacon stopped\n");
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -148,4 +148,5 @@ void main(void)
 
 	printk("Shutdown\n");
 	pm_state_force(0u, &(struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
+	return 0;
 }

--- a/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
+++ b/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
@@ -22,7 +22,7 @@ static const struct gpio_dt_spec sw0_gpio = GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpio
 
 extern void CC1352R1_LAUNCHXL_shutDownExtFlash(void);
 
-void main(void)
+int main(void)
 {
 	uint32_t config, status;
 
@@ -34,7 +34,7 @@ void main(void)
 	/* Configure to generate PORT event (wakeup) on button 1 press. */
 	if (!device_is_ready(sw0_gpio.port)) {
 		printk("%s: device not ready.\n", sw0_gpio.port->name);
-		return;
+		return 0;
 	}
 
 	gpio_pin_configure_dt(&sw0_gpio, GPIO_INPUT);
@@ -74,4 +74,5 @@ void main(void)
 	while (true) {
 		/* spin to avoid fall-off behavior */
 	}
+	return 0;
 }

--- a/samples/boards/up_squared/gpio_counter/src/main.c
+++ b/samples/boards/up_squared/gpio_counter/src/main.c
@@ -98,19 +98,19 @@ int get_gpio_dev(struct _pin *pin)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	uint32_t val;
 	int i, ret;
 
 	for (i = 0; i < NUM_PINS; i++) {
 		if (get_gpio_dev(&counter_pins[i]) != 0) {
-			return;
+			return 0;
 		}
 	}
 
 	if (get_gpio_dev(&intr_pin) != 0) {
-		return;
+		return 0;
 	}
 
 	/* Set pins to output */
@@ -121,7 +121,7 @@ void main(void)
 		if (ret) {
 			printk("ERROR: cannot set HAT pin %d to OUT (%d)\n",
 			       counter_pins[i].hat_num, ret);
-			return;
+			return 0;
 		}
 	}
 
@@ -131,7 +131,7 @@ void main(void)
 	if (ret) {
 		printk("ERROR: cannot set HAT pin %d to IN (%d)\n",
 			       intr_pin.hat_num, ret);
-			return;
+			return 0;
 	}
 
 
@@ -145,7 +145,7 @@ void main(void)
 	if (ret) {
 		printk("ERROR: cannot config interrupt on HAT pin %d (%d)\n",
 			       intr_pin.hat_num, ret);
-			return;
+			return 0;
 	}
 
 	/* main loop */
@@ -160,11 +160,12 @@ void main(void)
 			if (ret) {
 				printk("ERROR: cannot set HAT pin %d value (%d)\n",
 				       counter_pins[i].hat_num, ret);
-				return;
+				return 0;
 			}
 		}
 
 		k_sem_take(&counter_sem, K_FOREVER);
 		val = counter & MASK;
 	}
+	return 0;
 }

--- a/samples/compression/lz4/src/main.c
+++ b/samples/compression/lz4/src/main.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 #include "lz4.h"
 
-void main(void)
+int main(void)
 {
 	static const char *src = "Lorem ipsum dolor sit amet, consectetur "
 	"adipiscing elit. Quisque sodales lorem lorem, sed congue enim "
@@ -40,7 +40,7 @@ void main(void)
 
 	if (compressed_data == NULL) {
 		printk("Failed to allocate memory for compressed data\n");
-		return;
+		return 0;
 	}
 
 	const int compressed_data_size = LZ4_compress_default(src,
@@ -48,7 +48,7 @@ void main(void)
 					max_dst_size);
 	if (compressed_data_size <= 0) {
 		printk("Failed to compress the data\n");
-		return;
+		return 0;
 	}
 
 	printk("Original Data size: %d\n", src_size);
@@ -58,14 +58,14 @@ void main(void)
 					  (size_t)compressed_data_size);
 	if (compressed_data == NULL) {
 		printk("Failed to re-alloc memory for compressed data\n");
-		return;
+		return 0;
 	}
 
 	char * const decompressed_data = malloc(src_size);
 
 	if (decompressed_data == NULL) {
 		printk("Failed to allocate memory to decompress data\n");
-		return;
+		return 0;
 	}
 
 	const int decompressed_size = LZ4_decompress_safe(compressed_data,
@@ -73,7 +73,7 @@ void main(void)
 				      src_size);
 	if (decompressed_size < 0) {
 		printk("Failed to decompress the data\n");
-		return;
+		return 0;
 	}
 
 	free(compressed_data);
@@ -84,15 +84,16 @@ void main(void)
 
 	if (decompressed_size != src_size) {
 		printk("Decompressed data is different from original\n");
-		return;
+		return 0;
 	}
 
 	if (memcmp(src, decompressed_data, src_size) != 0) {
 		printk("Validation failed.\n");
 		printk("*src and *new_src are not identical\n");
-		return;
+		return 0;
 	}
 
 	printk("Validation done. The string we ended up with is:\n%s\n",
 			decompressed_data);
+	return 0;
 }

--- a/samples/drivers/adc/src/main.c
+++ b/samples/drivers/adc/src/main.c
@@ -29,7 +29,7 @@ static const struct adc_dt_spec adc_channels[] = {
 			     DT_SPEC_AND_COMMA)
 };
 
-void main(void)
+int main(void)
 {
 	int err;
 	uint32_t count = 0;
@@ -44,13 +44,13 @@ void main(void)
 	for (size_t i = 0U; i < ARRAY_SIZE(adc_channels); i++) {
 		if (!device_is_ready(adc_channels[i].dev)) {
 			printk("ADC controller device %s not ready\n", adc_channels[i].dev->name);
-			return;
+			return 0;
 		}
 
 		err = adc_channel_setup_dt(&adc_channels[i]);
 		if (err < 0) {
 			printk("Could not setup channel #%d (%d)\n", i, err);
-			return;
+			return 0;
 		}
 	}
 
@@ -94,4 +94,5 @@ void main(void)
 
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }

--- a/samples/drivers/audio/dmic/src/main.c
+++ b/samples/drivers/audio/dmic/src/main.c
@@ -74,7 +74,7 @@ static int do_pdm_transfer(const struct device *dmic_dev,
 	return ret;
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dmic_dev = DEVICE_DT_GET(DT_NODELABEL(dmic_dev));
 	int ret;
@@ -83,7 +83,7 @@ void main(void)
 
 	if (!device_is_ready(dmic_dev)) {
 		LOG_ERR("%s is not ready", dmic_dev->name);
-		return;
+		return 0;
 	}
 
 	struct pcm_stream_cfg stream = {
@@ -116,7 +116,7 @@ void main(void)
 
 	ret = do_pdm_transfer(dmic_dev, &cfg, 2 * BLOCK_COUNT);
 	if (ret < 0) {
-		return;
+		return 0;
 	}
 
 	cfg.channel.req_num_chan = 2;
@@ -129,8 +129,9 @@ void main(void)
 
 	ret = do_pdm_transfer(dmic_dev, &cfg, 2 * BLOCK_COUNT);
 	if (ret < 0) {
-		return;
+		return 0;
 	}
 
 	LOG_INF("Exiting");
+	return 0;
 }

--- a/samples/drivers/can/babbling/src/main.c
+++ b/samples/drivers/can/babbling/src/main.c
@@ -38,7 +38,7 @@ static void can_tx_callback(const struct device *dev, int error, void *user_data
 	k_sem_give(tx_queue_sem);
 }
 
-void main(void)
+int main(void)
 {
 #if DT_NODE_EXISTS(BUTTON_NODE)
 	const struct gpio_dt_spec btn = GPIO_DT_SPEC_GET(BUTTON_NODE, gpios);
@@ -54,21 +54,21 @@ void main(void)
 
 	if (!device_is_ready(dev)) {
 		printk("CAN device not ready");
-		return;
+		return 0;
 	}
 
 	if (IS_ENABLED(CONFIG_SAMPLE_CAN_BABBLING_FD_MODE)) {
 		err = can_set_mode(dev, CAN_MODE_FD);
 		if (err != 0) {
 			printk("Error setting CAN-FD mode (err %d)", err);
-			return;
+			return 0;
 		}
 	}
 
 	err = can_start(dev);
 	if (err != 0) {
 		printk("Error starting CAN controller (err %d)", err);
-		return;
+		return 0;
 	}
 
 #if DT_NODE_EXISTS(BUTTON_NODE)
@@ -76,19 +76,19 @@ void main(void)
 
 	if (!device_is_ready(btn.port)) {
 		printk("button device not ready\n");
-		return;
+		return 0;
 	}
 
 	err = gpio_pin_configure_dt(&btn, GPIO_INPUT);
 	if (err != 0) {
 		printk("failed to configure button GPIO (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	err = gpio_pin_interrupt_configure_dt(&btn, GPIO_INT_EDGE_TO_ACTIVE);
 	if (err != 0) {
 		printk("failed to configure button interrupt (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	gpio_init_callback(&btn_cb_ctx.callback, button_callback, BIT(btn.pin));
@@ -132,7 +132,7 @@ void main(void)
 #if DT_NODE_EXISTS(BUTTON_NODE)
 		if (k_sem_take(&btn_cb_ctx.sem, K_NO_WAIT) == 0) {
 			printk("button press detected, babbling stopped\n");
-			return;
+			return 0;
 		}
 #endif /* DT_NODE_EXISTS(BUTTON_NODE) */
 	}

--- a/samples/drivers/can/counter/src/main.c
+++ b/samples/drivers/can/counter/src/main.c
@@ -189,7 +189,7 @@ void state_change_callback(const struct device *dev, enum can_state state,
 	k_work_submit(work);
 }
 
-void main(void)
+int main(void)
 {
 	const struct can_filter change_led_filter = {
 		.flags = CAN_FILTER_DATA,
@@ -213,27 +213,27 @@ void main(void)
 
 	if (!device_is_ready(can_dev)) {
 		printf("CAN: Device %s not ready.\n", can_dev->name);
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_LOOPBACK_MODE
 	ret = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
 	if (ret != 0) {
 		printf("Error setting CAN mode [%d]", ret);
-		return;
+		return 0;
 	}
 #endif
 	ret = can_start(can_dev);
 	if (ret != 0) {
 		printf("Error starting CAN controller [%d]", ret);
-		return;
+		return 0;
 	}
 
 	if (led.port != NULL) {
 		if (!device_is_ready(led.port)) {
 			printf("LED: Device %s not ready.\n",
 			       led.port->name);
-			return;
+			return 0;
 		}
 		ret = gpio_pin_configure_dt(&led, GPIO_OUTPUT_HIGH);
 		if (ret < 0) {
@@ -249,7 +249,7 @@ void main(void)
 	ret = can_add_rx_filter_msgq(can_dev, &change_led_msgq, &change_led_filter);
 	if (ret == -ENOSPC) {
 		printf("Error, no filter available!\n");
-		return;
+		return 0;
 	}
 
 	printf("Change LED filter ID: %d\n", ret);
@@ -258,7 +258,7 @@ void main(void)
 				 ARRAY_SIZE(change_led_events), K_FOREVER);
 	if (ret != 0) {
 		printf("Failed to submit msgq polling: %d", ret);
-		return;
+		return 0;
 	}
 
 	rx_tid = k_thread_create(&rx_thread_data, rx_thread_stack,

--- a/samples/drivers/clock_control_litex/src/main.c
+++ b/samples/drivers/clock_control_litex/src/main.c
@@ -309,7 +309,7 @@ int litex_clk_test(const struct device *dev)
 
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET(MMCM);
 
@@ -318,11 +318,12 @@ void main(void)
 	printf("device name: %s\n", dev->name);
 	if (!device_is_ready(dev)) {
 		printf("error: device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	printf("clock control device is %p, name is %s\n",
 	       dev, dev->name);
 
 	litex_clk_test(dev);
+	return 0;
 }

--- a/samples/drivers/clock_control_xec/src/main.c
+++ b/samples/drivers/clock_control_xec/src/main.c
@@ -197,7 +197,7 @@ static const struct sys_clk sys_clocks[] = {
 	{ .id = MCHP_XEC_PCR_CLK_PERIPH_SLOW, .name = "Periph-slow" },
 };
 
-void main(void)
+int main(void)
 {
 	int rc = 0;
 	uint32_t rate = 0U;
@@ -208,7 +208,7 @@ void main(void)
 
 	if (!device_is_ready(clkdev)) {
 		LOG_ERR("XEC clock control driver is not ready!");
-		return;
+		return 0;
 	}
 
 	vbat_power_fail();
@@ -232,4 +232,5 @@ void main(void)
 			LOG_INF("rate = %u", rate);
 		}
 	}
+	return 0;
 }

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -82,7 +82,7 @@ static void test_counter_interrupt_fn(const struct device *counter_dev,
 	}
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const counter_dev = DEVICE_DT_GET(TIMER);
 	int err;
@@ -91,7 +91,7 @@ void main(void)
 
 	if (!device_is_ready(counter_dev)) {
 		printk("device not ready.\n");
-		return;
+		return 0;
 	}
 
 	counter_start(counter_dev);
@@ -119,4 +119,5 @@ void main(void)
 	while (1) {
 		k_sleep(K_FOREVER);
 	}
+	return 0;
 }

--- a/samples/drivers/counter/maxim_ds3231/src/main.c
+++ b/samples/drivers/counter/maxim_ds3231/src/main.c
@@ -227,13 +227,13 @@ static void set_aligned_clock(const struct device *ds3231)
 	       sp.syncclock);
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const ds3231 = DEVICE_DT_GET_ONE(maxim_ds3231);
 
 	if (!device_is_ready(ds3231)) {
 		printk("%s: device not ready.\n", ds3231->name);
-		return;
+		return 0;
 	}
 
 	uint32_t syncclock_Hz = maxim_ds3231_syncclock_frequency(ds3231);
@@ -247,7 +247,7 @@ void main(void)
 		       (rc & MAXIM_DS3231_REG_STAT_OSF) ? "" : " not");
 	} else {
 		printk("DS3231 stat fetch failed: %d\n", rc);
-		return;
+		return 0;
 	}
 
 	/* Show the DS3231 counter properties */
@@ -337,4 +337,5 @@ void main(void)
 	}
 
 	k_sleep(K_FOREVER);
+	return 0;
 }

--- a/samples/drivers/crypto/src/main.c
+++ b/samples/drivers/crypto/src/main.c
@@ -603,21 +603,21 @@ struct mode_test {
 	void (*mode_func)(const struct device *dev);
 };
 
-void main(void)
+int main(void)
 {
 #ifdef CRYPTO_DRV_NAME
 	const struct device *dev = device_get_binding(CRYPTO_DRV_NAME);
 
 	if (!dev) {
 		LOG_ERR("%s pseudo device not found", CRYPTO_DRV_NAME);
-		return;
+		return 0;
 	}
 #else
 	const struct device *const dev = DEVICE_DT_GET_ONE(CRYPTO_DEV_COMPAT);
 
 	if (!device_is_ready(dev)) {
 		LOG_ERR("Crypto device is not ready\n");
-		return;
+		return 0;
 	}
 #endif
 	const struct mode_test modes[] = {
@@ -632,7 +632,7 @@ void main(void)
 
 	if (validate_hw_compatibility(dev)) {
 		LOG_ERR("Incompatible h/w");
-		return;
+		return 0;
 	}
 
 	LOG_INF("Cipher Sample");
@@ -641,4 +641,5 @@ void main(void)
 		LOG_INF("%s", modes[i].mode);
 		modes[i].mode_func(dev);
 	}
+	return 0;
 }

--- a/samples/drivers/dac/src/main.c
+++ b/samples/drivers/dac/src/main.c
@@ -30,18 +30,18 @@ static const struct dac_channel_cfg dac_ch_cfg = {
 	.resolution  = DAC_RESOLUTION
 };
 
-void main(void)
+int main(void)
 {
 	if (!device_is_ready(dac_dev)) {
 		printk("DAC device %s is not ready\n", dac_dev->name);
-		return;
+		return 0;
 	}
 
 	int ret = dac_channel_setup(dac_dev, &dac_ch_cfg);
 
 	if (ret != 0) {
 		printk("Setting up of DAC channel failed with code %d\n", ret);
-		return;
+		return 0;
 	}
 
 	printk("Generating sawtooth signal at DAC channel %d.\n",
@@ -64,9 +64,10 @@ void main(void)
 			ret = dac_write_value(dac_dev, DAC_CHANNEL_ID, i);
 			if (ret != 0) {
 				printk("dac_write_value() failed with code %d\n", ret);
-				return;
+				return 0;
 			}
 			k_sleep(K_MSEC(sleep_time));
 		}
 	}
+	return 0;
 }

--- a/samples/drivers/display/src/main.c
+++ b/samples/drivers/display/src/main.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(sample, LOG_LEVEL_INF);
 #ifdef CONFIG_ARCH_POSIX
 #define RETURN_FROM_MAIN(exit_code) posix_exit_main(exit_code)
 #else
-#define RETURN_FROM_MAIN(exit_code) return
+#define RETURN_FROM_MAIN(exit_code) return(exit_code)
 #endif
 
 enum corner {
@@ -163,7 +163,7 @@ static void fill_buffer_mono(enum corner corner, uint8_t grey, uint8_t *buf,
 	memset(buf, color, buf_size);
 }
 
-void main(void)
+int main(void)
 {
 	size_t x;
 	size_t y;
@@ -299,4 +299,5 @@ void main(void)
 	}
 
 	RETURN_FROM_MAIN(0);
+	return 0;
 }

--- a/samples/drivers/display/src/main.c
+++ b/samples/drivers/display/src/main.c
@@ -18,12 +18,6 @@ LOG_MODULE_REGISTER(sample, LOG_LEVEL_INF);
 #include "posix_board_if.h"
 #endif
 
-#ifdef CONFIG_ARCH_POSIX
-#define RETURN_FROM_MAIN(exit_code) posix_exit_main(exit_code)
-#else
-#define RETURN_FROM_MAIN(exit_code) return(exit_code)
-#endif
-
 enum corner {
 	TOP_LEFT,
 	TOP_RIGHT,
@@ -184,7 +178,11 @@ int main(void)
 	if (!device_is_ready(display_dev)) {
 		LOG_ERR("Device %s not found. Aborting sample.",
 			display_dev->name);
-		RETURN_FROM_MAIN(1);
+#ifdef CONFIG_ARCH_POSIX
+		posix_exit_main(1);
+#else
+		return 0;
+#endif
 	}
 
 	LOG_INF("Display sample for %s", display_dev->name);
@@ -240,14 +238,22 @@ int main(void)
 		break;
 	default:
 		LOG_ERR("Unsupported pixel format. Aborting sample.");
-		RETURN_FROM_MAIN(1);
+#ifdef CONFIG_ARCH_POSIX
+		posix_exit_main(1);
+#else
+		return 0;
+#endif
 	}
 
 	buf = k_malloc(buf_size);
 
 	if (buf == NULL) {
 		LOG_ERR("Could not allocate memory. Aborting sample.");
-		RETURN_FROM_MAIN(1);
+#ifdef CONFIG_ARCH_POSIX
+		posix_exit_main(1);
+#else
+		return 0;
+#endif
 	}
 
 	(void)memset(buf, 0xFFu, buf_size);
@@ -298,6 +304,8 @@ int main(void)
 #endif
 	}
 
-	RETURN_FROM_MAIN(0);
+#ifdef CONFIG_ARCH_POSIX
+	posix_exit_main(0);
+#endif
 	return 0;
 }

--- a/samples/drivers/eeprom/src/main.c
+++ b/samples/drivers/eeprom/src/main.c
@@ -35,7 +35,7 @@ static const struct device *get_eeprom_device(void)
 	return dev;
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *eeprom = get_eeprom_device();
 	size_t eeprom_size;
@@ -43,7 +43,7 @@ void main(void)
 	int rc;
 
 	if (eeprom == NULL) {
-		return;
+		return 0;
 	}
 
 	eeprom_size = eeprom_get_size(eeprom);
@@ -52,7 +52,7 @@ void main(void)
 	rc = eeprom_read(eeprom, EEPROM_SAMPLE_OFFSET, &values, sizeof(values));
 	if (rc < 0) {
 		printk("Error: Couldn't read eeprom: err: %d.\n", rc);
-		return;
+		return 0;
 	}
 
 	if (values.magic != EEPROM_SAMPLE_MAGIC) {
@@ -66,8 +66,9 @@ void main(void)
 	rc = eeprom_write(eeprom, EEPROM_SAMPLE_OFFSET, &values, sizeof(values));
 	if (rc < 0) {
 		printk("Error: Couldn't write eeprom: err:%d.\n", rc);
-		return;
+		return 0;
 	}
 
 	printk("Reset the MCU to see the increasing boot counter.\n\n");
+	return 0;
 }

--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -1391,7 +1391,8 @@ int espi_test(void)
 	return ret;
 }
 
-void main(void)
+int main(void)
 {
 	espi_test();
+	return 0;
 }

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -725,7 +725,7 @@ static int cmd_set_dev(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	if (device_is_ready(flash_device)) {
 		printk("Found flash controller %s.\n", flash_device->name);
@@ -736,6 +736,7 @@ void main(void)
 		printk("Run set_device <name> to specify one "
 		       "before using other commands.\n");
 	}
+	return 0;
 }
 
 

--- a/samples/drivers/fpga/fpga_controller/src/main.c
+++ b/samples/drivers/fpga/fpga_controller/src/main.c
@@ -15,7 +15,7 @@
 
 const struct device *const fpga = DEVICE_DT_GET(DT_NODELABEL(fpga0));
 
-void main(void)
+int main(void)
 {
 	IO_MUX->PAD_21_CTRL = (PAD_E_4MA | PAD_P_PULLDOWN | PAD_OEN_NORMAL |
 			       PAD_SMT_DISABLE | PAD_REN_DISABLE | PAD_SR_SLOW |
@@ -46,4 +46,5 @@ void main(void)
 		fpga_reset(fpga);
 	}
 #endif
+	return 0;
 }

--- a/samples/drivers/ht16k33/src/main.c
+++ b/samples/drivers/ht16k33/src/main.c
@@ -22,7 +22,7 @@ static void keyscan_callback(const struct device *dev, uint32_t row,
 		pressed ? "pressed" : "released");
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const led = DEVICE_DT_GET(LED_NODE);
 	const struct device *const key = DEVICE_DT_GET(KEY_NODE);
@@ -31,12 +31,12 @@ void main(void)
 
 	if (!device_is_ready(led)) {
 		LOG_ERR("LED device not ready");
-		return;
+		return 0;
 	}
 
 	if (!device_is_ready(key)) {
 		LOG_ERR("Keyscan device not ready");
-		return;
+		return 0;
 	}
 
 	err = kscan_config(key, keyscan_callback);
@@ -71,4 +71,5 @@ void main(void)
 		}
 		led_set_brightness(led, 0, 100);
 	}
+	return 0;
 }

--- a/samples/drivers/i2s/echo/src/main.c
+++ b/samples/drivers/i2s/echo/src/main.c
@@ -244,7 +244,7 @@ static bool trigger_command(const struct device *i2s_dev_rx,
 	return true;
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const i2s_dev_rx = DEVICE_DT_GET(I2S_RX_NODE);
 	const struct device *const i2s_dev_tx = DEVICE_DT_GET(I2S_TX_NODE);
@@ -254,22 +254,22 @@ void main(void)
 
 #if DT_ON_BUS(DT_NODELABEL(wm8731), i2c)
 	if (!init_wm8731_i2c()) {
-		return;
+		return 0;
 	}
 #endif
 
 	if (!init_buttons()) {
-		return;
+		return 0;
 	}
 
 	if (!device_is_ready(i2s_dev_rx)) {
 		printk("%s is not ready\n", i2s_dev_rx->name);
-		return;
+		return 0;
 	}
 
 	if (i2s_dev_rx != i2s_dev_tx && !device_is_ready(i2s_dev_tx)) {
 		printk("%s is not ready\n", i2s_dev_tx->name);
-		return;
+		return 0;
 	}
 
 	config.word_size = SAMPLE_BIT_WIDTH;
@@ -281,19 +281,19 @@ void main(void)
 	config.block_size = BLOCK_SIZE;
 	config.timeout = TIMEOUT;
 	if (!configure_streams(i2s_dev_rx, i2s_dev_tx, &config)) {
-		return;
+		return 0;
 	}
 
 	for (;;) {
 		k_sem_take(&toggle_transfer, K_FOREVER);
 
 		if (!prepare_transfer(i2s_dev_rx, i2s_dev_tx)) {
-			return;
+			return 0;
 		}
 
 		if (!trigger_command(i2s_dev_rx, i2s_dev_tx,
 				     I2S_TRIGGER_START)) {
-			return;
+			return 0;
 		}
 
 		printk("Streams started\n");
@@ -320,7 +320,7 @@ void main(void)
 
 		if (!trigger_command(i2s_dev_rx, i2s_dev_tx,
 				     I2S_TRIGGER_DROP)) {
-			return;
+			return 0;
 		}
 
 		printk("Streams stopped\n");

--- a/samples/drivers/ipm/ipm_esp32/ipm_esp32_net/src/main.c
+++ b/samples/drivers/ipm/ipm_esp32/ipm_esp32_net/src/main.c
@@ -19,14 +19,14 @@ static void ipm_receive_callback(const struct device *ipmdev, void *user_data,
 	k_sem_give(&sync);
 }
 
-void main(void)
+int main(void)
 {
 	k_sem_init(&sync, 0, 1);
 
 	ipm_dev = DEVICE_DT_GET(DT_NODELABEL(ipm0));
 	if (!ipm_dev) {
 		printk("Failed to get IPM device.\n\r");
-		return;
+		return 0;
 	}
 
 	ipm_register_callback(ipm_dev, ipm_receive_callback, NULL);
@@ -35,4 +35,5 @@ void main(void)
 		k_sem_take(&sync, K_FOREVER);
 		ipm_send(ipm_dev, -1, sizeof(fake_resp), &fake_resp, sizeof(fake_resp));
 	}
+	return 0;
 }

--- a/samples/drivers/ipm/ipm_esp32/src/main.c
+++ b/samples/drivers/ipm/ipm_esp32/src/main.c
@@ -26,14 +26,14 @@ static void ipm_receive_callback(const struct device *ipmdev, void *user_data,
 	k_sem_give(&sync);
 }
 
-void main(void)
+int main(void)
 {
 	k_sem_init(&sync, 0, 1);
 
 	ipm_dev = DEVICE_DT_GET(DT_NODELABEL(ipm0));
 	if (!ipm_dev) {
 		printk("Failed to get IPM device.\n\r");
-		return;
+		return 0;
 	}
 
 	ipm_register_callback(ipm_dev, ipm_receive_callback, NULL);
@@ -48,4 +48,5 @@ void main(void)
 
 		k_sleep(K_MSEC(200));
 	}
+	return 0;
 }

--- a/samples/drivers/ipm/ipm_imx/src/main.c
+++ b/samples/drivers/ipm/ipm_imx/src/main.c
@@ -29,7 +29,7 @@ static void ipm_callback(const struct device *dev, void *context,
 	}
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *ipm;
 
@@ -45,4 +45,5 @@ void main(void)
 
 	while (1) {
 	}
+	return 0;
 }

--- a/samples/drivers/ipm/ipm_mcux/remote/src/main_remote.c
+++ b/samples/drivers/ipm/ipm_mcux/remote/src/main_remote.c
@@ -17,7 +17,7 @@ void ping_ipm_callback(const struct device *dev, void *context,
 
 
 
-void main(void)
+int main(void)
 {
 	const struct device *ipm;
 
@@ -30,4 +30,5 @@ void main(void)
 	ipm_set_enabled(ipm, 1);
 	while (1) {
 	}
+	return 0;
 }

--- a/samples/drivers/ipm/ipm_mcux/src/main_master.c
+++ b/samples/drivers/ipm/ipm_mcux/src/main_master.c
@@ -25,7 +25,7 @@ void ping_ipm_callback(const struct device *dev, void *context,
 	}
 }
 
-void main(void)
+int main(void)
 {
 	int first_message = 1; /* do not start from 0,
 				* zero value can't be sent via mailbox register
@@ -51,4 +51,5 @@ void main(void)
 	ipm_send(ipm, 1, 0, &first_message, 4);
 	while (1) {
 	}
+	return 0;
 }

--- a/samples/drivers/ipm/ipm_mhu_dual_core/src/main.c
+++ b/samples/drivers/ipm/ipm_mhu_dual_core/src/main.c
@@ -45,7 +45,7 @@ static void mhu_isr_callback(const struct device *dev, void *context,
 	}
 }
 
-void main(void)
+int main(void)
 {
 	printk("IPM MHU sample on %s\n", CONFIG_BOARD);
 
@@ -67,4 +67,5 @@ void main(void)
 	}
 
 	main_cpu_1();
+	return 0;
 }

--- a/samples/drivers/jesd216/src/main.c
+++ b/samples/drivers/jesd216/src/main.c
@@ -276,13 +276,13 @@ static void dump_bytes(const struct jesd216_param_header *php,
 	printf("];\n");
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET(FLASH_NODE);
 
 	if (!device_is_ready(dev)) {
 		printf("%s: device not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	const uint8_t decl_nph = 5;
@@ -296,14 +296,14 @@ void main(void)
 	if (rc != 0) {
 		printf("Read SFDP not supported: device not JESD216-compliant "
 		       "(err %d)\n", rc);
-		return;
+		return 0;
 	}
 
 	uint32_t magic = jesd216_sfdp_magic(hp);
 
 	if (magic != JESD216_SFDP_MAGIC) {
 		printf("SFDP magic %08x invalid", magic);
-		return;
+		return 0;
 	}
 
 	printf("%s: SFDP v %u.%u AP %x with %u PH\n", dev->name,
@@ -325,7 +325,7 @@ void main(void)
 		rc = flash_sfdp_read(dev, addr, dw, sizeof(dw));
 		if (rc != 0) {
 			printf("Read failed: %d\n", rc);
-			return;
+			return 0;
 		}
 
 		if (id == JESD216_SFDP_PARAM_ID_BFP) {
@@ -352,4 +352,5 @@ void main(void)
 	} else {
 		printf("JEDEC ID read failed: %d\n", rc);
 	}
+	return 0;
 }

--- a/samples/drivers/kscan/src/main.c
+++ b/samples/drivers/kscan/src/main.c
@@ -149,13 +149,13 @@ static void block_matrix_callback(struct k_timer *timer)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	printk("Kscan matrix sample application\n");
 
 	if (!device_is_ready(kscan_dev)) {
 		LOG_ERR("kscan device %s not ready", kscan_dev->name);
-		return;
+		return 0;
 	}
 
 	kscan_config(kscan_dev, kb_callback);
@@ -163,4 +163,5 @@ void main(void)
 	k_timer_init(&block_matrix_timer, block_matrix_callback, NULL);
 	k_timer_start(&block_matrix_timer, K_SECONDS(1), K_SECONDS(3));
 
+	return 0;
 }

--- a/samples/drivers/kscan_touch/src/main.c
+++ b/samples/drivers/kscan_touch/src/main.c
@@ -26,15 +26,16 @@ static void k_callback(const struct device *dev, uint32_t row, uint32_t col,
 	}
 }
 
-void main(void)
+int main(void)
 {
 	printk("Kscan touch panel sample application\n");
 
 	if (!device_is_ready(kscan_dev)) {
 		LOG_ERR("kscan device %s not ready", kscan_dev->name);
-		return;
+		return 0;
 	}
 
 	kscan_config(kscan_dev, k_callback);
 	kscan_enable_callback(kscan_dev);
+	return 0;
 }

--- a/samples/drivers/lcd_cyclonev_socdk/src/main.c
+++ b/samples/drivers/lcd_cyclonev_socdk/src/main.c
@@ -84,7 +84,7 @@ void next_line(void)
 	send_command_one_param(SET_CURSOR, 0x40);
 }
 
-void main(void)
+int main(void)
 {
 	printk("Hello World! %s\n", CONFIG_BOARD);
 	static const unsigned char string[] = "Hello world!";
@@ -102,4 +102,5 @@ void main(void)
 	k_sleep(K_MSEC(10));
 	send_string((uint8_t *)&string, len);
 
+	return 0;
 }

--- a/samples/drivers/lcd_hd44780/src/main.c
+++ b/samples/drivers/lcd_hd44780/src/main.c
@@ -525,13 +525,13 @@ void pi_lcd_init(const struct device *gpio_dev, uint8_t cols, uint8_t rows,
 	_pi_lcd_command(gpio_dev, LCD_ENTRY_MODE_SET | lcd_data.disp_mode);
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const gpio_dev = DEVICE_DT_GET(GPIO_NODE);
 
 	if (!device_is_ready(gpio_dev)) {
 		printk("Device %s not ready!\n", gpio_dev->name);
-		return;
+		return 0;
 	}
 
 	/* Setup GPIO output */
@@ -600,4 +600,5 @@ void main(void)
 		/* Clear display */
 		pi_lcd_clear(gpio_dev);
 	}
+	return 0;
 }

--- a/samples/drivers/led_apa102/src/main.c
+++ b/samples/drivers/led_apa102/src/main.c
@@ -51,7 +51,7 @@ const struct led_rgb *color_at(size_t time, size_t i)
 }
 
 #define DELAY_TIME K_MSEC(40)
-void main(void)
+int main(void)
 {
 	const struct device *strip;
 	size_t i, time;
@@ -59,10 +59,10 @@ void main(void)
 	strip = DEVICE_DT_GET_ANY(apa_apa102);
 	if (!strip) {
 		LOG_ERR("LED strip device not found");
-		return;
+		return 0;
 	} else if (!device_is_ready(strip)) {
 		LOG_ERR("LED strip device %s is not ready", strip->name);
-		return;
+		return 0;
 	} else {
 		LOG_INF("Found LED strip device %s", strip->name);
 	}
@@ -84,4 +84,5 @@ void main(void)
 		k_sleep(DELAY_TIME);
 		time++;
 	}
+	return 0;
 }

--- a/samples/drivers/led_apa102c_bitbang/src/main.c
+++ b/samples/drivers/led_apa102c_bitbang/src/main.c
@@ -63,7 +63,7 @@ void send_rgb(const struct device *gpio_dev, uint32_t rgb)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *gpio_dev;
 	int ret;
@@ -73,7 +73,7 @@ void main(void)
 	gpio_dev = DEVICE_DT_GET(DT_ALIAS(gpio_0));
 	if (!device_is_ready(gpio_dev)) {
 		printk("GPIO device %s is not ready!\n", gpio_dev->name);
-		return;
+		return 0;
 	}
 
 	/* Setup GPIO output */
@@ -107,4 +107,5 @@ void main(void)
 
 		k_sleep(SLEEPTIME);
 	}
+	return 0;
 }

--- a/samples/drivers/led_lp3943/src/main.c
+++ b/samples/drivers/led_lp3943/src/main.c
@@ -18,17 +18,17 @@ LOG_MODULE_REGISTER(app);
 
 #define DELAY_TIME K_MSEC(1000)
 
-void main(void)
+int main(void)
 {
 	const struct device *const led_dev = DEVICE_DT_GET_ANY(ti_lp3943);
 	int i, ret;
 
 	if (!led_dev) {
 		LOG_ERR("No device with compatible ti,lp3943 found");
-		return;
+		return 0;
 	} else if (!device_is_ready(led_dev)) {
 		LOG_ERR("LED device %s not ready", led_dev->name);
-		return;
+		return 0;
 	} else {
 		LOG_INF("Found LED device %s", led_dev->name);
 	}
@@ -45,7 +45,7 @@ void main(void)
 		for (i = 0; i < NUM_LEDS; i++) {
 			ret = led_on(led_dev, i);
 			if (ret < 0) {
-				return;
+				return 0;
 			}
 
 			k_sleep(DELAY_TIME);
@@ -55,10 +55,11 @@ void main(void)
 		for (i = NUM_LEDS - 1; i >= 0; i--) {
 			ret = led_off(led_dev, i);
 			if (ret < 0) {
-				return;
+				return 0;
 			}
 
 			k_sleep(DELAY_TIME);
 		}
 	}
+	return 0;
 }

--- a/samples/drivers/led_lp503x/src/main.c
+++ b/samples/drivers/led_lp503x/src/main.c
@@ -209,7 +209,7 @@ static int run_channel_test(const struct device *lp503x_dev)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const lp503x_dev = DEVICE_DT_GET_ANY(ti_lp503x);
 
@@ -219,10 +219,10 @@ void main(void)
 
 	if (!lp503x_dev) {
 		LOG_ERR("No device with compatible ti,lp503x found");
-		return;
+		return 0;
 	} else if (!device_is_ready(lp503x_dev)) {
 		LOG_ERR("LED controller %s is not ready", lp503x_dev->name);
-		return;
+		return 0;
 	}
 	LOG_INF("Found LED controller %s", lp503x_dev->name);
 
@@ -256,19 +256,20 @@ void main(void)
 	num_leds = led;
 	if (!num_leds) {
 		LOG_ERR("No LEDs found");
-		return;
+		return 0;
 	}
 
 	do {
 		err = run_channel_test(lp503x_dev);
 		if (err) {
-			return;
+			return 0;
 		}
 		for (led = 0; led < num_leds; led++) {
 			err = run_led_test(lp503x_dev, led);
 			if (err) {
-				return;
+				return 0;
 			}
 		}
 	} while (true);
+	return 0;
 }

--- a/samples/drivers/led_lp5562/src/main.c
+++ b/samples/drivers/led_lp5562/src/main.c
@@ -162,17 +162,17 @@ static int turn_off_all_leds(const struct device *dev)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ANY(ti_lp5562);
 	int i, ret;
 
 	if (!dev) {
 		LOG_ERR("No \"ti,lp5562\" device found");
-		return;
+		return 0;
 	} else if (!device_is_ready(dev)) {
 		LOG_ERR("LED device %s is not ready", dev->name);
-		return;
+		return 0;
 	} else {
 		LOG_INF("Found LED device %s", dev->name);
 	}
@@ -187,7 +187,7 @@ void main(void)
 					colors[i][1],
 					colors[i][2]);
 			if (ret) {
-				return;
+				return 0;
 			}
 
 			k_msleep(DELAY_TIME);
@@ -195,14 +195,14 @@ void main(void)
 
 		ret = turn_off_all_leds(dev);
 		if (ret < 0) {
-			return;
+			return 0;
 		}
 
 		/* Blink white. */
 		ret = blink_color(dev, true, true, true, BLINK_DELAY_ON,
 				BLINK_DELAY_OFF);
 		if (ret) {
-			return;
+			return 0;
 		}
 
 		/* Wait a few blinking before turning off the LEDs */
@@ -215,7 +215,7 @@ void main(void)
 					colors[i][1],
 					colors[i][2]);
 			if (ret) {
-				return;
+				return 0;
 			}
 
 			k_msleep(DELAY_TIME * 2);
@@ -223,9 +223,10 @@ void main(void)
 
 		ret = turn_off_all_leds(dev);
 		if (ret < 0) {
-			return;
+			return 0;
 		}
 
 		k_msleep(DELAY_TIME);
 	}
+	return 0;
 }

--- a/samples/drivers/led_lpd8806/src/main.c
+++ b/samples/drivers/led_lpd8806/src/main.c
@@ -51,16 +51,16 @@ const struct led_rgb *color_at(size_t time, size_t i)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	size_t i, time;
 
 	if (!strip) {
 		LOG_ERR("LED strip device not found");
-		return;
+		return 0;
 	} else if (!device_is_ready(strip)) {
 		LOG_INF("LED strip device %s is not ready", strip->name);
-		return;
+		return 0;
 	}
 	LOG_INF("Found LED strip device %s", strip->name);
 
@@ -80,4 +80,5 @@ void main(void)
 		k_sleep(DELAY_TIME);
 		time++;
 	}
+	return 0;
 }

--- a/samples/drivers/led_pca9633/src/main.c
+++ b/samples/drivers/led_pca9633/src/main.c
@@ -22,17 +22,17 @@ LOG_MODULE_REGISTER(main);
 #define DELAY_TIME_MS 1000
 #define DELAY_TIME K_MSEC(DELAY_TIME_MS)
 
-void main(void)
+int main(void)
 {
 	const struct device *const led_dev = DEVICE_DT_GET_ANY(nxp_pca9633);
 	int i, ret;
 
 	if (!led_dev) {
 		LOG_ERR("No devices with compatible nxp,pca9633 found");
-		return;
+		return 0;
 	} else if (!device_is_ready(led_dev)) {
 		LOG_ERR("LED device %s is not ready", led_dev->name);
-		return;
+		return 0;
 	} else {
 		LOG_INF("Found LED device %s", led_dev->name);
 	}
@@ -44,7 +44,7 @@ void main(void)
 		for (i = 0; i < NUM_LEDS; i++) {
 			ret = led_on(led_dev, i);
 			if (ret < 0) {
-				return;
+				return 0;
 			}
 
 			k_sleep(DELAY_TIME);
@@ -54,7 +54,7 @@ void main(void)
 		for (i = 0; i < NUM_LEDS; i++) {
 			ret = led_off(led_dev, i);
 			if (ret < 0) {
-				return;
+				return 0;
 			}
 
 			k_sleep(DELAY_TIME);
@@ -64,7 +64,7 @@ void main(void)
 		for (i = 0; i < NUM_LEDS; i++) {
 			ret = led_set_brightness(led_dev, i, HALF_BRIGHTNESS);
 			if (ret < 0) {
-				return;
+				return 0;
 			}
 
 			k_sleep(DELAY_TIME);
@@ -74,7 +74,7 @@ void main(void)
 		for (i = 0; i < NUM_LEDS; i++) {
 			ret = led_off(led_dev, i);
 			if (ret < 0) {
-				return;
+				return 0;
 			}
 
 			k_sleep(DELAY_TIME);
@@ -85,7 +85,7 @@ void main(void)
 			ret = led_blink(led_dev, i, BLINK_DELAY_ON,
 					BLINK_DELAY_OFF);
 			if (ret < 0) {
-				return;
+				return 0;
 			}
 
 			k_sleep(DELAY_TIME);
@@ -98,11 +98,12 @@ void main(void)
 		for (i = 0; i < NUM_LEDS; i++) {
 			ret = led_off(led_dev, i);
 			if (ret < 0) {
-				return;
+				return 0;
 			}
 
 			k_sleep(DELAY_TIME);
 		}
 
 	}
+	return 0;
 }

--- a/samples/drivers/led_pwm/src/main.c
+++ b/samples/drivers/led_pwm/src/main.c
@@ -98,7 +98,7 @@ static void run_led_test(const struct device *led_pwm, uint8_t led)
 	LOG_INF("  Turned off, loop end");
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *led_pwm;
 	uint8_t led;
@@ -106,12 +106,12 @@ void main(void)
 	led_pwm = DEVICE_DT_GET(LED_PWM_NODE_ID);
 	if (!device_is_ready(led_pwm)) {
 		LOG_ERR("Device %s is not ready", led_pwm->name);
-		return;
+		return 0;
 	}
 
 	if (!num_leds) {
 		LOG_ERR("No LEDs found for %s", led_pwm->name);
-		return;
+		return 0;
 	}
 
 	do {
@@ -119,4 +119,5 @@ void main(void)
 			run_led_test(led_pwm, led);
 		}
 	} while (true);
+	return 0;
 }

--- a/samples/drivers/led_sx1509b_intensity/src/main.c
+++ b/samples/drivers/led_sx1509b_intensity/src/main.c
@@ -65,7 +65,7 @@ static void rgb_work_handler(struct k_work *work)
 	k_work_schedule(k_work_delayable_from_work(work), K_MSEC(10));
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -75,7 +75,7 @@ void main(void)
 
 	if (!device_is_ready(sx1509b_dev)) {
 		printk("sx1509b: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	for (int i = 0; i < NUMBER_OF_LEDS; i++) {
@@ -89,4 +89,5 @@ void main(void)
 
 	k_work_init_delayable(&rgb_work, rgb_work_handler);
 	k_work_schedule(&rgb_work, K_NO_WAIT);
+	return 0;
 }

--- a/samples/drivers/led_ws2812/src/main.c
+++ b/samples/drivers/led_ws2812/src/main.c
@@ -35,7 +35,7 @@ struct led_rgb pixels[STRIP_NUM_PIXELS];
 
 static const struct device *const strip = DEVICE_DT_GET(STRIP_NODE);
 
-void main(void)
+int main(void)
 {
 	size_t cursor = 0, color = 0;
 	int rc;
@@ -44,7 +44,7 @@ void main(void)
 		LOG_INF("Found LED strip device %s", strip->name);
 	} else {
 		LOG_ERR("LED strip device %s is not ready", strip->name);
-		return;
+		return 0;
 	}
 
 	LOG_INF("Displaying pattern on strip");
@@ -68,4 +68,5 @@ void main(void)
 
 		k_sleep(DELAY_TIME);
 	}
+	return 0;
 }

--- a/samples/drivers/led_xec/src/main.c
+++ b/samples/drivers/led_xec/src/main.c
@@ -127,7 +127,8 @@ int led_test(void)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	led_test();
+	return 0;
 }

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -38,7 +38,7 @@ void lora_receive_cb(const struct device *dev, uint8_t *data, uint16_t size,
 	}
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const lora_dev = DEVICE_DT_GET(DEFAULT_RADIO_NODE);
 	struct lora_modem_config config;
@@ -49,7 +49,7 @@ void main(void)
 
 	if (!device_is_ready(lora_dev)) {
 		LOG_ERR("%s Device not ready", lora_dev->name);
-		return;
+		return 0;
 	}
 
 	config.frequency = 865100000;
@@ -65,7 +65,7 @@ void main(void)
 	ret = lora_config(lora_dev, &config);
 	if (ret < 0) {
 		LOG_ERR("LoRa config failed");
-		return;
+		return 0;
 	}
 
 	/* Receive 4 packets synchronously */
@@ -76,7 +76,7 @@ void main(void)
 				&rssi, &snr);
 		if (len < 0) {
 			LOG_ERR("LoRa receive failed");
-			return;
+			return 0;
 		}
 
 		LOG_INF("Received data: %s (RSSI:%ddBm, SNR:%ddBm)",
@@ -87,4 +87,5 @@ void main(void)
 	LOG_INF("Asynchronous reception");
 	lora_recv_async(lora_dev, lora_receive_cb);
 	k_sleep(K_FOREVER);
+	return 0;
 }

--- a/samples/drivers/lora/send/src/main.c
+++ b/samples/drivers/lora/send/src/main.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(lora_send);
 
 char data[MAX_DATA_LEN] = {'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd'};
 
-void main(void)
+int main(void)
 {
 	const struct device *const lora_dev = DEVICE_DT_GET(DEFAULT_RADIO_NODE);
 	struct lora_modem_config config;
@@ -30,7 +30,7 @@ void main(void)
 
 	if (!device_is_ready(lora_dev)) {
 		LOG_ERR("%s Device not ready", lora_dev->name);
-		return;
+		return 0;
 	}
 
 	config.frequency = 865100000;
@@ -46,14 +46,14 @@ void main(void)
 	ret = lora_config(lora_dev, &config);
 	if (ret < 0) {
 		LOG_ERR("LoRa config failed");
-		return;
+		return 0;
 	}
 
 	while (1) {
 		ret = lora_send(lora_dev, data, MAX_DATA_LEN);
 		if (ret < 0) {
 			LOG_ERR("LoRa send failed");
-			return;
+			return 0;
 		}
 
 		LOG_INF("Data sent!");
@@ -61,4 +61,5 @@ void main(void)
 		/* Send data at 1s interval */
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }

--- a/samples/drivers/mbox/remote/src/main.c
+++ b/samples/drivers/mbox/remote/src/main.c
@@ -18,7 +18,7 @@ static void callback(const struct device *dev, uint32_t channel,
 	printk("Pong (on channel %d)\n", channel);
 }
 
-void main(void)
+int main(void)
 {
 	struct mbox_channel tx_channel;
 	struct mbox_channel rx_channel;
@@ -33,12 +33,12 @@ void main(void)
 
 	if (mbox_register_callback(&rx_channel, callback, NULL)) {
 		printk("mbox_register_callback() error\n");
-		return;
+		return 0;
 	}
 
 	if (mbox_set_enabled(&rx_channel, 1)) {
 		printk("mbox_set_enable() error\n");
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -47,9 +47,10 @@ void main(void)
 
 		if (mbox_send(&tx_channel, NULL) < 0) {
 			printk("mbox_send() error\n");
-			return;
+			return 0;
 		}
 
 		k_sleep(K_MSEC(3000));
 	}
+	return 0;
 }

--- a/samples/drivers/mbox/src/main.c
+++ b/samples/drivers/mbox/src/main.c
@@ -18,7 +18,7 @@ static void callback(const struct device *dev, uint32_t channel,
 	printk("Pong (on channel %d)\n", channel);
 }
 
-void main(void)
+int main(void)
 {
 	struct mbox_channel tx_channel;
 	struct mbox_channel rx_channel;
@@ -33,12 +33,12 @@ void main(void)
 
 	if (mbox_register_callback(&rx_channel, callback, NULL)) {
 		printk("mbox_register_callback() error\n");
-		return;
+		return 0;
 	}
 
 	if (mbox_set_enabled(&rx_channel, 1)) {
 		printk("mbox_set_enable() error\n");
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -48,7 +48,8 @@ void main(void)
 
 		if (mbox_send(&tx_channel, NULL) < 0) {
 			printk("mbox_send() error\n");
-			return;
+			return 0;
 		}
 	}
+	return 0;
 }

--- a/samples/drivers/memc/src/main.c
+++ b/samples/drivers/memc/src/main.c
@@ -40,7 +40,7 @@ void dump_memory(uint8_t *p, uint32_t size)
 uint8_t memc_write_buffer[BUF_SIZE];
 uint8_t memc_read_buffer[BUF_SIZE];
 
-void main(void)
+int main(void)
 {
 	uint8_t *memc = (uint8_t *)MEMC_BASE;
 	uint32_t i, j;
@@ -66,7 +66,7 @@ void main(void)
 		if (memcmp(memc_read_buffer, memc_write_buffer, BUF_SIZE)) {
 			printk("Error: read data differs in range [0x%x- 0x%x]\n",
 				i, i + (BUF_SIZE - 1));
-			return;
+			return 0;
 		}
 	}
 	/* Copy any remaining space bytewise */
@@ -74,11 +74,12 @@ void main(void)
 		memc_read_buffer[i] = memc[i];
 		if (memc_write_buffer[i] != memc_read_buffer[i]) {
 			printk("Error: read data differs at offset 0x%x\n", i);
-			return;
+			return 0;
 		}
 	}
 	printk("First 1KB of Data in memory:\n");
 	printk("===========================\n");
 	dump_memory(memc, MIN(MEMC_SIZE, KB(1)));
 	printk("Read data matches written data\n");
+	return 0;
 }

--- a/samples/drivers/misc/ft800/src/main.c
+++ b/samples/drivers/misc/ft800/src/main.c
@@ -28,7 +28,7 @@ static void touch_irq(void)
 	process_touch = true;
 }
 
-void main(void)
+int main(void)
 {
 	int cnt;
 	int val;
@@ -93,4 +93,5 @@ void main(void)
 		/* Wait a while */
 		k_msleep(SLEEPTIME);
 	}
+	return 0;
 }

--- a/samples/drivers/misc/grove_display/src/main.c
+++ b/samples/drivers/misc/grove_display/src/main.c
@@ -31,7 +31,7 @@ uint8_t clamp_rgb(int val)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const glcd = DEVICE_DT_GET(DT_NODELABEL(glcd));
 	char str[20];
@@ -44,7 +44,7 @@ void main(void)
 
 	if (!device_is_ready(glcd)) {
 		printk("Grove LCD: Device not ready.\n");
-		return;
+		return 0;
 	}
 
 	/* Now configure the LCD the way we want it */
@@ -123,4 +123,5 @@ void main(void)
 		/* wait a while */
 		k_msleep(SLEEPTIME);
 	}
+	return 0;
 }

--- a/samples/drivers/peci/src/main.c
+++ b/samples/drivers/peci/src/main.c
@@ -174,7 +174,7 @@ static void monitor_temperature_func(void *dummy1, void *dummy2, void *dummy3)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	int ret;
 
@@ -186,13 +186,13 @@ void main(void)
 
 	if (!device_is_ready(peci_dev)) {
 		printk("Err: PECI device is not ready\n");
-		return;
+		return 0;
 	}
 
 	ret = peci_config(peci_dev, 1000u);
 	if (ret) {
 		printk("Err: Fail to configure bitrate\n");
-		return;
+		return 0;
 	}
 
 	peci_enable(peci_dev);
@@ -204,4 +204,5 @@ void main(void)
 	k_thread_start(&temp_id);
 
 	peci_initialized = true;
+	return 0;
 }

--- a/samples/drivers/ps2/src/main.c
+++ b/samples/drivers/ps2/src/main.c
@@ -167,7 +167,7 @@ void initialize_mouse(void)
 	k_msleep(MS_BETWEEN_REGULAR_CALLS);
 }
 
-void main(void)
+int main(void)
 {
 	printk("PS/2 test with mouse\n");
 	/* Wait for the PS/2 BAT to finish */
@@ -178,11 +178,12 @@ void main(void)
 	 */
 	if (!device_is_ready(ps2_0_dev)) {
 		printk("%s: device not ready.\n", ps2_0_dev->name);
-		return;
+		return 0;
 	}
 	ps2_config(ps2_0_dev, mb_callback);
 	/*Make sure there is a PS/2 device connected */
 	initialize_mouse();
 
 	k_timer_start(&block_ps2_timer, K_SECONDS(2), K_SECONDS(1));
+	return 0;
 }

--- a/samples/drivers/smbus/src/main.c
+++ b/samples/drivers/smbus/src/main.c
@@ -6,7 +6,8 @@
 
 #include <zephyr/kernel.h>
 
-void main(void)
+int main(void)
 {
 	printk("Start SMBUS shell sample %s\n", CONFIG_BOARD);
+	return 0;
 }

--- a/samples/drivers/soc_flash_nrf/src/main.c
+++ b/samples/drivers/soc_flash_nrf/src/main.c
@@ -31,7 +31,7 @@
 #define FLASH_TEST_OFFSET2 0x41234
 #define FLASH_TEST_PAGE_IDX 37
 
-void main(void)
+int main(void)
 {
 	const struct device *flash_dev = TEST_PARTITION_DEVICE;
 	uint32_t buf_array_1[4] = { TEST_DATA_WORD_0, TEST_DATA_WORD_1,
@@ -50,7 +50,7 @@ void main(void)
 
 	if (!device_is_ready(flash_dev)) {
 		printf("Flash device not ready\n");
-		return;
+		return 0;
 	}
 
 	printf("\nTest 1: Flash erase page at 0x%x\n", TEST_PARTITION_OFFSET);
@@ -68,13 +68,13 @@ void main(void)
 		if (flash_write(flash_dev, offset, &buf_array_1[i],
 					sizeof(uint32_t)) != 0) {
 			printf("   Flash write failed!\n");
-			return;
+			return 0;
 		}
 		printf("   Attempted to read 0x%x\n", offset);
 		if (flash_read(flash_dev, offset, &buf_word,
 					sizeof(uint32_t)) != 0) {
 			printf("   Flash read failed!\n");
-			return;
+			return 0;
 		}
 		printf("   Data read: %x\n", buf_word);
 		if (buf_array_1[i] == buf_word) {
@@ -100,13 +100,13 @@ void main(void)
 		if (flash_write(flash_dev, offset, &buf_array_2[i],
 					sizeof(uint32_t)) != 0) {
 			printf("   Flash write failed!\n");
-			return;
+			return 0;
 		}
 		printf("   Attempted to read 0x%x\n", offset);
 		if (flash_read(flash_dev, offset, &buf_word,
 					sizeof(uint32_t)) != 0) {
 			printf("   Flash read failed!\n");
-			return;
+			return 0;
 		}
 		printf("   Data read: %x\n", buf_word);
 		if (buf_array_2[i] == buf_word) {
@@ -131,13 +131,13 @@ void main(void)
 		if (flash_write(flash_dev, offset, &buf_array_3[i],
 					sizeof(uint32_t)) != 0) {
 			printf("   Flash write failed!\n");
-			return;
+			return 0;
 		}
 		printf("   Attempted to read 0x%x\n", offset);
 		if (flash_read(flash_dev, offset, &buf_word,
 					sizeof(uint32_t)) != 0) {
 			printf("   Flash read failed!\n");
-			return;
+			return 0;
 		}
 		printf("   Data read: %x\n", buf_word);
 		if (buf_array_3[i] == buf_word) {
@@ -191,4 +191,5 @@ void main(void)
 	printf("\nTest 8: Write block size API\n");
 	printf("   write-block-size = %u\n",
 	       flash_get_write_block_size(flash_dev));
+	return 0;
 }

--- a/samples/drivers/spi_bitbang/src/main.c
+++ b/samples/drivers/spi_bitbang/src/main.c
@@ -118,13 +118,13 @@ void test_8bit_xfer(const struct device *dev, struct spi_cs_control *cs)
 	       rxdata[0], rxdata[1], rxdata[2], rxdata[3], rxdata[4]);
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET(SPIBB_NODE);
 
 	if (!device_is_ready(dev)) {
 		printk("%s: device not ready.\n", dev->name);
-		return;
+		return 0;
 	}
 
 	struct spi_cs_control cs_ctrl = (struct spi_cs_control){
@@ -147,4 +147,5 @@ void main(void)
 		test_8bit_xfer(dev, &cs_ctrl);
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }

--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -175,13 +175,13 @@ void multi_sector_test(const struct device *flash_dev)
 }
 #endif
 
-void main(void)
+int main(void)
 {
 	const struct device *flash_dev = DEVICE_DT_GET(DT_ALIAS(spi_flash0));
 
 	if (!device_is_ready(flash_dev)) {
 		printk("%s: device not ready.\n", flash_dev->name);
-		return;
+		return 0;
 	}
 
 	printf("\n%s SPI flash testing\n", flash_dev->name);
@@ -191,4 +191,5 @@ void main(void)
 #if defined SPI_FLASH_MULTI_SECTOR_TEST
 	multi_sector_test(flash_dev);
 #endif
+	return 0;
 }

--- a/samples/drivers/spi_flash_at45/src/main.c
+++ b/samples/drivers/spi_flash_at45/src/main.c
@@ -23,7 +23,7 @@
 static uint8_t write_buf[TEST_REGION_SIZE];
 static uint8_t read_buf[TEST_REGION_SIZE];
 
-void main(void)
+int main(void)
 {
 	printk("DataFlash sample on %s\n", CONFIG_BOARD);
 
@@ -38,7 +38,7 @@ void main(void)
 
 	if (!device_is_ready(flash_dev)) {
 		printk("%s: device not ready.\n", flash_dev->name);
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
@@ -53,7 +53,7 @@ void main(void)
 	err = flash_read(flash_dev, TEST_REGION_OFFSET, &data, 1);
 	if (err != 0) {
 		printk("FAILED\n");
-		return;
+		return 0;
 	}
 
 	printk("OK\n");
@@ -80,7 +80,7 @@ void main(void)
 
 	if (err != 0) {
 		printk("FAILED\n");
-		return;
+		return 0;
 	}
 
 	printk("OK\n");
@@ -90,7 +90,7 @@ void main(void)
 			 read_buf, TEST_REGION_SIZE);
 	if (err != 0) {
 		printk("FAILED\n");
-		return;
+		return 0;
 	}
 
 	for (i = 0; i < TEST_REGION_SIZE; ++i) {
@@ -98,7 +98,7 @@ void main(void)
 			printk("\nERROR at read_buf[%d]: "
 			       "expected 0x%02X, got 0x%02X\n",
 			       i, 0xFF, read_buf[i]);
-			return;
+			return 0;
 		}
 	}
 
@@ -110,7 +110,7 @@ void main(void)
 			  write_buf,  TEST_REGION_SIZE/2);
 	if (err != 0) {
 		printk("FAILED\n");
-		return;
+		return 0;
 	}
 
 	printk("OK\n");
@@ -120,7 +120,7 @@ void main(void)
 			  &write_buf[TEST_REGION_SIZE/2], TEST_REGION_SIZE/2);
 	if (err != 0) {
 		printk("FAILED\n");
-		return;
+		return 0;
 	}
 
 	printk("OK\n");
@@ -130,7 +130,7 @@ void main(void)
 			 read_buf, TEST_REGION_SIZE);
 	if (err != 0) {
 		printk("FAILED\n");
-		return;
+		return 0;
 	}
 
 	printk("OK\n");
@@ -141,7 +141,7 @@ void main(void)
 			printk("\nERROR at read_buf[%d]: "
 			       "expected 0x%02X, got 0x%02X\n",
 			       i, write_buf[i], read_buf[i]);
-			return;
+			return 0;
 		}
 	}
 
@@ -152,7 +152,7 @@ void main(void)
 	err = pm_device_action_run(flash_dev, PM_DEVICE_ACTION_SUSPEND);
 	if (err != 0) {
 		printk("FAILED\n");
-		return;
+		return 0;
 	}
 
 	printk("OK\n");

--- a/samples/drivers/spi_fujitsu_fram/src/main.c
+++ b/samples/drivers/spi_fujitsu_fram/src/main.c
@@ -137,7 +137,7 @@ static int read_bytes(const struct device *spi, struct spi_config *spi_cfg,
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *spi;
 	struct spi_config spi_cfg = {0};
@@ -148,7 +148,7 @@ void main(void)
 	spi = DEVICE_DT_GET(DT_ALIAS(spi_1));
 	if (!device_is_ready(spi)) {
 		printk("SPI device %s is not ready\n", spi->name);
-		return;
+		return 0;
 	}
 
 	spi_cfg.operation = SPI_WORD_SET(8);
@@ -158,7 +158,7 @@ void main(void)
 	err = mb85rs64v_read_id(spi, &spi_cfg);
 	if (err) {
 		printk("Could not verify FRAM ID\n");
-		return;
+		return 0;
 	}
 
 	/* Do one-byte read/write */
@@ -166,7 +166,7 @@ void main(void)
 	err = write_bytes(spi, &spi_cfg, 0x00, data, 1);
 	if (err) {
 		printk("Error writing to FRAM! error code (%d)\n", err);
-		return;
+		return 0;
 	} else {
 		printk("Wrote 0xAE to address 0x00.\n");
 	}
@@ -175,7 +175,7 @@ void main(void)
 	err = write_bytes(spi, &spi_cfg, 0x01, data, 1);
 	if (err) {
 		printk("Error writing to FRAM! error code (%d)\n", err);
-		return;
+		return 0;
 	} else {
 		printk("Wrote 0x86 to address 0x01.\n");
 	}
@@ -184,7 +184,7 @@ void main(void)
 	err = read_bytes(spi, &spi_cfg, 0x00, data, 1);
 	if (err) {
 		printk("Error reading from FRAM! error code (%d)\n", err);
-		return;
+		return 0;
 	} else {
 		printk("Read 0x%X from address 0x00.\n", data[0]);
 	}
@@ -193,7 +193,7 @@ void main(void)
 	err = read_bytes(spi, &spi_cfg, 0x01, data, 1);
 	if (err) {
 		printk("Error reading from FRAM! error code (%d)\n", err);
-		return;
+		return 0;
 	} else {
 		printk("Read 0x%X from address 0x01.\n", data[0]);
 	}
@@ -209,7 +209,7 @@ void main(void)
 	err = write_bytes(spi, &spi_cfg, 0x00, cmp_data, sizeof(cmp_data));
 	if (err) {
 		printk("Error writing to FRAM! error code (%d)\n", err);
-		return;
+		return 0;
 	} else {
 		printk("Wrote %d bytes to address 0x00.\n",
 		       (uint32_t) sizeof(cmp_data));
@@ -218,7 +218,7 @@ void main(void)
 	err = read_bytes(spi, &spi_cfg, 0x00, data, sizeof(data));
 	if (err) {
 		printk("Error reading from FRAM! error code (%d)\n", err);
-		return;
+		return 0;
 	} else {
 		printk("Read %d bytes from address 0x00.\n",
 		       (uint32_t) sizeof(data));
@@ -234,4 +234,5 @@ void main(void)
 	if (err == 0) {
 		printk("Data comparison successful.\n");
 	}
+	return 0;
 }

--- a/samples/drivers/uart/echo_bot/src/main.c
+++ b/samples/drivers/uart/echo_bot/src/main.c
@@ -70,13 +70,13 @@ void print_uart(char *buf)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	char tx_buf[MSG_SIZE];
 
 	if (!device_is_ready(uart_dev)) {
 		printk("UART device not found!");
-		return;
+		return 0;
 	}
 
 	/* configure interrupt and callback to receive data */
@@ -90,7 +90,7 @@ void main(void)
 		} else {
 			printk("Error setting UART callback: %d\n", ret);
 		}
-		return;
+		return 0;
 	}
 	uart_irq_rx_enable(uart_dev);
 
@@ -103,4 +103,5 @@ void main(void)
 		print_uart(tx_buf);
 		print_uart("\r\n");
 	}
+	return 0;
 }

--- a/samples/drivers/uart/stm32/single_wire/src/main.c
+++ b/samples/drivers/uart/stm32/single_wire/src/main.c
@@ -15,13 +15,13 @@
 const struct device *const sl_uart1 = DEVICE_DT_GET(UART_NODE1);
 const struct device *const sl_uart2 = DEVICE_DT_GET(UART_NODE2);
 
-void main(void)
+int main(void)
 {
 	unsigned char recv;
 
 	if (!device_is_ready(sl_uart1) || !device_is_ready(sl_uart2)) {
 		printk("uart devices not ready\n");
-		return;
+		return 0;
 	}
 
 	while (true) {
@@ -41,4 +41,5 @@ void main(void)
 
 		k_sleep(K_MSEC(2000));
 	}
+	return 0;
 }

--- a/samples/drivers/virtualization/ivshmem/doorbell/src/ivshmem.c
+++ b/samples/drivers/virtualization/ivshmem/doorbell/src/ivshmem.c
@@ -266,7 +266,7 @@ static void ivshmem_sample_userspace_doorbell(void)
 }
 #endif /* CONFIG_USERSPACE */
 
-void main(void)
+int main(void)
 {
 #ifdef CONFIG_USERSPACE
 	ivshmem_sample_userspace_doorbell();
@@ -275,4 +275,5 @@ void main(void)
 #endif
 	/* if the code reaches here, it means the setup/loop has failed */
 	ivshmem_sample_failed();
+	return 0;
 }

--- a/samples/drivers/w1/scanner/src/main.c
+++ b/samples/drivers/w1/scanner/src/main.c
@@ -17,16 +17,17 @@ void w1_search_callback(struct w1_rom rom, void *user_data)
 		w1_rom_to_uint64(&rom));
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(w1));
 
 	if (!device_is_ready(dev)) {
 		LOG_ERR("Device not ready");
-		return;
+		return 0;
 	}
 
 	int num_devices = w1_search_rom(dev, w1_search_callback, NULL);
 
 	LOG_INF("Number of devices found on bus: %d", num_devices);
+	return 0;
 }

--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -68,7 +68,7 @@ static void wdt_callback(const struct device *wdt_dev, int channel_id)
 }
 #endif /* WDT_ALLOW_CALLBACK */
 
-void main(void)
+int main(void)
 {
 	int err;
 	int wdt_channel_id;
@@ -78,7 +78,7 @@ void main(void)
 
 	if (!device_is_ready(wdt)) {
 		printk("%s: device not ready.\n", wdt->name);
-		return;
+		return 0;
 	}
 
 	struct wdt_timeout_cfg wdt_config = {
@@ -108,13 +108,13 @@ void main(void)
 	}
 	if (wdt_channel_id < 0) {
 		printk("Watchdog install error\n");
-		return;
+		return 0;
 	}
 
 	err = wdt_setup(wdt, WDT_OPT_PAUSE_HALTED_BY_DBG);
 	if (err < 0) {
 		printk("Watchdog setup error\n");
-		return;
+		return 0;
 	}
 
 #if WDT_MIN_WINDOW != 0
@@ -134,4 +134,5 @@ void main(void)
 	while (1) {
 		k_yield();
 	}
+	return 0;
 }

--- a/samples/fuel_gauge/max17048/src/main.c
+++ b/samples/fuel_gauge/max17048/src/main.c
@@ -11,21 +11,21 @@
 
 
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ANY(maxim_max17048);
 	int ret = 0;
 
 	if (dev == NULL) {
 		printk("\nError: no device found.\n");
-		return;
+		return 0;
 	}
 
 	if (!device_is_ready(dev)) {
 		printk("\nError: Device \"%s\" is not ready; "
 		       "check the driver initialization logs for errors.\n",
 		       dev->name);
-		return;
+		return 0;
 	}
 
 
@@ -33,7 +33,7 @@ void main(void)
 	printk("Found device \"%s\", getting fuel gauge data\n", dev->name);
 
 	if (dev == NULL) {
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -101,4 +101,5 @@ void main(void)
 
 		k_sleep(K_MSEC(5000));
 	}
+	return 0;
 }

--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -6,8 +6,8 @@
 
 #include <zephyr/kernel.h>
 
-int main(void)
+void main(void)
 {
 	printk("Hello World! %s\n", CONFIG_BOARD);
-	return 0;
+	return;
 }

--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -6,7 +6,8 @@
 
 #include <zephyr/kernel.h>
 
-void main(void)
+int main(void)
 {
 	printk("Hello World! %s\n", CONFIG_BOARD);
+	return 0;
 }

--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -6,8 +6,8 @@
 
 #include <zephyr/kernel.h>
 
-void main(void)
+int main(void)
 {
 	printk("Hello World! %s\n", CONFIG_BOARD);
-	return;
+	return 0;
 }

--- a/samples/kernel/condition_variables/condvar/src/main.c
+++ b/samples/kernel/condition_variables/condvar/src/main.c
@@ -75,7 +75,7 @@ void watch_count(void *p1, void *p2, void *p3)
 	k_mutex_unlock(&count_mutex);
 }
 
-void main(void)
+int main(void)
 {
 	long t1 = 1, t2 = 2, t3 = 3;
 	int i;
@@ -101,4 +101,5 @@ void main(void)
 
 	printk("Main(): Waited and joined with %d threads. Final value of count = %d. Done.\n",
 	       NUM_THREADS, count);
+	return 0;
 }

--- a/samples/kernel/condition_variables/simple/src/main.c
+++ b/samples/kernel/condition_variables/simple/src/main.c
@@ -45,7 +45,7 @@ void worker_thread(void *p1, void *p2, void *p3)
 	k_mutex_unlock(&mutex);
 }
 
-void main(void)
+int main(void)
 {
 	k_tid_t tid[NUM_THREADS];
 
@@ -83,4 +83,5 @@ void main(void)
 		__func__, (int)NUM_THREADS);
 
 	k_mutex_unlock(&mutex);
+	return 0;
 }

--- a/samples/kernel/metairq_dispatch/src/main.c
+++ b/samples/kernel/metairq_dispatch/src/main.c
@@ -222,7 +222,7 @@ static void thread_fn(void *p1, void *p2, void *p3)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	for (long i = 0; i < NUM_THREADS; i++) {
 		/* Each thread gets a different priority.  Half should
@@ -243,4 +243,5 @@ void main(void)
 	}
 
 	message_dev_init();
+	return 0;
 }

--- a/samples/modules/canopennode/src/main.c
+++ b/samples/modules/canopennode/src/main.c
@@ -193,7 +193,7 @@ static void config_button(void)
  * The main application thread is responsible for initializing the
  * CANopen stack and doing the non real-time processing.
  */
-void main(void)
+int main(void)
 {
 	CO_NMT_reset_cmd_t reset = CO_RESET_NOT;
 	CO_ReturnError_t err;
@@ -208,7 +208,7 @@ void main(void)
 	can.dev = CAN_INTERFACE;
 	if (!device_is_ready(can.dev)) {
 		LOG_ERR("CAN interface not ready");
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_CANOPENNODE_STORAGE
@@ -216,13 +216,13 @@ void main(void)
 	if (ret) {
 		LOG_ERR("failed to initialize settings subsystem (err = %d)",
 			ret);
-		return;
+		return 0;
 	}
 
 	ret = settings_load();
 	if (ret) {
 		LOG_ERR("failed to load settings (err = %d)", ret);
-		return;
+		return 0;
 	}
 #endif /* CONFIG_CANOPENNODE_STORAGE */
 
@@ -236,7 +236,7 @@ void main(void)
 		err = CO_init(&can, CONFIG_CANOPEN_NODE_ID, CAN_BITRATE);
 		if (err != CO_ERROR_NO) {
 			LOG_ERR("CO_init failed (err = %d)", err);
-			return;
+			return 0;
 		}
 
 		LOG_INF("CANopen stack initialized");

--- a/samples/modules/nanopb/src/main.c
+++ b/samples/modules/nanopb/src/main.c
@@ -74,7 +74,7 @@ bool decode_message(uint8_t *buffer, size_t message_length)
 	return status;
 }
 
-void main(void)
+int main(void)
 {
 	/* This is the buffer where we will store our message. */
 	uint8_t buffer[SimpleMessage_size];
@@ -82,7 +82,7 @@ void main(void)
 
 	/* Encode our message */
 	if (!encode_message(buffer, sizeof(buffer), &message_length)) {
-		return;
+		return 0;
 	}
 
 	/* Now we could transmit the message over network, store it in a file or
@@ -91,4 +91,5 @@ void main(void)
 
 	/* But because we are lazy, we will just decode it immediately. */
 	decode_message(buffer, message_length);
+	return 0;
 }

--- a/samples/net/capture/src/main.c
+++ b/samples/net/capture/src/main.c
@@ -9,7 +9,8 @@ LOG_MODULE_REGISTER(net_capture_sample, LOG_LEVEL_DBG);
 
 #include <zephyr/kernel.h>
 
-void main(void)
+int main(void)
 {
 	LOG_INF("Starting network capture sample");
+	return 0;
 }

--- a/samples/net/cloud/google_iot_mqtt/src/main.c
+++ b/samples/net/cloud/google_iot_mqtt/src/main.c
@@ -60,7 +60,7 @@ int do_sntp(void)
  *   network will just stop working.
  *
  */
-void main(void)
+int main(void)
 {
 	LOG_INF("Main entered");
 
@@ -71,8 +71,9 @@ void main(void)
 	/* early return if we failed to acquire time */
 	if (do_sntp() != 0) {
 		LOG_ERR("Failed to get NTP time");
-		return;
+		return 0;
 	}
 
 	mqtt_startup("mqtt.googleapis.com", 8883);
+	return 0;
 }

--- a/samples/net/cloud/mqtt_azure/src/main.c
+++ b/samples/net/cloud/mqtt_azure/src/main.c
@@ -508,7 +508,7 @@ static void l4_event_handler(struct net_mgmt_event_callback *cb,
 }
 #endif
 
-void main(void)
+int main(void)
 {
 	int rc;
 
@@ -516,7 +516,7 @@ void main(void)
 
 	rc = tls_init();
 	if (rc) {
-		return;
+		return 0;
 	}
 
 	k_work_init_delayable(&pub_message, publish_timeout);
@@ -530,4 +530,5 @@ void main(void)
 #endif
 
 	connect_to_cloud_and_publish();
+	return 0;
 }

--- a/samples/net/cloud/tagoio_http_post/src/main.c
+++ b/samples/net/cloud/tagoio_http_post/src/main.c
@@ -72,7 +72,7 @@ static void next_turn(void)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	LOG_INF("TagoIO IoT - HTTP Client - Temperature demo");
 
@@ -83,4 +83,5 @@ void main(void)
 
 		k_sleep(K_SECONDS(CONFIG_TAGOIO_HTTP_PUSH_INTERVAL));
 	}
+	return 0;
 }

--- a/samples/net/dhcpv4_client/src/main.c
+++ b/samples/net/dhcpv4_client/src/main.c
@@ -57,7 +57,7 @@ static void handler(struct net_mgmt_event_callback *cb,
 	}
 }
 
-void main(void)
+int main(void)
 {
 	struct net_if *iface;
 
@@ -70,4 +70,5 @@ void main(void)
 	iface = net_if_get_default();
 
 	net_dhcpv4_start(iface);
+	return 0;
 }

--- a/samples/net/dns_resolve/src/main.c
+++ b/samples/net/dns_resolve/src/main.c
@@ -348,7 +348,7 @@ static void do_mdns_ipv6_lookup(struct k_work *work)
 #define setup_ipv6(...)
 #endif /* CONFIG_NET_IPV6 */
 
-void main(void)
+int main(void)
 {
 	struct net_if *iface = net_if_get_default();
 
@@ -359,4 +359,5 @@ void main(void)
 	setup_dhcpv4(iface);
 
 	setup_ipv6(iface);
+	return 0;
 }

--- a/samples/net/dsa/src/main.c
+++ b/samples/net/dsa/src/main.c
@@ -116,9 +116,10 @@ static int init_dsa_ports(void)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	init_dsa_ports();
 
 	LOG_INF("DSA ports init - OK");
+	return 0;
 }

--- a/samples/net/eth_native_posix/src/main.c
+++ b/samples/net/eth_native_posix/src/main.c
@@ -15,7 +15,8 @@ LOG_MODULE_REGISTER(net_native_posix_sample, LOG_LEVEL_DBG);
 /* This application itself does nothing as there is net-shell that can be used
  * to monitor things.
  */
-void main(void)
+int main(void)
 {
 	LOG_INF("Start application");
+	return 0;
 }

--- a/samples/net/gptp/src/main.c
+++ b/samples/net/gptp/src/main.c
@@ -156,9 +156,10 @@ static int init_app(void)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	init_app();
 
 	init_testing();
+	return 0;
 }

--- a/samples/net/ipv4_autoconf/src/main.c
+++ b/samples/net/ipv4_autoconf/src/main.c
@@ -52,11 +52,12 @@ static void handler(struct net_mgmt_event_callback *cb,
 	}
 }
 
-void main(void)
+int main(void)
 {
 	LOG_INF("Run ipv4 autoconf client");
 
 	net_mgmt_init_event_callback(&mgmt_cb, handler,
 				     NET_EVENT_IPV4_ADDR_ADD);
 	net_mgmt_add_event_callback(&mgmt_cb);
+	return 0;
 }

--- a/samples/net/lldp/src/main.c
+++ b/samples/net/lldp/src/main.c
@@ -214,11 +214,12 @@ static int init_app(void)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	/* The application will setup VLAN but does nothing meaningful.
 	 * The configuration will enable LLDP support so you should see
 	 * LLDPDU messages sent to the network interface.
 	 */
 	init_app();
+	return 0;
 }

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -257,7 +257,7 @@ static void observe_cb(enum lwm2m_observe_event event,
 	}
 }
 
-void main(void)
+int main(void)
 {
 	uint32_t flags = IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP) ?
 				LWM2M_RD_CLIENT_FLAG_BOOTSTRAP : 0;
@@ -270,7 +270,7 @@ void main(void)
 	ret = lwm2m_setup();
 	if (ret < 0) {
 		LOG_ERR("Cannot setup LWM2M fields (%d)", ret);
-		return;
+		return 0;
 	}
 
 	(void)memset(&client, 0x0, sizeof(client));
@@ -282,4 +282,5 @@ void main(void)
 	lwm2m_rd_client_start(&client, endpoint, flags, rd_client_event, observe_cb);
 
 	k_sem_take(&quit_lock, K_FOREVER);
+	return 0;
 }

--- a/samples/net/mdns_responder/src/main.c
+++ b/samples/net/mdns_responder/src/main.c
@@ -17,8 +17,9 @@ extern void service(void);
 /* Note that this application does not do anything itself.
  * It is just a placeholder for waiting mDNS queries.
  */
-void main(void)
+int main(void)
 {
 	LOG_INF("Waiting mDNS queries...");
 	service();
+	return 0;
 }

--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -514,7 +514,7 @@ K_THREAD_DEFINE(app_thread, STACK_SIZE,
 static K_HEAP_DEFINE(app_mem_pool, 1024 * 2);
 #endif
 
-void main(void)
+int main(void)
 {
 #if defined(CONFIG_MQTT_LIB_TLS)
 	int rc;
@@ -545,4 +545,5 @@ void main(void)
 #else
 	exit(start_app());
 #endif
+	return 0;
 }

--- a/samples/net/mqtt_sn_publisher/src/main.c
+++ b/samples/net/mqtt_sn_publisher/src/main.c
@@ -91,7 +91,7 @@ static int start_client(void)
 	return start_thread();
 }
 
-void main(void)
+int main(void)
 {
 	init_app();
 
@@ -111,4 +111,5 @@ void main(void)
 #else
 	exit(start_client());
 #endif
+	return 0;
 }

--- a/samples/net/openthread/coprocessor/src/main.c
+++ b/samples/net/openthread/coprocessor/src/main.c
@@ -11,7 +11,8 @@ LOG_MODULE_REGISTER(ot_br, LOG_LEVEL_DBG);
 
 #define APP_BANNER "***** OpenThread NCP on Zephyr %s *****"
 
-void main(void)
+int main(void)
 {
 	LOG_INF(APP_BANNER, CONFIG_NET_SAMPLE_APPLICATION_VERSION);
+	return 0;
 }

--- a/samples/net/promiscuous_mode/src/main.c
+++ b/samples/net/promiscuous_mode/src/main.c
@@ -229,7 +229,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(promisc_commands,
 SHELL_CMD_REGISTER(promisc, &promisc_commands,
 		   "Promiscuous mode commands", NULL);
 
-void main(void)
+int main(void)
 {
 	struct net_pkt *pkt;
 
@@ -243,4 +243,5 @@ void main(void)
 
 		net_pkt_unref(pkt);
 	}
+	return 0;
 }

--- a/samples/net/sockets/big_http_download/src/big_http_download.c
+++ b/samples/net/sockets/big_http_download/src/big_http_download.c
@@ -356,7 +356,7 @@ error:
 	return redirect;
 }
 
-void main(void)
+int main(void)
 {
 	static struct addrinfo hints;
 	struct addrinfo *res;
@@ -475,4 +475,5 @@ redirect:
 	printf("Finished downloading.\n");
 
 	mbedtls_md_free(&hash_ctx);
+	return 0;
 }

--- a/samples/net/sockets/can/src/main.c
+++ b/samples/net/sockets/can/src/main.c
@@ -254,7 +254,7 @@ cleanup:
 	return ret;
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 	int ret;
@@ -264,14 +264,14 @@ void main(void)
 	ret = can_set_mode(dev, CAN_MODE_LOOPBACK);
 	if (ret != 0) {
 		LOG_ERR("Cannot set CAN loopback mode (%d)", ret);
-		return;
+		return 0;
 	}
 #endif
 
 	ret = can_start(dev);
 	if (ret != 0) {
 		LOG_ERR("Cannot start CAN controller (%d)", ret);
-		return;
+		return 0;
 	}
 
 	/* Let the device start before doing anything */
@@ -280,8 +280,9 @@ void main(void)
 	fd = setup_socket();
 	if (fd < 0) {
 		LOG_ERR("Cannot start CAN application (%d)", fd);
-		return;
+		return 0;
 	}
 
 	rx(INT_TO_POINTER(fd), NULL, NULL);
+	return 0;
 }

--- a/samples/net/sockets/coap_client/src/coap-client.c
+++ b/samples/net/sockets/coap_client/src/coap-client.c
@@ -624,7 +624,7 @@ static int register_observer(void)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	int r;
 
@@ -657,10 +657,11 @@ void main(void)
 
 	LOG_DBG("Done");
 
-	return;
+	return 0;
 
 quit:
 	(void)close(sock);
 
 	LOG_ERR("quit");
+	return 0;
 }

--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -1427,7 +1427,7 @@ static int process_client_request(void)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	int r;
 
@@ -1458,8 +1458,9 @@ void main(void)
 	}
 
 	LOG_DBG("Done");
-	return;
+	return 0;
 
 quit:
 	LOG_ERR("Quit");
+	return 0;
 }

--- a/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
+++ b/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
@@ -40,7 +40,7 @@ static const char content[] = {
 #endif
 };
 
-void main(void)
+int main(void)
 {
 	int serv;
 	struct sockaddr_in bind_addr;
@@ -145,4 +145,5 @@ close_client:
 #endif
 
 	}
+	return 0;
 }

--- a/samples/net/sockets/dumb_http_server_mt/src/main.c
+++ b/samples/net/sockets/dumb_http_server_mt/src/main.c
@@ -402,7 +402,7 @@ void start_listener(void)
 	}
 }
 
-void main(void)
+int main(void)
 {
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 	int err = tls_credential_add(SERVER_CERTIFICATE_TAG,
@@ -450,4 +450,5 @@ void main(void)
 	} else {
 		exit(1);
 	}
+	return 0;
 }

--- a/samples/net/sockets/echo/src/socket_echo.c
+++ b/samples/net/sockets/echo/src/socket_echo.c
@@ -24,7 +24,7 @@
 
 #define BIND_PORT 4242
 
-void main(void)
+int main(void)
 {
 	int serv;
 	struct sockaddr_in bind_addr;
@@ -98,4 +98,5 @@ error:
 		close(client);
 		printf("Connection from %s closed\n", addr_str);
 	}
+	return 0;
 }

--- a/samples/net/sockets/echo_async/src/socket_echo.c
+++ b/samples/net/sockets/echo_async/src/socket_echo.c
@@ -104,7 +104,7 @@ void pollfds_del(int fd)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	int res;
 	static int counter;
@@ -257,4 +257,5 @@ error:
 			}
 		}
 	}
+	return 0;
 }

--- a/samples/net/sockets/echo_async_select/src/socket_echo_select.c
+++ b/samples/net/sockets/echo_async_select/src/socket_echo_select.c
@@ -91,7 +91,7 @@ void pollfds_del(int fd)
 	FD_CLR(fd, &readfds);
 }
 
-void main(void)
+int main(void)
 {
 	int res;
 	static int counter;
@@ -243,4 +243,5 @@ error:
 			}
 		}
 	}
+	return 0;
 }

--- a/samples/net/sockets/echo_client/src/echo-client.c
+++ b/samples/net/sockets/echo_client/src/echo-client.c
@@ -308,7 +308,7 @@ static int start_client(void)
 	return ret;
 }
 
-void main(void)
+int main(void)
 {
 	init_app();
 
@@ -331,4 +331,5 @@ void main(void)
 #else
 	exit(start_client());
 #endif
+	return 0;
 }

--- a/samples/net/sockets/echo_server/src/echo-server.c
+++ b/samples/net/sockets/echo_server/src/echo-server.c
@@ -227,7 +227,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sample_commands,
 SHELL_CMD_REGISTER(sample, &sample_commands,
 		   "Sample application commands", NULL);
 
-void main(void)
+int main(void)
 {
 	init_app();
 
@@ -249,4 +249,5 @@ void main(void)
 	if (connected) {
 		stop_udp_and_tcp();
 	}
+	return 0;
 }

--- a/samples/net/sockets/http_client/src/main.c
+++ b/samples/net/sockets/http_client/src/main.c
@@ -356,7 +356,7 @@ static int run_queries(void)
 	return ret;
 }
 
-void main(void)
+int main(void)
 {
 	int iterations = CONFIG_NET_SAMPLE_SEND_ITERATIONS;
 	int i = 0;
@@ -383,4 +383,5 @@ void main(void)
 	}
 
 	exit(0);
+	return 0;
 }

--- a/samples/net/sockets/http_get/src/http_get.c
+++ b/samples/net/sockets/http_get/src/http_get.c
@@ -55,7 +55,7 @@ void dump_addrinfo(const struct addrinfo *ai)
 	       ((struct sockaddr_in *)ai->ai_addr)->sin_port);
 }
 
-void main(void)
+int main(void)
 {
 	static struct addrinfo hints;
 	struct addrinfo *res;
@@ -76,7 +76,7 @@ void main(void)
 
 	if (st != 0) {
 		printf("Unable to resolve address, quitting\n");
-		return;
+		return 0;
 	}
 
 #if 0
@@ -116,7 +116,7 @@ void main(void)
 
 		if (len < 0) {
 			printf("Error reading response\n");
-			return;
+			return 0;
 		}
 
 		if (len == 0) {
@@ -130,4 +130,5 @@ void main(void)
 	printf("\n");
 
 	(void)close(sock);
+	return 0;
 }

--- a/samples/net/sockets/net_mgmt/src/main.c
+++ b/samples/net/sockets/net_mgmt/src/main.c
@@ -155,7 +155,7 @@ static void listener(void)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	/* The thread start to trigger network management events that
 	 * we then can catch.
@@ -168,4 +168,5 @@ void main(void)
 	} else {
 		listener();
 	}
+	return 0;
 }

--- a/samples/net/sockets/packet/src/packet.c
+++ b/samples/net/sockets/packet/src/packet.c
@@ -277,7 +277,7 @@ static void wait_for_interface(void)
 	net_mgmt_del_event_callback(&iface_up_cb);
 }
 
-void main(void)
+int main(void)
 {
 	k_sem_init(&quit_lock, 0, K_SEM_MAX_LIMIT);
 
@@ -304,4 +304,5 @@ void main(void)
 	if (packet.send_sock >= 0) {
 		(void)close(packet.send_sock);
 	}
+	return 0;
 }

--- a/samples/net/sockets/sntp_client/src/main.c
+++ b/samples/net/sockets/sntp_client/src/main.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(net_sntp_client_sample, LOG_LEVEL_DBG);
 
 #define SNTP_PORT 123
 
-void main(void)
+int main(void)
 {
 	struct sntp_ctx ctx;
 	struct sockaddr_in addr;
@@ -82,4 +82,5 @@ void main(void)
 
 end:
 	sntp_close(&ctx);
+	return 0;
 }

--- a/samples/net/sockets/socketpair/src/main.c
+++ b/samples/net/sockets/socketpair/src/main.c
@@ -221,16 +221,8 @@ static int handle_poll_events(const struct context *ctx, struct pollfd *fds, siz
 	return n_events;
 }
 
-#ifdef __ZEPHYR__
-void main(void)
+int main(void)
 {
-#else
-int main(int argc, char **argv)
-{
-	(void)argc;
-	(void)argv;
-#endif
-
 	int res;
 	struct context ctx[NUM_SOCKETPAIRS] = {};
 	struct pollfd fds[NUM_SOCKETPAIRS] = {};
@@ -264,7 +256,5 @@ out:
 
 	printf("%s\n", res == 0 ? "SUCCESS" : "FAILURE");
 
-#ifndef __ZEPHYR__
 	return res;
-#endif
 }

--- a/samples/net/sockets/tcp/src/main.c
+++ b/samples/net/sockets/tcp/src/main.c
@@ -33,11 +33,12 @@ do {									\
  * (see udp() below), but at the moment it's just a dummy loop
  * to keep the sample running in order to execute TTCN-3 TCP sanity check.
  */
-void main(void)
+int main(void)
 {
 	while (true) {
 		k_sleep(K_SECONDS(1));
 	}
+	return 0;
 }
 
 void udp(void)

--- a/samples/net/sockets/txtime/src/main.c
+++ b/samples/net/sockets/txtime/src/main.c
@@ -512,7 +512,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sample_commands,
 SHELL_CMD_REGISTER(sample, &sample_commands,
 		   "Sample application commands", NULL);
 
-void main(void)
+int main(void)
 {
 	struct net_if *iface = NULL;
 	char addr_str[INET6_ADDRSTRLEN];
@@ -553,7 +553,7 @@ void main(void)
 	if (IS_ENABLED(CONFIG_NET_SAMPLE_UDP_SOCKET)) {
 		ret = get_peer_address(&iface, addr_str, sizeof(addr_str));
 		if (ret < 0) {
-			return;
+			return 0;
 		}
 	} else {
 		struct sockaddr_ll *addr = (struct sockaddr_ll *)&data.peer;
@@ -566,7 +566,7 @@ void main(void)
 
 	if (!iface) {
 		LOG_ERR("Cannot get local network interface!");
-		return;
+		return 0;
 	}
 
 	if_index = net_if_get_by_iface(iface);
@@ -574,19 +574,19 @@ void main(void)
 	caps = net_eth_get_hw_capabilities(iface);
 	if (!(caps & ETHERNET_PTP)) {
 		LOG_ERR("Interface %p does not support %s", iface, "PTP");
-		return;
+		return 0;
 	}
 
 	if (!(caps & ETHERNET_TXTIME)) {
 		LOG_ERR("Interface %p does not support %s", iface, "TXTIME");
-		return;
+		return 0;
 	}
 
 	data.clk = net_eth_get_ptp_clock_by_index(if_index);
 	if (!data.clk) {
 		LOG_ERR("Interface %p does not support %s", iface,
 			"PTP clock");
-		return;
+		return 0;
 	}
 
 	/* Make sure the queues are enabled */
@@ -616,7 +616,7 @@ void main(void)
 	data.sock = create_socket(iface, &data.peer);
 	if (data.sock < 0) {
 		LOG_ERR("Cannot create socket (%d)", data.sock);
-		return;
+		return 0;
 	}
 
 	tx_tid = k_thread_create(&tx_thread, tx_stack,
@@ -626,7 +626,7 @@ void main(void)
 				 K_FOREVER);
 	if (!tx_tid) {
 		LOG_ERR("Cannot create TX thread!");
-		return;
+		return 0;
 	}
 
 	k_thread_name_set(tx_tid, "TX");
@@ -638,7 +638,7 @@ void main(void)
 				 K_FOREVER);
 	if (!rx_tid) {
 		LOG_ERR("Cannot create RX thread!");
-		return;
+		return 0;
 	}
 
 	k_thread_name_set(rx_tid, "RX");
@@ -656,4 +656,5 @@ void main(void)
 	if (data.sock >= 0) {
 		(void)close(data.sock);
 	}
+	return 0;
 }

--- a/samples/net/sockets/websocket_client/src/main.c
+++ b/samples/net/sockets/websocket_client/src/main.c
@@ -318,7 +318,7 @@ static bool send_and_wait_msg(int sock, size_t amount, const char *proto,
 	return true;
 }
 
-void main(void)
+int main(void)
 {
 	/* Just an example how to set extra headers */
 	const char *extra_headers[] = {
@@ -436,4 +436,5 @@ void main(void)
 	}
 
 	k_sleep(K_FOREVER);
+	return 0;
 }

--- a/samples/net/stats/src/main.c
+++ b/samples/net/stats/src/main.c
@@ -186,9 +186,10 @@ static void init_app(void)
 	k_work_reschedule(&stats_timer, K_SECONDS(CONFIG_SAMPLE_PERIOD));
 }
 
-void main(void)
+int main(void)
 {
 	/* Register a timer that will collect statistics after every n seconds.
 	 */
 	init_app();
+	return 0;
 }

--- a/samples/net/syslog_net/src/main.c
+++ b/samples/net/syslog_net/src/main.c
@@ -22,7 +22,7 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_LOG_BACKEND_NET), "syslog backend not enabled");
 extern const struct log_backend *log_backend_net_get(void);
 #endif
 
-void main(void)
+int main(void)
 {
 	int i, count, sleep;
 
@@ -76,4 +76,5 @@ void main(void)
 		k_msleep(1000);
 		exit(0);
 	}
+	return 0;
 }

--- a/samples/net/telnet/src/telnet.c
+++ b/samples/net/telnet/src/telnet.c
@@ -134,7 +134,7 @@ static void setup_ipv6(struct net_if *iface)
 #define setup_ipv6(...)
 #endif /* CONFIG_NET_IPV6 */
 
-void main(void)
+int main(void)
 {
 	struct net_if *iface = net_if_get_default();
 
@@ -145,4 +145,5 @@ void main(void)
 	setup_dhcpv4(iface);
 
 	setup_ipv6(iface);
+	return 0;
 }

--- a/samples/net/virtual/src/main.c
+++ b/samples/net/virtual/src/main.c
@@ -359,7 +359,7 @@ done:
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 #define MAX_NAME_LEN 32
 	char buf[MAX_NAME_LEN];
@@ -433,4 +433,5 @@ void main(void)
 	 * net-shell to send ping or UDP/TCP packets for testing
 	 * purposes.
 	 */
+	return 0;
 }

--- a/samples/net/vlan/src/main.c
+++ b/samples/net/vlan/src/main.c
@@ -109,7 +109,8 @@ static int init_app(void)
 	return ret;
 }
 
-void main(void)
+int main(void)
 {
 	init_app();
+	return 0;
 }

--- a/samples/net/wifi/src/wifi_test.c
+++ b/samples/net/wifi/src/wifi_test.c
@@ -7,7 +7,8 @@
 #include <zephyr/kernel.h>
 #include <errno.h>
 
-void main(void)
+int main(void)
 {
 
+	return 0;
 }

--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -526,7 +526,7 @@ enum net_verdict ieee802154_radio_handle_ack(struct net_if *iface, struct net_pk
 	return NET_CONTINUE;
 }
 
-void main(void)
+int main(void)
 {
 	uint32_t baudrate, dtr = 0U;
 	int ret;
@@ -535,13 +535,13 @@ void main(void)
 
 	if (!device_is_ready(uart_dev)) {
 		LOG_ERR("CDC ACM device not ready");
-		return;
+		return 0;
 	}
 
 	ret = usb_enable(NULL);
 	if (ret != 0) {
 		LOG_ERR("Failed to enable USB");
-		return;
+		return 0;
 	}
 
 	LOG_DBG("Wait for DTR");
@@ -579,11 +579,12 @@ void main(void)
 	/* Initialize ieee802154 device */
 	if (!init_ieee802154()) {
 		LOG_ERR("Unable to initialize ieee802154");
-		return;
+		return 0;
 	}
 
 	uart_irq_callback_set(uart_dev, interrupt_handler);
 
 	/* Enable rx interrupts */
 	uart_irq_rx_enable(uart_dev);
+	return 0;
 }

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -419,14 +419,14 @@ enum net_verdict ieee802154_radio_handle_ack(struct net_if *iface, struct net_pk
 	return NET_CONTINUE;
 }
 
-void main(void)
+int main(void)
 {
 	int ret;
 	LOG_INF("Starting wpanusb");
 
 	if (!device_is_ready(ieee802154_dev)) {
 		LOG_ERR("IEEE802.15.4 device not ready");
-		return;
+		return 0;
 	}
 
 	/* Initialize net_pkt */
@@ -440,9 +440,10 @@ void main(void)
 	ret = usb_enable(NULL);
 	if (ret != 0) {
 		LOG_ERR("Failed to enable USB");
-		return;
+		return 0;
 	}
 	/* TODO: Initialize more */
 
 	LOG_DBG("radio_api %p initialized", radio_api);
+	return 0;
 }

--- a/samples/net/zperf/src/main.c
+++ b/samples/net/zperf/src/main.c
@@ -14,7 +14,7 @@
 #ifdef CONFIG_NET_LOOPBACK_SIMULATE_PACKET_DROP
 #include <zephyr/net/loopback.h>
 #endif
-void main(void)
+int main(void)
 {
 #if defined(CONFIG_USB_DEVICE_STACK)
 	int ret;
@@ -29,4 +29,5 @@ void main(void)
 #ifdef CONFIG_NET_LOOPBACK_SIMULATE_PACKET_DROP
 	loopback_set_packet_drop_ratio(1);
 #endif
+	return 0;
 }

--- a/samples/philosophers/src/main.c
+++ b/samples/philosophers/src/main.c
@@ -249,7 +249,7 @@ static void display_demo_description(void)
 #endif
 }
 
-void main(void)
+int main(void)
 {
 	display_demo_description();
 #if CONFIG_TIMESLICING
@@ -265,4 +265,5 @@ void main(void)
 	 */
 	k_sleep(K_MSEC(5000));
 #endif
+	return 0;
 }

--- a/samples/sensor/accel_polling/src/main.c
+++ b/samples/sensor/accel_polling/src/main.c
@@ -51,14 +51,14 @@ static int print_accels(const struct device *dev)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	int ret;
 
 	for (size_t i = 0; i < ARRAY_SIZE(sensors); i++) {
 		if (!device_is_ready(sensors[i])) {
 			printk("sensor: device %s not ready.\n", sensors[i]->name);
-			return;
+			return 0;
 		}
 	}
 
@@ -66,9 +66,10 @@ void main(void)
 		for (size_t i = 0; i < ARRAY_SIZE(sensors); i++) {
 			ret = print_accels(sensors[i]);
 			if (ret < 0) {
-				return;
+				return 0;
 			}
 		}
 		k_msleep(1000);
 	}
+	return 0;
 }

--- a/samples/sensor/adc_cmp_npcx/src/main.c
+++ b/samples/sensor/adc_cmp_npcx/src/main.c
@@ -97,21 +97,21 @@ void threshold_trigger_handler(const struct device *dev,
 	enable_threshold(dev, true);
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const adc_cmp = DEVICE_DT_GET(ADC_CMP_NODE);
 	int err;
 
 	if (!device_is_ready(adc_cmp)) {
 		printf("ADC CMP: Error, device is not ready");
-		return;
+		return 0;
 	}
 
 	err = sensor_trigger_set(adc_cmp, &trigger,
 		threshold_trigger_handler);
 	if (err) {
 		printf("ADC CMP: Error setting handler");
-		return;
+		return 0;
 	}
 
 	set_upper_threshold(adc_cmp);
@@ -123,4 +123,5 @@ void main(void)
 	}
 
 	printf("ADC CMP: Exiting application");
+	return 0;
 }

--- a/samples/sensor/adt7420/src/main.c
+++ b/samples/sensor/adt7420/src/main.c
@@ -169,16 +169,17 @@ static void process(const struct device *dev)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(adi_adt7420);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	printf("device is %p, name is %s\n", dev, dev->name);
 
 	process(dev);
+	return 0;
 }

--- a/samples/sensor/amg88xx/src/main.c
+++ b/samples/sensor/amg88xx/src/main.c
@@ -48,14 +48,14 @@ void print_buffer(void *ptr, size_t l)
 	printk("\n");
 }
 
-void main(void)
+int main(void)
 {
 	int ret;
 	const struct device *const dev = DEVICE_DT_GET_ONE(panasonic_amg88xx);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	printk("device: %p, name: %s\n", dev, dev->name);
@@ -69,7 +69,7 @@ void main(void)
 	if (sensor_attr_set(dev, SENSOR_CHAN_AMBIENT_TEMP,
 			    SENSOR_ATTR_UPPER_THRESH, &attr)) {
 		printk("Could not set threshold\n");
-		return;
+		return 0;
 	}
 
 	struct sensor_trigger trig = {
@@ -79,7 +79,7 @@ void main(void)
 
 	if (sensor_trigger_set(dev, &trig, trigger_handler)) {
 		printk("Could not set trigger\n");
-		return;
+		return 0;
 	}
 #endif
 
@@ -92,14 +92,14 @@ void main(void)
 		ret = sensor_sample_fetch(dev);
 		if (ret) {
 			printk("Failed to fetch a sample, %d\n", ret);
-			return;
+			return 0;
 		}
 
 		ret = sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP,
 					 (struct sensor_value *)temp_value);
 		if (ret) {
 			printk("Failed to get sensor values, %d\n", ret);
-			return;
+			return 0;
 		}
 
 		printk("new sample:\n");

--- a/samples/sensor/ams_iAQcore/src/main.c
+++ b/samples/sensor/ams_iAQcore/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/sys/printk.h>
 
-void main(void)
+int main(void)
 {
 	const struct device *dev;
 	struct sensor_value co2, voc;
@@ -17,7 +17,7 @@ void main(void)
 	dev = DEVICE_DT_GET_ONE(ams_iaqcore);
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	printk("device is %p, name is %s\n", dev, dev->name);
@@ -32,4 +32,5 @@ void main(void)
 
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }

--- a/samples/sensor/apds9960/src/main.c
+++ b/samples/sensor/apds9960/src/main.c
@@ -24,7 +24,7 @@ static void trigger_handler(const struct device *dev,
 }
 #endif
 
-void main(void)
+int main(void)
 {
 	const struct device *dev;
 	struct sensor_value intensity, pdata;
@@ -33,7 +33,7 @@ void main(void)
 	dev = DEVICE_DT_GET_ONE(avago_apds9960);
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_APDS9960_TRIGGER
@@ -45,7 +45,7 @@ void main(void)
 	if (sensor_attr_set(dev, SENSOR_CHAN_PROX,
 			    SENSOR_ATTR_UPPER_THRESH, &attr)) {
 		printk("Could not set threshold\n");
-		return;
+		return 0;
 	}
 
 	struct sensor_trigger trig = {
@@ -55,7 +55,7 @@ void main(void)
 
 	if (sensor_trigger_set(dev, &trig, trigger_handler)) {
 		printk("Could not set trigger\n");
-		return;
+		return 0;
 	}
 #endif
 

--- a/samples/sensor/bme280/src/main.c
+++ b/samples/sensor/bme280/src/main.c
@@ -35,12 +35,12 @@ static const struct device *get_bme280_device(void)
 	return dev;
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *dev = get_bme280_device();
 
 	if (dev == NULL) {
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -57,4 +57,5 @@ void main(void)
 
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }

--- a/samples/sensor/bme680/src/main.c
+++ b/samples/sensor/bme680/src/main.c
@@ -9,14 +9,14 @@
 #include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(bosch_bme680);
 	struct sensor_value temp, press, humidity, gas_res;
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	printf("Device %p name is %s\n", dev, dev->name);
@@ -35,4 +35,5 @@ void main(void)
 				humidity.val1, humidity.val2, gas_res.val1,
 				gas_res.val2);
 	}
+	return 0;
 }

--- a/samples/sensor/bmg160/src/main.c
+++ b/samples/sensor/bmg160/src/main.c
@@ -170,7 +170,7 @@ static void test_trigger_mode(const struct device *bmg160)
 	printf("Gyro: Data ready trigger test finished.\n");
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const bmg160 = DEVICE_DT_GET_ANY(bosch_bmg160);
 #if defined(CONFIG_BMG160_RANGE_RUNTIME)
@@ -179,7 +179,7 @@ void main(void)
 
 	if (!device_is_ready(bmg160)) {
 		printf("Device %s is not ready.\n", bmg160->name);
-		return;
+		return 0;
 	}
 
 #if defined(CONFIG_BMG160_RANGE_RUNTIME)
@@ -192,7 +192,7 @@ void main(void)
 	if (sensor_attr_set(bmg160, SENSOR_CHAN_GYRO_XYZ,
 			    SENSOR_ATTR_FULL_SCALE, &attr) < 0) {
 		printf("Cannot set gyro range.\n");
-		return;
+		return 0;
 	}
 #endif
 
@@ -203,4 +203,5 @@ void main(void)
 	printf("Testing the trigger mode.\n");
 	test_trigger_mode(bmg160);
 	printf("Trigger mode test finished.\n");
+	return 0;
 }

--- a/samples/sensor/bmi270/src/main.c
+++ b/samples/sensor/bmi270/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(bosch_bmi270);
 	struct sensor_value acc[3], gyr[3];
@@ -17,7 +17,7 @@ void main(void)
 
 	if (!device_is_ready(dev)) {
 		printf("Device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	printf("Device %p name is %s\n", dev, dev->name);
@@ -83,4 +83,5 @@ void main(void)
 		       gyr[1].val1, gyr[1].val2,
 		       gyr[2].val1, gyr[2].val2);
 	}
+	return 0;
 }

--- a/samples/sensor/bq274xx/src/main.c
+++ b/samples/sensor/bq274xx/src/main.c
@@ -206,16 +206,17 @@ static void do_main(const struct device *dev)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(ti_bq274xx);
 
 	if (!device_is_ready(dev)) {
 		printk("Device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	printk("device is %p, name is %s\n", dev, dev->name);
 
 	do_main(dev);
+	return 0;
 }

--- a/samples/sensor/ccs811/src/main.c
+++ b/samples/sensor/ccs811/src/main.c
@@ -111,7 +111,7 @@ static void do_main(const struct device *dev)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(ams_ccs811);
 	struct ccs811_configver_type cfgver;
@@ -119,7 +119,7 @@ void main(void)
 
 	if (!device_is_ready(dev)) {
 		printk("Device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	printk("device is %p, name is %s\n", dev, dev->name);
@@ -188,4 +188,5 @@ void main(void)
 	if (rc == 0) {
 		do_main(dev);
 	}
+	return 0;
 }

--- a/samples/sensor/dht/src/main.c
+++ b/samples/sensor/dht/src/main.c
@@ -30,13 +30,13 @@ static const char *now_str(void)
 	return buf;
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dht22 = DEVICE_DT_GET_ONE(aosong_dht);
 
 	if (!device_is_ready(dht22)) {
 		printf("Device %s is not ready\n", dht22->name);
-		return;
+		return 0;
 	}
 
 	while (true) {
@@ -67,4 +67,5 @@ void main(void)
 		       sensor_value_to_double(&humidity));
 		k_sleep(K_SECONDS(2));
 	}
+	return 0;
 }

--- a/samples/sensor/die_temp_polling/src/main.c
+++ b/samples/sensor/die_temp_polling/src/main.c
@@ -38,14 +38,14 @@ static int print_die_temperature(const struct device *dev)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	int rc;
 
 	for (size_t i = 0; i < ARRAY_SIZE(sensors); i++) {
 		if (!device_is_ready(sensors[i])) {
 			printk("sensor: device %s not ready.\n", sensors[i]->name);
-			return;
+			return 0;
 		}
 	}
 
@@ -53,9 +53,10 @@ void main(void)
 		for (size_t i = 0; i < ARRAY_SIZE(sensors); i++) {
 			rc = print_die_temperature(sensors[i]);
 			if (rc < 0) {
-				return;
+				return 0;
 			}
 		}
 		k_msleep(300);
 	}
+	return 0;
 }

--- a/samples/sensor/dps310/src/main.c
+++ b/samples/sensor/dps310/src/main.c
@@ -9,14 +9,14 @@
 #include <zephyr/drivers/sensor.h>
 #include <stdlib.h>
 
-void main(void)
+int main(void)
 {
 	printk("Hello DPS310\n");
 	const struct device *const dev = DEVICE_DT_GET_ONE(infineon_dps310);
 
 	if (!device_is_ready(dev)) {
 		printk("Device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	printk("dev %p name %s\n", dev, dev->name);
@@ -33,4 +33,5 @@ void main(void)
 
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }

--- a/samples/sensor/ds18b20/src/main.c
+++ b/samples/sensor/ds18b20/src/main.c
@@ -34,12 +34,12 @@ static const struct device *get_ds18b20_device(void)
 	return dev;
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *dev = get_ds18b20_device();
 
 	if (dev == NULL) {
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -51,4 +51,5 @@ void main(void)
 		printk("Temp: %d.%06d\n", temp.val1, temp.val2);
 		k_sleep(K_MSEC(2000));
 	}
+	return 0;
 }

--- a/samples/sensor/ens210/src/main.c
+++ b/samples/sensor/ens210/src/main.c
@@ -9,14 +9,14 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/sys/printk.h>
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(ams_ens210);
 	struct sensor_value temperature, humidity;
 
 	if (!device_is_ready(dev)) {
 		printk("Device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	printk("device is %p, name is %s\n", dev, dev->name);
@@ -31,4 +31,5 @@ void main(void)
 
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }

--- a/samples/sensor/esp32_temp_sensor/src/main.c
+++ b/samples/sensor/esp32_temp_sensor/src/main.c
@@ -13,7 +13,7 @@
 #error "Temperature sensor is not supported on ESP32 soc"
 #endif /* CONFIG_SOC_ESP32 */
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(espressif_esp32_temp);
 	struct sensor_value val;
@@ -21,7 +21,7 @@ void main(void)
 
 	if (!device_is_ready(dev)) {
 		printk("Temperature sensor is not ready\n");
-		return;
+		return 0;
 	}
 
 	printk("ESP32 Die temperature sensor test\n");
@@ -33,15 +33,16 @@ void main(void)
 		rc = sensor_sample_fetch(dev);
 		if (rc) {
 			printk("Failed to fetch sample (%d)\n", rc);
-			return;
+			return 0;
 		}
 
 		rc = sensor_channel_get(dev, SENSOR_CHAN_DIE_TEMP, &val);
 		if (rc) {
 			printk("Failed to get data (%d)\n", rc);
-			return;
+			return 0;
 		}
 
 		printk("Current temperature: %.1f °C\n", sensor_value_to_double(&val));
 	}
+	return 0;
 }

--- a/samples/sensor/fdc2x1x/src/main.c
+++ b/samples/sensor/fdc2x1x/src/main.c
@@ -60,7 +60,7 @@ static void pm_info(enum pm_device_action action, int status)
 
 #define DEVICE_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(ti_fdc2x1x)
 
-void main(void)
+int main(void)
 {
 	struct sensor_value ch_buf[] = {
 		DT_FOREACH_CHILD(DEVICE_NODE, CH_BUF_INIT)
@@ -74,7 +74,7 @@ void main(void)
 
 	if (!device_is_ready(dev)) {
 		printk("Device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_FDC2X1X_TRIGGER
@@ -85,7 +85,7 @@ void main(void)
 
 	if (sensor_trigger_set(dev, &trig, trigger_handler)) {
 		printk("Could not set trigger\n");
-		return;
+		return 0;
 	}
 #endif
 
@@ -113,7 +113,7 @@ void main(void)
 #else
 		if (sensor_sample_fetch(dev) < 0) {
 			printk("Sample fetch failed\n");
-			return;
+			return 0;
 		}
 #endif
 		base = SENSOR_CHAN_FDC2X1X_FREQ_CH0;

--- a/samples/sensor/fxas21002/src/main.c
+++ b/samples/sensor/fxas21002/src/main.c
@@ -16,14 +16,14 @@ static void trigger_handler(const struct device *dev,
 	k_sem_give(&sem);
 }
 
-void main(void)
+int main(void)
 {
 	struct sensor_value gyro[3];
 	const struct device *const dev = DEVICE_DT_GET_ANY(nxp_fxas21002);
 
 	if (dev == NULL || !device_is_ready(dev)) {
 		printf("Could not get fxas21002 device\n");
-		return;
+		return 0;
 	}
 
 	struct sensor_trigger trig = {
@@ -33,7 +33,7 @@ void main(void)
 
 	if (sensor_trigger_set(dev, &trig, trigger_handler)) {
 		printf("Could not set trigger\n");
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -47,4 +47,5 @@ void main(void)
 		       sensor_value_to_double(&gyro[1]),
 		       sensor_value_to_double(&gyro[2]));
 	}
+	return 0;
 }

--- a/samples/sensor/fxos8700-hid/src/main.c
+++ b/samples/sensor/fxos8700-hid/src/main.c
@@ -166,7 +166,7 @@ static void trigger_handler(const struct device *dev,
 	}
 }
 
-void main(void)
+int main(void)
 {
 	int ret;
 	uint8_t report[4] = { 0x00 };
@@ -174,33 +174,33 @@ void main(void)
 
 	if (!device_is_ready(led_gpio.port)) {
 		LOG_ERR("%s: device not ready.", led_gpio.port->name);
-		return;
+		return 0;
 	}
 
 	hid_dev = device_get_binding("HID_0");
 	if (hid_dev == NULL) {
 		LOG_ERR("Cannot get USB HID Device");
-		return;
+		return 0;
 	}
 
 	gpio_pin_configure_dt(&led_gpio, GPIO_OUTPUT);
 
 	if (callbacks_configure(&sw0_gpio, &left_button, &callback[0], &def_val[0])) {
 		LOG_ERR("Failed configuring left button callback.");
-		return;
+		return 0;
 	}
 
 #if DT_NODE_HAS_STATUS(SW1_NODE, okay)
 	if (callbacks_configure(&sw1_gpio, &right_button, &callback[1], &def_val[1])) {
 		LOG_ERR("Failed configuring right button callback.");
-		return;
+		return 0;
 	}
 #endif
 
 	accel_dev = DEVICE_DT_GET_ONE(nxp_fxos8700);
 	if (!device_is_ready(accel_dev)) {
 		LOG_ERR("%s: device not ready.", accel_dev->name);
-		return;
+		return 0;
 	}
 
 	struct sensor_value attr = {
@@ -211,7 +211,7 @@ void main(void)
 	if (sensor_attr_set(accel_dev, SENSOR_CHAN_ALL,
 			    SENSOR_ATTR_SAMPLING_FREQUENCY, &attr)) {
 		LOG_ERR("Could not set sampling frequency");
-		return;
+		return 0;
 	}
 
 	struct sensor_trigger trig = {
@@ -221,7 +221,7 @@ void main(void)
 
 	if (sensor_trigger_set(accel_dev, &trig, trigger_handler)) {
 		LOG_ERR("Could not set trigger");
-		return;
+		return 0;
 	}
 
 	usb_hid_register_device(hid_dev, hid_report_desc,
@@ -230,7 +230,7 @@ void main(void)
 	ret = usb_enable(NULL);
 	if (ret != 0) {
 		LOG_ERR("Failed to enable USB");
-		return;
+		return 0;
 	}
 
 	usb_hid_init(hid_dev);

--- a/samples/sensor/fxos8700/src/main.c
+++ b/samples/sensor/fxos8700/src/main.c
@@ -29,14 +29,14 @@ static void trigger_handler(const struct device *dev,
 }
 #endif /* !CONFIG_FXOS8700_TRIGGER_NONE */
 
-void main(void)
+int main(void)
 {
 	struct sensor_value accel[3];
 	const struct device *const dev = DEVICE_DT_GET_ONE(nxp_fxos8700);
 
 	if (!device_is_ready(dev)) {
 		printf("Device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	struct sensor_value attr = {
@@ -47,7 +47,7 @@ void main(void)
 	if (sensor_attr_set(dev, SENSOR_CHAN_ALL,
 			    SENSOR_ATTR_SAMPLING_FREQUENCY, &attr)) {
 		printk("Could not set sampling frequency\n");
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_FXOS8700_MOTION
@@ -56,7 +56,7 @@ void main(void)
 	if (sensor_attr_set(dev, SENSOR_CHAN_ALL,
 			    SENSOR_ATTR_SLOPE_TH, &attr)) {
 		printk("Could not set slope threshold\n");
-		return;
+		return 0;
 	}
 #endif
 
@@ -72,7 +72,7 @@ void main(void)
 
 	if (sensor_trigger_set(dev, &trig, trigger_handler)) {
 		printf("Could not set trigger\n");
-		return;
+		return 0;
 	}
 #endif /* !CONFIG_FXOS8700_TRIGGER_NONE */
 

--- a/samples/sensor/grove_light/src/main.c
+++ b/samples/sensor/grove_light/src/main.c
@@ -11,13 +11,13 @@
 
 #define SLEEP_TIME	K_MSEC(1000)
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(seeed_grove_light);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -36,4 +36,5 @@ void main(void)
 
 		k_sleep(SLEEP_TIME);
 	}
+	return 0;
 }

--- a/samples/sensor/grove_temperature/src/main.c
+++ b/samples/sensor/grove_temperature/src/main.c
@@ -17,7 +17,7 @@
 
 #define SLEEP_TIME	K_MSEC(1000)
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(seeed_grove_temperature);
 	struct sensor_value temp;
@@ -25,7 +25,7 @@ void main(void)
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_GROVE_LCD_RGB
@@ -34,7 +34,7 @@ void main(void)
 	glcd = device_get_binding(GROVE_LCD_NAME);
 	if (glcd == NULL) {
 		printf("Failed to get Grove LCD\n");
-		return;
+		return 0;
 	}
 
 	/* configure LCD */

--- a/samples/sensor/grow_r502a/src/main.c
+++ b/samples/sensor/grow_r502a/src/main.c
@@ -68,7 +68,7 @@ static void trigger_handler(const struct device *dev,
 	}
 }
 
-void main(void)
+int main(void)
 {
 	static struct sensor_value del, fid_get;
 	int ret;
@@ -77,12 +77,12 @@ void main(void)
 
 	if (dev ==  NULL) {
 		printk("Error: no device found\n");
-		return;
+		return 0;
 	}
 
 	if (!device_is_ready(dev)) {
 		printk("Error: Device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	template_count_get(dev);
@@ -91,7 +91,7 @@ void main(void)
 	ret = sensor_attr_set(dev, SENSOR_CHAN_FINGERPRINT, SENSOR_ATTR_R502A_RECORD_DEL, &del);
 	if (ret != 0) {
 		printk("Sensor attr set failed %d\n", ret);
-		return;
+		return 0;
 	}
 	printk("Fingerprint Deleted at ID #%d\n", del.val1);
 
@@ -99,7 +99,7 @@ void main(void)
 					SENSOR_ATTR_R502A_RECORD_FREE_IDX, &fid_get);
 	if (ret != 0) {
 		printk("Sensor attr get failed %d\n", ret);
-		return;
+		return 0;
 	}
 	printk("Fingerprint template free idx at ID #%d\n", fid_get.val1);
 
@@ -116,8 +116,9 @@ void main(void)
 		ret = sensor_trigger_set(dev, &trig, trigger_handler);
 		if (ret != 0) {
 			printk("Could not set trigger\n");
-			return;
+			return 0;
 		}
 	}
 
+	return 0;
 }

--- a/samples/sensor/hts221/src/main.c
+++ b/samples/sensor/hts221/src/main.c
@@ -46,13 +46,13 @@ static void hts221_handler(const struct device *dev,
 	process_sample(dev);
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(st_hts221);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	if (IS_ENABLED(CONFIG_HTS221_TRIGGER)) {
@@ -62,7 +62,7 @@ void main(void)
 		};
 		if (sensor_trigger_set(dev, &trig, hts221_handler) < 0) {
 			printf("Cannot configure trigger\n");
-			return;
+			return 0;
 		}
 	}
 
@@ -71,4 +71,5 @@ void main(void)
 		k_sleep(K_MSEC(2000));
 	}
 	k_sleep(K_FOREVER);
+	return 0;
 }

--- a/samples/sensor/i3g4250d/src/main.c
+++ b/samples/sensor/i3g4250d/src/main.c
@@ -49,14 +49,14 @@ static void fetch_and_display(const struct device *sensor)
 	       sensor_value_to_double(&gyro[2]));
 }
 
-void main(void)
+int main(void)
 {
 	const double sampling_frequency = 1000.0 / SAMPLING_INTERVAL_MS;
 	const struct device *const sensor = DEVICE_DT_GET_ONE(st_i3g4250d);
 
 	if (!device_is_ready(sensor)) {
 		printf("Sensor %s is not ready\n", sensor->name);
-		return;
+		return 0;
 	}
 
 	printf("Set sensor sampling frequency to %f Hz.\n", sampling_frequency);
@@ -69,4 +69,5 @@ void main(void)
 		/* Wait some time before printing the next value */
 		k_sleep(K_MSEC(DISPLAY_INTERVAL_MS));
 	}
+	return 0;
 }

--- a/samples/sensor/icm42605/src/main.c
+++ b/samples/sensor/icm42605/src/main.c
@@ -96,13 +96,13 @@ static void handle_icm42605_double_tap(const struct device *dev,
 	printf("Double Tap detected!\n");
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const icm42605 = DEVICE_DT_GET_ONE(invensense_icm42605);
 
 	if (!device_is_ready(icm42605)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	tap_trigger = (struct sensor_trigger) {
@@ -113,7 +113,7 @@ void main(void)
 	if (sensor_trigger_set(icm42605, &tap_trigger,
 			       handle_icm42605_tap) < 0) {
 		printf("Cannot configure tap trigger!!!\n");
-		return;
+		return 0;
 	}
 
 	double_tap_trigger = (struct sensor_trigger) {
@@ -124,7 +124,7 @@ void main(void)
 	if (sensor_trigger_set(icm42605, &double_tap_trigger,
 			       handle_icm42605_double_tap) < 0) {
 		printf("Cannot configure double tap trigger!!!\n");
-		return;
+		return 0;
 	}
 
 	data_trigger = (struct sensor_trigger) {
@@ -135,8 +135,9 @@ void main(void)
 	if (sensor_trigger_set(icm42605, &data_trigger,
 			       handle_icm42605_drdy) < 0) {
 		printf("Cannot configure data trigger!!!\n");
-		return;
+		return 0;
 	}
 
 	printf("Configured for triggered sampling.\n");
+	return 0;
 }

--- a/samples/sensor/ina219/src/main.c
+++ b/samples/sensor/ina219/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/sensor.h>
 
 
-void main(void)
+int main(void)
 {
 	const struct device *const ina = DEVICE_DT_GET_ONE(ti_ina219);
 	struct sensor_value v_bus, power, current;
@@ -17,14 +17,14 @@ void main(void)
 
 	if (!device_is_ready(ina)) {
 		printf("Device %s is not ready.\n", ina->name);
-		return;
+		return 0;
 	}
 
 	while (true) {
 		rc = sensor_sample_fetch(ina);
 		if (rc) {
 			printf("Could not fetch sensor data.\n");
-			return;
+			return 0;
 		}
 
 		sensor_channel_get(ina, SENSOR_CHAN_VOLTAGE, &v_bus);
@@ -39,4 +39,5 @@ void main(void)
 		       sensor_value_to_double(&current));
 		k_sleep(K_MSEC(2000));
 	}
+	return 0;
 }

--- a/samples/sensor/isl29035/src/main.c
+++ b/samples/sensor/isl29035/src/main.c
@@ -100,13 +100,13 @@ static void process_sample(const struct device *dev)
 	       sensor_value_to_double(&val));
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(isil_isl29035);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	k_sem_init(&sem, 0, 1);
@@ -120,4 +120,5 @@ void main(void)
 			k_sleep(K_SECONDS(1));
 		}
 	}
+	return 0;
 }

--- a/samples/sensor/lis2dh/src/main.c
+++ b/samples/sensor/lis2dh/src/main.c
@@ -63,17 +63,17 @@ static void trigger_handler(const struct device *dev,
 }
 #endif
 
-void main(void)
+int main(void)
 {
 	const struct device *const sensor = DEVICE_DT_GET_ANY(st_lis2dh);
 
 	if (sensor == NULL) {
 		printf("No device found\n");
-		return;
+		return 0;
 	}
 	if (!device_is_ready(sensor)) {
 		printf("Device %s is not ready\n", sensor->name);
-		return;
+		return 0;
 	}
 
 #if CONFIG_LIS2DH_TRIGGER
@@ -94,7 +94,7 @@ void main(void)
 					     &odr);
 			if (rc != 0) {
 				printf("Failed to set odr: %d\n", rc);
-				return;
+				return 0;
 			}
 			printf("Sampling at %u Hz\n", odr.val1);
 		}
@@ -102,7 +102,7 @@ void main(void)
 		rc = sensor_trigger_set(sensor, &trig, trigger_handler);
 		if (rc != 0) {
 			printf("Failed to set trigger: %d\n", rc);
-			return;
+			return 0;
 		}
 
 		printf("Waiting for triggers\n");

--- a/samples/sensor/lps22hb/src/main.c
+++ b/samples/sensor/lps22hb/src/main.c
@@ -41,17 +41,18 @@ static void process_sample(const struct device *dev)
 
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(st_lps22hb_press);
 
 	if (!device_is_ready(dev)) {
 		printf("Device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	while (true) {
 		process_sample(dev);
 		k_sleep(K_MSEC(2000));
 	}
+	return 0;
 }

--- a/samples/sensor/lps22hh/src/main.c
+++ b/samples/sensor/lps22hh/src/main.c
@@ -48,13 +48,13 @@ static void lps22hh_handler(const struct device *dev,
 	process_sample(dev);
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(st_lps22hh);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	if (IS_ENABLED(CONFIG_LPS22HH_TRIGGER)) {
@@ -69,11 +69,11 @@ void main(void)
 		if (sensor_attr_set(dev, SENSOR_CHAN_ALL,
 				    SENSOR_ATTR_SAMPLING_FREQUENCY, &attr) < 0) {
 			printf("Cannot configure sampling rate\n");
-			return;
+			return 0;
 		}
 		if (sensor_trigger_set(dev, &trig, lps22hh_handler) < 0) {
 			printf("Cannot configure trigger\n");
-			return;
+			return 0;
 		}
 		printk("Configured for triggered collection at %u Hz\n",
 		       attr.val1);
@@ -84,4 +84,5 @@ void main(void)
 		k_sleep(K_MSEC(2000));
 	}
 	k_sleep(K_FOREVER);
+	return 0;
 }

--- a/samples/sensor/lsm303dlhc/src/main.c
+++ b/samples/sensor/lsm303dlhc/src/main.c
@@ -36,19 +36,19 @@ end:
 	return ret;
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const accelerometer = DEVICE_DT_GET_ONE(st_lis2dh);
 	const struct device *const magnetometer = DEVICE_DT_GET_ONE(st_lsm303dlhc_magn);
 
 	if (!device_is_ready(accelerometer)) {
 		printf("Device %s is not ready\n", accelerometer->name);
-		return;
+		return 0;
 	}
 
 	if (!device_is_ready(magnetometer)) {
 		printf("Device %s is not ready\n", magnetometer->name);
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -64,4 +64,5 @@ void main(void)
 
 		k_sleep(K_MSEC(2000));
 	}
+	return 0;
 }

--- a/samples/sensor/lsm6dsl/src/main.c
+++ b/samples/sensor/lsm6dsl/src/main.c
@@ -95,7 +95,7 @@ static void lsm6dsl_trigger_handler(const struct device *dev,
 }
 #endif
 
-void main(void)
+int main(void)
 {
 	int cnt = 0;
 	char out_str[64];
@@ -104,7 +104,7 @@ void main(void)
 
 	if (!device_is_ready(lsm6dsl_dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	/* set accel/gyro sampling frequency to 104 Hz */
@@ -114,13 +114,13 @@ void main(void)
 	if (sensor_attr_set(lsm6dsl_dev, SENSOR_CHAN_ACCEL_XYZ,
 			    SENSOR_ATTR_SAMPLING_FREQUENCY, &odr_attr) < 0) {
 		printk("Cannot set sampling frequency for accelerometer.\n");
-		return;
+		return 0;
 	}
 
 	if (sensor_attr_set(lsm6dsl_dev, SENSOR_CHAN_GYRO_XYZ,
 			    SENSOR_ATTR_SAMPLING_FREQUENCY, &odr_attr) < 0) {
 		printk("Cannot set sampling frequency for gyro.\n");
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_LSM6DSL_TRIGGER
@@ -131,13 +131,13 @@ void main(void)
 
 	if (sensor_trigger_set(lsm6dsl_dev, &trig, lsm6dsl_trigger_handler) != 0) {
 		printk("Could not set sensor type and channel\n");
-		return;
+		return 0;
 	}
 #endif
 
 	if (sensor_sample_fetch(lsm6dsl_dev) < 0) {
 		printk("Sensor sample update error\n");
-		return;
+		return 0;
 	}
 
 	while (1) {

--- a/samples/sensor/lsm6dso/src/main.c
+++ b/samples/sensor/lsm6dso/src/main.c
@@ -105,13 +105,13 @@ static void test_polling_mode(const struct device *dev)
 }
 #endif
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(st_lsm6dso);
 
 	if (!device_is_ready(dev)) {
 		printk("%s: device not ready.\n", dev->name);
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_LSM6DSO_TRIGGER
@@ -121,4 +121,5 @@ void main(void)
 	printf("Testing LSM6DSO sensor in polling mode.\n\n");
 	test_polling_mode(dev);
 #endif
+	return 0;
 }

--- a/samples/sensor/magn_polling/src/main.c
+++ b/samples/sensor/magn_polling/src/main.c
@@ -10,7 +10,7 @@
 #include <zephyr/sys/printk.h>
 #include <stdio.h>
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET(DT_ALIAS(magn0));
 	struct sensor_value value_x, value_y, value_z;
@@ -18,7 +18,7 @@ void main(void)
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	printk("Polling magnetometer data from %s.\n", dev->name);
@@ -27,7 +27,7 @@ void main(void)
 		ret = sensor_sample_fetch(dev);
 		if (ret) {
 			printk("sensor_sample_fetch failed ret %d\n", ret);
-			return;
+			return 0;
 		}
 
 		ret = sensor_channel_get(dev, SENSOR_CHAN_MAGN_X, &value_x);
@@ -40,4 +40,5 @@ void main(void)
 
 		k_sleep(K_MSEC(500));
 	}
+	return 0;
 }

--- a/samples/sensor/max17262/src/main.c
+++ b/samples/sensor/max17262/src/main.c
@@ -9,13 +9,13 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/sensor.h>
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(maxim_max17262);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -36,4 +36,5 @@ void main(void)
 
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }

--- a/samples/sensor/max30101/src/main.c
+++ b/samples/sensor/max30101/src/main.c
@@ -8,18 +8,18 @@
 #include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
-void main(void)
+int main(void)
 {
 	struct sensor_value green;
 	const struct device *const dev = DEVICE_DT_GET_ANY(maxim_max30101);
 
 	if (dev == NULL) {
 		printf("Could not get max30101 device\n");
-		return;
+		return 0;
 	}
 	if (!device_is_ready(dev)) {
 		printf("max30101 device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -31,4 +31,5 @@ void main(void)
 
 		k_sleep(K_MSEC(20));
 	}
+	return 0;
 }

--- a/samples/sensor/max44009/src/main.c
+++ b/samples/sensor/max44009/src/main.c
@@ -15,7 +15,7 @@
  * the result every 4 seconds.
  */
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(maxim_max44009);
 	struct sensor_value val;
@@ -25,18 +25,18 @@ void main(void)
 
 	if (!device_is_ready(dev)) {
 		printk("Device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	while (1) {
 		if (sensor_sample_fetch_chan(dev, SENSOR_CHAN_LIGHT) != 0) {
 			printk("sensor: sample fetch fail.\n");
-			return;
+			return 0;
 		}
 
 		if (sensor_channel_get(dev, SENSOR_CHAN_LIGHT, &val) != 0) {
 			printk("sensor: channel get fail.\n");
-			return;
+			return 0;
 		}
 
 		lum = val.val1;
@@ -44,4 +44,5 @@ void main(void)
 
 		k_sleep(K_MSEC(4000));
 	}
+	return 0;
 }

--- a/samples/sensor/max6675/src/main.c
+++ b/samples/sensor/max6675/src/main.c
@@ -17,14 +17,14 @@
  * This app will read and display the sensor temperature every second.
  */
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(maxim_max6675);
 	struct sensor_value val;
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -33,17 +33,18 @@ void main(void)
 		ret = sensor_sample_fetch_chan(dev, SENSOR_CHAN_AMBIENT_TEMP);
 		if (ret < 0) {
 			printf("Could not fetch temperature (%d)\n", ret);
-			return;
+			return 0;
 		}
 
 		ret = sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &val);
 		if (ret < 0) {
 			printf("Could not get temperature (%d)\n", ret);
-			return;
+			return 0;
 		}
 
 		printf("Temperature: %.2f C\n", sensor_value_to_double(&val));
 
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }

--- a/samples/sensor/mcp9808/src/main.c
+++ b/samples/sensor/mcp9808/src/main.c
@@ -104,18 +104,18 @@ static void trigger_handler(const struct device *dev,
 }
 #endif
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ANY(microchip_mcp9808);
 	int rc;
 
 	if (dev == NULL) {
 		printf("Device not found.\n");
-		return;
+		return 0;
 	}
 	if (!device_is_ready(dev)) {
 		printf("Device %s is not ready.\n", dev->name);
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_MCP9808_TRIGGER
@@ -128,7 +128,7 @@ void main(void)
 
 	if (rc != 0) {
 		printf("Trigger set failed: %d\n", rc);
-		return;
+		return 0;
 	}
 	printk("Trigger set got %d\n", rc);
 #endif
@@ -153,4 +153,5 @@ void main(void)
 
 		k_sleep(K_SECONDS(2));
 	}
+	return 0;
 }

--- a/samples/sensor/mcux_acmp/src/main.c
+++ b/samples/sensor/mcux_acmp/src/main.c
@@ -88,7 +88,7 @@ static void acmp_trigger_handler(const struct device *dev,
 			   SENSOR_TRIG_MCUX_ACMP_OUTPUT_RISING);
 }
 
-void main(void)
+int main(void)
 {
 	struct sensor_trigger trigger;
 	const struct device *const acmp = DEVICE_DT_GET(ACMP_NODE);
@@ -98,7 +98,7 @@ void main(void)
 
 	if (!device_is_ready(acmp)) {
 		printf("ACMP device not ready");
-		return;
+		return 0;
 	}
 
 	/* Set ACMP attributes */
@@ -109,7 +109,7 @@ void main(void)
 				      attrs[i].attr, &val);
 		if (err) {
 			printf("failed to set attribute %d (err %d)", i, err);
-			return;
+			return 0;
 		}
 	}
 
@@ -123,7 +123,7 @@ void main(void)
 		err = sensor_trigger_set(acmp, &trigger, acmp_trigger_handler);
 		if (err) {
 			printf("failed to set trigger %d (err %d)", i, err);
-			return;
+			return 0;
 		}
 	}
 
@@ -133,13 +133,13 @@ void main(void)
 	err = sensor_sample_fetch(acmp);
 	if (err) {
 		printf("failed to fetch sample (err %d)", err);
-		return;
+		return 0;
 	}
 
 	err = sensor_channel_get(acmp, SENSOR_CHAN_MCUX_ACMP_OUTPUT, &val);
 	if (err) {
 		printf("failed to get channel (err %d)", err);
-		return;
+		return 0;
 	}
 
 	acmp_input_handler(val.val1 == 1);
@@ -148,4 +148,5 @@ void main(void)
 	while (true) {
 		k_sleep(K_MSEC(1));
 	}
+	return 0;
 }

--- a/samples/sensor/mhz19b/src/main.c
+++ b/samples/sensor/mhz19b/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/sensor/mhz19b.h>
 
-void main(void)
+int main(void)
 {
 	const struct device *dev;
 	struct sensor_value val;
@@ -20,7 +20,7 @@ void main(void)
 	dev = DEVICE_DT_GET_ONE(winsen_mhz19b);
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not found.\n");
-		return;
+		return 0;
 	}
 
 	printk("Configuring sensor - ");
@@ -29,14 +29,14 @@ void main(void)
 	ret = sensor_attr_set(dev, SENSOR_CHAN_CO2, SENSOR_ATTR_FULL_SCALE, &val);
 	if (ret != 0) {
 		printk("failed to set range to %d\n", val.val1);
-		return;
+		return 0;
 	}
 
 	val.val1 = 1;
 	ret = sensor_attr_set(dev, SENSOR_CHAN_CO2, SENSOR_ATTR_MHZ19B_ABC, &val);
 	if (ret != 0) {
 		printk("failed to set ABC to %d\n", val.val1);
-		return;
+		return 0;
 	}
 
 	printk("OK\n");
@@ -46,7 +46,7 @@ void main(void)
 	ret = sensor_attr_get(dev, SENSOR_CHAN_CO2, SENSOR_ATTR_FULL_SCALE, &val);
 	if (ret != 0) {
 		printk("failed to get range\n");
-		return;
+		return 0;
 	}
 
 	printk("Sensor range is set to %dppm\n", val.val1);
@@ -54,7 +54,7 @@ void main(void)
 	ret = sensor_attr_get(dev, SENSOR_CHAN_CO2, SENSOR_ATTR_MHZ19B_ABC, &val);
 	if (ret != 0) {
 		printk("failed to get ABC\n");
-		return;
+		return 0;
 	}
 
 	printk("Sensor ABC is %s\n", val.val1 == 1 ? "enabled" : "disabled");
@@ -62,16 +62,17 @@ void main(void)
 	while (1) {
 		if (sensor_sample_fetch(dev) != 0) {
 			printk("sensor: sample fetch fail.\n");
-			return;
+			return 0;
 		}
 
 		if (sensor_channel_get(dev, SENSOR_CHAN_CO2, &val) != 0) {
 			printk("sensor: channel get fail.\n");
-			return;
+			return 0;
 		}
 
 		printk("sensor: co2 reading: %d\n", val.val1);
 
 		k_msleep(2000);
 	}
+	return 0;
 }

--- a/samples/sensor/mpr/src/main.c
+++ b/samples/sensor/mpr/src/main.c
@@ -9,14 +9,14 @@
 #include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(honeywell_mpr);
 	int rc;
 
 	if (!device_is_ready(dev)) {
 		printf("Device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -38,4 +38,5 @@ void main(void)
 
 		k_sleep(K_SECONDS(1));
 	}
+	return 0;
 }

--- a/samples/sensor/mpu6050/src/main.c
+++ b/samples/sensor/mpu6050/src/main.c
@@ -84,13 +84,13 @@ static void handle_mpu6050_drdy(const struct device *dev,
 }
 #endif /* CONFIG_MPU6050_TRIGGER */
 
-void main(void)
+int main(void)
 {
 	const struct device *const mpu6050 = DEVICE_DT_GET_ONE(invensense_mpu6050);
 
 	if (!device_is_ready(mpu6050)) {
 		printf("Device %s is not ready\n", mpu6050->name);
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_MPU6050_TRIGGER
@@ -101,7 +101,7 @@ void main(void)
 	if (sensor_trigger_set(mpu6050, &trigger,
 			       handle_mpu6050_drdy) < 0) {
 		printf("Cannot configure trigger\n");
-		return;
+		return 0;
 	}
 	printk("Configured for triggered sampling.\n");
 #endif
@@ -116,4 +116,5 @@ void main(void)
 	}
 
 	/* triggered runs with its own thread after exit */
+	return 0;
 }

--- a/samples/sensor/ms5837/src/main.c
+++ b/samples/sensor/ms5837/src/main.c
@@ -12,19 +12,19 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
-void main(void)
+int main(void)
 {
 	struct sensor_value oversampling_rate = { 8192, 0 };
 	const struct device *const dev = DEVICE_DT_GET_ANY(meas_ms5837);
 
 	if (dev == NULL) {
 		LOG_ERR("Could not find MS5837 device, aborting test.");
-		return;
+		return 0;
 	}
 	if (!device_is_ready(dev)) {
 		LOG_ERR("MS5837 device %s is not ready, aborting test.",
 			dev->name);
-		return;
+		return 0;
 	}
 
 	if (sensor_attr_set(dev, SENSOR_CHAN_ALL, SENSOR_ATTR_OVERSAMPLING,
@@ -32,7 +32,7 @@ void main(void)
 		LOG_ERR("Could not set oversampling rate of %d "
 			"on MS5837 device, aborting test.",
 			oversampling_rate.val1);
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -48,4 +48,5 @@ void main(void)
 
 		k_sleep(K_MSEC(10000));
 	}
+	return 0;
 }

--- a/samples/sensor/proximity_polling/src/main.c
+++ b/samples/sensor/proximity_polling/src/main.c
@@ -38,7 +38,7 @@ void print_prox_data(void)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	printk("Proximity sensor sample application\n");
 	printk("Found %d proximity sensor(s): ", ARRAY_SIZE(prox_devices));
@@ -51,4 +51,5 @@ void main(void)
 		k_sleep(K_MSEC(2000));
 		print_prox_data();
 	}
+	return 0;
 }

--- a/samples/sensor/qdec/src/main.c
+++ b/samples/sensor/qdec/src/main.c
@@ -66,7 +66,7 @@ void qenc_emulate_init(void) { };
 
 #endif /* QUAD_ENC_EMUL_ENABLED */
 
-void main(void)
+int main(void)
 {
 	struct sensor_value val;
 	int rc;
@@ -74,7 +74,7 @@ void main(void)
 
 	if (!device_is_ready(dev)) {
 		printk("Qdec device is not ready\n");
-		return;
+		return 0;
 	}
 
 	printk("Quadrature decoder sensor test\n");
@@ -85,17 +85,18 @@ void main(void)
 		rc = sensor_sample_fetch(dev);
 		if (rc != 0) {
 			printk("Failed to fetch sample (%d)\n", rc);
-			return;
+			return 0;
 		}
 
 		rc = sensor_channel_get(dev, SENSOR_CHAN_ROTATION, &val);
 		if (rc != 0) {
 			printk("Failed to get data (%d)\n", rc);
-			return;
+			return 0;
 		}
 
 		printk("Position = %d degrees\n", val.val1);
 
 		k_msleep(1000);
 	}
+	return 0;
 }

--- a/samples/sensor/sensor_shell/src/main.c
+++ b/samples/sensor/sensor_shell/src/main.c
@@ -74,7 +74,7 @@ static void data_ready_trigger_handler(const struct device *sensor,
 	}
 }
 
-void main(void)
+int main(void)
 {
 	STRUCT_SECTION_FOREACH(sensor_info, sensor)
 	{
@@ -84,4 +84,5 @@ void main(void)
 		};
 		sensor_trigger_set(sensor->dev, &trigger, data_ready_trigger_handler);
 	}
+	return 0;
 }

--- a/samples/sensor/sgp40_sht4x/src/main.c
+++ b/samples/sensor/sgp40_sht4x/src/main.c
@@ -20,7 +20,7 @@
 #error "No sensirion,sht4x compatible node found in the device tree"
 #endif
 
-void main(void)
+int main(void)
 {
 
 #if CONFIG_APP_USE_COMPENSATION
@@ -33,12 +33,12 @@ void main(void)
 
 	if (!device_is_ready(sht)) {
 		printf("Device %s is not ready.\n", sht->name);
-		return;
+		return 0;
 	}
 
 	if (!device_is_ready(sgp)) {
 		printf("Device %s is not ready.\n", sgp->name);
-		return;
+		return 0;
 	}
 
 #if CONFIG_APP_USE_HEATER
@@ -57,7 +57,7 @@ void main(void)
 
 		if (sensor_sample_fetch(sht)) {
 			printf("Failed to fetch sample from SHT4X device\n");
-			return;
+			return 0;
 		}
 
 		sensor_channel_get(sht, SENSOR_CHAN_AMBIENT_TEMP, &temp);
@@ -78,7 +78,7 @@ void main(void)
 
 			if (sht4x_fetch_with_heater(sht)) {
 				printf("Failed to fetch sample from SHT4X device\n");
-				return;
+				return 0;
 			}
 
 			sensor_channel_get(sht, SENSOR_CHAN_HUMIDITY, &hum);
@@ -99,7 +99,7 @@ void main(void)
 #endif
 		if (sensor_sample_fetch(sgp)) {
 			printf("Failed to fetch sample from SGP40 device.\n");
-			return;
+			return 0;
 		}
 
 		sensor_channel_get(sgp, SENSOR_CHAN_GAS_RES, &gas);

--- a/samples/sensor/sht3xd/src/main.c
+++ b/samples/sensor/sht3xd/src/main.c
@@ -23,14 +23,14 @@ static void trigger_handler(const struct device *dev,
 
 #endif
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(sensirion_sht3xd);
 	int rc;
 
 	if (!device_is_ready(dev)) {
 		printf("Device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_SHT3XD_TRIGGER
@@ -53,7 +53,7 @@ void main(void)
 	}
 	if (rc != 0) {
 		printf("SHT3XD: trigger config failed: %d\n", rc);
-		return;
+		return 0;
 	}
 	printf("Alert outside %d..%d %%RH got %d\n", lo_thr.val1,
 	       hi_thr.val1, rc);
@@ -98,4 +98,5 @@ void main(void)
 
 		k_sleep(K_MSEC(2000));
 	}
+	return 0;
 }

--- a/samples/sensor/sm351lt/src/main.c
+++ b/samples/sensor/sm351lt/src/main.c
@@ -39,13 +39,13 @@ static void trigger_handler(const struct device *dev,
 }
 #endif
 
-void main(void)
+int main(void)
 {
 	const struct device *const sensor = DEVICE_DT_GET_ONE(honeywell_sm351lt);
 
 	if (!device_is_ready(sensor)) {
 		printk("Device %s is not ready\n", sensor->name);
-		return;
+		return 0;
 	}
 
 #if CONFIG_SM351LT_TRIGGER
@@ -65,13 +65,13 @@ void main(void)
 				     &trigger_type);
 		if (rc != 0) {
 			printf("Failed to set trigger type: %d\n", rc);
-			return;
+			return 0;
 		}
 
 		rc = sensor_trigger_set(sensor, &trig, trigger_handler);
 		if (rc != 0) {
 			printf("Failed to set trigger: %d\n", rc);
-			return;
+			return 0;
 		}
 
 		printf("Waiting for triggers\n");

--- a/samples/sensor/stm32_vbat_sensor/src/main.c
+++ b/samples/sensor/stm32_vbat_sensor/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/sys/printk.h>
 
-void main(void)
+int main(void)
 {
 	struct sensor_value val;
 	int rc;
@@ -17,7 +17,7 @@ void main(void)
 
 	if (!device_is_ready(dev)) {
 		printk("VBAT sensor is not ready\n");
-		return;
+		return 0;
 	}
 
 	printk("STM32 Vbat sensor test\n");
@@ -26,14 +26,15 @@ void main(void)
 	rc = sensor_sample_fetch(dev);
 	if (rc) {
 		printk("Failed to fetch sample (%d)\n", rc);
-		return;
+		return 0;
 	}
 
 	rc = sensor_channel_get(dev, SENSOR_CHAN_VOLTAGE, &val);
 	if (rc) {
 		printk("Failed to get data (%d)\n", rc);
-		return;
+		return 0;
 	}
 
 	printk("Current Vbat voltage: %.2f V\n", sensor_value_to_double(&val));
+	return 0;
 }

--- a/samples/sensor/sx9500/src/main.c
+++ b/samples/sensor/sx9500/src/main.c
@@ -72,16 +72,17 @@ static void do_main(const struct device *dev)
 
 #endif /* CONFIG_SX9500_TRIGGER */
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(semtech_sx9500);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	printk("device is %p, name is %s\n", dev, dev->name);
 
 	do_main(dev);
+	return 0;
 }

--- a/samples/sensor/th02/src/main.c
+++ b/samples/sensor/th02/src/main.c
@@ -23,7 +23,7 @@ static struct channel_info info[] = {
 	{ SENSOR_CHAN_HUMIDITY, },
 };
 
-void main(void)
+int main(void)
 {
 	const struct device *const glcd = DEVICE_DT_GET(DT_NODELABEL(glcd));
 	const struct device *const th02 = DEVICE_DT_GET_ONE(hoperf_th02);
@@ -33,12 +33,12 @@ void main(void)
 
 	if (!device_is_ready(th02)) {
 		printk("TH02 is not ready\n");
-		return;
+		return 0;
 	}
 
 	if (!device_is_ready(glcd)) {
 		printk("Grove LCD not ready\n");
-		return;
+		return 0;
 	}
 
 	/* configure LCD */
@@ -84,4 +84,5 @@ void main(void)
 
 		k_sleep(K_MSEC(2000));
 	}
+	return 0;
 }

--- a/samples/sensor/thermometer/src/main.c
+++ b/samples/sensor/thermometer/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET(DT_ALIAS(ambient_temp0));
 	struct sensor_value value;
@@ -19,7 +19,7 @@ void main(void)
 
 	if (!device_is_ready(dev)) {
 		printf("Device %s is not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	printf("Temperature device is %p, name is %s\n", dev, dev->name);
@@ -41,4 +41,5 @@ void main(void)
 
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }

--- a/samples/sensor/ti_hdc/src/main.c
+++ b/samples/sensor/ti_hdc/src/main.c
@@ -12,14 +12,14 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/gpio.h>
 
-void main(void)
+int main(void)
 {
 	printk("Running on %s!\n", CONFIG_ARCH);
 	const struct device *const dev = DEVICE_DT_GET_ONE(ti_hdc);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	printk("Dev %p name %s is ready!\n", dev, dev->name);
@@ -40,4 +40,5 @@ void main(void)
 		/* wait for the next sample */
 		k_sleep(K_SECONDS(10));
 	}
+	return 0;
 }

--- a/samples/sensor/tmp108/src/main.c
+++ b/samples/sensor/tmp108/src/main.c
@@ -128,7 +128,7 @@ void get_temperature_continuous(const struct device *tmp108)
 	printf("temperature is %gC\n", sensor_value_to_double(&temp_value));
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *temp_sensor;
 	int result;
@@ -144,13 +144,13 @@ void main(void)
 
 		if (!temp_sensor) {
 			printf("error: tmp108 compatible devices not found\n");
-			return;
+			return 0;
 		}
 	}
 
 	if (!device_is_ready(temp_sensor)) {
 		printf("error: tmp108 device not ready\n");
-		return;
+		return 0;
 	}
 
 	sensor_attr_set(temp_sensor,
@@ -180,4 +180,5 @@ void main(void)
 #endif
 		k_sleep(K_MSEC(3000));
 	}
+	return 0;
 }

--- a/samples/sensor/tmp112/src/main.c
+++ b/samples/sensor/tmp112/src/main.c
@@ -54,7 +54,7 @@ static void do_main(const struct device *dev)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ANY(ti_tmp112);
 
@@ -63,4 +63,5 @@ void main(void)
 	printk("device is %p, name is %s\n", dev, dev->name);
 
 	do_main(dev);
+	return 0;
 }

--- a/samples/sensor/tmp116/src/main.c
+++ b/samples/sensor/tmp116/src/main.c
@@ -17,7 +17,7 @@
 
 static uint8_t eeprom_content[EEPROM_TMP116_SIZE];
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET(TMP116_NODE);
 	const struct device *const eeprom = DEVICE_DT_GET(TMP116_EEPROM_NODE);
@@ -62,18 +62,19 @@ void main(void)
 		ret = sensor_sample_fetch(dev);
 		if (ret) {
 			printk("Failed to fetch measurements (%d)\n", ret);
-			return;
+			return 0;
 		}
 
 		ret = sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP,
 					 &temp_value);
 		if (ret) {
 			printk("Failed to get measurements (%d)\n", ret);
-			return;
+			return 0;
 		}
 
 		printk("temp is %d.%d oC\n", temp_value.val1, temp_value.val2);
 
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }

--- a/samples/sensor/vcnl4040/src/main.c
+++ b/samples/sensor/vcnl4040/src/main.c
@@ -128,13 +128,13 @@ static void test_trigger_mode(const struct device *dev)
 
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const vcnl = DEVICE_DT_GET_ONE(vishay_vcnl4040);
 
 	if (!device_is_ready(vcnl)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	printf("Testing the polling mode.\n");
@@ -144,4 +144,5 @@ void main(void)
 	printf("Testing the trigger mode.\n");
 	test_trigger_mode(vcnl);
 	printf("Trigger mode test finished.\n");
+	return 0;
 }

--- a/samples/sensor/vl53l0x/src/main.c
+++ b/samples/sensor/vl53l0x/src/main.c
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <zephyr/sys/printk.h>
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET_ONE(st_vl53l0x);
 	struct sensor_value value;
@@ -18,14 +18,14 @@ void main(void)
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	while (1) {
 		ret = sensor_sample_fetch(dev);
 		if (ret) {
 			printk("sensor_sample_fetch failed ret %d\n", ret);
-			return;
+			return 0;
 		}
 
 		ret = sensor_channel_get(dev, SENSOR_CHAN_PROX, &value);
@@ -38,4 +38,5 @@ void main(void)
 
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }

--- a/samples/sensor/wsen_hids/src/main.c
+++ b/samples/sensor/wsen_hids/src/main.c
@@ -46,13 +46,13 @@ static void hids_drdy_interrupt_handler(const struct device *dev, const struct s
 	process_sample(dev);
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *dev = DEVICE_DT_GET_ONE(we_wsen_hids);
 
 	if (!device_is_ready(dev)) {
 		LOG_ERR("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	LOG_INF("HIDS device initialized.");
@@ -64,7 +64,7 @@ void main(void)
 		};
 		if (sensor_trigger_set(dev, &trig, hids_drdy_interrupt_handler) < 0) {
 			LOG_ERR("Failed to configure trigger.");
-			return;
+			return 0;
 		}
 	}
 
@@ -74,4 +74,5 @@ void main(void)
 	}
 
 	k_sleep(K_FOREVER);
+	return 0;
 }

--- a/samples/sensor/wsen_itds/src/main.c
+++ b/samples/sensor/wsen_itds/src/main.c
@@ -125,7 +125,7 @@ static void test_trigger_mode(const struct device *itds)
 
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const itds = DEVICE_DT_GET_ONE(we_wsen_itds);
 	struct sensor_value attr;
@@ -133,7 +133,7 @@ void main(void)
 	printf("get device wsen-itds\n");
 	if (!device_is_ready(itds)) {
 		printk("sensor: device not ready.\n");
-		return;
+		return 0;
 	}
 
 	/*
@@ -145,7 +145,7 @@ void main(void)
 	if (sensor_attr_set(itds, SENSOR_CHAN_ACCEL_XYZ,
 			    SENSOR_ATTR_FULL_SCALE, &attr) < 0) {
 		printf("Cannot set accl range.\n");
-		return;
+		return 0;
 	}
 
 	printf("Testing the polling mode.\n");
@@ -155,4 +155,5 @@ void main(void)
 	printf("Testing the trigger mode.\n");
 	test_trigger_mode(itds);
 	printf("Trigger mode test finished.\n");
+	return 0;
 }

--- a/samples/shields/lmp90100_evb/rtd/src/main.c
+++ b/samples/shields/lmp90100_evb/rtd/src/main.c
@@ -40,7 +40,7 @@ static double rtd_temperature(int nom, double resistance)
 	return temp;
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const lmp90100 = DEVICE_DT_GET_ONE(ti_lmp90100);
 	double resistance;
@@ -67,13 +67,13 @@ void main(void)
 
 	if (!device_is_ready(lmp90100)) {
 		LOG_ERR("LMP90100 device not ready");
-		return;
+		return 0;
 	}
 
 	err = adc_channel_setup(lmp90100, &ch_cfg);
 	if (err) {
 		LOG_ERR("failed to setup ADC channel (err %d)", err);
-		return;
+		return 0;
 	}
 
 	while (true) {
@@ -90,4 +90,5 @@ void main(void)
 
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }

--- a/samples/shields/npm6001_ek/src/main.c
+++ b/samples/shields/npm6001_ek/src/main.c
@@ -44,16 +44,16 @@ static const struct device *name2reg(const char *name)
 	return NULL;
 }
 
-void main(void)
+int main(void)
 {
 	if (!device_is_ready(gpio)) {
 		printk("nPM6001 GPIO device not ready\n");
-		return;
+		return 0;
 	}
 
 	if (!device_is_ready(wdt)) {
 		printk("nPM6001 Watchdog device not ready\n");
-		return;
+		return 0;
 	}
 
 	for (size_t i = 0U; i < ARRAY_SIZE(regulators); i++) {
@@ -61,9 +61,10 @@ void main(void)
 		    !device_is_ready(regulators[i].dev)) {
 			printk("nPM6001 %s regulator device not ready\n",
 			       regulators[i].name);
-			return;
+			return 0;
 		}
 	}
+	return 0;
 }
 
 static int cmd_regulator_list(const struct shell *sh, size_t argc, char **argv)

--- a/samples/shields/x_nucleo_53l0a1/src/main.c
+++ b/samples/shields/x_nucleo_53l0a1/src/main.c
@@ -114,7 +114,7 @@ static void change_mode(const struct device *dev, struct gpio_callback *cb, uint
 }
 
 
-void main(void)
+int main(void)
 {
 	struct gpio_callback button_cb_data;
 	const uint8_t Hello[4] = { CHAR_H, CHAR_E, CHAR_PIPE | CHAR_1, CHAR_0 };
@@ -126,7 +126,7 @@ void main(void)
 	if (!device_is_ready(button.port)) {
 		printk("Error: button device %s is not ready\n",
 		       button.port->name);
-		return;
+		return 0;
 	}
 
 	gpio_pin_configure_dt(&button, GPIO_INPUT);
@@ -137,4 +137,5 @@ void main(void)
 	while (1) {
 		modes[current_mode]();
 	}
+	return 0;
 }

--- a/samples/shields/x_nucleo_iks01a1/src/main.c
+++ b/samples/shields/x_nucleo_iks01a1/src/main.c
@@ -21,7 +21,7 @@ static void lis3mdl_trigger_handler(const struct device *dev,
 }
 #endif
 
-void main(void)
+int main(void)
 {
 	struct sensor_value temp, hum, press;
 	struct sensor_value magn_xyz[3], accel_xyz[3];
@@ -36,19 +36,19 @@ void main(void)
 
 	if (!device_is_ready(hts221)) {
 		printk("%s: device not ready.\n", hts221->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lis3mdl)) {
 		printk("%s: device not ready.\n", lis3mdl->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lsm6ds0)) {
 		printk("%s: device not ready.\n", lsm6ds0->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lps25hb)) {
 		printk("%s: device not ready.\n", lps25hb->name);
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_LIS3MDL_TRIGGER
@@ -63,21 +63,21 @@ void main(void)
 
 		if (sensor_sample_fetch(hts221) < 0) {
 			printf("HTS221 Sensor sample update error\n");
-			return;
+			return 0;
 		}
 		if (sensor_sample_fetch(lps25hb) < 0) {
 			printf("LPS25HB Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #ifndef CONFIG_LIS3MDL_TRIGGER
 		if (sensor_sample_fetch(lis3mdl) < 0) {
 			printf("LIS3MDL Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 		if (sensor_sample_fetch(lsm6ds0) < 0) {
 			printf("LSM6DS0 Sensor sample update error\n");
-			return;
+			return 0;
 		}
 
 		/* Get sensor data */

--- a/samples/shields/x_nucleo_iks01a2/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks01a2/sensorhub/src/main.c
@@ -21,7 +21,7 @@ static void lsm6dsl_trigger_handler(const struct device *dev,
 }
 #endif
 
-void main(void)
+int main(void)
 {
 #ifdef CONFIG_LSM6DSL_TRIGGER
 	int cnt = 1;
@@ -38,7 +38,7 @@ void main(void)
 
 	if (!device_is_ready(lsm6dsl)) {
 		printk("%s: device not ready.\n", lsm6dsl->name);
-		return;
+		return 0;
 	}
 
 	/* set LSM6DSL accel/gyro sampling frequency to 104 Hz */
@@ -50,13 +50,13 @@ void main(void)
 	if (sensor_attr_set(lsm6dsl, SENSOR_CHAN_ACCEL_XYZ,
 			    SENSOR_ATTR_SAMPLING_FREQUENCY, &odr_attr) < 0) {
 		printk("Cannot set sampling frequency for accelerometer.\n");
-		return;
+		return 0;
 	}
 
 	if (sensor_attr_set(lsm6dsl, SENSOR_CHAN_GYRO_XYZ,
 			    SENSOR_ATTR_SAMPLING_FREQUENCY, &odr_attr) < 0) {
 		printk("Cannot set sampling frequency for gyro.\n");
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_LSM6DSL_TRIGGER
@@ -73,7 +73,7 @@ void main(void)
 #ifndef CONFIG_LSM6DSL_TRIGGER
 		if (sensor_sample_fetch(lsm6dsl) < 0) {
 			printf("LSM6DSL Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 

--- a/samples/shields/x_nucleo_iks01a2/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks01a2/standard/src/main.c
@@ -21,7 +21,7 @@ static void lsm6dsl_trigger_handler(const struct device *dev,
 }
 #endif
 
-void main(void)
+int main(void)
 {
 	struct sensor_value temp1, temp2, hum, press;
 	struct sensor_value accel1[3], accel2[3];
@@ -38,23 +38,23 @@ void main(void)
 
 	if (!device_is_ready(hts221)) {
 		printk("%s: device not ready.\n", hts221->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lps22hb)) {
 		printk("%s: device not ready.\n", lps22hb->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lsm6dsl)) {
 		printk("%s: device not ready.\n", lsm6dsl->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lsm303agr_a)) {
 		printk("%s: device not ready.\n", lsm303agr_a->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lsm303agr_m)) {
 		printk("%s: device not ready.\n", lsm303agr_m->name);
-		return;
+		return 0;
 	}
 
 	/* set LSM6DSL accel/gyro sampling frequency to 104 Hz */
@@ -66,13 +66,13 @@ void main(void)
 	if (sensor_attr_set(lsm6dsl, SENSOR_CHAN_ACCEL_XYZ,
 			    SENSOR_ATTR_SAMPLING_FREQUENCY, &odr_attr) < 0) {
 		printk("Cannot set sampling frequency for accelerometer.\n");
-		return;
+		return 0;
 	}
 
 	if (sensor_attr_set(lsm6dsl, SENSOR_CHAN_GYRO_XYZ,
 			    SENSOR_ATTR_SAMPLING_FREQUENCY, &odr_attr) < 0) {
 		printk("Cannot set sampling frequency for gyro.\n");
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_LSM6DSL_TRIGGER
@@ -90,26 +90,26 @@ void main(void)
 
 		if (sensor_sample_fetch(hts221) < 0) {
 			printf("HTS221 Sensor sample update error\n");
-			return;
+			return 0;
 		}
 		if (sensor_sample_fetch(lps22hb) < 0) {
 			printf("LPS22HB Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #ifndef CONFIG_LSM6DSL_TRIGGER
 		if (sensor_sample_fetch(lsm6dsl) < 0) {
 			printf("LSM6DSL Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 		ret = sensor_sample_fetch(lsm303agr_a);
 		if (ret < 0 && ret != -EBADMSG) {
 			printf("LSM303AGR Accel Sensor sample update error\n");
-			return;
+			return 0;
 		}
 		if (sensor_sample_fetch(lsm303agr_m) < 0) {
 			printf("LSM303AGR Magn Sensor sample update error\n");
-			return;
+			return 0;
 		}
 
 		/* Get sensor data */

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
@@ -165,7 +165,7 @@ static void lsm6dso_config(const struct device *lsm6dso)
 #endif
 }
 
-void main(void)
+int main(void)
 {
 #ifdef CONFIG_LSM6DSO_EXT_LPS22HH
 	struct sensor_value temp2, press;
@@ -185,11 +185,11 @@ void main(void)
 
 	if (!device_is_ready(lis2dw12)) {
 		printk("%s: device not ready.\n", lis2dw12->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lsm6dso)) {
 		printk("%s: device not ready.\n", lsm6dso->name);
-		return;
+		return 0;
 	}
 
 	lis2dw12_config(lis2dw12);
@@ -201,13 +201,13 @@ void main(void)
 #ifndef CONFIG_LIS2DW12_TRIGGER
 		if (sensor_sample_fetch(lis2dw12) < 0) {
 			printf("LIS2DW12 Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 #ifndef CONFIG_LSM6DSO_TRIGGER
 		if (sensor_sample_fetch(lsm6dso) < 0) {
 			printf("LSM6DSO Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 

--- a/samples/shields/x_nucleo_iks01a3/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/standard/src/main.c
@@ -237,7 +237,7 @@ static void lsm6dso_config(const struct device *lsm6dso)
 #endif
 }
 
-void main(void)
+int main(void)
 {
 	struct sensor_value temp1, temp2, temp3, hum, press;
 #ifdef CONFIG_LSM6DSO_ENABLE_TEMP
@@ -257,27 +257,27 @@ void main(void)
 
 	if (!device_is_ready(hts221)) {
 		printk("%s: device not ready.\n", hts221->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lps22hh)) {
 		printk("%s: device not ready.\n", lps22hh->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(stts751)) {
 		printk("%s: device not ready.\n", stts751->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lis2mdl)) {
 		printk("%s: device not ready.\n", lis2mdl->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lis2dw12)) {
 		printk("%s: device not ready.\n", lis2dw12->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(lsm6dso)) {
 		printk("%s: device not ready.\n", lsm6dso->name);
-		return;
+		return 0;
 	}
 
 	lis2mdl_config(lis2mdl);
@@ -291,36 +291,36 @@ void main(void)
 
 		if (sensor_sample_fetch(hts221) < 0) {
 			printf("HTS221 Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #ifndef CONFIG_LPS22HH_TRIGGER
 		if (sensor_sample_fetch(lps22hh) < 0) {
 			printf("LPS22HH Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 		if (sensor_sample_fetch(stts751) < 0) {
 			printf("STTS751 Sensor sample update error\n");
-			return;
+			return 0;
 		}
 
 #ifndef CONFIG_LIS2MDL_TRIGGER
 		if (sensor_sample_fetch(lis2mdl) < 0) {
 			printf("LIS2MDL Magn Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 
 #ifndef CONFIG_LIS2DW12_TRIGGER
 		if (sensor_sample_fetch(lis2dw12) < 0) {
 			printf("LIS2DW12 Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 #ifndef CONFIG_LSM6DSO_TRIGGER
 		if (sensor_sample_fetch(lsm6dso) < 0) {
 			printf("LSM6DSO Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 

--- a/samples/shields/x_nucleo_iks02a1/microphone/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/microphone/src/main.c
@@ -43,7 +43,7 @@ struct dmic_cfg cfg = {
 void *rx_block[NUM_MS];
 size_t rx_size = PCM_BLK_SIZE_MS;
 
-void main(void)
+int main(void)
 {
 	int i;
 	uint32_t ms;
@@ -53,19 +53,19 @@ void main(void)
 
 	if (!device_is_ready(mic_dev)) {
 		printk("%s: device not ready.\n", mic_dev->name);
-		return;
+		return 0;
 	}
 
 	ret = dmic_configure(mic_dev, &cfg);
 	if (ret < 0) {
 		printk("microphone configuration error\n");
-		return;
+		return 0;
 	}
 
 	ret = dmic_trigger(mic_dev, DMIC_TRIGGER_START);
 	if (ret < 0) {
 		printk("microphone start trigger error\n");
-		return;
+		return 0;
 	}
 
 	/* Acquire microphone audio */
@@ -73,14 +73,14 @@ void main(void)
 		ret = dmic_read(mic_dev, 0, &rx_block[ms], &rx_size, 2000);
 		if (ret < 0) {
 			printk("microphone audio read error\n");
-			return;
+			return 0;
 		}
 	}
 
 	ret = dmic_trigger(mic_dev, DMIC_TRIGGER_STOP);
 	if (ret < 0) {
 		printk("microphone stop trigger error\n");
-		return;
+		return 0;
 	}
 
 	/* print PCM stream */
@@ -112,4 +112,5 @@ void main(void)
 		}
 	}
 #endif
+	return 0;
 }

--- a/samples/shields/x_nucleo_iks02a1/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/sensorhub/src/main.c
@@ -148,7 +148,7 @@ static void ism330dhcx_config(const struct device *ism330dhcx)
 #endif
 }
 
-void main(void)
+int main(void)
 {
 #ifdef CONFIG_ISM330DHCX_ENABLE_TEMP
 	struct sensor_value die_temp;
@@ -162,11 +162,11 @@ void main(void)
 
 	if (!device_is_ready(iis2dlpc)) {
 		printk("%s: device not ready.\n", iis2dlpc->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(ism330dhcx)) {
 		printk("%s: device not ready.\n", ism330dhcx->name);
-		return;
+		return 0;
 	}
 
 	iis2dlpc_config(iis2dlpc);
@@ -178,13 +178,13 @@ void main(void)
 #ifndef CONFIG_IIS2DLPC_TRIGGER
 		if (sensor_sample_fetch(iis2dlpc) < 0) {
 			printf("IIS2DLPC Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 #ifndef CONFIG_ISM330DHCX_TRIGGER
 		if (sensor_sample_fetch(ism330dhcx) < 0) {
 			printf("ISM330DHCX Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 

--- a/samples/shields/x_nucleo_iks02a1/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/standard/src/main.c
@@ -158,7 +158,7 @@ static void ism330dhcx_config(const struct device *ism330dhcx)
 #endif
 }
 
-void main(void)
+int main(void)
 {
 #ifdef CONFIG_ISM330DHCX_ENABLE_TEMP
 	struct sensor_value die_temp;
@@ -174,15 +174,15 @@ void main(void)
 
 	if (!device_is_ready(iis2dlpc)) {
 		printk("%s: device not ready.\n", iis2dlpc->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(iis2mdc)) {
 		printk("%s: device not ready.\n", iis2mdc->name);
-		return;
+		return 0;
 	}
 	if (!device_is_ready(ism330dhcx)) {
 		printk("%s: device not ready.\n", ism330dhcx->name);
-		return;
+		return 0;
 	}
 
 	iis2dlpc_config(iis2dlpc);
@@ -195,19 +195,19 @@ void main(void)
 #ifndef CONFIG_IIS2DLPC_TRIGGER
 		if (sensor_sample_fetch(iis2dlpc) < 0) {
 			printf("IIS2DLPC Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 #ifndef CONFIG_IIS2MDC_TRIGGER
 		if (sensor_sample_fetch(iis2mdc) < 0) {
 			printf("IIS2MDC Magn Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 #ifndef CONFIG_ISM330DHCX_TRIGGER
 		if (sensor_sample_fetch(ism330dhcx) < 0) {
 			printf("ISM330DHCX IMU Sensor sample update error\n");
-			return;
+			return 0;
 		}
 #endif
 

--- a/samples/subsys/canbus/isotp/src/main.c
+++ b/samples/subsys/canbus/isotp/src/main.c
@@ -141,7 +141,7 @@ void send_complette_cb(int error_nr, void *arg)
  * @brief Main application entry point.
  *
  */
-void main(void)
+int main(void)
 {
 	k_tid_t tid;
 	static struct isotp_send_ctx send_ctx_8_0;
@@ -151,21 +151,21 @@ void main(void)
 	can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 	if (!device_is_ready(can_dev)) {
 		printk("CAN: Device driver not ready.\n");
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_SAMPLE_LOOPBACK_MODE
 	ret = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
 	if (ret != 0) {
 		printk("CAN: Failed to set loopback mode [%d]", ret);
-		return;
+		return 0;
 	}
 #endif /* CONFIG_SAMPLE_LOOPBACK_MODE */
 
 	ret = can_start(can_dev);
 	if (ret != 0) {
 		printk("CAN: Failed to start device [%d]\n", ret);
-		return;
+		return 0;
 	}
 
 	tid = k_thread_create(&rx_8_0_thread_data, rx_8_0_thread_stack,

--- a/samples/subsys/console/echo/src/main.c
+++ b/samples/subsys/console/echo/src/main.c
@@ -8,7 +8,7 @@
 
 static const char prompt[] = "Start typing characters to see them echoed back\r\n";
 
-void main(void)
+int main(void)
 {
 	console_init();
 
@@ -24,4 +24,5 @@ void main(void)
 			console_putchar('\n');
 		}
 	}
+	return 0;
 }

--- a/samples/subsys/console/getchar/src/main.c
+++ b/samples/subsys/console/getchar/src/main.c
@@ -8,7 +8,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/console/console.h>
 
-void main(void)
+int main(void)
 {
 	console_init();
 
@@ -19,4 +19,5 @@ void main(void)
 
 		printk("char: [0x%x] %c\n", c, c);
 	}
+	return 0;
 }

--- a/samples/subsys/console/getline/src/main.c
+++ b/samples/subsys/console/getline/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/console/console.h>
 
-void main(void)
+int main(void)
 {
 	console_getline_init();
 
@@ -21,4 +21,5 @@ void main(void)
 		printk("line: %s\n", s);
 		printk("last char was: 0x%x\n", s[strlen(s) - 1]);
 	}
+	return 0;
 }

--- a/samples/subsys/debug/debugmon/src/main.c
+++ b/samples/subsys/debug/debugmon/src/main.c
@@ -55,19 +55,19 @@ void z_arm_debug_monitor(void)
 		;
 }
 
-void main(void)
+int main(void)
 {
 	/* Set up led and led timer */
 	if (!device_is_ready(led.port)) {
 		printk("Device not ready\n");
-		return;
+		return 0;
 	}
 
 	int err = gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
 
 	if (err) {
 		printk("Error configuring LED\n");
-		return;
+		return 0;
 	}
 	k_timer_start(&led_timer, K_NO_WAIT, K_SECONDS(1));
 
@@ -76,9 +76,10 @@ void main(void)
 	if (err) {
 		printk("Error enabling monitor mode:\n"
 			"Cannot enable DBM when CPU is in Debug mode");
-		return;
+		return 0;
 	}
 
 	/* Enter a breakpoint */
 	__asm("bkpt");
+	return 0;
 }

--- a/samples/subsys/debug/fuzz/src/main.c
+++ b/samples/subsys/debug/fuzz/src/main.c
@@ -62,7 +62,7 @@ static void fuzz_isr(const void *arg)
 	k_sem_give(&fuzz_sem);
 }
 
-void main(void)
+int main(void)
 {
 	printk("Hello World! %s\n", CONFIG_BOARD);
 
@@ -77,4 +77,5 @@ void main(void)
 		 */
 		check0(posix_fuzz_buf, posix_fuzz_sz);
 	}
+	return 0;
 }

--- a/samples/subsys/debug/gdbstub/src/main.c
+++ b/samples/subsys/debug/gdbstub/src/main.c
@@ -25,12 +25,13 @@ static void thread_entry(void *p1, void *p2, void *p3)
 	printk("Hello from user thread!\n");
 }
 
-void main(void)
+int main(void)
 {
 	int ret;
 
 	ret = test();
 	printk("%d\n", ret);
+	return 0;
 }
 
 K_THREAD_DEFINE(thread, STACKSIZE, thread_entry, NULL, NULL, NULL,

--- a/samples/subsys/display/cfb/src/main.c
+++ b/samples/subsys/display/cfb/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/display/cfb.h>
 #include <stdio.h>
 
-void main(void)
+int main(void)
 {
 	const struct device *dev;
 	uint16_t rows;
@@ -20,19 +20,19 @@ void main(void)
 	dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(dev)) {
 		printf("Device %s not ready\n", dev->name);
-		return;
+		return 0;
 	}
 
 	if (display_set_pixel_format(dev, PIXEL_FORMAT_MONO10) != 0) {
 		printf("Failed to set required pixel format\n");
-		return;
+		return 0;
 	}
 
 	printf("Initialized %s\n", dev->name);
 
 	if (cfb_framebuffer_init(dev)) {
 		printf("Framebuffer initialization failed!\n");
-		return;
+		return 0;
 	}
 
 	cfb_framebuffer_clear(dev, true);
@@ -74,4 +74,5 @@ void main(void)
 #endif
 		}
 	}
+	return 0;
 }

--- a/samples/subsys/display/cfb_custom_font/src/main.c
+++ b/samples/subsys/display/cfb_custom_font/src/main.c
@@ -11,7 +11,7 @@
 
 #include "cfb_font_dice.h"
 
-void main(void)
+int main(void)
 {
 	const struct device *const display = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	int err;
@@ -22,12 +22,12 @@ void main(void)
 
 	if (display_set_pixel_format(display, PIXEL_FORMAT_MONO10) != 0) {
 		printk("Failed to set required pixel format\n");
-		return;
+		return 0;
 	}
 
 	if (display_blanking_off(display) != 0) {
 		printk("Failed to turn off display blanking\n");
-		return;
+		return 0;
 	}
 
 	err = cfb_framebuffer_init(display);
@@ -49,4 +49,5 @@ void main(void)
 	if (err) {
 		printk("Could not finalize framebuffer (err %d)\n", err);
 	}
+	return 0;
 }

--- a/samples/subsys/display/lvgl/src/main.c
+++ b/samples/subsys/display/lvgl/src/main.c
@@ -36,7 +36,7 @@ static void button_isr_callback(const struct device *port,
 }
 #endif
 
-void main(void)
+int main(void)
 {
 	int err;
 	char count_str[11] = {0};
@@ -47,7 +47,7 @@ void main(void)
 	display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(display_dev)) {
 		LOG_ERR("Device not ready, aborting test");
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_GPIO
@@ -55,7 +55,7 @@ void main(void)
 		err = gpio_pin_configure_dt(&button_gpio, GPIO_INPUT);
 		if (err) {
 			LOG_ERR("failed to configure button gpio: %d", err);
-			return;
+			return 0;
 		}
 
 		gpio_init_callback(&button_callback, button_isr_callback,
@@ -64,14 +64,14 @@ void main(void)
 		err = gpio_add_callback(button_gpio.port, &button_callback);
 		if (err) {
 			LOG_ERR("failed to add button callback: %d", err);
-			return;
+			return 0;
 		}
 
 		err = gpio_pin_interrupt_configure_dt(&button_gpio,
 						      GPIO_INT_EDGE_TO_ACTIVE);
 		if (err) {
 			LOG_ERR("failed to enable button callback: %d", err);
-			return;
+			return 0;
 		}
 	}
 #endif

--- a/samples/subsys/edac/src/main.c
+++ b/samples/subsys/edac/src/main.c
@@ -30,21 +30,22 @@ static void notification_callback(const struct device *dev, void *data)
 	atomic_set(&handled, true);
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 
 	if (!device_is_ready(dev)) {
 		printk("%s: device not ready.\n", dev->name);
-		return;
+		return 0;
 	}
 
 	if (edac_notify_callback_set(dev, notification_callback)) {
 		LOG_ERR("Cannot set notification callback");
-		return;
+		return 0;
 	}
 
 	LOG_INF("EDAC shell application initialized");
+	return 0;
 }
 
 void thread_function(void)

--- a/samples/subsys/fs/fat_fs/src/main.c
+++ b/samples/subsys/fs/fat_fs/src/main.c
@@ -77,7 +77,7 @@ static bool create_some_entries(const char *base_path)
 */
 static const char *disk_mount_pt = DISK_MOUNT_PT;
 
-void main(void)
+int main(void)
 {
 	/* raw disk i/o */
 	do {
@@ -129,6 +129,7 @@ void main(void)
 	while (1) {
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }
 
 /* List dir entry by path

--- a/samples/subsys/fs/format/src/main.c
+++ b/samples/subsys/fs/format/src/main.c
@@ -38,7 +38,7 @@
 
 LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);
 
-void main(void)
+int main(void)
 {
 	int rc;
 
@@ -46,8 +46,9 @@ void main(void)
 
 	if (rc < 0) {
 		LOG_ERR("Format failed");
-		return;
+		return 0;
 	}
 
 	LOG_INF("Format successful");
+	return 0;
 }

--- a/samples/subsys/fs/littlefs/src/main.c
+++ b/samples/subsys/fs/littlefs/src/main.c
@@ -329,7 +329,7 @@ static int littlefs_mount(struct fs_mount_t *mp)
 }
 #endif /* CONFIG_APP_LITTLEFS_STORAGE_BLK_SDMMC */
 
-void main(void)
+int main(void)
 {
 	char fname1[MAX_PATH_LEN];
 	char fname2[MAX_PATH_LEN];
@@ -340,7 +340,7 @@ void main(void)
 
 	rc = littlefs_mount(mp);
 	if (rc < 0) {
-		return;
+		return 0;
 	}
 
 	snprintf(fname1, sizeof(fname1), "%s/boot_count", mp->mnt_point);
@@ -377,4 +377,5 @@ void main(void)
 out:
 	rc = fs_unmount(mp);
 	LOG_PRINTK("%s unmount: %d\n", mp->mnt_point, rc);
+	return 0;
 }

--- a/samples/subsys/input/input_dump/src/main.c
+++ b/samples/subsys/input/input_dump/src/main.c
@@ -18,7 +18,8 @@ static void input_cb(struct input_event *evt)
 }
 INPUT_LISTENER_CB_DEFINE(NULL, input_cb);
 
-void main(void)
+int main(void)
 {
 	printf("Input sample started\n");
+	return 0;
 }

--- a/samples/subsys/ipc/openamp/remote/src/main.c
+++ b/samples/subsys/ipc/openamp/remote/src/main.c
@@ -255,10 +255,11 @@ _cleanup:
 	printk("OpenAMP demo ended.\n");
 }
 
-void main(void)
+int main(void)
 {
 	printk("Starting application thread!\n");
 	k_thread_create(&thread_data, thread_stack, APP_TASK_STACK_SIZE,
 			(k_thread_entry_t)app_task,
 			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+	return 0;
 }

--- a/samples/subsys/ipc/openamp/src/main.c
+++ b/samples/subsys/ipc/openamp/src/main.c
@@ -281,7 +281,7 @@ _cleanup:
 	printk("OpenAMP demo ended.\n");
 }
 
-void main(void)
+int main(void)
 {
 	printk("Starting application thread!\n");
 	k_thread_create(&thread_data, thread_stack, APP_TASK_STACK_SIZE,
@@ -293,6 +293,7 @@ void main(void)
 	wakeup_cpu1();
 	k_msleep(500);
 #endif /* #if defined(CONFIG_SOC_MPS2_AN521) */
+	return 0;
 }
 
 /* Make sure we clear out the status flag very early (before we bringup the

--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -371,7 +371,7 @@ task_end:
 	printk("OpenAMP demo ended\n");
 }
 
-void main(void)
+int main(void)
 {
 	printk("Starting application threads!\n");
 	k_thread_create(&thread_mng_data, thread_mng_stack, APP_TASK_STACK_SIZE,
@@ -383,4 +383,5 @@ void main(void)
 	k_thread_create(&thread_tty_data, thread_tty_stack, APP_TTY_TASK_STACK_SIZE,
 			(k_thread_entry_t)app_rpmsg_tty,
 			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+	return 0;
 }

--- a/samples/subsys/ipc/rpmsg_service/remote/src/main.c
+++ b/samples/subsys/ipc/rpmsg_service/remote/src/main.c
@@ -74,12 +74,13 @@ void app_task(void *arg1, void *arg2, void *arg3)
 	printk("RPMsg Service demo ended.\n");
 }
 
-void main(void)
+int main(void)
 {
 	printk("Starting application thread!\n");
 	k_thread_create(&thread_data, thread_stack, APP_TASK_STACK_SIZE,
 			(k_thread_entry_t)app_task,
 			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+	return 0;
 }
 
 /* Make sure we register endpoint before RPMsg Service is initialized. */

--- a/samples/subsys/ipc/rpmsg_service/src/main.c
+++ b/samples/subsys/ipc/rpmsg_service/src/main.c
@@ -84,7 +84,7 @@ void app_task(void *arg1, void *arg2, void *arg3)
 	printk("RPMsg Service demo ended.\n");
 }
 
-void main(void)
+int main(void)
 {
 	printk("Starting application thread!\n");
 	k_thread_create(&thread_data, thread_stack, APP_TASK_STACK_SIZE,
@@ -96,6 +96,7 @@ void main(void)
 	wakeup_cpu1();
 	k_msleep(500);
 #endif /* #if defined(CONFIG_SOC_MPS2_AN521) */
+	return 0;
 }
 
 /* Make sure we register endpoint before RPMsg Service is initialized. */

--- a/samples/subsys/logging/ble_backend/src/main.c
+++ b/samples/subsys/logging/ble_backend/src/main.c
@@ -75,7 +75,7 @@ void backend_ble_hook(bool status, void *ctx)
 }
 
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -84,7 +84,7 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		LOG_ERR("Bluetooth init failed (err %d)", err);
-		return;
+		return 0;
 	}
 
 	bt_conn_auth_cb_register(&auth_cb_display);
@@ -97,4 +97,5 @@ void main(void)
 		LOG_INF("Uptime %d secs", uptime_secs);
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }

--- a/samples/subsys/logging/dictionary/src/main.c
+++ b/samples/subsys/logging/dictionary/src/main.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(hello_world, 4);
 
 static const char *hexdump_msg = "HEXDUMP! HEXDUMP@ HEXDUMP#";
 
-void main(void)
+int main(void)
 {
 	int8_t i8 = 1;
 	uint8_t u8 = 2;
@@ -70,4 +70,5 @@ void main(void)
 	LOG_DBG("long double %Lf", ld);
 #endif
 #endif
+	return 0;
 }

--- a/samples/subsys/logging/multidomain/remote/src/main.c
+++ b/samples/subsys/logging/multidomain/remote/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(app);
 
-void main(void)
+int main(void)
 {
 	int cnt = 0;
 
@@ -17,4 +17,5 @@ void main(void)
 		LOG_INF("loop: %d", cnt++);
 		k_sleep(K_MSEC(500));
 	}
+	return 0;
 }

--- a/samples/subsys/logging/multidomain/src/main.c
+++ b/samples/subsys/logging/multidomain/src/main.c
@@ -9,7 +9,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(app);
 
-void main(void)
+int main(void)
 {
 	printk("Hello World! %s\n", CONFIG_BOARD);
+	return 0;
 }

--- a/samples/subsys/lorawan/class_a/src/main.c
+++ b/samples/subsys/lorawan/class_a/src/main.c
@@ -45,7 +45,7 @@ static void lorwan_datarate_changed(enum lorawan_datarate dr)
 	LOG_INF("New Datarate: DR_%d, Max Payload %d", dr, max_size);
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *lora_dev;
 	struct lorawan_join_config join_cfg;
@@ -62,7 +62,7 @@ void main(void)
 	lora_dev = DEVICE_DT_GET(DT_ALIAS(lora0));
 	if (!device_is_ready(lora_dev)) {
 		LOG_ERR("%s: device not ready.", lora_dev->name);
-		return;
+		return 0;
 	}
 
 #if defined(CONFIG_LORAMAC_REGION_EU868)
@@ -72,14 +72,14 @@ void main(void)
 	ret = lorawan_set_region(LORAWAN_REGION_EU868);
 	if (ret < 0) {
 		LOG_ERR("lorawan_set_region failed: %d", ret);
-		return;
+		return 0;
 	}
 #endif
 
 	ret = lorawan_start();
 	if (ret < 0) {
 		LOG_ERR("lorawan_start failed: %d", ret);
-		return;
+		return 0;
 	}
 
 	lorawan_register_downlink_callback(&downlink_cb);
@@ -95,7 +95,7 @@ void main(void)
 	ret = lorawan_join(&join_cfg);
 	if (ret < 0) {
 		LOG_ERR("lorawan_join_network failed: %d", ret);
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_LORAWAN_APP_CLOCK_SYNC
@@ -121,7 +121,7 @@ void main(void)
 
 		if (ret < 0) {
 			LOG_ERR("lorawan_send failed: %d", ret);
-			return;
+			return 0;
 		}
 
 		LOG_INF("Data sent!");

--- a/samples/subsys/mgmt/hawkbit/src/main.c
+++ b/samples/subsys/mgmt/hawkbit/src/main.c
@@ -20,7 +20,7 @@
 
 LOG_MODULE_REGISTER(main);
 
-void main(void)
+int main(void)
 {
 	int ret = -1;
 
@@ -83,4 +83,5 @@ void main(void)
 	}
 
 #endif
+	return 0;
 }

--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
@@ -50,7 +50,7 @@ static struct fs_mount_t littlefs_mnt = {
 };
 #endif
 
-void main(void)
+int main(void)
 {
 	int rc = STATS_INIT_AND_REG(smp_svr_stats, STATS_SIZE_32,
 				    "smp_svr_stats");
@@ -75,7 +75,7 @@ void main(void)
 		rc = usb_enable(NULL);
 		if (rc) {
 			LOG_ERR("Failed to enable USB");
-			return;
+			return 0;
 		}
 	}
 	/* using __TIME__ ensure that a new binary will be built on every
@@ -90,4 +90,5 @@ void main(void)
 		k_sleep(K_MSEC(1000));
 		STATS_INC(smp_svr_stats, ticks);
 	}
+	return 0;
 }

--- a/samples/subsys/mgmt/osdp/control_panel/src/main.c
+++ b/samples/subsys/mgmt/osdp/control_panel/src/main.c
@@ -65,7 +65,7 @@ int event_handler(void *unused, int pd, struct osdp_event *e)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	int ret, led_state;
 	uint32_t cnt = 0;
@@ -78,13 +78,13 @@ void main(void)
 
 	if (!device_is_ready(led0.port)) {
 		printk("Failed to get LED GPIO port %s\n", led0.port->name);
-		return;
+		return 0;
 	}
 
 	ret = gpio_pin_configure_dt(&led0, GPIO_OUTPUT_ACTIVE);
 	if (ret < 0) {
 		printk("Failed to configure gpio pin\n");
-		return;
+		return 0;
 	}
 
 	osdp_cp_set_event_callback(event_handler, NULL);
@@ -102,4 +102,5 @@ void main(void)
 		k_msleep(SLEEP_TIME_MS);
 		cnt++;
 	}
+	return 0;
 }

--- a/samples/subsys/mgmt/osdp/peripheral_device/src/main.c
+++ b/samples/subsys/mgmt/osdp/peripheral_device/src/main.c
@@ -27,21 +27,21 @@ int cmd_handler(void *unused, struct osdp_cmd *p)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	int ret, led_state;
 	uint32_t cnt = 0;
 
 	if (!device_is_ready(led0.port)) {
 		printk("LED0 GPIO port %s is not ready\n", led0.port->name);
-		return;
+		return 0;
 	}
 
 	ret = gpio_pin_configure_dt(&led0, GPIO_OUTPUT_ACTIVE);
 	if (ret < 0) {
 		printk("Failed to configure gpio port %s pin %d\n",
 		       led0.port->name, led0.pin);
-		return;
+		return 0;
 	}
 
 	osdp_pd_set_command_callback(cmd_handler, NULL);
@@ -56,4 +56,5 @@ void main(void)
 		k_msleep(SLEEP_TIME_MS);
 		cnt++;
 	}
+	return 0;
 }

--- a/samples/subsys/mgmt/updatehub/src/main.c
+++ b/samples/subsys/mgmt/updatehub/src/main.c
@@ -83,7 +83,7 @@ static void event_handler(struct net_mgmt_event_callback *cb,
 	}
 }
 
-void main(void)
+int main(void)
 {
 	int ret;
 
@@ -95,7 +95,7 @@ void main(void)
 			       server_certificate,
 			       sizeof(server_certificate)) < 0) {
 		LOG_ERR("Failed to register server certificate");
-		return;
+		return 0;
 	}
 
 	if (tls_credential_add(CA_CERTIFICATE_TAG,
@@ -103,7 +103,7 @@ void main(void)
 			       private_key,
 			       sizeof(private_key)) < 0) {
 		LOG_ERR("Failed to register private key");
-		return;
+		return 0;
 	}
 #endif
 
@@ -151,4 +151,5 @@ void main(void)
 	net_mgmt_init_event_callback(&mgmt_cb, event_handler, EVENT_MASK);
 	net_mgmt_add_event_callback(&mgmt_cb);
 	net_conn_mgr_resend_status();
+	return 0;
 }

--- a/samples/subsys/modbus/rtu_client/src/main.c
+++ b/samples/subsys/modbus/rtu_client/src/main.c
@@ -35,7 +35,7 @@ static int init_modbus_client(void)
 	return modbus_init_client(client_iface, client_param);
 }
 
-void main(void)
+int main(void)
 {
 	uint16_t holding_reg[8] = {'H', 'e', 'l', 'l', 'o'};
 	const uint8_t coil_qty = 3;
@@ -47,21 +47,21 @@ void main(void)
 
 	if (init_modbus_client()) {
 		LOG_ERR("Modbus RTU client initialization failed");
-		return;
+		return 0;
 	}
 
 	err = modbus_write_holding_regs(client_iface, node, 0, holding_reg,
 					ARRAY_SIZE(holding_reg));
 	if (err != 0) {
 		LOG_ERR("FC16 failed with %d", err);
-		return;
+		return 0;
 	}
 
 	err = modbus_read_holding_regs(client_iface, node, 0, holding_reg,
 				       ARRAY_SIZE(holding_reg));
 	if (err != 0) {
 		LOG_ERR("FC03 failed with %d", err);
-		return;
+		return 0;
 	}
 
 	LOG_HEXDUMP_INF(holding_reg, sizeof(holding_reg),
@@ -73,7 +73,7 @@ void main(void)
 		err = modbus_read_coils(client_iface, node, 0, coil, coil_qty);
 		if (err != 0) {
 			LOG_ERR("FC01 failed with %d", err);
-			return;
+			return 0;
 		}
 
 		LOG_INF("Coils state 0x%02x", coil[0]);
@@ -81,28 +81,28 @@ void main(void)
 		err = modbus_write_coil(client_iface, node, addr++, true);
 		if (err != 0) {
 			LOG_ERR("FC05 failed with %d", err);
-			return;
+			return 0;
 		}
 
 		k_msleep(sleep);
 		err = modbus_write_coil(client_iface, node, addr++, true);
 		if (err != 0) {
 			LOG_ERR("FC05 failed with %d", err);
-			return;
+			return 0;
 		}
 
 		k_msleep(sleep);
 		err = modbus_write_coil(client_iface, node, addr++, true);
 		if (err != 0) {
 			LOG_ERR("FC05 failed with %d", err);
-			return;
+			return 0;
 		}
 
 		k_msleep(sleep);
 		err = modbus_read_coils(client_iface, node, 0, coil, coil_qty);
 		if (err != 0) {
 			LOG_ERR("FC01 failed with %d", err);
-			return;
+			return 0;
 		}
 
 		LOG_INF("Coils state 0x%02x", coil[0]);
@@ -111,7 +111,7 @@ void main(void)
 		err = modbus_write_coils(client_iface, node, 0, coil, coil_qty);
 		if (err != 0) {
 			LOG_ERR("FC15 failed with %d", err);
-			return;
+			return 0;
 		}
 
 		k_msleep(sleep);

--- a/samples/subsys/modbus/rtu_server/src/main.c
+++ b/samples/subsys/modbus/rtu_server/src/main.c
@@ -126,20 +126,20 @@ static int init_modbus_server(void)
 	return modbus_init_server(iface, server_param);
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
 	for (int i = 0; i < ARRAY_SIZE(led_dev); i++) {
 		if (!device_is_ready(led_dev[i].port)) {
 			LOG_ERR("LED%u GPIO device not ready", i);
-			return;
+			return 0;
 		}
 
 		err = gpio_pin_configure_dt(&led_dev[i], GPIO_OUTPUT_INACTIVE);
 		if (err != 0) {
 			LOG_ERR("Failed to configure LED%u pin", i);
-			return;
+			return 0;
 		}
 	}
 
@@ -148,7 +148,7 @@ void main(void)
 	uint32_t dtr = 0;
 
 	if (!device_is_ready(dev) || usb_enable(NULL)) {
-		return;
+		return 0;
 	}
 
 	while (!dtr) {
@@ -162,4 +162,5 @@ void main(void)
 	if (init_modbus_server()) {
 		LOG_ERR("Modbus RTU server initialization failed");
 	}
+	return 0;
 }

--- a/samples/subsys/modbus/tcp_gateway/src/main.c
+++ b/samples/subsys/modbus/tcp_gateway/src/main.c
@@ -88,7 +88,7 @@ static int modbus_tcp_connection(int client)
 	return modbus_tcp_reply(client, &tmp_adu);
 }
 
-void main(void)
+int main(void)
 {
 	int serv;
 	struct sockaddr_in bind_addr;
@@ -96,14 +96,14 @@ void main(void)
 
 	if (init_backend_iface()) {
 		LOG_ERR("Modbus initialization failed");
-		return;
+		return 0;
 	}
 
 	serv = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 
 	if (serv < 0) {
 		LOG_ERR("error: socket: %d", errno);
-		return;
+		return 0;
 	}
 
 	bind_addr.sin_family = AF_INET;
@@ -112,12 +112,12 @@ void main(void)
 
 	if (bind(serv, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
 		LOG_ERR("error: bind: %d", errno);
-		return;
+		return 0;
 	}
 
 	if (listen(serv, 5) < 0) {
 		LOG_ERR("error: listen: %d", errno);
-		return;
+		return 0;
 	}
 
 	LOG_INF("Started MODBUS TCP gateway example on port %d", MODBUS_TCP_PORT);
@@ -150,4 +150,5 @@ void main(void)
 		LOG_INF("Connection from %s closed, errno %d",
 			addr_str, rc);
 	}
+	return 0;
 }

--- a/samples/subsys/modbus/tcp_server/src/main.c
+++ b/samples/subsys/modbus/tcp_server/src/main.c
@@ -217,7 +217,7 @@ static int modbus_tcp_connection(int client)
 	return modbus_tcp_reply(client, &tmp_adu);
 }
 
-void main(void)
+int main(void)
 {
 	int serv;
 	struct sockaddr_in bind_addr;
@@ -225,19 +225,19 @@ void main(void)
 
 	if (init_modbus_server()) {
 		LOG_ERR("Modbus TCP server initialization failed");
-		return;
+		return 0;
 	}
 
 	if (init_leds()) {
 		LOG_ERR("Modbus TCP server initialization failed");
-		return;
+		return 0;
 	}
 
 	serv = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 
 	if (serv < 0) {
 		LOG_ERR("error: socket: %d", errno);
-		return;
+		return 0;
 	}
 
 	bind_addr.sin_family = AF_INET;
@@ -246,12 +246,12 @@ void main(void)
 
 	if (bind(serv, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
 		LOG_ERR("error: bind: %d", errno);
-		return;
+		return 0;
 	}
 
 	if (listen(serv, 5) < 0) {
 		LOG_ERR("error: listen: %d", errno);
-		return;
+		return 0;
 	}
 
 	LOG_INF("Started MODBUS TCP server example on port %d", MODBUS_TCP_PORT);
@@ -284,4 +284,5 @@ void main(void)
 		LOG_INF("Connection from %s closed, errno %d",
 			addr_str, rc);
 	}
+	return 0;
 }

--- a/samples/subsys/nvs/src/main.c
+++ b/samples/subsys/nvs/src/main.c
@@ -65,7 +65,7 @@ static struct nvs_fs fs;
 #define LONG_ID 5
 
 
-void main(void)
+int main(void)
 {
 	int rc = 0, cnt = 0, cnt_his = 0;
 	char buf[16];
@@ -81,13 +81,13 @@ void main(void)
 	fs.flash_device = NVS_PARTITION_DEVICE;
 	if (!device_is_ready(fs.flash_device)) {
 		printk("Flash device %s is not ready\n", fs.flash_device->name);
-		return;
+		return 0;
 	}
 	fs.offset = NVS_PARTITION_OFFSET;
 	rc = flash_get_page_info_by_offs(fs.flash_device, fs.offset, &info);
 	if (rc) {
 		printk("Unable to get page info\n");
-		return;
+		return 0;
 	}
 	fs.sector_size = info.size;
 	fs.sector_count = 3U;
@@ -95,7 +95,7 @@ void main(void)
 	rc = nvs_mount(&fs);
 	if (rc) {
 		printk("Flash Init failed\n");
-		return;
+		return 0;
 	}
 
 	/* ADDRESS_ID is used to store an address, lets see if we can
@@ -244,4 +244,5 @@ void main(void)
 			break;
 		}
 	}
+	return 0;
 }

--- a/samples/subsys/pm/device_pm/src/main.c
+++ b/samples/subsys/pm/device_pm/src/main.c
@@ -8,7 +8,7 @@
 #include "dummy_driver.h"
 
 /* Application main Thread */
-void main(void)
+int main(void)
 {
 	const struct device *dev;
 	struct dummy_driver_api *api;
@@ -23,4 +23,5 @@ void main(void)
 	ret = api->read(dev, &val);
 	ret = api->close(dev);
 	printk("Device PM sample app complete\n");
+	return 0;
 }

--- a/samples/subsys/pm/latency/src/main.c
+++ b/samples/subsys/pm/latency/src/main.c
@@ -23,7 +23,7 @@ static void on_latency_changed(int32_t latency)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	struct pm_policy_latency_subscription subs;
 	struct pm_policy_latency_request req;
@@ -32,7 +32,7 @@ void main(void)
 	dev = device_get_binding("dev_test");
 	if (!device_is_ready(dev)) {
 		LOG_ERR("Device not ready");
-		return;
+		return 0;
 	}
 
 	pm_policy_latency_changed_subscribe(&subs, on_latency_changed);
@@ -104,4 +104,5 @@ void main(void)
 	pm_policy_latency_changed_unsubscribe(&subs);
 
 	LOG_INF("Finished, we should now enter STANDBY");
+	return 0;
 }

--- a/samples/subsys/portability/cmsis_rtos_v1/philosophers/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v1/philosophers/src/main.c
@@ -218,8 +218,9 @@ static void display_demo_description(void)
 #endif
 }
 
-void main(void)
+int main(void)
 {
 	display_demo_description();
 	start_threads();
+	return 0;
 }

--- a/samples/subsys/portability/cmsis_rtos_v1/timer_synchronization/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v1/timer_synchronization/src/main.c
@@ -54,7 +54,7 @@ int send_msg_thread(void)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	osTimerId timer_id;
 	uint32_t counter = 10U;
@@ -90,4 +90,5 @@ exit:
 	} else {
 		printk("Error in execution\n");
 	}
+	return 0;
 }

--- a/samples/subsys/portability/cmsis_rtos_v2/philosophers/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v2/philosophers/src/main.c
@@ -246,7 +246,7 @@ static void display_demo_description(void)
 #endif
 }
 
-void main(void)
+int main(void)
 {
 	display_demo_description();
 	init_objects();
@@ -258,4 +258,5 @@ void main(void)
 	 */
 	k_sleep(K_MSEC(5000));
 #endif
+	return 0;
 }

--- a/samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/src/main.c
@@ -63,7 +63,7 @@ int send_msg_thread(void)
 	return 1;
 }
 
-void main(void)
+int main(void)
 {
 	osTimerId_t timer_id;
 	osStatus_t status;
@@ -105,4 +105,5 @@ exit:
 	} else {
 		printk("Error in execution! \n");
 	}
+	return 0;
 }

--- a/samples/subsys/rtio/sensor_batch_processing/src/main.c
+++ b/samples/subsys/rtio/sensor_batch_processing/src/main.c
@@ -25,7 +25,7 @@ RTIO_EXECUTOR_SIMPLE_DEFINE(simple_exec);
 RTIO_DEFINE_WITH_MEMPOOL(ez_io, (struct rtio_executor *)&simple_exec, SQ_SZ, CQ_SZ, N, SAMPLE_SIZE,
 			 4);
 
-void main(void)
+int main(void)
 {
 	const struct device *const vnd_sensor = DEVICE_DT_GET(NODE_ID);
 	struct rtio_iodev *iodev = vnd_sensor->data;
@@ -95,4 +95,5 @@ void main(void)
 			rtio_spsc_produce(ez_io.sq);
 		}
 	}
+	return 0;
 }

--- a/samples/subsys/settings/src/main.c
+++ b/samples/subsys/settings/src/main.c
@@ -534,7 +534,7 @@ void example_runtime_usage(void)
 	       source_name_val);
 }
 
-void main(void)
+int main(void)
 {
 
 	int i;
@@ -576,4 +576,5 @@ void main(void)
 	example_runtime_usage();
 
 	printk("\n*** THE END  ***\n");
+	return 0;
 }

--- a/samples/subsys/shell/devmem_load/src/main.c
+++ b/samples/subsys/shell/devmem_load/src/main.c
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
 
+	return 0;
 };

--- a/samples/subsys/shell/fs/src/main.c
+++ b/samples/subsys/shell/fs/src/main.c
@@ -9,6 +9,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(app);
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -427,7 +427,7 @@ SHELL_SUBCMD_ADD((section_cmd), cmd1, &sub_section_cmd1, "help for cmd1", cmd1_h
 SHELL_CMD_REGISTER(section_cmd, &sub_section_cmd,
 		   "Demo command using section for subcommand registration", NULL);
 
-void main(void)
+int main(void)
 {
 	if (IS_ENABLED(CONFIG_SHELL_START_OBSCURED)) {
 		login_init();
@@ -439,7 +439,7 @@ void main(void)
 
 	dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
 	if (!device_is_ready(dev) || usb_enable(NULL)) {
-		return;
+		return 0;
 	}
 
 	while (!dtr) {
@@ -447,4 +447,5 @@ void main(void)
 		k_sleep(K_MSEC(100));
 	}
 #endif
+	return 0;
 }

--- a/samples/subsys/task_wdt/src/main.c
+++ b/samples/subsys/task_wdt/src/main.c
@@ -58,7 +58,7 @@ static void task_wdt_callback(int channel_id, void *user_data)
 	sys_reboot(SYS_REBOOT_COLD);
 }
 
-void main(void)
+int main(void)
 {
 	int ret;
 	const struct device *const hw_wdt_dev = DEVICE_DT_GET_OR_NULL(WDT_NODE);
@@ -72,7 +72,7 @@ void main(void)
 	ret = task_wdt_init(hw_wdt_dev);
 	if (ret != 0) {
 		printk("task wdt init failure: %d\n", ret);
-		return;
+		return 0;
 	}
 
 
@@ -84,6 +84,7 @@ void main(void)
 		task_wdt_feed(task_wdt_id);
 		k_sleep(K_MSEC(1000));
 	}
+	return 0;
 }
 
 /*

--- a/samples/subsys/usb/audio/headphones_microphone/src/main.c
+++ b/samples/subsys/usb/audio/headphones_microphone/src/main.c
@@ -63,7 +63,7 @@ static const struct usb_audio_ops mic_ops = {
 	.feature_update_cb = feature_update,
 };
 
-void main(void)
+int main(void)
 {
 	const struct device *const hp_dev = DEVICE_DT_GET_ONE(usb_audio_hp);
 	int ret;
@@ -72,14 +72,14 @@ void main(void)
 
 	if (!device_is_ready(hp_dev)) {
 		LOG_ERR("Device USB Headphones is not ready");
-		return;
+		return 0;
 	}
 
 	LOG_INF("Found USB Headphones Device");
 
 	if (!device_is_ready(mic_dev)) {
 		LOG_ERR("Device USB Microphone is not ready");
-		return;
+		return 0;
 	}
 
 	LOG_INF("Found USB Microphone Device");
@@ -91,8 +91,9 @@ void main(void)
 	ret = usb_enable(NULL);
 	if (ret != 0) {
 		LOG_ERR("Failed to enable USB");
-		return;
+		return 0;
 	}
 
 	LOG_INF("USB enabled");
+	return 0;
 }

--- a/samples/subsys/usb/audio/headset/src/main.c
+++ b/samples/subsys/usb/audio/headset/src/main.c
@@ -57,7 +57,7 @@ static const struct usb_audio_ops ops = {
 	.feature_update_cb = feature_update,
 };
 
-void main(void)
+int main(void)
 {
 	const struct device *hs_dev;
 	int ret;
@@ -67,7 +67,7 @@ void main(void)
 
 	if (!device_is_ready(hs_dev)) {
 		LOG_ERR("Device USB Headset is not ready");
-		return;
+		return 0;
 	}
 
 	LOG_INF("Found USB Headset Device");
@@ -77,8 +77,9 @@ void main(void)
 	ret = usb_enable(NULL);
 	if (ret != 0) {
 		LOG_ERR("Failed to enable USB");
-		return;
+		return 0;
 	}
 
 	LOG_INF("USB enabled");
+	return 0;
 }

--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -150,7 +150,7 @@ static void interrupt_handler(const struct device *dev, void *user_data)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *dev;
 	uint32_t baudrate, dtr = 0U;
@@ -159,7 +159,7 @@ void main(void)
 	dev = DEVICE_DT_GET_ONE(zephyr_cdc_acm_uart);
 	if (!device_is_ready(dev)) {
 		LOG_ERR("CDC ACM device not ready");
-		return;
+		return 0;
 	}
 
 #if defined(CONFIG_USB_DEVICE_STACK_NEXT)
@@ -170,7 +170,7 @@ void main(void)
 
 	if (ret != 0) {
 		LOG_ERR("Failed to enable USB");
-		return;
+		return 0;
 	}
 
 	ring_buf_init(&ringbuf, sizeof(ring_buffer), ring_buffer);
@@ -214,4 +214,5 @@ void main(void)
 
 	/* Enable rx interrupts */
 	uart_irq_rx_enable(dev);
+	return 0;
 }

--- a/samples/subsys/usb/cdc_acm_composite/src/main.c
+++ b/samples/subsys/usb/cdc_acm_composite/src/main.c
@@ -115,7 +115,7 @@ static void uart_line_set(const struct device *dev)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	uint32_t dtr = 0U;
 	int ret;
@@ -124,14 +124,14 @@ void main(void)
 		if (!device_is_ready(peers[idx].dev)) {
 			LOG_ERR("CDC ACM device %s is not ready",
 				peers[idx].dev->name);
-			return;
+			return 0;
 		}
 	}
 
 	ret = usb_enable(NULL);
 	if (ret != 0) {
 		LOG_ERR("Failed to enable USB");
-		return;
+		return 0;
 	}
 
 	LOG_INF("Wait for DTR");
@@ -171,4 +171,5 @@ void main(void)
 	/* Enable rx interrupts */
 	uart_irq_rx_enable(peers[0].dev);
 	uart_irq_rx_enable(peers[1].dev);
+	return 0;
 }

--- a/samples/subsys/usb/console/src/main.c
+++ b/samples/subsys/usb/console/src/main.c
@@ -75,18 +75,18 @@ static int enable_usb_device_next(void)
 }
 #endif /* IS_ENABLED(CONFIG_USB_DEVICE_STACK_NEXT) */
 
-void main(void)
+int main(void)
 {
 	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 	uint32_t dtr = 0;
 
 #if defined(CONFIG_USB_DEVICE_STACK_NEXT)
 	if (enable_usb_device_next()) {
-		return;
+		return 0;
 	}
 #else
 	if (usb_enable(NULL)) {
-		return;
+		return 0;
 	}
 #endif
 

--- a/samples/subsys/usb/dfu/src/main.c
+++ b/samples/subsys/usb/dfu/src/main.c
@@ -12,15 +12,16 @@
 #include <zephyr/usb/usb_device.h>
 LOG_MODULE_REGISTER(main);
 
-void main(void)
+int main(void)
 {
 	int ret;
 
 	ret = usb_enable(NULL);
 	if (ret != 0) {
 		LOG_ERR("Failed to enable USB");
-		return;
+		return 0;
 	}
 
 	LOG_INF("This device supports USB DFU class.\n");
+	return 0;
 }

--- a/samples/subsys/usb/hid-cdc/src/main.c
+++ b/samples/subsys/usb/hid-cdc/src/main.c
@@ -534,7 +534,7 @@ static void status_cb(enum usb_dc_status_code status, const uint8_t *param)
 
 #define DEVICE_AND_COMMA(node_id) DEVICE_DT_GET(node_id),
 
-void main(void)
+int main(void)
 {
 	const struct device *cdc_dev[] = {
 		DT_FOREACH_STATUS_OKAY(zephyr_cdc_acm_uart, DEVICE_AND_COMMA)
@@ -550,46 +550,46 @@ void main(void)
 	hid0_dev = device_get_binding("HID_0");
 	if (hid0_dev == NULL) {
 		LOG_ERR("Cannot get USB HID 0 Device");
-		return;
+		return 0;
 	}
 
 	hid1_dev = device_get_binding("HID_1");
 	if (hid1_dev == NULL) {
 		LOG_ERR("Cannot get USB HID 1 Device");
-		return;
+		return 0;
 	}
 
 	for (int idx = 0; idx < ARRAY_SIZE(cdc_dev); idx++) {
 		if (!device_is_ready(cdc_dev[idx])) {
 			LOG_ERR("CDC ACM device %s is not ready",
 				cdc_dev[idx]->name);
-			return;
+			return 0;
 		}
 	}
 
 	if (callbacks_configure(&sw0_gpio, &btn0, &callback[0])) {
 		LOG_ERR("Failed configuring button 0 callback.");
-		return;
+		return 0;
 	}
 
 #if DT_NODE_HAS_STATUS(SW1_NODE, okay)
 	if (callbacks_configure(&sw1_gpio, &btn1, &callback[1])) {
 		LOG_ERR("Failed configuring button 1 callback.");
-		return;
+		return 0;
 	}
 #endif
 
 #if DT_NODE_HAS_STATUS(SW2_NODE, okay)
 	if (callbacks_configure(&sw2_gpio, &btn2, &callback[2])) {
 		LOG_ERR("Failed configuring button 2 callback.");
-		return;
+		return 0;
 	}
 #endif
 
 #if DT_NODE_HAS_STATUS(SW3_NODE, okay)
 	if (callbacks_configure(&sw3_gpio, &btn3, &callback[3])) {
 		LOG_ERR("Failed configuring button 3 callback.");
-		return;
+		return 0;
 	}
 #endif
 
@@ -607,7 +607,7 @@ void main(void)
 	ret = usb_enable(status_cb);
 	if (ret != 0) {
 		LOG_ERR("Failed to enable USB");
-		return;
+		return 0;
 	}
 
 	/* Initialize CDC ACM */

--- a/samples/subsys/usb/hid-mouse/src/main.c
+++ b/samples/subsys/usb/hid-mouse/src/main.c
@@ -235,7 +235,7 @@ int callbacks_configure(const struct gpio_dt_spec *spec,
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	int ret;
 	uint8_t report[4] = { 0x00 };
@@ -243,41 +243,41 @@ void main(void)
 
 	if (!device_is_ready(led0.port)) {
 		LOG_ERR("LED device %s is not ready", led0.port->name);
-		return;
+		return 0;
 	}
 
 	hid_dev = device_get_binding("HID_0");
 	if (hid_dev == NULL) {
 		LOG_ERR("Cannot get USB HID Device");
-		return;
+		return 0;
 	}
 
 	ret = gpio_pin_configure_dt(&led0, GPIO_OUTPUT);
 	if (ret < 0) {
 		LOG_ERR("Failed to configure the LED pin, error: %d", ret);
-		return;
+		return 0;
 	}
 
 	if (callbacks_configure(&sw0, &left_button, &callback[0],
 				&def_val[0])) {
 		LOG_ERR("Failed configuring left button callback.");
-		return;
+		return 0;
 	}
 
 	if (callbacks_configure(&sw1, &right_button, &callback[1],
 				&def_val[1])) {
 		LOG_ERR("Failed configuring right button callback.");
-		return;
+		return 0;
 	}
 
 	if (callbacks_configure(&sw2, &x_move, &callback[2], &def_val[2])) {
 		LOG_ERR("Failed configuring X axis movement callback.");
-		return;
+		return 0;
 	}
 
 	if (callbacks_configure(&sw3, &y_move, &callback[3], &def_val[3])) {
 		LOG_ERR("Failed configuring Y axis movement callback.");
-		return;
+		return 0;
 	}
 
 	usb_hid_register_device(hid_dev,
@@ -289,7 +289,7 @@ void main(void)
 	ret = usb_enable(status_cb);
 	if (ret != 0) {
 		LOG_ERR("Failed to enable USB");
-		return;
+		return 0;
 	}
 
 	while (true) {
@@ -311,4 +311,5 @@ void main(void)
 			LOG_ERR("Failed to toggle the LED pin, error: %d", ret);
 		}
 	}
+	return 0;
 }

--- a/samples/subsys/usb/hid/src/main.c
+++ b/samples/subsys/usb/hid/src/main.c
@@ -134,7 +134,7 @@ static void status_cb(enum usb_dc_status_code status, const uint8_t *param)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	int ret;
 
@@ -143,10 +143,11 @@ void main(void)
 	ret = usb_enable(status_cb);
 	if (ret != 0) {
 		LOG_ERR("Failed to enable USB");
-		return;
+		return 0;
 	}
 
 	k_work_init(&report_send, send_report);
+	return 0;
 }
 
 static int composite_pre_init(void)

--- a/samples/subsys/usb/mass/src/main.c
+++ b/samples/subsys/usb/mass/src/main.c
@@ -248,7 +248,7 @@ static void setup_disk(void)
 	return;
 }
 
-void main(void)
+int main(void)
 {
 	int ret;
 
@@ -261,8 +261,9 @@ void main(void)
 #endif
 	if (ret != 0) {
 		LOG_ERR("Failed to enable USB");
-		return;
+		return 0;
 	}
 
 	LOG_INF("The device is put in USB mass storage mode.\n");
+	return 0;
 }

--- a/samples/subsys/usb/shell/src/main.c
+++ b/samples/subsys/usb/shell/src/main.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/samples/subsys/usb/testusb/src/main.c
+++ b/samples/subsys/usb/testusb/src/main.c
@@ -9,15 +9,16 @@
 #include <zephyr/usb/usb_device.h>
 LOG_MODULE_REGISTER(main);
 
-void main(void)
+int main(void)
 {
 	int ret;
 
 	ret = usb_enable(NULL);
 	if (ret != 0) {
 		LOG_ERR("Failed to enable USB");
-		return;
+		return 0;
 	}
 
 	LOG_INF("entered main.");
+	return 0;
 }

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -299,7 +299,7 @@ static struct webusb_req_handlers req_handlers = {
 	.vendor_handler = vendor_handle_req,
 };
 
-void main(void)
+int main(void)
 {
 	int ret;
 
@@ -315,6 +315,7 @@ void main(void)
 	ret = usb_enable(NULL);
 	if (ret != 0) {
 		LOG_ERR("Failed to enable USB");
-		return;
+		return 0;
 	}
+	return 0;
 }

--- a/samples/subsys/usb_c/sink/src/main.c
+++ b/samples/subsys/usb_c/sink/src/main.c
@@ -293,7 +293,7 @@ bool port1_policy_check(const struct device *dev,
 }
 /* usbc.rst check end */
 
-void main(void)
+int main(void)
 {
 	const struct device *usbc_port1;
 
@@ -301,7 +301,7 @@ void main(void)
 	usbc_port1 = DEVICE_DT_GET(PORT1_NODE);
 	if (!device_is_ready(usbc_port1)) {
 		LOG_ERR("PORT1 device not ready");
-		return;
+		return 0;
 	}
 
 	/* usbc.rst register start */
@@ -340,4 +340,5 @@ void main(void)
 		/* Arbitrary delay */
 		k_msleep(1000);
 	}
+	return 0;
 }

--- a/samples/subsys/video/capture/src/main.c
+++ b/samples/subsys/video/capture/src/main.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(main);
 
 #define VIDEO_DEV_SW "VIDEO_SW_GENERATOR"
 
-void main(void)
+int main(void)
 {
 	struct video_buffer *buffers[2], *vbuf;
 	struct video_format fmt;
@@ -29,7 +29,7 @@ void main(void)
 	video = device_get_binding(VIDEO_DEV_SW);
 	if (video == NULL) {
 		LOG_ERR("Video device %s not found", VIDEO_DEV_SW);
-		return;
+		return 0;
 	}
 
 	/* But would be better to use a real video device if any */
@@ -38,7 +38,7 @@ void main(void)
 
 	if (!device_is_ready(dev)) {
 		LOG_ERR("%s: device not ready.\n", dev->name);
-		return;
+		return 0;
 	}
 
 	video = dev;
@@ -49,7 +49,7 @@ void main(void)
 	/* Get capabilities */
 	if (video_get_caps(video, VIDEO_EP_OUT, &caps)) {
 		LOG_ERR("Unable to retrieve video capabilities");
-		return;
+		return 0;
 	}
 
 	printk("- Capabilities:\n");
@@ -69,7 +69,7 @@ void main(void)
 	/* Get default/native format */
 	if (video_get_format(video, VIDEO_EP_OUT, &fmt)) {
 		LOG_ERR("Unable to retrieve video format");
-		return;
+		return 0;
 	}
 
 	printk("- Default format: %c%c%c%c %ux%u\n", (char)fmt.pixelformat,
@@ -86,7 +86,7 @@ void main(void)
 		buffers[i] = video_buffer_alloc(bsize);
 		if (buffers[i] == NULL) {
 			LOG_ERR("Unable to alloc video buffer");
-			return;
+			return 0;
 		}
 
 		video_enqueue(video, VIDEO_EP_OUT, buffers[i]);
@@ -95,7 +95,7 @@ void main(void)
 	/* Start video capture */
 	if (video_stream_start(video)) {
 		LOG_ERR("Unable to start capture (interface)");
-		return;
+		return 0;
 	}
 
 	printk("Capture started\n");
@@ -107,7 +107,7 @@ void main(void)
 		err = video_dequeue(video, VIDEO_EP_OUT, &vbuf, K_FOREVER);
 		if (err) {
 			LOG_ERR("Unable to dequeue video buf");
-			return;
+			return 0;
 		}
 
 		printk("\rGot frame %u! size: %u; timestamp %u ms",
@@ -116,7 +116,7 @@ void main(void)
 		err = video_enqueue(video, VIDEO_EP_OUT, vbuf);
 		if (err) {
 			LOG_ERR("Unable to requeue video buf");
-			return;
+			return 0;
 		}
 	}
 }

--- a/samples/subsys/video/tcpserversink/src/main.c
+++ b/samples/subsys/video/tcpserversink/src/main.c
@@ -33,7 +33,7 @@ static ssize_t sendall(int sock, const void *buf, size_t len)
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	struct sockaddr_in addr, client_addr;
 	socklen_t client_addr_len = sizeof(client_addr);
@@ -50,32 +50,32 @@ void main(void)
 	sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 	if (sock < 0) {
 		LOG_ERR("Failed to create TCP socket: %d", errno);
-		return;
+		return 0;
 	}
 
 	ret = bind(sock, (struct sockaddr *)&addr, sizeof(addr));
 	if (ret < 0) {
 		LOG_ERR("Failed to bind TCP socket: %d", errno);
 		close(sock);
-		return;
+		return 0;
 	}
 
 	ret = listen(sock, MAX_CLIENT_QUEUE);
 	if (ret < 0) {
 		LOG_ERR("Failed to listen on TCP socket: %d", errno);
 		close(sock);
-		return;
+		return 0;
 	}
 
 	if (!device_is_ready(video)) {
 		LOG_ERR("%s: device not ready.\n", video->name);
-		return;
+		return 0;
 	}
 
 	/* Get default/native format */
 	if (video_get_format(video, VIDEO_EP_OUT, &fmt)) {
 		LOG_ERR("Unable to retrieve video format");
-		return;
+		return 0;
 	}
 
 	printk("Video device detected, format: %c%c%c%c %ux%u\n",
@@ -88,7 +88,7 @@ void main(void)
 		buffers[i] = video_buffer_alloc(fmt.pitch * fmt.height);
 		if (buffers[i] == NULL) {
 			LOG_ERR("Unable to alloc video buffer");
-			return;
+			return 0;
 		}
 	}
 
@@ -100,7 +100,7 @@ void main(void)
 				&client_addr_len);
 		if (client < 0) {
 			printk("Failed to accept: %d\n", errno);
-			return;
+			return 0;
 		}
 
 		printk("TCP: Accepted connection\n");
@@ -113,7 +113,7 @@ void main(void)
 		/* Start video capture */
 		if (video_stream_start(video)) {
 			LOG_ERR("Unable to start video");
-			return;
+			return 0;
 		}
 
 		printk("Stream started\n");
@@ -125,7 +125,7 @@ void main(void)
 					    K_FOREVER);
 			if (ret) {
 				LOG_ERR("Unable to dequeue video buf");
-				return;
+				return 0;
 			}
 
 			printk("\rSending frame %d", i++);
@@ -144,7 +144,7 @@ void main(void)
 		/* stop capture */
 		if (video_stream_stop(video)) {
 			LOG_ERR("Unable to stop video");
-			return;
+			return 0;
 		}
 
 		/* Flush remaining buffers */

--- a/samples/subsys/zbus/dyn_channel/src/main.c
+++ b/samples/subsys/zbus/dyn_channel/src/main.c
@@ -72,9 +72,10 @@ static void filter_cb(const struct zbus_channel *chan)
 
 ZBUS_LISTENER_DEFINE(filter_lis, filter_cb);
 
-void main(void)
+int main(void)
 {
 	const struct version_msg *v = zbus_chan_const_msg(&version_chan);
 
 	LOG_DBG(" -> Dynamic channel sample version %u.%u-%u\n\n", v->major, v->minor, v->build);
+	return 0;
 }

--- a/samples/subsys/zbus/hello_world/src/main.c
+++ b/samples/subsys/zbus/hello_world/src/main.c
@@ -118,7 +118,7 @@ static bool print_observer_data_iterator(const struct zbus_observer *obs)
 }
 #endif /* CONFIG_ZBUS_STRUCTS_ITERABLE_ACCESS */
 
-void main(void)
+int main(void)
 {
 	int err, value;
 	struct acc_msg acc1 = {.x = 1, .y = 1, .z = 1};
@@ -160,4 +160,5 @@ void main(void)
 	if (err == -ENOMSG) {
 		LOG_INF("Pub an invalid value to a channel with validator successfully.");
 	}
+	return 0;
 }

--- a/samples/subsys/zbus/remote_mock/src/mock_proxy.c
+++ b/samples/subsys/zbus/remote_mock/src/mock_proxy.c
@@ -83,9 +83,10 @@ static void proxy_callback(const struct zbus_channel *chan)
 
 ZBUS_LISTENER_DEFINE(proxy_lis, proxy_callback);
 
-void main(void)
+int main(void)
 {
 	LOG_DBG("[Mock Proxy] Started.");
+	return 0;
 }
 
 static void decode_sentence(struct net_buf_simple *rx_buf)

--- a/samples/subsys/zbus/runtime_obs_registration/src/main.c
+++ b/samples/subsys/zbus/runtime_obs_registration/src/main.c
@@ -39,7 +39,7 @@ ZBUS_LISTENER_DEFINE(filter_lis, filter_callback);
 
 ZBUS_SUBSCRIBER_DEFINE(state_change_sub, 5);
 
-void main(void)
+int main(void)
 {
 	LOG_INF("System started");
 
@@ -64,4 +64,5 @@ void main(void)
 
 		zbus_sub_wait(&state_change_sub, &chan, K_FOREVER);
 	}
+	return 0;
 }

--- a/samples/subsys/zbus/work_queue/src/main.c
+++ b/samples/subsys/zbus/work_queue/src/main.c
@@ -114,7 +114,7 @@ static void dh3_cb(const struct zbus_channel *chan)
 
 ZBUS_LISTENER_DEFINE(delay_handler3_lis, dh3_cb);
 
-void main(void)
+int main(void)
 {
 	k_work_init(&wq_handler1.work, wq_dh_cb);
 	k_work_init(&wq_handler2.work, wq_dh_cb);
@@ -123,6 +123,7 @@ void main(void)
 	struct version_msg *v = zbus_chan_msg(&version_chan);
 
 	LOG_DBG("Sensor sample started, version %u.%u-%u!", v->major, v->minor, v->build);
+	return 0;
 }
 
 ZBUS_SUBSCRIBER_DEFINE(thread_handler1_sub, 4);

--- a/samples/synchronization/src/main.c
+++ b/samples/synchronization/src/main.c
@@ -103,7 +103,7 @@ void threadA(void *dummy1, void *dummy2, void *dummy3)
 	helloLoop(__func__, &threadA_sem, &threadB_sem);
 }
 
-void main(void)
+int main(void)
 {
 	k_thread_create(&threadA_data, threadA_stack_area,
 			K_THREAD_STACK_SIZEOF(threadA_stack_area),
@@ -129,4 +129,5 @@ void main(void)
 
 	k_thread_start(&threadA_data);
 	k_thread_start(&threadB_data);
+	return 0;
 }

--- a/samples/tfm_integration/psa_protected_storage/src/main.c
+++ b/samples/tfm_integration/psa_protected_storage/src/main.c
@@ -13,7 +13,7 @@
 #define TEST_STRING_1 "The quick brown fox jumps over the lazy dog"
 #define TEST_STRING_2 "Lorem ipsum dolor sit amet"
 
-void main(void)
+int main(void)
 {
 	psa_status_t status = 0;
 
@@ -28,7 +28,7 @@ void main(void)
 	status = psa_ps_set(uid1, sizeof(TEST_STRING_1), TEST_STRING_1, uid1_flag);
 	if (status != PSA_SUCCESS) {
 		printk("Failed to store data! (%d)\n", status);
-		return;
+		return 0;
 	}
 
 	/* Get info on UID1 */
@@ -37,7 +37,7 @@ void main(void)
 	status = psa_ps_get_info(uid1, &uid1_info);
 	if (status != PSA_SUCCESS) {
 		printk("Failed to get info! (%d)\n", status);
-		return;
+		return 0;
 	}
 	printk("Info on data stored in UID1:\n");
 	printk("- Size: %d\n", uid1_info.size);
@@ -51,7 +51,7 @@ void main(void)
 	status = psa_ps_get(uid1, 0, sizeof(TEST_STRING_1), &stored_data, &bytes_read);
 	if (status != PSA_SUCCESS) {
 		printk("Failed to get data stored in UID1! (%d)\n", status);
-		return;
+		return 0;
 	}
 	printk("Data stored in UID1: %s\n", stored_data);
 
@@ -59,7 +59,7 @@ void main(void)
 	status = psa_ps_set(uid1, sizeof(TEST_STRING_2), TEST_STRING_2, uid1_flag);
 	if (status != PSA_SUCCESS) {
 		printk("Failed to overwrite UID1! (%d)\n", status);
-		return;
+		return 0;
 	}
 
 	printk("Writing data to UID2 with overwrite protection: %s\n", TEST_STRING_1);
@@ -69,14 +69,14 @@ void main(void)
 	status = psa_ps_set(uid2, sizeof(TEST_STRING_1), TEST_STRING_1, uid2_flag);
 	if (status != PSA_SUCCESS) {
 		printk("Failed to set write once flag! (%d)\n", status);
-		return;
+		return 0;
 	}
 
 	printk("Attempting to write '%s' to UID2\n", TEST_STRING_2);
 	status = psa_ps_set(uid2, sizeof(TEST_STRING_2), TEST_STRING_2, uid2_flag);
 	if (status != PSA_ERROR_NOT_PERMITTED) {
 		printk("Got unexpected status when overwriting! (%d)\n", status);
-		return;
+		return 0;
 	}
 	printk("Got expected error (PSA_ERROR_NOT_PERMITTED) when writing to protected UID\n");
 
@@ -84,6 +84,7 @@ void main(void)
 	status = psa_ps_remove(uid1);
 	if (status != PSA_SUCCESS) {
 		printk("Failed to remove UID1! (%d)\n", status);
-		return;
+		return 0;
 	}
+	return 0;
 }

--- a/samples/tfm_integration/tfm_ipc/src/main.c
+++ b/samples/tfm_integration/tfm_ipc/src/main.c
@@ -74,7 +74,7 @@ void tfm_psa_crypto_rng(void)
 }
 #endif
 
-void main(void)
+int main(void)
 {
 	printk("TF-M IPC on %s\n", CONFIG_BOARD);
 
@@ -83,4 +83,5 @@ void main(void)
 	tfm_get_sid();
 	tfm_psa_crypto_rng();
 #endif
+	return 0;
 }

--- a/samples/tfm_integration/tfm_psa_test/src/main.c
+++ b/samples/tfm_integration/tfm_psa_test/src/main.c
@@ -10,7 +10,7 @@
 void psa_test(void);
 
 __attribute__((noreturn))
-void main(void)
+int main(void)
 {
 #ifdef CONFIG_TFM_PSA_TEST_NONE
 	#error "No PSA test suite set. Use Kconfig to enable a test suite.\n"

--- a/samples/tfm_integration/tfm_regression_test/src/main.c
+++ b/samples/tfm_integration/tfm_regression_test/src/main.c
@@ -6,8 +6,7 @@
 
 #include <zephyr/kernel.h>
 
-__attribute__((noreturn))
-void main(void)
+int main(void)
 {
 	printk("Should not be printed, expected TF-M's NS application to be run instead.\n");
 	k_panic();

--- a/samples/tfm_integration/tfm_secure_partition/src/main.c
+++ b/samples/tfm_integration/tfm_secure_partition/src/main.c
@@ -9,7 +9,7 @@
 
 #include "dummy_partition.h"
 
-void main(void)
+int main(void)
 {
 	uint8_t digest[32];
 
@@ -28,4 +28,5 @@ void main(void)
 			printk("\n");
 		}
 	}
+	return 0;
 }

--- a/samples/userspace/hello_world_user/src/main.c
+++ b/samples/userspace/hello_world_user/src/main.c
@@ -20,9 +20,10 @@ static void user_function(void *p1, void *p2, void *p3)
 }
 
 
-void main(void)
+int main(void)
 {
 	k_thread_create(&user_thread, user_stack, USER_STACKSIZE,
 			user_function, NULL, NULL, NULL,
 			-1, K_USER, K_MSEC(0));
+	return 0;
 }

--- a/samples/userspace/prod_consumer/src/main.c
+++ b/samples/userspace/prod_consumer/src/main.c
@@ -28,7 +28,7 @@ K_THREAD_STACK_DEFINE(app_a_stack, APP_A_STACKSIZE);
 struct k_thread app_b_thread;
 K_THREAD_STACK_DEFINE(app_b_stack, APP_B_STACKSIZE);
 
-void main(void)
+int main(void)
 {
 	k_tid_t thread_a, thread_b;
 
@@ -56,4 +56,5 @@ void main(void)
 
 	k_thread_join(thread_a, K_FOREVER);
 	k_thread_join(thread_b, K_FOREVER);
+	return 0;
 }

--- a/samples/userspace/shared_mem/src/main.c
+++ b/samples/userspace/shared_mem/src/main.c
@@ -100,7 +100,7 @@ _app_ct_d char ctMSG[] = "CT!\n";
 
 
 
-void main(void)
+int main(void)
 {
 	struct k_mem_partition *enc_parts[] = {
 #if Z_LIBC_PARTITION_EXISTS
@@ -193,6 +193,7 @@ void main(void)
 	k_thread_start(&ct_thread);
 	k_sem_give(&allforone);
 	printk("CT thread started\n");
+	return 0;
 }
 
 

--- a/samples/userspace/syscall_perf/src/main.c
+++ b/samples/userspace/syscall_perf/src/main.c
@@ -9,7 +9,7 @@
 
 #include "thread_def.h"
 
-void main(void)
+int main(void)
 {
 	printf("Main Thread started; %s\n", CONFIG_BOARD);
 
@@ -22,4 +22,5 @@ void main(void)
 	k_thread_create(&user_thread, user_stack, THREAD_STACKSIZE,
 			user_thread_function, NULL, NULL, NULL,
 			-1, K_USER | K_INHERIT_PERMS, K_NO_WAIT);
+	return 0;
 }

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -523,7 +523,7 @@ int main(void)
 	return test_status;
 }
 #else
-void main(void)
+int main(void)
 {
 #ifdef CONFIG_USERSPACE
 	int ret;
@@ -592,5 +592,6 @@ void main(void)
 	}
 	irq_unlock(key);
 #endif
+	return 0;
 }
 #endif

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -1060,7 +1060,7 @@ int main(void)
 	return test_status;
 }
 #else
-void main(void)
+int main(void)
 {
 #ifdef CONFIG_USERSPACE
 	/* Partition containing globals tagged with ZTEST_DMEM and ZTEST_BMEM
@@ -1101,5 +1101,6 @@ void main(void)
 			state.boots = 0;
 		}
 	}
+	return 0;
 }
 #endif

--- a/tests/arch/x86/info/src/main.c
+++ b/tests/arch/x86/info/src/main.c
@@ -21,7 +21,7 @@ __weak void acpi(void)
 	printk("ACPI: Not supported in this build.\n\n");
 }
 
-void main(void)
+int main(void)
 {
 	printk("\n\ninfo: the Zephyr x86 platform information tool\n\n");
 
@@ -31,4 +31,5 @@ void main(void)
 	timer();
 
 	printk("info: complete\n");
+	return 0;
 }

--- a/tests/benchmarks/app_kernel/src/master.c
+++ b/tests/benchmarks/app_kernel/src/master.c
@@ -111,7 +111,7 @@ void output_close(void)
  * see config.h to select or to unselect
  *
  */
-void main(void)
+int main(void)
 {
 	int autorun = 0, continuously = 0;
 
@@ -144,6 +144,7 @@ void main(void)
 	k_thread_abort(RECVTASK);
 
 	output_close();
+	return 0;
 }
 
 

--- a/tests/benchmarks/footprints/src/main.c
+++ b/tests/benchmarks/footprints/src/main.c
@@ -36,7 +36,7 @@ extern void run_timer(void);
 extern void run_userspace(void);
 extern void run_workq(void);
 
-void main(void)
+int main(void)
 {
 	printk("Hello from %s!\n", CONFIG_BOARD);
 
@@ -78,4 +78,5 @@ void main(void)
 #endif
 
 	printk("PROJECT EXECUTION SUCCESSFUL\n");
+	return 0;
 }

--- a/tests/benchmarks/latency_measure/src/main.c
+++ b/tests/benchmarks/latency_measure/src/main.c
@@ -65,7 +65,8 @@ void test_thread(void *arg1, void *arg2, void *arg3)
 
 K_THREAD_DEFINE(test_thread_id, STACK_SIZE, test_thread, NULL, NULL, NULL, K_PRIO_PREEMPT(10), 0, 0);
 
-void main(void)
+int main(void)
 {
 	k_thread_join(test_thread_id, K_FOREVER);
+	return 0;
 }

--- a/tests/benchmarks/mbedtls/src/benchmark.c
+++ b/tests/benchmarks/mbedtls/src/benchmark.c
@@ -299,7 +299,7 @@ typedef struct {
 	     havege, ctr_drbg, hmac_drbg, rsa, dhm, ecdsa, ecdh;
 } todo_list;
 
-void main(void)
+int main(void)
 {
 	mbedtls_ssl_config conf;
 	unsigned char tmp[200];
@@ -1029,4 +1029,5 @@ void main(void)
 	}
 #endif
 	mbedtls_printf("\n       Done\n");
+	return 0;
 }

--- a/tests/benchmarks/sched/src/main.c
+++ b/tests/benchmarks/sched/src/main.c
@@ -86,7 +86,7 @@ static void partner_fn(void *arg1, void *arg2, void *arg3)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	z_waitq_init(&waitq);
 
@@ -149,4 +149,5 @@ void main(void)
 		       whole, avg);
 	}
 	printk("fin\n");
+	return 0;
 }

--- a/tests/benchmarks/sched_userspace/src/main.c
+++ b/tests/benchmarks/sched_userspace/src/main.c
@@ -115,7 +115,7 @@ static int exec_test(uint8_t nb_threads)
 }
 
 
-void main(void)
+int main(void)
 {
 	int ret;
 
@@ -130,9 +130,10 @@ void main(void)
 		ret = exec_test(nb_threads_list[i]);
 		if (ret != 0) {
 			printk("FAIL\n");
-			return;
+			return 0;
 		}
 	}
 
 	printk("SUCCESS\n");
+	return 0;
 }

--- a/tests/benchmarks/sys_kernel/src/syskernel.c
+++ b/tests/benchmarks/sys_kernel/src/syskernel.c
@@ -120,7 +120,7 @@ void output_close(void)
  * @brief Perform all selected benchmarks
  *
  */
-void main(void)
+int main(void)
 {
 	int	    continuously = 0;
 	int	    test_result;
@@ -180,4 +180,5 @@ void main(void)
 	} while (continuously);
 
 	output_close();
+	return 0;
 }

--- a/tests/bluetooth/mesh/basic/src/main.c
+++ b/tests/bluetooth/mesh/basic/src/main.c
@@ -184,7 +184,7 @@ static void bt_ready(int err)
 	printk("Mesh initialized\n");
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -195,4 +195,5 @@ void main(void)
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 	}
+	return 0;
 }

--- a/tests/bluetooth/mesh_shell/src/main.c
+++ b/tests/bluetooth/mesh_shell/src/main.c
@@ -142,7 +142,7 @@ static void bt_ready(int err)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 
@@ -156,4 +156,5 @@ void main(void)
 
 	printk("Press the <Tab> button for supported commands.\n");
 	printk("Before any Mesh commands you must run \"mesh init\"\n");
+	return 0;
 }

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -121,7 +121,7 @@ static void hrs_notify(void)
 }
 #endif /* CONFIG_BT_HRS */
 
-void main(void)
+int main(void)
 {
 #if DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_shell_uart), zephyr_cdc_acm_uart)
 	const struct device *dev;
@@ -129,7 +129,7 @@ void main(void)
 
 	dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
 	if (!device_is_ready(dev) || usb_enable(NULL)) {
-		return;
+		return 0;
 	}
 
 	while (!dtr) {

--- a/tests/bluetooth/tester/src/main.c
+++ b/tests/bluetooth/tester/src/main.c
@@ -16,7 +16,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
 
 #include "btp/btp.h"
 
-void main(void)
+int main(void)
 {
 	tester_init();
+	return 0;
 }

--- a/tests/boards/native_posix/native_tasks/src/main.c
+++ b/tests/boards/native_posix/native_tasks/src/main.c
@@ -62,8 +62,9 @@ NATIVE_TASK(test_hook5, ON_EXIT, 20);
 NATIVE_TASK(test_hook6, ON_EXIT, 1);
 NATIVE_TASK(test_hook7, ON_EXIT, 310);
 
-void main(void)
+int main(void)
 {
 	k_sleep(K_MSEC(100));
 	posix_exit(0);
+	return 0;
 }

--- a/tests/boot/test_mcuboot/src/main.c
+++ b/tests/boot/test_mcuboot/src/main.c
@@ -9,11 +9,12 @@
 #include <zephyr/dfu/mcuboot.h>
 
 /* Main entry point */
-void main(void)
+int main(void)
 {
 	printk("Launching primary slot application on %s\n", CONFIG_BOARD);
 	/* Perform a permanent swap of MCUBoot application */
 	boot_request_upgrade(1);
 	printk("Secondary application ready for swap, rebooting\n");
 	sys_reboot(SYS_REBOOT_COLD);
+	return 0;
 }

--- a/tests/boot/test_mcuboot/swapped_app/src/main.c
+++ b/tests/boot/test_mcuboot/swapped_app/src/main.c
@@ -7,7 +7,8 @@
 #include <zephyr/kernel.h>
 
 /* Main entry point */
-void main(void)
+int main(void)
 {
 	printk("Swapped application booted on %s\n", CONFIG_BOARD);
+	return 0;
 }

--- a/tests/boot/uefi/src/main.c
+++ b/tests/boot/uefi/src/main.c
@@ -7,7 +7,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 
-void main(void)
+int main(void)
 {
 	printk("Hello World! %s\n", CONFIG_BOARD);
+	return 0;
 }

--- a/tests/bsim/bluetooth/audio/src/main.c
+++ b/tests/bsim/bluetooth/audio/src/main.c
@@ -59,7 +59,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/adv/chain/src/main.c
+++ b/tests/bsim/bluetooth/host/adv/chain/src/main.c
@@ -202,7 +202,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/main.c
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/main.c
@@ -59,7 +59,8 @@ struct bst_test_list *test_encrypted_ad_data_install(struct bst_test_list *tests
 
 bst_test_install_t test_installers[] = {test_encrypted_ad_data_install, NULL};
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/adv/periodic/src/main.c
+++ b/tests/bsim/bluetooth/host/adv/periodic/src/main.c
@@ -15,7 +15,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/adv/resume/src/main.c
+++ b/tests/bsim/bluetooth/host/adv/resume/src/main.c
@@ -55,7 +55,8 @@ static struct bst_test_list *install(struct bst_test_list *tests)
 
 bst_test_install_t test_installers[] = { install, NULL };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/att/eatt/src/main.c
+++ b/tests/bsim/bluetooth/host/att/eatt/src/main.c
@@ -17,7 +17,8 @@ bst_test_install_t test_installers[] = {
 	NULL,
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/main.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/main.c
@@ -15,7 +15,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/att/mtu_update/src/main.c
+++ b/tests/bsim/bluetooth/host/att/mtu_update/src/main.c
@@ -135,7 +135,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/gatt/caching/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/caching/src/main.c
@@ -15,7 +15,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/gatt/general/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/main.c
@@ -15,7 +15,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/gatt/notify/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/notify/src/main.c
@@ -15,7 +15,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/src/main.c
@@ -15,7 +15,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/gatt/settings/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/main.c
@@ -89,9 +89,10 @@ static struct bst_test_list *install(struct bst_test_list *tests)
 
 bst_test_install_t test_installers[] = { install, NULL };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }
 
 

--- a/tests/bsim/bluetooth/host/gatt/write/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/write/src/main.c
@@ -125,7 +125,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/l2cap/general/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/general/src/main.c
@@ -13,7 +13,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/l2cap/stress/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/stress/src/main.c
@@ -463,7 +463,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/l2cap/userdata/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/src/main.c
@@ -13,7 +13,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/misc/disable/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/main.c
@@ -17,7 +17,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/privacy/central/src/main.c
+++ b/tests/bsim/bluetooth/host/privacy/central/src/main.c
@@ -33,7 +33,8 @@ static struct bst_test_list *install(struct bst_test_list *tests)
 
 bst_test_install_t test_installers[] = {install, NULL};
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_main.c
+++ b/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_main.c
@@ -71,7 +71,8 @@ struct bst_test_list *test_privacy_install(struct bst_test_list *tests)
 
 bst_test_install_t test_installers[] = {test_privacy_install, NULL};
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/privacy/peripheral/src/main.c
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/src/main.c
@@ -33,7 +33,8 @@ static struct bst_test_list *install(struct bst_test_list *tests)
 
 bst_test_install_t test_installers[] = {install, NULL};
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/main.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/main.c
@@ -33,7 +33,8 @@ static struct bst_test_list *install(struct bst_test_list *tests)
 
 bst_test_install_t test_installers[] = {install, NULL};
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/main.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/main.c
@@ -33,7 +33,8 @@ static struct bst_test_list *install(struct bst_test_list *tests)
 
 bst_test_install_t test_installers[] = {install, NULL};
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/ll/advx/src/main.c
+++ b/tests/bsim/bluetooth/ll/advx/src/main.c
@@ -1850,7 +1850,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/ll/conn/src/main.c
+++ b/tests/bsim/bluetooth/ll/conn/src/main.c
@@ -17,7 +17,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/main.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/main.c
@@ -323,7 +323,7 @@ static void handle_service_indicate(uint16_t size)
 	edtt_write((uint8_t *)&size, sizeof(size), EDTTT_BLOCK);
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 	uint16_t command;
@@ -332,7 +332,7 @@ void main(void)
 	err = bt_enable(bt_ready);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	bt_conn_auth_cb_register(&auth_cb_display);
@@ -374,4 +374,5 @@ void main(void)
 			break;
 		}
 	}
+	return 0;
 }

--- a/tests/bsim/bluetooth/ll/edtt/hci_test_app/src/main.c
+++ b/tests/bsim/bluetooth/ll/edtt/hci_test_app/src/main.c
@@ -755,7 +755,7 @@ static struct k_thread service_events_data;
 /**
  * @brief Zephyr application main entry...
  */
-void main(void)
+int main(void)
 {
 	int err;
 	uint16_t command;
@@ -773,7 +773,7 @@ void main(void)
 	err = bt_enable_raw(&rx_queue);
 	if (err) {
 		LOG_ERR("Bluetooth initialization failed (err %d)", err);
-		return;
+		return 0;
 	}
 	/**
 	 * Initialize and start EDTT system...
@@ -865,4 +865,5 @@ void main(void)
 			}
 		}
 	}
+	return 0;
 }

--- a/tests/bsim/bluetooth/ll/iso/src/main.c
+++ b/tests/bsim/bluetooth/ll/iso/src/main.c
@@ -1003,7 +1003,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/ll/multiple_id/src/main.c
+++ b/tests/bsim/bluetooth/ll/multiple_id/src/main.c
@@ -119,7 +119,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/mesh/src/main.c
+++ b/tests/bsim/bluetooth/mesh/src/main.c
@@ -70,7 +70,8 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/drivers/build_all/adc/src/main.c
+++ b/tests/drivers/build_all/adc/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/counter/src/main.c
+++ b/tests/drivers/build_all/counter/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/dac/src/main.c
+++ b/tests/drivers/build_all/dac/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/eeprom/src/main.c
+++ b/tests/drivers/build_all/eeprom/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/ethernet/src/main.c
+++ b/tests/drivers/build_all/ethernet/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/fpga/src/main.c
+++ b/tests/drivers/build_all/fpga/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/gpio/src/main.c
+++ b/tests/drivers/build_all/gpio/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/i3c/src/main.c
+++ b/tests/drivers/build_all/i3c/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/ieee802154/src/main.c
+++ b/tests/drivers/build_all/ieee802154/src/main.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/led/src/main.c
+++ b/tests/drivers/build_all/led/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/led_strip/src/main.c
+++ b/tests/drivers/build_all/led_strip/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/mfd/src/main.c
+++ b/tests/drivers/build_all/mfd/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/modem/src/main.c
+++ b/tests/drivers/build_all/modem/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/pwm/src/main.c
+++ b/tests/drivers/build_all/pwm/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/sensor/src/main.c
+++ b/tests/drivers/build_all/sensor/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/build_all/video/src/main.c
+++ b/tests/drivers/build_all/video/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-void main(void)
+int main(void)
 {
+	return 0;
 }

--- a/tests/drivers/console/src/main.c
+++ b/tests/drivers/console/src/main.c
@@ -7,7 +7,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 
-void main(void)
+int main(void)
 {
 	printk("Hello World from Console\n");
+	return 0;
 }

--- a/tests/drivers/ipm/src/main.c
+++ b/tests/drivers/ipm/src/main.c
@@ -74,7 +74,7 @@ DEVICE_DEFINE(ipm_console_recv0, "ipm_recv0", ipm_console_receiver_init,
 
 static const char thestr[] = "everything is awesome\n";
 
-void main(void)
+int main(void)
 {
 	int rv, i;
 	const struct device *ipm;
@@ -107,4 +107,5 @@ void main(void)
 	TC_END_RESULT(rv);
 	TC_SUITE_END("test_ipm", rv);
 	TC_END_REPORT(rv);
+	return 0;
 }

--- a/tests/kernel/fatal/message_capture/src/main.c
+++ b/tests/kernel/fatal/message_capture/src/main.c
@@ -75,7 +75,7 @@ void test_message_capture(void)
 	irq_unlock(key);
 }
 
-void main(void)
+int main(void)
 {
 	/* main() is an essential thread, and we try to OOPS it.  When
 	 * this test was written, that worked (even though it wasn't
@@ -86,4 +86,5 @@ void main(void)
 	z_thread_essential_clear();
 
 	test_message_capture();
+	return 0;
 }

--- a/tests/kernel/fpu_sharing/generic/testcase.yaml
+++ b/tests/kernel/fpu_sharing/generic/testcase.yaml
@@ -29,6 +29,8 @@ tests:
     min_ram: 16
   kernel.fpu_sharing.generic.riscv64:
     extra_args: PI_NUM_ITERATIONS=500
+    extra_configs:
+      - CONFIG_MAIN_STACK_SIZE=2048
     filter: CONFIG_CPU_HAS_FPU
     arch_allow: riscv64
     tags: fpu kernel

--- a/tests/lib/cbprintf_fp/src/main.c
+++ b/tests/lib/cbprintf_fp/src/main.c
@@ -36,7 +36,8 @@
 #error Unsupported configuration
 #endif
 
-void main(void)
+int main(void)
 {
 	PRINT("Hello with %s on %s\nComplete\n", PRINT_S, CONFIG_BOARD);
+	return 0;
 }

--- a/tests/misc/print_format/src/main.c
+++ b/tests/misc/print_format/src/main.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 
-void main(void)
+int main(void)
 {
 	printk("d%" PRId8 "\n", INT8_C(8));
 	printk("d%" PRId16 "\n", INT16_C(16));
@@ -37,4 +37,5 @@ void main(void)
 	printk("X%" PRIX16 "\n", UINT16_C(16));
 	printk("X%" PRIX32 "\n", UINT32_C(32));
 	printk("X%" PRIX64 "\n", UINT64_C(64));
+	return 0;
 }

--- a/tests/subsys/debug/coredump/src/main.c
+++ b/tests/subsys/debug/coredump/src/main.c
@@ -45,9 +45,10 @@ void func_1(uint32_t *addr)
 	func_2(addr);
 }
 
-void main(void)
+int main(void)
 {
 	printk("Coredump: %s\n", CONFIG_BOARD);
 
 	func_1(0);
+	return 0;
 }


### PR DESCRIPTION
As both C and C++ standards require applications running under an OS to
return 'int', adapt that for Zephyr to align with those standard. This also
eliminates errors when building with clang when not using -ffreestanding,
and reduces the need for compiler flags to silence warnings for both clang
and gcc.

---

Related discussion: https://github.com/zephyrproject-rtos/zephyr/issues/54336#issuecomment-1421528758