### PR TITLE
maintainers: make myself SDHC maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1155,6 +1155,19 @@ Release Notes:
   labels:
     - "area: PWM"
 
+"Drivers: SDHC":
+  status: maintained
+  maintainers:
+    - danieldegrasse
+  files:
+    - drivers/sdhc/
+    - tests/drivers/sdhc/
+    - include/zephyr/drivers/sdhc.h
+    - dts/bindings/sdhc/
+    - doc/hardware/peripherals/sdhc.rst
+  labels:
+    - "area: Disk Access"
+
 "Drivers: Serial/UART":
   status: maintained
   maintainers:


### PR DESCRIPTION
Since I contributed Zephyr's SD rework, and SDHC drivers are currently marked as orphaned, make myself the maintainer.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>