### PR TITLE
board: google_dragonclaw: update the schematics link

### DIFF
--- a/boards/arm/google_dragonclaw/doc/index.rst
+++ b/boards/arm/google_dragonclaw/doc/index.rst
@@ -44,7 +44,7 @@ References
 .. target-notes::
 
 .. _Dragonclaw Schematics:
-   https://chromium.googlesource.com/chromiumos/platform/ec/+/HEAD/docs/schematics/dragonclaw
+   https://www.chromium.org/chromium-os/dragonclaw/dragonclaw_v0.2.html
 
 .. _Chromium EC Flashing Documentation:
    https://chromium.googlesource.com/chromiumos/platform/ec#Flashing-via-the-servo-debug-board


### PR DESCRIPTION
Update the schematics link for the google_dragonclaw for one that loads directly, replacing the current one that requires the file to be downloaded and opened locally.