### PR TITLE
tests: kernel: print FAILED when wrong faults caught

### DIFF
--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -52,17 +52,20 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 
 	if (expected_reason == -1) {
 		printk("Was not expecting a crash\n");
+		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);
 	}
 
 	if (k_current_get() != &alt_thread) {
 		printk("Wrong thread crashed\n");
+		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);
 	}
 
 	if (reason != expected_reason) {
 		printk("Wrong crash type got %d expected %d\n", reason,
 		       expected_reason);
+		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);
 	}
 

--- a/tests/kernel/fatal/message_capture/src/main.c
+++ b/tests/kernel/fatal/message_capture/src/main.c
@@ -17,12 +17,14 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 
 	if (expected_reason == -1) {
 		printk("Was not expecting a crash\n");
+		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);
 	}
 
 	if (reason != expected_reason) {
 		printk("Wrong crash type got %d expected %d\n", reason,
 		       expected_reason);
+		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);
 	}
 

--- a/tests/kernel/mem_protect/demand_paging/src/main.c
+++ b/tests/kernel/mem_protect/demand_paging/src/main.c
@@ -72,6 +72,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		ztest_test_pass();
 	} else {
 		printk("Unexpected fault during test");
+		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);
 	}
 }

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -38,7 +38,8 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		expect_fault = false;
 		ztest_test_pass();
 	} else {
-		printk("Unexpected fault during test");
+		printk("Unexpected fault during test\n");
+		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);
 	}
 }

--- a/tests/kernel/mem_protect/mem_protect/src/common.c
+++ b/tests/kernel/mem_protect/mem_protect/src/common.c
@@ -20,6 +20,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		post_fatal_error_handler(reason, pEsf);
 	} else {
 		printk("fatal error was unexpected, aborting\n");
+		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);
 	}
 }

--- a/tests/kernel/mem_protect/mem_protect/src/inherit.c
+++ b/tests/kernel/mem_protect/mem_protect/src/inherit.c
@@ -150,6 +150,8 @@ void parent_handler(void *p1, void *p2, void *p3)
 			child_handler,
 			NULL, NULL, NULL,
 			PRIORITY, 0, K_NO_WAIT);
+
+	k_thread_join(&child_thr, K_FOREVER);
 }
 
 /**
@@ -183,6 +185,8 @@ ZTEST(mem_protect, test_inherit_resource_pool)
 	zassert_true(parent_heap_mem_ptr == child_heap_mem_ptr,
 		     "Resource pool of the parent thread not inherited,"
 		     " by child thread");
+
+	k_thread_join(&parent_thr, K_FOREVER);
 }
 
 void mem_protect_inhert_setup(void)

--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -19,6 +19,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
 {
 	if (reason != K_ERR_STACK_CHK_FAIL) {
 		printk("wrong error type\n");
+		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);
 	}
 }

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -76,10 +76,12 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		} else {
 			printk("Wrong fault reason, expecting %d\n",
 			       expected_reason);
+			printk("PROJECT EXECUTION FAILED\n");
 			k_fatal_halt(reason);
 		}
 	} else {
 		printk("Unexpected fault during test\n");
+		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);
 	}
 }

--- a/tests/kernel/pipe/pipe/src/test_pipe.c
+++ b/tests/kernel/pipe/pipe/src/test_pipe.c
@@ -681,6 +681,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		valid_fault = false; /* reset back to normal */
 		ztest_test_pass();
 	} else {
+		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);
 	}
 }

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -679,6 +679,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
 
 	if (reason != K_ERR_KERNEL_OOPS) {
 		printk("wrong error reason\n");
+		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);
 	}
 

--- a/tests/kernel/threads/dynamic_thread/src/main.c
+++ b/tests/kernel/threads/dynamic_thread/src/main.c
@@ -20,10 +20,12 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
 {
 	if (reason != K_ERR_KERNEL_OOPS) {
 		printk("wrong error reason\n");
+		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);
 	}
 	if (k_current_get() != dyn_thread) {
 		printk("wrong thread crashed\n");
+		printk("PROJECT EXECUTION FAILED\n");
 		k_fatal_halt(reason);
 	}
 }


### PR DESCRIPTION
For some kernel tests, faults and exceptions are expected. They are caught and the test would continue if the reasons for faults are as expected. However, when the unexpected reasons are encountered, the code simply prints a message and calls k_fatal_halt(). When running under twister, these messages are not the expected failed messages so twister will spin till timeout although the execution has already been halted. This adds another printk() before halt to signal twister that the test has failed and bails early.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>