### PR TITLE
Only use -ffreestanding with minimal C library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,7 @@ endif()
 # @Intent: Set compiler specific macro inclusion of AUTOCONF_H
 zephyr_compile_options("SHELL: $<TARGET_PROPERTY:compiler,imacros> ${AUTOCONF_H}")
 
-if(NOT CONFIG_PICOLIBC)
+if(CONFIG_COMPILER_FREESTANDING)
   # @Intent: Set compiler specific flag for bare metal freestanding option
   zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,freestanding>>)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:compiler,freestanding>>)

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -320,6 +320,15 @@ config NATIVE_APPLICATION
 	  Build as a native application that can run on the host and using
 	  resources and libraries provided by the host.
 
+config COMPILER_FREESTANDING
+	bool "Build in a freestanding compiler mode"
+	help
+	  Configure the compiler to operate in freestanding mode according to
+	  the C and C++ language specifications. Freestanding mode reduces the
+	  requirements of the compiler and language environment, which can
+	  negatively impact the ability for the compiler to detect errors and
+	  perform optimizations.
+
 choice COMPILER_OPTIMIZATIONS
 	prompt "Optimization level"
 	default NO_OPTIMIZATIONS    if COVERAGE

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -37,6 +37,7 @@ config MINIMAL_LIBC
 	depends on !NATIVE_APPLICATION
 	depends on !REQUIRES_FULL_LIBC
 	depends on SUPPORT_MINIMAL_LIBC
+	imply COMPILER_FREESTANDING
 	help
 	  Build with minimal C library.
 


### PR DESCRIPTION
As Zephyr applications are "hosted" according to the C language spec, we should be telling the compiler to perform error checking and optimizations based upon the hosted language specification instead of the freestanding one.

However, this depends on having a C library which conforms with the language specification, and the minimal C library does not. Continue to use freestanding mode when that library is in use.

See discussion: https://github.com/zephyrproject-rtos/zephyr/issues/54336#issuecomment-1422174695

Signed-off-by: Keith Packard <keithp@keithp.com>