### PR TITLE
lib: tftp_client: Add TFTP PUT function

### DIFF
--- a/include/zephyr/net/tftp.h
+++ b/include/zephyr/net/tftp.h
@@ -71,6 +71,24 @@ struct tftpc {
 int tftp_get(struct sockaddr *server, struct tftpc *client,
 	     const char *remote_file, const char *mode);
 
+/* @brief This function puts data to "file" on the remote server.
+ *
+ * If the data is successfully sent, the size of data being sent will be returned in
+ * `client->user_buf_size` parameter.
+ *
+ * @param server      Control Block that represents the remote server.
+ * @param client      Client Buffer Information.
+ * @param remote_file Name of the remote file to put.
+ * @param mode        TFTP Client "mode" setting.
+ *
+ * @return TFTPC_SUCCESS if the operation completed successfully.
+ *         TFTPC_REMOTE_ERROR if the server failed to process our request.
+ *         TFTPC_RETRIES_EXHAUSTED if the client timed out waiting for server.
+ *         -EINVAL if `client->user_buf` is NULL or `client->user_buf_size` is zero.
+ */
+int tftp_put(struct sockaddr *server, struct tftpc *client,
+	     const char *remote_file, const char *mode);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/net/tftp.h
+++ b/include/zephyr/net/tftp.h
@@ -19,10 +19,31 @@
 extern "C" {
 #endif
 
+/**
+ * @typedef tftp_callback_t
+ *
+ * Handler to handle data received from the TFTP server.
+ *
+ * @param data    Data received.
+ * @param datalen Length of the data, 512 bytes or less.
+ *
+ * @note The handler must not call @ref tftp_get and @ref tftp_put.
+ */
+typedef void (*tftp_callback_t)(const uint8_t *data, size_t datalen);
+
 struct tftpc {
 	uint8_t   *user_buf;
 	uint32_t  user_buf_size;
+	tftp_callback_t callback;
 };
+
+/*
+ * RFC1350: the file is sent in fixed length blocks of 512 bytes.
+ * Each data packet contains one block of data, and must be acknowledged
+ * by an acknowledgment packet before the next packet can be sent.
+ * A data packet of less than 512 bytes signals termination of a transfer.
+ */
+#define TFTP_BLOCK_SIZE          512
 
 /* TFTP Client Error codes. */
 #define TFTPC_SUCCESS             0
@@ -40,7 +61,7 @@ struct tftpc {
  * @param server      Control Block that represents the remote server.
  * @param client      Client Buffer Information.
  * @param remote_file Name of the remote file to get.
- * @param mode        TFTP Client "mode" setting
+ * @param mode        TFTP Client "mode" setting.
  *
  * @return TFTPC_SUCCESS if the operation completed successfully.
  *         TFTPC_BUFFER_OVERFLOW if the file is larger than the user buffer.

--- a/subsys/net/lib/tftp/tftp_client.h
+++ b/subsys/net/lib/tftp/tftp_client.h
@@ -8,10 +8,10 @@
 #include <zephyr/kernel.h>
 #include <errno.h>
 #include <zephyr/net/socket.h>
+#include <zephyr/net/tftp.h>
 
 /* Defines for creating static arrays for TFTP communication. */
 #define TFTP_HEADER_SIZE         4
-#define TFTP_BLOCK_SIZE          512
 #define TFTP_MAX_MODE_SIZE       8
 #define TFTP_REQ_RETX            CONFIG_TFTPC_REQUEST_RETRANSMITS
 


### PR DESCRIPTION
Add tftp_put() API to support TFTP WRITE request.

Also add a callback for TFTP READ request so as to download a file with arbitary length.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>