### PR TITLE
ITE soc/riscv/ite: add intc, twd node for chip it82xx2

### DIFF
--- a/dts/riscv/ite/it82xx2.dtsi
+++ b/dts/riscv/ite/it82xx2.dtsi
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 ITE Corporation. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ite/it8xxx2.dtsi>
+
+/ {
+	soc {
+		intc: interrupt-controller@f01100 {
+			compatible = "ite,it8xxx2-intc-v2";
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
+			interrupt-controller;
+			reg = <0x00f01100 0x0100>;
+		};
+
+		twd0: watchdog@f01f80 {
+			compatible = "ite,it8xxx2-watchdog";
+			reg = <0x00f01f80 0x0019>;
+			interrupts = <IT8XXX2_IRQ_TIMER1 IRQ_TYPE_EDGE_RISING   /* Warning timer */
+				      IT8XXX2_IRQ_TIMER2 IRQ_TYPE_EDGE_RISING>; /* One shot timer */
+			interrupt-parent = <&intc>;
+		};
+	};
+};
+


### PR DESCRIPTION
Chip it82xx2 intc and twd register are remapped, so I add both new node.

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>