### PR TITLE
ITE: drivers/i2c: Mutex issue in I2C transfer

### DIFF
--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -854,13 +854,13 @@ static int i2c_enhance_transfer(const struct device *dev,
 				uint8_t num_msgs, uint16_t addr)
 {
 	struct i2c_enhance_data *data = dev->data;
-
-	data->num_msgs = num_msgs;
-	data->addr_16bit = addr;
+	int ret;
 
 	/* Lock mutex of i2c controller */
 	k_mutex_lock(&data->mutex, K_FOREVER);
 
+	data->num_msgs = num_msgs;
+	data->addr_16bit = addr;
 	/*
 	 * If the transaction of write to read is divided into two
 	 * transfers, the repeat start transfer uses this flag to
@@ -891,11 +891,12 @@ static int i2c_enhance_transfer(const struct device *dev,
 	{
 		data->err = i2c_enhance_pio_transfer(dev, msgs);
 	}
-
+	/* Save return value. */
+	ret = i2c_parsing_return_value(dev);
 	/* Unlock mutex of i2c controller */
 	k_mutex_unlock(&data->mutex);
 
-	return i2c_parsing_return_value(dev);
+	return ret;
 }
 
 static void i2c_enhance_isr(void *arg)

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -926,7 +926,7 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 {
 	struct i2c_it8xxx2_data *data = dev->data;
 	const struct i2c_it8xxx2_config *config = dev->config;
-	int res;
+	int res, ret;
 
 	/* Lock mutex of i2c controller */
 	k_mutex_lock(&data->mutex, K_FOREVER);
@@ -1051,10 +1051,12 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 	if (data->err || (data->active_msg->flags & I2C_MSG_STOP)) {
 		data->i2ccs = I2C_CH_NORMAL;
 	}
+	/* Save return value. */
+	ret = i2c_parsing_return_value(dev);
 	/* Unlock mutex of i2c controller */
 	k_mutex_unlock(&data->mutex);
 
-	return i2c_parsing_return_value(dev);
+	return ret;
 }
 
 static void i2c_it8xxx2_isr(const struct device *dev)


### PR DESCRIPTION
These global variables should be under the mutex lock, otherwise they will be overwritten by other transfers.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>