### PR TITLE
boards: arm: stm32h735g_disco: fix support for RNG

### DIFF
--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
@@ -59,6 +59,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &pll {
 	div-m = <5>;
 	mul-n = <110>;
@@ -96,6 +100,10 @@
 &i2c4 {
 	pinctrl-0 = <&i2c4_scl_pf14 &i2c4_sda_pf15>;
 	pinctrl-names = "default";
+};
+
+&rng {
+	status = "okay";
 };
 
 &mac {


### PR DESCRIPTION
The Zephyr board support documentation for the stm32h735g_disco states the current configuration supports RNG, but the RNG peripheral, and the HSI48 clock that the RNG depends on, were not enabled in devicetree.

This PR enables the RNG and the HSI48 clock, fixing this divergence between the configuration and documentation, and enabling the RNG to be used in the default board configuration. Change verified with entropy test.