### PR TITLE
bluetooth: host: conn: Utilize conn_set_state in conn_destroy

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -747,11 +747,10 @@ static void conn_cleanup(struct bt_conn *conn)
 
 static void conn_destroy(struct bt_conn *conn, void *data)
 {
-	k_work_cancel_delayable(&conn->deferred_work);
-
-	conn->pending_no_cb = 0;
-
-	conn_cleanup(conn);
+	if (conn->state == BT_CONN_CONNECTED ||
+	    conn->state == BT_CONN_DISCONNECTING) {
+		bt_conn_set_state(conn, BT_CONN_DISCONNECT_COMPLETE);
+	}
 
 	bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 }
@@ -1100,10 +1099,6 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 			bt_conn_unref(conn);
 			break;
 		case BT_CONN_CONNECTED:
-			/* Can only happen if bt_conn_cleanup_all is called
-			 * whilst in a connection.
-			 */
-			break;
 		case BT_CONN_DISCONNECTING:
 		case BT_CONN_DISCONNECTED:
 			/* Cannot happen. */

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3788,16 +3788,6 @@ int bt_disable(void)
 	/* If random address was set up - clear it */
 	bt_addr_le_copy(&bt_dev.random_addr, BT_ADDR_LE_ANY);
 
-	/* Abort TX thread */
-	k_thread_abort(&tx_thread_data);
-
-#if defined(CONFIG_BT_RECV_WORKQ_BT)
-	/* Abort RX thread */
-	k_thread_abort(&bt_workq.thread);
-#endif
-
-	bt_monitor_send(BT_MONITOR_CLOSE_INDEX, NULL, 0);
-
 #if defined(CONFIG_BT_BROADCASTER)
 	bt_adv_reset_adv_pool();
 #endif /* CONFIG_BT_BROADCASTER */
@@ -3817,6 +3807,17 @@ int bt_disable(void)
 	bt_conn_cleanup_all();
 	disconnected_handles_reset();
 #endif /* CONFIG_BT_CONN */
+
+	/* Abort TX thread */
+	k_thread_abort(&tx_thread_data);
+
+#if defined(CONFIG_BT_RECV_WORKQ_BT)
+	/* Abort RX thread */
+	k_thread_abort(&bt_workq.thread);
+#endif
+
+	bt_monitor_send(BT_MONITOR_CLOSE_INDEX, NULL, 0);
+
 	/* Clear BT_DEV_ENABLE here to prevent early bt_enable() calls, before disable is
 	 * completed.
 	 */


### PR DESCRIPTION
fixes https://github.com/zephyrproject-rtos/zephyr/issues/54542 , which highlighted a bug in bt_disable, where if you have pending tx packets for a connection and then call bt_disable, it will assert. 

Previously we would call conn_cleanup for all connections,
however this had multiple problems such as:
-Not destroying conn->tx_pending packets and causing an assert
-Calling conn_cleanup for connectable adv, triggering
disconnected callback

Now we will use bt_conn_set_state to manage the teardown of
connections correctly. First, if in connected or disconnecting,
set state to disconnect complete. Then for all states, set
state to disconnected. This will carry out proper cleanup
and teardown when required.

To do this, it was required to keep the tx_thread open as
this is used in disconnecting teardown, so this has been
moved to below the conn_cleanup_all call.

Signed-off-by: Sean Madigan <sean.madigan@nordicsemi.no>