### PR TITLE
boards: decawave_dwm1001_dev: enable pull-up on pins used for I2C, reset core after load

### DIFF
--- a/boards/arm/decawave_dwm1001_dev/board.cmake
+++ b/boards/arm/decawave_dwm1001_dev/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000" "--reset-after-load")
 board_runner_args(pyocd "--target=nrf52832")
 set(OPENOCD_NRF5_SUBFAMILY "nrf52")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev-pinctrl.dtsi
+++ b/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev-pinctrl.dtsi
@@ -23,6 +23,7 @@
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 0, 29)>,
 				<NRF_PSEL(TWIM_SCL, 0, 28)>;
+			bias-pull-up;
 		};
 	};
 


### PR DESCRIPTION
Enable pull-up on pins used for I2C, reset core after load.

Fixes: #54202