### PR TITLE
drivers: disk: sdmmc_stm32: handle DMA errors instead of ignoring them

### DIFF
--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -241,7 +241,7 @@ static int stm32_sdmmc_dma_init(struct stm32_sdmmc_priv *priv)
 	HAL_DMA_DeInit(&dma_tx_handle);
 	HAL_DMA_Init(&dma_tx_handle);
 
-	stm32_sdmmc_configure_dma(&dma_rx_handle, &priv->dma_rx);
+	err = stm32_sdmmc_configure_dma(&dma_rx_handle, &priv->dma_rx);
 	if (err) {
 		LOG_ERR("failed to init rx dma");
 		return err;
@@ -270,7 +270,11 @@ static int stm32_sdmmc_access_init(struct disk_info *disk)
 	}
 
 #if STM32_SDMMC_USE_DMA
-	stm32_sdmmc_dma_init(priv);
+	err = stm32_sdmmc_dma_init(priv);
+	if (err) {
+		LOG_ERR("DMA init failed");
+		return err;
+	}
 #endif
 
 	err = stm32_sdmmc_clock_enable(priv);


### PR DESCRIPTION
One was clearly a typo, the other should also be handled properly.