### PR TITLE
boards: arm: nrf52840dongle_nrf52840: Use USB CDC as default UART

### DIFF
--- a/boards/arm/nrf52840dongle_nrf52840/Kconfig
+++ b/boards/arm/nrf52840dongle_nrf52840/Kconfig
@@ -1,6 +1,6 @@
 # nRF52840 Dongle NRF52840 board configuration
 
-# Copyright (c) 2018 Nordic Semiconductor ASA
+# Copyright (c) 2018-2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_NRF52840DONGLE_NRF52840
@@ -21,5 +21,9 @@ config BOARD_HAS_NRF5_BOOTLOADER
 	help
 	  If selected, applications are linked so that they can be loaded by Nordic
 	  nRF5 bootloader.
+
+config BOARD_SERIAL_BACKEND_CDC_ACM
+	bool "USB CDC"
+	default y
 
 endif # BOARD_NRF52840DONGLE_NRF52840

--- a/boards/arm/nrf52840dongle_nrf52840/Kconfig.defconfig
+++ b/boards/arm/nrf52840dongle_nrf52840/Kconfig.defconfig
@@ -1,6 +1,6 @@
 # nRF52840 Dongle NRF52840 board configuration
 #
-# Copyright (c) 2018 Nordic Semiconductor ASA
+# Copyright (c) 2018-2023 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -24,6 +24,44 @@ config FLASH_LOAD_OFFSET
 	default 0x1000
 	depends on BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
 
+if BOARD_SERIAL_BACKEND_CDC_ACM
+
+config USB_DEVICE_STACK
+	default y
+
+config USB_CDC_ACM
+	default y
+
+config UART_CONSOLE
+	default CONSOLE
+
+config USB_DEVICE_INITIALIZE_AT_BOOT
+	default y if !MCUBOOT
+
+config SHELL_BACKEND_SERIAL_CHECK_DTR
+	default SHELL
+
+config USB_DEVICE_REMOTE_WAKEUP
+	default n
+
+if LOG
+
+# Logger cannot use itself to log
+choice USB_CDC_ACM_LOG_LEVEL_CHOICE
+	default USB_CDC_ACM_LOG_LEVEL_OFF
+endchoice
+
+# Set USB log level to error only
+choice USB_DEVICE_LOG_LEVEL_CHOICE
+	default USB_DEVICE_LOG_LEVEL_ERR
+endchoice
+
+# Wait 4000ms at startup for logging
+config LOG_PROCESS_THREAD_STARTUP_DELAY_MS
+	default 4000
+
+endif # LOG
+
 if USB_DEVICE_STACK
 
 # Enable UART driver, needed for CDC ACM
@@ -31,6 +69,8 @@ config SERIAL
 	default y
 
 endif # USB_DEVICE_STACK
+
+endif # BOARD_SERIAL_BACKEND_CDC_ACM
 
 config BT_CTLR
 	default BT

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2023 Nordic Semiconductor ASA
  * Copyright (c) 2017 Linaro Limited
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -14,11 +14,11 @@
 	compatible = "nordic,nrf52840-dongle-nrf52840";
 
 	chosen {
-		zephyr,console = &uart0;
-		zephyr,shell-uart = &uart0;
-		zephyr,uart-mcumgr = &uart0;
-		zephyr,bt-mon-uart = &uart0;
-		zephyr,bt-c2h-uart = &uart0;
+		zephyr,console = &cdc_acm_uart;
+		zephyr,shell-uart = &cdc_acm_uart;
+		zephyr,uart-mcumgr = &cdc_acm_uart;
+		zephyr,bt-mon-uart = &cdc_acm_uart;
+		zephyr,bt-c2h-uart = &cdc_acm_uart;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
@@ -173,4 +173,8 @@
 zephyr_udc0: &usbd {
 	compatible = "nordic,nrf-usbd";
 	status = "okay";
+
+	cdc_acm_uart: cdc_acm_uart {
+		compatible = "zephyr,cdc-acm-uart";
+	};
 };

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840_defconfig
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840_defconfig
@@ -18,3 +18,9 @@ CONFIG_GPIO_AS_PINRESET=y
 CONFIG_NFCT_PINS_AS_GPIOS=y
 
 CONFIG_PINCTRL=y
+
+# Board Kconfig.defconfig enables USB CDC ACM and should disable USB remote
+# wakeup by default. It needs to be disabled here, because the USB nrfx
+# driver always overwrites option from Kconfig mentioned above with the
+# imply from CONFIG_USB_NRFX.
+CONFIG_USB_DEVICE_REMOTE_WAKEUP=n

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -347,6 +347,10 @@ Boards & SoC Support
     Note that MCUboot and MCUboot image updates from pre-Zephyr 3.3 might be
     incompatible with Zephyr 3.3 onwards and vice versa.
 
+  * The default console for the ``nrf52840dongle_nrf52840`` board has been
+    changed from physical UART (which is not connected to anything on the
+    board) to use USB CDC instead.
+
 * Made these changes in other boards:
 
 * Added support for these following shields:


### PR DESCRIPTION
Enables use of the USB CDC port as the default UART for this board, as it is a USB dongle and makes more sense to use the on-board USB port instead of a disconnected/floating UART interface.

Fixes #54659
Also fixes https://github.com/mcu-tools/mcuboot/issues/1599