### PR TITLE
dts: arm: nordic: introduce easydma-maxcnt-bits

### DIFF
--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -86,6 +86,7 @@
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 
@@ -112,6 +113,7 @@
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -123,6 +123,7 @@
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <14>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -127,6 +127,7 @@
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <10>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -140,6 +140,7 @@
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <14>;
 			status = "disabled";
 		};
 
@@ -157,6 +158,7 @@
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <14>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -129,6 +129,7 @@
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <15>;
 			status = "disabled";
 		};
 
@@ -163,6 +164,7 @@
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <15>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -127,6 +127,7 @@
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 
@@ -161,6 +162,7 @@
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 
@@ -427,6 +429,7 @@
 			reg = <0x40023000 0x1000>;
 			interrupts = <35 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -134,6 +134,7 @@
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 
@@ -168,6 +169,7 @@
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 
@@ -441,6 +443,7 @@
 			reg = <0x40023000 0x1000>;
 			interrupts = <35 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 
@@ -497,6 +500,7 @@
 			reg = <0x4002f000 0x1000>;
 			interrupts = <47 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(32)>;
+			easydma-maxcnt-bits = <16>;
 			rx-delay-supported;
 			rx-delay = <2>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -129,6 +129,7 @@
 			reg = <0x40003000 0x1000>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 
@@ -163,6 +164,7 @@
 			reg = <0x40004000 0x1000>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 
@@ -436,6 +438,7 @@
 			reg = <0x40023000 0x1000>;
 			interrupts = <35 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 
@@ -502,6 +505,7 @@
 			reg = <0x4002f000 0x1000>;
 			interrupts = <47 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(32)>;
+			easydma-maxcnt-bits = <16>;
 			rx-delay-supported;
 			rx-delay = <2>;
 			status = "disabled";

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -90,6 +90,7 @@ spi0: spi@8000 {
 	reg = <0x8000 0x1000>;
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
 	max-frequency = <DT_FREQ_M(8)>;
+	easydma-maxcnt-bits = <16>;
 	status = "disabled";
 };
 
@@ -129,6 +130,7 @@ spi1: spi@9000 {
 	reg = <0x9000 0x1000>;
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
 	max-frequency = <DT_FREQ_M(8)>;
+	easydma-maxcnt-bits = <16>;
 	status = "disabled";
 };
 
@@ -146,6 +148,7 @@ spi4: spi@a000 {
 	reg = <0xa000 0x1000>;
 	interrupts = <10 NRF_DEFAULT_IRQ_PRIORITY>;
 	max-frequency = <DT_FREQ_M(32)>;
+	easydma-maxcnt-bits = <16>;
 	rx-delay-supported;
 	rx-delay = <2>;
 	status = "disabled";
@@ -180,6 +183,7 @@ spi2: spi@b000 {
 	reg = <0xb000 0x1000>;
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
 	max-frequency = <DT_FREQ_M(8)>;
+	easydma-maxcnt-bits = <16>;
 	status = "disabled";
 };
 
@@ -219,6 +223,7 @@ spi3: spi@c000 {
 	reg = <0xc000 0x1000>;
 	interrupts = <12 NRF_DEFAULT_IRQ_PRIORITY>;
 	max-frequency = <DT_FREQ_M(8)>;
+	easydma-maxcnt-bits = <16>;
 	status = "disabled";
 };
 

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -203,6 +203,7 @@
 			reg = <0x41013000 0x1000>;
 			interrupts = <19 NRF_DEFAULT_IRQ_PRIORITY>;
 			max-frequency = <DT_FREQ_M(8)>;
+			easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -218,6 +218,7 @@ spi0: spi@8000 {
 	reg = <0x8000 0x1000>;
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
 	max-frequency = <DT_FREQ_M(8)>;
+	easydma-maxcnt-bits = <13>;
 	status = "disabled";
 };
 
@@ -233,6 +234,7 @@ spi1: spi@9000 {
 	reg = <0x9000 0x1000>;
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
 	max-frequency = <DT_FREQ_M(8)>;
+	easydma-maxcnt-bits = <13>;
 	status = "disabled";
 };
 
@@ -248,6 +250,7 @@ spi2: spi@a000 {
 	reg = <0xa000 0x1000>;
 	interrupts = <10 NRF_DEFAULT_IRQ_PRIORITY>;
 	max-frequency = <DT_FREQ_M(8)>;
+	easydma-maxcnt-bits = <13>;
 	status = "disabled";
 };
 
@@ -263,6 +266,7 @@ spi3: spi@b000 {
 	reg = <0xb000 0x1000>;
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
 	max-frequency = <DT_FREQ_M(8)>;
+	easydma-maxcnt-bits = <13>;
 	status = "disabled";
 };
 

--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -29,3 +29,10 @@ properties:
       The overrun character (ORC) is used when all bytes from the TX buffer
       are sent, but the transfer continues due to RX. Defaults to 0xff
       (line high), the most common value used in SPI transfers.
+
+  easydma-maxcnt-bits:
+    type: int
+    required: true
+    description: |
+      Maximum number of bits available in the EasyDMA MAXCNT register. This
+      property must be set at SoC level DTS files.


### PR DESCRIPTION
The number of available EasyDMA MAXCNT bits is now defined per-instance in Devicetree.

Alternative to https://github.com/zephyrproject-rtos/zephyr/pull/54473

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>