### PR TITLE
net: AF_PACKET/SOCK_RAW/IPPROTO_RAW: set pkt family on lower layers

### DIFF
--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -747,6 +747,20 @@ static int ppp_send(const struct device *dev, struct net_pkt *pkt)
 			protocol = htons(PPP_IP);
 		} else if (net_pkt_family(pkt) == AF_INET6) {
 			protocol = htons(PPP_IPV6);
+		} else if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
+			   net_pkt_family(pkt) == AF_PACKET) {
+			char type = (NET_IPV6_HDR(pkt)->vtc & 0xf0);
+
+			switch (type) {
+			case 0x60:
+				protocol = htons(PPP_IPV6);
+				break;
+			case 0x40:
+				protocol = htons(PPP_IP);
+				break;
+			default:
+				return -EPROTONOSUPPORT;
+			}
 		}  else {
 			return -EPROTONOSUPPORT;
 		}

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1761,21 +1761,6 @@ static int context_sendto(struct net_context *context,
 		net_pkt_cursor_init(pkt);
 
 		if (net_context_get_proto(context) == IPPROTO_RAW) {
-			char type = (NET_IPV6_HDR(pkt)->vtc & 0xf0);
-
-			/* Set the family to pkt if detected */
-			switch (type) {
-			case 0x60:
-				net_pkt_set_family(pkt, AF_INET6);
-				break;
-			case 0x40:
-				net_pkt_set_family(pkt, AF_INET);
-				break;
-			default:
-				/* Not IP traffic, let it go forward as it is */
-				break;
-			}
-
 			/* Pass to L2: */
 			ret = net_send_data(pkt);
 		} else {

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -666,6 +666,37 @@ static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 			net_pkt_lladdr_src(pkt)->len =
 						sizeof(struct net_eth_addr);
 			ptype = dst_addr->sll_protocol;
+		} else if (context && net_context_get_type(context) == SOCK_RAW &&
+			   net_context_get_proto(context) == IPPROTO_RAW) {
+			char type = (NET_IPV6_HDR(pkt)->vtc & 0xf0);
+
+			switch (type) {
+			case 0x60:
+				ptype = htons(NET_ETH_PTYPE_IPV6);
+				break;
+			case 0x40: {
+				struct net_pkt *tmp = NULL;
+
+				tmp = ethernet_ll_prepare_on_ipv4(iface, pkt);
+				if (!tmp) {
+					ret = -ENOMEM;
+					goto error;
+				} else if (IS_ENABLED(CONFIG_NET_ARP) && tmp != pkt) {
+					/* Original pkt got queued and is replaced
+					 * by an ARP request packet.
+					 */
+					pkt = tmp;
+					ptype = htons(NET_ETH_PTYPE_ARP);
+					net_pkt_set_family(pkt, AF_INET);
+				} else {
+					ptype = htons(NET_ETH_PTYPE_IP);
+				}
+				break;
+			}
+			default:
+				ret = -ENOTSUP;
+				goto error;
+			}
 		} else {
 			goto send;
 		}


### PR DESCRIPTION
Setting pkt family already on net_context level breakk fundamentals of socket type IPPROTO_RAW where
Zephyr IP stack is supposed to be bypassed.
Thus, setting family in L2/driver level as it was originally in a breaking PR: https://github.com/zephyrproject-rtos/zephyr/pull/53440 
