### PR TITLE
drivers: spi: nrfx: use SPI(M|S)_TXD_MACNT_MAXCNT_Msk

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -19,6 +19,7 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
+#include <zephyr/toolchain.h>
 LOG_MODULE_REGISTER(spi_nrfx_spim, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"
@@ -28,7 +29,10 @@ LOG_MODULE_REGISTER(spi_nrfx_spim, CONFIG_SPI_LOG_LEVEL);
 #endif
 
 /* Maximum chunk length (depends on the EasyDMA bits, equal for all instances) */
-#define MAX_CHUNK_LEN BIT_MASK(SPIM0_EASYDMA_MAXCNT_SIZE)
+#define MAX_CHUNK_LEN SPIM_TXD_MAXCNT_MAXCNT_Msk
+/* Since we use TXD value for both TX/RX, make sure it is equally defined */
+BUILD_ASSERT(SPIM_TXD_MAXCNT_MAXCNT_Msk == SPIM_RXD_MAXCNT_MAXCNT_Msk,
+	     "SPIM MAXCNT not equal for RX/TX");
 
 struct spi_nrfx_data {
 	struct spi_context ctx;

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -11,6 +11,7 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
+#include <zephyr/toolchain.h>
 LOG_MODULE_REGISTER(spi_nrfx_spis, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"
@@ -29,11 +30,10 @@ struct spi_nrfx_config {
 };
 
 /* Maximum buffer length (depends on the EasyDMA bits, equal for all instances) */
-#if defined(SPIS0_EASYDMA_MAXCNT_SIZE)
-#define MAX_BUF_LEN BIT_MASK(SPIS0_EASYDMA_MAXCNT_SIZE)
-#else
-#define MAX_BUF_LEN BIT_MASK(SPIS1_EASYDMA_MAXCNT_SIZE)
-#endif
+#define MAX_BUF_LEN SPIS_TXD_MAXCNT_MAXCNT_Msk
+/* Since we use TXD value for both TX/RX, make sure it is equally defined */
+BUILD_ASSERT(SPIS_TXD_MAXCNT_MAXCNT_Msk == SPIS_RXD_MAXCNT_MAXCNT_Msk,
+	     "SPIS MAXCNT not equal for RX/TX");
 
 static inline nrf_spis_mode_t get_nrf_spis_mode(uint16_t operation)
 {


### PR DESCRIPTION
This definition from MDK provides the bit mask for the MAXCNT register in a instance agnostic way.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>