### PR TITLE
Fix stm32f1xx pwm input capture

### DIFF
--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -119,6 +119,17 @@
 	};
 };
 
+&timers2 {
+	st,prescaler = <255>;
+	status = "okay";
+
+	pwm2: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim2_ch2_pwm_in_pa1>;
+		pinctrl-names = "default";
+	};
+};
+
 &iwdg {
 	status = "okay";
 };

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -114,7 +114,7 @@
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch1_pwm_pa8>;
+		pinctrl-0 = <&tim1_ch1_pwm_out_pa8>;
 		pinctrl-names = "default";
 	};
 };

--- a/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
+++ b/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
@@ -115,7 +115,7 @@
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch1_pwm_pa8>;
+		pinctrl-0 = <&tim1_ch1_pwm_out_pa8>;
 		pinctrl-names = "default";
 	};
 };

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -152,7 +152,7 @@ zephyr_udc0: &usb {
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch1_pwm_pa8>;
+		pinctrl-0 = <&tim1_ch1_pwm_out_pa8>;
 		pinctrl-names = "default";
 	};
 };

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
@@ -107,7 +107,7 @@
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch1_pwm_pa8>;
+		pinctrl-0 = <&tim1_ch1_pwm_out_pa8>;
 		pinctrl-names = "default";
 	};
 };

--- a/boards/arm/stm32f103_mini/stm32f103_mini.dts
+++ b/boards/arm/stm32f103_mini/stm32f103_mini.dts
@@ -107,7 +107,7 @@
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch1_pwm_pa8>;
+		pinctrl-0 = <&tim1_ch1_pwm_out_pa8>;
 		pinctrl-names = "default";
 	};
 };

--- a/boards/arm/stm32vl_disco/stm32vl_disco.dts
+++ b/boards/arm/stm32vl_disco/stm32vl_disco.dts
@@ -120,7 +120,7 @@
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch1_pwm_pa8>;
+		pinctrl-0 = <&tim1_ch1_pwm_out_pa8>;
 		pinctrl-names = "default";
 	};
 };

--- a/boards/arm/waveshare_open103z/waveshare_open103z.dts
+++ b/boards/arm/waveshare_open103z/waveshare_open103z.dts
@@ -169,7 +169,7 @@ zephyr_udc0: &usb {
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch1_pwm_pa8>;
+		pinctrl-0 = <&tim1_ch1_pwm_out_pa8>;
 		pinctrl-names = "default";
 	};
 };

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -757,6 +757,18 @@ Devicetree
       * :dtcompatible: `st,stm32-ethernet`: now allows ``local-mac-address`` and
          ``zephyr,random-mac-address`` properties.
 
+* Others
+
+  * STM32F1 SoCs
+
+    * Added new pinctrl definitions for STM32F1xx PWM input. In PWM capture mode
+      STM32F1xx pins have to be configured as input and not as alternate.
+      The new names takes the form tim1_ch1_pwm_in_pa8 for example.
+
+    * Renamed pinctrl definitions for STM32F1xx PWM output to differentiate them
+      from newly created inputs. The new names takes the form tim1_ch1_pwm_out_pa8
+      instead of tim1_ch1_pwm_pa8.
+
 Libraries / Subsystems
 **********************
 

--- a/tests/drivers/pwm/pwm_loopback/boards/nucleo_f103rb.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/nucleo_f103rb.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		/* first index must be a 32-Bit timer */
+		pwms = <&pwm1 1 0 PWM_POLARITY_NORMAL>,
+			<&pwm2 2 0 PWM_POLARITY_NORMAL>;
+	};
+};

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: b916f9a01c665194fbbdd6a67a0f37b4e0a7e78c
+      revision: c36136b253a46ed8dd63525eeee659393047ce83
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
On STM32F1xx, pins used for PWM input must be configured as input, and not as alternate.
This PR uses the latest STM32 HAL where new entries were added for STM32F1xx PWM inputs.

Fixes #53584