### PR TITLE
ISO CIS establishement bugfix and improvement

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/isoal.c
+++ b/subsys/bluetooth/controller/ll_sw/isoal.c
@@ -113,7 +113,7 @@ isoal_status_t isoal_reset(void)
  * @param  time_diff Time difference (signed)
  * @return           Wrapped time after difference
  */
-static uint32_t isoal_get_wrapped_time_us(uint32_t time_now_us, int32_t time_diff_us)
+uint32_t isoal_get_wrapped_time_us(uint32_t time_now_us, int32_t time_diff_us)
 {
 	LL_ASSERT(time_now_us <= ISOAL_TIME_WRAPPING_POINT_US);
 

--- a/subsys/bluetooth/controller/ll_sw/isoal.h
+++ b/subsys/bluetooth/controller/ll_sw/isoal.h
@@ -419,6 +419,8 @@ struct isoal_source {
 	uint64_t context_active:1;
 };
 
+uint32_t isoal_get_wrapped_time_us(uint32_t time_now_us, int32_t time_diff_us);
+
 isoal_status_t isoal_init(void);
 
 isoal_status_t isoal_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -1312,6 +1312,7 @@ void ull_cp_cc_established(struct ll_conn *conn, uint8_t error_code)
 	if (ctx && ctx->proc == PROC_CIS_CREATE) {
 		ctx->data.cis_create.error = error_code;
 		llcp_rp_cc_established(conn, ctx);
+		llcp_rr_check_done(conn, ctx);
 	}
 #endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO */
 
@@ -1320,6 +1321,7 @@ void ull_cp_cc_established(struct ll_conn *conn, uint8_t error_code)
 	if (ctx && ctx->proc == PROC_CIS_CREATE) {
 		ctx->data.cis_create.error = error_code;
 		llcp_lp_cc_established(conn, ctx);
+		llcp_lr_check_done(conn, ctx);
 	}
 #endif /* CONFIG_BT_CTLR_CENTRAL_ISO */
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -524,6 +524,7 @@ void llcp_lr_complete(struct ll_conn *conn);
 void llcp_lr_connect(struct ll_conn *conn);
 void llcp_lr_disconnect(struct ll_conn *conn);
 void llcp_lr_abort(struct ll_conn *conn);
+void llcp_lr_check_done(struct ll_conn *conn, struct proc_ctx *ctx);
 
 /*
  * LLCP Remote Request
@@ -546,6 +547,7 @@ void llcp_rr_complete(struct ll_conn *conn);
 void llcp_rr_connect(struct ll_conn *conn);
 void llcp_rr_disconnect(struct ll_conn *conn);
 void llcp_rr_new(struct ll_conn *conn, struct node_rx_pdu *rx, bool valid_pdu);
+void llcp_rr_check_done(struct ll_conn *conn, struct proc_ctx *ctx);
 
 #if defined(CONFIG_BT_CTLR_LE_PING)
 /*

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -46,7 +46,6 @@
 #include <soc.h>
 #include "hal/debug.h"
 
-static void lr_check_done(struct ll_conn *conn, struct proc_ctx *ctx);
 static struct proc_ctx *lr_dequeue(struct ll_conn *conn);
 
 /* LLCP Local Request FSM State */
@@ -72,7 +71,7 @@ enum {
 	LR_EVT_DISCONNECT,
 };
 
-static void lr_check_done(struct ll_conn *conn, struct proc_ctx *ctx)
+void llcp_lr_check_done(struct ll_conn *conn, struct proc_ctx *ctx)
 {
 	if (ctx->done) {
 		struct proc_ctx *ctx_header;
@@ -273,7 +272,7 @@ void llcp_lr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *
 		break;
 	}
 
-	lr_check_done(conn, ctx);
+	llcp_lr_check_done(conn, ctx);
 }
 
 void llcp_lr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx)
@@ -306,7 +305,7 @@ void llcp_lr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *
 		break;
 		/* Ignore tx_ack */
 	}
-	lr_check_done(conn, ctx);
+	llcp_lr_check_done(conn, ctx);
 }
 
 void llcp_lr_tx_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
@@ -322,7 +321,7 @@ void llcp_lr_tx_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 		break;
 	}
 
-	lr_check_done(conn, ctx);
+	llcp_lr_check_done(conn, ctx);
 }
 
 static void lr_act_run(struct ll_conn *conn)
@@ -403,7 +402,7 @@ static void lr_act_run(struct ll_conn *conn)
 		break;
 	}
 
-	lr_check_done(conn, ctx);
+	llcp_lr_check_done(conn, ctx);
 }
 
 static void lr_act_complete(struct ll_conn *conn)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -47,7 +47,6 @@
 #include <soc.h>
 #include "hal/debug.h"
 
-static void rr_check_done(struct ll_conn *conn, struct proc_ctx *ctx);
 static struct proc_ctx *rr_dequeue(struct ll_conn *conn);
 static void rr_abort(struct ll_conn *conn);
 
@@ -110,7 +109,7 @@ static bool proc_with_instant(struct proc_ctx *ctx)
 	return 0U;
 }
 
-static void rr_check_done(struct ll_conn *conn, struct proc_ctx *ctx)
+void llcp_rr_check_done(struct ll_conn *conn, struct proc_ctx *ctx)
 {
 	if (ctx->done) {
 		struct proc_ctx *ctx_header;
@@ -289,7 +288,7 @@ void llcp_rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *
 		LL_ASSERT(0);
 		break;
 	}
-	rr_check_done(conn, ctx);
+	llcp_rr_check_done(conn, ctx);
 }
 
 void llcp_rr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx)
@@ -320,7 +319,7 @@ void llcp_rr_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *
 		break;
 	}
 
-	rr_check_done(conn, ctx);
+	llcp_rr_check_done(conn, ctx);
 }
 
 void llcp_rr_tx_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
@@ -341,7 +340,7 @@ void llcp_rr_tx_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 		break;
 	}
 
-	rr_check_done(conn, ctx);
+	llcp_rr_check_done(conn, ctx);
 }
 
 static void rr_act_run(struct ll_conn *conn)
@@ -421,7 +420,7 @@ static void rr_act_run(struct ll_conn *conn)
 		break;
 	}
 
-	rr_check_done(conn, ctx);
+	llcp_rr_check_done(conn, ctx);
 }
 
 static void rr_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
@@ -894,7 +893,7 @@ void llcp_rr_new(struct ll_conn *conn, struct node_rx_pdu *rx, bool valid_pdu)
 	/* Prepare procedure */
 	llcp_rr_prepare(conn, rx);
 
-	rr_check_done(conn, ctx);
+	llcp_rr_check_done(conn, ctx);
 
 	/* Handle PDU */
 	ctx = llcp_rr_peek(conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -293,10 +293,12 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 }
 
 uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
-				 uint8_t cig_id, uint16_t cis_handle)
+				 uint8_t cig_id, uint16_t cis_handle,
+				 uint16_t *conn_event_count)
 {
 	struct ll_conn_iso_stream *cis = NULL;
 	struct ll_conn_iso_group *cig;
+	uint32_t cis_offset;
 
 	/* Get CIG by id */
 	cig = ll_conn_iso_group_get_by_id(cig_id);
@@ -312,8 +314,22 @@ uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 		return BT_HCI_ERR_UNSPECIFIED;
 	}
 
+	cis_offset = sys_get_le24(ind->cis_offset);
+
+#if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO_EARLY_CIG_START)
+	if (!cig->started) {
+		/* This is the first CIS. Make sure we can make the anchorpoint, otherwise
+		 * we need to move up the instant up by one connection interval.
+		 */
+		if (cis_offset < EVENT_OVERHEAD_START_US) {
+			/* Start one connection event earlier */
+			(*conn_event_count)--;
+		}
+	}
+#endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO_EARLY_CIG_START */
+
 	cis->sync_delay = sys_get_le24(ind->cis_sync_delay);
-	cis->offset = sys_get_le24(ind->cis_offset);
+	cis->offset = cis_offset;
 	memcpy(cis->lll.access_addr, ind->aa, sizeof(ind->aa));
 	cis->lll.event_count = -1;
 	cis->lll.tx.payload_count = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso_internal.h
@@ -14,7 +14,8 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 				   uint16_t *cis_handle);
 uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 				 uint8_t cig_id,
-				 uint16_t cis_handle);
+				 uint16_t cis_handle,
+				 uint16_t *conn_event_count);
 void ull_peripheral_iso_update_peer_sca(struct ll_conn *acl);
 void ull_peripheral_iso_update_ticker(struct ll_conn_iso_group *cig,
 				      uint32_t ticks_at_expire,


### PR DESCRIPTION
**Bluetooth: controller: Fix CIS establishment procedures**

Fixing typo in llcp_lp_cc_established revealed the need for completing
the CIS establishment procedure by additional call to local/remote
check_done function.

Fixed by exposing lr_check_done and rr_check_done with naming update and
calling after injecting the CIS_ESTABLISHED event.

Fixes #54710.

**Bluetooth: controller: Enable CIS establishment in same ACL instant** 

If CIS offset in LL_CIS_IND is less than EVENT_OVERHEAD_START_US, the
controller is not able to establish the CIS in the ACL connection event
specified, but needs to start setup one connection event earlier.

With this commit, if offset is larger than EVENT_OVERHEAD_START_US the
first CIS event can be prepared in due time immediately.

This enables the controller to setup first CIS, even when instant is
equal to the ACL event_counter.

NOTE: Only applicable with **CONFIG_BT_CTLR_PERIPHERAL_ISO_EARLY_CIG_START=y**.

Signed-off-by: Morten Priess <mtpr@oticon.com>