### PR TITLE
west: runners: blackmagicprobe: add a \\.\ prefix to windows COM ports

### DIFF
--- a/scripts/west_commands/runners/blackmagicprobe.py
+++ b/scripts/west_commands/runners/blackmagicprobe.py
@@ -76,9 +76,10 @@ def blackmagicprobe_gdb_serial_win32():
             if port.vid == BMP_GDB_VID and port.pid == BMP_GDB_PID:
                 bmp_ports.append(port.device)
         if bmp_ports:
-            return sorted(bmp_ports)[0]
+            first_port = sorted(bmp_ports)[0]
+            return fr"\\.\{first_port}"
 
-    return 'COM1'
+    return r'\\.\COM1'
 
 def blackmagicprobe_gdb_serial(port):
     '''Guess the GDB port for the probe.

--- a/scripts/west_commands/tests/test_blackmagicprobe.py
+++ b/scripts/west_commands/tests/test_blackmagicprobe.py
@@ -174,8 +174,8 @@ def test_blackmagicprobe_gdb_serial_darwin(gg, stlpc, comports, globs, expected)
     assert expected == ret
 
 @pytest.mark.parametrize('comports, expected', [
-    (True, 'COM4'),
-    (False, 'COM1'),
+    (True, r'\\.\COM4'),
+    (False, r'\\.\COM1'),
     ])
 @patch('serial.tools.list_ports.comports')
 def test_blackmagicprobe_gdb_serial_win32(stlpc, comports, expected):


### PR DESCRIPTION
Seems like GDB needs COM port name prefixed with \\.\ to work correctly. Add the prefix to the port name returned by
blackmagicprobe_gdb_serial_win32().