### PR TITLE
Bluetooth: Mesh: avoid ll fragmentation for l2cap for mesh

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -9,6 +9,7 @@ menu "Bluetooth buffer configuration"
 config BT_BUF_ACL_TX_SIZE
 	int "Maximum supported ACL size for outgoing data"
 	range 27 65535
+	default 37 if BT_MESH_GATT_SERVER
 	default 27
 	help
 	  Maximum supported ACL size of data packets sent from the Host to the

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -431,6 +431,7 @@ config BT_CTLR_DATA_LENGTH
 config BT_CTLR_DATA_LENGTH_MAX
 	int "Maximum data length supported"
 	depends on BT_CTLR_DATA_LENGTH
+	default 37 if BT_MESH_GATT_SERVER
 	default 27
 	range 27 BT_BUF_ACL_RX_SIZE if BT_BUF_ACL_RX_SIZE < 251
 	range 27 251


### PR DESCRIPTION
Mesh sends via gatt proxy max 30 bytes frame prepared in advance. Default 27 bytes frame size always causes ll fragmentation that decreases gatt proxy performance. 37 bytes max length allows to fit mesh proxy frame in the single ll frame.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>