### PR TITLE
MAINTAINERS: add esp32 wifi driver to Espressif area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2024,6 +2024,7 @@ Espressif Platforms:
     - dts/bindings/*/*esp32*
     - samples/boards/esp32*/
     - tests/boards/espressif_esp32/
+    - drivers/wifi/esp32/
   labels:
     - "platform: ESP32"
 


### PR DESCRIPTION
Add missing file to Espressif area.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
