### PR TITLE
tests: fixes logging.add.async build warning

### DIFF
--- a/tests/subsys/logging/log_core_additional/src/log_test.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test.c
@@ -20,6 +20,8 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_output.h>
 
+#define TEST_MESSAGE "test msg"
+
 #define LOG_MODULE_NAME log_test
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL_INF);
 static K_SEM_DEFINE(log_sem, 0, 1);
@@ -29,7 +31,6 @@ ZTEST_BMEM uint32_t source_id;
 /* used when log_msg create in user space */
 ZTEST_BMEM uint8_t domain, level;
 ZTEST_DMEM uint32_t msg_data = 0x1234;
-ZTEST_DMEM char *test_msg_usr = "test msg";
 
 static uint8_t buf;
 static int char_out(uint8_t *data, size_t length, void *ctx)
@@ -489,7 +490,7 @@ ZTEST(test_log_core_additional, test_log_msg_create)
 
 		Z_LOG_MSG2_CREATE(!IS_ENABLED(CONFIG_USERSPACE), mode,
 			  Z_LOG_LOCAL_DOMAIN_ID, NULL,
-			  LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0, test_msg_usr);
+			  LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0, TEST_MESSAGE);
 
 		while (log_test_process()) {
 		}
@@ -507,15 +508,15 @@ ZTEST_USER(test_log_core_additional, test_log_msg_create_user)
 
 	z_log_msg_runtime_create(domain, NULL,
 				  level, &msg_data, 0,
-				  sizeof(msg_data), test_msg_usr);
+				  sizeof(msg_data), TEST_MESSAGE);
 	/* try z_log_msg_static_create() */
 	Z_LOG_MSG2_STACK_CREATE(0, domain, NULL,
 				level, &msg_data,
-				sizeof(msg_data), test_msg_usr);
+				sizeof(msg_data), TEST_MESSAGE);
 
 	Z_LOG_MSG2_CREATE(!IS_ENABLED(CONFIG_USERSPACE), mode,
 			  Z_LOG_LOCAL_DOMAIN_ID, NULL,
-		  LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0, test_msg_usr);
+		  LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0, TEST_MESSAGE);
 
 	while (log_test_process()) {
 	}


### PR DESCRIPTION
Fixes #54537.

Using a variable to point to the desired format string generates a build warning when the -Wformat-security compiler flag is used. To resolve this, replace the variable with a macro to the format string.

Signed-off-by: Peter Mitsis <peter.mitsis@intel.com>