### PR TITLE
tests: arch: x86: static_idt: Fix test when building with llvm

### DIFF
--- a/tests/arch/x86/static_idt/src/main.c
+++ b/tests/arch/x86/static_idt/src/main.c
@@ -175,7 +175,12 @@ ZTEST(static_idt, test_static_idt)
 	 * issuing a 'divide by zero' warning.
 	 */
 	error = 32;     /* avoid static checker uninitialized warnings */
-	error = error / exc_handler_executed;
+
+	__asm__ volatile ("movl $0x0, %%edx\n\t"
+			  "movl %0, %%eax\n\t"
+			  "movl %1, %%ebx\n\t"
+			  "idivl %%ebx;" : : "g" (error), "g" (exc_handler_executed) :
+			  "eax", "edx");
 
 	zassert_not_equal(exc_handler_executed, 0,
 			  "Exception handler did not execute");


### PR DESCRIPTION
llvm will generate a different div instruction than gcc does and than the number of types that the div instruction opcode takes is not 2.

Move to using inline asm with a idivl instruction to ensure the opcode size is what we expect so that exc_divide_error_handler() can properly skip over the instruction.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>