### PR TITLE
tests: Fix floating point test variants on x86 w/LLVM

### DIFF
--- a/tests/benchmarks/app_kernel/testcase.yaml
+++ b/tests/benchmarks/app_kernel/testcase.yaml
@@ -15,6 +15,17 @@ tests:
     min_flash: 34
     min_ram: 32
     slow: true
+    toolchain_exclude: llvm oneApi
+  benchmark.kernel.application.fp.x86.no_sse:
+    extra_args: CONF_FILE=prj_fp.conf
+    extra_configs:
+      - CONFIG_X86_SSE=n
+      - CONFIG_X86_SSE_FP_MATH=n
+    arch_allow: x86
+    filter: CONFIG_CPU_HAS_FPU
+    min_flash: 34
+    min_ram: 32
+    slow: true
   benchmark.kernel.application.fp.x86.sse:
     extra_args: CONF_FILE=prj_fp.conf
     extra_configs:

--- a/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
+++ b/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
@@ -14,10 +14,10 @@
  */
 #define PRIORITY  K_PRIO_COOP(0)
 
-#if defined(CONFIG_ARM) || defined(CONFIG_SPARC)
-#define K_FP_OPTS K_FP_REGS
-#elif defined(CONFIG_X86)
+#if defined(CONFIG_X86) && defined(CONFIG_X86_SSE)
 #define K_FP_OPTS (K_FP_REGS | K_SSE_REGS)
+#elif defined(CONFIG_X86) || defined(CONFIG_ARM) || defined(CONFIG_SPARC)
+#define K_FP_OPTS K_FP_REGS
 #else
 #error "Architecture not supported for this test"
 #endif

--- a/tests/kernel/fpu_sharing/float_disable/testcase.yaml
+++ b/tests/kernel/fpu_sharing/float_disable/testcase.yaml
@@ -10,9 +10,18 @@ tests:
     extra_args: CONF_FILE=prj_x86.conf
     extra_configs:
       - CONFIG_X86_SSE_FP_MATH=n
+      - CONFIG_X86_SSE=n
     platform_allow: qemu_x86 qemu_x86_lakemont ehl_crb acrn_ehl_crb
     integration_platforms:
       - qemu_x86
+  kernel.fpu_sharing.float_disable.x86.fpu.sse:
+    extra_args: CONF_FILE=prj_x86.conf
+    extra_configs:
+      - CONFIG_X86_SSE_FP_MATH=n
+    platform_allow: qemu_x86 qemu_x86_lakemont ehl_crb acrn_ehl_crb
+    integration_platforms:
+      - qemu_x86
+    toolchain_exclude: llvm oneApi
   kernel.fpu_sharing.float_disable.x86.sse:
     extra_args: CONF_FILE=prj_x86.conf
     extra_configs:

--- a/tests/kernel/fpu_sharing/generic/src/main.c
+++ b/tests/kernel/fpu_sharing/generic/src/main.c
@@ -17,10 +17,6 @@
 #error Rebuild with the FPU_SHARING config option enabled
 #endif
 
-#if defined(CONFIG_X86) && !defined(CONFIG_X86_SSE)
-#error Rebuild with the SSE config option enabled
-#endif
-
 static void *generic_setup(void)
 {
 	/*

--- a/tests/kernel/fpu_sharing/generic/src/test_common.h
+++ b/tests/kernel/fpu_sharing/generic/src/test_common.h
@@ -14,7 +14,7 @@
 #define THREAD_HIGH_PRIORITY	5
 #define THREAD_LOW_PRIORITY	10
 
-#if defined(CONFIG_X86)
+#if defined(CONFIG_X86) && defined(CONFIG_X86_SSE)
 #define THREAD_FP_FLAGS		(K_FP_REGS | K_SSE_REGS)
 #else
 #define THREAD_FP_FLAGS		(K_FP_REGS)

--- a/tests/kernel/fpu_sharing/generic/testcase.yaml
+++ b/tests/kernel/fpu_sharing/generic/testcase.yaml
@@ -44,12 +44,24 @@ tests:
     extra_args: CONF_FILE=prj_x86.conf
     extra_configs:
       - CONFIG_X86_SSE_FP_MATH=n
+      - CONFIG_X86_SSE=n
     platform_allow: qemu_x86 qemu_x86_lakemont
     integration_platforms:
       - qemu_x86
     slow: true
     tags: fpu kernel
     timeout: 600
+  kernel.fpu_sharing.generic.x86.fpu.sse:
+    extra_args: CONF_FILE=prj_x86.conf
+    extra_configs:
+      - CONFIG_X86_SSE_FP_MATH=n
+    platform_allow: qemu_x86 qemu_x86_lakemont
+    integration_platforms:
+      - qemu_x86
+    slow: true
+    tags: fpu kernel
+    timeout: 600
+    toolchain_exclude: llvm oneApi
   kernel.fpu_sharing.generic.x86.sse:
     extra_args: CONF_FILE=prj_x86.conf
     extra_configs:


### PR DESCRIPTION
LLVM doesn't support SSE + 387 math.  As such if SSE is enabled we have to utilize SSE floating point.  To utilize 387 math, SSE has to be disabled.

Update the floating point related tests to introduce 387 only variants that will build on both GCC & LLVM based tools.  Than we exclude llvm based (llvm, oneApi) toolchains from the CONFIG_X86_SSE_FP_MATH=n and CONFIG_X86_SSE=y test variants.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>