### PR TITLE
drivers: spi: nrfx_spis: changed signal result value from rx to max amount

### DIFF
--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -227,9 +227,10 @@ static void event_handler(const nrfx_spis_evt_t *p_event, void *p_context)
 {
 	struct spi_nrfx_data *dev_data = p_context;
 	struct device *dev = CONTAINER_OF(dev_data, struct device, data);
-
+	
 	if (p_event->evt_type == NRFX_SPIS_XFER_DONE) {
-		spi_context_complete(&dev_data->ctx, dev, p_event->rx_amount);
+		spi_context_complete(&dev_data->ctx, dev,
+				     MAX(p_event->rx_amount, p_event->tx_amount));
 	}
 }
 


### PR DESCRIPTION
Problem:

When using the SPIS Driver with a bigger TX buffer than RX buffer on the slave side, the slave does not get feedback about the amount of the clocked out bytes, since it is capped by RX buffer size. And since only RX amount is used in the signal callback the application has no information about how many bytes the master has read from the tx buffer.

Solution:

If the maximum of rx/tx buffer values is returned the slave can be used in all configurations.

This will probably be not braking for most people. Only users how are using bigger tx than rx buffers without caring about transmitted bytes will see a change in the result value. But that config makes only sense if you WANT to transmit more than receive, and then you need that change anyways to check if everything was transmitted.

Signed-off-by: Rico <schmitt@raceresult.com>