### PR TITLE
intel_adsp: move west sign from west flash to earlier west build

### DIFF
--- a/boards/xtensa/intel_adsp_ace15_mtpm/board.cmake
+++ b/boards/xtensa/intel_adsp_ace15_mtpm/board.cmake
@@ -3,3 +3,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_set_rimage_target(mtl)
+
+set(RIMAGE_SIGN_KEY "otc_private_key_3k.pem" CACHE STRING "default in ace15_mtpm/board.cmake")

--- a/boards/xtensa/intel_adsp_ace20_lnl/board.cmake
+++ b/boards/xtensa/intel_adsp_ace20_lnl/board.cmake
@@ -3,3 +3,5 @@
 set(SUPPORTED_EMU_PLATFORMS acesim)
 
 board_set_rimage_target(lnl)
+
+set(RIMAGE_SIGN_KEY "otc_private_key_3k.pem" CACHE STRING "default in ace20_lnl/board.cmake")

--- a/boards/xtensa/intel_adsp_cavs25/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs25/board.cmake
@@ -7,7 +7,7 @@ endif()
 
 board_set_flasher_ifnset(intel_adsp)
 
-set(RIMAGE_SIGN_KEY otc_private_key_3k.pem)
+set(RIMAGE_SIGN_KEY "otc_private_key_3k.pem" CACHE STRING "default in cavs25/board.cmake")
 
 if(CONFIG_BOARD_INTEL_ADSP_CAVS25)
 board_set_rimage_target(tgl)

--- a/doc/develop/west/sign.rst
+++ b/doc/develop/west/sign.rst
@@ -117,3 +117,54 @@ signing system or extending the default behaviour.
 
 .. _imgtool:
    https://pypi.org/project/imgtool/
+
+
+rimage
+******
+
+rimage configuration uses a different approach that does not rely on Kconfig or CMake
+but on :ref:`west config<west-config>` instead, similar to
+:ref:`west-building-cmake-config`.
+
+Signing involves a number of "wrapper" scripts stacked on top of each other: ``west
+flash`` invokes ``west build`` which invokes ``cmake`` and ``ninja`` which invokes
+``west sign`` which invokes ``imgtool`` or `rimage`_. As long as the signing
+parameters desired are the default ones and fairly static, these indirections are
+not a problem. On the other hand, passing ``imgtool`` or ``rimage`` options through
+all these layers can causes issues typical when the layers don't abstract
+anything. First, this usually requires boilerplate code in each layer. Quoting
+whitespace or other special characters through all the wrappers can be
+difficult. Reproducing a lower ``west sign`` command to debug some build-time issue
+can be very time-consuming: it requires at least enabling and searching verbose
+build logs to find which exact options were used. Copying these options from the
+build logs can be unreliable: it may produce different results because of subtle
+environment differences. Last and worst: new signing feature and options are
+impossible to use until more boilerplate code has been added in each layer.
+
+To avoid these issues, ``rimage`` parameters can bet set in ``west config``
+instead. Here's a ``workspace/.west/config`` example:
+
+.. code-block:: ini
+
+   [sign]
+   # Not needed when invoked from CMake
+   tool = rimage
+
+   [rimage]
+   # Quoting is optional and works like in Unix shells
+   # Not needed when rimage can be found in the default PATH
+   path = "/home/me/zworkspace/build-rimage/rimage"
+
+   # Not needed when using the default development key
+   extra-args = -i 4 -k 'keys/key argument with space.pem'
+
+In order to support quoting, values are parsed by Python's ``shlex.split()`` like in
+:ref:`west-building-cmake-args`.
+
+The ``extra-args`` are passed directly to the ``rimage`` command. The example
+above has the same effect as appending them on command line after ``--`` like this:
+``west sign --tool rimage -- -i 4 -k 'keys/key argument with space.pem'``. In case
+both are used, the command-line arguments go last.
+
+.. _rimage:
+   https://github.com/thesofproject/rimage

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -422,11 +422,15 @@ class RimageSigner(Signer):
     def sign(self, command, build_dir, build_conf, formats):
         args = command.args
 
-        if args.tool_path:
-            command.check_force(shutil.which(args.tool_path),
-                                '--tool-path {}: not an executable'.
-                                format(args.tool_path))
-            tool_path = args.tool_path
+        tool_path = (
+            args.tool_path if args.tool_path else
+            config_get(command.config, 'rimage.path', None)
+        )
+        err_prefix = '--tool-path' if args.tool_path else 'west config'
+
+        if tool_path:
+            command.check_force(shutil.which(tool_path),
+                                f'{err_prefix} {tool_path}: not an executable')
         else:
             tool_path = shutil.which('rimage')
             if not tool_path:

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -466,27 +466,21 @@ class RimageSigner(Signer):
         except ValueError: # sof is the manifest
             sof_src_dir = pathlib.Path(manifest.manifest_path()).parent
 
-        conf_path_cmd = []
-
         if '-c' in args.tool_args:
-            # Precedence to the -- rimage command line
-            conf_path_cmd = []
+            # Precedence to the arguments passed after '--': west sign ...  -- -c ...
             if args.tool_data:
-                log.wrn('--tool-data ' + args.tool_data + ' ignored, overridden by -c')
-            # For logging only
-            conf_path = args.tool_args[args.tool_args.index('-c') + 1]
+                log.wrn('--tool-data ' + args.tool_data + ' ignored, overridden by: -- -c ... ')
+            conf_dir = None
         elif args.tool_data:
             conf_dir = pathlib.Path(args.tool_data)
-            conf_path = str(conf_dir / cmake_toml)
-            conf_path_cmd = ['-c', conf_path]
         elif cache.get('RIMAGE_CONFIG_PATH'):
-            rimage_conf = pathlib.Path(cache['RIMAGE_CONFIG_PATH'])
-            conf_path = str(rimage_conf / cmake_toml)
-            conf_path_cmd = ['-c', conf_path]
+            conf_dir = pathlib.Path(cache['RIMAGE_CONFIG_PATH'])
         else:
             conf_dir = sof_src_dir / 'rimage' / 'config'
 
-        log.inf('Signing for SOC target ' + target + ' using ' + conf_path)
+        conf_path_cmd = ['-c', str(conf_dir / cmake_toml)] if conf_dir else []
+
+        log.inf('Signing for SOC target ' + target)
 
         # FIXME: deprecate --no-manifest and replace it with a much
         # simpler and more direct `-- -e` which the user can _already_

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -127,7 +127,6 @@ class Sign(Forceable):
         # general options
         group = parser.add_argument_group('tool control options')
         group.add_argument('-t', '--tool', choices=['imgtool', 'rimage'],
-                           required=True,
                            help='''image signing tool name; imgtool and rimage
                            are currently supported''')
         group.add_argument('-p', '--tool-path', default=None,
@@ -175,6 +174,9 @@ class Sign(Forceable):
                          'directory'.format(build_dir))
         build_conf = BuildConfiguration(build_dir)
 
+        if not args.tool:
+            args.tool = config_get(self.config, 'sign.tool')
+
         # Decide on output formats.
         formats = []
         bin_exists = build_conf.getboolean('CONFIG_BUILD_OUTPUT_BIN')
@@ -204,7 +206,10 @@ class Sign(Forceable):
             signer = RimageSigner()
         # (Add support for other signers here in elif blocks)
         else:
-            raise RuntimeError("can't happen")
+            if args.tool is None:
+                log.die('one --tool is required')
+            else:
+                log.die(f'invalid tool: {args.tool}')
 
         signer.sign(self, build_dir, build_conf, formats)
 

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -9,6 +9,7 @@ import pathlib
 import pickle
 import platform
 import shutil
+import shlex
 import subprocess
 import sys
 
@@ -70,7 +71,28 @@ directory:
    west sign -t rimage -- -k YOUR_SIGNING_KEY.pem
 
 For this to work, either rimage must be installed or you must pass
-the path to rimage using the -p option.'''
+the path to rimage using the -p option.
+
+You can also pass additional arguments to rimage thanks to [sign] and
+[rimage] sections in your west config file(s); this is especially useful
+when invoking west sign _indirectly_ through CMake/ninja. See how at
+https://docs.zephyrproject.org/latest/develop/west/sign.html
+'''
+
+
+def config_get_words(west_config, section_key, fallback=None):
+    unparsed = west_config.get(section_key)
+    log.dbg(f'west config {section_key}={unparsed}')
+    return fallback if unparsed is None else shlex.split(unparsed)
+
+
+def config_get(west_config, section_key, fallback=None):
+    words = config_get_words(west_config, section_key)
+    if words is None:
+        return fallback
+    if len(words) != 1:
+        log.die(f'Single word expected for: {section_key}={words}. Use quotes?')
+    return words[0]
 
 
 class ToggleAction(argparse.Action):

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -442,6 +442,11 @@ class RimageSigner(Signer):
             out_xman = str(b / 'zephyr' / 'zephyr.ri.xman')
             out_tmp = str(b / 'zephyr' / 'zephyr.rix')
 
+        # Clean any stale output. This is especially important when using --if-tool-available
+        # (but not just)
+        for o in [ out_bin, out_xman, out_tmp ]:
+            pathlib.Path(o).unlink(missing_ok=True)
+
         tool_path = (
             args.tool_path if args.tool_path else
             config_get(command.config, 'rimage.path', None)

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -508,9 +508,18 @@ class RimageSigner(Signer):
 
         components = [ ] if (target in ('imx8', 'imx8m')) else [ bootloader ]
         components += [ kernel ]
-        sign_base += (args.tool_args +
-                     ['-o', out_bin] + conf_path_cmd + extra_ri_args +
-                     components)
+
+        sign_config_extra_args = config_get_words(command.config, 'rimage.extra-args', [])
+
+        if '-k' not in sign_config_extra_args + args.tool_args:
+            cmake_default_key = cache.get('RIMAGE_SIGN_KEY')
+            extra_ri_args += [ '-k', str(sof_src_dir / 'keys' / cmake_default_key) ]
+
+        # Warning: while not officially supported (yet?), the rimage --option that is last
+        # on the command line currently wins in case of duplicate options. So pay
+        # attention to the _args order below.
+        sign_base += (['-o', out_bin] + sign_config_extra_args + conf_path_cmd +
+                      extra_ri_args + args.tool_args + components)
 
         if not args.quiet:
             log.inf(quote_sh_list(sign_base))

--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -118,3 +118,22 @@ add_custom_command(
             $<TARGET_PROPERTY:bintools,strip_flag_final>
 )
 endif()
+
+
+#  west sign
+add_custom_target(zephyr.ri ALL
+  DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
+)
+
+add_custom_command(
+  OUTPUT ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
+  COMMENT "west sign --if-tool-available --tool rimage ..."
+  # Use --if-tool-available so we don't force every CI to install
+  # rimage. We don't want to break build-only and other tests that don't
+  # require signing. When rimage is missing, `west flash` fails with a
+  # clear "zephyr.ri missing" error with an "rimage not found" warning
+  # from west sign immediately before it.
+  COMMAND  west sign --if-tool-available --tool rimage --build-dir ${CMAKE_BINARY_DIR}
+  DEPENDS gen_modules
+          ${CMAKE_BINARY_DIR}/zephyr/boot.mod ${CMAKE_BINARY_DIR}/zephyr/main.mod
+)


### PR DESCRIPTION
Invoking `west sign` in `west build` accelerates twister because `west
build` is run in parallel, see rationale in superseded and very different (CMake-based) PR #52942
- https://github.com/zephyrproject-rtos/zephyr/pull/52942.

To maximize backwards compatibility:
- `west sign` is optional in `west build`
- `west flash` will sign (again) if any rimage --option is passed

This PR started with "v3", v1 and v2 happened in #54189. v3 is significantly smaller and simpler than v2

Should fix https://github.com/thesofproject/sof/issues/6917

Unlike https://github.com/zephyrproject-rtos/zephyr/pull/52942, this moves the rimage configuration logic not to CMake but to `west sign` configuration instead.

You should read and understand #52942 before looking at this.

Also take a look at https://github.com/thesofproject/sof/issues/6917

Signed-off-by: Marc Herbert <marc.herbert@intel.com>

cc:
- https://github.com/zephyrproject-rtos/west/issues/429