### PR TITLE
shell: backend: Set RX size default to 256 if shell MCUmgr is enabled

### DIFF
--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -57,6 +57,7 @@ config SHELL_BACKEND_SERIAL_TX_RING_BUFFER_SIZE
 
 config SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE
 	int "Set RX ring buffer size"
+	default 256 if MCUMGR_TRANSPORT_SHELL
 	default 64
 	help
 	  RX ring buffer size impacts accepted latency of handling incoming


### PR DESCRIPTION
This fixes an issue whereby when USB CDC is used for receiving MCUmgr commands, the commands are corrupted, invalid or messed up by increasing the receive buffer size so that it can handle at least 1 full MCUmgr fragment.

Fixes #53227