### PR TITLE
doc: release-notes 3.3: Add MCUmgr shell buffer size change

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -1121,6 +1121,11 @@ Libraries / Subsystems
     ``printk()`` calls to the logging system, For user applications,
     :kconfig:option:`CONFIG_LOG_PRINTK` should be enabled to include this fix.
 
+  * A bug when MCUmgr shell transport is used (issue was observed over USB CDC
+    but could also occur with UART) whereby the default shell receive ring
+    buffer is insufficient has been fixed by making the default size 256 bytes
+    instead of 64 when the shell MCUmgr transport is selected.
+
 * LwM2M
 
   * The ``lwm2m_senml_cbor_*`` files have been regenerated using zcbor 0.6.0.


### PR DESCRIPTION
Adds details on a bug for for the shell RX ring buffer receive size being made larger when the shell MCUmgr transport is selected, to fix an issue whereby commands were corrupt.

Needs https://github.com/zephyrproject-rtos/zephyr/pull/54704 to be merged