### PR TITLE
Bluetooth: tests: Add tests for Bluetooth privacy

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/CMakeLists.txt
+++ b/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/CMakeLists.txt
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
+  message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set  \
+          the  environment variable BSIM_COMPONENTS_PATH to point to its       \
+          components folder. More information can be found in                  \
+          https://babblesim.github.io/folder_structure_and_env.html")
+endif()
+
+find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+project(bsim_test_privacy)
+
+target_sources(app PRIVATE
+  src/test_undirected_main.c
+  src/test_undirected_central.c
+  src/test_undirected_peripheral.c
+)
+
+zephyr_include_directories(
+  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/
+)

--- a/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/README.rst
+++ b/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/README.rst
@@ -1,0 +1,18 @@
+.. _bsim_test_bt_privacy:
+
+Privacy feature test
+********************
+
+Tests goals
+===========
+
+The tests check the following aspects of the Bluetooth privacy feature:
+
+* In device privacy mode, a scanner shall accept advertising packets from peers with any address
+  type. That, even if they have previously exchanged IRK; (Core Specification version 5.4, vol. 1
+  part A, 5.4.5.)
+* After devices have exchanged IRK, they must correctly resolve RPA when receiving packets from the
+  peer.
+
+For references, see the Bluetooth Core specification version 5.4, vol. 1, part A, 5.4.5 and vol. 6,
+part B, 6.

--- a/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/prj.conf
+++ b/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/prj.conf
@@ -1,0 +1,15 @@
+CONFIG_BT=y
+CONFIG_BT_CENTRAL=y
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_DEVICE_NAME="Privacy feature test"
+
+CONFIG_BT_SMP=y
+CONFIG_BT_PRIVACY=y
+CONFIG_BT_EXT_ADV=y
+
+CONFIG_LOG=y
+
+# Increase the maximum number of buffers for advertising data to be able to set the scanning data
+# CONFIG_BT_CTLR_ADVANCED_FEATURES is needed to enable CONFIG_BT_CTLR_ADV_DATA_BUF_MAX
+CONFIG_BT_CTLR_ADV_DATA_BUF_MAX=2
+CONFIG_BT_CTLR_ADVANCED_FEATURES=y

--- a/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/src/test_undirected_central.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/src/test_undirected_central.c
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/kernel.h>
+
+#include <zephyr/sys/printk.h>
+
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/bluetooth.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(bt_bsim_privacy, LOG_LEVEL_INF);
+
+#include "bs_types.h"
+#include "bs_tracing.h"
+#include "bstests.h"
+#include "bs_cmd_line.h"
+
+#define CREATE_FLAG(flag) static atomic_t flag = (atomic_t) false
+#define SET_FLAG(flag)	  (void)atomic_set(&flag, (atomic_t) true)
+#define GET_FLAG(flag)	  (bool)atomic_get(&flag)
+#define UNSET_FLAG(flag)  (void)atomic_set(&flag, (atomic_t) false)
+#define WAIT_FOR_FLAG(flag)                                                                        \
+	while (!(bool)atomic_get(&flag)) {                                                         \
+		(void)k_sleep(K_MSEC(1));                                                          \
+	}
+
+#define FAIL(...)                                                                                  \
+	do {                                                                                       \
+		bst_result = Failed;                                                               \
+		bs_trace_error_time_line(__VA_ARGS__);                                             \
+	} while (0)
+
+#define PASS(...)                                                                                  \
+	do {                                                                                       \
+		bst_result = Passed;                                                               \
+		bs_trace_info_time(1, __VA_ARGS__);                                                \
+	} while (0)
+
+extern enum bst_result_t bst_result;
+
+CREATE_FLAG(paired);
+CREATE_FLAG(rpa_tested);
+CREATE_FLAG(identity_tested);
+
+static void start_scan(void);
+
+static struct bt_conn *default_conn;
+
+static bt_addr_le_t peer_rpa;
+static bt_addr_le_t peer_identity;
+
+enum addr_type_t {
+	RPA,
+	IDENTITY_ADDR,
+};
+static enum addr_type_t test_addr_type;
+
+static bool use_active_scan;
+static bool connection_test;
+
+static int sim_id;
+
+void central_test_args_parse(int argc, char *argv[])
+{
+	char *addr_type_arg = NULL;
+
+	bs_args_struct_t args_struct[] = {
+		{
+			.dest = &sim_id,
+			.type = 'i',
+			.name = "{positive integer}",
+			.option = "sim-id",
+			.descript = "Simulation ID counter",
+		},
+		{
+			.dest = &addr_type_arg,
+			.type = 's',
+			.name = "{identity, rpa}",
+			.option = "addr-type",
+			.descript = "Address type to test",
+		},
+		{
+			.dest = &use_active_scan,
+			.type = 's',
+			.name = "{0, 1}",
+			.option = "active-scan",
+			.descript = "",
+		},
+		{
+			.dest = &connection_test,
+			.type = 'b',
+			.name = "{0, 1}",
+			.option = "connection-test",
+			.descript = "",
+		},
+	};
+
+	bs_args_parse_all_cmd_line(argc, argv, args_struct);
+
+	if (addr_type_arg != NULL) {
+		if (!strcmp(addr_type_arg, "identity")) {
+			test_addr_type = IDENTITY_ADDR;
+		} else if (!strcmp(addr_type_arg, "rpa")) {
+			test_addr_type = RPA;
+		}
+	}
+}
+
+static void wait_check_result(void)
+{
+	if (test_addr_type == IDENTITY_ADDR) {
+		WAIT_FOR_FLAG(identity_tested);
+		LOG_INF("Identity address tested");
+	} else if (test_addr_type == RPA) {
+		WAIT_FOR_FLAG(rpa_tested);
+		LOG_INF("Resolvable Private Address tested");
+	}
+}
+
+static void check_addresses(const bt_addr_le_t *peer_addr)
+{
+	LOG_DBG("Check addresses");
+
+	bool addr_equal;
+
+	if (test_addr_type == IDENTITY_ADDR) {
+		SET_FLAG(identity_tested);
+		addr_equal = bt_addr_le_eq(&peer_identity, peer_addr);
+		if (!addr_equal) {
+			FAIL("The peer address is not the same as the peer previously paired.\n");
+		}
+	} else if (test_addr_type == RPA) {
+		SET_FLAG(rpa_tested);
+		addr_equal = bt_addr_le_eq(&peer_identity, peer_addr);
+		if (!addr_equal) {
+			FAIL("The resolved address is not the same as the peer previously "
+			     "paired.\n");
+		}
+	}
+}
+
+static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
+			 struct net_buf_simple *ad)
+{
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	int err;
+
+	if (default_conn) {
+		return;
+	}
+
+	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	LOG_DBG("Device found: %s (RSSI %d)", addr_str, rssi);
+
+	if (GET_FLAG(paired)) {
+		check_addresses(addr);
+	}
+
+	if (connection_test || !GET_FLAG(paired)) {
+		if (bt_le_scan_stop()) {
+			LOG_DBG("Failed to stop scanner");
+			return;
+		}
+		LOG_DBG("Scanner stopped");
+
+		err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN, BT_LE_CONN_PARAM_DEFAULT,
+					&default_conn);
+		if (err) {
+			LOG_DBG("Create conn to %s failed (%u)", addr_str, err);
+			start_scan();
+		}
+	}
+}
+
+static void start_scan(void)
+{
+	int err;
+
+	LOG_DBG("Using %s scan", use_active_scan ? "active" : "passive");
+
+	err = bt_le_scan_start(use_active_scan ? BT_LE_SCAN_ACTIVE : BT_LE_SCAN_PASSIVE,
+			       device_found);
+	if (err) {
+		FAIL("Scanning failed to start (err %d)\n", err);
+	}
+
+	LOG_DBG("Scanning successfully started");
+}
+
+static void connected(struct bt_conn *conn, uint8_t err)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	LOG_DBG("Connected: %s", addr);
+}
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	if (conn != default_conn) {
+		return;
+	}
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	LOG_DBG("Disconnected: %s (reason 0x%02x)", addr, reason);
+
+	bt_conn_unref(default_conn);
+	default_conn = NULL;
+
+	start_scan();
+}
+
+static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
+			      const bt_addr_le_t *identity)
+{
+	char addr_identity[BT_ADDR_LE_STR_LEN];
+	char addr_rpa[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
+	bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
+
+	LOG_DBG("Identity resolved %s -> %s", addr_rpa, addr_identity);
+
+	bt_addr_le_copy(&peer_rpa, rpa);
+	bt_addr_le_copy(&peer_identity, identity);
+
+	SET_FLAG(paired);
+}
+
+static struct bt_conn_cb central_cb;
+
+void test_central(void)
+{
+	LOG_DBG("Central device");
+
+	int err;
+
+	central_cb.connected = connected;
+	central_cb.disconnected = disconnected;
+	central_cb.identity_resolved = identity_resolved;
+
+	bt_conn_cb_register(&central_cb);
+
+	err = bt_enable(NULL);
+	if (err) {
+		FAIL("Bluetooth init failed (err %d)\n", err);
+	}
+
+	start_scan();
+
+	wait_check_result();
+}
+
+void test_central_main(void)
+{
+	test_central();
+
+	char *addr_tested = "";
+
+	if (test_addr_type == RPA) {
+		addr_tested = "RPA";
+	} else if (test_addr_type == IDENTITY_ADDR) {
+		addr_tested = "identity address";
+	}
+
+	PASS("Central test passed (id: %d; params: %s scan, %sconnectable test, testing %s)\n",
+	     sim_id, use_active_scan ? "active" : "passive", connection_test ? "" : "non-",
+	     addr_tested);
+}

--- a/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/src/test_undirected_main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/src/test_undirected_main.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/kernel.h>
+
+#include <zephyr/sys/printk.h>
+
+#include "bs_types.h"
+#include "bs_tracing.h"
+#include "bstests.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(bt_bsim_privacy, LOG_LEVEL_INF);
+
+extern enum bst_result_t bst_result;
+
+#define WAIT_TIME_S 20
+#define WAIT_TIME   (WAIT_TIME_S * 1e6) /* 20 seconds */
+
+extern void central_test_args_parse(int argc, char *argv[]);
+extern void peripheral_test_args_parse(int argc, char *argv[]);
+
+extern void test_central_main(void);
+extern void test_peripheral(void);
+
+void sim_timeout(bs_time_t HW_device_time)
+{
+	if (bst_result != Passed) {
+		bst_result = Failed;
+		bs_trace_error_time_line("Test failed (not passed after %d seconds)\n",
+					 WAIT_TIME_S);
+	}
+}
+
+static void test_privacy_init(void)
+{
+	bst_ticker_set_next_tick_absolute(WAIT_TIME);
+	bst_result = In_progress;
+}
+
+static const struct bst_test_instance test_def[] = {
+	{
+		.test_id = "central",
+		.test_descr = "Central device",
+		.test_post_init_f = test_privacy_init,
+		.test_tick_f = sim_timeout,
+		.test_main_f = test_central_main,
+		.test_args_f = central_test_args_parse,
+	},
+	{
+		.test_id = "peripheral",
+		.test_descr = "Peripheral device",
+		.test_post_init_f = test_privacy_init,
+		.test_tick_f = sim_timeout,
+		.test_main_f = test_peripheral,
+		.test_args_f = peripheral_test_args_parse,
+	},
+	BSTEST_END_MARKER};
+
+struct bst_test_list *test_privacy_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_def);
+}
+
+bst_test_install_t test_installers[] = {test_privacy_install, NULL};
+
+void main(void)
+{
+	bst_main();
+}

--- a/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/src/test_undirected_peripheral.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/src/test_undirected_peripheral.c
@@ -1,0 +1,455 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <zephyr/kernel.h>
+
+#include <zephyr/sys/printk.h>
+
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(bt_bsim_privacy, LOG_LEVEL_INF);
+
+#include "bs_types.h"
+#include "bs_tracing.h"
+#include "bstests.h"
+#include "bs_cmd_line.h"
+
+#define FAIL(...)                                                                                  \
+	do {                                                                                       \
+		bst_result = Failed;                                                               \
+		bs_trace_error_time_line(__VA_ARGS__);                                             \
+	} while (0)
+
+#define PASS(...)                                                                                  \
+	do {                                                                                       \
+		bst_result = Passed;                                                               \
+		bs_trace_info_time(1, __VA_ARGS__);                                                \
+	} while (0)
+
+extern enum bst_result_t bst_result;
+
+#define CREATE_FLAG(flag) static atomic_t flag = (atomic_t) false
+#define SET_FLAG(flag)	  (void)atomic_set(&flag, (atomic_t) true)
+#define GET_FLAG(flag)	  (bool)atomic_get(&flag)
+#define UNSET_FLAG(flag)  (void)atomic_set(&flag, (atomic_t) false)
+#define WAIT_FOR_FLAG(flag)                                                                        \
+	while (!(bool)atomic_get(&flag)) {                                                         \
+		(void)k_sleep(K_MSEC(1));                                                          \
+	}
+
+CREATE_FLAG(paired_flag);
+CREATE_FLAG(connected_flag);
+CREATE_FLAG(wait_disconnection);
+CREATE_FLAG(wait_scanned);
+
+static struct bt_conn *default_conn;
+
+enum adv_param_t {
+	CONN_SCAN,
+	CONN_NSCAN,
+	NCONN_SCAN,
+	NCONN_NSCAN,
+};
+
+enum addr_type_t {
+	RPA,
+	IDENTITY_ADDR,
+};
+
+static enum addr_type_t test_addr_type;
+
+static bool use_ext_adv;
+
+static bool scannable_test;
+static bool connectable_test;
+static enum adv_param_t adv_param;
+
+static int sim_id;
+
+void peripheral_test_args_parse(int argc, char *argv[])
+{
+	char *addr_type_arg = NULL;
+
+	bs_args_struct_t args_struct[] = {
+		{
+			.dest = &sim_id,
+			.type = 'i',
+			.name = "{positive integer}",
+			.option = "sim-id",
+			.descript = "Simulation ID counter",
+		},
+		{
+			.dest = &addr_type_arg,
+			.type = 's',
+			.name = "{identity, rsa}",
+			.option = "addr-type",
+			.descript = "Address type to test",
+		},
+		{
+			.dest = &use_ext_adv,
+			.type = 'b',
+			.name = "{0, 1}",
+			.option = "use-ext-adv",
+			.descript = "Use Extended Advertising",
+		},
+		{
+			.dest = &scannable_test,
+			.type = 'b',
+			.name = "{0, 1}",
+			.option = "scannable",
+			.descript = "Use a scannable advertiser for the test",
+		},
+		{
+			.dest = &connectable_test,
+			.type = 'b',
+			.name = "{0, 1}",
+			.option = "connectable",
+			.descript = "Use a connectable advertiser for the test",
+		},
+	};
+
+	bs_args_parse_all_cmd_line(argc, argv, args_struct);
+
+	if (addr_type_arg != NULL) {
+		if (!strcmp(addr_type_arg, "identity")) {
+			test_addr_type = IDENTITY_ADDR;
+		} else if (!strcmp(addr_type_arg, "rpa")) {
+			test_addr_type = RPA;
+		}
+	}
+
+	if (connectable_test && scannable_test) {
+		if (!use_ext_adv) {
+			adv_param = CONN_SCAN;
+		}
+	} else if (connectable_test) {
+		adv_param = CONN_NSCAN;
+	} else if (scannable_test) {
+		adv_param = NCONN_SCAN;
+	} else {
+		adv_param = NCONN_NSCAN;
+	}
+}
+
+static void wait_for_scanned(void)
+{
+	LOG_DBG("Waiting for scan request");
+	WAIT_FOR_FLAG(wait_scanned);
+	UNSET_FLAG(wait_scanned);
+}
+
+static void adv_scanned_cb(struct bt_le_ext_adv *adv, struct bt_le_ext_adv_scanned_info *info)
+{
+	LOG_DBG("Scan request received");
+	SET_FLAG(wait_scanned);
+}
+
+static struct bt_le_ext_adv_cb adv_cb = {
+	.scanned = adv_scanned_cb,
+};
+
+static void create_adv(struct bt_le_ext_adv **adv)
+{
+	int err;
+	struct bt_le_adv_param params;
+
+	memset(&params, 0, sizeof(struct bt_le_adv_param));
+
+	params.options |= BT_LE_ADV_OPT_CONNECTABLE;
+
+	params.id = BT_ID_DEFAULT;
+	params.sid = 0;
+	params.interval_min = BT_GAP_ADV_SLOW_INT_MIN;
+	params.interval_max = BT_GAP_ADV_SLOW_INT_MAX;
+
+	err = bt_le_ext_adv_create(&params, &adv_cb, adv);
+	if (err) {
+		LOG_ERR("Failed to create advertiser (%d)", err);
+		return;
+	}
+
+	LOG_DBG("Advertiser created");
+}
+
+static void update_adv_params(struct bt_le_ext_adv *adv, enum adv_param_t adv_params,
+			      enum addr_type_t addr_type)
+{
+	int err;
+	struct bt_le_adv_param params;
+
+	memset(&params, 0, sizeof(struct bt_le_adv_param));
+
+	if (adv_params == CONN_SCAN) {
+		params.options |= BT_LE_ADV_OPT_CONNECTABLE;
+		params.options |= BT_LE_ADV_OPT_SCANNABLE;
+		LOG_DBG("Advertiser params: CONN_SCAN");
+	} else if (adv_params == CONN_NSCAN) {
+		params.options |= BT_LE_ADV_OPT_CONNECTABLE;
+		LOG_DBG("Advertiser params: CONN_NSCAN");
+	} else if (adv_params == NCONN_SCAN) {
+		params.options |= BT_LE_ADV_OPT_SCANNABLE;
+		LOG_DBG("Advertiser params: NCONN_SCAN");
+	} else if (adv_params == NCONN_NSCAN) {
+		LOG_DBG("Advertiser params: NCONN_NSCAN");
+	}
+
+	if (use_ext_adv) {
+		params.options |= BT_LE_ADV_OPT_EXT_ADV;
+		LOG_DBG("Advertiser params: EXT_ADV");
+		params.options |= BT_LE_ADV_OPT_NOTIFY_SCAN_REQ;
+		LOG_DBG("Advertiser params: NOTIFY_SCAN_REQ");
+	} else {
+		LOG_DBG("Advertiser params: LEGACY_ADV");
+	}
+
+	if (addr_type == IDENTITY_ADDR) {
+		LOG_DBG("Advertiser params: USE_IDENTITY");
+		params.options |= BT_LE_ADV_OPT_USE_IDENTITY;
+	} else if (addr_type == RPA) {
+		LOG_DBG("Advertiser params: USE_RPA");
+	}
+
+	params.id = BT_ID_DEFAULT;
+	params.sid = 0;
+	params.interval_min = BT_GAP_ADV_SLOW_INT_MIN;
+	params.interval_max = BT_GAP_ADV_SLOW_INT_MAX;
+
+	err = bt_le_ext_adv_update_param(adv, &params);
+	if (err) {
+		LOG_ERR("Failed to update advertiser set (%d)", err);
+		return;
+	}
+
+	if (use_ext_adv && adv_params == NCONN_SCAN) {
+		uint8_t data[4] = {0x61, 0x6c, 0x65, 0x64};
+		struct bt_data sd;
+		size_t sd_len = 1;
+
+		sd.type = 0x09;
+		sd.data_len = 0x05;
+		sd.data = data;
+
+		err = bt_le_ext_adv_set_data(adv, NULL, 0, &sd, sd_len);
+		if (err) {
+			LOG_ERR("Failed to set advertising data (%d)", err);
+		}
+
+		LOG_DBG("Advertiser data set");
+	}
+
+	LOG_DBG("Advertiser params updated");
+}
+
+static void start_adv(struct bt_le_ext_adv *adv)
+{
+	int err;
+	int32_t timeout = 0;
+	uint8_t num_events = 0;
+
+	struct bt_le_ext_adv_start_param start_params;
+
+	start_params.timeout = timeout;
+	start_params.num_events = num_events;
+
+	err = bt_le_ext_adv_start(adv, &start_params);
+
+	if (err) {
+		LOG_ERR("Failed to start advertiser (%d)", err);
+		return;
+	}
+
+	LOG_DBG("Advertiser started");
+}
+
+static void stop_adv(struct bt_le_ext_adv *adv)
+{
+	int err;
+
+	err = bt_le_ext_adv_stop(adv);
+	if (err) {
+		LOG_WRN("Failed to stop advertiser (%d)", err);
+		return;
+	}
+
+	LOG_DBG("Advertiser stopped");
+}
+
+static void disconnect(void)
+{
+	LOG_DBG("Starting disconnection");
+	int err;
+
+	err = bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	if (err) {
+		FAIL("Disconnection failed (err %d)\n", err);
+	}
+
+	WAIT_FOR_FLAG(wait_disconnection);
+	UNSET_FLAG(wait_disconnection);
+}
+
+static void wait_for_connection(void)
+{
+	WAIT_FOR_FLAG(connected_flag);
+	UNSET_FLAG(connected_flag);
+}
+
+static void connected(struct bt_conn *conn, uint8_t err)
+{
+	LOG_DBG("Peripheral Connected function");
+
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	if (err) {
+		LOG_WRN("Failed to connect to %s (%u)", addr, err);
+		return;
+	}
+
+	LOG_DBG("Connected: %s", addr);
+
+	default_conn = bt_conn_ref(conn);
+
+	if (!GET_FLAG(paired_flag)) {
+		if (bt_conn_set_security(conn, BT_SECURITY_L2)) {
+			FAIL("Failed to set security\n");
+		}
+	} else {
+		SET_FLAG(connected_flag);
+	}
+}
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	if (conn != default_conn) {
+		return;
+	}
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	LOG_DBG("Disconnected: %s (reason 0x%02x)", addr, reason);
+
+	bt_conn_unref(default_conn);
+	default_conn = NULL;
+
+	LOG_DBG("Disconnected");
+	SET_FLAG(wait_disconnection);
+}
+
+static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
+			      const bt_addr_le_t *identity)
+{
+	char addr_identity[BT_ADDR_LE_STR_LEN];
+	char addr_rpa[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
+	bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
+
+	LOG_DBG("Identity resolved %s -> %s", addr_rpa, addr_identity);
+}
+
+static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	if (!err) {
+		LOG_DBG("Security changed: %s level %u", addr, level);
+	} else {
+		LOG_ERR("Security failed: %s level %u err %d", addr, level);
+	}
+}
+
+static void pairing_complete(struct bt_conn *conn, bool bonded)
+{
+	LOG_DBG("Pairing complete");
+	SET_FLAG(paired_flag);
+}
+
+static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
+{
+	LOG_WRN("Pairing failed (%d). Disconnecting.", reason);
+	bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
+}
+
+static struct bt_conn_cb peri_cb;
+
+static struct bt_conn_auth_info_cb auth_cb_info = {
+	.pairing_complete = pairing_complete,
+	.pairing_failed = pairing_failed,
+};
+
+static void test_peripheral_main(void)
+{
+	LOG_DBG("Peripheral device");
+
+	int err;
+	struct bt_le_ext_adv *adv = NULL;
+
+	peri_cb.connected = connected;
+	peri_cb.disconnected = disconnected;
+	peri_cb.security_changed = security_changed;
+	peri_cb.identity_resolved = identity_resolved;
+
+	bt_conn_cb_register(&peri_cb);
+
+	err = bt_enable(NULL);
+	if (err) {
+		FAIL("Bluetooth init failed (err %d)\n", err);
+	}
+
+	LOG_DBG("Bluetooth initialized");
+
+	bt_conn_auth_info_cb_register(&auth_cb_info);
+
+	create_adv(&adv);
+
+	update_adv_params(adv, CONN_NSCAN, RPA);
+	start_adv(adv);
+	WAIT_FOR_FLAG(paired_flag);
+	disconnect();
+	stop_adv(adv);
+
+	update_adv_params(adv, adv_param, test_addr_type);
+	start_adv(adv);
+	/* (the connection with identity should fail with privacy network mode) */
+	if (connectable_test) {
+		wait_for_connection();
+		disconnect();
+	} else if (scannable_test && use_ext_adv) {
+		wait_for_scanned();
+	}
+	stop_adv(adv);
+}
+
+void test_peripheral(void)
+{
+	test_peripheral_main();
+
+	char *addr_tested = "";
+
+	if (test_addr_type == RPA) {
+		addr_tested = "RPA";
+	} else if (test_addr_type == IDENTITY_ADDR) {
+		addr_tested = "identity address";
+	}
+
+	PASS("Peripheral test passed (id: %d; %s advertiser, %sconnectable %sscannable, testing)\n",
+	     sim_id, use_ext_adv ? "extended" : "legacy", connectable_test ? "" : "non-",
+	     scannable_test ? "" : "non-", addr_tested);
+}

--- a/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/test_scripts/_compile.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/test_scripts/_compile.sh
@@ -1,0 +1,11 @@
+#!/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+
+source "${bash_source_dir}/_env.sh"
+
+west build -b nrf52_bsim && \
+        cp -v build/zephyr/zephyr.exe "${test_exe}"

--- a/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/test_scripts/_env.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/test_scripts/_env.sh
@@ -1,0 +1,15 @@
+#!/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+
+: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+
+test_name="$(basename "$(realpath "$bash_source_dir/..")")"
+bsim_bin="${BSIM_OUT_PATH}/bin"
+verbosity_level=2
+BOARD="${BOARD:-nrf52_bsim}"
+simulation_id="$test_name"
+test_exe="${bsim_bin}/bs_${BOARD}_tests_bluetooth_bsim_bt_${test_name}_prj_conf"

--- a/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/test_scripts/run_tests.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_bt_privacy/test_scripts/run_tests.sh
@@ -1,0 +1,85 @@
+#!/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+
+# Read variable definitions output by _env.sh
+source "${bash_source_dir}/_env.sh"
+
+process_ids=""
+exit_code=0
+
+function Execute() {
+    if [ ! -f $1 ]; then
+        echo -e "  \e[91m$(pwd)/$(basename $1) cannot be found (did you forget to\
+ compile it?)\e[39m"
+        exit 1
+    fi
+    timeout 30 $@ &
+    process_ids="$process_ids $!"
+}
+
+: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+
+cd ${BSIM_OUT_PATH}/bin
+
+TEST_ARGS=(
+    "leg_conn_scan_active"
+    "leg_conn_nscan_passive"
+    "ext_nconn_scan_active"
+    "ext_conn_nscan_passive"
+)
+TEST_ADDR_TYPE=("identity" "rpa")
+
+sim_id_count=0
+for args in ${TEST_ARGS[@]}; do
+    args=($(echo "${args}" | sed 's/_/ /g'))
+
+    use_ext_adv=0
+    if [ "${args[0]}" == "ext" ]; then
+        use_ext_adv=1
+    fi
+
+    connectable=0
+    if [ "${args[1]}" == "conn" ]; then
+        connectable=1
+    fi
+
+    scannable=0
+    if [ "${args[2]}" == "scan" ]; then
+        scannable=1
+    fi
+
+    use_active_scan=0
+    if [ "${args[3]}" == "active" ]; then
+        use_active_scan=1
+    fi
+
+    for addr_type in "${TEST_ADDR_TYPE[@]}"; do
+        Execute "$test_exe" \
+            -v=${verbosity_level} -s="${simulation_id}_${sim_id_count}" -d=0 -testid=central \
+            -RealEncryption=1 -argstest sim-id=${sim_id_count} connection-test=${connectable} \
+            active-scan=${use_active_scan} addr-type="${addr_type}"
+
+        Execute "$test_exe" \
+            -v=${verbosity_level} -s="${simulation_id}_${sim_id_count}" -d=1 -testid=peripheral \
+            -RealEncryption=1 -argstest sim-id=${sim_id_count} addr-type="${addr_type}" \
+            use-ext-adv=${use_ext_adv} scannable=${scannable} connectable=${connectable}
+
+        Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s="${simulation_id}_${sim_id_count}" \
+            -D=2 -sim_length=60e6 $@
+
+        sim_id_count=$(( sim_id_count + 1 ))
+    done
+done
+
+for process_id in $process_ids; do
+    wait $process_id || let "exit_code=$?"
+    if [ ${exit_code} -ne 0 ]; then
+        exit_code=1
+    fi
+done
+
+exit $exit_code # the last exit code != 0

--- a/tests/bluetooth/bsim_bt/compile.sh
+++ b/tests/bluetooth/bsim_bt/compile.sh
@@ -69,5 +69,6 @@ app=tests/bluetooth/bsim_bt/bsim_test_mesh conf_overlay=overlay_gatt.conf compil
 app=tests/bluetooth/bsim_bt/bsim_test_disable compile &
 app=tests/bluetooth/bsim_bt/bsim_test_per_adv compile &
 app=tests/bluetooth/bsim_bt/bsim_test_per_adv conf_file=prj_long_data.conf compile &
+app=tests/bluetooth/bsim_bt/bsim_test_bt_privacy compile &
 
 wait


### PR DESCRIPTION
Add tests to check the following aspects of the Bluetooth privacy feature:

- On device privacy mode, scanner shall accept advertising packets from peer with any address type. That, even if they have previously exchanged IRK;
- After devices have exchanged IRK, they must correctly resolve RPA.