### PR TITLE
boards: arm: stm32f429i_disc1: Add missing byte to fix compilation

### DIFF
--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -137,7 +137,7 @@
 		timctrlb = [00 00];
 		pwseqctrl = [64 03 12 81];
 		pumpratioctrl = [20];
-		disctrl = [08 82 27];
+		disctrl = [08 82 27 04];
 		vmctrl1 = [45 15];
 		vmctrl2 = [90];
 		enable3g = [00];


### PR DESCRIPTION
Add a missing bytes in the configuration of ili9341 screen that causes a compilation issue. The value added is the default one defined in the ilitek,ili9341.yaml file.

Fixes #54556