### PR TITLE
tests: kernel: mem_protect: stackprot: Dont inline check_input

### DIFF
--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -60,7 +60,7 @@ void print_loop(const char *name)
  *
  */
 
-void check_input(const char *name, const char *input)
+void __attribute__((noinline)) check_input(const char *name, const char *input)
 {
 	/* Stack will overflow when input is more than 16 characters */
 	char buf[16];


### PR DESCRIPTION
When building with LLVM on qemu_x86 we see the compiler ends up inlining the check_input function.  This breaks the stack overflow that the test is trying to generate, so mark the check_input() function as noinline to fix the issue.

Signed-off-by: Kumar Gala <kumar.gala@intel.com>