### PR TITLE
driver: clock_control: fix stm32 pll freq calculation

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -73,8 +73,7 @@ static uint32_t get_pll_div_frequency(uint32_t pllsrc_freq,
 {
 	__ASSERT_NO_MSG(pllm_div && pllout_div);
 
-	return (pllsrc_freq * plln_mul) /
-		(pllm_div * pllout_div);
+	return pllsrc_freq / pllm_div * plln_mul / pllout_div;
 }
 
 static uint32_t get_bus_clock(uint32_t clock, uint32_t prescaler)


### PR DESCRIPTION
change stm32 pll frequency calculation to resolve uint32_t overflow.

The origin calculation cause an overflow.

For example, use a stm32f411ce
- HSE 25MHz
- PLLM 25
- PLLN 192
- PLLP 2
- PLLQ 4
such a configuration leads to 48MHz for USB.

<img width="825" alt="image" src="https://user-images.githubusercontent.com/37612226/218140524-65744c27-bf37-4d6c-9745-fe0990f9e86d.png">

```c
    uint32_t pllsrc_freq = 25000000;
    int pllm_div = 25;
    int plln_mul = 192;
    int pllout_div = 4;
    
    uint32_t origin_result = (pllsrc_freq * plln_mul) / (pllm_div * pllout_div); // 5050327
    uint32_t new_result = pllsrc_freq / pllm_div * plln_mul / pllout_div;        // 48000000
```

Fixes #54719