### PR TITLE
Fixed struct Device order initialization for c++ compatibility

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -855,10 +855,10 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 #define Z_DEVICE_INIT(name_, pm_, data_, config_, api_, state_, handles_)      \
 	{                                                                      \
 		.name = name_,                                                 \
-		.data = (data_),                                               \
 		.config = (config_),                                           \
 		.api = (api_),                                                 \
 		.state = (state_),                                             \
+		.data = (data_),                                               \
 		.handles = (handles_),                                         \
 		IF_ENABLED(CONFIG_PM_DEVICE, (.pm = (pm_),)) /**/              \
 	}


### PR DESCRIPTION
The initialization of the struct device is in the wrong order. When compiling C++ sources that use this macro, the compiler complains that the order initialization is incorrect.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54737