### PR TITLE
Fix C++ compatibility of macro DEVICE_DT_INST_DEFINE

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -855,10 +855,10 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 #define Z_DEVICE_INIT(name_, pm_, data_, config_, api_, state_, handles_)      \
 	{                                                                      \
 		.name = name_,                                                 \
-		.data = (data_),                                               \
 		.config = (config_),                                           \
 		.api = (api_),                                                 \
 		.state = (state_),                                             \
+		.data = (data_),                                               \
 		.handles = (handles_),                                         \
 		IF_ENABLED(CONFIG_PM_DEVICE, (.pm = (pm_),)) /**/              \
 	}

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -771,7 +771,10 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 
 /** @brief Linker section were device handles are placed. */
 #define Z_DEVICE_HANDLES_SECTION                                               \
-	extern __attribute__((__section__(".__device_handles_pass1")))
+#ifdef __cplusplus                                                             \
+	extern                                                                 \ 
+#endif                                                                         \
+	 __attribute__((__section__(".__device_handles_pass1")))
 
 /**
  * @brief Define device handles.

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -771,7 +771,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 
 /** @brief Linker section were device handles are placed. */
 #define Z_DEVICE_HANDLES_SECTION                                               \
-	__attribute__((__section__(".__device_handles_pass1")))
+	extern __attribute__((__section__(".__device_handles_pass1")))
 
 /**
  * @brief Define device handles.


### PR DESCRIPTION
Developing drivers with C++ is not supported at the moment. What I propose is to fix this by adding the correct syntax that allows to compile the zephyr macros in include/device.h.

The change relates specifcally to the weak attribute declaration for the handles section, i.e., `Z_DEVICE_HANDLES_SECTION` and order initialization of `Z_DEVICE_INIT`.

Signed-off-by: Victor Chavez [chavez-bermudez@fh-aachen.de](mailto:chavez-bermudez@fh-aachen.de)