### PR TITLE
Fixed Driver Macro compatibility for CPP

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -771,7 +771,10 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 
 /** @brief Linker section were device handles are placed. */
 #define Z_DEVICE_HANDLES_SECTION                                               \
-	__attribute__((__section__(".__device_handles_pass1")))
+#ifdef __cplusplus                                                             \
+	extern                                                                 \ 
+#endif                                                                         \
+	 __attribute__((__section__(".__device_handles_pass1")))
 
 /**
  * @brief Define device handles.
@@ -855,10 +858,10 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 #define Z_DEVICE_INIT(name_, pm_, data_, config_, api_, state_, handles_)      \
 	{                                                                      \
 		.name = name_,                                                 \
-		.data = (data_),                                               \
 		.config = (config_),                                           \
 		.api = (api_),                                                 \
 		.state = (state_),                                             \
+		.data = (data_),                                               \
 		.handles = (handles_),                                         \
 		IF_ENABLED(CONFIG_PM_DEVICE, (.pm = (pm_),)) /**/              \
 	}

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -770,11 +770,13 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 	FOR_EACH_NONEMPTY_TERM(IDENTITY, (,), __VA_ARGS__)
 
 /** @brief Linker section were device handles are placed. */
+#ifdef __cplusplus
 #define Z_DEVICE_HANDLES_SECTION                                               \
-#ifdef __cplusplus                                                             \
-	extern                                                                 \ 
-#endif                                                                         \
-	 __attribute__((__section__(".__device_handles_pass1")))
+	extern  __attribute__((__section__(".__device_handles_pass1")))                                        
+#else
+#define Z_DEVICE_HANDLES_SECTION                                               \
+	__attribute__((__section__(".__device_handles_pass1")))
+#endif
 
 /**
  * @brief Define device handles.


### PR DESCRIPTION
The macro `DEVICE_DT_INST_DEFINE` is not compatible with C++ source files.  This commit fixes the order initialization of macro `Z_DEVICE_INIT` and  declaration of `Z_DEVICE_HANDLES_SECTION` with extern keyword.

Signed-off-by: Victor Chavez <chavez-bermudez@fh-aachen.de>