### PR TITLE
cmake: compiler/clang: tell clang to print actual libgcc name

### DIFF
--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -58,6 +58,7 @@ if(NOT "${ARCH}" STREQUAL "posix")
   # This libgcc code is partially duplicated in compiler/*/target.cmake
   execute_process(
     COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-libgcc-file-name
+            --rtlib=libgcc
     OUTPUT_VARIABLE LIBGCC_FILE_NAME
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )


### PR DESCRIPTION
This is to force clang to print the actual path to libgcc.a as we explicitly link libgcc. On some systems where llvm/clang is built to use libclang_rt.* by default, --print-ligcc-file-name would give the path to libclang_rt.*. This results in wrong path being extracted and incorrect library path being used in builds. Since libgcc.a is probably not in this provided path, clang may search on its own which may use incorrect libgcc.a (e.g. built for another arch for multilib systems). To avoid this, just tell clang to use libgcc.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>