### PR TITLE
Bluetooth: Controller: Fix scan window value corruption

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1362,13 +1362,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 
 #if !defined(CONFIG_BT_HCI_MESH_EXT)
 	ticks_anchor = ticker_ticks_now_get();
-
-#if !defined(CONFIG_BT_TICKER_LOW_LAT)
-	/* NOTE: mesh bsim loopback_group_low_lat test needs both adv and scan
-	 * to not have that start overhead added to pass the test.
-	 */
 	ticks_anchor += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
-#endif /* !CONFIG_BT_TICKER_LOW_LAT */
 
 #else /* CONFIG_BT_HCI_MESH_EXT */
 	if (!at_anchor) {

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -502,7 +502,8 @@ conn_is_valid:
 	memcpy(lll->adv_addr, peer_addr, BDADDR_SIZE);
 	lll->conn_timeout = timeout;
 
-	ull_scan_params_set(lll, 0, scan_interval, scan_window, filter_policy);
+	scan->ticks_window = ull_scan_params_set(lll, 0U, scan_interval,
+						 scan_window, filter_policy);
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	return 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -558,13 +558,7 @@ uint8_t ull_scan_enable(struct ll_scan_set *scan)
 	}
 
 	ticks_anchor = ticker_ticks_now_get();
-
-#if !defined(CONFIG_BT_TICKER_LOW_LAT)
-	/* NOTE: mesh bsim loopback_group_low_lat test needs both adv and scan
-	 * to not have that start overhead added to pass the test.
-	 */
 	ticks_anchor += HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US);
-#endif /* !CONFIG_BT_TICKER_LOW_LAT */
 
 #if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_CTLR_SCHED_ADVANCED)
 	if (!lll->conn) {

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -132,7 +132,8 @@ uint8_t ll_scan_params_set(uint8_t type, uint16_t interval, uint16_t window,
 
 	scan->own_addr_type = own_addr_type;
 
-	ull_scan_params_set(lll, type, interval, window, filter_policy);
+	scan->ticks_window = ull_scan_params_set(lll, type, interval, window,
+						 filter_policy);
 
 	return 0;
 }
@@ -349,8 +350,9 @@ int ull_scan_reset(void)
 	return 0;
 }
 
-void ull_scan_params_set(struct lll_scan *lll, uint8_t type, uint16_t interval,
-			 uint16_t window, uint8_t filter_policy)
+uint32_t ull_scan_params_set(struct lll_scan *lll, uint8_t type,
+			     uint16_t interval, uint16_t window,
+			     uint8_t filter_policy)
 {
 	/* type value:
 	 * 0000b - legacy 1M passive
@@ -369,6 +371,8 @@ void ull_scan_params_set(struct lll_scan *lll, uint8_t type, uint16_t interval,
 	lll->interval = interval;
 	lll->ticks_window = HAL_TICKER_US_TO_TICKS((uint64_t)window *
 						   SCAN_INT_UNIT_US);
+
+	return lll->ticks_window;
 }
 
 uint8_t ull_scan_enable(struct ll_scan_set *scan)
@@ -414,6 +418,7 @@ uint8_t ull_scan_enable(struct ll_scan_set *scan)
 		ticks_slot_overhead = 0U;
 	}
 
+	lll->ticks_window = scan->ticks_window;
 	if ((lll->ticks_window +
 	     HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US)) <
 	    (ticks_interval - ticks_slot_overhead)) {

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_internal.h
@@ -31,8 +31,9 @@ int ull_scan_init(void);
 int ull_scan_reset(void);
 
 /* Set scan parameters */
-void ull_scan_params_set(struct lll_scan *lll, uint8_t type, uint16_t interval,
-			 uint16_t window, uint8_t filter_policy);
+uint32_t ull_scan_params_set(struct lll_scan *lll, uint8_t type,
+			     uint16_t interval, uint16_t window,
+			     uint8_t filter_policy);
 
 /* Enable and start scanning/initiating role */
 uint8_t ull_scan_enable(struct ll_scan_set *scan);

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_types.h
@@ -8,9 +8,11 @@ struct ll_scan_set {
 	struct ull_hdr  ull;
 	struct lll_scan lll;
 
+	uint32_t ticks_window;
+
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-	uint16_t duration_lazy;
 	struct node_rx_hdr *node_rx_scan_term;
+	uint16_t duration_lazy;
 
 	uint8_t is_stop:1;
 #endif /* CONFIG_BT_CTLR_ADV_EXT */

--- a/tests/bluetooth/bsim/mesh/src/test_friendship.c
+++ b/tests/bluetooth/bsim/mesh/src/test_friendship.c
@@ -893,7 +893,7 @@ static void test_other_msg(void)
 		      "Failed to receive from LPN");
 
 	/* Send an unsegmented message to the LPN */
-	ASSERT_OK_MSG(bt_mesh_test_send(LPN_ADDR_START, 5, 0, K_SECONDS(1)),
+	ASSERT_OK_MSG(bt_mesh_test_send(LPN_ADDR_START, 5, FORCE_SEGMENTATION, K_FOREVER),
 		      "Failed to send to LPN");
 
 	/* Receive a segmented message from the LPN. */
@@ -903,7 +903,7 @@ static void test_other_msg(void)
 	/* Send a segmented message to the friend. Should trigger a poll for the
 	 * ack.
 	 */
-	ASSERT_OK_MSG(bt_mesh_test_send(LPN_ADDR_START, 15, 0, K_SECONDS(10)),
+	ASSERT_OK_MSG(bt_mesh_test_send(LPN_ADDR_START, 15, FORCE_SEGMENTATION, K_FOREVER),
 		      "Send to LPN failed");
 
 	/* Receive an unsegmented message from the LPN, originally sent with

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_scan.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_scan.c
@@ -78,9 +78,11 @@ uint8_t ull_scan_enable(struct ll_scan_set *scan)
 	return 0;
 }
 
-void ull_scan_params_set(struct lll_scan *lll, uint8_t type, uint16_t interval, uint16_t window,
-			 uint8_t filter_policy)
+uint32_t ull_scan_params_set(struct lll_scan *lll, uint8_t type,
+			     uint16_t interval, uint16_t window,
+			     uint8_t filter_policy)
 {
+	return 0;
 }
 
 uint8_t ull_scan_disable(uint8_t handle, struct ll_scan_set *scan)


### PR DESCRIPTION
Fix scan window value corruption due to modification of stored ticks_window value when enabling continuous scan.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>