### PR TITLE
subsys: shell: kernel: add shell command for system heap stats

### DIFF
--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -16,6 +16,9 @@
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <stdlib.h>
+#if defined(CONFIG_SYS_HEAP_RUNTIME_STATS) && (CONFIG_HEAP_MEM_POOL_SIZE > 0)
+#include <zephyr/sys/sys_heap.h>
+#endif
 #if defined(CONFIG_LOG_RUNTIME_FILTERING)
 #include <zephyr/logging/log_ctrl.h>
 #endif
@@ -232,6 +235,32 @@ static int cmd_kernel_stacks(const struct shell *shell,
 }
 #endif
 
+#if defined(CONFIG_SYS_HEAP_RUNTIME_STATS) && (CONFIG_HEAP_MEM_POOL_SIZE > 0)
+extern struct sys_heap _system_heap;
+
+static int cmd_kernel_heap(const struct shell *sh,
+			   size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	int err;
+	struct sys_memory_stats stats;
+
+	err = sys_heap_runtime_stats_get(&_system_heap, &stats);
+	if (err) {
+		shell_error(sh, "Failed to read kernel system heap statistics (err %d)", err);
+		return -ENOEXEC;
+	}
+
+	shell_print(sh, "free:           %zu", stats.free_bytes);
+	shell_print(sh, "allocated:      %zu", stats.allocated_bytes);
+	shell_print(sh, "max. allocated: %zu", stats.max_allocated_bytes);
+
+	return 0;
+}
+#endif
+
 static int cmd_kernel_sleep(const struct shell *sh,
 			    size_t argc, char **argv)
 {
@@ -329,6 +358,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_kernel,
 		defined(CONFIG_THREAD_MONITOR)
 	SHELL_CMD(stacks, NULL, "List threads stack usage.", cmd_kernel_stacks),
 	SHELL_CMD(threads, NULL, "List kernel threads.", cmd_kernel_threads),
+#endif
+#if defined(CONFIG_SYS_HEAP_RUNTIME_STATS) && (CONFIG_HEAP_MEM_POOL_SIZE > 0)
+	SHELL_CMD(heap, NULL, "System heap usage statistics.", cmd_kernel_heap),
 #endif
 	SHELL_CMD(uptime, NULL, "Kernel uptime.", cmd_kernel_uptime),
 	SHELL_CMD(version, NULL, "Kernel version.", cmd_kernel_version),


### PR DESCRIPTION
Added a shell command to print kernel system heap usage statistics.