### PR TITLE
doc: usb: Correct include path uhc.h

### DIFF
--- a/doc/services/usb/uhc.rst
+++ b/doc/services/usb/uhc.rst
@@ -5,7 +5,7 @@ USB host controller driver API
 
 The USB host controller (UHC) driver API implements the low level layer
 to interface with the host controller. All USB host controller drivers
-should implement the APIs described in :zephyr_file:`include/drivers/usb/uhc.h`.
+should implement the APIs described in :zephyr_file:`include/zephyr/drivers/usb/uhc.h`.
 
 UHC driver API is experimental and is subject to change without notice.
 


### PR DESCRIPTION
Fixes broken link to the USB HC API header file.