### PR TITLE
doc: Use rel="canonical" attribute when linking to "latest" docs pages

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -137,6 +137,7 @@ html_theme_options = {
     "logo_only": True,
     "prev_next_buttons_location": None
 }
+html_baseurl = "https://docs.zephyrproject.org/latest/"
 html_title = "Zephyr Project Documentation"
 html_logo = str(ZEPHYR_BASE / "doc" / "_static" / "images" / "logo.svg")
 html_favicon = str(ZEPHYR_BASE / "doc" / "_static" / "images" / "favicon.png")


### PR DESCRIPTION
Help search engines identify "latest" version of the documentation as the canonical source.
Fixes #54749.

It would be great if this can make it into 3.3.