### PR TITLE
doc: release-notes: Mention rpl_crb board

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -396,7 +396,9 @@ Boards & SoC Support
 
 * Removed support for these ARM boards:
 
-* Removed support for these X86 boards:
+* Added support for these X86 boards:
+
+  * Intel Raptor Lake CRB
 
 * Added support for these RISC-V boards:
 


### PR DESCRIPTION
Mention new Intel Raptor Lake CRB support in Zephyr 3.3 release notes.

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>