### PR TITLE
doc: release notes: added entry regarding app controlled image config

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -487,6 +487,8 @@ Build system and infrastructure
   * Issue with board revision not being passed to sysbuild images has been
     fixed.
 
+  * Application specific configurations of sysbuild controlled images.
+
 * Userspace
 
   * Userspace option to disable using the ``relax`` linker option has been


### PR DESCRIPTION
Added entry on application specific configurations of sysbuild controlled images.
Ref: https://github.com/zephyrproject-rtos/zephyr/pull/51166

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>