### PR TITLE
drivers: nrf_rtc_timer: Fix handling of COMPARE events in set_alarm()

### DIFF
--- a/tests/drivers/timer/nrf_rtc_timer/src/main.c
+++ b/tests/drivers/timer/nrf_rtc_timer/src/main.c
@@ -477,6 +477,69 @@ ZTEST(nrf_rtc_timer, test_next_cycle_timeouts)
 	z_nrf_rtc_timer_chan_free(chan);
 }
 
+static void tight_rescheduling_handler(int32_t chan,
+				       uint64_t expire_time,
+				       void *user_data)
+{
+	if (user_data) {
+		*(bool *)user_data = true;
+	}
+}
+
+ZTEST(nrf_rtc_timer, test_tight_rescheduling)
+{
+	int32_t chan;
+	volatile bool expired;
+	/* This test tries to schedule an alarm to CYCLE_DIFF cycles from
+	 * the current moment and then, after a delay that is changed in
+	 * each iteration, tries to reschedule this alarm to one cycle later.
+	 * It does not matter if the first alarm actually occurs, the key
+	 * thing is to always get the second one.
+	 */
+	enum {
+		CYCLE_DIFF = 5,
+		/* One RTC cycle is ~30.5 us. Check a range of delays from
+		 * more than one cycle before the moment on which the first
+		 * alarm is scheduled to a few microseconds after that alarm
+		 * (when it is actually too late for rescheduling).
+		 */
+		DELAY_MIN = 30 * CYCLE_DIFF - 40,
+		DELAY_MAX = 30 * CYCLE_DIFF + 10,
+	};
+
+	chan = z_nrf_rtc_timer_chan_alloc();
+	zassert_true(chan > 0, "Failed to allocate RTC channel.");
+
+	/* Repeat the whole test a couple of times to get also (presumably)
+	 * various micro delays resulting from execution of the test routine
+	 * itself asynchronously to the RTC.
+	 */
+	for (uint32_t i = 0; i < 20; ++i) {
+		for (uint32_t delay = DELAY_MIN; delay <= DELAY_MAX; ++delay) {
+			uint64_t start = z_nrf_rtc_timer_read();
+
+			z_nrf_rtc_timer_set(chan, start + CYCLE_DIFF,
+				tight_rescheduling_handler, NULL);
+
+			k_busy_wait(delay);
+
+			expired = false;
+			z_nrf_rtc_timer_set(chan, start + CYCLE_DIFF + 1,
+				tight_rescheduling_handler, (void *)&expired);
+
+			while (!expired &&
+				(z_nrf_rtc_timer_read() - start) <
+					CYCLE_DIFF + 10) {
+			}
+			zassert_true(expired,
+				"Timeout expiration missed (d: %u us, i: %u)",
+				delay, i);
+		}
+	}
+
+	z_nrf_rtc_timer_chan_free(chan);
+}
+
 static void *rtc_timer_setup(void)
 {
 	init_zli_timer0();


### PR DESCRIPTION
This is a follow-up to commits https://github.com/zephyrproject-rtos/zephyr/commit/cf871aec645dc45503b20c2e7684a4babbc436dc and https://github.com/zephyrproject-rtos/zephyr/commit/205e684958ebea4d7f2a15d75b94aac880fb2390.

It turns out that the current implementation of the nrf_rtc_timer may still fail to properly handle a timeout if that timeout is set in very specific conditions - when a previously set timeout is about to expire. When that happens, the new timeout is handled 512 seconds later (when the system timer overflows) than it should be.

This PR adds an nrf_rtc_timer test case (`test_tight_rescheduling`) that exposes this problem. Another commit fixes it by adding examination of COMPARE events that appear during setting of the CC register value for a given timeout. The `set_absolute_alarm` function is also renamed to `set_alarm` to avoid confusion regarding what the function really does.

Fixes #54782.