### PR TITLE
Add release notes: DSP, ztest, emul

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -2074,6 +2074,12 @@ Libraries / Subsystems
   * ``CONFIG_HAS_EXTERNAL_CACHE`` has been renamed to
     :kconfig:option:`CONFIG_EXTERNAL_CACHE`
 
+* DSP
+
+  * Introduced DSP (digital signal processing) subsystem with CMSIS-DSP as the
+    default backend.
+  * CMSIS-DSP now supports all architectures supported by Zephyr.
+
 * File systems
 
   * Added new API call `fs_mkfs`.

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -27,6 +27,10 @@ https://docs.zephyrproject.org/latest/security/vulnerabilities.html
 API Changes
 ***********
 
+* Emulator creation APIs have changed to better match
+  :c:macro:`DEVICE_DT_DEFINE`. It also includes a new backend API pointer to
+  allow sensors to share common APIs for more generic tests.
+
 Changes in this release
 =======================
 
@@ -128,6 +132,14 @@ Changes in this release
   bus that enables one-to-one, one-to-many and many-to-many communication
   between threads.
 
+* zTest now supports controlling test summary printouts via the
+  :kconfig:option:`CONFIG_ZTEST_SUMMARY`. This Kconfig can be set to ``n`` for
+  less verbose test output.
+
+* Emulators now support a backend API pointer which allows a single class of
+  devices to provide similar emulated functionality. This can be used to write
+  a single test for the class of devices and testing various boards using
+  different chips.
 
 Removed APIs in this release
 ============================


### PR DESCRIPTION
Document changes to the ztest Kconfigs, emul APIs, and the introduction of the DSP subsystem.