### PR TITLE
hwinfo: add release-notes for 3.3.0

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -666,6 +666,11 @@ Drivers and Sensors
 
   * Added driver for nPM6001 PMIC GPIOs
 
+* hwinfo
+
+  * Added hwinfo_get_device_id for ESP32-C3
+  * Add reset cause for iwdg and wwdg for STM32H7 and MP1
+
 * I2C
 
   * SAM0 Fixed spurious trailing data by moving stop condition from thread into ISR


### PR DESCRIPTION
Release-notes for 3.3.0 release

Signed-off-by: Alexander Wachter <alexander@wachter.cloud>