### PR TITLE
linker: rom_start_offset: add to address instead of set

### DIFF
--- a/arch/common/rom_start_offset.ld
+++ b/arch/common/rom_start_offset.ld
@@ -4,5 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-. = CONFIG_ROM_START_OFFSET;
+. += CONFIG_ROM_START_OFFSET;
 . = ALIGN(4);


### PR DESCRIPTION
The CONFIG_ROM_START_OFFSET is supposed to be added to the current when linking, instead of having the current address set to it. So fix that.

Not sure why it worked up to this point, but llvm/clang/lld complained that it could not move location counter backward.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>