### PR TITLE
logging: shell command "disable" fails for "backend" subcommand

### DIFF
--- a/subsys/logging/log_cmds.c
+++ b/subsys/logging/log_cmds.c
@@ -385,7 +385,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_log_backend,
 	SHELL_CMD_ARG(disable, &dsub_module_name,
 		  "'log disable <module_0> .. <module_n>' disables logs in "
 		  "specified modules (all if no modules specified).",
-		  cmd_log_backend_disable, 2, 255),
+		  cmd_log_backend_disable, 1, 255),
 	SHELL_CMD_ARG(enable, &dsub_severity_lvl,
 		  "'log enable <level> <module_0> ...  <module_n>' enables logs"
 		  " up to given level in specified modules (all if no modules "


### PR DESCRIPTION
A fix to accept valid shell commands of the form `log backend shell_rtt_backend disable`, i.e. to affect all modules when no modules are specified.

Signed-off-by: Marco Argiolas <marco.argiolas@ftpsolutions.com.au>