### PR TITLE
doc: release-notes: fix RISC-V release notes for v3.3.0

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -291,8 +291,8 @@ Architectures
 
 * RISC-V
 
-  * Converted :kconfig:option:`CONFIG_MP_MAX_CPUS` to
-    :kconfig:option:`CONFIG_MP_MAX_CPUS`.
+  * Converted :kconfig:option:`CONFIG_MP_NUM_CPUS` to
+    :kconfig:option:`CONFIG_MP_MAX_NUM_CPUS`.
 
   * Added support for hardware register stacking/unstacking during ISRs and
     exceptions.


### PR DESCRIPTION
This PR fixes one RISC-V release notes entry for Zephyr v3.3.0. Kconfig option names mentioned in that entry were incorrect.