### PR TITLE
Bluetooth: Controller: Fix Close Isochronous Event implementation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -457,6 +457,7 @@ static void isr_rx(void *param)
 
 		/* Rx receive */
 		if (!pdu_rx->npi &&
+		    (bn_rx <= cis_lll->rx.bn) &&
 		    (pdu_rx->sn == cis_lll->nesn) &&
 		    ull_iso_pdu_rx_alloc_peek(2U)) {
 			struct node_rx_iso_meta *iso_meta;
@@ -519,9 +520,7 @@ static void isr_rx(void *param)
 #endif /* CONFIG_BT_CTLR_LOW_LAT_ULL */
 
 			/* Increment burst number */
-			if (bn_rx <= cis_lll->rx.bn) {
-				bn_rx++;
-			}
+			bn_rx++;
 		}
 
 		/* Close Isochronous Event */
@@ -545,7 +544,9 @@ static void isr_rx(void *param)
 	}
 
 	/* Close Isochronous Event */
-	cie = (cie || (bn_rx > cis_lll->rx.bn)) && (bn_tx >= cis_lll->tx.bn);
+	cie = cie || ((bn_rx > cis_lll->rx.bn) &&
+		      (bn_tx > cis_lll->tx.bn) &&
+		      (se_curr < cis_lll->nse));
 
 	/* TODO: Get ISO data PDU */
 	if (bn_tx > cis_lll->tx.bn) {


### PR DESCRIPTION
Fix the Close Isochronous Event (CIE) implementation so that it follows the Bluetooth Core Specification definition: Link Layer implementations will normally end a CIS event early when all scheduled payloads in both directions have been transmitted and acknowledged.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>