### PR TITLE
gd32vf103: no longer needed particular version of OpenOCD

### DIFF
--- a/boards/riscv/gd32vf103c_starter/doc/index.rst
+++ b/boards/riscv/gd32vf103c_starter/doc/index.rst
@@ -83,20 +83,12 @@ The GD32VF103C-STARTER includes an onboard programmer/debugger (GD-Link) which
 allows flash programming and debugging over USB. There is also a JTAG header
 (JP1) which can be used with tools like Segger J-Link.
 
-.. note::
-
-   The OpenOCD shipped with Zephyr SDK does not support GD32VF103. You will need
-   to build the `riscv-openocd fork <https://github.com/riscv/riscv-openocd>`_.
-   Note that compared with OpenOCD, J-Link offers a better programming and
-   debugging experience on this board.
-
 #. Build the Zephyr kernel and the :ref:`hello_world` sample application:
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world
       :board: gd32vf103c_starter
       :goals: build
-      :gen-args: -DOPENOCD=<path/to/riscv-openocd/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/riscv-openocd/share/openocd/scripts>
       :compact:
 
 #. Run your favorite terminal program to listen for output. On Linux the

--- a/boards/riscv/gd32vf103v_eval/doc/index.rst
+++ b/boards/riscv/gd32vf103v_eval/doc/index.rst
@@ -93,20 +93,12 @@ The GD32VF103V-EVAL includes an onboard programmer/debugger (GD-Link) which
 allows flash programming and debugging over USB. There is also a JTAG header
 (JP1) which can be used with tools like Segger J-Link.
 
-.. note::
-
-   The OpenOCD shipped with Zephyr SDK does not support GD32VF103. You will need
-   to build the `riscv-openocd fork <https://github.com/riscv/riscv-openocd>`_.
-   Note that compared with OpenOCD, J-Link offers a better programming and
-   debugging experience on this board.
-
 #. Build the Zephyr kernel and the :ref:`hello_world` sample application:
 
    .. zephyr-app-commands::
       :zephyr-app: samples/hello_world
       :board: gd32vf103v_eval
       :goals: build
-      :gen-args: -DOPENOCD=<path/to/riscv-openocd/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/riscv-openocd/share/openocd/scripts>
       :compact:
 
 #. Run your favorite terminal program to listen for output. On Linux the

--- a/boards/riscv/longan_nano/doc/index.rst
+++ b/boards/riscv/longan_nano/doc/index.rst
@@ -84,23 +84,12 @@ Programming and debugging
 Building & Flashing
 ===================
 
-In order to upload the application to the device, you'll need OpenOCD with
-GD32V support. Download the tarball for your OS from the
-`SiPEED longan nano download site
-<http://dl.sipeed.com/LONGAN/platformio/dl-packages/>`_ and extract it.
-
-The Zephyr SDK uses a bundled version of OpenOCD by default. You can
-overwrite that behavior by adding the
-``-DOPENOCD=<path/to/riscv-openocd/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/riscv-openocd/share/openocd/scripts>``
-parameter when building:
-
 Here is an example for building the :ref:`blinky-sample` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
    :board: longan_nano
    :goals: build flash
-   :gen-args: -DOPENOCD=<path/to/riscv-openocd/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/riscv-openocd/share/openocd/scripts>
 
 When using a custom toolchain it should be enough to have the downloaded
 version of the binary in your ``PATH``.


### PR DESCRIPTION
The SDK version after 0.15.0 includes OpenOCD that support gd32vf103,
so no external installation is required.
Update document.

Both gd32vf103c_starter and gd32vf103v_eval also use same SoC with longan_nano, 
so no need to install the OpenOCD.
