### PR TITLE
doc: redirects: add old sockets page to redirects

### DIFF
--- a/doc/_scripts/redirects.py
+++ b/doc/_scripts/redirects.py
@@ -113,6 +113,7 @@ REDIRECTS = [
     ('reference/misc/notify', 'services/notify'),
     ('reference/misc/timeutil', 'kernel/timeutil'),
     ('reference/modbus/index', 'services/modbus/index'),
+    ('reference/networking/sockets', 'connectivity/networking/api/sockets'),
     ('reference/peripherals/adc', 'hardware/peripherals/adc'),
     ('reference/peripherals/dac', 'hardware/peripherals/dac'),
     ('reference/peripherals/dma', 'hardware/peripherals/dma'),


### PR DESCRIPTION
The BSD sockets page was moved a while ago when documentation was reorganized (reported by Nordic technical support). This patch adds a redirect so that old links keep working just fine.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>