### PR TITLE
boards: arm: nucleo_f303k8: make full name consistent

### DIFF
--- a/boards/arm/nucleo_f303k8/nucleo_f303k8.yaml
+++ b/boards/arm/nucleo_f303k8/nucleo_f303k8.yaml
@@ -1,5 +1,5 @@
 identifier: nucleo_f303k8
-name: ST Nucleo F303k8
+name: ST Nucleo F303K8
 type: mcu
 arch: arm
 toolchain:


### PR DESCRIPTION
This PR makes the full name of the `nucleo_f303k8` platform consistent with other Nucleo platforms. This is also the convention that this board manufacturer uses.