### PR TITLE
usb: udc_virtual: Adapt to new API

### DIFF
--- a/drivers/usb/udc/udc_virtual.c
+++ b/drivers/usb/udc/udc_virtual.c
@@ -181,7 +181,7 @@ static int vrt_handle_out(const struct device *dev,
 	min_len = MIN(pkt->length, net_buf_tailroom(buf));
 	net_buf_add_mem(buf, pkt->data, min_len);
 
-	LOG_DBG("Handle data OUT, %zu | %u", pkt->length, net_buf_tailroom(buf));
+	LOG_DBG("Handle data OUT, %zu | %zu", pkt->length, net_buf_tailroom(buf));
 
 	if (net_buf_tailroom(buf) == 0 || pkt->length < ep_cfg->mps) {
 		buf = udc_buf_get(dev, ep);
@@ -245,7 +245,7 @@ static int vrt_handle_in(const struct device *dev,
 		return vrt_request_reply(dev, pkt, UVB_REPLY_NACK);
 	}
 
-	LOG_DBG("Handle data IN, %u | %u | %u",
+	LOG_DBG("Handle data IN, %zu | %u | %u",
 		pkt->length, buf->len, ep_cfg->mps);
 	min_len = MIN(pkt->length, buf->len);
 	memcpy(pkt->data, buf->data, min_len);
@@ -258,7 +258,7 @@ static int vrt_handle_in(const struct device *dev,
 			goto continue_in;
 		}
 
-		LOG_DBG("Finish data IN %u | %u", pkt->length, buf->len);
+		LOG_DBG("Finish data IN %zu | %u", pkt->length, buf->len);
 		buf = udc_buf_get(dev, ep);
 
 		if (ep == USB_CONTROL_EP_IN) {

--- a/drivers/usb/udc/udc_virtual.c
+++ b/drivers/usb/udc/udc_virtual.c
@@ -172,7 +172,7 @@ static int vrt_handle_out(const struct device *dev,
 		return vrt_request_reply(dev, pkt, UVB_REPLY_STALL);
 	}
 
-	buf = udc_buf_peek(dev, ep, true);
+	buf = udc_buf_peek(dev, ep);
 	if (buf == NULL) {
 		LOG_DBG("reply NACK ep 0x%02x", ep);
 		return vrt_request_reply(dev, pkt, UVB_REPLY_NACK);
@@ -184,7 +184,7 @@ static int vrt_handle_out(const struct device *dev,
 	LOG_DBG("Handle data OUT, %zu | %u", pkt->length, net_buf_tailroom(buf));
 
 	if (net_buf_tailroom(buf) == 0 || pkt->length < ep_cfg->mps) {
-		buf = udc_buf_get(dev, ep, true);
+		buf = udc_buf_get(dev, ep);
 
 		if (ep == USB_CONTROL_EP_OUT) {
 			err = vrt_handle_ctrl_out(dev, buf);
@@ -239,7 +239,7 @@ static int vrt_handle_in(const struct device *dev,
 		return vrt_request_reply(dev, pkt, UVB_REPLY_STALL);
 	}
 
-	buf = udc_buf_peek(dev, ep, true);
+	buf = udc_buf_peek(dev, ep);
 	if (buf == NULL) {
 		LOG_DBG("reply NACK ep 0x%02x", ep);
 		return vrt_request_reply(dev, pkt, UVB_REPLY_NACK);
@@ -259,7 +259,7 @@ static int vrt_handle_in(const struct device *dev,
 		}
 
 		LOG_DBG("Finish data IN %u | %u", pkt->length, buf->len);
-		buf = udc_buf_get(dev, ep, true);
+		buf = udc_buf_get(dev, ep);
 
 		if (ep == USB_CONTROL_EP_IN) {
 			err = isr_handle_ctrl_in(dev, buf);

--- a/drivers/usb/uhc/uhc_virtual.c
+++ b/drivers/usb/uhc/uhc_virtual.c
@@ -248,11 +248,11 @@ static int vrt_hrslt_success(const struct device *dev,
 			length = MIN(net_buf_tailroom(buf), pkt->length);
 			net_buf_add(buf, length);
 			if (pkt->length > xfer->mps) {
-				LOG_ERR("Ambiguous packet with the length %u",
+				LOG_ERR("Ambiguous packet with the length %zu",
 					pkt->length);
 			}
 
-			LOG_DBG("IN chunk %zu out of %u", length, net_buf_tailroom(buf));
+			LOG_DBG("IN chunk %zu out of %zu", length, net_buf_tailroom(buf));
 			if (pkt->length < xfer->mps || !net_buf_tailroom(buf)) {
 				err = uhc_xfer_done(xfer);
 			}

--- a/samples/subsys/usb/shell/sample.yaml
+++ b/samples/subsys/usb/shell/sample.yaml
@@ -14,7 +14,6 @@ tests:
     platform_allow: nrf52840dk_nrf52840 frdm_k64f
     build_only: true
   sample.usbh.shell.virtual:
-    depends_on: usb_device
     tags: usb
     extra_args: CONF_FILE="device_and_host_prj.conf"
                 OVERLAY_CONFIG="virtual.conf"

--- a/samples/subsys/usb/shell/sample.yaml
+++ b/samples/subsys/usb/shell/sample.yaml
@@ -16,7 +16,5 @@ tests:
   sample.usbh.shell.virtual:
     tags: usb
     extra_args: CONF_FILE="device_and_host_prj.conf"
-                OVERLAY_CONFIG="virtual.conf"
-                DTC_OVERLAY_FILE="virtual.overlay"
     platform_allow: qemu_cortex_m3
     build_only: true

--- a/subsys/usb/device_next/class/loopback.c
+++ b/subsys/usb/device_next/class/loopback.c
@@ -228,7 +228,7 @@ static int lb_control_to_host(struct usbd_class_node *c_nd,
 				MIN(sizeof(lb_buf), setup->wLength));
 		usbd_ep_ctrl_enqueue(uds_ctx, buf);
 
-		LOG_WRN("Device-to-Host, wLength %u | %u", setup->wLength,
+		LOG_WRN("Device-to-Host, wLength %u | %zu", setup->wLength,
 			MIN(sizeof(lb_buf), setup->wLength));
 
 		return 0;
@@ -250,7 +250,7 @@ static int lb_control_to_dev(struct usbd_class_node *c_nd,
 	}
 
 	if (setup->bRequest == LB_VENDOR_REQ_OUT) {
-		LOG_WRN("Host-to-Device, wLength %u | %u", setup->wLength,
+		LOG_WRN("Host-to-Device, wLength %u | %zu", setup->wLength,
 			MIN(sizeof(lb_buf), buf->len));
 		memcpy(lb_buf, buf->data, MIN(sizeof(lb_buf), buf->len));
 		return 0;

--- a/subsys/usb/device_next/usbd_endpoint.c
+++ b/subsys/usb/device_next/usbd_endpoint.c
@@ -75,7 +75,7 @@ static void usbd_ep_ctrl_set_zlp(struct usbd_contex *const uds_ctx,
 		 * Transfer length is less as requested by wLength and
 		 * is multiple of wMaxPacketSize.
 		 */
-		LOG_DBG("add ZLP, wLength %u buf length %u",
+		LOG_DBG("add ZLP, wLength %u buf length %zu",
 			setup->wLength, min_len);
 		udc_ep_buf_set_zlp(buf);
 

--- a/subsys/usb/device_next/usbd_init.c
+++ b/subsys/usb/device_next/usbd_init.c
@@ -211,7 +211,7 @@ static int init_configuration(struct usbd_contex *const uds_ctx,
 			return ret;
 		}
 
-		LOG_INF("Init class node %p, descriptor length %u",
+		LOG_INF("Init class node %p, descriptor length %zu",
 			c_nd, usbd_class_desc_len(c_nd));
 		cfg_len += usbd_class_desc_len(c_nd);
 	}

--- a/subsys/usb/device_next/usbd_shell.c
+++ b/subsys/usb/device_next/usbd_shell.c
@@ -130,7 +130,7 @@ static int foobaz_cth(struct usbd_class_node *const node,
 
 		net_buf_add_mem(buf, foobaz_buf, min_len);
 		shell_info(ctx_shell,
-			   "dev: conrol transfer to host, wLength %u | %u",
+			   "dev: conrol transfer to host, wLength %u | %zu",
 			   setup->wLength, min_len);
 
 		return 0;
@@ -148,7 +148,7 @@ static int foobaz_ctd(struct usbd_class_node *const node,
 
 	if (setup->bRequest == FOOBAZ_VREQ_OUT) {
 		shell_info(ctx_shell,
-			   "dev: control transfer to device, wLength %u | %u",
+			   "dev: control transfer to device, wLength %u | %zu",
 			   setup->wLength, min_len);
 		memcpy(foobaz_buf, buf->data, min_len);
 		return 0;
@@ -299,7 +299,7 @@ static int cmd_submit_request(const struct shell *sh,
 		net_buf_add_mem(buf, foobaz_buf, len);
 	}
 
-	shell_print(sh, "dev: Submit ep 0x%02x len %u buf %p", ep, len, buf);
+	shell_print(sh, "dev: Submit ep 0x%02x len %zu buf %p", ep, len, buf);
 	ret = usbd_ep_enqueue(&foobaz, buf);
 	if (ret) {
 		shell_print(sh, "dev: Failed to queue request buffer");


### PR DESCRIPTION
- Fixes build when udc_virtual was using old API.
- Fixes build for 64 bit platforms
