### PR TITLE
scripts: gen_relocate_app.py: Give sections unique names

### DIFF
--- a/arch/arm/core/aarch32/mpu/arm_core_mpu.c
+++ b/arch/arm/core/aarch32/mpu/arm_core_mpu.c
@@ -58,8 +58,8 @@ uint32_t z_arm_mpu_stack_guard_and_fpu_adjust(struct k_thread *thread);
 #endif
 
 #if defined(CONFIG_CODE_DATA_RELOCATION_SRAM)
-extern char __ram_text_start[];
-extern char __ram_text_size[];
+extern char __ram_text_reloc_start[];
+extern char __ram_text_reloc_size[];
 #endif
 
 static const struct z_arm_mpu_partition static_regions[] = {
@@ -92,8 +92,8 @@ static const struct z_arm_mpu_partition static_regions[] = {
 #if defined(CONFIG_CODE_DATA_RELOCATION_SRAM)
 		{
 		/* RAM area for relocated text */
-		.start = (uint32_t)&__ram_text_start,
-		.size = (uint32_t)&__ram_text_size,
+		.start = (uint32_t)&__ram_text_reloc_start,
+		.size = (uint32_t)&__ram_text_reloc_size,
 		.attr = K_MEM_PARTITION_P_RX_U_RX,
 		},
 #endif /* CONFIG_CODE_DATA_RELOCATION_SRAM */

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -101,7 +101,7 @@ PRINT_TEMPLATE = """
 """
 
 SECTION_LOAD_MEMORY_SEQ = """
-        __{0}_{1}_rom_start = LOADADDR(_{2}_{3}_SECTION_NAME);
+        __{0}_{1}_rom_start = LOADADDR(.{0}_{1}_reloc);
 """
 
 LOAD_ADDRESS_LOCATION_FLASH = """
@@ -135,33 +135,33 @@ LINKER_SECTION_SEQ = """
 
 /* Linker section for memory region {2} for  {3} section  */
 
-	SECTION_PROLOGUE(_{2}_{3}_SECTION_NAME,,)
+	SECTION_PROLOGUE(.{0}_{1}_reloc,,)
         {{
                 . = ALIGN(4);
                 {4}
                 . = ALIGN(4);
 	}} {5}
-        __{0}_{1}_end = .;
-        __{0}_{1}_start = ADDR(_{2}_{3}_SECTION_NAME);
-        __{0}_{1}_size = SIZEOF(_{2}_{3}_SECTION_NAME);
+        __{0}_{1}_reloc_end = .;
+        __{0}_{1}_reloc_start = ADDR(.{0}_{1}_reloc);
+        __{0}_{1}_reloc_size = __{0}_{1}_reloc_end - __{0}_{1}_reloc_start;
 """
 
 LINKER_SECTION_SEQ_MPU = """
 
 /* Linker section for memory region {2} for {3} section  */
 
-	SECTION_PROLOGUE(_{2}_{3}_SECTION_NAME,,)
+	SECTION_PROLOGUE(.{0}_{1}_reloc,,)
         {{
-                __{0}_{1}_start = .;
+                __{0}_{1}_reloc_start = .;
                 {4}
 #if {6}
                 . = ALIGN({6});
 #else
-                MPU_ALIGN(__{0}_{1}_size);
+                MPU_ALIGN(__{0}_{1}_reloc_size);
 #endif
-                __{0}_{1}_end = .;
+                __{0}_{1}_reloc_end = .;
 	}} {5}
-        __{0}_{1}_size = __{0}_{1}_end - __{0}_{1}_start;
+        __{0}_{1}_reloc_size = __{0}_{1}_reloc_end - __{0}_{1}_reloc_start;
 """
 
 SOURCE_CODE_INCLUDES = """
@@ -173,9 +173,9 @@ SOURCE_CODE_INCLUDES = """
 """
 
 EXTERN_LINKER_VAR_DECLARATION = """
-extern char __{0}_{1}_start[];
+extern char __{0}_{1}_reloc_start[];
 extern char __{0}_{1}_rom_start[];
-extern char __{0}_{1}_size[];
+extern char __{0}_{1}_reloc_size[];
 """
 
 
@@ -194,14 +194,14 @@ void bss_zeroing_relocation(void)
 """
 
 MEMCPY_TEMPLATE = """
-	z_early_memcpy(&__{0}_{1}_start, &__{0}_{1}_rom_start,
-		           (size_t) &__{0}_{1}_size);
+	z_early_memcpy(&__{0}_{1}_reloc_start, &__{0}_{1}_rom_start,
+		           (size_t) &__{0}_{1}_reloc_size);
 
 """
 
 MEMSET_TEMPLATE = """
- 	z_early_memset(&__{0}_bss_start, 0,
-		           (size_t) &__{0}_bss_size);
+	z_early_memset(&__{0}_bss_reloc_start, 0,
+		           (size_t) &__{0}_bss_reloc_size);
 """
 
 

--- a/tests/application_development/code_relocation/src/test_file1.c
+++ b/tests/application_development/code_relocation/src/test_file1.c
@@ -29,14 +29,14 @@ void function_in_custom_section(void);
 
 ZTEST(code_relocation, test_function_in_sram2)
 {
-	extern uintptr_t __sram2_text_start;
-	extern uintptr_t __sram2_text_end;
-	extern uintptr_t __sram2_data_start;
-	extern uintptr_t __sram2_data_end;
-	extern uintptr_t __sram2_bss_start;
-	extern uintptr_t __sram2_bss_end;
-	extern uintptr_t __sram2_rodata_start;
-	extern uintptr_t __sram2_rodata_end;
+	extern uintptr_t __sram2_text_reloc_start;
+	extern uintptr_t __sram2_text_reloc_end;
+	extern uintptr_t __sram2_data_reloc_start;
+	extern uintptr_t __sram2_data_reloc_end;
+	extern uintptr_t __sram2_bss_reloc_start;
+	extern uintptr_t __sram2_bss_reloc_end;
+	extern uintptr_t __sram2_rodata_reloc_start;
+	extern uintptr_t __sram2_rodata_reloc_end;
 	extern uintptr_t __custom_section_start;
 	extern uintptr_t __custom_section_end;
 
@@ -47,20 +47,20 @@ ZTEST(code_relocation, test_function_in_sram2)
 	printk("Address of var_sram2_bss %p\n\n", &var_sram2_bss);
 
 	zassert_between_inclusive((uintptr_t)&var_sram2_data,
-		(uintptr_t)&__sram2_data_start,
-		(uintptr_t)&__sram2_data_end,
+		(uintptr_t)&__sram2_data_reloc_start,
+		(uintptr_t)&__sram2_data_reloc_end,
 		"var_sram2_data not in sram2 region");
 	zassert_between_inclusive((uintptr_t)&k_sem_give,
-		(uintptr_t)&__sram2_text_start,
-		(uintptr_t)&__sram2_text_end,
+		(uintptr_t)&__sram2_text_reloc_start,
+		(uintptr_t)&__sram2_text_reloc_end,
 		"k_sem_give not in sram_text region");
 	zassert_between_inclusive((uintptr_t)&var_sram2_rodata,
-		(uintptr_t)&__sram2_rodata_start,
-		(uintptr_t)&__sram2_rodata_end,
+		(uintptr_t)&__sram2_rodata_reloc_start,
+		(uintptr_t)&__sram2_rodata_reloc_end,
 		"var_sram2_rodata not in sram2_rodata region");
 	zassert_between_inclusive((uintptr_t)&var_sram2_bss,
-		(uintptr_t)&__sram2_bss_start,
-		(uintptr_t)&__sram2_bss_end,
+		(uintptr_t)&__sram2_bss_reloc_start,
+		(uintptr_t)&__sram2_bss_reloc_end,
 		"var_sram2_bss not in sram2_bss region");
 
 	/* Print values from sram */

--- a/tests/application_development/code_relocation/src/test_file3.c
+++ b/tests/application_development/code_relocation/src/test_file3.c
@@ -15,8 +15,8 @@ ZTEST(code_relocation, test_function_in_split_multiple)
 {
 	extern uintptr_t __data_start;
 	extern uintptr_t __data_end;
-	extern uintptr_t __sram2_bss_start;
-	extern uintptr_t __sram2_bss_end;
+	extern uintptr_t __sram2_bss_reloc_start;
+	extern uintptr_t __sram2_bss_reloc_end;
 
 	printk("Address of var_file3_sram_data %p\n", &var_file3_sram_data);
 	printk("Address of var_file3_sram2_bss %p\n\n", &var_file3_sram2_bss);
@@ -26,7 +26,7 @@ ZTEST(code_relocation, test_function_in_split_multiple)
 		(uintptr_t)&__data_end,
 		"var_file3_sram_data not in sram_data region");
 	zassert_between_inclusive((uintptr_t)&var_file3_sram2_bss,
-		(uintptr_t)&__sram2_bss_start,
-		(uintptr_t)&__sram2_bss_end,
+		(uintptr_t)&__sram2_bss_reloc_start,
+		(uintptr_t)&__sram2_bss_reloc_end,
 		"var_file3_sram2_bss not in sram2_bss region");
 }

--- a/tests/application_development/code_relocation/src/test_file4.c
+++ b/tests/application_development/code_relocation/src/test_file4.c
@@ -13,20 +13,20 @@ __in_section(bss, sram2, var) uint32_t var_file4_sram2_bss;
 
 ZTEST(code_relocation, test_function_genex_relocate_1)
 {
-	extern uintptr_t __sram2_data_start;
-	extern uintptr_t __sram2_data_end;
-	extern uintptr_t __sram2_bss_start;
-	extern uintptr_t __sram2_bss_end;
+	extern uintptr_t __sram2_data_reloc_start;
+	extern uintptr_t __sram2_data_reloc_end;
+	extern uintptr_t __sram2_bss_reloc_start;
+	extern uintptr_t __sram2_bss_reloc_end;
 
 	printk("Address of var_file4_sram2_data %p\n", &var_file4_sram2_data);
 	printk("Address of var_file4_sram2_bss %p\n\n", &var_file4_sram2_bss);
 
 	zassert_between_inclusive((uintptr_t)&var_file4_sram2_data,
-		(uintptr_t)&__sram2_data_start,
-		(uintptr_t)&__sram2_data_end,
+		(uintptr_t)&__sram2_data_reloc_start,
+		(uintptr_t)&__sram2_data_reloc_end,
 		"var_file4_sram2_data not in sram2_data region");
 	zassert_between_inclusive((uintptr_t)&var_file4_sram2_bss,
-		(uintptr_t)&__sram2_bss_start,
-		(uintptr_t)&__sram2_bss_end,
+		(uintptr_t)&__sram2_bss_reloc_start,
+		(uintptr_t)&__sram2_bss_reloc_end,
 		"var_file4_sram2_bss not in sram2_bss region");
 }

--- a/tests/application_development/code_relocation/src/test_file5.c
+++ b/tests/application_development/code_relocation/src/test_file5.c
@@ -13,20 +13,20 @@ __in_section(bss, sram2, var) uint32_t var_file5_sram2_bss;
 
 ZTEST(code_relocation, test_function_genex_relocate_2)
 {
-	extern uintptr_t __sram2_data_start;
-	extern uintptr_t __sram2_data_end;
-	extern uintptr_t __sram2_bss_start;
-	extern uintptr_t __sram2_bss_end;
+	extern uintptr_t __sram2_data_reloc_start;
+	extern uintptr_t __sram2_data_reloc_end;
+	extern uintptr_t __sram2_bss_reloc_start;
+	extern uintptr_t __sram2_bss_reloc_end;
 
 	printk("Address of var_file5_sram2_data %p\n", &var_file5_sram2_data);
 	printk("Address of var_file5_sram2_bss %p\n\n", &var_file5_sram2_bss);
 
 	zassert_between_inclusive((uintptr_t)&var_file5_sram2_data,
-		(uintptr_t)&__sram2_data_start,
-		(uintptr_t)&__sram2_data_end,
+		(uintptr_t)&__sram2_data_reloc_start,
+		(uintptr_t)&__sram2_data_reloc_end,
 		"var_file5_sram2_data not in sram2_data region");
 	zassert_between_inclusive((uintptr_t)&var_file5_sram2_bss,
-		(uintptr_t)&__sram2_bss_start,
-		(uintptr_t)&__sram2_bss_end,
+		(uintptr_t)&__sram2_bss_reloc_start,
+		(uintptr_t)&__sram2_bss_reloc_end,
 		"var_file5_sram2_bss not in sram2_bss region");
 }

--- a/tests/application_development/code_relocation/test_lib/test_lib1.c
+++ b/tests/application_development/code_relocation/test_lib/test_lib1.c
@@ -16,28 +16,28 @@ extern void relocated_helper(void);
 
 void relocated_library(void)
 {
-	extern uintptr_t __sram2_text_start;
-	extern uintptr_t __sram2_text_end;
-	extern uintptr_t __sram2_data_start;
-	extern uintptr_t __sram2_data_end;
-	extern uintptr_t __sram2_bss_start;
-	extern uintptr_t __sram2_bss_end;
+	extern uintptr_t __sram2_text_reloc_start;
+	extern uintptr_t __sram2_text_reloc_end;
+	extern uintptr_t __sram2_data_reloc_start;
+	extern uintptr_t __sram2_data_reloc_end;
+	extern uintptr_t __sram2_bss_reloc_start;
+	extern uintptr_t __sram2_bss_reloc_end;
 
 	printk("Address of var_lib1_sram2_data %p\n", &var_lib1_sram2_data);
 	printk("Address of var_lib1_sram2_bss %p\n", &var_lib1_sram2_bss);
 	printk("Address of relocated_lib_helper %p\n\n", &relocated_helper);
 
 	zassert_between_inclusive((uintptr_t)&var_lib1_sram2_data,
-		(uintptr_t)&__sram2_data_start,
-		(uintptr_t)&__sram2_data_end,
+		(uintptr_t)&__sram2_data_reloc_start,
+		(uintptr_t)&__sram2_data_reloc_end,
 		"var_lib1_sram2_data not in sram2_data region");
 	zassert_between_inclusive((uintptr_t)&var_lib1_sram2_bss,
-		(uintptr_t)&__sram2_bss_start,
-		(uintptr_t)&__sram2_bss_end,
+		(uintptr_t)&__sram2_bss_reloc_start,
+		(uintptr_t)&__sram2_bss_reloc_end,
 		"var_lib1_sram2_bss not in sram2_bss region");
 	zassert_between_inclusive((uintptr_t)&relocated_helper,
-		(uintptr_t)&__sram2_text_start,
-		(uintptr_t)&__sram2_text_end,
+		(uintptr_t)&__sram2_text_reloc_start,
+		(uintptr_t)&__sram2_text_reloc_end,
 		"relocated_helper not in sram2_text region");
 	relocated_helper();
 }


### PR DESCRIPTION
The code_relocation feature creates generic section names that sometimes conflict with already existing names.

This patch adds a '_reloc_' word to the created names to reduce the risk of conflict.

This solves #54785.

Signed-off-by: Björn Stenberg <bjorn@haxx.se>