### PR TITLE
littlefs: no longer requires explicit parameter setting.

### DIFF
--- a/dts/bindings/fs/zephyr,fstab,littlefs.yaml
+++ b/dts/bindings/fs/zephyr,fstab,littlefs.yaml
@@ -13,29 +13,26 @@ properties:
 
   read-size:
     type: int
-    required: true
     description: |
       The size of file system read operations, in bytes.
 
       All read operations will be a multiple of this value.  A
       reasonable default is 16.
 
-      This corresponds to CONFIG_FS_LITTLEFS_READ_SIZE.
+      If there isn't use CONFIG_FS_LITTLEFS_READ_SIZE.
 
   prog-size:
     type: int
-    required: true
     description: |
       The size of file system program (write) operations, in bytes.
 
       All program operations will be a multiple of this value.  A
       reasonable default is 16.
 
-      This corresponds to CONFIG_FS_LITTLEFS_PROG_SIZE.
+      If there isn't use CONFIG_FS_LITTLEFS_PROG_SIZE.
 
   cache-size:
     type: int
-    required: true
     description: |
       The size of block caches, in bytes.
 
@@ -48,11 +45,10 @@ properties:
 
       A reasonable default is 64.
 
-      This corresponds to CONFIG_FS_LITTLEFS_CACHE_SIZE.
+      If there isn't use CONFIG_FS_LITTLEFS_CACHE_SIZE.
 
   lookahead-size:
     type: int
-    required: true
     description: |
       The size of the lookahead buffer, in bytes.
 
@@ -63,11 +59,10 @@ properties:
 
       A reasonable default is 32.
 
-      This corresponds to CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE.
+      If there isn't use CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE.
 
   block-cycles:
     type: int
-    required: true
     description: |
       The number of erase cycles before moving data to another block.
 
@@ -75,4 +70,4 @@ properties:
       is moved to another block.  Set to a non-positive value to disable
       leveling.
 
-      This corresponds to CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE.
+      If there isn't use CONFIG_FS_LITTLEFS_BLOCK_CYCLES.


### PR DESCRIPTION
littlefs description no longer requires explicit setting of the following parameters: read-size, prog-size, cache-size, lookahead-size, block-cycles. The default values for these parameters are now taken from kconfig. Also added check for the heap size, because the heap size created depends on the CONFIG_FS_LITTLEFS_CACHE_SIZE parameter, and the used one can depend on the cache-size parameter from dts.

Signed-off-by: Mikhail Siomin <victorovich.01@mail.ru>