### PR TITLE
ARC: boards: qemu: workaround QEMU bug which cause illegal instruction

### DIFF
--- a/boards/arc/qemu_arc/board.cmake
+++ b/boards/arc/qemu_arc/board.cmake
@@ -27,6 +27,7 @@ endif()
 # After that we can specify board explicitly with '-M virt' option.
 list(APPEND QEMU_FLAGS_${ARCH}
   -m 8M
+  -singlestep
   -nographic
   -no-reboot
   -monitor none


### PR DESCRIPTION
Attempt to workaround tests failing with illegal instruction exception which is initially caused by ARC QEMU bug itself by running everything in singlestep mode.

Fixes: #54720