### PR TITLE
net: lwm2m: rd_client: cover dtls releated code path

### DIFF
--- a/tests/net/lib/lwm2m/lwm2m_rd_client/testcase.yaml
+++ b/tests/net/lib/lwm2m/lwm2m_rd_client/testcase.yaml
@@ -1,9 +1,13 @@
 common:
   depends_on: netif
+  tags: net lwm2m
+  platform_allow: native_posix qemu_x86 qemu_x86_64
+  integration_platforms:
+    - native_posix
+    - qemu_x86
+
 tests:
   subsys.net.lib.lwm2m_rd_client:
-    tags: net lwm2m
-    platform_allow: native_posix qemu_x86 qemu_x86_64
-    integration_platforms:
-      - native_posix
-      - qemu_x86
+    extra_args: EXTRA_CFLAGS=""
+  subsys.net.lib.lwm2m_rd_client_dtls:
+    extra_args: EXTRA_CFLAGS=-DCONFIG_LWM2M_DTLS_SUPPORT


### PR DESCRIPTION
As long the code path differs in case DTLS is used, we need tests for this.