### PR TITLE
Bluetooth: Mesh: fix access to uninitialized memory

### DIFF
--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -1145,7 +1145,7 @@ static void store_pending_mod_sub(struct bt_mesh_model *mod, bool vnd)
 
 static void store_pending_mod_pub(struct bt_mesh_model *mod, bool vnd)
 {
-	struct mod_pub_val pub;
+	struct mod_pub_val pub = {0};
 	char path[20];
 	int err;
 

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -683,7 +683,12 @@ static int mod_pub_status(struct bt_mesh_model *model,
 		}
 
 		if (param->pub) {
-			*param->pub = pub;
+			param->pub->addr = pub.addr;
+			param->pub->app_idx = pub.app_idx;
+			param->pub->cred_flag = pub.cred_flag;
+			param->pub->ttl = pub.ttl;
+			param->pub->period = pub.period;
+			param->pub->transmit = pub.transmit;
 		}
 
 		bt_mesh_msg_ack_ctx_rx(&cli->ack_ctx);

--- a/subsys/bluetooth/mesh/rpl.c
+++ b/subsys/bluetooth/mesh/rpl.c
@@ -290,7 +290,7 @@ BT_MESH_SETTINGS_DEFINE(rpl, "RPL", rpl_set);
 
 static void store_rpl(struct bt_mesh_rpl *entry)
 {
-	struct rpl_val rpl;
+	struct rpl_val rpl = {0};
 	char path[18];
 	int err;
 


### PR DESCRIPTION
Running bsim with Valgrind highlighted a couple of places where read access to uninitialized memory happens. Config client rewrites publication parameters with not initialized uuid pointer. Bitfields those are allocated on the stack keeps not used area uninitialized too.
Uninitialized area is stored in the persistent memory. PR fixes that.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>