### PR TITLE
sys: linear_range: fix return value when window is outside range

### DIFF
--- a/include/zephyr/sys/linear_range.h
+++ b/include/zephyr/sys/linear_range.h
@@ -265,14 +265,33 @@ static inline int linear_range_get_win_index(const struct linear_range *r,
 					     int32_t val_min, int32_t val_max,
 					     uint16_t *idx)
 {
-	int ret;
+	int32_t r_max = linear_range_get_max_value(r);
 
-	ret = linear_range_get_index(r, val_min, idx);
+	if ((val_max < r->min) || (val_min > r_max)) {
+		return -EINVAL;
+	}
+
+	if (val_min < r->min) {
+		*idx = r->min_idx;
+		return -ERANGE;
+	}
+
+	if (val_max > r_max) {
+		*idx = r->max_idx;
+		return -ERANGE;
+	}
+
+	if (r->step == 0U) {
+		*idx = r->min_idx;
+		return 0;
+	}
+
+	*idx = r->min_idx + ceiling_fraction((uint32_t)(val_min - r->min), r->step);
 	if ((r->min + r->step * (*idx - r->min_idx)) > val_max) {
 		return -EINVAL;
 	}
 
-	return ret;
+	return 0;
 }
 
 /**

--- a/tests/lib/linear_range/src/main.c
+++ b/tests/lib/linear_range/src/main.c
@@ -262,12 +262,15 @@ ZTEST(linear_range, test_linear_range_get_win_index)
 	ret = linear_range_get_win_index(&r[0], -20, -15, &idx);
 	zassert_equal(ret, -EINVAL);
 
+	ret = linear_range_get_win_index(&r[0], -4, -3, &idx);
+	zassert_equal(ret, -EINVAL);
+
 	/* out of range, partial intersection (< min, > max) */
 	ret = linear_range_get_win_index(&r[1], -1, 0, &idx);
 	zassert_equal(ret, -ERANGE);
 	zassert_equal(idx, 2U);
 
-	ret = linear_range_get_win_index(&r[1], 2, 3, &idx);
+	ret = linear_range_get_win_index(&r[1], 1, 2, &idx);
 	zassert_equal(ret, -ERANGE);
 	zassert_equal(idx, 3U);
 
@@ -308,7 +311,7 @@ ZTEST(linear_range, test_linear_range_get_win_index)
 	zassert_equal(idx, 2U);
 
 	ret = linear_range_group_get_win_index(r, r_cnt, 1, 120, &idx);
-	zassert_equal(ret, 0);
+	zassert_equal(ret, -ERANGE);
 	zassert_equal(idx, 3U);
 
 	ret = linear_range_group_get_win_index(r, r_cnt, 120, 140, &idx);
@@ -316,8 +319,8 @@ ZTEST(linear_range, test_linear_range_get_win_index)
 	zassert_equal(idx, 5U);
 
 	ret = linear_range_group_get_win_index(r, r_cnt, 140, 400, &idx);
-	zassert_equal(ret, 0);
-	zassert_equal(idx, 6U);
+	zassert_equal(ret, -ERANGE);
+	zassert_equal(idx, 10U);
 
 	ret = linear_range_group_get_win_index(r, r_cnt, 400, 400, &idx);
 	zassert_equal(ret, 0);


### PR DESCRIPTION
linear_range_get_win_index does not behave correctly when the window of values is above the linear range.
It reports -ERANGE (partial intersection) instead of -EINVAL.

Extra conditions added for edge cases and tests cases updated.

Signed-off-by: Andy Sinclair <andy.sinclair@nordicsemi.no>