### PR TITLE
tests: benchmark: no reason why we are excluding architectures

### DIFF
--- a/tests/benchmarks/app_kernel/testcase.yaml
+++ b/tests/benchmarks/app_kernel/testcase.yaml
@@ -3,7 +3,6 @@ common:
   timeout: 420
 tests:
   benchmark.kernel.application:
-    arch_allow: x86 arm riscv32 riscv64
     min_flash: 34
   benchmark.kernel.application.fp:
     extra_args: CONF_FILE=prj_fp.conf
@@ -25,6 +24,3 @@ tests:
     min_flash: 34
     min_ram: 32
     slow: true
-  benchmark.kernel.application.posix:
-    arch_allow: posix
-    min_ram: 32

--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -1,6 +1,5 @@
 tests:
   benchmark.kernel.latency:
-    arch_allow: x86 arm riscv32 riscv64
     # FIXME: no DWT and no RTC_TIMER for qemu_cortex_m0
     platform_exclude: qemu_cortex_m0 m2gl025_miv
     filter: CONFIG_PRINTK and not CONFIG_SOC_FAMILY_STM32
@@ -18,9 +17,8 @@ tests:
   # is achievable only if frequency is below 0x00FFFFFF (around 16MHz)
   # 20 Ticks per secondes allows a frequency up to 335544300Hz (335MHz)
   benchmark.kernel.latency.stm32:
+    arch_allow: arm
     filter: CONFIG_PRINTK and CONFIG_SOC_FAMILY_STM32
-    # FIXME: no DWT and no RTC_TIMER
-    platform_exclude: qemu_cortex_m0
     tags: benchmark
     extra_configs:
       - CONFIG_SYS_CLOCK_TICKS_PER_SEC=20


### PR DESCRIPTION
Can't find a good reason why we are excluding architectures in those
benchmarks. This should be runnable on all.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
