### PR TITLE
dts: arm: st: move can2 definition to stm32h7.dtsi

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -469,12 +469,24 @@
 
 			can1: can@4000a000 {
 				compatible = "st,stm32h7-fdcan";
-				#address-cells = <1>;
-				#size-cells = <0>;
 				reg = <0x4000a000 0x400>, <0x4000ac00 0x350>;
 				reg-names = "m_can", "message_ram";
 				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
 				interrupts = <19 0>, <21 0>, <63 0>;
+				interrupt-names = "LINE_0", "LINE_1", "CALIB";
+				status = "disabled";
+				sjw = <1>;
+				sample-point = <875>;
+				sjw-data = <1>;
+				sample-point-data = <875>;
+			};
+
+			can2: can@4000a400 {
+				compatible = "st,stm32h7-fdcan";
+				reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
+				reg-names = "m_can", "message_ram";
+				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
+				interrupts = <20 0>, <22 0>, <63 0>;
 				interrupt-names = "LINE_0", "LINE_1", "CALIB";
 				status = "disabled";
 				sjw = <1>;

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -102,26 +102,8 @@
 		};
 
 		can {
-			can2: can@4000A400 {
-				compatible = "st,stm32h7-fdcan";
-				#address-cells = <1>;
-				#size-cells = <1>;
-				reg = <0x4000A400 0x400>, <0x4000ac00 0x350>;
-				reg-names = "m_can", "message_ram";
-				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
-				interrupts = <20 0>, <22 0>, <63 0>;
-				interrupt-names = "LINE_0", "LINE_1", "CALIB";
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-				status = "disabled";
-			};
-
 			can3: can@4000D400 {
 				compatible = "st,stm32h7-fdcan";
-				#address-cells = <1>;
-				#size-cells = <1>;
 				reg = <0x4000D400 0x400>, <0x4000ac00 0x350>;
 				reg-names = "m_can", "message_ram";
 				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;


### PR DESCRIPTION
All STM32H7 variants seems to have two fd-can interfaces available. Add a can2 definition in stm32h7.dtsi, drop the current one in stm32h723.dtsi. Also drop the override of address/size cells, this node is not supposed to have any child node so they are not needed.