### PR TITLE
boards: arm: arduino_portenta_h7: fix wrong code block tag

### DIFF
--- a/boards/arm/arduino_portenta_h7/doc/index.rst
+++ b/boards/arm/arduino_portenta_h7/doc/index.rst
@@ -108,7 +108,7 @@ Here is an example for the :ref:`hello_world` application.
 
 Run a serial host program to connect with your board:
 
-code-block:: console
+.. code-block:: console
 
    $ minicom -D /dev/ttyACM0
 


### PR DESCRIPTION
Fix wrong code-block tag in the board documentation.