### PR TITLE
GPIO Hogs: add support for masking the output level

### DIFF
--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -59,6 +59,12 @@ config GPIO_HOGS_INIT_PRIORITY
 	  GPIO hogs initialization priority. GPIO hogs must be initialized after the
 	  GPIO controller drivers.
 
+config GPIO_HOGS_LINE_NAMES
+	bool "Include GPIO hogs line-names"
+	depends on GPIO_HOGS
+	help
+	  Enable support for storing the line-names for GPIO hogs.
+
 config GPIO_HOGS_INITIALIZE_BY_APPLICATION
 	bool "Application controls GPIO hogs initialization"
 	depends on GPIO_HOGS

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -59,6 +59,14 @@ config GPIO_HOGS_INIT_PRIORITY
 	  GPIO hogs initialization priority. GPIO hogs must be initialized after the
 	  GPIO controller drivers.
 
+config GPIO_HOGS_INITIALIZE_BY_APPLICATION
+	bool "Application controls GPIO hogs initialization"
+	depends on GPIO_HOGS
+	help
+	  When enabled, the GPIO hogs driver does not auto initialize and the
+	  application must call gpio_hogs_configure() to trigger the GPIO
+	  configuration.
+
 source "drivers/gpio/Kconfig.b91"
 
 source "drivers/gpio/Kconfig.dw"

--- a/drivers/gpio/gpio_hogs.c
+++ b/drivers/gpio/gpio_hogs.c
@@ -119,6 +119,15 @@ int gpio_hogs_configure(const struct device *port, gpio_flags_t mask)
                                 continue;
                         }
 
+			/*
+			 * Always skip configuring any pin that doesn't specify
+			 * input or output direction. This path allows applications
+			 * to add GPIO hogs for use with the shell commands.
+			 */
+			if ((spec->flags & GPIO_DIR_MASK) == 0) {
+				continue;
+			}
+
 			flags = spec->flags & mask;
 
 			err = gpio_pin_configure(hogs->port, spec->pin, flags);

--- a/drivers/gpio/gpio_hogs.c
+++ b/drivers/gpio/gpio_hogs.c
@@ -14,6 +14,9 @@ LOG_MODULE_REGISTER(gpio_hogs, CONFIG_GPIO_LOG_LEVEL);
 struct gpio_hog_dt_spec {
 	gpio_pin_t pin;
 	gpio_flags_t flags;
+#ifdef CONFIG_GPIO_HOGS_LINE_NAMES
+	const char *name;
+#endif
 };
 
 struct gpio_hogs {
@@ -32,6 +35,8 @@ struct gpio_hogs {
 						 (GPIO_OUTPUT_INACTIVE),			\
 						 (COND_CODE_1(DT_PROP(node_id, output_high),	\
 							     (GPIO_OUTPUT_ACTIVE), (0)))))),	\
+		IF_ENABLED(CONFIG_GPIO_HOGS_LINE_NAMES,                                         \
+			   (.name = DT_GPIO_HOG_LINE_NAME_BY_IDX(node_id, idx),))               \
 	}
 
 /* Expands to 1 if node_id is a GPIO controller, 0 otherwise */

--- a/dts/bindings/gpio/gpio-controller.yaml
+++ b/dts/bindings/gpio/gpio-controller.yaml
@@ -96,7 +96,7 @@ child-binding:
       type: boolean
       description: |
         If this property is set, the GPIO is configured as an output set to logical high.
-    line-name:
-      type: string
+    line-names:
+      type: string-array
       description: |
         Optional GPIO line name.

--- a/include/zephyr/devicetree/gpio.h
+++ b/include/zephyr/devicetree/gpio.h
@@ -363,6 +363,55 @@ extern "C" {
 		    (DT_CAT4(node_id, _GPIO_HOGS_IDX_, idx, _VAL_flags)), (0))
 
 /**
+ * @brief Get a GPIO hog specifier's line-name at an index
+ *
+ * If the line-names property is not specified, it defaults to returning
+ * the GPIO hog node full name, appended with the index.
+ *
+ * Example devicetree fragment:
+ *
+ *     gpio1: gpio@... {
+ *       compatible = "vnd,gpio";
+ *       #gpio-cells = <2>;
+ *
+ *       n1: node-1 {
+ *               gpio-hog;
+ *               gpios = <0 GPIO_ACTIVE_HIGH>, <1 GPIO_ACTIVE_LOW>;
+ *               output-high;
+ * 		 line-names = "GPIO_10", "GPIO_11_L";
+ *       };
+ *
+ *       n2: node-2 {
+ *               gpio-hog;
+ *               gpios = <3 GPIO_ACTIVE_HIGH>, <4 GPIO_ACTIVE_LOW>;
+ *               output-low;
+ *       };
+ *     };
+ *
+ * Bindings fragment for the vnd,gpio compatible:
+ *
+ *     gpio-cells:
+ *       - pin
+ *       - flags
+ *
+ * Example usage:
+ *
+ *     DT_GPIO_HOG_LINE_NAME_BY_IDX(DT_NODELABEL(n1), 0) // "GPIO_10"
+ *     DT_GPIO_HOG_LINE_NAME_BY_IDX(DT_NODELABEL(n1), 1) // "GIPO_11_L"
+ *     DT_GPIO_HOG_LINE_NAME_BY_IDX(DT_NODELABEL(n2), 0) // "n2_0"
+ *     DT_GPIO_HOG_LINE_NAME_BY_IDX(DT_NODELABEL(n2), 0) // "n2_1"
+ *
+ * @param node_id node identifier
+ * @param idx logical index into "line-names"
+ * @return the line-name at index "idx", or the node full name appended with the
+ *         an underscore and an index.
+ */
+#define DT_GPIO_HOG_LINE_NAME_BY_IDX(node_id, idx) \
+	COND_CODE_1(DT_PROP_HAS_IDX(node_id, line_names, idx), \
+		    (DT_CAT5(node_id, _P_, line_names, _IDX_, idx)), \
+		    (DT_NODE_FULL_NAME(node_id) "_" #idx))
+
+/**
  * @deprecated If used to obtain a device instance with device_get_binding,
  * consider using @c DEVICE_DT_GET(DT_INST_GPIO_CTLR_BY_IDX(node, gpio_pha, idx)).
  *

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -136,6 +136,7 @@ extern "C" {
 					GPIO_INT_LOW_0 | \
 					GPIO_INT_HIGH_1)
 
+#define GPIO_FLAGS_ALL                  (~0U)
 /** @endcond */
 
 /** Configures GPIO interrupt to be triggered on pin rising edge and enables it.
@@ -1498,6 +1499,26 @@ static inline int z_impl_gpio_get_pending_int(const struct device *dev)
 
 	return api->get_pending_int(dev);
 }
+
+/**
+ * @brief GPIO hog configure
+ *
+ * This function walks the list of of GPIO hogs created from the devicetree,
+ * applying the GPIO pin configuration to each GPIO hog.
+ *
+ * Note that when GPIO_HOGS_INITIALIZE_BY_APPLICATION=n, then GPIO hogs driver
+ * automatically configures all GPIO hogs via SYS_INIT().
+ *
+ * When GPIO_HOGS_INITIALIZE_BY_APPLICATION=y, this function allows the
+ * application run-time control over the GPIO hog configuration.
+ *
+ * @param port Specifies the specific GPIO port to apply the GPIO hog
+ *             configuration. If NULL, than all GPIO hogs are updated.
+ * @param mask Specifies the mask of GPIO flags to apply during the GPIO hog
+ *             configuration. Set to GPIO_FLAGS_ALL to apply all flags set
+ *             by the devicetree configuration.
+ */
+int gpio_hogs_configure(const struct device *port, gpio_flags_t mask);
 
 /**
  * @}

--- a/tests/drivers/gpio/gpio_hogs/CMakeLists.txt
+++ b/tests/drivers/gpio/gpio_hogs/CMakeLists.txt
@@ -4,5 +4,10 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gpio_hogs)
 
-FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
+target_sources(app PRIVATE src/common.c)
+
+if(CONFIG_GPIO_HOGS_INITIALIZE_BY_APPLICATION)
+  target_sources(app PRIVATE src/init_by_application.c)
+else()
+  target_sources(app PRIVATE src/main.c)
+endif()

--- a/tests/drivers/gpio/gpio_hogs/boards/frdm_k64f.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/frdm_k64f.overlay
@@ -8,9 +8,11 @@
 
 / {
      zephyr,user {
-             output-high-gpios = <&gpioc 5 GPIO_ACTIVE_LOW>;
+             output-high-gpios = <&gpioc 5 GPIO_ACTIVE_LOW>,
+                                 <&gpiob 21 GPIO_ACTIVE_HIGH>;
              output-low-gpios = <&gpiob 20 GPIO_ACTIVE_HIGH>;
              input-gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
+	     output-high-masked-gpios = <&gpiob 21 GPIO_ACTIVE_HIGH>;
      };
 };
 
@@ -33,5 +35,11 @@
 		gpio-hog;
 		gpios = <20 GPIO_ACTIVE_HIGH>;
 		output-low;
+	};
+
+	hog4 {
+		gpio-hog;
+		gpios = <21 GPIO_ACTIVE_HIGH>;
+		output-high;
 	};
 };

--- a/tests/drivers/gpio/gpio_hogs/boards/native_posix.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/native_posix.overlay
@@ -8,7 +8,8 @@
 
 / {
      zephyr,user {
-             output-high-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+             output-high-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>,
+	     			 <&gpio0 4 GPIO_ACTIVE_HIGH>;
              output-low-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
              input-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
      };
@@ -31,5 +32,11 @@
 		gpio-hog;
 		gpios = <3 GPIO_ACTIVE_HIGH>;
 		input;
+	};
+
+	hog4 {
+		gpio-hog;
+		gpios = <4 GPIO_ACTIVE_HIGH>;
+		output-high;
 	};
 };

--- a/tests/drivers/gpio/gpio_hogs/boards/native_posix.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/native_posix.overlay
@@ -18,8 +18,9 @@
 &gpio0 {
 	hog1 {
 		gpio-hog;
-		gpios = <1 GPIO_ACTIVE_LOW>;
+		gpios = <1 GPIO_ACTIVE_LOW>, <4 GPIO_ACTIVE_HIGH>;
 		output-high;
+                line-names = "GPIO_01_L", "GPIO_04";
 	};
 
 	hog2 {
@@ -32,11 +33,5 @@
 		gpio-hog;
 		gpios = <3 GPIO_ACTIVE_HIGH>;
 		input;
-	};
-
-	hog4 {
-		gpio-hog;
-		gpios = <4 GPIO_ACTIVE_HIGH>;
-		output-high;
 	};
 };

--- a/tests/drivers/gpio/gpio_hogs/boards/native_posix_64.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/native_posix_64.overlay
@@ -8,9 +8,10 @@
 
 / {
      zephyr,user {
-             output-high-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
-             output-low-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+             output-high-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>,
+                                 <&gpio0 4 GPIO_ACTIVE_HIGH>;
              input-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+	     output-high-masked-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
      };
 };
 
@@ -31,5 +32,11 @@
 		gpio-hog;
 		gpios = <3 GPIO_ACTIVE_HIGH>;
 		input;
+	};
+
+	hog4 {
+		gpio-hog;
+		gpios = <4 GPIO_ACTIVE_HIGH>;
+		output-high;
 	};
 };

--- a/tests/drivers/gpio/gpio_hogs/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/nrf52840dk_nrf52840.overlay
@@ -8,9 +8,10 @@
 
 / {
      zephyr,user {
-             output-high-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
-             output-low-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+             output-high-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>,
+                                 <&gpio0 10 GPIO_ACTIVE_HIGH>;
              input-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+	     output-high-masked-gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
      };
 };
 
@@ -31,5 +32,11 @@
 		gpio-hog;
 		gpios = <11 GPIO_ACTIVE_LOW>;
 		input;
+	};
+
+	hog4 {
+		gpio-hog;
+		gpios = <10 GPIO_ACTIVE_HIGH>;
+		output-high;
 	};
 };

--- a/tests/drivers/gpio/gpio_hogs/boards/nucleo_g474re.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/nucleo_g474re.overlay
@@ -8,9 +8,10 @@
 
 / {
      zephyr,user {
-             output-high-gpios = <&gpioc 2 GPIO_ACTIVE_LOW>;
-             output-low-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
+             output-high-gpios = <&gpioc 2 GPIO_ACTIVE_LOW>,
+                                 <&gpiof 1 GPIO_ACTIVE_HIGH>;
              input-gpios = <&gpioc 3 GPIO_ACTIVE_HIGH>;
+             output-high-masked-gpios = <&gpiof 2 GPIO_ACTIVE_HIGH>;
      };
 };
 
@@ -33,5 +34,11 @@
 		gpio-hog;
 		gpios = <1 GPIO_ACTIVE_HIGH>;
 		output-low;
+	};
+
+	hog4 {
+		gpio-hog;
+		gpios = <2 GPIO_ACTIVE_HIGH>;
+		output-high;
 	};
 };

--- a/tests/drivers/gpio/gpio_hogs/src/common.c
+++ b/tests/drivers/gpio/gpio_hogs/src/common.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Google, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(test_gpio_hogs, CONFIG_GPIO_LOG_LEVEL);
+
+void assert_gpio_hog_direction(const struct gpio_dt_spec *spec, bool output)
+{
+	int err;
+
+	if (spec->port == NULL) {
+		ztest_test_skip();
+	}
+
+	if (output) {
+		err = gpio_pin_is_output(spec->port, spec->pin);
+	} else {
+		err = gpio_pin_is_input(spec->port, spec->pin);
+	}
+
+	if (err == -ENOSYS) {
+		ztest_test_skip();
+	}
+
+	zassert_equal(err, 1, "GPIO hog %s pin %d not configured as %s",
+		      spec->port->name, spec->pin,
+		      output ? "output" : "input");
+}
+
+void assert_gpio_hog_config(const struct gpio_dt_spec *spec, gpio_flags_t expected)
+{
+	gpio_flags_t actual;
+	int err;
+
+	if (spec->port == NULL) {
+		ztest_test_skip();
+	}
+
+	err = gpio_pin_get_config_dt(spec, &actual);
+	if (err == -ENOSYS) {
+		ztest_test_skip();
+	}
+
+	LOG_INF("Get config: Pin %d, flags 0x%08x",
+		spec->pin, actual);
+	if (actual & GPIO_OUTPUT) {
+		LOG_INF("    level = %s", actual & GPIO_OUTPUT_INIT_HIGH ? "HIGH" : "low");
+	}
+
+	zassert_equal(err, 0, "failed to get config for GPIO hog %s, pin %d (err %d)",
+		      spec->port->name, spec->pin, err);
+	zassert_equal(actual & expected, expected,
+		      "GPIO hog %s, pin %d flags not set (0x%08x vs. 0x%08x)",
+		      spec->port->name, spec->pin, actual, expected);
+}

--- a/tests/drivers/gpio/gpio_hogs/src/common.h
+++ b/tests/drivers/gpio/gpio_hogs/src/common.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023 Google, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_TEST_DRIVERS_GPIO_GPIO_HOGS_COMMON_H_
+#define ZEPHYR_TEST_DRIVERS_GPIO_GPIO_HOGS_COMMON_H_
+
+#include <zephyr/drivers/gpio.h>
+
+void assert_gpio_hog_direction(const struct gpio_dt_spec *spec, bool output);
+void assert_gpio_hog_config(const struct gpio_dt_spec *spec, gpio_flags_t expected);
+
+#endif /* ZEPHYR_TEST_DRIVERS_GPIO_GPIO_HOGS_COMMON_H_ */

--- a/tests/drivers/gpio/gpio_hogs/src/init_by_application.c
+++ b/tests/drivers/gpio/gpio_hogs/src/init_by_application.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 Google, LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "common.h"
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
+
+#define ZEPHYR_USER_NODE DT_PATH(zephyr_user)
+
+#define GPIO_MASK_NO_OUTPUT \
+	GPIO_FLAGS_ALL & \
+        ~(GPIO_OUTPUT_INIT_LOW | GPIO_OUTPUT_INIT_HIGH | GPIO_OUTPUT_INIT_LOGICAL)
+
+const struct gpio_dt_spec output_high_gpio_specs[] = {
+	DT_FOREACH_PROP_ELEM_SEP(ZEPHYR_USER_NODE, output_high_gpios,
+				 GPIO_DT_SPEC_GET_BY_IDX, (,))
+};
+const struct gpio_dt_spec input_gpio =
+	GPIO_DT_SPEC_GET_OR(ZEPHYR_USER_NODE, input_gpios, {0});
+
+/*
+ * @brief Verify that the GPIO hogs driver did not automatically configure
+ * any GPIO pins when CONFIG_GPIO_HOGS_INITIALIZE_BY_APPLICATION=y.
+ */
+ZTEST(gpio_hogs_init_by_app, test_gpio_hogs_not_configured)
+{
+	const struct gpio_dt_spec *spec;
+	int err;
+
+	for (int i = 0; i < ARRAY_SIZE(output_high_gpio_specs); i++) {
+		spec = &output_high_gpio_specs[i];
+
+		err = gpio_pin_is_output(spec->port, spec->pin);
+
+		if (err == -ENOSYS) {
+			ztest_test_skip();
+		}
+
+		zassert_equal(err, 0, "GPIO hog %s pin %d configured as output, but should not be",
+			spec->port->name, spec->pin);
+	}
+
+	err = gpio_pin_is_input(input_gpio.port, spec->pin);
+	zassert_equal(err, 0, "GPIO hog %s pin %d configured as input, but should not be",
+		spec->port->name, spec->pin);
+}
+
+/*
+ * @brief Verify that the GPIO hogs driver respects the mask parameter.
+ */
+ZTEST(gpio_hogs_init_by_app, test_masked_output_level)
+{
+	gpio_flags_t expected;
+	const struct gpio_dt_spec *spec;
+
+	gpio_hogs_configure(NULL, GPIO_MASK_NO_OUTPUT);
+
+	for (int i = 0; i < ARRAY_SIZE(output_high_gpio_specs); i++) {
+		spec = &output_high_gpio_specs[i];
+
+		/* GPIO pin state should always by low when applying the GPIO_OUTPUT_INIT_MASK */
+		expected = GPIO_OUTPUT | GPIO_OUTPUT_INIT_LOW;
+
+		assert_gpio_hog_config(spec, expected);
+	}
+}
+
+/*
+ * @brief Verify that the GPIO hogs driver respects the port parameter.
+ */
+#if 0
+// FIXME - need to add another GPIO port to the overlay
+ZTEST(gpio_hogs_init_by_app, test_gpio_port)
+{
+	gpio_flags_t expected;
+	const struct gpio_dt_spec *spec;
+
+	gpio_hogs_configure(GPIO_MASK_NO_OUTPUT);
+
+	for (int i = 0; i < ARRAY_SIZE(output_high_gpio_specs); i++) {
+		spec = &output_high_gpio_specs[i];
+
+		/* GPIO pin state should always by low when applying the GPIO_OUTPUT_INIT_MASK */
+		expected = GPIO_OUTPUT | GPIO_OUTPUT_INIT_LOW;
+
+		assert_gpio_hog_config(spec, expected);
+	}
+}
+#endif
+
+ZTEST_SUITE(gpio_hogs_init_by_app, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/gpio/gpio_hogs/src/main.c
+++ b/tests/drivers/gpio/gpio_hogs/src/main.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "common.h"
+
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/ztest.h>
 
@@ -17,29 +19,6 @@ const struct gpio_dt_spec output_low_gpio =
 	GPIO_DT_SPEC_GET_OR(ZEPHYR_USER_NODE, output_low_gpios, {0});
 const struct gpio_dt_spec input_gpio =
 	GPIO_DT_SPEC_GET_OR(ZEPHYR_USER_NODE, input_gpios, {0});
-
-static void assert_gpio_hog_direction(const struct gpio_dt_spec *spec, bool output)
-{
-	int err;
-
-	if (spec->port == NULL) {
-		ztest_test_skip();
-	}
-
-	if (output) {
-		err = gpio_pin_is_output(spec->port, spec->pin);
-	} else {
-		err = gpio_pin_is_input(spec->port, spec->pin);
-	}
-
-	if (err == -ENOSYS) {
-		ztest_test_skip();
-	}
-
-	zassert_equal(err, 1, "GPIO hog %s pin %d not configured as %s",
-		      spec->port->name, spec->pin,
-		      output ? "output" : "input");
-}
 
 ZTEST(gpio_hogs, test_gpio_hog_output_high_direction)
 {
@@ -56,27 +35,6 @@ ZTEST(gpio_hogs, test_gpio_hog_output_low_direction)
 ZTEST(gpio_hogs, test_gpio_hog_input_direction)
 {
 	assert_gpio_hog_direction(&input_gpio, false);
-}
-
-static void assert_gpio_hog_config(const struct gpio_dt_spec *spec, gpio_flags_t expected)
-{
-	gpio_flags_t actual;
-	int err;
-
-	if (spec->port == NULL) {
-		ztest_test_skip();
-	}
-
-	err = gpio_pin_get_config_dt(spec, &actual);
-	if (err == -ENOSYS) {
-		ztest_test_skip();
-	}
-
-	zassert_equal(err, 0, "failed to get config for GPIO hog %s, pin %d (err %d)",
-		      spec->port->name, spec->pin, err);
-	zassert_equal(actual & expected, expected,
-		      "GPIO hog %s, pin %d flags not set (0x%08x vs. 0x%08x)",
-		      spec->port->name, spec->pin, actual, expected);
 }
 
 ZTEST(gpio_hogs, test_gpio_hog_output_high_config)

--- a/tests/drivers/gpio/gpio_hogs/testcase.yaml
+++ b/tests/drivers/gpio/gpio_hogs/testcase.yaml
@@ -6,3 +6,15 @@ tests:
     integration_platforms:
       - native_posix
       - native_posix_64
+  peripheral.gpio.hogs.app_init:
+    tags: drivers gpio
+    depends_on: gpio
+    # Note - This test verifies that both gpio_pin_is_input() and gpio_pin_is_output()
+    # return 0 out of reset, but this contract is only guaranteed by the GPIO
+    # emulator.
+    platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix
+      - native_posix_64
+    extra_configs:
+      - CONFIG_GPIO_HOGS_INITIALIZE_BY_APPLICATION=y


### PR DESCRIPTION
Allow applications to prevent the GPIO hogs driver from changing the physical state of a pin during GPIO configuration. 

One potential use case is an application that initiates a software jump between Zephyr images.  The first image that runs from the power on reset configures all GPIO hogs normally, but the second image doesn't want to change the physical state of any output pins, which might have side effects on the operation of the board.