### PR TITLE
MCUMGR image confirm wrongly returns MGMT_ERR_EINVAL

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -290,7 +290,7 @@ img_mgmt_state_write(struct smp_streamer *ctxt)
 	ok = zcbor_map_decode_bulk(zsd, image_list_decode,
 		ARRAY_SIZE(image_list_decode), &decoded) == 0;
 
-	if (!ok) {
+	if (ok) {
 		return MGMT_ERR_EINVAL;
 	}
 


### PR DESCRIPTION
When used as intended "mcumgr image confirm" would return error instead of correctly confirming running image.