### PR TITLE
rak5010_nrf52840: fix lis3dh irq gpio

### DIFF
--- a/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
+++ b/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
@@ -99,7 +99,7 @@
 	lis3dh: lis3dh@19 {
 		compatible = "st,lis3dh", "st,lis2dh";
 		reg = <0x19>;
-		irq-gpios = <&gpio0 15 0>;
+		irq-gpios = <&gpio0 16 0>;
 	};
 
 	/* ST Microelectronics LPS22HB pressure sensor */


### PR DESCRIPTION
This pull request fix the LIS3DH configuration of the irq-gpio that I have reported at https://github.com/zephyrproject-rtos/zephyr/issues/54844.