### PR TITLE
drivers: usb_dc_dw: cleanup, move USB_DW macros to driver code, use on additional platforms

### DIFF
--- a/boards/arm/cyclonev_socdk/cyclonev_socdk.dts
+++ b/boards/arm/cyclonev_socdk/cyclonev_socdk.dts
@@ -88,3 +88,8 @@
 		zephyr,ocm		= &ocram;
 	};
 };
+
+zephyr_udc0: &usb1 {
+	compatible = "snps,dwc2";
+	status = "okay";
+};

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -23,7 +23,7 @@ config USB_DEVICE_REMOTE_WAKEUP
 config USB_DW
 	bool "Designware USB Device Controller Driver"
 	default y
-	depends on DT_HAS_SNPS_DESIGNWARE_USB_ENABLED
+	depends on DT_HAS_SNPS_DWC2_ENABLED
 	help
 	  Designware USB Device Controller Driver.
 

--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -236,7 +236,7 @@ static int usb_dw_set_fifo(uint8_t ep)
 	volatile uint32_t *reg = &base->in_ep_reg[ep_idx].diepctl;
 	uint32_t val;
 	int fifo = 0;
-	int ded_fifo = !!(base->ghwcfg4 & USB_DW_HWCFG4_DEDFIFOMODE);
+	int ded_fifo = !!(base->ghwcfg4 & USB_DW_GHWCFG4_DEDFIFOMODE);
 
 	if (!ded_fifo) {
 		/* No support for shared-FIFO mode yet, existing

--- a/drivers/usb/device/usb_dc_dw_stm32.h
+++ b/drivers/usb/device/usb_dc_dw_stm32.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_USB_DEVICE_USB_DC_DW_STM32_H
+#define ZEPHYR_DRIVERS_USB_DEVICE_USB_DC_DW_STM32_H
+
+#include <stdint.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+
+#include "usb_dw_registers.h"
+
+struct usb_dw_stm32_clk {
+	const struct device *const dev;
+	const struct stm32_pclken *const pclken;
+	size_t pclken_len;
+};
+
+static inline int clk_enable_st_stm32f4_fsotg(const struct usb_dw_stm32_clk *const clk)
+{
+	int ret;
+
+	if (!device_is_ready(clk->dev)) {
+		return -ENODEV;
+	}
+
+	if (clk->pclken_len > 1) {
+		uint32_t clk_rate;
+
+		ret = clock_control_configure(clk->dev,
+					      (void *)&clk->pclken[1],
+					      NULL);
+		if (ret) {
+			return ret;
+		}
+
+		ret = clock_control_get_rate(clk->dev,
+					     (void *)&clk->pclken[1],
+					     &clk_rate);
+		if (ret) {
+			return ret;
+		}
+
+		if (clk_rate != MHZ(48)) {
+			return -ENOTSUP;
+		}
+	}
+
+	return clock_control_on(clk->dev, (void *)&clk->pclken[0]);
+}
+
+static inline int pwr_on_st_stm32f4_fsotg(struct usb_dw_reg *const base)
+{
+	base->ggpio |= USB_DW_GGPIO_STM32_PWRDWN | USB_DW_GGPIO_STM32_VBDEN;
+
+	return 0;
+}
+
+#define QUIRK_ST_STM32F4_FSOTG_DEFINE(n)					\
+	static const struct stm32_pclken pclken_##n[] = STM32_DT_INST_CLOCKS(n);\
+										\
+	static const struct usb_dw_stm32_clk stm32f4_clk_##n = {		\
+		.dev = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),			\
+		.pclken = pclken_##n,						\
+		.pclken_len = DT_INST_NUM_CLOCKS(n),				\
+	};									\
+										\
+	static int clk_enable_st_stm32f4_fsotg_##n(void)			\
+	{									\
+		return clk_enable_st_stm32f4_fsotg(&stm32f4_clk_##n);		\
+	}
+
+#define USB_DW_QUIRK_ST_STM32F4_FSOTG_DEFINE(n)					\
+	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_DRV_INST(n), st_stm32f4_fsotg),	\
+		    (QUIRK_ST_STM32F4_FSOTG_DEFINE(n)), ())
+
+#endif /* ZEPHYR_DRIVERS_USB_DEVICE_USB_DC_DW_STM32_H */

--- a/drivers/usb/device/usb_dw_registers.h
+++ b/drivers/usb/device/usb_dw_registers.h
@@ -1,28 +1,23 @@
 /*
  * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
- * @file
- * @brief Designware USB device controller driver private definitions
- *
- * This file contains the Designware USB device controller driver private
- * definitions.
  */
 
 #ifndef ZEPHYR_DRIVERS_USB_DEVICE_USB_DW_REGISTERS_H_
 #define ZEPHYR_DRIVERS_USB_DEVICE_USB_DW_REGISTERS_H_
 
-#include <zephyr/sys/util.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* Number of USB controllers */
-enum USB_DW_N { USB_DW_0 = 0, USB_DW_NUM };
+/*
+ * This file describes register set for the DesignWare USB 2.0 controller IP,
+ * other known names are OTG_FS, OTG_HS.
+ */
 
 /* USB IN EP Register block type */
 struct usb_dw_in_ep_reg {
@@ -74,7 +69,9 @@ struct usb_dw_reg {
 	volatile uint32_t dieptxf3;
 	volatile uint32_t dieptxf4;
 	volatile uint32_t dieptxf5;
+	/* Host mode register 0x0400 .. 0x0670 */
 	uint32_t reserved2[442];
+	/* Device mode register 0x0800 .. 0x0D00 */
 	volatile uint32_t dcfg;
 	volatile uint32_t dctl;
 	volatile uint32_t dsts;
@@ -93,88 +90,139 @@ struct usb_dw_reg {
 	struct usb_dw_out_ep_reg out_ep_reg[16];
 };
 
-/* USB register offsets and masks */
-#define USB_DW_HWCFG4_DEDFIFOMODE BIT(25)
-#define USB_DW_GUSBCFG_PHY_IF_MASK BIT(3)
-#define USB_DW_GUSBCFG_PHY_IF_8_BIT (0)
-#define USB_DW_GUSBCFG_PHY_IF_16_BIT (1<<3)
-#define USB_DW_GRSTCTL_AHB_IDLE BIT(31)
-#define USB_DW_GRSTCTL_TX_FNUM_OFFSET (6)
-#define USB_DW_GRSTCTL_TX_FFLSH BIT(5)
-#define USB_DW_GRSTCTL_C_SFT_RST BIT(0)
-#define USB_DW_GAHBCFG_DMA_EN BIT(5)
-#define USB_DW_GAHBCFG_GLB_INTR_MASK BIT(0)
-#define USB_DW_DCTL_SFT_DISCON BIT(1)
-#define USB_DW_GINTSTS_WK_UP_INT BIT(31)
-#define USB_DW_GINTSTS_OEP_INT BIT(19)
-#define USB_DW_GINTSTS_IEP_INT BIT(18)
-#define USB_DW_GINTSTS_ENUM_DONE BIT(13)
-#define USB_DW_GINTSTS_USB_RST BIT(12)
-#define USB_DW_GINTSTS_USB_SUSP BIT(11)
-#define USB_DW_GINTSTS_RX_FLVL BIT(4)
-#define USB_DW_GINTSTS_OTG_INT BIT(2)
-#define USB_DW_DCFG_DEV_SPD_USB2_HS (0)
-#define USB_DW_DCFG_DEV_SPD_USB2_FS (0x1)
-#define USB_DW_DCFG_DEV_SPD_LS (0x2)
-#define USB_DW_DCFG_DEV_SPD_FS (0x3)
-#define USB_DW_DCFG_DEV_ADDR_MASK (0x7F << 4)
-#define USB_DW_DCFG_DEV_ADDR_OFFSET (4)
-#define USB_DW_DAINT_IN_EP_INT(ep) (1 << (ep))
-#define USB_DW_DAINT_OUT_EP_INT(ep) (0x10000 << (ep))
-#define USB_DW_DEPCTL_EP_ENA BIT(31)
-#define USB_DW_DEPCTL_EP_DIS BIT(30)
-#define USB_DW_DEPCTL_SETDOPID BIT(28)
-#define USB_DW_DEPCTL_SNAK BIT(27)
-#define USB_DW_DEPCTL_CNAK BIT(26)
-#define USB_DW_DEPCTL_STALL BIT(21)
-#define USB_DW_DEPCTL_TXFNUM_OFFSET (22)
-#define USB_DW_DEPCTL_TXFNUM_MASK (0xf << 22)
-#define USB_DW_DEPCTL_EP_TYPE_MASK (0x3 << 18)
-#define USB_DW_DEPCTL_EP_TYPE_OFFSET (18)
-#define USB_DW_DEPCTL_EP_TYPE_CONTROL (0)
-#define USB_DW_DEPCTL_EP_TYPE_ISO (0x1)
-#define USB_DW_DEPCTL_EP_TYPE_BULK (0x2)
-#define USB_DW_DEPCTL_EP_TYPE_INTERRUPT (0x3)
-#define USB_DW_DEPCTL_USB_ACT_EP BIT(15)
-#define USB_DW_DEPCTL0_MSP_MASK (0x3)
-#define USB_DW_DEPCTL0_MSP_8 (0x3)
-#define USB_DW_DEPCTL0_MSP_16 (0x2)
-#define USB_DW_DEPCTL0_MSP_32 (0x1)
-#define USB_DW_DEPCTL0_MSP_64 (0)
-#define USB_DW_DEPCTLn_MSP_MASK (0x3FF)
-#define USB_DW_DEPCTL_MSP_OFFSET (0)
-#define USB_DW_DOEPTSIZ_SUP_CNT_MASK (0x3 << 29)
-#define USB_DW_DOEPTSIZ_SUP_CNT_OFFSET (29)
-#define USB_DW_DOEPTSIZ0_PKT_CNT_MASK (0x1 << 19)
-#define USB_DW_DOEPTSIZn_PKT_CNT_MASK (0x3FF << 19)
-#define USB_DW_DIEPTSIZ0_PKT_CNT_MASK (0x3 << 19)
-#define USB_DW_DIEPTSIZn_PKT_CNT_MASK (0x3FF << 19)
-#define USB_DW_DEPTSIZ_PKT_CNT_OFFSET (19)
-#define USB_DW_DEPTSIZ0_XFER_SIZE_MASK (0x7F)
-#define USB_DW_DEPTSIZn_XFER_SIZE_MASK (0x7FFFF)
-#define USB_DW_DEPTSIZ_XFER_SIZE_OFFSET (0)
-#define USB_DW_DIEPINT_XFER_COMPL BIT(0)
-#define USB_DW_DIEPINT_TX_FEMP BIT(7)
-#define USB_DW_DIEPINT_XFER_COMPL BIT(0)
-#define USB_DW_DOEPINT_SET_UP BIT(3)
-#define USB_DW_DOEPINT_XFER_COMPL BIT(0)
-#define USB_DW_DSTS_ENUM_SPD_MASK (0x3)
-#define USB_DW_DSTS_ENUM_SPD_OFFSET (1)
-#define USB_DW_DSTS_ENUM_LS (2)
-#define USB_DW_DSTS_ENUM_FS (3)
-#define USB_DW_GRXSTSR_EP_NUM_MASK (0xF << 0)
-#define USB_DW_GRXSTSR_PKT_STS_MASK (0xF << 17)
-#define USB_DW_GRXSTSR_PKT_STS_OFFSET (17)
-#define USB_DW_GRXSTSR_PKT_CNT_MASK (0x7FF << 4)
-#define USB_DW_GRXSTSR_PKT_CNT_OFFSET (4)
-#define USB_DW_GRXSTSR_PKT_STS_OUT_DATA (2)
-#define USB_DW_GRXSTSR_PKT_STS_OUT_DATA_DONE (3)
-#define USB_DW_GRXSTSR_PKT_STS_SETUP_DONE (4)
-#define USB_DW_GRXSTSR_PKT_STS_SETUP (6)
-#define USB_DW_DTXFSTS_TXF_SPC_AVAIL_MASK (0xFFFF)
+/*
+ * With the maximum number of supported endpoints, register set
+ * of the controller can occupy the region up to 0x0D00.
+ */
+BUILD_ASSERT(sizeof(struct usb_dw_reg) <= 0x0D00);
 
-#define USB_DW_CORE_RST_TIMEOUT_US 10000
-#define USB_DW_PLL_TIMEOUT_US 100
+/* AHB configuration register, offset: 0x0008 */
+#define USB_DW_GAHBCFG_DMA_EN			BIT(5)
+#define USB_DW_GAHBCFG_GLB_INTR_MASK		BIT(0)
+
+/* USB configuration register, offset: 0x000C */
+#define USB_DW_GUSBCFG_PHY_IF_MASK		BIT(3)
+#define USB_DW_GUSBCFG_PHY_IF_8_BIT		0
+#define USB_DW_GUSBCFG_PHY_IF_16_BIT		BIT(3)
+
+/* Reset register, offset: 0x0010 */
+#define USB_DW_GRSTCTL_AHB_IDLE			BIT(31)
+#define USB_DW_GRSTCTL_TX_FNUM_OFFSET		6
+#define USB_DW_GRSTCTL_TX_FFLSH			BIT(5)
+#define USB_DW_GRSTCTL_C_SFT_RST		BIT(0)
+
+/* Core interrupt register, offset: 0x0014 */
+#define USB_DW_GINTSTS_WK_UP_INT		BIT(31)
+#define USB_DW_GINTSTS_OEP_INT			BIT(19)
+#define USB_DW_GINTSTS_IEP_INT			BIT(18)
+#define USB_DW_GINTSTS_ENUM_DONE		BIT(13)
+#define USB_DW_GINTSTS_USB_RST			BIT(12)
+#define USB_DW_GINTSTS_USB_SUSP			BIT(11)
+#define USB_DW_GINTSTS_RX_FLVL			BIT(4)
+#define USB_DW_GINTSTS_OTG_INT			BIT(2)
+
+/* Status read and pop registers (device mode), offset: 0x001C 0x0020 */
+#define USB_DW_GRXSTSR_PKT_STS_MASK		(0xF << 17)
+#define USB_DW_GRXSTSR_PKT_STS_OFFSET		17
+#define USB_DW_GRXSTSR_PKT_STS_OUT_DATA		2
+#define USB_DW_GRXSTSR_PKT_STS_OUT_DATA_DONE	3
+#define USB_DW_GRXSTSR_PKT_STS_SETUP_DONE	4
+#define USB_DW_GRXSTSR_PKT_STS_SETUP		6
+#define USB_DW_GRXSTSR_PKT_CNT_MASK		(0x7FF << 4)
+#define USB_DW_GRXSTSR_PKT_CNT_OFFSET		4
+#define USB_DW_GRXSTSR_EP_NUM_MASK		(0xF << 0)
+
+/* ? register, offset: 0x0050 */
+#define USB_DW_HWCFG4_DEDFIFOMODE		BIT(25)
+
+/* Device configuration registers, offset: 0x0800 */
+#define USB_DW_DCFG_DEV_ADDR_MASK		(0x7F << 4)
+#define USB_DW_DCFG_DEV_ADDR_OFFSET		4
+#define USB_DW_DCFG_DEV_SPD_USB2_HS		0
+#define USB_DW_DCFG_DEV_SPD_USB2_FS		1
+#define USB_DW_DCFG_DEV_SPD_LS			2
+#define USB_DW_DCFG_DEV_SPD_FS			3
+
+/* Device control register, offset 0x0804 */
+#define USB_DW_DCTL_SFT_DISCON			BIT(1)
+
+/* Device status register, offset 0x0808 */
+#define USB_DW_DSTS_ENUM_SPD_MASK		(0x3 << 1)
+#define USB_DW_DSTS_ENUM_SPD_OFFSET		1
+#define USB_DW_DSTS_ENUM_LS			2
+#define USB_DW_DSTS_ENUM_FS			3
+
+/* Device all endpoints interrupt register, offset 0x0818 */
+#define USB_DW_DAINT_OUT_EP_INT(ep)		(0x10000 << (ep))
+#define USB_DW_DAINT_IN_EP_INT(ep)		(1 << (ep))
+
+/*
+ * Device IN/OUT endpoint control register
+ * IN endpoint offsets 0x0900 + (0x20 * n), n = 0 .. x,
+ * offset 0x0900 and 0x0B00 are hardcoded to control type.
+ *
+ * REVISE: Better own defenitions for DIEPTCTL0, DOEPTCTL0...
+ */
+#define USB_DW_DEPCTL_EP_ENA			BIT(31)
+#define USB_DW_DEPCTL_EP_DIS			BIT(30)
+#define USB_DW_DEPCTL_SETDOPID			BIT(28)
+#define USB_DW_DEPCTL_SNAK			BIT(27)
+#define USB_DW_DEPCTL_CNAK			BIT(26)
+#define USB_DW_DEPCTL_STALL			BIT(21)
+#define USB_DW_DEPCTL_TXFNUM_OFFSET		22
+#define USB_DW_DEPCTL_TXFNUM_MASK		(0xF << 22)
+#define USB_DW_DEPCTL_EP_TYPE_MASK		(0x3 << 18)
+#define USB_DW_DEPCTL_EP_TYPE_OFFSET		18
+#define USB_DW_DEPCTL_EP_TYPE_INTERRUPT		3
+#define USB_DW_DEPCTL_EP_TYPE_BULK		2
+#define USB_DW_DEPCTL_EP_TYPE_ISO		1
+#define USB_DW_DEPCTL_EP_TYPE_CONTROL		0
+#define USB_DW_DEPCTL_USB_ACT_EP		BIT(15)
+#define USB_DW_DEPCTL0_MSP_MASK			0x3
+#define USB_DW_DEPCTL0_MSP_8			3
+#define USB_DW_DEPCTL0_MSP_16			2
+#define USB_DW_DEPCTL0_MSP_32			1
+#define USB_DW_DEPCTL0_MSP_64			0
+#define USB_DW_DEPCTLn_MSP_MASK			0x3FF
+#define USB_DW_DEPCTL_MSP_OFFSET		0
+
+/*
+ * Device IN endpoint interrupt register
+ * offsets 0x0908 + (0x20 * n), n = 0 .. x
+ */
+#define USB_DW_DIEPINT_TX_FEMP			BIT(7)
+#define USB_DW_DIEPINT_XFER_COMPL		BIT(0)
+
+/*
+ * Device OUT endpoint interrupt register
+ * offsets 0x0B08 + (0x20 * n), n = 0 .. x
+ */
+#define USB_DW_DOEPINT_SET_UP			BIT(3)
+#define USB_DW_DOEPINT_XFER_COMPL		BIT(0)
+
+/*
+ * Device IN/OUT endpoint transfer size register
+ * IN at offsets 0x0910 + (0x20 * n), n = 0 .. x,
+ * OUT at offsets 0x0B10 + (0x20 * n), n = 0 .. x
+ *
+ * REVISE: Better own defenitions for DIEPTSIZ0, DOEPTSIZ0...
+ */
+#define USB_DW_DEPTSIZ_PKT_CNT_OFFSET		19
+#define USB_DW_DIEPTSIZ0_PKT_CNT_MASK		(0x3 << 19)
+#define USB_DW_DIEPTSIZn_PKT_CNT_MASK		(0x3FF << 19)
+#define USB_DW_DOEPTSIZn_PKT_CNT_MASK		(0x3FF << 19)
+#define USB_DW_DOEPTSIZ0_PKT_CNT_MASK		(0x1 << 19)
+#define USB_DW_DOEPTSIZ_SUP_CNT_OFFSET		29
+#define USB_DW_DOEPTSIZ_SUP_CNT_MASK		(0x3 << 29)
+#define USB_DW_DEPTSIZ_XFER_SIZE_OFFSET		0
+#define USB_DW_DEPTSIZ0_XFER_SIZE_MASK		0x7F
+#define USB_DW_DEPTSIZn_XFER_SIZE_MASK		0x7FFFF
+
+/*
+ * Device IN endpoint transmit FIFO status register,
+ * offsets 0x0918 + (0x20 * n), n = 0 .. x
+ */
+#define USB_DW_DTXFSTS_TXF_SPC_AVAIL_MASK	0xFFFF
 
 #ifdef __cplusplus
 }

--- a/drivers/usb/device/usb_dw_registers.h
+++ b/drivers/usb/device/usb_dw_registers.h
@@ -24,26 +24,6 @@ extern "C" {
 /* Number of USB controllers */
 enum USB_DW_N { USB_DW_0 = 0, USB_DW_NUM };
 
-/* USB IN EP index */
-enum usb_dw_in_ep_idx {
-	USB_DW_IN_EP_0 = 0,
-	USB_DW_IN_EP_1,
-	USB_DW_IN_EP_2,
-	USB_DW_IN_EP_3,
-	USB_DW_IN_EP_4,
-	USB_DW_IN_EP_5,
-	USB_DW_IN_EP_NUM
-};
-
-/* USB OUT EP index */
-enum usb_dw_out_ep_idx {
-	USB_DW_OUT_EP_0 = 0,
-	USB_DW_OUT_EP_1,
-	USB_DW_OUT_EP_2,
-	USB_DW_OUT_EP_3,
-	USB_DW_OUT_EP_NUM
-};
-
 /* USB IN EP Register block type */
 struct usb_dw_in_ep_reg {
 	volatile uint32_t diepctl;
@@ -109,9 +89,8 @@ struct usb_dw_reg {
 	volatile uint32_t dthrctl;
 	volatile uint32_t diepempmsk;
 	uint32_t reserved5[50];
-	struct usb_dw_in_ep_reg in_ep_reg[USB_DW_IN_EP_NUM];
-	uint32_t reserved6[80];
-	struct usb_dw_out_ep_reg out_ep_reg[USB_DW_OUT_EP_NUM];
+	struct usb_dw_in_ep_reg in_ep_reg[16];
+	struct usb_dw_out_ep_reg out_ep_reg[16];
 };
 
 /* USB register offsets and masks */
@@ -196,15 +175,6 @@ struct usb_dw_reg {
 
 #define USB_DW_CORE_RST_TIMEOUT_US 10000
 #define USB_DW_PLL_TIMEOUT_US 100
-
-#define USB_DW_EP_FIFO(ep)						\
-	(*(uint32_t *)(DT_INST_REG_ADDR(0) + 0x1000 * (ep + 1)))
-/* USB register block base address */
-#define USB_DW ((struct usb_dw_reg *)DT_INST_REG_ADDR(0))
-
-#define DW_USB_IN_EP_NUM		(6)
-#define DW_USB_OUT_EP_NUM		(4)
-#define DW_USB_MAX_PACKET_SIZE		(64)
 
 #ifdef __cplusplus
 }

--- a/drivers/usb/device/usb_dw_registers.h
+++ b/drivers/usb/device/usb_dw_registers.h
@@ -56,7 +56,9 @@ struct usb_dw_reg {
 	volatile uint32_t grxstsp;
 	volatile uint32_t grxfsiz;
 	volatile uint32_t gnptxfsiz;
-	uint32_t reserved[5];
+	uint32_t reserved[3];
+	volatile uint32_t ggpio;
+	volatile uint32_t guid;
 	volatile uint32_t gsnpsid;
 	volatile uint32_t ghwcfg1;
 	volatile uint32_t ghwcfg2;
@@ -101,6 +103,8 @@ BUILD_ASSERT(sizeof(struct usb_dw_reg) <= 0x0D00);
 #define USB_DW_GAHBCFG_GLB_INTR_MASK		BIT(0)
 
 /* USB configuration register, offset: 0x000C */
+#define USB_DW_GUSBCFG_FORCEDEVMODE		BIT(30)
+#define USB_DW_GUSBCFG_FORCEHSTMODE		BIT(29)
 #define USB_DW_GUSBCFG_PHY_IF_MASK		BIT(3)
 #define USB_DW_GUSBCFG_PHY_IF_8_BIT		0
 #define USB_DW_GUSBCFG_PHY_IF_16_BIT		BIT(3)
@@ -132,8 +136,41 @@ BUILD_ASSERT(sizeof(struct usb_dw_reg) <= 0x0D00);
 #define USB_DW_GRXSTSR_PKT_CNT_OFFSET		4
 #define USB_DW_GRXSTSR_EP_NUM_MASK		(0xF << 0)
 
-/* ? register, offset: 0x0050 */
-#define USB_DW_HWCFG4_DEDFIFOMODE		BIT(25)
+/* Application (vendor) general purpose registers, offset: 0x0038 */
+#define USB_DW_GGPIO_STM32_VBDEN		BIT(21)
+#define USB_DW_GGPIO_STM32_PWRDWN		BIT(16)
+
+/* GHWCFG1 register, offset: 0x0044 */
+#define USB_DW_GHWCFG1_EPDIR_MASK(i)		(0x3 << (i * 2))
+#define USB_DW_GHWCFG1_EPDIR_SHIFT(i)		(i * 2)
+#define USB_DW_GHWCFG1_OUTENDPT			2
+#define USB_DW_GHWCFG1_INENDPT			1
+#define USB_DW_GHWCFG1_BDIR			0
+
+/* GHWCFG2 register, offset: 0x0048 */
+#define USB_DW_GHWCFG2_NUMDEVEPS_MASK		(0xF << 10)
+#define USB_DW_GHWCFG2_NUMDEVEPS_SHIFT		10
+#define USB_DW_GHWCFG2_FSPHYTYPE_MASK		(0x3 << 8)
+#define USB_DW_GHWCFG2_FSPHYTYPE_SHIFT		8
+#define USB_DW_GHWCFG2_FSPHYTYPE_FSPLUSULPI	3
+#define USB_DW_GHWCFG2_FSPHYTYPE_FSPLUSUTMI	2
+#define USB_DW_GHWCFG2_FSPHYTYPE_FS		1
+#define USB_DW_GHWCFG2_FSPHYTYPE_NO_FS		0
+#define USB_DW_GHWCFG2_HSPHYTYPE_MASK		(0x3 << 6)
+#define USB_DW_GHWCFG2_HSPHYTYPE_SHIFT		6
+#define USB_DW_GHWCFG2_HSPHYTYPE_UTMIPLUSULPI	3
+#define USB_DW_GHWCFG2_HSPHYTYPE_ULPI		2
+#define USB_DW_GHWCFG2_HSPHYTYPE_UTMIPLUS	1
+#define USB_DW_GHWCFG2_HSPHYTYPE_NO_HS		0
+
+/* GHWCFG3 register, offset: 0x004C */
+#define USB_DW_GHWCFG3_DFIFODEPTH_MASK		(0xFFFFU << 16)
+#define USB_DW_GHWCFG3_DFIFODEPTH_SHIFT		16
+
+/* GHWCFG4 register, offset: 0x0050 */
+#define USB_DW_GHWCFG4_INEPS_MASK		(0xF << 26)
+#define USB_DW_GHWCFG4_INEPS_SHIFT		26
+#define USB_DW_GHWCFG4_DEDFIFOMODE		BIT(25)
 
 /* Device configuration registers, offset: 0x0800 */
 #define USB_DW_DCFG_DEV_ADDR_MASK		(0x7F << 4)

--- a/dts/arm/intel_socfpga_std/socfpga.dtsi
+++ b/dts/arm/intel_socfpga_std/socfpga.dtsi
@@ -223,20 +223,18 @@
 		};
 
 		usb0: usb@ffb30000 {
-			compatible = "snps,designware-usb";
+			compatible = "snps,dwc2";
 			reg = <0xffb30000 0xffff>;
 			interrupts = <0 127 4 IRQ_DEFAULT_PRIORITY>;
 			interrupt-parent = <&intc>;
-			num-bidir-endpoints = <16>;
 			status = "disabled";
 			};
 
 		usb1: usb@ffb40000 {
-			compatible = "snps,designware-usb";
+			compatible = "snps,dwc2";
 			reg = <0xffb40000 0xffff>;
 			interrupts = <0 128 4 IRQ_DEFAULT_PRIORITY>;
 			interrupt-parent = <&intc>;
-			num-bidir-endpoints = <16>;
 			status = "okay";
 			};
 

--- a/dts/bindings/usb/snps,dwc2.yaml
+++ b/dts/bindings/usb/snps,dwc2.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: DesignWare OTG USB 2.0 controller
+
+compatible: "snps,dwc2"
+
+include: [base.yaml]
+
+bus: usb
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  phys:
+    type: phandle

--- a/dts/bindings/usb/st,stm32f4-fsotg.yaml
+++ b/dts/bindings/usb/st,stm32f4-fsotg.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+#
+description: STM32F4 SoC series OTG_FS DWC2 compatible controller
+
+compatible: "st,stm32f4-fsotg"
+
+include: ["snps,dwc2.yaml", pinctrl-device.yaml]
+
+properties:
+  clocks:
+    required: true
+
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true

--- a/samples/subsys/usb/cdc_acm/nucleo_f413zh_dwc2.overlay
+++ b/samples/subsys/usb/cdc_acm/nucleo_f413zh_dwc2.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &zephyr_udc0;
+
+/ {
+	soc {
+		dwc2_fsotg0: usb@50000000 {
+			compatible = "st,stm32f4-fsotg", "snps,dwc2";
+			reg = <0x50000000 0x40000>;
+			interrupts = <67 0>;
+			interrupt-names = "fsotg";
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000080>,
+				 <&rcc STM32_SRC_PLL_Q NO_SEL>;
+			status = "disabled";
+		};
+	};
+};
+
+zephyr_udc0: &dwc2_fsotg0 {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+	cdc_acm_uart0 {
+		compatible = "zephyr,cdc-acm-uart";
+	};
+};


### PR DESCRIPTION
The goal of the PR is to cleanup and improve usb_dc_dw driver, make it usable on additional platforms, and prepare it for porting to a new experimental UDC API.