### PR TITLE
modules: esp32: add taint mark when binary blobs are used

### DIFF
--- a/modules/Kconfig.esp32
+++ b/modules/Kconfig.esp32
@@ -4,3 +4,6 @@
 config HAS_ESPRESSIF_HAL
 	bool
 	depends on SOC_ESP32 || SOC_ESP32S2 || SOC_ESP32C3 || SOC_ESP32_NET
+
+config TAINT_BLOBS
+	default y if WIFI_ESP32 || BT_ESP32


### PR DESCRIPTION
Whenever Wi-FI or BT are enabled, binary blobs are required. Adding this default option sets the TAINT as needed.

Fixes #54858