### PR TITLE
soc: arm: nxp_imx: rt: Allow to include boot header.

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -652,7 +652,7 @@ config PM_MCUX_PMU
 
 menuconfig NXP_IMX_RT_BOOT_HEADER
 	bool "Boot header"
-	depends on ((!BOOTLOADER_MCUBOOT) && (CODE_FLEXSPI || CODE_FLEXSPI2))
+	depends on (!BOOTLOADER_MCUBOOT)
 	help
 	  Enable data structures required by the boot ROM to boot the
 	  application from an external flash device.
@@ -710,9 +710,11 @@ choice CODE_LOCATION
 
 config CODE_SEMC
 	bool "Link code into external SEMC-controlled memory"
+	imply NXP_IMX_RT_BOOT_HEADER if !BOOTLOADER_MCUBOOT
 
 config CODE_ITCM
 	bool "Link code into internal instruction tightly coupled memory (ITCM)"
+	imply NXP_IMX_RT_BOOT_HEADER if !BOOTLOADER_MCUBOOT
 
 config CODE_FLEXSPI
 	bool "Link code into external FlexSPI-controlled memory"
@@ -724,9 +726,11 @@ config CODE_FLEXSPI2
 
 config CODE_SRAM0
 	bool "Link code into RAM_L memory (RAM_L)"
+	imply NXP_IMX_RT_BOOT_HEADER if !BOOTLOADER_MCUBOOT
 
 config CODE_OCRAM
 	bool "Link code into OCRAM memory (OCRAM-M4)"
+	imply NXP_IMX_RT_BOOT_HEADER if !BOOTLOADER_MCUBOOT
 
 endchoice
 


### PR DESCRIPTION
Allow to include boot header for code linked into
not only FlexSPI controlled memory.
Fixes #53867