### PR TITLE
arc_ better workaround for issue #54720

### DIFF
--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -128,23 +128,6 @@ static void merge_chunks(struct z_heap *h, chunkid_t lc, chunkid_t rc)
 
 	set_chunk_size(h, lc, newsz);
 	set_left_chunk_size(h, right_chunk(h, rc), newsz);
-
-#if defined(__arc__) && defined(__GNUC__)
-	/* This is a workaround for a compiler bug on (at least) GCC
-	 * 12.1.0 in Zephyr SDK 0.15.1.  The optimizer generates this
-	 * function with a last instruction that is an unconditional
-	 * branch (a tail call into the chunk_set() handling).  But
-	 * that means that the NEXT instruction gets decoded as part
-	 * of the branch delay slot, but that instruction isn't part
-	 * of this function!  Some instructions aren't legal in branch
-	 * delay slots.  One of those is ENTER_S, which is a very
-	 * common entry instruction for whatever function the linker
-	 * places after us.  It seems like the compiler doesn't
-	 * understand this problem.  Stuff a NOP in to guarantee the
-	 * code is legal.
-	 */
-	__asm__ volatile("nop");
-#endif
 }
 
 static void free_chunk(struct z_heap *h, chunkid_t c)

--- a/soc/arc/snps_qemu/tune_build_ops.cmake
+++ b/soc/arc/snps_qemu/tune_build_ops.cmake
@@ -1,0 +1,2 @@
+# workaround for issue #54720
+list(APPEND TOOLCHAIN_C_FLAGS -fno-optimize-sibling-calls)


### PR DESCRIPTION
Use -fno-optimize-sibling-calls on QEMU builds.

This is a workaround to make tests/kernel/mem_protect/syscalls (and
possibly others) work.

Without this, result is:

```
START - test_syscall_torture
Running syscall torture test with 4 threads on 1 cpu(s)
E: ***** Exception vector: 0x2, cause code: 0x1, parameter 0x0
E: Address 0x80006e48
E: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
E: Current thread: 0x8040095c (unknown)
E: Halting system
```

With this applied:

```
START - test_syscall_torture
Running syscall torture test with 4 threads on 1 cpu(s)

 PASS - test_syscall_torture in 15.004 seconds
[...]
PROJECT EXECUTION SUCCESSFUL
```

The previous workaround attempt is also reverted.

Fixes #54720

