### PR TITLE
Drivers: I2S: STM32: Mishandling of Master Clock output (MCK)

### DIFF
--- a/drivers/i2s/i2s_ll_stm32.h
+++ b/drivers/i2s/i2s_ll_stm32.h
@@ -69,6 +69,7 @@ struct i2s_stm32_cfg {
 	uint32_t i2s_clk_sel;
 	const struct pinctrl_dev_config *pcfg;
 	void (*irq_config)(const struct device *dev);
+	bool master_clk_sel;
 };
 
 struct stream {

--- a/dts/bindings/i2s/st,stm32-i2s.yaml
+++ b/dts/bindings/i2s/st,stm32-i2s.yaml
@@ -25,3 +25,9 @@ properties:
 
   pinctrl-names:
     required: true
+
+  mck-enabled:
+    type: boolean
+    description: |
+      Master Clock Output function.
+      An mck pin must be listed within pinctrl-0 when enabling this property.


### PR DESCRIPTION
Proposal to rectify the raised issue https://github.com/zephyrproject-rtos/zephyr/issues/54841 the reference manual for families supporting I2S have a section under the I2S peripheral (shared with SPI) called **Clock generator** that expands on the clock details.

The master clock output pin is enabled by setting the specific alternate function, in some cases multiple pins present such function for the same peripheral instance. Therefore, the detection of the pin can be made by leveraging device tree and its API. Since there are multiple options for different driver instances, an exhaustive search across all of the possible ports and pins needs carrying out. On top it, the device tree API operates at pre-compile time. These two reasons are the basis for having a set of macros that will generate the DT checks for the desired function on the specified port and pin ranges. This makes to determine during the driver initialisation whether the master clock output has been requested to be set.

The bit rate, I2S CK, is adjusted around the different constraints imposed by having MCK and channel widths.

A couple of sanity checks on existing operations have also been added, essentially to ensure that the rates are achievable and compliant with the hardware constraints.

The functionality introduced depends on https://github.com/zephyrproject-rtos/hal_stm32/pull/162 & https://github.com/zephyrproject-rtos/hal_stm32/pull/163