### PR TITLE
net: lib: zperf: Add support to disable Nagle's algorithm

### DIFF
--- a/include/zephyr/net/zperf.h
+++ b/include/zephyr/net/zperf.h
@@ -36,6 +36,7 @@ struct zperf_upload_params {
 	uint16_t packet_size;
 	struct {
 		uint8_t tos;
+		int tcp_nodelay;
 	} options;
 };
 

--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -670,6 +670,16 @@ static int shell_cmd_upload(const struct shell *sh, size_t argc,
 			opt_cnt += 1;
 			break;
 
+		case 'n':
+			if (is_udp) {
+				shell_fprintf(sh, SHELL_WARNING,
+					      "UDP does not support -n option\n");
+				return -ENOEXEC;
+			}
+			param.options.tcp_nodelay = 1;
+			opt_cnt += 1;
+			break;
+
 		default:
 			shell_fprintf(sh, SHELL_WARNING,
 				      "Unrecognized argument: %s\n", argv[i]);
@@ -830,6 +840,16 @@ static int shell_cmd_upload2(const struct shell *sh, size_t argc,
 
 		case 'a':
 			async = true;
+			opt_cnt += 1;
+			break;
+
+		case 'n':
+			if (is_udp) {
+				shell_fprintf(sh, SHELL_WARNING,
+					      "UDP does not support -n option\n");
+				return -ENOEXEC;
+			}
+			param.options.tcp_nodelay = 1;
 			opt_cnt += 1;
 			break;
 
@@ -1125,6 +1145,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(zperf_cmd_tcp,
 		  "Available options:\n"
 		  "-S tos: Specify IPv4/6 type of service\n"
 		  "-a: Asynchronous call (shell will not block for the upload)\n"
+		  "-n: Disable Nagle's algorithm\n"
 		  "Example: tcp upload 192.0.2.2 1111 1 1K\n"
 		  "Example: tcp upload 2001:db8::2\n",
 		  cmd_tcp_upload),
@@ -1140,6 +1161,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(zperf_cmd_tcp,
 		  "-a: Asynchronous call (shell will not block for the upload)\n"
 		  "Example: tcp upload2 v6 1 1K\n"
 		  "Example: tcp upload2 v4\n"
+		  "-n: Disable Nagle's algorithm\n"
 #if defined(CONFIG_NET_IPV6) && defined(MY_IP6ADDR_SET)
 		  "Default IPv6 address is " MY_IP6ADDR
 		  ", destination [" DST_IP6ADDR "]:" DEF_PORT_STR "\n"

--- a/subsys/net/lib/zperf/zperf_tcp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_tcp_uploader.c
@@ -124,6 +124,14 @@ int zperf_tcp_upload(const struct zperf_upload_params *param,
 		return sock;
 	}
 
+	if (param->options.tcp_nodelay &&
+	    zsock_setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
+			     &param->options.tcp_nodelay,
+			     sizeof(param->options.tcp_nodelay)) != 0) {
+		NET_WARN("Failed to set IPPROTO_TCP - TCP_NODELAY socket option.");
+		return -EINVAL;
+	}
+
 	ret = tcp_upload(sock, param->duration_ms, param->packet_size, result);
 
 	zsock_close(sock);


### PR DESCRIPTION
This helps in benchmarking smaller packets, esp. as this is the default behaviour of iperf.