### PR TITLE
dma_dw: separate intel specific registers from synopsys ones

### DIFF
--- a/drivers/dma/Kconfig.dw_common
+++ b/drivers/dma/Kconfig.dw_common
@@ -26,6 +26,7 @@ config DMA_DW_HW_LLI
 
 config DMA_DW_SUSPEND_DRAIN
 	bool "channels should be suspended and drained on stop"
+	depends on DMA_INTEL_ADSP_GPDMA
 	help
 	  Rather than immediately stopping a DMA channel the channel is suspended
 	  with the DRAIN bit flag set to allow for the hardware FIFO to be drained

--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -285,6 +285,10 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 				DW_CTLL_LLP_S_EN | DW_CTLL_LLP_D_EN;
 			LOG_DBG("lli_desc->ctrl_lo %x", lli_desc->ctrl_lo);
 #endif
+#if CONFIG_DMA_DW
+			chan_data->cfg_lo |= DW_CFGL_SRC_SW_HS;
+			chan_data->cfg_lo |= DW_CFGL_DST_SW_HS;
+#endif
 			break;
 		case MEMORY_TO_PERIPHERAL:
 			lli_desc->ctrl_lo |= DW_CTLL_FC_M2P | DW_CTLL_SRC_INC |
@@ -297,6 +301,9 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 			 * destination of the channel
 			 */
 			chan_data->cfg_hi |= DW_CFGH_DST(cfg->dma_slot);
+#if CONFIG_DMA_DW
+			chan_data->cfg_lo |= DW_CFGL_SRC_SW_HS;
+#endif
 			break;
 		case PERIPHERAL_TO_MEMORY:
 			lli_desc->ctrl_lo |= DW_CTLL_FC_P2M | DW_CTLL_SRC_FIX |
@@ -316,6 +323,9 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 			 * source of the channel
 			 */
 			chan_data->cfg_hi |= DW_CFGH_SRC(cfg->dma_slot);
+#if CONFIG_DMA_DW
+			chan_data->cfg_lo |= DW_CFGL_DST_SW_HS;
+#endif
 			break;
 		default:
 			LOG_ERR("%s: dma %s channel %d invalid direction %d",

--- a/drivers/dma/dma_dw_common.h
+++ b/drivers/dma/dma_dw_common.h
@@ -83,7 +83,9 @@ extern "C" {
 /* CFG_LO */
 #define DW_CFGL_RELOAD_DST	BIT(31)
 #define DW_CFGL_RELOAD_SRC	BIT(30)
-#define DW_CFGL_DRAIN		BIT(10)
+#define DW_CFGL_DRAIN		BIT(10) /* For Intel GPDMA variant only */
+#define DW_CFGL_SRC_SW_HS       BIT(10) /* For Synopsys variant only */
+#define DW_CFGL_DST_SW_HS       BIT(11) /* For Synopsys variant only */
 #define DW_CFGL_FIFO_EMPTY	BIT(9)
 #define DW_CFGL_SUSPEND		BIT(8)
 #define DW_CFGL_CTL_HI_UPD_EN	BIT(5)


### PR DESCRIPTION
CFG register uses fields that are not defined in Synopsys databook of Designware AHB DMA Controller.

Since current Zephyr code uses this driver only for the intel_adsp_gpdma driver I assume that those fields are specific to this DMA which is not the standard Designware one.

This patch allows to use either the standard Designware register or the Intel one.