### PR TITLE
treewide: imply CONFIG_CACHE_MANAGEMENT for subsystems that use it

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -518,6 +518,7 @@ endmenu # Interrupt configuration
 config INIT_ARCH_HW_AT_BOOT
 	bool "Initialize internal architecture state at boot"
 	depends on ARCH_SUPPORTS_ARCH_HW_INIT
+	imply CACHE_MANAGEMENT
 	help
 	  This option instructs Zephyr to force the initialization
 	  of the internal architectural state (for example ARCH-level

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -83,11 +83,13 @@ choice SPSC_PBUF_CACHE_HANDLING
 
 config SPSC_PBUF_CACHE_FLAG
 	bool "Use cache flag"
+	imply CACHE_MANAGEMENT
 	help
 	  Use instance specific configuration flag for cache handling.
 
 config SPSC_PBUF_CACHE_ALWAYS
 	bool "Always handle cache"
+	imply CACHE_MANAGEMENT
 	help
 	  Handle cache writeback and invalidation for all instances. Option used
 	  to avoid runtime check and thus reduce memory footprint.
@@ -161,6 +163,7 @@ endif
 
 config REBOOT
 	bool "Reboot functionality"
+	imply CACHE_MANAGEMENT
 	help
 	  Enable the sys_reboot() API. Enabling this can drag in other subsystems
 	  needed to perform a "safe" reboot (e.g. to stop the system clock before

--- a/soc/arm/bcm_vk/viper/Kconfig.defconfig.viper_bcm58402_m7
+++ b/soc/arm/bcm_vk/viper/Kconfig.defconfig.viper_bcm58402_m7
@@ -14,4 +14,13 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
 	default 500000000
 
+# Viper SOC does not appear to have cache support present.
+# Disable DCACHE and ICACHE functionality
+
+config DCACHE
+	default n
+
+config ICACHE
+	default n
+
 endif


### PR DESCRIPTION
Imply `CONFIG_CACHE_MANAGEMENT` for subsystems that use the sys_cache_* cache
management APIs. Without `CONFIG_CACHE_MANAGEMENT=y` when the target core
has a cache, these subsystems will silently skip cache management at
points where it is required.

Fixes #54731