### PR TITLE
Maintainers.yml: Add missing POSIX arch docs

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1485,6 +1485,8 @@ Native POSIX and POSIX arch:
   files:
     - arch/posix/
     - boards/posix/native_posix/
+    - boards/posix/doc/
+    - boards/posix/*.rst
     - drivers/*/*native_posix*
     - drivers/*/*/*native_posix*
     - dts/posix/


### PR DESCRIPTION
A few POSIX arch docs were orphaned.
Add them to the native posix & posix arch entry