### PR TITLE
doc: release-notes: Note xtools toolchain variant deprecation 

### DIFF
--- a/doc/develop/toolchains/crosstool_ng.rst
+++ b/doc/develop/toolchains/crosstool_ng.rst
@@ -1,5 +1,13 @@
-Crosstool-NG
-############
+.. _toolchain_xtools:
+
+Crosstool-NG (Deprecated)
+#########################
+
+.. warning::
+
+   ``xtools`` toolchain variant is deprecated. The
+   :ref:`cross-compile toolchain variant <other_x_compilers>` should be used
+   when using a custom toolchain built with Crosstool-NG.
 
 You can build toolchains from source code using crosstool-NG.
 

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -166,6 +166,10 @@ Removed APIs in this release
 Deprecated in this release
 ==========================
 
+* :ref:`xtools toolchain variant <toolchain_xtools>` is now deprecated. When using a
+  custom toolchain built with Crosstool-NG, the
+  :ref:`cross-compile toolchain variant <other_x_compilers>` should be used instead.
+
 * C++ library Kconfig options have been renamed to improve consistency. See
   below for the list of deprecated Kconfig options and their replacements:
 


### PR DESCRIPTION
Add a note about the deprecation of the xtools toolchain variant.

(xtools toolchain variant was deprecated in https://github.com/zephyrproject-rtos/zephyr/pull/51334).