### PR TITLE
drivers: flash: spi_nor: Return EINVAL when erase out of range

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -740,7 +740,7 @@ static int spi_nor_erase(const struct device *dev, off_t addr, size_t size)
 
 	/* erase area must be subregion of device */
 	if ((addr < 0) || ((size + addr) > flash_size)) {
-		return -ENODEV;
+		return -EINVAL;
 	}
 
 	/* address must be sector-aligned */


### PR DESCRIPTION
Fixes spi_nor_erase to return -EINVAL instead of -ENODEV when erase requested is out of flash range.
This makes the SPI NOR return the same error as all other errors.

Fixes #54897

Release note for 3.4 will be needed for this.