### PR TITLE
logging: Improve handling of long packages

### DIFF
--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -238,7 +238,7 @@ static inline char z_log_minimal_level_to_char(int level)
 	int _mode; \
 	void *_src = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
 		(void *)_dsource : (void *)_source; \
-	Z_LOG_MSG2_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode, \
+	Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode, \
 				  Z_LOG_LOCAL_DOMAIN_ID, _src, _level, NULL,\
 			  0, __VA_ARGS__); \
 	(void)_mode; \
@@ -314,7 +314,7 @@ static inline char z_log_minimal_level_to_char(int level)
 	int mode; \
 	void *_src = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
 		(void *)_dsource : (void *)_source; \
-	Z_LOG_MSG2_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), mode, \
+	Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), mode, \
 				  Z_LOG_LOCAL_DOMAIN_ID, _src, _level, \
 			  _data, _len, \
 			COND_CODE_0(NUM_VA_ARGS_LESS_1(_, ##__VA_ARGS__), \
@@ -411,7 +411,7 @@ extern struct log_source_const_data __log_const_end[];
 	if (0) {\
 		z_log_printf_arg_checker(__VA_ARGS__); \
 	} \
-	Z_LOG_MSG2_CREATE(!IS_ENABLED(CONFIG_USERSPACE), _mode, \
+	Z_LOG_MSG_CREATE(!IS_ENABLED(CONFIG_USERSPACE), _mode, \
 			  Z_LOG_LOCAL_DOMAIN_ID, (uintptr_t)_is_raw, \
 			  LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0, __VA_ARGS__);\
 } while (0)

--- a/include/zephyr/logging/log_link.h
+++ b/include/zephyr/logging/log_link.h
@@ -83,7 +83,7 @@ struct log_link {
  * @param _ctx      Context (void *) associated with the link.
  */
 #define LOG_LINK_DEF(_name, _api, _buf_wlen, _ctx) \
-	static uint32_t __aligned(Z_LOG_MSG2_ALIGNMENT) _name##_buf32[_buf_wlen]; \
+	static uint32_t __aligned(Z_LOG_MSG_ALIGNMENT) _name##_buf32[_buf_wlen]; \
 	static const struct mpsc_pbuf_buffer_config _name##_mpsc_pbuf_config = { \
 		.buf = (uint32_t *)_name##_buf32, \
 		.size = _buf_wlen, \

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -26,8 +26,8 @@
 extern "C" {
 #endif
 
-#define LOG_MSG2_DEBUG 0
-#define LOG_MSG2_DBG(...) IF_ENABLED(LOG_MSG2_DEBUG, (printk(__VA_ARGS__)))
+#define LOG_MSG_DEBUG 0
+#define LOG_MSG_DBG(...) IF_ENABLED(LOG_MSG_DEBUG, (printk(__VA_ARGS__)))
 
 #ifdef CONFIG_LOG_TIMESTAMP_64BIT
 typedef uint64_t log_timestamp_t;
@@ -42,17 +42,21 @@ typedef uint32_t log_timestamp_t;
  * @{
  */
 
-#define Z_LOG_MSG2_LOG 0
+#define Z_LOG_MSG_LOG 0
 
-#define LOG_MSG2_GENERIC_HDR \
+#define Z_LOG_MSG_PACKAGE_BITS 10
+
+#define Z_LOG_MSG_MAX_PACKAGE BIT_MASK(Z_LOG_MSG_PACKAGE_BITS)
+
+#define LOG_MSG_GENERIC_HDR \
 	MPSC_PBUF_HDR;\
 	uint32_t type:1
 
 struct log_msg_desc {
-	LOG_MSG2_GENERIC_HDR;
+	LOG_MSG_GENERIC_HDR;
 	uint32_t domain:3;
 	uint32_t level:3;
-	uint32_t package_len:10;
+	uint32_t package_len:Z_LOG_MSG_PACKAGE_BITS;
 	uint32_t data_len:12;
 	uint32_t reserved:1;
 };
@@ -78,11 +82,11 @@ struct log_msg_hdr {
 };
 
 /* Messages are aligned to alignment required by cbprintf package. */
-#define Z_LOG_MSG2_ALIGNMENT CBPRINTF_PACKAGE_ALIGNMENT
+#define Z_LOG_MSG_ALIGNMENT CBPRINTF_PACKAGE_ALIGNMENT
 
-#define Z_LOG_MSG2_PADDING \
-	((sizeof(struct log_msg_hdr) % Z_LOG_MSG2_ALIGNMENT) > 0 ? \
-	(Z_LOG_MSG2_ALIGNMENT - (sizeof(struct log_msg_hdr) % Z_LOG_MSG2_ALIGNMENT)) : \
+#define Z_LOG_MSG_PADDING \
+	((sizeof(struct log_msg_hdr) % Z_LOG_MSG_ALIGNMENT) > 0 ? \
+	(Z_LOG_MSG_ALIGNMENT - (sizeof(struct log_msg_hdr) % Z_LOG_MSG_ALIGNMENT)) : \
 		0)
 
 struct log_msg {
@@ -90,14 +94,14 @@ struct log_msg {
 	/* Adding padding to ensure that cbprintf package that follows is
 	 * properly aligned.
 	 */
-	uint8_t padding[Z_LOG_MSG2_PADDING];
+	uint8_t padding[Z_LOG_MSG_PADDING];
 	uint8_t data[];
 };
 
 /**
  * @cond INTERNAL_HIDDEN
  */
-BUILD_ASSERT(sizeof(struct log_msg) % Z_LOG_MSG2_ALIGNMENT == 0,
+BUILD_ASSERT(sizeof(struct log_msg) % Z_LOG_MSG_ALIGNMENT == 0,
 	     "Log msg size must aligned");
 /**
  * @endcond
@@ -105,7 +109,7 @@ BUILD_ASSERT(sizeof(struct log_msg) % Z_LOG_MSG2_ALIGNMENT == 0,
 
 
 struct log_msg_generic_hdr {
-	LOG_MSG2_GENERIC_HDR;
+	LOG_MSG_GENERIC_HDR;
 };
 
 union log_msg_generic {
@@ -122,25 +126,25 @@ enum z_log_msg_mode {
 	/* Runtime mode is least efficient but supports all cases thus it is
 	 * treated as a fallback method when others cannot be used.
 	 */
-	Z_LOG_MSG2_MODE_RUNTIME,
+	Z_LOG_MSG_MODE_RUNTIME,
 	/* Mode creates statically a string package on stack and calls a
 	 * function for creating a message. It takes code size than
-	 * Z_LOG_MSG2_MODE_ZERO_COPY but is a bit slower.
+	 * Z_LOG_MSG_MODE_ZERO_COPY but is a bit slower.
 	 */
-	Z_LOG_MSG2_MODE_FROM_STACK,
+	Z_LOG_MSG_MODE_FROM_STACK,
 
 	/* Mode calculates size of the message and allocates it and writes
 	 * directly to the message space. It is the fastest method but requires
 	 * more code size.
 	 */
-	Z_LOG_MSG2_MODE_ZERO_COPY,
+	Z_LOG_MSG_MODE_ZERO_COPY,
 };
 
 #define Z_LOG_MSG_DESC_INITIALIZER(_domain_id, _level, _plen, _dlen) \
 { \
 	.valid = 0, \
 	.busy = 0, \
-	.type = Z_LOG_MSG2_LOG, \
+	.type = Z_LOG_MSG_LOG, \
 	.domain = _domain_id, \
 	.level = _level, \
 	.package_len = _plen, \
@@ -148,28 +152,28 @@ enum z_log_msg_mode {
 	.reserved = 0, \
 }
 
-#define Z_LOG_MSG2_CBPRINTF_FLAGS(_cstr_cnt) \
+#define Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt) \
 	(CBPRINTF_PACKAGE_FIRST_RO_STR_CNT(_cstr_cnt) | \
 	(IS_ENABLED(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC) ? \
 	 CBPRINTF_PACKAGE_ADD_STRING_IDXS : 0))
 
 #ifdef CONFIG_LOG_USE_VLA
-#define Z_LOG_MSG2_ON_STACK_ALLOC(ptr, len) \
+#define Z_LOG_MSG_ON_STACK_ALLOC(ptr, len) \
 	long long _ll_buf[ceiling_fraction(len, sizeof(long long))]; \
 	long double _ld_buf[ceiling_fraction(len, sizeof(long double))]; \
-	ptr = (sizeof(long double) == Z_LOG_MSG2_ALIGNMENT) ? \
+	ptr = (sizeof(long double) == Z_LOG_MSG_ALIGNMENT) ? \
 			(struct log_msg *)_ld_buf : (struct log_msg *)_ll_buf; \
 	if (IS_ENABLED(CONFIG_LOG_TEST_CLEAR_MESSAGE_SPACE)) { \
 		/* During test fill with 0's to simplify message comparison */ \
 		memset(ptr, 0, len); \
 	}
-#else /* Z_LOG_MSG2_USE_VLA */
+#else /* Z_LOG_MSG_USE_VLA */
 /* When VLA cannot be used we need to trick compiler a bit and create multiple
  * fixed size arrays and take the smallest one that will fit the message.
  * Compiler will remove unused arrays and stack usage will be kept similar
  * to vla case, rounded to the size of the used buffer.
  */
-#define Z_LOG_MSG2_ON_STACK_ALLOC(ptr, len) \
+#define Z_LOG_MSG_ON_STACK_ALLOC(ptr, len) \
 	long long _ll_buf32[32 / sizeof(long long)]; \
 	long long _ll_buf48[48 / sizeof(long long)]; \
 	long long _ll_buf64[64 / sizeof(long long)]; \
@@ -180,7 +184,7 @@ enum z_log_msg_mode {
 	long double _ld_buf64[64 / sizeof(long double)]; \
 	long double _ld_buf128[128 / sizeof(long double)]; \
 	long double _ld_buf256[256 / sizeof(long double)]; \
-	if (sizeof(long double) == Z_LOG_MSG2_ALIGNMENT) { \
+	if (sizeof(long double) == Z_LOG_MSG_ALIGNMENT) { \
 		ptr = (len > 128) ? (struct log_msg *)_ld_buf256 : \
 			((len > 64) ? (struct log_msg *)_ld_buf128 : \
 			((len > 48) ? (struct log_msg *)_ld_buf64 : \
@@ -197,17 +201,17 @@ enum z_log_msg_mode {
 		/* During test fill with 0's to simplify message comparison */ \
 		memset(ptr, 0, len); \
 	}
-#endif /* Z_LOG_MSG2_USE_VLA */
+#endif /* Z_LOG_MSG_USE_VLA */
 
-#define Z_LOG_MSG2_ALIGN_OFFSET \
+#define Z_LOG_MSG_ALIGN_OFFSET \
 	offsetof(struct log_msg, data)
 
-#define Z_LOG_MSG2_LEN(pkg_len, data_len) \
+#define Z_LOG_MSG_LEN(pkg_len, data_len) \
 	(offsetof(struct log_msg, data) + pkg_len + (data_len))
 
-#define Z_LOG_MSG2_ALIGNED_WLEN(pkg_len, data_len) \
-	ceiling_fraction(ROUND_UP(Z_LOG_MSG2_LEN(pkg_len, data_len), \
-				  Z_LOG_MSG2_ALIGNMENT), \
+#define Z_LOG_MSG_ALIGNED_WLEN(pkg_len, data_len) \
+	ceiling_fraction(ROUND_UP(Z_LOG_MSG_LEN(pkg_len, data_len), \
+				  Z_LOG_MSG_ALIGNMENT), \
 			 sizeof(uint32_t))
 
 /*
@@ -221,49 +225,49 @@ enum z_log_msg_mode {
 
 #define Z_LOG_ARM64_VLA_PROTECT() compiler_barrier()
 
-#define Z_LOG_MSG2_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, _dlen, ...) \
+#define Z_LOG_MSG_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, _dlen, ...) \
 do { \
 	int _plen; \
-	uint32_t flags = Z_LOG_MSG2_CBPRINTF_FLAGS(_cstr_cnt) | \
+	uint32_t flags = Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt) | \
 			 CBPRINTF_PACKAGE_ADD_RW_STR_POS; \
 	if (GET_ARG_N(1, __VA_ARGS__) == NULL) { \
 		_plen = 0; \
 	} else { \
-		CBPRINTF_STATIC_PACKAGE(NULL, 0, _plen, Z_LOG_MSG2_ALIGN_OFFSET, flags, \
+		CBPRINTF_STATIC_PACKAGE(NULL, 0, _plen, Z_LOG_MSG_ALIGN_OFFSET, flags, \
 					__VA_ARGS__); \
 	} \
 	struct log_msg *_msg; \
-	Z_LOG_MSG2_ON_STACK_ALLOC(_msg, Z_LOG_MSG2_LEN(_plen, 0)); \
+	Z_LOG_MSG_ON_STACK_ALLOC(_msg, Z_LOG_MSG_LEN(_plen, 0)); \
 	Z_LOG_ARM64_VLA_PROTECT(); \
 	if (_plen != 0) { \
 		CBPRINTF_STATIC_PACKAGE(_msg->data, _plen, \
-					_plen, Z_LOG_MSG2_ALIGN_OFFSET, flags, \
+					_plen, Z_LOG_MSG_ALIGN_OFFSET, flags, \
 					__VA_ARGS__);\
 	} \
 	struct log_msg_desc _desc = \
 		Z_LOG_MSG_DESC_INITIALIZER(_domain_id, _level, \
 					   (uint32_t)_plen, _dlen); \
-	LOG_MSG2_DBG("creating message on stack: package len: %d, data len: %d\n", \
+	LOG_MSG_DBG("creating message on stack: package len: %d, data len: %d\n", \
 			_plen, (int)(_dlen)); \
 	z_log_msg_static_create((void *)_source, _desc, _msg->data, _data); \
 } while (false)
 
 #ifdef CONFIG_LOG_SPEED
-#define Z_LOG_MSG2_SIMPLE_CREATE(_cstr_cnt, _domain_id, _source, _level, ...) do { \
+#define Z_LOG_MSG_SIMPLE_CREATE(_cstr_cnt, _domain_id, _source, _level, ...) do { \
 	int _plen; \
-	CBPRINTF_STATIC_PACKAGE(NULL, 0, _plen, Z_LOG_MSG2_ALIGN_OFFSET, \
-				Z_LOG_MSG2_CBPRINTF_FLAGS(_cstr_cnt), \
+	CBPRINTF_STATIC_PACKAGE(NULL, 0, _plen, Z_LOG_MSG_ALIGN_OFFSET, \
+				Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt), \
 				__VA_ARGS__); \
-	size_t _msg_wlen = Z_LOG_MSG2_ALIGNED_WLEN(_plen, 0); \
+	size_t _msg_wlen = Z_LOG_MSG_ALIGNED_WLEN(_plen, 0); \
 	struct log_msg *_msg = z_log_msg_alloc(_msg_wlen); \
 	struct log_msg_desc _desc = \
 		Z_LOG_MSG_DESC_INITIALIZER(_domain_id, _level, (uint32_t)_plen, 0); \
-	LOG_MSG2_DBG("creating message zero copy: package len: %d, msg: %p\n", \
+	LOG_MSG_DBG("creating message zero copy: package len: %d, msg: %p\n", \
 			_plen, _msg); \
 	if (_msg) { \
 		CBPRINTF_STATIC_PACKAGE(_msg->data, _plen, _plen, \
-					Z_LOG_MSG2_ALIGN_OFFSET, \
-					Z_LOG_MSG2_CBPRINTF_FLAGS(_cstr_cnt), \
+					Z_LOG_MSG_ALIGN_OFFSET, \
+					Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt), \
 					__VA_ARGS__); \
 	} \
 	z_log_msg_finalize(_msg, (void *)_source, _desc, NULL); \
@@ -272,7 +276,7 @@ do { \
 /* Alternative empty macro created to speed up compilation when LOG_SPEED is
  * disabled (default).
  */
-#define Z_LOG_MSG2_SIMPLE_CREATE(...)
+#define Z_LOG_MSG_SIMPLE_CREATE(...)
 #endif
 
 /* Macro handles case when local variable with log message string is created. It
@@ -336,7 +340,7 @@ do { \
 /* Macro handles case when there is no string provided, in that case variable
  * is not created.
  */
-#define Z_LOG_MSG2_STR_VAR_IN_SECTION(_name, ...) \
+#define Z_LOG_MSG_STR_VAR_IN_SECTION(_name, ...) \
 	COND_CODE_0(NUM_VA_ARGS_LESS_1(_, ##__VA_ARGS__), \
 		    (/* No args provided, no variable */), \
 		    (static const char _name[] \
@@ -350,9 +354,9 @@ do { \
  * @param _name Variable name.
  * @param ... Optional log message with arguments (may be empty).
  */
-#define Z_LOG_MSG2_STR_VAR(_name, ...) \
+#define Z_LOG_MSG_STR_VAR(_name, ...) \
 	IF_ENABLED(CONFIG_LOG_FMT_SECTION, \
-		   (Z_LOG_MSG2_STR_VAR_IN_SECTION(_name, ##__VA_ARGS__)))
+		   (Z_LOG_MSG_STR_VAR_IN_SECTION(_name, ##__VA_ARGS__)))
 
 /** @brief Create log message and write it into the logger buffer.
  *
@@ -396,36 +400,36 @@ do { \
 #if defined(CONFIG_LOG_ALWAYS_RUNTIME) || \
 	(!defined(CONFIG_LOG) && \
 		(!TOOLCHAIN_HAS_PRAGMA_DIAG || !TOOLCHAIN_HAS_C_AUTO_TYPE))
-#define Z_LOG_MSG2_CREATE2(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
+#define Z_LOG_MSG_CREATE2(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
 			  _level, _data, _dlen, ...) \
 do {\
-	Z_LOG_MSG2_STR_VAR(_fmt, ##__VA_ARGS__) \
+	Z_LOG_MSG_STR_VAR(_fmt, ##__VA_ARGS__) \
 	z_log_msg_runtime_create(_domain_id, (void *)_source, \
 				  _level, (uint8_t *)_data, _dlen,\
-				  Z_LOG_MSG2_CBPRINTF_FLAGS(_cstr_cnt) | \
+				  Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt) | \
 				  (IS_ENABLED(CONFIG_LOG_USE_TAGGED_ARGUMENTS) ? \
 				   CBPRINTF_PACKAGE_ARGS_ARE_TAGGED : 0), \
 				  Z_LOG_FMT_RUNTIME_ARGS(_fmt, ##__VA_ARGS__));\
-	_mode = Z_LOG_MSG2_MODE_RUNTIME; \
+	_mode = Z_LOG_MSG_MODE_RUNTIME; \
 } while (false)
 #else /* CONFIG_LOG_ALWAYS_RUNTIME */
-#define Z_LOG_MSG2_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
+#define Z_LOG_MSG_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
 			  _level, _data, _dlen, ...) \
 do { \
-	Z_LOG_MSG2_STR_VAR(_fmt, ##__VA_ARGS__); \
+	Z_LOG_MSG_STR_VAR(_fmt, ##__VA_ARGS__); \
 	bool has_rw_str = CBPRINTF_MUST_RUNTIME_PACKAGE( \
-					Z_LOG_MSG2_CBPRINTF_FLAGS(_cstr_cnt), \
+					Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt), \
 					__VA_ARGS__); \
 	if (IS_ENABLED(CONFIG_LOG_SPEED) && _try_0cpy && ((_dlen) == 0) && !has_rw_str) {\
-		LOG_MSG2_DBG("create zero-copy message\n");\
-		Z_LOG_MSG2_SIMPLE_CREATE(_cstr_cnt, _domain_id, _source, \
+		LOG_MSG_DBG("create zero-copy message\n");\
+		Z_LOG_MSG_SIMPLE_CREATE(_cstr_cnt, _domain_id, _source, \
 					_level, Z_LOG_FMT_ARGS(_fmt, ##__VA_ARGS__)); \
-		_mode = Z_LOG_MSG2_MODE_ZERO_COPY; \
+		_mode = Z_LOG_MSG_MODE_ZERO_COPY; \
 	} else { \
-		LOG_MSG2_DBG("create on stack message\n");\
-		Z_LOG_MSG2_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, \
+		LOG_MSG_DBG("create on stack message\n");\
+		Z_LOG_MSG_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, \
 					_dlen, Z_LOG_FMT_ARGS(_fmt, ##__VA_ARGS__)); \
-		_mode = Z_LOG_MSG2_MODE_FROM_STACK; \
+		_mode = Z_LOG_MSG_MODE_FROM_STACK; \
 	} \
 	(void)_mode; \
 } while (false)
@@ -449,14 +453,14 @@ do { \
  * This is done to prevent multiple evaluations of input arguments (in case argument
  * evaluation has side effects, e.g. it is a non-pure function call).
  */
-#define Z_LOG_MSG2_CREATE2(_try_0cpy, _mode, _cstr_cnt,  _domain_id, _source, \
+#define Z_LOG_MSG_CREATE2(_try_0cpy, _mode, _cstr_cnt,  _domain_id, _source, \
 			   _level, _data, _dlen, ...) \
 do { \
 	_Pragma("GCC diagnostic push") \
 	_Pragma("GCC diagnostic ignored \"-Wpointer-arith\"") \
 	FOR_EACH_IDX(Z_LOG_LOCAL_ARG_CREATE, (;), __VA_ARGS__); \
 	_Pragma("GCC diagnostic pop") \
-	Z_LOG_MSG2_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
+	Z_LOG_MSG_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
 			   _level, _data, _dlen, \
 			   FOR_EACH_IDX(Z_LOG_LOCAL_ARG_NAME, (,), __VA_ARGS__)); \
 } while (false)
@@ -465,9 +469,9 @@ do { \
 	*/
 
 
-#define Z_LOG_MSG2_CREATE(_try_0cpy, _mode,  _domain_id, _source,\
+#define Z_LOG_MSG_CREATE(_try_0cpy, _mode,  _domain_id, _source,\
 			  _level, _data, _dlen, ...) \
-	Z_LOG_MSG2_CREATE2(_try_0cpy, _mode, UTIL_CAT(Z_LOG_FUNC_PREFIX_, _level), \
+	Z_LOG_MSG_CREATE2(_try_0cpy, _mode, UTIL_CAT(Z_LOG_FUNC_PREFIX_, _level), \
 			   _domain_id, _source, _level, _data, _dlen, \
 			   Z_LOG_STR(_level, __VA_ARGS__))
 
@@ -573,7 +577,7 @@ static inline void z_log_msg_runtime_create(uint8_t domain_id,
 
 static inline bool z_log_item_is_msg(const union log_msg_generic *msg)
 {
-	return msg->generic.type == Z_LOG_MSG2_LOG;
+	return msg->generic.type == Z_LOG_MSG_LOG;
 }
 
 /** @brief Get total length (in 32 bit words) of a log message.
@@ -584,7 +588,7 @@ static inline bool z_log_item_is_msg(const union log_msg_generic *msg)
  */
 static inline uint32_t log_msg_get_total_wlen(const struct log_msg_desc desc)
 {
-	return Z_LOG_MSG2_ALIGNED_WLEN(desc.package_len, desc.data_len);
+	return Z_LOG_MSG_ALIGNED_WLEN(desc.package_len, desc.data_len);
 }
 
 /** @brief Get length of the log item.

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -44,7 +44,7 @@ typedef uint32_t log_timestamp_t;
 
 #define Z_LOG_MSG_LOG 0
 
-#define Z_LOG_MSG_PACKAGE_BITS 10
+#define Z_LOG_MSG_PACKAGE_BITS 11
 
 #define Z_LOG_MSG_MAX_PACKAGE BIT_MASK(Z_LOG_MSG_PACKAGE_BITS)
 
@@ -58,7 +58,6 @@ struct log_msg_desc {
 	uint32_t level:3;
 	uint32_t package_len:Z_LOG_MSG_PACKAGE_BITS;
 	uint32_t data_len:12;
-	uint32_t reserved:1;
 };
 
 union log_msg_source {
@@ -149,7 +148,6 @@ enum z_log_msg_mode {
 	.level = _level, \
 	.package_len = _plen, \
 	.data_len = _dlen, \
-	.reserved = 0, \
 }
 
 #define Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt) \

--- a/include/zephyr/shell/shell_log_backend.h
+++ b/include/zephyr/shell/shell_log_backend.h
@@ -72,7 +72,7 @@ int z_shell_log_backend_output_func(uint8_t *data, size_t length, void *ctx);
 	LOG_OUTPUT_DEFINE(_name##_log_output, z_shell_log_backend_output_func,\
 			  _buf, _size); \
 	static struct shell_log_backend_control_block _name##_control_block; \
-	static uint32_t __aligned(Z_LOG_MSG2_ALIGNMENT) \
+	static uint32_t __aligned(Z_LOG_MSG_ALIGNMENT) \
 			_name##_buf[_queue_size / sizeof(uint32_t)]; \
 	const struct mpsc_pbuf_buffer_config _name##_mpsc_buffer_config = { \
 		.buf = _name##_buf, \

--- a/subsys/logging/backends/log_multidomain_backend.c
+++ b/subsys/logging/backends/log_multidomain_backend.c
@@ -33,7 +33,7 @@ static void process(const struct log_backend *const backend,
 	}
 
 	/* Need to ensure that package is aligned to a pointer size. */
-	uint32_t msg_len = Z_LOG_MSG2_LEN(fsc_plen, dlen);
+	uint32_t msg_len = Z_LOG_MSG_LEN(fsc_plen, dlen);
 	uint8_t buf[msg_len + sizeof(void *)] __aligned(sizeof(void *));
 	size_t msg_offset = offsetof(struct log_multidomain_msg, data);
 	struct log_multidomain_msg *out_msg =

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -112,7 +112,7 @@ static STRUCT_SECTION_ITERABLE(log_msg_ptr, log_msg_ptr);
 static STRUCT_SECTION_ITERABLE_ALTERNATE(log_mpsc_pbuf, mpsc_pbuf_buffer, log_buffer);
 static struct mpsc_pbuf_buffer *curr_log_buffer;
 
-static uint32_t __aligned(Z_LOG_MSG2_ALIGNMENT)
+static uint32_t __aligned(Z_LOG_MSG_ALIGNMENT)
 	buf32[CONFIG_LOG_BUFFER_SIZE / sizeof(int)];
 
 static void z_log_notify_drop(const struct mpsc_pbuf_buffer *buffer,
@@ -201,7 +201,7 @@ void z_log_vprintk(const char *fmt, va_list ap)
 
 	z_log_msg_runtime_vcreate(Z_LOG_LOCAL_DOMAIN_ID, NULL,
 				   LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0,
-				   Z_LOG_MSG2_CBPRINTF_FLAGS(0),
+				   Z_LOG_MSG_CBPRINTF_FLAGS(0),
 				   fmt, ap);
 }
 
@@ -752,7 +752,7 @@ bool z_log_msg_pending(void)
 void z_log_msg_enqueue(const struct log_link *link, const void *data, size_t len)
 {
 	struct log_msg *log_msg = (struct log_msg *)data;
-	size_t wlen = ceiling_fraction(ROUND_UP(len, Z_LOG_MSG2_ALIGNMENT), sizeof(int));
+	size_t wlen = ceiling_fraction(ROUND_UP(len, Z_LOG_MSG_ALIGNMENT), sizeof(int));
 	struct mpsc_pbuf_buffer *mpsc_pbuffer = link->mpsc_pbuf ? link->mpsc_pbuf : &log_buffer;
 	struct log_msg *local_msg = msg_alloc(mpsc_pbuffer, wlen);
 

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -12,6 +12,9 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(log);
 
+BUILD_ASSERT(sizeof(struct log_msg_desc) == sizeof(uint32_t),
+	     "Descriptor must fit in 32 bits");
+
 /* Returns true if any backend is in use. */
 #define BACKENDS_IN_USE() \
 	!(IS_ENABLED(CONFIG_LOG_FRONTEND) && \

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -63,10 +63,12 @@ void z_impl_z_log_msg_static_create(const void *source,
 					    NULL, 0, flags,
 					    strl, ARRAY_SIZE(strl));
 
-		if (len > Z_LOG_MSG_MAX_PACKAGE)
-		{
-			LOG_WRN("Log message dropped because it exceeds current limitation (%u)",
-				(uint32_t)Z_LOG_MSG_MAX_PACKAGE);
+		if (len > Z_LOG_MSG_MAX_PACKAGE) {
+			struct cbprintf_package_hdr_ext *pkg =
+				(struct cbprintf_package_hdr_ext *)package;
+
+			LOG_WRN("Message (\"%s\") dropped because it exceeds size limitation (%u)",
+				pkg->fmt, (uint32_t)Z_LOG_MSG_MAX_PACKAGE);
 			return;
 		}
 		/* Update package length with calculated value (which may be extended

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -9,6 +9,8 @@
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/logging/log_frontend.h>
 #include <zephyr/logging/log_backend.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(log);
 
 /* Returns true if any backend is in use. */
 #define BACKENDS_IN_USE() \
@@ -61,6 +63,12 @@ void z_impl_z_log_msg_static_create(const void *source,
 					    NULL, 0, flags,
 					    strl, ARRAY_SIZE(strl));
 
+		if (len > Z_LOG_MSG_MAX_PACKAGE)
+		{
+			LOG_WRN("Log message dropped because it exceeds current limitation (%u)",
+				(uint32_t)Z_LOG_MSG_MAX_PACKAGE);
+			return;
+		}
 		/* Update package length with calculated value (which may be extended
 		 * when strings are copied into the package.
 		 */
@@ -99,7 +107,7 @@ void z_impl_z_log_msg_runtime_vcreate(uint8_t domain_id, const void *source,
 		va_list ap2;
 
 		va_copy(ap2, ap);
-		plen = cbvprintf_package(NULL, Z_LOG_MSG2_ALIGN_OFFSET,
+		plen = cbvprintf_package(NULL, Z_LOG_MSG_ALIGN_OFFSET,
 					 package_flags, fmt, ap2);
 		__ASSERT_NO_MSG(plen >= 0);
 		va_end(ap2);
@@ -107,7 +115,7 @@ void z_impl_z_log_msg_runtime_vcreate(uint8_t domain_id, const void *source,
 		plen = 0;
 	}
 
-	size_t msg_wlen = Z_LOG_MSG2_ALIGNED_WLEN(plen, dlen);
+	size_t msg_wlen = Z_LOG_MSG_ALIGNED_WLEN(plen, dlen);
 	struct log_msg *msg;
 	uint8_t *pkg;
 	struct log_msg_desc desc =

--- a/tests/subsys/logging/log_core_additional/src/log_test.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test.c
@@ -484,11 +484,11 @@ ZTEST(test_log_core_additional, test_log_msg_create)
 					  level, &msg_data, 0,
 					  sizeof(msg_data), NULL);
 		/* try z_log_msg_static_create() */
-		Z_LOG_MSG2_STACK_CREATE(0, domain, __log_current_const_data,
+		Z_LOG_MSG_STACK_CREATE(0, domain, __log_current_const_data,
 					level, &msg_data,
 					sizeof(msg_data), NULL);
 
-		Z_LOG_MSG2_CREATE(!IS_ENABLED(CONFIG_USERSPACE), mode,
+		Z_LOG_MSG_CREATE(!IS_ENABLED(CONFIG_USERSPACE), mode,
 			  Z_LOG_LOCAL_DOMAIN_ID, NULL,
 			  LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0, TEST_MESSAGE);
 
@@ -510,11 +510,11 @@ ZTEST_USER(test_log_core_additional, test_log_msg_create_user)
 				  level, &msg_data, 0,
 				  sizeof(msg_data), TEST_MESSAGE);
 	/* try z_log_msg_static_create() */
-	Z_LOG_MSG2_STACK_CREATE(0, domain, NULL,
+	Z_LOG_MSG_STACK_CREATE(0, domain, NULL,
 				level, &msg_data,
 				sizeof(msg_data), TEST_MESSAGE);
 
-	Z_LOG_MSG2_CREATE(!IS_ENABLED(CONFIG_USERSPACE), mode,
+	Z_LOG_MSG_CREATE(!IS_ENABLED(CONFIG_USERSPACE), mode,
 			  Z_LOG_LOCAL_DOMAIN_ID, NULL,
 		  LOG_LEVEL_INTERNAL_RAW_STRING, NULL, 0, TEST_MESSAGE);
 

--- a/tests/subsys/logging/log_link_order/src/main.c
+++ b/tests/subsys/logging/log_link_order/src/main.c
@@ -95,14 +95,14 @@ ZTEST(log_link_order, test_log_only_local)
 	struct log_msg *log1;
 
 	log1 = z_log_msg_alloc(sizeof(struct log_msg) / sizeof(int));
-	log1->hdr.desc.type = Z_LOG_MSG2_LOG;
+	log1->hdr.desc.type = Z_LOG_MSG_LOG;
 	log1->hdr.desc.package_len = 0;
 	log1->hdr.desc.data_len = 0;
 
 	/* Commit local message. */
 	z_log_msg_commit(log1);
 
-	log2.hdr.desc.type = Z_LOG_MSG2_LOG;
+	log2.hdr.desc.type = Z_LOG_MSG_LOG;
 	log2.hdr.desc.package_len = 0;
 	log2.hdr.desc.data_len = 0;
 
@@ -136,7 +136,7 @@ ZTEST(log_link_order, test_log_local_unordered)
 	/* Simulate receiving of remote message. It is enqueued later but with
 	 * earlier timestamp.
 	 */
-	log2.hdr.desc.type = Z_LOG_MSG2_LOG;
+	log2.hdr.desc.type = Z_LOG_MSG_LOG;
 	log2.hdr.timestamp = t;
 	log2.hdr.desc.package_len = 0;
 	log2.hdr.desc.data_len = 0;
@@ -172,7 +172,7 @@ ZTEST(log_link_order, test_log_one_remote_ordering)
 	 */
 
 	log2.hdr.timestamp = t;
-	log2.hdr.desc.type = Z_LOG_MSG2_LOG;
+	log2.hdr.desc.type = Z_LOG_MSG_LOG;
 	log2.hdr.desc.package_len = 0;
 	log2.hdr.desc.data_len = 0;
 

--- a/tests/subsys/logging/log_msg/src/main.c
+++ b/tests/subsys/logging/log_msg/src/main.c
@@ -20,9 +20,9 @@
 #include <zephyr/sys/cbprintf.h>
 
 #if CONFIG_NO_OPTIMIZATIONS
-#define EXP_MODE(name) Z_LOG_MSG2_MODE_RUNTIME
+#define EXP_MODE(name) Z_LOG_MSG_MODE_RUNTIME
 #else
-#define EXP_MODE(name) Z_LOG_MSG2_MODE_##name
+#define EXP_MODE(name) Z_LOG_MSG_MODE_##name
 #endif
 
 #define TEST_TIMESTAMP_INIT_VALUE \
@@ -152,9 +152,9 @@ void validate_base_message_set(const struct log_source_const_data *source,
 				log_timestamp_t t, const void *data,
 				size_t data_len, char *str)
 {
-	uint8_t __aligned(Z_LOG_MSG2_ALIGNMENT) buf0[256];
-	uint8_t __aligned(Z_LOG_MSG2_ALIGNMENT) buf1[256];
-	uint8_t __aligned(Z_LOG_MSG2_ALIGNMENT) buf2[256];
+	uint8_t __aligned(Z_LOG_MSG_ALIGNMENT) buf0[256];
+	uint8_t __aligned(Z_LOG_MSG_ALIGNMENT) buf1[256];
+	uint8_t __aligned(Z_LOG_MSG_ALIGNMENT) buf2[256];
 	size_t len0, len1, len2;
 	union log_msg_generic *msg0, *msg1, *msg2;
 
@@ -209,11 +209,11 @@ ZTEST(log_msg, test_log_msg_0_args_msg)
 	test_init();
 	printk("Test string:%s\n", TEST_MSG);
 
-	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level,
+	Z_LOG_MSG_CREATE3(1, mode, 0, domain, source, level,
 			  NULL, 0, TEST_MSG);
 	zassert_equal(mode, EXP_MODE(ZERO_COPY));
 
-	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level,
+	Z_LOG_MSG_CREATE3(0, mode, 0, domain, source, level,
 			  NULL, 0, TEST_MSG);
 	zassert_equal(mode, EXP_MODE(FROM_STACK));
 
@@ -242,11 +242,11 @@ ZTEST(log_msg, test_log_msg_various_args)
 	test_init();
 	printk("Test string:%s\n", TEST_MSG);
 
-	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level, NULL, 0,
+	Z_LOG_MSG_CREATE3(1, mode, 0, domain, source, level, NULL, 0,
 			TEST_MSG, s8, u, lld, (void *)str, lld, (void *)iarray);
 	zassert_equal(mode, EXP_MODE(ZERO_COPY));
 
-	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level, NULL, 0,
+	Z_LOG_MSG_CREATE3(0, mode, 0, domain, source, level, NULL, 0,
 			TEST_MSG, s8, u, lld, (void *)str, lld, (void *)iarray);
 	zassert_equal(mode, EXP_MODE(FROM_STACK));
 
@@ -269,11 +269,11 @@ ZTEST(log_msg, test_log_msg_only_data)
 
 	test_init();
 
-	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level, array,
+	Z_LOG_MSG_CREATE3(1, mode, 0, domain, source, level, array,
 			   sizeof(array));
 	zassert_equal(mode, EXP_MODE(FROM_STACK));
 
-	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level, array,
+	Z_LOG_MSG_CREATE3(0, mode, 0, domain, source, level, array,
 			   sizeof(array));
 	zassert_equal(mode, EXP_MODE(FROM_STACK));
 
@@ -298,11 +298,11 @@ ZTEST(log_msg, test_log_msg_string_and_data)
 
 	test_init();
 
-	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level, array,
+	Z_LOG_MSG_CREATE3(1, mode, 0, domain, source, level, array,
 			   sizeof(array), TEST_MSG);
 	zassert_equal(mode, EXP_MODE(FROM_STACK));
 
-	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level, array,
+	Z_LOG_MSG_CREATE3(0, mode, 0, domain, source, level, array,
 			   sizeof(array), TEST_MSG);
 	zassert_equal(mode, EXP_MODE(FROM_STACK));
 
@@ -335,11 +335,11 @@ ZTEST(log_msg, test_log_msg_fp)
 
 	test_init();
 
-	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level, NULL, 0,
+	Z_LOG_MSG_CREATE3(1, mode, 0, domain, source, level, NULL, 0,
 			TEST_MSG, i, lli, (double)f, &i, d, source);
 	zassert_equal(mode, EXP_MODE(ZERO_COPY));
 
-	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level, NULL, 0,
+	Z_LOG_MSG_CREATE3(0, mode, 0, domain, source, level, NULL, 0,
 			TEST_MSG, i, lli, (double)f, &i, d, source);
 	zassert_equal(mode, EXP_MODE(FROM_STACK));
 
@@ -374,12 +374,12 @@ ZTEST(log_msg, test_mode_size_plain_string)
 	uint32_t exp_len;
 	int mode;
 
-	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level, NULL, 0,
+	Z_LOG_MSG_CREATE3(1, mode, 0, domain, source, level, NULL, 0,
 			"test str");
 	zassert_equal(mode, EXP_MODE(ZERO_COPY),
 			"Unexpected creation mode");
 
-	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level, NULL, 0,
+	Z_LOG_MSG_CREATE3(0, mode, 0, domain, source, level, NULL, 0,
 			"test str");
 	zassert_equal(mode, EXP_MODE(FROM_STACK),
 			"Unexpected creation mode");
@@ -393,7 +393,7 @@ ZTEST(log_msg, test_mode_size_plain_string)
 	exp_len = offsetof(struct log_msg, data) +
 			 /* package */sizeof(struct cbprintf_package_hdr_ext);
 
-	exp_len = ROUND_UP(exp_len, Z_LOG_MSG2_ALIGNMENT) / sizeof(int);
+	exp_len = ROUND_UP(exp_len, Z_LOG_MSG_ALIGNMENT) / sizeof(int);
 	get_msg_validate_length(exp_len);
 	get_msg_validate_length(exp_len);
 }
@@ -410,7 +410,7 @@ ZTEST(log_msg, test_mode_size_data_only)
 	 */
 	uint8_t data[] = {1, 2, 3};
 
-	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level,
+	Z_LOG_MSG_CREATE3(1, mode, 0, domain, source, level,
 			   data, sizeof(data));
 	zassert_equal(mode, EXP_MODE(FROM_STACK),
 			"Unexpected creation mode");
@@ -422,7 +422,7 @@ ZTEST(log_msg, test_mode_size_data_only)
 	 * Message size is rounded up to the required alignment.
 	 */
 	exp_len = offsetof(struct log_msg, data) + sizeof(data);
-	exp_len = ROUND_UP(exp_len, Z_LOG_MSG2_ALIGNMENT) / sizeof(int);
+	exp_len = ROUND_UP(exp_len, Z_LOG_MSG_ALIGNMENT) / sizeof(int);
 	get_msg_validate_length(exp_len);
 }
 
@@ -438,7 +438,7 @@ ZTEST(log_msg, test_mode_size_plain_str_data)
 	 */
 	uint8_t data[] = {1, 2, 3};
 
-	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level,
+	Z_LOG_MSG_CREATE3(1, mode, 0, domain, source, level,
 			   data, sizeof(data), "test");
 	zassert_equal(mode, EXP_MODE(FROM_STACK),
 			"Unexpected creation mode");
@@ -451,7 +451,7 @@ ZTEST(log_msg, test_mode_size_plain_str_data)
 	 */
 	exp_len = offsetof(struct log_msg, data) + sizeof(data) +
 		  /* package */sizeof(struct cbprintf_package_hdr_ext);
-	exp_len = ROUND_UP(exp_len, Z_LOG_MSG2_ALIGNMENT) / sizeof(int);
+	exp_len = ROUND_UP(exp_len, Z_LOG_MSG_ALIGNMENT) / sizeof(int);
 	get_msg_validate_length(exp_len);
 }
 
@@ -464,13 +464,13 @@ ZTEST(log_msg, test_mode_size_str_with_strings)
 	int mode;
 	static const char *prefix = "prefix";
 
-	Z_LOG_MSG2_CREATE3(1, mode,
+	Z_LOG_MSG_CREATE3(1, mode,
 			   1 /* accept one string pointer*/,
 			   domain, source, level,
 			   NULL, 0, "test %s", prefix);
 	zassert_equal(mode, EXP_MODE(ZERO_COPY),
 			"Unexpected creation mode");
-	Z_LOG_MSG2_CREATE3(0, mode,
+	Z_LOG_MSG_CREATE3(0, mode,
 			   1 /* accept one string pointer*/,
 			   domain, source, level,
 			   NULL, 0, "test %s", prefix);
@@ -486,7 +486,7 @@ ZTEST(log_msg, test_mode_size_str_with_strings)
 	exp_len = offsetof(struct log_msg, data) +
 			 /* package */sizeof(struct cbprintf_package_hdr_ext) +
 				      sizeof(const char *);
-	exp_len = ROUND_UP(exp_len, Z_LOG_MSG2_ALIGNMENT) / sizeof(int);
+	exp_len = ROUND_UP(exp_len, Z_LOG_MSG_ALIGNMENT) / sizeof(int);
 
 	get_msg_validate_length(exp_len);
 	get_msg_validate_length(exp_len);
@@ -505,13 +505,13 @@ ZTEST(log_msg, test_mode_size_str_with_2strings)
 	static const char *prefix = "prefix";
 	char sufix[] = "sufix";
 
-	Z_LOG_MSG2_CREATE3(1, mode,
+	Z_LOG_MSG_CREATE3(1, mode,
 			   1 /* accept one string pointer*/,
 			   domain, source, level,
 			   NULL, 0, TEST_STR, prefix, sufix);
 	zassert_equal(mode, EXP_MODE(FROM_STACK),
 			"Unexpected creation mode");
-	Z_LOG_MSG2_CREATE3(0, mode,
+	Z_LOG_MSG_CREATE3(0, mode,
 			   1 /* accept one string pointer*/,
 			   domain, source, level,
 			   NULL, 0, TEST_STR, prefix, sufix);
@@ -529,7 +529,7 @@ ZTEST(log_msg, test_mode_size_str_with_2strings)
 			 /* package */sizeof(struct cbprintf_package_hdr_ext) +
 				      2 * sizeof(const char *) + 2 + strlen(sufix);
 
-	exp_len = ROUND_UP(exp_len, Z_LOG_MSG2_ALIGNMENT) / sizeof(int);
+	exp_len = ROUND_UP(exp_len, Z_LOG_MSG_ALIGNMENT) / sizeof(int);
 
 	get_msg_validate_length(exp_len);
 	get_msg_validate_length(exp_len);
@@ -548,7 +548,7 @@ ZTEST(log_msg, test_saturate)
 
 	uint32_t exp_len =
 		ROUND_UP(offsetof(struct log_msg, data) + 2 * sizeof(void *),
-			 Z_LOG_MSG2_ALIGNMENT);
+			 Z_LOG_MSG_ALIGNMENT);
 	uint32_t exp_capacity = CONFIG_LOG_BUFFER_SIZE / exp_len;
 	int mode;
 	union log_msg_generic *msg;
@@ -558,14 +558,14 @@ ZTEST(log_msg, test_saturate)
 	log_set_timestamp_func(timestamp_get_inc, 0);
 
 	for (int i = 0; i < exp_capacity; i++) {
-		Z_LOG_MSG2_CREATE3(1, mode, 0, 0, (void *)1, 2, NULL, 0, "test");
+		Z_LOG_MSG_CREATE3(1, mode, 0, 0, (void *)1, 2, NULL, 0, "test");
 	}
 
 	zassert_equal(z_log_dropped_read_and_clear(), 0, "No dropped messages.");
 
 	/* Message should not fit in and be dropped. */
-	Z_LOG_MSG2_CREATE3(1, mode, 0, 0, (void *)1, 2, NULL, 0, "test");
-	Z_LOG_MSG2_CREATE3(0, mode, 0, 0, (void *)1, 2, NULL, 0, "test");
+	Z_LOG_MSG_CREATE3(1, mode, 0, 0, (void *)1, 2, NULL, 0, "test");
+	Z_LOG_MSG_CREATE3(0, mode, 0, 0, (void *)1, 2, NULL, 0, "test");
 	z_log_msg_runtime_create(0, (void *)1, 2, NULL, 0, 0, "test");
 
 	zassert_equal(z_log_dropped_read_and_clear(), 3, "No dropped messages.");


### PR DESCRIPTION
Package length in a message was stored on 10 bits which limited packages to 1023 bytes. If longer package was used (e.g. `LOG_INF("%s", extremely_long_string);`) application was asserting.

Added warning message in that case with message dropping (to prevent assert).

Additionally, increased field to 11 bits since there was one spare bit in 32 bit long log message descriptor.