### PR TITLE
net: ip: 6lo: Fix corner case with packet format after IPHC 

### DIFF
--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -832,7 +832,9 @@ sa_end:
 
 	compressed = inline_pos - pkt->buffer->data;
 
-	net_buf_pull(pkt->buffer, compressed);
+	net_pkt_cursor_init(pkt);
+	net_pkt_pull(pkt, compressed);
+	net_pkt_compact(pkt);
 
 	return compressed;
 }

--- a/tests/net/ieee802154/6lo_fragment/src/main.c
+++ b/tests/net/ieee802154/6lo_fragment/src/main.c
@@ -438,6 +438,24 @@ static struct net_fragment_data test_data_8 = {
 	.iphc = false
 };
 
+
+static struct net_fragment_data test_data_9 = {
+	.ipv6.vtc = 0x61,
+	.ipv6.tcflow = 0x20,
+	.ipv6.flow = 0x00,
+	.ipv6.len = 0,
+	.ipv6.nexthdr = IPPROTO_UDP,
+	.ipv6.hop_limit = 0xff,
+	.ipv6.src = src_sam00,
+	.ipv6.dst = dst_m1_dam01,
+	.udp.src_port = htons(udp_src_port_16bit),
+	.udp.dst_port = htons(udp_dst_port_16bit),
+	.udp.len = 0x00,
+	.udp.chksum = 0x00,
+	.len = 90,
+	.iphc = true
+};
+
 static uint8_t frame_buffer_data[IEEE802154_MTU];
 
 static struct net_buf frame_buf = {
@@ -631,5 +649,11 @@ ZTEST(ieee802154_6lo_fragment, test_fragment_ipv6_dispatch_big)
 	zassert_true(ret);
 }
 
+ZTEST(ieee802154_6lo_fragment, test_fragment_ipv6_no_fragmentation_after_iphc)
+{
+	bool ret = test_fragment(&test_data_9);
+
+	zassert_true(ret);
+}
 
 ZTEST_SUITE(ieee802154_6lo_fragment, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
IEEE802154 drivers expect, that a complete 802.15.4 frame fits into a
single net_buf provided in a net_pkt.

There is a corner case with header compression when this could not be
the case. If the IPv6 packet before IPHC exceeded 802.15.4 MTU, it'd
consist of several net_buf's. This was not an issue, if the IPv6 packet
after header compression still required fragmentation, as the
fragmentation module took care of formatting individual net_buf's
properly.

For short range of packet sizes however this was not the case. The IPv6
packet, after header compression, might not require fragmentation any
more. As the IPHC logic only modified the IPv6 header part, by trimming
the buffer in front of the net_buf, such a packet would still consist of
two net_bufs, even though it should fit into a single 15.4 frame. Such
packet was passed to the driver, causing the driver to send only part of
the packet, from the first net_buf.

Fix this, by using net_pkt functions to manipulate the packet, instead
of operating on net_buf directly. net_pkt_pull() will not trim the
buffer in front, but rather move the entire packet content to the front.
On the other hand, net_pkt_compact() will assure that there's no gaps in
the net_bufs. In result, packets that do not require fragmentation,
should be placed into a single net_buf, as expected by drivers.

Additionally, add a test case that reproduced the problem.

Fixes #54506

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>