### PR TITLE
boards: nxp_adsp: fix dtsi name

### DIFF
--- a/boards/xtensa/nxp_adsp_imx8m/nxp_adsp_imx8m.dts
+++ b/boards/xtensa/nxp_adsp_imx8m/nxp_adsp_imx8m.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <nxp/nxp_imx8.dtsi>
+#include <nxp/nxp_imx8m.dtsi>
 
 / {
 	model = "nxp_adsp_imx8m";


### PR DESCRIPTION
Include the correct dtsi for nxp_adsp_imx8m.