### PR TITLE
Improvements to the timer_behavior test

### DIFF
--- a/tests/kernel/timer/timer_behavior/prj.conf
+++ b/tests/kernel/timer/timer_behavior/prj.conf
@@ -1,3 +1,8 @@
 CONFIG_ZTEST=y
 CONFIG_ZTEST_NEW_API=y
 CONFIG_CBPRINTF_FP_SUPPORT=y
+
+# Make sure this is off. Otherwise a single 60-character line at
+# 115200 bauds would grab the printk lock and disable IRQs for more
+# than 5 ms screwing up timer latency statistics.
+CONFIG_PRINTK_SYNC=n


### PR DESCRIPTION
Make statistics output from included tests prettier, more useful, and
more reliable in the timer_tick_train case.
