### PR TITLE
cope with missing PMP modes on RISC-V

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -242,7 +242,7 @@ config MAIN_STACK_SIZE
 	default 2048 if PMP_STACK_GUARD
 
 config TEST_EXTRA_STACK_SIZE
-	default 1024
+	default 1536
 
 config CMSIS_THREAD_MAX_STACK_SIZE
 	default 1024 if 64BIT

--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -202,11 +202,26 @@ config PMP_SLOTS
 	  This is the number of PMP entries implemented by the hardware.
 	  Typical values are 8 or 16.
 
+config PMP_NO_TOR
+	bool
+	help
+	  Set this if TOR (Top Of Range) mode is not supported.
+
+config PMP_NO_NA4
+	bool
+	help
+	  Set this if NA4 (Naturally Aligned 4-byte) mode is not supported.
+
+config PMP_NO_NAPOT
+	bool
+	help
+	  Set this if NAPOT (Naturally Aligned Power Of Two) is not supported.
+
 config PMP_POWER_OF_TWO_ALIGNMENT
-	bool "Enforce power-of-two alignment on PMP memory areas"
-	depends on USERSPACE
+	bool "Enforce power-of-two alignment on PMP memory areas" if !PMP_NO_TOR
 	default y if TEST_USERSPACE
 	default y if (PMP_SLOTS = 8)
+	default y if PMP_NO_TOR
 	select MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 	select GEN_PRIV_STACKS
 	help

--- a/include/zephyr/arch/riscv/arch.h
+++ b/include/zephyr/arch/riscv/arch.h
@@ -43,12 +43,16 @@
  * configurable stack wiggle room to execute the fault handling code off of,
  * as well as some guard size to cover possible sudden stack pointer
  * displacement before the fault.
- *
- * The m-mode PMP set is not overly used so no need to force NAPOT.
  */
+#ifdef CONFIG_PMP_POWER_OF_TWO_ALIGNMENT
+#define Z_RISCV_STACK_GUARD_SIZE \
+	Z_POW2_CEIL(sizeof(z_arch_esf_t) + CONFIG_PMP_STACK_GUARD_MIN_SIZE)
+#define ARCH_KERNEL_STACK_OBJ_ALIGN Z_RISCV_STACK_GUARD_SIZE
+#else
 #define Z_RISCV_STACK_GUARD_SIZE \
 	ROUND_UP(sizeof(z_arch_esf_t) + CONFIG_PMP_STACK_GUARD_MIN_SIZE, \
 		 ARCH_STACK_PTR_ALIGN)
+#endif
 
 /* Kernel-only stacks have the following layout if a stack guard is enabled:
  *
@@ -68,7 +72,7 @@
 #define Z_RISCV_STACK_GUARD_SIZE 0
 #endif
 
-#ifdef CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
+#ifdef CONFIG_PMP_POWER_OF_TWO_ALIGNMENT
 /* The privilege elevation stack is located in another area of memory
  * generated at build time by gen_kobject_list.py
  *
@@ -111,7 +115,7 @@
 #define ARCH_THREAD_STACK_OBJ_ALIGN(size) \
 		ARCH_THREAD_STACK_SIZE_ADJUST(size)
 
-#else /* !CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT */
+#else /* !CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
 
 /* The stack object will contain the PMP guard, the privilege stack, and then
  * the usermode stack buffer in that order:
@@ -132,7 +136,7 @@
 	ROUND_UP(Z_RISCV_STACK_GUARD_SIZE + CONFIG_PRIVILEGED_STACK_SIZE, \
 		 ARCH_STACK_PTR_ALIGN)
 
-#endif /* CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT */
+#endif /* CONFIG_PMP_POWER_OF_TWO_ALIGNMENT */
 
 #ifdef CONFIG_64BIT
 #define RV_REGSIZE 8

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -57,7 +57,11 @@
 #define RAM_SIZE KB(CONFIG_SRAM_SIZE)
 
 #ifdef CONFIG_RISCV_PMP
-	#define MPU_MIN_SIZE 4
+	#if defined(CONFIG_PMP_NO_TOR) && defined(CONFIG_PMP_NO_NA4)
+		#define MPU_MIN_SIZE 8
+	#else
+		#define MPU_MIN_SIZE 4
+	#endif
 	#define MPU_MIN_SIZE_ALIGN . = ALIGN(MPU_MIN_SIZE);
 	#if defined(CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT)
 		#define MPU_ALIGN(region_size) \

--- a/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_protect.h
@@ -62,7 +62,11 @@ static inline void set_fault_valid(bool valid)
 #elif defined(CONFIG_ARM)
 #define MEM_REGION_ALLOC (Z_THREAD_MIN_STACK_ALIGN)
 #elif defined(CONFIG_RISCV)
+#if defined(CONFIG_PMP_NO_TOR) && defined(CONFIG_PMP_NO_NA4)
+#define MEM_REGION_ALLOC (8)
+#else
 #define MEM_REGION_ALLOC (4)
+#endif
 #else
 #error "Test suite not compatible for the given architecture"
 #endif


### PR DESCRIPTION
It had to happen. AT least one implementor didn't implement all the address 
matching modes defined by the spec. Let's pprovide a generic method for 
selectively disabling them before someone makes a mess in the code.
And yes this is put to use on real hardware.
