### PR TITLE
ITE drivers/sensor/vcmp/it8xxx2: add work queue for voltage comparator

### DIFF
--- a/drivers/sensor/ite_vcmp_it8xxx2/Kconfig
+++ b/drivers/sensor/ite_vcmp_it8xxx2/Kconfig
@@ -12,3 +12,37 @@ config VCMP_IT8XXX2
 	  This option enables the ITE it8xxx2 voltage comparator,
 	  it8xxx2 supports six 10-bit resolution voltage comparator
 	  channels, and the input of each comparator comes from ADC pin.
+
+config VCMP_IT8XXX2_INIT_PRIORITY
+	int "ITE it8xxx2 voltage comparator device instance init priority"
+	default SENSOR_INIT_PRIORITY
+	help
+	  This option sets ITE voltage comparator device instance init priority.
+
+if VCMP_IT8XXX2
+
+config VCMP_IT8XXX2_WORKQUEUE
+	bool "ITE it8xxx2 voltage comparator threshold detection uses internal work queue"
+	help
+	  Threshold detection ISR utilizes system work queue for calling
+	  trigger handlers; set this option to use dedicated work queue instead.
+
+if VCMP_IT8XXX2_WORKQUEUE
+
+config VCMP_IT8XXX2_WORKQUEUE_PRIORITY
+	int "ITE it8xxx2 voltage comparator threshold detection work queue priority"
+	default SYSTEM_WORKQUEUE_PRIORITY
+	help
+	  This option sets internal ITE voltage comparator threshold detection
+	  workqueue priority.
+
+config VCMP_IT8XXX2_WORKQUEUE_STACK_SIZE
+	int "ITE it8xxx2 voltage comparator threshold detection work queue stack size"
+	default 768
+	help
+	  This option sets internal ITE voltage comparator threshold detection
+	  workqueue stack size.
+
+endif # VCMP_IT8XXX2_WORKQUEUE
+
+endif # VCMP_IT8XXX2

--- a/drivers/sensor/ite_vcmp_it8xxx2/vcmp_ite_it8xxx2.c
+++ b/drivers/sensor/ite_vcmp_it8xxx2/vcmp_ite_it8xxx2.c
@@ -71,6 +71,13 @@ struct vcmp_it8xxx2_data {
 
 /* Voltage comparator work queue address */
 static uint32_t vcmp_work_addr[VCMP_CHANNEL_CNT];
+#ifdef CONFIG_VCMP_IT8XXX2_WORKQUEUE
+/*
+ * Pointer of work queue thread to be notified when threshold assertion
+ * occurs.
+ */
+struct k_work_q *work_q;
+#endif
 
 static void clear_vcmp_status(const struct device *dev, int vcmp_ch)
 {
@@ -247,7 +254,12 @@ static void vcmp_it8xxx2_isr(const struct device *dev)
 		if (status & BIT(idx)) {
 			/* Call triggered channel callback function in work queue */
 			if (vcmp_work_addr[idx]) {
+#ifdef CONFIG_VCMP_IT8XXX2_WORKQUEUE
+				k_work_submit_to_queue(work_q,
+						       (struct k_work *) vcmp_work_addr[idx]);
+#else
 				k_work_submit((struct k_work *) vcmp_work_addr[idx]);
+#endif
 			}
 			/* W/C voltage comparator specific channel interrupt status */
 			clear_vcmp_status(dev, idx);
@@ -298,7 +310,7 @@ static int vcmp_it8xxx2_init(const struct device *dev)
 	/* Data must keep device reference for worker handler */
 	data->vcmp = dev;
 
-	/* Init and set worker queue to enable notifications */
+	/* Init and set work item to enable notifications */
 	k_work_init(&data->work, it8xxx2_vcmp_trigger_work_handler);
 	vcmp_work_addr[config->vcmp_ch] = (uint32_t) &data->work;
 
@@ -344,6 +356,32 @@ static const struct sensor_driver_api vcmp_ite_it8xxx2_api = {
 	.channel_get = vcmp_it8xxx2_channel_get,
 };
 
+#ifdef CONFIG_VCMP_IT8XXX2_WORKQUEUE
+struct k_work_q vcmp_it8xxx2_work_q;
+
+static K_KERNEL_STACK_DEFINE(vcmp_it8xxx2_work_q_stack,
+			     CONFIG_VCMP_IT8XXX2_WORKQUEUE_STACK_SIZE);
+
+static int vcmp_it8xxx2_init_work_q(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	struct k_work_queue_config cfg = {
+		.name = "vcmp_work",
+		.no_yield = false,
+	};
+
+	k_work_queue_start(&vcmp_it8xxx2_work_q,
+			   vcmp_it8xxx2_work_q_stack,
+			   K_KERNEL_STACK_SIZEOF(vcmp_it8xxx2_work_q_stack),
+			   CONFIG_VCMP_IT8XXX2_WORKQUEUE_PRIORITY, &cfg);
+
+	work_q = &vcmp_it8xxx2_work_q;
+	return 0;
+}
+
+SYS_INIT(vcmp_it8xxx2_init_work_q, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY);
+#endif
+
 #define VCMP_IT8XXX2_INIT(inst)								\
 	static const struct vcmp_it8xxx2_config vcmp_it8xxx2_cfg_##inst = {		\
 		.reg_vcmpxctl = (uint8_t *)DT_INST_REG_ADDR_BY_IDX(inst, 0),		\
@@ -373,8 +411,12 @@ static const struct sensor_driver_api vcmp_ite_it8xxx2_api = {
 			      NULL,							\
 			      &vcmp_it8xxx2_data_##inst,				\
 			      &vcmp_it8xxx2_cfg_##inst,					\
-			      PRE_KERNEL_2,						\
-			      CONFIG_SENSOR_INIT_PRIORITY,				\
+			      POST_KERNEL,						\
+			      CONFIG_VCMP_IT8XXX2_INIT_PRIORITY,			\
 			      &vcmp_ite_it8xxx2_api);
 
 DT_INST_FOREACH_STATUS_OKAY(VCMP_IT8XXX2_INIT)
+#ifdef CONFIG_VCMP_IT8XXX2_WORKQUEUE
+BUILD_ASSERT(CONFIG_SENSOR_INIT_PRIORITY < CONFIG_VCMP_IT8XXX2_INIT_PRIORITY,
+	"CONFIG_SENSOR_INIT_PRIORITY must be less than CONFIG_VCMP_IT8XXX2_INIT_PRIORITY");
+#endif

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
@@ -40,6 +40,9 @@ config IT8XXX2_PLL_SEQUENCE_PRIORITY
 	default 1
 	depends on SOC_IT8XXX2_PLL_FLASH_48M
 
+config VCMP_IT8XXX2_INIT_PRIORITY
+	default 91 if VCMP_IT8XXX2_WORKQUEUE
+
 config PINCTRL
 	default y
 


### PR DESCRIPTION
Voltage comparator driver submits notifications into system work queue, this change will make driver to use dedicated work queue, and priority of dedicated work queue are configurable as well.