### PR TITLE
Bluetooth: l2cap: add checks for user_data size

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -280,6 +280,13 @@ config BT_LIM_ADV_TIMEOUT
 	  Appendix A (NORMATIVE): TIMERS AND CONSTANTS it's required to be no more
 	  than 180s.
 
+config BT_CONN_TX_USER_DATA_SIZE
+	int
+	default 8
+	help
+	  Necessary user_data size for allowing packet fragmentation when
+	  sending over HCI. See `struct tx_meta` in conn.c.
+
 if BT_CONN
 
 config BT_CONN_TX_MAX

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -754,7 +754,9 @@ config NET_BUF_DATA_POOL_SIZE
 
 config NET_PKT_BUF_USER_DATA_SIZE
 	int "Size of user_data available in rx and tx network buffers"
+	default BT_CONN_TX_USER_DATA_SIZE if NET_L2_BT
 	default 4
+	range BT_CONN_TX_USER_DATA_SIZE 16 if NET_L2_BT
 	range 4 16
 	help
 	  User data size used in rx and tx network buffers.


### PR DESCRIPTION
See commit messages.
This concerns both Bluetooth and the Bluetooth network backend.