### PR TITLE
Bluetooth: Controller: Replace WFE use with k_cpu_atomic_idle()

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h
@@ -5,25 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/kernel.h>
+
 static inline void cpu_sleep(void)
 {
-#if defined(CONFIG_CPU_CORTEX_M0) || \
-	defined(CONFIG_CPU_CORTEX_M4) || \
-	defined(CONFIG_CPU_CORTEX_M33) || \
-	defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
-	/*
-	 * To guarantee waking up from the event, the
-	 * SEV-On-Pend feature must be enabled (enabled
-	 * during ARCH initialization).
-	 *
-	 * DSB is recommended by spec before WFE (to
-	 * guarantee completion of memory transactions)
-	 */
-	__DSB();
-	__WFE();
-	__SEV();
-	__WFE();
-#endif
+	k_cpu_atomic_idle(irq_lock());
 }
 
 static inline void cpu_dmb(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h
@@ -11,6 +11,15 @@ static inline void cpu_sleep(void)
 	defined(CONFIG_CPU_CORTEX_M4) || \
 	defined(CONFIG_CPU_CORTEX_M33) || \
 	defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
+	/*
+	 * To guarantee waking up from the event, the
+	 * SEV-On-Pend feature must be enabled (enabled
+	 * during ARCH initialization).
+	 *
+	 * DSB is recommended by spec before WFE (to
+	 * guarantee completion of memory transactions)
+	 */
+	__DSB();
 	__WFE();
 	__SEV();
 	__WFE();

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ecb.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ecb.c
@@ -12,6 +12,8 @@
 #include <hal/nrf_ecb.h>
 
 #include "util/mem.h"
+
+#include "hal/cpu.h"
 #include "hal/ecb.h"
 
 #include "hal/debug.h"
@@ -36,7 +38,10 @@ static void do_ecb(struct ecb_param *ecb)
 #if defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
 			k_busy_wait(10);
 #else
-			/*__WFE();*/
+			/* FIXME: use cpu_sleep(), but that will need interrupt
+			 *        wake up source and hence necessary appropriate
+			 *        code.
+			 */
 #endif
 		}
 		nrf_ecb_task_trigger(NRF_ECB, NRF_ECB_TASK_STOPECB);
@@ -185,9 +190,7 @@ uint32_t ecb_ut(void)
 	ecb.context = &context;
 	status = ecb_encrypt_nonblocking(&ecb);
 	do {
-		__WFE();
-		__SEV();
-		__WFE();
+		cpu_sleep();
 	} while (!context.done);
 
 	if (context.status != 0U) {

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -17,6 +17,7 @@
 
 #include "util/mem.h"
 
+#include "hal/cpu.h"
 #include "hal/ccm.h"
 #include "hal/radio.h"
 #include "hal/radio_df.h"
@@ -1778,9 +1779,7 @@ uint32_t radio_ccm_is_done(void)
 {
 	nrf_ccm_int_enable(NRF_CCM, CCM_INTENSET_ENDCRYPT_Msk);
 	while (NRF_CCM->EVENTS_ENDCRYPT == 0) {
-		__WFE();
-		__SEV();
-		__WFE();
+		cpu_sleep();
 	}
 	nrf_ccm_int_disable(NRF_CCM, CCM_INTENCLR_ENDCRYPT_Msk);
 	NVIC_ClearPendingIRQ(nrfx_get_irq_number(NRF_CCM));
@@ -1871,9 +1870,7 @@ uint32_t radio_ar_has_match(void)
 	nrf_aar_int_enable(NRF_AAR, AAR_INTENSET_END_Msk);
 
 	while (NRF_AAR->EVENTS_END == 0U) {
-		__WFE();
-		__SEV();
-		__WFE();
+		cpu_sleep();
 	}
 
 	nrf_aar_int_disable(NRF_AAR, AAR_INTENCLR_END_Msk);
@@ -1907,9 +1904,7 @@ uint8_t radio_ar_resolve(const uint8_t *addr)
 	nrf_aar_task_trigger(NRF_AAR, NRF_AAR_TASK_START);
 
 	while (NRF_AAR->EVENTS_END == 0) {
-		__WFE();
-		__SEV();
-		__WFE();
+		cpu_sleep();
 	}
 
 	nrf_aar_int_disable(NRF_AAR, AAR_INTENCLR_END_Msk);


### PR DESCRIPTION
Replace the use of WFE with Zephyr kernel supplied
k_cpu_atomic_idle() interface.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>