### PR TITLE
drivers: uart: nrfx: Support custom baudrates

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -27,6 +27,15 @@ config UART_ASYNC_TX_CACHE_SIZE
 	  in RAM, because EasyDMA in UARTE peripherals can only transfer data
 	  from RAM.
 
+config UART_NRF_UARTE_APPROXIMATE_CUSTOM_BAUDRATES
+	bool "Experimental: Support custom (non standard) baudrates"
+	default n
+	help
+	  Enabling this option allows to use custom (non standard) baudrates.
+	  Warning: The register values for those baudrates are calculated
+	  using an approximation and the results need to be verified by the
+	  user. No guarantee is given for the correctness of the approximation.
+
 # ----------------- port 0 -----------------
 config UART_0_NRF_UART
 	def_bool HAS_HW_NRF_UART0

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -352,7 +352,8 @@ static int baudrate_set(const struct device *dev, uint32_t baudrate)
 		nrf_baudrate = NRF_UARTE_BAUDRATE_1000000;
 		break;
 	default:
-		return -EINVAL;
+		nrf_baudrate = (((uint64_t)baudrate * 0x100000000ULL) / (16000000ULL) + 0x800) & 0xfffff000;
+		break;
 	}
 
 	nrf_uarte_baudrate_set(uarte, nrf_baudrate);

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -352,8 +352,13 @@ static int baudrate_set(const struct device *dev, uint32_t baudrate)
 		nrf_baudrate = NRF_UARTE_BAUDRATE_1000000;
 		break;
 	default:
-		nrf_baudrate = (((uint64_t)baudrate * 0x100000000ULL) / (16000000ULL) + 0x800) & 0xfffff000;
+#if CONFIG_UART_NRF_UARTE_APPROXIMATE_CUSTOM_BAUDRATES
+		nrf_baudrate =
+			((((uint64_t)baudrate << 32) / 16000000ULL) + 0x800) & 0xfffff000;
 		break;
+#else
+		return -EINVAL;
+#endif
 	}
 
 	nrf_uarte_baudrate_set(uarte, nrf_baudrate);


### PR DESCRIPTION
Nordics UARTE does support custom (non-standard) baudrates. The baudrate register controlls a 20bit baudrate generator. This patch adds a simple approximation which yields a very small error to generate custom baudrates. The default baudrates haven't been touched, thus the reccomended values stated in the reference are used.

Signed-off-by: Benedikt-Alexander Mokroß [github@bamkrs.de](mailto:github@bamkrs.de)