### PR TITLE
drivers: i2c: stm32: add bus recovery support

### DIFF
--- a/drivers/i2c/Kconfig.stm32
+++ b/drivers/i2c/Kconfig.stm32
@@ -43,4 +43,10 @@ config I2C_STM32_COMBINED_INTERRUPT
 	depends on I2C_STM32_INTERRUPT
 	default y if SOC_SERIES_STM32F0X || SOC_SERIES_STM32G0X || SOC_SERIES_STM32L0X
 
+config I2C_STM32_BUS_RECOVERY
+	bool "Bus recovery support"
+	select I2C_BITBANG
+	help
+	  Enable STM32 driver bus recovery support via GPIO bitbanging.
+
 endif # I2C_STM32

--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -9,6 +9,10 @@
 #ifndef ZEPHYR_DRIVERS_I2C_I2C_LL_STM32_H_
 #define ZEPHYR_DRIVERS_I2C_I2C_LL_STM32_H_
 
+#ifdef CONFIG_I2C_STM32_BUS_RECOVERY
+#include <zephyr/drivers/gpio.h>
+#endif /* CONFIG_I2C_STM32_BUS_RECOVERY */
+
 typedef void (*irq_config_func_t)(const struct device *port);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2)
@@ -29,6 +33,10 @@ struct i2c_stm32_config {
 #ifdef CONFIG_I2C_STM32_INTERRUPT
 	irq_config_func_t irq_config_func;
 #endif
+#ifdef CONFIG_I2C_STM32_BUS_RECOVERY
+	struct gpio_dt_spec scl;
+	struct gpio_dt_spec sda;
+#endif /* CONFIG_I2C_STM32_BUS_RECOVERY */
 	const struct stm32_pclken *pclken;
 	size_t pclk_len;
 	I2C_TypeDef *i2c;

--- a/dts/bindings/i2c/st,stm32-i2c-v1.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v1.yaml
@@ -19,3 +19,15 @@ properties:
 
   pinctrl-names:
     required: true
+
+  scl-gpios:
+    type: phandle-array
+    description: |
+      GPIO to which the I2C SCL signal is routed. This is only needed for
+      I2C bus recovery support.
+
+  sda-gpios:
+    type: phandle-array
+    description: |
+      GPIO to which the I2C SDA signal is routed. This is only needed for
+      I2C bus recovery support.

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -43,3 +43,15 @@ properties:
                       <64000000 I2C_BITRATE_FAST 0x00603D56>,
                       <56000000 I2C_BITRATE_STANDARD 0x10606DA4>,
                       <56000000 I2C_BITRATE_FAST 0x00501D63>;
+
+  scl-gpios:
+    type: phandle-array
+    description: |
+      GPIO to which the I2C SCL signal is routed. This is only needed for
+      I2C bus recovery support.
+
+  sda-gpios:
+    type: phandle-array
+    description: |
+      GPIO to which the I2C SDA signal is routed. This is only needed for
+      I2C bus recovery support.


### PR DESCRIPTION
Add I2C bus recovery support to the STM32 v1 and v2 driver.

The STM32 i2c peripheral does not natively support I2C bus recovery so recovery is performed using GPIO bitbanging. This mirrors the bus recovery implementation for NXP MCUX LPI2C driver.

Fixes: #54917