### PR TITLE
net: l2: ethernet: Fix double free

### DIFF
--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -756,6 +756,19 @@ void net_arp_clear_cache(struct net_if *iface)
 	k_mutex_unlock(&arp_mutex);
 }
 
+int net_arp_clear_pending(struct net_if *iface, struct in_addr *dst)
+{
+	struct arp_entry *entry = arp_entry_find_pending(iface, dst);
+
+	if (!entry) {
+		return -ENOENT;
+	}
+
+	arp_entry_cleanup(entry, true);
+
+	return 0;
+}
+
 int net_arp_foreach(net_arp_cb_t cb, void *user_data)
 {
 	int ret = 0;

--- a/subsys/net/l2/ethernet/arp.h
+++ b/subsys/net/l2/ethernet/arp.h
@@ -49,6 +49,9 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
 enum net_verdict net_arp_input(struct net_pkt *pkt,
 			       struct net_eth_hdr *eth_hdr);
 
+int net_arp_clear_pending(struct net_if *iface,
+				struct in_addr *dst);
+
 struct arp_entry {
 	sys_snode_t node;
 	uint32_t req_start;
@@ -79,6 +82,7 @@ void net_arp_init(void);
 #define net_arp_clear_cache(...)
 #define net_arp_foreach(...) 0
 #define net_arp_init(...)
+#define net_arp_clear_pending(...) 0
 
 #endif /* CONFIG_NET_ARP */
 


### PR DESCRIPTION
In case of no ARP entry the incoming packet is added to the ARP's pending queue while ARP is being resolved but here a reference is added by the ARP layer to the packet to avoid it being freed but the Ethernet immediately puts down the reference, and if the ARP request fails for some reason L2 returns failure to net_if which then puts down the reference and the packet will be free as the reference count is now zero.

But the packet is still in the ARP's pending queue and after timeout it ARP will put down the reference and while tries to free the buffer again causing double free bus fault.

Fix this but not putting down the reference in Ethernet that was taken by ARP and let ARP timeout handling free the pending packet.