### PR TITLE
tests: bsim_bt: edtt tests: Use latest EDTT without the bridge

### DIFF
--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/_controller_tests_inner.sh
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/_controller_tests_inner.sh
@@ -95,12 +95,10 @@ fi
 cd ${EDTT_PATH}
 
 Execute ./src/edttool.py -s=${SIMULATION_ID} -d=2 --transport bsim \
-  -T $TEST_MODULE -C $TEST_FILE -v=${VERBOSITY_LEVEL_EDTT} -S -l --low-level-device-nbr=3
+  -T $TEST_MODULE -C $TEST_FILE -v=${VERBOSITY_LEVEL_EDTT} -S -l --low-level-device-nbr=3 \
+  -D=2 -devs 0 1 -RxWait=2.5e3
 
 cd ${BSIM_OUT_PATH}/bin
-
-Execute ./bs_device_EDTT_bridge -s=${SIMULATION_ID} -d=2 -AutoTerminate \
-  -RxWait=2.5e3 -D=2 -dev0=0 -dev1=1 -v=${VERBOSITY_LEVEL_BRIDGE}
 
 Execute \
   ${RR_ARGS_1} ./bs_${BOARD}_tests_bluetooth_bsim_bt_edtt_ble_test_app_hci_test_app_${PRJ_CONF_1}\

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/gatt.llcp.sh
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/gatt.llcp.sh
@@ -26,12 +26,10 @@ BOARD="${BOARD:-nrf52_bsim}"
 cd ${EDTT_PATH}
 
 Execute ./src/edttool.py -s=${SIMULATION_ID} -d=0 --transport bsim \
-  -T gatt_verification -C "${CWD}/gatt.llcp.test_list" -v=${VERBOSITY_LEVEL}
+  -T gatt_verification -C "${CWD}/gatt.llcp.test_list" -v=${VERBOSITY_LEVEL} \
+   -D=2 -devs 1 2 -RxWait=2.5e3
 
 cd ${BSIM_OUT_PATH}/bin
-
-Execute ./bs_device_EDTT_bridge -s=${SIMULATION_ID} -d=0 -AutoTerminate \
-  -RxWait=2.5e3 -D=2 -dev0=1 -dev1=2 -v=${VERBOSITY_LEVEL}
 
 Execute \
  ./bs_${BOARD}_tests_bluetooth_bsim_bt_edtt_ble_test_app_hci_test_app_prj_tst_llcp_conf\

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/gatt.sh
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/tests_scripts/gatt.sh
@@ -26,12 +26,10 @@ BOARD="${BOARD:-nrf52_bsim}"
 cd ${EDTT_PATH}
 
 Execute ./src/edttool.py -s=${SIMULATION_ID} -d=0 --transport bsim \
-  -T gatt_verification -C "${CWD}/gatt.test_list" -v=${VERBOSITY_LEVEL}
+  -T gatt_verification -C "${CWD}/gatt.test_list" -v=${VERBOSITY_LEVEL} \
+   -D=2 -devs 1 2 -RxWait=2.5e3
 
 cd ${BSIM_OUT_PATH}/bin
-
-Execute ./bs_device_EDTT_bridge -s=${SIMULATION_ID} -d=0 -AutoTerminate \
-  -RxWait=2.5e3 -D=2 -dev0=1 -dev1=2 -v=${VERBOSITY_LEVEL}
 
 Execute \
  ./bs_${BOARD}_tests_bluetooth_bsim_bt_edtt_ble_test_app_hci_test_app_prj_tst_conf\

--- a/west.yml
+++ b/west.yml
@@ -37,7 +37,7 @@ manifest:
       groups:
         - hal
     - name: edtt
-      revision: 8ef968c1471769af61ba3e5befb6b119b22a7afe
+      revision: fc998bcaed44796c3800a3e62cf026bd9403d299
       path: tools/edtt
       groups:
         - tools


### PR DESCRIPTION
The latest EDTT does not use the bridge anymore.