### PR TITLE
support cfb_shell and cfb samples on native_posix/native_posix_64

### DIFF
--- a/samples/subsys/display/cfb_custom_font/src/main.c
+++ b/samples/subsys/display/cfb_custom_font/src/main.c
@@ -25,6 +25,11 @@ void main(void)
 		return;
 	}
 
+	if (display_blanking_off(display) != 0) {
+		printk("Failed to turn off display blanking\n");
+		return;
+	}
+
 	err = cfb_framebuffer_init(display);
 	if (err) {
 		printk("Could not initialize framebuffer (err %d)\n", err);

--- a/subsys/fb/cfb_shell.c
+++ b/subsys/fb/cfb_shell.c
@@ -416,6 +416,12 @@ static int cmd_init(const struct shell *shell, size_t argc, char *argv[])
 		return -ENODEV;
 	}
 
+	err = display_blanking_off(dev);
+	if (err) {
+		shell_error(shell, "Failed to turn off display blanking: %d", err);
+		return err;
+	}
+
 	err = cfb_framebuffer_init(dev);
 	if (err) {
 		shell_error(shell, "Framebuffer initialization failed!");

--- a/subsys/fb/cfb_shell.c
+++ b/subsys/fb/cfb_shell.c
@@ -416,6 +416,15 @@ static int cmd_init(const struct shell *shell, size_t argc, char *argv[])
 		return -ENODEV;
 	}
 
+	err = display_set_pixel_format(dev, PIXEL_FORMAT_MONO10);
+	if (err) {
+		err = display_set_pixel_format(dev, PIXEL_FORMAT_MONO01);
+		if (err) {
+			shell_error(shell, "Failed to set required pixel format: %d", err);
+			return err;
+		}
+	}
+
 	err = display_blanking_off(dev);
 	if (err) {
 		shell_error(shell, "Failed to turn off display blanking: %d", err);


### PR DESCRIPTION
This PR makes cfb_shell and cfb samples work on native_posix/native_posix_64.

- sdl_dc (and some displays) enable display_blanking on boot up. Turn it off on sample startup or `cfb init` command at shell.
- cfb_shell not set the display pixel format. Set the pixel format to MONO10 or MONO01.