### PR TITLE
boards: longan_nano: add dfu-util runner

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -203,7 +203,7 @@ config SRAM_BASE_ADDRESS
 	  /chosen/zephyr,sram in devicetree. The user should generally avoid
 	  changing it via menuconfig or in configuration files.
 
-if ARC || ARM || ARM64 || NIOS2 || X86
+if ARC || ARM || ARM64 || NIOS2 || X86 || RISCV
 
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_FLASH := zephyr,flash
@@ -224,7 +224,7 @@ config FLASH_BASE_ADDRESS
 	  normally set by the board's defconfig file and the user should generally
 	  avoid modifying it via the menu configuration.
 
-endif # ARM || ARM64 || ARC || NIOS2 || X86
+endif # ARM || ARM64 || ARC || NIOS2 || X86 || RISCV
 
 if ARCH_HAS_TRUSTED_EXECUTION
 

--- a/boards/riscv/longan_nano/board.cmake
+++ b/boards/riscv/longan_nano/board.cmake
@@ -6,5 +6,7 @@ board_runner_args(openocd --cmd-pre-init "source [find target/gd32vf103.cfg]")
 board_runner_args(openocd "--cmd-pre-load=gd32vf103-pre-load")
 board_runner_args(openocd "--cmd-load=gd32vf103-load")
 board_runner_args(openocd "--cmd-post-verify=gd32vf103-post-verify")
+board_runner_args(dfu-util "--pid=28e9:0189" "--alt=0" "--dfuse")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)

--- a/boards/riscv/longan_nano/doc/index.rst
+++ b/boards/riscv/longan_nano/doc/index.rst
@@ -94,6 +94,13 @@ Here is an example for building the :ref:`blinky-sample` application.
 When using a custom toolchain it should be enough to have the downloaded
 version of the binary in your ``PATH``.
 
+The default runner tries to flash the board via an external programmer using openocd.
+To flash via the USB port, select the DFU runner when flashing:
+
+.. code-block:: console
+
+   west flash --runner dfu-util
+
 Debugging
 =========
 

--- a/soc/riscv/openisa_rv32m1/Kconfig.defconfig
+++ b/soc/riscv/openisa_rv32m1/Kconfig.defconfig
@@ -119,14 +119,4 @@ config RV32M1_INTMUX_CHANNEL_7
 
 endif # MULTI_LEVEL_INTERRUPTS
 
-if FLASH
-
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
-endif # FLASH
-
 endif # SOC_OPENISA_RV32M1_RISCV32

--- a/soc/riscv/riscv-privilege/gd32vf103/Kconfig.defconfig.gd32vf103
+++ b/soc/riscv/riscv-privilege/gd32vf103/Kconfig.defconfig.gd32vf103
@@ -34,9 +34,6 @@ config NUM_IRQS
 	default 87 if  NUCLEI_ECLIC
 	default 16 if !NUCLEI_ECLIC
 
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,flash0@8000000)
-
 config 2ND_LEVEL_INTERRUPTS
 	default y
 

--- a/soc/riscv/riscv-privilege/opentitan/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/opentitan/Kconfig.defconfig.series
@@ -27,8 +27,4 @@ config 2ND_LVL_ISR_TBL_OFFSET
 config NUM_IRQS
 	default 216
 
-config FLASH_BASE_ADDRESS
-	hex
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 endif # SOC_SERIES_RISCV_OPENTITAN

--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
@@ -38,7 +38,3 @@ config SOC_RISCV_TELINK_B91
 	select INCLUDE_RESET_VECTOR
 
 endchoice
-
-config FLASH_BASE_ADDRESS
-	hex
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))


### PR DESCRIPTION
This adds the runner arguments for dfu-util to the longan_nano board, to allow flashing via DFU in addition to openocd.

I added the `CONFIG_FLASH_BASE_ADDRESS` since that results in the proper `dfu-util` flag `-s 0x08000000`, which i found in the [platformio sources from sipeed](https://github.com/sipeed/platform-gd32v/blob/master/builder/main.py#L146).
I'm not sure if this has other, unintended effects... (This option also did not seem available for RISCV, was this on purpose?)
