### PR TITLE
drivers: wifi: esp_at: fetch version of ESP-AT firmware

### DIFF
--- a/drivers/wifi/esp_at/Kconfig.esp_at
+++ b/drivers/wifi/esp_at/Kconfig.esp_at
@@ -160,4 +160,12 @@ config WIFI_ESP_AT_DNS_USE
 	  Fetch DNS servers from ESP chip with AT+CIPDNS? command and apply that
 	  list to system DNS resolver.
 
+config WIFI_ESP_AT_FETCH_VERSION
+	bool "Fetch and log ESP-AT firmware version"
+	default y
+	depends on LOG
+	help
+	  Fetch information about ESP-AT firmware version. This includes AT
+	  command version, SDK (ESP-IDF), board and compile time.
+
 endif # WIFI_ESP_AT

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -721,6 +721,38 @@ MODEM_CMD_DEFINE(on_cmd_ready)
 	return 0;
 }
 
+#if defined(CONFIG_WIFI_ESP_AT_FETCH_VERSION)
+
+static int cmd_version_log(struct modem_cmd_handler_data *data,
+			   const char *type, const char *version)
+{
+	LOG_INF("%s: %s", type, version);
+
+	return 0;
+}
+
+MODEM_CMD_DEFINE(on_cmd_at_version)
+{
+	return cmd_version_log(data, "AT version", argv[0]);
+}
+
+MODEM_CMD_DEFINE(on_cmd_sdk_version)
+{
+	return cmd_version_log(data, "SDK version", argv[0]);
+}
+
+MODEM_CMD_DEFINE(on_cmd_compile_time)
+{
+	return cmd_version_log(data, "compile time", argv[0]);
+}
+
+MODEM_CMD_DEFINE(on_cmd_bin_version)
+{
+	return cmd_version_log(data, "Bin version", argv[0]);
+}
+
+#endif /* CONFIG_WIFI_ESP_AT_FETCH_VERSION */
+
 static const struct modem_cmd unsol_cmds[] = {
 	MODEM_CMD("WIFI CONNECTED", on_cmd_wifi_connected, 0U, ""),
 	MODEM_CMD("WIFI DISCONNECT", on_cmd_wifi_disconnected, 0U, ""),
@@ -738,6 +770,12 @@ static const struct modem_cmd unsol_cmds[] = {
 	MODEM_CMD("busy s...", on_cmd_busy_sending, 0U, ""),
 	MODEM_CMD("busy p...", on_cmd_busy_processing, 0U, ""),
 	MODEM_CMD("ready", on_cmd_ready, 0U, ""),
+#if defined(CONFIG_WIFI_ESP_AT_FETCH_VERSION)
+	MODEM_CMD("AT version:", on_cmd_at_version, 1U, ""),
+	MODEM_CMD("SDK version:", on_cmd_sdk_version, 1U, ""),
+	MODEM_CMD("Compile time", on_cmd_compile_time, 1U, ""),
+	MODEM_CMD("Bin version:", on_cmd_bin_version, 1U, ""),
+#endif
 	MODEM_CMD_DIRECT("+IPD", on_cmd_ipd),
 };
 
@@ -947,6 +985,9 @@ static void esp_init_work(struct k_work *work)
 	};
 	static const struct setup_cmd setup_cmds_target_baudrate[] = {
 		SETUP_CMD_NOHANDLE("AT"),
+#endif
+#if defined(CONFIG_WIFI_ESP_AT_FETCH_VERSION)
+		SETUP_CMD_NOHANDLE("AT+GMR"),
 #endif
 #if defined(CONFIG_WIFI_ESP_AT_VERSION_1_7)
 		SETUP_CMD_NOHANDLE(ESP_CMD_CWMODE(STA)),


### PR DESCRIPTION
For development and debugging purposes it is good to know what is the
version of ESP-AT firmware used on modem. This can be fetched with AT+GMR
command.

Fetch this information during driver init and log all available version
strings, so they look like that:

```
wifi_esp_at: AT version: 2.1.0.0(883f7f2 - Jul 24 2020 11:50:07)
wifi_esp_at: SDK version: v4.0.1-193-ge7ac221
wifi_esp_at: compile time: (0ad6331):Jul 28 2020 02:47:21
wifi_esp_at: Bin version: 2.1.0(WROOM-32)
```