### PR TITLE
arch: riscv enable flash config

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -203,7 +203,7 @@ config SRAM_BASE_ADDRESS
 	  /chosen/zephyr,sram in devicetree. The user should generally avoid
 	  changing it via menuconfig or in configuration files.
 
-if ARC || ARM || ARM64 || NIOS2 || X86
+if ARC || ARM || ARM64 || NIOS2 || X86 || RISCV
 
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_FLASH := zephyr,flash
@@ -224,7 +224,7 @@ config FLASH_BASE_ADDRESS
 	  normally set by the board's defconfig file and the user should generally
 	  avoid modifying it via the menu configuration.
 
-endif # ARM || ARM64 || ARC || NIOS2 || X86
+endif # ARM || ARM64 || ARC || NIOS2 || X86 || RISCV
 
 if ARCH_HAS_TRUSTED_EXECUTION
 

--- a/soc/riscv/esp32c3/Kconfig.soc
+++ b/soc/riscv/esp32c3/Kconfig.soc
@@ -26,14 +26,6 @@ config ESPTOOLPY_FLASHFREQ_80M
 	bool
 	default y
 
-config FLASH_SIZE
-	int
-	default $(dt_node_reg_size_int,/soc/flash-controller@60002000/flash@0,0)
-
-config FLASH_BASE_ADDRESS
-	hex
-	default $(dt_node_reg_addr_hex,/soc/flash-controller@60002000/flash@0)
-
 config ESP_SYSTEM_RTC_EXT_XTAL
 	bool
 

--- a/soc/riscv/openisa_rv32m1/Kconfig.defconfig
+++ b/soc/riscv/openisa_rv32m1/Kconfig.defconfig
@@ -119,14 +119,4 @@ config RV32M1_INTMUX_CHANNEL_7
 
 endif # MULTI_LEVEL_INTERRUPTS
 
-if FLASH
-
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_FLASH := zephyr,flash
-
-config FLASH_BASE_ADDRESS
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
-endif # FLASH
-
 endif # SOC_OPENISA_RV32M1_RISCV32

--- a/soc/riscv/riscv-privilege/gd32vf103/Kconfig.defconfig.gd32vf103
+++ b/soc/riscv/riscv-privilege/gd32vf103/Kconfig.defconfig.gd32vf103
@@ -34,9 +34,6 @@ config NUM_IRQS
 	default 87 if  NUCLEI_ECLIC
 	default 16 if !NUCLEI_ECLIC
 
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,flash0@8000000)
-
 config 2ND_LEVEL_INTERRUPTS
 	default y
 

--- a/soc/riscv/riscv-privilege/opentitan/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/opentitan/Kconfig.defconfig.series
@@ -27,8 +27,4 @@ config 2ND_LVL_ISR_TBL_OFFSET
 config NUM_IRQS
 	default 216
 
-config FLASH_BASE_ADDRESS
-	hex
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
 endif # SOC_SERIES_RISCV_OPENTITAN

--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
@@ -38,7 +38,3 @@ config SOC_RISCV_TELINK_B91
 	select INCLUDE_RESET_VECTOR
 
 endchoice
-
-config FLASH_BASE_ADDRESS
-	hex
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))


### PR DESCRIPTION
For RISCV arch, enable FLASH_SIZE and FLASH_BASE_ADDRESS config. To avoid duplicated work, remove flash config from RISCV soc.