### PR TITLE
Samples: Philosophers: Revert stack size change

### DIFF
--- a/samples/philosophers/src/main.c
+++ b/samples/philosophers/src/main.c
@@ -83,7 +83,7 @@
 /* end - control behaviour of the demo */
 /***************************************/
 
-#define STACK_SIZE (2048)
+#define STACK_SIZE (1024)
 
 #include "phil_obj_abstract.h"
 


### PR DESCRIPTION
In commit 31e0d864847ab8b132cfcc8c45d28577886280b2, the stack size was unjustifiably changed from a base of *768*
(plus a configurable extra stack size) to *2048*.
This change broke our sample tests for one of our products, which has less available memory for the threads' stacks.

The stack size is dropped to *1024* to align with the stack sizes specified in the other samples, which were changed in commit 31e0d864847ab8b132cfcc8c45d28577886280b2.