### PR TITLE
arch: riscv: Add ARG_UNUSED to the unused argument

### DIFF
--- a/include/zephyr/arch/riscv/irq.h
+++ b/include/zephyr/arch/riscv/irq.h
@@ -69,6 +69,7 @@ extern void __soc_handle_irq(unsigned long mcause);
 
 static inline void arch_isr_direct_footer(int swap)
 {
+	ARG_UNUSED(swap);
 	unsigned long mcause;
 
 	/* Get the IRQ number */


### PR DESCRIPTION
When compiler is more strict it triggers a warning that 'swap' argument is not used in arch_isr_direct_footer(). Adding ARG_UNUSED.