### PR TITLE
drivers: usb: udc: nrf: fix declaration after label

### DIFF
--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -443,7 +443,7 @@ static void usbd_event_handler(nrfx_usbd_evt_t const *const hal_evt)
 		udc_sof_check_iso_out(udc_nrf_dev);
 		break;
 	case NRFX_USBD_EVT_EPTRANSFER:
-	case NRFX_USBD_EVT_SETUP:
+	case NRFX_USBD_EVT_SETUP: {
 		struct udc_nrf_evt evt = {
 			.type = UDC_NRF_EVT_HAL,
 			.hal_evt = *hal_evt,
@@ -454,6 +454,7 @@ static void usbd_event_handler(nrfx_usbd_evt_t const *const hal_evt)
 		 */
 		k_msgq_put(&drv_msgq, &evt, K_NO_WAIT);
 		break;
+	}
 	default:
 		break;
 	}


### PR DESCRIPTION
C language does not allow declarations after labels, only statements are allowed. Add {} around the `NRFX_USBD_EVT_SETUP` case to fix build issues (`error: a label can only be part of a statement and a declaration is not a statement`)