### PR TITLE
nsim: Description of nsim_em11d was missing simulation_exec

### DIFF
--- a/boards/arc/nsim/nsim_em11d.yaml
+++ b/boards/arc/nsim/nsim_em11d.yaml
@@ -2,6 +2,7 @@ identifier: nsim_em11d
 name: EM11D Nsim simulator
 type: sim
 simulation: nsim
+simulation_exec: nsimdrv
 arch: arc
 toolchain:
   - zephyr


### PR DESCRIPTION
Yaml description for simulators should contain simulation_exec telling which tool to use. nsim_em11d was missing this entry causing twister to only build but not execute tests on this platform. Value from other nsims was used.