### PR TITLE
intel_adsp: cpu init refactor

### DIFF
--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -9,7 +9,6 @@
 #include <zephyr/debug/sparse.h>
 #include <cpu_init.h>
 
-#include <xtensa/corebits.h>
 #include <adsp_boot.h>
 #include <adsp_power.h>
 #include <adsp_memory.h>
@@ -20,8 +19,6 @@
 #define LPSCTL_BATTR_MASK       GENMASK(16, 12)
 #define SRAM_ALIAS_BASE         0xA0000000
 #define SRAM_ALIAS_MASK         0xF0000000
-#define MEMCTL_DEFAULT_VALUE    (MEMCTL_INV_EN | MEMCTL_ICWU_MASK | MEMCTL_DCWA_MASK | \
-				 MEMCTL_DCWU_MASK | MEMCTL_L0IBUF_EN)
 
 __imr void power_init(void)
 {
@@ -110,15 +107,6 @@ struct lpsram_header {
 	uint8_t rom_bypass_vectors_reserved[0xC00 - 0x14];
 };
 
-static ALWAYS_INLINE void _core_basic_init(void)
-{
-	XTENSA_WSR("MEMCTL", MEMCTL_DEFAULT_VALUE);
-	XTENSA_WSR("PREFCTL", ADSP_L1_CACHE_PREFCTL_VALUE);
-	ARCH_XTENSA_SET_RPO_TLB();
-	XTENSA_WSR("ATOMCTL", 0x15);
-	__asm__ volatile("rsync");
-}
-
 static ALWAYS_INLINE void _save_core_context(uint32_t core_id)
 {
 	core_desc[core_id].vecbase = XTENSA_RSR("VECBASE");
@@ -162,7 +150,7 @@ void power_gate_entry(uint32_t core_id)
 
 void power_gate_exit(void)
 {
-	_core_basic_init();
+	cpu_early_init();
 	_restore_core_context();
 }
 

--- a/soc/xtensa/intel_adsp/common/include/cpu_init.h
+++ b/soc/xtensa/intel_adsp/common/include/cpu_init.h
@@ -4,9 +4,19 @@
 #ifndef __INTEL_ADSP_CPU_INIT_H
 #define __INTEL_ADSP_CPU_INIT_H
 
+#include <zephyr/arch/arch_inlines.h>
 #include <zephyr/arch/xtensa/cache.h>
 #include <xtensa/config/core-isa.h>
+#include <xtensa/corebits.h>
 #include <adsp_memory.h>
+
+#define MEMCTL_VALUE    (MEMCTL_INV_EN | MEMCTL_ICWU_MASK | MEMCTL_DCWA_MASK | \
+			 MEMCTL_DCWU_MASK | MEMCTL_L0IBUF_EN)
+
+#define ATOMCTL_BY_RCW	BIT(0) /* RCW Transaction for Bypass Memory */
+#define ATOMCTL_WT_RCW	BIT(2) /* RCW Transaction for Writethrough Cacheable Memory */
+#define ATOMCTL_WB_RCW	BIT(4) /* RCW Transaction for Writeback Cacheable Memory */
+#define ATOMCTL_VALUE (ATOMCTL_BY_RCW | ATOMCTL_WT_RCW | ATOMCTL_WB_RCW)
 
 /* Low-level CPU initialization.  Call this immediately after entering
  * C code to initialize the cache, protection and synchronization
@@ -43,8 +53,9 @@ static ALWAYS_INLINE void cpu_early_init(void)
 	 * fetch buffer.
 	 */
 #if XCHAL_USE_MEMCTL
-	reg = 0xffffff01;
-	__asm__ volatile("wsr %0, MEMCTL; rsync" :: "r"(reg));
+	reg = MEMCTL_VALUE;
+	XTENSA_WSR("MEMCTL", reg);
+	__asm__ volatile("rsync");
 #endif
 
 	/* Likewise enable prefetching.  Sadly these values are not
@@ -54,7 +65,8 @@ static ALWAYS_INLINE void cpu_early_init(void)
 	 * we're supposed to ask Cadence I guess.
 	 */
 	reg = ADSP_L1_CACHE_PREFCTL_VALUE;
-	__asm__ volatile("wsr %0, PREFCTL; rsync" :: "r"(reg));
+	XTENSA_WSR("PREFCTL", reg);
+	__asm__ volatile("rsync");
 
 	/* Finally we need to enable the cache in the Region
 	 * Protection Option "TLB" entries.  The hardware defaults
@@ -67,12 +79,12 @@ static ALWAYS_INLINE void cpu_early_init(void)
 	 * local CPU!  We need external transactions on the shared
 	 * bus.
 	 */
-	reg = 0x15;
-	__asm__ volatile("wsr %0, ATOMCTL" :: "r"(reg));
+	reg = ATOMCTL_VALUE;
+	XTENSA_WSR("ATOMCTL", reg);
 
 	/* Initialize interrupts to "disabled" */
 	reg = 0;
-	__asm__ volatile("wsr %0, INTENABLE" :: "r"(reg));
+	XTENSA_WSR("INTENABLE", reg);
 
 	/* Finally VECBASE.  Note that on core 0 startup, we're still
 	 * running in IMR and the vectors at this address won't be
@@ -81,7 +93,7 @@ static ALWAYS_INLINE void cpu_early_init(void)
 	 * consistently until Zephyr switches into the main thread.
 	 */
 	reg = VECBASE_RESET_PADDR_SRAM;
-	__asm__ volatile("wsr %0, VECBASE" :: "r"(reg));
+	XTENSA_WSR("VECBASE", reg);
 }
 
 #endif /* __INTEL_ADSP_CPU_INIT_H */


### PR DESCRIPTION
Reusing existing code during CPU init at power gating exit.

Additional changes:
- replacing magic value for memctl with more readable definition,
- using dedicated macros in place of asm inlines.