### PR TITLE
MAINTAINERS: Update release notes maintainers for 3.4

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -541,8 +541,7 @@ Documentation Infrastructure:
 Release Notes:
   status: maintained
   maintainers:
-    - laurenmurphyx64
-    - stephanosio
+    - nashif
   files:
     - doc/releases/release-notes-*
   labels:


### PR DESCRIPTION
This commit changes the release notes area maintainers to the release managers for the Zephyr 3.4 release.