### PR TITLE
SECURITY: Update supported version list after v3.3

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,12 +8,12 @@ updates:
   - The most recent release, and the release prior to that.
   - Active LTS releases.
 
-At this time, with the latest release of v3.2.0, the supported
+At this time, with the latest release of v3.3.0, the supported
 versions are:
 
   - v2.7.0: Current LTS
-  - v3.1.0: Prior release
-  - v3.2.0: Current release
+  - v3.2.0: Prior release
+  - v3.3.0: Current release
 
 ## Reporting process
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,12 +8,12 @@ updates:
   - The most recent release, and the release prior to that.
   - Active LTS releases.
 
-At this time, with the latest release of v3.3.0, the supported
+At this time, with the latest release of v3.3, the supported
 versions are:
 
-  - v2.7.0: Current LTS
-  - v3.2.0: Prior release
-  - v3.3.0: Current release
+  - v2.7: Current LTS
+  - v3.2: Prior release
+  - v3.3: Current release
 
 ## Reporting process
 


### PR DESCRIPTION
This commit updates the list of supported versions in the project
security policy document after the Zephyr 3.3 release.