### PR TITLE
twister: coverage: initialize 'use_system_gcov'

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -237,6 +237,8 @@ class Gcovr(CoverageTool):
 
 
 def run_coverage(testplan, options):
+    use_system_gcov = False
+
     for plat in options.coverage_platform:
         _plat = testplan.get_platform(plat)
         if _plat and (_plat.type in {"native", "unit"}):


### PR DESCRIPTION
Initialize `use_system_gcov`, so it is always set before being referenced
in `elif` statement.

Fixes: 1440b19bded1