### PR TITLE
Bluetooth: Audio: Fix bad shell string formats

### DIFF
--- a/subsys/bluetooth/shell/micp_mic_ctlr.c
+++ b/subsys/bluetooth/shell/micp_mic_ctlr.c
@@ -310,7 +310,7 @@ static int cmd_micp_mic_ctlr_aics_input_state_get(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -342,7 +342,7 @@ static int cmd_micp_mic_ctlr_aics_gain_setting_get(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -374,7 +374,7 @@ static int cmd_micp_mic_ctlr_aics_input_type_get(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -406,7 +406,7 @@ static int cmd_micp_mic_ctlr_aics_input_status_get(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -438,7 +438,7 @@ static int cmd_micp_mic_ctlr_aics_input_unmute(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -466,7 +466,7 @@ static int cmd_micp_mic_ctlr_aics_input_mute(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -498,7 +498,7 @@ static int cmd_micp_mic_ctlr_aics_manual_input_gain_set(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -531,7 +531,7 @@ static int cmd_micp_mic_ctlr_aics_automatic_input_gain_set(const struct shell *s
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -564,7 +564,7 @@ static int cmd_micp_mic_ctlr_aics_gain_set(const struct shell *sh, size_t argc,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -578,7 +578,7 @@ static int cmd_micp_mic_ctlr_aics_gain_set(const struct shell *sh, size_t argc,
 	}
 
 	if (gain > INT8_MAX || gain < INT8_MIN) {
-		shell_error(sh, "Gain shall be %d-%d, was %d",
+		shell_error(sh, "Gain shall be %d-%d, was %ld",
 			    INT8_MIN, INT8_MAX, gain);
 
 		return -ENOEXEC;
@@ -610,7 +610,7 @@ static int cmd_micp_mic_ctlr_aics_input_description_get(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -642,7 +642,7 @@ static int cmd_micp_mic_ctlr_aics_input_description_set(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;

--- a/subsys/bluetooth/shell/micp_mic_dev.c
+++ b/subsys/bluetooth/shell/micp_mic_dev.c
@@ -212,7 +212,7 @@ static int cmd_micp_mic_dev_aics_deactivate(const struct shell *sh, size_t argc,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -240,7 +240,7 @@ static int cmd_micp_mic_dev_aics_activate(const struct shell *sh, size_t argc,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -268,7 +268,7 @@ static int cmd_micp_mic_dev_aics_input_state_get(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -296,7 +296,7 @@ static int cmd_micp_mic_dev_aics_gain_setting_get(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -324,7 +324,7 @@ static int cmd_micp_mic_dev_aics_input_type_get(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -352,7 +352,7 @@ static int cmd_micp_mic_dev_aics_input_status_get(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -380,7 +380,7 @@ static int cmd_micp_mic_dev_aics_input_unmute(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -408,7 +408,7 @@ static int cmd_micp_mic_dev_aics_input_mute(const struct shell *sh, size_t argc,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -436,7 +436,7 @@ static int cmd_micp_mic_dev_aics_manual_input_gain_set(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -465,7 +465,7 @@ static int cmd_micp_mic_dev_aics_automatic_input_gain_set(const struct shell *sh
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -494,14 +494,14 @@ static int cmd_micp_mic_dev_aics_gain_set(const struct shell *sh, size_t argc,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -515,7 +515,7 @@ static int cmd_micp_mic_dev_aics_gain_set(const struct shell *sh, size_t argc,
 	}
 
 	if (!IN_RANGE(gain, INT8_MIN, INT8_MAX)) {
-		shell_error(sh, "Gain shall be %d-%d, was %d",
+		shell_error(sh, "Gain shall be %d-%d, was %ld",
 			    INT8_MIN, INT8_MAX, gain);
 
 		return -ENOEXEC;
@@ -543,7 +543,7 @@ static int cmd_micp_mic_dev_aics_input_description_get(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -571,7 +571,7 @@ static int cmd_micp_mic_dev_aics_input_description_set(const struct shell *sh,
 	}
 
 	if (index >= micp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    micp_included.aics_cnt, index);
 
 		return -ENOEXEC;

--- a/subsys/bluetooth/shell/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/shell/vcp_vol_ctlr.c
@@ -1040,7 +1040,7 @@ static int cmd_vcp_vol_ctlr_aics_gain_set(const struct shell *sh, size_t argc,
 	}
 
 	if (index >= vcp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    vcp_included.aics_cnt, index);
 		return -ENOEXEC;
 	}
@@ -1052,7 +1052,7 @@ static int cmd_vcp_vol_ctlr_aics_gain_set(const struct shell *sh, size_t argc,
 	}
 
 	if (!IN_RANGE(gain, INT8_MIN, INT8_MAX)) {
-		shell_error(sh, "Gain shall be %d-%d, was %d",
+		shell_error(sh, "Gain shall be %d-%d, was %ld",
 			    INT8_MIN, INT8_MAX, gain);
 		return -ENOEXEC;
 	}

--- a/subsys/bluetooth/shell/vcp_vol_rend.c
+++ b/subsys/bluetooth/shell/vcp_vol_rend.c
@@ -534,7 +534,7 @@ static int cmd_vcp_vol_rend_vocs_offset_set(const struct shell *sh, size_t argc,
 	}
 
 	if (offset > BT_VOCS_MAX_OFFSET || offset < BT_VOCS_MIN_OFFSET) {
-		shell_error(sh, "Offset shall be %d-%d, was %d",
+		shell_error(sh, "Offset shall be %d-%d, was %ld",
 			    BT_VOCS_MIN_OFFSET, BT_VOCS_MAX_OFFSET, offset);
 		return -ENOEXEC;
 	}
@@ -838,7 +838,7 @@ static int cmd_vcp_vol_rend_aics_gain_set(const struct shell *sh, size_t argc,
 	}
 
 	if (index >= vcp_included.aics_cnt) {
-		shell_error(sh, "Index shall be less than %u, was %u",
+		shell_error(sh, "Index shall be less than %u, was %lu",
 			    vcp_included.aics_cnt, index);
 
 		return -ENOEXEC;
@@ -852,7 +852,7 @@ static int cmd_vcp_vol_rend_aics_gain_set(const struct shell *sh, size_t argc,
 	}
 
 	if (gain > INT8_MAX || gain < INT8_MIN) {
-		shell_error(sh, "Gain shall be %d-%d, was %d",
+		shell_error(sh, "Gain shall be %d-%d, was %ld",
 			    INT8_MIN, INT8_MAX, gain);
 
 		return -ENOEXEC;


### PR DESCRIPTION
There was a couple of shell prints that was not
formatted correctly.