### PR TITLE
Bluetooth: host: increase BT_CONN_TX_USER_DATA_SIZE for 64bit platforms

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -282,6 +282,7 @@ config BT_LIM_ADV_TIMEOUT
 
 config BT_CONN_TX_USER_DATA_SIZE
 	int
+	default 16 if 64BIT
 	default 8
 	help
 	  Necessary user_data size for allowing packet fragmentation when


### PR DESCRIPTION
Commit 2c00dd5fec4c ("Bluetooth: host: check net bufs have enough room in
user_data") added a build time check of user data size. This check does not pass
with default `CONFIG_BT_CONN_TX_USER_DATA_SIZE=8` and with `native_posix_64`
platform, as 16 bytes are needed in order to store `struct tx_meta`.

Select 16 as default value for 64bit platforms, so Bluetooth samples/tests
are buildable for `native_posix_64`.