### PR TITLE
 Add implementation of `otPlatRadioSetMacFrameCounterIfLarger`

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -952,6 +952,10 @@ static int nrf5_configure(const struct device *dev,
 	case IEEE802154_CONFIG_FRAME_COUNTER:
 		nrf_802154_security_global_frame_counter_set(config->frame_counter);
 		break;
+
+	case IEEE802154_CONFIG_FRAME_COUNTER_IF_LARGER:
+		nrf_802154_security_global_frame_counter_set_if_larger(config->frame_counter);
+		break;
 #endif /* CONFIG_IEEE802154_2015 */
 
 	case IEEE802154_CONFIG_ENH_ACK_HEADER_IE: {

--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -169,6 +169,12 @@ enum ieee802154_config_type {
 	/** Sets the current MAC frame counter value for radios supporting transmit security. */
 	IEEE802154_CONFIG_FRAME_COUNTER,
 
+	/** Sets the current MAC frame counter value if the provided value is greater than
+	 * the current one.
+	 */
+
+	IEEE802154_CONFIG_FRAME_COUNTER_IF_LARGER,
+
 	/** Configure a radio reception slot. This can be used for any scheduler reception, e.g.:
 	 *  Zigbee GP device, CSL, TSCH, etc.
 	 *

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -1145,6 +1145,15 @@ void otPlatRadioSetMacFrameCounter(otInstance *aInstance,
 	(void)radio_api->configure(radio_dev, IEEE802154_CONFIG_FRAME_COUNTER,
 				   &config);
 }
+
+void otPlatRadioSetMacFrameCounterIfLarger(otInstance *aInstance, uint32_t aMacFrameCounter)
+{
+	ARG_UNUSED(aInstance);
+
+	struct ieee802154_config config = { .frame_counter = aMacFrameCounter };
+	(void)radio_api->configure(radio_dev, IEEE802154_CONFIG_FRAME_COUNTER_IF_LARGER,
+				   &config);
+}
 #endif
 
 #if defined(CONFIG_OPENTHREAD_CSL_RECEIVER)

--- a/west.yml
+++ b/west.yml
@@ -83,7 +83,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 6c9f23498ee6a225fee049c8c5b2e1ac760bd4a8
+      revision: 609d4b41fe9773cd294eb8656d99eb9385389e52
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Adding an Openthread radio API `otPlatRadioSetMacFrameCounterIfLarger` implementation and the corresponding call to the IEEEE802154 driver.