### PR TITLE
drivers: net: initialize logging for the slip module

### DIFF
--- a/drivers/ethernet/eth_slip_tap.c
+++ b/drivers/ethernet/eth_slip_tap.c
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define LOG_MODULE_NAME eth_slip_tap
+#define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
 #include <zephyr/net/ethernet.h>
 #include "../net/slip.h"
 


### PR DESCRIPTION
To reproduce: `west build -p -b qemu_x86 samples/net/sockets/txtime`, used the same pattern I've found in other ethernet drivers, lmk if that's not correct for this.

---

This fixes a regression introduced in:

16a0e314ea drivers: net: Move Ethernet device definition for SLIP to
	   ethernet

Where the module would fail to build with:

log_core.h:153:20: error: '__log_level' undeclared (first use in this function)

Registering a module fixes the build.