### PR TITLE
MAINTAINERS: various updates

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -334,6 +334,7 @@ CMSIS API layer:
     - include/zephyr/portability/cmsis*
     - samples/subsys/portability/cmsis_rtos_v*/
     - tests/subsys/portability/cmsis_rtos_v*/
+    - doc/services/portability/
   labels:
     - "area: CMSIS API Layer"
     - "area: Portability"
@@ -409,6 +410,7 @@ Debug:
     - tests/subsys/debug/
     - scripts/coredump/
     - samples/subsys/debug/
+    - doc/services/debugging/
   labels:
     - "area: Debugging"
 
@@ -805,6 +807,7 @@ Release Notes:
     - samples/drivers/flash_shell/
     - samples/drivers/soc_flash_nrf/
     - tests/drivers/flash/
+    - doc/hardware/peripherals/flash.rst
   labels:
     - "area: Flash"
 
@@ -835,6 +838,7 @@ Release Notes:
     - dts/bindings/fuel-gauge/
     - include/zephyr/drivers/fuel_gauge.h
     - tests/drivers/fuel_gauge/
+    - doc/hardware/peripherals/fuel_gauge.rst
   labels:
     - "area: Fuel Gauge"
 
@@ -1484,6 +1488,7 @@ Logging:
     - subsys/logging/
     - tests/subsys/logging/
     - scripts/logging/
+    - doc/services/logging/
   labels:
     - "area: Logging"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1159,6 +1159,7 @@ Release Notes:
     - include/zephyr/drivers/sensor/
     - include/zephyr/dt-bindings/sensor/
     - doc/hardware/peripherals/sensor.rst
+    - tests/drivers/build_all/sensor/
   labels:
     - "area: Sensors"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -576,6 +576,17 @@ Release Notes:
   labels:
     - "area: Audio"
 
+"Drivers: bbram":
+  status: maintained
+  maintainers:
+    - yperess
+  files:
+    - tests/drivers/bbram/
+    - drivers/bbram/
+    - include/zephyr/drivers/bbram.h
+  labels:
+    - "area: Battery Backed RAM (bbram)"
+
 "Drivers: CAN":
   status: maintained
   maintainers:
@@ -1004,6 +1015,9 @@ Release Notes:
     - rerickson1
   files:
     - drivers/modem/
+    - tests/drivers/build_all/modem/
+    - dts/bindings/modem/
+    - include/zephyr/drivers/modem/
   labels:
     - "area: Modem"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1271,6 +1271,20 @@ Release Notes:
   labels:
     - "area: Memory Management"
 
+"Drivers: Virtualization":
+  status: maintained
+  maintainers:
+    - tbursztyka
+  files:
+    - drivers/virtualization/
+    - tests/drivers/virtualization/
+    - dts/bindings/virtualization/
+    - include/zephyr/drivers/virtualization/
+    - doc/services/virtualization/
+    - include/zephyr/drivers/virtualization/ivshmem.h
+  labels:
+    - "area: Virtualization"
+
 Xen Platform:
   status: maintained
   maintainers:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -990,6 +990,7 @@ Release Notes:
     - drivers/led_strip/
     - dts/bindings/led_strip/
     - include/zephyr/drivers/led_strip.h
+    - tests/drivers/build_all/led_strip/
   labels:
     - "area: LED"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -820,6 +820,7 @@ Release Notes:
     - dts/bindings/fpga/
     - include/zephyr/drivers/fpga.h
     - samples/drivers/fpga/
+    - tests/drivers/build_all/fpga/
   labels:
     - "area: FPGA"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1710,6 +1710,7 @@ POSIX API layer:
     - lib/posix/
     - tests/posix/
     - samples/posix/
+    - tests/lib/fdtable/
   labels:
     - "area: POSIX"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1386,6 +1386,7 @@ Kernel:
     - include/zephyr/sys_clock.h
     - samples/kernel/
     - include/zephyr/kernel/
+    - tests/lib/p4workq/
   files-exclude:
     - tests/kernel/mem_protect/
   labels:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -907,6 +907,7 @@ Release Notes:
     - include/zephyr/drivers/i3c.h
     - include/zephyr/drivers/i3c/
     - doc/hardware/peripherals/i3c.rst
+    - tests/drivers/build_all/i3c/
   labels:
     - "area: I3C"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2676,6 +2676,7 @@ West:
     - pdgendt
   files:
     - modules/Kconfig.lvgl
+    - tests/lib/gui/lvgl/
   labels:
     - manifest-lvgl
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -667,6 +667,7 @@ Release Notes:
     - tests/drivers/counter/
     - doc/hardware/peripherals/counter.rst
     - samples/drivers/counter/
+    - tests/drivers/build_all/counter/
   labels:
     - "area: Counter"
 


### PR DESCRIPTION
- MAINTAINERS: add fdtable tests to posix area
- MAINTAINERS: add p4workq to kernel area
- MAINTAINERS: add lvgl tests to area
- MAINTAINERS: add virtualization area
- MAINTAINERS: add sensor tests to area
- MAINTAINERS: add bbram area
- MAINTAINERS: add tests to fpga area
- MAINTAINERS: add tests to i3c area
- MAINTAINERS: add tests to led_strip area
- MAINTAINERS: add tests to counter area
- MAINTAINERS: add docs to respective areas
