### PR TITLE
doc: west 1.0 release notes

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -26,7 +26,7 @@ on:
 
 env:
   # NOTE: west docstrings will be extracted from the version listed here
-  WEST_VERSION: 0.14.0
+  WEST_VERSION: 1.0.0a1
   # The latest CMake available directly with apt is 3.18, but we need >=3.20
   # so we fetch that through pip.
   CMAKE_VERSION: 3.20.5

--- a/doc/develop/west/index.rst
+++ b/doc/develop/west/index.rst
@@ -26,7 +26,7 @@ You can run ``west --help`` (or ``west -h`` for short) to get top-level help
 for available west commands, and ``west <command> -h`` for detailed help on
 each command.
 
-The following pages document west's ``v0.14.x`` releases, and provide additional
+The following pages document west's ``v1.0.y`` releases, and provide additional
 context about the tool.
 
 .. toctree::

--- a/doc/develop/west/release-notes.rst
+++ b/doc/develop/west/release-notes.rst
@@ -3,6 +3,74 @@
 West Release Notes
 ##################
 
+v1.0.0
+******
+
+Major changes in this release:
+
+- The :ref:`west-apis` are now declared stable. Any breaking changes will be
+  communicated by a major version bump from v1.x.y to v2.x.y.
+
+- West v1.0 no longer works with the Zephyr v1.14 LTS releases. This LTS has
+  long been obsoleted by Zephyr v2.7 LTS. If you need to use Zephyr v1.14, you
+  must use west v0.14 or earlier.
+
+- Like the rest of Zephyr, west now requires Python v3.8 or later
+
+- West commands no longer accept abbreviated command line arguments. For
+  example, you must now specify ``west update --keep-descendants`` instead of
+  using an abbreviation like ``west update --keep-d``. This is part of a change
+  applied to all of Zephyr's Python scripts' command-line interfaces. The
+  abbreviations were causing problems in practice when commands were updated to
+  add new options with similar names but different behavior to existing ones.
+
+Other changes:
+
+- All built-in west functions have stopped using ``west.log``
+
+- ``west update``: new ``--submodule-init-config`` option.
+  See commit `9ba92b05`_ for details.
+
+Bug fixes:
+
+- West extension commands that failed to load properly sometimes dumped stack.
+  This has been fixed and west now prints a sensible error message in this case.
+
+- ``west config`` now fails on malformed configuration option arguments
+  which lack a ``.`` in the option name
+
+API changes:
+
+- The west package now contains the metadata files necessary for some static
+  analyzers (such as `mypy`_) to auto-detect its type annotations.
+  See commit `d9f00e24`_ for details.
+
+- the deprecated ``west.build`` module used for Zephyr v1.14 LTS compatibility was
+  removed
+
+- the deprecated ``west.cmake`` module used for Zephyr v1.14 LTS compatibility was
+  removed
+
+- the ``west.log`` module is now deprecated. This module's uses global state,
+  which can make it awkward to use it as an API which multiple different python
+  modules may rely on.
+
+- The :ref:`west-apis-commands` module got some new APIs which lay groundwork
+  for a future change to add a global verbosity control to a command's output,
+  and work to remove global state from the ``west`` package's API:
+
+  - New ``west.commands.WestCommand.__init__()`` keyword argument: ``verbosity``
+  - New ``west.commands.WestCommand`` property: ``color_ui``
+  - New ``west.commands.WestCommand`` methods, which should be used to print output
+    from extension commands instead of writing directly to sys.stdout or
+    sys.stderr: ``inf()``, ``wrn()``, ``err()``, ``die()``, ``banner()``,
+    ``small_banner()``
+  - New ``west.commands.VERBOSITY`` enum
+
+.. _9ba92b05: https://github.com/zephyrproject-rtos/west/commit/9ba92b054500d75518ff4c4646590bfe134db523
+.. _d9f00e24: https://github.com/zephyrproject-rtos/west/commit/d9f00e242b8cb297b56e941982adf231281c6bae
+.. _mypy: https://www.mypy-lang.org/
+
 v0.14.0
 *******
 

--- a/doc/develop/west/west-apis.rst
+++ b/doc/develop/west/west-apis.rst
@@ -10,14 +10,6 @@ This page documents the Python APIs provided by :ref:`west <west>`, as well as
 some additional APIs used by the :ref:`west extensions <west-extensions>` in
 the zephyr repository.
 
-.. warning::
-
-   These APIs should be considered unstable until west version 1.0 (see `west
-   #38`_).
-
-.. _west #38:
-   https://github.com/zephyrproject-rtos/west/issues/38
-
 **Contents**:
 
 .. contents::
@@ -111,6 +103,13 @@ WestCommand
 
    .. versionadded:: 0.11.0
 
+   .. py:attribute:: color_ui
+
+      True if the west configuration permits colorized output,
+      False otherwise.
+
+   .. versionadded:: 1.0.0
+
    Constructor:
 
    .. automethod:: __init__
@@ -123,6 +122,8 @@ WestCommand
       The *topdir* parameter can now be any ``os.PathLike``.
    .. versionchanged:: 0.13.0
       The deprecated *requires_installation* parameter was removed.
+   .. versionadded:: 1.0.0
+      The *verbosity* parameter.
 
    Methods:
 
@@ -132,6 +133,9 @@ WestCommand
       The *topdir* argument was added.
 
    .. automethod:: add_parser
+
+   .. automethod:: add_pre_run_hook
+   .. versionadded:: 1.0.0
 
    .. automethod:: check_call
 
@@ -147,6 +151,53 @@ WestCommand
    .. automethod:: do_add_parser
 
    .. automethod:: do_run
+
+   The following methods should be used when the command needs to print output.
+   These were introduced to enable a transition from the deprecated
+   ``west.log`` module to a per-command interface that will allow for a global
+   "quiet" mode for west commands in a future release:
+
+   .. automethod:: dbg
+   .. versionadded:: 1.0.0
+
+   .. automethod:: inf
+   .. versionadded:: 1.0.0
+
+   .. automethod:: wrn
+   .. versionadded:: 1.0.0
+
+   .. automethod:: err
+   .. versionadded:: 1.0.0
+
+   .. automethod:: die
+   .. versionadded:: 1.0.0
+
+   .. automethod:: banner
+   .. versionadded:: 1.0.0
+
+   .. automethod:: small_banner
+   .. versionadded:: 1.0.0
+
+.. _west-apis-commands-output:
+
+Verbosity
+=========
+
+Since west v1.0, west commands should print output using methods like
+west.commands.WestCommand.dbg(), west.commands.WestCommand.inf(), etc. (see
+above). This section documents a related enum used to declare verbosity levels.
+
+.. autoclass:: west.commands.Verbosity
+
+   .. autoattribute:: QUIET
+   .. autoattribute:: ERR
+   .. autoattribute:: WRN
+   .. autoattribute:: INF
+   .. autoattribute:: DBG
+   .. autoattribute:: DBG_MORE
+   .. autoattribute:: DBG_EXTREME
+
+.. versionadded:: 1.0.0
 
 Exceptions
 ==========
@@ -216,16 +267,10 @@ not be used in new code when west v0.13.0 or later may be assumed.
 
 .. _west-apis-log:
 
-west.log
-********
+west.log (deprecated)
+*********************
 
 .. automodule:: west.log
-
-This module's functions are used whenever a running west command needs to print
-to standard out or error streams.
-
-This is safe to use from extension commands if you want output that mirrors
-that of west itself.
 
 Verbosity control
 =================
@@ -266,8 +311,8 @@ west.manifest
 
 The main classes are :py:class:`Manifest` and :py:class:`Project`. These
 represent the contents of a :ref:`manifest file <west-manifests>`. The
-recommended methods for parsing west manifests are
-:py:meth:`Manifest.from_file` and :py:meth:`Manifest.from_data`.
+recommended method for parsing west manifests is
+:py:meth:`Manifest.from_topdir`.
 
 Constants and functions
 =======================


### PR DESCRIPTION
West has stabilized enough that it's time to call it a v1.0 and declare API stability. There are many scripts out there using the west APIs, so any future changes are going to need to go through a semantic versioning process.

This release formally removes support for the obsolete Zephyr v1.14 LTS. Otherwise, I am expecting the impact of the changes to be minor and incremental; see release notes for details.