### PR TITLE
.github: doc-build: move to west 1.0.0

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -26,7 +26,7 @@ on:
 
 env:
   # NOTE: west docstrings will be extracted from the version listed here
-  WEST_VERSION: 1.0.0a1
+  WEST_VERSION: 1.0.0
   # The latest CMake available directly with apt is 3.18, but we need >=3.20
   # so we fetch that through pip.
   CMAKE_VERSION: 3.20.5

--- a/doc/develop/west/release-notes.rst
+++ b/doc/develop/west/release-notes.rst
@@ -51,7 +51,7 @@ API changes:
 - the deprecated ``west.cmake`` module used for Zephyr v1.14 LTS compatibility was
   removed
 
-- the ``west.log`` module is now deprecated. This module's uses global state,
+- the ``west.log`` module is now deprecated. This module uses global state,
   which can make it awkward to use it as an API which multiple different python
   modules may rely on.
 


### PR DESCRIPTION
The release notes are in and west==1.0.0 is installable via pypi. Move the doc build over to it and fix a typo while we are here.