### PR TITLE
driver: bluetooth: Added Infineon AIROC CYW43xxx BT driver

### DIFF
--- a/boards/arm/cy8cproto_062_4343w/Kconfig.defconfig
+++ b/boards/arm/cy8cproto_062_4343w/Kconfig.defconfig
@@ -8,4 +8,34 @@ if BOARD_CY8CPROTO_062_4343W
 config BOARD
 	default "cy8cproto_062_4343w"
 
+if WIFI || BT
+
+# Select CYW43XXX part and module
+choice CYW43XXX_PART
+	default CYW4343W
+endchoice
+
+choice CYW4343W_MODULE
+	default CYW4343W_MURATA_1DX
+endchoice
+
+endif # WIFI || BT
+
+
+if BT
+
+# Select HCI components
+config UART
+	bool
+	default y
+
+config BT_UART
+	default y
+
+choice BT_HCI_BUS_TYPE
+	default BT_H4
+endchoice
+
+endif # BT
+
 endif   # BOARD_CY8CPROTO_062_4343W

--- a/boards/arm/cy8cproto_062_4343w/cy8cproto_062_4343w-pinctrl.dtsi
+++ b/boards/arm/cy8cproto_062_4343w/cy8cproto_062_4343w-pinctrl.dtsi
@@ -3,6 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Configure pin control bias mode for uart2 pins */
+&p3_1_scb2_uart_tx {
+	drive-push-pull;
+};
+
+&p3_0_scb2_uart_rx {
+	input-enable;
+};
+
+&p3_2_scb2_uart_rts {
+	drive-push-pull;
+};
+
+&p3_3_scb2_uart_cts {
+	input-enable;
+};
+
 /* Configure pin control bias mode for uart5 pins */
 &p5_1_scb5_uart_tx {
 	drive-push-pull;

--- a/boards/arm/cy8cproto_062_4343w/cy8cproto_062_4343w.dts
+++ b/boards/arm/cy8cproto_062_4343w/cy8cproto_062_4343w.dts
@@ -22,6 +22,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart5;
 		zephyr,shell-uart = &uart5;
+		zephyr,bt_uart = &uart2;
 	};
 };
 
@@ -31,6 +32,32 @@
 
 	pinctrl-0 = <&p5_1_scb5_uart_tx &p5_0_scb5_uart_rx>;
 	pinctrl-names = "default";
+};
+
+&uart2 {
+	status = "okay";
+	/* The UART bus speed (current_speed) for zephyr_bt_uart should be the same
+	 * as the default baudrate defined in CYW43xx firmware (default 115200).
+	 */
+
+	current-speed = <115200>;
+
+	/* HCI-UART pins*/
+	pinctrl-0 = <&p3_1_scb2_uart_tx &p3_0_scb2_uart_rx &p3_2_scb2_uart_rts &p3_3_scb2_uart_cts>;
+	pinctrl-names = "default";
+
+	bt-hci {
+		status = "okay";
+		compatible = "infineon,cyw43xxx-bt-hci";
+		bt-reg-on-gpios = <&gpio_prt3 4 (GPIO_ACTIVE_HIGH)>;
+
+		/* Configuration UART speeds for firmware download (fw-download-speed) and
+		 * HCI operation (hci-operation-speed).
+		 * If hci-operation-speed or fw-download-speed are not defined in bt-hci{...}
+		 * node, cyw43xx driver will use bus/current-speed as default speed.
+		 */
+		fw-download-speed = <3000000>;
+	};
 };
 
 /* System clock configuration */

--- a/boards/arm/cy8cproto_062_4343w/cy8cproto_062_4343w_defconfig
+++ b/boards/arm/cy8cproto_062_4343w/cy8cproto_062_4343w_defconfig
@@ -24,5 +24,8 @@ CONFIG_SERIAL=y
 # Enable pin controller
 CONFIG_PINCTRL=y
 
+# Enable GPIO driver
+CONFIG_GPIO=y
+
 # Enable clock controller
 CONFIG_CLOCK_CONTROL=y

--- a/drivers/bluetooth/hci/CMakeLists.txt
+++ b/drivers/bluetooth/hci/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library_sources_ifdef(CONFIG_BT_B91         hci_b91.c)
+zephyr_library_sources_ifdef(CONFIG_BT_CYW43XXX    cyw43xxx.c)
 zephyr_library_sources_ifdef(CONFIG_BT_ESP32       hci_esp32.c)
 zephyr_library_sources_ifdef(CONFIG_BT_H4          h4.c)
 zephyr_library_sources_ifdef(CONFIG_BT_H5          h5.c)

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -109,6 +109,19 @@ config BT_STM32_IPM_RX_STACK_SIZE
 	depends on BT_STM32_IPM
 	default 512
 
+menuconfig BT_CYW43XXX
+	bool "CYW43XXX BT connectivity"
+	default y
+	select BT_HCI_SETUP
+	depends on GPIO
+	depends on DT_HAS_INFINEON_CYW43XXX_BT_HCI_ENABLED
+	depends on BT_H4
+	help
+	  Infineon's AIROC™ Wi-Fi & combos portfolio integrates
+	  IEEE 802.11a/b/g/n/ac/ax Wi-Fi and Bluetooth® 5.2 in a single-chip
+	  solution to enable small-form-factor IoT designs.
+source "drivers/bluetooth/hci/Kconfig.infineon"
+
 config BT_DRIVER_QUIRK_NO_AUTO_DLE
 	bool "Host auto-initiated Data Length Update quirk"
 	depends on BT_AUTO_DATA_LEN_UPDATE

--- a/drivers/bluetooth/hci/Kconfig.infineon
+++ b/drivers/bluetooth/hci/Kconfig.infineon
@@ -1,0 +1,137 @@
+# Copyright (c) 2023 Cypress Semiconductor Corporation (an Infineon company) or
+# an affiliate of Cypress Semiconductor Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+if BT_CYW43XXX
+
+choice  CYW43XXX_PART
+	prompt "Select CYW43XXX part"
+
+config CYW4343W
+	bool "CYW4343W"
+	help
+	  Enable Infineon CYW4343W BLE connectivity,
+	  More information about CYW4343W device you can find on
+	  https://www.infineon.com/cms/en/product/wireless-connectivity/airoc-wi-fi-plus-bluetooth-combos/cyw4343w/
+
+config CYW4373
+	bool "CYW4373"
+	help
+	  Enable Infineon CYW4373 BLE connectivity,
+	  More information about CYW4373 device you can find on
+	  https://www.infineon.com/cms/en/product/wireless-connectivity/airoc-wi-fi-plus-bluetooth-combos/cyw4373/
+
+config CYW43012
+	bool "CYW43012"
+	help
+	  Enable Infineon CYW43012 BLE connectivity,
+	  More information about CYW43012 device you can find on
+	  https://www.infineon.com/cms/en/product/wireless-connectivity/airoc-wi-fi-plus-bluetooth-combos/cyw43012/
+
+config CYW43438
+	bool "CYW43438"
+	help
+	  Enable Infineon CYW43438 BLE connectivity,
+	  More information about CYW43438 device you can find on
+	  https://www.infineon.com/cms/en/product/wireless-connectivity/airoc-wi-fi-plus-bluetooth-combos/cyw43438/
+
+config CYW43439
+	bool "CYW43439"
+	help
+	  Enable Infineon CYW43439 BLE connectivity,
+	  More information about CYW43439 device you can find on
+	  https://www.infineon.com/cms/en/product/wireless-connectivity/airoc-wi-fi-plus-bluetooth-combos/cyw43439/
+
+config BT_CYW43XXX_CUSTOM
+	bool "Custom CYW43xx device/module"
+	help
+	  Select Custom CYW43xx device/module. For this option,
+	  user must to provide path to BT firmware HCD file for
+	  custom or vendor CYW43xx modules in CYW43XX_CUSTOM_FIRMWARE_HCD_BLOB.
+
+endchoice
+
+choice CYW43012_MODULE
+	prompt "Select CYW43012 module"
+	depends on CYW43012
+
+config CYW43012_MURATA_1LV
+	bool "MURATA-1LV"
+	help
+	  Murata Type 1LV module based on Infineon CYW43012 combo chipset
+	  which supports Wi-Fi® 802.11a/b/g/n + Bluetooth® 5.0 BR/EDR/LE
+	  up to 72.2Mbps PHY data rate on Wi-fi® and 3Mbps PHY data rate
+	  on Bluetooth®. 2Mbps LE PHY is also supported.
+
+	  Detailed information about Murata Type 1LV module you can find on
+	  https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type1lv
+
+endchoice
+
+choice CYW4343W_MODULE
+	prompt "Select CYW4343W module"
+	depends on CYW4343W
+
+config CYW4343W_MURATA_1DX
+	bool "MURATA-1DX"
+	help
+	  Murata Type 1DX modules based on Infineon CYW4343W combo chipset
+	  which supports Wi-Fi® 802.11b/g/n + Bluetooth® 5.1 BR/EDR/LE
+	  up to 65Mbps PHY data rate on Wi-fi® and 3Mbps PHY data rate
+	  on Bluetooth®.
+
+	  Detailed information about Type 1DX module you can find on
+	  https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type1dx
+
+endchoice
+
+choice CYW4373_MODULE
+	prompt "Select CYW4373 module"
+	depends on CYW4373
+
+config CYW4373_STERLING_LWB5PLUS
+	bool "STERLING-LWB5plus"
+	help
+	  Laird Sterling LWB5+ 802.11ac / Bluetooth 5.0 M.2 Carrier Board
+	  (E-Type Key w/ SDIO/UART)
+
+	  Detailed information about Type Sterling LWB5+ module you can find on
+	  https://www.lairdconnect.com/wireless-modules/wifi-modules-bluetooth/sterling-lwb5-plus-wifi-5-bluetooth-5-module
+
+endchoice
+
+choice CYW43439_MODULE
+	prompt "Select CYW43439 module"
+	depends on CYW43439
+
+config CYW43439_MURATA_1YN
+	bool "MURATA_1YN"
+	help
+	  Murata Type 1YN module based on Infineon CYW43439 combo chipset
+	  which supports Wi-Fi® 802.11b/g/n + Bluetooth® 5.2 BR/EDR/LE
+	  up to 65Mbps PHY data rate on Wi-fi® and 3Mbps PHY data rate on
+	  Bluetooth®.
+
+	  Detailed information about Murata Type 1YN module you can find on
+	  https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type1yn
+
+endchoice
+
+config CYW43XX_CUSTOM_FIRMWARE_HCD_BLOB
+	depends on BT_CYW43XXX_CUSTOM
+	string  "Path to user BT firmware HCD file"
+	help
+	  Path to BT firmware HCD file for custom or vendor CYW43xx modules.
+	  It can be absolute path, or relative from project folder.
+
+# Change size of command lengths. It for vendor commands related to
+# firmware downloading.
+config BT_BUF_CMD_TX_SIZE
+	default 255
+
+# Disable ATT_ENFORCE_FLOW feature, CYW43XX informs about frees buffer
+# (HCL Number Of Completed Packets event) after second packet.
+config BT_ATT_ENFORCE_FLOW
+	default n
+
+endif # BT_CYW43XXX

--- a/drivers/bluetooth/hci/cyw43xxx.c
+++ b/drivers/bluetooth/hci/cyw43xxx.c
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023 Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @brief CYW43xxx HCI extension driver.
+ */
+
+#include <errno.h>
+#include <stddef.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/drivers/bluetooth/hci_driver.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/uart.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(cyw43xxx_driver);
+
+#include <stdint.h>
+
+#define DT_DRV_COMPAT infineon_cyw43xxx_bt_hci
+
+/* BT settling time after power on */
+#define BT_POWER_ON_SETTLING_TIME_MS      (500u)
+
+/* Stabilization delay after FW loading */
+#define BT_STABILIZATION_DELAY_MS         (250u)
+
+/* HCI Command packet from Host to Controller */
+#define HCI_COMMAND_PACKET                (0x01)
+
+/* Length of UPDATE BAUD RATE command */
+#define HCI_VSC_UPDATE_BAUD_RATE_LENGTH   (6u)
+
+/* Default BAUDRATE */
+#define HCI_UART_DEFAULT_BAUDRATE         (115200)
+
+/* Externs for CY43xxx controller FW */
+extern const uint8_t brcm_patchram_buf[];
+extern const int brcm_patch_ram_length;
+
+enum {
+	BT_HCI_VND_OP_DOWNLOAD_MINIDRIVER       = 0xFC2E,
+	BT_HCI_VND_OP_WRITE_RAM                 = 0xFC4C,
+	BT_HCI_VND_OP_LAUNCH_RAM                = 0xFC4E,
+	BT_HCI_VND_OP_UPDATE_BAUDRATE           = 0xFC18,
+};
+
+/*  bt_h4_vnd_setup function.
+ * This function executes vendor-specific commands sequence to
+ * initialize BT Controller before BT Host executes Reset sequence.
+ * bt_h4_vnd_setup function must be implemented in vendor-specific HCI
+ * extansion module if CONFIG_BT_HCI_SETUP is enabled.
+ */
+int bt_h4_vnd_setup(const struct device *dev);
+
+static int bt_hci_uart_set_baudrate(const struct device *bt_uart_dev, uint32_t baudrate)
+{
+	struct uart_config uart_cfg;
+	int err;
+
+	/* Get current UART configuration */
+	err = uart_config_get(bt_uart_dev, &uart_cfg);
+	if (err) {
+		return err;
+	}
+
+	if (uart_cfg.baudrate != baudrate) {
+		/* Re-configure UART */
+		uart_cfg.baudrate = baudrate;
+		err = uart_configure(bt_uart_dev, &uart_cfg);
+		if (err) {
+			return err;
+		}
+
+		/* Revert Interrupt options */
+		uart_irq_rx_enable(bt_uart_dev);
+	}
+	return 0;
+}
+
+static int bt_update_controller_baudrate(const struct device *bt_uart_dev, uint32_t baudrate)
+{
+	/*
+	 *  NOTE from datasheet for update baudrate:
+	 *  - To speed up application downloading, the MCU host commands the CYWxxx device
+	 *    to communicate at a new, higher rate by issuing the following Vendor Specific
+	 *    UPDATE_BAUDRATE command:
+	 *      01 18 FC 06 00 00 xx xx xx xx
+	 *    In the above command, the xx xx xx xx bytes specify the 32-bit little-endian
+	 *    value of the new rate in bits per second. For example,
+	 *    115200 is represented as 00 C2 01 00.
+	 *  The following response to the UPDATE_BAUDRATE command is expected within 100 ms:
+	 *  04 0E 04 01 18 FC 00
+	 *  - The host switches to the new baud rate after receiving the response at the old
+	 *  baud rate.
+	 */
+	struct net_buf *buf;
+	int err;
+	uint8_t hci_data[HCI_VSC_UPDATE_BAUD_RATE_LENGTH];
+
+	/* Baudrate is loaded LittleEndian */
+	hci_data[0] = 0;
+	hci_data[1] = 0;
+	hci_data[2] = (uint8_t)(baudrate & 0xFFUL);
+	hci_data[3] = (uint8_t)((baudrate >> 8) & 0xFFUL);
+	hci_data[4] = (uint8_t)((baudrate >> 16) & 0xFFUL);
+	hci_data[5] = (uint8_t)((baudrate >> 24) & 0xFFUL);
+
+	/* Allocate buffer for update uart baudrate command.
+	 * It will be BT_HCI_OP_RESET with extra parameters.
+	 */
+	buf = bt_hci_cmd_create(BT_HCI_VND_OP_UPDATE_BAUDRATE,
+				HCI_VSC_UPDATE_BAUD_RATE_LENGTH);
+	if (buf == NULL) {
+		LOG_ERR("Unable to allocate command buffer");
+		return -ENOMEM;
+	}
+
+	/* Add data part of packet */
+	net_buf_add_mem(buf, &hci_data, HCI_VSC_UPDATE_BAUD_RATE_LENGTH);
+
+	/* Send update uart baudrate command. */
+	err = bt_hci_cmd_send_sync(BT_HCI_VND_OP_UPDATE_BAUDRATE, buf, NULL);
+	if (err) {
+		return err;
+	}
+
+	/* Re-configure Uart baudrate */
+	err = bt_hci_uart_set_baudrate(bt_uart_dev, baudrate);
+	if (err) {
+		return err;
+	}
+
+	return 0;
+}
+
+static int bt_firmware_download(const uint8_t *firmware_image, uint32_t size)
+{
+	uint8_t *data = (uint8_t *)firmware_image;
+	volatile uint32_t remaining_length = size;
+	struct net_buf *buf;
+	int err;
+
+	LOG_DBG("Executing Fw downloading for CYW43xx device");
+
+	/* Send hci_download_minidriver command */
+	err = bt_hci_cmd_send_sync(BT_HCI_VND_OP_DOWNLOAD_MINIDRIVER, NULL, NULL);
+	if (err) {
+		return err;
+	}
+
+	/* The firmware image (.hcd format) contains a collection of hci_write_ram
+	 * command + a block of the image, followed by a hci_write_ram image at the end.
+	 * Parse and send each individual command and wait for the response. This is to
+	 * ensure the integrity of the firmware image sent to the bluetooth chip.
+	 */
+	while (remaining_length) {
+		size_t data_length = data[2]; /* data length from firmware image block */
+		uint16_t op_code = *(uint16_t *)data;
+
+		/* Allocate buffer for hci_write_ram/hci_launch_ram command. */
+		buf = bt_hci_cmd_create(op_code, data_length);
+		if (buf == NULL) {
+			LOG_ERR("Unable to allocate command buffer");
+			return err;
+		}
+
+		/* Add data part of packet */
+		net_buf_add_mem(buf, &data[3], data_length);
+
+		/* Send hci_write_ram command. */
+		err = bt_hci_cmd_send_sync(op_code, buf, NULL);
+		if (err) {
+			return err;
+		}
+
+		switch (op_code) {
+		case BT_HCI_VND_OP_WRITE_RAM:
+			/* Update remaining length and data pointer:
+			 * content of data length + 2 bytes of opcode and 1 byte of data length.
+			 */
+			data += data_length + 3;
+			remaining_length -= data_length + 3;
+			break;
+
+		case BT_HCI_VND_OP_LAUNCH_RAM:
+			remaining_length = 0;
+			break;
+
+		default:
+			return -ENOMEM;
+		}
+	}
+
+	LOG_DBG("Fw downloading complete");
+	return 0;
+}
+
+int bt_h4_vnd_setup(const struct device *dev)
+{
+	int err;
+	uint32_t default_uart_speed = DT_PROP(DT_INST_BUS(0), current_speed);
+	uint32_t hci_operation_speed = DT_INST_PROP_OR(0, hci_operation_speed, default_uart_speed);
+	uint32_t fw_download_speed = DT_INST_PROP_OR(0, fw_download_speed, default_uart_speed);
+
+	/* Check BT Uart instance */
+	if (!device_is_ready(dev)) {
+		return -EINVAL;
+	}
+
+#if DT_INST_NODE_HAS_PROP(0, bt_reg_on_gpios)
+	struct gpio_dt_spec bt_reg_on = GPIO_DT_SPEC_GET(DT_DRV_INST(0), bt_reg_on_gpios);
+
+	/* Check BT REG_ON gpio instance */
+	if (!device_is_ready(bt_reg_on.port)) {
+		LOG_ERR("Error: failed to configure bt_reg_on %s pin %d",
+			bt_reg_on.port->name, bt_reg_on.pin);
+		return -EIO;
+	}
+
+	/* Configure bt_reg_on as output  */
+	err = gpio_pin_configure_dt(&bt_reg_on, GPIO_OUTPUT);
+	if (err) {
+		LOG_ERR("Error %d: failed to configure bt_reg_on %s pin %d",
+			err, bt_reg_on.port->name, bt_reg_on.pin);
+		return err;
+	}
+	err = gpio_pin_set_dt(&bt_reg_on, 1);
+	if (err) {
+		return err;
+	}
+#endif /* DT_INST_NODE_HAS_PROP(0, bt_reg_on_gpios) */
+
+	/* BT settling time after power on */
+	(void)k_msleep(BT_POWER_ON_SETTLING_TIME_MS);
+
+	/* Send HCI_RESET */
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_RESET, NULL, NULL);
+	if (err) {
+		return err;
+	}
+
+	/* Re-configure baudrate for BT Controller */
+	if (fw_download_speed != default_uart_speed) {
+		err = bt_update_controller_baudrate(dev, fw_download_speed);
+		if (err) {
+			return err;
+		}
+	}
+
+	/* BT firmware download */
+	err = bt_firmware_download(brcm_patchram_buf, (uint32_t) brcm_patch_ram_length);
+	if (err) {
+		return err;
+	}
+
+	/* Stabilization delay */
+	(void)k_msleep(BT_STABILIZATION_DELAY_MS);
+
+	/* When FW launched, HCI UART baudrate should be configured to default */
+	if (fw_download_speed != default_uart_speed) {
+		err = bt_hci_uart_set_baudrate(dev, default_uart_speed);
+		if (err) {
+			return err;
+		}
+	}
+
+	/* Send HCI_RESET */
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_RESET, NULL, NULL);
+	if (err) {
+		return err;
+	}
+
+	/* Set host controller functionality to user defined baudrate
+	 * after fw downloading.
+	 */
+	if (hci_operation_speed != default_uart_speed) {
+		err = bt_update_controller_baudrate(dev, hci_operation_speed);
+		if (err) {
+			return err;
+		}
+	}
+
+	return 0;
+}

--- a/dts/bindings/bluetooth/infineon,cyw43xxx-bt-hci.yaml
+++ b/dts/bindings/bluetooth/infineon,cyw43xxx-bt-hci.yaml
@@ -1,0 +1,75 @@
+# Copyright (c) 2023 Cypress Semiconductor Corporation (an Infineon company) or
+# an affiliate of Cypress Semiconductor Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    CYW43xxx Connectivity that uses Zephyr's Bluetooth Host Controller Interface UART
+    driver.
+
+    Example of enabling CYW43xxx device:
+
+      &uart2 {
+        status = "okay";
+        current-speed = <115200>;
+
+        /* HCI-UART pins*/
+        pinctrl-0 = <&p3_1_scb2_uart_tx &p3_0_scb2_uart_rx
+                     &p3_2_scb2_uart_rts &p3_3_scb2_uart_cts>;
+        pinctrl-names = "default";
+
+        bt-hci {
+          status = "okay";
+          compatible = "infineon,cyw43xxx-bt-hci";
+          bt-reg-on-gpios = <&gpio_prt3 4 (GPIO_ACTIVE_HIGH)>;
+
+          fw-download-speed = <3000000>;
+        };
+      };
+
+    NOTE1: The UART bus speed (current_speed) for zephyr_bt_uart should be the same
+           as the default baudrate defined in CYW43xx firmware (default 115200).
+
+    NOTE2: Use fw-download-speed and hci-operation-speed properties to configure UART
+           speeds for firmware download (fw-download-speed) and HCI operation
+           (hci-operation-speed).
+           If hci-operation-speed or fw-download-speed are not defined in bt-hci node,
+           cyw43xx driver will use bus/current-speed as default speed.
+
+    NOTE3: CYW43xxx requires fetch binary files of BT controller. To fetch binary blobs:
+           west blobs fetch hal_infineon
+
+compatible: "infineon,cyw43xxx-bt-hci"
+
+include: base.yaml
+
+properties:
+  bt-reg-on-gpios:
+    description: |
+      Power-up/down gpio to control the internal regulators used
+      by the Bluetooth section of CYW43xx device.
+    type: phandle-array
+
+  bt-dev-wake-gpios:
+    description: |
+      Bluetooth device wake-up gpio. Signal from the host to the
+      CYW43xx indicating that the host requires attention.
+    type: phandle-array
+
+  bt-host-wake-gpios:
+    description: |
+      Host wake-up gpio. Signal from the CYW43xx to the host
+      indicating that the CYW43xx requires attention.
+    type: phandle-array
+
+  hci-operation-speed:
+    type: int
+    description: |
+      HCI UART boudrate for feature operation. If not defined
+      bus/current-speed wil be used as default.
+
+  fw-download-speed:
+    type: int
+    description: |
+      HCI UART boudrate for FW dowload operation. If not defined
+      bus/current-speed wil be used as default.

--- a/modules/hal_infineon/CMakeLists.txt
+++ b/modules/hal_infineon/CMakeLists.txt
@@ -19,8 +19,6 @@ if (CONFIG_SOC_FAMILY_INFINEON_CAT1A OR CONFIG_SOC_FAMILY_PSOC6)
   add_subdirectory(mtb-pdl-cat1)
 endif()
 
-
-
 if (CONFIG_SOC_FAMILY_INFINEON_CAT1A)
   ## Add mtb-hal-cat1 sources for CAT1 devices
   add_subdirectory(mtb-hal-cat1)
@@ -29,5 +27,9 @@ if (CONFIG_SOC_FAMILY_INFINEON_CAT1A)
   if(CONFIG_SOC_PSOC6_CM0P_IMAGE_SLEEP)
     add_subdirectory(cat1cm0p)
   endif()
+endif()
 
+## Add btstack-integration for CYW43xx BT devices
+if (CONFIG_BT_CYW43XXX)
+  add_subdirectory(btstack-integration)
 endif()

--- a/modules/hal_infineon/btstack-integration/CMakeLists.txt
+++ b/modules/hal_infineon/btstack-integration/CMakeLists.txt
@@ -1,0 +1,49 @@
+# Copyright (c) 2022 Cypress Semiconductor Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set(hal_dir            ${ZEPHYR_HAL_INFINEON_MODULE_DIR})
+set(hal_ble_dir        ${hal_dir}/bluetooth-freertos)
+set(hal_blobs_dir      ${hal_dir}/zephyr/blobs/img/bluetooth/firmware)
+set(blob_gen_inc_file  ${ZEPHYR_BINARY_DIR}/include/generated/bt_firmware.hcd.inc)
+
+#########################################################################################
+# BT firmware
+#########################################################################################
+# CYW43012 modules
+if(CONFIG_CYW43012_MURATA_1LV)
+  set(blob_hcd_file  ${hal_blobs_dir}/COMPONENT_43012/COMPONENT_MURATA-1LV/bt_firmware.hcd)
+endif()
+
+# CYW4343W modules
+if(CONFIG_CYW4343W_MURATA_1DX)
+  set(blob_hcd_file  ${hal_blobs_dir}/COMPONENT_4343W/COMPONENT_MURATA-1DX/bt_firmware.hcd)
+endif()
+
+# CYW43439 modules
+if(CONFIG_CYW43439_MURATA_1YN)
+  set(blob_hcd_file  ${hal_blobs_dir}/COMPONENT_43439/COMPONENT_MURATA-1YN/bt_firmware.hcd)
+endif()
+
+# CYW4373 modules
+if(CONFIG_CYW4373_STERLING_LWB5PLUS)
+  set(blob_hcd_file  ${hal_blobs_dir}/COMPONENT_4373/COMPONENT_STERLING-LWB5plus/bt_firmware.hcd)
+endif()
+
+# use user provided FIRMWARE HCD file (path must be defined in CONFIG_CYW43XX_CUSTOM_FIRMWARE_HCD_BLOB)
+if(CONFIG_CYW43XX_CUSTOM_FIRMWARE_HCD_BLOB)
+  # Allowed to pass absolute path to HCD blob file, or relative path from Application folder.
+  if(IS_ABSOLUTE ${CONFIG_CYW43XX_CUSTOM_FIRMWARE_HCD_BLOB})
+    set(blob_hcd_file  ${CONFIG_CYW43XX_CUSTOM_FIRMWARE_HCD_BLOB})
+  else()
+    set(blob_hcd_file  ${APPLICATION_SOURCE_DIR}/${CONFIG_CYW43XX_CUSTOM_FIRMWARE_HCD_BLOB})
+  endif()
+endif()
+
+# generate Bluetooth include blob from HCD binary
+if(EXISTS ${blob_hcd_file})
+  message(INFO " generate include of blob Bluetooth file: ${blob_hcd_file}")
+
+  generate_inc_file_for_target(app ${blob_hcd_file} ${blob_gen_inc_file})
+  zephyr_library_sources(${CMAKE_CURRENT_SOURCE_DIR}/w_bt_firmware_controller.c)
+endif()

--- a/modules/hal_infineon/btstack-integration/w_bt_firmware_controller.c
+++ b/modules/hal_infineon/btstack-integration/w_bt_firmware_controller.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 Cypress Semiconductor Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+
+const uint8_t brcm_patchram_format = 0x01;
+/* Configuration Data Records (Write_RAM) */
+#ifndef FW_DATBLOCK_SEPARATE_FROM_APPLICATION
+const uint8_t brcm_patchram_buf[] = {
+   #include <bt_firmware.hcd.inc>
+};
+
+const int brcm_patch_ram_length = sizeof(brcm_patchram_buf);
+#endif /* FW_DATBLOCK_SEPARATE_FROM_APPLICATION */

--- a/west.yml
+++ b/west.yml
@@ -73,7 +73,7 @@ manifest:
       groups:
         - hal
     - name: hal_infineon
-      revision: 8485083ad91d3e2cc5d706da3464716718a6a42e
+      revision: 15d8a4278611fb2dc6ca52108c36ec1f4caab14e
       path: modules/hal/infineon
       groups:
         - hal


### PR DESCRIPTION
Added initial version of BT driver ( H4 HCI extension) for support Infineon AIROC CYW43xx devices.


dependency: 
- https://github.com/zephyrproject-rtos/zephyr/issues/54936
- https://github.com/zephyrproject-rtos/hal_infineon/pull/7
- https://github.com/zephyrproject-rtos/zephyr/pull/44211

cc: @ifyall 