### PR TITLE
modules: openthread: add `otPlatDiagRadioTransmitCarrier`

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -724,6 +724,23 @@ static int nrf5_stop(const struct device *dev)
 	return 0;
 }
 
+#if defined(CONFIG_NRF_802154_CARRIER_FUNCTIONS)
+static int nrf5_continuous_carrier(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	if (!nrf_802154_continuous_carrier()) {
+		LOG_ERR("Failed to enter continuous carrier state");
+		return -EIO;
+	}
+
+	LOG_DBG("Continuous carrier wave transmission started (channel: %d)",
+		nrf_802154_channel_get());
+
+	return 0;
+}
+#endif
+
 #if !IS_ENABLED(CONFIG_IEEE802154_NRF5_EXT_IRQ_MGMT)
 static void nrf5_radio_irq(const void *arg)
 {
@@ -1169,6 +1186,9 @@ static struct ieee802154_radio_api nrf5_radio_api = {
 	.set_txpower = nrf5_set_txpower,
 	.start = nrf5_start,
 	.stop = nrf5_stop,
+#if defined(CONFIG_NRF_802154_CARRIER_FUNCTIONS)
+	.continuous_carrier = nrf5_continuous_carrier,
+#endif
 	.tx = nrf5_tx,
 	.ed_scan = nrf5_energy_scan_start,
 	.get_time = nrf5_get_time,

--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -340,6 +340,12 @@ struct ieee802154_radio_api {
 	/** Stop the device */
 	int (*stop)(const struct device *dev);
 
+	/** Start continuous carrier wave transmission.
+	 *  To leave this mode, `start()` or `stop()` API function should be called,
+	 *  resulting in changing radio's state to receive or sleep, respectively.
+	 */
+	int (*continuous_carrier)(const struct device *dev);
+
 	/** Set specific radio driver configuration. */
 	int (*configure)(const struct device *dev,
 			 enum ieee802154_config_type type,

--- a/modules/openthread/platform/diag.c
+++ b/modules/openthread/platform/diag.c
@@ -67,6 +67,15 @@ void otPlatDiagRadioReceived(otInstance *aInstance,
 	ARG_UNUSED(aError);
 }
 
+otError otPlatDiagRadioTransmitCarrier(otInstance *aInstance, bool aEnable)
+{
+	if (!otPlatDiagModeGet()) {
+		return OT_ERROR_INVALID_STATE;
+	}
+
+	return platformRadioTransmitCarrier(aInstance, aEnable);
+}
+
 void otPlatDiagAlarmCallback(otInstance *aInstance)
 {
 	ARG_UNUSED(aInstance);

--- a/modules/openthread/platform/openthread-core-zephyr-config.h
+++ b/modules/openthread/platform/openthread-core-zephyr-config.h
@@ -425,4 +425,24 @@
 	CONFIG_OPENTHREAD_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_POWER_CALIBRATION_ENABLE
+ *
+ * In Zephyr, power calibration is handled by Radio Driver, so it can't be handled on OT level.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_POWER_CALIBRATION_ENABLE
+#define OPENTHREAD_CONFIG_POWER_CALIBRATION_ENABLE 0
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_PLATFORM_POWER_CALIBRATION_ENABLE
+ *
+ * In Zephyr, power calibration is handled by Radio Driver, so it can't be handled on OT level.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_PLATFORM_POWER_CALIBRATION_ENABLE
+#define OPENTHREAD_CONFIG_PLATFORM_POWER_CALIBRATION_ENABLE 0
+#endif
+
 #endif  /* OPENTHREAD_CORE_ZEPHYR_CONFIG_H_ */

--- a/modules/openthread/platform/platform-zephyr.h
+++ b/modules/openthread/platform/platform-zephyr.h
@@ -71,6 +71,11 @@ void platformUartPanic(void);
 uint16_t platformRadioChannelGet(otInstance *aInstance);
 
 /**
+ * Start/stop continuous carrier wave transmission.
+ */
+otError platformRadioTransmitCarrier(otInstance *aInstance, bool aEnable);
+
+/**
  * This function initializes the random number service used by OpenThread.
  *
  */

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -631,9 +631,8 @@ otError otPlatRadioSleep(otInstance *aInstance)
 	    sState == OT_RADIO_STATE_RECEIVE ||
 	    sState == OT_RADIO_STATE_TRANSMIT) {
 		error = OT_ERROR_NONE;
-		if (radio_api->stop(radio_dev)) {
-			sState = OT_RADIO_STATE_SLEEP;
-		}
+		radio_api->stop(radio_dev);
+		sState = OT_RADIO_STATE_SLEEP;
 	}
 
 	return error;
@@ -673,6 +672,36 @@ otError otPlatRadioReceiveAt(otInstance *aInstance, uint8_t aChannel,
 	return result ? OT_ERROR_FAILED : OT_ERROR_NONE;
 }
 #endif
+
+otError platformRadioTransmitCarrier(otInstance *aInstance, bool aEnable)
+{
+	if (radio_api->continuous_carrier == NULL) {
+		return OT_ERROR_NOT_IMPLEMENTED;
+	}
+
+	if ((aEnable) && (sState == OT_RADIO_STATE_RECEIVE)) {
+		radio_api->set_txpower(radio_dev, get_transmit_power_for_channel(channel));
+
+		if (radio_api->continuous_carrier(radio_dev) != 0) {
+			return OT_ERROR_FAILED;
+		}
+
+		sState = OT_RADIO_STATE_TRANSMIT;
+	} else if ((!aEnable) && (sState == OT_RADIO_STATE_TRANSMIT)) {
+		return otPlatRadioReceive(aInstance, channel);
+	} else {
+		return OT_ERROR_INVALID_STATE;
+	}
+
+	return OT_ERROR_NONE;
+}
+
+otRadioState otPlatRadioGetState(otInstance *aInstance)
+{
+	ARG_UNUSED(aInstance);
+
+	return sState;
+}
 
 otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aPacket)
 {


### PR DESCRIPTION
implemented `otPlatDiagRadioTransmitCarrier` functionality which lets user start and stop transmitting continuous carrier wave using `ot diag cw start` and `ot diag cw stop` commands.

implemented `otPlatRadioGetState` functionality to enable checking current state using `ot diag radio state` command.

disabled OT power calibration support as in Zephyr it is handled by Radio Driver, so it can't be handled on OT level.