### PR TITLE
Various fixes for LwM2M socket handling

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -968,6 +968,7 @@ static void sm_handle_registration_update_failure(void)
 	k_mutex_lock(&client.mutex, K_FOREVER);
 	LOG_WRN("Registration Update fail -> trigger full registration");
 	client.engine_state = ENGINE_SEND_REGISTRATION;
+	lwm2m_engine_context_close(client.ctx);
 	k_mutex_unlock(&client.mutex);
 }
 

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1013,6 +1013,8 @@ static int sm_do_registration(void)
 			}
 		}
 
+		client.last_update = 0;
+
 		client.ctx->bootstrap_mode = false;
 		ret = sm_select_security_inst(client.ctx->bootstrap_mode,
 					      &client.ctx->sec_obj_inst);


### PR DESCRIPTION
## Clear out the timestamp when we start registration
      
There was a corner case that last registration timestamp was used
to detect if we can try UPDATE instead of full registration.

When timestamp was not cleared and DNS resolving failed, it might
cause engine to skip the resolving and continue retrying an UPDATE
message until timeout.

Fixes #54504

## Drop observations when falling back to registration
      
When we have establised an DTLS handshake and try LwM2M Update,
if the server rejects it, we fall back to sending full registration
but when doing so, we should also clear out any observations.

It was intentional that we don't go to ENGINE_DO_REGISTRATION
state as that would close the socket and cause DTLS handshake.

Fixes #54974

## Don't ignore socket errors when sending
      
Only socket error that we should ignore is EAGAIN (EWOULDBLOCK),
others might be indicating that there are some serious errors
in network layer.
When network stack would block us, just drop the packet and
let CoAP layer handle the retrying.

Related to #54504 but not the root cause.

