### PR TITLE
Bluetooth: controller: correct conditional compile for central FEX

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -959,6 +959,8 @@ static void rp_comm_rx_decode(struct ll_conn *conn, struct proc_ctx *ctx, struct
 		/* ping_req has no data */
 		break;
 #endif /* CONFIG_BT_CTLR_LE_PING */
+#if defined(CONFIG_BT_PERIPHERAL) || \
+	(defined(CONFIG_BT_CTLR_PER_INIT_FEAT_XCHG) && defined(CONFIG_BT_CENTRAL))
 #if defined(CONFIG_BT_PERIPHERAL)
 	case PDU_DATA_LLCTRL_TYPE_FEATURE_REQ:
 #endif /* CONFIG_BT_PERIPHERAL */
@@ -974,6 +976,7 @@ static void rp_comm_rx_decode(struct ll_conn *conn, struct proc_ctx *ctx, struct
 		}
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH && CONFIG_BT_CTLR_PHY */
 		break;
+#endif /* CONFIG_BT_PERIPHERAL || (CONFIG_BT_CTLR_PER_INIT_FEAT_XCHG && CONFIG_BT_CENTRAL) */
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN) && defined(CONFIG_BT_CENTRAL)
 	case PDU_DATA_LLCTRL_TYPE_MIN_USED_CHAN_IND:
 		llcp_pdu_decode_min_used_chans_ind(conn, pdu);


### PR DESCRIPTION
In the switch statement there are two cases guarded by ifdef's. These cases are not compiled in for the following Kconfig settings: BT_PERIPHERAL=n
BT_CTRL_PER_INIT_FEAT_XCHG=n
The following function call then becomes dead code 

This is fixed here by adding the proper guards around the whole case statement

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>
