### PR TITLE
stm32u5 supports the BackuUp sram

### DIFF
--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a.yaml
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a.yaml
@@ -19,4 +19,5 @@ supported:
   - adc
   - watchdog
   - nvs
+  - backup_sram
   - pwm

--- a/boards/arm/b_u585i_iot02a/doc/index.rst
+++ b/boards/arm/b_u585i_iot02a/doc/index.rst
@@ -188,6 +188,8 @@ The Zephyr b_u585i_iot02a board configuration supports the following hardware fe
 +-----------+------------+-------------------------------------+
 | USB       | on-chip    | usb_device                          |
 +-----------+------------+-------------------------------------+
+| BKP SRAM  | on-chip    | Backup SRAM                         |
++-----------+------------+-------------------------------------+
 | PWM       | on-chip    | pwm                                 |
 | die-temp  | on-chip    | die temperature sensor              |
 +-----------+------------+-------------------------------------+
@@ -275,11 +277,19 @@ B_U585I_IOT02A Discovery kit has 4 U(S)ARTs. The Zephyr console output is assign
 Default settings are 115200 8N1.
 
 
+Backup SRAM
+-----------
+
+In order to test backup SRAM you may want to disconnect VBAT from VDD. You can
+do it by removing ``SB6`` jumper on the back side of the board.
+
+
 Programming and Debugging
 *************************
 
 B_U585I_IOT02A Discovery kit includes an ST-LINK/V3 embedded debug tool interface.
 This probe allows to flash the board using various tools.
+
 
 Flashing
 ========

--- a/boards/arm/nucleo_u575zi_q/doc/index.rst
+++ b/boards/arm/nucleo_u575zi_q/doc/index.rst
@@ -167,6 +167,8 @@ The Zephyr nucleo_u575zi_q board configuration supports the following hardware f
 +-----------+------------+-------------------------------------+
 | WATCHDOG  | on-chip    | independent watchdog                |
 +-----------+------------+-------------------------------------+
+| BKP SRAM  | on-chip    | Backup SRAM                         |
++-----------+------------+-------------------------------------+
 | RNG       | on-chip    | True Random number generator        |
 +-----------+------------+-------------------------------------+
 
@@ -223,6 +225,13 @@ Serial Port
 
 Nucleo U575ZI Q board has 6 U(S)ARTs. The Zephyr console output is assigned to
 USART1. Default settings are 115200 8N1.
+
+
+Backup SRAM
+-----------
+
+In order to test backup SRAM you may want to disconnect VBAT from VDD. You can
+do it by removing ``SB50`` jumper on the back side of the board.
 
 
 Programming and Debugging

--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q.yaml
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q.yaml
@@ -17,6 +17,7 @@ supported:
   - spi
   - usart
   - watchdog
+  - backup_sram
   - dma
 ram: 786
 flash: 2048

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -258,6 +258,15 @@
 			status = "disabled";
 		};
 
+		backup_sram: memory@40036400 {
+			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
+			reg = <0x40036400 DT_SIZE_K(2)>;
+			/* BKPSRAMEN and RAMCFGEN clock enable */
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x10020000>;
+			zephyr,memory-region = "BACKUP_SRAM";
+			status = "disabled";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/samples/boards/stm32/backup_sram/boards/b_u585i_iot02a.overlay
+++ b/samples/boards/stm32/backup_sram/boards/b_u585i_iot02a.overlay
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 STMicroelectronics
+ */
+
+&backup_sram{
+	status = "okay";
+};

--- a/samples/boards/stm32/backup_sram/boards/nucleo_u575zi_q.overlay
+++ b/samples/boards/stm32/backup_sram/boards/nucleo_u575zi_q.overlay
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 STMicroelectronics
+ */
+
+&backup_sram{
+	status = "okay";
+};

--- a/samples/boards/stm32/backup_sram/src/main.c
+++ b/samples/boards/stm32/backup_sram/src/main.c
@@ -4,15 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_backup_sram)
+#define BACKUP_DEV_COMPAT st_stm32_backup_sram
+#endif
 
 /** Value stored in backup SRAM. */
 __stm32_backup_sram_section uint32_t backup_value;
 
 void main(void)
 {
-	printk("Current value in backup SRAM: %d\n", backup_value);
+	const struct device *const dev = DEVICE_DT_GET_ONE(BACKUP_DEV_COMPAT);
+
+	if (!device_is_ready(dev)) {
+		printk("ERROR: BackUp SRAM device is not ready\n");
+		return;
+	}
+
+	printk("Current value in backup SRAM (%p): %d\n", &backup_value, backup_value);
 
 	backup_value++;
 #if __DCACHE_PRESENT

--- a/soc/arm/st_stm32/common/Kconfig.soc
+++ b/soc/arm/st_stm32/common/Kconfig.soc
@@ -11,8 +11,7 @@ config STM32_CCM
 
 config STM32_BACKUP_SRAM
 	bool "STM32 Backup SRAM"
-	depends on SOC_SERIES_STM32F2X || SOC_SERIES_STM32F4X || \
-		   SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X
+	depends on DT_HAS_ST_STM32_BACKUP_SRAM_ENABLED
 	help
 	  Enable support for STM32 backup SRAM.
 


### PR DESCRIPTION
Add the support of the BackUp SRAM  to the stm32u5.
Make the  samples/boards/stm32/backup_sram  run on stm32u585 disco or stm32u575 nucleo boards.

Note that there is no reset register from the RCC to the BackUp Ram

FIxes https://github.com/zephyrproject-rtos/zephyr/issues/54934

Signed-off-by: Francois Ramu <francois.ramu@st.com>
