### PR TITLE
CI: twister: set run_date when uploading data

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -292,10 +292,14 @@ jobs:
         name: Upload to opensearch
         run: |
           pip3 install elasticsearch
+          # set run date on upload to get consistent and unified data across the matrix.
+          run_date=`date --iso-8601=minutes`
           if [ "${{github.event_name}}" = "push" ]; then
-            python3 ./scripts/ci/upload_test_results_es.py --index zephyr-main-ci-push-1 artifacts/*/*/twister.json
+            python3 ./scripts/ci/upload_test_results_es.py -r ${run_date} \
+              --index zephyr-main-ci-push-1 artifacts/*/*/twister.json
           elif [ "${{github.event_name}}" = "schedule" ]; then
-            python3 ./scripts/ci/upload_test_results_es.py --index zephyr-main-ci-weekly-1 artifacts/*/*/twister.json
+            python3 ./scripts/ci/upload_test_results_es.py -r ${run_date} \
+              --index zephyr-main-ci-weekly-1 artifacts/*/*/twister.json
           fi
 
       - name: Merge Test Results

--- a/scripts/ci/upload_test_results_es.py
+++ b/scripts/ci/upload_test_results_es.py
@@ -30,7 +30,6 @@ def gendata(f, index, run_date=None):
             t['sub_component'] = sub_group
             yield {
                     "_index": index,
-                    "_id": t['run_id'],
                     "_source": t
                     }
 


### PR DESCRIPTION
- ci: elasticsearch:  set run date when uploading data
- ci: elasticsearch: do not set id for documentats.
- ci: twister: set run_date when uploading data to elasticsearch
