### PR TITLE
Bluetooth_Le_Audio: MICP

### DIFF
--- a/doc/connectivity/bluetooth/bluetooth-audio-arch.rst
+++ b/doc/connectivity/bluetooth/bluetooth-audio-arch.rst
@@ -88,7 +88,7 @@ Rendering and Capture Control
 -----------------------------
 
 Rendering and capture control is implemented by the Volume Control Profile
-(VCP) and Microphone Input Control Profile (MICP).
+(VCP) and Microphone Control Profile (MICP).
 
 The VCP implementation supports the following roles
 
@@ -97,14 +97,14 @@ The VCP implementation supports the following roles
 
 The MICP implementation supports the following roles
 
-* Microphone Input Control Profile (MICP) Microphone Device (server)
-* Microphone Input Control Profile (MICP) Microphone Controller (client)
+* Microphone Control Profile (MICP) Microphone Device (server)
+* Microphone Control Profile (MICP) Microphone Controller (client)
 
 The API reference for volume control can be found in
 :ref:`Bluetooth Volume Control <bluetooth_volume>`.
 
-The API reference for microphone input control can be found in
-:ref:`Bluetooth Microphone Input Control <bluetooth_microphone>`.
+The API reference for Microphone Control can be found in
+:ref:`Bluetooth Microphone Control <bluetooth_microphone>`.
 
 
 Content Control

--- a/include/zephyr/bluetooth/audio/micp.h
+++ b/include/zephyr/bluetooth/audio/micp.h
@@ -8,9 +8,9 @@
 #define ZEPHYR_INCLUDE_BLUETOOTH_MICP_H_
 
 /**
- * @brief Microphone Input Control Profile (MICP)
+ * @brief Microphone Control Profile (MICP)
  *
- * @defgroup bt_gatt_micp Microphone Input Control Profile (MICP)
+ * @defgroup bt_gatt_micp Microphone Control Profile (MICP)
  *
  * @ingroup bluetooth
  * @{
@@ -36,7 +36,7 @@ extern "C" {
 #define BT_MICP_ERR_MUTE_DISABLED                  0x80
 #define BT_MICP_ERR_VAL_OUT_OF_RANGE               0x81
 
-/** Microphone Input Control Profile mute states */
+/** Microphone Control Profile mute states */
 #define BT_MICP_MUTE_UNMUTED                       0x00
 #define BT_MICP_MUTE_MUTED                         0x01
 #define BT_MICP_MUTE_DISABLED                      0x02
@@ -44,21 +44,21 @@ extern "C" {
 /** @brief Opaque Microphone Controller instance. */
 struct bt_micp_mic_ctlr;
 
-/** @brief Register parameters structure for Microphone Input Control Service */
+/** @brief Register parameters structure for Microphone Control Service */
 struct bt_micp_mic_dev_register_param {
 #if defined(CONFIG_BT_MICP_MIC_DEV_AICS)
 	/** Register parameter structure for Audio Input Control Services */
 	struct bt_aics_register_param aics_param[BT_MICP_MIC_DEV_AICS_CNT];
 #endif /* CONFIG_BT_MICP_MIC_DEV_AICS */
 
-	/** Microphone Input Control Profile callback structure. */
+	/** Microphone Control Profile callback structure. */
 	struct bt_micp_mic_dev_cb *cb;
 };
 
 /**
- * @brief Microphone Input Control Profile included services
+ * @brief Microphone Control Profile included services
  *
- * Used for to represent the Microphone Input Control Profile included service
+ * Used for to represent the Microphone Control Profile included service
  * instances, for either a Microphone Controller or a Microphone Device.
  * The instance pointers either represent local service instances,
  * or remote service instances.
@@ -71,9 +71,9 @@ struct bt_micp_included {
 };
 
 /**
- * @brief Initialize the Microphone Input Control Profile Microphone Device
+ * @brief Initialize the Microphone Control Profile Microphone Device
  *
- * This will enable the Microphone Input Control Service instance and make it
+ * This will enable the Microphone Control Service instance and make it
  * discoverable by Microphone Controllers.
  *
  * @param param Pointer to an initialization structure.
@@ -104,7 +104,7 @@ struct bt_micp_mic_dev_cb {
 	 * or if the value is changed by either the Microphone Device or a
 	 * Microphone Controller.
 	 *
-	 * @param mute     The mute setting of the Microphone Input Control Service.
+	 * @param mute     The mute setting of the Microphone Control Service.
 	 */
 	void (*mute)(uint8_t mute);
 };
@@ -141,7 +141,7 @@ int bt_micp_mic_dev_mute_get(void);
 
 struct bt_micp_mic_ctlr_cb {
 	/**
-	 * @brief Callback function for Microphone Input Control Profile mute.
+	 * @brief Callback function for Microphone Control Profile mute.
 	 *
 	 * Called when the value is read,
 	 * or if the value is changed by either the Microphone Device or a
@@ -150,7 +150,7 @@ struct bt_micp_mic_ctlr_cb {
 	 * @param mic_ctlr Microphone Controller instance pointer.
 	 * @param err      Error value. 0 on success, GATT error or errno on fail.
 	 *                 For notifications, this will always be 0.
-	 * @param mute     The mute setting of the Microphone Input Control Service.
+	 * @param mute     The mute setting of the Microphone Control Service.
 	 */
 	void (*mute)(struct bt_micp_mic_ctlr *mic_ctlr, int err, uint8_t mute);
 
@@ -166,7 +166,7 @@ struct bt_micp_mic_ctlr_cb {
 			 uint8_t aics_count);
 
 	/**
-	 * @brief Callback function for Microphone Input Control Profile mute/unmute.
+	 * @brief Callback function for Microphone Control Profile mute/unmute.
 	 *
 	 * @param mic_ctlr  Microphone Controller instance pointer.
 	 * @param err       Error value. 0 on success, GATT error or errno on fail.
@@ -174,7 +174,7 @@ struct bt_micp_mic_ctlr_cb {
 	void (*mute_written)(struct bt_micp_mic_ctlr *mic_ctlr, int err);
 
 	/**
-	 * @brief Callback function for Microphone Input Control Profile mute/unmute.
+	 * @brief Callback function for Microphone Control Profile mute/unmute.
 	 *
 	 * @param mic_ctlr  Microphone Controller instance pointer.
 	 * @param err       Error value. 0 on success, GATT error or errno on fail.
@@ -188,10 +188,10 @@ struct bt_micp_mic_ctlr_cb {
 };
 
 /**
- * @brief Get Microphone Input Control Profile included services
+ * @brief Get Microphone Control Profile included services
  *
  * Returns a pointer to a struct that contains information about the
- * Microphone Input Control Profile included services instances, such as
+ * Microphone Control Profile included services instances, such as
  * pointers to the Audio Input Control Service instances.
  *
  * Requires that @kconfig{CONFIG_BT_MICP_MIC_CTLR_AICS} is enabled.
@@ -218,7 +218,7 @@ int bt_micp_mic_ctlr_conn_get(const struct bt_micp_mic_ctlr *mic_ctlr,
 			      struct bt_conn **conn);
 
 /**
- * @brief Discover Microphone Input Control Service
+ * @brief Discover Microphone Control Service
  *
  * This will start a GATT discovery and setup handles and subscriptions.
  * This shall be called once before any other actions can be executed for the

--- a/include/zephyr/bluetooth/uuid.h
+++ b/include/zephyr/bluetooth/uuid.h
@@ -4687,11 +4687,11 @@ struct bt_uuid_128 {
 #define BT_UUID_TBS_FRIENDLY_NAME \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_FRIENDLY_NAME_VAL)
 /**
- *  @brief Microphone Input Control Service Mute value
+ *  @brief Microphone Control Service Mute value
  */
 #define BT_UUID_MICS_MUTE_VAL 0x2bc3
 /**
- *  @brief Microphone Input Control Service Mute
+ *  @brief Microphone Control Service Mute
  */
 #define BT_UUID_MICS_MUTE \
 	BT_UUID_DECLARE_16(BT_UUID_MICS_MUTE_VAL)

--- a/samples/bluetooth/hap_ha/src/micp_mic_dev.c
+++ b/samples/bluetooth/hap_ha/src/micp_mic_dev.c
@@ -1,5 +1,5 @@
 /** @file
- *  @brief Bluetooth Microphone Input Control Profile (MICP) Microphone Device role.
+ *  @brief Bluetooth Microphone Control Profile (MICP) Microphone Device role.
  *
  *  Copyright (c) 2020 Bose Corporation
  *  Copyright (c) 2020-2022 Nordic Semiconductor ASA

--- a/subsys/bluetooth/audio/Kconfig.micp
+++ b/subsys/bluetooth/audio/Kconfig.micp
@@ -1,4 +1,4 @@
-# Bluetooth Audio - Microphone Input Control Service options
+# Bluetooth Audio - Microphone Control Service options
 #
 # Copyright (c) 2020 Bose Corporation
 # Copyright (c) 2020-2022 Nordic Semiconductor ASA
@@ -6,58 +6,58 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-########### Microphone Input Control Profile Microphone Device ###########
+########### Microphone Control Profile Microphone Device ###########
 
 config BT_MICP_MIC_DEV
-	bool "Microphone Input Control Profile Microphone Device Support [EXPERIMENTAL]"
+	bool "Microphone Control Profile Microphone Device Support [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
-	  This option enables support for Microphone Input Control Profile
+	  This option enables support for Microphone Control Profile
 	  Microphone Device.
 
 if BT_MICP_MIC_DEV
 
 config BT_MICP_MIC_DEV_AICS_INSTANCE_COUNT
 	int "Audio Input Control Service instance count for \
-	     Microphone Input Control Service Microphone Device"
+	     Microphone Control Service Microphone Device"
 	default 0
 	range 0 BT_AICS_MAX_INSTANCE_COUNT
 	help
 	  This option sets the number of instances of Audio Input Control
-	  Services for Microphone Input Control Profile Microphone Device.
+	  Services for Microphone Control Profile Microphone Device.
 
 config BT_MICP_MIC_DEV_AICS
 	bool # Hidden
 	default y if BT_MICP_MIC_DEV_AICS_INSTANCE_COUNT > 0
 	help
 	  This hidden option makes it possible to easily check if AICS is
-	  enabled for Microphone Input Control Profile Microphone Device.
+	  enabled for Microphone Control Profile Microphone Device.
 
 ############# DEBUG #############
 
 config BT_DEBUG_MICP_MIC_DEV
-	bool "Microphone Input Control Profile Microphone Device debug"
+	bool "Microphone Control Profile Microphone Device debug"
 	select DEPRECATED
 	help
-	  Use this option to enable Microphone Input Control Profile
+	  Use this option to enable Microphone Control Profile
 	  Microphone Device debug logs for the Bluetooth Audio functionality.
 
 module = BT_MICP_MIC_DEV
 legacy-debug-sym = BT_DEBUG_MICP_MIC_DEV
-module-str = "Microphone Input Control Profile Microphone Device"
+module-str = "Microphone Control Profile Microphone Device"
 source "subsys/bluetooth/common/Kconfig.template.log_config_bt"
 
 endif # BT_MICP_MIC_DEV
 
-########### Microphone Input Control Profile Microphone Controller ###########
+########### Microphone Control Profile Microphone Controller ###########
 
 config BT_MICP_MIC_CTLR
-	bool "Microphone Input Control Profile Microphone Controller Support [EXPERIMENTAL]"
+	bool "Microphone Control Profile Microphone Controller Support [EXPERIMENTAL]"
 	select BT_GATT_CLIENT
 	select BT_GATT_AUTO_DISCOVER_CCC
 	select EXPERIMENTAL
 	help
-	  This option enables support for the Microphone Input Control Profile
+	  This option enables support for the Microphone Control Profile
 	  Microphone Controller role
 
 if BT_MICP_MIC_CTLR
@@ -80,15 +80,15 @@ config BT_MICP_MIC_CTLR_AICS
 ############# DEBUG #############
 
 config BT_DEBUG_MICP_MIC_CTLR
-	bool "Microphone Input Control Profile Microphone Controller debug"
+	bool "Microphone Control Profile Microphone Controller debug"
 	select DEPRECATED
 	help
-	  Use this option to enable Microphone Input Control Profile Microphone
+	  Use this option to enable Microphone Control Profile Microphone
 	  Controller debug logs for the Bluetooth Audio functionality.
 
 module = BT_MICP_MIC_CTLR
 legacy-debug-sym = BT_DEBUG_MICP_MIC_CTLR
-module-str = "Microphone Input Control Profile Microphone Controller"
+module-str = "Microphone Control Profile Microphone Controller"
 source "subsys/bluetooth/common/Kconfig.template.log_config_bt"
 
 endif # BT_MICP_MIC_CTLR

--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -1,4 +1,4 @@
-/*  Bluetooth MICP - Microphone Input Control Profile - Microphone Controller */
+/*  Bluetooth MICP - Microphone Control Profile - Microphone Controller */
 
 /*
  * Copyright (c) 2020 Bose Corporation


### PR DESCRIPTION
Renamed Microphone Input Control to Microphone Control. Release notes kept unchanged.
Fixes #47858