### PR TITLE
net: icmpv6: Initialize dns sockaddr in RA RDNSS

### DIFF
--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -2334,7 +2334,9 @@ static inline bool handle_ra_rdnss(struct net_pkt *pkt, uint8_t len)
 	NET_PKT_DATA_ACCESS_DEFINE(rdnss_access, struct net_icmpv6_nd_opt_rdnss);
 	struct net_icmpv6_nd_opt_rdnss *rdnss;
 	struct dns_resolve_context *ctx;
-	struct sockaddr_in6 dns;
+	struct sockaddr_in6 dns = {
+		.sin6_family = AF_INET6
+	};
 	const struct sockaddr *dns_servers[] = {
 		(struct sockaddr *)&dns, NULL
 	};
@@ -2374,7 +2376,6 @@ static inline bool handle_ra_rdnss(struct net_pkt *pkt, uint8_t len)
 
 	/* TODO: Handle lifetime. */
 	ctx = dns_resolve_get_default();
-	dns.sin6_family = AF_INET6;
 	ret = dns_resolve_reconfigure(ctx, NULL, dns_servers);
 	if (ret < 0) {
 		NET_DBG("Failed to set RDNSS resolve address: %d", ret);

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -704,6 +704,7 @@ static void ra_message(void)
 	struct in6_addr route_prefix = { { { 0x20, 0x01, 0x0d, 0xb0, 0x0f, 0xff } } };
 	struct sockaddr_in6 dns_addr = {
 		.sin6_family = AF_INET6,
+		.sin6_port = htons(53),
 		.sin6_addr = { { {  0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
 				    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 } } },
 	};
@@ -740,8 +741,10 @@ static void ra_message(void)
 	zassert_equal(ctx->state, DNS_RESOLVE_CONTEXT_ACTIVE);
 	dns_server = (struct sockaddr_in6 *)&ctx->servers[0].dns_server;
 	zassert_equal(dns_server->sin6_family, dns_addr.sin6_family);
+	zassert_equal(dns_server->sin6_port, dns_addr.sin6_port);
 	zassert_mem_equal(&dns_server->sin6_addr, &dns_addr.sin6_addr,
 			  sizeof(dns_addr.sin6_addr), "Wrong DNS address set");
+	zassert_equal(dns_server->sin6_scope_id, dns_addr.sin6_scope_id);
 }
 
 ZTEST(net_ipv6, test_rs_ra_message)


### PR DESCRIPTION
Initialize struct sockaddr_in6 in RDNSS handling to avoid uninitialized sin6_port or sin6_scope_id.