### PR TITLE
arch: x86: Fix STI usage

### DIFF
--- a/arch/x86/core/ia32/excstub.S
+++ b/arch/x86/core/ia32/excstub.S
@@ -164,6 +164,7 @@ SECTION_FUNC(PINNED_TEXT, _exception_enter)
 	testl	$0x200, __z_arch_esf_t_eflags_OFFSET(%esp)
 	je	allDone
 	sti
+	nop
 
 allDone:
 	pushl	%esp			/* push z_arch_esf_t * parameter */

--- a/arch/x86/core/ia32/intstub.S
+++ b/arch/x86/core/ia32/intstub.S
@@ -165,6 +165,7 @@ alreadyOnIntStack:
 
 #ifdef CONFIG_NESTED_INTERRUPTS
 	sti			/* re-enable interrupts */
+	nop
 #endif
 	/* Now call the interrupt handler */
 	call	*%edx
@@ -371,6 +372,7 @@ SECTION_FUNC(PINNED_TEXT, z_SpuriousIntHandler)
 
 	/* re-enable interrupts */
 	sti
+	nop
 
 	/* call the fatal error handler */
 	call	z_x86_spurious_irq

--- a/arch/x86/core/ia32/userspace.S
+++ b/arch/x86/core/ia32/userspace.S
@@ -183,6 +183,7 @@ SECTION_FUNC(TEXT, z_x86_syscall_entry_stub)
 #endif /* CONFIG_X86_KPTI */
 
 	sti			/* re-enable interrupts */
+	nop
 	cld			/* clear direction flag, restored on 'iret' */
 
 	/* call_id is in ESI. bounds-check it, must be less than

--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -557,6 +557,7 @@ except: /*
 
 	/* We're done, it's safe to re-enable interrupts. */
 	sti
+	nop
 #endif /* CONFIG_X86_KPTI */
 #endif /* CONFIG_USERSPACE */
 
@@ -724,6 +725,7 @@ irq:
 	cmpl $CONFIG_ISR_DEPTH, ___cpu_t_nested_OFFSET(%rsi)
 	jz 1f
 	sti
+	nop
 1:	cmpl $1, ___cpu_t_nested_OFFSET(%rsi)
 	je irq_enter_unnested
 

--- a/arch/x86/core/intel64/userspace.S
+++ b/arch/x86/core/intel64/userspace.S
@@ -108,6 +108,8 @@ z_x86_syscall_entry_stub:
 
 	sti			/* re-enable interrupts */
 
+	nop
+
 	/* call_id is in RAX. bounds-check it, must be less than
 	 * K_SYSCALL_LIMIT.
 	 */

--- a/include/zephyr/arch/x86/arch.h
+++ b/include/zephyr/arch/x86/arch.h
@@ -46,7 +46,7 @@ typedef struct x86_msi_vector arch_msi_vector_t;
 static ALWAYS_INLINE void arch_irq_unlock(unsigned int key)
 {
 	if ((key & 0x00000200U) != 0U) { /* 'IF' bit */
-		__asm__ volatile ("sti" ::: "memory");
+		__asm__ volatile ("sti; nop" ::: "memory");
 	}
 }
 

--- a/tests/kernel/interrupt/src/regular_isr.c
+++ b/tests/kernel/interrupt/src/regular_isr.c
@@ -92,21 +92,6 @@ ZTEST(interrupt_feature, test_isr_regular)
 
 	irq_unlock(key);
 
-#ifdef CONFIG_BOARD_QEMU_X86
-	/* QEMU seems to have an issue in that interrupts seem to post on
-	 * the instruction after the 'sti' that is part of irq_unlock().  This
-	 * can cause an issue if the instruction after the 'sti' ends up looking
-	 * at the state that the ISR is suppose to update.  This has been shown
-	 * to happen when building this test for LLVM.
-	 *
-	 * Adding a nop instruction allows QEMU to post the ISR before any state
-	 * gets examined as a workaround.
-	 *
-	 * See GitHub issue zephyrproject-rtos/sdk-ng#629 for the qemu bug.
-	 */
-	arch_nop();
-#endif
-
 	/* interrupt serve after irq unlocked */
 	zassert_true(reg_int_executed[0] == 2 &&
 			reg_int_executed[1] == 2,


### PR DESCRIPTION
We need to have a nop or audit "STI" usage to ensure that they are safe to have interrupts enabled the instruction AFTER the "STI"