### PR TITLE
twister: cleanup: fixed typo preventing runtime cleanup

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -613,7 +613,7 @@ class ProjectBuilder(FilterBuilder):
             mode = message.get("mode")
             if mode == "device":
                 self.cleanup_device_testing_artifacts()
-            elif mode == "pass" or (mode == "all" and self.instance.reason != "Cmake build failure"):
+            elif mode == "passed" or (mode == "all" and self.instance.reason != "Cmake build failure"):
                 self.cleanup_artifacts()
 
     def determine_testcases(self, results):


### PR DESCRIPTION
Fixed runtime cleanup option. A typo in a conditional prevented the
cleanup from happened when a test has passed.

Fixes #54240

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
