### PR TITLE
kernel/atomic_c.c: prevent usage in SMP configs

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -841,6 +841,7 @@ menu "SMP Options"
 config SMP
 	bool "Symmetric multiprocessing support"
 	depends on USE_SWITCH
+	depends on !ATOMIC_OPERATIONS_C
 	help
 	  When true, kernel will be built with SMP support, allowing
 	  more than one CPU to schedule Zephyr tasks at a time.

--- a/kernel/atomic_c.c
+++ b/kernel/atomic_c.c
@@ -84,6 +84,14 @@ bool z_impl_atomic_cas(atomic_t *target, atomic_val_t old_value,
 	k_spinlock_key_t key;
 	int ret = false;
 
+	/*
+	 * On SMP the k_spin_lock() definition calls atomic_cas().
+	 * Using k_spin_lock() here would create an infinite loop and
+	 * massive stack overflow. Consider CONFIG_ATOMIC_OPERATIONS_ARCH
+	 * or CONFIG_ATOMIC_OPERATIONS_BUILTIN instead.
+	 */
+	BUILD_ASSERT(!IS_ENABLED(CONFIG_SMP));
+
 	key = k_spin_lock(&lock);
 
 	if (*target == old_value) {


### PR DESCRIPTION
The C version of atomic_cas() uses k_smp_lock() ... which uses
atomic_cas().

