### PR TITLE
shell: backends: add init log level for dummy shell

### DIFF
--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -405,6 +405,39 @@ config SHELL_BACKEND_DUMMY_BUF_SIZE
 	  This is size of output buffer that will be used by dummy backend, this limits number of
 	  characters that will be captured from command output.
 
+choice
+	prompt "Initial log level limit"
+	default SHELL_DUMMY_INIT_LOG_LEVEL_DEFAULT
+
+config SHELL_DUMMY_INIT_LOG_LEVEL_DEFAULT
+	bool "System limit (LOG_MAX_LEVEL)"
+
+config SHELL_DUMMY_INIT_LOG_LEVEL_DBG
+	bool "Debug"
+
+config SHELL_DUMMY_INIT_LOG_LEVEL_INF
+	bool "Info"
+
+config SHELL_DUMMY_INIT_LOG_LEVEL_WRN
+	bool "Warning"
+
+config SHELL_DUMMY_INIT_LOG_LEVEL_ERR
+	bool "Error"
+
+config SHELL_DUMMY_INIT_LOG_LEVEL_NONE
+	bool "None"
+
+endchoice
+
+config SHELL_DUMMY_INIT_LOG_LEVEL
+	int
+	default 0 if SHELL_DUMMY_INIT_LOG_LEVEL_NONE
+	default 1 if SHELL_DUMMY_INIT_LOG_LEVEL_ERR
+	default 2 if SHELL_DUMMY_INIT_LOG_LEVEL_WRN
+	default 3 if SHELL_DUMMY_INIT_LOG_LEVEL_INF
+	default 4 if SHELL_DUMMY_INIT_LOG_LEVEL_DBG
+	default 5 if SHELL_DUMMY_INIT_LOG_LEVEL_DEFAULT
+
 endif # SHELL_BACKEND_DUMMY
 
 endif # SHELL_BACKENDS

--- a/subsys/shell/backends/shell_dummy.c
+++ b/subsys/shell/backends/shell_dummy.c
@@ -101,9 +101,14 @@ const struct shell_transport_api shell_dummy_transport_api = {
 static int enable_shell_dummy(const struct device *arg)
 {
 	ARG_UNUSED(arg);
+	bool log_backend = CONFIG_SHELL_DUMMY_INIT_LOG_LEVEL > 0;
+	uint32_t level = (CONFIG_SHELL_DUMMY_INIT_LOG_LEVEL > LOG_LEVEL_DBG) ?
+		      CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_DUMMY_INIT_LOG_LEVEL;
 	static const struct shell_backend_config_flags cfg_flags =
 					SHELL_DEFAULT_BACKEND_CONFIG_FLAGS;
-	shell_init(&shell_dummy, NULL, cfg_flags, true, LOG_LEVEL_INF);
+
+	shell_init(&shell_dummy, NULL, cfg_flags, log_backend, level);
+
 	return 0;
 }
 SYS_INIT(enable_shell_dummy, POST_KERNEL, 0);


### PR DESCRIPTION
Dummy shell was always started with log backend enabled with filter statically set to INFO level.
AFAIK no use of such log backend can be made, thus causing waste of resources.
The new changes keep INFO as the default filter level. In order to disable log backend to be attached to the Dummy shell, CONFIG_SHELL_DUMMY_INIT_LOG_LEVEL_NONE has to be set.