### PR TITLE
Bluetooth: HCI: Make driver stack sizes configurable

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -134,3 +134,18 @@ config BT_HCI_SETUP
 	  The user should generally avoid changing it via menuconfig or in
 	  configuration files. This option are enabled by the vendor-specific
 	  HCI extension, where the Setup function is implemented.
+
+config BT_DRV_TX_STACK_SIZE
+	int
+	default 256
+	help
+	  Stack size for the HCI driver's TX thread.
+
+config BT_DRV_RX_STACK_SIZE
+	int
+	default 512 if BT_SPI
+	default BT_RX_STACK_SIZE if (BT_H4 || BT_HCI_RAW_H4)
+	default BT_STM32_IPM_RX_STACK_SIZE if BT_STM32_IPM
+	default 256
+	help
+	  Stack size for the HCI driver's RX thread.

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -37,7 +37,7 @@ LOG_MODULE_REGISTER(bt_driver);
 #define H4_EVT  0x04
 #define H4_ISO  0x05
 
-static K_KERNEL_STACK_DEFINE(rx_thread_stack, CONFIG_BT_RX_STACK_SIZE);
+static K_KERNEL_STACK_DEFINE(rx_thread_stack, CONFIG_BT_DRV_RX_STACK_SIZE);
 static struct k_thread rx_thread_data;
 
 static struct {

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -29,8 +29,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_driver);
 
-static K_KERNEL_STACK_DEFINE(tx_stack, 256);
-static K_KERNEL_STACK_DEFINE(rx_stack, 256);
+static K_KERNEL_STACK_DEFINE(tx_stack, CONFIG_BT_DRV_TX_STACK_SIZE);
+static K_KERNEL_STACK_DEFINE(rx_stack, CONFIG_BT_DRV_RX_STACK_SIZE);
 
 static struct k_thread tx_thread_data;
 static struct k_thread rx_thread_data;

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -80,7 +80,7 @@ static bt_addr_t bd_addr_udn;
 
 /* Rx thread definitions */
 K_FIFO_DEFINE(ipm_rx_events_fifo);
-static K_KERNEL_STACK_DEFINE(ipm_rx_stack, CONFIG_BT_STM32_IPM_RX_STACK_SIZE);
+static K_KERNEL_STACK_DEFINE(ipm_rx_stack, CONFIG_BT_DRV_RX_STACK_SIZE);
 static struct k_thread ipm_rx_thread_data;
 
 static bool c2_started_flag;

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -68,7 +68,7 @@ static K_SEM_DEFINE(sem_initialised, 0, 1);
 static K_SEM_DEFINE(sem_request, 0, 1);
 static K_SEM_DEFINE(sem_busy, 1, 1);
 
-static K_KERNEL_STACK_DEFINE(spi_rx_stack, 512);
+static K_KERNEL_STACK_DEFINE(spi_rx_stack, CONFIG_BT_DRV_RX_STACK_SIZE);
 static struct k_thread spi_rx_thread_data;
 
 #if defined(CONFIG_BT_HCI_DRIVER_LOG_LEVEL_DBG)


### PR DESCRIPTION
Adding them as hidden kconfig options to avoid the stuck kconfig syndrome. Users are free to redefine them in their app to force a value.

Fixes #52105 