### PR TITLE
Revert "Samples: Philosophers: Revert stack size change"

### DIFF
--- a/samples/philosophers/src/main.c
+++ b/samples/philosophers/src/main.c
@@ -83,7 +83,7 @@
 /* end - control behaviour of the demo */
 /***************************************/
 
-#define STACK_SIZE (1024)
+#define STACK_SIZE (2048)
 
 #include "phil_obj_abstract.h"
 


### PR DESCRIPTION
Reverts 7c00ecbbbfb75bd87c595de65625d319e416be1c.

Changes introduced in that commit break the Dining Philosophers demo
for the following in-tree platforms:
  - actinius_icarus
  - circuitdojo_feather_nrf9160
  - nrf5340_audio_dk_nrf5340_cpuapp
  - nrf5340dk_nrf5340_cpuapp

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55040.

Signed-off-by: Saku Rautio <saku.rautio@nordicsemi.no>