### PR TITLE
subsys: lorawan: add devicetime request support

### DIFF
--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -86,6 +86,13 @@ enum lorawan_message_type {
 };
 
 /**
+ * @brief  LoRaWAN downlink flags.
+ */
+enum lorawan_dl_flags {
+	LORAWAN_DATA_PENDING = BIT(0),
+};
+
+/**
  * @brief LoRaWAN join parameters for over-the-Air activation (OTAA)
  *
  * Note that all of the fields use LoRaWAN 1.1 terminology.
@@ -161,13 +168,13 @@ struct lorawan_downlink_cb {
 	 *       and should therefore be as short as possible.
 	 *
 	 * @param port Port message was sent on
-	 * @param data_pending Network server has more downlink packets pending
+	 * @param flags Downlink data flags (see @ref lorawan_dl_flags)
 	 * @param rssi Received signal strength in dBm
 	 * @param snr Signal to Noise ratio in dBm
 	 * @param len Length of data received, will be 0 for ACKs
 	 * @param data Data received, will be NULL for ACKs
 	 */
-	void (*cb)(uint8_t port, bool data_pending,
+	void (*cb)(uint8_t port, uint8_t flags,
 		   int16_t rssi, int8_t snr,
 		   uint8_t len, const uint8_t *data);
 	/** Node for callback list */

--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -90,6 +90,7 @@ enum lorawan_message_type {
  */
 enum lorawan_dl_flags {
 	LORAWAN_DATA_PENDING = BIT(0),
+	LORAWAN_TIME_UPDATED = BIT(1),
 };
 
 /**
@@ -336,6 +337,29 @@ void lorawan_get_payload_sizes(uint8_t *max_next_payload_size,
  * @return 0 if successful, negative errno otherwise
  */
 int lorawan_set_region(enum lorawan_region region);
+
+/**
+ * @brief Request for time according to DeviceTimeReq MAC cmd
+ *
+ * Append MAC DevTimeReq command. It will be processed on next send
+ * message or force sending empty message to request time immediately.
+ *
+ * @param force_request Immediately send an empty message to execute the request
+ * @return 0 if successful, negative errno otherwise
+ */
+int lorawan_request_device_time(bool force_request);
+
+/**
+ * @brief Retrieve the current time from LoRaWAN stack updated by
+ * DeviceTimeAns on MAC layer.
+ *
+ * The epoch starts at 1970-01-01T00:00:00Z.
+ *
+ * @param epoch_time Synchronized time in epoch format truncated to 32-bit.
+ *
+ * @return 0 if successful, -EAGAIN if the time is not yet updated.
+ */
+int lorawan_device_time_get(uint32_t *epoch_time);
 
 #ifdef CONFIG_LORAWAN_APP_CLOCK_SYNC
 

--- a/samples/subsys/lorawan/class_a/src/main.c
+++ b/samples/subsys/lorawan/class_a/src/main.c
@@ -27,11 +27,12 @@ LOG_MODULE_REGISTER(lorawan_class_a);
 
 char data[] = {'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd'};
 
-static void dl_callback(uint8_t port, bool data_pending,
+static void dl_callback(uint8_t port, uint8_t flags,
 			int16_t rssi, int8_t snr,
 			uint8_t len, const uint8_t *hex_data)
 {
-	LOG_INF("Port %d, Pending %d, RSSI %ddB, SNR %ddBm", port, data_pending, rssi, snr);
+	LOG_INF("Port %d, Pending %d, RSSI %ddB, SNR %ddBm",
+			port, flags & LORAWAN_DATA_PENDING, rssi, snr);
 	if (hex_data) {
 		LOG_HEXDUMP_INF(hex_data, len, "Payload: ");
 	}

--- a/samples/subsys/lorawan/class_a/src/main.c
+++ b/samples/subsys/lorawan/class_a/src/main.c
@@ -31,8 +31,9 @@ static void dl_callback(uint8_t port, uint8_t flags,
 			int16_t rssi, int8_t snr,
 			uint8_t len, const uint8_t *hex_data)
 {
-	LOG_INF("Port %d, Pending %d, RSSI %ddB, SNR %ddBm",
-			port, flags & LORAWAN_DATA_PENDING, rssi, snr);
+	LOG_INF("Port %d, Pending %d, RSSI %ddB, SNR %ddBm, Time %d",
+			port, flags & LORAWAN_DATA_PENDING, rssi, snr,
+			!!(flags & LORAWAN_TIME_UPDATED));
 	if (hex_data) {
 		LOG_HEXDUMP_INF(hex_data, len, "Payload: ");
 	}

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -52,14 +52,20 @@ K_SEM_DEFINE(mcps_confirm_sem, 0, 1);
 K_MUTEX_DEFINE(lorawan_join_mutex);
 K_MUTEX_DEFINE(lorawan_send_mutex);
 
+/* lorawan flags: store lorawan states */
+enum {
+	LORAWAN_FLAG_ADR_ENABLE,
+	LORAWAN_FLAG_DEVICETIME_UPDATED_ONCE,
+	LORAWAN_FLAG_COUNT,
+};
+
 /* We store both the default datarate requested through lorawan_set_datarate
  * and the current datarate so that we can use the default datarate for all
  * join requests, even as the current datarate changes due to ADR.
  */
 static enum lorawan_datarate default_datarate;
 static enum lorawan_datarate current_datarate;
-static bool lorawan_adr_enable;
-static bool lorawan_device_time_updated_once;
+static ATOMIC_DEFINE(lorawan_flags, LORAWAN_FLAG_COUNT);
 
 static sys_slist_t dl_callbacks;
 
@@ -126,7 +132,7 @@ static void mcps_confirm_handler(McpsConfirm_t *mcps_confirm)
 	}
 
 	/* Datarate may have changed due to a missed ADRACK */
-	if (lorawan_adr_enable) {
+	if (atomic_test_bit(lorawan_flags, LORAWAN_FLAG_ADR_ENABLE)) {
 		datarate_observe(false);
 	}
 
@@ -148,12 +154,14 @@ static void mcps_indication_handler(McpsIndication_t *mcps_indication)
 	}
 
 	/* Datarate can change as result of ADR command from server */
-	if (lorawan_adr_enable) {
+	if (atomic_test_bit(lorawan_flags, LORAWAN_FLAG_ADR_ENABLE)) {
 		datarate_observe(false);
 	}
+
 	/* Save time has been updated at least once */
-	if (!lorawan_device_time_updated_once && mcps_indication->DeviceTimeAnsReceived) {
-		lorawan_device_time_updated_once = true;
+	if (!atomic_test_bit(lorawan_flags, LORAWAN_FLAG_DEVICETIME_UPDATED_ONCE) &&
+			     mcps_indication->DeviceTimeAnsReceived) {
+		atomic_set_bit(lorawan_flags, LORAWAN_FLAG_DEVICETIME_UPDATED_ONCE);
 	}
 
 	/* IsUplinkTxPending also indicates pending downlinks */
@@ -407,7 +415,7 @@ int lorawan_device_time_get(uint32_t *epoch_time)
 
 	__ASSERT(epoch_time != NULL, "epoch_time parameter is required");
 
-	if (lorawan_device_time_updated_once) {
+	if (atomic_test_bit(lorawan_flags, LORAWAN_FLAG_DEVICETIME_UPDATED_ONCE)) {
 		local_time = SysTimeGet();
 		*epoch_time = local_time.Seconds;
 		return 0;
@@ -474,7 +482,7 @@ out:
 		 * performed when ADR is disabled as it the network servers
 		 * responsibility to increase datarates when ADR is enabled.
 		 */
-		if (!lorawan_adr_enable) {
+		if (!atomic_test_bit(lorawan_flags, LORAWAN_FLAG_ADR_ENABLE)) {
 			MibRequestConfirm_t mib_req2;
 
 			mib_req2.Type = MIB_CHANNELS_DATARATE;
@@ -534,7 +542,7 @@ int lorawan_set_datarate(enum lorawan_datarate dr)
 	MibRequestConfirm_t mib_req;
 
 	/* Bail out if using ADR */
-	if (lorawan_adr_enable) {
+	if (atomic_test_bit(lorawan_flags, LORAWAN_FLAG_ADR_ENABLE)) {
 		return -EINVAL;
 	}
 
@@ -578,11 +586,11 @@ void lorawan_enable_adr(bool enable)
 {
 	MibRequestConfirm_t mib_req;
 
-	if (enable != lorawan_adr_enable) {
-		lorawan_adr_enable = enable;
+	if (enable != atomic_test_bit(lorawan_flags, LORAWAN_FLAG_ADR_ENABLE)) {
+		atomic_set_bit_to(lorawan_flags, LORAWAN_FLAG_ADR_ENABLE, enable);
 
 		mib_req.Type = MIB_ADR;
-		mib_req.Param.AdrEnable = lorawan_adr_enable;
+		mib_req.Param.AdrEnable = atomic_test_bit(lorawan_flags, LORAWAN_FLAG_ADR_ENABLE);
 		LoRaMacMibSetRequestConfirm(&mib_req);
 	}
 }

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -136,6 +136,7 @@ static void mcps_confirm_handler(McpsConfirm_t *mcps_confirm)
 static void mcps_indication_handler(McpsIndication_t *mcps_indication)
 {
 	struct lorawan_downlink_cb *cb;
+	uint8_t flags = 0;
 
 	LOG_DBG("Received McpsIndication %d", mcps_indication->McpsIndication);
 
@@ -150,13 +151,15 @@ static void mcps_indication_handler(McpsIndication_t *mcps_indication)
 		datarate_observe(false);
 	}
 
+	/* IsUplinkTxPending also indicates pending downlinks */
+	flags |= (mcps_indication->IsUplinkTxPending == 1 ? LORAWAN_DATA_PENDING : 0);
+
 	/* Iterate over all registered downlink callbacks */
 	SYS_SLIST_FOR_EACH_CONTAINER(&dl_callbacks, cb, node) {
 		if ((cb->port == LW_RECV_PORT_ANY) ||
 		    (cb->port == mcps_indication->Port)) {
 			cb->cb(mcps_indication->Port,
-			       /* IsUplinkTxPending also indicates pending downlinks */
-			       mcps_indication->IsUplinkTxPending == 1,
+			       flags,
 			       mcps_indication->Rssi, mcps_indication->Snr,
 			       mcps_indication->BufferSize,
 			       mcps_indication->Buffer);

--- a/subsys/lorawan/services/clock_sync.c
+++ b/subsys/lorawan/services/clock_sync.c
@@ -85,7 +85,7 @@ static int clock_sync_serialize_device_time(uint8_t *buf, size_t size)
 	return sizeof(uint32_t);
 }
 
-static void clock_sync_package_callback(uint8_t port, bool data_pending, int16_t rssi, int8_t snr,
+static void clock_sync_package_callback(uint8_t port, uint8_t flags, int16_t rssi, int8_t snr,
 					uint8_t len, const uint8_t *rx_buf)
 {
 	uint8_t tx_buf[3 * MAX_CLOCK_SYNC_ANS_LEN];


### PR DESCRIPTION
Add devicetime request support:
-> Function to request devicetime : optionnally force sending message/optionnally blocking call
-> Function to retrieve current time from loramac-node stack
Fixes #55072