### PR TITLE
drivers: flash: stm32 qspi Enter 4-Byte Address Mode

### DIFF
--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -719,34 +719,21 @@ static int setup_pages_layout(const struct device *dev)
 
 static int qspi_program_addr_4b(const struct device *dev)
 {
-	uint8_t reg;
-	int ret;
-
 	/* Program the flash memory to use 4 bytes addressing */
 	QSPI_CommandTypeDef cmd = {
 		.Instruction = SPI_NOR_CMD_4BA,
 		.InstructionMode = QSPI_INSTRUCTION_1_LINE,
 	};
 
-	ret = qspi_send_cmd(dev, &cmd);
-	if (ret) {
-		return ret;
-	}
-
 	/*
-	 * Read control register to verify if 4byte addressing mode
-	 * is enabled.
+	 * No need to Read control register afterwards to verify if 4byte addressing mode
+	 * is enabled as the effect of the command is immediate
+	 * and the SPI_NOR_CMD_RDCR is vendor-specific :
+	 * SPI_NOR_4BYTE_BIT is BIT 5 for Macronix and 0 for Micron or Windbond
+	 * Moreover bit value meaning is also vendor-specific
 	 */
-	cmd.Instruction = SPI_NOR_CMD_RDCR;
-	cmd.InstructionMode = QSPI_INSTRUCTION_1_LINE;
-	cmd.DataMode = QSPI_DATA_1_LINE;
 
-	ret = qspi_read_access(dev, &cmd, &reg, sizeof(reg));
-	if (!ret && !(reg & SPI_NOR_4BYTE_BIT)) {
-		return -EINVAL;
-	}
-
-	return ret;
+	return qspi_send_cmd(dev, &cmd);
 }
 
 static int qspi_read_status_register(const struct device *dev, uint8_t reg_num, uint8_t *reg)

--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -15,9 +15,6 @@
 #define SPI_NOR_WIP_BIT         BIT(0)  /* Write in progress */
 #define SPI_NOR_WEL_BIT         BIT(1)  /* Write enable latch */
 
-/* Control register bits */
-#define SPI_NOR_4BYTE_BIT       BIT(5)  /* 4B addressing */
-
 /* Flash opcodes */
 #define SPI_NOR_CMD_WRSR        0x01    /* Write status register */
 #define SPI_NOR_CMD_RDSR        0x05    /* Read status register */


### PR DESCRIPTION
No need to read back the CR (NOR flash _config_ or _control_ register) to check if entering the 4-Byte Address Mode is effective.
The action of this command is immediate and the result (bit field of the CR) is NOR flash vendor-specific.
-   SPI_NOR_4BYTE_BIT is BIT 5 of the CR for Macronix
-   SPI_NOR_4BYTE_BIT is BIT 0 of the CR for Micron or Windbond


Moreover bit value meaning is also vendor-specific : 

- Enable 4-byte address mode is =0 for Micron but =1 for Winbond
- Enable 3-byte address mode is =1 for Micron but =0 for Winbond

It is not useful to check on this mix, afterwards.


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55041

Signed-off-by: Francois Ramu <francois.ramu@st.com>