### PR TITLE
boards: stm32f7/stm32h7: Configure external SDRAM region with RAM att…

### DIFF
--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -45,6 +45,7 @@
 		device_type = "memory";
 		reg = <0xc0000000 DT_SIZE_M(16)>;
 		zephyr,memory-region = "SDRAM1";
+		zephyr,memory-region-mpu = "RAM";
 	};
 
 	aliases {

--- a/boards/arm/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/arm/stm32f7508_dk/stm32f7508_dk.dts
@@ -46,6 +46,7 @@
 		device_type = "memory";
 		reg = <0xc0000000 DT_SIZE_M(16)>;
 		zephyr,memory-region = "SDRAM1";
+		zephyr,memory-region-mpu = "RAM";
 	};
 
 	aliases {

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -28,6 +28,7 @@
 		device_type = "memory";
 		reg = <0xc0000000 DT_SIZE_M(16)>;
 		zephyr,memory-region = "SDRAM1";
+		zephyr,memory-region-mpu = "RAM";
 	};
 
 	leds {

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -26,6 +26,7 @@
 		device_type = "memory";
 		reg = <0xd0000000 DT_SIZE_M(32)>;
 		zephyr,memory-region = "SDRAM2";
+		zephyr,memory-region-mpu = "RAM";
 	};
 
 	leds {

--- a/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -49,6 +49,7 @@
 		device_type = "memory";
 		reg = <0xd0000000 DT_SIZE_M(16)>;
 		zephyr,memory-region = "SDRAM2";
+		zephyr,memory-region-mpu = "RAM";
 	};
 
 	transceiver0: can-phy0 {


### PR DESCRIPTION
…ribute

On M7 based STM32 boards, external SDRAM may be present and mapped in the area 0xC0000000-0xDFFFFFFF.
According to ARMv7-M Architecture Reference Manual chapter B3.1 (table B3-1), this area is specified as Device Memory Type, with the consequence that all accesses should be naturally aligned, otherwise a hard fault will be triggered whatever UNALIGN_TRP status in the CCR reg.

To avoid this issue, when available, configure external SDRAM memory regions as a MPU with RAM attribute.

Fixes #54670