### PR TITLE
Refactor STM32L4xx dtsi tree

### DIFF
--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -410,6 +410,17 @@
 			status = "disabled";
 		};
 
+		lptim2: timers@40009400 {
+			compatible = "st,stm32-lptim";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40009400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000020>;
+			interrupts = <66 1>;
+			interrupt-names = "wakeup";
+			status = "disabled";
+		};
+
 		rng: rng@50060800 {
 			compatible = "st,stm32-rng";
 			reg = <0x50060800 0x400>;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -436,7 +436,7 @@
 		ts-cal1-addr = <0x1FFF75A8>;
 		ts-cal2-addr = <0x1FFF75CA>;
 		ts-cal1-temp = <30>;
-		ts-cal2-temp = <110>;
+		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;
 		io-channels = <&adc1 17>;
 		status = "disabled";

--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -68,10 +68,6 @@
 		};
 	};
 
-	die_temp: dietemp {
-		ts-cal2-temp = <130>;
-	};
-
 	usb_fs_phy: usbphy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;

--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -57,6 +57,15 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
 			status = "disabled";
 		};
+
+		usart3: serial@40004800 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00040000>;
+			resets = <&rctl STM32_RESET(APB1L, 18U)>;
+			interrupts = <39 0>;
+			status = "disabled";
+		};
 	};
 
 	die_temp: dietemp {

--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -36,6 +36,18 @@
 			status = "disabled";
 		};
 
+		i2c2: i2c@40005800 {
+			compatible = "st,stm32-i2c-v2";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00400000>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <33 0>, <34 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+		};
+
 		spi2: spi@40003800 {
 			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;

--- a/dts/arm/st/l4/stm32l422.dtsi
+++ b/dts/arm/st/l4/stm32l422.dtsi
@@ -5,3 +5,16 @@
  */
 
 #include <st/l4/stm32l412.dtsi>
+
+/ {
+	soc {
+		aes: aes@50060000 {
+			compatible = "st,stm32-aes";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			interrupts = <79 0>;
+			interrupt-names = "aes";
+			status = "disabled";
+		};
+	};
+};

--- a/dts/arm/st/l4/stm32l431.dtsi
+++ b/dts/arm/st/l4/stm32l431.dtsi
@@ -99,17 +99,6 @@
 			};
 		};
 
-		lptim2: timers@40009400 {
-			compatible = "st,stm32-lptim";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40009400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000020>;
-			interrupts = <66 1>;
-			interrupt-names = "wakeup";
-			status = "disabled";
-		};
-
 		can1: can@40006400 {
 			compatible = "st,stm32-can";
 			reg = <0x40006400 0x400>;

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -90,10 +90,6 @@
 		};
 	};
 
-	die_temp: dietemp {
-		ts-cal2-temp = <130>;
-	};
-
 	usb_fs_phy: usbphy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;

--- a/dts/arm/st/l4/stm32l433.dtsi
+++ b/dts/arm/st/l4/stm32l433.dtsi
@@ -56,5 +56,14 @@
 			interrupts = <39 0>;
 			status = "disabled";
 		};
+
+		sdmmc1: sdmmc@40012800 {
+			compatible = "st,stm32-sdmmc";
+			reg = <0x40012800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000400>,
+				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
+			interrupts = <49 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/l4/stm32l452.dtsi
+++ b/dts/arm/st/l4/stm32l452.dtsi
@@ -166,10 +166,6 @@
 		};
 	};
 
-	die_temp: dietemp {
-		ts-cal2-temp = <130>;
-	};
-
 	usb_fs_phy: usbphy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;

--- a/dts/arm/st/l4/stm32l462.dtsi
+++ b/dts/arm/st/l4/stm32l462.dtsi
@@ -5,3 +5,16 @@
  */
 
 #include <st/l4/stm32l452.dtsi>
+
+/ {
+	soc {
+		aes: aes@50060000 {
+			compatible = "st,stm32-aes";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			interrupts = <79 0>;
+			interrupt-names = "aes";
+			status = "disabled";
+		};
+	};
+};

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -270,4 +270,8 @@
 			};
 		};
 	};
+
+	die_temp: dietemp {
+		ts-cal2-temp = <110>;
+	};
 };

--- a/dts/arm/st/l4/stm32l476.dtsi
+++ b/dts/arm/st/l4/stm32l476.dtsi
@@ -5,16 +5,3 @@
  */
 
 #include <st/l4/stm32l475.dtsi>
-
-/ {
-	soc {
-		adc3: adc@50040200 {
-			compatible = "st,stm32-adc";
-			reg = <0x50040200 0x100>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00002000>;
-			interrupts = <47 0>;
-			status = "disabled";
-		    #io-channel-cells = <1>;
-		};
-	};
-};

--- a/dts/arm/st/l4/stm32l486.dtsi
+++ b/dts/arm/st/l4/stm32l486.dtsi
@@ -5,16 +5,3 @@
  */
 
 #include <st/l4/stm32l476.dtsi>
-
-/ {
-	soc {
-		aes: aes@50060000 {
-			compatible = "st,stm32-aes";
-			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
-			interrupts = <79 0>;
-			interrupt-names = "aes";
-			status = "disabled";
-		};
-	};
-};

--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -46,15 +46,6 @@
 			};
 		};
 
-		adc3: adc@50040200 {
-			compatible = "st,stm32-adc";
-			reg = <0x50040200 0x100>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00002000>;
-			interrupts = <47 0>;
-			status = "disabled";
-			#io-channel-cells = <1>;
-		};
-
 		usbotg_fs: otgfs@50000000 {
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00001000>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;

--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -46,6 +46,17 @@
 			};
 		};
 
+		can2: can@40006800 {
+			compatible = "st,stm32-can";
+			reg = <0x40006800 0x400>;
+			interrupts = <86 0>, <87 0>, <88 0>, <89 0>;
+			interrupt-names = "TX", "RX0", "RX1", "SCE";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x04000000>; //RCC_APB1ENR1_CAN2EN
+			status = "disabled";
+			sjw = <1>;
+			sample-point = <875>;
+		};
+
 		aes: aes@50060000 {
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;

--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -46,6 +46,15 @@
 			};
 		};
 
+		aes: aes@50060000 {
+			compatible = "st,stm32-aes";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			interrupts = <79 0>;
+			interrupt-names = "aes";
+			status = "disabled";
+		};
+
 		usbotg_fs: otgfs@50000000 {
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00001000>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;

--- a/dts/arm/st/l4/stm32l4a6.dtsi
+++ b/dts/arm/st/l4/stm32l4a6.dtsi
@@ -5,16 +5,3 @@
  */
 
 #include <st/l4/stm32l496.dtsi>
-
-/ {
-	soc {
-		aes: aes@50060000 {
-			compatible = "st,stm32-aes";
-			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
-			interrupts = <79 0>;
-			interrupt-names = "aes";
-			status = "disabled";
-		};
-	};
-};

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -283,6 +283,15 @@
 			sample-point = <875>;
 		};
 
+		aes: aes@50060000 {
+			compatible = "st,stm32-aes";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			interrupts = <79 0>;
+			interrupt-names = "aes";
+			status = "disabled";
+		};
+
 		usbotg_fs: otgfs@50000000 {
 			compatible = "st,stm32-otgfs";
 			reg = <0x50000000 0x40000>;

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -41,6 +41,8 @@
 		};
 
 		pinctrl: pin-controller@48000000 {
+			reg = <0x48000000 0x2400>;
+
 			gpiod: gpio@48000c00 {
 				compatible = "st,stm32-gpio";
 				gpio-controller;
@@ -71,6 +73,14 @@
 				#gpio-cells = <2>;
 				reg = <0x48001800 0x400>;
 				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000040>;
+			};
+
+			gpioi: gpio@48002000 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x48002000 0x400>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000100>;
 			};
 		};
 


### PR DESCRIPTION
Light rework of the STM32L4xx dtsi tree.
It adds some missing peripherals, remove an unnecessary duplication, fix a wrong inclusion and fix temperature reading.