### PR TITLE
kernel: More cruft removal--unused arch specific generated symbol offset macros

### DIFF
--- a/arch/arm/core/offsets/offsets_aarch32.c
+++ b/arch/arm/core/offsets/offsets_aarch32.c
@@ -50,34 +50,17 @@ GEN_OFFSET_SYM(_thread_arch_t, sp_usr);
 GEN_OFFSET_SYM(_thread_arch_t, preempt_float);
 #endif
 
-GEN_OFFSET_SYM(_basic_sf_t, a1);
-GEN_OFFSET_SYM(_basic_sf_t, a2);
-GEN_OFFSET_SYM(_basic_sf_t, a3);
-GEN_OFFSET_SYM(_basic_sf_t, a4);
-GEN_OFFSET_SYM(_basic_sf_t, ip);
-GEN_OFFSET_SYM(_basic_sf_t, lr);
 GEN_OFFSET_SYM(_basic_sf_t, pc);
 GEN_OFFSET_SYM(_basic_sf_t, xpsr);
 GEN_ABSOLUTE_SYM(___basic_sf_t_SIZEOF, sizeof(_basic_sf_t));
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-GEN_OFFSET_SYM(_fpu_sf_t, s);
 GEN_OFFSET_SYM(_fpu_sf_t, fpscr);
 
 GEN_ABSOLUTE_SYM(___fpu_t_SIZEOF, sizeof(_fpu_sf_t));
 #endif
 
 GEN_ABSOLUTE_SYM(___esf_t_SIZEOF, sizeof(_esf_t));
-
-GEN_OFFSET_SYM(_callee_saved_t, v1);
-GEN_OFFSET_SYM(_callee_saved_t, v2);
-GEN_OFFSET_SYM(_callee_saved_t, v3);
-GEN_OFFSET_SYM(_callee_saved_t, v4);
-GEN_OFFSET_SYM(_callee_saved_t, v5);
-GEN_OFFSET_SYM(_callee_saved_t, v6);
-GEN_OFFSET_SYM(_callee_saved_t, v7);
-GEN_OFFSET_SYM(_callee_saved_t, v8);
-GEN_OFFSET_SYM(_callee_saved_t, psp);
 
 /* size of the entire preempt registers structure */
 

--- a/arch/arm/include/aarch32/offsets_short_arch.h
+++ b/arch/arm/include/aarch32/offsets_short_arch.h
@@ -20,9 +20,6 @@
 #define _thread_offset_to_basepri \
 	(___thread_t_arch_OFFSET + ___thread_arch_t_basepri_OFFSET)
 
-#define _thread_offset_to_swap_return_value \
-	(___thread_t_arch_OFFSET + ___thread_arch_t_swap_return_value_OFFSET)
-
 #define _thread_offset_to_preempt_float \
 	(___thread_t_arch_OFFSET + ___thread_arch_t_preempt_float_OFFSET)
 

--- a/arch/posix/core/offsets/offsets.c
+++ b/arch/posix/core/offsets/offsets.c
@@ -28,8 +28,4 @@
 #include <gen_offset.h>
 #include <kernel_offsets.h>
 
-#if defined(CONFIG_FPU_SHARING)
-GEN_OFFSET_SYM(_thread_arch_t, excNestCount);
-#endif
-
 GEN_ABS_SYM_END

--- a/arch/posix/include/offsets_short_arch.h
+++ b/arch/posix/include/offsets_short_arch.h
@@ -11,21 +11,9 @@
 
 /* kernel */
 
-#define _kernel_offset_to_isf \
-	(___kernel_t_arch_OFFSET + ___kernel_arch_t_isf_OFFSET)
-
 /* end - kernel */
 
 /* threads */
-
-#define _thread_offset_to_excNestCount \
-	(___thread_t_arch_OFFSET + ___thread_arch_t_excNestCount_OFFSET)
-
-#define _thread_offset_to_esp \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_esp_OFFSET)
-
-#define _thread_offset_to_preempFloatReg \
-	(___thread_t_arch_OFFSET + ___thread_arch_t_preempFloatReg_OFFSET)
 
 /* end - threads */
 

--- a/arch/riscv/include/offsets_short_arch.h
+++ b/arch/riscv/include/offsets_short_arch.h
@@ -15,9 +15,6 @@
 #define _thread_offset_to_ra \
 	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_ra_OFFSET)
 
-#define _thread_offset_to_tp \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_tp_OFFSET)
-
 #define _thread_offset_to_s0 \
 	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s0_OFFSET)
 
@@ -65,12 +62,6 @@
 #endif
 
 #ifdef CONFIG_USERSPACE
-
-#define _thread_offset_to_priv_stack_start \
-	(___thread_t_arch_OFFSET + ___thread_arch_t_priv_stack_start_OFFSET)
-
-#define _thread_offset_to_user_sp \
-	(___thread_t_arch_OFFSET + ___thread_arch_t_user_sp_OFFSET)
 
 #define _curr_cpu_arch_user_exc_sp \
 	(___cpu_t_arch_OFFSET + ___cpu_arch_t_user_exc_sp_OFFSET)

--- a/arch/sparc/core/offsets/offsets.c
+++ b/arch/sparc/core/offsets/offsets.c
@@ -22,31 +22,20 @@ GEN_OFFSET_SYM(_callee_saved_t, psr);
 
 GEN_OFFSET_SYM(_callee_saved_t, l0_and_l1);
 GEN_OFFSET_SYM(_callee_saved_t, l2);
-GEN_OFFSET_SYM(_callee_saved_t, l3);
 GEN_OFFSET_SYM(_callee_saved_t, l4);
-GEN_OFFSET_SYM(_callee_saved_t, l5);
 GEN_OFFSET_SYM(_callee_saved_t, l6);
-GEN_OFFSET_SYM(_callee_saved_t, l7);
 GEN_OFFSET_SYM(_callee_saved_t, i0);
-GEN_OFFSET_SYM(_callee_saved_t, i1);
 GEN_OFFSET_SYM(_callee_saved_t, i2);
-GEN_OFFSET_SYM(_callee_saved_t, i3);
 GEN_OFFSET_SYM(_callee_saved_t, i4);
-GEN_OFFSET_SYM(_callee_saved_t, i5);
 GEN_OFFSET_SYM(_callee_saved_t, i6);
-GEN_OFFSET_SYM(_callee_saved_t, i7);
 GEN_OFFSET_SYM(_callee_saved_t, o6);
-GEN_OFFSET_SYM(_callee_saved_t, o7);
 
 /* esf member offsets */
 GEN_OFFSET_SYM(z_arch_esf_t, out);
 GEN_OFFSET_SYM(z_arch_esf_t, global);
-GEN_OFFSET_SYM(z_arch_esf_t, pc);
 GEN_OFFSET_SYM(z_arch_esf_t, npc);
 GEN_OFFSET_SYM(z_arch_esf_t, psr);
-GEN_OFFSET_SYM(z_arch_esf_t, wim);
 GEN_OFFSET_SYM(z_arch_esf_t, tbr);
-GEN_OFFSET_SYM(z_arch_esf_t, y);
 GEN_ABSOLUTE_SYM(__z_arch_esf_t_SIZEOF, STACK_ROUND_UP(sizeof(z_arch_esf_t)));
 
 /*

--- a/arch/sparc/include/offsets_short_arch.h
+++ b/arch/sparc/include/offsets_short_arch.h
@@ -18,50 +18,26 @@
 #define _thread_offset_to_l2 \
 	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_l2_OFFSET)
 
-#define _thread_offset_to_l3 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_l3_OFFSET)
-
 #define _thread_offset_to_l4 \
 	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_l4_OFFSET)
-
-#define _thread_offset_to_l5 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_l5_OFFSET)
 
 #define _thread_offset_to_l6 \
 	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_l6_OFFSET)
 
-#define _thread_offset_to_l7 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_l7_OFFSET)
-
 #define _thread_offset_to_i0 \
 	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_i0_OFFSET)
-
-#define _thread_offset_to_i1 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_i1_OFFSET)
 
 #define _thread_offset_to_i2 \
 	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_i2_OFFSET)
 
-#define _thread_offset_to_i3 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_i3_OFFSET)
-
 #define _thread_offset_to_i4 \
 	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_i4_OFFSET)
-
-#define _thread_offset_to_i5 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_i5_OFFSET)
 
 #define _thread_offset_to_i6 \
 	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_i6_OFFSET)
 
-#define _thread_offset_to_i7 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_i7_OFFSET)
-
 #define _thread_offset_to_o6 \
 	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_o6_OFFSET)
-
-#define _thread_offset_to_o7 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_o7_OFFSET)
 
 #define _thread_offset_to_psr \
 	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_psr_OFFSET)

--- a/arch/x86/core/offsets/ia32_offsets.c
+++ b/arch/x86/core/offsets/ia32_offsets.c
@@ -54,16 +54,5 @@ GEN_OFFSET_SYM(_callee_saved_t, esp);
 
 /* z_arch_esf_t structure member offsets */
 
-GEN_OFFSET_SYM(z_arch_esf_t, esp);
-GEN_OFFSET_SYM(z_arch_esf_t, ebp);
-GEN_OFFSET_SYM(z_arch_esf_t, ebx);
-GEN_OFFSET_SYM(z_arch_esf_t, esi);
-GEN_OFFSET_SYM(z_arch_esf_t, edi);
-GEN_OFFSET_SYM(z_arch_esf_t, edx);
-GEN_OFFSET_SYM(z_arch_esf_t, ecx);
-GEN_OFFSET_SYM(z_arch_esf_t, eax);
-GEN_OFFSET_SYM(z_arch_esf_t, errorCode);
-GEN_OFFSET_SYM(z_arch_esf_t, eip);
-GEN_OFFSET_SYM(z_arch_esf_t, cs);
 GEN_OFFSET_SYM(z_arch_esf_t, eflags);
 #endif /* _X86_OFFSETS_INC_ */

--- a/arch/x86/core/offsets/intel64_offsets.c
+++ b/arch/x86/core/offsets/intel64_offsets.c
@@ -46,13 +46,10 @@ GEN_OFFSET_SYM(x86_tss64_t, usp);
 #endif /* CONFIG_USERSPACE */
 GEN_ABSOLUTE_SYM(__X86_TSS64_SIZEOF, sizeof(x86_tss64_t));
 
-GEN_OFFSET_SYM(x86_cpuboot_t, ready);
 GEN_OFFSET_SYM(x86_cpuboot_t, tr);
 GEN_OFFSET_SYM(x86_cpuboot_t, gs_base);
 GEN_OFFSET_SYM(x86_cpuboot_t, sp);
 GEN_OFFSET_SYM(x86_cpuboot_t, stack_size);
-GEN_OFFSET_SYM(x86_cpuboot_t, fn);
-GEN_OFFSET_SYM(x86_cpuboot_t, arg);
 GEN_ABSOLUTE_SYM(__X86_CPUBOOT_SIZEOF, sizeof(x86_cpuboot_t));
 
 #endif /* _X86_OFFSETS_INC_ */


### PR DESCRIPTION
More cruft removal.

Similar in vein to a previous set of commits that removed unused generated symbol offset macros from the kernel, this set of commits removes the unused symbols at the arch level.