### PR TITLE
Implement i.MX8 UART clock gating

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm.c
+++ b/drivers/clock_control/clock_control_mcux_ccm.c
@@ -30,6 +30,13 @@ static const clock_root_control_t uart_clk_root[] = {
 	kCLOCK_RootUart3,
 	kCLOCK_RootUart4,
 };
+
+static const clock_ip_name_t uart_clocks[] = {
+	kCLOCK_Uart1,
+	kCLOCK_Uart2,
+	kCLOCK_Uart3,
+	kCLOCK_Uart4,
+};
 #endif
 #if defined(CONFIG_UART_MCUX_LPUART) && defined(CONFIG_SOC_MIMX93_A55)
 static const clock_root_t lpuart_clk_root[] = {
@@ -47,13 +54,43 @@ static const clock_root_t lpuart_clk_root[] = {
 static int mcux_ccm_on(const struct device *dev,
 			      clock_control_subsys_t sub_system)
 {
-	return 0;
+	uint32_t clock_name = (uintptr_t)sub_system;
+	uint32_t instance = clock_name & IMX_CCM_INSTANCE_MASK;
+
+	switch (clock_name) {
+#ifdef CONFIG_UART_MCUX_IUART
+	case IMX_CCM_UART1_CLK:
+	case IMX_CCM_UART2_CLK:
+	case IMX_CCM_UART3_CLK:
+	case IMX_CCM_UART4_CLK:
+		CLOCK_EnableClock(uart_clocks[instance]);
+		return 0;
+#endif
+	default:
+		(void)instance;
+		return 0;
+	}
 }
 
 static int mcux_ccm_off(const struct device *dev,
 			       clock_control_subsys_t sub_system)
 {
-	return 0;
+	uint32_t clock_name = (uintptr_t)sub_system;
+	uint32_t instance = clock_name & IMX_CCM_INSTANCE_MASK;
+
+	switch (clock_name) {
+#ifdef CONFIG_UART_MCUX_IUART
+	case IMX_CCM_UART1_CLK:
+	case IMX_CCM_UART2_CLK:
+	case IMX_CCM_UART3_CLK:
+	case IMX_CCM_UART4_CLK:
+		CLOCK_DisableClock(uart_clocks[instance]);
+		return 0;
+#endif
+	default:
+		(void)instance;
+		return 0;
+	}
 }
 
 static int mcux_ccm_get_subsys_rate(const struct device *dev,

--- a/drivers/clock_control/clock_control_mcux_ccm.c
+++ b/drivers/clock_control/clock_control_mcux_ccm.c
@@ -60,12 +60,7 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 				    clock_control_subsys_t sub_system,
 				    uint32_t *rate)
 {
-#ifdef CONFIG_ARM64
-	uint32_t clock_name = (uint32_t)(uint64_t) sub_system;
-#else
-	uint32_t clock_name = (uint32_t) sub_system;
-#endif
-	uint32_t mux __unused;
+	uint32_t clock_name = (uintptr_t)sub_system;
 
 	switch (clock_name) {
 

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -241,10 +241,12 @@ static int mcux_iuart_init(const struct device *dev)
 	uart_config.enableRx = true;
 	uart_config.baudRate_Bps = config->baud_rate;
 
+	clock_control_on(config->clock_dev, config->clock_subsys);
 	UART_Init(config->base, &uart_config, clock_freq);
 
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err) {
+		clock_control_off(config->clock_dev, config->clock_subsys);
 		return err;
 	}
 

--- a/soc/arm/nxp_imx/mimx8ml8_m7/soc.c
+++ b/soc/arm/nxp_imx/mimx8ml8_m7/soc.c
@@ -106,11 +106,31 @@ static void SOC_ClockInit(void)
 	/* switch AHB to SYSTEM PLL1 DIV6 */
 	CLOCK_SetRootMux(kCLOCK_RootAhb, kCLOCK_AhbRootmuxSysPll1Div6);
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart4), okay) && CONFIG_UART_MCUX_IUART
+#if defined(CONFIG_UART_MCUX_IUART)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart1), okay)
+	/* Set UART source to SysPLL1 Div10 80MHZ */
+	CLOCK_SetRootMux(kCLOCK_RootUart1, kCLOCK_UartRootmuxSysPll1Div10);
+	/* Set root clock to 80MHZ/ 1= 80MHZ */
+	CLOCK_SetRootDivider(kCLOCK_RootUart1, 1U, 1U);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart2), okay)
+	/* Set UART source to SysPLL1 Div10 80MHZ */
+	CLOCK_SetRootMux(kCLOCK_RootUart2, kCLOCK_UartRootmuxSysPll1Div10);
+	/* Set root clock to 80MHZ/ 1= 80MHZ */
+	CLOCK_SetRootDivider(kCLOCK_RootUart2, 1U, 1U);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart3), okay)
+	/* Set UART source to SysPLL1 Div10 80MHZ */
+	CLOCK_SetRootMux(kCLOCK_RootUart3, kCLOCK_UartRootmuxSysPll1Div10);
+	/* Set root clock to 80MHZ/ 1= 80MHZ */
+	CLOCK_SetRootDivider(kCLOCK_RootUart3, 1U, 1U);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart4), okay)
 	/* Set UART source to SysPLL1 Div10 80MHZ */
 	CLOCK_SetRootMux(kCLOCK_RootUart4, kCLOCK_UartRootmuxSysPll1Div10);
 	/* Set root clock to 80MHZ/ 1= 80MHZ */
 	CLOCK_SetRootDivider(kCLOCK_RootUart4, 1U, 1U);
+#endif
 #endif
 
 	CLOCK_EnableClock(kCLOCK_Rdc);   /* Enable RDC clock */
@@ -126,10 +146,6 @@ static void SOC_ClockInit(void)
 	CLOCK_EnableClock(kCLOCK_Debug);
 	CLOCK_EnableClock(kCLOCK_Dram);
 	CLOCK_EnableClock(kCLOCK_Sec_Debug);
-
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart4), okay) && CONFIG_UART_MCUX_IUART
-	CLOCK_EnableClock(kCLOCK_Uart4);
-#endif
 }
 
 static int nxp_mimx8ml8_init(const struct device *arg)

--- a/soc/arm/nxp_imx/mimx8mm6_m4/soc.c
+++ b/soc/arm/nxp_imx/mimx8mm6_m4/soc.c
@@ -103,10 +103,32 @@ static void SOC_ClockInit(void)
 	/* switch AUDIO AHB to SYSTEM PLL1 */
 	CLOCK_SetRootMux(kCLOCK_RootAudioAhb, kCLOCK_AudioAhbRootmuxSysPll1);
 
+#if defined(CONFIG_UART_MCUX_IUART)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart1), okay)
+	/* Set UART source to SysPLL1 Div10 80MHZ */
+	CLOCK_SetRootMux(kCLOCK_RootUart1, kCLOCK_UartRootmuxSysPll1Div10);
+	/* Set root clock to 80MHZ/ 1= 80MHZ */
+	CLOCK_SetRootDivider(kCLOCK_RootUart1, 1U, 1U);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart2), okay)
+	/* Set UART source to SysPLL1 Div10 80MHZ */
+	CLOCK_SetRootMux(kCLOCK_RootUart2, kCLOCK_UartRootmuxSysPll1Div10);
+	/* Set root clock to 80MHZ/ 1= 80MHZ */
+	CLOCK_SetRootDivider(kCLOCK_RootUart2, 1U, 1U);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart3), okay)
+	/* Set UART source to SysPLL1 Div10 80MHZ */
+	CLOCK_SetRootMux(kCLOCK_RootUart3, kCLOCK_UartRootmuxSysPll1Div10);
+	/* Set root clock to 80MHZ/ 1= 80MHZ */
+	CLOCK_SetRootDivider(kCLOCK_RootUart3, 1U, 1U);
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart4), okay)
 	/* Set UART source to SysPLL1 Div10 80MHZ */
 	CLOCK_SetRootMux(kCLOCK_RootUart4, kCLOCK_UartRootmuxSysPll1Div10);
 	/* Set root clock to 80MHZ/ 1= 80MHZ */
 	CLOCK_SetRootDivider(kCLOCK_RootUart4, 1U, 1U);
+#endif
+#endif
 
 	/* Enable RDC clock */
 	CLOCK_EnableClock(kCLOCK_Rdc);
@@ -124,8 +146,6 @@ static void SOC_ClockInit(void)
 	CLOCK_EnableClock(kCLOCK_Debug);
 	CLOCK_EnableClock(kCLOCK_Dram);
 	CLOCK_EnableClock(kCLOCK_Sec_Debug);
-
-	CLOCK_EnableClock(kCLOCK_Uart4);
 }
 
 static int nxp_mimx8mm6_init(const struct device *arg)

--- a/soc/arm/nxp_imx/mimx8mq6_m4/soc.c
+++ b/soc/arm/nxp_imx/mimx8mq6_m4/soc.c
@@ -66,32 +66,31 @@ static void SOC_ClockInit(void)
 	/* Switch cortex-m4 to SYSTEM PLL1 DIV3 */
 	CLOCK_SetRootMux(kCLOCK_RootM4, kCLOCK_M4RootmuxSysPll1Div3);
 
+#if defined(CONFIG_UART_MCUX_IUART)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart1), okay)
 	/* Set UART source to SysPLL1 Div10 80MHZ */
 	CLOCK_SetRootMux(kCLOCK_RootUart1, kCLOCK_UartRootmuxSysPll1Div10);
 	/* Set root clock to 80MHZ/ 1= 80MHZ */
 	CLOCK_SetRootDivider(kCLOCK_RootUart1, 1U, 1U);
 #endif
-
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart2), okay)
 	/* Set UART source to SysPLL1 Div10 80MHZ */
 	CLOCK_SetRootMux(kCLOCK_RootUart2, kCLOCK_UartRootmuxSysPll1Div10);
 	/* Set root clock to 80MHZ/ 1= 80MHZ */
 	CLOCK_SetRootDivider(kCLOCK_RootUart2, 1U, 1U);
 #endif
-
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart3), okay)
 	/* Set UART source to SysPLL1 Div10 80MHZ */
 	CLOCK_SetRootMux(kCLOCK_RootUart3, kCLOCK_UartRootmuxSysPll1Div10);
 	/* Set root clock to 80MHZ/ 1= 80MHZ */
 	CLOCK_SetRootDivider(kCLOCK_RootUart3, 1U, 1U);
 #endif
-
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart4), okay)
 	/* Set UART source to SysPLL1 Div10 80MHZ */
 	CLOCK_SetRootMux(kCLOCK_RootUart4, kCLOCK_UartRootmuxSysPll1Div10);
 	/* Set root clock to 80MHZ/ 1= 80MHZ */
 	CLOCK_SetRootDivider(kCLOCK_RootUart4, 1U, 1U);
+#endif
 #endif
 
 	/* Enable RDC clock */


### PR DESCRIPTION
This patch set introduces clock gating support for UART controllers found in i.MX SoC family, replacing the existing static configuration of serial ports. This change is especially important when Zephyr is sharing the bus with cores running other OSes, which might be already using the aforementioned controllers.

The mimx8mm6_m4 and mimx8ml8_m7 SoCs were tested on VAR-SOM-MX8M-MINI and VAR-SOM-MX8M-PLUS boards, respectively. The mimx8mq6_m4 changes remain untested for the lack of hardware.