### PR TITLE
fix: doc: in kernel/drivers interrupts function had mismatching types

### DIFF
--- a/doc/kernel/drivers/index.rst
+++ b/doc/kernel/drivers/index.rst
@@ -312,7 +312,7 @@ Then when the particular instance is declared:
 
   DEVICE_DECLARE(my_driver_0);
 
-  static void my_driver_config_irq_0(void)
+  static void my_driver_config_irq_0(const struct device *dev)
   {
         IRQ_CONNECT(MY_DRIVER_0_IRQ, MY_DRIVER_0_PRI, my_driver_isr,
                     DEVICE_GET(my_driver_0), MY_DRIVER_0_FLAGS);


### PR DESCRIPTION
The typedef defines an interrupt config routine with `const struct device *dev`, while the example function had (void) as argument. This could be considered confusing / would throw compiler warnings even though the parameter isn't strictly necessary.

Code examples for initializing an IRQ in a device example follow the updated pattern (e.g. see `drivers/serial/uart_npcx.c`).