### PR TITLE
kernel: remove init_abort from _static_thread_data

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -660,7 +660,6 @@ struct _static_thread_data {
 	int init_prio;
 	uint32_t init_options;
 	int32_t init_delay;
-	void (*init_abort)(void);
 	const char *init_name;
 };
 


### PR DESCRIPTION
Commit d823f88e3b34 ("kernel: move _static_thread_data to ROM") intended to
remove `init_abort` member from `struct _static_thread_data`, but instead it
just removed it from `Z_THREAD_INITIALIZER()` initializer.

Remove `init_abort`, which is a leftover.