### PR TITLE
arch: arm: limit FP16 support to Cortex-A or Cortex-R

### DIFF
--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -279,6 +279,7 @@ endchoice
 
 config FP16
 	bool "Half-precision floating point support"
+	depends on CPU_AARCH32_CORTEX_A || CPU_AARCH32_CORTEX_R
 	default y
 	help
 	  This option enables the half-precision (16-bit) floating point support


### PR DESCRIPTION
FP16 isn't something that is supported on Cortex-M so limit the Kconfig feature to Cortex-A or Cortex-R.