### PR TITLE
drivers: pwm: mchp_xec: fix PWM control register updates

### DIFF
--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -299,13 +299,14 @@ done:
 
 	params = xec_compare_params(target_freq, &hc_params, &lc_params);
 	if (params == &hc_params) {
-		cfgval |= MCHP_PWM_CFG_CLK_SEL_48M;
+		cfgval &= ~MCHP_PWM_CFG_CLK_SEL_100K;
 	} else {
 		cfgval |= MCHP_PWM_CFG_CLK_SEL_100K;
 	}
 
 	regs->COUNT_ON = params->on;
 	regs->COUNT_OFF = params->off;
+	cfgval &= ~MCHP_PWM_CFG_CLK_PRE_DIV(0xF);
 	cfgval |= MCHP_PWM_CFG_CLK_PRE_DIV(params->div);
 	cfgval |= MCHP_PWM_CFG_ENABLE;
 


### PR DESCRIPTION
The pwm_mchp_xec driver doesn't clear the divisor or clock select fields of the config register value before writing it back.  If the register was previously written, the new values were being logically OR'd with the prior values.