### PR TITLE
shell: backends: dummy: default to log level INF

### DIFF
--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -407,7 +407,7 @@ config SHELL_BACKEND_DUMMY_BUF_SIZE
 
 choice
 	prompt "Initial log level limit"
-	default SHELL_DUMMY_INIT_LOG_LEVEL_DEFAULT
+	default SHELL_DUMMY_INIT_LOG_LEVEL_INF
 
 config SHELL_DUMMY_INIT_LOG_LEVEL_DEFAULT
 	bool "System limit (LOG_MAX_LEVEL)"


### PR DESCRIPTION
This change fixes code to match the description in https://github.com/zephyrproject-rtos/zephyr/pull/55061 (see commit 9ecef4b).

This preserves the previous default behaviour of the shell dummy backend.