### PR TITLE
fix: doc: canbus: fix tx callback function name typo in code snippet

### DIFF
--- a/doc/hardware/peripherals/canbus/controller.rst
+++ b/doc/hardware/peripherals/canbus/controller.rst
@@ -194,7 +194,7 @@ occurred. It does not block until the message is sent like the example above.
           frame.data[0] = 1;
           frame.data[1] = 2;
 
-          return can_send(can_dev, &frame, K_FOREVER, tx_irq_callback, "Sender 1");
+          return can_send(can_dev, &frame, K_FOREVER, tx_callback, "Sender 1");
   }
 
 Receiving


### PR DESCRIPTION
In the `can_send()` example code snippet, it passed the `can_tx_callback_t` parameter as `tx_irq_callback` even though the function name was previously defined in the snippet as `tx_callback`. The function name has been updated to `tx_irq_callback` to maintain consistency.