### PR TITLE
MAINTAINERS: Add Desvauxm-st as STM32 collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2141,6 +2141,7 @@ STM32 Platforms:
     - ABOSTM
     - FRASTM
     - gautierg-st
+    - Desvauxm-st
     - GeorgeCGV
   files:
     - boards/arm/nucleo_*/
@@ -2637,6 +2638,8 @@ West:
   collaborators:
     - FRASTM
     - ABOSTM
+    - gautierg-st
+    - Desvauxm-st
   files:
     - modules/Kconfig.stm32
   labels:


### PR DESCRIPTION
Add Marc as STM32 Platform collaborator.
Additionally add him and gautierg-st as collaborators to STM32 HAL module.

@Desvauxm-st already contributed some fixes around STM32 ethernet recently:
https://github.com/zephyrproject-rtos/zephyr/issues?q=+author%3ADesvauxm-st

He'll contribute to more areas in future