### PR TITLE
Bluetooth: Controller: Fix Peripheral CIS supervision timeout

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -933,6 +933,13 @@ static void isr_prepare_subevent(void *param)
 	start_us = radio_tmr_start_us(0U, subevent_us);
 	LL_ASSERT(!trx_performed_bitmask || (start_us == (subevent_us + 1U)));
 
+	/* If no anchor point sync yet, continue to capture access address
+	 * timestamp.
+	 */
+	if (!radio_tmr_aa_restore()) {
+		radio_tmr_aa_capture();
+	}
+
 	cig_lll = ull_conn_iso_lll_group_get_by_stream(cis_lll);
 
 	hcto = start_us +


### PR DESCRIPTION
Fix Peripheral CIS supervision timeout due to missing access address timestamp capture in subsequent subevents when anchor point was not sync in the first subevent.