### PR TITLE
doc: tests: Fix incorrect table syntax

### DIFF
--- a/doc/develop/test/coverage.rst
+++ b/doc/develop/test/coverage.rst
@@ -165,6 +165,8 @@ default for the Twister ``--gcov-tool`` argument default:
 | Toolchain | ``--gcov-tool`` value |
 +-----------+-----------------------+
 | host      | ``gcov``              |
++-----------+-----------------------+
 | llvm      | ``llvm-cov gcov``     |
++-----------+-----------------------+
 | zephyr    | ``gcov``              |
 +-----------+-----------------------+


### PR DESCRIPTION
This fixes an incorrect use of the reStructuredText grid table syntax.

Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>
