### PR TITLE
soc: nrf53: Warn if workaround for anomaly 160 cannot be applied

### DIFF
--- a/soc/arm/nordic_nrf/nrf53/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf53/CMakeLists.txt
@@ -11,3 +11,15 @@ zephyr_library_sources_ifdef(CONFIG_PM
 zephyr_library_sources_ifdef(CONFIG_NRF53_SYNC_RTC
   sync_rtc.c
   )
+
+if (CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED AND
+    NOT CONFIG_SYS_CLOCK_EXISTS)
+  message(WARNING "
+    Your application may be affected by the anomaly 160 that concerns the
+    nRF5340 SoC. The related workaround cannot be applied, because your
+    application has the system clock disabled (CONFIG_SYS_CLOCK_EXISTS=n).
+    Consider enabling the system clock to apply the workaround.
+    " "
+    At your own risk, you can suppress this warning by setting
+    CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED=n.")
+endif()

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -13,7 +13,7 @@ config SOC_NRF5340_CPUAPP
 config SOC_NRF5340_CPUNET
 	bool
 	select HAS_NO_PM
-	imply SOC_NRF53_ANOMALY_160_WORKAROUND
+	imply SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED
 
 choice
 	prompt "nRF53x MCU Selection"
@@ -28,6 +28,19 @@ config SOC_NRF5340_CPUNET_QKAA
 
 endchoice
 
+config SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED
+	bool "Workaround for nRF5340 anomaly 160"
+	imply SOC_NRF53_ANOMALY_160_WORKAROUND
+	help
+	  Indicates that the workaround for the anomaly 160 that affects
+	  the nRF5340 SoC should be applied.
+	  This option is enabled by default for the Application MCU when
+	  DC/DC mode is enabled for the VREGMAIN or VREGRADIO regulator
+	  and always for the Network MCU.
+	  If this option is enabled, but the workaround cannot be applied,
+	  because the system clock is disabled, a related cmake warning is
+	  issued.
+
 config SOC_NRF53_ANOMALY_160_WORKAROUND
 	bool
 	depends on SYS_CLOCK_EXISTS
@@ -37,13 +50,13 @@ if SOC_NRF5340_CPUAPP
 
 config SOC_DCDC_NRF53X_APP
 	bool
-	imply SOC_NRF53_ANOMALY_160_WORKAROUND
+	imply SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED
 	help
 	  Enable nRF53 series System on Chip Application MCU DC/DC converter.
 
 config SOC_DCDC_NRF53X_NET
 	bool
-	imply SOC_NRF53_ANOMALY_160_WORKAROUND
+	imply SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED
 	help
 	  Enable nRF53 series System on Chip Network MCU DC/DC converter.
 


### PR DESCRIPTION
This is a follow-up to commit fe3b97a87f480eb473cd58cc1990a5845c2ca9c6.

Add a cmake warning issued when the workaround for the nRF5340 anomaly 160 cannot be applied because the application is configured with no system clock.