### PR TITLE
usb: device_next: add feature endpoint halt/clear state update API

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -179,6 +179,10 @@ struct usbd_class_node;
  * @brief USB device support class instance API
  */
 struct usbd_class_api {
+	/** Feature halt state update handler */
+	void (*feature_halt)(struct usbd_class_node *const node,
+			     uint8_t ep, bool halted);
+
 	/** Configuration update handler */
 	void (*update)(struct usbd_class_node *const node,
 		       uint8_t iface, uint8_t alternate);

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -192,6 +192,16 @@ static int sreq_set_interface(struct usbd_contex *const uds_ctx)
 	return ret;
 }
 
+static void sreq_feature_halt_notify(struct usbd_contex *const uds_ctx,
+				     const uint8_t ep, const bool halted)
+{
+	struct usbd_class_node *c_nd = usbd_class_get_by_ep(uds_ctx, ep);
+
+	if (c_nd != NULL) {
+		usbd_class_feature_halt(c_nd, ep, halted);
+	}
+}
+
 static int sreq_clear_feature(struct usbd_contex *const uds_ctx)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
@@ -232,7 +242,10 @@ static int sreq_clear_feature(struct usbd_contex *const uds_ctx)
 			/* UDC checks if endpoint is enabled */
 			errno = usbd_ep_clear_halt(uds_ctx, ep);
 			ret = (errno == -EPERM) ? errno : 0;
-			/* TODO: notify class instance */
+			if (ret == 0) {
+				/* Notify class instance */
+				sreq_feature_halt_notify(uds_ctx, ep, false);
+			}
 			break;
 		}
 		break;
@@ -287,7 +300,10 @@ static int sreq_set_feature(struct usbd_contex *const uds_ctx)
 			/* UDC checks if endpoint is enabled */
 			errno = usbd_ep_set_halt(uds_ctx, ep);
 			ret = (errno == -EPERM) ? errno : 0;
-			/* TODO: notify class instance */
+			if (ret == 0) {
+				/* Notify class instance */
+				sreq_feature_halt_notify(uds_ctx, ep, true);
+			}
 			break;
 		}
 		break;

--- a/subsys/usb/device_next/usbd_class_api.h
+++ b/subsys/usb/device_next/usbd_class_api.h
@@ -107,6 +107,31 @@ static inline int usbd_class_control_to_dev(struct usbd_class_node *const node,
 }
 
 /**
+ * @brief Feature endpoint halt update handler
+ *
+ * Called when an endpoint of the interface belonging
+ * to the instance has been halted or cleared by either
+ * a Set Feature Endpoint Halt or Clear Feature Endpoint Halt request.
+ *
+ * The execution of the handler must not block.
+ *
+ * @param[in] dev Pointer to device struct of the class instance
+ * @param[in] ep Endpoint
+ * @param[in] halted True if the endpoint has been halted and false if
+ *                   the endpoint halt has been cleared by a Feature request.
+ */
+static inline void usbd_class_feature_halt(struct usbd_class_node *const node,
+					   const uint8_t ep,
+					   const bool halted)
+{
+	const struct usbd_class_api *api = node->api;
+
+	if (api->feature_halt != NULL) {
+		api->feature_halt(node, ep, halted);
+	}
+}
+
+/**
  * @brief Configuration update handler
  *
  * Called when the configuration of the interface belonging


### PR DESCRIPTION
Add USB device class API to notify class instances that an endpoint has been halted or cleared due to a feature request.

For #54776, can be use like

```c
diff --git a/subsys/usb/device_next/class/usbd_msc.c b/subsys/usb/device_next/class/usbd_msc.c
index d25452e8254..01b692cf5c7 100644
--- a/subsys/usb/device_next/class/usbd_msc.c
+++ b/subsys/usb/device_next/class/usbd_msc.c
@@ -617,6 +617,13 @@ static void msc_bot_schedule_reset(struct usbd_class_node *node)
        k_msgq_put(&msc_msgq, &request, K_FOREVER);
 }
 
+/* Feature endpoint halt state handler */
+static void msc_bot_feature_halt(struct usbd_class_node *const node,
+                                const uint8_t ep, const bool halted)
+{
+       LOG_INF("Endpoint 0x%02x %s", ep, halted ? "halted" : "cleared");
+}
+
 /* Configuration update handler */
 static void msc_bot_update(struct usbd_class_node *const node,
                           uint8_t iface, uint8_t alternate)
@@ -749,6 +756,7 @@ static struct msc_bot_desc msc_bot_desc_##n = {                                           \
 };
 
 struct usbd_class_api msc_bot_api = {
+       .feature_halt = msc_bot_feature_halt,
        .update = msc_bot_update,
        .control_to_dev = msc_bot_control_to_dev,
        .control_to_host = msc_bot_control_to_host,
```