### PR TITLE
pts: gen_defines: Support FOREACH_PROP_ELEM for phandle properties

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2714,9 +2714,9 @@
  *     };
  * @endcode
  *
- * The "prop" argument must refer to a property with type string,
- * array, uint8-array, string-array, phandles, or phandle-array. It is
- * an error to use this macro with properties of other types.
+ * The "prop" argument must refer to a property with type array, uint8-array,
+ * string-array, phandle, phandles, or phandle-array.  It is an error to use
+ * this macro with properties of other types.
  *
  * @param node_id node identifier
  * @param prop lowercase-and-underscores property name

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -32,12 +32,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'python-devicetree',
 
 from devicetree import edtlib
 
-# The set of binding types whose values can be iterated over with
-# DT_FOREACH_PROP_ELEM(). If you change this, make sure to update the
-# doxygen string for that macro.
-FOREACH_PROP_ELEM_TYPES = set(['string', 'array', 'uint8-array', 'string-array',
-                               'phandles', 'phandle-array'])
-
 class LogFormatter(logging.Formatter):
     '''A log formatter that prints the level name in lower case,
     for compatibility with earlier versions of edtlib.'''
@@ -680,30 +674,29 @@ def write_vanilla_props(node):
                     macro2val[macro + f"_IDX_{i}"] = subval
                 macro2val[macro + f"_IDX_{i}_EXISTS"] = 1
 
-        if prop.type in FOREACH_PROP_ELEM_TYPES:
+        plen = prop_len(prop)
+        if plen is not None:
             # DT_N_<node-id>_P_<prop-id>_FOREACH_PROP_ELEM
             macro2val[f"{macro}_FOREACH_PROP_ELEM(fn)"] = \
                 ' \\\n\t'.join(
                     f'fn(DT_{node.z_path_id}, {prop_id}, {i})'
-                    for i in range(len(prop.val)))
+                    for i in range(plen))
 
             macro2val[f"{macro}_FOREACH_PROP_ELEM_SEP(fn, sep)"] = \
                 ' DT_DEBRACKET_INTERNAL sep \\\n\t'.join(
                     f'fn(DT_{node.z_path_id}, {prop_id}, {i})'
-                    for i in range(len(prop.val)))
+                    for i in range(plen))
 
             macro2val[f"{macro}_FOREACH_PROP_ELEM_VARGS(fn, ...)"] = \
                 ' \\\n\t'.join(
                     f'fn(DT_{node.z_path_id}, {prop_id}, {i}, __VA_ARGS__)'
-                    for i in range(len(prop.val)))
+                    for i in range(plen))
 
             macro2val[f"{macro}_FOREACH_PROP_ELEM_SEP_VARGS(fn, sep, ...)"] = \
                 ' DT_DEBRACKET_INTERNAL sep \\\n\t'.join(
                     f'fn(DT_{node.z_path_id}, {prop_id}, {i}, __VA_ARGS__)'
-                    for i in range(len(prop.val)))
+                    for i in range(plen))
 
-        plen = prop_len(prop)
-        if plen is not None:
             # DT_N_<node-id>_P_<prop-id>_LEN
             macro2val[macro + "_LEN"] = plen
 


### PR DESCRIPTION
The macros to allow FOREACH on singleton phandle properties were not generated.  A 'phandle' property acts as an array in other cases, such as having a defined length of 1 and support for BY_IDX access.

Instead of an explicit FOREACH enabled list, use prop_len() to determine if the property is considered iterable or not.

This will have the effect of removing 'string' from the list of FOREACH enabled property types.  While FOREACH was technically possible on a singleton string, DT_PROP_BY_IDX() was not, leaving no way to get the property's value in the expansion of the FOREACH, making it effectively useless.

Fixes #55115