### PR TITLE
Tests: Bluetooth: Fix missing CAP broadcast packing field

### DIFF
--- a/tests/bluetooth/bsim/audio/src/cap_initiator_test.c
+++ b/tests/bluetooth/bsim/audio/src/cap_initiator_test.c
@@ -394,6 +394,7 @@ static void test_cap_initiator_broadcast(void)
 	create_param.subgroup_count = 1U;
 	create_param.subgroup_params = &subgroup_param;
 	create_param.qos = &broadcast_preset_16_2_1.qos;
+	create_param.packing = BT_ISO_PACKING_SEQUENTIAL;
 
 	init();
 


### PR DESCRIPTION
Set uninitialized packing field in the broadcast create parameter.