### PR TITLE
doc: Fix CSS issue with keyboard shortcuts on dark theme

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -545,7 +545,9 @@ a.internal:visited code.literal {
 }
 
 /* Keyboard shortcuts tweaks */
-kbd, .kbd {
+kbd, .kbd,
+.rst-content :not(dl.option-list) > :not(dt):not(kbd):not(.kbd) > kbd,
+.rst-content :not(dl.option-list) > :not(dt):not(kbd):not(.kbd) > .kbd {
     background-color: var(--kbd-background-color);
     border: 1px solid var(--kbd-outline-color);
     border-radius: 3px;


### PR DESCRIPTION
Fixes CSS styling issue causing keyboard shortcuts to sometimes not be visible
(white text on white background) using dark theme.
Fixes #55126.

Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>
