### PR TITLE
drivers: wdt: Add intel watchdog driver

### DIFF
--- a/drivers/watchdog/CMakeLists.txt
+++ b/drivers/watchdog/CMakeLists.txt
@@ -33,6 +33,6 @@ zephyr_library_sources_ifdef(CONFIG_WDT_NXP_S32 wdt_nxp_s32.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_SMARTBOND wdt_smartbond.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_TI_TPS382X wdt_ti_tps382x.c)
 
-zephyr_library_sources_ifdef(CONFIG_WDT_DW wdt_dw.c)
+zephyr_library_sources_ifdef(CONFIG_WDT_DW wdt_dw.c wdt_dw_common.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE wdt_handlers.c)

--- a/drivers/watchdog/CMakeLists.txt
+++ b/drivers/watchdog/CMakeLists.txt
@@ -34,5 +34,6 @@ zephyr_library_sources_ifdef(CONFIG_WDT_SMARTBOND wdt_smartbond.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_TI_TPS382X wdt_ti_tps382x.c)
 
 zephyr_library_sources_ifdef(CONFIG_WDT_DW wdt_dw.c wdt_dw_common.c)
+zephyr_library_sources_ifdef(CONFIG_WDT_INTEL_ADSP wdt_intel_adsp.c wdt_dw_common.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE wdt_handlers.c)

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -96,6 +96,8 @@ source "drivers/watchdog/Kconfig.nxp_s32"
 
 source "drivers/watchdog/Kconfig.dw"
 
+source "drivers/watchdog/Kconfig.intel_adsp"
+
 source "drivers/watchdog/Kconfig.smartbond"
 
 source "drivers/watchdog/Kconfig.ti_tps382x"

--- a/drivers/watchdog/Kconfig.intel_adsp
+++ b/drivers/watchdog/Kconfig.intel_adsp
@@ -1,0 +1,11 @@
+# Intel ADSP Watchdog configuration options
+
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config WDT_INTEL_ADSP
+	bool "Intel ADSP Watchdog driver"
+	default y
+	depends on DT_HAS_INTEL_ADSP_WATCHDOG_ENABLED
+	help
+	  Intel ADSP Watchdog driver.

--- a/drivers/watchdog/wdt_dw_common.c
+++ b/drivers/watchdog/wdt_dw_common.c
@@ -1,0 +1,110 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * Author: Adrian Warecki <adrian.warecki@intel.com>
+ */
+
+#include <zephyr/drivers/watchdog.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/math/ilog2.h>
+
+#include "wdt_dw_common.h"
+#include "wdt_dw.h"
+
+LOG_MODULE_REGISTER(wdt_dw_common, CONFIG_WDT_LOG_LEVEL);
+
+#define WDT_DW_FLAG_CONFIGURED	0x80000000
+
+int dw_wdt_check_options(const uint8_t options)
+{
+	if (options & WDT_OPT_PAUSE_HALTED_BY_DBG) {
+		LOG_ERR("Pausing watchdog by debugger is not supported.");
+		return -ENOTSUP;
+	}
+
+	if (options & WDT_OPT_PAUSE_IN_SLEEP) {
+		LOG_ERR("Pausing watchdog in sleep is not supported.");
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+int dw_wdt_configure(const uint32_t base, const uint32_t config)
+{
+	uint32_t period;
+
+	if (!(config & WDT_DW_FLAG_CONFIGURED)) {
+		LOG_ERR("Timeout not installed.");
+		return -ENOTSUP;
+	}
+
+	/* Configure timeout */
+	period = config & ~WDT_DW_FLAG_CONFIGURED;
+
+	if (dw_wdt_dual_timeout_period_get(base)) {
+		dw_wdt_timeout_period_init_set(base, period);
+	}
+
+	dw_wdt_timeout_period_set(base, period);
+
+	/* Enable watchdog */
+	dw_wdt_enable(base);
+	dw_wdt_counter_restart(base);
+
+	return 0;
+}
+
+int dw_wdt_calc_period(const uint32_t base, const uint32_t clk_freq,
+		       const struct wdt_timeout_cfg *config, uint32_t *period_out)
+{
+	uint64_t period64;
+	uint32_t period;
+
+	/* Window timeout is not supported by this driver */
+	if (config->window.min) {
+		LOG_ERR("Window timeout is not supported.");
+		return -ENOTSUP;
+	}
+
+	period64 = (uint64_t)clk_freq * config->window.max;
+	period64 /= 1000;
+	if (!period64 || (period64 >> 31)) {
+		LOG_ERR("Window max is out of range.");
+		return -EINVAL;
+	}
+
+	period = period64 - 1;
+	period = ilog2(period);
+
+	if (period >= dw_wdt_cnt_width_get(base)) {
+		LOG_ERR("Watchdog timeout too long.");
+		return -EINVAL;
+	}
+
+	/* The minimum counter value is 64k, maximum 2G */
+	*period_out = WDT_DW_FLAG_CONFIGURED | (period >= 15 ? period - 15 : 0);
+	return 0;
+}
+
+int dw_wdt_probe(const uint32_t base, const uint32_t reset_pulse_length)
+{
+	/* Check component type */
+	const uint32_t type = dw_wdt_comp_type_get(base);
+
+	if (type != WDT_COMP_TYPE_VALUE) {
+		LOG_ERR("Invalid component type %x", type);
+		return -ENODEV;
+	}
+
+	dw_wdt_reset_pulse_length_set(base, reset_pulse_length);
+
+	return 0;
+}
+
+int dw_wdt_disable(const struct device *dev)
+{
+	return -ENOTSUP;
+}

--- a/drivers/watchdog/wdt_dw_common.h
+++ b/drivers/watchdog/wdt_dw_common.h
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * Author: Adrian Warecki <adrian.warecki@intel.com>
+ */
+
+#ifndef ZEPHYR_DRIVERS_WATCHDOG_WDT_DW_COMMON_H_
+#define ZEPHYR_DRIVERS_WATCHDOG_WDT_DW_COMMON_H_
+
+#include <stdint.h>
+
+/**
+ * @brief Check watchdog configuration options
+ *
+ * Check options value passed to a watchdog setup function. Returns error if unsupported option
+ * is used.
+ *
+ * @param options options value passed to a watchdog setup function.
+ * @return Error code, 0 on success.
+ */
+int dw_wdt_check_options(const uint8_t options);
+
+/**
+ * @brief Configure watchdog device
+ *
+ * @param base Device base address.
+ * @param config device configuration word
+ * @return Error code, 0 on success.
+ */
+int dw_wdt_configure(const uint32_t base, const uint32_t config);
+
+/**
+ * @brief Calculate period
+ *
+ * @param [in]base Device base address.
+ * @param [in]clk_freq frequency of a clock used by watchdog device
+ * @param [in]config pointer to a watchdog configuration structure
+ * @param [out]period_out pointer to a variable in which the period configuration word will be
+ *        placed
+ * @return Error code, 0 on success.
+ */
+int dw_wdt_calc_period(const uint32_t base, const uint32_t clk_freq,
+		       const struct wdt_timeout_cfg *config, uint32_t *period_out);
+
+/**
+ * @brief Watchdog probe
+ *
+ * Checks device id register and configure a reset pulse length.
+ *
+ * @param base Device base address.
+ * @param reset_pulse_length Length of a reset pulse produced by watchdog
+ * @return Error code, 0 on success.
+ */
+int dw_wdt_probe(const uint32_t base, const uint32_t reset_pulse_length);
+
+/**
+ * @brief Watchdog disable function
+ *
+ * @param dev Device structure.
+ * @return -ENOTSUP. The hardware does not support disabling.
+ */
+int dw_wdt_disable(const struct device *dev);
+
+#endif /* ZEPHYR_DRIVERS_WATCHDOG_WDT_DW_COMMON_H_ */

--- a/drivers/watchdog/wdt_intel_adsp.c
+++ b/drivers/watchdog/wdt_intel_adsp.c
@@ -1,0 +1,237 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * Author: Adrian Warecki <adrian.warecki@intel.com>
+ */
+
+/**
+ * @file
+ *
+ * @brief Intel ACE per-core watchdogs driver
+ *
+ * The ace platform has a set of designware watchdogs, one for each core. This driver is responsible
+ * for finding the base addresses of subordinate devices, controlling the pause signal and handling
+ * interrupts. The registers from the DSP Core Watch Dog Timer Control & Status block are used for
+ * this purpose. This block is shared by all per-core watchdogs.
+ *
+ * The base addresses of the subordinate watchdogs are read from the control registers. As a result,
+ * in the device tree we have only one base address for the intel watchdog.
+ *
+ * The designware watchdog only supports a hardware pause signal. It cannot be paused
+ * programmatically. On ace platform there are GPIO-like registers that allows control of a hardware
+ * pause signal for subordinate watchdogs.
+ *
+ * All subordinate watchdog devices share the same interrupt number. Each watchdog reports
+ * an interrupt to the core to which it has been assigned. The same interrupt number cannot
+ * be used by multiple devices in the device tree. This driver handles interrupts from all
+ * subordinate watchdogs and identifies which device signal it.
+ */
+
+#define DT_DRV_COMPAT intel_adsp_watchdog
+
+#include <zephyr/drivers/watchdog.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/math/ilog2.h>
+
+#include "wdt_dw.h"
+#include "wdt_dw_common.h"
+#include "wdt_intel_adsp.h"
+
+LOG_MODULE_REGISTER(wdt_intel_adsp, CONFIG_WDT_LOG_LEVEL);
+
+#define DEV_NODE				DT_INST(0, DT_DRV_COMPAT)
+#define WDT_INTEL_ADSP_INTERRUPT_SUPPORT	DT_NODE_HAS_PROP(DEV_NODE, interrupts)
+
+/* Device run time data */
+struct intel_adsp_wdt_dev_data {
+	uint32_t core_wdt[CONFIG_MP_MAX_NUM_CPUS];
+	uint32_t period_cfg;
+	bool allow_reset;
+#if WDT_INTEL_ADSP_INTERRUPT_SUPPORT
+	wdt_callback_t callback;
+#endif
+};
+
+/* Device constant configuration parameters */
+struct intel_adsp_wdt_dev_cfg {
+	uint32_t base;
+	uint32_t clk_freq;
+};
+
+static int intel_adsp_wdt_setup(const struct device *dev, uint8_t options)
+{
+	const struct intel_adsp_wdt_dev_cfg *const dev_config = dev->config;
+	struct intel_adsp_wdt_dev_data *const dev_data = dev->data;
+	unsigned int i;
+	int ret;
+
+	ret = dw_wdt_check_options(options);
+	if (ret) {
+		return ret;
+	}
+
+	for (i = 0; i < CONFIG_MP_MAX_NUM_CPUS; i++) {
+		ret = dw_wdt_configure(dev_data->core_wdt[i], dev_data->period_cfg);
+		if (ret) {
+			return ret;
+		}
+
+#if WDT_INTEL_ADSP_INTERRUPT_SUPPORT
+		dw_wdt_response_mode_set(dev_data->core_wdt[i], !!dev_data->callback);
+#endif
+		intel_adsp_wdt_reset_set(dev_config->base, i, dev_data->allow_reset);
+	}
+
+	return 0;
+}
+
+static int intel_adsp_wdt_install_timeout(const struct device *dev,
+					  const struct wdt_timeout_cfg *config)
+{
+	const struct intel_adsp_wdt_dev_cfg *const dev_config = dev->config;
+	struct intel_adsp_wdt_dev_data *const dev_data = dev->data;
+	int ret;
+
+#if WDT_INTEL_ADSP_INTERRUPT_SUPPORT
+	dev_data->callback = config->callback;
+#else
+	if (config->callback) {
+		LOG_ERR("Interrupt is not configured, can't set a callback.");
+		return -ENOTSUP;
+	}
+#endif
+
+	ret = dw_wdt_calc_period(dev_data->core_wdt[0], dev_config->clk_freq, config,
+				 &dev_data->period_cfg);
+	if (ret) {
+		return ret;
+	}
+
+	if (config->flags & WDT_FLAG_RESET_CPU_CORE) {
+		dev_data->allow_reset = true;
+	}
+
+	return 0;
+}
+
+static int intel_adsp_wdt_feed(const struct device *dev, int channel_id)
+{
+	struct intel_adsp_wdt_dev_data *const dev_data = dev->data;
+
+	if (channel_id >= CONFIG_MP_MAX_NUM_CPUS) {
+		return -EINVAL;
+	}
+
+	dw_wdt_counter_restart(dev_data->core_wdt[channel_id]);
+	return 0;
+}
+
+#if WDT_INTEL_ADSP_INTERRUPT_SUPPORT
+static void intel_adsp_wdt_isr(const struct device *dev)
+{
+	const struct intel_adsp_wdt_dev_cfg *const dev_config = dev->config;
+	struct intel_adsp_wdt_dev_data *const dev_data = dev->data;
+	const uint32_t cpu = arch_proc_id();
+	const uint32_t base = dev_data->core_wdt[cpu];
+
+	if (dw_wdt_interrupt_status_register_get(base)) {
+		if (dev_data->callback) {
+			dev_data->callback(dev, cpu);
+		}
+
+		dw_wdt_clear_interrupt(base);
+	}
+}
+#endif
+
+static int intel_adsp_wdt_init(const struct device *dev)
+{
+	const unsigned int reset_pulse_length =
+		ilog2(DT_PROP(DEV_NODE, reset_pulse_length)) - 1;
+	const struct intel_adsp_wdt_dev_cfg *const dev_config = dev->config;
+	struct intel_adsp_wdt_dev_data *const dev_data = dev->data;
+	unsigned int i;
+	int ret;
+
+	for (i = 0; i < CONFIG_MP_MAX_NUM_CPUS; i++) {
+		dev_data->core_wdt[i] = intel_adsp_wdt_pointer_get(dev_config->base, i);
+		ret = dw_wdt_probe(dev_data->core_wdt[i], reset_pulse_length);
+		if (ret) {
+			return ret;
+		}
+	}
+
+#if WDT_INTEL_ADSP_INTERRUPT_SUPPORT
+	IRQ_CONNECT(DT_IRQN(DEV_NODE), DT_IRQ(DEV_NODE, priority), intel_adsp_wdt_isr,
+		    DEVICE_DT_GET(DEV_NODE), DT_IRQ(DEV_NODE, sense));
+	irq_enable(DT_IRQN(DEV_NODE));
+#endif
+
+	return 0;
+}
+
+/**
+ * @brief Pause watchdog operation
+ *
+ * Sets the pause signal to stop the watchdog timing
+ *
+ * @param dev Pointer to the device structure
+ * @param channel_id Channel identifier
+ */
+int intel_adsp_watchdog_pause(const struct device *dev, const int channel_id)
+{
+	const struct intel_adsp_wdt_dev_cfg *const dev_config = dev->config;
+
+	if (channel_id >= CONFIG_MP_MAX_NUM_CPUS) {
+		return -EINVAL;
+	}
+
+	intel_adsp_wdt_pause(dev_config->base, channel_id);
+	return 0;
+}
+
+/**
+ * @brief Resume watchdog operation
+ *
+ * Clears the pause signal to resume the watchdog timing
+ *
+ * @param dev Pointer to the device structure
+ * @param channel_id Channel identifier
+ */
+int intel_adsp_watchdog_resume(const struct device *dev, const int channel_id)
+{
+	const struct intel_adsp_wdt_dev_cfg *const dev_config = dev->config;
+
+	if (channel_id >= CONFIG_MP_MAX_NUM_CPUS) {
+		return -EINVAL;
+	}
+
+	intel_adsp_wdt_resume(dev_config->base, channel_id);
+	return 0;
+}
+
+static const struct wdt_driver_api intel_adsp_wdt_api = {
+	.setup = intel_adsp_wdt_setup,
+	.disable = dw_wdt_disable,
+	.install_timeout = intel_adsp_wdt_install_timeout,
+	.feed = intel_adsp_wdt_feed,
+};
+
+#if !(DT_NODE_HAS_PROP(DEV_NODE, clock_frequency) || DT_NODE_HAS_PROP(DEV_NODE, clocks))
+#error Clock frequency not configured!
+#endif
+
+static const struct intel_adsp_wdt_dev_cfg wdt_intel_adsp_config = {
+	.base = DT_REG_ADDR(DEV_NODE),
+	COND_CODE_1(DT_NODE_HAS_PROP(DEV_NODE, clock_frequency),
+		    (.clk_freq = DT_PROP(DEV_NODE, clock_frequency)),
+		    (.clk_freq = DT_PROP_BY_PHANDLE(DEV_NODE, clocks, clock_frequency))
+	),
+};
+
+static struct intel_adsp_wdt_dev_data wdt_intel_adsp_data;
+
+DEVICE_DT_DEFINE(DEV_NODE, &intel_adsp_wdt_init, NULL, &wdt_intel_adsp_data, &wdt_intel_adsp_config,
+		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &intel_adsp_wdt_api);

--- a/drivers/watchdog/wdt_intel_adsp.h
+++ b/drivers/watchdog/wdt_intel_adsp.h
@@ -1,0 +1,167 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * Author: Adrian Warecki <adrian.warecki@intel.com>
+ */
+
+#ifndef ZEPHYR_DRIVERS_WATCHDOG_WDT_INTEL_ADSP_H_
+#define ZEPHYR_DRIVERS_WATCHDOG_WDT_INTEL_ADSP_H_
+
+/*
+ * Get register offset for core
+ */
+#define DSPBRx_OFFSET(x)	(0x0020 * (x))
+
+/*
+ * DSPCxWDTCS
+ * DSP Core Watch Dog Timer Control & Status
+ *
+ * Offset: 04h
+ * Block: DSPBRx
+ *
+ * This register controls the DSP Core watch dog timer policy.
+ */
+#define DSPCxWDTCS		0x0004
+
+/*
+ * Pause Code
+ * type: WO, rst: 00b, rst domain: nan
+ *
+ * FW write 76h as the code to set the PAUSED bit. Other value are ignored and has no effect.
+ */
+#define DSPCxWDTCS_PCODE	GENMASK(7, 0)
+#define DSPCxWDTCS_PCODE_VALUE	0x76
+
+/*
+ * Paused
+ * type: RW/1C, rst: 0b, rst domain: DSPLRST
+ *
+ * When set, it pauses the watch dog timer.  Set when 76h is written to the PCODE
+ * field.  Clear when FW writes a 1 to the bit.
+ */
+#define DSPCxWDTCS_PAUSED	BIT(8)
+
+/*
+ * Second Time Out Reset Enable
+ * type: RW/1S, rst: 0b, rst domain: DSPLRST
+ *
+ * When set, it allow the DSP Core reset to take place upon second time out of the
+ * watch dog timer. Clear when DSPCCTL.CPA = 0.  Set when FW writes a 1 to the bit.
+ */
+#define DSPCxWDTCS_STORE	BIT(9)
+
+/*
+ * DSPCxWDTIPPTR
+ * DSP Core Watch Dog Timer IP Pointer
+ *
+ * Offset: 08h
+ * Block: DSPBRx
+ *
+ * This register provides the pointer to the DSP Core watch dog timer IP registers.
+ */
+#define DSPCxWDTIPPTR		0x0008
+
+/*
+ * IP Pointer
+ * type: RO, rst: 07 8300h + 100h * x, rst domain: nan
+ *
+ * This field contains the offset to the IP.
+ */
+#define DSPCxWDTIPPTR_PTR	GENMASK(20, 0)
+
+/*
+ * IP Version
+ * type: RO, rst: 000b, rst domain: nan
+ *
+ * This field indicates the version of the IP.
+ */
+#define DSPCxWDTIPPTR_VER	GENMASK(23, 21)
+
+/**
+ * @brief Set pause signal
+ *
+ * Sets the pause signal to stop the watchdog timing
+ *
+ * @param base Device base address.
+ * @param core Core ID
+ */
+static inline void intel_adsp_wdt_pause(uint32_t base, const uint32_t core)
+{
+	const uint32_t reg_addr = base + DSPCxWDTCS + DSPBRx_OFFSET(core);
+	uint32_t control;
+
+	control = sys_read32(reg_addr);
+	control &= DSPCxWDTCS_STORE;
+	control |= FIELD_PREP(DSPCxWDTCS_PCODE, DSPCxWDTCS_PCODE_VALUE);
+	sys_write32(control, reg_addr);
+}
+
+/**
+ * @brief Clear pause signal
+ *
+ * Clears the pause signal to resume the watchdog timing
+ *
+ * @param base Device base address.
+ * @param core Core ID
+ */
+static inline void intel_adsp_wdt_resume(uint32_t base, const uint32_t core)
+{
+	const uint32_t reg_addr = base + DSPCxWDTCS + DSPBRx_OFFSET(core);
+	uint32_t control;
+
+	control = sys_read32(reg_addr);
+	control &= DSPCxWDTCS_STORE;
+	control |= DSPCxWDTCS_PAUSED;
+	sys_write32(control, reg_addr);
+}
+
+/**
+ * @brief Second Time Out Reset Enable
+ *
+ * When set, it allow the DSP Core reset to take place upon second time out of the watchdog timer.
+ *
+ * @param base Device base address.
+ * @param core Core ID
+ */
+static inline void intel_adsp_wdt_reset_set(uint32_t base, const uint32_t core, const bool enable)
+{
+	sys_write32(enable ? DSPCxWDTCS_STORE : 0, base + DSPCxWDTCS + DSPBRx_OFFSET(core));
+}
+
+/*
+ * Second Time Out Reset Enable
+ * type: RW/1S, rst: 0b, rst domain: DSPLRST
+ *
+ * When set, it allow the DSP Core reset to take place upon second time out of the
+ * watch dog timer. Clear when DSPCCTL.CPA = 0.  Set when FW writes a 1 to the bit.
+ */
+#define DSPCxWDTCS_STORE BIT(9)
+
+/**
+ * @brief Get watchdog IP pointer for specified core.
+ *
+ * Returns the base address of the watchdog IP
+ *
+ * @param base Device base address.
+ * @param core Core ID
+ */
+static inline uint32_t intel_adsp_wdt_pointer_get(uint32_t base, const uint32_t core)
+{
+	return FIELD_GET(DSPCxWDTIPPTR_PTR, sys_read32(base + DSPCxWDTIPPTR + DSPBRx_OFFSET(core)));
+}
+
+/**
+ * @brief Get watchdog version
+ *
+ * Returns the version of the watchdog IP
+ *
+ * @param base Device base address.
+ * @param core Core ID
+ */
+static inline uint32_t intel_adsp_wdt_version_get(uint32_t base, const uint32_t core)
+{
+	return FIELD_GET(DSPCxWDTIPPTR_VER, sys_read32(base + DSPCxWDTIPPTR + DSPBRx_OFFSET(core)));
+}
+
+#endif /* ZEPHYR_DRIVERS_WATCHDOG_WDT_INTEL_ADSP_H_ */

--- a/dts/bindings/watchdog/intel,adsp-watchdog.yaml
+++ b/dts/bindings/watchdog/intel,adsp-watchdog.yaml
@@ -1,0 +1,32 @@
+description: Intel ADSP Watchdog
+
+compatible: "intel,adsp-watchdog"
+
+include: base.yaml
+
+properties:
+  # This properties is also supported:
+  # interrupts:
+  # clocks:
+
+  reg:
+    required: true
+
+  clock-frequency:
+    type: int
+    description: |
+      Clock frequency used by counter in Hz. You can specify a frequency here or specify a clock
+      using the clocks propertie.
+
+  reset-pulse-length:
+    type: int
+    enum:
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
+      - 64
+      - 128
+      - 256
+    description: Duration of the reset pulse in clock cycles

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -510,32 +510,6 @@
 			interrupt-parent = <&ace_intc>;
 		};
 
-		watchdog0: watchdog@78300 {
-			compatible = "snps,designware-watchdog";
-			reg = <0x78300 0x100>;
-			interrupts = <8 0 0>;
-			interrupt-parent = <&core_intc>;
-			clock-frequency = <32768>;
-			reset-pulse-length = <2>;
-			status = "okay";
-		};
-
-		watchdog1: watchdog@78400 {
-			compatible = "snps,designware-watchdog";
-			reg = <0x78400 0x100>;
-			clock-frequency = <32768>;
-			reset-pulse-length = <2>;
-			status = "okay";
-		};
-
-		watchdog2: watchdog@78500 {
-			compatible = "snps,designware-watchdog";
-			reg = <0x78500 0x100>;
-			clock-frequency = <32768>;
-			reset-pulse-length = <2>;
-			status = "okay";
-		};
-
 		/* This is actually an array of per-core designware
 		 * controllers, but the special setup and extra
 		 * masking layer makes it easier for MTL to handle
@@ -587,6 +561,21 @@
 			dma-buf-size-alignment = <4>;
 			dma-copy-alignment = <4>;
 			power-domain = <&io0_domain>;
+			status = "okay";
+		};
+
+		/* This is actually an array of per-core designware
+		 * watchdogs, but the special setup and extra
+		 * masking layer makes it easier for MTL to handle
+		 * this internally.
+		 */
+		adsp_watchdog: adsp_watchdog@178D40 {
+			compatible = "intel,adsp-watchdog";
+			reg = <0x178D40 0x60>;
+			interrupts = <8 0 0>;
+			interrupt-parent = <&core_intc>;
+			clock-frequency = <32768>;
+			reset-pulse-length = <2>;
 			status = "okay";
 		};
 

--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_watchdog.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_watchdog.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * Author: Adrian Warecki <adrian.warecki@intel.com>
+ */
+
+#ifndef ZEPHYR_SOC_INTEL_ADSP_WATCHDOG_H_
+#define ZEPHYR_SOC_INTEL_ADSP_WATCHDOG_H_
+
+/**
+ * @brief Pause watchdog operation
+ *
+ * Sets the pause signal to stop the watchdog timing
+ *
+ * @param dev Pointer to the device structure
+ * @param channel_id Channel identifier
+ */
+int intel_adsp_watchdog_pause(const struct device *dev, const int channel_id);
+
+/**
+ * @brief Resume watchdog operation
+ *
+ * Clears the pause signal to resume the watchdog timing
+ *
+ * @param dev Pointer to the device structure
+ * @param channel_id Channel identifier
+ */
+int intel_adsp_watchdog_resume(const struct device *dev, const int channel_id);
+
+#endif /* ZEPHYR_SOC_INTEL_ADSP_WATCHDOG_H_ */


### PR DESCRIPTION
Functions that can be used by other wdt_dw based drivers have been moved to `wdt_dw_common.c` . Added a new intel watchdog driver which can handle a multiple wdt_dw instances and can control the pause signal. Switched ace platform to the new watchdog driver. 

EDIT: see commit messages for more details.