### PR TITLE
Bluetooth: Controller: Fix extended scanning for BT_CTLR_LOW_LAT

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -674,7 +674,7 @@ static void isr_rx(void *param)
 	uint8_t crc_ok;
 	uint8_t rl_idx;
 	bool has_adva;
-	int err;
+	int err = 0U;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
 		lll_prof_latency_capture();
@@ -767,7 +767,12 @@ static void isr_rx(void *param)
 	}
 
 isr_rx_do_close:
-	radio_isr_set(isr_done, lll);
+	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) && (err == -ECANCELED)) {
+		radio_isr_set(isr_done_cleanup, lll);
+	} else {
+		radio_isr_set(isr_done, lll);
+	}
+
 	radio_disable();
 }
 


### PR DESCRIPTION
Fix Extended Scanning support for BT_CTLR_LOW_LAT variant of the Controller implementation by closing the scan window for every ADV_EXT_IND PDU received that that ULL_LOW context is enabled back and ticker job can process the request to start auxiliary PDU reception. Without the change the ticker job would only run at the end of the scan window that caused the auxiliary scan prepare to assert due to delayed ticker timeout expiry callback.