### PR TITLE
net: websocket: Make sure the mbedtls_sha1 function is build in

### DIFF
--- a/subsys/net/lib/websocket/Kconfig
+++ b/subsys/net/lib/websocket/Kconfig
@@ -9,6 +9,7 @@ menuconfig WEBSOCKET_CLIENT
 	select HTTP_CLIENT
 	select MBEDTLS
 	select BASE64
+	select MBEDTLS_MAC_SHA1_ENABLED if MBEDTLS_BUILTIN
 	select EXPERIMENTAL
 	help
 	  Enable Websocket client library.


### PR DESCRIPTION
In the header the websocket protocol needs a SHA1 hash. This is implemented using the mbedtls_sha1 function. Select the option PSA_WANT_ALG_SHA_1 from the Kconfig of websocket to ensure this function is build in.