### PR TITLE
test: timer_jitter_drift move assert

### DIFF
--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -171,11 +171,13 @@ ZTEST(timer_jitter_drift, test_jitter_drift)
 		TC_PRINT("test timer period (%u us) is smaller than "
 			 "system tick period (%u us):\n",
 			 CONFIG_TIMER_TEST_PERIOD, k_ticks_to_us_near32(1));
-		TC_PRINT("  expected period drift %.8g us\n", expected_period_drift);
 		zassert_true(expected_period_drift != 0.0);
-	} else {
-		zassert_true(expected_period_drift == 0.0);
 	}
+
+	if (expected_period_drift != 0.0) {
+		TC_PRINT("expected period drift %.8g us\n", expected_period_drift);
+	}
+
 	TC_PRINT("period duration statistics for %d samples (%u rollovers):\n",
 		 CONFIG_TIMER_TEST_SAMPLES - periodic_rollovers, periodic_rollovers);
 	TC_PRINT("  expected: %d us,       \t%f cycles\n",


### PR DESCRIPTION
On hardware with 32.768KHz clocks, or clocks that don't evenly divide by the period, the periodic drift is non-zero. This is valid and should not be asserted on.


On nrf52840 prior to this fix I got the same assertion shown in #55136

Likely Fixes #55136