### PR TITLE
doc: ztest: various fixes

### DIFF
--- a/doc/develop/test/ztest.rst
+++ b/doc/develop/test/ztest.rst
@@ -10,8 +10,9 @@ test structure.
 The framework can be used in two ways, either as a generic framework for
 integration testing, or for unit testing specific modules.
 
-To enable the latest APIs of Ztest simply set :kconfig:option:`CONFIG_ZTEST_NEW_API=y`. The legacy
-APIs will soon be deprecated and eventually removed.
+To enable support for the latest Ztest API, set
+:kconfig:option:`CONFIG_ZTEST_NEW_API` to ``y``. There is also a legacy API
+that is deprecated and will eventually be removed.
 
 Creating a test suite
 *********************
@@ -32,17 +33,19 @@ accepts the following arguments:
 * :c:type:`ztest_suite_teardown_t` - An optional teardown function which will run at the end of
   all the tests in the suite.
 
-Below is an example of a test suite using a predicate::
+Below is an example of a test suite using a predicate:
 
-    #include <zephyr/ztest.h>
-    #include "test_state.h"
+.. code-block:: C
 
-    static bool predicate(const void *global_state)
-    {
-      return ((const struct test_state*)global_state)->x == 5;
-    }
+   #include <zephyr/ztest.h>
+   #include "test_state.h"
 
-    ZTEST_SUITE(alternating_suite, predicate, NULL, NULL, NULL, NULL);
+   static bool predicate(const void *global_state)
+   {
+   	return ((const struct test_state*)global_state)->x == 5;
+   }
+
+   ZTEST_SUITE(alternating_suite, predicate, NULL, NULL, NULL, NULL);
 
 Adding tests to a suite
 ***********************
@@ -65,46 +68,48 @@ Test fixtures
 
 Test fixtures can be used to help simplify repeated test setup operations. In many cases, tests in
 the same suite will require some initial setup followed by some form of reset between each test.
-This is achieved via fixtures in the following way::
+This is achieved via fixtures in the following way:
 
-    #include <zephyr/ztest.h>
+.. code-block:: C
 
-    struct my_suite_fixture {
-      size_t max_size;
-      size_t size;
-      uint8_t buff[1];
-    };
+   #include <zephyr/ztest.h>
 
-    static void *my_suite_setup(void)
-    {
-      /* Allocate the fixture with 256 byte buffer */
-      struct my_suite_fixture *fixture = k_malloc(sizeof(struct my_suite_fixture) + 255);
+   struct my_suite_fixture {
+   	size_t max_size;
+   	size_t size;
+   	uint8_t buff[1];
+   };
 
-      zassume_not_null(fixture, NULL);
-      fixture->max_size = 256;
+   static void *my_suite_setup(void)
+   {
+   	/* Allocate the fixture with 256 byte buffer */
+   	struct my_suite_fixture *fixture = k_malloc(sizeof(struct my_suite_fixture) + 255);
 
-      return fixture;
-    }
+   	zassume_not_null(fixture, NULL);
+   	fixture->max_size = 256;
 
-    static void my_suite_before(void *f)
-    {
-      struct my_suite_fixture *fixture = (struct my_suite_fixture *)f;
-      memset(fixture->buff, 0, fixture->max_size);
-      fixture->size = 0;
-    }
+   	return fixture;
+   }
 
-    static void my_suite_teardown(void *f)
-    {
-      k_free(f);
-    }
+   static void my_suite_before(void *f)
+   {
+   	struct my_suite_fixture *fixture = (struct my_suite_fixture *)f;
+   	memset(fixture->buff, 0, fixture->max_size);
+   	fixture->size = 0;
+   }
 
-    ZTEST_SUITE(my_suite, NULL, my_suite_setup, my_suite_before, NULL, my_suite_teardown);
+   static void my_suite_teardown(void *f)
+   {
+   	k_free(f);
+   }
 
-    ZTEST_F(my_suite, test_feature_x)
-    {
-      zassert_equal(0, fixture->size);
-      zassert_equal(256, fixture->max_size);
-    }
+   ZTEST_SUITE(my_suite, NULL, my_suite_setup, my_suite_before, NULL, my_suite_teardown);
+
+   ZTEST_F(my_suite, test_feature_x)
+   {
+   	zassert_equal(0, fixture->size);
+   	zassert_equal(256, fixture->max_size);
+   }
 
 
 Advanced features
@@ -145,28 +150,28 @@ Test rules
 Test rules are a way to run the same logic for every test and every suite. There are a lot of cases
 where you might want to reset some state for every test in the binary (regardless of which suite is
 currently running). As an example, this could be to reset mocks, reset emulators, flush the UART,
-etc.
+etc.:
 
-  .. code-block:: C
+.. code-block:: C
 
-    #include <zephyr/fff.h>
-    #include <zephyr/ztest.h>
+   #include <zephyr/fff.h>
+   #include <zephyr/ztest.h>
 
-    #include "test_mocks.h"
+   #include "test_mocks.h"
 
-    DEFINE_FFF_GLOBALS;
+   DEFINE_FFF_GLOBALS;
 
-    DEFINE_FAKE_VOID_FUN(my_weak_func);
+   DEFINE_FAKE_VOID_FUN(my_weak_func);
 
-    static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
-    {
-      ARG_UNUSED(test);
-      ARG_UNUSED(fixture);
+   static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
+   {
+   	ARG_UNUSED(test);
+   	ARG_UNUSED(fixture);
 
-      RESET_FAKE(my_weak_func);
-    }
+   	RESET_FAKE(my_weak_func);
+   }
 
-    ZTEST_RULE(fff_reset_rule, fff_reset_rule_before, NULL);
+   ZTEST_RULE(fff_reset_rule, fff_reset_rule_before, NULL);
 
 A custom ``test_main``
 ======================
@@ -177,31 +182,33 @@ state that the tests depend on and that state either cannot be replicated or is 
 replicate without starting the process over. For example, one such state could be a power sequence.
 Assuming there's a board with several steps in the power-on sequence a test suite can be written
 using the ``predicate`` to control when it would run. In that case, the :c:func:`test_main`
-function can be written as following::
+function can be written as follows:
 
-    #include <zephyr/ztest.h>
+.. code-block:: C
 
-    #include "my_test.h"
+   #include <zephyr/ztest.h>
 
-    void test_main(void)
-    {
-      struct power_sequence_state state;
+   #include "my_test.h"
 
-      /* Only suites that use a predicate checking for phase == PWR_PHASE_0 will run. */
-      state.phase = PWR_PHASE_0;
-      ztest_run_all(&state);
+   void test_main(void)
+   {
+        struct power_sequence_state state;
 
-      /* Only suites that use a predicate checking for phase == PWR_PHASE_1 will run. */
-      state.phase = PWR_PHASE_1;
-      ztest_run_all(&state);
+        /* Only suites that use a predicate checking for phase == PWR_PHASE_0 will run. */
+        state.phase = PWR_PHASE_0;
+        ztest_run_all(&state);
 
-      /* Only suites that use a predicate checking for phase == PWR_PHASE_2 will run. */
-      state.phase = PWR_PHASE_2;
-      ztest_run_all(&state);
+        /* Only suites that use a predicate checking for phase == PWR_PHASE_1 will run. */
+        state.phase = PWR_PHASE_1;
+        ztest_run_all(&state);
 
-      /* Check that all the suites in this binary ran at least once. */
-      ztest_verify_all_test_suites_ran();
-    }
+        /* Only suites that use a predicate checking for phase == PWR_PHASE_2 will run. */
+        state.phase = PWR_PHASE_2;
+        ztest_run_all(&state);
+
+        /* Check that all the suites in this binary ran at least once. */
+        ztest_verify_all_test_suites_ran();
+   }
 
 
 Quick start - Integration testing
@@ -211,15 +218,18 @@ A simple working base is located at :zephyr_file:`samples/subsys/testsuite/integ
 copy the files to ``tests/`` and edit them for your needs. The test will then
 be automatically built and run by the twister script. If you are testing
 the **bar** component of **foo**, you should copy the sample folder to
-``tests/foo/bar``. It can then be tested with::
+``tests/foo/bar``. It can then be tested with:
 
-    ./scripts/twister -s tests/foo/bar/test-identifier
+.. code-block:: console
 
+   ./scripts/twister -s tests/foo/bar/test-identifier
 
 In the example above ``tests/foo/bar`` signifies the path to the test and the
 ``test-identifier`` references a test defined in the :file:`testcase.yaml` file.
 
-To run all tests defined in a test project, run::
+To run all tests defined in a test project, run:
+
+.. code-block:: console
 
     ./scripts/twister -T tests/foo/bar/
 
@@ -265,19 +275,19 @@ should follow the guidelines below:
 * Test function names should be unique within the section or component being
   tested
 
+For example:
 
-An example can be seen below::
+.. code-block:: C
 
-    /**
-     * @brief Test Asserts
-     *
-     * This test verifies the zassert_true macro.
-     */
-    ZTEST(my_suite, test_assert)
-    {
-            zassert_true(1, "1 was false");
-    }
-
+   /**
+    * @brief Test Asserts
+    *
+    * This test verifies the zassert_true macro.
+    */
+   ZTEST(my_suite, test_assert)
+   {
+           zassert_true(1, "1 was false");
+   }
 
 Listing Tests
 =============
@@ -289,10 +299,11 @@ test projects or a subset of them, and can generate reports on a granular
 level, i.e. if cases have passed or failed or if they were blocked or skipped.
 
 Twister parses the source files looking for test case names, so you
-can list all kernel test cases, for example, by entering::
+can list all kernel test cases, for example, by running:
 
-        twister --list-tests -T tests/kernel
+.. code-block:: console
 
+   twister --list-tests -T tests/kernel
 
 Skipping Tests
 ==============
@@ -304,27 +315,29 @@ the list of tests is extracted from the code, adding
 conditionals inside the test suite is sub-optimal.  Tests that need
 to be skipped for a certain platform or feature need to explicitly
 report a skip using :c:func:`ztest_test_skip` or :c:macro:`Z_TEST_SKIP_IFDEF`. If the test runs,
-it needs to report either a pass or fail.  For example::
+it needs to report either a pass or fail.  For example:
 
-        #ifdef CONFIG_TEST1
-	ZTEST(common, test_test1)
-	{
-	  zassert_true(1, "true");
-	}
-        #else
-	ZTEST(common, test_test1)
-	{
-		ztest_test_skip();
-	}
-	#endif
+.. code-block:: C
 
-        ZTEST(common, test_test2)
-        {
-          Z_TEST_SKIP_IFDEF(CONFIG_BUGxxxxx);
-          zassert_equal(1, 0, NULL);
-        }
+   #ifdef CONFIG_TEST1
+   ZTEST(common, test_test1)
+   {
+   	zassert_true(1, "true");
+   }
+   #else
+   ZTEST(common, test_test1)
+   {
+   	ztest_test_skip();
+   }
+   #endif
 
-        ZTEST_SUITE(common, NULL, NULL, NULL, NULL, NULL);
+   ZTEST(common, test_test2)
+   {
+   	Z_TEST_SKIP_IFDEF(CONFIG_BUGxxxxx);
+   	zassert_equal(1, 0, NULL);
+   }
+
+   ZTEST_SUITE(common, NULL, NULL, NULL, NULL, NULL);
 
 Quick start - Unit testing
 **************************
@@ -445,7 +458,7 @@ Assertions
 These macros will instantly fail the test if the related assertion fails.
 When an assertion fails, it will print the current file, line and function,
 alongside a reason for the failure and an optional message. If the config
-option:`CONFIG_ZTEST_ASSERT_VERBOSE` is 0, the assertions will only print the
+:kconfig:option:`CONFIG_ZTEST_ASSERT_VERBOSE` is 0, the assertions will only print the
 file and line numbers, reducing the binary size of the test.
 
 Example output for a failed macro from
@@ -465,20 +478,24 @@ Expectations
 These macros will continue test execution if the related expectation fails and subsequently fail the
 test at the end of its execution.  When an expectation fails, it will print the current file, line,
 and function, alongside a reason for the failure and an optional message but continue executing the
-test. If the config option:`CONFIG_ZTEST_ASSERT_VERBOSE` is 0, the expectations will only print the
+test. If the config :kconfig:option:`CONFIG_ZTEST_ASSERT_VERBOSE` is 0, the expectations will only print the
 file and line numbers, reducing the binary size of the test.
 
-Example output for a failed macro from::
+For example, if the following expectations fail:
 
-  zexpect_equal(buf->ref, 2, "Invalid refcount");
-  zexpect_equal(buf->ref, 1337, "Invalid refcount");
+.. code-block:: C
 
-.. code-block::none
+   zexpect_equal(buf->ref, 2, "Invalid refcount");
+   zexpect_equal(buf->ref, 1337, "Invalid refcount");
 
-    START - test_get_single_buffer
-        Expectation failed at main.c:62: test_get_single_buffer: Invalid refcount (buf->ref not equal to 2)
-        Expectation failed at main.c:63: test_get_single_buffer: Invalid refcount (buf->ref not equal to 1337)
-     FAIL - test_get_single_buffer in 0.0 seconds
+The output will look something like:
+
+.. code-block:: none
+
+   START - test_get_single_buffer
+       Expectation failed at main.c:62: test_get_single_buffer: Invalid refcount (buf->ref not equal to 2)
+       Expectation failed at main.c:63: test_get_single_buffer: Invalid refcount (buf->ref not equal to 1337)
+    FAIL - test_get_single_buffer in 0.0 seconds
 
 .. doxygengroup:: ztest_expect
 
@@ -488,7 +505,7 @@ Assumptions
 These macros will instantly skip the test or suite if the related assumption fails.
 When an assumption fails, it will print the current file, line, and function,
 alongside a reason for the failure and an optional message. If the config
-option:`CONFIG_ZTEST_ASSERT_VERBOSE` is 0, the assumptions will only print the
+:kconfig:option:`CONFIG_ZTEST_ASSERT_VERBOSE` is 0, the assumptions will only print the
 file and line numbers, reducing the binary size of the test.
 
 Example output for a failed macro from
@@ -513,10 +530,12 @@ Ztress
 Mocking via FFF
 ===============
 
-Zephyr has integrated with FFF for mocking. See `FFF`_ for documentation. To use it, use the
-following in your source::
+Zephyr has integrated with FFF for mocking. See `FFF`_ for documentation. To use it,
+include the relevant header:
 
-    #include <zephyr/fff.h>
+.. code-block:: C
+
+   #include <zephyr/fff.h>
 
 Zephyr provides several FFF-based fake drivers which can be used as either stubs or mocks. Fake
 driver instances are configured via :ref:`devicetree` and :ref:`kconfig`. See the following
@@ -537,11 +556,13 @@ Add the line ``zephyr_include_directories(my_folder)`` to
 your project's :file:`CMakeLists.txt` to let Zephyr find your header file during builds.
 
 See the file :zephyr_file:`subsys/testsuite/include/tc_util.h` to see which macros and/or defines can be overridden.
-These will be surrounded by blocks such as::
+These will be surrounded by blocks such as:
 
-        #ifndef SOMETHING
-        #define SOMETHING <default implementation>
-        #endif /* SOMETHING */
+.. code-block:: C
+
+   #ifndef SOMETHING
+   #define SOMETHING <default implementation>
+   #endif /* SOMETHING */
 
 .. _ztest_shuffle:
 


### PR DESCRIPTION
This page is:

- using literal blocks [1] where it should be using code blocks [2], which won't produce the desired results [3]

- missing required whitespace between code block directives and their pygments syntax arguments [4]

  In other words, this:

    .. code-block::foo

  should be:

    .. code-block:: foo

- using an incorrect syntax:

  ```
  option:`CONFIG_FOO`
  ```

  to refer to Kconfig options; this should be:

  ```
  :kconfig:option:`CONFIG_FOO`
  ```

Fix these issues so we get syntax-highlighted code blocks in the correct pygments highlight syntax.

Adjust directive content indentation to match the usual .rst style and make some grammar tweaks as well.

[1] https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks

[2] https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block

[3] Use of literal blocks can produce the same results if there is a
    consistent choice of highlight language specified for the file, but
    this file is intermixing code blocks that should be highlighted as
    either C or shell commands, so there is no single choice of
    highlight syntax that works.

[4] https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#directives