### PR TITLE
usb: device_next: use consistent nil descriptor name

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -222,7 +222,9 @@ struct usbd_class_api {
 struct usbd_class_data {
 	/** Pointer to USB device stack context structure */
 	struct usbd_contex *uds_ctx;
-	/** Terminated descriptor for class implementation */
+	/** Pointer to a class implementation descriptor that should end with
+	 *  a nil descriptor (bLength = 0 and bDescriptorType = 0).
+	 */
 	void *desc;
 	/** Supported vendor request table, can be NULL */
 	const struct usbd_cctx_vendor_req *v_reqs;

--- a/subsys/usb/device_next/class/loopback.c
+++ b/subsys/usb/device_next/class/loopback.c
@@ -41,7 +41,7 @@ struct loopback_desc {
 	struct usb_if_descriptor if3;
 	struct usb_ep_descriptor if3_out_ep;
 	struct usb_ep_descriptor if3_in_ep;
-	struct usb_desc_header term_desc;
+	struct usb_desc_header nil_desc;
 } __packed;
 
 #define DEFINE_LOOPBACK_DESCRIPTOR(x, _)			\
@@ -199,7 +199,7 @@ static struct loopback_desc lb_desc_##x = {			\
 	},							\
 								\
 	/* Termination descriptor */				\
-	.term_desc = {						\
+	.nil_desc = {						\
 		.bLength = 0,					\
 		.bDescriptorType = 0,				\
 	},							\

--- a/subsys/usb/device_next/usbd_shell.c
+++ b/subsys/usb/device_next/usbd_shell.c
@@ -34,7 +34,7 @@ struct foobaz_iface_desc {
 	struct usb_if_descriptor if1;
 	struct usb_ep_descriptor if1_out_ep;
 	struct usb_ep_descriptor if1_in_ep;
-	struct usb_desc_header term_desc;
+	struct usb_desc_header nil_desc;
 } __packed;
 
 static struct foobaz_iface_desc foobaz_desc = {
@@ -81,7 +81,7 @@ static struct foobaz_iface_desc foobaz_desc = {
 	},
 
 	/* Termination descriptor */
-	.term_desc = {
+	.nil_desc = {
 		.bLength = 0,
 		.bDescriptorType = 0,
 	},


### PR DESCRIPTION
Use a consistent nil_desc name for the descriptor that terminates a class (function) descriptor.