### PR TITLE
drivers: sensor: th02: Handle unsupported channels

### DIFF
--- a/drivers/sensor/th02/th02.c
+++ b/drivers/sensor/th02/th02.c
@@ -110,10 +110,12 @@ static int th02_channel_get(const struct device *dev,
 		/* val = sample / 32 - 50 */
 		val->val1 = drv_data->t_sample / 32U - 50;
 		val->val2 = (drv_data->t_sample % 32) * (1000000 / 32);
-	} else {
+	} else if (chan == SENSOR_CHAN_HUMIDITY) {
 		/* val = sample / 16 -24 */
 		val->val1 = drv_data->rh_sample / 16U - 24;
 		val->val2 = (drv_data->rh_sample % 16) * (1000000 / 16);
+	} else {
+		return -ENOTSUP;
 	}
 
 	return 0;


### PR DESCRIPTION
Fixed th02_channel_get() code to return -ENOTSUP when the channel is not
supported.
Fixes #55160.
