### PR TITLE
MAINTAINERS: Renesas

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2151,7 +2151,7 @@ Renesas R-Car Platforms:
     - boards/arm/rcar_*/
     - drivers/*/*rcar*
     - drivers/clock_control/*cpg_mssr*
-    - dts/arm/renesas/
+    - dts/arm/renesas/gen3/
     - dts/bindings/*/*rcar*
     - soc/arm/renesas_rcar/
   labels:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2141,6 +2141,23 @@ nRF Platforms:
   labels:
     - "platform: nRF"
 
+Renesas SmartBond Platforms:
+  status: maintained
+  maintainers:
+    - andrzej-kaczmarek
+    - blauret
+  files:
+    - boards/arm/da14*/
+    - drivers/*/*smartbond*
+    - dts/arm/renesas/smartbond/
+    - dts/bindings/*/renesas,smartbond*
+    - soc/arm/renesas_smartbond/
+  labels:
+    - "platform: Renesas SmartBond"
+  description: >-
+    Renesas SmartBond SOCs, dts files, and related drivers. Renesas boards based
+    on SmartBond SoCs.
+
 Renesas R-Car Platforms:
   status: maintained
   maintainers:


### PR DESCRIPTION
I noticed that all new PRs for the Smartbond SoCs were wrongly assigned to the R-Car platform therefore I am proposing the following commits.

- rcar: limit dts scope to gen3 folder
  - After the introduction of the Renesas Smartbond family the scope of dts
    files needs to be limited to the R-Car subfolder.
- add new MAINTAINERS entry for Renesas (smartbond)
  - Renesas platform only had an entry for the maintainer of the HAL, but not for Zephyr drivers etc.

As @andrzej-kaczmarek is the maintainer of the HAL I assume that he is also maintaining the zephyr side, please let me know if this is no longer the case.
See also [HAL module request](https://github.com/zephyrproject-rtos/zephyr/issues/46721), [introduction of platform](https://github.com/zephyrproject-rtos/zephyr/pull/46720), and [PR Renesas HAL maintainer](https://github.com/zephyrproject-rtos/zephyr/pull/50430)