### PR TITLE
Bluetooth: host: clear ATT pending flag on failure to send

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -255,6 +255,7 @@ static int chan_send(struct bt_att_chan *chan, struct net_buf *buf)
 		 */
 		err = bt_l2cap_chan_send_cb(&chan->chan.chan, buf, chan_cb(buf), data);
 		if (err < 0) {
+			atomic_clear_bit(chan->flags, ATT_PENDING_SENT);
 			return err;
 		}
 

--- a/tests/bluetooth/bsim/host/gatt/notify_multiple/src/gatt_server_test.c
+++ b/tests/bluetooth/bsim/host/gatt/notify_multiple/src/gatt_server_test.c
@@ -172,8 +172,8 @@ static void test_main(void)
 
 	k_sleep(K_MSEC(1000));
 
-	if (num_notifications_sent > NOTIFICATION_COUNT) {
-		FAIL("The notify callback is called more than expected\n");
+	if (num_notifications_sent != NOTIFICATION_COUNT) {
+		FAIL("Unexpected notification callback value\n");
 	}
 
 	PASS("GATT server passed\n");


### PR DESCRIPTION
`ATT_PENDING_SENT` wasn't cleared when L2CAP reported an error when sending the packet. This resulted in the channel being unusable for ever, since we only clear that bit on a response (that will never be sent).

Found when setting `CONFIG_SYS_CLOCK_TICKS_PER_SEC=32768` in the `notify_multiple` test. The kicker was the bug didn't manifest when EATT wasn't enabled:
- we were queuing two unsubscribes back to back in the test
- on UATT we have to wait for a req-rsp pair before enqueuing a new one
- on UATT we only have one channel anyways