### PR TITLE
drivers: sensor: mcux qdec single-phase option

### DIFF
--- a/dts/bindings/sensor/nxp,mcux-qdec.yaml
+++ b/dts/bindings/sensor/nxp,mcux-qdec.yaml
@@ -21,6 +21,13 @@ properties:
       This is a number that is used to determine how many revolutions
       were done based on the current counter's value.
 
+  single-phase-mode:
+    type: boolean
+    description: |
+      Bypass the quadrature decoder. A positive transition of the PHASEA input
+      generates a count signal. The PHASEB input and the REV bit control the
+      counter direction.
+
   xbar:
     type: phandle
     required: true

--- a/include/zephyr/drivers/sensor/qdec_mcux.h
+++ b/include/zephyr/drivers/sensor/qdec_mcux.h
@@ -12,6 +12,8 @@
 enum sensor_attribute_qdec_mcux {
 	/* Number of counts per revolution */
 	SENSOR_ATTR_QDEC_MOD_VAL = SENSOR_ATTR_PRIV_START,
+	/* Single phase counting */
+	SENSOR_ATTR_QDEC_ENABLE_SINGLE_PHASE,
 };
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_QDEC_MCUX_H_ */


### PR DESCRIPTION
Add binding and sensor attribute to allow single phase mode where only one signal is required from the encoder.
The signal must be connected to Phase A input.