### PR TITLE
MAINTAINERS: Add larsgk to Bluetooth Audio

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -268,6 +268,7 @@ Bluetooth Audio:
     - asbjornsabo
     - fredrikdanebjer
     - kruithofa
+    - larsgk
   files:
     - subsys/bluetooth/audio/
     - include/zephyr/bluetooth/audio/


### PR DESCRIPTION
larsgk is collaborating on Bluetooth Audio.

Lars had contributed the following PRs
https://github.com/zephyrproject-rtos/zephyr/pull/54616
https://github.com/zephyrproject-rtos/zephyr/pull/53803
https://github.com/zephyrproject-rtos/zephyr/pull/52672
https://github.com/zephyrproject-rtos/zephyr/pull/46923
https://github.com/zephyrproject-rtos/zephyr/pull/46376

and is attending the weekly LE Audio Zephyr meetings