### PR TITLE
usb: device: fix k_usleep in ISR context in set_endpoint

### DIFF
--- a/subsys/usb/device/usb_device.c
+++ b/subsys/usb/device/usb_device.c
@@ -570,7 +570,9 @@ static bool set_endpoint(const struct usb_ep_descriptor *ep_desc)
 	if (ep_bm & usb_dev.ep_bm) {
 		reset_endpoint(ep_desc);
 		/* allow any canceled transfers to terminate */
-		k_usleep(150);
+		if (!k_is_in_isr()) {
+			k_usleep(150);
+		}
 	}
 
 	ret = usb_dc_ep_configure(&ep_cfg);


### PR DESCRIPTION
set_device can be called in interrupt context at least with stm32u5 soc. Calling k_usleep from there causes the isr to run forever.