### PR TITLE
devicetree: fix DT_PROP_HAS_NAME doxygen example

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -701,8 +701,8 @@
  * Example usage:
  *
  * @code{.c}
- *     DT_PROP_HAS_NAME(nx, foos, event)    // 1
- *     DT_PROP_HAS_NAME(nx, foos, failure)  // 0
+ *     DT_PROP_HAS_NAME(DT_NODELABEL(nx), foos, event)    // 1
+ *     DT_PROP_HAS_NAME(DT_NODELABEL(nx), foos, failure)  // 0
  * @endcode
  *
  * @param node_id node identifier


### PR DESCRIPTION
The node identifier is missing a DT_NODELABEL() around the node label.