### PR TITLE
drivers: serial: uart_rtt: fix multi-channel

### DIFF
--- a/drivers/serial/uart_rtt.c
+++ b/drivers/serial/uart_rtt.c
@@ -203,6 +203,7 @@ static const struct uart_driver_api uart_rtt_driver_api = {
 		.up_size = sizeof(uart_rtt##idx##_tx_buf),		    \
 		.down_buffer = uart_rtt##idx##_rx_buf,			    \
 		.down_size = sizeof(uart_rtt##idx##_rx_buf),		    \
+		.channel = idx,						    \
 	}
 
 #define UART_RTT_INIT(idx, config)					      \


### PR DESCRIPTION
Populate the `channel` index when constructing configuration structs for secondary RTT channels. Originally missed in #27704.

Fixes #54955.