### PR TITLE
bindings: add raspberrypi gpio header

### DIFF
--- a/boards/arm/wio_terminal/raspberrypi_40pins_connector.dtsi
+++ b/boards/arm/wio_terminal/raspberrypi_40pins_connector.dtsi
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Joel Guittet
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	raspberrypi_header: raspberrypi_header {
+		compatible = "raspberrypi-40pins-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &porta 17 0>,	/* I2C1_SDA */
+			   <1 0 &porta 16 0>,	/* I2C1_SCL */
+			   <2 0 &portb 14 0>,	/* GPCLK0 */
+			   <3 0 &portb 26 0>,	/* TXD */
+			   <4 0 &portb 27 0>,	/* RXD */
+			   <5 0 &porta 2 0>,	/* DAC0 */
+			   <6 0 &portb 16 0>,	/* I2S_BLCK */
+			   <7 0 &portb 8 0>,	/* A0/D0 */
+			   <8 0 &portb 9 0>,	/* A1/D1 */
+			   <9 0 &porta 7 0>,	/* A2/D2 */
+			   <10 0 &portb 4 0>,	/* A3/D3 */
+			   <11 0 &portb 2 0>,	/* SPI_MOSI */
+			   <12 0 &portb 0 0>,	/* SPI_MISO */
+			   <13 0 &portb 5 0>,	/* A4/D4 */
+			   <14 0 &portb 3 0>,	/* SPI_SCK */
+			   <15 0 &portb 1 0>,	/* SPI_CS */
+			   <16 0 &porta 5 0>,	/* DAC1 */
+			   <17 0 &porta 13 0>,	/* I2C0_SDA */
+			   <18 0 &porta 12 0>,	/* I2C0_SCL */
+			   <19 0 &portb 12 0>,	/* GPCLK1 */
+			   <20 0 &portb 13 0>,	/* GPCLK2 */
+			   <21 0 &portb 6 0>,	/* A5/D5 */
+			   <22 0 &porta 4 0>,	/* A6/D6 */
+			   <23 0 &porta 20 0>,	/* I2S_LRCLK */
+			   <24 0 &portb 7 0>,	/* A7/D7 */
+			   <25 0 &porta 6 0>,	/* A8/D8 */
+			   <26 0 &porta 21 0>,	/* I2S_SDIN */
+			   <27 0 &porta 22 0>;	/* I2S_SDOUT */
+	};
+};
+
+raspberrypi_serial: &sercom2 {};
+raspberrypi_i2c0: &sercom4 {};
+raspberrypi_i2c1: &sercom3 {};
+raspberrypi_spi: &sercom5 {};

--- a/boards/arm/wio_terminal/wio_terminal.dts
+++ b/boards/arm/wio_terminal/wio_terminal.dts
@@ -6,6 +6,7 @@
 /dts-v1/;
 #include <atmel/samd5xx19.dtsi>
 #include "wio_terminal-pinctrl.dtsi"
+#include "raspberrypi_40pins_connector.dtsi"
 #include <zephyr/dt-bindings/display/ili9xxx.h>
 
 / {

--- a/dts/bindings/gpio/raspberrypi-40pins-header.yaml
+++ b/dts/bindings/gpio/raspberrypi-40pins-header.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 Joel Guittet
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    GPIO pins exposed on Raspberry Pi 40-pin header.
+
+    The Raspberry Pi layout provides a 2x20 pins header.
+
+    This binding provides a nexus mapping for 28 pins as depicted below.
+
+        -  3V3                  5V               -
+        0  GPIO2/I2C1_SDA       5V               -
+        1  GPIO3/I2C1_SCL       GND              -
+        2  GPIO4                GPIO14/UART0_TXD 3
+        -  GND                  GPIO15/UART0_RXD 4
+        5  GPIO17               GPIO18           6
+        7  GPIO27               GND              -
+        8  GPIO22               GPIO23           9
+        -  3V3                  GPIO24           10
+        11 GPIO10/SPI0_MOSI     GND              -
+        12 GPIO9/SPI0_MISO      GPIO25           13
+        14 GPIO11/SPI0_SCLK     GPIO8/SPI0_CE0   15
+        -  GND                  GPIO7/SPI0_CE1   16
+        17 ID_SD/I2C0_SDA       ID_SC/I2C0_SCL   18
+        19 GPIO5                GND              -
+        20 GPIO6                GPIO12           21
+        22 GPIO13               GND              -
+        23 GPIO19               GPIO16           24
+        25 GPIO26               GPIO20           26
+        -  GND                  GPIO21           27
+
+
+compatible: "raspberrypi-40pins-header"
+
+include: [gpio-nexus.yaml, base.yaml]


### PR DESCRIPTION
Add binding support for Raspberry Pi header.

This will be used later for Wio Terminal board added with https://github.com/zephyrproject-rtos/zephyr/pull/54953.

This can be used later for other boards as well!