### PR TITLE
bindings: add grove gpio header

### DIFF
--- a/boards/arm/wio_terminal/grove_connectors.dtsi
+++ b/boards/arm/wio_terminal/grove_connectors.dtsi
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Joel Guittet
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	grove_header0: grove_header0 {
+		compatible = "grove-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &portb 8 0>,	/* A0/D0 */
+			   <1 0 &portb 9 0>;	/* A1/D1 */
+	};
+	grove_header1: grove_header1 {
+		compatible = "grove-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &porta 16 0>,	/* I2C1_SCL */
+			   <1 0 &porta 17 0>;	/* I2C1_SDA */
+	};
+};
+
+grove_i2c1: &sercom3 {};

--- a/boards/arm/wio_terminal/wio_terminal.dts
+++ b/boards/arm/wio_terminal/wio_terminal.dts
@@ -6,6 +6,7 @@
 /dts-v1/;
 #include <atmel/samd5xx19.dtsi>
 #include "wio_terminal-pinctrl.dtsi"
+#include "grove_connectors.dtsi"
 #include "raspberrypi_40pins_connector.dtsi"
 #include <zephyr/dt-bindings/display/ili9xxx.h>
 

--- a/dts/bindings/gpio/grove-header.yaml
+++ b/dts/bindings/gpio/grove-header.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2023 Joel Guittet
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    GPIO pins exposing on Grove 4 pins headers.
+
+    This binding provides a nexus mapping for 2 pins as depicted below.
+
+        0  SCL/RXD/A/IN
+        1  SDA/TXD/B/OUT
+        -  VCC
+        -  GND
+
+
+compatible: "grove-header"
+
+include: [gpio-nexus.yaml, base.yaml]


### PR DESCRIPTION
Add binding support for Grove header.

This will be used later for Wio Terminal board added with https://github.com/zephyrproject-rtos/zephyr/pull/54953.

This can be used later for other boards as well!