### PR TITLE
net: dhcpv4: Fix potential packet leak in DHCPv4

### DIFF
--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -1039,12 +1039,10 @@ static enum net_verdict net_dhcpv4_input(struct net_conn *conn,
 		return NET_DROP;
 	}
 
-	/* If the message is not DHCP then continue passing to
-	 * related handlers.
-	 */
+	/* If the message is not DHCP then drop the packet. */
 	if (net_pkt_get_len(pkt) < NET_IPV4UDPH_LEN + sizeof(struct dhcp_msg)) {
 		NET_DBG("Input msg is not related to DHCPv4");
-		return NET_CONTINUE;
+		return NET_DROP;
 
 	}
 


### PR DESCRIPTION
Packet handlers registered with net_conn API should not use NET_CONTINUE to report packet processing status. As they register for a specific local port, it cannot be assumed someone else will handle the packet, and for net_conn this status is not really handled differently from NET_OK. Therefore, reporting NET_CONTINUE, and not freeing the packet, can result in a packet leak.

Too short packets should not really be handled differently from other malformed packets in DHCPv4 module, therefore report NET_DROP instead of NET_CONTINUE.