### PR TITLE
Samples: Bluetooth: Fix scanning restart for broadcast audio sink

### DIFF
--- a/samples/bluetooth/broadcast_audio_sink/src/main.c
+++ b/samples/bluetooth/broadcast_audio_sink/src/main.c
@@ -222,7 +222,7 @@ void main(void)
 
 		printk("Scanning for broadcast sources\n");
 		err = bt_audio_broadcast_sink_scan_start(BT_LE_SCAN_ACTIVE);
-		if (err != 0) {
+		if (err != 0 && err != -EALREADY) {
 			printk("Unable to start scan for broadcast sources: %d\n",
 			       err);
 			return;


### PR DESCRIPTION
If waiting on the first semaphore in the main loop times out, the main loop starts from the beginning and attempts to start scanning for broadcast sources. But since the first semaphore was not passed, the scan_recv_cb callback was not called yet and thus the previously started scanning was not stopped. As a result, an attempt to start the scanning will fail with -EALREADY and the main thread will end. To solve this, -EALREADY is now ignored when checking the return value of bt_audio_broadcast_sink_scan_start.