### PR TITLE
dts: arm: stm32u5 devices has 768KB of contiguous SRAM

### DIFF
--- a/dts/arm/st/u5/stm32u575Xi.dtsi
+++ b/dts/arm/st/u5/stm32u575Xi.dtsi
@@ -8,7 +8,8 @@
 
 / {
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(786)>;
+		/* SRAM1 + SRAM2 + SRAM3 */
+		reg = <0x20000000 DT_SIZE_K(768)>;
 	};
 
 	soc {

--- a/dts/arm/st/u5/stm32u585Xi.dtsi
+++ b/dts/arm/st/u5/stm32u585Xi.dtsi
@@ -8,7 +8,8 @@
 
 / {
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(786)>;
+		/* SRAM1 + SRAM2 + SRAM3 */
+		reg = <0x20000000 DT_SIZE_K(768)>;
 	};
 
 	soc {


### PR DESCRIPTION
The SRAM1(total 192 KBytes) plus SRAM2: (total 64 KBytes) plus SRAM3(total 512 KBytes) is available from 0x20000000 to 0x200BFFFF.

-> the SRAM size is only 768KB at address  0x20000000

The 16KB SRAM4 is located at address 0x28000000, so that no ram is present from 0x200c0000 to 0x28000000.


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55211


Signed-off-by: Francois Ramu <francois.ramu@st.com>