### PR TITLE
clang-format: Add CHECKIF to IfMacros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -64,6 +64,8 @@ ForEachMacros:
   - 'Z_GENLIST_FOR_EACH_CONTAINER_SAFE'
   - 'Z_GENLIST_FOR_EACH_NODE'
   - 'Z_GENLIST_FOR_EACH_NODE_SAFE'
+IfMacros:
+  - 'CHECKIF'
 # Disabled for now, see bug https://github.com/zephyrproject-rtos/zephyr/issues/48520
 #IncludeBlocks: Regroup
 IncludeCategories:


### PR DESCRIPTION
Add the CHECKIF macro to the IfMacros list so that it gets formatted correctly