### PR TITLE
pm: runtime: Early check if device runtime is enabled

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -47,6 +47,13 @@ static int runtime_suspend(const struct device *dev, bool async)
 	int ret = 0;
 	struct pm_device *pm = dev->pm;
 
+	/*
+	 * Early return if device runtime is not enabled.
+	 */
+	if (!atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
+		return 0;
+	}
+
 	if (k_is_pre_kernel()) {
 		async = false;
 	} else {
@@ -54,10 +61,6 @@ static int runtime_suspend(const struct device *dev, bool async)
 		if (ret < 0) {
 			return -EBUSY;
 		}
-	}
-
-	if (!atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
-		goto unlock;
 	}
 
 	if (pm->usage == 0U) {

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -134,12 +134,15 @@ int pm_device_runtime_get(const struct device *dev)
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_get, dev);
 
-	if (!k_is_pre_kernel()) {
-		(void)k_sem_take(&pm->lock, K_FOREVER);
+	/*
+	 * Early return if device runtime is not enabled.
+	 */
+	if (!atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
+		return 0;
 	}
 
-	if (!atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
-		goto unlock;
+	if (!k_is_pre_kernel()) {
+		(void)k_sem_take(&pm->lock, K_FOREVER);
 	}
 
 	/*


### PR DESCRIPTION
`pm_device_runtime_(get|put)`  already check if device runtime is enabled. This pr just move this check to begginning of function to avoid unecessary checks.