### PR TITLE
soc: mec172x: drop non existing option PINMUX_XEC

### DIFF
--- a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnlj
+++ b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnlj
@@ -11,10 +11,6 @@ config SOC
 config GPIO
 	default y
 
-config PINMUX_XEC
-	default y
-	depends on PINMUX
-
 config ESPI_XEC_V2
 	default y
 	depends on ESPI


### PR DESCRIPTION
Hi, hotfix from a race between the pinmux removal and https://github.com/zephyrproject-rtos/zephyr/pull/55108

Error:

```
warning: PINMUX_XEC (defined at soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnlj:14) defined without a type
```
---

Drop the non existing option PINMUX_XEC, this has been removed in

d76f4f2c8a drivers: pinmux: mchp_xec: drop driver

And is currently causing build errors.