### PR TITLE
dts: esp32s3: add i2c support

### DIFF
--- a/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm-pinctrl.dtsi
+++ b/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm-pinctrl.dtsi
@@ -18,4 +18,24 @@
 			bias-pull-up;
 		};
 	};
+
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <I2C0_SDA_GPIO1>,
+				 <I2C0_SCL_GPIO2>;
+			bias-pull-up;
+			drive-open-drain;
+			output-high;
+		};
+	};
+
+	i2c1_default: i2c1_default {
+		group1 {
+			pinmux = <I2C1_SDA_GPIO4>,
+				 <I2C1_SCL_GPIO5>;
+			bias-pull-up;
+			drive-open-drain;
+			output-high;
+		};
+	};
 };

--- a/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.dts
+++ b/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.dts
@@ -12,6 +12,10 @@
 	model = "esp32s3_devkitm";
 	compatible = "espressif,esp32s3";
 
+	aliases {
+		i2c-0 = &i2c0;
+	};
+
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,console = &uart0;
@@ -54,6 +58,18 @@
 
 &gpio1 {
 	status = "okay";
+};
+
+&i2c0 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-names = "default";
+};
+
+&i2c1 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c1_default>;
+	pinctrl-names = "default";
 };
 
 &flash0 {

--- a/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.yaml
+++ b/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.yaml
@@ -7,6 +7,7 @@ toolchain:
 supported:
   - gpio
   - uart
+  - i2c
 testing:
   ignore_tags:
     - net

--- a/dts/xtensa/espressif/esp32s3.dtsi
+++ b/dts/xtensa/espressif/esp32s3.dtsi
@@ -6,6 +6,7 @@
 #include <mem.h>
 #include <xtensa/xtensa.dtsi>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/clock/esp32s3_clock.h>
 #include <zephyr/dt-bindings/interrupt-controller/esp32s3-xtensa-intmux.h>
 #include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
@@ -148,6 +149,28 @@
 				interrupt-parent = <&intc>;
 				ngpios = <13>;
 			};
+		};
+
+		i2c0: i2c@60013000 {
+			compatible = "espressif,esp32-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x60013000 DT_SIZE_K(4)>;
+			interrupts = <I2C_EXT0_INTR_SOURCE>;
+			interrupt-parent = <&intc>;
+			clocks = <&rtc ESP32_I2C0_MODULE>;
+			status = "disabled";
+		};
+
+		i2c1: i2c@60027000 {
+			compatible = "espressif,esp32-i2c";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x60027000 DT_SIZE_K(4)>;
+			interrupts = <I2C_EXT1_INTR_SOURCE>;
+			interrupt-parent = <&intc>;
+			clocks = <&rtc ESP32_I2C1_MODULE>;
+			status = "disabled";
 		};
 
 	};

--- a/west.yml
+++ b/west.yml
@@ -57,7 +57,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 76f8d87d9938482ad73ee71b70323e6479e054a1
+      revision: d2564ca5c14439888f7c4351884a2cf4db517a33
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Add i2c support for esp32s3.
Remove direct register access and use hal functions instead.
Update hal_espressif to latest revision