### PR TITLE
bluetooth: host: Check bounds on le_adv_report event

### DIFF
--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1187,6 +1187,11 @@ void bt_hci_le_adv_report(struct net_buf *buf)
 
 		evt = net_buf_pull_mem(buf, sizeof(*evt));
 
+		if (buf->len <= evt->length) {
+			LOG_ERR("Unexpected end of buffer");
+			break;
+		}
+
 		adv_info.primary_phy = BT_GAP_LE_PHY_1M;
 		adv_info.secondary_phy = 0;
 		adv_info.tx_power = BT_GAP_TX_POWER_INVALID;

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1187,7 +1187,7 @@ void bt_hci_le_adv_report(struct net_buf *buf)
 
 		evt = net_buf_pull_mem(buf, sizeof(*evt));
 
-		if (buf->len <= evt->length) {
+		if (buf->len < evt->length + sizeof(adv_info.rssi)) {
 			LOG_ERR("Unexpected end of buffer");
 			break;
 		}


### PR DESCRIPTION
If an event with corrupted length arrives, the extra check makes the handler return early to avoid reading data out of bounds.