### PR TITLE
bluetooth: sco: Error out early on null acl

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1987,6 +1987,11 @@ struct bt_conn *bt_conn_add_sco(const bt_addr_t *peer, int link_type)
 	}
 
 	sco_conn->sco.acl = bt_conn_lookup_addr_br(peer);
+	if (!sco_conn->sco.acl) {
+		bt_conn_unref(sco_conn);
+		return NULL;
+	}
+
 	sco_conn->type = BT_CONN_TYPE_SCO;
 
 	if (link_type == BT_HCI_SCO) {


### PR DESCRIPTION
Cleanup unrefs the ACL connection, so ensure it is never null in the constructor.