### PR TITLE
boards: arm: stm32h735g_disco: Enable DT mac node

### DIFF
--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
@@ -123,6 +123,7 @@
 		     &eth_txd0_pb12
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &sdmmc1 {


### PR DESCRIPTION
This board's documentation states the current configuration supports Ethernet. However, the mac node was not enabled in devicetree.

This commit enables the mac node in devicetree.