### PR TITLE
Sc timer pwm period bug fix

### DIFF
--- a/drivers/pwm/pwm_mcux_sctimer.c
+++ b/drivers/pwm/pwm_mcux_sctimer.c
@@ -76,7 +76,8 @@ static int mcux_sctimer_pwm_set_cycles(const struct device *dev,
 		return 0;
 	}
 
-	if (period_cycles != data->period_cycles[channel]) {
+	if (period_cycles != data->period_cycles[channel] &&
+	    duty_cycle != data->channel[channel].dutyCyclePercent) {
 		uint32_t clock_freq;
 		uint32_t pwm_freq;
 
@@ -107,6 +108,7 @@ static int mcux_sctimer_pwm_set_cycles(const struct device *dev,
 
 		SCTIMER_StartTimer(config->base, kSCTIMER_Counter_U);
 	} else {
+		data->period_cycles[channel] = period_cycles;
 		SCTIMER_UpdatePwmDutycycle(config->base, channel, duty_cycle,
 					   data->event_number[channel]);
 	}

--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -159,4 +159,5 @@ ZTEST_USER(pwm_basic, test_pwm_cycle)
 	/* Period : Pulse (64000 : 0), unit (cycle). Voltage : 0V */
 	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_CYCLE,
 				0, UNIT_CYCLES) == TC_PASS, NULL);
+	k_sleep(K_MSEC(1000));
 }


### PR DESCRIPTION
Bug fix for #55284

If a user were to test a pwm signal with the pwm_api test it will succeed, 
however, if they were to change to ordering of the test to allow the nanosecond
test to run before the generic cycles test, the user will notice an inconsistency in
the pwm duty_cycle, this PR address this issue by testing for a change in duty
cycle as well as a change in period length before the driver suggests to create a
new pwm channel.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55284