### PR TITLE
RFC: Add a "chosen node" for the RT soc series that gives the ability to change the load address

### DIFF
--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -734,6 +734,18 @@ def shields_list_contains(kconf, _, shield):
 
     return "y" if shield in list.split(";") else "n"
 
+def conditional(kconf, _, cond, true_expr, false_expr):
+    """
+    Return "true_expr" if "cond" is "y".
+    Return "false_expr" if "cond" is "n".
+    Return empty string if cond is not valid input.
+    """
+    if cond == "y":
+        return true_expr
+    elif cond == "n":
+        return false_expr
+    else:
+        return ""
 
 # Keys in this dict are the function names as they appear
 # in Kconfig files. The values are tuples in this form:
@@ -781,4 +793,5 @@ functions = {
         "dt_nodelabel_array_prop_has_val": (dt_nodelabel_array_prop_has_val, 3, 3),
         "dt_gpio_hogs_enabled": (dt_gpio_hogs_enabled, 0, 0),
         "shields_list_contains": (shields_list_contains, 1, 1),
+        "conditional": (conditional,3,3),
 }

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -75,73 +75,22 @@ config PM_MCUX_PMU
 
 endif # SOC_SERIES_IMX_RT10XX && PM
 
-if CODE_SEMC
+DT_CHOSEN_Z_FLASH := zephyr,flash
+DT_COMPAT_FLEXSPI := nxp,imx-flexspi
 
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/memory@80000000,0,K)
+DT_CHOSEN_FLASH_NODE := $(dt_chosen_path,$(DT_CHOSEN_Z_FLASH))
+DT_CHOSEN_FLASH_PARENT := $(dt_node_parent,$(DT_CHOSEN_FLASH_NODE))
 
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/memory@80000000)
-
-endif # CODE_SEMC
-
-if CODE_ITCM
-
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/flexram@40028000/itcm@0,0,K) if SOC_SERIES_IMX_RT11XX
-	default $(dt_node_reg_size_int,/soc/flexram@400b0000/itcm@0,0,K) if SOC_SERIES_IMX_RT10XX
+DT_FLASH_PARENT_IS_FLEXSPI := $(dt_node_has_compat,$(DT_CHOSEN_FLASH_PARENT),$(DT_COMPAT_FLEXSPI))
+DT_FLASH_HAS_SIZE_PROP := $(dt_node_has_prop,$(DT_CHOSEN_FLASH_NODE),size)
 
 config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/flexram@40028000/itcm@0) if SOC_SERIES_IMX_RT11XX
-	default $(dt_node_reg_addr_hex,/soc/flexram@400b0000/itcm@0) if SOC_SERIES_IMX_RT10XX
-
-endif # CODE_ITCM
-
-if CODE_SRAM0
+	default $(dt_node_reg_addr_hex,$(DT_CHOSEN_FLASH_PARENT),1) \
+		if $(DT_FLASH_PARENT_IS_FLEXSPI)
 
 config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/memory@1ffe0000,0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/memory@1ffe0000)
-
-endif # CODE_SRAM0
-
-if CODE_OCRAM
-
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/ocram@20200000,0,K)
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/ocram@20200000)
-
-endif # CODE_OCRAM
-
-if CODE_FLEXSPI
-
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/spi@400cc000,1,K) if SOC_SERIES_IMX_RT11XX
-	default $(dt_node_reg_size_int,/soc/spi@400a0000,1,K) if SOC_MIMXRT1011
-	default $(dt_node_reg_size_int,/soc/spi@402a8000,1,K) if SOC_SERIES_IMX_RT10XX
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/spi@400cc000,1) if SOC_SERIES_IMX_RT11XX
-	default $(dt_node_reg_addr_hex,/soc/spi@400a0000,1) if SOC_MIMXRT1011
-	default $(dt_node_reg_addr_hex,/soc/spi@402a8000,1) if SOC_SERIES_IMX_RT10XX
-
-endif # CODE_FLEXSPI
-
-if CODE_FLEXSPI2
-
-config FLASH_SIZE
-	default $(dt_node_reg_size_int,/soc/spi@400d0000,1,K) if SOC_SERIES_IMX_RT11XX
-	default $(dt_node_reg_size_int,/soc/spi@402a4000,1,K) if SOC_SERIES_IMX_RT10XX
-
-config FLASH_BASE_ADDRESS
-	default $(dt_node_reg_addr_hex,/soc/spi@400d0000,1) if SOC_SERIES_IMX_RT11XX
-	default $(dt_node_reg_addr_hex,/soc/spi@402a4000,1) if SOC_SERIES_IMX_RT10XX
-
-endif # CODE_FLEXSPI2
+	default $(dt_node_int_prop_int,$(DT_CHOSEN_FLASH_NODE),size,Kb) \
+		if $(DT_FLASH_HAS_SIZE_PROP)
 
 choice USB_MCUX_CONTROLLER_TYPE
 	default USB_DC_NXP_EHCI

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -75,22 +75,51 @@ config PM_MCUX_PMU
 
 endif # SOC_SERIES_IMX_RT10XX && PM
 
+###########################################################################
+
+DT_CHOSEN_RT_BOOT_DEV := rt,boot-device
 DT_CHOSEN_Z_FLASH := zephyr,flash
 DT_COMPAT_FLEXSPI := nxp,imx-flexspi
 
 DT_CHOSEN_FLASH_NODE := $(dt_chosen_path,$(DT_CHOSEN_Z_FLASH))
 DT_CHOSEN_FLASH_PARENT := $(dt_node_parent,$(DT_CHOSEN_FLASH_NODE))
-
 DT_FLASH_PARENT_IS_FLEXSPI := $(dt_node_has_compat,$(DT_CHOSEN_FLASH_PARENT),$(DT_COMPAT_FLEXSPI))
 DT_FLASH_HAS_SIZE_PROP := $(dt_node_has_prop,$(DT_CHOSEN_FLASH_NODE),size)
+
+DT_CHOSEN_RT_BOOT_DEVICE := $(dt_chosen_path,$(DT_CHOSEN_RT_BOOT_DEV))
+DT_CHOSEN_RT_BOOT_DEVICE_PARENT := $(dt_node_parent,$(DT_CHOSEN_RT_BOOT_DEVICE))
+DT_RT_BOOT_DEVICE_PARENT_IS_FLEXSPI := \
+	$(dt_node_has_compat,$(DT_CHOSEN_RT_BOOT_DEVICE_PARENT),$(DT_COMPAT_FLEXSPI))
+DT_RT_BOOT_DEVICE_HAS_SIZE_PROP := $(dt_node_has_prop,$(DT_CHOSEN_RT_BOOT_DEVICE),size)
+
+RT_BOOT_DEVICE_BASE_ADDR := \
+$(conditional,$(DT_RT_BOOT_DEVICE_PARENT_IS_FLEXSPI),$(dt_node_reg_addr_hex,$(DT_CHOSEN_RT_BOOT_DEVICE_PARENT),1),$(dt_node_reg_addr_hex,$(DT_CHOSEN_RT_BOOT_DEVICE),1))
+RT_BOOT_DEVICE_SIZE := \
+$(conditional,$(DT_RT_BOOT_DEVICE_PARENT_IS_FLEXSPI),$(dt_node_int_prop_int,$(DT_CHOSEN_RT_BOOT_DEVICE),size,Kb),$(dt_node_reg_size_hex,$(DT_CHOSEN_RT_BOOT_DEVICE)))
+
+PROGRAM_LOGICAL_BASE_ADDR := \
+$(conditional,$(DT_FLASH_PARENT_IS_FLEXSPI),$(dt_node_reg_addr_hex,$(DT_CHOSEN_FLASH_PARENT),1),$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)))
+
+if $(dt_chosen_enabled,$(DT_CHOSEN_RT_BOOT_DEV))
+
+config BUILD_OUTPUT_HEX
+	default y
+
+config BUILD_OUTPUT_ADJUST_LMA
+	default "$(RT_BOOT_DEVICE_BASE_ADDR)-$(PROGRAM_LOGICAL_BASE_ADDR)"
+
+endif # $(dt_chosen_enabled,DT_CHOSEN_RT_BOOT_DEV)
 
 config FLASH_BASE_ADDRESS
 	default $(dt_node_reg_addr_hex,$(DT_CHOSEN_FLASH_PARENT),1) \
 		if $(DT_FLASH_PARENT_IS_FLEXSPI)
 
 config FLASH_SIZE
+	#default $(RT_BOOT_DEVICE_SIZE)
 	default $(dt_node_int_prop_int,$(DT_CHOSEN_FLASH_NODE),size,Kb) \
 		if $(DT_FLASH_HAS_SIZE_PROP)
+
+###########################################################################
 
 choice USB_MCUX_CONTROLLER_TYPE
 	default USB_DC_NXP_EHCI


### PR DESCRIPTION
This PR adds a "chosen node" for the RT series that would give the ability to specify in devicetree a different load address than the logical program address (which is the address of the flash chosen node). This functionality allows users to take advantage of the RT boot ROM capability to copy the image from a boot device to a different location.

The PR is marked as RFC in case there is any discussion about this type of functionality being valuable to other vendors as well and needing a more generic and mature solution in zephyr.

Depends on #55233

todo: 
* document the rt,boot-device chosen node
* create example board overlay to show how to use rt,boot-device
* add the rt,boot-device chosen node to the rt 3 digit series