### PR TITLE
Unbreak builds with old C++ compilers

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -119,10 +119,15 @@ set_compiler_property(TARGET compiler-cpp PROPERTY nostdincxx "-nostdinc++")
 # Required C++ flags when using gcc
 set_property(TARGET compiler-cpp PROPERTY required "-fcheck-new")
 
-# GCC compiler flags for C++ dialects
+# GCC compiler flags for C++ dialect: "register" variables and some
+# "volatile" usage generates warnings by default in standard versions
+# higher than 17 and 20 respectively.  Zephyr uses both, so turn off
+# the warnings where needed (but only on the compilers that generate
+# them, older toolchains like xcc don't understand the command line
+# flags!)
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp98 "-std=c++98")
-set_property(TARGET compiler-cpp PROPERTY dialect_cpp11 "-std=c++11" "-Wno-register")
-set_property(TARGET compiler-cpp PROPERTY dialect_cpp14 "-std=c++14" "-Wno-register")
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp11 "-std=c++11")
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp14 "-std=c++14")
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp17 "-std=c++17" "-Wno-register")
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp2a "-std=c++2a"
   "-Wno-register" "-Wno-volatile")

--- a/doc/develop/languages/cpp/index.rst
+++ b/doc/develop/languages/cpp/index.rst
@@ -19,6 +19,12 @@ and the included compiler must be supported by the Zephyr build system. The
 is supported by Zephyr, and the features and their availability documented
 here assume the use of the Zephyr SDK.
 
+The default C++ standard level (i.e. the language enforced by the
+compiler flags passed) for Zephyr apps is C++11.  Other standards are
+available via kconfig choice, for example
+:kconfig:option:`CONFIG_STD_CPP98`.  The oldest standard supported and
+tested in Zephyr is C++98.
+
 When compiling a source file, the build system selects the C++ compiler based
 on the suffix (extension) of the files. Files identified with either a **cpp**
 or a **cxx** suffix are compiled using the C++ compiler. For example,

--- a/include/zephyr/drivers/gna.h
+++ b/include/zephyr/drivers/gna.h
@@ -32,6 +32,9 @@ extern "C" {
  * Currently empty.
  */
 struct gna_config {
+#ifdef __cplusplus
+	char no_empty_structs; /* technically a gcc C extension */
+#endif
 };
 
 /**

--- a/include/zephyr/sys/cbprintf_cxx.h
+++ b/include/zephyr/sys/cbprintf_cxx.h
@@ -249,10 +249,12 @@ struct z_cbprintf_cxx_remove_reference < T & > {
 	typedef T type;
 };
 
+#if __cplusplus >= 201103L
 template < typename T >
 struct z_cbprintf_cxx_remove_reference < T && > {
 	typedef T type;
 };
+#endif
 
 template < typename T >
 struct z_cbprintf_cxx_remove_cv {

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -70,11 +70,14 @@
 #define BUILD_ASSERT(EXPR, MSG...) static_assert(EXPR, "" MSG)
 
 /*
- * GCC 4.6 and higher have the C11 _Static_assert built in, and its
+ * GCC 4.6 and higher have the C11 _Static_assert built in and its
  * output is easier to understand than the common BUILD_ASSERT macros.
+ * Don't use this in C++98 mode though (which we can hit, as
+ * static_assert() is not available)
  */
-#elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) || \
-	(__STDC_VERSION__) >= 201100
+#elif !defined(__cplusplus) && \
+	((__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) ||	\
+	 (__STDC_VERSION__) >= 201100)
 #define BUILD_ASSERT(EXPR, MSG...) _Static_assert(EXPR, "" MSG)
 #else
 #define BUILD_ASSERT(EXPR, MSG...)

--- a/lib/cpp/minimal/include/cstddef
+++ b/lib/cpp/minimal/include/cstddef
@@ -18,8 +18,10 @@
 namespace std {
 	using ::ptrdiff_t;
 	using ::size_t;
+#if __cplusplus >= 201103L
 	using ::max_align_t;
 	using nullptr_t = decltype(nullptr);
+#endif
 }
 
 #endif /* ZEPHYR_SUBSYS_CPP_INCLUDE_CSTDDEF_ */

--- a/tests/lib/cpp/cxx/testcase.yaml
+++ b/tests/lib/cpp/cxx/testcase.yaml
@@ -25,3 +25,41 @@ tests:
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_PICOLIBC=y
+
+  # Note: the -std= variants below exclude the host compilers, which
+  # aren't part of the SDK and can't be managed as part of the test
+  # suite. (e.g. as of commit time the g++ used in CI didn't support
+  # C++20/2B and emits a command line error when presented with
+  # -Wno-pointer-sign or -Werror=implicit-int in C++ mode with
+  # -std=c++98)
+  cpp.main.cpp98:
+    platform_exclude: native_posix native_posix_64
+    build_only: true
+    extra_configs:
+      - CONFIG_STD_CPP98=y
+  # Note: no "cpp.main.cpp11" as that's the default standard tested above
+  cpp.main.cpp14:
+    platform_exclude: native_posix native_posix_64
+    build_only: true
+    extra_configs:
+      - CONFIG_STD_CPP14=y
+  cpp.main.cpp17:
+    platform_exclude: native_posix native_posix_64
+    build_only: true
+    extra_configs:
+      - CONFIG_STD_CPP17=y
+  cpp.main.cpp2A:
+    platform_exclude: native_posix native_posix_64
+    build_only: true
+    extra_configs:
+      - CONFIG_STD_CPP2A=y
+  cpp.main.cpp20:
+    platform_exclude: native_posix native_posix_64
+    build_only: true
+    extra_configs:
+      - CONFIG_STD_CPP20=y
+  cpp.main.cpp2B:
+    platform_exclude: native_posix native_posix_64
+    build_only: true
+    extra_configs:
+      - CONFIG_STD_CPP2B=y


### PR DESCRIPTION
Cadence xcc can't handle some of the recent C++11 code.  (There are third party out of tree SOF modules using C++ too that aren't ready for xt-clang).  Let's slow walk the transition a bit and recompatibilize things for older compilers.