### PR TITLE
fix: ESP32-S2, use correct storage label

### DIFF
--- a/soc/xtensa/esp32s2/loader.c
+++ b/soc/xtensa/esp32s2/loader.c
@@ -30,7 +30,7 @@ static int map_rom_segments(void)
 {
 	int rc = 0;
 
-	size_t _partition_offset = FIXED_PARTITION_OFFSET(image_0);
+	size_t _partition_offset = FIXED_PARTITION_OFFSET(slot0_partition);
 	uint32_t _app_irom_start = _partition_offset + (uint32_t)&_image_irom_start;
 	uint32_t _app_irom_size = (uint32_t)&_image_irom_size;
 	uint32_t _app_irom_vaddr = (uint32_t)&_image_irom_vaddr;


### PR DESCRIPTION
This is a bugfix. It uses the right storage label `slot0_partition` for esp32s2. Note that this is already the case for esp32 and esp32s3.

Fixes #55286.