### PR TITLE
drivers: spi: stm32 spi driver supporting DMA in asynchronous mode

### DIFF
--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -22,7 +22,7 @@ typedef void (*irq_config_func_t)(const struct device *port);
 struct spi_stm32_config {
 	SPI_TypeDef *spi;
 	const struct pinctrl_dev_config *pcfg;
-#ifdef CONFIG_SPI_STM32_INTERRUPT
+#if defined(CONFIG_SPI_STM32_INTERRUPT) || defined(CONFIG_SPI_ASYNC)
 	irq_config_func_t irq_config;
 #endif
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)

--- a/tests/drivers/spi/spi_loopback/boards/disco_l475_iot1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/disco_l475_iot1.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi1 {
+	dmas = <&dma1 1 3 STM32_DMA_PERIPH_TX
+		&dma1 1 2 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -33,9 +33,28 @@ tests:
     integration_platforms:
       - sam_e70_xplained
   drivers.spi.stm32_spi_dma.loopback:
-    extra_args: OVERLAY_CONFIG="overlay-stm32-spi-dma.conf"
+    extra_configs:
+      - CONFIG_SPI_STM32_DMA=y
+      - CONFIG_SPI_ASYNC=n
     filter: CONFIG_SOC_FAMILY_STM32
     platform_allow:
+      - disco_l475_iot1
+      - nucleo_g474re
+      - nucleo_f207zg
+      - nucleo_f429zi
+      - nucleo_f746zg
+      - nucleo_wb55rg
+      - nucleo_l152re
+      - nucleo_wl55jc
+      - nucleo_h743zi
+    integration_platforms:
+      - nucleo_g474re
+  drivers.spi.stm32_spi_async_dma.loopback:
+    extra_configs:
+      - CONFIG_SPI_STM32_DMA=y
+    filter: CONFIG_SOC_FAMILY_STM32
+    platform_allow:
+      - disco_l475_iot1
       - nucleo_g474re
       - nucleo_f207zg
       - nucleo_f429zi


### PR DESCRIPTION
add the support of the SPI asynchronous mode to the sm32 spi driver with DMA enabled or not
Enable this async mode when running the tests/drivers/spi/spi_loopback 
and add the dma for spi transfer with _overlay-stm32-spi-dma.conf_
This is now the case hen the CONFIG_SPI_STM32_DMA is selected,

The SPI transfer is possible in ASYNC mode is possible CONFIG_SPI_ASYNC=y or not (CONFIG_SPI_ASYNC=n)
--> adding one more config to the tests/drivers/spi/spi_loopback for stm32 serie.

Add the b_l4s5i_iot01a disco kit to the list of supported boards
 
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55205

Signed-off-by: Francois Ramu <francois.ramu@st.com>

