### PR TITLE
drivers: usb: initial work for gd32 usb

### DIFF
--- a/drivers/usb/udc/udc_gd32.c
+++ b/drivers/usb/udc/udc_gd32.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2023 BrainCo Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/usb/udc.h>
+
+#include <gd32_usb.h>

--- a/modules/hal_gigadevice/CMakeLists.txt
+++ b/modules/hal_gigadevice/CMakeLists.txt
@@ -57,6 +57,10 @@ zephyr_include_directories(${gd32_std_dir}/include)
 zephyr_include_directories(${ZEPHYR_HAL_GIGADEVICE_MODULE_DIR}/include)
 zephyr_include_directories(${ZEPHYR_HAL_GIGADEVICE_MODULE_DIR}/common_include)
 
+if (${CONFIG_GD32_USB_SUPPORT})
+  zephyr_include_directories(${gd32_soc_dir}/usb_drivers/include)
+endif()
+
 zephyr_library_sources(${gd32_soc_sys_dir}/source/system_${CONFIG_SOC_SERIES}.c)
 
 zephyr_library_sources_ifdef(CONFIG_USE_GD32_ADC      ${gd32_std_src_dir}/${CONFIG_SOC_SERIES}_adc.c)

--- a/modules/hal_gigadevice/Kconfig
+++ b/modules/hal_gigadevice/Kconfig
@@ -79,6 +79,11 @@ config GD32_DBG_SUPPORT
 	  This option makes allows using functions that access to
 	  DBG_CTL register such as dbg_periph_enable().
 
+config GD32_USB_SUPPORT
+	bool "USB driver support"
+	help
+	  Enable this if usb driver is supported for certain gd32 soc.
+
 config USE_GD32_ADC
 	bool
 	help

--- a/soc/arm/gigadevice/gd32f4xx/Kconfig.series
+++ b/soc/arm/gigadevice/gd32f4xx/Kconfig.series
@@ -10,5 +10,6 @@ config SOC_SERIES_GD32F4XX
 	select SOC_FAMILY_GD32_ARM
 	select GD32_HAS_AF_PINMUX
 	select GD32_HAS_IRC_32K
+	select GD32_USB_SUPPORT
 	help
 	  Enable support for GigaDevice GD32F4XX MCU series


### PR DESCRIPTION
I'm trying to add gd32 usb support recently.

## HAL 

Gigadevice provide an usb_library in gd32 firmware library.  This usb library contain its own device and host inmplement, based on a register wrapper(drivers directory). Most of the register wrapper are same between gd32 series.

Currently solution is to use this reigster wrapper to implement a new udc drivers. 

register wrapper import work: https://github.com/zephyrproject-rtos/hal_gigadevice/pull/32

## GD32 USB

Below is a list for gd32 sos with USB(FS, HS) supported:

| SoC | Features |
| ------------- | ------------- |
| GD32C10x      | FS       |
| GD32C11x      | FS       |
| GD32E10x      | FS       |
| GD32E11x      | FS       |
| GD32E50x      | FS, HS   |
| GD32F10x<1>   | FS       |
| GD32F20x      | FS       |
| GD32F30x      | FS       |
| GD32F350      | FS       |
| GD32F4xx      | FS, HS   |
| GD32L23x      | FS       |
| GD32VF103     | FS       |
| GD32W51x      | FS       |
| GD32L233      | FS       |

> 1. GD32F101 not support USB.


