### PR TITLE
manifest: Update PSA arch test with timeout and crypto test 221 fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -246,7 +246,7 @@ manifest:
       groups:
         - tee
     - name: psa-arch-tests
-      revision: 24ed42e34e03ebbc945a7204819c1471cce2bda8
+      revision: 6a17330e0dfb5f319730f974d5b05f7b7f04757b
       path: modules/tee/tf-m/psa-arch-tests
       groups:
         - tee


### PR DESCRIPTION
Crypto test-case 221 has a false negative, not passing because the ECC family is disabled, not because of the key length.

Increase the timeout for the nRF5340/nRF9160 devices. RSA keygen will sometimes take more than 90 seconds