### PR TITLE
drivers: dma: stm32 disabling stream waits for disable

### DIFF
--- a/drivers/dma/dma_stm32_v1.c
+++ b/drivers/dma/dma_stm32_v1.c
@@ -332,11 +332,12 @@ int stm32_dma_disable_stream(DMA_TypeDef *dma, uint32_t id)
 {
 	LL_DMA_DisableStream(dma, dma_stm32_id_to_stream(id));
 
-	if (!LL_DMA_IsEnabledStream(dma, dma_stm32_id_to_stream(id))) {
-		return 0;
+	while (stm32_dma_is_enabled_stream(dma, id)) {
 	}
 
-	return -EAGAIN;
+	dma_stm32_clear_tc(dma, id);
+
+	return 0;
 }
 
 void stm32_dma_disable_fifo_irq(DMA_TypeDef *dma, uint32_t id)


### PR DESCRIPTION
Add the loop to wait until the stream is really disable after disabling and also cleared the TCIF flag.
This is a specifity of the dma of type V1.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54805

Signed-off-by: Francois Ramu <francois.ramu@st.com>