### PR TITLE
samples and tests: Add REQUIRED to Zephyr find_package call

### DIFF
--- a/samples/boards/esp32/ethernet/CMakeLists.txt
+++ b/samples/boards/esp32/ethernet/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(esp32_ethernet)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/boards/google_kukui/CMakeLists.txt
+++ b/samples/boards/google_kukui/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(google_kukui)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/adc/CMakeLists.txt
+++ b/samples/drivers/adc/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ADC)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/clock_control_xec/CMakeLists.txt
+++ b/samples/drivers/clock_control_xec/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(clock_control_xec)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/led_lp503x/CMakeLists.txt
+++ b/samples/drivers/led_lp503x/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(led_lp503x)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/led_pwm/CMakeLists.txt
+++ b/samples/drivers/led_pwm/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(led_pwm)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/drivers/led_xec/CMakeLists.txt
+++ b/samples/drivers/led_xec/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(led_xec)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/modules/tflite-micro/tflm_ethosu/CMakeLists.txt
+++ b/samples/modules/tflite-micro/tflm_ethosu/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(tflm_ethosu_app)
 

--- a/samples/net/dsa/CMakeLists.txt
+++ b/samples/net/dsa/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dsa)
 
 target_sources(app PRIVATE src/main.c src/dsa_lldp.c)

--- a/samples/net/sockets/txtime/CMakeLists.txt
+++ b/samples/net/sockets/txtime/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sockets_txtime)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/sensor/bmi270/CMakeLists.txt
+++ b/samples/sensor/bmi270/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 3.20.0)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/fdc2x1x/CMakeLists.txt
+++ b/samples/sensor/fdc2x1x/CMakeLists.txt
@@ -4,7 +4,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fdc2x1x)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/sensor/vcnl4040/CMakeLists.txt
+++ b/samples/sensor/vcnl4040/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(vcnl4040)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/sensor/wsen_itds/CMakeLists.txt
+++ b/samples/sensor/wsen_itds/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(wsen_itds)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/bluetooth/bsim/host/adv/chain/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/adv/chain/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
           https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_adv_chain)
 
 target_sources(app PRIVATE

--- a/tests/bluetooth/bsim/host/adv/resume/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/adv/resume/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_adv_resume)
 
 target_sources(app PRIVATE

--- a/tests/bluetooth/bsim/host/att/eatt/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/att/eatt/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_host)
 
 

--- a/tests/bluetooth/bsim/host/att/eatt_notif/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/att/eatt_notif/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_eatt_notif)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/bsim/host/att/mtu_update/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/att/mtu_update/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
           https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_mtu_update)
 
 target_sources(app PRIVATE

--- a/tests/bluetooth/bsim/host/gatt/caching/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/gatt/caching/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_gatt)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/bsim/host/gatt/general/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/gatt/general/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_gatt)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/bsim/host/gatt/notify/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/gatt/notify/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_gatt)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/bsim/host/gatt/notify_multiple/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/gatt/notify_multiple/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_gatt)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/bsim/host/gatt/settings/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/gatt/settings/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_gatt_settings)
 
 target_sources(app PRIVATE

--- a/tests/bluetooth/bsim/host/gatt/write/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/gatt/write/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
           https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_gatt_write)
 
 target_sources(app PRIVATE

--- a/tests/bluetooth/bsim/host/l2cap/general/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/l2cap/general/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_l2cap)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/bsim/host/l2cap/stress/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/l2cap/stress/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_l2cap_stress)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/bsim/host/l2cap/userdata/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/l2cap/userdata/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_l2cap_userdata)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/bsim/host/misc/disable/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/misc/disable/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_disable)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/bluetooth/bsim/host/misc/multiple_id/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/misc/multiple_id/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
           https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_multiple)
 
 target_sources(app PRIVATE

--- a/tests/bluetooth/bsim/host/privacy/central/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/privacy/central/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_rpa_central)
 
 target_sources(app PRIVATE

--- a/tests/bluetooth/bsim/host/privacy/device/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/privacy/device/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
           https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_privacy)
 
 target_sources(app PRIVATE

--- a/tests/bluetooth/bsim/host/privacy/peripheral/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/privacy/peripheral/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_rpa_peripheral)
 
 target_sources(app PRIVATE

--- a/tests/bluetooth/bsim/host/security/bond_overwrite_allowed/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/security/bond_overwrite_allowed/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_multi_id_bond_overwrite_deny)
 
 target_sources(app PRIVATE

--- a/tests/bluetooth/bsim/host/security/bond_overwrite_denied/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/security/bond_overwrite_denied/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_multi_id_bond_overwrite_deny)
 
 target_sources(app PRIVATE

--- a/tests/bluetooth/bsim/ll/advx/CMakeLists.txt
+++ b/tests/bluetooth/bsim/ll/advx/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
  https://babblesim.github.io/folder_structure_and_env.html")
 endif()
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_advx)
 
 target_sources(app PRIVATE src/main.c)

--- a/tests/bluetooth/controller/ctrl_api/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_api/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_api)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_chmu/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_chmu/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_chmu)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_cis_create/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_cis_create/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_cis_create)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_cis_terminate/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_cis_terminate/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_cis_terminate)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_collision/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_collision/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_collision)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_conn_update/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_conn_update/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_conn_update)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_cte_req/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_cte_req/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_cte_req)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_data_length_update/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_data_length_update/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_data_length_update)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_encrypt/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_encrypt/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_encrypt)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_feature_exchange/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_feature_exchange)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_hci/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_hci/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_hci_api)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_invalid/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_invalid/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_invalid)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_le_ping/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_le_ping/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_le_ping)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_min_used_chans/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_min_used_chans)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_phy_update/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_phy_update/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_phy_update)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_sca_update/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_sca_update/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_sca_update)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_terminate/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_terminate/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_terminate)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_tx_buffer_alloc/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_tx_buffer_alloc/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_tx_buffer_alloc)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_tx_queue/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_tx_queue/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_tx_queue)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_unsupported/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_unsupported/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_unsupported)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/controller/ctrl_version/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_version/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_ull_llcp_version)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/common common)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/controller/uut uut)

--- a/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/CMakeLists.txt
+++ b/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_bt_buf_get_cmd_complete)
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/buf mocks)

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/CMakeLists.txt
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_bt_buf_get_evt)
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/buf mocks)

--- a/tests/bluetooth/host/buf/bt_buf_get_rx/CMakeLists.txt
+++ b/tests/bluetooth/host/buf/bt_buf_get_rx/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_bt_buf_get_rx)
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/buf mocks)

--- a/tests/bluetooth/host/buf/bt_buf_get_type/CMakeLists.txt
+++ b/tests/bluetooth/host/buf/bt_buf_get_type/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20.0)
 
 project(bluetooth_bt_buf_get_type)
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/buf mocks)

--- a/tests/bluetooth/host/crypto/prng_init/CMakeLists.txt
+++ b/tests/bluetooth/host/crypto/prng_init/CMakeLists.txt
@@ -7,7 +7,7 @@ FILE(GLOB SOURCES src/*.c)
 project(prng_init)
 add_compile_definitions(test_unit_name="${PROJECT_NAME}")
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/crypto mocks)

--- a/tests/bluetooth/host/id/bt_br_oob_get_local/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_br_oob_get_local/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_add/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_add/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_adv_random_addr_check/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_adv_random_addr_check/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_create/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_create/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_del/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_del/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_delete/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_delete/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_get/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_get/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_init/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_init/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_read_public_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_read_public_addr/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_reset/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_reset/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_scan_random_addr_check/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_scan_random_addr_check/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_set_adv_private_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_adv_private_addr/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_set_adv_random_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_adv_random_addr/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_set_private_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_private_addr/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_le_oob_get_local/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_get_local/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_le_oob_get_sc_data/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_get_sc_data/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_le_oob_set_sc_data/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_set_sc_data/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_lookup_id_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_lookup_id_addr/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_setup_public_id_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_setup_public_id_addr/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(BEFORE
     $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
 )
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/keys/bt_keys_add_type/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_add_type/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bt_keys_add_type)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/keys/mocks mocks)

--- a/tests/bluetooth/host/keys/bt_keys_clear/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_clear/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bt_keys_clear)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/keys/mocks mocks)

--- a/tests/bluetooth/host/keys/bt_keys_find/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_find/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bt_keys_find)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/keys/mocks mocks)

--- a/tests/bluetooth/host/keys/bt_keys_find_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_find_addr/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bt_keys_find_addr)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/keys/mocks mocks)

--- a/tests/bluetooth/host/keys/bt_keys_find_irk/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_find_irk/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bt_keys_find_irk)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/keys/mocks mocks)

--- a/tests/bluetooth/host/keys/bt_keys_foreach_bond/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_bond/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bt_keys_foreach_bond)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/keys/mocks mocks)

--- a/tests/bluetooth/host/keys/bt_keys_foreach_type/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_type/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bt_keys_foreach_type)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/keys/mocks mocks)

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bt_keys_get_addr)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)

--- a/tests/bluetooth/host/keys/bt_keys_get_type/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_get_type/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bt_keys_get_type)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/keys/mocks mocks)

--- a/tests/bluetooth/host/keys/bt_keys_store/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_store/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bt_keys_store)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/keys/mocks mocks)

--- a/tests/bluetooth/host/keys/bt_keys_update_usage/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_update_usage/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 project(bt_keys_update_usage)
-find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/keys/mocks mocks)

--- a/tests/drivers/adc/adc_dma/CMakeLists.txt
+++ b/tests/drivers/adc/adc_dma/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(adc_dma)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/kernel/threads/thread_stack/CMakeLists.txt
+++ b/tests/kernel/threads/thread_stack/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(thread_stack)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/shell/shell_flash/CMakeLists.txt
+++ b/tests/subsys/shell/shell_flash/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(shell)
 
 FILE(GLOB app_sources src/*.c)


### PR DESCRIPTION
Adds REQUIRED to samples and tests for finding the zephyr package to align all samples and tests with the same call and parameters.