### PR TITLE
Bluetooth: Audio: Fix MCC discover callback on reconnected issue

### DIFF
--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -1361,6 +1361,7 @@ static int do_subscribe(struct mcs_instance_t *mcs_inst, struct bt_conn *conn,
 	sub_params->subscribe = subscribe_mcs_char_func;
 	/* disc_params pointer is also used as subscription flag */
 	sub_params->disc_params = &mcs_inst->discover_params;
+	atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_NO_RESUB);
 
 	LOG_DBG("Subscring to handle %d", handle);
 	return bt_gatt_subscribe(conn, sub_params);


### PR DESCRIPTION
With BT_GATT_SUBSCRIBE_FLAG_NO_RESUB the MCC subscriptions would be resent to the server on reconnection. Since this may trigger an error, the error will trigger a call to the MCC discover complete callback.

For MCP We can assume that the server stores the subscriptions if we are bonded, and thus we can use BT_GATT_SUBSCRIBE_FLAG_NO_RESUB.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55163