### PR TITLE
samples and tests: Use non-environmental zephyr base variable

### DIFF
--- a/samples/bluetooth/central_ht/CMakeLists.txt
+++ b/samples/bluetooth/central_ht/CMakeLists.txt
@@ -7,4 +7,4 @@ project(central_ht)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
 
-zephyr_library_include_directories($ENV{ZEPHYR_BASE}/samples/bluetooth)
+zephyr_library_include_directories(${ZEPHYR_BASE}/samples/bluetooth)

--- a/samples/subsys/mgmt/hawkbit/CMakeLists.txt
+++ b/samples/subsys/mgmt/hawkbit/CMakeLists.txt
@@ -14,7 +14,7 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
 target_sources_ifdef(CONFIG_NET_DHCPV4 app PRIVATE src/dhcp.c)
 
-include($ENV{ZEPHYR_BASE}/samples/net/common/common.cmake)
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)
 
 set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
 

--- a/tests/bluetooth/bsim/audio/CMakeLists.txt
+++ b/tests/bluetooth/bsim/audio/CMakeLists.txt
@@ -18,5 +18,5 @@ target_sources(app PRIVATE ${app_sources} )
 zephyr_include_directories(
   $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
   $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
-  $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/audio/
+  ${ZEPHYR_BASE}/subsys/bluetooth/host/audio/
 )

--- a/tests/bluetooth/bsim/host/adv/periodic/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/adv/periodic/CMakeLists.txt
@@ -22,5 +22,5 @@ target_sources(app PRIVATE
 zephyr_include_directories(
   $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
   $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
-  $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/audio/
+  ${ZEPHYR_BASE}/subsys/bluetooth/host/audio/
 )

--- a/tests/bluetooth/bsim/host/privacy/device/CMakeLists.txt
+++ b/tests/bluetooth/bsim/host/privacy/device/CMakeLists.txt
@@ -21,5 +21,5 @@ target_sources(app PRIVATE
 zephyr_include_directories(
   $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
   $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
-  $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/
+  ${ZEPHYR_BASE}/subsys/bluetooth/host/
 )

--- a/tests/bluetooth/bt_crypto_ccm/CMakeLists.txt
+++ b/tests/bluetooth/bt_crypto_ccm/CMakeLists.txt
@@ -7,5 +7,5 @@ project(app)
 target_sources(app PRIVATE
   src/test_bt_crypto_ccm.c
 
-  $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/aes_ccm.c
+  ${ZEPHYR_BASE}/subsys/bluetooth/host/aes_ccm.c
 )

--- a/tests/bluetooth/ctrl_user_ext/CMakeLists.txt
+++ b/tests/bluetooth/ctrl_user_ext/CMakeLists.txt
@@ -10,13 +10,13 @@ zephyr_library_include_directories(${ZEPHYR_BASE}/subsys/bluetooth/controller/)
 
 if(CONFIG_SOC_COMPATIBLE_NRF)
   zephyr_library_include_directories(
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/hci/nordic
+    ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
+    ${ZEPHYR_BASE}/subsys/bluetooth/hci/nordic
   )
 elseif(CONFIG_SOC_OPENISA_RV32M1_RISCV32)
   zephyr_library_include_directories(
-    $ENV{ZEPHYR_BASE}/bluetooth/controller/ll_sw/openisa
-    $ENV{ZEPHYR_BASE}/bluetooth/hci/openisa
+    ${ZEPHYR_BASE}/bluetooth/controller/ll_sw/openisa
+    ${ZEPHYR_BASE}/bluetooth/hci/openisa
   )
 endif()
 

--- a/tests/bluetooth/df/connection_cte_req/CMakeLists.txt
+++ b/tests/bluetooth/df/connection_cte_req/CMakeLists.txt
@@ -17,19 +17,19 @@ target_include_directories(app PRIVATE
 			   ${CMAKE_CURRENT_SOURCE_DIR}/../common/include)
 
 zephyr_library_include_directories(
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw
+    ${ZEPHYR_BASE}/subsys/bluetooth/
+    ${ZEPHYR_BASE}/subsys/bluetooth/controller/
+    ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw
 )
 
 if(CONFIG_SOC_COMPATIBLE_NRF)
   zephyr_library_include_directories(
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/hci/nordic
+    ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
+    ${ZEPHYR_BASE}/subsys/bluetooth/hci/nordic
   )
 elseif(CONFIG_SOC_OPENISA_RV32M1_RISCV32)
   zephyr_library_include_directories(
-    $ENV{ZEPHYR_BASE}/bluetooth/controller/ll_sw/openisa
-    $ENV{ZEPHYR_BASE}/bluetooth/hci/openisa
+    ${ZEPHYR_BASE}/bluetooth/controller/ll_sw/openisa
+    ${ZEPHYR_BASE}/bluetooth/hci/openisa
   )
 endif()

--- a/tests/bluetooth/df/connection_cte_tx_params/CMakeLists.txt
+++ b/tests/bluetooth/df/connection_cte_tx_params/CMakeLists.txt
@@ -18,19 +18,19 @@ target_include_directories(app PRIVATE
 			   ${CMAKE_CURRENT_SOURCE_DIR}/../common/include)
 
 zephyr_library_include_directories(
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw
+    ${ZEPHYR_BASE}/subsys/bluetooth/
+    ${ZEPHYR_BASE}/subsys/bluetooth/controller/
+    ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw
 )
 
 if(CONFIG_SOC_COMPATIBLE_NRF)
   zephyr_library_include_directories(
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/hci/nordic
+    ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
+    ${ZEPHYR_BASE}/subsys/bluetooth/hci/nordic
   )
 elseif(CONFIG_SOC_OPENISA_RV32M1_RISCV32)
   zephyr_library_include_directories(
-    $ENV{ZEPHYR_BASE}/bluetooth/controller/ll_sw/openisa
-    $ENV{ZEPHYR_BASE}/bluetooth/hci/openisa
+    ${ZEPHYR_BASE}/bluetooth/controller/ll_sw/openisa
+    ${ZEPHYR_BASE}/bluetooth/hci/openisa
   )
 endif()

--- a/tests/bluetooth/df/connectionless_cte_rx/CMakeLists.txt
+++ b/tests/bluetooth/df/connectionless_cte_rx/CMakeLists.txt
@@ -16,19 +16,19 @@ target_include_directories(app PRIVATE
 			   ${CMAKE_CURRENT_SOURCE_DIR}/../common/include)
 
 zephyr_library_include_directories(
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw
+    ${ZEPHYR_BASE}/subsys/bluetooth/
+    ${ZEPHYR_BASE}/subsys/bluetooth/controller/
+    ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw
 )
 
 if(CONFIG_SOC_COMPATIBLE_NRF)
   zephyr_library_include_directories(
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/hci/nordic
+    ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
+    ${ZEPHYR_BASE}/subsys/bluetooth/hci/nordic
   )
 elseif(CONFIG_SOC_OPENISA_RV32M1_RISCV32)
   zephyr_library_include_directories(
-    $ENV{ZEPHYR_BASE}/bluetooth/controller/ll_sw/openisa
-    $ENV{ZEPHYR_BASE}/bluetooth/hci/openisa
+    ${ZEPHYR_BASE}/bluetooth/controller/ll_sw/openisa
+    ${ZEPHYR_BASE}/bluetooth/hci/openisa
   )
 endif()

--- a/tests/bluetooth/df/connectionless_cte_tx/CMakeLists.txt
+++ b/tests/bluetooth/df/connectionless_cte_tx/CMakeLists.txt
@@ -16,19 +16,19 @@ target_include_directories(app PRIVATE
 			   ${CMAKE_CURRENT_SOURCE_DIR}/../common/include)
 
 zephyr_library_include_directories(
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw
+    ${ZEPHYR_BASE}/subsys/bluetooth/
+    ${ZEPHYR_BASE}/subsys/bluetooth/controller/
+    ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw
 )
 
 if(CONFIG_SOC_COMPATIBLE_NRF)
   zephyr_library_include_directories(
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/hci/nordic
+    ${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
+    ${ZEPHYR_BASE}/subsys/bluetooth/hci/nordic
   )
 elseif(CONFIG_SOC_OPENISA_RV32M1_RISCV32)
   zephyr_library_include_directories(
-    $ENV{ZEPHYR_BASE}/bluetooth/controller/ll_sw/openisa
-    $ENV{ZEPHYR_BASE}/bluetooth/hci/openisa
+    ${ZEPHYR_BASE}/bluetooth/controller/ll_sw/openisa
+    ${ZEPHYR_BASE}/bluetooth/hci/openisa
   )
 endif()

--- a/tests/bluetooth/host/id/bt_br_oob_get_local/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_br_oob_get_local/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_add/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_add/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_adv_random_addr_check/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_adv_random_addr_check/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_create/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_create/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_del/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_del/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_delete/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_delete/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_get/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_get/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_init/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_init/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_read_public_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_read_public_addr/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_reset/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_reset/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_scan_random_addr_check/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_scan_random_addr_check/CMakeLists.txt
@@ -9,14 +9,15 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)
+
 
 target_link_libraries(testbinary PRIVATE mocks host_mocks)
 

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_set_adv_private_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_adv_private_addr/CMakeLists.txt
@@ -14,11 +14,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_set_adv_random_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_adv_random_addr/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_set_private_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_private_addr/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_le_oob_get_local/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_get_local/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_le_oob_get_sc_data/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_get_sc_data/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_le_oob_set_sc_data/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_le_oob_set_sc_data/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_lookup_id_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_lookup_id_addr/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_setup_public_id_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_setup_public_id_addr/CMakeLists.txt
@@ -9,11 +9,11 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/CMakeLists.txt
@@ -9,14 +9,14 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 add_compile_options(-Wno-error=format-zero-length -Wno-format-zero-length)
 endif()
 
-include_directories(BEFORE
-    $ENV{ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
-)
-
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
 add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks mocks)
+
+include_directories(BEFORE
+    ${ZEPHYR_BASE}/tests/bluetooth/host/id/mocks
+)
 
 target_link_libraries(testbinary PRIVATE mocks host_mocks)
 

--- a/tests/bluetooth/host/keys/bt_keys_add_type/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_add_type/CMakeLists.txt
@@ -16,6 +16,6 @@ target_sources(testbinary
     src/test_suite_add_type_invalid_inputs.c
 
     # Unit under test
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
 )

--- a/tests/bluetooth/host/keys/bt_keys_clear/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_clear/CMakeLists.txt
@@ -17,6 +17,6 @@ target_sources(testbinary
     src/test_suite_clear_invalid_inputs.c
 
     # Unit under test
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
 )

--- a/tests/bluetooth/host/keys/bt_keys_find/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_find/CMakeLists.txt
@@ -16,6 +16,6 @@ target_sources(testbinary
     src/test_suite_find_invalid_inputs.c
 
     # Unit under test
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
 )

--- a/tests/bluetooth/host/keys/bt_keys_find_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_find_addr/CMakeLists.txt
@@ -16,6 +16,6 @@ target_sources(testbinary
     src/test_suite_find_addr_invalid_inputs.c
 
     # Unit under test
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
 )

--- a/tests/bluetooth/host/keys/bt_keys_find_irk/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_find_irk/CMakeLists.txt
@@ -16,6 +16,6 @@ target_sources(testbinary
     src/test_suite_find_irk_invalid_inputs.c
 
     # Unit under test
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
 )

--- a/tests/bluetooth/host/keys/bt_keys_foreach_bond/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_bond/CMakeLists.txt
@@ -16,6 +16,6 @@ target_sources(testbinary
     src/test_suite_foreach_bond_invalid_inputs.c
 
     # Unit under test
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
 )

--- a/tests/bluetooth/host/keys/bt_keys_foreach_type/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_type/CMakeLists.txt
@@ -16,6 +16,6 @@ target_sources(testbinary
     src/test_suite_foreach_type_invalid_inputs.c
 
     # Unit under test
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
 )

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/CMakeLists.txt
@@ -16,10 +16,10 @@ target_sources(testbinary
     src/test_suite_full_list_invalid_values.c
     src/test_suite_full_list_no_overwrite.c
     src/test_suite_full_list_overwrite_oldest.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
 
     # Unit under test
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
 )

--- a/tests/bluetooth/host/keys/bt_keys_get_type/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_get_type/CMakeLists.txt
@@ -14,10 +14,10 @@ target_sources(testbinary
     PRIVATE
     src/main.c
     src/test_suite_get_type_invalid_inputs.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/common/bt_str.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/host/uuid.c
 
     # Unit under test
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
 )

--- a/tests/bluetooth/host/keys/bt_keys_store/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_store/CMakeLists.txt
@@ -16,6 +16,6 @@ target_sources(testbinary
     src/test_suite_store_invalid_inputs.c
 
     # Unit under test
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
 )

--- a/tests/bluetooth/host/keys/bt_keys_update_usage/CMakeLists.txt
+++ b/tests/bluetooth/host/keys/bt_keys_update_usage/CMakeLists.txt
@@ -17,6 +17,6 @@ target_sources(testbinary
     src/test_suite_update_usage_invalid_inputs.c
 
     # Unit under test
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
-    $ENV{ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/host/keys.c
+    ${ZEPHYR_BASE}/subsys/bluetooth/common/addr.c
 )

--- a/tests/net/lib/lwm2m/lwm2m_registry/CMakeLists.txt
+++ b/tests/net/lib/lwm2m/lwm2m_registry/CMakeLists.txt
@@ -11,7 +11,7 @@ target_sources(app
 )
 
 set(includes
-"$ENV{ZEPHYR_BASE}/subsys/net/lib/lwm2m/"
+"${ZEPHYR_BASE}/subsys/net/lib/lwm2m/"
 "src/"
 )
 


### PR DESCRIPTION
This drops using the environmental part when referencing ZEPHYR_BASE as the environment value does not have to be set and, in most cases, is no longer set at all.

Fixes #55306