### PR TITLE
tests: lib: cmis_dsp matrix_unary_f64 requires more than 64KB of RAM

### DIFF
--- a/tests/lib/cmsis_dsp/matrix/testcase.yaml
+++ b/tests/lib/cmsis_dsp/matrix/testcase.yaml
@@ -148,7 +148,7 @@ tests:
       - native_posix
     tags: cmsis_dsp
     min_flash: 128
-    min_ram: 64
+    min_ram: 72
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_F64=y
@@ -160,7 +160,7 @@ tests:
       - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
-    min_ram: 64
+    min_ram: 72
     extra_args: CONF_FILE=prj_base.conf
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_F64=y


### PR DESCRIPTION
Increase the min ram configuration when running libraries.cmsis_dsp.matrix.unary_f64 testcase of the tests/lib/cmsis_dsp/matrix/  Issue occured on MEC172x after moved the cmsis_dsp tests to new ztest API in this commit: #50075 . Error from the test was "buffer allocation failed, " meaning it is running out of memory. This should have been included in #51883 but was skipped for some reason.