### PR TITLE
subsys: net: dns: prevent crash on nullptr as callback

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -413,7 +413,7 @@ static inline void invoke_query_callback(int status,
 	/* Only notify if the slot is neither released nor in the process of
 	 * being released.
 	 */
-	if (pending_query->query != NULL)  {
+	if (pending_query->query != NULL && pending_query->cb != NULL)  {
 		pending_query->cb(status, info, pending_query->user_data);
 	}
 }


### PR DESCRIPTION
When a query is done, the query isn't set to NULL. This can cause a nullptr exception in invoke_query_callback().

This was at least happening on Zephyr 2.6, which we patched locally. Tested this again on Zephyr 3.3 and issue wasn't seen. However, I think there still is a mistake in the code, where it could happen that a invoke_query_callback() is done where cb == null.