### PR TITLE
tests: Bluetooth: Add missing encryption value for CAP broadcaster

### DIFF
--- a/tests/bluetooth/bsim/audio/src/cap_initiator_test.c
+++ b/tests/bluetooth/bsim/audio/src/cap_initiator_test.c
@@ -395,6 +395,7 @@ static void test_cap_initiator_broadcast(void)
 	create_param.subgroup_params = &subgroup_param;
 	create_param.qos = &broadcast_preset_16_2_1.qos;
 	create_param.packing = BT_ISO_PACKING_SEQUENTIAL;
+	create_param.encryption = false;
 
 	init();
 


### PR DESCRIPTION
The field was uninitialized, causing the test to fail.