### PR TITLE
samples: net: sockets: echo_server: Fix userspace crash

### DIFF
--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -302,8 +302,6 @@ static void process_tcp4(void)
 		return;
 	}
 
-	k_work_reschedule(&conf.ipv4.tcp.stats_print, K_SECONDS(STATS_TIMER));
-
 	while (ret == 0) {
 		ret = process_tcp(&conf.ipv4);
 		if (ret < 0) {
@@ -329,8 +327,6 @@ static void process_tcp6(void)
 		quit();
 		return;
 	}
-
-	k_work_reschedule(&conf.ipv6.tcp.stats_print, K_SECONDS(STATS_TIMER));
 
 	while (ret == 0) {
 		ret = process_tcp(&conf.ipv6);
@@ -384,8 +380,6 @@ void start_tcp(void)
 	k_mem_domain_add_thread(&app_domain, tcp6_thread_id);
 
 	for (i = 0; i < CONFIG_NET_SAMPLE_NUM_HANDLERS; i++) {
-		k_mem_domain_add_thread(&app_domain, &tcp6_handler_thread[i]);
-
 		k_thread_access_grant(tcp6_thread_id, &tcp6_handler_thread[i]);
 		k_thread_access_grant(tcp6_thread_id, &tcp6_handler_stack[i]);
 	}
@@ -393,6 +387,7 @@ void start_tcp(void)
 
 	k_work_init_delayable(&conf.ipv6.tcp.stats_print, print_stats);
 	k_thread_start(tcp6_thread_id);
+	k_work_reschedule(&conf.ipv6.tcp.stats_print, K_SECONDS(STATS_TIMER));
 #endif
 
 #if defined(CONFIG_NET_IPV4)
@@ -400,8 +395,6 @@ void start_tcp(void)
 	k_mem_domain_add_thread(&app_domain, tcp4_thread_id);
 
 	for (i = 0; i < CONFIG_NET_SAMPLE_NUM_HANDLERS; i++) {
-		k_mem_domain_add_thread(&app_domain, &tcp4_handler_thread[i]);
-
 		k_thread_access_grant(tcp4_thread_id, &tcp4_handler_thread[i]);
 		k_thread_access_grant(tcp4_thread_id, &tcp4_handler_stack[i]);
 	}
@@ -409,6 +402,7 @@ void start_tcp(void)
 
 	k_work_init_delayable(&conf.ipv4.tcp.stats_print, print_stats);
 	k_thread_start(tcp4_thread_id);
+	k_work_reschedule(&conf.ipv4.tcp.stats_print, K_SECONDS(STATS_TIMER));
 #endif
 }
 

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -150,8 +150,6 @@ static void process_udp4(void)
 		return;
 	}
 
-	k_work_reschedule(&conf.ipv4.udp.stats_print, K_SECONDS(STATS_TIMER));
-
 	while (ret == 0) {
 		ret = process_udp(&conf.ipv4);
 		if (ret < 0) {
@@ -175,8 +173,6 @@ static void process_udp6(void)
 		quit();
 		return;
 	}
-
-	k_work_reschedule(&conf.ipv6.udp.stats_print, K_SECONDS(STATS_TIMER));
 
 	while (ret == 0) {
 		ret = process_udp(&conf.ipv6);
@@ -217,6 +213,8 @@ void start_udp(void)
 		k_work_init_delayable(&conf.ipv6.udp.stats_print, print_stats);
 		k_thread_name_set(udp6_thread_id, "udp6");
 		k_thread_start(udp6_thread_id);
+		k_work_reschedule(&conf.ipv6.udp.stats_print,
+				  K_SECONDS(STATS_TIMER));
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
@@ -227,6 +225,8 @@ void start_udp(void)
 		k_work_init_delayable(&conf.ipv4.udp.stats_print, print_stats);
 		k_thread_name_set(udp4_thread_id, "udp4");
 		k_thread_start(udp4_thread_id);
+		k_work_reschedule(&conf.ipv4.udp.stats_print,
+				  K_SECONDS(STATS_TIMER));
 	}
 }
 


### PR DESCRIPTION
Userspace support in `echo_server` sample has gone bitrotten over time. This PR fixes two issues related to userspace support in the sample itself. For the details about the fixes applied, please refer to the commit message.

There's one issue remaining that prevents the sample from running in userspace flawlessly, but it's a global one, related to the logger module, not the sample itself. The bug was reported in https://github.com/zephyrproject-rtos/zephyr/issues/55323.

`echo_client` will also require fixes related to the `k_work` API usage in the sample ,but in this case it involves more significant refactoring of the sample, hence will be submitted separately.