### PR TITLE
footprint: ci: Remove audio SOF samples

### DIFF
--- a/scripts/footprint/plan.txt
+++ b/scripts/footprint/plan.txt
@@ -24,5 +24,3 @@ bt_unicast_audio_server,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/unica
 bt_hci_rpmsg,default,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,
 bt_hci_rpmsg,iso-broadcast,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,-DCONF_FILE=nrf5340_cpunet_iso_broadcast-bt_ll_sw_split.conf
 bt_hci_rpmsg,iso-receive,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,-DCONF_FILE=nrf5340_cpunet_iso_receive-bt_ll_sw_split.conf
-sof,default,intel_adsp_cavs25,samples/subsys/audio/sof,
-sof,default,nxp_adsp_imx8,samples/subsys/audio/sof,


### PR DESCRIPTION
Removes audio SOF samples from footprint test plan as they no longer live in-tree
