### PR TITLE
ztest: Remove zexpect API test unnecessary timeout

### DIFF
--- a/tests/ztest/zexpect/testcase.yaml
+++ b/tests/ztest/zexpect/testcase.yaml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 common:
-  timeout: 15
   integration_platforms:
     - native_posix
 tests:


### PR DESCRIPTION
The zexpect API tests included a 15 sec timeout. This is an unnecessarily short timeout and not consistent with the rest of the ztest API tests, which don't include timeouts themselves. Particularly this timeout seems to go off on slower hardware.

Remove unnecessary timeout. Fixes #55335.