### PR TITLE
Kernel events race fix

### DIFF
--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -264,6 +264,9 @@ struct k_thread {
 
 	uint32_t   events;
 	uint32_t   event_options;
+
+	/** true if timeout should not wake the thread */
+	bool no_wake_on_timeout;
 #endif
 
 #if defined(CONFIG_THREAD_MONITOR)

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -316,6 +316,18 @@ static ALWAYS_INLINE bool z_is_thread_timeout_expired(struct k_thread *thread)
 bool z_sched_wake(_wait_q_t *wait_q, int swap_retval, void *swap_data);
 
 /**
+ * Wakes the specified thread.
+ *
+ * Given a specific thread, wake it up. This routine assumes that the given
+ * thread is not on the timeout queue.
+ *
+ * @param thread Given thread to wake up.
+ * @param is_timeout True if called from the timer ISR; false otherwise.
+ *
+ */
+void z_sched_wake_thread(struct k_thread *thread, bool is_timeout);
+
+/**
  * Wake up all threads pending on the provided wait queue
  *
  * Convenience function to invoke z_sched_wake() on all threads in the queue

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -794,6 +794,27 @@ ALWAYS_INLINE void z_unpend_thread_no_timeout(struct k_thread *thread)
 	}
 }
 
+void z_sched_wake_thread(struct k_thread *thread, bool is_timeout)
+{
+	LOCKED(&sched_spinlock) {
+		bool killed = ((thread->base.thread_state & _THREAD_DEAD) ||
+			       (thread->base.thread_state & _THREAD_ABORTING));
+
+		if (!killed) {
+			/* The thread is not being killed */
+			if (thread->base.pended_on != NULL) {
+				unpend_thread_no_timeout(thread);
+			}
+			z_mark_thread_as_started(thread);
+			if (is_timeout) {
+				z_mark_thread_as_not_suspended(thread);
+			}
+			ready_thread(thread);
+		}
+	}
+
+}
+
 #ifdef CONFIG_SYS_CLOCK_EXISTS
 /* Timeout handler for *_thread_timeout() APIs */
 void z_thread_timeout(struct _timeout *timeout)
@@ -801,19 +822,7 @@ void z_thread_timeout(struct _timeout *timeout)
 	struct k_thread *thread = CONTAINER_OF(timeout,
 					       struct k_thread, base.timeout);
 
-	LOCKED(&sched_spinlock) {
-		bool killed = ((thread->base.thread_state & _THREAD_DEAD) ||
-			       (thread->base.thread_state & _THREAD_ABORTING));
-
-		if (!killed) {
-			if (thread->base.pended_on != NULL) {
-				unpend_thread_no_timeout(thread);
-			}
-			z_mark_thread_as_started(thread);
-			z_mark_thread_as_not_suspended(thread);
-			ready_thread(thread);
-		}
-	}
+	z_sched_wake_thread(thread, true);
 }
 #endif
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -800,6 +800,16 @@ void z_sched_wake_thread(struct k_thread *thread, bool is_timeout)
 		bool killed = ((thread->base.thread_state & _THREAD_DEAD) ||
 			       (thread->base.thread_state & _THREAD_ABORTING));
 
+#ifdef CONFIG_EVENTS
+		bool do_nothing = thread->no_wake_on_timeout && is_timeout;
+
+		thread->no_wake_on_timeout = false;
+
+		if (do_nothing) {
+			continue;
+		}
+#endif
+
 		if (!killed) {
 			/* The thread is not being killed */
 			if (thread->base.pended_on != NULL) {

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -578,6 +578,9 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 	/* Initialize custom data field (value is opaque to kernel) */
 	new_thread->custom_data = NULL;
 #endif
+#ifdef CONFIG_EVENTS
+	new_thread->no_wake_on_timeout = false;
+#endif
 #ifdef CONFIG_THREAD_MONITOR
 	new_thread->entry.pEntry = entry;
 	new_thread->entry.parameter1 = p1;


### PR DESCRIPTION
kernel: events: fix walking the waitq race condition

Fixes race condition for k_event_post_internal() in an
SMP environment while walking the waitq. Uses z_sched_waitq_walk()
to safely walk the waitq by using a sched_spinlock.
It should be noted that since walking the wait queue is an
operation of indeterminant length, there exists the possibility
that the sched_spinlock (which is a highly used and contended-for
lock) may be locked for an indeterminant amount of time. However,
it is expected that few threads will be waiting on any given kernel
event object, which should ameliorate this risk.

kernel: events: Add spin lock/unlock pair to fix race

Adds a spin lock/unlock pair after the waiting thread wakes from
waiting to ensure that the posting thread does not corrupt any data
while processing the list of threads to wake.

Fixes #54317