### PR TITLE
board: teensy: drop spi-nor from the flash nodes

### DIFF
--- a/boards/arm/teensy4/teensy40.dts
+++ b/boards/arm/teensy4/teensy40.dts
@@ -38,7 +38,7 @@
 	reg = <0x402a8000 0x4000>, <0x60000000 0x200000>;
 	/* WINBOND flash memory*/
 	w25q16jvuxim: w25q16jvuxim@0 {
-		compatible = "winbond,w25q16jvuxim", "jedec,spi-nor";
+		compatible = "winbond,w25q16jvuxim";
 		size = <16777208>;
 		reg = <0>;
 		spi-max-frequency = <133000000>;

--- a/boards/arm/teensy4/teensy41.dts
+++ b/boards/arm/teensy4/teensy41.dts
@@ -11,7 +11,7 @@
 	reg = < 0x402a8000 0x4000 >, < 0x60000000 0x800000 >;
 	/* WINBOND flash memory*/
 	w25q64jvxgim: w25q64jvxgim@0 {
-		compatible = "winbond,w25q64jvxgim", "jedec,spi-nor";
+		compatible = "winbond,w25q64jvxgim";
 		size = < 8388607 >;
 		reg = < 0 >;
 		spi-max-frequency = < 133000000 >;


### PR DESCRIPTION
Hey, bumpted into this when working on another PR, the board enables SPI and fails few tests. Made it work like https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts#L114.

Sample build problem:

`west build -p -b teensy41 samples/hello_world -DCONFIG_FLASH=y`

This started to after in https://github.com/zephyrproject-rtos/zephyr/pull/51598, as it caused SPI to be enabled with FLASH through the nor node.

---

These are RT1060 based boards that use the flash for XIP, the bus (nxp,imx-flexspi) lives under memc or flash. Declaring the flash as "jedec,spi-nor" causes the SPI NOR driver to create an instance for it, but then there's no bus and the build fails.

Dropping the spi-nor compatible as well as the custom one, and using `nxp,imx-flexspi-nor` instead as currently done in mimxrt1060_ev and mm_feather.