### PR TITLE
dts: bindings: Add Pmod connector GPIO nexus

### DIFF
--- a/boards/arm/stm32h735g_disco/pmod_connector.dtsi
+++ b/boards/arm/stm32h735g_disco/pmod_connector.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Elektronikutvecklingsbyrån EUB AB
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	pmod0: pmod-connector {
+		compatible = "digilent,pmod";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpiof 9 0>,	/* IO1 */
+			   <1 0 &gpiof 7 0>,	/* IO2 */
+			   <2 0 &gpiof 6 0>,	/* IO3 */
+			   <3 0 &gpiof 8 0>,	/* IO4 */
+			   <4 0 &gpioh 12 0>,	/* IO5 */
+			   <5 0 &gpioh 1 0>;	/* IO6 */
+						/* IO7 - not connected */
+						/* IO8 - not connected */
+	};
+};

--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <st/h7/stm32h735Xg.dtsi>
 #include <st/h7/stm32h735igkx-pinctrl.dtsi>
+#include "pmod_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32H735G DISCOVERY board";

--- a/boards/arm/stm32h747i_disco/pmod_connector.dtsi
+++ b/boards/arm/stm32h747i_disco/pmod_connector.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Elektronikutvecklingsbyrån EUB AB
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	pmod0: pmod-connector {
+		compatible = "digilent,pmod";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpioa 11 0>,	/* IO1 */
+			   <1 0 &gpioc 3 0>,	/* IO2 */
+			   <2 0 &gpioc 2 0>,	/* IO3 */
+			   <3 0 &gpioa 12 0>,	/* IO4 */
+			   <4 0 &gpioc 6 0>,	/* IO5 */
+			   <5 0 &gpioj 13 0>;	/* IO6 */
+						/* IO7 - not connected */
+						/* IO8 - not connected */
+	};
+};

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco.dtsi
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include "arduino_r3_connector.dtsi"
+#include "pmod_connector.dtsi"
 
 / {
 	leds {

--- a/dts/bindings/gpio/digilent,pmod.yaml
+++ b/dts/bindings/gpio/digilent,pmod.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2023 Elektronikutvecklingsbyrån EUB AB
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    GPIO pins exposed on a Digilent Pmod interface.
+
+    This binding provides a nexus mapping for 8 pins where parent pins 0
+    through 3 correspond to IO1 through IO4, and parent pins 4 through 7
+    correspond to IO5 through IO8, as depicted below for a 12-pin connector.
+
+    12-pin Pmod interface:
+
+        0 IO1                    IO5   4
+        1 IO2                    IO6   5
+        2 IO3                    IO7   6
+        3 IO4                    IO8   7
+        - GND                    GND   -
+        - VDD                    VDD   -
+
+    This binding can also be used with the 6-pin Pmod connector variant which
+    is a proper subset of the 12-pin connector. In that case parent pins 4
+    through 7 are omitted from the GPIO nexus node, resulting in a mapping
+    as depicted below.
+
+    6-pin Pmod interface:
+
+        0 IO1
+        1 IO2
+        2 IO3
+        3 IO4
+        - GND
+        - VDD
+
+compatible: "digilent,pmod"
+
+include: [gpio-nexus.yaml, base.yaml]

--- a/include/zephyr/dt-bindings/gpio/digilent-pmod.h
+++ b/include/zephyr/dt-bindings/gpio/digilent-pmod.h
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2023 Elektronikutvecklingsbyrån EUB AB
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Pmod GPIO nexus signal index definitions
+ *
+ * Defines meant to be used in conjunction with the "digilent,pmod"
+ * GPIO nexus mapping.
+ *
+ * Example usage:
+ *
+ * @code{.dts}
+ * &spi1 {
+ *         cs-gpios = <&pmod0 PMOD_SPI_CS GPIO_ACTIVE_LOW>;
+ *
+ *         example_device: example-dev@0 {
+ *                 compatible = "vnd,spi-device";
+ *                 reg = <0>;
+ *         };
+ * };
+ * @endcode
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_DIGILENT_PMOD_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_DIGILENT_PMOD_H_
+
+/**
+ * For reference see the Pmod interface specification:
+ * https://digilent.com/reference/_media/reference/pmod/pmod-interface-specification-1_2_0.pdf
+ */
+
+/* GPIO */
+
+/**
+ * @brief IO[n] signal on a Pmod GPIO nexus node following
+ * Pmod Interface Type 1 or 1A (GPIO or expanded GPIO)
+ *
+ * The Pmod GPIO nexus maps pin indexes 0..7 to IO1..IO8.
+ */
+#define PMOD_IO(n) ((n) - 1)
+
+/* SPI */
+
+/**
+ * @brief SPI CS signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 2 (SPI) peripherals.
+ */
+#define PMOD_SPI_CS	PMOD_IO(1)
+
+/**
+ * @brief SPI MOSI signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 2 (SPI) peripherals.
+ */
+#define PMOD_SPI_MOSI	PMOD_IO(2)
+
+/**
+ * @brief SPI MISO signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 2 (SPI) peripherals.
+ */
+#define PMOD_SPI_MISO	PMOD_IO(3)
+
+/**
+ * @brief SPI SCK signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 2 (SPI) peripherals.
+ */
+#define PMOD_SPI_SCK	PMOD_IO(4)
+
+/* Expanded SPI */
+
+/**
+ * @brief SPI CS signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 2A (expanded SPI) peripherals.
+ */
+#define PMOD_EXP_SPI_CS		PMOD_IO(1)
+
+/**
+ * @brief SPI MOSI signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 2A (expanded SPI) peripherals.
+ */
+#define PMOD_EXP_SPI_MOSI	PMOD_IO(2)
+
+/**
+ * @brief SPI MISO signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 2A (expanded SPI) peripherals.
+ */
+#define PMOD_EXP_SPI_MISO	PMOD_IO(3)
+
+/**
+ * @brief SPI SCK signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 2A (expanded SPI) peripherals.
+ */
+#define PMOD_EXP_SPI_SCK	PMOD_IO(4)
+
+/**
+ * @brief INT alternate signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 2A (expanded SPI) peripherals.
+ */
+#define PMOD_EXP_SPI_INT	PMOD_IO(5)
+
+/**
+ * @brief RESET alternate signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 2A (expanded SPI) peripherals.
+ */
+#define PMOD_EXP_SPI_RESET	PMOD_IO(6)
+
+/**
+ * @brief SPI CS2 alternate signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 2A (expanded SPI) peripherals.
+ */
+#define PMOD_EXP_SPI_CS2	PMOD_IO(7)
+
+/**
+ * @brief SPI CS3 alternate signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 2A (expanded SPI) peripherals.
+ */
+#define PMOD_EXP_SPI_CS3	PMOD_IO(8)
+
+/* Expanded UART */
+
+/**
+ * @brief INT alternate signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 3A (expanded UART) peripherals.
+ */
+#define PMOD_EXP_UART_INT	PMOD_IO(5)
+
+/**
+ * @brief RESET alternate signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 3A (expanded UART) peripherals.
+ */
+#define PMOD_EXP_UART_RESET	PMOD_IO(6)
+
+/* H-bridge */
+
+/**
+ * @brief DIR signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 4 (H-bridge) peripherals.
+ */
+#define PMOD_HBRIDGE_DIR	PMOD_IO(1)
+
+/**
+ * @brief EN signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 4 (H-bridge) peripherals.
+ */
+#define PMOD_HBRIDGE_EN		PMOD_IO(2)
+
+/* Dual H-bridge */
+
+/**
+ * @brief DIR1 signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 5 (dual H-bridge) peripherals.
+ */
+#define PMOD_DUAL_HBRIDGE_DIR1	PMOD_IO(1)
+
+/**
+ * @brief EN1 signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 5 (dual H-bridge) peripherals.
+ */
+#define PMOD_DUAL_HBRIDGE_EN1	PMOD_IO(2)
+
+/**
+ * @brief DIR2 signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 5 (dual H-bridge) peripherals.
+ */
+#define PMOD_DUAL_HBRIDGE_DIR2	PMOD_IO(3)
+
+/**
+ * @brief EN2 signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 5 (dual H-bridge) peripherals.
+ */
+#define PMOD_DUAL_HBRIDGE_EN2	PMOD_IO(4)
+
+/* Expanded dual H-bridge */
+
+/**
+ * @brief DIR1 signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 5A (expanded dual H-bridge) peripherals.
+ */
+#define PMOD_EXP_DUAL_HBRIDGE_DIR1	PMOD_IO(1)
+
+/**
+ * @brief EN1 signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 5A (expanded dual H-bridge) peripherals.
+ */
+#define PMOD_EXP_DUAL_HBRIDGE_EN1	PMOD_IO(2)
+
+/**
+ * @brief DIR2 signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 5A (expanded dual H-bridge) peripherals.
+ */
+#define PMOD_EXP_DUAL_HBRIDGE_DIR2	PMOD_IO(5)
+
+/**
+ * @brief EN2 signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 5A (expanded dual H-bridge) peripherals.
+ */
+#define PMOD_EXP_DUAL_HBRIDGE_EN2	PMOD_IO(6)
+
+/* I2C */
+
+/**
+ * @brief INT signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 6 (I2C) peripherals.
+ */
+#define PMOD_I2C_INT	PMOD_IO(1)
+
+/**
+ * @brief RESET signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 6 (I2C) peripherals.
+ */
+#define PMOD_I2C_RESET	PMOD_IO(2)
+
+/**
+ * @brief SCL signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 6 (I2C) peripherals.
+ */
+#define PMOD_I2C_SCL	PMOD_IO(3)
+
+/**
+ * @brief SDA signal index on a Pmod GPIO nexus node.
+ * Used with Pmod Interface Type 6 (I2C) peripherals.
+ */
+#define PMOD_I2C_SDA	PMOD_IO(4)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_DIGILENT_PMOD_H_ */


### PR DESCRIPTION
Add a GPIO nexus binding for Pmod interface connectors. This commit also includes a header file with macros that map signal names in the Pmod specification to the corresponding indices in the GPIO nexus, meant for use in devicetree files.

There are multiple boards in the tree sporting Pmod connectors where this binding could be useful. With the right GPIO mapping nodes and pinctrl nodes added to the board definitions it becomes easy to set up the devicetree for Pmod peripherals. At Elektronikutvecklingsbyrån we already use this with some in-house boards for prototyping.

Example:
```
&spi3 {
    status = "okay";

    cs-gpios = <&pmod2 PMOD_SPI_CS GPIO_ACTIVE_LOW>;
    pinctrl-0 = <&spi3_pmod2_default>;
    pinctrl-1 = <&spi3_pmod2_sleep>;
    pinctrl-names = "default", "sleep";

    sensor@0 { /* ... */ };
};
```
