### PR TITLE
intel_adsp: cmake: add_custom_command(.mod) to fix incremental build

### DIFF
--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -55,7 +55,13 @@ endif()
 # breaks easily.  Set noload flags explicitly here.
 add_custom_target(
   gen_modules ALL
-  DEPENDS ${ZEPHYR_FINAL_EXECUTABLE}
+  DEPENDS ${CMAKE_BINARY_DIR}/zephyr/boot.mod ${CMAKE_BINARY_DIR}/zephyr/main.mod
+)
+
+add_custom_command(
+  OUTPUT  ${CMAKE_BINARY_DIR}/zephyr/boot.mod ${CMAKE_BINARY_DIR}/zephyr/main.mod
+  COMMENT "Extracting .mod(ule) files for rimage"
+  DEPENDS ${ZEPHYR_FINAL_EXECUTABLE} ${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}
 
   # The .fw_metadata section may not be present (xcc's older linker
   # will remove it if empty).  Extract it here (which will create an
@@ -102,7 +108,8 @@ add_custom_target(
 
 if(CONFIG_BUILD_OUTPUT_STRIPPED)
 add_custom_command(
-  TARGET gen_modules POST_BUILD
+  COMMENT "strip main.mod"
+  APPEND OUTPUT ${CMAKE_BINARY_DIR}/zephyr/main.mod
     COMMAND $<TARGET_PROPERTY:bintools,strip_command>
             $<TARGET_PROPERTY:bintools,strip_flag>
             $<TARGET_PROPERTY:bintools,strip_flag_all>


### PR DESCRIPTION
Now building twice back to back does not build anything the second time when CONFIG_CLEANUP_INTERMEDIATE_FILES (which obviously breaks incremental builds) is also turned off.

Fixes commit 2906d1aa51cc ("soc/intel_adsp: Build bootloader with Zephyr")

Properly implementing custom commands requires BOTH `add_custom_command()` and an `add_custom_target()` wrapper with some careful DEPENDS wizardry between them.

https://cmake.org/cmake/help/latest/command/add_custom_target.html
> Use the add_custom_command() command to generate a file with
> dependencies.

The documentation of add_custom_command() also similarly refers to add_custom_target()

When this is not done properly, the build is cursed in various, very time-consuming ways which are not officially documented but here instead:
https://samthursfield.wordpress.com/2015/11/21/cmake-dependencies-between-targets-and-files-and-custom-commands