### PR TITLE
samples: basic: hash_map increasing the stack size for cxx_unordered_map

### DIFF
--- a/samples/basic/hash_map/sample.yaml
+++ b/samples/basic/hash_map/sample.yaml
@@ -45,6 +45,7 @@ tests:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_SYS_HASH_MAP_CHOICE_CXX=y
       - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
+      - CONFIG_MAIN_STACK_SIZE=2048
   # PicoLibc
   libraries.hash_map.picolibc.separate_chaining.djb2:
     extra_configs:


### PR DESCRIPTION
When running the testcase libraries.hash_map.newlib.cxx_unordered_map.djb2 of this samples/basic/hash_map, it appears that some platforms have a too low stack size.
This PR is increasing that value to pass the testcase.

--> CONFIG_MAIN_STACK_SIZE  of 2048  is tested 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55166

Signed-off-by: Francois Ramu <francois.ramu@st.com>