### PR TITLE
usbc: explicitly declare sizes of state machines arrays

### DIFF
--- a/subsys/usb/usb_c/usbc_pe_common.c
+++ b/subsys/usb/usb_c/usbc_pe_common.c
@@ -16,7 +16,7 @@ LOG_MODULE_DECLARE(usbc_stack, CONFIG_USBC_STACK_LOG_LEVEL);
 #include "usbc_pe_common_internal.h"
 #include "usbc_pe_snk_states_internal.h"
 
-static const struct smf_state pe_states[];
+static const struct smf_state pe_states[PE_STATE_COUNT];
 
 /**
  * @brief Handle common DPM requests
@@ -976,7 +976,7 @@ static void pe_sender_response_exit(void *obj)
 /**
  * @brief Policy engine State table
  */
-static const struct smf_state pe_states[] = {
+static const struct smf_state pe_states[PE_STATE_COUNT] = {
 	/* PE Super States */
 	[PE_SENDER_RESPONSE_PARENT] = SMF_CREATE_STATE(
 		NULL,

--- a/subsys/usb/usb_c/usbc_prl.c
+++ b/subsys/usb/usb_c/usbc_prl.c
@@ -95,8 +95,8 @@ enum usbc_prl_hr_state_t {
 	PRL_HR_STATE_COUNT
 };
 
-static const struct smf_state prl_tx_states[];
-static const struct smf_state prl_hr_states[];
+static const struct smf_state prl_tx_states[PRL_TX_STATE_COUNT];
+static const struct smf_state prl_hr_states[PRL_HR_STATE_COUNT];
 
 static void prl_tx_construct_message(const struct device *dev);
 static void prl_rx_wait_for_phy_message(const struct device *dev);
@@ -1128,7 +1128,7 @@ static void prl_rx_wait_for_phy_message(const struct device *dev)
 /**
  * @brief Protocol Layer Transmit State table
  */
-static const struct smf_state prl_tx_states[] = {
+static const struct smf_state prl_tx_states[PRL_TX_STATE_COUNT] = {
 	[PRL_TX_PHY_LAYER_RESET] = SMF_CREATE_STATE(
 		prl_tx_phy_layer_reset_entry,
 		NULL,
@@ -1170,7 +1170,7 @@ BUILD_ASSERT(ARRAY_SIZE(prl_tx_states) == PRL_TX_STATE_COUNT);
 /**
  * @brief Protocol Layer Hard Reset State table
  */
-static const struct smf_state prl_hr_states[] = {
+static const struct smf_state prl_hr_states[PRL_HR_STATE_COUNT] = {
 	[PRL_HR_WAIT_FOR_REQUEST] = SMF_CREATE_STATE(
 		prl_hr_wait_for_request_entry,
 		prl_hr_wait_for_request_run,

--- a/subsys/usb/usb_c/usbc_tc_common.c
+++ b/subsys/usb/usb_c/usbc_tc_common.c
@@ -11,7 +11,7 @@ LOG_MODULE_DECLARE(usbc_stack, CONFIG_USBC_STACK_LOG_LEVEL);
 #include "usbc_tc_snk_states_internal.h"
 #include "usbc_tc_common_internal.h"
 
-static const struct smf_state tc_states[];
+static const struct smf_state tc_states[TC_STATE_COUNT];
 static void tc_init(const struct device *dev);
 
 /**
@@ -223,7 +223,7 @@ static void tc_error_recovery_run(void *obj)
 /**
  * @brief Type-C State Table
  */
-static const struct smf_state tc_states[] = {
+static const struct smf_state tc_states[TC_STATE_COUNT] = {
 	/* Super States */
 	[TC_CC_OPEN_SUPER_STATE] = SMF_CREATE_STATE(
 		tc_cc_open_entry,


### PR DESCRIPTION
The asserts in the USB-C stack functions were causing compilation errors when asserts were enabled in Kconfig.
This was caused because the asserts checked if the functions parameters were within limits specified by the state machine arrays.
At the position of these asserts, these arrays were only declared without specifying the size of them, what prohibited the asserts from knowing the size of arrays and checking if specified value is within limit of it.