### PR TITLE
Bluetooth: Audio: Move stream_reset before released callback

### DIFF
--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -451,6 +451,8 @@ static void unicast_client_ep_idle_state(struct bt_bap_ep *ep)
 		return;
 	}
 
+	bt_bap_stream_reset(stream);
+
 	/* Notify upper layer */
 	ops = stream->ops;
 	if (ops != NULL && ops->released != NULL) {
@@ -458,8 +460,6 @@ static void unicast_client_ep_idle_state(struct bt_bap_ep *ep)
 	} else {
 		LOG_WRN("No callback for released set");
 	}
-
-	bt_bap_stream_reset(stream);
 }
 
 static void unicast_client_ep_qos_update(struct bt_bap_ep *ep,


### PR DESCRIPTION
In the unicast client we should reset the stream before calling the released callback. This is so that we can reuse the stream object in the released callback.