### PR TITLE
Bluetooth: ISO: Fix BT_ISO_TX_MTU range

### DIFF
--- a/subsys/bluetooth/Kconfig.iso
+++ b/subsys/bluetooth/Kconfig.iso
@@ -96,7 +96,7 @@ config BT_ISO_TX_FRAG_COUNT
 config BT_ISO_TX_MTU
 	int "Maximum supported MTU for Isochronous TX buffers"
 	default 251
-	range 23 4095
+	range 1 4095
 	help
 	  Maximum MTU for Isochronous channels TX buffers.
 


### PR DESCRIPTION
In the Bluetooth Core Specification, the minimum
ISO_Data_Packet_Length is 0x0001, hence fix the
BT_ISO_TX_MTU range to allow a minimum value of 1.