### PR TITLE
drivers: peci: remove misplaced pwm header

### DIFF
--- a/include/zephyr/drivers/peci.h
+++ b/include/zephyr/drivers/peci.h
@@ -23,7 +23,6 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <zephyr/device.h>
-#include <zephyr/dt-bindings/pwm/pwm.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
PWM binading do not seem to belong here, removing possible wrong
inclusion of a header zephyr/dt-bindings/pwm/pwm.h.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
