### PR TITLE
ci: twister: Enable tests on bsim boards

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -35,6 +35,8 @@ jobs:
       PUSH_MATRIX_SIZE: 15
       DAILY_MATRIX_SIZE: 80
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.2
+      BSIM_OUT_PATH: /opt/bsim/
+      BSIM_COMPONENTS_PATH: /opt/bsim/components
       TESTS_PER_BUILDER: 700
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}
@@ -128,6 +130,8 @@ jobs:
         subset: ${{fromJSON(needs.twister-build-prep.outputs.subset)}}
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.2
+      BSIM_OUT_PATH: /opt/bsim/
+      BSIM_COMPONENTS_PATH: /opt/bsim/components
       TWISTER_COMMON: ' --force-color --inline-logs -v -N -M --retry-failed 3 '
       DAILY_OPTIONS: ' -M --build-only --all --show-footprint'
       PR_OPTIONS: ' --clobber-output --integration'


### PR DESCRIPTION
Since the move to github workflows
e366d7948a536951d63392dd3bc63c36212e8081
we lost the ability to run in CI in twister the bsim boards. This means people cannot use the nrf52_bsim in normal twister workflows even if it would work perfectly fine otherwise (say as a stand alone test of the controller that does not require an actual BT pair).
It also meant changes to the bsim board itself where not tested with twister like for other boards, but relied solely on the BT tests.

Enable this kind of tests again.

Fixes #54348

-------
This has uncovered a set of bugs, which are being fixed here:

- https://github.com/zephyrproject-rtos/zephyr/pull/55371
- https://github.com/zephyrproject-rtos/zephyr/pull/55374 
- https://github.com/zephyrproject-rtos/zephyr/pull/55375
  - https://github.com/zephyrproject-rtos/zephyr/pull/55397
- https://github.com/zephyrproject-rtos/zephyr/pull/55391
- https://github.com/zephyrproject-rtos/zephyr/pull/55395
- https://github.com/zephyrproject-rtos/zephyr/pull/55398
- https://github.com/zephyrproject-rtos/zephyr/pull/55548