### PR TITLE
Bluetooth: Audio: Add reason to BAP stream stopped callback

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1760,8 +1760,9 @@ struct bt_audio_stream_ops {
 	 *  stopped.
 	 *
 	 *  @param stream Stream object that has been stopped.
+	 *  @param reason BT_HCI_ERR_* reason for the disconnection.
 	 */
-	void (*stopped)(struct bt_audio_stream *stream);
+	void (*stopped)(struct bt_audio_stream *stream, uint8_t reason);
 
 #if defined(CONFIG_BT_AUDIO_UNICAST) || defined(CONFIG_BT_AUDIO_BROADCAST_SINK)
 	/** @brief Stream audio HCI receive callback.

--- a/samples/bluetooth/broadcast_audio_sink/src/main.c
+++ b/samples/bluetooth/broadcast_audio_sink/src/main.c
@@ -34,9 +34,9 @@ static void stream_started_cb(struct bt_audio_stream *stream)
 	printk("Stream %p started\n", stream);
 }
 
-static void stream_stopped_cb(struct bt_audio_stream *stream)
+static void stream_stopped_cb(struct bt_audio_stream *stream, uint8_t reason)
 {
-	printk("Stream %p stopped\n", stream);
+	printk("Stream %p stopped with reason 0x%02X\n", stream, reason);
 }
 
 static void stream_recv_cb(struct bt_audio_stream *stream,

--- a/samples/bluetooth/broadcast_audio_source/src/main.c
+++ b/samples/bluetooth/broadcast_audio_source/src/main.c
@@ -40,7 +40,7 @@ static void stream_started_cb(struct bt_audio_stream *stream)
 	k_sem_give(&sem_started);
 }
 
-static void stream_stopped_cb(struct bt_audio_stream *stream)
+static void stream_stopped_cb(struct bt_audio_stream *stream, uint8_t reason)
 {
 	k_sem_give(&sem_stopped);
 }

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -503,9 +503,9 @@ static void stream_disabled(struct bt_audio_stream *stream)
 	printk("Audio Stream %p disabled\n", stream);
 }
 
-static void stream_stopped(struct bt_audio_stream *stream)
+static void stream_stopped(struct bt_audio_stream *stream, uint8_t reason)
 {
-	printk("Audio Stream %p stopped\n", stream);
+	printk("Audio Stream %p stopped with reason 0x%02X\n", stream, reason);
 
 	/* Stop send timer */
 	k_work_cancel_delayable(&audio_send_work);

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -535,9 +535,9 @@ static void stream_recv(struct bt_audio_stream *stream,
 
 #endif
 
-static void stream_stopped(struct bt_audio_stream *stream)
+static void stream_stopped(struct bt_audio_stream *stream, uint8_t reason)
 {
-	printk("Audio Stream %p stopped\n", stream);
+	printk("Audio Stream %p stopped with reason 0x%02X\n", stream, reason);
 
 	/* Stop send timer */
 	k_work_cancel_delayable(&audio_send_work);

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -742,7 +742,7 @@ static void ascs_ep_iso_disconnected(struct bt_audio_ep *ep, uint8_t reason)
 	}
 
 	if (ops != NULL && ops->stopped != NULL) {
-		ops->stopped(stream);
+		ops->stopped(stream, reason);
 	} else {
 		LOG_WRN("No callback for stopped set");
 	}

--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -213,7 +213,7 @@ static void broadcast_sink_iso_disconnected(struct bt_iso_chan *chan,
 	broadcast_sink_set_ep_state(ep, BT_AUDIO_EP_STATE_IDLE);
 
 	if (ops != NULL && ops->stopped != NULL) {
-		ops->stopped(stream);
+		ops->stopped(stream, reason);
 	} else {
 		LOG_WRN("No callback for stopped set");
 	}

--- a/subsys/bluetooth/audio/broadcast_source.c
+++ b/subsys/bluetooth/audio/broadcast_source.c
@@ -200,7 +200,7 @@ static void broadcast_source_iso_disconnected(struct bt_iso_chan *chan, uint8_t 
 	broadcast_source_set_ep_state(ep, BT_AUDIO_EP_STATE_QOS_CONFIGURED);
 
 	if (ops != NULL && ops->stopped != NULL) {
-		ops->stopped(stream);
+		ops->stopped(stream, reason);
 	} else {
 		LOG_WRN("No callback for stopped set");
 	}

--- a/subsys/bluetooth/audio/cap_stream.c
+++ b/subsys/bluetooth/audio/cap_stream.c
@@ -94,7 +94,7 @@ static void cap_stream_started_cb(struct bt_audio_stream *bap_stream)
 	}
 }
 
-static void cap_stream_stopped_cb(struct bt_audio_stream *bap_stream)
+static void cap_stream_stopped_cb(struct bt_audio_stream *bap_stream, uint8_t reason)
 {
 	struct bt_cap_stream *cap_stream = CONTAINER_OF(bap_stream,
 							struct bt_cap_stream,
@@ -102,7 +102,7 @@ static void cap_stream_stopped_cb(struct bt_audio_stream *bap_stream)
 	struct bt_audio_stream_ops *ops = cap_stream->ops;
 
 	if (ops != NULL && ops->stopped != NULL) {
-		ops->stopped(bap_stream);
+		ops->stopped(bap_stream, reason);
 	}
 }
 

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -276,7 +276,7 @@ static void unicast_client_ep_iso_disconnected(struct bt_audio_ep *ep,
 		unicast_client_ep_idle_state(ep);
 	} else {
 		if (stream->ops != NULL && stream->ops->stopped != NULL) {
-			stream->ops->stopped(stream);
+			stream->ops->stopped(stream, reason);
 		} else {
 			LOG_WRN("No callback for stopped set");
 		}

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -1645,10 +1645,9 @@ static void stream_started_cb(struct bt_audio_stream *stream)
 	printk("Stream %p started\n", stream);
 }
 
-static void stream_stopped_cb(struct bt_audio_stream *stream)
+static void stream_stopped_cb(struct bt_audio_stream *stream, uint8_t reason)
 {
-	printk("Stream %p stopped\n", stream);
-
+	printk("Stream %p stopped with reason 0x%02X\n", stream, reason);
 
 #if defined(CONFIG_LIBLC3)
 	if (stream == default_stream) {

--- a/tests/bluetooth/bsim/audio/src/broadcast_sink_test.c
+++ b/tests/bluetooth/bsim/audio/src/broadcast_sink_test.c
@@ -154,9 +154,9 @@ static void started_cb(struct bt_audio_stream *stream)
 	k_sem_give(&sem_started);
 }
 
-static void stopped_cb(struct bt_audio_stream *stream)
+static void stopped_cb(struct bt_audio_stream *stream, uint8_t reason)
 {
-	printk("Stream %p stopped\n", stream);
+	printk("Stream %p stopped with reason 0x%02X\n", stream, reason);
 	k_sem_give(&sem_stopped);
 }
 

--- a/tests/bluetooth/bsim/audio/src/broadcast_source_test.c
+++ b/tests/bluetooth/bsim/audio/src/broadcast_source_test.c
@@ -44,9 +44,9 @@ static void started_cb(struct bt_audio_stream *stream)
 	k_sem_give(&sem_started);
 }
 
-static void stopped_cb(struct bt_audio_stream *stream)
+static void stopped_cb(struct bt_audio_stream *stream, uint8_t reason)
 {
-	printk("Stream %p stopped\n", stream);
+	printk("Stream %p stopped with reason 0x%02X\n", stream, reason);
 	k_sem_give(&sem_stopped);
 }
 

--- a/tests/bluetooth/bsim/audio/src/cap_acceptor_test.c
+++ b/tests/bluetooth/bsim/audio/src/cap_acceptor_test.c
@@ -171,9 +171,9 @@ static void started_cb(struct bt_audio_stream *stream)
 	k_sem_give(&sem_broadcast_started);
 }
 
-static void stopped_cb(struct bt_audio_stream *stream)
+static void stopped_cb(struct bt_audio_stream *stream, uint8_t reason)
 {
-	printk("Stream %p stopped\n", stream);
+	printk("Stream %p stopped with reason 0x%02X\n", stream, reason);
 	k_sem_give(&sem_broadcast_stopped);
 }
 

--- a/tests/bluetooth/bsim/audio/src/cap_initiator_test.c
+++ b/tests/bluetooth/bsim/audio/src/cap_initiator_test.c
@@ -47,9 +47,9 @@ static void broadcast_started_cb(struct bt_audio_stream *stream)
 	k_sem_give(&sem_broadcast_started);
 }
 
-static void broadcast_stopped_cb(struct bt_audio_stream *stream)
+static void broadcast_stopped_cb(struct bt_audio_stream *stream, uint8_t reason)
 {
-	printk("Stream %p stopped\n", stream);
+	printk("Stream %p stopped with reason 0x%02X\n", stream, reason);
 	k_sem_give(&sem_broadcast_stopped);
 }
 

--- a/tests/bluetooth/bsim/audio/src/unicast_client_test.c
+++ b/tests/bluetooth/bsim/audio/src/unicast_client_test.c
@@ -72,9 +72,9 @@ static void stream_disabled(struct bt_audio_stream *stream)
 	printk("Disabled stream %p\n", stream);
 }
 
-static void stream_stopped(struct bt_audio_stream *stream)
+static void stream_stopped(struct bt_audio_stream *stream, uint8_t reason)
 {
-	printk("Stopped stream %p\n", stream);
+	printk("Stopped stream %p with reason 0x%02X\n", stream, reason);
 }
 
 static void stream_released(struct bt_audio_stream *stream)


### PR DESCRIPTION
Forwards the reason parameter from the ISO disconnect to the stream stopped callback.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/47724