### PR TITLE
Samples: zbus: benchmark: Exclude nrf52_bsim

### DIFF
--- a/samples/subsys/zbus/benchmark/sample.yaml
+++ b/samples/subsys/zbus/benchmark/sample.yaml
@@ -21,6 +21,7 @@ tests:
       - CONFIG_BM_ASYNC=y
       - arch:nios2:CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
       - CONFIG_IDLE_STACK_SIZE=1024
+    platform_exclude: nrf52_bsim
   sample.zbus.benchmark_sync:
     tags: zbus
     min_ram: 16
@@ -41,3 +42,4 @@ tests:
       - CONFIG_BM_ASYNC=n
       - arch:nios2:CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
       - CONFIG_IDLE_STACK_SIZE=1024
+    platform_exclude: nrf52_bsim

--- a/samples/subsys/zbus/benchmark/src/benchmark.c
+++ b/samples/subsys/zbus/benchmark/src/benchmark.c
@@ -13,9 +13,11 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/zbus/zbus.h>
 
-#if defined(CONFIG_ARCH_POSIX)
+#if defined(CONFIG_BOARD_NATIVE_POSIX)
 #include "native_rtc.h"
 #define GET_ARCH_TIME_NS() (native_rtc_gettime_us(RTC_CLOCK_PSEUDOHOSTREALTIME) * NSEC_PER_USEC)
+#elif defined(CONFIG_ARCH_POSIX)
+#error "This sample cannot be built for other POSIX arch boards than native_posix"
 #else
 #define GET_ARCH_TIME_NS() (k_cyc_to_ns_near32(sys_clock_cycle_get_32()))
 #endif


### PR DESCRIPTION
For the POSIX arch, this test relays on the native_posix RTC. But that does not exist in the nrf52_bsim.
And without something to measure actual execution time, it does not make sense to benchmark in the POSIX arch. So disable this test for this platform,
and add a clear build error to warn users.