### PR TITLE
samples: bluetooth: PAST: Disable for nrf52_bsim

### DIFF
--- a/samples/bluetooth/central_past/sample.yaml
+++ b/samples/bluetooth/central_past/sample.yaml
@@ -3,7 +3,7 @@ sample:
 tests:
   sample.bluetooth.central_past:
     harness: bluetooth
-    platform_allow: qemu_cortex_m3 qemu_x86 nrf52_bsim
+    platform_allow: qemu_cortex_m3 qemu_x86
     integration_platforms:
       - qemu_cortex_m3
     tags: bluetooth

--- a/samples/bluetooth/peripheral_past/sample.yaml
+++ b/samples/bluetooth/peripheral_past/sample.yaml
@@ -3,7 +3,7 @@ sample:
 tests:
   sample.bluetooth.peripheral_past:
     harness: bluetooth
-    platform_allow: qemu_cortex_m3 qemu_x86 nrf52_bsim
+    platform_allow: qemu_cortex_m3 qemu_x86
     tags: bluetooth
     integration_platforms:
       - qemu_cortex_m3


### PR DESCRIPTION
The Zephyr controller does not support PAST, and there is no other controller we can build upstream with these samples for this board.

Disable these 2 samples for the nrf52_bsim until PAST is supported by the controller.