### PR TITLE
drivers: sdhc: add support for configurable power on delay to SPI SDHC

### DIFF
--- a/drivers/sdhc/sdhc_spi.c
+++ b/drivers/sdhc/sdhc_spi.c
@@ -82,6 +82,7 @@ struct sdhc_spi_config {
 	const struct device *spi_dev;
 	const struct gpio_dt_spec pwr_gpio;
 	const uint32_t spi_max_freq;
+	uint32_t power_delay_ms;
 };
 
 struct sdhc_spi_data {
@@ -718,7 +719,7 @@ static int sdhc_spi_get_host_props(const struct device *dev,
 
 	props->f_min = SDMMC_CLOCK_400KHZ;
 	props->f_max = cfg->spi_max_freq;
-	props->power_delay = 1000; /* SPI always needs 1ms power delay */
+	props->power_delay = cfg->power_delay_ms;
 	props->host_caps.vol_330_support = true;
 	props->is_spi = true;
 	return 0;
@@ -762,6 +763,7 @@ static struct sdhc_driver_api sdhc_spi_api = {
 		.spi_dev = DEVICE_DT_GET(DT_INST_PARENT(n)),			\
 		.pwr_gpio = GPIO_DT_SPEC_INST_GET_OR(n, pwr_gpios, {0}),	\
 		.spi_max_freq = DT_INST_PROP(n, spi_max_frequency),		\
+		.power_delay_ms = DT_INST_PROP(n, power_delay_ms),		\
 	};									\
 										\
 	struct sdhc_spi_data sdhc_spi_data_##n = {				\

--- a/dts/bindings/sdhc/zephyr,sdhc-spi-slot.yaml
+++ b/dts/bindings/sdhc/zephyr,sdhc-spi-slot.yaml
@@ -4,4 +4,13 @@ compatible: "zephyr,sdhc-spi-slot"
 
 include: [spi-device.yaml]
 
+properties:
+  power-delay-ms:
+    type: int
+    default: 1
+    description: |
+      Time in ms for SPI SDHC to delay when toggling power to the SD card. This
+      delay gives the card time to power up or down fully. It can be increased
+      if you observe issues initializing your card.
+
 bus: sd


### PR DESCRIPTION
Add support for configuring power on delay when using SPI SDHC. This allows cards that reliably initialize with a shorter (1ms) delay to avoid the long initialize delay otherwise imposed.