### PR TITLE
logging: add support for 64 bit timestamps with Linux format

### DIFF
--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -276,7 +276,11 @@ static int timestamp_print(const struct log_output *output,
 		} else {
 			if (IS_ENABLED(CONFIG_LOG_OUTPUT_FORMAT_LINUX_TIMESTAMP)) {
 				length = print_formatted(output,
-							"[%5ld.%06d] ",
+#if defined(CONFIG_LOG_TIMESTAMP_64BIT)
+							"[%5llu.%06d] ",
+#else
+							"[%5lu.%06d] ",
+#endif
 							total_seconds, ms * 1000U + us);
 			} else {
 				length = print_formatted(output,


### PR DESCRIPTION
Combining CONFIG_LOG_OUTPUT_FORMAT_LINUX_TIMESTAMP and CONFIG_LOG_TIMESTAMP_64BIT results in a wrong timestamp, as the Linux timestamp format print call assumes a 32 bit variable for the seconds. Fix it by using a different print format for 64 bit timestamps.

Fixes: #55372