### PR TITLE
tests: logging: log_msg: Filter platforms with LOG_ALWAYS_RUNTIME set

### DIFF
--- a/tests/subsys/logging/log_msg/testcase.yaml
+++ b/tests/subsys/logging/log_msg/testcase.yaml
@@ -5,6 +5,7 @@ common:
   tags: log_api logging
   integration_platforms:
     - native_posix
+  filter: not CONFIG_LOG_ALWAYS_RUNTIME
 tests:
   logging.log_msg:
     extra_configs:


### PR DESCRIPTION
Test is checking behavior of compile time macros used for generation of log messages thus if platform enforces runtime approach does macros are not available and complilation fails.