### PR TITLE
samples: fix path to tensorflow lite micro examples

### DIFF
--- a/samples/modules/tflite-micro/hello_world/README.rst
+++ b/samples/modules/tflite-micro/hello_world/README.rst
@@ -37,7 +37,7 @@ on any sensors.
 The reference kernel application can be built and executed on QEMU as follows:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/modules/tensorflow/hello_world
+   :zephyr-app: samples/modules/tflite-micro/hello_world
    :host-os: unix
    :board: qemu_x86
    :goals: run

--- a/samples/modules/tflite-micro/magic_wand/README.rst
+++ b/samples/modules/tflite-micro/magic_wand/README.rst
@@ -28,7 +28,7 @@ The application can be built for the :ref:`litex-vexriscv` for
 emulation in Renode as follows:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/tensorflow/magic_wand
+   :zephyr-app: samples/modules/tflite-micro/magic_wand
    :host-os: unix
    :board: litex_vexriscv
    :goals: build

--- a/samples/modules/tflite-micro/tflm_ethosu/README.rst
+++ b/samples/modules/tflite-micro/tflm_ethosu/README.rst
@@ -33,5 +33,5 @@ commands.
 
 .. code-block:: bash
 
-    $ west build -b mps3_an547 zephyr/samples/tflm_ethosu
+    $ west build -b mps3_an547 zephyr/samples/modules/tflite-micro/tflm_ethosu
     $ FVP_Corstone_SSE-300_Ethos-U55 build/zephyr/zephyr.elf


### PR DESCRIPTION
The samples under the tensorflow modules directory has been renamed since commit 6fd1b024962bd379c20a0ef97964d01fc45aff2c. However, the path in their README.rst was not updated.

Additionnaly, the modules top directory under the samples is missing for the samples magic_wand and tflm_ethosu.

This fixes the path to the tensorflow lite micro samples in their README.rst.