### PR TITLE
rtio: Fix for all POSIX arch platforms

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -782,11 +782,11 @@ static inline int z_impl_rtio_submit(struct rtio *r, uint32_t wait_count)
 	}
 #else
 	while (rtio_spsc_consumable(r->cq) < wait_count) {
-#ifdef CONFIG_BOARD_NATIVE_POSIX
-		k_busy_wait(1);
+#ifdef CONFIG_ARCH_POSIX
+		k_busy_wait(10);
 #else
 		k_yield();
-#endif /* CONFIG_BOARD_NATIVE_POSIX */
+#endif /* CONFIG_ARCH_POSIX */
 	}
 #endif
 


### PR DESCRIPTION
The same k_busy_wait needed for native_posix is needed for all POSIX arch platforms.
Also increase that busy wait a bit. There is no point of waiting for just 1 microsecond at a time, and waiting a bit longer speeds up the test.

Fixes 
samples/subsys/rtio/sensor_batch_processing/sample.rtio.sensor_batch_processing 
&
tests/subsys/rtio/rtio_api/subsys.rtio.api 
on nrf52_bsim