### PR TITLE
i2c: shell: Fix shell error output

### DIFF
--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -163,7 +163,7 @@ static int i2c_write_from_buffer(const struct shell *shell_ctx,
 			buf + MAX_BYTES_FOR_REGISTER_INDEX - reg_addr_bytes,
 			reg_addr_bytes + data_length, dev_addr);
 	if (ret < 0) {
-		shell_error(shell_ctx, "Failed to read from device: %s",
+		shell_error(shell_ctx, "Failed to write to device: %s",
 			    s_dev_addr);
 		return -EIO;
 	}


### PR DESCRIPTION
The i2c shell write command outputs the error "Failed to read from device" while it tries to write data to device.

This fixes the error by outputting "Failed to write to device" instead.

Fixes:

	uart:~$ i2c write i2c@3ff53000 23 01
	Failed to read from device: 23