### PR TITLE
include/sys/util: Fix WAIT_FOR for POSIX_ARCH

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -617,6 +617,7 @@ char *utf8_lcpy(char *dst, const char *src, size_t n);
 		uint32_t start = k_cycle_get_32();                                                 \
 		while (!(expr) && (cycle_count > (k_cycle_get_32() - start))) {                    \
 			delay_stmt;                                                                \
+			Z_SPIN_DELAY(10);                                                          \
 		}                                                                                  \
 		(expr);                                                                            \
 	})

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -579,6 +579,24 @@ char *utf8_lcpy(char *dst, const char *src, size_t n);
 #define MHZ(x) (KHZ(x) * 1000)
 
 /**
+ * @brief For the POSIX architecture add a minimal delay in a busy wait loop.
+ * For other architectures this is a no-op.
+ *
+ * In the POSIX ARCH, code takes zero simulated time to execute,
+ * so busy wait loops become infinite loops, unless we
+ * force the loop to take a bit of time.
+ * Include this macro in all busy wait/spin loops
+ * so they will also work when building for the POSIX architecture.
+ *
+ * @param t Time in microseconds we will busy wait
+ */
+#if defined(CONFIG_ARCH_POSIX)
+#define Z_SPIN_DELAY(t) k_busy_wait(t)
+#else
+#define Z_SPIN_DELAY(t)
+#endif
+
+/**
  * @brief Wait for an expression to return true with a timeout
  *
  * Spin on an expression with a timeout and optional delay between iterations

--- a/tests/lib/sys_util/testcase.yaml
+++ b/tests/lib/sys_util/testcase.yaml
@@ -1,4 +1,3 @@
 tests:
   libraries.sys_util:
-    platform_exclude: native_posix native_posix_64
     tags: sys_util


### PR DESCRIPTION
WAIT_FOR is a busy wait loop, which in the POSIX ARCH should include a very minor delay in each iteration.

After this fix, tests/lib/sys_util does not need to exclude native_posix anymore.