### PR TITLE
subsys/storage/flash_map: remove unnecessary includes

### DIFF
--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -16,7 +16,6 @@
 #include <zephyr/storage/flash_map.h>
 #include "flash_map_priv.h"
 #include <zephyr/drivers/flash.h>
-#include <soc.h>
 #include <zephyr/init.h>
 
 void flash_area_foreach(flash_area_cb_t user_cb, void *user_data)

--- a/subsys/storage/flash_map/flash_map_integrity.c
+++ b/subsys/storage/flash_map/flash_map_integrity.c
@@ -16,7 +16,6 @@
 #include <zephyr/storage/flash_map.h>
 #include "flash_map_priv.h"
 #include <zephyr/drivers/flash.h>
-#include <soc.h>
 #include <zephyr/init.h>
 
 #if defined(CONFIG_FLASH_AREA_CHECK_INTEGRITY)

--- a/subsys/storage/flash_map/flash_map_layout.c
+++ b/subsys/storage/flash_map/flash_map_layout.c
@@ -15,7 +15,6 @@
 #include <zephyr/device.h>
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/drivers/flash.h>
-#include <soc.h>
 #include <zephyr/init.h>
 
 struct layout_data {


### PR DESCRIPTION
Those files includes soc.h header which exists not for all boards. soc.h consists soc-depended defenitions and need to be included by soc-depended sources