### PR TITLE
samples: net: sockets: echo_client: Fix userspace crash

### DIFF
--- a/samples/net/sockets/echo_client/src/common.h
+++ b/samples/net/sockets/echo_client/src/common.h
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/kernel.h>
+
 /* Value of 0 will cause the IP stack to select next free port */
 #define MY_PORT 0
 
@@ -27,17 +29,23 @@ extern struct k_mem_domain app_domain;
 #define THREAD_PRIORITY K_PRIO_COOP(CONFIG_NUM_COOP_PRIORITIES - 1)
 #endif
 
+#define UDP_STACK_SIZE 2048
+
+struct udp_control {
+	struct k_poll_signal tx_signal;
+	struct k_timer tx_timer;
+	struct k_timer rx_timer;
+};
+
 struct data {
 	const char *proto;
 
 	struct {
 		int sock;
-		/* Work controlling udp data sending */
-		struct k_work_delayable recv;
-		struct k_work_delayable transmit;
 		uint32_t expecting;
 		uint32_t counter;
 		uint32_t mtu;
+		struct udp_control *ctrl;
 	} udp;
 
 	struct {
@@ -65,6 +73,10 @@ extern const char lorem_ipsum[];
 extern const int ipsum_len;
 extern struct configs conf;
 
+/* init_udp initializes kernel objects, hence it has to be called from
+ * supervisor thread.
+ */
+void init_udp(void);
 int start_udp(void);
 int process_udp(void);
 void stop_udp(void);

--- a/samples/net/sockets/echo_client/src/echo-client.c
+++ b/samples/net/sockets/echo_client/src/echo-client.c
@@ -275,6 +275,7 @@ static void init_app(void)
 	}
 
 	init_vlan();
+	init_udp();
 }
 
 static int start_client(void)


### PR DESCRIPTION
Similarily to `echo_server` sample, `echo_client` had to get rid of `k_work_*` API usage from the user thread. This time howerver, the changes needed are considerably more complex, as `k_work_*` API was actively used for communication in the UDP module.

This PR reworks the sample as follows:
  * Replace delayed work items with combination of `k_timer` and a
    dedicated thread to send UDP packets. `k_poll_signal` is used for
    communication between `k_timer` callback and UDP thread.
  * As kernel objects should not be placed in a memory modifiable from
    user threads, declare a separate structure for them, and link it
    with the client context structure with a pointer.
  * `k_timer_init()` is not a system call, therefore it has to be called
    from supervisor thread. Therefore, add an additional function to
    initialize UDP, and use it to initialize kernel objects used by the
    UDP module and grant access for the main thread before it becomes an
    user thread. UDP thread inherits permissions from the parent (main
    thread).

Note, that this sample is also affected by https://github.com/zephyrproject-rtos/zephyr/issues/55323, so all testing has been done with logger runtime filtering disabled: `CONFIG_LOG_RUNTIME_FILTERING=n`.
