### PR TITLE
Shell vt100 function runtime enable/disable

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -1189,6 +1189,18 @@ int shell_insert_mode_set(const struct shell *shell, bool val);
 int shell_use_colors_set(const struct shell *shell, bool val);
 
 /**
+ * @brief Allow application to control whether terminal is using vt100 commands.
+ * Value is modified atomically and the previous value is returned.
+ *
+ * @param[in] sh	Pointer to the shell instance.
+ * @param[in] val	vt100 mode.
+ *
+ * @retval 0 or 1: previous value
+ * @retval -EINVAL if shell is NULL.
+ */
+int shell_use_vt100_set(const struct shell *sh, bool val);
+
+/**
  * @brief Allow application to control whether user input is echoed back.
  * Value is modified atomically and the previous value is returned.
  *

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1658,6 +1658,15 @@ int shell_use_colors_set(const struct shell *shell, bool val)
 	return (int)z_flag_use_colors_set(shell, val);
 }
 
+int shell_use_vt100_set(const struct shell *sh, bool val)
+{
+	if (sh == NULL) {
+		return -EINVAL;
+	}
+
+	return (int)z_flag_use_vt100_set(sh, val);
+}
+
 int shell_echo_set(const struct shell *shell, bool val)
 {
 	if (shell == NULL) {

--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -24,6 +24,9 @@
 #define SHELL_HELP_COLORS		"Toggle colored syntax."
 #define SHELL_HELP_COLORS_OFF		"Disable colored syntax."
 #define SHELL_HELP_COLORS_ON		"Enable colored syntax."
+#define SHELL_HELP_VT100		"Toggle vt100 commands."
+#define SHELL_HELP_VT100_OFF		"Disable vt100 commands."
+#define SHELL_HELP_VT100_ON		"Enable vt100 commands."
 #define SHELL_HELP_STATISTICS		"Shell statistics."
 #define SHELL_HELP_STATISTICS_SHOW	\
 	"Get shell statistics for the Logger module."
@@ -260,6 +263,26 @@ static int cmd_colors_on(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
+static int cmd_vt100_off(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	z_flag_use_vt100_set(sh, false);
+
+	return 0;
+}
+
+static int cmd_vt100_on(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argv);
+	ARG_UNUSED(argv);
+
+	z_flag_use_vt100_set(sh, true);
+
+	return 0;
+}
+
 static int cmd_echo_off(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
@@ -415,6 +438,14 @@ SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_colors,
 	SHELL_SUBCMD_SET_END
 );
 
+SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_vt100,
+	SHELL_COND_CMD_ARG(CONFIG_SHELL_VT100_COMMANDS, off, NULL,
+			   SHELL_HELP_VT100_OFF, cmd_vt100_off, 1, 0),
+	SHELL_COND_CMD_ARG(CONFIG_SHELL_VT100_COMMANDS, on, NULL,
+			   SHELL_HELP_VT100_ON, cmd_vt100_on, 1, 0),
+	SHELL_SUBCMD_SET_END
+);
+
 SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_echo,
 	SHELL_CMD_ARG(off, NULL, SHELL_HELP_ECHO_OFF, cmd_echo_off, 1, 0),
 	SHELL_CMD_ARG(on, NULL, SHELL_HELP_ECHO_ON, cmd_echo_on, 1, 0),
@@ -443,6 +474,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_shell,
 			SHELL_HELP_BACKSPACE_MODE, NULL),
 	SHELL_COND_CMD(CONFIG_SHELL_VT100_COMMANDS, colors, &m_sub_colors,
 		       SHELL_HELP_COLORS, NULL),
+	SHELL_COND_CMD(CONFIG_SHELL_VT100_COMMANDS, vt100, &m_sub_vt100,
+		       SHELL_HELP_VT100, NULL),
 	SHELL_CMD_ARG(echo, &m_sub_echo, SHELL_HELP_ECHO, cmd_echo, 1, 1),
 	SHELL_COND_CMD(CONFIG_SHELL_STATS, stats, &m_sub_shell_stats,
 			SHELL_HELP_STATISTICS, NULL),


### PR DESCRIPTION
Added shell commands to enable and disable vt100 commands in runtime.

Added API function `shell_use_vt100_set` that allows the application to enable/disable vt100.

Command and function are based on color function and command.