### PR TITLE
wifi: shell: Rectify data type of beacon interval and DTIM period

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -181,8 +181,8 @@ struct wifi_iface_status {
 	enum wifi_security_type security;
 	enum wifi_mfp_options mfp;
 	int rssi;
-	unsigned short dtim_period;
-	unsigned char beacon_interval;
+	unsigned char dtim_period;
+	unsigned short beacon_interval;
 };
 
 struct wifi_ps_params {


### PR DESCRIPTION
Data types of beacon interval and DTIM period are defined incorrectly.

dtim_period=1-255, so, unsigned char 802.11-202: 9.4.2.5.1 General.

beacon_interval=2 bytes, so, unsigned short: 802.11-2020 - 9.4.1.3 Beacon Interval field.