### PR TITLE
soc: nrf53: Restore accidentally removed suppress_message flag check

### DIFF
--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -171,7 +171,7 @@ bool z_arm_on_enter_cpu_idle(void)
 
 	if (ok_to_sleep) {
 		suppress_message = false;
-	} else {
+	} else if (!suppress_message) {
 		LOG_DBG("Anomaly 160 trigger conditions detected.");
 		suppress_message = true;
 	}


### PR DESCRIPTION
This is a follow-up to commit 7195db01f45d8045c3dc8e982155694ee6d06928.

Restore the check that was accidentally removed in the above commit, so that the message is again logged only once per detection of the anomaly 160 conditions.