### PR TITLE
Bluetooth: Shell: Add indication of default_conn in connections cmd

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -3011,21 +3011,19 @@ static void connection_info(struct bt_conn *conn, void *user_data)
 #if defined(CONFIG_BT_BREDR)
 	case BT_CONN_TYPE_BR:
 		bt_addr_to_str(info.br.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, "#%u [BR][%s] %s", info.id,
-			    role_str(info.role), addr);
+		shell_print(ctx_shell, " #%u [BR][%s] %s", info.id, role_str(info.role), addr);
 		break;
 #endif
 	case BT_CONN_TYPE_LE:
 		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, "#%u [LE][%s] %s: Interval %u latency %u"
-			    " timeout %u", info.id, role_str(info.role), addr,
+		shell_print(ctx_shell, "%s#%u [LE][%s] %s: Interval %u latency %u timeout %u",
+			    conn == default_conn ? "*" : " ", info.id, role_str(info.role), addr,
 			    info.le.interval, info.le.latency, info.le.timeout);
 		break;
 #if defined(CONFIG_BT_ISO)
 	case BT_CONN_TYPE_ISO:
 		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, "#%u [ISO][%s] %s", info.id,
-			    role_str(info.role), addr);
+		shell_print(ctx_shell, " #%u [ISO][%s] %s", info.id, role_str(info.role), addr);
 		break;
 #endif
 	}


### PR DESCRIPTION
When doing "bt connections" the currently selected ACL (default_conn) is now indicated with a "*" making it easier to determine which of the connections is currently selected.