### PR TITLE
util: Replace all POSIX arch busy_waits with Z_SPIN_DELAY

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -757,11 +757,8 @@ static inline int z_impl_rtio_submit(struct rtio *r, uint32_t wait_count)
 	}
 #else
 	while (rtio_spsc_consumable(r->cq) < wait_count) {
-#ifdef CONFIG_ARCH_POSIX
-		k_busy_wait(10);
-#else
+		Z_SPIN_DELAY(10);
 		k_yield();
-#endif /* CONFIG_ARCH_POSIX */
 	}
 #endif
 

--- a/samples/subsys/logging/logger/src/main.c
+++ b/samples/subsys/logging/logger/src/main.c
@@ -206,9 +206,7 @@ static void performance_showcase(void)
 		start_timestamp = timestamp_get();
 
 		while (start_timestamp == timestamp_get()) {
-	#if (CONFIG_ARCH_POSIX)
-			k_busy_wait(100);
-	#endif
+			Z_SPIN_DELAY(100);
 		}
 
 		start_timestamp = timestamp_get();
@@ -217,9 +215,7 @@ static void performance_showcase(void)
 			LOG_INF("performance test - log message %d", cnt);
 			cnt++;
 			current_timestamp = timestamp_get();
-	#if (CONFIG_ARCH_POSIX)
-			k_busy_wait(100);
-	#endif
+			Z_SPIN_DELAY(100);
 		} while (current_timestamp < (start_timestamp + window));
 
 		wait_on_log_flushed();

--- a/tests/kernel/common/src/clock.c
+++ b/tests/kernel/common/src/clock.c
@@ -6,21 +6,12 @@
 
 #include <zephyr/ztest.h>
 
-#if defined(CONFIG_ARCH_POSIX)
 #define ALIGN_MS_BOUNDARY		       \
 	do {				       \
 		uint32_t t = k_uptime_get_32();   \
 		while (t == k_uptime_get_32()) \
-			k_busy_wait(50);       \
+			Z_SPIN_DELAY(50);      \
 	} while (0)
-#else
-#define ALIGN_MS_BOUNDARY		       \
-	do {				       \
-		uint32_t t = k_uptime_get_32();   \
-		while (t == k_uptime_get_32()) \
-			;		       \
-	} while (0)
-#endif
 
 struct timer_data {
 	int duration_count;
@@ -55,17 +46,13 @@ ZTEST_USER(clock, test_clock_uptime)
 	/**TESTPOINT: uptime elapse*/
 	t64 = k_uptime_get();
 	while (k_uptime_get() < (t64 + 5)) {
-#if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(50);
-#endif
+		Z_SPIN_DELAY(50);
 	}
 
 	/**TESTPOINT: uptime elapse lower 32-bit*/
 	t32 = k_uptime_get_32();
 	while (k_uptime_get_32() < (t32 + 5)) {
-#if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(50);
-#endif
+		Z_SPIN_DELAY(50);
 	}
 
 	/**TESTPOINT: uptime straddled ms boundary*/
@@ -76,9 +63,7 @@ ZTEST_USER(clock, test_clock_uptime)
 	/**TESTPOINT: uptime delta*/
 	d64 = k_uptime_delta(&d64);
 	while (k_uptime_delta(&d64) == 0) {
-#if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(50);
-#endif
+		Z_SPIN_DELAY(50);
 	}
 }
 
@@ -132,9 +117,7 @@ ZTEST(clock, test_clock_cycle_32)
 	/*break if cycle counter wrap around*/
 	while (k_cycle_get_32() > c32 &&
 	       k_cycle_get_32() < (c32 + k_ticks_to_cyc_floor32(1))) {
-#if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(50);
-#endif
+		Z_SPIN_DELAY(50);
 	}
 
 	/**TESTPOINT: cycle/uptime cross check*/
@@ -142,9 +125,7 @@ ZTEST(clock, test_clock_cycle_32)
 	ALIGN_MS_BOUNDARY;
 	t32 = k_uptime_get_32();
 	while (t32 == k_uptime_get_32()) {
-#if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(50);
-#endif
+		Z_SPIN_DELAY(50);
 	}
 
 	c1 = k_uptime_get_32();

--- a/tests/kernel/common/src/timeout_order.c
+++ b/tests/kernel/common/src/timeout_order.c
@@ -66,9 +66,7 @@ ZTEST(common_1cpu, test_timeout_order)
 
 	/* sync on tick */
 	while (uptime == k_uptime_get_32()) {
-#if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(50);
-#endif
+		Z_SPIN_DELAY(50);
 	}
 
 	for (ii = 0; ii < NUM_TIMEOUTS; ii++) {

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -254,9 +254,7 @@ static void _test_kernel_cpu_idle(int atomic)
 	/* Align to a "ms boundary". */
 	tms = k_uptime_get_32();
 	while (tms == k_uptime_get_32()) {
-#if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(50);
-#endif
+		Z_SPIN_DELAY(50);
 	}
 
 	tms = k_uptime_get_32();
@@ -396,16 +394,12 @@ static void _test_kernel_interrupts(disable_int_func disable_int,
 	/* Align to a "tick boundary" */
 	tick = sys_clock_tick_get_32();
 	while (sys_clock_tick_get_32() == tick) {
-#if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(1000);
-#endif
+		Z_SPIN_DELAY(1000);
 	}
 
 	tick++;
 	while (sys_clock_tick_get_32() == tick) {
-#if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(1000);
-#endif
+		Z_SPIN_DELAY(1000);
 		count++;
 	}
 
@@ -422,9 +416,7 @@ static void _test_kernel_interrupts(disable_int_func disable_int,
 	tick = sys_clock_tick_get_32();
 	for (i = 0; i < count; i++) {
 		sys_clock_tick_get_32();
-#if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(1000);
-#endif
+		Z_SPIN_DELAY(1000);
 	}
 
 	tick2 = sys_clock_tick_get_32();
@@ -446,9 +438,7 @@ static void _test_kernel_interrupts(disable_int_func disable_int,
 	/* Now repeat with interrupts unlocked. */
 	for (i = 0; i < count; i++) {
 		sys_clock_tick_get_32();
-#if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(1000);
-#endif
+		Z_SPIN_DELAY(1000);
 	}
 
 	tick2 = sys_clock_tick_get_32();

--- a/tests/kernel/sched/preempt/src/main.c
+++ b/tests/kernel/sched/preempt/src/main.c
@@ -117,18 +117,7 @@ void wakeup_src_thread(int id)
 
 	while (do_sleep && !(src_thread->base.thread_state & _THREAD_PENDING)) {
 		/* spin, waiting on the sleep timeout */
-#if defined(CONFIG_ARCH_POSIX)
-		/**
-		 * In the posix arch busy wait loops waiting for something to
-		 * happen need to halt the CPU due to the infinitely fast clock
-		 * assumption. (Or in plain English: otherwise you hang in this
-		 * loop. Because the posix arch emulates having 1 CPU by only
-		 * enabling 1 thread at a time. And because it assumes code
-		 * executes in 0 time: it always waits for the code to finish
-		 * and it letting the cpu sleep before letting time pass)
-		 */
-		k_busy_wait(50);
-#endif
+		Z_SPIN_DELAY(50);
 	}
 
 	/* We are lowest priority, SOMEONE must have run */

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -177,9 +177,7 @@ ZTEST(threads_scheduling, test_slice_reset)
 		/* current thread (ztest native) consumed a half timeslice */
 		t32 = k_cycle_get_32();
 		while (k_cycle_get_32() - t32 < half_slice_cyc) {
-#if defined(CONFIG_ARCH_POSIX)
-			k_busy_wait(50);
-#endif
+			Z_SPIN_DELAY(50);
 		}
 
 		/* relinquish CPU and wait for each thread to complete */

--- a/tests/kernel/sleep/src/main.c
+++ b/tests/kernel/sleep/src/main.c
@@ -83,9 +83,7 @@ static void align_to_tick_boundary(void)
 	tick = k_uptime_get_32();
 	while (k_uptime_get_32() == tick) {
 		/* Busy wait to align to tick boundary */
-#if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(50);
-#endif
+		Z_SPIN_DELAY(50);
 	}
 
 }

--- a/tests/kernel/tickless/tickless_concept/src/main.c
+++ b/tests/kernel/tickless/tickless_concept/src/main.c
@@ -27,21 +27,13 @@ static struct k_thread tdata[NUM_THREAD];
 #define SLICE_SIZE_LIMIT k_ticks_to_ms_floor64((IDLE_THRESH >> 1) + 1)
 
 /*align to millisecond boundary*/
-#if defined(CONFIG_ARCH_POSIX)
 #define ALIGN_MS_BOUNDARY()		       \
 	do {				       \
 		uint32_t t = k_uptime_get_32();   \
 		while (t == k_uptime_get_32()) \
-			k_busy_wait(50);       \
+			Z_SPIN_DELAY(50);       \
 	} while (0)
-#else
-#define ALIGN_MS_BOUNDARY()		       \
-	do {				       \
-		uint32_t t = k_uptime_get_32();   \
-		while (t == k_uptime_get_32()) \
-			;		       \
-	} while (0)
-#endif
+
 K_SEM_DEFINE(sema, 0, NUM_THREAD);
 static int64_t elapsed_slice;
 

--- a/tests/kernel/workq/critical/src/main.c
+++ b/tests/kernel/workq/critical/src/main.c
@@ -100,14 +100,7 @@ uint32_t critical_loop(const char *tag, uint32_t count)
 		k_work_init(&work_item, critical_rtn);
 		k_work_submit_to_queue(&offload_work_q, &work_item);
 		count++;
-#if defined(CONFIG_ARCH_POSIX)
-		k_busy_wait(50);
-		/*
-		 * For the POSIX arch this loop and critical_rtn would otherwise
-		 * run in 0 time and therefore would never finish.
-		 * => We purposely waste 50us per loop
-		 */
-#endif
+		Z_SPIN_DELAY(50);
 	}
 	TC_PRINT("End %s at %u\n", tag, (uint32_t)now);
 


### PR DESCRIPTION
Follow up to
- #55398

A new Z_SPIN_DELAY() macro has been added which can be used to reduce a bit the amount of noise
due to the POSIX arch need to break busy loops with k_busy_wait().
Use it.
