### PR TITLE
scripts: Print file causing error for syscalls

### DIFF
--- a/scripts/build/parse_syscalls.py
+++ b/scripts/build/parse_syscalls.py
@@ -77,7 +77,11 @@ def analyze_headers(multiple_directories):
                     continue
 
                 with open(path, "r", encoding="utf-8") as fp:
-                    contents = fp.read()
+                    try:
+                        contents = fp.read()
+                    except Exception:
+                        sys.stderr.write("Error decoding %s\n" % path)
+                        raise
 
                 try:
                     syscall_result = [(mo.groups(), fn)


### PR DESCRIPTION
I had an issue with a file I was using that caused the `read()` call to fail, but I wasn't able to find which file until I made this change. Hopefully this will make it easier for the next person.