### PR TITLE
drivers: espi: espi_mchp_xec: removed redundant state variables

### DIFF
--- a/drivers/espi/espi_mchp_xec_v2.h
+++ b/drivers/espi/espi_mchp_xec_v2.h
@@ -53,9 +53,6 @@ struct espi_xec_data {
 	struct k_sem tx_lock;
 	struct k_sem rx_lock;
 	struct k_sem flash_lock;
-	uint8_t plt_rst_asserted;
-	uint8_t espi_rst_asserted;
-	uint8_t sx_state;
 #ifdef ESPI_XEC_V2_DEBUG
 	uint32_t espi_rst_count;
 #endif


### PR DESCRIPTION
Removed struct variables for storing states: sx, plt_rst, espi_rst.
While Sx & espi_rst state variables were totally redundant, plt_rst
variable had a use-case to prevent sending multiple callbacks to app.
Experimentally proven that use-case was not valid, as plt_rst isr
itself gets called only upon rising/falling edge.
Removing the condition to check plt_rst's current and previous state,
also solves the problem where global reset do not update plt_rst state.

Signed-off-by: Aditya Bhutada <aditya.bhutada@intel.com>