### PR TITLE
soc: infineon_cat1: Added FPU definition for PSoC6

### DIFF
--- a/soc/arm/infineon_cat1/psoc6/Kconfig.soc
+++ b/soc/arm/infineon_cat1/psoc6/Kconfig.soc
@@ -10,6 +10,7 @@ config SOC_DIE_PSOC6
 	select CPU_HAS_ARM_MPU
 	select SOC_FAMILY_INFINEON_CAT1A
 	select DYNAMIC_INTERRUPTS
+	select CPU_HAS_FPU
 
 # Infineon PSoC6_01 die
 config SOC_DIE_PSOC6_01


### PR DESCRIPTION
Added FPU definition to the PSoC6 soc to enable the definition of hardabi for our boards





cc: @ifyall @npal-cy 