### PR TITLE
Revert "linker: rom_start_offset: add to address instead of set"

### DIFF
--- a/arch/common/rom_start_offset.ld
+++ b/arch/common/rom_start_offset.ld
@@ -4,5 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-. += CONFIG_ROM_START_OFFSET;
+. = CONFIG_ROM_START_OFFSET;
 . = ALIGN(4);

--- a/soc/arm/infineon_cat1/psoc6/CMakeLists.txt
+++ b/soc/arm/infineon_cat1/psoc6/CMakeLists.txt
@@ -9,7 +9,7 @@ zephyr_include_directories(.)
 zephyr_linker_sources_ifdef(CONFIG_SOC_FAMILY_INFINEON_CAT1 NOINIT noinit.ld)
 
 # Add section for cm0p image ROM
-zephyr_linker_sources_ifdef(CONFIG_SOC_FAMILY_INFINEON_CAT1A ROM_START SORT_KEY 0 rom_cm0image.ld)
+zephyr_linker_sources_ifdef(CONFIG_SOC_FAMILY_INFINEON_CAT1A ROM_START SORT_KEY 0x0cm0p rom_cm0image.ld)
 
 # Add section for cm0p image RAM
 zephyr_linker_sources_ifdef(CONFIG_SOC_FAMILY_INFINEON_CAT1A RAM_SECTIONS SORT_KEY 0 ram_cm0image.ld)


### PR DESCRIPTION
Revert commit 44628735b870b2806bbea47477c3300bb624ad31

This commit broke the ability for nxp rt series to reset except with power cycle

fixes #55296