### PR TITLE
net: http: Make http_client.c compile with CONFIG_NET_SOCKETS_POSIX_NAMES=n

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -424,7 +424,7 @@ static int http_wait_data(int sock, struct http_request *req, int32_t timeout)
 	int64_t timestamp = k_uptime_get();
 
 	fds[0].fd = sock;
-	fds[0].events = POLLIN;
+	fds[0].events = ZSOCK_POLLIN;
 
 	do {
 		if (timeout > 0) {


### PR DESCRIPTION
Use internal constant ZSOCK_POLLIN instead of POLLIN to
make the http_client source file compile without error with
CONFIG_NET_SOCKETS_POSIX_NAMES disabled.

 Fixes #55423