### PR TITLE
net: lwm2m: Register callback for firmware update cancel

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -446,6 +446,42 @@ void lwm2m_firmware_set_write_cb_inst(uint16_t obj_inst_id, lwm2m_engine_set_dat
  */
 lwm2m_engine_set_data_cb_t lwm2m_firmware_get_write_cb_inst(uint16_t obj_inst_id);
 
+/**
+ * @brief Set callback for firmware update cancel.
+ *
+ * LwM2M clients use this function to register a callback to perform actions
+ * on firmware update cancel.
+ *
+ * @param[in] cb A callback function perform actions on firmware update cancel.
+ */
+void lwm2m_firmware_set_cancel_cb(lwm2m_engine_user_cb_t cb);
+
+/**
+ * @brief Get a callback for firmware update cancel.
+ *
+ * @return A registered callback function perform actions on firmware update cancel.
+ */
+lwm2m_engine_user_cb_t lwm2m_firmware_get_cancel_cb(void);
+
+/**
+ * @brief Set data callback for firmware update cancel.
+ *
+ * LwM2M clients use this function to register a callback to perform actions
+ * on firmware update cancel.
+ *
+ * @param[in] obj_inst_id Object instance ID
+ * @param[in] cb A callback function perform actions on firmware update cancel.
+ */
+void lwm2m_firmware_set_cancel_cb_inst(uint16_t obj_inst_id, lwm2m_engine_user_cb_t cb);
+
+/**
+ * @brief Get the callback for firmware update cancel.
+ *
+ * @param[in] obj_inst_id Object instance ID
+ * @return A registered callback function perform actions on firmware update cancel.
+ */
+lwm2m_engine_user_cb_t lwm2m_firmware_get_cancel_cb_inst(uint16_t obj_inst_id);
+
 #if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT)
 /**
  * @brief Set data callback to handle firmware update execute events.

--- a/samples/net/lwm2m_client/src/firmware_update.c
+++ b/samples/net/lwm2m_client/src/firmware_update.c
@@ -48,11 +48,20 @@ static int firmware_block_received_cb(uint16_t obj_inst_id,
 	return 0;
 }
 
+static int firmware_cancel_cb(const uint16_t obj_inst_id)
+{
+	LOG_INF("FIRMWARE: Update canceled");
+	return 0;
+}
+
 void init_firmware_update(void)
 {
 	/* setup data buffer for block-wise transfer */
 	lwm2m_register_pre_write_callback(&LWM2M_OBJ(5, 0, 0), firmware_get_buf);
 	lwm2m_firmware_set_write_cb(firmware_block_received_cb);
+
+	/* register cancel callback */
+	lwm2m_firmware_set_cancel_cb(firmware_cancel_cb);
 
 	if (IS_ENABLED(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT)) {
 		lwm2m_create_res_inst(&LWM2M_OBJ(5, 0, 8, 0));


### PR DESCRIPTION
Allow to register a callback function which is called when a firmware update is canceled by the cancel command. This function can be used to clean up after a firmware update was canceled.

How to test with `lwm2m_client` sample:

- Connect to a LwM2M server e.g. Leshan or Wakaama.
- Upload some bytes, watch `state` transition from `IDLE`, `DOWNLOADING` to `DOWNLOADED`.
- Send cancel command, e.g. by uploading 0x00 (length 1 byte). `state` transits back to `IDLE`.
- "FIRMWARE: Update canceled" log message should be printed.