### PR TITLE
toolchain: common: iterable sections: add alternate foreach

### DIFF
--- a/include/zephyr/toolchain/common.h
+++ b/include/zephyr/toolchain/common.h
@@ -230,6 +230,26 @@
 	__in_section(_##out_type, static, name) __used __noasan
 
 /**
+ * @brief Iterate over a specified iterable section (alternate).
+ *
+ * @details
+ * Iterator for structure instances gathered by STRUCT_SECTION_ITERABLE().
+ * The linker must provide a _<out_type>_list_start symbol and a
+ * _<out_type>_list_end symbol to mark the start and the end of the
+ * list of struct objects to iterate over. This is normally done using
+ * ITERABLE_SECTION_ROM() or ITERABLE_SECTION_RAM() in the linker script.
+ */
+#define STRUCT_SECTION_FOREACH_ALTERNATE(out_type, struct_type, iterator)                          \
+	extern struct struct_type _CONCAT(_##out_type, _list_start)[];                             \
+	extern struct struct_type _CONCAT(_##out_type, _list_end)[];                               \
+	for (struct struct_type *iterator = _CONCAT(_##out_type, _list_start); ({                  \
+		     __ASSERT(iterator <= _CONCAT(_##out_type, _list_end),                         \
+			      "unexpected list end location");                                     \
+		     iterator < _CONCAT(_##out_type, _list_end);                                   \
+	     });                                                                                   \
+	     iterator++)
+
+/**
  * @brief Iterate over a specified iterable section.
  *
  * @details
@@ -240,14 +260,7 @@
  * ITERABLE_SECTION_ROM() or ITERABLE_SECTION_RAM() in the linker script.
  */
 #define STRUCT_SECTION_FOREACH(struct_type, iterator) \
-	extern struct struct_type _CONCAT(_##struct_type, _list_start)[]; \
-	extern struct struct_type _CONCAT(_##struct_type, _list_end)[]; \
-	for (struct struct_type *iterator = \
-			_CONCAT(_##struct_type, _list_start); \
-	     ({ __ASSERT(iterator <= _CONCAT(_##struct_type, _list_end), \
-			 "unexpected list end location"); \
-		iterator < _CONCAT(_##struct_type, _list_end); }); \
-	     iterator++)
+	STRUCT_SECTION_FOREACH_ALTERNATE(struct_type, struct_type, iterator)
 
 /**
  * @brief Get element from section.

--- a/tests/misc/iterable_sections/sections-ram.ld
+++ b/tests/misc/iterable_sections/sections-ram.ld
@@ -1,1 +1,2 @@
 ITERABLE_SECTION_RAM(test_ram, 4)
+ITERABLE_SECTION_RAM(test_ram2, 4)

--- a/tests/misc/iterable_sections/sections-rom.ld
+++ b/tests/misc/iterable_sections/sections-rom.ld
@@ -1,1 +1,2 @@
 ITERABLE_SECTION_ROM(test_rom, 4)
+ITERABLE_SECTION_ROM(test_rom2, 4)

--- a/tests/misc/iterable_sections/src/main.c
+++ b/tests/misc/iterable_sections/src/main.c
@@ -20,6 +20,9 @@ STRUCT_SECTION_ITERABLE(test_ram, ram1) = {0x01};
 
 #define RAM_EXPECT 0x01020304
 
+/* iterable section items can also be static */
+static const STRUCT_SECTION_ITERABLE_ALTERNATE(test_ram2, test_ram, ram5) = {RAM_EXPECT};
+
 /**
  *
  * @brief Test iterable in read write section.
@@ -44,6 +47,13 @@ ZTEST(iterable_sections, test_ram)
 		      "ram3.i check bit incorrect (got: 0x%x)", ram3.i);
 	zassert_equal(ram4.i & CHECK_BIT, CHECK_BIT,
 		      "ram4.i check bit incorrect (got: 0x%x)", ram4.i);
+
+	out = 0;
+	STRUCT_SECTION_FOREACH_ALTERNATE(test_ram2, test_ram, t) {
+		out = (out << 8) | t->i;
+	}
+
+	zassert_equal(out, RAM_EXPECT, "Check value incorrect (got: 0x%08x)", out);
 }
 
 struct test_rom {
@@ -58,6 +68,9 @@ const STRUCT_SECTION_ITERABLE(test_rom, rom2) = {0x20};
 
 #define ROM_EXPECT 0x10203040
 
+/* iterable section items can also be static */
+static const STRUCT_SECTION_ITERABLE_ALTERNATE(test_rom2, test_rom, rom5) = {ROM_EXPECT};
+
 /**
  *
  * @brief Test iterable in read only section.
@@ -68,6 +81,13 @@ ZTEST(iterable_sections, test_rom)
 	int out = 0;
 
 	STRUCT_SECTION_FOREACH(test_rom, t) {
+		out = (out << 8) | t->i;
+	}
+
+	zassert_equal(out, ROM_EXPECT, "Check value incorrect (got: 0x%x)", out);
+
+	out = 0;
+	STRUCT_SECTION_FOREACH_ALTERNATE(test_rom2, test_rom, t) {
 		out = (out << 8) | t->i;
 	}
 


### PR DESCRIPTION
Previously, it was possible to declare an iterable section using the alternate form (where the `out_type` does not correspond to the `struct_type`) but there was no convenient means to iterate over them.

Add `STRUCT_SECTION_FOREACH_ALTERNATE()` to fill the gap.