### PR TITLE
toolchain: esp32: support esp32s3 in 'espressif' toolchain

### DIFF
--- a/cmake/toolchain/espressif/target.cmake
+++ b/cmake/toolchain/espressif/target.cmake
@@ -9,6 +9,7 @@ set(BINTOOLS gnu)
 
 set(CROSS_COMPILE_TARGET_xtensa_esp32     xtensa-esp32-elf)
 set(CROSS_COMPILE_TARGET_xtensa_esp32s2   xtensa-esp32s2-elf)
+set(CROSS_COMPILE_TARGET_xtensa_esp32s3   xtensa-esp32s3-elf)
 set(CROSS_COMPILE_TARGET_riscv_esp32c3    riscv32-esp-elf)
 
 set(CROSS_COMPILE_TARGET ${CROSS_COMPILE_TARGET_${ARCH}_${CONFIG_SOC}})


### PR DESCRIPTION
`CROSS_COMPILE_TARGET` is defined based on `CONFIG_SOC` selected. So far
`esp32s3` SoC was not taken into account, so building Zephyr with
`espressif` toolchain (the only one supported for now) is was not possible
out of the box.

Add`'CROSS_COMPILE_TARGET_xtensa_esp32s3` CMake variable, same as it is
done for other SoC specific variables. That way toolchain paths are
automatically figured out and building succeeds.