### PR TITLE
drivers: sensor: bq274xx: add CONFIG_BQ274XX_PM

### DIFF
--- a/drivers/sensor/bq274xx/Kconfig
+++ b/drivers/sensor/bq274xx/Kconfig
@@ -12,6 +12,16 @@ menuconfig BQ274XX
 
 if BQ274XX
 
+config BQ274XX_PM
+	bool "BQ274XX Power Management"
+	depends on PM_DEVICE
+	default y
+	help
+	  This option enables the device power management feature of the
+	  BQ274XX.
+	  Note: if the int_gpios pin is not used then this feature must be
+	  disabled.
+
 choice BQ274XX_TRIGGER_MODE
 	prompt "Trigger mode"
 	default BQ274XX_TRIGGER_NONE

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -384,7 +384,7 @@ static int bq274xx_gauge_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-#if defined(CONFIG_PM_DEVICE) || defined(CONFIG_BQ274XX_TRIGGER)
+#if defined(CONFIG_BQ274XX_PM) || defined(CONFIG_BQ274XX_TRIGGER)
 	if (!device_is_ready(config->int_gpios.port)) {
 		LOG_ERR("GPIO device pointer is not ready to be used");
 		return -ENODEV;
@@ -659,7 +659,7 @@ static int bq274xx_gauge_configure(const struct device *dev)
 	return 0;
 }
 
-#ifdef CONFIG_PM_DEVICE
+#ifdef CONFIG_BQ274XX_PM
 static int bq274xx_enter_shutdown_mode(const struct device *dev)
 {
 	int status;
@@ -756,7 +756,7 @@ static int bq274xx_pm_action(const struct device *dev,
 
 	return ret;
 }
-#endif /* CONFIG_PM_DEVICE */
+#endif /* CONFIG_BQ274XX_PM */
 
 static const struct sensor_driver_api bq274xx_battery_driver_api = {
 	.sample_fetch = bq274xx_sample_fetch,
@@ -766,11 +766,16 @@ static const struct sensor_driver_api bq274xx_battery_driver_api = {
 #endif
 };
 
-#if defined(CONFIG_PM_DEVICE) || defined(CONFIG_BQ274XX_TRIGGER)
+#if defined(CONFIG_BQ274XX_PM) || defined(CONFIG_BQ274XX_TRIGGER)
 #define BQ274XX_INT_CFG(index)						      \
 	.int_gpios = GPIO_DT_SPEC_INST_GET(index, int_gpios),
+#define PM_BQ274XX_DT_INST_DEFINE(index, bq274xx_pm_action) \
+	PM_DEVICE_DT_INST_DEFINE(index, bq274xx_pm_action)
+#define PM_BQ274XX_DT_INST_GET(index) PM_DEVICE_DT_INST_GET(index)
 #else
 #define BQ274XX_INT_CFG(index)
+#define PM_BQ274XX_DT_INST_DEFINE(index, bq274xx_pm_action)
+#define PM_BQ274XX_DT_INST_GET(index) NULL
 #endif
 
 #define BQ274XX_INIT(index)							\
@@ -786,10 +791,10 @@ static const struct sensor_driver_api bq274xx_battery_driver_api = {
 		.lazy_loading = DT_INST_PROP(index, zephyr_lazy_load),		\
 	};									\
 										\
-	PM_DEVICE_DT_INST_DEFINE(index, bq274xx_pm_action);			\
+	PM_BQ274XX_DT_INST_DEFINE(index, bq274xx_pm_action);			\
 										\
 	SENSOR_DEVICE_DT_INST_DEFINE(index, &bq274xx_gauge_init,		\
-			    PM_DEVICE_DT_INST_GET(index),			\
+			    PM_BQ274XX_DT_INST_GET(index),			\
 			    &bq274xx_driver_##index,				\
 			    &bq274xx_config_##index, POST_KERNEL,		\
 			    CONFIG_SENSOR_INIT_PRIORITY,			\

--- a/drivers/sensor/bq274xx/bq274xx.h
+++ b/drivers/sensor/bq274xx/bq274xx.h
@@ -114,7 +114,7 @@ struct bq274xx_config {
 	uint16_t design_capacity;
 	uint16_t taper_current;
 	uint16_t terminate_voltage;
-#if defined(CONFIG_PM_DEVICE) || defined(CONFIG_BQ274XX_TRIGGER)
+#if defined(CONFIG_BQ274XX_PM) || defined(CONFIG_BQ274XX_TRIGGER)
 	struct gpio_dt_spec int_gpios;
 #endif
 	bool lazy_loading;

--- a/drivers/sensor/bq274xx/bq274xx_trigger.c
+++ b/drivers/sensor/bq274xx/bq274xx_trigger.c
@@ -10,7 +10,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/logging/log.h>
 
-#ifdef CONFIG_PM_DEVICE
+#ifdef CONFIG_BQ274XX_PM
 #include <zephyr/pm/device.h>
 #endif
 
@@ -111,7 +111,7 @@ int bq274xx_trigger_set(const struct device *dev,
 	struct bq274xx_data *data = dev->data;
 	int status;
 
-#ifdef CONFIG_PM_DEVICE
+#ifdef CONFIG_BQ274XX_PM
 	enum pm_device_state state;
 
 	(void)pm_device_state_get(dev, &state);

--- a/dts/bindings/sensor/ti,bq274xx.yaml
+++ b/dts/bindings/sensor/ti,bq274xx.yaml
@@ -36,7 +36,8 @@ properties:
     description: |
       The INT signal defaults to active low open drain, so requires a
       pull-up on the board. By default it acts as an output and signals
-      specific events happening (e.g. change in State of Charge). While in
+      specific events happening (e.g. change in State of Charge).
+      Note this pin is required for this sensor's power management APIs: in
       shutdown mode it acts as an input and toggling it will make the sensor
       exit the mode.
 

--- a/samples/sensor/bq274xx/sample.yaml
+++ b/samples/sensor/bq274xx/sample.yaml
@@ -9,3 +9,12 @@ tests:
       - nrf9160_innblue22
     tags: sensors
     depends_on: i2c
+  sample.sensor.bq274xx_without_int_gpios:
+    harness: sensor
+    platform_allow: nrf9160_innblue22
+    integration_platforms:
+      - nrf9160_innblue22
+    tags: sensors
+    depends_on: i2c
+    extra_configs:
+      - CONFIG_BQ274XX_PM=n


### PR DESCRIPTION
This symbol allows users of the driver to disable the power management feature of just this sensor if they are not using the int_gpios pin of the BQ274XX.