### PR TITLE
Make preemptive time slicing actually work on SMP

### DIFF
--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -37,11 +37,6 @@
  *
  * HPET_COUNTER_CLK_PERIOD can be overridden in soc.h if
  * COUNTER_CLK_PERIOD is not in femtoseconds (1e-15 sec).
- *
- * HPET_CMP_MIN_DELAY can be overridden in soc.h to better match
- * the frequency of the timers. Default is 1000 where the value
- * written to the comparator must be 1000 larger than the current
- * main counter value.
  */
 
 /* General Configuration register */
@@ -215,11 +210,6 @@ static inline void hpet_timer_comparator_set(uint64_t val)
 #define HPET_COUNTER_CLK_PERIOD		(1000000000000000ULL)
 #endif
 
-#ifndef HPET_CMP_MIN_DELAY
-/* Minimal delay for comparator before the next timer event */
-#define HPET_CMP_MIN_DELAY		(1000)
-#endif
-
 /*
  * HPET_INT_LEVEL_TRIGGER is used to set HPET interrupt as level trigger
  * for ARM CPU with NVIC like EHL PSE, whose DTS interrupt setting
@@ -237,6 +227,8 @@ __WARN("HPET_INT_LEVEL_TRIGGER has no effect, DTS setting is used instead")
 
 static __pinned_bss struct k_spinlock lock;
 static __pinned_bss uint64_t last_count;
+static __pinned_bss uint64_t last_tick;
+static __pinned_bss uint32_t last_elapsed;
 
 #ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 static __pinned_bss unsigned int cyc_per_tick;
@@ -260,6 +252,25 @@ static inline void hpet_int_sts_set(uint32_t val)
 	sys_write32(val, INTR_STATUS_REG);
 }
 #endif
+
+/* ensure the comparator is always set ahead of the current counter value */
+static inline void hpet_timer_comparator_set_safe(uint64_t next)
+{
+	hpet_timer_comparator_set(next);
+
+	uint64_t now = hpet_counter_get();
+
+	if (unlikely((int64_t)(next - now) <= 0)) {
+		uint32_t bump = 1;
+
+		do {
+			next = now + bump;
+			bump *= 2;
+			hpet_timer_comparator_set(next);
+			now = hpet_counter_get();
+		} while ((int64_t)(next - now) <= 0);
+	}
+}
 
 __isr
 static void hpet_isr(const void *arg)
@@ -295,14 +306,13 @@ static void hpet_isr(const void *arg)
 	uint32_t dticks = (uint32_t)((now - last_count) / cyc_per_tick);
 
 	last_count += (uint64_t)dticks * cyc_per_tick;
+	last_tick += dticks;
+	last_elapsed = 0;
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		uint64_t next = last_count + cyc_per_tick;
 
-		if ((int64_t)(next - now) < HPET_CMP_MIN_DELAY) {
-			next = now + HPET_CMP_MIN_DELAY;
-		}
-		hpet_timer_comparator_set(next);
+		hpet_timer_comparator_set_safe(next);
 	}
 
 	k_spin_unlock(&lock, key);
@@ -354,28 +364,12 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	}
 
 	ticks = ticks == K_TICKS_FOREVER ? HPET_MAX_TICKS : ticks;
-	ticks = CLAMP(ticks - 1, 0, HPET_MAX_TICKS);
+	ticks = CLAMP(ticks, 0, HPET_MAX_TICKS/2);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint64_t now = hpet_counter_get(), cyc, adj;
-	uint64_t max_cyc = (uint64_t)HPET_MAX_TICKS * cyc_per_tick;
+	uint64_t cyc = (last_tick + last_elapsed + ticks) * cyc_per_tick;
 
-	/* Round up to next tick boundary. */
-	cyc = (uint64_t)ticks * cyc_per_tick;
-	adj = (now - last_count) + (cyc_per_tick - 1);
-	if (cyc <= max_cyc - adj) {
-		cyc += adj;
-	} else {
-		cyc = max_cyc;
-	}
-	cyc = (cyc / cyc_per_tick) * cyc_per_tick;
-	cyc += last_count;
-
-	if ((int64_t)(cyc - now) < HPET_CMP_MIN_DELAY) {
-		cyc = now + HPET_CMP_MIN_DELAY;
-	}
-
-	hpet_timer_comparator_set(cyc);
+	hpet_timer_comparator_set_safe(cyc);
 	k_spin_unlock(&lock, key);
 #endif
 }
@@ -391,6 +385,7 @@ uint32_t sys_clock_elapsed(void)
 	uint64_t now = hpet_counter_get();
 	uint32_t ret = (uint32_t)((now - last_count) / cyc_per_tick);
 
+	last_elapsed = ret;
 	k_spin_unlock(&lock, key);
 	return ret;
 }
@@ -462,12 +457,9 @@ static int sys_clock_driver_init(const struct device *dev)
 
 	hpet_gconf_set(reg);
 
-	last_count = hpet_counter_get();
-	if (cyc_per_tick >= HPET_CMP_MIN_DELAY) {
-		hpet_timer_comparator_set(last_count + cyc_per_tick);
-	} else {
-		hpet_timer_comparator_set(last_count + HPET_CMP_MIN_DELAY);
-	}
+	last_tick = hpet_counter_get() / cyc_per_tick;
+	last_count = last_tick * cyc_per_tick;
+	hpet_timer_comparator_set_safe(last_count + cyc_per_tick);
 
 	return 0;
 }

--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -104,6 +104,10 @@ struct _thread_base {
 	int prio_deadline;
 #endif
 
+#ifdef CONFIG_TIMESLICING
+	uint64_t bias_end;
+#endif
+
 	uint32_t order_key;
 
 #ifdef CONFIG_SMP

--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -120,8 +120,8 @@ struct _cpu {
 #endif
 
 #ifdef CONFIG_TIMESLICING
-	/* number of ticks remaining in current time slice */
-	int slice_ticks;
+	/* deadline for current time slice */
+	uint64_t slice_deadline;
 #endif
 
 	uint8_t id;

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -55,7 +55,7 @@ void z_thread_priority_set(struct k_thread *thread, int prio);
 bool z_set_prio(struct k_thread *thread, int prio);
 void *z_get_next_switch_handle(void *interrupted);
 void idle(void *unused1, void *unused2, void *unused3);
-void z_time_slice(int ticks);
+void z_time_slice_expired(void);
 void z_reset_time_slice(struct k_thread *curr);
 void z_sched_abort(struct k_thread *thread);
 void z_sched_ipi(void);

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -444,12 +444,7 @@ static inline bool sliceable(struct k_thread *thread)
 
 void z_reset_time_slice(struct k_thread *thread)
 {
-	/* Add the elapsed time since the last announced tick to the
-	 * slice count, as we'll see those "expired" ticks arrive in a
-	 * FUTURE z_time_slice() call.
-	 */
 	if (sliceable(thread)) {
-		_current_cpu->slice_ticks = slice_time(thread) + sys_clock_elapsed();
 		z_set_timeout_expiry(slice_time(thread), false);
 	}
 }
@@ -457,7 +452,6 @@ void z_reset_time_slice(struct k_thread *thread)
 void k_sched_time_slice_set(int32_t slice, int prio)
 {
 	LOCKED(&sched_spinlock) {
-		_current_cpu->slice_ticks = 0;
 		slice_ticks = k_ms_to_ticks_ceil32(slice);
 		if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && slice > 0) {
 			/* It's not possible to reliably set a 1-tick

--- a/tests/kernel/sched/timeslicing/CMakeLists.txt
+++ b/tests/kernel/sched/timeslicing/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sched_timeslicing)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/kernel/sched/timeslicing/boards/qemu_cortex_a53_smp.conf
+++ b/tests/kernel/sched/timeslicing/boards/qemu_cortex_a53_smp.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_MP_MAX_NUM_CPUS=4

--- a/tests/kernel/sched/timeslicing/boards/qemu_cortex_a53_smp.overlay
+++ b/tests/kernel/sched/timeslicing/boards/qemu_cortex_a53_smp.overlay
@@ -1,0 +1,19 @@
+/* Copyright 2022 Carlo Caione <ccaione@baylibre.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	cpus {
+		cpu@2 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53";
+			reg = <2>;
+		};
+
+		cpu@3 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53";
+			reg = <3>;
+		};
+	};
+};

--- a/tests/kernel/sched/timeslicing/prj.conf
+++ b/tests/kernel/sched/timeslicing/prj.conf
@@ -1,0 +1,8 @@
+CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y
+CONFIG_MULTITHREADING=y
+CONFIG_TIMESLICING=y
+
+# System tick periods have to be large enough to contain all print traces
+# from all CPUs at 115200 bauds in polling mode (10 is a good value).
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=10

--- a/tests/kernel/sched/timeslicing/src/main.c
+++ b/tests/kernel/sched/timeslicing/src/main.c
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2023 BayLibre SAS
+ * SPDX-License-Identifier: Apache-2.0
+ * Written by Nicolas Pitre
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+/*
+ * This test is designed to validate the time slice expiration mechanism
+ * and scheduler interaction on SMP systems, although it can be valuable
+ * on !SMP systems too. This implies proper sys_clock_announce() invocations
+ * by the platform's timer driver on the appropriate CPU at the appropriate
+ * time, whether or not the announced tick value is 0, etc.
+ */
+
+#define THREADS_PER_CPU 2
+#define TIMESLICE_ROUNDS 3
+
+#define NB_THREADS (THREADS_PER_CPU * CONFIG_MP_MAX_NUM_CPUS)
+#define STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
+
+static K_KERNEL_STACK_ARRAY_DEFINE(thread_stacks, NB_THREADS, STACK_SIZE);
+static struct k_thread threads[NB_THREADS];
+
+/* native_posix doesn't like k_thread_abort() on never-started threads */
+static k_tid_t started_threads[NB_THREADS];
+
+/*
+ * This thread busily checks for tick progression until it is preempted
+ * due to time slicing. Time slice transitions are detected when a sudden
+ * tick increase is larger than 1, at which point the actual slice duration
+ * and "time away" duration are validated against the expected duration.
+ */
+static void thread_fn(void *p1, void *p2, void *p3)
+{
+	uint64_t curr_tick = sys_clock_tick_get(), last_tick = curr_tick;
+	uint32_t curr_cycle = k_cycle_get_32(), last_cycle = curr_cycle;
+	uint32_t tick_diff = 0, cycle_diff = 0;
+	uint32_t tick_changes = 0, slice_rounds = 0;
+	uint32_t thread_id = POINTER_TO_UINT(p1);
+	uint32_t expected_start_time = POINTER_TO_UINT(p2);
+	uint32_t slice_ticks = POINTER_TO_UINT(p3);
+
+	TC_PRINT("th%d: sr=%d ct=%lld td=%d tc=%d cc=%d cd=%d\n",
+		 thread_id, slice_rounds, curr_tick, tick_diff,
+		 tick_changes, curr_cycle, cycle_diff);
+
+	/*
+	 * Make sure the start delay was respected.
+	 * Note: z_add_timeout() always adds 1 to relative timeouts.
+	 */
+	expected_start_time += 1;
+	zassert_true(expected_start_time == (uint32_t)curr_tick,
+		     "%d vs %d", expected_start_time, (uint32_t)curr_tick);
+
+	do {
+		k_busy_wait(200);
+
+		/* spin until we move to another tick */
+		curr_tick = sys_clock_tick_get();
+		if (curr_tick == last_tick) {
+			continue;
+		}
+
+		/*
+		 * The tick transition corresponding to the end of a time slice
+		 * might have happened while the above sys_clock_tick_get() had
+		 * the timeout_lock locked preventing the timer IRQ from being
+		 * serviced right away. Because the thread would have been
+		 * suspended right before returning, the returned value would
+		 * no longer be up to date.
+		 *
+		 * Another possibility is sys_clock_tick_get() sampling the
+		 * hardware timer counter past the new tick transition but
+		 * the actual timer match IRQ may take some time to propagate
+		 * (especially notable on QEMU).
+		 *
+		 * To work around those issues, we busy wait for a quarter of
+		 * a tick duration and update curr_tick again.
+		 */
+		k_busy_wait((k_ticks_to_us_ceil32(1) + 3) / 4);
+		curr_tick = sys_clock_tick_get();
+
+		tick_diff = curr_tick - last_tick;
+		last_tick = curr_tick;
+		tick_changes++;
+
+		curr_cycle = k_cycle_get_32();
+		cycle_diff = curr_cycle - last_cycle;
+		last_cycle = curr_cycle;
+
+		TC_PRINT("th%d: sr=%d ct=%lld td=%d tc=%d cc=%d cd=%d\n",
+			 thread_id, slice_rounds, curr_tick, tick_diff,
+			 tick_changes, curr_cycle, cycle_diff);
+
+		/* make sure ticks and hardware cycles are in sync */
+		zassert_true(k_cyc_to_ticks_near32(cycle_diff) == tick_diff,
+			     "%d vs %d", k_cyc_to_ticks_near32(cycle_diff), tick_diff);
+
+		/*
+		 * We're expecting a tick step of 1 within a time slice.
+		 * Therefore there should not be more than `slice_ticks`
+		 * consecutive ticks in that case.
+		 *
+		 * When the slice expires, the CPU is switched away to spend
+		 * ticks in the other threads on this CPU. The time spent
+		 * away is: (THREADS_PER_CPU - 1) * slice_ticks.
+		 * However, we didn't have the chance to register the end of
+		 * the last tick period before being preempted, so one tick
+		 * must be added to that number.
+		 */
+		uint32_t ticks_away = (THREADS_PER_CPU - 1) * slice_ticks + 1;
+
+		if (tick_diff == 1) {
+			/* still in the same time slice */
+			zassert_true(tick_changes < slice_ticks,
+				     "tick_changes=%d slice_ticks=%d",
+				     tick_changes, slice_ticks);
+		} else if (tick_diff == ticks_away) {
+			/* we started a new time slice */
+			zassert_true(tick_changes == slice_ticks,
+				     "tick_changes=%d slice_ticks=%d",
+				     tick_changes, slice_ticks);
+			tick_changes = 0;
+			slice_rounds++;
+		} else {
+			zassert_unreachable("tick_diff=%d (is neither 1 nor %d)",
+					    tick_diff, ticks_away);
+		}
+	} while (slice_rounds < TIMESLICE_ROUNDS);
+
+	TC_PRINT("th%d: done\n", thread_id);
+
+	/* fill this last slice not to switch to the other threads too soon */
+	k_busy_wait(k_ticks_to_us_ceil32(1 + slice_ticks));
+}
+
+/*
+ * Start threads to make all CPUs busy. The start delay makes those threads'
+ * time slices either all synchronous across all CPUs, or staggered so that
+ * none of the slices coincide.
+ */
+static void create_threads(bool staggered_timeslices)
+{
+	uint32_t nb_cpus = arch_num_cpus();
+	uint32_t i, start_delay_ticks;
+	char name[8];
+
+	/*
+	 * Beware k_sched_time_slice_set() takes ms not ticks.
+	 * In the staggered case, we want slices to be long enough so
+	 * that each CPU can expire its slices alone i.e. never at the
+	 * same time as another CPU. And a slice needs to be at least
+	 * 2 ticks long to be detectable by the code above.
+	 */
+	uint32_t slice_ms = k_ticks_to_ms_ceil32(2) + k_ticks_to_ms_ceil32(1) * nb_cpus;
+	uint32_t slice_ticks = k_ms_to_ticks_ceil32(slice_ms);
+
+	TC_PRINT("creating %d threads per CPU on %d CPUs, with %d ticks per time slice\n",
+		 THREADS_PER_CPU, nb_cpus, slice_ticks);
+
+	k_sched_time_slice_set(slice_ms, 0);
+
+	/* synchronize to a tick edge */
+	k_msleep(1);
+	uint32_t now = sys_clock_tick_get();
+
+	for (i = 0; i < (nb_cpus * THREADS_PER_CPU); i++) {
+		start_delay_ticks = 1 + (i / nb_cpus) * slice_ticks;
+		start_delay_ticks += (staggered_timeslices) ? (i % nb_cpus) : 0;
+		started_threads[i] =
+			k_thread_create(&threads[i], thread_stacks[i],
+					K_THREAD_STACK_SIZEOF(thread_stacks[i]),
+					thread_fn,
+					UINT_TO_POINTER(i),
+					UINT_TO_POINTER(now + start_delay_ticks),
+					UINT_TO_POINTER(slice_ticks),
+					1, 0, K_TICKS(start_delay_ticks));
+		snprintf(name, sizeof(name), "th%d", i);
+		k_thread_name_set(&threads[i], name);
+	}
+}
+
+static void clean_threads(void)
+{
+	uint32_t nb_cpus = arch_num_cpus();
+	uint32_t i;
+
+	for (i = 0; i < (nb_cpus * THREADS_PER_CPU); i++) {
+		k_thread_join(&threads[i], K_FOREVER);
+		started_threads[i] = NULL;
+	}
+}
+
+/* forcefully stop all thread if one of them failed and ended the test */
+static void force_cleanup(void *unused)
+{
+	uint32_t nb_cpus = arch_num_cpus();
+	uint32_t i;
+
+	for (i = 0; i < (nb_cpus * THREADS_PER_CPU); i++) {
+		if (started_threads[i] != NULL) {
+			k_thread_abort(&threads[i]);
+			started_threads[i] = NULL;
+		}
+	}
+}
+
+/*
+ * Synchronous test scenario:
+ *
+ *         CPU0         CPU1         CPU2         CPU3
+ * t1  +----------+ +----------+ +----------+ +----------+
+ * t2  |          | |          | |          | |          |
+ * t3  |          | |          | |          | |          |
+ * t3  | thread 0 | | thread 1 | | thread 2 | | thread 3 |
+ * t4  |          | |          | |          | |          |
+ * t5  |          | |          | |          | |          |
+ * t6  +----------+ +----------+ +----------+ +----------+
+ * t7  |          | |          | |          | |          |
+ * t8  |          | |          | |          | |          |
+ * t9  | thread 4 | | thread 5 | | thread 6 | | thread 7 |
+ * t10 |          | |          | |          | |          |
+ * t11 |          | |          | |          | |          |
+ * t12 +----------+ +----------+ +----------+ +----------+
+ * t13 |          | |          | |          | |          |
+ * t14 |          | |          | |          | |          |
+ * t15 | thread 0 | | thread 1 | | thread 2 | | thread 3 |
+ * t16 |          | |          | |          | |          |
+ * ... .          . .          . .          . .          .
+ *
+ * Here the time slice expiries happen synchronously on all CPUs.
+ * The second wave of threads is made runnable through timeouts which
+ * coincide with the end of the first wave's time slices. The scheduler
+ * must pick the second set of threads and not the still-runnable first
+ * set which might or might not have been requeued faster due to the inherent
+ * race between the one CPU that is processing all global timeouts and the
+ * others which only have their own time slice expiration to process.
+ */
+ZTEST(timeslicing, test_timeslicing_synchronous)
+{
+	create_threads(false);
+	clean_threads();
+}
+
+/*
+ * Staggered test scenario:
+ *
+ *         CPU0         CPU1         CPU2         CPU3
+ * t1  +----------+ .          . .          . .          .
+ * t2  |          | +----------+ .          . .          .
+ * t3  |          | |          | +----------+ .          .
+ * t4  | thread 0 | |          | |          | +----------+
+ * t5  |          | | thread 1 | |          | |          |
+ * t6  |          | |          | | thread 2 | |          |
+ * t7  +----------+ |          | |          | | thread 3 |
+ * t8  |          | +----------+ |          | |          |
+ * t9  |          | |          | +----------+ |          |
+ * t10 | thread 4 | |          | |          | +----------+
+ * t11 |          | | thread 5 | |          | |          |
+ * t12 |          | |          | | thread 6 | |          |
+ * t13 +----------+ |          | |          | | thread 7 |
+ * t14 |          | +----------+ |          | |          |
+ * t15 |          | |          | +----------+ |          |
+ * t16 | thread 0 | |          | |          | +----------+
+ * t17 |          | | thread 1 | |          | |          |
+ * t18 |          | |          | | thread 2 | |          |
+ * t19 +----------+ |          | |          | | thread 3 |
+ * t20 |          | +----------+ |          | |          |
+ * t21 |          | |          | +----------+ |          |
+ * t22 | thread 4 | |          | |          | +----------+
+ * ... .          . .          . .          . .          .
+ *
+ * Here the time slice expiries happen independently on each CPU.
+ * Like in the synchronous case, the second wave of threads is made
+ * runnable through a timeout which expiration coincide with the end
+ * of a time slice. However some CPUs will see timeouts that don't match
+ * their corresponding time slice and they must be able to rearm their own
+ * timer accordingly.
+ *
+ * Also, scheduler fairness requires that CPU1 picks up thread 5 that is
+ * made runnable at t8 and not thread 0 which was still runnable and
+ * re-queued at t7, etc.
+ */
+ZTEST(timeslicing, test_timeslicing_staggered)
+{
+	if (!IS_ENABLED(CONFIG_SMP) || !(arch_num_cpus() > 1)) {
+		/* no point without multiple CPUs */
+		ztest_test_skip();
+	}
+	create_threads(true);
+	clean_threads();
+}
+
+static void *display_params(void)
+{
+	TC_PRINT("hardware clock frequency: %d cycles/sec\n", sys_clock_hw_cycles_per_sec());
+	TC_PRINT("system tick frequency:    %d ticks/sec\n", CONFIG_SYS_CLOCK_TICKS_PER_SEC);
+	TC_PRINT("system tick duration:     %d cycles/tick\n",
+		 sys_clock_hw_cycles_per_sec() / CONFIG_SYS_CLOCK_TICKS_PER_SEC);
+	PRINT_LINE;
+	return NULL;
+}
+
+ZTEST_SUITE(timeslicing, NULL, display_params, NULL, force_cleanup, NULL);

--- a/tests/kernel/sched/timeslicing/testcase.yaml
+++ b/tests/kernel/sched/timeslicing/testcase.yaml
@@ -1,0 +1,17 @@
+common:
+  # platforms with a lacking timer driver are likely to fail
+  platform_exclude: qemu_nios2
+tests:
+  kernel.scheduler.timeslicing:
+    tags: kernel
+    extra_configs:
+      - CONFIG_SMP=n
+      - CONFIG_MP_MAX_NUM_CPUS=1
+  kernel.scheduler.timeslicing.smp.1cpu:
+    tags: kernel smp
+    filter: CONFIG_SMP
+    extra_configs:
+      - CONFIG_MP_MAX_NUM_CPUS=1
+  kernel.scheduler.timeslicing.smp.full:
+    tags: kernel smp
+    filter: CONFIG_SMP and (CONFIG_MP_MAX_NUM_CPUS > 1)


### PR DESCRIPTION
Time slicing is completely broken on SMP at the moment, and suboptimal 
on !SMP in some cases.

Let's start with the most obvious. The documentation says:

* The sys_clock_announce() call is expected to be globally synchronized 
  at the driver level. The kernel does not do any per-CPU tracking, and 
  expects that if two timer interrupts fire near simultaneously, that only 
  one will provide the current tick count to the timing subsystem. The 
  other may legally provide a tick count of zero if no ticks have elapsed. 
  It should not “skip” the announce call because of timeslicing 
  requirements.

https://docs.zephyrproject.org/latest/kernel/services/timing/clocks.html#smp-details

Given a timeout expiration handled by CPU0 and a timeslice expiration on 
CPU1, the former will announce some timer ticks while the later will 
announce 0 ticks per the above.

Then the code goes like this:

```
void sys_clock_announce(int32_t ticks)
{
#ifdef CONFIG_TIMESLICING
        z_time_slice(ticks);
#endif
[...]

void z_time_slice(int ticks)
{
        if (slice_time(_current) && sliceable(_current)) {
                if (ticks >= _current_cpu->slice_ticks) {
                        slice_expired_locked();
                } else {
                        _current_cpu->slice_ticks -= ticks;
                }
        }
[...]
```

In other words, announcing 0 ticks upon time slice expiration does fail to 
actually expire it and also sets it up for potentially never expiring 
again.

Next issue: Run queue race. In fact this race is always lost on !SMP. 
If thread A becomes runable on the same tick as thread b's time slice 
expiration then thread B always gets requeued first and selected to run 
for another time slice when it should have been thread A's turn.

A variation of the above on SMP goes like this:

```
        CPU0         CPU1
 t0 +----------+ .          .
 t1 |          | |          |
 t2 | thread A | +----------+
 t3 |          | |          |
 t4 +----------+ | thread B | <-- Timeslice done: thread A requeued.
 t5 |          | |          | <-- Some event: thread D queued.
 t6 | thread C | +----------+ <-- Timeslice done: thread B requeued
 t7 |          | |          |     with thread A in front of the queue.
 t8 +----------+ | thread A |
 t9 |          | |          |
 .. .          . +----------+
```

To be fair, the scheduler should have preferred thread D over thread A 
at t6 but but thread A quickly re-entered the queue when its timeslice 
expired and was picked up by another CPU almost right away.

And finally a benign issue which is about spurious timeslice timeouts.
Those are normally harmless but still wasteful.

This PR fixes all those issues in an incremental way in order to make it 
easier on reviewers. In fact, the patch splitting took almost as much 
time as the initial work.

Then I created a new test to tightly control and validate proper time 
slicing behavior on SMP. Not only do all the issues above need fixing,
but this test has no mercy for flawed timer drivers either. Recent changes 
to the RISC-V timer driver (PR #54919) and the ARM architected timer driver 
(PR #55346) were necessary for the test to pass.

Also included in this PR are changes to improve the hpet driver like for 
those above, and changes to make it "SMP aware" for the timeslicing test 
to pass.

This was tested and validated on actual 4-CPUs RISC-V hardware as well as 
qemu_cortex_a53_smp, qemu_riscv64_smp, qemu_x86_64, native_posix and more. 
However QEMU isn't fully reliable with SMP and time emulation, especially 
on a busy system with several QEMU instances in parallel, and the test 
may fail in those circumstances (tried icount to no avail). I still don't 
know what to do about that if e.g. CI gets affected.
