### PR TITLE
Bluetooth: Controller: Fix connected ISO time reservation calculation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -471,6 +471,7 @@ conn_is_valid:
 
 	conn->ull.ticks_slot =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US +
+				       EVENT_OVERHEAD_END_US +
 				       ready_delay_us +
 				       max_tx_time +
 				       EVENT_IFS_US +

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -671,7 +671,8 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 
 #else /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
 	cis_offset = MAX((HAL_TICKER_TICKS_TO_US(conn->ull.ticks_slot) +
-			 (EVENT_TICKER_RES_MARGIN_US << 1U)), *cis_offset_min);
+			  (EVENT_TICKER_RES_MARGIN_US << 1U)), *cis_offset_min);
+
 #endif /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
 
 	/* Calculate offset for CIS */

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -914,8 +914,20 @@ void ull_conn_iso_start(struct ll_conn *conn, uint32_t ticks_at_expire,
 	uint32_t ticks_slot_offset;
 	uint32_t slot_us;
 
-	/* FIXME: time reservations */
-	slot_us = cis->lll.sub_interval;
+	/* Calculate time reservations for sequential and interleaved packing as
+	 * configured.
+	 */
+	if (IS_CENTRAL(cig)) {
+		/* CIG sync_delay has been calculated considering the configured
+		 * packing.
+		 */
+		slot_us = cig->sync_delay;
+	} else {
+		/* FIXME: Time reservation for interleaved packing */
+		/* Below is time reservation for sequential packing */
+		slot_us = cis->lll.sub_interval * cis->lll.nse;
+	}
+	slot_us += EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;
 
 	/* Populate the ULL hdr with event timings overheads */
 	cig->ull.ticks_active_to_start = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -391,6 +391,7 @@ void ull_periph_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_PREEMPT_MIN_US);
 	conn->ull.ticks_slot =
 		HAL_TICKER_US_TO_TICKS(EVENT_OVERHEAD_START_US +
+				       EVENT_OVERHEAD_END_US +
 				       ready_delay_us +
 				       max_rx_time +
 				       EVENT_IFS_US +


### PR DESCRIPTION
Fix Connected ISO time reservation that was missing the event start and end overhead values.
Fix missing event end overhead values in ACL connection time reservation.