### PR TITLE
Bluetooth: host: gatt: respect `BT_GATT_ENFORCE_SUBSCRIPTION`

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2941,7 +2941,8 @@ static int gatt_notify_multiple_verify_params(struct bt_conn *conn,
 		}
 
 		/* Check if the characteristic is subscribed. */
-		if (!bt_gatt_is_subscribed(conn, params[i].attr,
+		if (IS_ENABLED(CONFIG_BT_GATT_ENFORCE_SUBSCRIPTION) &&
+		    !bt_gatt_is_subscribed(conn, params[i].attr,
 					   BT_GATT_CCC_NOTIFY)) {
 			LOG_WRN("Device is not subscribed to characteristic");
 			return -EINVAL;


### PR DESCRIPTION
A subscription check was still being done in the
gatt_notify_multiple_verify_params() fn, regardless of the value of CONFIG_BT_GATT_ENFORCE_SUBSCRIPTION.

This could lead to getting this warning if BT_GATT_NOTIFY_MULTIPLE is enabled, and the notifications not being sent to unsubscribed peers.