### PR TITLE
drivers: wifi: esp32: fix possible interface null pointer

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -434,6 +434,16 @@ static void esp32_wifi_init(struct net_if *iface)
 	net_if_carrier_off(iface);
 
 	esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, eth_esp32_rx);
+
+	wifi_init_config_t config = WIFI_INIT_CONFIG_DEFAULT();
+	esp_err_t ret = esp_wifi_init(&config);
+
+	ret |= esp_wifi_set_mode(ESP32_WIFI_MODE_STA);
+	ret |= esp_wifi_start();
+
+	if (ret != ESP_OK) {
+		LOG_ERR("Failed to start Wi-Fi driver");
+	}
 }
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
@@ -460,17 +470,6 @@ static int esp32_wifi_dev_init(const struct device *dev)
 	if (IS_ENABLED(CONFIG_ESP32_WIFI_STA_AUTO_DHCPV4)) {
 		net_mgmt_init_event_callback(&esp32_dhcp_cb, wifi_event_handler, DHCPV4_MASK);
 		net_mgmt_add_event_callback(&esp32_dhcp_cb);
-	}
-
-	wifi_init_config_t config = WIFI_INIT_CONFIG_DEFAULT();
-	esp_err_t ret = esp_wifi_init(&config);
-
-	ret |= esp_wifi_set_mode(ESP32_WIFI_MODE_STA);
-	ret |= esp_wifi_start();
-
-	if (ret != ESP_OK) {
-		LOG_ERR("Failed to start Wi-Fi driver");
-		return -EIO;
 	}
 
 	return 0;


### PR DESCRIPTION
esp32_wifi_dev_init() currently starts Wi-Fi stack before the interface is properly configured, which happens in function esp32_wifi_init(). This can trigger a ESP32_WIFI_EVENT_STA_START event before interface initialization, causing a crash.
Moving esp_wifi_start() to esp32_wifi_init() will guarantee that this won't happen.