### PR TITLE
tests: Bluetooth: Mesh: fix read access to uninitialized memory

### DIFF
--- a/tests/bluetooth/bsim/mesh/src/test_blob.c
+++ b/tests/bluetooth/bsim/mesh/src/test_blob.c
@@ -87,6 +87,8 @@ static int blob_chunk_rd(const struct bt_mesh_blob_io *io,
 			 const struct bt_mesh_blob_block *block,
 			 const struct bt_mesh_blob_chunk *chunk)
 {
+	memset(chunk->data, 0, chunk->size);
+
 	return 0;
 }
 

--- a/tests/bluetooth/bsim/mesh/src/test_dfu.c
+++ b/tests/bluetooth/bsim/mesh/src/test_dfu.c
@@ -85,6 +85,8 @@ static int dummy_blob_chunk_rd(const struct bt_mesh_blob_io *io,
 			 const struct bt_mesh_blob_block *block,
 			 const struct bt_mesh_blob_chunk *chunk)
 {
+	memset(chunk->data, 0, chunk->size);
+
 	return 0;
 }
 

--- a/tests/bluetooth/bsim/mesh/src/test_op_agg.c
+++ b/tests/bluetooth/bsim/mesh/src/test_op_agg.c
@@ -73,7 +73,8 @@ static int get_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	bt_mesh_model_msg_init(&msg, BT_MESH_DUMMY_VND_MOD_STATUS_OP);
 
 	net_buf_simple_add_u8(&msg, seq);
-	net_buf_simple_add(&msg, BT_MESH_DUMMY_VND_MOD_MSG_MINLEN - 1);
+	memset(net_buf_simple_add(&msg, BT_MESH_DUMMY_VND_MOD_MSG_MINLEN - 1), 0,
+		BT_MESH_DUMMY_VND_MOD_MSG_MINLEN);
 
 	/* Last message: One additional byte is added to fill the available access payload.*/
 	if (get_rcvd_count >= TEST_SEND_ITR) {
@@ -107,7 +108,8 @@ static int dummy_vnd_mod_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx
 	bt_mesh_model_msg_init(&msg, BT_MESH_DUMMY_VND_MOD_GET_OP);
 
 	net_buf_simple_add_u8(&msg, seq);
-	net_buf_simple_add(&msg, BT_MESH_DUMMY_VND_MOD_MSG_MINLEN - 1);
+	memset(net_buf_simple_add(&msg, BT_MESH_DUMMY_VND_MOD_MSG_MINLEN - 1), 0,
+		BT_MESH_DUMMY_VND_MOD_MSG_MINLEN);
 
 	/* Last message: One additional byte is added to fill the available access payload.*/
 	if (seq >= TEST_SEND_ITR - 1) {


### PR DESCRIPTION
There are a couple of places where read access to uninitialized memory happens in new mesh-1.1 tests. Valgrind highlights them. PR fixes them.