### PR TITLE
drivers: udc: move transfer status to buffer info structure

### DIFF
--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -187,6 +187,7 @@ int udc_submit_ep_event(const struct device *dev,
 			struct net_buf *const buf,
 			const int err)
 {
+	struct udc_buf_info *bi = udc_get_buf_info(buf);
 	struct udc_data *data = dev->data;
 	const struct udc_event drv_evt = {
 		.type = UDC_EVT_EP_REQUEST,
@@ -198,6 +199,8 @@ int udc_submit_ep_event(const struct device *dev,
 	if (!udc_is_initialized(dev)) {
 		return -EPERM;
 	}
+
+	bi->err = err;
 
 	return data->event_cb(dev, &drv_evt);
 }

--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -165,13 +165,11 @@ void udc_ep_buf_clear_zlp(const struct net_buf *const buf)
 
 int udc_submit_event(const struct device *dev,
 		     const enum udc_event_type type,
-		     const int status,
-		     struct net_buf *const buf)
+		     const int status)
 {
 	struct udc_data *data = dev->data;
 	struct udc_event drv_evt = {
 		.type = type,
-		.buf = buf,
 		.status = status,
 		.dev = dev,
 	};
@@ -192,7 +190,6 @@ int udc_submit_ep_event(const struct device *dev,
 	const struct udc_event drv_evt = {
 		.type = UDC_EVT_EP_REQUEST,
 		.buf = buf,
-		.status = err,
 		.dev = dev,
 	};
 

--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -183,6 +183,25 @@ int udc_submit_event(const struct device *dev,
 	return data->event_cb(dev, &drv_evt);
 }
 
+int udc_submit_ep_event(const struct device *dev,
+			struct net_buf *const buf,
+			const int err)
+{
+	struct udc_data *data = dev->data;
+	const struct udc_event drv_evt = {
+		.type = UDC_EVT_EP_REQUEST,
+		.buf = buf,
+		.status = err,
+		.dev = dev,
+	};
+
+	if (!udc_is_initialized(dev)) {
+		return -EPERM;
+	}
+
+	return data->event_cb(dev, &drv_evt);
+}
+
 static uint8_t ep_attrib_get_transfer(uint8_t attributes)
 {
 	return attributes & USB_EP_TRANSFER_TYPE_MASK;
@@ -850,7 +869,7 @@ int udc_ctrl_submit_s_out_status(const struct device *dev,
 		ret = -ENOMEM;
 	}
 
-	return udc_submit_event(dev, UDC_EVT_EP_REQUEST, ret, data->setup);
+	return udc_submit_ep_event(dev, data->setup, ret);
 }
 
 int udc_ctrl_submit_s_in_status(const struct device *dev)
@@ -869,7 +888,7 @@ int udc_ctrl_submit_s_in_status(const struct device *dev)
 		ret = -ENOMEM;
 	}
 
-	return udc_submit_event(dev, UDC_EVT_EP_REQUEST, ret, data->setup);
+	return udc_submit_ep_event(dev, data->setup, ret);
 }
 
 int udc_ctrl_submit_s_status(const struct device *dev)
@@ -884,7 +903,7 @@ int udc_ctrl_submit_s_status(const struct device *dev)
 		ret = -ENOMEM;
 	}
 
-	return udc_submit_event(dev, UDC_EVT_EP_REQUEST, ret, data->setup);
+	return udc_submit_ep_event(dev, data->setup, ret);
 }
 
 int udc_ctrl_submit_status(const struct device *dev,
@@ -894,7 +913,7 @@ int udc_ctrl_submit_status(const struct device *dev,
 
 	bi->status = true;
 
-	return udc_submit_event(dev, UDC_EVT_EP_REQUEST, 0, buf);
+	return udc_submit_ep_event(dev, buf, 0);
 }
 
 bool udc_ctrl_stage_is_data_out(const struct device *dev)

--- a/drivers/usb/udc/udc_common.h
+++ b/drivers/usb/udc/udc_common.h
@@ -140,15 +140,13 @@ void udc_buf_put(struct udc_ep_config *const ep_cfg,
  * @param[in] dev    Pointer to device struct of the driver instance
  * @param[in] type   Event type
  * @param[in] status Event status
- * @param[in] buf    Pointer to UDC request buffer
  *
  * @return 0 on success, all other values should be treated as error.
  * @retval -EPERM controller is not initialized
  */
 int udc_submit_event(const struct device *dev,
 		     const enum udc_event_type type,
-		     const int status,
-		     struct net_buf *const buf);
+		     const int status);
 
 /**
  * @brief Helper function to send UDC endpoint event to a higher level.

--- a/drivers/usb/udc/udc_common.h
+++ b/drivers/usb/udc/udc_common.h
@@ -151,6 +151,22 @@ int udc_submit_event(const struct device *dev,
 		     struct net_buf *const buf);
 
 /**
+ * @brief Helper function to send UDC endpoint event to a higher level.
+ *
+ * Type of this event is hardcoded to UDC_EVT_EP_REQUEST.
+ * The callback would typically sends UDC even to a message queue (k_msgq).
+ *
+ * @param[in] dev    Pointer to device struct of the driver instance
+ * @param[in] buf    Pointer to UDC request buffer
+ * @param[in] err    Request result
+ *
+ * @return 0 on success, all other values should be treated as error.
+ * @retval -EPERM controller is not initialized
+ */
+int udc_submit_ep_event(const struct device *dev,
+			struct net_buf *const buf,
+			const int err);
+/**
  * @brief Helper function to enable endpoint.
  *
  * This function can be used by the driver to enable control IN/OUT endpoint.

--- a/drivers/usb/udc/udc_kinetis.c
+++ b/drivers/usb/udc/udc_kinetis.c
@@ -331,7 +331,7 @@ static inline int work_handler_setup(const struct device *dev)
 		err = usbfsotg_ctrl_feed_dout(dev, udc_data_stage_length(buf),
 					      false, true);
 		if (err == -ENOMEM) {
-			err = udc_submit_event(dev, UDC_EVT_EP_REQUEST, err, buf);
+			err = udc_submit_ep_event(dev, buf, err);
 		}
 	} else if (udc_ctrl_stage_is_data_in(dev)) {
 		/*
@@ -397,7 +397,7 @@ static inline int work_handler_out(const struct device *dev,
 			err = udc_ctrl_submit_s_out_status(dev, buf);
 		}
 	} else {
-		err = udc_submit_event(dev, UDC_EVT_EP_REQUEST, 0, buf);
+		err = udc_submit_ep_event(dev, buf, 0);
 	}
 
 	return err;
@@ -434,7 +434,7 @@ static inline int work_handler_in(const struct device *dev,
 		return 0;
 	}
 
-	return udc_submit_event(dev, UDC_EVT_EP_REQUEST, 0, buf);
+	return udc_submit_ep_event(dev, buf, 0);
 }
 
 static void usbfsotg_event_submit(const struct device *dev,
@@ -735,7 +735,7 @@ static int usbfsotg_ep_dequeue(const struct device *dev,
 	cfg->stat.halted = false;
 	buf = udc_buf_get_all(dev, cfg->addr);
 	if (buf) {
-		udc_submit_event(dev, UDC_EVT_EP_REQUEST, -ECONNABORTED, buf);
+		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 	}
 
 	udc_ep_set_busy(dev, cfg->addr, false);

--- a/drivers/usb/udc/udc_kinetis.c
+++ b/drivers/usb/udc/udc_kinetis.c
@@ -447,7 +447,7 @@ static void usbfsotg_event_submit(const struct device *dev,
 
 	ret = k_mem_slab_alloc(&usbfsotg_ee_slab, (void **)&ev, K_NO_WAIT);
 	if (ret) {
-		udc_submit_event(dev, UDC_EVT_ERROR, ret, NULL);
+		udc_submit_event(dev, UDC_EVT_ERROR, ret);
 	}
 
 	ev->dev = dev;
@@ -471,7 +471,7 @@ static void xfer_work_handler(struct k_work *item)
 			ev->dev, ev->ep, ev->event);
 		ep_cfg = udc_get_ep_cfg(ev->dev, ev->ep);
 		if (unlikely(ep_cfg == NULL)) {
-			udc_submit_event(ev->dev, UDC_EVT_ERROR, -ENODATA, NULL);
+			udc_submit_event(ev->dev, UDC_EVT_ERROR, -ENODATA);
 			goto xfer_work_error;
 		}
 
@@ -495,7 +495,7 @@ static void xfer_work_handler(struct k_work *item)
 		}
 
 		if (unlikely(err)) {
-			udc_submit_event(ev->dev, UDC_EVT_ERROR, err, NULL);
+			udc_submit_event(ev->dev, UDC_EVT_ERROR, err);
 		}
 
 		/* Peek next transer */
@@ -569,7 +569,7 @@ static ALWAYS_INLINE void isr_handle_xfer_done(const struct device *dev,
 			usbfsotg_event_submit(dev, ep, USBFSOTG_EVT_SETUP);
 		} else {
 			LOG_ERR("No buffer for ep 0x00");
-			udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS, NULL);
+			udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
 		}
 
 		break;
@@ -587,7 +587,7 @@ static ALWAYS_INLINE void isr_handle_xfer_done(const struct device *dev,
 
 		if (buf == NULL) {
 			LOG_ERR("No buffer for ep 0x%02x", ep);
-			udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS, NULL);
+			udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
 			break;
 		}
 
@@ -614,7 +614,7 @@ static ALWAYS_INLINE void isr_handle_xfer_done(const struct device *dev,
 		buf = udc_buf_peek(dev, ep_cfg->addr);
 		if (buf == NULL) {
 			LOG_ERR("No buffer for ep 0x%02x", ep);
-			udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS, NULL);
+			udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
 			break;
 		}
 
@@ -646,12 +646,12 @@ static void usbfsotg_isr_handler(const struct device *dev)
 
 	if (istatus & USB_ISTAT_USBRST_MASK) {
 		base->ADDR = 0U;
-		udc_submit_event(dev, UDC_EVT_RESET, 0, NULL);
+		udc_submit_event(dev, UDC_EVT_RESET, 0);
 	}
 
 	if (istatus == USB_ISTAT_ERROR_MASK) {
 		LOG_DBG("ERROR IRQ 0x%02x", base->ERRSTAT);
-		udc_submit_event(dev, UDC_EVT_ERROR, base->ERRSTAT, NULL);
+		udc_submit_event(dev, UDC_EVT_ERROR, base->ERRSTAT);
 		base->ERRSTAT = 0xFF;
 	}
 
@@ -687,7 +687,7 @@ static void usbfsotg_isr_handler(const struct device *dev)
 		base->INTEN |= USB_INTEN_RESUMEEN_MASK;
 
 		udc_set_suspended(dev, true);
-		udc_submit_event(dev, UDC_EVT_SUSPEND, 0, NULL);
+		udc_submit_event(dev, UDC_EVT_SUSPEND, 0);
 	}
 
 	if (istatus & USB_ISTAT_RESUME_MASK) {
@@ -696,7 +696,7 @@ static void usbfsotg_isr_handler(const struct device *dev)
 		base->INTEN &= ~USB_INTEN_RESUMEEN_MASK;
 
 		udc_set_suspended(dev, false);
-		udc_submit_event(dev, UDC_EVT_RESUME, 0, NULL);
+		udc_submit_event(dev, UDC_EVT_RESUME, 0);
 	}
 
 	/* Clear interrupt status bits */

--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -113,8 +113,7 @@ static void udc_event_xfer_in_next(const struct device *dev, const uint8_t ep)
 		if (err != NRFX_SUCCESS) {
 			LOG_ERR("ep 0x%02x nrfx error: %x", ep, err);
 			/* REVISE: remove from endpoint queue? ASSERT? */
-			udc_submit_event(dev, UDC_EVT_EP_REQUEST,
-					 -ECONNREFUSED, buf);
+			udc_submit_ep_event(dev, buf, -ECONNREFUSED);
 		} else {
 			udc_ep_set_busy(dev, ep, true);
 		}
@@ -179,7 +178,7 @@ static void udc_event_xfer_in(const struct device *dev,
 			return udc_event_xfer_ctrl_in(dev, buf);
 		}
 
-		udc_submit_event(dev, UDC_EVT_EP_REQUEST, 0, buf);
+		udc_submit_ep_event(dev, buf, 0);
 		break;
 
 	case NRFX_USBD_EP_ABORTED:
@@ -192,8 +191,7 @@ static void udc_event_xfer_in(const struct device *dev,
 		}
 
 		udc_ep_set_busy(dev, ep, false);
-		udc_submit_event(dev, UDC_EVT_EP_REQUEST,
-				 -ECONNABORTED, buf);
+		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 		break;
 
 	default:
@@ -241,8 +239,7 @@ static void udc_event_xfer_out_next(const struct device *dev, const uint8_t ep)
 		if (err != NRFX_SUCCESS) {
 			LOG_ERR("ep 0x%02x nrfx error: %x", ep, err);
 			/* REVISE: remove from endpoint queue? ASSERT? */
-			udc_submit_event(dev, UDC_EVT_EP_REQUEST,
-					 -ECONNREFUSED, buf);
+			udc_submit_ep_event(dev, buf, -ECONNREFUSED);
 		} else {
 			udc_ep_set_busy(dev, ep, true);
 		}
@@ -284,7 +281,7 @@ static void udc_event_xfer_out(const struct device *dev,
 		if (ep == USB_CONTROL_EP_OUT) {
 			udc_event_xfer_ctrl_out(dev, buf);
 		} else {
-			udc_submit_event(dev, UDC_EVT_EP_REQUEST, 0, buf);
+			udc_submit_ep_event(dev, buf, 0);
 		}
 
 		break;
@@ -340,7 +337,7 @@ static int udc_event_xfer_setup(const struct device *dev)
 		LOG_DBG("s:%p|feed for -out-", buf);
 		err = usbd_ctrl_feed_dout(dev, udc_data_stage_length(buf));
 		if (err == -ENOMEM) {
-			err = udc_submit_event(dev, UDC_EVT_EP_REQUEST, err, buf);
+			err = udc_submit_ep_event(dev, buf, err);
 		}
 	} else if (udc_ctrl_stage_is_data_in(dev)) {
 		err = udc_ctrl_submit_s_in_status(dev);
@@ -529,8 +526,7 @@ static int udc_nrf_ep_dequeue(const struct device *dev,
 		 */
 		buf = udc_buf_get_all(dev, cfg->addr);
 		if (buf) {
-			udc_submit_event(dev, UDC_EVT_EP_REQUEST,
-					 -ECONNABORTED, buf);
+			udc_submit_ep_event(dev, buf, -ECONNABORTED);
 		} else {
 			LOG_INF("ep 0x%02x queue is empty", cfg->addr);
 		}

--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -197,7 +197,7 @@ static void udc_event_xfer_in(const struct device *dev,
 	default:
 		LOG_ERR("Unexpected event (nrfx_usbd): %d, ep 0x%02x",
 			event->data.eptransfer.status, ep);
-		udc_submit_event(dev, UDC_EVT_ERROR, -EIO, NULL);
+		udc_submit_event(dev, UDC_EVT_ERROR, -EIO);
 		break;
 	}
 }
@@ -289,7 +289,7 @@ static void udc_event_xfer_out(const struct device *dev,
 	default:
 		LOG_ERR("Unexpected event (nrfx_usbd): %d, ep 0x%02x",
 			event->data.eptransfer.status, ep);
-		udc_submit_event(dev, UDC_EVT_ERROR, -EIO, NULL);
+		udc_submit_event(dev, UDC_EVT_ERROR, -EIO);
 		break;
 	}
 }
@@ -421,22 +421,22 @@ static void usbd_event_handler(nrfx_usbd_evt_t const *const hal_evt)
 		LOG_INF("SUSPEND state detected");
 		nrfx_usbd_suspend();
 		udc_set_suspended(udc_nrf_dev, true);
-		udc_submit_event(udc_nrf_dev, UDC_EVT_SUSPEND, 0, NULL);
+		udc_submit_event(udc_nrf_dev, UDC_EVT_SUSPEND, 0);
 		break;
 	case NRFX_USBD_EVT_RESUME:
 		LOG_INF("RESUMING from suspend");
 		udc_set_suspended(udc_nrf_dev, false);
-		udc_submit_event(udc_nrf_dev, UDC_EVT_RESUME, 0, NULL);
+		udc_submit_event(udc_nrf_dev, UDC_EVT_RESUME, 0);
 		break;
 	case NRFX_USBD_EVT_WUREQ:
 		LOG_INF("Remote wakeup initiated");
 		break;
 	case NRFX_USBD_EVT_RESET:
 		LOG_INF("Reset");
-		udc_submit_event(udc_nrf_dev, UDC_EVT_RESET, 0, NULL);
+		udc_submit_event(udc_nrf_dev, UDC_EVT_RESET, 0);
 		break;
 	case NRFX_USBD_EVT_SOF:
-		udc_submit_event(udc_nrf_dev, UDC_EVT_SOF, 0, NULL);
+		udc_submit_event(udc_nrf_dev, UDC_EVT_SOF, 0);
 		udc_sof_check_iso_out(udc_nrf_dev);
 		break;
 	case NRFX_USBD_EVT_EPTRANSFER:
@@ -465,12 +465,12 @@ static void udc_nrf_power_handler(nrfx_power_usb_evt_t pwr_evt)
 		break;
 	case NRFX_POWER_USB_EVT_READY:
 		LOG_INF("POWER event ready");
-		udc_submit_event(udc_nrf_dev, UDC_EVT_VBUS_READY, 0, NULL);
+		udc_submit_event(udc_nrf_dev, UDC_EVT_VBUS_READY, 0);
 		nrfx_usbd_start(true);
 		break;
 	case NRFX_POWER_USB_EVT_REMOVED:
 		LOG_INF("POWER event removed");
-		udc_submit_event(udc_nrf_dev, UDC_EVT_VBUS_REMOVED, 0, NULL);
+		udc_submit_event(udc_nrf_dev, UDC_EVT_VBUS_REMOVED, 0);
 		break;
 	default:
 		LOG_ERR("Unknown power event %d", pwr_evt);

--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -197,7 +197,7 @@ static void udc_event_xfer_in(const struct device *dev,
 	default:
 		LOG_ERR("Unexpected event (nrfx_usbd): %d, ep 0x%02x",
 			event->data.eptransfer.status, ep);
-		udc_submit_event(dev, UDC_EVT_EP_REQUEST, -EIO, NULL);
+		udc_submit_event(dev, UDC_EVT_ERROR, -EIO, NULL);
 		break;
 	}
 }
@@ -289,7 +289,7 @@ static void udc_event_xfer_out(const struct device *dev,
 	default:
 		LOG_ERR("Unexpected event (nrfx_usbd): %d, ep 0x%02x",
 			event->data.eptransfer.status, ep);
-		udc_submit_event(dev, UDC_EVT_EP_REQUEST, -EIO, NULL);
+		udc_submit_event(dev, UDC_EVT_ERROR, -EIO, NULL);
 		break;
 	}
 }

--- a/drivers/usb/udc/udc_virtual.c
+++ b/drivers/usb/udc/udc_virtual.c
@@ -116,7 +116,7 @@ static int vrt_handle_setup(const struct device *dev,
 			 * Pass it on to the higher level which will
 			 * halt control OUT endpoint.
 			 */
-			err = udc_submit_event(dev, UDC_EVT_EP_REQUEST, err, buf);
+			err = udc_submit_ep_event(dev, buf, err);
 		}
 	} else if (udc_ctrl_stage_is_data_in(dev)) {
 		LOG_DBG("s: %p | submit for -in-", buf);
@@ -189,7 +189,7 @@ static int vrt_handle_out(const struct device *dev,
 		if (ep == USB_CONTROL_EP_OUT) {
 			err = vrt_handle_ctrl_out(dev, buf);
 		} else {
-			err = udc_submit_event(dev, UDC_EVT_EP_REQUEST, 0, buf);
+			err = udc_submit_ep_event(dev, buf, 0);
 		}
 	}
 
@@ -264,7 +264,7 @@ static int vrt_handle_in(const struct device *dev,
 		if (ep == USB_CONTROL_EP_IN) {
 			err = isr_handle_ctrl_in(dev, buf);
 		} else {
-			err = udc_submit_event(dev, UDC_EVT_EP_REQUEST, 0, buf);
+			err = udc_submit_ep_event(dev, buf, 0);
 		}
 	}
 
@@ -406,7 +406,7 @@ static int udc_vrt_ep_dequeue(const struct device *dev,
 	/* Draft dequeue implementation */
 	buf = udc_buf_get_all(dev, cfg->addr);
 	if (buf) {
-		udc_submit_event(dev, UDC_EVT_EP_REQUEST, -ECONNABORTED, buf);
+		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 	}
 	irq_unlock(lock_key);
 

--- a/drivers/usb/udc/udc_virtual.c
+++ b/drivers/usb/udc/udc_virtual.c
@@ -307,19 +307,19 @@ static ALWAYS_INLINE void udc_vrt_thread_handler(void *arg)
 
 		switch (vrt_ev->type) {
 		case UVB_EVT_VBUS_REMOVED:
-			err = udc_submit_event(dev, UDC_EVT_VBUS_REMOVED, 0, NULL);
+			err = udc_submit_event(dev, UDC_EVT_VBUS_REMOVED, 0);
 			break;
 		case UVB_EVT_VBUS_READY:
-			err = udc_submit_event(dev, UDC_EVT_VBUS_READY, 0, NULL);
+			err = udc_submit_event(dev, UDC_EVT_VBUS_READY, 0);
 			break;
 		case UVB_EVT_SUSPEND:
-			err = udc_submit_event(dev, UDC_EVT_SUSPEND, 0, NULL);
+			err = udc_submit_event(dev, UDC_EVT_SUSPEND, 0);
 			break;
 		case UVB_EVT_RESUME:
-			err = udc_submit_event(dev, UDC_EVT_RESUME, 0, NULL);
+			err = udc_submit_event(dev, UDC_EVT_RESUME, 0);
 			break;
 		case UVB_EVT_RESET:
-			err = udc_submit_event(dev, UDC_EVT_RESET, 0, NULL);
+			err = udc_submit_event(dev, UDC_EVT_RESET, 0);
 			break;
 		case UVB_EVT_REQUEST:
 			err = vrt_handle_request(dev, vrt_ev->pkt);
@@ -329,7 +329,7 @@ static ALWAYS_INLINE void udc_vrt_thread_handler(void *arg)
 		};
 
 		if (err) {
-			udc_submit_event(dev, UDC_EVT_ERROR, err, NULL);
+			udc_submit_event(dev, UDC_EVT_ERROR, err);
 		}
 
 		k_mem_slab_free(&udc_vrt_slab, (void **)&vrt_ev);

--- a/include/zephyr/drivers/usb/udc.h
+++ b/include/zephyr/drivers/usb/udc.h
@@ -191,6 +191,8 @@ struct udc_buf_info {
 	unsigned int queued : 1;
 	/** Transfer owner (usually pointer to a class instance) */
 	void *owner;
+	/** Transfer result, 0 on success, other values on error */
+	int err;
 } __packed;
 
 /**

--- a/include/zephyr/drivers/usb/udc.h
+++ b/include/zephyr/drivers/usb/udc.h
@@ -158,11 +158,11 @@ struct udc_event {
 	union {
 		/** Event value */
 		uint32_t value;
+		/** Event status value, if any */
+		int status;
 		/** Pointer to request used only for UDC_EVT_EP_REQUEST */
 		struct net_buf *buf;
 	};
-	/** Event status, 0 on success, other values on error */
-	int status;
 	/** Pointer to device struct */
 	const struct device *dev;
 };

--- a/subsys/usb/device_next/usbd_core.c
+++ b/subsys/usb/device_next/usbd_core.c
@@ -43,11 +43,9 @@ static int event_handler_ep_request(struct usbd_contex *const uds_ctx,
 	bi = udc_get_buf_info(event->buf);
 
 	if (USB_EP_GET_IDX(bi->ep) == 0) {
-		ret = usbd_handle_ctrl_xfer(uds_ctx, event->buf,
-					    event->status);
+		ret = usbd_handle_ctrl_xfer(uds_ctx, event->buf, bi->err);
 	} else {
-		ret = usbd_class_handle_xfer(uds_ctx, event->buf,
-					     event->status);
+		ret = usbd_class_handle_xfer(uds_ctx, event->buf, bi->err);
 	}
 
 	if (ret) {

--- a/tests/drivers/udc/src/main.c
+++ b/tests/drivers/udc/src/main.c
@@ -41,7 +41,7 @@ static void event_ep_request(const struct device *dev, struct udc_event event)
 	err = udc_ep_buf_free(dev, event.buf);
 	zassert_ok(err, "Failed to free request buffer");
 
-	if (event.status == -ECONNABORTED && bi->ep == last_used_ep) {
+	if (bi->err == -ECONNABORTED && bi->ep == last_used_ep) {
 		k_sem_give(&ep_queue_sem);
 	}
 }


### PR DESCRIPTION
Move transfer status to buffer info structure
This allows us to get the result of synchronous transfer without
any hacks, just from the net_buf structure.