### PR TITLE
sysbuild: Add support for running prebuild and postbuild tools

### DIFF
--- a/cmake/modules/zephyr_module.cmake
+++ b/cmake/modules/zephyr_module.cmake
@@ -42,11 +42,11 @@ if(ZEPHYR_EXTRA_MODULES)
 endif()
 
 file(MAKE_DIRECTORY ${KCONFIG_BINARY_DIR})
-set(KCONFIG_MODULES_FILE ${KCONFIG_BINARY_DIR}/Kconfig.modules)
-set(ZEPHYR_SETTINGS_FILE ${CMAKE_BINARY_DIR}/zephyr_settings.txt)
+set(kconfig_modules_file ${KCONFIG_BINARY_DIR}/Kconfig.modules)
+set(zephyr_settings_file ${CMAKE_BINARY_DIR}/zephyr_settings.txt)
 
 if(WEST)
-  set(WEST_ARG "--zephyr-base" ${ZEPHYR_BASE})
+  set(west_arg "--zephyr-base" ${ZEPHYR_BASE})
 endif()
 
 if(WEST OR ZEPHYR_MODULES)
@@ -55,12 +55,12 @@ if(WEST OR ZEPHYR_MODULES)
   execute_process(
     COMMAND
     ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/zephyr_module.py
-    ${WEST_ARG}
+    ${west_arg}
     ${ZEPHYR_MODULES_ARG}
     ${ZEPHYR_EXTRA_MODULES_ARG}
-    --kconfig-out ${KCONFIG_MODULES_FILE}
+    --kconfig-out ${kconfig_modules_file}
     --cmake-out ${CMAKE_BINARY_DIR}/zephyr_modules.txt
-    --settings-out ${ZEPHYR_SETTINGS_FILE}
+    --settings-out ${zephyr_settings_file}
     WORKING_DIRECTORY ${ZEPHYR_BASE}
     ERROR_VARIABLE
     zephyr_module_error_text
@@ -72,9 +72,9 @@ if(WEST OR ZEPHYR_MODULES)
       message(FATAL_ERROR "${zephyr_module_error_text}")
   endif()
 
-  if(EXISTS ${ZEPHYR_SETTINGS_FILE})
-    file(STRINGS ${ZEPHYR_SETTINGS_FILE} ZEPHYR_SETTINGS_TXT ENCODING UTF-8 REGEX "^[^#]")
-    foreach(setting ${ZEPHYR_SETTINGS_TXT})
+  if(EXISTS ${zephyr_settings_file})
+    file(STRINGS ${zephyr_settings_file} zephyr_settings_txt ENCODING UTF-8 REGEX "^[^#]")
+    foreach(setting ${zephyr_settings_txt})
       # Match <key>:<value> for each line of file, each corresponding to
       # a setting.  The use of quotes is required due to CMake not supporting
       # lazy regexes (it supports greedy only).
@@ -88,11 +88,11 @@ if(WEST OR ZEPHYR_MODULES)
   list(APPEND MODULE_EXT_ROOT ${ZEPHYR_BASE})
 
   if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
-    file(STRINGS ${CMAKE_BINARY_DIR}/zephyr_modules.txt ZEPHYR_MODULES_TXT
+    file(STRINGS ${CMAKE_BINARY_DIR}/zephyr_modules.txt zephyr_modules_txt
          ENCODING UTF-8)
 
     set(ZEPHYR_MODULE_NAMES)
-    foreach(module ${ZEPHYR_MODULES_TXT})
+    foreach(module ${zephyr_modules_txt})
       # Match "<name>":"<path>" for each line of file, each corresponding to
       # one module. The use of quotes is required due to CMake not supporting
       # lazy regexes (it supports greedy only).
@@ -112,8 +112,8 @@ if(WEST OR ZEPHYR_MODULES)
     include(${root}/modules/modules.cmake)
   endforeach()
 
-  if(DEFINED ZEPHYR_MODULES_TXT)
-    foreach(module ${ZEPHYR_MODULES_TXT})
+  if(DEFINED zephyr_modules_txt)
+    foreach(module ${zephyr_modules_txt})
       # Match "<name>":"<path>" for each line of file, each corresponding to
       # one Zephyr module. The use of quotes is required due to CMake not
       # supporting lazy regexes (it supports greedy only).
@@ -135,7 +135,7 @@ ${MODULE_NAME_UPPER} is a restricted name for Zephyr modules as it is used for \
   endif()
 else()
 
-  file(WRITE ${KCONFIG_MODULES_FILE}
+  file(WRITE ${kconfig_modules_file}
     "# No west and no Zephyr modules\n"
     )
 

--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -562,3 +562,18 @@ debug the application.
 
 .. _MCUboot with Zephyr: https://mcuboot.com/documentation/readme-zephyr/
 .. _ExternalProject: https://cmake.org/cmake/help/latest/module/ExternalProject.html
+
+Extending sysbuild
+******************
+
+Sysbuild can be extended by other modules to give it additional functionality
+or include other configuration or images, an example could be to add support
+for another bootloader or external signing method.
+
+Modules can be extended by adding custom CMake or Kconfig files as normal
+:ref:`modules <module-yml>` do, this will cause the files to be included in
+each image that is part of a project. Alternatively, there are
+:ref:`sysbuild-specific module extension <sysbuild_module_integration>` files
+which can be used to include CMake and Kconfig files for the overall sysbuild
+image itself, this is where e.g. a custom image for a particular board or SoC
+can be added.

--- a/modules/Kconfig.sysbuild
+++ b/modules/Kconfig.sysbuild
@@ -1,0 +1,28 @@
+# Copyright (c) 2019 Intel Corporation
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+comment "Available modules."
+
+source "$(KCONFIG_BINARY_DIR)/Kconfig.sysbuild.modules"
+
+comment "Unavailable modules, please install those via the project manifest."
+
+# List of comments to display when Zephyr modules are not available, please
+# use the following syntax:
+# ---------------------------------------------------
+# comment "<module_name> module not available."
+#	depends on !SYSBUILD_<MODULE_NAME_UPPER>_MODULE
+#
+# Remember to add the following code inside the `<module>/Kconfig file:
+# ---------------------------------------------------
+# config SYSBUILD_<MODULE_NAME_UPPER>_MODULE
+# 	bool
+
+# This ensures that symbols are available in Kconfig for dependency checking
+# and referencing, while keeping the settings themselves unavailable when the
+# modules are not present in the workspace
+if 0
+osource "modules/*/Kconfig.sysbuild"
+endif

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -57,6 +57,20 @@ mapping:
         required: false
         type: bool
         default: false
+      sysbuild-cmake:
+        required: false
+        type: str
+      sysbuild-kconfig:
+        required: false
+        type: str
+      sysbuild-cmake-ext:
+        required: false
+        type: bool
+        default: false
+      sysbuild-kconfig-ext:
+        required: false
+        type: bool
+        default: false
       depends:
         required: false
         type: seq
@@ -216,6 +230,40 @@ def process_cmake(module, meta):
                        module_path.as_posix()))
 
 
+def process_sysbuildcmake(module, meta):
+    section = meta.get('build', dict())
+    module_path = PurePath(module)
+    module_yml = module_path.joinpath('zephyr/module.yml')
+
+    cmake_extern = section.get('sysbuild-cmake-ext', False)
+    if cmake_extern:
+        return('\"{}\":\"{}\":\"{}\"\n'
+               .format(meta['name'],
+                       module_path.as_posix(),
+                       "${SYSBUILD_" + meta['name-sanitized'].upper() + "_CMAKE_DIR}"))
+
+    cmake_setting = section.get('sysbuild-cmake', None)
+    if not validate_setting(cmake_setting, module, 'CMakeLists.txt'):
+        sys.exit('ERROR: "cmake" key in {} has folder value "{}" which '
+                 'does not contain a CMakeLists.txt file.'
+                 .format(module_yml.as_posix(), cmake_setting))
+
+    if cmake_setting is None:
+        return ""
+
+    cmake_path = os.path.join(module, cmake_setting or 'zephyr')
+    cmake_file = os.path.join(cmake_path, 'CMakeLists.txt')
+    if os.path.isfile(cmake_file):
+        return('\"{}\":\"{}\":\"{}\"\n'
+               .format(meta['name'],
+                       module_path.as_posix(),
+                       Path(cmake_path).resolve().as_posix()))
+    else:
+        return('\"{}\":\"{}\":\"\"\n'
+               .format(meta['name'],
+                       module_path.as_posix()))
+
+
 def process_settings(module, meta):
     section = meta.get('build', dict())
     build_settings = section.get('settings', None)
@@ -260,13 +308,14 @@ def process_blobs(module, meta):
     return blobs
 
 
-def kconfig_snippet(meta, path, kconfig_file=None, blobs=False):
+def kconfig_snippet(meta, path, kconfig_file=None, blobs=False, sysbuild=False):
     name = meta['name']
     name_sanitized = meta['name-sanitized']
 
     snippet = [f'menu "{name} ({path.as_posix()})"',
                f'osource "{kconfig_file.resolve().as_posix()}"' if kconfig_file
-               else f'osource "$(ZEPHYR_{name_sanitized.upper()}_KCONFIG)"',
+               else f'osource "$(SYSBUILD_{name_sanitized.upper()}_KCONFIG)"' if sysbuild is True
+	       else f'osource "$(ZEPHYR_{name_sanitized.upper()}_KCONFIG)"',
                f'config ZEPHYR_{name_sanitized.upper()}_MODULE',
                '	bool',
                '	default y',
@@ -297,6 +346,30 @@ def process_kconfig(module, meta):
     if os.path.isfile(kconfig_file):
         return kconfig_snippet(meta, module_path, Path(kconfig_file),
                                blobs=taint_blobs)
+    else:
+        return ""
+
+
+def process_sysbuildkconfig(module, meta):
+    section = meta.get('build', dict())
+    module_path = PurePath(module)
+    module_yml = module_path.joinpath('zephyr/module.yml')
+    kconfig_extern = section.get('sysbuild-kconfig-ext', False)
+    if kconfig_extern:
+        return kconfig_snippet(meta, module_path, sysbuild=True)
+
+    kconfig_setting = section.get('sysbuild-kconfig', None)
+    if not validate_setting(kconfig_setting, module):
+        sys.exit('ERROR: "kconfig" key in {} has value "{}" which does '
+                 'not point to a valid Kconfig file.'
+                 .format(module_yml, kconfig_setting))
+
+    if kconfig_setting is None:
+        return ""
+
+    kconfig_file = os.path.join(module, kconfig_setting)
+    if os.path.isfile(kconfig_file):
+        return kconfig_snippet(meta, module_path, Path(kconfig_file))
     else:
         return ""
 
@@ -553,6 +626,12 @@ def main():
     parser.add_argument('--cmake-out',
                         help="""File to write with resulting <name>:<path>
                              values to use for including in CMake""")
+    parser.add_argument('--sysbuild-kconfig-out',
+                        help="""File to write with resulting KConfig import
+                             statements.""")
+    parser.add_argument('--sysbuild-cmake-out',
+                        help="""File to write with resulting <name>:<path>
+                             values to use for including in CMake""")
     parser.add_argument('--meta-out',
                         help="""Write a build meta YaML file containing a list
                              of Zephyr modules and west projects.
@@ -576,6 +655,8 @@ def main():
 
     kconfig = ""
     cmake = ""
+    sysbuild_kconfig = ""
+    sysbuild_cmake = ""
     settings = ""
     twister = ""
 
@@ -586,6 +667,8 @@ def main():
     for module in modules:
         kconfig += process_kconfig(module.project, module.meta)
         cmake += process_cmake(module.project, module.meta)
+        sysbuild_kconfig += process_sysbuildkconfig(module.project, module.meta)
+        sysbuild_cmake += process_sysbuildcmake(module.project, module.meta)
         settings += process_settings(module.project, module.meta)
         twister += process_twister(module.project, module.meta)
 
@@ -596,6 +679,14 @@ def main():
     if args.cmake_out:
         with open(args.cmake_out, 'w', encoding="utf-8") as fp:
             fp.write(cmake)
+
+    if args.sysbuild_kconfig_out:
+        with open(args.sysbuild_kconfig_out, 'w', encoding="utf-8") as fp:
+            fp.write(sysbuild_kconfig)
+
+    if args.sysbuild_cmake_out:
+        with open(args.sysbuild_cmake_out, 'w', encoding="utf-8") as fp:
+            fp.write(sysbuild_cmake)
 
     if args.settings_out:
         with open(args.settings_out, 'w', encoding="utf-8") as fp:

--- a/share/sysbuild/CMakeLists.txt
+++ b/share/sysbuild/CMakeLists.txt
@@ -91,4 +91,7 @@ while(NOT "${images_length}" EQUAL "${processed_length}")
   set(processed_length ${processed_length_new})
 endwhile()
 
+foreach(image ${IMAGES})
+  ExternalZephyrProject_Cmake(APPLICATION ${image})
+endforeach()
 include(cmake/domains.cmake)

--- a/share/sysbuild/CMakeLists.txt
+++ b/share/sysbuild/CMakeLists.txt
@@ -30,6 +30,24 @@ set(IMAGES)
 get_filename_component(APP_DIR  ${APP_DIR} ABSOLUTE)
 get_filename_component(app_name ${APP_DIR} NAME)
 
+# Include zephyr modules generated sysbuild CMake file.
+foreach(module_name ${SYSBUILD_MODULE_NAMES})
+  # Note the second, binary_dir parameter requires the added
+  # subdirectory to have its own, local cmake target(s). If not then
+  # this binary_dir is created but stays empty. Object files land in
+  # the main binary dir instead.
+  # https://cmake.org/pipermail/cmake/2019-June/069547.html
+  zephyr_string(SANITIZE TOUPPER MODULE_NAME_UPPER ${module_name})
+  if(NOT ${SYSBUILD_${MODULE_NAME_UPPER}_CMAKE_DIR} STREQUAL "")
+    set(SYSBUILD_CURRENT_MODULE_DIR ${SYSBUILD_${MODULE_NAME_UPPER}_MODULE_DIR})
+    set(SYSBUILD_CURRENT_CMAKE_DIR ${SYSBUILD_${MODULE_NAME_UPPER}_CMAKE_DIR})
+    add_subdirectory(${SYSBUILD_CURRENT_CMAKE_DIR} ${CMAKE_BINARY_DIR}/modules/${module_name})
+  endif()
+endforeach()
+# Done processing modules, clear SYSBUILD_CURRENT_MODULE_DIR and SYSBUILD_CURRENT_CMAKE_DIR.
+set(SYSBUILD_CURRENT_MODULE_DIR)
+set(SYSBUILD_CURRENT_CMAKE_DIR)
+
 # Propagate bootloader and signing settings from this system to the MCUboot and
 # application image build systems.
 if(SB_CONFIG_BOOTLOADER_MCUBOOT)

--- a/share/sysbuild/CMakeLists.txt
+++ b/share/sysbuild/CMakeLists.txt
@@ -13,6 +13,11 @@ endif()
 # on current working dir.
 set(APP_DIR ${APP_DIR} CACHE PATH "Main Application Source Directory")
 
+# This is a global variable which sysbuild modules can add to, which allows for
+# custom CMake files to be ran at specific points of the sysbuild image
+# configuration.
+set(SYSBUILD_EXTRA_TOOLS)
+
 # Add sysbuild/cmake/modules to CMAKE_MODULE_PATH which allows us to integrate
 # sysbuild CMake modules with general Zephyr CMake modules.
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/modules)
@@ -73,6 +78,11 @@ else()
   )
 endif()
 
+# Run any sysbuild-configured tools with the prebuild suffix.
+foreach(tool ${SYSBUILD_EXTRA_TOOLS})
+  include(${tool}_prebuild.cmake OPTIONAL)
+endforeach()
+
 # This adds the primary application to the build.
 ExternalZephyrProject_Add(
   APPLICATION ${app_name}
@@ -113,3 +123,8 @@ foreach(image ${IMAGES})
   ExternalZephyrProject_Cmake(APPLICATION ${image})
 endforeach()
 include(cmake/domains.cmake)
+
+# Run any sysbuild-configured tools with the postbuild suffix.
+foreach(tool ${SYSBUILD_EXTRA_TOOLS})
+  include(${tool}_postbuild.cmake OPTIONAL)
+endforeach()

--- a/share/sysbuild/Kconfig
+++ b/share/sysbuild/Kconfig
@@ -6,6 +6,12 @@ comment "Sysbuild image configuration"
 
 osource "$(BOARD_DIR)/Kconfig.sysbuild"
 
+menu "Modules"
+
+source "modules/Kconfig.sysbuild"
+
+endmenu
+
 config EXPERIMENTAL
 	bool
 	help

--- a/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
@@ -46,7 +46,6 @@ endif()
 # Empty files to make kconfig.py happy.
 file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/empty.conf)
 set(APPLICATION_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(KCONFIG_BINARY_DIR     ${CMAKE_CURRENT_BINARY_DIR})
 set(AUTOCONF_H             ${CMAKE_CURRENT_BINARY_DIR}/autoconf.h)
 set(CONF_FILE              ${SB_CONF_FILE})
 set(BOARD_DEFCONFIG        "${CMAKE_CURRENT_BINARY_DIR}/empty.conf")


### PR DESCRIPTION
    Adds a feature to sysbuild which allows modules to register files
    that can be ran to further extend sysbuilds functionality. The
    prebuild one runs prior to applications being configured, the
    postbuild one runs after all images have been configured.
