### PR TITLE
samples/bluetooth: Relax RSSI requirement 

### DIFF
--- a/samples/bluetooth/central_multilink/src/central_multilink.c
+++ b/samples/bluetooth/central_multilink/src/central_multilink.c
@@ -70,7 +70,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	/* connect only to devices in close proximity */
-	if (rssi < -35) {
+	if (rssi < -70) {
 		return;
 	}
 

--- a/samples/bluetooth/mtu_update/central/src/central_mtu_update.c
+++ b/samples/bluetooth/mtu_update/central/src/central_mtu_update.c
@@ -130,7 +130,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
 
 	/* connect only to devices in close proximity */
-	if (rssi < -40) {
+	if (rssi < -70) {
 		return;
 	}
 


### PR DESCRIPTION
samples/bluetooth/central_multilink: Relax RSSI requirement
samples/bluetooth/mtu_update: Relax RSSI requirement

The sample was only willing to connect if the pair RSSI level
was over -40/-35dBm. That is ok when testing physically keeping
devices at less than ~1 meter from each other.
But in CI we test with a default attenuation of 60dB between
devices and the Tx power is 0dBm.
Which causes the tests based on this sample to fail.