### PR TITLE
scripts: runners: nrfjprog: Multiple improvements

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -24,6 +24,7 @@ import subprocess
 import re
 from functools import partial
 from enum import Enum
+from inspect import isabstract
 from typing import Dict, List, NamedTuple, NoReturn, Optional, Set, Type, \
     Union
 
@@ -423,7 +424,19 @@ class ZephyrBinaryRunner(abc.ABC):
     @staticmethod
     def get_runners() -> List[Type['ZephyrBinaryRunner']]:
         '''Get a list of all currently defined runner classes.'''
-        return ZephyrBinaryRunner.__subclasses__()
+        def inheritors(klass):
+            subclasses = set()
+            work = [klass]
+            while work:
+                parent = work.pop()
+                for child in parent.__subclasses__():
+                    if child not in subclasses:
+                        if not isabstract(child):
+                            subclasses.add(child)
+                        work.append(child)
+            return subclasses
+
+        return inheritors(ZephyrBinaryRunner)
 
     @classmethod
     @abc.abstractmethod

--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -1,0 +1,401 @@
+# Copyright (c) 2017 Linaro Limited.
+# Copyright (c) 2023 Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Runner base class for flashing with nrf tools.'''
+
+import abc
+from collections import deque
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+from re import fullmatch, escape
+
+from runners.core import ZephyrBinaryRunner, RunnerCaps
+
+try:
+    from intelhex import IntelHex
+except ImportError:
+    IntelHex = None
+
+# https://infocenter.nordicsemi.com/index.jsp?topic=%2Fug_nrf_cltools%2FUG%2Fcltools%2Fnrf_nrfjprogexe_return_codes.html&cp=9_1_3_1
+UnavailableOperationBecauseProtectionError = 16
+VerifyError = 55
+
+class NrfBinaryRunner(ZephyrBinaryRunner):
+    '''Runner front-end base class for nrf tools.'''
+
+    def __init__(self, cfg, family, softreset, dev_id, erase=False,
+                 tool_opt=[], force=False, recover=False):
+        super().__init__(cfg)
+        self.hex_ = cfg.hex_file
+        self.family = family
+        self.softreset = softreset
+        self.dev_id = dev_id
+        self.erase = bool(erase)
+        self.force = force
+        self.recover = bool(recover)
+
+        self.tool_opt = []
+        for opts in [shlex.split(opt) for opt in tool_opt]:
+            self.tool_opt += opts
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'flash'}, dev_id=True, erase=True,
+                          tool_opt=True)
+
+    @classmethod
+    def dev_id_help(cls) -> str:
+        return '''Device identifier. Use it to select the J-Link Serial Number
+                  of the device connected over USB. '*' matches one or more
+                  characters/digits'''
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.add_argument('--nrf-family',
+                            choices=['NRF51', 'NRF52', 'NRF53', 'NRF91'],
+                            help='''MCU family; still accepted for
+                            compatibility only''')
+        parser.add_argument('--softreset', required=False,
+                            action='store_true',
+                            help='use reset instead of pinreset')
+        parser.add_argument('--snr', required=False, dest='dev_id',
+                            help='obsolete synonym for -i/--dev-id')
+        parser.add_argument('--force', required=False,
+                            action='store_true',
+                            help='Flash even if the result cannot be guaranteed.')
+        parser.add_argument('--recover', required=False,
+                            action='store_true',
+                            help='''erase all user available non-volatile
+                            memory and disable read back protection before
+                            flashing (erases flash for both cores on nRF53)''')
+
+    def ensure_snr(self):
+        if not self.dev_id or "*" in self.dev_id:
+            self.dev_id = self.get_board_snr(self.dev_id or "*")
+        self.dev_id = self.dev_id.lstrip("0")
+
+    @abc.abstractmethod
+    def do_get_boards(self):
+        ''' Return an array of Segger SNRs '''
+
+    def get_boards(self):
+        snrs = self.do_get_boards()
+        if not snrs:
+            raise RuntimeError('Unable to find a board; '
+                               'is the board connected?')
+        return snrs
+
+    @staticmethod
+    def verify_snr(snr):
+        if snr == '0':
+            raise RuntimeError('The Segger SNR obtained is 0; '
+                                'is a debugger already connected?')
+
+    def get_board_snr(self, glob):
+        # Use nrfjprog or nrfutil to discover connected boards.
+        #
+        # If there's exactly one board connected, it's safe to assume
+        # the user wants that one. Otherwise, bail unless there are
+        # multiple boards and we are connected to a terminal, in which
+        # case use print() and input() to ask what the user wants.
+
+        re_glob = escape(glob).replace(r"\*", ".+")
+        snrs = [snr for snr in self.get_boards() if fullmatch(re_glob, snr)]
+
+        if len(snrs) == 0:
+            raise RuntimeError(
+                'There are no boards connected{}.'.format(
+                        f" matching '{glob}'" if glob != "*" else ""))
+        elif len(snrs) == 1:
+            board_snr = snrs[0]
+            self.verify_snr(board_snr)
+            print("Using board {}".format(board_snr))
+            return board_snr
+        elif not sys.stdin.isatty():
+            raise RuntimeError(
+                f'refusing to guess which of {len(snrs)} '
+                'connected boards to use. (Interactive prompts '
+                'disabled since standard input is not a terminal.) '
+                'Please specify a serial number on the command line.')
+
+        snrs = sorted(snrs)
+        print('There are multiple boards connected{}.'.format(
+                        f" matching '{glob}'" if glob != "*" else ""))
+        for i, snr in enumerate(snrs, 1):
+            print('{}. {}'.format(i, snr))
+
+        p = 'Please select one with desired serial number (1-{}): '.format(
+                len(snrs))
+        while True:
+            try:
+                value = input(p)
+            except EOFError:
+                sys.exit(0)
+            try:
+                value = int(value)
+            except ValueError:
+                continue
+            if 1 <= value <= len(snrs):
+                break
+
+        return snrs[value - 1]
+
+    def ensure_family(self):
+        # Ensure self.family is set.
+
+        if self.family is not None:
+            return
+
+        if self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF51X'):
+            self.family = 'NRF51_FAMILY'
+        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF52X'):
+            self.family = 'NRF52_FAMILY'
+        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF53X'):
+            self.family = 'NRF53_FAMILY'
+        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF91X'):
+            self.family = 'NRF91_FAMILY'
+        else:
+            raise RuntimeError(f'unknown nRF; update {__file__}')
+
+    def hex_refers_region(self, region_start, region_end):
+        for segment_start, _ in self.hex_contents.segments():
+            if region_start <= segment_start <= region_end:
+                return True
+        return False
+
+    def hex_has_uicr_content(self):
+        # A map from SoCs which need this check to their UICR address
+        # ranges. If self.family isn't in here, do nothing.
+        uicr_ranges = {
+            'NRF53': ((0x00FF8000, 0x00FF8800),
+                      (0x01FF8000, 0x01FF8800)),
+            'NRF91': ((0x00FF8000, 0x00FF8800),),
+        }
+
+        if self.family not in uicr_ranges:
+            return
+
+        for region_start, region_end in uicr_ranges[self.family]:
+            if self.hex_refers_region(region_start, region_end):
+                return True
+
+    def recover_target(self):
+        if self.family == 'NRF53_FAMILY':
+            self.logger.info(
+                'Recovering and erasing flash memory for both the network '
+                'and application cores.')
+        else:
+            self.logger.info('Recovering and erasing all flash memory.')
+
+        if self.family == 'NRF53_FAMILY':
+            self.exec_op('recover', core='NRFDL_DEVICE_CORE_NETWORK')
+
+        self.exec_op('recover')
+
+    def program_hex(self):
+        # Get the command use to actually program self.hex_.
+        self.logger.info('Flashing file: {}'.format(self.hex_))
+
+        # What type of erase argument should we pass to the tool?
+        if self.erase:
+            erase_arg = 'ERASE_ALL'
+        else:
+            if self.family == 'NRF52_FAMILY':
+                erase_arg = 'ERASE_PAGES_INCLUDING_UICR'
+            else:
+                erase_arg = 'ERASE_PAGES'
+
+        xip_ranges = {
+            'NRF52_FAMILY': (0x12000000, 0x19FFFFFF),
+            'NRF53_FAMILY': (0x10000000, 0x1FFFFFFF),
+        }
+        qspi_erase_opt = None
+        if self.family in xip_ranges:
+            xip_start, xip_end = xip_ranges[self.family]
+            if self.hex_refers_region(xip_start, xip_end):
+                qspi_erase_opt = 'ERASE_ALL'
+
+        # What tool commands do we need to flash this target?
+        if self.family == 'NRF53_FAMILY':
+            # nRF53 requires special treatment due to the extra coprocessor.
+            self.program_hex_nrf53(erase_arg, qspi_erase_opt)
+        else:
+            self.op_program(self.hex_, erase_arg, qspi_erase_opt, defer=True)
+
+        try:
+            self.flush_ops()
+        except subprocess.CalledProcessError as cpe:
+            if cpe.returncode == UnavailableOperationBecauseProtectionError:
+                if self.family == 'NRF53_FAMILY':
+                    family_help = (
+                        '  Note: your target is an nRF53; all flash memory '
+                        'for both the network and application cores will be '
+                        'erased prior to reflashing.')
+                else:
+                    family_help = (
+                        '  Note: this will recover and erase all flash memory '
+                        'prior to reflashing.')
+                self.logger.error(
+                    'Flashing failed because the target '
+                    'must be recovered.\n'
+                    '  To fix, run "west flash --recover" instead.\n' +
+                    family_help)
+            if cpe.returncode == VerifyError:
+                # If there are data in  the UICR region it is likely that the
+                # verify failed du to the UICR not been erased before, so giving
+                # a warning here will hopefully enhance UX.
+                if self.hex_has_uicr_content():
+                    self.logger.warning(
+                        'The hex file contains data placed in the UICR, which '
+                        'may require a full erase before reprogramming. Run '
+                        'west flash again with --erase, or --recover.')
+            raise
+
+    def program_hex_nrf53(self, erase_arg, qspi_erase_opt):
+        # program_hex() helper for nRF53.
+
+        # *********************** NOTE *******************************
+        # self.hex_ can contain code for both the application core and
+        # the network core.
+        #
+        # We can't assume, for example, that
+        # CONFIG_SOC_NRF5340_CPUAPP=y means self.hex_ only contains
+        # data for the app core's flash: the user can put arbitrary
+        # addresses into one of the files in HEX_FILES_TO_MERGE.
+        #
+        # Therefore, on this family, we may need to generate two new
+        # hex files, one for each core, and flash them individually
+        # with the correct '--coprocessor' arguments.
+        #
+        # Kind of hacky, but it works, and the tools are not capable of
+        # flashing to both cores at once. If self.hex_ only affects
+        # one core's flash, then we skip the extra work to save time.
+        # ************************************************************
+
+        # Address range of the network coprocessor's flash. From nRF5340 OPS.
+        # We should get this from DTS instead if multiple values are possible,
+        # but this is fine for now.
+        net_flash_start = 0x01000000
+        net_flash_end   = 0x0103FFFF
+
+        # If there is nothing in the hex file for the network core,
+        # only the application core is programmed.
+        if not self.hex_refers_region(net_flash_start, net_flash_end):
+            self.op_program(self.hex_, erase_arg, qspi_erase_opt, defer=True,
+                            core='NRFDL_DEVICE_CORE_APPLICATION')
+        # If there is some content that addresses a region beyond the network
+        # core flash range, two hex files are generated and the two cores
+        # are programmed one by one.
+        elif self.hex_contents.minaddr() < net_flash_start or \
+             self.hex_contents.maxaddr() > net_flash_end:
+
+            net_hex, app_hex = IntelHex(), IntelHex()
+            for start, end in self.hex_contents.segments():
+                if net_flash_start <= start <= net_flash_end:
+                    net_hex.merge(self.hex_contents[start:end])
+                else:
+                    app_hex.merge(self.hex_contents[start:end])
+
+            hex_path = Path(self.hex_)
+            hex_dir, hex_name = hex_path.parent, hex_path.name
+
+            net_hex_file = os.fspath(
+                hex_dir / f'GENERATED_CP_NETWORK_{hex_name}')
+            app_hex_file = os.fspath(
+                hex_dir / f'GENERATED_CP_APPLICATION_{hex_name}')
+
+            self.logger.info(
+                f'{self.hex_} targets both nRF53 coprocessors; '
+                f'splitting it into: {net_hex_file} and {app_hex_file}')
+
+            net_hex.write_hex_file(net_hex_file)
+            app_hex.write_hex_file(app_hex_file)
+
+            self.op_program(net_hex_file, erase_arg, None, defer=True,
+                            core='NRFDL_DEVICE_CORE_NETWORK')
+            self.op_program(app_hex_file, erase_arg, qspi_erase_opt, defer=True,
+                            core='NRFDL_DEVICE_CORE_APPLICATION')
+        # Otherwise, only the network core is programmed.
+        else:
+            self.op_program(self.hex_, erase_arg, None, defer=True,
+                            core='NRFDL_DEVICE_CORE_NETWORK')
+
+    def reset_target(self):
+        if self.family == 'NRF52_FAMILY' and not self.softreset:
+            self.exec_op('pinreset-enable')
+
+        if self.softreset:
+            self.exec_op('reset', option="RESET_SYSTEM")
+        else:
+            self.exec_op('reset', option="RESET_PIN")
+
+    @abc.abstractmethod
+    def do_require(self):
+        ''' Ensure the tool is installed '''
+
+    def op_program(self, hex_file, erase, qspi_erase, defer=False, core=None):
+        args = {'firmware': {'file': hex_file, 'format': 'NRFDL_FW_INTEL_HEX'},
+                'chip_erase_mode': erase, 'verify': 'VERIFY_READ'}
+        if qspi_erase:
+            args['firmware']['qspi_erase_mode'] = qspi_erase
+        self.exec_op('program', defer, core, **args)
+
+    def exec_op(self, op, defer=False, core=None, **kwargs):
+        _op = f'{op}'
+        op = {'operation': {'type': _op}}
+        if core:
+            op['core'] = core
+        op['operation'].update(kwargs)
+        self.logger.debug(f'defer: {defer} op: {op}')
+        if defer or not self.do_exec_op(op, force=False):
+            self.ops.append(op)
+
+    @abc.abstractmethod
+    def do_exec_op(self, op, force=False):
+        ''' Execute an operation. Return True if executed, False if not.
+            Throws subprocess.CalledProcessError with the appropriate
+            returncode if a failure arises.'''
+
+    def flush_ops(self):
+        ''' Execute any remaining ops in the self.ops array.
+            Throws subprocess.CalledProcessError with the appropriate
+            returncode if a failure arises.
+            Subclasses can override this method for special handling of
+            queued ops.'''
+        self.logger.debug('Flushing ops')
+        while self.ops:
+            self.do_exec_op(self.ops.popleft(), force=True)
+
+    def do_run(self, command, **kwargs):
+        self.do_require()
+
+        self.ensure_output('hex')
+        if IntelHex is None:
+            raise RuntimeError('one or more Python dependencies were missing; '
+                               'see the getting started guide for details on '
+                               'how to fix')
+        self.hex_contents = IntelHex()
+        try:
+            self.hex_contents.loadfile(self.hex_, format='hex')
+        except FileNotFoundError:
+            pass
+
+        self.ensure_snr()
+        self.ensure_family()
+
+        self.ops = deque()
+
+        if self.recover:
+            self.recover_target()
+        self.program_hex()
+        self.reset_target()
+        # All done, now flush any outstanding ops
+        self.flush_ops()
+
+        self.logger.info(f'Board with serial number {self.dev_id} '
+                         'flashed successfully.')

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -43,7 +43,6 @@ class NrfJprogBinaryRunner(NrfBinaryRunner):
         cores = {'NRFDL_DEVICE_CORE_APPLICATION': 'CP_APPLICATION',
                  'NRFDL_DEVICE_CORE_NETWORK': 'CP_NETWORK'}
 
-        tool_opt = []
         core_opt = ['--coprocessor', cores[op['core']]] \
                    if op.get('core') else []
 
@@ -56,7 +55,6 @@ class NrfJprogBinaryRunner(NrfBinaryRunner):
         elif op_type == 'program':
             cmd.append('--program')
             cmd.append(_op['firmware']['file'])
-            tool_opt = self.tool_opt
             erase = _op['chip_erase_mode']
             if erase == 'ERASE_ALL':
                 cmd.append('--chiperase')
@@ -84,5 +82,5 @@ class NrfJprogBinaryRunner(NrfBinaryRunner):
             raise RuntimeError(f'Invalid operation: {op_type}')
 
         self.check_call(cmd + ['-f', families[self.family]] + core_opt +
-                        ['--snr', self.dev_id] + tool_opt)
+                        ['--snr', self.dev_id] + self.tool_opt)
         return True

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -1,84 +1,24 @@
 # Copyright (c) 2017 Linaro Limited.
-# Copyright (c) 2019 Nordic Semiconductor ASA.
+# Copyright (c) 2023 Nordic Semiconductor ASA.
 #
 # SPDX-License-Identifier: Apache-2.0
 
 '''Runner for flashing with nrfjprog.'''
 
-import os
-from pathlib import Path
-import shlex
-import subprocess
 import sys
-from re import fullmatch, escape
 
-from runners.core import ZephyrBinaryRunner, RunnerCaps
+from runners.nrf_common import NrfBinaryRunner
 
-try:
-    from intelhex import IntelHex
-except ImportError:
-    IntelHex = None
-
-# https://infocenter.nordicsemi.com/index.jsp?topic=%2Fug_nrf_cltools%2FUG%2Fcltools%2Fnrf_nrfjprogexe_return_codes.html&cp=9_1_3_1
-UnavailableOperationBecauseProtectionError = 16
-VerifyError = 55
-
-class NrfJprogBinaryRunner(ZephyrBinaryRunner):
+class NrfJprogBinaryRunner(NrfBinaryRunner):
     '''Runner front-end for nrfjprog.'''
-
-    def __init__(self, cfg, family, softreset, dev_id, erase=False,
-                 tool_opt=[], force=False, recover=False):
-        super().__init__(cfg)
-        self.hex_ = cfg.hex_file
-        self.family = family
-        self.softreset = softreset
-        self.dev_id = dev_id
-        self.erase = bool(erase)
-        self.force = force
-        self.recover = bool(recover)
-
-        self.tool_opt = []
-        for opts in [shlex.split(opt) for opt in tool_opt]:
-            self.tool_opt += opts
 
     @classmethod
     def name(cls):
         return 'nrfjprog'
 
     @classmethod
-    def capabilities(cls):
-        return RunnerCaps(commands={'flash'}, dev_id=True, erase=True,
-                          tool_opt=True)
-
-    @classmethod
-    def dev_id_help(cls) -> str:
-        return '''Device identifier. Use it to select the J-Link Serial Number
-                  of the device connected over USB. '*' matches one or more
-                  characters/digits'''
-
-    @classmethod
     def tool_opt_help(cls) -> str:
         return 'Additional options for nrfjprog, e.g. "--recover"'
-
-    @classmethod
-    def do_add_parser(cls, parser):
-        parser.add_argument('--nrf-family',
-                            choices=['NRF51', 'NRF52', 'NRF53', 'NRF91'],
-                            help='''MCU family; still accepted for
-                            compatibility only''')
-        parser.add_argument('--softreset', required=False,
-                            action='store_true',
-                            help='use reset instead of pinreset')
-        parser.add_argument('--snr', required=False, dest='dev_id',
-                            help='obsolete synonym for -i/--dev-id')
-        parser.add_argument('--force', required=False,
-                            action='store_true',
-                            help='Flash even if the result cannot be guaranteed.')
-        parser.add_argument('--recover', required=False,
-                            action='store_true',
-                            help='''erase all user available non-volatile
-                            memory and disable read back protection before
-                            flashing (erases flash for both cores on nRF53)''')
 
     @classmethod
     def do_create(cls, cfg, args):
@@ -87,303 +27,62 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
                                     tool_opt=args.tool_opt, force=args.force,
                                     recover=args.recover)
 
-    def ensure_snr(self):
-        if not self.dev_id or "*" in self.dev_id:
-            self.dev_id = self.get_board_snr(self.dev_id or "*")
-        self.dev_id = self.dev_id.lstrip("0")
-
-    def get_boards(self):
+    def do_get_boards(self):
         snrs = self.check_output(['nrfjprog', '--ids'])
-        snrs = snrs.decode(sys.getdefaultencoding()).strip().splitlines()
-        if not snrs:
-            raise RuntimeError('"nrfjprog --ids" did not find a board; '
-                               'is the board connected?')
-        return snrs
+        return snrs.decode(sys.getdefaultencoding()).strip().splitlines()
 
-    @staticmethod
-    def verify_snr(snr):
-        if snr == '0':
-            raise RuntimeError('"nrfjprog --ids" returned 0; '
-                                'is a debugger already connected?')
-
-    def get_board_snr(self, glob):
-        # Use nrfjprog --ids to discover connected boards.
-        #
-        # If there's exactly one board connected, it's safe to assume
-        # the user wants that one. Otherwise, bail unless there are
-        # multiple boards and we are connected to a terminal, in which
-        # case use print() and input() to ask what the user wants.
-
-        re_glob = escape(glob).replace(r"\*", ".+")
-        snrs = [snr for snr in self.get_boards() if fullmatch(re_glob, snr)]
-
-        if len(snrs) == 0:
-            raise RuntimeError(
-                'There are no boards connected{}.'.format(
-                        f" matching '{glob}'" if glob != "*" else ""))
-        elif len(snrs) == 1:
-            board_snr = snrs[0]
-            self.verify_snr(board_snr)
-            print("Using board {}".format(board_snr))
-            return board_snr
-        elif not sys.stdin.isatty():
-            raise RuntimeError(
-                f'refusing to guess which of {len(snrs)} '
-                'connected boards to use. (Interactive prompts '
-                'disabled since standard input is not a terminal.) '
-                'Please specify a serial number on the command line.')
-
-        snrs = sorted(snrs)
-        print('There are multiple boards connected{}.'.format(
-                        f" matching '{glob}'" if glob != "*" else ""))
-        for i, snr in enumerate(snrs, 1):
-            print('{}. {}'.format(i, snr))
-
-        p = 'Please select one with desired serial number (1-{}): '.format(
-                len(snrs))
-        while True:
-            try:
-                value = input(p)
-            except EOFError:
-                sys.exit(0)
-            try:
-                value = int(value)
-            except ValueError:
-                continue
-            if 1 <= value <= len(snrs):
-                break
-
-        return snrs[value - 1]
-
-    def ensure_family(self):
-        # Ensure self.family is set.
-
-        if self.family is not None:
-            return
-
-        if self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF51X'):
-            self.family = 'NRF51'
-        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF52X'):
-            self.family = 'NRF52'
-        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF53X'):
-            self.family = 'NRF53'
-        elif self.build_conf.getboolean('CONFIG_SOC_SERIES_NRF91X'):
-            self.family = 'NRF91'
-        else:
-            raise RuntimeError(f'unknown nRF; update {__file__}')
-
-    def hex_refers_region(self, region_start, region_end):
-        for segment_start, _ in self.hex_contents.segments():
-            if region_start <= segment_start <= region_end:
-                return True
-        return False
-
-    def hex_has_uicr_content(self):
-        # A map from SoCs which need this check to their UICR address
-        # ranges. If self.family isn't in here, do nothing.
-        uicr_ranges = {
-            'NRF53': ((0x00FF8000, 0x00FF8800),
-                      (0x01FF8000, 0x01FF8800)),
-            'NRF91': ((0x00FF8000, 0x00FF8800),),
-        }
-
-        if self.family not in uicr_ranges:
-            return
-
-        for region_start, region_end in uicr_ranges[self.family]:
-            if self.hex_refers_region(region_start, region_end):
-                return True
-
-    def recover_target(self):
-        if self.family == 'NRF53':
-            self.logger.info(
-                'Recovering and erasing flash memory for both the network '
-                'and application cores.')
-        else:
-            self.logger.info('Recovering and erasing all flash memory.')
-
-        if self.family == 'NRF53':
-            self.check_call(['nrfjprog', '--recover', '-f', self.family,
-                             '--coprocessor', 'CP_NETWORK',
-                             '--snr', self.dev_id])
-
-        self.check_call(['nrfjprog', '--recover',  '-f', self.family,
-                         '--snr', self.dev_id])
-
-    def program_hex(self):
-        # Get the nrfjprog command use to actually program self.hex_.
-        self.logger.info('Flashing file: {}'.format(self.hex_))
-
-        # What type of erase argument should we pass to nrfjprog?
-        if self.erase:
-            erase_arg = '--chiperase'
-        else:
-            if self.family == 'NRF52':
-                erase_arg = '--sectoranduicrerase'
-            else:
-                erase_arg = '--sectorerase'
-
-        xip_ranges = {
-            'NRF52': (0x12000000, 0x19FFFFFF),
-            'NRF53': (0x10000000, 0x1FFFFFFF),
-        }
-        qspi_erase_opt = []
-        if self.family in xip_ranges:
-            xip_start, xip_end = xip_ranges[self.family]
-            if self.hex_refers_region(xip_start, xip_end):
-                qspi_erase_opt = ['--qspisectorerase']
-
-        # What nrfjprog commands do we need to flash this target?
-        program_commands = []
-        if self.family == 'NRF53':
-            # nRF53 requires special treatment due to the extra coprocessor.
-            self.program_hex_nrf53(erase_arg, qspi_erase_opt, program_commands)
-        else:
-            # It's important for tool_opt to come last, so it can override
-            # any options that we set here.
-            program_commands.append(['nrfjprog', '--program', self.hex_,
-                                     erase_arg] +
-                                    qspi_erase_opt +
-                                    ['--verify', '-f', self.family,
-                                     '--snr', self.dev_id] +
-                                    self.tool_opt)
-
-        try:
-            for command in program_commands:
-                self.check_call(command)
-        except subprocess.CalledProcessError as cpe:
-            if cpe.returncode == UnavailableOperationBecauseProtectionError:
-                if self.family == 'NRF53':
-                    family_help = (
-                        '  Note: your target is an nRF53; all flash memory '
-                        'for both the network and application cores will be '
-                        'erased prior to reflashing.')
-                else:
-                    family_help = (
-                        '  Note: this will recover and erase all flash memory '
-                        'prior to reflashing.')
-                self.logger.error(
-                    'Flashing failed because the target '
-                    'must be recovered.\n'
-                    '  To fix, run "west flash --recover" instead.\n' +
-                    family_help)
-            if cpe.returncode == VerifyError:
-                # If there are data in  the UICR region it is likely that the
-                # verify failed du to the UICR not been erased before, so giving
-                # a warning here will hopefully enhance UX.
-                if self.hex_has_uicr_content():
-                    self.logger.warning(
-                        'The hex file contains data placed in the UICR, which '
-                        'may require a full erase before reprogramming. Run '
-                        'west flash again with --erase, or --recover.')
-            raise
-
-    def program_hex_nrf53(self, erase_arg, qspi_erase_opt, program_commands):
-        # program_hex() helper for nRF53.
-
-        # *********************** NOTE *******************************
-        # self.hex_ can contain code for both the application core and
-        # the network core.
-        #
-        # We can't assume, for example, that
-        # CONFIG_SOC_NRF5340_CPUAPP=y means self.hex_ only contains
-        # data for the app core's flash: the user can put arbitrary
-        # addresses into one of the files in HEX_FILES_TO_MERGE.
-        #
-        # Therefore, on this family, we may need to generate two new
-        # hex files, one for each core, and flash them individually
-        # with the correct '--coprocessor' arguments.
-        #
-        # Kind of hacky, but it works, and nrfjprog is not capable of
-        # flashing to both cores at once. If self.hex_ only affects
-        # one core's flash, then we skip the extra work to save time.
-        # ************************************************************
-
-        def add_program_cmd(hex_file, coprocessor, qspi_erase_opt):
-            program_commands.append(
-                ['nrfjprog', '--program', hex_file, erase_arg] +
-                qspi_erase_opt +
-                ['--verify', '-f', 'NRF53', '--snr', self.dev_id,
-                 '--coprocessor', coprocessor] +
-                self.tool_opt)
-
-        # Address range of the network coprocessor's flash. From nRF5340 OPS.
-        # We should get this from DTS instead if multiple values are possible,
-        # but this is fine for now.
-        net_flash_start = 0x01000000
-        net_flash_end   = 0x0103FFFF
-
-        # If there is nothing in the hex file for the network core,
-        # only the application core is programmed.
-        if not self.hex_refers_region(net_flash_start, net_flash_end):
-            add_program_cmd(self.hex_, 'CP_APPLICATION', qspi_erase_opt)
-        # If there is some content that addresses a region beyond the network
-        # core flash range, two hex files are generated and the two cores
-        # are programmed one by one.
-        elif self.hex_contents.minaddr() < net_flash_start or \
-             self.hex_contents.maxaddr() > net_flash_end:
-
-            net_hex, app_hex = IntelHex(), IntelHex()
-            for start, end in self.hex_contents.segments():
-                if net_flash_start <= start <= net_flash_end:
-                    net_hex.merge(self.hex_contents[start:end])
-                else:
-                    app_hex.merge(self.hex_contents[start:end])
-
-            hex_path = Path(self.hex_)
-            hex_dir, hex_name = hex_path.parent, hex_path.name
-
-            net_hex_file = os.fspath(
-                hex_dir / f'GENERATED_CP_NETWORK_{hex_name}')
-            app_hex_file = os.fspath(
-                hex_dir / f'GENERATED_CP_APPLICATION_{hex_name}')
-
-            self.logger.info(
-                f'{self.hex_} targets both nRF53 coprocessors; '
-                f'splitting it into: {net_hex_file} and {app_hex_file}')
-
-            net_hex.write_hex_file(net_hex_file)
-            app_hex.write_hex_file(app_hex_file)
-
-            add_program_cmd(net_hex_file, 'CP_NETWORK', [])
-            add_program_cmd(app_hex_file, 'CP_APPLICATION', qspi_erase_opt)
-        # Otherwise, only the network core is programmed.
-        else:
-            add_program_cmd(self.hex_, 'CP_NETWORK', [])
-
-    def reset_target(self):
-        if self.family == 'NRF52' and not self.softreset:
-            self.check_call(['nrfjprog', '--pinresetenable', '-f', self.family,
-                             '--snr', self.dev_id])  # Enable pin reset
-
-        if self.softreset:
-            self.check_call(['nrfjprog', '--reset', '-f', self.family,
-                             '--snr', self.dev_id])
-        else:
-            self.check_call(['nrfjprog', '--pinreset', '-f', self.family,
-                             '--snr', self.dev_id])
-
-    def do_run(self, command, **kwargs):
+    def do_require(self):
         self.require('nrfjprog')
 
-        self.ensure_output('hex')
-        if IntelHex is None:
-            raise RuntimeError('one or more Python dependencies were missing; '
-                               'see the getting started guide for details on '
-                               'how to fix')
-        self.hex_contents = IntelHex()
-        try:
-            self.hex_contents.loadfile(self.hex_, format='hex')
-        except FileNotFoundError:
-            pass
+    def do_exec_op(self, op, force=False):
+        self.logger.debug(f'Executing op: {op}')
+        # Translate the op
 
-        self.ensure_snr()
-        self.ensure_family()
+        families = {'NRF51_FAMILY': 'NRF51', 'NRF52_FAMILY': 'NRF52',
+                    'NRF53_FAMILY': 'NRF53', 'NRF91_FAMILY': 'NRF91'}
+        cores = {'NRFDL_DEVICE_CORE_APPLICATION': 'CP_APPLICATION',
+                 'NRFDL_DEVICE_CORE_NETWORK': 'CP_NETWORK'}
 
-        if self.recover:
-            self.recover_target()
-        self.program_hex()
-        self.reset_target()
+        tool_opt = []
+        core_opt = ['--coprocessor', cores[op['core']]] \
+                   if op.get('core') else []
 
-        self.logger.info(f'Board with serial number {self.dev_id} '
-                         'flashed successfully.')
+        cmd = ['nrfjprog']
+        _op = op['operation']
+        op_type = _op['type']
+        # options that are an empty dict must use "in" instead of get()
+        if op_type == 'pinreset-enable':
+            cmd.append('--pinresetenable')
+        elif op_type == 'program':
+            cmd.append('--program')
+            cmd.append(_op['firmware']['file'])
+            tool_opt = self.tool_opt
+            erase = _op['chip_erase_mode']
+            if erase == 'ERASE_ALL':
+                cmd.append('--chiperase')
+            elif erase == 'ERASE_PAGES':
+                cmd.append('--sectorerase')
+            elif erase == 'ERASE_PAGES_INCLUDING_UICR':
+                cmd.append('--sectoranduicrerase')
+            else:
+                raise RuntimeError(f'Invalid erase mode: {erase}')
+
+            if _op.get('qspi_erase_mode'):
+                # In the future there might be multiple QSPI erase modes
+                cmd.append('--qspisectorerase')
+            if _op.get('verify'):
+                # In the future there might be multiple verify modes
+                cmd.append('--verify')
+        elif op_type == 'recover':
+            cmd.append('--recover')
+        elif op_type == 'reset':
+            if _op['option'] == 'RESET_SYSTEM':
+                cmd.append('--reset')
+            if _op['option'] == 'RESET_PIN':
+                cmd.append('--pinreset')
+        else:
+            raise RuntimeError(f'Invalid operation: {op_type}')
+
+        self.check_call(cmd + ['-f', families[self.family]] + core_opt +
+                        ['--snr', self.dev_id] + tool_opt)
+        return True

--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -70,34 +70,34 @@ EXPECTED_RESULTS = {
     # -------------------------------------------------------------------------
     # NRF51
     #
-    #  family   CP    recov  soft   snr    erase
-    TC('NRF51', None, False, False, False, False):
+    #  family          CP    recov  soft   snr    erase
+    TC('NRF51_FAMILY', None, False, False, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51', None, False, False, False, True):
+    TC('NRF51_FAMILY', None, False, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51', None, False, False, True, False):
+    TC('NRF51_FAMILY', None, False, False, True, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF51', None, False, True, False, False):
+    TC('NRF51_FAMILY', None, False, True, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51', None, True, False, False, False):
+    TC('NRF51_FAMILY', None, True, False, False, False):
     (['nrfjprog', '--recover', '-f', 'NRF51', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51', None, True, True, True, True):
+    TC('NRF51_FAMILY', None, True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF51', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF51',
       '--snr', TEST_OVR_SNR],
@@ -106,38 +106,38 @@ EXPECTED_RESULTS = {
     # -------------------------------------------------------------------------
     # NRF52
     #
-    #  family   CP    recov  soft   snr    erase
-    TC('NRF52', None, False, False, False, False):
+    #  family          CP    recov  soft   snr    erase
+    TC('NRF52_FAMILY', None, False, False, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52', None, False, False, False, True):
+    TC('NRF52_FAMILY', None, False, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF52',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52', None, False, False, True, False):
+    TC('NRF52_FAMILY', None, False, False, True, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF52', None, False, True, False, False):
+    TC('NRF52_FAMILY', None, False, True, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52', None, True, False, False, False):
+    TC('NRF52_FAMILY', None, True, False, False, False):
     (['nrfjprog', '--recover', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52', None, True, True, True, True):
+    TC('NRF52_FAMILY', None, True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF52', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF52',
       '--snr', TEST_OVR_SNR],
@@ -146,147 +146,144 @@ EXPECTED_RESULTS = {
     # -------------------------------------------------------------------------
     # NRF53 APP only
     #
-    #  family   CP     recov  soft   snr    erase
-
-    TC('NRF53', 'APP', False, False, False, False):
+    #  family          CP     recov  soft   snr    erase
+    TC('NRF53_FAMILY', 'APP', False, False, False, False):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
-      '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_APPLICATION'],
+      '--verify', '-f', 'NRF53', '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'APP', False, False, False, True):
+    TC('NRF53_FAMILY', 'APP', False, False, False, True):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--chiperase',
-      '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_APPLICATION'],
+      '--verify', '-f', 'NRF53', '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'APP', False, False, True, False):
+    TC('NRF53_FAMILY', 'APP', False, False, True, False):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
-      '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR, '--coprocessor', 'CP_APPLICATION'],
+      '--verify', '-f', 'NRF53', '--coprocessor', 'CP_APPLICATION', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF53', 'APP', False, True, False, False):
+    TC('NRF53_FAMILY', 'APP', False, True, False, False):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
-      '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_APPLICATION'],
+      '--verify', '-f', 'NRF53', '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'APP', True, False, False, False):
+    TC('NRF53_FAMILY', 'APP', True, False, False, False):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
-      '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_APPLICATION'],
+      '--verify', '-f', 'NRF53', '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'APP', True, True, True, True):
+    TC('NRF53_FAMILY', 'APP', True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--chiperase',
-      '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR, '--coprocessor', 'CP_APPLICATION'],
+      '--verify', '-f', 'NRF53', '--coprocessor', 'CP_APPLICATION', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
     # -------------------------------------------------------------------------
     # NRF53 NET only
     #
-    #  family   CP     recov  soft   snr    erase
-
-    TC('NRF53', 'NET', False, False, False, False):
+    #  family          CP     recov  soft   snr    erase
+    TC('NRF53_FAMILY', 'NET', False, False, False, False):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
-      '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_NETWORK'],
+      '--verify', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'NET', False, False, False, True):
+    TC('NRF53_FAMILY', 'NET', False, False, False, True):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--chiperase',
-      '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_NETWORK'],
+      '--verify', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'NET', False, False, True, False):
+    TC('NRF53_FAMILY', 'NET', False, False, True, False):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
-      '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR, '--coprocessor', 'CP_NETWORK'],
+      '--verify', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF53', 'NET', False, True, False, False):
+    TC('NRF53_FAMILY', 'NET', False, True, False, False):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
-      '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_NETWORK'],
+      '--verify', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'NET', True, False, False, False):
+    TC('NRF53_FAMILY', 'NET', True, False, False, False):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
-      '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR, '--coprocessor', 'CP_NETWORK'],
+      '--verify', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53', 'NET', True, True, True, True):
+    TC('NRF53_FAMILY', 'NET', True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--chiperase',
-      '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR, '--coprocessor', 'CP_NETWORK'],
+      '--verify', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
     # -------------------------------------------------------------------------
     # NRF53 APP+NET
     #
-    #  family   CP     recov  soft   snr    erase
-
-    TC('NRF53', 'APP+NET', False, False, False, False):
+    #  family          CP         recov  soft   snr    erase
+    TC('NRF53_FAMILY', 'APP+NET', False, False, False, False):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
           os.fspath(tmpdir / 'GENERATED_CP_NETWORK_' + Path(infile).name),
-          '--sectorerase', '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR,
-          '--coprocessor', 'CP_NETWORK'],
+          '--sectorerase', '--verify', '-f', 'NRF53',
+          '--coprocessor', 'CP_NETWORK', '--snr', TEST_DEF_SNR],
          ['nrfjprog',
           '--program',
           os.fspath(tmpdir / 'GENERATED_CP_APPLICATION_' + Path(infile).name),
-          '--sectorerase', '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR,
-          '--coprocessor', 'CP_APPLICATION'],
+          '--sectorerase', '--verify', '-f', 'NRF53',
+          '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53', 'APP+NET', False, False, False, True):
+    TC('NRF53_FAMILY', 'APP+NET', False, False, False, True):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
           os.fspath(tmpdir / 'GENERATED_CP_NETWORK_' + Path(infile).name),
-          '--chiperase', '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR,
-          '--coprocessor', 'CP_NETWORK'],
+          '--chiperase', '--verify', '-f', 'NRF53',
+          '--coprocessor', 'CP_NETWORK', '--snr', TEST_DEF_SNR],
          ['nrfjprog',
           '--program',
           os.fspath(tmpdir / 'GENERATED_CP_APPLICATION_' + Path(infile).name),
-          '--chiperase', '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR,
-          '--coprocessor', 'CP_APPLICATION'],
+          '--chiperase', '--verify', '-f', 'NRF53',
+          '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53', 'APP+NET', False, False, True, False):
+    TC('NRF53_FAMILY', 'APP+NET', False, False, True, False):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
           os.fspath(tmpdir / 'GENERATED_CP_NETWORK_' + Path(infile).name),
-          '--sectorerase', '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR,
-          '--coprocessor', 'CP_NETWORK'],
+          '--sectorerase', '--verify', '-f', 'NRF53',
+          '--coprocessor', 'CP_NETWORK', '--snr', TEST_OVR_SNR],
          ['nrfjprog',
           '--program',
           os.fspath(tmpdir / 'GENERATED_CP_APPLICATION_' + Path(infile).name),
-          '--sectorerase', '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR,
-          '--coprocessor', 'CP_APPLICATION'],
+          '--sectorerase', '--verify', '-f', 'NRF53',
+          '--coprocessor', 'CP_APPLICATION', '--snr', TEST_OVR_SNR],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_OVR_SNR])),
 
-    TC('NRF53', 'APP+NET', False, True, False, False):
+    TC('NRF53_FAMILY', 'APP+NET', False, True, False, False):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
           os.fspath(tmpdir / 'GENERATED_CP_NETWORK_' + Path(infile).name),
-          '--sectorerase', '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR,
-          '--coprocessor', 'CP_NETWORK'],
+          '--sectorerase', '--verify', '-f', 'NRF53',
+          '--coprocessor', 'CP_NETWORK', '--snr', TEST_DEF_SNR],
          ['nrfjprog',
           '--program',
           os.fspath(tmpdir / 'GENERATED_CP_APPLICATION_' + Path(infile).name),
-          '--sectorerase', '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR,
-          '--coprocessor', 'CP_APPLICATION'],
+          '--sectorerase', '--verify', '-f', 'NRF53',
+          '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
          ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53', 'APP+NET', True, False, False, False):
+    TC('NRF53_FAMILY', 'APP+NET', True, False, False, False):
     (lambda tmpdir, infile: \
         (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
           '--snr', TEST_DEF_SNR],
@@ -294,16 +291,16 @@ EXPECTED_RESULTS = {
          ['nrfjprog',
           '--program',
           os.fspath(tmpdir / 'GENERATED_CP_NETWORK_' + Path(infile).name),
-          '--sectorerase', '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR,
-          '--coprocessor', 'CP_NETWORK'],
+          '--sectorerase', '--verify', '-f', 'NRF53',
+          '--coprocessor', 'CP_NETWORK', '--snr', TEST_DEF_SNR],
          ['nrfjprog',
           '--program',
           os.fspath(tmpdir / 'GENERATED_CP_APPLICATION_' + Path(infile).name),
-          '--sectorerase', '--verify', '-f', 'NRF53', '--snr', TEST_DEF_SNR,
-          '--coprocessor', 'CP_APPLICATION'],
+          '--sectorerase', '--verify', '-f', 'NRF53',
+          '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53', 'APP+NET', True, True, True, True):
+    TC('NRF53_FAMILY', 'APP+NET', True, True, True, True):
     (lambda tmpdir, infile: \
         (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
           '--snr', TEST_OVR_SNR],
@@ -311,46 +308,46 @@ EXPECTED_RESULTS = {
          ['nrfjprog',
           '--program',
           os.fspath(tmpdir / 'GENERATED_CP_NETWORK_' + Path(infile).name),
-          '--chiperase', '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR,
-          '--coprocessor', 'CP_NETWORK'],
+          '--chiperase', '--verify', '-f', 'NRF53',
+          '--coprocessor', 'CP_NETWORK', '--snr', TEST_OVR_SNR],
          ['nrfjprog',
           '--program',
           os.fspath(tmpdir / 'GENERATED_CP_APPLICATION_' + Path(infile).name),
-          '--chiperase', '--verify', '-f', 'NRF53', '--snr', TEST_OVR_SNR,
-          '--coprocessor', 'CP_APPLICATION'],
+          '--chiperase', '--verify', '-f', 'NRF53',
+          '--coprocessor', 'CP_APPLICATION', '--snr', TEST_OVR_SNR],
          ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR])),
 
     # -------------------------------------------------------------------------
     # NRF91
     #
-    #  family   CP    recov  soft   snr    erase
-    TC('NRF91', None, False, False, False, False):
+    #  family          CP    recov  soft   snr    erase
+    TC('NRF91_FAMILY', None, False, False, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91', None, False, False, False, True):
+    TC('NRF91_FAMILY', None, False, False, False, True):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91', None, False, False, True, False):
+    TC('NRF91_FAMILY', None, False, False, True, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF91', None, False, True, False, False):
+    TC('NRF91_FAMILY', None, False, True, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91', None, True, False, False, False):
+    TC('NRF91_FAMILY', None, True, False, False, False):
     (['nrfjprog', '--recover', '-f', 'NRF91', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91', None, True, True, True, True):
+    TC('NRF91_FAMILY', None, True, True, True, True):
     (['nrfjprog', '--recover', '-f', 'NRF91', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF91',
       '--snr', TEST_OVR_SNR],
@@ -390,7 +387,7 @@ def id_fn(test_case):
     e = 'chip erase' if test_case.erase else 'sector[anduicr] erase'
     r = 'recover' if test_case.recover else 'no recover'
 
-    return f'{test_case.family}{cp}, {s}, {sn}, {e}, {r}'
+    return f'{test_case.family[:5]}{cp}, {s}, {sn}, {e}, {r}'
 
 def fix_up_runner_config(test_case, runner_config, tmpdir):
     # Helper that adjusts the common runner_config fixture for our
@@ -405,11 +402,11 @@ def fix_up_runner_config(test_case, runner_config, tmpdir):
     dotconfig = os.fspath(zephyr / '.config')
     with open(dotconfig, 'w') as f:
         f.write(f'''
-CONFIG_SOC_SERIES_{test_case.family}X=y
+CONFIG_SOC_SERIES_{test_case.family[:5]}X=y
 ''')
     to_replace['build_dir'] = tmpdir
 
-    if test_case.family != 'NRF53':
+    if test_case.family != 'NRF53_FAMILY':
         return runner_config._replace(**to_replace)
 
     if test_case.coprocessor == 'APP':

--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -110,10 +110,10 @@ EXPECTED_RESULTS = {
      ['nrfjprog', '--reset', '-f', 'NRF51', '--snr', TEST_OVR_SNR]),
 
     TC('NRF51_FAMILY', None, True, True, True, True, True):
-    (['nrfjprog', '--recover', '-f', 'NRF51', '--snr', TEST_OVR_SNR],
+    (['nrfjprog', '--recover', '-f', 'NRF51', '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L,
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF51',
       '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L,
-     ['nrfjprog', '--reset', '-f', 'NRF51', '--snr', TEST_OVR_SNR]),
+     ['nrfjprog', '--reset', '-f', 'NRF51', '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L),
 
 
     # -------------------------------------------------------------------------
@@ -157,10 +157,10 @@ EXPECTED_RESULTS = {
      ['nrfjprog', '--reset', '-f', 'NRF52', '--snr', TEST_OVR_SNR]),
 
     TC('NRF52_FAMILY', None, True, True, True, True, True):
-    (['nrfjprog', '--recover', '-f', 'NRF52', '--snr', TEST_OVR_SNR],
+    (['nrfjprog', '--recover', '-f', 'NRF52', '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L,
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF52',
       '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L,
-     ['nrfjprog', '--reset', '-f', 'NRF52', '--snr', TEST_OVR_SNR]),
+     ['nrfjprog', '--reset', '-f', 'NRF52', '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L),
 
     # -------------------------------------------------------------------------
     # NRF53 APP only
@@ -339,8 +339,8 @@ EXPECTED_RESULTS = {
     TC('NRF53_FAMILY', 'APP+NET', True, True, True, True, True):
     (lambda tmpdir, infile: \
         (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
-          '--snr', TEST_OVR_SNR],
-         ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR],
+          '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L,
+         ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L,
          ['nrfjprog',
           '--program',
           os.fspath(tmpdir / 'GENERATED_CP_NETWORK_' + Path(infile).name),
@@ -351,7 +351,7 @@ EXPECTED_RESULTS = {
           os.fspath(tmpdir / 'GENERATED_CP_APPLICATION_' + Path(infile).name),
           '--chiperase', '--verify', '-f', 'NRF53',
           '--coprocessor', 'CP_APPLICATION', '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L,
-         ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR])),
+         ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L)),
 
 
     # -------------------------------------------------------------------------
@@ -391,10 +391,10 @@ EXPECTED_RESULTS = {
      ['nrfjprog', '--reset', '-f', 'NRF91', '--snr', TEST_OVR_SNR]),
 
     TC('NRF91_FAMILY', None, True, True, True, True, True):
-    (['nrfjprog', '--recover', '-f', 'NRF91', '--snr', TEST_OVR_SNR],
+    (['nrfjprog', '--recover', '-f', 'NRF91', '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L,
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF91',
       '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L,
-     ['nrfjprog', '--reset', '-f', 'NRF91', '--snr', TEST_OVR_SNR]),
+     ['nrfjprog', '--reset', '-f', 'NRF91', '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L),
 }
 
 #

--- a/scripts/west_commands/tests/test_nrfjprog.py
+++ b/scripts/west_commands/tests/test_nrfjprog.py
@@ -6,6 +6,7 @@
 import argparse
 import os
 from pathlib import Path
+import shlex
 import shutil
 import typing
 from unittest.mock import patch, call
@@ -22,6 +23,9 @@ from conftest import RC_KERNEL_HEX
 
 TEST_DEF_SNR = 'test-default-serial-number'  # for mocking user input
 TEST_OVR_SNR = 'test-override-serial-number'
+
+TEST_TOOL_OPT = '--ip 192.168.1.10'
+TEST_TOOL_OPT_L = shlex.split(TEST_TOOL_OPT)
 
 # nRF53 flashing is special in that we have different results
 # depending on the input hex file. For that reason, we test it with
@@ -64,6 +68,8 @@ class TC(typing.NamedTuple):    # 'TestCase'
     # --sectorerase if False (or --sectoranduicrerase on nRF52)
     erase: bool
 
+    # --tool-opt TEST_TOOL_OPT if True
+    tool_opt: bool
 
 EXPECTED_RESULTS = {
 
@@ -71,103 +77,116 @@ EXPECTED_RESULTS = {
     # NRF51
     #
     #  family          CP    recov  soft   snr    erase
-    TC('NRF51_FAMILY', None, False, False, False, False):
+    TC('NRF51_FAMILY', None, False, False, False, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51_FAMILY', None, False, False, False, True):
+    TC('NRF51_FAMILY', None, False, False, False, True, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51_FAMILY', None, False, False, True, False):
+    TC('NRF51_FAMILY', None, False, False, True, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF51_FAMILY', None, False, True, False, False):
+    TC('NRF51_FAMILY', None, False, True, False, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51_FAMILY', None, True, False, False, False):
+    TC('NRF51_FAMILY', None, True, False, False, False, False):
     (['nrfjprog', '--recover', '-f', 'NRF51', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF51',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF51', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF51_FAMILY', None, True, True, True, True):
+    TC('NRF51_FAMILY', None, True, True, True, True, False):
     (['nrfjprog', '--recover', '-f', 'NRF51', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF51',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF51', '--snr', TEST_OVR_SNR]),
 
+    TC('NRF51_FAMILY', None, True, True, True, True, True):
+    (['nrfjprog', '--recover', '-f', 'NRF51', '--snr', TEST_OVR_SNR],
+     ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF51',
+      '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L,
+     ['nrfjprog', '--reset', '-f', 'NRF51', '--snr', TEST_OVR_SNR]),
+
+
     # -------------------------------------------------------------------------
     # NRF52
     #
     #  family          CP    recov  soft   snr    erase
-    TC('NRF52_FAMILY', None, False, False, False, False):
+    TC('NRF52_FAMILY', None, False, False, False, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52_FAMILY', None, False, False, False, True):
+    TC('NRF52_FAMILY', None, False, False, False, True, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF52',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52_FAMILY', None, False, False, True, False):
+    TC('NRF52_FAMILY', None, False, False, True, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF52_FAMILY', None, False, True, False, False):
+    TC('NRF52_FAMILY', None, False, True, False, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52_FAMILY', None, True, False, False, False):
+    TC('NRF52_FAMILY', None, True, False, False, False, False):
     (['nrfjprog', '--recover', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--sectoranduicrerase',
       '--verify', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinresetenable', '-f', 'NRF52', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF52', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF52_FAMILY', None, True, True, True, True):
+    TC('NRF52_FAMILY', None, True, True, True, True, False):
     (['nrfjprog', '--recover', '-f', 'NRF52', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF52',
       '--snr', TEST_OVR_SNR],
+     ['nrfjprog', '--reset', '-f', 'NRF52', '--snr', TEST_OVR_SNR]),
+
+    TC('NRF52_FAMILY', None, True, True, True, True, True):
+    (['nrfjprog', '--recover', '-f', 'NRF52', '--snr', TEST_OVR_SNR],
+     ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF52',
+      '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L,
      ['nrfjprog', '--reset', '-f', 'NRF52', '--snr', TEST_OVR_SNR]),
 
     # -------------------------------------------------------------------------
     # NRF53 APP only
     #
     #  family          CP     recov  soft   snr    erase
-    TC('NRF53_FAMILY', 'APP', False, False, False, False):
+    TC('NRF53_FAMILY', 'APP', False, False, False, False, False):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53_FAMILY', 'APP', False, False, False, True):
+    TC('NRF53_FAMILY', 'APP', False, False, False, True, False):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--chiperase',
       '--verify', '-f', 'NRF53', '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53_FAMILY', 'APP', False, False, True, False):
+    TC('NRF53_FAMILY', 'APP', False, False, True, False, False):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--coprocessor', 'CP_APPLICATION', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF53_FAMILY', 'APP', False, True, False, False):
+    TC('NRF53_FAMILY', 'APP', False, True, False, False, False):
     (['nrfjprog', '--program', NRF5340_APP_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53_FAMILY', 'APP', True, False, False, False):
+    TC('NRF53_FAMILY', 'APP', True, False, False, False, False):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_DEF_SNR],
@@ -175,7 +194,7 @@ EXPECTED_RESULTS = {
       '--verify', '-f', 'NRF53', '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53_FAMILY', 'APP', True, True, True, True):
+    TC('NRF53_FAMILY', 'APP', True, True, True, True, False):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR],
@@ -187,27 +206,27 @@ EXPECTED_RESULTS = {
     # NRF53 NET only
     #
     #  family          CP     recov  soft   snr    erase
-    TC('NRF53_FAMILY', 'NET', False, False, False, False):
+    TC('NRF53_FAMILY', 'NET', False, False, False, False, False):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53_FAMILY', 'NET', False, False, False, True):
+    TC('NRF53_FAMILY', 'NET', False, False, False, True, False):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--chiperase',
       '--verify', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53_FAMILY', 'NET', False, False, True, False):
+    TC('NRF53_FAMILY', 'NET', False, False, True, False, False):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF53_FAMILY', 'NET', False, True, False, False):
+    TC('NRF53_FAMILY', 'NET', False, True, False, False, False):
     (['nrfjprog', '--program', NRF5340_NET_ONLY_HEX, '--sectorerase',
       '--verify', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53_FAMILY', 'NET', True, False, False, False):
+    TC('NRF53_FAMILY', 'NET', True, False, False, False, False):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_DEF_SNR],
@@ -215,7 +234,7 @@ EXPECTED_RESULTS = {
       '--verify', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF53_FAMILY', 'NET', True, True, True, True):
+    TC('NRF53_FAMILY', 'NET', True, True, True, True, False):
     (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR],
@@ -227,7 +246,7 @@ EXPECTED_RESULTS = {
     # NRF53 APP+NET
     #
     #  family          CP         recov  soft   snr    erase
-    TC('NRF53_FAMILY', 'APP+NET', False, False, False, False):
+    TC('NRF53_FAMILY', 'APP+NET', False, False, False, False, False):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
@@ -241,7 +260,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53_FAMILY', 'APP+NET', False, False, False, True):
+    TC('NRF53_FAMILY', 'APP+NET', False, False, False, True, False):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
@@ -255,7 +274,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53_FAMILY', 'APP+NET', False, False, True, False):
+    TC('NRF53_FAMILY', 'APP+NET', False, False, True, False, False):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
@@ -269,7 +288,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION', '--snr', TEST_OVR_SNR],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_OVR_SNR])),
 
-    TC('NRF53_FAMILY', 'APP+NET', False, True, False, False):
+    TC('NRF53_FAMILY', 'APP+NET', False, True, False, False, False):
     (lambda tmpdir, infile: \
         (['nrfjprog',
           '--program',
@@ -283,7 +302,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
          ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53_FAMILY', 'APP+NET', True, False, False, False):
+    TC('NRF53_FAMILY', 'APP+NET', True, False, False, False, False):
     (lambda tmpdir, infile: \
         (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
           '--snr', TEST_DEF_SNR],
@@ -300,7 +319,7 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION', '--snr', TEST_DEF_SNR],
          ['nrfjprog', '--pinreset', '-f', 'NRF53', '--snr', TEST_DEF_SNR])),
 
-    TC('NRF53_FAMILY', 'APP+NET', True, True, True, True):
+    TC('NRF53_FAMILY', 'APP+NET', True, True, True, True, False):
     (lambda tmpdir, infile: \
         (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
           '--snr', TEST_OVR_SNR],
@@ -317,40 +336,64 @@ EXPECTED_RESULTS = {
           '--coprocessor', 'CP_APPLICATION', '--snr', TEST_OVR_SNR],
          ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR])),
 
+    TC('NRF53_FAMILY', 'APP+NET', True, True, True, True, True):
+    (lambda tmpdir, infile: \
+        (['nrfjprog', '--recover', '-f', 'NRF53', '--coprocessor', 'CP_NETWORK',
+          '--snr', TEST_OVR_SNR],
+         ['nrfjprog', '--recover', '-f', 'NRF53', '--snr', TEST_OVR_SNR],
+         ['nrfjprog',
+          '--program',
+          os.fspath(tmpdir / 'GENERATED_CP_NETWORK_' + Path(infile).name),
+          '--chiperase', '--verify', '-f', 'NRF53',
+          '--coprocessor', 'CP_NETWORK', '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L,
+         ['nrfjprog',
+          '--program',
+          os.fspath(tmpdir / 'GENERATED_CP_APPLICATION_' + Path(infile).name),
+          '--chiperase', '--verify', '-f', 'NRF53',
+          '--coprocessor', 'CP_APPLICATION', '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L,
+         ['nrfjprog', '--reset', '-f', 'NRF53', '--snr', TEST_OVR_SNR])),
+
+
     # -------------------------------------------------------------------------
     # NRF91
     #
     #  family          CP    recov  soft   snr    erase
-    TC('NRF91_FAMILY', None, False, False, False, False):
+    TC('NRF91_FAMILY', None, False, False, False, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91_FAMILY', None, False, False, False, True):
+    TC('NRF91_FAMILY', None, False, False, False, True, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91_FAMILY', None, False, False, True, False):
+    TC('NRF91_FAMILY', None, False, False, True, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_OVR_SNR]),
 
-    TC('NRF91_FAMILY', None, False, True, False, False):
+    TC('NRF91_FAMILY', None, False, True, False, False, False):
     (['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--reset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91_FAMILY', None, True, False, False, False):
+    TC('NRF91_FAMILY', None, True, False, False, False, False):
     (['nrfjprog', '--recover', '-f', 'NRF91', '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--sectorerase', '--verify', '-f', 'NRF91',
       '--snr', TEST_DEF_SNR],
      ['nrfjprog', '--pinreset', '-f', 'NRF91', '--snr', TEST_DEF_SNR]),
 
-    TC('NRF91_FAMILY', None, True, True, True, True):
+    TC('NRF91_FAMILY', None, True, True, True, True, False):
     (['nrfjprog', '--recover', '-f', 'NRF91', '--snr', TEST_OVR_SNR],
      ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF91',
       '--snr', TEST_OVR_SNR],
+     ['nrfjprog', '--reset', '-f', 'NRF91', '--snr', TEST_OVR_SNR]),
+
+    TC('NRF91_FAMILY', None, True, True, True, True, True):
+    (['nrfjprog', '--recover', '-f', 'NRF91', '--snr', TEST_OVR_SNR],
+     ['nrfjprog', '--program', RC_KERNEL_HEX, '--chiperase', '--verify', '-f', 'NRF91',
+      '--snr', TEST_OVR_SNR] + TEST_TOOL_OPT_L,
      ['nrfjprog', '--reset', '-f', 'NRF91', '--snr', TEST_OVR_SNR]),
 }
 
@@ -386,8 +429,9 @@ def id_fn(test_case):
     sn = 'default snr' if test_case.snr else 'override snr'
     e = 'chip erase' if test_case.erase else 'sector[anduicr] erase'
     r = 'recover' if test_case.recover else 'no recover'
+    t = 'tool opt' if test_case.tool_opt else 'no tool opt'
 
-    return f'{test_case.family[:5]}{cp}, {s}, {sn}, {e}, {r}'
+    return f'{test_case.family[:5]}{cp}, {s}, {sn}, {e}, {r}, {t}'
 
 def fix_up_runner_config(test_case, runner_config, tmpdir):
     # Helper that adjusts the common runner_config fixture for our
@@ -434,11 +478,13 @@ def test_nrfjprog_init(check_call, get_snr, require, test_case,
     runner_config = fix_up_runner_config(test_case, runner_config, tmpdir)
     expected = EXPECTED_RESULTS[test_case]
     snr = TEST_OVR_SNR if test_case.snr else None
+    tool_opt = TEST_TOOL_OPT_L if test_case.tool_opt else []
     runner = NrfJprogBinaryRunner(runner_config,
                                   test_case.family,
                                   test_case.softreset,
                                   snr,
                                   erase=test_case.erase,
+                                  tool_opt=tool_opt,
                                   recover=test_case.recover)
 
     with patch('os.path.isfile', side_effect=os_path_isfile_patch):
@@ -475,6 +521,8 @@ def test_nrfjprog_create(check_call, get_snr, require, test_case,
         args.append('--erase')
     if test_case.recover:
         args.append('--recover')
+    if test_case.tool_opt:
+        args.extend(['--tool-opt', TEST_TOOL_OPT])
 
     parser = argparse.ArgumentParser(allow_abbrev=False)
     NrfJprogBinaryRunner.add_parser(parser)


### PR DESCRIPTION
```
    scripts: runners: nrfjprog: Use --tool-opt in all operations

    Pass on the tool-specific options to nrfjprog during all operations, and
    not only when programming. This is useful when combined with options
    like --ip, that allows west flash to be used over the network.

    Fixes #55340.

    Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>
```
```
    scripts: runners: tests: nrfjprog: Test --tool-opt

    Add tests for the --tool-opt command-line switch, to ensure that if the
    user includes additional tool options those get passed on to nrfjprog at
    the end of the command-line to override any preceding ones.

    Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>
```
```
    scripts: runners: nrf: Add support for multiple nRF backends

    Generalize the logic that was previously in nrfjprog.py into a new
    nrf_common.py, which can then use specific tool subclasses, one of which
    is nrfjprog.py, to implement the actual tool invocation.

    This commit lays down the groundwork for the addition of a new backend
    for nRF boards, the new nrfutil tool from Nordic. Both nrfjprog and
    nrfutil will coexist in the immediate future, but nrfutil is expected to
    be the sole tool for everything nRF in due time.  This is why the internal
    representation of the operations is based in JSON and is using the exact
    format that nrfutil expects when using the 'execute-batch' option, that
    takes a JSON file with an array of operations to be executed.

    Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>
```
```
    scripts: west: runners: Support class hierarchies in the runners

    Allow for multiple levels of inheritance in the runners in order to make
    it possible to share common infrastructure in similar runners.
    Also check if the class can be instantiated (i.e. it is not abstract) to
    avoid returning abstract base classes.

    Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>
```

Fixes #55340.