### PR TITLE
ci: bluetooth-tests: Also trigger on BT samples changes

### DIFF
--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -7,6 +7,7 @@ on:
       - "west.yml"
       - "subsys/bluetooth/**"
       - "tests/bluetooth/bsim/**"
+      - "samples/bluetooth/**"
       - "boards/posix/**"
       - "soc/posix/**"
       - "arch/posix/**"


### PR DESCRIPTION
Quite a few applications in samples/bluetooth
are part of the bluetooth regression run in simulation. Changes to them should also trigger this CI workflow.

An example PR which should have been triggering this is
https://github.com/zephyrproject-rtos/zephyr/pull/55478
