### PR TITLE
Thread analyzer: Prevent on POSIX ARCH

### DIFF
--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -8,6 +8,7 @@ menu "System Monitoring Options"
 
 menuconfig THREAD_ANALYZER
 	bool "Thread analyzer"
+	depends on !ARCH_POSIX
 	select INIT_STACKS
 	select THREAD_MONITOR
 	select THREAD_STACK_INFO


### PR DESCRIPTION
The thread analyzer cannot be really used with the POSIX architecture.

As:
* Code takes 0 simulated time to execute. So the analyzer will report 0 cycles being used. (and result in a division by zero exception)
* The stack allocated by Zephyr is not actually used (except for a tiny part used by the arch code itself to do a bit of thread bookkeeping). The POSIX architecture uses a separate stack (from an underlying Linux pthread) which Zephyr is blind about. So the thread analyzer is going to only report a tiny stack utilization.

Prevent users from selecting them together to avoid confusion.

Fixes #55428