### PR TITLE
gitignore: Ignore new bsim tests build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ doc/latex
 doc/themes/zephyr-docs-theme
 sanity-out*
 twister-out*
+bsim_out
 bsim_bt_out
 scripts/grub
 doc/reference/kconfig/*.rst


### PR DESCRIPTION
The default bsim tests build folder was changed in 2a9eda226ba4747b3016aae896c47fe692bf87ff
Ignore it by default for users convenience.