### PR TITLE
intel_adsp: dts: ace: lower case 71C00 to fix DTC warning

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -420,9 +420,9 @@
 			};
 		};
 
-		ace_comm_widget: ace_comm_widget@71C00 {
+		ace_comm_widget: ace_comm_widget@71c00 {
 			compatible = "intel,adsp-communication-widget";
-			reg = <0x00071C00 0x100>;
+			reg = <0x00071c00 0x100>;
 			interrupts = <0x19 0 0>;
 			interrupt-parent = <&ace_intc>;
 			status = "okay";


### PR DESCRIPTION
Fixes the warning below. This commit does not change the firmware binary. Thanks Kumar Gala for the suggestion.
```
  build-mtl/zephyr/zephyr.dts:279.42-285.5: Warning (simple_bus_reg):
  /soc/ace_comm_widget@71C00: simple-bus unit address format error,
  expected "71c00"
```