### PR TITLE
fix timeslice reporting on SMP

### DIFF
--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -120,8 +120,8 @@ struct _cpu {
 #endif
 
 #ifdef CONFIG_TIMESLICING
-	/* number of ticks remaining in current time slice */
-	int slice_ticks;
+	/* deadline for current time slice */
+	uint64_t slice_deadline;
 #endif
 
 	uint8_t id;

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -55,7 +55,7 @@ void z_thread_priority_set(struct k_thread *thread, int prio);
 bool z_set_prio(struct k_thread *thread, int prio);
 void *z_get_next_switch_handle(void *interrupted);
 void idle(void *unused1, void *unused2, void *unused3);
-void z_time_slice(int ticks);
+void z_time_slice_expired(void);
 void z_reset_time_slice(struct k_thread *curr);
 void z_sched_abort(struct k_thread *thread);
 void z_sched_ipi(void);

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -444,12 +444,7 @@ static inline bool sliceable(struct k_thread *thread)
 
 void z_reset_time_slice(struct k_thread *thread)
 {
-	/* Add the elapsed time since the last announced tick to the
-	 * slice count, as we'll see those "expired" ticks arrive in a
-	 * FUTURE z_time_slice() call.
-	 */
 	if (sliceable(thread)) {
-		_current_cpu->slice_ticks = slice_time(thread) + sys_clock_elapsed();
 		z_set_timeout_expiry(slice_time(thread), false);
 	}
 }
@@ -457,7 +452,6 @@ void z_reset_time_slice(struct k_thread *thread)
 void k_sched_time_slice_set(int32_t slice, int prio)
 {
 	LOCKED(&sched_spinlock) {
-		_current_cpu->slice_ticks = 0;
 		slice_ticks = k_ms_to_ticks_ceil32(slice);
 		if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && slice > 0) {
 			/* It's not possible to reliably set a 1-tick


### PR DESCRIPTION
This is a subset of PR #55444. This part should be uncontrovertial
and strictly makes the code behave as documented.

