### PR TITLE
boards: arm: Configure sensor devicetree aliases on tdk_robokit1

### DIFF
--- a/boards/arm/tdk_robokit1/tdk_robokit1-common.dtsi
+++ b/boards/arm/tdk_robokit1/tdk_robokit1-common.dtsi
@@ -9,6 +9,9 @@
 / {
 	aliases {
 		led0 = &led_0;
+		magn0 = &akm09918c;
+		accel0 = &icm42688;
+		die-temp0 = &icm42688;
 	};
 
 	chosen {
@@ -76,7 +79,7 @@
 	pinctrl-0 = <&twihs2_default>;
 	pinctrl-names = "default";
 	status = "okay";
-	akm09918c@c {
+	akm09918c: akm09918c@c {
 		compatible = "asahi-kasei,akm09918c";
 		reg = <0xc>;
 	};
@@ -90,7 +93,7 @@
 	cs-gpios =<&pioa 31 GPIO_ACTIVE_LOW>;
 	status = "okay";
 
-	icm42688p@0 {
+	icm42688: icm42688p@0 {
 		compatible = "invensense,icm42688";
 		reg = <0>;
 		int-gpios = <&pioc 5 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
Configures magnetometer, accelerometer, and die temperature devicetree aliases on the tdk_robokit1 board to enable generic sensor sample applications (magn_polling, accel_polling, die_temp_polling) on this board.