### PR TITLE
kernel/sched: Use kernel timeouts for timeslice expirations

### DIFF
--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -119,11 +119,6 @@ struct _cpu {
 	struct k_thread *metairq_preempted;
 #endif
 
-#ifdef CONFIG_TIMESLICING
-	/* number of ticks remaining in current time slice */
-	int slice_ticks;
-#endif
-
 	uint8_t id;
 
 #if defined(CONFIG_FPU_SHARING)

--- a/include/zephyr/timeout_q.h
+++ b/include/zephyr/timeout_q.h
@@ -56,8 +56,6 @@ static inline int z_abort_thread_timeout(struct k_thread *thread)
 
 int32_t z_get_next_timeout_expiry(void);
 
-void z_set_timeout_expiry(int32_t ticks, bool is_idle);
-
 k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 
 #else

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -55,7 +55,7 @@ void z_thread_priority_set(struct k_thread *thread, int prio);
 bool z_set_prio(struct k_thread *thread, int prio);
 void *z_get_next_switch_handle(void *interrupted);
 void idle(void *unused1, void *unused2, void *unused3);
-void z_time_slice(int ticks);
+void z_time_slice(void);
 void z_reset_time_slice(struct k_thread *curr);
 void z_sched_abort(struct k_thread *thread);
 void z_sched_ipi(void);

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -9,6 +9,7 @@
 #include <zephyr/timeout_q.h>
 #include <zephyr/init.h>
 #include <string.h>
+#include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/pm/pm.h>
@@ -235,7 +236,7 @@ bool pm_system_suspend(int32_t ticks)
 		 * We need to set the timer to interrupt a little bit early to
 		 * accommodate the time required by the CPU to fully wake up.
 		 */
-		z_set_timeout_expiry(ticks -
+		sys_clock_set_timeout(ticks -
 		     k_us_to_ticks_ceil32(
 			     z_cpus_pm_state[id].exit_latency_us),
 				     true);


### PR DESCRIPTION
[~~Not ready for merge yet, posted just for discussion.~~  This is how I think we want
to address the core bug in #55444, ~~please discuss there, not here~~.  (*Edit: this is working out and I think I'd like to merge this one.  Please review here, for real.*) It's quite a bit smaller
and more orthogonally leverages existing kernel features (timeouts) instead of perpetuating
the microdisaster with doing the timeslice accounting separately.  ~~It also doesn't quite work yet,
the measured times in the scheduler_api test are off by a tick and I'm trying to figure out if I've
simply messed something up or if that's a latent bug in the old version~~]

Rework the fragile and ad-hoc computation of timeslice expirations
into per-CPU struct _timeout objects with regular callbacks.  The
expiration callbacks themselves simply set a per-cpu flag (they might
run on any CPU), which gets checked at the end of the timer ISR on
every CPU.

This simplifies logic and removes a bunch of code.  It also fixes at
least three bugs:

1. On SMP, the number of ticks announced on any given CPU is going to
be a subset of all expired ticks.  This broke the accounting of
timeslice ticks, and effectively meant that timeslicing only worked on
SMP on systems where one CPU could hog all the announcements, and only
on that CPU.

2. The bootstrap path to set the arm the timer driver after setting
the first timeout couldn't take into account sys_clock_elapsed()
ticks, as it didn't know whether it was being called underneath an
existing announce loop.  Now this code is no longer responsible for
knowing anything about time slicing at all.

3. Also on SMP, there was a case where two CPUs timeslicing
simultaneously could stomp on each others' timeouts in
z_set_timeout_expiry(), as neither had a way of knowing what the
other's state was.  Now, timeouts are global objects with simple
expiration times, and there's no need for that function at all.
