### PR TITLE
drivers: clock_control: stm32: clear mask bits before setting them

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -253,6 +253,8 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 		return 0;
 	}
 
+	sys_clear_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_CLOCK_REG_GET(pclken->enr),
+		       STM32_CLOCK_MASK_GET(pclken->enr) << STM32_CLOCK_SHIFT_GET(pclken->enr));
 	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_CLOCK_REG_GET(pclken->enr),
 		     STM32_CLOCK_VAL_GET(pclken->enr) << STM32_CLOCK_SHIFT_GET(pclken->enr));
 

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -414,6 +414,8 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 
+	sys_clear_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_CLOCK_REG_GET(pclken->enr),
+		       STM32_CLOCK_MASK_GET(pclken->enr) << STM32_CLOCK_SHIFT_GET(pclken->enr));
 	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_CLOCK_REG_GET(pclken->enr),
 		     STM32_CLOCK_VAL_GET(pclken->enr) << STM32_CLOCK_SHIFT_GET(pclken->enr));
 

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -194,6 +194,8 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 		return err;
 	}
 
+	sys_clear_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_CLOCK_REG_GET(pclken->enr),
+		       STM32_CLOCK_MASK_GET(pclken->enr) << STM32_CLOCK_SHIFT_GET(pclken->enr));
 	sys_set_bits(DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_CLOCK_REG_GET(pclken->enr),
 		     STM32_CLOCK_VAL_GET(pclken->enr) << STM32_CLOCK_SHIFT_GET(pclken->enr));
 

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -16,7 +16,6 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/sys/util.h>
-#include <stm32_ll_utils.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 
 /* Macros to fill up prescaler values */

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/l4_i2c1_hsi_lptim1_lse.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/l4_i2c1_hsi_lptim1_lse.overlay
@@ -71,8 +71,10 @@
 
 &i2c1 {
 	/delete-property/ clocks;
+	/* an extra clock at index 2 to check if switching clocks works */
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>,
-			<&rcc STM32_SRC_HSI I2C1_SEL(2)>;
+			<&rcc STM32_SRC_HSI I2C1_SEL(2)>,
+			<&rcc STM32_SRC_SYSCLK I2C1_SEL(1)>;
 	status = "okay";
 };
 

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/l4_i2c1_sysclk_lptim1_lsi.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/l4_i2c1_sysclk_lptim1_lsi.overlay
@@ -71,8 +71,10 @@
 
 &i2c1 {
 	/delete-property/ clocks;
+	/* an extra clock at index 2 to check if switching clocks works */
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>,
-			<&rcc STM32_SRC_SYSCLK I2C1_SEL(1)>;
+			<&rcc STM32_SRC_SYSCLK I2C1_SEL(1)>,
+			<&rcc STM32_SRC_HSI I2C1_SEL(2)>;
 	status = "okay";
 };
 

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration.c
@@ -39,12 +39,51 @@ ZTEST(stm32_common_devices_clocks, test_sysclk_freq)
 #define STM32_I2C_DOMAIN_CLOCK_SUPPORT 0
 #endif
 
+static void i2c_set_clock(const struct stm32_pclken *clk)
+{
+	uint32_t dev_dt_clk_freq, dev_actual_clk_freq;
+
+	/* Test clock_on(domain_clk) */
+	int r = clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+				    (clock_control_subsys_t) clk,
+				    NULL);
+	zassert_true((r == 0), "Could not enable I2C domain clock");
+	TC_PRINT("I2C1 domain clock configured\n");
+
+	/* Test clock source */
+	uint32_t dev_actual_clk_src = __HAL_RCC_GET_I2C1_SOURCE();
+
+	if (clk->bus == STM32_SRC_HSI) {
+		zassert_equal(dev_actual_clk_src, RCC_I2C1CLKSOURCE_HSI,
+				"Expected I2C src: HSI (0x%lx). Actual I2C src: 0x%x",
+				RCC_I2C1CLKSOURCE_HSI, dev_actual_clk_src);
+	} else if (clk->bus == STM32_SRC_SYSCLK) {
+		zassert_equal(dev_actual_clk_src, RCC_I2C1CLKSOURCE_SYSCLK,
+				"Expected I2C src: SYSCLK (0x%lx). Actual I2C src: 0x%x",
+				RCC_I2C1CLKSOURCE_SYSCLK, dev_actual_clk_src);
+	} else {
+		zassert_true(0, "Unexpected domain clk (0x%x)", dev_actual_clk_src);
+	}
+
+	/* Test get_rate(srce clk) */
+	r = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+				(clock_control_subsys_t) clk,
+				&dev_dt_clk_freq);
+	zassert_true((r == 0), "Could not get I2C clk srce freq");
+
+	dev_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C1);
+	zassert_equal(dev_dt_clk_freq, dev_actual_clk_freq,
+			"Expected freq: %d Hz. Actual clk: %d Hz",
+			dev_dt_clk_freq, dev_actual_clk_freq);
+
+	TC_PRINT("I2C1 clock source rate: %d Hz\n", dev_dt_clk_freq);
+}
+
 ZTEST(stm32_common_devices_clocks, test_i2c_clk_config)
 {
 	static const struct stm32_pclken pclken[] = STM32_DT_CLOCKS(DT_NODELABEL(i2c1));
 
 	uint32_t dev_dt_clk_freq, dev_actual_clk_freq;
-	uint32_t dev_actual_clk_src;
 	int r;
 
 	/* Test clock_on(gating clock) */
@@ -56,40 +95,13 @@ ZTEST(stm32_common_devices_clocks, test_i2c_clk_config)
 	TC_PRINT("I2C1 gating clock on\n");
 
 	if (IS_ENABLED(STM32_I2C_DOMAIN_CLOCK_SUPPORT) && DT_NUM_CLOCKS(DT_NODELABEL(i2c1)) > 1) {
-		/* Test clock_on(domain_clk) */
-		r = clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					    (clock_control_subsys_t) &pclken[1],
-					    NULL);
-		zassert_true((r == 0), "Could not enable I2C domain clock");
-		TC_PRINT("I2C1 domain clock configured\n");
-
-		/* Test clock source */
-		dev_actual_clk_src = __HAL_RCC_GET_I2C1_SOURCE();
-
-		if (pclken[1].bus == STM32_SRC_HSI) {
-			zassert_equal(dev_actual_clk_src, RCC_I2C1CLKSOURCE_HSI,
-					"Expected I2C src: HSI (0x%lx). Actual I2C src: 0x%x",
-					RCC_I2C1CLKSOURCE_HSI, dev_actual_clk_src);
-		} else if (pclken[1].bus == STM32_SRC_SYSCLK) {
-			zassert_equal(dev_actual_clk_src, RCC_I2C1CLKSOURCE_SYSCLK,
-					"Expected I2C src: SYSCLK (0x%lx). Actual I2C src: 0x%x",
-					RCC_I2C1CLKSOURCE_SYSCLK, dev_actual_clk_src);
-		} else {
-			zassert_true(0, "Unexpected domain clk (0x%x)", dev_actual_clk_src);
+		if (DT_NUM_CLOCKS(DT_NODELABEL(i2c1)) > 2) {
+			/* set a dummy clock first, to check if the register is set correctly even
+			 * if not in reset state
+			 */
+			i2c_set_clock(&pclken[2]);
 		}
-
-		/* Test get_rate(srce clk) */
-		r = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					(clock_control_subsys_t) &pclken[1],
-					&dev_dt_clk_freq);
-		zassert_true((r == 0), "Could not get I2C clk srce freq");
-
-		dev_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C1);
-		zassert_equal(dev_dt_clk_freq, dev_actual_clk_freq,
-				"Expected freq: %d Hz. Actual clk: %d Hz",
-				dev_dt_clk_freq, dev_actual_clk_freq);
-
-		TC_PRINT("I2C1 clock source rate: %d Hz\n", dev_dt_clk_freq);
+		i2c_set_clock(&pclken[1]);
 	} else {
 		zassert_true((DT_NUM_CLOCKS(DT_NODELABEL(i2c1)) == 1), "test config issue");
 		/* No domain clock available, get rate from gating clock */


### PR DESCRIPTION
Without this, setting a value of 0 leaves the bits unchanged rather than zeroing them.