### PR TITLE
cmake: prefix local version of return variable

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1016,9 +1016,9 @@ endfunction()
 function(zephyr_check_compiler_flag lang option check)
   # Check if the option is covered by any hardcoded check before doing
   # an automated test.
-  zephyr_check_compiler_flag_hardcoded(${lang} "${option}" ${check} exists)
+  zephyr_check_compiler_flag_hardcoded(${lang} "${option}" _${check} exists)
   if(exists)
-    set(${check} ${${check}} PARENT_SCOPE)
+    set(${check} ${_${check}} PARENT_SCOPE)
     return()
   endif()
 


### PR DESCRIPTION
Fixes: #55490
Follow-up: #53124

Prefix local version of the return variable before calling `zephyr_check_compiler_flag_hardcoded()`.

This ensures that there will never be any naming collision between named return argument and the variable name used in later functions when PARENT_SCOPE is used.

The issue #55490 provided description of situation where the double de-referencing was not working correctly.