### PR TITLE
drivers: can: shell: add support for CAN-FD frame format filters

### DIFF
--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -652,6 +652,9 @@ static int cmd_can_filter_add(const struct shell *sh, size_t argc, char **argv)
 			filter.flags |= CAN_FILTER_IDE;
 			max_id = CAN_MAX_EXT_ID;
 			argidx++;
+		} else if (strcmp(argv[argidx], "-f") == 0) {
+			filter.flags |= CAN_FILTER_FDF;
+			argidx++;
 		} else if (strcmp(argv[argidx], "-r") == 0) {
 			filter.flags |= CAN_FILTER_RTR;
 			argidx++;
@@ -715,13 +718,14 @@ static int cmd_can_filter_add(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	shell_print(sh, "adding filter with %s (%d-bit) CAN ID 0x%0*x, "
-		    "CAN ID mask 0x%0*x, data frames %d, RTR frames %d",
+		    "CAN ID mask 0x%0*x, data frames %d, RTR frames %d, CAN-FD frames %d",
 		    (filter.flags & CAN_FILTER_IDE) != 0 ? "extended" : "standard",
 		    (filter.flags & CAN_FILTER_IDE) != 0 ? 29 : 11,
 		    (filter.flags & CAN_FILTER_IDE) != 0 ? 8 : 3, filter.id,
 		    (filter.flags & CAN_FILTER_IDE) != 0 ? 8 : 3, filter.mask,
 		    (filter.flags & CAN_FILTER_DATA) != 0 ? 1 : 0,
-		    (filter.flags & CAN_FILTER_RTR) != 0 ? 1 : 0);
+		    (filter.flags & CAN_FILTER_RTR) != 0 ? 1 : 0,
+		    (filter.flags & CAN_FILTER_FDF) != 0 ? 1 : 0);
 
 	err = can_add_rx_filter_msgq(dev, &can_shell_rx_msgq, &filter);
 	if (err < 0) {
@@ -839,11 +843,12 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_can_device_name_mode, cmd_can_device_name_mode);
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_can_filter_cmds,
 	SHELL_CMD_ARG(add, &dsub_can_device_name,
 		"Add rx filter\n"
-		"Usage: can filter add <device> [-e] [-r] [-R] <CAN ID> [CAN ID mask]\n"
+		"Usage: can filter add <device> [-e] [-f] [-r] [-R] <CAN ID> [CAN ID mask]\n"
 		"-e  use extended (29-bit) CAN ID/CAN ID mask\n"
+		"-f  match CAN-FD format frames\n"
 		"-r  also match Remote Transmission Request (RTR) frames\n"
 		"-R  only match Remote Transmission Request (RTR) frames",
-		cmd_can_filter_add, 3, 4),
+		cmd_can_filter_add, 3, 5),
 	SHELL_CMD_ARG(remove, &dsub_can_device_name,
 		"Remove rx filter\n"
 		"Usage: can filter remove <device> <filter_id>",


### PR DESCRIPTION
Add shell support for adding filters for CAN-FD format frames.