### PR TITLE
soc: stm32u5: Add simple POWER_SUPPLY_CHOICE configuration

### DIFF
--- a/soc/arm/st_stm32/common/Kconfig.soc
+++ b/soc/arm/st_stm32/common/Kconfig.soc
@@ -24,7 +24,7 @@ config USE_STM32_ASSERT
 choice POWER_SUPPLY_CHOICE
 	prompt "STM32 power supply configuration"
 	default POWER_SUPPLY_LDO
-	depends on SOC_SERIES_STM32H7X
+	depends on SOC_SERIES_STM32H7X || SOC_SERIES_STM32U5X
 
 config POWER_SUPPLY_LDO
 	bool "LDO supply"
@@ -34,23 +34,30 @@ config POWER_SUPPLY_DIRECT_SMPS
 
 config POWER_SUPPLY_SMPS_1V8_SUPPLIES_LDO
 	bool "SMPS 1.8V supplies LDO (no external supply)"
+	depends on !SOC_SERIES_STM32U5X
 
 config POWER_SUPPLY_SMPS_2V5_SUPPLIES_LDO
 	bool "SMPS 2.5V supplies LDO (no external supply)"
+	depends on !SOC_SERIES_STM32U5X
 
 config POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT_AND_LDO
 	bool "External SMPS 1.8V supply, supplies LDO"
+	depends on !SOC_SERIES_STM32U5X
 
 config POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT_AND_LDO
 	bool "External SMPS 2.5V supply, supplies LDO"
+	depends on !SOC_SERIES_STM32U5X
 
 config POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT
 	bool "External SMPS 1.8V supply and bypass"
+	depends on !SOC_SERIES_STM32U5X
 
 config POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT
 	bool "External SMPS 2.5V supply and bypass"
+	depends on !SOC_SERIES_STM32U5X
 
 config POWER_SUPPLY_EXTERNAL_SOURCE
 	bool "Bypass"
+	depends on !SOC_SERIES_STM32U5X
 
 endchoice

--- a/soc/arm/st_stm32/stm32u5/soc.c
+++ b/soc/arm/st_stm32/stm32u5/soc.c
@@ -60,6 +60,15 @@ static int stm32u5_init(const struct device *arg)
 	/* Disable USB Type-C dead battery pull-down behavior */
 	LL_PWR_DisableUCPDDeadBattery();
 
+	/* Power Configuration */
+#if defined(CONFIG_POWER_SUPPLY_DIRECT_SMPS)
+	LL_PWR_SetRegulatorSupply(LL_PWR_SMPS_SUPPLY);
+#elif defined(CONFIG_POWER_SUPPLY_LDO)
+	LL_PWR_SetRegulatorSupply(LL_PWR_LDO_SUPPLY);
+#else
+#error "Unsupported power configuration"
+#endif
+
 	return 0;
 }
 


### PR DESCRIPTION
Allow selecting between direct SMPS and LDO on the startup. This enables selecting to use SMPS regulators which can save bit of power.

Related to older issue https://github.com/zephyrproject-rtos/zephyr/issues/40730 which was for stm32h7. This PR implements only selection between LDO and SMPS regulators.