### PR TITLE
Bluetooth: GATT: Doc: start_handle is updated when reading by type

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1507,6 +1507,9 @@ struct bt_gatt_read_params;
 /** @typedef bt_gatt_read_func_t
  *  @brief Read callback function
  *
+ *  When reading using by_uuid, `params->start_handle` is the attribute handle
+ *  for this `data` item.
+ *
  *  @param conn Connection object.
  *  @param err ATT error code.
  *  @param params Read parameters used.


### PR DESCRIPTION
At `gatt.c:4560`, `params->start_handle` is updated just before calling `params->func`. I think this is intentional, as the read handle is useful information for the applicaion and there is no other method of getting it. This change just documents this behavior.