### PR TITLE
Microchip XEC Clock Control domain parameter added

### DIFF
--- a/drivers/interrupt_controller/intc_mchp_ecia_xec.c
+++ b/drivers/interrupt_controller/intc_mchp_ecia_xec.c
@@ -47,7 +47,8 @@
 
 #define ECIA_XEC_PCR_INFO						\
 	MCHP_XEC_PCR_SCR_ENCODE(DT_INST_CLOCKS_CELL(0, regidx),		\
-				DT_INST_CLOCKS_CELL(0, bitpos))
+				DT_INST_CLOCKS_CELL(0, bitpos),		\
+				DT_INST_CLOCKS_CELL(0, domain))
 
 struct xec_girq_config {
 	uintptr_t base;

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -61,7 +61,7 @@
 			/* pin configured only if the sources is set to PIN */
 			pinctrl-0 = <&clk_32khz_in_gpio165>;
 			pinctrl-names = "default";
-			#clock-cells = <2>;
+			#clock-cells = <3>;
 		};
 		ecia: ecia@4000e000 {
 			reg = <0x4000e000 0x400>;

--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -59,13 +59,13 @@
 			/* pin configured only if one of the sources is set to PIN */
 			pinctrl-0 = <&clk_32khz_in_gpio165>;
 			pinctrl-names = "default";
-			#clock-cells = <2>;
+			#clock-cells = <3>;
 		};
 		ecia: ecia@4000e000 {
 			compatible = "microchip,xec-ecia";
 			reg = <0x4000e000 0x400>;
 			direct-capable-girqs = <13 14 15 16 17 18 19 20 21 23>;
-			clocks = <&pcr 1 0>;
+			clocks = <&pcr 1 0 MCHP_XEC_PCR_CLK_PERIPH>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -720,7 +720,6 @@
 			interrupts = <91 2>;
 			girqs = < MCHP_XEC_ECIA(18, 1, 10, 91) >;
 			pcrs = <4 8>;
-			clocks = <&pcr 1 0>;
 			clock-frequency = <12000000>;
 			lines = <1>;
 			chip-select = <0>;

--- a/dts/bindings/clock/microchip,xec-pcr.yaml
+++ b/dts/bindings/clock/microchip,xec-pcr.yaml
@@ -94,8 +94,9 @@ properties:
     required: true
 
   "#clock-cells":
-    const: 2
+    const: 3
 
 clock-cells:
   - regidx
   - bitpos
+  - domain

--- a/soc/arm/microchip_mec/common/soc_pcr.h
+++ b/soc/arm/microchip_mec/common/soc_pcr.h
@@ -12,8 +12,9 @@ extern "C" {
 #endif
 
 /* slp_idx = [0, 4], bitpos = [0, 31] refer above */
-#define MCHP_XEC_PCR_SCR_ENCODE(slp_idx, bitpos)			\
-	(((uint16_t)(slp_idx) & 0x7u) | (((uint16_t)bitpos & 0x1fu) << 3))
+#define MCHP_XEC_PCR_SCR_ENCODE(slp_idx, bitpos, domain)			\
+	((((uint32_t)(domain) & 0xff) << 24) | (((bitpos) & 0x1f) << 3)		\
+	 | ((uint32_t)(slp_idx) & 0x7))
 
 #define MCHP_XEC_PCR_SCR_GET_IDX(e)	((e) & 0x7u)
 #define MCHP_XEC_PCR_SCR_GET_BITPOS(e)	(((e) & 0xf8u) >> 3)


### PR DESCRIPTION
The clock control driver requires three pieces of information: PCR register index, bit position, and clock domain. Clock domain was missing from DT information and MCHP macros.