### PR TITLE
subsys: canbus: isotp: Allow to override ISOTP_FIXED_ADDR_* constants

### DIFF
--- a/include/zephyr/canbus/isotp.h
+++ b/include/zephyr/canbus/isotp.h
@@ -104,25 +104,25 @@
  */
 
 /** Position of fixed source address (SA) */
-#define ISOTP_FIXED_ADDR_SA_POS         (0U)
+#define ISOTP_FIXED_ADDR_SA_POS         (CONFIG_ISOTP_FIXED_ADDR_SA_POS)
 
 /** Mask to obtain fixed source address (SA) */
-#define ISOTP_FIXED_ADDR_SA_MASK        (0xFF << ISOTP_FIXED_ADDR_SA_POS)
+#define ISOTP_FIXED_ADDR_SA_MASK        (CONFIG_ISOTP_FIXED_ADDR_SA_MASK)
 
 /** Position of fixed target address (TA) */
-#define ISOTP_FIXED_ADDR_TA_POS         (8U)
+#define ISOTP_FIXED_ADDR_TA_POS         (CONFIG_ISOTP_FIXED_ADDR_TA_POS)
 
 /** Mask to obtain fixed target address (TA) */
-#define ISOTP_FIXED_ADDR_TA_MASK        (0xFF << ISOTP_FIXED_ADDR_TA_POS)
+#define ISOTP_FIXED_ADDR_TA_MASK        (CONFIG_ISOTP_FIXED_ADDR_TA_MASK)
 
 /** Position of priority in fixed addressing mode */
-#define ISOTP_FIXED_ADDR_PRIO_POS       (26U)
+#define ISOTP_FIXED_ADDR_PRIO_POS       (CONFIG_ISOTP_FIXED_ADDR_PRIO_POS)
 
 /** Mask for priority in fixed addressing mode */
-#define ISOTP_FIXED_ADDR_PRIO_MASK      (0x7 << ISOTP_FIXED_ADDR_PRIO_POS)
+#define ISOTP_FIXED_ADDR_PRIO_MASK      (CONFIG_ISOTP_FIXED_ADDR_PRIO_MASK)
 
 /* CAN filter RX mask to match any priority and source address (SA) */
-#define ISOTP_FIXED_ADDR_RX_MASK        (0x03FFFF00)
+#define ISOTP_FIXED_ADDR_RX_MASK        (CONFIG_ISOTP_FIXED_ADDR_RX_MASK)
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/canbus/isotp/Kconfig
+++ b/subsys/canbus/isotp/Kconfig
@@ -129,4 +129,58 @@ config ISOTP_TX_CONTEXT_BUF_COUNT
 	  This defines the size of the memory slab where the buffers are
 	  allocated from.
 
+config ISOTP_CUSTOM_FIXED_ADDR
+	bool "Use fixed address not compatible with SAE J1939"
+	default n
+	help
+	  This option allow to use an alternative CAN frame id format.
+	  If not set ISO-TP fixed addressing use SAE J1939 standard.
+
+menu "Fixed address definition"
+	visible if ISOTP_CUSTOM_FIXED_ADDR
+
+config ISOTP_FIXED_ADDR_SA_POS
+	int "Position of fixed source address (SA)"
+	default 0
+	help
+	  Source address position in bits.
+
+config ISOTP_FIXED_ADDR_SA_MASK
+	hex "Mask to obtain fixed source address (SA)"
+	default 0xFF
+	help
+	  Source address mask.
+
+config ISOTP_FIXED_ADDR_TA_POS
+	int "Position of fixed target address (TA)"
+	default 8
+	help
+	  Target address position in bits.
+
+config ISOTP_FIXED_ADDR_TA_MASK
+	hex "Mask to obtain fixed target address (TA)"
+	default 0xFF00
+	help
+	  Target address mask.
+
+config ISOTP_FIXED_ADDR_PRIO_POS
+	int "Position of priority in fixed addressing mode"
+	default 26
+	help
+	  Priority address position in bits.
+
+config ISOTP_FIXED_ADDR_PRIO_MASK
+	hex "Mask for priority in fixed addressing mode"
+	default 0x1C000000
+	help
+	  Priority address mask.
+
+config ISOTP_FIXED_ADDR_RX_MASK
+	hex "CAN filter RX mask to match any priority and source address (SA)"
+	default 0x03FFFF00
+	help
+	  CAN filter RX mask
+
+endmenu
+
 endif # ISOTP

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -395,8 +395,10 @@ static void process_ff_sf(struct isotp_recv_ctx *ctx, struct can_frame *frame)
 		ctx->tx_addr.ext_id &= ~(ISOTP_FIXED_ADDR_TA_MASK);
 		ctx->tx_addr.ext_id |= rx_sa << ISOTP_FIXED_ADDR_TA_POS;
 		/* use same priority for TX as in received message */
-		ctx->tx_addr.ext_id &= ~(ISOTP_FIXED_ADDR_PRIO_MASK);
-		ctx->tx_addr.ext_id |= frame->id & ISOTP_FIXED_ADDR_PRIO_MASK;
+		if (ISOTP_FIXED_ADDR_PRIO_MASK) {
+			ctx->tx_addr.ext_id &= ~(ISOTP_FIXED_ADDR_PRIO_MASK);
+			ctx->tx_addr.ext_id |= frame->id & ISOTP_FIXED_ADDR_PRIO_MASK;
+		}
 	}
 
 	switch (frame->data[index] & ISOTP_PCI_TYPE_MASK) {


### PR DESCRIPTION
This patch allow to use isotp use_fixed_addr feature with CAN identifier which not match SAE J1939 format.