### PR TITLE
bluetooth: controller: Fix build with BT_HCI_VS_EXT disabled

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5445,14 +5445,6 @@ int hci_vendor_cmd_handle_common(uint16_t ocf, struct net_buf *cmd,
 		vs_read_tx_power_level(cmd, evt);
 		break;
 #endif /* CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL */
-#endif /* CONFIG_BT_HCI_VS_EXT */
-
-#if defined(CONFIG_BT_HCI_MESH_EXT)
-	case BT_OCF(BT_HCI_OP_VS_MESH):
-		mesh_cmd_handle(cmd, evt);
-		break;
-#endif /* CONFIG_BT_HCI_MESH_EXT */
-
 #if !defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN) && defined(CONFIG_BT_PERIPHERAL)
 	case BT_OCF(BT_HCI_OP_VS_SET_MIN_NUM_USED_CHANS):
@@ -5460,6 +5452,13 @@ int hci_vendor_cmd_handle_common(uint16_t ocf, struct net_buf *cmd,
 		break;
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN && CONFIG_BT_PERIPHERAL */
 #endif /* !CONFIG_BT_LL_SW_LLCP_LEGACY */
+#endif /* CONFIG_BT_HCI_VS_EXT */
+
+#if defined(CONFIG_BT_HCI_MESH_EXT)
+	case BT_OCF(BT_HCI_OP_VS_MESH):
+		mesh_cmd_handle(cmd, evt);
+		break;
+#endif /* CONFIG_BT_HCI_MESH_EXT */
 
 	default:
 		return -EINVAL;


### PR DESCRIPTION
[216/319] Building C object zephyr/subsys/bluetooth/controller/
  CMakeFiles/subsys__bluetooth__controller.dir/hci/hci.c.obj
zephyrproject/zephyr/subsys/bluetooth/controller/hci/hci.c:
   In function 'hci_vendor_cmd_handle_common':
zephyrproject/zephyr/subsys/bluetooth/controller/hci/hci.c:5459:17:
   warning: implicit declaration of function 'vs_set_min_used_chans';
   did you mean 'll_set_min_used_chans'? [-Wimplicit-function-declaration]
 5459 |                 vs_set_min_used_chans(cmd, evt);
      |                 ^~~~~~~~~~~~~~~~~~~~~
      |                 ll_set_min_used_chans
....
zephyr-sdk-0.15.0/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.1.0/../
  ../../../arm-zephyr-eabi/bin/ld.exe: zephyr/subsys/bluetooth/controller/
  libsubsys__bluetooth__controller.a(hci.c.obj): in function `hci_vendor_cmd_handle_common':
zephyrproject/zephyr/subsys/bluetooth/controller/hci/hci.c:5459: undefined reference to
   `vs_set_min_used_chans'
collect2.exe: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.