### PR TITLE
Implement current source of ADC ADS114S08

### DIFF
--- a/drivers/adc/Kconfig
+++ b/drivers/adc/Kconfig
@@ -28,6 +28,12 @@ config ADC_SHELL
 config ADC_CONFIGURABLE_INPUTS
 	bool
 
+# By selecting or not this option particular ADC drivers indicate if it is
+# required to explicitly specify for the excitation current source the pin
+# which should be used.
+config ADC_CONFIGURABLE_EXCITATION_CURRENT_SOURCE_PIN
+	bool
+
 config ADC_ASYNC
 	bool "Asynchronous call support"
 	select POLL

--- a/drivers/adc/Kconfig.ads114s0x
+++ b/drivers/adc/Kconfig.ads114s0x
@@ -8,6 +8,7 @@ menuconfig ADC_ADS114S0X
 	depends on DT_HAS_TI_ADS114S08_ENABLED
 	select SPI
 	select ADC_CONFIGURABLE_INPUTS
+	select ADC_CONFIGURABLE_EXCITATION_CURRENT_SOURCE_PIN
 	help
 	  Enable the driver implementation for the ADS114S0X family
 

--- a/dts/bindings/adc/adc-controller.yaml
+++ b/dts/bindings/adc/adc-controller.yaml
@@ -146,3 +146,11 @@ child-binding:
         Oversampling setting to be used for the channel.
         When specified, each sample is averaged from 2^N conversion results
         (where N is the provided value).
+
+    zephyr,current-source-pin:
+      type: uint8-array
+      description: |
+        Output pin selection for the current sources. The actual
+        interpretation depends on the driver. This is used only for drivers
+        which select the ADC_CONFIGURABLE_EXCITATION_CURRENT_SOURCE_PIN
+        Kconfig option.

--- a/dts/bindings/adc/ti,ads114s08.yaml
+++ b/dts/bindings/adc/ti,ads114s08.yaml
@@ -28,5 +28,22 @@ properties:
     description: |
       GPIO for start/sync, used to signal the ADC that a conversion should be started
 
+  idac-current:
+    type: int
+    enum:
+      - 0
+      - 10
+      - 50
+      - 100
+      - 250
+      - 500
+      - 750
+      - 1000
+      - 1500
+      - 2000
+    default: 0
+    description: |
+      IDAC current in microampere, the default value turns the current source off
+
 io-channel-cells:
   - input

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -145,6 +145,17 @@ struct adc_channel_cfg {
 	 */
 	uint8_t input_negative;
 #endif /* CONFIG_ADC_CONFIGURABLE_INPUTS */
+
+#ifdef CONFIG_ADC_CONFIGURABLE_EXCITATION_CURRENT_SOURCE_PIN
+	uint8_t current_source_pin_set : 1;
+	/**
+	 * Output pin for the current sources.
+	 * This is only available if the driver enables this feature
+	 * via the hidden configuration option ADC_CONFIGURABLE_EXCITATION_CURRENT_SOURCE_PIN.
+	 * The meaning itself is then defined by the driver itself.
+	 */
+	uint8_t current_source_pin[2];
+#endif /* CONFIG_ADC_CONFIGURABLE_EXCITATION_CURRENT_SOURCE_PIN */
 };
 
 /**
@@ -220,6 +231,9 @@ IF_ENABLED(CONFIG_ADC_CONFIGURABLE_INPUTS, \
 	(.differential    = DT_NODE_HAS_PROP(node_id, zephyr_input_negative), \
 	 .input_positive  = DT_PROP_OR(node_id, zephyr_input_positive, 0), \
 	 .input_negative  = DT_PROP_OR(node_id, zephyr_input_negative, 0),)) \
+IF_ENABLED(CONFIG_ADC_CONFIGURABLE_EXCITATION_CURRENT_SOURCE_PIN, \
+	(.current_source_pin_set = DT_NODE_HAS_PROP(node_id, zephyr_current_source_pin), \
+	 .current_source_pin = DT_PROP_OR(node_id, zephyr_current_source_pin, {0}),)) \
 }
 
 /**


### PR DESCRIPTION
This extends the channel configuration to allow the selection of the output pins for the current sources within an ADC. It also implements this feature for the ADC ADS114S08, which requires the configuration of a pin mux within the ADC to be able to use the current sources.