### PR TITLE
MAINTAINERS: add maintainers for "platform: SiLabs" area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2040,7 +2040,11 @@ Raspberry Pi Pico Platforms:
     - "platform: Raspberry Pi Pico"
 
 SiLabs Platforms:
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - fkokosinski
+  collaborators:
+    - tgorochowik
   files:
     - soc/arm/silabs_*/
     - boards/arm/ef*/


### PR DESCRIPTION
This PR adds a maintainer (@fkokosinski) and a collaborator (@tgorochowik) to the "platform: SiLabs" area. It also changes its status to "maintained".

This area is currently not being maintained.