### PR TITLE
cmake: recommend CMake >=3.20.5 as minimum CMake version

### DIFF
--- a/cmake/package_helper.cmake
+++ b/cmake/package_helper.cmake
@@ -42,7 +42,7 @@
 #          find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 #       the 'foo.overlay' must be specified using '-DOVERLAY_CONFIG=foo.overlay'
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.20.5)
 
 # add_custom_target and set_target_properties are not supported in script mode.
 # However, several Zephyr CMake modules create custom target for user convenience

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -62,7 +62,7 @@ The current minimum required version for the main dependencies are:
      - Min. Version
 
    * - `CMake <https://cmake.org/>`_
-     - 3.20.0
+     - 3.20.5
 
    * - `Python <https://www.python.org/>`_
      - 3.8


### PR DESCRIPTION
CMake versions <3.20.5 contains the following bug: https://gitlab.kitware.com/cmake/cmake/-/issues/22310

This bug was fixed in CMake 3.20.5:
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/6232

Generally Zephyr can build with CMake >=3.20.0, however the `cmake/package_helper.cmake` is impacted by the above issue.

Therefore, specifically request CMake >=3.20.5 for package helper and update documentation to recommend CMake version 3.20.5 in order to minimize risk of users being impacted by this bug.

Users invoking package helper with CMake 3.20.0-3.20.4 will see:
> CMake Error at cmake/package_helper.cmake:45 (cmake_minimum_required):
>  CMake 3.20.5 or higher is required.  You are running version 3.20.x

Rest of Zephyr still builds with CMake versions >=3.20.0.