### PR TITLE
tests/lib/cpp/cxx: Fix for all POSIX arch platforms

### DIFF
--- a/tests/lib/cpp/cxx/testcase.yaml
+++ b/tests/lib/cpp/cxx/testcase.yaml
@@ -33,33 +33,33 @@ tests:
   # -Wno-pointer-sign or -Werror=implicit-int in C++ mode with
   # -std=c++98)
   cpp.main.cpp98:
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     build_only: true
     extra_configs:
       - CONFIG_STD_CPP98=y
   # Note: no "cpp.main.cpp11" as that's the default standard tested above
   cpp.main.cpp14:
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     build_only: true
     extra_configs:
       - CONFIG_STD_CPP14=y
   cpp.main.cpp17:
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     build_only: true
     extra_configs:
       - CONFIG_STD_CPP17=y
   cpp.main.cpp2A:
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     build_only: true
     extra_configs:
       - CONFIG_STD_CPP2A=y
   cpp.main.cpp20:
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     build_only: true
     extra_configs:
       - CONFIG_STD_CPP20=y
   cpp.main.cpp2B:
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     build_only: true
     extra_configs:
       - CONFIG_STD_CPP2B=y


### PR DESCRIPTION
We need to exclude all POSIX arch boards, not just native_posix* as all use the host compiler toolchain.

Please note this PR is gating https://github.com/zephyrproject-rtos/zephyr/pull/55365