### PR TITLE
Bluetooth: audio: Fix setting callbacks in BT_AUDIO_CHRC macro

### DIFF
--- a/subsys/bluetooth/audio/audio.c
+++ b/subsys/bluetooth/audio/audio.c
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/sys/__assert.h>
 #include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
@@ -46,9 +47,7 @@ ssize_t bt_audio_read_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr
 {
 	const struct bt_audio_attr_user_data *user_data = attr->user_data;
 
-	if (user_data->read == NULL) {
-		return BT_GATT_ERR(BT_ATT_ERR_READ_NOT_PERMITTED);
-	}
+	__ASSERT(user_data->read != NULL, "read callback is NULL");
 
 	if (conn != NULL) {
 		uint8_t err;
@@ -67,9 +66,7 @@ ssize_t bt_audio_write_chrc(struct bt_conn *conn, const struct bt_gatt_attr *att
 {
 	const struct bt_audio_attr_user_data *user_data = attr->user_data;
 
-	if (user_data->write == NULL) {
-		return BT_GATT_ERR(BT_ATT_ERR_WRITE_NOT_PERMITTED);
-	}
+	__ASSERT(user_data->write != NULL, "write callback is NULL");
 
 	if (conn != NULL) {
 		uint8_t err;

--- a/subsys/bluetooth/audio/audio_internal.h
+++ b/subsys/bluetooth/audio/audio_internal.h
@@ -39,9 +39,14 @@ ssize_t bt_audio_write_chrc(struct bt_conn *conn, const struct bt_gatt_attr *att
 	.user_data = _user_data, \
 }
 
+/** Helper macro to suppress -Werror=address */
+#define POINTER_IS_NULL(x) (POINTER_TO_UINT(x) == POINTER_TO_UINT(NULL))
+
 /** Helper to define LE Audio characteristic. */
 #define BT_AUDIO_CHRC(_uuid, _props, _perm, _read, _write, _user_data) \
-	BT_GATT_CHARACTERISTIC(_uuid, _props, _perm, bt_audio_read_chrc, bt_audio_write_chrc, \
+	BT_GATT_CHARACTERISTIC(_uuid, _props, _perm, \
+			       (POINTER_IS_NULL(_read) ? bt_audio_read_chrc : NULL), \
+			       (POINTER_IS_NULL(_write) ? bt_audio_write_chrc : NULL), \
 			       ((struct bt_audio_attr_user_data[]) { \
 				BT_AUDIO_ATTR_USER_DATA_INIT(_read, _write, _user_data), \
 			       }))


### PR DESCRIPTION
Do not set the bt_audio_read_chrc/bt_audio_write_chrc callback if the _read/_write is NULL.
The callbacks shall be set only if value is readable/writable.