### PR TITLE
Bluetooth: audio: Remove redundant forward declaration

### DIFF
--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -31,7 +31,6 @@
 struct bt_bap_unicast_group;
 struct bt_bap_broadcast_source;
 struct bt_bap_broadcast_sink;
-struct bt_bap_ep;
 
 struct bt_bap_ep {
 	uint8_t  dir;


### PR DESCRIPTION
This removes redundant bt_bap_ep declaration, as the structure is
defined right below.