### PR TITLE
samples/fs/fat_fs: Support for nrf52840dk_nrf52840 board

### DIFF
--- a/samples/subsys/fs/fat_fs/Kconfig
+++ b/samples/subsys/fs/fat_fs/Kconfig
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+mainmenu "FAT Filesystem Sample Application"
+
+config SAMPLE_FATFS_CREATE_SOME_ENTRIES
+	bool "When no files are found on mounted partition create some"
+	default y
+	help
+	  In case when no files could be listed, because there are none,
+	  "some.dir" directory and "other.txt" file will be created
+	  and list will run again to show them. This is useful when
+	  showing how FAT works on non-SD devices like internal flash
+	  or (Q)SPI connected memories, where it is not possible to
+	  easily add files with use of other device.
+
+source "Kconfig.zephyr"

--- a/samples/subsys/fs/fat_fs/README.rst
+++ b/samples/subsys/fs/fat_fs/README.rst
@@ -7,20 +7,42 @@ Overview
 ********
 
 This sample app demonstrates use of the filesystem API and uses the FAT file
-system driver to mount an SDHC card connected over a SPI bus or to an on-chip
-SDHC controller.
+system driver with SDHC card, SoC flash or external flash chip.
 
-Requirements
-************
+To access device the sample uses :ref:`disk_access_api`.
+
+Requirements for SD card support
+********************************
 
 This project requires SD card support and microSD card formatted with FAT filesystem.
 See the :ref:`disk_access_api` documentation for Zephyr implementation details.
+Boards that by default use SD card for storage:
+``arduino_mkrzero``, ``esp_wrover_kit``, ``mimxrt1050_evk``, ``nrf52840_blip``
+and  ``olimexino_stm32``.
+The sample should be able to run with any other board that has "zephyr,sdmmc-disk"
+DT node enabled.
+
+Requirements for setting up FAT FS on SoC flash
+***********************************************
+
+For the FAT FS to work with internal flash, the device needs to support erase
+pages of size <= 4096 bytes and have at least 64kiB of flash available for
+FAT FS partition alone.
+Currently the following boards are supported:
+``nrf52840dk_nrf52840``
+
+Requirements for setting up FAT FS on external flash
+****************************************************
+
+This type of configuration requires external flash device to be available
+on DK board. Currently following boards support the configuration:
+``nrf52840dk_nrf52840`` by ``nrf52840dk_nrf52840_qspi`` configuration.
 
 Building and Running
 ********************
 
-This sample can be built for a variety of boards, including ``nrf52840_blip``,
-``mimxrt1050_evk``, ``olimexino_stm32``, ``esp_wrover_kit`` and ``arduino_mkrzero``.
+Boards with default configurations, for example ``arduino_mkrzero`` or
+``nrf52840dk_nrf52840`` using internal flash can be build using command:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/fs/fat_fs
@@ -28,6 +50,23 @@ This sample can be built for a variety of boards, including ``nrf52840_blip``,
    :goals: build
    :compact:
 
-To run this sample, a FAT formatted microSD card should be present in the
+Where used example board ``nrf52840_blip`` should be replaced with desired board.
+
+In case when some more specific configuration is to be used for a given board,
+for example ``nrf52840dk_nrf52840`` with MX25 device over QSPI, configuration
+and DTS overlays need to be also selected. The command would look like this:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/fs/fat_fs
+   :board: nrf52840dk_nrf52840
+   :gen-args: -DOVERLAY_CONFIG=nrf52840dk_nrf52840_qspi.conf -DDTC_OVERLAY_FILE=nrf52840dk_nrf52840_qspi.overlay
+   :goals: build
+   :compact:
+
+In case when board with SD card is used FAT microSD card should be present in the
 microSD slot. If there are any files or directories present in the card, the
 sample lists them out on the debug serial output.
+
+.. warning::
+   In case when mount fails the device may get re-formatted to FAT FS.
+   To disable this behaviour disable :kconfig:option:`CONFIG_FS_FATFS_MOUNT_MKFS` .

--- a/samples/subsys/fs/fat_fs/boards/nrf52840dk_nrf52840.conf
+++ b/samples/subsys/fs/fat_fs/boards/nrf52840dk_nrf52840.conf
@@ -6,3 +6,7 @@
 
 CONFIG_DISK_DRIVERS=y
 CONFIG_DISK_DRIVER_FLASH=y
+# There may be no files on internal SoC flash, so this Kconfig
+# options has ben enabled to create some if listing does not
+# find in the first place.
+CONFIG_SAMPLE_FATFS_CREATE_SOME_ENTRIES=y

--- a/samples/subsys/fs/fat_fs/boards/nrf52840dk_nrf52840.conf
+++ b/samples/subsys/fs/fat_fs/boards/nrf52840dk_nrf52840.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_DISK_DRIVERS=y
+CONFIG_DISK_DRIVER_FLASH=y

--- a/samples/subsys/fs/fat_fs/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/subsys/fs/fat_fs/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Because FAT FS needs at least 64kiB partition and default
+ * storage_partition is 32kiB for that board, we need to reorgatnize
+ * partitions to get at least 64KiB.
+ * This overlay removes image slot partitions and strips each of 64kiB,
+ * and removes the storage partition to add the additional 2*64kiB to
+ * it.
+ */
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
+&flash0 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		slot0_partition: partition@c000 {
+			reg = <0x0000C000 0x00066000>;
+		};
+		slot1_partition: partition@72000 {
+			reg = <0x00072000 0x00066000>;
+		};
+
+		storage_partition: partition@d8000 {
+			label = "storage";
+			reg = <0x000d8000 0x00028000>;
+		};
+	};
+};
+
+/ {
+	msc_disk0 {
+		status="okay";
+		compatible = "zephyr,flash-disk";
+		partition = <&storage_partition>;
+		disk-name = "SD";
+		/* cache-size == page erase size */
+		cache-size = <4096>;
+	};
+};

--- a/samples/subsys/fs/fat_fs/boards/nrf52840dk_nrf52840_qspi.conf
+++ b/samples/subsys/fs/fat_fs/boards/nrf52840dk_nrf52840_qspi.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_NORDIC_QSPI_NOR=y
+# The mx25 erase page size
+CONFIG_NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
+CONFIG_DISK_DRIVERS=y
+CONFIG_DISK_DRIVER_FLASH=y

--- a/samples/subsys/fs/fat_fs/boards/nrf52840dk_nrf52840_qspi.conf
+++ b/samples/subsys/fs/fat_fs/boards/nrf52840dk_nrf52840_qspi.conf
@@ -9,3 +9,7 @@ CONFIG_NORDIC_QSPI_NOR=y
 CONFIG_NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 CONFIG_DISK_DRIVERS=y
 CONFIG_DISK_DRIVER_FLASH=y
+# There may be no files on internal SoC flash, so this Kconfig
+# options has ben enabled to create some if listing does not
+# find in the first place.
+CONFIG_SAMPLE_FATFS_CREATE_SOME_ENTRIES=y

--- a/samples/subsys/fs/fat_fs/boards/nrf52840dk_nrf52840_qspi.overlay
+++ b/samples/subsys/fs/fat_fs/boards/nrf52840dk_nrf52840_qspi.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Note that default partition layout, provided by board DTS, is not
+ * altered here as external_partition used by the disk is defined
+ * over QSPI device and does not collide with any other partition
+ * definition.
+ */
+
+&mx25r64 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* 128kiB external storage partition */
+		external_partition: partition@0 {
+			reg = <0x00000000 0x00020000>;
+		};
+	};
+};
+
+/ {
+	msc_disk0 {
+		status="okay";
+		compatible = "zephyr,flash-disk";
+		partition = <&external_partition>;
+		disk-name = "SD";
+		/* cache-size == page erase size */
+		cache-size = <4096>;
+	};
+};

--- a/samples/subsys/fs/fat_fs/sample.yaml
+++ b/samples/subsys/fs/fat_fs/sample.yaml
@@ -20,3 +20,15 @@ tests:
     harness: console
     harness_config:
       fixture: fixture_shield_adafruit_2_8_tft_touch_v2
+  sample.filesystem.fat_fs.nrf52840dk_nrf52840:
+    build_only: true
+    platform_allow: nrf52840dk_nrf52840
+  sample.filesystem.fat_fs.nrf52840dk_nrf52840.qspi:
+    build_only: true
+    platform_allow: nrf52840dk_nrf52840
+    extra_args:
+      OVERLAY_CONFIG=boards/nrf52840dk_nrf52840_qspi.conf
+      DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840_qspi.overlay
+  sample.filesystem.fat_fs.has_sdmmc_disk:
+    build_only: true
+    filter: dt_compat_enabled("zephyr,sdmmc-disk")


### PR DESCRIPTION
PR consists of commits that add support for nrf52840dk_nrf52840 board with FAT FS partition created on internal SoC flash and QSPI connected MX25 device.