### PR TITLE
drivers: adc: stm32 adc driver disable before calibration

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1255,6 +1255,7 @@ static int adc_stm32_init(const struct device *dev)
 	 * Calibration of F1 and F3 (ADC1_V2_5) series has to be started
 	 * after ADC Module is enabled.
 	 */
+	adc_stm32_disable(adc);
 	adc_stm32_calib(dev);
 #endif
 


### PR DESCRIPTION
In the adc_stm32_init() function, when adc_stm32_calib() is called, the ADC is not yet enabled but still disabled.
This patch makes sure to Disable the ADC before  its calibration.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54932

Signed-off-by: Francois Ramu <francois.ramu@st.com>