### PR TITLE
dts: arm: stm32H7 have pll1_q for sdmmc clock source by default

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -861,7 +861,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x52007000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00010000>,
-				 <&rcc STM32_SRC_HSI48 SDMMC_SEL(0)>;
+				 <&rcc STM32_SRC_PLL1_Q SDMMC_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB3, 16U)>;
 			interrupts = <49 0>;
 			status = "disabled";
@@ -871,7 +871,7 @@
 			compatible = "st,stm32-sdmmc";
 			reg = <0x48022400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000100>,
-				 <&rcc STM32_SRC_HSI48 SDMMC_SEL(0)>;
+				 <&rcc STM32_SRC_PLL1_Q SDMMC_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB2, 8U)>;
 			interrupts = <124 0>;
 			status = "disabled";


### PR DESCRIPTION
The sdmmc clock source is either pll1_q or pll2_r according to the refMan of the stm32h7 devices. 
HSI48 is not a vaild clock source.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55358

Signed-off-by: Francois Ramu <francois.ramu@st.com>