### PR TITLE
dts: mpfs_icicle: add all uart nodes to the devicetree

### DIFF
--- a/dts/riscv/mpfs-icicle.dtsi
+++ b/dts/riscv/mpfs-icicle.dtsi
@@ -140,6 +140,50 @@
 			status = "disabled";
 		};
 
+		uart1: uart@20100000 {
+			compatible = "ns16550";
+			reg = <0x20100000 0x1000>;
+			clock-frequency = <150000000>;
+			current-speed = <115200>;
+			interrupt-parent = <&plic>;
+			interrupts = <91 1>;
+			reg-shift = <2>;
+			status = "disabled";
+		};
+
+		uart2: uart@20102000 {
+			compatible = "ns16550";
+			reg = <0x20102000 0x1000>;
+			clock-frequency = <150000000>;
+			current-speed = <115200>;
+			interrupt-parent = <&plic>;
+			interrupts = <92 1>;
+			reg-shift = <2>;
+			status = "disabled";
+		};
+
+		uart3: uart@20104000 {
+			compatible = "ns16550";
+			reg = <0x20104000 0x1000>;
+			clock-frequency = <150000000>;
+			current-speed = <115200>;
+			interrupt-parent = <&plic>;
+			interrupts = <93 1>;
+			reg-shift = <2>;
+			status = "disabled";
+		};
+
+		uart4: uart@20106000 {
+			compatible = "ns16550";
+			reg = <0x20106000 0x1000>;
+			clock-frequency = <150000000>;
+			current-speed = <115200>;
+			interrupt-parent = <&plic>;
+			interrupts = <94 1>;
+			reg-shift = <2>;
+			status = "disabled";
+		};
+
 		qspi0: spi@21000000 {
 			compatible = "microchip,mpfs-qspi";
 			#address-cells = <1>;

--- a/dts/riscv/mpfs-icicle.dtsi
+++ b/dts/riscv/mpfs-icicle.dtsi
@@ -104,10 +104,10 @@
 		clint: clint@2000000 {
 			compatible = "sifive,clint0";
 			interrupts-extended = <&hlic0 3 &hlic0 7
-					       &hlic1 3 &hlic1 7
-					       &hlic2 3 &hlic2 7
-						   &hlic3 3 &hlic3 7
-						   &hlic4 3 &hlic4 7>;
+							&hlic1 3 &hlic1 7
+							&hlic2 3 &hlic2 7
+							&hlic3 3 &hlic3 7
+							&hlic4 3 &hlic4 7>;
 			interrupt-names = "soft0", "timer0", "soft1", "timer1",
 							"soft2", "timer2", "soft3", "timer3",
 							"soft4", "timer4";
@@ -122,8 +122,8 @@
 			interrupts-extended = <&hlic0 11
 						&hlic1 11>;
 			reg = <0x0c000000 0x00002000
-			       0x0c002000 0x001fe000
-			       0x0c200000 0x3e000000>;
+					0x0c002000 0x001fe000
+					0x0c200000 0x3e000000>;
 			reg-names = "prio", "irq_en", "reg";
 			riscv,max-priority = <7>;
 			riscv,ndev = <187>;


### PR DESCRIPTION
Microchip's PolarFire-SoC Icicle Kit has 4x UART interfaces available via single micro USB and 1x UART for programming and debugging via micro USB. Add the remaining UARTs to the Devicetree.

While we are at it, cleanup the use of white space that had crept in. 