### PR TITLE
test: Filter HW test from prototyped SBS Gauge

### DIFF
--- a/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
+++ b/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
@@ -2,7 +2,9 @@ tests:
   # section.subsection
   drivers.sbs_gauge_new_api.emulated:
     tags: test_framework
-    filter: dt_compat_enabled("sbs,sbs-gauge-new-api")
+    filter: >
+      dt_compat_enabled("sbs,sbs-gauge-new-api") and
+      (CONFIG_QEMU_TARGET or CONFIG_BOARD_NATIVE_POSIX)
     extra_args:
       CONF_FILE="prj.conf;boards/emulated_board.conf"
       DTC_OVERLAY_FILE="boards/emulated_board.overlay"
@@ -15,7 +17,9 @@ tests:
       xenvm_gicv3
   drivers.sbs_gauge_new_api.emulated_64_bit_i2c_addr:
     tags: test_framework
-    filter: dt_compat_enabled("sbs,sbs-gauge-new-api")
+    filter: >
+      dt_compat_enabled("sbs,sbs-gauge-new-api") and
+      (CONFIG_QEMU_TARGET or CONFIG_BOARD_NATIVE_POSIX)
     platform_allow:
       qemu_cortex_a53
       qemu_cortex_a53_smp


### PR DESCRIPTION
Issue #55521 shows hardware tests hanging when run against the Fuel Gauge's SBS gauge that's still being prototyped against emulated boards.

Prevent accidental running of HW tests on the emulated SBS tests until HW tests have been contributed upstream by filtering for qemu and native posix boards.

Fixes #55521 