### PR TITLE
riscv: timer: avoid possible tick announcing overflow on boot

### DIFF
--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -208,7 +208,9 @@ static int sys_clock_driver_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	IRQ_CONNECT(TIMER_IRQN, 0, timer_isr, NULL, 0);
-	timer_isr(NULL); /* prime it */
+	last_ticks = mtime() / CYC_PER_TICK;
+	last_count = last_ticks * CYC_PER_TICK;
+	set_mtimecmp(last_count + CYC_PER_TICK);
 	irq_enable(TIMER_IRQN);
 	return 0;
 }


### PR DESCRIPTION
If for any reason the timer counter didn't hold a value close enough to
zero on boot then the cycle delta could overflow and the reported ticks
won't be right. Those who really want the hardware uptime where this
makes sense (as opposed to Zephyr's uptime) can still rely on
sys_clock_cycle_get_64().

