### PR TITLE
drivers: sensor: Store sensor trigger as a pointer - batch 1

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -104,6 +104,14 @@ Changes in this release
    | :kconfig:option:`CONFIG_HWINFO`                  |
    +--------------------------------------------------+
 
+* The sensor driver API clarified :c:func:`sensor_trigger_set` to state that
+  the user-allocated sensor trigger will be stored by the driver as a pointer,
+  rather than a copy, and passed back to the handler. This enables the handler
+  to use :c:macro:`CONTAINER_OF` to retrieve a context pointer when the trigger
+  is embedded in a larger struct and requires that the trigger is not allocated
+  on the stack. Applications that allocate a sensor trigger on the stack need
+  to be updated.
+
 Removed APIs in this release
 ============================
 

--- a/drivers/sensor/adt7420/adt7420.h
+++ b/drivers/sensor/adt7420/adt7420.h
@@ -64,7 +64,7 @@ struct adt7420_data {
 	struct gpio_callback gpio_cb;
 
 	sensor_trigger_handler_t th_handler;
-	struct sensor_trigger th_trigger;
+	const struct sensor_trigger *th_trigger;
 
 	const struct device *dev;
 

--- a/drivers/sensor/adt7420/adt7420_trigger.c
+++ b/drivers/sensor/adt7420/adt7420_trigger.c
@@ -53,7 +53,7 @@ static void process_int(const struct device *dev)
 	}
 
 	if (drv_data->th_handler != NULL) {
-		drv_data->th_handler(dev, &drv_data->th_trigger);
+		drv_data->th_handler(dev, drv_data->th_trigger);
 	}
 
 	setup_int(dev, true);
@@ -114,7 +114,7 @@ int adt7420_trigger_set(const struct device *dev,
 	drv_data->th_handler = handler;
 
 	if (handler != NULL) {
-		drv_data->th_trigger = *trig;
+		drv_data->th_trigger = trig;
 
 		setup_int(dev, true);
 

--- a/drivers/sensor/adxl362/adxl362.h
+++ b/drivers/sensor/adxl362/adxl362.h
@@ -198,11 +198,11 @@ struct adxl362_data {
 	struct k_mutex trigger_mutex;
 
 	sensor_trigger_handler_t inact_handler;
-	struct sensor_trigger inact_trigger;
+	const struct sensor_trigger *inact_trigger;
 	sensor_trigger_handler_t act_handler;
-	struct sensor_trigger act_trigger;
+	const struct sensor_trigger *act_trigger;
 	sensor_trigger_handler_t drdy_handler;
-	struct sensor_trigger drdy_trigger;
+	const struct sensor_trigger *drdy_trigger;
 
 #if defined(CONFIG_ADXL362_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_ADXL362_THREAD_STACK_SIZE);

--- a/drivers/sensor/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adxl362/adxl362_trigger.c
@@ -31,19 +31,19 @@ static void adxl362_thread_cb(const struct device *dev)
 	k_mutex_lock(&drv_data->trigger_mutex, K_FOREVER);
 	if (drv_data->inact_handler != NULL) {
 		if (ADXL362_STATUS_CHECK_INACT(status_buf)) {
-			drv_data->inact_handler(dev, &drv_data->inact_trigger);
+			drv_data->inact_handler(dev, drv_data->inact_trigger);
 		}
 	}
 
 	if (drv_data->act_handler != NULL) {
 		if (ADXL362_STATUS_CHECK_ACTIVITY(status_buf)) {
-			drv_data->act_handler(dev, &drv_data->act_trigger);
+			drv_data->act_handler(dev, drv_data->act_trigger);
 		}
 	}
 
 	if (drv_data->drdy_handler != NULL &&
 	    ADXL362_STATUS_CHECK_DATA_READY(status_buf)) {
-		drv_data->drdy_handler(dev, &drv_data->drdy_trigger);
+		drv_data->drdy_handler(dev, drv_data->drdy_trigger);
 	}
 	k_mutex_unlock(&drv_data->trigger_mutex);
 }
@@ -95,7 +95,7 @@ int adxl362_trigger_set(const struct device *dev,
 	case SENSOR_TRIG_MOTION:
 		k_mutex_lock(&drv_data->trigger_mutex, K_FOREVER);
 		drv_data->act_handler = handler;
-		drv_data->act_trigger = *trig;
+		drv_data->act_trigger = trig;
 		k_mutex_unlock(&drv_data->trigger_mutex);
 		int_mask = ADXL362_INTMAP1_ACT;
 		/* Clear activity and inactivity interrupts */
@@ -104,7 +104,7 @@ int adxl362_trigger_set(const struct device *dev,
 	case SENSOR_TRIG_STATIONARY:
 		k_mutex_lock(&drv_data->trigger_mutex, K_FOREVER);
 		drv_data->inact_handler = handler;
-		drv_data->inact_trigger = *trig;
+		drv_data->inact_trigger = trig;
 		k_mutex_unlock(&drv_data->trigger_mutex);
 		int_mask = ADXL362_INTMAP1_INACT;
 		/* Clear activity and inactivity interrupts */
@@ -113,7 +113,7 @@ int adxl362_trigger_set(const struct device *dev,
 	case SENSOR_TRIG_DATA_READY:
 		k_mutex_lock(&drv_data->trigger_mutex, K_FOREVER);
 		drv_data->drdy_handler = handler;
-		drv_data->drdy_trigger = *trig;
+		drv_data->drdy_trigger = trig;
 		k_mutex_unlock(&drv_data->trigger_mutex);
 		int_mask = ADXL362_INTMAP1_DATA_READY;
 		adxl362_clear_data_ready(dev);

--- a/drivers/sensor/adxl372/adxl372.h
+++ b/drivers/sensor/adxl372/adxl372.h
@@ -306,9 +306,9 @@ struct adxl372_data {
 	struct gpio_callback gpio_cb;
 
 	sensor_trigger_handler_t th_handler;
-	struct sensor_trigger th_trigger;
+	const struct sensor_trigger *th_trigger;
 	sensor_trigger_handler_t drdy_handler;
-	struct sensor_trigger drdy_trigger;
+	const struct sensor_trigger *drdy_trigger;
 	const struct device *dev;
 
 #if defined(CONFIG_ADXL372_TRIGGER_OWN_THREAD)

--- a/drivers/sensor/adxl372/adxl372_trigger.c
+++ b/drivers/sensor/adxl372/adxl372_trigger.c
@@ -34,17 +34,17 @@ static void adxl372_thread_cb(const struct device *dev)
 		 */
 		if (cfg->max_peak_detect_mode &&
 			ADXL372_STATUS_2_INACT(status2)) {
-			drv_data->th_handler(dev, &drv_data->th_trigger);
+			drv_data->th_handler(dev, drv_data->th_trigger);
 		} else if (!cfg->max_peak_detect_mode &&
 			(ADXL372_STATUS_2_INACT(status2) ||
 			ADXL372_STATUS_2_ACTIVITY(status2))) {
-			drv_data->th_handler(dev, &drv_data->th_trigger);
+			drv_data->th_handler(dev, drv_data->th_trigger);
 		}
 	}
 
 	if ((drv_data->drdy_handler != NULL) &&
 		ADXL372_STATUS_1_DATA_RDY(status1)) {
-		drv_data->drdy_handler(dev, &drv_data->drdy_trigger);
+		drv_data->drdy_handler(dev, drv_data->drdy_trigger);
 	}
 
 	ret = gpio_pin_interrupt_configure_dt(&cfg->interrupt,
@@ -105,13 +105,13 @@ int adxl372_trigger_set(const struct device *dev,
 	switch (trig->type) {
 	case SENSOR_TRIG_THRESHOLD:
 		drv_data->th_handler = handler;
-		drv_data->th_trigger = *trig;
+		drv_data->th_trigger = trig;
 		int_mask = ADXL372_INT1_MAP_ACT_MSK |
 			   ADXL372_INT1_MAP_INACT_MSK;
 		break;
 	case SENSOR_TRIG_DATA_READY:
 		drv_data->drdy_handler = handler;
-		drv_data->drdy_trigger = *trig;
+		drv_data->drdy_trigger = trig;
 		int_mask = ADXL372_INT1_MAP_DATA_RDY_MSK;
 		break;
 	default:

--- a/drivers/sensor/amg88xx/amg88xx.h
+++ b/drivers/sensor/amg88xx/amg88xx.h
@@ -81,10 +81,10 @@ struct amg88xx_data {
 	struct gpio_callback gpio_cb;
 
 	sensor_trigger_handler_t drdy_handler;
-	struct sensor_trigger drdy_trigger;
+	const struct sensor_trigger *drdy_trigger;
 
 	sensor_trigger_handler_t th_handler;
-	struct sensor_trigger th_trigger;
+	const struct sensor_trigger *th_trigger;
 
 #if defined(CONFIG_AMG88XX_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_AMG88XX_THREAD_STACK_SIZE);

--- a/drivers/sensor/amg88xx/amg88xx_trigger.c
+++ b/drivers/sensor/amg88xx/amg88xx_trigger.c
@@ -102,11 +102,11 @@ static void amg88xx_thread_cb(const struct device *dev)
 	}
 
 	if (drv_data->drdy_handler != NULL) {
-		drv_data->drdy_handler(dev, &drv_data->drdy_trigger);
+		drv_data->drdy_handler(dev, drv_data->drdy_trigger);
 	}
 
 	if (drv_data->th_handler != NULL) {
-		drv_data->th_handler(dev, &drv_data->th_trigger);
+		drv_data->th_handler(dev, drv_data->th_trigger);
 	}
 
 	amg88xx_setup_int(config, true);
@@ -151,7 +151,7 @@ int amg88xx_trigger_set(const struct device *dev,
 
 	if (trig->type == SENSOR_TRIG_THRESHOLD) {
 		drv_data->th_handler = handler;
-		drv_data->th_trigger = *trig;
+		drv_data->th_trigger = trig;
 	} else {
 		LOG_ERR("Unsupported sensor trigger");
 		return -ENOTSUP;

--- a/drivers/sensor/apds9960/apds9960.h
+++ b/drivers/sensor/apds9960/apds9960.h
@@ -230,7 +230,7 @@ struct apds9960_data {
 
 #ifdef CONFIG_APDS9960_TRIGGER
 	sensor_trigger_handler_t p_th_handler;
-	struct sensor_trigger p_th_trigger;
+	const struct sensor_trigger *p_th_trigger;
 #else
 	struct k_sem data_sem;
 #endif

--- a/drivers/sensor/apds9960/apds9960_trigger.c
+++ b/drivers/sensor/apds9960/apds9960_trigger.c
@@ -25,7 +25,7 @@ void apds9960_work_cb(struct k_work *work)
 	const struct device *dev = data->dev;
 
 	if (data->p_th_handler != NULL) {
-		data->p_th_handler(dev, &data->p_th_trigger);
+		data->p_th_handler(dev, data->p_th_trigger);
 	}
 
 	apds9960_setup_int(dev->config, true);
@@ -75,6 +75,7 @@ int apds9960_trigger_set(const struct device *dev,
 	case SENSOR_TRIG_THRESHOLD:
 		if (trig->chan == SENSOR_CHAN_PROX) {
 			data->p_th_handler = handler;
+			data->p_th_trigger = trig;
 			if (i2c_reg_update_byte_dt(&config->i2c,
 						   APDS9960_ENABLE_REG,
 						   APDS9960_ENABLE_PIEN,

--- a/drivers/sensor/bma280/bma280.h
+++ b/drivers/sensor/bma280/bma280.h
@@ -123,10 +123,10 @@ struct bma280_data {
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
 
-	struct sensor_trigger data_ready_trigger;
+	const struct sensor_trigger *data_ready_trigger;
 	sensor_trigger_handler_t data_ready_handler;
 
-	struct sensor_trigger any_motion_trigger;
+	const struct sensor_trigger *any_motion_trigger;
 	sensor_trigger_handler_t any_motion_handler;
 
 #if defined(CONFIG_BMA280_TRIGGER_OWN_THREAD)

--- a/drivers/sensor/bma280/bma280_trigger.c
+++ b/drivers/sensor/bma280/bma280_trigger.c
@@ -99,7 +99,7 @@ static void bma280_thread_cb(const struct device *dev)
 	    drv_data->data_ready_handler != NULL &&
 	    err == 0) {
 		drv_data->data_ready_handler(dev,
-					     &drv_data->data_ready_trigger);
+					     drv_data->data_ready_trigger);
 	}
 
 	/* check for any motion */
@@ -109,7 +109,7 @@ static void bma280_thread_cb(const struct device *dev)
 	    drv_data->any_motion_handler != NULL &&
 	    err == 0) {
 		drv_data->any_motion_handler(dev,
-					     &drv_data->data_ready_trigger);
+					     drv_data->any_motion_trigger);
 
 		/* clear latched interrupt */
 		err = i2c_reg_update_byte_dt(&config->i2c,
@@ -170,7 +170,7 @@ int bma280_trigger_set(const struct device *dev,
 		if (handler == NULL) {
 			return 0;
 		}
-		drv_data->data_ready_trigger = *trig;
+		drv_data->data_ready_trigger = trig;
 
 		/* enable data ready interrupt */
 		if (i2c_reg_update_byte_dt(&config->i2c,
@@ -193,7 +193,7 @@ int bma280_trigger_set(const struct device *dev,
 		if (handler == NULL) {
 			return 0;
 		}
-		drv_data->any_motion_trigger = *trig;
+		drv_data->any_motion_trigger = trig;
 
 		/* enable any-motion interrupt */
 		if (i2c_reg_update_byte_dt(&config->i2c,

--- a/drivers/sensor/bmc150_magn/bmc150_magn.h
+++ b/drivers/sensor/bmc150_magn/bmc150_magn.h
@@ -120,7 +120,7 @@ struct bmc150_magn_data {
 	const struct device *gpio_drdy;
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
-	struct sensor_trigger trigger_drdy;
+	const struct sensor_trigger *trigger_drdy;
 	sensor_trigger_handler_t handler_drdy;
 #endif
 

--- a/drivers/sensor/bmc150_magn/bmc150_magn_trigger.c
+++ b/drivers/sensor/bmc150_magn/bmc150_magn_trigger.c
@@ -49,7 +49,7 @@ int bmc150_magn_trigger_set(const struct device *dev,
 		}
 
 		data->handler_drdy = handler;
-		data->trigger_drdy = *trig;
+		data->trigger_drdy = trig;
 
 		if (i2c_reg_update_byte_dt(&config->i2c,
 					   BMC150_MAGN_REG_INT_DRDY,
@@ -96,7 +96,7 @@ static void bmc150_magn_thread_main(struct bmc150_magn_data *data)
 		}
 
 		if (data->handler_drdy) {
-			data->handler_drdy(data->dev, &data->trigger_drdy);
+			data->handler_drdy(data->dev, data->trigger_drdy);
 		}
 
 		setup_drdy(data->dev, true);

--- a/drivers/sensor/bmg160/bmg160.h
+++ b/drivers/sensor/bmg160/bmg160.h
@@ -198,7 +198,9 @@ struct bmg160_device_data {
 #endif
 #ifdef CONFIG_BMG160_TRIGGER
 	sensor_trigger_handler_t anymotion_handler;
+	const struct sensor_trigger *anymotion_trig;
 	sensor_trigger_handler_t drdy_handler;
+	const struct sensor_trigger *drdy_trig;
 #endif
 	int16_t raw_gyro_xyz[3];
 	uint16_t scale;

--- a/drivers/sensor/bmi160/bmi160.h
+++ b/drivers/sensor/bmi160/bmi160.h
@@ -504,10 +504,13 @@ struct bmi160_data {
 #ifdef CONFIG_BMI160_TRIGGER
 #if !defined(CONFIG_BMI160_ACCEL_PMU_SUSPEND)
 	sensor_trigger_handler_t handler_drdy_acc;
+	const struct sensor_trigger *trig_drdy_acc;
 	sensor_trigger_handler_t handler_anymotion;
+	const struct sensor_trigger *trig_anymotion;
 #endif
 #if !defined(CONFIG_BMI160_GYRO_PMU_SUSPEND)
 	sensor_trigger_handler_t handler_drdy_gyr;
+	const struct sensor_trigger *trig_drdy_gyr;
 #endif
 #endif /* CONFIG_BMI160_TRIGGER */
 };

--- a/drivers/sensor/bmi160/bmi160_trigger.c
+++ b/drivers/sensor/bmi160/bmi160_trigger.c
@@ -17,34 +17,25 @@ LOG_MODULE_DECLARE(BMI160, CONFIG_SENSOR_LOG_LEVEL);
 static void bmi160_handle_anymotion(const struct device *dev)
 {
 	struct bmi160_data *data = dev->data;
-	struct sensor_trigger anym_trigger = {
-		.type = SENSOR_TRIG_DELTA,
-		.chan = SENSOR_CHAN_ACCEL_XYZ,
-	};
 
 	if (data->handler_anymotion) {
-		data->handler_anymotion(dev, &anym_trigger);
+		data->handler_anymotion(dev, data->trig_anymotion);
 	}
 }
 
 static void bmi160_handle_drdy(const struct device *dev, uint8_t status)
 {
 	struct bmi160_data *data = dev->data;
-	struct sensor_trigger drdy_trigger = {
-		.type = SENSOR_TRIG_DATA_READY,
-	};
 
 #if !defined(CONFIG_BMI160_ACCEL_PMU_SUSPEND)
 	if (data->handler_drdy_acc && (status & BMI160_STATUS_ACC_DRDY)) {
-		drdy_trigger.chan = SENSOR_CHAN_ACCEL_XYZ;
-		data->handler_drdy_acc(dev, &drdy_trigger);
+		data->handler_drdy_acc(dev, data->trig_drdy_acc);
 	}
 #endif
 
 #if !defined(CONFIG_BMI160_GYRO_PMU_SUSPEND)
 	if (data->handler_drdy_gyr && (status & BMI160_STATUS_GYR_DRDY)) {
-		drdy_trigger.chan = SENSOR_CHAN_GYRO_XYZ;
-		data->handler_drdy_gyr(dev, &drdy_trigger);
+		data->handler_drdy_gyr(dev, data->trig_drdy_gyr);
 	}
 #endif
 }
@@ -118,6 +109,7 @@ static void bmi160_gpio_callback(const struct device *port,
 
 static int bmi160_trigger_drdy_set(const struct device *dev,
 				   enum sensor_channel chan,
+				   const struct sensor_trigger *trig,
 				   sensor_trigger_handler_t handler)
 {
 	struct bmi160_data *data = dev->data;
@@ -126,6 +118,7 @@ static int bmi160_trigger_drdy_set(const struct device *dev,
 #if !defined(CONFIG_BMI160_ACCEL_PMU_SUSPEND)
 	if (chan == SENSOR_CHAN_ACCEL_XYZ) {
 		data->handler_drdy_acc = handler;
+		data->trig_drdy_acc = trig;
 	}
 
 	if (data->handler_drdy_acc) {
@@ -136,6 +129,7 @@ static int bmi160_trigger_drdy_set(const struct device *dev,
 #if !defined(CONFIG_BMI160_GYRO_PMU_SUSPEND)
 	if (chan == SENSOR_CHAN_GYRO_XYZ) {
 		data->handler_drdy_gyr = handler;
+		data->trig_drdy_gyr = trig;
 	}
 
 	if (data->handler_drdy_gyr) {
@@ -153,12 +147,14 @@ static int bmi160_trigger_drdy_set(const struct device *dev,
 
 #if !defined(CONFIG_BMI160_ACCEL_PMU_SUSPEND)
 static int bmi160_trigger_anym_set(const struct device *dev,
+				   const struct sensor_trigger *trig,
 				   sensor_trigger_handler_t handler)
 {
 	struct bmi160_data *data = dev->data;
 	uint8_t anym_en = 0U;
 
 	data->handler_anymotion = handler;
+	data->trig_anymotion = trig;
 
 	if (handler) {
 		anym_en = BMI160_INT_ANYM_X_EN |
@@ -179,9 +175,9 @@ static int bmi160_trigger_set_acc(const struct device *dev,
 				  sensor_trigger_handler_t handler)
 {
 	if (trig->type == SENSOR_TRIG_DATA_READY) {
-		return bmi160_trigger_drdy_set(dev, trig->chan, handler);
+		return bmi160_trigger_drdy_set(dev, trig->chan, trig, handler);
 	} else if (trig->type == SENSOR_TRIG_DELTA) {
-		return bmi160_trigger_anym_set(dev, handler);
+		return bmi160_trigger_anym_set(dev, trig, handler);
 	}
 
 	return -ENOTSUP;
@@ -238,7 +234,7 @@ static int bmi160_trigger_set_gyr(const struct device *dev,
 				  sensor_trigger_handler_t handler)
 {
 	if (trig->type == SENSOR_TRIG_DATA_READY) {
-		return bmi160_trigger_drdy_set(dev, trig->chan, handler);
+		return bmi160_trigger_drdy_set(dev, trig->chan, trig, handler);
 	}
 
 	return -ENOTSUP;

--- a/drivers/sensor/bmp388/bmp388.h
+++ b/drivers/sensor/bmp388/bmp388.h
@@ -184,6 +184,7 @@ struct bmp388_data {
 
 #ifdef CONFIG_BMP388_TRIGGER
 	sensor_trigger_handler_t handler_drdy;
+	const struct sensor_trigger *trig_drdy;
 #endif /* CONFIG_BMP388_TRIGGER */
 };
 

--- a/drivers/sensor/bmp388/bmp388_trigger.c
+++ b/drivers/sensor/bmp388/bmp388_trigger.c
@@ -25,13 +25,8 @@ static void bmp388_handle_interrupts(const void *arg)
 	const struct device *dev = (const struct device *)arg;
 	struct bmp388_data *data = dev->data;
 
-	struct sensor_trigger drdy_trigger = {
-		.type = SENSOR_TRIG_DATA_READY,
-		.chan = SENSOR_CHAN_PRESS,
-	};
-
 	if (data->handler_drdy) {
-		data->handler_drdy(dev, &drdy_trigger);
+		data->handler_drdy(dev, data->trig_drdy);
 	}
 }
 
@@ -115,6 +110,7 @@ int bmp388_trigger_set(
 	}
 
 	data->handler_drdy = handler;
+	data->trig_drdy = trig;
 
 	return 0;
 }

--- a/drivers/sensor/bq274xx/bq274xx.h
+++ b/drivers/sensor/bq274xx/bq274xx.h
@@ -97,6 +97,7 @@ struct bq274xx_data {
 	const struct device *dev;
 	struct gpio_callback ready_callback;
 	sensor_trigger_handler_t ready_handler;
+	const struct sensor_trigger *ready_trig;
 
 #ifdef CONFIG_BQ274XX_TRIGGER_OWN_THREAD
 	struct k_sem sem;

--- a/drivers/sensor/bq274xx/bq274xx_trigger.c
+++ b/drivers/sensor/bq274xx/bq274xx_trigger.c
@@ -22,13 +22,8 @@ static void bq274xx_handle_interrupts(const struct device *dev)
 {
 	struct bq274xx_data *data = dev->data;
 
-	struct sensor_trigger trig = {
-		.type = SENSOR_TRIG_DATA_READY,
-		.chan = SENSOR_CHAN_ALL,
-	};
-
 	if (data->ready_handler) {
-		data->ready_handler(dev, &trig);
+		data->ready_handler(dev, data->ready_trig);
 	}
 }
 
@@ -130,6 +125,7 @@ int bq274xx_trigger_set(const struct device *dev,
 	}
 
 	data->ready_handler = handler;
+	data->ready_trig = trig;
 
 	if (handler) {
 		status = gpio_pin_configure_dt(&config->int_gpios, GPIO_INPUT);

--- a/drivers/sensor/ccs811/ccs811.h
+++ b/drivers/sensor/ccs811/ccs811.h
@@ -58,7 +58,7 @@ struct ccs811_data {
 	 */
 	struct gpio_callback gpio_cb;
 	sensor_trigger_handler_t handler;
-	struct sensor_trigger trigger;
+	const struct sensor_trigger *trigger;
 #if defined(CONFIG_CCS811_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_CCS811_THREAD_STACK_SIZE);
 	struct k_sem gpio_sem;

--- a/drivers/sensor/ccs811/ccs811_trigger.c
+++ b/drivers/sensor/ccs811/ccs811_trigger.c
@@ -77,7 +77,7 @@ static void process_irq(const struct device *dev)
 	struct ccs811_data *data = dev->data;
 
 	if (data->handler != NULL) {
-		data->handler(dev, &data->trigger);
+		data->handler(dev, data->trigger);
 	}
 
 	if (data->handler != NULL) {
@@ -159,7 +159,7 @@ int ccs811_trigger_set(const struct device *dev,
 	}
 
 	if (rc == 0) {
-		drv_data->trigger = *trig;
+		drv_data->trigger = trig;
 		setup_irq(dev, true);
 
 		if (gpio_pin_get_dt(&config->irq_gpio) > 0) {

--- a/drivers/sensor/fdc2x1x/fdc2x1x.h
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.h
@@ -155,7 +155,7 @@ struct fdc2x1x_data {
 
 	struct k_mutex trigger_mutex;
 	sensor_trigger_handler_t drdy_handler;
-	struct sensor_trigger drdy_trigger;
+	const struct sensor_trigger *drdy_trigger;
 	const struct device *dev;
 
 #ifdef CONFIG_FDC2X1X_TRIGGER_OWN_THREAD

--- a/drivers/sensor/fdc2x1x/fdc2x1x_trigger.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x_trigger.c
@@ -41,7 +41,7 @@ static void fdc2x1x_thread_cb(const struct device *dev)
 
 	k_mutex_lock(&drv_data->trigger_mutex, K_FOREVER);
 	if ((drv_data->drdy_handler != NULL) && FDC2X1X_STATUS_DRDY(status)) {
-		drv_data->drdy_handler(dev, &drv_data->drdy_trigger);
+		drv_data->drdy_handler(dev, drv_data->drdy_trigger);
 	}
 	k_mutex_unlock(&drv_data->trigger_mutex);
 }
@@ -93,7 +93,7 @@ int fdc2x1x_trigger_set(const struct device *dev,
 	case SENSOR_TRIG_DATA_READY:
 		k_mutex_lock(&drv_data->trigger_mutex, K_FOREVER);
 		drv_data->drdy_handler = handler;
-		drv_data->drdy_trigger = *trig;
+		drv_data->drdy_trigger = trig;
 		k_mutex_unlock(&drv_data->trigger_mutex);
 
 		int_mask = FDC2X1X_ERROR_CONFIG_DRDY_2INT_MSK;

--- a/drivers/sensor/fxas21002/fxas21002.h
+++ b/drivers/sensor/fxas21002/fxas21002.h
@@ -110,6 +110,7 @@ struct fxas21002_data {
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
 	sensor_trigger_handler_t drdy_handler;
+	const struct sensor_trigger *drdy_trig;
 #endif
 #ifdef CONFIG_FXAS21002_TRIGGER_OWN_THREAD
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_FXAS21002_THREAD_STACK_SIZE);

--- a/drivers/sensor/fxas21002/fxas21002_trigger.c
+++ b/drivers/sensor/fxas21002/fxas21002_trigger.c
@@ -37,13 +37,8 @@ static int fxas21002_handle_drdy_int(const struct device *dev)
 {
 	struct fxas21002_data *data = dev->data;
 
-	struct sensor_trigger drdy_trig = {
-		.type = SENSOR_TRIG_DATA_READY,
-		.chan = SENSOR_CHAN_ALL,
-	};
-
 	if (data->drdy_handler) {
-		data->drdy_handler(dev, &drdy_trig);
+		data->drdy_handler(dev, data->drdy_trig);
 	}
 
 	return 0;
@@ -113,6 +108,7 @@ int fxas21002_trigger_set(const struct device *dev,
 	case SENSOR_TRIG_DATA_READY:
 		mask = FXAS21002_CTRLREG2_CFG_EN_MASK;
 		data->drdy_handler = handler;
+		data->drdy_trig = trig;
 		break;
 	default:
 		LOG_ERR("Unsupported sensor trigger");

--- a/drivers/sensor/fxos8700/fxos8700.h
+++ b/drivers/sensor/fxos8700/fxos8700.h
@@ -193,16 +193,21 @@ struct fxos8700_data {
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
 	sensor_trigger_handler_t drdy_handler;
+	const struct sensor_trigger *drdy_trig;
 #endif
 #ifdef CONFIG_FXOS8700_PULSE
 	sensor_trigger_handler_t tap_handler;
+	const struct sensor_trigger *tap_trig;
 	sensor_trigger_handler_t double_tap_handler;
+	const struct sensor_trigger *double_tap_trig;
 #endif
 #ifdef CONFIG_FXOS8700_MOTION
 	sensor_trigger_handler_t motion_handler;
+	const struct sensor_trigger *motion_trig;
 #endif
 #ifdef CONFIG_FXOS8700_MAG_VECM
 	sensor_trigger_handler_t m_vecm_handler;
+	const struct sensor_trigger *m_vecm_trig;
 #endif
 #ifdef CONFIG_FXOS8700_TRIGGER_OWN_THREAD
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_FXOS8700_THREAD_STACK_SIZE);

--- a/drivers/sensor/grow_r502a/grow_r502a.h
+++ b/drivers/sensor/grow_r502a/grow_r502a.h
@@ -171,7 +171,7 @@ struct grow_r502a_data {
 	struct gpio_callback gpio_cb;
 
 	sensor_trigger_handler_t th_handler;
-	struct sensor_trigger th_trigger;
+	const struct sensor_trigger *th_trigger;
 #if defined(CONFIG_GROW_R502A_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_GROW_R502A_THREAD_STACK_SIZE);
 	struct k_sem gpio_sem;

--- a/drivers/sensor/grow_r502a/grow_r502a_trigger.c
+++ b/drivers/sensor/grow_r502a/grow_r502a_trigger.c
@@ -32,7 +32,7 @@ static void process_int(const struct device *dev)
 	struct grow_r502a_data *drv_data = dev->data;
 
 	if (drv_data->th_handler != NULL) {
-		drv_data->th_handler(dev, &drv_data->th_trigger);
+		drv_data->th_handler(dev, drv_data->th_trigger);
 	}
 	setup_int(dev, true);
 }
@@ -45,7 +45,7 @@ int grow_r502a_trigger_set(const struct device *dev,
 
 	if ((enum sensor_trigger_type_grow_r502a)trig->type == SENSOR_TRIG_TOUCH) {
 		drv_data->th_handler = handler;
-		drv_data->th_trigger = *trig;
+		drv_data->th_trigger = trig;
 		setup_int(dev, true);
 	} else {
 		LOG_ERR("Unsupported sensor trigger");

--- a/drivers/sensor/hmc5883l/hmc5883l.h
+++ b/drivers/sensor/hmc5883l/hmc5883l.h
@@ -52,7 +52,7 @@ struct hmc5883l_data {
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
 
-	struct sensor_trigger data_ready_trigger;
+	const struct sensor_trigger *data_ready_trigger;
 	sensor_trigger_handler_t data_ready_handler;
 
 #if defined(CONFIG_HMC5883L_TRIGGER_OWN_THREAD)

--- a/drivers/sensor/hmc5883l/hmc5883l_trigger.c
+++ b/drivers/sensor/hmc5883l/hmc5883l_trigger.c
@@ -37,7 +37,7 @@ int hmc5883l_trigger_set(const struct device *dev,
 		return 0;
 	}
 
-	drv_data->data_ready_trigger = *trig;
+	drv_data->data_ready_trigger = trig;
 
 	gpio_pin_interrupt_configure_dt(&config->int_gpio,
 					GPIO_INT_EDGE_TO_ACTIVE);
@@ -70,7 +70,7 @@ static void hmc5883l_thread_cb(const struct device *dev)
 
 	if (drv_data->data_ready_handler != NULL) {
 		drv_data->data_ready_handler(dev,
-					     &drv_data->data_ready_trigger);
+					     drv_data->data_ready_trigger);
 	}
 
 	gpio_pin_interrupt_configure_dt(&config->int_gpio,

--- a/drivers/sensor/hts221/hts221.h
+++ b/drivers/sensor/hts221/hts221.h
@@ -43,7 +43,7 @@ struct hts221_data {
 	const struct device *dev;
 	struct gpio_callback drdy_cb;
 
-	struct sensor_trigger data_ready_trigger;
+	const struct sensor_trigger *data_ready_trigger;
 	sensor_trigger_handler_t data_ready_handler;
 
 #if defined(CONFIG_HTS221_TRIGGER_OWN_THREAD)

--- a/drivers/sensor/hts221/hts221_trigger.c
+++ b/drivers/sensor/hts221/hts221_trigger.c
@@ -45,7 +45,7 @@ static void process_drdy(const struct device *dev)
 	struct hts221_data *data = dev->data;
 
 	if (data->data_ready_handler != NULL) {
-		data->data_ready_handler(dev, &data->data_ready_trigger);
+		data->data_ready_handler(dev, data->data_ready_trigger);
 	}
 
 	if (data->data_ready_handler != NULL) {
@@ -69,7 +69,7 @@ int hts221_trigger_set(const struct device *dev,
 		return 0;
 	}
 
-	data->data_ready_trigger = *trig;
+	data->data_ready_trigger = trig;
 
 	setup_drdy(dev, true);
 

--- a/drivers/sensor/icm42605/icm42605.c
+++ b/drivers/sensor/icm42605/icm42605.c
@@ -134,23 +134,23 @@ int icm42605_tap_fetch(const struct device *dev)
 			result = inv_spi_read(&cfg->spi, REG_APEX_DATA4,
 					      drv_data->fifo_data, 1);
 			if (drv_data->fifo_data[0] & APEX_TAP) {
-				if (drv_data->tap_trigger.type ==
+				if (drv_data->tap_trigger->type ==
 				    SENSOR_TRIG_TAP) {
 					if (drv_data->tap_handler) {
 						LOG_DBG("Single Tap detected");
 						drv_data->tap_handler(dev
-						      , &drv_data->tap_trigger);
+						      , drv_data->tap_trigger);
 					}
 				} else {
 					LOG_ERR("Trigger type is mismatched");
 				}
 			} else if (drv_data->fifo_data[0] & APEX_DOUBLE_TAP) {
-				if (drv_data->double_tap_trigger.type ==
+				if (drv_data->double_tap_trigger->type ==
 				    SENSOR_TRIG_DOUBLE_TAP) {
 					if (drv_data->double_tap_handler) {
 						LOG_DBG("Double Tap detected");
 						drv_data->double_tap_handler(dev
-						     , &drv_data->tap_trigger);
+						     , drv_data->tap_trigger);
 					}
 				} else {
 					LOG_ERR("Trigger type is mismatched");

--- a/drivers/sensor/icm42605/icm42605.h
+++ b/drivers/sensor/icm42605/icm42605.h
@@ -47,13 +47,13 @@ struct icm42605_data {
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
 
-	struct sensor_trigger data_ready_trigger;
+	const struct sensor_trigger *data_ready_trigger;
 	sensor_trigger_handler_t data_ready_handler;
 
-	struct sensor_trigger tap_trigger;
+	const struct sensor_trigger *tap_trigger;
 	sensor_trigger_handler_t tap_handler;
 
-	struct sensor_trigger double_tap_trigger;
+	const struct sensor_trigger *double_tap_trigger;
 	sensor_trigger_handler_t double_tap_handler;
 
 #ifdef CONFIG_ICM42605_TRIGGER

--- a/drivers/sensor/icm42605/icm42605_trigger.c
+++ b/drivers/sensor/icm42605/icm42605_trigger.c
@@ -37,14 +37,14 @@ int icm42605_trigger_set(const struct device *dev,
 
 	if (trig->type == SENSOR_TRIG_DATA_READY) {
 		drv_data->data_ready_handler = handler;
-		drv_data->data_ready_trigger = *trig;
+		drv_data->data_ready_trigger = trig;
 	} else if (trig->type == SENSOR_TRIG_TAP) {
 		drv_data->tap_handler = handler;
-		drv_data->tap_trigger = *trig;
+		drv_data->tap_trigger = trig;
 		drv_data->tap_en = true;
 	} else if (trig->type == SENSOR_TRIG_DOUBLE_TAP) {
 		drv_data->double_tap_handler = handler;
-		drv_data->double_tap_trigger = *trig;
+		drv_data->double_tap_trigger = trig;
 		drv_data->tap_en = true;
 	} else {
 		return -ENOTSUP;
@@ -78,7 +78,7 @@ static void icm42605_thread_cb(const struct device *dev)
 
 	if (drv_data->data_ready_handler != NULL) {
 		drv_data->data_ready_handler(dev,
-					     &drv_data->data_ready_trigger);
+					     drv_data->data_ready_trigger);
 	}
 
 	if (drv_data->tap_handler != NULL ||

--- a/drivers/sensor/iis2dh/iis2dh.h
+++ b/drivers/sensor/iis2dh/iis2dh.h
@@ -65,6 +65,7 @@ struct iis2dh_data {
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
 	sensor_trigger_handler_t drdy_handler;
+	const struct sensor_trigger *drdy_trig;
 #if defined(CONFIG_IIS2DH_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_IIS2DH_THREAD_STACK_SIZE);
 	struct k_thread thread;

--- a/drivers/sensor/iis2dh/iis2dh_trigger.c
+++ b/drivers/sensor/iis2dh/iis2dh_trigger.c
@@ -55,6 +55,7 @@ int iis2dh_trigger_set(const struct device *dev,
 	switch (trig->type) {
 	case SENSOR_TRIG_DATA_READY:
 		iis2dh->drdy_handler = handler;
+		iis2dh->drdy_trig = trig;
 		if (state) {
 			/* dummy read: re-trigger interrupt */
 			iis2dh_acceleration_raw_get(iis2dh->ctx, raw);
@@ -70,13 +71,8 @@ static int iis2dh_handle_drdy_int(const struct device *dev)
 {
 	struct iis2dh_data *data = dev->data;
 
-	struct sensor_trigger drdy_trig = {
-		.type = SENSOR_TRIG_DATA_READY,
-		.chan = SENSOR_CHAN_ALL,
-	};
-
 	if (data->drdy_handler) {
-		data->drdy_handler(dev, &drdy_trig);
+		data->drdy_handler(dev, data->drdy_trig);
 	}
 
 	return 0;

--- a/drivers/sensor/iis2dlpc/iis2dlpc.h
+++ b/drivers/sensor/iis2dlpc/iis2dlpc.h
@@ -95,12 +95,16 @@ struct iis2dlpc_data {
 	uint8_t gpio_pin;
 	struct gpio_callback gpio_cb;
 	sensor_trigger_handler_t drdy_handler;
+	const struct sensor_trigger *drdy_trig;
 #ifdef CONFIG_IIS2DLPC_TAP
 	sensor_trigger_handler_t tap_handler;
+	const struct sensor_trigger *tap_trig;
 	sensor_trigger_handler_t double_tap_handler;
+	const struct sensor_trigger *double_tap_trig;
 #endif /* CONFIG_IIS2DLPC_TAP */
 #ifdef CONFIG_IIS2DLPC_ACTIVITY
 	sensor_trigger_handler_t activity_handler;
+	const struct sensor_trigger *activity_trig;
 #endif /* CONFIG_IIS2DLPC_ACTIVITY */
 #if defined(CONFIG_IIS2DLPC_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_IIS2DLPC_THREAD_STACK_SIZE);

--- a/drivers/sensor/iis2iclx/iis2iclx.h
+++ b/drivers/sensor/iis2iclx/iis2iclx.h
@@ -86,7 +86,9 @@ struct iis2iclx_data {
 #ifdef CONFIG_IIS2ICLX_TRIGGER
 	struct gpio_callback gpio_cb;
 	sensor_trigger_handler_t handler_drdy_acc;
+	const struct sensor_trigger *trig_drdy_acc;
 	sensor_trigger_handler_t handler_drdy_temp;
+	const struct sensor_trigger *trig_drdy_temp;
 
 #if defined(CONFIG_IIS2ICLX_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_IIS2ICLX_THREAD_STACK_SIZE);

--- a/drivers/sensor/iis2iclx/iis2iclx_trigger.c
+++ b/drivers/sensor/iis2iclx/iis2iclx_trigger.c
@@ -101,6 +101,7 @@ int iis2iclx_trigger_set(const struct device *dev,
 
 	if (trig->chan == SENSOR_CHAN_ACCEL_XYZ) {
 		iis2iclx->handler_drdy_acc = handler;
+		iis2iclx->trig_drdy_acc = trig;
 		if (handler) {
 			return iis2iclx_enable_xl_int(dev, IIS2ICLX_EN_BIT);
 		} else {
@@ -110,6 +111,7 @@ int iis2iclx_trigger_set(const struct device *dev,
 #if defined(CONFIG_IIS2ICLX_ENABLE_TEMP)
 	else if (trig->chan == SENSOR_CHAN_DIE_TEMP) {
 		iis2iclx->handler_drdy_temp = handler;
+		iis2iclx->trig_drdy_temp = trig;
 		if (handler) {
 			return iis2iclx_enable_t_int(dev, IIS2ICLX_EN_BIT);
 		} else {
@@ -128,9 +130,6 @@ int iis2iclx_trigger_set(const struct device *dev,
 static void iis2iclx_handle_interrupt(const struct device *dev)
 {
 	struct iis2iclx_data *iis2iclx = dev->data;
-	struct sensor_trigger drdy_trigger = {
-		.type = SENSOR_TRIG_DATA_READY,
-	};
 	const struct iis2iclx_config *cfg = dev->config;
 	iis2iclx_status_reg_t status;
 
@@ -150,12 +149,12 @@ static void iis2iclx_handle_interrupt(const struct device *dev)
 		}
 
 		if ((status.xlda) && (iis2iclx->handler_drdy_acc != NULL)) {
-			iis2iclx->handler_drdy_acc(dev, &drdy_trigger);
+			iis2iclx->handler_drdy_acc(dev, iis2iclx->trig_drdy_acc);
 		}
 
 #if defined(CONFIG_IIS2ICLX_ENABLE_TEMP)
 		if ((status.tda) && (iis2iclx->handler_drdy_temp != NULL)) {
-			iis2iclx->handler_drdy_temp(dev, &drdy_trigger);
+			iis2iclx->handler_drdy_temp(dev, iis2iclx->trig_drdy_temp);
 		}
 #endif
 	}

--- a/drivers/sensor/iis2mdc/iis2mdc.h
+++ b/drivers/sensor/iis2mdc/iis2mdc.h
@@ -59,6 +59,7 @@ struct iis2mdc_data {
 	struct gpio_callback gpio_cb;
 
 	sensor_trigger_handler_t handler_drdy;
+	const struct sensor_trigger *trig_drdy;
 
 #if defined(CONFIG_IIS2MDC_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_IIS2MDC_THREAD_STACK_SIZE);

--- a/drivers/sensor/iis2mdc/iis2mdc_trigger.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_trigger.c
@@ -36,6 +36,7 @@ int iis2mdc_trigger_set(const struct device *dev,
 
 	if (trig->chan == SENSOR_CHAN_MAGN_XYZ) {
 		iis2mdc->handler_drdy = handler;
+		iis2mdc->trig_drdy = trig;
 		if (handler) {
 			/* fetch raw data sample: re-trigger lost interrupt */
 			iis2mdc_magnetic_raw_get(iis2mdc->ctx, raw);
@@ -54,12 +55,9 @@ static void iis2mdc_handle_interrupt(const struct device *dev)
 {
 	struct iis2mdc_data *iis2mdc = dev->data;
 	const struct iis2mdc_dev_config *const config = dev->config;
-	struct sensor_trigger drdy_trigger = {
-		.type = SENSOR_TRIG_DATA_READY,
-	};
 
 	if (iis2mdc->handler_drdy != NULL) {
-		iis2mdc->handler_drdy(dev, &drdy_trigger);
+		iis2mdc->handler_drdy(dev, iis2mdc->trig_drdy);
 	}
 
 	gpio_pin_interrupt_configure_dt(&config->gpio_drdy,

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -474,6 +474,11 @@ static inline int z_impl_sensor_attr_get(const struct device *dev,
  * driver.  It is currently up to the caller to ensure that the handler
  * does not overflow the stack.
  *
+ * The user-allocated trigger will be stored by the driver as a pointer, rather
+ * than a copy, and passed back to the handler. This enables the handler to use
+ * CONTAINER_OF to retrieve a context pointer when the trigger is embedded in a
+ * larger struct and requires that the trigger is not allocated on the stack.
+ *
  * @funcprops \supervisor
  *
  * @param dev Pointer to the sensor device


### PR DESCRIPTION
Fixes a batch of sensor drivers to store the user-supplied sensor
trigger as a pointer rather than a copy. This enables the trigger
handler to use CONTAINER_OF to retrieve a context pointer when the
trigger is embedded in a larger struct.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>

re: #55130 (not using GH "fixes" notation because not all the drivers are done yet)

cc: @anthony32086 @huhebo