### PR TITLE
[osdp_fixes 4/5] Secure channel fixes

### DIFF
--- a/subsys/mgmt/osdp/src/osdp_common.c
+++ b/subsys/mgmt/osdp/src/osdp_common.c
@@ -41,6 +41,11 @@ int64_t osdp_millis_since(int64_t last)
 	return (int64_t) k_uptime_delta(&tmp);
 }
 
+void osdp_keyset_complete(struct osdp_pd *pd)
+{
+	cp_keyset_complete(pd);
+}
+
 #ifdef CONFIG_OSDP_SC_ENABLED
 
 void osdp_encrypt(uint8_t *key, uint8_t *iv, uint8_t *data, int len)

--- a/subsys/mgmt/osdp/src/osdp_common.h
+++ b/subsys/mgmt/osdp/src/osdp_common.h
@@ -501,12 +501,18 @@ struct osdp {
 	cp_event_callback_t event_callback;
 };
 
+#ifdef CONFIG_OSDP_MODE_PD
+static inline void cp_keyset_complete(struct osdp_pd *pd) { }
+#else
+void cp_keyset_complete(struct osdp_pd *pd);
+#endif
+
 void osdp_keyset_complete(struct osdp_pd *pd);
 
 /* from osdp_phy.c */
 int osdp_phy_packet_init(struct osdp_pd *p, uint8_t *buf, int max_len);
 int osdp_phy_packet_finalize(struct osdp_pd *p, uint8_t *buf,
-			       int len, int max_len);
+			     int len, int max_len);
 int osdp_phy_check_packet(struct osdp_pd *pd, uint8_t *buf, int len,
 			  int *one_pkt_len);
 int osdp_phy_decode_packet(struct osdp_pd *p, uint8_t *buf, int len,

--- a/subsys/mgmt/osdp/src/osdp_common.h
+++ b/subsys/mgmt/osdp/src/osdp_common.h
@@ -15,6 +15,7 @@
 #define OSDP_PACKET_BUF_SIZE           CONFIG_OSDP_UART_BUFFER_LENGTH
 #define OSDP_PD_SC_TIMEOUT_MS          (800)
 #define OSDP_ONLINE_RETRY_WAIT_MAX_MS  (300 * 1000)
+#define OSDP_PD_MAX                    CONFIG_OSDP_NUM_CONNECTED_PD
 
 #define OSDP_QUEUE_SLAB_SIZE \
 	(sizeof(union osdp_ephemeral_data) * CONFIG_OSDP_PD_COMMAND_QUEUE_SIZE)
@@ -123,6 +124,7 @@
 #define PD_FLAG_SC_SCBKD_DONE   0x00000200 /* SCBKD check is done */
 #define PD_FLAG_PKT_HAS_MARK    0x00000400 /* Packet has mark byte */
 #define PD_FLAG_PKT_SKIP_MARK   0x00000800 /* CONFIG_OSDP_SKIP_MARK_BYTE */
+#define PD_FLAG_HAS_SCBK        0x00001000 /* PD has a dedicated SCBK */
 #define PD_FLAG_INSTALL_MODE    0x40000000 /* PD is in install mode */
 #define PD_FLAG_PD_MODE         0x80000000 /* device is setup as PD */
 
@@ -499,6 +501,8 @@ struct osdp {
 	cp_event_callback_t event_callback;
 };
 
+void osdp_keyset_complete(struct osdp_pd *pd);
+
 /* from osdp_phy.c */
 int osdp_phy_packet_init(struct osdp_pd *p, uint8_t *buf, int max_len);
 int osdp_phy_packet_finalize(struct osdp_pd *p, uint8_t *buf,
@@ -531,7 +535,7 @@ void osdp_decrypt(uint8_t *key, uint8_t *iv, uint8_t *data, int len);
 #endif
 
 /* from osdp_sc.c */
-void osdp_compute_scbk(struct osdp_pd *pd, uint8_t *scbk);
+void osdp_compute_scbk(struct osdp_pd *pd, uint8_t *master_key, uint8_t *scbk);
 void osdp_compute_session_keys(struct osdp_pd *pd);
 void osdp_compute_cp_cryptogram(struct osdp_pd *pd);
 int osdp_verify_cp_cryptogram(struct osdp_pd *pd);
@@ -542,7 +546,7 @@ int osdp_decrypt_data(struct osdp_pd *pd, int is_cmd, uint8_t *data, int len);
 int osdp_encrypt_data(struct osdp_pd *pd, int is_cmd, uint8_t *data, int len);
 int osdp_compute_mac(struct osdp_pd *pd, int is_cmd,
 		     const uint8_t *data, int len);
-void osdp_sc_init(struct osdp_pd *pd);
+void osdp_sc_setup(struct osdp_pd *pd);
 void osdp_fill_random(uint8_t *buf, int len);
 
 /* must be implemented by CP or PD */

--- a/subsys/mgmt/osdp/src/osdp_cp.c
+++ b/subsys/mgmt/osdp/src/osdp_cp.c
@@ -937,7 +937,7 @@ static int state_update(struct osdp_pd *pd)
 			cp_set_online(pd);
 			break;
 		}
-		osdp_keyset_complete(pd);
+		cp_keyset_complete(pd);
 		pd->seq_number = -1;
 		break;
 #endif /* CONFIG_OSDP_SC_ENABLED */
@@ -991,7 +991,7 @@ static int osdp_cp_send_command_keyset(struct osdp_cmd_keyset *p)
 	return res;
 }
 
-void osdp_keyset_complete(struct osdp_pd *pd)
+void cp_keyset_complete(struct osdp_pd *pd)
 {
 	struct osdp_cmd *c = (struct osdp_cmd *)pd->ephemeral_data;
 

--- a/subsys/mgmt/osdp/src/osdp_pd.c
+++ b/subsys/mgmt/osdp/src/osdp_pd.c
@@ -508,8 +508,8 @@ static int pd_decode_command(struct osdp_pd *pd, uint8_t *buf, int len)
 		if (!pd_cmd_cap_ok(pd, NULL)) {
 			break;
 		}
-		osdp_sc_init(pd);
 		sc_deactivate(pd);
+		osdp_sc_setup(pd);
 		memcpy(pd->sc.cp_random, buf + pos, 8);
 		pd->reply_id = REPLY_CCRYPT;
 		ret = OSDP_PD_ERR_NONE;
@@ -739,6 +739,7 @@ static int pd_build_reply(struct osdp_pd *pd, uint8_t *buf, int max_len)
 		if (osdp_verify_cp_cryptogram(pd) == 0) {
 			smb[2] = 1;  /* CP auth succeeded */
 			sc_activate(pd);
+			pd->sc_tstamp = osdp_millis_now();
 			if (ISSET_FLAG(pd, PD_FLAG_SC_USE_SCBKD)) {
 				LOG_WRN("SC Active with SCBK-D");
 			} else {

--- a/subsys/mgmt/osdp/src/osdp_pd.c
+++ b/subsys/mgmt/osdp/src/osdp_pd.c
@@ -497,6 +497,7 @@ static int pd_decode_command(struct osdp_pd *pd, uint8_t *buf, int len)
 		memcpy(pd->sc.scbk, cmd.keyset.data, 16);
 		CLEAR_FLAG(pd, PD_FLAG_SC_USE_SCBKD);
 		CLEAR_FLAG(pd, PD_FLAG_INSTALL_MODE);
+		sc_deactivate(pd);
 		pd->reply_id = REPLY_ACK;
 		ret = OSDP_PD_ERR_NONE;
 		break;

--- a/subsys/mgmt/osdp/src/osdp_phy.c
+++ b/subsys/mgmt/osdp/src/osdp_phy.c
@@ -482,12 +482,21 @@ int osdp_phy_decode_packet(struct osdp_pd *pd, uint8_t *buf, int len,
 			 * ID (data[0])  when calling osdp_decrypt_data().
 			 */
 			len = osdp_decrypt_data(pd, is_cmd, data + 1, len - 1);
-			if (len <= 0) {
+			if (len < 0) {
 				LOG_ERR("Failed at decrypt; discarding SC");
 				sc_deactivate(pd);
 				pd->reply_id = REPLY_NAK;
 				pd->ephemeral_data[0] = OSDP_PD_NAK_SC_COND;
 				return OSDP_ERR_PKT_NACK;
+			}
+			if (len == 0) {
+				/**
+				 * If cmd/reply has no data, PD "should" have
+				 * used SCS_15/SCS_16 but we will be tolerant
+				 * towards those faulty implementations.
+				 */
+				LOG_INF("Received encrypted data block with 0 "
+					"length; tolerating non-conformance!");
 			}
 			len += 1; /* put back cmd/reply ID */
 		}

--- a/subsys/mgmt/osdp/src/osdp_sc.c
+++ b/subsys/mgmt/osdp/src/osdp_sc.c
@@ -18,6 +18,20 @@ static const uint8_t osdp_scbk_default[16] = {
 	0x38, 0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F
 };
 
+/**
+ * Tail memsets can be optimized away by compilers. To sidestep this problem,
+ * we cast the pointer to volatile and then operate on it.
+ */
+static void osdp_memzero(void *mem, size_t size)
+{
+	size_t i;
+	volatile uin8_t *p = mem;
+
+	for (i = 0; i < size; i++) {
+		p[i] = 0;
+	}
+}
+
 void osdp_compute_scbk(struct osdp_pd *pd, uint8_t *master_key, uint8_t *scbk)
 {
 	int i;
@@ -233,6 +247,7 @@ void osdp_sc_setup(struct osdp_pd *pd)
 	if (preserve_scbk) {
 		memcpy(pd->sc.scbk, scbk, 16);
 	}
+	osdp_memzero(scbk, sizeof(scbk));
 	if (is_pd_mode(pd)) {
 		pd->sc.pd_client_uid[0] = BYTE_0(pd->id.vendor_code);
 		pd->sc.pd_client_uid[1] = BYTE_1(pd->id.vendor_code);

--- a/subsys/mgmt/osdp/src/osdp_sc.c
+++ b/subsys/mgmt/osdp/src/osdp_sc.c
@@ -50,12 +50,15 @@ void osdp_compute_session_keys(struct osdp_pd *pd)
 	memset(pd->sc.s_mac1, 0, 16);
 	memset(pd->sc.s_mac2, 0, 16);
 
-	pd->sc.s_enc[0]  = 0x01;  pd->sc.s_enc[1]  = 0x82;
-	pd->sc.s_mac1[0] = 0x01;  pd->sc.s_mac1[1] = 0x01;
-	pd->sc.s_mac2[0] = 0x01;  pd->sc.s_mac2[1] = 0x02;
+	pd->sc.s_enc[0] = 0x01;
+	pd->sc.s_enc[1] = 0x82;
+	pd->sc.s_mac1[0] = 0x01;
+	pd->sc.s_mac1[1] = 0x01;
+	pd->sc.s_mac2[0] = 0x01;
+	pd->sc.s_mac2[1] = 0x02;
 
 	for (i = 2; i < 8; i++) {
-		pd->sc.s_enc[i]  = pd->sc.cp_random[i - 2];
+		pd->sc.s_enc[i] = pd->sc.cp_random[i - 2];
 		pd->sc.s_mac1[i] = pd->sc.cp_random[i - 2];
 		pd->sc.s_mac2[i] = pd->sc.cp_random[i - 2];
 	}
@@ -143,7 +146,6 @@ int osdp_decrypt_data(struct osdp_pd *pd, int is_cmd, uint8_t *data, int length)
 	uint8_t iv[16];
 
 	if (length % 16 != 0) {
-		LOG_ERR("decrypt_pkt invalid len:%d", length);
 		return -1;
 	}
 
@@ -154,15 +156,16 @@ int osdp_decrypt_data(struct osdp_pd *pd, int is_cmd, uint8_t *data, int length)
 
 	osdp_decrypt(pd->sc.s_enc, iv, data, length);
 
-	while (data[length - 1] == 0x00) {
+	length--;
+	while (length && data[length] == 0x00) {
 		length--;
 	}
-	if (data[length - 1] != OSDP_SC_EOM_MARKER) {
+	if (data[length] != OSDP_SC_EOM_MARKER) {
 		return -1;
 	}
-	data[length - 1] = 0;
+	data[length] = 0;
 
-	return length - 1;
+	return length;
 }
 
 int osdp_encrypt_data(struct osdp_pd *pd, int is_cmd, uint8_t *data, int length)

--- a/subsys/mgmt/osdp/src/osdp_sc.c
+++ b/subsys/mgmt/osdp/src/osdp_sc.c
@@ -144,7 +144,7 @@ int osdp_decrypt_data(struct osdp_pd *pd, int is_cmd, uint8_t *data, int length)
 	int i;
 	uint8_t iv[16];
 
-	if (length % 16 != 0) {
+	if (length <= 0 || length % 16 != 0) {
 		return -1;
 	}
 


### PR DESCRIPTION
Some minor fixes to SC:

- [mgmt/osdp: sc: Restructure loop to avoid a bunch of -1s](https://github.com/zephyrproject-rtos/zephyr/commit/ceb1ceed685387021a5344a09ca8da43ffc97667) 
- [mgmt/osdp: Rework secure channel key management](https://github.com/zephyrproject-rtos/zephyr/commit/90f8e19d21e4cfa3b0876dcced13230671018f91) 
- [mgmt/osdp: phy: Allow non-conformant, 0 length, encrypted data blocks](https://github.com/zephyrproject-rtos/zephyr/commit/91252e5daeca381d4f829a47ad7afbc799ace841) 
- [mgmt/osdp: discard secure channel if KEYSET is ACKed in plaintext](https://github.com/zephyrproject-rtos/zephyr/commit/ccf2e16bb2f9c8b4d6d609ebc4ac1d0245fb01eb) 
