### PR TITLE
Fix pathname for SMP sample examples

### DIFF
--- a/samples/arch/smp/pi/README.rst
+++ b/samples/arch/smp/pi/README.rst
@@ -26,7 +26,7 @@ required for all the calculation to be done. It can be built and executed
 on Synopsys ARC HSDK board as follows:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/smp/pi
+   :zephyr-app: samples/arch/smp/pi
    :host-os: unix
    :board: qemu_x86_64
    :goals: run

--- a/samples/arch/smp/pktqueue/README.rst
+++ b/samples/arch/smp/pktqueue/README.rst
@@ -64,7 +64,7 @@ This project outputs total time required for processing all packet headers.
 It can be built and executed on QEMU as follows:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/smp_pktqueue
+   :zephyr-app: samples/arch/smp/pktqueue
    :host-os: unix
    :board: qemu_x86_64
    :goals: run


### PR DESCRIPTION
SMP sample applications are located in the 'arch' directory.
This patch fixes the pathname for SMP sample examples.