### PR TITLE
net/lib: mqtt_sn: Fix MQTT-SN IPv6 Support and assertation in Example

### DIFF
--- a/samples/net/mqtt_sn_publisher/src/udp.c
+++ b/samples/net/mqtt_sn_publisher/src/udp.c
@@ -116,7 +116,7 @@ static void process_thread(void)
 	gateway.sin_family = AF_INET;
 	gateway.sin_port = htons(CONFIG_NET_SAMPLE_MQTT_SN_GATEWAY_PORT);
 	err = zsock_inet_pton(AF_INET, CONFIG_NET_SAMPLE_MQTT_SN_GATEWAY_IP, &gateway.sin_addr);
-	__ASSERT(err == 0, "zsock_inet_pton() failed %d", err);
+	__ASSERT(err == 1, "zsock_inet_pton() failed %d", err);
 
 	LOG_INF("Waiting for connection...");
 	LOG_HEXDUMP_DBG(&gateway, sizeof(gateway), "gateway");

--- a/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
@@ -48,7 +48,7 @@ static int tp_udp_init(struct mqtt_sn_transport *transport)
 	struct mqtt_sn_transport_udp *udp = UDP_TRANSPORT(transport);
 	int err;
 
-	udp->sock = zsock_socket(PF_INET, SOCK_DGRAM, 0);
+	udp->sock = zsock_socket(udp->gwaddr.sa_family, SOCK_DGRAM, 0);
 	if (udp->sock < 0) {
 		return errno;
 	}


### PR DESCRIPTION
Fixes `zsock_socket()` getting always PF_INET packet Familiy also when using IPv6. Fixes assertation as  `inet_pton()` returns 1 on success.

Fixes #55193.