### PR TITLE
net: wifi_shell: Display correct security type in scan results

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -19,9 +19,13 @@
  */
 enum wifi_security_type {
 	WIFI_SECURITY_TYPE_NONE = 0,
+	WIFI_SECURITY_TYPE_WEP,
+	WIFI_SECURITY_TYPE_WPA_PSK,
 	WIFI_SECURITY_TYPE_PSK,
 	WIFI_SECURITY_TYPE_PSK_SHA256,
 	WIFI_SECURITY_TYPE_SAE,
+	WIFI_SECURITY_TYPE_WAPI,
+	WIFI_SECURITY_TYPE_EAP,
 
 	__WIFI_SECURITY_TYPE_AFTER_LAST,
 	WIFI_SECURITY_TYPE_MAX = __WIFI_SECURITY_TYPE_AFTER_LAST - 1,
@@ -36,12 +40,20 @@ static inline const char *wifi_security_txt(enum wifi_security_type security)
 	switch (security) {
 	case WIFI_SECURITY_TYPE_NONE:
 		return "OPEN";
+	case WIFI_SECURITY_TYPE_WEP:
+		return "WEP";
+	case WIFI_SECURITY_TYPE_WPA_PSK:
+		return "WPA-PSK";
 	case WIFI_SECURITY_TYPE_PSK:
 		return "WPA2-PSK";
 	case WIFI_SECURITY_TYPE_PSK_SHA256:
 		return "WPA2-PSK-SHA256";
 	case WIFI_SECURITY_TYPE_SAE:
 		return "WPA3-SAE";
+	case WIFI_SECURITY_TYPE_WAPI:
+		return "WAPI";
+	case WIFI_SECURITY_TYPE_EAP:
+		return "EAP";
 	case WIFI_SECURITY_TYPE_UNKNOWN:
 	default:
 		return "UNKNOWN";


### PR DESCRIPTION
In status output, algos like WPA, WEP etc. are not being identified in the scan results. Instead security mode is being displayed as "UNKNOWN" for APs using these security modes.
Identify all such modes and display the security mode correctly.