### PR TITLE
sysbuild: Fix mcuboot checksum only verification not working

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -203,8 +203,8 @@ Boards & SoC Support
 Build system and infrastructure
 *******************************
 
-* Fixed an issue whereby whereby older versions of the Zephyr SDK toolchain
-  were used instead of the latest compatible version.
+* Fixed an issue whereby older versions of the Zephyr SDK toolchain were used
+  instead of the latest compatible version.
 
 Drivers and Sensors
 *******************

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -206,6 +206,9 @@ Build system and infrastructure
 * Fixed an issue whereby older versions of the Zephyr SDK toolchain were used
   instead of the latest compatible version.
 
+* Fixed an issue whereby building an application with sysbuild and specifying
+  mcuboot's verification to be checksum only did not build a bootable image.
+
 Drivers and Sensors
 *******************
 

--- a/share/sysbuild/CMakeLists.txt
+++ b/share/sysbuild/CMakeLists.txt
@@ -41,6 +41,12 @@ if(SB_CONFIG_BOOTLOADER_MCUBOOT)
       "Signature key file for signing" FORCE
   )
 
+  if(SB_CONFIG_BOOT_SIGNATURE_TYPE_NONE)
+    set(${app_name}_CONFIG_MCUBOOT_GENERATE_UNSIGNED_IMAGE y CACHE STRING
+        "MCUBOOT is configured for checksum mode" FORCE
+    )
+  endif()
+
   # Set corresponding values in mcuboot
   set(mcuboot_CONFIG_BOOT_SIGNATURE_TYPE_${SB_CONFIG_SIGNATURE_TYPE} y CACHE STRING
       "MCUBOOT signature type" FORCE


### PR DESCRIPTION
    Fixes an issue when configuring a project through sysbuild to use
    mcuboot and setting the verification to checksum only whereby the
    image would be unbootable.

Fixes #55545