### PR TITLE
CODEOWNERS/MAINTAINERS: Add sysbuild entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -211,6 +211,7 @@
 /doc/_scripts/                            @carlescufi
 /doc/connectivity/bluetooth/                    @alwa-nordic @jhedberg @Vudentz
 /doc/build/dts/                          @galak @mbolivar-nordic
+/doc/build/sysbuild/                      @tejlmand @nordicjm
 /doc/hardware/peripherals/canbus/                    @alexanderwachter @henrikbrixandersen
 /doc/security/                            @ceolin @d3zd3z
 /drivers/debug/                           @nashif
@@ -685,6 +686,7 @@
 /kernel/device.c                          @andyross @nashif
 /kernel/idle.c                            @andyross @nashif
 /samples/                                 @nashif
+/samples/application_development/sysbuild/      @tejlmand @nordicjm
 /samples/basic/minimal/                   @carlescufi
 /samples/basic/servo_motor/boards/*microbit* @jhe
 /samples/bluetooth/                       @jhedberg @Vudentz @alwa-nordic @sjanc
@@ -761,7 +763,7 @@ scripts/build/gen_image_info.py           @tejlmand
 /scripts/build/uf2conv.py                 @petejohanson
 /scripts/build/user_wordsize.py           @cfriedt
 /scripts/valgrind.supp                    @aescolar @daor-oti
-/share/sysbuild/                          @tejlmand
+/share/sysbuild/                          @tejlmand @nordicjm
 /share/zephyr-package/                    @tejlmand
 /share/zephyrunittest-package/            @tejlmand
 /subsys/bluetooth/                        @alwa-nordic @jhedberg @Vudentz

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2362,6 +2362,19 @@ Storage:
   labels:
     - "area: Storage"
 
+Sysbuild:
+  status: maintained
+  maintainers:
+    - tejlmand
+  collaborators:
+    - nordicjm
+  files:
+    - share/sysbuild/
+    - samples/application_development/sysbuild/
+    - doc/build/sysbuild/
+  labels:
+    - "area: Sysbuild"
+
 Task Watchdog:
   status: maintained
   maintainers:


### PR DESCRIPTION
    MAINTAINERS: Add sysbuild entry
    
    Adds a sysbuild maintainers entry.
    
    CODEOWNERS: Add self to sysbuild
    
    Add myself to sysbuild entry.
