### PR TITLE
mgmt: mcumgr: transport: shell: Add optional input expiration

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -376,6 +376,15 @@ Libraries / Subsystems
 
   * Added :kconfig:option:`CONFIG_FS_FATFS_REENTRANT` to enable the FAT FS reentrant option.
 
+* Management
+
+  * Added optional input expiration to shell MCUmgr transport, this allows
+    returning the shell to normal operation if a complete MCUmgr packet is not
+    received in a specific duration. Can be enabled with
+    :kconfig:option:`CONFIG_MCUMGR_TRANSPORT_SHELL_INPUT_TIMEOUT` and timeout
+    set with
+    :kconfig:option:`CONFIG_MCUMGR_TRANSPORT_SHELL_INPUT_TIMEOUT_TIME`.
+
 HALs
 ****
 

--- a/subsys/mgmt/mcumgr/transport/Kconfig.shell
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.shell
@@ -33,4 +33,21 @@ config MCUMGR_TRANSPORT_SHELL_RX_BUF_COUNT
 	help
 	  Number of buffers used for receiving SMP fragments over shell.
 
+config MCUMGR_TRANSPORT_SHELL_INPUT_TIMEOUT
+	bool "Shell input expiration"
+	help
+	  If enabled, will time out a partial or erroneous MCUmgr command
+	  received via the shell transport after a given time. This prevents
+	  the shell from becoming locked if it never receives the full packet
+	  that a header indicated it would receive.
+
+config MCUMGR_TRANSPORT_SHELL_INPUT_TIMEOUT_TIME
+	int "Shell input expiration timeout"
+	depends on MCUMGR_TRANSPORT_SHELL_INPUT_TIMEOUT
+	default 3000
+	help
+	  Time (in msec) after receiving a valid MCUmgr header on the serial
+	  transport before considering it as timed out and returning the shell
+	  to normal operation.
+
 endif # MCUMGR_TRANSPORT_SHELL


### PR DESCRIPTION
    Adds an optional feature that can be used to time out a partially
    received MCUmgr packet over the shell interface. Prior to this
    change, if a header was received, then the whole shell would be
    unavailable until the module is rebooted or additional full MCUmgr
    packet was sent.

Fixes #54411