### PR TITLE
tests: Bluetooth: Audio: Streamline connection handling in tests

### DIFF
--- a/tests/bluetooth/bsim/audio/src/bap_unicast_client_test.c
+++ b/tests/bluetooth/bsim/audio/src/bap_unicast_client_test.c
@@ -23,7 +23,6 @@ static struct bt_bap_ep *g_sinks[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
 static struct bt_bap_lc3_preset preset_16_2_1 = BT_BAP_LC3_UNICAST_PRESET_16_2_1(
 	BT_AUDIO_LOCATION_FRONT_LEFT, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
 
-CREATE_FLAG(flag_connected);
 CREATE_FLAG(flag_mtu_exchanged);
 CREATE_FLAG(flag_sink_discovered);
 CREATE_FLAG(flag_stream_codec_configured);
@@ -169,29 +168,6 @@ static void discover_sink_cb(struct bt_conn *conn, struct bt_codec *codec, struc
 		FAIL("Did not discover endpoint and codec\n");
 	}
 }
-
-static void connected(struct bt_conn *conn, uint8_t err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	if (err != 0) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
-
-		FAIL("Failed to connect to %s (%u)\n", addr, err);
-		return;
-	}
-
-	printk("Connected to %s\n", addr);
-	SET_FLAG(flag_connected);
-}
-
-BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected = connected,
-	.disconnected = disconnected,
-};
 
 static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {

--- a/tests/bluetooth/bsim/audio/src/bap_unicast_server_test.c
+++ b/tests/bluetooth/bsim/audio/src/bap_unicast_server_test.c
@@ -32,7 +32,6 @@ static const struct bt_data unicast_server_ad[] = {
 	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_ASCS_VAL)),
 };
 
-CREATE_FLAG(flag_connected);
 CREATE_FLAG(flag_stream_configured);
 
 static void print_ase_info(struct bt_bap_ep *ep, void *user_data)
@@ -243,26 +242,6 @@ static void stream_recv(struct bt_bap_stream *stream, const struct bt_iso_recv_i
 static struct bt_bap_stream_ops stream_ops = {
 	.enabled = stream_enabled_cb,
 	.recv = stream_recv
-};
-
-static void connected(struct bt_conn *conn, uint8_t err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	if (err != 0) {
-		FAIL("Failed to connect to %s (%u)\n", addr, err);
-		return;
-	}
-
-	printk("Connected to %s\n", addr);
-	SET_FLAG(flag_connected);
-}
-
-BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected = connected,
-	.disconnected = disconnected,
 };
 
 static void init(void)

--- a/tests/bluetooth/bsim/audio/src/cap_acceptor_test.c
+++ b/tests/bluetooth/bsim/audio/src/cap_acceptor_test.c
@@ -193,28 +193,6 @@ static const struct bt_data cap_acceptor_ad[] = {
 
 static struct bt_csip_set_member_svc_inst *csip_set_member;
 
-CREATE_FLAG(flag_connected);
-
-static void connected(struct bt_conn *conn, uint8_t err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	if (err != 0) {
-		FAIL("Failed to connect to %s (%u)\n", addr, err);
-		return;
-	}
-
-	printk("Connected to %s\n", addr);
-	SET_FLAG(flag_connected);
-}
-
-BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected = connected,
-	.disconnected = disconnected,
-};
-
 static void init(void)
 {
 	struct bt_csip_set_member_register_param csip_set_member_param = {

--- a/tests/bluetooth/bsim/audio/src/cap_initiator_test.c
+++ b/tests/bluetooth/bsim/audio/src/cap_initiator_test.c
@@ -36,7 +36,6 @@ static struct bt_bap_lc3_preset broadcast_preset_16_2_1 = BT_BAP_LC3_BROADCAST_P
 static K_SEM_DEFINE(sem_broadcast_started, 0U, ARRAY_SIZE(broadcast_streams));
 static K_SEM_DEFINE(sem_broadcast_stopped, 0U, ARRAY_SIZE(broadcast_streams));
 
-CREATE_FLAG(flag_connected);
 CREATE_FLAG(flag_discovered);
 CREATE_FLAG(flag_mtu_exchanged);
 CREATE_FLAG(flag_broadcast_stopping);
@@ -127,29 +126,6 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 
 static struct bt_cap_initiator_cb cap_cb = {
 	.unicast_discovery_complete = cap_discovery_complete_cb
-};
-
-static void connected(struct bt_conn *conn, uint8_t err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	(void)bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	if (err != 0) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
-
-		FAIL("Failed to connect to %s (%u)\n", addr, err);
-		return;
-	}
-
-	printk("Connected to %s\n", addr);
-	SET_FLAG(flag_connected);
-}
-
-BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected = connected,
-	.disconnected = disconnected,
 };
 
 static void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)

--- a/tests/bluetooth/bsim/audio/src/common.h
+++ b/tests/bluetooth/bsim/audio/src/common.h
@@ -57,6 +57,7 @@
 #define AD_SIZE 1
 extern const struct bt_data ad[AD_SIZE];
 extern struct bt_conn *default_conn;
+extern atomic_t flag_connected;
 
 void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 		  struct net_buf_simple *ad);

--- a/tests/bluetooth/bsim/audio/src/csip_set_member_test.c
+++ b/tests/bluetooth/bsim/audio/src/csip_set_member_test.c
@@ -10,7 +10,6 @@
 #include "common.h"
 
 static struct bt_csip_set_member_svc_inst *svc_inst;
-static struct bt_conn_cb conn_callbacks;
 extern enum bst_result_t bst_result;
 static volatile bool g_locked;
 static uint8_t sirk_read_req_rsp = BT_CSIP_READ_SIRK_REQ_RSP_ACCEPT;
@@ -22,19 +21,6 @@ struct bt_csip_set_member_register_param param = {
 	.set_sirk = { 0xcd, 0xcc, 0x72, 0xdd, 0x86, 0x8c, 0xcd, 0xce,
 		      0x22, 0xfd, 0xa1, 0x21, 0x09, 0x7d, 0x7d, 0x45 },
 };
-
-static void connected(struct bt_conn *conn, uint8_t err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	if (err != 0) {
-		FAIL("Failed to connect to %s (%u)\n", addr, err);
-		return;
-	}
-	printk("Connected\n");
-}
 
 static void csip_disconnected(struct bt_conn *conn, uint8_t reason)
 {
@@ -102,7 +88,6 @@ static void bt_ready(int err)
 }
 
 static struct bt_conn_cb conn_callbacks = {
-	.connected = connected,
 	.disconnected = csip_disconnected,
 };
 

--- a/tests/bluetooth/bsim/audio/src/has_client_test.c
+++ b/tests/bluetooth/bsim/audio/src/has_client_test.c
@@ -17,13 +17,11 @@ extern const uint8_t test_preset_index_1;
 extern const uint8_t test_preset_index_5;
 extern const enum bt_has_properties test_preset_properties;
 
-CREATE_FLAG(g_is_connected);
 CREATE_FLAG(g_service_discovered);
 CREATE_FLAG(g_preset_switched);
 CREATE_FLAG(g_preset_1_found);
 CREATE_FLAG(g_preset_5_found);
 
-static struct bt_conn *g_conn;
 static struct bt_has *g_has;
 static uint8_t g_active_index;
 
@@ -88,26 +86,6 @@ static const struct bt_has_client_cb has_cb = {
 	.discover = discover_cb,
 	.preset_switch = preset_switch_cb,
 	.preset_read_rsp = preset_read_rsp_cb,
-};
-
-static void connected(struct bt_conn *conn, uint8_t err)
-{
-	if (err > 0) {
-		char addr[BT_ADDR_LE_STR_LEN];
-
-		bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-		FAIL("Failed to connect to %s (err %u)\n", addr, err);
-		return;
-	}
-
-	g_conn = conn;
-	SET_FLAG(g_is_connected);
-}
-
-BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected = connected,
-	.disconnected = disconnected,
 };
 
 static bool test_preset_switch(uint8_t index)
@@ -187,9 +165,9 @@ static void test_main(void)
 
 	printk("Scanning successfully started\n");
 
-	WAIT_FOR_COND(g_is_connected);
+	WAIT_FOR_FLAG(flag_connected);
 
-	err = bt_has_client_discover(g_conn);
+	err = bt_has_client_discover(default_conn);
 	if (err < 0) {
 		FAIL("Failed to discover HAS (err %d)\n", err);
 		return;

--- a/tests/bluetooth/bsim/audio/src/ias_test.c
+++ b/tests/bluetooth/bsim/audio/src/ias_test.c
@@ -23,7 +23,6 @@
 
 extern enum bst_result_t bst_result;
 
-CREATE_FLAG(g_is_connected);
 CREATE_FLAG(g_high_alert_received);
 CREATE_FLAG(g_mild_alert_received);
 CREATE_FLAG(g_stop_alert_received);
@@ -49,27 +48,6 @@ BT_IAS_CB_DEFINE(ias_callbacks) = {
 	.no_alert = no_alert_cb,
 };
 
-static void connected(struct bt_conn *conn, uint8_t err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	if (err) {
-		FAIL("Failed to connect to %s (%u)\n", addr, err);
-		return;
-	}
-
-	printk("Connected to %s\n", addr);
-	default_conn = bt_conn_ref(conn);
-	g_is_connected = true;
-}
-
-static struct bt_conn_cb conn_callbacks = {
-	.connected = connected,
-	.disconnected = disconnected,
-};
-
 static void test_main(void)
 {
 	int err;
@@ -80,8 +58,6 @@ static void test_main(void)
 		return;
 	}
 
-	bt_conn_cb_register(&conn_callbacks);
-
 	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
@@ -90,7 +66,7 @@ static void test_main(void)
 
 	printk("Advertising successfully started\n");
 
-	WAIT_FOR_FLAG(g_is_connected);
+	WAIT_FOR_FLAG(flag_connected);
 
 	WAIT_FOR_FLAG(g_high_alert_received);
 	printk("High alert received\n");

--- a/tests/bluetooth/bsim/audio/src/mcs_test.c
+++ b/tests/bluetooth/bsim/audio/src/mcs_test.c
@@ -12,8 +12,6 @@
 
 extern enum bst_result_t bst_result;
 
-CREATE_FLAG(ble_link_is_ready);
-
 /* Callback after Bluetoot initialization attempt */
 static void bt_ready(int err)
 {
@@ -33,33 +31,11 @@ static void bt_ready(int err)
 	printk("Advertising successfully started\n");
 }
 
-/* Callback when connected */
-static void connected(struct bt_conn *conn, uint8_t err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	if (err) {
-		FAIL("Failed to connect to %s (%u)\n", addr, err);
-	} else {
-		default_conn = bt_conn_ref(conn);
-		printk("Connected: %s\n", addr);
-		SET_FLAG(ble_link_is_ready);
-	}
-}
-
 static void test_main(void)
 {
 	int err;
-	static struct bt_conn_cb conn_callbacks = {
-		.connected = connected,
-		.disconnected = disconnected,
-	};
 
 	printk("Media Control Server test application.  Board: %s\n", CONFIG_BOARD);
-
-	bt_conn_cb_register(&conn_callbacks);
 
 	/* Initialize media player */
 	err = media_proxy_pl_init();
@@ -75,7 +51,7 @@ static void test_main(void)
 		return;
 	}
 
-	WAIT_FOR_FLAG(ble_link_is_ready);
+	WAIT_FOR_FLAG(flag_connected);
 
 	PASS("MCS passed\n");
 }

--- a/tests/bluetooth/bsim/audio/src/micp_mic_dev_test.c
+++ b/tests/bluetooth/bsim/audio/src/micp_mic_dev_test.c
@@ -29,7 +29,6 @@ static volatile uint8_t g_aics_gain_min;
 static volatile bool g_aics_active = true;
 static char g_aics_desc[AICS_DESC_SIZE];
 static volatile bool g_cb;
-static bool g_is_connected;
 
 static void micp_mute_cb(uint8_t mute)
 {
@@ -115,27 +114,6 @@ static struct bt_aics_cb aics_cb = {
 	.description = aics_description_cb
 };
 #endif /* CONFIG_BT_MICP_MIC_DEV_AICS */
-
-static void connected(struct bt_conn *conn, uint8_t err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	if (err != 0) {
-		FAIL("Failed to connect to %s (%u)\n", addr, err);
-		return;
-	}
-
-	printk("Connected to %s\n", addr);
-	default_conn = bt_conn_ref(conn);
-	g_is_connected = true;
-}
-
-BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected = connected,
-	.disconnected = disconnected,
-};
 
 static int test_aics_server_only(void)
 {
@@ -450,7 +428,7 @@ static void test_main(void)
 
 	printk("Advertising successfully started\n");
 
-	WAIT_FOR_COND(g_is_connected);
+	WAIT_FOR_FLAG(flag_connected);
 
 	PASS("MICP mic_dev passed\n");
 }

--- a/tests/bluetooth/bsim/audio/src/vcp_vol_ctlr_test.c
+++ b/tests/bluetooth/bsim/audio/src/vcp_vol_ctlr_test.c
@@ -20,7 +20,6 @@ extern enum bst_result_t bst_result;
 
 static struct bt_vcp_vol_ctlr *vol_ctlr;
 static struct bt_vcp_included vcp_included;
-static volatile bool g_is_connected;
 static volatile bool g_discovery_complete;
 static volatile bool g_write_complete;
 
@@ -225,27 +224,6 @@ static void vcs_write_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err)
 
 	g_write_complete = true;
 }
-
-static void connected(struct bt_conn *conn, uint8_t err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	if (err != 0) {
-		bt_conn_unref(default_conn);
-		default_conn = NULL;
-		FAIL("Failed to connect to %s (%u)\n", addr, err);
-		return;
-	}
-	printk("Connected to %s\n", addr);
-	g_is_connected = true;
-}
-
-BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected = connected,
-	.disconnected = disconnected,
-};
 
 static void test_aics_deactivate(void)
 {
@@ -1187,7 +1165,7 @@ static void test_main(void)
 
 	printk("Scanning successfully started\n");
 
-	WAIT_FOR_COND(g_is_connected);
+	WAIT_FOR_FLAG(flag_connected);
 
 	test_discover();
 	test_included_get();

--- a/tests/bluetooth/bsim/audio/src/vcp_vol_rend_test.c
+++ b/tests/bluetooth/bsim/audio/src/vcp_vol_rend_test.c
@@ -42,7 +42,6 @@ static volatile uint8_t g_aics_gain_min;
 static volatile bool g_aics_active = 1;
 static char g_aics_desc[AICS_DESC_SIZE];
 static volatile bool g_cb;
-static bool g_is_connected;
 
 static void vcs_state_cb(int err, uint8_t volume, uint8_t mute)
 {
@@ -183,26 +182,6 @@ static struct bt_aics_cb aics_cb = {
 	.type = aics_input_type_cb,
 	.status = aics_status_cb,
 	.description = aics_description_cb
-};
-
-static void connected(struct bt_conn *conn, uint8_t err)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	if (err != 0) {
-		FAIL("Failed to connect to %s (%u)\n", addr, err);
-		return;
-	}
-	printk("Connected to %s\n", addr);
-	default_conn = bt_conn_ref(conn);
-	g_is_connected = true;
-}
-
-BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected = connected,
-	.disconnected = disconnected,
 };
 
 static void test_aics_deactivate(void)
@@ -1071,7 +1050,7 @@ static void test_main(void)
 
 	printk("Advertising successfully started\n");
 
-	WAIT_FOR_COND(g_is_connected);
+	WAIT_FOR_FLAG(flag_connected);
 
 	PASS("VCP volume renderer passed\n");
 }


### PR DESCRIPTION
Modify the tests to only have a single set of connection callbacks, where all the tests can use the same default_conn and flag_connected.

Pre-requisite for properly support reconnections in the BSIM tests for e.g. https://github.com/zephyrproject-rtos/zephyr/issues/51382