### PR TITLE
Bluetooth: ascs: Fix uninitialized stream object

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1150,17 +1150,6 @@ static struct bt_bap_iso *bap_iso_get_or_new(struct bt_ascs *ascs, uint8_t cig_i
 	return iso;
 }
 
-static void ase_stream_add(struct bt_ascs *ascs, struct bt_ascs_ase *ase,
-			   struct bt_bap_stream *stream)
-{
-	LOG_DBG("ase %p stream %p", ase, stream);
-	ase->ep.stream = stream;
-	if (stream->conn == NULL) {
-		stream->conn = bt_conn_ref(ascs->conn);
-	}
-	stream->ep = &ase->ep;
-}
-
 static void ascs_init(struct bt_ascs *ascs, struct bt_conn *conn)
 {
 	memset(ascs, 0, sizeof(*ascs));
@@ -1515,15 +1504,10 @@ static int ase_config(struct bt_ascs *ascs, struct bt_ascs_ase *ase,
 
 			return err;
 		}
-
-		ase_stream_add(ascs, ase, stream);
 	}
 
 	ascs_cp_rsp_success(ASE_ID(ase), BT_ASCS_CONFIG_OP);
 
-	/* TODO: bt_bap_stream_attach duplicates some of the
-	 * ase_stream_add. Should be cleaned up.
-	 */
 	bt_bap_stream_attach(ascs->conn, stream, &ase->ep, &ase->ep.codec);
 
 	ascs_ep_set_state(&ase->ep, BT_BAP_EP_STATE_CODEC_CONFIGURED);

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1504,6 +1504,8 @@ static int ase_config(struct bt_ascs *ascs, struct bt_ascs_ase *ase,
 
 			return err;
 		}
+
+		bt_bap_stream_init(stream);
 	}
 
 	ascs_cp_rsp_success(ASE_ID(ase), BT_ASCS_CONFIG_OP);

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -78,6 +78,22 @@ void bt_audio_codec_qos_to_iso_qos(struct bt_iso_chan_io_qos *io,
 	* CONFIG_BT_BAP_BROADCAST_SINK                                                             \
 	*/
 
+void bt_bap_stream_init(struct bt_bap_stream *stream)
+{
+	struct bt_bap_stream_ops *ops;
+	void *user_data;
+
+	/* Save the stream->ops and stream->user_data owned by API user */
+	ops = stream->ops;
+	user_data = stream->user_data;
+
+	memset(stream, 0, sizeof(*stream));
+
+	/* Restore */
+	stream->ops = ops;
+	stream->user_data = user_data;
+}
+
 void bt_bap_stream_attach(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_bap_ep *ep,
 			  struct bt_codec *codec)
 {

--- a/subsys/bluetooth/audio/bap_stream.h
+++ b/subsys/bluetooth/audio/bap_stream.h
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+void bt_bap_stream_init(struct bt_bap_stream *stream);
+
 /* Disconnect ISO channel */
 int bt_bap_stream_disconnect(struct bt_bap_stream *stream);
 


### PR DESCRIPTION
This fixes "Conditional jump or move depends on uninitialised value(s)"
error seen in valgrind.
The stream object that is allocated by application has to be initialized
as it may contain invalid data.