### PR TITLE
twister: extend --force-platform to skip platform_allow option

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -754,7 +754,9 @@ class TestPlan:
                 if platform_filter and plat.name not in platform_filter:
                     instance.add_filter("Command line platform filter", Filters.CMD_LINE)
 
-                if ts.platform_allow and plat.name not in ts.platform_allow:
+                if ts.platform_allow \
+                        and plat.name not in ts.platform_allow \
+                        and not (platform_filter and force_platform):
                     instance.add_filter("Not in testsuite platform allow list", Filters.TESTSUITE)
 
                 if ts.platform_type and plat.type not in ts.platform_type:


### PR DESCRIPTION
This change allows to force running tests on platform given with `-p` or `--hardware-map` even if it is not listed in `platform_allow` in spec yaml file
