### PR TITLE
usb-c: tcpc: Disable Dead Battery after system starts

### DIFF
--- a/drivers/usb_c/tcpc/ucpd_stm32_priv.h
+++ b/drivers/usb_c/tcpc/ucpd_stm32_priv.h
@@ -322,6 +322,9 @@ struct tcpc_data {
 	/* Track CC line that VCONN was active on */
 	enum tc_cc_polarity ucpd_vconn_cc;
 
+	/* Dead Battery active */
+	bool dead_battery_active;
+
 	/* Timer for amount of time to wait for receiving a GoodCRC */
 	struct k_timer goodcrc_rx_timer;
 };


### PR DESCRIPTION
The Dead Battery resistors interfere with port partner detection. So, Dead Battery is disabled after the system starts and sets the Rd or Rp resistors on the CC lines.

Tested on b_g474e_dpow1 with JP5 set to USBC.
Tested on stm32g081b_eval with JP17 set to D5V.