### PR TITLE
west.yaml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -181,7 +181,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 59624334748129cb93f096408911a227b0dd64c0
+      revision: 143485e35b8da7d234677d8920a28f5ea03f6d09
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
 - 143485e35b8da7d234677d8920a28f5ea03f6d09

Brings following Zephyr relevant fixes:
 - 143485e3 zephyr: Add missing Kconfig dependencies for USB DFU
 - 16f3de56 imgtool: fix boot_magic when -e big and max-align > 8
 - 259d989f bootutil: Fix erase of trailer when located in scratch area
 - e8294b2a boot_serial: Add packed to struct
 - 68dcc0ee zephyr: single_loader: Switch to flash_area_get_sector
 - 069aea48 zephry: Add flash_area_get_sector
 - 9551b6ef boot: zephyr: Remove deprecated GPIO Kconfig entries
 - dc8ef879 zephyr: serial_recovery: Use Zephyr manifest zcbor files
 - e026c367 imgtool: sign: allow using 16-bit custom TLVs from valid range


Notes on process:
 1) The MCUboot update from mcu-tools/mcuboot with the SHA used in west.yaml is already synchronized to https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to https://github.com/zephyrproject-rtos/mcuboot/tree/main branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.