### PR TITLE
Doc: build: require an up to date minimum west version

### DIFF
--- a/cmake/modules/west.cmake
+++ b/cmake/modules/west.cmake
@@ -62,7 +62,7 @@ else()
   # We can import west from PYTHON_EXECUTABLE and have its version.
 
   # Make sure its version matches the minimum required one.
-  set(MIN_WEST_VERSION 0.7.1)
+  set_ifndef(MIN_WEST_VERSION 0.7.1)
   if(${west_version} VERSION_LESS ${MIN_WEST_VERSION})
     message(FATAL_ERROR "The detected west version, ${west_version}, is unsupported.\n\
   The minimum supported version is ${MIN_WEST_VERSION}.\n\

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -3,6 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 project(Zephyr-Kernel-Doc LANGUAGES)
 
+set(MIN_WEST_VERSION 1.0.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} .. COMPONENTS doc)
 
 file(TO_CMAKE_PATH "${ZEPHYR_BASE}" ZEPHYR_BASE)


### PR DESCRIPTION
**This change only applies to the Zephyr documentation build system itself, not the regular Zephyr build system. Users who do not need to build the documentation are not affected by this change.**

If west is installed, we have to build the Zephyr documentation with a
recent version of west. This is because the west API documentation is
part of the Zephyr documentation, and the west API documentation
contains Sphinx autodoc directives which pull API documentation out of
the west source code itself. This is similar to how we pull Doxygen
comments out of the Zephyr API headers using breathe. (If west is not
installed, we don't build the west API docs, so you can uninstall west
if you don't want this.)

The current API docs require west v1.0.0 or later to build, since that
version of west introduced new APIs and documentation for them not
available in prior versions.
