### PR TITLE
tests: bluetooth gatt settings: Fix random test failures

### DIFF
--- a/tests/bluetooth/bsim/host/gatt/settings/test_scripts/run_gatt_settings.sh
+++ b/tests/bluetooth/bsim/host/gatt/settings/test_scripts/run_gatt_settings.sh
@@ -26,10 +26,11 @@ function Execute() {
 cd ${BSIM_OUT_PATH}/bin
 
 # Remove the files used by the custom SETTINGS backend
-echo "remove settings files ${simulation_id}_*.log"
-rm ${simulation_id}_*.log || true
+TO_DELETE="${simulation_id}_server.log ${simulation_id}_client.log"
+echo "remove settings files ${TO_DELETE}"
+rm ${TO_DELETE} || true
 
-Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s="${simulation_id}" -D=8 -sim_length=30e6
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s="${simulation_id}" -D=8 -sim_length=30e6 $@
 
 # Only one `server` device is really running at a time. This is a necessary hack
 # because bsim doesn't support plugging devices in and out of a running

--- a/tests/bluetooth/bsim/host/gatt/settings/test_scripts/run_gatt_settings_2.sh
+++ b/tests/bluetooth/bsim/host/gatt/settings/test_scripts/run_gatt_settings_2.sh
@@ -26,10 +26,11 @@ function Execute() {
 cd ${BSIM_OUT_PATH}/bin
 
 # Remove the files used by the custom SETTINGS backend
-echo "remove settings files ${simulation_id}_*.log"
-rm ${simulation_id}_*.log || true
+TO_DELETE="${simulation_id}_server_2.log ${simulation_id}_client_2.log"
+echo "remove settings files ${TO_DELETE}"
+rm ${TO_DELETE} || true
 
-Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s="${simulation_id}" -D=8 -sim_length=30e6
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s="${simulation_id}" -D=8 -sim_length=30e6 $@
 
 # Only one `server` device is really running at a time. This is a necessary hack
 # because bsim doesn't support plugging devices in and out of a running


### PR DESCRIPTION
These tests are creating and deleting temporary files. But they deleted them with a wildcard that
matched the other temporary files causing failures when the tests run in parallel.
Avoid it by only deleting the files for each test.

As a freeby: Add the option to pass arbitrary commands to Phy from the calling script, as with most other tests

meaning `${simulation_id}_*` matched also `${simulation_id}_2_{client_2,server_2}`