### PR TITLE
cmake: sysbuild PRE_CMAKE, POST_CMAKE, PRE_DOMAINS, POST_DOMAINS hooks

### DIFF
--- a/doc/develop/modules.rst
+++ b/doc/develop/modules.rst
@@ -656,6 +656,45 @@ PARENT_SCOPE of the CMakeLists.txt file. For example, to append ``bar`` to the
   list(APPEND FOO_LIST bar)
   set(FOO_LIST ${FOO_LIST} PARENT_SCOPE)
 
+Sysbuild modules hooks
+----------------------
+
+Sysbuild provides an infrastructure which allows a sysbuild module to define
+a function which will be invoked by sysbuild at a pre-defined point in the
+CMake flow.
+
+Functions invoked by sysbuild:
+
+- ``<module-name>_pre_cmake(IMAGES <images>)``: This function is called for each
+  sysbuild module before CMake configure is invoked for all images.
+- ``<module-name>_post_cmake(IMAGES <images>)``: This function is called for each
+  sysbuild module after CMake configure has completed for all images.
+- ``<module-name>_pre_domains(IMAGES <images>)``: This function is called for each
+  sysbuild module before domains yaml is created by sysbuild.
+- ``<module-name>_post_domains(IMAGES <images>)``: This function is called for each
+  sysbuild module after domains yaml has been created by sysbuild.
+
+arguments passed from sysbuild to the function defined by a module:
+
+- ``<images>`` is the list of Zephyr images that will be created by the build system.
+
+If a module ``foo`` want to provide a post CMake configure function, then the
+module's sysbuild :file:`CMakeLists.txt` file must define function ``foo_post_cmake()``.
+
+To facilitate naming of functions, the module name is provided by sysbuild CMake
+through the ``SYSBUILD_CURRENT_MODULE_NAME`` CMake variable when loading the
+module's sysbuild :file:`CMakeLists.txt` file.
+
+Example of how the ``foo`` sysbuild module can define ``foo_post_cmake()``:
+
+.. code-block:: cmake
+
+   function(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
+     cmake_parse_arguments(POST_CMAKE "" "" "IMAGES" ${ARGN})
+
+     message("Invoking ${CMAKE_CURRENT_FUNCTION}. Images: ${POST_CMAKE_IMAGES}")
+   endfunction()
+
 Zephyr module dependencies
 ==========================
 

--- a/share/sysbuild/CMakeLists.txt
+++ b/share/sysbuild/CMakeLists.txt
@@ -31,17 +31,17 @@ get_filename_component(APP_DIR  ${APP_DIR} ABSOLUTE)
 get_filename_component(app_name ${APP_DIR} NAME)
 
 # Include zephyr modules generated sysbuild CMake file.
-foreach(module_name ${SYSBUILD_MODULE_NAMES})
+foreach(SYSBUILD_CURRENT_MODULE_NAME ${SYSBUILD_MODULE_NAMES})
   # Note the second, binary_dir parameter requires the added
   # subdirectory to have its own, local cmake target(s). If not then
   # this binary_dir is created but stays empty. Object files land in
   # the main binary dir instead.
   # https://cmake.org/pipermail/cmake/2019-June/069547.html
-  zephyr_string(SANITIZE TOUPPER MODULE_NAME_UPPER ${module_name})
+  zephyr_string(SANITIZE TOUPPER MODULE_NAME_UPPER ${SYSBUILD_CURRENT_MODULE_NAME})
   if(NOT ${SYSBUILD_${MODULE_NAME_UPPER}_CMAKE_DIR} STREQUAL "")
     set(SYSBUILD_CURRENT_MODULE_DIR ${SYSBUILD_${MODULE_NAME_UPPER}_MODULE_DIR})
     set(SYSBUILD_CURRENT_CMAKE_DIR ${SYSBUILD_${MODULE_NAME_UPPER}_CMAKE_DIR})
-    add_subdirectory(${SYSBUILD_CURRENT_CMAKE_DIR} ${CMAKE_BINARY_DIR}/modules/${module_name})
+    add_subdirectory(${SYSBUILD_CURRENT_CMAKE_DIR} ${CMAKE_BINARY_DIR}/modules/${SYSBUILD_CURRENT_MODULE_NAME})
   endif()
 endforeach()
 # Done processing modules, clear SYSBUILD_CURRENT_MODULE_DIR and SYSBUILD_CURRENT_CMAKE_DIR.
@@ -109,7 +109,12 @@ while(NOT "${images_length}" EQUAL "${processed_length}")
   set(processed_length ${processed_length_new})
 endwhile()
 
+sysbuild_module_call(PRE_CMAKE MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES})
 foreach(image ${IMAGES})
   ExternalZephyrProject_Cmake(APPLICATION ${image})
 endforeach()
+sysbuild_module_call(POST_CMAKE MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES})
+
+sysbuild_module_call(PRE_DOMAINS MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES})
 include(cmake/domains.cmake)
+sysbuild_module_call(POST_DOMAINS MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES})

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -346,3 +346,39 @@ function(ExternalZephyrProject_Cmake)
   load_cache(IMAGE ${ZCMAKE_APPLICATION} BINARY_DIR ${BINARY_DIR})
   import_kconfig(CONFIG_ ${BINARY_DIR}/zephyr/.config TARGET ${ZCMAKE_APPLICATION})
 endfunction()
+
+# Usage:
+#   sysbuild_module_call(<hook> MODULES <modules> [IMAGES <images>] [EXTRA_ARGS <arguments>])
+#
+# This function invokes the sysbuild hook provided as <hook> for <modules>.
+#
+# If `IMAGES` is passed, then the provided list of of images will be passed to
+# the hook.
+#
+# `EXTRA_ARGS` can be used to pass extra arguments to the hook.
+#
+# Valid <hook> values:
+# PRE_CMAKE   : Invoke pre-CMake call for modules before CMake configure is invoked for images
+# POST_CMAKE  : Invoke post-CMake call for modules after CMake configure has been invoked for images
+# PRE_DOMAINS : Invoke pre-domains call for modules before creating domains yaml.
+# POST_DOMAINS: Invoke post-domains call for modules after creation of domains yaml.
+#
+function(sysbuild_module_call)
+  set(options "PRE_CMAKE;POST_CMAKE;PRE_DOMAINS;POST_DOMAINS")
+  set(multi_args "MODULES;IMAGES;EXTRA_ARGS")
+  cmake_parse_arguments(SMC "${options}" "${test_args}" "${multi_args}" ${ARGN})
+
+  zephyr_check_flags_required("sysbuild_module_call" SMC ${options})
+  zephyr_check_flags_exclusive("sysbuild_module_call" SMC ${options})
+
+  foreach(call ${options})
+    if(SMC_${call})
+      foreach(module ${SMC_MODULES})
+        if(COMMAND ${module}_${call})
+          cmake_language(CALL ${module}_${call} IMAGES ${SMC_IMAGES} ${SMC_EXTRA_ARGS})
+        endif()
+      endforeach()
+    endif()
+  endforeach()
+
+endfunction()


### PR DESCRIPTION
Provide a uniform way for sysbuild modules to create hooks that are
called at specific time during sysbuild CMake configure time.
    
A module can create functions following the scheme:
- \<module-name>_pre_cmake
- \<module-name>_post_cmake
- \<module-name>_pre_domains
- \<module-name>_post_domains
    
those functions, if defined, will be called by sysbuild CMake at the
location indicated by the function name.
    
A new global variable `SYSBUILD_CURRENT_MODULE_NAME` is created, which
a module can use to know it's own name when defining those functions
during sysbuild module CMake inclusion.
