### PR TITLE
Bluetooth: Bsim: Test DFU Server phase and image index recovery from persistent storage

### DIFF
--- a/include/zephyr/bluetooth/mesh/dfu_cli.h
+++ b/include/zephyr/bluetooth/mesh/dfu_cli.h
@@ -221,6 +221,8 @@ struct bt_mesh_dfu_cli_xfer_blob_params {
 
 /** Firmware Update Client transfer parameters: */
 struct bt_mesh_dfu_cli_xfer {
+	/** BLOB ID to use for this transfer, or 0 to set it randomly. */
+	uint64_t blob_id;
 	/** DFU image slot to transfer. */
 	const struct bt_mesh_dfu_slot *slot;
 	/**  Transfer mode (Push (Push BLOB Transfer Mode) or Pull (Pull BLOB Transfer Mode)) */

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -838,7 +838,7 @@ enum bt_mesh_dfd_status bt_mesh_dfd_srv_start(struct bt_mesh_dfd_srv *srv,
 					      struct bt_mesh_dfd_start_params *params)
 {
 	int err, i;
-	struct bt_mesh_dfu_cli_xfer xfer;
+	struct bt_mesh_dfu_cli_xfer xfer = { 0 };
 
 	if (!srv->target_cnt) {
 		return BT_MESH_DFD_ERR_RECEIVERS_LIST_EMPTY;

--- a/subsys/bluetooth/mesh/dfu_cli.c
+++ b/subsys/bluetooth/mesh/dfu_cli.c
@@ -427,24 +427,29 @@ static void initiate(struct bt_mesh_dfu_cli *cli)
 	blob_cli_broadcast(&cli->blob, &tx);
 }
 
-static void skip_cli_from_broadcast(struct bt_mesh_dfu_cli *cli, bool skip)
+static void skip_targets_from_broadcast(struct bt_mesh_dfu_cli *cli, bool skip)
 {
 	struct bt_mesh_dfu_target *target;
 
 	TARGETS_FOR_EACH(cli, target) {
-		if (bt_mesh_has_addr(target->blob.addr)) {
+		/* If distributor is in the targets list, or target is in Verify phase,
+		 * disable it until Retrieve Capabilities and BLOB Transfer procedures
+		 * are completed.
+		 */
+		if (bt_mesh_has_addr(target->blob.addr) ||
+		    target->phase == BT_MESH_DFU_PHASE_VERIFY) {
 			target->blob.skip = skip;
 			break;
 		}
 	}
 }
 
-static bool is_self_update(struct bt_mesh_dfu_cli *cli)
+static bool transfer_skip(struct bt_mesh_dfu_cli *cli)
 {
 	struct bt_mesh_dfu_target *target;
 
 	TARGETS_FOR_EACH(cli, target) {
-		if (!bt_mesh_has_addr(target->blob.addr)) {
+		if (!bt_mesh_has_addr(target->blob.addr) || !target->blob.skip) {
 			return false;
 		}
 	}
@@ -464,16 +469,15 @@ static void transfer(struct bt_mesh_blob_cli *b)
 		return;
 	}
 
-	if (is_self_update(cli)) {
-		/* If distributor only updates itself, proceed to the refresh step immediately. */
+	skip_targets_from_broadcast(cli, true);
+
+	if (transfer_skip(cli)) {
+		/* If distributor only updates itself, or all targets are in Verify phase,
+		 * proceed to the refresh step immediately.
+		 */
 		refresh(cli);
 		return;
 	}
-
-	/* If distributor is in the targets list, disable it until Retrieve Capabilities and BLOB
-	 * Transfer procedures are completed.
-	 */
-	skip_cli_from_broadcast(cli, true);
 
 	if (cli->xfer.flags & FLAG_RESUME) {
 		cli->xfer.flags ^= FLAG_RESUME;
@@ -527,7 +531,7 @@ static void refresh(struct bt_mesh_dfu_cli *cli)
 	/* If distributor is in the targets list, enable it again so it participates in Distribute
 	 * Firmware procedure.
 	 */
-	skip_cli_from_broadcast(cli, false);
+	skip_targets_from_broadcast(cli, false);
 
 	blob_cli_broadcast(&cli->blob, &tx);
 }

--- a/subsys/bluetooth/mesh/dfu_cli.c
+++ b/subsys/bluetooth/mesh/dfu_cli.c
@@ -997,7 +997,12 @@ int bt_mesh_dfu_cli_send(struct bt_mesh_dfu_cli *cli,
 
 	cli->xfer.blob.mode = xfer->mode;
 	cli->xfer.blob.size = xfer->slot->size;
-	sys_rand_get(&cli->xfer.blob.id, sizeof(cli->xfer.blob.id));
+
+	if (xfer->blob_id == 0) {
+		sys_rand_get(&cli->xfer.blob.id, sizeof(cli->xfer.blob.id));
+	} else {
+		cli->xfer.blob.id = xfer->blob_id;
+	}
 
 	cli->xfer.io = io;
 	cli->blob.inputs = inputs;

--- a/subsys/bluetooth/mesh/shell/dfu.c
+++ b/subsys/bluetooth/mesh/shell/dfu.c
@@ -723,7 +723,7 @@ static int cmd_dfu_target_check(const struct shell *sh, size_t argc, char *argv[
 static int cmd_dfu_send(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct bt_mesh_dfu_cli_xfer_blob_params blob_params;
-	struct bt_mesh_dfu_cli_xfer xfer;
+	struct bt_mesh_dfu_cli_xfer xfer = { 0 };
 	uint8_t slot_idx;
 	uint16_t group;
 	int err = 0;

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_srv_persistence.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_srv_persistence.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Note:
+# Tests must be added in pairs and in sequence.
+# First test pair: executes Receive Firmware procedure up to certain point using distributor and
+# target.
+# Second test pair: tests are executed with `recover` enabled. This means target will recover
+# settings from persistent storage, which will allow to verify if stored DFU server's phase and
+# image index were loaded correctly.
+# Test cases are designed to be run using single target. `dfu_cli_stop` test case in recovery part
+# plays dummy role, and is there to keep order of settings files being loaded.
+conf=prj_mesh1d1_conf
+overlay=overlay_pst_conf
+RunTest dfu_dist_recover_phase dfu_cli_stop dfu_target_dfu_stop -- -argstest \
+   recover=0 expected-phase=2
+
+conf=prj_mesh1d1_conf
+overlay=overlay_pst_conf
+RunTest dfu_dist_recover_phase dfu_cli_stop dfu_target_dfu_stop  -- -argstest \
+  recover=1 expected-phase=3
+
+conf=prj_mesh1d1_conf
+overlay=overlay_pst_conf
+RunTest dfu_dist_recover_phase dfu_cli_stop dfu_target_dfu_stop -- -argstest \
+  recover=1 expected-phase=4
+
+conf=prj_mesh1d1_conf
+overlay=overlay_pst_conf
+RunTest dfu_dist_recover_phase dfu_cli_stop dfu_target_dfu_stop -- -argstest \
+  recover=1 expected-phase=6
+
+# Use phase `BT_MESH_DFU_PHASE_APPLY_SUCCESS` as marker to bring whole procedure to an end
+conf=prj_mesh1d1_conf
+overlay=overlay_pst_conf
+RunTest dfu_dist_recover_phase dfu_cli_stop dfu_target_dfu_stop -- -argstest \
+  recover=1 expected-phase=8
+
+# To test recovery from Verify Fail begin new distribution that will end there,
+# reboot devices and continue to Applying.
+conf=prj_mesh1d1_conf
+overlay=overlay_pst_conf
+RunTest dfu_dist_recover_phase dfu_cli_stop dfu_target_dfu_stop -- -argstest \
+   recover=0 expected-phase=5
+
+conf=prj_mesh1d1_conf
+overlay=overlay_pst_conf
+RunTest dfu_dist_recover_phase dfu_cli_stop dfu_target_dfu_stop -- -argstest \
+   recover=1 expected-phase=6


### PR DESCRIPTION
Adds tests for DFU Server recovery on reboot. Tests are run in series, which simulates devices reboots. Each test progresses from previously reached DFU phase to next one. One additional test reaches `BT_MESH_DFU_PHASE_VERIFY_FAIL` by failing verify procedure and tests if DFU server accepts new FW Update start and can reach `BT_MESH_DFU_PHASE_APPLYING`.

This PR also contains two fixes for DFU Client and Server issues discovered while testing this behavior.