### PR TITLE
samples: blinky_pwm: Add stm32f072b_disco support

### DIFF
--- a/samples/basic/blinky_pwm/boards/stm32f072b_disco.overlay
+++ b/samples/basic/blinky_pwm/boards/stm32f072b_disco.overlay
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 STMicroelectronics
+ */
+
+/ {
+	pwmleds: pwmleds {
+		compatible = "pwm-leds";
+		status = "okay";
+
+		red_pwm_led: red_pwm_led {
+			pwms = <&pwm3 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+
+    aliases {
+        pwm-led0 = &red_pwm_led;
+    };
+
+};
+
+&timers3 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm3: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim3_ch1_pc6>;
+		pinctrl-names = "default";
+	};
+};


### PR DESCRIPTION
This will enable the use of stm23f072b_disco on this sample.