### PR TITLE
mbedtls: Remove dependency on MBEDTLS_BUILTIN for MBEDTLS_DEBUG

### DIFF
--- a/modules/mbedtls/Kconfig
+++ b/modules/mbedtls/Kconfig
@@ -82,7 +82,6 @@ source "subsys/logging/Kconfig.template.log_config"
 
 config MBEDTLS_DEBUG
 	bool "mbed TLS debug activation"
-	depends on MBEDTLS_BUILTIN
 	help
 	  Enable debugging activation for mbed TLS configuration. If you use
 	  mbedTLS/Zephyr integration (e.g. native TLS sockets), this will

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -56,7 +56,7 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include "sockets_internal.h"
 #include "tls_internal.h"
 
-#if defined(CONFIG_MBEDTLS_BUILTIN)
+#if defined(CONFIG_MBEDTLS_DEBUG)
 #include <zephyr_mbedtls_priv.h>
 #endif
 


### PR DESCRIPTION
Allows using MBEDTLS_DEBUG functionality when not using MBEDTLS_BUILTIN.