### PR TITLE
Bluetooth: Mesh: Reschedule dedicated relay adv sets immediately

### DIFF
--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -324,7 +324,8 @@ static bool schedule_send(struct bt_mesh_ext_adv *adv)
 
 	atomic_clear_bit(adv->flags, ADV_FLAG_SCHEDULE_PENDING);
 
-	if (IS_ENABLED(CONFIG_BT_MESH_ADV_EXT_FRIEND_SEPARATE) && adv->tag & BT_MESH_FRIEND_ADV) {
+	if ((IS_ENABLED(CONFIG_BT_MESH_ADV_EXT_FRIEND_SEPARATE) && adv->tag & BT_MESH_FRIEND_ADV) ||
+	    (CONFIG_BT_MESH_RELAY_ADV_SETS > 0 && adv->tag == BT_MESH_RELAY_ADV)) {
 		k_work_reschedule(&adv->work, K_NO_WAIT);
 	} else {
 		/* The controller will send the next advertisement immediately.


### PR DESCRIPTION
Reschedule dedicated relay adv sets immediatey after finishing advertising of the previous relay message. This allows a node to relay messages as fast as possible when Relay Retransmit Count state is zero using less relay adv sets.

When Relay Retransmit Count state is non-zero, the delay doesn't do anything as the time between pushing a relay message to the host and triggering adv_sent callback will be greater than this delay. In this case the relay adv set will send a next message immediately.