### PR TITLE
samples: sensor: stm32 temperature sensor of the stmf429 nucleo

### DIFF
--- a/samples/sensor/stm32_temp_sensor/boards/nucleo_f429zi.overlay
+++ b/samples/sensor/stm32_temp_sensor/boards/nucleo_f429zi.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Application overlay for creating temperature sensor device instance
+ */
+
+/ {
+	stm-temp {
+		compatible = "st,stm32-temp";
+		io-channels = <&adc1 18>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Add the overlay file to enable the temperature sensor for the nucleo_f429zi board. The temperature sensor is internally connected to the ADC1 channel 18 on the stm32F42X.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55592

Signed-off-by: Francois Ramu <francois.ramu@st.com>