### PR TITLE
boards: thingy53_nrf5340: Add missing DTS nodelabels for sensors

### DIFF
--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -166,13 +166,13 @@
 		reg = <0x10>;
 	};
 
-	bh1749@38 {
+	bh1749: bh1749@38 {
 		compatible = "rohm,bh1749";
 		reg = <0x38>;
 		int-gpios = <&gpio1 5 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 
-	bme688@76 {
+	bme688: bme688@76 {
 		compatible = "bosch,bme680";
 		reg = <0x76>;
 	};


### PR DESCRIPTION
Change adds missing DTS nodelabels for bh1749 and bme688 sensors. This is done to simplify referring to the sensors in application.