### PR TITLE
tests/bluetooth/bsim: Fail CI on build failure 

### DIFF
--- a/tests/bluetooth/bsim/audio/compile.sh
+++ b/tests/bluetooth/bsim/audio/compile.sh
@@ -20,6 +20,6 @@ mkdir -p ${WORK_DIR}
 
 source ${ZEPHYR_BASE}/tests/bluetooth/bsim/compile.source
 
-app=tests/bluetooth/bsim/audio compile &
+app=tests/bluetooth/bsim/audio compile
 
-wait
+wait_for_background_jobs

--- a/tests/bluetooth/bsim/compile.sh
+++ b/tests/bluetooth/bsim/compile.sh
@@ -18,9 +18,11 @@ BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 
 mkdir -p ${WORK_DIR}
 
-${ZEPHYR_BASE}/tests/bluetooth/bsim/audio/compile.sh &
-${ZEPHYR_BASE}/tests/bluetooth/bsim/host/compile.sh &
-${ZEPHYR_BASE}/tests/bluetooth/bsim/ll/compile.sh &
-${ZEPHYR_BASE}/tests/bluetooth/bsim/mesh/compile.sh &
+source ${ZEPHYR_BASE}/tests/bluetooth/bsim/sh_common.source
 
-wait
+run_in_background ${ZEPHYR_BASE}/tests/bluetooth/bsim/audio/compile.sh
+run_in_background ${ZEPHYR_BASE}/tests/bluetooth/bsim/host/compile.sh
+run_in_background ${ZEPHYR_BASE}/tests/bluetooth/bsim/ll/compile.sh
+run_in_background ${ZEPHYR_BASE}/tests/bluetooth/bsim/mesh/compile.sh
+
+wait_for_background_jobs

--- a/tests/bluetooth/bsim/compile.source
+++ b/tests/bluetooth/bsim/compile.source
@@ -1,13 +1,15 @@
 # Copyright 2018 Oticon A/S
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bluetooth/bsim/sh_common.source
+
 function print_error_info(){
   echo -e "\033[0;31mFailure building ${app} ${conf_file} for ${BOARD}\033[0m\n\
   You can rebuild it with\n\
   ${cmake_cmd[@]} && ninja ${ninja_args}"
 }
 
-function compile(){
+function _compile(){
   : "${app:?app must be defined}"
 
   local app_root="${app_root:-${ZEPHYR_BASE}}"
@@ -62,4 +64,8 @@ function compile(){
 
   nm ${exe_name} | grep -v " [U|w] " | sort | cut -d" " -f1,3 > ${map_file_name}
   sed -i "1i $(wc -l ${map_file_name} | cut -d" " -f1)" ${map_file_name}
+}
+
+function compile(){
+  run_in_background _compile
 }

--- a/tests/bluetooth/bsim/host/compile.sh
+++ b/tests/bluetooth/bsim/host/compile.sh
@@ -20,38 +20,38 @@ mkdir -p ${WORK_DIR}
 
 source ${ZEPHYR_BASE}/tests/bluetooth/bsim/compile.source
 
-app=tests/bluetooth/bsim/host/adv/resume compile &
-app=tests/bluetooth/bsim/host/adv/resume conf_file=prj_2.conf compile &
-app=tests/bluetooth/bsim/host/adv/chain compile &
-app=tests/bluetooth/bsim/host/adv/periodic compile &
-app=tests/bluetooth/bsim/host/adv/periodic conf_file=prj_long_data.conf compile &
+app=tests/bluetooth/bsim/host/adv/resume compile
+app=tests/bluetooth/bsim/host/adv/resume conf_file=prj_2.conf compile
+app=tests/bluetooth/bsim/host/adv/chain compile
+app=tests/bluetooth/bsim/host/adv/periodic compile
+app=tests/bluetooth/bsim/host/adv/periodic conf_file=prj_long_data.conf compile
 
-app=tests/bluetooth/bsim/host/att/eatt conf_file=prj_collision.conf compile &
-app=tests/bluetooth/bsim/host/att/eatt conf_file=prj_multiple_conn.conf compile &
-app=tests/bluetooth/bsim/host/att/eatt conf_file=prj_autoconnect.conf compile &
-app=tests/bluetooth/bsim/host/att/eatt_notif conf_file=prj.conf compile &
-app=tests/bluetooth/bsim/host/att/mtu_update compile &
+app=tests/bluetooth/bsim/host/att/eatt conf_file=prj_collision.conf compile
+app=tests/bluetooth/bsim/host/att/eatt conf_file=prj_multiple_conn.conf compile
+app=tests/bluetooth/bsim/host/att/eatt conf_file=prj_autoconnect.conf compile
+app=tests/bluetooth/bsim/host/att/eatt_notif conf_file=prj.conf compile
+app=tests/bluetooth/bsim/host/att/mtu_update compile
 
-app=tests/bluetooth/bsim/host/gatt/caching compile &
-app=tests/bluetooth/bsim/host/gatt/general compile &
-app=tests/bluetooth/bsim/host/gatt/notify compile &
-app=tests/bluetooth/bsim/host/gatt/notify_multiple compile &
-app=tests/bluetooth/bsim/host/gatt/settings compile &
-app=tests/bluetooth/bsim/host/gatt/settings conf_file=prj_2.conf compile &
-app=tests/bluetooth/bsim/host/gatt/write compile &
+app=tests/bluetooth/bsim/host/gatt/caching compile
+app=tests/bluetooth/bsim/host/gatt/general compile
+app=tests/bluetooth/bsim/host/gatt/notify compile
+app=tests/bluetooth/bsim/host/gatt/notify_multiple compile
+app=tests/bluetooth/bsim/host/gatt/settings compile
+app=tests/bluetooth/bsim/host/gatt/settings conf_file=prj_2.conf compile
+app=tests/bluetooth/bsim/host/gatt/write compile
 
-app=tests/bluetooth/bsim/host/l2cap/general compile &
-app=tests/bluetooth/bsim/host/l2cap/userdata compile &
-app=tests/bluetooth/bsim/host/l2cap/stress compile &
+app=tests/bluetooth/bsim/host/l2cap/general compile
+app=tests/bluetooth/bsim/host/l2cap/userdata compile
+app=tests/bluetooth/bsim/host/l2cap/stress compile
 
-app=tests/bluetooth/bsim/host/misc/disable compile &
-app=tests/bluetooth/bsim/host/misc/multiple_id compile &
+app=tests/bluetooth/bsim/host/misc/disable compile
+app=tests/bluetooth/bsim/host/misc/multiple_id compile
 
-app=tests/bluetooth/bsim/host/privacy/central compile &
-app=tests/bluetooth/bsim/host/privacy/peripheral compile &
-app=tests/bluetooth/bsim/host/privacy/device compile &
+app=tests/bluetooth/bsim/host/privacy/central compile
+app=tests/bluetooth/bsim/host/privacy/peripheral compile
+app=tests/bluetooth/bsim/host/privacy/device compile
 
-app=tests/bluetooth/bsim/host/security/bond_overwrite_allowed compile &
-app=tests/bluetooth/bsim/host/security/bond_overwrite_denied compile &
+app=tests/bluetooth/bsim/host/security/bond_overwrite_allowed compile
+app=tests/bluetooth/bsim/host/security/bond_overwrite_denied compile
 
-wait
+wait_for_background_jobs

--- a/tests/bluetooth/bsim/ll/compile.sh
+++ b/tests/bluetooth/bsim/ll/compile.sh
@@ -20,26 +20,26 @@ mkdir -p ${WORK_DIR}
 
 source ${ZEPHYR_BASE}/tests/bluetooth/bsim/compile.source
 
-app=tests/bluetooth/bsim/ll/advx compile &
+app=tests/bluetooth/bsim/ll/advx compile
 
-app=tests/bluetooth/bsim/ll/conn conf_file=prj_split.conf compile &
-app=tests/bluetooth/bsim/ll/conn conf_file=prj_split_privacy.conf compile &
-app=tests/bluetooth/bsim/ll/conn conf_file=prj_split_low_lat.conf compile &
+app=tests/bluetooth/bsim/ll/conn conf_file=prj_split.conf compile
+app=tests/bluetooth/bsim/ll/conn conf_file=prj_split_privacy.conf compile
+app=tests/bluetooth/bsim/ll/conn conf_file=prj_split_low_lat.conf compile
 
-app=tests/bluetooth/bsim/ll/iso compile &
-app=tests/bluetooth/bsim/ll/iso conf_file=prj_vs_dp.conf compile &
+app=tests/bluetooth/bsim/ll/iso compile
+app=tests/bluetooth/bsim/ll/iso conf_file=prj_vs_dp.conf compile
 
 app=tests/bluetooth/bsim/ll/edtt/hci_test_app \
-  conf_file=prj_dut_llcp.conf compile &
+  conf_file=prj_dut_llcp.conf compile
 app=tests/bluetooth/bsim/ll/edtt/hci_test_app \
-  conf_file=prj_tst_llcp.conf compile &
+  conf_file=prj_tst_llcp.conf compile
 app=tests/bluetooth/bsim/ll/edtt/hci_test_app \
-  conf_file=prj_dut.conf compile &
+  conf_file=prj_dut.conf compile
 app=tests/bluetooth/bsim/ll/edtt/hci_test_app \
-  conf_file=prj_tst.conf compile &
+  conf_file=prj_tst.conf compile
 app=tests/bluetooth/bsim/ll/edtt/gatt_test_app \
-  conf_file=prj.conf compile &
+  conf_file=prj.conf compile
 app=tests/bluetooth/bsim/ll/edtt/gatt_test_app \
-  conf_file=prj_llcp.conf compile &
+  conf_file=prj_llcp.conf compile
 
-wait
+wait_for_background_jobs

--- a/tests/bluetooth/bsim/mesh/compile.sh
+++ b/tests/bluetooth/bsim/mesh/compile.sh
@@ -20,16 +20,16 @@ mkdir -p ${WORK_DIR}
 
 source ${ZEPHYR_BASE}/tests/bluetooth/bsim/compile.source
 
-app=tests/bluetooth/bsim/mesh compile &
-app=tests/bluetooth/bsim/mesh conf_overlay=overlay_low_lat.conf compile &
-app=tests/bluetooth/bsim/mesh conf_overlay=overlay_pst.conf compile &
-app=tests/bluetooth/bsim/mesh conf_overlay=overlay_gatt.conf compile &
-app=tests/bluetooth/bsim/mesh conf_file=prj_mesh1d1.conf compile &
+app=tests/bluetooth/bsim/mesh compile
+app=tests/bluetooth/bsim/mesh conf_overlay=overlay_low_lat.conf compile
+app=tests/bluetooth/bsim/mesh conf_overlay=overlay_pst.conf compile
+app=tests/bluetooth/bsim/mesh conf_overlay=overlay_gatt.conf compile
+app=tests/bluetooth/bsim/mesh conf_file=prj_mesh1d1.conf compile
 app=tests/bluetooth/bsim/mesh \
-  conf_file=prj_mesh1d1.conf conf_overlay=overlay_pst.conf compile &
+  conf_file=prj_mesh1d1.conf conf_overlay=overlay_pst.conf compile
 app=tests/bluetooth/bsim/mesh \
-  conf_file=prj_mesh1d1.conf conf_overlay=overlay_gatt.conf compile &
+  conf_file=prj_mesh1d1.conf conf_overlay=overlay_gatt.conf compile
 app=tests/bluetooth/bsim/mesh \
-  conf_file=prj_mesh1d1.conf conf_overlay=overlay_low_lat.conf compile &
+  conf_file=prj_mesh1d1.conf conf_overlay=overlay_low_lat.conf compile
 
-wait
+wait_for_background_jobs

--- a/tests/bluetooth/bsim/sh_common.source
+++ b/tests/bluetooth/bsim/sh_common.source
@@ -1,0 +1,16 @@
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+_process_ids="";
+
+function run_in_background(){
+  $@ & _process_ids="$_process_ids $!"
+}
+
+function wait_for_background_jobs(){
+  exit_code=0
+  for process_id in $_process_ids; do
+    wait $process_id || let "exit_code=$?"
+  done
+  exit $exit_code #the last exit code != 0
+}


### PR DESCRIPTION
After https://github.com/zephyrproject-rtos/zephyr/commit/1de363d9d5279e2c3d6021fecad41ffca96e09f1, compile.sh stopped failing on build
failures as failing jobs in the background would neither stop
the script nor have their status propagated.
Fix it.

Test that it works:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/4374456034/jobs/7653905690