### PR TITLE
Bluetooth: Mesh: Fix compilation issue in access.c

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1280,6 +1280,7 @@ config BT_MESH_COMP_PAGE_1
 config BT_MESH_MODEL_EXTENSION_LIST_SIZE
 	int "Model extensions list size"
 	depends on BT_MESH_COMP_PAGE_1
+	range 1 255
 	default 10
 	help
 	  This option specifies how many models relations can be saved.

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -79,7 +79,7 @@ static struct mod_relation mod_rel_list[MOD_REL_LIST_SIZE];
 
 #define MOD_REL_LIST_FOR_EACH(idx) \
 	for ((idx) = 0; \
-		(idx) < MOD_REL_LIST_SIZE && \
+		(idx) < ARRAY_SIZE(mod_rel_list) && \
 		!(mod_rel_list[(idx)].elem_base == 0 && \
 		  mod_rel_list[(idx)].idx_base == 0 && \
 		  mod_rel_list[(idx)].elem_ext == 0 && \
@@ -1437,7 +1437,7 @@ static int mod_rel_register(struct bt_mesh_model *base,
 	};
 	int i;
 
-	for (i = 0; i < MOD_REL_LIST_SIZE; i++) {
+	for (i = 0; i < ARRAY_SIZE(mod_rel_list); i++) {
 		if (mod_rel_list[i].elem_base == 0 &&
 			mod_rel_list[i].idx_base == 0 &&
 			mod_rel_list[i].elem_ext == 0 &&


### PR DESCRIPTION
This fixes warning generated by gcc-12 when MOD_REL_LIST_SIZE is zero.