### PR TITLE
samples: bluetooth: hci_spi: add nrf52dk_nrf52832 board support

### DIFF
--- a/samples/bluetooth/hci_spi/boards/nrf52dk_nrf52832.overlay
+++ b/samples/bluetooth/hci_spi/boards/nrf52dk_nrf52832.overlay
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi1_default_alt: spi1_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 0, 31)>,
+				<NRF_PSEL(SPIS_MOSI, 0, 30)>,
+				<NRF_PSEL(SPIS_MISO, 0, 29)>,
+				<NRF_PSEL(SPIS_CSN, 0, 28)>;
+		};
+	};
+};
+
+&spi1 {
+	compatible = "nordic,nrf-spis";
+	status = "okay";
+	def-char = <0x00>;
+	pinctrl-0 = <&spi1_default_alt>;
+	/delete-property/ pinctrl-1;
+	pinctrl-names = "default";
+
+	bt-hci@0 {
+		compatible = "zephyr,bt-hci-spi-slave";
+		reg = <0>;
+		irq-gpios = <&gpio0 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+	};
+};

--- a/samples/bluetooth/hci_spi/sample.yaml
+++ b/samples/bluetooth/hci_spi/sample.yaml
@@ -5,8 +5,9 @@ sample:
 tests:
   sample.bluetooth.hci_spi:
     harness: bluetooth
-    platform_allow: 96b_carbon_nrf51 nrf51dk_nrf51422
+    platform_allow: 96b_carbon_nrf51 nrf51dk_nrf51422 nrf52dk_nrf52832
     integration_platforms:
       - 96b_carbon_nrf51
       - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
     tags: bluetooth spi


### PR DESCRIPTION
Add nrf52dk_nrf52832 board support to bluetooth hci_spi sample.

SPI1 is used as bluetooth hci_spi slave.
Configured with a pin slave config and gpio P0.03 is output interrupt to communicate with the host board.