### PR TITLE
bluetooth: tester: Add nrf5340_hci_rpmsg.conf file

### DIFF
--- a/tests/bluetooth/tester/nrf5340_hci_rpmsg.conf
+++ b/tests/bluetooth/tester/nrf5340_hci_rpmsg.conf
@@ -1,0 +1,13 @@
+# Those have to be the same as in the controller (hci_rpmsg)
+CONFIG_BT_MAX_CONN=2
+CONFIG_BT_BUF_EVT_RX_COUNT=16
+CONFIG_BT_BUF_EVT_RX_SIZE=255
+CONFIG_BT_BUF_CMD_TX_SIZE=255
+CONFIG_BT_BUF_ACL_TX_SIZE=251
+
+# L2CAP SDU/PDU TX MTU
+CONFIG_BT_L2CAP_TX_MTU=247
+
+# The minimum value for this is
+# L2AP MPS + L2CAP header (4)
+CONFIG_BT_BUF_ACL_RX_SIZE=255


### PR DESCRIPTION
To apply when the hci_rpmsg controller with overlay nrf5340_cpunet_iso-bt_ll_sw_split.conf is used on the netcore.