### PR TITLE
Bluetooth: Host: Add missing include in bluetooth/gap.h

### DIFF
--- a/include/zephyr/bluetooth/gap.h
+++ b/include/zephyr/bluetooth/gap.h
@@ -15,6 +15,8 @@
 extern "C" {
 #endif
 
+#include <zephyr/sys/util_macro.h>
+
 /**
  * @brief Bluetooth Generic Access Profile defines and Assigned Numbers.
  * @defgroup bt_gap_defines Defines and Assigned Numbers


### PR DESCRIPTION
bluetooth/gap.h uses some utility macros. Include the relevant header to avoid users having to include it before including the GAP header.