### PR TITLE
drivers: memc: fix flexspi init priorities

### DIFF
--- a/drivers/memc/memc_mcux_flexspi_aps6408l.c
+++ b/drivers/memc/memc_mcux_flexspi_aps6408l.c
@@ -323,7 +323,7 @@ static int memc_flexspi_aps6408l_init(const struct device *dev)
 			      &memc_flexspi_aps6408l_data_##n,  \
 			      &memc_flexspi_aps6408l_config_##n,  \
 			      POST_KERNEL,			  \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			      CONFIG_MEMC_INIT_PRIORITY, \
 			      NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(MEMC_FLEXSPI_APS6408L)

--- a/drivers/memc/memc_mcux_flexspi_s27ks0641.c
+++ b/drivers/memc/memc_mcux_flexspi_s27ks0641.c
@@ -197,7 +197,7 @@ static int memc_flexspi_s27ks0641_init(const struct device *dev)
 			      &memc_flexspi_s27ks0641_data_##n,  \
 			      &memc_flexspi_s27ks0641_config_##n,  \
 			      POST_KERNEL,			  \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			      CONFIG_MEMC_INIT_PRIORITY, \
 			      NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(MEMC_FLEXSPI_S27KS0641)


### PR DESCRIPTION
Fix flexspi memc drivers init priorities