### PR TITLE
Atmel SAM: Introduce peripheral clock control

### DIFF
--- a/boards/arm/arduino_due/arduino_due-pinctrl.dtsi
+++ b/boards/arm/arduino_due/arduino_due-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2022-2023, Gerson Fernando Budke <nandojve@gmail.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -50,6 +50,13 @@
 		group1 {
 			pinmux = <PD5B_USART3_RXD>,
 				 <PD4B_USART3_TXD>;
+		};
+	};
+
+	pwm0_default: pwm0_default {
+		group1 {
+			pinmux = <PC4B_PWM_PWML1>,
+				 <PC5B_PWM_PWMH1>;
 		};
 	};
 };

--- a/boards/arm/arduino_due/arduino_due.dts
+++ b/boards/arm/arduino_due/arduino_due.dts
@@ -13,6 +13,7 @@
 		uart-0 = &uart;
 		i2c-0 = &twi0;
 		i2c-1 = &twi1;
+		pwm-0 = &pwm0;
 		led0 = &yellow_led;
 		watchdog0 = &wdt;
 	};
@@ -61,6 +62,13 @@
 	current-speed = <115200>;
 
 	pinctrl-0 = <&uart_default>;
+	pinctrl-names = "default";
+};
+
+&pwm0 {
+	status = "okay";
+
+	pinctrl-0 = <&pwm0_default>;
 	pinctrl-names = "default";
 };
 

--- a/boards/arm/sam4e_xpro/sam4e_xpro-pinctrl.dtsi
+++ b/boards/arm/sam4e_xpro/sam4e_xpro-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2022-2023, Gerson Fernando Budke <nandojve@gmail.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -72,6 +72,13 @@
 		group2 {
 			pinmux = <PA22A_USART1_TXD>,
 				 <PA25A_USART1_CTS>;
+		};
+	};
+
+	pwm0_default: pwm0_default {
+		group1 {
+			pinmux = <PD20A_PWM_PWMH0>,
+				 <PD24A_PWM_PWML0>;
 		};
 	};
 };

--- a/boards/arm/sam4e_xpro/sam4e_xpro-pinctrl.dtsi
+++ b/boards/arm/sam4e_xpro/sam4e_xpro-pinctrl.dtsi
@@ -6,6 +6,19 @@
 #include <dt-bindings/pinctrl/sam4eXe-pinctrl.h>
 
 &pinctrl {
+	afec0_default: afec0_default {
+		group1 {
+			pinmux = <PA17X_AFEC0_AD0>,
+				 <PC13X_AFEC0_AD6>;
+		};
+	};
+	afec1_default: afec1_default {
+		group1 {
+			pinmux = <PB2X_AFEC1_AD0>,
+				 <PB3X_AFEC1_AD1>;
+		};
+	};
+
 	gmac_mii: gmac_mii {
 		group1 {
 			pinmux = <PD0A_GMAC_GTXCK>,

--- a/boards/arm/sam4e_xpro/sam4e_xpro.dts
+++ b/boards/arm/sam4e_xpro/sam4e_xpro.dts
@@ -126,6 +126,20 @@
 	clock-frequency = <120000000>;
 };
 
+&afec0 {
+	status = "okay";
+
+	pinctrl-0 = <&afec0_default>;
+	pinctrl-names = "default";
+};
+
+&afec1 {
+	status = "okay";
+
+	pinctrl-0 = <&afec1_default>;
+	pinctrl-names = "default";
+};
+
 &twi0 {
 	status = "okay";
 

--- a/boards/arm/sam4e_xpro/sam4e_xpro.dts
+++ b/boards/arm/sam4e_xpro/sam4e_xpro.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Gerson Fernando Budke
+ * Copyright (c) 2019-2023 Gerson Fernando Budke
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,6 +15,7 @@
 
 	aliases {
 		i2c-0 = &twi0;
+		pwm-0 = &pwm0;
 		led0 = &yellow_led_1;
 		sw0 = &user_button;
 		wdog = &wdt;
@@ -184,6 +185,13 @@
 	status = "okay";
 
 	pinctrl-0 = <&mdio_default>;
+	pinctrl-names = "default";
+};
+
+&pwm0 {
+	status = "okay";
+
+	pinctrl-0 = <&pwm0_default>;
 	pinctrl-names = "default";
 };
 

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained.dts
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained.dts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 Piotr Mienkowski
  * Copyright (c) 2017 Justin Watson
- * Copyright (c) 2020 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2020-2023 Gerson Fernando Budke <nandojve@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,4 +14,12 @@
 / {
 	model = "Atmel SAM E70 Xplained board";
 	compatible = "atmel,sam_e70_xplained", "atmel,same70q21", "atmel,same70";
+};
+
+&tc0 {
+	status = "okay";
+	compatible = "atmel,sam-tc-qdec";
+
+	pinctrl-0 = <&tc0_qdec_default>;
+	pinctrl-names = "default";
 };

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -7,6 +7,7 @@
 
 #include <zephyr/drivers/can.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include <soc.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -20,8 +21,8 @@ LOG_MODULE_REGISTER(can_sam, CONFIG_CAN_LOG_LEVEL);
 
 struct can_sam_config {
 	void (*config_irq)(void);
+	const struct atmel_sam_pmc_config clock_cfg;
 	const struct pinctrl_dev_config *pcfg;
-	uint8_t pmc_id;
 	int divider;
 };
 
@@ -44,7 +45,9 @@ static void can_sam_clock_enable(const struct can_sam_config *sam_cfg)
 	REG_PMC_PCK5 = PMC_PCK_CSS_UPLL_CLK | PMC_PCK_PRES(sam_cfg->divider - 1);
 	PMC->PMC_SCER |= PMC_SCER_PCK5;
 
-	soc_pmc_peripheral_enable(sam_cfg->pmc_id);
+	/* Enable CAN clock in PMC */
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&sam_cfg->clock_cfg);
 }
 
 static int can_sam_init(const struct device *dev)
@@ -136,7 +139,7 @@ static void config_can_##inst##_irq(void)                                       
 
 #define CAN_SAM_CFG_INST(inst)						\
 	static const struct can_sam_config can_sam_cfg_##inst = {	\
-		.pmc_id = DT_INST_PROP(inst, peripheral_id),		\
+		.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(inst),		\
 		.divider = DT_INST_PROP(inst, divider),			\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),		\
 		.config_irq = config_can_##inst##_irq,			\

--- a/drivers/clock_control/CMakeLists.txt
+++ b/drivers/clock_control/CMakeLists.txt
@@ -21,6 +21,7 @@ zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_NRF                 clock_cont
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_NRF_DRIVER_CALIBRATION nrf_clock_calibration.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_RV32M1_PCC          clock_control_rv32m1_pcc.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_INFINEON_CAT1       clock_control_ifx_cat1.c)
+zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_SAM                 clock_control_sam_pmc.c)
 
 
 if(CONFIG_CLOCK_CONTROL_STM32_CUBE)

--- a/drivers/clock_control/Kconfig
+++ b/drivers/clock_control/Kconfig
@@ -68,4 +68,6 @@ source "drivers/clock_control/Kconfig.aspeed"
 
 source "drivers/clock_control/Kconfig.gd32"
 
+source "drivers/clock_control/Kconfig.sam"
+
 endif # CLOCK_CONTROL

--- a/drivers/clock_control/Kconfig.sam
+++ b/drivers/clock_control/Kconfig.sam
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Gerson Fernando Budke <nandojve@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config CLOCK_CONTROL_SAM
+	bool "Atmel SAM clock control"
+	default y
+	depends on DT_HAS_ATMEL_SAM_PMC_ENABLED
+	help
+	  Enable driver for Atmel SAM Clock Control.

--- a/drivers/clock_control/clock_control_sam_pmc.c
+++ b/drivers/clock_control/clock_control_sam_pmc.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2023 Gerson Fernando Budke <nandojve@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT atmel_sam_pmc
+
+#include <stdint.h>
+
+#include <zephyr/arch/cpu.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(clock_control, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
+
+static int atmel_sam_clock_control_on(const struct device *dev,
+				      clock_control_subsys_t sys)
+{
+	ARG_UNUSED(dev);
+
+	const struct atmel_sam_pmc_config *cfg = (const struct atmel_sam_pmc_config *)sys;
+
+	if (cfg == NULL) {
+		LOG_ERR("The PMC config can not be NULL.");
+		return -ENXIO;
+	}
+
+	LOG_DBG("Type: %x, Id: %d", cfg->clock_type, cfg->peripheral_id);
+
+	switch (cfg->clock_type) {
+	case PMC_TYPE_PERIPHERAL:
+		soc_pmc_peripheral_enable(cfg->peripheral_id);
+		break;
+	default:
+		LOG_ERR("The PMC clock type is not implemented.");
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static int atmel_sam_clock_control_off(const struct device *dev,
+				       clock_control_subsys_t sys)
+{
+	ARG_UNUSED(dev);
+
+	const struct atmel_sam_pmc_config *cfg = (const struct atmel_sam_pmc_config *)sys;
+
+	if (cfg == NULL) {
+		LOG_ERR("The PMC config can not be NULL.");
+		return -ENXIO;
+	}
+
+	LOG_DBG("Type: %x, Id: %d", cfg->clock_type, cfg->peripheral_id);
+
+	switch (cfg->clock_type) {
+	case PMC_TYPE_PERIPHERAL:
+		soc_pmc_peripheral_disable(cfg->peripheral_id);
+		break;
+	default:
+		LOG_ERR("The PMC clock type is not implemented.");
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static int atmel_sam_clock_control_get_rate(const struct device *dev,
+					    clock_control_subsys_t sys,
+					    uint32_t *rate)
+{
+	ARG_UNUSED(dev);
+
+	const struct atmel_sam_pmc_config *cfg = (const struct atmel_sam_pmc_config *)sys;
+
+	if (cfg == NULL) {
+		LOG_ERR("The PMC config can not be NULL.");
+		return -ENXIO;
+	}
+
+	LOG_DBG("Type: %x, Id: %d", cfg->clock_type, cfg->peripheral_id);
+
+	switch (cfg->clock_type) {
+	case PMC_TYPE_PERIPHERAL:
+		*rate = SOC_ATMEL_SAM_MCK_FREQ_HZ;
+		break;
+	default:
+		LOG_ERR("The PMC clock type is not implemented.");
+		return -ENODEV;
+	}
+
+	LOG_DBG("Rate: %d", *rate);
+
+	return 0;
+}
+
+static enum clock_control_status
+atmel_sam_clock_control_get_status(const struct device *dev,
+				   clock_control_subsys_t sys)
+{
+	ARG_UNUSED(dev);
+
+	const struct atmel_sam_pmc_config *cfg = (const struct atmel_sam_pmc_config *)sys;
+	enum clock_control_status status;
+
+	if (cfg == NULL) {
+		LOG_ERR("The PMC config can not be NULL.");
+		return -ENXIO;
+	}
+
+	LOG_DBG("Type: %x, Id: %d", cfg->clock_type, cfg->peripheral_id);
+
+	switch (cfg->clock_type) {
+	case PMC_TYPE_PERIPHERAL:
+		status = soc_pmc_peripheral_is_enabled(cfg->peripheral_id) > 0
+		       ? CLOCK_CONTROL_STATUS_ON
+		       : CLOCK_CONTROL_STATUS_OFF;
+		break;
+	default:
+		LOG_ERR("The PMC clock type is not implemented.");
+		return -ENODEV;
+	}
+
+	return status;
+}
+
+static struct clock_control_driver_api atmel_sam_clock_control_api = {
+	.on = atmel_sam_clock_control_on,
+	.off = atmel_sam_clock_control_off,
+	.get_rate = atmel_sam_clock_control_get_rate,
+	.get_status = atmel_sam_clock_control_get_status,
+};
+
+static int atmel_sam_clock_control_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return 0;
+}
+
+DEVICE_DT_INST_DEFINE(0, atmel_sam_clock_control_init,
+		      NULL,
+		      NULL,
+		      NULL,
+		      PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
+		      &atmel_sam_clock_control_api);

--- a/drivers/counter/counter_sam_tc.c
+++ b/drivers/counter/counter_sam_tc.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Piotr Mienkowski
+ * Copyright (c) 2023, Gerson Fernando Budke
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -31,6 +32,7 @@
 #include <soc.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
@@ -51,11 +53,11 @@ struct counter_sam_dev_cfg {
 	uint32_t reg_cmr;
 	uint32_t reg_rc;
 	void (*irq_config_func)(const struct device *dev);
+	const struct atmel_sam_pmc_config clock_cfg[TCCHANNEL_NUMBER];
 	const struct pinctrl_dev_config *pcfg;
 	uint8_t clk_sel;
 	bool nodivclk;
 	uint8_t tc_chan_num;
-	uint8_t periph_id[TCCHANNEL_NUMBER];
 };
 
 struct counter_sam_alarm_data {
@@ -322,7 +324,8 @@ static int counter_sam_initialize(const struct device *dev)
 	}
 
 	/* Enable channel's clock */
-	soc_pmc_peripheral_enable(dev_cfg->periph_id[dev_cfg->tc_chan_num]);
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&dev_cfg->clock_cfg[dev_cfg->tc_chan_num]);
 
 	/* Clock and Mode Selection */
 	tc_ch->TC_CMR = dev_cfg->reg_cmr;
@@ -384,7 +387,7 @@ static const struct counter_sam_dev_cfg counter_##n##_sam_config = { \
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
 	.nodivclk = DT_INST_PROP(n, nodivclk),			\
 	.tc_chan_num = DT_INST_PROP_OR(n, channel, 0),		\
-	.periph_id = DT_INST_PROP(n, peripheral_id),		\
+	.clock_cfg = SAM_DT_INST_CLOCKS_PMC_CFG(n),		\
 };								\
 								\
 static struct counter_sam_dev_data counter_##n##_sam_data;	\

--- a/drivers/dac/dac_sam.c
+++ b/drivers/dac/dac_sam.c
@@ -19,6 +19,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/dac.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
@@ -33,10 +34,10 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_SOC_SERIES_SAME70) ||
 /* Device constant configuration parameters */
 struct dac_sam_dev_cfg {
 	Dacc *regs;
+	const struct atmel_sam_pmc_config clock_cfg;
 	const struct pinctrl_dev_config *pcfg;
 	void (*irq_config)(void);
 	uint8_t irq_id;
-	uint8_t periph_id;
 	uint8_t prescaler;
 };
 
@@ -133,7 +134,8 @@ static int dac_sam_init(const struct device *dev)
 	}
 
 	/* Enable DAC clock in PMC */
-	soc_pmc_peripheral_enable(dev_cfg->periph_id);
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&dev_cfg->clock_cfg);
 
 	retval = pinctrl_apply_state(dev_cfg->pcfg, PINCTRL_STATE_DEFAULT);
 	if (retval < 0) {
@@ -171,7 +173,7 @@ static const struct dac_sam_dev_cfg dacc_sam_config = {
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 	.irq_id = DT_INST_IRQN(0),
 	.irq_config = dacc_irq_config,
-	.periph_id = DT_INST_PROP(0, peripheral_id),
+	.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(0),
 	.prescaler = DT_INST_PROP(0, prescaler),
 };
 

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <soc.h>
 #include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include "dma_sam_xdmac.h"
 
 #define LOG_LEVEL CONFIG_DMA_LOG_LEVEL
@@ -38,7 +39,7 @@ struct sam_xdmac_channel_cfg {
 struct sam_xdmac_dev_cfg {
 	Xdmac *regs;
 	void (*irq_config)(void);
-	uint8_t periph_id;
+	const struct atmel_sam_pmc_config clock_cfg;
 	uint8_t irq_id;
 };
 
@@ -357,8 +358,9 @@ static int sam_xdmac_initialize(const struct device *dev)
 	/* Configure interrupts */
 	dev_cfg->irq_config();
 
-	/* Enable module's clock */
-	soc_pmc_peripheral_enable(dev_cfg->periph_id);
+	/* Enable XDMAC clock in PMC */
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&dev_cfg->clock_cfg);
 
 	/* Disable all channels */
 	xdmac->XDMAC_GD = UINT32_MAX;
@@ -391,7 +393,7 @@ static void dma0_sam_irq_config(void)
 static const struct sam_xdmac_dev_cfg dma0_sam_config = {
 	.regs = (Xdmac *)DT_INST_REG_ADDR(0),
 	.irq_config = dma0_sam_irq_config,
-	.periph_id = DT_INST_PROP(0, peripheral_id),
+	.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(0),
 	.irq_id = DT_INST_IRQN(0),
 };
 

--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Aurelien Jarno
+ * Copyright (c) 2023 Gerson Fernando Budke
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +9,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include <errno.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
@@ -165,8 +167,10 @@ static int entropy_sam_init(const struct device *dev)
 	/* Enable the TRNG */
 	trng->CTRLA.bit.ENABLE = 1;
 #else
-	/* Enable the user interface clock */
-	soc_pmc_peripheral_enable(DT_INST_PROP(0, peripheral_id));
+	/* Enable TRNG in PMC */
+	const struct atmel_sam_pmc_config clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(0);
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&clock_cfg);
 
 	/* Enable the TRNG */
 	trng->TRNG_CR = TRNG_CR_KEY_PASSWD | TRNG_CR_ENABLE;

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016 Piotr Mienkowski
  * Copyright (c) 2018 Antmicro Ltd
+ * Copyright (c) 2023 Gerson Fernando Budke
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -43,6 +44,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <ethernet/eth_stats.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include <soc.h>
 #include "eth_sam_gmac_priv.h"
 
@@ -1776,8 +1778,8 @@ static int eth_initialize(const struct device *dev)
 
 #ifdef CONFIG_SOC_FAMILY_SAM
 	/* Enable GMAC module's clock */
-	soc_pmc_peripheral_enable(cfg->periph_id);
-
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&cfg->clock_cfg);
 #else
 	/* Enable MCLK clock on GMAC */
 	MCLK->AHBMASK.reg |= MCLK_AHBMASK_GMAC;
@@ -2212,7 +2214,7 @@ static const struct eth_sam_dev_cfg eth0_config = {
 	.regs = (Gmac *)DT_INST_REG_ADDR(0),
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 #ifdef CONFIG_SOC_FAMILY_SAM
-	.periph_id = DT_INST_PROP_OR(0, peripheral_id, 0),
+	.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(0),
 #endif
 	.config_func = eth0_irq_config,
 #if DT_NODE_EXISTS(DT_INST_CHILD(0, phy))

--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -261,10 +261,10 @@ struct gmac_queue {
 /* Device constant configuration parameters */
 struct eth_sam_dev_cfg {
 	Gmac *regs;
-	const struct pinctrl_dev_config *pcfg;
 #ifdef CONFIG_SOC_FAMILY_SAM
-	uint32_t periph_id;
+	const struct atmel_sam_pmc_config clock_cfg;
 #endif
+	const struct pinctrl_dev_config *pcfg;
 	void (*config_func)(void);
 	const struct device *phy_dev;
 };

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Justin Watson
+ * Copyright (c) 2023 Gerson Fernando Budke
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,6 +13,7 @@
 #include <zephyr/init.h>
 #include <soc.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include <zephyr/dt-bindings/gpio/atmel-sam-gpio.h>
 #include <zephyr/irq.h>
 
@@ -24,7 +26,8 @@ struct gpio_sam_config {
 	struct gpio_driver_config common;
 	Pio *regs;
 	config_func_t config_func;
-	uint32_t periph_id;
+
+	const struct atmel_sam_pmc_config clock_cfg;
 };
 
 struct gpio_sam_runtime {
@@ -305,8 +308,9 @@ int gpio_sam_init(const struct device *dev)
 {
 	const struct gpio_sam_config * const cfg = dev->config;
 
-	/* The peripheral clock must be enabled for the interrupts to work. */
-	soc_pmc_peripheral_enable(cfg->periph_id);
+	/* Enable GPIO clock in PMC. This is necessary to enable interrupts */
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&cfg->clock_cfg);
 
 	cfg->config_func(dev);
 
@@ -321,7 +325,7 @@ int gpio_sam_init(const struct device *dev)
 			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),\
 		},							\
 		.regs = (Pio *)DT_INST_REG_ADDR(n),			\
-		.periph_id = DT_INST_PROP(n, peripheral_id),		\
+		.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(n),		\
 		.config_func = port_##n##_sam_config_func,		\
 	};								\
 									\

--- a/drivers/gpio/gpio_sam4l.c
+++ b/drivers/gpio/gpio_sam4l.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018 Justin Watson
- * Copyright (c) 2020 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2020-2023 Gerson Fernando Budke <nandojve@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +13,7 @@
 #include <zephyr/init.h>
 #include <soc.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include <zephyr/irq.h>
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
@@ -24,7 +25,8 @@ struct gpio_sam_config {
 	struct gpio_driver_config common;
 	Gpio *regs;
 	config_func_t config_func;
-	uint32_t periph_id;
+
+	const struct atmel_sam_pmc_config clock_cfg;
 };
 
 struct gpio_sam_runtime {
@@ -230,7 +232,9 @@ int gpio_sam_init(const struct device *dev)
 {
 	const struct gpio_sam_config * const cfg = dev->config;
 
-	soc_pmc_peripheral_enable(cfg->periph_id);
+	/* Enable GPIO clock in PM */
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&cfg->clock_cfg);
 
 	cfg->config_func(dev);
 
@@ -254,7 +258,7 @@ int gpio_sam_init(const struct device *dev)
 			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),\
 		},							\
 		.regs = (Gpio *)DT_INST_REG_ADDR(n),			\
-		.periph_id = DT_INST_PROP(n, peripheral_id),		\
+		.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(n),		\
 		.config_func = port_##n##_sam_config_func,		\
 	};								\
 									\

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -89,8 +89,7 @@ config HWINFO_RPI_PICO
 config HWINFO_SAM_RSTC
 	bool "Atmel SAM reset cause"
 	default y
-	depends on SOC_SERIES_SAM4S || SOC_SERIES_SAME70 || \
-		   SOC_SERIES_SAMV71
+	depends on SOC_FAMILY_SAM && !SOC_SERIES_SAM4L
 	help
 	  Enable Atmel SAM reset cause hwinfo driver.
 

--- a/drivers/hwinfo/hwinfo_sam_rstc.c
+++ b/drivers/hwinfo/hwinfo_sam_rstc.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Basalte bv
+ * Copyright (c) 2023 Gerson Fernando Budke
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,8 +9,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/hwinfo.h>
-#include <zephyr/init.h>
-#include <soc.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 	     "No atmel,sam-rstc compatible device found");
@@ -56,12 +56,14 @@ int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
 static int hwinfo_rstc_init(const struct device *dev)
 {
 	Rstc *regs = (Rstc *)DT_INST_REG_ADDR(0);
+	const struct atmel_sam_pmc_config clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(0);
 	uint32_t mode;
 
 	ARG_UNUSED(dev);
 
 	/* Enable RSTC in PMC */
-	soc_pmc_peripheral_enable(DT_INST_PROP(0, peripheral_id));
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&clock_cfg);
 
 	/* Get current Mode Register value */
 	mode = regs->RSTC_MR;

--- a/drivers/i2c/i2c_sam4l_twim.c
+++ b/drivers/i2c/i2c_sam4l_twim.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Piotr Mienkowski
- * Copyright (c) 2020 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2020-2023 Gerson Fernando Budke <nandojve@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,6 +23,7 @@
 #include <soc.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -66,8 +67,8 @@ struct i2c_sam_twim_dev_cfg {
 	Twim *regs;
 	void (*irq_config)(void);
 	uint32_t bitrate;
+	const struct atmel_sam_pmc_config clock_cfg;
 	const struct pinctrl_dev_config *pcfg;
-	uint8_t periph_id;
 	uint8_t irq_id;
 
 	uint8_t std_clk_slew_lim;
@@ -558,8 +559,9 @@ static int i2c_sam_twim_initialize(const struct device *dev)
 		return ret;
 	}
 
-	/* Enable module's clock */
-	soc_pmc_peripheral_enable(cfg->periph_id);
+	/* Enable TWIM clock in PM */
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&cfg->clock_cfg);
 
 	/* Enable the module*/
 	twim->CR = TWIM_CR_MEN;
@@ -614,7 +616,7 @@ static const struct i2c_driver_api i2c_sam_twim_driver_api = {
 	static const struct i2c_sam_twim_dev_cfg i2c##n##_sam_config = {\
 		.regs = (Twim *)DT_INST_REG_ADDR(n),			\
 		.irq_config = i2c##n##_sam_irq_config,			\
-		.periph_id = DT_INST_PROP(n, peripheral_id),		\
+		.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(n),		\
 		.irq_id = DT_INST_IRQN(n),				\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
 		.bitrate = DT_INST_PROP(n, clock_frequency),		\

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017 Piotr Mienkowski
+ * Copyright (c) 2023 Gerson Fernando Budke
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,6 +24,7 @@
 #include <soc.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -43,8 +45,8 @@ struct i2c_sam_twi_dev_cfg {
 	Twi *regs;
 	void (*irq_config)(void);
 	uint32_t bitrate;
+	const struct atmel_sam_pmc_config clock_cfg;
 	const struct pinctrl_dev_config *pcfg;
-	uint8_t periph_id;
 	uint8_t irq_id;
 };
 
@@ -325,8 +327,9 @@ static int i2c_sam_twi_initialize(const struct device *dev)
 		return ret;
 	}
 
-	/* Enable module's clock */
-	soc_pmc_peripheral_enable(dev_cfg->periph_id);
+	/* Enable TWI clock in PMC */
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&dev_cfg->clock_cfg);
 
 	/* Reset TWI module */
 	twi->TWI_CR = TWI_CR_SWRST;
@@ -364,7 +367,7 @@ static const struct i2c_driver_api i2c_sam_twi_driver_api = {
 	static const struct i2c_sam_twi_dev_cfg i2c##n##_sam_config = {	\
 		.regs = (Twi *)DT_INST_REG_ADDR(n),			\
 		.irq_config = i2c##n##_sam_irq_config,			\
-		.periph_id = DT_INST_PROP(n, peripheral_id),		\
+		.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(n),		\
 		.irq_id = DT_INST_IRQN(n),				\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
 		.bitrate = DT_INST_PROP(n, clock_frequency),		\

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017 Piotr Mienkowski
+ * Copyright (c) 2023 Gerson Fernando Budke
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,6 +22,7 @@
 #include <soc.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -43,8 +45,8 @@ struct i2c_sam_twihs_dev_cfg {
 	Twihs *regs;
 	void (*irq_config)(void);
 	uint32_t bitrate;
+	const struct atmel_sam_pmc_config clock_cfg;
 	const struct pinctrl_dev_config *pcfg;
-	uint8_t periph_id;
 	uint8_t irq_id;
 };
 
@@ -296,8 +298,9 @@ static int i2c_sam_twihs_initialize(const struct device *dev)
 		return ret;
 	}
 
-	/* Enable module's clock */
-	soc_pmc_peripheral_enable(dev_cfg->periph_id);
+	/* Enable TWIHS clock in PMC */
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&dev_cfg->clock_cfg);
 
 	/* Reset the module */
 	twihs->TWIHS_CR = TWIHS_CR_SWRST;
@@ -335,7 +338,7 @@ static const struct i2c_driver_api i2c_sam_twihs_driver_api = {
 	static const struct i2c_sam_twihs_dev_cfg i2c##n##_sam_config = {\
 		.regs = (Twihs *)DT_INST_REG_ADDR(n),			\
 		.irq_config = i2c##n##_sam_irq_config,			\
-		.periph_id = DT_INST_PROP(n, peripheral_id),		\
+		.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(n),		\
 		.irq_id = DT_INST_IRQN(n),				\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
 		.bitrate = DT_INST_PROP(n, clock_frequency),		\

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -28,6 +28,7 @@
 #include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/i2s.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include <soc.h>
 
 #define LOG_DOMAIN dev_i2s_sam_ssc
@@ -69,8 +70,8 @@ struct i2s_sam_dev_cfg {
 	const struct device *dev_dma;
 	Ssc *regs;
 	void (*irq_config)(void);
+	const struct atmel_sam_pmc_config clock_cfg;
 	const struct pinctrl_dev_config *pcfg;
-	uint8_t periph_id;
 	uint8_t irq_id;
 };
 
@@ -974,8 +975,9 @@ static int i2s_sam_initialize(const struct device *dev)
 		return ret;
 	}
 
-	/* Enable module's clock */
-	soc_pmc_peripheral_enable(dev_cfg->periph_id);
+	/* Enable SSC clock in PMC */
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&dev_cfg->clock_cfg);
 
 	/* Reset the module, disable receiver & transmitter */
 	ssc->SSC_CR = SSC_CR_RXDIS | SSC_CR_TXDIS | SSC_CR_SWRST;
@@ -1015,7 +1017,7 @@ static const struct i2s_sam_dev_cfg i2s0_sam_config = {
 	.dev_dma = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(0, tx)),
 	.regs = (Ssc *)DT_INST_REG_ADDR(0),
 	.irq_config = i2s0_sam_irq_config,
-	.periph_id = DT_INST_PROP(0, peripheral_id),
+	.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(0),
 	.irq_id = DT_INST_IRQN(0),
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };

--- a/drivers/memc/memc_sam_smc.c
+++ b/drivers/memc/memc_sam_smc.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include <soc.h>
 
 #include <zephyr/logging/log.h>
@@ -23,11 +24,9 @@ struct memc_smc_bank_config {
 
 struct memc_smc_config {
 	Smc *regs;
-	uint32_t periph_id;
-
 	size_t banks_len;
 	const struct memc_smc_bank_config *banks;
-
+	const struct atmel_sam_pmc_config clock_cfg;
 	const struct pinctrl_dev_config *pcfg;
 };
 
@@ -37,7 +36,9 @@ static int memc_smc_init(const struct device *dev)
 	const struct memc_smc_config *cfg = dev->config;
 	SmcCs_number *bank;
 
-	soc_pmc_peripheral_enable(cfg->periph_id);
+	/* Enable SMC clock in PMC */
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&cfg->clock_cfg);
 
 	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
@@ -93,7 +94,7 @@ static int memc_smc_init(const struct device *dev)
 	PINCTRL_DT_INST_DEFINE(inst);							\
 	static const struct memc_smc_config smc_config_##inst = {			\
 		.regs = (Smc *)DT_INST_REG_ADDR(inst),					\
-		.periph_id = DT_INST_PROP(inst, peripheral_id),				\
+		.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(inst),				\
 		.banks_len = ARRAY_SIZE(smc_bank_config_##inst),			\
 		.banks = smc_bank_config_##inst,					\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),				\

--- a/drivers/pinctrl/pinctrl_sam.c
+++ b/drivers/pinctrl/pinctrl_sam.c
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2022, Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2022-2023, Gerson Fernando Budke <nandojve@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include <soc_gpio.h>
 
 /** Utility macro that expands to the GPIO port address if it exists */
@@ -13,9 +14,9 @@
 		   (DT_REG_ADDR(DT_NODELABEL(nodelabel)),))
 
 /** Utility macro that expands to the GPIO Peripheral ID if it exists */
-#define SAM_PORT_PERIPH_ID_OR_NONE(nodelabel)					\
+#define SAM_PORT_CLOCKS_OR_NONE(nodelabel)					\
 	IF_ENABLED(DT_NODE_EXISTS(DT_NODELABEL(nodelabel)),			\
-		   (DT_PROP(DT_NODELABEL(nodelabel), peripheral_id),))
+		   (SAM_DT_CLOCK_PMC_CFG(0, DT_NODELABEL(nodelabel)),))
 
 /** SAM port addresses */
 static const uint32_t sam_port_addrs[] = {
@@ -33,19 +34,19 @@ static const uint32_t sam_port_addrs[] = {
 #endif
 };
 
-/** SAM port peripheral id */
-static const uint32_t sam_port_periph_id[] = {
+/** SAM port clocks */
+static const struct atmel_sam_pmc_config sam_port_clocks[] = {
 #ifdef ID_GPIO
-	SAM_PORT_PERIPH_ID_OR_NONE(gpioa)
-	SAM_PORT_PERIPH_ID_OR_NONE(gpiob)
-	SAM_PORT_PERIPH_ID_OR_NONE(gpioc)
+	SAM_PORT_CLOCKS_OR_NONE(gpioa)
+	SAM_PORT_CLOCKS_OR_NONE(gpiob)
+	SAM_PORT_CLOCKS_OR_NONE(gpioc)
 #else
-	SAM_PORT_PERIPH_ID_OR_NONE(pioa)
-	SAM_PORT_PERIPH_ID_OR_NONE(piob)
-	SAM_PORT_PERIPH_ID_OR_NONE(pioc)
-	SAM_PORT_PERIPH_ID_OR_NONE(piod)
-	SAM_PORT_PERIPH_ID_OR_NONE(pioe)
-	SAM_PORT_PERIPH_ID_OR_NONE(piof)
+	SAM_PORT_CLOCKS_OR_NONE(pioa)
+	SAM_PORT_CLOCKS_OR_NONE(piob)
+	SAM_PORT_CLOCKS_OR_NONE(pioc)
+	SAM_PORT_CLOCKS_OR_NONE(piod)
+	SAM_PORT_CLOCKS_OR_NONE(pioe)
+	SAM_PORT_CLOCKS_OR_NONE(piof)
 #endif
 };
 
@@ -63,7 +64,7 @@ static void pinctrl_configure_pin(pinctrl_soc_pin_t pin)
 #else
 	soc_pin.regs = (Pio *) sam_port_addrs[port_idx];
 #endif
-	soc_pin.periph_id = sam_port_periph_id[port_idx];
+	soc_pin.periph_id = sam_port_clocks[port_idx].peripheral_id;
 	soc_pin.mask = 1 << SAM_PINMUX_PIN_GET(pin);
 	soc_pin.flags = SAM_PINCTRL_FLAGS_GET(pin) << SOC_GPIO_FLAGS_POS;
 

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include <soc.h>
 
 #include <zephyr/logging/log.h>
@@ -23,8 +24,8 @@ LOG_MODULE_REGISTER(pwm_sam, CONFIG_PWM_LOG_LEVEL);
 
 struct sam_pwm_config {
 	Pwm *regs;
+	const struct atmel_sam_pmc_config clock_cfg;
 	const struct pinctrl_dev_config *pcfg;
-	uint32_t id;
 	uint8_t prescaler;
 	uint8_t divider;
 };
@@ -96,15 +97,15 @@ static int sam_pwm_init(const struct device *dev)
 	const struct sam_pwm_config *config = dev->config;
 
 	Pwm * const pwm = config->regs;
-	uint32_t id = config->id;
 	uint8_t prescaler = config->prescaler;
 	uint8_t divider = config->divider;
 	int retval;
 
 	/* FIXME: way to validate prescaler & divider */
 
-	/* Enable the PWM peripheral */
-	soc_pmc_peripheral_enable(id);
+	/* Enable PWM clock in PMC */
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&config->clock_cfg);
 
 	retval = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	if (retval < 0) {
@@ -127,7 +128,7 @@ static const struct pwm_driver_api sam_pwm_driver_api = {
 	static const struct sam_pwm_config sam_pwm_config_##inst = {	\
 		.regs = (Pwm *)DT_INST_REG_ADDR(inst),			\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),		\
-		.id = DT_INST_PROP(inst, peripheral_id),		\
+		.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(inst),		\
 		.prescaler = DT_INST_PROP(inst, prescaler),		\
 		.divider = DT_INST_PROP(inst, divider),			\
 	};								\

--- a/drivers/sensor/qdec_sam/qdec_sam.c
+++ b/drivers/sensor/qdec_sam/qdec_sam.c
@@ -18,6 +18,7 @@
 #include <soc.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(qdec_sam, CONFIG_SENSOR_LOG_LEVEL);
@@ -25,8 +26,8 @@ LOG_MODULE_REGISTER(qdec_sam, CONFIG_SENSOR_LOG_LEVEL);
 /* Device constant configuration parameters */
 struct qdec_sam_dev_cfg {
 	Tc *regs;
+	const struct atmel_sam_pmc_config clock_cfg[TCCHANNEL_NUMBER];
 	const struct pinctrl_dev_config *pcfg;
-	uint8_t periph_id[TCCHANNEL_NUMBER];
 };
 
 /* Device run time data */
@@ -103,9 +104,10 @@ static int qdec_sam_initialize(const struct device *dev)
 		return retval;
 	}
 
-	for (int i = 0; i < ARRAY_SIZE(dev_cfg->periph_id); i++) {
-		/* Enable module's clock */
-		soc_pmc_peripheral_enable(dev_cfg->periph_id[i]);
+	for (int i = 0; i < ARRAY_SIZE(dev_cfg->clock_cfg); i++) {
+		/* Enable TC clock in PMC */
+		(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+				       (clock_control_subsys_t *)&dev_cfg->clock_cfg[i]);
 	}
 
 	qdec_sam_configure(dev);
@@ -125,7 +127,7 @@ static const struct sensor_driver_api qdec_sam_driver_api = {
 	static const struct qdec_sam_dev_cfg qdec##n##_sam_config = {	\
 		.regs = (Tc *)DT_INST_REG_ADDR(n),			\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
-		.periph_id = DT_INST_PROP(n, peripheral_id),		\
+		.clock_cfg = SAM_DT_INST_CLOCKS_PMC_CFG(n),		\
 	};								\
 									\
 	static struct qdec_sam_dev_data qdec##n##_sam_data;		\

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017 Piotr Mienkowski
  * Copyright (c) 2018 Justin Watson
+ * Copyright (c) 2023 Gerson Fernando Budke
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,10 +9,6 @@
 
 /** @file
  * @brief UART driver for Atmel SAM MCU family.
- *
- * Note:
- * - Error handling is not implemented.
- * - The driver works only in polling mode, interrupt mode is not implemented.
  */
 
 #include <errno.h>
@@ -21,12 +18,13 @@
 #include <soc.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include <zephyr/irq.h>
 
 /* Device constant configuration parameters */
 struct uart_sam_dev_cfg {
 	Uart *regs;
-	uint32_t periph_id;
+	const struct atmel_sam_pmc_config clock_cfg;
 	const struct pinctrl_dev_config *pcfg;
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -40,7 +38,7 @@ struct uart_sam_dev_data {
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_callback_user_data_t irq_cb;	/* Interrupt Callback */
-	void *irq_cb_data;	/* Interrupt Callback Arg */
+	void *irq_cb_data;			/* Interrupt Callback Arg */
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
@@ -391,7 +389,8 @@ static int uart_sam_init(const struct device *dev)
 	Uart * const uart = cfg->regs;
 
 	/* Enable UART clock in PMC */
-	soc_pmc_peripheral_enable(cfg->periph_id);
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&cfg->clock_cfg);
 
 	/* Connect pins to the peripheral */
 	retval = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
@@ -445,7 +444,7 @@ static const struct uart_driver_api uart_sam_driver_api = {
 #define UART_SAM_DECLARE_CFG(n, IRQ_FUNC_INIT)				\
 	static const struct uart_sam_dev_cfg uart##n##_sam_config = {	\
 		.regs = (Uart *)DT_INST_REG_ADDR(n),			\
-		.periph_id = DT_INST_PROP(n, peripheral_id),		\
+		.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(n),		\
 									\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
 									\

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2018 Justin Watson
  * Copyright (c) 2016 Piotr Mienkowski
+ * Copyright (c) 2018 Justin Watson
+ * Copyright (c) 2023 Gerson Fernando Budke
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,10 +9,6 @@
 
 /** @file
  * @brief USART driver for Atmel SAM MCU family.
- *
- * Note:
- * - Only basic USART features sufficient to support printf functionality
- *   are currently implemented.
  */
 
 #include <errno.h>
@@ -21,14 +18,15 @@
 #include <soc.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include <zephyr/irq.h>
 
 /* Device constant configuration parameters */
 struct usart_sam_dev_cfg {
 	Usart *regs;
-	uint32_t periph_id;
-	bool hw_flow_control;
+	const struct atmel_sam_pmc_config clock_cfg;
 	const struct pinctrl_dev_config *pcfg;
+	bool hw_flow_control;
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_config_func_t	irq_config_func;
@@ -485,7 +483,8 @@ static int usart_sam_init(const struct device *dev)
 	Usart * const usart = cfg->regs;
 
 	/* Enable USART clock in PMC */
-	soc_pmc_peripheral_enable(cfg->periph_id);
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&cfg->clock_cfg);
 
 	/* Connect pins to the peripheral */
 	retval = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
@@ -542,7 +541,7 @@ static const struct uart_driver_api usart_sam_driver_api = {
 #define USART_SAM_DECLARE_CFG(n, IRQ_FUNC_INIT)				\
 	static const struct usart_sam_dev_cfg usart##n##_sam_config = {	\
 		.regs = (Usart *)DT_INST_REG_ADDR(n),			\
-		.periph_id = DT_INST_PROP(n, peripheral_id),		\
+		.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(n),		\
 		.hw_flow_control = DT_INST_PROP(n, hw_flow_control),	\
 									\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\

--- a/drivers/usb/device/usb_dc_sam_usbhs.c
+++ b/drivers/usb/device/usb_dc_sam_usbhs.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT atmel_sam_usbhs
 
 #include <zephyr/usb/usb_device.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <soc.h>
@@ -309,10 +310,12 @@ static void usb_dc_isr(void)
 /* Attach USB for device connection */
 int usb_dc_attach(void)
 {
+	const struct atmel_sam_pmc_config clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(0);
 	uint32_t regval;
 
-	/* Start the peripheral clock */
-	soc_pmc_peripheral_enable(DT_INST_PROP(0, peripheral_id));
+	/* Enable USBHS clock in PMC */
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&clock_cfg);
 
 	/* Enable the USB controller in device mode with the clock frozen */
 	USBHS->USBHS_CTRL = USBHS_CTRL_UIMOD | USBHS_CTRL_USBE |
@@ -359,6 +362,8 @@ int usb_dc_attach(void)
 /* Detach the USB device */
 int usb_dc_detach(void)
 {
+	const struct atmel_sam_pmc_config clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(0);
+
 	/* Detach the device */
 	USBHS->USBHS_DEVCTRL |= USBHS_DEVCTRL_DETACH;
 
@@ -368,8 +373,9 @@ int usb_dc_detach(void)
 	/* Disable the USB controller and freeze the clock */
 	USBHS->USBHS_CTRL = USBHS_CTRL_UIMOD | USBHS_CTRL_FRZCLK;
 
-	/* Disable the peripheral clock */
-	soc_pmc_peripheral_enable(DT_INST_PROP(0, peripheral_id));
+	/* Disable USBHS clock in PMC */
+	(void)clock_control_off(SAM_DT_PMC_CONTROLLER,
+				(clock_control_subsys_t *)&clock_cfg);
 
 	/* Disable interrupt */
 	irq_disable(DT_INST_IRQN(0));

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/atmel_sam_pmc.h>
 
 / {
 	aliases {
@@ -28,6 +29,14 @@
 	};
 
 	soc {
+		pmc: pmc@400e0600 {
+			compatible = "atmel,sam-pmc";
+			reg = <0x400e0600 0x200>;
+			interrupts = <5 0>;
+			#clock-cells = <2>;
+			status = "okay";
+		};
+
 		sram0: memory@20070000 {
 			compatible = "mmio-sram";
 			reg = <0x20070000 0x18000>;

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -199,7 +199,9 @@
 			interrupts = <27 0
 				      28 0
 				      29 0>;
-			peripheral-id = <27 28 29>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 27>,
+				 <&pmc PMC_TYPE_PERIPHERAL 28>,
+				 <&pmc PMC_TYPE_PERIPHERAL 29>;
 			status = "disabled";
 		};
 
@@ -209,7 +211,9 @@
 			interrupts = <30 0
 				      31 0
 				      32 0>;
-			peripheral-id = <30 31 32>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 30>,
+				 <&pmc PMC_TYPE_PERIPHERAL 31>,
+				 <&pmc PMC_TYPE_PERIPHERAL 32>;
 			status = "disabled";
 		};
 
@@ -219,7 +223,9 @@
 			interrupts = <33 0
 				      34 0
 				      35 0>;
-			peripheral-id = <33 34 35>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 33>,
+				 <&pmc PMC_TYPE_PERIPHERAL 34>,
+				 <&pmc PMC_TYPE_PERIPHERAL 35>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -228,6 +228,13 @@
 				 <&pmc PMC_TYPE_PERIPHERAL 35>;
 			status = "disabled";
 		};
+
+		rstc: rstc@400e1a00 {
+			compatible = "atmel,sam-rstc";
+			reg = <0x400e1a00 0x10>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 1>;
+			user-nrst;
+		};
 	};
 };
 

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -70,7 +70,7 @@
 			compatible = "atmel,sam-watchdog";
 			reg = <0x400e1a50 0xc>;
 			interrupts = <4 0>;
-			peripheral-id = <4>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -46,7 +46,7 @@
 		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
 			reg = <0x400e0a00 0x200>;
-			peripheral-id = <6>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 6>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -229,6 +229,17 @@
 			status = "disabled";
 		};
 
+		pwm0: pwm@40094000 {
+			compatible = "atmel,sam-pwm";
+			reg = <0x40094000 0x4000>;
+			interrupts = <36 1>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 36>;
+			prescaler = <10>;
+			divider = <1>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
 		rstc: rstc@400e1a00 {
 			compatible = "atmel,sam-rstc";
 			reg = <0x400e1a00 0x10>;

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -79,7 +79,7 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x4008c000 0x128>;
 			interrupts = <22 0>;
-			peripheral-id = <22>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 22>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -90,7 +90,7 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x40090000 0x128>;
 			interrupts = <23 0>;
-			peripheral-id = <23>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 23>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -146,7 +146,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e0e00 0x190>;
 				interrupts = <11 1>;
-				peripheral-id = <11>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 11>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -156,7 +156,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e1000 0x190>;
 				interrupts = <12 1>;
-				peripheral-id = <12>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 12>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -166,7 +166,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e1200 0x190>;
 				interrupts = <13 1>;
-				peripheral-id = <13>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 13>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -176,7 +176,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e1400 0x190>;
 				interrupts = <14 1>;
-				peripheral-id = <14>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 14>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -186,7 +186,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e1600 0x190>;
 				interrupts = <15 1>;
-				peripheral-id = <15>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 15>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -100,7 +100,7 @@
 			compatible = "atmel,sam-uart";
 			reg = <0x400e0800 0x124>;
 			interrupts = <8 1>;
-			peripheral-id = <8>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 8>;
 			status = "disabled";
 		};
 
@@ -108,7 +108,7 @@
 			compatible = "atmel,sam-usart";
 			reg = <0x40098000 0x130>;
 			interrupts = <17 0>;
-			peripheral-id = <17>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 17>;
 			status = "disabled";
 		};
 
@@ -116,7 +116,7 @@
 			compatible = "atmel,sam-usart";
 			reg = <0x4009c000 0x130>;
 			interrupts = <18 0>;
-			peripheral-id = <18>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 18>;
 			status = "disabled";
 		};
 
@@ -124,7 +124,7 @@
 			compatible = "atmel,sam-usart";
 			reg = <0x400a0000 0x130>;
 			interrupts = <19 0>;
-			peripheral-id = <19>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 19>;
 			status = "disabled";
 		};
 
@@ -132,7 +132,7 @@
 			compatible = "atmel,sam-usart";
 			reg = <0x400a4000 0x130>;
 			interrupts = <20 0>;
-			peripheral-id = <20>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 20>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -102,7 +102,7 @@
 			#size-cells = <0>;
 			reg = <0x40088000 0x4000>;
 			interrupts = <19 0>;
-			peripheral-id = <19>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 19>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -248,6 +248,17 @@
 			status = "disabled";
 		};
 
+		pwm0: pwm@40000000 {
+			compatible = "atmel,sam-pwm";
+			reg = <0x40000000 0x4000>;
+			interrupts = <36 1>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 36>;
+			prescaler = <10>;
+			divider = <1>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
 		rstc: rstc@400e1800 {
 			compatible = "atmel,sam-rstc";
 			reg = <0x400e1800 0x10>;

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -71,7 +71,7 @@
 		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
 			reg = <0x400e0a00 0x200>;
-			peripheral-id = <6>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 6>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -141,7 +141,7 @@
 		gmac: ethernet@40034000 {
 			compatible = "atmel,sam-gmac";
 			reg = <0x40034000 0x4000>;
-			peripheral-id = <44>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 44>;
 			interrupts = <44 0>;
 			interrupt-names = "gmac";
 			num-queues = <1>;

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -50,6 +50,24 @@
 			compatible = "mmio-sram";
 		};
 
+		afec0: adc@400b0000 {
+			compatible = "atmel,sam-afec";
+			reg = <0x400b0000 0x4000>;
+			interrupts = <30 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 30>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+		};
+
+		afec1: adc@400b4000 {
+			compatible = "atmel,sam-afec";
+			reg = <0x400b4000 0x4000>;
+			interrupts = <31 0>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 31>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+		};
+
 		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
 			reg = <0x400e0a00 0x200>;

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -7,6 +7,7 @@
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/clock/atmel_sam_pmc.h>
 
 / {
 	aliases {
@@ -37,6 +38,14 @@
 	};
 
 	soc {
+		pmc: pmc@400e0400 {
+			compatible = "atmel,sam-pmc";
+			reg = <0x400e0400 0x200>;
+			interrupts = <5 0>;
+			#clock-cells = <2>;
+			status = "okay";
+		};
+
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
 		};

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -88,7 +88,7 @@
 			compatible = "atmel,sam-watchdog";
 			reg = <0x400e1850 0x10>;
 			interrupts = <4 0>;
-			peripheral-id = <4>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -260,7 +260,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40060000 0x200>;
-			peripheral-id = <8>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 8>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -218,7 +218,9 @@
 			interrupts = <21 0
 				      22 0
 				      23 0>;
-			peripheral-id = <21 22 23>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 21>,
+				 <&pmc PMC_TYPE_PERIPHERAL 22>,
+				 <&pmc PMC_TYPE_PERIPHERAL 23>;
 			status = "disabled";
 		};
 
@@ -228,7 +230,9 @@
 			interrupts = <24 0
 				      25 0
 				      26 0>;
-			peripheral-id = <24 25 26>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 24>,
+				 <&pmc PMC_TYPE_PERIPHERAL 25>,
+				 <&pmc PMC_TYPE_PERIPHERAL 26>;
 			status = "disabled";
 		};
 
@@ -238,7 +242,9 @@
 			interrupts = <27 0
 				      28 0
 				      29 0>;
-			peripheral-id = <27 28 29>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 27>,
+				 <&pmc PMC_TYPE_PERIPHERAL 28>,
+				 <&pmc PMC_TYPE_PERIPHERAL 29>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -110,7 +110,7 @@
 			compatible = "atmel,sam-uart";
 			reg = <0x400e0600 0x140>;
 			interrupts = <7 1>;
-			peripheral-id = <7>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 7>;
 			status = "disabled";
 		};
 
@@ -118,7 +118,7 @@
 			compatible = "atmel,sam-uart";
 			reg = <0x40060600 0x200>;
 			interrupts = <45 1>;
-			peripheral-id = <45>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 45>;
 			status = "disabled";
 		};
 
@@ -126,7 +126,7 @@
 			compatible = "atmel,sam-usart";
 			reg = <0x400a0000 0x4000>;
 			interrupts = <14 1>;
-			peripheral-id = <14>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 14>;
 			status = "disabled";
 		};
 
@@ -134,7 +134,7 @@
 			compatible = "atmel,sam-usart";
 			reg = <0x400a4000 0x4000>;
 			interrupts = <15 1>;
-			peripheral-id = <15>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 15>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -165,7 +165,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e0e00 0x200>;
 				interrupts = <9 1>;
-				peripheral-id = <9>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 9>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -175,7 +175,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e1000 0x200>;
 				interrupts = <10 1>;
-				peripheral-id = <10>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 10>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -185,7 +185,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e1200 0x200>;
 				interrupts = <11 1>;
-				peripheral-id = <11>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 11>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -195,7 +195,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e1400 0x200>;
 				interrupts = <12 1>;
-				peripheral-id = <12>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 12>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -205,7 +205,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e1600 0x200>;
 				interrupts = <13 1>;
-				peripheral-id = <13>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 13>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -248,6 +248,13 @@
 			status = "disabled";
 		};
 
+		rstc: rstc@400e1800 {
+			compatible = "atmel,sam-rstc";
+			reg = <0x400e1800 0x10>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 1>;
+			user-nrst;
+		};
+
 		smc: smc@40060000 {
 			compatible = "atmel,sam-smc";
 			#address-cells = <1>;

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -79,7 +79,7 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x400a8000 0x4000>;
 			interrupts = <17 0>;
-			peripheral-id = <17>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 17>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -90,7 +90,7 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x400ac000 0x4000>;
 			interrupts = <18 0>;
-			peripheral-id = <18>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 18>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -211,7 +211,7 @@
 			interrupts = <55 0
 				      56 0
 				      57 0>;
-			peripheral-id = <2>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 2>;
 			status = "disabled";
 		};
 
@@ -221,7 +221,7 @@
 			interrupts = <58 0
 				      59 0
 				      60 0>;
-			peripheral-id = <3>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -7,6 +7,7 @@
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/clock/atmel_sam_pmc.h>
 
 / {
 	chosen {
@@ -50,6 +51,14 @@
 	};
 
 	soc {
+		pmc: pmc@400e0000 {
+			compatible = "atmel,sam-pmc";
+			reg = <0x400e0000 0x740>;
+			interrupts = <22 0>;
+			#clock-cells = <2>;
+			status = "okay";
+		};
+
 		flashcalw: flash-controller@400a0000 {
 			compatible = "atmel,sam4l-flashcalw-controller";
 			reg = <0x400a0000 0x400>;

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -166,7 +166,7 @@
 			interrupt-names = "usbc";
 			maximum-speed = "full-speed";
 			num-bidir-endpoints = <8>;
-			peripheral-id = <101>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 101>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -124,7 +124,7 @@
 			compatible = "atmel,sam-spi";
 			reg = <0x40008000 0x4000>;
 			interrupts = <54 0>;
-			peripheral-id = <1>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 1>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -180,7 +180,7 @@
 				compatible = "atmel,sam4l-gpio";
 				reg = <0x400e1000 0x200>;
 				interrupts = <25 1>, <26 1>, <27 1>, <28 1>;
-				peripheral-id = <68>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 68>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -189,7 +189,7 @@
 				compatible = "atmel,sam4l-gpio";
 				reg = <0x400e1200 0x200>;
 				interrupts = <29 1>, <30 1>, <31 1>, <32 1>;
-				peripheral-id = <68>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 68>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -198,7 +198,7 @@
 				compatible = "atmel,sam4l-gpio";
 				reg = <0x400e1400 0x200>;
 				interrupts = <33 1>, <34 1>, <35 1>, <36 1>;
-				peripheral-id = <68>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 68>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -134,28 +134,28 @@
 			compatible = "atmel,sam-usart";
 			reg = <0x40024000 0x4000>;
 			interrupts = <65 1>;
-			peripheral-id = <8>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 8>;
 			status = "disabled";
 		};
 		usart1: usart@40028000 {
 			compatible = "atmel,sam-usart";
 			reg = <0x40028000 0x4000>;
 			interrupts = <66 1>;
-			peripheral-id = <9>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 9>;
 			status = "disabled";
 		};
 		usart2: usart@4002c000 {
 			compatible = "atmel,sam-usart";
 			reg = <0x4002c000 0x4000>;
 			interrupts = <67 1>;
-			peripheral-id = <10>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 10>;
 			status = "disabled";
 		};
 		usart3: usart@40030000 {
 			compatible = "atmel,sam-usart";
 			reg = <0x40030000 0x4000>;
 			interrupts = <68 1>;
-			peripheral-id = <11>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 11>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -229,7 +229,7 @@
 			compatible = "atmel,sam-trng";
 			reg = <0x40068000 0x4000>;
 			interrupts = <73 0>;
-			peripheral-id = <17>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 17>;
 			status = "okay";
 		};
 

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -84,7 +84,7 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x40018000 0x4000>;
 			interrupts = <61 0>;
-			peripheral-id = <4>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 4>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -94,7 +94,7 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x4001c000 0x4000>;
 			interrupts = <63 0>;
-			peripheral-id = <6>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 6>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -104,7 +104,7 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x40078000 0x4000>;
 			interrupts = <77 0>;
-			peripheral-id = <21>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 21>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -114,7 +114,7 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x4007c000 0x4000>;
 			interrupts = <78 0>;
-			peripheral-id = <22>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 22>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -162,7 +162,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e0e00 0x190>;
 				interrupts = <11 1>;
-				peripheral-id = <11>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 11>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -172,7 +172,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e1000 0x190>;
 				interrupts = <12 1>;
-				peripheral-id = <12>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 12>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -182,7 +182,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e1200 0x190>;
 				interrupts = <13 1>;
-				peripheral-id = <13>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 13>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/clock/atmel_sam_pmc.h>
 
 / {
 	aliases {
@@ -39,6 +40,14 @@
 	};
 
 	soc {
+		pmc: pmc@400e0400 {
+			compatible = "atmel,sam-pmc";
+			reg = <0x400e0400 0x200>;
+			interrupts = <5 0>;
+			#clock-cells = <2>;
+			status = "okay";
+		};
+
 		sram0: memory@20100000 {
 			compatible = "mmio-sram";
 		};

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -225,7 +225,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x400e0000 0x200>;
-			peripheral-id = <10>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 10>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -55,7 +55,7 @@
 		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
 			reg = <0x400e0a00 0x200>;
-			peripheral-id = <6>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 6>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -81,7 +81,7 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x40018000 0x128>;
 			interrupts = <19 0>;
-			peripheral-id = <19>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 19>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -92,7 +92,7 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x4001c000 0x128>;
 			interrupts = <20 0>;
-			peripheral-id = <20>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 20>;
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -72,7 +72,7 @@
 			compatible = "atmel,sam-watchdog";
 			reg = <0x400e1450 0xc>;
 			interrupts = <4 0>;
-			peripheral-id = <4>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -216,7 +216,7 @@
 		rstc: rstc@400e1400 {
 			compatible = "atmel,sam-rstc";
 			reg = <0x400e1400 0x10>;
-			peripheral-id = <1>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 1>;
 			user-nrst;
 		};
 

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -112,7 +112,7 @@
 			compatible = "atmel,sam-uart";
 			reg = <0x400e0600 0x200>;
 			interrupts = <8 1>;
-			peripheral-id = <8>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 8>;
 			status = "disabled";
 		};
 
@@ -120,7 +120,7 @@
 			compatible = "atmel,sam-uart";
 			reg = <0x400e0800 0x200>;
 			interrupts = <9 1>;
-			peripheral-id = <9>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 9>;
 			status = "disabled";
 		};
 
@@ -139,7 +139,7 @@
 			compatible = "atmel,sam-usart";
 			reg = <0x40024000 0x130>;
 			interrupts = <14 1>;
-			peripheral-id = <14>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 14>;
 			status = "disabled";
 		};
 
@@ -147,7 +147,7 @@
 			compatible = "atmel,sam-usart";
 			reg = <0x40028000 0x130>;
 			interrupts = <15 1>;
-			peripheral-id = <15>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 15>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -195,7 +195,9 @@
 			interrupts = <23 0
 				      24 0
 				      25 0>;
-			peripheral-id = <23 24 25>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 23>,
+				 <&pmc PMC_TYPE_PERIPHERAL 24>,
+				 <&pmc PMC_TYPE_PERIPHERAL 25>;
 			status = "disabled";
 		};
 
@@ -205,7 +207,9 @@
 			interrupts = <26 0
 				      27 0
 				      28 0>;
-			peripheral-id = <26 27 28>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 26>,
+				 <&pmc PMC_TYPE_PERIPHERAL 27>,
+				 <&pmc PMC_TYPE_PERIPHERAL 28>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -104,7 +104,7 @@
 			#size-cells = <0>;
 			reg = <0x40008000 0x4000>;
 			interrupts = <21 0>;
-			peripheral-id = <21>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 21>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -128,7 +128,7 @@
 			compatible = "atmel,sam-pwm";
 			reg = <0x40020000 0x4000>;
 			interrupts = <31 1>;
-			peripheral-id = <31>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 31>;
 			prescaler = <10>;
 			divider = <1>;
 			#pwm-cells = <3>;

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -279,7 +279,6 @@
 		trng: random@42002800 {
 			compatible = "atmel,sam-trng";
 			reg = <0x42002800 0x1e>;
-			peripheral-id = <0>;
 			interrupts = <131 0>;
 		};
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -403,7 +403,7 @@
 			compatible = "atmel,sam-ssc";
 			reg = <0x40004000 0x4000>;
 			interrupts = <22 0>;
-			peripheral-id = <22>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 22>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -60,7 +60,7 @@
 			compatible = "atmel,sam-flash-controller";
 			reg = <0x400e0c00 0x200>;
 			interrupts = <6 0>;
-			peripheral-id = <6>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 6>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -139,7 +139,7 @@
 			compatible = "atmel,sam-uart";
 			reg = <0x400e0800 0x100>;
 			interrupts = <7 1>;
-			peripheral-id = <7>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 7>;
 			status = "disabled";
 		};
 
@@ -147,7 +147,7 @@
 			compatible = "atmel,sam-uart";
 			reg = <0x400e0a00 0x100>;
 			interrupts = <8 1>;
-			peripheral-id = <8>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 8>;
 			status = "disabled";
 		};
 
@@ -155,7 +155,7 @@
 			compatible = "atmel,sam-uart";
 			reg = <0x400e1a00 0x100>;
 			interrupts = <44 1>;
-			peripheral-id = <44>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 44>;
 			status = "disabled";
 		};
 
@@ -163,7 +163,7 @@
 			compatible = "atmel,sam-uart";
 			reg = <0x400e1c00 0x100>;
 			interrupts = <45 1>;
-			peripheral-id = <45>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 45>;
 			status = "disabled";
 		};
 
@@ -171,7 +171,7 @@
 			compatible = "atmel,sam-uart";
 			reg = <0x400e1e00 0x100>;
 			interrupts = <46 1>;
-			peripheral-id = <46>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 46>;
 			status = "disabled";
 		};
 
@@ -179,7 +179,7 @@
 			compatible = "atmel,sam-usart";
 			reg = <0x40024000 0x100>;
 			interrupts = <13 0>;
-			peripheral-id = <13>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 13>;
 			status = "disabled";
 		};
 
@@ -187,7 +187,7 @@
 			compatible = "atmel,sam-usart";
 			reg = <0x40028000 0x100>;
 			interrupts = <14 0>;
-			peripheral-id = <14>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 14>;
 			status = "disabled";
 		};
 
@@ -195,7 +195,7 @@
 			compatible = "atmel,sam-usart";
 			reg = <0x4002c000 0x100>;
 			interrupts = <15 0>;
-			peripheral-id = <15>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 15>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -89,7 +89,7 @@
 			#size-cells = <0>;
 			reg = <0x40018000 0x12B>;
 			interrupts = <19 0>;
-			peripheral-id = <19>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 19>;
 			status = "disabled";
 		};
 
@@ -100,7 +100,7 @@
 			#size-cells = <0>;
 			reg = <0x4001c000 0x12B>;
 			interrupts = <20 0>;
-			peripheral-id = <20>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 20>;
 			status = "disabled";
 		};
 
@@ -111,7 +111,7 @@
 			#size-cells = <0>;
 			reg = <0x40060000 0x12B>;
 			interrupts = <41 0>;
-			peripheral-id = <41>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 41>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -221,7 +221,7 @@
 			compatible = "atmel,sam-dac";
 			reg = <0x40040000 0x100>;
 			interrupts = <30 0>;
-			peripheral-id = <30>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 30>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -452,7 +452,7 @@
 		rstc: rstc@400e1800 {
 			compatible = "atmel,sam-rstc";
 			reg = <0x400e1800 0x10>;
-			peripheral-id = <1>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 1>;
 			user-nrst;
 		};
 	};

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -314,7 +314,7 @@
 			interrupt-names = "usbhs";
 			maximum-speed = "high-speed";
 			num-bidir-endpoints = <10>;
-			peripheral-id = <34>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 34>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -424,7 +424,7 @@
 				reg-names = "m_can";
 				interrupts = <35 0>, <36 0>;
 				interrupt-names = "LINE_0", "LINE_1";
-				peripheral-id = <35>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 35>;
 				divider = <6>;
 				sjw = <1>;
 				sample-point = <875>;
@@ -439,7 +439,7 @@
 				reg-names = "m_can";
 				interrupts = <37 0>, <38 0>;
 				interrupt-names = "LINE_0", "LINE_1";
-				peripheral-id = <37>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 37>;
 				divider = <6>;
 				sjw = <1>;
 				sample-point = <875>;

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -394,14 +394,14 @@
 			compatible = "atmel,sam-xdmac";
 			reg = <0x40078000 0x400>;
 			interrupts = <58 0>;
-			peripheral-id = <58>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 58>;
 			#dma-cells = <2>;
 			status = "disabled";
 		};
 
 		ssc: ssc@40004000 {
 			compatible = "atmel,sam-ssc";
-			reg = <0x40004000 0x400>;
+			reg = <0x40004000 0x4000>;
 			interrupts = <22 0>;
 			peripheral-id = <22>;
 			status = "disabled";

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -386,7 +386,7 @@
 			compatible = "atmel,sam-trng";
 			reg = <0x40070000 0x4000>;
 			interrupts = <57 0>;
-			peripheral-id = <57>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 57>;
 			status = "okay";
 		};
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -236,7 +236,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e0e00 0x190>;
 				interrupts = <10 1>;
-				peripheral-id = <10>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 10>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -246,7 +246,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e1000 0x190>;
 				interrupts = <11 1>;
-				peripheral-id = <11>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 11>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -256,7 +256,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e1200 0x190>;
 				interrupts = <12 1>;
-				peripheral-id = <12>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 12>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -266,7 +266,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e1400 0x190>;
 				interrupts = <16 1>;
-				peripheral-id = <16>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 16>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -276,7 +276,7 @@
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e1600 0x190>;
 				interrupts = <17 1>;
-				peripheral-id = <17>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 17>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -203,7 +203,7 @@
 			compatible = "atmel,sam-afec";
 			reg = <0x4003c000 0x100>;
 			interrupts = <29 0>;
-			peripheral-id = <29>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 29>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -212,7 +212,7 @@
 			compatible = "atmel,sam-afec";
 			reg = <0x40064000 0x100>;
 			interrupts = <40 0>;
-			peripheral-id = <40>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 40>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -287,7 +287,7 @@
 			compatible = "atmel,sam-pwm";
 			reg = <0x40020000 0x4000>;
 			interrupts = <31 0>;
-			peripheral-id = <31>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 31>;
 			status = "disabled";
 			prescaler = <10>;
 			divider = <1>;
@@ -298,7 +298,7 @@
 			compatible = "atmel,sam-pwm";
 			reg = <0x4005c000 0x4000>;
 			interrupts = <60 0>;
-			peripheral-id = <60>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 60>;
 			status = "disabled";
 			prescaler = <10>;
 			divider = <1>;

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -340,7 +340,9 @@
 			interrupts = <23 0
 				      24 0
 				      25 0>;
-			peripheral-id = <23 24 25>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 23>,
+				 <&pmc PMC_TYPE_PERIPHERAL 24>,
+				 <&pmc PMC_TYPE_PERIPHERAL 25>;
 			status = "disabled";
 		};
 
@@ -350,7 +352,9 @@
 			interrupts = <26 0
 				      27 0
 				      28 0>;
-			peripheral-id = <26 27 28>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 26>,
+				 <&pmc PMC_TYPE_PERIPHERAL 27>,
+				 <&pmc PMC_TYPE_PERIPHERAL 28>;
 			status = "disabled";
 		};
 
@@ -360,7 +364,9 @@
 			interrupts = <47 0
 				      48 0
 				      49 0>;
-			peripheral-id = <47 48 49>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 47>,
+				 <&pmc PMC_TYPE_PERIPHERAL 48>,
+				 <&pmc PMC_TYPE_PERIPHERAL 49>;
 			status = "disabled";
 		};
 
@@ -370,7 +376,9 @@
 			interrupts = <50 0
 				      51 0
 				      52 0>;
-			peripheral-id = <50 51 52>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 50>,
+				 <&pmc PMC_TYPE_PERIPHERAL 51>,
+				 <&pmc PMC_TYPE_PERIPHERAL 52>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/clock/atmel_sam_pmc.h>
 
 / {
 	aliases {
@@ -47,6 +48,14 @@
 	};
 
 	soc {
+		pmc: pmc@400e0600 {
+			compatible = "atmel,sam-pmc";
+			reg = <0x400e0600 0x200>;
+			interrupts = <5 0>;
+			#clock-cells = <2>;
+			status = "okay";
+		};
+
 		eefc: flash-controller@400e0c00 {
 			compatible = "atmel,sam-flash-controller";
 			reg = <0x400e0c00 0x200>;

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -121,7 +121,7 @@
 			#size-cells = <0>;
 			reg = <0x40008000 0x4000>;
 			interrupts = <21 0>;
-			peripheral-id = <21>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 21>;
 			status = "disabled";
 		};
 
@@ -131,7 +131,7 @@
 			#size-cells = <0>;
 			reg = <0x40058000 0x4000>;
 			interrupts = <42 0>;
-			peripheral-id = <42>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 42>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -78,7 +78,7 @@
 			compatible = "atmel,sam-watchdog";
 			reg = <0x400e1850 0xc>;
 			interrupts = <4 0>;
-			peripheral-id = <4>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 4>;
 			status = "disabled";
 		};
 

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -321,7 +321,7 @@
 		gmac: ethernet@40050000 {
 			compatible = "atmel,sam-gmac";
 			reg = <0x40050000 0x4000>;
-			peripheral-id = <39>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 39>;
 			interrupts = <39 0>, <66 0>, <67 0>;
 			interrupt-names = "gmac", "q1", "q2";
 			num-queues = <3>;

--- a/dts/arm/atmel/saml2x.dtsi
+++ b/dts/arm/atmel/saml2x.dtsi
@@ -195,7 +195,6 @@
 		trng: random@42003800 {
 			compatible = "atmel,sam-trng";
 			reg = <0x42003800 0x24>;
-			peripheral-id = <0>;
 			interrupts = <27 0>;
 		};
 	};

--- a/dts/bindings/adc/atmel,sam-afec.yaml
+++ b/dts/bindings/adc/atmel,sam-afec.yaml
@@ -13,9 +13,7 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
-    description: peripheral ID
+  clocks:
     required: true
 
   "#io-channel-cells":

--- a/dts/bindings/arm/atmel,sam-ssc.yaml
+++ b/dts/bindings/arm/atmel,sam-ssc.yaml
@@ -16,9 +16,7 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
-    description: peripheral ID
+  clocks:
     required: true
 
   dmas:

--- a/dts/bindings/can/atmel,sam-can.yaml
+++ b/dts/bindings/can/atmel,sam-can.yaml
@@ -13,10 +13,8 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
+  clocks:
     required: true
-    description: peripheral ID
 
   divider:
     type: int

--- a/dts/bindings/clock/atmel,sam-pmc.yaml
+++ b/dts/bindings/clock/atmel,sam-pmc.yaml
@@ -1,0 +1,51 @@
+# Copyright (c) 2023 Gerson Fernando Budke <nandojve@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Atmel Power Management Controller (PMC)
+
+  The Power Management Controller (PMC) optimizes power consumption by
+  controlling all system and user peripheral clocks. The PMC enables/disables
+  the clock inputs to many of the peripherals and the processor.
+
+  To specify the clocks in a peripheral, the standard clocks property needs
+  to be used, e.g.:
+
+    uart: uart@xxx {
+      ...
+      clocks = <&pmc PMC_TYPE_PERIPHERAL p-id>;
+      ...
+    };
+
+  In this example the clock-type was defined as PMC_TYPE_PERIPHERAL and the
+  peripheral-id was defined as p-id. The p-id number should be consulted on
+  datasheet, usually it is available at Product Mapping figure.
+
+  NOTE: The predefined clock type cell is defined at
+  include/zephyr/drivers/clock_clontrol/atmel_sam_pmc.h header file.
+
+  The clock-type constants are:
+    PMC_TYPE_CORE
+    PMC_TYPE_SYSTEM
+    PMC_TYPE_PERIPHERAL
+    PMC_TYPE_GCK
+    PMC_TYPE_PROGRAMMABLE
+
+compatible: "atmel,sam-pmc"
+
+include: [clock-controller.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  "#clock-cells":
+    const: 2
+    description: |
+      from common clock binding; shall be set to 2. The first entry is the type
+      of the clock (core, system, peripheral or generated) and the second entry
+      it's the peripheral identification index as provided by the datasheet.
+
+clock-cells:
+  - clock-type
+  - peripheral-id

--- a/dts/bindings/dac/atmel,sam-dac.yaml
+++ b/dts/bindings/dac/atmel,sam-dac.yaml
@@ -13,11 +13,8 @@ properties:
   reg:
     required: true
 
-  peripheral-id:
-    type: int
+  clocks:
     required: true
-    description: |
-      peripheral ID
 
   prescaler:
     type: int

--- a/dts/bindings/dma/atmel,sam-xdmac.yaml
+++ b/dts/bindings/dma/atmel,sam-xdmac.yaml
@@ -14,9 +14,7 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
-    description: peripheral ID
+  clocks:
     required: true
 
   "#dma-cells":

--- a/dts/bindings/ethernet/atmel,sam-gmac.yaml
+++ b/dts/bindings/ethernet/atmel,sam-gmac.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Gerson Fernando Budke <nandojve@gmail.com>
+# Copyright (c) 2021-2023 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 description: Atmel SAM-family GMAC Ethernet
@@ -8,11 +8,5 @@ compatible: "atmel,sam-gmac"
 include: atmel,gmac-common.yaml
 
 properties:
-  peripheral-id:
-    type: int
+  clocks:
     required: true
-    description: |
-      The peripheral identifier is required for Atmel SAMs MCUs to indicate
-      which is the clock line associated with a specific peripheral.  This
-      clock line is defined at Power Management Controller (PMC) and it
-      enables the peripheral.

--- a/dts/bindings/flash_controller/atmel,sam-flash-controller.yaml
+++ b/dts/bindings/flash_controller/atmel,sam-flash-controller.yaml
@@ -8,7 +8,5 @@ compatible: "atmel,sam-flash-controller"
 include: flash-controller.yaml
 
 properties:
-  peripheral-id:
-    type: int
-    description: peripheral ID
+  clocks:
     required: true

--- a/dts/bindings/gpio/atmel,sam-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam-gpio.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021-2023, Gerson Fernando Budke <nandojve@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
 description: SAM GPIO PORT node
 
 compatible: "atmel,sam-gpio"
@@ -11,9 +14,7 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
-    description: peripheral ID
+  clocks:
     required: true
 
   "#gpio-cells":

--- a/dts/bindings/gpio/atmel,sam4l-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam4l-gpio.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2021-2023, Gerson Fernando Budke <nandojve@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
 description: SAM4L GPIO PORT node
 
 compatible: "atmel,sam4l-gpio"

--- a/dts/bindings/hwinfo/atmel,sam-rstc.yaml
+++ b/dts/bindings/hwinfo/atmel,sam-rstc.yaml
@@ -11,9 +11,7 @@ properties:
   reg:
     required: true
 
-  peripheral-id:
-    type: int
-    description: peripheral ID
+  clocks:
     required: true
 
   user-nrst:

--- a/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twi.yaml
@@ -16,7 +16,5 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
-    description: peripheral ID
+  clocks:
     required: true

--- a/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twihs.yaml
@@ -16,7 +16,5 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
-    description: peripheral ID
+  clocks:
     required: true

--- a/dts/bindings/i2c/atmel,sam-i2c-twim.yaml
+++ b/dts/bindings/i2c/atmel,sam-i2c-twim.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Gerson Fernando Budke <nandojve@gmail.com>
+# Copyright (c) 2020-2023 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -48,10 +48,8 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
+  clocks:
     required: true
-    description: peripheral ID
 
   std-clk-slew-lim:
     type: int

--- a/dts/bindings/memory-controllers/atmel,sam-smc.yaml
+++ b/dts/bindings/memory-controllers/atmel,sam-smc.yaml
@@ -67,6 +67,9 @@ properties:
   reg:
     required: true
 
+  clocks:
+    required: true
+
   "#address-cells":
     required: true
     const: 1
@@ -74,11 +77,6 @@ properties:
   "#size-cells":
     required: true
     const: 0
-
-  peripheral-id:
-    type: int
-    description: peripheral ID
-    required: true
 
 child-binding:
   description: |

--- a/dts/bindings/pwm/atmel,sam-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam-pwm.yaml
@@ -17,9 +17,7 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
-    description: peripheral ID
+  clocks:
     required: true
 
   prescaler:

--- a/dts/bindings/rng/atmel,sam-trng.yaml
+++ b/dts/bindings/rng/atmel,sam-trng.yaml
@@ -13,8 +13,3 @@ properties:
 
   interrupts:
     required: true
-
-  peripheral-id:
-    type: int
-    description: peripheral ID
-    required: true

--- a/dts/bindings/sensor/atmel,sam-tc-qdec.yaml
+++ b/dts/bindings/sensor/atmel,sam-tc-qdec.yaml
@@ -15,7 +15,5 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: array
-    description: peripheral ID
+  clocks:
     required: true

--- a/dts/bindings/serial/atmel,sam-uart.yaml
+++ b/dts/bindings/serial/atmel,sam-uart.yaml
@@ -13,7 +13,5 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
-    description: peripheral ID
+  clocks:
     required: true

--- a/dts/bindings/serial/atmel,sam-usart.yaml
+++ b/dts/bindings/serial/atmel,sam-usart.yaml
@@ -13,7 +13,5 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
-    description: peripheral ID
+  clocks:
     required: true

--- a/dts/bindings/spi/atmel,sam-spi.yaml
+++ b/dts/bindings/spi/atmel,sam-spi.yaml
@@ -16,9 +16,7 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
-    description: peripheral ID
+  clocks:
     required: true
 
   loopback:

--- a/dts/bindings/timer/atmel,sam-tc.yaml
+++ b/dts/bindings/timer/atmel,sam-tc.yaml
@@ -15,9 +15,7 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: array
-    description: peripheral ID
+  clocks:
     required: true
 
   channel:

--- a/dts/bindings/usb/atmel,sam-usbc.yaml
+++ b/dts/bindings/usb/atmel,sam-usbc.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) 2018 Aurelien Jarno
-# Copyright (c) 2020 Gerson Fernando Budke <nandojve@gmail.com>
+# Copyright (c) 2020*2023 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -18,7 +18,5 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
+  clocks:
     required: true
-    description: peripheral ID

--- a/dts/bindings/usb/atmel,sam-usbhs.yaml
+++ b/dts/bindings/usb/atmel,sam-usbhs.yaml
@@ -17,7 +17,5 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
+  clocks:
     required: true
-    description: peripheral ID

--- a/dts/bindings/watchdog/atmel,sam-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam-watchdog.yaml
@@ -14,7 +14,5 @@ properties:
   interrupts:
     required: true
 
-  peripheral-id:
-    type: int
-    description: peripheral ID
+  clocks:
     required: true

--- a/include/zephyr/drivers/clock_control/atmel_sam_pmc.h
+++ b/include/zephyr/drivers/clock_control/atmel_sam_pmc.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Gerson Fernando Budke <nandojve@gmail.com
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ATMEL_SAM_PMC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ATMEL_SAM_PMC_H_
+
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/dt-bindings/clock/atmel_sam_pmc.h>
+
+#define SAM_DT_PMC_CONTROLLER DEVICE_DT_GET(DT_NODELABEL(pmc))
+
+struct atmel_sam_pmc_config {
+	uint32_t clock_type;
+	uint32_t peripheral_id;
+};
+
+#define SAM_DT_CLOCK_PMC_CFG(clock_id, node_id)					\
+	{									\
+	.clock_type = DT_CLOCKS_CELL_BY_IDX(node_id, clock_id, clock_type),	\
+	.peripheral_id = DT_CLOCKS_CELL_BY_IDX(node_id, clock_id, peripheral_id)\
+	}
+
+#define SAM_DT_INST_CLOCK_PMC_CFG(inst) SAM_DT_CLOCK_PMC_CFG(0, DT_DRV_INST(inst))
+
+#define SAM_DT_CLOCKS_PMC_CFG(node_id)						\
+	{									\
+		LISTIFY(DT_NUM_CLOCKS(node_id),					\
+			SAM_DT_CLOCK_PMC_CFG, (,), node_id)			\
+	}
+
+#define SAM_DT_INST_CLOCKS_PMC_CFG(inst)					\
+	SAM_DT_CLOCKS_PMC_CFG(DT_DRV_INST(inst))
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_ATMEL_SAM_PMC_H_ */

--- a/include/zephyr/dt-bindings/clock/atmel_sam_pmc.h
+++ b/include/zephyr/dt-bindings/clock/atmel_sam_pmc.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023 Gerson Fernando Budke <nandojve@gmail.com
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_ATMEL_SAM_PMC_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_ATMEL_SAM_PMC_H_
+
+#define PMC_TYPE_CORE		0
+#define PMC_TYPE_SYSTEM		1
+#define PMC_TYPE_PERIPHERAL	2
+#define PMC_TYPE_GCK		3
+#define PMC_TYPE_PROGRAMMABLE	4
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_ATMEL_SAM_PMC_H_ */

--- a/samples/drivers/adc/boards/sam4e_xpro.overlay
+++ b/samples/drivers/adc/boards/sam4e_xpro.overlay
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023, Gerson Fernando Budke
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&afec0 0>, <&afec0 6>;
+	};
+};
+
+&afec0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@6 {
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/soc/arm/atmel_sam/Kconfig.defconfig
+++ b/soc/arm/atmel_sam/Kconfig.defconfig
@@ -10,6 +10,9 @@ if SOC_FAMILY_SAM
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
+config CLOCK_CONTROL
+	default y
+
 config PINCTRL
 	default y
 

--- a/tests/drivers/i2s/i2s_api/boards/sam_e70_xplained.overlay
+++ b/tests/drivers/i2s/i2s_api/boards/sam_e70_xplained.overlay
@@ -1,0 +1,3 @@
+&xdmac {
+	status = "okay";
+};

--- a/tests/drivers/i2s/i2s_api/boards/sam_v71_xult.overlay
+++ b/tests/drivers/i2s/i2s_api/boards/sam_v71_xult.overlay
@@ -1,0 +1,3 @@
+&xdmac {
+	status = "okay";
+};

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: d45adfb6897aba323cac29cdda8070ce4f23f014
+      revision: f47a9a8b55677b5d03bf7f066f907e6b74c9e57d
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
The Atmel SAM/SAM0 uses peripheral-id to identify clock source index at Power Management Controller (PMC). This introduce support to clock API which is selected by PMC_TYPE_PERIPHERAL cell. With this feature the peripheral-id is complete removed from devicetree. The devicetree cells were inspired on the currently Atmel Linux bindings.

In addition, hwinfo (reset cause), pwm and afec (adc) drivers are now enabled for all compatible SoCs.