### PR TITLE
twister: fix wrong reason when timeout occurs

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -645,7 +645,7 @@ class DeviceHandler(Handler):
                 self.instance.reason = "Failed"
         elif not flash_error:
             self.instance.status = "error"
-            self.instance.reason = "No Console Output(Timeout)"
+            self.instance.reason = "Timeout"
 
         if self.instance.status == "error":
             self.instance.add_missing_case_status("blocked", self.instance.reason)


### PR DESCRIPTION
We are wrongly claiming no console output, yet console output is there
and the failure is just a regular timeout, i.e. the test did not
complete within allocated time.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
