### PR TITLE
tests/bt/bsim/mesh: Fix tests dependent on RSSI

### DIFF
--- a/tests/bluetooth/bsim/mesh/_mesh_test.sh
+++ b/tests/bluetooth/bsim/mesh/_mesh_test.sh
@@ -84,7 +84,7 @@ function RunTest(){
 
   echo "Starting phy with $count devices"
 
-  Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=$s_id -D=$count
+  Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=$s_id -D=$count -argschannel -at=35
 
   for process_id in ${process_ids[@]}; do
     wait $process_id || let "exit_code=$?"


### PR DESCRIPTION
The friendship tests are dependent on the attenuation level as they take (much) longer with higher channel attenuation.

As BabbleSim's "magic" modem model (default one used in these tests) has been updated to provide a somehow accurate RSSI measurement, one of these tests
( tests/bluetooth/bsim/mesh/tests_scripts/friendship/msg_mesh_low_lat.sh )
fails with the default channel attenuation of 60dBs. Reduce the channel attenuation to 35dBs to approach the previous RSSI values this tests were seeing on the DUTs with the default modem.

Possible replacement for #55650
Fixes issue mentioned in https://github.com/zephyrproject-rtos/zephyr/pull/55640#issuecomment-1462206074 