### PR TITLE
west.yml: Update hal_stm32 with the new stm32h5 cube package

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: c36136b253a46ed8dd63525eeee659393047ce83
+      revision: pull/165/head
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Introduce the 
. stm32h5 to version V1.0.0

Refer to the https://github.com/STMicroelectronics/STM32CubeH5

This PR takes the new ../modules/hal/stm32/stm32cube/stm32h5xx  from the https://github.com/zephyrproject-rtos/hal_stm32/pull/165

Signed-off-by: Francois Ramu francois.ramu@st.com