### PR TITLE
boards: arm: nrf5340_audio_dk_nrf5340: add missing hardware description

### DIFF
--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -112,6 +112,13 @@
 
 &gpio0 {
 	status = "okay";
+
+	codec-interface {
+		gpio-hog;
+		gpios = <21 GPIO_ACTIVE_HIGH>;
+		/* low output to select on-board codec control */
+		output-low;
+	};
 };
 
 &gpio1 {

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -59,6 +59,14 @@
 		nordic,iset-gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>;
 	};
 
+	board_id: board_id {
+		compatible = "voltage-divider";
+		io-channels = <&adc 0>;
+		output-ohms = <20000>;
+		full-ohms = <47000>;
+		power-gpios = <&gpio0 24 GPIO_ACTIVE_HIGH>;
+	};
+
 	pwmleds {
 		compatible = "pwm-leds";
 		rgb1_red_pwm_led: pwm_led_0 {
@@ -84,6 +92,18 @@
 
 &adc {
 	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_VDD_1_4";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 40)>;
+		zephyr,input-positive = <NRF_SAADC_AIN6>;
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
 };
 
 &gpiote {

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -184,8 +184,14 @@
 
 		spi-max-frequency = <8000000>;
 	};
+
 	cs47l63: cs47l63@1 {
+		compatible = "cirrus,cs47l63";
 		reg = <1>;
+		spi-max-frequency = <8000000>;
+		irq-gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+		gpio9-gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/dts/bindings/sound/cirrus,cs47l63.yaml
+++ b/dts/bindings/sound/cirrus,cs47l63.yaml
@@ -1,0 +1,82 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Cirrus Logic CS47L63 Low-Power Audio DSP
+
+compatible: "cirrus,cs47l63"
+
+include: spi-device.yaml
+
+properties:
+  reg:
+    required: true
+
+  irq-gpios:
+    type: phandle-array
+    description:
+      Interrupt request (IRQ) output.
+
+  reset-gpios:
+    type: phandle-array
+    description:
+      Digital reset input.
+
+  gpio1-gpios:
+    type: phandle-array
+    description:
+      GPIO1 input with bus-keeper
+
+  gpio2-gpios:
+    type: phandle-array
+    description:
+      GPIO2 input with bus-keeper
+
+  gpio3-gpios:
+    type: phandle-array
+    description:
+      GPIO3 input with bus-keeper
+
+  gpio4-gpios:
+    type: phandle-array
+    description:
+      GPIO4 input with bus-keeper
+
+  gpio5-gpios:
+    type: phandle-array
+    description:
+      GPIO5 input with bus-keeper
+
+  gpio6-gpios:
+    type: phandle-array
+    description:
+      GPIO6 input with bus-keeper
+
+  gpio7-gpios:
+    type: phandle-array
+    description:
+      GPIO7 input with bus-keeper
+
+  gpio8-gpios:
+    type: phandle-array
+    description:
+      GPIO8 input with bus-keeper
+
+  gpio9-gpios:
+    type: phandle-array
+    description:
+      GPIO9 input with bus-keeper
+
+  gpio10-gpios:
+    type: phandle-array
+    description:
+      GPIO10 input with bus-keeper
+
+  gpio11-gpios:
+    type: phandle-array
+    description:
+      GPIO11 input with bus-keeper
+
+  gpio12-gpios:
+    type: phandle-array
+    description:
+      GPIO12 input with bus-keeper


### PR DESCRIPTION
The board had a few missing hardware description entries, most notably:

- Audio codec, which had an entry without any binding (so no properties)
- Board ID circuitry (a voltage divider)
- Codec control multiplexer

This PR is an alternative to https://github.com/zephyrproject-rtos/zephyr/pull/55639, where DT was not being used properly. Sorry if I've missed/misunderstood something. Refer to each commit for more details.

Ref. https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/dev-kits/nrf5340-audio-dk/nrf5340-audio-development-kit---hardware-files-1_0_0.zip