### PR TITLE
tests: Bluetooth: Shell: Add LC3 support for native_posix

### DIFF
--- a/tests/bluetooth/shell/boards/native_posix.conf
+++ b/tests/bluetooth/shell/boards/native_posix.conf
@@ -7,3 +7,12 @@ CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=4096
 # 5ms ISO interval bidirectional data the system shall never stall for more
 # than 1.5 ms in average.
 CONFIG_SYS_CLOCK_TICKS_PER_SEC=500
+
+# For LC3 the following configs are needed
+CONFIG_FPU=y
+CONFIG_LIBLC3=y
+# The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
+# inctease stack size for that thread.
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+# LC3 lib requires floating point support in the c-lib NEWLIB is one way of getting that.
+CONFIG_NEWLIB_LIBC=y


### PR DESCRIPTION
The native_posix board can also be used for audio, and thus should have LC3 support similar to the nrf5340.