### PR TITLE
tests: remove subsys as component name from some tests

### DIFF
--- a/tests/net/lib/lwm2m/lwm2m_engine/testcase.yaml
+++ b/tests/net/lib/lwm2m/lwm2m_engine/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   depends_on: netif
 tests:
-  subsys.net.lib.lwm2m.lwm2m_engine:
+  net.lwm2m.lwm2m_engine:
     platform_allow: native_posix
     tags: lwm2m net

--- a/tests/net/lib/lwm2m/lwm2m_rd_client/testcase.yaml
+++ b/tests/net/lib/lwm2m/lwm2m_rd_client/testcase.yaml
@@ -7,7 +7,7 @@ common:
     - qemu_x86
 
 tests:
-  subsys.net.lib.lwm2m_rd_client:
+  net.lwm2m.lwm2m_rd_client:
     extra_args: EXTRA_CFLAGS=""
-  subsys.net.lib.lwm2m_rd_client_dtls:
+  net.lwm2m.lwm2m_rd_client_dtls:
     extra_args: EXTRA_CFLAGS=-DCONFIG_LWM2M_DTLS_SUPPORT

--- a/tests/net/lib/lwm2m/lwm2m_registry/testcase.yaml
+++ b/tests/net/lib/lwm2m/lwm2m_registry/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   depends_on: netif
 tests:
-  subsys.net.lib.lwm2m.lwm2m_registry:
+  net.lwm2m.lwm2m_registry:
     tags: lwm2m net
     filter: TOOLCHAIN_HAS_NEWLIB == 1

--- a/tests/subsys/emul/testcase.yaml
+++ b/tests/subsys/emul/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  subsys.emul:
-    tags: devicetree
+  emul.emul:
+    tags: emul
     platform_allow: native_posix

--- a/tests/subsys/input/api/testcase.yaml
+++ b/tests/subsys/input/api/testcase.yaml
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 tests:
-  subsys.input.api.thread:
+  input.api.thread:
     tags: input
     integration_platforms:
       - native_posix
     extra_configs:
       - CONFIG_INPUT_MODE_THREAD=y
       - CONFIG_INPUT_THREAD_STACK_SIZE=1024
-  subsys.input.api.synchronous:
+  input.api.synchronous:
     tags: input
     integration_platforms:
       - native_posix

--- a/tests/subsys/rtio/rtio_api/testcase.yaml
+++ b/tests/subsys/rtio/rtio_api/testcase.yaml
@@ -4,20 +4,20 @@ common:
     - arch
     - simulation
 tests:
-  subsys.rtio.api:
+  rtio.api:
     filter: not CONFIG_ARCH_HAS_USERSPACE
     tags: rtio
-  subsys.rtio.api.submit_sem:
+  rtio.api.submit_sem:
     filter: not CONFIG_ARCH_HAS_USERSPACE
     tags: rtio
     extra_configs:
       - CONFIG_RTIO_SUBMIT_SEM=y
-  subsys.rtio.api.userspace:
+  rtio.api.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y
     tags: rtio userspace
-  subsys.rtio.api.userspace.submit_sem:
+  rtio.api.userspace.submit_sem:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y

--- a/tests/subsys/sd/mmc/testcase.yaml
+++ b/tests/subsys/sd/mmc/testcase.yaml
@@ -2,7 +2,7 @@ common:
   depends_on: sdhc
   tags: drivers sdhc
 tests:
-  subsys.sd.mmc:
+  sd.mmc:
     harness: ztest
     filter: dt_compat_enabled("zephyr,mmc-disk")
     tags: sdhc

--- a/tests/subsys/sd/sdmmc/testcase.yaml
+++ b/tests/subsys/sd/sdmmc/testcase.yaml
@@ -2,7 +2,7 @@ common:
   depends_on: sdhc
   tags: drivers sdhc
 tests:
-  subsys.sd.sdmmc:
+  sd.sdmmc:
     harness: ztest
     harness_config:
       fixture: fixture_sdhc


### PR DESCRIPTION
- tests: lwm2m: fix test identifier
- tests: emul: remove subsys from test identifer
- tests: input: remove subsys from test identifer
- tests: rtio: remove subsys from test identifer
- tests: sd: remove subsys from test identifer
