### PR TITLE
Add nRF5340 Audio dk board configs

### DIFF
--- a/samples/bluetooth/unicast_audio_client/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/unicast_audio_client/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -1,0 +1,8 @@
+# For LC3 the following configs are needed
+CONFIG_FPU=y
+CONFIG_LIBLC3=y
+# The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
+# inctease stack size for that thread.
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+# LC3 lib requires floating point support in the c-lib NEWLIB is one way of getting that.
+CONFIG_NEWLIB_LIBC=y

--- a/samples/bluetooth/unicast_audio_server/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/unicast_audio_server/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -1,0 +1,8 @@
+# For LC3 the following configs are needed
+CONFIG_FPU=y
+CONFIG_LIBLC3=y
+# The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
+# inctease stack size for that thread.
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+# LC3 lib requires floating point support in the c-lib NEWLIB is one way of getting that.
+CONFIG_NEWLIB_LIBC=y

--- a/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -1,0 +1,8 @@
+# For LC3 the following configs are needed
+CONFIG_FPU=y
+CONFIG_LIBLC3=y
+# The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
+# inctease stack size for that thread.
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+# LC3 lib requires floating point support in the c-lib NEWLIB is one way of getting that.
+CONFIG_NEWLIB_LIBC=y


### PR DESCRIPTION
Add nRF5340 Audio dk board configs to samples and the BT shell similar to what we have for the non-audio nRF5340 DK