### PR TITLE
tests: drivers: can: timing: remove superfluous timing test

### DIFF
--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -53,13 +53,8 @@ static const struct can_timing_test can_timing_tests[] = {
 	{  125000, 800, false },
 	/** Valid bitrate, invalid sample point. */
 	{  125000, 1000, true },
-#ifdef CONFIG_CAN_FD_MODE
-	/** Invalid CAN-FD bitrate, valid sample point. */
-	{ 8000000 + 1, 750, true },
-#else /* CONFIG_CAN_FD_MODE */
-	/** Invalid classical bitrate, valid sample point. */
+	/** Invalid classic/arbitration bitrate, valid sample point. */
 	{ 1000000 + 1, 750, true },
-#endif /* CONFIG_CAN_FD_MODE */
 };
 
 /**


### PR DESCRIPTION
Remove test for attempting to set an arbitration bitrate of 8000001 bit/s. This test belongs in the data phase timing test, where it already present as well.