### PR TITLE
tests: drivers: can: timing: use recommended sample point

### DIFF
--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -69,7 +69,7 @@ static const struct can_timing_test can_timing_tests[] = {
 static const struct can_timing_test can_timing_data_tests[] = {
 	/** Standard bitrates. */
 	{  500000, 875, false },
-	{ 1000000, 875, false },
+	{ 1000000, 750, false },
 	/** Additional, valid sample points. */
 	{  500000, 900, false },
 	{  500000, 800, false },


### PR DESCRIPTION
Use the recommended sample point of 75.0% for the data phase bitrate test @ 1Mbit/s. This matches the default sample point calculated in can_common.c:sample_point_for_bitrate().