### PR TITLE
net: lwm2m: Typo in LWM2M_IPSO_TIMER description

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig.ipso
+++ b/subsys/net/lib/lwm2m/Kconfig.ipso
@@ -215,7 +215,7 @@ config LWM2M_IPSO_BUZZER_VERSION_1_1
 endchoice
 
 config LWM2M_IPSO_TIMER
-	bool "IPSO Light Control Support"
+	bool "IPSO Timer Support"
 	help
 	  This Object is used to time events / actions
 


### PR DESCRIPTION
Changed description to "IPSO Timer Support" in place of "Light Control Support"