### PR TITLE
manifest: Give the option to get BabbleSim via the manifest

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -69,6 +69,7 @@ jobs:
     - name: west setup
       run: |
         west init -l .
+        west update bsim
 
     - name: build-docs
       run: |
@@ -154,6 +155,7 @@ jobs:
     - name: west setup
       run: |
         west init -l .
+        west update bsim
 
     - name: build-docs
       run: |

--- a/west.yml
+++ b/west.yml
@@ -22,9 +22,16 @@ manifest:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
 
+  group-filter: [-babblesim]
+
   #
   # Please add items below based on alphabetical order
   projects:
+    - name: bsim
+      repo-path: babblesim-manifest
+      revision: 908ffde6298a937c6549dbfa843a62caab26bfc5
+      import:
+        path-prefix: tools
     - name: canopennode
       revision: dec12fa3f0d790cafa8414a4c2930ea71ab72ffd
       path: modules/lib/canopennode


### PR DESCRIPTION
To improve users experience, give the option to users to fetch the required BabbleSim components using the west manifest.
Until now, users would need to either use the Zephyr docker image, or fetch bsim on their own.
For many years there has been a request to automate this process. This is the first step.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55698

Note: A set of follow ups could/would:
* For developers ease, have cmake find the simulator thru west if the environment variables that tell where
the simulator is are not set.  https://github.com/aescolar/zephyr/commit/9e331be4c79a1cdab7e0ad0a3cfe2cb36017e575 
* Add a cmake check to check the simulator is the necessary version, and otherwise instruct users to west update and rebuild it: https://github.com/aescolar/zephyr/commit/d9a49dced8f6b9c7b6dfbd4f017bca7c2e1d2155
* Have CI use the version of the simulator in the manifest