### PR TITLE
Adding FMC support to STM32U5

### DIFF
--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -14,6 +14,7 @@
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
 #include <zephyr/dt-bindings/reset/stm32u5_reset.h>
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
+#include <zephyr/dt-bindings/memory-controller/stm32-fmc-nor-psram.h>
 #include <freq.h>
 
 / {
@@ -682,6 +683,20 @@
 			dma-requests = <114>;
 			dma-offset = <0>;
 			status = "disabled";
+		};
+
+		fmc: memory-controller@420d0400 {
+			compatible = "st,stm32-fmc";
+			reg = <0x420d0400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2_2 0x00000001>;
+			status = "disabled";
+
+			sram {
+				compatible = "st,stm32-fmc-nor-psram";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
 		};
 	};
 

--- a/tests/drivers/memc/ram/testcase.yaml
+++ b/tests/drivers/memc/ram/testcase.yaml
@@ -1,4 +1,8 @@
 tests:
+  drivers.memc.stm32_fmc_nor_psram:
+    tags: drivers memc
+    depends_on: memc
+    filter: dt_compat_enabled("st,stm32-fmc-nor-psram")
   drivers.memc.stm32_sdram:
     tags: drivers memc
     depends_on: memc


### PR DESCRIPTION
Adding fmc definition to device tree and solved a minor warning.