### PR TITLE
doc: Clean up documentation for cycle counter API

### DIFF
--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -119,6 +119,37 @@ extern uint32_t sys_clock_elapsed(void);
 extern void sys_clock_disable(void);
 
 /**
+ * @brief Hardware cycle counter
+ *
+ * Timer drivers are generally responsible for the system cycle
+ * counter as well as the tick announcements.  This function is
+ * generally called out of the architecture layer (@see
+ * arch_k_cycle_get_32()) to implement the cycle counter, though the
+ * user-facing API is owned by the architecture, not the driver.  The
+ * rate must match CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC.
+ *
+ * @return The current cycle time.  This should count up monotonically
+ * through the full 32 bit space, wrapping at 0xffffffff.  Hardware
+ * with fewer bits of precision in the timer is expected to synthesize
+ * a 32 bit count.
+ */
+uint32_t sys_clock_cycle_get_32(void);
+
+/**
+ * @brief 64 bit hardware cycle counter
+ *
+ * As for sys_clock_cycle_get_32(), but with a 64 bit return value.
+ * Not all hardware has 64 bit counters.  This function need be
+ * implemented only if CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER is set.
+ *
+ * @return The current cycle time.  This should count up monotonically
+ * through the full 64 bit space, wrapping at 2^64-1.  Hardware with
+ * fewer bits of precision in the timer is generally not expected to
+ * implement this API.
+ */
+uint64_t sys_clock_cycle_get_64(void);
+
+/**
  * @}
  */
 

--- a/include/zephyr/sys/arch_interface.h
+++ b/include/zephyr/sys/arch_interface.h
@@ -52,16 +52,32 @@ typedef void (*k_thread_entry_t)(void *p1, void *p2, void *p3);
  */
 
 /**
- * Obtain the current cycle count, in units that are hardware-specific
+ * Obtain the current cycle count, in units specified by
+ * CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC.  While this is historically
+ * specified as part of the architecture API, in practice virtually
+ * all platforms forward it to the sys_clock_cycle_get_32() API
+ * provided by the timer driver.
  *
  * @see k_cycle_get_32()
+ *
+ * @return The current cycle time.  This should count up monotonically
+ * through the full 32 bit space, wrapping at 0xffffffff.  Hardware
+ * with fewer bits of precision in the timer is expected to synthesize
+ * a 32 bit count.
  */
 static inline uint32_t arch_k_cycle_get_32(void);
 
 /**
- * Obtain the current cycle count, in units that are hardware-specific
+ * As for arch_k_cycle_get_32(), but with a 64 bit return value.  Not
+ * all timer hardware has a 64 bit timer, this needs to be implemented
+ * only if CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER is set.
  *
- * @see k_cycle_get_64()
+ * @see arch_k_cycle_get_32()
+ *
+ * @return The current cycle time.  This should count up monotonically
+ * through the full 64 bit space, wrapping at 2^64-1.  Hardware with
+ * fewer bits of precision in the timer is generally not expected to
+ * implement this API.
  */
 static inline uint64_t arch_k_cycle_get_64(void);
 


### PR DESCRIPTION
Discussion in #55658 showed that our API docs for the hardware cycle counter layer were a little lacking.  Technically it's owned by the architecture layer, but the arch docs were unhelpful.  And the arch layers uniformly farm it out to an API in the timer drivers that was never documented at all.  Clean things up.