### PR TITLE
Bluetooth: Audio: Rename BT_AUDIO_LC3_PRESET to BT_BAP...

### DIFF
--- a/include/zephyr/bluetooth/audio/bap_lc3_preset.h
+++ b/include/zephyr/bluetooth/audio/bap_lc3_preset.h
@@ -19,7 +19,7 @@ struct bt_bap_lc3_preset {
 };
 
 /** Helper to declare an LC3 preset structure */
-#define BT_AUDIO_LC3_PRESET(_codec, _qos)                                                          \
+#define BT_BAP_LC3_PRESET(_codec, _qos)                                                            \
 	{                                                                                          \
 		.codec = _codec, .qos = _qos,                                                      \
 	}
@@ -33,8 +33,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_8_1_1(_loc, _stream_context)                                     \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_1(_loc, _stream_context),                        \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 2u, 8u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_1(_loc, _stream_context),                          \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 2u, 8u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 8_2_1 codec configuration
@@ -43,8 +43,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_8_2_1(_loc, _stream_context)                                     \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_2(_loc, _stream_context),                        \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 2u, 10u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_2(_loc, _stream_context),                          \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 2u, 10u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 16_1_1 codec configuration
@@ -53,8 +53,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_16_1_1(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 2u, 8u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 2u, 8u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 16_2_1 codec configuration
@@ -65,8 +65,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_16_2_1(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 2u, 10u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 2u, 10u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 24_1_1 codec configuration
@@ -75,8 +75,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_24_1_1(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 2u, 8u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 2u, 8u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 24_2_1 codec configuration
@@ -87,8 +87,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_24_2_1(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 2u, 10u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 2u, 10u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 32_1_1 codec configuration
@@ -97,8 +97,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_32_1_1(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 2u, 8u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 2u, 8u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 32_2_1 codec configuration
@@ -107,8 +107,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_32_2_1(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 2u, 10u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 2u, 10u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 441_1_1 codec configuration
@@ -117,7 +117,7 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_441_1_1(_loc, _stream_context)                                   \
-	BT_AUDIO_LC3_PRESET(                                                                       \
+	BT_BAP_LC3_PRESET(                                                                         \
 		BT_CODEC_LC3_CONFIG_441_1(_loc, _stream_context),                                  \
 		BT_CODEC_QOS(8163u, BT_CODEC_QOS_FRAMED, BT_CODEC_QOS_2M, 97u, 5u, 24u, 40000u))
 
@@ -128,7 +128,7 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_441_2_1(_loc, _stream_context)                                   \
-	BT_AUDIO_LC3_PRESET(                                                                       \
+	BT_BAP_LC3_PRESET(                                                                         \
 		BT_CODEC_LC3_CONFIG_441_2(_loc, _stream_context),                                  \
 		BT_CODEC_QOS(10884u, BT_CODEC_QOS_FRAMED, BT_CODEC_QOS_2M, 130u, 5u, 31u, 40000u))
 
@@ -139,8 +139,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_1_1(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 5u, 15u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 5u, 15u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 48_2_1 codec configuration
@@ -149,8 +149,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_2_1(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 5u, 20u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 5u, 20u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 48_3_1 codec configuration
@@ -159,8 +159,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_3_1(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_3(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 5u, 15u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_3(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 5u, 15u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 48_4_1 codec configuration
@@ -169,8 +169,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_4_1(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_4(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 5u, 20u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_4(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 5u, 20u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 8_5_1 codec configuration
@@ -179,8 +179,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_5_1(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_5(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 5u, 15u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_5(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 5u, 15u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 48_6_1 codec configuration
@@ -189,8 +189,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_6_1(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_6(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 5u, 20u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_6(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 5u, 20u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 8_1_2 codec configuration
@@ -200,8 +200,8 @@ struct bt_bap_lc3_preset {
  */
 /* Following presets are for unicast high reliability audio data */
 #define BT_BAP_LC3_UNICAST_PRESET_8_1_2(_loc, _stream_context)                                     \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_1(_loc, _stream_context),                        \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 13u, 75u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_1(_loc, _stream_context),                          \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 13u, 75u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 8_2_2 codec configuration
@@ -210,8 +210,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_8_2_2(_loc, _stream_context)                                     \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_2(_loc, _stream_context),                        \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 13u, 95u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_2(_loc, _stream_context),                          \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 13u, 95u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 16_1_2 codec configuration
@@ -220,8 +220,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_16_1_2(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 13u, 75u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 13u, 75u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 16_2_2 codec configuration
@@ -230,8 +230,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_16_2_2(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 13u, 95u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 13u, 95u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 24_1_2 codec configuration
@@ -240,8 +240,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_24_1_2(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 13u, 75u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 13u, 75u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 24_2_2 codec configuration
@@ -250,8 +250,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_24_2_2(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 13u, 95u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 13u, 95u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 32_1_2 codec configuration
@@ -260,8 +260,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_32_1_2(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 13u, 75u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 13u, 75u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 32_2_2 codec configuration
@@ -270,8 +270,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_32_2_2(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 13u, 95u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 13u, 95u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 441_1_2 codec configuration
@@ -280,7 +280,7 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_441_1_2(_loc, _stream_context)                                   \
-	BT_AUDIO_LC3_PRESET(                                                                       \
+	BT_BAP_LC3_PRESET(                                                                         \
 		BT_CODEC_LC3_CONFIG_441_1(_loc, _stream_context),                                  \
 		BT_CODEC_QOS(8163u, BT_CODEC_QOS_FRAMED, BT_CODEC_QOS_2M, 97u, 13u, 80u, 40000u))
 
@@ -291,9 +291,9 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_441_2_2(_loc, _stream_context)                                   \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_441_2(_loc, _stream_context),                      \
-			    BT_CODEC_QOS(10884u, BT_CODEC_QOS_FRAMED, BT_CODEC_QOS_2M, 130u, 13u,  \
-					 85u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_441_2(_loc, _stream_context),                        \
+			  BT_CODEC_QOS(10884u, BT_CODEC_QOS_FRAMED, BT_CODEC_QOS_2M, 130u, 13u,    \
+				       85u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 48_1_2 codec configuration
@@ -302,8 +302,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_1_2(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 13u, 75u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 13u, 75u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 48_2_2 codec configuration
@@ -312,8 +312,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_2_2(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 13u, 95u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 13u, 95u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 48_3_2 codec configuration
@@ -322,8 +322,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_3_2(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_3(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 13u, 75u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_3(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 13u, 75u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 48_4_2 codec configuration
@@ -332,8 +332,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_4_2(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_4(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 13u, 100u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_4(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 13u, 100u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 48_5_2 codec configuration
@@ -342,8 +342,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_5_2(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_5(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 13u, 75u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_5(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 13u, 75u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Unicast 48_6_2 codec configuration
@@ -352,8 +352,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_UNICAST_PRESET_48_6_2(_loc, _stream_context)                                    \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_6(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 13u, 100u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_6(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 13u, 100u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 8_1_1 codec configuration
@@ -363,8 +363,8 @@ struct bt_bap_lc3_preset {
  */
 /* LC3 Broadcast presets defined by table 6.4 in the BAP v1.0 specification */
 #define BT_BAP_LC3_BROADCAST_PRESET_8_1_1(_loc, _stream_context)                                   \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_1(_loc, _stream_context),                        \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 2u, 8u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_1(_loc, _stream_context),                          \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 2u, 8u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 8_2_1 codec configuration
@@ -373,8 +373,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_8_2_1(_loc, _stream_context)                                   \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_2(_loc, _stream_context),                        \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 2u, 10u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_2(_loc, _stream_context),                          \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 2u, 10u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 16_1_1 codec configuration
@@ -383,8 +383,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_16_1_1(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 2u, 8u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 2u, 8u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 16_2_1 codec configuration
@@ -395,8 +395,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_16_2_1(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 2u, 10u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 2u, 10u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 24_1_1 codec configuration
@@ -405,8 +405,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_24_1_1(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 2u, 8u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 2u, 8u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 24_2_1 codec configuration
@@ -417,8 +417,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_24_2_1(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 2u, 10u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 2u, 10u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 32_1_1 codec configuration
@@ -427,8 +427,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_32_1_1(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 2u, 8u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 2u, 8u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 32_2_1 codec configuration
@@ -437,8 +437,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_32_2_1(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 2u, 10u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 2u, 10u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 441_1_1 codec configuration
@@ -447,7 +447,7 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_441_1_1(_loc, _stream_context)                                 \
-	BT_AUDIO_LC3_PRESET(                                                                       \
+	BT_BAP_LC3_PRESET(                                                                         \
 		BT_CODEC_LC3_CONFIG_441_1(_loc, _stream_context),                                  \
 		BT_CODEC_QOS(8163u, BT_CODEC_QOS_FRAMED, BT_CODEC_QOS_2M, 97u, 4u, 24u, 40000u))
 
@@ -458,7 +458,7 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_441_2_1(_loc, _stream_context)                                 \
-	BT_AUDIO_LC3_PRESET(                                                                       \
+	BT_BAP_LC3_PRESET(                                                                         \
 		BT_CODEC_LC3_CONFIG_441_2(_loc, _stream_context),                                  \
 		BT_CODEC_QOS(10884u, BT_CODEC_QOS_FRAMED, BT_CODEC_QOS_2M, 130u, 4u, 31u, 40000u))
 
@@ -469,8 +469,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_1_1(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 4u, 15u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 4u, 15u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 48_2_1 codec configuration
@@ -479,8 +479,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_2_1(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 4u, 20u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 4u, 20u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 48_3_1 codec configuration
@@ -489,8 +489,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_3_1(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_3(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 4u, 15u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_3(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 4u, 15u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 48_4_1 codec configuration
@@ -499,8 +499,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_4_1(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_4(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 4u, 20u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_4(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 4u, 20u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 48_5_1 codec configuration
@@ -509,8 +509,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_5_1(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_5(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 4u, 15u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_5(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 4u, 15u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 48_6_1 codec configuration
@@ -519,8 +519,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_6_1(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_6(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 4u, 20u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_6(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 4u, 20u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 8_1_2 codec configuration
@@ -530,8 +530,8 @@ struct bt_bap_lc3_preset {
  */
 /* Following presets are for broadcast high reliability audio data */
 #define BT_BAP_LC3_BROADCAST_PRESET_8_1_2(_loc, _stream_context)                                   \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_1(_loc, _stream_context),                        \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 4u, 45u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_1(_loc, _stream_context),                          \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 4u, 45u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 8_2_2 codec configuration
@@ -540,8 +540,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_8_2_2(_loc, _stream_context)                                   \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_2(_loc, _stream_context),                        \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 4u, 60u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_8_2(_loc, _stream_context),                          \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 4u, 60u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 16_1_2 codec configuration
@@ -550,8 +550,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_16_1_2(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 4u, 45u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 4u, 45u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 16_2_2 codec configuration
@@ -562,8 +562,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_16_2_2(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 4u, 60u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_16_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 4u, 60u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 24_1_2 codec configuration
@@ -572,8 +572,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_24_1_2(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 4u, 45u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 4u, 45u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 24_2_2 codec configuration
@@ -584,8 +584,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_24_2_2(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 4u, 60u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_24_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 4u, 60u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 32_1_2 codec configuration
@@ -594,8 +594,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_32_1_2(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 4u, 45u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 4u, 45u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 32_2_2 codec configuration
@@ -604,8 +604,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_32_2_2(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 4u, 60u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_32_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 4u, 60u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 441_1_2 codec configuration
@@ -614,7 +614,7 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_441_1_2(_loc, _stream_context)                                 \
-	BT_AUDIO_LC3_PRESET(                                                                       \
+	BT_BAP_LC3_PRESET(                                                                         \
 		BT_CODEC_LC3_CONFIG_441_1(_loc, _stream_context),                                  \
 		BT_CODEC_QOS(8163u, BT_CODEC_QOS_FRAMED, BT_CODEC_QOS_2M, 97u, 4u, 54u, 40000u))
 
@@ -625,7 +625,7 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_441_2_2(_loc, _stream_context)                                 \
-	BT_AUDIO_LC3_PRESET(                                                                       \
+	BT_BAP_LC3_PRESET(                                                                         \
 		BT_CODEC_LC3_CONFIG_441_2(_loc, _stream_context),                                  \
 		BT_CODEC_QOS(10884u, BT_CODEC_QOS_FRAMED, BT_CODEC_QOS_2M, 130u, 4u, 60u, 40000u))
 
@@ -636,8 +636,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_1_2(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 4u, 50u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_1(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 4u, 50u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 48_2_2 codec configuration
@@ -646,8 +646,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_2_2(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 4u, 65u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_2(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 4u, 65u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 48_3_2 codec configuration
@@ -656,8 +656,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_3_2(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_3(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 4u, 50u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_3(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 4u, 50u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 48_4_2 codec configuration
@@ -666,8 +666,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_4_2(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_4(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 4u, 65u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_4(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 4u, 65u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 48_5_2 codec configuration
@@ -676,8 +676,8 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_5_2(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_5(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 4u, 50u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_5(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 4u, 50u, 40000u))
 
 /**
  *  @brief Helper to declare LC3 Broadcast 48_6_2 codec configuration
@@ -686,7 +686,7 @@ struct bt_bap_lc3_preset {
  *  @param _stream_context  Stream context (BT_AUDIO_CONTEXT_*)
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_48_6_2(_loc, _stream_context)                                  \
-	BT_AUDIO_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_6(_loc, _stream_context),                       \
-			    BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 4u, 65u, 40000u))
+	BT_BAP_LC3_PRESET(BT_CODEC_LC3_CONFIG_48_6(_loc, _stream_context),                         \
+			  BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 4u, 65u, 40000u))
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_BAP_LC3_PRESET_ */


### PR DESCRIPTION
This was missing from the recent BT_AUDIO -> BT_BAP rename.