### PR TITLE
drivers: can: add CAN-FD Error State Indicator (ESI) flag

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -643,6 +643,10 @@ static void can_mcan_get_message(const struct device *dev,
 			frame.flags |= CAN_FRAME_BRS;
 		}
 
+		if (hdr.esi != 0) {
+			frame.flags |= CAN_FRAME_ESI;
+		}
+
 #if defined(CONFIG_CAN_RX_TIMESTAMP)
 		frame.timestamp = hdr.rxts;
 #endif

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -72,7 +72,9 @@ static void can_shell_print_frame(const struct shell *sh, const struct can_frame
 
 #ifdef CONFIG_CAN_FD_MODE
 	/* Flags */
-	shell_fprintf(sh, SHELL_NORMAL, "%c  ", (frame->flags & CAN_FRAME_BRS) == 0 ? '-' : 'B');
+	shell_fprintf(sh, SHELL_NORMAL, "%c%c  ",
+		      (frame->flags & CAN_FRAME_BRS) == 0 ? '-' : 'B',
+		      (frame->flags & CAN_FRAME_ESI) == 0 ? '-' : 'P');
 #endif /* CONFIG_CAN_FD_MODE */
 
 	/* CAN ID */

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -145,6 +145,11 @@ enum can_state {
 /** Frame uses CAN-FD Baud Rate Switch (BRS). Only valid in combination with ``CAN_FRAME_FDF``. */
 #define CAN_FRAME_BRS BIT(3)
 
+/** CAN-FD Error State Indicator (ESI). Indicates that the transmitting node is in error-passive
+ * state. Only valid in combination with ``CAN_FRAME_FDF``.
+ */
+#define CAN_FRAME_ESI BIT(4)
+
 /** @} */
 
 /**


### PR DESCRIPTION
- Add definition for the CAN-FD Error State Indicator (ESI) flag. The presence of this flag indicates that the transmitting CAN-FD node is in error-passive state.
- In the CAN shell module, print the CAN-FD Error State Indicator (ESI) flag as "P" for "Passive" in received frames.
- Add support for the CAN-FD Error State Indicator (ESI) flag in received frames in the Bosch M_CAN driver backend.