### PR TITLE
doc: west: fix WestCommand self.configuration -> self.config

### DIFF
--- a/doc/develop/west/west-apis.rst
+++ b/doc/develop/west/west-apis.rst
@@ -34,7 +34,7 @@ provided.
 WestCommand
 ===========
 
-.. py:class:: west.commands.WestCommand
+.. autoclass:: west.commands.WestCommand
 
    Instance attributes:
 
@@ -223,7 +223,7 @@ Since west v0.13, the recommended class for reading this is
 :py:class:`west.configuration.Configuration`.
 
 Note that if you are writing a :ref:`west extension <west-extensions>`, you can
-access the current ``Configuration`` object as ``self.configuration``. See
+access the current ``Configuration`` object as ``self.config``. See
 :py:class:`west.commands.WestCommand`.
 
 Configuration API


### PR DESCRIPTION
WestCommand has no .configuration field, it's .config.

In the same (and cursed!) sentence, also fix the broken link to west.command.WestCommand by switching the link target from the unusual `py:class::` to the common `autoclass::` used by all other classes in the same page. I don't understand why that fixes the hyperlink but it works and it's consistent.