### PR TITLE
tests: drivers: regulator: fixed: Unify set of pins for nrf9160dk_nrf9160

### DIFF
--- a/tests/drivers/regulator/fixed/boards/nrf9160dk_nrf9160.overlay
+++ b/tests/drivers/regulator/fixed/boards/nrf9160dk_nrf9160.overlay
@@ -7,12 +7,12 @@
 
 / {
 	regulator {
-		/* Arduino D0 */
-		enable-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		/* Arduino D10 */
+		enable-gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
 	};
 	resources {
-		/* Arduino D1 */
-		check-gpios = <&gpio0 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+		/* Arduino D11 */
+		check-gpios = <&gpio0 11 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 	};
 };
 


### PR DESCRIPTION
Unify set of the pins on `nrf9160dk_nrf9160`, which is used by `gpio_loopback` fixture.