### PR TITLE
LE Audio: BAP shell improvements

### DIFF
--- a/doc/connectivity/bluetooth/api/shell/bap.rst
+++ b/doc/connectivity/bluetooth/api/shell/bap.rst
@@ -28,7 +28,7 @@ Commands
       stop_broadcast_sink  :Stops broadcast sink
       term_broadcast_sink  :
       discover             :[dir: sink, source]
-      config               :<direction: sink, source> <index> [preset]
+      config               :<direction: sink, source> <index> [loc <loc_bits>] [preset <preset_name>]
       stream_qos           :interval [framing] [latency] [pd] [sdu] [phy] [rtn]
       qos                  :Send QoS configure for Unicast Group
       enable               :[context]
@@ -286,7 +286,7 @@ or in case it is omitted the default preset is used.
 
 .. code-block:: console
 
-   uart:~$ bap config <direction: sink, source> <index> [preset]
+   uart:~$ bap config <direction: sink, source> <index> [loc <loc_bits>] [preset <preset_name>]
    uart:~$ bap config sink 0
    ASE Codec Config: conn 0x8173800 ep 0x81754e0 cap 0x816a360
    codec 0x06 cid 0x0000 vid 0x0000 count 3

--- a/doc/connectivity/bluetooth/api/shell/bap.rst
+++ b/doc/connectivity/bluetooth/api/shell/bap.rst
@@ -18,30 +18,36 @@ Commands
    Subcommands:
       init
       select_broadcast     :<stream>
-      create_broadcast     :[codec] [preset]
+      create_broadcast     :[preset <preset_name>] [enc <broadcast_code>]
       start_broadcast      :
       stop_broadcast       :
       delete_broadcast     :
       broadcast_scan       :<on, off>
       accept_broadcast     :0x<broadcast_id>
-      sync_broadcast       :0x<bis_bitfield>
+      sync_broadcast       :0x<bis_index> [[[0x<bis_index>] 0x<bis_index>] ...]
       stop_broadcast_sink  :Stops broadcast sink
       term_broadcast_sink  :
-      discover             :[type: sink, source]
-      preset               :[preset]
-      config               :<direction: sink, source> <index> [codec] [preset]
-      qos                  :[preset] [interval] [framing] [latency] [pd] [sdu] [phy]
-                            [rtn]
-      enable
+      discover             :[dir: sink, source]
+      config               :<direction: sink, source> <index> [preset]
+      stream_qos           :interval [framing] [latency] [pd] [sdu] [phy] [rtn]
+      qos                  :Send QoS configure for Unicast Group
+      enable               :[context]
+      stop
+      print_ase_info       :Print ASE info for default connection
       metadata             :[context]
       start
       disable
-      stop
       release
       list
-      connect              :<direction: sink, source> <index>  [codec] [preset]
       select_unicast       :<stream>
+      preset               :<sink, source, broadcast> [preset]
       send                 :Send to Audio Stream [data]
+      start_sine           :Start sending a LC3 encoded sine wave
+      stop_sine            :Stop sending a LC3 encoded sine wave
+      set_location         :<direction: sink, source> <location bitmask>
+      set_context          :<direction: sink, source><context bitmask> <type:
+                            supported, available>
+
 
 .. csv-table:: State Machine Transitions
    :header: "Command", "Depends", "Allowed States", "Next States"
@@ -237,19 +243,33 @@ any stream previously configured.
 
 .. code-block:: console
 
-   uart:~$ bap preset [preset]
-   uart:~$ bap preset
+   uart:~$ bap preset <sink, source, broadcast> [preset]
+   uart:~$ bap preset sink
    16_2_1
-   codec 0x06 cid 0x0000 vid 0x0000 count 3
+   codec 0x06 cid 0x0000 vid 0x0000 count 4
    data #0: type 0x01 len 1
-   00000000: 02                                             |.                |
    data #1: type 0x02 len 1
-   00000000: 01                                             |.                |
-   data #2: type 0x04 len 2
-   00000000: 28 00                                          |(.               |
+   data #2: type 0x03 len 4
+   00000000: 01 00 00                                         |...              |
+   data #3: type 0x04 len 2
+   00000000: 28                                               |(                |
    meta #0: type 0x02 len 2
-   00000000: 02 00                                          |..               |
-   QoS: dir 0x02 interval 10000 framing 0x00 phy 0x02 sdu 40 rtn 2 latency 10 pd 40000
+   00000000: 06                                               |.                |
+   QoS: interval 10000 framing 0x00 phy 0x02 sdu 40 rtn 2 latency 10 pd 40000
+
+   uart:~$ bap preset sink 32_2_1
+   32_2_1
+   codec 0x06 cid 0x0000 vid 0x0000 count 4
+   data #0: type 0x01 len 1
+   data #1: type 0x02 len 1
+   data #2: type 0x03 len 4
+   00000000: 01 00 00                                         |...              |
+   data #3: type 0x04 len 2
+   00000000: 50                                               |P                |
+   meta #0: type 0x02 len 2
+   00000000: 06                                               |.                |
+   QoS: interval 10000 framing 0x00 phy 0x02 sdu 80 rtn 2 latency 10 pd 40000
+
 
 Configure Codec
 ***************
@@ -266,7 +286,7 @@ or in case it is omitted the default preset is used.
 
 .. code-block:: console
 
-   uart:~$ bap config <direction: sink, source> <index> [codec] [preset]
+   uart:~$ bap config <direction: sink, source> <index> [preset]
    uart:~$ bap config sink 0
    ASE Codec Config: conn 0x8173800 ep 0x81754e0 cap 0x816a360
    codec 0x06 cid 0x0000 vid 0x0000 count 3
@@ -281,6 +301,16 @@ or in case it is omitted the default preset is used.
    ASE Codec Config stream 0x8179e60
    Default ase: 1
    ASE config: preset 16_2_1
+
+Configure Stream QoS
+********************
+
+The :code:`stream_qos` Sets a new stream QoS.
+
+.. code-block:: console
+
+   uart:~$ bap stream_qos <interval> [framing] [latency] [pd] [sdu] [phy] [rtn]
+   uart:~$ bap stream_qos 10
 
 Configure QoS
 *************
@@ -297,9 +327,7 @@ parameters.
 
 .. code-block:: console
 
-   uart:~$ bap qos [preset] [interval] [framing] [latency] [pd] [sdu] [phy] [rtn]
    uart:~$ bap qos
-   ASE config: preset 16_2_1
 
 Enable
 ******
@@ -315,10 +343,11 @@ if the remote peer accepts then the ISO connection procedure is also initiated.
 
 .. code-block:: console
 
-   uart:~$ bap enable
+   uart:~$ bap enable [context]
+   uart:~$ bap enable Media
 
-Start [sink only]
-*****************
+Start
+*****
 
 The :code:`start` command is only necessary when acting as a sink as it
 indicates to the source the stack is ready to start receiving data.
@@ -350,8 +379,8 @@ initiated.
 
    uart:~$ bap disable
 
-Stop [sink only]
-****************
+Stop
+****
 
 The :code:`stop` command is only necessary when acting as a sink as it indicates
 to the source the stack is ready to stop receiving data.
@@ -420,49 +449,6 @@ To select a broadcast stream:
 
    uart:~$ bap select 0x01 broadcast
    Default stream: 1 (broadcast)
-
-Connect
-*******
-
-The :code:`connect` command combines config, qos and enable commands in one so
-it can be used to quickly configure and enable a stream.
-
-.. csv-table:: State Machine Transitions
-   :header: "Depends", "Allowed States", "Next States"
-   :widths: auto
-
-   "discover","idle/codec-configured/qos-configured","streaming"
-
-.. code-block:: console
-
-   uart:~$ bap connect <direction: sink, source> <index> [codec] [preset]
-   uart:~$ bap connect sink 0
-   ASE Codec Config: conn 0x17ca40 ep 0x17f860 cap 0x19f6a0
-   codec 0x06 cid 0x0000 vid 0x0000 count 3
-   data #0: type 0x01 len 1
-   00000000: 02                                               |.                |
-   data #1: type 0x02 len 1
-   00000000: 01                                               |.                |
-   data #2: type 0x04 len 2
-   00000000: 28 00                                            |(.               |
-   meta #0: type 0x02 len 2
-   00000000: 02 00                                            |..               |
-   ASE Codec Config stream 0x1851c0
-   Default ase: 1
-   ASE config: preset 16_2_1
-   ASE Codec Reconfig: stream 0x1851c0 cap 0x19f6a0
-   codec 0x06 cid 0x0000 vid 0x0000 count 3
-   data #0: type 0x01 len 1
-   00000000: 02                                               |.                |
-   data #1: type 0x02 len 1
-   00000000: 01                                               |.                |
-   data #2: type 0x04 len 2
-   00000000: 28 00                                            |(.               |
-   meta #0: type 0x02 len 2
-   00000000: 02 00                                            |..               |
-   QoS: stream 0x1851c0
-   QoS: dir 0x02 interval 10000 framing 0x00 phy 0x02 sdu 40 rtn 2 latency 10 pd 40000
-   Start: stream 0x1851c0
 
 Send
 ****

--- a/subsys/bluetooth/shell/bap.c
+++ b/subsys/bluetooth/shell/bap.c
@@ -896,6 +896,7 @@ static int cmd_discover(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 {
+	enum bt_audio_location location = BT_AUDIO_LOCATION_PROHIBITED;
 	const struct named_lc3_preset *named_preset;
 	struct unicast_stream *uni_stream;
 	struct bt_bap_ep *ep = NULL;
@@ -949,11 +950,49 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	if (argc > 3) {
-		named_preset = get_named_preset(true, argv[3]);
-		if (named_preset == NULL) {
-			shell_error(sh, "Unable to parse named_preset %s", argv[3]);
-			return -ENOEXEC;
+	for (size_t i = 3U; i < argc; i++) {
+		const char *arg = argv[i];
+
+		/* argc needs to be larger than `i` to parse the argument value */
+		if (argc <= i) {
+			shell_help(sh);
+
+			return SHELL_CMD_HELP_PRINTED;
+		}
+
+		if (strcmp(arg, "loc") == 0) {
+			unsigned long loc_bits;
+
+			arg = argv[++i];
+			loc_bits = shell_strtoul(arg, 0, &err);
+			if (err != 0) {
+				shell_error(sh, "Could not parse loc_bits: %d", err);
+
+				return -ENOEXEC;
+			}
+
+			if (loc_bits == BT_AUDIO_LOCATION_PROHIBITED ||
+			    loc_bits > BT_AUDIO_LOCATION_ANY) {
+				shell_error(sh, "Invalid loc_bits: %lu", loc_bits);
+
+				return -ENOEXEC;
+			}
+
+			location = (enum bt_audio_location)loc_bits;
+		} else if (strcmp(arg, "preset") == 0) {
+			if (argc > i) {
+				arg = argv[++i];
+
+				named_preset = get_named_preset(true, arg);
+				if (named_preset == NULL) {
+					shell_error(sh, "Unable to parse named_preset %s", arg);
+					return -ENOEXEC;
+				}
+			} else {
+				shell_help(sh);
+
+				return SHELL_CMD_HELP_PRINTED;
+			}
 		}
 	}
 
@@ -971,6 +1010,23 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 		struct bt_codec_data *data = &uni_stream->codec.meta[i];
 
 		data->data.data = data->value;
+	}
+
+	/* If location has been modifed, we update the location in the codec configuration */
+	if (location != BT_AUDIO_LOCATION_PROHIBITED) {
+		for (size_t i = 0U; i < uni_stream->codec.data_count; i++) {
+			struct bt_codec_data *data = &uni_stream->codec.data[i];
+
+			/* Overwrite the location value */
+			if (data->data.type == BT_CODEC_CONFIG_LC3_CHAN_ALLOC) {
+				const uint32_t loc_32 = location;
+
+				sys_put_le32(loc_32, data->value);
+
+				shell_print(sh, "Setting location to 0x%08X", location);
+				break;
+			}
+		}
 	}
 
 	if (default_stream->ep == ep) {
@@ -2336,7 +2392,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 #if defined(CONFIG_BT_BAP_UNICAST)
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 	SHELL_CMD_ARG(discover, NULL, "[dir: sink, source]", cmd_discover, 1, 1),
-	SHELL_CMD_ARG(config, NULL, "<direction: sink, source> <index> [preset]", cmd_config, 3, 1),
+	SHELL_CMD_ARG(config, NULL,
+		      "<direction: sink, source> <index> [loc <loc_bits>] [preset <preset_name>]",
+		      cmd_config, 3, 4),
 	SHELL_CMD_ARG(stream_qos, NULL, "interval [framing] [latency] [pd] [sdu] [phy] [rtn]",
 		      cmd_stream_qos, 2, 6),
 	SHELL_CMD_ARG(qos, NULL, "Send QoS configure for Unicast Group", cmd_qos, 1, 0),

--- a/subsys/bluetooth/shell/bap.c
+++ b/subsys/bluetooth/shell/bap.c
@@ -830,40 +830,17 @@ static uint16_t strmeta(const char *name)
 	return 0u;
 }
 
-static int handle_metadata_update(struct bt_codec *codec,
-				  const char *meta_str,
-				  struct bt_codec_data *meta_out[],
-				  size_t *meta_count_out)
+static int set_metadata(struct bt_codec *codec, const char *meta_str)
 {
-	static struct bt_codec_data meta[CONFIG_BT_CODEC_MAX_METADATA_COUNT];
-	size_t meta_count;
+	uint16_t context;
 
-	/* We create a copy of the preset meta, as the presets cannot be modified */
-	meta_count = codec->meta_count;
-	(void)memset(meta, 0, sizeof(meta));
-
-	for (size_t i = 0U; i < meta_count; i++) {
-		(void)memcpy(meta[i].value, codec->meta[i].data.data,
-			     codec->meta[i].data.data_len);
-		meta[i].data.data_len = codec->meta[i].data.data_len;
-		meta[i].data.type = codec->meta[i].data.type;
-		meta[i].data.data = meta[i].value;
+	context = strmeta(meta_str);
+	if (context == 0) {
+		return -ENOEXEC;
 	}
 
-	if (meta_str != NULL) {
-		uint16_t context;
-
-		context = strmeta(meta_str);
-		if (context == 0) {
-			return -ENOEXEC;
-		}
-
-		/* TODO: Check the type and only overwrite the streaming context */
-		sys_put_le16(context, meta[0].value);
-	}
-
-	*meta_count_out = meta_count;
-	*meta_out = meta;
+	/* TODO: Check the type and only overwrite the streaming context */
+	sys_put_le16(context, codec->meta[0].value);
 
 	return 0;
 }
@@ -1247,9 +1224,7 @@ static int cmd_qos(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_enable(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct bt_codec_data *meta;
 	struct bt_codec *codec;
-	size_t meta_count;
 	int err;
 
 	if (default_stream == NULL) {
@@ -1260,17 +1235,14 @@ static int cmd_enable(const struct shell *sh, size_t argc, char *argv[])
 	codec = default_stream->codec;
 
 	if (argc > 1) {
-		err = handle_metadata_update(codec, argv[1], &meta, &meta_count);
-	} else {
-		err = handle_metadata_update(codec, NULL, &meta, &meta_count);
+		err = set_metadata(codec, argv[1]);
+		if (err != 0) {
+			shell_error(sh, "Unable to handle metadata update: %d", err);
+			return err;
+		}
 	}
 
-	if (err != 0) {
-		shell_error(sh, "Unable to handle metadata update: %d", err);
-		return err;
-	}
-
-	err = bt_bap_stream_enable(default_stream, meta, meta_count);
+	err = bt_bap_stream_enable(default_stream, codec->meta, codec->meta_count);
 	if (err) {
 		shell_error(sh, "Unable to enable Channel");
 		return -ENOEXEC;
@@ -1338,9 +1310,7 @@ static int cmd_preset(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_metadata(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct bt_codec_data *meta;
 	struct bt_codec *codec;
-	size_t meta_count;
 	int err;
 
 	if (default_stream == NULL) {
@@ -1351,17 +1321,14 @@ static int cmd_metadata(const struct shell *sh, size_t argc, char *argv[])
 	codec = default_stream->codec;
 
 	if (argc > 1) {
-		err = handle_metadata_update(codec, argv[1], &meta, &meta_count);
-	} else {
-		err = handle_metadata_update(codec, NULL, &meta, &meta_count);
+		err = set_metadata(codec, argv[1]);
+		if (err != 0) {
+			shell_error(sh, "Unable to handle metadata update: %d", err);
+			return err;
+		}
 	}
 
-	if (err != 0) {
-		shell_error(sh, "Unable to handle metadata update: %d", err);
-		return err;
-	}
-
-	err = bt_bap_stream_metadata(default_stream, meta, meta_count);
+	err = bt_bap_stream_metadata(default_stream, codec->meta, codec->meta_count);
 	if (err) {
 		shell_error(sh, "Unable to set Channel metadata");
 		return -ENOEXEC;
@@ -2385,7 +2352,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "[preset] [interval] [framing] [latency] [pd] [sdu] [phy]"
 		      " [rtn]",
 		      cmd_qos, 1, 8),
-	SHELL_CMD_ARG(enable, NULL, NULL, cmd_enable, 1, 1),
+	SHELL_CMD_ARG(enable, NULL, "[context]", cmd_enable, 1, 1),
 	SHELL_CMD_ARG(stop, NULL, NULL, cmd_stop, 1, 0),
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
 #if defined(CONFIG_BT_BAP_UNICAST_SERVER)

--- a/subsys/bluetooth/shell/bap.c
+++ b/subsys/bluetooth/shell/bap.c
@@ -405,158 +405,23 @@ static void print_codec(const struct bt_codec *codec)
 	}
 }
 
-static const struct named_lc3_preset *set_preset(enum bt_audio_dir dir, bool is_unicast,
-						 size_t argc, char **argv)
+static const struct named_lc3_preset *get_named_preset(bool is_unicast, const char *preset_arg)
 {
-	static struct named_lc3_preset named_preset;
-	const struct named_lc3_preset *set_preset = NULL;
-	int err = 0;
-
 	if (is_unicast) {
 		for (size_t i = 0U; i < ARRAY_SIZE(lc3_unicast_presets); i++) {
-			if (!strcmp(argv[0], lc3_unicast_presets[i].name)) {
-				if (dir == BT_AUDIO_DIR_SINK) {
-					default_sink_preset = &lc3_unicast_presets[i];
-					set_preset = default_sink_preset;
-				} else {
-					default_source_preset = &lc3_unicast_presets[i];
-					set_preset = default_source_preset;
-				}
-
-				break;
+			if (!strcmp(preset_arg, lc3_unicast_presets[i].name)) {
+				return &lc3_unicast_presets[i];
 			}
 		}
 	} else {
 		for (size_t i = 0U; i < ARRAY_SIZE(lc3_broadcast_presets); i++) {
-			if (!strcmp(argv[0], lc3_broadcast_presets[i].name)) {
-				default_broadcast_source_preset = &lc3_broadcast_presets[i];
-				set_preset = default_broadcast_source_preset;
-				break;
+			if (!strcmp(preset_arg, lc3_broadcast_presets[i].name)) {
+				return &lc3_broadcast_presets[i];
 			}
 		}
 	}
 
-	if (argc == 1) {
-		return set_preset;
-	}
-
-	named_preset = *set_preset;
-	set_preset = &named_preset;
-
-	if (argc > 1) {
-		unsigned long interval;
-
-		interval = shell_strtoul(argv[1], 0, &err);
-		if (err != 0) {
-			return NULL;
-		}
-
-		if (!IN_RANGE(interval,
-			      BT_ISO_SDU_INTERVAL_MIN,
-			      BT_ISO_SDU_INTERVAL_MAX)) {
-			return NULL;
-		}
-
-		named_preset.preset.qos.interval = interval;
-	}
-
-	if (argc > 2) {
-		unsigned long framing;
-
-		framing = shell_strtoul(argv[2], 0, &err);
-		if (err != 0) {
-			return NULL;
-		}
-
-		if (!IN_RANGE(framing,
-			      BT_ISO_FRAMING_UNFRAMED,
-			      BT_ISO_FRAMING_FRAMED)) {
-			return NULL;
-		}
-
-		named_preset.preset.qos.framing = framing;
-	}
-
-	if (argc > 3) {
-		unsigned long latency;
-
-		latency = shell_strtoul(argv[3], 0, &err);
-		if (err != 0) {
-			return NULL;
-		}
-
-		if (!IN_RANGE(latency,
-			      BT_ISO_LATENCY_MIN,
-			      BT_ISO_LATENCY_MAX)) {
-			return NULL;
-		}
-
-		named_preset.preset.qos.latency = latency;
-	}
-
-	if (argc > 4) {
-		unsigned long pd;
-
-		pd = shell_strtoul(argv[4], 0, &err);
-		if (err != 0) {
-			return NULL;
-		}
-
-		if (pd > BT_AUDIO_PD_MAX) {
-			return NULL;
-		}
-
-		named_preset.preset.qos.pd = pd;
-	}
-
-	if (argc > 5) {
-		unsigned long sdu;
-
-		sdu = shell_strtoul(argv[5], 0, &err);
-		if (err != 0) {
-			return NULL;
-		}
-
-		if (sdu > BT_ISO_MAX_SDU) {
-			return NULL;
-		}
-
-		named_preset.preset.qos.sdu = sdu;
-	}
-
-	if (argc > 6) {
-		unsigned long phy;
-
-		phy = shell_strtoul(argv[6], 0, &err);
-		if (err != 0) {
-			return NULL;
-		}
-
-		if (phy != BT_GAP_LE_PHY_1M &&
-		    phy != BT_GAP_LE_PHY_2M &&
-		    phy != BT_GAP_LE_PHY_CODED) {
-			return NULL;
-		}
-
-		named_preset.preset.qos.phy = phy;
-	}
-
-	if (argc > 7) {
-		unsigned long rtn;
-
-		rtn = shell_strtoul(argv[7], 0, &err);
-		if (err != 0) {
-			return NULL;
-		}
-
-		if (rtn > BT_ISO_CONNECTED_RTN_MAX) {
-			return NULL;
-		}
-
-		named_preset.preset.qos.rtn = rtn;
-	}
-
-	return set_preset;
+	return NULL;
 }
 
 static void set_unicast_stream(struct bt_bap_stream *stream)
@@ -1034,7 +899,6 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 	const struct named_lc3_preset *named_preset;
 	struct unicast_stream *uni_stream;
 	struct bt_bap_ep *ep = NULL;
-	enum bt_audio_dir dir;
 	unsigned long index;
 	int err = 0;
 
@@ -1064,7 +928,6 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 
 #if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0
 	} else if (!strcmp(argv[1], "sink")) {
-		dir = BT_AUDIO_DIR_SINK;
 		ep = snks[index];
 
 		named_preset = default_source_preset;
@@ -1072,7 +935,6 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 
 #if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0
 	} else if (!strcmp(argv[1], "source")) {
-		dir = BT_AUDIO_DIR_SOURCE;
 		ep = srcs[index];
 
 		named_preset = default_sink_preset;
@@ -1088,10 +950,9 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (argc > 3) {
-		named_preset = set_preset(dir, true, 1, argv + 3);
+		named_preset = get_named_preset(true, argv[3]);
 		if (named_preset == NULL) {
-			shell_error(sh, "Unable to parse named_preset %s",
-				    argv[4]);
+			shell_error(sh, "Unable to parse named_preset %s", argv[3]);
 			return -ENOEXEC;
 		}
 	}
@@ -1128,6 +989,129 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	shell_print(sh, "ASE config: preset %s", named_preset->name);
+
+	return 0;
+}
+
+static int cmd_stream_qos(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct bt_codec_qos *qos;
+	unsigned long interval;
+	int err;
+
+	if (default_stream == NULL) {
+		shell_print(sh, "No stream selected");
+		return -ENOEXEC;
+	}
+
+	qos = default_stream->qos;
+
+	if (qos == NULL) {
+		shell_print(sh, "Stream not configured");
+		return -ENOEXEC;
+	}
+
+	interval = shell_strtoul(argv[1], 0, &err);
+	if (err != 0) {
+		return -ENOEXEC;
+	}
+
+	if (!IN_RANGE(interval, BT_ISO_SDU_INTERVAL_MIN, BT_ISO_SDU_INTERVAL_MAX)) {
+		return -ENOEXEC;
+	}
+
+	qos->interval = interval;
+
+	if (argc > 2) {
+		unsigned long framing;
+
+		framing = shell_strtoul(argv[2], 0, &err);
+		if (err != 0) {
+			return -ENOEXEC;
+		}
+
+		if (!IN_RANGE(framing, BT_ISO_FRAMING_UNFRAMED, BT_ISO_FRAMING_FRAMED)) {
+			return -ENOEXEC;
+		}
+
+		qos->framing = framing;
+	}
+
+	if (argc > 3) {
+		unsigned long latency;
+
+		latency = shell_strtoul(argv[3], 0, &err);
+		if (err != 0) {
+			return -ENOEXEC;
+		}
+
+		if (!IN_RANGE(latency, BT_ISO_LATENCY_MIN, BT_ISO_LATENCY_MAX)) {
+			return -ENOEXEC;
+		}
+
+		qos->latency = latency;
+	}
+
+	if (argc > 4) {
+		unsigned long pd;
+
+		pd = shell_strtoul(argv[4], 0, &err);
+		if (err != 0) {
+			return -ENOEXEC;
+		}
+
+		if (pd > BT_AUDIO_PD_MAX) {
+			return -ENOEXEC;
+		}
+
+		qos->pd = pd;
+	}
+
+	if (argc > 5) {
+		unsigned long sdu;
+
+		sdu = shell_strtoul(argv[5], 0, &err);
+		if (err != 0) {
+			return -ENOEXEC;
+		}
+
+		if (sdu > BT_ISO_MAX_SDU) {
+			return -ENOEXEC;
+		}
+
+		qos->sdu = sdu;
+	}
+
+	if (argc > 6) {
+		unsigned long phy;
+
+		phy = shell_strtoul(argv[6], 0, &err);
+		if (err != 0) {
+			return -ENOEXEC;
+		}
+
+		if (phy != BT_GAP_LE_PHY_1M && phy != BT_GAP_LE_PHY_2M &&
+		    phy != BT_GAP_LE_PHY_CODED) {
+			return -ENOEXEC;
+		}
+
+		qos->phy = phy;
+	}
+
+	if (argc > 7) {
+		unsigned long rtn;
+
+		rtn = shell_strtoul(argv[7], 0, &err);
+		if (err != 0) {
+			return -ENOEXEC;
+		}
+
+		if (rtn > BT_ISO_CONNECTED_RTN_MAX) {
+			return -ENOEXEC;
+		}
+
+		qos->rtn = rtn;
+	}
 
 	return 0;
 }
@@ -1273,27 +1257,34 @@ static int cmd_stop(const struct shell *sh, size_t argc, char *argv[])
 static int cmd_preset(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct named_lc3_preset *named_preset;
-	enum bt_audio_dir dir;
+	bool unicast = true;
 
 	if (!strcmp(argv[1], "sink")) {
-		dir = BT_AUDIO_DIR_SINK;
-
 		named_preset = default_sink_preset;
 	} else if (!strcmp(argv[1], "source")) {
-		dir = BT_AUDIO_DIR_SOURCE;
-
 		named_preset = default_source_preset;
+	} else if (!strcmp(argv[1], "broadcast")) {
+		unicast = false;
+
+		named_preset = default_broadcast_source_preset;
 	} else {
 		shell_error(sh, "Unsupported dir: %s", argv[1]);
 		return -ENOEXEC;
 	}
 
 	if (argc > 2) {
-		named_preset = set_preset(dir, true, argc - 2, argv + 2);
+		named_preset = get_named_preset(unicast, argv[2]);
 		if (named_preset == NULL) {
-			shell_error(sh, "Unable to parse named_preset %s",
-				    argv[1]);
+			shell_error(sh, "Unable to parse named_preset %s", argv[2]);
 			return -ENOEXEC;
+		}
+
+		if (!strcmp(argv[1], "sink")) {
+			default_sink_preset = named_preset;
+		} else if (!strcmp(argv[1], "source")) {
+			default_source_preset = named_preset;
+		} else if (!strcmp(argv[1], "broadcast")) {
+			default_broadcast_source_preset = named_preset;
 		}
 	}
 
@@ -1751,8 +1742,7 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 				i++;
 				arg = argv[i];
 
-				named_preset = set_preset(BT_AUDIO_DIR_SOURCE,
-							  false, 1, &arg);
+				named_preset = get_named_preset(false, arg);
 				if (named_preset == NULL) {
 					shell_error(sh, "Unable to parse named_preset %s",
 						    arg);
@@ -2346,12 +2336,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 #if defined(CONFIG_BT_BAP_UNICAST)
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 	SHELL_CMD_ARG(discover, NULL, "[dir: sink, source]", cmd_discover, 1, 1),
-	SHELL_CMD_ARG(config, NULL, "<direction: sink, source> <index> [codec] [preset]",
-		      cmd_config, 3, 2),
-	SHELL_CMD_ARG(qos, NULL,
-		      "[preset] [interval] [framing] [latency] [pd] [sdu] [phy]"
-		      " [rtn]",
-		      cmd_qos, 1, 8),
+	SHELL_CMD_ARG(config, NULL, "<direction: sink, source> <index> [preset]", cmd_config, 3, 1),
+	SHELL_CMD_ARG(stream_qos, NULL, "interval [framing] [latency] [pd] [sdu] [phy] [rtn]",
+		      cmd_stream_qos, 2, 6),
+	SHELL_CMD_ARG(qos, NULL, "Send QoS configure for Unicast Group", cmd_qos, 1, 0),
 	SHELL_CMD_ARG(enable, NULL, "[context]", cmd_enable, 1, 1),
 	SHELL_CMD_ARG(stop, NULL, NULL, cmd_stop, 1, 0),
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
@@ -2359,7 +2347,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(print_ase_info, NULL, "Print ASE info for default connection",
 		      cmd_print_ase_info, 0, 0),
 #endif /* CONFIG_BT_BAP_UNICAST_SERVER */
-	SHELL_CMD_ARG(preset, NULL, "dir [preset]", cmd_preset, 2, 1),
 	SHELL_CMD_ARG(metadata, NULL, "[context]", cmd_metadata, 1, 1),
 	SHELL_CMD_ARG(start, NULL, NULL, cmd_start, 1, 0),
 	SHELL_CMD_ARG(disable, NULL, NULL, cmd_disable, 1, 0),
@@ -2367,6 +2354,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(list, NULL, NULL, cmd_list, 1, 0),
 	SHELL_CMD_ARG(select_unicast, NULL, "<stream>", cmd_select_unicast, 2, 0),
 #endif /* CONFIG_BT_BAP_UNICAST */
+	SHELL_CMD_ARG(preset, NULL, "<sink, source, broadcast> [preset]", cmd_preset, 2, 1),
 	SHELL_CMD_ARG(send, NULL, "Send to Audio Stream [data]", cmd_send, 1, 1),
 #if defined(CONFIG_LIBLC3)
 	SHELL_CMD_ARG(start_sine, NULL, "Start sending a LC3 encoded sine wave", cmd_start_sine, 1,

--- a/subsys/bluetooth/shell/bap.c
+++ b/subsys/bluetooth/shell/bap.c
@@ -40,7 +40,8 @@
 		     CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT),                                  \
 		    (0))
 
-static struct bt_bap_stream streams[UNICAST_SERVER_STREAM_COUNT + UNICAST_CLIENT_STREAM_COUNT];
+static struct bt_bap_stream
+	unicast_streams[UNICAST_SERVER_STREAM_COUNT + UNICAST_CLIENT_STREAM_COUNT];
 
 static const struct bt_codec_qos_pref qos_pref = BT_CODEC_QOS_PREF(true, BT_GAP_LE_PHY_2M, 0u, 60u,
 								   20000u, 40000u, 20000u, 40000u);
@@ -555,15 +556,13 @@ static struct named_lc3_preset *set_preset(enum bt_audio_dir dir,
 	return set_preset;
 }
 
-static void set_stream(struct bt_bap_stream *stream)
+static void set_unicast_stream(struct bt_bap_stream *stream)
 {
-	int i;
-
 	default_stream = stream;
 
-	for (i = 0; i < ARRAY_SIZE(streams); i++) {
-		if (stream == &streams[i]) {
-			shell_print(ctx_shell, "Default stream: %u", i + 1);
+	for (size_t i = 0; i < ARRAY_SIZE(unicast_streams); i++) {
+		if (stream == &unicast_streams[i]) {
+			shell_print(ctx_shell, "Default stream: %zu", i + 1);
 		}
 	}
 }
@@ -589,23 +588,23 @@ static int cmd_select_unicast(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	if (index > ARRAY_SIZE(streams)) {
+	if (index > ARRAY_SIZE(unicast_streams)) {
 		shell_error(sh, "Invalid index: %lu", index);
 
 		return -ENOEXEC;
 	}
 
-	stream = &streams[index];
+	stream = &unicast_streams[index];
 
-	set_stream(stream);
+	set_unicast_stream(stream);
 
 	return 0;
 }
 
 static struct bt_bap_stream *stream_alloc(void)
 {
-	for (size_t i = 0; i < ARRAY_SIZE(streams); i++) {
-		struct bt_bap_stream *stream = &streams[i];
+	for (size_t i = 0; i < ARRAY_SIZE(unicast_streams); i++) {
+		struct bt_bap_stream *stream = &unicast_streams[i];
 
 		if (!stream->conn) {
 			return stream;
@@ -625,14 +624,14 @@ static int lc3_config(struct bt_conn *conn, const struct bt_bap_ep *ep, enum bt_
 
 	*stream = stream_alloc();
 	if (*stream == NULL) {
-		shell_print(ctx_shell, "No streams available");
+		shell_print(ctx_shell, "No unicast_streams available");
 
 		return -ENOMEM;
 	}
 
 	shell_print(ctx_shell, "ASE Codec Config stream %p", *stream);
 
-	set_stream(*stream);
+	set_unicast_stream(*stream);
 
 	*pref = qos_pref;
 
@@ -647,7 +646,7 @@ static int lc3_reconfig(struct bt_bap_stream *stream, enum bt_audio_dir dir,
 	print_codec(codec);
 
 	if (default_stream == NULL) {
-		set_stream(stream);
+		set_unicast_stream(stream);
 	}
 
 	*pref = qos_pref;
@@ -1070,7 +1069,7 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	if (index > ARRAY_SIZE(streams)) {
+	if (index > ARRAY_SIZE(unicast_streams)) {
 		shell_error(sh, "Invalid index: %lu", index);
 
 		return -ENOEXEC;
@@ -1123,7 +1122,7 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 		int err;
 
 		if (default_stream == NULL) {
-			stream = &streams[0];
+			stream = &unicast_streams[0];
 		} else {
 			stream = default_stream;
 		}
@@ -1145,8 +1144,8 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 
 static int create_unicast_group(const struct shell *sh)
 {
-	struct bt_bap_unicast_group_stream_pair_param pair_param[ARRAY_SIZE(streams)];
-	struct bt_bap_unicast_group_stream_param stream_params[ARRAY_SIZE(streams)];
+	struct bt_bap_unicast_group_stream_pair_param pair_param[ARRAY_SIZE(unicast_streams)];
+	struct bt_bap_unicast_group_stream_param stream_params[ARRAY_SIZE(unicast_streams)];
 	struct bt_bap_unicast_group_param group_param;
 	size_t source_cnt = 0;
 	size_t sink_cnt = 0;
@@ -1157,8 +1156,8 @@ static int create_unicast_group(const struct shell *sh)
 	memset(stream_params, 0, sizeof(stream_params));
 	memset(&group_param, 0, sizeof(group_param));
 
-	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
-		struct bt_bap_stream *stream = &streams[i];
+	for (size_t i = 0U; i < ARRAY_SIZE(unicast_streams); i++) {
+		struct bt_bap_stream *stream = &unicast_streams[i];
 
 		if (stream->ep != NULL) {
 			struct bt_bap_unicast_group_stream_param *stream_param;
@@ -1398,8 +1397,8 @@ static int cmd_list(const struct shell *sh, size_t argc, char *argv[])
 
 	shell_print(sh, "Configured Channels:");
 
-	for (i = 0; i < ARRAY_SIZE(streams); i++) {
-		struct bt_bap_stream *stream = &streams[i];
+	for (i = 0; i < ARRAY_SIZE(unicast_streams); i++) {
+		struct bt_bap_stream *stream = &unicast_streams[i];
 
 		if (stream->conn) {
 			shell_print(sh, "  %s#%u: stream %p ep %p group %p",
@@ -1699,7 +1698,6 @@ static struct bt_bap_stream_ops stream_ops = {
 static int cmd_select_broadcast_source(const struct shell *sh, size_t argc,
 				       char *argv[])
 {
-	struct bt_bap_stream *stream;
 	unsigned long index;
 	int err = 0;
 
@@ -1716,9 +1714,7 @@ static int cmd_select_broadcast_source(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	stream = &broadcast_source_streams[index];
-
-	set_stream(stream);
+	default_stream = &broadcast_source_streams[index];
 
 	return 0;
 }
@@ -2178,8 +2174,8 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 #if defined(CONFIG_BT_BAP_UNICAST)
-	for (i = 0; i < ARRAY_SIZE(streams); i++) {
-		bt_bap_stream_cb_register(&streams[i], &stream_ops);
+	for (i = 0; i < ARRAY_SIZE(unicast_streams); i++) {
+		bt_bap_stream_cb_register(&unicast_streams[i], &stream_ops);
 	}
 #endif /* CONFIG_BT_BAP_UNICAST */
 

--- a/subsys/bluetooth/shell/bap.c
+++ b/subsys/bluetooth/shell/bap.c
@@ -40,8 +40,11 @@
 		     CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT),                                  \
 		    (0))
 
-static struct bt_bap_stream
-	unicast_streams[UNICAST_SERVER_STREAM_COUNT + UNICAST_CLIENT_STREAM_COUNT];
+static struct unicast_stream {
+	struct bt_bap_stream stream;
+	struct bt_codec codec;
+	struct bt_codec_qos qos;
+} unicast_streams[UNICAST_SERVER_STREAM_COUNT + UNICAST_CLIENT_STREAM_COUNT];
 
 static const struct bt_codec_qos_pref qos_pref = BT_CODEC_QOS_PREF(true, BT_GAP_LE_PHY_2M, 0u, 60u,
 								   20000u, 40000u, 20000u, 40000u);
@@ -60,6 +63,8 @@ static struct bt_bap_ep *srcs[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT];
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
 static struct bt_bap_stream broadcast_source_streams[CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT];
 static struct bt_bap_broadcast_source *default_source;
+static struct bt_codec broadcast_source_codec;
+static struct bt_codec_qos broadcast_source_qos;
 #endif /* CONFIG_BT_BAP_BROADCAST_SOURCE */
 #if defined(CONFIG_BT_BAP_BROADCAST_SINK)
 static struct bt_bap_stream broadcast_sink_streams[BROADCAST_SNK_STREAM_CNT];
@@ -75,7 +80,7 @@ struct named_lc3_preset {
 	struct bt_bap_lc3_preset preset;
 };
 
-static struct named_lc3_preset lc3_unicast_presets[] = {
+static const struct named_lc3_preset lc3_unicast_presets[] = {
 	{"8_1_1", BT_BAP_LC3_UNICAST_PRESET_8_1_1(LOCATION, CONTEXT)},
 	{"8_2_1", BT_BAP_LC3_UNICAST_PRESET_8_2_1(LOCATION, CONTEXT)},
 	{"16_1_1", BT_BAP_LC3_UNICAST_PRESET_16_1_1(LOCATION, CONTEXT)},
@@ -111,7 +116,7 @@ static struct named_lc3_preset lc3_unicast_presets[] = {
 	{"48_6_2", BT_BAP_LC3_UNICAST_PRESET_48_6_2(LOCATION, CONTEXT)},
 };
 
-static struct named_lc3_preset lc3_broadcast_presets[] = {
+static const struct named_lc3_preset lc3_broadcast_presets[] = {
 	{"8_1_1", BT_BAP_LC3_BROADCAST_PRESET_8_1_1(LOCATION, CONTEXT)},
 	{"8_2_1", BT_BAP_LC3_BROADCAST_PRESET_8_2_1(LOCATION, CONTEXT)},
 	{"16_1_1", BT_BAP_LC3_BROADCAST_PRESET_16_1_1(LOCATION, CONTEXT)},
@@ -148,9 +153,9 @@ static struct named_lc3_preset lc3_broadcast_presets[] = {
 };
 
 /* Default to 16_2_1 */
-static struct named_lc3_preset *default_sink_preset = &lc3_unicast_presets[3];
-static struct named_lc3_preset *default_source_preset = &lc3_unicast_presets[3];
-static struct named_lc3_preset *default_broadcast_source_preset = &lc3_broadcast_presets[3];
+static const struct named_lc3_preset *default_sink_preset = &lc3_unicast_presets[3];
+static const struct named_lc3_preset *default_source_preset = &lc3_unicast_presets[3];
+static const struct named_lc3_preset *default_broadcast_source_preset = &lc3_broadcast_presets[3];
 static bool initialized;
 
 static uint16_t get_next_seq_num(uint32_t interval_us)
@@ -400,13 +405,11 @@ static void print_codec(const struct bt_codec *codec)
 	}
 }
 
-static struct named_lc3_preset *set_preset(enum bt_audio_dir dir,
-					   bool is_unicast,
-					   size_t argc,
-					   char **argv)
+static const struct named_lc3_preset *set_preset(enum bt_audio_dir dir, bool is_unicast,
+						 size_t argc, char **argv)
 {
 	static struct named_lc3_preset named_preset;
-	struct named_lc3_preset *set_preset = NULL;
+	const struct named_lc3_preset *set_preset = NULL;
 	int err = 0;
 
 	if (is_unicast) {
@@ -561,7 +564,7 @@ static void set_unicast_stream(struct bt_bap_stream *stream)
 	default_stream = stream;
 
 	for (size_t i = 0; i < ARRAY_SIZE(unicast_streams); i++) {
-		if (stream == &unicast_streams[i]) {
+		if (stream == &unicast_streams[i].stream) {
 			shell_print(ctx_shell, "Default stream: %zu", i + 1);
 		}
 	}
@@ -594,7 +597,7 @@ static int cmd_select_unicast(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	stream = &unicast_streams[index];
+	stream = &unicast_streams[index].stream;
 
 	set_unicast_stream(stream);
 
@@ -604,7 +607,7 @@ static int cmd_select_unicast(const struct shell *sh, size_t argc, char *argv[])
 static struct bt_bap_stream *stream_alloc(void)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(unicast_streams); i++) {
-		struct bt_bap_stream *stream = &unicast_streams[i];
+		struct bt_bap_stream *stream = &unicast_streams[i].stream;
 
 		if (!stream->conn) {
 			return stream;
@@ -1051,8 +1054,9 @@ static int cmd_discover(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 {
+	const struct named_lc3_preset *named_preset;
+	struct unicast_stream *uni_stream;
 	struct bt_bap_ep *ep = NULL;
-	struct named_lc3_preset *named_preset;
 	enum bt_audio_dir dir;
 	unsigned long index;
 	int err = 0;
@@ -1060,6 +1064,10 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 	if (!default_conn) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
+	}
+
+	if (default_stream == NULL) {
+		default_stream = &unicast_streams[0].stream;
 	}
 
 	index = shell_strtoul(argv[2], 0, &err);
@@ -1111,30 +1119,35 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 		}
 	}
 
-	if (default_stream && default_stream->ep == ep) {
-		if (bt_bap_stream_reconfig(default_stream,
-					     &named_preset->preset.codec) < 0) {
-			shell_error(sh, "Unable reconfig stream");
+	uni_stream = CONTAINER_OF(default_stream, struct unicast_stream, stream);
+	memcpy(&uni_stream->qos, &named_preset->preset.qos, sizeof(uni_stream->qos));
+	memcpy(&uni_stream->codec, &named_preset->preset.codec, sizeof(uni_stream->codec));
+	/* Need to update the `bt_data.data` pointer to the new value after copying the codec */
+	for (size_t i = 0U; i < ARRAY_SIZE(uni_stream->codec.data); i++) {
+		struct bt_codec_data *data = &uni_stream->codec.data[i];
+
+		data->data.data = data->value;
+	}
+
+	for (size_t i = 0U; i < ARRAY_SIZE(uni_stream->codec.meta); i++) {
+		struct bt_codec_data *data = &uni_stream->codec.meta[i];
+
+		data->data.data = data->value;
+	}
+
+	if (default_stream->ep == ep) {
+		err = bt_bap_stream_reconfig(default_stream, &uni_stream->codec);
+		if (err != 0) {
+			shell_error(sh, "Unable reconfig stream: %d", err);
 			return -ENOEXEC;
 		}
 	} else {
-		struct bt_bap_stream *stream;
-		int err;
 
-		if (default_stream == NULL) {
-			stream = &unicast_streams[0];
-		} else {
-			stream = default_stream;
-		}
-
-		err = bt_bap_stream_config(default_conn, stream, ep,
-					     &named_preset->preset.codec);
+		err = bt_bap_stream_config(default_conn, default_stream, ep, &uni_stream->codec);
 		if (err != 0) {
 			shell_error(sh, "Unable to config stream: %d", err);
 			return err;
 		}
-
-		default_stream = stream;
 	}
 
 	shell_print(sh, "ASE config: preset %s", named_preset->name);
@@ -1157,7 +1170,9 @@ static int create_unicast_group(const struct shell *sh)
 	memset(&group_param, 0, sizeof(group_param));
 
 	for (size_t i = 0U; i < ARRAY_SIZE(unicast_streams); i++) {
-		struct bt_bap_stream *stream = &unicast_streams[i];
+		struct bt_bap_stream *stream = &unicast_streams[i].stream;
+		struct unicast_stream *uni_stream =
+			CONTAINER_OF(stream, struct unicast_stream, stream);
 
 		if (stream->ep != NULL) {
 			struct bt_bap_unicast_group_stream_param *stream_param;
@@ -1166,10 +1181,10 @@ static int create_unicast_group(const struct shell *sh)
 
 			stream_param->stream = stream;
 			if (stream_dir(stream) == BT_AUDIO_DIR_SINK) {
-				stream_param->qos = &default_sink_preset->preset.qos;
+				stream_param->qos = &uni_stream->qos;
 				pair_param[sink_cnt++].tx_param = stream_param;
 			} else {
-				stream_param->qos = &default_source_preset->preset.qos;
+				stream_param->qos = &uni_stream->qos;
 				pair_param[source_cnt++].rx_param = stream_param;
 			}
 
@@ -1285,7 +1300,7 @@ static int cmd_stop(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_preset(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct named_lc3_preset *named_preset;
+	const struct named_lc3_preset *named_preset;
 	enum bt_audio_dir dir;
 
 	if (!strcmp(argv[1], "sink")) {
@@ -1398,7 +1413,7 @@ static int cmd_list(const struct shell *sh, size_t argc, char *argv[])
 	shell_print(sh, "Configured Channels:");
 
 	for (i = 0; i < ARRAY_SIZE(unicast_streams); i++) {
-		struct bt_bap_stream *stream = &unicast_streams[i];
+		struct bt_bap_stream *stream = &unicast_streams[i].stream;
 
 		if (stream->conn) {
 			shell_print(sh, "  %s#%u: stream %p ep %p group %p",
@@ -1726,7 +1741,7 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 		stream_params[ARRAY_SIZE(broadcast_source_streams)];
 	struct bt_bap_broadcast_source_subgroup_param subgroup_param;
 	struct bt_bap_broadcast_source_create_param create_param = {0};
-	struct named_lc3_preset *named_preset;
+	const struct named_lc3_preset *named_preset;
 	int err;
 
 	if (default_source != NULL) {
@@ -1785,16 +1800,20 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 		}
 	}
 
+	memcpy(&broadcast_source_codec, &named_preset->preset.codec,
+	       sizeof(broadcast_source_codec));
+	memcpy(&broadcast_source_qos, &named_preset->preset.qos, sizeof(broadcast_source_qos));
+
 	(void)memset(stream_params, 0, sizeof(stream_params));
 	for (size_t i = 0; i < ARRAY_SIZE(stream_params); i++) {
 		stream_params[i].stream = &broadcast_source_streams[i];
 	}
 	subgroup_param.params_count = ARRAY_SIZE(stream_params);
 	subgroup_param.params = stream_params;
-	subgroup_param.codec = &named_preset->preset.codec;
+	subgroup_param.codec = &broadcast_source_codec;
 	create_param.params_count = 1U;
 	create_param.params = &subgroup_param;
-	create_param.qos = &named_preset->preset.qos;
+	create_param.qos = &broadcast_source_qos;
 
 	err = bt_bap_broadcast_source_create(&create_param, &default_source);
 	if (err != 0) {
@@ -2175,7 +2194,7 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 
 #if defined(CONFIG_BT_BAP_UNICAST)
 	for (i = 0; i < ARRAY_SIZE(unicast_streams); i++) {
-		bt_bap_stream_cb_register(&unicast_streams[i], &stream_ops);
+		bt_bap_stream_cb_register(&unicast_streams[i].stream, &stream_ops);
 	}
 #endif /* CONFIG_BT_BAP_UNICAST */
 


### PR DESCRIPTION
This PR improves the BAP shell by

- Making presets constant, and moving stream-specific configuration into a new unicast_stream struct
- Improve metadata handling
- Refactor handling of QoS
- Refactor handling of default presets