### PR TITLE
tests: drivers: uart: uart_pm: Unify set of pins on nrf52840dk_nrf52840

### DIFF
--- a/tests/drivers/uart/uart_pm/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/uart/uart_pm/boards/nrf52840dk_nrf52840.overlay
@@ -20,8 +20,8 @@
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 1)>,
 				<NRF_PSEL(UART_RX, 1, 2)>,
-				<NRF_PSEL(UART_RTS, 0, 5)>,
-				<NRF_PSEL(UART_CTS, 0, 7)>;
+				<NRF_PSEL(UART_RTS, 1, 3)>,
+				<NRF_PSEL(UART_CTS, 1, 4)>;
 		};
 	};
 
@@ -29,8 +29,8 @@
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 1)>,
 				<NRF_PSEL(UART_RX, 1, 2)>,
-				<NRF_PSEL(UART_RTS, 0, 5)>,
-				<NRF_PSEL(UART_CTS, 0, 7)>;
+				<NRF_PSEL(UART_RTS, 1, 3)>,
+				<NRF_PSEL(UART_CTS, 1, 4)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
Unify set of the pins on `nrf52840dk_nrf52840`, which is used by `gpio_loopback` fixture.

Signed-off-by: Katarzyna Giądła <katarzyna.giadla@nordicsemi.no>