### PR TITLE
drivers: video: video_mcux_csi: removed camera device check

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -15,7 +15,7 @@ if VIDEO
 
 config VIDEO_INIT_PRIORITY
 	int "Video initialization priority"
-	default 90
+	default 49
 	help
 	  System initialization priority for video drivers.
 

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -369,11 +369,6 @@ static int video_mcux_csi_init(const struct device *dev)
 
 	CSI_GetDefaultConfig(&data->csi_config);
 
-	/* check if there is any sensor device (video ctrl device) */
-	if (!device_is_ready(config->sensor_dev)) {
-		return -ENODEV;
-	}
-
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err) {
 		return err;


### PR DESCRIPTION
Camera device cannot be checked in CSI driver since the CSI driver enables the CLK signal required by camera to work. Besides, the `VIDEO_INIT_PRIORITY` must be lower than `CONFIG_KERNEL_INIT_PRIORITY_DEVICE` to initialize the CSI driver before the camera driver.

fixes #55278 