### PR TITLE
dts/arm/st/l4: add missing "mmio-sram" compat string

### DIFF
--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -8,7 +8,6 @@
 #include <st/l4/stm32l4p5.dtsi>
 
 /delete-node/ &sdmmc2;
-/delete-node/ &sram0;
 
 / {
 	sram0: memory@20000000 {


### PR DESCRIPTION
This PR adds the missing `mmio-sram` compat string to `sram` nodes in the devicetree for stm32l4{p,r}-based platforms.

This compat string was previously removed in 306dea6ff3716f9a0b4b5928d044e8f69a285c37.