### PR TITLE
samples: metairq_dispatch: Ensure large enough queues

### DIFF
--- a/samples/kernel/metairq_dispatch/src/main.c
+++ b/samples/kernel/metairq_dispatch/src/main.c
@@ -12,7 +12,7 @@ LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);
 #define STACK_SIZE 2048
 
 /* How many messages can be queued for a single thread */
-#define QUEUE_DEPTH 16
+#define QUEUE_DEPTH MAX_EVENTS
 
 /* Array of worker threads, and their stacks */
 static struct thread_rec {

--- a/samples/kernel/metairq_dispatch/src/msgdev.c
+++ b/samples/kernel/metairq_dispatch/src/msgdev.c
@@ -24,7 +24,7 @@ uint32_t max_duty_cyc;
 
 uint32_t msg_seq;
 
-K_MSGQ_DEFINE(hw_msgs, sizeof(struct msg), 2, sizeof(uint32_t));
+K_MSGQ_DEFINE(hw_msgs, sizeof(struct msg), MAX_EVENTS, sizeof(uint32_t));
 
 static void timeout_reset(void);
 


### PR DESCRIPTION
Make queues used in metairq dispatch sample capable of storing all generated messages. This prevents seemingly random hangs that tend to happen with some random seeds.

Fixes: #54610