### PR TITLE
boards: arm: lpcxpresso55s06: enable CAN controller

### DIFF
--- a/boards/arm/lpcxpresso55s06/lpcxpresso55s06-pinctrl.dtsi
+++ b/boards/arm/lpcxpresso55s06/lpcxpresso55s06-pinctrl.dtsi
@@ -18,4 +18,12 @@
 		};
 	};
 
+	pinmux_can0: pinmux_can0 {
+		group0 {
+			pinmux = <CAN0_RD_PIO1_3>,
+				<CAN0_TD_PIO1_2>;
+			slew-rate = "standard";
+		};
+	};
+
 };

--- a/boards/arm/lpcxpresso55s06/lpcxpresso55s06.yaml
+++ b/boards/arm/lpcxpresso55s06/lpcxpresso55s06.yaml
@@ -15,3 +15,4 @@ toolchain:
   - xtools
 supported:
   - gpio
+  - can

--- a/boards/arm/lpcxpresso55s06/lpcxpresso55s06_common.dtsi
+++ b/boards/arm/lpcxpresso55s06/lpcxpresso55s06_common.dtsi
@@ -17,6 +17,7 @@
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &iap;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,canbus = &can0;
 	};
 
 	aliases {
@@ -139,4 +140,16 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&pinmux_flexcomm0_usart>;
 	pinctrl-names = "default";
+};
+
+&can0 {
+	status = "okay";
+	bus-speed = <125000>;
+	bus-speed-data = <1000000>;
+	pinctrl-0 = <&pinmux_can0>;
+	pinctrl-names = "default";
+
+	can-transceiver {
+		max-bitrate = <5000000>;
+	};
 };

--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -205,6 +205,25 @@
 		#size-cells = <0>;
 	};
 
+	can0: can@9d000 {
+		compatible = "nxp,lpc-mcan";
+		reg = <0x9d000 0x1000>;
+		reg-names = "m_can";
+		interrupts = <43 0>, <44 0>;
+		clocks = <&syscon MCUX_MCAN_CLK>;
+		std-filter-elements = <15>;
+		ext-filter-elements = <15>;
+		rx-fifo0-elements = <8>;
+		rx-fifo1-elements = <8>;
+		rx-buffer-elements = <8>;
+		tx-buffer-elements = <15>;
+		sjw = <1>;
+		sample-point = <875>;
+		sjw-data = <1>;
+		sample-point-data = <875>;
+		status = "disabled";
+	};
+
 	rng: rng@3a000 {
 		compatible = "nxp,lpc-rng";
 		reg = <0x3a000 0x1000>;


### PR DESCRIPTION
Add a devicetree node for the CAN controller present in the NXP LPC55S0x series and enable it on the NXP LPCXpresso55S06 Development Board.