### PR TITLE
drivers: regulator: Added initial voltage configuration

### DIFF
--- a/drivers/regulator/regulator_common.c
+++ b/drivers/regulator/regulator_common.c
@@ -28,6 +28,13 @@ int regulator_common_init(const struct device *dev, bool is_enabled)
 		}
 	}
 
+	if (config->init_uv > INT32_MIN) {
+		ret = regulator_set_voltage(dev, config->init_uv, config->init_uv);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
 	/* If we have valid range values, we try to match them before enabling */
 	if ((config->min_uv > INT32_MIN) || (config->max_uv < INT32_MAX)) {
 

--- a/dts/bindings/regulator/regulator.yaml
+++ b/dts/bindings/regulator/regulator.yaml
@@ -15,6 +15,10 @@ properties:
     type: string
     description: A string used as a descriptive name for regulator outputs
 
+  regulator-init-microvolt:
+    type: int
+    description: Voltage set during initialisation
+
   regulator-min-microvolt:
     type: int
     description: smallest voltage consumers may set

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -123,6 +123,8 @@ struct regulator_common_config {
 	int32_t min_uv;
 	/** Maximum allowed voltage, in microvolts. */
 	int32_t max_uv;
+	/** Initial voltage, in microvolts. */
+	int32_t init_uv;
 	/** Minimum allowed current, in microamps. */
 	int32_t min_ua;
 	/** Maximum allowed current, in microamps. */
@@ -148,6 +150,8 @@ struct regulator_common_config {
 				     INT32_MIN),                               \
 		.max_uv = DT_PROP_OR(node_id, regulator_max_microvolt,         \
 				     INT32_MAX),                               \
+		.init_uv = DT_PROP_OR(node_id, regulator_init_microvolt,       \
+				      INT32_MIN),			       \
 		.min_ua = DT_PROP_OR(node_id, regulator_min_microamp,          \
 				     INT32_MIN),                               \
 		.max_ua = DT_PROP_OR(node_id, regulator_max_microamp,          \


### PR DESCRIPTION
The regulator driver has a configured min/max range that is used to limit set values, and to initialise the regulator.

A new init value has been added, so that the startup voltage can be higher than the lowest permitted value.