### PR TITLE
intel_adsp: cavs: add missing lpgpdma access and ownership initialization

### DIFF
--- a/drivers/dai/intel/alh/alh.c
+++ b/drivers/dai/intel/alh/alh.c
@@ -11,6 +11,10 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/logging/log.h>
 
+#ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V25
+#include <adsp_shim.h>
+#endif
+
 #define DT_DRV_COMPAT intel_alh_dai
 #define LOG_DOMAIN dai_intel_alh
 
@@ -75,6 +79,10 @@ static void alh_claim_ownership(void)
 	sys_write32(sys_read32(ALHASCTL) | ALHASCTL_OSEL(0x3), ALHASCTL);
 	sys_write32(sys_read32(ALHCSCTL) | ALHASCTL_OSEL(0x3), ALHCSCTL);
 #endif
+#ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V25
+	/* Allow LPGPDMA connection to Audio Link Hub */
+	sys_set_bits(ADSP_DSPALHO_ADDRESS, DSPALHO_ASO_FLAG | DSPALHO_CSO_FLAG);
+#endif
 }
 
 static void alh_release_ownership(void)
@@ -85,6 +93,9 @@ static void alh_release_ownership(void)
 
 	sys_write32(sys_read32(ALHASCTL) | ALHASCTL_OSEL(0), ALHASCTL);
 	sys_write32(sys_read32(ALHCSCTL) | ALHASCTL_OSEL(0), ALHCSCTL);
+#endif
+#ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V25
+	sys_clear_bits(ADSP_DSPALHO_ADDRESS, DSPALHO_ASO_FLAG | DSPALHO_CSO_FLAG);
 #endif
 }
 

--- a/soc/xtensa/intel_adsp/cavs/include/intel_tgl_adsp/adsp_shim.h
+++ b/soc/xtensa/intel_adsp/cavs/include/intel_tgl_adsp/adsp_shim.h
@@ -145,4 +145,8 @@ struct cavs_win {
 #define GENO_MDIVOSEL           BIT(1)
 #define GENO_DIOPTOSEL          BIT(2)
 
+#define DSPALHO_ASO_FLAG        BIT(0)
+#define DSPALHO_CSO_FLAG        BIT(1)
+#define DSPALHO_CFO_FLAG        BIT(2)
+
 #endif /* ZEPHYR_SOC_INTEL_ADSP_SHIM_H_ */


### PR DESCRIPTION
While pruning SOF code from HW access that should be done in Zephyr. a few registers were found that were programmed in SOF (i.e. in application code) where as these should be programmed in Zephyr code.

These registers are similar to DSP_INIT_IOPO which is already programmed in power_init().