### PR TITLE
drivers: kscan: gt911: ignore touch events if TOUCH_STATUS mask is clear

### DIFF
--- a/drivers/kscan/kscan_gt911.c
+++ b/drivers/kscan/kscan_gt911.c
@@ -96,6 +96,10 @@ static int gt911_process(const struct device *dev)
 		return 0;
 	}
 
+	if (!(status & TOUCH_STATUS_MSK)) {
+		/* Status bit not set, ignore this event */
+		return 0;
+	}
 	/* need to clear the status */
 	uint8_t clear_buffer[3] = {(uint8_t)REG_STATUS, (uint8_t)(REG_STATUS >> 8), 0};
 


### PR DESCRIPTION
Ignore touch events from GT911 IC when TOUCH_STATUS_MSK bit is not set in status register. This resolves an error where the GT911 driver would report a touch event end directly after a touch occured, as the touch status register would be 0x0, which the driver incorrectly interpreted as a touch release.