### PR TITLE
nrf52_bsim: Fix unfreed memory

### DIFF
--- a/boards/posix/nrf52_bsim/main.c
+++ b/boards/posix/nrf52_bsim/main.c
@@ -37,6 +37,7 @@ uint8_t inner_main_clean_up(int exit_code)
 	bs_dump_files_close_all();
 
 	bs_clean_back_channels();
+	bs_clear_Tsymbols();
 
 	uint8_t bst_result = bst_delete();
 


### PR DESCRIPTION
There was a chunk of unfreed memory left over at exit(). Clear it as it should be.
The issue is only a cause for a warning in valgrind, as Linux frees all process booked memory on exit,
but nonetheless it is better fixing it.