### PR TITLE
drivers: sensor: mcux qdec add filter parameters 

### DIFF
--- a/dts/bindings/sensor/nxp,mcux-qdec.yaml
+++ b/dts/bindings/sensor/nxp,mcux-qdec.yaml
@@ -28,6 +28,25 @@ properties:
       generates a count signal. The PHASEB input and the REV bit control the
       counter direction.
 
+  filter-count:
+    type: int
+    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+    description: |
+      The number of consecutive samples that must agree prior to the input
+      filter accepting an input transition. A value of 0 represents 3
+      samples. A value of 7 represents 10 samples.
+
+  filter-sample-period:
+    type: int
+    description: |
+      The sampling period (in IPBus clock cycles) of the decoder input signals.
+      Each input is sampled multiple times at the rate specified by the Filter
+      Sample Period. If FILT_PER is 0 (default), then the input filter is
+      bypassed. Bypassing the digital filter enables the position/position
+      difference counters to operate with count rates up to the IPBus
+      frequency. Turning on the input filter introduces a latency of:
+      ((FILT_CNT + 3) * FILT_PER) FILT clock cycles + 2 IPBus clock periods.
+
   xbar:
     type: phandle
     required: true


### PR DESCRIPTION
Add optional filter value properties. The filter is disabled by default but can be enabled by setting the filter-sample-period > 0 in the dts file. A latency is introduced if the filter is enabled. The latency can be printed by setting sensor log level to debug.