### PR TITLE
lib: json: Decoding of partially-recognized keys

### DIFF
--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -637,6 +637,9 @@ static int64_t obj_parse(struct json_obj *obj, const struct json_obj_descr *desc
 			if (depth == 0) {
 				return decoded_fields;
 			}
+		} else if (depth > 1) {
+			/* Do not attempt to parse any fields in nested subobjects */
+			continue;
 		}
 
 		for (i = 0; i < descr_len; i++) {

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -581,6 +581,18 @@ ZTEST(lib_json_test, test_json_key_obj_not_in_descr_partial)
 	zassert_equal(ts.some_int, 123, "some_int not decoded correctly");
 }
 
+ZTEST(lib_json_test, test_json_key_obj_not_in_descr_partial_nested_key)
+{
+	struct test_struct ts;
+	char encoded[] = "{\"key_not_in_descr\":{\"some_int\": 42}, \"some_int\": 123}";
+	int ret;
+
+	ret = json_obj_parse(encoded, sizeof(encoded) - 1, test_descr,
+			     ARRAY_SIZE(test_descr), &ts);
+	zassert_equal(ret, 0b10, "some_int should be decoded");
+	zassert_equal(ts.some_int, 123, "some_int not decoded correctly");
+}
+
 ZTEST(lib_json_test, test_json_escape)
 {
 	char buf[42];

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -557,6 +557,30 @@ ZTEST(lib_json_test, test_json_key_not_in_descr)
 	zassert_equal(ret, 0, "No items should be decoded");
 }
 
+ZTEST(lib_json_test, test_json_key_not_in_descr_partial)
+{
+	struct test_struct ts;
+	char encoded[] = "{\"key_not_in_descr\":123456, \"some_int\": 123}";
+	int ret;
+
+	ret = json_obj_parse(encoded, sizeof(encoded) - 1, test_descr,
+			     ARRAY_SIZE(test_descr), &ts);
+	zassert_equal(ret, 0b10, "some_int should be decoded");
+	zassert_equal(ts.some_int, 123, "some_int not decoded correctly");
+}
+
+ZTEST(lib_json_test, test_json_key_obj_not_in_descr_partial)
+{
+	struct test_struct ts;
+	char encoded[] = "{\"key_not_in_descr\":{}, \"some_int\": 123}";
+	int ret;
+
+	ret = json_obj_parse(encoded, sizeof(encoded) - 1, test_descr,
+			     ARRAY_SIZE(test_descr), &ts);
+	zassert_equal(ret, 0b10, "some_int should be decoded");
+	zassert_equal(ts.some_int, 123, "some_int not decoded correctly");
+}
+
 ZTEST(lib_json_test, test_json_escape)
 {
 	char buf[42];


### PR DESCRIPTION
IMO, the JSON library should be able to parse a JSON that contains known as well as unknown fields. These two tests verify that behaviour.

Fixes #55758