### PR TITLE
tests: net: socketpair: resolve include order issues

### DIFF
--- a/tests/net/socket/socketpair/src/_main.h
+++ b/tests/net/socket/socketpair/src/_main.h
@@ -12,15 +12,9 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/net/socket.h>
+#include <zephyr/posix/fcntl.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/ztest.h>
-
-#ifdef CONFIG_ARCH_POSIX
-#include <fcntl.h>
-#else
-#include <zephyr/posix/fcntl.h>
-#include <zephyr/posix/unistd.h>
-#endif
 
 LOG_MODULE_DECLARE(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 

--- a/tests/net/socket/socketpair/src/fcntl.c
+++ b/tests/net/socket/socketpair/src/fcntl.c
@@ -12,11 +12,6 @@ ZTEST_USER(net_socketpair, fcntl)
 	int sv[2] = {-1, -1};
 	int flags;
 
-	if (IS_ENABLED(CONFIG_ARCH_POSIX)) {
-		printk("non-blocking socketpair I/O is unsupported with CONFIG_ARCH_POSIX\n");
-		ztest_test_skip();
-	}
-
 	res = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
 	zassert_equal(res, 0,
 		"socketpair(AF_UNIX, SOCK_STREAM, 0, sv) failed");

--- a/tests/net/socket/socketpair/src/nonblock.c
+++ b/tests/net/socket/socketpair/src/nonblock.c
@@ -11,11 +11,6 @@ ZTEST_USER(net_socketpair, write_nonblock)
 	int res;
 	int sv[2] = {-1, -1};
 
-	if (IS_ENABLED(CONFIG_ARCH_POSIX)) {
-		printk("non-blocking socketpair I/O is unsupported with CONFIG_ARCH_POSIX\n");
-		ztest_test_skip();
-	}
-
 	res = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
 	zassert_equal(res, 0, "socketpair() failed: %d", errno);
 
@@ -50,11 +45,6 @@ ZTEST_USER(net_socketpair, read_nonblock)
 	int res;
 	int sv[2] = {-1, -1};
 	char c;
-
-	if (IS_ENABLED(CONFIG_ARCH_POSIX)) {
-		printk("non-blocking socketpair I/O is unsupported with CONFIG_ARCH_POSIX\n");
-		ztest_test_skip();
-	}
 
 	res = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
 	zassert_equal(res, 0, "socketpair() failed: %d", errno);


### PR DESCRIPTION
It seems that socketpair tests were not passing on `native_posix` due to what seems to be an ordering issue in include paths. Normally, system include paths are searched first, and then paths added with `-I<path>`.

When running the Zephyr testsuite, explicitly use the `<zephyr/posix/fcntl.h>` header to avoid ambiguity. In the future, we there might be a more elaborate scheme for removing ambiguity for `native_posix`.

Fixes #54996