### PR TITLE
drivers: can: reset statistics when starting the CAN controller

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -204,7 +204,8 @@ static int mcux_flexcan_start(const struct device *dev)
 		}
 	}
 
-	/* Clear error counters */
+	/* Reset statistics and clear error counters */
+	CAN_STATS_RESET(dev);
 	config->base->ECR &= ~(CAN_ECR_TXERRCNT_MASK | CAN_ECR_RXERRCNT_MASK);
 
 	/* Delay this until start since setting the timing automatically exits freeze mode */

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -592,6 +592,8 @@ static int can_rcar_start(const struct device *dev)
 
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 
+	CAN_STATS_RESET(dev);
+
 	ret = can_rcar_enter_operation_mode(config);
 	if (ret != 0) {
 		LOG_ERR("failed to enter operation mode (err %d)", ret);

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -383,6 +383,8 @@ static int can_stm32_start(const struct device *dev)
 		}
 	}
 
+	CAN_STATS_RESET(dev);
+
 	ret = can_stm32_leave_init_mode(can);
 	if (ret < 0) {
 		LOG_ERR("Failed to leave init mode");

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -579,6 +579,17 @@ struct can_device_state {
 #define CAN_STATS_RX_OVERRUN_INC(dev_)			\
 	STATS_INC(Z_CAN_GET_STATS(dev_), rx_overrun)
 
+/**
+ * @brief Zero all statistics for a CAN device
+ *
+ * The driver is reponsible for resetting the statistics before starting the CAN
+ * controller.
+ *
+ * @param dev_ Pointer to the device structure for the driver instance.
+ */
+#define CAN_STATS_RESET(dev_)				\
+	stats_reset(&(Z_CAN_GET_STATS(dev_).s_hdr))
+
 /** @cond INTERNAL_HIDDEN */
 
 /**
@@ -647,6 +658,7 @@ struct can_device_state {
 #define CAN_STATS_FORM_ERROR_INC(dev_)
 #define CAN_STATS_ACK_ERROR_INC(dev_)
 #define CAN_STATS_RX_OVERRUN_INC(dev_)
+#define CAN_STATS_RESET(dev_)
 
 #define CAN_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
 			     prio, api, ...)				\


### PR DESCRIPTION
Reset CAN controller statistics when starting the CAN controller.