### PR TITLE
Reworked cortex m systick

### DIFF
--- a/dts/bindings/timer/arm,armv6m-systick.yaml
+++ b/dts/bindings/timer/arm,armv6m-systick.yaml
@@ -5,8 +5,4 @@ description: ARMv6-M System Tick
 
 compatible: "arm,armv6m-systick"
 
-include: base.yaml
-
-properties:
-  reg:
-    required: true
+include: [cortex-m-systick.yaml, base.yaml]

--- a/dts/bindings/timer/arm,armv7m-systick.yaml
+++ b/dts/bindings/timer/arm,armv7m-systick.yaml
@@ -5,8 +5,4 @@ description: ARMv7-M System Tick
 
 compatible: "arm,armv7m-systick"
 
-include: base.yaml
-
-properties:
-  reg:
-    required: true
+include: [cortex-m-systick.yaml, base.yaml]

--- a/dts/bindings/timer/arm,armv8.1m-systick.yaml
+++ b/dts/bindings/timer/arm,armv8.1m-systick.yaml
@@ -5,8 +5,4 @@ description: ARMv8.1-M System Tick
 
 compatible: "arm,armv8.1m-systick"
 
-include: base.yaml
-
-properties:
-  reg:
-    required: true
+include: [cortex-m-systick.yaml, base.yaml]

--- a/dts/bindings/timer/arm,armv8m-systick.yaml
+++ b/dts/bindings/timer/arm,armv8m-systick.yaml
@@ -5,8 +5,4 @@ description: ARMv8-M System Tick
 
 compatible: "arm,armv8m-systick"
 
-include: base.yaml
-
-properties:
-  reg:
-    required: true
+include: [cortex-m-systick.yaml, base.yaml]

--- a/dts/bindings/timer/cortex-m-systick.yaml
+++ b/dts/bindings/timer/cortex-m-systick.yaml
@@ -6,3 +6,13 @@
 properties:
   reg:
     required: true
+
+  use-external-clk:
+    type: boolean
+    description: |
+      When set, SysTick will use the "external" clock as
+      own reference instead of CPU's one.
+
+  external-frequency:
+    type: int
+    description: external clock frequency value

--- a/dts/bindings/timer/cortex-m-systick.yaml
+++ b/dts/bindings/timer/cortex-m-systick.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 MUNIC SA
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for SysTick of ARM Cortex-M chips
+
+properties:
+  reg:
+    required: true


### PR DESCRIPTION
Hello,

This commit added missing support of the EXTERNAL clock to the Cortex-M Systick driver.
Also some minor refactoring has been done to fix following problems: old IRQ API usage and non-atomic writing to the control registers.

Regards
Andrey VOLKOV

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/56117