### PR TITLE
dts: arm: stm32l4r5 restore compatible sram node

### DIFF
--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -8,7 +8,7 @@
 #include <st/l4/stm32l4p5.dtsi>
 
 /delete-node/ &sdmmc2;
-/delete-node/ &sram0;
+
 
 / {
 	sram0: memory@20000000 {


### PR DESCRIPTION
Set the correct sram0 node in the stm32l4r5 dtsi
No need to delete the entire node, just overwrites the ram size.

That is a regression introduced by the https://github.com/zephyrproject-rtos/zephyr/pull/55028

Signed-off-by: Francois Ramu <francois.ramu@st.com>