### PR TITLE
Bluetooth: host: shrink bt_l2cap_le_chan size

### DIFF
--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -172,6 +172,7 @@ struct bt_l2cap_le_chan {
 
 	/** Channel Transmission Endpoint */
 	struct bt_l2cap_le_endpoint	tx;
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	/** Channel Transmission queue */
 	struct k_fifo                   tx_queue;
 	/** Channel Pending Transmission buffer  */
@@ -185,7 +186,6 @@ struct bt_l2cap_le_chan {
 	struct k_work			rx_work;
 	struct k_fifo			rx_queue;
 
-#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	bt_l2cap_chan_state_t		state;
 	/** Remote PSM to be connected */
 	uint16_t			psm;

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1865,7 +1865,6 @@ static void l2cap_chan_tx_resume(struct bt_l2cap_le_chan *ch)
 	k_work_submit(&ch->tx_work);
 }
 
-#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 static void resume_all_channels(struct bt_conn *conn, void *data)
 {
 	struct bt_l2cap_chan *chan;
@@ -1874,7 +1873,6 @@ static void resume_all_channels(struct bt_conn *conn, void *data)
 		l2cap_chan_tx_resume(BT_L2CAP_LE_CHAN(chan));
 	}
 }
-#endif
 
 static void l2cap_chan_sdu_sent(struct bt_conn *conn, void *user_data, int err)
 {


### PR DESCRIPTION
Most of this struct is bookkeeping for the dynamic channels. This isn't needed for e.g., a simple peripheral using GATT.

With a peripheral_hr build for nrf52840dk_nrf52840, we save 280 bytes of RAM.

Extracted from #55519