### PR TITLE
samples: Bluetooth: add more documentation for hci_uart

### DIFF
--- a/samples/bluetooth/hci_uart/README.rst
+++ b/samples/bluetooth/hci_uart/README.rst
@@ -148,3 +148,45 @@ Using a USB CDC ACM UART
 ========================
 
 The sample can be configured to use a USB UART instead. See :zephyr_file:`samples/bluetooth/hci_uart/nrf52840dongle_nrf52840.conf` and :zephyr_file:`samples/bluetooth/hci_uart/nrf52840dongle_nrf52840.overlay`.
+
+Using the controller with the Zephyr host
+=========================================
+
+This describes how to hook up a board running this sample to a board running
+an application that uses the Zephyr host.
+
+On the controller side, the `zephyr,bt-c2h-uart` DTS property (in the `chosen`
+block) is used to select which uart device to use. For example if we want to
+keep the console logs, we can keep console on uart0 and the HCI on uart1 like
+so:
+
+.. code-block:: dts
+
+   / {
+      chosen {
+         zephyr,console = &uart0;
+         zephyr,shell-uart = &uart0;
+         zephyr,bt-c2h-uart = &uart1;
+      };
+   };
+
+On the host application, some config options need to be used to select the H4
+driver instead of the built-in controller:
+
+.. code-block:: kconfig
+
+   CONFIG_BT_HCI=y
+   CONFIG_BT_CTLR=n
+   CONFIG_BT_H4=y
+
+Similarly, the `zephyr,bt-uart` DTS property selects which uart to use:
+
+.. code-block:: dts
+
+   / {
+      chosen {
+         zephyr,console = &uart0;
+         zephyr,shell-uart = &uart0;
+         zephyr,bt-uart = &uart1;
+      };
+   };


### PR DESCRIPTION
Try to explain how to use the hci_uart sample with another board running the zephyr host.

Extracted from #55648