### PR TITLE
Bluetooth: Mesh: Fix issues related to timeout handling in Remote Provisioning Client

### DIFF
--- a/subsys/bluetooth/mesh/prov_bearer.h
+++ b/subsys/bluetooth/mesh/prov_bearer.h
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define PROTOCOL_TIMEOUT     K_SECONDS(60)
+/** Provisioning protocol timeout in seconds. */
+#define PROTOCOL_TIMEOUT_SEC  60
+
+/** Provisioning protocol timeout. */
+#define PROTOCOL_TIMEOUT     K_SECONDS(PROTOCOL_TIMEOUT_SEC)
 
 /** @def PROV_BEARER_BUF_HEADROOM
  *

--- a/subsys/bluetooth/mesh/rpr_cli.c
+++ b/subsys/bluetooth/mesh/rpr_cli.c
@@ -59,6 +59,11 @@ static void link_report(struct bt_mesh_rpr_cli *cli,
 		bearer.link = BEARER_LINK_OPENED;
 		LOG_DBG("Opened");
 		bearer.cb->link_opened(&pb_remote_cli, &ctx);
+
+		/* PB-Remote Open Link procedure timeout is configurable, but the provisioning
+		 * protocol timeout is not. Use default provisioning protocol timeout.
+		 */
+		cli->link.time = PROTOCOL_TIMEOUT_SEC;
 		return;
 	}
 

--- a/subsys/bluetooth/mesh/rpr_cli.c
+++ b/subsys/bluetooth/mesh/rpr_cli.c
@@ -405,7 +405,10 @@ static void pdu_send_end(int err, void *cb_data)
 
 		link_closed(cli,
 			    BT_MESH_RPR_ERR_LINK_CLOSED_AS_CANNOT_SEND_PDU);
+		return;
 	}
+
+	k_work_reschedule(&cli->link.timeout, K_SECONDS(cli->link.time));
 }
 
 static const struct bt_mesh_send_cb pdu_send_cb = {
@@ -465,8 +468,8 @@ static void link_closed(struct bt_mesh_rpr_cli *cli,
 		.state = BT_MESH_RPR_LINK_IDLE,
 	};
 
-	LOG_DBG("0x%04x: status: %u state: %u", srv.addr, link.status,
-	       link.state);
+	LOG_DBG("0x%04x: status: %u state: %u rx: %u tx: %u", srv.addr, link.status,
+		cli->link.state, cli->link.rx_pdu, cli->link.tx_pdu);
 
 	link_reset(cli);
 
@@ -626,6 +629,7 @@ static int link_close(struct bt_mesh_rpr_cli *cli,
 		link_reset(cli);
 	}
 
+	k_work_reschedule(&cli->link.timeout, K_SECONDS(cli->link.time));
 	return err;
 }
 


### PR DESCRIPTION
This PR fixes 3 issues related to timeout handling on Remote Provisioning Client:
- Where the RPR Client gets stuck forever if it doesn't receive Link Status or Link Report message when opening the remote provisioning link;
- Where the RPR Client gets stuck after sending PDU to RPR Server (even with segmented flag), but doesn't hear anything back from the server;
- Where the link between RPR Client and RPR Server expires earlier than between PB-Remote Server and unprovisioned device.

Details are in the commit messages.