### PR TITLE
tests: iterable_sections: stop excluding posix

### DIFF
--- a/tests/misc/iterable_sections/testcase.yaml
+++ b/tests/misc/iterable_sections/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   misc.iterable_sections:
     tags: iterable_sections
-    arch_exclude: posix xtensa
+    arch_exclude: xtensa


### PR DESCRIPTION
The iterable_sections test is excluding posix. Whatever the issue was at the time this was set, the test seems to run fine on native_posix just fine now.

Dropping the exclude to make this test run on native_posix.