### PR TITLE
drivers: gpio: mec172x: Prevent voltage drop in gpio during reconfigu…

### DIFF
--- a/drivers/gpio/gpio_mchp_xec_v2.c
+++ b/drivers/gpio/gpio_mchp_xec_v2.c
@@ -118,7 +118,6 @@ static int gpio_xec_configure(const struct device *dev,
 	 * Clear input pad disable allowing input pad to operate.
 	 * Clear Power gate to allow pads to operate.
 	 */
-	mask |= MCHP_GPIO_CTRL_DIR_MASK;
 	mask |= MCHP_GPIO_CTRL_INPAD_DIS_MASK;
 	mask |= MCHP_GPIO_CTRL_PWRG_MASK;
 	pcr1 |= MCHP_GPIO_CTRL_DIR_INPUT;


### PR DESCRIPTION
If a gpio is already configured as output (e.g. by ROM bootloader) and then is reconfigured by app as output again but different gpio flags. There is glitch since driver is temporary changing gpio direction.