### PR TITLE
sensors: BMI160 power management

### DIFF
--- a/boards/shields/ti_bp_bassensorsmkii/Kconfig.shield
+++ b/boards/shields/ti_bp_bassensorsmkii/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_TI_BP_BASSENSORSMKII
+	def_bool $(shields_list_contains,ti_bp_bassensorsmkii)

--- a/boards/shields/ti_bp_bassensorsmkii/doc/index.rst
+++ b/boards/shields/ti_bp_bassensorsmkii/doc/index.rst
@@ -1,0 +1,34 @@
+.. _ti_bp_bassensorsmkii:
+
+TI Building Automation Sensors MKII: Building Automation Multi sensor shield
+############################################################################
+
+Overview
+********
+The BP-BASSENSORSMKII is a motion MEMS and environmental sensor expansion board
+using the TI BoosterPack shield layout.
+
+More information about the board can be found at the
+`TI BP-BASSENSORSMKII website`_.
+
+Hardware Description
+********************
+
+BP-BASSENSORSMKII provides the following key features:
+
+ - BMI160 6 axis IMU
+ - BMM150 connected to BMI160 for sensor hub use
+ - TI OP3001 Ambient Light sensors
+ - TI DR5055 Hall Effect Sensor
+ - TI HDC2080 Temperature and Humidity Sensor
+ - TI TMP117 ultra-high accuracy temperature sensor with breakout
+ - TI LaunchPad support
+ - RoHS compliant
+
+
+References
+**********
+
+.. target-notes::
+.. _TI BP-BASSENSORSMKII website:
+	https://www.ti.com/tool/BP-BASSENSORSMKII

--- a/boards/shields/ti_bp_bassensorsmkii/ti_bp_bassensorsmkii.overlay
+++ b/boards/shields/ti_bp_bassensorsmkii/ti_bp_bassensorsmkii.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		accel0 = &bmi160_ti_bp_bassensorsmkii;
+		gyro0 = &bmi160_ti_bp_bassensorsmkii;
+		optical0 = &opt3001_ti_bp_bassensorsmkii;
+	};
+};
+
+&arduino_i2c {
+	bmi160_ti_bp_bassensorsmkii: bmi160@69 {
+		compatible = "bosch,bmi160";
+		reg = <0x69>;
+		int-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
+	};
+
+	opt3001_ti_bp_bassensorsmkii: opt3001@44 {
+		compatible = "ti,opt3001";
+		reg = <0x44>;
+	};
+};

--- a/drivers/sensor/bmi160/bmi160.c
+++ b/drivers/sensor/bmi160/bmi160.c
@@ -14,6 +14,9 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
 #include <zephyr/logging/log.h>
 
 #include "bmi160.h"
@@ -712,6 +715,15 @@ static int bmi160_sample_fetch(const struct device *dev,
 	struct bmi160_data *data = dev->data;
 	uint8_t status;
 	size_t i;
+	int ret = 0;
+	enum pm_device_state pm_state;
+
+	(void)pm_device_state_get(dev, &pm_state);
+	if (pm_state != PM_DEVICE_STATE_ACTIVE) {
+		LOG_DBG("Device is suspended, fetch is unavailable");
+		ret = -EIO;
+		goto out;
+	}
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
@@ -719,13 +731,15 @@ static int bmi160_sample_fetch(const struct device *dev,
 	while ((status & BMI160_DATA_READY_BIT_MASK) == 0) {
 
 		if (bmi160_byte_read(dev, BMI160_REG_STATUS, &status) < 0) {
-			return -EIO;
+			ret = -EIO;
+			goto out;
 		}
 	}
 
 	if (bmi160_read(dev, BMI160_SAMPLE_BURST_READ_ADDR, data->sample.raw,
 			BMI160_BUF_SIZE) < 0) {
-		return -EIO;
+		ret = -EIO;
+		goto out;
 	}
 
 	/* convert samples to cpu endianness */
@@ -736,7 +750,8 @@ static int bmi160_sample_fetch(const struct device *dev,
 		*sample = sys_le16_to_cpu(*sample);
 	}
 
-	return 0;
+out:
+	return ret;
 }
 
 static void bmi160_to_fixed_point(int16_t raw_val, uint16_t scale,
@@ -872,6 +887,33 @@ static const struct sensor_driver_api bmi160_api = {
 	.channel_get = bmi160_channel_get,
 };
 
+
+static inline int bmi160_resume(const struct device *dev)
+{
+	struct bmi160_data *data = dev->data;
+
+	return bmi160_pmu_set(dev, &data->pmu_sts);
+}
+
+static inline int bmi160_suspend(const struct device *dev)
+{
+	struct bmi160_data *data = dev->data;
+
+	/* Suspend everything */
+	union bmi160_pmu_status st = {
+		.acc = BMI160_PMU_SUSPEND,
+		.gyr = BMI160_PMU_SUSPEND,
+		.mag = BMI160_PMU_SUSPEND,
+	};
+
+	int ret = bmi160_pmu_set(dev, &st);
+
+	if (ret == 0) {
+		memset(data->sample.raw, 0, sizeof(data->sample.raw));
+	}
+	return ret;
+}
+
 int bmi160_init(const struct device *dev)
 {
 	const struct bmi160_cfg *cfg = dev->config;
@@ -913,8 +955,23 @@ int bmi160_init(const struct device *dev)
 	/* set default PMU for gyro, accelerometer */
 	data->pmu_sts.gyr = BMI160_DEFAULT_PMU_GYR;
 	data->pmu_sts.acc = BMI160_DEFAULT_PMU_ACC;
+
 	/* compass not supported, yet */
 	data->pmu_sts.mag = BMI160_PMU_SUSPEND;
+
+	/* Start in a suspended state (never turning on the mems sensors) if
+	 * PM_DEVICE_RUNTIME is enabled.
+	 */
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	pm_device_init_suspended(dev);
+
+	int ret = pm_device_runtime_enable(dev);
+
+	if (ret < 0 && ret != -ENOSYS) {
+		LOG_ERR("Failed to enabled runtime power management");
+		return -EIO;
+	}
+#else
 
 	/*
 	 * The next command will take around 100ms (contains some necessary busy
@@ -926,6 +983,7 @@ int bmi160_init(const struct device *dev)
 		LOG_DBG("Failed to set power mode.");
 		return -EIO;
 	}
+#endif
 
 	/* set accelerometer default range */
 	if (bmi160_byte_write(dev, BMI160_REG_ACC_RANGE,
@@ -975,6 +1033,24 @@ int bmi160_init(const struct device *dev)
 	return 0;
 }
 
+int bmi160_pm(const struct device *dev, enum pm_device_action action)
+{
+	int ret = 0;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		bmi160_resume(dev);
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		bmi160_suspend(dev);
+		break;
+	default:
+		ret = -ENOTSUP;
+	}
+
+	return ret;
+}
+
 #if defined(CONFIG_BMI160_TRIGGER)
 #define BMI160_TRIGGER_CFG(inst) \
 	.interrupt = GPIO_DT_SPEC_INST_GET(inst, int_gpios),
@@ -982,11 +1058,13 @@ int bmi160_init(const struct device *dev)
 #define BMI160_TRIGGER_CFG(inst)
 #endif
 
-#define BMI160_DEVICE_INIT(inst)					\
-	SENSOR_DEVICE_DT_INST_DEFINE(inst, bmi160_init, NULL,		\
-			      &bmi160_data_##inst, &bmi160_cfg_##inst,	\
-			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,	\
-			      &bmi160_api);
+#define BMI160_DEVICE_INIT(inst)								\
+	IF_ENABLED(CONFIG_PM_DEVICE_RUNTIME, (PM_DEVICE_DT_INST_DEFINE(inst, bmi160_pm)));	\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, bmi160_init,						\
+		COND_CODE_1(CONFIG_PM_DEVICE_RUNTIME, (PM_DEVICE_DT_INST_GET(inst)), (NULL)),	\
+		&bmi160_data_##inst, &bmi160_cfg_##inst,					\
+		POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,					\
+		&bmi160_api);
 
 /* Instantiation macros used when a device is on a SPI bus */
 #define BMI160_DEFINE_SPI(inst)						   \

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <zephyr/device.h>
 #include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/arch_interface.h>
 
 extern const struct device __device_EARLY_start[];
@@ -153,6 +154,7 @@ static int cmd_device_list(const struct shell *sh,
 	size_t devcnt = z_device_get_all_static(&devlist);
 	const struct device *devlist_end = devlist + devcnt;
 	const struct device *dev;
+
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
@@ -192,10 +194,51 @@ static int cmd_device_list(const struct shell *sh,
 	return 0;
 }
 
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+static int cmd_device_pm_toggle(const struct shell *sh,
+			 size_t argc, char **argv)
+{
+	const struct device *dev;
+	enum pm_device_state pm_state;
+
+	dev = device_get_binding(argv[1]);
+	if (dev == NULL) {
+		shell_error(sh, "Device unknown (%s)", argv[1]);
+		return -ENODEV;
+	}
+
+	if (!pm_device_runtime_is_enabled(dev)) {
+		shell_error(sh, "Device (%s) does not have runtime power management",
+			    argv[1]);
+		return -ENOTSUP;
+	}
+
+	(void)pm_device_state_get(dev, &pm_state);
+
+	if (pm_state == PM_DEVICE_STATE_ACTIVE) {
+		shell_fprintf(sh, SHELL_NORMAL, "pm_device_runtime_put(%s)\n",
+			      argv[1]);
+		pm_device_runtime_put(dev);
+	} else {
+		shell_fprintf(sh, SHELL_NORMAL, "pm_device_runtime_get(%s)\n",
+			      argv[1]);
+		pm_device_runtime_get(dev);
+	}
+
+	return 0;
+}
+#define PM_SHELL_CMD SHELL_CMD(pm_toggle, NULL, "Toggle device power (pm get/put)",\
+			       cmd_device_pm_toggle),
+#else
+#define PM_SHELL_CMD
+#endif /* CONFIG_PM_DEVICE_RUNTIME  */
+
+
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_device,
 	SHELL_CMD(levels, NULL, "List configured devices by levels", cmd_device_levels),
 	SHELL_CMD(list, NULL, "List configured devices", cmd_device_list),
+	PM_SHELL_CMD
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 


### PR DESCRIPTION
Adds the ti building automation sensor board as a shield, and explores adding device power management to the BMI160. By default the power of a sensor should likely be suspended with an application having control over the power of any given sensor.

The PR adds a simple device pm_toggle shell command which lets a shell user call pm_device_runtime_get or put depending on the state of the device.

Example usage in the sensor shell sample app

``` sh
uart:~$ sensor get bmi160@69 accel_xyz
Failed to read sensor: -5
channel idx=3 accel_xyz x =   0.000000 y =   0.000000 z =   0.000000
uart:~$ device pm_toggle bmi160@69
pm_device_runtime_get(bmi160@69)
uart:~$ sensor get bmi160@69 accel_xyz
channel idx=3 accel_xyz x =  -0.333086 y =   1.090154 z =   9.748596
uart:~$ device pm_toggle bmi160@69
pm_device_runtime_put(bmi160@69)
uart:~$ sensor get bmi160@69 accel_xyz
Failed to read sensor: -5
channel idx=3 accel_xyz x =   0.000000 y =   0.000000 z =   0.000000
```

If this is a useful pattern I'm happy to document it in the sensor docs as the defacto way power management with sensors should be done (I think this is the case, but want feedback).