### PR TITLE
MAINTAINERS: add drivers/input/ to the input file list

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1427,6 +1427,7 @@ Input:
     - gmarull
   files:
     - doc/services/input/
+    - drivers/input/
     - include/zephyr/dt-bindings/input/
     - include/zephyr/input/
     - samples/subsys/input/


### PR DESCRIPTION
Add the driver/input subdirectory to the list of paths maintained under input.