### PR TITLE
drivers: flash: nRF: Move sync ticker to Subsys Bluetooth Controller

### DIFF
--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -10,7 +10,6 @@ zephyr_library_sources_ifdef(CONFIG_FLASH_SIMULATOR flash_simulator.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_FLASH_AT45 spi_flash_at45.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_ITE_IT8XXX2 flash_ite_it8xxx2.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_NRF soc_flash_nrf.c)
-zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_NRF_RADIO_SYNC_TICKER soc_flash_nrf_ticker.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_MCUX soc_flash_mcux.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_LPC soc_flash_lpc.c)
 zephyr_library_sources_ifdef(CONFIG_FLASH_PAGE_LAYOUT flash_page_layout.c)
@@ -83,12 +82,6 @@ zephyr_library_include_directories_ifdef(
   CONFIG_FLASH_MCUX_FLEXSPI_HYPERFLASH
   ${ZEPHYR_BASE}/drivers/memc
 )
-
-zephyr_library_include_directories_ifdef(
-	CONFIG_SOC_FLASH_NRF_RADIO_SYNC_TICKER
-	${ZEPHYR_BASE}/subsys/bluetooth
-	${ZEPHYR_BASE}/subsys/bluetooth/controller/ll_sw/nordic
-	)
 
 zephyr_library_sources_ifdef(CONFIG_FLASH_SHELL flash_shell.c)
 zephyr_library_sources_ifdef(CONFIG_FLASH_JESD216 jesd216.c)

--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if(CONFIG_BT_CTLR_ADVANCED_FEATURES)
+  message(WARNING "\nCONFIG_BT_CTLR_ADVANCED_FEATURES=y, Advanced Features' "
+                  "default value change could change Zephyr Bluetooth "
+                  "Controller's functional behavior.")
+endif()
+
 zephyr_library()
+
 zephyr_library_sources(
   util/mem.c
   util/memq.c
@@ -8,10 +15,144 @@ zephyr_library_sources(
   util/dbuf.c
   util/util.c
   ticker/ticker.c
-  ll_sw/ll_addr.c
+  ll_sw/ll_feat.c
   ll_sw/ll_tx_pwr.c
+  ll_sw/ll_addr.c
+  ll_sw/ull.c
+  ll_sw/lll_common.c
   hci/hci_driver.c
   hci/hci.c
+  )
+
+if(CONFIG_BT_BROADCASTER)
+  zephyr_library_sources(
+    ll_sw/ull_adv.c
+    )
+  zephyr_library_sources_ifdef(
+    CONFIG_BT_CTLR_ADV_EXT
+    ll_sw/ull_adv_aux.c
+    )
+  zephyr_library_sources_ifdef(
+    CONFIG_BT_CTLR_ADV_PERIODIC
+    ll_sw/ull_adv_sync.c
+    )
+  zephyr_library_sources_ifdef(
+    CONFIG_BT_CTLR_ADV_ISO
+    ll_sw/ull_adv_iso.c
+    )
+endif()
+
+if(CONFIG_BT_OBSERVER)
+  zephyr_library_sources(
+    ll_sw/ull_scan.c
+    )
+  zephyr_library_sources_ifdef(
+    CONFIG_BT_CTLR_ADV_EXT
+    ll_sw/ull_scan_aux.c
+    )
+  zephyr_library_sources_ifdef(
+    CONFIG_BT_CTLR_SYNC_PERIODIC
+    ll_sw/ull_sync.c
+    )
+  zephyr_library_sources_ifdef(
+    CONFIG_BT_CTLR_SYNC_ISO
+    ll_sw/ull_sync_iso.c
+    )
+endif()
+
+if(CONFIG_BT_CONN)
+  zephyr_library_sources(
+    ll_sw/ull_conn.c
+    )
+  zephyr_library_sources_ifdef(
+    CONFIG_BT_CTLR_LE_ENC
+    ll_sw/ull_llcp_enc.c
+    )
+  zephyr_library_sources_ifdef(
+    CONFIG_BT_CTLR_PHY
+    ll_sw/ull_llcp_phy.c
+    )
+  if (CONFIG_BT_CTLR_PERIPHERAL_ISO OR
+      CONFIG_BT_CTLR_CENTRAL_ISO)
+    zephyr_library_sources(
+      ll_sw/ull_llcp_cc.c
+      )
+  endif()
+  zephyr_library_sources(
+    ll_sw/ull_tx_queue.c
+    ll_sw/ull_llcp.c
+    ll_sw/ull_llcp_common.c
+    ll_sw/ull_llcp_local.c
+    ll_sw/ull_llcp_pdu.c
+    ll_sw/ull_llcp_conn_upd.c
+    ll_sw/ull_llcp_chmu.c
+    ll_sw/ull_llcp_remote.c
+    )
+  zephyr_library_sources_ifdef(
+    CONFIG_BT_PERIPHERAL
+    ll_sw/ull_peripheral.c
+    )
+  zephyr_library_sources_ifdef(
+    CONFIG_BT_CTLR_PERIPHERAL_ISO
+    ll_sw/ull_peripheral_iso.c
+    )
+  zephyr_library_sources_ifdef(
+    CONFIG_BT_CENTRAL
+    ll_sw/ull_central.c
+    )
+  zephyr_library_sources_ifdef(
+    CONFIG_BT_CTLR_CENTRAL_ISO
+    ll_sw/ull_central_iso.c
+    )
+endif()
+
+zephyr_library_sources_ifdef(
+  CONFIG_BT_CTLR_SCHED_ADVANCED
+  ll_sw/ull_sched.c
+  )
+
+zephyr_library_sources_ifdef(
+  CONFIG_BT_CTLR_DF
+  ll_sw/ull_df.c
+  )
+
+zephyr_library_sources_ifdef(
+  CONFIG_BT_CTLR_CONN_ISO
+  ll_sw/ull_conn_iso.c
+  )
+
+zephyr_library_sources_ifdef(
+  CONFIG_BT_CTLR_ISO
+  ll_sw/ull_iso.c
+  ll_sw/isoal.c
+  )
+
+if(CONFIG_BT_CONN OR
+   (CONFIG_BT_BROADCASTER AND
+    CONFIG_BT_CTLR_ADV_EXT) OR
+   CONFIG_BT_CTLR_ADV_PERIODIC OR
+   CONFIG_BT_CTLR_SYNC_PERIODIC)
+  zephyr_library_sources(
+    ll_sw/ull_chan.c
+    ll_sw/lll_chan.c
+    )
+endif()
+
+if(CONFIG_BT_CTLR_FILTER_ACCEPT_LIST OR
+   CONFIG_BT_CTLR_SYNC_PERIODIC_ADV_LIST)
+  zephyr_library_sources(
+    ll_sw/ull_filter.c
+    )
+endif()
+
+zephyr_library_sources_ifdef(
+  CONFIG_BT_HCI_MESH_EXT
+  ll_sw/ll_mesh.c
+  )
+
+zephyr_library_sources_ifdef(
+  CONFIG_BT_CTLR_SETTINGS
+  ll_sw/ll_settings.c
   )
 
 zephyr_library_sources_ifdef(
@@ -19,141 +160,10 @@ zephyr_library_sources_ifdef(
   crypto/crypto.c
   )
 
-if(CONFIG_BT_LL_SW_SPLIT)
-  if(CONFIG_BT_CTLR_ADVANCED_FEATURES)
-    message(WARNING "\nCONFIG_BT_CTLR_ADVANCED_FEATURES=y, Advanced Features' "
-		    "default value change could change Zephyr Bluetooth "
-		    "Controller's functional behavior.")
-  endif()
-  zephyr_library_sources(
-    ll_sw/ll_feat.c
-    ll_sw/ull.c
-    ll_sw/lll_common.c
-    )
-  if(CONFIG_BT_BROADCASTER)
-    zephyr_library_sources(
-      ll_sw/ull_adv.c
-      )
-    zephyr_library_sources_ifdef(
-      CONFIG_BT_CTLR_ADV_EXT
-      ll_sw/ull_adv_aux.c
-      )
-    zephyr_library_sources_ifdef(
-      CONFIG_BT_CTLR_ADV_PERIODIC
-      ll_sw/ull_adv_sync.c
-      )
-    zephyr_library_sources_ifdef(
-      CONFIG_BT_CTLR_ADV_ISO
-      ll_sw/ull_adv_iso.c
-      )
-  endif()
-  if(CONFIG_BT_OBSERVER)
-    zephyr_library_sources(
-      ll_sw/ull_scan.c
-      )
-    zephyr_library_sources_ifdef(
-      CONFIG_BT_CTLR_ADV_EXT
-      ll_sw/ull_scan_aux.c
-      )
-    zephyr_library_sources_ifdef(
-      CONFIG_BT_CTLR_SYNC_PERIODIC
-      ll_sw/ull_sync.c
-      )
-    zephyr_library_sources_ifdef(
-      CONFIG_BT_CTLR_SYNC_ISO
-      ll_sw/ull_sync_iso.c
-      )
-  endif()
-  if(CONFIG_BT_CONN)
-    zephyr_library_sources(
-      ll_sw/ull_conn.c
-      )
-    zephyr_library_sources_ifdef(
-      CONFIG_BT_CTLR_PHY
-      ll_sw/ull_llcp_phy.c
-      )
-    zephyr_library_sources_ifdef(
-      CONFIG_BT_CTLR_LE_ENC
-      ll_sw/ull_llcp_enc.c
-      )
-    if (CONFIG_BT_CTLR_PERIPHERAL_ISO OR
-        CONFIG_BT_CTLR_CENTRAL_ISO)
-      zephyr_library_sources(
-        ll_sw/ull_llcp_cc.c
-      )
-    endif()
-    zephyr_library_sources(
-      ll_sw/ull_tx_queue.c
-      ll_sw/ull_llcp.c
-      ll_sw/ull_llcp_common.c
-      ll_sw/ull_llcp_local.c
-      ll_sw/ull_llcp_pdu.c
-      ll_sw/ull_llcp_conn_upd.c
-      ll_sw/ull_llcp_chmu.c
-      ll_sw/ull_llcp_remote.c
-      )
-    if(CONFIG_BT_PERIPHERAL)
-      zephyr_library_sources(
-        ll_sw/ull_peripheral.c
-      )
-    zephyr_library_sources_ifdef(
-        CONFIG_BT_CTLR_PERIPHERAL_ISO
-        ll_sw/ull_peripheral_iso.c
-      )
-    endif()
-    if(CONFIG_BT_CENTRAL)
-      zephyr_library_sources(
-        ll_sw/ull_central.c
-        )
-      zephyr_library_sources_ifdef(
-        CONFIG_BT_CTLR_CENTRAL_ISO
-        ll_sw/ull_central_iso.c
-      )
-    endif()
-  endif()
-  if(CONFIG_BT_CTLR_SCHED_ADVANCED)
-    zephyr_library_sources(
-      ll_sw/ull_sched.c
-    )
-  endif()
-  if(CONFIG_BT_CTLR_DF)
-    zephyr_library_sources(
-      ll_sw/ull_df.c
-      )
-  endif()
-  if(CONFIG_BT_CTLR_CONN_ISO)
-    zephyr_library_sources(
-      ll_sw/ull_conn_iso.c
-      )
-  endif()
-  if(CONFIG_BT_CTLR_ISO)
-    zephyr_library_sources(
-      ll_sw/ull_iso.c
-      ll_sw/isoal.c
-      )
-  endif()
-  if(CONFIG_BT_CONN OR
-     (CONFIG_BT_BROADCASTER AND
-      CONFIG_BT_CTLR_ADV_EXT) OR
-     CONFIG_BT_CTLR_ADV_PERIODIC OR
-     CONFIG_BT_CTLR_SYNC_PERIODIC)
-    zephyr_library_sources(
-      ll_sw/ull_chan.c
-      ll_sw/lll_chan.c
-      )
-  endif()
-  if(CONFIG_BT_CTLR_FILTER_ACCEPT_LIST OR
-     CONFIG_BT_CTLR_SYNC_PERIODIC_ADV_LIST)
-    zephyr_library_sources(
-      ll_sw/ull_filter.c
-      )
-  endif()
-  zephyr_library_sources_ifdef(
-    CONFIG_BT_HCI_MESH_EXT
-    ll_sw/ll_mesh.c
-    )
-  add_subdirectory_ifdef(CONFIG_BT_CTLR_COEX_DRIVERS coex)
-endif()
+add_subdirectory_ifdef(
+  CONFIG_BT_CTLR_COEX_DRIVERS
+  coex
+  )
 
 if(CONFIG_SOC_COMPATIBLE_NRF)
   include(ll_sw/nrf.cmake)
@@ -161,16 +171,15 @@ elseif(CONFIG_SOC_OPENISA_RV32M1_RISCV32)
   include(ll_sw/openisa.cmake)
 endif()
 
-zephyr_library_sources_ifdef(
-  CONFIG_BT_CTLR_SETTINGS
-  ll_sw/ll_settings.c
-)
-
 zephyr_library_include_directories(
   .
   include
-  ../crypto
   )
+
+zephyr_library_include_directories_ifdef(
+  CONFIG_BT_CTLR_CRYPTO
+  ../crypto
+)
 
 zephyr_library_compile_options_ifdef(
   CONFIG_BT_CTLR_OPTIMIZE_FOR_SPEED

--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -160,6 +160,11 @@ zephyr_library_sources_ifdef(
   crypto/crypto.c
   )
 
+zephyr_library_sources_ifdef(
+  CONFIG_SOC_FLASH_NRF_RADIO_SYNC_TICKER
+  flash/soc_flash_nrf_ticker.c
+  )
+
 add_subdirectory_ifdef(
   CONFIG_BT_CTLR_COEX_DRIVERS
   coex
@@ -179,6 +184,11 @@ zephyr_library_include_directories(
 zephyr_library_include_directories_ifdef(
   CONFIG_BT_CTLR_CRYPTO
   ../crypto
+)
+
+zephyr_library_include_directories_ifdef(
+  CONFIG_SOC_FLASH_NRF_RADIO_SYNC_TICKER
+  ${ZEPHYR_BASE}/drivers/flash
 )
 
 zephyr_library_compile_options_ifdef(

--- a/subsys/bluetooth/controller/flash/soc_flash_nrf_ticker.c
+++ b/subsys/bluetooth/controller/flash/soc_flash_nrf_ticker.c
@@ -6,18 +6,18 @@
 
 #include <errno.h>
 
+#include <soc.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
-#include <soc.h>
-
-#include "soc_flash_nrf.h"
-
 #include <zephyr/sys/__assert.h>
 #include <zephyr/bluetooth/hci.h>
-#include "controller/hal/ticker.h"
-#include "controller/ticker/ticker.h"
-#include "controller/include/ll.h"
+
+#include "hal/ticker.h"
+#include "ticker/ticker.h"
+#include "ll.h"
+
+#include "soc_flash_nrf.h"
 
 #define FLASH_RADIO_ABORT_DELAY_US 1500
 #define FLASH_RADIO_WORK_DELAY_US  200


### PR DESCRIPTION
Move the SoC Flash nRF sync ticker implementation into Bluetooth Controller Subsystem folder, as internal headers are included.

Refactor the Bluetooth Controller's CMakelists.txt to consistently use zephyr_library_sources_ifdef() and zephyr_library_include_directories_ifdef().

Fixes #55756