### PR TITLE
net: wifi: Use micro seconds for precision for TWT intervals

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -328,6 +328,9 @@ Trusted Firmware-M
 
 Networking
 **********
+* Wi-Fi
+
+  * TWT intervals are changed from milli-seconds to micro-seconds, interval variables are also renamed.
 
 USB
 ***

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -212,13 +212,13 @@ struct wifi_twt_params {
 	union {
 		struct {
 			/* Interval = Wake up time + Sleeping time */
-			uint32_t twt_interval_ms;
+			uint64_t twt_interval;
 			bool responder;
 			bool trigger;
 			bool implicit;
 			bool announce;
 			/* Wake up time */
-			uint8_t twt_wake_interval_ms;
+			uint32_t twt_wake_interval;
 		} setup;
 		struct {
 			/* Only for Teardown */
@@ -229,10 +229,10 @@ struct wifi_twt_params {
 
 /* Flow ID is only 3 bits */
 #define WIFI_MAX_TWT_FLOWS 8
-#define WIFI_MAX_TWT_INTERVAL_MS 0x7FFFFFFF
+#define WIFI_MAX_TWT_INTERVAL_US (ULONG_MAX - 1)
 struct wifi_twt_flow_info {
 	/* Interval = Wake up time + Sleeping time */
-	uint32_t  twt_interval_ms;
+	uint64_t  twt_interval;
 	/* Map requests to responses */
 	uint8_t dialog_token;
 	/* Map setup with teardown */
@@ -243,7 +243,7 @@ struct wifi_twt_flow_info {
 	bool implicit;
 	bool announce;
 	/* Wake up time */
-	uint8_t twt_wake_interval_ms;
+	uint32_t twt_wake_interval;
 };
 
 struct wifi_ps_config {

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -230,6 +230,8 @@ struct wifi_twt_params {
 /* Flow ID is only 3 bits */
 #define WIFI_MAX_TWT_FLOWS 8
 #define WIFI_MAX_TWT_INTERVAL_US (ULONG_MAX - 1)
+/* 256 (u8) * 1TU */
+#define WIFI_MAX_TWT_WAKE_INTERVAL_US 262144
 struct wifi_twt_flow_info {
 	/* Interval = Wake up time + Sleeping time */
 	uint64_t  twt_interval;

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -599,7 +599,8 @@ static int cmd_wifi_twt_setup_quick(const struct shell *sh, size_t argc,
 	params.setup.trigger = 1;
 	params.setup.announce = 0;
 
-	if (!parse_number(sh, (long *)&params.setup.twt_wake_interval, argv[idx++], 1, 255) ||
+	if (!parse_number(sh, (long *)&params.setup.twt_wake_interval, argv[idx++],
+			  1, WIFI_MAX_TWT_WAKE_INTERVAL_US) ||
 	    !parse_number(sh, (long *)&params.setup.twt_interval, argv[idx++], 1,
 			  WIFI_MAX_TWT_INTERVAL_US))
 		return -EINVAL;
@@ -648,7 +649,8 @@ static int cmd_wifi_twt_setup(const struct shell *sh, size_t argc,
 	    !parse_number(sh, (long *)&params.setup.trigger, argv[idx++], 0, 1) ||
 	    !parse_number(sh, (long *)&params.setup.implicit, argv[idx++], 0, 1) ||
 	    !parse_number(sh, (long *)&params.setup.announce, argv[idx++], 0, 1) ||
-	    !parse_number(sh, (long *)&params.setup.twt_wake_interval, argv[idx++], 1, 255) ||
+	    !parse_number(sh, (long *)&params.setup.twt_wake_interval, argv[idx++], 1,
+			  WIFI_MAX_TWT_WAKE_INTERVAL_US) ||
 	    !parse_number(sh, (long *)&params.setup.twt_interval, argv[idx++], 1,
 			  WIFI_MAX_TWT_INTERVAL_US))
 		return -EINVAL;

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -160,10 +160,10 @@ static void handle_wifi_twt_event(struct net_mgmt_event_callback *cb)
 		/* If accepted, then no need to print TWT params */
 		if (resp->setup_cmd != WIFI_TWT_SETUP_CMD_ACCEPT) {
 			print(context.sh, SHELL_NORMAL,
-			      "TWT parameters: trigger: %s wake_interval: %d ms, interval: %d ms\n",
+			      "TWT parameters: trigger: %s wake_interval: %d us, interval: %lld us\n",
 			      resp->setup.trigger ? "trigger" : "no_trigger",
-			      resp->setup.twt_wake_interval_ms,
-			      resp->setup.twt_interval_ms);
+			      resp->setup.twt_wake_interval,
+			      resp->setup.twt_interval);
 		}
 	} else {
 		print(context.sh, SHELL_NORMAL, "TWT response timed out\n");
@@ -478,10 +478,10 @@ static int cmd_wifi_ps(const struct shell *sh, size_t argc, char *argv[])
 					config.twt_flows[i].trigger ? "true" : "false");
 				shell_fprintf(sh, SHELL_NORMAL, "TWT announce: %s\n",
 					config.twt_flows[i].announce ? "true" : "false");
-				shell_fprintf(sh, SHELL_NORMAL, "TWT wake interval: %d ms\n",
-					config.twt_flows[i].twt_wake_interval_ms);
-				shell_fprintf(sh, SHELL_NORMAL, "TWT interval: %d ms\n",
-					config.twt_flows[i].twt_interval_ms);
+				shell_fprintf(sh, SHELL_NORMAL, "TWT wake interval: %d us\n",
+					config.twt_flows[i].twt_wake_interval);
+				shell_fprintf(sh, SHELL_NORMAL, "TWT interval: %lld us\n",
+					config.twt_flows[i].twt_interval);
 				shell_fprintf(sh, SHELL_NORMAL, "========================\n");
 			}
 		}
@@ -599,9 +599,9 @@ static int cmd_wifi_twt_setup_quick(const struct shell *sh, size_t argc,
 	params.setup.trigger = 1;
 	params.setup.announce = 0;
 
-	if (!parse_number(sh, (long *)&params.setup.twt_wake_interval_ms, argv[idx++], 1, 255) ||
-	    !parse_number(sh, (long *)&params.setup.twt_interval_ms, argv[idx++], 1,
-			  WIFI_MAX_TWT_INTERVAL_MS))
+	if (!parse_number(sh, (long *)&params.setup.twt_wake_interval, argv[idx++], 1, 255) ||
+	    !parse_number(sh, (long *)&params.setup.twt_interval, argv[idx++], 1,
+			  WIFI_MAX_TWT_INTERVAL_US))
 		return -EINVAL;
 
 	if (net_mgmt(NET_REQUEST_WIFI_TWT, iface, &params, sizeof(params))) {
@@ -648,9 +648,9 @@ static int cmd_wifi_twt_setup(const struct shell *sh, size_t argc,
 	    !parse_number(sh, (long *)&params.setup.trigger, argv[idx++], 0, 1) ||
 	    !parse_number(sh, (long *)&params.setup.implicit, argv[idx++], 0, 1) ||
 	    !parse_number(sh, (long *)&params.setup.announce, argv[idx++], 0, 1) ||
-	    !parse_number(sh, (long *)&params.setup.twt_wake_interval_ms, argv[idx++], 1, 255) ||
-	    !parse_number(sh, (long *)&params.setup.twt_interval_ms, argv[idx++], 1,
-			  WIFI_MAX_TWT_INTERVAL_MS))
+	    !parse_number(sh, (long *)&params.setup.twt_wake_interval, argv[idx++], 1, 255) ||
+	    !parse_number(sh, (long *)&params.setup.twt_interval, argv[idx++], 1,
+			  WIFI_MAX_TWT_INTERVAL_US))
 		return -EINVAL;
 
 	params.negotiation_type = neg_type;
@@ -849,13 +849,13 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_cmd_ap,
 
 SHELL_STATIC_SUBCMD_SET_CREATE(wifi_twt_ops,
 	SHELL_CMD(quick_setup, NULL, " Start a TWT flow with defaults:\n"
-		"<twt_wake_interval_ms: 1-256ms> <twt_interval_ms: 1ms-2^32ms>\n",
+		"<twt_wake_interval: 1-262144us> <twt_interval: 1us-2^64us>\n",
 		cmd_wifi_twt_setup_quick),
 	SHELL_CMD(setup, NULL, " Start a TWT flow:\n"
 		"<negotiation_type, 0: Individual, 1: Broadcast, 2: Wake TBTT>\n"
 		"<setup_cmd: 0: Request, 1: Suggest, 2: Demand>\n"
 		"<dialog_token: 1-255> <flow_id: 1-255> <responder: 0/1> <trigger: 0/1> <implicit:0/1> "
-		"<announce: 0/1> <twt_wake_interval_ms: 1-256ms> <twt_interval_ms: 1ms-2^32ms>\n",
+		"<announce: 0/1> <twt_wake_interval: 1-262144us> <twt_interval: 1us-2^64us>\n",
 		cmd_wifi_twt_setup),
 	SHELL_CMD(teardown, NULL, " Teardown a TWT flow:\n"
 		"<negotiation_type, 0: Individual, 1: Broadcast, 2: Wake TBTT>\n"


### PR DESCRIPTION
In order to take granular input use micro seconds as input for TWT intervals, this helps us in providing inputs such as 65.28ms without the need of using floating points.

This also expands the TWT wake interval range to 262.144ms, earlier as we want to use uint8, limited to 256ms.

Also, remove the units from the variable names, this is unnecessary and also avoids doing breaking changes.

Update release notes as this is a breaking change, both type and variable names are changed.

@sachinthegreen @udaynordic @ajayparida @chiranjeevi2776 @lakshmi-nagumothu 