### PR TITLE
tests: remove test_framework tag from tests non-framework tests

### DIFF
--- a/tests/bluetooth/controller/ctrl_api/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_api/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_api bt_ull_llcp
+  tags: bluetooth bt_api bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_api.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_chmu/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_chmu/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_chmu bt_ull_llcp
+  tags: bluetooth bt_chmu bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_chmu.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_cis_create/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_cis_create/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_cis_create bt_ull_llcp
+  tags: bluetooth bt_cis_create bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_cis_create.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_cis_terminate/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_cis_terminate/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_cis_terminate bt_ull_llcp
+  tags: bluetooth bt_cis_terminate bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_cis_terminate.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_collision/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_collision/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_collision bt_ull_llcp
+  tags: bluetooth bt_collision bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_collision.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_conn_update/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_conn_update/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_conn_update bt_conn_param_req bt_ull_llcp
+  tags: bluetooth bt_conn_update bt_conn_param_req bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_conn_update.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_cte_req/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_cte_req/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_le_cte_req bt_ull_llcp
+  tags: bluetooth bt_le_cte_req bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_cte_req.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_data_length_update/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_data_length_update/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_data_length_update bt_ull_llcp
+  tags: bluetooth bt_data_length_update bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_data_length_update.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_encrypt/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_encrypt/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_encrypt bt_ull_llcp
+  tags: bluetooth bt_encrypt bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_encrypt.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_feature_exchange/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_feature_exchange bt_ull_llcp
+  tags: bluetooth bt_feature_exchange bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_feature_exchange.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_hci/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_hci/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_ctrl_hci bt_ull_llcp
+  tags: bluetooth bt_ctrl_hci bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_hci.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_invalid/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_invalid/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_invalid bt_ull_llcp
+  tags: bluetooth bt_invalid bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_invalid.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_le_ping/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_le_ping/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_le_ping bt_ull_llcp
+  tags: bluetooth bt_le_ping bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_le_ping.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_min_used_chans/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_min_used_chans bt_ull_llcp
+  tags: bluetooth bt_min_used_chans bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_min_used_chans.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_phy_update/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_phy_update/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_phy_update bt_ull_llcp
+  tags: bluetooth bt_phy_update bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_phy_update.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_sca_update/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_sca_update/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_sca_update bt_ull_llcp
+  tags: bluetooth bt_sca_update bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_sca_update.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_terminate/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_terminate/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_terminate bt_ull_llcp
+  tags: bluetooth bt_terminate bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_terminate.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_tx_buffer_alloc/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_tx_buffer_alloc/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_tx_buffer_alloc bt_ull_llcp
+  tags: bluetooth bt_tx_buffer_alloc bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_tx_buffer_alloc.test_0_per_conn:
     type: unit

--- a/tests/bluetooth/controller/ctrl_unsupported/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_unsupported/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_unsupported bt_ull_llcp
+  tags: bluetooth bt_unsupported bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_unsupported.default.test:
     type: unit

--- a/tests/bluetooth/controller/ctrl_version/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_version/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth bt_version_exchange bt_ull_llcp
+  tags: bluetooth bt_version_exchange bt_ull_llcp
 tests:
   bluetooth.controller.ctrl_version.test:
     type: unit

--- a/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/testcase.yaml
+++ b/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_buf_get_cmd_complete.default:
     type: unit

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/testcase.yaml
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_buf_get_evt.default:
     type: unit

--- a/tests/bluetooth/host/buf/bt_buf_get_rx/testcase.yaml
+++ b/tests/bluetooth/host/buf/bt_buf_get_rx/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_buf_get_rx.default:
     type: unit

--- a/tests/bluetooth/host/buf/bt_buf_get_type/testcase.yaml
+++ b/tests/bluetooth/host/buf/bt_buf_get_type/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_buf_get_type.default:
     type: unit

--- a/tests/bluetooth/host/crypto/bt_encrypt_be/testcase.yaml
+++ b/tests/bluetooth/host/crypto/bt_encrypt_be/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_encrypt_be.default:
     type: unit

--- a/tests/bluetooth/host/crypto/bt_encrypt_be/testcase.yaml
+++ b/tests/bluetooth/host/crypto/bt_encrypt_be/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_encrypt_be.default:
-     type: unit
+    type: unit

--- a/tests/bluetooth/host/crypto/bt_encrypt_le/testcase.yaml
+++ b/tests/bluetooth/host/crypto/bt_encrypt_le/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_encrypt_le.default:
-     type: unit
+    type: unit

--- a/tests/bluetooth/host/crypto/bt_encrypt_le/testcase.yaml
+++ b/tests/bluetooth/host/crypto/bt_encrypt_le/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_encrypt_le.default:
     type: unit

--- a/tests/bluetooth/host/crypto/bt_rand/testcase.yaml
+++ b/tests/bluetooth/host/crypto/bt_rand/testcase.yaml
@@ -1,9 +1,9 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_rand.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_rand.host_crypto_prng_disabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_HOST_CRYPTO_PRNG=n

--- a/tests/bluetooth/host/crypto/bt_rand/testcase.yaml
+++ b/tests/bluetooth/host/crypto/bt_rand/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_rand.default:
     type: unit

--- a/tests/bluetooth/host/crypto/prng_init/testcase.yaml
+++ b/tests/bluetooth/host/crypto/prng_init/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.prng_init.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_br_oob_get_local/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_br_oob_get_local/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_br_oob_get_local.default:
-     type: unit
+    type: unit

--- a/tests/bluetooth/host/id/bt_br_oob_get_local/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_br_oob_get_local/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_br_oob_get_local.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_add/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_add/testcase.yaml
@@ -1,20 +1,20 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_add.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_id_add.broadcaster_ext_adv_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_EXT_ADV=y
       - CONFIG_BT_BROADCASTER=y
   bluetooth.host.bt_id_add.broadcaster_no_ext_adv:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_BROADCASTER=y
   bluetooth.host.bt_id_add.observer_ext_adv:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_EXT_ADV=y
       - CONFIG_BT_OBSERVER=y
       - CONFIG_BT_BROADCASTER=y

--- a/tests/bluetooth/host/id/bt_id_add/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_add/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_add.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_adv_random_addr_check/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_adv_random_addr_check/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_adv_random_addr_check.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_adv_random_addr_check/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_adv_random_addr_check/testcase.yaml
@@ -1,27 +1,27 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_adv_random_addr_check.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_id_adv_random_addr_check.observer_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_CENTRAL=y
       - CONFIG_BT_OBSERVER=y
   bluetooth.host.bt_id_adv_random_addr_check.observer_privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y
       - CONFIG_BT_CENTRAL=y
       - CONFIG_BT_OBSERVER=y
   bluetooth.host.bt_id_adv_random_addr_check.observer_scan_with_identity_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SCAN_WITH_IDENTITY=y
       - CONFIG_BT_CENTRAL=y
       - CONFIG_BT_OBSERVER=y
   bluetooth.host.bt_id_adv_random_addr_check.bt_ext_adv_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_EXT_ADV=y

--- a/tests/bluetooth/host/id/bt_id_create/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_create/testcase.yaml
@@ -1,10 +1,10 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_create.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_id_create.bt_privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y

--- a/tests/bluetooth/host/id/bt_id_create/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_create/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_create.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_del/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_del/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_del.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_del/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_del/testcase.yaml
@@ -1,26 +1,26 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_del.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_id_del.broadcaster_ext_adv_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_EXT_ADV=y
       - CONFIG_BT_BROADCASTER=y
   bluetooth.host.bt_id_del.broadcaster_no_ext_adv:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_BROADCASTER=y
   bluetooth.host.bt_id_del.broadcaster_no_ext_adv_privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_CENTRAL=y
       - CONFIG_BT_PRIVACY=y
       - CONFIG_BT_BROADCASTER=y
   bluetooth.host.bt_id_del.observer_ext_adv:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_EXT_ADV=y
       - CONFIG_BT_OBSERVER=y
       - CONFIG_BT_BROADCASTER=y

--- a/tests/bluetooth/host/id/bt_id_delete/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_delete/testcase.yaml
@@ -1,21 +1,21 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_delete.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_id_delete.default_bt_settings_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_SETTINGS=y
       - CONFIG_BT_SETTINGS=y
   bluetooth.host.bt_id_delete.privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y
   bluetooth.host.bt_id_delete.privacy_bt_settings_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_SETTINGS=y
       - CONFIG_BT_SETTINGS=y
       - CONFIG_BT_SMP=y

--- a/tests/bluetooth/host/id/bt_id_delete/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_delete/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_delete.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_get/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_get/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_get.default:
-     type: unit
+    type: unit

--- a/tests/bluetooth/host/id/bt_id_get/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_get/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_get.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_init/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_init/testcase.yaml
@@ -1,15 +1,15 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_init.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_id_init.default_bt_settings_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_SETTINGS=y
       - CONFIG_BT_SETTINGS=y
   bluetooth.host.bt_id_create.bt_privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y

--- a/tests/bluetooth/host/id/bt_id_init/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_init/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_init.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_read_public_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_read_public_addr/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_read_public_addr.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_reset/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_reset/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_reset.default:
-     type: unit
+    type: unit

--- a/tests/bluetooth/host/id/bt_id_reset/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_reset/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_reset.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_scan_random_addr_check/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_scan_random_addr_check/testcase.yaml
@@ -1,19 +1,19 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_scan_random_addr_check.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_id_scan_random_addr_check.broadcaster_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_BROADCASTER=y
   bluetooth.host.bt_id_scan_random_addr_check.broadcaster_privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y
       - CONFIG_BT_BROADCASTER=y
   bluetooth.host.bt_id_scan_random_addr_check.bt_ext_adv_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_EXT_ADV=y

--- a/tests/bluetooth/host/id/bt_id_scan_random_addr_check/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_scan_random_addr_check/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_scan_random_addr_check.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_set_adv_own_addr.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/testcase.yaml
@@ -1,14 +1,14 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_set_adv_own_addr.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_id_set_adv_own_addr.default_ext_adv_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_EXT_ADV=y
   bluetooth.host.bt_id_set_adv_own_addr.privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y

--- a/tests/bluetooth/host/id/bt_id_set_adv_private_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_set_adv_private_addr/testcase.yaml
@@ -1,16 +1,16 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_set_adv_private_addr.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_id_set_adv_private_addr.bt_privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y
   bluetooth.host.bt_id_set_adv_private_addr.bt_privacy_ext_adv_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y
       - CONFIG_BT_EXT_ADV=y

--- a/tests/bluetooth/host/id/bt_id_set_adv_private_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_set_adv_private_addr/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_set_adv_private_addr.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_set_adv_random_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_set_adv_random_addr/testcase.yaml
@@ -1,9 +1,9 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_set_adv_random_addr.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_id_set_adv_random_addr.bt_ext_adv_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_EXT_ADV=y

--- a/tests/bluetooth/host/id/bt_id_set_adv_random_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_set_adv_random_addr/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_set_adv_random_addr.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/testcase.yaml
@@ -1,10 +1,10 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_set_create_conn_own_addr.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_id_set_create_conn_own_addr.privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y

--- a/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_set_create_conn_own_addr.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_set_private_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_set_private_addr/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_set_private_addr.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_set_private_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_set_private_addr/testcase.yaml
@@ -1,10 +1,10 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_set_private_addr.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_id_set_private_addr.bt_privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_set_scan_own_addr.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/testcase.yaml
@@ -1,20 +1,20 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_set_scan_own_addr.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_id_set_scan_own_addr.privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y
   bluetooth.host.bt_id_set_scan_own_addr.default_scan_with_identity:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SCAN_WITH_IDENTITY=y
   bluetooth.host.bt_id_set_scan_own_addr.privacy_scan_with_identity_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SCAN_WITH_IDENTITY=y
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y

--- a/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_le_ext_adv_oob_get_local.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/testcase.yaml
@@ -1,10 +1,10 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_le_ext_adv_oob_get_local.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_le_oob_get_local.bt_privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y

--- a/tests/bluetooth/host/id/bt_le_oob_get_local/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_le_oob_get_local/testcase.yaml
@@ -1,16 +1,16 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_le_oob_get_local.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_le_oob_get_local.bt_privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y
   bluetooth.host.bt_le_oob_get_local.bt_broadcaster_privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y
       - CONFIG_BT_BROADCASTER=y

--- a/tests/bluetooth/host/id/bt_le_oob_get_local/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_le_oob_get_local/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_le_oob_get_local.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_le_oob_get_sc_data/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_le_oob_get_sc_data/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_le_oob_get_sc_data.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_le_oob_get_sc_data/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_le_oob_get_sc_data/testcase.yaml
@@ -1,7 +1,7 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_le_oob_get_sc_data.default:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y

--- a/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_le_oob_set_legacy_tk.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/testcase.yaml
@@ -1,7 +1,7 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_le_oob_set_legacy_tk.default:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y

--- a/tests/bluetooth/host/id/bt_le_oob_set_sc_data/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_le_oob_set_sc_data/testcase.yaml
@@ -1,7 +1,7 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_le_oob_set_sc_data.default:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y

--- a/tests/bluetooth/host/id/bt_le_oob_set_sc_data/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_le_oob_set_sc_data/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_le_oob_set_sc_data.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_lookup_id_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_lookup_id_addr/testcase.yaml
@@ -1,9 +1,9 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_lookup_id_addr.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_lookup_id_addr.bt_smp_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y

--- a/tests/bluetooth/host/id/bt_lookup_id_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_lookup_id_addr/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_lookup_id_addr.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_setup_public_id_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_setup_public_id_addr/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_setup_public_id_addr.default:
     type: unit

--- a/tests/bluetooth/host/id/bt_setup_public_id_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_setup_public_id_addr/testcase.yaml
@@ -1,21 +1,21 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_setup_public_id_addr.default:
-     type: unit
+    type: unit
   bluetooth.host.bt_setup_public_id_addr.default_bt_settings_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_SETTINGS=y
       - CONFIG_BT_SETTINGS=y
   bluetooth.host.bt_setup_public_id_addr.bt_privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y
   bluetooth.host.bt_setup_public_id_addr.bt_privacy_settings_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y
       - CONFIG_SETTINGS=y

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/testcase.yaml
@@ -1,34 +1,34 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_id_create.default:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_ID_MAX=1
   bluetooth.host.bt_id_create.multiple_identities:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_ID_MAX=4
   bluetooth.host.bt_id_create.hci_vs_ext_detect:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_ID_MAX=1
       - CONFIG_BT_HCI_VS_EXT_DETECT=y
   bluetooth.host.bt_id_create.multiple_identities_hci_vs_ext_detect:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_ID_MAX=4
       - CONFIG_BT_HCI_VS_EXT_DETECT=y
   bluetooth.host.bt_id_create.multiple_identities_hci_vs_ext_detect_privacy_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_ID_MAX=4
       - CONFIG_BT_HCI_VS_EXT_DETECT=y
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y
   bluetooth.host.bt_id_create.multiple_identities_hci_vs_ext_detect_privacy_settings_enabled:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_ID_MAX=4
       - CONFIG_BT_HCI_VS_EXT_DETECT=y
       - CONFIG_BT_SMP=y

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_id_create.default:
     type: unit

--- a/tests/bluetooth/host/keys/bt_keys_add_type/testcase.yaml
+++ b/tests/bluetooth/host/keys/bt_keys_add_type/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_keys_add_type.default:
     type: unit

--- a/tests/bluetooth/host/keys/bt_keys_clear/testcase.yaml
+++ b/tests/bluetooth/host/keys/bt_keys_clear/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_keys_clear.default:
     type: unit

--- a/tests/bluetooth/host/keys/bt_keys_find/testcase.yaml
+++ b/tests/bluetooth/host/keys/bt_keys_find/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_keys_find.default:
     type: unit

--- a/tests/bluetooth/host/keys/bt_keys_find_addr/testcase.yaml
+++ b/tests/bluetooth/host/keys/bt_keys_find_addr/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_keys_find_addr.default:
     type: unit

--- a/tests/bluetooth/host/keys/bt_keys_find_irk/testcase.yaml
+++ b/tests/bluetooth/host/keys/bt_keys_find_irk/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_keys_find_irk.default:
     type: unit

--- a/tests/bluetooth/host/keys/bt_keys_foreach_bond/testcase.yaml
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_bond/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_keys_foreach_bond.default:
     type: unit

--- a/tests/bluetooth/host/keys/bt_keys_foreach_type/testcase.yaml
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_type/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_keys_foreach_type.default:
     type: unit

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/testcase.yaml
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_keys_get_addr.default:
     type: unit

--- a/tests/bluetooth/host/keys/bt_keys_get_type/testcase.yaml
+++ b/tests/bluetooth/host/keys/bt_keys_get_type/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_keys_get_type.default:
     type: unit

--- a/tests/bluetooth/host/keys/bt_keys_store/testcase.yaml
+++ b/tests/bluetooth/host/keys/bt_keys_store/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_keys_store.default:
     type: unit

--- a/tests/bluetooth/host/keys/bt_keys_store/testcase.yaml
+++ b/tests/bluetooth/host/keys/bt_keys_store/testcase.yaml
@@ -1,8 +1,8 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_keys_store.default:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_SETTINGS=y
       - CONFIG_BT_SETTINGS=y

--- a/tests/bluetooth/host/keys/bt_keys_update_usage/testcase.yaml
+++ b/tests/bluetooth/host/keys/bt_keys_update_usage/testcase.yaml
@@ -1,14 +1,14 @@
 common:
-    tags: test_framework bluetooth host
+  tags: test_framework bluetooth host
 tests:
   bluetooth.host.bt_keys_update_usage.default:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_KEYS_OVERWRITE_OLDEST=y
   bluetooth.host.bt_keys_update_usage.save_aging_counter:
-     type: unit
-     extra_configs:
+    type: unit
+    extra_configs:
       - CONFIG_SETTINGS=y
       - CONFIG_BT_SETTINGS=y
       - CONFIG_BT_SMP=y

--- a/tests/bluetooth/host/keys/bt_keys_update_usage/testcase.yaml
+++ b/tests/bluetooth/host/keys/bt_keys_update_usage/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  tags: test_framework bluetooth host
+  tags: bluetooth host
 tests:
   bluetooth.host.bt_keys_update_usage.default:
     type: unit

--- a/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
+++ b/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
   # section.subsection
   drivers.sbs_gauge_new_api.emulated:
-    tags: test_framework
+    tags: drivers fuel_gauge
     filter: >
       dt_compat_enabled("sbs,sbs-gauge-new-api") and
       (CONFIG_QEMU_TARGET or CONFIG_BOARD_NATIVE_POSIX)
@@ -16,7 +16,7 @@ tests:
       xenvm
       xenvm_gicv3
   drivers.sbs_gauge_new_api.emulated_64_bit_i2c_addr:
-    tags: test_framework
+    tags: drivers fuel_gauge
     filter: >
       dt_compat_enabled("sbs,sbs-gauge-new-api") and
       (CONFIG_QEMU_TARGET or CONFIG_BOARD_NATIVE_POSIX)

--- a/tests/drivers/sensor/sbs_gauge/testcase.yaml
+++ b/tests/drivers/sensor/sbs_gauge/testcase.yaml
@@ -1,13 +1,13 @@
 tests:
   # section.subsection
-  drivers.sbs_gauge:
+  drivers.sensors.sbs_gauge:
     build_only: true
-    tags: test_framework
+    tags: drivers sensors
     filter: dt_compat_enabled("sbs,sbs-gauge")
     integration_platforms:
       - nucleo_f070rb
-  drivers.sbs_gauge.emulated:
-    tags: test_framework
+  drivers.sensors.sbs_gauge.emulated:
+    tags: drivers sensors
     filter: dt_compat_enabled("sbs,sbs-gauge")
     platform_allow: native_posix qemu_cortex_a9 qemu_arc_hs
     integration_platforms:


### PR DESCRIPTION
Remove the "test_framework" tag from tests that are not testing the ztest framework itself.