### PR TITLE
net: mqtt: Debug logging of pointers

### DIFF
--- a/subsys/net/lib/mqtt/mqtt_decoder.c
+++ b/subsys/net/lib/mqtt/mqtt_decoder.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(net_mqtt_dec, CONFIG_MQTT_LOG_LEVEL);
  */
 static int unpack_uint8(struct buf_ctx *buf, uint8_t *val)
 {
-	NET_DBG(">> cur:%p, end:%p", buf->cur, buf->end);
+	NET_DBG(">> cur:%p, end:%p", (void *)buf->cur, (void *)buf->end);
 
 	if ((buf->end - buf->cur) < sizeof(uint8_t)) {
 		return -EINVAL;
@@ -55,7 +55,7 @@ static int unpack_uint8(struct buf_ctx *buf, uint8_t *val)
  */
 static int unpack_uint16(struct buf_ctx *buf, uint16_t *val)
 {
-	NET_DBG(">> cur:%p, end:%p", buf->cur, buf->end);
+	NET_DBG(">> cur:%p, end:%p", (void *)buf->cur, (void *)buf->end);
 
 	if ((buf->end - buf->cur) < sizeof(uint16_t)) {
 		return -EINVAL;
@@ -85,7 +85,7 @@ static int unpack_utf8_str(struct buf_ctx *buf, struct mqtt_utf8 *str)
 	uint16_t utf8_strlen;
 	int err_code;
 
-	NET_DBG(">> cur:%p, end:%p", buf->cur, buf->end);
+	NET_DBG(">> cur:%p, end:%p", (void *)buf->cur, (void *)buf->end);
 
 	err_code = unpack_uint16(buf, &utf8_strlen);
 	if (err_code != 0) {
@@ -126,7 +126,7 @@ static int unpack_utf8_str(struct buf_ctx *buf, struct mqtt_utf8 *str)
 static int unpack_data(uint32_t length, struct buf_ctx *buf,
 		       struct mqtt_binstr *str)
 {
-	NET_DBG(">> cur:%p, end:%p", buf->cur, buf->end);
+	NET_DBG(">> cur:%p, end:%p", (void *)buf->cur, (void *)buf->end);
 
 	if ((buf->end - buf->cur) < length) {
 		return -EINVAL;

--- a/subsys/net/lib/mqtt/mqtt_encoder.c
+++ b/subsys/net/lib/mqtt/mqtt_encoder.c
@@ -49,7 +49,7 @@ static int pack_uint8(uint8_t val, struct buf_ctx *buf)
 		return -ENOMEM;
 	}
 
-	NET_DBG(">> val:%02x cur:%p, end:%p", val, buf->cur, buf->end);
+	NET_DBG(">> val:%02x cur:%p, end:%p", val, (void *)buf->cur, (void *)buf->end);
 
 	/* Pack value. */
 	*(buf->cur++) = val;
@@ -73,7 +73,7 @@ static int pack_uint16(uint16_t val, struct buf_ctx *buf)
 		return -ENOMEM;
 	}
 
-	NET_DBG(">> val:%04x cur:%p, end:%p", val, buf->cur, buf->end);
+	NET_DBG(">> val:%04x cur:%p, end:%p", val, (void *)buf->cur, (void *)buf->end);
 
 	/* Pack value. */
 	*(buf->cur++) = (val >> 8) & 0xFF;
@@ -99,7 +99,7 @@ static int pack_utf8_str(const struct mqtt_utf8 *str, struct buf_ctx *buf)
 	}
 
 	NET_DBG(">> str_size:%08x cur:%p, end:%p",
-		 (uint32_t)GET_UT8STR_BUFFER_SIZE(str), buf->cur, buf->end);
+		 (uint32_t)GET_UT8STR_BUFFER_SIZE(str), (void *)buf->cur, (void *)buf->end);
 
 	/* Pack length followed by string. */
 	(void)pack_uint16(str->size, buf);
@@ -140,7 +140,7 @@ static uint8_t packet_length_encode(uint32_t length, struct buf_ctx *buf)
 	uint8_t encoded_bytes = 0U;
 
 	NET_DBG(">> length:0x%08x cur:%p, end:%p", length,
-		 (buf == NULL) ? 0 : buf->cur, (buf == NULL) ? 0 : buf->end);
+		 (buf == NULL) ? 0 : (void *)buf->cur, (buf == NULL) ? 0 : (void *)buf->end);
 
 	do {
 		encoded_bytes++;


### PR DESCRIPTION
Cast pointer to `void *` for `%p` parameter.
Otherwise lots of warnings in the log like below:

 `<wrn> cbprintf_package: (unsigned) char * used for %p argument.
 It's recommended to cast it to void * because it may cause
 misbehavior in certain configurations. String:"%s: (%p): >>
 length:0x%08x cur:%p, end:%p" argument:3`