### PR TITLE
dts: stm32: u5: fixes dts warning

### DIFF
--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -96,6 +96,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x40021800 0x400>;
 			num-lines = <16>;
 			interrupts = <5 0>, <6 0>, <7 0>;

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -106,6 +106,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x40010400 0x400>;
 			num-lines = <16>;
 			interrupts = <5 0>, <6 0>, <7 0>;

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -106,6 +106,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x40010400 0x400>;
 			num-lines = <16>;
 			interrupts = <6 0>, <7 0>, <8 0>, <9 0>,

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -105,6 +105,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x40013c00 0x400>;
 			num-lines = <16>;
 			interrupts = <6 0>, <7 0>, <8 0>, <9 0>,

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -108,6 +108,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x40010400 0x400>;
 			num-lines = <16>;
 			interrupts = <6 0>, <7 0>, <8 0>, <9 0>,

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -105,6 +105,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x40013c00 0x400>;
 			num-lines = <16>;
 			interrupts = <6 0>, <7 0>, <8 0>, <9 0>,

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -125,6 +125,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x40013c00 0x400>;
 			num-lines = <16>;
 			interrupts = <6 0>, <7 0>, <8 0>, <9 0>,

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -126,6 +126,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x40021800 0x400>;
 			num-lines = <16>;
 			interrupts = <5 0>, <6 0>, <7 0>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -170,6 +170,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x40010400 0x400>;
 			num-lines = <16>;
 			interrupts = <6 0>, <7 0>, <8 0>, <9 0>,

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -143,6 +143,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x58000000 0x400>;
 			num-lines = <16>;
 			interrupts = <6 0>, <7 0>, <8 0>, <9 0>,

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -127,6 +127,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x40010400 0x400>;
 			num-lines = <16>;
 			interrupts = <5 0>, <6 0>, <7 0>;

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -231,6 +231,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x40010400 0x400>;
 			num-lines = <16>;
 			interrupts = <6 0>, <7 0>, <8 0>, <9 0>,

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -137,6 +137,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x40010400 0x400>;
 			num-lines = <16>;
 			interrupts = <6 0>, <7 0>, <8 0>, <9 0>,

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -55,6 +55,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x5000d000 0x400>;
 			num-lines = <16>;
 			interrupts = <6 0>, <7 0>, <8 0>, <9 0>,

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -170,6 +170,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x46022000 0x400>;
 			num-lines = <16>;
 			interrupts = <11 0>, <12 0>, <13 0>, <14 0>,

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -170,6 +170,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x58000800 0x400>;
 			num-lines = <16>;
 			interrupts = <6 0>, <7 0>, <8 0>, <9 0>,

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -137,6 +137,7 @@
 			compatible = "st,stm32-exti";
 			interrupt-controller;
 			#interrupt-cells = <1>;
+			#address-cells = <1>;
 			reg = <0x58000800 0x400>;
 			num-lines = <16>;
 			interrupts = <6 0>, <7 0>, <8 0>, <9 0>,


### PR DESCRIPTION
I am getting a warning if this is not set.

Fixes warning: /soc/interrupt-controller:
Missing #address-cells in interrupt provider