### PR TITLE
net: sockets: Update zsock_poll() API documentation

### DIFF
--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -458,8 +458,7 @@ __syscall int zsock_fcntl(int sock, int cmd, int flags);
  * @rst
  * See `POSIX.1-2017 article
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html>`__
- * for normative description. (In Zephyr this function works only with
- * sockets, not arbitrary file descriptors.)
+ * for normative description.
  * This function is also exposed as ``poll()``
  * if :kconfig:option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined (in which case
  * it may conflict with generic POSIX ``poll()`` function).


### PR DESCRIPTION
It is no longer true that zsock_poll() works only with networking sockets, we now support for example eventfd objects which can also be polled. Therefore just remove the outdated comment in the zsock_poll() documentation, as it is misleading.

Fixes #55506