### PR TITLE
retention: Add bootloader configuration interface

### DIFF
--- a/include/zephyr/retention/bootloader.h
+++ b/include/zephyr/retention/bootloader.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Public API for bootloader configuration interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_RETENTION_BOOTLOADER_
+#define ZEPHYR_INCLUDE_RETENTION_BOOTLOADER_
+
+#include <stdint.h>
+#include <stddef.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/types.h>
+#include <bootutil/image.h>
+#include <bootutil/zephyr/mcuboot_shared.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Bootloader configuration interface
+ * @defgroup bootloader_config_interface Bootloader configuration interface
+ * @ingroup retention
+ * @{
+ */
+
+/**
+ * @brief		Loads mcuboot bootloader configuration from shared memory area.
+ *
+ * @param config	Configuration struct which will be updated.
+ *
+ * @retval		0 if successful, else negative errno code.
+ */
+int bootloader_load_config(struct mcuboot_configuration *config);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_RETENTION_BOOTLOADER_ */

--- a/subsys/retention/CMakeLists.txt
+++ b/subsys/retention/CMakeLists.txt
@@ -3,3 +3,8 @@
 zephyr_library()
 zephyr_library_sources(retention.c)
 zephyr_library_sources_ifdef(CONFIG_RETENTION_BOOT_MODE bootmode.c)
+zephyr_library_sources_ifdef(CONFIG_RETENTION_BOOTLOADER_CONFIG bootloader.c)
+
+if(CONFIG_RETENTION_BOOTLOADER_CONFIG)
+  zephyr_link_libraries(MCUBOOT_BOOTUTIL)
+endif()

--- a/subsys/retention/Kconfig
+++ b/subsys/retention/Kconfig
@@ -50,6 +50,22 @@ config RETENTION_BOOT_MODE
 	  byte must be created and set as the "zephyr,boot-mode" chosen node
 	  via device tree.
 
+config RETENTION_BOOTLOADER_CONFIG
+	bool "Bootloader configuration"
+	depends on !MCUBOOT && BOOTLOADER_MCUBOOT
+	select MCUBOOT_BOOTUTIL_LIB
+	help
+	  Adds a bootloader configuration sharing system for mcuboot and
+	  applications which allows applications to read the configurion of
+	  mcuboot and the running image. This can be used by applications so
+	  that they know how to e.g. handle firmware updates and place them
+	  into the correct slot.
+
+	  In order to use this, a retention area with at least X usable user
+	  bytes must be created and set as the "zephyr,bootloader-config"
+	  chosen node via device tree, this option must also be selected in the
+	  mcuboot build or the shared information will not be generated.
+
 endmenu
 
 module = RETENTION

--- a/subsys/retention/bootloader.c
+++ b/subsys/retention/bootloader.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/retention/retention.h>
+#include <zephyr/retention/bootloader.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(bootloader_config, CONFIG_RETENTION_LOG_LEVEL);
+
+static const struct device *bootloader_config_dev =
+					DEVICE_DT_GET(DT_CHOSEN(zephyr_bootloader_config));
+
+int bootloader_load_config(struct mcuboot_configuration *config)
+{
+	int rc;
+
+	rc = retention_is_valid(bootloader_config_dev);
+
+	if (rc == 1 || rc == -ENOTSUP) {
+		rc = retention_read(bootloader_config_dev, 0, (void *)config,
+				    sizeof(struct mcuboot_configuration));
+
+		if (rc == 0 && config->configuration_version != MCUBOOT_CONFIGURATION_VERSION_1) {
+			/* Unknown configuration version */
+			rc = -EINVAL;
+		}
+	}
+
+	return rc;
+}

--- a/west.yml
+++ b/west.yml
@@ -21,6 +21,8 @@ manifest:
   remotes:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
+    - name: mcuboot
+      url-base: https://github.com/mcu-tools
 
   group-filter: [-babblesim]
 
@@ -188,8 +190,9 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 1558e7ab0aadb4eac11f03befb5ccd3fa3f0aafe
+      revision: pull/1692/head
       path: bootloader/mcuboot
+      remote: mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t
       groups:


### PR DESCRIPTION
    retention: Add bootloader configuration interface
    
    Adds a bootloader configuration interface which allows for a
    bootloader (mcuboot) to set configuration in a shared data area
    which is then read by the application.

    west: sign: Add Kconfig with version
    
    Adds a Kconfig option which controls the version of the application
    to use when the image is signed using imgtool or embedded into
    mcuboot's data sharing system.

Fixes #46194