### PR TITLE
scripts: runners: nrf_common: Fix QSPI erase switch

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -342,7 +342,7 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
         args = {'firmware': {'file': hex_file, 'format': 'NRFDL_FW_INTEL_HEX'},
                 'chip_erase_mode': erase, 'verify': 'VERIFY_READ'}
         if qspi_erase:
-            args['firmware']['qspi_erase_mode'] = qspi_erase
+            args['qspi_erase_mode'] = qspi_erase
         self.exec_op('program', defer, core, **args)
 
     def exec_op(self, op, defer=False, core=None, **kwargs):


### PR DESCRIPTION
The QSPI erase switch is not part of the "firmware" dict, but rather placed in the overall operation dict.

Fixes #55625.