### PR TITLE
Bluetooth: controller: Avoid the use of weak functions for ISO data path

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -640,10 +640,14 @@ static void configure_data_path(struct net_buf *buf,
 
 	vs_config = &cmd->vs_config[0];
 
-	status = ll_configure_data_path(cmd->data_path_dir,
-					cmd->data_path_id,
-					cmd->vs_config_len,
-					vs_config);
+	if (IS_ENABLED(CONFIG_BT_CTLR_ISO_VENDOR_DATA_PATH)) {
+		status = ll_configure_data_path(cmd->data_path_dir,
+						cmd->data_path_id,
+						cmd->vs_config_len,
+						vs_config);
+	} else {
+		status = BT_HCI_ERR_INVALID_PARAM;
+	}
 
 	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -164,6 +164,7 @@ uint8_t ll_cis_parameters_test_set(uint8_t cis_id, uint8_t nse,
 				   uint16_t c_pdu, uint16_t p_pdu,
 				   uint8_t c_phy, uint8_t p_phy,
 				   uint8_t c_bn, uint8_t p_bn);
+/* Must be implemented by vendor if vendor-specific data path is supported */
 uint8_t ll_configure_data_path(uint8_t data_path_dir,
 			       uint8_t data_path_id,
 			       uint8_t vs_config_len,

--- a/subsys/bluetooth/controller/ll_sw/nordic/ull/ull_iso_vendor.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/ull/ull_iso_vendor.c
@@ -8,6 +8,8 @@
 #include <stdbool.h>
 
 #include <zephyr/bluetooth/hci.h>
+#include "isoal.h"
+#include "ull_iso_types.h"
 
 /* FIXME: Implement vendor specific data path configuration */
 static bool dummy;
@@ -18,6 +20,23 @@ bool ll_data_path_configured(uint8_t data_path_dir, uint8_t data_path_id)
 	ARG_UNUSED(data_path_id);
 
 	return dummy;
+}
+
+bool ll_data_path_source_create(uint16_t handle,
+				struct ll_iso_datapath *datapath,
+				isoal_source_pdu_alloc_cb *pdu_alloc,
+				isoal_source_pdu_write_cb *pdu_write,
+				isoal_source_pdu_emit_cb *pdu_emit,
+				isoal_source_pdu_release_cb *pdu_release)
+{
+	ARG_UNUSED(handle);
+	ARG_UNUSED(datapath);
+	ARG_UNUSED(pdu_alloc);
+	ARG_UNUSED(pdu_write);
+	ARG_UNUSED(pdu_emit);
+	ARG_UNUSED(pdu_release);
+
+	return false;
 }
 
 uint8_t ll_configure_data_path(uint8_t data_path_dir, uint8_t data_path_id,

--- a/subsys/bluetooth/controller/ll_sw/nrf.cmake
+++ b/subsys/bluetooth/controller/ll_sw/nrf.cmake
@@ -80,7 +80,7 @@ if(CONFIG_BT_LL_SW_SPLIT)
     CONFIG_BT_CTLR_PERIPHERAL_ISO
     ll_sw/nordic/lll/lll_peripheral_iso.c
     )
-  if(CONFIG_BT_CTLR_ISO)
+  if(CONFIG_BT_CTLR_ISO_VENDOR_DATA_PATH)
     zephyr_library_sources(
       ll_sw/nordic/ull/ull_iso_vendor.c
       )

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -3084,19 +3084,3 @@ void *ull_rxfifo_release(uint8_t s, uint8_t n, uint8_t f, uint8_t *l, uint8_t *m
 
 	return rx;
 }
-
-#if defined(CONFIG_BT_CTLR_HCI_CODEC_AND_DELAY_INFO)
-/* Contains vendor specific argument, function to be implemented by vendors */
-__weak uint8_t ll_configure_data_path(uint8_t data_path_dir,
-				      uint8_t data_path_id,
-				      uint8_t vs_config_len,
-				      uint8_t *vs_config)
-{
-	ARG_UNUSED(data_path_dir);
-	ARG_UNUSED(data_path_id);
-	ARG_UNUSED(vs_config_len);
-	ARG_UNUSED(vs_config);
-
-	return BT_HCI_ERR_CMD_DISALLOWED;
-}
-#endif /* CONFIG_BT_CTLR_HCI_CODEC_AND_DELAY_INFO */

--- a/subsys/bluetooth/controller/ll_sw/ull_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso_internal.h
@@ -29,3 +29,19 @@ void ll_iso_rx_put(memq_link_t *link, void *rx);
 void *ll_iso_rx_get(void);
 void ll_iso_rx_dequeue(void);
 void ll_iso_transmit_test_send_sdu(uint16_t handle, uint32_t ticks_at_expire);
+
+/* Must be implemented by vendor if vendor-specific data path is supported */
+bool ll_data_path_configured(uint8_t data_path_dir, uint8_t data_path_id);
+/* Must be implemented by vendor if vendor-specific data path is supported */
+bool ll_data_path_sink_create(uint16_t handle,
+			      struct ll_iso_datapath *datapath,
+			      isoal_sink_sdu_alloc_cb *sdu_alloc,
+			      isoal_sink_sdu_emit_cb *sdu_emit,
+			      isoal_sink_sdu_write_cb *sdu_write);
+/* Must be implemented by vendor if vendor-specific data path is supported */
+bool ll_data_path_source_create(uint16_t handle,
+				struct ll_iso_datapath *datapath,
+				isoal_source_pdu_alloc_cb *pdu_alloc,
+				isoal_source_pdu_write_cb *pdu_write,
+				isoal_source_pdu_emit_cb *pdu_emit,
+				isoal_source_pdu_release_cb *pdu_release);


### PR DESCRIPTION
Avoid the use of weak functions and call the respective functions only if vendor-specific data path is supported. The weak dummy functions will not implement the desired behavior anyway. This change makes it explicit that these functions need to be implemented by the vendor.