### PR TITLE
soc: arm: st_stm32: Move STM32H7_DUAL_CORE

### DIFF
--- a/boards/arm/arduino_giga_r1/Kconfig.defconfig
+++ b/boards/arm/arduino_giga_r1/Kconfig.defconfig
@@ -7,9 +7,6 @@ config BOARD
 	default "arduino_giga_r1_m7" if BOARD_ARDUINO_GIGA_R1_M7
 	default "arduino_giga_r1_m4" if BOARD_ARDUINO_GIGA_R1_M4
 
-config STM32H7_DUAL_CORE
-	default y
-
 if BT
 
 choice CYW43XXX_PART

--- a/boards/arm/arduino_portenta_h7/Kconfig.defconfig
+++ b/boards/arm/arduino_portenta_h7/Kconfig.defconfig
@@ -9,7 +9,4 @@ config BOARD
 	default "arduino_portenta_h7_m7" if BOARD_ARDUINO_PORTENTA_H7_M7
 	default "arduino_portenta_h7_m4" if BOARD_ARDUINO_PORTENTA_H7_M4
 
-config STM32H7_DUAL_CORE
-	default y
-
 endif # BOARD_ARDUINO_PORTENTA_H7_M7 || BOARD_ARDUINO_PORTENTA_H7_M4

--- a/boards/arm/nucleo_h745zi_q/Kconfig.defconfig
+++ b/boards/arm/nucleo_h745zi_q/Kconfig.defconfig
@@ -9,9 +9,6 @@ config BOARD
 	default "nucleo_h745zi_q_m7" if BOARD_NUCLEO_H745ZI_Q_M7
 	default "nucleo_h745zi_q_m4" if BOARD_NUCLEO_H745ZI_Q_M4
 
-config STM32H7_DUAL_CORE
-	default y
-
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/boards/arm/stm32h747i_disco/Kconfig.defconfig
+++ b/boards/arm/stm32h747i_disco/Kconfig.defconfig
@@ -9,9 +9,6 @@ config BOARD
 	default "stm32h747i_disco_m7" if BOARD_STM32H747I_DISCO_M7
 	default "stm32h747i_disco_m4" if BOARD_STM32H747I_DISCO_M4
 
-config STM32H7_DUAL_CORE
-	default y
-
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/soc/arm/st_stm32/stm32h7/Kconfig.series
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.series
@@ -16,7 +16,3 @@ config SOC_SERIES_STM32H7X
 	select CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	help
 	  Enable support for STM32H7 MCU series
-
-config STM32H7_DUAL_CORE
-	bool "Dual Core"
-	depends on SOC_SERIES_STM32H7X

--- a/soc/arm/st_stm32/stm32h7/Kconfig.soc
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.soc
@@ -5,6 +5,10 @@
 # Copyright (c) 2021 Electrolance Solutions
 # SPDX-License-Identifier: Apache-2.0
 
+config STM32H7_DUAL_CORE
+	bool "Dual Core"
+	depends on SOC_SERIES_STM32H7X
+
 choice
 	prompt "STM32H7x MCU Selection"
 	depends on SOC_SERIES_STM32H7X
@@ -42,10 +46,12 @@ config SOC_STM32H743XX
 config SOC_STM32H745XX
 	bool "STM32H745XX"
 	select CPU_HAS_FPU_DOUBLE_PRECISION if CPU_CORTEX_M7
+	select STM32H7_DUAL_CORE
 
 config SOC_STM32H747XX
 	bool "STM32H747XX"
 	select CPU_HAS_FPU_DOUBLE_PRECISION if CPU_CORTEX_M7
+	select STM32H7_DUAL_CORE
 
 config SOC_STM32H750XX
 	bool "STM32H750XX"


### PR DESCRIPTION
Move STM32H7_DUAL_CORE to soc/arm/st_stm32/stm32h7/Kconfig.defconfig.series. Set default to y.
Cleanup occurences where was set to y.