### PR TITLE
QUAD SPI nor flash working with DMA2

### DIFF
--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -1140,10 +1140,9 @@ static int flash_stm32_qspi_init(const struct device *dev)
 #else
 	hdma.Init.Request = dma_cfg.dma_slot;
 #ifdef CONFIG_DMAMUX_STM32
-	/* HAL expects a valid DMA channel (not DAMMUX) */
-	/* TODO: Get DMA instance from DT */
-	hdma.Instance = __LL_DMA_GET_CHANNEL_INSTANCE(DMA1,
-						      dev_data->dma.channel+1);
+	/* HAL expects a valid DMA channel (not a DMAMUX channel) */
+	hdma.Instance = __LL_DMA_GET_CHANNEL_INSTANCE(dev_data->dma.reg,
+						      dev_data->dma.channel);
 #else
 	hdma.Instance = __LL_DMA_GET_CHANNEL_INSTANCE(dev_data->dma.reg,
 						      dev_data->dma.channel-1);

--- a/dts/bindings/qspi/st,stm32-qspi.yaml
+++ b/dts/bindings/qspi/st,stm32-qspi.yaml
@@ -38,11 +38,19 @@ properties:
   dmas:
     description: |
       Optional DMA channel specifier. If DMA should be used, specifier should
-      hold a phandle reference to the dma controller, the channel number,
-      the slot number, channel configuration and finally features.
+      hold a phandle reference to the dma controller (not the DMAMUX even if present),
+      the channel number, the slot number, channel configuration and finally features.
+      (depending on the type of DMA: 'features' is optional)
 
-      For example dmas for TX/RX on QSPI
-         dmas = <&dma1 5 5 0x0000 0x03>;
+      When a DMAMUX is present and enabled, the channel is the dma one
+      (not dmamux channel). The request is given by the DMAMUX (no 'features' required).
+
+      For example with DMA 2 for TX/RX on QSPI like stm32l496 (no 'features')
+         /* select DMA2 channel 7 request 3 for QUADSPI */
+         dmas = <&dma2 7 3 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>;
+      For example with a DMAMUX for TX/RX on QSPI like stm32wb55  (no 'features')
+         /* select DMA2 channel 0, request 20 for QUADSPI */
+         dmas = <&dma2 0 20 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>;
 
   dma-names:
     description: |


### PR DESCRIPTION
Correct the hdma.Instance when a DMAMUX is enable, it could be DMA1 or DMA2.

Note that the dma phandle for the quadspi when a  DMAMUX is present, defines the DMA channel (not DMAMUX one) and the DMAMUX request. It looks like (example for wb55 nucleo)

```
&quadspi {
            dmas = <&dma2 0 20 0x480>; /* channel 0 of DMA2, request 20 for QUADSPI */
            dma-names = "tx_rx";
};
```

--> dma2 channel 0 
--> request 20 given by the DMAMUX
Requires
```
&dma1 {
	status = "okay";
};

&dma2 {
	status = "okay";
};

&dmamux {
	status = "okay";
};
```


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55754

Signed-off-by: Francois Ramu <francois.ramu@st.com>