### PR TITLE
soc: configuration: microchip SOC Kconfig bug fix

### DIFF
--- a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
+++ b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
@@ -11,12 +11,4 @@ config SOC
 config GPIO
 	default y
 
-config ESPI_XEC_V2
-	default y
-	depends on ESPI
-
-config EEPROM_XEC
-	default y
-	depends on EEPROM
-
 endif # SOC_MEC172X_NSZ


### PR DESCRIPTION
Removed the EEPROM and ESPI configuration from file Kconfig.defconfig.mec172xnsz. Since it overrides the setting present in the Device Tree file.