### PR TITLE
serial: xilinx: uartlite: Fix infinite spin in xlnx_uartlite_fifo_read

### DIFF
--- a/drivers/serial/uart_xlnx_uartlite.c
+++ b/drivers/serial/uart_xlnx_uartlite.c
@@ -214,6 +214,9 @@ static int xlnx_uartlite_fifo_read(const struct device *dev, uint8_t *rx_data,
 			rx_data[count++] = xlnx_uartlite_read_rx_fifo(dev);
 		}
 		k_spin_unlock(&data->rx_lock, key);
+		if (!(status & STAT_REG_RX_FIFO_VALID_DATA)) {
+			break;
+		}
 	}
 
 	return count;


### PR DESCRIPTION
The xlnx_uartlite_fifo_read function would spin indefinitely if there was less data available in the RX FIFO than the size of the passed-in buffer. This call is supposed to be non-blocking.

Fixed to break out of the loop if there are no more bytes left in the RX FIFO.