### PR TITLE
Bluetooth: Mesh:: Fix compiler warning

### DIFF
--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -771,7 +771,7 @@ static void link_open(struct prov_rx *rx, struct net_buf_simple *buf)
 		/* Ignore errors, message will be attempted again if we keep receiving link open: */
 		(void)bearer_ctl_send_unacked(
 			ctl_buf_create(LINK_ACK, NULL, 0, RETRANSMITS_ACK),
-			PROV_BEARER_LINK_STATUS_SUCCESS);
+			(void *)PROV_BEARER_LINK_STATUS_SUCCESS);
 		return;
 	}
 
@@ -786,7 +786,7 @@ static void link_open(struct prov_rx *rx, struct net_buf_simple *buf)
 
 	err = bearer_ctl_send_unacked(
 		ctl_buf_create(LINK_ACK, NULL, 0, RETRANSMITS_ACK),
-		PROV_BEARER_LINK_STATUS_SUCCESS);
+		(void *)PROV_BEARER_LINK_STATUS_SUCCESS);
 	if (err) {
 		reset_adv_link();
 		return;


### PR DESCRIPTION
When building with an LLVM toolchain get the following warning:

bluetooth/mesh/pb_adv.c:774:4: error: expression which evaluates to zero treated as a null pointer constant of type
'void *' [-Werror,-Wnon-literal-null-conversion]
                        PROV_BEARER_LINK_STATUS_SUCCESS);
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Fix by adding a cast to (void *).