### PR TITLE
samples: net: sockets: tcp: Add newlib filter to samples.yaml

### DIFF
--- a/samples/net/sockets/tcp/sample.yaml
+++ b/samples/net/sockets/tcp/sample.yaml
@@ -3,6 +3,7 @@ sample:
   name: tcp
 tests:
   sample.net.socket.tcp:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     harness: net
     platform_allow: qemu_x86
     tags: socket tcp


### PR DESCRIPTION
Not all toolchains support newlib so tests that require newlib need to have a filter to we don't try and build those tests on those testcases.  Add the following to samples.yaml to handle the issue:

	filter: TOOLCHAIN_HAS_NEWLIB == 1