### PR TITLE
samples: hash_map: Add newlib filter to samples.yaml

### DIFF
--- a/samples/basic/hash_map/sample.yaml
+++ b/samples/basic/hash_map/sample.yaml
@@ -31,16 +31,19 @@ tests:
       - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
   # Newlib
   libraries.hash_map.newlib.separate_chaining.djb2:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_SYS_HASH_MAP_CHOICE_SC=y
       - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
   libraries.hash_map.newlib.open_addressing.djb2:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_SYS_HASH_MAP_CHOICE_OA_LP=y
       - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
   libraries.hash_map.newlib.cxx_unordered_map.djb2:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_SYS_HASH_MAP_CHOICE_CXX=y


### PR DESCRIPTION
Not all toolchains support newlib so tests that require newlib need to have a filter to we don't try and build those tests on those testcases.  Add the following to samples.yaml to handle the issue:

	filter: TOOLCHAIN_HAS_NEWLIB == 1