### PR TITLE
soc: intel_adsp: update toolchain usage

### DIFF
--- a/soc/xtensa/intel_adsp/ace/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/ace/Kconfig.defconfig.series
@@ -9,7 +9,7 @@ config SOC_SERIES
 
 config SOC_TOOLCHAIN_NAME
 	string
-	default "intel_s1000"
+	default "intel_ace15_mtpm"
 
 config SMP
 	default y

--- a/soc/xtensa/intel_adsp/cavs/Kconfig.defconfig.cavs_v25
+++ b/soc/xtensa/intel_adsp/cavs/Kconfig.defconfig.cavs_v25
@@ -5,7 +5,7 @@ if SOC_INTEL_CAVS_V25
 
 config SOC_TOOLCHAIN_NAME
 	string
-	default "intel_s1000"
+	default "intel_tgl_adsp"
 
 config SOC
 	default "intel_tgl_adsp"

--- a/west.yml
+++ b/west.yml
@@ -156,7 +156,7 @@ manifest:
       groups:
         - hal
     - name: hal_xtensa
-      revision: bce25bd242fb07c4cfd13ccb1ed29bc8bc12b0b8
+      revision: pull/20/head
       path: modules/hal/xtensa
       groups:
         - hal


### PR DESCRIPTION
* Upates the manifest SHA to use the latest Xtensa HAL commit which is to support building intel_adsp_ace15_mtpm using Zephyr SDK.
* Update toolchain usage for both intel_adsp_cavs25 and ACE series.

Requires https://github.com/zephyrproject-rtos/sdk-ng/pull/651 and https://github.com/zephyrproject-rtos/sdk-ng/pull/664