### PR TITLE
drivers: pwm: Add Intel PCH blink PWM driver and sample app

### DIFF
--- a/drivers/pwm/CMakeLists.txt
+++ b/drivers/pwm/CMakeLists.txt
@@ -30,6 +30,7 @@ zephyr_library_sources_ifdef(CONFIG_PWM_PCA9685 	pwm_pca9685.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_TEST		pwm_test.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_RPI_PICO	pwm_rpi_pico.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_BBLED_XEC	pwm_mchp_xec_bbled.c)
+zephyr_library_sources_ifdef(CONFIG_PWM_BLINKY_INTEL	pwm_pch_blinky.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   pwm_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_CAPTURE pwm_capture.c)

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -85,4 +85,5 @@ source "drivers/pwm/Kconfig.test"
 
 source "drivers/pwm/Kconfig.rpi_pico"
 
+source "drivers/pwm/Kconfig.pch_blinky"
 endif # PWM

--- a/drivers/pwm/Kconfig.pch_blinky
+++ b/drivers/pwm/Kconfig.pch_blinky
@@ -1,0 +1,13 @@
+# Kconfig.blinky_intel - Blinky PWM configuration options
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menuconfig PWM_BLINKY_INTEL
+	bool "Blinky PWM driver"
+	default y
+	depends on DT_HAS_INTEL_BLINKY_PWM_ENABLED
+	help
+	  Enable the BK PWM driver found on Intel SoCs

--- a/drivers/pwm/pwm_pch_blinky.c
+++ b/drivers/pwm/pwm_pch_blinky.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT intel_blinky_pwm
+
+#include <errno.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/pwm.h>
+
+#define PWM_CTRL_REG            0x304
+#define PWM_ENABLE              0x80000000
+#define PWM_SWUP                0x40000000
+#define PWM_FREQ_INT_SHIFT      22
+#define PWM_FREQ_MAX            0x100
+#define PWM_DUTY_MAX            0x100
+
+struct bk_intel_config {
+	DEVICE_MMIO_NAMED_ROM(reg_base);
+	uint32_t clock_freq;
+	uint32_t max_pins;
+};
+
+struct bk_intel_runtime {
+	DEVICE_MMIO_NAMED_RAM(reg_base);
+	uint32_t pwm_ctrl;
+};
+
+static int bk_intel_set_cycles(const struct device *dev, uint32_t pin,
+			       uint32_t period_cycles, uint32_t pulse_cycles,
+			       pwm_flags_t flags)
+{
+	uint32_t ret = 0;
+	uint32_t val;
+	uint32_t period;
+	uint32_t duty;
+	struct bk_intel_runtime *rt = dev->data;
+	const struct bk_intel_config *cfg = dev->config;
+
+	if (pin > cfg->max_pins) {
+		ret = -EINVAL;
+		goto err;
+	}
+
+	period = (period_cycles * PWM_FREQ_MAX) / cfg->clock_freq;
+	duty = (pulse_cycles * PWM_DUTY_MAX) / period_cycles;
+
+	val = PWM_DUTY_MAX - duty;
+	val = val | (period << PWM_FREQ_INT_SHIFT);
+	val = val | PWM_ENABLE | PWM_SWUP;
+
+	if (period >= PWM_FREQ_MAX) {
+		ret = -EINVAL;
+		goto err;
+	}
+
+	if (duty >= PWM_DUTY_MAX) {
+		ret = -EINVAL;
+		goto err;
+	}
+
+	sys_write32(val, rt->pwm_ctrl);
+err:
+	return ret;
+}
+
+static int bk_intel_get_cycles_per_sec(const struct device *dev, uint32_t pin,
+				       uint64_t *cycles)
+{
+	const struct bk_intel_config *cfg = dev->config;
+
+	if (pin > cfg->max_pins) {
+		return -EINVAL;
+	}
+
+	*cycles = cfg->clock_freq;
+
+	return 0;
+}
+
+static const struct pwm_driver_api api_funcs = {
+	.set_cycles = bk_intel_set_cycles,
+	.get_cycles_per_sec = bk_intel_get_cycles_per_sec,
+};
+
+static int bk_intel_init(const struct device *dev)
+{
+	struct bk_intel_runtime *runtime = dev->data;
+	const struct bk_intel_config *config = dev->config;
+
+	device_map(&runtime->reg_base,
+		   config->reg_base.phys_addr & ~0xFFU,
+		   config->reg_base.size,
+		   K_MEM_CACHE_NONE);
+
+	runtime->pwm_ctrl = runtime->reg_base + PWM_CTRL_REG;
+
+	return 0;
+}
+
+#define BK_INTEL_DEV_CFG(n)						       \
+	static const struct bk_intel_config bk_cfg_##n = {		       \
+		DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_DRV_INST(n)),	       \
+		.max_pins = DT_INST_PROP(n, max_pins),			       \
+		.clock_freq = DT_INST_PROP(n, clock_frequency),		       \
+	};								       \
+									       \
+	static struct bk_intel_runtime bk_rt_##n;			       \
+	DEVICE_DT_INST_DEFINE(n, &bk_intel_init, NULL,			       \
+			      &bk_rt_##n, &bk_cfg_##n,			       \
+			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			      &api_funcs);				       \
+
+DT_INST_FOREACH_STATUS_OKAY(BK_INTEL_DEV_CFG)

--- a/dts/bindings/pwm/intel,blinky-pwm.yaml
+++ b/dts/bindings/pwm/intel,blinky-pwm.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+description: INTEL BLINKY PWM
+
+compatible: "intel,blinky-pwm"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true
+
+    clock-frequency:
+      type: int
+      required: true
+      description: PWM Peripheral Clock frequency in Hz
+
+    max-pins:
+      type: int
+      required: true
+      description: Maximum number of pins supported by platform

--- a/dts/x86/intel/raptor_lake.dtsi
+++ b/dts/x86/intel/raptor_lake.dtsi
@@ -78,5 +78,13 @@
 			reg = <0x70 0x0D 0x71 0x0D>;
 			status = "okay";
 		};
+
+		pwm0: pwm0@e06a0000 {
+			compatible = "intel,blinky-pwm";
+			reg = <0xe06a0000 0x400>;
+			clock-frequency = <32768>;
+			max-pins = <1>;
+			status = "okay";
+		};
 	};
 };

--- a/samples/drivers/pwm/CMakeLists.txt
+++ b/samples/drivers/pwm/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(NONE)
+
+target_include_directories(app PRIVATE $ENV{ZEPHYR_BASE}/drivers/pwm)
+target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/pwm/README.rst
+++ b/samples/drivers/pwm/README.rst
@@ -1,0 +1,31 @@
+.. _pwm_test:
+
+Test for PWM
+###########
+
+Overview
+********
+This is a sample PWM application.
+This test verifies the APIs for PWM IP
+
+To validate the output in PWM mode, you need to connect the oscilloscope
+to pin1 on pwm0. 
+
+Below parameters need to be changed as per platform -
+a. PWM_CHANNEL
+b. PWM_LABEL
+
+The granularity of duty cycles depends on the input clock speed of the PWM IP
+on the platform; higher the input clock, better accuracy of duty cycles.
+
+Building and Running
+********************
+Standard build procedure.
+
+Sample Output
+=============
+
+[PWM] Bind Success
+[PWM] Running rate: 32768
+[PWM] Generating pulses-Period: 100000000 nsec, Pulse: 20000000 nsec
+[PWM] Generating pulses-Period: 8192 cycles, Pulse: 4096 cycles

--- a/samples/drivers/pwm/prj.conf
+++ b/samples/drivers/pwm/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_PWM=y

--- a/samples/drivers/pwm/sample.yaml
+++ b/samples/drivers/pwm/sample.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+sample:
+  description: Test app for pwm
+  name: pwm
+  platforms: rpl_crb, ehl_crb
+common:
+    tags: samples
+    harness: console
+    harness_config:
+      type: one_line

--- a/samples/drivers/pwm/src/main.c
+++ b/samples/drivers/pwm/src/main.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Sample Application for PWM
+ * This example demonstrates the following
+ * a. Derive the clock rate for the PWM device
+ * b. Generate the PWM output by setting the period and pulse width
+ *    in nanoseconds
+ * c. Generate the PWM output by setting the period and pulse width
+ *    in terms of clock cycles
+ * @{
+ */
+
+/* Local Includes */
+#include <zephyr/sys/util.h>
+#include <zephyr/drivers/pwm.h>
+#include <zephyr/kernel.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define PWM_LABEL   DT_NODELABEL(pwm0)
+#define PWM_CHANNEL 1
+
+#define PERIOD_USEC 100000000 /* 100 ms */
+#define PULSE_USEC  20000000  /* 20% duty cycle */
+
+#define PERIOD_HW 8192 /* Period in hw cycles */
+#define PULSE_HW  4096 /* 50% Duty in hw cycles */
+
+/* @brief main function
+ * PWM Sample Application
+ * The sample app tests the PWM IP
+ * The user is required to connect a probing device like oscilloscope on
+ * PWM_CHANNEL pin on PWM_LABEL dev to check the PWM output.
+ */
+void main(void)
+{
+	const struct device *pwm_dev;
+	uint64_t cl;
+	int ret;
+	uint8_t pwm_flag = 0;
+
+	/* Get the device handle for PWM instance  */
+	pwm_dev = DEVICE_DT_GET(PWM_LABEL);
+	if (!device_is_ready(pwm_dev)) {
+		printk("[PWM] Bind failed\n");
+		return;
+	}
+	printk("[PWM] Bind Success\n");
+
+	/* Gets the clock rate(cycles per second) for the PWM device */
+	ret = pwm_get_cycles_per_sec(pwm_dev, 0, &cl);
+	if (ret != 0) {
+		printk("[PWM] Get clock rate failed\n");
+		return;
+	}
+	printk("[PWM] Running rate: %lld\n", cl);
+
+	/* Set the period and pulse width of the PWM output in
+	 * micro seconds. Expected output-Pulse with 50% duty cycle
+	 */
+	printk("[PWM] Generating pulses-Period: %d nsec, Pulse: %d nsec\n", PERIOD_USEC,
+	       PULSE_USEC);
+	ret = pwm_set(pwm_dev, PWM_CHANNEL, PERIOD_USEC, PULSE_USEC, pwm_flag);
+	if (ret != 0) {
+		printk("[PWM] Pin set nsec failed\n");
+		return;
+	}
+
+	k_sleep(K_SECONDS(10));
+
+	printk("[PWM] Generating pulses-Period: %d cycles, Pulse: %d cycles\n", PERIOD_HW,
+	       PULSE_HW);
+	ret = pwm_set_cycles(pwm_dev, PWM_CHANNEL, PERIOD_HW, PULSE_HW, pwm_flag);
+	if (ret != 0) {
+		printk("[PWM] Pin set cycles failed\n");
+		return;
+	}
+
+	while (1) {
+		k_sleep(K_MSEC(100));
+	}
+}


### PR DESCRIPTION
Submitting this PR for review for new PWM driver for the IP found in multiple intel PCH hardwares.
This PR includes commits for
 a) The driver code
 b) dts node for pwm
 c) a sample app ( there is no generic pwm driver sample app at the moment)

we can verify using "west build -b rpl_crb samples/drivers/pwm/"


