### PR TITLE
Bluetooth: BAP: Shell: Fix problems with codec and qos config

### DIFF
--- a/subsys/bluetooth/shell/bap.c
+++ b/subsys/bluetooth/shell/bap.c
@@ -995,14 +995,14 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 	} else if (!strcmp(argv[1], "sink")) {
 		ep = snks[index];
 
-		named_preset = default_source_preset;
+		named_preset = default_sink_preset;
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0 */
 
 #if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0
 	} else if (!strcmp(argv[1], "source")) {
 		ep = srcs[index];
 
-		named_preset = default_sink_preset;
+		named_preset = default_source_preset;
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0 */
 	} else {
 		shell_error(sh, "Unsupported dir: %s", argv[1]);
@@ -1057,6 +1057,10 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 
 				return SHELL_CMD_HELP_PRINTED;
 			}
+		} else {
+			shell_help(sh);
+
+			return SHELL_CMD_HELP_PRINTED;
 		}
 	}
 
@@ -1064,16 +1068,25 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 	memcpy(&uni_stream->qos, &named_preset->preset.qos, sizeof(uni_stream->qos));
 	memcpy(&uni_stream->codec, &named_preset->preset.codec, sizeof(uni_stream->codec));
 	/* Need to update the `bt_data.data` pointer to the new value after copying the codec */
+	/* Need to copy from the data pointer, as the preset->value is empty, as they are defined as
+	 * compound literals
+	 */
 	for (size_t i = 0U; i < ARRAY_SIZE(uni_stream->codec.data); i++) {
+		const struct bt_codec_data *preset_data = &named_preset->preset.codec.data[i];
 		struct bt_codec_data *data = &uni_stream->codec.data[i];
 
 		data->data.data = data->value;
+		data->data.data_len = preset_data->data.data_len;
+		memcpy(data->value, preset_data->data.data, preset_data->data.data_len);
 	}
 
 	for (size_t i = 0U; i < ARRAY_SIZE(uni_stream->codec.meta); i++) {
-		struct bt_codec_data *data = &uni_stream->codec.meta[i];
+		const struct bt_codec_data *preset_meta = &named_preset->preset.codec.meta[i];
+		struct bt_codec_data *meta = &uni_stream->codec.meta[i];
 
-		data->data.data = data->value;
+		meta->data.data = meta->value;
+		meta->data.data_len = preset_meta->data.data_len;
+		memcpy(meta->value, preset_meta->data.data, preset_meta->data.data_len);
 	}
 
 	/* If location has been modifed, we update the location in the codec configuration */


### PR DESCRIPTION
The copying from the presets to the stream codec and qos structs were not done in a way that worked. Fixed by doing a more proper and deeper copy.