### PR TITLE
MAINTAINERS: Correct intel bindings for ADSP

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2106,7 +2106,7 @@ Intel Platforms (Xtensa):
     - dts/xtensa/intel/
     - tests/boards/intel_adsp/
     - samples/boards/intel_adsp/
-    - dts/bindings/*/intel,*
+    - dts/bindings/*/intel,adsp*
   labels:
     - "platform: Intel ADSP"
 


### PR DESCRIPTION
At the moment all Intel drivers get label Intel ADSP. Correct to match `intel,adsp*`