### PR TITLE
cmake: Throw error if no prj.conf file is in the app config dir

### DIFF
--- a/boards/arm/mps2_an521/empty_cpu0/prj.conf
+++ b/boards/arm/mps2_an521/empty_cpu0/prj.conf
@@ -1,0 +1,1 @@
+# Empty file

--- a/cmake/modules/configuration_files.cmake
+++ b/cmake/modules/configuration_files.cmake
@@ -67,10 +67,12 @@ elseif(CACHED_CONF_FILE)
   set(CONF_FILE ${CACHED_CONF_FILE})
 elseif(EXISTS   ${APPLICATION_CONFIG_DIR}/prj_${BOARD}.conf)
   set(CONF_FILE ${APPLICATION_CONFIG_DIR}/prj_${BOARD}.conf)
-
 elseif(EXISTS   ${APPLICATION_CONFIG_DIR}/prj.conf)
   set(CONF_FILE ${APPLICATION_CONFIG_DIR}/prj.conf)
   set(CONF_FILE_INCLUDE_FRAGMENTS true)
+else()
+  message(FATAL_ERROR "No prj.conf file was found in the ${APPLICATION_CONFIG_DIR} folder, "
+                      "please read the Zephyr documentation on application development.")
 endif()
 
 if(CONF_FILE_INCLUDE_FRAGMENTS)

--- a/doc/build/kconfig/setting.rst
+++ b/doc/build/kconfig/setting.rst
@@ -165,8 +165,8 @@ The application configuration can come from the sources below. By default,
    configuration directory, the result of merging it with :file:`prj.conf` and
    :file:`boards/<BOARD>.conf` is used.
 
-6. Otherwise, :file:`prj.conf` is used if it exists in the application
-   configuration directory
+6. Otherwise, :file:`prj.conf` is used from the application configuration
+   directory. If it does not exist then a fatal error will be emitted.
 
 All configuration files will be taken from the application's configuration
 directory except for files with an absolute path that are given with the

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -357,7 +357,8 @@ Zephyr's :ref:`samples-and-demos` as a starting point is likely to be easier.
 
 #. Create at least one Kconfig fragment for your application (usually named
    :file:`prj.conf`) and set Kconfig option values needed by your application
-   there. See :ref:`application-kconfig`.
+   there. See :ref:`application-kconfig`. If no Kconfig options need to be set,
+   create an empty file.
 
 #. Configure any devicetree overlays needed by your application, usually in a
    file named :file:`app.overlay`. See :ref:`set-devicetree-overlays`.

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -217,6 +217,10 @@ Build system and infrastructure
 * Fixed an issue whereby building an application with sysbuild and specifying
   mcuboot's verification to be checksum only did not build a bootable image.
 
+* Fixed an issue whereby if no prj.conf file was present then board
+  configuration files would not be included by emitting a fatal error. As a
+  result, prj.conf files are now mandatory in projects.
+
 Drivers and Sensors
 *******************
 

--- a/samples/application_development/sysbuild/with_mcuboot/prj.conf
+++ b/samples/application_development/sysbuild/with_mcuboot/prj.conf
@@ -1,0 +1,1 @@
+# Empty file

--- a/samples/boards/arc_secure_services/prj.conf
+++ b/samples/boards/arc_secure_services/prj.conf
@@ -1,0 +1,1 @@
+# Empty file

--- a/tests/misc/test_build/prj.conf
+++ b/tests/misc/test_build/prj.conf
@@ -1,0 +1,1 @@
+# Empty file


### PR DESCRIPTION
This now throws an error if there is no prj.conf file located in a user-specified APPLICATION_CONFIG_DIR, which otherwise would have used an empty configuration and not included board-specific files.

Fixes #55842