### PR TITLE
drivers: wifi: esp32: register rxcb after wifi init

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -433,10 +433,10 @@ static void esp32_wifi_init(struct net_if *iface)
 	ethernet_init(iface);
 	net_if_carrier_off(iface);
 
-	esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, eth_esp32_rx);
-
 	wifi_init_config_t config = WIFI_INIT_CONFIG_DEFAULT();
 	esp_err_t ret = esp_wifi_init(&config);
+
+	esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, eth_esp32_rx);
 
 	ret |= esp_wifi_set_mode(ESP32_WIFI_MODE_STA);
 	ret |= esp_wifi_start();


### PR DESCRIPTION
Move `esp_wifi_internal_reg_rxcb()` after `esp_wifi_init()`, so that
`wifi_connect()` is successful.

Fixes: 690f65dbd9a0 ("drivers: wifi: esp32: fix possible interface null
  pointer")

Fixes: #55834