### PR TITLE
bluetooth: tester: Fix BTP L2CAP listen command

### DIFF
--- a/tests/bluetooth/tester/src/btp_l2cap.c
+++ b/tests/bluetooth/tester/src/btp_l2cap.c
@@ -472,6 +472,8 @@ static uint8_t listen(const void *cmd, uint16_t cmd_len,
 	server->psm = psm;
 
 	switch (cp->response) {
+	case BTP_L2CAP_CONNECTION_RESPONSE_SUCCESS:
+		break;
 	case BTP_L2CAP_CONNECTION_RESPONSE_INSUFF_ENC_KEY:
 		/* TSPX_psm_encryption_key_size_required */
 		req_keysize = 16;


### PR DESCRIPTION
Fixes regression introduced in 26cf0b68506b441ccc29b2b4eb579606ecbe7e65 "bluetooth: tester: Add support for missing BTP L2CAP listen param".

Success status was missing resulting in BTP to fail for tests that require success on connection.