### PR TITLE
soc: arm: stm32h7 soc defines the _STM32H7_SOC_H_ flag

### DIFF
--- a/soc/arm/st_stm32/stm32h7/soc.h
+++ b/soc/arm/st_stm32/stm32h7/soc.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _STM32F7_SOC_H_
-#define _STM32F7_SOC_H_
+#ifndef _STM32H7_SOC_H_
+#define _STM32H7_SOC_H_
 
 #ifndef _ASMLANGUAGE
 
@@ -13,4 +13,4 @@
 
 #endif /* !_ASMLANGUAGE */
 
-#endif /* _STM32F7_SOC_H7_ */
+#endif /* _STM32H7_SOC_H7_ */


### PR DESCRIPTION
Fix the error of the _STM32H7_SOC_H_ flag name
for the stm32h7 serie
    
Signed-off-by: Francois Ramu <francois.ramu@st.com>
