### PR TITLE
drivers: can: shell: show min/max timing parameters

### DIFF
--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -273,6 +273,8 @@ static int cmd_can_stop(const struct shell *sh, size_t argc, char **argv)
 static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev = device_get_binding(argv[1]);
+	const struct can_timing *timing_min;
+	const struct can_timing *timing_max;
 	struct can_bus_err_cnt err_cnt;
 	enum can_state state;
 	uint32_t max_bitrate = 0;
@@ -335,6 +337,30 @@ static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 	shell_print(sh, "state:           %s", can_shell_state_to_string(state));
 	shell_print(sh, "rx errors:       %d", err_cnt.rx_err_cnt);
 	shell_print(sh, "tx errors:       %d", err_cnt.tx_err_cnt);
+
+	timing_min = can_get_timing_min(dev);
+	timing_max = can_get_timing_max(dev);
+
+	shell_print(sh, "timing:          sjw %u..%u, prop_seg %u..%u, "
+		    "phase_seg1 %u..%u, phase_seg2 %u..%u, prescaler %u..%u",
+		    timing_min->sjw, timing_max->sjw,
+		    timing_min->prop_seg, timing_max->prop_seg,
+		    timing_min->phase_seg1, timing_max->phase_seg1,
+		    timing_min->phase_seg2, timing_max->phase_seg2,
+		    timing_min->prescaler, timing_max->prescaler);
+
+	if (IS_ENABLED(CONFIG_CAN_FD_MODE) && (cap & CAN_MODE_FD) != 0) {
+		timing_min = can_get_timing_data_min(dev);
+		timing_max = can_get_timing_data_max(dev);
+
+		shell_print(sh, "timing data:     sjw %u..%u, prop_seg %u..%u, "
+			    "phase_seg1 %u..%u, phase_seg2 %u..%u, prescaler %u..%u",
+			    timing_min->sjw, timing_max->sjw,
+			    timing_min->prop_seg, timing_max->prop_seg,
+			    timing_min->phase_seg1, timing_max->phase_seg1,
+			    timing_min->phase_seg2, timing_max->phase_seg2,
+			    timing_min->prescaler, timing_max->prescaler);
+	}
 
 	return 0;
 }

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -421,6 +421,10 @@ static int cmd_can_bitrate_set(const struct shell *sh, size_t argc, char **argv)
 				    timing.sjw);
 		}
 
+		LOG_DBG("sjw %u, prop_seg %u, phase_seg1 %u, phase_seg2 %u, prescaler %u",
+			timing.sjw, timing.prop_seg, timing.phase_seg1, timing.phase_seg2,
+			timing.prescaler);
+
 		err = can_set_timing(dev, &timing);
 		if (err != 0) {
 			shell_error(sh, "failed to set timing (err %d)", err);
@@ -494,6 +498,10 @@ static int cmd_can_dbitrate_set(const struct shell *sh, size_t argc, char **argv
 				    bitrate, sample_pnt / 10, sample_pnt % 10, err / 10, err % 10,
 				    timing.sjw);
 		}
+
+		LOG_DBG("sjw %u, prop_seg %u, phase_seg1 %u, phase_seg2 %u, prescaler %u",
+			timing.sjw, timing.prop_seg, timing.phase_seg1, timing.phase_seg2,
+			timing.prescaler);
 
 		err = can_set_timing_data(dev, &timing);
 		if (err != 0) {


### PR DESCRIPTION
Include the minimum/maximum timing parameters when showing details about a CAN controller. Add debug logs for the timing parameters calculated by the shell commands.