### PR TITLE
BAP unicast client released fix

### DIFF
--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -97,6 +97,8 @@ static int unicast_client_ep_set_codec(struct bt_bap_ep *ep, uint8_t id, uint16_
 static int unicast_client_ep_start(struct bt_bap_ep *ep,
 				   struct net_buf_simple *buf);
 
+static void unicast_client_reset(struct bt_bap_ep *ep);
+
 static int unicast_client_send_start(struct bt_bap_ep *ep)
 {
 	if (ep->receiver_ready != true || ep->dir != BT_AUDIO_DIR_SOURCE) {
@@ -133,7 +135,7 @@ static int unicast_client_send_start(struct bt_bap_ep *ep)
 	return 0;
 }
 
-static void unicast_client_ep_idle_state(struct bt_bap_ep *ep);
+static int unicast_client_ep_idle_state(struct bt_bap_ep *ep);
 
 /** Checks if the stream can terminate the CIS
  *
@@ -349,7 +351,21 @@ static void unicast_client_ep_iso_disconnected(struct bt_bap_ep *ep, uint8_t rea
 	 * the ISO has finalized the disconnection
 	 */
 	if (ep->status.state == BT_BAP_EP_STATE_IDLE) {
-		unicast_client_ep_idle_state(ep);
+
+		(void)unicast_client_ep_idle_state(ep);
+
+		if (stream->conn != NULL) {
+			struct bt_conn_info conn_info;
+			int err;
+
+			err = bt_conn_get_info(stream->conn, &conn_info);
+			if (err != 0 || conn_info.state == BT_CONN_STATE_DISCONNECTED) {
+				/* Retrigger the reset of the EP if the ACL is disconnected before
+				 * the ISO is disconnected
+				 */
+				unicast_client_reset(ep);
+			}
+		}
 	} else {
 		if (stream->ops != NULL && stream->ops->stopped != NULL) {
 			stream->ops->stopped(stream, reason);
@@ -515,7 +531,7 @@ static struct bt_bap_ep *unicast_client_ep_get(struct bt_conn *conn, enum bt_aud
 	return unicast_client_ep_new(conn, dir, handle);
 }
 
-static void unicast_client_ep_idle_state(struct bt_bap_ep *ep)
+static int unicast_client_ep_idle_state(struct bt_bap_ep *ep)
 {
 	struct bt_bap_unicast_client_ep *client_ep =
 		CONTAINER_OF(ep, struct bt_bap_unicast_client_ep, ep);
@@ -523,21 +539,24 @@ static void unicast_client_ep_idle_state(struct bt_bap_ep *ep)
 	const struct bt_bap_stream_ops *ops;
 
 	if (stream == NULL) {
-		return;
+		return -EINVAL;
 	}
 
 	/* If CIS is connected, disconnect and wait for CIS disconnection */
 	if (unicast_client_can_disconnect_stream(stream)) {
-		const int err = bt_bap_stream_disconnect(stream);
+		int err;
+
+		LOG_DBG("Disconnecting stream");
+		err = bt_bap_stream_disconnect(stream);
 
 		if (err != 0) {
 			LOG_ERR("Failed to disconnect stream: %d", err);
-		} else {
-			return;
 		}
+
+		return err;
 	} else if (ep->iso != NULL && ep->iso->chan.state == BT_ISO_STATE_DISCONNECTING) {
 		/* Wait */
-		return;
+		return -EBUSY;
 	}
 
 	bt_bap_stream_reset(stream);
@@ -562,6 +581,8 @@ static void unicast_client_ep_idle_state(struct bt_bap_ep *ep)
 	} else {
 		LOG_WRN("No callback for released set");
 	}
+
+	return 0;
 }
 
 static void unicast_client_ep_qos_update(struct bt_bap_ep *ep,
@@ -912,7 +933,7 @@ static void unicast_client_ep_set_status(struct bt_bap_ep *ep, struct net_buf_si
 
 	switch (status->state) {
 	case BT_BAP_EP_STATE_IDLE:
-		unicast_client_ep_idle_state(ep);
+		(void)unicast_client_ep_idle_state(ep);
 		break;
 	case BT_BAP_EP_STATE_CODEC_CONFIGURED:
 		switch (old_state) {
@@ -1753,23 +1774,21 @@ static void unicast_client_reset(struct bt_bap_ep *ep)
 {
 	struct bt_bap_unicast_client_ep *client_ep =
 		CONTAINER_OF(ep, struct bt_bap_unicast_client_ep, ep);
-	struct bt_bap_stream *stream = ep->stream;
+	int err;
 
 	LOG_DBG("ep %p", ep);
 
-	if (stream != NULL && ep->status.state != BT_BAP_EP_STATE_IDLE) {
-		const struct bt_bap_stream_ops *ops;
+	/* Pretend we received an idle state notification from the server to trigger all cleanup */
+	ep->status.state = BT_BAP_EP_STATE_IDLE;
+	err = unicast_client_ep_idle_state(ep);
+	if (err != 0) {
+		LOG_DBG("unicast_client_ep_idle_state returned %d", err);
 
-		/* Notify upper layer */
-		ops = stream->ops;
-		if (ops != NULL && ops->released != NULL) {
-			ops->released(stream);
-		} else {
-			LOG_WRN("No callback for released set");
+		if (err == -EBUSY) {
+			/* Wait for ISO disconnected event */
+			return;
 		}
 	}
-
-	bt_bap_stream_reset(stream);
 
 	(void)memset(ep, 0, sizeof(*ep));
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -886,6 +886,8 @@ int bt_iso_chan_get_tx_sync(const struct bt_iso_chan *chan, struct bt_iso_tx_inf
 #if defined(CONFIG_BT_ISO_UNICAST)
 int bt_iso_chan_disconnect(struct bt_iso_chan *chan)
 {
+	int err;
+
 	CHECKIF(!chan) {
 		LOG_DBG("Invalid parameter: chan %p", chan);
 		return -EINVAL;
@@ -920,7 +922,12 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan)
 		return -EALREADY;
 	}
 
-	return bt_conn_disconnect(chan->iso, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	err = bt_conn_disconnect(chan->iso, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	if (err == 0) {
+		bt_iso_chan_set_state(chan, BT_ISO_STATE_DISCONNECTING);
+	}
+
+	return err;
 }
 
 void bt_iso_cleanup_acl(struct bt_conn *iso)


### PR DESCRIPTION
Fixes an issue in the unicast client partially caused by a bug in ISO and bad handling the BAP unicast client implementation. 