### PR TITLE
nrf52_bsim: Add options to synchronize to the Phy before booting

### DIFF
--- a/boards/posix/nrf52_bsim/argparse.c
+++ b/boards/posix/nrf52_bsim/argparse.c
@@ -63,6 +63,16 @@ static void cmd_no_delay_init_found(char *argv, int offset)
 	arg.delay_init = false;
 }
 
+static void cmd_no_sync_preinit_found(char *argv, int offset)
+{
+	arg.sync_preinit = false;
+}
+
+static void cmd_no_sync_preboot_found(char *argv, int offset)
+{
+	arg.sync_preboot = false;
+}
+
 static void save_test_arg(struct NRF_bsim_args_t *args, char *argv)
 {
 	if (args->test_case_argc >= MAXPARAMS_TESTCASES) {
@@ -115,6 +125,29 @@ void nrfbsim_register_args(void)
 		"nosim", "", 'b',
 		(void *)&nosim, cmd_nosim_found,
 		"(debug feature) Do not connect to the phy"},
+		{ false, false, true,
+		"sync_preinit", "", 'b',
+		(void *)&arg.sync_preinit, NULL,
+		"Postpone pre-initialization and boot "
+		"until the phy has reached time 0 (or start_offset) (by default not set)"
+		},
+		{ false, false, true,
+		"no_sync_preinit", "", 'b',
+		NULL, cmd_no_sync_preinit_found,
+		"Clear sync_preinit. Note that by default sync_preinit is not set"
+		},
+		{ false, false, true,
+		"sync_preboot", "", 'b',
+		(void *)&arg.sync_preboot, NULL,
+		"Postpone CPU boot "
+		"until the phy has reached time 0 (or start_offset) (by default not set)"
+		"If sync_preinit is set, this option has no effect."
+		},
+		{ false, false, true,
+		"no_sync_preboot", "", 'b',
+		NULL, cmd_no_sync_preboot_found,
+		"Clear sync_preboot. Note that by default sync_preboot is not set"
+		},
 		{ false, false, true,
 		"delay_init", "", 'b',
 		(void *)&arg.delay_init, NULL,

--- a/boards/posix/nrf52_bsim/argparse.h
+++ b/boards/posix/nrf52_bsim/argparse.h
@@ -22,6 +22,8 @@ struct NRF_bsim_args_t {
 	char *test_case_argv[MAXPARAMS_TESTCASES];
 	int test_case_argc;
 	bool delay_init;
+	bool sync_preinit;
+	bool sync_preboot;
 	nrf_hw_sub_args_t nrf_hw;
 };
 

--- a/boards/posix/nrf52_bsim/main.c
+++ b/boards/posix/nrf52_bsim/main.c
@@ -95,11 +95,13 @@ int main(int argc, char *argv[])
 	/* We pass to a possible testcase its command line arguments */
 	bst_pass_args(args->test_case_argc, args->test_case_argv);
 
-	if ((args->nrf_hw.start_offset > 0) && (args->delay_init)) {
+	if (((args->nrf_hw.start_offset > 0) && (args->delay_init))
+	    || args->sync_preinit) {
 		/* Delay the next steps until the simulation time has
-		 * reached start_offset
+		 * reached either time 0 or start_offset.
 		 */
-		hwll_wait_for_phy_simu_time(args->nrf_hw.start_offset);
+		hwll_wait_for_phy_simu_time(BS_MAX(args->nrf_hw.start_offset, 0));
+		args->sync_preboot = false; /* Already sync'ed */
 	}
 
 	nrf_hw_initialize(&args->nrf_hw);
@@ -107,6 +109,10 @@ int main(int argc, char *argv[])
 	run_native_tasks(_NATIVE_PRE_BOOT_3_LEVEL);
 
 	bst_pre_init();
+
+	if (args->sync_preboot) {
+		hwll_wait_for_phy_simu_time(BS_MAX(args->nrf_hw.start_offset, 0));
+	}
 
 	posix_boot_cpu();
 


### PR DESCRIPTION
Some testcases may benefit from having options to synchronize to the Phy either before running the test pre-initialization and/or before booting the CPU.
Provide these options.

Background: Before synchronizing to the Phy devices execute ahead asynchronously. This is not a problem in most cases, as normally the only interaction between devices happens thru the radio, and as soon as any radio interaction occurs, the devices are step-locked by the Phy.
But some devices do share information in other ways inbetween them, like for example using the backchannels. These may benefit from using these options.