### PR TITLE
libc: add option for optimised string/memory ops

### DIFF
--- a/lib/libc/minimal/CMakeLists.txt
+++ b/lib/libc/minimal/CMakeLists.txt
@@ -21,7 +21,6 @@ zephyr_library_sources(
   source/string/strerror.c
   source/string/strncasecmp.c
   source/string/strstr.c
-  source/string/string.c
   source/string/strspn.c
   source/stdout/stdout_console.c
   source/stdout/sprintf.c
@@ -30,6 +29,29 @@ zephyr_library_sources(
   source/math/sqrt.c
   ${STRERROR_TABLE_H}
 )
+
+if (CONFIG_CYGWIN_STRING_FUNCS)
+  zephyr_library_sources(
+    newlib-cygwin/strnlen.c
+    newlib-cygwin/strlen.c
+    newlib-cygwin/strcpy.c
+    newlib-cygwin/strncpy.c
+    newlib-cygwin/strchr.c
+    newlib-cygwin/strrchr.c
+    newlib-cygwin/strncmp.c
+    newlib-cygwin/strtok_r.c
+    newlib-cygwin/strcat.c
+    newlib-cygwin/memcmp.c
+    newlib-cygwin/memchr.c
+    newlib-cygwin/memcpy.c
+    newlib-cygwin/memcpy-asm.S
+    newlib-cygwin/memmove.S
+    newlib-cygwin/memset.S
+    newlib-cygwin/strcmp.S
+  )
+else()
+  zephyr_library_sources(source/string/string.c)
+endif()
 
 if(CONFIG_MINIMAL_LIBC_TIME)
   zephyr_library_sources(source/time/gmtime.c)

--- a/lib/libc/minimal/Kconfig
+++ b/lib/libc/minimal/Kconfig
@@ -87,4 +87,15 @@ config MINIMAL_LIBC_STRING_ERROR_TABLE
 	  symbols are still present, but the functions produce an empty
 	  string.
 
+config CYGWIN_STRING_FUNCS
+	bool "Replace default memory operations to Cywgin based"
+	default n
+	depends on RISCV
+	help
+	  Select this option to use alternative string/memory manipulation
+	  functions. These are sourced from Cygwin.
+
+	  This new set of functions are tailored for RISCV, some in C and
+	  some in assembly.
+
 endif # MINIMAL_LIBC

--- a/lib/libc/minimal/newlib-cygwin/LICENSE
+++ b/lib/libc/minimal/newlib-cygwin/LICENSE
@@ -1,0 +1,10 @@
+Copyright(c) 2017 SiFive Inc.All rights reserved.
+
+	This copyrighted material is made available to anyone wishing to use,
+	modify, copy,
+	or redistribute it subject to the terms and conditions of the FreeBSD License
+			.This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY expressed or implied,
+	including the implied warranties of MERCHANTABILITY
+		or FITNESS FOR A PARTICULAR PURPOSE.A copy of this license is available at http
+	: // www.opensource.org/licenses.

--- a/lib/libc/minimal/newlib-cygwin/asm.h
+++ b/lib/libc/minimal/newlib-cygwin/asm.h
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ * Copyright (c) 2017  SiFive Inc. All rights reserved.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the FreeBSD License.   This program is distributed in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY expressed or implied,
+ * including the implied warranties of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  A copy of this license is available at
+ * http://www.opensource.org/licenses.
+ */
+
+#ifndef _SYS_ASM_H
+#define _SYS_ASM_H
+
+/**
+ * Macros to handle different pointer/register sizes for 32/64-bit code
+ */
+#if __riscv_xlen == 64
+#define PTRLOG 3
+#define SZREG  8
+#define REG_S  sd
+#define REG_L  ld
+#elif __riscv_xlen == 32
+#define PTRLOG 2
+#define SZREG  4
+#define REG_S  sw
+#define REG_L  lw
+#else
+#error __riscv_xlen must equal 32 or 64
+#endif
+
+#ifndef __riscv_float_abi_soft
+/** For ABI uniformity, reserve 8 bytes for floats, even if double-precision
+ * floating-point is not supported in hardware.
+ */
+#define SZFREG 8
+#ifdef __riscv_float_abi_single
+#define FREG_L flw
+#define FREG_S fsw
+#elif defined(__riscv_float_abi_double)
+#define FREG_L fld
+#define FREG_S fsd
+#elif defined(__riscv_float_abi_quad)
+#define FREG_L flq
+#define FREG_S fsq
+#else
+#error unsupported FLEN
+#endif
+#endif
+
+#endif /* sys/asm.h */

--- a/lib/libc/minimal/newlib-cygwin/memchr.c
+++ b/lib/libc/minimal/newlib-cygwin/memchr.c
@@ -1,0 +1,131 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * FUNCTION
+ * <<memchr>>---find character in memory
+ *
+ * INDEX
+ * memchr
+ *
+ * SYNOPSIS
+ * #include <string.h>
+ * void *memchr(const void *<[src]>, int <[c]>, size_t <[length]>);
+ *
+ * DESCRIPTION
+ * This function searches memory starting at <<*<[src]>>> for the
+ * character <[c]>.  The search only ends with the first
+ * occurrence of <[c]>, or after <[length]> characters; in
+ * particular, <<NUL>> does not terminate the search.
+ *
+ * RETURNS
+ * If the character <[c]> is found within <[length]> characters
+ * of <<*<[src]>>>, a pointer to the character is returned. If
+ * <[c]> is not found, then <<NULL>> is returned.
+ *
+ * PORTABILITY
+ * <<memchr>> is ANSI C.
+ *
+ * <<memchr>> requires no supporting OS subroutines.
+ *
+ * QUICKREF
+ * memchr ansi pure
+ */
+
+#include <string.h>
+#include <limits.h>
+
+/** Nonzero if either X or Y is not aligned on a "long" boundary.  */
+#define UNALIGNED(X) ((long)X & (sizeof(long) - 1))
+
+/** How many bytes are loaded each iteration of the word copy loop.  */
+#define LBLOCKSIZE (sizeof(long))
+
+/** Threshold for punting to the bytewise iterator.  */
+#define TOO_SMALL(LEN) ((LEN) < LBLOCKSIZE)
+
+#if LONG_MAX == 2147483647L
+#define DETECTNULL(X) (((X)-0x01010101) & ~(X)&0x80808080)
+#else
+#if LONG_MAX == 9223372036854775807L
+/** Nonzero if X (a long int) contains a NULL byte. */
+#define DETECTNULL(X) (((X)-0x0101010101010101) & ~(X)&0x8080808080808080)
+#else
+#error long int is not a 32bit or 64bit type.
+#endif
+#endif
+
+#ifndef DETECTNULL
+#error long int is not a 32bit or 64bit byte
+#endif
+
+/**
+ * DETECTCHAR returns nonzero if (long)X contains the byte used
+ * to fill (long)MASK.
+ */
+#define DETECTCHAR(X, MASK) (DETECTNULL(X ^ MASK))
+
+void *memchr(const void *src_void, int c, size_t length)
+{
+	const unsigned char *src = (const unsigned char *)src_void;
+	unsigned char d = c;
+
+#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+	unsigned long *asrc;
+	unsigned long mask;
+	unsigned int i;
+
+	while (UNALIGNED(src)) {
+		if (!length--) {
+			return NULL;
+		}
+		if (*src == d) {
+			return (void *)src;
+		}
+		src++;
+	}
+
+	if (!TOO_SMALL(length)) {
+		/**
+		 * If we get this far, we know that length is large and src is
+		 * word-aligned.
+		 */
+		/**
+		 * The fast code reads the source one word at a time and only
+		 * performs the bytewise search on word-sized segments if they
+		 * contain the search character, which is detected by XORing
+		 * the word-sized segment with a word-sized block of the search
+		 * character and then detecting for the presence of NUL in the
+		 * result.
+		 */
+		asrc = (unsigned long *)src;
+		mask = d << 8 | d;
+		mask = mask << 16 | mask;
+		for (i = 32; i < LBLOCKSIZE * 8; i <<= 1) {
+			mask = (mask << i) | mask;
+		}
+
+		while (length >= LBLOCKSIZE) {
+			if (DETECTCHAR(*asrc, mask)) {
+				break;
+			}
+			length -= LBLOCKSIZE;
+			asrc++;
+		}
+
+		/**
+		 * If there are fewer than LBLOCKSIZE characters left,
+		 * then we resort to the bytewise loop.
+		 */
+		src = (unsigned char *)asrc;
+	}
+
+#endif /* not PREFER_SIZE_OVER_SPEED */
+
+	while (length--) {
+		if (*src == d) {
+			return (void *)src;
+		}
+		src++;
+	}
+
+	return NULL;
+}

--- a/lib/libc/minimal/newlib-cygwin/memcmp.c
+++ b/lib/libc/minimal/newlib-cygwin/memcmp.c
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * FUNCTION
+ * <<memcmp>>---compare two memory areas
+ *
+ * INDEX
+ * memcmp
+ *
+ * SYNOPSIS
+ * #include <string.h>
+ * int memcmp(const void *<[s1]>, const void *<[s2]>, size_t <[n]>);
+ *
+ * DESCRIPTION
+ * This function compares not more than <[n]> characters of the
+ * object pointed to by <[s1]> with the object pointed to by <[s2]>.
+ *
+ * RETURNS
+ * The function returns an integer greater than, equal to or
+ * less than zero	according to whether the object pointed to by
+ * <[s1]> is greater than, equal to or less than the object
+ * pointed to by <[s2]>.
+ *
+ * PORTABILITY
+ * <<memcmp>> is ANSI C.
+ *
+ * <<memcmp>> requires no supporting OS subroutines.
+ *
+ * QUICKREF
+ * memcmp ansi pure
+ */
+
+#include <string.h>
+
+/** Nonzero if either X or Y is not aligned on a "long" boundary. */
+#define UNALIGNED(X, Y) (((long)X & (sizeof(long) - 1)) | ((long)Y & (sizeof(long) - 1)))
+
+/** How many bytes are copied each iteration of the word copy loop. */
+#define LBLOCKSIZE (sizeof(long))
+
+/** Threshold for punting to the byte copier. */
+#define TOO_SMALL(LEN) ((LEN) < LBLOCKSIZE)
+
+int memcmp(const void *m1, const void *m2, size_t n)
+{
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+	unsigned char *s1 = (unsigned char *)m1;
+	unsigned char *s2 = (unsigned char *)m2;
+
+	while (n--) {
+		if (*s1 != *s2) {
+			return *s1 - *s2;
+		}
+
+		s1++;
+		s2++;
+	}
+
+	return 0;
+#else
+	unsigned char *s1 = (unsigned char *)m1;
+	unsigned char *s2 = (unsigned char *)m2;
+	unsigned long *a1;
+	unsigned long *a2;
+
+	/**
+	 * If the size is too small, or either pointer is unaligned,
+	 * then we punt to the byte compare loop.  Hopefully this will
+	 * not turn up in inner loops.
+	 */
+	if (!TOO_SMALL(n) && !UNALIGNED(s1, s2)) {
+		/**
+		 * Otherwise, load and compare the blocks of memory one
+		 * word at a time.
+		 */
+		a1 = (unsigned long *)s1;
+		a2 = (unsigned long *)s2;
+		while (n >= LBLOCKSIZE) {
+			if (*a1 != *a2) {
+				break;
+			}
+			a1++;
+			a2++;
+			n -= LBLOCKSIZE;
+		}
+
+		/** check m mod LBLOCKSIZE remaining characters */
+
+		s1 = (unsigned char *)a1;
+		s2 = (unsigned char *)a2;
+	}
+
+	while (n--) {
+		if (*s1 != *s2) {
+			return *s1 - *s2;
+		}
+		s1++;
+		s2++;
+	}
+
+	return 0;
+#endif /* not PREFER_SIZE_OVER_SPEED */
+}

--- a/lib/libc/minimal/newlib-cygwin/memcpy-asm.S
+++ b/lib/libc/minimal/newlib-cygwin/memcpy-asm.S
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ * Copyright (c) 2019  SiFive Inc. All rights reserved.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the FreeBSD License.   This program is distributed in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY expressed or implied,
+ * including the implied warranties of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  A copy of this license is available at
+ * http://www.opensource.org/licenses.
+ */
+
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+.text
+.global memcpy
+.type	memcpy, @function
+memcpy:
+  mv t1, a0
+  beqz a2, 2f
+
+1:
+  lb t2, 0(a1)
+  sb t2, 0(t1)
+  add   a2, a2, -1
+  add   t1, t1, 1
+  add   a1, a1, 1
+  bnez a2, 1b
+
+2:
+  ret
+
+  .size	memcpy, .-memcpy
+#endif

--- a/lib/libc/minimal/newlib-cygwin/memcpy.c
+++ b/lib/libc/minimal/newlib-cygwin/memcpy.c
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ * Copyright (c) 2017  SiFive Inc. All rights reserved.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the FreeBSD License.   This program is distributed in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY expressed or implied,
+ * including the implied warranties of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  A copy of this license is available at
+ * http://www.opensource.org/licenses.
+ */
+
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+/* memcpy defined in memcpy-asm.S */
+#else
+
+#include <string.h>
+#include <stdint.h>
+
+void *memcpy(void *__restrict aa, const void *__restrict bb, size_t n)
+{
+#define BODY(a, b, t)                                                                              \
+	{                                                                                          \
+		t tt = *b;                                                                         \
+		a++, b++;                                                                          \
+		*(a - 1) = tt;                                                                     \
+	}
+
+	char *a = (char *)aa;
+	const char *b = (const char *)bb;
+	char *end = a + n;
+	uintptr_t msk = sizeof(long) - 1;
+
+	if (unlikely((((uintptr_t)a & msk) != ((uintptr_t)b & msk)) || n < sizeof(long))) {
+	small:
+		if (__builtin_expect(a < end, 1)) {
+			while (a < end) {
+				BODY(a, b, char);
+			}
+		}
+		return aa;
+	}
+
+	if (unlikely(((uintptr_t)a & msk) != 0)) {
+		while ((uintptr_t)a & msk) {
+			BODY(a, b, char);
+		}
+	}
+
+	long *la = (long *)a;
+	const long *lb = (const long *)b;
+	long *lend = (long *)((uintptr_t)end & ~msk);
+
+	if (unlikely(lend - la > 8)) {
+		while (lend - la > 8) {
+			long b0 = *lb++;
+			long b1 = *lb++;
+			long b2 = *lb++;
+			long b3 = *lb++;
+			long b4 = *lb++;
+			long b5 = *lb++;
+			long b6 = *lb++;
+			long b7 = *lb++;
+			long b8 = *lb++;
+
+			*la++ = b0;
+			*la++ = b1;
+			*la++ = b2;
+			*la++ = b3;
+			*la++ = b4;
+			*la++ = b5;
+			*la++ = b6;
+			*la++ = b7;
+			*la++ = b8;
+		}
+	}
+
+	while (la < lend) {
+		BODY(la, lb, long);
+	}
+
+	a = (char *)la;
+	b = (const char *)lb;
+	if (unlikely(a < end)) {
+		goto small;
+	}
+	return aa;
+}
+#endif

--- a/lib/libc/minimal/newlib-cygwin/memmove.S
+++ b/lib/libc/minimal/newlib-cygwin/memmove.S
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ * Copyright (c) 2019  SiFive Inc. All rights reserved.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the FreeBSD License.   This program is distributed in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY expressed or implied,
+ * including the implied warranties of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  A copy of this license is available at
+ * http://www.opensource.org/licenses.
+ */
+
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+.text
+.global memmove
+.type	memmove, @function
+memmove:
+  beqz a2, 2f
+
+  mv t1, a0
+  li a3, 1
+  bgtu  a1, a0, 1f
+
+  li a3, -1
+  addi  a4, a2 , -1
+  add t1, t1, a4
+  add a1, a1, a4
+
+1:
+  lb t2, 0(a1)
+  sb t2, 0(t1)
+  add   a2, a2, -1
+  add   t1, t1, a3
+  add   a1, a1, a3
+  bnez a2, 1b
+
+2:
+  ret
+
+  .size	memmove, .-memmove
+#endif

--- a/lib/libc/minimal/newlib-cygwin/memset.S
+++ b/lib/libc/minimal/newlib-cygwin/memset.S
@@ -1,0 +1,113 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ * Copyright (c) 2017  SiFive Inc. All rights reserved.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the FreeBSD License.   This program is distributed in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY expressed or implied,
+ * including the implied warranties of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  A copy of this license is available at
+ * http://www.opensource.org/licenses.
+ */
+
+.text
+.global memset
+.type	memset, @function
+memset:
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+  mv t1, a0
+  beqz a2, 2f
+
+1:
+  sb a1, 0(t1)
+  add   a2, a2, -1
+  add   t1, t1, 1
+  bnez a2, 1b
+
+2:
+  ret
+#else
+  li t1, 15
+  move a4, a0
+  bleu a2, t1, .Ltiny
+  and a5, a4, 15
+  bnez a5, .Lmisaligned
+
+.Laligned:
+  bnez a1, .Lwordify
+
+.Lwordified:
+  and a3, a2, ~15
+  and a2, a2, 15
+  add a3, a3, a4
+
+#if __riscv_xlen == 64
+1:sd a1, 0(a4)
+  sd a1, 8(a4)
+#else
+1:sw a1, 0(a4)
+  sw a1, 4(a4)
+  sw a1, 8(a4)
+  sw a1, 12(a4)
+#endif
+  add a4, a4, 16
+  bltu a4, a3, 1b
+
+  bnez a2, .Ltiny
+  ret
+
+.Ltiny:
+  sub a3, t1, a2
+  sll a3, a3, 2
+1:auipc t0, %pcrel_hi(.Ltable)
+  add a3, a3, t0
+.option push
+.option norvc
+.Ltable_misaligned:
+  jr a3, %pcrel_lo(1b)
+.Ltable:
+  sb a1,14(a4)
+  sb a1,13(a4)
+  sb a1,12(a4)
+  sb a1,11(a4)
+  sb a1,10(a4)
+  sb a1, 9(a4)
+  sb a1, 8(a4)
+  sb a1, 7(a4)
+  sb a1, 6(a4)
+  sb a1, 5(a4)
+  sb a1, 4(a4)
+  sb a1, 3(a4)
+  sb a1, 2(a4)
+  sb a1, 1(a4)
+  sb a1, 0(a4)
+.option pop
+  ret
+
+.Lwordify:
+  and a1, a1, 0xFF
+  sll a3, a1, 8
+  or  a1, a1, a3
+  sll a3, a1, 16
+  or  a1, a1, a3
+#if __riscv_xlen == 64
+  sll a3, a1, 32
+  or  a1, a1, a3
+#endif
+  j .Lwordified
+
+.Lmisaligned:
+  sll a3, a5, 2
+1:auipc t0, %pcrel_hi(.Ltable_misaligned)
+  add a3, a3, t0
+  mv t0, ra
+  jalr a3, %pcrel_lo(1b)
+  mv ra, t0
+
+  add a5, a5, -16
+  sub a4, a4, a5
+  add a2, a2, a5
+  bleu a2, t1, .Ltiny
+  j .Laligned
+#endif
+  .size	memset, .-memset

--- a/lib/libc/minimal/newlib-cygwin/strcat.c
+++ b/lib/libc/minimal/newlib-cygwin/strcat.c
@@ -1,0 +1,99 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * FUNCTION
+ * <<strcat>>---concatenate strings
+ *
+ * INDEX
+ * strcat
+ *
+ * SYNOPSIS
+ * #include <string.h>
+ * char *strcat(char *restrict <[dst]>, const char *restrict <[src]>);
+ *
+ * DESCRIPTION
+ * <<strcat>> appends a copy of the string pointed to by <[src]>
+ * (including the terminating null character) to the end of the
+ * string pointed to by <[dst]>.  The initial character of
+ * <[src]> overwrites the null character at the end of <[dst]>.
+ *
+ * RETURNS
+ * This function returns the initial value of <[dst]>
+ *
+ * PORTABILITY
+ * <<strcat>> is ANSI C.
+ *
+ * <<strcat>> requires no supporting OS subroutines.
+ *
+ * QUICKREF
+ * strcat ansi pure
+ */
+
+#include <string.h>
+#include <limits.h>
+
+/** Nonzero if X is aligned on a "long" boundary.  */
+#define ALIGNED(X) (((long)X & (sizeof(long) - 1)) == 0)
+
+#if LONG_MAX == 2147483647L
+#define DETECTNULL(X) (((X)-0x01010101) & ~(X)&0x80808080)
+#else
+#if LONG_MAX == 9223372036854775807L
+/** Nonzero if X (a long int) contains a NULL byte. */
+#define DETECTNULL(X) (((X)-0x0101010101010101) & ~(X)&0x8080808080808080)
+#else
+#error long int is not a 32bit or 64bit type.
+#endif
+#endif
+
+#ifndef DETECTNULL
+#error long int is not a 32bit or 64bit byte
+#endif
+
+/**SUPPRESS 560*/
+/**SUPPRESS 530*/
+
+char *strcat(char *__restrict s1, const char *__restrict s2)
+{
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+	char *s = s1;
+
+	while (*s1) {
+		s1++;
+	}
+
+	while ((*s1++ = *s2++)) {
+		;
+	}
+	return s;
+#else
+	char *s = s1;
+
+	/** Skip over the data in s1 as quickly as possible.  */
+	if (ALIGNED(s1)) {
+		unsigned long *aligned_s1 = (unsigned long *)s1;
+
+		while (!DETECTNULL(*aligned_s1)) {
+			aligned_s1++;
+		}
+
+		s1 = (char *)aligned_s1;
+	}
+
+	while (*s1) {
+		s1++;
+	}
+
+	/**
+	 * s1 now points to the its trailing null character, we can
+	 * just use strcpy to do the work for us now.
+	 *
+	 * ?!? We might want to just include strcpy here.
+	 * Also, this will cause many more unaligned string copies because
+	 * s1 is much less likely to be aligned.  I don't know if its worth
+	 * tweaking strcpy to handle this better.
+	 */
+	strcpy(s1, s2);
+
+	return s;
+#endif /* not PREFER_SIZE_OVER_SPEED */
+}

--- a/lib/libc/minimal/newlib-cygwin/strchr.c
+++ b/lib/libc/minimal/newlib-cygwin/strchr.c
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * FUNCTION
+ *	<<strchr>>---search for character in string
+ *
+ * INDEX
+ *	strchr
+ *
+ * SYNOPSIS
+ *	#include <string.h>
+ *	char * strchr(const char *<[string]>, int <[c]>);
+ *
+ * DESCRIPTION
+ *	This function finds the first occurrence of <[c]> (converted to
+ *	a char) in the string pointed to by <[string]> (including the
+ *	terminating null character).
+ *
+ * RETURNS
+ *	Returns a pointer to the located character, or a null pointer
+ *	if <[c]> does not occur in <[string]>.
+ *
+ * PORTABILITY
+ * <<strchr>> is ANSI C.
+ *
+ * <<strchr>> requires no supporting OS subroutines.
+ *
+ * QUICKREF
+ *	strchr ansi pure
+ */
+
+#include <string.h>
+#include <limits.h>
+
+/** Nonzero if X is not aligned on a "long" boundary.  */
+#define UNALIGNED(X) ((long)X & (sizeof(long) - 1))
+
+/** How many bytes are loaded each iteration of the word copy loop.  */
+#define LBLOCKSIZE (sizeof(long))
+
+#if LONG_MAX == 2147483647L
+#define DETECTNULL(X) (((X)-0x01010101) & ~(X)&0x80808080)
+#else
+#if LONG_MAX == 9223372036854775807L
+/** Nonzero if X (a long int) contains a NULL byte. */
+#define DETECTNULL(X) (((X)-0x0101010101010101) & ~(X)&0x8080808080808080)
+#else
+#error long int is not a 32bit or 64bit type.
+#endif
+#endif
+
+/**
+ * DETECTCHAR returns nonzero if (long)X contains the byte used
+ * to fill (long)MASK.
+ */
+#define DETECTCHAR(X, MASK) (DETECTNULL(X ^ MASK))
+
+char *strchr(const char *s1, int i)
+{
+	const unsigned char *s = (const unsigned char *)s1;
+	unsigned char c = i;
+
+#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+	unsigned long *aligned_addr;
+	unsigned long mask, j;
+
+	/** Special case for finding 0.  */
+	if (!c) {
+		while (UNALIGNED(s)) {
+			if (!*s) {
+				return (char *)s;
+			}
+			s++;
+		}
+		/** Operate a word at a time.  */
+		aligned_addr = (unsigned long *)s;
+		while (!DETECTNULL(*aligned_addr)) {
+			aligned_addr++;
+		}
+		/** Found the end of string.  */
+		s = (const unsigned char *)aligned_addr;
+		while (*s) {
+			s++;
+		}
+		return (char *)s;
+	}
+
+	/** All other bytes. Align the pointer, then search a long at a time.  */
+	while (UNALIGNED(s)) {
+		if (!*s) {
+			return NULL;
+		}
+		if (*s == c) {
+			return (char *)s;
+		}
+		s++;
+	}
+
+	mask = c;
+	for (j = 8; j < LBLOCKSIZE * 8; j <<= 1) {
+		mask = (mask << j) | mask;
+	}
+
+	aligned_addr = (unsigned long *)s;
+	while (!DETECTNULL(*aligned_addr) && !DETECTCHAR(*aligned_addr, mask)) {
+		aligned_addr++;
+	}
+
+	/**
+	 * The block of bytes currently pointed to by aligned_addr
+	 * contains either a null or the target char, or both. We
+	 * catch it using the bytewise search.
+	 */
+
+	s = (unsigned char *)aligned_addr;
+
+#endif /* not PREFER_SIZE_OVER_SPEED */
+
+	while (*s && *s != c) {
+		s++;
+	}
+	if (*s == c) {
+		return (char *)s;
+	}
+
+	return NULL;
+}

--- a/lib/libc/minimal/newlib-cygwin/strcmp.S
+++ b/lib/libc/minimal/newlib-cygwin/strcmp.S
@@ -1,0 +1,197 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ * Copyright (c) 2017  SiFive Inc. All rights reserved.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the FreeBSD License.   This program is distributed in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY expressed or implied,
+ * including the implied warranties of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  A copy of this license is available at
+ * http://www.opensource.org/licenses.
+ */
+
+#include "asm.h"
+
+.text
+.globl strcmp
+.type  strcmp, @function
+strcmp:
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+1:
+  lbu   a2, 0(a0)
+  lbu   a3, 0(a1)
+  add   a0, a0, 1
+  add   a1, a1, 1
+  bne   a2, a3, 2f
+  bnez  a2, 1b
+
+2:
+  sub   a0, a2, a3
+  ret
+
+.size	strcmp, .-strcmp
+#else
+  or    a4, a0, a1
+  li    t2, -1
+  and   a4, a4, SZREG-1
+  bnez  a4, .Lmisaligned
+
+#if SZREG == 4
+  li a5, 0x7f7f7f7f
+#else
+  ld a5, mask
+#endif
+
+  .macro check_one_word i n
+    REG_L a2, \i*SZREG(a0)
+    REG_L a3, \i*SZREG(a1)
+
+    and   t0, a2, a5
+    or    t1, a2, a5
+    add   t0, t0, a5
+    or    t0, t0, t1
+
+    bne   t0, t2, .Lnull\i
+    .if \i+1-\n
+      bne   a2, a3, .Lmismatch
+    .else
+      add   a0, a0, \n*SZREG
+      add   a1, a1, \n*SZREG
+      beq   a2, a3, .Lloop
+      # fall through to .Lmismatch
+    .endif
+  .endm
+
+  .macro foundnull i n
+    .ifne \i
+      .Lnull\i:
+      add   a0, a0, \i*SZREG
+      add   a1, a1, \i*SZREG
+      .ifeq \i-1
+        .Lnull0:
+      .endif
+      bne   a2, a3, .Lmisaligned
+      li    a0, 0
+      ret
+    .endif
+  .endm
+
+.Lloop:
+  # examine full words at a time, favoring strings of a couple dozen chars
+#if __riscv_xlen == 32
+  check_one_word 0 5
+  check_one_word 1 5
+  check_one_word 2 5
+  check_one_word 3 5
+  check_one_word 4 5
+#else
+  check_one_word 0 3
+  check_one_word 1 3
+  check_one_word 2 3
+#endif
+  # backwards branch to .Lloop contained above
+
+.Lmismatch:
+  # words don't match, but a2 has no null byte.
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+
+#if __riscv_xlen == 64
+  sll   a4, a2, 48
+  sll   a5, a3, 48
+  bne   a4, a5, .Lmismatch_upper
+  sll   a4, a2, 32
+  sll   a5, a3, 32
+  bne   a4, a5, .Lmismatch_upper
+#endif
+  sll   a4, a2, 16
+  sll   a5, a3, 16
+  bne   a4, a5, .Lmismatch_upper
+
+  srl   a4, a2, 8*SZREG-16
+  srl   a5, a3, 8*SZREG-16
+  sub   a0, a4, a5
+  and   a1, a0, 0xff
+  bnez  a1, 1f
+  ret
+
+.Lmismatch_upper:
+  srl   a4, a4, 8*SZREG-16
+  srl   a5, a5, 8*SZREG-16
+  sub   a0, a4, a5
+  and   a1, a0, 0xff
+  bnez  a1, 1f
+  ret
+
+1:and   a4, a4, 0xff
+  and   a5, a5, 0xff
+  sub   a0, a4, a5
+  ret
+
+#else
+
+#if __riscv_xlen == 64
+  srl   a4, a2, 48
+  srl   a5, a3, 48
+  bne   a4, a5, .Lmismatch_lower
+  srl   a4, a2, 32
+  srl   a5, a3, 32
+  bne   a4, a5, .Lmismatch_lower
+#endif
+  srl   a4, a2, 16
+  srl   a5, a3, 16
+  bne   a4, a5, .Lmismatch_lower
+
+  srl	a4, a2, 8
+  srl   a5, a3, 8
+  bne   a4, a5, 1f
+  and   a4, a2, 0xff
+  and   a5, a3, 0xff
+1:sub	a0, a4, a5
+  ret
+
+.Lmismatch_lower:
+  srl	a2, a4, 8
+  srl   a3, a5, 8
+  bne   a2, a3, 1f
+  and   a2, a4, 0xff
+  and   a3, a5, 0xff
+1:sub	a0, a2, a3
+  ret
+
+#endif
+
+.Lmisaligned:
+  # misaligned
+  lbu   a2, 0(a0)
+  lbu   a3, 0(a1)
+  add   a0, a0, 1
+  add   a1, a1, 1
+  bne   a2, a3, 1f
+  bnez  a2, .Lmisaligned
+
+1:
+  sub   a0, a2, a3
+  ret
+
+  # cases in which a null byte was detected
+#if __riscv_xlen == 32
+  foundnull 0 5
+  foundnull 1 5
+  foundnull 2 5
+  foundnull 3 5
+  foundnull 4 5
+#else
+  foundnull 0 3
+  foundnull 1 3
+  foundnull 2 3
+#endif
+.size	strcmp, .-strcmp
+
+#if SZREG == 8
+.section .srodata.cst8,"aM",@progbits,8
+.align 3
+mask:
+.dword 0x7f7f7f7f7f7f7f7f
+#endif
+#endif

--- a/lib/libc/minimal/newlib-cygwin/strcpy.c
+++ b/lib/libc/minimal/newlib-cygwin/strcpy.c
@@ -1,0 +1,109 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ * Copyright (c) 2017  SiFive Inc. All rights reserved.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the FreeBSD License.   This program is distributed in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY expressed or implied,
+ * including the implied warranties of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  A copy of this license is available at
+ * http://www.opensource.org/licenses.
+ */
+
+#include <limits.h>
+#include <string.h>
+#include <stdint.h>
+
+#if LONG_MAX == 2147483647L
+static inline unsigned long __detect_null(unsigned long X)
+{
+	return ((X)-0x01010101) & ~(X)&0x80808080;
+}
+#else
+#if LONG_MAX == 9223372036854775807L
+static inline unsigned long __detect_null(unsigned long X)
+{
+	return ((X)-0x0101010101010101) & ~(X)&0x8080808080808080;
+}
+#else
+#error long int is not a 32bit or 64bit type.
+#endif
+#endif
+
+char *strcpy(char *dst, const char *src)
+{
+	char *dst0 = dst;
+
+#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+	int misaligned = ((uintptr_t)dst | (uintptr_t)src) & (sizeof(long) - 1);
+
+	if (__builtin_expect(!misaligned, 1)) {
+		const long *lsrc = (const long *)src;
+		long *ldst = (long *)dst;
+
+		while (!__detect_null(*lsrc)) {
+			*ldst++ = *lsrc++;
+		}
+
+		dst = (char *)ldst;
+		src = (const char *)lsrc;
+
+		char c0 = src[0];
+		char c1 = src[1];
+		char c2 = src[2];
+
+		if (!(*dst++ = c0)) {
+			return dst0;
+		}
+		if (!(*dst++ = c1)) {
+			return dst0;
+		}
+
+		char c3 = src[3];
+
+		if (!(*dst++ = c2)) {
+			return dst0;
+		}
+		if (sizeof(long) == 4) {
+			goto out;
+		}
+
+		char c4 = src[4];
+
+		if (!(*dst++ = c3)) {
+			return dst0;
+		}
+
+		char c5 = src[5];
+
+		if (!(*dst++ = c4)) {
+			return dst0;
+		}
+
+		char c6 = src[6];
+
+		if (!(*dst++ = c5)) {
+			return dst0;
+		}
+		if (!(*dst++ = c6)) {
+			return dst0;
+		}
+
+	out:
+		*dst++ = 0;
+
+		return dst0;
+	}
+#endif /* not PREFER_SIZE_OVER_SPEED */
+
+	char ch;
+
+	do {
+		ch = *src;
+		src++;
+		dst++;
+		*(dst - 1) = ch;
+	} while (ch);
+
+	return dst0;
+}

--- a/lib/libc/minimal/newlib-cygwin/strlen.c
+++ b/lib/libc/minimal/newlib-cygwin/strlen.c
@@ -1,0 +1,91 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ * Copyright (c) 2017  SiFive Inc. All rights reserved.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the FreeBSD License.   This program is distributed in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY expressed or implied,
+ * including the implied warranties of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  A copy of this license is available at
+ * http://www.opensource.org/licenses.
+ */
+
+#include <limits.h>
+#include <string.h>
+#include <stdint.h>
+
+#if LONG_MAX == 2147483647L
+static inline unsigned long __detect_null(unsigned long X)
+{
+	return ((X)-0x01010101) & ~(X)&0x80808080;
+}
+#else
+#if LONG_MAX == 9223372036854775807L
+static inline unsigned long __detect_null(unsigned long X)
+{
+	return ((X)-0x0101010101010101) & ~(X)&0x8080808080808080;
+}
+#else
+#error long int is not a 32bit or 64bit type.
+#endif
+#endif
+
+size_t strlen(const char *str)
+{
+	const char *start = str;
+
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+	while (*str++) {
+		;
+	}
+	return str - start - 1;
+#else
+	if (__builtin_expect((uintptr_t)str & (sizeof(long) - 1), 0)) {
+		do {
+			char ch = *str;
+
+			str++;
+			if (!ch) {
+				return str - start - 1;
+			}
+		} while ((uintptr_t)str & (sizeof(long) - 1));
+	}
+
+	unsigned long *ls = (unsigned long *)str;
+	while (!__detect_null(*ls++)) {
+		;
+	}
+	__asm__ volatile("" : "+r"(ls)); /* prevent "optimization" */
+
+	str = (const char *)ls;
+
+	size_t ret = str - start, sl = sizeof(long);
+	char c0 = str[0 - sl], c1 = str[1 - sl], c2 = str[2 - sl], c3 = str[3 - sl];
+
+	if (c0 == 0) {
+		return ret + 0 - sl;
+	}
+	if (c1 == 0) {
+		return ret + 1 - sl;
+	}
+	if (c2 == 0) {
+		return ret + 2 - sl;
+	}
+	if (sl == 4 || c3 == 0) {
+		return ret + 3 - sl;
+	}
+
+	c0 = str[4 - sl], c1 = str[5 - sl], c2 = str[6 - sl], c3 = str[7 - sl];
+	if (c0 == 0) {
+		return ret + 4 - sl;
+	}
+	if (c1 == 0) {
+		return ret + 5 - sl;
+	}
+	if (c2 == 0) {
+		return ret + 6 - sl;
+	}
+
+	return ret + 7 - sl;
+#endif /* not PREFER_SIZE_OVER_SPEED */
+}

--- a/lib/libc/minimal/newlib-cygwin/strncmp.c
+++ b/lib/libc/minimal/newlib-cygwin/strncmp.c
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ *   FUNCTION
+ * <<strncmp>>---character string compare
+ *
+ * INDEX
+ * strncmp
+ *
+ * SYNOPSIS
+ * #include <string.h>
+ * int strncmp(const char *<[a]>, const char * <[b]>, size_t <[length]>);
+ *
+ * DESCRIPTION
+ * <<strncmp>> compares up to <[length]> characters
+ * from the string at <[a]> to the string at <[b]>.
+ *
+ * RETURNS
+ * If <<*<[a]>>> sorts lexicographically after <<*<[b]>>>,
+ * <<strncmp>> returns a number greater than zero.  If the two
+ * strings are equivalent, <<strncmp>> returns zero.  If <<*<[a]>>>
+ * sorts lexicographically before <<*<[b]>>>, <<strncmp>> returns a
+ * number less than zero.
+ *
+ * PORTABILITY
+ * <<strncmp>> is ANSI C.
+ *
+ * <<strncmp>> requires no supporting OS subroutines.
+ *
+ * QUICKREF
+ * strncmp ansi pure
+ */
+
+#include <string.h>
+#include <limits.h>
+
+/** Nonzero if either X or Y is not aligned on a "long" boundary.  */
+#define UNALIGNED(X, Y) (((long)X & (sizeof(long) - 1)) | ((long)Y & (sizeof(long) - 1)))
+
+/** DETECTNULL returns nonzero if (long)X contains a NULL byte. */
+#if LONG_MAX == 2147483647L
+#define DETECTNULL(X) (((X)-0x01010101) & ~(X)&0x80808080)
+#else
+#if LONG_MAX == 9223372036854775807L
+#define DETECTNULL(X) (((X)-0x0101010101010101) & ~(X)&0x8080808080808080)
+#else
+#error long int is not a 32bit or 64bit type.
+#endif
+#endif
+
+#ifndef DETECTNULL
+#error long int is not a 32bit or 64bit byte
+#endif
+
+int strncmp(const char *s1, const char *s2, size_t n)
+{
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+	if (n == 0) {
+		return 0;
+	}
+
+	while (n-- != 0 && *s1 == *s2) {
+		if (n == 0 || *s1 == '\0') {
+			break;
+		}
+		s1++;
+		s2++;
+	}
+
+	return (*(unsigned char *)s1) - (*(unsigned char *)s2);
+#else
+	unsigned long *a1;
+	unsigned long *a2;
+
+	if (n == 0) {
+		return 0;
+	}
+
+	/** If s1 or s2 are unaligned, then compare bytes. */
+	if (!UNALIGNED(s1, s2)) {
+		/** If s1 and s2 are word-aligned, compare them a word at a time. */
+		a1 = (unsigned long *)s1;
+		a2 = (unsigned long *)s2;
+		while (n >= sizeof(long) && *a1 == *a2) {
+			n -= sizeof(long);
+
+			/**
+			 * If we've run out of bytes or hit a null, return zero
+			 * since we already know *a1 == *a2.
+			 */
+			if (n == 0 || DETECTNULL(*a1)) {
+				return 0;
+			}
+
+			a1++;
+			a2++;
+		}
+
+		/** A difference was detected in last few bytes of s1, so search bytewise */
+		s1 = (char *)a1;
+		s2 = (char *)a2;
+	}
+
+	while (n-- > 0 && *s1 == *s2) {
+		/**
+		 * If we've run out of bytes or hit a null, return zero
+		 * since we already know *s1 == *s2.
+		 */
+		if (n == 0 || *s1 == '\0') {
+			return 0;
+		}
+		s1++;
+		s2++;
+	}
+
+	return (*(unsigned char *)s1) - (*(unsigned char *)s2);
+#endif /* not PREFER_SIZE_OVER_SPEED */
+}

--- a/lib/libc/minimal/newlib-cygwin/strncpy.c
+++ b/lib/libc/minimal/newlib-cygwin/strncpy.c
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * FUNCTION
+ * <<strncpy>>---counted copy string
+ *
+ * INDEX
+ * strncpy
+ *
+ * SYNOPSIS
+ * #include <string.h>
+ * char *strncpy(char *restrict <[dst]>, const char *restrict <[src]>,
+ * size_t <[length]>);
+ *
+ * DESCRIPTION
+ * <<strncpy>> copies not more than <[length]> characters from
+ * the string pointed to by <[src]> (including the terminating
+ * null character) to the array pointed to by <[dst]>.  If the
+ * string pointed to by <[src]> is shorter than <[length]>
+ * characters, null characters are appended to the destination
+ * array until a total of <[length]> characters have been
+ * written.
+ *
+ * RETURNS
+ * This function returns the initial value of <[dst]>.
+ *
+ * PORTABILITY
+ * <<strncpy>> is ANSI C.
+ *
+ * <<strncpy>> requires no supporting OS subroutines.
+ *
+ * QUICKREF
+ * strncpy ansi pure
+ */
+
+#include <string.h>
+#include <limits.h>
+
+/**SUPPRESS 560*/
+/**SUPPRESS 530*/
+
+/** Nonzero if either X or Y is not aligned on a "long" boundary.  */
+#define UNALIGNED(X, Y) (((long)X & (sizeof(long) - 1)) | ((long)Y & (sizeof(long) - 1)))
+
+#if LONG_MAX == 2147483647L
+#define DETECTNULL(X) (((X)-0x01010101) & ~(X)&0x80808080)
+#else
+#if LONG_MAX == 9223372036854775807L
+/** Nonzero if X (a long int) contains a NULL byte. */
+#define DETECTNULL(X) (((X)-0x0101010101010101) & ~(X)&0x8080808080808080)
+#else
+#error long int is not a 32bit or 64bit type.
+#endif
+#endif
+
+#ifndef DETECTNULL
+#error long int is not a 32bit or 64bit byte
+#endif
+
+#define TOO_SMALL(LEN) ((LEN) < sizeof(long))
+
+char *strncpy(char *__restrict dst0, const char *__restrict src0, size_t count)
+{
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+	char *dscan;
+	const char *sscan;
+
+	dscan = dst0;
+	sscan = src0;
+	while (count > 0) {
+		--count;
+		if ((*dscan++ = *sscan++) == '\0') {
+			break;
+		}
+	}
+	while (count-- > 0) {
+		*dscan++ = '\0';
+	}
+
+	return dst0;
+#else
+	char *dst = dst0;
+	const char *src = src0;
+	long *aligned_dst;
+	const long *aligned_src;
+
+	/** If SRC and DEST is aligned and count large enough, then copy words.  */
+	if (!UNALIGNED(src, dst) && !TOO_SMALL(count)) {
+		aligned_dst = (long *)dst;
+		aligned_src = (long *)src;
+
+		/**
+		 * SRC and DEST are both "long int" aligned, try to do "long int"
+		 * sized copies.
+		 */
+		while (count >= sizeof(long) && !DETECTNULL(*aligned_src)) {
+			count -= sizeof(long);
+			*aligned_dst++ = *aligned_src++;
+		}
+
+		dst = (char *)aligned_dst;
+		src = (char *)aligned_src;
+	}
+
+	while (count > 0) {
+		--count;
+		if ((*dst++ = *src++) == '\0') {
+			break;
+		}
+	}
+
+	while (count-- > 0) {
+		*dst++ = '\0';
+	}
+
+	return dst0;
+#endif /* not PREFER_SIZE_OVER_SPEED */
+}

--- a/lib/libc/minimal/newlib-cygwin/strnlen.c
+++ b/lib/libc/minimal/newlib-cygwin/strnlen.c
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * FUNCTION
+ * <<strnlen>>---character string length
+ *
+ * INDEX
+ * strnlen
+ *
+ * SYNOPSIS
+ * #include <string.h>
+ * size_t strnlen(const char *<[str]>, size_t <[n]>);
+ *
+ * DESCRIPTION
+ * The <<strnlen>> function works out the length of the string
+ * starting at <<*<[str]>>> by counting chararacters until it
+ * reaches a NUL character or the maximum: <[n]> number of
+ * characters have been inspected.
+ *
+ * RETURNS
+ * <<strnlen>> returns the character count or <[n]>.
+ *
+ * PORTABILITY
+ * <<strnlen>> is a GNU extension.
+ *
+ * <<strnlen>> requires no supporting OS subroutines.
+ *
+ */
+
+#undef __STRICT_ANSI__
+#include <string.h>
+
+size_t strnlen(const char *str, size_t n)
+{
+	const char *start = str;
+
+	while (n-- > 0 && *str) {
+		str++;
+	}
+
+	return str - start;
+}

--- a/lib/libc/minimal/newlib-cygwin/strrchr.c
+++ b/lib/libc/minimal/newlib-cygwin/strrchr.c
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * FUNCTION
+ * <<strrchr>>---reverse search for character in string
+ *
+ * INDEX
+ * strrchr
+ *
+ * SYNOPSIS
+ * #include <string.h>
+ * char * strrchr(const char *<[string]>, int <[c]>);
+ *
+ * DESCRIPTION
+ * This function finds the last occurrence of <[c]> (converted to
+ * a char) in the string pointed to by <[string]> (including the
+ * terminating null character).
+ *
+ * RETURNS
+ * Returns a pointer to the located character, or a null pointer
+ * if <[c]> does not occur in <[string]>.
+ *
+ * PORTABILITY
+ * <<strrchr>> is ANSI C.
+ *
+ * <<strrchr>> requires no supporting OS subroutines.
+ *
+ * QUICKREF
+ * strrchr ansi pure
+ */
+
+#include <string.h>
+
+char *strrchr(const char *s, int i)
+{
+	const char *last = NULL;
+	char c = i;
+
+	if (c) {
+		while ((s = strchr(s, c))) {
+			last = s;
+			s++;
+		}
+	} else {
+		last = strchr(s, c);
+	}
+
+	return (char *)last;
+}

--- a/lib/libc/minimal/newlib-cygwin/strtok_r.c
+++ b/lib/libc/minimal/newlib-cygwin/strtok_r.c
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: BSD-4-Clause-UC
+ * Copyright (c) 1988 Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <string.h>
+
+char *__strtok_r(register char *s, register const char *delim, char **lasts, int skip_leading_delim)
+{
+	register char *spanp;
+	register int c, sc;
+	char *tok;
+
+	if (s == NULL && (s = *lasts) == NULL) {
+		return NULL;
+	}
+
+	/**
+	 * Skip (span) leading delimiters (s += strspn(s, delim), sort of).
+	 */
+cont:
+	c = *s++;
+	for (spanp = (char *)delim; (sc = *spanp++) != 0;) {
+		if (c == sc) {
+			if (skip_leading_delim) {
+				goto cont;
+			} else {
+				*lasts = s;
+				s[-1] = 0;
+				return (s - 1);
+			}
+		}
+	}
+
+	if (c == 0) { /** no non-delimiter characters */
+		*lasts = NULL;
+		return NULL;
+	}
+	tok = s - 1;
+
+	/**
+	 * Scan token (scan for delimiters: s += strcspn(s, delim), sort of).
+	 * Note that delim must have one NUL; we stop if we see that, too.
+	 */
+	for (;;) {
+		c = *s++;
+		spanp = (char *)delim;
+		do {
+			sc = *spanp++;
+			if (sc == c) {
+				if (c == 0) {
+					s = NULL;
+				} else {
+					s[-1] = 0;
+				}
+				*lasts = s;
+				return tok;
+			}
+		} while (sc != 0);
+	}
+	/** NOTREACHED */
+}
+
+char *strtok_r(register char *__restrict s, register const char *__restrict delim,
+	       char **__restrict lasts)
+{
+	return __strtok_r(s, delim, lasts, 1);
+}


### PR DESCRIPTION
As an alternative Cygwin version of string/memory functions is available. Some are available in assembly and also internally provide extra defines to further optimize for speed or size which might be a second step in fine-tuning. By default compiler is optimised for size which also impacts this implementation.