### PR TITLE
debug: coredump: Fix build issue with armclang

### DIFF
--- a/include/zephyr/debug/coredump.h
+++ b/include/zephyr/debug/coredump.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_INCLUDE_DEBUG_COREDUMP_H_
 
 #include <stddef.h>
+#include <stdint.h>
 #include <sys/types.h>
 
 /* Query ID */


### PR DESCRIPTION
Building tests/drivers/coredump/coredump_api with armclang gets:

include/zephyr/debug/coredump.h:98:2: error: unknown type name 'uint8_t'
        uint8_t *buffer;
        ^

Fix simply be including <stdint.h> to get uint8_t typedef.