### PR TITLE
drivers: clock: Microchip XEC: Fix enum usage

### DIFF
--- a/drivers/clock_control/clock_control_mchp_xec.c
+++ b/drivers/clock_control/clock_control_mchp_xec.c
@@ -640,7 +640,7 @@ enum periph_clk32k_src get_periph_32k_source(const struct device *dev)
 	} else if (temp == VBR_CLK32K_SRC_PIN_SO) {
 		src = PERIPH_CLK32K_SRC_PIN_SO;
 	} else {
-		src = VBR_CLK32K_SRC_PIN_XTAL;
+		src = PERIPH_CLK32K_SRC_PIN_XTAL;
 	}
 
 	return src;


### PR DESCRIPTION
We get a compiler warning in this code with arm clang due to using the wrong enum type for the variable.  The enum should be of type `enum periph_clk32k_src` so replace VBR_CLK32K_SRC_PIN_XTAL with PERIPH_CLK32K_SRC_PIN_XTAL.