### PR TITLE
dts: bindings: arm,sbsa-uart: fix dangling entry

### DIFF
--- a/dts/bindings/serial/arm,sbsa-uart.yaml
+++ b/dts/bindings/serial/arm,sbsa-uart.yaml
@@ -7,5 +7,3 @@ include: uart-controller.yaml
 properties:
   reg:
     required: true
-
-  interrupts:


### PR DESCRIPTION
interrupts property was previously added with "required: false", but when required was removed (redundant), the interrupts property was left dangling.