### PR TITLE
toolchain: Add ARMClang to gcc related toolchain flags check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,7 +408,8 @@ zephyr_compile_options(${COMPILER_OPT_AS_LIST})
 # TODO: Include arch compiler options at this point.
 
 if(NOT CMAKE_C_COMPILER_ID STREQUAL "Clang" AND
-   NOT CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
+   NOT CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM" AND
+   NOT CMAKE_C_COMPILER_ID STREQUAL "ARMClang")
   # GCC assumed
   zephyr_cc_option(-fno-reorder-functions)
 


### PR DESCRIPTION
Add ARMClang similar to LLVM to check to skip GCC specific flags