### PR TITLE
tests: lib: mem_alloc: skip reallocarray test on arm clang

### DIFF
--- a/tests/lib/mem_alloc/src/main.c
+++ b/tests/lib/mem_alloc/src/main.c
@@ -242,10 +242,10 @@ ZTEST(c_lib_dynamic_memalloc, test_realloc)
  *
  * @see malloc(), reallocarray(), free()
  */
-#ifdef CONFIG_NEWLIB_LIBC
+#if defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_ARMCLANG_STD_LIBC)
 ZTEST(c_lib_dynamic_memalloc, test_reallocarray)
 {
-	/* reallocarray not implemented for newlib */
+	/* reallocarray not implemented for newlib or arm libc */
 	ztest_test_skip();
 }
 ZTEST(c_lib_dynamic_memalloc, test_calloc)


### PR DESCRIPTION
The arm clang toolchain provides its own libc and that libc doesn't implement reallocarray, so skip the test like we do on newlib.