### PR TITLE
Bluetooth: Mesh: Fix registering GATT Proxy service after reboot

### DIFF
--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -525,7 +525,6 @@ int bt_mesh_start(void)
 
 		if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
 			(void)bt_mesh_proxy_gatt_enable();
-			bt_mesh_adv_gatt_update();
 		}
 	}
 

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -875,10 +875,24 @@ static struct bt_gatt_attr proxy_attrs[] = {
 
 static struct bt_gatt_service proxy_svc = BT_GATT_SERVICE(proxy_attrs);
 
+static void svc_reg_work_handler(struct k_work *work)
+{
+	(void)bt_gatt_service_register(&proxy_svc);
+	service_registered = true;
+
+	for (int i = 0; i < ARRAY_SIZE(clients); i++) {
+		if (clients[i].cli) {
+			clients[i].filter_type = ACCEPT;
+		}
+	}
+
+	bt_mesh_adv_gatt_update();
+}
+
+static struct k_work svc_reg_work = Z_WORK_INITIALIZER(svc_reg_work_handler);
+
 int bt_mesh_proxy_gatt_enable(void)
 {
-	int i;
-
 	LOG_DBG("");
 
 	if (!bt_mesh_is_provisioned()) {
@@ -889,16 +903,7 @@ int bt_mesh_proxy_gatt_enable(void)
 		return -EBUSY;
 	}
 
-	(void)bt_gatt_service_register(&proxy_svc);
-	service_registered = true;
-
-	for (i = 0; i < ARRAY_SIZE(clients); i++) {
-		if (clients[i].cli) {
-			clients[i].filter_type = ACCEPT;
-		}
-	}
-
-	return 0;
+	return k_work_submit(&svc_reg_work);
 }
 
 void bt_mesh_proxy_gatt_disconnect(void)


### PR DESCRIPTION
After commit https://github.com/zephyrproject-rtos/zephyr/commit/3486f133e9dcfc48e0291b9a31fdbdc9af2f5f09 GATT Proxy service registration is broken because it is registered from settings_load() in mesh_commit(). Because mesh_commit() is called before sc_commit() is called in gatt.c, bt_gatt_service_register() can't be called yet.

Use k_work to postpone the service registration.