### PR TITLE
armclang: fix compiler warnings with isprint()

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -505,7 +505,7 @@ static void uart_console_isr(const struct device *unused, void *user_data)
 		}
 
 		/* Handle special control characters */
-		if (!isprint(byte)) {
+		if (isprint(byte) == 0) {
 			switch (byte) {
 			case BS:
 			case DEL:

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -140,7 +140,7 @@ static int cmd_demo_getopt_ts(const struct shell *sh, size_t argc,
 				shell_print(sh,
 					"Option -%c requires an argument.",
 					state->optopt);
-			} else if (isprint(state->optopt)) {
+			} else if (isprint(state->optopt) != 0) {
 				shell_print(sh,
 					"Unknown option `-%c'.",
 					state->optopt);
@@ -190,7 +190,7 @@ static int cmd_demo_getopt(const struct shell *sh, size_t argc,
 				shell_print(sh,
 					"Option -%c requires an argument.",
 					optopt);
-			} else if (isprint(optopt)) {
+			} else if (isprint(optopt) != 0) {
 				shell_print(sh, "Unknown option `-%c'.",
 					optopt);
 			} else {

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -397,7 +397,7 @@ static void hexdump_line_print(const struct log_output *output,
 			unsigned char c = (unsigned char)data[i];
 
 			print_formatted(output, "%c",
-			      isprint((int)c) ? c : '.');
+			      isprint((int)c) != 0 ? c : '.');
 		} else {
 			print_formatted(output, " ");
 		}

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1049,7 +1049,7 @@ static void state_collect(const struct shell *shell)
 				break;
 
 			default:
-				if (isprint((int) data)) {
+				if (isprint((int) data) != 0) {
 					z_flag_history_exit_set(shell, true);
 					z_shell_op_char_insert(shell, data);
 				} else if (z_flag_echo_get(shell)) {
@@ -1557,7 +1557,7 @@ void shell_hexdump_line(const struct shell *shell, unsigned int offset,
 			char c = data[i];
 
 			shell_fprintf(shell, SHELL_NORMAL, "%c",
-				      isprint((int)c) ? c : '.');
+				      isprint((int)c) != 0 ? c : '.');
 		} else {
 			shell_fprintf(shell, SHELL_NORMAL, " ");
 		}

--- a/subsys/tracing/tracing_backend_uart.c
+++ b/subsys/tracing/tracing_backend_uart.c
@@ -48,7 +48,7 @@ static void uart_isr(const struct device *dev, void *user_data)
 			length = tracing_cmd_buffer_alloc(&cmd);
 		}
 
-		if (!isprint(byte)) {
+		if (isprint(byte) == 0) {
 			if (byte == '\r') {
 				cmd[cur] = '\0';
 				tracing_cmd_handle(cmd, cur);

--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -479,7 +479,7 @@ ZTEST(test_c_lib, test_checktype)
 
 	ptr = buf;
 	for (int i = 0; i < 128; i++) {
-		if (isprint(i)) {
+		if (isprint(i) != 0) {
 			*ptr++ = i;
 		}
 	}


### PR DESCRIPTION
We get compile warnings of the form:

drivers/console/uart_console.c:508:8: error: converting the result of '<<' to a boolean; did you mean
'((__aeabi_ctype_table_ + 1)[(byte)] << 28) != 0'? [-Werror,-Wint-in-bool-context]
                if (!isprint(byte)) {
                     ^

Since isprint returns an int, change check to an explicit test against the return value.