### PR TITLE
fuel_gauge: Add init priority

### DIFF
--- a/drivers/fuel_gauge/Kconfig
+++ b/drivers/fuel_gauge/Kconfig
@@ -13,6 +13,12 @@ module = FUEL_GAUGE
 module-str = fuel_gauge
 source "subsys/logging/Kconfig.template.log_config"
 
+config FUEL_GAUGE_INIT_PRIORITY
+	int "Battery Fuel Gauge init priority"
+	default 90
+	help
+	  Battery fuel gauge initialization priority.
+
 source "drivers/fuel_gauge/sbs_gauge/Kconfig"
 
 endif # FUEL_GAUGE

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -214,6 +214,6 @@ static const struct fuel_gauge_driver_api sbs_gauge_driver_api = {
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(index, &sbs_gauge_init, NULL, NULL, &sbs_gauge_config_##index,       \
-			      POST_KERNEL, 90, &sbs_gauge_driver_api);
+			      POST_KERNEL, CONFIG_FUEL_GAUGE_INIT_PRIORITY, &sbs_gauge_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SBS_GAUGE_INIT)


### PR DESCRIPTION
Add an device driver initialization priority for fuel gauge drivers.