### PR TITLE
RISCV: Refactor inline ASM in favor of macro functions

### DIFF
--- a/arch/riscv/core/irq_manage.c
+++ b/arch/riscv/core/irq_manage.c
@@ -7,6 +7,8 @@
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/arch/riscv/csr.h>
+
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 FUNC_NORETURN void z_irq_spurious(const void *unused)
@@ -15,7 +17,7 @@ FUNC_NORETURN void z_irq_spurious(const void *unused)
 
 	ARG_UNUSED(unused);
 
-	__asm__ volatile("csrr %0, mcause" : "=r" (mcause));
+	mcause = csr_read(mcause);
 
 	mcause &= SOC_MCAUSE_EXP_MASK;
 

--- a/soc/riscv/riscv-privilege/common/soc_common_irq.c
+++ b/soc/riscv/riscv-privilege/common/soc_common_irq.c
@@ -56,9 +56,7 @@ void arch_irq_enable(unsigned int irq)
 	 * CSR mie register is updated using atomic instruction csrrs
 	 * (atomic read and set bits in CSR register)
 	 */
-	__asm__ volatile ("csrrs %0, mie, %1\n"
-			  : "=r" (mie)
-			  : "r" (1 << irq));
+	mie = csr_read_set(mie, 1 << irq);
 }
 
 void arch_irq_disable(unsigned int irq)
@@ -79,9 +77,7 @@ void arch_irq_disable(unsigned int irq)
 	 * Use atomic instruction csrrc to disable device interrupt in mie CSR.
 	 * (atomic read and clear bits in CSR register)
 	 */
-	__asm__ volatile ("csrrc %0, mie, %1\n"
-			  : "=r" (mie)
-			  : "r" (1 << irq));
+	mie = csr_read_clear(mie, 1 << irq);
 }
 
 int arch_irq_is_enabled(unsigned int irq)
@@ -97,7 +93,7 @@ int arch_irq_is_enabled(unsigned int irq)
 	}
 #endif
 
-	__asm__ volatile ("csrr %0, mie" : "=r" (mie));
+	mie = csr_read(mie);
 
 	return !!(mie & (1 << irq));
 }
@@ -121,7 +117,7 @@ __weak void soc_interrupt_init(void)
 	/* ensure that all interrupts are disabled */
 	(void)arch_irq_lock();
 
-	__asm__ volatile ("csrwi mie, 0\n"
-			  "csrwi mip, 0\n");
+	csr_write(mie, 0);
+	csr_write(mip, 0);
 }
 #endif

--- a/soc/riscv/riscv-privilege/neorv32/soc.c
+++ b/soc/riscv/riscv-privilege/neorv32/soc.c
@@ -12,6 +12,6 @@ void soc_interrupt_init(void)
 {
 	(void)arch_irq_lock();
 
-	__asm__ volatile ("csrwi mie, 0\n");
+	csr_write(mie, 0);
 }
 #endif


### PR DESCRIPTION
This PR refactors the code to use macro functions from `csr.h` instead of repeating inline ASM, which results in cleaner and more maintainable code. 

- No impact on the existing logic of the code