### PR TITLE
z_sched_init: don't use arch_num_cpus()

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1306,9 +1306,7 @@ void init_ready_q(struct _ready_q *rq)
 void z_sched_init(void)
 {
 #ifdef CONFIG_SCHED_CPU_MASK_PIN_ONLY
-	unsigned int num_cpus = arch_num_cpus();
-
-	for (int i = 0; i < num_cpus; i++) {
+	for (int i = 0; i < CONFIG_MP_MAX_NUM_CPUS; i++) {
 		init_ready_q(&_kernel.cpus[i].ready_q);
 	}
 #else


### PR DESCRIPTION
The reason for arch_num_cpus() is to be able to dynamically adapt to
the actual number of available CPUs at run time. In such case the value
returned by arch_num_cpus() would always be 1 when z_sched_init() is
called as SMP is not yet initialized at that point.

