### PR TITLE
drivers: ieee802154: Fix `csl_rx_time` overflow issue for NRF5 and clean up redundant static functions

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -839,47 +839,6 @@ static void nrf5_config_mac_keys(struct ieee802154_key *mac_keys)
 }
 #endif /* CONFIG_IEEE802154_2015 */
 
-#if defined(CONFIG_IEEE802154_CSL_ENDPOINT)
-static void nrf5_receive_at(uint32_t start, uint32_t duration, uint8_t channel, uint32_t id)
-{
-	/*
-	 * Workaround until OpenThread (the only CSL user in Zephyr so far) is able to schedule
-	 * RX windows using 64-bit time.
-	 */
-	uint64_t rx_time = target_time_convert_to_64_bits(start);
-
-	nrf_802154_receive_at(rx_time, duration, channel, id);
-}
-
-static void nrf5_config_csl_period(uint16_t period)
-{
-	nrf_802154_csl_writer_period_set(period);
-
-	/* Update the CSL anchor time to match the nearest requested CSL window, so that
-	 * the proper CSL Phase in the transmitted CSL Information Elements can be injected.
-	 */
-	if (period > 0) {
-		nrf_802154_csl_writer_anchor_time_set(nrf5_data.csl_rx_time);
-	}
-}
-
-static void nrf5_schedule_rx(uint8_t channel, uint32_t start, uint32_t duration)
-{
-	nrf5_receive_at(start, duration, channel, DRX_SLOT_RX);
-
-	/* Update the CSL anchor time to match the nearest requested CSL window, so that
-	 * the proper CSL Phase in the transmitted CSL Information Elements can be injected.
-	 *
-	 * Note that even if the nrf5_schedule_rx function is not called in time (for example
-	 * due to the call being blocked by higher priority threads) and the delayed reception
-	 * window is not scheduled, the CSL phase will still be calculated as if the following
-	 * reception windows were at times anchor_time + n * csl_period. The previously set
-	 * anchor_time will be used for calculations.
-	 */
-	nrf_802154_csl_writer_anchor_time_set(nrf5_data.csl_rx_time);
-}
-#endif /* CONFIG_IEEE802154_CSL_ENDPOINT */
-
 static int nrf5_configure(const struct device *dev,
 			  enum ieee802154_config_type type,
 			  const struct ieee802154_config *config)
@@ -988,16 +947,35 @@ static int nrf5_configure(const struct device *dev,
 
 #if defined(CONFIG_IEEE802154_CSL_ENDPOINT)
 	case IEEE802154_CONFIG_CSL_RX_TIME:
-		nrf5_data.csl_rx_time = config->csl_rx_time;
+		/*
+		 * `target_time_convert_to_64_bits()` is a workaround until OpenThread (the only
+		 * CSL user in Zephyr so far) is able to schedule RX windows using 64-bit time.
+		 */
+		uint64_t csl_rx_time = target_time_convert_to_64_bits(config->csl_rx_time);
+
+		nrf_802154_csl_writer_anchor_time_set(csl_rx_time);
 		break;
 
 	case IEEE802154_CONFIG_RX_SLOT:
-		nrf5_schedule_rx(config->rx_slot.channel, config->rx_slot.start,
-				 config->rx_slot.duration);
+		/* Note that even if the nrf_802154_receive_at function is not called in time
+		 * (for example due to the call being blocked by higher priority threads) and
+		 * the delayed reception window is not scheduled, the CSL phase will still be
+		 * calculated as if the following reception windows were at times
+		 * anchor_time + n * csl_period. The previously set
+		 * anchor_time will be used for calculations.
+		 *
+		 * `target_time_convert_to_64_bits()` is a workaround until OpenThread
+		 * (the only CSL user in Zephyr so far) is able to schedule RX windows
+		 * using 64-bit time.
+		 */
+		uint64_t start = target_time_convert_to_64_bits(config->rx_slot.start);
+
+		nrf_802154_receive_at(start, config->rx_slot.duration, config->rx_slot.channel,
+				      DRX_SLOT_RX);
 		break;
 
 	case IEEE802154_CONFIG_CSL_PERIOD:
-		nrf5_config_csl_period(config->csl_period);
+		nrf_802154_csl_writer_period_set(config->csl_period);
 		break;
 #endif /* CONFIG_IEEE802154_CSL_ENDPOINT */
 

--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -84,9 +84,6 @@ struct nrf5_802154_data {
 	/* Capabilities of the network interface. */
 	enum ieee802154_hw_caps capabilities;
 
-	/* Next CSL receive time */
-	uint32_t csl_rx_time;
-
 	/* Indicates if currently processed TX frame is secured. */
 	bool tx_frame_is_secured;
 


### PR DESCRIPTION
convert `csl_rx_time` to uint32_t and remove redundant `nrf5_schedule_rx`
`nrf5_config_csl_period` and `nrf5_receive_at` static functions.

`csl_rx_time` has been passed as uint32. It is compared to uint64 value
returned by `nrf_802154_sl_timer_current_time_get` in
`nrf_802154_ie_writer.c` which leads to wrong calculation of phase in CSL.