### PR TITLE
west.yml: Update nanopb to 0.4.7

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -189,7 +189,7 @@ manifest:
         - debug
       revision: 0d521d8055f3b2b4842f728b0365d3f0ece9c37f
     - name: nanopb
-      revision: dc4deed54fd4c7e1935e3b6387eedf21bb45dc38
+      revision: 42fa8b211e946b90b9d968523fce7b1cfe27617e
       path: modules/lib/nanopb
     - name: net-tools
       revision: e0828aa9629b533644dc96ff6d1295c939bd713c


### PR DESCRIPTION
Update `nanopb` to the latest released version 0.4.7.

Fixes #47817