### PR TITLE
drivers: sensor: bmi270: Use bulk SPI reads

### DIFF
--- a/drivers/sensor/bmi270/bmi270_spi.c
+++ b/drivers/sensor/bmi270/bmi270_spi.c
@@ -25,7 +25,6 @@ static int bmi270_reg_read_spi(const union bmi270_bus *bus,
 	int ret;
 	uint8_t addr;
 	uint8_t tmp[2];
-	int i;
 	const struct spi_buf tx_buf = {
 		.buf = &addr,
 		.len = 1
@@ -40,19 +39,18 @@ static int bmi270_reg_read_spi(const union bmi270_bus *bus,
 		.count = ARRAY_SIZE(rx_buf)
 	};
 
-	rx_buf[0].buf = &tmp[0];
+	/* First byte we read should be discarded. */
+	rx_buf[0].buf = &tmp;
 	rx_buf[0].len = 2;
-	rx_buf[1].len = 1;
+	rx_buf[1].len = len;
+	rx_buf[1].buf = data;
 
-	for (i = 0; i < len; i++) {
-		addr = (start + i) | 0x80;
-		rx_buf[1].buf = &data[i];
+	addr = start | 0x80;
 
-		ret = spi_transceive_dt(&bus->spi, &tx, &rx);
-		if (ret < 0) {
-			LOG_DBG("spi_transceive failed %i", ret);
-			return ret;
-		}
+	ret = spi_transceive_dt(&bus->spi, &tx, &rx);
+	if (ret < 0) {
+		LOG_DBG("spi_transceive failed %i", ret);
+		return ret;
 	}
 
 	k_usleep(BMI270_SPI_ACC_DELAY_US);


### PR DESCRIPTION
BMI270 supports bulk register reads, use them to make trasnfers faster.
See the discussion on
https://github.com/zephyrproject-rtos/zephyr/commit/6cbb84c3eed97efa33375ae24d050abf49ee5b86#r104543405 Tested on an nrf52840 board connected to a bmi270 sensor via SPI.