### PR TITLE
Bluetooth: BAP: Remove BT_BAP_UNICAST_CLIENT_PAC_COUNT

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.bap
+++ b/subsys/bluetooth/audio/Kconfig.bap
@@ -91,14 +91,6 @@ config BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT
 	  Since BAP streams are unidirectional, two BAP streams may use a single CIS, the number of
 	  BAP audio streams per group may be up to twice of this value.
 
-config BT_BAP_UNICAST_CLIENT_PAC_COUNT
-	int "Basic Audio Profile PAC count"
-	default 2
-	range 0 146
-	help
-	  This option enables caching a number of Published Audio Capabilities
-	  (PAC) for Basic Audio Profile on a per connection basis.
-
 config BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT
 	int "Basic Audio Profile ASE Sink count"
 	default 2


### PR DESCRIPTION
The BT_BAP_UNICAST_CLIENT_PAC_COUNT is there due to a merge conflict gone wrong. Removed again.