### PR TITLE
drivers: can: check timing parameters

### DIFF
--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -232,7 +232,7 @@ int can_calc_prescaler(const struct device *dev, struct can_timing *timing,
  * @param  bitrate The bitrate in bits/second.
  * @return The sample point in permille.
  */
-uint16_t sample_point_for_bitrate(uint32_t bitrate)
+static uint16_t sample_point_for_bitrate(uint32_t bitrate)
 {
 	uint16_t sample_pnt;
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -234,6 +234,11 @@ struct can_bus_err_cnt {
 	uint8_t rx_err_cnt;
 };
 
+/** Synchronization Jump Width (SJW) value to indicate that the SJW should not
+ * be changed by the timing calculation.
+ */
+#define CAN_SJW_NO_CHANGE 0
+
 /**
  * @brief CAN bus timing structure
  *
@@ -856,24 +861,11 @@ __syscall int can_calc_timing_data(const struct device *dev, struct can_timing *
  * @retval 0 If successful.
  * @retval -EBUSY if the CAN controller is not in stopped state.
  * @retval -EIO General input/output error, failed to configure device.
+ * @retval -ENOTSUP if the timing parameters are not supported by the driver.
  * @retval -ENOSYS if CAN-FD support is not implemented by the driver.
  */
 __syscall int can_set_timing_data(const struct device *dev,
 				  const struct can_timing *timing_data);
-
-#ifdef CONFIG_CAN_FD_MODE
-static inline int z_impl_can_set_timing_data(const struct device *dev,
-					     const struct can_timing *timing_data)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	if (api->set_timing_data == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->set_timing_data(dev, timing_data);
-}
-#endif /* CONFIG_CAN_FD_MODE */
 
 /**
  * @brief Set the bitrate for the data phase of the CAN-FD controller
@@ -924,11 +916,6 @@ __syscall int can_set_bitrate_data(const struct device *dev, uint32_t bitrate_da
 int can_calc_prescaler(const struct device *dev, struct can_timing *timing,
 		       uint32_t bitrate);
 
-/** Synchronization Jump Width (SJW) value to indicate that the SJW should not
- * be changed by the timing calculation.
- */
-#define CAN_SJW_NO_CHANGE 0
-
 /**
  * @brief Configure the bus timing of a CAN controller.
  *
@@ -941,18 +928,11 @@ int can_calc_prescaler(const struct device *dev, struct can_timing *timing,
  *
  * @retval 0 If successful.
  * @retval -EBUSY if the CAN controller is not in stopped state.
+ * @retval -ENOTSUP if the timing parameters are not supported by the driver.
  * @retval -EIO General input/output error, failed to configure device.
  */
 __syscall int can_set_timing(const struct device *dev,
 			     const struct can_timing *timing);
-
-static inline int z_impl_can_set_timing(const struct device *dev,
-					const struct can_timing *timing)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->set_timing(dev, timing);
-}
 
 /**
  * @brief Get the supported modes of the CAN controller


### PR DESCRIPTION
Check the requested CAN timing parameters against the min/max values supported by the driver and return an error if they are out of range. Add missing static keyword for internal function `sample_point_for_bitrate()` while here.