### PR TITLE
pm: device_runtime: option to enable from devicetree

### DIFF
--- a/doc/services/pm/device_runtime.rst
+++ b/doc/services/pm/device_runtime.rst
@@ -168,6 +168,18 @@ suspended, the init function should call
         }
     }
 
+Device runtime power management can also be automatically enabled on a device
+instance by adding the ``zephyr,pm-device-runtime-auto`` flag onto the corresponding
+devicetree node. If enabled, :c:func:`pm_device_runtime_enable` is called immediately
+after the ``init`` function of the device runs and returns successfully.
+
+.. code-block:: dts
+
+    foo {
+        /* ... */
+        zephyr,pm-device-runtime-auto;
+    };
+
 Assuming an example device driver that implements an ``operation`` API call, the
 *get* and *put* operations could be carried out as follows:
 

--- a/dts/bindings/base/pm.yaml
+++ b/dts/bindings/base/pm.yaml
@@ -24,3 +24,9 @@ properties:
 
       The device will be notified when the power domain it belongs to is either
       suspended or resumed.
+
+  zephyr,pm-device-runtime-auto:
+    type: boolean
+    description: |
+      Automatically configure the device for runtime power management after the
+      init function runs.

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -162,6 +162,20 @@ struct pm_device {
 #endif /* CONFIG_PM_DEVICE_POWER_DOMAIN */
 
 /**
+ * @brief Utility macro to initialize #pm_device flags
+ *
+ * @param node_id Devicetree node for the initialized device (can be invalid).
+ */
+#define Z_PM_DEVICE_FLAGS(node_id)				\
+	(COND_CODE_1(						\
+		 DT_NODE_EXISTS(node_id),			\
+		 ((DT_PROP_OR(node_id, wakeup_source, 0)	\
+			 << PM_DEVICE_FLAG_WS_CAPABLE) |	\
+		  (DT_NODE_HAS_COMPAT(node_id, power_domain) <<	\
+			 PM_DEVICE_FLAG_PD)),			\
+		 (0)))
+
+/**
  * @brief Utility macro to initialize #pm_device.
  *
  * @note #DT_PROP_OR is used to retrieve the wakeup_source property because
@@ -171,18 +185,13 @@ struct pm_device {
  * @param node_id Devicetree node for the initialized device (can be invalid).
  * @param pm_action_cb Device PM control callback function.
  */
-#define Z_PM_DEVICE_INIT(obj, node_id, pm_action_cb)			\
-	{								\
-		Z_PM_DEVICE_RUNTIME_INIT(obj)				\
-		.action_cb = pm_action_cb,				\
-		.state = PM_DEVICE_STATE_ACTIVE,			\
-		.flags = ATOMIC_INIT(COND_CODE_1(			\
-				DT_NODE_EXISTS(node_id),		\
-				((DT_PROP_OR(node_id, wakeup_source, 0) \
-				  << PM_DEVICE_FLAG_WS_CAPABLE) |	\
-				 (DT_NODE_HAS_COMPAT(node_id, power_domain) << \
-				  PM_DEVICE_FLAG_PD)), (0))),		\
-		Z_PM_DEVICE_POWER_DOMAIN_INIT(node_id)			\
+#define Z_PM_DEVICE_INIT(obj, node_id, pm_action_cb)		  \
+	{							  \
+		Z_PM_DEVICE_RUNTIME_INIT(obj)			  \
+		.action_cb = pm_action_cb,			  \
+		.state = PM_DEVICE_STATE_ACTIVE,		  \
+		.flags = ATOMIC_INIT(Z_PM_DEVICE_FLAGS(node_id)), \
+		Z_PM_DEVICE_POWER_DOMAIN_INIT(node_id)		  \
 	}
 
 /**

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -43,8 +43,10 @@ enum pm_device_flag {
 	PM_DEVICE_FLAG_RUNTIME_ENABLED,
 	/** Indicates if the device pm is locked.  */
 	PM_DEVICE_FLAG_STATE_LOCKED,
-	/** Indicateds if the device is used as a power domain */
+	/** Indicates if the device is used as a power domain */
 	PM_DEVICE_FLAG_PD,
+	/** Indicates if device runtime PM should be automatically enabled */
+	PM_DEVICE_FLAG_RUNTIME_AUTO,
 };
 
 /** @endcond */
@@ -166,13 +168,15 @@ struct pm_device {
  *
  * @param node_id Devicetree node for the initialized device (can be invalid).
  */
-#define Z_PM_DEVICE_FLAGS(node_id)				\
-	(COND_CODE_1(						\
-		 DT_NODE_EXISTS(node_id),			\
-		 ((DT_PROP_OR(node_id, wakeup_source, 0)	\
-			 << PM_DEVICE_FLAG_WS_CAPABLE) |	\
-		  (DT_NODE_HAS_COMPAT(node_id, power_domain) <<	\
-			 PM_DEVICE_FLAG_PD)),			\
+#define Z_PM_DEVICE_FLAGS(node_id)					 \
+	(COND_CODE_1(							 \
+		 DT_NODE_EXISTS(node_id),				 \
+		 ((DT_PROP_OR(node_id, wakeup_source, 0)		 \
+			 << PM_DEVICE_FLAG_WS_CAPABLE) |		 \
+		  (DT_PROP_OR(node_id, zephyr_pm_device_runtime_auto, 0) \
+			 << PM_DEVICE_FLAG_RUNTIME_AUTO) |		 \
+		  (DT_NODE_HAS_COMPAT(node_id, power_domain) <<		 \
+			 PM_DEVICE_FLAG_PD)),				 \
 		 (0)))
 
 /**

--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -23,6 +23,20 @@ extern "C" {
 
 #if defined(CONFIG_PM_DEVICE_RUNTIME) || defined(__DOXYGEN__)
 /**
+ * @brief Automatically enable device runtime based on devicetree properties
+ *
+ * @note Must not be called from application code. See the
+ * zephyr,pm-device-runtime-auto property in pm.yaml and z_sys_init_run_level.
+ *
+ * @param dev Device instance.
+ *
+ * @retval 0 If the device runtime PM is enabled successfully or it has not
+ * been requested for this device in devicetree.
+ * @retval -errno Other negative errno, result of enabled device runtime PM.
+ */
+int pm_device_runtime_auto_enable(const struct device *dev);
+
+/**
  * @brief Enable device runtime PM
  *
  * This function will enable runtime PM on the given device. If the device is
@@ -144,6 +158,12 @@ int pm_device_runtime_put_async(const struct device *dev);
 bool pm_device_runtime_is_enabled(const struct device *dev);
 
 #else
+
+static inline int pm_device_runtime_auto_enable(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	return 0;
+}
 
 static inline int pm_device_runtime_enable(const struct device *dev)
 {

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -34,6 +34,7 @@
 #include <kswap.h>
 #include <zephyr/timing/timing.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device_runtime.h>
 LOG_MODULE_REGISTER(os, CONFIG_KERNEL_LOG_LEVEL);
 
 /* the only struct z_kernel instance */
@@ -261,6 +262,10 @@ static void z_sys_init_run_level(enum init_level level)
 				dev->state->init_res = rc;
 			}
 			dev->state->initialized = true;
+			if (rc == 0) {
+				/* Run automatic device runtime enablement */
+				(void)pm_device_runtime_auto_enable(dev);
+			}
 		}
 	}
 }

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -239,6 +239,17 @@ int pm_device_runtime_put_async(const struct device *dev)
 	return ret;
 }
 
+int pm_device_runtime_auto_enable(const struct device *dev)
+{
+	struct pm_device *pm = dev->pm;
+
+	/* No action needed if PM_DEVICE_FLAG_RUNTIME_AUTO is not enabled */
+	if (!pm || !atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_AUTO)) {
+		return 0;
+	}
+	return pm_device_runtime_enable(dev);
+}
+
 int pm_device_runtime_enable(const struct device *dev)
 {
 	int ret = 0;

--- a/tests/subsys/pm/device_runtime_api/app.overlay
+++ b/tests/subsys/pm/device_runtime_api/app.overlay
@@ -1,0 +1,7 @@
+/ {
+	test_dev: test_dev {
+		compatible = "test-device-pm";
+		status = "okay";
+		zephyr,pm-device-runtime-auto;
+	};
+};

--- a/tests/subsys/pm/device_runtime_api/dts/bindings/test-device-pm.yaml
+++ b/tests/subsys/pm/device_runtime_api/dts/bindings/test-device-pm.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2023, CSIRO
+# SPDX-License-Identifier: Apache-2.0
+
+include: [base.yaml, pm.yaml]
+
+description: |
+  This binding provides resources required to build and run the
+  tests/subsys/pm/device_runtime_api test in Zephyr.
+
+compatible: "test-device-pm"

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -236,6 +236,32 @@ ZTEST(device_runtime_api, test_unsupported)
 	zassert_equal(pm_device_runtime_put(dev), -ENOTSUP, "");
 }
 
+static int dev_init(const struct device *dev)
+{
+	return 0;
+}
+
+int dev_pm_control(const struct device *dev, enum pm_device_action action)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(action);
+
+	return 0;
+}
+
+PM_DEVICE_DT_DEFINE(DT_NODELABEL(test_dev), dev_pm_control);
+DEVICE_DT_DEFINE(DT_NODELABEL(test_dev), dev_init, PM_DEVICE_DT_GET(DT_NODELABEL(test_dev)),
+		 NULL, NULL, POST_KERNEL, 80, NULL);
+
+ZTEST(device_runtime_api, test_pm_device_runtime_auto)
+{
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(test_dev));
+
+	zassert_true(pm_device_runtime_is_enabled(dev), "");
+	zassert_equal(pm_device_runtime_get(dev), 0, "");
+	zassert_equal(pm_device_runtime_put(dev), 0, "");
+}
+
 void *device_runtime_api_setup(void)
 {
 	dev = device_get_binding("test_driver");


### PR DESCRIPTION
Add the option to automatically enable PM device runtime on a device from devicetree. Devicetree is the only mechanism we have for per-instance configuration, which is why this route was chosen.

Absent this option, application code must be written to enable PM manually on devices, which cannot be done in a generic fashion.