### PR TITLE
driver: gpdma: balance the pm usage

### DIFF
--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -12,6 +12,7 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/drivers/dma.h>
+#include <zephyr/pm/device_runtime.h>
 #include <soc.h>
 #include "dma_dw_common.h"
 
@@ -508,6 +509,7 @@ int dw_dma_start(const struct device *dev, uint32_t channel)
 
 	/* enable the channel */
 	dw_write(dev_cfg->base, DW_DMA_CHAN_EN, DW_CHAN_UNMASK(channel));
+	ret = pm_device_runtime_get(dev);
 
 out:
 	return ret;
@@ -577,7 +579,7 @@ int dw_dma_stop(const struct device *dev, uint32_t channel)
 	}
 #endif
 	chan_data->state = DW_DMA_IDLE;
-
+	ret = pm_device_runtime_put(dev);
 out:
 	return ret;
 }


### PR DESCRIPTION
Because the DMA driver allows multiple start and stop calls for the same instance and the same channel, we cannot rely on the error codes returned by these functions to notify the device's power manager that a device is still in use.