### PR TITLE
mailmap: add two fixes for bad commits

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -33,3 +33,5 @@ Sean Nyekjaer <sean@geanix.com> <sean@nyekjaer.dk>
 Marc Herbert <marc.herbert@intel.com> <46978960+marc-hb@users.noreply.github.com>
 Martin Jäger <martin@libre.solar>  <17674105+martinjaeger@users.noreply.github.com>
 Armand Ciejak <armand@riedonetworks.com>  <armandciejak@users.noreply.github.com>
+Chunlin Han <chunlin.han@linaro.org> <chunlin.han@acer.com>
+chao an <anchao@xiaomi.com>


### PR DESCRIPTION
Make sure we count the same people once and show them as one
contributor.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
