### PR TITLE
intel_adsp: device power management

### DIFF
--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -882,8 +882,12 @@ static int dai_dmic_initialize_device(const struct device *dev)
 		dai_dmic_irq_handler,
 		DEVICE_DT_INST_GET(0),
 		0);
+	if (pm_device_on_power_domain(dev)) {
+		pm_device_init_off(dev);
+	} else {
+		pm_device_init_suspended(dev);
+	}
 
-	pm_device_init_suspended(dev);
 	return pm_device_runtime_enable(dev);
 };
 

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -2144,11 +2144,13 @@ static int ssp_pm_action(const struct device *dev, enum pm_device_action action)
 
 static int ssp_init(const struct device *dev)
 {
-	int ret;
+	if (pm_device_on_power_domain(dev)) {
+		pm_device_init_off(dev);
+	} else {
+		pm_device_init_suspended(dev);
+	}
 
-	pm_device_init_suspended(dev);
-	ret = pm_device_runtime_enable(dev);
-	return ret;
+	return pm_device_runtime_enable(dev);
 }
 
 static struct dai_driver_api dai_intel_ssp_api_funcs = {


### PR DESCRIPTION
Setting the DMIC and SSP devices into OFF state after initialization as this more closely matches the actual state of the device.