### PR TITLE
Counter support for STM32H7 series and stm32h735g_disco board

### DIFF
--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.yaml
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.yaml
@@ -14,3 +14,4 @@ supported:
   - netif:eth
   - memc
   - adc
+  - counter

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -528,6 +528,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers3: timers@40000400 {
@@ -544,6 +549,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -562,6 +572,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers5: timers@40000c00 {
@@ -578,6 +593,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -635,6 +655,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers13: timers@40001c00 {
@@ -651,6 +676,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -669,6 +699,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers15: timers@40014000 {
@@ -685,6 +720,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -703,6 +743,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers17: timers@40014800 {
@@ -719,6 +764,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/samples/drivers/counter/alarm/boards/stm32h735g_disco.overlay
+++ b/samples/drivers/counter/alarm/boards/stm32h735g_disco.overlay
@@ -1,0 +1,6 @@
+&timers2 {
+	st,prescaler = <83>;
+	counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -9,7 +9,7 @@ tests:
                         bl5340_dvk_cpuapp gd32e103v_eval gd32e507z_eval
                         gd32f403z_eval gd32f450i_eval gd32f450z_eval
                         gd32e507v_start gd32f407v_start gd32f450v_start
-                        gd32f470i_eval
+                        gd32f470i_eval stm32h735g_disco
     integration_platforms:
       - nucleo_f746zg
     harness_config:

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -23,6 +23,8 @@ struct counter_alarm_cfg alarm_cfg;
 #define TIMER DT_NODELABEL(extrtc0)
 #elif defined(CONFIG_COUNTER_RTC0)
 #define TIMER DT_NODELABEL(rtc0)
+#elif defined(CONFIG_COUNTER_TIMER_STM32)
+#define TIMER DT_INST(0, st_stm32_counter)
 #elif defined(CONFIG_COUNTER_RTC_STM32)
 #define TIMER DT_INST(0, st_stm32_rtc)
 #elif defined(CONFIG_COUNTER_NATIVE_POSIX)

--- a/tests/drivers/counter/counter_basic_api/boards/stm32h735g_disco.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/stm32h735g_disco.overlay
@@ -1,0 +1,10 @@
+&timers2 {
+	st,prescaler = <83>;
+	counter {
+		status = "okay";
+	};
+};
+
+&rtc {
+	status = "disabled";
+};


### PR DESCRIPTION
This PR adds counter support for the STM32H7 series and the stm32h735g_disco board.

This PR is very similar to https://github.com/zephyrproject-rtos/zephyr/pull/47574 which added support for the STM32L4 series.
Like that PR, there are no changes to the previously implemented driver for the STM32F4 series (see https://github.com/zephyrproject-rtos/zephyr/pull/39414).

This PR includes:

- Device tree additions to enable H7 series to use the counter API and the existing STM32 counter driver
- Test extensions to run the counter_basic_api testsuite on the stm32h735g_disco board
- Sample extensions to run the counter alarm sample on the stm32h735g_disco board