### PR TITLE
armclang: handle cases when build c++ code but file extension is .c

### DIFF
--- a/cmake/compiler/armclang/target.cmake
+++ b/cmake/compiler/armclang/target.cmake
@@ -64,3 +64,7 @@ if(CONFIG_ARMCLANG_STD_LIBC)
   # library, for example error numbers, errno.h.
   list(APPEND TOOLCHAIN_C_FLAGS -D_AEABI_PORTABILITY_LEVEL=1)
 endif()
+
+if(CONFIG_CPP)
+  list(APPEND EXTRA_CXXFLAGS "-xc++")
+endif()


### PR DESCRIPTION
We have some tests cases like tests/subsys/logging/log_api that build the same .c files as C or C++ for testing purposes.  In those cases the testcases do something like:

  set_source_files_properties(main.c PROPERTIES LANGUAGE CXX)

Since the arm compiler is a single binary for C or C++ and normally uses the file extension to determine C or C++ add an explicit setting of -xc++ for when we are utilizing as a C++ compiler.  This fixes any issues with filenames not being what the compiler expects.