### PR TITLE
linker: Fix handling of _static_thread_data section

### DIFF
--- a/cmake/linker_script/common/common-ram.cmake
+++ b/cmake/linker_script/common/common-ram.cmake
@@ -35,8 +35,6 @@ zephyr_linker_section_configure(SECTION initshell
 zephyr_linker_section(NAME log_dynamic GROUP DATA_REGION NOINPUT)
 zephyr_linker_section_configure(SECTION log_dynamic KEEP INPUT ".log_dynamic_*")
 
-zephyr_iterable_section(NAME _static_thread_data GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
-
 if(CONFIG_USERSPACE)
   # All kernel objects within are assumed to be either completely
   # initialized at build time, or initialized automatically at runtime

--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -191,3 +191,5 @@ zephyr_linker_section_configure(SECTION zephyr_dbg_info INPUT ".zephyr_dbg_info"
 zephyr_linker_section(NAME device_handles KVMA RAM_REGION GROUP RODATA_REGION NOINPUT ${XIP_ALIGN_WITH_INPUT} ENDALIGN 16)
 zephyr_linker_section_configure(SECTION device_handles INPUT .__device_handles_pass1* KEEP SORT NAME PASS LINKER_DEVICE_HANDLES_PASS1)
 zephyr_linker_section_configure(SECTION device_handles INPUT .__device_handles_pass2* KEEP SORT NAME PASS NOT LINKER_DEVICE_HANDLES_PASS1)
+
+zephyr_iterable_section(NAME _static_thread_data KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)


### PR DESCRIPTION
_static_thread_data should be in ROM as its static data.  So move it from common-ram.cmake to common-rom.cmake and fix it the params we call zephyr_iterable_section with.