### PR TITLE
ci: Switch to CI image v0.25.1

### DIFF
--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -21,7 +21,7 @@ jobs:
     if: github.repository_owner == 'zephyrproject-rtos'
     runs-on: zephyr-runner-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.25.0
+      image: ghcr.io/zephyrproject-rtos/ci:v0.25.1
       options: '--entrypoint /bin/bash'
       volumes:
         - /repo-cache/zephyrproject:/github/cache/zephyrproject

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository_owner == 'zephyrproject-rtos'
     runs-on: zephyr-runner-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.25.0
+      image: ghcr.io/zephyrproject-rtos/ci:v0.25.1
       options: '--entrypoint /bin/bash'
       volumes:
         - /repo-cache/zephyrproject:/github/cache/zephyrproject

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     runs-on: zephyr-runner-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.25.0
+      image: ghcr.io/zephyrproject-rtos/ci:v0.25.1
       options: '--entrypoint /bin/bash'
       volumes:
         - /repo-cache/zephyrproject:/github/cache/zephyrproject

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -22,7 +22,7 @@ jobs:
     if: github.repository_owner == 'zephyrproject-rtos'
     runs-on: zephyr-runner-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.25.0
+      image: ghcr.io/zephyrproject-rtos/ci:v0.25.1
       options: '--entrypoint /bin/bash'
       volumes:
         - /repo-cache/zephyrproject:/github/cache/zephyrproject
@@ -120,7 +120,7 @@ jobs:
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.25.0
+      image: ghcr.io/zephyrproject-rtos/ci:v0.25.1
       options: '--entrypoint /bin/bash'
       volumes:
         - /repo-cache/zephyrproject:/github/cache/zephyrproject


### PR DESCRIPTION
Which includes the latest babblesim (v2.0.1)
which is required to enable 802.15.4

This one affects several workflows, so I guess will need to be spun in the zephyr-testing repo with @stephanosio  help