### PR TITLE
drivers: sbs_gauge: Add support for AtRate properties

### DIFF
--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -95,9 +95,9 @@ static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_pr
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_VOLTAGE, &val);
 		prop->value.voltage = val * 1000;
 		break;
-	case FUEL_GAUGE_MODE:
+	case FUEL_GAUGE_SBS_MODE:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_BATTERY_MODE, &val);
-		prop->value.mode = val;
+		prop->value.sbs_mode = val;
 		break;
 	case FUEL_GAUGE_CHARGE_CURRENT:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CHG_CURRENT, &val);
@@ -119,21 +119,21 @@ static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_pr
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_DESIGN_VOLTAGE, &val);
 		prop->value.design_volt = val;
 		break;
-	case FUEL_GAUGE_ATRATE:
+	case FUEL_GAUGE_SBS_ATRATE:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AR, &val);
-		prop->value.at_rate = val;
+		prop->value.sbs_at_rate = val;
 		break;
-	case FUEL_GAUGE_ATRATE_TIME_TO_FULL:
+	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ARTTF, &val);
-		prop->value.at_rate_time_to_full = val;
+		prop->value.sbs_at_rate_time_to_full = val;
 		break;
-	case FUEL_GAUGE_ATRATE_TIME_TO_EMPTY:
+	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ARTTE, &val);
-		prop->value.at_rate_time_to_empty = val;
+		prop->value.sbs_at_rate_time_to_empty = val;
 		break;
-	case FUEL_GAUGE_ATRATE_OK:
+	case FUEL_GAUGE_SBS_ATRATE_OK:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AROK, &val);
-		prop->value.at_rate_ok = val;
+		prop->value.sbs_at_rate_ok = val;
 		break;
 
 	default:
@@ -157,13 +157,13 @@ static int sbs_gauge_set_prop(const struct device *dev, struct fuel_gauge_set_pr
 				       prop->value.sbs_mfr_access_word);
 		prop->value.sbs_mfr_access_word = val;
 		break;
-	case FUEL_GAUGE_MODE:
-		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_BATTERY_MODE, prop->value.mode);
-		prop->value.mode = val;
+	case FUEL_GAUGE_SBS_MODE:
+		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_BATTERY_MODE, prop->value.sbs_mode);
+		prop->value.sbs_mode = val;
 		break;
-	case FUEL_GAUGE_ATRATE:
-		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_AR, prop->value.at_rate);
-		prop->value.at_rate = val;
+	case FUEL_GAUGE_SBS_ATRATE:
+		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_AR, prop->value.sbs_at_rate);
+		prop->value.sbs_at_rate = val;
 		break;
 
 	default:

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -119,6 +119,22 @@ static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_pr
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_DESIGN_VOLTAGE, &val);
 		prop->value.design_volt = val;
 		break;
+	case FUEL_GAUGE_ATRATE:
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AR, &val);
+		prop->value.at_rate = val;
+		break;
+	case FUEL_GAUGE_ATRATE_TIME_TO_FULL:
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ARTTF, &val);
+		prop->value.at_rate_time_to_full = val;
+		break;
+	case FUEL_GAUGE_ATRATE_TIME_TO_EMPTY:
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ARTTE, &val);
+		prop->value.at_rate_time_to_empty = val;
+		break;
+	case FUEL_GAUGE_ATRATE_OK:
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AROK, &val);
+		prop->value.at_rate_ok = val;
+		break;
 
 	default:
 		rc = -ENOTSUP;
@@ -141,6 +157,15 @@ static int sbs_gauge_set_prop(const struct device *dev, struct fuel_gauge_set_pr
 				       prop->value.sbs_mfr_access_word);
 		prop->value.sbs_mfr_access_word = val;
 		break;
+	case FUEL_GAUGE_MODE:
+		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_BATTERY_MODE, prop->value.mode);
+		prop->value.mode = val;
+		break;
+	case FUEL_GAUGE_ATRATE:
+		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_AR, prop->value.at_rate);
+		prop->value.at_rate = val;
+		break;
+
 	default:
 		rc = -ENOTSUP;
 	}

--- a/drivers/sensor/sbs_gauge/emul_sbs_gauge.c
+++ b/drivers/sensor/sbs_gauge/emul_sbs_gauge.c
@@ -26,6 +26,8 @@ LOG_MODULE_REGISTER(sbs_sbs_gauge);
 /** Run-time data used by the emulator */
 struct sbs_gauge_emul_data {
 	uint16_t mfr_acc;
+	uint16_t mode;
+	int16_t at_rate;
 };
 
 /** Static configuration for the emulator */
@@ -42,6 +44,12 @@ static int emul_sbs_gauge_reg_write(const struct emul *target, int reg, int val)
 	switch (reg) {
 	case SBS_GAUGE_CMD_MANUFACTURER_ACCESS:
 		data->mfr_acc = val;
+		break;
+	case SBS_GAUGE_CMD_BATTERY_MODE:
+		data->mode = val;
+		break;
+	case SBS_GAUGE_CMD_AR:
+		data->at_rate = val;
 		break;
 	default:
 		LOG_INF("Unknown write %x", reg);
@@ -76,6 +84,10 @@ static int emul_sbs_gauge_reg_read(const struct emul *target, int reg, int *val)
 	case SBS_GAUGE_CMD_CHG_CURRENT:
 	case SBS_GAUGE_CMD_CHG_VOLTAGE:
 	case SBS_GAUGE_CMD_FLAGS:
+	case SBS_GAUGE_CMD_AR:
+	case SBS_GAUGE_CMD_ARTTF:
+	case SBS_GAUGE_CMD_ARTTE:
+	case SBS_GAUGE_CMD_AROK:
 		/* Arbitrary stub value. */
 		*val = 1;
 		break;

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -37,45 +37,45 @@ extern "C" {
 #define FUEL_GAUGE_AVG_CURRENT 0
 
 /** Battery current (uA); negative=discharging */
-#define FUEL_GAUGE_CURRENT		FUEL_GAUGE_AVG_CURRENT + 1
+#define FUEL_GAUGE_CURRENT		    FUEL_GAUGE_AVG_CURRENT + 1
 /** Whether the battery underlying the fuel-gauge is cut off from charge */
-#define FUEL_GAUGE_CHARGE_CUTOFF	FUEL_GAUGE_CURRENT + 1
+#define FUEL_GAUGE_CHARGE_CUTOFF	    FUEL_GAUGE_CURRENT + 1
 /** Cycle count in 1/100ths (number of charge/discharge cycles) */
-#define FUEL_GAUGE_CYCLE_COUNT		FUEL_GAUGE_CHARGE_CUTOFF + 1
+#define FUEL_GAUGE_CYCLE_COUNT		    FUEL_GAUGE_CHARGE_CUTOFF + 1
 /** Connect state of battery */
-#define FUEL_GAUGE_CONNECT_STATE	FUEL_GAUGE_CYCLE_COUNT + 1
+#define FUEL_GAUGE_CONNECT_STATE	    FUEL_GAUGE_CYCLE_COUNT + 1
 /** General Error/Runtime Flags */
-#define FUEL_GAUGE_FLAGS		FUEL_GAUGE_CONNECT_STATE + 1
+#define FUEL_GAUGE_FLAGS		    FUEL_GAUGE_CONNECT_STATE + 1
 /** Full Charge Capacity in uAh (might change in some implementations to determine wear) */
-#define FUEL_GAUGE_FULL_CHARGE_CAPACITY FUEL_GAUGE_FLAGS + 1
+#define FUEL_GAUGE_FULL_CHARGE_CAPACITY	    FUEL_GAUGE_FLAGS + 1
 /** Is the battery physically present */
-#define FUEL_GAUGE_PRESENT_STATE	FUEL_GAUGE_FULL_CHARGE_CAPACITY + 1
+#define FUEL_GAUGE_PRESENT_STATE	    FUEL_GAUGE_FULL_CHARGE_CAPACITY + 1
 /** Remaining capacity in uAh */
-#define FUEL_GAUGE_REMAINING_CAPACITY	FUEL_GAUGE_PRESENT_STATE + 1
+#define FUEL_GAUGE_REMAINING_CAPACITY	    FUEL_GAUGE_PRESENT_STATE + 1
 /** Remaining battery life time in minutes */
-#define FUEL_GAUGE_RUNTIME_TO_EMPTY	FUEL_GAUGE_REMAINING_CAPACITY + 1
+#define FUEL_GAUGE_RUNTIME_TO_EMPTY	    FUEL_GAUGE_REMAINING_CAPACITY + 1
 /** Remaining time in minutes until battery reaches full charge */
-#define FUEL_GAUGE_RUNTIME_TO_FULL	FUEL_GAUGE_RUNTIME_TO_EMPTY + 1
+#define FUEL_GAUGE_RUNTIME_TO_FULL	    FUEL_GAUGE_RUNTIME_TO_EMPTY + 1
 /** Retrieve word from SBS1.1 ManufactuerAccess */
-#define FUEL_GAUGE_SBS_MFR_ACCESS	FUEL_GAUGE_RUNTIME_TO_FULL + 1
+#define FUEL_GAUGE_SBS_MFR_ACCESS	    FUEL_GAUGE_RUNTIME_TO_FULL + 1
 /** Absolute state of charge (percent, 0-100) - expressed as % of design capacity */
-#define FUEL_GAUGE_STATE_OF_CHARGE	FUEL_GAUGE_SBS_MFR_ACCESS + 1
+#define FUEL_GAUGE_STATE_OF_CHARGE	    FUEL_GAUGE_SBS_MFR_ACCESS + 1
 /** Temperature in 0.1 K */
-#define FUEL_GAUGE_TEMPERATURE		FUEL_GAUGE_STATE_OF_CHARGE + 1
+#define FUEL_GAUGE_TEMPERATURE		    FUEL_GAUGE_STATE_OF_CHARGE + 1
 /** Battery voltage (uV) */
-#define FUEL_GAUGE_VOLTAGE		FUEL_GAUGE_TEMPERATURE + 1
+#define FUEL_GAUGE_VOLTAGE		    FUEL_GAUGE_TEMPERATURE + 1
 /** Battery Mode (flags) */
-#define FUEL_GAUGE_SBS_MODE			FUEL_GAUGE_VOLTAGE + 1
+#define FUEL_GAUGE_SBS_MODE		    FUEL_GAUGE_VOLTAGE + 1
 /** Battery desired Max Charging Current (mA) */
-#define FUEL_GAUGE_CHARGE_CURRENT	FUEL_GAUGE_SBS_MODE + 1
+#define FUEL_GAUGE_CHARGE_CURRENT	    FUEL_GAUGE_SBS_MODE + 1
 /** Battery desired Max Charging Voltage (mV) */
-#define FUEL_GAUGE_CHARGE_VOLTAGE	FUEL_GAUGE_CHARGE_CURRENT + 1
+#define FUEL_GAUGE_CHARGE_VOLTAGE	    FUEL_GAUGE_CHARGE_CURRENT + 1
 /** Alarm, Status and Error codes (flags) */
-#define FUEL_GAUGE_STATUS		FUEL_GAUGE_CHARGE_VOLTAGE + 1
+#define FUEL_GAUGE_STATUS		    FUEL_GAUGE_CHARGE_VOLTAGE + 1
 /** Design Capacity (mAh or 10mWh) */
-#define FUEL_GAUGE_DESIGN_CAPACITY	FUEL_GAUGE_STATUS + 1
+#define FUEL_GAUGE_DESIGN_CAPACITY	    FUEL_GAUGE_STATUS + 1
 /** Design Voltage (mV) */
-#define FUEL_GAUGE_DESIGN_VOLTAGE	FUEL_GAUGE_DESIGN_CAPACITY + 1
+#define FUEL_GAUGE_DESIGN_VOLTAGE	    FUEL_GAUGE_DESIGN_CAPACITY + 1
 /** AtRate (mA or 10 mW) */
 #define FUEL_GAUGE_SBS_ATRATE		    FUEL_GAUGE_DESIGN_VOLTAGE + 1
 /** AtRateTimeToFull (minutes) */

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -76,6 +76,14 @@ extern "C" {
 #define FUEL_GAUGE_DESIGN_CAPACITY	FUEL_GAUGE_STATUS + 1
 /** Design Voltage (mV) */
 #define FUEL_GAUGE_DESIGN_VOLTAGE	FUEL_GAUGE_DESIGN_CAPACITY + 1
+/** AtRate (mA or 10 mW) */
+#define FUEL_GAUGE_ATRATE		    FUEL_GAUGE_DESIGN_VOLTAGE + 1
+/** AtRateTimeToFull (minutes) */
+#define FUEL_GAUGE_ATRATE_TIME_TO_FULL  FUEL_GAUGE_ATRATE + 1
+/** AtRateTimeToEmpty (minutes) */
+#define FUEL_GAUGE_ATRATE_TIME_TO_EMPTY FUEL_GAUGE_ATRATE_TIME_TO_FULL + 1
+/** AtRateOK (boolean) */
+#define FUEL_GAUGE_ATRATE_OK	    FUEL_GAUGE_ATRATE_TIME_TO_EMPTY + 1
 
 /** Reserved to demark end of common fuel gauge properties */
 #define FUEL_GAUGE_COMMON_COUNT FUEL_GAUGE_DESIGN_VOLTAGE + 1
@@ -104,7 +112,7 @@ struct fuel_gauge_get_property {
 		/* Dynamic Battery Info */
 		/** FUEL_GAUGE_AVG_CURRENT */
 		int avg_current;
-		/** FUEL_GAUGE_CUTOFF */
+		/** FUEL_GAUGE_CHARGE_CUTOFF */
 		bool cutoff;
 		/** FUEL_GAUGE_CURRENT */
 		int current;
@@ -140,6 +148,14 @@ struct fuel_gauge_get_property {
 		uint16_t design_cap;
 		/** FUEL_GAUGE_DESIGN_VOLTAGE */
 		uint16_t design_volt;
+		/** FUEL_GAUGE_ATRATE */
+		int16_t at_rate;
+		/** FUEL_GAUGE_ATRATE_TIME_TO_FULL */
+		uint16_t at_rate_time_to_full;
+		/** FUEL_GAUGE_ATRATE_TIME_TO_EMPTY	*/
+		uint16_t at_rate_time_to_empty;
+		/** FUEL_GAUGE_ATRATE_OK */
+		bool at_rate_ok;
 	} value;
 };
 
@@ -159,6 +175,10 @@ struct fuel_gauge_set_property {
 		/* Writable Dynamic Battery Info */
 		/** FUEL_GAUGE_SBS_MFR_ACCESS */
 		uint16_t sbs_mfr_access_word;
+		/** FUEL_GAUGE_MODE */
+		uint16_t mode;
+		/** FUEL_GAUGE_ATRATE */
+		int16_t at_rate;
 	} value;
 };
 

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -65,9 +65,9 @@ extern "C" {
 /** Battery voltage (uV) */
 #define FUEL_GAUGE_VOLTAGE		FUEL_GAUGE_TEMPERATURE + 1
 /** Battery Mode (flags) */
-#define FUEL_GAUGE_MODE			FUEL_GAUGE_VOLTAGE + 1
+#define FUEL_GAUGE_SBS_MODE			FUEL_GAUGE_VOLTAGE + 1
 /** Battery desired Max Charging Current (mA) */
-#define FUEL_GAUGE_CHARGE_CURRENT	FUEL_GAUGE_MODE + 1
+#define FUEL_GAUGE_CHARGE_CURRENT	FUEL_GAUGE_SBS_MODE + 1
 /** Battery desired Max Charging Voltage (mV) */
 #define FUEL_GAUGE_CHARGE_VOLTAGE	FUEL_GAUGE_CHARGE_CURRENT + 1
 /** Alarm, Status and Error codes (flags) */
@@ -77,13 +77,13 @@ extern "C" {
 /** Design Voltage (mV) */
 #define FUEL_GAUGE_DESIGN_VOLTAGE	FUEL_GAUGE_DESIGN_CAPACITY + 1
 /** AtRate (mA or 10 mW) */
-#define FUEL_GAUGE_ATRATE		    FUEL_GAUGE_DESIGN_VOLTAGE + 1
+#define FUEL_GAUGE_SBS_ATRATE		    FUEL_GAUGE_DESIGN_VOLTAGE + 1
 /** AtRateTimeToFull (minutes) */
-#define FUEL_GAUGE_ATRATE_TIME_TO_FULL  FUEL_GAUGE_ATRATE + 1
+#define FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL  FUEL_GAUGE_SBS_ATRATE + 1
 /** AtRateTimeToEmpty (minutes) */
-#define FUEL_GAUGE_ATRATE_TIME_TO_EMPTY FUEL_GAUGE_ATRATE_TIME_TO_FULL + 1
+#define FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL + 1
 /** AtRateOK (boolean) */
-#define FUEL_GAUGE_ATRATE_OK	    FUEL_GAUGE_ATRATE_TIME_TO_EMPTY + 1
+#define FUEL_GAUGE_SBS_ATRATE_OK	    FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY + 1
 
 /** Reserved to demark end of common fuel gauge properties */
 #define FUEL_GAUGE_COMMON_COUNT FUEL_GAUGE_DESIGN_VOLTAGE + 1
@@ -136,8 +136,8 @@ struct fuel_gauge_get_property {
 		uint16_t temperature;
 		/** FUEL_GAUGE_VOLTAGE */
 		int voltage;
-		/** FUEL_GAUGE_MODE */
-		uint16_t mode;
+		/** FUEL_GAUGE_SBS_MODE */
+		uint16_t sbs_mode;
 		/** FUEL_GAUGE_CHARGE_CURRENT */
 		uint16_t chg_current;
 		/** FUEL_GAUGE_CHARGE_VOLTAGE */
@@ -148,14 +148,14 @@ struct fuel_gauge_get_property {
 		uint16_t design_cap;
 		/** FUEL_GAUGE_DESIGN_VOLTAGE */
 		uint16_t design_volt;
-		/** FUEL_GAUGE_ATRATE */
-		int16_t at_rate;
-		/** FUEL_GAUGE_ATRATE_TIME_TO_FULL */
-		uint16_t at_rate_time_to_full;
-		/** FUEL_GAUGE_ATRATE_TIME_TO_EMPTY	*/
-		uint16_t at_rate_time_to_empty;
-		/** FUEL_GAUGE_ATRATE_OK */
-		bool at_rate_ok;
+		/** FUEL_GAUGE_SBS_ATRATE */
+		int16_t sbs_at_rate;
+		/** FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL */
+		uint16_t sbs_at_rate_time_to_full;
+		/** FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY	*/
+		uint16_t sbs_at_rate_time_to_empty;
+		/** FUEL_GAUGE_SBS_ATRATE_OK */
+		bool sbs_at_rate_ok;
 	} value;
 };
 
@@ -175,10 +175,10 @@ struct fuel_gauge_set_property {
 		/* Writable Dynamic Battery Info */
 		/** FUEL_GAUGE_SBS_MFR_ACCESS */
 		uint16_t sbs_mfr_access_word;
-		/** FUEL_GAUGE_MODE */
-		uint16_t mode;
-		/** FUEL_GAUGE_ATRATE */
-		int16_t at_rate;
+		/** FUEL_GAUGE_SBS_MODE */
+		uint16_t sbs_mode;
+		/** FUEL_GAUGE_SBS_ATRATE */
+		int16_t sbs_at_rate;
 	} value;
 };
 

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -192,7 +192,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_props__returns_ok)
 			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
 		},
 		{
-			.property_type = FUEL_GAUGE_MODE,
+			.property_type = FUEL_GAUGE_SBS_MODE,
 		},
 		{
 			.property_type = FUEL_GAUGE_CHARGE_CURRENT,
@@ -210,16 +210,16 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_props__returns_ok)
 			.property_type = FUEL_GAUGE_DESIGN_VOLTAGE,
 		},
 		{
-			.property_type = FUEL_GAUGE_ATRATE,
+			.property_type = FUEL_GAUGE_SBS_ATRATE,
 		},
 		{
-			.property_type = FUEL_GAUGE_ATRATE_TIME_TO_FULL,
+			.property_type = FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL,
 		},
 		{
-			.property_type = FUEL_GAUGE_ATRATE_TIME_TO_EMPTY,
+			.property_type = FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY,
 		},
 		{
-			.property_type = FUEL_GAUGE_ATRATE_OK,
+			.property_type = FUEL_GAUGE_SBS_ATRATE_OK,
 		},
 	};
 
@@ -242,10 +242,10 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_props__returns_ok)
 			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
 		},
 		{
-			.property_type = FUEL_GAUGE_MODE,
+			.property_type = FUEL_GAUGE_SBS_MODE,
 		},
 		{
-			.property_type = FUEL_GAUGE_ATRATE,
+			.property_type = FUEL_GAUGE_SBS_ATRATE,
 		},
 	};
 

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -209,6 +209,18 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_props__returns_ok)
 		{
 			.property_type = FUEL_GAUGE_DESIGN_VOLTAGE,
 		},
+		{
+			.property_type = FUEL_GAUGE_ATRATE,
+		},
+		{
+			.property_type = FUEL_GAUGE_ATRATE_TIME_TO_FULL,
+		},
+		{
+			.property_type = FUEL_GAUGE_ATRATE_TIME_TO_EMPTY,
+		},
+		{
+			.property_type = FUEL_GAUGE_ATRATE_OK,
+		},
 	};
 
 	int ret = fuel_gauge_get_prop(fixture->dev, props, ARRAY_SIZE(props));
@@ -228,6 +240,12 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_props__returns_ok)
 	struct fuel_gauge_set_property props[] = {
 		{
 			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
+		},
+		{
+			.property_type = FUEL_GAUGE_MODE,
+		},
+		{
+			.property_type = FUEL_GAUGE_ATRATE,
 		},
 	};
 


### PR DESCRIPTION
BatteryMode(w), AtRate(r/w), AtRateTimeToFull(r), AtRateTimeToEmpty(r) and AtRateOK(r)