### PR TITLE
Add Watchdog support on STM32C0-series

### DIFF
--- a/boards/arm/nucleo_c031c6/doc/index.rst
+++ b/boards/arm/nucleo_c031c6/doc/index.rst
@@ -76,6 +76,10 @@ The Zephyr nucleo_c031c6 board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | RTC       | on-chip    | counter                             |
 +-----------+------------+-------------------------------------+
+| IWDG      | on-chip    | independent watchdog                |
++-----------+------------+-------------------------------------+
+| WWDG      | on-chip    | window watchdog                     |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 

--- a/boards/arm/nucleo_c031c6/nucleo_c031c6.dts
+++ b/boards/arm/nucleo_c031c6/nucleo_c031c6.dts
@@ -40,6 +40,7 @@
 	aliases {
 		led0 = &green_led_4;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 
@@ -75,5 +76,9 @@
 &rtc {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>,
 		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
+	status = "okay";
+};
+
+&iwdg {
 	status = "okay";
 };

--- a/boards/arm/nucleo_c031c6/nucleo_c031c6.yaml
+++ b/boards/arm/nucleo_c031c6/nucleo_c031c6.yaml
@@ -9,5 +9,6 @@ toolchain:
 supported:
   - gpio
   - counter
+  - watchdog
 ram: 12
 flash: 32

--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -92,7 +92,7 @@ static int iwdg_stm32_setup(const struct device *dev, uint8_t options)
 	if (options & WDT_OPT_PAUSE_HALTED_BY_DBG) {
 #if defined(CONFIG_SOC_SERIES_STM32F0X)
 		LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_DBGMCU);
-#elif defined(CONFIG_SOC_SERIES_STM32G0X)
+#elif defined(CONFIG_SOC_SERIES_STM32C0X) || defined(CONFIG_SOC_SERIES_STM32G0X)
 		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_DBGMCU);
 #elif defined(CONFIG_SOC_SERIES_STM32L0X)
 		LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_DBGMCU);

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -170,7 +170,7 @@ static int wwdg_stm32_setup(const struct device *dev, uint8_t options)
 		LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_DBGMCU);
 #elif defined(CONFIG_SOC_SERIES_STM32L0X)
 		LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_DBGMCU);
-#elif defined(CONFIG_SOC_SERIES_STM32G0X)
+#elif defined(CONFIG_SOC_SERIES_STM32C0X) || defined(CONFIG_SOC_SERIES_STM32G0X)
 		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_DBGMCU);
 #endif
 #if defined(CONFIG_SOC_SERIES_STM32H7X)

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -151,6 +151,20 @@
 			status = "disabled";
 		};
 
+		wwdg: watchdog@40002c00 {
+			compatible = "st,stm32-window-watchdog";
+			reg = <0x40002C00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000800>;
+			interrupts = <0 2>;
+			status = "disabled";
+		};
+
+		iwdg: watchdog@40003000 {
+			compatible = "st,stm32-watchdog";
+			reg = <0x40003000 0x400>;
+			status = "disabled";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -15,7 +15,7 @@ tests:
     platform_allow: nucleo_f091rc nucleo_f103rb nucleo_f207zg stm32f3_disco
         nucleo_f429zi nucleo_f746zg nucleo_g071rb nucleo_g474re nucleo_l073rz
         nucleo_l152re nucleo_l4r5zi stm32l562e_dk nucleo_wb55rg nucleo_wl55jc
-        b_u585i_iot02a nucleo_u575zi_q
+        b_u585i_iot02a nucleo_u575zi_q nucleo_c031c6
     integration_platforms:
       - nucleo_f091rc
   drivers.watchdog.stm32wwdg_h7:
@@ -28,7 +28,7 @@ tests:
     platform_allow: nucleo_f091rc nucleo_f103rb nucleo_f207zg stm32f3_disco
         nucleo_f429zi nucleo_f746zg nucleo_g071rb nucleo_g474re nucleo_l073rz
         nucleo_l152re nucleo_l4r5zi stm32l562e_dk nucleo_wb55rg nucleo_wl55jc
-        b_u585i_iot02a nucleo_u575zi_q nucleo_h753zi nucleo_h743zi
+        b_u585i_iot02a nucleo_u575zi_q nucleo_h753zi nucleo_h743zi nucleo_c031c6
     integration_platforms:
       - nucleo_f091rc
   drivers.watchdog.mec15xxevb_assy6853:


### PR DESCRIPTION
Adding watchdog support for STM32C0-series using Nucleo C031C6.

The functionality has been verified using:
- samples/drivers/watchdog/

and running twister on target with:
- tests/drivers/watchdog/wdt_basic_api/