### PR TITLE
ci: bluetooth worflow: Do not install parallel

### DIFF
--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -67,12 +67,6 @@ jobs:
           west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/zephyrproject)
           west forall -c 'git reset --hard HEAD'
 
-      - name: Install parallel
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y parallel
-          parallel --version
-
       - name: Run Bluetooth Tests with BSIM
         run: |
           export ZEPHYR_BASE=${PWD}


### PR DESCRIPTION
Parallel is already installed in the docker image. Let's save a few seconds in each CI run.