### PR TITLE
drivers: wifi: esp32: fix wifi receive callback

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -433,13 +433,12 @@ static void esp32_wifi_init(struct net_if *iface)
 	ethernet_init(iface);
 	net_if_carrier_off(iface);
 
-	esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, eth_esp32_rx);
-
 	wifi_init_config_t config = WIFI_INIT_CONFIG_DEFAULT();
 	esp_err_t ret = esp_wifi_init(&config);
 
 	ret |= esp_wifi_set_mode(ESP32_WIFI_MODE_STA);
 	ret |= esp_wifi_start();
+	ret |= esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, eth_esp32_rx);
 
 	if (ret != ESP_OK) {
 		LOG_ERR("Failed to start Wi-Fi driver");


### PR DESCRIPTION
The wifi receive callback was being set before the underlying interface was initialised. This resulted in no packets being passed up to station once connected.