### PR TITLE
bluetooth:mesh: Do not skip PDU forwarding on ADV

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -579,12 +579,8 @@ int bt_mesh_net_send(struct bt_mesh_net_tx *tx, struct net_buf *buf,
 	BT_MESH_ADV(buf)->cb_data = cb_data;
 
 	/* Deliver to GATT Proxy Clients if necessary. */
-	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY) &&
-	    bt_mesh_proxy_relay(buf, tx->ctx->addr) &&
-	    BT_MESH_ADDR_IS_UNICAST(tx->ctx->addr)) {
-
-		err = 0;
-		goto done;
+	if (IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY)) {
+		(void)bt_mesh_proxy_relay(buf, tx->ctx->addr);
 	}
 
 	/* Deliver to GATT Proxy Servers if necessary. */


### PR DESCRIPTION
Fixes a bug where goto statement results into network layer skipping the forwarding of unicast message on the ADV bearer, if the message gets succesfully sent on the GATT bearer. This is undesirable. Node has no knowledge of which external entity has which unicast address. It may be possible that Proxy node can deliberately add unicast addresses of other nodes to the whitelist to receive some traffic for sniffing.