### PR TITLE
modules: hal_nordic: check if `gpio1` is enabled

### DIFF
--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_gpiote_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_gpiote_zephyr.c
@@ -55,7 +55,7 @@ void nrf_802154_gpiote_init(void)
 					GPIO_PULL_UP :
 					GPIO_PULL_DOWN;
 
-#if DT_NODE_EXISTS(DT_NODELABEL(gpio1))
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio1), okay)
 		if (use_port_1) {
 			dev = DEVICE_DT_GET(DT_NODELABEL(gpio1));
 		} else {


### PR DESCRIPTION
Without this change, the build will fail if `gpio1` is `disabled` in an overlay.

For example:
```devicetree
&gpio1 {
	status = "disabled";
};
```

Since this is Nordic specific code, this PR was first submitted on their sdk fork but Nordic requested that it be sent here instead.

More info on the original: https://github.com/nrfconnect/sdk-zephyr/pull/1060

 