### PR TITLE
ARC: SMP: fix IDU mask setup

### DIFF
--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -67,7 +67,7 @@ static int arc_shared_intc_update_post_smp(const struct device *unused)
 
 	for (uint32_t i = 0; i < (CONFIG_NUM_IRQS - ARC_CONNECT_IDU_IRQ_START); i++) {
 		/* TODO: take arc_connect_spinlock one time to avoid locking/unlocking every time */
-		z_arc_connect_idu_set_dest(i, GENMASK(CONFIG_MP_NUM_CPUS, 0));
+		z_arc_connect_idu_set_dest(i, GENMASK((arch_num_cpus() - 1), 0));
 	}
 
 	z_arc_connect_idu_enable();

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -67,7 +67,7 @@ static int arc_shared_intc_update_post_smp(const struct device *unused)
 
 	for (uint32_t i = 0; i < (CONFIG_NUM_IRQS - ARC_CONNECT_IDU_IRQ_START); i++) {
 		/* TODO: take arc_connect_spinlock one time to avoid locking/unlocking every time */
-		z_arc_connect_idu_set_dest(i, GENMASK((arch_num_cpus() - 1), 0));
+		z_arc_connect_idu_set_dest(i, BIT_MASK(arch_num_cpus()));
 	}
 
 	z_arc_connect_idu_enable();


### PR DESCRIPTION
Fix IDU mask setup:
 * fix GENMASK usage to avoid generating mask to one extra cpu (which doesn't exist in configuration)
 * use arch_num_cpus() instead of CONFIG_MP_NUM_CPUS to allow having some cpu's disabled (with detection in runtime)

Fixes one of the issue in #55434