### PR TITLE
samples: input_dump: handle events with no device set

### DIFF
--- a/samples/subsys/input/input_dump/src/main.c
+++ b/samples/subsys/input/input_dump/src/main.c
@@ -10,7 +10,7 @@
 static void input_cb(struct input_event *evt)
 {
 	printf("input event: dev=%-16s %3s type=%2x code=%3d value=%d\n",
-	       evt->dev->name,
+	       evt->dev ? evt->dev->name : "NULL",
 	       evt->sync ? "SYN" : "",
 	       evt->type,
 	       evt->code,


### PR DESCRIPTION
Input events with no associated device structure are valid. Handle them in the sample by printing NULL instead of crashing trying to lookup the device name.