### PR TITLE
subsys: input: move the listener section in common-rom

### DIFF
--- a/include/zephyr/linker/common-rom/common-rom-misc.ld
+++ b/include/zephyr/linker/common-rom/common-rom-misc.ld
@@ -16,6 +16,10 @@
 	ITERABLE_SECTION_ROM(mcumgr_handler, 4)
 #endif
 
+#if defined(CONFIG_INPUT)
+	ITERABLE_SECTION_ROM(input_listener, 4)
+#endif
+
 #if defined(CONFIG_EMUL)
 	SECTION_DATA_PROLOGUE(emulators_section,,)
 	{

--- a/subsys/input/CMakeLists.txt
+++ b/subsys/input/CMakeLists.txt
@@ -3,5 +3,3 @@
 zephyr_library()
 
 zephyr_library_sources(input.c)
-
-zephyr_linker_sources(SECTIONS input.ld)

--- a/subsys/input/input.ld
+++ b/subsys/input/input.ld
@@ -1,1 +1,0 @@
-ITERABLE_SECTION_ROM(input_listener, 4)


### PR DESCRIPTION
Move the input listener section declaration in common-rom-misc.ld instead of using a custom input.ld file. This seems to be the common practice for upstream iterable sections and seems to solve a compatibility issue where the section was getting allocated incorrectly on esp32 based platforms.

Fixes #55958