### PR TITLE
soc: fvp_aemv8r: add mpu region from device tree

### DIFF
--- a/include/zephyr/arch/arm64/cortex_r/arm_mpu.h
+++ b/include/zephyr/arch/arm64/cortex_r/arm_mpu.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 Linaro Limited.
  * Copyright (c) 2018 Nordic Semiconductor ASA.
- * Copyright (c) 2021 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2021-2023 Arm Limited (or its affiliates). All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -148,6 +148,14 @@
 		.mair_idx = MPU_MAIR_INDEX_SRAM,		      \
 	}
 
+#define REGION_RAM_NOCACHE_ATTR					      \
+	{							      \
+		/* AP, XN, SH */				      \
+		.rbar = NOT_EXEC | P_RW_U_NA_Msk | NON_SHAREABLE_Msk, \
+		/* Cache-ability */				      \
+		.mair_idx = MPU_MAIR_INDEX_SRAM_NOCACHE,	      \
+	}
+
 #define REGION_RAM_TEXT_ATTR				   \
 	{						   \
 		/* AP, XN, SH */			   \
@@ -217,6 +225,14 @@ struct arm_mpu_config {
 		.base = _base,			      \
 		.limit = _limit,		      \
 		.attr = _attr,			      \
+	}
+
+#define MPU_REGION_ENTRY_FROM_DTS(_name, _base, _size, _attr) \
+	{						      \
+		.name = _name,				      \
+		.base = _base,				      \
+		.limit = _base + _size,			      \
+		.attr = _attr,				      \
 	}
 
 #define K_MEM_PARTITION_P_RW_U_RW ((k_mem_partition_attr_t) \

--- a/soc/arm64/arm/fvp_aemv8r/arm_mpu_regions.c
+++ b/soc/arm64/arm/fvp_aemv8r/arm_mpu_regions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Arm Limited (or its affiliates). All rights reserved.
+ * Copyright (c) 2021-2023 Arm Limited (or its affiliates). All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,6 +7,7 @@
 
 #include <zephyr/arch/arm64/cortex_r/arm_mpu.h>
 #include <zephyr/linker/linker-defs.h>
+#include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/sys/util.h>
 
 #define DEVICE_REGION_START 0x80000000UL
@@ -46,7 +47,10 @@ static const struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("DEVICE",
 			 DEVICE_REGION_START,
 			 DEVICE_REGION_END,
-			 REGION_DEVICE_ATTR)
+			 REGION_DEVICE_ATTR),
+
+	/* Extra regions defined in device tree */
+	LINKER_DT_REGION_MPU(MPU_REGION_ENTRY_FROM_DTS)
 };
 
 const struct arm_mpu_config mpu_config = {


### PR DESCRIPTION
The fvp_aemv8r soc (Arm64 arch) does not support configuring extra mpu regions from device tree. In some variant boards with this soc, some extra memory and device regions need to be added in a specific range with specific mpu attributes.
These patches support this configuration based on zephyr,memory-region binding. e.g.
```
        shared_ram: memory@18000000 {
                compatible = "zephyr,memory-region", "mmio-sram";
                reg = <0x18000000 DT_SIZE_M(40)>;
                zephyr,memory-region = "SHRAM";
                zephyr,memory-region-mpu = "RAM_NOCACHE";
        };
```
