### PR TITLE
samples: shields: x_nucleo_53l0a1: Add missing prj.conf

### DIFF
--- a/samples/shields/x_nucleo_53l0a1/prj.conf
+++ b/samples/shields/x_nucleo_53l0a1/prj.conf
@@ -1,0 +1,1 @@
+# nothing here


### PR DESCRIPTION
This sample was missing a proj.conf which is required for any zephyr application.