### PR TITLE
boards: arm: stm32f723 disco kit has quadspi NOR flash

### DIFF
--- a/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
+++ b/boards/arm/stm32f723e_disco/stm32f723e_disco.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &usart6;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,flash-controller = &mx25r512;
 	};
 
 	leds {
@@ -49,6 +50,7 @@
 		led1 = &red_led;
 		led2 = &green_led;
 		sw0 = &user_button;
+		spi-flash0 = &mx25r512;
 	};
 };
 
@@ -110,6 +112,25 @@
 	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pb4 &spi1_mosi_pb5>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&quadspi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&quadspi_clk_pb2 &quadspi_bk1_ncs_pb6
+		&quadspi_bk1_io0_pc9 &quadspi_bk1_io1_pc10
+		&quadspi_bk1_io2_pe2 &quadspi_bk1_io3_pd13>;
+	flash-id = <1>;
+	status = "okay";
+
+	mx25r512: qspi-nor-flash@0 {
+		compatible = "st,stm32-qspi-nor";
+		reg = <0>;
+		qspi-max-frequency = <8000000>;
+		size = <DT_SIZE_M(512)>; /* 64 MBytes */
+		status = "okay";
+		spi-bus-width = <4>;
+		writeoc = "PP_1_4_4";
+	};
 };
 
 zephyr_udc0: &usbotg_fs {


### PR DESCRIPTION
Enables the quadspi interface of the stm32f723e_disco board to access the mx25r512 512Mbits NOR flash.
Pins of the bk1 quadspi bus are connected to the external NOR flash on the board HW.


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55384

Signed-off-by: Francois Ramu <francois.ramu@st.com>
