### PR TITLE
doc: kconfig: setting: Add "fragment" to text

### DIFF
--- a/doc/build/kconfig/setting.rst
+++ b/doc/build/kconfig/setting.rst
@@ -134,8 +134,10 @@ settings from three sources:
 
 3. The application configuration
 
-The application configuration can come from the sources below. By default,
-:file:`prj.conf` is used.
+The application configuration can come from the sources below (each file is
+known as a Kconfig fragment, which are then merged to get the final
+configuration used for a particular build). By default, :file:`prj.conf` is
+used.
 
 1. If ``CONF_FILE`` is set, the configuration file(s) specified in it are
    merged and used as the application configuration. ``CONF_FILE`` can be set


### PR DESCRIPTION
Adds "fragment" to the Kconfig text, this is because these files are known as Kconfig fragments, and when searching the documentation for this, all you get are irrelevant results instead of this page - which is by far the most important one.