### PR TITLE
tests: Bluetooth: quick-fix to EATT reconfigure

### DIFF
--- a/tests/bsim/bluetooth/host/att/eatt/src/main_reconfigure.c
+++ b/tests/bsim/bluetooth/host/att/eatt/src/main_reconfigure.c
@@ -55,6 +55,8 @@ static void test_central_main(void)
 		k_sleep(K_MSEC(10));
 	}
 
+	k_sleep(K_MSEC(1000));
+
 	err = bt_eatt_reconfigure(default_conn, NEW_MTU);
 	if (err < 0) {
 		FAIL("Reconfigure failed (%d)\n", err);


### PR DESCRIPTION
This test is going away when #55976 is merged.

Add a sleep to work around this sequence of events:
- central establishes channels
- peripheral tries to establish channels, fails (max num reached)
- central (still thinking chans are valid) triggers reconfigure
- collision mitigation on the peripheral, triggering a disconnect of both sides
- channels are established again, but the reconfigure isn't triggered again
- devices wait forever for the reconfigure cb

Fixes #55912