### PR TITLE
drivers: clock_control: correct enable / disable of backup domain on STM32

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -622,13 +622,13 @@ static void set_up_fixed_clock_sources(void)
 
 		z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 
-#if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP)
+#if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP) || defined(PWR_DBPR_DBP)
 		/* Set the DBP bit in the Power control register 1 (PWR_CR1) */
 		LL_PWR_EnableBkUpAccess();
 		while (!LL_PWR_IsEnabledBkUpAccess()) {
 			/* Wait for Backup domain access */
 		}
-#endif /* PWR_CR_DBP || PWR_CR1_DBP */
+#endif /* PWR_CR_DBP || PWR_CR1_DBP || PWR_DBPR_DBP */
 
 #if STM32_LSE_DRIVING
 		/* Configure driving capability */
@@ -653,9 +653,9 @@ static void set_up_fixed_clock_sources(void)
 		}
 #endif /* RCC_BDCR_LSESYSEN */
 
-#if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP)
+#if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP) || defined(PWR_DBPR_DBP)
 		LL_PWR_DisableBkUpAccess();
-#endif /* PWR_CR_DBP || PWR_CR1_DBP */
+#endif /* PWR_CR_DBP || PWR_CR1_DBP || PWR_DBPR_DBP */
 
 		z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
 	}


### PR DESCRIPTION
I missed that the U5-series had its own DBP register when porting the C0-series, correcting this here so that the U5-series continues to work as expected.