### PR TITLE
p4wq: add optional group_id priority

### DIFF
--- a/include/zephyr/sys/p4wq.h
+++ b/include/zephyr/sys/p4wq.h
@@ -27,6 +27,7 @@ typedef void (*k_p4wq_handler_t)(struct k_p4wq_work *work);
  */
 struct k_p4wq_work {
 	/* Filled out by submitting code */
+	uint32_t group_id;
 	int32_t priority;
 	int32_t deadline;
 	k_p4wq_handler_t handler;

--- a/include/zephyr/sys/p4wq.h
+++ b/include/zephyr/sys/p4wq.h
@@ -32,6 +32,7 @@ struct k_p4wq_work {
 	k_p4wq_handler_t handler;
 	bool sync;
 	struct k_sem done_sem;
+	void *priv_data;
 
 	/* reserved for implementation */
 	union {

--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -30,6 +30,10 @@ static bool rb_lessthan(struct rbnode *a, struct rbnode *b)
 		return aw->priority > bw->priority;
 	}
 
+	if (aw->group_id != bw->group_id) {
+		return aw->group_id > bw->group_id;
+	}
+
 	if (aw->deadline != bw->deadline) {
 		return aw->deadline - bw->deadline > 0;
 	}
@@ -59,13 +63,16 @@ static bool thread_was_requeued(struct k_thread *th)
  */
 static inline bool item_lessthan(struct k_p4wq_work *a, struct k_p4wq_work *b)
 {
-	if (a->priority > b->priority) {
-		return true;
-	} else if ((a->priority == b->priority) &&
-		   (a->deadline != b->deadline)) {
+	if (a->priority != b->priority) {
+		return a->priority > b->priority;
+	}
+
+	if (a->group_id != b->group_id) {
+		return a->group_id > b->group_id;
+	}
+
+	if (a->deadline != b->deadline) {
 		return a->deadline - b->deadline > 0;
-	} else {
-		;
 	}
 	return false;
 }

--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -34,7 +34,7 @@ static bool rb_lessthan(struct rbnode *a, struct rbnode *b)
 		return aw->deadline - bw->deadline > 0;
 	}
 
-	return (uintptr_t)a < (uintptr_t)b;
+	return (uintptr_t)a > (uintptr_t)b;
 }
 
 static void thread_set_requeued(struct k_thread *th)

--- a/tests/lib/p4workq/src/main.c
+++ b/tests/lib/p4workq/src/main.c
@@ -42,6 +42,7 @@ static void stress_sub(struct test_item *item)
 	 */
 	item->item.priority = sys_rand32_get() % (K_LOWEST_THREAD_PRIO - 1);
 	item->item.deadline = sys_rand32_get() % k_ms_to_cyc_ceil32(2);
+	item->item.group_id = 0;
 	item->item.handler = stress_handler;
 	item->running = false;
 	item->active = true;
@@ -154,6 +155,7 @@ static bool add_new_item(int pri)
 	__ASSERT_NO_MSG(num_items < MAX_ITEMS);
 	item->priority = pri;
 	item->deadline = k_us_to_cyc_ceil32(100);
+	item->group_id = 0;
 	item->handler = spin_handler;
 	k_p4wq_submit(&wq, item);
 	k_usleep(1);
@@ -258,6 +260,7 @@ ZTEST(lib_p4wq_1cpu, test_p4wq_simple)
 	/* Lower priority item, should not run until we yield */
 	simple_item.priority = prio + 1;
 	simple_item.deadline = 0;
+	simple_item.group_id = 0;
 	simple_item.handler = simple_handler;
 
 	has_run = false;


### PR DESCRIPTION
Example set of changes to support SOF_SCHEDULE_COMM scheduler:
https://github.com/thesofproject/sof/issues/7238

The main changes is group_id in work item which allows work items to be sorted by groups within the same priority.