### PR TITLE
twister: Treat overflows as error on integration_platforms during integration mode

### DIFF
--- a/samples/sensor/fxas21002/sample.yaml
+++ b/samples/sensor/fxas21002/sample.yaml
@@ -6,4 +6,4 @@ tests:
     tags: sensors
     platform_allow: hexiwear_k64 warp7_m4
     integration_platforms:
-      - warp7_m4
+      - hexiwear_k64

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -31,6 +31,7 @@ if sys.platform == 'linux':
 
 from twisterlib.log_helper import log_command
 from twisterlib.testinstance import TestInstance
+from twisterlib.testplan import change_skip_to_error_if_integration
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
@@ -287,9 +288,11 @@ class CMake:
                     logger.debug("Test skipped due to {} Overflow".format(overflow_found[0]))
                     self.instance.status = "skipped"
                     self.instance.reason = "{} overflow".format(overflow_found[0])
+                    change_skip_to_error_if_integration(self.options, self.instance)
                 elif imgtool_overflow_found and not self.options.overflow_as_errors:
                     self.instance.status = "skipped"
                     self.instance.reason = "imgtool overflow"
+                    change_skip_to_error_if_integration(self.options, self.instance)
                 else:
                     self.instance.status = "error"
                     self.instance.reason = "Build failure"

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -878,7 +878,6 @@ class TestPlan:
                     continue
                 filtered_instance.status = "error"
                 filtered_instance.reason += " but is one of the integration platforms"
-                self.instances[filtered_instance.name] = filtered_instance
 
             filtered_instance.add_missing_case_status(filtered_instance.status)
 

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -869,15 +869,7 @@ class TestPlan:
 
         filtered_instances = list(filter(lambda item:  item.status == "filtered", self.instances.values()))
         for filtered_instance in filtered_instances:
-            # If integration mode is on all skips on integration_platforms are treated as errors.
-            if self.options.integration and filtered_instance.platform.name in filtered_instance.testsuite.integration_platforms \
-                and "quarantine" not in filtered_instance.reason.lower():
-                # Do not treat this as error if filter type is command line
-                filters = {t['type'] for t in filtered_instance.filters}
-                if Filters.CMD_LINE in filters or Filters.SKIP in filters:
-                    continue
-                filtered_instance.status = "error"
-                filtered_instance.reason += " but is one of the integration platforms"
+            change_skip_to_error_if_integration(self.options, filtered_instance)
 
             filtered_instance.add_missing_case_status(filtered_instance.status)
 
@@ -951,3 +943,15 @@ class TestPlan:
         instance.build_dir = link_path
 
         self.link_dir_counter += 1
+
+
+def change_skip_to_error_if_integration(options, instance):
+    ''' If integration mode is on all skips on integration_platforms are treated as errors.'''
+    if options.integration and instance.platform.name in instance.testsuite.integration_platforms \
+        and "quarantine" not in instance.reason.lower():
+        # Do not treat this as error if filter type is command line
+        filters = {t['type'] for t in instance.filters}
+        if Filters.CMD_LINE in filters or Filters.SKIP in filters:
+            return
+        instance.status = "error"
+        instance.reason += " but is one of the integration platforms"


### PR DESCRIPTION
Skips due to overflows on integration_platforms during integretion mode should be treated as errors.