### PR TITLE
drivers: counter: Minor tweaks in nordic driver and test

### DIFF
--- a/drivers/counter/counter_nrfx_rtc.c
+++ b/drivers/counter/counter_nrfx_rtc.c
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/drivers/counter.h>
+#include <hal/nrf_rtc.h>
+#ifdef CONFIG_CLOCK_CONTROL_NRF
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
-#include <hal/nrf_rtc.h>
+#endif
 #include <zephyr/sys/atomic.h>
 #ifdef DPPI_PRESENT
 #include <nrfx_dppi.h>
@@ -541,7 +543,9 @@ static int init_rtc(const struct device *dev, uint32_t prescaler)
 	NRF_RTC_Type *rtc = nrfx_config->rtc;
 	int err;
 
+#ifdef CONFIG_CLOCK_CONTROL_NRF
 	z_nrf_clock_control_lf_on(CLOCK_CONTROL_NRF_LF_START_NOWAIT);
+#endif
 
 	nrf_rtc_prescaler_set(rtc, prescaler);
 

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -804,7 +804,7 @@ static void test_short_relative_alarm_instance(const struct device *dev)
 				dev->name, err);
 
 		/* wait to ensure that tick+1 timeout will expire. */
-		k_busy_wait(3*tick_us);
+		k_busy_wait(10 * tick_us);
 
 		cnt = IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS) ?
 			alarm_cnt : k_sem_count_get(&alarm_cnt_sem);


### PR DESCRIPTION
In `counter_nrfx_rtc.c` added ifdefs around clock control usage.
In test relaxed timing requirement in one test as test could occasionally fail.