### PR TITLE
dma: dw: always program SAR/DAR and CTL_HI/LO on cAVS2.5

### DIFF
--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -475,7 +475,9 @@ int dw_dma_start(const struct device *dev, uint32_t channel)
 	dw_write(dev_cfg->base, DW_LLP(channel), llp);
 	LOG_DBG("ctrl_lo %x, masked ctrl_lo %x, LLP %x",
 		lli->ctrl_lo, masked_ctrl_lo, dw_read(dev_cfg->base, DW_LLP(channel)));
-#else
+#endif /* CONFIG_DMA_DW_HW_LLI */
+
+#if !CONFIG_DMA_DW_HW_LLI || CONFIG_SOC_SERIES_INTEL_ADSP_CAVS
 	/* channel needs to start from scratch, so write SAR and DAR */
 	dw_write(dev_cfg->base, DW_SAR(channel), lli->sar);
 	dw_write(dev_cfg->base, DW_DAR(channel), lli->dar);
@@ -483,7 +485,7 @@ int dw_dma_start(const struct device *dev, uint32_t channel)
 	/* program CTL_LO and CTL_HI */
 	dw_write(dev_cfg->base, DW_CTRL_LOW(channel), lli->ctrl_lo);
 	dw_write(dev_cfg->base, DW_CTRL_HIGH(channel), lli->ctrl_hi);
-#endif /* CONFIG_DMA_DW_HW_LLI */
+#endif
 
 	/* program CFG_LO and CFG_HI */
 	dw_write(dev_cfg->base, DW_CFG_LOW(channel), chan_data->cfg_lo);


### PR DESCRIPTION
The change in commit 08d9efb202 ("dma: dw: Do not program SAR/DAR and CTL_HI/LO when using HW LLI") caused regressions on Intel cAVS2.5 platform where DMA start fails in large number of cases. It seems the SAR/DAR/CTL_HI/LO direct registers need to be programmed even if LLI is used when starting DMA.