### PR TITLE
Bluetooth: audio: ascs: Fix ASE release from QoS configured

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -229,6 +229,8 @@ void ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state)
 
 		switch (state) {
 		case BT_BAP_EP_STATE_IDLE:
+			bt_bap_stream_detach(stream);
+
 			if (ops->released != NULL) {
 				ops->released(stream);
 			}
@@ -394,7 +396,6 @@ void ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state)
 					bt_bap_iso_unbind_ep(ep->iso, ep);
 				}
 
-				bt_bap_stream_detach(stream);
 				ascs_ep_set_state(ep, BT_BAP_EP_STATE_IDLE);
 			} else {
 				/* Either the client or the server may disconnect the


### PR DESCRIPTION
This fixes ASE release from QoS configured state.
The `ops->released` callback was not called and the `bt_ascs_ase`
was not returned to the pool, because `stream` object was already
detached.

Fixes: #55900