### PR TITLE
Bluetooth: Tests: Fix `bt_buf_get_evt` test

### DIFF
--- a/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_num_completed_packets.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_num_completed_packets.c
@@ -62,13 +62,17 @@ ZTEST_SUITE(bt_buf_get_evt_num_completed_pkts_type, NULL, NULL, NULL, NULL, NULL
  */
 ZTEST(bt_buf_get_evt_num_completed_pkts_type, test_returns_not_null)
 {
-	static struct net_buf expected_buf;
+	const size_t user_data_size = sizeof(struct bt_buf_data);
+	uint8_t *expected_buf_data[sizeof(struct net_buf) + user_data_size];
+	struct net_buf *expected_buf = (struct net_buf *)expected_buf_data;
 	struct net_buf *returned_buf;
 	uint8_t returned_buffer_type;
 	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
 	struct testing_params const *params_vector;
 	uint8_t evt;
 	bool discardable;
+
+	expected_buf->user_data_size = user_data_size;
 
 	for (size_t i = 0; i < (ARRAY_SIZE(testing_params_lut)); i++) {
 
@@ -82,15 +86,15 @@ ZTEST(bt_buf_get_evt_num_completed_pkts_type, test_returns_not_null)
 		zassert_true((evt == BT_HCI_EVT_NUM_COMPLETED_PACKETS),
 			     "Invalid event type %u to this test", evt);
 
-		net_buf_alloc_fixed_fake.return_val = &expected_buf;
+		net_buf_alloc_fixed_fake.return_val = expected_buf;
 
 		returned_buf = bt_buf_get_evt(evt, discardable, timeout);
 
 		expect_single_call_net_buf_alloc(get_memory_pool(discardable), &timeout);
-		expect_single_call_net_buf_reserve(&expected_buf);
+		expect_single_call_net_buf_reserve(expected_buf);
 		expect_not_called_net_buf_ref();
 
-		zassert_equal(returned_buf, &expected_buf,
+		zassert_equal(returned_buf, expected_buf,
 			      "bt_buf_get_evt() returned incorrect buffer pointer value");
 
 		returned_buffer_type = bt_buf_get_type(returned_buf);


### PR DESCRIPTION
Fix #55957. 

The `bt_buf_get_evt` test was using `net_buf` structures without allocating it properly.