### PR TITLE
MAINTAINERS: move mesh and ll from bsim/tests to their proper section

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -211,9 +211,11 @@ Bluetooth:
     - subsys/bluetooth/audio/
     - include/zephyr/bluetooth/audio/
     - tests/bsim/bluetooth/audio/
+    - tests/bsim/bluetooth/ll/
     - tests/bluetooth/controller/
     - tests/bluetooth/mesh_*/
     - tests/bluetooth/mesh/
+    - tests/bsim/bluetooth/mesh/
     - tests/bluetooth/shell/audio*
   labels:
     - "area: Bluetooth"
@@ -233,6 +235,7 @@ Bluetooth controller:
   files:
     - subsys/bluetooth/controller/
     - tests/bluetooth/controller/
+    - tests/bsim/bluetooth/ll/
   labels:
     - "area: Bluetooth Controller"
     - "area: Bluetooth"
@@ -250,6 +253,7 @@ Bluetooth Mesh:
     - subsys/bluetooth/mesh/
     - include/zephyr/bluetooth/mesh/
     - tests/bluetooth/mesh*/
+    - tests/bsim/bluetooth/mesh/
     - samples/bluetooth/mesh/
   labels:
     - "area: Bluetooth Mesh"

--- a/tests/bsim/bluetooth/_compile_permutate_kconfigs.sh
+++ b/tests/bsim/bluetooth/_compile_permutate_kconfigs.sh
@@ -15,7 +15,8 @@ DEBUG_PERMUTATE=false
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
  directory}"
 
-WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_bt_out}"
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
+echo ${WORK_DIR}
 BOARD="${BOARD:-nrf52_bsim}"
 BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 
@@ -62,10 +63,13 @@ perm_compile() {
 	echo "Compile with config overlay:"
 	cat $3
     fi
-    local app=tests/bsim/bluetooth/edtt_ble_test_app/hci_test_app
+    local app=tests/bsim/bluetooth/ll/edtt/hci_test_app
     local conf_file=prj_dut_llcp.conf
     local conf_overlay=$3
-    compile
+# Note: we need to call '_compile' instead of 'compile' because the latter starts
+# compilations in parallel, but here we need to do it in serial since we modify
+# the configuration file between each run
+    _compile
     if [ ! -f ${executable_name} ]; then
     	compile_failures=$(expr $compile_failures + 1)
     fi


### PR DESCRIPTION
The babblesim tests for bluetooth have been moved to a new folder.
To ensure that the proper people still get involved this PR adds
the bsim/tests/bluetooth/ll folder to the bluetooth controller section
and similar for the mesh babblesim folder
    
Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>
