### PR TITLE
tests/bsim/bluetooth: Tests scripts refactor

### DIFF
--- a/tests/bsim/README.txt
+++ b/tests/bsim/README.txt
@@ -7,9 +7,9 @@ the needed images and execute these tests in batch.
 You can also run them manually if desired, but be sure to call them setting
 the variables they expect. For example, from Zephyr's root folder, you can run:
 
-WORK_DIR=${ZEPHYR_BASE}/bsim_bt_out tests/bsim/compile.sh
+WORK_DIR=${ZEPHYR_BASE}/bsim_out tests/bsim/compile.sh
 RESULTS_FILE=${ZEPHYR_BASE}/myresults.xml SEARCH_PATH=tests/bsim tests/bsim/run_parallel.sh
 
 Or to run only a specific subset, e.g. host advertising tests:
-WORK_DIR=${ZEPHYR_BASE}/bsim_bt_out tests/bsim/bluetooth/host/compile.sh
+WORK_DIR=${ZEPHYR_BASE}/bsim_out tests/bsim/bluetooth/host/compile.sh
 RESULTS_FILE=${ZEPHYR_BASE}/myresults.xml SEARCH_PATH=tests/bsim/bluetooth/host/adv tests/bsim/run_parallel.sh

--- a/tests/bsim/bluetooth/audio/compile.sh
+++ b/tests/bsim/bluetooth/audio/compile.sh
@@ -7,13 +7,14 @@
 #set -x #uncomment this line for debugging
 set -ue
 
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+
+
 : "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
  directory}"
 
 WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
-BOARD="${BOARD:-nrf52_bsim}"
+
 BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 
 mkdir -p ${WORK_DIR}

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass.sh
@@ -6,21 +6,9 @@
 
 SIMULATION_ID="bass"
 VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
+EXECUTE_TIMEOUT=20
 
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 20 $@ & PROCESS_IDS="$PROCESS_IDS $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -41,8 +29,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -D=3 \
   -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio.sh
@@ -5,21 +5,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
+EXECUTE_TIMEOUT=20
 
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 20 $@ & PROCESS_IDS="$PROCESS_IDS $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -38,9 +26,7 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
+wait_for_background_jobs
 
 printf "\n\n======== Broadcaster sink disconnect test =========\n\n"
 
@@ -58,8 +44,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio.sh
@@ -6,21 +6,9 @@
 
 SIMULATION_ID="unicast_audio"
 VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
+EXECUTE_TIMEOUT=20
 
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 20 $@ & PROCESS_IDS="$PROCESS_IDS $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -29,7 +17,6 @@ printf "\n\n======== Unicast Audio test =========\n\n"
 Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=unicast_client -rs=23
 
-
 Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=unicast_server -rs=27
 
@@ -37,8 +24,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast.sh
@@ -6,21 +6,9 @@
 
 SIMULATION_ID="cap_broadcast"
 VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
+EXECUTE_TIMEOUT=20
 
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 20 $@ & PROCESS_IDS="$PROCESS_IDS $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -36,8 +24,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast.sh
@@ -6,21 +6,9 @@
 
 SIMULATION_ID="cap_unicast"
 VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
+EXECUTE_TIMEOUT=20
 
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 20 $@ & PROCESS_IDS="$PROCESS_IDS $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -36,8 +24,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/csip.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip.sh
@@ -7,22 +7,10 @@
 # Basic CSIP test. A set coordinator connects to multiple set members
 # lock thems, unlocks them and disconnects.
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 20 $@ & PROCESS_IDS="$PROCESS_IDS $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -51,11 +39,7 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=4 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-
-PROCESS_IDS="";
+wait_for_background_jobs
 
 # TEST WITH FORCE RELEASE
 
@@ -82,9 +66,7 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=4 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
+wait_for_background_jobs
 
 # TEST WITH SIRK ENC
 
@@ -111,7 +93,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=4 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/has.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/has.sh
@@ -4,23 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 SIMULATION_ID="has"
 VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 20 $@ & PROCESS_IDS="$PROCESS_IDS $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -35,8 +23,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/ias.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/ias.sh
@@ -4,23 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 SIMULATION_ID="ias"
 VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 20 $@ & PROCESS_IDS="$PROCESS_IDS $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -36,8 +24,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/mcs_mcc.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/mcs_mcc.sh
@@ -4,23 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 SIMULATION_ID="mcs_mcc"
 VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 20 $@ & PROCESS_IDS="$PROCESS_IDS $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -36,8 +24,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/media_controller.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/media_controller.sh
@@ -4,23 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 SIMULATION_ID="media_controller"
 VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 20 $@ & PROCESS_IDS="$PROCESS_IDS $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -33,9 +21,7 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=1 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
+wait_for_background_jobs
 
 printf "\n\n======== Running media controller remote_player test =========\n\n"
 
@@ -49,8 +35,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/micp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/micp.sh
@@ -4,23 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 SIMULATION_ID="micp"
 VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 20 $@ & PROCESS_IDS="$PROCESS_IDS $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -33,9 +21,7 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=1 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
+wait_for_background_jobs
 
 printf "\n\n==== Running MICP Microphone Device and MICP Microphone Controller test ====n\n"
 
@@ -49,8 +35,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/tbs.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/tbs.sh
@@ -7,21 +7,10 @@
 
 SIMULATION_ID="tbs_ccp"
 VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
 
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 20 $@ & PROCESS_IDS="$PROCESS_IDS $!"
-}
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -35,7 +24,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/vcp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/vcp.sh
@@ -4,23 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 SIMULATION_ID="vcp"
 VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 20 $@ & PROCESS_IDS="$PROCESS_IDS $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=20
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -33,9 +21,7 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=1 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
+wait_for_background_jobs
 
 printf "\n\n======== Running VCP Volume Renderer and VCP Volume Controller test =========\n\n"
 
@@ -49,8 +35,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/adv/chain/tests_scripts/adv_chain.sh
+++ b/tests/bsim/bluetooth/host/adv/chain/tests_scripts/adv_chain.sh
@@ -4,23 +4,11 @@
 
 # Validate Extended Advertising AD Data fragment operation, PDU chaining and
 # Extended Scanning of chain PDUs
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="adv_chain"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 10 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=10
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -33,7 +21,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_adv_chain_prj_conf\
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=10e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv.sh
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv.sh
@@ -4,23 +4,12 @@
 
 # Basic periodic advertising sync test: an advertiser advertises with periodic
 # advertising, and a scanner scans for and syncs to the periodic advertising.
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="per_adv"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 10 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=10
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -35,7 +24,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_adv_periodic_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=20e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_conn.sh
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_conn.sh
@@ -4,23 +4,12 @@
 
 # Basic periodic advertising sync test: an advertiser advertises with periodic
 # advertising, and a scanner scans for and syncs to the periodic advertising.
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="per_adv_conn"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 10 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=10
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -35,7 +24,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_adv_periodic_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=20e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_conn_privacy.sh
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_conn_privacy.sh
@@ -4,23 +4,12 @@
 
 # Basic periodic advertising sync test: an advertiser advertises with periodic
 # advertising, and a scanner scans for and syncs to the periodic advertising.
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="per_adv_conn_privacy"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 10 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=10
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -35,7 +24,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_adv_periodic_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=20e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_long_data.sh
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests_scripts/per_adv_long_data.sh
@@ -4,23 +4,12 @@
 
 # Basic periodic advertising sync test: an advertiser advertises with periodic
 # advertising, and a scanner scans for and syncs to the periodic advertising.
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="per_adv_long_data"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 10 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=10
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -35,7 +24,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_adv_periodic_prj_long_data_conf 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=20e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/adv/resume/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/adv/resume/test_scripts/_env.sh
@@ -4,8 +4,6 @@
 set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
 test_name="$(basename "$(realpath "$bash_source_dir/..")")"
 bsim_bin="${BSIM_OUT_PATH}/bin"
 BOARD="${BOARD:-nrf52_bsim}"

--- a/tests/bsim/bluetooth/host/adv/resume/test_scripts/run_adv_resume.sh
+++ b/tests/bsim/bluetooth/host/adv/resume/test_scripts/run_adv_resume.sh
@@ -5,25 +5,12 @@
 set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-# Read variable definitions output by _env.sh
 source "${bash_source_dir}/_env.sh"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="${test_name}"
 verbosity_level=2
-process_ids=""
-exit_code=0
-
-function Execute() {
-    if [ ! -f $1 ]; then
-        echo -e "  \e[91m$(pwd)/$(basename $1) cannot be found (did you forget to\
- compile it?)\e[39m"
-        exit 1
-    fi
-    timeout 30 $@ &
-    process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -43,7 +30,4 @@ Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
 # gdb --args "$test_exe" \
 #     -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -RealEncryption=1
 
-for process_id in $process_ids; do
-    wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/adv/resume/test_scripts/run_adv_resume_2.sh
+++ b/tests/bsim/bluetooth/host/adv/resume/test_scripts/run_adv_resume_2.sh
@@ -5,25 +5,12 @@
 set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-# Read variable definitions output by _env.sh
 source "${bash_source_dir}/_env.sh"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="${test_name}_2"
 verbosity_level=2
-process_ids=""
-exit_code=0
-
-function Execute() {
-    if [ ! -f $1 ]; then
-        echo -e "  \e[91m$(pwd)/$(basename $1) cannot be found (did you forget to\
- compile it?)\e[39m"
-        exit 1
-    fi
-    timeout 30 $@ &
-    process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -36,7 +23,4 @@ Execute "$test_2_exe" \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s="${simulation_id}" \
     -D=2 -sim_length=10e6 $@
 
-for process_id in $process_ids; do
-    wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/autoconnect.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/autoconnect.sh
@@ -2,23 +2,11 @@
 # Copyright (c) 2022 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="connection"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 120 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -31,7 +19,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_prj_autoconnect_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=200e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/collision.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/collision.sh
@@ -2,23 +2,11 @@
 # Copyright (c) 2022 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="collision"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 120 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -31,7 +19,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_prj_collision_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=200e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/multiple_conn.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/multiple_conn.sh
@@ -2,23 +2,11 @@
 # Copyright (c) 2022 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="multiple_conn"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 120 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -31,7 +19,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_prj_multiple_conn_conf 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=200e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/reconfigure.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/reconfigure.sh
@@ -2,23 +2,11 @@
 # Copyright (c) 2022 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="reconfigure"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 120 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -31,7 +19,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_prj_autoconnect_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/att/eatt_notif/test_scripts/eatt_notif.sh
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/test_scripts/eatt_notif.sh
@@ -4,23 +4,11 @@
 
 # EATT notification reliability test
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="eatt_notif"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 120 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -33,7 +21,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_att_eatt_notif_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/att/mtu_update/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/att/mtu_update/test_scripts/_compile.sh
@@ -10,7 +10,7 @@ source "${bash_source_dir}/_env.sh"
 : "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be defined}"
 
-WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_bt_out}"
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
 BOARD="${BOARD:-nrf52_bsim}"
 BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 INCR_BUILD=1

--- a/tests/bsim/bluetooth/host/att/mtu_update/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/att/mtu_update/test_scripts/_compile.sh
@@ -6,10 +6,7 @@ set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
 # Read variable definitions output by _env.sh
-source <("${bash_source_dir}/_env.sh")
-
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+source "${bash_source_dir}/_env.sh"
 : "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be defined}"
 

--- a/tests/bsim/bluetooth/host/att/mtu_update/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/att/mtu_update/test_scripts/_env.sh
@@ -13,18 +13,3 @@ BOARD="${BOARD:-nrf52_bsim}"
 simulation_id="$test_name"
 central_exe="${bsim_bin}/bs_${BOARD}_tests_bsim_bluetooth_host_att_mtu_update_prj_conf"
 peripheral_exe="${central_exe}"
-
-function print_var {
-	# Print a shell-sourceable variable definition.
-	local var_name="$1"
-	local var_repr="${!var_name@Q}"
-	echo "$var_name=$var_repr"
-}
-
-print_var test_name
-print_var bsim_bin
-print_var verbosity_level
-print_var BOARD
-print_var simulation_id
-print_var central_exe
-print_var peripheral_exe

--- a/tests/bsim/bluetooth/host/att/mtu_update/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/att/mtu_update/test_scripts/run_test.sh
@@ -5,23 +5,12 @@
 set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-# Read variable definitions output by _env.sh
-source <("${bash_source_dir}/_env.sh")
+source "${bash_source_dir}/_env.sh"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-process_ids=""
-exit_code=0
-
-function Execute() {
-    if [ ! -f $1 ]; then
-        echo -e "  \e[91m$(pwd)/$(basename $1) cannot be found (did you forget to\
- compile it?)\e[39m"
-        exit 1
-    fi
-    timeout 30 $@ &
-    process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+simulation_id="$test_name"
+verbosity_level=2
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -34,7 +23,4 @@ Execute "$peripheral_exe" \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
     -D=2 -sim_length=60e6 $@
 
-for process_id in $process_ids; do
-    wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/compile.sh
+++ b/tests/bsim/bluetooth/host/compile.sh
@@ -7,13 +7,12 @@
 #set -x #uncomment this line for debugging
 set -ue
 
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
 : "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
  directory}"
 
 WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
-BOARD="${BOARD:-nrf52_bsim}"
+
 BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 
 mkdir -p ${WORK_DIR}

--- a/tests/bsim/bluetooth/host/gatt/caching/test_scripts/_run_test.sh
+++ b/tests/bsim/bluetooth/host/gatt/caching/test_scripts/_run_test.sh
@@ -2,24 +2,10 @@
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 verbosity_level=2
-process_ids=""
-exit_code=0
-
-function Execute() {
-    if [ ! -f $1 ]; then
-        echo -e "  \e[91m$(pwd)/$(basename $1) cannot be found (did you forget to\
- compile it?)\e[39m"
-        exit 1
-    fi
-    timeout 120 $@ &
-    process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -32,7 +18,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_gatt_caching_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
     -D=2 -sim_length=60e6 $@
 
-for process_id in $process_ids; do
-    wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/gatt/general/test_scripts/gatt.sh
+++ b/tests/bsim/bluetooth/host/gatt/general/test_scripts/gatt.sh
@@ -5,23 +5,12 @@
 # Basic GATT test: A central acting as a GATT client scans for and connects
 # to a peripheral acting as a GATT server. The GATT client will then attempt
 # to write and read to and from a few GATT characteristics.
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="gatt"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 120 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -34,7 +23,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_gatt_general_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/_run_test.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/_run_test.sh
@@ -1,25 +1,12 @@
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
+set -eu
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 verbosity_level=2
-process_ids=""
-exit_code=0
-
-function Execute() {
-    if [ ! -f $1 ]; then
-        echo -e "  \e[91m$(pwd)/$(basename $1) cannot be found (did you forget to\
- compile it?)\e[39m"
-        exit 1
-    fi
-    timeout 30 $@ &
-    process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -32,7 +19,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_gatt_notify_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
     -D=2 -sim_length=60e6 $@
 
-for process_id in $process_ids; do
-    wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_enhanced_enhanced.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_enhanced_enhanced.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_enhanced_enhanced" \
     server_id="gatt_server_enhanced" \
     client_id="gatt_client_enhanced" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_enhanced_mixed.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_enhanced_mixed.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_enhanced_mixed" \
     server_id="gatt_server_enhanced" \
     client_id="gatt_client_mixed" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_enhanced_none.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_enhanced_none.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_enhanced_none" \
     server_id="gatt_server_enhanced" \
     client_id="gatt_client_none" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_enhanced_unenhanced.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_enhanced_unenhanced.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_enhanced_unenhanced" \
     server_id="gatt_server_enhanced" \
     client_id="gatt_client_unenhanced" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_mixed_enhanced.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_mixed_enhanced.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_mixed_enhanced" \
     server_id="gatt_server_mixed" \
     client_id="gatt_client_enhanced" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_mixed_mixed.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_mixed_mixed.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_mixed_mixed" \
     server_id="gatt_server_mixed" \
     client_id="gatt_client_mixed" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_mixed_none.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_mixed_none.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_mixed_none" \
     server_id="gatt_server_mixed" \
     client_id="gatt_client_none" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_mixed_unenhanced.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_mixed_unenhanced.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_mixed_unenhanced" \
     server_id="gatt_server_mixed" \
     client_id="gatt_client_unenhanced" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_none_enhanced.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_none_enhanced.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_none_enhanced" \
     server_id="gatt_server_none" \
     client_id="gatt_client_enhanced" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_none_mixed.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_none_mixed.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_none_mixed" \
     server_id="gatt_server_none" \
     client_id="gatt_client_mixed" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_none_none.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_none_none.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_none_none" \
     server_id="gatt_server_none" \
     client_id="gatt_client_none" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_none_unenhanced.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_none_unenhanced.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_none_unenhanced" \
     server_id="gatt_server_none" \
     client_id="gatt_client_unenhanced" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_unenhanced_enhanced.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_unenhanced_enhanced.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_unenhanced_enhanced" \
     server_id="gatt_server_unenhanced" \
     client_id="gatt_client_enhanced" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_unenhanced_mixed.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_unenhanced_mixed.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_unenhanced_mixed" \
     server_id="gatt_server_unenhanced" \
     client_id="gatt_client_mixed" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_unenhanced_none.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_unenhanced_none.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_unenhanced_none" \
     server_id="gatt_server_unenhanced" \
     client_id="gatt_client_none" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_unenhanced_unenhanced.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/gatt_notify_unenhanced_unenhanced.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
@@ -7,4 +6,3 @@ simulation_id="gatt_notify_unenhanced_unenhanced" \
     server_id="gatt_server_unenhanced" \
     client_id="gatt_client_unenhanced" \
     $(dirname "${BASH_SOURCE[0]}")/_run_test.sh
-

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/test_scripts/_notify-debug.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/test_scripts/_notify-debug.sh
@@ -11,10 +11,8 @@
 # GDB can be run on the two devices at the same time without issues, just append
 # `debug` when running the script.
 
-
 simulation_id="notify_multiple"
 verbosity_level=2
-process_ids=""; exit_code=0
 
 : "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
 

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/test_scripts/notify.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/test_scripts/notify.sh
@@ -1,24 +1,13 @@
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
+set -eu
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 simulation_id="notify_multiple"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 120 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -31,7 +20,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_gatt_notify_multiple_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/gatt/settings/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/gatt/settings/test_scripts/_compile.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
-
 set -eu
+
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
 # Read variable definitions output by _env.sh

--- a/tests/bsim/bluetooth/host/gatt/settings/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/gatt/settings/test_scripts/_env.sh
@@ -4,8 +4,6 @@
 set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
 test_name="$(basename "$(realpath "$bash_source_dir/..")")"
 bsim_bin="${BSIM_OUT_PATH}/bin"
 BOARD="${BOARD:-nrf52_bsim}"

--- a/tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings.sh
+++ b/tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings.sh
@@ -1,27 +1,16 @@
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
-
 set -eu
+
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
 source "${bash_source_dir}/_env.sh"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="${test_name}"
 verbosity_level=2
-process_ids=""
-exit_code=0
-
-function Execute() {
-    if [ ! -f $1 ]; then
-        echo -e "  \e[91m$(pwd)/$(basename $1) cannot be found (did you forget to\
- compile it?)\e[39m"
-        exit 1
-    fi
-    $@ &
-    process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -57,7 +46,4 @@ Execute "$test_exe" -v=${verbosity_level} \
 Execute "$test_exe" -v=${verbosity_level} \
     -s="${simulation_id}" -d=7 -testid=client -RealEncryption=1 -argstest 0 0 "client"
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings_2.sh
+++ b/tests/bsim/bluetooth/host/gatt/settings/test_scripts/run_gatt_settings_2.sh
@@ -1,27 +1,16 @@
 #!/usr/bin/env bash
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
-
 set -eu
+
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
 source "${bash_source_dir}/_env.sh"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="${test_name}_2"
 verbosity_level=2
-process_ids=""
-exit_code=0
-
-function Execute() {
-    if [ ! -f $1 ]; then
-        echo -e "  \e[91m$(pwd)/$(basename $1) cannot be found (did you forget to\
- compile it?)\e[39m"
-        exit 1
-    fi
-    $@ &
-    process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -57,7 +46,4 @@ Execute "$test_2_exe" -v=${verbosity_level} \
 Execute "$test_2_exe" -v=${verbosity_level} \
     -s="${simulation_id}" -d=7 -testid=client -RealEncryption=1 -argstest 0 0 "client_2"
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/gatt/write/tests_scripts/gatt_write.sh
+++ b/tests/bsim/bluetooth/host/gatt/write/tests_scripts/gatt_write.sh
@@ -2,24 +2,12 @@
 # Copyright 2018 Oticon A/S
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Multiple connection between two devices with multiple peripheral identity
 simulation_id="gatt_write"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 60 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=60
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -32,7 +20,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_gatt_write_prj_conf\
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/l2cap/general/tests_scripts/l2cap.sh
+++ b/tests/bsim/bluetooth/host/l2cap/general/tests_scripts/l2cap.sh
@@ -2,24 +2,12 @@
 # Copyright (c) 2022 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # EATT test
 simulation_id="l2cap_ecred"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 120 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -32,7 +20,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_l2cap_general_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap.sh
+++ b/tests/bsim/bluetooth/host/l2cap/stress/tests_scripts/l2cap.sh
@@ -2,25 +2,12 @@
 # Copyright (c) 2022 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # EATT test
 simulation_id="l2cap_stress"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  # timeout 30 $@ & process_ids="$process_ids $!"
-  $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -37,7 +24,4 @@ Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=6 -testid=per
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=7 -sim_length=270e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/l2cap/userdata/tests_scripts/l2cap.sh
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/tests_scripts/l2cap.sh
@@ -2,25 +2,11 @@
 # Copyright (c) 2022 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 simulation_id="l2cap_ecred_userdata"
 verbosity_level=2
-process_ids=""
-exit_code=0
-
-function Execute() {
-    if [ ! -f $1 ]; then
-        echo -e "  \e[91m$(pwd)/$(basename $1) cannot be found (did you forget to\
- compile it?)\e[39m"
-        exit 1
-    fi
-    timeout 120 $@ &
-    process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -33,7 +19,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_l2cap_userdata_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
     -D=2 -sim_length=30e6 $@
 
-for process_id in $process_ids; do
-    wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable.sh
+++ b/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable.sh
@@ -2,24 +2,12 @@
 # Copyright (c) 2022 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Disable test: bt_enable and bt_disable are called in a loop.
 simulation_id="disable_test"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 120 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -29,7 +17,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_misc_disable_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=1 -sim_length=60e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable_with_gatt.sh
+++ b/tests/bsim/bluetooth/host/misc/disable/tests_scripts/disable_with_gatt.sh
@@ -2,27 +2,15 @@
 # Copyright 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Disable with GATT test: A central acting as a GATT client scans for and connects
 # to a peripheral acting as a GATT server. The GATT client will then attempt
 # to write and read to and from a few GATT characteristics. Both the central and
 # peripheral then disable bluetooth and the test repeats.
 simulation_id="disable_with_gatt"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 120 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -35,7 +23,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_misc_disable_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=600e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/misc/multiple_id/tests_scripts/multiple.sh
+++ b/tests/bsim/bluetooth/host/misc/multiple_id/tests_scripts/multiple.sh
@@ -2,24 +2,12 @@
 # Copyright 2018 Oticon A/S
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Multiple connection between two devices with multiple peripheral identity
 simulation_id="multiple"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 1800 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=1800
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -32,7 +20,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_host_misc_multiple_id_prj_conf\
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=4500e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/privacy/central/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/privacy/central/test_scripts/_compile.sh
@@ -11,7 +11,7 @@ source "${bash_source_dir}/_env.sh"
 : "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be defined}"
 
-WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_bt_out}"
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
 BOARD="${BOARD:-nrf52_bsim}"
 BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 INCR_BUILD=1

--- a/tests/bsim/bluetooth/host/privacy/central/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/privacy/central/test_scripts/_compile.sh
@@ -5,14 +5,11 @@
 set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-# Read variable definitions output by _env.sh
-source <("${bash_source_dir}/_env.sh")
-
+source "${bash_source_dir}/_env.sh"
 
 : "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
 : "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be defined}"
-
 
 WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_bt_out}"
 BOARD="${BOARD:-nrf52_bsim}"

--- a/tests/bsim/bluetooth/host/privacy/central/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/privacy/central/test_scripts/_env.sh
@@ -5,8 +5,6 @@
 set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
 test_name="$(basename "$(realpath "$bash_source_dir/..")")"
 bsim_bin="${BSIM_OUT_PATH}/bin"
 verbosity_level=2
@@ -14,18 +12,3 @@ BOARD="${BOARD:-nrf52_bsim}"
 simulation_id="$test_name"
 central_exe="${bsim_bin}/bs_${BOARD}_tests_bsim_bluetooth_host_privacy_central_prj_conf"
 peripheral_exe="${central_exe}"
-
-function print_var {
-	# Print a shell-sourceable variable definition.
-	local var_name="$1"
-	local var_repr="${!var_name@Q}"
-	echo "$var_name=$var_repr"
-}
-
-print_var test_name
-print_var bsim_bin
-print_var verbosity_level
-print_var BOARD
-print_var simulation_id
-print_var central_exe
-print_var peripheral_exe

--- a/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test.sh
@@ -1,27 +1,14 @@
 #!/usr/bin/env bash
 # Copyright 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
-
 set -eu
+
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-# Read variable definitions output by _env.sh
-source <("${bash_source_dir}/_env.sh")
+source "${bash_source_dir}/_env.sh"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-process_ids=""
-exit_code=0
-
-function Execute() {
-    if [ ! -f $1 ]; then
-        echo -e "  \e[91m$(pwd)/$(basename $1) cannot be found (did you forget to\
- compile it?)\e[39m"
-        exit 1
-    fi
-    timeout 30 $@ &
-    process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -34,8 +21,4 @@ Execute "$peripheral_exe" \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
     -D=2 -sim_length=60e6 $@
 
-for process_id in $process_ids; do
-    wait $process_id || let "exit_code=$?"
-done
-
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/privacy/device/test_scripts/run_tests.sh
+++ b/tests/bsim/bluetooth/host/privacy/device/test_scripts/run_tests.sh
@@ -5,23 +5,10 @@
 set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-# Read variable definitions output by _env.sh
 source "${bash_source_dir}/_env.sh"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-process_ids=""
-exit_code=0
-
-function Execute() {
-    if [ ! -f $1 ]; then
-        echo -e "  \e[91m$(pwd)/$(basename $1) cannot be found (did you forget to\
- compile it?)\e[39m"
-        exit 1
-    fi
-    timeout 30 $@ &
-    process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -75,11 +62,4 @@ for args in ${TEST_ARGS[@]}; do
     done
 done
 
-for process_id in $process_ids; do
-    wait $process_id || let "exit_code=$?"
-    if [ ${exit_code} -ne 0 ]; then
-        exit_code=1
-    fi
-done
-
-exit $exit_code # the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/_compile.sh
@@ -6,7 +6,7 @@ set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
 # Read variable definitions output by _env.sh
-source <("${bash_source_dir}/_env.sh")
+source "${bash_source_dir}/_env.sh"
 
 
 : "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/_compile.sh
@@ -14,7 +14,7 @@ source "${bash_source_dir}/_env.sh"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be defined}"
 
 
-WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_bt_out}"
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
 BOARD="${BOARD:-nrf52_bsim}"
 BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 INCR_BUILD=1

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/_env.sh
@@ -5,8 +5,6 @@
 set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
 test_name="$(basename "$(realpath "$bash_source_dir/..")")"
 bsim_bin="${BSIM_OUT_PATH}/bin"
 verbosity_level=2
@@ -14,18 +12,3 @@ BOARD="${BOARD:-nrf52_bsim}"
 simulation_id="$test_name"
 central_exe="${bsim_bin}/bs_${BOARD}_tests_bsim_bluetooth_host_privacy_peripheral_prj_conf"
 peripheral_exe="${central_exe}"
-
-function print_var {
-	# Print a shell-sourceable variable definition.
-	local var_name="$1"
-	local var_repr="${!var_name@Q}"
-	echo "$var_name=$var_repr"
-}
-
-print_var test_name
-print_var bsim_bin
-print_var verbosity_level
-print_var BOARD
-print_var simulation_id
-print_var central_exe
-print_var peripheral_exe

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test.sh
@@ -5,23 +5,10 @@
 set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-# Read variable definitions output by _env.sh
-source <("${bash_source_dir}/_env.sh")
+source "${bash_source_dir}/_env.sh"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-process_ids=""
-exit_code=0
-
-function Execute() {
-    if [ ! -f $1 ]; then
-        echo -e "  \e[91m$(pwd)/$(basename $1) cannot be found (did you forget to\
- compile it?)\e[39m"
-        exit 1
-    fi
-    timeout 30 $@ &
-    process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -34,8 +21,4 @@ Execute "$peripheral_exe" \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
     -D=2 -sim_length=120e6 $@
 
-for process_id in $process_ids; do
-    wait $process_id || let "exit_code=$?"
-done
-
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/test_scripts/_compile.sh
@@ -11,7 +11,7 @@ source "${bash_source_dir}/_env.sh"
 : "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be defined}"
 
-WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_bt_out}"
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
 BOARD="${BOARD:-nrf52_bsim}"
 BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 INCR_BUILD=1

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/test_scripts/_compile.sh
@@ -6,10 +6,8 @@ set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
 # Read variable definitions output by _env.sh
-source <("${bash_source_dir}/_env.sh")
+source "${bash_source_dir}/_env.sh"
 
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
 : "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be defined}"
 

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/test_scripts/_env.sh
@@ -13,18 +13,3 @@ BOARD="${BOARD:-nrf52_bsim}"
 simulation_id="$test_name"
 central_exe="${bsim_bin}/bs_${BOARD}_tests_bsim_bluetooth_host_${test_name}_prj_conf"
 peripheral_exe="${central_exe}"
-
-function print_var {
-	# Print a shell-sourceable variable definition.
-	local var_name="$1"
-	local var_repr="${!var_name@Q}"
-	echo "$var_name=$var_repr"
-}
-
-print_var test_name
-print_var bsim_bin
-print_var verbosity_level
-print_var BOARD
-print_var simulation_id
-print_var central_exe
-print_var peripheral_exe

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/test_scripts/run_test.sh
@@ -5,23 +5,10 @@
 set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-# Read variable definitions output by _env.sh
-source <("${bash_source_dir}/_env.sh")
+source "${bash_source_dir}/_env.sh"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-process_ids=""
-exit_code=0
-
-function Execute() {
-    if [ ! -f $1 ]; then
-        echo -e "  \e[91m$(pwd)/$(basename $1) cannot be found (did you forget to\
- compile it?)\e[39m"
-        exit 1
-    fi
-    timeout 30 $@ &
-    process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -34,7 +21,4 @@ Execute "$peripheral_exe" \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
     -D=2 -sim_length=60e6 $@
 
-for process_id in $process_ids; do
-    wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/test_scripts/_compile.sh
@@ -11,7 +11,7 @@ source "${bash_source_dir}/_env.sh"
 : "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be defined}"
 
-WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_bt_out}"
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
 BOARD="${BOARD:-nrf52_bsim}"
 BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 INCR_BUILD=1

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/test_scripts/_compile.sh
@@ -6,10 +6,8 @@ set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
 # Read variable definitions output by _env.sh
-source <("${bash_source_dir}/_env.sh")
+source "${bash_source_dir}/_env.sh"
 
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
 : "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be defined}"
 

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/test_scripts/run_test.sh
@@ -6,22 +6,10 @@ set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
 # Read variable definitions output by _env.sh
-source <("${bash_source_dir}/_env.sh")
+source "${bash_source_dir}/_env.sh"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
-process_ids=""
-exit_code=0
-
-function Execute() {
-    if [ ! -f $1 ]; then
-        echo -e "  \e[91m$(pwd)/$(basename $1) cannot be found (did you forget to\
- compile it?)\e[39m"
-        exit 1
-    fi
-    timeout 30 $@ &
-    process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -34,7 +22,4 @@ Execute "$peripheral_exe" \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
     -D=2 -sim_length=60e6 $@
 
-for process_id in $process_ids; do
-    wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx.sh
+++ b/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx.sh
@@ -2,25 +2,13 @@
 # Copyright 2018 Oticon A/S
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Basic connection test: a central connects to a peripheral and expects a
 # notification, using the split controller (ULL LLL)
 simulation_id="basic_advx"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 120 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=120
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -33,7 +21,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_advx_prj_conf\
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/compile.sh
+++ b/tests/bsim/bluetooth/ll/compile.sh
@@ -6,14 +6,12 @@
 
 #set -x #uncomment this line for debugging
 set -ue
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
 : "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
  directory}"
 
 WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
-BOARD="${BOARD:-nrf52_bsim}"
+
 BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 
 mkdir -p ${WORK_DIR}

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split.sh
@@ -2,25 +2,13 @@
 # Copyright 2018 Oticon A/S
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Basic connection test: a central connects to a peripheral and expects a
 # notification
 simulation_id="basic_conn_encr_split"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 5 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=5
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -35,7 +23,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_conn_prj_split_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=20e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_privacy.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_encrypted_split_privacy.sh
@@ -2,25 +2,13 @@
 # Copyright 2018 Oticon A/S
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Basic connection test: a central connects to a peripheral and expects a
 # notification
 simulation_id="basic_conn_encr_split_privacy"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 5 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=5
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -37,7 +25,4 @@ Execute \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=20e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split.sh
@@ -2,25 +2,13 @@
 # Copyright 2018 Oticon A/S
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Basic connection test: a central connects to a peripheral and expects a
 # notification, using the split controller (ULL LLL)
 simulation_id="basic_conn_split"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 5 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=5
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -35,7 +23,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_conn_prj_split_conf\
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=20e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split_low_lat.sh
+++ b/tests/bsim/bluetooth/ll/conn/tests_scripts/basic_conn_split_low_lat.sh
@@ -2,25 +2,13 @@
 # Copyright 2018 Oticon A/S
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Basic connection test: a central connects to a peripheral and expects a
 # notification, using the split controller (ULL LLL) in Low Latency Variant
 simulation_id="basic_conn_split_low_lat"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 5 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=5
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -37,7 +25,4 @@ Execute \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=20e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/edtt/README.txt
+++ b/tests/bsim/bluetooth/ll/edtt/README.txt
@@ -53,7 +53,7 @@ In short the whole process being:
 ```
 cd ${ZEPHYR_BASE} && source zephyr-env.sh
 #Compile all apps:
-WORK_DIR=${ZEPHYR_BASE}/bsim_bt_out tests/bsim/bluetooth/ll/compile.sh
+WORK_DIR=${ZEPHYR_BASE}/bsim_out tests/bsim/bluetooth/ll/compile.sh
 
 #run all tests
 RESULTS_FILE=${ZEPHYR_BASE}/banana.xml SEARCH_PATH=tests/bsim/bluetooth/ll/edtt/ tests/bsim/run_parallel.sh

--- a/tests/bsim/bluetooth/ll/edtt/tests_scripts/_controller_tests_inner.sh
+++ b/tests/bsim/bluetooth/ll/edtt/tests_scripts/_controller_tests_inner.sh
@@ -44,9 +44,10 @@ VERBOSITY_LEVEL_DEVS=${VERBOSITY_LEVEL_DEVS:-${VERBOSITY_LEVEL}}
 VERBOSITY_LEVEL_DEV1=${VERBOSITY_LEVEL_1:-${VERBOSITY_LEVEL_DEVS}}
 VERBOSITY_LEVEL_DEV2=${VERBOSITY_LEVEL_2:-${VERBOSITY_LEVEL_DEVS}}
 
-PROCESS_IDS=""; EXIT_CODE=0
 
-function Execute(){
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+function _Execute(){
   local rr=
   if [ "rr" = "$1" ]; then
     local devno=$2
@@ -56,19 +57,12 @@ function Execute(){
     rm -rf ${out}
     rr="rr record -o ${out}"
   fi
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 300 ${rr} $@ & PROCESS_IDS="$PROCESS_IDS $!"
+  check_program_exists $1
+  run_in_background timeout 300 ${rr} $@
 }
 
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-: "${EDTT_PATH:?EDTT_PATH must be defined}"
 
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+: "${EDTT_PATH:?EDTT_PATH must be defined}"
 
 #Give a default value to PRJ_CONF_x if it does not have one yet:
 PRJ_CONF="${PRJ_CONF:-prj_dut_conf}"
@@ -94,24 +88,21 @@ fi
 
 cd ${EDTT_PATH}
 
-Execute ./src/edttool.py -s=${SIMULATION_ID} -d=2 --transport bsim \
+_Execute ./src/edttool.py -s=${SIMULATION_ID} -d=2 --transport bsim \
   -T $TEST_MODULE -C $TEST_FILE -v=${VERBOSITY_LEVEL_EDTT} -S -l --low-level-device-nbr=3 \
   -D=2 -devs 0 1 -RxWait=2.5e3
 
 cd ${BSIM_OUT_PATH}/bin
 
-Execute \
+_Execute \
   ${RR_ARGS_1} ./bs_${BOARD}_tests_bsim_bluetooth_ll_edtt_hci_test_app_${PRJ_CONF_1}\
   -s=${SIMULATION_ID} -d=0 -v=${VERBOSITY_LEVEL_DEV1} -RealEncryption=1
 
-Execute \
+_Execute \
   ${RR_ARGS_2} ./bs_${BOARD}_tests_bsim_bluetooth_ll_edtt_hci_test_app_${PRJ_CONF_2}\
   -s=${SIMULATION_ID} -d=1 -v=${VERBOSITY_LEVEL_DEV2} -RealEncryption=1
 
-Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL_PHY} -s=${SIMULATION_ID} \
+_Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL_PHY} -s=${SIMULATION_ID} \
   -D=4 -sim_length=3600e6 -dump_imm $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/edtt/tests_scripts/gatt.llcp.sh
+++ b/tests/bsim/bluetooth/ll/edtt/tests_scripts/gatt.llcp.sh
@@ -2,26 +2,16 @@
 # Copyright 2019 Oticon A/S
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # GATT regression tests based on the EDTTool
 SIMULATION_ID="edtt_gatt_llcp"
 VERBOSITY_LEVEL=2
-PROCESS_IDS=""; EXIT_CODE=0
+EXECUTE_TIMEOUT=300
+
 CWD="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 300 $@ & PROCESS_IDS="$PROCESS_IDS $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
 : "${EDTT_PATH:?EDTT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
 
 cd ${EDTT_PATH}
 
@@ -42,7 +32,4 @@ Execute \
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=3 -sim_length=3600e6 $@
 
-for PROCESS_ID in $PROCESS_IDS; do
-  wait $PROCESS_ID || let "EXIT_CODE=$?"
-done
-exit $EXIT_CODE #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/iso/tests_scripts/broadcast_iso.sh
+++ b/tests/bsim/bluetooth/ll/iso/tests_scripts/broadcast_iso.sh
@@ -2,25 +2,13 @@
 # Copyright 2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Basic ISO broadcast test: a broadcaster transmits a BIS and a receiver listens
 # to the BIS.
 simulation_id="broadcast_iso"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 30 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -33,7 +21,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_iso_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=30e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/ll/iso/tests_scripts/broadcast_iso_vs_dp.sh
+++ b/tests/bsim/bluetooth/ll/iso/tests_scripts/broadcast_iso_vs_dp.sh
@@ -2,25 +2,13 @@
 # Copyright 2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
 # Basic ISO broadcast test: a broadcaster transmits a BIS and a receiver listens
 # to the BIS, and recevied SDUs are emitted via vendor data path implementation.
 simulation_id="broadcast_iso_vs_dp"
 verbosity_level=2
-process_ids=""; exit_code=0
-
-function Execute(){
-  if [ ! -f $1 ]; then
-    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
- compile it?)\e[39m"
-    exit 1
-  fi
-  timeout 30 $@ & process_ids="$process_ids $!"
-}
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
-
-#Give a default value to BOARD if it does not have one yet:
-BOARD="${BOARD:-nrf52_bsim}"
+EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin
 
@@ -33,7 +21,4 @@ Execute ./bs_${BOARD}_tests_bsim_bluetooth_ll_iso_prj_conf \
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=30e6 $@
 
-for process_id in $process_ids; do
-  wait $process_id || let "exit_code=$?"
-done
-exit $exit_code #the last exit code != 0
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/mesh/compile.sh
+++ b/tests/bsim/bluetooth/mesh/compile.sh
@@ -6,14 +6,11 @@
 
 #set -x #uncomment this line for debugging
 set -ue
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
 : "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
  directory}"
 
 WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
-BOARD="${BOARD:-nrf52_bsim}"
 BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 
 mkdir -p ${WORK_DIR}

--- a/tests/bsim/compile.sh
+++ b/tests/bsim/compile.sh
@@ -6,14 +6,12 @@
 
 #set -x #uncomment this line for debugging
 set -ue
-
-: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
 : "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
 : "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root\
  directory}"
 
 WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
-BOARD="${BOARD:-nrf52_bsim}"
+
 BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
 
 mkdir -p ${WORK_DIR}

--- a/tests/bsim/sh_common.source
+++ b/tests/bsim/sh_common.source
@@ -3,6 +3,12 @@
 
 _process_ids="";
 
+#All user scripts require these variable, let's check for them here already
+: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+
+#Give a default value to BOARD if it does not have one yet:
+BOARD="${BOARD:-nrf52_bsim}"
+
 function run_in_background(){
   $@ & _process_ids="$_process_ids $!"
 }
@@ -12,5 +18,31 @@ function wait_for_background_jobs(){
   for process_id in $_process_ids; do
     wait $process_id || let "exit_code=$?"
   done
-  exit $exit_code #the last exit code != 0
+  [ $exit_code -eq 0 ] || exit $exit_code
 }
+
+trap ctrl_c INT
+
+function ctrl_c() {
+  echo "Aborted by CTRL-C"
+
+  for process_id in $_process_ids; do
+    kill -15 $process_id
+  done
+}
+
+function check_program_exists() {
+  if [ ! -f $1 ]; then
+    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
+ compile it?)\e[39m"
+    exit 1
+  fi
+}
+
+function Execute() {
+  EXECUTE_TIMEOUT="${EXECUTE_TIMEOUT:-30}"
+
+  check_program_exists $1
+  run_in_background timeout ${EXECUTE_TIMEOUT} $@
+}
+


### PR DESCRIPTION
Mostly move common parts of the bsim tests scripts to a common source file, 
and clean up some other minor things.

&&

The default build path was the old one in some scripts and READMEs. Correct it.

-----

The scripts are used just like before, this is just a code cleanup.
The motivation being to remove crud, have common parts refactored into a single place for easier maintenance, and provide some niceties that already existed in some tests for all.