### PR TITLE
samples: Bluetooth: Kconfig for limited printout in some ISO samples

### DIFF
--- a/samples/bluetooth/iso_broadcast/Kconfig
+++ b/samples/bluetooth/iso_broadcast/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+mainmenu "Bluetooth: ISO Broadcast"
+
+config ISO_PRINT_INTERVAL
+	int "Interval between each packet report"
+	range 1 360000
+	default 1
+	help
+	  Only print the packet report once in a given interval of ISO packets.

--- a/samples/bluetooth/iso_broadcast/src/main.c
+++ b/samples/bluetooth/iso_broadcast/src/main.c
@@ -167,12 +167,12 @@ void main(void)
 
 		}
 
-		iso_send_count++;
-		seq_num++;
-
-		if ((iso_send_count % 100) == 0) {
+		if ((iso_send_count % CONFIG_ISO_PRINT_INTERVAL) == 0) {
 			printk("Sending value %u\n", iso_send_count);
 		}
+
+		iso_send_count++;
+		seq_num++;
 
 		timeout_counter--;
 		if (!timeout_counter) {

--- a/samples/bluetooth/iso_receive/Kconfig
+++ b/samples/bluetooth/iso_receive/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+mainmenu "Bluetooth: ISO Receive"
+
+config ISO_PRINT_INTERVAL
+	int "Interval between each packet report"
+	range 1 360000
+	default 1
+	help
+	  Only print the packet report once in a given interval of ISO packets.
+
+config ISO_ALIGN_PRINT_INTERVALS
+	bool "Align report interval with incoming packets"
+	help
+	  Align interval-counter with packet number from incoming ISO packets.
+	  This may be needed if report printouts are to be synchronized between
+	  the iso_broadcast sample and the iso_receive sample.


### PR DESCRIPTION
Add kconfig to let the ISO broadcast and ISO receive samples report packets no more than once per set interval of packets.