### PR TITLE
Revert "dma: dw: Do not program SAR/DAR and CTL_HI/LO when using HW LLI"

### DIFF
--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -475,7 +475,8 @@ int dw_dma_start(const struct device *dev, uint32_t channel)
 	dw_write(dev_cfg->base, DW_LLP(channel), llp);
 	LOG_DBG("ctrl_lo %x, masked ctrl_lo %x, LLP %x",
 		lli->ctrl_lo, masked_ctrl_lo, dw_read(dev_cfg->base, DW_LLP(channel)));
-#else
+#endif /* CONFIG_DMA_DW_HW_LLI */
+
 	/* channel needs to start from scratch, so write SAR and DAR */
 	dw_write(dev_cfg->base, DW_SAR(channel), lli->sar);
 	dw_write(dev_cfg->base, DW_DAR(channel), lli->dar);
@@ -483,7 +484,6 @@ int dw_dma_start(const struct device *dev, uint32_t channel)
 	/* program CTL_LO and CTL_HI */
 	dw_write(dev_cfg->base, DW_CTRL_LOW(channel), lli->ctrl_lo);
 	dw_write(dev_cfg->base, DW_CTRL_HIGH(channel), lli->ctrl_hi);
-#endif /* CONFIG_DMA_DW_HW_LLI */
 
 	/* program CFG_LO and CFG_HI */
 	dw_write(dev_cfg->base, DW_CFG_LOW(channel), chan_data->cfg_lo);


### PR DESCRIPTION
This reverts commit 08d9efb202cc4f436c7321fd49130c21a525e90d.

Failures are seen with SOF digital mic capture test cases on Intel cAVS2.5
platforms if the SAR/DAR/CTL writes are skipped.

See also https://github.com/zephyrproject-rtos/zephyr/pull/55990 