### PR TITLE
Add timers and PWM to STM32C0-Series and Nucleo C031C6 board

### DIFF
--- a/boards/arm/nucleo_c031c6/doc/index.rst
+++ b/boards/arm/nucleo_c031c6/doc/index.rst
@@ -80,6 +80,8 @@ The Zephyr nucleo_c031c6 board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | WWDG      | on-chip    | window watchdog                     |
 +-----------+------------+-------------------------------------+
+| PWM       | on-chip    | pwm                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 

--- a/boards/arm/nucleo_c031c6/nucleo_c031c6.dts
+++ b/boards/arm/nucleo_c031c6/nucleo_c031c6.dts
@@ -28,6 +28,14 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+
+		green_pwm_led: green_pwm_led {
+			pwms = <&pwm1 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+
 	gpio_keys {
 		compatible = "gpio-keys";
 		user_button: button {
@@ -39,6 +47,7 @@
 
 	aliases {
 		led0 = &green_led_4;
+		pwm-led0 = &green_pwm_led;
 		sw0 = &user_button;
 		watchdog0 = &iwdg;
 	};
@@ -81,4 +90,15 @@
 
 &iwdg {
 	status = "okay";
+};
+
+&timers1 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm1: pwm {
+		pinctrl-0 = <&tim1_ch1_pa5>;
+		pinctrl-names = "default";
+		status = "okay";
+	};
 };

--- a/boards/arm/nucleo_c031c6/nucleo_c031c6.yaml
+++ b/boards/arm/nucleo_c031c6/nucleo_c031c6.yaml
@@ -10,5 +10,6 @@ supported:
   - gpio
   - counter
   - watchdog
+  - pwm
 ram: 12
 flash: 32

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -174,7 +174,8 @@ static int get_tim_clk(const struct stm32_pclken *pclken, uint32_t *tim_clk)
 	if (pclken->bus == STM32_CLOCK_BUS_APB1) {
 		apb_psc = STM32_APB1_PRESCALER;
 	}
-#if !defined(CONFIG_SOC_SERIES_STM32F0X) && !defined(CONFIG_SOC_SERIES_STM32G0X)
+#if !defined(CONFIG_SOC_SERIES_STM32C0X) && !defined(CONFIG_SOC_SERIES_STM32F0X) &&                \
+	!defined(CONFIG_SOC_SERIES_STM32G0X)
 	else {
 		apb_psc = STM32_APB2_PRESCALER;
 	}

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -7,6 +7,8 @@
 #include <arm/armv6-m.dtsi>
 #include <zephyr/dt-bindings/clock/stm32c0_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/reset/stm32c0_reset.h>
 #include <freq.h>
 
@@ -181,6 +183,91 @@
 			resets = <&rctl STM32_RESET(APB1L, 17U)>;
 			interrupts = <28 0>;
 			status = "disabled";
+		};
+
+		timers1: timers@40012c00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40012C00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000800>;
+			resets = <&rctl STM32_RESET(APB1H, 11U)>;
+			interrupts = <13 0>, <14 0>;
+			interrupt-names = "brk_up_trg_com", "cc";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers3: timers@40000400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000002>;
+			resets = <&rctl STM32_RESET(APB1L, 1U)>;
+			interrupts = <16 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers14: timers@40002000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40002000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00008000>;
+			resets = <&rctl STM32_RESET(APB1H, 15U)>;
+			interrupts = <19 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers16: timers@40014400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00020000>;
+			resets = <&rctl STM32_RESET(APB1H, 17U)>;
+			interrupts = <21 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers17: timers@40014800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00040000>;
+			resets = <&rctl STM32_RESET(APB1H, 18U)>;
+			interrupts = <22 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
 		};
 	};
 };


### PR DESCRIPTION
Adding timers and pwm to the STM32C0-series.

I've tested this using the basic/fade_led sample on the nucleo_c031c6 board with the following nodes, I verified pwm output on an oscilloscope:

```
&timers1 {
	st,prescaler = <10000>;
	status = "okay";

	pwm1: pwm {
		pinctrl-0 = <&tim1_ch1_pa5>;
		pinctrl-names = "default";
		status = "okay";
	};
};

&timers3 {
	st,prescaler = <10000>;
	status = "okay";

	pwm3: pwm {
		pinctrl-0 = <&tim3_ch1_pa6>;
		pinctrl-names = "default";
		status = "okay";
	};
};

&timers14 {
	st,prescaler = <10000>;
	status = "okay";

	pwm14: pwm {
		pinctrl-0 = <&tim14_ch1_pa4>;
		pinctrl-names = "default";
		status = "okay";
	};
};

&timers16 {
	st,prescaler = <10000>;
	status = "okay";

	pwm16: pwm {
		pinctrl-0 = <&tim16_ch1_pa0>;
		pinctrl-names = "default";
		status = "okay";
	};
};

&timers17 {
	st,prescaler = <10000>;
	status = "okay";

	pwm17: pwm {
		pinctrl-0 = <&tim17_ch1_pa1>;
		pinctrl-names = "default";
		status = "okay";
	};
};
```