### PR TITLE
twister: fix timeout status for the device handler

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -630,7 +630,7 @@ class DeviceHandler(Handler):
             if harness.state == "failed":
                 self.instance.reason = "Failed"
         elif not flash_error:
-            self.instance.status = "error"
+            self.instance.status = "failed"
             self.instance.reason = "Timeout"
 
         if self.instance.status == "error":


### PR DESCRIPTION
Currently in binary handler and qemu handler we have status `failed` in case of test timeout, but in device handler we have status `error`. This not only adds inconsistency between handlers, but also prevents us from usage test retry functionality for the runs on HW.

Fix timeout status by changing it to `failed` instead of `error`.