### PR TITLE
drivers/sensor: lsm6dso: Pass back matching trigger pointer

### DIFF
--- a/drivers/sensor/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/lsm6dso/lsm6dso.h
@@ -108,8 +108,16 @@ struct lsm6dso_data {
 	struct gpio_callback gpio_cb;
 	sensor_trigger_handler_t handler_drdy_acc;
 	sensor_trigger_handler_t handler_drdy_gyr;
-	sensor_trigger_handler_t handler_drdy_temp;
 
+	IF_ENABLED(CONFIG_LSM6DSO_ENABLE_TEMP, (
+		sensor_trigger_handler_t handler_drdy_temp;
+	))
+	const struct sensor_trigger *trigger_drdy_acc;
+	const struct sensor_trigger *trigger_drdy_gyr;
+
+	IF_ENABLED(CONFIG_LSM6DSO_ENABLE_TEMP, (
+		const struct sensor_trigger *trigger_drdy_temp;
+	))
 #if defined(CONFIG_LSM6DSO_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_LSM6DSO_THREAD_STACK_SIZE);
 	struct k_thread thread;

--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -135,6 +135,7 @@ int lsm6dso_trigger_set(const struct device *dev,
 
 	if (trig->chan == SENSOR_CHAN_ACCEL_XYZ) {
 		lsm6dso->handler_drdy_acc = handler;
+		lsm6dso->trigger_drdy_acc = trig;
 		if (handler) {
 			return lsm6dso_enable_xl_int(dev, LSM6DSO_EN_BIT);
 		} else {
@@ -142,6 +143,7 @@ int lsm6dso_trigger_set(const struct device *dev,
 		}
 	} else if (trig->chan == SENSOR_CHAN_GYRO_XYZ) {
 		lsm6dso->handler_drdy_gyr = handler;
+		lsm6dso->trigger_drdy_gyr = trig;
 		if (handler) {
 			return lsm6dso_enable_g_int(dev, LSM6DSO_EN_BIT);
 		} else {
@@ -151,6 +153,7 @@ int lsm6dso_trigger_set(const struct device *dev,
 #if defined(CONFIG_LSM6DSO_ENABLE_TEMP)
 	else if (trig->chan == SENSOR_CHAN_DIE_TEMP) {
 		lsm6dso->handler_drdy_temp = handler;
+		lsm6dso->trigger_drdy_temp = trig;
 		if (handler) {
 			return lsm6dso_enable_t_int(dev, LSM6DSO_EN_BIT);
 		} else {
@@ -169,9 +172,6 @@ int lsm6dso_trigger_set(const struct device *dev,
 static void lsm6dso_handle_interrupt(const struct device *dev)
 {
 	struct lsm6dso_data *lsm6dso = dev->data;
-	struct sensor_trigger drdy_trigger = {
-		.type = SENSOR_TRIG_DATA_READY,
-	};
 	const struct lsm6dso_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	lsm6dso_status_reg_t status;
@@ -191,16 +191,16 @@ static void lsm6dso_handle_interrupt(const struct device *dev)
 		}
 
 		if ((status.xlda) && (lsm6dso->handler_drdy_acc != NULL)) {
-			lsm6dso->handler_drdy_acc(dev, &drdy_trigger);
+			lsm6dso->handler_drdy_acc(dev, lsm6dso->trigger_drdy_acc);
 		}
 
 		if ((status.gda) && (lsm6dso->handler_drdy_gyr != NULL)) {
-			lsm6dso->handler_drdy_gyr(dev, &drdy_trigger);
+			lsm6dso->handler_drdy_gyr(dev, lsm6dso->trigger_drdy_gyr);
 		}
 
 #if defined(CONFIG_LSM6DSO_ENABLE_TEMP)
 		if ((status.tda) && (lsm6dso->handler_drdy_temp != NULL)) {
-			lsm6dso->handler_drdy_temp(dev, &drdy_trigger);
+			lsm6dso->handler_drdy_temp(dev, lsm6dso->trigger_drdy_temp);
 		}
 #endif
 	}


### PR DESCRIPTION
The trigger pointer passed to the handler should be the same one passed in when the trigger was set.  This is not well documented.

This way the calling code can embedded the trigger inside another struct and use CONTAINER_OF to get back to the containing struct, where there can be data for the handler to use.  The sensor API does not provide a "user_data" field for callbacks, as the embedded struct method was supposed to be used.

Also make the fields needed in the data struct for the temperature trigger conditional on the trigger being supported in the driver.  All the code using the fields was already coditionally compiled; only the field itself wasn't.