### PR TITLE
drivers: adc: stm32f1x serie has no overrun interrupt

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1087,7 +1087,9 @@ static int start_read(const struct device *dev,
 	 */
 	adc_stm32_enable(adc);
 
+#if !defined(CONFIG_SOC_SERIES_STM32F1X)
 	LL_ADC_ClearFlag_OVR(adc);
+#endif  /* ! CONFIG_SOC_SERIES_STM32F1X */
 
 #if !defined(CONFIG_ADC_STM32_DMA)
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || \


### PR DESCRIPTION
In the adc_stm32 driver, at adc start_read(), the OVR flag when it exists in ADC peripheral --> not available on the stm32f1 serie.

Following the https://github.com/zephyrproject-rtos/zephyr/pull/52965
there was a regression (build error)  on the stm32f1 serie:  

```
` $ west build -p auto -b nucleo_f103rb tests/drivers/adc/adc_api/`  
[1/11] Building C object zephyr/drivers/adc/CMakeFiles/drivers__adc.dir/adc_stm32.c.obj
./drivers/adc/adc_stm32.c: In function 'start_read':
./drivers/adc/adc_stm32.c:1091:9: warning: implicit declaration of function 'LL_ADC_ClearFlag_OVR'; did you mean 'LL_ADC_ClearFlag_EOS'? [-Wimplicit-function-declaration]
 1091 |         LL_ADC_ClearFlag_OVR(adc);

```
The stm32f1x serie has no OVerRun interrupt. 
A simple compilation Flag will fix the issue.

   Signed-off-by: Francois Ramu <francois.ramu@st.com>