### PR TITLE
net: icmpv6: fix Kconfig dependency if NET_NATIVE is not used

### DIFF
--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -132,7 +132,7 @@ config NET_IPV6_DAD
 config NET_IPV6_RA_RDNSS
 	bool "Support RA RDNSS option"
 	depends on NET_IPV6_ND
-	select DNS_RESOLVER
+	depends on DNS_RESOLVER
 	default y
 	help
 	  Support Router Advertisement Recursive DNS Server option.


### PR DESCRIPTION
DNS_RESOLVER has direct dependency NET_NATIVE.
NET_IPV6 does not depend on NET_NATIVE, consequently neither does the Kconfig option NET_IPV6_RA_RDNSS.

Change select, added by the commit cb50d49f33b0
("net: icmpv6: Implement IPv6 RA Recursive DNS Server option"), to "depends on DNS_RESOLVER". This should not change the behavior when using NET_NATIVE since NET_IPV6_RA_RDNSS is enabled by default.