### PR TITLE
tests/bsim compile: Several improvements

### DIFF
--- a/tests/bsim/compile.source
+++ b/tests/bsim/compile.source
@@ -39,8 +39,11 @@ function _compile(){
 
   local ret=0
 
-  local cmake_cmd=(cmake -GNinja -DBOARD_ROOT=${BOARD_ROOT} -DBOARD=${BOARD} \
-            -DCONF_FILE=${conf_file} -DOVERLAY_CONFIG=${conf_overlay} \
+  local cmake_cmd=(cmake -GNinja -DBOARD_ROOT=${BOARD_ROOT} -DBOARD=${BOARD})
+  if [ $conf_file != "prj.conf" ]; then
+    local cmake_cmd+=( -DCONF_FILE=${conf_file})
+  fi
+  local cmake_cmd+=( -DOVERLAY_CONFIG=${conf_overlay} \
             ${modules_arg} \
             ${cmake_args} -DCMAKE_C_FLAGS=\"${cc_flags}\" ${app_root}/${app})
 

--- a/tests/bsim/compile.source
+++ b/tests/bsim/compile.source
@@ -22,21 +22,16 @@ function _compile(){
   local cc_flags="${cc_flags:-"-Werror"}"
 
   if [ "${conf_overlay}" ]; then
-    local exe_name="${exe_name:-bs_${BOARD}_${app}_${conf_file}_${conf_overlay}}"
+    local exe_basename="${exe_name:-bs_${BOARD}_${app}_${conf_file}_${conf_overlay}}"
   else
-    local exe_name="${exe_name:-bs_${BOARD}_${app}_${conf_file}}"
+    local exe_basename="${exe_name:-bs_${BOARD}_${app}_${conf_file}}"
   fi
 
-  local exe_name=${exe_name//\//_}
-  local exe_name=${exe_name//./_}
-  local exe_name=${BSIM_OUT_PATH}/bin/$exe_name
+  local exe_basename=$(echo ${exe_basename} | tr \"/\\.\; _ )
+  local exe_name=${BSIM_OUT_PATH}/bin/$exe_basename
   local map_file_name=${exe_name}.Tsymbols
 
-  if [ "${conf_overlay}" ]; then
-    local this_dir=${WORK_DIR}/${app}/${conf_file}_${conf_overlay}
-  else
-    local this_dir=${WORK_DIR}/${app}/${conf_file}
-  fi
+  local this_dir=${WORK_DIR}/${app}/${exe_basename}
 
   local modules_arg="${ZEPHYR_MODULES:+-DZEPHYR_MODULES=${ZEPHYR_MODULES}}"
 


### PR DESCRIPTION
tests/bsim compile: Add support for multiple conf files

Add support for multiple conf files and
configuration files with paths, quotes, etc.
Now it is possible to do, for example
conf_file='myprj.conf;boards/board_name.conf'
to provide both a project configuration and an overlay

----

tests/bsim compile: Do not provide prj conf if default
 
Do not provide the default prj.conf to cmake, as that
causes it to not use the board overlays, which is not
what users would normally expect.
