### PR TITLE
Bluetooth: controller: Fix incorrect iso_interval at ISO-AL for BIS

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -250,9 +250,10 @@ uint8_t ll_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
 	/* iso_interval shall be at least SDU interval,
 	 * or integer multiple of SDU interval for unframed PDUs
 	 */
-	iso_interval_us = ((sdu_interval * lll_adv_iso->bn * sdu_per_event) /
-			   (bn * PERIODIC_INT_UNIT_US)) * PERIODIC_INT_UNIT_US;
-	lll_adv_iso->iso_interval = iso_interval_us;
+	lll_adv_iso->iso_interval = ((sdu_interval * lll_adv_iso->bn
+				      * sdu_per_event) /
+				     (bn * PERIODIC_INT_UNIT_US));
+	iso_interval_us = lll_adv_iso->iso_interval * PERIODIC_INT_UNIT_US;
 
 	/* Immediate Repetition Count (IRC), Mandatory IRC = 1 */
 	lll_adv_iso->irc = rtn + 1U;


### PR DESCRIPTION
Value received at ISO-AL for BIS iso_interval is a time value but what is expected is an integer multiplier of 1250us similar to the information in the CIG.

lll_adv_iso->iso_interval is only 12-bits and is not sufficient for the range of iso_interval_us.

_This was reported from a third party. The information that I received:_
> For host parameters RTN=2, interval=10000 latency=10 sdu=40 packing=0 framing=0 bis_count=1,
> which become in big_info: NSE=4, PTO=1, IRC=3, BN=1, ISO_interval=10.00ms,
> here's what gets passed into `isoal_source_create()`:
> bn==1
> sdu_interval==10000
> iso_interval==1808
>  
> and since ISO_INT_UNIT_US==1250, we have
>  
> pdus_per_sdu= (burst_number * sdu_interval) / ((uint32_t)iso_interval * ISO_INT_UNIT_US)
> = 1 * 10000 / (1808 * 1250)
> = 10000/2260000
> = 0.0044
> = 0