### PR TITLE
mgmt/mcumgr: Image management upgrade minor fix

### DIFF
--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -297,10 +297,11 @@ where:
     | "data"                | optional image data                               |
     +-----------------------+---------------------------------------------------+
     | "upgrade"             | optional flag that states that only upgrade       |
-    |                       | should be allowed, so if version of uploaded      |
-    |                       | software is lower then already on device, the     |
-    |                       | image update should be rejected                   |
-    |                       | (unused by Zephyr at this time)                   |
+    |                       | should be allowed, so if the version of uploaded  |
+    |                       | software is not higher then already on a device,  |
+    |                       | the image upload will be rejected.                |
+    |                       | Zephyr only compares major, minor and revision    |
+    |                       | (x.y.z).                                          |
     +-----------------------+---------------------------------------------------+
 
 .. note::

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -654,7 +654,7 @@ img_mgmt_upload_inspect(const struct img_mgmt_upload_req *req,
 				return MGMT_ERR_EUNKNOWN;
 			}
 
-			if (img_mgmt_vercmp(&cur_ver, &hdr->ih_ver) >= 0) {
+			if (img_mgmt_vercmp(&cur_ver, &hdr->ih_ver) > 0) {
 				IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action,
 					img_mgmt_err_str_downgrade);
 				return MGMT_ERR_EBADSTATE;


### PR DESCRIPTION
Two commits:
 1) Fixing "upgrade" flag logic to only allow upgrade; previously when the flag was set the same version could be uploaded, as running, which seems to not follow meaning of upgrade;
 2) Doc update, to clarify what "upgrade" does and removal of info that Zephyr does not support this flag, which is not true.