### PR TITLE
Bluetooth: audio: Expand AICS API

### DIFF
--- a/include/zephyr/bluetooth/audio/aics.h
+++ b/include/zephyr/bluetooth/audio/aics.h
@@ -346,6 +346,18 @@ int bt_aics_type_get(struct bt_aics *inst);
 int bt_aics_status_get(struct bt_aics *inst);
 
 /**
+ * @brief Disable mute in the Audio Input Control Service.
+ *
+ * Calling bt_aics_unmute() or bt_aics_mute() will enable
+ * mute again and set the mute state to either unmuted or muted.
+ *
+ * @param inst          The instance pointer.
+ *
+ * @return 0 on success, errno value on fail.
+ */
+int bt_aics_disable_mute(struct bt_aics *inst);
+
+/**
  * @brief Unmute the Audio Input Control Service input.
  *
  * @param inst          The instance pointer.
@@ -362,6 +374,27 @@ int bt_aics_unmute(struct bt_aics *inst);
  * @return 0 on success, GATT error value on fail.
  */
 int bt_aics_mute(struct bt_aics *inst);
+
+/**
+ * @brief Set manual only gain mode in Audio Input Control Service.
+ *
+ * @param inst          The instance pointer.
+ *
+ * @return 0 on success, errno value on fail.
+ */
+int bt_aics_gain_set_manual_only(struct bt_aics *inst);
+
+/**
+ * @brief Set automatic only gain mode in Audio Input Control Service.
+ *
+ * Using this function and enabling automatic only gain disables
+ * setting the gain with bt_aics_gain_set
+ *
+ * @param inst          The instance pointer.
+ *
+ * @return 0 on success, errno value on fail.
+ */
+int bt_aics_gain_set_auto_only(struct bt_aics *inst);
 
 /**
  * @brief Set input gain to manual.

--- a/subsys/bluetooth/audio/aics.c
+++ b/subsys/bluetooth/audio/aics.c
@@ -563,6 +563,35 @@ int bt_aics_activate(struct bt_aics *inst)
 }
 
 #endif /* CONFIG_BT_AICS */
+int bt_aics_gain_set_manual_only(struct bt_aics *inst)
+{
+	CHECKIF(!inst) {
+		LOG_DBG("NULL instance");
+		return -EINVAL;
+	}
+
+	inst->srv.state.gain_mode = BT_AICS_MODE_MANUAL_ONLY;
+
+	bt_gatt_notify_uuid(NULL, BT_UUID_AICS_STATE, inst->srv.service_p->attrs,
+			    &inst->srv.state, sizeof(inst->srv.state));
+
+	return 0;
+}
+
+int bt_aics_gain_set_auto_only(struct bt_aics *inst)
+{
+	CHECKIF(!inst) {
+		LOG_DBG("NULL instance");
+		return -EINVAL;
+	}
+
+	inst->srv.state.gain_mode = BT_AICS_MODE_AUTO_ONLY;
+
+	bt_gatt_notify_uuid(NULL, BT_UUID_AICS_STATE, inst->srv.service_p->attrs,
+			    &inst->srv.state, sizeof(inst->srv.state));
+
+	return 0;
+}
 
 int bt_aics_state_get(struct bt_aics *inst)
 {
@@ -651,6 +680,21 @@ int bt_aics_status_get(struct bt_aics *inst)
 	}
 
 	return -ENOTSUP;
+}
+
+int bt_aics_disable_mute(struct bt_aics *inst)
+{
+	CHECKIF(!inst) {
+		LOG_DBG("NULL instance");
+		return -EINVAL;
+	}
+
+	inst->srv.state.mute = BT_AICS_STATE_MUTE_DISABLED;
+
+	bt_gatt_notify_uuid(NULL, BT_UUID_AICS_STATE, inst->srv.service_p->attrs,
+			    &inst->srv.state, sizeof(inst->srv.state));
+
+	return 0;
 }
 
 int bt_aics_unmute(struct bt_aics *inst)

--- a/tests/bluetooth/tester/src/btp_vcp.c
+++ b/tests/bluetooth/tester/src/btp_vcp.c
@@ -170,8 +170,11 @@ static uint8_t aics_supported_commands(const void *cmd, uint16_t cmd_len,
 	tester_set_bit(rp->data, BTP_AICS_SET_GAIN);
 	tester_set_bit(rp->data, BTP_AICS_MUTE);
 	tester_set_bit(rp->data, BTP_AICS_UNMUTE);
+	tester_set_bit(rp->data, BTP_AICS_MUTE_DISABLE);
 	tester_set_bit(rp->data, BTP_AICS_MAN_GAIN);
 	tester_set_bit(rp->data, BTP_AICS_AUTO_GAIN);
+	tester_set_bit(rp->data, BTP_AICS_MAN_GAIN_ONLY);
+	tester_set_bit(rp->data, BTP_AICS_AUTO_GAIN_ONLY);
 
 	/* octet 1 */
 	tester_set_bit(rp->data, BTP_AICS_DESCRIPTION);
@@ -248,6 +251,20 @@ static uint8_t aics_mute(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
+static uint8_t aics_mute_disable(const void *cmd, uint16_t cmd_len,
+				 void *rsp, uint16_t *rsp_len)
+{
+	LOG_DBG("AICS mute disable");
+
+	for (int i = 0; i < CONFIG_BT_VCP_VOL_REND_AICS_INSTANCE_COUNT; i++) {
+		if (bt_aics_disable_mute(included.aics[i]) != 0) {
+			return BTP_STATUS_FAILED;
+		}
+	}
+
+	return BTP_STATUS_SUCCESS;
+}
+
 static uint8_t aics_unmute(const void *cmd, uint16_t cmd_len,
 			   void *rsp, uint16_t *rsp_len)
 {
@@ -283,6 +300,34 @@ static uint8_t aics_auto_gain(const void *cmd, uint16_t cmd_len,
 
 	for (int i = 0; i < CONFIG_BT_VCP_VOL_REND_AICS_INSTANCE_COUNT; i++) {
 		if (bt_aics_automatic_gain_set(included.aics[i]) != 0) {
+			return BTP_STATUS_FAILED;
+		}
+	}
+
+	return BTP_STATUS_SUCCESS;
+}
+
+static uint8_t aics_auto_gain_only(const void *cmd, uint16_t cmd_len,
+				   void *rsp, uint16_t *rsp_len)
+{
+	LOG_DBG("AICS auto gain only set");
+
+	for (int i = 0; i < CONFIG_BT_VCP_VOL_REND_AICS_INSTANCE_COUNT; i++) {
+		if (bt_aics_gain_set_auto_only(included.aics[i]) != 0) {
+			return BTP_STATUS_FAILED;
+		}
+	}
+
+	return BTP_STATUS_SUCCESS;
+}
+
+static uint8_t aics_man_gain_only(const void *cmd, uint16_t cmd_len,
+				  void *rsp, uint16_t *rsp_len)
+{
+	LOG_DBG("AICS manual gain only set");
+
+	for (int i = 0; i < CONFIG_BT_VCP_VOL_REND_AICS_INSTANCE_COUNT; i++) {
+		if (bt_aics_gain_set_manual_only(included.aics[i]) != 0) {
 			return BTP_STATUS_FAILED;
 		}
 	}
@@ -342,6 +387,11 @@ static const struct btp_handler aics_handlers[] = {
 		.func = aics_unmute,
 	},
 	{
+		.opcode = BTP_AICS_MUTE_DISABLE,
+		.expect_len = 0,
+		.func = aics_mute_disable,
+	},
+	{
 		.opcode = BTP_AICS_MAN_GAIN,
 		.expect_len = 0,
 		.func = aics_man_gain,
@@ -350,6 +400,16 @@ static const struct btp_handler aics_handlers[] = {
 		.opcode = BTP_AICS_AUTO_GAIN,
 		.expect_len = 0,
 		.func = aics_auto_gain,
+	},
+	{
+		.opcode = BTP_AICS_AUTO_GAIN_ONLY,
+		.expect_len = 0,
+		.func = aics_auto_gain_only,
+	},
+	{
+		.opcode = BTP_AICS_MAN_GAIN_ONLY,
+		.expect_len = 0,
+		.func = aics_man_gain_only,
 	},
 	{
 		.opcode = BTP_AICS_DESCRIPTION,


### PR DESCRIPTION
This PR adds new API functions for AICS
Setting automatic/manual only gain modes.
Setting mute disabled.

Auto-pts tests:
1/2   AICS    AICS/SR/SGGIT/CP/BI-03-C   PASS           36.713                  
2/2   AICS    AICS/SR/SGGIT/CP/BI-04-C   PASS           37.512
