### PR TITLE
kernel: cleaner solution to pipes SMP race condition

### DIFF
--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -337,6 +337,8 @@ struct k_thread {
 	struct k_mem_paging_stats_t paging_stats;
 #endif
 
+	struct k_spinlock *obj_lock;
+
 #ifdef CONFIG_PIPES
 	/** Pipe descriptor used with blocking k_pipe operations */
 	struct _pipe_desc pipe_desc;

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -65,11 +65,6 @@ void z_requeue_current(struct k_thread *curr);
 struct k_thread *z_swap_next_thread(void);
 void z_thread_abort(struct k_thread *thread);
 
-static inline void z_pend_curr_unlocked(_wait_q_t *wait_q, k_timeout_t timeout)
-{
-	(void) z_pend_curr_irqlock(arch_irq_lock(), wait_q, timeout);
-}
-
 static inline void z_reschedule_unlocked(void)
 {
 	(void) z_reschedule_irqlock(arch_irq_lock());

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -351,8 +351,8 @@ static size_t pipe_write(struct k_pipe *pipe, sys_dlist_t *src_list,
 
 			/* The thread's read request has been satisfied. */
 
-			z_unpend_thread(dest->thread);
-			z_ready_thread(dest->thread);
+			z_abort_timeout(&dest->thread->base.timeout);
+			z_sched_wake_thread(dest->thread, false);
 
 			*reschedule = true;
 		}
@@ -484,16 +484,6 @@ int z_impl_k_pipe_put(struct k_pipe *pipe, void *data, size_t bytes_to_write,
 
 	z_sched_wait(&pipe->lock, key, &pipe->wait_q.writers, timeout, NULL);
 
-	/*
-	 * On SMP systems, threads in the processing list may timeout before
-	 * the data has finished copying. The following spin lock/unlock pair
-	 * prevents those threads from executing further until the data copying
-	 * is complete.
-	 */
-
-	key = k_spin_lock(&pipe->lock);
-	k_spin_unlock(&pipe->lock, key);
-
 	*bytes_written = bytes_to_write - src_desc->bytes_to_xfer;
 
 	int ret = pipe_return_code(min_xfer, src_desc->bytes_to_xfer,
@@ -609,8 +599,8 @@ static int pipe_get_internal(k_spinlock_key_t key, struct k_pipe *pipe,
 
 			/* The thread's write request has been satisfied. */
 
-			z_unpend_thread(src_desc->thread);
-			z_ready_thread(src_desc->thread);
+			z_abort_timeout(&src_desc->thread->base.timeout);
+			z_sched_wake_thread(src_desc->thread, false);
 
 			reschedule_needed = true;
 		}
@@ -669,16 +659,6 @@ static int pipe_get_internal(k_spinlock_key_t key, struct k_pipe *pipe,
 	_current->base.swap_data = dest_desc;
 
 	z_sched_wait(&pipe->lock, key, &pipe->wait_q.readers, timeout, NULL);
-
-	/*
-	 * On SMP systems, threads in the processing list may timeout before
-	 * the data has finished copying. The following spin lock/unlock pair
-	 * prevents those threads from executing further until the data copying
-	 * is complete.
-	 */
-
-	key = k_spin_lock(&pipe->lock);
-	k_spin_unlock(&pipe->lock, key);
 
 	*bytes_read = bytes_to_read - dest_desc->bytes_to_xfer;
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -821,30 +821,6 @@ void z_thread_timeout(struct _timeout *timeout)
 }
 #endif
 
-int z_pend_curr_irqlock(uint32_t key, _wait_q_t *wait_q, k_timeout_t timeout)
-{
-	/* This is a legacy API for pre-switch architectures and isn't
-	 * correctly synchronized for multi-cpu use
-	 */
-	__ASSERT_NO_MSG(!IS_ENABLED(CONFIG_SMP));
-
-	pend_locked(_current, wait_q, timeout);
-
-#if defined(CONFIG_TIMESLICING) && defined(CONFIG_SWAP_NONATOMIC)
-	pending_current = _current;
-
-	int ret = z_swap_irqlock(key);
-	LOCKED(&sched_spinlock) {
-		if (pending_current == _current) {
-			pending_current = NULL;
-		}
-	}
-	return ret;
-#else
-	return z_swap_irqlock(key);
-#endif
-}
-
 int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
 	       _wait_q_t *wait_q, k_timeout_t timeout)
 {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -810,17 +810,6 @@ void z_sched_wake_thread(struct k_thread *thread, bool is_timeout)
 
 }
 
-#ifdef CONFIG_SYS_CLOCK_EXISTS
-/* Timeout handler for *_thread_timeout() APIs */
-void z_thread_timeout(struct _timeout *timeout)
-{
-	struct k_thread *thread = CONTAINER_OF(timeout,
-					       struct k_thread, base.timeout);
-
-	z_sched_wake_thread(thread, true);
-}
-#endif
-
 int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
 	       _wait_q_t *wait_q, k_timeout_t timeout)
 {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -827,6 +827,7 @@ int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
 	 * held.
 	 */
 	(void) k_spin_lock(&sched_spinlock);
+	_current->obj_lock = lock;
 	pend_locked(_current, wait_q, timeout);
 	k_spin_release(lock);
 	return z_swap(&sched_spinlock, key);

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -773,9 +773,7 @@ static inline void unpend_thread_no_timeout(struct k_thread *thread)
 ALWAYS_INLINE void z_unpend_thread_no_timeout(struct k_thread *thread)
 {
 	LOCKED(&sched_spinlock) {
-		if (thread->base.pended_on != NULL) {
-			unpend_thread_no_timeout(thread);
-		}
+		unpend_thread_no_timeout(thread);
 	}
 }
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1121,3 +1121,14 @@ int k_thread_runtime_stats_all_get(k_thread_runtime_stats_t *stats)
 
 	return 0;
 }
+
+#ifdef CONFIG_SYS_CLOCK_EXISTS
+/* Timeout handler for *_thread_timeout() APIs */
+void z_thread_timeout(struct _timeout *timeout)
+{
+	struct k_thread *thread = CONTAINER_OF(timeout,
+					       struct k_thread, base.timeout);
+
+	z_sched_wake_thread(thread, true);
+}
+#endif


### PR DESCRIPTION
An earlier set of commits had a rather hacky solution to the following race condition in the kernel pipes.

> While processing the list of threads involved in the pipe operation, one or more of those threads timeout could expire, which in turn would lead to the thread waking and executing while data was still being copied to it.

This set of commits proposes a (hopefully) cleaner solution. Waiting threads involved in the data copying are tagged via the k_thread `no_wake_on_timeout` field. This prevents them from timing out while the operation is in progress. This approach also requires some minor post-work cleanup to undo `no_wake_on_timeout` changes in the case of a failure and incomplete timeouts flagged by `timeout_expired`.