### PR TITLE
ci: backport_issue_check: Use ubuntu-22.04 virtual environment

### DIFF
--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   backport:
     name: Backport Issue Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
 
     steps:


### PR DESCRIPTION
This commit updates the pull request backport issue check workflow to use the Ubuntu 22.04 virtual environment.

Hotfix for the following pyopenssl error due to the outdated distro-provided Python packages:

```
Traceback (most recent call last):
  File "/home/runner/work/_actions/zephyrproject-rtos/action-manifest/a6d0c6e52bbbb7d6df23ceb42842edcb4582b8dc/action.py", line 17, in <module>
    import requests
  File "/usr/lib/python3/dist-packages/requests/__init__.py", line 95, in <module>
    from urllib3.contrib import pyopenssl
  File "/usr/lib/python3/dist-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
  File "/usr/lib/python3/dist-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1553, in <module>
    class X509StoreFlags(object):
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1573, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
```

Related to https://github.com/zephyrproject-rtos/zephyr/pull/55954