### PR TITLE
kernel: Add missing stdbool.h to kernel/stats.h

### DIFF
--- a/include/zephyr/kernel/stats.h
+++ b/include/zephyr/kernel/stats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Intel Corporation
+ * Copyright (c) 2021,2023, Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +8,7 @@
 #define ZEPHYR_INCLUDE_KERNEL_STATS_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /*
  * [k_cycle_stats] is used to track internal statistics about both thread


### PR DESCRIPTION
The structure k_cycle_stats uses the bool type. Consequently it should include the stdbool.h header file.

Fixes #55972