### PR TITLE
[Backport v2.7-branch] ci: assigner, manifest: Use ubuntu-22.04 virtual environment

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   contribs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Manifest
     steps:
       - name: Checkout the code


### PR DESCRIPTION
Backport of https://github.com/zephyrproject-rtos/zephyr/pull/55954

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/56055