### PR TITLE
drivers: sensor: Add generic ADC thermistor sensor driver

### DIFF
--- a/drivers/sensor/CMakeLists.txt
+++ b/drivers/sensor/CMakeLists.txt
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+add_subdirectory_ifdef(CONFIG_ADC_THERMISTOR	adc_thermistor)
 add_subdirectory_ifdef(CONFIG_ADT7420		adt7420)
 add_subdirectory_ifdef(CONFIG_ADXL345		adxl345)
 add_subdirectory_ifdef(CONFIG_ADXL362		adxl362)

--- a/drivers/sensor/Kconfig
+++ b/drivers/sensor/Kconfig
@@ -41,6 +41,8 @@ config SENSOR_INFO
 
 comment "Device Drivers"
 
+source "drivers/sensor/adc_thermistor/Kconfig"
+
 source "drivers/sensor/adt7420/Kconfig"
 
 source "drivers/sensor/adxl345/Kconfig"

--- a/drivers/sensor/adc_thermistor/CMakeLists.txt
+++ b/drivers/sensor/adc_thermistor/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(adc_thermistor.c)

--- a/drivers/sensor/adc_thermistor/Kconfig
+++ b/drivers/sensor/adc_thermistor/Kconfig
@@ -1,0 +1,12 @@
+# Generic ADC temperature sensor configuration options
+
+# Copyright (c) 2023 Basalte bv
+# SPDX-License-Identifier: Apache-2.0
+
+config ADC_THERMISTOR
+	bool "ADC Temperature Sensor"
+	default y
+	depends on DT_HAS_ZEPHYR_ADC_THERMISTOR_ENABLED
+	select ADC
+	help
+	  Enable driver for generic ADC temperature thermistor sensor.

--- a/drivers/sensor/adc_thermistor/adc_thermistor.c
+++ b/drivers/sensor/adc_thermistor/adc_thermistor.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2023 Basalte bv
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/adc.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(adc_thermistor, CONFIG_SENSOR_LOG_LEVEL);
+
+#define DT_DRV_COMPAT zephyr_adc_thermistor
+
+struct adc_thermistor_config {
+	const struct adc_dt_spec adc;
+
+	const int32_t *lut;
+	size_t lut_size;
+};
+
+struct adc_thermistor_data {
+	struct k_mutex mutex;
+
+	int32_t val;
+};
+
+static int adc_thermistor_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	const struct adc_thermistor_config *config = dev->config;
+	struct adc_thermistor_data *data = dev->data;
+	int ret;
+
+	uint16_t buf;
+	struct adc_sequence sequence = {
+		.buffer = &buf,
+		/* buffer size in bytes, not number of samples */
+		.buffer_size = sizeof(buf),
+	};
+
+	/* Allow fetching using ambient or die temperature channel */
+	switch (chan) {
+	case SENSOR_CHAN_ALL:
+	case SENSOR_CHAN_AMBIENT_TEMP:
+	case SENSOR_CHAN_DIE_TEMP:
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	k_mutex_lock(&data->mutex, K_FOREVER);
+
+	ret = adc_channel_setup_dt(&config->adc);
+	if (ret < 0) {
+		LOG_ERR("Failed to setup thermal ADC (%d)", ret);
+		goto unlock;
+	}
+
+	ret = adc_sequence_init_dt(&config->adc, &sequence);
+	if (ret < 0) {
+		LOG_ERR("Failed to init thermal ADC sequence (%d)", ret);
+		goto unlock;
+	}
+
+	ret = adc_read(config->adc.dev, &sequence);
+	if (ret < 0) {
+		LOG_ERR("Failed to read thermal ADC (%d)", ret);
+		goto unlock;
+	}
+
+	data->val = buf;
+
+	/* Try to convert to mV if supported, leave as raw otherwise */
+	adc_raw_to_millivolts_dt(&config->adc, &data->val);
+
+unlock:
+	k_mutex_unlock(&data->mutex);
+
+	return ret;
+}
+
+static int adc_thermistor_channel_get(const struct device *dev, enum sensor_channel chan,
+				      struct sensor_value *val)
+{
+	const struct adc_thermistor_config *config = dev->config;
+	struct adc_thermistor_data *data = dev->data;
+	int temp_val = data->val;
+
+	/* Allow getting using ambient or die temperature channel */
+	switch (chan) {
+	case SENSOR_CHAN_AMBIENT_TEMP:
+	case SENSOR_CHAN_DIE_TEMP:
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	if (config->lut_size > 0) {
+		size_t i;
+
+		for (i = 0; i < config->lut_size; ++i) {
+			if (temp_val >= config->lut[2 * i + 1]) {
+				break;
+			}
+		}
+
+		if (i == 0) {
+			temp_val = config->lut[0];
+		} else if (i >= config->lut_size) {
+			temp_val = config->lut[2 * (config->lut_size - 1)];
+		} else {
+			/* Linear in between two values */
+			int32_t adc_hi, adc_lo, temp_hi, temp_lo;
+
+			adc_hi = config->lut[2 * i - 1];
+			adc_lo = config->lut[2 * i + 1];
+
+			if (adc_hi == adc_lo) {
+				/* Prevent division by zero */
+				LOG_ERR("Duplicate ADC entries for %d", adc_hi);
+				return -EINVAL;
+			}
+
+			temp_hi = config->lut[2 * i - 2];
+			temp_lo = config->lut[2 * i];
+
+			temp_val = (temp_lo - temp_hi) * (temp_val - adc_hi);
+			temp_val /= (adc_lo - adc_hi);
+			temp_val += temp_hi;
+		}
+	}
+
+	val->val1 = temp_val / 1000;
+	val->val2 = (temp_val % 1000) * 1000;
+
+	return 0;
+}
+
+static const struct sensor_driver_api adc_thermistor_driver_api = {
+	.sample_fetch = adc_thermistor_sample_fetch,
+	.channel_get = adc_thermistor_channel_get,
+};
+
+static int adc_thermistor_init(const struct device *dev)
+{
+	const struct adc_thermistor_config *config = dev->config;
+	struct adc_thermistor_data *data = dev->data;
+
+	k_mutex_init(&data->mutex);
+
+	if (!device_is_ready(config->adc.dev)) {
+		LOG_ERR("Thermal ADC device not ready");
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+#define ADC_THERMISTOR_DEFINE(inst)								\
+	BUILD_ASSERT(DT_INST_PROP_LEN_OR(inst, temperature_lookup_table, 0) % 2 == 0,		\
+		     "Temperature lookup table needs an even size");				\
+	static const int32_t adc_thermistor_lut_##inst[]					\
+		= DT_INST_PROP_OR(inst, temperature_lookup_table, {});				\
+												\
+	static const struct adc_thermistor_config adc_thermistor_dev_config_##inst = {		\
+		.adc = ADC_DT_SPEC_INST_GET(inst),						\
+		.lut = adc_thermistor_lut_##inst,						\
+		.lut_size = DT_INST_PROP_LEN_OR(inst, temperature_lookup_table, 0) / 2,		\
+	};											\
+												\
+	static struct adc_thermistor_data adc_thermistor_dev_data_##inst;			\
+												\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, adc_thermistor_init, NULL,				\
+				     &adc_thermistor_dev_data_##inst,				\
+				     &adc_thermistor_dev_config_##inst,				\
+				     POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,			\
+				     &adc_thermistor_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(ADC_THERMISTOR_DEFINE)

--- a/dts/bindings/sensor/zephyr,adc-thermistor.yaml
+++ b/dts/bindings/sensor/zephyr,adc-thermistor.yaml
@@ -1,0 +1,50 @@
+# Copyright (c) 2023, Basalte bv
+# SPDX-License-Identifier: Apache-2.0
+
+compatible: "zephyr,adc-thermistor"
+
+include: sensor-device.yaml
+
+description: |
+  General Purpose ADC based thermistor sensor with an optional lookup table.
+
+  Example:
+    ntc: ntc {
+      compatible = "zephyr,adc-thermistor";
+      io-channels = <&adc0 1>;
+      temperature-lookup-table = <
+        0      3086
+        10000  2951
+        20000  2761
+        30000  2512
+        40000  2214
+        50000  1887
+        60000  1558
+        70000  1251
+        80000  985
+        90000  763
+        100000 585
+        110000 449
+        120000 347
+        125000 305
+      >;
+    };
+
+properties:
+  io-channels:
+    required: true
+    description: ADC channel for temperature sensor.
+
+  temperature-lookup-table:
+    type: array
+    description: |
+      Lookup table to map the relation between ADC value and temperature.
+      When ADC is read, the value is looked up in the table to get the
+      equivalent temperature.
+
+      The table has to have pairs of values where the first value of each
+      is the temperature in milliCelsius and the second value is the ADC
+      read value. The ADC values have to be in descending order.
+
+      If not specified, the driver assumes the ADC channel gives milliCelsius
+      directly.

--- a/samples/sensor/die_temp_polling/boards/sam4s_xplained.overlay
+++ b/samples/sensor/die_temp_polling/boards/sam4s_xplained.overlay
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023, Basalte bv
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/ {
+	aliases {
+		die-temp0 = &die_temp;
+	};
+
+	die_temp: die-temp {
+		status = "okay";
+		compatible = "zephyr,adc-thermistor";
+		io-channels = <&adc0 15>;
+		temperature-lookup-table = <
+			105000   1806
+			27000    1440
+			(-40000) 1125
+		>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/* Internal die temperature sensor */
+	channel@f {
+		reg = <15>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <15>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/samples/sensor/die_temp_polling/sample.yaml
+++ b/samples/sensor/die_temp_polling/sample.yaml
@@ -10,3 +10,11 @@ tests:
       type: one_line
       regex:
         - "CPU Die temperature\\[[A-Za-z0-9_]+\\]: [1-9][0-9].[0-9] °C"
+  sample.sensor.adc_die_temperature_polling:
+    tags: sensors tests
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "CPU Die temperature\\[[A-Za-z0-9_]+\\]: [1-9][0-9].[0-9] °C"
+    platform_allow: sam4s_xplained


### PR DESCRIPTION
Add a generic driver to translate ADC readings to a temperature value using an optional lookup table. Similar to linux's [thermal-generic-adc](https://www.kernel.org/doc/Documentation/devicetree/bindings/thermal/thermal-generic-adc.txt) driver.

Tested on a custom Atmel SAM4S SoC board with `samples/sensor/die_temp_polling`:
```
*** Booting Zephyr OS build zephyr-v3.3.0-1634-g38bb20cf9140 ***
CPU Die temperature[die-temp]: 30.8 °C
CPU Die temperature[die-temp]: 31.5 °C
CPU Die temperature[die-temp]: 30.8 °C
CPU Die temperature[die-temp]: 31.9 °C
CPU Die temperature[die-temp]: 32.1 °C
```

**Review the changes of #54947 first, to see if that implementation is favoured.**