### PR TITLE
armclang: Fix building cortex-m4 w/o floating point

### DIFF
--- a/cmake/compiler/armclang/target.cmake
+++ b/cmake/compiler/armclang/target.cmake
@@ -38,6 +38,8 @@ else()
     elseif(CONFIG_FP_HARDABI)
       list(APPEND TOOLCHAIN_C_FLAGS   -mfloat-abi=hard)
     endif()
+  else()
+    list(APPEND TOOLCHAIN_C_FLAGS   -mfloat-abi=soft)
   endif()
 endif()
 


### PR DESCRIPTION
When we build for a SoC that has a cortex-m4 w/o a FPU that utilizes CMSIS headers with armclang (like mec1501modular_assy6885) we get the following warning:

modules/hal/cmsis/CMSIS/Core/Include/core_cm4.h:93:8: warning:
   "Compiler generates FPU instructions for a device without
    an FPU (check __FPU_PRESENT)" [-W#warnings]
   #warning "Compiler generates FPU instructions for a device
   without an FPU (check __FPU_PRESENT)"

Fix the by setting -mfloat-abi=soft for such cases that don't have FPU enabled.

Fixes #56068