### PR TITLE
bluetooth: ascs: Fix NULL pointer dereference in ascs_ase_read

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1249,11 +1249,17 @@ static ssize_t ascs_ase_read(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
-	struct bt_ascs *ascs = ascs_get(conn);
+	struct bt_ascs *ascs;
 	struct bt_ascs_ase *ase;
 	uint8_t ase_id;
 
 	LOG_DBG("conn %p attr %p buf %p len %u offset %u", (void *)conn, attr, buf, len, offset);
+
+	if (!conn) {
+		return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
+	}
+
+	ascs = ascs_get(conn);
 
 	ase_id = POINTER_TO_UINT(BT_AUDIO_CHRC_USER_DATA(attr));
 


### PR DESCRIPTION
"The (ATT attribute read) callback can also be used locally to read the contents of the attribute in which case no connection will be set."

This means that callback may be called with NULL conn. Since for ascs_ase_read NULL conn object have no meaning just return error.