### PR TITLE
boards: arm: nrf9160dk: change order of buttons on IO expander

### DIFF
--- a/boards/arm/nrf9160dk_nrf9160/dts/nrf9160dk_buttons_on_io_expander.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160/dts/nrf9160dk_buttons_on_io_expander.dtsi
@@ -11,17 +11,17 @@
 };
 
 &button0 {
-	gpios = <&pcal6408a 2 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-};
-
-&button1 {
-	gpios = <&pcal6408a 3 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-};
-
-&button2 {
 	gpios = <&pcal6408a 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 };
 
-&button3 {
+&button1 {
 	gpios = <&pcal6408a 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+};
+
+&button2 {
+	gpios = <&pcal6408a 2 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+};
+
+&button3 {
+	gpios = <&pcal6408a 3 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 };

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -319,8 +319,9 @@ Boards & SoC Support
     ``nrf9160dk_nrf9160`` and ``nrf9160dk_nrf52840``. To build for an
     older revision of the nRF9160 DK without external flash, specify that
     older board revision when building.
-
-  * Enabled external_flash_pins_routing switch in ``nrf9160dk_nrf52840`` by default.
+  * ``nrf9160dk_nrf52840``: Enabled external_flash_pins_routing switch by default.
+  * ``nrf9160dk_nrf9160``: Changed the order of buttons and switches on the GPIO
+    expander to match the order when using GPIO directly on the nRF9160 SoC.
 
 * Made these changes for ARM64 boards:
 


### PR DESCRIPTION
Change order of buttons and switches on the nRF9160DK IO expander to match the configuration without the IO expander.