### PR TITLE
Cleanup after moving nordic counter drivers to use device tree

### DIFF
--- a/drivers/timer/Kconfig.nrf_rtc
+++ b/drivers/timer/Kconfig.nrf_rtc
@@ -8,6 +8,7 @@ config NRF_RTC_TIMER
 	depends on CLOCK_CONTROL
 	depends on SOC_COMPATIBLE_NRF
 	select TICKLESS_CAPABLE
+	depends on !$(dt_nodelabel_enabled,rtc1)
 	help
 	  This module implements a kernel device driver for the nRF Real Time
 	  Counter NRF_RTC1 and provides the standard "system clock driver"

--- a/samples/drivers/counter/alarm/Kconfig
+++ b/samples/drivers/counter/alarm/Kconfig
@@ -3,10 +3,6 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-config COUNTER_RTC0
-	bool
-	default y if SOC_FAMILY_NRF
-
 config COUNTER_SAM0_TC32
 	bool
 	default y if BOARD_ATSAMD20_XPRO

--- a/samples/drivers/counter/alarm/boards/nrf51dk_nrf51422.overlay
+++ b/samples/drivers/counter/alarm/boards/nrf51dk_nrf51422.overlay
@@ -1,0 +1,3 @@
+&rtc0 {
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/counter/alarm/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,3 @@
+&rtc0 {
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/nrf52dk_nrf52832.overlay
+++ b/samples/drivers/counter/alarm/boards/nrf52dk_nrf52832.overlay
@@ -1,0 +1,3 @@
+&rtc0 {
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/nrf9160dk_nrf9160.overlay
+++ b/samples/drivers/counter/alarm/boards/nrf9160dk_nrf9160.overlay
@@ -1,0 +1,3 @@
+&rtc0 {
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -21,7 +21,7 @@ struct counter_alarm_cfg alarm_cfg;
 #define TIMER DT_NODELABEL(tc0)
 #elif defined(CONFIG_COUNTER_MICROCHIP_MCP7940N)
 #define TIMER DT_NODELABEL(extrtc0)
-#elif defined(CONFIG_COUNTER_RTC0)
+#elif defined(CONFIG_COUNTER_NRF_RTC)
 #define TIMER DT_NODELABEL(rtc0)
 #elif defined(CONFIG_COUNTER_TIMER_STM32)
 #define TIMER DT_INST(0, st_stm32_counter)


### PR DESCRIPTION
Cleanup after #55898.

Fixing compilation of `samples/drivers/counter/alarm` for nordic DKs.
Adding missing protection in `nrf_rtc_timer`.

Fixes #56105.
Fixes #56188.