### PR TITLE
Bluetooth: Host: Add missing `bt_conn_unref`s

### DIFF
--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -689,11 +689,13 @@ int hci_df_prepare_connection_iq_report(struct net_buf *buf,
 
 	if (!atomic_test_bit(conn->flags, BT_CONN_CTE_RX_ENABLED)) {
 		LOG_ERR("Received conn CTE report when CTE receive disabled");
+		bt_conn_unref(conn);
 		return -EINVAL;
 	}
 
 	if (!(conn->cte_types & BIT(evt->cte_type))) {
 		LOG_DBG("CTE filtered out by cte_type: %u", evt->cte_type);
+		bt_conn_unref(conn);
 		return -EINVAL;
 	}
 
@@ -739,11 +741,13 @@ int hci_df_vs_prepare_connection_iq_report(struct net_buf *buf,
 
 	if (!atomic_test_bit(conn->flags, BT_CONN_CTE_RX_ENABLED)) {
 		LOG_ERR("Received conn CTE report when CTE receive disabled");
+		bt_conn_unref(conn);
 		return -EINVAL;
 	}
 
 	if (!(conn->cte_types & BIT(evt->cte_type))) {
 		LOG_DBG("CTE filtered out by cte_type: %u", evt->cte_type);
+		bt_conn_unref(conn);
 		return -EINVAL;
 	}
 
@@ -862,6 +866,7 @@ int hci_df_prepare_conn_cte_req_failed(struct net_buf *buf,
 
 	if (!atomic_test_bit(conn->flags, BT_CONN_CTE_REQ_ENABLED)) {
 		LOG_ERR("Received conn CTE request notification when CTE REQ disabled");
+		bt_conn_unref(conn);
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -985,6 +985,7 @@ void hci_le_cis_established(struct net_buf *buf)
 
 	CHECKIF(iso->type != BT_CONN_TYPE_ISO) {
 		LOG_DBG("Invalid connection type %u", iso->type);
+		bt_conn_unref(iso);
 		return;
 	}
 
@@ -1230,6 +1231,8 @@ void hci_le_cis_req(struct net_buf *buf)
 		if (err != 0) {
 			LOG_ERR("Failed to reject CIS");
 		}
+
+		bt_conn_unref(acl);
 		return;
 	}
 
@@ -1253,6 +1256,7 @@ void hci_le_cis_req(struct net_buf *buf)
 	err = iso_accept(acl, iso);
 	if (err) {
 		LOG_DBG("App rejected ISO %d", err);
+		bt_iso_cleanup_acl(iso);
 		bt_conn_unref(iso);
 		hci_le_reject_cis(cis_handle,
 				  BT_HCI_ERR_INSUFFICIENT_RESOURCES);
@@ -1265,6 +1269,7 @@ void hci_le_cis_req(struct net_buf *buf)
 
 	err = hci_le_accept_cis(cis_handle);
 	if (err) {
+		bt_iso_cleanup_acl(iso);
 		bt_conn_unref(iso);
 		hci_le_reject_cis(cis_handle,
 				  BT_HCI_ERR_INSUFFICIENT_RESOURCES);

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1064,6 +1064,7 @@ void bt_hci_le_past_received(struct net_buf *buf)
 	if (!per_adv_sync) {
 		LOG_WRN("Could not allocate new PA sync from PAST");
 		per_adv_sync_terminate(sys_le16_to_cpu(evt->sync_handle));
+		bt_conn_unref(sync_info.conn);
 		return;
 	}
 
@@ -1094,6 +1095,8 @@ void bt_hci_le_past_received(struct net_buf *buf)
 			listener->synced(per_adv_sync, &sync_info);
 		}
 	}
+
+	bt_conn_unref(sync_info.conn);
 }
 #endif /* CONFIG_BT_CONN */
 


### PR DESCRIPTION
A few places in the host were missing bt_conn_unref in error cases