### PR TITLE
kconfig: add note about increasing default stack sizes for -O0

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -360,6 +360,9 @@ config NO_OPTIMIZATIONS
 	help
 	  Compiler optimizations will be set to -O0 independently of other
 	  options.
+
+	  Selecting this option will likely require manual tuning of the
+	  default stack sizes in order to avoid stack overflows.
 endchoice
 
 config COMPILER_WARNINGS_AS_ERRORS


### PR DESCRIPTION
Add a note about increasing default stack sizes to the CONFIG_NO_OPTIMIZATIONS help text.

A quick search for closed issues mentioning `CONFIG_NO_OPTIMIZATIONS` reveals that many users are not aware of non-optimized code resulting in higher RAM usage (see https://github.com/zephyrproject-rtos/zephyr/issues?q=is%3Aissue+CONFIG_NO_OPTIMIZATIONS+is%3Aclosed+).