### PR TITLE
zefi: Remove unneeded include

### DIFF
--- a/arch/x86/zefi/efi.h
+++ b/arch/x86/zefi/efi.h
@@ -10,7 +10,6 @@
 #ifndef _ASMLANGUAGE
 
 #include <stdbool.h>
-#include <zephyr/sys/util.h>
 
 #define __abi __attribute__((ms_abi))
 


### PR DESCRIPTION
Fixes unneeded chain of includes.
It would make sense to strip util.h from any include

Fixes issues in:  #56014