### PR TITLE
drivers: adc: stm32 adc driver must wait about 1ms after enabling

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -666,21 +666,21 @@ static int adc_stm32_enable(ADC_TypeDef *adc)
 
 	LL_ADC_ClearFlag_ADRDY(adc);
 	LL_ADC_Enable(adc);
-
 	/*
-	 * Enabling ADC modules in L4, WB, G0 and G4 series may fail if they are
-	 * still not stabilized, this will wait for a short time to ensure ADC
-	 * modules are properly enabled.
+	 * Enabling ADC modules in WL, L4, WB, G0 and G4 series may fail if they are
+	 * still not stabilized, this will wait for a short time (about 1ms)
+	 * to ensure ADC modules are properly enabled.
 	 */
 	uint32_t count_timeout = 0;
 
 	while (LL_ADC_IsActiveFlag_ADRDY(adc) == 0) {
 		if (LL_ADC_IsEnabled(adc) == 0UL) {
 			LL_ADC_Enable(adc);
-			count_timeout++;
-			if (count_timeout == 10) {
-				return -ETIMEDOUT;
-			}
+		}
+		count_timeout++;
+		k_busy_wait(100);
+		if (count_timeout >= 10) {
+			return -ETIMEDOUT;
 		}
 	}
 #else


### PR DESCRIPTION
After enabling the ADC, the peripheral has a certain delay (about 1ms) to set its ADC Ready flag in the ADC ISR register.
In between, the ADRDY is still 0 and the ADEN is 1 in the CR. 
The ADC can be used for conversion, only when the ADRDY bit is set

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55728
This fixes the pb  on internal temperature measurement with nucleo_wl55jc:  
$ west build -p auto -b nucleo_wl55jc samples/sensor/stm32_temp_sensor
```
Current temperature: 4.6 �°C
Current temperature: 4.3 �°C
```
