### PR TITLE
Parametrize west sign with CONFIG_MCUBOOT_CMAKE_WEST_SIGN_PARAMS

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -791,6 +791,18 @@ config BOOTLOADER_MCUBOOT
 
 if BOOTLOADER_MCUBOOT
 
+config MCUBOOT_CMAKE_WEST_SIGN_PARAMS
+	string "Extra parameters to west sign"
+	default "--quiet"
+	help
+	  Parameters that are passed by cmake to west sign, just after
+	  the command, before all other parameters needed for image
+	  signing.
+	  By default this is set to "--quiet" to prevent extra, non-error,
+	  diagnostic messages from west sign. This does not affect signing
+	  tool for which extra parameters are passed with
+	  MCUBOOT_EXTRA_IMGTOOL_ARGS.
+
 config MCUBOOT_SIGNATURE_KEY_FILE
 	string "Path to the mcuboot signing key file"
 	default ""

--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -71,7 +71,9 @@ function(zephyr_mcuboot_tasks)
   endif()
 
   # Basic 'west sign' command and output format independent arguments.
-  set(west_sign ${WEST} sign --quiet --tool imgtool
+  separate_arguments(west_sign_extra UNIX_COMMAND ${CONFIG_MCUBOOT_CMAKE_WEST_SIGN_PARAMS})
+  set(west_sign ${WEST} sign ${west_sign_extra}
+    --tool imgtool
     --tool-path "${imgtool_path}"
     --build-dir "${APPLICATION_BINARY_DIR}")
 

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -382,6 +382,9 @@ HALs
 MCUboot
 *******
 
+* Added :kconfig:option:`CONFIG_MCUBOOT_CMAKE_WEST_SIGN_PARAMS` that allows to pass arguments to
+  west sign when invoked from cmake.
+
 Storage
 *******
 


### PR DESCRIPTION
The PR adds Kconfig option CONFIG_MCUBOOT_CMAKE_WEST_SIGN_PARAMS that is used to pass parameters to west sign command in cmake invocation.
By default it takes value of "--quiet" and replaces the "--quiet" argument within cmake invocation, which allows to pass additional arguments to cmake or remove the default.

In my use case it allows me to remove "--quiet" and get diagnostic info from west sign, without edit on cmake/mcuboot.cmake