### PR TITLE
littlefs: fix return code on mount

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -381,6 +381,9 @@ Libraries / Subsystems
 * File systems
 
   * Added :kconfig:option:`CONFIG_FS_FATFS_REENTRANT` to enable the FAT FS reentrant option.
+  * With LittleFS as backend, :c:func:`fs_mount` return code was corrected to ``EFAULT`` when
+    called with ``FS_MOUNT_FLAG_NO_FORMAT`` and the designated LittleFS area could not be
+    mounted because it has not yet been mounted or it required reformatting.
 
 * Management
 

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -855,8 +855,8 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 	ret = lfs_mount(&fs->lfs, &fs->cfg);
 	if (ret < 0 &&
 	    (mountp->flags & FS_MOUNT_FLAG_NO_FORMAT) == 0) {
-		LOG_WRN("can't mount (LFS %d); formatting", ret);
 		if ((mountp->flags & FS_MOUNT_FLAG_READ_ONLY) == 0) {
+			LOG_WRN("can't mount (LFS %d); formatting", ret);
 			ret = lfs_format(&fs->lfs, &fs->cfg);
 			if (ret < 0) {
 				LOG_ERR("format failed (LFS %d)", ret);
@@ -875,6 +875,9 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 			ret = lfs_to_errno(ret);
 			goto out;
 		}
+	} else {
+		ret = lfs_to_errno(ret);
+		goto out;
 	}
 
 	LOG_INF("%s mounted", mountp->mnt_point);

--- a/tests/subsys/fs/common/test_fs_mkfs.c
+++ b/tests/subsys/fs/common/test_fs_mkfs.c
@@ -26,7 +26,7 @@ void test_fs_mkfs_simple(void)
 	ret = fs_mount(fs_mkfs_mp);
 
 	if (fs_mkfs_mp->type == FS_LITTLEFS) {
-		zassert_equal(ret, -EILSEQ, "Expected EILSEQ got %d", ret);
+		zassert_equal(ret, -EFAULT, "Expected EFAULT got %d", ret);
 	} else if (fs_mkfs_mp->type == FS_FATFS) {
 		zassert_equal(ret, -ENODEV, "Expected ENODEV got %d", ret);
 	}


### PR DESCRIPTION
When littlefs mount fails and there is no formatting requested, the return code must be translated to errno before being passed to the application layer.

Additionally, only log a warning that the FS will be formatted, when the system is not read-only.

Fixes #56378