### PR TITLE
soc: esp32s3: enable zephyr toolchain

### DIFF
--- a/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.yaml
+++ b/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.yaml
@@ -3,7 +3,7 @@ name: ESP32-S3 DevKitM
 type: mcu
 arch: xtensa
 toolchain:
-  - espressif
+  - zephyr
 supported:
   - gpio
   - uart


### PR DESCRIPTION
SDK 0.16 includes ESP32-S3 toolchain. This PR enable its usage.