### PR TITLE
Bluetooth: controller: fix kconfig dependency

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -546,7 +546,7 @@ config BT_CTLR_ADV_EXT
 	depends on BT_CTLR_ADV_EXT_SUPPORT
 	select BT_CTLR_CHAN_SEL_2 if BT_LL_SW_SPLIT && BT_BROADCASTER
 	select BT_CTLR_SCAN_REQ_NOTIFY if BT_LL_SW_SPLIT && BT_BROADCASTER
-	select BT_TICKER_EXT
+	select BT_TICKER_EXT if BT_LL_SW_SPLIT
 	default y if BT_EXT_ADV
 	help
 	  Enable support for Bluetooth 5.0 LE Advertising Extensions in the


### PR DESCRIPTION
BT_TICKER_EXT is being selected undiscriminately, but it's a Zephyr controller feature.