### PR TITLE
tests: Bluetooth: ascs: Fix bap_unicast_server_cb mocks

### DIFF
--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -566,10 +566,12 @@ static struct bt_bap_stream *stream_allocated;
 int unicast_server_cb_config_custom_fake(struct bt_conn *conn, const struct bt_bap_ep *ep,
 					 enum bt_audio_dir dir, const struct bt_codec *codec,
 					 struct bt_bap_stream **stream,
-					 struct bt_codec_qos_pref *const pref)
+					 struct bt_codec_qos_pref *const pref,
+					 struct bt_bap_ascs_rsp *rsp)
 {
 	*stream = stream_allocated;
 	*pref = qos_pref;
+	*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS, BT_BAP_ASCS_REASON_NONE);
 
 	bt_bap_stream_cb_register(*stream, &mock_bap_stream_ops);
 

--- a/tests/bluetooth/audio/mocks/include/bap_unicast_server.h
+++ b/tests/bluetooth/audio/mocks/include/bap_unicast_server.h
@@ -17,19 +17,24 @@ void mock_bap_unicast_server_cleanup(void);
 
 DECLARE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_config, struct bt_conn *,
 			const struct bt_bap_ep *, enum bt_audio_dir, const struct bt_codec *,
-			struct bt_bap_stream **, struct bt_codec_qos_pref *const);
+			struct bt_bap_stream **, struct bt_codec_qos_pref *const,
+			struct bt_bap_ascs_rsp *);
 DECLARE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_reconfig, struct bt_bap_stream *,
 			enum bt_audio_dir, const struct bt_codec *,
-			struct bt_codec_qos_pref *const);
+			struct bt_codec_qos_pref *const, struct bt_bap_ascs_rsp *);
 DECLARE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_qos, struct bt_bap_stream *,
-			const struct bt_codec_qos *);
+			const struct bt_codec_qos *, struct bt_bap_ascs_rsp *);
 DECLARE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_enable, struct bt_bap_stream *,
-			const struct bt_codec_data *, size_t);
-DECLARE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_start, struct bt_bap_stream *);
+			const struct bt_codec_data *, size_t, struct bt_bap_ascs_rsp *);
+DECLARE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_start, struct bt_bap_stream *,
+			struct bt_bap_ascs_rsp *);
 DECLARE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_metadata, struct bt_bap_stream *,
-			const struct bt_codec_data *, size_t);
-DECLARE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_disable, struct bt_bap_stream *);
-DECLARE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_stop, struct bt_bap_stream *);
-DECLARE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_release, struct bt_bap_stream *);
+			const struct bt_codec_data *, size_t, struct bt_bap_ascs_rsp *);
+DECLARE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_disable, struct bt_bap_stream *,
+			struct bt_bap_ascs_rsp *);
+DECLARE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_stop, struct bt_bap_stream *,
+			struct bt_bap_ascs_rsp *);
+DECLARE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_release, struct bt_bap_stream *,
+			struct bt_bap_ascs_rsp *);
 
 #endif /* MOCKS_BAP_UNICAST_SERVER_H_ */

--- a/tests/bluetooth/audio/mocks/src/bap_unicast_server.c
+++ b/tests/bluetooth/audio/mocks/src/bap_unicast_server.c
@@ -32,19 +32,25 @@ void mock_bap_unicast_server_cleanup(void)
 
 DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_config, struct bt_conn *,
 		       const struct bt_bap_ep *, enum bt_audio_dir, const struct bt_codec *,
-		       struct bt_bap_stream **, struct bt_codec_qos_pref *const);
+		       struct bt_bap_stream **, struct bt_codec_qos_pref *const,
+		       struct bt_bap_ascs_rsp *);
 DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_reconfig, struct bt_bap_stream *,
-		       enum bt_audio_dir, const struct bt_codec *, struct bt_codec_qos_pref *const);
+		       enum bt_audio_dir, const struct bt_codec *, struct bt_codec_qos_pref *const,
+		       struct bt_bap_ascs_rsp *);
 DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_qos, struct bt_bap_stream *,
-		       const struct bt_codec_qos *);
+		       const struct bt_codec_qos *, struct bt_bap_ascs_rsp *);
 DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_enable, struct bt_bap_stream *,
-		       const struct bt_codec_data *, size_t);
-DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_start, struct bt_bap_stream *);
+		       const struct bt_codec_data *, size_t, struct bt_bap_ascs_rsp *);
+DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_start, struct bt_bap_stream *,
+		       struct bt_bap_ascs_rsp *);
 DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_metadata, struct bt_bap_stream *,
-		       const struct bt_codec_data *, size_t);
-DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_disable, struct bt_bap_stream *);
-DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_stop, struct bt_bap_stream *);
-DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_release, struct bt_bap_stream *);
+		       const struct bt_codec_data *, size_t, struct bt_bap_ascs_rsp *);
+DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_disable, struct bt_bap_stream *,
+		       struct bt_bap_ascs_rsp *);
+DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_stop, struct bt_bap_stream *,
+		       struct bt_bap_ascs_rsp *);
+DEFINE_FAKE_VALUE_FUNC(int, mock_bap_unicast_server_cb_release, struct bt_bap_stream *,
+		       struct bt_bap_ascs_rsp *);
 
 const struct bt_bap_unicast_server_cb mock_bap_unicast_server_cb = {
 	.config = mock_bap_unicast_server_cb_config,


### PR DESCRIPTION
This fixes merge conflict issue by adding missing function parameters that were introduced in
57784df5f0df665ef5012f0ad7e3528494a27b12.