### PR TITLE
soc: esp32s3: add ble support

### DIFF
--- a/boards/riscv/esp32c3_devkitm/Kconfig.defconfig
+++ b/boards/riscv/esp32c3_devkitm/Kconfig.defconfig
@@ -9,7 +9,7 @@ config BOARD
 
 config HEAP_MEM_POOL_SIZE
 	default 98304 if WIFI
-	default 16384 if BT
+	default 40960 if BT
 	default 4096
 
 choice BT_HCI_BUS_TYPE

--- a/boards/riscv/icev_wireless/Kconfig.defconfig
+++ b/boards/riscv/icev_wireless/Kconfig.defconfig
@@ -7,7 +7,7 @@ config BOARD
 
 config HEAP_MEM_POOL_SIZE
 	default 98304 if WIFI
-	default 16384 if BT
+	default 40960 if BT
 	default 4096
 
 choice BT_HCI_BUS_TYPE

--- a/boards/riscv/stamp_c3/Kconfig.defconfig
+++ b/boards/riscv/stamp_c3/Kconfig.defconfig
@@ -9,7 +9,7 @@ config BOARD
 
 config HEAP_MEM_POOL_SIZE
 	default 98304 if WIFI
-	default 16384 if BT
+	default 40960 if BT
 	default 4096
 
 if BT

--- a/boards/riscv/xiao_esp32c3/Kconfig.defconfig
+++ b/boards/riscv/xiao_esp32c3/Kconfig.defconfig
@@ -7,7 +7,7 @@ config BOARD
 
 config HEAP_MEM_POOL_SIZE
 	default 98304 if WIFI
-	default 16384 if BT
+	default 40960 if BT
 	default 4096
 
 choice BT_HCI_BUS_TYPE

--- a/boards/xtensa/esp32/Kconfig.defconfig
+++ b/boards/xtensa/esp32/Kconfig.defconfig
@@ -12,7 +12,7 @@ config ENTROPY_GENERATOR
 
 config HEAP_MEM_POOL_SIZE
 	default 98304 if WIFI
-	default 16384 if BT
+	default 40960 if BT
 	default 4096
 
 choice BT_HCI_BUS_TYPE

--- a/boards/xtensa/esp32_ethernet_kit/Kconfig.defconfig
+++ b/boards/xtensa/esp32_ethernet_kit/Kconfig.defconfig
@@ -19,7 +19,7 @@ config ENTROPY_GENERATOR
 
 config HEAP_MEM_POOL_SIZE
 	default 98304 if WIFI
-	default 16384 if BT
+	default 40960 if BT
 	default 4096
 
 choice BT_HCI_BUS_TYPE

--- a/boards/xtensa/esp32_net/Kconfig.defconfig
+++ b/boards/xtensa/esp32_net/Kconfig.defconfig
@@ -12,7 +12,7 @@ config ENTROPY_GENERATOR
 
 config HEAP_MEM_POOL_SIZE
 	default 98304 if WIFI
-	default 16384 if BT
+	default 40960 if BT
 	default 4096
 
 choice BT_HCI_BUS_TYPE

--- a/boards/xtensa/esp32s2_franzininho/Kconfig.defconfig
+++ b/boards/xtensa/esp32s2_franzininho/Kconfig.defconfig
@@ -12,9 +12,4 @@ config ENTROPY_GENERATOR
 
 config HEAP_MEM_POOL_SIZE
 	default 98304 if WIFI
-	default 16384 if BT
 	default 4096
-
-choice BT_HCI_BUS_TYPE
-	default BT_ESP32 if BT
-endchoice

--- a/boards/xtensa/esp32s3_devkitm/Kconfig.defconfig
+++ b/boards/xtensa/esp32s3_devkitm/Kconfig.defconfig
@@ -9,3 +9,11 @@ config BOARD
 
 config ENTROPY_GENERATOR
 	default y
+
+config HEAP_MEM_POOL_SIZE
+	default 40960 if BT
+	default 4096
+
+choice BT_HCI_BUS_TYPE
+	default BT_ESP32 if BT
+endchoice

--- a/boards/xtensa/esp_wrover_kit/Kconfig.defconfig
+++ b/boards/xtensa/esp_wrover_kit/Kconfig.defconfig
@@ -9,7 +9,7 @@ config BOARD
 
 config HEAP_MEM_POOL_SIZE
 	default 98304 if WIFI
-	default 16384 if BT
+	default 40960 if BT
 	default 4096
 
 choice BT_HCI_BUS_TYPE

--- a/boards/xtensa/heltec_wifi_lora32_v2/Kconfig.defconfig
+++ b/boards/xtensa/heltec_wifi_lora32_v2/Kconfig.defconfig
@@ -12,7 +12,7 @@ config ENTROPY_GENERATOR
 
 config HEAP_MEM_POOL_SIZE
 	default 98304 if WIFI
-	default 16384 if BT
+	default 40960 if BT
 	default 4096
 
 choice BT_HCI_BUS_TYPE

--- a/boards/xtensa/m5stickc_plus/Kconfig.defconfig
+++ b/boards/xtensa/m5stickc_plus/Kconfig.defconfig
@@ -12,7 +12,7 @@ config ENTROPY_GENERATOR
 
 config HEAP_MEM_POOL_SIZE
 	default 98304 if WIFI
-	default 16384 if BT
+	default 40960 if BT
 	default 4096
 
 choice BT_HCI_BUS_TYPE

--- a/boards/xtensa/odroid_go/Kconfig.defconfig
+++ b/boards/xtensa/odroid_go/Kconfig.defconfig
@@ -18,7 +18,7 @@ config ENTROPY_GENERATOR
 
 config HEAP_MEM_POOL_SIZE
 	default 98304 if WIFI
-	default 16384 if BT
+	default 40960 if BT
 	default 4096
 
 choice BT_HCI_BUS_TYPE

--- a/boards/xtensa/olimex_esp32_evb/Kconfig.defconfig
+++ b/boards/xtensa/olimex_esp32_evb/Kconfig.defconfig
@@ -13,7 +13,7 @@ config ENTROPY_GENERATOR
 
 config HEAP_MEM_POOL_SIZE
 	default 98304 if WIFI
-	default 16384 if BT
+	default 40960 if BT
 	default 4096
 
 choice BT_HCI_BUS_TYPE

--- a/soc/riscv/esp32c3/Kconfig.soc
+++ b/soc/riscv/esp32c3/Kconfig.soc
@@ -95,4 +95,14 @@ config ESP32_PHY_MAX_TX_POWER
 	int
 	default ESP32_PHY_MAX_WIFI_TX_POWER
 
+config MAC_BB_PD
+	bool "Power down MAC and baseband of Wi-Fi and Bluetooth when PHY is disabled"
+	depends on SOC_ESP32C3 && TICKLESS_KERNEL
+	default n
+	help
+	  If enabled, the MAC and baseband of Wi-Fi and Bluetooth will be powered
+	  down when PHY is disabled. Enabling this setting reduces power consumption
+	  by a small amount but increases RAM use by approximately 4 KB(Wi-Fi only),
+	  2 KB(Bluetooth only) or 5.3 KB(Wi-Fi + Bluetooth).
+
 endif

--- a/soc/xtensa/esp32s3/Kconfig.soc
+++ b/soc/xtensa/esp32s3/Kconfig.soc
@@ -261,6 +261,15 @@ config ESP32S3_DATA_CACHE_WRAP
 	  The wrap length equals to ESP32S3_DATA_CACHE_LINE_SIZE.
 	  However, it depends on complex conditions.
 
+config MAC_BB_PD
+	bool "Power down MAC and baseband of Wi-Fi and Bluetooth when PHY is disabled"
+	depends on SOC_ESP32S3 && TICKLESS_KERNEL
+	default n
+	help
+	  If enabled, the MAC and baseband of Wi-Fi and Bluetooth will be powered
+	  down when PHY is disabled. Enabling this setting reduces power consumption
+	  by a small amount but increases RAM use by approximat
+
 endmenu  # Cache config
 
 endif # SOC_ESP32S3

--- a/west.yml
+++ b/west.yml
@@ -57,7 +57,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 8ee96508f329c7e59fcbf739f060cf12082dd805
+      revision: d7576d0da639acbd9a191a3eb7e4f3f3476c9641
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This update includes the following:

* Add ESP32-S3 support

* Modify BT heap to use system heap instead of custom heap,
which adds ~13kB of RAM to application.