### PR TITLE
tests: uart_mix_fifo_poll: Use "counter_dev" node label

### DIFF
--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf52840dk_nrf52840.overlay
@@ -64,6 +64,6 @@
 	interrupts = <17 2>;
 };
 
-&timer0 {
+counter_dev: &timer0 {
 	status = "okay";
 };

--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -35,6 +35,6 @@
 	interrupts = <21 2>;
 };
 
-&timer0 {
+counter_dev: &timer0 {
 	status = "okay";
 };

--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf9160dk_nrf9160.overlay
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf9160dk_nrf9160.overlay
@@ -35,6 +35,6 @@
 	interrupts = <21 2>;
 };
 
-&timer0 {
+counter_dev: &timer0 {
 	status = "okay";
 };

--- a/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
+++ b/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
@@ -33,6 +33,12 @@
 #define UART_DEVICE_DEV DT_CHOSEN(zephyr_console)
 #endif
 
+#if DT_NODE_EXISTS(DT_NODELABEL(counter_dev))
+#define COUNTER_NODE DT_NODELABEL(counter_dev)
+#else
+#define COUNTER_NODE DT_NODELABEL(timer0)
+#endif
+
 struct rx_source {
 	int cnt;
 	uint8_t prev;
@@ -63,7 +69,7 @@ static struct test_data test_data[3];
 static struct test_data int_async_data;
 
 static const struct device *const counter_dev =
-	DEVICE_DT_GET(DT_NODELABEL(timer0));
+	DEVICE_DT_GET(COUNTER_NODE);
 static const struct device *const uart_dev =
 	DEVICE_DT_GET(UART_DEVICE_DEV);
 


### PR DESCRIPTION
This test needs a counter device. Introduce a node label that allows selecting one in dts overlays instead of using hard-coded `timer0`.