### PR TITLE
Bluetooth: Host: Fix handling of incomplete data status adv reports

### DIFF
--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -831,7 +831,6 @@ void bt_hci_le_per_adv_report(struct net_buf *buf)
 			LOG_DBG("Received incomplete advertising data. "
 				"Advertising report dropped.");
 
-			per_adv_sync->report_truncated = true;
 			net_buf_simple_reset(&per_adv_sync->reassembly);
 
 		} else if (evt->data_status == BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_PARTIAL) {


### PR DESCRIPTION
When receiving extended advertising reports with incomplete data status, it is not necessary to mark for recovering from currently assembled fragments, but rather drop them and start a fresh assembly of subsequently received extended advertising reports.

Timing changes in the Controller cause Periodic Advertising PDUs AUX_SYNC_IND + AUX_CHAIN_IND to be placed between primary channel ADV_EXT_IND and AUX_ADV_IND. This causes the Controller to generate alternating incomplete and complete data status reports, exposing the Host bug that is fixed in this commit.

Relates to commit ba09a252ecd8 ("bluetooth: host: refactor bt_hci_le_per_adv_report data reassembly").


The issue can be reproduced by using the following parameters in the test (test is not updated and merged as TST implementation will depend on internal knowledge of Controller behavior, and also be influenced by random number sequences):
Broadcaster Side:
```c
/* Zephyr Controller schedules the AUX_ADV_IND with added 10 ms to the
 * Extended Advertising Interval.
 * Use 1196.25 (0x077A) ms to get 1206.25 ms AUX_ADV_IND interval, this
 * will place the AUX_SYNC_IND between ADV_EXT_IND and AUX_ADV_IND so that
 * the scanner will generate incomplete data status for periodic advertising
 * report due to scan aux content being occupied for the reception of
 * AUX_ADV_IND until the very last periodic advertising interval before
 * 10 second timeout of long data test.
 */
#define BT_LE_EXT_ADV_NCONN_CUSTOM BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
						   BT_LE_ADV_OPT_USE_NAME, \
						   0x077A, \
						   0x077A, \
						   NULL)
#define BT_LE_PER_ADV_CUSTOM BT_LE_PER_ADV_PARAM(BT_GAP_PER_ADV_SLOW_INT_MIN, \
						 BT_GAP_PER_ADV_SLOW_INT_MAX, \
						 BT_LE_PER_ADV_OPT_NONE)
```

Observer Side:
```c
#define BT_LE_SCAN_CUSTOM BT_LE_SCAN_PARAM(BT_LE_SCAN_TYPE_ACTIVE, \
					   BT_LE_SCAN_OPT_FILTER_DUPLICATE, \
					   0x0030, \
					   0x0030)
```