### PR TITLE
boards: mimxrt101X_evk: Add flash chosen node

### DIFF
--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -23,6 +23,7 @@
 		zephyr,itcm = &itcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
+		zephyr,flash = &at25sf128a;
 	};
 
 	leds {

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -23,6 +23,7 @@
 		zephyr,itcm = &itcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
+		zephyr,flash = &at25sf128a;
 	};
 
 	leds {


### PR DESCRIPTION
RT series now uses flash chosen node, add to RT101X boards

Fixes #56082