### PR TITLE
samples: coap_client: Return correct result from send_simple_coap_request

### DIFF
--- a/samples/net/sockets/coap_client/src/coap-client.c
+++ b/samples/net/sockets/coap_client/src/coap-client.c
@@ -190,7 +190,7 @@ static int send_simple_coap_request(uint8_t method)
 end:
 	k_free(data);
 
-	return 0;
+	return r;
 }
 
 static int send_simple_coap_msgs_and_wait_for_reply(void)


### PR DESCRIPTION
The coap_client sample does not return error results from `send_simple_coap_request`. This means that it may end up waiting for a reply when no message has been sent.