### PR TITLE
Bluetooth: BAP: Do not allow start op when CIS is connecting

### DIFF
--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -1944,6 +1944,7 @@ static int unicast_client_stream_connect(struct bt_bap_stream *stream)
 	case BT_ISO_STATE_DISCONNECTED:
 		return bt_iso_chan_connect(&param, 1);
 	case BT_ISO_STATE_CONNECTING:
+		return -EBUSY;
 	case BT_ISO_STATE_CONNECTED:
 		return -EALREADY;
 	default:


### PR DESCRIPTION
When the CIS is connecting we should not allow sending the receiver start ready command.