### PR TITLE
drivers: sensor: Store sensor trigger as a pointer - batch 2

### DIFF
--- a/drivers/sensor/iis3dhhc/iis3dhhc.h
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.h
@@ -39,6 +39,7 @@ struct iis3dhhc_data {
 	struct gpio_callback gpio_cb;
 
 	sensor_trigger_handler_t handler_drdy;
+	const struct sensor_trigger *trig_drdy;
 	const struct device *dev;
 
 #if defined(CONFIG_IIS3DHHC_TRIGGER_OWN_THREAD)

--- a/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
@@ -51,6 +51,7 @@ int iis3dhhc_trigger_set(const struct device *dev,
 
 	if (trig->chan == SENSOR_CHAN_ACCEL_XYZ) {
 		iis3dhhc->handler_drdy = handler;
+		iis3dhhc->trig_drdy = trig;
 		if (handler) {
 			/* dummy read: re-trigger interrupt */
 			iis3dhhc_acceleration_raw_get(iis3dhhc->ctx, raw);
@@ -70,13 +71,10 @@ int iis3dhhc_trigger_set(const struct device *dev,
 static void iis3dhhc_handle_interrupt(const struct device *dev)
 {
 	struct iis3dhhc_data *iis3dhhc = dev->data;
-	struct sensor_trigger drdy_trigger = {
-		.type = SENSOR_TRIG_DATA_READY,
-	};
 	const struct iis3dhhc_config *cfg = dev->config;
 
 	if (iis3dhhc->handler_drdy != NULL) {
-		iis3dhhc->handler_drdy(dev, &drdy_trigger);
+		iis3dhhc->handler_drdy(dev, iis3dhhc->trig_drdy);
 	}
 
 	gpio_pin_interrupt_configure_dt(&cfg->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);

--- a/drivers/sensor/ina23x/ina230.h
+++ b/drivers/sensor/ina23x/ina230.h
@@ -42,6 +42,7 @@ struct ina230_data {
 	struct gpio_callback gpio_cb;
 	struct k_work work;
 	sensor_trigger_handler_t handler_alert;
+	const struct sensor_trigger *trig_alert;
 #endif  /* CONFIG_INA230_TRIGGER */
 };
 

--- a/drivers/sensor/ina23x/ina230_trigger.c
+++ b/drivers/sensor/ina23x/ina230_trigger.c
@@ -16,7 +16,6 @@ LOG_MODULE_DECLARE(INA230, CONFIG_SENSOR_LOG_LEVEL);
 static void ina230_gpio_callback(const struct device *port,
 				 struct gpio_callback *cb, uint32_t pin)
 {
-	struct sensor_trigger ina230_trigger;
 	struct ina230_data *ina230 = CONTAINER_OF(cb, struct ina230_data, gpio_cb);
 	const struct device *dev = (const struct device *)ina230->dev;
 
@@ -25,8 +24,7 @@ static void ina230_gpio_callback(const struct device *port,
 	ARG_UNUSED(cb);
 
 	if (ina230->handler_alert) {
-		ina230_trigger.type = SENSOR_TRIG_DATA_READY;
-		ina230->handler_alert(dev, &ina230_trigger);
+		ina230->handler_alert(dev, ina230->trig_alert);
 	}
 }
 
@@ -39,6 +37,7 @@ int ina230_trigger_set(const struct device *dev,
 	ARG_UNUSED(trig);
 
 	ina230->handler_alert = handler;
+	ina230->trig_alert = trig;
 
 	return 0;
 }

--- a/drivers/sensor/ina23x/ina237.c
+++ b/drivers/sensor/ina23x/ina237.c
@@ -260,7 +260,6 @@ static void ina237_trigger_work_handler(struct k_work *work)
 	struct ina23x_trigger *trigg = CONTAINER_OF(work, struct ina23x_trigger, conversion_work);
 	struct ina237_data *data = CONTAINER_OF(trigg, struct ina237_data, trigger);
 	const struct ina237_config *config = data->dev->config;
-	struct sensor_trigger ina237_trigger;
 	int ret;
 	uint16_t reg_alert;
 
@@ -277,8 +276,7 @@ static void ina237_trigger_work_handler(struct k_work *work)
 	}
 
 	if (data->trigger.handler_alert) {
-		ina237_trigger.type = SENSOR_TRIG_DATA_READY;
-		data->trigger.handler_alert(data->dev, &ina237_trigger);
+		data->trigger.handler_alert(data->dev, data->trigger.trig_alert);
 	}
 }
 
@@ -361,6 +359,7 @@ static int ina237_trigger_set(const struct device *dev,
 	}
 
 	ina237->trigger.handler_alert = handler;
+	ina237->trigger.trig_alert = trig;
 
 	return 0;
 }

--- a/drivers/sensor/ina23x/ina23x_trigger.h
+++ b/drivers/sensor/ina23x/ina23x_trigger.h
@@ -15,6 +15,7 @@ struct ina23x_trigger {
 	struct gpio_callback gpio_cb;
 	struct k_work conversion_work;
 	sensor_trigger_handler_t handler_alert;
+	const struct sensor_trigger *trig_alert;
 };
 
 int ina23x_trigger_mode_init(struct ina23x_trigger *trigg,

--- a/drivers/sensor/isl29035/isl29035.h
+++ b/drivers/sensor/isl29035/isl29035.h
@@ -116,7 +116,7 @@ struct isl29035_driver_data {
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
 
-	struct sensor_trigger th_trigger;
+	const struct sensor_trigger *th_trigger;
 	sensor_trigger_handler_t th_handler;
 
 #if defined(CONFIG_ISL29035_TRIGGER_OWN_THREAD)

--- a/drivers/sensor/isl29035/isl29035_trigger.c
+++ b/drivers/sensor/isl29035/isl29035_trigger.c
@@ -114,7 +114,7 @@ static void isl29035_thread_cb(const struct device *dev)
 	}
 
 	if (drv_data->th_handler != NULL) {
-		drv_data->th_handler(dev, &drv_data->th_trigger);
+		drv_data->th_handler(dev, drv_data->th_trigger);
 	}
 
 	setup_int(dev, true);
@@ -157,7 +157,7 @@ int isl29035_trigger_set(const struct device *dev,
 	setup_int(dev, false);
 
 	drv_data->th_handler = handler;
-	drv_data->th_trigger = *trig;
+	drv_data->th_trigger = trig;
 
 	/* enable interrupt callback */
 	setup_int(dev, true);

--- a/drivers/sensor/ism330dhcx/ism330dhcx.h
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.h
@@ -96,8 +96,11 @@ struct ism330dhcx_data {
 #ifdef CONFIG_ISM330DHCX_TRIGGER
 	struct gpio_callback gpio_cb;
 	sensor_trigger_handler_t handler_drdy_acc;
+	const struct sensor_trigger *trig_drdy_acc;
 	sensor_trigger_handler_t handler_drdy_gyr;
+	const struct sensor_trigger *trig_drdy_gyr;
 	sensor_trigger_handler_t handler_drdy_temp;
+	const struct sensor_trigger *trig_drdy_temp;
 
 #if defined(CONFIG_ISM330DHCX_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_ISM330DHCX_THREAD_STACK_SIZE);

--- a/drivers/sensor/ism330dhcx/ism330dhcx_trigger.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_trigger.c
@@ -135,6 +135,7 @@ int ism330dhcx_trigger_set(const struct device *dev,
 
 	if (trig->chan == SENSOR_CHAN_ACCEL_XYZ) {
 		ism330dhcx->handler_drdy_acc = handler;
+		ism330dhcx->trig_drdy_acc = trig;
 		if (handler) {
 			return ism330dhcx_enable_xl_int(dev, ISM330DHCX_EN_BIT);
 		} else {
@@ -142,6 +143,7 @@ int ism330dhcx_trigger_set(const struct device *dev,
 		}
 	} else if (trig->chan == SENSOR_CHAN_GYRO_XYZ) {
 		ism330dhcx->handler_drdy_gyr = handler;
+		ism330dhcx->trig_drdy_gyr = trig;
 		if (handler) {
 			return ism330dhcx_enable_g_int(dev, ISM330DHCX_EN_BIT);
 		} else {
@@ -151,6 +153,7 @@ int ism330dhcx_trigger_set(const struct device *dev,
 #if defined(CONFIG_ISM330DHCX_ENABLE_TEMP)
 	else if (trig->chan == SENSOR_CHAN_DIE_TEMP) {
 		ism330dhcx->handler_drdy_temp = handler;
+		ism330dhcx->trig_drdy_temp = trig;
 		if (handler) {
 			return ism330dhcx_enable_t_int(dev, ISM330DHCX_EN_BIT);
 		} else {
@@ -169,9 +172,6 @@ int ism330dhcx_trigger_set(const struct device *dev,
 static void ism330dhcx_handle_interrupt(const struct device *dev)
 {
 	struct ism330dhcx_data *ism330dhcx = dev->data;
-	struct sensor_trigger drdy_trigger = {
-		.type = SENSOR_TRIG_DATA_READY,
-	};
 	const struct ism330dhcx_config *cfg = dev->config;
 	ism330dhcx_status_reg_t status;
 
@@ -190,16 +190,16 @@ static void ism330dhcx_handle_interrupt(const struct device *dev)
 		}
 
 		if ((status.xlda) && (ism330dhcx->handler_drdy_acc != NULL)) {
-			ism330dhcx->handler_drdy_acc(dev, &drdy_trigger);
+			ism330dhcx->handler_drdy_acc(dev, ism330dhcx->trig_drdy_acc);
 		}
 
 		if ((status.gda) && (ism330dhcx->handler_drdy_gyr != NULL)) {
-			ism330dhcx->handler_drdy_gyr(dev, &drdy_trigger);
+			ism330dhcx->handler_drdy_gyr(dev, ism330dhcx->trig_drdy_gyr);
 		}
 
 #if defined(CONFIG_ISM330DHCX_ENABLE_TEMP)
 		if ((status.tda) && (ism330dhcx->handler_drdy_temp != NULL)) {
-			ism330dhcx->handler_drdy_temp(dev, &drdy_trigger);
+			ism330dhcx->handler_drdy_temp(dev, ism330dhcx->trig_drdy_temp);
 		}
 #endif
 	}

--- a/drivers/sensor/ite_vcmp_it8xxx2/vcmp_ite_it8xxx2.c
+++ b/drivers/sensor/ite_vcmp_it8xxx2/vcmp_ite_it8xxx2.c
@@ -69,6 +69,7 @@ struct vcmp_it8xxx2_data {
 	struct k_work work;
 	/* Sensor trigger hanlder to notify user of assetion */
 	sensor_trigger_handler_t handler;
+	const struct sensor_trigger *trig;
 	/* Pointer of voltage comparator device */
 	const struct device *vcmp;
 };
@@ -148,13 +149,9 @@ static void it8xxx2_vcmp_trigger_work_handler(struct k_work *item)
 {
 	struct vcmp_it8xxx2_data *data =
 			CONTAINER_OF(item, struct vcmp_it8xxx2_data, work);
-	struct sensor_trigger trigger = {
-		.type = SENSOR_TRIG_THRESHOLD,
-		.chan = SENSOR_CHAN_VOLTAGE
-	};
 
 	if (data->handler) {
-		data->handler(data->vcmp, &trigger);
+		data->handler(data->vcmp, data->trig);
 	}
 }
 
@@ -214,6 +211,7 @@ static int vcmp_ite_it8xxx2_trigger_set(const struct device *dev,
 	}
 
 	data->handler = handler;
+	data->trig = trig;
 
 	vcmp_work_addr[config->vcmp_ch] = (uint32_t) &data->work;
 

--- a/drivers/sensor/lis2dh/lis2dh.h
+++ b/drivers/sensor/lis2dh/lis2dh.h
@@ -257,7 +257,9 @@ struct lis2dh_data {
 	struct gpio_callback gpio_int2_cb;
 
 	sensor_trigger_handler_t handler_drdy;
+	const struct sensor_trigger *trig_drdy;
 	sensor_trigger_handler_t handler_anymotion;
+	const struct sensor_trigger *trig_anymotion;
 	atomic_t trig_flags;
 	enum sensor_channel chan_drdy;
 

--- a/drivers/sensor/lis2ds12/lis2ds12.h
+++ b/drivers/sensor/lis2ds12/lis2ds12.h
@@ -57,7 +57,7 @@ struct lis2ds12_data {
 #ifdef CONFIG_LIS2DS12_TRIGGER
 	struct gpio_callback gpio_cb;
 
-	struct sensor_trigger data_ready_trigger;
+	const struct sensor_trigger *data_ready_trigger;
 	sensor_trigger_handler_t data_ready_handler;
 	const struct device *dev;
 

--- a/drivers/sensor/lis2ds12/lis2ds12_trigger.c
+++ b/drivers/sensor/lis2ds12/lis2ds12_trigger.c
@@ -42,7 +42,7 @@ static void lis2ds12_handle_drdy_int(const struct device *dev)
 	struct lis2ds12_data *data = dev->data;
 
 	if (data->data_ready_handler != NULL) {
-		data->data_ready_handler(dev, &data->data_ready_trigger);
+		data->data_ready_handler(dev, data->data_ready_trigger);
 	}
 }
 
@@ -203,7 +203,7 @@ int lis2ds12_trigger_set(const struct device *dev,
 	/* re-trigger lost interrupt */
 	lis2ds12_acceleration_raw_get(ctx, raw);
 
-	data->data_ready_trigger = *trig;
+	data->data_ready_trigger = trig;
 
 	lis2ds12_init_interrupt(dev);
 	return gpio_pin_interrupt_configure_dt(&cfg->gpio_int,

--- a/drivers/sensor/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/lis2dw12/lis2dw12.h
@@ -113,15 +113,20 @@ struct lis2dw12_data {
 
 	struct gpio_callback gpio_cb;
 	sensor_trigger_handler_t drdy_handler;
+	const struct sensor_trigger *drdy_trig;
 #ifdef CONFIG_LIS2DW12_TAP
 	sensor_trigger_handler_t tap_handler;
+	const struct sensor_trigger *tap_trig;
 	sensor_trigger_handler_t double_tap_handler;
+	const struct sensor_trigger *double_tap_trig;
 #endif /* CONFIG_LIS2DW12_TAP */
 #ifdef CONFIG_LIS2DW12_THRESHOLD
 	sensor_trigger_handler_t threshold_handler;
+	const struct sensor_trigger *threshold_trig;
 #endif /* CONFIG_LIS2DW12_THRESHOLD */
 #ifdef CONFIG_LIS2DW12_FREEFALL
 	sensor_trigger_handler_t freefall_handler;
+	const struct sensor_trigger *freefall_trig;
 #endif /* CONFIG_LIS2DW12_FREEFALL */
 #if defined(CONFIG_LIS2DW12_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_LIS2DW12_THREAD_STACK_SIZE);

--- a/drivers/sensor/lis2mdl/lis2mdl.h
+++ b/drivers/sensor/lis2mdl/lis2mdl.h
@@ -56,6 +56,7 @@ struct lis2mdl_data {
 	struct gpio_callback gpio_cb;
 
 	sensor_trigger_handler_t handler_drdy;
+	const struct sensor_trigger *trig_drdy;
 
 #if defined(CONFIG_LIS2MDL_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_LIS2MDL_THREAD_STACK_SIZE);

--- a/drivers/sensor/lis2mdl/lis2mdl_trigger.c
+++ b/drivers/sensor/lis2mdl/lis2mdl_trigger.c
@@ -45,6 +45,7 @@ int lis2mdl_trigger_set(const struct device *dev,
 
 	if (trig->chan == SENSOR_CHAN_MAGN_XYZ) {
 		lis2mdl->handler_drdy = handler;
+		lis2mdl->trig_drdy = trig;
 		if (handler) {
 			/* fetch raw data sample: re-trigger lost interrupt */
 			lis2mdl_magnetic_raw_get(ctx, raw);
@@ -63,12 +64,9 @@ static void lis2mdl_handle_interrupt(const struct device *dev)
 {
 	struct lis2mdl_data *lis2mdl = dev->data;
 	const struct lis2mdl_config *const cfg = dev->config;
-	struct sensor_trigger drdy_trigger = {
-		.type = SENSOR_TRIG_DATA_READY,
-	};
 
 	if (lis2mdl->handler_drdy != NULL) {
-		lis2mdl->handler_drdy(dev, &drdy_trigger);
+		lis2mdl->handler_drdy(dev, lis2mdl->trig_drdy);
 	}
 
 	if (cfg->single_mode) {

--- a/drivers/sensor/lis3mdl/lis3mdl.h
+++ b/drivers/sensor/lis3mdl/lis3mdl.h
@@ -119,7 +119,7 @@ struct lis3mdl_data {
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
 
-	struct sensor_trigger data_ready_trigger;
+	const struct sensor_trigger *data_ready_trigger;
 	sensor_trigger_handler_t data_ready_handler;
 
 #if defined(CONFIG_LIS3MDL_TRIGGER_OWN_THREAD)

--- a/drivers/sensor/lis3mdl/lis3mdl_trigger.c
+++ b/drivers/sensor/lis3mdl/lis3mdl_trigger.c
@@ -46,7 +46,7 @@ int lis3mdl_trigger_set(const struct device *dev,
 		return 0;
 	}
 
-	drv_data->data_ready_trigger = *trig;
+	drv_data->data_ready_trigger = trig;
 
 	gpio_pin_interrupt_configure_dt(&config->irq_gpio,
 					GPIO_INT_EDGE_TO_ACTIVE);
@@ -79,7 +79,7 @@ static void lis3mdl_thread_cb(const struct device *dev)
 
 	if (drv_data->data_ready_handler != NULL) {
 		drv_data->data_ready_handler(dev,
-					     &drv_data->data_ready_trigger);
+					     drv_data->data_ready_trigger);
 	}
 
 	gpio_pin_interrupt_configure_dt(&config->irq_gpio,

--- a/drivers/sensor/lps22hh/lps22hh.h
+++ b/drivers/sensor/lps22hh/lps22hh.h
@@ -60,7 +60,7 @@ struct lps22hh_data {
 #ifdef CONFIG_LPS22HH_TRIGGER
 	struct gpio_callback gpio_cb;
 
-	struct sensor_trigger data_ready_trigger;
+	const struct sensor_trigger *data_ready_trigger;
 	sensor_trigger_handler_t handler_drdy;
 	const struct device *dev;
 

--- a/drivers/sensor/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/lps22hh/lps22hh_trigger.c
@@ -48,6 +48,7 @@ int lps22hh_trigger_set(const struct device *dev,
 
 	if (trig->chan == SENSOR_CHAN_ALL) {
 		lps22hh->handler_drdy = handler;
+		lps22hh->data_ready_trigger = trig;
 		if (handler) {
 			/* dummy read: re-trigger interrupt */
 			if (lps22hh_pressure_raw_get(ctx, &raw_press) < 0) {
@@ -72,12 +73,9 @@ static void lps22hh_handle_interrupt(const struct device *dev)
 	int ret;
 	struct lps22hh_data *lps22hh = dev->data;
 	const struct lps22hh_config *cfg = dev->config;
-	struct sensor_trigger drdy_trigger = {
-		.type = SENSOR_TRIG_DATA_READY,
-	};
 
 	if (lps22hh->handler_drdy != NULL) {
-		lps22hh->handler_drdy(dev, &drdy_trigger);
+		lps22hh->handler_drdy(dev, lps22hh->data_ready_trigger);
 	}
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)

--- a/drivers/sensor/lsm6dsl/lsm6dsl.h
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.h
@@ -675,7 +675,7 @@ struct lsm6dsl_data {
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
 
-	struct sensor_trigger data_ready_trigger;
+	const struct sensor_trigger *data_ready_trigger;
 	sensor_trigger_handler_t data_ready_handler;
 
 #if defined(CONFIG_LSM6DSL_TRIGGER_OWN_THREAD)

--- a/drivers/sensor/lsm6dsl/lsm6dsl_trigger.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl_trigger.c
@@ -63,7 +63,7 @@ int lsm6dsl_trigger_set(const struct device *dev,
 		return 0;
 	}
 
-	drv_data->data_ready_trigger = *trig;
+	drv_data->data_ready_trigger = trig;
 
 	setup_irq(dev, true);
 	if (gpio_pin_get_dt(&config->int_gpio) > 0) {
@@ -90,7 +90,7 @@ static void lsm6dsl_thread_cb(const struct device *dev)
 
 	if (drv_data->data_ready_handler != NULL) {
 		drv_data->data_ready_handler(dev,
-					     &drv_data->data_ready_trigger);
+					     drv_data->data_ready_trigger);
 	}
 
 	setup_irq(dev, true);

--- a/drivers/sensor/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/lsm6dso/lsm6dso.h
@@ -107,8 +107,11 @@ struct lsm6dso_data {
 #ifdef CONFIG_LSM6DSO_TRIGGER
 	struct gpio_callback gpio_cb;
 	sensor_trigger_handler_t handler_drdy_acc;
+	const struct sensor_trigger *trig_drdy_acc;
 	sensor_trigger_handler_t handler_drdy_gyr;
+	const struct sensor_trigger *trig_drdy_gyr;
 	sensor_trigger_handler_t handler_drdy_temp;
+	const struct sensor_trigger *trig_drdy_temp;
 
 #if defined(CONFIG_LSM6DSO_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_LSM6DSO_THREAD_STACK_SIZE);

--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -135,6 +135,7 @@ int lsm6dso_trigger_set(const struct device *dev,
 
 	if (trig->chan == SENSOR_CHAN_ACCEL_XYZ) {
 		lsm6dso->handler_drdy_acc = handler;
+		lsm6dso->trig_drdy_acc = trig;
 		if (handler) {
 			return lsm6dso_enable_xl_int(dev, LSM6DSO_EN_BIT);
 		} else {
@@ -142,6 +143,7 @@ int lsm6dso_trigger_set(const struct device *dev,
 		}
 	} else if (trig->chan == SENSOR_CHAN_GYRO_XYZ) {
 		lsm6dso->handler_drdy_gyr = handler;
+		lsm6dso->trig_drdy_gyr = trig;
 		if (handler) {
 			return lsm6dso_enable_g_int(dev, LSM6DSO_EN_BIT);
 		} else {
@@ -151,6 +153,7 @@ int lsm6dso_trigger_set(const struct device *dev,
 #if defined(CONFIG_LSM6DSO_ENABLE_TEMP)
 	else if (trig->chan == SENSOR_CHAN_DIE_TEMP) {
 		lsm6dso->handler_drdy_temp = handler;
+		lsm6dso->trig_drdy_temp = trig;
 		if (handler) {
 			return lsm6dso_enable_t_int(dev, LSM6DSO_EN_BIT);
 		} else {
@@ -169,9 +172,6 @@ int lsm6dso_trigger_set(const struct device *dev,
 static void lsm6dso_handle_interrupt(const struct device *dev)
 {
 	struct lsm6dso_data *lsm6dso = dev->data;
-	struct sensor_trigger drdy_trigger = {
-		.type = SENSOR_TRIG_DATA_READY,
-	};
 	const struct lsm6dso_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	lsm6dso_status_reg_t status;
@@ -191,16 +191,16 @@ static void lsm6dso_handle_interrupt(const struct device *dev)
 		}
 
 		if ((status.xlda) && (lsm6dso->handler_drdy_acc != NULL)) {
-			lsm6dso->handler_drdy_acc(dev, &drdy_trigger);
+			lsm6dso->handler_drdy_acc(dev, lsm6dso->trig_drdy_acc);
 		}
 
 		if ((status.gda) && (lsm6dso->handler_drdy_gyr != NULL)) {
-			lsm6dso->handler_drdy_gyr(dev, &drdy_trigger);
+			lsm6dso->handler_drdy_gyr(dev, lsm6dso->trig_drdy_gyr);
 		}
 
 #if defined(CONFIG_LSM6DSO_ENABLE_TEMP)
 		if ((status.tda) && (lsm6dso->handler_drdy_temp != NULL)) {
-			lsm6dso->handler_drdy_temp(dev, &drdy_trigger);
+			lsm6dso->handler_drdy_temp(dev, lsm6dso->trig_drdy_temp);
 		}
 #endif
 	}

--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.h
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro.h
@@ -230,7 +230,7 @@ struct lsm9ds0_gyro_data {
 	const struct device *dev;
 
 	struct gpio_callback gpio_cb;
-	struct sensor_trigger trigger_drdy;
+	const struct sensor_trigger *trigger_drdy;
 	sensor_trigger_handler_t handler_drdy;
 #endif
 

--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro_trigger.c
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro_trigger.c
@@ -52,7 +52,7 @@ int lsm9ds0_gyro_trigger_set(const struct device *dev,
 		}
 
 		data->handler_drdy = handler;
-		data->trigger_drdy = *trig;
+		data->trigger_drdy = trig;
 
 		if (i2c_reg_update_byte_dt(&config->i2c, LSM9DS0_GYRO_REG_CTRL_REG3_G,
 					   LSM9DS0_GYRO_MASK_CTRL_REG3_G_I2_DRDY,
@@ -88,7 +88,7 @@ static void lsm9ds0_gyro_thread_main(const struct device *dev)
 		k_sem_take(&data->sem, K_FOREVER);
 
 		if (data->handler_drdy) {
-			data->handler_drdy(dev, &data->trigger_drdy);
+			data->handler_drdy(dev, data->trigger_drdy);
 		}
 
 		setup_drdy(dev, true);


### PR DESCRIPTION
Fixes a batch of sensor drivers to store the user-supplied sensor
trigger as a pointer rather than a copy. This enables the trigger
handler to use CONTAINER_OF to retrieve a context pointer when the
trigger is embedded in a larger struct.

Signed-off-by: Maureen Helm maureen.helm@intel.com

re: #55130 (not using GH "fixes" notation because not all the drivers are done yet)

cc: @anthony32086 @huhebo