### PR TITLE
boards: arduino_giga: enable BLE support

### DIFF
--- a/boards/arm/arduino_giga_r1/Kconfig.defconfig
+++ b/boards/arm/arduino_giga_r1/Kconfig.defconfig
@@ -10,4 +10,16 @@ config BOARD
 config STM32H7_DUAL_CORE
 	default y
 
+if BT
+
+choice CYW43XXX_PART
+	default CYW4343W
+endchoice
+
+choice CYW4343W_MODULE
+	default CYW4343W_MURATA_1DX
+endchoice
+
+endif # BT
+
 endif # BOARD_ARDUINO_GIGA_R1_M7 || BOARD_ARDUINO_GIGA_R1_M4

--- a/boards/arm/arduino_giga_r1/arduino_giga_r1_m7.dts
+++ b/boards/arm/arduino_giga_r1/arduino_giga_r1_m7.dts
@@ -17,6 +17,7 @@
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,uart-mcumgr = &usart1;
+		zephyr,bt-uart = &uart7;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,canbus = &can2;
@@ -89,13 +90,20 @@
 };
 
 &uart7 {
-	status = "disabled";
 	pinctrl-0 = <&uart7_tx_pf7 &uart7_rx_pa8
 		     &uart7_cts_pf9 &uart7_rts_pf8>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
 	status = "okay";
 	hw-flow-control;
+
+	murata-1dx {
+		compatible = "infineon,cyw43xxx-bt-hci";
+		bt-reg-on-gpios = <&gpioa 10 GPIO_ACTIVE_HIGH>;
+		bt-host-wake-gpios = <&gpiog 3 GPIO_ACTIVE_HIGH>;
+		bt-dev-wake-gpios = <&gpioh 7 GPIO_ACTIVE_HIGH>;
+		fw-download-speed = <115200>;
+	};
 };
 
 &i2c4 {

--- a/boards/arm/arduino_giga_r1/doc/index.rst
+++ b/boards/arm/arduino_giga_r1/doc/index.rst
@@ -67,8 +67,22 @@ following hardware features:
 +-----------+------------+-------------------------------------+
 | QSPI      | on-chip    | QSPI flash                          |
 +-----------+------------+-------------------------------------+
+| RADIO     | Murata 1DX | WiFi and Bluetooth module           |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr port.
+
+Fetch Binary Blobs
+******************
+
+The board Bluetooth/WiFi module requires fetching some binary blob files, to do
+that run the command:
+
+.. code-block:: console
+
+   west blobs fetch hal_infineon
+
+.. note: Only Bluetooth functionality is currently supported.
 
 Resources sharing
 =================


### PR DESCRIPTION
Add BLE support to arduino_giga through the on-board Murata-1DX module.