### PR TITLE
microchip: espi: Fix bug in dependency in ESPI Kconfig

### DIFF
--- a/drivers/espi/Kconfig.xec
+++ b/drivers/espi/Kconfig.xec
@@ -5,13 +5,15 @@
 
 config ESPI_XEC
 	bool "XEC Microchip ESPI driver"
-	depends on DT_HAS_MICROCHIP_XEC_ESPI_SAF_ENABLED
+	default y
+	depends on DT_HAS_MICROCHIP_XEC_ESPI_ENABLED
 	help
 	  Enable the Microchip XEC ESPI driver for MEC15xx family.
 
 config ESPI_XEC_V2
 	bool "XEC Microchip ESPI V2 driver"
-	depends on DT_HAS_MICROCHIP_XEC_ESPI_SAF_V2_ENABLED
+	default y
+	depends on DT_HAS_MICROCHIP_XEC_ESPI_V2_ENABLED
 	help
 	  Enable the Microchip XEC ESPI driver for MEC172x series.
 


### PR DESCRIPTION
`Kconfig.xec` for the ESPI drivers requires
DT_HAS_MICROCHIP_XEC_ESPI_SAF_ENABLED and
DT_HAS_MICROCHIP_XEC_ESPI_SAF_V2_ENABLED for ESPI_XEC and ESPI_XEC_V2, respectively, but SAF is not mandatory for using ESPI. This is a bug and should be dependent on DT_HAS_MICROCHIP_XEC_ESPI_ENABLED and DT_HAS_MICROCHIP_XEC_ESPI_ENABLED, respectively. Also make these default to `y` so they can be automatically enabled by the device tree.