### PR TITLE
input: convert the ft5336 driver from kscan to input

### DIFF
--- a/boards/arm/mimxrt1050_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1050_evk/Kconfig.defconfig
@@ -28,12 +28,15 @@ endif #FLASH
 config KSCAN
 	default y if LVGL
 
-if KSCAN
+config INPUT
+	default y if KSCAN
 
-config KSCAN_FT5336_INTERRUPT
+if INPUT
+
+config INPUT_FT5336_INTERRUPT
 	default y
 
-endif # KSCAN
+endif # INPUT
 
 if NETWORKING
 

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -16,7 +16,7 @@
 	aliases {
 		led0 = &green_led;
 		sw0 = &user_button;
-		kscan0 = &touch_controller;
+		kscan0 = &kscan_input;
 		watchdog0 = &wdog0;
 		magn0 = &fxos8700;
 		accel0 = &fxos8700;
@@ -33,7 +33,7 @@
 		zephyr,flash = &s26ks512s0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,display = &lcdif;
-		zephyr,keyboard-scan = &touch_controller;
+		zephyr,keyboard-scan = &kscan_input;
 	};
 
 	sdram0: memory@80000000 {
@@ -209,10 +209,14 @@ arduino_serial: &lpuart3 {
 		int2-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 	};
 
-	touch_controller: ft5336@38 {
+	ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		int-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+
+		kscan_input: kscan-input {
+			compatible = "zephyr,kscan-input";
+		};
 	};
 };
 

--- a/boards/arm/mimxrt1060_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1060_evk/Kconfig.defconfig
@@ -31,12 +31,15 @@ endif #FLASH
 config KSCAN
 	default y if LVGL
 
-if KSCAN
+config INPUT
+	default y if KSCAN
 
-config KSCAN_FT5336_INTERRUPT
+if INPUT
+
+config INPUT_FT5336_INTERRUPT
 	default y
 
-endif # KSCAN
+endif # INPUT
 
 if NETWORKING
 

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -16,7 +16,7 @@
 	aliases {
 		led0 = &green_led;
 		sw0 = &user_button;
-		kscan0 = &touch_controller;
+		kscan0 = &kscan_input;
 		watchdog0 = &wdog0;
 		sdhc0 = &usdhc1;
 	};
@@ -32,7 +32,7 @@
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan2;
 		zephyr,display = &lcdif;
-		zephyr,keyboard-scan = &touch_controller;
+		zephyr,keyboard-scan = &kscan_input;
 	};
 
 	sdram0: memory@80000000 {
@@ -177,10 +177,14 @@ arduino_serial: &lpuart3 {
 	pinctrl-0 = <&pinmux_lpi2c1>;
 	pinctrl-names = "default";
 
-	touch_controller: ft5336@38 {
+	ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		int-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+
+		kscan_input: kscan-input {
+			compatible = "zephyr,kscan-input";
+		};
 	};
 };
 

--- a/boards/arm/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1064_evk/Kconfig.defconfig
@@ -15,12 +15,15 @@ endchoice
 config KSCAN
 	default y if LVGL
 
-if KSCAN
+config INPUT
+	default y if KSCAN
 
-config KSCAN_FT5336_INTERRUPT
+if INPUT
+
+config INPUT_FT5336_INTERRUPT
 	default y
 
-endif # KSCAN
+endif # INPUT
 
 if NETWORKING
 

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -17,7 +17,7 @@
 		led0 = &green_led;
 		pwm-led0 = &green_pwm_led;
 		sw0 = &user_button;
-		kscan0 = &touch_controller;
+		kscan0 = &kscan_input;
 		watchdog0 = &wdog0;
 		sdhc0 = &usdhc1;
 	};
@@ -33,7 +33,7 @@
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan2;
 		zephyr,display = &lcdif;
-		zephyr,keyboard-scan = &touch_controller;
+		zephyr,keyboard-scan = &kscan_input;
 	};
 
 	sdram0: memory@80000000 {
@@ -167,10 +167,14 @@ arduino_i2c: &lpi2c1 {};
 		};
 	};
 
-	touch_controller: ft5336@38 {
+	ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		int-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+
+		kscan_input: kscan-input {
+			compatible = "zephyr,kscan-input";
+		};
 	};
 };
 

--- a/boards/arm/stm32f746g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f746g_disco/Kconfig.defconfig
@@ -15,6 +15,9 @@ config NET_L2_ETHERNET
 
 endif # NETWORKING
 
+config INPUT
+	default y if KSCAN
+
 if DISPLAY
 
 config KSCAN
@@ -27,12 +30,12 @@ config MEMC
 
 endif # DISPLAY
 
-if KSCAN
+if INPUT
 
-config KSCAN_FT5336_INTERRUPT
+config INPUT_FT5336_INTERRUPT
 	default y
 
-endif # KSCAN
+endif # INPUT
 
 config DISK_DRIVER_SDMMC
 	default y if DISK_DRIVERS

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -21,7 +21,7 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,flash-controller = &n25q128a1;
 		zephyr,display = &ltdc;
-		zephyr,keyboard-scan = &touch_controller;
+		zephyr,keyboard-scan = &kscan_input;
 	};
 
 	leds {
@@ -51,7 +51,7 @@
 	aliases {
 		led0 = &green_led_1;
 		sw0 = &user_button;
-		kscan0 = &touch_controller;
+		kscan0 = &kscan_input;
 		spi-flash0 = &n25q128a1;
 	};
 };
@@ -95,10 +95,14 @@
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
-	touch_controller: ft5336@38 {
+	ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		int-gpios = <&gpioi 13 0>;
+
+		kscan_input: kscan-input {
+			compatible = "zephyr,kscan-input";
+		};
 	};
 };
 

--- a/boards/arm/stm32f7508_dk/Kconfig.defconfig
+++ b/boards/arm/stm32f7508_dk/Kconfig.defconfig
@@ -27,12 +27,15 @@ config MEMC
 
 endif # DISPLAY
 
-if KSCAN
+config INPUT
+	default y if KSCAN
 
-config KSCAN_FT5336_INTERRUPT
+if INPUT
+
+config INPUT_FT5336_INTERRUPT
 	default y
 
-endif # KSCAN
+endif # INPUT
 
 config DISK_DRIVER_SDMMC
 	default y if DISK_DRIVERS

--- a/boards/arm/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/arm/stm32f7508_dk/stm32f7508_dk.dts
@@ -22,7 +22,7 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,flash-controller = &n25q128a1;
 		zephyr,display = &ltdc;
-		zephyr,keyboard-scan = &touch_controller;
+		zephyr,keyboard-scan = &kscan_input;
 	};
 
 	leds {
@@ -52,7 +52,7 @@
 	aliases {
 		led0 = &green_led_1;
 		sw0 = &user_button;
-		kscan0 = &touch_controller;
+		kscan0 = &kscan_input;
 		spi-flash0 = &n25q128a1;
 	};
 };
@@ -96,10 +96,14 @@
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
-	touch_controller: ft5336@38 {
+	ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		int-gpios = <&gpioi 13 0>;
+
+		kscan_input: kscan-input {
+			compatible = "zephyr,kscan-input";
+		};
 	};
 };
 

--- a/boards/arm/stm32f769i_disco/Kconfig.defconfig
+++ b/boards/arm/stm32f769i_disco/Kconfig.defconfig
@@ -12,6 +12,9 @@ config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI
 
+config INPUT
+	default y if KSCAN
+
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -20,7 +20,7 @@
 		zephyr,flash = &flash0;
 		zephyr,dtcm = &dtcm;
 		zephyr,flash-controller = &mx25l51245g;
-		zephyr,keyboard-scan = &touch_controller;
+		zephyr,keyboard-scan = &kscan_input;
 	};
 
 	sdram1: sdram@c0000000 {
@@ -65,7 +65,7 @@
 		led2 = &green_led_3;
 		led3 = &red_led_4;
 		sw0 = &user_button;
-		kscan0 = &touch_controller;
+		kscan0 = &kscan_input;
 		spi-flash0 = &mx25l51245g;
 	};
 };
@@ -123,10 +123,14 @@ arduino_serial: &usart6 {};
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
-	touch_controller: ft6202@2a {
+	ft6202@2a {
 		compatible = "focaltech,ft5336";
 		reg = <0x2a>;
 		int-gpios = <&gpioi 13 0>;
+
+		kscan_input: kscan-input {
+			compatible = "zephyr,kscan-input";
+		};
 	};
 };
 

--- a/boards/arm/stm32h7b3i_dk/Kconfig.defconfig
+++ b/boards/arm/stm32h7b3i_dk/Kconfig.defconfig
@@ -11,8 +11,11 @@ config BOARD
 config KSCAN
 	default y if DISPLAY
 
-config KSCAN_FT5336_INTERRUPT
-	default y if KSCAN_FT5336
+config INPUT
+	default y if KSCAN
+
+config INPUT_FT5336_INTERRUPT
+	default y if INPUT_FT5336
 
 # MEMC needs to be enabled in order to store
 # display buffer to external SDRAM connected to FMC

--- a/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -21,7 +21,7 @@
 		zephyr,flash = &flash0;
 		zephyr,display = &ltdc;
 		zephyr,canbus = &can1;
-		zephyr,keyboard-scan = &touch_controller;
+		zephyr,keyboard-scan = &kscan_input;
 	};
 
 	leds {
@@ -63,7 +63,7 @@
 		led0 = &blue_led;
 		led1 = &red_led;
 		sw0 = &user_button;
-		kscan0 = &touch_controller;
+		kscan0 = &kscan_input;
 	};
 };
 
@@ -129,10 +129,14 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 
-	touch_controller: ft5336@38 {
+	ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		int-gpios = <&gpioh 2 0>;
+
+		kscan_input: kscan-input {
+			compatible = "zephyr,kscan-input";
+		};
 	};
 };
 

--- a/boards/shields/adafruit_2_8_tft_touch_v2/Kconfig.defconfig
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/Kconfig.defconfig
@@ -8,13 +8,13 @@ config GPIO
 
 if DISPLAY
 
-if KSCAN
+if INPUT
 
 # NOTE: Enable if IRQ line is available (requires to solder jumper)
-config KSCAN_FT5336_INTERRUPT
+config INPUT_FT5336_INTERRUPT
 	default n
 
-endif # KSCAN
+endif # INPUT
 
 if LVGL
 
@@ -29,6 +29,9 @@ choice LV_COLOR_DEPTH
 endchoice
 
 config KSCAN
+	default y
+
+config INPUT
 	default y
 
 config LV_Z_POINTER_KSCAN

--- a/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
@@ -9,7 +9,7 @@
 / {
 	chosen {
 		zephyr,display = &ili9340;
-		zephyr,keyboard-scan = &touch_controller;
+		zephyr,keyboard-scan = &kscan_input;
 	};
 };
 
@@ -49,10 +49,14 @@
 };
 
 &arduino_i2c {
-	touch_controller: ft5336@38 {
+	ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		/* Uncomment if IRQ line is available (requires to solder jumper) */
 		/* int-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>; */ /* D7 */
+
+		kscan_input: kscan-input {
+			compatible = "zephyr,kscan-input";
+		};
 	};
 };

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/Kconfig.defconfig
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/Kconfig.defconfig
@@ -5,13 +5,13 @@ if SHIELD_BUYDISPLAY_2_8_TFT_TOUCH_ARDUINO
 
 if DISPLAY
 
-if KSCAN
+if INPUT
 
 # NOTE: Enable if IRQ line is available (requires to solder jumper)
-config KSCAN_FT5336_INTERRUPT
+config INPUT_FT5336_INTERRUPT
 	default n
 
-endif # KSCAN
+endif # INPUT
 
 if LVGL
 
@@ -29,6 +29,9 @@ config LV_COLOR_16_SWAP
 	default y
 
 config KSCAN
+	default y
+
+config INPUT
 	default y
 
 config LV_Z_POINTER_KSCAN

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
@@ -9,6 +9,7 @@
 / {
 	chosen {
 		zephyr,display = &ili9340_buydisplay_2_8_tft_touch_arduino;
+		zephyr,keyboard-scan = &kscan_input;
 	};
 };
 
@@ -36,10 +37,14 @@
 };
 
 &arduino_i2c {
-	ft5336_buydisplay_2_8_tft_touch_arduino: ft5336@38 {
+	ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		/* Uncomment if IRQ line is available (requires to solder jumper) */
 		/* int-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>; */ /* D5 */
+
+		kscan_input: kscan-input {
+			compatible = "zephyr,kscan-input";
+		};
 	};
 };

--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/Kconfig.defconfig
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/Kconfig.defconfig
@@ -5,13 +5,13 @@ if SHIELD_BUYDISPLAY_3_5_TFT_TOUCH_ARDUINO
 
 if DISPLAY
 
-if KSCAN
+if INPUT
 
 # NOTE: Enable if IRQ line is available (requires to solder jumper)
-config KSCAN_FT5336_INTERRUPT
+config INPUT_FT5336_INTERRUPT
 	default n
 
-endif # KSCAN
+endif # INPUT
 
 if LVGL
 
@@ -26,6 +26,9 @@ choice LV_COLOR_DEPTH
 endchoice
 
 config KSCAN
+	default y
+
+config INPUT
 	default y
 
 config LV_Z_POINTER_KSCAN

--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
@@ -9,6 +9,7 @@
 / {
 	chosen {
 		zephyr,display = &ili9488_buydisplay_3_5_tft_touch_arduino;
+		zephyr,keyboard-scan = &kscan_input;
 	};
 };
 
@@ -35,10 +36,14 @@
 };
 
 &arduino_i2c {
-	ft5336_buydisplay_3_5_tft_touch_arduino: ft5336@38 {
+	ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		/* Uncomment if IRQ line is available (requires to solder jumper) */
 		/* int-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>; */ /* D5 */
+
+		kscan_input: kscan-input {
+			compatible = "zephyr,kscan-input";
+		};
 	};
 };

--- a/drivers/input/CMakeLists.txt
+++ b/drivers/input/CMakeLists.txt
@@ -3,4 +3,5 @@
 zephyr_library()
 zephyr_library_property(ALLOW_EMPTY TRUE)
 
+zephyr_library_sources_ifdef(CONFIG_INPUT_FT5336 input_ft5336.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_GPIO_KEYS input_gpio_keys.c)

--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -5,6 +5,7 @@ if INPUT
 
 menu "Input drivers"
 
+source "drivers/input/Kconfig.ft5336"
 source "drivers/input/Kconfig.gpio_keys"
 
 endmenu # Input Drivers

--- a/drivers/input/Kconfig.ft5336
+++ b/drivers/input/Kconfig.ft5336
@@ -2,7 +2,7 @@
 # Copyright (c) 2020 Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig KSCAN_FT5336
+menuconfig INPUT_FT5336
 	bool "FT5XX6/FT6XX6 capacitive touch panel driver"
 	default y
 	depends on DT_HAS_FOCALTECH_FT5336_ENABLED
@@ -12,18 +12,18 @@ menuconfig KSCAN_FT5336
 	  controllers. This driver should support FT5x06, FT5606, FT5x16,
 	  FT6x06, Ft6x36, FT5x06i, FT5336, FT3316, FT5436i, FT5336i and FT5x46.
 
-if KSCAN_FT5336
+if INPUT_FT5336
 
-config KSCAN_FT5336_PERIOD
+config INPUT_FT5336_PERIOD
 	int "Sample period"
-	depends on !KSCAN_FT5336_INTERRUPT
+	depends on !INPUT_FT5336_INTERRUPT
 	default 10
 	help
 	  Sample period in milliseconds when in polling mode.
 
-config KSCAN_FT5336_INTERRUPT
+config INPUT_FT5336_INTERRUPT
 	bool "Interrupt"
 	help
 	  Enable interrupt support (requires GPIO).
 
-endif # KSCAN_FT5336
+endif # INPUT_FT5336

--- a/drivers/kscan/CMakeLists.txt
+++ b/drivers/kscan/CMakeLists.txt
@@ -2,7 +2,6 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_KSCAN_FT5336	kscan_ft5336.c)
 zephyr_library_sources_ifdef(CONFIG_KSCAN_GT911  	kscan_gt911.c)
 zephyr_library_sources_ifdef(CONFIG_KSCAN_ITE_IT8XXX2	kscan_ite_it8xxx2.c)
 zephyr_library_sources_ifdef(CONFIG_KSCAN_XEC		kscan_mchp_xec.c)

--- a/drivers/kscan/Kconfig
+++ b/drivers/kscan/Kconfig
@@ -10,7 +10,6 @@ menuconfig KSCAN
 
 if KSCAN
 
-source "drivers/kscan/Kconfig.ft5336"
 source "drivers/kscan/Kconfig.gt911"
 source "drivers/kscan/Kconfig.it8xxx2"
 source "drivers/kscan/Kconfig.xec"


### PR DESCRIPTION
Convert the ft5336 to the input subsystem, fix all the config in the repository and add the Kscan compatibility driver to the current dts driver instances.

On the board files, set a bunch of:
```
config INPUT
	default y if KSCAN
```
to maintain compatibility with the current test and samples. This is mean to be cleaned up at a later stage after moving the remaining touchscreen drivers off kscan and converting the LVGL code to use the input API directly.