### PR TITLE
    tests: mem_protect: sys_sem/syscalls: print FAILED when faulting

### DIFF
--- a/tests/kernel/mem_protect/sys_sem/src/main.c
+++ b/tests/kernel/mem_protect/sys_sem/src/main.c
@@ -568,6 +568,14 @@ ZTEST_USER(sys_sem_1cpu, test_sem_multiple_threads_wait)
  * @}
  */
 
+void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
+{
+	printk("Caught system error -- reason %d\n", reason);
+	printk("Unexpected fault during test\n");
+	printk("PROJECT EXECUTION FAILED\n");
+	k_fatal_halt(reason);
+}
+
 void *sys_sem_setup(void)
 {
 #ifdef CONFIG_USERSPACE

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -36,6 +36,14 @@ char kernel_string[BUF_SIZE];
 char kernel_buf[BUF_SIZE];
 ZTEST_BMEM char user_string[BUF_SIZE];
 
+void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
+{
+	printk("Caught system error -- reason %d\n", reason);
+	printk("Unexpected fault during test\n");
+	printk("PROJECT EXECUTION FAILED\n");
+	k_fatal_halt(reason);
+}
+
 size_t z_impl_string_nlen(char *src, size_t maxlen, int *err)
 {
 	return z_user_string_nlen(src, maxlen, err);


### PR DESCRIPTION
If there are any CPU exceptions, printing a failed message would allow twister to stop early instead of waiting for timeout.