### PR TITLE
mm: intel: adsp: simplify code in mm_drv_intel_adsp_regions.c

### DIFF
--- a/drivers/mm/mm_drv_intel_adsp_regions.c
+++ b/drivers/mm/mm_drv_intel_adsp_regions.c
@@ -21,40 +21,37 @@ const struct sys_mm_drv_region *sys_mm_drv_query_memory_regions(void)
 }
 
 static inline void append_region(void *address, uint32_t mem_size,
-	uint32_t attributes, uint32_t position, uint32_t *checksum)
+	uint32_t attributes, uint32_t position, uint32_t *total_size)
 {
 	virtual_memory_regions[position].addr = address;
 	virtual_memory_regions[position].size = mem_size;
 	virtual_memory_regions[position].attr = attributes;
-	checksum += mem_size;
+	total_size += mem_size;
 }
 
 int calculate_memory_regions(uintptr_t static_alloc_end_ptr)
 {
-	struct sys_mm_drv_region *temporary_table =
-		(struct sys_mm_drv_region *)&virtual_memory_regions[0];
-
-	int i, checksum = 0;
+	int i, total_size = 0;
 
 	for (i = 0; i < CONFIG_MP_MAX_NUM_CPUS; i++)	{
 		append_region((void *)(static_alloc_end_ptr + i * CORE_HEAP_SIZE),
-			CORE_HEAP_SIZE, MEM_REG_ATTR_CORE_HEAP, i, &checksum);
+			      CORE_HEAP_SIZE, MEM_REG_ATTR_CORE_HEAP, i, &total_size);
 	}
 
-	append_region((void *)((uintptr_t)
-		virtual_memory_regions[i - 1].addr + temporary_table[i - 1].size),
-		CORE_HEAP_SIZE, MEM_REG_ATTR_SHARED_HEAP, i, &checksum);
+	append_region((void *)((uintptr_t)virtual_memory_regions[i - 1].addr +
+			       virtual_memory_regions[i - 1].size),
+		      CORE_HEAP_SIZE, MEM_REG_ATTR_SHARED_HEAP, i, &total_size);
 	i++;
-	append_region((void *)((uintptr_t)
-		virtual_memory_regions[i - 1].addr + temporary_table[i - 1].size),
-		OPPORTUNISTIC_REGION_SIZE, MEM_REG_ATTR_OPPORTUNISTIC_MEMORY, i, &checksum);
+	append_region((void *)((uintptr_t)virtual_memory_regions[i - 1].addr +
+			       virtual_memory_regions[i - 1].size),
+		      OPPORTUNISTIC_REGION_SIZE, MEM_REG_ATTR_OPPORTUNISTIC_MEMORY, i, &total_size);
 	i++;
 	/* Apending last region as 0 so iterators know where table is over
 	 * check is for size = 0;
 	 */
-	append_region((void *)0, 0, 0, i, &checksum);
+	append_region(NULL, 0, 0, i, &total_size);
 
-	if (checksum > L2_VIRTUAL_SRAM_SIZE) {
+	if (total_size > L2_VIRTUAL_SRAM_SIZE) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
temporary_table is a trivial copy of virtual_memory_regions, it isn't clear why it's needed. All the more that it's freely mixed with virtual_memory_regions itself. Also change a variable name to avoid confusion and improve indentation.