### PR TITLE
Bluetooth: audio: ascs: Fix missing ASCS/ASE cleanup

### DIFF
--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -567,6 +567,16 @@ struct bt_iso_server {
  */
 int bt_iso_server_register(struct bt_iso_server *server);
 
+/** @brief Unregister ISO server.
+ *
+ *  Unregister previously registered ISO server.
+ *
+ *  @param server Server structure.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_iso_server_unregister(struct bt_iso_server *server);
+
 /** @brief Creates a CIG as a central
  *
  *  This can called at any time, even before connecting to a remote device.

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -767,7 +767,6 @@ static void ascs_ep_iso_disconnected(struct bt_bap_ep *ep, uint8_t reason)
 
 	if (ep->status.state == BT_BAP_EP_STATE_RELEASING) {
 		bt_bap_iso_unbind_ep(ep->iso, ep);
-		bt_bap_stream_detach(stream);
 		ascs_ep_set_state(ep, BT_BAP_EP_STATE_IDLE);
 	} else {
 		/* The ASE state machine goes into different states from this operation

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -919,7 +919,7 @@ static void ase_release(struct bt_ascs_ase *ase)
 		err = unicast_server_cb->release(ase->ep.stream, &rsp);
 	} else {
 		err = -ENOTSUP;
-		rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_NOT_SUPPORTED,
+		rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_UNSPECIFIED,
 				      BT_BAP_ASCS_REASON_NONE);
 	}
 
@@ -971,7 +971,7 @@ static void ase_disable(struct bt_ascs_ase *ase)
 		err = unicast_server_cb->disable(stream, &rsp);
 	} else {
 		err = -ENOTSUP;
-		rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_NOT_SUPPORTED,
+		rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_UNSPECIFIED,
 				      BT_BAP_ASCS_REASON_NONE);
 	}
 
@@ -1418,7 +1418,7 @@ static int ase_config(struct bt_ascs *ascs, struct bt_ascs_ase *ase,
 							  &rsp);
 		} else {
 			err = -ENOTSUP;
-			rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_NOT_SUPPORTED,
+			rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_UNSPECIFIED,
 					      BT_BAP_ASCS_REASON_NONE);
 		}
 
@@ -1447,7 +1447,7 @@ static int ase_config(struct bt_ascs *ascs, struct bt_ascs_ase *ase,
 							&ase->ep.qos_pref, &rsp);
 		} else {
 			err = -ENOTSUP;
-			rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_NOT_SUPPORTED,
+			rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_UNSPECIFIED,
 					      BT_BAP_ASCS_REASON_NONE);
 		}
 
@@ -2076,7 +2076,7 @@ static void ase_metadata(struct bt_ascs_ase *ase, uint8_t op,
 						  ep->codec.meta_count, &rsp);
 	} else {
 		err = -ENOTSUP;
-		rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_NOT_SUPPORTED,
+		rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_UNSPECIFIED,
 				      BT_BAP_ASCS_REASON_NONE);
 	}
 
@@ -2134,7 +2134,7 @@ static int ase_enable(struct bt_ascs_ase *ase, struct bt_ascs_metadata *meta,
 						ep->codec.meta_count, &rsp);
 	} else {
 		err = -ENOTSUP;
-		rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_NOT_SUPPORTED,
+		rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_UNSPECIFIED,
 				      BT_BAP_ASCS_REASON_NONE);
 	}
 
@@ -2259,7 +2259,7 @@ static void ase_start(struct bt_ascs_ase *ase)
 		err = unicast_server_cb->start(ep->stream, &rsp);
 	} else {
 		err = -ENOTSUP;
-		rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_NOT_SUPPORTED,
+		rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_UNSPECIFIED,
 				      BT_BAP_ASCS_REASON_NONE);
 	}
 
@@ -2419,7 +2419,7 @@ static void ase_stop(struct bt_ascs_ase *ase)
 		err = unicast_server_cb->stop(stream, &rsp);
 	} else {
 		err = -ENOTSUP;
-		rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_NOT_SUPPORTED,
+		rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_UNSPECIFIED,
 				      BT_BAP_ASCS_REASON_NONE);
 	}
 

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1166,9 +1166,7 @@ static struct bt_ascs_ase *ase_new(struct bt_ascs *ascs, uint8_t id)
 {
 	struct bt_ascs_ase *ase;
 
-	if (!id || id > ASE_COUNT) {
-		return NULL;
-	}
+	__ASSERT(id > 0 && id <= ASE_COUNT, "invalid ASE_ID 0x%02x", id);
 
 	ase = bt_ascs_ase_get_from_slab();
 	if (!ase) {

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -234,6 +234,10 @@ void ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state)
 
 		switch (state) {
 		case BT_BAP_EP_STATE_IDLE:
+			if (ep->iso != NULL) {
+				bt_bap_iso_unbind_ep(ep->iso, ep);
+			}
+
 			bt_bap_stream_detach(stream);
 
 			if (ops->released != NULL) {
@@ -396,10 +400,6 @@ void ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state)
 
 			if (ep->iso == NULL ||
 			    ep->iso->chan.state == BT_ISO_STATE_DISCONNECTED) {
-				if (ep->iso != NULL) {
-					bt_bap_iso_unbind_ep(ep->iso, ep);
-				}
-
 				ascs_ep_set_state(ep, BT_BAP_EP_STATE_IDLE);
 			} else {
 				/* Either the client or the server may disconnect the
@@ -766,7 +766,6 @@ static void ascs_ep_iso_disconnected(struct bt_bap_ep *ep, uint8_t reason)
 	}
 
 	if (ep->status.state == BT_BAP_EP_STATE_RELEASING) {
-		bt_bap_iso_unbind_ep(ep->iso, ep);
 		ascs_ep_set_state(ep, BT_BAP_EP_STATE_IDLE);
 	} else {
 		/* The ASE state machine goes into different states from this operation

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -331,7 +331,7 @@ static inline const char *bt_ascs_reason_str(uint8_t reason)
 	return "Unknown";
 }
 
-void bt_ascs_init(const struct bt_bap_unicast_server_cb *cb);
+int bt_ascs_init(const struct bt_bap_unicast_server_cb *cb);
 void bt_ascs_cleanup(void);
 
 void ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state);

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -331,6 +331,9 @@ static inline const char *bt_ascs_reason_str(uint8_t reason)
 	return "Unknown";
 }
 
+void bt_ascs_init(const struct bt_bap_unicast_server_cb *cb);
+void bt_ascs_cleanup(void);
+
 void ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state);
 
 int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_codec *codec,

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -19,7 +19,6 @@
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 
-#include "../host/conn_internal.h"
 #include "../host/iso_internal.h"
 
 #include "bap_iso.h"
@@ -97,11 +96,11 @@ void bt_bap_stream_init(struct bt_bap_stream *stream)
 void bt_bap_stream_attach(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_bap_ep *ep,
 			  struct bt_codec *codec)
 {
-	LOG_DBG("conn %p stream %p ep %p codec %p", conn, stream, ep, codec);
+	LOG_DBG("conn %p stream %p ep %p codec %p", (void *)conn, stream, ep, codec);
 
 	if (conn != NULL) {
 		__ASSERT(stream->conn == NULL || stream->conn == conn,
-			 "stream->conn %p already attached", stream->conn);
+			 "stream->conn %p already attached", (void *)stream->conn);
 		if (stream->conn == NULL) {
 			stream->conn = bt_conn_ref(conn);
 		}
@@ -273,6 +272,17 @@ void bt_bap_stream_reset(struct bt_bap_stream *stream)
 	bt_bap_stream_detach(stream);
 }
 
+static uint8_t conn_get_role(const struct bt_conn *conn)
+{
+	struct bt_conn_info info;
+	int err;
+
+	err = bt_conn_get_info(conn, &info);
+	__ASSERT(err == 0, "Failed to get conn info");
+
+	return info.role;
+}
+
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 
 int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_bap_ep *ep,
@@ -282,7 +292,7 @@ int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, str
 	int err;
 
 	LOG_DBG("conn %p stream %p, ep %p codec %p codec id 0x%02x "
-	       "codec cid 0x%04x codec vid 0x%04x", conn, stream, ep,
+	       "codec cid 0x%04x codec vid 0x%04x", (void *)conn, stream, ep,
 	       codec, codec ? codec->id : 0, codec ? codec->cid : 0,
 	       codec ? codec->vid : 0);
 
@@ -292,11 +302,11 @@ int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, str
 	}
 
 	if (stream->conn != NULL) {
-		LOG_DBG("Stream already configured for conn %p", stream->conn);
+		LOG_DBG("Stream already configured for conn %p", (void *)stream->conn);
 		return -EALREADY;
 	}
 
-	role = conn->role;
+	role = conn_get_role(conn);
 	if (role != BT_HCI_ROLE_CENTRAL) {
 		LOG_DBG("Invalid conn role: %u, shall be central", role);
 		return -EINVAL;
@@ -331,7 +341,7 @@ int bt_bap_stream_qos(struct bt_conn *conn, struct bt_bap_unicast_group *group)
 	uint8_t role;
 	int err;
 
-	LOG_DBG("conn %p group %p", conn, group);
+	LOG_DBG("conn %p group %p", (void *)conn, group);
 
 	CHECKIF(conn == NULL) {
 		LOG_DBG("conn is NULL");
@@ -348,7 +358,7 @@ int bt_bap_stream_qos(struct bt_conn *conn, struct bt_bap_unicast_group *group)
 		return -ENOEXEC;
 	}
 
-	role = conn->role;
+	role = conn_get_role(conn);
 	if (role != BT_HCI_ROLE_CENTRAL) {
 		LOG_DBG("Invalid conn role: %u, shall be central", role);
 		return -EINVAL;
@@ -377,7 +387,7 @@ int bt_bap_stream_enable(struct bt_bap_stream *stream,
 		return -EINVAL;
 	}
 
-	role = stream->conn->role;
+	role = conn_get_role(stream->conn);
 	if (role != BT_HCI_ROLE_CENTRAL) {
 		LOG_DBG("Invalid conn role: %u, shall be central", role);
 		return -EINVAL;
@@ -409,7 +419,7 @@ int bt_bap_stream_stop(struct bt_bap_stream *stream)
 		return -EINVAL;
 	}
 
-	role = stream->conn->role;
+	role = conn_get_role(stream->conn);
 	if (role != BT_HCI_ROLE_CENTRAL) {
 		LOG_DBG("Invalid conn role: %u, shall be central", role);
 		return -EINVAL;
@@ -469,7 +479,7 @@ int bt_bap_stream_reconfig(struct bt_bap_stream *stream,
 		return -EBADMSG;
 	}
 
-	role = stream->conn->role;
+	role = conn_get_role(stream->conn);
 	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_HCI_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_config(stream, codec);
 	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_HCI_ROLE_PERIPHERAL) {
@@ -510,7 +520,7 @@ int bt_bap_stream_start(struct bt_bap_stream *stream)
 		return -EBADMSG;
 	}
 
-	role = stream->conn->role;
+	role = conn_get_role(stream->conn);
 	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_HCI_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_start(stream);
 	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_HCI_ROLE_PERIPHERAL) {
@@ -560,7 +570,7 @@ int bt_bap_stream_metadata(struct bt_bap_stream *stream,
 		return -EBADMSG;
 	}
 
-	role = stream->conn->role;
+	role = conn_get_role(stream->conn);
 	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_HCI_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_metadata(stream, meta, meta_count);
 	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_HCI_ROLE_PERIPHERAL) {
@@ -602,7 +612,7 @@ int bt_bap_stream_disable(struct bt_bap_stream *stream)
 		return -EBADMSG;
 	}
 
-	role = stream->conn->role;
+	role = conn_get_role(stream->conn);
 	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_HCI_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_disable(stream);
 	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_HCI_ROLE_PERIPHERAL) {
@@ -650,7 +660,7 @@ int bt_bap_stream_release(struct bt_bap_stream *stream)
 		return -EBADMSG;
 	}
 
-	role = stream->conn->role;
+	role = conn_get_role(stream->conn);
 	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && role == BT_HCI_ROLE_CENTRAL) {
 		err = bt_bap_unicast_client_release(stream);
 	} else if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_SERVER) && role == BT_HCI_ROLE_PERIPHERAL) {

--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -19,7 +19,7 @@
 
 LOG_MODULE_REGISTER(bt_bap_unicast_server, CONFIG_BT_BAP_UNICAST_SERVER_LOG_LEVEL);
 
-const struct bt_bap_unicast_server_cb *unicast_server_cb;
+static const struct bt_bap_unicast_server_cb *unicast_server_cb;
 
 int bt_bap_unicast_server_register_cb(const struct bt_bap_unicast_server_cb *cb)
 {
@@ -34,6 +34,7 @@ int bt_bap_unicast_server_register_cb(const struct bt_bap_unicast_server_cb *cb)
 	}
 
 	unicast_server_cb = cb;
+	bt_ascs_init(unicast_server_cb);
 
 	return 0;
 }
@@ -50,6 +51,7 @@ int bt_bap_unicast_server_unregister_cb(const struct bt_bap_unicast_server_cb *c
 		return -EINVAL;
 	}
 
+	bt_ascs_cleanup();
 	unicast_server_cb = NULL;
 
 	return 0;

--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -23,6 +23,8 @@ static const struct bt_bap_unicast_server_cb *unicast_server_cb;
 
 int bt_bap_unicast_server_register_cb(const struct bt_bap_unicast_server_cb *cb)
 {
+	int err;
+
 	CHECKIF(cb == NULL) {
 		LOG_DBG("cb is NULL");
 		return -EINVAL;
@@ -33,8 +35,12 @@ int bt_bap_unicast_server_register_cb(const struct bt_bap_unicast_server_cb *cb)
 		return -EALREADY;
 	}
 
+	err = bt_ascs_init(cb);
+	if (err != 0) {
+		return err;
+	}
+
 	unicast_server_cb = cb;
-	bt_ascs_init(unicast_server_cb);
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/bap_unicast_server.h
+++ b/subsys/bluetooth/audio/bap_unicast_server.h
@@ -9,8 +9,6 @@
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 
-extern const struct bt_bap_unicast_server_cb *unicast_server_cb;
-
 int bt_bap_unicast_server_reconfig(struct bt_bap_stream *stream, const struct bt_codec *codec);
 int bt_bap_unicast_server_start(struct bt_bap_stream *stream);
 int bt_bap_unicast_server_metadata(struct bt_bap_stream *stream, struct bt_codec_data meta[],

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -124,6 +124,8 @@ static struct bt_conn sco_conns[CONFIG_BT_MAX_SCO_CONN];
 #endif /* CONFIG_BT_CONN */
 
 #if defined(CONFIG_BT_ISO)
+extern struct bt_conn iso_conns[CONFIG_BT_ISO_MAX_CHAN];
+
 /* Callback TX buffers for ISO */
 static struct bt_conn_tx iso_tx[CONFIG_BT_ISO_TX_BUF_COUNT];
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1094,6 +1094,22 @@ int bt_iso_server_register(struct bt_iso_server *server)
 	return 0;
 }
 
+int bt_iso_server_unregister(struct bt_iso_server *server)
+{
+	CHECKIF(!server) {
+		LOG_DBG("Invalid parameter: server %p", server);
+		return -EINVAL;
+	}
+
+	if (iso_server != server) {
+		return -EINVAL;
+	}
+
+	iso_server = NULL;
+
+	return 0;
+}
+
 static int iso_accept(struct bt_conn *acl, struct bt_conn *iso)
 {
 	struct bt_iso_accept_info accept_info;

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -72,10 +72,6 @@ struct bt_iso_big {
 
 #define iso(buf) ((struct iso_data *)net_buf_user_data(buf))
 
-#if defined(CONFIG_BT_ISO_MAX_CHAN)
-extern struct bt_conn iso_conns[CONFIG_BT_ISO_MAX_CHAN];
-#endif
-
 /* Process ISO buffer */
 void hci_iso(struct net_buf *buf);
 

--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -739,6 +739,28 @@ ZTEST_F(ascs_ase_control_test_suite, test_sink_ase_control_release_from_qos_conf
 	expect_bt_bap_stream_ops_released_called_once(&fixture->stream);
 }
 
+ZTEST_F(ascs_ase_control_test_suite, test_sink_ase_control_streaming_from_enabling)
+{
+	struct bt_iso_chan *chan;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	/* Preamble */
+	ase_cp_write_codec_config(fixture->ase_cp, &fixture->conn, &fixture->stream);
+	ase_cp_write_config_qos(fixture->ase_cp, &fixture->conn, &fixture->stream);
+	ase_cp_write_enable(fixture->ase_cp, &fixture->conn, &fixture->stream);
+
+	err = mock_bt_iso_accept(&fixture->conn, 0x01, 0x01, &chan);
+	zassert_equal(0, err, "Failed to connect iso: err %d", err);
+
+	err = bt_bap_stream_start(&fixture->stream);
+	zassert_equal(0, err, "Failed to start stream: err %d", err);
+
+	/* XXX: unicast_server_cb->start is not called for Sink ASE */
+	expect_bt_bap_stream_ops_started_called_once(&fixture->stream);
+}
+
 static void ascs_test_suite_after(void *f)
 {
 	bt_ascs_cleanup();

--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -73,7 +73,7 @@ static void mock_init_rule_before(const struct ztest_unit_test *test, void *fixt
 {
 	mock_bap_unicast_server_init();
 	mock_bt_iso_init();
-	KERNEL_FFF_FAKES_LIST(RESET_FAKE);
+	mock_kernel_init();
 	PACS_FFF_FAKES_LIST(RESET_FAKE);
 	mock_bap_stream_init();
 	mock_bt_gatt_init();
@@ -83,6 +83,7 @@ static void mock_destroy_rule_after(const struct ztest_unit_test *test, void *fi
 {
 	mock_bap_unicast_server_cleanup();
 	mock_bt_iso_cleanup();
+	mock_kernel_cleanup();
 	mock_bap_stream_cleanup();
 	mock_bt_gatt_cleanup();
 }

--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -72,7 +72,7 @@ static const struct bt_gatt_attr *ascs_get_attr(const struct bt_uuid *uuid, uint
 static void mock_init_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
 	mock_bap_unicast_server_init();
-	ISO_FFF_FAKES_LIST(RESET_FAKE);
+	mock_bt_iso_init();
 	KERNEL_FFF_FAKES_LIST(RESET_FAKE);
 	PACS_FFF_FAKES_LIST(RESET_FAKE);
 	mock_bap_stream_init();
@@ -82,6 +82,7 @@ static void mock_init_rule_before(const struct ztest_unit_test *test, void *fixt
 static void mock_destroy_rule_after(const struct ztest_unit_test *test, void *fixture)
 {
 	mock_bap_unicast_server_cleanup();
+	mock_bt_iso_cleanup();
 	mock_bap_stream_cleanup();
 	mock_bt_gatt_cleanup();
 }

--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -19,7 +19,7 @@
 #include <zephyr/sys/util_macro.h>
 
 #include "assert.h"
-#include "ascs_help_utils.h"
+#include "ascs_internal.h"
 #include "bap_unicast_server.h"
 #include "bap_unicast_server_expects.h"
 #include "bap_stream.h"
@@ -168,8 +168,6 @@ static void *ascs_ase_control_test_suite_setup(void)
 	fixture->ase_cp = ascs_get_attr(BT_UUID_ASCS_ASE_CP, 1);
 	fixture->ase_snk = ascs_get_attr(BT_UUID_ASCS_ASE_SNK, 1);
 
-	bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
-
 	return fixture;
 }
 
@@ -180,18 +178,18 @@ static void ascs_ase_control_test_suite_before(void *f)
 	ARG_UNUSED(fixture);
 
 	bt_pacs_cap_foreach_fake.custom_fake = pacs_cap_foreach_custom_fake;
+
+	bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
 }
 
 static void ascs_ase_control_test_suite_after(void *f)
 {
-	ascs_cleanup();
+	bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
 }
 
 static void ascs_ase_control_test_suite_teardown(void *f)
 {
 	struct ascs_ase_control_test_suite_fixture *fixture = f;
-
-	bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
 
 	free(fixture);
 }
@@ -737,4 +735,55 @@ ZTEST_F(ascs_ase_control_test_suite, test_sink_ase_control_release_from_qos_conf
 	ase_cp_write_release(fixture->ase_cp, &fixture->conn, &fixture->stream);
 	expect_bt_bap_unicast_server_cb_release_called_once(&fixture->stream);
 	expect_bt_bap_stream_ops_released_called_once(&fixture->stream);
+}
+
+static void ascs_test_suite_after(void *f)
+{
+	bt_ascs_cleanup();
+}
+
+ZTEST_SUITE(ascs_test_suite, NULL, NULL, NULL, ascs_test_suite_after, NULL);
+
+ZTEST(ascs_test_suite, test_release_ase_on_callback_unregister)
+{
+	const struct bt_uuid *ase_uuid = COND_CODE_1(CONFIG_BT_ASCS_ASE_SNK,
+						     (BT_UUID_ASCS_ASE_SNK),
+						     (BT_UUID_ASCS_ASE_SRC));
+	const struct bt_gatt_attr *ase_cp;
+	const struct bt_gatt_attr *ase;
+	struct bt_bap_stream stream;
+	struct bt_conn conn;
+	const uint8_t expect_ase_state_idle[] = {
+		0x01,   /* ASE_ID */
+		0x00,   /* ASE_State = Idle */
+	};
+
+	ase_cp = ascs_get_attr(BT_UUID_ASCS_ASE_CP, 1);
+	zassert_not_null(ase_cp);
+
+	ase = ascs_get_attr(ase_uuid, 1);
+	zassert_not_null(ase);
+
+	conn_init(&conn);
+
+	bt_pacs_cap_foreach_fake.custom_fake = pacs_cap_foreach_custom_fake;
+
+	bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
+
+	/* Set ASE to non-idle state */
+	ase_cp_write_codec_config(ase_cp, &conn, &stream);
+
+	/* Reset mock, as we expect ASE notification to be sent */
+	bt_gatt_notify_cb_reset();
+
+	/* Unregister the callbacks - whis will clean up the ASCS */
+	bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
+
+	/* Expected to notify the upper layers */
+	expect_bt_bap_unicast_server_cb_release_called_once(&stream);
+	expect_bt_bap_stream_ops_released_called_once(&stream);
+
+	/* Expected to notify the client */
+	expect_bt_gatt_notify_cb_called_once(&conn, ase_uuid, ase, expect_ase_state_idle,
+					     sizeof(expect_ase_state_idle));
 }

--- a/tests/bluetooth/audio/mocks/include/ascs_help_utils.h
+++ b/tests/bluetooth/audio/mocks/include/ascs_help_utils.h
@@ -1,8 +1,0 @@
-/*
- * Copyright (c) 2023 Codecoup
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/* ascs.c declarations */
-void ascs_cleanup(void);

--- a/tests/bluetooth/audio/mocks/include/bap_unicast_server_expects.h
+++ b/tests/bluetooth/audio/mocks/include/bap_unicast_server_expects.h
@@ -108,4 +108,19 @@ do {                                                                            
 				       func_name, "stream");))                                     \
 } while (0)
 
+#define expect_bt_bap_unicast_server_cb_start_called_once(_stream)                                 \
+do {                                                                                               \
+	const char *func_name = "bt_bap_unicast_server_cb.start";                                  \
+												   \
+	zassert_true(mock_bap_unicast_server_cb_start_fake.call_count > 0,                         \
+		     "'%s()' was not called", func_name);                                          \
+	zassert_equal(1, mock_bap_unicast_server_cb_start_fake.call_count,                         \
+		      "'%s()' was called more than once", func_name);                              \
+												   \
+	IF_NOT_EMPTY(_stream, (                                                                    \
+		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_start_fake.arg0_val,    \
+				       "'%s()' was called with incorrect '%s' value",              \
+				       func_name, "stream");))                                     \
+} while (0)
+
 #endif /* MOCKS_BAP_UNICAST_SERVER_EXPECTS_H_ */

--- a/tests/bluetooth/audio/mocks/include/iso.h
+++ b/tests/bluetooth/audio/mocks/include/iso.h
@@ -10,17 +10,12 @@
 #include <zephyr/fff.h>
 #include <zephyr/bluetooth/iso.h>
 
-/* List of fakes used by this unit tester */
-#define ISO_FFF_FAKES_LIST(FAKE)                                                                   \
-	FAKE(bt_iso_chan_send)                                                                     \
-	FAKE(bt_iso_server_register)                                                               \
-	FAKE(bt_iso_server_unregister)                                                             \
-	FAKE(bt_iso_chan_disconnect)                                                               \
+void mock_bt_iso_init(void);
+void mock_bt_iso_cleanup(void);
+int mock_bt_iso_accept(struct bt_conn *conn, uint8_t cig_id, uint8_t cis_id,
+		       struct bt_iso_chan **chan);
 
 DECLARE_FAKE_VALUE_FUNC(int, bt_iso_chan_send, struct bt_iso_chan *, struct net_buf *, uint16_t,
 			uint32_t);
-DECLARE_FAKE_VALUE_FUNC(int, bt_iso_server_register, struct bt_iso_server *);
-DECLARE_FAKE_VALUE_FUNC(int, bt_iso_server_unregister, struct bt_iso_server *);
-DECLARE_FAKE_VALUE_FUNC(int, bt_iso_chan_disconnect, struct bt_iso_chan *);
 
 #endif /* MOCKS_ISO_H_ */

--- a/tests/bluetooth/audio/mocks/include/iso.h
+++ b/tests/bluetooth/audio/mocks/include/iso.h
@@ -14,11 +14,13 @@
 #define ISO_FFF_FAKES_LIST(FAKE)                                                                   \
 	FAKE(bt_iso_chan_send)                                                                     \
 	FAKE(bt_iso_server_register)                                                               \
+	FAKE(bt_iso_server_unregister)                                                             \
 	FAKE(bt_iso_chan_disconnect)                                                               \
 
 DECLARE_FAKE_VALUE_FUNC(int, bt_iso_chan_send, struct bt_iso_chan *, struct net_buf *, uint16_t,
 			uint32_t);
 DECLARE_FAKE_VALUE_FUNC(int, bt_iso_server_register, struct bt_iso_server *);
+DECLARE_FAKE_VALUE_FUNC(int, bt_iso_server_unregister, struct bt_iso_server *);
 DECLARE_FAKE_VALUE_FUNC(int, bt_iso_chan_disconnect, struct bt_iso_chan *);
 
 #endif /* MOCKS_ISO_H_ */

--- a/tests/bluetooth/audio/mocks/include/mock_kernel.h
+++ b/tests/bluetooth/audio/mocks/include/mock_kernel.h
@@ -11,21 +11,12 @@
 #include <zephyr/fff.h>
 #include <zephyr/kernel.h>
 
-/* List of fakes used by this unit tester */
-#define KERNEL_FFF_FAKES_LIST(FAKE)                                                                \
-	FAKE(z_timeout_remaining)                                                                  \
-	FAKE(k_work_schedule)                                                                      \
-	FAKE(k_work_cancel_delayable_sync)                                                         \
-	FAKE(k_work_init_delayable)                                                                \
-	FAKE(k_work_cancel_delayable)                                                              \
-	FAKE(k_work_reschedule)                                                                    \
+void mock_kernel_init(void);
+void mock_kernel_cleanup(void);
 
 DECLARE_FAKE_VALUE_FUNC(k_ticks_t, z_timeout_remaining, const struct _timeout *);
 DECLARE_FAKE_VALUE_FUNC(int, k_work_schedule, struct k_work_delayable *, k_timeout_t);
 DECLARE_FAKE_VALUE_FUNC(bool, k_work_cancel_delayable_sync, struct k_work_delayable *,
 			struct k_work_sync *);
-DECLARE_FAKE_VOID_FUNC(k_work_init_delayable, struct k_work_delayable *, k_work_handler_t);
-DECLARE_FAKE_VALUE_FUNC(int, k_work_cancel_delayable, struct k_work_delayable *);
-DECLARE_FAKE_VALUE_FUNC(int, k_work_reschedule, struct k_work_delayable *, k_timeout_t);
 
 #endif /* MOCKS_KERNEL_H_ */

--- a/tests/bluetooth/audio/mocks/src/iso.c
+++ b/tests/bluetooth/audio/mocks/src/iso.c
@@ -4,12 +4,85 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdlib.h>
 #include <zephyr/bluetooth/iso.h>
 
+#include "conn.h"
 #include "iso.h"
+
+/* List of fakes used by this unit tester */
+#define FFF_FAKES_LIST(FAKE)                                                                       \
+	FAKE(bt_iso_chan_send)                                                                     \
+
+static struct bt_iso_server *iso_server;
 
 DEFINE_FAKE_VALUE_FUNC(int, bt_iso_chan_send, struct bt_iso_chan *, struct net_buf *, uint16_t,
 		       uint32_t);
-DEFINE_FAKE_VALUE_FUNC(int, bt_iso_server_register, struct bt_iso_server *);
-DEFINE_FAKE_VALUE_FUNC(int, bt_iso_server_unregister, struct bt_iso_server *);
-DEFINE_FAKE_VALUE_FUNC(int, bt_iso_chan_disconnect, struct bt_iso_chan *);
+
+int bt_iso_server_register(struct bt_iso_server *server)
+{
+	zassert_not_null(server, "server is NULL");
+	zassert_not_null(server->accept, "server->accept is NULL");
+	zassert_is_null(iso_server, "iso_server is NULL");
+
+	iso_server = server;
+
+	return 0;
+}
+
+int bt_iso_server_unregister(struct bt_iso_server *server)
+{
+	zassert_not_null(server, "server is NULL");
+	zassert_equal_ptr(iso_server, server, "not registered");
+
+	iso_server = NULL;
+
+	return 0;
+}
+
+int bt_iso_chan_disconnect(struct bt_iso_chan *chan)
+{
+	chan->state = BT_ISO_STATE_DISCONNECTED;
+	chan->ops->disconnected(chan, 0x13);
+	free(chan->iso);
+
+	return 0;
+}
+
+void mock_bt_iso_init(void)
+{
+	FFF_FAKES_LIST(RESET_FAKE);
+}
+
+void mock_bt_iso_cleanup(void)
+{
+	iso_server = NULL;
+}
+
+int mock_bt_iso_accept(struct bt_conn *conn, uint8_t cig_id, uint8_t cis_id,
+		       struct bt_iso_chan **chan)
+{
+	struct bt_iso_accept_info info = {
+		.acl = conn,
+		.cig_id = cig_id,
+		.cis_id = cis_id,
+	};
+	int err;
+
+	zassert_not_null(iso_server, "iso_server is NULL");
+
+	err = iso_server->accept(&info, chan);
+	if (err != 0) {
+		return err;
+	}
+
+	zassert_not_null(*chan, "chan is NULL");
+
+	(*chan)->state = BT_ISO_STATE_CONNECTED;
+	(*chan)->iso = malloc(sizeof(struct bt_conn));
+	zassert_not_null((*chan)->iso);
+
+	(*chan)->ops->connected(*chan);
+
+	return 0;
+}

--- a/tests/bluetooth/audio/mocks/src/iso.c
+++ b/tests/bluetooth/audio/mocks/src/iso.c
@@ -11,4 +11,5 @@
 DEFINE_FAKE_VALUE_FUNC(int, bt_iso_chan_send, struct bt_iso_chan *, struct net_buf *, uint16_t,
 		       uint32_t);
 DEFINE_FAKE_VALUE_FUNC(int, bt_iso_server_register, struct bt_iso_server *);
+DEFINE_FAKE_VALUE_FUNC(int, bt_iso_server_unregister, struct bt_iso_server *);
 DEFINE_FAKE_VALUE_FUNC(int, bt_iso_chan_disconnect, struct bt_iso_chan *);

--- a/tests/bluetooth/audio/mocks/src/kernel.c
+++ b/tests/bluetooth/audio/mocks/src/kernel.c
@@ -6,13 +6,66 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/sys/slist.h>
 
 #include "mock_kernel.h"
+
+/* List of fakes used by this unit tester */
+#define FFF_FAKES_LIST(FAKE)                                                                       \
+	FAKE(z_timeout_remaining)                                                                  \
+	FAKE(k_work_schedule)                                                                      \
+	FAKE(k_work_cancel_delayable_sync)                                                         \
+
+/* List of k_work items to be worked. */
+static sys_slist_t work_pending;
 
 DEFINE_FAKE_VALUE_FUNC(k_ticks_t, z_timeout_remaining, const struct _timeout *);
 DEFINE_FAKE_VALUE_FUNC(int, k_work_schedule, struct k_work_delayable *, k_timeout_t);
 DEFINE_FAKE_VALUE_FUNC(bool, k_work_cancel_delayable_sync, struct k_work_delayable *,
 		       struct k_work_sync *);
-DEFINE_FAKE_VOID_FUNC(k_work_init_delayable, struct k_work_delayable *, k_work_handler_t);
-DEFINE_FAKE_VALUE_FUNC(int, k_work_cancel_delayable, struct k_work_delayable *);
-DEFINE_FAKE_VALUE_FUNC(int, k_work_reschedule, struct k_work_delayable *, k_timeout_t);
+
+void k_work_init_delayable(struct k_work_delayable *dwork, k_work_handler_t handler)
+{
+	dwork->work.handler = handler;
+}
+
+int k_work_reschedule(struct k_work_delayable *dwork, k_timeout_t delay)
+{
+	struct k_work *work;
+
+	/* Determine whether the work item is queued already. */
+	SYS_SLIST_FOR_EACH_CONTAINER(&work_pending, work, node) {
+		if (work == &dwork->work) {
+			return 0;
+		}
+	}
+
+	sys_slist_append(&work_pending, &dwork->work.node);
+
+	return 0;
+}
+
+int k_work_cancel_delayable(struct k_work_delayable *dwork)
+{
+	(void)sys_slist_find_and_remove(&work_pending, &dwork->work.node);
+
+	return 0;
+}
+
+void mock_kernel_init(void)
+{
+	FFF_FAKES_LIST(RESET_FAKE);
+
+	sys_slist_init(&work_pending);
+}
+
+void mock_kernel_cleanup(void)
+{
+	struct k_work *work, *tmp;
+
+	/* Run all pending works */
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&work_pending, work, tmp, node) {
+		(void)sys_slist_remove(&work_pending, NULL, &work->node);
+		work->handler(work);
+	}
+}


### PR DESCRIPTION
This adds fixes for ASE/ASCS cleanup that was missing in few places.
The unit tests have been added that trigger invalid behavior fixed in this PR.

Fixes: #56111
Fixes: #56138
Fixes: #56139
Fixes: #51552