### PR TITLE
Add die_temp_polling support for nRF51-DK and nRF52840-DK

### DIFF
--- a/samples/sensor/die_temp_polling/boards/nrf51dk_nrf51422.overlay
+++ b/samples/sensor/die_temp_polling/boards/nrf51dk_nrf51422.overlay
@@ -1,0 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Mizuki Agawa
+ */
+
+/ {
+        aliases {
+                die-temp0 = &temp;
+        };
+};

--- a/samples/sensor/die_temp_polling/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/sensor/die_temp_polling/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Hisanori YAMAOKU
+ */
+
+/ {
+        aliases {
+                die-temp0 = &temp;
+        };
+};


### PR DESCRIPTION
Adding die-temp0 aliases for nrf51822 and nrf52840.
The die_temp_polling sample uses this alias
This PR verified with nRF51-DK and nRF52840-DK