### PR TITLE
drivers: dma: stm32: do not clear busy flag in circular mode

### DIFF
--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -22,6 +22,7 @@ struct dma_stm32_stream {
 #endif /* CONFIG_DMAMUX_STM32 */
 	bool source_periph;
 	bool hal_override;
+	bool circular;
 	volatile bool busy;
 	uint32_t src_size;
 	uint32_t dst_size;


### PR DESCRIPTION
The STM32 DMA driver supports circular mode by setting source_reload_en and dest_reload_en. This causes the dma_callback to be called twice per buffer run-through, at half-time and when wrapping back to the start of the buffer.

However, the current implementation only calls dma_callback twice. When wrapping the first time, it sets stream->busy to false and ignores subsequent interrupts.

This commit fixes this problem in the following way:
- In the half transfer interrupt, the busy flag is never cleared
- In the transfer complete interrupt, the busy flag is only cleared in non-circular mode
- The handling in all other interrupts is unchanged

(I could not find any documentation why in the error cases, the busy flag is only cleared when CONFIG_DMAMUX_STM32 is not defined, but I decided to keep it that way)