### PR TITLE
tests: drivers: gpio_basic_api: add overlays for esp32s2/c3/s3

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/esp32c3_devkitm.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/esp32c3_devkitm.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio0 4 0>;
+		in-gpios = <&gpio0 5 0>;
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/esp32s2_saola.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/esp32s2_saola.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio0 4 0>;
+		in-gpios = <&gpio0 5 0>;
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/esp32s3_devkitm.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/esp32s3_devkitm.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio0 4 0>;
+		in-gpios = <&gpio0 5 0>;
+	};
+};


### PR DESCRIPTION
Add support for the following boards:
- esp32s2_saola
- esp32c3_devkitm
- esp32s3_devkitm