### PR TITLE
net: shell: Fix shell freeze

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -4492,6 +4492,7 @@ static void ping_work(struct k_work *work)
 
 	if (ret != 0) {
 		PR_WARNING("Failed to send ping, err: %d", ret);
+		ping_done(ctx);
 		return;
 	}
 


### PR DESCRIPTION
Adds clean up after failed ping from shell,
so it does not freeze the output.