### PR TITLE
cmake: Allow extending/replacing signing functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1719,7 +1719,18 @@ endif()
 
 # Generate and use MCUboot related artifacts as needed.
 if(CONFIG_BOOTLOADER_MCUBOOT)
-  include(${CMAKE_CURRENT_LIST_DIR}/cmake/mcuboot.cmake)
+  get_target_property(signing_script zephyr_property_target SIGNING_SCRIPT)
+  if(NOT signing_script)
+    set_target_properties(zephyr_property_target PROPERTIES SIGNING_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/cmake/mcuboot.cmake)
+  endif()
+endif()
+
+# Include signing script, if set
+get_target_property(signing_script zephyr_property_target SIGNING_SCRIPT)
+if(signing_script)
+  message(STATUS "Including signing script: ${signing_script}")
+
+  include(${signing_script})
 endif()
 
 # Generate USB-C VIF policies in XML format

--- a/doc/develop/west/sign.rst
+++ b/doc/develop/west/sign.rst
@@ -89,6 +89,29 @@ Whether ``west flash`` supports this feature depends on your runner. The
 does not support this flow and you would like it to, please send a patch or
 file an issue for adding support.
 
+.. _west-extending-signing:
+
+Extending signing externally
+****************************
+
+The signing script used when running ``west flash`` can be extended or replaced
+to change features or introduce different signing mechanisms. By default with
+MCUboot enabled, signing is setup by the :file:`cmake/mcuboot.cmake` file in
+Zephyr which adds extra post build commands for generating the signed images.
+The file used for signing can be replaced by adjusting the ``SIGNING_SCRIPT``
+property on the `zephyr_property_target`, ideally done by a module using:
+
+.. code-block:: cmake
+
+   if(CONFIG_BOOTLOADER_MCUBOOT)
+     set_target_properties(zephyr_property_target PROPERTIES SIGNING_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/custom_signing.cmake)
+   endif()
+
+This will include the custom signing CMake file instead of the default Zephyr
+one when projects are built with MCUboot signing support enabled. The base
+Zephyr MCUboot signing file can be used as a reference for creating a new
+signing system or extending the default behaviour.
+
 .. _MCUboot:
    https://mcuboot.com/
 

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -238,6 +238,10 @@ Build system and infrastructure
   configuration files would not be included by emitting a fatal error. As a
   result, prj.conf files are now mandatory in projects.
 
+* Introduced support for extending/replacing the signing mechanism in zephyr,
+  see :ref:`West extending signing <west-extending-signing>` for further
+  details.
+
 Drivers and Sensors
 *******************
 


### PR DESCRIPTION
Allows extended or replacing the default MCUboot signing functionality by using a cmake property which can be set by modules if alternate or modified signing functionality is required.

Fixes #54653

- [x] Implementation
- [x] Release notes update
- [x] Documentation update