### PR TITLE
Bluetooth: Clean up public header inclusion

### DIFF
--- a/include/zephyr/bluetooth/a2dp-codec.h
+++ b/include/zephyr/bluetooth/a2dp-codec.h
@@ -20,6 +20,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_A2DP_CODEC_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_A2DP_CODEC_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/a2dp.h
+++ b/include/zephyr/bluetooth/a2dp.h
@@ -10,6 +10,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_A2DP_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_A2DP_H_
 
+#include <stdint.h>
+
 #include <zephyr/bluetooth/avdtp.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/addr.h
+++ b/include/zephyr/bluetooth/addr.h
@@ -10,9 +10,10 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_ADDR_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_ADDR_H_
 
+#include <stdint.h>
 #include <string.h>
+
 #include <zephyr/sys/printk.h>
-#include <zephyr/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/audio/aics.h
+++ b/include/zephyr/bluetooth/audio/aics.h
@@ -26,7 +26,6 @@
  * [Experimental] Users should note that the APIs can change as a part of ongoing development.
  */
 
-#include <zephyr/types.h>
 #include <zephyr/bluetooth/bluetooth.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -11,6 +11,13 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_AUDIO_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_AUDIO_H_
 
+/**
+ * @brief Bluetooth Audio
+ * @defgroup bt_audio Bluetooth Audio
+ * @ingroup bluetooth
+ * @{
+ */
+
 #include <zephyr/sys/atomic.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/conn.h>
@@ -19,12 +26,6 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/audio/lc3.h>
 
-/**
- * @brief Bluetooth Audio
- * @defgroup bt_audio Bluetooth Audio
- * @ingroup bluetooth
- * @{
- */
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -9,9 +9,6 @@
 
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_BAP_
 #define ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_BAP_
-#include <zephyr/types.h>
-#include <zephyr/bluetooth/conn.h>
-#include <zephyr/bluetooth/audio/audio.h>
 
 /**
  * @brief Bluetooth Basic Audio Profile (BAP)
@@ -19,6 +16,9 @@
  * @ingroup bluetooth
  * @{
  */
+
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/audio/audio.h>
 
 #if defined(CONFIG_BT_BAP_SCAN_DELEGATOR)
 #define BT_BAP_SCAN_DELEGATOR_MAX_METADATA_LEN CONFIG_BT_BAP_SCAN_DELEGATOR_MAX_METADATA_LEN

--- a/include/zephyr/bluetooth/audio/bap_lc3_preset.h
+++ b/include/zephyr/bluetooth/audio/bap_lc3_preset.h
@@ -8,6 +8,7 @@
 
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_BAP_LC3_PRESET_
 #define ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_BAP_LC3_PRESET_
+
 #include <zephyr/bluetooth/audio/audio.h>
 
 /** Struct to hold a BAP defined LC3 preset */

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -19,7 +19,8 @@
  * as a part of ongoing development.
  */
 
-#include <zephyr/types.h>
+#include <stdint.h>
+
 #include <zephyr/bluetooth/audio/csip.h>
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/audio/audio.h>

--- a/include/zephyr/bluetooth/audio/csip.h
+++ b/include/zephyr/bluetooth/audio/csip.h
@@ -18,8 +18,6 @@
  * [Experimental] Users should note that the APIs can change as a part of ongoing development.
  */
 
-#include <zephyr/types.h>
-#include <stdbool.h>
 #include <zephyr/bluetooth/conn.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/audio/has.h
+++ b/include/zephyr/bluetooth/audio/has.h
@@ -22,8 +22,9 @@
  * ongoing development.
  */
 
-#include <zephyr/bluetooth/bluetooth.h>
 #include <sys/types.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/sys/util.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/audio/lc3.h
+++ b/include/zephyr/bluetooth/audio/lc3.h
@@ -18,7 +18,6 @@
  * @{
  */
 
-#include <zephyr/types.h>
 #include <zephyr/sys/util_macro.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/audio/mcc.h
+++ b/include/zephyr/bluetooth/audio/mcc.h
@@ -21,7 +21,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_MCC_
 #define ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_MCC_
 
-#include <zephyr/types.h>
+#include <stdint.h>
+
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/net/buf.h>
 #include <zephyr/bluetooth/audio/media_proxy.h>

--- a/include/zephyr/bluetooth/audio/media_proxy.h
+++ b/include/zephyr/bluetooth/audio/media_proxy.h
@@ -36,8 +36,9 @@
  * as a part of ongoing development.
  */
 
+#include <stdint.h>
 #include <stdbool.h>
-#include <zephyr/types.h>
+
 #include <zephyr/bluetooth/bluetooth.h>
 
 /* TODO: Remove dependency on mcs.h */

--- a/include/zephyr/bluetooth/audio/micp.h
+++ b/include/zephyr/bluetooth/audio/micp.h
@@ -19,7 +19,8 @@
  * as a part of ongoing development.
  */
 
-#include <zephyr/types.h>
+#include <stdint.h>
+
 #include <zephyr/bluetooth/audio/aics.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -10,7 +10,9 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_TBS_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_TBS_H_
 
-#include <zephyr/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+
 #include <zephyr/bluetooth/conn.h>
 
 /* Call States */

--- a/include/zephyr/bluetooth/audio/vcp.h
+++ b/include/zephyr/bluetooth/audio/vcp.h
@@ -19,7 +19,8 @@
  * as a part of ongoing development.
  */
 
-#include <zephyr/types.h>
+#include <stdint.h>
+
 #include <zephyr/bluetooth/audio/aics.h>
 #include <zephyr/bluetooth/audio/vocs.h>
 

--- a/include/zephyr/bluetooth/audio/vocs.h
+++ b/include/zephyr/bluetooth/audio/vocs.h
@@ -26,7 +26,8 @@
  * [Experimental] Users should note that the APIs can change as a part of ongoing development.
  */
 
-#include <zephyr/types.h>
+#include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/avdtp.h
+++ b/include/zephyr/bluetooth/avdtp.h
@@ -10,11 +10,11 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_AVDTP_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_AVDTP_H_
 
+#include <zephyr/bluetooth/l2cap.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <zephyr/bluetooth/l2cap.h>
 
 /** @brief AVDTP SEID Information */
 struct bt_avdtp_seid_info {

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -19,6 +19,7 @@
 
 #include <stdbool.h>
 #include <string.h>
+
 #include <zephyr/sys/util.h>
 #include <zephyr/net/buf.h>
 #include <zephyr/bluetooth/gap.h>

--- a/include/zephyr/bluetooth/buf.h
+++ b/include/zephyr/bluetooth/buf.h
@@ -18,7 +18,8 @@
  * @{
  */
 
-#include <zephyr/types.h>
+#include <stdint.h>
+
 #include <zephyr/net/buf.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/util.h>

--- a/include/zephyr/bluetooth/controller.h
+++ b/include/zephyr/bluetooth/controller.h
@@ -17,6 +17,8 @@
  * @{
  */
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/crypto.h
+++ b/include/zephyr/bluetooth/crypto.h
@@ -19,6 +19,7 @@
  */
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/direction.h
+++ b/include/zephyr/bluetooth/direction.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_DF_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_DF_H_
 
+#include <stdint.h>
+
 /** Constant Tone Extension (CTE) types. */
 enum bt_df_cte_type {
 	/** Convenience value for purposes where non of CTE types is allowed. */

--- a/include/zephyr/bluetooth/ead.h
+++ b/include/zephyr/bluetooth/ead.h
@@ -6,7 +6,6 @@
 #include <stdint.h>
 
 #include <zephyr/kernel.h>
-
 #include <zephyr/bluetooth/bluetooth.h>
 
 /** Randomizer size in bytes */

--- a/include/zephyr/bluetooth/gap.h
+++ b/include/zephyr/bluetooth/gap.h
@@ -11,11 +11,11 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_GAP_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_GAP_H_
 
+#include <zephyr/sys/util_macro.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <zephyr/sys/util_macro.h>
 
 /**
  * @brief Bluetooth Generic Access Profile defines and Assigned Numbers.

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -17,9 +17,12 @@
  * @{
  */
 
+#include <stdint.h>
 #include <stddef.h>
-#include <zephyr/sys/slist.h>
+
 #include <sys/types.h>
+
+#include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/uuid.h>

--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -8,10 +8,12 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_HCI_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_HCI_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
-#include <stdbool.h>
-#include <string.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/net/buf.h>
 #include <zephyr/bluetooth/addr.h>

--- a/include/zephyr/bluetooth/hci_raw.h
+++ b/include/zephyr/bluetooth/hci_raw.h
@@ -17,6 +17,8 @@
  * @{
  */
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/hci_vs.h
+++ b/include/zephyr/bluetooth/hci_vs.h
@@ -9,6 +9,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_HCI_VS_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_HCI_VS_H_
 
+#include <stdint.h>
+
 #include <zephyr/bluetooth/hci.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -18,14 +18,14 @@
  * @{
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <zephyr/sys/atomic.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  *  @brief Headroom needed for outgoing ISO SDUs

--- a/include/zephyr/bluetooth/mesh.h
+++ b/include/zephyr/bluetooth/mesh.h
@@ -10,8 +10,9 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_H_
 
-#include <zephyr/types.h>
 #include <stddef.h>
+
+#include <zephyr/types.h>
 #include <zephyr/net/buf.h>
 
 #include <zephyr/bluetooth/mesh/msg.h>

--- a/include/zephyr/bluetooth/mesh/access.h
+++ b/include/zephyr/bluetooth/mesh/access.h
@@ -10,8 +10,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_ACCESS_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_ACCESS_H_
 
-#include <zephyr/settings/settings.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/settings/settings.h>
 #include <zephyr/bluetooth/mesh/msg.h>
 
 /* Internal macros used to initialize array members */

--- a/include/zephyr/bluetooth/mesh/blob.h
+++ b/include/zephyr/bluetooth/mesh/blob.h
@@ -14,8 +14,9 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_H__
 
-#include <zephyr/kernel.h>
 #include <sys/types.h>
+
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/mesh/blob_cli.h
+++ b/include/zephyr/bluetooth/mesh/blob_cli.h
@@ -14,9 +14,10 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_CLI_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_CLI_H_
 
+#include <sys/types.h>
+
 #include <zephyr/bluetooth/mesh/access.h>
 #include <zephyr/bluetooth/mesh/blob.h>
-#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/mesh/blob_io_flash.h
+++ b/include/zephyr/bluetooth/mesh/blob_io_flash.h
@@ -14,6 +14,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_IO_FLASH_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_IO_FLASH_H__
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/mesh/cdb.h
+++ b/include/zephyr/bluetooth/mesh/cdb.h
@@ -6,7 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_CDB_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_CDB_H_
 
-#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+
 #include <zephyr/sys/atomic.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/mesh/cfg.h
+++ b/include/zephyr/bluetooth/mesh/cfg.h
@@ -12,6 +12,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+
 #include <sys/types.h>
 
 /**

--- a/include/zephyr/bluetooth/mesh/cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/cfg_cli.h
@@ -17,6 +17,9 @@
  * @{
  */
 
+#include <stdint.h>
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/mesh/dfu.h
+++ b/include/zephyr/bluetooth/mesh/dfu.h
@@ -15,8 +15,9 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_DFU_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_DFU_H__
 
-#include <zephyr/kernel.h>
 #include <sys/types.h>
+
+#include <zephyr/kernel.h>
 #include <zephyr/bluetooth/mesh/blob.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/mesh/dfu_metadata.h
+++ b/include/zephyr/bluetooth/mesh/dfu_metadata.h
@@ -15,8 +15,11 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_DFU_METADATA_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_DFU_METADATA_H__
 
-#include <zephyr/kernel.h>
+#include <stdint.h>
+
 #include <sys/types.h>
+
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/mesh/health_cli.h
+++ b/include/zephyr/bluetooth/mesh/health_cli.h
@@ -10,6 +10,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_HEALTH_CLI_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_HEALTH_CLI_H_
 
+#include <zephyr/bluetooth/mesh.h>
+
 /**
  * @brief Health Client Model
  * @defgroup bt_mesh_health_cli Health Client Model

--- a/include/zephyr/bluetooth/mesh/health_srv.h
+++ b/include/zephyr/bluetooth/mesh/health_srv.h
@@ -17,6 +17,8 @@
  * @{
  */
 
+#include <zephyr/bluetooth/mesh.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/mesh/heartbeat.h
+++ b/include/zephyr/bluetooth/mesh/heartbeat.h
@@ -10,6 +10,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_HEARTBEAT_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_HEARTBEAT_H_
 
+#include <stdint.h>
+
 #include <zephyr/sys/slist.h>
 
 /**

--- a/include/zephyr/bluetooth/mesh/large_comp_data_cli.h
+++ b/include/zephyr/bluetooth/mesh/large_comp_data_cli.h
@@ -13,6 +13,8 @@
 #ifndef BT_MESH_LARGE_COMP_DATA_CLI_H__
 #define BT_MESH_LARGE_COMP_DATA_CLI_H__
 
+#include <zephyr/bluetooth/mesh.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/mesh/large_comp_data_srv.h
+++ b/include/zephyr/bluetooth/mesh/large_comp_data_srv.h
@@ -13,6 +13,8 @@
 #ifndef BT_MESH_LARGE_COMP_DATA_SRV_H__
 #define BT_MESH_LARGE_COMP_DATA_SRV_H__
 
+#include <zephyr/bluetooth/mesh.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/mesh/main.h
+++ b/include/zephyr/bluetooth/mesh/main.h
@@ -10,6 +10,11 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_MAIN_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_MAIN_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/kernel.h>
+
 /**
  * @brief Provisioning
  * @defgroup bt_mesh_prov Provisioning

--- a/include/zephyr/bluetooth/mesh/od_priv_proxy_cli.h
+++ b/include/zephyr/bluetooth/mesh/od_priv_proxy_cli.h
@@ -13,6 +13,9 @@
 
 #ifndef BT_MESH_OD_PRIV_PROXY_CLI_H__
 #define BT_MESH_OD_PRIV_PROXY_CLI_H__
+
+#include <zephyr/bluetooth/mesh.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/mesh/od_priv_proxy_srv.h
+++ b/include/zephyr/bluetooth/mesh/od_priv_proxy_srv.h
@@ -14,6 +14,8 @@
 #ifndef BT_MESH_OD_PRIV_PROXY_SRV_H__
 #define BT_MESH_OD_PRIV_PROXY_SRV_H__
 
+#include <zephyr/bluetooth/mesh.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/mesh/op_agg_cli.h
+++ b/include/zephyr/bluetooth/mesh/op_agg_cli.h
@@ -13,6 +13,8 @@
 #ifndef BT_MESH_OP_AGG_CLI_H__
 #define BT_MESH_OP_AGG_CLI_H__
 
+#include <zephyr/bluetooth/mesh.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/mesh/op_agg_srv.h
+++ b/include/zephyr/bluetooth/mesh/op_agg_srv.h
@@ -13,6 +13,8 @@
 #ifndef BT_MESH_OP_AGG_SRV_H__
 #define BT_MESH_OP_AGG_SRV_H__
 
+#include <zephyr/bluetooth/mesh.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/mesh/proxy.h
+++ b/include/zephyr/bluetooth/mesh/proxy.h
@@ -10,6 +10,10 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_PROXY_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_PROXY_H_
 
+#include <stdint.h>
+
+#include <zephyr/kernel.h>
+
 /**
  * @brief Proxy
  * @defgroup bt_mesh_proxy Proxy

--- a/include/zephyr/bluetooth/mesh/sar_cfg.h
+++ b/include/zephyr/bluetooth/mesh/sar_cfg.h
@@ -14,6 +14,8 @@
 #ifndef BT_MESH_SAR_CFG_H__
 #define BT_MESH_SAR_CFG_H__
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/mesh/sar_cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/sar_cfg_cli.h
@@ -10,6 +10,7 @@
 #ifndef BT_MESH_SAR_CFG_CLI_H__
 #define BT_MESH_SAR_CFG_CLI_H__
 
+#include <zephyr/bluetooth/mesh.h>
 #include <zephyr/bluetooth/mesh/sar_cfg.h>
 
 /**

--- a/include/zephyr/bluetooth/mesh/sar_cfg_srv.h
+++ b/include/zephyr/bluetooth/mesh/sar_cfg_srv.h
@@ -10,6 +10,7 @@
 #ifndef BT_MESH_SAR_CFG_SRV_H__
 #define BT_MESH_SAR_CFG_SRV_H__
 
+#include <zephyr/bluetooth/mesh.h>
 #include <zephyr/bluetooth/mesh/sar_cfg.h>
 
 /**

--- a/include/zephyr/bluetooth/mesh/sol_pdu_rpl_cli.h
+++ b/include/zephyr/bluetooth/mesh/sol_pdu_rpl_cli.h
@@ -13,6 +13,9 @@
 
 #ifndef BT_MESH_SOL_PDU_RPL_CLI_H__
 #define BT_MESH_SOL_PDU_RPL_CLI_H__
+
+#include <zephyr/bluetooth/mesh.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/services/bas.h
+++ b/include/zephyr/bluetooth/services/bas.h
@@ -18,7 +18,7 @@
  * as a part of ongoing development.
  */
 
-#include <zephyr/types.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/services/hrs.h
+++ b/include/zephyr/bluetooth/services/hrs.h
@@ -17,6 +17,8 @@
  * as a part of ongoing development.
  */
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/zephyr/bluetooth/services/ots.h
+++ b/include/zephyr/bluetooth/services/ots.h
@@ -17,19 +17,21 @@
  * as a part of ongoing development.
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
-#include <zephyr/types.h>
-#include <zephyr/sys/byteorder.h>
+#include <stdint.h>
+
 #include <sys/types.h>
+
+#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/crc.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** @brief Size of OTS object ID (in bytes). */
 #define BT_OTS_OBJ_ID_SIZE 6

--- a/include/zephyr/bluetooth/testing.h
+++ b/include/zephyr/bluetooth/testing.h
@@ -11,6 +11,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_TESTING_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_TESTING_H_
 
+#include <stdint.h>
+
 #if defined(CONFIG_BT_MESH)
 #include <zephyr/bluetooth/mesh.h>
 #endif /* CONFIG_BT_MESH */

--- a/include/zephyr/bluetooth/uuid.h
+++ b/include/zephyr/bluetooth/uuid.h
@@ -17,6 +17,8 @@
  * @{
  */
 
+#include <stdint.h>
+
 #include <zephyr/sys/util.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
A bit of cleanup in the public header files inclusion policy and statements:

- Include only what is needed if possible
- Include in the right location
- Include in the right order

Fixes #55971.