### PR TITLE
soc: arm: stm32h7: expand linker with sram sections 1 to 3

### DIFF
--- a/soc/arm/st_stm32/stm32h7/sections.ld
+++ b/soc/arm/st_stm32/stm32h7/sections.ld
@@ -26,6 +26,33 @@ SECTION_DATA_PROLOGUE(eth_stm32,(NOLOAD),)
 #endif
 #endif
 
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(sram1), okay)
+SECTION_PROLOGUE (sram1, ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram1))) (NOLOAD),)
+{
+    __sram1_start = .;
+    KEEP(*(SORT_BY_NAME(".sram1*")))
+    __sram1_end = .;
+} GROUP_DATA_LINK_IN(SRAM1, SRAM1)
+#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(sram1), okay) */
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(sram2), okay)
+SECTION_PROLOGUE (sram2, ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram2))) (NOLOAD),)
+{
+    __sram2_start = .;
+    KEEP(*(SORT_BY_NAME(".sram2*")))
+    __sram2_end = .;
+} GROUP_DATA_LINK_IN(SRAM2, SRAM2)
+#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(sram2), okay) */
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(sram3), okay)
+SECTION_PROLOGUE (sram3, ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram3))) (NOLOAD),)
+{
+    __sram3_start = .;
+    KEEP(*(SORT_BY_NAME(".sram3*")))
+    __sram3_end = .;
+} GROUP_DATA_LINK_IN(SRAM3, SRAM3)
+#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(sram3), okay) */
+
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(sram4), okay)
 SECTION_PROLOGUE (sram4, ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram4))) (NOLOAD),)
 {


### PR DESCRIPTION
In #53184 a linker section for SRAM4 was added because it's required for use with the STM32H7 BDMA. Now in #52965 support was added for the ADC DMA which expects a similar linker section which is non-cachable, but is limited to use SRAM4 to place it's buffers. This commit gives the user more flexibility to use any SRAM region to place buffers to use with ADC DMA.

The region SRAM0 isn't supported because it doesn't have the "zephyr,memory-region" compatibility required to turn it into a non-cacheable region, meaning it doesn't fit the mentioned use case.