### PR TITLE
tfm: Use relative path to the runners.yaml hex file and move tfm_merged

### DIFF
--- a/boards/arm/b_u585i_iot02a/board.cmake
+++ b/boards/arm/b_u585i_iot02a/board.cmake
@@ -3,7 +3,7 @@ if(CONFIG_BUILD_WITH_TFM)
   set(TFM_FLASH_BASE_ADDRESS 0x0C000000)
 
   # Flash merged TF-M + Zephyr binary
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file "${CMAKE_BINARY_DIR}/tfm_merged.hex")
+  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 
   if (CONFIG_HAS_FLASH_LOAD_OFFSET)
     MATH(EXPR TFM_HEX_BASE_ADDRESS_NS "${TFM_FLASH_BASE_ADDRESS}+${CONFIG_FLASH_LOAD_OFFSET}")

--- a/boards/arm/bl5340_dvk/board.cmake
+++ b/boards/arm/bl5340_dvk/board.cmake
@@ -11,7 +11,7 @@ board_runner_args(jlink "--device=nrf5340_xxaa_app" "--speed=4000")
 endif()
 
 if(CONFIG_TFM_FLASH_MERGED_BINARY)
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file "${CMAKE_BINARY_DIR}/tfm_merged.hex")
+  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 endif()
 
 if(CONFIG_BOARD_BL5340_DVK_CPUNET)

--- a/boards/arm/lpcxpresso55s69/doc/index.rst
+++ b/boards/arm/lpcxpresso55s69/doc/index.rst
@@ -335,7 +335,7 @@ a J-Link as follows (reset and erase are for recovering a locked core):
       JLinkExe -device lpc55s69 -if swd -speed 2000 -autoconnect 1
       J-Link>r
       J-Link>erase
-      J-Link>loadfile build/tfm_merged.hex
+      J-Link>loadfile build/zephyr/tfm_merged.hex
 
 We need to reset the board manually after flashing the image to run this code.
 

--- a/boards/arm/mps2_an521/board.cmake
+++ b/boards/arm/mps2_an521/board.cmake
@@ -20,7 +20,7 @@ if (CONFIG_BUILD_WITH_TFM)
   # Override the binary used by qemu, to use the combined
   # TF-M (Secure) & Zephyr (Non Secure) image (when running
   # in-tree tests).
-  set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/tfm_merged.hex")
+  set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/zephyr/tfm_merged.hex")
 elseif(CONFIG_OPENAMP)
   set(QEMU_EXTRA_FLAGS "-device;loader,file=${REMOTE_ZEPHYR_DIR}/zephyr.elf")
 elseif (CONFIG_SOC_MPS2_AN521_CPU1)

--- a/boards/arm/mps3_an547/board.cmake
+++ b/boards/arm/mps3_an547/board.cmake
@@ -25,7 +25,7 @@ if (CONFIG_BUILD_WITH_TFM)
   # Override the binary used by qemu, to use the combined
   # TF-M (Secure) & Zephyr (Non Secure) image (when running
   # in-tree tests).
-  set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/tfm_merged.hex")
+  set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/zephyr/merged.hex")
 endif()
 
 # FVP settings

--- a/boards/arm/nrf5340dk_nrf5340/board.cmake
+++ b/boards/arm/nrf5340dk_nrf5340/board.cmake
@@ -9,7 +9,7 @@ board_runner_args(jlink "--device=nrf5340_xxaa_app" "--speed=4000")
 endif()
 
 if(CONFIG_TFM_FLASH_MERGED_BINARY)
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file "${CMAKE_BINARY_DIR}/tfm_merged.hex")
+  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 endif()
 
 if(CONFIG_BOARD_NRF5340DK_NRF5340_CPUNET)

--- a/boards/arm/nrf9160dk_nrf9160/board.cmake
+++ b/boards/arm/nrf9160dk_nrf9160/board.cmake
@@ -5,7 +5,7 @@ if(CONFIG_BOARD_NRF9160DK_NRF9160_NS)
 endif()
 
 if(CONFIG_TFM_FLASH_MERGED_BINARY)
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file "${CMAKE_BINARY_DIR}/tfm_merged.hex")
+  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 endif()
 
 board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")

--- a/boards/arm/nucleo_l552ze_q/board.cmake
+++ b/boards/arm/nucleo_l552ze_q/board.cmake
@@ -3,7 +3,7 @@ if(CONFIG_BUILD_WITH_TFM)
   set(FLASH_BASE_ADDRESS_S 0x0C000000)
 
   # Flash merged TF-M + Zephyr binary
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file "${CMAKE_BINARY_DIR}/tfm_merged.hex")
+  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 
   if (CONFIG_HAS_FLASH_LOAD_OFFSET)
     MATH(EXPR TFM_HEX_BASE_ADDRESS_NS "${FLASH_BASE_ADDRESS_S}+${CONFIG_FLASH_LOAD_OFFSET}")

--- a/boards/arm/stm32l562e_dk/board.cmake
+++ b/boards/arm/stm32l562e_dk/board.cmake
@@ -3,7 +3,7 @@ if(CONFIG_BUILD_WITH_TFM)
   set(TFM_FLASH_BASE_ADDRESS 0x0C000000)
 
   # Flash merged TF-M + Zephyr binary
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file "${CMAKE_BINARY_DIR}/tfm_merged.hex")
+  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 
   if (CONFIG_HAS_FLASH_LOAD_OFFSET)
     MATH(EXPR TFM_HEX_BASE_ADDRESS_NS "${TFM_FLASH_BASE_ADDRESS}+${CONFIG_FLASH_LOAD_OFFSET}")

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -483,11 +483,11 @@ if (CONFIG_BUILD_WITH_TFM)
       PARENT_SCOPE)
   endfunction()
 
-  set(MERGED_FILE ${CMAKE_BINARY_DIR}/tfm_merged.hex)
-  set(S_NS_FILE ${CMAKE_BINARY_DIR}/tfm_s_zephyr_ns.hex)
-  set(S_NS_SIGNED_FILE ${CMAKE_BINARY_DIR}/tfm_s_zephyr_ns_signed.hex)
-  set(NS_SIGNED_FILE ${CMAKE_BINARY_DIR}/zephyr_ns_signed.hex)
-  set(S_SIGNED_FILE ${CMAKE_BINARY_DIR}/tfm_s_signed.hex)
+  set(MERGED_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_merged.hex)
+  set(S_NS_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns.hex)
+  set(S_NS_SIGNED_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_zephyr_ns_signed.hex)
+  set(NS_SIGNED_FILE ${CMAKE_BINARY_DIR}/zephyr/zephyr_ns_signed.hex)
+  set(S_SIGNED_FILE ${CMAKE_BINARY_DIR}/zephyr/tfm_s_signed.hex)
 
   if (CONFIG_TFM_USE_NS_APP)
     # Use the TF-M NS binary as the Non-Secure application firmware image

--- a/samples/tfm_integration/tfm_ipc/README.rst
+++ b/samples/tfm_integration/tfm_ipc/README.rst
@@ -91,7 +91,7 @@ be run via ``qemu-system-arm``. The binary can be executed as follows:
 
    .. code-block:: bash
 
-      qemu-system-arm -M mps2-an521 -device loader,file=tfm_merged.hex -serial stdio
+      qemu-system-arm -M mps2-an521 -device loader,file=build/zephyr/tfm_merged.hex -serial stdio
 
 You can also run the binary as part of the ``west`` build process by appending
 the ``-t run`` flag to the end of your build command, or in the case of
@@ -160,7 +160,7 @@ J-Link as follows:
       JLinkExe -device lpc55s69 -if swd -speed 2000 -autoconnect 1
       J-Link>r
       J-Link>erase
-      J-Link>loadfile build/tfm_merged.bin
+      J-Link>loadfile build/zephyr/tfm_merged.bin
 
 Resetting the board and erasing it will unlock the board, this is useful in case
 it's in an unknown state and can't be flashed.
@@ -220,7 +220,7 @@ Flash the concatenated TF-M + Zephyr binary.
 
    .. code-block:: bash
 
-      west flash --hex-file tfm_merged.hex
+      west flash --hex-file zephyr/tfm_merged.hex
 
 Sample Output
 =============


### PR DESCRIPTION
Move tfm_merged.hex from `<build>/tfm_merged.hex` to `<build>/zephyr/tfm_merged.hex`.
Use relative path to the runners.yaml hex file.

This makes it possible to move the build folder.
Example would be to copy out the runners.yaml and tfm_merged.hex file and still be able to call west flash --skip-rebuild.