### PR TITLE
MAINTAINERS: remove inactive self as GPIO maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -865,12 +865,11 @@ Release Notes:
     - "area: Fuel Gauge"
 
 "Drivers: GPIO":
-  status: maintained
-  maintainers:
-    - mnkp
+  status: odd fixes
   collaborators:
     - henrikbrixandersen
     - cfriedt
+    - mnkp
   files:
     - doc/hardware/peripherals/gpio.rst
     - drivers/gpio/


### PR DESCRIPTION
I am no longer able to act as GPIO subsystem maintainer. I would like to degrade my role to collaborator.