### PR TITLE
drivers: intel_adsp: IPC driver uses D3 power state

### DIFF
--- a/drivers/ipm/ipm_cavs_host.c
+++ b/drivers/ipm/ipm_cavs_host.c
@@ -78,7 +78,7 @@ static int send(const struct device *dev, int wait, uint32_t id,
 
 	memcpy(buf, data, size);
 
-	bool ok = intel_adsp_ipc_send_message(INTEL_ADSP_IPC_HOST_DEV, id, ext_data);
+	int ret = intel_adsp_ipc_send_message(INTEL_ADSP_IPC_HOST_DEV, id, ext_data);
 
 	/* The IPM docs call for "busy waiting" here, but in fact
 	 * there's a blocking synchronous call available that might be
@@ -87,13 +87,13 @@ static int send(const struct device *dev, int wait, uint32_t id,
 	 * benefit anyway as all its usage is async. This is OK for
 	 * now.
 	 */
-	if (ok && wait) {
+	if (ret == -EBUSY && wait) {
 		while (!intel_adsp_ipc_is_complete(INTEL_ADSP_IPC_HOST_DEV)) {
 			k_busy_wait(1);
 		}
 	}
 
-	return ok ? 0 : -EBUSY;
+	return ret;
 }
 
 static bool ipc_handler(const struct device *dev, void *arg,

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -225,5 +225,14 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
+#ifdef CONFIG_PM
+
+void sys_clock_idle_exit(void)
+{
+	sys_clock_driver_init();
+}
+
+#endif
+
 SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -16,6 +16,7 @@
 #include <adsp_memory.h>
 #include <adsp_imr_layout.h>
 #include <zephyr/drivers/mm/mm_drv_intel_adsp_mtl_tlb.h>
+#include <zephyr/drivers/timer/system_timer.h>
 
 #define LPSRAM_MAGIC_VALUE      0x13579BDF
 #define LPSCTL_BATTR_MASK       GENMASK(16, 12)
@@ -317,6 +318,7 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 			imr_layout->imr_state.header.adsp_imr_magic = 0;
 			imr_layout->imr_state.header.imr_restore_vector = NULL;
 			imr_layout->imr_state.header.imr_ram_storage = NULL;
+			sys_clock_idle_exit();
 		}
 #endif /* CONFIG_ADSP_IMR_CONTEXT_SAVE */
 		soc_cpus_active[cpu] = true;

--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -17,6 +17,7 @@
 #include <adsp_imr_layout.h>
 #include <zephyr/drivers/mm/mm_drv_intel_adsp_mtl_tlb.h>
 #include <zephyr/drivers/timer/system_timer.h>
+#include <mem_window.h>
 
 #define LPSRAM_MAGIC_VALUE      0x13579BDF
 #define LPSCTL_BATTR_MASK       GENMASK(16, 12)
@@ -319,6 +320,7 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 			imr_layout->imr_state.header.imr_restore_vector = NULL;
 			imr_layout->imr_state.header.imr_ram_storage = NULL;
 			sys_clock_idle_exit();
+			mem_window_idle_exit();
 		}
 #endif /* CONFIG_ADSP_IMR_CONTEXT_SAVE */
 		soc_cpus_active[cpu] = true;

--- a/soc/xtensa/intel_adsp/common/include/intel_adsp_ipc.h
+++ b/soc/xtensa/intel_adsp/common/include/intel_adsp_ipc.h
@@ -139,30 +139,32 @@ bool intel_adsp_ipc_is_complete(const struct device *dev);
  *
  * Sends a message to the other side of an IPC link. The data and
  * ext_data parameters are passed using the IDR/IDD registers.
- * Returns true if the message was sent, false if a current message is
- * in progress (in the sense of intel_adsp_ipc_is_complete()).
+ * Returns 0 if the message was sent, negative error values:
+ * -EBUSY if there is already IPC message processed (intel_adsp_ipc_is_complete returns false).
+ * -ESHUTDOWN if IPC device will not send the message as it undergoes power
+ * transition.
  *
  * @param dev IPC device.
  * @param data 30 bits value to transmit with the message (IDR register).
  * @param ext_data Extended value to transmit with the message (IDD register).
  * @return message successfully transmitted.
  */
-bool intel_adsp_ipc_send_message(const struct device *dev,
+int intel_adsp_ipc_send_message(const struct device *dev,
 	uint32_t data, uint32_t ext_data);
 
 /** @brief Send an IPC message, block until completion.
  *
  * As for intel_adsp_ipc_send_message(), but blocks the current thread until
  * the completion of the message or the expiration of the provided
- * timeout.
+ * timeout. Returns immediately if IPC device is during power transition.
  *
  * @param dev IPC device
  * @param data 30 bits value to transmit with the message (IDR register)
  * @param ext_data Extended value to transmit with the message (IDD register)
  * @param timeout Maximum time to wait, or K_FOREVER, or K_NO_WAIT
- * @return message successfully transmitted
+ * @return returns 0 if message successfully transmited, otherwise error code.
  */
-bool intel_adsp_ipc_send_message_sync(const struct device *dev,
+int intel_adsp_ipc_send_message_sync(const struct device *dev,
 	uint32_t data, uint32_t ext_data, k_timeout_t timeout);
 
 

--- a/soc/xtensa/intel_adsp/common/include/intel_adsp_ipc.h
+++ b/soc/xtensa/intel_adsp/common/include/intel_adsp_ipc.h
@@ -7,6 +7,10 @@
 #include <intel_adsp_ipc_devtree.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#endif
 
 struct intel_adsp_ipc_config {
 	volatile struct intel_adsp_ipc *regs;
@@ -174,4 +178,38 @@ bool intel_adsp_ipc_send_message_sync(const struct device *dev,
 void intel_adsp_ipc_send_message_emergency(const struct device *dev, uint32_t data,
 					   uint32_t ext_data);
 
+#ifdef CONFIG_PM_DEVICE
+
+typedef int (*intel_adsp_ipc_resume_handler_t)(const struct device *dev, void *arg);
+
+typedef int (*intel_adsp_ipc_suspend_handler_t)(const struct device *dev, void *arg);
+
+/**
+ * @brief Registers resume callback handler used to resume Device from suspended state.
+ *
+ * @param dev IPC device.
+ * @param fn Callback function.
+ * @param arg Value to pass as the "arg" parameter to the function.
+ */
+void intel_adsp_ipc_set_resume_handler(const struct device *dev,
+	intel_adsp_ipc_resume_handler_t fn, void *arg);
+
+/**
+ * @brief Registers suspend callback handler used to suspend active Device.
+ *
+ * @param dev IPC device.
+ * @param fn Callback function.
+ * @param arg Value to pass as the "arg" parameter to the function.
+ */
+void intel_adsp_ipc_set_suspend_handler(const struct device *dev,
+	intel_adsp_ipc_suspend_handler_t fn, void *arg);
+
+struct ipc_control_driver_api {
+	intel_adsp_ipc_resume_handler_t resume_fn;
+	void *resume_fn_args;
+	intel_adsp_ipc_suspend_handler_t suspend_fn;
+	void *suspend_fn_args;
+};
+
+#endif /* CONFIG_PM_DEVICE */
 #endif /* ZEPHYR_INCLUDE_INTEL_ADSP_IPC_H */

--- a/soc/xtensa/intel_adsp/common/include/mem_window.h
+++ b/soc/xtensa/intel_adsp/common/include/mem_window.h
@@ -42,6 +42,12 @@ struct mem_win_config {
 	bool read_only;
 };
 
+/**
+ * @brief Reinitializes device after power state change.
+ * Should be run on Primary Core only.
+ */
+void mem_window_idle_exit(void);
+
 #endif
 
 #endif

--- a/soc/xtensa/intel_adsp/common/ipc.c
+++ b/soc/xtensa/intel_adsp/common/ipc.c
@@ -7,7 +7,10 @@
 #include <adsp_ipc_regs.h>
 #include <adsp_interrupt.h>
 #include <zephyr/irq.h>
-
+#include <zephyr/pm/state.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/device.h>
+#include <errno.h>
 
 void intel_adsp_ipc_set_message_handler(const struct device *dev,
 	intel_adsp_ipc_handler_t fn, void *arg)
@@ -79,6 +82,7 @@ void z_intel_adsp_ipc_isr(const void *devarg)
 		}
 
 		regs->ida = INTEL_ADSP_IPC_DONE;
+		pm_device_busy_clear(dev);
 	}
 
 	k_spin_unlock(&devdata->lock, key);
@@ -86,6 +90,7 @@ void z_intel_adsp_ipc_isr(const void *devarg)
 
 int intel_adsp_ipc_init(const struct device *dev)
 {
+	pm_device_busy_set(dev);
 	struct intel_adsp_ipc_data *devdata = dev->data;
 	const struct intel_adsp_ipc_config *config = dev->config;
 
@@ -102,6 +107,8 @@ int intel_adsp_ipc_init(const struct device *dev)
 	config->regs->tda = INTEL_ADSP_IPC_DONE;
 #endif
 	config->regs->ctl |= (INTEL_ADSP_IPC_CTL_IDIE | INTEL_ADSP_IPC_CTL_TBIE);
+	pm_device_busy_clear(dev);
+
 	return 0;
 }
 
@@ -128,6 +135,7 @@ bool intel_adsp_ipc_is_complete(const struct device *dev)
 bool intel_adsp_ipc_send_message(const struct device *dev,
 			   uint32_t data, uint32_t ext_data)
 {
+	pm_device_busy_set(dev);
 	const struct intel_adsp_ipc_config *config = dev->config;
 	struct intel_adsp_ipc_data *devdata = dev->data;
 	k_spinlock_key_t key = k_spin_lock(&devdata->lock);
@@ -207,12 +215,119 @@ static int dt_init(const struct device *dev)
 	return intel_adsp_ipc_init(dev);
 }
 
+#ifdef CONFIG_PM_DEVICE
+
+void intel_adsp_ipc_set_resume_handler(const struct device *dev,
+	intel_adsp_ipc_resume_handler_t fn, void *arg)
+{
+	struct ipc_control_driver_api *api =
+		(struct ipc_control_driver_api *)dev->api;
+	struct intel_adsp_ipc_data *devdata = dev->data;
+	k_spinlock_key_t key = k_spin_lock(&devdata->lock);
+
+	api->resume_fn = fn;
+	api->resume_fn_args = arg;
+
+	k_spin_unlock(&devdata->lock, key);
+}
+
+void intel_adsp_ipc_set_suspend_handler(const struct device *dev,
+	intel_adsp_ipc_suspend_handler_t fn, void *arg)
+{
+	struct ipc_control_driver_api *api =
+		(struct ipc_control_driver_api *)dev->api;
+	struct intel_adsp_ipc_data *devdata = dev->data;
+	k_spinlock_key_t key = k_spin_lock(&devdata->lock);
+
+	api->suspend_fn = fn;
+	api->suspend_fn_args = arg;
+
+	k_spin_unlock(&devdata->lock, key);
+}
+
+/**
+ * @brief Manages IPC driver power state change.
+ *
+ * @param dev IPC device.
+ * @param action Power state to be changed to.
+ * @return int Returns 0 on success or optionaly error code from the
+ * registered ipc_power_control_api callbacks.
+ *
+ * @note PM lock is taken at the start of each power transition to prevent concurrent calls
+ * to @ref pm_device_action_run function.
+ * If IPC Device performs hardware operation and device is busy (what should not happen)
+ * function returns failure. It is API user responsibility to make sure we are not entering
+ * device power transition while device is busy.
+ */
+static int ipc_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	if (pm_device_is_busy(INTEL_ADSP_IPC_HOST_DEV)) {
+		return -EBUSY;
+	}
+
+	const struct ipc_control_driver_api *api =
+		(const struct ipc_control_driver_api *)dev->api;
+
+	int ret = 0;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		pm_device_state_lock(dev);
+		if (api->suspend_fn) {
+			ret = api->suspend_fn(dev, api->suspend_fn_args);
+			if (!ret) {
+				irq_disable(DT_IRQN(INTEL_ADSP_IPC_HOST_DTNODE));
+			}
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		pm_device_state_lock(dev);
+		irq_enable(DT_IRQN(INTEL_ADSP_IPC_HOST_DTNODE));
+		if (!irq_is_enabled(DT_IRQN(INTEL_ADSP_IPC_HOST_DTNODE))) {
+			ret = -EINTR;
+			break;
+		}
+		ace_ipc_intc_unmask();
+		ret = intel_adsp_ipc_init(dev);
+		if (ret) {
+			break;
+		}
+		if (api->resume_fn) {
+			ret = api->resume_fn(dev, api->resume_fn_args);
+		}
+		break;
+	default:
+		/* Return as default value when given PM action is not supported */
+		return -ENOTSUP;
+	}
+
+	pm_device_state_unlock(dev);
+	return ret;
+}
+
+/**
+ * @brief Callback functions to be executed by Zephyr application
+ * during IPC device suspend and resume.
+ */
+static struct ipc_control_driver_api ipc_power_control_api = {
+	.resume_fn = NULL,
+	.resume_fn_args = NULL,
+	.suspend_fn = NULL,
+	.suspend_fn_args = NULL
+};
+
+PM_DEVICE_DT_DEFINE(INTEL_ADSP_IPC_HOST_DTNODE, ipc_pm_action);
+
+#endif /* CONFIG_PM_DEVICE */
+
 static const struct intel_adsp_ipc_config ipc_host_config = {
 	.regs = (void *)INTEL_ADSP_IPC_REG_ADDRESS,
 };
 
 static struct intel_adsp_ipc_data ipc_host_data;
 
-DEVICE_DT_DEFINE(INTEL_ADSP_IPC_HOST_DTNODE, dt_init, NULL, &ipc_host_data, &ipc_host_config,
-		 PRE_KERNEL_2, 0, NULL);
-#endif
+DEVICE_DT_DEFINE(INTEL_ADSP_IPC_HOST_DTNODE, dt_init, PM_DEVICE_DT_GET(INTEL_ADSP_IPC_HOST_DTNODE),
+	&ipc_host_data, &ipc_host_config, PRE_KERNEL_2, 0, COND_CODE_1(CONFIG_PM_DEVICE,
+	(&ipc_power_control_api), (NULL)));
+
+#endif /* DT_NODE_EXISTS(INTEL_ADSP_IPC_HOST_DTNODE) */

--- a/soc/xtensa/intel_adsp/common/mem_window.c
+++ b/soc/xtensa/intel_adsp/common/mem_window.c
@@ -37,6 +37,14 @@ __imr int mem_win_init(const struct device *dev)
 	return 0;
 }
 
+void mem_window_idle_exit(void)
+{
+	mem_win_init(DEVICE_DT_GET(MEM_WINDOW_NODE(0)));
+	mem_win_init(DEVICE_DT_GET(MEM_WINDOW_NODE(1)));
+	mem_win_init(DEVICE_DT_GET(MEM_WINDOW_NODE(2)));
+	mem_win_init(DEVICE_DT_GET(MEM_WINDOW_NODE(3)));
+}
+
 #define MEM_WINDOW_DEFINE(n)                                                                       \
 	static const struct mem_win_config mem_win_config_##n = {                                  \
 		.base_addr = DT_REG_ADDR(MEM_WINDOW_NODE(n)),                                      \

--- a/tests/boards/intel_adsp/hda/src/tests.h
+++ b/tests/boards/intel_adsp/hda/src/tests.h
@@ -31,8 +31,9 @@
 static inline void hda_ipc_msg(const struct device *dev, uint32_t data,
 			       uint32_t ext, k_timeout_t timeout)
 {
-	zassert_true(intel_adsp_ipc_send_message_sync(dev, data, ext, timeout),
-		"Unexpected ipc send message failure, try increasing IPC_TIMEOUT");
+	int ret = intel_adsp_ipc_send_message_sync(dev, data, ext, timeout);
+
+	zassert_true(!ret, "Unexpected ipc send message failure, error code: %d", ret);
 }
 
 #endif /* ZEPHYR_TESTS_INTEL_ADSP_TESTS_H */

--- a/tests/boards/intel_adsp/hda_log/src/tests.h
+++ b/tests/boards/intel_adsp/hda_log/src/tests.h
@@ -13,8 +13,9 @@
 static inline void hda_ipc_msg(const struct device *dev, uint32_t data,
 			       uint32_t ext, k_timeout_t timeout)
 {
-	zassert_true(intel_adsp_ipc_send_message_sync(dev, data, ext, timeout),
-		"Unexpected ipc send message failure, try increasing IPC_TIMEOUT");
+	int ret = intel_adsp_ipc_send_message_sync(dev, data, ext, timeout);
+
+	zassert_true(!ret, "Unexpected ipc send message failure, error code: %d", ret);
 }
 
 #endif /* ZEPHYR_TESTS_INTEL_ADSP_TESTS_H */

--- a/tests/boards/intel_adsp/smoke/src/cpus.c
+++ b/tests/boards/intel_adsp/smoke/src/cpus.c
@@ -162,7 +162,7 @@ static void halt_and_restart(int cpu)
 	int ret;
 
 	/* On older hardware we need to get the host to turn the core
-	 * off.  Construct an ADSPCS with only this core disabled
+	 * off. Construct an ADSPCS with only this core disabled
 	 */
 	if (!IS_ENABLED(CONFIG_SOC_INTEL_CAVS_V25)) {
 		intel_adsp_ipc_send_message(INTEL_ADSP_IPC_HOST_DEV, IPCCMD_ADSPCS,

--- a/tests/boards/intel_adsp/smoke/src/hostipc.c
+++ b/tests/boards/intel_adsp/smoke/src/hostipc.c
@@ -32,7 +32,7 @@ static bool ipc_done(const struct device *dev, void *arg)
 
 ZTEST(intel_adsp, test_host_ipc)
 {
-	bool ret;
+	int ret;
 
 	intel_adsp_ipc_set_message_handler(INTEL_ADSP_IPC_HOST_DEV, ipc_message, NULL);
 	intel_adsp_ipc_set_done_handler(INTEL_ADSP_IPC_HOST_DEV, ipc_done, NULL);
@@ -41,7 +41,7 @@ ZTEST(intel_adsp, test_host_ipc)
 	printk("Simple message send...\n");
 	done_flag = false;
 	ret = intel_adsp_ipc_send_message(INTEL_ADSP_IPC_HOST_DEV, IPCCMD_SIGNAL_DONE, 0);
-	zassert_true(ret, "send failed");
+	zassert_true(!ret, "send failed");
 	AWAIT(intel_adsp_ipc_is_complete(INTEL_ADSP_IPC_HOST_DEV));
 	AWAIT(done_flag);
 
@@ -53,7 +53,7 @@ ZTEST(intel_adsp, test_host_ipc)
 	msg_flag = false;
 	ret = intel_adsp_ipc_send_message(INTEL_ADSP_IPC_HOST_DEV, IPCCMD_RETURN_MSG,
 				RETURN_MSG_SYNC_VAL);
-	zassert_true(ret, "send failed");
+	zassert_true(!ret, "send failed");
 	AWAIT(done_flag);
 	AWAIT(intel_adsp_ipc_is_complete(INTEL_ADSP_IPC_HOST_DEV));
 	AWAIT(msg_flag);
@@ -66,7 +66,7 @@ ZTEST(intel_adsp, test_host_ipc)
 	msg_flag = false;
 	ret = intel_adsp_ipc_send_message(INTEL_ADSP_IPC_HOST_DEV, IPCCMD_RETURN_MSG,
 				RETURN_MSG_SYNC_VAL);
-	zassert_true(ret, "send failed");
+	zassert_true(!ret, "send failed");
 	AWAIT(done_flag);
 	AWAIT(intel_adsp_ipc_is_complete(INTEL_ADSP_IPC_HOST_DEV));
 	AWAIT(msg_flag);
@@ -77,7 +77,7 @@ ZTEST(intel_adsp, test_host_ipc)
 	msg_flag = false;
 	ret = intel_adsp_ipc_send_message(INTEL_ADSP_IPC_HOST_DEV, IPCCMD_RETURN_MSG,
 				RETURN_MSG_ASYNC_VAL);
-	zassert_true(ret, "send failed");
+	zassert_true(!ret, "send failed");
 	AWAIT(done_flag);
 	AWAIT(intel_adsp_ipc_is_complete(INTEL_ADSP_IPC_HOST_DEV));
 	AWAIT(msg_flag);
@@ -92,7 +92,7 @@ ZTEST(intel_adsp, test_host_ipc)
 	done_flag = false;
 	ret = intel_adsp_ipc_send_message_sync(INTEL_ADSP_IPC_HOST_DEV, IPCCMD_ASYNC_DONE_DELAY,
 					 0, K_FOREVER);
-	zassert_true(ret, "send failed");
+	zassert_true(!ret, "send failed");
 	zassert_true(done_flag, "done interrupt failed to fire");
 	zassert_true(intel_adsp_ipc_is_complete(INTEL_ADSP_IPC_HOST_DEV),
 		"sync message incomplete");


### PR DESCRIPTION
This PR enables suspend/resume of the Intel ADSP IPC driver using Zephyr Power Manager Device API.
Options are enabled when CONFIG_PM_DEVICE=y.
New power control API performs hardware reinitialization after wake from D3 power state (PM_DEVICE_ACTION_SUSPEND):
* enabled interrupts
* resets register state to accept new messages
* allows to register callbacks to Zephyr application that may perform additional actions

Consists of 4 commits (2 main commits and two dependent):

1. Commit 2ea0d25892da45fdc316766efa52485b0ccdfade sets up Power Manager calls for IPC driver
2. Commit fa839a99d9113963a81a0a64d70887d4ceccb307 adds returned error codes to IPC functions, returning -EBUSY when Device is during power transition. 
3. Commit fc367d468ae86b8ba669b72e728645717fb8a795 allows system timer re-initialization - this commit is needed to resume system from low power state.
4. Commit 8dcac84c15ed3f7b1b8b553b1646e1204d4e53b2 allows to re-initialize memory window - this commit is also needed to complete IPC messages correctly after waking up from D3.

Blocked by bug:

- [x] https://github.com/zephyrproject-rtos/zephyr/issues/58502

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>
