### PR TITLE
tests: kernel: usage: Relax timing requirements for RISCV

### DIFF
--- a/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
+++ b/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
@@ -15,8 +15,8 @@
 	((((val1) * 100) < ((val2) * (100 + (pcnt)))) &&              \
 	 (((val1) * 100) > ((val2) * (100 - (pcnt))))) ? true : false
 
-#if defined(CONFIG_RISCV_MACHINE_TIMER)
-#define IDLE_EVENT_STATS_PRECISION 5
+#if defined(CONFIG_RISCV)
+#define IDLE_EVENT_STATS_PRECISION 7
 #else
 #define IDLE_EVENT_STATS_PRECISION 1
 #endif


### PR DESCRIPTION
Test was previously relaxed for RISCV machine timer. I have a platform where it fails on RISCV requiring further relaxation. Relaxing precision for RISCV architecture.