### PR TITLE
Bluetooth: tester: Fix not updating value length on write

### DIFF
--- a/tests/bluetooth/tester/src/btp_gatt.c
+++ b/tests/bluetooth/tester/src/btp_gatt.c
@@ -411,6 +411,7 @@ static ssize_t write_value(struct bt_conn *conn,
 	}
 
 	memcpy(value->data + offset, buf, len);
+	value->len = len;
 
 	/* Maximum attribute value size is 512 bytes */
 	__ASSERT_NO_MSG(value->len < 512);


### PR DESCRIPTION
Previously tests were passing only because initial value in database and PTS value used for testing had same length.