### PR TITLE
doc: external components: Introduce a section about external tooling

### DIFF
--- a/doc/contribute/external.rst
+++ b/doc/contribute/external.rst
@@ -208,3 +208,17 @@ project is made optional via the ``group-filter:`` field in the main
 The TSC must approve every Pull Request that introduces a new external tooling
 component. This will be done on a case-by-case, individual analysis of the
 proposed addition by the TSC representatives.
+
+Additional considerations about the main manifest
+*************************************************
+
+In general, any additions or removals whatsoever to the ``projects:`` section of
+the `main manifest file`_ requires TSC approval. This includes, but is not
+limited to:
+
+- Adding and removing groups and group filters
+- Adding and removing projects
+- Adding and removing ``import`` statements
+
+.. _main manifest file:
+   https://github.com/zephyrproject-rtos/zephyr/blob/main/west.yml

--- a/doc/contribute/external.rst
+++ b/doc/contribute/external.rst
@@ -14,6 +14,12 @@ There are three main factors that will be considered during the inclusion
 process in order to determine whether it will be accepted. These will be
 described in the following sections.
 
+Note that most of this page deals with external components that end up being
+compiled and linked into the final image, and programmed into the target
+hardware. For external tooling that is only used during compilation,
+code analysis, testing or simulation please refer to the
+:ref:`external-tooling` section at the end of the page.
+
 Software License
 ================
 
@@ -164,3 +170,41 @@ The flowchart below shows an overview of the process:
    :align: center
 
    Submission process
+
+.. _external-tooling:
+
+Contributing External Tooling
+*****************************
+
+This section deals exclusively with the inclusion of external tooling in the
+Zephyr project, where tooling is defined as software that assists the
+compilation, testing or simulation processes but in no case ends up being part
+of the code compiled and linked into the final image. "Inclusion" in this
+context means becoming part of the Zephyr default distribution either in the
+main tree directly under the :file:`scripts/` folder or indirectly as a west
+project in the main :file:`west.yml` manifest. Therefore, this section does not
+apply to 3rd-party tooling such as toolchains, simulators or others, which may
+still be referenced by the Zephyr build system or docs without being included in
+Zephyr.
+
+Tooling components must be released under a license approved by the
+`Open Source Initiative (OSI)`_.
+
+Just like with regular external components, tooling that is imported from
+another project can be integrated either in the main tree or as a :ref:`west
+project <west-workspace>`. Note that in this case the corresponding west project
+will not be a :ref:`module <modules>`, because tooling does not make use of the
+Zephyr build system and does not need to be processed by it. Please see
+:ref:`modules-vs-projects` for additional information on the differences.
+
+If the tool is integrated in the main tree it should be placed under the
+:file:`scripts/` folder.
+If the tool is integrated as a west project, then the project repository can be
+hosted outside the zephyrproject-rtos GitHub organization, provided that the
+project is made optional via the ``group-filter:`` field in the main
+:file:`west.yml` manifest. More info on optional projects can be found in
+:ref:`this section <west-manifest-groups>`.
+
+The TSC must approve every Pull Request that introduces a new external tooling
+component. This will be done on a case-by-case, individual analysis of the
+proposed addition by the TSC representatives.

--- a/doc/develop/modules.rst
+++ b/doc/develop/modules.rst
@@ -38,6 +38,32 @@ references to optional :ref:`binary blobs <bin-blobs>`.
 This page summarizes a list of policies and best practices which aim at
 better organizing the workflow in Zephyr modules.
 
+.. _modules-vs-projects:
+
+Modules vs west projects
+************************
+
+Zephyr modules, described in this page, are not the same as :ref:`west projects
+<west-workspace>`. In fact, modules :ref:`do not require west
+<modules_without_west>` at all. However, when using modules :ref:`with west
+<modules_using_west>`, then the build system uses west in order to find modules.
+
+In summary:
+
+Modules are repositories that contain a :file:`zephyr/module.yml` file, so that
+the Zephyr build system can pull in the source code from the repository.
+:ref:`West projects <west-manifests-projects>` are entries in the `projects:`
+section in the :file:`west.yml` manifest file.
+West projects are often also modules, but not always. There are west projects
+that are not included in the final firmware image (eg. tools) and thus do not
+need to be modules.
+Modules are found by the Zephyr build system either via :ref:`west itself
+<modules_using_west>`, or via the :ref:`ZEPHYR_MODULES CMake variable
+<modules_without_west>`.
+
+The contents of this page only apply to modules, and not to west projects in
+general (unless they are a module themselves).
+
 Module Repositories
 *******************
 

--- a/doc/develop/west/basics.rst
+++ b/doc/develop/west/basics.rst
@@ -88,7 +88,8 @@ projects
 
   By default, the Zephyr :ref:`build system <build_overview>` uses west to get
   the locations of all the projects in the workspace, so any code they contain
-  can be used as :ref:`modules`.
+  can be used as :ref:`modules`. Note however that modules and projects
+  :ref:`are conceptually different <modules-vs-projects>`.
 
 extensions
   Any repository known to west (either the manifest repository or any project

--- a/doc/develop/west/manifest.rst
+++ b/doc/develop/west/manifest.rst
@@ -160,7 +160,8 @@ The ``projects`` subsection contains a sequence describing the project
 repositories in the west workspace. Every project has a unique name. You can
 specify what Git remote URLs to use when cloning and fetching the projects,
 what revisions to track, and where the project should be stored on the local
-file system.
+file system. Note that west projects :ref:`are different from modules
+<modules-vs-projects>`.
 
 Here is an example. We'll assume the ``remotes`` given above.
 


### PR DESCRIPTION
Since tools that are not software that is compiled into the final images may have very different requirements from regular external components, introduce a new section outlining the process and rules to introduce new tools into the project.