### PR TITLE
board: npcx: use templates for the openocd setup

### DIFF
--- a/boards/arm/npcx7m6fb_evb/board.cmake
+++ b/boards/arm/npcx7m6fb_evb/board.cmake
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(openocd)
-board_set_debugger_ifnset(openocd)
+board_runner_args(openocd --cmd-load "npcx_write_image")
+board_runner_args(openocd --cmd-verify "npcx_verify_image")
 
-board_finalize_runner_args(openocd
-  --cmd-load "npcx_write_image"
-  --cmd-verify "npcx_verify_image"
-  )
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/npcx9m6f_evb/board.cmake
+++ b/boards/arm/npcx9m6f_evb/board.cmake
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(openocd)
-board_set_debugger_ifnset(openocd)
+board_runner_args(openocd --cmd-load "npcx_write_image")
+board_runner_args(openocd --cmd-verify "npcx_verify_image")
 
-board_finalize_runner_args(openocd
-  --cmd-load "npcx_write_image"
-  --cmd-verify "npcx_verify_image"
-  )
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)


### PR DESCRIPTION
The NPCX boards use the normal openocd setup with custom --cmd-load and --cmd-verify. This can be done using the normal template instead of calling board_set_flasher_ifnset and board_set_debugger_ifnset directly

Verified that the runner is indeed being called with the correct arguments after this commit.