### PR TITLE
bluetooth: Fix linking issues with armclang

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1291,9 +1291,11 @@ int bt_le_adv_start_ext(struct bt_le_ext_adv *adv,
 	}
 
 	if (!dir_adv) {
-		err = bt_le_ext_adv_set_data(adv, ad, ad_len, sd, sd_len);
-		if (err) {
-			return err;
+		if (IS_ENABLED(CONFIG_BT_EXT_ADV)) {
+			err = bt_le_ext_adv_set_data(adv, ad, ad_len, sd, sd_len);
+			if (err) {
+				return err;
+			}
 		}
 	} else {
 		if (!(param->options & BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY)) {


### PR DESCRIPTION
Various bluetooth tests fails to link because bt_le_ext_adv_set_data can't be resolved.  Solve this by implementing an inline function version of bt_le_ext_adv_set_data when CONFIG_BT_EXT_ADV=n.