### PR TITLE
cmake: python: Allow for explicit specification of a Python interpreter

### DIFF
--- a/cmake/modules/FindDtc.cmake
+++ b/cmake/modules/FindDtc.cmake
@@ -16,6 +16,8 @@
 # 'DTC_VERSION_STRING'
 # The version of devicetree compiler, dtc.
 
+include(FindPackageHandleStandardArgs)
+
 find_program(
   DTC
   dtc

--- a/cmake/modules/python.cmake
+++ b/cmake/modules/python.cmake
@@ -13,35 +13,51 @@ endif()
 
 set(PYTHON_MINIMUM_REQUIRED 3.8)
 
-# We are using foreach here, instead of find_program(PYTHON_EXECUTABLE_SYSTEM_DEFAULT "python" "python3")
-# cause just using find_program directly could result in a python2.7 as python, and not finding a valid python3.
-foreach(PYTHON_PREFER ${PYTHON_PREFER} ${WEST_PYTHON} "python" "python3")
-  find_program(PYTHON_PREFER_EXECUTABLE ${PYTHON_PREFER})
-  if(PYTHON_PREFER_EXECUTABLE)
-      execute_process (COMMAND "${PYTHON_PREFER_EXECUTABLE}" -c
-                               "import sys; sys.stdout.write('.'.join([str(x) for x in sys.version_info[:2]]))"
-                       RESULT_VARIABLE result
-                       OUTPUT_VARIABLE version
-                       ERROR_QUIET
-                       OUTPUT_STRIP_TRAILING_WHITESPACE)
+function(python_get_version interpreter)
+  execute_process(COMMAND "${interpreter}" -c
+    "import sys; sys.stdout.write('.'.join([str(x) for x in sys.version_info[:2]]))"
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE version
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(PYTHON_VERSION "${version}" PARENT_SCOPE)
+endfunction()
 
-     if(version VERSION_LESS PYTHON_MINIMUM_REQUIRED)
-       set(PYTHON_PREFER_EXECUTABLE "PYTHON_PREFER_EXECUTABLE-NOTFOUND")
-     else()
-       set(PYTHON_MINIMUM_REQUIRED ${version})
-       set(PYTHON_EXACT EXACT)
-       # Python3_ROOT_DIR ensures that location will be preferred by FindPython3.
-       # On Linux, this has no impact as it will usually be /usr/bin
-       # but on Windows it solve issues when both 32 and 64 bit versions are
-       # installed, as version is not enough and FindPython3 might pick the
-       # version not on %PATH%. Setting Python3_ROOT_DIR ensures we are using
-       # the version we just tested.
-       get_filename_component(PYTHON_PATH ${PYTHON_PREFER_EXECUTABLE} DIRECTORY)
-       set(Python3_ROOT_DIR ${PYTHON_PATH})
-       break()
-     endif()
+# If we're told exactly which Python executable to use, we should respect that,
+# instead of using the default matching process below.
+if(DEFINED PYTHON_EXECUTABLE)
+  python_get_version("${PYTHON_EXECUTABLE}")
+  if(PYTHON_VERSION VERSION_LESS PYTHON_MINIMUM_REQUIRED)
+    message(FATAL_ERROR
+      "Python executable ${PYTHON_EXECUTABLE} has version ${PYTHON_VERSION}, "
+      "however, the minimum required version is ${PYTHON_MINIMUM_REQUIRED}.")
   endif()
-endforeach()
+  set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  # We are using foreach here, instead of find_program(PYTHON_EXECUTABLE_SYSTEM_DEFAULT "python" "python3")
+  # cause just using find_program directly could result in a python2.7 as python, and not finding a valid python3.
+  foreach(PYTHON_PREFER ${PYTHON_PREFER} ${WEST_PYTHON} "python" "python3")
+    find_program(PYTHON_PREFER_EXECUTABLE ${PYTHON_PREFER})
+    if(PYTHON_PREFER_EXECUTABLE)
+      python_get_version("${PYTHON_PREFER_EXECUTABLE}")
+      if(PYTHON_VERSION VERSION_LESS PYTHON_MINIMUM_REQUIRED)
+        set(PYTHON_PREFER_EXECUTABLE "PYTHON_PREFER_EXECUTABLE-NOTFOUND")
+      else()
+        set(PYTHON_MINIMUM_REQUIRED "${PYTHON_VERSION}")
+        set(PYTHON_EXACT EXACT)
+        # Python3_ROOT_DIR ensures that location will be preferred by FindPython3.
+        # On Linux, this has no impact as it will usually be /usr/bin
+        # but on Windows it solve issues when both 32 and 64 bit versions are
+        # installed, as version is not enough and FindPython3 might pick the
+        # version not on %PATH%. Setting Python3_ROOT_DIR ensures we are using
+        # the version we just tested.
+        get_filename_component(PYTHON_PATH ${PYTHON_PREFER_EXECUTABLE} DIRECTORY)
+        set(Python3_ROOT_DIR ${PYTHON_PATH})
+        break()
+      endif()
+    endif()
+  endforeach()
 
-find_package(Python3 ${PYTHON_MINIMUM_REQUIRED} REQUIRED ${PYTHON_EXACT})
-set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+  find_package(Python3 ${PYTHON_MINIMUM_REQUIRED} REQUIRED ${PYTHON_EXACT})
+  set(PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()


### PR DESCRIPTION
    Setting PYTHON_PREFER may not select the desired interpreter under all
    circumstances.  find_package(Python3 ... EXACT) will try to find the Python
    interpreter of the desired version, but will not provide the correct
    interpreter if it's not in PATH, or if multiple interpreters exist of the
    same major+minor version in the PATH.
    
    Let's add an option for a user to explicitly specify PYTHON_EXECUTABLE, not
    just a preference.  The build system will then try that executable, and
    only that executable, and if it doesn't meet the version requirement, it'll
    error out instead of keep searching.
    
    Signed-off-by: Jack Rosenthal <jrosenth@chromium.org>