### PR TITLE
Cleanup loading of edt pickle file

### DIFF
--- a/scripts/build/gen_handles.py
+++ b/scripts/build/gen_handles.py
@@ -36,7 +36,6 @@ from elf_parser import ZephyrElf
 # This is needed to load edt.pickle files.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..',
                                 'dts', 'python-devicetree', 'src'))
-from devicetree import edtlib  # pylint: disable=unused-import
 
 def parse_args():
     global args

--- a/scripts/generate_usb_vif/generate_vif.py
+++ b/scripts/generate_usb_vif/generate_vif.py
@@ -7,6 +7,7 @@
 EDT.pickle generated at build and generates a XML file containing USB VIF policies"""
 
 import argparse
+import inspect
 import os
 import pickle
 import sys
@@ -17,16 +18,14 @@ import constants
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..")
 sys.path.insert(0, os.path.join(SCRIPTS_DIR, 'dts', 'python-devicetree', 'src'))
 
-from devicetree import edtlib
-
-
 def main():
+    global edtlib
+
     args = parse_args()
-    try:
-        with open(args.edt_pickle, 'rb') as f:
-            edt = pickle.load(f)
-    except edtlib.EDTError as err:
-        sys.exit(f"devicetree error: {err}")
+    with open(args.edt_pickle, 'rb') as f:
+        edt = pickle.load(f)
+    edtlib = inspect.getmodule(edt)
+
     xml_root = get_root()
     add_elements_to_xml(xml_root, constants.VIF_SPEC_ELEMENTS)
     add_element_to_xml(xml_root, constants.MODEL_PART_NUMBER, args.board)

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
 import os
 import pickle
 import sys
@@ -11,8 +12,6 @@ from pathlib import Path
 ZEPHYR_BASE = str(Path(__file__).resolve().parents[2])
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "dts",
                                 "python-devicetree", "src"))
-
-from devicetree import edtlib
 
 # Types we support
 # 'string', 'int', 'hex', 'bool'
@@ -26,6 +25,7 @@ if not doc_mode:
     if EDT_PICKLE is not None and os.path.isfile(EDT_PICKLE):
         with open(EDT_PICKLE, 'rb') as f:
             edt = pickle.load(f)
+            edtlib = inspect.getmodule(edt)
     else:
         edt = None
 

--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -14,16 +14,6 @@ import sys
 
 from runners.core import ZephyrBinaryRunner, RunnerCaps
 
-# This is needed to load edt.pickle files.
-try:
-    from devicetree import edtlib  # pylint: disable=unused-import
-    MISSING_EDTLIB = False
-except ImportError:
-    # This can happen when building the documentation for the
-    # runners package if edtlib is not on sys.path. This is fine
-    # to ignore in that case.
-    MISSING_EDTLIB = True
-
 if platform.system() == 'Darwin':
     DEFAULT_BOSSAC_PORT = None
 else:
@@ -110,8 +100,13 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
             raise RuntimeError(error_msg)
 
         # Load the devicetree.
-        with open(edt_pickle, 'rb') as f:
-            edt = pickle.load(f)
+        try:
+            with open(edt_pickle, 'rb') as f:
+                edt = pickle.load(f)
+        except ModuleNotFoundError:
+            error_msg = "could not load devicetree, something may be wrong " \
+                    + "with the python environment"
+            raise RuntimeError(error_msg)
 
         return edt.chosen_node('zephyr,code-partition')
 
@@ -247,11 +242,6 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
         return devices[value - 1]
 
     def do_run(self, command, **kwargs):
-        if MISSING_EDTLIB:
-            self.logger.warning(
-                'could not import edtlib; something may be wrong with the '
-                'python environment')
-
         if platform.system() == 'Linux':
             if 'microsoft' in platform.uname().release.lower() or \
                 os.getenv('WSL_DISTRO_NAME') is not None or \


### PR DESCRIPTION
Using an explicit import of edtlib in files that also use pickle.load() creates a duplicate module object.  Cleanup scripts that load the devicetree using the edt pickle file.