### PR TITLE
drivers: dmic: clear SOFT_RESET bit to ACE as well

### DIFF
--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -475,11 +475,9 @@ static void dai_dmic_gain_ramp(struct dai_intel_dmic *dmic)
 		if (!dmic->enable[i])
 			continue;
 
-#ifndef CONFIG_SOC_SERIES_INTEL_ACE
 		if (dmic->startcount == DMIC_UNMUTE_CIC)
 			dai_dmic_update_bits(dmic, base[i] + CIC_CONTROL,
 					     CIC_CONTROL_MIC_MUTE_BIT, 0);
-#endif
 
 		if (dmic->startcount == DMIC_UNMUTE_FIR) {
 			switch (dmic->dai_config_params.dai_index) {

--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -555,6 +555,14 @@ static void dai_dmic_start(struct dai_intel_dmic *dmic)
 	}
 
 	for (i = 0; i < CONFIG_DAI_DMIC_HW_CONTROLLERS; i++) {
+#ifdef CONFIG_SOC_SERIES_INTEL_ACE
+		dai_dmic_update_bits(dmic, base[i] + CIC_CONTROL,
+				     CIC_CONTROL_SOFT_RESET_BIT, 0);
+
+		LOG_INF("dmic_start(), cic 0x%08x",
+			dai_dmic_read(dmic, base[i] + CIC_CONTROL));
+#endif
+
 		mic_a = dmic->enable[i] & 1;
 		mic_b = (dmic->enable[i] & 2) >> 1;
 		fir_a = (dmic->enable[i] > 0) ? 1 : 0;


### PR DESCRIPTION
Clearing sof-reset bit applies to ACE as well. And when releasing a paused stream, unmuting mic is necessary. Without unmuting there will be no input data after resume.

fixes: https://github.com/thesofproject/sof/issues/6723