### PR TITLE
mcuboot: force .hex and .bin same content

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -883,6 +883,16 @@ config MCUBOOT_GENERATE_CONFIRMED_IMAGE
 	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
 	  and CONFIG_BUILD_OUTPUT_HEX.
 
+config MCUBOOT_GENERATED_HEX_BIN_SAME_CONTENT
+	bool "Ensure that generated .hex and .bin files have the same logical content"
+	default y
+	depends on BUILD_OUTPUT_HEX && BUILD_OUTPUT_BIN
+	help
+	  Enabling this configuration ensures that the signed hex and binary files generated
+	  by the signing tool have the same logical content. Disabling this option will
+	  result in the hex and binary files having different image signatures due to the
+	  multiple calls to the signing tool.
+
 endif # BOOTLOADER_MCUBOOT
 
 config BOOTLOADER_ESP_IDF


### PR DESCRIPTION
Ensure that the automatically generated `zephyr.signed.hex` and `zephyr.signed.bin` files (and derivatives) have the same logical content. Previously the two files would have different image signatures due to the indepenent calls to the image signing tool.

Note this only resolves the issue when the images are automatically signed, calling `west sign` manually with still result in different content. Resolving this is much harder as the tool has no knowledge of the commands requires to convert a `.hex` to a `.bin`.

Fixes #52271.