### PR TITLE
pm: device_runtime: balanced power domain operations

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -584,8 +584,12 @@ device_supported_handles_get(const struct device *dev, size_t *count)
 			}
 			rv++;
 		}
-		/* Count supporting devices */
-		while (rv[i] != DEVICE_HANDLE_ENDS) {
+		/* Count supporting devices.
+		 * Trailing NULL's can be injected by gen_handles.py due to
+		 * CONFIG_PM_DEVICE_POWER_DOMAIN_DYNAMIC_NUM
+		 */
+		while ((rv[i] != DEVICE_HANDLE_ENDS) &&
+		       (rv[i] != DEVICE_HANDLE_NULL)) {
 			++i;
 		}
 		*count = i;

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -32,6 +32,8 @@ enum pm_device_flag {
 	PM_DEVICE_FLAG_BUSY,
 	/** Indicate if the device failed to power up. */
 	PM_DEVICE_FLAG_TURN_ON_FAILED,
+	/** Indicate if the device has claimed a power domain */
+	PM_DEVICE_FLAG_PD_CLAIMED,
 	/**
 	 * Indicates whether or not the device is capable of waking the system
 	 * up.

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -163,6 +163,8 @@ int pm_device_runtime_get(const struct device *dev)
 			ret = -EAGAIN;
 			goto unlock;
 		}
+		/* Power domain successfully claimed */
+		atomic_set_bit(&pm->flags, PM_DEVICE_FLAG_PD_CLAIMED);
 	}
 
 	pm->usage++;
@@ -216,7 +218,8 @@ int pm_device_runtime_put(const struct device *dev)
 	/*
 	 * Now put the domain
 	 */
-	if ((ret == 0) && PM_DOMAIN(dev->pm) != NULL) {
+	if ((ret == 0) &&
+	    atomic_test_and_clear_bit(&dev->pm->flags, PM_DEVICE_FLAG_PD_CLAIMED)) {
 		ret = pm_device_runtime_put(PM_DOMAIN(dev->pm));
 	}
 	SYS_PORT_TRACING_FUNC_EXIT(pm, device_runtime_put, dev, ret);

--- a/tests/subsys/pm/power_domain/app.overlay
+++ b/tests/subsys/pm/power_domain/app.overlay
@@ -21,4 +21,15 @@
 		status = "okay";
 		power-domain = <&test_domain>;
 	};
+
+	test_domain_balanced: test_domain_balanced {
+		compatible = "power-domain";
+		status = "okay";
+	};
+
+	test_dev_balanced: test_dev_balanced {
+		compatible = "test-device-pm";
+		status = "okay";
+		power-domain = <&test_domain_balanced>;
+	};
 };


### PR DESCRIPTION
  Only run `pm_device_runtime_put` on the dependent domain if the original
  claim operation succeeded. This fixes unbalanced operations when running
  ```
  pm_device_runtime_get(dev);
  pm_device_runtime_put(dev);
  ```
  On a device that does not have PM enabled but does have a power domain.

Issues raised in #53979 cannot be trivially resolved as `pm_device_runtime_get` returns an error code if PM is not enabled on a device. IMO saving the return value and checking against both `< 0` and `-ENOTSUP` is less clear than the existing `pm_device_runtime_is_enabled` check.

Includes a fix for counting dynamic supported devices introduced with #42105