### PR TITLE
pm: device_runtime: PM unsupported is not an error

### DIFF
--- a/drivers/adc/adc_mchp_xec.c
+++ b/drivers/adc/adc_mchp_xec.c
@@ -369,7 +369,7 @@ static void adc_xec_single_isr(const struct device *dev)
 static int adc_xec_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	const struct adc_xec_config *const devcfg = dev->config;
-	struct adc_xec_regs *adc_regs = ADC_XEC_REG_BASE(dev);
+	struct adc_xec_regs * const adc_regs = devcfg->regs;
 	int ret;
 
 	switch (action) {

--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -75,7 +75,6 @@ int pm_device_runtime_disable(const struct device *dev);
  *
  * @retval 0 If it succeeds. In case device runtime PM is not enabled or not
  * available this function will be a no-op and will also return 0.
- * @retval -ENOTSUP If the device does not support PM.
  * @retval -errno Other negative errno, result of the PM action callback.
  */
 int pm_device_runtime_get(const struct device *dev);
@@ -94,7 +93,6 @@ int pm_device_runtime_get(const struct device *dev);
  *
  * @retval 0 If it succeeds. In case device runtime PM is not enabled or not
  * available this function will be a no-op and will also return 0.
- * @retval -ENOTSUP If the device does not support PM.
  * @retval -EALREADY If device is already suspended (can only happen if get/put
  * calls are unbalanced).
  * @retval -errno Other negative errno, result of the action callback.
@@ -120,7 +118,6 @@ int pm_device_runtime_put(const struct device *dev);
  *
  * @retval 0 If it succeeds. In case device runtime PM is not enabled or not
  * available this function will be a no-op and will also return 0.
- * @retval -ENOTSUP If the device does not support PM.
  * @retval -EBUSY If the device is busy.
  * @retval -EALREADY If device is already suspended (can only happen if get/put
  * calls are unbalanced).

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -132,7 +132,7 @@ int pm_device_runtime_get(const struct device *dev)
 	struct pm_device *pm = dev->pm;
 
 	if (pm == NULL) {
-		return -ENOTSUP;
+		return 0;
 	}
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_get, dev);
@@ -207,7 +207,7 @@ int pm_device_runtime_put(const struct device *dev)
 	__ASSERT(!k_is_in_isr(), "use pm_device_runtime_put_async() in ISR");
 
 	if (dev->pm == NULL) {
-		return -ENOTSUP;
+		return 0;
 	}
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_put, dev);
@@ -229,7 +229,7 @@ int pm_device_runtime_put_async(const struct device *dev)
 	int ret;
 
 	if (dev->pm == NULL) {
-		return -ENOTSUP;
+		return 0;
 	}
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_put_async, dev);

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -232,8 +232,8 @@ ZTEST(device_runtime_api, test_unsupported)
 	zassert_false(pm_device_runtime_is_enabled(dev), "");
 	zassert_equal(pm_device_runtime_enable(dev), -ENOTSUP, "");
 	zassert_equal(pm_device_runtime_disable(dev), -ENOTSUP, "");
-	zassert_equal(pm_device_runtime_get(dev), -ENOTSUP, "");
-	zassert_equal(pm_device_runtime_put(dev), -ENOTSUP, "");
+	zassert_equal(pm_device_runtime_get(dev), 0, "");
+	zassert_equal(pm_device_runtime_put(dev), 0, "");
 }
 
 void *device_runtime_api_setup(void)


### PR DESCRIPTION
Returning an error code when PM is not supported for a device only makes
writing drivers harder, as instead of checking for failures with `< 0`,
they also need to check for `-ENOTSUP`.

From the point of view of a driver, an `-ENOTSUP` return value is
equivalent to success, as if the device it is trying to turn on doesn't
support PM, by definition it is already enabled. This is equivalent to
the API behaviour when `CONFIG_PM_DEVICE_RUNTIME=n`.

Whether a device supports PM or not can still be determined at runtime
by inspecting the return code of `pm_device_runtime_enable` if
necessary.

Updating documentation for a return value of `0` is not necessary as this case
already falls under `In case device runtime PM is not enabled or not available`