### PR TITLE
soc: mec172x: Add hardware debug configuration

### DIFF
--- a/soc/arm/microchip_mec/mec172x/Kconfig.soc
+++ b/soc/arm/microchip_mec/mec172x/Kconfig.soc
@@ -26,3 +26,49 @@ config SOC_MEC172X_PROC_CLK_DIV
 	  and main 96 MHz clock (MCK):
 	  HCLK = MCK / PROC_CLK_DIV
 	  Allowed divider values: 1, 3, 4, 16, and 48.
+
+choice
+	prompt "MEC172x debug interface general configuration"
+	default SOC_MEC172X_DEBUG_WITHOUT_TRACING
+	depends on SOC_SERIES_MEC172X
+	help
+	  Select Debug SoC interface support for MEC172X SoC family
+
+	config SOC_MEC172X_DEBUG_DISABLED
+		bool "Disable debug support"
+		help
+		  Debug port is disabled, JTAG/SWD cannot be enabled. JTAG_RST#
+		  pin is ignored. All other JTAG pins can be used as GPIOs
+		  or other non-JTAG alternate functions.
+
+	config SOC_MEC172X_DEBUG_WITHOUT_TRACING
+		bool "Debug support via Serial wire debug"
+		help
+		  JTAG port in SWD mode. I2C09 and ADC00-03 can be used.
+
+	config SOC_MEC172X_DEBUG_AND_TRACING
+		bool "Debug support via Serial wire debug with tracing enabled"
+		help
+		  JTAG port is enabled in SWD mode. Refer to tracing options
+		  to see if ADC00-03 can be used or not.
+endchoice
+
+choice
+	prompt "MEC172X debug interface trace configuration"
+	default SOC_MEC172X_DEBUG_AND_ETM_TRACING
+	depends on SOC_MEC172X_DEBUG_AND_TRACING
+	help
+	  Select tracing mode for debug interface
+
+	config SOC_MEC172X_DEBUG_AND_ETM_TRACING
+		bool "Debug support via Serial wire debug"
+		help
+		  JTAG port in SWD mode and ETM as tracing method.
+		  I2C09 can be used, but ADC00-03 cannot.
+
+	config SOC_MEC172X_DEBUG_AND_SWV_TRACING
+		bool "debug support via Serial Wire Debug and Viewer"
+		help
+		  JTAG port in SWD mode and SWV as tracing method.
+		  I2C09 cannot be used. ADC00-03 can be used.
+endchoice

--- a/soc/arm/microchip_mec/mec172x/soc.c
+++ b/soc/arm/microchip_mec/mec172x/soc.c
@@ -12,9 +12,37 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
+/* Enable SWD and ETM debug interface and pins.
+ * NOTE: ETM TRACE pins exposed on MEC172x EVB J30 12,14,16,18,20.
+ */
+static void configure_debug_interface(void)
+{
+	struct ecs_regs *ecs = (struct ecs_regs *)(DT_REG_ADDR(DT_NODELABEL(ecs)));
+
+#ifdef CONFIG_SOC_MEC172X_DEBUG_DISABLED
+	ecs->ETM_CTRL = 0;
+	ecs->DEBUG_CTRL = 0;
+#elif defined(CONFIG_SOC_MEC172X_DEBUG_WITHOUT_TRACING)
+	ecs->ETM_CTRL = 0;
+	ecs->DEBUG_CTRL = (MCHP_ECS_DCTRL_DBG_EN | MCHP_ECS_DCTRL_MODE_SWD);
+#elif defined(CONFIG_SOC_MEC172X_DEBUG_AND_TRACING)
+
+	#if defined(CONFIG_SOC_MEC172X_DEBUG_AND_ETM_TRACING)
+	ecs->ETM_CTRL = 1u;
+	ecs->DEBUG_CTRL = (MCHP_ECS_DCTRL_DBG_EN | MCHP_ECS_DCTRL_MODE_SWD);
+	#elif defined(CONFIG_SOC_MEC172X_DEBUG_AND_SWV_TRACING)
+	ecs->ETM_CTRL = 0;
+	ecs->DEBUG_CTRL = (MCHP_ECS_DCTRL_DBG_EN | MCHP_ECS_DCTRL_MODE_SWD_SWV);
+	#endif /* CONFIG_SOC_MEC172X_DEBUG_AND_ETM_TRACING */
+
+#endif /* CONFIG_SOC_MEC172X_DEBUG_DISABLED */
+}
+
 static int soc_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
+
+	configure_debug_interface();
 
 	return 0;
 }


### PR DESCRIPTION
Add missing configuration items to select various ARM debug options such as SWD only, SWD plus SWV, or SWD plus ETM. The default is SWD only.  These Kconfig items are necessary for production parts.  Production parts ship with SWD debug disabled.  The application loaded by ROM is expected to enable SWD debug if it is required.