### PR TITLE
Fixes and additional sensor support for Si7006, SHT21, HTU21D sensors

### DIFF
--- a/drivers/sensor/silabs/si7006/Kconfig
+++ b/drivers/sensor/silabs/si7006/Kconfig
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SI7006
-	bool "Si7006 Temperature and Humidity Sensor"
+	bool "SHT21, Si7006, and HTU21D Humidity and Temperature Sensors"
 	default y
-	depends on DT_HAS_SILABS_SI7006_ENABLED
+	depends on DT_HAS_SILABS_SI7006_ENABLED || DT_HAS_SENSIRION_SHT21_ENABLED
 	select I2C
 	help
-	  Enable I2C-based driver for Si7006 Temperature and Humidity Sensor.
+	  Enable I2C-based driver for several humidity and temperature sensors
+	  compatible with the Sensirion SHT21, such as the Silicon Labs
+	  Si7006/13/20/21 and Measurement Specialties HTU21D

--- a/drivers/sensor/silabs/si7006/si7006.c
+++ b/drivers/sensor/silabs/si7006/si7006.c
@@ -197,17 +197,23 @@ static int si7006_init(const struct device *dev)
 	return 0;
 }
 
-#define SI7006_DEFINE(inst, temp_cmd)							\
-	static struct si7006_data si7006_data_##inst;					\
+#define SI7006_DEFINE(inst, name, temp_cmd)						\
+	static struct si7006_data si7006_data_##name##_##inst;				\
 											\
-	static const struct si7006_config si7006_config_##inst = {			\
-		.i2c = I2C_DT_SPEC_GET(inst),						\
+	static const struct si7006_config si7006_config_##name##_##inst = {		\
+		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 		.read_temp_cmd = temp_cmd,						\
 	};										\
 											\
-	SENSOR_DEVICE_DT_DEFINE(inst, si7006_init, NULL,				\
-				&si7006_data_##inst, &si7006_config_##inst,		\
-				POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &si7006_api); \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, si7006_init, NULL,				\
+				     &si7006_data_##name##_##inst,			\
+				     &si7006_config_##name##_##inst,			\
+				     POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,		\
+				     &si7006_api);
 
-DT_FOREACH_STATUS_OKAY_VARGS(silabs_si7006, SI7006_DEFINE, SI7006_READ_OLD_TEMP);
-DT_FOREACH_STATUS_OKAY_VARGS(sensirion_sht21, SI7006_DEFINE, SI7006_MEAS_TEMP_MASTER_MODE);
+#define DT_DRV_COMPAT silabs_si7006
+DT_INST_FOREACH_STATUS_OKAY_VARGS(SI7006_DEFINE, DT_DRV_COMPAT, SI7006_READ_OLD_TEMP);
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT sensirion_sht21
+DT_INST_FOREACH_STATUS_OKAY_VARGS(SI7006_DEFINE, DT_DRV_COMPAT, SI7006_MEAS_TEMP_MASTER_MODE);

--- a/drivers/sensor/silabs/si7006/si7006.c
+++ b/drivers/sensor/silabs/si7006/si7006.c
@@ -5,11 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/kernel.h>
-#include <zephyr/device.h>
-#include <zephyr/init.h>
-#include <string.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/drivers/i2c.h>

--- a/drivers/sensor/silabs/si7006/si7006.c
+++ b/drivers/sensor/silabs/si7006/si7006.c
@@ -40,16 +40,15 @@ static int si7006_get_humidity(const struct device *dev)
 	struct si7006_data *si_data = dev->data;
 	const struct si7006_config *config = dev->config;
 	int retval;
-	uint8_t hum[2];
+	uint16_t hum;
 
-	retval = i2c_burst_read_dt(&config->i2c,
-				   SI7006_MEAS_REL_HUMIDITY_MASTER_MODE, hum,
-				   sizeof(hum));
+	retval = i2c_burst_read_dt(&config->i2c, SI7006_MEAS_REL_HUMIDITY_MASTER_MODE,
+				   (uint8_t *)&hum, sizeof(hum));
 
 	if (retval == 0) {
-		si_data->humidity = (hum[0] << 8) | hum[1];
+		si_data->humidity = sys_be16_to_cpu(hum) & ~3;
 	} else {
-		LOG_ERR("read register err");
+		LOG_ERR("read register err: %d", retval);
 	}
 
 	return retval;
@@ -68,16 +67,16 @@ static int si7006_get_temperature(const struct device *dev)
 {
 	struct si7006_data *si_data = dev->data;
 	const struct si7006_config *config = dev->config;
-	uint8_t temp[2];
+	uint16_t temp;
 	int retval;
 
-	retval = i2c_burst_read_dt(&config->i2c, config->read_temp_cmd, temp,
-				   sizeof(temp));
+	retval = i2c_burst_read_dt(&config->i2c, config->read_temp_cmd,
+				   (uint8_t *)&temp, sizeof(temp));
 
 	if (retval == 0) {
-		si_data->temperature = (temp[0] << 8) | temp[1];
+		si_data->temperature = sys_be16_to_cpu(temp) & ~3;
 	} else {
-		LOG_ERR("read register err");
+		LOG_ERR("read register err: %d", retval);
 	}
 
 	return retval;

--- a/drivers/sensor/silabs/si7006/si7006.c
+++ b/drivers/sensor/silabs/si7006/si7006.c
@@ -22,7 +22,6 @@
 LOG_MODULE_REGISTER(si7006, CONFIG_SENSOR_LOG_LEVEL);
 
 struct si7006_data {
-	const struct device *i2c_dev;
 	uint16_t temperature;
 	uint16_t humidity;
 };

--- a/dts/bindings/sensor/sensirion,sht21.yaml
+++ b/dts/bindings/sensor/sensirion,sht21.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2023, Trent Piepho <tpiepho@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Sensirion SHT21 Humidity and Temperature Sensor
+
+  This is compatible with the Measurement Specialties HUT21D, "meas,htu21d".
+
+  For the Silicon Labs Si7006/13/20/21 series, use the "silabs,si7006"
+  compatible for slightly altered operation.
+
+compatible: "sensirion,sht21"
+
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/silabs,si7006.yaml
+++ b/dts/bindings/sensor/silabs,si7006.yaml
@@ -1,8 +1,14 @@
 # Copyright (c) 2019, Electronut Labs
+# Copyright (c) 2023, Trent Piepho <tpiepho@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: Si7006 temperature and humidity sensor
+description: |
+  Silicon Labs Si7006 Humidity and Temperature Sensor
+
+  This is compatible with a range of Silicon Labs sensors, such as the Si7013,
+  Si7020, and Si7021.  This binding will use a slightly different (better)
+  command to read temperature from the "sensirion,sht21" binding.
 
 compatible: "silabs,si7006"
 
-include: [sensor-device.yaml, i2c-device.yaml]
+include: sensirion,sht21.yaml

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1061,3 +1061,8 @@ test_i2c_lm95234: lm95234@8f {
 	reg = <0x8f>;
 	status = "okay";
 };
+
+test_i2c_sht21@90 {
+	compatible = "sensirion,sht21";
+	reg = <0x90>;
+};


### PR DESCRIPTION
This driver can support other sensors that use the same commands and conversion formulas.

Add SHT21 and HTU21D support.

The math to convert the values was rounding down to an integer.

See individual commits for much more detail.