### PR TITLE
soc: include: fvp_aemv8r: Define device memory as device tree node

### DIFF
--- a/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.dts
+++ b/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.dts
@@ -36,6 +36,13 @@
 			compatible = "mmio-dram";
 			reg = <0x0 DT_SIZE_M(128)>;
 		};
+
+		device_region: memory@80000000 {
+			compatible = "zephyr,memory-region", "mmio-dram";
+			reg = <0x80000000 DT_SIZE_M(2048)>;
+			zephyr,memory-region = "DEVICE_REGION";
+			zephyr,memory-region-mpu = "IO";
+		};
 	};
 };
 

--- a/include/zephyr/arch/arm64/cortex_r/arm_mpu.h
+++ b/include/zephyr/arch/arm64/cortex_r/arm_mpu.h
@@ -132,7 +132,7 @@
  * recommended to use these helper defines only for configuring
  * fixed MPU regions at build-time.
  */
-#define REGION_DEVICE_ATTR					      \
+#define REGION_IO_ATTR						      \
 	{							      \
 		/* AP, XN, SH */				      \
 		.rbar = NOT_EXEC | P_RW_U_NA_Msk | NON_SHAREABLE_Msk, \

--- a/soc/arm64/arm/fvp_aemv8r/arm_mpu_regions.c
+++ b/soc/arm64/arm/fvp_aemv8r/arm_mpu_regions.c
@@ -10,9 +10,6 @@
 #include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/sys/util.h>
 
-#define DEVICE_REGION_START 0x80000000UL
-#define DEVICE_REGION_END   0xFFFFFFFFUL
-
 static const struct arm_mpu_region mpu_regions[] = {
 	/* Region 0 */
 	MPU_REGION_ENTRY("FLASH_0",
@@ -42,12 +39,6 @@ static const struct arm_mpu_region mpu_regions[] = {
 #endif
 			 (uintptr_t)__kernel_ram_end,
 			 REGION_RAM_ATTR),
-
-	/* Region 4 device region */
-	MPU_REGION_ENTRY("DEVICE",
-			 DEVICE_REGION_START,
-			 DEVICE_REGION_END,
-			 REGION_DEVICE_ATTR),
 
 	/* Extra regions defined in device tree */
 	LINKER_DT_REGION_MPU(MPU_REGION_ENTRY_FROM_DTS)


### PR DESCRIPTION
A recent change introduced the possibility to declare MPU memory regions using the device tree and the framework described in zephyr/linker/devicetree_regions.h.

So remove the device region declared in mpu_regions[] and the used defines for the addresses, rename REGION_DEVICE_ATTR to REGION_IO_ATTR in arm_mpu.h to be compatible with the framework and add a device tree node to fvp_baser_aemv8r.dts to describe the device memory region.