### PR TITLE
drivers/apbuart: correct the baud formula

### DIFF
--- a/drivers/serial/uart_apbuart.c
+++ b/drivers/serial/uart_apbuart.c
@@ -225,7 +225,7 @@ static void set_baud(volatile struct apbuart_regs *const regs, uint32_t baud)
 	core_clk_hz = sys_clock_hw_cycles_per_sec();
 
 	/* Calculate Baud rate generator "scaler" number */
-	scaler = (((core_clk_hz * 10) / (baud * 8)) - 5) / 10;
+	scaler = (core_clk_hz / (baud * 8)) - 1;
 
 	/* Set new baud rate by setting scaler */
 	regs->scaler = scaler;


### PR DESCRIPTION
The current scaler formula from set_baud() function:
`scaler = (((core_clk_hz * 10) / (baud * 8)) - 5) / 10;`
which is equivalent to:
scaler = (core_clk_hz / (baud * 8)) - 0.5
which is not consistent with get_baud() function:
`return core_clk_hz / ((scaler + 1) * 8);`
which is equivalent to:
scaler = (core_clk_hz / (baud * 8)) - 1
One of them must be false...

According to the chapter 18.3 of the ![GRLIB User's manual](https://www.gaisler.com/products/grlib/grip.pdf)
scaler value = (system_clock_frequency) / (baud_rate * 8) - 1
which is equivalent to the get_baud() formula.