### PR TITLE
linker: Fix handling of sw_isr_table section

### DIFF
--- a/arch/common/isr_tables.c
+++ b/arch/common/isr_tables.c
@@ -66,7 +66,7 @@ void __irq_vector_table __attribute__((naked)) _irq_vector_table(void) {
 #else
 
 /* The IRQ vector table is an array of vector addresses */
-uintptr_t __irq_vector_table _irq_vector_table[IRQ_TABLE_SIZE] = {
+ISR_CONST_TABLE uintptr_t __irq_vector_table _irq_vector_table[IRQ_TABLE_SIZE] = {
 	[0 ...(IRQ_TABLE_SIZE - 1)] = (uintptr_t)&IRQ_VECTOR_TABLE_DEFAULT_ISR,
 };
 #endif /* CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_CODE */
@@ -76,7 +76,7 @@ uintptr_t __irq_vector_table _irq_vector_table[IRQ_TABLE_SIZE] = {
  * type and bypass the _sw_isr_table, then do not generate one.
  */
 #ifdef CONFIG_GEN_SW_ISR_TABLE
-struct _isr_table_entry __sw_isr_table _sw_isr_table[IRQ_TABLE_SIZE] = {
+ISR_CONST_TABLE struct _isr_table_entry __sw_isr_table _sw_isr_table[IRQ_TABLE_SIZE] = {
 	[0 ...(IRQ_TABLE_SIZE - 1)] = {(const void *)0x42,
 				       (void *)&z_irq_spurious},
 };

--- a/arch/mips/core/irq_manage.c
+++ b/arch/mips/core/irq_manage.c
@@ -70,7 +70,7 @@ void z_mips_enter_irq(uint32_t ipending)
 
 	while (ipending) {
 		int index;
-		struct _isr_table_entry *ite;
+		const struct _isr_table_entry *ite;
 
 		if (IS_ENABLED(CONFIG_TRACING_ISR)) {
 			sys_trace_isr_enter();

--- a/arch/nios2/core/irq_manage.c
+++ b/arch/nios2/core/irq_manage.c
@@ -87,7 +87,7 @@ void _enter_irq(uint32_t ipending)
 #endif
 
 	while (ipending) {
-		struct _isr_table_entry *ite;
+		const struct _isr_table_entry *ite;
 
 #ifdef CONFIG_TRACING_ISR
 		sys_trace_isr_enter();

--- a/arch/sparc/core/irq_manage.c
+++ b/arch/sparc/core/irq_manage.c
@@ -26,7 +26,7 @@ FUNC_NORETURN void z_irq_spurious(const void *unused)
 
 void z_sparc_enter_irq(uint32_t irl)
 {
-	struct _isr_table_entry *ite;
+	const struct _isr_table_entry *ite;
 
 	_current_cpu->nested++;
 

--- a/drivers/interrupt_controller/intc_dw_ace.c
+++ b/drivers/interrupt_controller/intc_dw_ace.c
@@ -149,7 +149,7 @@ static void dwint_isr(const void *arg)
 	while (fs) {
 		uint32_t bit = find_lsb_set(fs) - 1;
 		uint32_t offset = CONFIG_2ND_LVL_ISR_TBL_OFFSET + bit;
-		struct _isr_table_entry *ent = &_sw_isr_table[offset];
+		const struct _isr_table_entry *ent = &_sw_isr_table[offset];
 
 		fs &= ~BIT(bit);
 		ent->isr(ent->arg);

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -134,7 +134,7 @@ static void plic_irq_handler(const void *arg)
 	    (volatile struct plic_regs_t *) PLIC_REG;
 
 	uint32_t irq;
-	struct _isr_table_entry *ite;
+	const struct _isr_table_entry *ite;
 
 	/* Get the IRQ number generating the interrupt */
 	irq = regs->claim_complete;
@@ -157,7 +157,7 @@ static void plic_irq_handler(const void *arg)
 	irq += CONFIG_2ND_LVL_ISR_TBL_OFFSET;
 
 	/* Call the corresponding IRQ handler in _sw_isr_table */
-	ite = (struct _isr_table_entry *)&_sw_isr_table[irq];
+	ite = (const struct _isr_table_entry *)&_sw_isr_table[irq];
 	ite->isr(ite->arg);
 
 	/*

--- a/drivers/interrupt_controller/intc_rv32m1_intmux.c
+++ b/drivers/interrupt_controller/intc_rv32m1_intmux.c
@@ -42,7 +42,7 @@ struct rv32m1_intmux_config {
 	INTMUX_Type *regs;
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
-	struct _isr_table_entry *isr_base;
+	const struct _isr_table_entry *isr_base;
 };
 
 #define DEV_REGS(dev) (((const struct rv32m1_intmux_config *)(dev->config))->regs)
@@ -111,8 +111,8 @@ static void rv32m1_intmux_isr(const void *arg)
 	INTMUX_Type *regs = DEV_REGS(dev);
 	uint32_t channel = POINTER_TO_UINT(arg);
 	uint32_t line = (regs->CHANNEL[channel].CHn_VEC >> 2);
-	struct _isr_table_entry *isr_base = config->isr_base;
-	struct _isr_table_entry *entry;
+	const struct _isr_table_entry *isr_base = config->isr_base;
+	const struct _isr_table_entry *entry;
 
 	/*
 	 * Make sure the vector is valid, there is a note of page 1243~1244

--- a/drivers/interrupt_controller/intc_swerv_pic.c
+++ b/drivers/interrupt_controller/intc_swerv_pic.c
@@ -119,7 +119,7 @@ static void swerv_pic_irq_handler(const void *arg)
 {
 	uint32_t tmp;
 	uint32_t irq;
-	struct _isr_table_entry *ite;
+	const struct _isr_table_entry *ite;
 
 	/* trigger the capture of the interrupt source ID */
 	__asm__ swerv_pic_writecsr(meicpct, 0);
@@ -135,7 +135,7 @@ static void swerv_pic_irq_handler(const void *arg)
 	irq += RISCV_MAX_GENERIC_IRQ;
 
 	/* Call the corresponding IRQ handler in _sw_isr_table */
-	ite = (struct _isr_table_entry *)&_sw_isr_table[irq];
+	ite = (const struct _isr_table_entry *)&_sw_isr_table[irq];
 	if (ite->isr) {
 		ite->isr(ite->arg);
 	}

--- a/drivers/interrupt_controller/intc_vexriscv_litex.c
+++ b/drivers/interrupt_controller/intc_vexriscv_litex.c
@@ -60,7 +60,7 @@ static inline void vexriscv_litex_irq_setie(uint32_t ie)
 
 static void vexriscv_litex_irq_handler(const void *device)
 {
-	struct _isr_table_entry *ite;
+	const struct _isr_table_entry *ite;
 	uint32_t pending, mask, irqs;
 
 	pending = vexriscv_litex_irq_pending();

--- a/include/zephyr/sw_isr_table.h
+++ b/include/zephyr/sw_isr_table.h
@@ -22,6 +22,15 @@
 extern "C" {
 #endif
 
+/* When dynamic interrupts are disabled, mark IRQ vector tables as const.
+ * This is required to prevent linker from marking section as writable.
+ */
+#ifdef CONFIG_DYNAMIC_INTERRUPTS
+#define ISR_CONST_TABLE
+#else
+#define ISR_CONST_TABLE const
+#endif /* CONFIG_DYNAMIC_INTERRUPTS */
+
 /* Default vector for the IRQ vector table */
 extern void _isr_wrapper(void);
 
@@ -41,7 +50,7 @@ struct _isr_table_entry {
 /* The software ISR table itself, an array of these structures indexed by the
  * irq line
  */
-extern struct _isr_table_entry _sw_isr_table[];
+extern ISR_CONST_TABLE struct _isr_table_entry _sw_isr_table[];
 
 /*
  * Data structure created in a special binary .intlist section for each

--- a/soc/xtensa/sample_controller/include/_soc_inthandlers.h
+++ b/soc/xtensa/sample_controller/include/_soc_inthandlers.h
@@ -90,19 +90,19 @@ static inline int _xtensa_handle_one_int1(unsigned int mask)
 	if (mask & 0x7f) {
 		if (mask & 0x7) {
 			if (mask & (1 << 0)) {
-				struct _isr_table_entry *e = &_sw_isr_table[0];
+				const struct _isr_table_entry *e = &_sw_isr_table[0];
 
 				e->isr(e->arg);
 				return 1 << 0;
 			}
 			if (mask & (1 << 1)) {
-				struct _isr_table_entry *e = &_sw_isr_table[1];
+				const struct _isr_table_entry *e = &_sw_isr_table[1];
 
 				e->isr(e->arg);
 				return 1 << 1;
 			}
 			if (mask & (1 << 2)) {
-				struct _isr_table_entry *e = &_sw_isr_table[2];
+				const struct _isr_table_entry *e = &_sw_isr_table[2];
 
 				e->isr(e->arg);
 				return 1 << 2;
@@ -110,26 +110,26 @@ static inline int _xtensa_handle_one_int1(unsigned int mask)
 		} else {
 			if (mask & 0x18) {
 				if (mask & (1 << 3)) {
-					struct _isr_table_entry *e = &_sw_isr_table[3];
+					const struct _isr_table_entry *e = &_sw_isr_table[3];
 
 					e->isr(e->arg);
 					return 1 << 3;
 				}
 				if (mask & (1 << 4)) {
-					struct _isr_table_entry *e = &_sw_isr_table[4];
+					const struct _isr_table_entry *e = &_sw_isr_table[4];
 
 					e->isr(e->arg);
 					return 1 << 4;
 				}
 			} else {
 				if (mask & (1 << 5)) {
-					struct _isr_table_entry *e = &_sw_isr_table[5];
+					const struct _isr_table_entry *e = &_sw_isr_table[5];
 
 					e->isr(e->arg);
 					return 1 << 5;
 				}
 				if (mask & (1 << 6)) {
-					struct _isr_table_entry *e = &_sw_isr_table[6];
+					const struct _isr_table_entry *e = &_sw_isr_table[6];
 
 					e->isr(e->arg);
 					return 1 << 6;
@@ -139,19 +139,19 @@ static inline int _xtensa_handle_one_int1(unsigned int mask)
 	} else {
 		if (mask & 0x18080) {
 			if (mask & (1 << 7)) {
-				struct _isr_table_entry *e = &_sw_isr_table[7];
+				const struct _isr_table_entry *e = &_sw_isr_table[7];
 
 				e->isr(e->arg);
 				return 1 << 7;
 			}
 			if (mask & (1 << 15)) {
-				struct _isr_table_entry *e = &_sw_isr_table[15];
+				const struct _isr_table_entry *e = &_sw_isr_table[15];
 
 				e->isr(e->arg);
 				return 1 << 15;
 			}
 			if (mask & (1 << 16)) {
-				struct _isr_table_entry *e = &_sw_isr_table[16];
+				const struct _isr_table_entry *e = &_sw_isr_table[16];
 
 				e->isr(e->arg);
 				return 1 << 16;
@@ -159,26 +159,26 @@ static inline int _xtensa_handle_one_int1(unsigned int mask)
 		} else {
 			if (mask & 0x60000) {
 				if (mask & (1 << 17)) {
-					struct _isr_table_entry *e = &_sw_isr_table[17];
+					const struct _isr_table_entry *e = &_sw_isr_table[17];
 
 					e->isr(e->arg);
 					return 1 << 17;
 				}
 				if (mask & (1 << 18)) {
-					struct _isr_table_entry *e = &_sw_isr_table[18];
+					const struct _isr_table_entry *e = &_sw_isr_table[18];
 
 					e->isr(e->arg);
 					return 1 << 18;
 				}
 			} else {
 				if (mask & (1 << 19)) {
-					struct _isr_table_entry *e = &_sw_isr_table[19];
+					const struct _isr_table_entry *e = &_sw_isr_table[19];
 
 					e->isr(e->arg);
 					return 1 << 19;
 				}
 				if (mask & (1 << 20)) {
-					struct _isr_table_entry *e = &_sw_isr_table[20];
+					const struct _isr_table_entry *e = &_sw_isr_table[20];
 
 					e->isr(e->arg);
 					return 1 << 20;
@@ -192,7 +192,7 @@ static inline int _xtensa_handle_one_int1(unsigned int mask)
 static inline int _xtensa_handle_one_int2(unsigned int mask)
 {
 	if (mask & (1 << 8)) {
-		struct _isr_table_entry *e = &_sw_isr_table[8];
+		const struct _isr_table_entry *e = &_sw_isr_table[8];
 
 		e->isr(e->arg);
 		return 1 << 8;
@@ -204,26 +204,26 @@ static inline int _xtensa_handle_one_int3(unsigned int mask)
 {
 	if (mask & 0x600) {
 		if (mask & (1 << 9)) {
-			struct _isr_table_entry *e = &_sw_isr_table[9];
+			const struct _isr_table_entry *e = &_sw_isr_table[9];
 
 			e->isr(e->arg);
 			return 1 << 9;
 		}
 		if (mask & (1 << 10)) {
-			struct _isr_table_entry *e = &_sw_isr_table[10];
+			const struct _isr_table_entry *e = &_sw_isr_table[10];
 
 			e->isr(e->arg);
 			return 1 << 10;
 		}
 	} else {
 		if (mask & (1 << 11)) {
-			struct _isr_table_entry *e = &_sw_isr_table[11];
+			const struct _isr_table_entry *e = &_sw_isr_table[11];
 
 			e->isr(e->arg);
 			return 1 << 11;
 		}
 		if (mask & (1 << 21)) {
-			struct _isr_table_entry *e = &_sw_isr_table[21];
+			const struct _isr_table_entry *e = &_sw_isr_table[21];
 
 			e->isr(e->arg);
 			return 1 << 21;
@@ -235,7 +235,7 @@ static inline int _xtensa_handle_one_int3(unsigned int mask)
 static inline int _xtensa_handle_one_int4(unsigned int mask)
 {
 	if (mask & (1 << 12)) {
-		struct _isr_table_entry *e = &_sw_isr_table[12];
+		const struct _isr_table_entry *e = &_sw_isr_table[12];
 
 		e->isr(e->arg);
 		return 1 << 12;
@@ -246,7 +246,7 @@ static inline int _xtensa_handle_one_int4(unsigned int mask)
 static inline int _xtensa_handle_one_int5(unsigned int mask)
 {
 	if (mask & (1 << 13)) {
-		struct _isr_table_entry *e = &_sw_isr_table[13];
+		const struct _isr_table_entry *e = &_sw_isr_table[13];
 
 		e->isr(e->arg);
 		return 1 << 13;
@@ -262,7 +262,7 @@ static inline int _xtensa_handle_one_int6(unsigned int mask)
 static inline int _xtensa_handle_one_int7(unsigned int mask)
 {
 	if (mask & (1 << 14)) {
-		struct _isr_table_entry *e = &_sw_isr_table[14];
+		const struct _isr_table_entry *e = &_sw_isr_table[14];
 
 		e->isr(e->arg);
 		return 1 << 14;

--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -207,7 +207,7 @@ static int check_vector(void *isr, int offset)
 #ifdef CONFIG_GEN_SW_ISR_TABLE
 static int check_sw_isr(void *isr, uintptr_t arg, int offset)
 {
-	struct _isr_table_entry *e = &_sw_isr_table[TABLE_INDEX(offset)];
+	const struct _isr_table_entry *e = &_sw_isr_table[TABLE_INDEX(offset)];
 
 	TC_PRINT("Checking _sw_isr_table entry %d for irq %d\n",
 		 TABLE_INDEX(offset), IRQ_LINE(offset));


### PR DESCRIPTION
This commit attempt to implement solution described in issue: #17517
When CONFIG_DYNAMIC_INTERRUPTS feature is disabled, the sw_isr_table section is placed in ROM and should be marked as read-only. To archive this, all interrupt vector tables have been marked as `const`.