### PR TITLE
scripts: requirements: Move requests and pyserial to base

### DIFF
--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -19,6 +19,8 @@ packaging
 progress
 psutil
 pylink-square
+pyserial
+requests
 
 # for ram/rom reports
 anytree

--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -2,9 +2,6 @@
 #
 # things used by twister or related in run time testing
 
-# used to connect to boards for console IO
-pyserial
-
 # used to flash & debug various boards
 pyocd>=0.29.0
 


### PR DESCRIPTION
Both the requests and pyserial Python packages are used by west commands (west fetch and west build -b esp* respectively) so move them to the requirements-base.txt file.

Fixes #56215.
Fixes #56224.