### PR TITLE
riscv: Add macro to adjust the initial stack frame

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -71,6 +71,11 @@ config RISCV_SOC_HAS_ISR_STACKING
 	    IRQ wrapper assembly code on ISR exit to restore the part of the
 	    context from the ESF that won't be restored by hardware on mret.
 
+	  - SOC_ISR_STACKING_STACK_INIT_ADJUST: macro called by
+	    arch_new_thread() to fix the initial stack frame for the incoming
+	    thread when for example an offset must be added to the ESF to
+	    account for the registers unstacked by hardware on MRET.
+
 	  - SOC_ISR_STACKING_ESF_DECLARE: structure declaration for the ESF
 	    guarded by !_ASMLANGUAGE. The ESF should be defined to account for
 	    the hardware stacked registers in the proper order as they are

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -34,6 +34,9 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 				Z_STACK_PTR_TO_FRAME(struct __esf, stack_ptr)
 				);
 
+#if defined(CONFIG_RISCV_SOC_HAS_ISR_STACKING)
+	SOC_ISR_STACKING_STACK_INIT_ADJUST(stack_init);
+#endif
 	/* Setup the initial stack frame */
 	stack_init->a0 = (unsigned long)entry;
 	stack_init->a1 = (unsigned long)p1;


### PR DESCRIPTION
When the SOC is implementing a stacking / unstacking mechanism in hardware possibly several registers could be automatically unstacked by the hardware (and the `SP` moved accordingly) when an `MRET` is issued.

While this is usually not a problem (because the of stacking / unstacking symmetry), the only case which we have to pay attention to, is at thread creation time.

In this case the initial stack pointer must not only consider the `ESF` that is being popped out by the assembly code before `MRET`, but we also need to take into account the registers that are unstacked automatically by the hardware and add a proper offset for that.

In this patch we add a new `SOC_ISR_STACKING_STACK_INIT_ADJUST` macro (to conditionally enable on `CONFIG_RISCV_SOC_HAS_ISR_STACKING`) that can be used to fix the initial stack frame pointer.