### PR TITLE
tests: Bluetooth: ascs: Add Sink ASE state machine test cases

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1131,9 +1131,9 @@ static ssize_t ascs_ase_read(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
+	uint8_t ase_id = POINTER_TO_UINT(BT_AUDIO_CHRC_USER_DATA(attr));
 	struct bt_ascs *ascs;
 	struct bt_ascs_ase *ase;
-	uint8_t ase_id;
 
 	LOG_DBG("conn %p attr %p buf %p len %u offset %u", (void *)conn, attr, buf, len, offset);
 
@@ -1142,13 +1142,6 @@ static ssize_t ascs_ase_read(struct bt_conn *conn,
 	}
 
 	ascs = ascs_get(conn);
-
-	ase_id = POINTER_TO_UINT(BT_AUDIO_CHRC_USER_DATA(attr));
-
-	if (ase_id > ASE_COUNT) {
-		LOG_ERR("Unable to get ASE, id out of range");
-		return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
-	}
 
 	ase = ase_find(ascs, ase_id);
 

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1132,18 +1132,16 @@ static ssize_t ascs_ase_read(struct bt_conn *conn,
 			     uint16_t len, uint16_t offset)
 {
 	uint8_t ase_id = POINTER_TO_UINT(BT_AUDIO_CHRC_USER_DATA(attr));
-	struct bt_ascs *ascs;
-	struct bt_ascs_ase *ase;
+	struct bt_ascs_ase *ase = NULL;
 
 	LOG_DBG("conn %p attr %p buf %p len %u offset %u", (void *)conn, attr, buf, len, offset);
 
-	if (!conn) {
-		return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
+	/* The callback can be used locally to read the ASE_ID in which case conn won't be set. */
+	if (conn != NULL) {
+		struct bt_ascs *ascs = ascs_get(conn);
+
+		ase = ase_find(ascs, ase_id);
 	}
-
-	ascs = ascs_get(conn);
-
-	ase = ase_find(ascs, ase_id);
 
 	/* If NULL, we haven't assigned an ASE, this also means that we are currently in IDLE */
 	if (!ase) {

--- a/tests/bluetooth/audio/ascs/CMakeLists.txt
+++ b/tests/bluetooth/audio/ascs/CMakeLists.txt
@@ -9,7 +9,11 @@ add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/audio/ascs/uut uut)
 
 target_link_libraries(testbinary PRIVATE uut)
 
+target_include_directories(testbinary PRIVATE include)
+
 target_sources(testbinary
   PRIVATE
     src/main.c
+    src/test_ase_state_transition.c
+    src/test_common.c
 )

--- a/tests/bluetooth/audio/ascs/include/test_common.h
+++ b/tests/bluetooth/audio/ascs/include/test_common.h
@@ -11,15 +11,23 @@
 #define test_ase_snk_get(_num_ase, ...) test_ase_get(BT_UUID_ASCS_ASE_SNK, _num_ase, __VA_ARGS__)
 #define test_ase_src_get(_num_ase, ...) test_ase_get(BT_UUID_ASCS_ASE_SRC, _num_ase, __VA_ARGS__)
 
+struct test_ase_chrc_value_hdr {
+	uint8_t ase_id;
+	uint8_t ase_state;
+	uint8_t params[0];
+} __packed;
+
 /* Initialize connection object for test */
 void test_conn_init(struct bt_conn *conn);
 uint8_t test_ase_get(const struct bt_uuid *uuid, int num_ase, ...);
+uint8_t test_ase_id_get(const struct bt_gatt_attr *ase);
 const struct bt_gatt_attr *test_ase_control_point_get(void);
 
 /* client-initiated ASE Control Operations */
-void test_ase_control_client_config_codec(struct bt_conn *conn, struct bt_bap_stream *stream);
-void test_ase_control_client_config_qos(struct bt_conn *conn);
-void test_ase_control_client_enable(struct bt_conn *conn);
-void test_ase_control_client_disable(struct bt_conn *conn);
-void test_ase_control_client_release(struct bt_conn *conn);
-void test_ase_control_client_update_metadata(struct bt_conn *conn);
+void test_ase_control_client_config_codec(struct bt_conn *conn, uint8_t ase_id,
+					  struct bt_bap_stream *stream);
+void test_ase_control_client_config_qos(struct bt_conn *conn, uint8_t ase_id);
+void test_ase_control_client_enable(struct bt_conn *conn, uint8_t ase_id);
+void test_ase_control_client_disable(struct bt_conn *conn, uint8_t ase_id);
+void test_ase_control_client_release(struct bt_conn *conn, uint8_t ase_id);
+void test_ase_control_client_update_metadata(struct bt_conn *conn, uint8_t ase_id);

--- a/tests/bluetooth/audio/ascs/include/test_common.h
+++ b/tests/bluetooth/audio/ascs/include/test_common.h
@@ -8,8 +8,12 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
 
+#define test_ase_snk_get(_num_ase, ...) test_ase_get(BT_UUID_ASCS_ASE_SNK, _num_ase, __VA_ARGS__)
+#define test_ase_src_get(_num_ase, ...) test_ase_get(BT_UUID_ASCS_ASE_SRC, _num_ase, __VA_ARGS__)
+
 /* Initialize connection object for test */
 void test_conn_init(struct bt_conn *conn);
+uint8_t test_ase_get(const struct bt_uuid *uuid, int num_ase, ...);
 const struct bt_gatt_attr *test_ase_control_point_get(void);
 
 /* client-initiated ASE Control Operations */

--- a/tests/bluetooth/audio/ascs/include/test_common.h
+++ b/tests/bluetooth/audio/ascs/include/test_common.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 Codecoup
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
+
+/* Initialize connection object for test */
+void test_conn_init(struct bt_conn *conn);
+const struct bt_gatt_attr *test_ase_control_point_get(void);
+
+/* client-initiated ASE Control Operations */
+void test_ase_control_client_config_codec(struct bt_conn *conn, struct bt_bap_stream *stream);
+void test_ase_control_client_config_qos(struct bt_conn *conn);
+void test_ase_control_client_enable(struct bt_conn *conn);
+void test_ase_control_client_disable(struct bt_conn *conn);
+void test_ase_control_client_release(struct bt_conn *conn);
+void test_ase_control_client_update_metadata(struct bt_conn *conn);

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -1,0 +1,166 @@
+/* test_ase_state_transition.c - ASE state transition tests */
+
+/*
+ * Copyright (c) 2023 Codecoup
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdlib.h>
+#include <zephyr/types.h>
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "bap_unicast_server.h"
+#include "bap_unicast_server_expects.h"
+#include "bap_stream.h"
+#include "bap_stream_expects.h"
+#include "conn.h"
+#include "gatt.h"
+#include "gatt_expects.h"
+#include "iso.h"
+
+#include "test_common.h"
+
+struct test_sink_ase_state_transition_fixture {
+	struct bt_conn conn;
+	struct bt_bap_stream stream;
+};
+
+static void *test_sink_ase_state_transition_setup(void)
+{
+	struct test_sink_ase_state_transition_fixture *fixture;
+
+	fixture = malloc(sizeof(*fixture));
+	zassert_not_null(fixture);
+
+	memset(fixture, 0, sizeof(*fixture));
+	test_conn_init(&fixture->conn);
+
+	return fixture;
+}
+
+static void test_ase_state_transition_before(void *f)
+{
+	bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
+}
+
+static void test_ase_state_transition_after(void *f)
+{
+	bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
+}
+
+static void test_ase_state_transition_teardown(void *f)
+{
+	free(f);
+}
+
+ZTEST_SUITE(test_sink_ase_state_transition, NULL, test_sink_ase_state_transition_setup,
+	    test_ase_state_transition_before, test_ase_state_transition_after,
+	    test_ase_state_transition_teardown);
+
+ZTEST_F(test_sink_ase_state_transition, test_client_idle_to_codec_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	test_ase_control_client_config_codec(conn, stream);
+	expect_bt_bap_unicast_server_cb_config_called_once(conn, EMPTY, BT_AUDIO_DIR_SINK, EMPTY);
+	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_qos_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	/* Preamble */
+	test_ase_control_client_config_codec(conn, stream);
+
+	test_ase_control_client_config_qos(conn);
+	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
+	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_enabling)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	/* Preamble */
+	test_ase_control_client_config_codec(conn, stream);
+	test_ase_control_client_config_qos(conn);
+
+	test_ase_control_client_enable(conn);
+	expect_bt_bap_unicast_server_cb_enable_called_once(stream, EMPTY, EMPTY);
+	expect_bt_bap_stream_ops_enabled_called_once(stream);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_qos_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	/* Preamble */
+	test_ase_control_client_config_codec(conn, stream);
+	test_ase_control_client_config_qos(conn);
+	test_ase_control_client_enable(conn);
+
+	/* Reset the bap_stream_ops.qos_set callback that is expected to be called again */
+	mock_bap_stream_qos_set_cb_reset();
+
+	test_ase_control_client_disable(conn);
+	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
+	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_releasing)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	/* Preamble */
+	test_ase_control_client_config_codec(conn, stream);
+	test_ase_control_client_config_qos(conn);
+
+	test_ase_control_client_release(conn);
+	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_released_called_once(stream);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_streaming)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	struct bt_iso_chan *chan;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	/* Preamble */
+	test_ase_control_client_config_codec(conn, stream);
+	test_ase_control_client_config_qos(conn);
+	test_ase_control_client_enable(conn);
+
+	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
+	zassert_equal(0, err, "Failed to connect iso: err %d", err);
+
+	err = bt_bap_stream_start(stream);
+	zassert_equal(0, err, "Failed to start stream: err %d", err);
+
+	/* XXX: unicast_server_cb->start is not called for Sink ASE */
+	expect_bt_bap_stream_ops_started_called_once(stream);
+}

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2023 Codecoup
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/fff.h>
+#include <zephyr/types.h>
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
+
+#include "bap_unicast_server.h"
+#include "bap_stream.h"
+#include "conn.h"
+
+#include "test_common.h"
+
+static uint8_t attr_found(const struct bt_gatt_attr *attr, uint16_t handle, void *user_data)
+{
+	const struct bt_gatt_attr **result = user_data;
+
+	*result = attr;
+
+	return BT_GATT_ITER_STOP;
+}
+
+void test_conn_init(struct bt_conn *conn)
+{
+	conn->index = 0;
+	conn->info.type = BT_CONN_TYPE_LE;
+	conn->info.role = BT_CONN_ROLE_PERIPHERAL;
+	conn->info.state = BT_CONN_STATE_CONNECTED;
+	conn->info.security.level = BT_SECURITY_L2;
+	conn->info.security.enc_key_size = BT_ENC_KEY_SIZE_MAX;
+	conn->info.security.flags = BT_SECURITY_FLAG_OOB | BT_SECURITY_FLAG_SC;
+}
+
+const struct bt_gatt_attr *test_ase_control_point_get(void)
+{
+	static const struct bt_gatt_attr *attr;
+
+	if (attr == NULL) {
+		bt_gatt_foreach_attr_type(BT_ATT_FIRST_ATTRIBUTE_HANDLE,
+					  BT_ATT_LAST_ATTRIBUTE_HANDLE,
+					  BT_UUID_ASCS_ASE_CP, NULL, 1, attr_found, &attr);
+	}
+
+	zassert_not_null(attr, "ASE Control Point not found");
+
+	return attr;
+
+}
+
+static struct bt_bap_stream *stream_allocated;
+static const struct bt_codec_qos_pref qos_pref = BT_CODEC_QOS_PREF(true, BT_GAP_LE_PHY_2M,
+								   0x02, 10, 40000, 40000,
+								   40000, 40000);
+
+static int unicast_server_cb_config_custom_fake(struct bt_conn *conn, const struct bt_bap_ep *ep,
+						enum bt_audio_dir dir, const struct bt_codec *codec,
+						struct bt_bap_stream **stream,
+						struct bt_codec_qos_pref *const pref,
+						struct bt_bap_ascs_rsp *rsp)
+{
+	*stream = stream_allocated;
+	*pref = qos_pref;
+	*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS, BT_BAP_ASCS_REASON_NONE);
+
+	bt_bap_stream_cb_register(*stream, &mock_bap_stream_ops);
+
+	return 0;
+}
+
+void test_ase_control_client_config_codec(struct bt_conn *conn, struct bt_bap_stream *stream)
+{
+	const struct bt_gatt_attr *attr = test_ase_control_point_get();
+	const uint8_t buf[] = {
+		0x01,           /* Opcode = Config Codec */
+		0x01,           /* Number_of_ASEs */
+		0x01,           /* ASE_ID[0] */
+		0x01,           /* Target_Latency[0] = Target low latency */
+		0x02,           /* Target_PHY[0] = LE 2M PHY */
+		0x06,           /* Codec_ID[0].Coding_Format = LC3 */
+		0x00, 0x00,     /* Codec_ID[0].Company_ID */
+		0x00, 0x00,     /* Codec_ID[0].Vendor_Specific_Codec_ID */
+		0x00,           /* Codec_Specific_Configuration_Length[0] */
+	};
+
+	ssize_t ret;
+
+	stream_allocated = stream;
+	mock_bap_unicast_server_cb_config_fake.custom_fake = unicast_server_cb_config_custom_fake;
+
+	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
+	zassert_false(ret < 0, "cp_attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+
+	stream_allocated = NULL;
+}
+
+void test_ase_control_client_config_qos(struct bt_conn *conn)
+{
+	const struct bt_gatt_attr *attr = test_ase_control_point_get();
+	const uint8_t buf[] = {
+		0x02,                   /* Opcode = Config QoS */
+		0x01,                   /* Number_of_ASEs */
+		0x01,                   /* ASE_ID[0] */
+		0x01,                   /* CIG_ID[0] */
+		0x01,                   /* CIS_ID[0] */
+		0xFF, 0x00, 0x00,       /* SDU_Interval[0] */
+		0x00,                   /* Framing[0] */
+		0x02,                   /* PHY[0] */
+		0x64, 0x00,             /* Max_SDU[0] */
+		0x02,                   /* Retransmission_Number[0] */
+		0x0A, 0x00,             /* Max_Transport_Latency[0] */
+		0x40, 0x9C, 0x00,       /* Presentation_Delay[0] */
+	};
+	ssize_t ret;
+
+	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
+	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+}
+
+void test_ase_control_client_enable(struct bt_conn *conn)
+{
+	const struct bt_gatt_attr *attr = test_ase_control_point_get();
+	const uint8_t buf[] = {
+		0x03,                   /* Opcode = Enable */
+		0x01,                   /* Number_of_ASEs */
+		0x01,                   /* ASE_ID[0] */
+		0x00,                   /* Metadata_Length[0] */
+	};
+	ssize_t ret;
+
+	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
+	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+}
+
+void test_ase_control_client_disable(struct bt_conn *conn)
+{
+	const struct bt_gatt_attr *attr = test_ase_control_point_get();
+	const uint8_t buf[] = {
+		0x05,                   /* Opcode = Disable */
+		0x01,                   /* Number_of_ASEs */
+		0x01,                   /* ASE_ID[0] */
+	};
+	ssize_t ret;
+
+	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
+	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+}
+
+void test_ase_control_client_release(struct bt_conn *conn)
+{
+	const struct bt_gatt_attr *attr = test_ase_control_point_get();
+	const uint8_t buf[] = {
+		0x08,                   /* Opcode = Disable */
+		0x01,                   /* Number_of_ASEs */
+		0x01,                   /* ASE_ID[0] */
+	};
+	ssize_t ret;
+
+	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
+	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+}
+
+void test_ase_control_client_update_metadata(struct bt_conn *conn)
+{
+	const struct bt_gatt_attr *attr = test_ase_control_point_get();
+	const uint8_t buf[] = {
+		0x07,                   /* Opcode = Update Metadata */
+		0x01,                   /* Number_of_ASEs */
+		0x01,                   /* ASE_ID[0] */
+		0x03,                   /* Metadata_Length[0] */
+		0x02, 0x02, 0x04,       /* Metadata[0] = Streaming Context (Media) */
+	};
+	ssize_t ret;
+
+	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
+	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+}

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -11,9 +11,11 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/uuid.h>
+#include <zephyr/sys/util_macro.h>
 
 #include "bap_unicast_server.h"
 #include "bap_stream.h"
+#include "gatt_expects.h"
 #include "conn.h"
 
 #include "test_common.h"
@@ -82,6 +84,24 @@ uint8_t test_ase_get(const struct bt_uuid *uuid, int num_ase, ...)
 	return i;
 }
 
+uint8_t test_ase_id_get(const struct bt_gatt_attr *ase)
+{
+	const struct test_ase_chrc_value_hdr *hdr;
+	ssize_t ret;
+
+	ret = ase->read(NULL, ase, NULL, 0, 0);
+	zassert_false(ret < 0, "ase->read returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+
+	expect_bt_gatt_attr_read_called_once(NULL, ase, EMPTY, EMPTY, 0, EMPTY, sizeof(*hdr));
+
+	hdr = bt_gatt_attr_read_fake.arg5_val;
+
+	/* Reset the mock state */
+	bt_gatt_attr_read_reset();
+
+	return hdr->ase_id;
+}
+
 static struct bt_bap_stream *stream_allocated;
 static const struct bt_codec_qos_pref qos_pref = BT_CODEC_QOS_PREF(true, BT_GAP_LE_PHY_2M,
 								   0x02, 10, 40000, 40000,
@@ -102,13 +122,14 @@ static int unicast_server_cb_config_custom_fake(struct bt_conn *conn, const stru
 	return 0;
 }
 
-void test_ase_control_client_config_codec(struct bt_conn *conn, struct bt_bap_stream *stream)
+void test_ase_control_client_config_codec(struct bt_conn *conn, uint8_t ase_id,
+					  struct bt_bap_stream *stream)
 {
 	const struct bt_gatt_attr *attr = test_ase_control_point_get();
 	const uint8_t buf[] = {
 		0x01,           /* Opcode = Config Codec */
 		0x01,           /* Number_of_ASEs */
-		0x01,           /* ASE_ID[0] */
+		ase_id,         /* ASE_ID[0] */
 		0x01,           /* Target_Latency[0] = Target low latency */
 		0x02,           /* Target_PHY[0] = LE 2M PHY */
 		0x06,           /* Codec_ID[0].Coding_Format = LC3 */
@@ -128,13 +149,13 @@ void test_ase_control_client_config_codec(struct bt_conn *conn, struct bt_bap_st
 	stream_allocated = NULL;
 }
 
-void test_ase_control_client_config_qos(struct bt_conn *conn)
+void test_ase_control_client_config_qos(struct bt_conn *conn, uint8_t ase_id)
 {
 	const struct bt_gatt_attr *attr = test_ase_control_point_get();
 	const uint8_t buf[] = {
 		0x02,                   /* Opcode = Config QoS */
 		0x01,                   /* Number_of_ASEs */
-		0x01,                   /* ASE_ID[0] */
+		ase_id,                 /* ASE_ID[0] */
 		0x01,                   /* CIG_ID[0] */
 		0x01,                   /* CIS_ID[0] */
 		0xFF, 0x00, 0x00,       /* SDU_Interval[0] */
@@ -151,13 +172,13 @@ void test_ase_control_client_config_qos(struct bt_conn *conn)
 	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
 }
 
-void test_ase_control_client_enable(struct bt_conn *conn)
+void test_ase_control_client_enable(struct bt_conn *conn, uint8_t ase_id)
 {
 	const struct bt_gatt_attr *attr = test_ase_control_point_get();
 	const uint8_t buf[] = {
 		0x03,                   /* Opcode = Enable */
 		0x01,                   /* Number_of_ASEs */
-		0x01,                   /* ASE_ID[0] */
+		ase_id,                 /* ASE_ID[0] */
 		0x00,                   /* Metadata_Length[0] */
 	};
 	ssize_t ret;
@@ -166,13 +187,13 @@ void test_ase_control_client_enable(struct bt_conn *conn)
 	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
 }
 
-void test_ase_control_client_disable(struct bt_conn *conn)
+void test_ase_control_client_disable(struct bt_conn *conn, uint8_t ase_id)
 {
 	const struct bt_gatt_attr *attr = test_ase_control_point_get();
 	const uint8_t buf[] = {
 		0x05,                   /* Opcode = Disable */
 		0x01,                   /* Number_of_ASEs */
-		0x01,                   /* ASE_ID[0] */
+		ase_id,                 /* ASE_ID[0] */
 	};
 	ssize_t ret;
 
@@ -180,13 +201,13 @@ void test_ase_control_client_disable(struct bt_conn *conn)
 	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
 }
 
-void test_ase_control_client_release(struct bt_conn *conn)
+void test_ase_control_client_release(struct bt_conn *conn, uint8_t ase_id)
 {
 	const struct bt_gatt_attr *attr = test_ase_control_point_get();
 	const uint8_t buf[] = {
 		0x08,                   /* Opcode = Disable */
 		0x01,                   /* Number_of_ASEs */
-		0x01,                   /* ASE_ID[0] */
+		ase_id,                 /* ASE_ID[0] */
 	};
 	ssize_t ret;
 
@@ -194,13 +215,13 @@ void test_ase_control_client_release(struct bt_conn *conn)
 	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
 }
 
-void test_ase_control_client_update_metadata(struct bt_conn *conn)
+void test_ase_control_client_update_metadata(struct bt_conn *conn, uint8_t ase_id)
 {
 	const struct bt_gatt_attr *attr = test_ase_control_point_get();
 	const uint8_t buf[] = {
 		0x07,                   /* Opcode = Update Metadata */
 		0x01,                   /* Number_of_ASEs */
-		0x01,                   /* ASE_ID[0] */
+		ase_id,                 /* ASE_ID[0] */
 		0x03,                   /* Metadata_Length[0] */
 		0x02, 0x02, 0x04,       /* Metadata[0] = Streaming Context (Media) */
 	};

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -10,6 +10,7 @@
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/uuid.h>
 
 #include "bap_unicast_server.h"
 #include "bap_stream.h"
@@ -51,6 +52,34 @@ const struct bt_gatt_attr *test_ase_control_point_get(void)
 
 	return attr;
 
+}
+
+uint8_t test_ase_get(const struct bt_uuid *uuid, int num_ase, ...)
+{
+	const struct bt_gatt_attr *attr = NULL;
+	va_list attrs;
+	uint8_t i;
+
+	va_start(attrs, num_ase);
+
+	for (i = 0; i < num_ase; i++) {
+		const struct bt_gatt_attr *prev = attr;
+
+		bt_gatt_foreach_attr_type(BT_ATT_FIRST_ATTRIBUTE_HANDLE,
+					  BT_ATT_LAST_ATTRIBUTE_HANDLE,
+					  uuid, NULL, i + 1, attr_found, &attr);
+
+		/* Another attribute was not found */
+		if (attr == prev) {
+			break;
+		}
+
+		*(va_arg(attrs, const struct bt_gatt_attr **)) = attr;
+	}
+
+	va_end(attrs);
+
+	return i;
 }
 
 static struct bt_bap_stream *stream_allocated;

--- a/tests/bluetooth/audio/mocks/include/bap_unicast_server_expects.h
+++ b/tests/bluetooth/audio/mocks/include/bap_unicast_server_expects.h
@@ -40,6 +40,30 @@ do {                                                                            
 		     zassert_unreachable("Not implemented");))                                     \
 } while (0)
 
+#define expect_bt_bap_unicast_server_cb_reconfig_called_once(_stream, _dir, _codec)                \
+do {                                                                                               \
+	const char *func_name = "bt_bap_unicast_server_cb.reconfig";                               \
+												   \
+	zassert_true(mock_bap_unicast_server_cb_reconfig_fake.call_count > 0,                      \
+		     "'%s()' was not called", func_name);                                          \
+	zassert_equal(1, mock_bap_unicast_server_cb_reconfig_fake.call_count,                      \
+		      "'%s()' was called more than once", func_name);                              \
+												   \
+	IF_NOT_EMPTY(_stream, (                                                                    \
+		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_reconfig_fake.arg0_val, \
+				       "'%s()' was called with incorrect '%s' value",              \
+				       func_name, "stream");))                                     \
+												   \
+	IF_NOT_EMPTY(_dir, (                                                                       \
+		     zassert_equal(_dir, mock_bap_unicast_server_cb_reconfig_fake.arg1_val,        \
+				   "'%s()' was called with incorrect '%s' value",                  \
+				   func_name, "_dir");))                                           \
+												   \
+	IF_NOT_EMPTY(_codec, (                                                                     \
+		     /* TODO */                                                                    \
+		     zassert_unreachable("Not implemented");))                                     \
+} while (0)
+
 #define expect_bt_bap_unicast_server_cb_qos_called_once(_stream, _qos)                             \
 do {                                                                                               \
 	const char *func_name = "bt_bap_unicast_server_cb.qos";                                    \
@@ -68,6 +92,29 @@ do {                                                                            
 												   \
 	IF_NOT_EMPTY(_stream, (                                                                    \
 		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_enable_fake.arg0_val,   \
+				       "'%s()' was called with incorrect '%s' value",              \
+				       func_name, "stream");))                                     \
+												   \
+	IF_NOT_EMPTY(_meta, (                                                                      \
+		     /* TODO */                                                                    \
+		     zassert_unreachable("Not implemented");))                                     \
+												   \
+	IF_NOT_EMPTY(_meta_count, (                                                                \
+		     /* TODO */                                                                    \
+		     zassert_unreachable("Not implemented");))                                     \
+} while (0)
+
+#define expect_bt_bap_unicast_server_cb_metadata_called_once(_stream, _meta, _meta_count)          \
+do {                                                                                               \
+	const char *func_name = "bt_bap_unicast_server_cb.enable";                                 \
+												   \
+	zassert_true(mock_bap_unicast_server_cb_metadata_fake.call_count > 0,                      \
+		     "'%s()' was not called", func_name);                                          \
+	zassert_equal(1, mock_bap_unicast_server_cb_metadata_fake.call_count,                      \
+		      "'%s()' was called more than once", func_name);                              \
+												   \
+	IF_NOT_EMPTY(_stream, (                                                                    \
+		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_metadata_fake.arg0_val, \
 				       "'%s()' was called with incorrect '%s' value",              \
 				       func_name, "stream");))                                     \
 												   \
@@ -122,5 +169,13 @@ do {                                                                            
 				       "'%s()' was called with incorrect '%s' value",              \
 				       func_name, "stream");))                                     \
 } while (0)
+
+static void expect_bt_bap_unicast_server_cb_config_not_called(void)
+{
+	const char *func_name = "bt_bap_unicast_server_cb.config";
+
+	zassert_equal(0, mock_bap_unicast_server_cb_config_fake.call_count,
+		      "'%s()' was called unexpectedly", func_name);
+}
 
 #endif /* MOCKS_BAP_UNICAST_SERVER_EXPECTS_H_ */

--- a/tests/bluetooth/audio/mocks/include/iso.h
+++ b/tests/bluetooth/audio/mocks/include/iso.h
@@ -14,6 +14,7 @@ void mock_bt_iso_init(void);
 void mock_bt_iso_cleanup(void);
 int mock_bt_iso_accept(struct bt_conn *conn, uint8_t cig_id, uint8_t cis_id,
 		       struct bt_iso_chan **chan);
+int mock_bt_iso_disconnect(struct bt_iso_chan *chan);
 
 DECLARE_FAKE_VALUE_FUNC(int, bt_iso_chan_send, struct bt_iso_chan *, struct net_buf *, uint16_t,
 			uint32_t);

--- a/tests/bluetooth/audio/mocks/src/iso.c
+++ b/tests/bluetooth/audio/mocks/src/iso.c
@@ -86,3 +86,8 @@ int mock_bt_iso_accept(struct bt_conn *conn, uint8_t cig_id, uint8_t cis_id,
 
 	return 0;
 }
+
+int mock_bt_iso_disconnect(struct bt_iso_chan *chan)
+{
+	return bt_iso_chan_disconnect(chan);
+}


### PR DESCRIPTION
This adds another set of test cases to cover the ASE state transitions.