### PR TITLE
tests/boards/mec15xxevb_assy6853/qspi: Fix typo in test

### DIFF
--- a/tests/boards/mec15xxevb_assy6853/qspi/src/main.c
+++ b/tests/boards/mec15xxevb_assy6853/qspi/src/main.c
@@ -102,7 +102,7 @@ ZTEST_USER(spi, test_spi_device)
  * - erase data in flash device
  * - read register1 and wait for erase operation completed
  */
-ZTEST_USER(spi_sec_erase, test_spi_sector_erase)
+ZTEST_USER(spi_sector_erase, test_spi_sector_erase)
 {
 	int ret;
 


### PR DESCRIPTION
Actually, more of a name mismatch between suite declaration and usage.