### PR TITLE
drivers: i2c: mec15xx: I2C reset fix

### DIFF
--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -200,6 +200,7 @@
 			reg = <0x40004000 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <20 1>;
+			pcrs = <1 10>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -212,6 +213,7 @@
 			reg = <0x40004400 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <21 1>;
+			pcrs = <3 13>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -224,6 +226,7 @@
 			reg = <0x40004800 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <22 1>;
+			pcrs = <3 14>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -236,6 +239,7 @@
 			reg = <0x40004C00 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <23 1>;
+			pcrs = <3 15>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -248,6 +252,7 @@
 			reg = <0x40005000 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <158 1>;
+			pcrs = <3 20>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";

--- a/dts/bindings/i2c/microchip,xec-i2c.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c.yaml
@@ -26,6 +26,11 @@ properties:
     required: true
     description: Bit position in GIRQ for this device
 
+  pcrs:
+    type: array
+    required: true
+    description: PCR sleep register index and bit position
+
   pinctrl-0:
     required: true
 


### PR DESCRIPTION
Updated the code to to invoke reset using PCR block z_mchp_xec_pcr_periph_reset()  instead of resetting using I2C Configuration register