### PR TITLE
kernel: Remove unused K_END macro

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -42,7 +42,6 @@ BUILD_ASSERT(sizeof(intptr_t) == sizeof(long));
  */
 
 #define K_ANY NULL
-#define K_END NULL
 
 #if CONFIG_NUM_COOP_PRIORITIES + CONFIG_NUM_PREEMPT_PRIORITIES == 0
 #error Zero available thread priorities defined!


### PR DESCRIPTION
Removes the unused K_END macro. This macro used to be used with the long since removed semaphore groups functionality.