### PR TITLE
drivers:gpio:Update NXP gpio for wakeup source

### DIFF
--- a/drivers/interrupt_controller/intc_nxp_pint.c
+++ b/drivers/interrupt_controller/intc_nxp_pint.c
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/interrupt_controller/nxp_pint.h>
 
 #include <fsl_inputmux.h>
+#include <fsl_power.h>
 
 #define DT_DRV_COMPAT nxp_pint
 
@@ -25,6 +26,7 @@ struct pint_irq_slot {
 	void *user_data;
 	uint8_t pin: 6;
 	uint8_t used: 1;
+	uint8_t irq;
 };
 
 #define NO_PINT_ID 0xFF
@@ -60,9 +62,10 @@ static void attach_pin_to_pint(uint8_t pin, uint8_t pint_slot)
  * @param pin: pin to use as interrupt source
  *     0-64, corresponding to GPIO0 pin 1 - GPIO1 pin 31)
  * @param trigger: one of nxp_pint_trigger flags
+ * @param wake: indicates if the pin should wakeup the system
  * @return 0 on success, or negative value on error
  */
-int nxp_pint_pin_enable(uint8_t pin, enum nxp_pint_trigger trigger)
+int nxp_pint_pin_enable(uint8_t pin, enum nxp_pint_trigger trigger, bool wake)
 {
 	uint8_t slot = 0U;
 
@@ -93,6 +96,13 @@ int nxp_pint_pin_enable(uint8_t pin, enum nxp_pint_trigger trigger)
 	 * driver handles the IRQ
 	 */
 	PINT_PinInterruptConfig(pint_base, slot, trigger, NULL);
+
+	if (wake) {
+		EnableDeepSleepIRQ(pint_irq_cfg[slot].irq);
+	} else {
+		DisableDeepSleepIRQ(pint_irq_cfg[slot].irq);
+	}
+
 	return 0;
 }
 
@@ -186,6 +196,7 @@ static void nxp_pint_isr(uint8_t *slot)
 			    DT_IRQ_BY_IDX(node_id, idx, priority),		\
 			    nxp_pint_isr, &nxp_pint_idx_##idx, 0);		\
 		irq_enable(DT_IRQ_BY_IDX(node_id, idx, irq));			\
+		pint_irq_cfg[idx].irq = DT_IRQ_BY_IDX(node_id, idx, irq);	\
 	} while (false)))
 
 static int intc_nxp_pint_init(void)

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -216,6 +216,10 @@ extern "C" {
 					GPIO_INT_LEVELS_LOGICAL | \
 					GPIO_INT_HIGH_1)
 
+/** Configures GPIO interrupt to wakeup the system from low power mode.
+ */
+#define GPIO_INT_WAKEUP          (1u << 28)
+
 /** @} */
 
 /** @cond INTERNAL_HIDDEN */
@@ -540,6 +544,8 @@ enum gpio_int_trig {
 	GPIO_INT_TRIG_HIGH = GPIO_INT_HIGH_1,
 	/* Trigger detection on pin rising or falling edge. */
 	GPIO_INT_TRIG_BOTH = GPIO_INT_LOW_0 | GPIO_INT_HIGH_1,
+	/* Trigger a system wakup. */
+	GPIO_INT_TRIG_WAKE = GPIO_INT_WAKEUP,
 };
 
 __subsystem struct gpio_driver_api {
@@ -661,7 +667,7 @@ static inline int z_impl_gpio_pin_interrupt_configure(const struct device *port,
 		flags ^= (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1);
 	}
 
-	trig = (enum gpio_int_trig)(flags & (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1));
+	trig = (enum gpio_int_trig)(flags & (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1 | GPIO_INT_WAKEUP));
 #ifdef CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT
 	mode = (enum gpio_int_mode)(flags & (GPIO_INT_EDGE | GPIO_INT_DISABLE | GPIO_INT_ENABLE |
 					     GPIO_INT_ENABLE_DISABLE_ONLY));

--- a/include/zephyr/drivers/interrupt_controller/nxp_pint.h
+++ b/include/zephyr/drivers/interrupt_controller/nxp_pint.h
@@ -50,8 +50,9 @@ typedef void (*nxp_pint_cb_t) (uint8_t pin, void *user);
  * @param pin: pin to use as interrupt source
  *     0-64, corresponding to GPIO0 pin 1 - GPIO1 pin 31)
  * @param trigger: one of nxp_pint_trigger flags
+ * @param wake: indicates if the pin should wakeup the system
  */
-int nxp_pint_pin_enable(uint8_t pin, enum nxp_pint_trigger trigger);
+int nxp_pint_pin_enable(uint8_t pin, enum nxp_pint_trigger trigger, bool wake);
 
 
 /**


### PR DESCRIPTION
Using the Pin as the wake up source. And add a property into DTS to tell the system which pins are used to wake up the system.