### PR TITLE
net: lwm2m: Add is_suspended() routine

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -246,6 +246,16 @@ static bool sm_is_registered(void)
 	return registered;
 }
 
+static bool sm_is_suspended(void)
+{
+	k_mutex_lock(&client.mutex, K_FOREVER);
+	bool suspended = (client.engine_state == ENGINE_SUSPENDED);
+
+	k_mutex_unlock(&client.mutex);
+	return suspended;
+}
+
+
 static uint8_t get_sm_state(void)
 {
 	k_mutex_lock(&client.mutex, K_FOREVER);
@@ -1516,6 +1526,15 @@ bool lwm2m_rd_client_is_registred(struct lwm2m_ctx *client_ctx)
 
 	return true;
 }
+bool lwm2m_rd_client_is_suspended(struct lwm2m_ctx *client_ctx)
+{
+	if (client.ctx != client_ctx || !sm_is_suspended()) {
+		return false;
+	}
+
+	return true;
+}
+
 
 int lwm2m_rd_client_init(void)
 {

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.h
@@ -46,6 +46,7 @@ int lwm2m_rd_client_resume(void);
 
 int lwm2m_rd_client_timeout(struct lwm2m_ctx *client_ctx);
 bool lwm2m_rd_client_is_registred(struct lwm2m_ctx *client_ctx);
+bool lwm2m_rd_client_is_suspended(struct lwm2m_ctx *client_ctx);
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
 void engine_bootstrap_finish(void);
 #endif


### PR DESCRIPTION
Add is_suspended() routine to have control over the rd client from the outside whether it is suspended.