### PR TITLE
Treewide: Update clock control API usage

### DIFF
--- a/drivers/adc/adc_gd32.c
+++ b/drivers/adc/adc_gd32.c
@@ -383,7 +383,7 @@ static int adc_gd32_init(const struct device *dev)
 #endif
 
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clkid);
+			       (clock_control_subsys_t)&cfg->clkid);
 
 	(void)reset_line_toggle_dt(&cfg->reset);
 

--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -784,14 +784,14 @@ static int adc_npcx_init(const struct device *dev)
 	data->adc_dev = dev;
 
 	/* Turn on device clock first and get source clock freq. */
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
+	ret = clock_control_on(clk_dev, (clock_control_subsys_t)
 							&config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on ADC clock fail %d", ret);
 		return ret;
 	}
 
-	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)
+	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t)
 			&config->clk_cfg, &data->input_clk);
 	if (ret < 0) {
 		LOG_ERR("Get ADC clock rate error %d", ret);

--- a/drivers/adc/adc_sam_afec.c
+++ b/drivers/adc/adc_sam_afec.c
@@ -298,7 +298,7 @@ static int adc_sam_init(const struct device *dev)
 
 	/* Enable AFEC clock in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clock_cfg);
+			       (clock_control_subsys_t)&cfg->clock_cfg);
 
 	/* Connect pins to the peripheral */
 	retval = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1366,7 +1366,7 @@ static int adc_stm32_init(const struct device *dev)
 #endif
 
 	if (clock_control_on(clk,
-		(clock_control_subsys_t *) &config->pclken) != 0) {
+		(clock_control_subsys_t) &config->pclken) != 0) {
 		return -EIO;
 	}
 
@@ -1504,7 +1504,7 @@ static int adc_stm32_init(const struct device *dev)
 	uint32_t adc_rate, wait_cycles;
 
 	if (clock_control_get_rate(clk,
-		(clock_control_subsys_t *) &config->pclken, &adc_rate) < 0) {
+		(clock_control_subsys_t) &config->pclken, &adc_rate) < 0) {
 		LOG_ERR("ADC clock rate get error.");
 	}
 

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -1015,19 +1015,19 @@ static int can_rcar_init(const struct device *dev)
 
 	/* reset the registers */
 	ret = clock_control_off(config->clock_dev,
-				(clock_control_subsys_t *)&config->mod_clk);
+				(clock_control_subsys_t)&config->mod_clk);
 	if (ret < 0) {
 		return ret;
 	}
 
 	ret = clock_control_on(config->clock_dev,
-			       (clock_control_subsys_t *)&config->mod_clk);
+			       (clock_control_subsys_t)&config->mod_clk);
 	if (ret < 0) {
 		return ret;
 	}
 
 	ret = clock_control_on(config->clock_dev,
-			       (clock_control_subsys_t *)&config->bus_clk);
+			       (clock_control_subsys_t)&config->bus_clk);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -47,7 +47,7 @@ static void can_sam_clock_enable(const struct can_sam_config *sam_cfg)
 
 	/* Enable CAN clock in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&sam_cfg->clock_cfg);
+			       (clock_control_subsys_t)&sam_cfg->clock_cfg);
 }
 
 static int can_sam_init(const struct device *dev)

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -532,7 +532,7 @@ static int can_stm32_get_core_clock(const struct device *dev, uint32_t *rate)
 	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	ret = clock_control_get_rate(clock,
-				     (clock_control_subsys_t *) &cfg->pclken,
+				     (clock_control_subsys_t) &cfg->pclken,
 				     rate);
 	if (ret != 0) {
 		LOG_ERR("Failed call clock_control_get_rate: return [%d]", ret);
@@ -589,7 +589,7 @@ static int can_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(clock, (clock_control_subsys_t *) &cfg->pclken);
+	ret = clock_control_on(clock, (clock_control_subsys_t) &cfg->pclken);
 	if (ret != 0) {
 		LOG_ERR("HAL_CAN_Init clock control on failed: %d", ret);
 		return -EIO;

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -58,7 +58,7 @@ static int can_stm32h7_clock_enable(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(clk, (clock_control_subsys_t *)&stm32h7_cfg->pclken);
+	ret = clock_control_on(clk, (clock_control_subsys_t)&stm32h7_cfg->pclken);
 	if (ret != 0) {
 		LOG_ERR("failure enabling clock");
 		return ret;

--- a/drivers/counter/counter_gd32_timer.c
+++ b/drivers/counter/counter_gd32_timer.c
@@ -431,9 +431,9 @@ static int counter_gd32_timer_init(const struct device *dev)
 	uint32_t pclk;
 
 	clock_control_on(GD32_CLOCK_CONTROLLER,
-			 (clock_control_subsys_t *)&cfg->clkid);
+			 (clock_control_subsys_t)&cfg->clkid);
 	clock_control_get_rate(GD32_CLOCK_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clkid, &pclk);
+			       (clock_control_subsys_t)&cfg->clkid, &pclk);
 
 	data->freq = pclk / (cfg->prescaler + 1);
 

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -398,7 +398,7 @@ static int rtc_stm32_init(const struct device *dev)
 	}
 
 	/* Enable RTC bus clock */
-	if (clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken[0]) != 0) {
+	if (clock_control_on(clk, (clock_control_subsys_t) &cfg->pclken[0]) != 0) {
 		LOG_ERR("clock op failed\n");
 		return -EIO;
 	}
@@ -411,7 +411,7 @@ static int rtc_stm32_init(const struct device *dev)
 
 	/* Enable RTC clock source */
 	if (clock_control_configure(clk,
-				    (clock_control_subsys_t *) &cfg->pclken[1],
+				    (clock_control_subsys_t) &cfg->pclken[1],
 				    NULL) != 0) {
 		LOG_ERR("clock configure failed\n");
 		return -EIO;

--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -372,7 +372,7 @@ static int counter_stm32_get_tim_clk(const struct stm32_pclken *pclken, uint32_t
 		return -ENODEV;
 	}
 
-	r = clock_control_get_rate(clk, (clock_control_subsys_t *)pclken,
+	r = clock_control_get_rate(clk, (clock_control_subsys_t)pclken,
 				   &bus_clk);
 	if (r < 0) {
 		return r;
@@ -458,7 +458,7 @@ static int counter_stm32_init_timer(const struct device *dev)
 
 	/* initialize clock and check its speed  */
 	r = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-			     (clock_control_subsys_t *)&cfg->pclken);
+			     (clock_control_subsys_t)&cfg->pclken);
 	if (r < 0) {
 		LOG_ERR("Could not initialize clock (%d)", r);
 		return r;

--- a/drivers/counter/counter_sam_tc.c
+++ b/drivers/counter/counter_sam_tc.c
@@ -325,7 +325,7 @@ static int counter_sam_initialize(const struct device *dev)
 
 	/* Enable channel's clock */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&dev_cfg->clock_cfg[dev_cfg->tc_chan_num]);
+			       (clock_control_subsys_t)&dev_cfg->clock_cfg[dev_cfg->tc_chan_num]);
 
 	/* Clock and Mode Selection */
 	tc_ch->TC_CMR = dev_cfg->reg_cmr;

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -155,9 +155,9 @@ static int dtmr_cmsdk_apb_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_SOC_SERIES_BEETLE
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->dtimer_cc_as);
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->dtimer_cc_ss);
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->dtimer_cc_dss);
+	clock_control_on(clk, (clock_control_subsys_t) &cfg->dtimer_cc_as);
+	clock_control_on(clk, (clock_control_subsys_t) &cfg->dtimer_cc_ss);
+	clock_control_on(clk, (clock_control_subsys_t) &cfg->dtimer_cc_dss);
 #endif /* CONFIG_SOC_SERIES_BEETLE */
 #endif /* CONFIG_CLOCK_CONTROL */
 

--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -155,9 +155,9 @@ static int tmr_cmsdk_apb_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_SOC_SERIES_BEETLE
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->timer_cc_as);
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->timer_cc_ss);
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->timer_cc_dss);
+	clock_control_on(clk, (clock_control_subsys_t) &cfg->timer_cc_as);
+	clock_control_on(clk, (clock_control_subsys_t) &cfg->timer_cc_ss);
+	clock_control_on(clk, (clock_control_subsys_t) &cfg->timer_cc_dss);
 #endif /* CONFIG_SOC_SERIES_BEETLE */
 #endif /* CONFIG_CLOCK_CONTROL */
 

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -458,7 +458,7 @@ static int crypto_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	if (clock_control_on(clk, (clock_control_subsys_t *)&cfg->pclken) != 0) {
+	if (clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken) != 0) {
 		LOG_ERR("clock op failed\n");
 		return -EIO;
 	}

--- a/drivers/dac/dac_esp32.c
+++ b/drivers/dac/dac_esp32.c
@@ -66,7 +66,7 @@ static int dac_esp32_init(const struct device *dev)
 	}
 
 	if (clock_control_on(cfg->clock_dev,
-		(clock_control_subsys_t *) &cfg->clock_subsys) != 0) {
+		(clock_control_subsys_t) &cfg->clock_subsys) != 0) {
 		LOG_ERR("DAC clock setup failed (%d)", -EIO);
 		return -EIO;
 	}

--- a/drivers/dac/dac_gd32.c
+++ b/drivers/dac/dac_gd32.c
@@ -156,7 +156,7 @@ static int dac_gd32_init(const struct device *dev)
 	}
 
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clkid);
+			       (clock_control_subsys_t)&cfg->clkid);
 
 	(void)reset_line_toggle_dt(&cfg->reset);
 

--- a/drivers/dac/dac_sam.c
+++ b/drivers/dac/dac_sam.c
@@ -135,7 +135,7 @@ static int dac_sam_init(const struct device *dev)
 
 	/* Enable DAC clock in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&dev_cfg->clock_cfg);
+			       (clock_control_subsys_t)&dev_cfg->clock_cfg);
 
 	retval = pinctrl_apply_state(dev_cfg->pcfg, PINCTRL_STATE_DEFAULT);
 	if (retval < 0) {

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -127,7 +127,7 @@ static int dac_stm32_init(const struct device *dev)
 	}
 
 	if (clock_control_on(clk,
-			     (clock_control_subsys_t *) &cfg->pclken) != 0) {
+			     (clock_control_subsys_t) &cfg->pclken) != 0) {
 		return -EIO;
 	}
 

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -139,7 +139,7 @@ static int stm32_sdmmc_clock_enable(struct stm32_sdmmc_priv *priv)
 
 	if (DT_INST_NUM_CLOCKS(0) > 1) {
 		if (clock_control_configure(clock,
-					    (clock_control_subsys_t *)&priv->pclken[1],
+					    (clock_control_subsys_t)&priv->pclken[1],
 					    NULL) != 0) {
 			LOG_ERR("Failed to enable SDMMC domain clock");
 			return -EIO;
@@ -150,7 +150,7 @@ static int stm32_sdmmc_clock_enable(struct stm32_sdmmc_priv *priv)
 		uint32_t sdmmc_clock_rate;
 
 		if (clock_control_get_rate(clock,
-					   (clock_control_subsys_t *)&priv->pclken[1],
+					   (clock_control_subsys_t)&priv->pclken[1],
 					   &sdmmc_clock_rate) != 0) {
 			LOG_ERR("Failed to get SDMMC domain clock rate");
 			return -EIO;
@@ -163,7 +163,7 @@ static int stm32_sdmmc_clock_enable(struct stm32_sdmmc_priv *priv)
 	}
 
 	/* Enable the APB clock for stm32_sdmmc */
-	return clock_control_on(clock, (clock_control_subsys_t *)&priv->pclken[0]);
+	return clock_control_on(clock, (clock_control_subsys_t)&priv->pclken[0]);
 }
 
 static int stm32_sdmmc_clock_disable(struct stm32_sdmmc_priv *priv)
@@ -173,7 +173,7 @@ static int stm32_sdmmc_clock_disable(struct stm32_sdmmc_priv *priv)
 	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	return clock_control_off(clock,
-				 (clock_control_subsys_t *)&priv->pclken);
+				 (clock_control_subsys_t)&priv->pclken);
 }
 
 #if STM32_SDMMC_USE_DMA

--- a/drivers/dma/dma_gd32.c
+++ b/drivers/dma/dma_gd32.c
@@ -602,7 +602,7 @@ static int dma_gd32_init(const struct device *dev)
 	const struct dma_gd32_config *cfg = dev->config;
 
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clkid);
+			       (clock_control_subsys_t)&cfg->clkid);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(gd_gd32_dma_v1)
 	(void)reset_line_toggle_dt(&cfg->reset);

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -360,7 +360,7 @@ static int sam_xdmac_initialize(const struct device *dev)
 
 	/* Enable XDMAC clock in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&dev_cfg->clock_cfg);
+			       (clock_control_subsys_t)&dev_cfg->clock_cfg);
 
 	/* Disable all channels */
 	xdmac->XDMAC_GD = UINT32_MAX;

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -635,7 +635,7 @@ static int dma_stm32_init(const struct device *dev)
 	}
 
 	if (clock_control_on(clk,
-		(clock_control_subsys_t *) &config->pclken) != 0) {
+		(clock_control_subsys_t) &config->pclken) != 0) {
 		LOG_ERR("clock op failed\n");
 		return -EIO;
 	}

--- a/drivers/dma/dma_stm32_bdma.c
+++ b/drivers/dma/dma_stm32_bdma.c
@@ -786,7 +786,7 @@ static int bdma_stm32_init(const struct device *dev)
 	}
 
 	if (clock_control_on(clk,
-		(clock_control_subsys_t *) &config->pclken) != 0) {
+		(clock_control_subsys_t) &config->pclken) != 0) {
 		LOG_ERR("clock op failed\n");
 		return -EIO;
 	}

--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -647,7 +647,7 @@ static int dma_stm32_init(const struct device *dev)
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	if (clock_control_on(clk,
-		(clock_control_subsys_t *) &config->pclken) != 0) {
+		(clock_control_subsys_t) &config->pclken) != 0) {
 		LOG_ERR("clock op failed\n");
 		return -EIO;
 	}

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -287,7 +287,7 @@ static int dmamux_stm32_init(const struct device *dev)
 	}
 
 	if (clock_control_on(clk,
-		(clock_control_subsys_t *) &config->pclken) != 0) {
+		(clock_control_subsys_t) &config->pclken) != 0) {
 		LOG_ERR("clock op failed\n");
 		return -EIO;
 	}

--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -170,7 +170,7 @@ static int entropy_sam_init(const struct device *dev)
 	/* Enable TRNG in PMC */
 	const struct atmel_sam_pmc_config clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(0);
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&clock_cfg);
+			       (clock_control_subsys_t)&clock_cfg);
 
 	/* Enable the TRNG */
 	trng->TRNG_CR = TRNG_CR_KEY_PASSWD | TRNG_CR_ENABLE;

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -590,13 +590,13 @@ static int entropy_stm32_rng_init(const struct device *dev)
 	}
 
 	res = clock_control_on(dev_data->clock,
-		(clock_control_subsys_t *)&dev_cfg->pclken[0]);
+		(clock_control_subsys_t)&dev_cfg->pclken[0]);
 	__ASSERT_NO_MSG(res == 0);
 
 	/* Configure domain clock if any */
 	if (DT_INST_NUM_CLOCKS(0) > 1) {
 		res = clock_control_configure(dev_data->clock,
-					      (clock_control_subsys_t *)&dev_cfg->pclken[1],
+					      (clock_control_subsys_t)&dev_cfg->pclken[1],
 					      NULL);
 		__ASSERT(res == 0, "Could not select RNG domain clock");
 	}

--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -1207,7 +1207,7 @@ static int espi_npcx_init(const struct device *dev)
 	}
 
 	/* Turn on eSPI device clock first */
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
+	ret = clock_control_on(clk_dev, (clock_control_subsys_t)
 							&config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on eSPI clock fail %d", ret);

--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -1090,7 +1090,7 @@ int npcx_host_init_subs_core_domain(const struct device *host_bus_dev,
 			return -ENODEV;
 		}
 
-		ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
+		ret = clock_control_on(clk_dev, (clock_control_subsys_t)
 				&host_sub_cfg.clks_list[i]);
 		if (ret < 0) {
 			return ret;

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -57,9 +57,9 @@ int dwmac_bus_init(struct dwmac_priv *p)
 		return -ENODEV;
 	}
 
-	ret  = clock_control_on(p->clock, (clock_control_subsys_t *)&pclken);
-	ret |= clock_control_on(p->clock, (clock_control_subsys_t *)&pclken_tx);
-	ret |= clock_control_on(p->clock, (clock_control_subsys_t *)&pclken_rx);
+	ret  = clock_control_on(p->clock, (clock_control_subsys_t)&pclken);
+	ret |= clock_control_on(p->clock, (clock_control_subsys_t)&pclken_tx);
+	ret |= clock_control_on(p->clock, (clock_control_subsys_t)&pclken_rx);
 	if (ret) {
 		LOG_ERR("Failed to enable ethernet clock");
 		return -EIO;

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1779,7 +1779,7 @@ static int eth_initialize(const struct device *dev)
 #ifdef CONFIG_SOC_FAMILY_SAM
 	/* Enable GMAC module's clock */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clock_cfg);
+			       (clock_control_subsys_t)&cfg->clock_cfg);
 #else
 	/* Enable MCLK clock on GMAC */
 	MCLK->AHBMASK.reg |= MCLK_AHBMASK_GMAC;

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1142,14 +1142,14 @@ static int eth_initialize(const struct device *dev)
 
 	/* enable clock */
 	ret = clock_control_on(dev_data->clock,
-		(clock_control_subsys_t *)&cfg->pclken);
+		(clock_control_subsys_t)&cfg->pclken);
 	ret |= clock_control_on(dev_data->clock,
-		(clock_control_subsys_t *)&cfg->pclken_tx);
+		(clock_control_subsys_t)&cfg->pclken_tx);
 	ret |= clock_control_on(dev_data->clock,
-		(clock_control_subsys_t *)&cfg->pclken_rx);
+		(clock_control_subsys_t)&cfg->pclken_rx);
 #if DT_INST_CLOCKS_HAS_NAME(0, mac_clk_ptp)
 	ret |= clock_control_on(dev_data->clock,
-		(clock_control_subsys_t *)&cfg->pclken_ptp);
+		(clock_control_subsys_t)&cfg->pclken_ptp);
 #endif
 
 	if (ret) {
@@ -1889,9 +1889,9 @@ static int ptp_stm32_init(const struct device *port)
 	/* Query ethernet clock rate */
 	ret = clock_control_get_rate(eth_dev_data->clock,
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
-		(clock_control_subsys_t *)&eth_cfg->pclken,
+		(clock_control_subsys_t)&eth_cfg->pclken,
 #else
-		(clock_control_subsys_t *)&eth_cfg->pclken_ptp,
+		(clock_control_subsys_t)&eth_cfg->pclken_ptp,
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
 		&ptp_hclk_rate);
 	if (ret) {

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -536,7 +536,7 @@ static int stm32_flash_init(const struct device *dev)
 	}
 
 	/* enable clock */
-	if (clock_control_on(clk, (clock_control_subsys_t *)&p->pclken) != 0) {
+	if (clock_control_on(clk, (clock_control_subsys_t)&p->pclken) != 0) {
 		LOG_ERR("Failed to enable clock");
 		return -EIO;
 	}

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -672,7 +672,7 @@ static int stm32h7_flash_init(const struct device *dev)
 	}
 
 	/* enable clock */
-	if (clock_control_on(clk, (clock_control_subsys_t *)&p->pclken) != 0) {
+	if (clock_control_on(clk, (clock_control_subsys_t)&p->pclken) != 0) {
 		LOG_ERR("Failed to enable clock");
 		return -EIO;
 	}

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -246,9 +246,9 @@ static int gpio_cmsdk_ahb_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_SOC_SERIES_BEETLE
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->gpio_cc_as);
-	clock_control_off(clk, (clock_control_subsys_t *) &cfg->gpio_cc_ss);
-	clock_control_off(clk, (clock_control_subsys_t *) &cfg->gpio_cc_dss);
+	clock_control_on(clk, (clock_control_subsys_t) &cfg->gpio_cc_as);
+	clock_control_off(clk, (clock_control_subsys_t) &cfg->gpio_cc_ss);
+	clock_control_off(clk, (clock_control_subsys_t) &cfg->gpio_cc_dss);
 #endif /* CONFIG_SOC_SERIES_BEETLE */
 #endif /* CONFIG_CLOCK_CONTROL */
 

--- a/drivers/gpio/gpio_gd32.c
+++ b/drivers/gpio/gpio_gd32.c
@@ -349,9 +349,9 @@ static int gpio_gd32_init(const struct device *port)
 	const struct gpio_gd32_config *config = port->config;
 
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
-			       (clock_control_subsys_t *)&config->clkid);
+			       (clock_control_subsys_t)&config->clkid);
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
-			       (clock_control_subsys_t *)&config->clkid_exti);
+			       (clock_control_subsys_t)&config->clkid_exti);
 
 	(void)reset_line_toggle_dt(&config->reset);
 

--- a/drivers/gpio/gpio_rcar.c
+++ b/drivers/gpio/gpio_rcar.c
@@ -253,7 +253,7 @@ static int gpio_rcar_init(const struct device *dev)
 	}
 
 	ret = clock_control_on(config->clock_dev,
-			       (clock_control_subsys_t *) &config->mod_clk);
+			       (clock_control_subsys_t) &config->mod_clk);
 
 	if (ret < 0) {
 		return ret;

--- a/drivers/gpio/gpio_sam.c
+++ b/drivers/gpio/gpio_sam.c
@@ -310,7 +310,7 @@ int gpio_sam_init(const struct device *dev)
 
 	/* Enable GPIO clock in PMC. This is necessary to enable interrupts */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clock_cfg);
+			       (clock_control_subsys_t)&cfg->clock_cfg);
 
 	cfg->config_func(dev);
 

--- a/drivers/gpio/gpio_sam4l.c
+++ b/drivers/gpio/gpio_sam4l.c
@@ -234,7 +234,7 @@ int gpio_sam_init(const struct device *dev)
 
 	/* Enable GPIO clock in PM */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clock_cfg);
+			       (clock_control_subsys_t)&cfg->clock_cfg);
 
 	cfg->config_func(dev);
 

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -279,10 +279,10 @@ static int gpio_stm32_clock_request(const struct device *dev, bool on)
 
 	if (on) {
 		ret = clock_control_on(clk,
-					(clock_control_subsys_t *)&cfg->pclken);
+					(clock_control_subsys_t)&cfg->pclken);
 	} else {
 		ret = clock_control_off(clk,
-					(clock_control_subsys_t *)&cfg->pclken);
+					(clock_control_subsys_t)&cfg->pclken);
 	}
 
 	if (ret != 0) {
@@ -385,7 +385,7 @@ static int gpio_stm32_enable_int(int port, int pin)
 	int ret;
 
 	/* Enable SYSCFG clock */
-	ret = clock_control_on(clk, (clock_control_subsys_t *) &pclken);
+	ret = clock_control_on(clk, (clock_control_subsys_t) &pclken);
 	if (ret != 0) {
 		return ret;
 	}

--- a/drivers/hwinfo/hwinfo_sam_rstc.c
+++ b/drivers/hwinfo/hwinfo_sam_rstc.c
@@ -63,7 +63,7 @@ static int hwinfo_rstc_init(const struct device *dev)
 
 	/* Enable RSTC in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&clock_cfg);
+			       (clock_control_subsys_t)&clock_cfg);
 
 	/* Get current Mode Register value */
 	mode = regs->RSTC_MR;

--- a/drivers/i2c/i2c_gd32.c
+++ b/drivers/i2c/i2c_gd32.c
@@ -504,7 +504,7 @@ static int i2c_gd32_configure(const struct device *dev,
 	I2C_CTL0(cfg->reg) &= ~I2C_CTL0_I2CEN;
 
 	(void)clock_control_get_rate(GD32_CLOCK_CONTROLLER,
-				     (clock_control_subsys_t *)&cfg->clkid,
+				     (clock_control_subsys_t)&cfg->clkid,
 				     &pclk1);
 
 	/* i2c clock frequency, us */
@@ -668,7 +668,7 @@ static int i2c_gd32_init(const struct device *dev)
 	k_sem_init(&data->sync_sem, 0, K_SEM_MAX_LIMIT);
 
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clkid);
+			       (clock_control_subsys_t)&cfg->clkid);
 
 	(void)reset_line_toggle_dt(&cfg->reset);
 

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -61,7 +61,7 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 		}
 	} else {
 		if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					   (clock_control_subsys_t *) &cfg->pclken[0],
+					   (clock_control_subsys_t) &cfg->pclken[0],
 					   &clock) < 0) {
 			LOG_ERR("Failed call clock_control_get_rate(pclken[0])");
 			return -EIO;
@@ -380,7 +380,7 @@ static int i2c_stm32_activate(const struct device *dev)
 
 	/* Enable device clock. */
 	if (clock_control_on(clk,
-			     (clock_control_subsys_t *) &cfg->pclken[0]) != 0) {
+			     (clock_control_subsys_t) &cfg->pclken[0]) != 0) {
 		LOG_ERR("i2c: failure enabling clock");
 		return -EIO;
 	}
@@ -418,7 +418,7 @@ static int i2c_stm32_init(const struct device *dev)
 	if (IS_ENABLED(STM32_I2C_DOMAIN_CLOCK_SUPPORT) && (cfg->pclk_len > 1)) {
 		/* Enable I2C clock source */
 		ret = clock_control_configure(clk,
-					(clock_control_subsys_t *) &cfg->pclken[1],
+					(clock_control_subsys_t) &cfg->pclken[1],
 					NULL);
 		if (ret < 0) {
 			return -EIO;

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -1039,7 +1039,7 @@ static int i2c_ctrl_init(const struct device *dev)
 
 	/* Turn on device clock first and get source clock freq. */
 	if (clock_control_on(clk_dev,
-		(clock_control_subsys_t *) &config->clk_cfg) != 0) {
+		(clock_control_subsys_t) &config->clk_cfg) != 0) {
 		LOG_ERR("Turn on %s clock fail.", dev->name);
 		return -EIO;
 	}
@@ -1049,7 +1049,7 @@ static int i2c_ctrl_init(const struct device *dev)
 	 * configuration of the device to meet SMBus timing spec. Please refer
 	 * Table 21/22/23 and section 7.5.9 SMBus Timing for more detail.
 	 */
-	if (clock_control_get_rate(clk_dev, (clock_control_subsys_t *)
+	if (clock_control_get_rate(clk_dev, (clock_control_subsys_t)
 			&config->clk_cfg, &i2c_rate) != 0) {
 		LOG_ERR("Get %s clock rate error.", dev->name);
 		return -EIO;

--- a/drivers/i2c/i2c_rcar.c
+++ b/drivers/i2c/i2c_rcar.c
@@ -327,7 +327,7 @@ static int i2c_rcar_init(const struct device *dev)
 	}
 
 	ret = clock_control_on(config->clock_dev,
-			       (clock_control_subsys_t *)&config->mod_clk);
+			       (clock_control_subsys_t)&config->mod_clk);
 
 	if (ret != 0) {
 		return ret;

--- a/drivers/i2c/i2c_sam4l_twim.c
+++ b/drivers/i2c/i2c_sam4l_twim.c
@@ -561,7 +561,7 @@ static int i2c_sam_twim_initialize(const struct device *dev)
 
 	/* Enable TWIM clock in PM */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clock_cfg);
+			       (clock_control_subsys_t)&cfg->clock_cfg);
 
 	/* Enable the module*/
 	twim->CR = TWIM_CR_MEN;

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -329,7 +329,7 @@ static int i2c_sam_twi_initialize(const struct device *dev)
 
 	/* Enable TWI clock in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&dev_cfg->clock_cfg);
+			       (clock_control_subsys_t)&dev_cfg->clock_cfg);
 
 	/* Reset TWI module */
 	twi->TWI_CR = TWI_CR_SWRST;

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -300,7 +300,7 @@ static int i2c_sam_twihs_initialize(const struct device *dev)
 
 	/* Enable TWIHS clock in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&dev_cfg->clock_cfg);
+			       (clock_control_subsys_t)&dev_cfg->clock_cfg);
 
 	/* Reset the module */
 	twihs->TWIHS_CR = TWIHS_CR_SWRST;

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -108,7 +108,7 @@ static int i2s_stm32_enable_clock(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken[0]);
+	ret = clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken[0]);
 	if (ret != 0) {
 		LOG_ERR("Could not enable I2S clock");
 		return -EIO;
@@ -117,7 +117,7 @@ static int i2s_stm32_enable_clock(const struct device *dev)
 	if (cfg->pclk_len > 1) {
 		/* Enable I2S clock source */
 		ret = clock_control_configure(clk,
-					      (clock_control_subsys_t *) &cfg->pclken[1],
+					      (clock_control_subsys_t)&cfg->pclken[1],
 					      NULL);
 		if (ret < 0) {
 			LOG_ERR("Could not configure I2S domain clock");

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -977,7 +977,7 @@ static int i2s_sam_initialize(const struct device *dev)
 
 	/* Enable SSC clock in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&dev_cfg->clock_cfg);
+			       (clock_control_subsys_t)&dev_cfg->clock_cfg);
 
 	/* Reset the module, disable receiver & transmitter */
 	ssc->SSC_CR = SSC_CR_RXDIS | SSC_CR_TXDIS | SSC_CR_SWRST;

--- a/drivers/interrupt_controller/intc_mchp_ecia_xec.c
+++ b/drivers/interrupt_controller/intc_mchp_ecia_xec.c
@@ -522,7 +522,7 @@ static int xec_ecia_init(const struct device *dev)
 	}
 
 	ret = clock_control_on(clk_dev,
-			       (clock_control_subsys_t *)&cfg->clk_ctrl);
+			       (clock_control_subsys_t)&cfg->clk_ctrl);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/ipm/ipm_stm32_hsem.c
+++ b/drivers/ipm/ipm_stm32_hsem.c
@@ -164,7 +164,7 @@ static int stm32_hsem_mailbox_init(const struct device *dev)
 		}
 
 		/* Enable clock */
-		if (clock_control_on(clk, (clock_control_subsys_t *)&cfg->pclken) != 0) {
+		if (clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken) != 0) {
 			LOG_WRN("Failed to enable clock");
 			return -EIO;
 		}

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -253,7 +253,7 @@ static int stm32_ipcc_mailbox_init(const struct device *dev)
 
 	/* enable clock */
 	if (clock_control_on(clk,
-			     (clock_control_subsys_t *)&cfg->pclken) != 0) {
+			     (clock_control_subsys_t)&cfg->pclken) != 0) {
 		return -EIO;
 	}
 

--- a/drivers/kscan/kscan_npcx.c
+++ b/drivers/kscan/kscan_npcx.c
@@ -425,7 +425,7 @@ static int kscan_npcx_init(const struct device *dev)
 	}
 
 	/* Turn on KBSCAN controller device clock */
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)&config->clk_cfg);
+	ret = clock_control_on(clk_dev, (clock_control_subsys_t)&config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on KBSCAN clock fail %d", ret);
 	}

--- a/drivers/memc/memc_sam_smc.c
+++ b/drivers/memc/memc_sam_smc.c
@@ -38,7 +38,7 @@ static int memc_smc_init(const struct device *dev)
 
 	/* Enable SMC clock in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clock_cfg);
+			       (clock_control_subsys_t)&cfg->clock_cfg);
 
 	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {

--- a/drivers/memc/memc_stm32.c
+++ b/drivers/memc/memc_stm32.c
@@ -49,7 +49,7 @@ static int memc_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	r = clock_control_on(clk, (clock_control_subsys_t *)&config->pclken);
+	r = clock_control_on(clk, (clock_control_subsys_t)&config->pclken);
 	if (r < 0) {
 		LOG_ERR("Could not initialize FMC clock (%d)", r);
 		return r;

--- a/drivers/peci/peci_npcx.c
+++ b/drivers/peci/peci_npcx.c
@@ -244,13 +244,13 @@ static int peci_npcx_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)&config->clk_cfg);
+	ret = clock_control_on(clk_dev, (clock_control_subsys_t)&config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on PECI clock fail %d", ret);
 		return ret;
 	}
 
-	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)&config->clk_cfg,
+	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t)&config->clk_cfg,
 				     &data->peci_src_clk_freq);
 	if (ret < 0) {
 		LOG_ERR("Get PECI source clock rate error %d", ret);

--- a/drivers/pinctrl/pinctrl_gd32_af.c
+++ b/drivers/pinctrl/pinctrl_gd32_af.c
@@ -89,7 +89,7 @@ static void pinctrl_configure_pin(pinctrl_soc_pin_t pin)
 	af = GD32_AF_GET(pin);
 
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
-			       (clock_control_subsys_t *)&clkid);
+			       (clock_control_subsys_t)&clkid);
 
 	if (af != GD32_ANALOG) {
 		mode = GPIO_MODE_AF;

--- a/drivers/pinctrl/pinctrl_gd32_afio.c
+++ b/drivers/pinctrl/pinctrl_gd32_afio.c
@@ -69,7 +69,7 @@ static int afio_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
-			       (clock_control_subsys_t *)&clkid);
+			       (clock_control_subsys_t)&clkid);
 
 #ifdef AFIO_CPSCTL
 	if (DT_PROP(AFIO_NODE, enable_cps)) {
@@ -139,7 +139,7 @@ static void configure_pin(pinctrl_soc_pin_t pin)
 	}
 
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
-			       (clock_control_subsys_t *)&clkid);
+			       (clock_control_subsys_t)&clkid);
 
 	reg_val = *reg;
 	reg_val &= ~GPIO_MODE_MASK(pin_num);

--- a/drivers/ps2/ps2_npcx_controller.c
+++ b/drivers/ps2/ps2_npcx_controller.c
@@ -338,7 +338,7 @@ static int ps2_npcx_ctrl_init(const struct device *dev)
 
 	/* Turn on PS/2 controller device clock */
 	ret = clock_control_on(clk_dev,
-			       (clock_control_subsys_t *)&config->clk_cfg);
+			       (clock_control_subsys_t)&config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on PS/2 clock fail %d", ret);
 		return ret;

--- a/drivers/pwm/pwm_gd32.c
+++ b/drivers/pwm/pwm_gd32.c
@@ -155,7 +155,7 @@ static int pwm_gd32_init(const struct device *dev)
 	int ret;
 
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
-			       (clock_control_subsys_t *)&config->clkid);
+			       (clock_control_subsys_t)&config->clkid);
 
 	(void)reset_line_toggle_dt(&config->reset);
 
@@ -167,7 +167,7 @@ static int pwm_gd32_init(const struct device *dev)
 
 	/* cache timer clock value */
 	(void)clock_control_get_rate(GD32_CLOCK_CONTROLLER,
-				     (clock_control_subsys_t *)&config->clkid,
+				     (clock_control_subsys_t)&config->clkid,
 				     &data->tim_clk);
 
 	/* basic timer operation: edge aligned, up counting, shadowed CAR */

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -189,14 +189,14 @@ static int pwm_npcx_init(const struct device *dev)
 	}
 
 	/* Turn on device clock first and get source clock freq. */
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
+	ret = clock_control_on(clk_dev, (clock_control_subsys_t)
 							&config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on PWM clock fail %d", ret);
 		return ret;
 	}
 
-	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)
+	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t)
 			&config->clk_cfg, &data->cycles_per_sec);
 	if (ret < 0) {
 		LOG_ERR("Get PWM clock rate error %d", ret);

--- a/drivers/pwm/pwm_rcar.c
+++ b/drivers/pwm/pwm_rcar.c
@@ -228,12 +228,12 @@ static int pwm_rcar_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = clock_control_on(config->clock_dev, (clock_control_subsys_t *)&config->mod_clk);
+	ret = clock_control_on(config->clock_dev, (clock_control_subsys_t)&config->mod_clk);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = clock_control_get_rate(config->clock_dev, (clock_control_subsys_t *)&config->core_clk,
+	ret = clock_control_get_rate(config->clock_dev, (clock_control_subsys_t)&config->core_clk,
 				     &data->clk_rate);
 
 	if (ret < 0) {

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -105,7 +105,7 @@ static int sam_pwm_init(const struct device *dev)
 
 	/* Enable PWM clock in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&config->clock_cfg);
+			       (clock_control_subsys_t)&config->clock_cfg);
 
 	retval = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	if (retval < 0) {

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -158,7 +158,7 @@ static int get_tim_clk(const struct stm32_pclken *pclken, uint32_t *tim_clk)
 
 	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	r = clock_control_get_rate(clk, (clock_control_subsys_t *)pclken,
+	r = clock_control_get_rate(clk, (clock_control_subsys_t)pclken,
 				   &bus_clk);
 	if (r < 0) {
 		return r;
@@ -643,7 +643,7 @@ static int pwm_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	r = clock_control_on(clk, (clock_control_subsys_t *)&cfg->pclken);
+	r = clock_control_on(clk, (clock_control_subsys_t)&cfg->pclken);
 	if (r < 0) {
 		LOG_ERR("Could not initialize clock (%d)", r);
 		return r;

--- a/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
+++ b/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
@@ -320,14 +320,14 @@ static int tach_npcx_init(const struct device *dev)
 	}
 
 	/* Turn on device clock first and get source clock freq. */
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
+	ret = clock_control_on(clk_dev, (clock_control_subsys_t)
 							&config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on tachometer clock fail %d", ret);
 		return ret;
 	}
 
-	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)
+	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t)
 					&config->clk_cfg, &data->input_clk);
 	if (ret < 0) {
 		LOG_ERR("Get tachometer clock rate error %d", ret);

--- a/drivers/sensor/qdec_sam/qdec_sam.c
+++ b/drivers/sensor/qdec_sam/qdec_sam.c
@@ -107,7 +107,7 @@ static int qdec_sam_initialize(const struct device *dev)
 	for (int i = 0; i < ARRAY_SIZE(dev_cfg->clock_cfg); i++) {
 		/* Enable TC clock in PMC */
 		(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-				       (clock_control_subsys_t *)&dev_cfg->clock_cfg[i]);
+				       (clock_control_subsys_t)&dev_cfg->clock_cfg[i]);
 	}
 
 	qdec_sam_configure(dev);

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -135,9 +135,9 @@ static int uart_cmsdk_apb_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_SOC_SERIES_BEETLE
-	clock_control_on(clk, (clock_control_subsys_t *) &data->uart_cc_as);
-	clock_control_on(clk, (clock_control_subsys_t *) &data->uart_cc_ss);
-	clock_control_on(clk, (clock_control_subsys_t *) &data->uart_cc_dss);
+	clock_control_on(clk, (clock_control_subsys_t) &data->uart_cc_as);
+	clock_control_on(clk, (clock_control_subsys_t) &data->uart_cc_ss);
+	clock_control_on(clk, (clock_control_subsys_t) &data->uart_cc_dss);
 #endif /* CONFIG_SOC_SERIES_BEETLE */
 #endif /* CONFIG_CLOCK_CONTROL */
 

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -469,7 +469,7 @@ static int uart_npcx_init(const struct device *dev)
 	}
 
 	/* Turn on device clock first and get source clock freq. */
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)&config->clk_cfg);
+	ret = clock_control_on(clk_dev, (clock_control_subsys_t)&config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on UART clock fail %d", ret);
 		return ret;
@@ -479,7 +479,7 @@ static int uart_npcx_init(const struct device *dev)
 	 * If apb2's clock is not 15MHz, we need to find the other optimized
 	 * values of UPSR and UBAUD for baud rate 115200.
 	 */
-	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)&config->clk_cfg,
+	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t)&config->clk_cfg,
 				     &uart_rate);
 	if (ret < 0) {
 		LOG_ERR("Get UART clock rate error %d", ret);

--- a/drivers/serial/uart_rcar.c
+++ b/drivers/serial/uart_rcar.c
@@ -279,13 +279,13 @@ static int uart_rcar_init(const struct device *dev)
 	}
 
 	ret = clock_control_on(config->clock_dev,
-			       (clock_control_subsys_t *)&config->mod_clk);
+			       (clock_control_subsys_t)&config->mod_clk);
 	if (ret < 0) {
 		return ret;
 	}
 
 	ret = clock_control_get_rate(config->clock_dev,
-				     (clock_control_subsys_t *)&config->bus_clk,
+				     (clock_control_subsys_t)&config->bus_clk,
 				     &data->clk_rate);
 	if (ret < 0) {
 		return ret;

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -390,7 +390,7 @@ static int uart_sam_init(const struct device *dev)
 
 	/* Enable UART clock in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clock_cfg);
+			       (clock_control_subsys_t)&cfg->clock_cfg);
 
 	/* Connect pins to the peripheral */
 	retval = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);

--- a/drivers/serial/usart_gd32.c
+++ b/drivers/serial/usart_gd32.c
@@ -86,7 +86,7 @@ static int usart_gd32_init(const struct device *dev)
 	}
 
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clkid);
+			       (clock_control_subsys_t)&cfg->clkid);
 
 	(void)reset_line_toggle_dt(&cfg->reset);
 

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -484,7 +484,7 @@ static int usart_sam_init(const struct device *dev)
 
 	/* Enable USART clock in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clock_cfg);
+			       (clock_control_subsys_t)&cfg->clock_cfg);
 
 	/* Connect pins to the peripheral */
 	retval = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);

--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -173,7 +173,7 @@ static int spi_gd32_configure(const struct device *dev,
 	}
 
 	(void)clock_control_get_rate(GD32_CLOCK_CONTROLLER,
-				     (clock_control_subsys_t *)&cfg->clkid,
+				     (clock_control_subsys_t)&cfg->clkid,
 				     &bus_freq);
 
 	for (uint8_t i = 0U; i <= GD32_SPI_PSC_MAX; i++) {
@@ -583,7 +583,7 @@ int spi_gd32_init(const struct device *dev)
 #endif
 
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clkid);
+			       (clock_control_subsys_t)&cfg->clkid);
 
 	(void)reset_line_toggle_dt(&cfg->reset);
 

--- a/drivers/spi/spi_npcx_fiu.c
+++ b/drivers/spi/spi_npcx_fiu.c
@@ -152,7 +152,7 @@ static int spi_npcx_fiu_init(const struct device *dev)
 
 	/* Turn on device clock first and get source clock freq. */
 	ret = clock_control_on(clk_dev,
-			       (clock_control_subsys_t *)&config->clk_cfg);
+			       (clock_control_subsys_t)&config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on FIU clock fail %d", ret);
 		return ret;

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -840,7 +840,7 @@ static int spi_sam_init(const struct device *dev)
 
 	/* Enable SPI clock in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&cfg->clock_cfg);
+			       (clock_control_subsys_t)&cfg->clock_cfg);
 
 	err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
 	if (err < 0) {

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -317,7 +317,7 @@ static int sys_clock_driver_init(const struct device *dev)
 
 	/* Turn on all itim module clocks used for counting */
 	for (int i = 0; i < ARRAY_SIZE(itim_clk_cfg); i++) {
-		ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
+		ret = clock_control_on(clk_dev, (clock_control_subsys_t)
 				&itim_clk_cfg[i]);
 		if (ret < 0) {
 			LOG_ERR("Turn on timer %d clock failed.", i);
@@ -329,7 +329,7 @@ static int sys_clock_driver_init(const struct device *dev)
 	 * In npcx series, we use ITIM64 as system kernel timer. Its source
 	 * clock frequency must equal to CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC.
 	 */
-	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)
+	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t)
 			&itim_clk_cfg[1], &sys_tmr_rate);
 	if (ret < 0) {
 		LOG_ERR("Get ITIM64 clock rate failed %d", ret);

--- a/drivers/timer/rcar_cmt_timer.c
+++ b/drivers/timer/rcar_cmt_timer.c
@@ -101,7 +101,7 @@ static int sys_clock_driver_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(clk, (clock_control_subsys_t *)&mod_clk);
+	ret = clock_control_on(clk, (clock_control_subsys_t)&mod_clk);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -181,12 +181,12 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	}
 
 	if (ticks == K_TICKS_FOREVER) {
-		clock_control_off(clk_ctrl, (clock_control_subsys_t *) &lptim_clk[0]);
+		clock_control_off(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
 		return;
 	}
 
 	/* if LPTIM clock was previously stopped, it must now be restored */
-	clock_control_on(clk_ctrl, (clock_control_subsys_t *) &lptim_clk[0]);
+	clock_control_on(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
 
 	/* passing ticks==1 means "announce the next tick",
 	 * ticks value of zero (or even negative) is legal and
@@ -326,7 +326,7 @@ static int sys_clock_driver_init(const struct device *dev)
 	}
 
 	/* Enable LPTIM bus clock */
-	err = clock_control_on(clk_ctrl, (clock_control_subsys_t *) &lptim_clk[0]);
+	err = clock_control_on(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
 	if (err < 0) {
 		return -EIO;
 	}
@@ -339,14 +339,14 @@ static int sys_clock_driver_init(const struct device *dev)
 
 	/* Enable LPTIM clock source */
 	err = clock_control_configure(clk_ctrl,
-				      (clock_control_subsys_t *) &lptim_clk[1],
+				      (clock_control_subsys_t) &lptim_clk[1],
 				      NULL);
 	if (err < 0) {
 		return -EIO;
 	}
 
 	/* Get LPTIM clock freq */
-	err = clock_control_get_rate(clk_ctrl, (clock_control_subsys_t *) &lptim_clk[1],
+	err = clock_control_get_rate(clk_ctrl, (clock_control_subsys_t) &lptim_clk[1],
 			       &lptim_clock_freq);
 
 	if (err < 0) {

--- a/drivers/usb/device/usb_dc_sam_usbhs.c
+++ b/drivers/usb/device/usb_dc_sam_usbhs.c
@@ -315,7 +315,7 @@ int usb_dc_attach(void)
 
 	/* Enable USBHS clock in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
-			       (clock_control_subsys_t *)&clock_cfg);
+			       (clock_control_subsys_t)&clock_cfg);
 
 	/* Enable the USB controller in device mode with the clock frozen */
 	USBHS->USBHS_CTRL = USBHS_CTRL_UIMOD | USBHS_CTRL_USBE |
@@ -375,7 +375,7 @@ int usb_dc_detach(void)
 
 	/* Disable USBHS clock in PMC */
 	(void)clock_control_off(SAM_DT_PMC_CONTROLLER,
-				(clock_control_subsys_t *)&clock_cfg);
+				(clock_control_subsys_t)&clock_cfg);
 
 	/* Disable interrupt */
 	irq_disable(DT_INST_IRQN(0));

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -219,14 +219,14 @@ static int usb_dc_stm32_clock_enable(void)
 #endif /* CONFIG_SOC_SERIES_STM32U5X */
 
 	if (DT_INST_NUM_CLOCKS(0) > 1) {
-		if (clock_control_configure(clk, (clock_control_subsys_t *)&pclken[1],
+		if (clock_control_configure(clk, (clock_control_subsys_t)&pclken[1],
 									NULL) != 0) {
 			LOG_ERR("Could not select USB domain clock");
 			return -EIO;
 		}
 	}
 
-	if (clock_control_on(clk, (clock_control_subsys_t *)&pclken[0]) != 0) {
+	if (clock_control_on(clk, (clock_control_subsys_t)&pclken[0]) != 0) {
 		LOG_ERR("Unable to enable USB clock");
 		return -EIO;
 	}
@@ -235,7 +235,7 @@ static int usb_dc_stm32_clock_enable(void)
 		uint32_t usb_clock_rate;
 
 		if (clock_control_get_rate(clk,
-					   (clock_control_subsys_t *)&pclken[1],
+					   (clock_control_subsys_t)&pclken[1],
 					   &usb_clock_rate) != 0) {
 			LOG_ERR("Failed to get USB domain clock rate");
 			return -EIO;
@@ -284,7 +284,7 @@ static int usb_dc_stm32_clock_disable(void)
 {
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	if (clock_control_off(clk, (clock_control_subsys_t *)&pclken[0]) != 0) {
+	if (clock_control_off(clk, (clock_control_subsys_t)&pclken[0]) != 0) {
 		LOG_ERR("Unable to disable USB clock");
 		return -EIO;
 	}

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -93,7 +93,7 @@ static uint32_t wwdg_stm32_get_pclk(const struct device *dev)
 	const struct wwdg_stm32_config *cfg = WWDG_STM32_CFG(dev);
 	uint32_t pclk_rate;
 
-	if (clock_control_get_rate(clk, (clock_control_subsys_t *) &cfg->pclken,
+	if (clock_control_get_rate(clk, (clock_control_subsys_t) &cfg->pclken,
 			       &pclk_rate) < 0) {
 		LOG_ERR("Failed call clock_control_get_rate");
 		return -EIO;
@@ -289,7 +289,7 @@ static int wwdg_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	return clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken);
+	return clock_control_on(clk, (clock_control_subsys_t) &cfg->pclken);
 }
 
 static struct wwdg_stm32_data wwdg_stm32_dev_data = {

--- a/drivers/watchdog/wdt_wwdgt_gd32.c
+++ b/drivers/watchdog/wdt_wwdgt_gd32.c
@@ -57,7 +57,7 @@ static inline uint32_t gd32_wwdgt_calc_ticks(const struct device *dev,
 	uint32_t pclk;
 
 	(void)clock_control_get_rate(GD32_CLOCK_CONTROLLER,
-				       (clock_control_subsys_t *)&config->clkid,
+				       (clock_control_subsys_t)&config->clkid,
 				       &pclk);
 
 	return ((timeout * pclk)
@@ -204,7 +204,7 @@ static int gd32_wwdgt_init(const struct device *dev)
 	const struct gd32_wwdgt_config *config = dev->config;
 
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
-			       (clock_control_subsys_t *)&config->clkid);
+			       (clock_control_subsys_t)&config->clkid);
 	(void)reset_line_toggle_dt(&config->reset);
 	gd32_wwdgt_irq_config(dev);
 

--- a/samples/drivers/clock_control_litex/README.rst
+++ b/samples/drivers/clock_control_litex/README.rst
@@ -57,7 +57,7 @@ The driver is interfaced with the :ref:`Clock Control API <clock_control_api>` f
 		.phase = 90
 	};
 	dev = DEVICE_DT_GET(MMCM);
-	clock_control_subsys_t sub_system = (clock_control_subsys_t*)&setup;
+	clock_control_subsys_t sub_system = (clock_control_subsys_t)&setup;
 	if ((ret = clock_control_on(dev, sub_system)) != 0) {
 		LOG_ERR("Set CLKOUT%d param error!", setup.clkout_nr);
 		return ret;

--- a/samples/drivers/clock_control_litex/src/main.c
+++ b/samples/drivers/clock_control_litex/src/main.c
@@ -66,7 +66,7 @@ int litex_clk_test_getters(const struct device *dev)
 	uint32_t rate;
 	int i;
 
-	clock_control_subsys_t sub_system = (clock_control_subsys_t *)&setup;
+	clock_control_subsys_t sub_system = (clock_control_subsys_t)&setup;
 
 	printf("Getters test\n");
 	for (i = 0; i < NCLKOUT; i++) {
@@ -96,8 +96,8 @@ int litex_clk_test_single(const struct device *dev)
 		.phase = LITEX_TEST_SINGLE_PHASE_VAL2,
 	};
 	uint32_t ret = 0;
-	clock_control_subsys_t sub_system1 = (clock_control_subsys_t *)&setup1;
-	clock_control_subsys_t sub_system2 = (clock_control_subsys_t *)&setup2;
+	clock_control_subsys_t sub_system1 = (clock_control_subsys_t)&setup1;
+	clock_control_subsys_t sub_system2 = (clock_control_subsys_t)&setup2;
 
 	printf("Single test\n");
 	ret = clock_control_on(dev, sub_system1);
@@ -121,7 +121,7 @@ int litex_clk_test_freq(const struct device *dev)
 		.duty = LITEX_TEST_FREQUENCY_DUTY_VAL,
 		.phase = LITEX_TEST_FREQUENCY_PHASE_VAL
 	};
-	clock_control_subsys_t sub_system = (clock_control_subsys_t *)&setup;
+	clock_control_subsys_t sub_system = (clock_control_subsys_t)&setup;
 	uint32_t i, ret = 0;
 
 	printf("Frequency test\n");
@@ -131,7 +131,7 @@ int litex_clk_test_freq(const struct device *dev)
 				i += LITEX_TEST_FREQUENCY_STEP) {
 			setup.clkout_nr = LITEX_CLK_TEST_CLK1;
 			setup.rate = i;
-			sub_system = (clock_control_subsys_t *)&setup;
+			sub_system = (clock_control_subsys_t)&setup;
 			/*
 			 * Don't check for ENOTSUP here because it is expected.
 			 * The reason is that set of possible frequencies for
@@ -159,7 +159,7 @@ int litex_clk_test_freq(const struct device *dev)
 				i -= LITEX_TEST_FREQUENCY_STEP) {
 			setup.clkout_nr = LITEX_CLK_TEST_CLK1;
 			setup.rate = i;
-			sub_system = (clock_control_subsys_t *)&setup;
+			sub_system = (clock_control_subsys_t)&setup;
 			ret = clock_control_on(dev, sub_system);
 			if (ret != 0 && ret != -ENOTSUP) {
 				return ret;
@@ -189,8 +189,8 @@ int litex_clk_test_phase(const struct device *dev)
 		.rate = LITEX_TEST_PHASE_FREQ_VAL,
 		.duty = LITEX_TEST_PHASE_DUTY_VAL
 	};
-	clock_control_subsys_t sub_system1 = (clock_control_subsys_t *)&setup1;
-	clock_control_subsys_t sub_system2 = (clock_control_subsys_t *)&setup2;
+	clock_control_subsys_t sub_system1 = (clock_control_subsys_t)&setup1;
+	clock_control_subsys_t sub_system2 = (clock_control_subsys_t)&setup2;
 	uint32_t ret = 0;
 	int i;
 
@@ -205,7 +205,7 @@ int litex_clk_test_phase(const struct device *dev)
 		for (i = LITEX_TEST_PHASE_MIN; i <= LITEX_TEST_PHASE_MAX;
 				i += LITEX_TEST_PHASE_STEP) {
 			setup2.phase = i;
-			sub_system2 = (clock_control_subsys_t *)&setup2;
+			sub_system2 = (clock_control_subsys_t)&setup2;
 			ret = clock_control_on(dev, sub_system2);
 			if (ret != 0) {
 				return ret;
@@ -232,8 +232,8 @@ int litex_clk_test_duty(const struct device *dev)
 		.duty = 0
 	};
 	uint32_t ret = 0, i;
-	clock_control_subsys_t sub_system1 = (clock_control_subsys_t *)&setup1;
-	clock_control_subsys_t sub_system2 = (clock_control_subsys_t *)&setup2;
+	clock_control_subsys_t sub_system1 = (clock_control_subsys_t)&setup1;
+	clock_control_subsys_t sub_system2 = (clock_control_subsys_t)&setup2;
 
 	ret = clock_control_on(dev, sub_system1);
 	if (ret != 0 && ret != -ENOTSUP) {
@@ -250,13 +250,13 @@ int litex_clk_test_duty(const struct device *dev)
 		for (i = LITEX_TEST_DUTY_MIN; i <= LITEX_TEST_DUTY_MAX;
 				i += LITEX_TEST_DUTY_STEP) {
 			setup1.duty = i;
-			sub_system1 = (clock_control_subsys_t *)&setup1;
+			sub_system1 = (clock_control_subsys_t)&setup1;
 			ret = clock_control_on(dev, sub_system1);
 			if (ret != 0) {
 				return ret;
 			}
 			setup2.duty = 100 - i;
-			sub_system2 = (clock_control_subsys_t *)&setup2;
+			sub_system2 = (clock_control_subsys_t)&setup2;
 			ret = clock_control_on(dev, sub_system2);
 			if (ret != 0) {
 				return ret;
@@ -266,13 +266,13 @@ int litex_clk_test_duty(const struct device *dev)
 		for (i = LITEX_TEST_DUTY_MAX; i > LITEX_TEST_DUTY_MIN;
 				i -= LITEX_TEST_DUTY_STEP) {
 			setup1.duty = i;
-			sub_system1 = (clock_control_subsys_t *)&setup1;
+			sub_system1 = (clock_control_subsys_t)&setup1;
 			ret = clock_control_on(dev, sub_system1);
 			if (ret != 0) {
 				return ret;
 			}
 			setup2.duty = 100 - i;
-			sub_system2 = (clock_control_subsys_t *)&setup2;
+			sub_system2 = (clock_control_subsys_t)&setup2;
 			ret = clock_control_on(dev, sub_system2);
 			if (ret != 0) {
 				return ret;

--- a/soc/arm/st_stm32/common/stm32_backup_sram.c
+++ b/soc/arm/st_stm32/common/stm32_backup_sram.c
@@ -32,7 +32,7 @@ static int stm32_backup_sram_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(clk, (clock_control_subsys_t *)&config->pclken);
+	ret = clock_control_on(clk, (clock_control_subsys_t)&config->pclken);
 	if (ret < 0) {
 		LOG_ERR("Could not initialize backup SRAM clock (%d)", ret);
 		return ret;

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
@@ -719,7 +719,7 @@ static int shi_npcx_enable(const struct device *dev)
 	const struct shi_npcx_config *const config = dev->config;
 	int ret;
 
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)&config->clk_cfg);
+	ret = clock_control_on(clk_dev, (clock_control_subsys_t)&config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on SHI clock fail %d", ret);
 		return ret;
@@ -761,7 +761,7 @@ static int shi_npcx_disable(const struct device *dev)
 		return ret;
 	}
 
-	ret = clock_control_off(clk_dev, (clock_control_subsys_t *)&config->clk_cfg);
+	ret = clock_control_off(clk_dev, (clock_control_subsys_t)&config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn off SHI clock fail %d", ret);
 		return ret;
@@ -778,7 +778,7 @@ static int shi_npcx_init_registers(const struct device *dev)
 	const struct device *clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 
 	/* Turn on shi device clock first */
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)&config->clk_cfg);
+	ret = clock_control_on(clk_dev, (clock_control_subsys_t)&config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on SHI clock fail %d", ret);
 		return ret;


### PR DESCRIPTION
Replace all `(clock_control_subsys_t *)` casts with `(clock_control_subsys_t)` as it is supposed to be used in the clock control API:

```c
typedef void *clock_control_subsys_t;
// ...
typedef void (*clock_control_cb_t)(const struct device *dev,
				   clock_control_subsys_t subsys,
				   void *user_data);
typedef int (*clock_control)(const struct device *dev,
			     clock_control_subsys_t sys);
typedef int (*clock_control_get)(const struct device *dev,
				 clock_control_subsys_t sys,
				 uint32_t *rate);
```

Fixes #56133