### PR TITLE
[RFC] include: adc: add support for batch_mode

### DIFF
--- a/drivers/adc/adc_context.h
+++ b/drivers/adc/adc_context.h
@@ -216,6 +216,10 @@ static inline void adc_context_start_read(struct adc_context *ctx,
 			adc_context_enable_timer(ctx);
 			return;
 		}
+	} else {
+		/* Explicitly overwrite in case previous read contained options */
+		ctx->options = (struct adc_sequence_options){ 0 };
+		ctx->sequence.options = NULL;
 	}
 
 	adc_context_start_sampling(ctx);

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -482,6 +482,16 @@ struct adc_sequence_options {
 	 * is 1 + extra_samplings).
 	 */
 	uint16_t extra_samplings;
+
+	/**
+	 * Sets ADC reading in batch_mode mode. The driver will complete reading
+	 * of all channels and sample required extra_samples as one batch.
+	 * Depending on the driver it may offload as much processing to the silicon
+	 * as possible. For example, if coupled with DMA, the entire read sequence
+	 * can be completed without any interrupts, meaning context switches, except
+	 * for when it's completed.
+	 */
+	bool batch_mode;
 };
 
 /**

--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2023 Nobleo Technology
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -705,6 +706,68 @@ static int test_task_with_interval(void)
 ZTEST(adc_basic, test_adc_sample_with_interval)
 {
 	zassert_true(test_task_with_interval() == TC_PASS);
+}
+
+/*
+ * test_adc_sample_batch_mode
+ */
+static uint8_t test_batch_mode_callback_counter;
+
+static enum adc_action test_task_batch_mode_callback(const struct device *dev,
+						     const struct adc_sequence *sequence,
+						     uint16_t sampling_index)
+{
+	test_batch_mode_callback_counter++;
+	return ADC_ACTION_CONTINUE;
+}
+
+static int test_task_batch_mode(void)
+{
+	int ret;
+	const struct adc_sequence_options options = {
+		.interval_us     = 0,
+		.callback        = test_task_batch_mode_callback,
+		.extra_samplings = 1,  /* Non zero */
+		.batch_mode      = true,
+	};
+	const struct adc_sequence sequence = {
+		.options     = &options,
+#if defined(ADC_2ND_CHANNEL_ID)
+		/* Test with multiple channels if possible */
+		.channels    = BIT(ADC_1ST_CHANNEL_ID) |
+			       BIT(ADC_2ND_CHANNEL_ID),
+#else
+		.channels    = BIT(ADC_1ST_CHANNEL_ID),
+#endif /* defined(ADC_2ND_CHANNEL_ID) */
+		.buffer      = m_sample_buffer,
+		.buffer_size = sizeof(m_sample_buffer),
+		.resolution  = ADC_RESOLUTION,
+	};
+
+	const struct device *adc_dev = init_adc();
+
+	if (!adc_dev) {
+		return TC_FAIL;
+	}
+
+	test_batch_mode_callback_counter = 0;
+	ret = adc_read(adc_dev, &sequence);
+	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
+
+#if defined(ADC_2ND_CHANNEL_ID)
+	check_samples((1 + options.extra_samplings) * 2);
+#else
+	check_samples(1 + options.extra_samplings);
+#endif /* defined(ADC_2ND_CHANNEL_ID) */
+
+	zassert_equal(test_batch_mode_callback_counter, 1);
+
+	return TC_PASS;
+}
+
+ZTEST(adc_basic, test_adc_batch_mode)
+{
+	zassert_true(test_task_batch_mode() == TC_PASS);
 }
 
 /*

--- a/tests/drivers/adc/adc_dma/src/test_adc.c
+++ b/tests/drivers/adc/adc_dma/src/test_adc.c
@@ -477,6 +477,67 @@ ZTEST(adc_dma, test_adc_repeated_samplings)
 }
 
 /*
+ * test_adc_sample_batch_mode
+ */
+static uint8_t test_batch_mode_callback_counter;
+
+static enum adc_action test_task_batch_mode_callback(const struct device *dev,
+						     const struct adc_sequence *sequence,
+						     uint16_t sampling_index)
+{
+	test_batch_mode_callback_counter++;
+	return ADC_ACTION_CONTINUE;
+}
+
+static int test_task_batch_mode(void)
+{
+	int ret;
+	const struct adc_sequence_options options = {
+		.interval_us     = 0,
+		.callback        = test_task_batch_mode_callback,
+		.extra_samplings = 1, /* Non zero */
+		.batch_mode      = true,
+	};
+	const struct adc_sequence sequence = {
+		.options     = &options,
+#if defined(ADC_2ND_CHANNEL_ID)
+		/* Test with multiple channels if possible */
+		.channels    = BIT(ADC_1ST_CHANNEL_ID) |
+			       BIT(ADC_2ND_CHANNEL_ID),
+#else
+		.channels    = BIT(ADC_1ST_CHANNEL_ID),
+#endif /* defined(ADC_2ND_CHANNEL_ID) */
+		.buffer      = m_sample_buffer,
+		.buffer_size = sizeof(m_sample_buffer),
+		.resolution  = ADC_RESOLUTION,
+	};
+
+	const struct device *adc_dev = init_adc();
+
+	if (!adc_dev) {
+		return TC_FAIL;
+	}
+
+	ret = adc_read(adc_dev, &sequence);
+	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
+
+#if defined(ADC_2ND_CHANNEL_ID)
+	check_samples((1 + options.extra_samplings) * 2);
+#else
+	check_samples(1 + options.extra_samplings);
+#endif /* defined(ADC_2ND_CHANNEL_ID) */
+
+	zassert_equal(test_batch_mode_callback_counter, 1);
+
+	return TC_PASS;
+}
+
+ZTEST(adc_dma, test_adc_batch_mode)
+{
+	zassert_true(test_task_batch_mode() == TC_PASS);
+}
+
+/*
  * test_adc_invalid_request
  */
 static int test_task_invalid_request(void)
@@ -495,6 +556,7 @@ static int test_task_invalid_request(void)
 		return TC_FAIL;
 	}
 
+	test_batch_mode_callback_counter = 0;
 	ret = adc_read(adc_dev, &sequence);
 	zassert_not_equal(ret, 0, "adc_read() unexpectedly succeeded");
 


### PR DESCRIPTION
Adds support for `batch_mode` as proposed in https://github.com/zephyrproject-rtos/zephyr/issues/55783. The change is quite minimal, but it allows the driver to have much more control, as it only needs to call `adc_context_on_sampling_done` once all sampling is done. This allows the driver to offload as much processing to the silicon as possible by doing all the samplings, setting the `ctx->sampling_index` to the final correct value, and then calling `adc_context_on_sampling_done`.

This PR also includes two commits which will be dropped later:
- A bugfix that was found which causes tests to fail: https://github.com/zephyrproject-rtos/zephyr/pull/56314
- The function implementation of `batch_mode` in the STM32 driver with an executing unit test. However, this is still WIP as the cleanup after batch mode is not yet successful, and breaks subsequent reads.