### PR TITLE
drivers: kconfig: unify menuconfig title strings

### DIFF
--- a/drivers/adc/Kconfig
+++ b/drivers/adc/Kconfig
@@ -7,7 +7,7 @@
 # ADC options
 #
 menuconfig ADC
-	bool "ADC drivers"
+	bool "Analog-to-Digital Converter (ADC) drivers"
 	# All platforms that implement the ADC driver are now required to
 	# provide relevant DTS entries.
 	help

--- a/drivers/audio/Kconfig
+++ b/drivers/audio/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig AUDIO
-	bool "Support for Audio"
+	bool "Audio drivers"
 	help
 	  Enable support for Audio
 

--- a/drivers/bbram/Kconfig
+++ b/drivers/bbram/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig BBRAM
-	bool "Battery-backed RAM drivers"
+	bool "Battery-backed RAM (BBRAM) drivers"
 	help
 	  Enable BBRAM (battery-backed RAM) driver configuration.
 

--- a/drivers/bluetooth/Kconfig
+++ b/drivers/bluetooth/Kconfig
@@ -10,7 +10,7 @@
 # Controller support is an HCI driver in itself, so these HCI driver
 # options are only applicable if controller support hasn't been enabled.
 menuconfig BT_DRIVERS
-	bool "Bluetooth Drivers"
+	bool "Bluetooth drivers"
 	default y
 	depends on BT && !BT_CTLR
 

--- a/drivers/cache/Kconfig
+++ b/drivers/cache/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig CACHE
-	bool "External cache controllers drivers"
+	bool "External cache controller drivers"
 	default y if CACHE_MANAGEMENT
 	help
 	  Enable support for external cache controllers drivers

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -7,7 +7,7 @@
 # CAN options
 #
 menuconfig CAN
-	bool "CAN Drivers"
+	bool "Controller Area Network (CAN) drivers"
 	help
 	  Enable CAN Driver Configuration
 

--- a/drivers/clock_control/Kconfig
+++ b/drivers/clock_control/Kconfig
@@ -7,7 +7,7 @@
 # Clock controller drivers
 #
 menuconfig CLOCK_CONTROL
-	bool "Hardware clock controller support"
+	bool "Clock controller drivers"
 	help
 	  Enable support for hardware clock controller. Such hardware can
 	  provide clock for other subsystem, and thus can be also used for

--- a/drivers/coredump/Kconfig
+++ b/drivers/coredump/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig COREDUMP_DEVICE
-	bool "Coredump pseudo-device driver"
+	bool "Coredump pseudo-device drivers"
 	help
 	  Enable support for a pseudo-device to help capturing
 	  desired data into core dumps.

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig COUNTER
-	bool "Counter Drivers"
+	bool "Counter drivers"
 	help
 	  Enable support for counter and timer.
 

--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -7,7 +7,7 @@
 # CRYPTO options
 #
 menuconfig CRYPTO
-	bool "Crypto Drivers"
+	bool "Crypto drivers"
 
 if CRYPTO
 

--- a/drivers/dac/Kconfig
+++ b/drivers/dac/Kconfig
@@ -7,7 +7,7 @@
 # DAC options
 #
 menuconfig DAC
-	bool "DAC drivers"
+	bool "Digital-to-Analog Converter (DAC) drivers"
 	help
 	  Enable DAC (Digital to Analog Converter) driver configuration.
 

--- a/drivers/dai/Kconfig
+++ b/drivers/dai/Kconfig
@@ -7,7 +7,7 @@
 # DAI Drivers
 #
 menuconfig DAI
-	bool "DAI drivers"
+	bool "Digital Audio Interface (DAI) drivers"
 	help
 		Enable support for the DAI interface drivers.
 

--- a/drivers/disk/Kconfig
+++ b/drivers/disk/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig DISK_DRIVERS
-	bool "Disk Drivers"
+	bool "Disk drivers"
 	help
 	  Disk Driver configuration
 

--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig DISPLAY
-	bool "Display Drivers"
+	bool "Display controller drivers"
 	help
 	  Enable display drivers
 

--- a/drivers/dma/Kconfig
+++ b/drivers/dma/Kconfig
@@ -7,7 +7,7 @@
 # DMA options
 #
 menuconfig DMA
-	bool "DMA driver Configuration"
+	bool "Direct Memory Access (DMA) drivers"
 
 if DMA
 config DMA_64BIT

--- a/drivers/edac/Kconfig
+++ b/drivers/edac/Kconfig
@@ -4,7 +4,7 @@
 # EDAC configuration options
 
 menuconfig EDAC
-	bool "Error Detection and Correction (EDAC) Drivers"
+	bool "Error Detection and Correction (EDAC) drivers"
 	help
 	  Enable Error Detection and Correction (EDAC) driver.
 

--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig EEPROM
-	bool "EEPROM hardware support"
+	bool "Electrically Erasable Programmable Read-Only Memory (EEPROM) drivers"
 	help
 	  Enable support for EEPROM hardware.
 

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig ENTROPY_GENERATOR
-	bool "Entropy Drivers"
+	bool "Entropy drivers"
 	help
 	  Include entropy drivers in system config.
 

--- a/drivers/espi/Kconfig
+++ b/drivers/espi/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig ESPI
-	bool "ESPI Driver"
+	bool "Enhanced Serial Peripheral Interface (eSPI) bus drivers"
 	help
 	  Enable ESPI Driver.
 

--- a/drivers/ethernet/Kconfig
+++ b/drivers/ethernet/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig ETH_DRIVER
-	bool "Ethernet Drivers"
+	bool "Ethernet drivers"
 	default y
 	depends on NET_L2_ETHERNET
 

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -30,7 +30,7 @@ config FLASH_JESD216
 	 devices to enable building a common support module.
 
 menuconfig FLASH
-	bool "Flash hardware support"
+	bool "Flash drivers"
 	help
 	  Enable support for the flash hardware.
 

--- a/drivers/fpga/Kconfig
+++ b/drivers/fpga/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig FPGA
-	bool "FPGA Drivers"
+	bool "Field-Programmable Gate Array (FPGA) drivers"
 	help
 	  Enable support for FPGA drivers.
 

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig GPIO
-	bool "GPIO Drivers"
+	bool "General-Purpose Input/Output (GPIO) drivers"
 	help
 	  Include GPIO drivers in system config
 

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig HWINFO
-	bool "Hardware Information driver"
+	bool "Hardware Information drivers"
 	help
 	  Enable hwinfo driver.
 

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -7,7 +7,7 @@
 # I2C options
 #
 menuconfig I2C
-	bool "I2C Drivers"
+	bool "Inter-Integrated Circuit (I2C) bus drivers"
 	help
 	  Enable I2C Driver Configuration
 

--- a/drivers/i2s/Kconfig
+++ b/drivers/i2s/Kconfig
@@ -7,7 +7,7 @@
 # I2S Drivers
 #
 menuconfig I2S
-	bool "I2S bus drivers"
+	bool "Inter-IC Sound (I2S) bus drivers"
 	help
 	  Enable support for the I2S (Inter-IC Sound) hardware bus.
 

--- a/drivers/i3c/Kconfig
+++ b/drivers/i3c/Kconfig
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig I3C
-	bool "I3C Drivers"
+	bool "Improved Inter-Integrated Circuit (I3C) bus drivers"
 	help
 	  Enable I3C Driver Configuration
 

--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -7,7 +7,7 @@
 # IEEE 802.15.4 options
 #
 menuconfig IEEE802154
-	bool "IEEE 802.15.4 drivers options"
+	bool "IEEE 802.15.4 drivers"
 	depends on NETWORKING
 	default y if NET_L2_PHY_IEEE802154
 

--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -3,7 +3,7 @@
 
 if INPUT
 
-menu "Input Drivers"
+menu "Input drivers"
 
 source "drivers/input/Kconfig.gpio_keys"
 

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -3,7 +3,7 @@
 # Copyright (c) 2015 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-menu "Interrupt Controllers"
+menu "Interrupt controller drivers"
 
 config ARCV2_INTERRUPT_UNIT
 	bool "ARCv2 Interrupt Unit"

--- a/drivers/ipm/Kconfig
+++ b/drivers/ipm/Kconfig
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig IPM
-	bool "IPM drivers"
+	bool "Inter-Processor Mailbox (IPM) drivers"
 	help
 	  Include interrupt-based inter-processor mailboxes
 	  drivers in system configuration

--- a/drivers/kscan/Kconfig
+++ b/drivers/kscan/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig KSCAN
-	bool "Keyboard Scan Drivers"
+	bool "Keyboard scan drivers"
 	help
 	  Include Keyboard scan drivers in system config.
 

--- a/drivers/led/Kconfig
+++ b/drivers/led/Kconfig
@@ -4,7 +4,7 @@
 # Top-level configuration file for LED drivers.
 
 menuconfig LED
-	bool "LED drivers"
+	bool "Light-Emitting Diode (LED) drivers"
 	help
 	  Include LED drivers in the system configuration.
 

--- a/drivers/led_strip/Kconfig
+++ b/drivers/led_strip/Kconfig
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig LED_STRIP
-	bool "LED strip drivers"
+	bool "Light-Emitting Diode (LED) strip drivers"
 	help
 	  Include LED strip drivers in the system configuration.
 

--- a/drivers/lora/Kconfig
+++ b/drivers/lora/Kconfig
@@ -7,7 +7,7 @@
 # Top-level configuration file for LORA drivers.
 
 menuconfig LORA
-	bool "LoRa support [EXPERIMENTAL]"
+	bool "LoRa drivers [EXPERIMENTAL]"
 	select POLL
 	select EXPERIMENTAL
 	help

--- a/drivers/mbox/Kconfig
+++ b/drivers/mbox/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig MBOX
-	bool "MBOX drivers"
+	bool "Multi-Channel Inter-Processor Mailbox (MBOX) drivers"
 	help
 	  Include multi-channel interrupt-based inter-processor mailboxes
 	  drivers in system configuration

--- a/drivers/mdio/Kconfig
+++ b/drivers/mdio/Kconfig
@@ -7,7 +7,7 @@
 # MDIO options
 #
 menuconfig MDIO
-	bool "MDIO Drivers"
+	bool "Management Data Input/Output (MDIO) drivers"
 	help
 	  Enable MDIO Driver Configuration
 

--- a/drivers/memc/Kconfig
+++ b/drivers/memc/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig MEMC
-	bool "Memory controllers [EXPERIMENTAL]"
+	bool "Memory controller drivers [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
 	  Add support for memory controllers

--- a/drivers/mipi_dsi/Kconfig
+++ b/drivers/mipi_dsi/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig MIPI_DSI
-	bool "MIPI-DSI Host Controllers [EXPERIMENTAL]"
+	bool "MIPI-DSI Host Controller drivers [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
 	  Add support for MIPI-DSI host controllers

--- a/drivers/mm/Kconfig
+++ b/drivers/mm/Kconfig
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig MM_DRV
-	bool "Memory Management Drivers [EXPERIMENTAL]"
+	bool "Memory Management drivers [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	select KERNEL_VM_SUPPORT
 	help

--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig MODEM
-	bool "Modem Drivers"
+	bool "Modem drivers"
 	help
 	  Enable config options for modem drivers.
 

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig NET_DRIVERS
-	bool "Network Drivers"
+	bool "Network drivers"
 
 if NET_DRIVERS
 

--- a/drivers/neural_net/Kconfig
+++ b/drivers/neural_net/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig NEURAL_NET_ACCEL
-	bool "Neural Network Accelerator Drivers"
+	bool "Neural Network Accelerator drivers"
 	help
 	  Enable support for Neural Network Accelerators
 

--- a/drivers/peci/Kconfig
+++ b/drivers/peci/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig PECI
-	bool "PECI Driver"
+	bool "Platform Environment Control Interface (PECI) drivers"
 	help
 	  Include PECI drivers in system config.
 

--- a/drivers/ps2/Kconfig
+++ b/drivers/ps2/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig PS2
-	bool "PS/2 Drivers"
+	bool "PS/2 drivers"
 	help
 	  Include PS/2 drivers in system config.
 

--- a/drivers/ptp_clock/Kconfig
+++ b/drivers/ptp_clock/Kconfig
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config PTP_CLOCK
-	bool "Precision Time Protocol Clock driver support"
+	bool "Precision Time Protocol (PTP) Clock drivers"
 	help
 	  Enable options for Precision Time Protocol Clock drivers.

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig PWM
-	bool "PWM (Pulse Width Modulation) Drivers"
+	bool "Pulse Width Modulation (PWM) drivers"
 	help
 	  Enable config options for PWM drivers.
 

--- a/drivers/retained_mem/Kconfig
+++ b/drivers/retained_mem/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig RETAINED_MEM
-	bool "Retained memory support"
+	bool "Retained memory drivers"
 	help
 	  Enables support for drivers that can retain their data whilst the
 	  device is powered (may be lost in low power states).

--- a/drivers/sdhc/Kconfig
+++ b/drivers/sdhc/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig SDHC
-	bool "SDHC drivers"
+	bool "Secure Digital High Capacity (SDHC) drivers"
 	help
 	  Include drivers for SD host controller
 

--- a/drivers/sensor/Kconfig
+++ b/drivers/sensor/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig SENSOR
-	bool "Sensor Drivers"
+	bool "Sensor drivers"
 	help
 	  Include sensor drivers in system config
 

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig SERIAL
-	bool "Serial Drivers"
+	bool "Serial drivers"
 	help
 	  Enable options for serial drivers.
 

--- a/drivers/smbus/Kconfig
+++ b/drivers/smbus/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig SMBUS
-	bool "SMBus Drivers"
+	bool "System Management Bus (SMBus) drivers"
 	help
 	  Enable SMBus Driver Configuration
 

--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -7,7 +7,7 @@
 # SPI Drivers
 #
 menuconfig SPI
-	bool "SPI hardware bus support"
+	bool "Serial Peripheral Interface (SPI) bus drivers"
 	help
 	  Enable support for the SPI hardware bus.
 

--- a/drivers/syscon/Kconfig
+++ b/drivers/syscon/Kconfig
@@ -7,7 +7,7 @@
 # SYSCON options
 #
 menuconfig SYSCON
-	bool "SYSCON (System Controller) drivers"
+	bool "System Controller (SYSCON) drivers"
 	help
 	  SYSCON (System Controller) drivers. System controller node represents
 	  a register region containing a set of miscellaneous registers. The

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -7,7 +7,7 @@
 
 if SYS_CLOCK_EXISTS
 
-menu "Timer Drivers"
+menu "Timer drivers"
 
 config TIMER_HAS_64BIT_CYCLE_COUNTER
 	bool

--- a/drivers/usb/udc/Kconfig
+++ b/drivers/usb/udc/Kconfig
@@ -3,7 +3,7 @@
 
 
 menuconfig UDC_DRIVER
-	bool "USB device controller driver [EXPERIMENTAL]"
+	bool "USB device controller drivers [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	select NET_BUF
 	help

--- a/drivers/usb/uhc/Kconfig
+++ b/drivers/usb/uhc/Kconfig
@@ -3,7 +3,7 @@
 
 
 menuconfig UHC_DRIVER
-	bool "USB host controller driver [EXPERIMENTAL]"
+	bool "USB host controller drivers [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	select NET_BUF
 	help

--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -7,7 +7,7 @@
 # VIDEO Drivers
 #
 menuconfig VIDEO
-	bool "VIDEO hardware support"
+	bool "Video drivers"
 	help
 	  Enable support for the VIDEO.
 

--- a/drivers/virtualization/Kconfig
+++ b/drivers/virtualization/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig VIRTUALIZATION
-	bool "Virtualization guests drivers"
+	bool "Virtualization guest drivers"
 	help
 	  This contains various drivers meant to support and expose features
 	  when Zephyr is running as a guest in a virtualized or emulated

--- a/drivers/w1/Kconfig
+++ b/drivers/w1/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig W1
 	bool
-	prompt "1-Wire Drivers"
+	prompt "1-Wire bus drivers"
 	select CRC
 	help
 	  Enable 1-Wire Drivers

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig WATCHDOG
-	bool "Watchdog Support"
+	bool "Watchdog drivers"
 	help
 	  Include support for watchdogs.
 

--- a/drivers/wifi/Kconfig
+++ b/drivers/wifi/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig WIFI
-	bool "Wi-Fi Drivers"
+	bool "Wi-Fi drivers"
 
 if WIFI
 


### PR DESCRIPTION
Unify the drivers/*/Kconfig menuconfig title strings to the format `<class> [(acronym)] [bus] drivers`.

Including both the full name of the driver class and an acronym makes menuconfig more user friendly as some of the acronyms are less well-known than others. It also improves Kconfig search, both via menuconfig and via the generated Kconfig documentation.