### PR TITLE
arm64: Break circular dependency on syscall.h

### DIFF
--- a/include/zephyr/arch/arm64/cpu.h
+++ b/include/zephyr/arch/arm64/cpu.h
@@ -7,7 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM64_CPU_H_
 #define ZEPHYR_INCLUDE_ARCH_ARM64_CPU_H_
 
-#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <stdbool.h>
 
 #define DAIFSET_FIQ_BIT		BIT(0)
 #define DAIFSET_IRQ_BIT		BIT(1)


### PR DESCRIPTION
Commit fbf851cdc4d8f0afe60131aea6154945f126d778 is introducing a dependency between util.h and time_units.h.

Now, the problem is that time_units.h is from one side included by arm64/syscall.h (syscall.h -> lib_helpers.h -> cpu.h -> util.h) but on the other side it is including syscall.h (time_units.h -> syscall.h).

Break the dependency at cpu.h level.

Fixes: #56264