### PR TITLE
Define an empty project configuration for the minimal application

### DIFF
--- a/samples/basic/minimal/prj.conf
+++ b/samples/basic/minimal/prj.conf
@@ -1,0 +1,1 @@
+# empty config


### PR DESCRIPTION
![Cmake configuration](https://github.com/zephyrproject-rtos/zephyr/commit/f9d0e3837625bee9c3a58e60b5e6239dae8b26bb) forces projects to define a prj.conf

