### PR TITLE
tests: Bluetooth: Mesh: add bsims test for DFU Client losing all targets

### DIFF
--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_cli_all_targets_lost_on_apply.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_cli_all_targets_lost_on_apply.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test if callback `lost_target` is called on every target failing on Apply step and `ended`
+# callback is called when all targets are lost at this step.
+
+# The test instance sequence must stay as it is due to addressing scheme
+conf=prj_mesh1d1_conf
+overlay=overlay_pst_conf
+RunTest dfu_all_tgts_lost_on_apply \
+	dfu_cli_all_targets_lost_on_apply \
+	dfu_target_fail_on_apply \
+	dfu_target_fail_on_apply \
+	dfu_target_fail_on_apply \
+	-- -argstest targets=3

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_cli_all_targets_lost_on_caps_get.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_cli_all_targets_lost_on_caps_get.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test if callback `lost_target` is called on every target that fails to respond to Caps Get message
+# and `ended` callback is called when all targets are lost at this step.
+
+# The test instance sequence must stay as it is due to addressing scheme
+conf=prj_mesh1d1_conf
+overlay=overlay_pst_conf
+RunTest dfu_all_tgts_lost_on_caps_get \
+	dfu_cli_all_targets_lost_on_caps_get \
+	dfu_target_fail_on_caps_get \
+	dfu_target_fail_on_caps_get \
+	dfu_target_fail_on_caps_get \
+	-- -argstest targets=3

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_cli_all_targets_lost_on_metadata.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_cli_all_targets_lost_on_metadata.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test if callback `lost_target` is called on every target rejects metadata and `ended` callback is
+# called when all targets are lost at this step.
+
+# The test instance sequence must stay as it is due to addressing scheme
+conf=prj_mesh1d1_conf
+overlay=overlay_pst_conf
+RunTest dfu_all_tgts_lost_on_metadata \
+	dfu_cli_all_targets_lost_on_metadata \
+	dfu_target_fail_on_metadata \
+	dfu_target_fail_on_metadata \
+	dfu_target_fail_on_metadata \
+	-- -argstest targets=3

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_cli_all_targets_lost_on_update_get.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_cli_all_targets_lost_on_update_get.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test if callback `lost_target` is called on every target that fails to respond to
+# Firmware Update Get message and `ended` callback is called when all targets are lost at this step.
+
+# The test instance sequence must stay as it is due to addressing scheme
+conf=prj_mesh1d1_conf
+overlay=overlay_pst_conf
+RunTest dfu_all_tgts_lost_on_update_get \
+	dfu_cli_all_targets_lost_on_update_get \
+	dfu_target_fail_on_update_get \
+	dfu_target_fail_on_update_get \
+	dfu_target_fail_on_update_get \
+	-- -argstest targets=3

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_cli_all_targets_lost_on_verify.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_cli_all_targets_lost_on_verify.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test if callback `lost_target` is called on every target failing on Verify step and `ended`
+# callback is called when all targets are lost at this step.
+
+# The test instance sequence must stay as it is due to addressing scheme
+conf=prj_mesh1d1_conf
+overlay=overlay_pst_conf
+RunTest dfu_all_tgts_lost_on_verify \
+	dfu_cli_all_targets_lost_on_verify \
+	dfu_target_fail_on_verify \
+	dfu_target_fail_on_verify \
+	dfu_target_fail_on_verify \
+	-- -argstest targets=3


### PR DESCRIPTION
Test that if all targets are lost because of failing each DFU Transfer step `target_lost` callback is called on every one, and `end` callback is called as procedure aborts.