### PR TITLE
drivers: can: mcux: flexcan: add missing mutex unlock in error path

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -515,7 +515,7 @@ static int mcux_flexcan_add_rx_filter(const struct device *dev,
 	}
 
 	if (alloc == -ENOSPC) {
-		return alloc;
+		goto unlock;
 	}
 
 	mcux_flexcan_can_filter_to_mbconfig(filter, &data->rx_cbs[alloc].mb_config,
@@ -544,6 +544,7 @@ static int mcux_flexcan_add_rx_filter(const struct device *dev,
 		alloc = -ENOSPC;
 	}
 
+unlock:
 	k_mutex_unlock(&data->rx_mutex);
 
 	return alloc;


### PR DESCRIPTION
Add missing mutex unlock to error handling path in `mcux_flexcan_add_rx_filter()`.

Fixes: #56284