### PR TITLE
boards: xtensa: m5stickc_plus: fix baudrate

### DIFF
--- a/boards/xtensa/m5stickc_plus/board.cmake
+++ b/boards/xtensa/m5stickc_plus/board.cmake
@@ -7,3 +7,6 @@ find_program(OPENOCD openocd PATHS ${ESPRESSIF_TOOLCHAIN_PATH}/openocd-esp32/bin
 
 include(${ZEPHYR_BASE}/boards/common/esp32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+
+# the default ESP32 baud rate is not supported
+board_runner_args(esp32 "--esp-baud-rate=1500000")

--- a/boards/xtensa/m5stickc_plus/doc/index.rst
+++ b/boards/xtensa/m5stickc_plus/doc/index.rst
@@ -104,7 +104,7 @@ application.
    :board: m5stickc_plus
    :goals: flash
 
-The baud rate of 921600bps is set by default. If experiencing issues when flashing,
+The default baud rate for the M5StickC PLUS is set to 1500000bps. If experiencing issues when flashing,
 try using different values by using ``--esp-baud-rate <BAUD>`` option during
 ``west flash`` (e.g. ``west flash --esp-baud-rate 115200``).
 


### PR DESCRIPTION
The doc instruction of using `west flash` will not work because the default baudrate for ESP32 flash runner is set to a value not supported by this board.