### PR TITLE
doc: peripherals: unify title strings

### DIFF
--- a/doc/hardware/peripherals/adc.rst
+++ b/doc/hardware/peripherals/adc.rst
@@ -1,7 +1,7 @@
 .. _adc_api:
 
-ADC
-###
+Analog-to-Digital Converter (ADC)
+#################################
 
 Overview
 ********

--- a/doc/hardware/peripherals/audio/dai.rst
+++ b/doc/hardware/peripherals/audio/dai.rst
@@ -1,8 +1,7 @@
 .. _dai_api:
 
-
-DAI
-####
+Digital Audio Interface (DAI)
+#############################
 
 Overview
 ********

--- a/doc/hardware/peripherals/audio/dmic.rst
+++ b/doc/hardware/peripherals/audio/dmic.rst
@@ -1,7 +1,7 @@
 .. _audio_dmic_api:
 
-Audio DMIC
-##########
+Digital Microphone (DMIC)
+#########################
 
 Overview
 ********

--- a/doc/hardware/peripherals/audio/i2s.rst
+++ b/doc/hardware/peripherals/audio/i2s.rst
@@ -1,8 +1,7 @@
 .. _i2s_api:
 
-
-I2S
-####
+Inter-IC Sound (I2S) Bus
+########################
 
 Overview
 ********

--- a/doc/hardware/peripherals/coredump.rst
+++ b/doc/hardware/peripherals/coredump.rst
@@ -1,7 +1,7 @@
 .. _coredump_device_api:
 
 Coredump Device
-####################
+###############
 
 Overview
 ********

--- a/doc/hardware/peripherals/dac.rst
+++ b/doc/hardware/peripherals/dac.rst
@@ -1,7 +1,7 @@
 .. _dac_api:
 
-DAC
-###
+Digital-to-Analog Converter (DAC)
+#################################
 
 Overview
 ********

--- a/doc/hardware/peripherals/display/index.rst
+++ b/doc/hardware/peripherals/display/index.rst
@@ -7,8 +7,6 @@
 Display Interface
 #################
 
-
-
 API Reference
 *************
 

--- a/doc/hardware/peripherals/dma.rst
+++ b/doc/hardware/peripherals/dma.rst
@@ -1,7 +1,7 @@
 .. _dma_api:
 
-DMA
-###
+Direct Memory Access (DMA)
+##########################
 
 Overview
 ********

--- a/doc/hardware/peripherals/eeprom.rst
+++ b/doc/hardware/peripherals/eeprom.rst
@@ -1,7 +1,7 @@
 .. _eeprom_api:
 
-EEPROM
-######
+Electrically Erasable Programmable Read-Only Memory (EEPROM)
+############################################################
 
 Overview
 ********

--- a/doc/hardware/peripherals/espi.rst
+++ b/doc/hardware/peripherals/espi.rst
@@ -1,7 +1,7 @@
 .. _espi_api:
 
-eSPI
-####
+Enhanced Serial Peripheral Interface (eSPI) Bus
+###############################################
 
 Overview
 ********

--- a/doc/hardware/peripherals/gna.rst
+++ b/doc/hardware/peripherals/gna.rst
@@ -1,7 +1,7 @@
 .. _gna_api:
 
-GNA
-###
+Gaussian & Neural Accelerator (GNA)
+###################################
 
 Overview
 ********

--- a/doc/hardware/peripherals/gpio.rst
+++ b/doc/hardware/peripherals/gpio.rst
@@ -1,8 +1,8 @@
 .. _gpio_api:
 
 
-GPIO
-####
+General-Purpose Input/Output (GPIO)
+###################################
 
 Overview
 ********

--- a/doc/hardware/peripherals/i2c.rst
+++ b/doc/hardware/peripherals/i2c.rst
@@ -1,7 +1,7 @@
 .. _i2c_api:
 
-I2C
-####
+Inter-Integrated Circuit (I2C) Bus
+##################################
 
 Overview
 ********

--- a/doc/hardware/peripherals/i3c.rst
+++ b/doc/hardware/peripherals/i3c.rst
@@ -1,7 +1,7 @@
 .. _i3c_api:
 
-I3C
-###
+Improved Inter-Integrated Circuit (I3C) Bus
+###########################################
 
 I3C (Improved Inter-Integrated Circuit) is a two-signal shared
 peripheral interface bus.  Devices on the bus can operate in

--- a/doc/hardware/peripherals/index.rst
+++ b/doc/hardware/peripherals/index.rst
@@ -3,50 +3,53 @@
 Peripherals
 ###########
 
+..
+  Please keep the ToC tree sorted based on the titles of the pages included
+
 .. toctree::
    :maxdepth: 1
 
+   w1.rst
    adc.rst
    audio/index.rst
+   clock_control.rst
    canbus/index.rst
    coredump.rst
    counter.rst
-   clock_control.rst
    dac.rst
-   display/index.rst
    dma.rst
-   edac/index.rst
+   display/index.rst
    eeprom.rst
+   espi.rst
    entropy.rst
+   edac/index.rst
    flash.rst
    fuel_gauge.rst
    gna.rst
    gpio.rst
    hwinfo.rst
    i2c_eeprom_target.rst
-   i2c.rst
    i3c.rst
-   smbus.rst
+   i2c.rst
    ipm.rst
    kscan.rst
    led.rst
+   mdio.rst
+   mipi_dsi.rst
    mbox.rst
-   pwm.rst
-   ps2.rst
    peci.rst
-   regulators.rst
-   retained_mem.rst
-   reset.rst
+   ps2.rst
+   pwm.rst
    rtc.rst
+   regulators.rst
+   reset.rst
+   retained_mem.rst
    sdhc.rst
    sensor.rst
    spi.rst
-   tcpc.rst
+   smbus.rst
    uart.rst
    usbc_vbus.rst
-   mdio.rst
-   watchdog.rst
+   tcpc.rst
    video.rst
-   espi.rst
-   mipi_dsi.rst
-   w1.rst
+   watchdog.rst

--- a/doc/hardware/peripherals/ipm.rst
+++ b/doc/hardware/peripherals/ipm.rst
@@ -1,7 +1,7 @@
 .. _ipm_api:
 
-IPM
-###
+Inter-Processor Mailbox (IPM)
+#############################
 
 Overview
 ********

--- a/doc/hardware/peripherals/kscan.rst
+++ b/doc/hardware/peripherals/kscan.rst
@@ -1,8 +1,8 @@
 .. _kscan_api:
 
 
-KSCAN
-#####
+Keyboard Scan
+#############
 
 Overview
 ********

--- a/doc/hardware/peripherals/led.rst
+++ b/doc/hardware/peripherals/led.rst
@@ -1,7 +1,7 @@
 .. _led_api:
 
-LED
-###
+Light-Emitting Diode (LED)
+##########################
 
 Overview
 ********

--- a/doc/hardware/peripherals/mbox.rst
+++ b/doc/hardware/peripherals/mbox.rst
@@ -1,7 +1,7 @@
 .. _mbox_api:
 
-MBOX
-####
+Multi-Channel Inter-Processor Mailbox (MBOX)
+############################################
 
 Overview
 ********

--- a/doc/hardware/peripherals/mdio.rst
+++ b/doc/hardware/peripherals/mdio.rst
@@ -1,7 +1,7 @@
 .. _mdio_api:
 
-MDIO
-####
+Management Data Input/Output (MDIO)
+###################################
 
 Overview
 ********

--- a/doc/hardware/peripherals/mipi_dsi.rst
+++ b/doc/hardware/peripherals/mipi_dsi.rst
@@ -1,7 +1,7 @@
 .. _mipi_dsi_api:
 
-MIPI-DSI
-########
+MIPI Display Serial Interface (DSI)
+###################################
 
 API Reference
 *************

--- a/doc/hardware/peripherals/peci.rst
+++ b/doc/hardware/peripherals/peci.rst
@@ -1,7 +1,7 @@
 .. _peci_api:
 
-PECI
-####
+Platform Environment Control Interface (PECI)
+#############################################
 
 Overview
 ********

--- a/doc/hardware/peripherals/pwm.rst
+++ b/doc/hardware/peripherals/pwm.rst
@@ -1,7 +1,7 @@
 .. _pwm_api:
 
-PWM
-###
+Pulse Width Modulation (PWM)
+############################
 
 Overview
 ********

--- a/doc/hardware/peripherals/retained_mem.rst
+++ b/doc/hardware/peripherals/retained_mem.rst
@@ -1,6 +1,6 @@
 .. _retained_mem_api:
 
-Retained memory
+Retained Memory
 ###############
 
 Overview

--- a/doc/hardware/peripherals/rtc.rst
+++ b/doc/hardware/peripherals/rtc.rst
@@ -1,7 +1,7 @@
 .. _rtc_api:
 
-RTC
-###
+Real-Time Clock (RTC)
+#####################
 
 Overview
 ********

--- a/doc/hardware/peripherals/sdhc.rst
+++ b/doc/hardware/peripherals/sdhc.rst
@@ -1,8 +1,8 @@
 .. _sdhc_api:
 
 
-SDHC
-####
+Secure Digital High Capacity (SDHC)
+###################################
 
 The SDHC api offers a generic interface for interacting with an SD host
 controller device. It is used by the SD subsystem, and is not intended to be

--- a/doc/hardware/peripherals/smbus.rst
+++ b/doc/hardware/peripherals/smbus.rst
@@ -1,7 +1,7 @@
 .. _smbus_api:
 
-SMBus
-#####
+System Management Bus (SMBus)
+#############################
 
 .. contents::
     :local:

--- a/doc/hardware/peripherals/spi.rst
+++ b/doc/hardware/peripherals/spi.rst
@@ -1,7 +1,7 @@
 .. _spi_api:
 
-SPI
-###
+Serial Peripheral Interface (SPI) Bus
+#####################################
 
 Overview
 ********

--- a/doc/hardware/peripherals/tcpc.rst
+++ b/doc/hardware/peripherals/tcpc.rst
@@ -1,7 +1,7 @@
 .. _tcpc_api:
 
-TCPC
-####
+USB Type-C Port Controller (TCPC)
+#################################
 
 Overview
 ********

--- a/doc/hardware/peripherals/uart.rst
+++ b/doc/hardware/peripherals/uart.rst
@@ -1,7 +1,7 @@
 .. _uart_api:
 
-UART
-####
+Universal Asynchronous Receiver-Transmitter (UART)
+##################################################
 
 Overview
 ********

--- a/doc/hardware/peripherals/video.rst
+++ b/doc/hardware/peripherals/video.rst
@@ -1,6 +1,5 @@
 .. _video_api:
 
-
 Video
 #####
 

--- a/doc/hardware/peripherals/w1.rst
+++ b/doc/hardware/peripherals/w1.rst
@@ -1,7 +1,7 @@
 .. _w1_api:
 
-W1: Dallas 1-Wire Interface
-###########################
+1-Wire Bus
+##########
 
 Overview
 ********


### PR DESCRIPTION
Unify the peripheral documentation title strings to the format "<class> [(acronym)] [Bus]".

Including both the full name of the peripheral class and an acronym makes the documentation more user friendly as some of the acronyms are less well-known than others.

This is a follow-up to #56275.