### PR TITLE
kernel: Remove unused absolute symbols

### DIFF
--- a/arch/arc/core/offsets/offsets.c
+++ b/arch/arc/core/offsets/offsets.c
@@ -79,7 +79,6 @@ GEN_OFFSET_SYM(_isf_t, status32);
 GEN_ABSOLUTE_SYM(___isf_t_SIZEOF, sizeof(_isf_t));
 
 GEN_OFFSET_SYM(_callee_saved_t, sp);
-GEN_ABSOLUTE_SYM(___callee_saved_t_SIZEOF, sizeof(_callee_saved_t));
 
 GEN_OFFSET_SYM(_callee_saved_stack_t, r13);
 GEN_OFFSET_SYM(_callee_saved_stack_t, r14);
@@ -123,7 +122,5 @@ GEN_OFFSET_SYM(_callee_saved_stack_t, dpfp1l);
 #endif
 
 GEN_ABSOLUTE_SYM(___callee_saved_stack_t_SIZEOF, sizeof(_callee_saved_stack_t));
-
-GEN_ABSOLUTE_SYM(_K_THREAD_NO_FLOAT_SIZEOF, sizeof(struct k_thread));
 
 GEN_ABS_SYM_END

--- a/arch/arm/core/offsets/offsets_aarch32.c
+++ b/arch/arm/core/offsets/offsets_aarch32.c
@@ -52,7 +52,6 @@ GEN_OFFSET_SYM(_thread_arch_t, preempt_float);
 
 GEN_OFFSET_SYM(_basic_sf_t, pc);
 GEN_OFFSET_SYM(_basic_sf_t, xpsr);
-GEN_ABSOLUTE_SYM(___basic_sf_t_SIZEOF, sizeof(_basic_sf_t));
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 GEN_OFFSET_SYM(_fpu_sf_t, fpscr);
@@ -72,21 +71,6 @@ GEN_ABSOLUTE_SYM(___extra_esf_info_t_SIZEOF, sizeof(struct __extra_esf_info));
 
 #if defined(CONFIG_THREAD_STACK_INFO)
 GEN_OFFSET_SYM(_thread_stack_info_t, start);
-
-GEN_ABSOLUTE_SYM(___thread_stack_info_t_SIZEOF,
-	 sizeof(struct _thread_stack_info));
-#endif
-
-/*
- * size of the struct k_thread structure sans save area for floating
- * point registers.
- */
-
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-GEN_ABSOLUTE_SYM(_K_THREAD_NO_FLOAT_SIZEOF, sizeof(struct k_thread) -
-					    sizeof(struct _preempt_float));
-#else
-GEN_ABSOLUTE_SYM(_K_THREAD_NO_FLOAT_SIZEOF, sizeof(struct k_thread));
 #endif
 
 /*
@@ -105,8 +89,6 @@ GEN_OFFSET_SYM(_cpu_context_t, primask);
 GEN_OFFSET_SYM(_cpu_context_t, faultmask);
 GEN_OFFSET_SYM(_cpu_context_t, basepri);
 GEN_OFFSET_SYM(_cpu_context_t, control);
-
-GEN_ABSOLUTE_SYM(___cpu_context_t_SIZEOF, sizeof(_cpu_context_t));
 #endif /* CONFIG_PM_S2RAM */
 
 #endif /* _ARM_OFFSETS_INC_ */

--- a/arch/arm64/core/offsets/offsets.c
+++ b/arch/arm64/core/offsets/offsets.c
@@ -40,8 +40,6 @@ GEN_NAMED_OFFSET_SYM(_callee_saved_t, x27, x27_x28);
 GEN_NAMED_OFFSET_SYM(_callee_saved_t, x29, x29_sp_el0);
 GEN_NAMED_OFFSET_SYM(_callee_saved_t, sp_elx, sp_elx_lr);
 
-GEN_ABSOLUTE_SYM(___callee_saved_t_SIZEOF, sizeof(struct _callee_saved));
-
 GEN_NAMED_OFFSET_SYM(_esf_t, spsr, spsr_elr);
 GEN_NAMED_OFFSET_SYM(_esf_t, x18, x18_lr);
 GEN_NAMED_OFFSET_SYM(_esf_t, x16, x16_x17);

--- a/arch/nios2/core/offsets/offsets.c
+++ b/arch/nios2/core/offsets/offsets.c
@@ -64,10 +64,4 @@ GEN_OFFSET_SYM(z_arch_esf_t, estatus);
 GEN_OFFSET_SYM(z_arch_esf_t, instr);
 GEN_ABSOLUTE_SYM(__z_arch_esf_t_SIZEOF, sizeof(z_arch_esf_t));
 
-/*
- * size of the struct k_thread structure sans save area for floating
- * point regs
- */
-GEN_ABSOLUTE_SYM(_K_THREAD_NO_FLOAT_SIZEOF, sizeof(struct k_thread));
-
 GEN_ABS_SYM_END

--- a/arch/sparc/core/offsets/offsets.c
+++ b/arch/sparc/core/offsets/offsets.c
@@ -38,10 +38,4 @@ GEN_OFFSET_SYM(z_arch_esf_t, psr);
 GEN_OFFSET_SYM(z_arch_esf_t, tbr);
 GEN_ABSOLUTE_SYM(__z_arch_esf_t_SIZEOF, STACK_ROUND_UP(sizeof(z_arch_esf_t)));
 
-/*
- * size of the struct k_thread structure sans save area for floating
- * point regs
- */
-GEN_ABSOLUTE_SYM(_K_THREAD_NO_FLOAT_SIZEOF, sizeof(struct k_thread));
-
 GEN_ABS_SYM_END

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -175,16 +175,34 @@ New APIs in this release
 Kernel
 ******
 
+* Removed absolute symbols :c:macro:`___cpu_t_SIZEOF`,
+  :c:macro:`_STRUCT_KERNEL_SIZE`, :c:macro:`K_THREAD_SIZEOF` and
+  :c:macro:`_DEVICE_STRUCT_SIZEOF`
+
 Architectures
 *************
 
-* ARM
+* ARC
+  * Removed absolute symbols :c:macro:`___callee_saved_t_SIZEOF` and
+  :c:macro:`_K_THREAD_NO_FLOAT_SIZEOF`
 
 * ARM
+  * Removed absolute symbols :c:macro:`___basic_sf_t_SIZEOF`,
+  :c:macro:`_K_THREAD_NO_FLOAT_SIZEOF`, :c:macro:`___cpu_context_t_SIZEOF`
+  and :c:macro:`___thread_stack_info_t_SIZEOF`
 
 * ARM64
+  * Removed absolute symbol :c:macro:`___callee_saved_t_SIZEOF`
+
+* NIOS2
+  * Removed absolute symbol :c:macro:`_K_THREAD_NO_FLOAT_SIZEOF`
 
 * RISC-V
+
+* SPARC
+  * Removed absolute symbol :c:macro:`_K_THREAD_NO_FLOAT_SIZEOF`
+
+* X86
 
 * Xtensa
 

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -30,8 +30,6 @@ GEN_OFFSET_SYM(_cpu_t, nested);
 GEN_OFFSET_SYM(_cpu_t, irq_stack);
 GEN_OFFSET_SYM(_cpu_t, arch);
 
-GEN_ABSOLUTE_SYM(___cpu_t_SIZEOF, sizeof(struct _cpu));
-
 GEN_OFFSET_SYM(_kernel_t, cpus);
 
 #if defined(CONFIG_FPU_SHARING)
@@ -54,8 +52,6 @@ GEN_OFFSET_SYM(_ready_q_t, cache);
 GEN_OFFSET_SYM(_kernel_t, current_fp);
 #endif
 
-GEN_ABSOLUTE_SYM(_STRUCT_KERNEL_SIZE, sizeof(struct z_kernel));
-
 GEN_OFFSET_SYM(_thread_base_t, user_options);
 
 GEN_OFFSET_SYM(_thread_t, base);
@@ -74,12 +70,7 @@ GEN_OFFSET_SYM(_thread_t, stack_info);
 GEN_OFFSET_SYM(_thread_t, tls);
 #endif
 
-GEN_ABSOLUTE_SYM(K_THREAD_SIZEOF, sizeof(struct k_thread));
-
 GEN_ABSOLUTE_SYM(__z_interrupt_stack_SIZEOF, sizeof(z_interrupt_stacks[0]));
-
-/* size of the device structure. Used by linker scripts */
-GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_SIZEOF, sizeof(const struct device));
 
 /* member offsets in the device structure. Used in image post-processing */
 GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_HANDLES_OFFSET,


### PR DESCRIPTION
Removes unused absolute symbols (generated via the GEN_ABSOLUTE_SYM() macro) from both common kernel code and architecture specific code.