### PR TITLE
west/sign: Rework of how MCUboot partitions are taken from DT

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -896,6 +896,36 @@ config MCUBOOT_GENERATE_CONFIRMED_IMAGE
 	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
 	  and CONFIG_BUILD_OUTPUT_HEX.
 
+choice
+	prompt "Application assumed MCUboot mode of operation"
+	default MCUBOOT_BOOTLOADER_USES_SWAP
+	help
+	  Informs application build on assumed MCUboot mode of operation.
+	  This is important for validataing application against DT configuration,
+	  which is done by west sign.
+
+config MCUBOOT_BOOTLOADER_USES_SWAP
+	bool "MCUboot has been configured for swap-move operation"
+	help
+	  MCUboot expects slot0_partition and swap1_partition to be present
+	  in DT and application will boot from slot0_partition.
+	  Sizes of both slots will be checked and smaller slot size is used.
+	  The size of slot is reduced by size of single page, which is required
+	  by move algorithm and compared against application binary size extended
+	  by required MCUboot magic.
+	  All the checks are done when signing application to make sure that
+	  resulting binary will fit into image secondary slot and can be actually
+	  swapped to primary slot.
+
+config MCUBOOT_BOOTLOADER_USES_SINGLE
+	bool "MCUboot has been configured for single slot execution"
+	help
+	  MCUboot will only boot slot0_partition placed application and does
+	  not care about other slots. In this mode application is not able
+	  to DFU its own update to secondary slot.
+
+endchoice
+
 endif # BOOTLOADER_MCUBOOT
 
 config BOOTLOADER_ESP_IDF

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -870,6 +870,18 @@ config MCUBOOT_ENCRYPTION_KEY_FILE
 
 	  If left empty, you must encrypt the Zephyr binaries manually.
 
+config MCUBOOT_IMGTOOL_ENCODE_SLOT_ADDRESS
+	bool "Sign image with designated slot address in header"
+	default y if MCUBOOT_BOOTLOADER_USES_DIRECT_XIP
+	help
+	  Image will have offset of application slot partition, as selected by chosen
+	  zephyr,code-partition, within internal flash encoded into header.
+	  This is useful, for example for DFU, to make sure that uploaded
+	  application will be able to boot from designated slot.
+	  Whem MCUboot is in DirectXIP mode this may be used, together with
+	  MCUmgr option CONFIG_MCUMGR_GRP_IMG_REJECT_DIRECT_XIP_MISMATCHED_SLOT
+	  to reject DFU of application that will not boot.
+
 config MCUBOOT_EXTRA_IMGTOOL_ARGS
 	string "Extra arguments to pass to imgtool when signing"
 	default ""

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -924,6 +924,22 @@ config MCUBOOT_BOOTLOADER_USES_SINGLE
 	  not care about other slots. In this mode application is not able
 	  to DFU its own update to secondary slot.
 
+config MCUBOOT_BOOTLOADER_USES_SWAP_SCRATCH
+	bool "MCUboot has been configured for swap-scratch operation"
+	help
+	  MCUboot expects slot0_partition, swap1_partition and scratch_partition
+	  to be present in DT, and application will boot from slot0_partition.
+	  In this mode scratch_partition is used as temporary storage when
+	  MCUboot swaps application from the secondary slot to the primary
+	  slot.
+	  Sizes of both slots will be checked and smaller slot size is used.
+	  The size of slot is against application binary size extended
+	  by required MCUboot magic.
+	  scratch_partition is supposed to have size of largest page that
+	  will be swapped. west sign does not check this to be true, as
+	  information on flash layout can not be pulled from DT and is not
+	  warranted to be uniform across whole device.
+
 endchoice
 
 endif # BOOTLOADER_MCUBOOT

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -940,6 +940,15 @@ config MCUBOOT_BOOTLOADER_USES_SWAP_SCRATCH
 	  information on flash layout can not be pulled from DT and is not
 	  warranted to be uniform across whole device.
 
+config MCUBOOT_BOOTLOADER_USES_DIRECT_XIP
+	bool "MCUboot has been configured for DirectXIP operation"
+	help
+	  MCUboot expects slot0_partition and slot1_partition to exist in DT.
+	  In this mode MCUboot can boot from either partition and will
+	  select one with higher version.
+	  Partitions does not have to be of the same size, although it means
+	  that some application versions may not fit to one of slots.
+
 endchoice
 
 endif # BOOTLOADER_MCUBOOT

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -261,6 +261,10 @@ Build system and infrastructure
   see :ref:`West extending signing <west-extending-signing>` for further
   details.
 
+* west sign now checks for additional Kconfig options allowing it to properly
+  validate device tree configuration against selected MCUboot mode of operation
+  (boot algorithm), before signing application with that mode in mind.
+
 Drivers and Sensors
 *******************
 
@@ -447,6 +451,22 @@ MCUboot
 
 * Added :kconfig:option:`CONFIG_MCUBOOT_CMAKE_WEST_SIGN_PARAMS` that allows to pass arguments to
   west sign when invoked from cmake.
+
+* Added :kconfig:option:`CONFIG_MCUBOOT_BOOTLOADER_USES_SWAP` and :kconfig:option:`CONFIG_MCUBOOT_BOOTLOADER_USES_SINGLEA`
+  that allow to indicate whether application will be built for MCUboot configured for MCUboot with
+  swap-move algorithm or for single application slot. Previously lack of secondary slot was used
+  to detect type of built, and this is left as is to remain compatible with previous behaviour.
+
+* Added :kconfig:option:`CONFIG_MCUBOOT_BOOTLOADER_USES_SWAP_SCRATCH` that should be selected when
+  application is built for MCUboot configured for swap-scratch algorithm.
+
+* Added :kconfig:option:`CONFIG_MCUBOOT_BOOTLOADER_USES_DIRECT_XIP` that should be selected when
+  application is built for MCUboot configured for DirectXIP.
+
+* Added :kconfig:option:`CONFIG_MCUBOOT_IMGTOOL_ENCODE_SLOT_ADDRESS` that makes imgtool encode
+  slot offset application has been built for. MCUmgr can use that offset to reject application
+  that would not boot, because it has been built for different slot then the one MCUboot will
+  try to boot it from.
 
 Storage
 *******

--- a/samples/boards/esp32/flash_encryption/boards/esp32.overlay
+++ b/samples/boards/esp32/flash_encryption/boards/esp32.overlay
@@ -7,3 +7,9 @@
 &flash0 {
 	write-block-size = <32>;
 };
+
+/{
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+	};
+};

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -643,11 +643,13 @@ class ImgtoolSigner(Signer):
         size = 0
         # Legacy behaviour: automatically assume MCUboot in single application
         # mode if slot1_partition does not exist
-        if not mcuboot_dtconf.get_partition('slot1_partition'):
+        if not mcuboot_dtconf.get_partition('slot1_partition') or \
+           build_conf.getboolean('CONFIG_MCUBOOT_BOOTLOADER_USES_SINGLE'):
             log.inf("slot1_partition not defined, assuming MCUboot configured for"
                     " single slot operation")
             align, addr, size = self.mcuboot_single_validate(mcuboot_dtconf, bin_size, self.quiet)
         else:
+            # Although there is CONFIG_MCUBOOT_BOOTLOADER_USES_SWAP, it is not checked as
             # swap-move algorithm is assumed by default.
             align, addr, size = self.mcuboot_swap_validate(mcuboot_dtconf, bin_size, self.quiet)
 

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -825,6 +825,11 @@ class ImgtoolSigner(Signer):
                                '--align', str(align),
                                '--header-size', str(vtoff),
                                '--slot-size', str(size)]
+
+        if build_conf.getboolean('CONFIG_MCUBOOT_IMGTOOL_ENCODE_SLOT_ADDRESS'):
+            log.inf(f"Encoding application partition address {addr} into MCUboot header")
+            sign_base.extend(['--rom-fixed', str(addr)])
+
         sign_base.extend(args.tool_args)
 
         if not args.quiet:


### PR DESCRIPTION
The commit moves from using chosen `zephyr,flash` to flash device where chosen `zephyr,code-partition` is placed. There has been special class created MCUbootDTConfig that is helper class for accessing MCUboot type partitions. The class incorporates edt_flash_node logic, and the method has been removed.

Object of the MCUbootDTConfig class is now used by mcuboot_swap_validate method, which replaces edt_flash_params, that is supposed to validate partition layout for swap configuration. mcuboot_swap_validate extends edt_flash_params with additional checks and warning logs.
The mcuboot_swap_validate maintains compatibility with legacy behaviour where single slot MCUboot configuration is assumed if slot1_partition is not found.

**Note**: This is base work for separating current validation into swap-move and single application mode, and addition of DirectXIP and swap-scratch.

- [x] Documentation is missing
- [x] Commit with binary file validation against image slot size
- [x]  Separate swap-move and single application mode
- [x]  Support for swap-scratch
- [x]  Support for DirectXIP
- [x] Release notes 

**CONTENTS**
The PR consists of commits that:
 1) rewrite swap/single slot validation
 2) add application size validation against slot size
 3) split swap/single validation to separate swap and separate single slot validation
 4) add esp32 overlay required 
 5) Kconfig options to let application know what mode of operation has been set for MCUboot
 6) swap-scratch validation support

The sing script commits can be squashed, they are separated to make it easier to understand steps taken.

Fixes #54373.