### PR TITLE
drivers/reset: Add MEC172x peripheral reset driver

### DIFF
--- a/drivers/reset/Kconfig.xec
+++ b/drivers/reset/Kconfig.xec
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 Silicom Connectivity Solutions, Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+config RESET_XEC
+	bool "XEC Reset Controller Driver"
+	default y
+	depends on DT_HAS_MICROCHIP_XEC_PCR_RCTL_ENABLED

--- a/drivers/reset/reset_xec.c
+++ b/drivers/reset/reset_xec.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 Silicom Connectivity Solutions, Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT microchip_xec_pcr_rctl
+
+#include <zephyr/arch/cpu.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/reset.h>
+
+#include <zephyr/logging/log.h>
+#define XEC_RESET_SET_OFFSET(id) (((id) >> 5U) & 0xFFFU)
+#define XEC_RESET_REG_BIT(id)	   ((id)&0x1FU)
+#define XEC_RESET_LOCK_OFFSET	0x84
+#define XEC_RESET_UNLOCK_VAL	0xA6382D4C
+#define XEC_RESET_LOCK_VAL	0xA6382D4D
+
+LOG_MODULE_REGISTER(reset_xec, 4);
+
+struct reset_xec_config {
+	uintptr_t base;
+};
+
+static int reset_xec_status(const struct device *dev, uint32_t id,
+			      uint8_t *status)
+{
+	return -ENOSYS;
+}
+
+static int reset_xec_line_assert(const struct device *dev, uint32_t id)
+{
+	const struct reset_xec_config *config = dev->config;
+
+	sys_write32(XEC_RESET_UNLOCK_VAL,
+		    config->base + XEC_RESET_LOCK_OFFSET);
+	sys_write32(BIT(XEC_RESET_REG_BIT(id)),
+		    config->base + XEC_RESET_SET_OFFSET(id));
+	sys_write32(XEC_RESET_LOCK_VAL,
+		    config->base + XEC_RESET_LOCK_OFFSET);
+
+	return 0;
+}
+
+static int reset_xec_line_deassert(const struct device *dev, uint32_t id)
+{
+	return -ENOSYS;
+}
+
+static int reset_xec_line_toggle(const struct device *dev, uint32_t id)
+{
+	reset_xec_line_assert(dev, id);
+
+	return 0;
+}
+
+static int reset_xec_init(const struct device *dev)
+{
+	return 0;
+}
+
+static const struct reset_driver_api reset_xec_driver_api = {
+	.status = reset_xec_status,
+	.line_assert = reset_xec_line_assert,
+	.line_deassert = reset_xec_line_deassert,
+	.line_toggle = reset_xec_line_toggle,
+};
+
+static const struct reset_xec_config reset_xec_config = {
+	.base = DT_REG_ADDR(DT_INST_PARENT(0)),
+};
+
+DEVICE_DT_INST_DEFINE(0, reset_xec_init, NULL, NULL, &reset_xec_config,
+		      PRE_KERNEL_1, CONFIG_RESET_INIT_PRIORITY,
+		      &reset_xec_driver_api);

--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -60,6 +60,11 @@
 			pinctrl-0 = <&clk_32khz_in_gpio165>;
 			pinctrl-names = "default";
 			#clock-cells = <3>;
+
+			rctl: reset-controller {
+				compatible = "microchip,xec-pcr-rctl";
+				#reset-cells = <1>;
+			};
 		};
 		ecia: ecia@4000e000 {
 			compatible = "microchip,xec-ecia";

--- a/dts/bindings/reset/microchip,xec-pcr-rctl.yaml
+++ b/dts/bindings/reset/microchip,xec-pcr-rctl.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2023, Silicom Connectivity Solutions, Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Microchip XEC Reset Control (RC) node.
+  This node is in charge of reset control APB (Advanced Peripheral) bus domains.
+
+  To specify the reset line in a peripheral, the standard resets property needs
+  to be used, e.g.:
+
+    pwm1: pwm@xxx {
+        ...
+        /* Cell contains information about RC register offset and bit */
+        resets = <&rctl XEC_RESET(1, 20U)>;
+        ...
+    };
+
+  RC reset cells are available in
+  include/zephyr/dts-bindings/reset/mec{soc_family}_reset.h header files.
+
+compatible: "microchip,xec-pcr-rctl"
+
+include: [reset-controller.yaml, base.yaml]
+
+properties:
+  "#reset-cells":
+    const: 1
+
+reset-cells:
+  - id

--- a/include/zephyr/dt-bindings/reset/mec172x_reset.h
+++ b/include/zephyr/dt-bindings/reset/mec172x_reset.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Silicom Connectivity Solutions, Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_MEC172X_RESET_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_MEC172X_RESET_H_
+
+#include "xec-common.h"
+
+/* RC bus reset register offset */
+#define XEC_PCR_PERIPH_RST0  0x70
+#define XEC_PCR_PERIPH_RST1  0x74
+#define XEC_PCR_PERIPH_RST2  0x78
+#define XEC_PCR_PERIPH_RST3  0x7C
+#define XEC_PCR_PERIPH_RST4  0x80
+
+/* I2C resets */
+#define MEC172X_RESET_I2C0	XEC_RESET(1, 10U)
+#define MEC172X_RESET_I2C1	XEC_RESET(3, 13U)
+#define MEC172X_RESET_I2C2	XEC_RESET(3, 14U)
+#define MEC172X_RESET_I2C3	XEC_RESET(3, 15U)
+#define MEC172X_RESET_I2C4	XEC_RESET(3, 20U)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_MEC172X_RESET_H_ */

--- a/include/zephyr/dt-bindings/reset/xec-common.h
+++ b/include/zephyr/dt-bindings/reset/xec-common.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Silicom Connectivity Solutions, Ltd
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESET_XEC_RESET_COMMON_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_RESET_XEC_RESET_COMMON_H_
+
+/**
+ * Pack RC register offset and bit in one 32-bit value.
+ *
+ * 5 LSBs are used to keep bit number in 32-bit RC register.
+ * Next 12 bits are used to keep RC register offset.
+ * Remaining bits are unused.
+ *
+ * @param reg XEC reg name (expands to XEC_PCR_PERIPH_RST{reg})
+ * @param bit Reset bit
+ */
+#define XEC_RESET(reg, bit) (((XEC_PCR_PERIPH_RST##reg) << 5U) | (bit))
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESET_XEC_RESET_COMMON_H_ */


### PR DESCRIPTION
Individual IP blocks in MEC172x SoC can be reset independently with an internal reset controller in the PCR block.  Resets may not be required for any particular block but this driver allows this functionality to be included easily if necessary.