### PR TITLE
Add dietemp stm32l1 config

### DIFF
--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -41,6 +41,7 @@
 		sw0 = &user_button;
 		eeprom-0 = &eeprom;
 		watchdog0 = &iwdg;
+		die-temp0 = &die_temp;
 	};
 };
 


### PR DESCRIPTION
Adding die-temp0 aliases for stm32l1.dtsi.
The die_temp_polling sample uses this alias
This PR verified with NUCLEO-L152RE