### PR TITLE
doc: device_mgmt: smp_groups: smp_group_1: Add upload hash note

### DIFF
--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -113,7 +113,7 @@ CBOR data of successful response:
                 (str,opt)"image"        : (int)
                 (str)"slot"             : (int)
                 (str)"version"          : (str)
-                (str)"hash"             : (byte str)
+                (str,opt*)"hash"        : (byte str)
                 (str,opt)"bootable"     : (bool)
                 (str,opt)"pending"      : (bool)
                 (str,opt)"confirmed"    : (bool)
@@ -156,7 +156,13 @@ where:
     |                       | the whole file, it is the field in the MCUboot    |
     |                       | TLV section that contains a hash of the data      |
     |                       | which is used for signature verification          |
-    |                       | purposes.                                         |
+    |                       | purposes. This field is optional but only         |
+    |                       | optional when using MCUboot's serial recovery     |
+    |                       | feature with one pair of image slots, Kconfig     |
+    |                       | :kconfig:option:`CONFIG_BOOT_SERIAL_IMG_GRP_HASH` |
+    |                       | can be disabled to remove support for hashes in   |
+    |                       | this configuration. MCUmgr in applications must   |
+    |                       | support sending hashes.                           |
     |                       |                                                   |
     |                       | .. note::                                         |
     |                       |    See ``IMAGE_TLV_SHA256`` in the MCUboot image  |

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -603,6 +603,7 @@ flagged.
                               # visible to compliance.
         "BOOT_UPGRADE_ONLY", # Used in example adjusting MCUboot config, but
                              # symbol is defined in MCUboot itself.
+        "BOOT_SERIAL_IMG_GRP_HASH", # Used in documentation
         "CDC_ACM_PORT_NAME_",
         "CLOCK_STM32_SYSCLK_SRC_",
         "CMU",


### PR DESCRIPTION
    Adds a note that the upload response hash is partially
    optionally from the point of view of MCUboot's serial recovery.

Fixes #54064