### PR TITLE
kconfig,toolchain: add an option for compiler save-temps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,11 @@ zephyr_compile_options($<TARGET_PROPERTY:compiler,no_common>)
 # @Intent: Set compiler specific flag for production of debug information
 zephyr_compile_options($<TARGET_PROPERTY:compiler,debug>)
 
+if(CONFIG_COMPILER_SAVE_TEMPS)
+  # @Intent: Set compiler specific flag for saving temporary object files
+  zephyr_compile_options($<TARGET_PROPERTY:compiler,save_temps>)
+endif()
+
 if(CONFIG_COMPILER_COLOR_DIAGNOSTICS)
 # @Intent: Set compiler specific flag for diagnostic messages
 zephyr_compile_options($<TARGET_PROPERTY:compiler,diagnostic>)

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -370,6 +370,12 @@ config COMPILER_WARNINGS_AS_ERRORS
 	help
 	  Turn on "warning as error" toolchain flags
 
+config COMPILER_SAVE_TEMPS
+	bool "Save temporary object files"
+	help
+	  Instruct the compiler to save the temporary intermediate files
+	  permanently. These can be useful for troubleshooting build issues.
+
 config COMPILER_COLOR_DIAGNOSTICS
 	bool "Colored diagnostics"
 	default y

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -20,6 +20,9 @@ set_property(TARGET compiler PROPERTY coverage --coverage -fno-inline)
 # clang flag for colourful diagnostic messages
 set_compiler_property(PROPERTY diagnostic -fcolor-diagnostics)
 
+# clang flag to save temporary object files
+set_compiler_property(PROPERTY save_temps -save-temps)
+
 #######################################################
 # This section covers flags related to warning levels #
 #######################################################

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -103,6 +103,9 @@ set_compiler_property(PROPERTY freestanding)
 # Flag to include debugging symbol in compilation
 set_compiler_property(PROPERTY debug)
 
+# Flags to save temporary object files
+set_compiler_property(PROPERTY save_temps)
+
 set_compiler_property(PROPERTY no_common)
 
 # Flags for imacros. The specific header must be appended by user.

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -180,6 +180,9 @@ check_set_compiler_property(PROPERTY freestanding -ffreestanding)
 # Flag to enable debugging
 set_compiler_property(PROPERTY debug -g)
 
+# Flags to save temporary object files
+set_compiler_property(PROPERTY save_temps -save-temps=obj)
+
 # GCC 11 by default emits DWARF version 5 which cannot be parsed by
 # pyelftools. Can be removed once pyelftools supports v5.
 check_set_compiler_property(APPEND PROPERTY debug -gdwarf-4)

--- a/doc/build/dts/troubleshooting.rst
+++ b/doc/build/dts/troubleshooting.rst
@@ -82,13 +82,13 @@ And if you're trying to **set** that property in a devicetree overlay:
 Look at the preprocessor output
 *******************************
 
-To save preprocessor output when using GCC-based toolchains, add
-``-save-temps=obj`` to the ``EXTRA_CFLAGS`` CMake variable. For example, to
-build :ref:`hello_world` with west with this option set, use:
+To save preprocessor output files, enable the
+:kconfig:option:`CONFIG_COMPILER_SAVE_TEMPS` option. For example, to build
+:ref:`hello_world` with west with this option set, use:
 
 .. code-block:: sh
 
-   west build -b BOARD samples/hello_world -- -DEXTRA_CFLAGS=-save-temps=obj
+   west build -b BOARD samples/hello_world -- -DCONFIG_COMPILER_SAVE_TEMPS=y
 
 This will create a preprocessor output file named :file:`foo.c.i` in the build
 directory for each source file :file:`foo.c`.


### PR DESCRIPTION
Hi, adding a Kconfig option for save-temps. I think this option is used a lot and makes sense to have it with the other compiler options. What do you think?