### PR TITLE
drivers: adc: adc_context: fix bug where options aren't cleaned

### DIFF
--- a/drivers/adc/adc_context.h
+++ b/drivers/adc/adc_context.h
@@ -216,6 +216,10 @@ static inline void adc_context_start_read(struct adc_context *ctx,
 			adc_context_enable_timer(ctx);
 			return;
 		}
+	} else {
+		/* Explicitly overwrite in case previous read contained options */
+		ctx->options = (struct adc_sequence_options){ 0 };
+		ctx->sequence.options = NULL;
 	}
 
 	adc_context_start_sampling(ctx);


### PR DESCRIPTION
This fixes the case when a read without options is executed after a read was done with options. In that case the context would erroniously retain the previous options, along with the set values. This commit explicitly resets the options contained in the context.