### PR TITLE
Bluetooth: Mesh: Link Close without success should fail NPPI procedure

### DIFF
--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -405,7 +405,7 @@ static void prov_link_closed(const struct prov_bearer *bearer, void *cb_data,
 	LOG_DBG("%u", reason);
 
 	if (bt_mesh_prov_link.role->link_closed) {
-		bt_mesh_prov_link.role->link_closed();
+		bt_mesh_prov_link.role->link_closed(reason);
 	}
 
 	if (bt_mesh_prov->link_close) {

--- a/subsys/bluetooth/mesh/prov.h
+++ b/subsys/bluetooth/mesh/prov.h
@@ -105,7 +105,7 @@ enum {
 struct bt_mesh_prov_role {
 	void (*link_opened)(void);
 
-	void (*link_closed)(void);
+	void (*link_closed)(enum prov_bearer_link_status status);
 
 	void (*error)(uint8_t reason);
 

--- a/subsys/bluetooth/mesh/prov_device.c
+++ b/subsys/bluetooth/mesh/prov_device.c
@@ -688,11 +688,12 @@ static void local_input_complete(void)
 	}
 }
 
-static void prov_link_closed(void)
+static void prov_link_closed(enum prov_bearer_link_status status)
 {
 	if (IS_ENABLED(CONFIG_BT_MESH_RPR_SRV) &&
 	    atomic_test_bit(bt_mesh_prov_link.flags, REPROVISION)) {
-		if (atomic_test_bit(bt_mesh_prov_link.flags, COMPLETE)) {
+		if (atomic_test_bit(bt_mesh_prov_link.flags, COMPLETE) &&
+		    status == PROV_BEARER_LINK_STATUS_SUCCESS) {
 			reprovision_complete();
 		} else {
 			reprovision_fail();

--- a/subsys/bluetooth/mesh/provisioner.c
+++ b/subsys/bluetooth/mesh/provisioner.c
@@ -730,7 +730,7 @@ static void local_input_complete(void)
 	}
 }
 
-static void prov_link_closed(void)
+static void prov_link_closed(enum prov_bearer_link_status status)
 {
 	LOG_DBG("");
 	if (atomic_test_bit(bt_mesh_prov_link.flags, COMPLETE)) {


### PR DESCRIPTION
When we receive `RPR_OP_LINK_CLOSE` message with reason other than `SUCCESS` we should fail NPPI refresh procedure, not complete it. Dropping `COMPLETE` flag will result in calling `reprovision_fail` in `prov_link_closed`, not `reprovision_complete`.