### PR TITLE
bluetooth: host: Fix checking if LTK is present

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2063,6 +2063,10 @@ bool bt_conn_ltk_present(const struct bt_conn *conn)
 {
 	const struct bt_keys *keys = conn->le.keys;
 
+	if (!keys) {
+		keys = bt_keys_find_addr(conn->id, &conn->le.dst);
+	}
+
 	if (keys) {
 		if (conn->role == BT_HCI_ROLE_CENTRAL) {
 			return keys->keys & (BT_KEYS_LTK_P256 | BT_KEYS_PERIPH_LTK);


### PR DESCRIPTION
conn->le.keys are set on-demand when actual security action happens and it is possible that permission check needs to happen before those.

This fix regression in following qualification test cases:
GAP/SEC/AUT/BV-23-C
L2CAP/LE/CFC/BV-25-C
L2CAP/ECFC/BV-32-C