### PR TITLE
tests: kernel: timer_behavior: Decrease tick rate for nRF

### DIFF
--- a/tests/kernel/timer/timer_behavior/Kconfig
+++ b/tests/kernel/timer/timer_behavior/Kconfig
@@ -3,6 +3,9 @@
 
 mainmenu "Timer Behavior Test"
 
+config SYS_CLOCK_TICKS_PER_SEC
+	default 8192 if NRF_RTC_TIMER && TICKLESS_KERNEL
+
 source "Kconfig.zephyr"
 
 config TIMER_TEST_SAMPLES


### PR DESCRIPTION
Nordic targets use 24-bit RTC peripheral for system clock. Nordic system clock timeout implementation relies on RTC CC (capture compare) when the timeout is in future. Nordic system clock driver allows setting alarm only to 3 or more counts from current counter value due to silicon limitation (to ensure that CC event triggers before counter overflow).

RTC CC limitation does not have much impact on normal applications where there is no need to schedule such short timeouts, but is problematic in a timer test that expects being able to repeatedly schedule timeouts on subsequent ticks.

Reduce system tick rate to 8192 on nRF targets to allow setting CC to the very next tick. With system tick rate being 4 times less than the hardware tick rate, it is always possible to schedule timeout to happen in the next tick because ticks are 4 counts apart, i.e. current timer value + 3 never runs past the next tick.

Fixes: #54211