### PR TITLE
Bluetooth: Logging: Remove `BT_DEBUG`

### DIFF
--- a/subsys/bluetooth/Kconfig.logging
+++ b/subsys/bluetooth/Kconfig.logging
@@ -10,7 +10,6 @@ menuconfig BT_LOG
 	imply LOG_FUNC_NAME_PREFIX_WRN
 	imply LOG_FUNC_NAME_PREFIX_ERR
 	imply LOG_FUNC_NAME_PREFIX_DBG
-	select BT_DEBUG
 	select BT_LOG_LEGACY
 
 if BT_LOG
@@ -323,7 +322,6 @@ config BT_DEBUG_GATT
 config BT_DEBUG_L2CAP
 	bool "[DEPRECATED] Bluetooth L2CAP debug"
 	select DEPRECATED
-	depends on BT_DEBUG
 	help
 	  This option enables debug support for the Bluetooth
 	  L2ACP layer.
@@ -451,7 +449,6 @@ menu "[DEPRECATED] Mesh"
 config BT_MESH_DEBUG
 	bool "[DEPRECATED] Debug logs"
 	select DEPRECATED
-	depends on BT_DEBUG
 	help
 	  Use this option to enable debug logs for the Bluetooth
 	  Mesh functionality.

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -282,10 +282,6 @@ config BT_ASSERT_PANIC
 
 endif # BT_ASSERT
 
-config BT_DEBUG
-	# Hidden option to make the conditions more intuitive
-	bool
-
 config BT_MONITOR
 	bool
 
@@ -301,7 +297,6 @@ config BT_DEBUG_NONE
 config BT_DEBUG_LOG
 	bool "[DEPRECATED] Normal printf-style to console"
 	select DEPRECATED
-	select BT_DEBUG
 	select LOG
 	imply LOG_FUNC_NAME_PREFIX_INF
 	imply LOG_FUNC_NAME_PREFIX_WRN
@@ -312,7 +307,6 @@ config BT_DEBUG_LOG
 
 config BT_DEBUG_MONITOR_UART
 	bool "Monitor protocol over UART"
-	select BT_DEBUG
 	select LOG
 	select CONSOLE_HAS_DRIVER
 	select BT_MONITOR
@@ -332,7 +326,6 @@ config BT_DEBUG_MONITOR_RTT
 	bool "Monitor protocol over RTT"
 	depends on USE_SEGGER_RTT
 	depends on SEGGER_RTT_MAX_NUM_UP_BUFFERS >= 2
-	select BT_DEBUG
 	select LOG
 	select CONSOLE_HAS_DRIVER
 	select BT_MONITOR

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -926,8 +926,6 @@ config BT_PER_ADV_SYNC_BUF_SIZE
 	  than this buffer size, then the data will be discarded.
 	  Unfragmented reports are forwarded as they are received.
 
-if BT_DEBUG
-
 config BT_DEBUG_ISO_DATA
 	bool "ISO channel data debug"
 	depends on BT_ISO_LOG_LEVEL_DBG
@@ -950,8 +948,6 @@ config BT_SMP_FORCE_BREDR
 	  This option enables SMP over BR/EDR even if controller is not
 	  supporting BR/EDR Secure Connections. This option is solely for
 	  testing and should never be enabled on production devices.
-
-endif # BT_DEBUG
 
 config BT_LOG_SNIFFER_INFO
 	bool "Bluetooth log information for sniffer"

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3175,7 +3175,7 @@ static int set_event_mask(void)
 	return bt_hci_cmd_send_sync(BT_HCI_OP_SET_EVENT_MASK, buf, NULL);
 }
 
-#if defined(CONFIG_BT_DEBUG)
+#if defined(CONFIG_BT_HCI_CORE_LOG_LEVEL_INF)
 static const char *ver_str(uint8_t ver)
 {
 	const char * const str[] = {
@@ -3234,10 +3234,10 @@ static void bt_dev_show_info(void)
 static inline void bt_dev_show_info(void)
 {
 }
-#endif /* CONFIG_BT_DEBUG */
+#endif /* CONFIG_BT_HCI_CORE_LOG_LEVEL_INF */
 
 #if defined(CONFIG_BT_HCI_VS_EXT)
-#if defined(CONFIG_BT_DEBUG)
+#if defined(CONFIG_BT_HCI_CORE_LOG_LEVEL_INF)
 static const char *vs_hw_platform(uint16_t platform)
 {
 	static const char * const plat_str[] = {
@@ -3283,7 +3283,7 @@ static const char *vs_fw_variant(uint8_t variant)
 
 	return "unknown";
 }
-#endif /* CONFIG_BT_DEBUG */
+#endif /* CONFIG_BT_HCI_CORE_LOG_LEVEL_INF */
 
 static void hci_vs_init(void)
 {
@@ -3323,7 +3323,7 @@ static void hci_vs_init(void)
 		return;
 	}
 
-#if defined(CONFIG_BT_DEBUG)
+#if defined(CONFIG_BT_HCI_CORE_LOG_LEVEL_INF)
 	rp.info = (void *)rsp->data;
 	LOG_INF("HW Platform: %s (0x%04x)", vs_hw_platform(sys_le16_to_cpu(rp.info->hw_platform)),
 		sys_le16_to_cpu(rp.info->hw_platform));
@@ -3334,7 +3334,7 @@ static void hci_vs_init(void)
 	LOG_INF("Firmware: %s (0x%02x) Version %u.%u Build %u", vs_fw_variant(rp.info->fw_variant),
 		rp.info->fw_variant, rp.info->fw_version, sys_le16_to_cpu(rp.info->fw_revision),
 		sys_le32_to_cpu(rp.info->fw_build));
-#endif /* CONFIG_BT_DEBUG */
+#endif /* CONFIG_BT_HCI_CORE_LOG_LEVEL_INF */
 
 	net_buf_unref(rsp);
 

--- a/subsys/bluetooth/mesh/prov_device.c
+++ b/subsys/bluetooth/mesh/prov_device.c
@@ -742,7 +742,7 @@ int bt_mesh_prov_enable(bt_mesh_prov_bearer_t bearers)
 		return -EALREADY;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_DEBUG)) {
+	if (IS_ENABLED(CONFIG_BT_MESH_PROV_DEVICE_LOG_LEVEL_INF)) {
 		struct bt_uuid_128 uuid = { .uuid = { BT_UUID_TYPE_128 } };
 
 		memcpy(uuid.val, bt_mesh_prov->uuid, 16);


### PR DESCRIPTION
Remove Kconfig symbol `BT_DEBUG`. It was not useful anymore with the previous logging updates.

Replace it, where it was used, by the file local debug symbol.