### PR TITLE
Bluetooth: audio: csis: Fix Big Endianness for RSI generation

### DIFF
--- a/include/zephyr/bluetooth/audio/csip.h
+++ b/include/zephyr/bluetooth/audio/csip.h
@@ -43,7 +43,7 @@ extern "C" {
 #define BT_CSIP_READ_SIRK_REQ_RSP_OOB_ONLY      0x03
 
 /** Size of the Set Identification Resolving Key (SIRK) */
-#define BT_CSIP_SET_SIRK_SIZE 16
+#define BT_CSIP_SET_SIRK_SIZE                   16
 
 /** Size of the Resolvable Set Identifier (RSI) */
 #define BT_CSIP_RSI_SIZE                        6
@@ -199,7 +199,7 @@ void bt_csip_set_member_print_sirk(const struct bt_csip_set_member_svc_inst *svc
  * This will generate RSI for given @p svc_inst instance.
  *
  * @param svc_inst  Pointer to the Coordinated Set Identification Service.
- * @param rsi       Pointer to the 6-octet newly generated RSI data.
+ * @param rsi       Pointer to the 6-octet newly generated RSI data in little-endian.
  *
  * @return int		0 if on success, errno on error.
  */

--- a/subsys/bluetooth/audio/csip_crypto.h
+++ b/subsys/bluetooth/audio/csip_crypto.h
@@ -12,6 +12,8 @@
 
 #define BT_CSIP_CRYPTO_KEY_SIZE   16
 #define BT_CSIP_CRYPTO_SALT_SIZE  16
+#define BT_CSIP_CRYPTO_PRAND_SIZE 3
+#define BT_CSIP_CRYPTO_HASH_SIZE  3
 
 /**
  * @brief Private Set Unique identifier hash function sih.
@@ -20,13 +22,14 @@
  * used in RSIs - Used by the Coordinated Set Identification service and
  * profile.
  *
- * @param sirk The 16-byte SIRK
- * @param r 3 byte random value
- * @param out The 3 byte output buffer
+ * @param sirk  16 byte LS byte first SIRK
+ * @param r     3 byte LS byte first random value
+ * @param out   3 byte LS byte first output buffer
  * @return int 0 on success, any other value indicates a failure.
  */
-int bt_csip_sih(const uint8_t sirk[BT_CSIP_SET_SIRK_SIZE], uint32_t r,
-		uint32_t *out);
+int bt_csip_sih(const uint8_t sirk[BT_CSIP_SET_SIRK_SIZE],
+		uint8_t r[BT_CSIP_CRYPTO_PRAND_SIZE],
+		uint8_t out[BT_CSIP_CRYPTO_HASH_SIZE]);
 
 /**
  * @brief SIRK encryption function sef

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -28,8 +28,6 @@
 #include "../host/hci_core.h"
 #include "../host/keys.h"
 
-#define BT_CSIP_SIH_PRAND_SIZE          3
-#define BT_CSIP_SIH_HASH_SIZE           3
 #define CSIP_SET_LOCK_TIMER_VALUE       K_SECONDS(60)
 
 #include "common/bt_str.h"
@@ -173,27 +171,29 @@ static int sirk_encrypt(struct bt_conn *conn,
 	return 0;
 }
 
-static int generate_prand(uint32_t *dest)
+static int generate_prand(uint8_t dest[BT_CSIP_CRYPTO_PRAND_SIZE])
 {
 	bool valid = false;
 
 	do {
 		int res;
+		uint32_t prand;
 
 		*dest = 0;
-		res = bt_rand(dest, BT_CSIP_SIH_PRAND_SIZE);
+		res = bt_rand(dest, BT_CSIP_CRYPTO_PRAND_SIZE);
 		if (res != 0) {
 			return res;
 		}
 
 		/* Validate Prand: Must contain both a 1 and a 0 */
-		if (*dest != 0 && *dest != 0x3FFFFF) {
+		prand = sys_get_le24(dest);
+		if (prand != 0 && prand != 0x3FFFFF) {
 			valid = true;
 		}
 	} while (!valid);
 
-	*dest &= 0x3FFFFF;
-	*dest |= BIT(22); /* bit 23 shall be 0, and bit 22 shall be 1 */
+	dest[BT_CSIP_CRYPTO_PRAND_SIZE - 1] &= 0x3F;
+	dest[BT_CSIP_CRYPTO_PRAND_SIZE - 1] |= BIT(6);
 
 	return 0;
 }
@@ -202,14 +202,14 @@ int bt_csip_set_member_generate_rsi(const struct bt_csip_set_member_svc_inst *sv
 				    uint8_t rsi[BT_CSIP_RSI_SIZE])
 {
 	int res = 0;
-	uint32_t prand;
-	uint32_t hash;
+	uint8_t prand[BT_CSIP_CRYPTO_PRAND_SIZE];
+	uint8_t hash[BT_CSIP_CRYPTO_HASH_SIZE];
 
 	if (IS_ENABLED(CONFIG_BT_CSIP_SET_MEMBER_TEST_SAMPLE_DATA)) {
 		/* prand is from the sample data from A.2 in the CSIS spec */
-		prand = 0x69f563;
+		sys_put_le24(0x69f563, prand);
 	} else {
-		res = generate_prand(&prand);
+		res = generate_prand(prand);
 
 		if (res != 0) {
 			LOG_WRN("Could not generate new prand");
@@ -217,14 +217,14 @@ int bt_csip_set_member_generate_rsi(const struct bt_csip_set_member_svc_inst *sv
 		}
 	}
 
-	res = bt_csip_sih(svc_inst->set_sirk.value, prand, &hash);
+	res = bt_csip_sih(svc_inst->set_sirk.value, prand, hash);
 	if (res != 0) {
 		LOG_WRN("Could not generate new RSI");
 		return res;
 	}
 
-	(void)memcpy(rsi, &hash, BT_CSIP_SIH_HASH_SIZE);
-	(void)memcpy(rsi + BT_CSIP_SIH_HASH_SIZE, &prand, BT_CSIP_SIH_PRAND_SIZE);
+	(void)memcpy(rsi, hash, BT_CSIP_CRYPTO_HASH_SIZE);
+	(void)memcpy(rsi + BT_CSIP_CRYPTO_HASH_SIZE, prand, BT_CSIP_CRYPTO_PRAND_SIZE);
 
 	return res;
 }


### PR DESCRIPTION
This changes so that instead of using uint32 for storing the 24-bit hash and prand, instead 3-byte arrays are used. In addition this change will handle the RSI generation uniformly for both BE and LE, and thus fixes RSI generation for BE, which wasn't working.