### PR TITLE
LE Audio: BASE PD and stream->qos for broadcast sink fixes

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -401,8 +401,14 @@ struct bt_codec_qos {
 	/** QoS SDU */
 	uint16_t sdu;
 
-	/** QoS Transport Latency */
+#if defined(CONFIG_BT_BAP_BROADCAST_SOURCE) || defined(CONFIG_BT_BAP_UNICAST)
+	/**
+	 * @brief QoS Transport Latency
+	 *
+	 * Not used for the @kconfig{CONFIG_BT_BAP_BROADCAST_SINK} role.
+	 */
 	uint16_t latency;
+#endif /*  CONFIG_BT_BAP_BROADCAST_SOURCE || CONFIG_BT_BAP_UNICAST */
 
 	/** QoS Frame Interval */
 	uint32_t interval;

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1163,8 +1163,15 @@ struct bt_bap_base_subgroup {
 };
 
 struct bt_bap_base {
+	/** @brief QoS Presentation Delay in microseconds
+	 *
+	 *  Value range 0 to @ref BT_AUDIO_PD_MAX.
+	 */
+	uint32_t pd;
+
 	/* Number of subgroups in the BASE */
 	size_t subgroup_count;
+
 	/* Array of subgroups in the BASE */
 	struct bt_bap_base_subgroup subgroups[BROADCAST_SNK_SUBGROUP_CNT];
 };

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -537,7 +537,6 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 {
 	struct bt_bap_broadcast_sink *sink = (struct bt_bap_broadcast_sink *)user_data;
 	struct bt_bap_broadcast_sink_cb *listener;
-	struct bt_codec_qos codec_qos = { 0 };
 	struct bt_bap_base base = {0};
 	struct bt_uuid_16 broadcast_uuid;
 	struct net_buf_simple net_buf;
@@ -571,7 +570,7 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 		return true;
 	}
 
-	codec_qos.pd = net_buf_simple_pull_le24(&net_buf);
+	base.pd = net_buf_simple_pull_le24(&net_buf);
 	base.subgroup_count = net_buf_simple_pull_u8(&net_buf);
 
 	if (base.subgroup_count > ARRAY_SIZE(base.subgroups)) {

--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -101,6 +101,7 @@ struct bt_bap_broadcast_sink {
 	bool big_encrypted;
 	uint32_t broadcast_id; /* 24 bit */
 	struct bt_bap_base base;
+	struct bt_codec_qos codec_qos;
 	struct bt_le_per_adv_sync *pa_sync;
 	struct bt_iso_big *big;
 	struct bt_iso_chan *bis[BROADCAST_SNK_STREAM_CNT];


### PR DESCRIPTION
Adds missing (but known) data to the BASE and stream->qos values when in the Broadcast Sink role. 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55690