### PR TITLE
modules/hal_st: Align sensor drivers to stmemsc HAL i/f v2.02

### DIFF
--- a/drivers/sensor/hts221/hts221.c
+++ b/drivers/sensor/hts221/hts221.c
@@ -240,6 +240,8 @@ int hts221_init(const struct device *dev)
 			   (stmdev_read_ptr) stmemsc_spi_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_spi_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&hts221_config_##inst.stmemsc_cfg,	\
 		},							\
@@ -263,6 +265,8 @@ int hts221_init(const struct device *dev)
 			   (stmdev_read_ptr) stmemsc_i2c_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_i2c_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&hts221_config_##inst.stmemsc_cfg,	\
 		},							\

--- a/drivers/sensor/i3g4250d/CMakeLists.txt
+++ b/drivers/sensor/i3g4250d/CMakeLists.txt
@@ -3,3 +3,5 @@
 zephyr_library()
 
 zephyr_library_sources(i3g4250d.c i3g4250d_spi.c)
+
+zephyr_library_include_directories(../stmemsc)

--- a/drivers/sensor/i3g4250d/i3g4250d.h
+++ b/drivers/sensor/i3g4250d/i3g4250d.h
@@ -16,6 +16,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/sys/util.h>
+#include <stmemsc.h>
 #include "i3g4250d_reg.h"
 
 struct i3g4250d_device_config {

--- a/drivers/sensor/i3g4250d/i3g4250d_spi.c
+++ b/drivers/sensor/i3g4250d/i3g4250d_spi.c
@@ -85,6 +85,7 @@ static int i3g4250d_spi_write(const struct device *dev, uint8_t reg,
 stmdev_ctx_t i3g4250d_spi_ctx = {
 	.read_reg = (stmdev_read_ptr) i3g4250d_spi_read,
 	.write_reg = (stmdev_write_ptr) i3g4250d_spi_write,
+	.mdelay = (stmdev_mdelay_ptr) stmemsc_mdelay,
 };
 
 int i3g4250d_spi_init(const struct device *dev)

--- a/drivers/sensor/iis2dh/CMakeLists.txt
+++ b/drivers/sensor/iis2dh/CMakeLists.txt
@@ -10,3 +10,5 @@ zephyr_library_sources(iis2dh.c)
 zephyr_library_sources(iis2dh_i2c.c)
 zephyr_library_sources(iis2dh_spi.c)
 zephyr_library_sources_ifdef(CONFIG_IIS2DH_TRIGGER    iis2dh_trigger.c)
+
+zephyr_library_include_directories(../stmemsc)

--- a/drivers/sensor/iis2dh/iis2dh.h
+++ b/drivers/sensor/iis2dh/iis2dh.h
@@ -17,6 +17,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/kernel.h>
+#include <stmemsc.h>
 #include "iis2dh_reg.h"
 
 /*

--- a/drivers/sensor/iis2dh/iis2dh_i2c.c
+++ b/drivers/sensor/iis2dh/iis2dh_i2c.c
@@ -38,6 +38,7 @@ static int iis2dh_i2c_write(const struct device *dev, uint8_t reg_addr, uint8_t 
 stmdev_ctx_t iis2dh_i2c_ctx = {
 	.read_reg = (stmdev_read_ptr) iis2dh_i2c_read,
 	.write_reg = (stmdev_write_ptr) iis2dh_i2c_write,
+	.mdelay = (stmdev_mdelay_ptr) stmemsc_mdelay,
 };
 
 int iis2dh_i2c_init(const struct device *dev)

--- a/drivers/sensor/iis2dh/iis2dh_spi.c
+++ b/drivers/sensor/iis2dh/iis2dh_spi.c
@@ -85,6 +85,7 @@ static int iis2dh_spi_write(const struct device *dev, uint8_t reg, uint8_t *data
 stmdev_ctx_t iis2dh_spi_ctx = {
 	.read_reg = (stmdev_read_ptr) iis2dh_spi_read,
 	.write_reg = (stmdev_write_ptr) iis2dh_spi_write,
+	.mdelay = (stmdev_mdelay_ptr) stmemsc_mdelay,
 };
 
 int iis2dh_spi_init(const struct device *dev)

--- a/drivers/sensor/iis2dlpc/iis2dlpc.c
+++ b/drivers/sensor/iis2dlpc/iis2dlpc.c
@@ -459,6 +459,8 @@ static int iis2dlpc_init(const struct device *dev)
 			   (stmdev_read_ptr) stmemsc_spi_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_spi_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&iis2dlpc_config_##inst.stmemsc_cfg,	\
 		},							\
@@ -485,6 +487,8 @@ static int iis2dlpc_init(const struct device *dev)
 			   (stmdev_read_ptr) stmemsc_i2c_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_i2c_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&iis2dlpc_config_##inst.stmemsc_cfg,	\
 		},							\

--- a/drivers/sensor/iis2iclx/iis2iclx.c
+++ b/drivers/sensor/iis2iclx/iis2iclx.c
@@ -663,6 +663,8 @@ static int iis2iclx_init(const struct device *dev)
 			   (stmdev_read_ptr) stmemsc_spi_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_spi_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&iis2iclx_config_##inst.stmemsc_cfg,	\
 		},							\
@@ -688,6 +690,8 @@ static int iis2iclx_init(const struct device *dev)
 			   (stmdev_read_ptr) stmemsc_i2c_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_i2c_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&iis2iclx_config_##inst.stmemsc_cfg,	\
 		},							\

--- a/drivers/sensor/iis2mdc/CMakeLists.txt
+++ b/drivers/sensor/iis2mdc/CMakeLists.txt
@@ -9,3 +9,5 @@ zephyr_library_sources(iis2mdc.c)
 zephyr_library_sources(iis2mdc_i2c.c)
 zephyr_library_sources(iis2mdc_spi.c)
 zephyr_library_sources_ifdef(CONFIG_IIS2MDC_TRIGGER iis2mdc_trigger.c)
+
+zephyr_library_include_directories(../stmemsc)

--- a/drivers/sensor/iis2mdc/iis2mdc.h
+++ b/drivers/sensor/iis2mdc/iis2mdc.h
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
+#include <stmemsc.h>
 #include "iis2mdc_reg.h"
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)

--- a/drivers/sensor/iis2mdc/iis2mdc_i2c.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_i2c.c
@@ -47,6 +47,7 @@ int iis2mdc_i2c_init(const struct device *dev)
 
 	data->ctx_i2c.read_reg = (stmdev_read_ptr) iis2mdc_i2c_read;
 	data->ctx_i2c.write_reg = (stmdev_write_ptr) iis2mdc_i2c_write;
+	data->ctx_i2c.mdelay = (stmdev_mdelay_ptr) stmemsc_mdelay;
 
 	data->ctx = &data->ctx_i2c;
 	data->ctx->handle = (void *)dev;

--- a/drivers/sensor/iis2mdc/iis2mdc_spi.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_spi.c
@@ -102,6 +102,7 @@ int iis2mdc_spi_init(const struct device *dev)
 
 	data->ctx_spi.read_reg = (stmdev_read_ptr) iis2mdc_spi_read;
 	data->ctx_spi.write_reg = (stmdev_write_ptr) iis2mdc_spi_write;
+	data->ctx_spi.mdelay = (stmdev_mdelay_ptr) stmemsc_mdelay;
 
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = (void *)dev;

--- a/drivers/sensor/iis3dhhc/CMakeLists.txt
+++ b/drivers/sensor/iis3dhhc/CMakeLists.txt
@@ -9,3 +9,5 @@ zephyr_library()
 zephyr_library_sources(iis3dhhc.c)
 zephyr_library_sources(iis3dhhc_spi.c)
 zephyr_library_sources_ifdef(CONFIG_IIS3DHHC_TRIGGER    iis3dhhc_trigger.c)
+
+zephyr_library_include_directories(../stmemsc)

--- a/drivers/sensor/iis3dhhc/iis3dhhc.h
+++ b/drivers/sensor/iis3dhhc/iis3dhhc.h
@@ -18,6 +18,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
+#include <stmemsc.h>
 #include "iis3dhhc_reg.h"
 
 struct iis3dhhc_config {

--- a/drivers/sensor/iis3dhhc/iis3dhhc_spi.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_spi.c
@@ -84,6 +84,7 @@ static int iis3dhhc_spi_write(const struct device *dev, uint8_t reg, uint8_t *da
 stmdev_ctx_t iis3dhhc_spi_ctx = {
 	.read_reg = (stmdev_read_ptr) iis3dhhc_spi_read,
 	.write_reg = (stmdev_write_ptr) iis3dhhc_spi_write,
+	.mdelay = (stmdev_mdelay_ptr) stmemsc_mdelay,
 };
 
 int iis3dhhc_spi_init(const struct device *dev)

--- a/drivers/sensor/ism330dhcx/CMakeLists.txt
+++ b/drivers/sensor/ism330dhcx/CMakeLists.txt
@@ -11,3 +11,5 @@ zephyr_library_sources(ism330dhcx_i2c.c)
 zephyr_library_sources(ism330dhcx_spi.c)
 zephyr_library_sources_ifdef(CONFIG_ISM330DHCX_SENSORHUB  ism330dhcx_shub.c)
 zephyr_library_sources_ifdef(CONFIG_ISM330DHCX_TRIGGER    ism330dhcx_trigger.c)
+
+zephyr_library_include_directories(../stmemsc)

--- a/drivers/sensor/ism330dhcx/ism330dhcx.h
+++ b/drivers/sensor/ism330dhcx/ism330dhcx.h
@@ -18,6 +18,7 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
+#include <stmemsc.h>
 #include "ism330dhcx_reg.h"
 
 #define ISM330DHCX_EN_BIT					0x01

--- a/drivers/sensor/ism330dhcx/ism330dhcx_i2c.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_i2c.c
@@ -46,8 +46,9 @@ int ism330dhcx_i2c_init(const struct device *dev)
 		return -ENODEV;
 	};
 
-	data->ctx_i2c.read_reg = (stmdev_read_ptr) ism330dhcx_i2c_read,
-	data->ctx_i2c.write_reg = (stmdev_write_ptr) ism330dhcx_i2c_write,
+	data->ctx_i2c.read_reg = (stmdev_read_ptr) ism330dhcx_i2c_read;
+	data->ctx_i2c.write_reg = (stmdev_write_ptr) ism330dhcx_i2c_write;
+	data->ctx_i2c.mdelay = (stmdev_mdelay_ptr) stmemsc_mdelay;
 
 	data->ctx = &data->ctx_i2c;
 	data->ctx->handle = (void *)dev;

--- a/drivers/sensor/ism330dhcx/ism330dhcx_spi.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_spi.c
@@ -102,8 +102,9 @@ int ism330dhcx_spi_init(const struct device *dev)
 		return -ENODEV;
 	};
 
-	data->ctx_spi.read_reg = (stmdev_read_ptr) ism330dhcx_spi_read,
-	data->ctx_spi.write_reg = (stmdev_write_ptr) ism330dhcx_spi_write,
+	data->ctx_spi.read_reg = (stmdev_read_ptr) ism330dhcx_spi_read;
+	data->ctx_spi.write_reg = (stmdev_write_ptr) ism330dhcx_spi_write;
+	data->ctx_spi.mdelay = (stmdev_mdelay_ptr) stmemsc_mdelay;
 
 	data->ctx = &data->ctx_spi;
 	data->ctx->handle = data;

--- a/drivers/sensor/lis2ds12/lis2ds12.c
+++ b/drivers/sensor/lis2ds12/lis2ds12.c
@@ -364,6 +364,8 @@ static int lis2ds12_init(const struct device *dev)
 			   (stmdev_read_ptr) stmemsc_spi_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_spi_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&lis2ds12_config_##inst.stmemsc_cfg,	\
 		},							\
@@ -390,6 +392,8 @@ static int lis2ds12_init(const struct device *dev)
 			   (stmdev_read_ptr) stmemsc_i2c_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_i2c_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&lis2ds12_config_##inst.stmemsc_cfg,	\
 		},							\

--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -541,6 +541,8 @@ static int lis2dw12_init(const struct device *dev)
 			   (stmdev_read_ptr) stmemsc_spi_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_spi_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&lis2dw12_config_##inst.stmemsc_cfg,	\
 		},							\
@@ -574,6 +576,8 @@ static int lis2dw12_init(const struct device *dev)
 			   (stmdev_read_ptr) stmemsc_i2c_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_i2c_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&lis2dw12_config_##inst.stmemsc_cfg,	\
 		},							\

--- a/drivers/sensor/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/lis2mdl/lis2mdl.c
@@ -524,6 +524,8 @@ static int lis2mdl_pm_action(const struct device *dev,
 			   (stmdev_read_ptr) stmemsc_spi_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_spi_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&lis2mdl_config_##inst.stmemsc_cfg,	\
 		},							\
@@ -550,6 +552,8 @@ static int lis2mdl_pm_action(const struct device *dev,
 			   (stmdev_read_ptr) stmemsc_i2c_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_i2c_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&lis2mdl_config_##inst.stmemsc_cfg,	\
 		},							\

--- a/drivers/sensor/lps22hh/lps22hh.c
+++ b/drivers/sensor/lps22hh/lps22hh.c
@@ -270,6 +270,8 @@ static int lps22hh_init(const struct device *dev)
 			   (stmdev_read_ptr) stmemsc_spi_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_spi_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&lps22hh_config_##inst.stmemsc_cfg,	\
 		},							\
@@ -294,6 +296,8 @@ static int lps22hh_init(const struct device *dev)
 			   (stmdev_read_ptr) stmemsc_i2c_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_i2c_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&lps22hh_config_##inst.stmemsc_cfg,	\
 		},							\

--- a/drivers/sensor/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/lps22hh/lps22hh_trigger.c
@@ -26,12 +26,12 @@ static int lps22hh_enable_int(const struct device *dev, int enable)
 {
 	const struct lps22hh_config * const cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
-	lps22hh_reg_t int_route;
+	lps22hh_pin_int_route_t int_route;
 
 	/* set interrupt */
-	lps22hh_pin_int_route_get(ctx, &int_route.ctrl_reg3);
-	int_route.ctrl_reg3.drdy = enable;
-	return lps22hh_pin_int_route_set(ctx, &int_route.ctrl_reg3);
+	lps22hh_pin_int_route_get(ctx, &int_route);
+	int_route.drdy_pres = enable;
+	return lps22hh_pin_int_route_set(ctx, &int_route);
 }
 
 /**

--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -928,6 +928,8 @@ static int lsm6dso_init(const struct device *dev)
 			   (stmdev_read_ptr) stmemsc_spi_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_spi_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&lsm6dso_config_##inst.stmemsc_cfg,	\
 		},							\
@@ -950,6 +952,8 @@ static int lsm6dso_init(const struct device *dev)
 			   (stmdev_read_ptr) stmemsc_i2c_read,		\
 			.write_reg =					\
 			   (stmdev_write_ptr) stmemsc_i2c_write,	\
+			.mdelay =					\
+			   (stmdev_mdelay_ptr) stmemsc_mdelay,		\
 			.handle =					\
 			   (void *)&lsm6dso_config_##inst.stmemsc_cfg,	\
 		},							\

--- a/drivers/sensor/stmemsc/stmemsc.h
+++ b/drivers/sensor/stmemsc/stmemsc.h
@@ -10,9 +10,15 @@
 #ifndef ZEPHYR_DRIVERS_SENSOR_STMEMSC_STMEMSC_H_
 #define ZEPHYR_DRIVERS_SENSOR_STMEMSC_STMEMSC_H_
 
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/i3c.h>
 #include <zephyr/drivers/spi.h>
+
+static inline void stmemsc_mdelay(uint32_t millisec)
+{
+	k_msleep(millisec);
+}
 
 #ifdef CONFIG_I2C
 int stmemsc_i2c_read(const struct i2c_dt_spec *stmemsc,

--- a/drivers/sensor/stts751/CMakeLists.txt
+++ b/drivers/sensor/stts751/CMakeLists.txt
@@ -9,3 +9,5 @@ zephyr_library()
 zephyr_library_sources(stts751.c)
 zephyr_library_sources(stts751_i2c.c)
 zephyr_library_sources_ifdef(CONFIG_STTS751_TRIGGER    stts751_trigger.c)
+
+zephyr_library_include_directories(../stmemsc)

--- a/drivers/sensor/stts751/stts751.h
+++ b/drivers/sensor/stts751/stts751.h
@@ -18,6 +18,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
+#include <stmemsc.h>
 #include "stts751_reg.h"
 
 struct stts751_config {

--- a/drivers/sensor/stts751/stts751_i2c.c
+++ b/drivers/sensor/stts751/stts751_i2c.c
@@ -42,6 +42,7 @@ int stts751_i2c_init(const struct device *dev)
 
 	data->ctx_i2c.read_reg = (stmdev_read_ptr) stts751_i2c_read;
 	data->ctx_i2c.write_reg = (stmdev_write_ptr) stts751_i2c_write;
+	data->ctx_i2c.mdelay = (stmdev_mdelay_ptr) stmemsc_mdelay,
 
 	data->ctx = &data->ctx_i2c;
 	data->ctx->handle = (void *)dev;

--- a/tests/drivers/build_all/sensor/app.overlay
+++ b/tests/drivers/build_all/sensor/app.overlay
@@ -169,68 +169,13 @@
  */
 
 /* disable device to conflict with i2c version */
-&test_i2c_iis2dlpc {
-	status = "disabled";
-};
-
-/* disable device to conflict with i2c version */
 &test_i2c_ism330dhcx {
-	status = "disabled";
-};
-
-/* disable device to conflict with i2c version */
-&test_i2c_lis2dh {
-	status = "disabled";
-};
-
-/* disable device to conflict with i2c version */
-&test_i2c_lis2ds12 {
-	status = "disabled";
-};
-
-/* disable device to conflict with i2c version */
-&test_i2c_lis2dw12 {
-	status = "disabled";
-};
-
-/* disable device to conflict with i2c version */
-&test_i2c_lis2mdl {
-	status = "disabled";
-};
-
-/* disable device to conflict with i2c version */
-&test_i2c_lps22hh {
-	status = "disabled";
-};
-
-/* disable device to conflict with i2c version */
-&test_i2c_lsm6dsl {
-	status = "disabled";
-};
-
-/* disable device to conflict with i2c version */
-&test_i2c_lsm6dso {
 	status = "disabled";
 };
 
 /* disable device to conflict with i2c version */
 &test_spi_bme280 {
 	status = "disabled";
-};
-
-/* disable device to conflict with i2c version */
-&test_spi_iis2iclx {
-	status = "disabled";
-};
-
-/* disable device to conflict with i2c version */
-&test_spi_iis2mdc {
-	status = "disabled";
-};
-
-/* setup valid params for the device */
-&test_spi_iis3dhhc {
-	irq-gpios = <&test_gpio 0 0>, <&test_gpio 0 0>;
 };
 
 /* disable device to conflict with i2c version */

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -360,3 +360,10 @@ test_spi_bmm150: bmm150@2b {
 	reg = <0x2b>;
 	spi-max-frequency = <0>;
 };
+
+test_spi_hts221: hts221@2c {
+	compatible = "st,hts221";
+	reg = <0x2c>;
+	spi-max-frequency = <0>;
+	drdy-gpios = <&test_gpio 0 0>;
+};

--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
       groups:
         - hal
     - name: hal_st
-      revision: 60b149c2df9b7766737af243d2ee5f8c6bd83804
+      revision: 5948f7b3304f1628a45ee928cd607619a7f53bbb
       path: modules/hal/st
       groups:
         - hal


### PR DESCRIPTION
Align all sensor drivers that are using stmemsc (STdC) HAL i/f to new APIs of stmemsc v2.02.

Requires https://github.com/zephyrproject-rtos/hal_st/pull/13