### PR TITLE
boards: olimex_lora_stm32wl_devkit: Support newer board revisions

### DIFF
--- a/boards/arm/olimex_lora_stm32wl_devkit/doc/olimex_lora_stm32wl_devkit.rst
+++ b/boards/arm/olimex_lora_stm32wl_devkit/doc/olimex_lora_stm32wl_devkit.rst
@@ -116,6 +116,15 @@ Connect the board to your host computer and build and flash an application.
    :board: olimex_lora_stm32wl_devkit
    :goals: build flash
 
+If you're using devkit revision C or higher, you'll need to specify the
+appropriate revision letter to enable the VDDIO supply to the UEXT1 connector and
+CON1 pin header.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: olimex_lora_stm32wl_devkit@D
+   :goals: build flash
+
 Run a serial terminal to connect with your board. By default, ``usart1`` is
 accessible via the the built-in USB to UART converter.
 
@@ -132,6 +141,14 @@ You can debug an application in the usual way.  Here is an example for the
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
    :board: olimex_lora_stm32wl_devkit
+   :maybe-skip-config:
+   :goals: debug
+
+On board revisions C or newer:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: olimex_lora_stm32wl_devkit@D
    :maybe-skip-config:
    :goals: debug
 

--- a/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
+++ b/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
@@ -76,7 +76,7 @@
 };
 
 uext_serial: &lpuart1 {
-	pinctrl-0 = <&lpuart1_tx_pa2 &lpuart1_rx_pa3 &lpuart1_cts_pa6 &lpuart1_rts_pb12>;
+	pinctrl-0 = <&lpuart1_tx_pa2 &lpuart1_rx_pa3>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
 	status = "okay";

--- a/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit_C.conf
+++ b/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit_C.conf
@@ -1,0 +1,2 @@
+# Regulator support
+CONFIG_REGULATOR=y

--- a/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit_C.overlay
+++ b/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit_C.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023 Kenneth J. Miller <ken@miller.ec>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/* Controls 3.3V VDDIO supply for UEXT1 connector and CON1 header */
+	vddio_reg: fet2_regulator {
+		compatible = "regulator-fixed";
+		enable-gpios = <&gpiob 12 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
+		regulator-name = "fet2_regulator";
+		regulator-boot-on;
+	};
+};

--- a/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit_D.conf
+++ b/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit_D.conf
@@ -1,0 +1,2 @@
+# Regulator support
+CONFIG_REGULATOR=y

--- a/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit_D.overlay
+++ b/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit_D.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023 Kenneth J. Miller <ken@miller.ec>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "olimex_lora_stm32wl_devkit_C.overlay"

--- a/boards/arm/olimex_lora_stm32wl_devkit/revision.cmake
+++ b/boards/arm/olimex_lora_stm32wl_devkit/revision.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2023 Kenneth J. Miller <ken@miller.ec>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+board_check_revision(
+			FORMAT LETTER
+			DEFAULT_REVISION B
+			VALID_REVISIONS A B C D
+)


### PR DESCRIPTION
Add configuration and DT overlays for new devkit revisions C and D.

This enables identical behavior to earlier revisions by powering the VDDIO pins on the UEXT1 connector and CON1 header via the new FET2 regulator. In these new revisons this regulator is also user-togglable.

Update documentation build/flash/debug steps.

---

The C and D board revisions add a MOSFET for switching the VDDIO supply on the UEXT1 connector and CON1 header (as well as the CDS cell voltage divider):

![Rev-CD-FET2](https://user-images.githubusercontent.com/6822406/228614241-77799506-f448-4473-abf2-dfbac0f04fab.jpg)

I've tested this PR's functionality and confirm it working on my revision D devkit.