### PR TITLE
    device: Fixed CPP compatiblity for driver instantation

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -773,6 +773,12 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 #define Z_DEVICE_HANDLES_SECTION                                               \
 	__attribute__((__section__(".__device_handles_pass1")))
 
+#ifdef __cplusplus
+#define Z_DEVICE_HANDLES_EXTERN extern
+#else
+#define Z_DEVICE_HANDLES_EXTERN
+#endif
+
 /**
  * @brief Define device handles.
  *
@@ -812,7 +818,8 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 	extern Z_DEVICE_HANDLES_CONST device_handle_t Z_DEVICE_HANDLES_NAME(   \
 		dev_id)[];                                                     \
 	Z_DEVICE_HANDLES_CONST Z_DECL_ALIGN(device_handle_t)                   \
-	Z_DEVICE_HANDLES_SECTION __weak Z_DEVICE_HANDLES_NAME(dev_id)[] = {    \
+	Z_DEVICE_HANDLES_SECTION Z_DEVICE_HANDLES_EXTERN __weak                \
+		Z_DEVICE_HANDLES_NAME(dev_id)[] = {                            \
 		COND_CODE_1(                                                   \
 			DT_NODE_EXISTS(node_id),                               \
 			(DT_DEP_ORD(node_id), DT_REQUIRES_DEP_ORDS(node_id)),  \

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -855,10 +855,10 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 #define Z_DEVICE_INIT(name_, pm_, data_, config_, api_, state_, handles_)      \
 	{                                                                      \
 		.name = name_,                                                 \
-		.data = (data_),                                               \
 		.config = (config_),                                           \
 		.api = (api_),                                                 \
 		.state = (state_),                                             \
+		.data = (data_),                                               \
 		.handles = (handles_),                                         \
 		IF_ENABLED(CONFIG_PM_DEVICE, (.pm = (pm_),)) /**/              \
 	}


### PR DESCRIPTION
    The macro `DEVICE_DT_INST_DEFINE` is not compatible with C++.
    There are two macros that cause this problem.

    1. `Z_DEVICE_INIT` : Wrong order of initialization in struct `device`.
    2. `Z_DEVICE_HANDLES_DEFINE` : By using the __weak attribute with the
    variable declared with `Z_DEVICE_HANDLES_NAME`, C++ throws the error
    "weak declaration must be public".

    This commit fixes the issue by first rearranging the order of
    initialization of the members in the macro `Z_DEVICE_INIT`.
    Secondly, a macro called `Z_DEVICE_HANDLES_EXTERN` has been added.
    This allows to declares the variable defined by `Z_DEVICE_HANDLES_NAME`
    as `extern` if used in a CPP context.

    Signed-off-by: Victor Chavez <chavez-bermudez@fh-aachen.de>

Fixes #54739
Fixes #54737

Disclaimer: I have recreated the pull-request because it seems I made a mistake while doing a force push and the pull-request was closed https://github.com/zephyrproject-rtos/zephyr/pull/54762, sorry!
