### PR TITLE
drivers: gpio: Update NXP GPIO driver for the updated IP Block

### DIFF
--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -14,7 +14,6 @@
 #include <zephyr/irq.h>
 #include <soc.h>
 #include <fsl_common.h>
-#include <fsl_port.h>
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
 
@@ -80,7 +79,12 @@ static int gpio_mcux_configure(const struct device *dev,
 
 	/* Set PCR mux to GPIO for the pin we are configuring */
 	mask |= PORT_PCR_MUX_MASK;
-	pcr |= PORT_PCR_MUX(kPORT_MuxAsGpio);
+	pcr |= PORT_PCR_MUX(PORT_MUX_GPIO);
+
+#if defined(FSL_FEATURE_PORT_HAS_INPUT_BUFFER) && FSL_FEATURE_PORT_HAS_INPUT_BUFFER
+	/* Enable digital input buffer */
+	pcr |= PORT_PCR_IBE_MASK;
+#endif
 
 	/* Now do the PORT module. Figure out the pullup/pulldown
 	 * configuration, but don't write it to the PCR register yet.

--- a/soc/arm/nxp_kinetis/k2x/soc.h
+++ b/soc/arm/nxp_kinetis/k2x/soc.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2014-2015 Wind River Systems, Inc.
  * Copyright (c) Thomas Burdick <thomas.burdick@gmail.com>
-
+ * Copyright 2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,6 +18,7 @@
 #define _SOC__H_
 
 #include <zephyr/sys/util.h>
+#include <fsl_port.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,6 +27,8 @@ extern "C" {
 /* address bases */
 
 #define PERIPH_ADDR_BASE_WDOG 0x40052000 /* Watchdog Timer module */
+
+#define PORT_MUX_GPIO kPORT_MuxAsGpio /* GPIO setting for the Port Mux Register */
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/nxp_kinetis/k6x/soc.h
+++ b/soc/arm/nxp_kinetis/k6x/soc.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014-2015 Wind River Systems, Inc.
+ * Copyright 2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,10 +17,13 @@
 #define _SOC__H_
 
 #include <zephyr/sys/util.h>
+#include <fsl_port.h>
 
 /* address bases */
 
 #define PERIPH_ADDR_BASE_WDOG 0x40052000 /* Watchdog Timer module */
+
+#define PORT_MUX_GPIO kPORT_MuxAsGpio /* GPIO setting for the Port Mux Register */
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/nxp_kinetis/k8x/soc.h
+++ b/soc/arm/nxp_kinetis/k8x/soc.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 SEAL AG
+ * Copyright 2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +9,7 @@
 #define _SOC__H_
 
 #include <zephyr/sys/util.h>
+#include <fsl_port.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,5 +28,7 @@ extern "C" {
 
 /* address bases */
 #define PERIPH_ADDR_BASE_WDOG 0x40052000 /* Watchdog Timer module */
+
+#define PORT_MUX_GPIO kPORT_MuxAsGpio /* GPIO setting for the Port Mux Register */
 
 #endif /* _SOC__H_ */

--- a/soc/arm/nxp_kinetis/ke1xf/soc.h
+++ b/soc/arm/nxp_kinetis/ke1xf/soc.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Vestas Wind Systems A/S
+ * Copyright 2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +9,9 @@
 #define _SOC__H_
 
 #include <zephyr/sys/util.h>
+#include <fsl_port.h>
+
+#define PORT_MUX_GPIO kPORT_MuxAsGpio /* GPIO setting for the Port Mux Register */
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/nxp_kinetis/kl2x/soc.h
+++ b/soc/arm/nxp_kinetis/kl2x/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NXP
+ * Copyright (c) 2017, 2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,8 +8,11 @@
 #define _SOC__H_
 
 #include <zephyr/sys/util.h>
+#include <fsl_port.h>
 
 #define UART0_CLK_SRC kCLOCK_CoreSysClk
+
+#define PORT_MUX_GPIO kPORT_MuxAsGpio /* GPIO setting for the Port Mux Register */
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/nxp_kinetis/kv5x/soc.h
+++ b/soc/arm/nxp_kinetis/kv5x/soc.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 SEAL AG
+ * Copyright 2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +9,7 @@
 #define _SOC__H_
 
 #include <zephyr/sys/util.h>
+#include <fsl_port.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,5 +28,7 @@ extern "C" {
 
 /* address bases */
 #define PERIPH_ADDR_BASE_WDOG 0x40052000 /* Watchdog Timer module */
+
+#define PORT_MUX_GPIO kPORT_MuxAsGpio /* GPIO setting for the Port Mux Register */
 
 #endif /* _SOC__H_ */

--- a/soc/arm/nxp_kinetis/kwx/soc.h
+++ b/soc/arm/nxp_kinetis/kwx/soc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NXP
+ * Copyright (c) 2017, 2023 NXP
  * Copyright (c) 2017, Phytec Messtechnik GmbH
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -9,6 +9,7 @@
 #define _SOC__H_
 
 #include <zephyr/sys/util.h>
+#include <fsl_port.h>
 
 #if defined(CONFIG_SOC_MKW40Z4) || defined(CONFIG_SOC_MKW41Z4)
 
@@ -21,6 +22,8 @@
 #define PERIPH_ADDR_BASE_WDOG 0x40052000 /* Watchdog Timer module */
 
 #endif
+
+#define PORT_MUX_GPIO kPORT_MuxAsGpio /* GPIO setting for the Port Mux Register */
 
 #ifndef _ASMLANGUAGE
 


### PR DESCRIPTION
1. Move the GPIO mux setting to the soc layer. The GPIO MUX value may vary based on the SoC Family
2. Enable the digital input buffer if available