### PR TITLE
cmake: Add zephyr_interface_library_include_directories

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -611,12 +611,20 @@ endfunction()
 # should exist for each interface_library and will determine if 'app'
 # links with the interface_library.
 #
-# This API has a constructor like the zephyr_library API has, but it
-# does not have wrappers over the other cmake target functions.
+# This API has a constructor and include_directories() like the
+# zephyr_library API has, but it does not have other wrappers over the
+# other cmake target functions.  If you need to set compile options or
+# compile definitions, use native CMake target functions such as
+# target_compile_options, target_compile_definitions with INTERFACE
+# scope, respectively.
 macro(zephyr_interface_library_named name)
   add_library(${name} INTERFACE)
   set_property(GLOBAL APPEND PROPERTY ZEPHYR_INTERFACE_LIBS ${name})
 endmacro()
+
+function(zephyr_interface_library_include_directories name item)
+  target_include_directories(${name} INTERFACE ${item})
+endfunction()
 
 # 1.3 generate_inc_*
 


### PR DESCRIPTION
Add `zephyr_interface_library_include_directories` to Zephyr interface library API.

As Zephyr ecosystem expands, more libraries are added.  As the number of Zephyr libraries grows, many are only consumed by specific applications and not required by any subsystem.

When we add a new library to Zephyr, we use `zephyr_library_*` APIs and link against `zephyr_interface`.  Which works good, except that it adds all its `PUBLIC` and `INTERFACE` scoped information to every other subsystems / libraries depending on `zephyr_interface`.  As a result, the number of include directories passed to a subsystem/library is increasing.

One thing `zephyr_interface_library_*` provides is access to the library header files to the 'app' without polluting the subsystem build options.

Given that

```cmake
set(MOD_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
```

We can currently do

```cmake
zephyr_interface_library_named(libsome)
target_include_directories(libsome INTERFACE ${MOD_DIR}/include)

zephyr_library()
zephyr_library_include_directories(${MOD_DIR}/private/)
zephyr_library_sources(${MOD_DIR}/src/some.c)

zephyr_library_link_libraries(libsome)
```

This enables the 'app' to compile using libsome header files.

This commit changes the second line to

```cmake
zephyr_interface_library_named(libsome)
zephyr_interface_library_include_directories(libsome ${MOD_DIR}/include)
```

This doesn't gain any technical functionality but the user experience is much more straightforward.

BTW, I'm aware of #8439.