### PR TITLE
tests/kernel/smp: Limit 'stress' tests based on factor

### DIFF
--- a/tests/kernel/smp/Kconfig
+++ b/tests/kernel/smp/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "SMP test"
+
+source "Kconfig.zephyr"
+
+config SMP_TEST_RUN_FACTOR
+	int "Run factor for stressing tests, such as 'switch torture', \
+		as a percentage"
+	default 100

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -14,6 +14,8 @@
 #error SMP test requires at least two CPUs!
 #endif
 
+#define RUN_FACTOR (CONFIG_SMP_TEST_RUN_FACTOR / 100.0)
+
 #define T2_STACK_SIZE (2048 + CONFIG_TEST_EXTRA_STACK_SIZE)
 #define STACK_SIZE (384 + CONFIG_TEST_EXTRA_STACK_SIZE)
 #define DELAY_US 50000
@@ -21,7 +23,7 @@
 #define EQUAL_PRIORITY 1
 #define TIME_SLICE_MS 500
 #define THREAD_DELAY 1
-#define SLEEP_MS_LONG 15000
+#define SLEEP_MS_LONG ((int)(15000 * RUN_FACTOR))
 
 struct k_thread t2;
 K_THREAD_STACK_DEFINE(t2_stack, T2_STACK_SIZE);
@@ -836,7 +838,7 @@ ZTEST(smp, test_smp_release_global_lock)
 	cleanup_resources();
 }
 
-#define LOOP_COUNT 20000
+#define LOOP_COUNT ((int)(20000 * RUN_FACTOR))
 
 enum sync_t {
 	LOCK_IRQ,


### PR DESCRIPTION
SMP tests `inc_concurrency` and `smp_switch_torture` use a 'stressing' approach to verify their results: run something for some time (or some number of repetitions). However, in some environments, current 'stress' levels can be quite high, making tests take a long time - environments like emulators/simulators.
This patch adds a Kconfig that allows one to define a percentage factor to the 'stress' (time or repetitions) used by these tests.