### PR TITLE
drivers: gpio: gpio_mcux_lpc: add support for module interrupts, and implement PINT interrupt controller driver

### DIFF
--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -304,12 +304,24 @@ arduino_serial: &flexcomm12 {
 	status = "okay";
 };
 
+/*
+ * GPIO module interrupts are shared between all GPIO devices on this
+ * SOC, but Zephyr does not currently support sharing interrupts between
+ * devices. The user can select GPIO modules to support interrupts by
+ * setting the appropriate `int-source` and `interrupt` property for
+ * a given module. On this board, GPIO3 and GPIO4 are configured to support
+ * interrupts.
+ */
 &gpio3 {
 	status = "okay";
+	int-source = "int-a";
+	interrupts = <2 0>;
 };
 
 &gpio4 {
 	status = "okay";
+	int-source = "int-b";
+	interrupts = <3 0>;
 };
 
 &gpio5 {

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020, NXP
+ * Copyright 2017-2020,2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,30 +21,14 @@
 #include <soc.h>
 #include <fsl_common.h>
 #include <zephyr/drivers/gpio/gpio_utils.h>
+#include <zephyr/drivers/interrupt_controller/nxp_pint.h>
 #include <fsl_gpio.h>
-#include <fsl_pint.h>
-#include <fsl_inputmux.h>
 #include <fsl_device_registers.h>
-
-#define PIN_TO_INPUT_MUX_CONNECTION(port, pin) \
-	((PINTSEL_PMUX_ID << PMUX_SHIFT) + (32 * port) + (pin))
-
-#ifndef FSL_FEATURE_PINT_NUMBER_OF_CONNECTED_OUTPUTS
-#define FSL_FEATURE_PINT_NUMBER_OF_CONNECTED_OUTPUTS 0
-#endif
-#ifndef FSL_FEATURE_SECPINT_NUMBER_OF_CONNECTED_OUTPUTS
-#define FSL_FEATURE_SECPINT_NUMBER_OF_CONNECTED_OUTPUTS 0
-#endif
-
-#define NO_PINT_INT                                                                                \
-	MAX(FSL_FEATURE_PINT_NUMBER_OF_CONNECTED_OUTPUTS,                                          \
-	    FSL_FEATURE_SECPINT_NUMBER_OF_CONNECTED_OUTPUTS)
 
 struct gpio_mcux_lpc_config {
 	/* gpio_driver_config needs to be first */
 	struct gpio_driver_config common;
 	GPIO_Type *gpio_base;
-	PINT_Type *pint_base;
 #ifdef IOPCTL
 	IOPCTL_Type *pinmux_base;
 #else
@@ -59,12 +43,6 @@ struct gpio_mcux_lpc_data {
 	struct gpio_driver_data common;
 	/* port ISR callback routine address */
 	sys_slist_t callbacks;
-	/* pin association with PINT id */
-	pint_pin_int_t pint_id[32];
-	/* ISR allocated in device tree to this port */
-	uint32_t isr_list[INPUTMUX_PINTSEL_COUNT];
-	/* index to to table above */
-	uint32_t isr_list_idx;
 };
 
 static int gpio_mcux_lpc_configure(const struct device *dev, gpio_pin_t pin,
@@ -211,82 +189,22 @@ static int gpio_mcux_lpc_port_toggle_bits(const struct device *dev,
 	return 0;
 }
 
-static void gpio_mcux_lpc_port_isr(const struct device *dev)
+
+/* Called by PINT when pin interrupt fires */
+static void gpio_mcux_lpc_pint_cb(uint8_t pin, void *user)
 {
+	const struct device *dev = user;
 	const struct gpio_mcux_lpc_config *config = dev->config;
 	struct gpio_mcux_lpc_data *data = dev->data;
-	uint32_t enabled_int;
-	uint32_t int_flags;
-	uint32_t pin;
+	uint32_t gpio_pin;
 
-	for (pin = 0; pin < 32; pin++) {
-		if (data->pint_id[pin] != NO_PINT_INT) {
-			int_flags = PINT_PinInterruptGetStatus(
-				config->pint_base, data->pint_id[pin]);
-			enabled_int = int_flags << pin;
-
-			if (int_flags) {
-				PINT_PinInterruptClrStatus(config->pint_base,
-							   data->pint_id[pin]);
-			}
-
-			gpio_fire_callbacks(&data->callbacks, dev, enabled_int);
-		}
-	}
-}
-
-static uint32_t get_free_isr(struct gpio_mcux_lpc_data *data)
-{
-	uint32_t i;
-	uint32_t isr;
-
-	for (i = 0; i < data->isr_list_idx; i++) {
-		if (data->isr_list[i] != -1) {
-			isr = data->isr_list[i];
-			data->isr_list[i] = -1;
-			return isr;
-		}
-	}
-
-	return -EINVAL;
-}
-
-/* Function configures INPUTMUX device to route pin interrupts to a certain
- * PINT. PINT no. is unknown, rather it's determined from ISR no.
- */
-static uint32_t attach_pin_to_isr(uint32_t port, uint32_t pin, uint32_t isr_no)
-{
-	uint32_t pint_idx;
-	/* Connect trigger sources to PINT */
-	INPUTMUX_Init(INPUTMUX);
-
-	/* Code asumes PIN_INT values are grouped [0..3] and [4..7].
-	 * This scenario is true in LPC54xxx/LPC55xxx.
+	/* Subtract port number times 32 from pin number to get GPIO API
+	 * pin number.
 	 */
-#if (FSL_FEATURE_PINT_NUMBER_OF_CONNECTED_OUTPUTS > 8)
-	#error having more than 8 PINT IRQs not supported in driver
-#elif (FSL_FEATURE_PINT_NUMBER_OF_CONNECTED_OUTPUTS > 4)
-	if (isr_no < PIN_INT4_IRQn) {
-		pint_idx = isr_no - PIN_INT0_IRQn;
-	} else {
-		pint_idx = isr_no - PIN_INT4_IRQn + 4;
-	}
-#else
-	pint_idx = isr_no - PIN_INT0_IRQn;
-#endif
+	gpio_pin = pin - (config->port_no * 32);
 
-	INPUTMUX_AttachSignal(INPUTMUX, pint_idx,
-			      PIN_TO_INPUT_MUX_CONNECTION(port, pin));
-
-	/* Turnoff clock to inputmux to save power. Clock is only needed to make
-	 * changes. Can be turned off after.
-	 */
-	INPUTMUX_Deinit(INPUTMUX);
-
-	return pint_idx;
+	gpio_fire_callbacks(&data->callbacks, dev, BIT(gpio_pin));
 }
-
-static void gpio_mcux_lpc_port_isr(const struct device *dev);
 
 
 static int gpio_mcux_lpc_pin_interrupt_configure(const struct device *dev,
@@ -295,13 +213,10 @@ static int gpio_mcux_lpc_pin_interrupt_configure(const struct device *dev,
 						 enum gpio_int_trig trig)
 {
 	const struct gpio_mcux_lpc_config *config = dev->config;
-	struct gpio_mcux_lpc_data *data = dev->data;
-	pint_pin_enable_t interruptMode = kPINT_PinIntEnableNone;
+	enum nxp_pint_trigger interrupt_mode = NXP_PINT_NONE;
 	GPIO_Type *gpio_base = config->gpio_base;
 	uint32_t port = config->port_no;
-	uint32_t isr;
-	uint32_t pint_idx;
-	static bool pint_inited;
+	int ret;
 
 	/* Ensure pin used as interrupt is set as input*/
 	if ((mode & GPIO_INT_ENABLE) &&
@@ -311,50 +226,39 @@ static int gpio_mcux_lpc_pin_interrupt_configure(const struct device *dev,
 
 	switch (mode) {
 	case GPIO_INT_MODE_DISABLED:
-		interruptMode = kPINT_PinIntEnableNone;
-		break;
+		nxp_pint_pin_disable((config->port_no * 32) + pin);
+		return 0;
 	case GPIO_INT_MODE_LEVEL:
 		if (trig == GPIO_INT_TRIG_HIGH) {
-			interruptMode = kPINT_PinIntEnableHighLevel;
+			interrupt_mode = NXP_PINT_HIGH;
 		} else if (trig == GPIO_INT_TRIG_LOW) {
-			interruptMode = kPINT_PinIntEnableLowLevel;
+			interrupt_mode = NXP_PINT_LOW;
 		} else {
 			return -ENOTSUP;
 		}
 		break;
 	case GPIO_INT_MODE_EDGE:
 		if (trig == GPIO_INT_TRIG_HIGH) {
-			interruptMode = kPINT_PinIntEnableRiseEdge;
+			interrupt_mode = NXP_PINT_RISING;
 		} else if (trig == GPIO_INT_TRIG_LOW) {
-			interruptMode = kPINT_PinIntEnableFallEdge;
+			interrupt_mode = NXP_PINT_FALLING;
 		} else {
-			interruptMode = kPINT_PinIntEnableBothEdges;
+			interrupt_mode = NXP_PINT_BOTH;
 		}
 		break;
 	default:
 		return -ENOTSUP;
 	}
 
-	/* First time calling this function routes PIN->PINT->INPUTMUX->NVIC */
-	if (data->pint_id[pin] == NO_PINT_INT) {
-		isr = get_free_isr(data);
-		if (isr == -EINVAL) {
-			/* Didn't find any free interrupt in this port */
-			return -EBUSY;
-		}
-		pint_idx = attach_pin_to_isr(port, pin, isr);
-		data->pint_id[pin] = pint_idx;
+	/* PINT treats GPIO pins as continuous. Each port has 32 pins */
+	ret = nxp_pint_pin_enable((config->port_no * 32) + pin, interrupt_mode);
+	if (ret < 0) {
+		return ret;
 	}
-
-	if (!pint_inited) {
-		PINT_Init(config->pint_base);
-		pint_inited = true;
-	}
-	PINT_PinInterruptConfig(config->pint_base, data->pint_id[pin],
-		interruptMode,
-		(pint_cb_t)gpio_mcux_lpc_port_isr);
-
-	return 0;
+	/* Install callback */
+	return nxp_pint_pin_set_callback((config->port_no * 32) + pin,
+					  gpio_mcux_lpc_pint_cb,
+					  (struct device *)dev);
 }
 
 static int gpio_mcux_lpc_manage_cb(const struct device *port,
@@ -368,16 +272,8 @@ static int gpio_mcux_lpc_manage_cb(const struct device *port,
 static int gpio_mcux_lpc_init(const struct device *dev)
 {
 	const struct gpio_mcux_lpc_config *config = dev->config;
-	struct gpio_mcux_lpc_data *data = dev->data;
-	int i;
 
 	GPIO_PortInit(config->gpio_base, config->port_no);
-
-	for (i = 0; i < 32; i++) {
-		data->pint_id[i] = NO_PINT_INT;
-	}
-
-	data->isr_list_idx = 0;
 
 	return 0;
 }
@@ -401,20 +297,6 @@ static const clock_ip_name_t gpio_clock_names[] = GPIO_CLOCKS;
 #define PINMUX_BASE	IOCON
 #endif
 
-#define GPIO_MCUX_LPC_IRQ_CONNECT(n, m)							\
-	do {										\
-		struct gpio_mcux_lpc_data *data = dev->data;				\
-		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, m, irq),				\
-			    DT_INST_IRQ_BY_IDX(n, m, priority),				\
-			    gpio_mcux_lpc_port_isr, DEVICE_DT_INST_GET(n), 0);		\
-		irq_enable(DT_INST_IRQ_BY_IDX(n, m, irq));				\
-		data->isr_list[data->isr_list_idx++] = DT_INST_IRQ_BY_IDX(n, m, irq);	\
-	} while (false)
-
-#define GPIO_MCUX_LPC_IRQ(idx, inst)							\
-	COND_CODE_1(DT_INST_IRQ_HAS_IDX(inst, idx),					\
-		(GPIO_MCUX_LPC_IRQ_CONNECT(inst, idx)), ())
-
 
 #define GPIO_MCUX_LPC(n)								\
 	static int lpc_gpio_init_##n(const struct device *dev);				\
@@ -424,7 +306,6 @@ static const clock_ip_name_t gpio_clock_names[] = GPIO_CLOCKS;
 			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),		\
 		},									\
 		.gpio_base = GPIO,							\
-		.pint_base = PINT, /* TODO: SECPINT issue #16330 */			\
 		.pinmux_base = PINMUX_BASE,						\
 		.port_no = DT_INST_PROP(n, port),					\
 		.clock_ip_name = gpio_clock_names[DT_INST_PROP(n, port)],		\
@@ -441,8 +322,6 @@ static const clock_ip_name_t gpio_clock_names[] = GPIO_CLOCKS;
 	static int lpc_gpio_init_##n(const struct device *dev)				\
 	{										\
 		gpio_mcux_lpc_init(dev);						\
-											\
-		LISTIFY(8, GPIO_MCUX_LPC_IRQ, (;), n)					\
 											\
 		return 0;								\
 	}

--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -32,6 +32,7 @@ zephyr_library_sources_ifdef(CONFIG_VEXRISCV_LITEX_IRQ      intc_vexriscv_litex.
 zephyr_library_sources_ifdef(CONFIG_NUCLEI_ECLIC            intc_nuclei_eclic.c)
 zephyr_library_sources_ifdef(CONFIG_NXP_S32_EIRQ            intc_eirq_nxp_s32.c)
 zephyr_library_sources_ifdef(CONFIG_XMC4XXX_INTC            intc_xmc4xxx.c)
+zephyr_library_sources_ifdef(CONFIG_NXP_PINT                intc_nxp_pint.c)
 
 if(CONFIG_INTEL_VTD_ICTL)
   zephyr_library_include_directories(${ZEPHYR_BASE}/arch/x86/include)

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -98,4 +98,6 @@ source "drivers/interrupt_controller/Kconfig.nxp_s32"
 
 source "drivers/interrupt_controller/Kconfig.xmc4xxx"
 
+source "drivers/interrupt_controller/Kconfig.nxp_pint"
+
 endmenu

--- a/drivers/interrupt_controller/Kconfig.nxp_pint
+++ b/drivers/interrupt_controller/Kconfig.nxp_pint
@@ -1,0 +1,9 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config NXP_PINT
+	bool "Pin interrupt and pattern match engine (PINT) for NXP MCUs"
+	default y
+	depends on DT_HAS_NXP_PINT_ENABLED
+	help
+	  Enable PINT driver for NXP MCUs

--- a/drivers/interrupt_controller/intc_nxp_pint.c
+++ b/drivers/interrupt_controller/intc_nxp_pint.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Based on STM32 EXTI driver, which is (c) 2016 Open-RnD Sp. z o.o. */
+
+#include <zephyr/device.h>
+#include <zephyr/irq.h>
+#include <errno.h>
+#include <zephyr/drivers/interrupt_controller/nxp_pint.h>
+
+#include <fsl_inputmux.h>
+
+#define DT_DRV_COMPAT nxp_pint
+
+#define PINT_NODE DT_INST(0, DT_DRV_COMPAT)
+
+static PINT_Type *pint_base = (PINT_Type *)DT_REG_ADDR(PINT_NODE);
+
+/* Describes configuration of PINT IRQ slot */
+struct pint_irq_slot {
+	nxp_pint_cb_t callback;
+	void *user_data;
+	uint8_t pin: 6;
+	uint8_t used: 1;
+};
+
+#define NO_PINT_ID 0xFF
+
+/* Tracks IRQ configuration for each pint interrupt source */
+static struct pint_irq_slot pint_irq_cfg[DT_PROP(PINT_NODE, num_lines)];
+/* Tracks pint interrupt source selected for each pin */
+static uint8_t pin_pint_id[DT_PROP(PINT_NODE, num_inputs)];
+
+#define PIN_TO_INPUT_MUX_CONNECTION(pin) \
+	((PINTSEL_PMUX_ID << PMUX_SHIFT) + (pin))
+
+/* Attaches pin to PINT IRQ slot using INPUTMUX */
+static void attach_pin_to_pint(uint8_t pin, uint8_t pint_slot)
+{
+	INPUTMUX_Init(INPUTMUX);
+
+	/* Three parameters here- INPUTMUX base, the ID of the PINT slot,
+	 * and a integer describing the GPIO pin.
+	 */
+	INPUTMUX_AttachSignal(INPUTMUX, pint_slot,
+			      PIN_TO_INPUT_MUX_CONNECTION(pin));
+
+	/* Disable INPUTMUX after making changes, this gates clock and
+	 * saves power.
+	 */
+	INPUTMUX_Deinit(INPUTMUX);
+}
+
+/**
+ * @brief Enable PINT interrupt source.
+ *
+ * @param pin: pin to use as interrupt source
+ *     0-64, corresponding to GPIO0 pin 1 - GPIO1 pin 31)
+ * @param trigger: one of nxp_pint_trigger flags
+ * @return 0 on success, or negative value on error
+ */
+int nxp_pint_pin_enable(uint8_t pin, enum nxp_pint_trigger trigger)
+{
+	uint8_t slot = 0U;
+
+	if (pin > ARRAY_SIZE(pin_pint_id)) {
+		/* Invalid pin ID */
+		return -EINVAL;
+	}
+	/* Find unused IRQ slot */
+	if (pin_pint_id[pin] != NO_PINT_ID) {
+		slot = pin_pint_id[pin];
+	} else {
+		for (slot = 0; slot < ARRAY_SIZE(pint_irq_cfg); slot++) {
+			if (!pint_irq_cfg[slot].used) {
+				break;
+			}
+		}
+		if (slot == ARRAY_SIZE(pint_irq_cfg)) {
+			/* No free IRQ slots */
+			return -EBUSY;
+		}
+		pin_pint_id[pin] = slot;
+	}
+	pint_irq_cfg[slot].used = true;
+	pint_irq_cfg[slot].pin = pin;
+	/* Attach pin to interrupt slot using INPUTMUX */
+	attach_pin_to_pint(pin, slot);
+	/* Now configure the interrupt. No need to install callback, this
+	 * driver handles the IRQ
+	 */
+	PINT_PinInterruptConfig(pint_base, slot, trigger, NULL);
+	return 0;
+}
+
+
+/**
+ * @brief disable PINT interrupt source.
+ *
+ * @param pin: pin interrupt source to disable
+ */
+void nxp_pint_pin_disable(uint8_t pin)
+{
+	uint8_t slot;
+
+	if (pin > ARRAY_SIZE(pin_pint_id)) {
+		return;
+	}
+
+	slot = pin_pint_id[pin];
+	if (slot == NO_PINT_ID) {
+		return;
+	}
+	/* Remove this pin from the PINT slot if one was in use */
+	pint_irq_cfg[slot].used = false;
+	PINT_PinInterruptConfig(pint_base, slot, kPINT_PinIntEnableNone, NULL);
+}
+
+/**
+ * @brief Install PINT callback
+ *
+ * @param pin: interrupt source to install callback for
+ * @param cb: callback to install
+ * @param data: user data to include in callback
+ * @return 0 on success, or negative value on error
+ */
+int nxp_pint_pin_set_callback(uint8_t pin, nxp_pint_cb_t cb, void *data)
+{
+	uint8_t slot;
+
+	if (pin > ARRAY_SIZE(pin_pint_id)) {
+		return -EINVAL;
+	}
+
+	slot = pin_pint_id[pin];
+	if (slot == NO_PINT_ID) {
+		return -EINVAL;
+	}
+
+	pint_irq_cfg[slot].callback = cb;
+	pint_irq_cfg[slot].user_data = data;
+	return 0;
+}
+
+/**
+ * @brief Remove PINT callback
+ *
+ * @param pin: interrupt source to remove callback for
+ */
+void nxp_pint_pin_unset_callback(uint8_t pin)
+{
+	uint8_t slot;
+
+	if (pin > ARRAY_SIZE(pin_pint_id)) {
+		return;
+	}
+
+	slot = pin_pint_id[pin];
+	if (slot == NO_PINT_ID) {
+		return;
+	}
+
+	pint_irq_cfg[slot].callback = NULL;
+}
+
+/* NXP PINT ISR handler- called with PINT slot ID */
+static void nxp_pint_isr(uint8_t *slot)
+{
+	PINT_PinInterruptClrStatus(pint_base, *slot);
+	if (pint_irq_cfg[*slot].used && pint_irq_cfg[*slot].callback) {
+		pint_irq_cfg[*slot].callback(pint_irq_cfg[*slot].pin,
+					pint_irq_cfg[*slot].user_data);
+	}
+}
+
+
+/* Defines PINT IRQ handler for a given irq index */
+#define NXP_PINT_IRQ(idx, node_id)						\
+	IF_ENABLED(DT_IRQ_HAS_IDX(node_id, idx),				\
+	(static uint8_t nxp_pint_idx_##idx = idx;				\
+	do {									\
+		IRQ_CONNECT(DT_IRQ_BY_IDX(node_id, idx, irq),			\
+			    DT_IRQ_BY_IDX(node_id, idx, priority),		\
+			    nxp_pint_isr, &nxp_pint_idx_##idx, 0);		\
+		irq_enable(DT_IRQ_BY_IDX(node_id, idx, irq));			\
+	} while (false)))
+
+static int intc_nxp_pint_init(void)
+{
+	/* First, connect IRQs for each interrupt.
+	 * The IRQ handler will receive the PINT slot as a
+	 * parameter.
+	 */
+	LISTIFY(8, NXP_PINT_IRQ, (;), PINT_NODE);
+	PINT_Init(pint_base);
+	memset(pin_pint_id, NO_PINT_ID, ARRAY_SIZE(pin_pint_id));
+	return 0;
+}
+
+SYS_INIT(intc_nxp_pint_init, PRE_KERNEL_1,
+	CONFIG_INTC_INIT_PRIORITY);

--- a/dts/arm/nxp/nxp_lpc51u68.dtsi
+++ b/dts/arm/nxp/nxp_lpc51u68.dtsi
@@ -57,7 +57,6 @@
 		gpio0: gpio@0 {
 			compatible = "nxp,lpc-gpio";
 			reg = <0x4008c000 0x2484>;
-			interrupts = <4 2>,<5 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
 			port = <0>;
@@ -66,10 +65,20 @@
 		gpio1: gpio@1 {
 			compatible = "nxp,lpc-gpio";
 			reg = <0x4008C000 0x2484>;
-			interrupts = <6 2>,<7 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
 			port = <1>;
+		};
+
+		pint: pint@4000 {
+			compatible = "nxp,pint";
+			reg = <0x4000 0x1000>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			#address-cells = <0>;
+			interrupts = <4 2>, <5 2>, <6 2>, <7 2>;
+			num-lines = <4>;
+			num-inputs = <64>;
 		};
 
 		flexcomm0: flexcomm@40086000 {

--- a/dts/arm/nxp/nxp_lpc51u68.dtsi
+++ b/dts/arm/nxp/nxp_lpc51u68.dtsi
@@ -57,6 +57,7 @@
 		gpio0: gpio@0 {
 			compatible = "nxp,lpc-gpio";
 			reg = <0x4008c000 0x2484>;
+			int-source = "pint";
 			gpio-controller;
 			#gpio-cells = <2>;
 			port = <0>;
@@ -65,6 +66,7 @@
 		gpio1: gpio@1 {
 			compatible = "nxp,lpc-gpio";
 			reg = <0x4008C000 0x2484>;
+			int-source = "pint";
 			gpio-controller;
 			#gpio-cells = <2>;
 			port = <1>;

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -112,6 +112,7 @@
 		gpio0: gpio@0 {
 			compatible = "nxp,lpc-gpio";
 			reg = <0x4008c000 0x2488>;
+			int-source = "pint";
 			gpio-controller;
 			#gpio-cells = <2>;
 			port = <0>;
@@ -120,6 +121,7 @@
 		gpio1: gpio@1 {
 			compatible = "nxp,lpc-gpio";
 			reg = <0x4008C000 0x2488>;
+			int-source = "pint";
 			gpio-controller;
 			#gpio-cells = <2>;
 			port = <1>;

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -112,7 +112,6 @@
 		gpio0: gpio@0 {
 			compatible = "nxp,lpc-gpio";
 			reg = <0x4008c000 0x2488>;
-			interrupts = <4 2>,<5 2>,<6 2>,<7 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
 			port = <0>;
@@ -121,10 +120,21 @@
 		gpio1: gpio@1 {
 			compatible = "nxp,lpc-gpio";
 			reg = <0x4008C000 0x2488>;
-			interrupts = <32 2>,<33 2>,<34 2>,<35 2>;
 			gpio-controller;
 			#gpio-cells = <2>;
 			port = <1>;
+		};
+
+		pint: pint@4000 {
+			compatible = "nxp,pint";
+			reg = <0x4000 0x1000>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			#address-cells = <0>;
+			interrupts = <4 2>, <5 2>, <6 2>, <7 2>,
+				<32 2>, <33 2>, <34 2>, <35 2>;
+			num-lines = <8>;
+			num-inputs = <64>;
 		};
 
 		mailbox0:mailbox@4008b000 {

--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -116,7 +116,6 @@
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
-		interrupts = <4 2>,<5 2>,<6 2>,<7 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <0>;
@@ -125,10 +124,21 @@
 	gpio1: gpio@1 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
-		interrupts = <32 2>,<33 2>,<34 2>,<35 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <1>;
+	};
+
+	pint: pint@4000 {
+		compatible = "nxp,pint";
+		reg = <0x4000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		#address-cells = <0>;
+		interrupts = <4 2>, <5 2>, <6 2>, <7 2>,
+			<32 2>, <33 2>, <34 2>, <35 2>;
+		num-lines = <8>;
+		num-inputs = <64>;
 	};
 
 	flexcomm0: flexcomm@86000 {

--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -116,6 +116,7 @@
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
+		int-source = "pint";
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <0>;
@@ -124,6 +125,7 @@
 	gpio1: gpio@1 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
+		int-source = "pint";
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <1>;

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -120,7 +120,6 @@
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
-		interrupts = <4 2>,<5 2>,<6 2>,<7 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <0>;
@@ -129,10 +128,21 @@
 	gpio1: gpio@1 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
-		interrupts = <32 2>,<33 2>,<34 2>,<35 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <1>;
+	};
+
+	pint: pint@4000 {
+		compatible = "nxp,pint";
+		reg = <0x4000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		#address-cells = <0>;
+		interrupts = <4 2>, <5 2>, <6 2>, <7 2>,
+			<32 2>, <33 2>, <34 2>, <35 2>;
+		num-lines = <8>;
+		num-inputs = <64>;
 	};
 
 	flexcomm0: flexcomm@86000 {

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -120,6 +120,7 @@
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
+		int-source = "pint";
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <0>;
@@ -128,6 +129,7 @@
 	gpio1: gpio@1 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
+		int-source = "pint";
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <1>;

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -127,6 +127,7 @@
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
+		int-source = "pint";
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <0>;
@@ -135,6 +136,7 @@
 	gpio1: gpio@1 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
+		int-source = "pint";
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <1>;

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -127,7 +127,6 @@
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
-		interrupts = <4 2>,<5 2>,<6 2>,<7 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <0>;
@@ -136,10 +135,21 @@
 	gpio1: gpio@1 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
-		interrupts = <32 2>,<33 2>,<34 2>,<35 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <1>;
+	};
+
+	pint: pint@4000 {
+		compatible = "nxp,pint";
+		reg = <0x4000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		#address-cells = <0>;
+		interrupts = <4 2>, <5 2>, <6 2>, <7 2>,
+			<32 2>, <33 2>, <34 2>, <35 2>;
+		num-lines = <8>;
+		num-inputs = <64>;
 	};
 
 	dma0: dma-controller@82000 {

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -123,7 +123,6 @@
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x278c>;
-		interrupts = <4 2>,<5 2>,<6 2>,<7 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <0>;
@@ -132,7 +131,6 @@
 	gpio1: gpio@1 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x278c>;
-		interrupts = <32 2>,<33 2>,<34 2>,<35 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <1>;
@@ -141,10 +139,21 @@
 	gpio2: gpio@2 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x278c>;
-		#interrupts = <32 2>,<33 2>,<34 2>,<35 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <2>;
+	};
+
+	pint: pint@4000 {
+		compatible = "nxp,pint";
+		reg = <0x4000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		#address-cells = <0>;
+		interrupts = <4 2>, <5 2>, <6 2>, <7 2>,
+			<32 2>, <33 2>, <34 2>, <35 2>;
+		num-lines = <8>;
+		num-inputs = <64>;
 	};
 
 	flexcomm0: flexcomm@86000 {

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -123,6 +123,7 @@
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x278c>;
+		int-source = "pint";
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <0>;
@@ -131,6 +132,7 @@
 	gpio1: gpio@1 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x278c>;
+		int-source = "pint";
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <1>;

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -146,7 +146,6 @@
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
-		interrupts = <4 2>,<5 2>,<6 2>,<7 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <0>;
@@ -155,10 +154,21 @@
 	gpio1: gpio@1 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
-		interrupts = <32 2>,<33 2>,<34 2>,<35 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <1>;
+	};
+
+	pint: pint@4000 {
+		compatible = "nxp,pint";
+		reg = <0x4000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		#address-cells = <0>;
+		interrupts = <4 2>, <5 2>, <6 2>, <7 2>,
+			<32 2>, <33 2>, <34 2>, <35 2>;
+		num-lines = <8>;
+		num-inputs = <64>;
 	};
 
 	dma0: dma-controller@82000 {

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -146,6 +146,7 @@
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
+		int-source = "pint";
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <0>;
@@ -154,6 +155,7 @@
 	gpio1: gpio@1 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x8c000 0x2488>;
+		int-source = "pint";
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <1>;

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -98,6 +98,7 @@
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x100000 0x1000>;
+		int-source = "pint";
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <0>;
@@ -106,6 +107,7 @@
 	gpio1: gpio@1 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x100000 0x1000>;
+		int-source = "pint";
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <1>;

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -98,7 +98,6 @@
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x100000 0x1000>;
-		interrupts = <4 2>,<5 2>,<6 2>,<7 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <0>;
@@ -107,7 +106,6 @@
 	gpio1: gpio@1 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x100000 0x1000>;
-		interrupts = <35 2>,<36 2>,<37 2>,<38 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <1>;
@@ -151,6 +149,18 @@
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <6>;
+	};
+
+	pint: pint@25000 {
+		compatible = "nxp,pint";
+		reg = <0x25000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		#address-cells = <0>;
+		interrupts = <4 2>, <5 2>, <6 2>, <7 2>,
+			<35 2>, <36 2>, <37 2>, <38 2>;
+		num-lines = <8>;
+		num-inputs = <64>;
 	};
 
 	flexcomm0: flexcomm@106000 {

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -97,6 +97,7 @@
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x100000 0x1000>;
+		int-source = "pint";
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <0>;
@@ -105,6 +106,7 @@
 	gpio1: gpio@1 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x100000 0x1000>;
+		int-source = "pint";
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <1>;

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -97,7 +97,6 @@
 	gpio0: gpio@0 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x100000 0x1000>;
-		interrupts = <4 2>,<5 2>,<6 2>,<7 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <0>;
@@ -106,7 +105,6 @@
 	gpio1: gpio@1 {
 		compatible = "nxp,lpc-gpio";
 		reg = <0x100000 0x1000>;
-		interrupts = <35 2>,<36 2>,<37 2>,<38 2>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <1>;
@@ -142,6 +140,18 @@
 		gpio-controller;
 		#gpio-cells = <2>;
 		port = <7>;
+	};
+
+	pint: pint@25000 {
+		compatible = "nxp,pint";
+		reg = <0x25000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		#address-cells = <0>;
+		interrupts = <4 2>, <5 2>, <6 2>, <7 2>,
+			<35 2>, <36 2>, <37 2>, <38 2>;
+		num-lines = <8>;
+		num-inputs = <64>;
 	};
 
 	flexcomm0: flexcomm@106000 {

--- a/dts/bindings/gpio/nxp,lpc-gpio.yaml
+++ b/dts/bindings/gpio/nxp,lpc-gpio.yaml
@@ -28,6 +28,21 @@ properties:
       - 6
       - 7
 
+  int-source:
+    type: string
+    default: "none"
+    enum:
+      - "pint"
+      - "int-a"
+      - "int-b"
+      - "none"
+    description: |
+      Interrupt source for the gpio port. For ports that can use the PINT
+      as an interrupt source for their pins (typically ports 0 and 1),
+      this can be set to PINT. Otherwise, the property should be set to "int-a"
+      or "int-b" if interrupt support is desired, and the appropriate IRQ number
+      should set for the device.
+
 gpio-cells:
   - pin
   - flags

--- a/dts/bindings/interrupt-controller/nxp,pint.yaml
+++ b/dts/bindings/interrupt-controller/nxp,pint.yaml
@@ -1,0 +1,24 @@
+description: NXP Pin interrupt and pattern match engine (PINT)
+
+compatible: "nxp,pint"
+
+include: [base.yaml, interrupt-controller.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  num-lines:
+    type: int
+    required: true
+    description: Number of interrupt lines supported by the interrupt controller.
+
+  num-inputs:
+    type: int
+    required: true
+    description: |
+      Number of inputs available to the PINT engine. These inputs are typically
+      GPIO pins.

--- a/include/zephyr/drivers/interrupt_controller/nxp_pint.h
+++ b/include/zephyr/drivers/interrupt_controller/nxp_pint.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @brief Driver for Pin interrupt and pattern match engine in NXP MCUs
+ *
+ * The Pin interrupt and pattern match engine (PINT) supports
+ * sourcing inputs from any pins on GPIO ports 0 and 1 of NXP MCUs
+ * featuring the module, and generating interrupts based on these inputs.
+ * Pin inputs can generate separate interrupts to the NVIC, or be combined
+ * using the PINT's boolean logic based pattern match engine.
+ * This driver currently only supports the pin interrupt feature of
+ * the PINT.
+ */
+
+#ifndef ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_NXP_PINT_H_
+#define ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_NXP_PINT_H_
+
+#include <fsl_pint.h>
+
+/**
+ * @brief Pin interrupt sources
+ *
+ * Pin interrupt sources available for use.
+ */
+enum nxp_pint_trigger {
+	/* Do not generate Pin Interrupt */
+	NXP_PINT_NONE = kPINT_PinIntEnableNone,
+	/* Generate Pin Interrupt on rising edge */
+	NXP_PINT_RISING  = kPINT_PinIntEnableRiseEdge,
+	/* Generate Pin Interrupt on falling edge */
+	NXP_PINT_FALLING  = kPINT_PinIntEnableFallEdge,
+	/* Generate Pin Interrupt on both edges */
+	NXP_PINT_BOTH = kPINT_PinIntEnableBothEdges,
+	/* Generate Pin Interrupt on low level */
+	NXP_PINT_LOW  = kPINT_PinIntEnableLowLevel,
+	/* Generate Pin Interrupt on high level */
+	NXP_PINT_HIGH = kPINT_PinIntEnableHighLevel
+};
+
+/* Callback for NXP PINT interrupt */
+typedef void (*nxp_pint_cb_t) (uint8_t pin, void *user);
+
+/**
+ * @brief Enable PINT interrupt source.
+ *
+ * @param pin: pin to use as interrupt source
+ *     0-64, corresponding to GPIO0 pin 1 - GPIO1 pin 31)
+ * @param trigger: one of nxp_pint_trigger flags
+ */
+int nxp_pint_pin_enable(uint8_t pin, enum nxp_pint_trigger trigger);
+
+
+/**
+ * @brief disable PINT interrupt source.
+ *
+ * @param pin: pin interrupt source to disable
+ */
+void nxp_pint_pin_disable(uint8_t pin);
+
+/**
+ * @brief Install PINT callback
+ *
+ * @param pin: interrupt source to install callback for
+ * @param cb: callback to install
+ * @param data: user data to include in callback
+ * @return 0 on success, or negative value on error
+ */
+int nxp_pint_pin_set_callback(uint8_t pin, nxp_pint_cb_t cb, void *data);
+
+/**
+ * @brief Remove PINT callback
+ *
+ * @param pin: interrupt source to remove callback for
+ */
+void nxp_pint_pin_unset_callback(uint8_t pin);
+
+
+#endif /* ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_NXP_PINT_H_ */

--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: d3c964cd854e53d55d21532431ee337d55348d8c
+      revision: f41cf88971505257e7f4798d845699da3fdc36d0
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
LPC gpio driver has historically used the PINT to route interrupts, which limits interrupt routing to GPIO ports that the PINT supports as inputs. Add the ability to configure the interrupt source for each GPIO driver, so the user can allocate the two interrupts shared between all ports as needed for their application.

Note that this still subject to the limitation in Zephyr that device instances cannot share interrupts. Thus, only two additional GPIO ports can have interrupts enabled using this feature.


This PR now also includes a interrupt controller driver for NXP's PINT (pin interrupt and pattern match engine), in order to remove the integration of this IP block directly into the LPC GPIO driver