### PR TITLE
dts: arm: stm32l1 fix Timers 11 node definition

### DIFF
--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -326,9 +326,9 @@
 			};
 		};
 
-		timers11: timers@40011400 {
+		timers11: timers@40011000 {
 			compatible = "st,stm32-timers";
-			reg = <0x40011400 0x400>;
+			reg = <0x40011000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000010>;
 			resets = <&rctl STM32_RESET(APB2, 4U)>;
 			interrupts = <27 0>;


### PR DESCRIPTION
In the stm32l1 family, the Timers11 node has a register at 0x40011000.
It was wrong in the DTS file

Signed-off-by: Francois Ramu <francois.ramu@st.com>