### PR TITLE
Bluetooth: controller: move bn scope from filescope to lll-scope

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -12,6 +12,8 @@ struct lll_conn_iso_stream_rxtx {
 	uint64_t bn:4;             /* Burst number (BN) */
 	uint64_t phy:3;            /* PHY */
 	uint64_t rfu:1;
+	uint8_t bn_curr:4;        /* Current burst number */
+
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	struct ccm ccm;

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -570,6 +570,8 @@ void ll_cis_create(uint16_t cis_handle, uint16_t acl_handle)
 	cis->lll.flushed = 0;
 	cis->lll.active = 0;
 	cis->lll.datapath_ready_rx = 0;
+	cis->lll.tx.bn_curr = 1U;
+	cis->lll.rx.bn_curr = 1U;
 
 	(void)memset(&cis->hdr, 0U, sizeof(cis->hdr));
 
@@ -742,6 +744,9 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 	cis->lll.datapath_ready_rx = 0U;
 	cis->lll.tx.payload_count = 0U;
 	cis->lll.rx.payload_count = 0U;
+
+	cis->lll.tx.bn_curr = 1U;
+	cis->lll.rx.bn_curr = 1U;
 
 	/* Transfer to caller */
 	*cig_sync_delay = cig->sync_delay;

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -259,12 +259,14 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 	cis->lll.rx.ft = req->c_ft;
 	cis->lll.rx.max_pdu = sys_le16_to_cpu(req->c_max_pdu);
 	cis->lll.rx.payload_count = 0;
+	cis->lll.rx.bn_curr = 1U;
 
 	cis->lll.tx.phy = req->p_phy;
 	cis->lll.tx.bn = req->p_bn;
 	cis->lll.tx.ft = req->p_ft;
 	cis->lll.tx.max_pdu = sys_le16_to_cpu(req->p_max_pdu);
 	cis->lll.tx.payload_count = 0;
+	cis->lll.tx.bn_curr = 1U;
 
 	if (!cis->lll.link_tx_free) {
 		cis->lll.link_tx_free = &cis->lll.link_tx;
@@ -330,6 +332,8 @@ uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 	cis->lll.datapath_ready_rx = 0U;
 	cis->lll.tx.payload_count = 0U;
 	cis->lll.rx.payload_count = 0U;
+	cis->lll.rx.bn_curr = 1U;
+	cis->lll.tx.bn_curr = 1U;
 
 	return 0;
 }


### PR DESCRIPTION
The scope for the burst number for tx and rx is currently at module level in lll_central_iso.c and lll_peripheral_iso.c. This PR puts the scope to the lll level

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>
