### PR TITLE
doc: peripherals: fuel_gauge: align title with the rest of the docs

### DIFF
--- a/doc/hardware/peripherals/fuel_gauge.rst
+++ b/doc/hardware/peripherals/fuel_gauge.rst
@@ -1,7 +1,7 @@
 .. _fuel_gauge_api:
 
-Fuel Gauges (Experimental API Stub Doc)
-#######################################
+Fuel Gauge
+##########
 
 The fuel gauge subsystem exposes an API to uniformly access battery fuel gauge devices. Currently,
 only reading data is supported.


### PR DESCRIPTION
Align the title for the fuel gauge peripheral API with the rest of the documentation.