### PR TITLE
drivers: ethernet: add dependency to CONFIG_ETH_INIT_PRIORITY

### DIFF
--- a/drivers/ethernet/Kconfig
+++ b/drivers/ethernet/Kconfig
@@ -66,6 +66,7 @@ endif # "Ethernet Drivers"
 config ETH_INIT_PRIORITY
 	int "Ethernet driver init priority"
 	default 80
+	depends on NET_L2_ETHERNET
 	help
 	  Ethernet device driver initialization priority.
 	  Do not mess with it unless you know what you are doing.


### PR DESCRIPTION
Add a dependency on CONFIG_NET_L2_ETHERNET for CONFIG_ETH_INIT_PRIORITY. This hides the Ethernet driver initialization priority option in menuconfig unless CONFIG_NET_L2_ETHERNET is selected.

CONFIG_ETH_INIT_PRIORITY cannot currently be moved inside the CONFIG_ETH_DRIVER if-statement in Kconfig as it is used outside the Ethernet driver source files.

