### PR TITLE
drivers: peci: move CONFIG_PECI_INTERRUPT_DRIVEN inside if statement

### DIFF
--- a/drivers/peci/Kconfig
+++ b/drivers/peci/Kconfig
@@ -26,10 +26,10 @@ config PECI_INIT_PRIORITY
 	  There isn't any critical component relying on this priority at
 	  the moment.
 
-endif # PECI
-
 config PECI_INTERRUPT_DRIVEN
 	bool "PECI driver interrupt support"
 	help
 	  This is an option to be enabled by individual peci driver
 	  to indicate that the driver and hardware supports interrupts.
+
+endif # PECI


### PR DESCRIPTION
Move CONFIG_PECI_INTERRUPT_DRIVEN inside the CONFIG_PECI if statement to avoid showing it in menuconfig when PECI drivers are disabled.