### PR TITLE
drivers: dac: sam: add missing zephyr/kernel.h include

### DIFF
--- a/drivers/dac/dac_sam.c
+++ b/drivers/dac/dac_sam.c
@@ -20,7 +20,7 @@
 #include <zephyr/drivers/dac.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
-
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
 LOG_MODULE_REGISTER(dac_sam, CONFIG_DAC_LOG_LEVEL);


### PR DESCRIPTION
The missing include was detected when adding the driver to the CI build tests in #56140.