### PR TITLE
[Backport v3.3-branch] drivers: dac: sam: add missing zephyr/kernel.h include

### DIFF
--- a/drivers/dac/dac_sam.c
+++ b/drivers/dac/dac_sam.c
@@ -19,7 +19,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/dac.h>
 #include <zephyr/drivers/pinctrl.h>
-
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
 LOG_MODULE_REGISTER(dac_sam, CONFIG_DAC_LOG_LEVEL);


### PR DESCRIPTION
The missing include was detected when adding the driver to the CI build tests.

Manually backporting #56357 because of merge conflict, see #56360.

Fixes #56360.