### PR TITLE
mainfest: west.yml: Update version of SEGGER RTT library

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -299,7 +299,7 @@ manifest:
       path: modules/lib/picolibc
       revision: d07c38ff051386f8e09a143ea0a6c1d6d66dd1d8
     - name: segger
-      revision: 4bfaf28a11c3e5ec29badac744fab6d2f342749e
+      revision: 5792675a2470d0f3857de1e77bff57b38c28de3b
       path: modules/debug/segger
       groups:
         - debug


### PR DESCRIPTION
Bumped segger libary version up to version 3.40