### PR TITLE
nrf52_bsim: Default 15.4 driver encryption to n

### DIFF
--- a/boards/posix/nrf52_bsim/Kconfig.defconfig
+++ b/boards/posix/nrf52_bsim/Kconfig.defconfig
@@ -32,6 +32,12 @@ config BT_CTLR
 config NRF_802154_TEMPERATURE_UPDATE
 	default n
 
+# The 15.4 driver Tx encryption is currently not functional with this
+# simulated board => we disable it by default. With this Openthread will normally
+# default to encrypt packets on its own.
+config NRF_802154_ENCRYPTION
+	default n
+
 if LOG
 
 # For this board we can log synchronously without any problem


### PR DESCRIPTION
The 15.4 driver Tx encryption does not work yet in simulation. Let's disable it by default.
(Encryption at Openthread can be used instead).