### PR TITLE
NXP LPC55s16 USB-HS support

### DIFF
--- a/boards/arm/lpcxpresso55s16/lpcxpresso55s16.dts
+++ b/boards/arm/lpcxpresso55s16/lpcxpresso55s16.dts
@@ -13,3 +13,7 @@
 	model = "NXP LPCXpresso55S16 board";
 	compatible = "nxp,lpc55xxx", "nxp,lpc";
 };
+
+zephyr_udc0: &usbhs {
+	status = "okay";
+};

--- a/boards/arm/lpcxpresso55s16/lpcxpresso55s16.yaml
+++ b/boards/arm/lpcxpresso55s16/lpcxpresso55s16.yaml
@@ -22,3 +22,4 @@ supported:
   - gpio
   - i2c
   - spi
+  - usb_device

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -56,11 +56,12 @@
 		zephyr,memory-region = "SRAM2";
 	};
 
-	sram4: memory@20010000 {
+	usb_sram: memory@20010000 {
 		/* Connected to USB bus*/
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20010000 DT_SIZE_K(16)>;
-		zephyr,memory-region = "SRAM4";
+		zephyr,memory-region = "USB_SRAM";
+		zephyr,memory-region-mpu = "RAM";
 	};
 };
 
@@ -231,6 +232,15 @@
 		compatible = "nxp,lpc-rng";
 		reg = <0x3a000 0x1000>;
 		status = "okay";
+	};
+
+	usbhs: usbhs@144000 {
+		compatible = "nxp,mcux-usbd";
+		reg = <0x94000 0x1000>;
+		interrupts = <47 1>;
+		num-bidir-endpoints = <6>;
+		usb-controller-index = "LpcIp3511Hs0";
+		status = "disabled";
 	};
 };
 

--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S16
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S16
@@ -12,4 +12,8 @@ config CAN_MCUX_MCAN
 	default y
 	depends on CAN
 
+choice USB_MCUX_CONTROLLER_TYPE
+	default USB_DC_NXP_LPCIP3511
+endchoice
+
 endif # SOC_LPC55S16


### PR DESCRIPTION
- This make USB samples work for LPC55s16-based boards


EDIT:
It was first crashing during `USB_DeviceLpc3511IpInit()`, at the first write to USB_RAM region,
but that has been solved in a follow-up commit.

Left here for documentation:

Here's additional information on the crash:
`USB_DeviceLpc3511IpInit()` -> `USB_DeviceLpc3511IpSetDefaultState()`, and at the first write to USB_RAM region we get a crash:

Full backtrace:
```
#0  arch_system_halt (reason=reason@entry=25) at <path>/zephyr/kernel/fatal.c:32
#1  0x00005c16 in k_sys_fatal_error_handler (reason=reason@entry=25, esf=esf@entry=0x20002bf8 <z_interrupt_stacks+1976>) at <path>/zephyr/kernel/fatal.c:46
#2  0x00005ce2 in z_fatal_error (reason=reason@entry=25, esf=esf@entry=0x20002bf8 <z_interrupt_stacks+1976>) at <path>/zephyr/kernel/fatal.c:131
#3  0x00003244 in z_arm_fatal_error (reason=reason@entry=25, esf=0x20002bf8 <z_interrupt_stacks+1976>, esf@entry=0x20002c10 <z_interrupt_stacks+2000>) at <path>/zephyr/arch/arm/core/aarch32/fatal.c:63
#4  0x0000398c in z_arm_fault (msp=<optimized out>, psp=<optimized out>, exc_return=<optimized out>, callee_regs=<optimized out>) at <path>/zephyr/arch/arm/core/aarch32/cortex_m/fault.c:1131
#5  0x00003a60 in z_arm_usage_fault () at <path>/zephyr/arch/arm/core/aarch32/cortex_m/fault_s.S:102
#6  <signal handler called>
#7  0x00008a72 in USB_DeviceLpc3511IpSetDefaultState (lpc3511IpState=lpc3511IpState@entry=0x20001360 <s_UsbDeviceLpc3511IpState+364>) at <path>/modules/hal/nxp/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_lpcip3511.c:443
#8  0x00005af6 in USB_DeviceLpc3511IpInit (controllerId=controllerId@entry=6 '\006', handle=handle@entry=0x20000660 <dev_state>, controllerHandle=controllerHandle@entry=0x20000660 <dev_state>) at <path>/modules/hal/nxp/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_lpcip3511.c:1683
#9  0x000045d6 in usb_dc_attach () at <path>/zephyr/drivers/usb/device/usb_dc_mcux.c:156
#10 0x00002b7c in usb_enable (status_cb=status_cb@entry=0x7189 <status_cb>) at <path>/zephyr/subsys/usb/device/usb_device.c:1619
#11 0x0000080c in main () at <path>/zephyr/samples/subsys/usb/hid-mouse/src/main.c:289
```

Here's a screenshot of the code portion:
![image](https://user-images.githubusercontent.com/3796135/228867541-fbb3f1bc-8299-4d5a-b55a-6240d307ace8.png)
