### PR TITLE
drivers: flash: nrf_qspi_nor: Add custom API function to allow XIP

### DIFF
--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840-pinctrl.dtsi
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840-pinctrl.dtsi
@@ -147,6 +147,7 @@
 				<NRF_PSEL(QSPI_IO2, 0, 22)>,
 				<NRF_PSEL(QSPI_IO3, 0, 23)>,
 				<NRF_PSEL(QSPI_CSN, 0, 17)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
 		};
 	};
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
@@ -62,6 +62,7 @@
 				<NRF_PSEL(QSPI_IO2, 0, 15)>,
 				<NRF_PSEL(QSPI_IO3, 0, 16)>,
 				<NRF_PSEL(QSPI_CSN, 0, 18)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
 		};
 	};
 

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -328,6 +328,10 @@ Drivers and Sensors
     selected by the driver to indicate that extra operations are supported.
     To enable extra operations user should select
     :kconfig:option:`CONFIG_FLASH_EX_OP_ENABLED`.
+  * nrf_qspi_nor: Replaced custom API function ``nrf_qspi_nor_base_clock_div_force``
+    with ``nrf_qspi_nor_xip_enable`` which apart from forcing the clock divider
+    prevents the driver from deactivating the QSPI peripheral so that the XIP
+    operation is actually possible.
 
 * FPGA
 

--- a/include/zephyr/drivers/flash/nrf_qspi_nor.h
+++ b/include/zephyr/drivers/flash/nrf_qspi_nor.h
@@ -12,24 +12,24 @@ extern "C" {
 #endif
 
 /**
- * @brief Specifies whether the QSPI base clock divider should be kept set
- *        when the driver is idle
+ * @brief Specifies whether XIP (execute in place) operation should be possible
  *
- * On nRF53 Series SoCs, it is necessary to change the default base clock
- * divider to achieve the highest possible SCK frequencies. This divider
- * should be changed only for periods when it is actually needed, as such
- * configuration significantly increases power consumption, so the driver
- * normally does this only when it performs an operation on the QSPI bus.
- * But when XIP accesses to the flash chip are also used, and the driver
- * is not aware of those, it may be necessary for the divider to be kept
- * changed also when the driver is idle. This function allows forcing this.
+ * Normally, the driver deactivates the QSPI peripheral for periods when
+ * no QSPI operation is performed. This is done to avoid increased current
+ * consumption when the peripheral is idle. For the same reason, the base
+ * clock on nRF53 Series SoCs (HFCLK192M) is configured for those periods
+ * with the default /4 divider that cannot be used otherwise. However, when
+ * XIP accesses are used, the driver must be prevented from doing both these
+ * things as that would make XIP to fail. Hence, the application should use
+ * this function to signal to the driver that XIP accesses are expected to
+ * occur so that it keeps the QSPI peripheral operable. When XIP operation
+ * is no longer needed, it should be disabled with this function.
  *
  * @param dev   flash device
- * @param force if true, forces the base clock divider to be kept set even
- *              when the driver is idle
+ * @param enable if true, the driver enables XIP operation and suppresses
+ *               idle actions that would make XIP to fail
  */
-__syscall void nrf_qspi_nor_base_clock_div_force(const struct device *dev,
-						 bool force);
+__syscall void nrf_qspi_nor_xip_enable(const struct device *dev, bool enable);
 
 #ifdef __cplusplus
 }

--- a/west.yml
+++ b/west.yml
@@ -83,7 +83,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 79b4577543654666144f2d0bb9221ee2abfd54dc
+      revision: c4044b04b8bf04f11e3051d5f7a41f3d636b6b0c
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Normally, the driver deactivates the QSPI peripheral for periods when
no QSPI operation is performed. This is done to avoid increased current
consumption when the peripheral is idle. For the same reason, the base
clock on nRF53 Series SoCs (HFCLK192M) is configured for those periods
with the default /4 divider that cannot be used otherwise. However,
when XIP accesses are used, the driver must be prevented from doing
both these things as that would make XIP to fail. Hence, a function
is provided so that applications can inform the driver that XIP is
needed and the above idle actions should be suppressed.
This function (`nrf_qspi_nor_xip_enable()`) replaces the old one
(`nrf_qspi_nor_base_clock_div_force()`) that was intended for similar
purpose but after deactivation of the peripheral was introduced in
commit 95d867e8ed09176961a1a65006e489af64606927 it became useless.