### PR TITLE
posix: Add support for arm-clang libc

### DIFF
--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -47,7 +47,7 @@ struct pthread_attr {
 	int32_t detachstate;
 	uint32_t initialized;
 };
-#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC)
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC)
 typedef struct pthread_attr pthread_attr_t;
 #endif
 BUILD_ASSERT(sizeof(pthread_attr_t) >= sizeof(struct pthread_attr));
@@ -63,7 +63,7 @@ typedef uint32_t pthread_mutex_t;
 struct pthread_mutexattr {
 	int type;
 };
-#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC)
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC)
 typedef struct pthread_mutexattr pthread_mutexattr_t;
 #endif
 BUILD_ASSERT(sizeof(pthread_mutexattr_t) >= sizeof(struct pthread_mutexattr));
@@ -74,7 +74,7 @@ typedef uint32_t pthread_cond_t;
 struct pthread_condattr {
 };
 
-#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC)
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC)
 typedef struct pthread_condattr pthread_condattr_t;
 #endif
 BUILD_ASSERT(sizeof(pthread_condattr_t) >= sizeof(struct pthread_condattr));

--- a/include/zephyr/posix/pthread_key.h
+++ b/include/zephyr/posix/pthread_key.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC)
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC)
 typedef struct {
 	int is_initialized;
 	int init_executed;

--- a/include/zephyr/posix/sched.h
+++ b/include/zephyr/posix/sched.h
@@ -16,7 +16,7 @@ extern "C" {
 /* Priority based preemptive scheduling policy */
 #define SCHED_RR 2
 
-#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC)
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC)
 struct sched_param {
 	int sched_priority;
 };

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -17,6 +17,10 @@ tests:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
+  portability.posix.common.armclang_std_libc:
+    toolchain_allow: armclang
+    extra_configs:
+      - CONFIG_ARMCLANG_STD_LIBC=y
   portability.posix.common.arcmwdtlib:
     toolchain_allow: arcmwdt
     extra_configs:


### PR DESCRIPTION
Add CONFIG_ARMCLANG_STD_LIBC to places they are needed for things to build correct when compiling with arm-clang.