### PR TITLE
cortex_m: tz_ns.h: Fix compiling with arm-clang

### DIFF
--- a/arch/arm/include/aarch32/cortex_m/tz_ns.h
+++ b/arch/arm/include/aarch32/cortex_m/tz_ns.h
@@ -47,7 +47,6 @@
  *                  r0-r3 unmodified.
  */
 #define __TZ_WRAP_FUNC_RAW(preface, name, postface, store_lr, load_lr) \
-	do { \
 		__asm__ volatile( \
 			".global "#preface"; .type "#preface", %function"); \
 		__asm__ volatile( \
@@ -64,8 +63,7 @@
 			"bl " #postface "\n\t" \
 			"pop {r0-r3}\n\t" \
 			load_lr "\n\t" \
-			::); \
-	} while (false)
+			::);
 
 /**
  * @brief Macro for "sandwiching" a function call (@p name) in two other calls


### PR DESCRIPTION
We get the following error when building with arm-clang:

error: non-ASM statement in naked function is not supported
        __TZ_WRAP_FUNC(preface, foo1, postface);
        ^
tests/arch/arm/arm_tz_wrap_func/src/main.c:69:25: note: attribute is here uint32_t __attribute__((naked)) wrap_foo1(uint32_t arg1, uint32_t arg2,
                        ^
1 error generated.

Remove the do/while wrapper to make this a true naked function.