### PR TITLE
lwm2m: fix armclang compiler warnings with is*() functions

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -662,7 +662,7 @@ static int read_int(struct lwm2m_input_context *in, int64_t *value,
 		c = *(buf + i);
 		if (c == '-' && accept_sign && i == 0) {
 			neg = true;
-		} else if (isdigit(c)) {
+		} else if (isdigit(c) != 0) {
 			*value = *value * 10 + (c - '0');
 		} else {
 			/* anything else stop reading */
@@ -757,7 +757,7 @@ static int get_float(struct lwm2m_input_context *in, double *value)
 		tmp = *(json_buf + len);
 
 		if ((tmp == '-' && i == 0) || (tmp == '.' && !has_dot) ||
-		    isdigit(tmp)) {
+		    isdigit(tmp) != 0) {
 			len++;
 
 			/* Copy only if it fits into provided buffer - we won't

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -199,7 +199,7 @@ static int plain_text_read_int(struct lwm2m_input_context *in, int64_t *value,
 
 		if (tmp == '-' && accept_sign && i == 0) {
 			neg = true;
-		} else if (isdigit(tmp)) {
+		} else if (isdigit(tmp) != 0) {
 			*value = *value * 10 + (tmp - '0');
 		} else {
 			/* anything else stop reading */
@@ -287,7 +287,7 @@ static int get_float(struct lwm2m_input_context *in, double *value)
 		}
 
 		if ((tmp == '-' && i == 0) || (tmp == '.' && !has_dot) ||
-		    isdigit(tmp)) {
+		    isdigit(tmp) != 0) {
 			len++;
 
 			/* Copy only if it fits into provided buffer - we won't

--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.c
@@ -1039,7 +1039,7 @@ static int read_int(struct lwm2m_input_context *in, int64_t *value, bool accept_
 		c = *(buf + i);
 		if (c == '-' && accept_sign && i == 0) {
 			neg = true;
-		} else if (isdigit(c)) {
+		} else if (isdigit(c) != 0) {
 			*value = *value * 10 + (c - '0');
 		} else {
 			/* anything else stop reading */
@@ -1132,7 +1132,7 @@ static int get_float(struct lwm2m_input_context *in, double *value)
 	while (*(json_buf + len) && len < value_length) {
 		tmp = *(json_buf + len);
 
-		if ((tmp == '-' && i == 0) || (tmp == '.' && !has_dot) || isdigit(tmp)) {
+		if ((tmp == '-' && i == 0) || (tmp == '.' && !has_dot) || isdigit(tmp) != 0) {
 			len++;
 
 			/* Copy only if it fits into provided buffer - we won't

--- a/subsys/net/lib/lwm2m/lwm2m_util.c
+++ b/subsys/net/lib/lwm2m/lwm2m_util.c
@@ -361,7 +361,7 @@ int lwm2m_atof(const char *input, double *out)
 		return 0;
 	}
 
-	while (*(++pos) && base > 1 && isdigit((unsigned char)*pos)) {
+	while (*(++pos) && base > 1 && isdigit((unsigned char)*pos) != 0) {
 		val2 = val2 * 10 + (*pos - '0');
 		base /= 10;
 	}
@@ -481,7 +481,7 @@ uint16_t lwm2m_atou16(const uint8_t *buf, uint16_t buflen, uint16_t *len)
 	uint16_t pos = 0U;
 
 	/* we should get a value first - consume all numbers */
-	while (pos < buflen && isdigit(buf[pos])) {
+	while (pos < buflen && isdigit(buf[pos]) != 0) {
 		val = val * 10U + (buf[pos] - '0');
 		pos++;
 	}
@@ -501,7 +501,7 @@ int lwm2m_string_to_path(const char *pathstr, struct lwm2m_obj_path *path,
 	for (i = 0; i <= end_index; i++) {
 		/* search for first numeric */
 		if (tokstart == -1) {
-			if (!isdigit((unsigned char)pathstr[i])) {
+			if (isdigit((unsigned char)pathstr[i]) == 0) {
 				continue;
 			}
 


### PR DESCRIPTION
We get compile warnings of the form:

error: converting the result of
'<<' to a boolean; did you mean
'((__aeabi_ctype_table_ + 1)[(byte)] << 28) != 0'?
 [-Werror,-Wint-in-bool-context]
                if (!isprint(byte)) {
                     ^

Since isprint (and the other is* functions) return an int, change check to an explicit test against the return value.