### PR TITLE
adc: fix armclang compiler warnings with is*() functions

### DIFF
--- a/drivers/adc/adc_shell.c
+++ b/drivers/adc/adc_shell.c
@@ -135,7 +135,7 @@ static int cmd_adc_ch_id(const struct shell *shell, size_t argc, char **argv)
 		return -ENODEV;
 	}
 
-	if (!isdigit((unsigned char)argv[1][0])) {
+	if (isdigit((unsigned char)argv[1][0]) == 0) {
 		shell_error(shell, "<channel> must be digits");
 		return -EINVAL;
 	}
@@ -159,7 +159,7 @@ static int cmd_adc_ch_neg(const struct shell *shell, size_t argc, char **argv)
 		return -ENODEV;
 	}
 
-	if (!isdigit((unsigned char)argv[1][0])) {
+	if (isdigit((unsigned char)argv[1][0]) == 0) {
 		shell_error(shell, "<negative input> must be digits");
 		return -EINVAL;
 	}
@@ -186,7 +186,7 @@ static int cmd_adc_ch_pos(const struct shell *shell, size_t argc, char **argv)
 		return -ENODEV;
 	}
 
-	if (!isdigit((unsigned char)argv[1][0])) {
+	if (isdigit((unsigned char)argv[1][0]) == 0) {
 		shell_error(shell, "<positive input> must be digits");
 		return -EINVAL;
 	}
@@ -237,7 +237,7 @@ static int cmd_adc_acq(const struct shell *shell, size_t argc, char **argv)
 		return -ENODEV;
 	}
 
-	if (!isdigit((unsigned char)argv[1][0])) {
+	if (isdigit((unsigned char)argv[1][0]) == 0) {
 		shell_error(shell, "<time> must be digits");
 		return -EINVAL;
 	}
@@ -272,7 +272,7 @@ static int cmd_adc_reso(const struct shell *shell, size_t argc, char **argv)
 		return -ENODEV;
 	}
 
-	if (!isdigit((unsigned char)argv[1][0])) {
+	if (isdigit((unsigned char)argv[1][0]) == 0) {
 		shell_error(shell, "<resolution> must be digits");
 		return -EINVAL;
 	}


### PR DESCRIPTION
We get compile warnings of the form:

error: converting the result of
'<<' to a boolean; did you mean
'((__aeabi_ctype_table_ + 1)[(byte)] << 28) != 0'?
 [-Werror,-Wint-in-bool-context]
                if (!isprint(byte)) {
                     ^

Since isprint (and the other is* functions) return an int, change check to an explicit test against the return value.