### PR TITLE
console: fix armclang compiler warnings with is*() functions

### DIFF
--- a/drivers/console/native_posix_console.c
+++ b/drivers/console/native_posix_console.c
@@ -93,7 +93,7 @@ static inline void found_eof(void)
  */
 static int catch_directive(char *s, int32_t *towait)
 {
-	while (*s != 0  && isspace(*s)) {
+	while (*s != 0  && isspace(*s) != 0) {
 		s++;
 	}
 
@@ -213,7 +213,7 @@ static int32_t attempt_read_from_stdin(void)
 
 		/* Remove a possible end of line and other trailing spaces */
 		last = (int)strlen(cmd->line) - 1;
-		while ((last >= 0) && isspace(cmd->line[last])) {
+		while ((last >= 0) && isspace(cmd->line[last]) != 0) {
 			cmd->line[last--] = 0;
 		}
 

--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -247,7 +247,7 @@ static uint8_t cur, end;
 static void handle_ansi(uint8_t byte, char *line)
 {
 	if (atomic_test_and_clear_bit(&esc_state, ESC_ANSI_FIRST)) {
-		if (!isdigit(byte)) {
+		if (isdigit(byte) == 0) {
 			ansi_val = 1U;
 			goto ansi_cmd;
 		}
@@ -259,7 +259,7 @@ static void handle_ansi(uint8_t byte, char *line)
 	}
 
 	if (atomic_test_bit(&esc_state, ESC_ANSI_VAL)) {
-		if (isdigit(byte)) {
+		if (isdigit(byte) != 0) {
 			if (atomic_test_bit(&esc_state, ESC_ANSI_VAL_2)) {
 				ansi_val_2 *= 10U;
 				ansi_val_2 += byte - '0';


### PR DESCRIPTION
We get compile warnings of the form:

error: converting the result of
'<<' to a boolean; did you mean
'((__aeabi_ctype_table_ + 1)[(byte)] << 28) != 0'?
 [-Werror,-Wint-in-bool-context]
                if (!isprint(byte)) {
                     ^

Since isprint (and the other is* functions) return an int, change check to an explicit test against the return value.