### PR TITLE
dns: fix armclang compiler warnings with is*() functions

### DIFF
--- a/subsys/net/lib/dns/dns_sd.c
+++ b/subsys/net/lib/dns/dns_sd.c
@@ -117,12 +117,12 @@ bool label_is_valid(const char *label, size_t label_size)
 	}
 
 	for (i = 0; i < label_size; ++i) {
-		if (isalpha((int)label[i])) {
+		if (isalpha((int)label[i]) != 0) {
 			continue;
 		}
 
 		if (i > 0) {
-			if (isdigit((int)label[i])) {
+			if (isdigit((int)label[i]) != 0) {
 				continue;
 			}
 


### PR DESCRIPTION
We get compile warnings of the form:

error: converting the result of
'<<' to a boolean; did you mean
'((__aeabi_ctype_table_ + 1)[(byte)] << 28) != 0'?
 [-Werror,-Wint-in-bool-context]
                if (!isprint(byte)) {
                     ^

Since isprint (and the other is* functions) return an int, change check to an explicit test against the return value.