### PR TITLE
libc: fix armclang compiler warnings with is*() functions

### DIFF
--- a/lib/libc/minimal/source/stdlib/atoi.c
+++ b/lib/libc/minimal/source/stdlib/atoi.c
@@ -33,7 +33,7 @@ int atoi(const char *s)
 	int n = 0;
 	int neg = 0;
 
-	while (isspace((unsigned char)*s)) {
+	while (isspace((unsigned char)*s) != 0) {
 		s++;
 	}
 	switch (*s) {
@@ -51,7 +51,7 @@ int atoi(const char *s)
 		break;
 	}
 	/* Compute n as a negative number to avoid overflow on INT_MIN */
-	while (isdigit((unsigned char)*s)) {
+	while (isdigit((unsigned char)*s) != 0) {
 		n = 10*n - (*s++ - '0');
 	}
 	return neg ? n : -n;

--- a/lib/libc/minimal/source/stdlib/strtol.c
+++ b/lib/libc/minimal/source/stdlib/strtol.c
@@ -55,7 +55,7 @@ long strtol(const char *nptr, char **endptr, register int base)
 	 */
 	do {
 		c = *s++;
-	} while (isspace((unsigned char)c));
+	} while (isspace((unsigned char)c) != 0);
 	if (c == '-') {
 		neg = 1;
 		c = *s++;
@@ -95,10 +95,10 @@ long strtol(const char *nptr, char **endptr, register int base)
 	cutlim = cutoff % (unsigned long)base;
 	cutoff /= (unsigned long)base;
 	for (acc = 0, any = 0;; c = *s++) {
-		if (isdigit((unsigned char)c)) {
+		if (isdigit((unsigned char)c) != 0) {
 			c -= '0';
-		} else if (isalpha((unsigned char)c)) {
-			c -= isupper((unsigned char)c) ? 'A' - 10 : 'a' - 10;
+		} else if (isalpha((unsigned char)c) != 0) {
+			c -= isupper((unsigned char)c) != 0 ? 'A' - 10 : 'a' - 10;
 		} else {
 			break;
 		}

--- a/lib/libc/minimal/source/stdlib/strtoll.c
+++ b/lib/libc/minimal/source/stdlib/strtoll.c
@@ -55,7 +55,7 @@ long long strtoll(const char *nptr, char **endptr, register int base)
 	 */
 	do {
 		c = *s++;
-	} while (isspace(c));
+	} while (isspace(c) != 0);
 	if (c == '-') {
 		neg = 1;
 		c = *s++;
@@ -94,10 +94,10 @@ long long strtoll(const char *nptr, char **endptr, register int base)
 	cutlim = cutoff % (unsigned long long)base;
 	cutoff /= (unsigned long long)base;
 	for (acc = 0, any = 0;; c = *s++) {
-		if (isdigit(c)) {
+		if (isdigit(c) != 0) {
 			c -= '0';
-		} else if (isalpha(c)) {
-			c -= isupper(c) ? 'A' - 10 : 'a' - 10;
+		} else if (isalpha(c) != 0) {
+			c -= isupper(c) != 0 ? 'A' - 10 : 'a' - 10;
 		} else {
 			break;
 		}

--- a/lib/libc/minimal/source/stdlib/strtoul.c
+++ b/lib/libc/minimal/source/stdlib/strtoul.c
@@ -53,7 +53,7 @@ unsigned long strtoul(const char *nptr, char **endptr, register int base)
 	 */
 	do {
 		c = *s++;
-	} while (isspace((unsigned char)c));
+	} while (isspace((unsigned char)c) != 0);
 	if (c == '-') {
 		neg = 1;
 		c = *s++;
@@ -75,10 +75,10 @@ unsigned long strtoul(const char *nptr, char **endptr, register int base)
 	cutoff = (unsigned long)ULONG_MAX / (unsigned long)base;
 	cutlim = (unsigned long)ULONG_MAX % (unsigned long)base;
 	for (acc = 0, any = 0;; c = *s++) {
-		if (isdigit((unsigned char)c)) {
+		if (isdigit((unsigned char)c) != 0) {
 			c -= '0';
-		} else if (isalpha((unsigned char)c)) {
-			c -= isupper((unsigned char)c) ? 'A' - 10 : 'a' - 10;
+		} else if (isalpha((unsigned char)c) != 0) {
+			c -= isupper((unsigned char)c) != 0 ? 'A' - 10 : 'a' - 10;
 		} else {
 			break;
 		}

--- a/lib/libc/minimal/source/stdlib/strtoull.c
+++ b/lib/libc/minimal/source/stdlib/strtoull.c
@@ -53,7 +53,7 @@ unsigned long long strtoull(const char *nptr, char **endptr, register int base)
 	 */
 	do {
 		c = *s++;
-	} while (isspace(c));
+	} while (isspace(c) != 0);
 	if (c == '-') {
 		neg = 1;
 		c = *s++;
@@ -74,10 +74,10 @@ unsigned long long strtoull(const char *nptr, char **endptr, register int base)
 	cutoff = (unsigned long long)ULLONG_MAX / (unsigned long long)base;
 	cutlim = (unsigned long long)ULLONG_MAX % (unsigned long long)base;
 	for (acc = 0, any = 0;; c = *s++) {
-		if (isdigit(c)) {
+		if (isdigit(c) != 0) {
 			c -= '0';
-		} else if (isalpha(c)) {
-			c -= isupper(c) ? 'A' - 10 : 'a' - 10;
+		} else if (isalpha(c) != 0) {
+			c -= isupper(c) != 0 ? 'A' - 10 : 'a' - 10;
 		} else {
 			break;
 		}

--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -443,7 +443,7 @@ ZTEST(test_c_lib, test_checktype)
 	char *ptr = buf;
 
 	for (int i = 0; i < 128; i++) {
-		if (isalnum(i)) {
+		if (isalnum(i) != 0) {
 			*ptr++ = i;
 		}
 	}
@@ -452,7 +452,7 @@ ZTEST(test_c_lib, test_checktype)
 
 	ptr = buf;
 	for (int i = 0; i < 128; i++) {
-		if (isalpha(i)) {
+		if (isalpha(i) != 0) {
 			*ptr++ = i;
 		}
 	}
@@ -461,7 +461,7 @@ ZTEST(test_c_lib, test_checktype)
 
 	ptr = buf;
 	for (int i = 0; i < 128; i++) {
-		if (isdigit(i)) {
+		if (isdigit(i) != 0) {
 			*ptr++ = i;
 		}
 	}
@@ -470,7 +470,7 @@ ZTEST(test_c_lib, test_checktype)
 
 	ptr = buf;
 	for (int i = 0; i < 128; i++) {
-		if (isgraph(i)) {
+		if (isgraph(i) != 0) {
 			*ptr++ = i;
 		}
 	}
@@ -488,7 +488,7 @@ ZTEST(test_c_lib, test_checktype)
 
 	ptr = buf;
 	for (int i = 0; i < 128; i++) {
-		if (isupper(i)) {
+		if (isupper(i) != 0) {
 			*ptr++ = i;
 		}
 	}
@@ -497,7 +497,7 @@ ZTEST(test_c_lib, test_checktype)
 
 	ptr = buf;
 	for (int i = 0; i < 128; i++) {
-		if (isspace(i)) {
+		if (isspace(i) != 0) {
 			*ptr++ = i;
 		}
 	}
@@ -506,7 +506,7 @@ ZTEST(test_c_lib, test_checktype)
 
 	ptr = buf;
 	for (int i = 0; i < 128; i++) {
-		if (isxdigit(i)) {
+		if (isxdigit(i) != 0) {
 			*ptr++ = i;
 		}
 	}


### PR DESCRIPTION
We get compile warnings of the form:

error: converting the result of
'<<' to a boolean; did you mean
'((__aeabi_ctype_table_ + 1)[(byte)] << 28) != 0'?
 [-Werror,-Wint-in-bool-context]
                if (!isprint(byte)) {
                     ^

Since isprint (and the other is* functions) return an int, change check to an explicit test against the return value.