### PR TITLE
lib: os: fix armclang compiler warnings with is*() functions

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -320,7 +320,7 @@ static size_t extract_decimal(const char **str)
 	const char *sp = *str;
 	size_t val = 0;
 
-	while (isdigit((int)(unsigned char)*sp)) {
+	while (isdigit((int)(unsigned char)*sp) != 0) {
 		val = 10U * val + *sp++ - '0';
 	}
 	*str = sp;
@@ -790,7 +790,7 @@ static char *encode_uint(uint_value_type value,
 			 char *bps,
 			 const char *bpe)
 {
-	bool upcase = isupper((int)conv->specifier);
+	bool upcase = isupper((int)conv->specifier) != 0;
 	const unsigned int radix = conversion_radix(conv->specifier);
 	char *bp = bps + (bpe - bps);
 
@@ -905,7 +905,7 @@ static char *encode_float(double value,
 	 */
 	if (expo == BIT_MASK(EXPONENT_BITS)) {
 		if (fract == 0) {
-			if (isupper((unsigned char)c)) {
+			if (isupper((unsigned char)c) != 0) {
 				*buf++ = 'I';
 				*buf++ = 'N';
 				*buf++ = 'F';
@@ -915,7 +915,7 @@ static char *encode_float(double value,
 				*buf++ = 'f';
 			}
 		} else {
-			if (isupper((unsigned char)c)) {
+			if (isupper((unsigned char)c) != 0) {
 				*buf++ = 'N';
 				*buf++ = 'A';
 				*buf++ = 'N';
@@ -997,7 +997,7 @@ static char *encode_float(double value,
 		 * for a and X for A.
 		 */
 		struct conversion aconv = {
-			.specifier = isupper((unsigned char)c) ? 'X' : 'x',
+			.specifier = isupper((unsigned char)c) != 0 ? 'X' : 'x',
 		};
 		const char *spe = *bpe;
 		char *sp = bps + (spe - bps);
@@ -1783,7 +1783,7 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
 					OUTC(*cp++);
 				}
 			} else {
-				while (isdigit((unsigned char)*cp)) {
+				while (isdigit((unsigned char)*cp) != 0) {
 					OUTC(*cp++);
 				}
 
@@ -1803,7 +1803,7 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
 						OUTC('0');
 					}
 				}
-				while (isdigit((unsigned char)*cp)) {
+				while (isdigit((unsigned char)*cp) != 0) {
 					OUTC(*cp++);
 				}
 			}

--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -113,19 +113,19 @@ static void *lexer_string(struct json_lexer *lex)
 			case 't':
 				continue;
 			case 'u':
-				if (!isxdigit(next(lex))) {
+				if (isxdigit(next(lex)) == 0) {
 					goto error;
 				}
 
-				if (!isxdigit(next(lex))) {
+				if (isxdigit(next(lex)) == 0) {
 					goto error;
 				}
 
-				if (!isxdigit(next(lex))) {
+				if (isxdigit(next(lex)) == 0) {
 					goto error;
 				}
 
-				if (!isxdigit(next(lex))) {
+				if (isxdigit(next(lex)) == 0) {
 					goto error;
 				}
 
@@ -201,7 +201,7 @@ static void *lexer_number(struct json_lexer *lex)
 	while (true) {
 		int chr = next(lex);
 
-		if (isdigit(chr) || chr == '.') {
+		if (isdigit(chr) != 0 || chr == '.') {
 			continue;
 		}
 
@@ -237,18 +237,18 @@ static void *lexer_json(struct json_lexer *lex)
 		case 'f':
 			return lexer_boolean;
 		case '-':
-			if (isdigit(peek(lex))) {
+			if (isdigit(peek(lex)) != 0) {
 				return lexer_number;
 			}
 
 			__fallthrough;
 		default:
-			if (isspace(chr)) {
+			if (isspace(chr) != 0) {
 				ignore(lex);
 				continue;
 			}
 
-			if (isdigit(chr)) {
+			if (isdigit(chr) != 0) {
 				return lexer_number;
 			}
 


### PR DESCRIPTION
We get compile warnings of the form:

error: converting the result of
'<<' to a boolean; did you mean
'((__aeabi_ctype_table_ + 1)[(byte)] << 28) != 0'?
 [-Werror,-Wint-in-bool-context]
                if (!isprint(byte)) {
                     ^

Since isprint (and the other is* functions) return an int, change check to an explicit test against the return value.