### PR TITLE
shell: fix armclang compiler warnings with is*() functions

### DIFF
--- a/samples/subsys/shell/shell_module/src/dynamic_cmd.c
+++ b/samples/subsys/shell/shell_module/src/dynamic_cmd.c
@@ -47,7 +47,7 @@ static int cmd_dynamic_add(const struct shell *shell,
 	}
 
 	for (idx = 0U; idx < cmd_len; idx++) {
-		if (!isalnum((int)(argv[1][idx]))) {
+		if (isalnum((int)(argv[1][idx])) == 0) {
 			shell_error(shell,
 				    "bad command name - please use only"
 				    " alphanumerical characters");

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -385,8 +385,8 @@ static void autocomplete(const struct shell *shell,
 	}
 
 	/* Next character in the buffer is not 'space'. */
-	if (!isspace((int) shell->ctx->cmd_buff[
-					shell->ctx->cmd_buff_pos])) {
+	if (isspace((int) shell->ctx->cmd_buff[
+					shell->ctx->cmd_buff_pos]) == 0) {
 		if (z_flag_insert_mode_get(shell)) {
 			z_flag_insert_mode_set(shell, false);
 			z_shell_op_char_insert(shell, ' ');

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -32,7 +32,7 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 
 
 	/* Skipping whitespace. */
-	while (isspace((int) *(str + offset))) {
+	while (isspace((int) *(str + offset)) != 0) {
 		++offset;
 	}
 
@@ -69,7 +69,7 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 
 		while (true) {
 			/* Determining line break. */
-			if (isspace((int) (*(str + offset + idx)))) {
+			if (isspace((int) (*(str + offset + idx))) != 0) {
 				length = idx;
 				if (*(str + offset + idx) == '\n') {
 					break;
@@ -95,7 +95,7 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 		/* Calculating text offset to ensure that next line will
 		 * not begin with a space.
 		 */
-		while (isspace((int) (*(str + offset)))) {
+		while (isspace((int) (*(str + offset))) != 0) {
 			++offset;
 		}
 

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -194,7 +194,7 @@ static char make_argv(char **ppcmd, uint8_t c)
 			}
 		}
 
-		if (!quote && isspace((int) c)) {
+		if (!quote && isspace((int) c) != 0) {
 			break;
 		}
 
@@ -219,7 +219,7 @@ char z_shell_make_argv(size_t *argc, const char **argv, char *cmd,
 			break;
 		}
 
-		if (isspace((int) c)) {
+		if (isspace((int) c) != 0) {
 			*cmd++ = '\0';
 			continue;
 		}
@@ -431,9 +431,9 @@ void z_shell_spaces_trim(char *str)
 	}
 
 	for (uint16_t i = 0; i < len - 1; i++) {
-		if (isspace((int)str[i])) {
+		if (isspace((int)str[i]) != 0) {
 			for (uint16_t j = i + 1; j < len; j++) {
-				if (isspace((int)str[j])) {
+				if (isspace((int)str[j]) != 0) {
 					shift++;
 					continue;
 				}
@@ -465,7 +465,7 @@ static void buffer_trim(char *buff, uint16_t *buff_len)
 		return;
 	}
 
-	while (isspace((int) buff[*buff_len - 1U])) {
+	while (isspace((int) buff[*buff_len - 1U]) != 0) {
 		*buff_len -= 1U;
 		if (*buff_len == 0U) {
 			buff[0] = '\0';
@@ -477,7 +477,7 @@ static void buffer_trim(char *buff, uint16_t *buff_len)
 	/* Counting whitespace characters starting from beginning of the
 	 * command.
 	 */
-	while (isspace((int) buff[i++])) {
+	while (isspace((int) buff[i++]) != 0) {
 	}
 
 


### PR DESCRIPTION
We get compile warnings of the form:

error: converting the result of
'<<' to a boolean; did you mean
'((__aeabi_ctype_table_ + 1)[(byte)] << 28) != 0'?
 [-Werror,-Wint-in-bool-context]
                if (!isprint(byte)) {
                     ^

Since isprint (and the other is* functions) return an int, change check to an explicit test against the return value.