### PR TITLE
wncm14a2a: fix armclang compiler warnings with is*() functions

### DIFF
--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -823,10 +823,10 @@ static void on_cmd_sockread(struct net_buf **buf, uint16_t len)
 	for (i = 0; i < actual_length * 2; i++) {
 		char c2 = *(*buf)->data;
 
-		if (isdigit(c2)) {
+		if (isdigit(c2) != 0) {
 			c += c2 - '0';
-		} else if (isalpha(c2)) {
-			c += c2 - (isupper(c2) ? 'A' - 10 : 'a' - 10);
+		} else if (isalpha(c2) != 0) {
+			c += c2 - (isupper(c2) != 0 ? 'A' - 10 : 'a' - 10);
 		} else {
 			/* TODO: unexpected input! skip? */
 		}


### PR DESCRIPTION
We get compile warnings of the form:

error: converting the result of
'<<' to a boolean; did you mean
'((__aeabi_ctype_table_ + 1)[(byte)] << 28) != 0'?
 [-Werror,-Wint-in-bool-context]
                if (!isprint(byte)) {
                     ^

Since isprint (and the other is* functions) return an int, change check to an explicit test against the return value.