### PR TITLE
Revert "drivers: hwinfo: add wakeup flag cause"

### DIFF
--- a/drivers/hwinfo/hwinfo_stm32.c
+++ b/drivers/hwinfo/hwinfo_stm32.c
@@ -10,7 +10,6 @@
 #if defined(CONFIG_SOC_SERIES_STM32H5X)
 #include <stm32_ll_icache.h>
 #endif /* CONFIG_SOC_SERIES_STM32H5X */
-#include <stm32_ll_pwr.h>
 #include <zephyr/drivers/hwinfo.h>
 #include <string.h>
 #include <zephyr/sys/byteorder.h>
@@ -113,11 +112,6 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 		flags |= RESET_LOW_POWER_WAKE;
 	}
 #endif
-#if defined(PWR_FLAG_SB)
-	if (LL_PWR_IsActiveFlag_SB()) {
-		flags |= RESET_LOW_POWER_WAKE;
-	}
-#endif
 
 	*cause = flags;
 
@@ -127,9 +121,7 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 int z_impl_hwinfo_clear_reset_cause(void)
 {
 	LL_RCC_ClearResetFlags();
-#if defined(PWR_FLAG_SB)
-	LL_PWR_ClearFlag_SB();
-#endif
+
 	return 0;
 }
 

--- a/samples/boards/stm32/power_mgmt/standby_shutdown/src/main.c
+++ b/samples/boards/stm32/power_mgmt/standby_shutdown/src/main.c
@@ -96,16 +96,19 @@ void main(void)
 	hwinfo_get_reset_cause(&cause);
 	hwinfo_clear_reset_cause();
 
-	if (cause == RESET_LOW_POWER_WAKE)	{
-		hwinfo_clear_reset_cause();
+	if ((LL_PWR_IsActiveFlag_SB() == true) && (cause == 0))	{
+		LL_PWR_ClearFlag_SB();
+		LL_PWR_ClearFlag_WU();
 		printk("\nReset cause: Standby mode\n\n");
 	}
 
 	if (cause == (RESET_PIN | RESET_BROWNOUT)) {
+		LL_PWR_ClearFlag_WU();
 		printk("\nReset cause: Shutdown mode or power up\n\n");
 	}
 
 	if (cause == RESET_PIN) {
+		LL_PWR_ClearFlag_WU();
 		printk("\nReset cause: Reset pin\n\n");
 	}
 


### PR DESCRIPTION
Reverts zephyrproject-rtos/zephyr#55993

The mentioned PR breaks the `hwinfo` driver on STM32 platforms with dual-core variants. Changes need to be made to the code added in the reverted PR for compatibility with all STM32 platforms.

See #56375.