### PR TITLE
west.yml: update hal_atmel to include picolibc compat fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: f47a9a8b55677b5d03bf7f066f907e6b74c9e57d
+      revision: 5ab43007eda3f380c125f957f03638d2e8d1144d
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
This update removes the LITTLE_ENDIAN/__LITTLE_ENDIAN defines in all of the chip-specific headers as those conflict with usage of these macros in picolibc.