### PR TITLE
Clang fixes when building without -ffreestanding

### DIFF
--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -513,7 +513,7 @@ static int rf2xx_set_txpower(const struct device *dev, int16_t dbm)
 		dbm = max;
 	}
 
-	idx = abs(((float)(dbm - max) / step));
+	idx = abs((int) (((float)(dbm - max) / step)));
 	LOG_DBG("Tx-power idx: %d", idx);
 
 	if (idx >= conf->tx_pwr_table_size) {

--- a/subsys/net/lib/zperf/zperf_tcp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_tcp_receiver.c
@@ -167,10 +167,10 @@ static void tcp_server_session(void)
 				goto use_existing_ipv4;
 			}
 		} else {
-		use_existing_ipv4:
 			/* Use existing IP */
-			const struct in_addr *addr =
-				zperf_get_default_if_in4_addr();
+			const struct in_addr *addr;
+use_existing_ipv4:
+			addr = zperf_get_default_if_in4_addr();
 			if (!addr) {
 				NET_ERR("Unable to get IPv4 by default");
 				goto error;
@@ -215,10 +215,10 @@ static void tcp_server_session(void)
 				goto use_existing_ipv6;
 			}
 		} else {
-		use_existing_ipv6:
 			/* Use existing IP */
-			const struct in6_addr *addr =
-				zperf_get_default_if_in6_addr();
+			const struct in6_addr *addr;
+use_existing_ipv6:
+			addr = zperf_get_default_if_in6_addr();
 			if (!addr) {
 				NET_ERR("Unable to get IPv6 by default");
 				goto error;

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -239,7 +239,7 @@ static void _test_kernel_cpu_idle(int atomic)
 			k_cpu_idle();
 		}
 		dt = k_uptime_ticks() - t0;
-		zassert_true(abs(dt - dur) <= slop,
+		zassert_true(abs((int32_t) (dt - dur)) <= slop,
 			     "Inaccurate wakeup, idled for %d ticks, expected %d",
 			     dt, dur);
 	}

--- a/tests/unit/cbprintf/main.c
+++ b/tests/unit/cbprintf/main.c
@@ -465,10 +465,10 @@ ZTEST(prf, test_d_length)
 	PRF_CHECK("3060399406/1876543210", rc);
 
 	if (!IS_ENABLED(CONFIG_CBPRINTF_NANO)) {
-		TEST_PRF(&rc, "%hd/%hd", min, max);
+		TEST_PRF(&rc, "%hd/%hd", (short) min, (short) max);
 		PRF_CHECK("-722/-14614", rc);
 
-		TEST_PRF(&rc, "%hhd/%hhd", min, max);
+		TEST_PRF(&rc, "%hhd/%hhd", (char) min, (char) max);
 		PRF_CHECK("46/-22", rc);
 	}
 
@@ -601,10 +601,10 @@ ZTEST(prf, test_x_length)
 		return;
 	}
 
-	TEST_PRF(&rc, "%hx/%hX", min, max);
+	TEST_PRF(&rc, "%hx/%hX", (short) min, (short) max);
 	PRF_CHECK("2c1c/2D1D", rc);
 
-	TEST_PRF(&rc, "%hhx/%hhX", min, max);
+	TEST_PRF(&rc, "%hhx/%hhX", (char) min, (char) max);
 	PRF_CHECK("1c/1D", rc);
 
 	if (IS_ENABLED(CONFIG_CBPRINTF_FULL_INTEGRAL)) {


### PR DESCRIPTION
PR #54638 proposes eliminating -ffreestanding when building with a C library other than the minimal C library. When building in this mode, clang finds a number of things to complain about in the code, including calls to abs with unsigned/float values and inappropriate types to printf.

This series also includes a C language conformance fix -- code using labels on declarations, which is not valid.