### PR TITLE
tests: Remove references to deleted board "beaglev_starlight_jh7100".

### DIFF
--- a/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
+++ b/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
@@ -12,7 +12,6 @@ tests:
       qemu_cortex_a53
       qemu_cortex_a53_smp
       qemu_kvm_arm64
-      beaglev_starlight_jh7100
       xenvm
       xenvm_gicv3
   drivers.sbs_gauge_new_api.emulated_64_bit_i2c_addr:
@@ -24,7 +23,6 @@ tests:
       qemu_cortex_a53
       qemu_cortex_a53_smp
       qemu_kvm_arm64
-      beaglev_starlight_jh7100
       xenvm
       xenvm_gicv3
     extra_args:

--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -5,9 +5,8 @@ common:
 tests:
   kernel.device:
     tags: kernel device
-    platform_exclude: beaglev_starlight_jh7100
   kernel.device.pm:
     tags: kernel device
-    platform_exclude: mec15xxevb_assy6853 beaglev_starlight_jh7100
+    platform_exclude: mec15xxevb_assy6853
     extra_configs:
       - CONFIG_PM_DEVICE=y


### PR DESCRIPTION
beaglev_starlight_jh7100 board was deleted so remove references to it in tests/.

Fixes #56398