### PR TITLE
ARC: MWDT: fix build with cpp98 standard

### DIFF
--- a/include/zephyr/toolchain/mwdt.h
+++ b/include/zephyr/toolchain/mwdt.h
@@ -89,8 +89,11 @@
 #include <zephyr/toolchain/gcc.h>
 
 #undef BUILD_ASSERT
-#ifdef __cplusplus
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
 #define BUILD_ASSERT(EXPR, MSG...) static_assert(EXPR, "" MSG)
+#elif defined(__cplusplus)
+/* For cpp98 */
+#define BUILD_ASSERT(EXPR, MSG...)
 #else
 #define BUILD_ASSERT(EXPR, MSG...) _Static_assert(EXPR, "" MSG)
 #endif


### PR DESCRIPTION
cpp98 doesn't support static_assert, so we shouldn't use it.