### PR TITLE
samples: hci_usb: disable CDC-ACM for nrf52840dongle

### DIFF
--- a/samples/bluetooth/hci_usb/boards/nrf52840dongle_nrf52840.conf
+++ b/samples/bluetooth/hci_usb/boards/nrf52840dongle_nrf52840.conf
@@ -1,0 +1,2 @@
+# CDC-ACM causes the BT HCI interface to be ignored
+CONFIG_USB_CDC_ACM=n


### PR DESCRIPTION
Hi, bumped into this while trying the usb hci sample on the nrf52840dongle, seems like Linux really wants it to be interface 0 (and the code claim it's in the spec) so the sample is broken there since CDC-ACM has been enabled in the board config. Tried to swap the linking order but then the CDC-ACM interface stops working. 

---

Bluetooth devices are apparently expected to show up as interface 0, Linux btusb driver ignores them otherwise (or need special configuration).

This is a problem for boards with USB_CDC_ACM enabled by default, such as nrf52840dongle_nrf52840, as interfaces are configured in linking order and currently cdc_acm comes first.

Swapping the order of interface causes the opposite problem though (CDC-ACM does not show up), so fix this for nrf52840dongle by forcing the CDC-ACM option to be off when building for it.

Link: https://elixir.bootlin.com/linux/v6.2.8/source/drivers/bluetooth/btusb.c#L3845