### PR TITLE
dts: esp32s3: add MCPWM device

### DIFF
--- a/dts/xtensa/espressif/esp32s3.dtsi
+++ b/dts/xtensa/espressif/esp32s3.dtsi
@@ -266,5 +266,25 @@
 			clocks = <&rtc ESP32_LEDC_MODULE>;
 			status = "disabled";
 		};
+
+		mcpwm0: mcpwm@6001e000 {
+			compatible = "espressif,esp32-mcpwm";
+			reg = <0x6001e000 DT_SIZE_K(4)>;
+			interrupts = <PWM0_INTR_SOURCE>;
+			interrupt-parent = <&intc>;
+			clocks = <&rtc ESP32_PWM0_MODULE>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		mcpwm1: mcpwm@6002c000 {
+			compatible = "espressif,esp32-mcpwm";
+			reg = <0x6002c000 DT_SIZE_K(4)>;
+			interrupts = <PWM1_INTR_SOURCE>;
+			interrupt-parent = <&intc>;
+			clocks = <&rtc ESP32_PWM1_MODULE>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
 	};
 };

--- a/tests/drivers/pwm/pwm_loopback/boards/esp32s3_devkitm.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/esp32s3_devkitm.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <dt-bindings/pinctrl/esp32s3-pinctrl.h>
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		/* first index must be a 32-Bit timer */
+		pwms = <&mcpwm0 0 0 PWM_POLARITY_NORMAL>,
+		       <&mcpwm0 6 0 PWM_POLARITY_NORMAL>;
+	};
+};
+
+&pinctrl {
+	mcpwm0_default: mcpwm0_default {
+		group1 {
+			pinmux = <MCPWM0_OUT0A_GPIO2>;
+			output-enable;
+		};
+		group2 {
+			pinmux = <MCPWM0_CAP0_GPIO4>;
+		};
+	};
+};
+
+&mcpwm0 {
+	pinctrl-0 = <&mcpwm0_default>;
+	pinctrl-names = "default";
+	prescale = <255>;
+	prescale-timer0 = <103>;
+	status = "okay";
+};


### PR DESCRIPTION
Add MCPWM device node to esp32s3.
Add esp32s3 overlay to pwm_loopback test using mcpwm
peripheral.