### PR TITLE
hwinfo: stm32: add retrieve wakeup flag of device and Clear wakeup flag

### DIFF
--- a/drivers/hwinfo/hwinfo_stm32.c
+++ b/drivers/hwinfo/hwinfo_stm32.c
@@ -10,6 +10,7 @@
 #if defined(CONFIG_SOC_SERIES_STM32H5X)
 #include <stm32_ll_icache.h>
 #endif /* CONFIG_SOC_SERIES_STM32H5X */
+#include <stm32_ll_pwr.h>
 #include <zephyr/drivers/hwinfo.h>
 #include <string.h>
 #include <zephyr/sys/byteorder.h>
@@ -113,6 +114,28 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 	}
 #endif
 
+#if defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CORE_CM4)
+	if (LL_PWR_CPU2_IsActiveFlag_SB()) {
+		flags |= RESET_LOW_POWER_WAKE;
+	}
+#elif defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CORE_CM7)
+	if (LL_PWR_CPU_IsActiveFlag_SB()) {
+		flags |= RESET_LOW_POWER_WAKE;
+	}
+#elif defined(CONFIG_SOC_SERIES_STM32MP1X)
+	if (LL_PWR_MCU_IsActiveFlag_SB()) {
+		flags |= RESET_LOW_POWER_WAKE;
+	}
+#elif defined(CONFIG_SOC_SERIES_STM32WLX) || defined(CONFIG_SOC_SERIES_STM32WBX)
+	if (LL_PWR_IsActiveFlag_C1SB()) {
+		flags |= RESET_LOW_POWER_WAKE;
+	}
+#elif defined(PWR_FLAG_SB)
+	if (LL_PWR_IsActiveFlag_SB()) {
+		flags |= RESET_LOW_POWER_WAKE;
+	}
+#endif /* PWR_FLAG_SB */
+
 	*cause = flags;
 
 	return 0;
@@ -121,6 +144,18 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 int z_impl_hwinfo_clear_reset_cause(void)
 {
 	LL_RCC_ClearResetFlags();
+
+#if defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CORE_CM4)
+	LL_PWR_ClearFlag_CPU2();
+#elif defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CORE_CM7)
+	LL_PWR_ClearFlag_CPU();
+#elif defined(CONFIG_SOC_SERIES_STM32MP1X)
+	LL_PWR_ClearFlag_MCU();
+#elif defined(CONFIG_SOC_SERIES_STM32WLX) || defined(CONFIG_SOC_SERIES_STM32WBX)
+	LL_PWR_ClearFlag_C1STOP_C1STB();
+#elif defined(PWR_FLAG_SB)
+	LL_PWR_ClearFlag_SB();
+#endif /* PWR_FLAG_SB */
 
 	return 0;
 }

--- a/samples/boards/stm32/power_mgmt/standby_shutdown/src/main.c
+++ b/samples/boards/stm32/power_mgmt/standby_shutdown/src/main.c
@@ -96,19 +96,16 @@ void main(void)
 	hwinfo_get_reset_cause(&cause);
 	hwinfo_clear_reset_cause();
 
-	if ((LL_PWR_IsActiveFlag_SB() == true) && (cause == 0))	{
-		LL_PWR_ClearFlag_SB();
-		LL_PWR_ClearFlag_WU();
+	if (cause == RESET_LOW_POWER_WAKE)	{
+		hwinfo_clear_reset_cause();
 		printk("\nReset cause: Standby mode\n\n");
 	}
 
 	if (cause == (RESET_PIN | RESET_BROWNOUT)) {
-		LL_PWR_ClearFlag_WU();
 		printk("\nReset cause: Shutdown mode or power up\n\n");
 	}
 
 	if (cause == RESET_PIN) {
-		LL_PWR_ClearFlag_WU();
 		printk("\nReset cause: Reset pin\n\n");
 	}
 


### PR DESCRIPTION
add retrieve flag SB into hwinfo_get_reset_cause()
add Clear flag SB into clear_reset_cause()

Signed-off-by: Marc Desvaux <marc.desvaux-ext@st.com>
