### PR TITLE
rtio: Move spsc buffer to bss

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -158,7 +158,7 @@ struct rtio_sqe {
  */
 struct rtio_sq {
 	struct rtio_spsc _spsc;
-	struct rtio_sqe buffer[];
+	struct rtio_sqe *const buffer;
 };
 
 /**
@@ -177,7 +177,7 @@ struct rtio_cqe {
  */
 struct rtio_cq {
 	struct rtio_spsc _spsc;
-	struct rtio_cqe buffer[];
+	struct rtio_cqe *const buffer;
 };
 
 struct rtio;
@@ -417,21 +417,21 @@ static inline void rtio_sqe_prep_write(struct rtio_sqe *sqe,
  * @param sq_sz Size of the submission queue, must be power of 2
  * @param cq_sz Size of the completion queue, must be power of 2
  */
-#define RTIO_DEFINE(name, exec, sq_sz, cq_sz)	\
-	IF_ENABLED(CONFIG_RTIO_SUBMIT_SEM,							   \
-		   (static K_SEM_DEFINE(_submit_sem_##name, 0, K_SEM_MAX_LIMIT)))		   \
-	IF_ENABLED(CONFIG_RTIO_CONSUME_SEM,							   \
-		   (static K_SEM_DEFINE(_consume_sem_##name, 0, K_SEM_MAX_LIMIT)))		   \
-	static RTIO_SQ_DEFINE(_sq_##name, sq_sz);						   \
-	static RTIO_CQ_DEFINE(_cq_##name, cq_sz);						   \
-	STRUCT_SECTION_ITERABLE(rtio, name) = {							   \
-		.executor = (exec),                                                                \
-		.xcqcnt = ATOMIC_INIT(0),                                                          \
-		IF_ENABLED(CONFIG_RTIO_SUBMIT_SEM, (.submit_sem = &_submit_sem_##name,))	   \
-		IF_ENABLED(CONFIG_RTIO_SUBMIT_SEM, (.submit_count = 0,))			   \
-		IF_ENABLED(CONFIG_RTIO_CONSUME_SEM, (.consume_sem = &_consume_sem_##name,))	   \
-		.sq = (struct rtio_sq *const)&_sq_##name,					   \
-		.cq = (struct rtio_cq *const)&_cq_##name,                                          \
+#define RTIO_DEFINE(name, exec, sq_sz, cq_sz)							\
+	IF_ENABLED(CONFIG_RTIO_SUBMIT_SEM,							\
+		   (static K_SEM_DEFINE(_submit_sem_##name, 0, K_SEM_MAX_LIMIT)))		\
+	IF_ENABLED(CONFIG_RTIO_CONSUME_SEM,							\
+		   (static K_SEM_DEFINE(_consume_sem_##name, 0, K_SEM_MAX_LIMIT)))		\
+	RTIO_SQ_DEFINE(_sq_##name, sq_sz);							\
+	RTIO_CQ_DEFINE(_cq_##name, cq_sz);							\
+	STRUCT_SECTION_ITERABLE(rtio, name) = {							\
+		.executor = (exec),								\
+		.xcqcnt = ATOMIC_INIT(0),							\
+		IF_ENABLED(CONFIG_RTIO_SUBMIT_SEM, (.submit_sem = &_submit_sem_##name,))	\
+		IF_ENABLED(CONFIG_RTIO_SUBMIT_SEM, (.submit_count = 0,))			\
+		IF_ENABLED(CONFIG_RTIO_CONSUME_SEM, (.consume_sem = &_consume_sem_##name,))	\
+		.sq = (struct rtio_sq *const)&_sq_##name,					\
+		.cq = (struct rtio_cq *const)&_cq_##name,					\
 	};
 
 /**

--- a/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
+++ b/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
@@ -239,7 +239,7 @@ void rtio_syscall_test(void *p1, void *p2, void *p3)
 {
 	int res;
 	struct rtio_sqe sqe;
-	struct rtio_cqe cqe;
+	struct rtio_cqe cqe = {0};
 
 	struct rtio *r = &r_syscall;
 


### PR DESCRIPTION
This can save a sizeable region of rom depending on the number of spsc instances and their size.