### PR TITLE
pm: mark pm_device_runtime_auto_enable as boot function

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -242,6 +242,7 @@ int pm_device_runtime_put_async(const struct device *dev)
 	return ret;
 }
 
+__boot_func
 int pm_device_runtime_auto_enable(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;


### PR DESCRIPTION
When demand paging is enabled, only a minimal set of functions are available at boot. Anything not marked as boot functions would not be loading in memory at boot which would result in page faults when jumping to those functions. However, at early boot, demand paging has not been enabled yet. So we need to mark necessary functions as boot functions so they are placed in the correct linker section where they are loaded at boot.

Fixes #56414