### PR TITLE
drivers: i3c: cdns: set tx fifo threshold interrupt to half the fifo

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -2103,9 +2103,13 @@ static int cdns_i3c_target_tx_write(const struct device *dev, uint8_t *buf, uint
 	/* setup THR interrupt */
 	uint32_t thr_ctrl = sys_read32(config->base + TX_RX_THR_CTRL);
 
-	/* TODO: investigate if setting to THR to 1 is good enough */
+	/*
+	 * Interrupt at half of the data or FIFO depth to give it enough time to be
+	 * processed. The ISR will then callback to the function pointer
+	 * `read_processed_cb` to collect more data to transmit
+	 */
 	thr_ctrl &= ~TX_THR_MASK;
-	thr_ctrl |= TX_THR(MIN((data->hw_cfg.tx_mem_depth / 4) - 1, i - 1));
+	thr_ctrl |= TX_THR(MIN((data->hw_cfg.tx_mem_depth / 4) / 2, i / 2));
 	sys_write32(thr_ctrl, config->base + TX_RX_THR_CTRL);
 
 	k_mutex_unlock(&data->bus_lock);


### PR DESCRIPTION
When a controller is running at full SDR speed at 12.5MHz, there needs to be enough time for the processor get around to writing more data in the fifo. Previously at -1 the size, this was enough for 1MHz with a decent processor, but not enough at a 12.5MHz SCL.