### PR TITLE
Bluetooth: Controller: Fix BIG handle when operation cancelled by Host

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -219,7 +219,7 @@ uint8_t ll_big_sync_terminate(uint8_t big_handle, void **rx)
 
 		node_rx = (void *)&sync_iso->node_rx_lost;
 		node_rx->hdr.type = NODE_RX_TYPE_SYNC_ISO;
-		node_rx->hdr.handle = 0xffff;
+		node_rx->hdr.handle = big_handle;
 
 		/* NOTE: Since NODE_RX_TYPE_SYNC_ISO is only generated from ULL
 		 *       context, pass ULL context as parameter.


### PR DESCRIPTION
Fix the BIG handle in the HCI LE BIG Sync Established event when BIG Create Sync operation is cancelled by Host.

Fix #53148.