### PR TITLE
tests: drivers: counter: nrf_rtc: Add delay to the start of test_short_relative_alarm test

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -786,7 +786,7 @@ static void test_short_relative_alarm_instance(const struct device *dev)
 				dev->name, err);
 
 		/* wait to ensure that tick+1 timeout will expire. */
-		k_busy_wait(10 * tick_us);
+		k_busy_wait(3*tick_us);
 
 		cnt = IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS) ?
 			alarm_cnt : k_sem_count_get(&alarm_cnt_sem);

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -777,6 +777,10 @@ static void test_short_relative_alarm_instance(const struct device *dev)
 	err = counter_start(dev);
 	zassert_equal(0, err, "%s: Unexpected error", dev->name);
 
+	if (IS_ENABLED(CONFIG_COUNTER_NRF_RTC)) {
+		k_busy_wait(1000);
+	}
+
 	alarm_cfg.ticks = 1;
 
 	for (int i = 0; i < 100; ++i) {


### PR DESCRIPTION
Reverting previous fix which was causing issues on some platforms (#56438) and applying a fix which is applicable only to Nordic devices.

Fixes #56291.