### PR TITLE
doc: testing: Fix testing expectations example

### DIFF
--- a/doc/develop/test/ztest.rst
+++ b/doc/develop/test/ztest.rst
@@ -134,7 +134,7 @@ nature of the code, it's possible to annotate the test as such. For example:
       zassert_true(false, NULL);
     }
 
-    ZTEST_EXPECT_SKIP(my_suite, test_fail)
+    ZTEST_EXPECT_SKIP(my_suite, test_skip)
     ZTEST(my_suite, test_skip)
     {
       /** This will skip the test */


### PR DESCRIPTION
This fixes a typo in the testing framework docs where the ZTEST_EXPECT_SKIP MACRO seems to be referring to the wrong function.

Signed-off-by: Ivan Herrera Olivares <ivan.herreraolivares@gmail.com>