### PR TITLE
doc: services: device_mgmt: smp_groups: Fix doc issues

### DIFF
--- a/doc/services/device_mgmt/mcumgr.rst
+++ b/doc/services/device_mgmt/mcumgr.rst
@@ -434,8 +434,8 @@ available sub-commands are::
 
 Statistics are organized in sections (also called groups), and each section can
 be individually queried. Defining new statistics sections is done by using macros
-available under ``<stats/stats.h>``. Each section consists of multiple variables
-(or counters), all with the same size (16, 32 or 64 bits).
+available under :file:`zephyr/stats/stats.h`. Each section consists of multiple
+variables (or counters), all with the same size (16, 32 or 64 bits).
 
 To create a new section ``my_stats``::
 
@@ -447,8 +447,9 @@ To create a new section ``my_stats``::
 
   STATS_SECT_DECL(my_stats) my_stats;
 
-Each entry can be declared with ``STATS_SECT_ENTRY`` (or the equivalent
-``STATS_SECT_ENTRY32``), ``STATS_SECT_ENTRY16`` or ``STATS_SECT_ENTRY64``.
+Each entry can be declared with :c:macro:`STATS_SECT_ENTRY` (or the equivalent
+:c:macro:`STATS_SECT_ENTRY32`), :c:macro:`STATS_SECT_ENTRY16` or
+:c:macro:`STATS_SECT_ENTRY64`.
 All statistics in a section must be declared with the same size.
 
 The statistics counters can either have names or not, depending on the setting
@@ -479,7 +480,8 @@ The final steps to use a statistics section is to initialize and register it::
   assert (rc == 0);
 
 In the running code a statistics counter can be incremented by 1 using
-``STATS_INC``, by N using ``STATS_INCN`` or reset with ``STATS_CLEAR``.
+:c:macro:`STATS_INC`, by N using :c:macro:`STATS_INCN` or reset with
+:c:macro:`STATS_CLEAR`.
 
 Let's suppose we want to increment those counters by ``1``, ``2`` and ``3``
 every second. To get a list of stats::
@@ -591,3 +593,8 @@ Discord channel
 Developers welcome!
 
 * Discord mcumgr channel: https://discord.com/invite/Ck7jw53nU2
+
+API Reference
+*************
+
+.. doxygengroup:: mcumgr_mgmt_api

--- a/doc/services/device_mgmt/smp_groups/smp_group_0.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_0.rst
@@ -102,12 +102,12 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | "r"                   | Replying echo string                              |
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
-    |                       | only appears if non-zero (error condition).       |
-    +-----------------------+---------------------------------------------------+
+    +-----------------------+-----------------------------------------------+
+    | "r"                   | Replying echo string                          |
+    +-----------------------+-----------------------------------------------+
+    | "rc"                  | :c:enum:`mcumgr_err_t`                        |
+    |                       | only appears if non-zero (error condition).   |
+    +-----------------------+-----------------------------------------------+
 
 Task statistics command
 ***********************
@@ -179,30 +179,30 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | <task_name>           | string identifying task                           |
-    +-----------------------+---------------------------------------------------+
-    | "prio"                | task priority                                     |
-    +-----------------------+---------------------------------------------------+
-    | "tid"                 | numeric task ID                                   |
-    +-----------------------+---------------------------------------------------+
-    | "state"               | numeric task state                                |
-    +-----------------------+---------------------------------------------------+
-    | "stkuse"              | task's/thread's stack usage                       |
-    +-----------------------+---------------------------------------------------+
-    | "stksiz"              | task's/thread's stack size                        |
-    +-----------------------+---------------------------------------------------+
-    | "cswcnt"              | task's/thread's context switches                  |
-    +-----------------------+---------------------------------------------------+
-    | "runtime"             | task's/thread's runtime in "ticks"                |
-    +-----------------------+---------------------------------------------------+
-    | "last_checkin"        | set to 0 by Zephyr                                |
-    +-----------------------+---------------------------------------------------+
-    | "next_checkin"        | set to 0 by Zephyr                                |
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
-    |                       | only appears if non-zero (error condition).       |
-    +-----------------------+---------------------------------------------------+
+    +-----------------------+-----------------------------------------------+
+    | <task_name>           | string identifying task                       |
+    +-----------------------+-----------------------------------------------+
+    | "prio"                | task priority                                 |
+    +-----------------------+-----------------------------------------------+
+    | "tid"                 | numeric task ID                               |
+    +-----------------------+-----------------------------------------------+
+    | "state"               | numeric task state                            |
+    +-----------------------+-----------------------------------------------+
+    | "stkuse"              | task's/thread's stack usage                   |
+    +-----------------------+-----------------------------------------------+
+    | "stksiz"              | task's/thread's stack size                    |
+    +-----------------------+-----------------------------------------------+
+    | "cswcnt"              | task's/thread's context switches              |
+    +-----------------------+-----------------------------------------------+
+    | "runtime"             | task's/thread's runtime in "ticks"            |
+    +-----------------------+-----------------------------------------------+
+    | "last_checkin"        | set to 0 by Zephyr                            |
+    +-----------------------+-----------------------------------------------+
+    | "next_checkin"        | set to 0 by Zephyr                            |
+    +-----------------------+-----------------------------------------------+
+    | "rc"                  | :c:enum:`mcumgr_err_t`                        |
+    |                       | only appears if non-zero (error condition).   |
+    +-----------------------+-----------------------------------------------+
 
 .. note::
     The unit for "stkuse" and "stksiz" is system dependent and in case of Zephyr
@@ -271,22 +271,22 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | <pool_name>           | string representing the pool name, used as a key  |
-    |                       | for dictionary with pool statistics data          |
-    +-----------------------+---------------------------------------------------+
-    | "blksiz"              | size of the memory block in the pool              |
-    +-----------------------+---------------------------------------------------+
-    | "nblks"               | number of blocks in the pool                      |
-    +-----------------------+---------------------------------------------------+
-    | "nrfree"              | number of free blocks                             |
-    +-----------------------+---------------------------------------------------+
-    | "min"                 | lowest number of free blocks the pool reached     |
-    |                       | during run-time                                   |
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
-    |                       | only appears if non-zero (error condition).       |
-    +-----------------------+---------------------------------------------------+
+    +-----------------------+--------------------------------------------------+
+    | <pool_name>           | string representing the pool name, used as a key |
+    |                       | for dictionary with pool statistics data         |
+    +-----------------------+--------------------------------------------------+
+    | "blksiz"              | size of the memory block in the pool             |
+    +-----------------------+--------------------------------------------------+
+    | "nblks"               | number of blocks in the pool                     |
+    +-----------------------+--------------------------------------------------+
+    | "nrfree"              | number of free blocks                            |
+    +-----------------------+--------------------------------------------------+
+    | "min"                 | lowest number of free blocks the pool reached    |
+    |                       | during run-time                                  |
+    +-----------------------+--------------------------------------------------+
+    | "rc"                  | :c:enum:`mcumgr_err_t`                           |
+    |                       | only appears if non-zero (error condition).      |
+    +-----------------------+--------------------------------------------------+
 
 Date-time command
 *****************
@@ -353,13 +353,13 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | "datetime"            | String in format                                  |
-    |                       | yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ                 |
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`;          |
-    |                       | only appears if non-zero (error condition).       |
-    +-----------------------+---------------------------------------------------+
+    +-----------------------+---------------------------------------------+
+    | "datetime"            | String in format                            |
+    |                       | yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZZ           |
+    +-----------------------+---------------------------------------------+
+    | "rc"                  | :c:enum:`mcumgr_err_t`;                     |
+    |                       | only appears if non-zero (error condition). |
+    +-----------------------+---------------------------------------------+
 
 
 Date-time set
@@ -427,10 +427,10 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
-    |                       | only appears if non-zero (error condition).       |
-    +-----------------------+---------------------------------------------------+
+    +-----------------------+---------------------------------------------+
+    | "rc"                  | :c:enum:`mcumgr_err_t`                      |
+    |                       | only appears if non-zero (error condition). |
+    +-----------------------+---------------------------------------------+
 
 System reset
 ************
@@ -506,20 +506,20 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`;          |
-    |                       | only appears if non-zero (error condition).       |
-    +-----------------------+---------------------------------------------------+
+    +-----------------------+---------------------------------------------+
+    | "rc"                  | :c:enum:`mcumgr_err_t`;                     |
+    |                       | only appears if non-zero (error condition). |
+    +-----------------------+---------------------------------------------+
 
-MCUMGR Parameters
+MCUmgr Parameters
 *****************
 
 Used to obtain parameters of mcumgr library.
 
-MCUMGR Parameters Request
+MCUmgr Parameters Request
 =========================
 
-MCUMGR parameters request header fields:
+MCUmgr parameters request header fields:
 
 .. table::
     :align: center
@@ -532,10 +532,10 @@ MCUMGR parameters request header fields:
 
 The command sends an empty CBOR map as data.
 
-MCUMGR Parameters Response
+MCUmgr Parameters Response
 ==========================
 
-MCUMGR parameters response header fields
+MCUmgr parameters response header fields
 
 .. table::
     :align: center
@@ -568,15 +568,15 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | "buf_size"            | Single SMP buffer size, this includes SMP header  |
-    |                       | and CBOR payload                                  |
-    +-----------------------+---------------------------------------------------+
-    | "buf_count"           | Number of SMP buffers supported                   |
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`;          |
-    |                       | only appears if non-zero (error condition).       |
-    +-----------------------+---------------------------------------------------+
+    +-----------------------+--------------------------------------------------+
+    | "buf_size"            | Single SMP buffer size, this includes SMP header |
+    |                       | and CBOR payload                                 |
+    +-----------------------+--------------------------------------------------+
+    | "buf_count"           | Number of SMP buffers supported                  |
+    +-----------------------+--------------------------------------------------+
+    | "rc"                  | :c:enum:`mcumgr_err_t`;                          |
+    |                       | only appears if non-zero (error condition).      |
+    +-----------------------+--------------------------------------------------+
 
 .. _mcumgr_os_application_info:
 
@@ -663,9 +663,9 @@ where:
 .. table::
     :align: center
 
-    +--------------+------------------------------------------------------------+
-    | "output"     | Text response including requested parameters               |
-    +--------------+------------------------------------------------------------+
-    | "rc"         | :ref:`mcumgr_smp_protocol_status_codes`; will not appear   |
-    |              | if 0                                                       |
-    +--------------+------------------------------------------------------------+
+    +--------------+-----------------------------------------------+
+    | "output"     | Text response including requested parameters. |
+    +--------------+-----------------------------------------------+
+    | "rc"         | :c:enum:`mcumgr_err_t`                        |
+    |              | only appears if non-zero (error condition).   |
+    +--------------+-----------------------------------------------+

--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -130,7 +130,7 @@ In case of error the CBOR data takes the form:
 .. code-block:: none
 
     {
-        (str)"rc" : (int)
+        (str)"rc"      : (int)
         (str,opt)"rsn" : (str)
     }
 
@@ -187,7 +187,7 @@ where:
     | "splitStatus"         | states whether loader of split image is compatible|
     |                       | with application part; this is unused by Zephyr   |
     +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    | "rc"                  | :c:enum:`mcumgr_err_t`                            |
     |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
     | "rsn"                 | optional string that clarifies reason for an      |
@@ -229,9 +229,9 @@ CBOR data of request:
         }
     }
 
-If "confirm" is false an image with the "hash" will be set for test, which means
-that it will not be marked as permanent and upon hard reset the previous
-application will be restored to the primary slot.
+If "confirm" is false or not provided, an image with the "hash" will be set for
+test, which means that it will not be marked as permanent and upon hard reset
+the previous application will be restored to the primary slot.
 In case when "confirm" is true, the "hash" is optional as the currently running
 application will be assumed as target for confirmation.
 
@@ -251,7 +251,7 @@ Image upload request
 The image upload request is sent for each chunk of image that is uploaded, until
 complete image gets uploaded to a device.
 
-Set state of image request header fields:
+Image upload request header fields:
 
 .. table::
     :align: center
@@ -314,8 +314,9 @@ where:
     There is no field representing size of chunk that is carried as "data" because
     that information is embedded within "data" field itself.
 
-The mcumgr library uses "sha" field to tag ongoing update session, to be able
-to continue it in case when it gets broken.
+The MCUmgr library uses "sha" field to tag ongoing update session, to be able
+to continue it in case when it gets broken, and for upload verification
+purposes.
 If library gets request with "off" equal zero it checks stored "sha" within its
 state and if it matches it will respond to update client application with
 offset that it should continue with.
@@ -323,7 +324,7 @@ offset that it should continue with.
 Image upload response
 =====================
 
-Set state of image request header fields:
+Image upload response header fields:
 
 .. table::
     :align: center
@@ -366,7 +367,7 @@ where:
     |                       | :kconfig:option:`CONFIG_IMG_ENABLE_IMAGE_CHECK` is  |
     |                       | enabled.                                            |
     +-----------------------+-----------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes` only        |
+    | "rc"                  | :c:enum:`mcumgr_err_t` only                         |
     |                       | appears if non-zero (error condition).              |
     +-----------------------+-----------------------------------------------------+
     | "rsn"                 | Optional string that clarifies reason for an error; |
@@ -384,7 +385,7 @@ The command is used for erasing image slot on a target device.
 
 .. note::
     This is synchronous command which means that a sender of request will not
-    receive response until the command completes.
+    receive response until the command completes, which can take a long time.
 
 Image erase request
 ===================
@@ -449,16 +450,16 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
-    |                       | only appears if non-zero (error condition).       |
-    +-----------------------+---------------------------------------------------+
-    | "rsn"                 | Optional string that clarifies reason for an      |
-    |                       | error; specifically useful for error code ``1``,  |
-    |                       | unknown error                                     |
-    +-----------------------+---------------------------------------------------+
+    +-----------------------+--------------------------------------------------+
+    | "rc"                  | :c:enum:`mcumgr_err_t`                           |
+    |                       | only appears if non-zero (error condition).      |
+    +-----------------------+--------------------------------------------------+
+    | "rsn"                 | Optional string that clarifies reason for an     |
+    |                       | error; specifically useful when rc value is      |
+    |                       | :c:enum:`MGMT_ERR_EUNKNOWN`                      |
+    +-----------------------+--------------------------------------------------+
 
 .. note::
-    Response from Zephyr running device may have "rc" value of 6, bad state
-    (:ref:`mcumgr_smp_protocol_status_codes`), which means that the secondary
+    Response from Zephyr running device may have "rc" value of
+    :c:enum:`MGMT_ERR_EBADSTATE`, which means that the secondary
     image has been marked for next boot already and may not be erased.

--- a/doc/services/device_mgmt/smp_groups/smp_group_2.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_2.rst
@@ -4,7 +4,7 @@ Statistics management
 #####################
 
 Statistics management allows to obtain data gathered by Statistics subsystem
-of Zephyr, enabled by ``CONFIG_STATS``.
+of Zephyr, enabled with :kconfig:option:`CONFIG_STATS`.
 
 Statistics management group defines commands:
 
@@ -23,9 +23,9 @@ Statistics: group data
 **********************
 
 The command is used to obtain data for group specified by a name.
-The name is one of group names as registered, with ``STATS_INIT_AND_REG`` macro
-or ``stats_init_and_reg(...)`` function call, within module that gathers
-the statistics.
+The name is one of group names as registered, with
+:c:macro:`STATS_INIT_AND_REG` macro or :c:func:`stats_init_and_reg` function
+call, within module that gathers the statistics.
 
 Statistics: group data request
 ==============================
@@ -108,7 +108,7 @@ where:
     | <entry_name>          | single entry to value mapping; value is hardcoded |
     |                       | to unsigned integer type, in a CBOR meaning       |
     +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    | "rc"                  | :c:enum:`mcumgr_err_t`                            |
     |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+
 
@@ -117,11 +117,10 @@ Statistics: list of groups
 
 The command is used to obtain list of groups of statistics that are gathered
 on a device. This is a list of names as given to groups with
-``STATS_INIT_AND_REG`` macro or ``stats_init_and_reg(...)`` function calls,
-within module that gathers the statistics; this means that this command may
-be considered optional as it is known during compilation what groups will
-be included into build and listing them is not needed prior to issuing
-a query.
+:c:macro:`STATS_INIT_AND_REG` macro or :c:func:`stats_init_and_reg` function
+calls, within module that gathers the statistics; this means that this command
+may be considered optional as it is known during compilation what groups will
+be included into build and listing them is not needed prior to issuing a query.
 
 Statistics: list of groups request
 ==================================
@@ -180,6 +179,6 @@ where:
     | "stat_list"           | array of strings representing group names; this   |
     |                       | array may be empty if there are no groups         |
     +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
+    | "rc"                  | :c:enum:`mcumgr_err_t`                            |
     |                       | only appears if non-zero (error condition).       |
     +-----------------------+---------------------------------------------------+

--- a/doc/services/device_mgmt/smp_groups/smp_group_8.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_8.rst
@@ -118,19 +118,19 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | "off"                 | offset the response is for                        |
-    +-----------------------+---------------------------------------------------+
-    | "data"                | chunk of data read from file; it is CBOR encoded  |
-    |                       | stream of bytes with embedded size;               |
-    |                       | "data" appears only in responses where "rc" is 0  |
-    +-----------------------+---------------------------------------------------+
-    | "len"                 | length of file, this field is only mandatory      |
-    |                       | when "off" is 0                                   |
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
-    |                       | only appears if non-zero (error condition).       |
-    +-----------------------+---------------------------------------------------+
+    +-----------------------+--------------------------------------------------+
+    | "off"                 | offset the response is for                       |
+    +-----------------------+--------------------------------------------------+
+    | "data"                | chunk of data read from file; it is CBOR encoded |
+    |                       | stream of bytes with embedded size;              |
+    |                       | "data" appears only in responses where "rc" is 0 |
+    +-----------------------+--------------------------------------------------+
+    | "len"                 | length of file, this field is only mandatory     |
+    |                       | when "off" is 0                                  |
+    +-----------------------+--------------------------------------------------+
+    | "rc"                  | :c:enum:`mcumgr_err_t`                           |
+    |                       | only appears if non-zero (error condition).      |
+    +-----------------------+--------------------------------------------------+
 
 In case when "rc" is not 0, success, the other fields will not appear.
 
@@ -239,12 +239,12 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | "off"                 | offset of last successfully written data.         |
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
-    |                       | only appears if non-zero (error condition).       |
-    +-----------------------+---------------------------------------------------+
+    +-----------------------+---------------------------------------------+
+    | "off"                 | offset of last successfully written data.   |
+    +-----------------------+---------------------------------------------+
+    | "rc"                  | :c:enum:`mcumgr_err_t`                      |
+    |                       | only appears if non-zero (error condition). |
+    +-----------------------+---------------------------------------------+
 
 File status
 ***********
@@ -318,12 +318,12 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | "len"                 | length of file (in bytes)                         |
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
-    |                       | only appears if non-zero (error condition).       |
-    +-----------------------+---------------------------------------------------+
+    +-----------------------+---------------------------------------------+
+    | "len"                 | length of file (in bytes)                   |
+    +-----------------------+---------------------------------------------+
+    | "rc"                  | :c:enum:`mcumgr_err_t`                      |
+    |                       | only appears if non-zero (error condition). |
+    +-----------------------+---------------------------------------------+
 
 In case when "rc" is not 0, success, the other fields will not appear.
 
@@ -437,21 +437,21 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
-    |                       | only appears if non-zero (error condition).       |
-    +-----------------------+---------------------------------------------------+
-    | "type"                | type of hash/checksum that was performed          |
-    |                       | :ref:`mcumgr_group_8_hash_checksum_types`         |
-    +-----------------------+---------------------------------------------------+
-    | "off"                 | offset that hash/checksum calculation started at  |
-    |                       | (only present if off is not 0)                    |
-    +-----------------------+---------------------------------------------------+
-    | "len"                 | length of input data used for hash/checksum       |
-    |                       | generation (in bytes)                             |
-    +-----------------------+---------------------------------------------------+
-    | "output"              | output hash/checksum                              |
-    +-----------------------+---------------------------------------------------+
+    +-----------------------+--------------------------------------------------+
+    | "rc"                  | :c:enum:`mcumgr_err_t`                           |
+    |                       | only appears if non-zero (error condition).      |
+    +-----------------------+--------------------------------------------------+
+    | "type"                | type of hash/checksum that was performed         |
+    |                       | :ref:`mcumgr_group_8_hash_checksum_types`        |
+    +-----------------------+--------------------------------------------------+
+    | "off"                 | offset that hash/checksum calculation started at |
+    |                       | (only present if off is not 0)                   |
+    +-----------------------+--------------------------------------------------+
+    | "len"                 | length of input data used for hash/checksum      |
+    |                       | generation (in bytes)                            |
+    +-----------------------+--------------------------------------------------+
+    | "output"              | output hash/checksum                             |
+    +-----------------------+--------------------------------------------------+
 
 In case when "rc" is not 0, success, the other fields will not appear.
 

--- a/doc/services/device_mgmt/smp_groups/smp_group_9.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_9.rst
@@ -3,7 +3,7 @@
 Shell management
 ################
 
-Shell management allows to pass commands to shell subsystem with use of SMP
+Shell management allows passing commands to the shell subsystem over the SMP
 protocol.
 
 Shell management group defines following commands:
@@ -21,7 +21,7 @@ Shell command line execute
 **************************
 
 The command allows to execute command line in a similar way to typing it into
-a shell, but both a request and a response are transported with use of SMP.
+a shell, but both a request and a response are transported over SMP.
 
 Shell command line execute request
 ==================================
@@ -55,8 +55,8 @@ where:
     :align: center
 
     +-----------------------+---------------------------------------------------+
-    | "argv"                | is array consisting of strings representing       |
-    |                       | command and its arguments                         |
+    | "argv"                | array consisting of strings representing command  |
+    |                       | and its arguments                                 |
     +-----------------------+---------------------------------------------------+
     | <cmd>                 | command to be executed                            |
     +-----------------------+---------------------------------------------------+
@@ -99,14 +99,14 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
-    |                       | only appears if non-zero (error condition).       |
-    +-----------------------+---------------------------------------------------+
-    | "o"                   | command output                                    |
-    +-----------------------+---------------------------------------------------+
-    | "ret"                 | return code from shell command execution          |
-    +-----------------------+---------------------------------------------------+
+    +-----------------------+-----------------------------------------------+
+    | "rc"                  | :c:enum:`mcumgr_err_t`                        |
+    |                       | only appears if non-zero (error condition).   |
+    +-----------------------+-----------------------------------------------+
+    | "o"                   | command output                                |
+    +-----------------------+-----------------------------------------------+
+    | "ret"                 | return code from shell command execution      |
+    +-----------------------+-----------------------------------------------+
 
 .. note::
     In older versions of Zephyr, "rc" was used for both the mcumgr status code

--- a/doc/services/device_mgmt/smp_protocol.rst
+++ b/doc/services/device_mgmt/smp_protocol.rst
@@ -191,66 +191,9 @@ where:
 .. table::
     :align: center
 
-    +-----------------------+---------------------------------------------------+
-    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`           |
-    +-----------------------+---------------------------------------------------+
-
-.. _mcumgr_smp_protocol_status_codes:
-
-Status/error codes in responses
-===============================
-
-.. table::
-    :align: center
-
-    +---------------+-----------------------------------------------+
-    | Decimal ID    | Meaning                                       |
-    +===============+===============================================+
-    | ``0``         | No error, OK.                                 |
-    +---------------+-----------------------------------------------+
-    | ``1``         | Unknown error.                                |
-    +---------------+-----------------------------------------------+
-    | ``2``         | Not enough memory; this error is reported     |
-    |               | when there is not enough memory to complete   |
-    |               | response.                                     |
-    +---------------+-----------------------------------------------+
-    | ``3``         | Invalid value; a request contains an invalid  |
-    |               | value.                                        |
-    +---------------+-----------------------------------------------+
-    | ``4``         | Timeout; the operation for some reason could  |
-    |               | not be completed in assumed time.             |
-    +---------------+-----------------------------------------------+
-    | ``5``         | No entry; the error means that request frame  |
-    |               | has been missing some information that is     |
-    |               | required to perform action.                   |
-    |               | It may also mean that requested information   |
-    |               | is not available.                             |
-    +---------------+-----------------------------------------------+
-    | ``6``         | Bad state; the error means that application   |
-    |               | or device is in a state that would not allow  |
-    |               | it to perform or complete a requested action. |
-    +---------------+-----------------------------------------------+
-    | ``7``         | Response too long; this error is issued when  |
-    |               | buffer assigned for gathering response is     |
-    |               | not big enough.                               |
-    +---------------+-----------------------------------------------+
-    | ``8``         | Not supported; usually issued when requested  |
-    |               | ``Group ID`` or ``Command ID`` is not         |
-    |               | supported by application.                     |
-    +---------------+-----------------------------------------------+
-    | ``9``         | Corrupted payload received.                   |
-    +---------------+-----------------------------------------------+
-    | ``10``        | Device is busy with processing previous SMP   |
-    |               | request and may not process incoming one.     |
-    |               | Client should re-try later.                   |
-    +---------------+-----------------------------------------------+
-    | ``256``       | This is base error number of user defined     |
-    |               | error codes.                                  |
-    +---------------+-----------------------------------------------+
-
-
-Zephyr uses ``MGMT_ERR_`` prefixed definitions gathered in this header file
-:zephyr_file:`subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h`
+    +-----------------------+--------------------------+
+    | "rc"                  | :c:enum:`mcumgr_err_t`   |
+    +-----------------------+--------------------------+
 
 Specifications of management groups supported by Zephyr
 *******************************************************

--- a/doc/services/device_mgmt/smp_transport.rst
+++ b/doc/services/device_mgmt/smp_transport.rst
@@ -193,3 +193,8 @@ CRC Details
 The CRC16 included in final type frames is calculated over only
 raw data and does not include packet length.
 CRC16 polynomial is 0x1021 and initial value is 0.
+
+API Reference
+*************
+
+.. doxygengroup:: mcumgr_transport_smp


### PR DESCRIPTION
Fixes some issues with the documentation for MCUmgr.

Fixes #56459

Due to a pending fs_mgmt PR which changes the documentation, that group has not been fixed as part of this PR.