### PR TITLE
Bluetooth: audio: Introduce helper BT_AUDIO_RX(TX) flags

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -406,7 +406,7 @@ struct bt_bap_stream_ops {
 	 */
 	void (*stopped)(struct bt_bap_stream *stream, uint8_t reason);
 
-#if defined(CONFIG_BT_BAP_UNICAST) || defined(CONFIG_BT_BAP_BROADCAST_SINK)
+#if defined(CONFIG_BT_AUDIO_RX)
 	/**
 	 * @brief Stream audio HCI receive callback.
 	 *
@@ -420,9 +420,9 @@ struct bt_bap_stream_ops {
 	 */
 	void (*recv)(struct bt_bap_stream *stream, const struct bt_iso_recv_info *info,
 		     struct net_buf *buf);
-#endif /* CONFIG_BT_BAP_UNICAST || CONFIG_BT_BAP_BROADCAST_SINK */
+#endif /* CONFIG_BT_AUDIO_RX */
 
-#if defined(CONFIG_BT_BAP_UNICAST) || defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
+#if defined(CONFIG_BT_AUDIO_TX)
 	/**
 	 * @brief Stream audio HCI sent callback
 	 *
@@ -434,7 +434,7 @@ struct bt_bap_stream_ops {
 	 * @param chan The channel which has sent data.
 	 */
 	void (*sent)(struct bt_bap_stream *stream);
-#endif /* CONFIG_BT_BAP_UNICAST || CONFIG_BT_BAP_BROADCAST_SOURCE */
+#endif /* CONFIG_BT_AUDIO_TX */
 };
 
 /**

--- a/subsys/bluetooth/audio/Kconfig
+++ b/subsys/bluetooth/audio/Kconfig
@@ -19,6 +19,18 @@ menuconfig BT_AUDIO
 
 if BT_AUDIO
 
+config BT_AUDIO_RX
+	bool
+	help
+	  This hidden option is enabled when any of the profiles/services
+	  enables support for receiving of audio data.
+
+config BT_AUDIO_TX
+	bool
+	help
+	  This hidden option is enabled when any of the profiles/services
+	  enables support for transmitting of audio data.
+
 config BT_CCID
 	bool
 	help

--- a/subsys/bluetooth/audio/Kconfig.ascs
+++ b/subsys/bluetooth/audio/Kconfig.ascs
@@ -31,10 +31,12 @@ config BT_ASCS_ASE_SRC_COUNT
 config BT_ASCS_ASE_SNK
 	def_bool BT_ASCS_ASE_SNK_COUNT > 0
 	select BT_PAC_SNK
+	select BT_AUDIO_RX
 
 config BT_ASCS_ASE_SRC
 	def_bool BT_ASCS_ASE_SRC_COUNT > 0
 	select BT_PAC_SRC
+	select BT_AUDIO_TX
 
 config BT_ASCS_MAX_ACTIVE_ASES
 	int "Number of simultaneously supported ASE sessions"

--- a/subsys/bluetooth/audio/Kconfig.bap
+++ b/subsys/bluetooth/audio/Kconfig.bap
@@ -107,12 +107,21 @@ config BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT
 	  This option enables caching a number of Audio Stream Endpoint Source
 	  instances for Basic Audio Profile on a per connection basis.
 
+config BT_BAP_UNICAST_CLIENT_ASE_SNK
+	def_bool BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0
+	select BT_AUDIO_TX
+
+config BT_BAP_UNICAST_CLIENT_ASE_SRC
+	def_bool BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0
+	select BT_AUDIO_RX
+
 endif # BT_BAP_UNICAST_CLIENT
 
 config BT_BAP_BROADCAST_SOURCE
 	bool "Bluetooth Broadcast Source Audio Support [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	select BT_ISO_BROADCASTER
+	select BT_AUDIO_TX
 	help
 	  This option enables support for Bluetooth Broadcast Source Audio using
 	  Isochronous channels.
@@ -152,6 +161,7 @@ config BT_BAP_BROADCAST_SINK
 	bool "Bluetooth Broadcast Sink Audio Support [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	select BT_ISO_SYNC_RECEIVER
+	select BT_AUDIO_RX
 	depends on BT_PERIPHERAL
 	depends on BT_PAC_SNK
 	help

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -607,6 +607,7 @@ static int ascs_iso_accept(const struct bt_iso_accept_info *info, struct bt_iso_
 	return -EACCES;
 }
 
+#if defined(CONFIG_BT_AUDIO_RX)
 static void ascs_iso_recv(struct bt_iso_chan *chan,
 			  const struct bt_iso_recv_info *info,
 			  struct net_buf *buf)
@@ -658,7 +659,9 @@ static void ascs_iso_recv(struct bt_iso_chan *chan,
 		LOG_WRN("No callback for recv set");
 	}
 }
+#endif /* CONFIG_BT_AUDIO_RX */
 
+#if defined(CONFIG_BT_AUDIO_TX)
 static void ascs_iso_sent(struct bt_iso_chan *chan)
 {
 	struct bt_bap_iso *iso = CONTAINER_OF(chan, struct bt_bap_iso, chan);
@@ -688,6 +691,7 @@ static void ascs_iso_sent(struct bt_iso_chan *chan)
 		ops->sent(stream);
 	}
 }
+#endif /* CONFIG_BT_AUDIO_TX */
 
 static void ascs_ep_iso_connected(struct bt_bap_ep *ep)
 {
@@ -801,8 +805,12 @@ static void ascs_iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 }
 
 static struct bt_iso_chan_ops ascs_iso_ops = {
+#if defined(CONFIG_BT_AUDIO_RX)
 	.recv = ascs_iso_recv,
+#endif /* CONFIG_BT_AUDIO_RX */
+#if defined(CONFIG_BT_AUDIO_TX)
 	.sent = ascs_iso_sent,
+#endif /* CONFIG_BT_AUDIO_TX */
 	.connected = ascs_iso_connected,
 	.disconnected = ascs_iso_disconnected,
 };

--- a/subsys/bluetooth/audio/cap_stream.c
+++ b/subsys/bluetooth/audio/cap_stream.c
@@ -152,7 +152,7 @@ static void cap_stream_stopped_cb(struct bt_bap_stream *bap_stream, uint8_t reas
 	}
 }
 
-#if defined(CONFIG_BT_BAP_UNICAST) || defined(CONFIG_BT_BAP_BROADCAST_SINK)
+#if defined(CONFIG_BT_AUDIO_RX)
 static void cap_stream_recv_cb(struct bt_bap_stream *bap_stream,
 			       const struct bt_iso_recv_info *info, struct net_buf *buf)
 {
@@ -165,9 +165,9 @@ static void cap_stream_recv_cb(struct bt_bap_stream *bap_stream,
 		ops->recv(bap_stream, info, buf);
 	}
 }
-#endif /* CONFIG_BT_BAP_UNICAST || CONFIG_BT_BAP_BROADCAST_SINK */
+#endif /* CONFIG_BT_AUDIO_RX */
 
-#if defined(CONFIG_BT_BAP_UNICAST) || defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
+#if defined(CONFIG_BT_AUDIO_TX)
 static void cap_stream_sent_cb(struct bt_bap_stream *bap_stream)
 {
 	struct bt_cap_stream *cap_stream = CONTAINER_OF(bap_stream,
@@ -179,7 +179,7 @@ static void cap_stream_sent_cb(struct bt_bap_stream *bap_stream)
 		ops->sent(bap_stream);
 	}
 }
-#endif /* CONFIG_BT_BAP_UNICAST || CONFIG_BT_BAP_BROADCAST_SOURCE */
+#endif /* CONFIG_BT_AUDIO_TX */
 
 static struct bt_bap_stream_ops bap_stream_ops = {
 #if defined(CONFIG_BT_BAP_UNICAST)
@@ -192,12 +192,12 @@ static struct bt_bap_stream_ops bap_stream_ops = {
 #endif /* CONFIG_BT_BAP_UNICAST */
 	.started = cap_stream_started_cb,
 	.stopped = cap_stream_stopped_cb,
-#if defined(CONFIG_BT_BAP_UNICAST) || defined(CONFIG_BT_BAP_BROADCAST_SINK)
+#if defined(CONFIG_BT_AUDIO_RX)
 	.recv = cap_stream_recv_cb,
-#endif /* CONFIG_BT_BAP_UNICAST || CONFIG_BT_BAP_BROADCAST_SINK */
-#if defined(CONFIG_BT_BAP_UNICAST) || defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
+#endif /* CONFIG_BT_AUDIO_RX */
+#if defined(CONFIG_BT_AUDIO_TX)
 	.sent = cap_stream_sent_cb,
-#endif /* CONFIG_BT_BAP_UNICAST || CONFIG_BT_BAP_BROADCAST_SOURCE */
+#endif /* CONFIG_BT_AUDIO_TX */
 };
 
 void bt_cap_stream_ops_register_bap(struct bt_cap_stream *cap_stream)

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -1719,7 +1719,7 @@ static struct bt_bap_broadcast_sink_cb sink_cbs = {
 };
 #endif /* CONFIG_BT_BAP_BROADCAST_SINK */
 
-#if defined(CONFIG_BT_BAP_UNICAST) || defined(CONFIG_BT_BAP_BROADCAST_SINK)
+#if defined(CONFIG_BT_AUDIO_RX)
 static void audio_recv(struct bt_bap_stream *stream,
 		       const struct bt_iso_recv_info *info,
 		       struct net_buf *buf)
@@ -1748,7 +1748,7 @@ static void audio_recv(struct bt_bap_stream *stream,
 
 	rx_cnt++;
 }
-#endif /* CONFIG_BT_BAP_UNICAST || CONFIG_BT_BAP_BROADCAST_SINK */
+#endif /* CONFIG_BT_AUDIO_RX */
 
 static void stream_enabled_cb(struct bt_bap_stream *stream)
 {
@@ -1860,9 +1860,9 @@ static void stream_released_cb(struct bt_bap_stream *stream)
 #endif /* CONFIG_BT_BAP_UNICAST */
 
 static struct bt_bap_stream_ops stream_ops = {
-#if defined(CONFIG_BT_BAP_UNICAST) || defined(CONFIG_BT_BAP_BROADCAST_SINK)
+#if defined(CONFIG_BT_AUDIO_RX)
 	.recv = audio_recv,
-#endif /* CONFIG_BT_BAP_UNICAST || CONFIG_BT_BAP_BROADCAST_SINK */
+#endif /* CONFIG_BT_AUDIO_RX */
 #if defined(CONFIG_BT_BAP_UNICAST)
 	.released = stream_released_cb,
 	.enabled = stream_enabled_cb,

--- a/tests/bluetooth/audio/mocks/src/bap_stream.c
+++ b/tests/bluetooth/audio/mocks/src/bap_stream.c
@@ -48,8 +48,12 @@ void mock_bap_stream_init(void)
 	mock_bap_stream_ops.released = mock_bap_stream_released_cb;
 	mock_bap_stream_ops.started = mock_bap_stream_started_cb;
 	mock_bap_stream_ops.stopped = mock_bap_stream_stopped_cb;
+#if defined(CONFIG_BT_AUDIO_RX)
 	mock_bap_stream_ops.recv = mock_bap_stream_recv_cb;
+#endif /* CONFIG_BT_AUDIO_RX */
+#if defined(CONFIG_BT_AUDIO_TX)
 	mock_bap_stream_ops.sent = mock_bap_stream_sent_cb;
+#endif /* CONFIG_BT_AUDIO_TX */
 }
 
 void mock_bap_stream_cleanup(void)


### PR DESCRIPTION
This adds new hidden compilation flags that indicate whether the
implementation is configured to be able to receive/transmit audio data.
The flags are profile agnostic to loosen dependencies between
modules/services.