### PR TITLE
 tests/drivers/counter/counter_basic_api  for rtc and timer counters

### DIFF
--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a.yaml
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a.yaml
@@ -21,3 +21,4 @@ supported:
   - nvs
   - backup_sram
   - pwm
+  - counter

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.yaml
@@ -14,6 +14,7 @@ supported:
   - lps22hb
   - lsm6dsl
   - pwm
+  - counter
   - gpio
   - ble
   - spi

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
@@ -19,5 +19,6 @@ supported:
   - adc
   - dac
   - pwm
+  - counter
   - rng
   - eeprom

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.yaml
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.yaml
@@ -18,6 +18,7 @@ supported:
   - adc
   - dac
   - pwm
+  - counter
   - dma
   - watchdog
   - nvs

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk.yaml
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk.yaml
@@ -10,6 +10,7 @@ supported:
   - i2c
   - lptim
   - pwm
+  - counter
   - watchdog
   - dac
   - adc

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -8,7 +8,8 @@ menuconfig CLOCK_CONTROL_STM32_CUBE
 	bool "STM32 Reset & Clock Control"
 	depends on SOC_FAMILY_STM32
 	select USE_STM32_LL_UTILS
-	select USE_STM32_LL_RCC if (SOC_SERIES_STM32MP1X || SOC_SERIES_STM32H7X)
+	select USE_STM32_LL_RCC if (SOC_SERIES_STM32MP1X || SOC_SERIES_STM32H7X || \
+		SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X)
 	help
 	  Enable driver for Reset & Clock Control subsystem found
 	  in STM32 family of MCUs

--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -18,6 +18,11 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(counter_timer_stm32, CONFIG_COUNTER_LOG_LEVEL);
 
+/* L0 series MCUs only have 16-bit timers and don't have below macro defined */
+#ifndef IS_TIM_32B_COUNTER_INSTANCE
+#define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE) (0)
+#endif
+
 /** Maximum number of timer channels. */
 #define TIMER_MAX_CH 4U
 
@@ -37,7 +42,13 @@ static void(*const set_timer_compare[TIMER_MAX_CH])(TIM_TypeDef *,
 };
 
 /** Channel to compare get function mapping. */
-#if !defined(CONFIG_SOC_SERIES_STM32F4X)
+#if !defined(CONFIG_SOC_SERIES_STM32C0X) && \
+	!defined(CONFIG_SOC_SERIES_STM32F1X) && \
+	!defined(CONFIG_SOC_SERIES_STM32F2X) && \
+	!defined(CONFIG_SOC_SERIES_STM32F4X) && \
+	!defined(CONFIG_SOC_SERIES_STM32G4X) && \
+	!defined(CONFIG_SOC_SERIES_STM32L1X) && \
+	!defined(CONFIG_SOC_SERIES_STM32MP1X)
 static uint32_t(*const get_timer_compare[TIMER_MAX_CH])(const TIM_TypeDef *) = {
 	LL_TIM_OC_GetCompareCH1, LL_TIM_OC_GetCompareCH2,
 	LL_TIM_OC_GetCompareCH3, LL_TIM_OC_GetCompareCH4,
@@ -62,7 +73,13 @@ static void(*const disable_it[TIMER_MAX_CH])(TIM_TypeDef *) = {
 
 #ifdef CONFIG_ASSERT
 /** Channel to interrupt enable check function mapping. */
-#if !defined(CONFIG_SOC_SERIES_STM32F4X)
+#if !defined(CONFIG_SOC_SERIES_STM32C0X) && \
+	!defined(CONFIG_SOC_SERIES_STM32F1X) && \
+	!defined(CONFIG_SOC_SERIES_STM32F2X) && \
+	!defined(CONFIG_SOC_SERIES_STM32F4X) && \
+	!defined(CONFIG_SOC_SERIES_STM32G4X) && \
+	!defined(CONFIG_SOC_SERIES_STM32L1X) && \
+	!defined(CONFIG_SOC_SERIES_STM32MP1X)
 static uint32_t(*const check_it_enabled[TIMER_MAX_CH])(const TIM_TypeDef *) = {
 	LL_TIM_IsEnabledIT_CC1, LL_TIM_IsEnabledIT_CC2,
 	LL_TIM_IsEnabledIT_CC3, LL_TIM_IsEnabledIT_CC4,

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -250,6 +250,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers14: timers@40002000 {
@@ -266,6 +271,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -284,6 +294,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers17: timers@40014800 {
@@ -300,6 +315,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/f0/stm32f031.dtsi
+++ b/dts/arm/st/f0/stm32f031.dtsi
@@ -23,6 +23,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+					compatible = "st,stm32-counter";
+					status = "disabled";
+				};
 		};
 
 		rtc@40002800 {

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -271,6 +271,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers3: timers@40000400 {
@@ -288,6 +293,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers4: timers@40000800 {
@@ -304,6 +314,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -445,6 +445,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers4: timers@40000800 {
@@ -461,6 +466,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -479,6 +489,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers6: timers@40001000 {
@@ -490,6 +505,11 @@
 			interrupt-names = "global";
 			st,prescaler = <0>;
 			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers7: timers@40001400 {
@@ -501,6 +521,11 @@
 			interrupt-names = "global";
 			st,prescaler = <0>;
 			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers8: timers@40010400 {
@@ -535,6 +560,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers10: timers@40014400 {
@@ -551,6 +581,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -569,6 +604,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers12: timers@40001800 {
@@ -585,6 +625,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -603,6 +648,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers14: timers@40002000 {
@@ -619,6 +669,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -277,6 +277,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers3: timers@40000400 {
@@ -294,6 +299,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers6: timers@40001000 {
@@ -305,6 +315,11 @@
 			interrupt-names = "global";
 			st,prescaler = <0>;
 			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers7: timers@40001400 {
@@ -316,6 +331,11 @@
 			interrupt-names = "global";
 			st,prescaler = <0>;
 			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers15: timers@40014000 {
@@ -332,6 +352,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -350,6 +375,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers17: timers@40014800 {
@@ -366,6 +396,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -430,6 +430,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers3: timers@40000400 {
@@ -446,6 +451,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -464,6 +474,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers5: timers@40000c00 {
@@ -481,6 +496,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers6: timers@40001000 {
@@ -492,6 +512,11 @@
 			interrupt-names = "global";
 			st,prescaler = <0>;
 			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers7: timers@40001400 {
@@ -503,6 +528,11 @@
 			interrupt-names = "global";
 			st,prescaler = <0>;
 			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers8: timers@40010400 {
@@ -537,6 +567,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers10: timers@40014400 {
@@ -553,6 +588,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -571,6 +611,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers12: timers@40001800 {
@@ -587,6 +632,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -605,6 +655,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers14: timers@40002000 {
@@ -621,6 +676,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -248,6 +248,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers3: timers@40000400 {
@@ -264,6 +269,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -282,6 +292,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers16: timers@40014400 {
@@ -299,6 +314,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers17: timers@40014800 {
@@ -315,6 +335,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/g0/stm32g051.dtsi
+++ b/dts/arm/st/g0/stm32g051.dtsi
@@ -16,6 +16,11 @@
 			interrupts = <17 0>;
 			interrupt-names = "global";
 			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers7: timers@40001400 {
@@ -27,6 +32,11 @@
 			interrupt-names = "global";
 			st,prescaler = <0>;
 			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers15: timers@40014000 {
@@ -43,6 +53,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -433,6 +433,11 @@
 			st,prescaler = <0>;
 			status = "disabled";
 
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
 			pwm {
 				compatible = "st,stm32-pwm";
 				status = "disabled";
@@ -450,6 +455,11 @@
 			st,prescaler = <0>;
 			status = "disabled";
 
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
 			pwm {
 				compatible = "st,stm32-pwm";
 				status = "disabled";
@@ -466,6 +476,11 @@
 			interrupt-names = "global";
 			st,prescaler = <0>;
 			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 
 			pwm {
 				compatible = "st,stm32-pwm";
@@ -528,6 +543,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers16: timers@40014400 {
@@ -545,6 +565,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers17: timers@40014800 {
@@ -561,6 +586,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -251,6 +251,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers21: timers@40010800 {
@@ -267,6 +272,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/l0/stm32l071.dtsi
+++ b/dts/arm/st/l0/stm32l071.dtsi
@@ -67,6 +67,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers6: timers@40001000 {
@@ -78,6 +83,11 @@
 			interrupt-names = "global";
 			st,prescaler = <0>;
 			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers7: timers@40001400 {
@@ -89,6 +99,11 @@
 			interrupt-names = "global";
 			st,prescaler = <0>;
 			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers22: timers@40011400 {
@@ -105,6 +120,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -257,6 +257,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers3: timers@40000400 {
@@ -273,6 +278,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -291,6 +301,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers9: timers@40010800 {
@@ -307,6 +322,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -325,6 +345,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers11: timers@40011000 {
@@ -341,6 +366,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -494,6 +494,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers3: timers@40000400 {
@@ -510,6 +515,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -528,6 +538,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers5: timers@40000c00 {
@@ -544,6 +559,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -579,6 +599,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers16: timers@40014400 {
@@ -596,6 +621,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers17: timers@40014800 {
@@ -612,6 +642,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -481,6 +481,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers5: timers@40000c00 {
@@ -496,6 +501,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 
@@ -529,6 +539,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers16: timers@40014400 {
@@ -545,6 +560,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers17: timers@40014800 {
@@ -560,6 +580,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -353,6 +353,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers16: timers@40014400 {
@@ -370,6 +375,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers17: timers@40014800 {
@@ -386,6 +396,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -374,6 +374,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers16: timers@40014400 {
@@ -391,6 +396,11 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		timers17: timers@40014800 {
@@ -407,6 +417,11 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
 			};
 		};
 

--- a/tests/drivers/counter/counter_basic_api/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/b_u585i_iot02a.overlay
@@ -1,0 +1,34 @@
+&timers4 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers5 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers15 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers17 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/disco_l475_iot1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/disco_l475_iot1.overlay
@@ -1,0 +1,27 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers6 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers15 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_f091rc.overlay
@@ -1,0 +1,34 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers3 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers14 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers17 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_f103rb.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_f103rb.overlay
@@ -1,0 +1,20 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers3 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers4 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_f207zg.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_f207zg.overlay
@@ -1,82 +1,83 @@
 &timers2 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers3 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers4 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers5 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers6 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers7 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
+&timers9 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers10 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers11 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+
 &timers12 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers13 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers14 {
-	st,prescaler = <239>;
-	counter {
-		status = "okay";
-	};
-};
-
-&timers15 {
-	st,prescaler = <239>;
-	counter {
-		status = "okay";
-	};
-};
-
-&timers16 {
-	st,prescaler = <239>;
-	counter {
-		status = "okay";
-	};
-};
-
-&timers17 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_f429zi.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_f429zi.overlay
@@ -1,0 +1,47 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers3 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers4 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers5 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+&timers9 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers10 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers11 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_f746zg.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_f746zg.overlay
@@ -1,82 +1,82 @@
 &timers2 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers3 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers4 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers5 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers6 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers7 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers9 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers10 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers11 {
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers12 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers13 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers14 {
-	st,prescaler = <239>;
-	counter {
-		status = "okay";
-	};
-};
-
-&timers15 {
-	st,prescaler = <239>;
-	counter {
-		status = "okay";
-	};
-};
-
-&timers16 {
-	st,prescaler = <239>;
-	counter {
-		status = "okay";
-	};
-};
-
-&timers17 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_g071rb.overlay
@@ -1,0 +1,48 @@
+&timers3 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers6 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers7 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers14 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers15 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers17 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_g474re.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_g474re.overlay
@@ -1,0 +1,41 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers3 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers4 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers15 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers17 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_h743zi.overlay
@@ -1,82 +1,82 @@
 &timers2 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers3 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers4 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers5 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers6 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers7 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers12 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers13 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers14 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers15 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers16 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};
 };
 
 &timers17 {
-	st,prescaler = <239>;
+	st,prescaler = <79>;
 	counter {
 		status = "okay";
 	};

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_l073rz.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_l073rz.overlay
@@ -1,0 +1,41 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers3 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers6 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers7 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers21 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers22 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_l152re.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_l152re.overlay
@@ -1,0 +1,41 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers3 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers4 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers9 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers10 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers11 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_wb55rg.overlay
@@ -1,0 +1,20 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers17 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_wl55jc.overlay
@@ -1,0 +1,20 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers17 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/stm32f3_disco.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/stm32f3_disco.overlay
@@ -1,0 +1,48 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers3 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers6 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers7 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers15 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers17 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/stm32h735g_disco.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/stm32h735g_disco.overlay
@@ -4,7 +4,3 @@
 		status = "okay";
 	};
 };
-
-&rtc {
-	status = "disabled";
-};

--- a/tests/drivers/counter/counter_basic_api/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/stm32l562e_dk.overlay
@@ -1,0 +1,49 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers3 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers4 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+
+&timers5 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers15 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers17 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};


### PR DESCRIPTION
When testing the tests/drivers/counter/counter_basic_api on stm32 boards when RTC is enabled, 
it is also possible to run the test on timer counter.
This is done when _also_ enabling all the timer counter on stm32 boards in each board overlay file:

-  nucleo_f091rc.overlay
-  nucleo_f103rb.overlay
-  nucleo_f207zg.overlay 
-  nucleo_f429zi.overlay 
-  nucleo_f746zg.overlay 
-  nucleo_g071rb.overlay  
-  nucleo_g474re.overlay   
-  nucleo_h743zi.overlay     
-  nucleo_l152re.overlay    
-  nucleo_wb55rg.overlay   
-  stm32f3_disco.overlay  
-  stm32h735g_disco.overlay  
-  stm32h747i_disco_m7.overlay
- nucleo_wl55jc

 
