### PR TITLE
Bluetooth: audio: iso: Remove code duplicates

### DIFF
--- a/subsys/bluetooth/audio/bap_iso.c
+++ b/subsys/bluetooth/audio/bap_iso.c
@@ -144,8 +144,35 @@ void bt_bap_iso_init(struct bt_bap_iso *iso, struct bt_iso_chan_ops *ops)
 	iso->chan.qos->tx->path->cc = iso->tx.cc;
 }
 
+static struct bt_bap_iso_dir *bap_iso_get_iso_dir(bool unicast_client, struct bt_bap_iso *iso,
+						  enum bt_audio_dir dir)
+{
+	/* TODO FIX FOR CLIENT */
+	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && unicast_client) {
+		/* For the unicast client, the direction and tx/rx is reversed */
+		if (dir == BT_AUDIO_DIR_SOURCE) {
+			return &iso->rx;
+		} else {
+			return &iso->tx;
+		}
+	}
+
+	if (dir == BT_AUDIO_DIR_SINK) {
+		return &iso->rx;
+	} else {
+		return &iso->tx;
+	}
+}
+
+static bool is_unicast_client_ep(struct bt_bap_ep *ep)
+{
+	return IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && bt_bap_ep_is_unicast_client(ep);
+}
+
 void bt_bap_iso_bind_ep(struct bt_bap_iso *iso, struct bt_bap_ep *ep)
 {
+	struct bt_bap_iso_dir *iso_dir;
+
 	__ASSERT_NO_MSG(ep != NULL);
 	__ASSERT_NO_MSG(iso != NULL);
 	__ASSERT(ep->iso == NULL, "ep %p bound with iso %p already", ep, ep->iso);
@@ -154,34 +181,17 @@ void bt_bap_iso_bind_ep(struct bt_bap_iso *iso, struct bt_bap_ep *ep)
 
 	LOG_DBG("iso %p ep %p dir %s", iso, ep, bt_audio_dir_str(ep->dir));
 
-	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && bt_bap_ep_is_unicast_client(ep)) {
-		/* For the unicast client, the direction and tx/rx is reversed */
-		if (ep->dir == BT_AUDIO_DIR_SOURCE) {
-			__ASSERT(iso->rx.ep == NULL,
-				"iso %p bound with ep %p", iso, iso->rx.ep);
-			iso->rx.ep = ep;
-		} else {
-			__ASSERT(iso->tx.ep == NULL,
-				"iso %p bound with ep %p", iso, iso->tx.ep);
-			iso->tx.ep = ep;
-		}
-	} else {
-		if (ep->dir == BT_AUDIO_DIR_SINK) {
-			__ASSERT(iso->rx.ep == NULL,
-				"iso %p bound with ep %p", iso, iso->rx.ep);
-			iso->rx.ep = ep;
-		} else {
-			__ASSERT(iso->tx.ep == NULL,
-				"iso %p bound with ep %p", iso, iso->tx.ep);
-			iso->tx.ep = ep;
-		}
-	}
+	iso_dir = bap_iso_get_iso_dir(is_unicast_client_ep(ep), iso, ep->dir);
+	__ASSERT(iso_dir->ep == NULL, "iso %p bound with ep %p", iso, iso_dir);
+	iso_dir->ep = ep;
 
 	ep->iso = bt_bap_iso_ref(iso);
 }
 
 void bt_bap_iso_unbind_ep(struct bt_bap_iso *iso, struct bt_bap_ep *ep)
 {
+	struct bt_bap_iso_dir *iso_dir;
+
 	__ASSERT_NO_MSG(ep != NULL);
 	__ASSERT_NO_MSG(iso != NULL);
 	__ASSERT(ep->iso == iso, "ep %p not bound with iso %p, was bound to %p",
@@ -191,28 +201,9 @@ void bt_bap_iso_unbind_ep(struct bt_bap_iso *iso, struct bt_bap_ep *ep)
 
 	LOG_DBG("iso %p ep %p dir %s", iso, ep, bt_audio_dir_str(ep->dir));
 
-	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && bt_bap_ep_is_unicast_client(ep)) {
-		/* For the unicast client, the direction and tx/rx is reversed */
-		if (ep->dir == BT_AUDIO_DIR_SOURCE) {
-			__ASSERT(iso->rx.ep == ep,
-				 "iso %p not bound with ep %p", iso, ep);
-			iso->rx.ep = NULL;
-		} else {
-			__ASSERT(iso->tx.ep == ep,
-				 "iso %p not bound with ep %p", iso, ep);
-			iso->tx.ep = NULL;
-		}
-	} else {
-		if (ep->dir == BT_AUDIO_DIR_SINK) {
-			__ASSERT(iso->rx.ep == ep,
-				 "iso %p not bound with ep %p", iso, ep);
-			iso->rx.ep = NULL;
-		} else  {
-			__ASSERT(iso->tx.ep == ep,
-				 "iso %p not bound with ep %p", iso, ep);
-			iso->tx.ep = NULL;
-		}
-	}
+	iso_dir = bap_iso_get_iso_dir(is_unicast_client_ep(ep), iso, ep->dir);
+	__ASSERT(iso_dir->ep == ep, "iso %p not bound with ep %p", iso, ep);
+	iso_dir->ep = NULL;
 
 	bt_bap_iso_unref(ep->iso);
 	ep->iso = NULL;
@@ -221,26 +212,16 @@ void bt_bap_iso_unbind_ep(struct bt_bap_iso *iso, struct bt_bap_ep *ep)
 struct bt_bap_ep *bt_bap_iso_get_ep(bool unicast_client, struct bt_bap_iso *iso,
 				    enum bt_audio_dir dir)
 {
+	struct bt_bap_iso_dir *iso_dir;
+
 	__ASSERT(dir == BT_AUDIO_DIR_SINK || dir == BT_AUDIO_DIR_SOURCE,
 		 "invalid dir: %u", dir);
 
 	LOG_DBG("iso %p dir %s", iso, bt_audio_dir_str(dir));
 
-	/* TODO FIX FOR CLIENT */
-	if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) && unicast_client) {
-		/* For the unicast client, the direction and tx/rx is reversed */
-		if (dir == BT_AUDIO_DIR_SOURCE) {
-			return iso->rx.ep;
-		} else {
-			return iso->tx.ep;
-		}
-	}
+	iso_dir = bap_iso_get_iso_dir(unicast_client, iso, dir);
 
-	if (dir == BT_AUDIO_DIR_SINK) {
-		return iso->rx.ep;
-	} else {
-		return iso->tx.ep;
-	}
+	return iso_dir->ep;
 }
 
 struct bt_bap_ep *bt_bap_iso_get_paired_ep(const struct bt_bap_ep *ep)


### PR DESCRIPTION
This removes duplicated code related to bap iso binding/unbinding.