### PR TITLE
drivers: intc: stm32: allow same callback to be set again

### DIFF
--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -248,6 +248,10 @@ int stm32_exti_set_callback(int line, stm32_exti_callback_t cb, void *arg)
 	const struct device *const dev = DEVICE_DT_GET(EXTI_NODE);
 	struct stm32_exti_data *data = dev->data;
 
+	if (data->cb[line].cb == cb && data->cb[line].data == arg) {
+		return 0;
+	}
+
 	if (data->cb[line].cb) {
 		return -EBUSY;
 	}


### PR DESCRIPTION
Setting the same callback with the same data as is already configured should not cause an error.