### PR TITLE
drivers: flash: stm32 ospi flash driver waits for full chip erase

### DIFF
--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -83,6 +83,9 @@
 #define SPI_NOR_WREN_MATCH    0x02
 #define SPI_NOR_WREN_MASK     0x02
 
+#define SPI_NOR_WEL_MATCH     0x00
+#define SPI_NOR_WEL_MASK      0x02
+
 #define SPI_NOR_MEM_RDY_MATCH 0x00
 #define SPI_NOR_MEM_RDY_MASK  0x01
 


### PR DESCRIPTION
Add a function to wait for the full (bulk) Nor-octoflah erase command. When erasing the full octo-flash, the drivers waits until the operation is ready and the external NOR mem becomes ready itself. The full (bulk) erase operation lasts for several seconds.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/56442

To erase the NOR octoFlash, call the flash_erase  with size = full flash size, for example : 
    flash_erase(flash_dev, 0, 0x4000000);

Note that erasing a 64MB NOR flash will take (blocking) about 45s.