### PR TITLE
Bluetooth: Add missing dependency for PAST feature

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -163,11 +163,11 @@ config BT_DATA_LEN_UPDATE
 
 config BT_PER_ADV_SYNC_TRANSFER_RECEIVER
 	bool "Periodic Advertising Sync Transfer receiver"
-	depends on !BT_CTLR || BT_CTLR_SYNC_TRANSFER_RECEIVER_SUPPORT
+	depends on BT_PER_ADV_SYNC && (!BT_CTLR || BT_CTLR_SYNC_TRANSFER_RECEIVER_SUPPORT)
 
 config BT_PER_ADV_SYNC_TRANSFER_SENDER
 	bool "Periodic Advertising Sync Transfer sender"
-	depends on !BT_CTLR || BT_CTLR_SYNC_TRANSFER_SENDER_SUPPORT
+	depends on (BT_PER_ADV_SYNC || BT_PER_ADV) && (!BT_CTLR || BT_CTLR_SYNC_TRANSFER_SENDER_SUPPORT)
 
 config BT_SCA_UPDATE
 	bool "Sleep Clock Accuracy Update"


### PR DESCRIPTION
The PAST sender needs to support periodic advertising and the PAST receiver needs to support periodic advertising sync.