### PR TITLE
Bluetooth: Audio: Add select BT_GATT_DYNAMIC_DB for audio services

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.aics
+++ b/subsys/bluetooth/audio/Kconfig.aics
@@ -20,6 +20,7 @@ config BT_AICS
 	bool # hidden
 	default y if BT_AICS_MAX_INSTANCE_COUNT > 0
 	select EXPERIMENTAL
+	select BT_GATT_DYNAMIC_DB
 	help
 	  This hidden option enables support for Audio Input Control Service.
 

--- a/subsys/bluetooth/audio/Kconfig.cap
+++ b/subsys/bluetooth/audio/Kconfig.cap
@@ -20,6 +20,7 @@ config BT_CAP_ACCEPTOR_SET_MEMBER
 	bool "Common Audio Profile Acceptor Role Set Member support"
 	depends on BT_CAP_ACCEPTOR
 	depends on BT_CSIP_SET_MEMBER
+	select BT_GATT_DYNAMIC_DB
 	help
 	  Enabling this will allow a CAP acceptor to be a set member.
 	  Enabling this will require a manual register of the CAS service.

--- a/subsys/bluetooth/audio/Kconfig.has
+++ b/subsys/bluetooth/audio/Kconfig.has
@@ -8,6 +8,7 @@ menuconfig BT_HAS
 	bool "Hearing Access Service support [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	select UTF8
+	select BT_GATT_DYNAMIC_DB
 	depends on BT_BAP_UNICAST_SERVER
 	help
 	  This option enables support for Hearing Access Service.

--- a/subsys/bluetooth/audio/Kconfig.mcs
+++ b/subsys/bluetooth/audio/Kconfig.mcs
@@ -14,6 +14,7 @@ config BT_MCS
 	depends on UTF8
 	select BT_CCID
 	select EXPERIMENTAL
+	select BT_GATT_DYNAMIC_DB
 	help
 	  This option enables support for the Media Control Service.
 

--- a/subsys/bluetooth/audio/Kconfig.micp
+++ b/subsys/bluetooth/audio/Kconfig.micp
@@ -11,6 +11,7 @@
 config BT_MICP_MIC_DEV
 	bool "Microphone Control Profile Microphone Device Support [EXPERIMENTAL]"
 	select EXPERIMENTAL
+	select BT_GATT_DYNAMIC_DB
 	help
 	  This option enables support for Microphone Control Profile
 	  Microphone Device.

--- a/subsys/bluetooth/audio/Kconfig.tbs
+++ b/subsys/bluetooth/audio/Kconfig.tbs
@@ -12,6 +12,7 @@ if BT_AUDIO
 config BT_TBS
 	bool "Telephone Bearer Service Support"
 	select BT_CCID
+	select BT_GATT_DYNAMIC_DB
 	help
 	  This option enables support for Telephone Bearer Service.
 

--- a/subsys/bluetooth/audio/Kconfig.vcp
+++ b/subsys/bluetooth/audio/Kconfig.vcp
@@ -11,6 +11,7 @@
 config BT_VCP_VOL_REND
 	bool "Volume Control Profile Volume Renderer Support [EXPERIMENTAL]"
 	select EXPERIMENTAL
+	select BT_GATT_DYNAMIC_DB
 	help
 	  This option enables support for Volume Control Profile Volume Renderer
 	  role and the Volume Control Service.


### PR DESCRIPTION
Many/most LE Audio services are dynamically registered, but have been enabled without BT_GATT_DYNAMIC_DB.

Add select BT_GATT_DYNAMIC_DB for the services. Select was used instead of depends on to make it simpler
to enable them.