### PR TITLE
drivers: uart_nrfx_uarte: Revert workaround for bytes dropping

### DIFF
--- a/boards/arm/nrf5340_audio_dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/Kconfig.defconfig
@@ -84,13 +84,3 @@ config BT_CTLR
 	default y if BT
 
 endif # BOARD_NRF5340_AUDIO_DK_NRF5340_CPUNET
-
-config UART_NRF_DK_SERIAL_WORKAROUND
-	default y if ZTEST
-
-# When the nRF DK serial workaround is enabled, increase the stack size in
-# tests built with no optimizations, as the standard size may be insufficient
-# then. Use 512 to align with the FPU_SHARING case, where the default value
-# is also modified.
-config TEST_EXTRA_STACK_SIZE
-	default 512 if UART_NRF_DK_SERIAL_WORKAROUND && NO_OPTIMIZATIONS

--- a/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
@@ -96,13 +96,3 @@ config BT_CTLR
 	default y if BT
 
 endif # BOARD_NRF5340DK_NRF5340_CPUNET
-
-config UART_NRF_DK_SERIAL_WORKAROUND
-	default y if ZTEST
-
-# When the nRF DK serial workaround is enabled, increase the stack size in
-# tests built with no optimizations, as the standard size may be insufficient
-# then. Use 512 to align with the FPU_SHARING case, where the default value
-# is also modified.
-config TEST_EXTRA_STACK_SIZE
-	default 512 if UART_NRF_DK_SERIAL_WORKAROUND && NO_OPTIMIZATIONS

--- a/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
@@ -60,13 +60,3 @@ config I2C
 	default $(dt_compat_on_bus,$(DT_COMPAT_NXP_PCAL6408A),i2c)
 
 endif # BOARD_NRF9160DK_NRF9160 || BOARD_NRF9160DK_NRF9160_NS
-
-config UART_NRF_DK_SERIAL_WORKAROUND
-	default y if ZTEST
-
-# When the nRF DK serial workaround is enabled, increase the stack size in
-# tests built with no optimizations, as the standard size may be insufficient
-# then. Use 512 to align with the FPU_SHARING case, where the default value
-# is also modified.
-config TEST_EXTRA_STACK_SIZE
-	default 512 if UART_NRF_DK_SERIAL_WORKAROUND && NO_OPTIMIZATIONS

--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -27,32 +27,6 @@ config UART_ASYNC_TX_CACHE_SIZE
 	  in RAM, because EasyDMA in UARTE peripherals can only transfer data
 	  from RAM.
 
-config UART_NRF_DK_SERIAL_WORKAROUND
-	bool
-	help
-	  On some development kits there are characters being dropped by the
-	  controller chip (Segger interface) if there are burst of bytes being
-	  printed. It can lead to test failures since test out is corrupted.
-	  A workaround is to enforce gaps (by adding busy waits) in the transmission.
-	  It is recommended to enable the workaround only in the test since
-	  busy waits can impact application flow.
-
-if UART_NRF_DK_SERIAL_WORKAROUND
-
-config UART_NRF_DK_SERIAL_WORKAROUND_COUNT
-	int
-	default 64
-	help
-	  Number of bytes transferred after which a busy wait is added.
-
-config UART_NRF_DK_SERIAL_WORKAROUND_WAIT_MS
-	int
-	default 7
-	help
-	  Busy wait time (in milliseconds).
-endif
-
-
 # ----------------- port 0 -----------------
 config UART_0_NRF_UART
 	def_bool HAS_HW_NRF_UART0

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1482,32 +1482,6 @@ static void uarte_nrfx_poll_out(const struct device *dev, unsigned char c)
 	bool isr_mode = k_is_in_isr() || k_is_pre_kernel();
 	unsigned int key;
 
-#if CONFIG_UART_NRF_DK_SERIAL_WORKAROUND
-	/* On some boards (usually those which have multiple virtual coms) it can
-	 * be seen that bytes are dropped on the console serial (serial that goes
-	 * through Segger interface chip) when working in virtual environment.
-	 * It's the Segger chip that drops those bytes. A workaround is to enforce
-	 * periodic gaps which allows to handle the traffic correctly.
-	 */
-	if (dev == DEVICE_DT_GET(DT_CHOSEN(zephyr_console))) {
-		static int cnt;
-		static uint32_t t;
-		uint32_t now = k_uptime_get_32();
-
-		if ((now - t) >= CONFIG_UART_NRF_DK_SERIAL_WORKAROUND_WAIT_MS) {
-			cnt = 0;
-		} else {
-			cnt++;
-			if (cnt >= CONFIG_UART_NRF_DK_SERIAL_WORKAROUND_COUNT) {
-				k_busy_wait(1000 * CONFIG_UART_NRF_DK_SERIAL_WORKAROUND_WAIT_MS);
-				cnt = 0;
-			}
-		}
-
-		t = now;
-	}
-#endif
-
 	if (isr_mode) {
 		while (1) {
 			key = irq_lock();


### PR DESCRIPTION
This effectively reverts the following three commits:
- 0f9f18843f1471e256465b2a84c3b58a698fc14d
- 681244109946f788792d6a1e82f0a24117ed0995
- 326f7bd45056023b62bc7c382ebebb14205dbca1

and also the changes that got copied to the nrf5340_audio_dk_nrf5340
board.

The workaround brings more harm than good. It already required many tweaks in various tests to make them pass (because it introduced a significant overhead in processing of the console UART interrupt) and now it makes the I2S driver tests to fail. It's not reasonable to add more tweaks in Zephyr tests just to keep this workaround in the tree. Instead the root cause should be fixed (if the original problem still occurs).