### PR TITLE
Bluetooth: controller: implement ISO flush timeout

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -12,7 +12,10 @@ struct lll_conn_iso_stream_rxtx {
 	uint64_t bn:4;             /* Burst number (BN) */
 	uint64_t phy:3;            /* PHY */
 	uint64_t rfu:1;
+	/* Flush timeout is described in BT 5.4 Vol. 6 Part B, section 4.5.13.5 */
+	uint8_t ft_cntr_se;            /* Nr. of subevents for flush point */
 	uint8_t bn_curr:4;        /* Current burst number */
+
 
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -120,13 +120,15 @@ static int init_reset(void)
 
 static inline void lll_flush_tx(struct lll_conn_iso_stream *cis_lll)
 {
-	/* sn and nesn are 1-bit, only Least Significant bit is needed */
-	uint8_t sn_update = cis_lll->tx.bn + 1U - cis_lll->tx.bn_curr;
+	uint8_t se_remaining = cis_lll->nse + 1U - se_curr;
 
-	cis_lll->sn += sn_update;
-	if (cis_lll->tx.ft_cntr_se > sn_update) {
-		cis_lll->tx.ft_cntr_se -= sn_update;
+	if (cis_lll->tx.ft_cntr_se > se_remaining) {
+		cis_lll->tx.ft_cntr_se -= se_remaining;
 	} else {
+		/* sn and nesn are 1-bit, only Least Significant bit is needed */
+		uint8_t sn_update = cis_lll->tx.bn + 1U - cis_lll->tx.bn_curr;
+
+		cis_lll->sn += sn_update;
 		if (cis_lll->tx.bn != 0) {
 			cis_lll->tx.ft_cntr_se =  cis_lll->tx.ft *
 				DIV_ROUND_UP(cis_lll->nse, cis_lll->tx.bn);
@@ -136,13 +138,15 @@ static inline void lll_flush_tx(struct lll_conn_iso_stream *cis_lll)
 
 static inline void lll_flush_rx(struct lll_conn_iso_stream *cis_lll)
 {
-	/* sn and nesn are 1-bit, only Least Significant bit is needed */
-	uint8_t nesn_update = cis_lll->rx.bn + 1U - cis_lll->rx.bn_curr;
+	uint8_t se_remaining = cis_lll->nse + 1U - se_curr;
 
-	cis_lll->nesn += nesn_update;
-	if (cis_lll->rx.ft_cntr_se > nesn_update) {
-		cis_lll->rx.ft_cntr_se -= nesn_update;
+	if (cis_lll->rx.ft_cntr_se > se_remaining) {
+		cis_lll->rx.ft_cntr_se -= se_remaining;
 	} else {
+		/* sn and nesn are 1-bit, only Least Significant bit is needed */
+		uint8_t nesn_update = cis_lll->rx.bn + 1U - cis_lll->rx.bn_curr;
+
+		cis_lll->nesn += nesn_update;
 		if (cis_lll->rx.bn != 0) {
 			cis_lll->rx.ft_cntr_se =  cis_lll->rx.ft *
 				DIV_ROUND_UP(cis_lll->nse, cis_lll->rx.bn);

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -572,6 +572,20 @@ void ll_cis_create(uint16_t cis_handle, uint16_t acl_handle)
 	cis->lll.datapath_ready_rx = 0;
 	cis->lll.tx.bn_curr = 1U;
 	cis->lll.rx.bn_curr = 1U;
+	/* Set the flush points in nr. of subevents */
+	/* TODO: verify that the use of DIV_ROUND_UP is the right thing to do */
+	if (cis->lll.tx.bn != 0) {
+		cis->lll.tx.ft_cntr_se = cis->lll.tx.ft *
+			DIV_ROUND_UP(cis->lll.nse, cis->lll.tx.bn);
+	} else {
+		cis->lll.tx.ft_cntr_se = 0;
+	}
+	if (cis->lll.rx.bn != 0) {
+		cis->lll.rx.ft_cntr_se = cis->lll.rx.ft *
+			DIV_ROUND_UP(cis->lll.nse, cis->lll.rx.bn);
+	} else {
+		cis->lll.rx.ft_cntr_se = 0;
+	}
 
 	(void)memset(&cis->hdr, 0U, sizeof(cis->hdr));
 
@@ -747,6 +761,20 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 
 	cis->lll.tx.bn_curr = 1U;
 	cis->lll.rx.bn_curr = 1U;
+	/* Set the flush points in nr. of subevents */
+	/* TODO: verify that the use of DIV_ROUND_UP is the right thing to do */
+	if (cis->lll.tx.bn != 0) {
+		cis->lll.tx.ft_cntr_se = cis->lll.tx.ft *
+			DIV_ROUND_UP(cis->lll.nse, cis->lll.tx.bn);
+	} else {
+		cis->lll.tx.ft_cntr_se = 0;
+	}
+	if (cis->lll.rx.bn != 0) {
+		cis->lll.rx.ft_cntr_se = cis->lll.rx.ft *
+			DIV_ROUND_UP(cis->lll.nse, cis->lll.rx.bn);
+	} else {
+		cis->lll.rx.ft_cntr_se = 0;
+	}
 
 	/* Transfer to caller */
 	*cig_sync_delay = cig->sync_delay;

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -268,6 +268,22 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 	cis->lll.tx.payload_count = 0;
 	cis->lll.tx.bn_curr = 1U;
 
+	/* Set the flush points in nr. of subevents */
+	/* TODO: verify that the use of DIV_ROUND_UP is the right thing to do */
+	if (cis->lll.tx.bn != 0) {
+		cis->lll.tx.ft_cntr_se = cis->lll.tx.ft *
+			DIV_ROUND_UP(cis->lll.nse, cis->lll.tx.bn);
+	} else {
+		cis->lll.tx.ft_cntr_se = 0;
+	}
+	if (cis->lll.rx.bn != 0) {
+		cis->lll.rx.ft_cntr_se = cis->lll.rx.ft *
+			DIV_ROUND_UP(cis->lll.nse, cis->lll.rx.bn);
+	} else {
+		cis->lll.rx.ft_cntr_se = 0;
+	}
+
+
 	if (!cis->lll.link_tx_free) {
 		cis->lll.link_tx_free = &cis->lll.link_tx;
 	}
@@ -334,6 +350,20 @@ uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 	cis->lll.rx.payload_count = 0U;
 	cis->lll.rx.bn_curr = 1U;
 	cis->lll.tx.bn_curr = 1U;
+	/* Set the flush points in nr. of subevents */
+	/* TODO: verify that the use of DIV_ROUND_UP is the right thing to do */
+	if (cis->lll.tx.bn != 0) {
+		cis->lll.tx.ft_cntr_se = cis->lll.tx.ft *
+			DIV_ROUND_UP(cis->lll.nse, cis->lll.tx.bn);
+	} else {
+		cis->lll.tx.ft_cntr_se = 0;
+	}
+	if (cis->lll.rx.bn != 0) {
+		cis->lll.rx.ft_cntr_se = cis->lll.rx.ft *
+			DIV_ROUND_UP(cis->lll.nse, cis->lll.rx.bn);
+	} else {
+		cis->lll.rx.ft_cntr_se = 0;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Bluetooth: controller: implement ISO flush timeout
This commit implements the flush timeout for ISO as per BT
spec 5.4 Vol 6. Part B section 4.5.13.5

fixes #42901

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>
