### PR TITLE
Bluetooth: Mesh: check buffer tailroom before relaying proxy message

### DIFF
--- a/subsys/bluetooth/mesh/proxy_msg.c
+++ b/subsys/bluetooth/mesh/proxy_msg.c
@@ -78,6 +78,11 @@ ssize_t bt_mesh_proxy_msg_recv(struct bt_conn *conn,
 	const uint8_t *data = buf;
 	struct bt_mesh_proxy_role *role = &roles[bt_conn_index(conn)];
 
+	if (net_buf_simple_tailroom(&role->buf) < len - 1) {
+		LOG_WRN("Proxy role buffer overflow");
+		return -EINVAL;
+	}
+
 	switch (PDU_SAR(data)) {
 	case SAR_COMPLETE:
 		if (role->buf.len) {


### PR DESCRIPTION
PR adds checking proxy buffer tailroom before adding a relayed message. That prevents potential proxy trash attacks.