### PR TITLE
sam: atsamc2x: dmac enable, fix uart-async

### DIFF
--- a/boards/arm/atsamc21n_xpro/atsamc21n_xpro.yaml
+++ b/boards/arm/atsamc21n_xpro/atsamc21n_xpro.yaml
@@ -12,6 +12,7 @@ toolchain:
   - xtools
 supported:
   - adc
+  - dma
   - gpio
   - i2c
   - pwm

--- a/dts/arm/atmel/samc2x.dtsi
+++ b/dts/arm/atmel/samc2x.dtsi
@@ -102,6 +102,13 @@
 			interrupts = <1 0>;
 		};
 
+		dmac: dmac@41006000 {
+			compatible = "atmel,sam0-dmac";
+			reg = <0x41006000 0x50>;
+			interrupts = <7 0>;
+			#dma-cells = <2>;
+		};
+
 		adc0: adc@42004400 {
 			compatible = "atmel,sam0-adc";
 			status = "disabled";

--- a/tests/drivers/dma/chan_blen_transfer/boards/atsamc21n_xpro.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/atsamc21n_xpro.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2022 Kumar Gala <galak@kernel.org>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+test_dma0: &dmac { };

--- a/tests/drivers/dma/loop_transfer/boards/atsamc21n_xpro.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/atsamc21n_xpro.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2022 Kumar Gala <galak@kernel.org>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+test_dma0: &dmac { };

--- a/tests/drivers/uart/uart_async_api/boards/atsamc21n_xpro.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/atsamc21n_xpro.overlay
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&dmac {
+	status = "okay";
+};
+
+dut: &sercom0 {
+	/* Internally loop-back TX and RX on PAD0 */
+	rxpo = <0>;
+	txpo = <0>;
+
+	/* Configure DMA channels for async operation */
+	dmas = <&dmac 0 0x02>, <&dmac 1 0x03>;
+	dma-names = "rx", "tx";
+};
+
+&sercom2 {
+	status = "disabled";
+};
+
+&sercom3 {
+	status = "disabled";
+};
+
+&sercom4 {
+	/* configure DMA channels for async operation */
+	dmas = <&dmac 10 0x0A>, <&dmac 11 0x0B>;
+	dma-names = "rx", "tx";
+};

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -1,9 +1,9 @@
 common:
   platform_exclude: seeeduino_xiao serpente arduino_nano_33_iot atsamr21_xpro
-    adafruit_itsybitsy_m4_express atsame54_xpro atsamd21_xpro adafruit_trinket_m0
+    adafruit_itsybitsy_m4_express atsame54_xpro atsamc21n_xpro adafruit_trinket_m0
     arduino_nano_33_iot arduino_zero atsamd21_xpro adafruit_feather_m0_basic_proto
     adafruit_feather_m0_lora arduino_mkrzero atsaml21_xpro atsamr34_xpro stamp_c3
-    wio_terminal xiao_esp32c3
+    wio_terminal xiao_esp32c3 atsamd20_xpro xmc45_relax_kit
   tags: drivers uart
 tests:
   drivers.uart.async_api:


### PR DESCRIPTION
Enable dmac driver for C2x in dtsi file.
Fix tests for atsamc21n_xpro board by adding
overlay.