### PR TITLE
spi: Remove extranous logging message for SAM

### DIFF
--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -384,7 +384,6 @@ static int spi_sam_dma_txrx(const struct device *dev,
 		source_address = (uint32_t)tx_buf;
 		source_addr_adjust = DMA_ADDR_ADJ_INCREMENT;
 	} else {
-		LOG_INF("using tx dummy");
 		source_address = (uint32_t)&tx_dummy;
 		source_addr_adjust = DMA_ADDR_ADJ_NO_CHANGE;
 	}


### PR DESCRIPTION
Mistakenly left a log message in with the RTIO work, remove.