### PR TITLE
modules/hal/st: Merge clang abs type fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
       groups:
         - hal
     - name: hal_st
-      revision: cccbc24c14decfd3f93959f7b14514536af973c7
+      revision: 60b149c2df9b7766737af243d2ee5f8c6bd83804
       path: modules/hal/st
       groups:
         - hal


### PR DESCRIPTION
FixPoint1616_t is typedef'd to uint32_t. The result of dividing two variables of that type is also unsigned. Passing an unsigned value to abs doesn't make sense.

Cast the value to int32_t in case the computaton of diff1_mcps generates a negative result so that xTalkCorrection doesn't end up with a huge value.