### PR TITLE
tests: lib: mpsc_pbuf: Increase test timeout on mpsc_pbuf_concurrent

### DIFF
--- a/tests/lib/mpsc_pbuf/testcase.yaml
+++ b/tests/lib/mpsc_pbuf/testcase.yaml
@@ -10,6 +10,7 @@ tests:
 
   libraries.mpsc_pbuf_concurrent:
     tags: mpsc_pbuf
+    timeout: 90
     platform_allow: >
       qemu_cortex_m3 qemu_x86 qemu_x86_64
     extra_configs:


### PR DESCRIPTION
Increase timeout for tests/lib/mpsc_pbuf/libraries.mpsc_pbuf_concurrent as it fails sometimes on the 60 sec. default timeout.

Fixes #56349