### PR TITLE
drivers: adc: add LPADC driver support to lpc55s36

### DIFF
--- a/boards/arm/lpcxpresso55s36/lpcxpresso55s36-pinctrl.dtsi
+++ b/boards/arm/lpcxpresso55s36/lpcxpresso55s36-pinctrl.dtsi
@@ -39,6 +39,14 @@
 		};
 	};
 
+	pinmux_lpadc0: pinmux_lpadc0 {
+		group0 {
+			pinmux = <ADC0_CH0A_PIO1_9>;
+			slew-rate = "standard";
+			nxp,analog-mode;
+		};
+	};
+
 	/* Configures pin routing and optionally pin electrical features. */
 	pinmux_sctimer_default: pinmux_sctimer_default {
 		group0 {

--- a/boards/arm/lpcxpresso55s36/lpcxpresso55s36.dts
+++ b/boards/arm/lpcxpresso55s36/lpcxpresso55s36.dts
@@ -134,6 +134,12 @@
 	};
 };
 
+&adc0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_lpadc0>;
+	pinctrl-names = "default";
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -423,6 +423,10 @@ static int mcux_lpadc_init(const struct device *dev)
 	RESET_PeripheralReset(kADC0_RST_SHIFT_RSTn);
 	CLOCK_AttachClk(kFRO_DIV4_to_ADC_CLK);
 	CLOCK_SetClkDiv(kCLOCK_DivAdcClk, 1);
+
+#elif defined(CONFIG_SOC_LPC55S36)
+	CLOCK_SetClkDiv(kCLOCK_DivAdc0Clk, 2U, true);
+	CLOCK_AttachClk(kFRO_HF_to_ADC0);
 #else
 
 	CLOCK_SetClkDiv(kCLOCK_DivAdcAsyncClk, config->clock_div, true);
@@ -513,7 +517,8 @@ static const struct adc_driver_api mcux_lpadc_driver_api = {
 
 #if defined(CONFIG_SOC_SERIES_IMX_RT11XX) || \
 	defined(CONFIG_SOC_SERIES_IMX_RT6XX) || \
-	defined(CONFIG_SOC_SERIES_IMX_RT5XX)
+	defined(CONFIG_SOC_SERIES_IMX_RT5XX) || \
+	defined(CONFIG_SOC_LPC55S36)
 #define TO_LPADC_CLOCK_SOURCE(val) 0
 #else
 #define TO_LPADC_CLOCK_SOURCE(val) \

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -22,6 +22,10 @@
 #include <fsl_power.h>
 #endif
 
+#if defined(CONFIG_SOC_LPC55S36)
+#include <fsl_vref.h>
+#endif
+
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
@@ -427,6 +431,19 @@ static int mcux_lpadc_init(const struct device *dev)
 #elif defined(CONFIG_SOC_LPC55S36)
 	CLOCK_SetClkDiv(kCLOCK_DivAdc0Clk, 2U, true);
 	CLOCK_AttachClk(kFRO_HF_to_ADC0);
+
+	/* Disable VREF power down */
+	POWER_DisablePD(kPDRUNCFG_PD_VREF);
+
+	vref_config_t vrefConfig;
+
+	VREF_GetDefaultConfig(&vrefConfig);
+	vrefConfig.bufferMode                     = kVREF_ModeHighPowerBuffer;
+	vrefConfig.enableInternalVoltageRegulator = true;
+	vrefConfig.enableVrefOut                  = true;
+	adc_config.referenceVoltageSource = kLPADC_ReferenceVoltageAlt3;
+	VREF_Init((VREF_Type *)VREF_BASE, &vrefConfig);
+
 #else
 
 	CLOCK_SetClkDiv(kCLOCK_DivAdcAsyncClk, config->clock_div, true);

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -227,6 +227,21 @@
 		status = "okay";
 	};
 
+	adc0: adc@A0000 {
+		compatible = "nxp,lpc-lpadc";
+		reg = <0xA0000 0x1000>;
+		interrupts = <22 0>;
+		status = "disabled";
+		clk-divider = <8>;
+		clk-source = <0>;
+		voltage-ref= <2>;
+		calibration-average = <128>;
+		power-level = <1>;
+		offset-value-a = <10>;
+		offset-value-b = <10>;
+		#io-channel-cells = <1>;
+	};
+
 	can0: can@4009d000 {
 		compatible = "nxp,lpc-mcan";
 		reg = <0x4009d000 0x1000>;

--- a/samples/drivers/adc/boards/lpcxpresso55s36.overlay
+++ b/samples/drivers/adc/boards/lpcxpresso55s36.overlay
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2023 NXP
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/mcux-lpadc.h>
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc0 0>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	/*
+	 * This sample requires PIO1_9 found on J7 pin 1 as the ADC0 channel 3 input
+	 * be connected to various voltages to observe the change in reading.
+	 */
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <3300>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <MCUX_LPADC_CH0A>;
+	};
+};

--- a/samples/drivers/adc/sample.yaml
+++ b/samples/drivers/adc/sample.yaml
@@ -7,7 +7,7 @@ tests:
     platform_allow: nucleo_l073rz disco_l475_iot1 cc3220sf_launchxl cc3235sf_launchxl
         stm32l496g_disco stm32h735g_disco nrf51dk_nrf51422 nrf52840dk_nrf52840
         mec172xevb_assy6906 gd32f350r_eval gd32f450i_eval gd32vf103v_eval gd32f403z_eval
-        esp32 esp32s2_saola esp32c3_devkitm gd32l233r_eval
+        esp32 esp32s2_saola esp32c3_devkitm gd32l233r_eval lpcxpresso55s36
     integration_platforms:
       - nucleo_l073rz
       - nrf52840dk_nrf52840

--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: afd053086e9e36a413f7cbec40694733588e1b9f
+      revision: d3c964cd854e53d55d21532431ee337d55348d8c
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Add LPADC support to the lpcxpresso55s36 platform.