### PR TITLE
modules/picolibc: Update to version 1.8.1

### DIFF
--- a/tests/lib/mpsc_pbuf/testcase.yaml
+++ b/tests/lib/mpsc_pbuf/testcase.yaml
@@ -14,6 +14,7 @@ tests:
       qemu_cortex_m3 qemu_x86 qemu_x86_64
     extra_configs:
       - CONFIG_SYS_CLOCK_TICKS_PER_SEC=100000
+    timeout: 120
     integration_platforms:
       - qemu_x86
       - qemu_x86_64

--- a/west.yml
+++ b/west.yml
@@ -207,7 +207,7 @@ manifest:
       path: modules/lib/openthread
     - name: picolibc
       path: modules/lib/picolibc
-      revision: 0694a78fc08b3300c7db79602c46ba0a64428c8e
+      revision: 93b5d5f2ad44867b60267417cd6d6250dbf68983
     - name: segger
       revision: e2ff2200556e8a8f962921444275c04971a2bb3d
       path: modules/debug/segger


### PR DESCRIPTION
We're already using all of the relevant changes from 1.8.1, but it's good to use a released version instead of an intermediate revision.

See the related sdk-ng PR here: https://github.com/zephyrproject-rtos/sdk-ng/pull/655