### PR TITLE
drivers: clock_control:  stm32f3: Enable PWR clock to access BDCR

### DIFF
--- a/drivers/clock_control/clock_stm32f0_f3.c
+++ b/drivers/clock_control/clock_stm32f0_f3.c
@@ -150,6 +150,9 @@ void config_enable_default_clocks(void)
 	LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_SYSCFG);
 #endif
 #else
+	/* Enable PWR clock, required to access BDCR */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+
 #if defined(CONFIG_USB_DC_STM32) && defined(SYSCFG_CFGR1_USB_IT_RMP)
 	/* Enable System Configuration Controller clock. */
 	/* SYSCFG is required to remap IRQ to avoid conflicts with CAN */


### PR DESCRIPTION
BDCR could be required for LSE or RTC for instance. Enable it here as for now, no sophisticated PM handling is available on F3 series.

Fixes #56449