### PR TITLE
shell: uart: Fix wait for DTR before TX

### DIFF
--- a/include/zephyr/shell/shell_uart.h
+++ b/include/zephyr/shell/shell_uart.h
@@ -39,17 +39,23 @@ struct shell_uart_ctrl_blk {
 
 #define Z_UART_SHELL_RX_TIMER_PTR(_name) NULL
 
+#define Z_UART_SHELL_DTR_TIMER_DECLARE(_name) static struct k_timer _name##_dtr_timer
+#define Z_UART_SHELL_DTR_TIMER_PTR(_name) (&_name##_dtr_timer)
+
 #else /* CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN */
 #define Z_UART_SHELL_TX_RINGBUF_DECLARE(_name, _size) /* Empty */
 #define Z_UART_SHELL_RX_TIMER_DECLARE(_name) static struct k_timer _name##_timer
 #define Z_UART_SHELL_TX_RINGBUF_PTR(_name) NULL
 #define Z_UART_SHELL_RX_TIMER_PTR(_name) (&_name##_timer)
+#define Z_UART_SHELL_DTR_TIMER_DECLARE(_name) /* Empty */
+#define Z_UART_SHELL_DTR_TIMER_PTR(_name) NULL
 #endif /* CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN */
 
 /** @brief Shell UART transport instance structure. */
 struct shell_uart {
 	struct shell_uart_ctrl_blk *ctrl_blk;
 	struct k_timer *timer;
+	struct k_timer *dtr_timer;
 	struct ring_buf *tx_ringbuf;
 	struct ring_buf *rx_ringbuf;
 };
@@ -58,11 +64,13 @@ struct shell_uart {
 #define SHELL_UART_DEFINE(_name, _tx_ringbuf_size, _rx_ringbuf_size)	\
 	static struct shell_uart_ctrl_blk _name##_ctrl_blk;		\
 	Z_UART_SHELL_RX_TIMER_DECLARE(_name);				\
+	Z_UART_SHELL_DTR_TIMER_DECLARE(_name);				\
 	Z_UART_SHELL_TX_RINGBUF_DECLARE(_name, _tx_ringbuf_size);	\
 	RING_BUF_DECLARE(_name##_rx_ringbuf, _rx_ringbuf_size);		\
 	static const struct shell_uart _name##_shell_uart = {		\
 		.ctrl_blk = &_name##_ctrl_blk,				\
 		.timer = Z_UART_SHELL_RX_TIMER_PTR(_name),		\
+		.dtr_timer = Z_UART_SHELL_DTR_TIMER_PTR(_name),		\
 		.tx_ringbuf = Z_UART_SHELL_TX_RINGBUF_PTR(_name),	\
 		.rx_ringbuf = &_name##_rx_ringbuf,			\
 	};								\

--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -75,6 +75,7 @@ config SHELL_BACKEND_SERIAL_RX_POLL_PERIOD
 
 config SHELL_BACKEND_SERIAL_CHECK_DTR
 	bool "Check DTR signal before TX"
+	depends on SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
 	depends on UART_LINE_CTRL
 	help
 	  Check DTR signal before TX.

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -101,23 +101,37 @@ static void uart_rx_handle(const struct device *dev,
 	}
 }
 
-static void uart_dtr_wait(const struct device *dev)
+static bool uart_dtr_check(const struct device *dev)
 {
+	BUILD_ASSERT(!IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_CHECK_DTR) ||
+		IS_ENABLED(CONFIG_UART_LINE_CTRL),
+		"DTR check requires CONFIG_UART_LINE_CTRL");
+
 	if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_CHECK_DTR)) {
 		int dtr, err;
 
-		while (true) {
-			err = uart_line_ctrl_get(dev, UART_LINE_CTRL_DTR, &dtr);
-			if (err == -ENOSYS || err == -ENOTSUP) {
-				break;
-			}
-			if (dtr) {
-				break;
-			}
-			/* Give CPU resources to low priority threads. */
-			k_sleep(K_MSEC(100));
+		err = uart_line_ctrl_get(dev, UART_LINE_CTRL_DTR, &dtr);
+		if (err == -ENOSYS || err == -ENOTSUP) {
+			return true;
 		}
+
+		return dtr;
 	}
+
+	return true;
+}
+
+static void dtr_timer_handler(struct k_timer *timer)
+{
+	const struct shell_uart *sh_uart = k_timer_user_data_get(timer);
+
+	if (!uart_dtr_check(sh_uart->ctrl_blk->dev)) {
+		return;
+	}
+
+	/* DTR is active, stop timer and start TX */
+	k_timer_stop(timer);
+	uart_irq_tx_enable(sh_uart->ctrl_blk->dev);
 }
 
 static void uart_tx_handle(const struct device *dev,
@@ -126,13 +140,18 @@ static void uart_tx_handle(const struct device *dev,
 	uint32_t len;
 	const uint8_t *data;
 
+	if (!uart_dtr_check(dev)) {
+		/* Wait for DTR signal before sending anything to output. */
+		uart_irq_tx_disable(dev);
+		k_timer_start(sh_uart->dtr_timer, K_MSEC(100), K_MSEC(100));
+		return;
+	}
+
 	len = ring_buf_get_claim(sh_uart->tx_ringbuf, (uint8_t **)&data,
 				 sh_uart->tx_ringbuf->size);
 	if (len) {
 		int err;
 
-		/* Wait for DTR signal before sending anything to output. */
-		uart_dtr_wait(dev);
 		len = uart_fifo_fill(dev, data, len);
 		err = ring_buf_get_finish(sh_uart->tx_ringbuf, len);
 		__ASSERT_NO_MSG(err == 0);
@@ -172,6 +191,11 @@ static void uart_irq_init(const struct shell_uart *sh_uart)
 	sh_uart->ctrl_blk->tx_busy = 0;
 	uart_irq_callback_user_data_set(dev, uart_callback, (void *)sh_uart);
 	uart_irq_rx_enable(dev);
+
+	if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_CHECK_DTR)) {
+		k_timer_init(sh_uart->dtr_timer, dtr_timer_handler, NULL);
+		k_timer_user_data_set(sh_uart->dtr_timer, (void *)sh_uart);
+	}
 #endif
 }
 
@@ -224,6 +248,7 @@ static int uninit(const struct shell_transport *transport)
 	if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN)) {
 		const struct device *dev = sh_uart->ctrl_blk->dev;
 
+		k_timer_stop(sh_uart->dtr_timer);
 		uart_irq_tx_disable(dev);
 		uart_irq_rx_disable(dev);
 	} else {


### PR DESCRIPTION
Fail compilation when incorrect configuration is detected, i.e. when SHELL_BACKEND_SERIAL_CHECK_DTR is set but UART_LINE_CTRL is not set.

Use periodic timer to wait for DTR instead of waiting in uart callback to prevent blocking caller workqueue and/or sleeping in ISR.

DTR check was only ever supported with interrupt driven backend so add appropriate depends on to Kconfig.

Fixes: e9f238889b1a ("shell: uart: Add waiting on DTR signal before sending data")
Fixes: #47120
Fixes: #54705