### PR TITLE
input: ft5336: move the ft5336 binding under input

### DIFF
--- a/dts/bindings/input/focaltech,ft5336.yaml
+++ b/dts/bindings/input/focaltech,ft5336.yaml
@@ -5,7 +5,7 @@ description: FT5XX6/FT6XX6 capacitive touch panels
 
 compatible: "focaltech,ft5336"
 
-include: [kscan.yaml, i2c-device.yaml]
+include: i2c-device.yaml
 
 properties:
   int-gpios:


### PR DESCRIPTION
The rest of the code has been moved in https://github.com/zephyrproject-rtos/zephyr/pull/56128

---

The driver has been recently moved under the input subsystem but the corresponding driver was left over. Move it from kscan to input.