### PR TITLE
MAINTAINERS: add dts/bindings/input/ to the input file list

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1481,6 +1481,7 @@ Input:
   files:
     - doc/services/input/
     - drivers/input/
+    - dts/bindings/input/
     - include/zephyr/dt-bindings/input/
     - include/zephyr/input/
     - samples/subsys/input/


### PR DESCRIPTION
Add the dts/bindings/input/ subdirectory to the list of paths maintained under input.