### PR TITLE
twister: mark tests as started to improve reporting in case of timeouts

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -633,7 +633,7 @@ class DeviceHandler(Handler):
             self.instance.status = "failed"
             self.instance.reason = "Timeout"
 
-        if self.instance.status == "error":
+        if self.instance.status in ["error", "failed"]:
             self.instance.add_missing_case_status("blocked", self.instance.reason)
 
         if not flash_error:

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -272,17 +272,17 @@ class Test(Harness):
             self.testcase_output += line + "\n"
             self._match = True
 
-        match = result_re.match(line)
+        result_match = result_re.match(line)
 
-        if match and match.group(2):
-            name = "{}.{}".format(self.id, match.group(3))
+        if result_match and result_match.group(2):
+            name = "{}.{}".format(self.id, result_match.group(3))
             tc = self.instance.get_case_or_create(name)
 
-            matched_status = match.group(1)
+            matched_status = result_match.group(1)
             tc.status = self.ztest_to_status[matched_status]
             if tc.status == "skipped":
                 tc.reason = "ztest skip"
-            tc.duration = float(match.group(4))
+            tc.duration = float(result_match.group(4))
             if tc.status == "failed":
                 tc.output = self.testcase_output
             self.testcase_output = ""

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -268,6 +268,14 @@ class Test(Harness):
             self.detected_suite_names.append(suite_name)
 
         testcase_match = re.search(self.ZTEST_START_PATTERN, line)
+        if testcase_match:
+            name = "{}.{}".format(self.id, testcase_match.group(2))
+            tc = self.instance.get_case_or_create(name)
+            # Mark the test as started, if something happens here, it is mostly
+            # due to this tests, for example timeout. This should in this case
+            # be marked as failed and not blocked (not run).
+            tc.status = "started"
+
         if testcase_match or self._match:
             self.testcase_output += line + "\n"
             self._match = True
@@ -275,10 +283,9 @@ class Test(Harness):
         result_match = result_re.match(line)
 
         if result_match and result_match.group(2):
+            matched_status = result_match.group(1)
             name = "{}.{}".format(self.id, result_match.group(3))
             tc = self.instance.get_case_or_create(name)
-
-            matched_status = result_match.group(1)
             tc.status = self.ztest_to_status[matched_status]
             if tc.status == "skipped":
                 tc.reason = "ztest skip"
@@ -292,6 +299,7 @@ class Test(Harness):
         self.process_test(line)
 
         if not self.ztest and self.state:
+            logger.debug(f"not a ztest and no state for  {self.id}")
             tc = self.instance.get_case_or_create(self.id)
             if self.state == "passed":
                 tc.status = "passed"

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -73,7 +73,9 @@ class TestInstance:
 
     def add_missing_case_status(self, status, reason=None):
         for case in self.testcases:
-            if not case.status:
+            if case.status == 'started':
+                case.status = "failed"
+            elif not case.status:
                 case.status = status
                 if reason:
                     case.reason = reason

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -131,7 +131,7 @@ class TestInstance:
             # command-line, then we need to run the test, not just build it.
             fixture = testsuite.harness_config.get('fixture')
             if fixture:
-                can_run = (fixture in fixtures)
+                can_run = fixture in fixtures
 
         return can_run
 

--- a/subsys/testsuite/include/zephyr/tc_util.h
+++ b/subsys/testsuite/include/zephyr/tc_util.h
@@ -189,6 +189,11 @@ static inline void print_nothing(const char *fmt, ...)
 	Z_TC_END_RESULT((result), __func__)
 #endif
 
+#ifndef TC_END_RESULT_CUSTOM
+#define TC_END_RESULT_CUSTOM(result, func)                           \
+	Z_TC_END_RESULT((result), func)
+#endif
+
 #ifndef TC_SUITE_PRINT
 #define TC_SUITE_PRINT(fmt, ...) PRINT_DATA(fmt, ##__VA_ARGS__)
 #endif

--- a/tests/crypto/mbedtls/src/mbedtls.c
+++ b/tests/crypto/mbedtls/src/mbedtls.c
@@ -153,8 +153,6 @@ ZTEST_USER(mbedtls_fn, test_mbedtls)
 	mbedtls_platform_set_printf(MBEDTLS_PRINT);
 #endif
 
-	TC_START("Performing mbedTLS crypto tests:");
-
 /*
  * The C standard doesn't guarantee that all-bits-0 is the representation
  * of a NULL pointer. We do however use that in our code for initializing

--- a/tests/crypto/tinycrypt/src/cbc_mode.c
+++ b/tests/crypto/tinycrypt/src/cbc_mode.c
@@ -104,8 +104,6 @@ const uint8_t ciphertext[80] = {
 ZTEST(tinycrypt, test_cbc_sp_800_38a_encrypt_decrypt)
 {
 
-	TC_START("Performing AES128 tests:");
-
 	TC_PRINT("Performing CBC tests:\n");
 
 	struct tc_aes_key_sched_struct a;

--- a/tests/crypto/tinycrypt/src/cmac_mode.c
+++ b/tests/crypto/tinycrypt/src/cmac_mode.c
@@ -265,7 +265,6 @@ ZTEST(tinycrypt, test_cmac_mode)
 	};
 	uint8_t K1[BUF_LEN], K2[BUF_LEN];
 
-	TC_START("Performing CMAC tests:");
 
 	(void) tc_cmac_setup(&state, key, &sched);
 	result = verify_gf_2_128_double(K1, K2, state);

--- a/tests/crypto/tinycrypt/src/ctr_mode.c
+++ b/tests/crypto/tinycrypt/src/ctr_mode.c
@@ -51,7 +51,6 @@
  */
 void test_ctr_sp_800_38a_encrypt_decrypt(void)
 {
-	TC_START("Performing AES128-CTR mode tests:");
 
 	TC_PRINT("Performing CTR tests:\n");
 

--- a/tests/crypto/tinycrypt/src/ctr_prng.c
+++ b/tests/crypto/tinycrypt/src/ctr_prng.c
@@ -544,7 +544,6 @@ ZTEST(tinycrypt, test_ctr_prng_vector)
 	int rc;
 	int i;
 
-	TC_START("Performing CTR-PRNG tests:");
 
 	elements = (int)sizeof(vectors) / sizeof(vectors[0]);
 	for (i = 0; i < elements; i++) {

--- a/tests/crypto/tinycrypt/src/ecc_dh.c
+++ b/tests/crypto/tinycrypt/src/ecc_dh.c
@@ -450,7 +450,6 @@ ZTEST(tinycrypt, test_ecc_dh)
 {
 	unsigned int result = TC_PASS;
 
-	TC_START("Performing ECC-DH tests:");
 
 	/* Setup of the Cryptographically Secure PRNG. */
 	uECC_set_rng(&default_CSPRNG);

--- a/tests/crypto/tinycrypt/src/ecc_dsa.c
+++ b/tests/crypto/tinycrypt/src/ecc_dsa.c
@@ -632,7 +632,6 @@ ZTEST(tinycrypt, test_ecc_dsa)
 {
 	unsigned int result = TC_PASS;
 
-	TC_START("Performing ECC-DSA tests:");
 	/* Setup of the Cryptographically Secure PRNG. */
 	uECC_set_rng(&default_CSPRNG);
 

--- a/tests/crypto/tinycrypt/src/hmac.c
+++ b/tests/crypto/tinycrypt/src/hmac.c
@@ -64,7 +64,6 @@ ZTEST(tinycrypt, test_hmac_1)
 {
 	uint32_t result = TC_PASS;
 
-	TC_START("Performing HMAC tests (RFC4231 test vectors):");
 
 	TC_PRINT("HMAC %s:\n", __func__);
 

--- a/tests/crypto/tinycrypt/src/sha256.c
+++ b/tests/crypto/tinycrypt/src/sha256.c
@@ -52,7 +52,6 @@
  */
 ZTEST(tinycrypt, test_sha256_1)
 {
-	TC_START("Performing SHA256 tests (NIST tests vectors):");
 
 	uint32_t result = TC_PASS;
 

--- a/tests/crypto/tinycrypt_hmac_prng/src/hmac_prng.c
+++ b/tests/crypto/tinycrypt_hmac_prng/src/hmac_prng.c
@@ -7548,7 +7548,6 @@ ZTEST(hmac_prng_fn, test_hmac_prng)
 {
 	unsigned int result = TC_PASS;
 
-	TC_START("Performing HMAC-PRNG tests:");
 
 	result = test_1();
 	zassert_false(result == TC_FAIL, "HMAC test 1 failed");

--- a/tests/drivers/ipm/src/main.c
+++ b/tests/drivers/ipm/src/main.c
@@ -80,7 +80,6 @@ void main(void)
 	const struct device *ipm;
 
 	TC_SUITE_START("test_ipm");
-	TC_START(__func__);
 	ipm = device_get_binding("ipm_dummy0");
 
 	/* Try sending a raw string to the IPM device to show that the

--- a/tests/kernel/fatal/no-multithreading/src/main.c
+++ b/tests/kernel/fatal/no-multithreading/src/main.c
@@ -22,7 +22,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 		TC_PRINT("Unexpected reason (exp: %d)\n", expected_reason);
 		rv = TC_FAIL;
 	}
-
+	TC_END_RESULT_CUSTOM(rv, "test_fatal");
 	TC_END_REPORT(rv);
 	arch_system_halt(reason);
 }

--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -372,8 +372,6 @@ ZTEST(gen_isr_table, test_run_time_interrupt)
 
 static void *gen_isr_table_setup(void)
 {
-	TC_START("Test gen_isr_tables");
-
 	TC_PRINT("IRQ configuration (total lines %d):\n", CONFIG_NUM_IRQS);
 
 #pragma GCC diagnostic push

--- a/tests/kernel/mutex/sys_mutex/src/main.c
+++ b/tests/kernel/mutex/sys_mutex/src/main.c
@@ -322,8 +322,6 @@ ZTEST_USER_OR_NOT(mutex_complex, test_mutex)
 	int priority[4] = { 9, 8, 7, 5 };
 	int droppri[3] = { 8, 8, 9 };
 
-	TC_START("Test kernel Mutex API");
-
 	PRINT_LINE;
 
 	/*

--- a/tests/kernel/timer/timer_monotonic/src/main.c
+++ b/tests/kernel/timer/timer_monotonic/src/main.c
@@ -61,8 +61,6 @@ ZTEST(timer_fn, test_timer)
 	TC_PRINT("sys_clock_hw_cycles_per_sec() = %d\n",
 		 sys_clock_hw_cycles_per_sec());
 
-	TC_START("test monotonic timer");
-
 	t_last = k_cycle_get_32();
 
 	for (i = 0U; i < 1000000; i++) {

--- a/tests/net/6lo/src/main.c
+++ b/tests/net/6lo/src/main.c
@@ -1167,7 +1167,7 @@ ZTEST(t_6lo, test_loop)
 #endif
 
 	for (count = 0; count < ARRAY_SIZE(tests); count++) {
-		TC_START(tests[count].name);
+		TC_PRINT("Starting %s\n", tests[count].name);
 
 		test_6lo(tests[count].data);
 	}

--- a/tests/net/lib/mqtt_packet/src/mqtt_packet.c
+++ b/tests/net/lib/mqtt_packet/src/mqtt_packet.c
@@ -1125,8 +1125,6 @@ static int eval_corrupted_pkt_len(struct mqtt_test *mqtt_test)
 
 ZTEST(mqtt_packet_fn, test_mqtt_packet)
 {
-	TC_START("MQTT Library test");
-
 	int rc;
 	int i;
 

--- a/tests/net/socket/socketpair/src/block.c
+++ b/tests/net/socket/socketpair/src/block.c
@@ -54,7 +54,7 @@ static void work_handler(struct k_work *work)
 	}
 }
 
-ZTEST(net_socketpair, write_block)
+ZTEST(net_socketpair, test_write_block)
 {
 	int res;
 	int sv[2] = {-1, -1};
@@ -102,7 +102,7 @@ ZTEST(net_socketpair, write_block)
 	close(sv[1]);
 }
 
-ZTEST(net_socketpair, read_block)
+ZTEST(net_socketpair, test_read_block)
 {
 	int res;
 	char x;

--- a/tests/net/socket/socketpair/src/closed_ends.c
+++ b/tests/net/socket/socketpair/src/closed_ends.c
@@ -5,7 +5,7 @@
 
 #include "_main.h"
 
-ZTEST_USER(net_socketpair, close_one_end_and_write_to_the_other)
+ZTEST_USER(net_socketpair, test_close_one_end_and_write_to_the_other)
 {
 	int res;
 	int sv[2] = {-1, -1};
@@ -27,7 +27,7 @@ ZTEST_USER(net_socketpair, close_one_end_and_write_to_the_other)
 	}
 }
 
-ZTEST_USER(net_socketpair, close_one_end_and_read_from_the_other)
+ZTEST_USER(net_socketpair, test_close_one_end_and_read_from_the_other)
 {
 	int res;
 	int sv[2] = {-1, -1};

--- a/tests/net/socket/socketpair/src/expected_failures.c
+++ b/tests/net/socket/socketpair/src/expected_failures.c
@@ -6,7 +6,7 @@
 
 #include "_main.h"
 
-ZTEST_USER(net_socketpair, expected_failures)
+ZTEST_USER(net_socketpair, test_expected_failures)
 {
 	int res;
 	int sv[2] = {-1, -1};

--- a/tests/net/socket/socketpair/src/fcntl.c
+++ b/tests/net/socket/socketpair/src/fcntl.c
@@ -6,7 +6,7 @@
 
 #include "_main.h"
 
-ZTEST_USER(net_socketpair, fcntl)
+ZTEST_USER(net_socketpair, test_fcntl)
 {
 	int res;
 	int sv[2] = {-1, -1};

--- a/tests/net/socket/socketpair/src/happy_path.c
+++ b/tests/net/socket/socketpair/src/happy_path.c
@@ -119,7 +119,7 @@ static void happy_path(
 	zassert_equal(res, 0, "close failed");
 }
 
-ZTEST_USER(net_socketpair, AF_LOCAL__SOCK_STREAM__0)
+ZTEST_USER(net_socketpair, test_AF_LOCAL__SOCK_STREAM__0)
 {
 	happy_path(
 		AF_LOCAL, "AF_LOCAL",
@@ -128,7 +128,7 @@ ZTEST_USER(net_socketpair, AF_LOCAL__SOCK_STREAM__0)
 	);
 }
 
-ZTEST_USER(net_socketpair, AF_UNIX__SOCK_STREAM__0)
+ZTEST_USER(net_socketpair, test_AF_UNIX__SOCK_STREAM__0)
 {
 	happy_path(
 		AF_UNIX, "AF_UNIX",

--- a/tests/net/socket/socketpair/src/nonblock.c
+++ b/tests/net/socket/socketpair/src/nonblock.c
@@ -6,7 +6,7 @@
 
 #include "_main.h"
 
-ZTEST_USER(net_socketpair, write_nonblock)
+ZTEST_USER(net_socketpair, test_write_nonblock)
 {
 	int res;
 	int sv[2] = {-1, -1};
@@ -40,7 +40,7 @@ ZTEST_USER(net_socketpair, write_nonblock)
 	close(sv[1]);
 }
 
-ZTEST_USER(net_socketpair, read_nonblock)
+ZTEST_USER(net_socketpair, test_read_nonblock)
 {
 	int res;
 	int sv[2] = {-1, -1};

--- a/tests/net/socket/socketpair/src/poll.c
+++ b/tests/net/socket/socketpair/src/poll.c
@@ -48,7 +48,7 @@ static void test_socketpair_poll_timeout_common(int sv[2])
 	close(sv[1]);
 }
 
-ZTEST_USER(net_socketpair, poll_timeout)
+ZTEST_USER(net_socketpair, test_poll_timeout)
 {
 	int sv[2] = {-1, -1};
 	int res = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
@@ -59,7 +59,7 @@ ZTEST_USER(net_socketpair, poll_timeout)
 }
 
 /* O_NONBLOCK should have no affect on poll(2) */
-ZTEST_USER(net_socketpair, poll_timeout_nonblocking)
+ZTEST_USER(net_socketpair, test_poll_timeout_nonblocking)
 {
 	int sv[2] = {-1, -1};
 	int res = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
@@ -100,7 +100,7 @@ static void close_fun(struct k_work *work)
  *   - close remote fd while the local fd is blocking in poll. r: 1,
  *     POLLOUT, write -> r: -1, errno: EPIPE.
  */
-ZTEST(net_socketpair, poll_close_remote_end_POLLIN)
+ZTEST(net_socketpair, test_poll_close_remote_end_POLLIN)
 {
 	int res;
 	char c;
@@ -138,7 +138,7 @@ ZTEST(net_socketpair, poll_close_remote_end_POLLIN)
 	close(sv[0]);
 }
 
-ZTEST(net_socketpair, poll_close_remote_end_POLLOUT)
+ZTEST(net_socketpair, test_poll_close_remote_end_POLLOUT)
 {
 	int res;
 	struct pollfd fds[1];
@@ -188,7 +188,7 @@ ZTEST(net_socketpair, poll_close_remote_end_POLLOUT)
  *   - even with a timeout value of 0us, poll should return immediately with
  *     a value of 2 if both read and write are available
  */
-ZTEST_USER(net_socketpair, poll_immediate_data)
+ZTEST_USER(net_socketpair, test_poll_immediate_data)
 {
 	int sv[2] = {-1, -1};
 	int res;
@@ -269,7 +269,7 @@ static void rw_fun(struct k_work *work)
  *   - say there is a timeout value of 5 s, poll should return immediately
  *     with the a value of 1 (for either read or write cases)
  */
-ZTEST(net_socketpair, poll_delayed_data)
+ZTEST(net_socketpair, test_poll_delayed_data)
 {
 	int sv[2] = {-1, -1};
 	int res;
@@ -331,7 +331,7 @@ ZTEST(net_socketpair, poll_delayed_data)
  *     if the poll was called after the data was written
  *   - after reading data from a remote socket, POLLIN shouldn't be reported
  */
-ZTEST_USER(net_socketpair, poll_signalling_POLLIN)
+ZTEST_USER(net_socketpair, test_poll_signalling_POLLIN)
 {
 	int sv[2] = {-1, -1};
 	int res;
@@ -389,7 +389,7 @@ ZTEST_USER(net_socketpair, poll_signalling_POLLIN)
  *   - after reading data from a remote socket, POLLOUT should be reported
  *     again
  */
-ZTEST_USER(net_socketpair, poll_signalling_POLLOUT)
+ZTEST_USER(net_socketpair, test_poll_signalling_POLLOUT)
 {
 	int sv[2] = {-1, -1};
 	int res;

--- a/tests/net/socket/socketpair/src/unsupported_calls.c
+++ b/tests/net/socket/socketpair/src/unsupported_calls.c
@@ -6,7 +6,7 @@
 
 #include "_main.h"
 
-ZTEST_USER(net_socketpair, unsupported_calls)
+ZTEST_USER(net_socketpair, test_unsupported_calls)
 {
 	int res;
 	int sv[2] = {-1, -1};

--- a/tests/net/utils/src/main.c
+++ b/tests/net/utils/src/main.c
@@ -407,13 +407,13 @@ ZTEST(test_utils_fn, test_net_addr)
 	int count, pass;
 
 	for (count = 0, pass = 0; count < ARRAY_SIZE(tests); count++) {
-		TC_START(tests[count].name);
+		TC_PRINT("Running test: %s: ", tests[count].name);
 
 		if (check_net_addr(tests[count].data)) {
-			TC_END(PASS, "passed\n");
+			TC_PRINT("passed\n");
 			pass++;
 		} else {
-			TC_END(FAIL, "failed\n");
+			TC_PRINT("failed\n");
 		}
 	}
 

--- a/tests/posix/common/src/fnmatch.c
+++ b/tests/posix/common/src/fnmatch.c
@@ -11,7 +11,7 @@
  * Adapted from
  * https://git.musl-libc.org/cgit/libc-testsuite/tree/fnmatch.c
  */
-ZTEST(posix_apis, fnmatch)
+ZTEST(posix_apis, test_fnmatch)
 {
 	/* Note: commented out lines indicate known problems to be addressed in #55186 */
 

--- a/tests/ztest/register/src/test_step_0.c
+++ b/tests/ztest/register/src/test_step_0.c
@@ -7,7 +7,7 @@
 #include <zephyr/ztest.h>
 #include "common.h"
 
-static void test(void)
+static void test_step_0(void)
 {
 }
 
@@ -18,4 +18,4 @@ static bool predicate(const void *state)
 	return s->phase == PHASE_STEPS_0;
 }
 
-ztest_register_test_suite(test_step_0, predicate, ztest_unit_test(test));
+ztest_register_test_suite(test_step_0, predicate, ztest_unit_test(test_step_0));

--- a/tests/ztest/register/src/test_step_1.c
+++ b/tests/ztest/register/src/test_step_1.c
@@ -7,7 +7,7 @@
 #include <zephyr/ztest.h>
 #include "common.h"
 
-static void test(void)
+static void test_step_1(void)
 {
 }
 
@@ -18,4 +18,4 @@ static bool predicate(const void *state)
 	return s->phase == PHASE_STEPS_1;
 }
 
-ztest_register_test_suite(test_step_1, predicate, ztest_unit_test(test));
+ztest_register_test_suite(test_step_1, predicate, ztest_unit_test(test_step_1));

--- a/tests/ztest/register/src/test_step_all.c
+++ b/tests/ztest/register/src/test_step_all.c
@@ -7,7 +7,7 @@
 #include <zephyr/ztest.h>
 #include "common.h"
 
-static void test(void)
+static void test_step_all(void)
 {
 }
 
@@ -18,4 +18,4 @@ static bool predicate(const void *state)
 	return s->phase == PHASE_STEPS_0 || s->phase == PHASE_STEPS_1;
 }
 
-ztest_register_test_suite(test_step_all, predicate, ztest_unit_test(test));
+ztest_register_test_suite(test_step_all, predicate, ztest_unit_test(test_step_all));


### PR DESCRIPTION

Whenever a test starts, mark it as such, any tests that do not update their status with the final result will be marked as failed. Until now such tests were wrongly marked as blocked.

This has a positive side effect of detecting wrong output and misconfigued tests using TC_START and not naming tests correctly, so fixing all those tests we could find.


- tests: gen_isr_table: remove exta TC_START call
- ztest: add macro for custom testcase result
- tests: kernel: fatal: report testcase results
- tests: kernel: timer: remove extra TC_START
- tests: net: 6lo: do not use TC_START for debugging
- tests: tinycrypt_hmac_prng: do not use TC_START for debugging
- tests: mbedtls: do not use TC_START for debugging
- tests: tinycrypt: do not use TC_START for debugging
- tests: ipm: do not use TC_START for debugging
- tests: sys_mutex: do not use TC_START for debugging
- tests: mqtt: do not use TC_START for debugging
- tests: net: socketpair: prefix tests with test_
- tests: net: util: do not use TC_START for debugging
- tests: posix: prefix tests with test_
- tests: ztest: use more verbose testname
- twister: harness: rename match variable
- twister: marked tests causing timeout as fail
