### PR TITLE
subsys: logging: Changed log template to consider default log level

### DIFF
--- a/subsys/logging/Kconfig.template.log_config
+++ b/subsys/logging/Kconfig.template.log_config
@@ -2,7 +2,7 @@
 
 choice "$(module)_LOG_LEVEL_CHOICE"
 	prompt "Max compiled-in log level for $(module-str)"
-	default $(module)_LOG_LEVEL_INF
+	default $(module)_LOG_LEVEL_DEFAULT
 	depends on LOG
 
 config $(module)_LOG_LEVEL_OFF
@@ -20,6 +20,9 @@ config $(module)_LOG_LEVEL_INF
 config $(module)_LOG_LEVEL_DBG
 	bool "Debug"
 
+config $(module)_LOG_LEVEL_DEFAULT
+	bool "Default"
+
 endchoice
 
 config $(module)_LOG_LEVEL
@@ -30,3 +33,4 @@ config $(module)_LOG_LEVEL
 	default 2 if $(module)_LOG_LEVEL_WRN
 	default 3 if $(module)_LOG_LEVEL_INF
 	default 4 if $(module)_LOG_LEVEL_DBG
+	default LOG_DEFAULT_LEVEL if $(module)_LOG_LEVEL_DEFAULT


### PR DESCRIPTION
Added using LOG_DEFAULT_LEVEL kconfig option in log module template for assigning the default log level to newly created module instance, instead of assuming always INFO level.

Fixes issue: https://github.com/zephyrproject-rtos/zephyr/issues/56523