### PR TITLE
Bluetooth: Controller: Fix cis_offset_min used in CIS Create Response

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -733,7 +733,13 @@ uint16_t ull_central_iso_cis_offset_get(uint16_t cis_handle, uint32_t *cis_offse
 		 * CIS_Offset_Max < (connInterval - (CIG_Sync_Delay + T_MSS))
 		 */
 		*cis_offset_max = (conn->lll.interval * CONN_INT_UNIT_US) - cig->sync_delay;
-		*cis_offset_min = MAX(400, EVENT_OVERHEAD_CIS_SETUP_US);
+
+		if (IS_ENABLED(CONFIG_BT_CTLR_JIT_SCHEDULING)) {
+			*cis_offset_min = MAX(400, EVENT_OVERHEAD_CIS_SETUP_US);
+		} else {
+			*cis_offset_min = HAL_TICKER_TICKS_TO_US(conn->ull.ticks_slot) +
+					  (EVENT_TICKER_RES_MARGIN_US << 1U);
+		}
 	}
 
 	cis->central.instant = ull_conn_event_counter(conn) + 3;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -1260,12 +1260,23 @@ uint16_t ull_cp_cc_ongoing_handle(struct ll_conn *conn)
 	return 0xFFFF;
 }
 
-void ull_cp_cc_accept(struct ll_conn *conn)
+void ull_cp_cc_accept(struct ll_conn *conn, uint32_t cis_offset_min)
 {
 	struct proc_ctx *ctx;
 
 	ctx = llcp_rr_peek(conn);
 	if (ctx && ctx->proc == PROC_CIS_CREATE) {
+		if (cis_offset_min > ctx->data.cis_create.cis_offset_min) {
+			if (cis_offset_min > ctx->data.cis_create.cis_offset_max) {
+				ctx->data.cis_create.error = BT_HCI_ERR_UNSUPP_LL_PARAM_VAL;
+				llcp_rp_cc_reject(conn, ctx);
+
+				return;
+			}
+
+			ctx->data.cis_create.cis_offset_min = cis_offset_min;
+		}
+
 		llcp_rp_cc_accept(conn, ctx);
 	}
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -205,7 +205,7 @@ uint16_t ull_cp_cc_ongoing_handle(struct ll_conn *conn);
 /**
  * @brief Accept the remote device’s request to create cis.
  */
-void ull_cp_cc_accept(struct ll_conn *conn);
+void ull_cp_cc_accept(struct ll_conn *conn, uint32_t cis_offset_min);
 
 /**
  * @brief Reject the remote device’s request to create cis.

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -99,11 +99,20 @@ static struct ll_conn *ll_cis_get_acl_awaiting_reply(uint16_t handle, uint8_t *e
 uint8_t ll_cis_accept(uint16_t handle)
 {
 	uint8_t status = BT_HCI_ERR_SUCCESS;
-	struct ll_conn *acl_conn = ll_cis_get_acl_awaiting_reply(handle, &status);
+	struct ll_conn *conn = ll_cis_get_acl_awaiting_reply(handle, &status);
 
-	if (acl_conn) {
+	if (conn) {
+		uint32_t cis_offset_min;
+
+		if (IS_ENABLED(CONFIG_BT_CTLR_JIT_SCHEDULING)) {
+			cis_offset_min = MAX(400, EVENT_OVERHEAD_CIS_SETUP_US);
+		} else {
+			cis_offset_min = HAL_TICKER_TICKS_TO_US(conn->ull.ticks_slot) +
+					 (EVENT_TICKER_RES_MARGIN_US << 1U);
+		}
+
 		/* Accept request */
-		ull_cp_cc_accept(acl_conn);
+		ull_cp_cc_accept(conn, cis_offset_min);
 	}
 
 	return status;

--- a/tests/bluetooth/controller/ctrl_cis_create/src/main.c
+++ b/tests/bluetooth/controller/ctrl_cis_create/src/main.c
@@ -156,7 +156,7 @@ ZTEST(cis_create, test_cc_create_periph_rem_host_accept)
 	ull_cp_release_ntf(ntf);
 
 	/* Accept request */
-	ull_cp_cc_accept(&conn);
+	ull_cp_cc_accept(&conn, 0U);
 
 	/* Prepare */
 	event_prepare(&conn);


### PR DESCRIPTION
Use the minimum supported cis_offset_min considering that ACL radio event does not overlap with CIG event. Use the calculated maximum of local and remote cis_offset_min in the Response PDU.