### PR TITLE
dts: drivers: intel_adsp_2.0: Lnl dmic changes

### DIFF
--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -322,14 +322,9 @@ static inline void dai_dmic_en_power(const struct dai_intel_dmic *dmic)
 {
 	uint32_t base = dai_dmic_base(dmic);
 	/* Enable DMIC power */
-#ifdef CONFIG_SOC_INTEL_ACE15_MTPM
 	sys_write32((sys_read32(base + DMICLCTL_OFFSET) | DMICLCTL_SPA),
 			base + DMICLCTL_OFFSET);
-#else /* CONFIG_SOC_INTEL_ACE20_LNL */
-	sys_write32((sys_read32(base + DMICLCTL_OFFSET) |
-		    DMICLCTL_SPA | DMICLCTL_OFLEN),
-		    base + DMICLCTL_OFFSET);
-#endif /* CONFIG_SOC_INTEL_ACE20_LNL */
+
 	while (!(sys_read32(base + DMICLCTL_OFFSET) & DMICLCTL_CPA)) {
 		k_sleep(K_USEC(100));
 	}

--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -885,6 +885,10 @@ static int dai_dmic_initialize_device(const struct device *dev)
 		},							\
 		.reg_base = DT_INST_REG_ADDR_BY_IDX(n, 0),		\
 		.shim_base = DT_INST_PROP(n, shim),			\
+		IF_ENABLED(DT_NODE_EXISTS(DT_NODELABEL(hdamlddmic)),	\
+			(.hdamldmic_base = DT_REG_ADDR(DT_NODELABEL(hdamlddmic)),))	\
+		IF_ENABLED(DT_NODE_EXISTS(DT_NODELABEL(dmicvss)),	\
+			(.vshim_base = DT_REG_ADDR(DT_NODELABEL(dmicvss)),))	\
 		.irq = DT_INST_IRQN(n),					\
 		.fifo =							\
 		{							\

--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -156,44 +156,69 @@ static inline void dai_dmic_release_ownership(const struct dai_intel_dmic *dmic)
 
 #endif /* CONFIG_DAI_DMIC_HAS_OWNERSHIP */
 
+static inline uint32_t dai_dmic_base(const struct dai_intel_dmic *dmic)
+{
+#ifdef CONFIG_SOC_INTEL_ACE20_LNL
+	return dmic->hdamldmic_base;
+#else
+	return dmic->shim_base;
+#endif
+}
+
 #if CONFIG_DAI_DMIC_HAS_MULTIPLE_LINE_SYNC
 static inline void dai_dmic_set_sync_period(uint32_t period, const struct dai_intel_dmic *dmic)
 {
 	uint32_t val = CONFIG_DAI_DMIC_HW_IOCLK / period - 1;
-
+	uint32_t base = dai_dmic_base(dmic);
 	/* DMIC Change sync period */
-	sys_write32(sys_read32(dmic->shim_base + DMICSYNC_OFFSET) | DMICSYNC_SYNCPRD(val),
-			dmic->shim_base + DMICSYNC_OFFSET);
-	sys_write32(sys_read32(dmic->shim_base + DMICSYNC_OFFSET) | DMICSYNC_CMDSYNC,
-			dmic->shim_base + DMICSYNC_OFFSET);
+#ifdef CONFIG_SOC_INTEL_ACE20_LNL
+	sys_write32(sys_read32(base + DMICSYNC_OFFSET) | DMICSYNC_SYNCPRD(val),
+		    base + DMICSYNC_OFFSET);
+	sys_write32(sys_read32(base + DMICSYNC_OFFSET) | DMICSYNC_SYNCPU,
+		    base + DMICSYNC_OFFSET);
+	while (sys_read32(base + DMICSYNC_OFFSET) & DMICSYNC_SYNCPU) {
+		k_sleep(K_USEC(100));
+	}
+	sys_write32(sys_read32(base + DMICSYNC_OFFSET) | DMICSYNC_CMDSYNC,
+		    base + DMICSYNC_OFFSET);
+#else /* All other CAVS and ACE platforms */
+	sys_write32(sys_read32(base + DMICSYNC_OFFSET) | DMICSYNC_SYNCPRD(val),
+		    base + DMICSYNC_OFFSET);
+	sys_write32(sys_read32(base + DMICSYNC_OFFSET) | DMICSYNC_CMDSYNC,
+		    base + DMICSYNC_OFFSET);
+#endif
 }
 
 static inline void dai_dmic_clear_sync_period(const struct dai_intel_dmic *dmic)
 {
+	uint32_t base = dai_dmic_base(dmic);
 	/* DMIC Clean sync period */
-	sys_write32(sys_read32(dmic->shim_base + DMICSYNC_OFFSET) & ~DMICSYNC_SYNCPRD(0x0000),
-			dmic->shim_base + DMICSYNC_OFFSET);
-	sys_write32(sys_read32(dmic->shim_base + DMICSYNC_OFFSET) & ~DMICSYNC_CMDSYNC,
-			dmic->shim_base + DMICSYNC_OFFSET);
-
+	sys_write32(sys_read32(base + DMICSYNC_OFFSET) & ~DMICSYNC_SYNCPRD(0x0000),
+			base + DMICSYNC_OFFSET);
+	sys_write32(sys_read32(base + DMICSYNC_OFFSET) & ~DMICSYNC_CMDSYNC,
+			base + DMICSYNC_OFFSET);
 }
 
 /* Preparing for command synchronization on multiple link segments */
 static inline void dai_dmic_sync_prepare(const struct dai_intel_dmic *dmic)
 {
-	sys_write32(sys_read32(dmic->shim_base + DMICSYNC_OFFSET) | DMICSYNC_CMDSYNC,
-			dmic->shim_base + DMICSYNC_OFFSET);
+	uint32_t base = dai_dmic_base(dmic);
+
+	sys_write32(sys_read32(base + DMICSYNC_OFFSET) | DMICSYNC_CMDSYNC,
+		    base + DMICSYNC_OFFSET);
 }
 
 /* Trigering synchronization of command execution */
 static void dmic_sync_trigger(const struct dai_intel_dmic *dmic)
 {
-	__ASSERT_NO_MSG((sys_read32(dmic->shim_base + DMICSYNC_OFFSET) & DMICSYNC_CMDSYNC) != 0);
+	uint32_t base = dai_dmic_base(dmic);
 
-	sys_write32(sys_read32(dmic->shim_base + DMICSYNC_OFFSET) |
-		    DMICSYNC_SYNCGO, dmic->shim_base + DMICSYNC_OFFSET);
+	__ASSERT_NO_MSG((sys_read32(base + DMICSYNC_OFFSET) & DMICSYNC_CMDSYNC) != 0);
+
+	sys_write32(sys_read32(base + DMICSYNC_OFFSET) |
+		    DMICSYNC_SYNCGO, base + DMICSYNC_OFFSET);
 	/* waiting for CMDSYNC bit clearing */
-	while (sys_read32(dmic->shim_base + DMICSYNC_OFFSET) & DMICSYNC_CMDSYNC) {
+	while (sys_read32(base + DMICSYNC_OFFSET) & DMICSYNC_CMDSYNC) {
 		k_sleep(K_USEC(100));
 	}
 }
@@ -255,28 +280,52 @@ static void dai_dmic_irq_handler(const void *data)
 static inline void dai_dmic_dis_clk_gating(const struct dai_intel_dmic *dmic)
 {
 	/* Disable DMIC clock gating */
+#ifdef CONFIG_SOC_INTEL_ACE20_LNL /* Ace 2.0 */
+	sys_write32((sys_read32(dmic->vshim_base + DMICLCTL_OFFSET) | DMIC_DCGD),
+		    dmic->vshim_base + DMICLCTL_OFFSET);
+#else
 	sys_write32((sys_read32(dmic->shim_base + DMICLCTL_OFFSET) | DMIC_DCGD),
-			dmic->shim_base + DMICLCTL_OFFSET);
+		    dmic->shim_base + DMICLCTL_OFFSET);
+#endif
 }
 
 static inline void dai_dmic_en_clk_gating(const struct dai_intel_dmic *dmic)
 {
 	/* Enable DMIC clock gating */
+#ifdef CONFIG_SOC_INTEL_ACE20_LNL /* Ace 2.0 */
+	sys_write32((sys_read32(dmic->vshim_base + DMICLCTL_OFFSET) & ~DMIC_DCGD),
+		    dmic->vshim_base + DMICLCTL_OFFSET);
+#else
 	sys_write32((sys_read32(dmic->shim_base + DMICLCTL_OFFSET) & ~DMIC_DCGD),
-			dmic->shim_base + DMICLCTL_OFFSET);
+		    dmic->shim_base + DMICLCTL_OFFSET);
+#endif
+
 }
 
 static inline void dai_dmic_en_power(const struct dai_intel_dmic *dmic)
 {
+	uint32_t base = dai_dmic_base(dmic);
 	/* Enable DMIC power */
-	sys_write32((sys_read32(dmic->shim_base + DMICLCTL_OFFSET) | DMICLCTL_SPA),
-			dmic->shim_base + DMICLCTL_OFFSET);
+#ifdef CONFIG_SOC_INTEL_ACE15_MTPM
+	sys_write32((sys_read32(base + DMICLCTL_OFFSET) | DMICLCTL_SPA),
+			base + DMICLCTL_OFFSET);
+#else /* CONFIG_SOC_INTEL_ACE20_LNL */
+	sys_write32((sys_read32(base + DMICLCTL_OFFSET) |
+		    DMICLCTL_SPA | DMICLCTL_OFLEN),
+		    base + DMICLCTL_OFFSET);
+#endif /* CONFIG_SOC_INTEL_ACE20_LNL */
+	while (!(sys_read32(base + DMICLCTL_OFFSET) & DMICLCTL_CPA)) {
+		k_sleep(K_USEC(100));
+	}
+
 }
+
 static inline void dai_dmic_dis_power(const struct dai_intel_dmic *dmic)
 {
+	uint32_t base = dai_dmic_base(dmic);
 	/* Disable DMIC power */
-	sys_write32((sys_read32(dmic->shim_base + DMICLCTL_OFFSET) & (~DMICLCTL_SPA)),
-			dmic->shim_base + DMICLCTL_OFFSET);
+	sys_write32((sys_read32(base + DMICLCTL_OFFSET) & (~DMICLCTL_SPA)),
+		     base + DMICLCTL_OFFSET);
 }
 
 static int dai_dmic_probe(struct dai_intel_dmic *dmic)
@@ -759,6 +808,7 @@ static int dai_dmic_set_config(const struct device *dev,
 		return -EINVAL;
 	}
 
+	__ASSERT_NO_MSG(dmic->created);
 	key = k_spin_lock(&dmic->lock);
 
 #if CONFIG_DAI_INTEL_DMIC_TPLG_PARAMS

--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -302,6 +302,22 @@ static inline void dai_dmic_en_clk_gating(const struct dai_intel_dmic *dmic)
 
 }
 
+static inline void dai_dmic_program_channel_map(const struct dai_intel_dmic *dmic,
+						const struct dai_config *cfg,
+						uint32_t index)
+{
+#ifdef CONFIG_SOC_INTEL_ACE20_LNL
+	uint16_t pcmsycm = cfg->link_config;
+	uint32_t reg_add = dmic->shim_base + DMICXPCMSyCM_OFFSET + 0x0004*index;
+
+	sys_write16(pcmsycm, reg_add);
+#else
+	ARG_UNUSED(dmic);
+	ARG_UNUSED(cfg);
+	ARG_UNUSED(index);
+#endif /* defined(CONFIG_SOC_INTEL_ACE20_LNL) */
+}
+
 static inline void dai_dmic_en_power(const struct dai_intel_dmic *dmic)
 {
 	uint32_t base = dai_dmic_base(dmic);
@@ -808,7 +824,8 @@ static int dai_dmic_set_config(const struct device *dev,
 		return -EINVAL;
 	}
 
-	__ASSERT_NO_MSG(dmic->created);
+	dai_dmic_program_channel_map(dmic, cfg, di);
+
 	key = k_spin_lock(&dmic->lock);
 
 #if CONFIG_DAI_INTEL_DMIC_TPLG_PARAMS

--- a/drivers/dai/intel/dmic/dmic.h
+++ b/drivers/dai/intel/dmic/dmic.h
@@ -58,12 +58,32 @@
 #define TS_LOCAL_OFFS_CLK		GET_BITS(11, 0)
 
 /* Digital Mic Shim Registers */
-#define DMICLCTL_OFFSET        0x04
-#define DMICIPPTR_OFFSET       0x08
-#define DMICSYNC_OFFSET        0x0C
+#define DMICLCTL_OFFSET		0x04
+#define DMICIPPTR_OFFSET	0x08
 
+#ifdef CONFIG_SOC_INTEL_ACE20_LNL
+#define DMICSYNC_OFFSET		0x1C
+
+#define DMICLCTL_SPA		BIT(16)
+#define DMICLCTL_CPA		BIT(23)
+#define DMICLCTL_OFLEN		BIT(4)
+
+/* DMIC disable clock gating */
+#define DMIC_DCGD		BIT(30)
+
+/* DMIC Command Sync */
+#define DMICSYNC_CMDSYNC	BIT(24)
+/* DMIC Sync Go */
+#define DMICSYNC_SYNCGO		BIT(23)
+#define DMICSYNC_SYNCPU		BIT(20)
+/* DMIC Sync Period */
+#define DMICSYNC_SYNCPRD(x)	SET_BITS(19, 0, x)
+#define DMICXPCMSyCM_OFFSET	0x16
+#else /* All other CAVS and ACE platforms */
+#define DMICSYNC_OFFSET		0x0C
 /* DMIC power ON bit */
 #define DMICLCTL_SPA		BIT(0)
+#define DMICLCTL_CPA		BIT(8)
 /* DMIC Owner Select */
 #define DMICLCTL_OSEL(x)	SET_BITS(25, 24, x)
 /* DMIC disable clock gating */
@@ -75,6 +95,7 @@
 #define DMICSYNC_SYNCGO		BIT(24)
 /* DMIC Sync Period */
 #define DMICSYNC_SYNCPRD(x)	SET_BITS(14, 0, x)
+#endif
 
 /* Parameters used in modes computation */
 #define DMIC_HW_BITS_CIC		26

--- a/drivers/dai/intel/dmic/dmic.h
+++ b/drivers/dai/intel/dmic/dmic.h
@@ -562,6 +562,10 @@ struct dai_intel_dmic {
 	/* hardware parameters */
 	uint32_t reg_base;
 	uint32_t shim_base;
+#ifdef CONFIG_SOC_INTEL_ACE20_LNL
+	uint32_t hdamldmic_base;
+	uint32_t vshim_base;
+#endif
 	int irq;
 	uint32_t flags;
 };

--- a/dts/bindings/dai/intel,adsp-dmic-vss.yaml
+++ b/dts/bindings/dai/intel,adsp-dmic-vss.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Intel DMIC Vendor SHIM controller
+
+compatible: "intel,adsp-dmic-vss"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true

--- a/dts/bindings/dma/intel,adsp-hda-dmic-cap.yaml
+++ b/dts/bindings/dma/intel,adsp-hda-dmic-cap.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Intel HDA DMIC Capabilities controller
+
+compatible: "intel,adsp-hda-dmic-cap"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -128,6 +128,36 @@
 			#interrupt-cells = <3>;
 		};
 
+		hdamlddmic: hdamlddmic@cc0 {
+			compatible = "intel,adsp-hda-dmic-cap";
+			reg = <0xcc0 0x40>;
+			status = "okay";
+		};
+
+		dmic0: dai-dmic0@10100 {
+			compatible = "intel,dai-dmic";
+			reg = <0x10100 0x8000>;
+			shim = <0x10000>;
+			fifo = <0x0008>;
+			interrupts = <0x08 0 0>;
+			interrupt-parent = <&ace_intc>;
+		};
+
+		dmic1: dai-dmic1@10100 {
+			compatible = "intel,dai-dmic";
+			reg = <0x10100 0x8000>;
+			shim = <0x10000>;
+			fifo = <0x0108>;
+			interrupts = <0x08 0 0>;
+			interrupt-parent = <&ace_intc>;
+		};
+
+		dmicvss: dmicvss@16000 {
+			compatible = "intel,adsp-dmic-vss";
+			reg = <0x16000 0x2000>;
+			status = "okay";
+		};
+
 		sspbase: ssp_base@28000 {
 			compatible = "intel,ssp-sspbase";
 			reg = <0x28000 0x1000>;

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -200,6 +200,7 @@ struct dai_properties {
  * @param options Dai specific configuration options.
  * @param word_size Number of bits representing one data word.
  * @param block_size Size of one RX/TX memory block (buffer) in bytes.
+ * @param link_config Dai specific link configuration.
  */
 struct dai_config {
 	enum dai_type type;
@@ -210,6 +211,7 @@ struct dai_config {
 	uint8_t options;
 	uint8_t word_size;
 	size_t block_size;
+	uint16_t link_config;
 };
 
 struct dai_ts_cfg {


### PR DESCRIPTION
Add DMIC changes required in driver and DTS to enable dmic on
LNL (ACE 2.0) platform.

Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>